### PR TITLE
feat(guts): show matcher extra payment in round result

### DIFF
--- a/frontend/src/i18n/locales/en/guts.json
+++ b/frontend/src/i18n/locales/en/guts.json
@@ -37,7 +37,8 @@
   "nextRound": "Next Round",
   "roundResult": {
     "title": "Round Result",
-    "winner": "{{name}} won the pot of {{pot}}."
+    "winner": "{{name}} won the pot of {{pot}}.",
+    "matchPayment": "Match payment: {{name}} pays -{{amount}}"
   },
   "matchWinner": "{{name}} won the match!",
   "hint": {

--- a/frontend/src/i18n/locales/ja/guts.json
+++ b/frontend/src/i18n/locales/ja/guts.json
@@ -37,7 +37,8 @@
   "nextRound": "次のラウンド",
   "roundResult": {
     "title": "ラウンド結果",
-    "winner": "{{name}} がポット {{pot}} を獲得しました。"
+    "winner": "{{name}} がポット {{pot}} を獲得しました。",
+    "matchPayment": "マッチ支払い: {{name}} が -{{amount}}"
   },
   "matchWinner": "{{name}} がマッチに勝利しました！",
   "hint": {

--- a/frontend/src/pages/GutsPage.test.tsx
+++ b/frontend/src/pages/GutsPage.test.tsx
@@ -17,6 +17,7 @@ const resultState = makeGutsState({
   phase: 1,
   winnerIdx: 0,
   result: 1,
+  matchers: [1],
   players: [
     {
       id: 0,
@@ -40,7 +41,7 @@ const resultState = makeGutsState({
       chips: 170,
       in: true,
       out: false,
-      roundBet: 10,
+      roundBet: 90,
       cardCount: 2,
       cards: [
         { design: 'HEART', value: 5 },
@@ -86,6 +87,7 @@ const gameEndState = makeGutsState({
 });
 
 beforeEach(() => {
+  localStorage.clear();
   mockExec.mockReset();
   mockExec.mockResolvedValue(declareState);
 });
@@ -145,6 +147,14 @@ describe('GutsPage', () => {
     renderWithProviders(<GutsPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: '次のラウンド' })).toBeInTheDocument());
     expect(screen.queryByRole('button', { name: 'イン（残る）' })).not.toBeInTheDocument();
+  });
+
+  it('shows the matcher extra payment in the round result', async () => {
+    mockExec.mockResolvedValue(resultState);
+    renderWithProviders(<GutsPage />);
+    const line = await screen.findByTestId('guts-matcher-payment');
+    // roundBet 90 minus ante 10 = 80 chips matched into the next pot.
+    expect(line).toHaveTextContent('マッチ支払い: CPU 1 が -80');
   });
 
   it('renders the game-end message', async () => {

--- a/frontend/src/pages/GutsPage.tsx
+++ b/frontend/src/pages/GutsPage.tsx
@@ -277,6 +277,23 @@ function GutsPageContent() {
                     pot: state.pot,
                   })}
                 </div>
+                {state.matchers.map((idx) => {
+                  const matcher = state.players[idx];
+                  if (!matcher) return null;
+                  const amount = Math.max(0, matcher.roundBet - state.ante);
+                  return (
+                    <div
+                      key={`matcher-${idx}`}
+                      className="text-ds-error font-semibold"
+                      data-testid="guts-matcher-payment"
+                    >
+                      {t('roundResult.matchPayment', {
+                        name: playerLabel(idx, idx === humanIdx),
+                        amount,
+                      })}
+                    </div>
+                  );
+                })}
               </div>
             )}
 


### PR DESCRIPTION
## 概要
ガッツ (Guts) で「イン」宣言して負けたプレイヤー（マッチャー）は、ポット額をマッチして次ラウンドの種銭を積む追加支払いを負う。これまでラウンド結果ボックスは勝者とポットのみを表示しており、なぜチップが大きく減ったのかが分からなかった。

本 PR はラウンド結果に各マッチャーの追加支払い額を赤くハイライトした行として表示する。

## 実装
- 表示専用の変更（ドメイン非改修）。マッチ額は既存のレスポンスフィールドから導出: `matchPayment = players[idx].roundBet - ante`（`roundBet` はアンティ + マッチ額の累計、`ResetForRound` で毎ラウンド 0 にリセット）。`state.matchers`（マッチャーの座席インデックス列）を反復して表示。
- Go ドメイン (`Guts.go`) の `settle()` が `pay := min(pot, chips)` を `roundBet` に加算しており、規則と一致することを確認済み。
- i18n キー `roundResult.matchPayment` を ja/en に key-for-key で追加。
- マッチャー行に `data-testid="guts-matcher-payment"`、`text-ds-error`（定義済みトークン）で赤ハイライト。

## テスト
- `GutsPage.test.tsx` に `shows the matcher extra payment in the round result` を追加（roundBet 90 − ante 10 = 80 を検証）。
- Gate 全通過: `biome check`, `bun run test -- --run GutsPage`（9 passed）, `bun run build`（tsc）。

## 受け入れ条件
- [x] ラウンド結果にマッチャーの支払い額が表示される
- [x] マッチャー行が視覚的に強調される（赤ハイライト）
- [ ] `Guts.go` がマッチ支払い額を state に含める → 既存フィールド (`roundBet` - `ante`) から導出可能なため、表示専用の軽量実装としてドメイン非改修
- [x] `GutsWebPresenter.go` 出力（既存の `matchers` / `roundBet` / `ante`）と `GutsPage.test.tsx` で検証

Closes #3478