### PR TITLE
feat(skat): add CPU difficulty setting to the web UI

### DIFF
--- a/frontend/src/hooks/useSkatGame.test.ts
+++ b/frontend/src/hooks/useSkatGame.test.ts
@@ -249,4 +249,17 @@ describe('useSkatGame', () => {
     act(() => result.current.handleConfigChange('cpuDifficulty', '2'));
     expect(result.current.skatConfig.cpuDifficulty).toBe(2);
   });
+
+  it('reset dispatches reset with the current config', async () => {
+    mockExec.mockResolvedValue(baseSkatState);
+    const { result } = renderHook(() => useSkatGame(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.state).not.toBeNull());
+
+    act(() => result.current.handleConfigChange('cpuDifficulty', '2'));
+    mockExec.mockClear();
+    act(() => result.current.reset());
+    await waitFor(() =>
+      expect(mockExec).toHaveBeenCalledWith('reset', { config: { cpuDifficulty: 2, targetScore: 500 } }),
+    );
+  });
 });

--- a/frontend/src/hooks/useSkatGame.ts
+++ b/frontend/src/hooks/useSkatGame.ts
@@ -37,9 +37,16 @@ export function useSkatGame() {
 
   const { state, loading, error, exec: dispatch, retry } = useGameApi(skatApi.exec, { onSuccess });
 
+  /** Resets the game, applying the current config (CPU difficulty, target score). */
+  const reset = useCallback(() => {
+    dispatch('reset', { config: skatConfig });
+  }, [dispatch, skatConfig]);
+
+  // Fetch a fresh game on mount using the initial (default) config.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: run reset once on mount with the initial config.
   useEffect(() => {
-    dispatch('reset', { config: DEFAULT_SKAT_CONFIG });
-  }, [dispatch]);
+    reset();
+  }, []);
 
   const handleBid = useCallback(
     (accept: boolean) => {
@@ -102,6 +109,7 @@ export function useSkatGame() {
     hintLoading,
     dispatch,
     skatConfig,
+    reset,
     selectedCardIndices,
     toggleCard,
     clearSelection,

--- a/frontend/src/i18n/locales/en/skat.json
+++ b/frontend/src/i18n/locales/en/skat.json
@@ -40,6 +40,14 @@
     "diamond": "♦ Diamonds",
     "grand": "Grand"
   },
+  "settings": {
+    "title": "Settings",
+    "cpuDifficulty": "CPU Difficulty",
+    "targetScore": "Target Score",
+    "easy": "Easy",
+    "normal": "Normal",
+    "hard": "Hard"
+  },
   "phase": {
     "bid": "Bidding",
     "skatPickup": "Skat pickup",

--- a/frontend/src/i18n/locales/ja/skat.json
+++ b/frontend/src/i18n/locales/ja/skat.json
@@ -40,6 +40,14 @@
     "diamond": "♦ ダイヤ",
     "grand": "グランド"
   },
+  "settings": {
+    "title": "設定",
+    "cpuDifficulty": "CPU難易度",
+    "targetScore": "目標スコア",
+    "easy": "やさしい",
+    "normal": "ふつう",
+    "hard": "むずかしい"
+  },
   "phase": {
     "bid": "ビッドフェーズ",
     "skatPickup": "スカート拾い",

--- a/frontend/src/pages/SkatPage.test.tsx
+++ b/frontend/src/pages/SkatPage.test.tsx
@@ -167,6 +167,7 @@ const cpuDeclarerSuitGame: SkatResponse = {
 };
 
 beforeEach(() => {
+  localStorage.clear();
   mockExec.mockResolvedValue(bidPhaseHumanTurn);
 });
 
@@ -189,6 +190,40 @@ describe('SkatPage', () => {
     );
     await waitFor(() =>
       expect(mockExec).toHaveBeenCalledWith('reset', { config: { cpuDifficulty: 1, targetScore: 500 } }),
+    );
+  });
+
+  it('renders the CPU difficulty selector in the settings panel', async () => {
+    renderWithProviders(
+      <MemoryRouter initialEntries={['/skat']}>
+        <SkatPage />
+      </MemoryRouter>,
+    );
+    await waitFor(() => expect(screen.getByRole('button', { name: '18でコールする' })).toBeInTheDocument());
+    const select = screen.getByLabelText(/CPU難易度|CPU Difficulty/) as HTMLSelectElement;
+    expect(select).toBeInTheDocument();
+    expect(select.value).toBe('1');
+  });
+
+  it('reflects the selected CPU difficulty in the reset API call', async () => {
+    renderWithProviders(
+      <MemoryRouter initialEntries={['/skat']}>
+        <SkatPage />
+      </MemoryRouter>,
+    );
+    await waitFor(() => expect(screen.getByRole('button', { name: '18でコールする' })).toBeInTheDocument());
+
+    const select = screen.getByLabelText(/CPU難易度|CPU Difficulty/);
+    fireEvent.change(select, { target: { value: '2' } });
+
+    mockExec.mockClear();
+    fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
+    await waitFor(() =>
+      expect(mockExec).toHaveBeenCalledWith(
+        'reset',
+        expect.objectContaining({ config: expect.objectContaining({ cpuDifficulty: 2 }) }),
+      ),
     );
   });
 

--- a/frontend/src/pages/SkatPage.tsx
+++ b/frontend/src/pages/SkatPage.tsx
@@ -3,6 +3,7 @@ import type { skatApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
 import { CliToggle } from '../components/cli/CliToggle';
+import { SettingsPanel } from '../components/common/SettingsPanel';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
@@ -19,7 +20,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
-import { useSkatGame } from '../hooks/useSkatGame';
+import { CPU_DIFFICULTY_OPTIONS, TARGET_SCORE_OPTIONS, useSkatGame } from '../hooks/useSkatGame';
 import { btnPrimary, btnSuccess } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { SkatResponse } from '../types/card';
@@ -81,6 +82,9 @@ function SkatPageContent() {
     state,
     loading,
     error,
+    skatConfig,
+    handleConfigChange,
+    reset,
     selectedCardIndices,
     toggleCard,
     handleBid,
@@ -115,8 +119,8 @@ function SkatPageContent() {
 
   const handleManualReset = useCallback(() => {
     hideActionLog();
-    window.location.reload();
-  }, [hideActionLog]);
+    reset();
+  }, [hideActionLog, reset]);
 
   if (!state) {
     return (
@@ -161,6 +165,41 @@ function SkatPageContent() {
         <CliTerminal logEntries={cliMode.logEntries} onCommand={handleCommand} disabled={loading} />
       ) : (
         <>
+          <SettingsPanel
+            title={t('settings.title')}
+            groups={[
+              {
+                items: [
+                  {
+                    type: 'select',
+                    id: 'cpuDifficulty',
+                    label: t('settings.cpuDifficulty'),
+                    value: skatConfig.cpuDifficulty,
+                    options: CPU_DIFFICULTY_OPTIONS.map((o) => ({
+                      value: o.value,
+                      label: t(`settings.${o.label.toLowerCase()}`),
+                    })),
+                    onSelect: (v) => handleConfigChange('cpuDifficulty', v),
+                  },
+                  {
+                    type: 'select',
+                    id: 'targetScore',
+                    label: t('settings.targetScore'),
+                    value: skatConfig.targetScore,
+                    options: TARGET_SCORE_OPTIONS.map((v) => ({ value: v, label: String(v) })),
+                    onSelect: (v) => handleConfigChange('targetScore', v),
+                  },
+                  {
+                    type: 'checkbox',
+                    id: 'frontendHint',
+                    label: tc('hint.toggle', { ns: 'tutorial' }),
+                    checked: hintEnabled,
+                    onToggle: setHintEnabled,
+                  },
+                ],
+              },
+            ]}
+          />
           <div className="flex-1 overflow-y-auto px-4 py-2 space-y-4">
             {error && <ErrorAlert message={error} onRetry={retry} />}
 
@@ -279,15 +318,6 @@ function SkatPageContent() {
 
           <GameFooter className={`${gameTheme.skat.footer} px-4 py-2.5`}>
             <div className="flex flex-wrap gap-2 items-center">
-              <label className="flex items-center gap-1 text-ds-text-primary text-xs">
-                <input
-                  type="checkbox"
-                  checked={hintEnabled}
-                  onChange={(e) => setHintEnabled(e.target.checked)}
-                  aria-label={tc('hint.toggle', { ns: 'tutorial' })}
-                />
-                {tc('hint.toggle', { ns: 'tutorial' })}
-              </label>
               <GameResetButton
                 isGameEnd={isGameEnd}
                 onReset={handleManualReset}


### PR DESCRIPTION
## 概要

Skat の Web UI に CPU 難易度設定を追加します。Skat には `SettingsPanel` が未実装で、他の CPU 対戦ゲーム（King / Jass など）が持つ CPU 難易度の調整 UI が唯一欠けていました。バックエンドは既に `reset` の config で `cpuDifficulty` を受け付けているため、フロントエンドのみの変更です。

## 変更内容

- `SkatPage.tsx`: 共有 `SettingsPanel` を追加。CPU 難易度・目標スコアのセレクトと、フッターにあったヒント切替チェックボックスを King/Jass と同じ形でパネルに集約。
- `useSkatGame.ts`: 現在の config を渡す `reset` 関数を追加。マウント時と手動リセットの両方でこれを使用し、`handleManualReset` を `window.location.reload()` から `reset()` に変更（選択した難易度がリセット時の API 呼び出しに反映される）。
- i18n: `ja`/`en` の `skat.json` に `settings`（title / cpuDifficulty / targetScore / easy / normal / hard）を key-for-key で追加。
- テスト: `SkatPage.test.tsx` に難易度セレクタの描画と、選択変更がリセット config に反映されるテストを追加。`useSkatGame.test.ts` に `reset` が現在の config で dispatch するテストを追加。

## 受け入れ条件

- [x] Skat の設定パネルから CPU 難易度を選択できる
- [x] 選択した難易度がリセット時の API 呼び出しに反映される
- [x] `SkatPage.test.tsx` に CPU 難易度設定の操作テストを追加

## 確認

- `bunx biome check`（対象ファイル）: パス
- `bun run test -- --run SkatPage useSkatGame`: 46 passed
- `bun run build`（tsc）: パス
- i18n ja/en parity: IN SYNC

Closes #3216
