### PR TITLE
feat(shithead): render face-down cards as card-back images

### DIFF
--- a/frontend/src/pages/ShitheadPage.test.tsx
+++ b/frontend/src/pages/ShitheadPage.test.tsx
@@ -288,6 +288,48 @@ describe('ShitheadPage', () => {
     expect(screen.getByText('リセット: 次のプレイヤーは何でも出せます')).toBeInTheDocument();
   });
 
+  it('renders face-down cards as card-back images rather than "?" buttons', async () => {
+    renderWithProviders(
+      <MemoryRouter initialEntries={['/shithead']}>
+        <ShitheadPage />
+      </MemoryRouter>,
+    );
+    // faceDownCount is 3 for the human player.
+    await waitFor(() => expect(screen.getByTestId('sh-facedown-0')).toBeInTheDocument());
+    expect(screen.getByTestId('sh-facedown-1')).toBeInTheDocument();
+    expect(screen.getByTestId('sh-facedown-2')).toBeInTheDocument();
+    // Each face-down slot renders a card-back image, not a literal "?".
+    expect(screen.getAllByTestId('animated-card-back').length).toBeGreaterThanOrEqual(3);
+    expect(screen.getByTestId('sh-facedown-0')).not.toHaveTextContent('?');
+  });
+
+  it('makes face-down cards selectable with a ring when currentSource is facedown', async () => {
+    mockExec.mockResolvedValue({ ...humanTurnState, currentSource: 'facedown' });
+    renderWithProviders(
+      <MemoryRouter initialEntries={['/shithead']}>
+        <ShitheadPage />
+      </MemoryRouter>,
+    );
+    const first = await screen.findByTestId('sh-facedown-0');
+    expect(first).toBeEnabled();
+    expect(first).toHaveAttribute('aria-pressed', 'false');
+    fireEvent.click(first);
+    await waitFor(() => expect(screen.getByTestId('sh-facedown-0')).toHaveAttribute('aria-pressed', 'true'));
+    expect(screen.getByTestId('sh-facedown-0').className).toContain('ring-ds-warning');
+  });
+
+  it('disables face-down cards when the current source is not facedown', async () => {
+    renderWithProviders(
+      <MemoryRouter initialEntries={['/shithead']}>
+        <ShitheadPage />
+      </MemoryRouter>,
+    );
+    // Default humanTurnState currentSource is 'hand'.
+    const first = await screen.findByTestId('sh-facedown-0');
+    expect(first).toBeDisabled();
+    expect(first).not.toHaveAttribute('aria-pressed');
+  });
+
   it('renders a joker discard top as a card image with an accessible label', async () => {
     mockExec.mockResolvedValue({
       ...humanTurnState,

--- a/frontend/src/pages/ShitheadPage.tsx
+++ b/frontend/src/pages/ShitheadPage.tsx
@@ -10,6 +10,7 @@ import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
+import { AnimatedCardBack } from '../components/motion/AnimatedCardBack';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCliGame } from '../hooks/useCliGame';
@@ -388,28 +389,28 @@ interface FaceDownRowProps {
   onToggle: (index: number) => void;
 }
 
-/** Row of face-down (hidden) cards selectable for blind play. */
+/** Row of face-down (hidden) cards rendered as card-back images, selectable for blind play. */
 function FaceDownRow({ label, count, selectable, selected, onToggle }: FaceDownRowProps) {
+  const { cardWidth } = useCardDimensions();
   return (
     <div className="space-y-1">
       <div className="text-xs uppercase tracking-wide text-ds-text-muted">{label}</div>
       <div className="flex flex-wrap gap-2">
         {Array.from({ length: count }).map((_, i) => {
           const isSelected = selected.includes(i);
-          const cls = isSelected
-            ? 'bg-ds-warning text-ds-text-on-accent border-ds-warning'
-            : selectable
-              ? 'bg-ds-accent text-ds-text-on-accent border-ds-border-subtle hover:bg-ds-accent-hover'
-              : 'bg-ds-surface text-ds-text-muted border-ds-border-subtle';
           return (
             <button
               key={`fd-${i}`}
               type="button"
               disabled={!selectable}
               onClick={() => onToggle(i)}
-              className={`min-w-[3rem] px-2 py-2 rounded border text-sm ${cls}`}
+              aria-pressed={selectable ? isSelected : undefined}
+              data-testid={`sh-facedown-${i}`}
+              className={`relative rounded transition-transform ${focusRingCard} ${
+                isSelected ? 'ring-2 ring-ds-warning -translate-y-1' : ''
+              } ${selectable ? 'cursor-pointer' : 'cursor-default'}`}
             >
-              ?
+              <AnimatedCardBack width={cardWidth} />
             </button>
           );
         })}


### PR DESCRIPTION
## 概要
シットヘッド（`shithead`）の伏せ札を「?」テキストボタンではなく、実際のカード裏面画像（`AnimatedCardBack`）で描画するように変更しました。手札・場札の行（`AnimatedCard`）と表現を揃え、プレイヤーエリア内の見た目の一貫性を確保します。

## 変更内容
- `FaceDownRow` を `AnimatedCardBack` ベースに置き換え、`useCardDimensions` の `cardWidth` に合わせたサイズで描画
- 選択状態は共通の `ring-2 ring-ds-warning` リングで表現（`CardRow` と同じ）
- ブラインドプレイ時の選択操作は既存の `onToggle(i)` を維持（`currentSource === 'facedown'` のとき選択可能）
- `data-testid="sh-facedown-<i>"` と `aria-pressed` を付与し、テストで検証可能に
- フロントエンドのみの表示変更（バックエンド変更なし）

## 受け入れ条件
- [x] 伏せ札が `AnimatedCardBack` によるカード裏面画像で表示される
- [x] `currentSource === 'facedown'` のとき選択可能で、選択中はリング表示される
- [x] 手札・場札とカード幅が揃い、モバイルでもレイアウトが崩れない（`cardWidth` を共有）
- [x] `ShitheadPage.test.tsx` の関連テストを更新し全て通過する

## テスト
- `bun run test -- --run ShitheadPage`: 21 passed（伏せ札のカード裏面描画・選択リング・非facedown時の無効化を新規追加）
- `bunx biome check`: パス
- `bun run build`（tsc）: パス

Closes #3217