### PR TITLE
feat(president): add revolution-end flash on true→false revert

### DIFF
--- a/frontend/src/i18n/locales/en/president.json
+++ b/frontend/src/i18n/locales/en/president.json
@@ -8,6 +8,7 @@
   "label.tableCards": "Table",
   "label.tableEmpty": "Empty (anyone can play)",
   "badge.revolution": "[Revolution] 2 weakest, 3 strongest",
+  "flash.revolutionEnd": "Revolution ended — strength order back to normal",
   "rank.president": "President",
   "rank.vicePresident": "Vice President",
   "rank.viceScum": "Vice Scum",

--- a/frontend/src/i18n/locales/ja/president.json
+++ b/frontend/src/i18n/locales/ja/president.json
@@ -8,6 +8,7 @@
   "label.tableCards": "場",
   "label.tableEmpty": "なし (誰でも出せます)",
   "badge.revolution": "【革命中】2が最弱、3が最強",
+  "flash.revolutionEnd": "革命終了 — 強さの序列が通常に戻りました",
   "rank.president": "大統領",
   "rank.vicePresident": "副大統領",
   "rank.viceScum": "副スカム",

--- a/frontend/src/pages/PresidentPage.test.tsx
+++ b/frontend/src/pages/PresidentPage.test.tsx
@@ -120,6 +120,25 @@ describe('PresidentPage', () => {
     expect(screen.getByTestId('president-revolution-flash')).toHaveClass('bg-ds-warning/40');
   });
 
+  it('shows a distinct status banner when revolution reverts (true → false)', async () => {
+    mockExec.mockReset();
+    // Mount fetches an active-revolution state; the follow-up pass returns a
+    // state where revolution has ended, driving the true → false transition.
+    mockExec
+      .mockResolvedValueOnce(makeState({ revolutionActive: true }))
+      .mockResolvedValue(makeState({ revolutionActive: false }));
+    renderWithProviders(<PresidentPage />);
+    await waitFor(() => expect(screen.getByTestId('president-revolution-flash')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('pass-button'));
+    await waitFor(() => expect(screen.getByTestId('president-revolution-end-flash')).toBeInTheDocument());
+    const endFlash = screen.getByTestId('president-revolution-end-flash');
+    expect(endFlash).toHaveAttribute('role', 'status');
+    expect(endFlash).toHaveTextContent('革命終了');
+    // Distinct from the activation flash (info-coloured banner vs warning scrim).
+    expect(endFlash.querySelector('span')).toHaveClass('bg-ds-info');
+  });
+
   it('disables action buttons when it is not human turn', async () => {
     mockExec.mockResolvedValue(makeState({ currentTurn: 1 }));
     renderWithProviders(<PresidentPage />);

--- a/frontend/src/pages/PresidentPage.tsx
+++ b/frontend/src/pages/PresidentPage.tsx
@@ -125,16 +125,31 @@ function PresidentPageContent() {
   // One-shot full-screen flash when revolution toggles on (false → true), to
   // make the strength inversion impossible to miss. flashKey re-triggers the
   // CSS animation without AnimatePresence; the timer hides the scrim after 400ms.
+  // The reverse transition (true → false, i.e. revolution reverting to normal)
+  // fires a distinct info-coloured status banner so it is never mistaken for the
+  // activation flash and is announced to screen readers via role="status".
   const [revolutionFlash, setRevolutionFlash] = useState(0);
+  const [revolutionEndFlash, setRevolutionEndFlash] = useState(0);
   const prevRevolution = useRef(false);
   const revolutionFlashTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  useEffect(() => () => clearTimeout(revolutionFlashTimer.current ?? undefined), []);
+  const revolutionEndFlashTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(
+    () => () => {
+      clearTimeout(revolutionFlashTimer.current ?? undefined);
+      clearTimeout(revolutionEndFlashTimer.current ?? undefined);
+    },
+    [],
+  );
   useEffect(() => {
     const active = state?.revolutionActive ?? false;
     if (active && !prevRevolution.current) {
       setRevolutionFlash((k) => k + 1);
       clearTimeout(revolutionFlashTimer.current ?? undefined);
       revolutionFlashTimer.current = setTimeout(() => setRevolutionFlash(0), 400);
+    } else if (!active && prevRevolution.current) {
+      setRevolutionEndFlash((k) => k + 1);
+      clearTimeout(revolutionEndFlashTimer.current ?? undefined);
+      revolutionEndFlashTimer.current = setTimeout(() => setRevolutionEndFlash(0), 1800);
     }
     prevRevolution.current = active;
   }, [state?.revolutionActive]);
@@ -195,6 +210,18 @@ function PresidentPageContent() {
               aria-hidden="true"
               className="pointer-events-none fixed inset-0 z-40 bg-ds-warning/40 motion-safe:animate-[fadeIn_0.2s_ease-out] motion-reduce:hidden"
             />
+          )}
+          {revolutionEndFlash > 0 && (
+            <div
+              key={revolutionEndFlash}
+              data-testid="president-revolution-end-flash"
+              role="status"
+              className="pointer-events-none fixed inset-x-0 top-16 z-40 flex justify-center px-4 motion-safe:animate-[fadeIn_0.2s_ease-out]"
+            >
+              <span className="rounded-full bg-ds-info px-4 py-2 font-semibold text-ds-text-on-accent shadow-lg">
+                {t('flash.revolutionEnd')}
+              </span>
+            </div>
           )}
           <div className="flex-1 overflow-y-auto px-4 py-2 space-y-3">
             {error && (


### PR DESCRIPTION
## 概要

プレジデントの革命フラッシュは `false → true`（発動）時のみ発火し、`true → false`（革命解除・元の強弱に戻る）時には演出が一切なかった。解除時にも視覚的な演出を追加した。

## 変更内容

- `PresidentPage.tsx`: `revolutionActive` の `true → false` 遷移を検知し、専用の解除バナーを発火（`useRef` + `useEffect` の transient パターン、クリーンアップタイマー付き）。
- 発動フラッシュ（全画面 `bg-ds-warning/40` スクリム）とは色・形状で明確に区別: 解除は上部中央の `bg-ds-info` ピル型バナー。
- `role="status"` によりスクリーンリーダーが解除を読み上げ。1.8 秒後にタイマーで自動的に消去。
- i18n キー `flash.revolutionEnd` を ja/en に key-for-key で追加。
- `PresidentPage.test.tsx`: `true → false` 遷移（2 状態）で解除バナーが表示され `role="status"` を持つことを検証するテストを追加。

## 受け入れ条件

- [x] 革命解除時にも視覚的な演出が発生する
- [x] 発動時のフラッシュと区別できる（色・形状を変更: warning 全画面スクリム vs info ピルバナー）
- [x] `PresidentPage.test.tsx` に解除時フラッシュのテストを追加

## テスト

- `bunx biome check` パス
- `bun run test -- --run PresidentPage`: 24 tests パス（新規: "shows a distinct status banner when revolution reverts (true → false)"）
- `bun run build`（tsc）パス

Closes #3200
