### PR TITLE
feat(simplesimon): visualize movable-run boundary and block invalid selection

### DIFF
--- a/frontend/src/pages/SimpleSimonPage.test.tsx
+++ b/frontend/src/pages/SimpleSimonPage.test.tsx
@@ -100,6 +100,38 @@ describe('SimpleSimonPage', () => {
     }
   });
 
+  it('marks only the movable-run cards as grabbable and blocks invalid source selection', async () => {
+    // Column 3: ♠9 (not a run head), then ♥6 ♥5 ♥4 (a same-suit descending run).
+    mockExec.mockResolvedValue(
+      makeState({
+        columns: (() => {
+          const cols: Card[][] = Array.from({ length: 10 }, () => []);
+          cols[0] = [card('SPADE', 5)];
+          cols[3] = [card('SPADE', 9), card('HEART', 6), card('HEART', 5), card('HEART', 4)];
+          return cols;
+        })(),
+      }),
+    );
+    renderWithProviders(<SimpleSimonPage />);
+    const top = await screen.findByTestId('card-3-0');
+    // The out-of-run top card is not grabbable and is disabled.
+    expect(top).toHaveAttribute('data-grabbable', 'false');
+    expect(top).toBeDisabled();
+    // The run head and its tail are grabbable.
+    expect(screen.getByTestId('card-3-1')).toHaveAttribute('data-grabbable', 'true');
+    expect(screen.getByTestId('card-3-3')).toHaveAttribute('data-grabbable', 'true');
+
+    // Clicking the invalid top card selects nothing (no aria-pressed run).
+    fireEvent.click(top);
+    expect(screen.getByTestId('card-3-1')).toHaveAttribute('aria-pressed', 'false');
+
+    // Clicking the run head selects it and its descendants.
+    fireEvent.click(screen.getByTestId('card-3-1'));
+    expect(screen.getByTestId('card-3-1')).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByTestId('card-3-3')).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByTestId('card-3-0')).toHaveAttribute('aria-pressed', 'false');
+  });
+
   it('hides controls at game over', async () => {
     mockExec.mockResolvedValue(makeState({ phase: 2 }));
     renderWithProviders(<SimpleSimonPage />);

--- a/frontend/src/pages/SimpleSimonPage.tsx
+++ b/frontend/src/pages/SimpleSimonPage.tsx
@@ -19,6 +19,7 @@ import type { Card } from '../types/card';
 import { SimpleSimonPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
+import { isGrabbable, movableFromIndex } from '../utils/simpleSimonRun';
 
 /** Simple Simon tutorial step definitions. */
 const SS_TUTORIAL_STEPS: TutorialStep[] = [
@@ -97,6 +98,9 @@ function SimpleSimonPageContent() {
       setSelected(null);
       return;
     }
+    // Only a valid movable run (same-suit descending to the tail) can be grabbed
+    // as a source; ignore clicks on cards above the run boundary.
+    if (!isGrabbable(state.columns[col], idx)) return;
     setSelected({ col, idx });
   };
 
@@ -107,46 +111,59 @@ function SimpleSimonPageContent() {
     setSelected(null);
   };
 
-  const renderColumn = (column: Card[], col: number) => (
-    <div
-      key={`col-${col}`}
-      className={`flex flex-col items-center rounded p-0.5 ${selected && selected.col !== col ? 'ring-1 ring-ds-success' : ''}`}
-      style={{ minHeight: Math.round(w * 1.4) }}
-      data-testid={`column-${col}`}
-    >
-      {column.length === 0 ? (
-        <button
-          type="button"
-          className="rounded border border-dashed border-white/25 bg-black/20"
-          style={{ width: w, height: Math.round(w * 1.4) }}
-          onClick={canAct ? () => clickColumn(col) : undefined}
-          disabled={!canAct}
-          title={t('empty')}
-          aria-label={t('emptyColAria', { col: col + 1 })}
-          data-testid={`column-${col}-drop`}
-        />
-      ) : (
-        column.map((c, i) => {
-          const inSelectedRun = Boolean(selected && selected.col === col && i >= selected.idx);
-          return (
-            <button
-              type="button"
-              key={`col-${col}-${i}`}
-              className={`rounded ${inSelectedRun ? 'ring-2 ring-ds-warning' : ''}`}
-              style={{ marginTop: i === 0 ? 0 : -Math.round(w * 1.05) }}
-              onClick={canAct ? () => clickCard(col, i) : undefined}
-              disabled={!canAct}
-              data-testid={`card-${col}-${i}`}
-              aria-label={t('cardPosAria', { card: cardAlt(c), col: col + 1, pos: i + 1 })}
-              aria-pressed={inSelectedRun}
-            >
-              <CardImage card={c} width={w} />
-            </button>
-          );
-        })
-      )}
-    </div>
-  );
+  const renderColumn = (column: Card[], col: number) => {
+    const isDestination = Boolean(selected && selected.col !== col);
+    const runStart = movableFromIndex(column);
+    return (
+      <div
+        key={`col-${col}`}
+        className={`flex flex-col items-center rounded p-0.5 ${isDestination ? 'ring-1 ring-ds-success' : ''}`}
+        style={{ minHeight: Math.round(w * 1.4) }}
+        data-testid={`column-${col}`}
+      >
+        {column.length === 0 ? (
+          <button
+            type="button"
+            className="rounded border border-dashed border-white/25 bg-black/20"
+            style={{ width: w, height: Math.round(w * 1.4) }}
+            onClick={canAct ? () => clickColumn(col) : undefined}
+            disabled={!canAct}
+            title={t('empty')}
+            aria-label={t('emptyColAria', { col: col + 1 })}
+            data-testid={`column-${col}-drop`}
+          />
+        ) : (
+          column.map((c, i) => {
+            const inSelectedRun = Boolean(selected && selected.col === col && i >= selected.idx);
+            // Grabbable = head of a valid movable run in this column. In a
+            // destination column every card just forwards to the move.
+            const grabbable = i >= runStart;
+            const clickable = isDestination || grabbable;
+            // Highlight the movable-run boundary only while this column can be a
+            // source (no selection, or the selection is here).
+            const showRunHint = !isDestination && grabbable && !inSelectedRun;
+            const ring = inSelectedRun ? 'ring-2 ring-ds-warning' : showRunHint ? 'ring-1 ring-ds-success/70' : '';
+            return (
+              <button
+                type="button"
+                key={`col-${col}-${i}`}
+                className={`rounded ${ring} ${clickable ? '' : 'cursor-not-allowed'}`}
+                style={{ marginTop: i === 0 ? 0 : -Math.round(w * 1.05) }}
+                onClick={canAct ? () => clickCard(col, i) : undefined}
+                disabled={!canAct || !clickable}
+                data-testid={`card-${col}-${i}`}
+                data-grabbable={grabbable}
+                aria-label={t('cardPosAria', { card: cardAlt(c), col: col + 1, pos: i + 1 })}
+                aria-pressed={inSelectedRun}
+              >
+                <CardImage card={c} width={w} />
+              </button>
+            );
+          })
+        )}
+      </div>
+    );
+  };
 
   return (
     <GamePageShell

--- a/frontend/src/utils/simpleSimonRun.test.ts
+++ b/frontend/src/utils/simpleSimonRun.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import type { Card } from '../types/card';
+import { isGrabbable, isRunLink, movableFromIndex } from './simpleSimonRun';
+
+const card = (design: Card['design'], value: number): Card => ({ design, value });
+
+describe('isRunLink', () => {
+  it('is true for a same-suit descending pair', () => {
+    expect(isRunLink(card('SPADE', 9), card('SPADE', 8))).toBe(true);
+  });
+
+  it('is false for a different suit', () => {
+    expect(isRunLink(card('SPADE', 9), card('HEART', 8))).toBe(false);
+  });
+
+  it('is false for a non-descending value', () => {
+    expect(isRunLink(card('SPADE', 9), card('SPADE', 7))).toBe(false);
+    expect(isRunLink(card('SPADE', 9), card('SPADE', 9))).toBe(false);
+  });
+});
+
+describe('movableFromIndex', () => {
+  it('returns 0 for an empty column', () => {
+    expect(movableFromIndex([])).toBe(0);
+  });
+
+  it('returns the last index for a single card', () => {
+    expect(movableFromIndex([card('SPADE', 5)])).toBe(0);
+  });
+
+  it('returns 0 when the whole column is one run', () => {
+    expect(movableFromIndex([card('SPADE', 9), card('SPADE', 8), card('SPADE', 7)])).toBe(0);
+  });
+
+  it('returns the index where the tail run begins', () => {
+    // ♠9, ♥6, ♥5, ♥4 → only ♥6..♥4 form a run → boundary at index 1.
+    const col = [card('SPADE', 9), card('HEART', 6), card('HEART', 5), card('HEART', 4)];
+    expect(movableFromIndex(col)).toBe(1);
+  });
+
+  it('breaks the run at a suit mismatch mid-column', () => {
+    // ♥8, ♠7, ♠6 → run only ♠7..♠6 → boundary at index 1.
+    const col = [card('HEART', 8), card('SPADE', 7), card('SPADE', 6)];
+    expect(movableFromIndex(col)).toBe(1);
+  });
+
+  it('returns the last index when only the bottom card is free', () => {
+    // ♠5, ♠5 (value gap broken) → boundary at the bottom card.
+    const col = [card('SPADE', 5), card('SPADE', 5)];
+    expect(movableFromIndex(col)).toBe(1);
+  });
+});
+
+describe('isGrabbable', () => {
+  const col = [card('SPADE', 9), card('HEART', 6), card('HEART', 5), card('HEART', 4)];
+
+  it('is false above the run boundary', () => {
+    expect(isGrabbable(col, 0)).toBe(false);
+  });
+
+  it('is true at and below the run boundary', () => {
+    expect(isGrabbable(col, 1)).toBe(true);
+    expect(isGrabbable(col, 2)).toBe(true);
+    expect(isGrabbable(col, 3)).toBe(true);
+  });
+
+  it('is false for an empty column', () => {
+    expect(isGrabbable([], 0)).toBe(false);
+  });
+});

--- a/frontend/src/utils/simpleSimonRun.ts
+++ b/frontend/src/utils/simpleSimonRun.ts
@@ -1,0 +1,35 @@
+import type { Card } from '../types/card';
+
+/**
+ * Whether two vertically adjacent tableau cards continue a same-suit descending
+ * run. `upper` is the card nearer the top of the column (lower array index),
+ * `lower` the one just below it. Mirrors the Go domain rule in
+ * `SimpleSimon.simpleSimonIsRun`: same design and the upper value is exactly one
+ * greater than the lower value.
+ */
+export function isRunLink(upper: Card, lower: Card): boolean {
+  return upper.design === lower.design && upper.value === lower.value + 1;
+}
+
+/**
+ * Index of the topmost card in a column that begins a valid movable run — a
+ * same-suit descending sequence running unbroken to the bottom of the column.
+ * Cards at an index `>=` the returned value can be grabbed as a move source;
+ * cards above it cannot. Returns 0 for an empty column (no grabbable cards).
+ */
+export function movableFromIndex(column: Card[]): number {
+  if (column.length === 0) return 0;
+  let idx = column.length - 1;
+  while (idx > 0 && isRunLink(column[idx - 1], column[idx])) {
+    idx--;
+  }
+  return idx;
+}
+
+/**
+ * Whether the card at `idx` in `column` can be grabbed as the head of a movable
+ * run (i.e. `column[idx..]` is a same-suit descending run).
+ */
+export function isGrabbable(column: Card[], idx: number): boolean {
+  return column.length > 0 && idx >= movableFromIndex(column);
+}


### PR DESCRIPTION
## 概要

シンプル・サイモン（`simplesimon`）のタブローで、一括移動できる「同スート連続降順ラン」の境界をフロントエンドで可視化し、無効な位置の選択を防ぐ。

## 変更内容

- `frontend/src/utils/simpleSimonRun.ts`（新規）: 各列の移動可能ラン境界を算出するピュア関数群（`isRunLink` / `movableFromIndex` / `isGrabbable`）。Go ドメインの `simpleSimonIsRun`（同スート、値が 1 ずつ降順）と厳密に一致。
- `SimpleSimonPage.tsx`:
  - 掴める範囲のカードに薄い成功リング（`ring-1 ring-ds-success/70`）を付与し、`data-grabbable` 属性を公開。
  - ラン境界より上のカードは `disabled` + `cursor-not-allowed` で選択不可に。
  - `clickCard` に `isGrabbable` ガードを追加し、無効なソース選択を無視。
  - 移動先へのクリック（別列のカード／空列ドロップ）の挙動は不変。既存の合法な移動操作はブロックしない。
- 単体テスト（ラン境界）＋ページテスト（掴める判定・無効選択の防止）を追加。

## 受け入れ条件

- [x] 掴める範囲のカードだけが選択できる
- [x] 掴める境界が視覚的に判別できる
- [x] ラン判定ユーティリティの単体テスト（分岐網羅80%以上）
- [x] 既存の移動操作テストが green のまま

## テスト

- `bun run test -- --run SimpleSimon` → 2 files / 21 tests passed
- `bun run build`（tsc）通過
- `biome check --write` 通過

Closes #3580
