### PR TITLE
feat(cinch): annotate bid buttons with a hand-strength guide

### DIFF
--- a/frontend/src/i18n/locales/en/cinch.json
+++ b/frontend/src/i18n/locales/en/cinch.json
@@ -23,6 +23,13 @@
   "bidPrompt": "Your turn to bid — pass or declare 1-14.",
   "bidCpu": "CPU {{id}} is bidding…",
   "bidPass": "Pass",
+  "bidStrength": {
+    "range": "Estimated points held: {{min}}-{{max}} pts (rough guide, depends on trump)",
+    "best": "Strongest trump: {{symbol}} {{suit}} (holding {{points}} pts)",
+    "legendTitle": "The 14 points",
+    "legend": "High(A)=1 / King(K)=1 / Ten(10)=1 / Jack(J)=1 / Right Pedro(5 of trump)=5 / Left Pedro(off-color 5)=5",
+    "note": "A rough guide only — your actual take depends on play after trump is named."
+  },
   "trumpPrompt": "You won the bid — name the trump suit.",
   "bidderBadge": "Bidder",
   "cards": "{{count}} cards",

--- a/frontend/src/i18n/locales/ja/cinch.json
+++ b/frontend/src/i18n/locales/ja/cinch.json
@@ -23,6 +23,13 @@
   "bidPrompt": "あなたのビッド番です — パスするか 1〜14 を宣言してください。",
   "bidCpu": "CPU {{id}} がビッド中です…",
   "bidPass": "パス",
+  "bidStrength": {
+    "range": "手札の推定獲得点: {{min}}〜{{max}}点（切り札次第の目安）",
+    "best": "最有力の切り札: {{symbol}} {{suit}}（{{points}}点分を保持）",
+    "legendTitle": "14点の構成",
+    "legend": "High(A)=1 / King(K)=1 / Ten(10)=1 / Jack(J)=1 / Right Pedro(切5)=5 / Left Pedro(同色5)=5",
+    "note": "あくまで目安です。実際の獲得点は切り札宣言後のプレイ次第で変わります。"
+  },
   "trumpPrompt": "あなたがビッドに勝ちました — 切り札を宣言してください。",
   "bidderBadge": "ビッダー",
   "cards": "{{count}}枚",

--- a/frontend/src/pages/CinchPage.test.tsx
+++ b/frontend/src/pages/CinchPage.test.tsx
@@ -114,6 +114,25 @@ describe('CinchPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('bid', { bid: 6 }));
   });
 
+  it('shows the bid-strength guide with the estimated point range and the 14-point legend', async () => {
+    mockExec.mockResolvedValue(bidPhaseState);
+    renderWithProviders(<CinchPage />);
+    const guide = await screen.findByTestId('cinch-bid-strength');
+    // Default bid hand (K♥, Q♥, A♠) holds 1 point for spades/hearts, 0 otherwise.
+    expect(screen.getByTestId('cinch-bid-strength-range')).toHaveTextContent('0〜1点');
+    expect(screen.getByTestId('cinch-bid-strength-best')).toHaveTextContent('スペード');
+    // The 14-point composition legend is present.
+    expect(guide).toHaveTextContent('14点の構成');
+    expect(guide).toHaveTextContent('Right Pedro');
+  });
+
+  it('does not show the bid-strength guide outside the human bid turn', async () => {
+    mockExec.mockResolvedValue(playPhaseState);
+    renderWithProviders(<CinchPage />);
+    await waitFor(() => expect(screen.getByTestId('cinch-trump-header')).toBeInTheDocument());
+    expect(screen.queryByTestId('cinch-bid-strength')).not.toBeInTheDocument();
+  });
+
   it('renders the name-trump phase with four suit buttons', async () => {
     mockExec.mockResolvedValue(nameTrumpState);
     renderWithProviders(<CinchPage />);

--- a/frontend/src/pages/CinchPage.tsx
+++ b/frontend/src/pages/CinchPage.tsx
@@ -27,6 +27,7 @@ import { gameTheme } from '../styles/gameTheme';
 import type { CinchResponse } from '../types/card';
 import { CinchPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { estimateCinchBidStrength } from '../utils/cinchBidStrength';
 import { CINCH_HELP, parseCinchCommand } from '../utils/cli/commands/cinchCommands';
 import { formatCinchState } from '../utils/cli/formatters/cinchFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
@@ -155,6 +156,10 @@ function CinchPageContent() {
   const canBid = isBidPhase && state.bidPlayerIdx === humanIdx && isHumanTurn;
   const canNameTrump = isNameTrumpPhase && state.bidWinnerIdx === humanIdx;
   const canPlay = isPlayPhase && isHumanTurn;
+
+  // Rough, hand-only strength guide shown alongside the bid buttons so a player
+  // can gauge how high to bid. Purely advisory — not a capture guarantee.
+  const bidStrength = canBid && humanPlayer ? estimateCinchBidStrength(humanPlayer.cards) : null;
 
   // Legal bids: pass (0) plus any raise strictly above the current highest bid, up to 14.
   const minRaise = Math.max(1, state.currentBid + 1);
@@ -365,6 +370,28 @@ function CinchPageContent() {
             {canBid && (
               <div className="mb-1 text-center text-sm text-ds-accent font-semibold" data-testid="cinch-bid-prompt">
                 {t('bidPrompt')}
+              </div>
+            )}
+            {canBid && bidStrength && (
+              <div
+                className="mb-2 mx-auto max-w-xl p-2 rounded bg-black/30 text-ds-text-muted text-xs text-center"
+                data-testid="cinch-bid-strength"
+              >
+                <div className="text-ds-text-primary" data-testid="cinch-bid-strength-range">
+                  {t('bidStrength.range', { min: bidStrength.minPoints, max: bidStrength.maxPoints })}
+                </div>
+                <div data-testid="cinch-bid-strength-best">
+                  {t('bidStrength.best', {
+                    symbol: SUIT_SYMBOLS[bidStrength.bestSuit],
+                    suit: suitLabel(bidStrength.bestSuit),
+                    points: bidStrength.pointsBySuit[bidStrength.bestSuit],
+                  })}
+                </div>
+                <div className="mt-1">
+                  <span className="text-ds-text-primary">{t('bidStrength.legendTitle')}:</span>{' '}
+                  {t('bidStrength.legend')}
+                </div>
+                <div className="mt-1 italic">{t('bidStrength.note')}</div>
               </div>
             )}
             {canNameTrump && (

--- a/frontend/src/utils/cinchBidStrength.test.ts
+++ b/frontend/src/utils/cinchBidStrength.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import type { Card } from '../types/card';
+import { cinchCardPoints, estimateCinchBidStrength } from './cinchBidStrength';
+
+const card = (design: Card['design'], value: number): Card => ({ design, value });
+
+describe('cinchCardPoints', () => {
+  it('scores the trump A/K/10/J as 1 point each', () => {
+    expect(cinchCardPoints(card('HEART', 1), 3)).toBe(1); // High (A)
+    expect(cinchCardPoints(card('HEART', 13), 3)).toBe(1); // King
+    expect(cinchCardPoints(card('HEART', 10), 3)).toBe(1); // Ten (Game)
+    expect(cinchCardPoints(card('HEART', 11), 3)).toBe(1); // Jack
+  });
+
+  it('scores the Right Pedro (5 of trump) as 5 points', () => {
+    expect(cinchCardPoints(card('HEART', 5), 3)).toBe(5);
+  });
+
+  it('scores the Left Pedro (5 of same-color off-suit) as 5 points', () => {
+    // Trump hearts -> same-color diamonds; the 5♦ is the Left Pedro.
+    expect(cinchCardPoints(card('DIAMOND', 5), 3)).toBe(5);
+    // Trump spades -> same-color clubs; the 5♣ is the Left Pedro.
+    expect(cinchCardPoints(card('CLOVER', 5), 1)).toBe(5);
+  });
+
+  it('scores non-point trump cards and off-suit cards as 0', () => {
+    expect(cinchCardPoints(card('HEART', 9), 3)).toBe(0); // trump but not a point card
+    expect(cinchCardPoints(card('SPADE', 1), 3)).toBe(0); // off-suit ace
+    expect(cinchCardPoints(card('JOKER', 0), 3)).toBe(0); // unknown design
+  });
+});
+
+describe('estimateCinchBidStrength', () => {
+  it('picks the strongest suit and brackets the range', () => {
+    // Strong in hearts: A♥, K♥, 5♥ (Right Pedro) = 1+1+5 = 7, and 5♦ is the
+    // Left Pedro for hearts (+5) => hearts total 12. Diamonds trump: 5♦ Right
+    // Pedro (5) + 5♥ Left Pedro (5) = 10.
+    const hand = [card('HEART', 1), card('HEART', 13), card('HEART', 5), card('DIAMOND', 5), card('SPADE', 2)];
+    const s = estimateCinchBidStrength(hand);
+    expect(s.bestSuit).toBe(3); // hearts
+    expect(s.pointsBySuit[3]).toBe(12);
+    expect(s.pointsBySuit[4]).toBe(10); // diamonds
+    expect(s.maxPoints).toBe(12);
+    expect(s.minPoints).toBe(0); // clubs holds no point cards here
+  });
+
+  it('returns all-zero strength for a hand with no point cards', () => {
+    const hand = [card('SPADE', 2), card('CLOVER', 3), card('HEART', 8), card('DIAMOND', 9)];
+    const s = estimateCinchBidStrength(hand);
+    expect(s.maxPoints).toBe(0);
+    expect(s.minPoints).toBe(0);
+    expect(s.bestSuit).toBe(1); // ties resolve to the lowest suit index
+  });
+});

--- a/frontend/src/utils/cinchBidStrength.ts
+++ b/frontend/src/utils/cinchBidStrength.ts
@@ -1,0 +1,76 @@
+import type { Card } from '../types/card';
+
+/** Numeric suit index for each card design (1=♠ 2=♣ 3=♥ 4=♦; 0 for JOKER/unknown). */
+const DESIGN_TO_SUIT: Readonly<Record<string, number>> = { SPADE: 1, CLOVER: 2, HEART: 3, DIAMOND: 4 };
+
+/** Same-color partner suit (♠↔♣, ♥↔♦), used to locate the Left Pedro. */
+const SAME_COLOR: Readonly<Record<number, number>> = { 1: 2, 2: 1, 3: 4, 4: 3 };
+
+/** Candidate trump suits, 1=♠ 2=♣ 3=♥ 4=♦. */
+export const CINCH_TRUMP_SUITS = [1, 2, 3, 4] as const;
+
+/**
+ * Point value a card contributes toward the 14 deal points when `suit` is trump.
+ *
+ * Mirrors `cinchPointValue` in `internal/domain/Cinch.go`: the trump A/K/10/J
+ * are worth 1 each ("High"/"King"/"Ten (Game)"/"Jack"), the Right Pedro (5 of
+ * trump) is worth 5, and the Left Pedro (5 of the same-color off-suit) is worth
+ * 5. Every other card is worth 0.
+ */
+export function cinchCardPoints(card: Card, suit: number): number {
+  const cardSuit = DESIGN_TO_SUIT[card.design] ?? 0;
+  if (cardSuit === 0) return 0;
+  // Left Pedro: the 5 of the same-color off-suit counts as a trump point card.
+  if (card.value === 5 && cardSuit === SAME_COLOR[suit]) return 5;
+  if (cardSuit !== suit) return 0;
+  switch (card.value) {
+    case 1: // High (A)
+    case 13: // King
+    case 11: // Jack
+    case 10: // Ten (Game)
+      return 1;
+    case 5: // Right Pedro
+      return 5;
+    default:
+      return 0;
+  }
+}
+
+/** A rough, hand-only estimate of Cinch bidding strength. */
+export interface CinchBidStrength {
+  /** Point-card points held in hand for each candidate trump suit (index 1-4). */
+  pointsBySuit: Readonly<Record<number, number>>;
+  /** Strongest candidate trump suit (1-4); the lowest suit index wins ties. */
+  bestSuit: number;
+  /** Points held in the strongest suit — the upper end of the guide range. */
+  maxPoints: number;
+  /** Points held in the weakest suit — the lower end of the guide range. */
+  minPoints: number;
+}
+
+/**
+ * Estimate how many of the 14 deal points the hand already holds, per candidate
+ * trump suit. This is a rough guide only: holding a point card is not the same
+ * as capturing it in play, and the estimate ignores trump length / control.
+ * `maxPoints`/`minPoints` bracket the "depending on trump" range, and `bestSuit`
+ * is the suit that maximizes held points.
+ */
+export function estimateCinchBidStrength(cards: Card[]): CinchBidStrength {
+  const pointsBySuit: Record<number, number> = { 1: 0, 2: 0, 3: 0, 4: 0 };
+  for (const suit of CINCH_TRUMP_SUITS) {
+    let total = 0;
+    for (const c of cards) total += cinchCardPoints(c, suit);
+    pointsBySuit[suit] = total;
+  }
+  let bestSuit: number = CINCH_TRUMP_SUITS[0];
+  for (const suit of CINCH_TRUMP_SUITS) {
+    if (pointsBySuit[suit] > pointsBySuit[bestSuit]) bestSuit = suit;
+  }
+  const values = CINCH_TRUMP_SUITS.map((s) => pointsBySuit[s]);
+  return {
+    pointsBySuit,
+    bestSuit,
+    maxPoints: Math.max(...values),
+    minPoints: Math.min(...values),
+  };
+}


### PR DESCRIPTION
## 概要
シンチ（Cinch / Double Pedro）のビッド選択ボタンの上に、手札から算出した「推定獲得点の目安」を併記しました。初心者が幾つビッドすべきか判断しやすくなります。

フロントエンドのみのヒューリスティック（バックエンド変更なし）。手札の各切り札候補スートについて、保持しているポイントカードの点数を合計し、最有力スートと min〜max のレンジを表示します。ポイント配点は `internal/domain/Cinch.go` の `cinchPointValue` に準拠（High/King/Ten/Jack=各1点、Right Pedro=切り札の5＝5点、Left Pedro=同色スートの5＝5点、計14点）。

## 表示内容（人間のビッド番のみ）
- 推定獲得点レンジ: `{min}〜{max}点（切り札次第の目安）`
- 最有力の切り札スートと保持点数
- 14点の構成凡例（High/King/Ten/Jack/Right Pedro/Left Pedro）
- 「あくまで目安」の注記

## 実装
- `frontend/src/utils/cinchBidStrength.ts` — 純粋関数 `estimateCinchBidStrength` / `cinchCardPoints`（+ 単体テスト）
- `frontend/src/pages/CinchPage.tsx` — `data-testid="cinch-bid-strength"` のガイド枠を bidPrompt 直下に追加（ビッド挙動は不変）
- `frontend/src/i18n/locales/{ja,en}/cinch.json` — `bidStrength.*` キーを追加（ja/en 同期）

## 受け入れ条件
- [x] ビッドフェーズで手札の推定点レンジが表示される
- [x] 14点の構成凡例（High/King/Ten/Jack/Right Pedro/Left Pedro）を表示
- [x] `bidPrompt` 表示との整合が取れている（直下に配置）
- [x] `CinchPage.test.tsx` にレンジ表示テストを追加

## テスト
- `bun run test -- --run CinchPage cinchBidStrength` … 24 passed
- `bun run build`（tsc -b + vite）… OK
- `biome check` … クリーン

Closes #3619
