### PR TITLE
feat(spanish21): gate reset button behind confirmation dialog

### DIFF
--- a/frontend/src/components/blackjack/BjEndPhaseControls.test.tsx
+++ b/frontend/src/components/blackjack/BjEndPhaseControls.test.tsx
@@ -23,6 +23,15 @@ describe('BjEndPhaseControls', () => {
     expect(onReset).toHaveBeenCalled();
   });
 
+  it('calls onRequestReset instead of onReset when the button is clicked', () => {
+    const onReset = vi.fn();
+    const onRequestReset = vi.fn();
+    render(<BjEndPhaseControls {...defaultProps({ onReset, onRequestReset })} />);
+    fireEvent.click(screen.getByRole('button', { name: '次のゲーム' }));
+    expect(onRequestReset).toHaveBeenCalled();
+    expect(onReset).not.toHaveBeenCalled();
+  });
+
   it('disables button when loading is true', () => {
     render(<BjEndPhaseControls {...defaultProps({ loading: true })} />);
     expect(screen.getByRole('button', { name: '次のゲーム' })).toBeDisabled();
@@ -81,6 +90,17 @@ describe('BjEndPhaseControls', () => {
 
       vi.advanceTimersByTime(2000);
       await waitFor(() => expect(onReset).toHaveBeenCalled());
+    });
+
+    it('auto-advance fires onReset directly, bypassing onRequestReset', async () => {
+      const onReset = vi.fn();
+      const onRequestReset = vi.fn();
+      render(<BjEndPhaseControls {...defaultProps({ onReset, onRequestReset, autoAdvanceSeconds: 2 })} />);
+
+      vi.advanceTimersByTime(2000);
+      await waitFor(() => expect(onReset).toHaveBeenCalled());
+      // The confirmation path is skipped for auto-advance.
+      expect(onRequestReset).not.toHaveBeenCalled();
     });
 
     it('clears countdown text after reaching 0', async () => {

--- a/frontend/src/components/blackjack/BjEndPhaseControls.tsx
+++ b/frontend/src/components/blackjack/BjEndPhaseControls.tsx
@@ -5,13 +5,20 @@ import { btnPrimary } from '../../styles/buttonStyles';
 /** Props for BlackJack end phase controls. */
 export interface BjEndPhaseControlsProps {
   loading: boolean;
+  /** Raw reset callback. Fired directly by the auto-advance countdown (no confirmation). */
   onReset: () => void;
+  /**
+   * Handler for a manual button click. Typically opens a reset confirmation dialog before
+   * invoking the reset. Falls back to {@link BjEndPhaseControlsProps.onReset} when omitted.
+   */
+  onRequestReset?: () => void;
   autoAdvanceSeconds?: number;
 }
 
 /**
  * Renders the "Next Game" button with optional auto-advance countdown for BlackJack end phase.
- * No confirmation dialog — the hand is already resolved, so clicking just deals the next one.
+ * A manual click routes through `onRequestReset` (reset confirmation dialog) so a stray tap does
+ * not discard the session; the auto-advance countdown still fires `onReset` directly.
  */
 export function BjEndPhaseControls(props: BjEndPhaseControlsProps) {
   const { t } = useTranslation('common');
@@ -45,7 +52,7 @@ export function BjEndPhaseControls(props: BjEndPhaseControlsProps) {
       type="button"
       className={`${btnPrimary} animate-pulse ring-2 ring-white ring-offset-2 ring-offset-green-800`}
       disabled={props.loading}
-      onClick={props.onReset}
+      onClick={props.onRequestReset ?? props.onReset}
     >
       {t('button.nextGame')}
       {countdown !== null ? ` (${countdown}s)` : ''}

--- a/frontend/src/pages/BlackJackPage.test.tsx
+++ b/frontend/src/pages/BlackJackPage.test.tsx
@@ -1045,13 +1045,14 @@ describe('BlackJackPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('split'));
   });
 
-  it('sends config params when reset button is clicked in end phase', async () => {
+  it('sends config params when reset button is confirmed in end phase', async () => {
     mockExec.mockResolvedValue(endPhaseState);
     renderWithProviders(<BlackJackPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument());
     mockExec.mockClear();
     mockExec.mockResolvedValue(betPhaseState);
     fireEvent.click(screen.getByRole('button', { name: '次のゲーム' }));
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
     await waitFor(() =>
       expect(mockExec).toHaveBeenCalledWith('reset', undefined, {
         dealerHitsSoft17: false,
@@ -1461,16 +1462,40 @@ describe('BlackJackPage', () => {
     expect(screen.getByText('棋譜を見る')).toBeInTheDocument();
   });
 
-  // --- Next Game button tests ---
+  // --- Next Game button / reset confirmation tests ---
 
-  it('executes reset when next game button is clicked in end phase', async () => {
+  it('shows the reset confirmation dialog when the next game button is clicked', async () => {
+    mockExec.mockResolvedValue(endPhaseState);
+    renderWithProviders(<BlackJackPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument());
+    mockExec.mockClear();
+    fireEvent.click(screen.getByRole('button', { name: '次のゲーム' }));
+    // Confirmation dialog appears and no reset fires until it is confirmed.
+    expect(screen.getByText('本当にゲームをリセットしますか？')).toBeInTheDocument();
+    expect(mockExec).not.toHaveBeenCalled();
+  });
+
+  it('executes reset after confirming the dialog in end phase', async () => {
     mockExec.mockResolvedValue(endPhaseState);
     renderWithProviders(<BlackJackPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument());
     mockExec.mockClear();
     mockExec.mockResolvedValue(betPhaseState);
     fireEvent.click(screen.getByRole('button', { name: '次のゲーム' }));
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined, expect.any(Object)));
+  });
+
+  it('does not reset when the confirmation dialog is cancelled', async () => {
+    mockExec.mockResolvedValue(endPhaseState);
+    renderWithProviders(<BlackJackPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument());
+    mockExec.mockClear();
+    fireEvent.click(screen.getByRole('button', { name: '次のゲーム' }));
+    fireEvent.click(screen.getByRole('button', { name: 'キャンセル' }));
+    // Dialog closes and no reset command is sent.
+    await waitFor(() => expect(screen.queryByText('本当にゲームをリセットしますか？')).not.toBeInTheDocument());
+    expect(mockExec).not.toHaveBeenCalled();
   });
 
   // --- Keyboard navigation tests ---

--- a/frontend/src/pages/BlackJackPage.tsx
+++ b/frontend/src/pages/BlackJackPage.tsx
@@ -182,7 +182,8 @@ function BlackJackPageContent({ variant = 'blackjack' }: BlackJackPageProps) {
   const gamePath = variant === 'spanish21' ? '/spanish21' : '/';
   const navTitleKey = variant === 'spanish21' ? 'nav.spanish21' : 'nav.blackjack';
   const themeKey: 'blackjack' | 'spanish21' = variant === 'spanish21' ? 'spanish21' : 'blackjack';
-  const { t, tc, actionLog, showActionLog, hideActionLog } = useGamePageSetup(variant);
+  const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
+    useGamePageSetup(variant);
   const phaseNames = usePhaseNames(variant, BJ_PHASE_KEYS);
   const suggestionLabels = useSuggestionLabels(t);
   const { playSound } = useSound();
@@ -295,6 +296,11 @@ function BlackJackPageContent({ variant = 'blackjack' }: BlackJackPageProps) {
     hideActionLog,
   ]);
 
+  // Manual "Next Game" clicks route through the shared reset-confirm dialog so a stray tap
+  // does not discard the session. The auto-advance countdown keeps firing handleReset directly
+  // (see BjEndPhaseControls), so the automatic next-round flow is unaffected.
+  const requestResetConfirm = useCallback(() => requestConfirm(handleReset), [requestConfirm, handleReset]);
+
   if (!state)
     return (
       <GameSkeleton
@@ -320,9 +326,9 @@ function BlackJackPageContent({ variant = 'blackjack' }: BlackJackPageProps) {
       winShow={phase === BjPhase.END}
       onCelebrate={() => playSound('winFanfare')}
       loading={loading}
-      confirmOpen={false}
-      confirmReset={() => {}}
-      cancelReset={() => {}}
+      confirmOpen={confirmOpen}
+      confirmReset={confirmReset}
+      cancelReset={cancelReset}
       headerExtra={
         <>
           <span>
@@ -676,6 +682,7 @@ function BlackJackPageContent({ variant = 'blackjack' }: BlackJackPageProps) {
                   <BjEndPhaseControls
                     loading={loading}
                     onReset={handleReset}
+                    onRequestReset={requestResetConfirm}
                     autoAdvanceSeconds={autoAdvance > 0 ? autoAdvance : undefined}
                   />
                 </div>

--- a/frontend/src/pages/Spanish21Page.test.tsx
+++ b/frontend/src/pages/Spanish21Page.test.tsx
@@ -86,6 +86,38 @@ describe('Spanish21Page', () => {
     expect(badge).not.toHaveTextContent('bonus.777.spade');
   });
 
+  it('shows the reset confirmation dialog when the next game button is clicked', async () => {
+    mockExec.mockResolvedValue(endPhaseWithBonus);
+    renderWithProviders(<Spanish21Page />);
+    await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument());
+    mockExec.mockClear();
+    fireEvent.click(screen.getByRole('button', { name: '次のゲーム' }));
+    expect(screen.getByText('本当にゲームをリセットしますか？')).toBeInTheDocument();
+    expect(mockExec).not.toHaveBeenCalled();
+  });
+
+  it('resets after confirming the dialog', async () => {
+    mockExec.mockResolvedValue(endPhaseWithBonus);
+    renderWithProviders(<Spanish21Page />);
+    await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument());
+    mockExec.mockClear();
+    mockExec.mockResolvedValue(betPhaseState);
+    fireEvent.click(screen.getByRole('button', { name: '次のゲーム' }));
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined, expect.any(Object)));
+  });
+
+  it('does not reset when the confirmation dialog is cancelled', async () => {
+    mockExec.mockResolvedValue(endPhaseWithBonus);
+    renderWithProviders(<Spanish21Page />);
+    await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument());
+    mockExec.mockClear();
+    fireEvent.click(screen.getByRole('button', { name: '次のゲーム' }));
+    fireEvent.click(screen.getByRole('button', { name: 'キャンセル' }));
+    await waitFor(() => expect(screen.queryByText('本当にゲームをリセットしますか？')).not.toBeInTheDocument());
+    expect(mockExec).not.toHaveBeenCalled();
+  });
+
   it('opens a Spanish 21 specific tutorial step describing the 48-card deck and bonuses', async () => {
     renderWithProviders(<Spanish21Page />);
     await waitFor(() => expect(screen.getByRole('button', { name: 'チュートリアル' })).toBeInTheDocument());


### PR DESCRIPTION
## 概要

Spanish 21（`spanish21`）が共有する `BlackJackPage.tsx` は `GamePageShell` の確認ダイアログ用 props を `confirmOpen={false}` / `confirmReset={() => {}}` / `cancelReset={() => {}}` とハードコードしており、リセット確認が完全に無効化されていた。そのためエンドフェーズの「次のゲーム」ボタンを誤タップするとセッションが即座にリセットされていた。

他ゲームと同じ `useGamePageSetup` の `requestConfirm` / `confirmReset` / `cancelReset` 経由で、手動クリック時にリセット確認ダイアログを挟むよう配線した。

## 変更点

- `BlackJackPage.tsx`: `useGamePageSetup` から確認ダイアログ状態を取得し、`GamePageShell` に実値を渡す。手動リセットは `requestConfirm(handleReset)` 経由に。
- `BjEndPhaseControls.tsx`: 手動クリック用の任意 prop `onRequestReset` を追加（未指定時は `onReset` にフォールバック）。**自動進行のカウントダウンは従来どおり `onReset` を直接発火**するため、自動リセットフローは影響を受けない。
- テスト: `BlackJackPage.test.tsx` / `Spanish21Page.test.tsx` / `BjEndPhaseControls.test.tsx` に確認ダイアログの表示・確定・キャンセル、および自動進行が確認をバイパスするテストを追加。

## 受け入れ条件

- [x] リセット操作時に確認ダイアログが表示される
- [x] ラウンド終了後の通常リセットフロー（自動進行）は維持される
- [x] 確認ダイアログの表示・キャンセルのテストを追加

## ゲート

- `biome check` パス
- `bun run test -- --run Spanish21Page BlackJackPage BjEndPhaseControls` 152 件パス
- `bun run build`（tsc）パス

Closes #3206