### PR TITLE
feat(tysiac): add per-player progress bar toward the 1000-point target

### DIFF
--- a/frontend/src/i18n/locales/en/tysiac.json
+++ b/frontend/src/i18n/locales/en/tysiac.json
@@ -47,6 +47,7 @@
   "nextTrick": "Next Trick",
   "nextRound": "Next Round",
   "target": "Target: {{points}} pts",
+  "progressLabel": "Progress: {{score}} / {{target}}",
   "lastTrickBonus": "Last trick +10",
   "playPhase": {
     "lead": "Your turn — pick a card to lead.",

--- a/frontend/src/i18n/locales/ja/tysiac.json
+++ b/frontend/src/i18n/locales/ja/tysiac.json
@@ -47,6 +47,7 @@
   "nextTrick": "次のトリック",
   "nextRound": "次のラウンド",
   "target": "目標: {{points}}点",
+  "progressLabel": "進捗: {{score}} / {{target}}",
   "lastTrickBonus": "ラストトリック +10",
   "playPhase": {
     "lead": "あなたの番です — リードするカードを選んでください。",

--- a/frontend/src/pages/TysiacPage.test.tsx
+++ b/frontend/src/pages/TysiacPage.test.tsx
@@ -177,4 +177,61 @@ describe('TysiacPage', () => {
     await waitFor(() => expect(screen.getByAltText('♥ Q')).toBeInTheDocument());
     expect(screen.queryByRole('button', { name: '出す' })).not.toBeInTheDocument();
   });
+
+  it('renders a progress bar toward the target for each player', async () => {
+    const state = makeTysiacState({
+      players: [
+        { id: 0, isHuman: true, cardCount: 7, cards: [], trickCount: 0, score: 250, isDeclarer: false },
+        { id: 1, isHuman: false, cardCount: 7, cards: [], trickCount: 0, score: 500, isDeclarer: false },
+        { id: 2, isHuman: false, cardCount: 7, cards: [], trickCount: 0, score: 100, isDeclarer: false },
+      ],
+    });
+    mockExec.mockResolvedValue(state);
+    renderWithProviders(<TysiacPage />);
+    const bar0 = await screen.findByTestId('tysiac-progress-0');
+    expect(bar0).toHaveAttribute('role', 'progressbar');
+    expect(bar0).toHaveAttribute('aria-valuemax', '1000');
+    expect(bar0).toHaveAttribute('aria-valuenow', '250');
+    expect(screen.getByTestId('tysiac-progress-1')).toHaveAttribute('aria-valuenow', '500');
+    expect(screen.getByTestId('tysiac-progress-2')).toHaveAttribute('aria-valuenow', '100');
+    // Below 80%: accent (non-warning) fill.
+    expect(bar0.querySelector('.bg-ds-accent')).not.toBeNull();
+    expect(bar0.querySelector('.bg-ds-warning')).toBeNull();
+  });
+
+  it('turns the bar to the warning color once a player passes 80% of the target', async () => {
+    const state = makeTysiacState({
+      players: [
+        { id: 0, isHuman: true, cardCount: 7, cards: [], trickCount: 0, score: 850, isDeclarer: false },
+        { id: 1, isHuman: false, cardCount: 7, cards: [], trickCount: 0, score: 400, isDeclarer: false },
+        { id: 2, isHuman: false, cardCount: 7, cards: [], trickCount: 0, score: 800, isDeclarer: false },
+      ],
+    });
+    mockExec.mockResolvedValue(state);
+    renderWithProviders(<TysiacPage />);
+    const bar0 = await screen.findByTestId('tysiac-progress-0');
+    // 850/1000 = 85% > 80% → warning fill.
+    expect(bar0.querySelector('.bg-ds-warning')).not.toBeNull();
+    // Exactly 80% is not "over" 80% → still accent.
+    expect(screen.getByTestId('tysiac-progress-2').querySelector('.bg-ds-warning')).toBeNull();
+  });
+
+  it('overlays the contract-forecast marker on the Declarer bar only', async () => {
+    const state = makeTysiacState({
+      players: [
+        { id: 0, isHuman: true, cardCount: 7, cards: [], trickCount: 0, score: 300, isDeclarer: true },
+        { id: 1, isHuman: false, cardCount: 7, cards: [], trickCount: 0, score: 200, isDeclarer: false },
+        { id: 2, isHuman: false, cardCount: 7, cards: [], trickCount: 0, score: 100, isDeclarer: false },
+      ],
+      contract: 120,
+    });
+    mockExec.mockResolvedValue(state);
+    renderWithProviders(<TysiacPage />);
+    const marker = await screen.findByTestId('tysiac-forecast-0');
+    // (300 + 120) / 1000 = 42%.
+    expect(marker).toHaveStyle({ left: '42%' });
+    // Non-declarers get no forecast marker.
+    expect(screen.queryByTestId('tysiac-forecast-1')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('tysiac-forecast-2')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/TysiacPage.tsx
+++ b/frontend/src/pages/TysiacPage.tsx
@@ -251,20 +251,56 @@ function TysiacPageContent() {
 
               {/* Right: info sidebar */}
               <div data-tutorial="tysiac-info">
-                {/* Per-player match scores with Declarer badge */}
+                {/* Per-player match scores with Declarer badge + progress toward the target */}
                 <div className="mb-2 p-2 rounded bg-black/30 text-ds-text-muted text-sm">
-                  {state.players.map((p) => (
-                    <div key={p.id} className="py-0.5 flex items-center gap-2">
-                      <span className={p.isDeclarer ? 'text-ds-warning font-semibold' : ''}>
-                        {playerName(p.id, p.isHuman)}: {t('score', { score: p.score })}
-                      </span>
-                      {p.isDeclarer && (
-                        <span className="px-1.5 py-0.5 rounded bg-ds-warning/30 text-ds-warning text-xs">
-                          {t('declarerBadge')}
-                        </span>
-                      )}
-                    </div>
-                  ))}
+                  {state.players.map((p) => {
+                    const target = state.config.targetPoints;
+                    const pct = Math.max(0, Math.min(100, (p.score / target) * 100));
+                    // Warn once a player is within striking distance of the target (>80%).
+                    const isNearWin = p.score / target > 0.8;
+                    // Declarer forecast: score if this round's contract is met, marked on the bar.
+                    const forecastPct =
+                      p.isDeclarer && state.contract > 0
+                        ? Math.max(0, Math.min(100, ((p.score + state.contract) / target) * 100))
+                        : null;
+                    const barLabel = t('progressLabel', { score: p.score, target });
+                    return (
+                      <div key={p.id} className="py-0.5">
+                        <div className="flex items-center gap-2">
+                          <span className={p.isDeclarer ? 'text-ds-warning font-semibold' : ''}>
+                            {playerName(p.id, p.isHuman)}: {t('score', { score: p.score })}
+                          </span>
+                          {p.isDeclarer && (
+                            <span className="px-1.5 py-0.5 rounded bg-ds-warning/30 text-ds-warning text-xs">
+                              {t('declarerBadge')}
+                            </span>
+                          )}
+                        </div>
+                        <div
+                          role="progressbar"
+                          aria-label={barLabel}
+                          aria-valuemin={0}
+                          aria-valuemax={target}
+                          aria-valuenow={Math.max(0, p.score)}
+                          data-testid={`tysiac-progress-${p.id}`}
+                          className="relative mt-0.5 h-1.5 w-full rounded-sm bg-white/15 overflow-hidden"
+                        >
+                          <div
+                            className={`h-full rounded-sm ${isNearWin ? 'bg-ds-warning' : 'bg-ds-accent'}`}
+                            style={{ width: `${pct}%` }}
+                          />
+                          {forecastPct !== null && (
+                            <div
+                              data-testid={`tysiac-forecast-${p.id}`}
+                              aria-hidden="true"
+                              className="absolute top-0 h-full border-l border-dashed border-ds-text-primary"
+                              style={{ left: `${forecastPct}%` }}
+                            />
+                          )}
+                        </div>
+                      </div>
+                    );
+                  })}
                 </div>
 
                 {/* Players: cards / tricks */}


### PR DESCRIPTION
## 概要

サウザンド（Tysiąc）のサイドバーで、各プレイヤーが勝利目標（`config.targetPoints`、デフォルト1000）にどれだけ迫っているかを視覚的に示す `score / target` の水平プログレスバーを追加します。

- 各プレイヤー行に目標比のプログレスバー（`role="progressbar"`、`aria-valuenow/max`）を表示
- 目標の80%を超えたプレイヤーのバーを警告色（`bg-ds-warning`）に変更
- デクレアラーのバーに契約達成予測（`(score + contract) / target`）を破線マーカーで重ねて、今ラウンドがゲームを決めるかを可視化
- フロントエンドのみ。目標値はGoドメイン `internal/domain/Tysiac.go` の `TysiacWinTarget = 1000`（`config.TargetPoints` 経由でゲーム終了判定に使用）と一致

## 受け入れ条件

- [x] 各プレイヤーに目標比のプログレスバーが表示される
- [x] 80%超のプレイヤーが警告色になる
- [x] デクレアラーのバーに契約達成予測マーカーが出る
- [x] `TysiacPage.test.tsx` に表示分岐のテストを追加

## テスト

- `bun run test -- --run TysiacPage` — 19 passed（新規3件: 進捗バー描画 / 80%超の警告色 / デクレアラーの予測マーカー）
- `bun run build`（tsc）— 成功
- `biome check` — クリーン

Closes #3605