### PR TITLE
feat(pineapple): guide preflop discard with keep-2 card features

### DIFF
--- a/frontend/src/i18n/locales/en/pineapple.json
+++ b/frontend/src/i18n/locales/en/pineapple.json
@@ -20,7 +20,12 @@
     "confirmYes": "Confirm",
     "confirmNo": "Cancel",
     "limitReached": "You can select up to {{count}} card(s). Deselect one first.",
-    "limitDescription": "You can select at most {{count}} card(s) to discard."
+    "limitDescription": "You can select at most {{count}} card(s) to discard.",
+    "keepLabel": "Keep",
+    "featurePair": "Pair",
+    "featureSuited": "Suited",
+    "featureConnector": "Connector",
+    "featureHighcard": "High card"
   },
   "rebuy": {
     "prompt": "Rebuy? ({{chips}} chips, {{used}}/{{max}} used)",

--- a/frontend/src/i18n/locales/ja/pineapple.json
+++ b/frontend/src/i18n/locales/ja/pineapple.json
@@ -20,7 +20,12 @@
     "confirmYes": "確定",
     "confirmNo": "キャンセル",
     "limitReached": "選択できるのは{{count}}枚までです。先に選択を解除してください",
-    "limitDescription": "ディスカードで選択できるのは最大{{count}}枚です"
+    "limitDescription": "ディスカードで選択できるのは最大{{count}}枚です",
+    "keepLabel": "残り2枚",
+    "featurePair": "ペア",
+    "featureSuited": "スーテッド",
+    "featureConnector": "コネクター",
+    "featureHighcard": "ハイカード"
   },
   "rebuy": {
     "prompt": "リバイしますか? ({{chips}}チップ, {{used}}/{{max}}回使用済)",

--- a/frontend/src/pages/PineapplePage.test.tsx
+++ b/frontend/src/pages/PineapplePage.test.tsx
@@ -554,6 +554,49 @@ describe('PineapplePage', () => {
     expect(screen.queryByTestId('irishpoker-discard-preview')).not.toBeInTheDocument();
   });
 
+  it('annotates each Pineapple hole card with the keep-2 feature during discard', async () => {
+    const pineappleDiscardState: PineappleResponse = {
+      ...discardState,
+      players: [
+        humanPlayer({
+          cards: [
+            { design: 'SPADE', value: 5 },
+            { design: 'SPADE', value: 9 },
+            { design: 'HEART', value: 5 },
+          ],
+        }),
+        cpuPlayer(1),
+        cpuPlayer(2),
+        cpuPlayer(3),
+      ],
+    };
+    mockExec.mockResolvedValue(pineappleDiscardState);
+    renderWithProviders(<PineapplePage />);
+    await waitFor(() => expect(screen.getByTestId('discard-controls')).toBeInTheDocument());
+    const notes = screen.getAllByTestId('pn-discard-keep-feature');
+    expect(notes).toHaveLength(3); // one per hole card
+    // Discard S5 → keep S9,H5: no pair/suited/connector → high card.
+    expect(notes[0]).toHaveTextContent('残り2枚: ハイカード');
+    // Discard S9 → keep S5,H5: a pair.
+    expect(notes[1]).toHaveTextContent('残り2枚: ペア');
+    // Discard H5 → keep S5,S9: same suit but not adjacent → suited.
+    expect(notes[2]).toHaveTextContent('残り2枚: スーテッド');
+  });
+
+  it('does not show Pineapple keep-feature notes outside the discard phase', async () => {
+    mockExec.mockResolvedValue(preFlopState);
+    renderWithProviders(<PineapplePage />);
+    await waitFor(() => expect(screen.getByText('あなたの手札')).toBeInTheDocument());
+    expect(screen.queryByTestId('pn-discard-keep-feature')).not.toBeInTheDocument();
+  });
+
+  it('does not show Pineapple keep-feature notes for the Crazy Pineapple variant', async () => {
+    mockCrazyExec.mockResolvedValue({ ...discardState, initialDealCount: 3 });
+    renderWithProviders(<PineapplePage variant="crazypineapple" />);
+    await waitFor(() => expect(screen.getByTestId('discard-controls')).toBeInTheDocument());
+    expect(screen.queryByTestId('pn-discard-keep-feature')).not.toBeInTheDocument();
+  });
+
   it('cancels the discard confirm step and returns to selection', async () => {
     mockExec.mockResolvedValue(discardState);
     renderWithProviders(<PineapplePage />);

--- a/frontend/src/pages/PineapplePage.tsx
+++ b/frontend/src/pages/PineapplePage.tsx
@@ -46,6 +46,7 @@ import { PINEAPPLE_HELP, parsePineappleCommand } from '../utils/cli/commands/pin
 import { formatPineappleState } from '../utils/cli/formatters/pineappleFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
 import { holdemBestFive } from '../utils/holdemBestFive';
+import { type PineappleKeepFeature, pineappleKeepFeatures } from '../utils/pineappleDiscardHint';
 import { findPlayerName } from '../utils/playerUtils';
 import { evaluateFiveCardHand, pokerHandKey } from '../utils/pokerSquaresUtils';
 
@@ -271,6 +272,19 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
       return rank == null ? null : pokerHandKey(rank);
     });
   }, [variant, isDiscardPhase, humanPlayer, state?.communityCards]);
+  // Plain Pineapple discards 1 of 3 preflop (before any board), so a board-based
+  // preview is impossible. Instead annotate each hole card with the qualitative
+  // shape (pair / suited / connector / high card) the OTHER two would keep, a
+  // board-free judgment the player can use to pick which card to throw.
+  const keepFeaturePreviews = useMemo<(PineappleKeepFeature[] | null)[] | null>(() => {
+    if (variant !== 'pineapple' || !isDiscardPhase) return null;
+    const hole = humanPlayer?.cards ?? [];
+    if (hole.length !== 3) return null;
+    return hole.map((_, discardIdx) => {
+      const [a, b] = hole.filter((_, i) => i !== discardIdx);
+      return pineappleKeepFeatures(a, b);
+    });
+  }, [variant, isDiscardPhase, humanPlayer]);
 
   const actionBindings = useMemo(
     () => [
@@ -527,6 +541,7 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
                         const inBest = showdownBest5.holeSet.has(idx);
                         const dim = showdownBest5.holeSet.size > 0 && !inBest;
                         const candKey = candidatePreviews?.[idx] ?? null;
+                        const keepFeatures = keepFeaturePreviews?.[idx] ?? null;
                         return (
                           <div key={`${card.design}-${card.value}`} className="flex flex-col items-center">
                             <button
@@ -546,6 +561,16 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
                                 data-testid="cp-discard-candidate"
                               >
                                 {`${t('discard.candidateHand')}: ${t(`hand.${candKey}`)}`}
+                              </span>
+                            )}
+                            {keepFeatures && (
+                              <span
+                                className="mt-0.5 text-[10px] text-ds-text-muted"
+                                data-testid="pn-discard-keep-feature"
+                              >
+                                {`${t('discard.keepLabel')}: ${keepFeatures
+                                  .map((f) => t(`discard.feature${f.charAt(0).toUpperCase()}${f.slice(1)}`))
+                                  .join('・')}`}
                               </span>
                             )}
                           </div>

--- a/frontend/src/utils/pineappleDiscardHint.test.ts
+++ b/frontend/src/utils/pineappleDiscardHint.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import type { Card } from '../types/card';
+import { pineappleKeepFeatures } from './pineappleDiscardHint';
+
+const card = (design: Card['design'], value: number): Card => ({ design, value });
+
+describe('pineappleKeepFeatures', () => {
+  it('detects a pair (exclusive of other features)', () => {
+    expect(pineappleKeepFeatures(card('SPADE', 10), card('HEART', 10))).toEqual(['pair']);
+  });
+
+  it('detects suited cards', () => {
+    expect(pineappleKeepFeatures(card('SPADE', 5), card('SPADE', 9))).toEqual(['suited']);
+  });
+
+  it('detects a connector (adjacent ranks)', () => {
+    expect(pineappleKeepFeatures(card('SPADE', 8), card('HEART', 9))).toEqual(['connector']);
+  });
+
+  it('detects a suited connector (both features)', () => {
+    expect(pineappleKeepFeatures(card('CLOVER', 6), card('CLOVER', 7))).toEqual(['suited', 'connector']);
+  });
+
+  it('treats Ace as high (A-K is a connector)', () => {
+    expect(pineappleKeepFeatures(card('SPADE', 1), card('HEART', 13))).toEqual(['connector']);
+  });
+
+  it('treats Ace as low (A-2 is a connector)', () => {
+    expect(pineappleKeepFeatures(card('SPADE', 1), card('HEART', 2))).toEqual(['connector']);
+  });
+
+  it('falls back to highcard when nothing else applies', () => {
+    expect(pineappleKeepFeatures(card('SPADE', 4), card('HEART', 11))).toEqual(['highcard']);
+  });
+});

--- a/frontend/src/utils/pineappleDiscardHint.ts
+++ b/frontend/src/utils/pineappleDiscardHint.ts
@@ -1,0 +1,44 @@
+import type { Card } from '../types/card';
+
+/**
+ * A qualitative feature of the two hole cards a Pineapple player would keep
+ * after discarding the third one, judged without any community cards:
+ *
+ * - `pair` — the two cards share the same rank.
+ * - `suited` — the two cards share the same suit.
+ * - `connector` — the two ranks are adjacent (Ace counts as both low and high,
+ *   so A-2 and A-K are connectors).
+ * - `highcard` — none of the above.
+ *
+ * `pair` is exclusive (a pair is neither suited nor a connector); `suited` and
+ * `connector` can co-occur (a suited connector), so callers receive an array.
+ */
+export type PineappleKeepFeature = 'pair' | 'suited' | 'connector' | 'highcard';
+
+/** True when the two ranks are adjacent, treating an Ace (value 1) as both low
+ * (adjacent to 2) and high (adjacent to King, value 13). */
+function isConnector(v1: number, v2: number): boolean {
+  const expand = (v: number) => (v === 1 ? [1, 14] : [v]);
+  for (const a of expand(v1)) {
+    for (const b of expand(v2)) {
+      if (Math.abs(a - b) === 1) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Classify the two Pineapple hole cards that would remain after a discard,
+ * using only the cards themselves (no board). Returns every applicable
+ * {@link PineappleKeepFeature}, in a stable order (pair, suited, connector,
+ * highcard). A pair short-circuits to `['pair']`; otherwise `highcard` is the
+ * fallback when neither suited nor connector applies.
+ */
+export function pineappleKeepFeatures(a: Card, b: Card): PineappleKeepFeature[] {
+  if (a.value === b.value) return ['pair'];
+  const features: PineappleKeepFeature[] = [];
+  if (a.design === b.design) features.push('suited');
+  if (isConnector(a.value, b.value)) features.push('connector');
+  if (features.length === 0) features.push('highcard');
+  return features;
+}


### PR DESCRIPTION
## 概要
プレーンな Pineapple のプリフロップ捨て札選択に、判断材料となる軽量ガイドを追加します。crazypineapple のプレビュー（`candidatePreviews`）はボードを使う後フロップ専用、`discardPreview` は irishpoker 専用のため、ボードが出る前に3枚から1枚を捨てるプレーン Pineapple には表示が一切ありませんでした。

各ホールカードの下に、そのカードを捨てた場合に**残る2枚の特徴**（ペア / スーテッド / コネクター / ハイカード）をボード不要のクライアント判定で注記します（例: `残り2枚: スーテッド・コネクター`）。エース（value=1）はロー（A-2）とハイ（A-K）の両方でコネクター判定します。

## 変更点
- `frontend/src/utils/pineappleDiscardHint.ts`: `pineappleKeepFeatures(a, b)` 純関数を追加（ユニットテスト付き）
- `frontend/src/pages/PineapplePage.tsx`: `variant === 'pineapple'` かつ捨て札フェーズのときのみ、各カード下に特徴注記を描画（`data-testid="pn-discard-keep-feature"`）
- `frontend/src/i18n/locales/{ja,en}/pineapple.json`: `discard.keepLabel` と `discard.feature{Pair,Suited,Connector,Highcard}` を key-for-key で追加

crazypineapple / irishpoker の既存プレビューには影響しません（バリアントで分岐）。Go ドメイン確認: Pineapple は `initialDealCount: 3` を配り2枚まで捨てる（`internal/domain/Pineapple.go`）ので keep-2 判定が正しいことを確認済み。

## 受け入れ条件
- [x] pineapple の捨て札フェーズで残り2枚の特徴が表示される
- [x] crazypineapple / irishpoker の既存プレビューに影響しない
- [x] 判定関数のユニットテストを追加する
- [x] ja/en の翻訳キーを追加する

## テスト
- `pineappleDiscardHint.test.ts`: ペア/スーテッド/コネクター/スーテッドコネクター/A高/A低/ハイカードの判定（7 件）
- `PineapplePage.test.tsx`: 捨て札フェーズで3件の注記表示＋正しいラベル、フェーズ外で非表示、crazypineapple で非表示
- ゲート: `bun run test`（42 passed）/ `bun run build`（tsc OK）/ `bunx biome check`（clean）

Closes #3016
