### PR TITLE
feat(prsi): render draw pile as a clickable card-back stock

### DIFF
--- a/frontend/src/i18n/locales/en/prsi.json
+++ b/frontend/src/i18n/locales/en/prsi.json
@@ -12,7 +12,7 @@
   },
   "drawPile": "Draw pile: {{count}} cards",
   "stock": "Stock",
-  "stockAria": "Draw from stock ({{count}} cards left)",
+  "stockAria": "Draw a card from the stock ({{count}} left)",
   "discardTop": "Discard",
   "penalty": "Penalty: {{count}} — stack a 7 or draw",
   "cards": "{{count}} cards",

--- a/frontend/src/i18n/locales/en/prsi.json
+++ b/frontend/src/i18n/locales/en/prsi.json
@@ -11,6 +11,8 @@
     "hard": "Hard"
   },
   "drawPile": "Draw pile: {{count}} cards",
+  "stock": "Stock",
+  "stockAria": "Draw from stock ({{count}} cards left)",
   "discardTop": "Discard",
   "penalty": "Penalty: {{count}} — stack a 7 or draw",
   "cards": "{{count}} cards",

--- a/frontend/src/i18n/locales/ja/prsi.json
+++ b/frontend/src/i18n/locales/ja/prsi.json
@@ -11,6 +11,8 @@
     "hard": "Hard"
   },
   "drawPile": "山札: {{count}}枚",
+  "stock": "山札",
+  "stockAria": "山札から引く（残り{{count}}枚）",
   "discardTop": "捨て札",
   "penalty": "ペナルティ: {{count}}枚 — 7を重ねるか引く",
   "cards": "{{count}}枚",

--- a/frontend/src/i18n/locales/ja/prsi.json
+++ b/frontend/src/i18n/locales/ja/prsi.json
@@ -12,7 +12,7 @@
   },
   "drawPile": "山札: {{count}}枚",
   "stock": "山札",
-  "stockAria": "山札から引く（残り{{count}}枚）",
+  "stockAria": "山札から1枚ドロー（残り{{count}}枚）",
   "discardTop": "捨て札",
   "penalty": "ペナルティ: {{count}}枚 — 7を重ねるか引く",
   "cards": "{{count}}枚",

--- a/frontend/src/pages/PrsiPage.test.tsx
+++ b/frontend/src/pages/PrsiPage.test.tsx
@@ -279,6 +279,38 @@ describe('PrsiPage', () => {
     await waitFor(() => expect(screen.getByText('山札: 30枚')).toBeInTheDocument());
   });
 
+  it('renders the clickable stock pile with the remaining count', async () => {
+    renderWithProviders(<PrsiPage />);
+    const stock = await screen.findByTestId('prsi-stock');
+    expect(stock).toHaveTextContent('30');
+    expect(stock).not.toBeDisabled();
+  });
+
+  it('drawing via a stock click dispatches the draw action on the human turn', async () => {
+    renderWithProviders(<PrsiPage />);
+    const stock = await screen.findByTestId('prsi-stock');
+
+    mockExec.mockClear();
+    mockExec.mockResolvedValue(playPhaseState);
+    fireEvent.click(stock);
+
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('draw'));
+  });
+
+  it('disables the stock pile when it is not the human turn', async () => {
+    mockExec.mockResolvedValue(cpuTurnState);
+    renderWithProviders(<PrsiPage />);
+    const stock = await screen.findByTestId('prsi-stock');
+    expect(stock).toBeDisabled();
+  });
+
+  it('shows the penalty badge on the stock pile when penaltyDrawCount > 0', async () => {
+    mockExec.mockResolvedValue(penaltyState);
+    renderWithProviders(<PrsiPage />);
+    const badge = await screen.findByTestId('prsi-stock-penalty');
+    expect(badge).toHaveTextContent('+2');
+  });
+
   it('phase indicator shows your turn when human play turn', async () => {
     renderWithProviders(<PrsiPage />);
     await waitFor(() => expect(screen.getByTestId('phase-indicator')).toHaveTextContent('あなたのターン'));

--- a/frontend/src/pages/PrsiPage.tsx
+++ b/frontend/src/pages/PrsiPage.tsx
@@ -11,6 +11,7 @@ import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
+import { AnimatedCardBack } from '../components/motion/AnimatedCardBack';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useCardDimensions } from '../hooks/useCardDimensions';
@@ -196,18 +197,50 @@ function PrsiPageContent() {
             <div className={lgTwoColGrid}>
               {/* Left: game play area */}
               <div>
-                {/* Discard pile top */}
-                {state.discardTop && (
-                  <div
-                    className="my-3 p-3 rounded bg-black/40 flex items-center gap-3"
-                    data-tutorial="prsi-discard-pile"
-                  >
-                    <AnimatedCard card={state.discardTop} width={cardWidth} />
-                    <div className="text-ds-text-muted text-sm">
-                      <div>{t('discardTop')}</div>
+                {/* Discard pile top + clickable stock pile */}
+                <div className="my-3 flex items-start gap-4 flex-wrap">
+                  {state.discardTop && (
+                    <div className="p-3 rounded bg-black/40 flex items-center gap-3" data-tutorial="prsi-discard-pile">
+                      <AnimatedCard card={state.discardTop} width={cardWidth} />
+                      <div className="text-ds-text-muted text-sm">
+                        <div>{t('discardTop')}</div>
+                      </div>
                     </div>
+                  )}
+
+                  {/* Stock pile: a face-down stack the human can click to draw. */}
+                  <div className="p-3 rounded bg-black/40 flex flex-col items-center gap-1">
+                    <button
+                      type="button"
+                      data-testid="prsi-stock"
+                      onClick={handleDraw}
+                      disabled={!isHumanTurn || loading || state.drawPileCount === 0}
+                      aria-label={t('stockAria', { count: state.drawPileCount })}
+                      className={`relative ${focusRingCard} ${
+                        isHumanTurn && state.drawPileCount > 0 ? 'cursor-pointer' : 'cursor-default opacity-70'
+                      }`}
+                      style={{ background: 'none', padding: 0, border: 'none', lineHeight: 0 }}
+                    >
+                      <AnimatedCardBack width={cardWidth} silent />
+                      <span
+                        className="absolute -top-1 -right-1 min-w-[1.25rem] px-1 rounded-full bg-ds-surface text-ds-text-primary text-xs font-bold text-center leading-5 shadow"
+                        aria-hidden="true"
+                      >
+                        {state.drawPileCount}
+                      </span>
+                      {hasPenalty && (
+                        <span
+                          className="absolute -bottom-1 -left-1 px-1.5 rounded-full bg-ds-warning text-black text-xs font-bold leading-5 shadow"
+                          aria-hidden="true"
+                          data-testid="prsi-stock-penalty"
+                        >
+                          +{state.penaltyDrawCount}
+                        </span>
+                      )}
+                    </button>
+                    <div className="text-ds-text-muted text-sm">{t('stock')}</div>
                   </div>
-                )}
+                </div>
 
                 {hasPenalty && (
                   <div


### PR DESCRIPTION
## 概要

プルシー（Prší）の山札をテキスト1行から、カード裏面（`AnimatedCardBack`）＋枚数バッジのクリック可能なパイルに変更しました。捨て札トップとの視覚的な非対称を解消し、「山札をタップして引く」物理カードゲームのメンタルモデルに合わせます。

## 変更点

- 捨て札トップの隣に `AnimatedCardBack` の山札パイルを描画（`data-testid="prsi-stock"`）。右上に残り枚数バッジを表示。
- 人間の手番中のみクリックで**既存の** `handleDraw`（`exec('draw')`）を実行。CPU手番・ローディング中・山札0枚のときは `disabled`。
- ペナルティ中（`penaltyDrawCount > 0`）は山札上に警告色の `+n` バッジを重ねて表示（`data-testid="prsi-stock-penalty"`）。
- フッターのドローボタンは維持（挙動変更なし）。ゲームロジックは一切変更していません。
- i18n キー `stock` / `stockAria` を ja/en 両方に追加。

## 受け入れ条件

- [x] 山札がカード裏面+枚数で視覚表示される
- [x] 手番中のみ山札クリックでドローできる
- [x] ペナルティ枚数が山札上にバッジ表示される
- [x] `PrsiPage.test.tsx` にクリックドローのテストを追加

## テスト

`cd frontend && bun run test -- --run PrsiPage` → 34 passed（新規4件）
`bun run build`（tsc）/ `biome check` パス

Closes #3595
