### PR TITLE
feat(crescent): highlight valid move destinations when a card is selected

### DIFF
--- a/frontend/src/pages/CrescentPage.test.tsx
+++ b/frontend/src/pages/CrescentPage.test.tsx
@@ -216,6 +216,48 @@ describe('CrescentPage', () => {
     );
   });
 
+  it('rings valid destinations when a source is selected (no hover needed)', async () => {
+    // col0 top ♠4 can go onto foundation ♠3 (asc) and onto tableau ♠5; ♥6 is invalid.
+    const highlightState: CrescentResponse = {
+      ...playingState,
+      tableau: makeTableau([
+        [{ card: card('SPADE', 4), faceUp: true }],
+        [{ card: card('SPADE', 5), faceUp: true }],
+        [{ card: card('HEART', 6), faceUp: true }],
+      ]),
+      foundation: [
+        [card('SPADE', 3)],
+        [card('CLOVER', 1)],
+        [card('HEART', 1)],
+        [card('DIAMOND', 1)],
+        [card('SPADE', 13)],
+        [card('CLOVER', 13)],
+        [card('HEART', 13)],
+        [card('DIAMOND', 13)],
+      ],
+    };
+    mockExec.mockResolvedValue(highlightState);
+
+    const { container } = renderWithProviders(<CrescentPage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
+
+    const foundations = container.querySelector('[data-tutorial="crescent-foundations"]') as HTMLElement;
+    const tableau = container.querySelector('[data-tutorial="crescent-tableau"]') as HTMLElement;
+    // No selection yet -> nothing highlighted.
+    expect(foundations.querySelectorAll('.ring-ds-success')).toHaveLength(0);
+    expect(tableau.querySelectorAll('.ring-ds-success')).toHaveLength(0);
+
+    // Select ♠4 as the source.
+    const cardButton = screen.getByAltText('♠ 4').closest('button') as HTMLButtonElement;
+    fireEvent.click(cardButton);
+
+    await waitFor(() => expect(foundations.querySelectorAll('.ring-ds-success').length).toBe(1));
+    // Exactly the ♠5 column rings; the ♥6 column and the source do not.
+    expect(tableau.querySelectorAll('.ring-ds-success')).toHaveLength(1);
+    const invalidTop = screen.getByAltText('♥ 6').closest('button') as HTMLButtonElement;
+    expect(invalidTop.className).toContain('opacity-40');
+  });
+
   it('clicking reset dispatches reset (after confirm)', async () => {
     renderWithProviders(<CrescentPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: 'リセット' })).toBeInTheDocument());

--- a/frontend/src/pages/CrescentPage.tsx
+++ b/frontend/src/pages/CrescentPage.tsx
@@ -28,13 +28,14 @@ import { useSolitaireDragDrop } from '../hooks/useSolitaireDragDrop';
 import { useSound } from '../providers/SoundProvider';
 import { btnDanger, btnPrimary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
-import type { CrescentResponse } from '../types/card';
+import type { Card, CrescentResponse } from '../types/card';
 import { CrescentPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import { CRESCENT_HELP, parseCrescentCommand } from '../utils/cli/commands/crescentCommands';
 import { formatCrescentState } from '../utils/cli/formatters/crescentFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { crescentCanPlaceOnFoundation, crescentCanPlaceOnTableau } from '../utils/crescentTargets';
 
 const FOUNDATION_SUITS = ['♠', '♣', '♥', '♦'] as const;
 
@@ -154,6 +155,16 @@ function CrescentPageContent() {
     disabled: loading,
   });
 
+  // The card the player has picked up (always a tableau top card). Drives the
+  // persistent valid-destination highlight so mouse, touch, and keyboard users
+  // all see where the selected card can legally go (#3257).
+  const selectedCard: Card | null = useMemo(() => {
+    if (!selectedSource || selectedSource.zone !== 'tableau' || selectedSource.col === undefined) return null;
+    const col = state?.tableau[selectedSource.col];
+    if (!col || col.length === 0) return null;
+    return col[col.length - 1]?.card ?? null;
+  }, [selectedSource, state]);
+
   const handleManualReset = useCallback(() => {
     hideActionLog();
     handleReset();
@@ -195,6 +206,18 @@ function CrescentPageContent() {
 
   const isSourceSelected = (zone: string, col?: number) =>
     selectedSource !== null && selectedSource.zone === zone && selectedSource.col === col;
+
+  // With a card selected, ring the piles it can legally move to (persistent, so
+  // it survives touch/keyboard where there is no hover), and dim the other
+  // playable tops so mistaken clicks stand out (#3257).
+  const isFoundationTarget = (idx: number) =>
+    selectedCard !== null && crescentCanPlaceOnFoundation(selectedCard, state.foundation, idx);
+  const isTableauTarget = (colIdx: number) =>
+    selectedCard !== null &&
+    !isSourceSelected('tableau', colIdx) &&
+    crescentCanPlaceOnTableau(selectedCard, state.tableau, colIdx);
+  const targetRingClass = (valid: boolean, active: boolean) =>
+    valid && !active ? 'ring-2 ring-ds-success rounded' : '';
 
   return (
     <GamePageShell
@@ -262,6 +285,7 @@ function CrescentPageContent() {
                             onDragOver={dnd.handleDragOver(foundationZone)}
                             onDrop={dnd.handleDrop(foundationZone)}
                             onDragLeave={dnd.handleDragLeave}
+                            className={targetRingClass(isFoundationTarget(idx), dnd.isDropTarget(foundationZone))}
                           >
                             {pile.length > 0 ? (
                               <button
@@ -274,7 +298,7 @@ function CrescentPageContent() {
                                   count: pile.length,
                                   top: cardAlt(pile[pile.length - 1]),
                                 })}
-                                className={`p-0 border-0 bg-transparent cursor-pointer rounded ${focusRingWhite}`}
+                                className={`p-0 border-0 bg-transparent cursor-pointer rounded ${focusRingWhite} ${selectedCard !== null && !isFoundationTarget(idx) ? 'opacity-40' : ''}`}
                               >
                                 <AnimatedCard card={pile[pile.length - 1]} width={tableauDim.cw} draggable={false} />
                               </button>
@@ -331,7 +355,7 @@ function CrescentPageContent() {
                       onDragOver={dnd.handleDragOver(tableauColZone)}
                       onDrop={dnd.handleDrop(tableauColZone)}
                       onDragLeave={dnd.handleDragLeave}
-                      className="relative block"
+                      className={`relative block ${targetRingClass(isTableauTarget(colIdx), dnd.isDropTarget(tableauColZone))}`}
                     >
                       <div className="relative" style={{ minHeight: tableauDim.ch }}>
                         {col.length === 0 ? (
@@ -367,7 +391,7 @@ function CrescentPageContent() {
                                     draggable={isPlaying && !loading && isTop}
                                     onDragStart={isTop ? dnd.handleDragStart(tableauColZone) : undefined}
                                     onDragEnd={dnd.handleDragEnd}
-                                    className={`p-0 border-0 bg-transparent w-full rounded ${isTop ? 'cursor-pointer' : 'cursor-default'} ${focusRingWhite} ${isTop && isSourceSelected('tableau', colIdx) ? 'ring-2 ring-ds-warning' : ''} ${dnd.isDragSource(tableauColZone) && isTop ? 'opacity-50' : ''}`}
+                                    className={`p-0 border-0 bg-transparent w-full rounded ${isTop ? 'cursor-pointer' : 'cursor-default'} ${focusRingWhite} ${isTop && isSourceSelected('tableau', colIdx) ? 'ring-2 ring-ds-warning' : ''} ${dnd.isDragSource(tableauColZone) && isTop ? 'opacity-50' : ''} ${isTop && selectedCard !== null && !isTableauTarget(colIdx) && !isSourceSelected('tableau', colIdx) ? 'opacity-40' : ''}`}
                                   >
                                     <AnimatedCard
                                       card={tc.card}

--- a/frontend/src/utils/crescentTargets.test.ts
+++ b/frontend/src/utils/crescentTargets.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import type { Card, CardDesign, CrescentTableauCard } from '../types/card';
+import { crescentCanPlaceOnFoundation, crescentCanPlaceOnTableau } from './crescentTargets';
+
+const card = (design: CardDesign, value: number): Card => ({ design, value });
+const tc = (design: CardDesign, value: number): CrescentTableauCard => ({ card: card(design, value), faceUp: true });
+
+/** Foundations pre-seeded like a real deal: 0..3 asc (A), 4..7 desc (K). */
+const seededFoundation = (): Card[][] => [
+  [card('SPADE', 1)],
+  [card('CLOVER', 1)],
+  [card('HEART', 1)],
+  [card('DIAMOND', 1)],
+  [card('SPADE', 13)],
+  [card('CLOVER', 13)],
+  [card('HEART', 13)],
+  [card('DIAMOND', 13)],
+];
+
+describe('crescentCanPlaceOnFoundation', () => {
+  it('accepts the next rank up on an ascending pile of the matching suit', () => {
+    expect(crescentCanPlaceOnFoundation(card('SPADE', 2), seededFoundation(), 0)).toBe(true);
+  });
+
+  it('rejects a non-sequential rank on an ascending pile', () => {
+    expect(crescentCanPlaceOnFoundation(card('SPADE', 4), seededFoundation(), 0)).toBe(false);
+  });
+
+  it('accepts the next rank down on a descending pile of the matching suit', () => {
+    expect(crescentCanPlaceOnFoundation(card('SPADE', 12), seededFoundation(), 4)).toBe(true);
+  });
+
+  it('rejects a suit mismatch even when the rank fits', () => {
+    expect(crescentCanPlaceOnFoundation(card('HEART', 2), seededFoundation(), 0)).toBe(false);
+  });
+
+  it('accepts an Ace onto an empty ascending pile and a King onto an empty descending pile', () => {
+    const empty: Card[][] = [[], [], [], [], [], [], [], []];
+    expect(crescentCanPlaceOnFoundation(card('SPADE', 1), empty, 0)).toBe(true);
+    expect(crescentCanPlaceOnFoundation(card('SPADE', 2), empty, 0)).toBe(false);
+    expect(crescentCanPlaceOnFoundation(card('SPADE', 13), empty, 4)).toBe(true);
+    expect(crescentCanPlaceOnFoundation(card('SPADE', 12), empty, 4)).toBe(false);
+  });
+
+  it('rejects out-of-range indices', () => {
+    expect(crescentCanPlaceOnFoundation(card('SPADE', 2), seededFoundation(), -1)).toBe(false);
+    expect(crescentCanPlaceOnFoundation(card('SPADE', 2), seededFoundation(), 8)).toBe(false);
+  });
+});
+
+describe('crescentCanPlaceOnTableau', () => {
+  const tableau: CrescentTableauCard[][] = [[tc('SPADE', 5)], [tc('SPADE', 3)], [tc('HEART', 6)], []];
+
+  it('accepts a same-suit card one rank higher', () => {
+    expect(crescentCanPlaceOnTableau(card('SPADE', 6), tableau, 0)).toBe(true);
+  });
+
+  it('accepts a same-suit card one rank lower', () => {
+    expect(crescentCanPlaceOnTableau(card('SPADE', 4), tableau, 0)).toBe(true);
+  });
+
+  it('rejects a same-suit card two ranks away', () => {
+    expect(crescentCanPlaceOnTableau(card('SPADE', 7), tableau, 0)).toBe(false);
+  });
+
+  it('rejects a suit mismatch', () => {
+    expect(crescentCanPlaceOnTableau(card('HEART', 4), tableau, 0)).toBe(false);
+  });
+
+  it('allows the A↔K wrap in both directions', () => {
+    const wrap: CrescentTableauCard[][] = [[tc('SPADE', 13)], [tc('SPADE', 1)]];
+    expect(crescentCanPlaceOnTableau(card('SPADE', 1), wrap, 0)).toBe(true);
+    expect(crescentCanPlaceOnTableau(card('SPADE', 13), wrap, 1)).toBe(true);
+  });
+
+  it('rejects an empty column and out-of-range indices', () => {
+    expect(crescentCanPlaceOnTableau(card('SPADE', 6), tableau, 3)).toBe(false);
+    expect(crescentCanPlaceOnTableau(card('SPADE', 6), tableau, -1)).toBe(false);
+    expect(crescentCanPlaceOnTableau(card('SPADE', 6), tableau, 99)).toBe(false);
+  });
+});

--- a/frontend/src/utils/crescentTargets.ts
+++ b/frontend/src/utils/crescentTargets.ts
@@ -1,0 +1,53 @@
+import type { Card, CrescentTableauCard } from '../types/card';
+
+/** Highest rank in a standard deck (King). */
+const CRESCENT_MAX_VALUE = 13;
+/** Foundation indices 0..3 build up (A→K); 4..7 build down (K→A). */
+const CRESCENT_ASCENDING_FOUNDATION_CNT = 4;
+
+/**
+ * Maps a card design to its 0-based suit index, matching the foundation layout
+ * (`♠`=0, `♣`=1, `♥`=2, `♦`=3). Mirrors the backend's `crescentFoundationSuit`.
+ */
+const DESIGN_TO_SUIT_INDEX: Record<string, number> = {
+  SPADE: 0,
+  CLOVER: 1,
+  HEART: 2,
+  DIAMOND: 3,
+};
+
+/**
+ * Reports whether `card` can be placed on foundation pile `fIdx`.
+ * Ascending piles (0..3) build up A→K in-suit; descending piles (4..7) build
+ * down K→A in-suit. Mirrors the domain's `canPlaceOnFoundation`.
+ */
+export function crescentCanPlaceOnFoundation(card: Card, foundation: Card[][], fIdx: number): boolean {
+  if (fIdx < 0 || fIdx >= foundation.length) return false;
+  if (DESIGN_TO_SUIT_INDEX[card.design] !== fIdx % CRESCENT_ASCENDING_FOUNDATION_CNT) return false;
+  const pile = foundation[fIdx];
+  const ascending = fIdx < CRESCENT_ASCENDING_FOUNDATION_CNT;
+  if (pile.length === 0) {
+    return ascending ? card.value === 1 : card.value === CRESCENT_MAX_VALUE;
+  }
+  const top = pile[pile.length - 1];
+  return ascending ? card.value === top.value + 1 : card.value === top.value - 1;
+}
+
+/**
+ * Reports whether `card` can be placed on the top of tableau column `toCol`:
+ * same suit, adjacent rank (±1) with A↔K wrap allowed. Empty columns reject.
+ * Mirrors the domain's `canPlaceOnTableau`.
+ */
+export function crescentCanPlaceOnTableau(card: Card, tableau: CrescentTableauCard[][], toCol: number): boolean {
+  if (toCol < 0 || toCol >= tableau.length) return false;
+  const col = tableau[toCol];
+  if (col.length === 0) return false;
+  const top = col[col.length - 1].card;
+  if (!top || card.design !== top.design) return false;
+  const cv = card.value;
+  const tv = top.value;
+  if (cv === tv + 1 || cv === tv - 1) return true;
+  if (cv === 1 && tv === CRESCENT_MAX_VALUE) return true;
+  if (cv === CRESCENT_MAX_VALUE && tv === 1) return true;
+  return false;
+}


### PR DESCRIPTION
## 概要

クレセント・ソリティアでタブローのカードを選択元にした際、置ける先（同スート昇順/降順ファウンデーション、隣接ランクのタブロー列）を `ring-2 ring-ds-success` で常時強調し、それ以外の操作可能なトップカードを `opacity-40` で淡色化します。ホバー依存ではないためマウス/タッチ/キーボードで同じ強調が効き、ドラッグ&ドロップ中にも適用されます。

移動可否判定はドメインの `canPlaceOnFoundation` / `canPlaceOnTableau` を写した新規ユーティリティ `frontend/src/utils/crescentTargets.ts` にクライアント側で切り出し、単体テストを追加しました。

## 変更内容

- `frontend/src/utils/crescentTargets.ts`（新規）— 移動可否判定ユーティリティ
- `frontend/src/utils/crescentTargets.test.ts`（新規）— 判定の単体テスト
- `frontend/src/pages/CrescentPage.tsx` — 選択中の強調表示（ファウンデーション/タブローの ring + 無効トップの淡色化）
- `frontend/src/pages/CrescentPage.test.tsx` — 選択時に有効な移動先へ ring が付くページテスト（ホバーなし）

## 受け入れ条件

- [x] カード選択中に有効な移動先が強調される
- [x] 無効な先が淡色化され誤クリックが減る
- [x] 判定ユーティリティの単体テストがある
- [x] ドラッグ&ドロップ（useSolitaireDragDrop）にも同じ強調が効く

## テスト

- `bunx biome check` — pass
- `bun run test -- --run crescentTargets CrescentPage` — 35 passed
- `bun run build`（tsc）— pass

Closes #3257