### PR TITLE
feat(sultan): show remaining redeal count on the web redeal button

### DIFF
--- a/frontend/src/i18n/locales/en/sultan.json
+++ b/frontend/src/i18n/locales/en/sultan.json
@@ -11,6 +11,7 @@
   "moveCount": "Moves",
   "draw": "Draw",
   "redeal": "Redeal",
+  "redealWithCount": "Redeal ({{count}} left)",
   "giveup": "Give Up",
   "empty": "Empty",
   "emptyDivanSlot": "Empty divan slot {{idx}}",

--- a/frontend/src/i18n/locales/ja/sultan.json
+++ b/frontend/src/i18n/locales/ja/sultan.json
@@ -11,6 +11,7 @@
   "moveCount": "手数",
   "draw": "引く",
   "redeal": "リディール",
+  "redealWithCount": "リディール（残り{{count}}回）",
   "giveup": "ギブアップ",
   "empty": "空",
   "emptyDivanSlot": "空のディヴァン枠 {{idx}}",

--- a/frontend/src/pages/SultanPage.test.tsx
+++ b/frontend/src/pages/SultanPage.test.tsx
@@ -174,11 +174,11 @@ describe('SultanPage', () => {
   it('redeal button shown and dispatches redeal when canRedeal', async () => {
     mockExec.mockResolvedValue(canRedealState);
     renderWithProviders(<SultanPage />);
-    await waitFor(() => expect(screen.getByRole('button', { name: 'リディール' })).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole('button', { name: /リディール/ })).toBeInTheDocument());
 
     mockExec.mockClear();
     mockExec.mockResolvedValue(canRedealState);
-    fireEvent.click(screen.getByRole('button', { name: 'リディール' }));
+    fireEvent.click(screen.getByRole('button', { name: /リディール/ }));
 
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('redeal'));
   });
@@ -186,7 +186,21 @@ describe('SultanPage', () => {
   it('redeal button hidden when canRedeal is false', async () => {
     renderWithProviders(<SultanPage />);
     await waitFor(() => expect(screen.getByText('ウェイスト')).toBeInTheDocument());
-    expect(screen.queryByRole('button', { name: 'リディール' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /リディール/ })).not.toBeInTheDocument();
+  });
+
+  it('redeal button shows the remaining redeal count', async () => {
+    // redealCount 0 of a max of 2 → 2 redeals remaining.
+    mockExec.mockResolvedValue(canRedealState);
+    renderWithProviders(<SultanPage />);
+    await waitFor(() => expect(screen.getByTestId('sultan-redeal-count')).toHaveTextContent('リディール（残り2回）'));
+  });
+
+  it('redeal button count reflects one redeal already used', async () => {
+    // redealCount 1 of a max of 2 → 1 redeal remaining (matches CUI display).
+    mockExec.mockResolvedValue({ ...canRedealState, redealCount: 1 });
+    renderWithProviders(<SultanPage />);
+    await waitFor(() => expect(screen.getByTestId('sultan-redeal-count')).toHaveTextContent('リディール（残り1回）'));
   });
 
   it('clicking waste card dispatches move from waste', async () => {

--- a/frontend/src/pages/SultanPage.tsx
+++ b/frontend/src/pages/SultanPage.tsx
@@ -31,6 +31,12 @@ import { cardAlt } from '../utils/cardAlt';
 import { parseSultanCommand, SULTAN_HELP } from '../utils/cli/commands/sultanCommands';
 import { formatSultanState } from '../utils/cli/formatters/sultanFormatter';
 
+/**
+ * Maximum number of waste redeals allowed in Sultan of Turkey.
+ * Mirrors `domain.SultanMaxRedeal` (total of 3 passes through the stock).
+ */
+const SULTAN_MAX_REDEAL = 2;
+
 /** Sultan of Turkey tutorial step definitions. */
 const SULTAN_TUTORIAL_STEPS: TutorialStep[] = [
   {
@@ -375,8 +381,11 @@ function SultanPageContent() {
                       className={btnPrimary}
                       onClick={handleRedeal}
                       disabled={loading || isAutoCompleting}
+                      data-testid="sultan-redeal-count"
                     >
-                      {t('redeal')}
+                      {t('redealWithCount', {
+                        count: SULTAN_MAX_REDEAL - state.redealCount,
+                      })}
                     </button>
                   )}
                   <button


### PR DESCRIPTION
## 概要
スルタン（Sultan of Turkey）の Web UI で、残りリディール回数が一切表示されていなかった問題を修正します。CUI は `SultanMaxRedeal - GetRedealCount()`（残り回数）を明示していましたが、Web UI は `canRedeal` の真偽値でボタンの表示/非表示を切り替えるだけでした。

## 変更内容
- リディールボタンのラベルを「リディール（残り{{count}}回）」に変更（`redealCount` と定数 `SULTAN_MAX_REDEAL = 2` から算出。CUI と同じ値）
- 読み取り用に `data-testid="sultan-redeal-count"` を付与
- ja/en の `sultan.json` に `redealWithCount` キーを追加（key-for-key で同期）
- ボタンは `canRedeal` により残り0回で従来どおり非表示（domain: `redealCount < SultanMaxRedeal`）
- ページテストを追加（残り2回/残り1回の表示を検証）

フロントエンドのみの追加変更です。バックエンド（`SultanResponse`）には既存の `redealCount` を活用し、新規フィールドは追加していません。

## 受け入れ条件
- [x] Web UIに残りリディール回数が表示される
- [x] CUIの表示内容と数値が一致する（`SultanMaxRedeal - redealCount`）
- [x] 回数が0になった時点でボタンが非表示になる（`canRedeal`）
- [x] フロントエンドに単体テストを追加する（バックエンドは既存フィールド利用のため変更なし）

## テスト
- `bun run test -- --run SultanPage` : 30 passed
- `bun run build`（tsc）: 成功
- `biome check`: 成功

Closes #3293
