### PR TITLE
feat(carioca): annotate contract slots with what is still missing

### DIFF
--- a/frontend/src/i18n/locales/en/carioca.json
+++ b/frontend/src/i18n/locales/en/carioca.json
@@ -16,6 +16,15 @@
   "slotsBuilt": "Slots staged",
   "slotSet": "Set of {{n}}",
   "slotRun": "Run of {{n}}",
+  "shortfall": {
+    "empty": "Not started",
+    "needMoreSet": "{{n}} more of same rank",
+    "needMoreRun": "{{n}} more in sequence",
+    "tooMany": "{{n}} too many",
+    "setRankMismatch": "Match the ranks",
+    "runSuitMismatch": "Use one suit",
+    "runNotConsecutive": "Sequence is broken"
+  },
   "drawStock": "Draw from stock",
   "drawDiscard": "Take discard",
   "addSlot": "Add to slot",

--- a/frontend/src/i18n/locales/ja/carioca.json
+++ b/frontend/src/i18n/locales/ja/carioca.json
@@ -16,6 +16,15 @@
   "slotsBuilt": "組成済スロット",
   "slotSet": "{{n}}枚セット",
   "slotRun": "{{n}}枚ラン",
+  "shortfall": {
+    "empty": "未着手",
+    "needMoreSet": "あと{{n}}枚 同ランク",
+    "needMoreRun": "あと{{n}}枚 連番",
+    "tooMany": "{{n}}枚 多い",
+    "setRankMismatch": "同ランクで揃えて",
+    "runSuitMismatch": "スートを統一して",
+    "runNotConsecutive": "連番が途切れている"
+  },
   "drawStock": "山札から引く",
   "drawDiscard": "捨て札を取る",
   "addSlot": "スロットに追加",

--- a/frontend/src/pages/CariocaPage.test.tsx
+++ b/frontend/src/pages/CariocaPage.test.tsx
@@ -310,6 +310,29 @@ describe('CariocaPage', () => {
     expect(screen.getByTestId('ca-submit-contract')).not.toBeDisabled();
   });
 
+  it('annotates each slot with what is still missing and clears it once satisfied', async () => {
+    mockExec.mockResolvedValue(playState);
+    renderWithProviders(<CariocaPage />);
+    await waitFor(() => expect(screen.getByTestId('ca-slot-progress')).toBeInTheDocument());
+    // An empty slot shows the "not started" hint.
+    expect(screen.getByTestId('ca-slot-shortfall-0')).toHaveTextContent('未着手');
+
+    const cardButtons = screen.getAllByRole('button').filter((b) => b.querySelector('img'));
+    // Place a single 5 into slot 0 — a set of 3 still needs 2 more of the same rank.
+    fireEvent.click(cardButtons[0]);
+    fireEvent.click(screen.getByRole('button', { name: /Add to slot|スロットに追加/ }));
+    await waitFor(() => expect(screen.getByTestId('ca-slot-shortfall-0')).toHaveTextContent('あと2枚 同ランク'));
+
+    // Complete slot 0 with the three 5s — the shortfall annotation disappears.
+    fireEvent.click(screen.getByRole('button', { name: /Undo last slot|最後のスロットを取り消す/ }));
+    fireEvent.click(cardButtons[0]);
+    fireEvent.click(cardButtons[1]);
+    fireEvent.click(cardButtons[2]);
+    fireEvent.click(screen.getByRole('button', { name: /Add to slot|スロットに追加/ }));
+    await waitFor(() => expect(screen.getByTestId('ca-slot-progress-0')).toHaveAttribute('data-state', 'satisfied'));
+    expect(screen.queryByTestId('ca-slot-shortfall-0')).not.toBeInTheDocument();
+  });
+
   it('enables Submit for a joker-wild contract meld', async () => {
     // Slot 0 = 5,5,JOKER (a set completed by a wild); slot 1 = three 13s.
     const jokerHand: Card[] = [

--- a/frontend/src/pages/CariocaPage.tsx
+++ b/frontend/src/pages/CariocaPage.tsx
@@ -19,7 +19,7 @@ import { btnDanger, btnOutline, btnPrimary, focusRingWhite } from '../styles/but
 import { gameTheme } from '../styles/gameTheme';
 import type { Card, CariocaContractSlot, CariocaResponse } from '../types/card';
 import type { TutorialStep } from '../types/tutorial';
-import { evaluateCariocaContractSlot } from '../utils/cariocaUtils';
+import { describeCariocaSlotShortfall, evaluateCariocaContractSlot } from '../utils/cariocaUtils';
 
 /** Phase identifiers for Carioca. */
 const CA_PHASE = {
@@ -182,7 +182,8 @@ function CariocaPageContent() {
     return state.contractSlots.map((slot, slotIdx) => {
       const cardIdxs = contractSlots[slotIdx] ?? [];
       const cards = cardIdxs.map((i) => humanPlayer.cards[i]).filter(Boolean);
-      return evaluateCariocaContractSlot(slot, cards);
+      // `shortfall` annotates the badge with what the slot still needs (or null when done).
+      return { ev: evaluateCariocaContractSlot(slot, cards), shortfall: describeCariocaSlotShortfall(slot, cards) };
     });
   }, [state, humanPlayer, contractSlots]);
 
@@ -190,7 +191,7 @@ function CariocaPageContent() {
   // intent obvious; the length>0 guard prevents `[].every(...)` from vacuously
   // enabling submit on a contract with zero slots.
   const allSlotsSatisfied =
-    humanPlayer != null && slotEvaluations.length > 0 && slotEvaluations.every((ev) => ev.satisfied);
+    humanPlayer != null && slotEvaluations.length > 0 && slotEvaluations.every((e) => e.ev.satisfied);
 
   if (!state) {
     return (
@@ -233,7 +234,9 @@ function CariocaPageContent() {
       {isPlayPhase && humanPlayer && !humanPlayer.contractMet && state.contractSlots.length > 0 && (
         <section className="px-4 py-2 flex flex-wrap gap-2 text-sm" data-testid="ca-slot-progress">
           {state.contractSlots.map((slot, slotIdx) => {
-            const ev = slotEvaluations[slotIdx] ?? { placed: 0, required: slot.size, satisfied: false, invalid: false };
+            const detail = slotEvaluations[slotIdx];
+            const ev = detail?.ev ?? { placed: 0, required: slot.size, satisfied: false, invalid: false };
+            const shortfall = detail?.shortfall ?? null;
             const color = ev.satisfied
               ? badgeSuccessColors
               : ev.invalid
@@ -242,13 +245,21 @@ function CariocaPageContent() {
                   ? 'bg-black/20 border border-white/30 text-ds-text-muted'
                   : badgeWarningColors;
             return (
-              <span
-                key={`slot-${slotIdx}`}
-                className={`px-2 py-1 rounded ${color}`}
-                data-testid={`ca-slot-progress-${slotIdx}`}
-                data-state={ev.satisfied ? 'satisfied' : ev.invalid ? 'invalid' : ev.placed === 0 ? 'empty' : 'partial'}
-              >
-                {formatSlot(slot, t)} ({ev.placed}/{ev.required}){ev.satisfied ? ' ✓' : ''}
+              <span key={`slot-${slotIdx}`} className="flex flex-col items-start gap-0.5">
+                <span
+                  className={`px-2 py-1 rounded ${color}`}
+                  data-testid={`ca-slot-progress-${slotIdx}`}
+                  data-state={
+                    ev.satisfied ? 'satisfied' : ev.invalid ? 'invalid' : ev.placed === 0 ? 'empty' : 'partial'
+                  }
+                >
+                  {formatSlot(slot, t)} ({ev.placed}/{ev.required}){ev.satisfied ? ' ✓' : ''}
+                </span>
+                {shortfall && (
+                  <span className="text-xs text-ds-text-muted" data-testid={`ca-slot-shortfall-${slotIdx}`}>
+                    {t(`shortfall.${shortfall.code}`, shortfall.count != null ? { n: shortfall.count } : undefined)}
+                  </span>
+                )}
               </span>
             );
           })}

--- a/frontend/src/utils/cariocaUtils.test.ts
+++ b/frontend/src/utils/cariocaUtils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { Card, ContractRummyContractSlot } from '../types/card';
-import { evaluateCariocaContractSlot, isCariocaRun, isCariocaSet } from './cariocaUtils';
+import { describeCariocaSlotShortfall, evaluateCariocaContractSlot, isCariocaRun, isCariocaSet } from './cariocaUtils';
 import { CONTRACT_SLOT_RUN, CONTRACT_SLOT_SET } from './contractRummyUtils';
 
 const card = (design: Card['design'], value: number): Card => ({ design, value });
@@ -105,5 +105,64 @@ describe('evaluateCariocaContractSlot', () => {
   it('reports empty as neither satisfied nor invalid', () => {
     const ev = evaluateCariocaContractSlot(setSlot, []);
     expect(ev).toEqual({ required: 3, placed: 0, satisfied: false, invalid: false });
+  });
+});
+
+describe('describeCariocaSlotShortfall', () => {
+  const setSlot: ContractRummyContractSlot = { kind: CONTRACT_SLOT_SET, size: 3 };
+  const runSlot: ContractRummyContractSlot = { kind: CONTRACT_SLOT_RUN, size: 4 };
+
+  it('returns null for a satisfied set', () => {
+    expect(describeCariocaSlotShortfall(setSlot, [card('SPADE', 5), card('HEART', 5), joker()])).toBeNull();
+  });
+
+  it('returns null for a satisfied run', () => {
+    expect(
+      describeCariocaSlotShortfall(runSlot, [card('HEART', 7), card('HEART', 8), joker(), card('HEART', 10)]),
+    ).toBeNull();
+  });
+
+  it('reports empty for a slot with no cards', () => {
+    expect(describeCariocaSlotShortfall(setSlot, [])).toEqual({ code: 'empty' });
+  });
+
+  it('reports how many more cards a set needs', () => {
+    expect(describeCariocaSlotShortfall(setSlot, [card('SPADE', 5)])).toEqual({ code: 'needMoreSet', count: 2 });
+  });
+
+  it('reports how many more cards a run needs', () => {
+    expect(describeCariocaSlotShortfall(runSlot, [card('SPADE', 2), card('SPADE', 3)])).toEqual({
+      code: 'needMoreRun',
+      count: 2,
+    });
+  });
+
+  it('reports excess cards as tooMany', () => {
+    expect(
+      describeCariocaSlotShortfall(setSlot, [
+        card('SPADE', 5),
+        card('HEART', 5),
+        card('DIAMOND', 5),
+        card('CLOVER', 5),
+      ]),
+    ).toEqual({ code: 'tooMany', count: 1 });
+  });
+
+  it('reports a rank mismatch for a full but invalid set', () => {
+    expect(describeCariocaSlotShortfall(setSlot, [card('SPADE', 5), card('HEART', 6), card('DIAMOND', 7)])).toEqual({
+      code: 'setRankMismatch',
+    });
+  });
+
+  it('reports a suit mismatch for a full run with mixed suits', () => {
+    expect(
+      describeCariocaSlotShortfall(runSlot, [card('SPADE', 2), card('HEART', 3), card('SPADE', 4), card('SPADE', 5)]),
+    ).toEqual({ code: 'runSuitMismatch' });
+  });
+
+  it('reports a broken sequence for a full same-suit run with a gap', () => {
+    expect(
+      describeCariocaSlotShortfall(runSlot, [card('SPADE', 2), card('SPADE', 3), card('SPADE', 4), card('SPADE', 9)]),
+    ).toEqual({ code: 'runNotConsecutive' });
   });
 });

--- a/frontend/src/utils/cariocaUtils.ts
+++ b/frontend/src/utils/cariocaUtils.ts
@@ -1,6 +1,24 @@
 import type { Card, ContractRummyContractSlot } from '../types/card';
 import { CONTRACT_SLOT_SET, type ContractSlotEvaluation } from './contractRummyUtils';
 
+/** Reason a Carioca contract slot is not yet satisfied. Drives the "what's missing" annotation. */
+export type CariocaSlotShortfallCode =
+  | 'empty'
+  | 'needMoreSet'
+  | 'needMoreRun'
+  | 'tooMany'
+  | 'setRankMismatch'
+  | 'runSuitMismatch'
+  | 'runNotConsecutive';
+
+/** A single unmet contract-slot requirement: a reason code plus an optional card count. */
+export interface CariocaSlotShortfall {
+  /** i18n key suffix describing the shortfall. */
+  code: CariocaSlotShortfallCode;
+  /** Cards still needed (`needMore*`) or excess cards to remove (`tooMany`); absent for combination errors. */
+  count?: number;
+}
+
 /**
  * Joker-aware contract-slot helpers for Carioca.
  *
@@ -107,4 +125,28 @@ export function evaluateCariocaContractSlot(slot: ContractRummyContractSlot, car
   }
   const ok = slot.kind === CONTRACT_SLOT_SET ? isCariocaSet(cards) : isCariocaRun(cards);
   return { required, placed, satisfied: ok, invalid: !ok };
+}
+
+/**
+ * Describe what a Carioca contract slot still needs to be satisfied. Returns `null` when the
+ * slot already forms a valid set/run at the required size (nothing missing). Otherwise it
+ * reports why the slot cannot be submitted yet: not started, too few / too many cards, or a
+ * combination error (rank mismatch, suit mismatch, or a broken sequence). Reuses
+ * `isCariocaSet` / `isCariocaRun`, so it stays in sync with the Go domain's validation.
+ */
+export function describeCariocaSlotShortfall(
+  slot: ContractRummyContractSlot,
+  cards: Card[],
+): CariocaSlotShortfall | null {
+  const placed = cards.length;
+  const required = slot.size;
+  const isSet = slot.kind === CONTRACT_SLOT_SET;
+  if (placed === 0) return { code: 'empty' };
+  if (placed > required) return { code: 'tooMany', count: placed - required };
+  if (placed < required) return { code: isSet ? 'needMoreSet' : 'needMoreRun', count: required - placed };
+  // placed === required: the count is right, so any failure is a combination error.
+  if (isSet ? isCariocaSet(cards) : isCariocaRun(cards)) return null;
+  if (isSet) return { code: 'setRankMismatch' };
+  const suits = new Set(cards.filter((c) => !isJoker(c)).map((c) => c.design));
+  return suits.size > 1 ? { code: 'runSuitMismatch' } : { code: 'runNotConsecutive' };
 }


### PR DESCRIPTION
## 概要

カリオカのコントラクトスロットバッジに、まだ提出できない理由（不足要素）を併記しました。`(placed/required)` と ✓ だけでは「なぜ出せないか」が分からなかった点を解消します。

## 変更内容

- `cariocaUtils.ts` に `describeCariocaSlotShortfall` を追加。既存の `isCariocaSet` / `isCariocaRun` を再利用するため Go ドメイン（`cariocaIsSet`/`cariocaIsRun`、SetSize=3・RunSize=4・ワイルドジョーカー1枚まで）と整合します。
  - `empty`（未着手） / `needMoreSet`・`needMoreRun`（あと N 枚） / `tooMany`（N 枚多い） / `setRankMismatch`・`runSuitMismatch`・`runNotConsecutive`（組み合わせ不正）
- `CariocaPage.tsx`: 各スロットバッジの下に不足理由を `data-testid="ca-slot-shortfall-{i}"` で表示。satisfied のスロットには表示しない。
- ja/en `carioca.json` に `shortfall.*` キーを key-for-key で追加。
- テスト追加（`cariocaUtils.test.ts` 9 ケース、`CariocaPage.test.tsx` の不足理由テスト1件）。

純追加のフロントエンドのみ、バックエンド変更なし。

## 受け入れ条件

- [x] 各スロットに不足要素/不正理由が表示される
- [x] satisfied スロットには不足表示が出ない
- [x] `evaluateCariocaContractSlot`（および同じ配置カードから算出）の結果を利用する
- [x] `CariocaPage.test.tsx` に不足理由テストを追加

## テスト

- `bun run test -- --run CariocaPage cariocaUtils` : 48 passed
- `bun run build` (tsc) : OK
- `biome check` : OK
- i18n ja/en キー整合: OK

Closes #3492
