### PR TITLE
feat(ulti): 捨札フェーズに選択枚数ガイドを表示

### DIFF
--- a/frontend/src/i18n/locales/en/ulti.json
+++ b/frontend/src/i18n/locales/en/ulti.json
@@ -46,6 +46,7 @@
   "bidDurchmarsch": "Durchmarsch",
   "bidPhase": "Declare a contract — pick a trump suit for Party, or declare Betli / Durchmarsch.",
   "discardPhase": "Talon exchange — pick 2 unwanted cards to discard face down.",
+  "discardProgress": "Selecting {{selected}}/{{required}} cards to discard",
   "discardButton": "Discard",
   "playButton": "Play",
   "nextTrick": "Next Trick",

--- a/frontend/src/i18n/locales/ja/ulti.json
+++ b/frontend/src/i18n/locales/ja/ulti.json
@@ -46,6 +46,7 @@
   "bidDurchmarsch": "ドゥルマルス",
   "bidPhase": "契約宣言 — 切り札を選んでパルティ、またはベトリ／ドゥルマルスを宣言します。",
   "discardPhase": "タロン交換 — 手札から不要な2枚を選んで伏せて捨てます。",
+  "discardProgress": "捨て札を {{selected}}/{{required}} 枚選択中",
   "discardButton": "捨てる",
   "playButton": "出す",
   "nextTrick": "次のトリック",

--- a/frontend/src/pages/UltiPage.test.tsx
+++ b/frontend/src/pages/UltiPage.test.tsx
@@ -134,6 +134,18 @@ describe('UltiPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('discard', { cardIndices: [0, 1] }));
   });
 
+  it('shows the discard selection count that updates as cards are picked', async () => {
+    mockExec.mockResolvedValue(discardPhaseState);
+    renderWithProviders(<UltiPage />);
+    const progress = await screen.findByTestId('ulti-discard-progress');
+    // Starts at 0 of the required 2.
+    expect(progress).toHaveTextContent('0/2');
+    fireEvent.click(screen.getByAltText('♥ Q'));
+    expect(screen.getByTestId('ulti-discard-progress')).toHaveTextContent('1/2');
+    fireEvent.click(screen.getByAltText('♥ K'));
+    expect(screen.getByTestId('ulti-discard-progress')).toHaveTextContent('2/2');
+  });
+
   it('selecting a card then playing dispatches play', async () => {
     renderWithProviders(<UltiPage />);
     const card = await screen.findByAltText('♥ Q');

--- a/frontend/src/pages/UltiPage.tsx
+++ b/frontend/src/pages/UltiPage.tsx
@@ -84,6 +84,9 @@ function signedCoins(delta: number): string {
   return delta > 0 ? `+${delta}` : `${delta}`;
 }
 
+/** Number of talon cards the declarer must discard in the Discard phase (matches `UltiDiscardSize` in `internal/domain/Ulti.go`). */
+const DISCARD_COUNT = 2;
+
 /** Selectable trump suits with their playing-card symbols (1=♠ 2=♣ 3=♥ 4=♦). */
 const TRUMP_CHOICES = [
   { code: 1, symbol: '♠' },
@@ -382,7 +385,10 @@ function UltiPageContent() {
             )}
             {canDiscard && (
               <div className="mb-1 text-center text-sm text-ds-accent font-semibold" data-testid="ulti-discard-prompt">
-                {t('discardPhase')}
+                <div>{t('discardPhase')}</div>
+                <div className="text-ds-text-muted" data-testid="ulti-discard-progress">
+                  {t('discardProgress', { selected: selectedCardIndices.length, required: DISCARD_COUNT })}
+                </div>
               </div>
             )}
             {humanPlayer && (


### PR DESCRIPTION
## 概要
ウルティのディスカードフェーズで、デクレアラーがタロンから拾った札のうち何枚を選択済みか（現在 n/2）をリアルタイム表示する選択枚数ガイドを追加します。Calabresella の捨札カウンターと同じパターンです。

必要枚数の定数 `2` は `internal/domain/Ulti.go` の `UltiDiscardSize` と一致します（フロントに `DISCARD_COUNT = 2` として明記）。

## 変更点（フロントエンドのみ・純粋な追加）
- `frontend/src/pages/UltiPage.tsx` — 捨札プロンプト直下に `data-testid="ulti-discard-progress"` の選択数表示を追加。選択数は `selectedCardIndices.length`、必要数は `DISCARD_COUNT`（=2）。
- `frontend/src/pages/UltiPage.test.tsx` — 0/2 → 1/2 → 2/2 と選択に応じて更新されることを検証するテストを追加。
- `frontend/src/i18n/locales/{ja,en}/ulti.json` — `discardProgress` キーを両言語に追加（キー同期）。

## 受け入れ条件
- [x] 選択数 n/2 がリアルタイム表示される
- [ ] タロン由来の2枚にバッジが付く — **見送り**。現状の `UltiResponse` にタロン由来カードを識別するフィールド（インデックス等）が無いため、フロントからは導出不可能。実装には `UltiWebPresenter.go` へのフィールド追加（バックエンド変更）が必要で、本PRはフロントエンド限定のためスコープ外としました。
- [x] ベトリ/ドゥルヒマルシュ時も正しく動作する — 契約種別に依らずディスカードフェーズ（`phase===1` かつ人間の手番）で共通に表示。
- [x] ページのテストを追加（WebPresenter テストはバックエンド変更を伴わないため対象外）

## テスト
- `bun run test -- --run UltiPage` — 17 tests passed（新規テスト: `shows the discard selection count that updates as cards are picked`）
- `bun run build`（tsc）通過
- `biome check` 通過

Closes #3613