### PR TITLE
feat(bidwhist): disable bid directions that cannot exceed the highest bid

### DIFF
--- a/frontend/src/i18n/locales/en/bidwhist.json
+++ b/frontend/src/i18n/locales/en/bidwhist.json
@@ -23,6 +23,7 @@
   "dirUptown": "Uptown",
   "dirDowntown": "Downtown",
   "dirNoTrump": "No Trump",
+  "bidTooLow": "Must exceed the current highest bid ({{tricks}} {{dir}})",
   "passButton": "Pass",
   "declareTrumpPrompt": "Choose a trump suit:",
   "exchangeButton": "Exchange ({{count}}/6)",

--- a/frontend/src/i18n/locales/ja/bidwhist.json
+++ b/frontend/src/i18n/locales/ja/bidwhist.json
@@ -23,6 +23,7 @@
   "dirUptown": "アップタウン",
   "dirDowntown": "ダウンタウン",
   "dirNoTrump": "ノートランプ",
+  "bidTooLow": "現在の最高ビッド ({{tricks}} {{dir}}) を上回る必要があります",
   "passButton": "パス",
   "declareTrumpPrompt": "切り札スートを選択:",
   "exchangeButton": "交換 ({{count}}/6)",

--- a/frontend/src/pages/BidWhistPage.test.tsx
+++ b/frontend/src/pages/BidWhistPage.test.tsx
@@ -171,4 +171,49 @@ describe('BidWhistPage', () => {
     await screen.findByTestId('hand-card-0');
     expect(screen.queryByTestId('kitty-progress')).not.toBeInTheDocument();
   });
+
+  it('enables every direction when there is no highest bid', async () => {
+    renderWithProviders(<BidWhistPage />);
+    // Default selected tricks is 1; with no highest bid, all directions are valid.
+    expect(await screen.findByTestId('bid-dir-0')).toBeEnabled();
+    expect(screen.getByTestId('bid-dir-1')).toBeEnabled();
+    expect(screen.getByTestId('bid-dir-2')).toBeEnabled();
+    expect(screen.getByTestId('pass-button')).toBeEnabled();
+  });
+
+  it('disables directions that do not exceed the current highest bid', async () => {
+    // Highest bid = 1 Uptown (order 10). Selected tricks default to 1, so:
+    //   Uptown (order 10) is not strictly greater → disabled,
+    //   Downtown (11) and No Trump (12) beat it → enabled.
+    mockExec.mockResolvedValue(makeState({ highestBid: { tricks: 1, direction: 0 }, highestBidder: 3 }));
+    renderWithProviders(<BidWhistPage />);
+    const uptown = await screen.findByTestId('bid-dir-0');
+    expect(uptown).toBeDisabled();
+    expect(uptown).toHaveAttribute('aria-disabled', 'true');
+    expect(screen.getByTestId('bid-dir-1')).toBeEnabled();
+    expect(screen.getByTestId('bid-dir-2')).toBeEnabled();
+    // Pass is always available.
+    expect(screen.getByTestId('pass-button')).toBeEnabled();
+  });
+
+  it('surfaces a reason tooltip on a disabled direction button', async () => {
+    mockExec.mockResolvedValue(makeState({ highestBid: { tricks: 3, direction: 2 }, highestBidder: 1 }));
+    renderWithProviders(<BidWhistPage />);
+    // Highest bid 3 No Trump (order 32) beats every tricks-1 bid → all disabled with a title.
+    const wrap = await screen.findByTestId('bid-dir-wrap-0');
+    expect(wrap).toHaveAttribute('title', expect.stringContaining('3'));
+    expect(screen.getByTestId('bid-dir-0')).toBeDisabled();
+  });
+
+  it('disables lower-order directions but enables higher tricks after selecting them', async () => {
+    mockExec.mockResolvedValue(makeState({ highestBid: { tricks: 4, direction: 0 }, highestBidder: 2 }));
+    renderWithProviders(<BidWhistPage />);
+    // With tricks 1 selected, nothing beats a 4-trick bid.
+    expect(await screen.findByTestId('bid-dir-0')).toBeDisabled();
+    // Raising the selector to 5 tricks makes all directions valid again (order 50+ > 40).
+    fireEvent.change(screen.getByLabelText('トリック数を選択 (1-7):'), { target: { value: '5' } });
+    expect(screen.getByTestId('bid-dir-0')).toBeEnabled();
+    expect(screen.getByTestId('bid-dir-1')).toBeEnabled();
+    expect(screen.getByTestId('bid-dir-2')).toBeEnabled();
+  });
 });

--- a/frontend/src/pages/BidWhistPage.tsx
+++ b/frontend/src/pages/BidWhistPage.tsx
@@ -374,18 +374,39 @@ function BidWhistPageContent() {
                       </option>
                     ))}
                   </select>
-                  {DIRECTIONS.map((d) => (
-                    <button
-                      key={d.id}
-                      type="button"
-                      onClick={() => bid(bidTricks, d.id)}
-                      disabled={loading}
-                      className="px-3 py-2 rounded-lg bg-ds-info text-white text-sm disabled:opacity-40"
-                      data-testid={`bid-dir-${d.id}`}
-                    >
-                      {t(d.key)}
-                    </button>
-                  ))}
+                  {DIRECTIONS.map((d) => {
+                    // A bid's strength is tricks*10 + direction (matches BidWhistBid.Order in
+                    // the Go domain). A new bid must strictly exceed the current highest bid.
+                    const highestOrder = state.highestBid
+                      ? state.highestBid.tricks * 10 + state.highestBid.direction
+                      : -1;
+                    const tooLow = bidTricks * 10 + d.id <= highestOrder;
+                    const disabled = loading || tooLow;
+                    const reason =
+                      tooLow && state.highestBid
+                        ? t('bidTooLow', {
+                            tricks: state.highestBid.tricks,
+                            dir: t(DIRECTIONS[state.highestBid.direction]?.key ?? 'dirUptown'),
+                          })
+                        : undefined;
+                    // The title lives on the wrapping span: browsers suppress native tooltips on
+                    // disabled buttons, so hovering the span still surfaces the reason.
+                    return (
+                      <span key={d.id} title={reason} data-testid={`bid-dir-wrap-${d.id}`}>
+                        <button
+                          type="button"
+                          onClick={() => bid(bidTricks, d.id)}
+                          disabled={disabled}
+                          aria-disabled={disabled}
+                          aria-label={reason ? `${t(d.key)} — ${reason}` : undefined}
+                          className="px-3 py-2 rounded-lg bg-ds-info text-white text-sm disabled:opacity-40"
+                          data-testid={`bid-dir-${d.id}`}
+                        >
+                          {t(d.key)}
+                        </button>
+                      </span>
+                    );
+                  })}
                   <button
                     type="button"
                     onClick={pass}


### PR DESCRIPTION
## 概要
ビッド・ホイストのビッドフェーズで、現在の最高ビッドを上回れない方向ボタン（Uptown / Downtown / No Trump）を無効化しました。ビッドの強さは `tricks*10 + direction`（Go ドメインの `BidWhistBid.Order` と一致）で判定し、選択中のトリック数と各方向の組み合わせが最高ビッドを厳密に上回らない場合に disabled + 理由 title を付けます。パスは常に選択可能です。

## 変更内容
- `BidWhistPage.tsx`: 方向ボタンを wrap span でくるみ、`state.highestBid` と選択中 `bidTricks` を比較して `<=` の組み合わせを `disabled` + `aria-disabled` + 理由 title（`bidTooLow`）に。
- i18n: `bidTooLow` キーを ja/en に追加（key-for-key で同期）。
- `BidWhistPage.test.tsx`: 有効/無効判定テストを4件追加。

## 受け入れ条件
- [x] 最高ビッドを上回れない入札ボタンが無効化される
- [x] 無効ボタンに理由の title が付く
- [x] パスは常に選択可能
- [x] `BidWhistPage.test.tsx` に有効/無効判定のテスト追加

## テスト
- `bun run test -- --run BidWhistPage` → 14 passed
- `bun run build`（tsc）→ 成功
- `biome check` → クリーン

Go ドメインのルール（`internal/domain/BidWhist.go`）: `bid.Order() <= g.highestBid.Order()` はエラー（`現在のビッドより強い必要があります`）。`Order() = Tricks*10 + Direction`。フロントの判定はこれと一致します。

Closes #3383