### PR TITLE
feat(samba): show per-meld canasta/samba progress with completion pulse

### DIFF
--- a/frontend/src/i18n/locales/en/samba.json
+++ b/frontend/src/i18n/locales/en/samba.json
@@ -31,6 +31,12 @@
   "mixedCanasta": "Mixed Canasta",
   "samba": "Samba",
   "sequence": "Sequence",
+  "meldProgress": {
+    "toCanasta": "{{n}} more for Canasta",
+    "toSamba": "{{n}} more for Samba",
+    "canastaComplete": "Canasta complete!",
+    "sambaComplete": "Samba complete!"
+  },
   "drawStockButton": "Draw from stock",
   "drawDiscardButton": "Pick up discard",
   "meldButton": "Meld",

--- a/frontend/src/i18n/locales/ja/samba.json
+++ b/frontend/src/i18n/locales/ja/samba.json
@@ -31,6 +31,12 @@
   "mixedCanasta": "ミックスカナスタ",
   "samba": "サンバ",
   "sequence": "シーケンス",
+  "meldProgress": {
+    "toCanasta": "あと{{n}}枚でカナスタ",
+    "toSamba": "あと{{n}}枚でサンバ",
+    "canastaComplete": "カナスタ成立！",
+    "sambaComplete": "サンバ成立！"
+  },
   "drawStockButton": "山札から引く",
   "drawDiscardButton": "捨て札を取る",
   "meldButton": "メルドする",

--- a/frontend/src/pages/SambaPage.test.tsx
+++ b/frontend/src/pages/SambaPage.test.tsx
@@ -166,4 +166,41 @@ describe('SambaPage', () => {
     expect(screen.queryByTestId('sa-draw-discard-reason')).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: '捨て札を取る' })).not.toBeDisabled();
   });
+
+  it('shows canasta/samba progress and a completion pulse per meld', async () => {
+    const base = makeSambaState();
+    const human = {
+      ...base.players[0],
+      melds: [
+        // Incomplete set: 5 cards → 2 more for a canasta.
+        {
+          cards: Array.from({ length: 5 }, () => ({ design: 'SPADE' as const, value: 4 })),
+          kind: 0,
+          isNatural: true,
+          isCanasta: false,
+          isSamba: false,
+          rank: 4,
+        },
+        // Completed 7-card sequence → samba, with pulse emphasis.
+        {
+          cards: Array.from({ length: 7 }, (_, i) => ({ design: 'HEART' as const, value: i + 3 })),
+          kind: 1,
+          isNatural: true,
+          isCanasta: false,
+          isSamba: true,
+          rank: 3,
+        },
+      ],
+    };
+    mockExec.mockResolvedValue(makeSambaState({ players: [human, ...base.players.slice(1)] }));
+    renderWithProviders(<SambaPage />);
+
+    const setProgress = await screen.findByTestId('sa-meld-progress-0-0');
+    expect(setProgress).toHaveTextContent('あと2枚でカナスタ');
+    expect(setProgress.className).not.toContain('animate-pulse');
+
+    const sambaProgress = screen.getByTestId('sa-meld-progress-0-1');
+    expect(sambaProgress).toHaveTextContent('サンバ成立！');
+    expect(sambaProgress.className).toContain('animate-pulse');
+  });
 });

--- a/frontend/src/pages/SambaPage.tsx
+++ b/frontend/src/pages/SambaPage.tsx
@@ -36,6 +36,12 @@ import type { CliGameConfig } from '../utils/cli/types';
 import { playerName } from '../utils/playerUtils';
 import { sambaMinMeld, sambaSelectionPoints } from '../utils/sambaScore';
 
+/**
+ * Cards required to complete a canasta (7-card set) or samba (7-card sequence).
+ * Matches the Go domain rule (`SambaMeld.IsCanasta`/`IsSamba`: `len(Cards) >= 7`).
+ */
+const SAMBA_CANASTA_SIZE = 7;
+
 const SAMBA_PHASE_KEYS: Readonly<Record<number, string>> = {
   [SambaPhase.DRAW]: 'draw',
   [SambaPhase.MELD]: 'meld',
@@ -297,24 +303,41 @@ function SambaPageContent() {
                         {p.hasCanasta && <span className="ml-2 text-ds-warning">★</span>}
                         {p.hasSamba && <span className="ml-1 text-ds-accent">▲</span>}
                       </div>
-                      {p.melds.map((m, mi) => (
-                        <div key={mi} className="flex flex-wrap gap-1 mb-1">
-                          <span className="text-xs text-ds-text-muted self-center mr-1">
-                            {m.kind === 1
-                              ? m.isSamba
-                                ? t('samba')
-                                : t('sequence')
-                              : m.isCanasta
-                                ? m.isNatural
-                                  ? t('naturalCanasta')
-                                  : t('mixedCanasta')
-                                : `(${m.cards.length})`}
-                          </span>
-                          {m.cards.map((card, ci) => (
-                            <AnimatedCard key={`meld-${pi}-${mi}-${ci}`} card={card} width={cardWidth * 0.6} />
-                          ))}
-                        </div>
-                      ))}
+                      {p.melds.map((m, mi) => {
+                        // Progress toward the 7-card canasta (set) / samba (sequence)
+                        // milestone, derived purely from `cards.length` and `kind`.
+                        const remaining = SAMBA_CANASTA_SIZE - m.cards.length;
+                        const toSamba = m.kind === 1;
+                        const complete = remaining <= 0;
+                        return (
+                          <div key={mi} className="flex flex-wrap gap-1 mb-1">
+                            <span className="text-xs text-ds-text-muted self-center mr-1">
+                              {m.kind === 1
+                                ? m.isSamba
+                                  ? t('samba')
+                                  : t('sequence')
+                                : m.isCanasta
+                                  ? m.isNatural
+                                    ? t('naturalCanasta')
+                                    : t('mixedCanasta')
+                                  : `(${m.cards.length})`}
+                            </span>
+                            <span
+                              data-testid={`sa-meld-progress-${pi}-${mi}`}
+                              className={`text-xs self-center mr-1 ${
+                                complete ? 'text-ds-success font-bold motion-safe:animate-pulse' : 'text-ds-info'
+                              }`}
+                            >
+                              {complete
+                                ? t(toSamba ? 'meldProgress.sambaComplete' : 'meldProgress.canastaComplete')
+                                : t(toSamba ? 'meldProgress.toSamba' : 'meldProgress.toCanasta', { n: remaining })}
+                            </span>
+                            {m.cards.map((card, ci) => (
+                              <AnimatedCard key={`meld-${pi}-${mi}-${ci}`} card={card} width={cardWidth * 0.6} />
+                            ))}
+                          </div>
+                        );
+                      })}
                       {p.red3s.length > 0 && (
                         <div className="flex flex-wrap gap-1 mt-1">
                           <span className="text-xs text-ds-error self-center mr-1">{t('red3s')}</span>


### PR DESCRIPTION
## 概要

サンバの各メルド行に、カナスタ(7枚セット)/サンバ(7枚連番)の**成立までの残枚数**を表示し、成立時には success 色の pulse 演出で強調します。データは既存の `meld.cards.length` と `meld.kind` から算出するのみで、バックエンド変更はありません。

要件の7枚は Go ドメイン (`internal/domain/SambaPlayer.go` の `SambaMeld.IsCanasta`/`IsSamba`: `len(Cards) >= 7`) と一致します。フロント側に `SAMBA_CANASTA_SIZE = 7` 定数を定義。

## 変更点

- `SambaPage.tsx`: メルドごとに `sa-meld-progress-<pi>-<mi>` を出力。未完成は「あと{n}枚でカナスタ/サンバ」、完成は「カナスタ/サンバ成立！」+ `motion-safe:animate-pulse`。
- `i18n/locales/{ja,en}/samba.json`: `meldProgress` キーを key-for-key で追加。
- `SambaPage.test.tsx`: 未完成(set 5枚→あと2枚)と完成(sequence 7枚→pulse)の両ケースを検証するテストを追加。

## 受け入れ条件

- [x] 未完成メルドに Canasta/Samba までの残枚数が表示される
- [x] 成立時に強調演出(pulse)が出る
- [x] メルドの `cards.length` と `kind` から算出
- [x] `SambaPage.test.tsx` に進捗表示テストを追加

## 確認

- `bun run test -- --run SambaPage` … 18 passed
- `bun run build` (tsc) … 成功
- `biome check` … クリーン

Closes #3495
