### PR TITLE
feat(pan): visualize meld progress toward the win condition

### DIFF
--- a/frontend/src/i18n/locales/en/pan.json
+++ b/frontend/src/i18n/locales/en/pan.json
@@ -21,6 +21,8 @@
   "chips": "Chips: {{count}}",
   "melded": "Melded: {{count}}",
   "winMeld": "Melds needed to go out: {{count}}",
+  "meldProgress": "Melds {{count}}/{{total}}",
+  "meldRemaining": "{{count}} to go",
   "cumulativeScore": "Total: {{score}}",
   "meldsTitle": "Table Melds",
   "noMelds": "No melds yet",

--- a/frontend/src/i18n/locales/ja/pan.json
+++ b/frontend/src/i18n/locales/ja/pan.json
@@ -21,6 +21,8 @@
   "chips": "チップ: {{count}}",
   "melded": "メルド: {{count}}枚",
   "winMeld": "上がりに必要なメルド数: {{count}}枚",
+  "meldProgress": "メルド {{count}}/{{total}}",
+  "meldRemaining": "あと {{count}} 枚",
   "cumulativeScore": "累計: {{score}}",
   "meldsTitle": "場のメルド",
   "noMelds": "まだメルドはありません",

--- a/frontend/src/pages/PanPage.test.tsx
+++ b/frontend/src/pages/PanPage.test.tsx
@@ -392,6 +392,33 @@ describe('PanPage', () => {
     });
   });
 
+  it('shows human meld progress toward the win condition', async () => {
+    const progressState: PanResponse = {
+      ...drawPhaseState,
+      players: [player({ cards: [...humanHand], meldedCount: 4 }), drawPhaseState.players[1]],
+    };
+    mockExec.mockResolvedValue(progressState);
+    renderWithProviders(<PanPage />);
+    const bar = await screen.findByTestId('pan-meld-progress');
+    expect(bar).toHaveTextContent('メルド 4/11');
+    const progressbar = screen.getByRole('progressbar');
+    expect(progressbar).toHaveAttribute('aria-valuenow', '4');
+    expect(progressbar).toHaveAttribute('aria-valuemax', '11');
+    // Not yet in the final stretch, so no "remaining" callout.
+    expect(screen.queryByText('あと 2 枚')).not.toBeInTheDocument();
+  });
+
+  it('highlights remaining melds when close to going out', async () => {
+    const closeState: PanResponse = {
+      ...drawPhaseState,
+      players: [player({ cards: [...humanHand], meldedCount: 9 }), drawPhaseState.players[1]],
+    };
+    mockExec.mockResolvedValue(closeState);
+    renderWithProviders(<PanPage />);
+    await waitFor(() => expect(screen.getByTestId('pan-meld-progress')).toHaveTextContent('メルド 9/11'));
+    expect(screen.getByText('あと 2 枚')).toBeInTheDocument();
+  });
+
   it('phase indicator shows your turn on human draw turn', async () => {
     renderWithProviders(<PanPage />);
     await waitFor(() => expect(screen.getByTestId('phase-indicator')).toHaveTextContent('あなたのターン'));

--- a/frontend/src/pages/PanPage.tsx
+++ b/frontend/src/pages/PanPage.tsx
@@ -26,7 +26,7 @@ import { btnPrimary, btnSuccess } from '../styles/buttonStyles';
 import { focusRingCard, selectedCardStyle } from '../styles/cardStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
-import type { PanResponse } from '../types/card';
+import type { PanPlayer, PanResponse } from '../types/card';
 import { PanPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
@@ -160,6 +160,38 @@ function PanPageContent() {
   const isHumanTurn = (isDrawPhase || isPlayPhase) && state.players[state.currentPlayerIdx]?.isHuman === true;
   const canLayoff = isPlayPhase && isHumanTurn && selectedCardIndices.length === 1 && !loading;
 
+  // Meld-progress indicator toward the win condition (winMeldCount cards laid on
+  // the table), highlighting the final stretch (<=2 cards left) to go out.
+  const renderMeldProgress = (p: PanPlayer) => {
+    const melded = p.meldedCount;
+    const total = state.winMeldCount;
+    const remaining = total - melded;
+    const isClose = remaining > 0 && remaining <= 2;
+    const pct = total > 0 ? Math.min(100, (melded / total) * 100) : 0;
+    const label = t('meldProgress', { count: melded, total });
+    return (
+      <div data-testid="pan-meld-progress" className="mx-auto mb-2 max-w-xs">
+        <div className="flex items-center justify-between text-xs mb-0.5">
+          <span className="text-ds-text-muted">{label}</span>
+          {isClose && <span className="text-ds-warning font-bold">{t('meldRemaining', { count: remaining })}</span>}
+        </div>
+        <div
+          role="progressbar"
+          aria-label={label}
+          aria-valuemin={0}
+          aria-valuemax={total}
+          aria-valuenow={melded}
+          className="h-1.5 w-full rounded-sm bg-white/15 overflow-hidden"
+        >
+          <div
+            className={`h-full rounded-sm ${isClose ? 'bg-ds-warning' : 'bg-ds-accent'}`}
+            style={{ width: `${pct}%` }}
+          />
+        </div>
+      </div>
+    );
+  };
+
   return (
     <GamePageShell
       title={tc('nav.pan')}
@@ -229,6 +261,8 @@ function PanPageContent() {
               <span className="mr-4">{t('drawPile', { count: state.drawPileCount })}</span>
               <span>{t('winMeld', { count: state.winMeldCount })}</span>
             </div>
+
+            {humanPlayer && renderMeldProgress(humanPlayer)}
 
             <div className={lgTwoColGrid}>
               {/* Left: game play area */}


### PR DESCRIPTION
## 概要
パングインゲ（Pan）で、人間プレイヤーの上がり進捗（`meldedCount` / `winMeldCount`）をプログレスバーで可視化する。既存のレスポンスフィールドのみを利用した純粋な追加変更。

- ヘッダ直下に `メルド {melded}/{winMeldCount}` の進捗表示とバー（`role="progressbar"`）を追加
- 上がりまで残り2枚以下になると「あと {n} 枚」を強調表示（`text-ds-warning`）
- 兄弟ゲーム `ConquianPage` の進捗バー実装パターンを踏襲
- `data-testid="pan-meld-progress"` を付与

## 受け入れ条件
- [x] 勝利メルド数への進捗が可視化される
- [x] winMeldCount/meldedCount の既存値を利用
- [x] `PanPage.test.tsx` に進捗表示テストを追加
- [ ] チップ獲得対象メルドにバッジが付く — レスポンスにメルド単位のチップ獲得フラグが無いため（valle 判定のドメインロジック複製が必要）、スコープ外として見送り

## テスト
- `bun run test -- --run PanPage`（37 件パス、うち新規2件: `shows human meld progress toward the win condition` / `highlights remaining melds when close to going out`）
- `bunx biome check`、`bun run build`（tsc）パス

Closes #3504