### PR TITLE
feat(manille): add card-strength order help panel

### DIFF
--- a/frontend/src/i18n/locales/en/manille.json
+++ b/frontend/src/i18n/locales/en/manille.json
@@ -37,6 +37,15 @@
     "teamA": "Team A card points: {{points}}",
     "teamB": "Team B card points: {{points}}"
   },
+  "strengthLegend": {
+    "title": "Card Strength & Points",
+    "rankCol": "Rank",
+    "cardCol": "Card",
+    "pointCol": "Points",
+    "manille": "Manille",
+    "manillon": "Manillon",
+    "note": "10 > A > K > Q > J > 9 > 8 > 7 (same for trump and non-trump). 60 points total."
+  },
   "hintAvailable": "Hint",
   "hint": {
     "lead_low": "Lead a low card to conserve points",

--- a/frontend/src/i18n/locales/ja/manille.json
+++ b/frontend/src/i18n/locales/ja/manille.json
@@ -37,6 +37,15 @@
     "teamA": "チームAのカード点: {{points}}",
     "teamB": "チームBのカード点: {{points}}"
   },
+  "strengthLegend": {
+    "title": "カード強さ順・得点",
+    "rankCol": "順位",
+    "cardCol": "カード",
+    "pointCol": "得点",
+    "manille": "マニーユ",
+    "manillon": "マニヨン",
+    "note": "10 > A > K > Q > J > 9 > 8 > 7（切り札・非切り札で共通）。得点合計60点。"
+  },
   "hintAvailable": "ヒント",
   "hint": {
     "lead_low": "低い札でリードして温存することを推奨",

--- a/frontend/src/pages/ManillePage.test.tsx
+++ b/frontend/src/pages/ManillePage.test.tsx
@@ -141,6 +141,15 @@ describe('ManillePage', () => {
     expect(screen.getByTestId('manille-player-3')).not.toHaveAttribute('data-own-team');
   });
 
+  it('renders the card-strength legend with the reversed rank order and points', async () => {
+    renderWithProviders(<ManillePage />);
+    const legend = await screen.findByTestId('manille-strength-legend');
+    // Manille (10) tops the order, then Manillon (A); note lists 10 > A > K > Q > J > 9 > 8 > 7.
+    expect(legend).toHaveTextContent('10 (マニーユ)');
+    expect(legend).toHaveTextContent('A (マニヨン)');
+    expect(legend).toHaveTextContent('10 > A > K > Q > J > 9 > 8 > 7（切り札・非切り札で共通）。得点合計60点。');
+  });
+
   it('applies the same-team highlight in the mobile player list', async () => {
     mobileFlag.value = true;
     renderWithProviders(<ManillePage />);

--- a/frontend/src/pages/ManillePage.tsx
+++ b/frontend/src/pages/ManillePage.tsx
@@ -35,6 +35,23 @@ import { playerName } from '../utils/playerUtils';
 /** Suit symbols indexed by suit number (1=♠ 2=♣ 3=♥ 4=♦; index 0 unused). */
 const SUIT_SYMBOLS = ['', '♠', '♣', '♥', '♦'] as const;
 
+/**
+ * Static card-strength legend rows, strongest first, mirroring the Go domain
+ * (`manilleStrength`/`manilleCardPoints` in `internal/domain/Manille.go`):
+ * 10 (Manille) > A (Manillon) > K > Q > J > 9 > 8 > 7, with points 10=5, A=4,
+ * K=3, Q=2, J=1 and 9/8/7 worth zero. `nameKey` labels the two special cards.
+ */
+const MANILLE_STRENGTH_ROWS: ReadonlyArray<{ face: string; points: number; nameKey?: string }> = [
+  { face: '10', points: 5, nameKey: 'strengthLegend.manille' },
+  { face: 'A', points: 4, nameKey: 'strengthLegend.manillon' },
+  { face: 'K', points: 3 },
+  { face: 'Q', points: 2 },
+  { face: 'J', points: 1 },
+  { face: '9', points: 0 },
+  { face: '8', points: 0 },
+  { face: '7', points: 0 },
+];
+
 /** Manille tutorial step definitions. */
 const MANILLE_TUTORIAL_STEPS: TutorialStep[] = [
   {
@@ -276,6 +293,41 @@ function ManillePageContent() {
                 ) : (
                   <div className="mb-2 p-2 rounded bg-black/30">{state.players.map(renderPlayerRow)}</div>
                 )}
+
+                {/* Card-strength legend (static reference): the Manille (10) tops the
+                    reversed rank order, so a first-time player can see why 10 beats A. */}
+                <details className="mb-2 p-2 rounded bg-black/30" data-testid="manille-strength-legend">
+                  <summary className="cursor-pointer select-none text-ds-text-muted text-sm">
+                    {t('strengthLegend.title')}
+                  </summary>
+                  <div className="mt-1 text-ds-text-muted text-xs">
+                    <table className="w-full">
+                      <thead>
+                        <tr>
+                          <th scope="col" className="text-left font-normal">
+                            {t('strengthLegend.rankCol')}
+                          </th>
+                          <th scope="col" className="text-left font-normal">
+                            {t('strengthLegend.cardCol')}
+                          </th>
+                          <th scope="col" className="text-right font-normal">
+                            {t('strengthLegend.pointCol')}
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {MANILLE_STRENGTH_ROWS.map((row, i) => (
+                          <tr key={row.face}>
+                            <td>{i + 1}</td>
+                            <td>{row.nameKey ? `${row.face} (${t(row.nameKey)})` : row.face}</td>
+                            <td className="text-right">{row.points}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                    <div className="mt-1">{t('strengthLegend.note')}</div>
+                  </div>
+                </details>
 
                 {/* Round result */}
                 {(isRoundEnd || isGameEnd) && (


### PR DESCRIPTION
## 概要

マニーユの特殊なカード強さ順（10=マニーユが最強、次いで A=マニヨン、以下 K>Q>J>9>8>7）を説明する折りたたみ式ヘルプパネルを情報サイドバーに追加。初見プレイヤーが「なぜ 10 がトリックに勝つのか」を学べるようにする。

- サイドバー（`data-tutorial="manille-info"`）内に静的な `<details>` 凡例パネルを追加（`data-testid="manille-strength-legend"`）
- 強さ順位・カード・得点（10=5, A=4, K=3, Q=2, J=1, 9/8/7=0）を表形式で一覧
- 強さ順とポイントは Go ドメイン `internal/domain/Manille.go` の `manilleStrength` / `manilleCardPoints` を正確にミラー
- 既存の `<details>` パターン（プレイヤー一覧・tressette 凡例）を踏襲
- 純粋に追加のみ。バックエンド変更なし、トリック勝者バナー等の既存要素は不変

## 受け入れ条件

- [x] ランク順と得点の一覧パネルがサイドバーに表示される
- [x] 折りたたみ（`<details>`）表示、モバイルでも折りたたまれる
- [x] ja/en 両ロケールに文言を追加（key-for-key 同期）
- [x] `ManillePage.test.tsx` にテストを追加

## テスト

- `bun run test -- --run ManillePage` → 14 tests passed（新規 `renders the card-strength legend...` 含む）
- `bunx biome check` → clean
- `bun run build`（tsc）→ 成功

Closes #3424
