### PR TITLE
feat(memory): show captured pairs as mini cards per player

### DIFF
--- a/frontend/src/hooks/useMemoryGame.test.ts
+++ b/frontend/src/hooks/useMemoryGame.test.ts
@@ -21,10 +21,10 @@ function createWrapper() {
 
 const defaultState: MemoryResponse = {
   players: [
-    { id: 0, isHuman: true, pairCount: 0 },
-    { id: 1, isHuman: false, pairCount: 0 },
-    { id: 2, isHuman: false, pairCount: 0 },
-    { id: 3, isHuman: false, pairCount: 0 },
+    { id: 0, isHuman: true, pairCount: 0, pairs: [] },
+    { id: 1, isHuman: false, pairCount: 0, pairs: [] },
+    { id: 2, isHuman: false, pairCount: 0, pairs: [] },
+    { id: 3, isHuman: false, pairCount: 0, pairs: [] },
   ],
   board: Array.from({ length: 52 }, () => ({ card: null, faceUp: false, taken: false })),
   phase: 0,

--- a/frontend/src/i18n/locales/en/memory.json
+++ b/frontend/src/i18n/locales/en/memory.json
@@ -22,6 +22,8 @@
   "cardFaceDown": "Card {{position}} (face down)",
   "visitedMark": "Already seen",
   "scoreLine": "{{name}}: {{count}}",
+  "capturedPairs": "Captured Pairs",
+  "noCapturedPairs": "None",
   "nextButton": "Next",
   "flipPrompt1": "Flip the first card",
   "flipPrompt2": "Flip the second card",

--- a/frontend/src/i18n/locales/ja/memory.json
+++ b/frontend/src/i18n/locales/ja/memory.json
@@ -22,6 +22,8 @@
   "cardFaceDown": "{{position}}枚目のカード（裏向き）",
   "visitedMark": "一度めくったカード",
   "scoreLine": "{{name}}: {{count}}",
+  "capturedPairs": "獲得ペア",
+  "noCapturedPairs": "なし",
   "nextButton": "次へ",
   "flipPrompt1": "1枚目をめくってください",
   "flipPrompt2": "2枚目をめくってください",

--- a/frontend/src/pages/MemoryPage.test.tsx
+++ b/frontend/src/pages/MemoryPage.test.tsx
@@ -29,10 +29,10 @@ function makeBoard(
 
 const flip1State: MemoryResponse = {
   players: [
-    { id: 0, isHuman: true, pairCount: 0 },
-    { id: 1, isHuman: false, pairCount: 2 },
-    { id: 2, isHuman: false, pairCount: 1 },
-    { id: 3, isHuman: false, pairCount: 0 },
+    { id: 0, isHuman: true, pairCount: 0, pairs: [] },
+    { id: 1, isHuman: false, pairCount: 2, pairs: [] },
+    { id: 2, isHuman: false, pairCount: 1, pairs: [] },
+    { id: 3, isHuman: false, pairCount: 0, pairs: [] },
   ],
   board: makeBoard(),
   phase: 0,
@@ -521,6 +521,43 @@ describe('MemoryPage', () => {
     const cardBtn = screen.getByTestId('board-0');
     expect(cardBtn.className).not.toContain('border-ds-info');
     expect(cardBtn.className).toContain('border-white/10');
+  });
+
+  // --- Captured pairs mini-cards (#3028) ---
+
+  it('renders captured-pair mini cards per player', async () => {
+    const capturedState: MemoryResponse = {
+      ...flip1State,
+      players: [
+        {
+          id: 0,
+          isHuman: true,
+          pairCount: 2,
+          pairs: [
+            { design: 'CLOVER' as const, value: 3 },
+            { design: 'SPADE' as const, value: 7 },
+          ],
+        },
+        { id: 1, isHuman: false, pairCount: 1, pairs: [{ design: 'HEART' as const, value: 11 }] },
+        { id: 2, isHuman: false, pairCount: 0, pairs: [] },
+        { id: 3, isHuman: false, pairCount: 0, pairs: [] },
+      ],
+    };
+    mockExec.mockResolvedValue(capturedState);
+    renderWithProviders(<MemoryPage />);
+    await waitFor(() => expect(screen.getByTestId('mem-captured')).toBeInTheDocument());
+    // Human captured 3♣ and 7♠ → two mini cards rendered in their row.
+    const humanRow = screen.getByTestId('mem-captured-0');
+    expect(humanRow.querySelectorAll('img').length).toBe(2);
+    // A player with no captures shows the "none" placeholder.
+    expect(screen.getByTestId('mem-captured-2')).toHaveTextContent('なし');
+  });
+
+  it('captured-pairs panel is collapsible', async () => {
+    renderWithProviders(<MemoryPage />);
+    await waitFor(() => expect(screen.getByTestId('mem-captured')).toBeInTheDocument());
+    expect(screen.getByText('獲得ペア')).toBeInTheDocument();
+    expect(screen.getByTestId('mem-captured').tagName).toBe('DETAILS');
   });
 
   // --- Frontend hint ---

--- a/frontend/src/pages/MemoryPage.tsx
+++ b/frontend/src/pages/MemoryPage.tsx
@@ -124,6 +124,12 @@ function MemoryPageContent() {
 
   const [visited, setVisited] = useState<Set<number>>(() => new Set());
 
+  // Captured-pairs panel is expanded on desktop and collapsed on mobile so the
+  // board grid keeps its full height on small screens (#3028).
+  const [pairsOpen, setPairsOpen] = useState<boolean>(
+    () => typeof window !== 'undefined' && window.matchMedia('(min-width: 1024px)').matches,
+  );
+
   useEffect(() => {
     if (!state) return;
     setVisited((prev) => {
@@ -248,6 +254,42 @@ function MemoryPageContent() {
                 </span>
               ))}
             </div>
+
+            {/* Captured pairs – mini cards per player. Collapsible on mobile so
+                the board grid keeps its full height (#3028). */}
+            <details
+              className="my-1 px-2 py-1 rounded bg-black/20 text-ds-text-primary text-sm lg:shrink-0"
+              data-testid="mem-captured"
+              open={pairsOpen}
+              onToggle={(e) => setPairsOpen(e.currentTarget.open)}
+            >
+              <summary className="cursor-pointer select-none font-bold py-0.5">{t('capturedPairs')}</summary>
+              <div className="mt-1 flex flex-col gap-1">
+                {state.players.map((p) => (
+                  <div
+                    key={p.id}
+                    data-testid={`mem-captured-${p.id.toString()}`}
+                    className="flex items-center gap-1 flex-wrap"
+                  >
+                    <span className={`shrink-0 ${p.isHuman ? 'text-ds-accent' : 'text-ds-text-muted'}`}>
+                      {playerName(p.id, p.isHuman)}
+                    </span>
+                    {p.pairs.length === 0 ? (
+                      <span className="text-ds-text-muted/70">{t('noCapturedPairs')}</span>
+                    ) : (
+                      p.pairs.map((c, i) => (
+                        <AnimatedCard
+                          key={`p${p.id.toString()}-pair-${i.toString()}-${c.design}${c.value.toString()}`}
+                          card={c}
+                          width={Math.max(20, Math.round(cardWidth * 0.5))}
+                          silent
+                        />
+                      ))
+                    )}
+                  </div>
+                ))}
+              </div>
+            </details>
 
             {/* Board: responsive grid (4/8/13 columns); on lg fills remaining height */}
             <div

--- a/frontend/src/types/card.ts
+++ b/frontend/src/types/card.ts
@@ -5184,11 +5184,13 @@ export interface ThreeThirteenResponse extends BaseGameResponse {
 
 // --- Memory (神経衰弱) ---
 
-/** Memory player data with pair count. */
+/** Memory player data with pair count and captured-pair representative cards. */
 export interface MemoryPlayerData {
   id: number;
   isHuman: boolean;
   pairCount: number;
+  /** One representative card per captured pair, in ascending rank order. */
+  pairs: Card[];
 }
 
 /** A card on the Memory game board. */

--- a/frontend/src/utils/hints/memoryHint.test.ts
+++ b/frontend/src/utils/hints/memoryHint.test.ts
@@ -6,8 +6,8 @@ import { getMemoryHint } from './memoryHint';
 function makeState(overrides: Partial<MemoryResponse> = {}): MemoryResponse {
   return {
     players: [
-      { id: 0, isHuman: true, pairCount: 0 },
-      { id: 1, isHuman: false, pairCount: 0 },
+      { id: 0, isHuman: true, pairCount: 0, pairs: [] },
+      { id: 1, isHuman: false, pairCount: 0, pairs: [] },
     ],
     board: [
       { card: { design: 'SPADE', value: 1 }, faceUp: false, taken: false },

--- a/internal/adapter/controller/MemoryWebController.go
+++ b/internal/adapter/controller/MemoryWebController.go
@@ -27,6 +27,8 @@ type MemoryWebOutputPlayer struct {
 	ID        int  `json:"id"`
 	IsHuman   bool `json:"isHuman"`
 	PairCount int  `json:"pairCount"`
+	// Pairs は獲得した各ペアの代表カード（ランク昇順）。取得ペアのミニカード表示に使う。
+	Pairs []*WebOutputCard `json:"pairs"`
 }
 
 // MemoryWebOutputBoardCard 神経衰弱Webアウトプットボードカード

--- a/internal/adapter/presenter/MemoryWebPresenter.go
+++ b/internal/adapter/presenter/MemoryWebPresenter.go
@@ -3,6 +3,8 @@
 package presenter
 
 import (
+	"sort"
+
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
@@ -52,6 +54,7 @@ func (p *MemoryWebPresenter) Output(m interfaces.MemoryGame, lastErr error) stri
 			ID:        i,
 			IsHuman:   player.GetIsHuman(),
 			PairCount: player.GetPairCount(),
+			Pairs:     memoryCapturedPairs(player),
 		}
 		resObj.Players = append(resObj.Players, pObj)
 	}
@@ -87,4 +90,24 @@ func (p *MemoryWebPresenter) Output(m interfaces.MemoryGame, lastErr error) stri
 // ActionLogOutput 棋譜をJSON出力
 func (p *MemoryWebPresenter) ActionLogOutput(m interfaces.MemoryGame) string {
 	return actionLogOutputJSON(m)
+}
+
+// memoryCapturedPairs はプレイヤーが獲得した各ペアの代表カード（各ペアの1枚目）を
+// ランク昇順で返す。取得ペアのミニカード表示（issue #3028）のためのデータ。
+func memoryCapturedPairs(player *domain.MemoryPlayer) []*controller.WebOutputCard {
+	if player == nil {
+		return make([]*controller.WebOutputCard, 0)
+	}
+	pairs := player.GetPairs()
+	out := make([]*controller.WebOutputCard, 0, len(pairs))
+	for _, pair := range pairs {
+		if pair[0] == nil {
+			continue
+		}
+		out = append(out, cardToOutput(pair[0]))
+	}
+	sort.SliceStable(out, func(a, b int) bool {
+		return out[a].Value < out[b].Value
+	})
+	return out
 }

--- a/internal/adapter/presenter/MemoryWebPresenter_test.go
+++ b/internal/adapter/presenter/MemoryWebPresenter_test.go
@@ -269,6 +269,49 @@ func TestMemoryWebPresenterOutput(t *testing.T) {
 		assert.Equal(t, "2", result.MessageParams["cpuId"])
 	})
 
+	t.Run("captured pairs are output in rank order", func(t *testing.T) {
+		mg := newMockMemoryGame()
+		mg.ExpectedCalls = nil
+		mg.On("GetPlayerCnt").Return(4)
+		mg.On("GetGameEndFlag").Return(false)
+		mg.On("GetPhase").Return(domain.MemoryPhaseFlip1)
+		mg.On("GetCurrentPlayerIdx").Return(0)
+		mg.On("GetFirstFlipPos").Return(-1)
+		mg.On("GetSecondFlipPos").Return(-1)
+		mg.On("GetLastMatchResult").Return(false)
+		mg.On("GetWinnerIdx").Return(-1)
+		mg.On("GetTurnNumber").Return(0)
+		mg.On("GetConfig").Return(domain.DefaultMemoryConfig())
+
+		var board [domain.MemoryBoardSize]*domain.MemoryBoardCard
+		for i := 0; i < domain.MemoryBoardSize; i++ {
+			board[i] = &domain.MemoryBoardCard{
+				Card:   domain.NewCard(domain.CardDesignSpade, (i%13)+1, false),
+				FaceUp: false,
+				Taken:  false,
+			}
+		}
+		mg.On("GetBoard").Return(board)
+
+		human := domain.NewMemoryPlayer(true)
+		// Add pairs out of rank order to verify presenter sorts them.
+		human.AddPair(domain.NewCard(domain.CardDesignSpade, 7, false), domain.NewCard(domain.CardDesignHeart, 7, false))
+		human.AddPair(domain.NewCard(domain.CardDesignClover, 3, false), domain.NewCard(domain.CardDesignDiamond, 3, false))
+		mg.On("GetPlayer", 0).Return(human)
+		for i := 1; i < 4; i++ {
+			mg.On("GetPlayer", i).Return(domain.NewMemoryPlayer(false))
+		}
+
+		p := new(MemoryWebPresenter)
+		result := parseMemoryOutput(t, p.Output(mg, nil))
+		assert.Len(t, result.Players[0].Pairs, 2)
+		// Rank-ascending: 3 before 7.
+		assert.Equal(t, 3, result.Players[0].Pairs[0].Value)
+		assert.Equal(t, 7, result.Players[0].Pairs[1].Value)
+		// Players with no captures expose an empty (non-nil) slice.
+		assert.Empty(t, result.Players[1].Pairs)
+	})
+
 	t.Run("error message", func(t *testing.T) {
 		mg := newMockMemoryGame()
 		setupMemoryWebMockDefaults(mg)


### PR DESCRIPTION
## 概要

神経衰弱（`memory`）で各プレイヤーの獲得ペアをミニカードで可視化する。従来はスコア行に枚数のテキストしか出ておらず、どのランクが場から消えたかは記憶頼みだった。獲得済みペアをランク順のミニカードで一覧表示することで終盤の推理を助ける。

## 変更内容

- **Backend**: `MemoryWebOutputPlayer` に `pairs`（各ペアの代表カード1枚、ランク昇順）を追加し、`MemoryWebPresenter` が `MemoryPlayer.GetPairs()` から生成して出力（ドメインは既にペアを保持済み。追加のドメイン変更なし）。
- **Frontend**: `MemoryPlayerData.pairs: Card[]` を型に追加。スコア行の下に、プレイヤーごとの獲得ペアを縮小幅の `AnimatedCard` で表示する `<details>` パネルを追加。デスクトップでは展開、モバイルでは折りたたみ（`matchMedia('(min-width:1024px)')` で初期状態を決定）にして盤面グリッドの高さを維持。
- **i18n**: `capturedPairs` / `noCapturedPairs` を ja/en に追加。
- 純粋な表示追加。新しい操作ボタンは無し。

## 受け入れ条件

- [x] API レスポンスに各プレイヤーの獲得ペア一覧が追加される
- [x] 各プレイヤー行の下に獲得ペアがランク順で表示される
- [x] モバイルでは折りたたみ表示になり盤面グリッドの高さが変わらない
- [x] Presenter・Page 双方にテストを追加

## テスト

- Go: `go test -tags test ./internal/adapter/...` パス（presenter に `captured pairs are output in rank order` を追加）
- Frontend: `bun run test -- --run MemoryPage`（50 passed。`renders captured-pair mini cards per player` / `captured-pairs panel is collapsible` を追加）
- `bun run build`（tsc）パス、`biome check` クリーン、`golangci-lint` 0 issues

Closes #3028
