### PR TITLE
feat(zheng): show all-player standings table during play

### DIFF
--- a/frontend/src/i18n/locales/en/zheng.json
+++ b/frontend/src/i18n/locales/en/zheng.json
@@ -6,6 +6,9 @@
     "4": "4th"
   },
   "cardCount": "{{count}} cards",
+  "rankTable": {
+    "title": "Standings"
+  },
   "selectToPlay": "Click cards to select",
   "tableCards": "Table",
   "tableEmpty": "(empty)",

--- a/frontend/src/i18n/locales/ja/zheng.json
+++ b/frontend/src/i18n/locales/ja/zheng.json
@@ -6,6 +6,9 @@
     "4": "4位"
   },
   "cardCount": "{{count}}枚",
+  "rankTable": {
+    "title": "順位表"
+  },
   "selectToPlay": "カードを選択して出す",
   "tableCards": "場のカード",
   "tableEmpty": "(なし)",

--- a/frontend/src/pages/ZhengPage.test.tsx
+++ b/frontend/src/pages/ZhengPage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { zhengApi } from '../api/gameApi';
 import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
@@ -200,6 +200,34 @@ describe('ZhengPage', () => {
     renderWithProviders(<ZhengPage />);
     await screen.findByTestId('pass-button');
     expect(screen.getByText('— 7')).toBeInTheDocument();
+  });
+
+  it('hides the standings table until a player has finished', async () => {
+    renderWithProviders(<ZhengPage />);
+    await screen.findByTestId('pass-button');
+    expect(screen.queryByTestId('zheng-rank-table')).not.toBeInTheDocument();
+  });
+
+  it('renders a standings table ordering finished players by rank then unfinished by fewest cards', async () => {
+    mockExec.mockResolvedValue(
+      makeState({
+        players: [
+          player(0, true, [], { isFinished: true, rank: 2, cardCount: 0 }),
+          player(1, false, [], { isFinished: true, rank: 1, cardCount: 0 }),
+          player(2, false, [card('SPADE', 3)], { cardCount: 3 }),
+          player(3, false, [], { cardCount: 8 }),
+        ],
+      }),
+    );
+    renderWithProviders(<ZhengPage />);
+    const table = await screen.findByTestId('zheng-rank-table');
+    const rows = within(table).getAllByRole('listitem');
+    expect(rows).toHaveLength(4);
+    // CPU1 out first (1位), human out second (2位), then still-playing by fewest cards.
+    expect(rows[0]).toHaveTextContent('1位');
+    expect(rows[1]).toHaveTextContent('2位');
+    expect(rows[2]).toHaveTextContent('3枚');
+    expect(rows[3]).toHaveTextContent('8枚');
   });
 
   it('renders the game-end rankings message via messageCode', async () => {

--- a/frontend/src/pages/ZhengPage.tsx
+++ b/frontend/src/pages/ZhengPage.tsx
@@ -164,6 +164,16 @@ function ZhengPageContent() {
   const showInvalidCombo = isHumanTurn && selectedIndices.length > 0 && !hasValidCombo;
   const phaseName = isGameEnd ? t('phase.end') : t('phase.play');
 
+  // Standings: finished players first (by confirmed rank), then still-playing
+  // players ordered by fewest cards left. Shown once anyone has gone out so the
+  // remaining race (avoiding last place) is visible without waiting for game end.
+  const anyFinished = state.players.some((p) => p.isFinished);
+  const rankedPlayers = [...state.players].sort((a, b) => {
+    if (a.isFinished && b.isFinished) return a.rank - b.rank;
+    if (a.isFinished !== b.isFinished) return a.isFinished ? -1 : 1;
+    return a.cardCount - b.cardCount;
+  });
+
   return (
     <GamePageShell
       title={tc('nav.zheng')}
@@ -212,6 +222,29 @@ function ZhengPageContent() {
                   </div>
                 ))}
             </div>
+
+            {/* Standings — finished players' confirmed ranks + remaining card counts */}
+            {anyFinished && (
+              <div className="mx-auto max-w-xs rounded-lg bg-black/20 px-3 py-2" data-testid="zheng-rank-table">
+                <div className="mb-1 text-center text-xs text-ds-text-muted">{t('rankTable.title')}</div>
+                <ul className="space-y-0.5">
+                  {rankedPlayers.map((p) => (
+                    <li
+                      key={p.id}
+                      className="flex items-center justify-between text-xs"
+                      data-testid={`zheng-rank-row-${p.id}`}
+                    >
+                      <span>{p.isHuman ? tc('player.you') : tc('player.cpu', { id: p.id })}</span>
+                      {p.isFinished ? (
+                        <span className="font-bold text-ds-text">{t(`rank.${p.rank}`)}</span>
+                      ) : (
+                        <span className="text-ds-text-muted">{t('cardCount', { count: p.cardCount })}</span>
+                      )}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
 
             {/* Table cards */}
             <div className="py-3 bg-black/20 rounded-lg" data-tutorial="zheng-table-cards">


### PR DESCRIPTION
## 概要
争上游（ジェンシャンヨウ / `zheng`）で、進行中に全プレイヤーの状況を一覧できる順位表（Standings）を追加しました。既存の `state.players` の `isFinished` / `rank` / `cardCount` から算出する表示のみの変更で、バックエンド変更はありません。

- 上がり済みプレイヤーは確定順位（1位〜）を昇順で表示
- 未上がりプレイヤーは残り札数を表示（少ない順に並べ、ラス回避の争いが見やすい）
- 誰か1人でも上がった時点で表示（開始直後は非表示）
- i18n キー `rankTable.title` を ja/en 両方に追加

## 受け入れ条件
- [x] 上がり済みプレイヤーの順位一覧が進行中に表示される
- [x] 未上がりのプレイヤーは残り札数を表示
- [x] ゲーム終了時の最終順位表示と整合する（同じ rank/cardCount ソースを使用）
- [x] i18n キーを ja/en に追加

## テスト
- `frontend/src/pages/ZhengPage.test.tsx` に2件追加（順位表の並び順、未上がり時の非表示）
- `bun run test -- --run ZhengPage`: 18 passed
- `bun run build`（tsc）: OK
- `bunx biome check`: OK

Closes #3538
