### PR TITLE
feat(mus): guard 0-card discard and add selection-count guide

### DIFF
--- a/frontend/src/i18n/locales/en/mus.json
+++ b/frontend/src/i18n/locales/en/mus.json
@@ -36,6 +36,8 @@
   "corteButton": "Corte (play)",
   "discardButton": "Exchange",
   "discardSelected": "Selected {{count}}",
+  "discardGuide": "Choose 1–4 cards to exchange",
+  "discardCount": "{{count}} selected",
   "keepAll": "Keep all",
   "bet": {
     "paso": "Paso (pass)",

--- a/frontend/src/i18n/locales/ja/mus.json
+++ b/frontend/src/i18n/locales/ja/mus.json
@@ -36,6 +36,8 @@
   "corteButton": "コルテ（勝負）",
   "discardButton": "交換する",
   "discardSelected": "選択 {{count}}枚",
+  "discardGuide": "交換するカードを1〜4枚選んでください",
+  "discardCount": "{{count}}枚選択中",
   "keepAll": "全保持",
   "bet": {
     "paso": "パソ（パス）",

--- a/frontend/src/pages/MusPage.test.tsx
+++ b/frontend/src/pages/MusPage.test.tsx
@@ -79,14 +79,27 @@ describe('MusPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('mus', { mus: false }));
   });
 
-  it('renders the discard button in the discard phase', async () => {
+  it('disables the discard button and shows the guide when nothing is selected', async () => {
     mockExec.mockResolvedValue(discardState);
     renderWithProviders(<MusPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: /交換する/ })).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: /交換する/ })).toBeDisabled();
+    expect(screen.getByTestId('mus-discard-guide')).toHaveTextContent('交換するカードを1〜4枚選んでください');
+  });
+
+  it('enables the discard button once a card is selected and dispatches the discard', async () => {
+    mockExec.mockResolvedValue(discardState);
+    renderWithProviders(<MusPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: /交換する/ })).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: '♠ A' }));
+    expect(screen.getByRole('button', { name: /交換する/ })).toBeEnabled();
+    expect(screen.getByTestId('mus-discard-guide')).toHaveTextContent('1枚選択中');
+
     mockExec.mockClear();
     mockExec.mockResolvedValue(discardState);
     fireEvent.click(screen.getByRole('button', { name: /交換する/ }));
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('discard', { discardIndices: [] }));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('discard', { discardIndices: [0] }));
   });
 
   it('renders bet buttons gated by can flags and dispatches envido', async () => {

--- a/frontend/src/pages/MusPage.tsx
+++ b/frontend/src/pages/MusPage.tsx
@@ -305,9 +305,21 @@ function MusPageContent() {
               )}
 
               {isDiscardPhase && isHumanTurn && (
-                <button type="button" className={btnPrimary} onClick={handleDiscard} disabled={loading}>
-                  {t('discardButton')} ({t('discardSelected', { count: selectedCardIndices.length })})
-                </button>
+                <>
+                  <button
+                    type="button"
+                    className={btnPrimary}
+                    onClick={handleDiscard}
+                    disabled={loading || selectedCardIndices.length === 0}
+                  >
+                    {t('discardButton')} ({t('discardSelected', { count: selectedCardIndices.length })})
+                  </button>
+                  <span className="text-ds-text-muted text-sm" data-testid="mus-discard-guide">
+                    {selectedCardIndices.length === 0
+                      ? t('discardGuide')
+                      : t('discardCount', { count: selectedCardIndices.length })}
+                  </span>
+                </>
               )}
 
               {isBetPhase && isHumanTurn && (


### PR DESCRIPTION
## 概要

ムスの DISCARD フェーズで、カードを 1 枚も選ばずに交換ボタンを押せてしまう問題を修正します。sheepshead の BURY 枚数ガードと同様に、未選択時は交換ボタンを無効化し、選択枚数のガイドを表示します。フロントエンドのみ・既存の選択状態から導出。捨て札アクション自体は変更していません。

## 変更内容

- `MusPage.tsx`: 交換ボタンの `disabled` に `selectedCardIndices.length === 0` を追加
- `MusPage.tsx`: `data-testid="mus-discard-guide"` のガイド表示（未選択時「交換するカードを1〜4枚選んでください」／選択時「n枚選択中」）
- `mus.json` (ja/en): `discardGuide` / `discardCount` キーを追加（key-for-key 同期）
- `MusPage.test.tsx`: 0 枚時の無効化・ガイド文、1 枚選択で有効化して discard が dispatch されることを検証

ムスの手札は 4 枚のため、そもそも 5 枚以上は選択できません（受け入れ条件 3 はデッキ仕様で自然に満たされます）。

## 受け入れ条件

- [x] 0 枚選択時に捨て札ボタンが無効化される
- [x] 未選択時にガイド文が表示される（ja/en）
- [x] 5 枚以上の選択ができない（手札 4 枚のため自然に成立）
- [x] `MusPage.test.tsx` にガードのテスト追加

## テスト

- `bun run test -- --run MusPage` (12 passed)
- `bun run build`（tsc）通過
- `biome check` 通過

Closes #3408
