### PR TITLE
feat(ecarte): guard discard button with selection count and reason

### DIFF
--- a/frontend/src/i18n/locales/en/ecarte.json
+++ b/frontend/src/i18n/locales/en/ecarte.json
@@ -38,6 +38,9 @@
   "refuseButton": "Refuse",
   "discardPrompt": "Choose cards to discard:",
   "discardButton": "Exchange ({{count}})",
+  "discardSelectionGuide": "{{count}} selected",
+  "discardReasonEmpty": "Select at least one card",
+  "discardReasonExceed": "Not enough stock",
   "nextRound": "Next Deal",
   "target": "Target: {{points}} pts",
   "roundResult": {

--- a/frontend/src/i18n/locales/ja/ecarte.json
+++ b/frontend/src/i18n/locales/ja/ecarte.json
@@ -38,6 +38,9 @@
   "refuseButton": "拒否",
   "discardPrompt": "捨てるカードを選んでください:",
   "discardButton": "交換する ({{count}})",
+  "discardSelectionGuide": "{{count}}枚選択中",
+  "discardReasonEmpty": "カードを選択してください",
+  "discardReasonExceed": "山札が足りません",
   "nextRound": "次のディール",
   "target": "目標: {{points}}点",
   "roundResult": {

--- a/frontend/src/pages/EcartePage.test.tsx
+++ b/frontend/src/pages/EcartePage.test.tsx
@@ -112,6 +112,34 @@ describe('EcartePage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('discard', { discardIndices: [0] }));
   });
 
+  it('disables the discard button and shows the empty reason when no card is selected', async () => {
+    mockExec.mockResolvedValue(discardState);
+    renderWithProviders(<EcartePage />);
+    const discard = await screen.findByTestId('ecarte-discard');
+    expect(discard).toBeDisabled();
+    expect(screen.getByTestId('ecarte-discard-reason')).toHaveTextContent('カードを選択してください');
+    expect(screen.getByTestId('ecarte-discard-guide')).toHaveTextContent('0枚選択中');
+  });
+
+  it('enables the discard button and updates the count guide once a card is selected', async () => {
+    mockExec.mockResolvedValue(discardState);
+    renderWithProviders(<EcartePage />);
+    const card = await screen.findByAltText('♠ K');
+    fireEvent.click(card);
+    expect(screen.getByTestId('ecarte-discard')).toBeEnabled();
+    expect(screen.getByTestId('ecarte-discard-guide')).toHaveTextContent('1枚選択中');
+    expect(screen.queryByTestId('ecarte-discard-reason')).not.toBeInTheDocument();
+  });
+
+  it('disables the discard button and shows the stock reason when selecting more than the stock', async () => {
+    mockExec.mockResolvedValue(makeEcarteState({ phase: 0, negStep: 2, currentPlayerIdx: 0, stockRemaining: 0 }));
+    renderWithProviders(<EcartePage />);
+    const card = await screen.findByAltText('♠ K');
+    fireEvent.click(card);
+    expect(screen.getByTestId('ecarte-discard')).toBeDisabled();
+    expect(screen.getByTestId('ecarte-discard-reason')).toHaveTextContent('山札が足りません');
+  });
+
   it('renders the play phase with the human cards and the play button', async () => {
     mockExec.mockResolvedValue(playPhaseState);
     renderWithProviders(<EcartePage />);

--- a/frontend/src/pages/EcartePage.tsx
+++ b/frontend/src/pages/EcartePage.tsx
@@ -150,6 +150,14 @@ function EcartePageContent() {
     isHumanExchangeTurn &&
     (state.negStep === EcarteNegStep.ELDER_DISCARD || state.negStep === EcarteNegStep.DEALER_DISCARD);
 
+  // Discard-step guards: block an empty selection (server-error otherwise) and a
+  // selection larger than the remaining stock, surfacing the reason inline (#3454).
+  const discardCount = selectedCardIndices.length;
+  const discardExceedsStock = discardCount > state.stockRemaining;
+  const discardDisabled = loading || discardCount === 0 || discardExceedsStock;
+  const discardReasonKey =
+    discardCount === 0 ? 'discardReasonEmpty' : discardExceedsStock ? 'discardReasonExceed' : null;
+
   const trumpSymbol = state.trumpSuit >= 1 && state.trumpSuit <= 4 ? SUIT_SYMBOLS[state.trumpSuit] : t('noTrump');
 
   const handleManualReset = () => {
@@ -379,15 +387,23 @@ function EcartePageContent() {
               {isDiscardStep && (
                 <>
                   <span className="text-xs text-ds-text-muted self-center mr-1">{t('discardPrompt')}</span>
+                  <span className="text-xs text-ds-text-primary self-center mr-1" data-testid="ecarte-discard-guide">
+                    {t('discardSelectionGuide', { count: selectedCardIndices.length })}
+                  </span>
                   <button
                     type="button"
                     className={btnPrimary}
                     onClick={handleDiscard}
-                    disabled={loading}
+                    disabled={discardDisabled}
                     data-testid="ecarte-discard"
                   >
                     {t('discardButton', { count: selectedCardIndices.length })}
                   </button>
+                  {discardReasonKey && (
+                    <span className="text-xs text-ds-warning self-center" data-testid="ecarte-discard-reason">
+                      {t(discardReasonKey)}
+                    </span>
+                  )}
                 </>
               )}
               {isRoundEnd && (


### PR DESCRIPTION
## 概要

エカルテの交換フェーズ discard ステップで、捨て札ボタン（`data-testid="ecarte-discard"`）が 0 枚選択でも押せてしまいサーバー側エラーに頼っていた問題を修正。既存の選択状態から派生させたフロントエンドのみのガードを追加した。

- 0 枚選択、または選択枚数が山札残数（`state.stockRemaining`）を超える場合はボタンを無効化
- 無効理由を discardPrompt の隣にインライン表示（「カードを選択してください」／「山札が足りません」）
- 選択枚数ガイド「n枚選択中」を常時表示（`data-testid="ecarte-discard-guide"`）
- discard アクション自体は変更なし

## 受け入れ条件

- [x] 0 枚選択時に捨て札ボタンが無効になる
- [x] 山札残数を超える選択時に無効化と理由表示がされる
- [x] ja/en 両ロケールに理由文言を追加
- [x] EcartePage.test.tsx に選択枚数別テストを追加

## テスト

- `bun run test -- --run EcartePage` — 18 passed（新規 3 件追加）
- `bun run build`（tsc）通過
- `bunx biome check` 通過

Closes #3454
