### PR TITLE
feat(preference): show declarer contract progress and failure status

### DIFF
--- a/frontend/src/i18n/locales/en/preference.json
+++ b/frontend/src/i18n/locales/en/preference.json
@@ -55,6 +55,12 @@
     "title": "Round Result",
     "tricks": "{{name}} tricks: {{count}}"
   },
+  "progress": {
+    "line": "Declarer progress: {{won}} / {{needed}} tricks",
+    "misere": "Declarer progress: {{won}} tricks (Misère, target 0)",
+    "made": "Contract made",
+    "failed": "Contract failed"
+  },
   "hintAvailable": "Hint",
   "hint": {
     "lead_low": "Lead a low card to conserve strength",

--- a/frontend/src/i18n/locales/ja/preference.json
+++ b/frontend/src/i18n/locales/ja/preference.json
@@ -55,6 +55,12 @@
     "title": "ラウンド結果",
     "tricks": "{{name}} トリック: {{count}}"
   },
+  "progress": {
+    "line": "宣言者の進捗: {{won}} / {{needed}} トリック",
+    "misere": "宣言者の進捗: {{won}} トリック（ミゼール・目標0）",
+    "made": "達成",
+    "failed": "失敗確定"
+  },
   "hintAvailable": "ヒント",
   "hint": {
     "lead_low": "低い札でリードして温存することを推奨",

--- a/frontend/src/pages/PreferencePage.test.tsx
+++ b/frontend/src/pages/PreferencePage.test.tsx
@@ -175,4 +175,77 @@ describe('PreferencePage', () => {
     renderWithProviders(<PreferencePage />);
     await waitFor(() => expect(screen.getByText('ゲーム終了！ あなたの勝ち！')).toBeInTheDocument());
   });
+
+  // A play-phase state where CPU 1 is the declarer with the given contract and trick progress.
+  const declarerProgressState = (contract: number, tricksWon: number, cardsLeft: number) =>
+    makePreferenceState({
+      phase: 1,
+      declarerIdx: 1,
+      contract,
+      trumpSuit: 3,
+      isHumanBidTurn: false,
+      isHumanTurn: false,
+      currentPlayerIdx: 0,
+      players: [
+        { id: 0, isHuman: true, cardCount: cardsLeft, cards: [], trickCount: 0, score: 0, isDeclarer: false },
+        {
+          id: 1,
+          isHuman: false,
+          cardCount: cardsLeft,
+          cards: [],
+          trickCount: tricksWon,
+          score: 0,
+          isDeclarer: true,
+        },
+        { id: 2, isHuman: false, cardCount: cardsLeft, cards: [], trickCount: 0, score: 0, isDeclarer: false },
+      ],
+    });
+
+  it('shows in-progress contract progress with the target', async () => {
+    // Six (needs 6), 4 won with 3 tricks left → reachable, still in progress.
+    mockExec.mockResolvedValue(declarerProgressState(1, 4, 3));
+    renderWithProviders(<PreferencePage />);
+    const readout = await screen.findByTestId('preference-contract-progress');
+    expect(readout).toHaveTextContent('4 / 6');
+    expect(readout).toHaveClass('text-ds-warning');
+    expect(readout).not.toHaveTextContent('達成');
+    expect(readout).not.toHaveTextContent('失敗確定');
+  });
+
+  it('shows the contract as made once the target is reached', async () => {
+    // Six (needs 6), 6 won with 0 left → made.
+    mockExec.mockResolvedValue(declarerProgressState(1, 6, 0));
+    renderWithProviders(<PreferencePage />);
+    const readout = await screen.findByTestId('preference-contract-progress');
+    expect(readout).toHaveTextContent('6 / 6');
+    expect(readout).toHaveTextContent('達成');
+    expect(readout).toHaveClass('text-ds-success');
+  });
+
+  it('shows failure once the target becomes unreachable', async () => {
+    // Eight (needs 8), 2 won with 3 left → 2+3 < 8, failure certain.
+    mockExec.mockResolvedValue(declarerProgressState(4, 2, 3));
+    renderWithProviders(<PreferencePage />);
+    const readout = await screen.findByTestId('preference-contract-progress');
+    expect(readout).toHaveTextContent('2 / 8');
+    expect(readout).toHaveTextContent('失敗確定');
+    expect(readout).toHaveClass('text-ds-error');
+  });
+
+  it('flags Misère failure the instant the declarer wins a trick', async () => {
+    // Misère (target 0), 1 trick won → immediate failure.
+    mockExec.mockResolvedValue(declarerProgressState(2, 1, 5));
+    renderWithProviders(<PreferencePage />);
+    const readout = await screen.findByTestId('preference-contract-progress');
+    expect(readout).toHaveTextContent('ミゼール');
+    expect(readout).toHaveTextContent('失敗確定');
+    expect(readout).toHaveClass('text-ds-error');
+  });
+
+  it('does not show contract progress before a declarer is decided', async () => {
+    mockExec.mockResolvedValue(bidPhaseState);
+    renderWithProviders(<PreferencePage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalled());
+    expect(screen.queryByTestId('preference-contract-progress')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/PreferencePage.tsx
+++ b/frontend/src/pages/PreferencePage.tsx
@@ -38,6 +38,60 @@ const SUIT_SYMBOLS = ['', '♠', '♣', '♥', '♦'] as const;
 /** Contract i18n key suffixes indexed by contract value (0=Pass…4=Eight). */
 const CONTRACT_KEYS = ['pass', 'six', 'misere', 'seven', 'eight'] as const;
 
+/**
+ * Target trick count for each contract, indexed by contract value
+ * (0=Pass 1=Six 2=Misère 3=Seven 4=Eight). Mirrors the Go domain
+ * `preferenceBidTarget`; Misère targets 0 tricks won.
+ */
+const CONTRACT_TARGET_TRICKS = [0, 6, 0, 7, 8] as const;
+
+/** Whether the declarer has made their contract, failed it, or is still in progress. */
+type ContractStatus = 'made' | 'failed' | 'progress';
+
+/** Tailwind text color per contract status (made=success, in-progress=warning, failed=error). */
+const CONTRACT_STATUS_COLOR: Readonly<Record<ContractStatus, string>> = {
+  made: 'text-ds-success',
+  failed: 'text-ds-error',
+  progress: 'text-ds-warning',
+};
+
+/** The declarer's contract progress derived from tricks won and cards still in hand. */
+interface ContractProgress {
+  /** Tricks the declarer has won so far this round. */
+  won: number;
+  /** Tricks the declarer needs (0 for Misère). */
+  needed: number;
+  /** Made / failed / still in progress. */
+  status: ContractStatus;
+  /** Whether the contract is Misère (win no tricks). */
+  isMisere: boolean;
+}
+
+/**
+ * Computes the declarer's contract progress from tricks won and remaining tricks.
+ * `remaining` is the declarer's card count (each remaining card equals one trick still to play).
+ * Matches the Go domain `contractMade`: Misère succeeds on zero tricks, others on reaching the target.
+ */
+function computeContractProgress(contract: number, won: number, remaining: number): ContractProgress {
+  const isMisere = contract === PreferenceContract.MISERE;
+  const needed = CONTRACT_TARGET_TRICKS[contract] ?? 0;
+  let status: ContractStatus;
+  if (isMisere) {
+    // Misère fails the instant a trick is won; it is only made once the round completes clean.
+    if (won > 0) status = 'failed';
+    else if (remaining === 0) status = 'made';
+    else status = 'progress';
+  } else if (won >= needed) {
+    status = 'made';
+  } else if (won + remaining < needed) {
+    // Not enough tricks left to reach the target — failure is mathematically certain.
+    status = 'failed';
+  } else {
+    status = 'progress';
+  }
+  return { won, needed, status, isMisere };
+}
+
 /** Bid button options (Pass/Six/Misère/Seven/Eight). */
 const BIDS: { value: number; key: string }[] = [
   { value: PreferenceContract.PASS, key: 'bid.pass' },
@@ -152,6 +206,13 @@ function PreferencePageContent() {
   const contractName =
     state.declarerIdx >= 0 ? t(`contractName.${CONTRACT_KEYS[state.contract] ?? 'pass'}`) : t('contractUndecided');
 
+  // Declarer's progress toward the contract, derived from tricks won and cards still in hand.
+  const declarer = state.declarerIdx >= 0 ? state.players[state.declarerIdx] : undefined;
+  const contractProgress =
+    declarer && state.contract !== PreferenceContract.PASS
+      ? computeContractProgress(state.contract, declarer.trickCount, declarer.cardCount)
+      : undefined;
+
   const handleManualReset = () => {
     hideActionLog();
     reset();
@@ -228,6 +289,19 @@ function PreferencePageContent() {
                   })
                 : t('contractUndecided')}
             </div>
+
+            {contractProgress && (
+              <div
+                className={`text-center mb-2 text-sm font-semibold ${CONTRACT_STATUS_COLOR[contractProgress.status]}`}
+                data-testid="preference-contract-progress"
+              >
+                {contractProgress.isMisere
+                  ? t('progress.misere', { won: contractProgress.won })
+                  : t('progress.line', { won: contractProgress.won, needed: contractProgress.needed })}
+                {contractProgress.status === 'made' && ` — ${t('progress.made')}`}
+                {contractProgress.status === 'failed' && ` — ${t('progress.failed')}`}
+              </div>
+            )}
 
             <div className={lgTwoColGrid}>
               {/* Left: play area */}


### PR DESCRIPTION
## 概要

プレフェランス（`preference`）で、宣言者のコントラクト進捗と失敗確定を、プレイ中にリアルタイム表示します。declarerLine の直下にステータス読み取り行を追加しました。

`declarerIdx` / `contract` / 宣言者の `trickCount`・`cardCount` から純粋にフロントで算出（バックエンド変更なし）。ロジックは Go ドメインの `contractMade` / `preferenceBidTarget` と一致させています。

## 表示ロジック

- **目標トリック**: Six=6, Seven=7, Eight=8, Misère=0
- **残りトリック** = 宣言者の手札枚数（`cardCount`）
- **進行中**（warning 色）: `宣言者の進捗: 4 / 6 トリック`
- **達成**（success 色）: `won >= needed` で「達成」を併記
- **失敗確定**（error 色）:
  - 通常契約: `won + remaining < needed`（数学的に到達不能）
  - Misère: `won > 0`（1トリック取った瞬間）

## 受け入れ条件

- [x] 宣言者のトリック進捗が契約目標と並記される
- [x] ミゼール失敗が即時表示される
- [x] 達成不能の判定が正しく機能する
- [x] PreferencePage.test.tsx に契約別テストを追加（in-progress / made / failed / Misère-failed / 宣言前非表示）

## テスト

`bun run test -- --run PreferencePage` 全19件パス、`bun run build`（tsc）パス、biome パス。

Closes #3442
