### PR TITLE
feat(fortyfives): プレイ中のライブラウンドポイントと契約達成状況の表示

### DIFF
--- a/frontend/src/i18n/locales/en/fortyfives.json
+++ b/frontend/src/i18n/locales/en/fortyfives.json
@@ -53,6 +53,15 @@
     "teamA": "Team A: {{points}} pts",
     "teamB": "Team B: {{points}} pts"
   },
+  "livePoints": {
+    "title": "Live Points",
+    "contract": "{{team}} (bid): {{got}} / contract {{contract}} pts",
+    "status": {
+      "made": "Contract made",
+      "failed": "Cannot make it",
+      "needMore": "{{remaining}} pt(s) to go"
+    }
+  },
   "hintAvailable": "Hint",
   "hint": {
     "lead_high": "Lead a strong card to win the trick",

--- a/frontend/src/i18n/locales/ja/fortyfives.json
+++ b/frontend/src/i18n/locales/ja/fortyfives.json
@@ -53,6 +53,15 @@
     "teamA": "チームA: {{points}}点",
     "teamB": "チームB: {{points}}点"
   },
+  "livePoints": {
+    "title": "ライブ得点",
+    "contract": "{{team}}（落札）: {{got}} / 契約{{contract}}点",
+    "status": {
+      "made": "契約達成",
+      "failed": "達成不能",
+      "needMore": "あと{{remaining}}点"
+    }
+  },
   "hintAvailable": "ヒント",
   "hint": {
     "lead_high": "強い札でリードしてトリックを取りに行く",

--- a/frontend/src/pages/FortyFivesPage.test.tsx
+++ b/frontend/src/pages/FortyFivesPage.test.tsx
@@ -174,4 +174,43 @@ describe('FortyFivesPage', () => {
     renderWithProviders(<FortyFivesPage />);
     await waitFor(() => expect(screen.getByText('ゲーム終了！ あなたのチームの勝ち！')).toBeInTheDocument());
   });
+
+  it('shows the live round points panel during play with team points', async () => {
+    // Team A has won 2 tricks (10 pts), team B 1 trick (5 pts) so far this round.
+    mockExec.mockResolvedValue({ ...playPhaseState, roundTeamPoints: [10, 5] });
+    renderWithProviders(<FortyFivesPage />);
+    const panel = await screen.findByTestId('ff-live-points');
+    expect(panel).toHaveTextContent('ライブ得点');
+    expect(panel).toHaveTextContent('チームA: 10点');
+    expect(panel).toHaveTextContent('チームB: 5点');
+  });
+
+  it('shows the declarer contract progress with a "needMore" status while still reachable', async () => {
+    // Declarer team A (declarerIdx 0) has 10 of a 20-pt contract; 15 pts remain, so it is still on track.
+    mockExec.mockResolvedValue({ ...playPhaseState, contract: 20, declarerIdx: 0, roundTeamPoints: [10, 5] });
+    renderWithProviders(<FortyFivesPage />);
+    const progress = await screen.findByTestId('ff-contract-progress');
+    expect(progress).toHaveTextContent('契約20点');
+    expect(progress).toHaveTextContent('あと10点');
+  });
+
+  it('marks the contract as made once the declarer team reaches the contract', async () => {
+    mockExec.mockResolvedValue({ ...playPhaseState, contract: 15, declarerIdx: 0, roundTeamPoints: [15, 5] });
+    renderWithProviders(<FortyFivesPage />);
+    await waitFor(() => expect(screen.getByTestId('ff-contract-progress')).toHaveTextContent('契約達成'));
+  });
+
+  it('marks the contract as unreachable when even every remaining trick would fall short', async () => {
+    // Contract 25 for team A: A has 5, B has 15 (4 tricks resolved), only 1 trick (5 pts) left → max 10 < 25.
+    mockExec.mockResolvedValue({ ...playPhaseState, contract: 25, declarerIdx: 0, roundTeamPoints: [5, 15] });
+    renderWithProviders(<FortyFivesPage />);
+    await waitFor(() => expect(screen.getByTestId('ff-contract-progress')).toHaveTextContent('達成不能'));
+  });
+
+  it('hides the live points panel at round end in favor of the round result', async () => {
+    mockExec.mockResolvedValue(roundEndState);
+    renderWithProviders(<FortyFivesPage />);
+    await waitFor(() => expect(screen.getByText('ラウンド結果')).toBeInTheDocument());
+    expect(screen.queryByTestId('ff-live-points')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/FortyFivesPage.tsx
+++ b/frontend/src/pages/FortyFivesPage.tsx
@@ -157,6 +157,31 @@ function FortyFivesPageContent() {
   };
   const contractLabel = state.contract === 0 ? t('contractUndecided') : bidName(state.contract);
 
+  // Live round-points readout. Each trick awards 5 points to the winning team and a
+  // round has 5 tricks, so points accrue up to 25. Tricks resolved so far is the total
+  // points awarded divided by 5, and the points still up for grabs follow from that.
+  const POINTS_PER_TRICK = 5;
+  const TOTAL_TRICKS = 5;
+  const roundPointsA = state.roundTeamPoints[0] ?? 0;
+  const roundPointsB = state.roundTeamPoints[1] ?? 0;
+  const tricksResolved = (roundPointsA + roundPointsB) / POINTS_PER_TRICK;
+  const remainingPoints = Math.max(0, (TOTAL_TRICKS - tricksResolved) * POINTS_PER_TRICK);
+
+  // Contract progress for the declaring team (known once bidding resolves). The team makes
+  // the bid when its accrued points reach the contract; it can no longer make it once even
+  // every remaining trick would not close the gap.
+  const declarerTeam = state.declarerIdx >= 0 ? state.declarerIdx % 2 : -1;
+  const declarerPoints = declarerTeam >= 0 ? (state.roundTeamPoints[declarerTeam] ?? 0) : 0;
+  const contractStatus: 'made' | 'failed' | 'needMore' =
+    declarerPoints >= state.contract
+      ? 'made'
+      : declarerPoints + remainingPoints < state.contract
+        ? 'failed'
+        : 'needMore';
+  const contractRemaining = Math.max(0, state.contract - declarerPoints);
+  const contractStatusColor =
+    contractStatus === 'made' ? 'text-ds-success' : contractStatus === 'failed' ? 'text-ds-danger' : 'text-ds-warning';
+
   const handleManualReset = () => {
     hideActionLog();
     reset();
@@ -274,6 +299,29 @@ function FortyFivesPageContent() {
                     )}
                   </div>
                 ))}
+
+                {/* Live round points during bidding/play (matches the CUI readout); the
+                    round-result block below takes over once the round ends. */}
+                {!(isRoundEnd || isGameEnd) && (
+                  <div className="my-3 p-2 rounded bg-black/30 text-ds-text-muted text-sm" data-testid="ff-live-points">
+                    <div className="mb-1 text-ds-text-primary">{t('livePoints.title')}</div>
+                    <div>{t('roundResult.teamA', { points: roundPointsA })}</div>
+                    <div>{t('roundResult.teamB', { points: roundPointsB })}</div>
+                    {declarerTeam >= 0 && state.contract > 0 && (
+                      <div className="mt-1 text-ds-text-primary" data-testid="ff-contract-progress">
+                        {t('livePoints.contract', {
+                          team: declarerTeam === 0 ? t('team.a') : t('team.b'),
+                          got: declarerPoints,
+                          contract: state.contract,
+                        })}
+                        {' — '}
+                        <span className={contractStatusColor}>
+                          {t(`livePoints.status.${contractStatus}`, { remaining: contractRemaining })}
+                        </span>
+                      </div>
+                    )}
+                  </div>
+                )}
 
                 {/* Round result: points per team */}
                 {(isRoundEnd || isGameEnd) && (


### PR DESCRIPTION
## 概要
オークション・フォーティファイブズのプレイ中（BID / PLAY / TRICK_END）に、チーム別のライブラウンドポイントと宣言チームの契約達成進捗をサイドバーへ表示する。ラウンド終了時は従来の「ラウンド結果」表示に切り替わる。

## 変更内容
- `FortyFivesPage.tsx`: `roundTeamPoints` を使ったライブ得点パネル（`data-testid="ff-live-points"`）を追加。宣言チームには契約進捗（取得点 / 契約点）と達成状況（`data-testid="ff-contract-progress"`）を併記。
  - 各トリック5点・全5トリック（最大25点）の規則から、残りトリックで到達可能かをフロントエンドで導出（達成 / 達成不能 / あと◯点）。
  - すべて既存の `FortyFivesResponse` フィールド（`roundTeamPoints` / `declarerIdx` / `contract`）から算出。バックエンド変更なし。
- i18n: ja/en の `fortyfives.json` に `livePoints` キーを追加（キー対応）。
- `FortyFivesPage.test.tsx`: ライブ得点パネル・契約進捗（needMore / made / failed）・ラウンド終了時の切り替えのテストを追加。

## 受け入れ条件
- [x] プレイ中にチーム別ラウンドポイントが表示される
- [x] 宣言チームの契約進捗が併記される
- [x] ラウンド終了時は既存表示に切り替わる
- [x] `FortyFivesPage.test.tsx` にテストを追加

## テスト
- `bun run test -- --run FortyFivesPage`: 19 passed
- `bun run build`: 成功（tsc 通過）
- `biome check`: 通過

Closes #3416

🤖 Generated with [Claude Code](https://claude.com/claude-code)
