### PR TITLE
feat(solowhist): show declarer contract progress toward the trick target

### DIFF
--- a/frontend/src/i18n/locales/en/solowhist.json
+++ b/frontend/src/i18n/locales/en/solowhist.json
@@ -31,6 +31,12 @@
   "contract": "Contract: {{contract}}",
   "contractUndecided": "Contract: undecided",
   "declarerLine": "Declarer: {{name}} — {{contract}}",
+  "progress": {
+    "line": "Declarer progress: {{won}} / {{needed}} tricks",
+    "misere": "Declarer progress: {{won}} tricks (Misère, target 0)",
+    "made": "Contract made",
+    "failed": "Contract failed"
+  },
   "bidLabel": "Bid",
   "playButton": "Play",
   "nextTrick": "Next Trick",

--- a/frontend/src/i18n/locales/ja/solowhist.json
+++ b/frontend/src/i18n/locales/ja/solowhist.json
@@ -31,6 +31,12 @@
   "contract": "契約: {{contract}}",
   "contractUndecided": "契約: 未決定",
   "declarerLine": "宣言者: {{name}} — {{contract}}",
+  "progress": {
+    "line": "宣言者の進捗: {{won}} / {{needed}} トリック",
+    "misere": "宣言者の進捗: {{won}} トリック（ミゼール・目標0）",
+    "made": "達成",
+    "failed": "失敗確定"
+  },
   "bidLabel": "入札",
   "playButton": "出す",
   "nextTrick": "次のトリック",

--- a/frontend/src/pages/SoloWhistPage.test.tsx
+++ b/frontend/src/pages/SoloWhistPage.test.tsx
@@ -59,7 +59,29 @@ const gameEndState = makeSoloWhistState({
   message: 'ゲーム終了！ あなたの勝ちです！',
 });
 
+/**
+ * Builds a play-phase fixture with the human declarer holding a given contract,
+ * tricks won, and cards left in hand — the three inputs to the contract-progress readout.
+ */
+function makeProgressState(contract: number, won: number, cardCount: number) {
+  return makeSoloWhistState({
+    phase: 1,
+    declarerIdx: 0,
+    contract,
+    trumpSuit: contract === 2 ? 0 : 3,
+    isHumanBidTurn: false,
+    isHumanTurn: true,
+    players: [
+      { id: 0, isHuman: true, cardCount, cards: [], trickCount: won, score: 0, isDeclarer: true },
+      { id: 1, isHuman: false, cardCount, cards: [], trickCount: 0, score: 0, isDeclarer: false },
+      { id: 2, isHuman: false, cardCount, cards: [], trickCount: 0, score: 0, isDeclarer: false },
+      { id: 3, isHuman: false, cardCount, cards: [], trickCount: 0, score: 0, isDeclarer: false },
+    ],
+  });
+}
+
 beforeEach(() => {
+  localStorage.clear();
   mockExec.mockReset();
   mockExec.mockResolvedValue(bidPhaseState);
 });
@@ -177,5 +199,63 @@ describe('SoloWhistPage', () => {
     mockExec.mockResolvedValue(gameEndState);
     renderWithProviders(<SoloWhistPage />);
     await waitFor(() => expect(screen.getByText('ゲーム終了！ あなたの勝ちです！')).toBeInTheDocument());
+  });
+
+  it('shows the Solo contract progress in-progress (won < 8, still reachable)', async () => {
+    // Solo targets 8 tricks; 3 won with 9 cards left is still reachable → in progress.
+    mockExec.mockResolvedValue(makeProgressState(1, 3, 9));
+    renderWithProviders(<SoloWhistPage />);
+    const line = await screen.findByTestId('solowhist-contract-progress');
+    expect(line).toHaveTextContent('宣言者の進捗: 3 / 8 トリック');
+    expect(line).not.toHaveTextContent('達成');
+    expect(line).not.toHaveTextContent('失敗確定');
+    expect(line.className).toContain('text-ds-warning');
+  });
+
+  it('marks the Solo contract as made once the target is reached', async () => {
+    // 8 tricks won meets the Solo target → made.
+    mockExec.mockResolvedValue(makeProgressState(1, 8, 5));
+    renderWithProviders(<SoloWhistPage />);
+    const line = await screen.findByTestId('solowhist-contract-progress');
+    expect(line).toHaveTextContent('宣言者の進捗: 8 / 8 トリック');
+    expect(line).toHaveTextContent('達成');
+    expect(line.className).toContain('text-ds-success');
+  });
+
+  it('marks the Solo contract as failed when the target is out of reach', async () => {
+    // 2 won + 5 remaining = 7 < 8 → mathematically impossible → failed.
+    mockExec.mockResolvedValue(makeProgressState(1, 2, 5));
+    renderWithProviders(<SoloWhistPage />);
+    const line = await screen.findByTestId('solowhist-contract-progress');
+    expect(line).toHaveTextContent('失敗確定');
+    expect(line.className).toContain('text-ds-error');
+  });
+
+  it('fails the Misère contract the instant a trick is won', async () => {
+    // Misère (contract 2) targets 0 tricks; winning even 1 fails immediately.
+    mockExec.mockResolvedValue(makeProgressState(2, 1, 8));
+    renderWithProviders(<SoloWhistPage />);
+    const line = await screen.findByTestId('solowhist-contract-progress');
+    expect(line).toHaveTextContent('宣言者の進捗: 1 トリック（ミゼール・目標0）');
+    expect(line).toHaveTextContent('失敗確定');
+    expect(line.className).toContain('text-ds-error');
+  });
+
+  it('keeps a clean Misère in progress while no trick is won', async () => {
+    // 0 tricks won with cards still in hand → still in progress.
+    mockExec.mockResolvedValue(makeProgressState(2, 0, 8));
+    renderWithProviders(<SoloWhistPage />);
+    const line = await screen.findByTestId('solowhist-contract-progress');
+    expect(line).toHaveTextContent('宣言者の進捗: 0 トリック（ミゼール・目標0）');
+    expect(line).not.toHaveTextContent('失敗確定');
+    expect(line).not.toHaveTextContent('達成');
+    expect(line.className).toContain('text-ds-warning');
+  });
+
+  it('does not show the progress readout before the contract is decided', async () => {
+    mockExec.mockResolvedValue(makeSoloWhistState({ declarerIdx: -1 }));
+    renderWithProviders(<SoloWhistPage />);
+    await waitFor(() => expect(screen.getByTestId('solowhist-declarer')).toBeInTheDocument());
+    expect(screen.queryByTestId('solowhist-contract-progress')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/SoloWhistPage.tsx
+++ b/frontend/src/pages/SoloWhistPage.tsx
@@ -38,6 +38,60 @@ const SUIT_SYMBOLS = ['', '♠', '♣', '♥', '♦'] as const;
 /** Contract i18n key suffixes indexed by contract value (0=Pass…3=Abundance). */
 const CONTRACT_KEYS = ['pass', 'solo', 'misere', 'abundance'] as const;
 
+/**
+ * Target trick count for each contract, indexed by contract value
+ * (0=Pass 1=Solo 2=Misère 3=Abundance). Mirrors the Go domain
+ * `soloWhistBidTarget`; Misère targets 0 tricks won.
+ */
+const CONTRACT_TARGET_TRICKS = [0, 8, 0, 9] as const;
+
+/** Whether the declarer has made their contract, failed it, or is still in progress. */
+type ContractStatus = 'made' | 'failed' | 'progress';
+
+/** Tailwind text color per contract status (made=success, in-progress=warning, failed=error). */
+const CONTRACT_STATUS_COLOR: Readonly<Record<ContractStatus, string>> = {
+  made: 'text-ds-success',
+  failed: 'text-ds-error',
+  progress: 'text-ds-warning',
+};
+
+/** The declarer's contract progress derived from tricks won and cards still in hand. */
+interface ContractProgress {
+  /** Tricks the declarer has won so far this round. */
+  won: number;
+  /** Tricks the declarer needs (0 for Misère). */
+  needed: number;
+  /** Made / failed / still in progress. */
+  status: ContractStatus;
+  /** Whether the contract is Misère (win no tricks). */
+  isMisere: boolean;
+}
+
+/**
+ * Computes the declarer's contract progress from tricks won and remaining tricks.
+ * `remaining` is the declarer's card count (each remaining card equals one trick still to play).
+ * Misère fails the instant a trick is won; Solo/Abundance succeed on reaching the target.
+ */
+function computeContractProgress(contract: number, won: number, remaining: number): ContractProgress {
+  const isMisere = contract === SoloWhistContract.MISERE;
+  const needed = CONTRACT_TARGET_TRICKS[contract] ?? 0;
+  let status: ContractStatus;
+  if (isMisere) {
+    // Misère fails the instant a trick is won; it is only made once the round completes clean.
+    if (won > 0) status = 'failed';
+    else if (remaining === 0) status = 'made';
+    else status = 'progress';
+  } else if (won >= needed) {
+    status = 'made';
+  } else if (won + remaining < needed) {
+    // Not enough tricks left to reach the target — failure is mathematically certain.
+    status = 'failed';
+  } else {
+    status = 'progress';
+  }
+  return { won, needed, status, isMisere };
+}
+
 /** Bid button options (Pass/Solo/Misère/Abundance). */
 const BIDS: { value: number; key: string }[] = [
   { value: SoloWhistContract.PASS, key: 'bid.pass' },
@@ -171,6 +225,13 @@ function SoloWhistPageContent() {
   const contractName =
     state.declarerIdx >= 0 ? t(`contractName.${CONTRACT_KEYS[state.contract] ?? 'pass'}`) : t('contractUndecided');
 
+  // Declarer's progress toward the contract, derived from tricks won and cards still in hand.
+  const declarer = state.declarerIdx >= 0 ? state.players[state.declarerIdx] : undefined;
+  const contractProgress =
+    declarer && state.contract !== SoloWhistContract.PASS
+      ? computeContractProgress(state.contract, declarer.trickCount, declarer.cardCount)
+      : undefined;
+
   const handleManualReset = () => {
     hideActionLog();
     reset();
@@ -254,6 +315,21 @@ function SoloWhistPageContent() {
                   })
                 : t('contractUndecided')}
             </div>
+
+            {contractProgress && (
+              <div
+                className={`text-center mb-2 text-sm font-semibold ${CONTRACT_STATUS_COLOR[contractProgress.status]}`}
+                data-testid="solowhist-contract-progress"
+                role="status"
+                aria-live="polite"
+              >
+                {contractProgress.isMisere
+                  ? t('progress.misere', { won: contractProgress.won })
+                  : t('progress.line', { won: contractProgress.won, needed: contractProgress.needed })}
+                {contractProgress.status === 'made' && ` — ${t('progress.made')}`}
+                {contractProgress.status === 'failed' && ` — ${t('progress.failed')}`}
+              </div>
+            )}
 
             <div className={lgTwoColGrid}>
               {/* Left: play area */}


### PR DESCRIPTION
## 概要

ソロ・ホイストの宣言者行（declarerLine）の直下に、契約の目標トリック数に対する進捗インジケーターを追加しました。OhHell / Preference の bid-progress 表示と同じパターンです。

`state.declarerIdx` / `state.contract` / 宣言者の `trickCount`（獲得トリック）と `cardCount`（残りトリック相当）だけで算出でき、バックエンド変更はありません。

## 目標トリック数（Go ドメイン `soloWhistBidTarget` に一致）

- Solo = **8** トリック
- Abundance = **9** トリック
- Misère = **0** トリック

（issue 本文には「ソロ=5」とありましたが、実装ドメインは Solo=8 なので `internal/domain/SoloWhist.go` の値に合わせています。）

## 挙動

- 「宣言者の進捗: X / 8 トリック」を表示（Misère は「X トリック（ミゼール・目標0）」）
- **達成** = success 色 / **進行中** = warning 色 / **失敗確定** = error 色
- Solo/Abundance: 目標到達で達成、残りトリックを足しても目標に届かなくなった時点で失敗確定
- Misère: 1 トリックでも取った時点で失敗確定

## テスト

`SoloWhistPage.test.tsx` に契約別テストを追加（Solo 進行中/達成/失敗、Misère 失敗即時/クリーン進行中、契約未確定時は非表示）。

## 受け入れ条件

- [x] 宣言者のトリック数と契約目標が並記される
- [x] ミゼールで 1 トリック以上取った場合に失敗表示になる
- [x] ja/en 両ロケールに進捗文言を追加
- [x] SoloWhistPage.test.tsx に契約別のテストを追加

## ゲート

- `biome check` パス
- `bun run test -- --run SoloWhistPage`（20 passed）
- `bun run build`（tsc）パス

Closes #3433
