### PR TITLE
feat(nertz): highlight valid drop targets for the selected source

### DIFF
--- a/frontend/src/pages/NertzPage.test.tsx
+++ b/frontend/src/pages/NertzPage.test.tsx
@@ -79,6 +79,7 @@ const gameEndState: NertzResponse = {
 };
 
 beforeEach(() => {
+  localStorage.clear();
   mockExec.mockResolvedValue(playingState);
 });
 
@@ -249,6 +250,63 @@ describe('NertzPage', () => {
         to: { zone: 'foundation', idx: 0 },
       }),
     );
+  });
+
+  it('rings valid foundation and tableau drop targets while a source is selected', async () => {
+    const foundations: NertzResponse['foundations'] = Array.from({ length: 8 }, () => ({ suit: -1, size: 0 }));
+    // Foundation 0 holds ♥5 → only ♥6 completes it; empty foundations need an Ace.
+    foundations[0] = { suit: 2, size: 5, top: { design: 'HEART', value: 5 } };
+    const state: NertzResponse = {
+      ...playingState,
+      foundations,
+      players: [
+        {
+          ...playingState.players[0],
+          nertzTop: { design: 'HEART', value: 6 },
+          tableau: [
+            [{ card: { design: 'SPADE', value: 7 }, faceUp: true }], // valid: black 7 below red 6
+            [{ card: { design: 'HEART', value: 8 }, faceUp: true }], // invalid: same colour
+            [], // valid: empty column accepts anything
+            [{ card: { design: 'SPADE', value: 9 }, faceUp: true }], // invalid: rank gap
+          ],
+        },
+        playingState.players[1],
+      ],
+    };
+    mockExec.mockResolvedValue(state);
+    renderWithProviders(
+      <MemoryRouter initialEntries={['/nertz']}>
+        <NertzPage />
+      </MemoryRouter>,
+    );
+
+    // No selection → no target rings anywhere.
+    await waitFor(() => expect(screen.getByAltText('♥ 6')).toBeInTheDocument());
+    expect(screen.getByTestId('nertz-foundation-0')).not.toHaveAttribute('data-valid-target');
+    expect(screen.getByTestId('nertz-tableau-col-0')).not.toHaveAttribute('data-valid-target');
+
+    // Select the nertz pile (♥6).
+    fireEvent.click(screen.getByAltText('♥ 6').closest('button') as HTMLElement);
+
+    // Foundation 0 (♥5) is a legal target; empty foundation 1 is not (needs an Ace).
+    const f0 = screen.getByTestId('nertz-foundation-0');
+    expect(f0).toHaveAttribute('data-valid-target', 'true');
+    expect(f0.className).toContain('ring-ds-success');
+    const f1 = screen.getByTestId('nertz-foundation-1');
+    expect(f1).not.toHaveAttribute('data-valid-target');
+    expect(f1.className).toContain('opacity-60');
+
+    // Tableau: black-7 column and the empty column are legal; the others are not.
+    expect(screen.getByTestId('nertz-tableau-col-0')).toHaveAttribute('data-valid-target', 'true');
+    expect(screen.getByTestId('nertz-tableau-col-2')).toHaveAttribute('data-valid-target', 'true');
+    expect(screen.getByTestId('nertz-tableau-col-1')).not.toHaveAttribute('data-valid-target');
+    expect(screen.getByTestId('nertz-tableau-col-3')).not.toHaveAttribute('data-valid-target');
+    expect(screen.getByTestId('nertz-tableau-col-0').className).toContain('ring-ds-success');
+
+    // Deselecting (click the source again) clears every ring.
+    fireEvent.click(screen.getByAltText('♥ 6').closest('button') as HTMLElement);
+    expect(screen.getByTestId('nertz-foundation-0')).not.toHaveAttribute('data-valid-target');
+    expect(screen.getByTestId('nertz-tableau-col-0')).not.toHaveAttribute('data-valid-target');
   });
 
   it('announces a foundation placement to screen readers', async () => {

--- a/frontend/src/pages/NertzPage.tsx
+++ b/frontend/src/pages/NertzPage.tsx
@@ -21,7 +21,7 @@ import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useMountReset } from '../hooks/useMountReset';
 import { btnOutline, btnPrimary, btnSecondary } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
-import type { Card, NertzPlayerData, NertzResponse, NertzTableauCard } from '../types/card';
+import type { Card, NertzFoundationData, NertzPlayerData, NertzResponse, NertzTableauCard } from '../types/card';
 import { NertzPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { NERTZ_HELP, parseNertzCommand } from '../utils/cli/commands/nertzCommands';
@@ -49,6 +49,34 @@ const NERTZ_TUTORIAL_STEPS: TutorialStep[] = [
 ];
 
 type Selection = { kind: 'nertz' } | { kind: 'waste' } | { kind: 'tableau'; col: number; cardIndex: number } | null;
+
+/** Whether a card belongs to a red suit (hearts / diamonds). */
+function isRedNertzCard(card: Card): boolean {
+  return card.design === 'HEART' || card.design === 'DIAMOND';
+}
+
+/**
+ * Client-side mirror of the backend `NertzFoundation.CanAccept`: a foundation
+ * cell accepts an Ace when empty, otherwise the same-suit next-higher rank.
+ */
+function nertzFoundationAccepts(card: Card | null, foundation: NertzFoundationData): boolean {
+  if (!card || card.design === 'JOKER') return false;
+  if (foundation.top) {
+    return card.design === foundation.top.design && card.value === foundation.top.value + 1;
+  }
+  return card.value === 1;
+}
+
+/**
+ * Client-side mirror of the backend `canPlaceOnNertzTableau`: an empty column
+ * accepts any card, otherwise the card must be one rank lower and the opposite
+ * colour of the column's bottom card.
+ */
+function nertzTableauAccepts(card: Card | null, destTop: Card | null): boolean {
+  if (!card) return false;
+  if (!destTop) return true;
+  return isRedNertzCard(card) !== isRedNertzCard(destTop) && card.value === destTop.value - 1;
+}
 
 /** Renders the Nertz / Pounce game page. */
 export const NertzPage = withTutorial(NertzPageContent, 'nertz', NERTZ_TUTORIAL_STEPS);
@@ -309,6 +337,45 @@ function NertzPageContent() {
     enabled: state?.phase === NertzPhase.PLAYING && !loading,
   });
 
+  // The concrete card the current selection would move, used to derive which
+  // destinations can legally accept it.
+  const selectedCard: Card | null = useMemo(() => {
+    if (!selection || !human) return null;
+    if (selection.kind === 'nertz') return human.nertzTop ?? null;
+    if (selection.kind === 'waste') return human.wasteTop ?? null;
+    return human.tableau[selection.col]?.[selection.cardIndex]?.card ?? null;
+  }, [selection, human]);
+
+  // A foundation only ever takes the bottom (top-of-column) card, so a tableau
+  // selection is foundation-eligible only when it is that bottom card. Nertz and
+  // waste sources are always foundation-eligible.
+  const foundationEligible = useMemo(() => {
+    if (!selection || !human) return false;
+    if (selection.kind !== 'tableau') return true;
+    return selection.cardIndex === human.tableau[selection.col].length - 1;
+  }, [selection, human]);
+
+  const validFoundations = useMemo(() => {
+    const set = new Set<number>();
+    if (!state || !selectedCard || !foundationEligible) return set;
+    state.foundations.forEach((f, idx) => {
+      if (nertzFoundationAccepts(selectedCard, f)) set.add(idx);
+    });
+    return set;
+  }, [state, selectedCard, foundationEligible]);
+
+  const validTableauCols = useMemo(() => {
+    const set = new Set<number>();
+    if (!human || !selectedCard) return set;
+    human.tableau.forEach((col, colIdx) => {
+      // A tableau card cannot be dropped back onto its own column.
+      if (selection?.kind === 'tableau' && selection.col === colIdx) return;
+      const destTop = col.length > 0 ? (col[col.length - 1].card ?? null) : null;
+      if (nertzTableauAccepts(selectedCard, destTop)) set.add(colIdx);
+    });
+    return set;
+  }, [human, selectedCard, selection]);
+
   const phaseName = useMemo(() => {
     if (isGameEnd) return t('phase.gameEnd');
     if (isRoundEnd) return t('phase.roundEnd');
@@ -418,6 +485,8 @@ function NertzPageContent() {
                       collided={collidedFoundationIdx === idx}
                       placedBy={flash?.placedBy ?? null}
                       placedFlashKey={flash?.key ?? 0}
+                      validTarget={validFoundations.has(idx)}
+                      selectionActive={!!selection}
                     />
                   );
                 })}
@@ -491,6 +560,8 @@ function NertzPageContent() {
                       onSelectCard={handleSelectTableau}
                       onTarget={() => handleTableauTargetClick(colIdx)}
                       disabled={!isHumanTurn}
+                      validTarget={validTableauCols.has(colIdx)}
+                      selectionActive={!!selection}
                     />
                   ))}
                 </div>
@@ -556,6 +627,10 @@ interface FoundationCellProps {
   placedBy?: 'human' | 'cpu' | null;
   /** Re-applies the placed flash even when `placedBy` stays the same (e.g., two human placements in a row). */
   placedFlashKey?: number;
+  /** The current selection can legally be placed here → persistent success ring. */
+  validTarget?: boolean;
+  /** A source is currently selected → invalid destinations are dimmed. */
+  selectionActive?: boolean;
 }
 
 function FoundationCell({
@@ -568,10 +643,21 @@ function FoundationCell({
   collided = false,
   placedBy = null,
   placedFlashKey = 0,
+  validTarget = false,
+  selectionActive = false,
 }: FoundationCellProps) {
   const { cardWidth } = useCardDimensions();
   const w = Math.max(44, Math.round(cardWidth * 0.6));
-  const collisionCls = collided ? 'animate-shake ring-2 ring-ds-error' : '';
+  // A rejected move flashes an error ring transiently; otherwise a legal
+  // destination shows a persistent success ring (a non-colour "has a ring"
+  // cue), and invalid destinations dim while a source is selected.
+  const targetCls = collided
+    ? 'animate-shake ring-2 ring-ds-error'
+    : validTarget
+      ? 'ring-2 ring-ds-success'
+      : selectionActive
+        ? 'opacity-60'
+        : '';
   // The placement flash is a sibling overlay so we can remount *it* (via key)
   // to re-fire animate-pulse-once on back-to-back placements without
   // unmounting the underlying <button> and breaking keyboard focus.
@@ -587,11 +673,12 @@ function FoundationCell({
         type="button"
         onClick={onClick}
         disabled={disabled}
-        className={`flex flex-col items-center rounded p-0.5 text-xs text-ds-text-muted disabled:opacity-50 ${collisionCls}`}
+        className={`flex flex-col items-center rounded p-0.5 text-xs text-ds-text-muted disabled:opacity-50 ${targetCls}`}
         aria-label={ariaLabel}
         data-testid={`nertz-foundation-${idx}`}
         data-collided={collided || undefined}
         data-placed-by={placedBy ?? undefined}
+        data-valid-target={validTarget || undefined}
       >
         <span className="block leading-none">F{idx}</span>
         {top ? (
@@ -656,26 +743,50 @@ interface TableauColumnProps {
   onSelectCard: (col: number, cardIndex: number) => void;
   onTarget: () => void;
   disabled: boolean;
+  /** The current selection can legally be placed on this column → persistent success ring. */
+  validTarget?: boolean;
+  /** A source is currently selected → invalid destinations are dimmed. */
+  selectionActive?: boolean;
 }
 
-function TableauColumn({ col, colIdx, selection, onSelectCard, onTarget, disabled }: TableauColumnProps) {
+function TableauColumn({
+  col,
+  colIdx,
+  selection,
+  onSelectCard,
+  onTarget,
+  disabled,
+  validTarget = false,
+  selectionActive = false,
+}: TableauColumnProps) {
   const { cardWidth } = useCardDimensions();
   const w = Math.max(44, Math.round(cardWidth * 0.6));
+  const isSource = selection?.kind === 'tableau' && selection.col === colIdx;
+  // A legal drop column shows a persistent success ring (a non-colour "has a
+  // ring" cue); invalid columns dim while a source is selected, except the
+  // source column itself which keeps its own selection highlight.
+  const targetCls = validTarget ? 'ring-2 ring-ds-success' : selectionActive && !isSource ? 'opacity-60' : '';
   if (col.length === 0) {
     return (
       <button
         type="button"
         onClick={onTarget}
         disabled={disabled}
-        className="min-h-[4rem] rounded border border-dashed border-white/30 text-ds-text-muted text-xs"
+        className={`min-h-[4rem] rounded border border-dashed border-white/30 text-ds-text-muted text-xs ${targetCls}`}
         style={{ width: w }}
+        data-testid={`nertz-tableau-col-${colIdx}`}
+        data-valid-target={validTarget || undefined}
       >
         —
       </button>
     );
   }
   return (
-    <div className="flex flex-col gap-1">
+    <div
+      className={`flex flex-col gap-1 rounded ${targetCls}`}
+      data-testid={`nertz-tableau-col-${colIdx}`}
+      data-valid-target={validTarget || undefined}
+    >
       {col.map((tc, i) => {
         const isSelected = selection?.kind === 'tableau' && selection.col === colIdx && selection.cardIndex === i;
         const isLast = i === col.length - 1;


### PR DESCRIPTION
## 概要

ナーツ（Nertz / Pounce）で、選択中のカード（ナッツ／ウェイスト／タブロー札）に対して、**有効な移動先を視覚的に強調**します。これまでは選択中でもどの列・ファウンデーションが有効かのヒントが一切なく、プレイヤーは総当たりでクリックして衝突エラーを引く必要がありました（コード内コメントおよび PR #1528 レビューでも non-obvious と指摘済み）。Wasp (#3189) / Accordion (#3190) と同クラスのタッチ強調対応です。

## 変更内容

- クライアント側で移動可否を判定するヘルパーを追加（バックエンドの `NertzFoundation.CanAccept` と `canPlaceOnNertzTableau` をミラー）
  - ファウンデーション: 空なら A のみ、非空なら同スート昇順（`top.value + 1`）
  - タブロー: 空列は任意、非空は赤黒交互かつ 1 ランク下（`destTop.value - 1`）
  - ファウンデーションはタブロー列の末尾（トップ）札のみ受理するため、タブロー選択時はその末尾札のみ foundation-eligible とする
- 選択が立っている間、有効な `FoundationCell` / `TableauColumn`（空列・末尾札）を `ring-2 ring-ds-success` で持続的に強調
- 無効な移動先は `opacity-60` で淡色化（選択元のタブロー列自体は既存の選択ハイライトを維持）
- ドラッグ＆ドロップ／クリック操作は一切ブロックしない
- `data-valid-target` 属性を付与しテスト可能に
- フロントエンドのみ（バックエンド変更なし）

## 受け入れ条件

- [x] カード選択中、有効なファウンデーションとタブロー列が視覚的に強調される
- [x] 無効な移動先との区別が色以外（リング形状の有無）でも判別できる
- [x] 選択解除（Escape / 再クリック）で強調が消える
- [x] `NertzPage.test.tsx` にハイライト判定のテストを追加する

## テスト

- 追加テスト: `rings valid foundation and tableau drop targets while a source is selected`
- `bun run test -- --run NertzPage` → 22 passed
- `bunx biome check` → pass
- `bun run build`（tsc）→ pass

Closes #3220