### PR TITLE
feat(ginrummy): color-code hand cards by meld vs deadwood

### DIFF
--- a/frontend/src/i18n/locales/en/ginrummy.json
+++ b/frontend/src/i18n/locales/en/ginrummy.json
@@ -29,6 +29,8 @@
   "discardButton": "Discard",
   "knockButton": "Knock",
   "deadwoodLabel": "Deadwood: {{score}} pts (knock ≤ {{threshold}})",
+  "meldLegend": "Meld",
+  "deadwoodLegend": "Deadwood",
   "layoffButton": "Lay Off",
   "skipLayoffButton": "Skip",
   "nextRound": "Next Round",

--- a/frontend/src/i18n/locales/ja/ginrummy.json
+++ b/frontend/src/i18n/locales/ja/ginrummy.json
@@ -29,6 +29,8 @@
   "discardButton": "捨てる",
   "knockButton": "ノック",
   "deadwoodLabel": "デッドウッド: {{score}}点（ノック上限 {{threshold}}）",
+  "meldLegend": "メルド",
+  "deadwoodLegend": "デッドウッド",
   "layoffButton": "レイオフ",
   "skipLayoffButton": "スキップ",
   "nextRound": "次のラウンド",

--- a/frontend/src/pages/GinRummyPage.test.tsx
+++ b/frontend/src/pages/GinRummyPage.test.tsx
@@ -168,6 +168,44 @@ describe('GinRummyPage', () => {
     expect(screen.queryByTestId('ginrummy-deadwood-indicator')).not.toBeInTheDocument();
   });
 
+  it('color-codes the hand into meld and deadwood cards during discard phase', async () => {
+    // ♠5-6-7 form a run (melded); ♥K is deadwood.
+    const meldHandState: GinRummyResponse = {
+      ...discardPhaseState,
+      players: [
+        {
+          id: 0,
+          isHuman: true,
+          cardCount: 4,
+          cards: [
+            { design: 'SPADE', value: 5 },
+            { design: 'SPADE', value: 6 },
+            { design: 'SPADE', value: 7 },
+            { design: 'HEART', value: 13 },
+          ],
+          roundScore: 0,
+          cumulativeScore: 0,
+        },
+        discardPhaseState.players[1],
+      ],
+    };
+    mockExec.mockResolvedValue(meldHandState);
+    renderWithProviders(<GinRummyPage />);
+    await waitFor(() => expect(screen.getByTestId('gr-hand-card-0')).toBeInTheDocument());
+    expect(screen.getByTestId('gr-hand-card-0')).toHaveAttribute('data-meld', 'meld');
+    expect(screen.getByTestId('gr-hand-card-1')).toHaveAttribute('data-meld', 'meld');
+    expect(screen.getByTestId('gr-hand-card-2')).toHaveAttribute('data-meld', 'meld');
+    expect(screen.getByTestId('gr-hand-card-3')).toHaveAttribute('data-meld', 'deadwood');
+    expect(screen.getByTestId('ginrummy-meld-legend')).toBeInTheDocument();
+  });
+
+  it('does not color-code the hand outside discard phase', async () => {
+    renderWithProviders(<GinRummyPage />);
+    await waitFor(() => expect(screen.getByTestId('gr-hand-card-0')).toBeInTheDocument());
+    expect(screen.getByTestId('gr-hand-card-0')).not.toHaveAttribute('data-meld');
+    expect(screen.queryByTestId('ginrummy-meld-legend')).not.toBeInTheDocument();
+  });
+
   it('pulses the knock button when deadwood ≤10 during discard phase', async () => {
     const lowDeadwoodHand: GinRummyResponse = {
       ...discardPhaseState,

--- a/frontend/src/pages/GinRummyPage.tsx
+++ b/frontend/src/pages/GinRummyPage.tsx
@@ -23,7 +23,7 @@ import { CPU_DIFFICULTY_OPTIONS, POINT_LIMIT_OPTIONS, useGinRummyGame } from '..
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
 import { btnPrimary, btnSuccess } from '../styles/buttonStyles';
-import { focusRingCard, selectedCardStyle } from '../styles/cardStyles';
+import { focusRingCard, meldCardStyle, selectedCardStyle } from '../styles/cardStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { GinRummyResponse } from '../types/card';
@@ -33,7 +33,12 @@ import { cardAlt } from '../utils/cardAlt';
 import { GINRUMMY_HELP, parseGinrummyCommand } from '../utils/cli/commands/ginrummyCommands';
 import { formatGinrummyState } from '../utils/cli/formatters/ginrummyFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
-import { bestDeadwoodValue, GIN_RUMMY_KNOCK_THRESHOLD, ginRummyMeldLabel } from '../utils/ginRummyDeadwood';
+import {
+  bestDeadwoodValue,
+  bestMeldSplit,
+  GIN_RUMMY_KNOCK_THRESHOLD,
+  ginRummyMeldLabel,
+} from '../utils/ginRummyDeadwood';
 import { playerName } from '../utils/playerUtils';
 
 const GINRUMMY_PHASE_KEYS: Readonly<Record<number, string>> = {
@@ -179,6 +184,17 @@ function GinRummyPageContent() {
     return Number.isFinite(best) ? best : null;
   }, [state, selectedCardIndices]);
   const canKnockNow = liveDeadwood != null && liveDeadwood <= GIN_RUMMY_KNOCK_THRESHOLD;
+
+  // During DISCARD, color-code the human's hand by best meld split so the
+  // player can see which cards form melds vs. which are deadwood. Shares the
+  // same search as the deadwood indicator, so the two always agree. Empty set
+  // outside DISCARD leaves every card in its neutral (uncolored) state.
+  const meldedIndices = useMemo<ReadonlySet<number>>(() => {
+    if (!state || state.phase !== GinRummyPhase.DISCARD) return new Set();
+    const human = state.players.find((p) => p.isHuman);
+    if (!human || human.cards.length === 0) return new Set();
+    return bestMeldSplit(human.cards).meldedIndices;
+  }, [state]);
 
   if (!state)
     return (
@@ -375,6 +391,29 @@ function GinRummyPageContent() {
                 {t('deadwoodLabel', { score: liveDeadwood, threshold: GIN_RUMMY_KNOCK_THRESHOLD })}
               </div>
             )}
+            {isDiscardPhase && (
+              <div
+                data-testid="ginrummy-meld-legend"
+                className="flex items-center gap-3 text-xs text-ds-text-muted mb-1"
+              >
+                <span className="flex items-center gap-1">
+                  <span
+                    aria-hidden="true"
+                    className="inline-block h-3 w-3 rounded-sm"
+                    style={{ outline: '2px solid var(--color-ds-success)', outlineOffset: '-2px' }}
+                  />
+                  {t('meldLegend')}
+                </span>
+                <span className="flex items-center gap-1">
+                  <span
+                    aria-hidden="true"
+                    className="inline-block h-3 w-3 rounded-sm"
+                    style={{ outline: '2px dashed rgba(148, 163, 184, 0.6)', outlineOffset: '-2px' }}
+                  />
+                  {t('deadwoodLegend')}
+                </span>
+              </div>
+            )}
             {humanPlayer && (
               <div className="flex flex-wrap gap-1 mb-2" data-tutorial="gr-player-hand">
                 {humanPlayer.cards.map((card, idx) => (
@@ -384,11 +423,14 @@ function GinRummyPageContent() {
                     onClick={() => toggleCard(idx)}
                     aria-label={cardAlt(card)}
                     aria-pressed={selectedCardIndices.includes(idx)}
+                    data-testid={`gr-hand-card-${idx}`}
+                    data-meld={isDiscardPhase ? (meldedIndices.has(idx) ? 'meld' : 'deadwood') : undefined}
                     className={`transition-transform ${focusRingCard}`}
                     style={{
                       background: 'none',
                       padding: 0,
                       borderRadius: 8,
+                      ...(isDiscardPhase ? meldCardStyle(meldedIndices.has(idx)) : undefined),
                       ...selectedCardStyle(selectedCardIndices.includes(idx)),
                       boxSizing: 'border-box',
                     }}

--- a/frontend/src/styles/cardStyles.ts
+++ b/frontend/src/styles/cardStyles.ts
@@ -65,6 +65,21 @@ export function trumpRingStyle(): React.CSSProperties {
 }
 
 /**
+ * Return inline styles that color-code a hand card by meld membership (e.g. Gin
+ * Rummy): a melded card gets a green outline, a deadwood card a subtle grey one.
+ * Uses `outline` (not `border`/`boxShadow`) so it stacks additively on top of
+ * the selection border and lift without clobbering them — a card can be both
+ * melded and selected. Purely decorative; never blocks clicks.
+ */
+export function meldCardStyle(isMelded: boolean): React.CSSProperties {
+  return {
+    outline: isMelded ? '2px solid var(--color-ds-success)' : '2px dashed rgba(148, 163, 184, 0.5)',
+    outlineOffset: '1px',
+    borderRadius: 8,
+  };
+}
+
+/**
  * Return adjusted overlap margin for a card that is adjacent to a selected card on mobile.
  * Reduces the negative overlap by EXPANSION_GAP_PX, effectively widening the visible area.
  * Returns the original overlap when the card is not adjacent to a selection.

--- a/frontend/src/utils/ginRummyDeadwood.test.ts
+++ b/frontend/src/utils/ginRummyDeadwood.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import type { Card } from '../types/card';
-import { bestDeadwoodValue, calcDeadwoodValue, ginRummyCardValue, ginRummyMeldLabel } from './ginRummyDeadwood';
+import {
+  bestDeadwoodValue,
+  bestMeldSplit,
+  calcDeadwoodValue,
+  ginRummyCardValue,
+  ginRummyMeldLabel,
+} from './ginRummyDeadwood';
 
 const c = (design: Card['design'], value: number): Card => ({ design, value });
 
@@ -57,6 +63,63 @@ describe('bestDeadwoodValue', () => {
       c('DIAMOND', 9),
     ];
     expect(bestDeadwoodValue(hand)).toBe(0);
+  });
+});
+
+describe('bestMeldSplit', () => {
+  const sorted = (s: ReadonlySet<number>) => [...s].sort((a, b) => a - b);
+
+  it('returns an empty split for an empty hand', () => {
+    const split = bestMeldSplit([]);
+    expect(sorted(split.meldedIndices)).toEqual([]);
+    expect(split.deadwoodValue).toBe(0);
+  });
+
+  it('melds no card when no meld exists', () => {
+    const split = bestMeldSplit([c('SPADE', 2), c('HEART', 5), c('CLOVER', 9)]);
+    expect(sorted(split.meldedIndices)).toEqual([]);
+    expect(split.deadwoodValue).toBe(2 + 5 + 9);
+  });
+
+  it('marks a set of 3 as melded, leaving the stray as deadwood', () => {
+    // indices 0,1,2 = three 7s (set); index 3 = stray 4 (deadwood)
+    const split = bestMeldSplit([c('SPADE', 7), c('HEART', 7), c('CLOVER', 7), c('DIAMOND', 4)]);
+    expect(sorted(split.meldedIndices)).toEqual([0, 1, 2]);
+    expect(split.deadwoodValue).toBe(4);
+  });
+
+  it('marks a run of 3 as melded, leaving the stray as deadwood', () => {
+    // indices 0,1,2 = ♠5-6-7 run; index 3 = stray K (deadwood)
+    const split = bestMeldSplit([c('SPADE', 5), c('SPADE', 6), c('SPADE', 7), c('HEART', 13)]);
+    expect(sorted(split.meldedIndices)).toEqual([0, 1, 2]);
+    expect(split.deadwoodValue).toBe(10);
+  });
+
+  it('prefers the run over an impossible set with duplicate ranks', () => {
+    // ♠7-8-9 run (0,1,2); leftover ♥7,♣7 (3,4) are only 2 sevens → no set → deadwood
+    const split = bestMeldSplit([c('SPADE', 7), c('SPADE', 8), c('SPADE', 9), c('HEART', 7), c('CLOVER', 7)]);
+    expect(sorted(split.meldedIndices)).toEqual([0, 1, 2]);
+    expect(split.deadwoodValue).toBe(14);
+  });
+
+  it('melds every card when the hand is fully melded', () => {
+    const hand: Card[] = [
+      c('SPADE', 5),
+      c('SPADE', 6),
+      c('SPADE', 7),
+      c('SPADE', 8),
+      c('HEART', 9),
+      c('CLOVER', 9),
+      c('DIAMOND', 9),
+    ];
+    const split = bestMeldSplit(hand);
+    expect(sorted(split.meldedIndices)).toEqual([0, 1, 2, 3, 4, 5, 6]);
+    expect(split.deadwoodValue).toBe(0);
+  });
+
+  it('stays consistent with bestDeadwoodValue', () => {
+    const hand = [c('SPADE', 7), c('SPADE', 8), c('SPADE', 9), c('HEART', 7), c('CLOVER', 7)];
+    expect(bestMeldSplit(hand).deadwoodValue).toBe(bestDeadwoodValue(hand));
   });
 });
 

--- a/frontend/src/utils/ginRummyDeadwood.ts
+++ b/frontend/src/utils/ginRummyDeadwood.ts
@@ -42,25 +42,50 @@ interface IndexedCard {
   card: Card;
 }
 
-/** Find the minimum-deadwood split of `hand` into melds + deadwood.
- * Mirrors `FindBestMelds` in internal/domain/GinRummy.go but the only
- * value we surface back to React is the integer deadwood total. */
-export function bestDeadwoodValue(hand: readonly Card[]): number {
-  if (hand.length === 0) return 0;
-  const indexed: IndexedCard[] = hand.map((card, idx) => ({ idx, card }));
-  return search(indexed);
+/** Result of splitting a hand into melds + deadwood: which original hand
+ * indices belong to some meld in the best split, plus the deadwood total. */
+export interface MeldSplit {
+  /** Original hand indices that are part of a meld in the best split. */
+  meldedIndices: ReadonlySet<number>;
+  /** Sum of card values of the unmelded (deadwood) cards. */
+  deadwoodValue: number;
 }
 
-function search(remaining: IndexedCard[]): number {
+/** Find the minimum-deadwood split of `hand`, returning which original hand
+ * indices are melded and the deadwood total of the rest. Mirrors
+ * `FindBestMelds` in internal/domain/GinRummy.go. Shares the same search as
+ * {@link bestDeadwoodValue}, so the two stay consistent. */
+export function bestMeldSplit(hand: readonly Card[]): MeldSplit {
+  if (hand.length === 0) return { meldedIndices: new Set(), deadwoodValue: 0 };
+  const indexed: IndexedCard[] = hand.map((card, idx) => ({ idx, card }));
+  const { value, melded } = search(indexed);
+  return { meldedIndices: melded, deadwoodValue: value };
+}
+
+/** Find the minimum-deadwood split of `hand` into melds + deadwood.
+ * Mirrors `FindBestMelds` in internal/domain/GinRummy.go but the only
+ * value we surface back is the integer deadwood total. */
+export function bestDeadwoodValue(hand: readonly Card[]): number {
+  return bestMeldSplit(hand).deadwoodValue;
+}
+
+/** Minimum-deadwood split of `remaining`, returning the deadwood value and the
+ * set of original indices that end up melded in that best split. */
+function search(remaining: IndexedCard[]): { value: number; melded: Set<number> } {
   const candidates = enumerateMelds(remaining);
-  let best = calcDeadwoodValue(remaining.map((r) => r.card));
+  // Baseline: take no meld here → every remaining card is deadwood.
+  let best = { value: calcDeadwoodValue(remaining.map((r) => r.card)), melded: new Set<number>() };
   if (candidates.length === 0) return best;
   for (const meld of candidates) {
     const meldIdx = new Set(meld.map((m) => m.idx));
     const rest = remaining.filter((r) => !meldIdx.has(r.idx));
-    const dv = search(rest);
-    if (dv < best) best = dv;
-    if (best === 0) break;
+    const sub = search(rest);
+    if (sub.value < best.value) {
+      const melded = new Set<number>(meldIdx);
+      for (const i of sub.melded) melded.add(i);
+      best = { value: sub.value, melded };
+    }
+    if (best.value === 0) break;
   }
   return best;
 }


### PR DESCRIPTION
## 概要

ジンラミーのディスカードフェーズで、自分の手札をメルド構成カード（緑の枠線）とデッドウッド（控えめなグレーの破線）に色分け表示します。手札の下に凡例も表示され、どのカードを捨てるべきか一目で判断できるようになります。

## 実装

- `frontend/src/utils/ginRummyDeadwood.ts`: 既存の最良分割探索（`search`）を拡張し、メルド所属 index 集合を返す `bestMeldSplit` を追加。`bestDeadwoodValue` は `bestMeldSplit` 経由に統一したため、色分けとデッドウッド値表示が常に同一探索を共有して整合します。
- `frontend/src/styles/cardStyles.ts`: `meldCardStyle(isMelded)` を追加。`outline` を使うため選択枠（border/boxShadow）と加算的に重なり、クリックを妨げません。
- `frontend/src/pages/GinRummyPage.tsx`: ディスカードフェーズのみ手札ボタンに色分けと `data-meld` 属性を付与。凡例を追加。
- i18n: ja/en に `meldLegend` / `deadwoodLegend` を key-for-key で追加。

## 受け入れ条件

- [x] DISCARD フェーズで手札がメルド/デッドウッドに色分けされる
- [x] 分割結果が deadwood 値と整合する（同一探索を共有）
- [x] `bestMeldSplit` の単体テストを追加（セット/ラン/重複ランク/フルメルド/整合性）
- [x] 既存の deadwood インジケータ表示が回帰しない

## テスト

- `bun run test -- --run GinRummy`: 138 passed
- `bun run build`（tsc）: 成功
- `biome check`: クリーン

Closes #3052
