### PR TITLE
feat(knockoutwhist): preview next round hand size and trump chooser at round end

### DIFF
--- a/frontend/src/i18n/locales/en/knockoutwhist.json
+++ b/frontend/src/i18n/locales/en/knockoutwhist.json
@@ -38,7 +38,9 @@
     "title": "Round Result",
     "winner": "Round winner: {{name}}",
     "survived": "{{name}} spent a Dogbone to survive",
-    "eliminated": "{{name}} took zero tricks and was knocked out"
+    "eliminated": "{{name}} took zero tricks and was knocked out",
+    "nextRoundPreview": "Next round: {{count}} cards each / trump chosen by {{name}}",
+    "finalRoundPreview": "Final round: {{count}} cards each / trump chosen by {{name}}"
   },
   "hintAvailable": "Hint",
   "hint": {

--- a/frontend/src/i18n/locales/ja/knockoutwhist.json
+++ b/frontend/src/i18n/locales/ja/knockoutwhist.json
@@ -38,7 +38,9 @@
     "title": "ラウンド結果",
     "winner": "ラウンド勝者: {{name}}",
     "survived": "{{name}} はDogboneを消費して生き残りました",
-    "eliminated": "{{name}} は0トリックで脱落しました"
+    "eliminated": "{{name}} は0トリックで脱落しました",
+    "nextRoundPreview": "次ラウンド: 手札{{count}}枚 / 切り札選択: {{name}}",
+    "finalRoundPreview": "最終ラウンド: 手札{{count}}枚 / 切り札選択: {{name}}"
   },
   "hintAvailable": "ヒント",
   "hint": {

--- a/frontend/src/pages/KnockoutWhistPage.test.tsx
+++ b/frontend/src/pages/KnockoutWhistPage.test.tsx
@@ -83,6 +83,28 @@ describe('KnockoutWhistPage', () => {
     expect(screen.getByText('ラウンド結果')).toBeInTheDocument();
   });
 
+  it('previews the next round hand size (one fewer card) and trump chooser at round end', async () => {
+    mockExec.mockResolvedValue(roundEndState);
+    renderWithProviders(<KnockoutWhistPage />);
+    const preview = await screen.findByTestId('kw-next-round-preview');
+    // Default round-end hand size is 7, so the next round deals 6 cards; winner idx 0 is the human.
+    expect(preview).toHaveTextContent('次ラウンド: 手札6枚 / 切り札選択: あなた');
+  });
+
+  it('flags the final round when the next hand size bottoms out at 1', async () => {
+    mockExec.mockResolvedValue(makeKnockoutWhistState({ phase: 2, roundWinnerIdx: 1, handSize: 2 }));
+    renderWithProviders(<KnockoutWhistPage />);
+    const preview = await screen.findByTestId('kw-next-round-preview');
+    expect(preview).toHaveTextContent('最終ラウンド: 手札1枚');
+  });
+
+  it('does not preview the next round at game end', async () => {
+    mockExec.mockResolvedValue(gameEndState);
+    renderWithProviders(<KnockoutWhistPage />);
+    await waitFor(() => expect(screen.getByText('ゲーム終了！ あなたの勝ち！')).toBeInTheDocument());
+    expect(screen.queryByTestId('kw-next-round-preview')).not.toBeInTheDocument();
+  });
+
   it('renders the game end message', async () => {
     mockExec.mockResolvedValue(gameEndState);
     renderWithProviders(<KnockoutWhistPage />);

--- a/frontend/src/pages/KnockoutWhistPage.tsx
+++ b/frontend/src/pages/KnockoutWhistPage.tsx
@@ -147,6 +147,8 @@ function KnockoutWhistPageContent() {
   const isTrumpSelect = state.phase === KnockoutWhistPhase.TRUMP_SELECT;
   const isGameEnd = state.phase === KnockoutWhistPhase.GAME_END || state.gameEndFlag;
 
+  // Knockout Whist deals one fewer card each round, bottoming out at 1 (see KnockoutWhist.startRound in the Go domain).
+  const nextHandSize = Math.max(state.handSize - 1, 1);
   const isHumanEliminated = state.players[humanIdx]?.eliminated ?? false;
   const canPlay = isPlayPhase && isHumanTurn && !isHumanEliminated;
   // Show a spectator banner while the human is knocked out but the match continues among the CPUs.
@@ -280,6 +282,15 @@ function KnockoutWhistPageContent() {
                         name: playerName(state.roundWinnerIdx, state.players[state.roundWinnerIdx]?.isHuman ?? false),
                       })}
                     </div>
+                    {/* Preview the upcoming round: hand size drops by 1 (min 1) and the round winner chooses trump. */}
+                    {isRoundEnd && !isGameEnd && (
+                      <div data-testid="kw-next-round-preview" className="mt-1 text-ds-text-primary">
+                        {t(nextHandSize === 1 ? 'roundResult.finalRoundPreview' : 'roundResult.nextRoundPreview', {
+                          count: nextHandSize,
+                          name: playerName(state.roundWinnerIdx, state.players[state.roundWinnerIdx]?.isHuman ?? false),
+                        })}
+                      </div>
+                    )}
                   </div>
                 )}
               </div>


### PR DESCRIPTION
## 概要

ノックアウト・ホイストの ROUND_END フェーズで、次ラウンドの手札枚数と切り札選択者をプレビュー表示する。ラウンド結果ブロックのラウンド勝者行の下に「次ラウンド: 手札6枚 / 切り札選択: あなた」を追加した。

手札枚数はラウンドごとに 1 枚ずつ減り最小 1 枚（Go ドメイン `KnockoutWhist.startRound` の `handSize = KnockoutWhistMaxRounds + 1 - roundNumber`（最小 1）と一致）。次ラウンドが 1 枚になる場合は「最終ラウンド」として表示する。フロントエンドのみで、`state.handSize` と `state.roundWinnerIdx` から導出する。ゲーム終了時（次ラウンドなし）は表示しない。

## 受け入れ条件

- [x] RoundEnd に次ラウンドの手札枚数が表示される
- [x] 切り札選択者（ラウンド勝者）が表示される
- [x] ja/en 両ロケールに文言を追加（`roundResult.nextRoundPreview` / `roundResult.finalRoundPreview`、key-for-key 同期）
- [x] KnockoutWhistPage.test.tsx にテストを追加

## テスト

- `previews the next round hand size (one fewer card) and trump chooser at round end`
- `flags the final round when the next hand size bottoms out at 1`
- `does not preview the next round at game end`
- `bun run test -- --run KnockoutWhistPage` 17 passed
- `bun run build`（tsc）green / `biome check` clean

Closes #3437
