### PR TITLE
feat(faro): add case keeper tracking remaining cards per rank

### DIFF
--- a/frontend/src/i18n/locales/en/faro.json
+++ b/frontend/src/i18n/locales/en/faro.json
@@ -32,6 +32,8 @@
   "win": "You won chips!",
   "gameEnd": "Out of chips. Game over.",
   "rankName": "Rank",
+  "caseKeeperTitle": "Case keeper (cards left per rank)",
+  "caseKeeperCell": "{{rank}}: {{count}} left",
   "phase": {
     "betting": "Betting",
     "turn": "Turn",

--- a/frontend/src/i18n/locales/ja/faro.json
+++ b/frontend/src/i18n/locales/ja/faro.json
@@ -32,6 +32,8 @@
   "win": "チップを増やしました！",
   "gameEnd": "チップが尽きました。ゲーム終了です。",
   "rankName": "ランク",
+  "caseKeeperTitle": "ケースキーパー（各ランクの残り枚数）",
+  "caseKeeperCell": "{{rank}}：残り{{count}}枚",
   "phase": {
     "betting": "ベット",
     "turn": "ターン",

--- a/frontend/src/pages/FaroPage.test.tsx
+++ b/frontend/src/pages/FaroPage.test.tsx
@@ -59,6 +59,7 @@ const roundEndWinState = makeState({ phase: 4, totalPayout: 200, chips: 1200 });
 const gameEndState = makeState({ phase: 5, gameEndFlag: true, chips: 0 });
 
 beforeEach(() => {
+  localStorage.clear();
   mockExec.mockReset();
   mockExec.mockResolvedValue(bettingState);
 });
@@ -201,5 +202,50 @@ describe('FaroPage', () => {
     mockExec.mockResolvedValue(gameEndState);
     renderWithProviders(<FaroPage />);
     await waitFor(() => expect(screen.getByText('チップが尽きました。ゲーム終了です。')).toBeInTheDocument());
+  });
+
+  describe('case keeper', () => {
+    it('starts every rank at four before any card is revealed', async () => {
+      renderWithProviders(<FaroPage />);
+      const grid = await screen.findByTestId('case-keeper');
+      expect(grid).toBeInTheDocument();
+      for (const rank of [1, 7, 13]) {
+        expect(screen.getByTestId(`case-keeper-rank-${rank}`)).toHaveTextContent('4');
+      }
+    });
+
+    it('decrements ranks by the cards revealed on a turn', async () => {
+      // soda (SPADE A), losing (SPADE 3), winning (HEART 7) -> A, 3, 7 each drop to 3.
+      mockExec.mockResolvedValue(
+        makeState({
+          phase: 2,
+          soda: card('SPADE', 1),
+          losingCard: card('SPADE', 3),
+          winningCard: card('HEART', 7),
+          turnsPlayed: 1,
+        }),
+      );
+      renderWithProviders(<FaroPage />);
+      await waitFor(() => expect(screen.getByTestId('case-keeper-rank-1')).toHaveTextContent('3'));
+      expect(screen.getByTestId('case-keeper-rank-3')).toHaveTextContent('3');
+      expect(screen.getByTestId('case-keeper-rank-7')).toHaveTextContent('3');
+      // An untouched rank stays at four.
+      expect(screen.getByTestId('case-keeper-rank-5')).toHaveTextContent('4');
+    });
+
+    it('resets all ranks to four when the game is reset', async () => {
+      mockExec.mockResolvedValue(
+        makeState({ phase: 2, losingCard: card('SPADE', 3), winningCard: card('HEART', 7), turnsPlayed: 1 }),
+      );
+      renderWithProviders(<FaroPage />);
+      await waitFor(() => expect(screen.getByTestId('case-keeper-rank-3')).toHaveTextContent('3'));
+
+      // Reset returns a fresh deck; the case keeper must clear back to four.
+      mockExec.mockResolvedValue(bettingState);
+      fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
+      const confirm = await screen.findByRole('button', { name: '確認' });
+      fireEvent.click(confirm);
+      await waitFor(() => expect(screen.getByTestId('case-keeper-rank-3')).toHaveTextContent('4'));
+    });
   });
 });

--- a/frontend/src/pages/FaroPage.tsx
+++ b/frontend/src/pages/FaroPage.tsx
@@ -22,9 +22,11 @@ import { gameTheme } from '../styles/gameTheme';
 import type { FaroResponse } from '../types/card';
 import { FaroPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { valueName } from '../utils/cardUtils';
 import { FARO_HELP, parseFaroCommand } from '../utils/cli/commands/faroCommands';
 import { formatFaroState } from '../utils/cli/formatters/faroFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { FARO_RANK_COUNT, mergeSeenCards, remainingByRank } from '../utils/faroCaseKeeper';
 
 /** Rank values on the Faro layout, A (1) through K (13). */
 const RANKS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13] as const;
@@ -95,11 +97,29 @@ function FaroPageContent() {
   const [copper, setCopper] = useState(false);
   const [callOrder, setCallOrder] = useState<number[]>([]);
 
+  // Case keeper: the server sends only the current turn's cards, so accumulate
+  // every revealed card into a local set of unique keys and derive the
+  // per-rank remaining counts from it. Reset each round (reset / next).
+  const [seenKeys, setSeenKeys] = useState<Set<string>>(() => new Set());
+
   // Fetch a fresh game on mount.
   // biome-ignore lint/correctness/useExhaustiveDependencies: run once on mount.
   useEffect(() => {
     exec('reset');
   }, []);
+
+  // Merge each turn's newly revealed cards (soda, last turn, and any call cards)
+  // into the running set. Only new keys grow the set, so returning the previous
+  // reference when nothing changed avoids a redundant re-render.
+  useEffect(() => {
+    if (!state) return;
+    setSeenKeys((prev) => {
+      const next = mergeSeenCards(prev, [state.soda, state.losingCard, state.winningCard, ...state.callCards]);
+      return next.size === prev.size ? prev : next;
+    });
+  }, [state]);
+
+  const remaining = useMemo(() => remainingByRank(seenKeys), [seenKeys]);
 
   const phaseNames = usePhaseNames('faro', FARO_PHASE_KEYS);
 
@@ -133,6 +153,7 @@ function FaroPageContent() {
   const handleReset = () => {
     hideActionLog();
     setCallOrder([]);
+    setSeenKeys(new Set());
     exec('reset');
   };
 
@@ -140,6 +161,7 @@ function FaroPageContent() {
 
   const handleNext = () => {
     setCallOrder([]);
+    setSeenKeys(new Set());
     exec('next');
   };
 
@@ -246,6 +268,39 @@ function FaroPageContent() {
                         </span>
                       )}
                     </button>
+                  );
+                })}
+              </div>
+            </div>
+
+            {/* Case keeper: remaining cards per rank, accumulated from revealed cards */}
+            <div className="mb-3 p-3 rounded bg-black/20" data-testid="case-keeper">
+              <div className="text-ds-text-muted text-xs mb-2 text-center">{t('caseKeeperTitle')}</div>
+              <div className="grid grid-cols-7 gap-1.5 justify-items-center">
+                {RANKS.map((rank) => {
+                  const left = remaining[rank] ?? FARO_RANK_COUNT;
+                  const depleted = left === 0;
+                  return (
+                    <div
+                      key={`case-${rank}`}
+                      className={`flex flex-col items-center rounded border px-1 py-0.5 text-center leading-tight ${
+                        depleted ? 'border-white/10 bg-black/30 opacity-50' : 'border-white/25 bg-black/20'
+                      }`}
+                      data-testid={`case-keeper-rank-${rank}`}
+                      role="img"
+                      aria-label={t('caseKeeperCell', { rank: valueName(rank), count: left })}
+                    >
+                      <span className="text-[11px] font-bold text-ds-text-primary" aria-hidden="true">
+                        {valueName(rank)}
+                      </span>
+                      <span
+                        className={`text-[13px] font-semibold tabular-nums ${
+                          depleted ? 'text-ds-text-muted' : 'text-ds-warning'
+                        }`}
+                      >
+                        {left}
+                      </span>
+                    </div>
                   );
                 })}
               </div>

--- a/frontend/src/utils/faroCaseKeeper.test.ts
+++ b/frontend/src/utils/faroCaseKeeper.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import type { Card } from '../types/card';
+import { FARO_RANK_COUNT, faroCardKey, mergeSeenCards, remainingByRank } from './faroCaseKeeper';
+
+const card = (design: Card['design'], value: number): Card => ({ design, value });
+
+describe('faroCardKey', () => {
+  it('builds a unique key from suit design and value', () => {
+    expect(faroCardKey(card('SPADE', 3))).toBe('SPADE-3');
+    expect(faroCardKey(card('HEART', 13))).toBe('HEART-13');
+  });
+});
+
+describe('mergeSeenCards', () => {
+  it('adds revealed cards to the running set', () => {
+    const seen = mergeSeenCards(new Set(), [card('SPADE', 3), card('HEART', 7)]);
+    expect(seen.has('SPADE-3')).toBe(true);
+    expect(seen.has('HEART-7')).toBe(true);
+    expect(seen.size).toBe(2);
+  });
+
+  it('ignores null and undefined entries', () => {
+    const seen = mergeSeenCards(new Set(), [null, card('SPADE', 3), undefined]);
+    expect(seen.size).toBe(1);
+    expect(seen.has('SPADE-3')).toBe(true);
+  });
+
+  it('deduplicates a card revealed again by an idempotent refresh', () => {
+    const first = mergeSeenCards(new Set(), [card('SPADE', 3)]);
+    const second = mergeSeenCards(first, [card('SPADE', 3), card('CLOVER', 3)]);
+    expect(second.size).toBe(2);
+  });
+
+  it('does not mutate the previous set', () => {
+    const prev = new Set(['SPADE-3']);
+    mergeSeenCards(prev, [card('HEART', 7)]);
+    expect(prev.size).toBe(1);
+  });
+});
+
+describe('remainingByRank', () => {
+  it('starts every rank at four when nothing has been seen', () => {
+    const remaining = remainingByRank(new Set());
+    for (let rank = 1; rank <= 13; rank++) {
+      expect(remaining[rank]).toBe(FARO_RANK_COUNT);
+    }
+  });
+
+  it('subtracts one per distinct seen card of a rank', () => {
+    const seen = new Set(['SPADE-3', 'HEART-3', 'SPADE-7']);
+    const remaining = remainingByRank(seen);
+    expect(remaining[3]).toBe(2);
+    expect(remaining[7]).toBe(3);
+    expect(remaining[5]).toBe(4);
+  });
+
+  it('clamps at zero when all four of a rank are seen', () => {
+    const seen = new Set(['SPADE-9', 'HEART-9', 'CLOVER-9', 'DIAMOND-9']);
+    const remaining = remainingByRank(seen);
+    expect(remaining[9]).toBe(0);
+  });
+
+  it('ignores keys whose rank is out of range', () => {
+    const seen = new Set(['JOKER-0', 'SPADE-14', 'HEART-5']);
+    const remaining = remainingByRank(seen);
+    expect(remaining[5]).toBe(3);
+    expect(remaining[0]).toBeUndefined();
+    expect(remaining[14]).toBeUndefined();
+  });
+});

--- a/frontend/src/utils/faroCaseKeeper.ts
+++ b/frontend/src/utils/faroCaseKeeper.ts
@@ -1,0 +1,47 @@
+import type { Card } from '../types/card';
+
+/** Number of cards of each rank in the standard 52-card Faro deck. */
+export const FARO_RANK_COUNT = 4;
+
+/** Rank values tracked by the case keeper, A (1) through K (13). */
+export const FARO_RANKS: readonly number[] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13];
+
+/**
+ * Returns a stable identity key for a card (suit design + value). Every card in
+ * a standard 52-card deck maps to a unique key, so a Set of keys deduplicates
+ * cards that are revealed again by an idempotent state refresh.
+ */
+export function faroCardKey(card: Card): string {
+  return `${card.design}-${card.value}`;
+}
+
+/**
+ * Merges newly revealed cards into the running set of seen-card keys. Null or
+ * undefined entries are ignored, and duplicates are naturally deduped by the
+ * Set. Returns a new Set (the input is never mutated).
+ */
+export function mergeSeenCards(prev: ReadonlySet<string>, cards: ReadonlyArray<Card | null | undefined>): Set<string> {
+  const next = new Set(prev);
+  for (const card of cards) {
+    if (card) next.add(faroCardKey(card));
+  }
+  return next;
+}
+
+/**
+ * Computes how many cards of each rank (1..13) remain unseen, given the set of
+ * already-seen card keys. Each rank starts at {@link FARO_RANK_COUNT}; every
+ * distinct seen card of that rank subtracts one. Values are clamped to
+ * `[0, FARO_RANK_COUNT]`, and keys with out-of-range ranks are ignored.
+ */
+export function remainingByRank(seen: ReadonlySet<string>): Record<number, number> {
+  const remaining: Record<number, number> = {};
+  for (const rank of FARO_RANKS) remaining[rank] = FARO_RANK_COUNT;
+  for (const key of seen) {
+    const value = Number(key.slice(key.lastIndexOf('-') + 1));
+    if (Number.isInteger(value) && remaining[value] !== undefined && remaining[value] > 0) {
+      remaining[value] -= 1;
+    }
+  }
+  return remaining;
+}


### PR DESCRIPTION
## 概要

ファロに「ケースキーパー」表示を追加しました。実際のファロで既出カードを記録する道具立てにならい、ターンごとに公開されるカード（ソーダ／直前ターンの負け札・勝ち札／コール札）をフロントエンドのローカル state に蓄積し、13ランク（A〜K）の残り枚数（4→0）をグリッド表示します。

バックエンドは変更していません（レスポンスに履歴フィールドは無いため、公開済みカードをクライアント側で集計）。

## 変更点

- `frontend/src/utils/faroCaseKeeper.ts`（新規）— カード集計の純粋ロジック（`faroCardKey` / `mergeSeenCards` / `remainingByRank`）＋ 単体テスト
- `frontend/src/pages/FaroPage.tsx` — 公開カードを `seenKeys` に蓄積する effect、`remainingByRank` から残枚数を導出、`data-testid="case-keeper"` のグリッド追加。`reset` / `next` で全ランク4枚にリセット
- `frontend/src/i18n/locales/{ja,en}/faro.json` — `caseKeeperTitle` / `caseKeeperCell` を追加（キー同期済み）
- 各カードは `design`+`value` で一意に識別できるため Set で重複排除（bet/clearBet 等の冪等な再取得で二重計上しない）

## 受け入れ条件

- [x] 各ランクの残枚数がレイアウト上に表示される
- [x] ターン経過（deal）で公開カード分だけ残枚数が減る
- [x] reset で全ランク4枚に戻る（next も新しいデッキとして4枚にリセット）
- [x] 集計ロジックを `utils` に切り出し単体テストを追加（分岐網羅80%以上）

## テスト

- `bunx biome check` クリーン
- `bun run test -- --run FaroPage faroCaseKeeper` → 30 passed（page の case keeper 3 件＋util 10 件を含む）
- `bun run build`（tsc）成功

Closes #3569
