### PR TITLE
feat(cuarenta): highlight capturable table cards on hand-card preview

### DIFF
--- a/frontend/src/pages/CuarentaPage.test.tsx
+++ b/frontend/src/pages/CuarentaPage.test.tsx
@@ -83,6 +83,7 @@ const cpuWinState = makeState({
 });
 
 beforeEach(() => {
+  localStorage.clear();
   mockExec.mockReset();
   mockPlaySound.mockReset();
   mockExec.mockResolvedValue(playState);
@@ -180,6 +181,32 @@ describe('CuarentaPage', () => {
     mockExec.mockClear();
     fireEvent.click(cardBtn);
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', { handIndex: 1 }));
+  });
+
+  it('rings capturable table cards while a hand card is focused, then clears on blur', async () => {
+    // hand[3] is ♣7; table[0] is ♣7 (equal rank → capturable), table[1] is ♥3.
+    renderWithProviders(<CuarentaPage />);
+    const handCard = await screen.findByTestId('hand-card-3');
+    // No preview yet: nothing is ringed.
+    expect(screen.getByTestId('cuarenta-table-card-0')).not.toHaveAttribute('data-capturable');
+
+    fireEvent.focus(handCard);
+    await waitFor(() => expect(screen.getByTestId('cuarenta-table-card-0')).toHaveAttribute('data-capturable', 'true'));
+    expect(screen.getByTestId('cuarenta-table-card-0').className).toContain('ring-ds-success');
+    // The non-matching table card stays un-ringed.
+    expect(screen.getByTestId('cuarenta-table-card-1')).not.toHaveAttribute('data-capturable');
+
+    fireEvent.blur(handCard);
+    await waitFor(() => expect(screen.getByTestId('cuarenta-table-card-0')).not.toHaveAttribute('data-capturable'));
+  });
+
+  it('does not ring any table card when it is not the human turn', async () => {
+    mockExec.mockResolvedValue(makeState({ currentTurn: 2 }));
+    renderWithProviders(<CuarentaPage />);
+    const handCard = await screen.findByTestId('hand-card-3');
+    fireEvent.focus(handCard);
+    // Hover preview is suppressed off-turn — no capturable ring appears.
+    expect(screen.getByTestId('cuarenta-table-card-0')).not.toHaveAttribute('data-capturable');
   });
 
   it('shows the empty-table label when the table is empty', async () => {

--- a/frontend/src/pages/CuarentaPage.tsx
+++ b/frontend/src/pages/CuarentaPage.tsx
@@ -29,6 +29,7 @@ import { cardAlt } from '../utils/cardAlt';
 import { CUARENTA_HELP, parseCuarentaCommand } from '../utils/cli/commands/cuarentaCommands';
 import { formatCuarentaState } from '../utils/cli/formatters/cuarentaFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { cuarentaCaptureIndices } from '../utils/cuarentaCapture';
 
 /** Cards a team must capture in a round to earn the extra "más de veinte" points. */
 const CUARENTA_CAPTURE_BONUS = 20;
@@ -94,6 +95,10 @@ function CuarentaPageContent() {
 
   const [cpuDifficulty, setCpuDifficulty] = useState(1);
 
+  // Hand card the human is hovering/focusing, used to preview which table cards
+  // that card would capture (equal-rank sweep). Clicking still plays instantly.
+  const [previewHandIndex, setPreviewHandIndex] = useState<number | null>(null);
+
   // Fetch a fresh game on mount.
   // biome-ignore lint/correctness/useExhaustiveDependencies: run once on mount.
   useEffect(() => {
@@ -157,6 +162,11 @@ function CuarentaPageContent() {
   const humanPlayer = state.players.find((p) => p.isHuman);
   // Team A = seats {0,2}; the human (seat 0) is on Team A.
   const humanTeam = humanPlayer?.team ?? 0;
+
+  // Table cards the previewed hand card would capture (equal-rank sweep), shown
+  // only while it is the human's turn so the ring is actionable advice.
+  const previewCard = isHumanTurn && previewHandIndex !== null ? (humanPlayer?.cards[previewHandIndex] ?? null) : null;
+  const captureIndices = cuarentaCaptureIndices(previewCard, state.tableCards);
 
   // Per-team captured-card totals this round: capturing 20+ cards earns the
   // "más de veinte" bonus, so the running tally matters mid-round (#3563).
@@ -300,9 +310,21 @@ function CuarentaPageContent() {
               </div>
               {state.tableCards.length > 0 ? (
                 <div className="flex flex-wrap justify-center gap-2">
-                  {state.tableCards.map((c, i) => (
-                    <CardImage key={`table-${i}`} card={c} width={cardWidth} />
-                  ))}
+                  {state.tableCards.map((c, i) => {
+                    const capturable = captureIndices.has(i);
+                    return (
+                      <div
+                        key={`table-${i}`}
+                        className={`rounded-md transition-all ${
+                          capturable ? 'ring-2 ring-ds-success motion-safe:animate-pulse' : ''
+                        }`}
+                        data-testid={`cuarenta-table-card-${i}`}
+                        data-capturable={capturable ? 'true' : undefined}
+                      >
+                        <CardImage card={c} width={cardWidth} />
+                      </div>
+                    );
+                  })}
                 </div>
               ) : (
                 <div className="text-ds-text-muted text-sm">{t('tableEmpty')}</div>
@@ -344,6 +366,10 @@ function CuarentaPageContent() {
                     key={`hand-${i}`}
                     type="button"
                     onClick={() => isHumanTurn && exec('play', { handIndex: i })}
+                    onMouseEnter={() => setPreviewHandIndex(i)}
+                    onMouseLeave={() => setPreviewHandIndex(null)}
+                    onFocus={() => setPreviewHandIndex(i)}
+                    onBlur={() => setPreviewHandIndex(null)}
                     disabled={!isHumanTurn || loading}
                     className={`rounded transition-all ${
                       isHumanTurn ? 'cursor-pointer hover:opacity-90 hover:-translate-y-1' : 'cursor-default'

--- a/frontend/src/utils/cuarentaCapture.test.ts
+++ b/frontend/src/utils/cuarentaCapture.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import type { Card } from '../types/card';
+import { cuarentaCaptureIndices } from './cuarentaCapture';
+
+const card = (design: Card['design'], value: number): Card => ({ design, value });
+
+describe('cuarentaCaptureIndices', () => {
+  it('returns an empty set when no hand card is selected', () => {
+    const table = [card('SPADE', 5), card('HEART', 5)];
+    expect(cuarentaCaptureIndices(null, table).size).toBe(0);
+  });
+
+  it('captures every table card of the same rank regardless of suit', () => {
+    const table = [card('SPADE', 7), card('HEART', 3), card('DIAMOND', 7)];
+    const result = cuarentaCaptureIndices(card('CLOVER', 7), table);
+    expect([...result].sort()).toEqual([0, 2]);
+  });
+
+  it('returns an empty set when no table card matches the rank', () => {
+    const table = [card('SPADE', 5), card('HEART', 3)];
+    expect(cuarentaCaptureIndices(card('CLOVER', 12), table).size).toBe(0);
+  });
+
+  it('captures a single matching table card', () => {
+    const table = [card('SPADE', 1), card('HEART', 11), card('DIAMOND', 2)];
+    const result = cuarentaCaptureIndices(card('CLOVER', 11), table);
+    expect([...result]).toEqual([1]);
+  });
+
+  it('handles an empty table', () => {
+    expect(cuarentaCaptureIndices(card('CLOVER', 7), []).size).toBe(0);
+  });
+});

--- a/frontend/src/utils/cuarentaCapture.ts
+++ b/frontend/src/utils/cuarentaCapture.ts
@@ -1,0 +1,23 @@
+import type { Card } from '../types/card';
+
+/**
+ * Returns the set of table-card indices a given hand card would capture in
+ * Cuarenta. Capture is a pure rank match: playing a card sweeps every table
+ * card of the same rank (`value`) at once. This mirrors the Go domain's
+ * `cuarentaRankMatchIndexes` exactly — Cuarenta has no sum/sequence capture,
+ * so no other table cards are ever taken.
+ *
+ * @param handCard - the card the human is previewing, or `null` when none.
+ * @param tableCards - the current face-up table cards.
+ * @returns a set of indices into `tableCards` that would be captured.
+ */
+export function cuarentaCaptureIndices(handCard: Card | null, tableCards: readonly Card[]): Set<number> {
+  const captured = new Set<number>();
+  if (!handCard) return captured;
+  for (let i = 0; i < tableCards.length; i++) {
+    if (tableCards[i]?.value === handCard.value) {
+      captured.add(i);
+    }
+  }
+  return captured;
+}


### PR DESCRIPTION
## 概要

クアレンタ (`cuarenta`) で、人間が手札カードにホバー/フォーカスすると、そのカードで獲得できる場札に success リング (`ring-2 ring-ds-success`) を表示します。Escoba/Scopone のキャプチャ候補ハイライトに相当するプレビュー機能です。

クリックは従来どおり即 `play` を発火します（プレビューはブロックしません）。マウスを外す / blur でリングは消えます。

## キャプチャルールの確認（重要）

Go ドメイン `internal/domain/Cuarenta.go` / `CuarentaCPU.go` の `cuarentaRankMatchIndexes` を厳密に確認しました。クアレンタの捕獲は**純粋なランク一致 (equal-rank sweep)** のみで、出したカードと同じ `GetValue()` を持つ場札を全て同時に捕獲します。ドメインのコメントにも「純粋なランク一致 (合計ではなく)」と明記されています。

- issue 文面には「連続 (sequence) キャプチャ」の記述がありますが、**現行の Go 実装には sequence/run キャプチャは存在しません**。ドメインは同ランク一致のみです。
- したがって本 PR はドメインに忠実な**同ランクハイライトのみ**を実装しています。存在しない連続キャプチャを勝手に実装してハイライトを誤らせることは避けました（受け入れ条件の「連続で追加獲得される札」はドメイン上そもそも発生しないため対象外）。

フロントエンドのみの軽量実装です（バックエンド presenter は変更していません。issue が提案する `handCaptures` の追加は不要 — 同ランク一致はフロントで正確に導出できます）。

## 変更ファイル

- `frontend/src/utils/cuarentaCapture.ts` (新規) — `cuarentaCaptureIndices(handCard, tableCards)` ヘルパー
- `frontend/src/utils/cuarentaCapture.test.ts` (新規) — ヘルパーの単体テスト
- `frontend/src/pages/CuarentaPage.tsx` — プレビュー state + 場札リング + 手札 hover/focus ハンドラ
- `frontend/src/pages/CuarentaPage.test.tsx` — フォーカス/blur プレビュー、手番外の抑止テスト

## 受け入れ条件

- [x] 手札フォーカスで獲得可能な場札が強調される（同ランク）
- [ ] 連続 (sequence) で追加獲得される札 — **Go ドメインに sequence キャプチャが存在しないため対象外**（本文参照）
- [x] 候補計算をテストで検証（`cuarentaCaptureIndices` 単体テスト + ページテスト）
- [x] `bun run test` green（CuarentaPage + cuarentaCapture 27 tests pass）
- [x] `bun run build` (tsc) pass / `biome check` clean

## テスト

- `bun run test -- --run CuarentaPage cuarentaCapture` → 27 passed
- `bun run build` → 成功
- `biome check` → No fixes applied

Closes #3562
