### PR TITLE
feat(doudizhu): show human hand during bid phase (display-only)

### DIFF
--- a/frontend/src/pages/DoudizhuPage.test.tsx
+++ b/frontend/src/pages/DoudizhuPage.test.tsx
@@ -108,6 +108,40 @@ describe('DoudizhuPage', () => {
     });
   });
 
+  it('shows the human hand during the bid phase as display-only (no selection)', async () => {
+    mockExec.mockResolvedValue({
+      ...defaultState,
+      phase: 'bid',
+      landlordIdx: -1,
+      highestBid: 0,
+      currentTurn: 0,
+      players: [
+        {
+          id: 0,
+          isHuman: true,
+          isFinished: false,
+          isLandlord: false,
+          cardCount: 1,
+          cards: [{ design: 'SPADE', value: 5 }],
+        },
+        { id: 1, isHuman: false, isFinished: false, isLandlord: false, cardCount: 17, cards: [] },
+        { id: 2, isHuman: false, isFinished: false, isLandlord: false, cardCount: 17, cards: [] },
+      ],
+    });
+    renderWithProviders(<DoudizhuPage />);
+
+    // The hand card is rendered during the bid phase.
+    const cardBtn = await screen.findByRole('button', { name: '♠ 5' });
+    // It is display-only: disabled, with no selection toggle state.
+    expect(cardBtn).toBeDisabled();
+    expect(cardBtn).not.toHaveAttribute('aria-pressed');
+    fireEvent.click(cardBtn);
+    expect(cardBtn).not.toHaveAttribute('aria-pressed');
+
+    // No play/pass controls during bidding.
+    expect(screen.queryByRole('button', { name: '出す' })).not.toBeInTheDocument();
+  });
+
   it('passes during the bid phase', async () => {
     mockExec.mockResolvedValue({
       ...defaultState,

--- a/frontend/src/pages/DoudizhuPage.tsx
+++ b/frontend/src/pages/DoudizhuPage.tsx
@@ -277,28 +277,33 @@ function DoudizhuPageContent() {
             </div>
           )}
 
-          {/* Human hand */}
-          {humanPlayer && phase === 'play' && (
+          {/* Human hand — shown during both bid and play phases (display-only while bidding) */}
+          {humanPlayer && (phase === 'play' || phase === 'bid') && (
             <div data-tutorial="ddz-hand">
               <div className="flex flex-wrap justify-center gap-1">
-                {humanPlayer.cards.map((c, i) => (
-                  <button
-                    key={`hand-${c.design}-${c.value}`}
-                    type="button"
-                    className={
-                      selectedCards.has(i)
-                        ? 'transition-transform -translate-y-2 ring-2 ring-ds-warning rounded'
-                        : 'transition-transform'
-                    }
-                    onClick={() => toggleCard(i)}
-                    aria-label={cardAlt(c)}
-                    aria-pressed={selectedCards.has(i)}
-                  >
-                    <AnimatedCard card={c} width={cardWidth * 0.9} />
-                  </button>
-                ))}
+                {humanPlayer.cards.map((c, i) => {
+                  const interactive = phase === 'play';
+                  const selected = interactive && selectedCards.has(i);
+                  return (
+                    <button
+                      key={`hand-${c.design}-${c.value}`}
+                      type="button"
+                      disabled={!interactive}
+                      className={
+                        selected
+                          ? 'transition-transform -translate-y-2 ring-2 ring-ds-warning rounded'
+                          : 'transition-transform'
+                      }
+                      onClick={interactive ? () => toggleCard(i) : undefined}
+                      aria-label={cardAlt(c)}
+                      aria-pressed={interactive ? selectedCards.has(i) : undefined}
+                    >
+                      <AnimatedCard card={c} width={cardWidth * 0.9} />
+                    </button>
+                  );
+                })}
               </div>
-              {isHumanTurn && (
+              {phase === 'play' && isHumanTurn && (
                 <div className="flex justify-center gap-2 mt-2">
                   <button type="button" className={btnPrimary} onClick={handlePlay} disabled={selectedCards.size === 0}>
                     {t('button.play')}


### PR DESCRIPTION
## 概要
斗地主（Dou Dizhu / `doudizhu`）のビッドフェーズで、人間プレイヤーの手札17枚が一切表示されず、手札の強さ（爆弾・ロケット・2の枚数）を評価できないままビッドを選ばされていた問題を修正。

`DoudizhuPage.tsx` の手札描画条件を `phase === 'play'` から `phase === 'play' || phase === 'bid'` に広げ、ビッド中は表示専用（`disabled`・選択トグルなし・出す/パスボタンなし）とした。プレイフェーズの挙動は不変。

## 受け入れ条件
- [x] ビッドフェーズで自分の手札17枚が表示される
- [x] ビッド中はカード選択（持ち上げ）が発生しない（`disabled` + `aria-pressed` なし）
- [x] プレイフェーズの既存挙動が変わらない（`phase === 'play'` でのみ選択・出す・パスが有効）
- [x] `DoudizhuPage.test.tsx` にビッド中の手札表示テストを追加

## テスト
- `DoudizhuPage.test.tsx`: 新規テスト "shows the human hand during the bid phase as display-only (no selection)" を追加。ビッド中にカードが描画され、`disabled`・`aria-pressed` なし・クリックしても選択されず、出す/パスボタンが無いことを検証。
- `bun run test -- --run DoudizhuPage` … 17 passed
- `bun run build`（tsc）… 成功
- `biome check` … クリーン

Closes #3337

フロントエンドのみの変更です。