### PR TITLE
feat(mighty): replace bid number input with discrete button grid

### DIFF
--- a/frontend/src/i18n/locales/en/mighty.json
+++ b/frontend/src/i18n/locales/en/mighty.json
@@ -66,6 +66,7 @@
   "scoresTotal": "Total",
   "scoresRole": "Role",
   "bidButton": "Bid",
+  "bidSelectLabel": "Select your bid",
   "passButton": "Pass",
   "declareButton": "Declare",
   "exchangeButton": "Exchange",

--- a/frontend/src/i18n/locales/ja/mighty.json
+++ b/frontend/src/i18n/locales/ja/mighty.json
@@ -66,6 +66,7 @@
   "scoresTotal": "累計",
   "scoresRole": "役割",
   "bidButton": "ビッド",
+  "bidSelectLabel": "ビッド数を選択",
   "passButton": "パス",
   "declareButton": "宣言",
   "exchangeButton": "交換",

--- a/frontend/src/pages/MightyPage.test.tsx
+++ b/frontend/src/pages/MightyPage.test.tsx
@@ -292,13 +292,49 @@ describe('MightyPage', () => {
     expect(screen.queryByTestId('card-role-badge-2')).not.toBeInTheDocument();
   });
 
-  it('renders bid phase with bid button and input', async () => {
+  it('renders bid phase with bid button and a discrete bid grid', async () => {
     mockCall.mockResolvedValue(bidPhaseState);
     renderWithProviders(<MightyPage />);
     await waitFor(() => {
       expect(screen.getByRole('button', { name: 'ビッド' })).toBeInTheDocument();
-      expect(screen.getByLabelText('bid-input')).toBeInTheDocument();
+      expect(screen.getByTestId('mighty-bid-grid')).toBeInTheDocument();
     });
+    // minBid (13) through MightyMaxPoints (20) are rendered as buttons.
+    for (let n = 13; n <= 20; n++) {
+      expect(screen.getByTestId(`bid-option-${n}`)).toBeInTheDocument();
+    }
+    expect(screen.queryByTestId('bid-option-12')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('bid-option-21')).not.toBeInTheDocument();
+  });
+
+  it('marks the selected bid button with aria-pressed', async () => {
+    mockCall.mockResolvedValue(bidPhaseState);
+    renderWithProviders(<MightyPage />);
+    await waitFor(() => expect(screen.getByTestId('bid-option-15')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('bid-option-15'));
+    expect(screen.getByTestId('bid-option-15')).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByTestId('bid-option-16')).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('disables bids at or below the current highest bid', async () => {
+    mockCall.mockResolvedValue({ ...bidPhaseState, highestBid: 15 });
+    renderWithProviders(<MightyPage />);
+    await waitFor(() => expect(screen.getByTestId('bid-option-16')).toBeInTheDocument());
+
+    expect(screen.getByTestId('bid-option-15')).toBeDisabled();
+    expect(screen.getByTestId('bid-option-16')).toBeEnabled();
+  });
+
+  it('disables bids below the raised minimum when no-trump is toggled on', async () => {
+    // minBid 13 + noTrumpExtra 2 = 15 effective minimum under no-trump.
+    mockCall.mockResolvedValue(bidPhaseState);
+    renderWithProviders(<MightyPage />);
+    await waitFor(() => expect(screen.getByLabelText('bid-no-trump')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByLabelText('bid-no-trump'));
+    expect(screen.getByTestId('bid-option-14')).toBeDisabled();
+    expect(screen.getByTestId('bid-option-15')).toBeEnabled();
   });
 
   it('shows bid instruction during human bid turn', async () => {
@@ -339,13 +375,12 @@ describe('MightyPage', () => {
     });
   });
 
-  it('calls bid command when bid button clicked', async () => {
+  it('calls bid command with the selected grid value when bid button clicked', async () => {
     mockCall.mockResolvedValue(bidPhaseState);
     renderWithProviders(<MightyPage />);
-    await waitFor(() => expect(screen.getByRole('button', { name: 'ビッド' })).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByTestId('bid-option-15')).toBeInTheDocument());
 
-    const input = screen.getByLabelText('bid-input');
-    fireEvent.change(input, { target: { value: '15' } });
+    fireEvent.click(screen.getByTestId('bid-option-15'));
 
     mockCall.mockClear();
     mockCall.mockResolvedValue(playPhaseState);
@@ -360,9 +395,7 @@ describe('MightyPage', () => {
     await waitFor(() => expect(screen.getByLabelText('bid-no-trump')).toBeInTheDocument());
 
     fireEvent.click(screen.getByLabelText('bid-no-trump'));
-
-    const input = screen.getByLabelText('bid-input');
-    fireEvent.change(input, { target: { value: '15' } });
+    fireEvent.click(screen.getByTestId('bid-option-15'));
 
     mockCall.mockClear();
     mockCall.mockResolvedValue(playPhaseState);

--- a/frontend/src/pages/MightyPage.tsx
+++ b/frontend/src/pages/MightyPage.tsx
@@ -108,6 +108,9 @@ const MIGHTY_PHASE_KEYS: Readonly<Record<number, string>> = {
 const SUIT_KEYS: Record<number, string> = { 1: 'spade', 2: 'club', 3: 'heart', 4: 'diamond' };
 const SUIT_SYMBOLS: Record<number, string> = { 1: '♠', 2: '♣', 3: '♥', 4: '♦' };
 
+/** Highest Mighty bid (all 20 point cards); mirrors the domain `MightyMaxPoints`. */
+const MIGHTY_MAX_BID = 20;
+
 /** Tailwind classes for a suit/option toggle button (44px tap target, highlighted when selected). */
 function suitToggleClass(selected: boolean): string {
   return selected
@@ -238,6 +241,12 @@ function MightyPageContent() {
   const isHumanBidTurn = isBidPhase && state.players[state.bidPlayerIdx]?.isHuman === true;
   const isHumanDeclarer = isTrumpAndFriend && state.players[state.declarerIdx]?.isHuman === true;
   const isHumanExchange = isKittyExchange && state.players[state.declarerIdx]?.isHuman === true;
+
+  // Bidding: no-trump declarations raise the minimum bid by the configured extra.
+  // A discrete button grid (mirroring CallBreak/Tarneeb) replaces the raw number input;
+  // out-of-range and already-beaten values are disabled instead of clamped client-side.
+  const bidEffectiveMin = bidNoTrumpToggle ? state.config.minBid + state.config.noTrumpExtra : state.config.minBid;
+  const isBidSelectionValid = bidValue >= bidEffectiveMin && bidValue <= MIGHTY_MAX_BID && bidValue > state.highestBid;
 
   const roleBadge = (p: { isDeclarer: boolean; isPartner: boolean; partnerRevealed: boolean }) => {
     if (p.isDeclarer) return ` [${t('role.declarer')}]`;
@@ -652,16 +661,33 @@ function MightyPageContent() {
 
               {/* Bid controls */}
               {isHumanBidTurn && (
-                <>
-                  <input
-                    type="number"
-                    min={mightyConfig.minBid}
-                    max={20}
-                    value={bidValue}
-                    onChange={(e) => setBidValue(Number(e.target.value))}
-                    className="w-16 px-2 py-1 rounded bg-white/20 text-ds-text-primary text-center"
-                    aria-label="bid-input"
-                  />
+                <div className="flex flex-col items-center gap-2">
+                  <fieldset
+                    className="grid grid-cols-4 gap-1 border-0 p-0"
+                    aria-label={t('bidSelectLabel')}
+                    data-testid="mighty-bid-grid"
+                  >
+                    {Array.from(
+                      { length: MIGHTY_MAX_BID - state.config.minBid + 1 },
+                      (_, i) => i + state.config.minBid,
+                    ).map((n) => (
+                      <button
+                        key={n}
+                        type="button"
+                        onClick={() => setBidValue(n)}
+                        disabled={loading || n < bidEffectiveMin || n <= state.highestBid}
+                        aria-pressed={bidValue === n}
+                        data-testid={`bid-option-${n}`}
+                        className={`min-h-[44px] min-w-[44px] rounded-lg font-medium text-sm transition-all disabled:cursor-not-allowed disabled:opacity-40 ${
+                          bidValue === n
+                            ? 'bg-ds-accent text-white ring-2 ring-ds-accent'
+                            : 'bg-white/20 text-ds-text-primary hover:bg-white/30'
+                        }`}
+                      >
+                        {n}
+                      </button>
+                    ))}
+                  </fieldset>
                   <label className="flex items-center gap-1 text-ds-text-primary text-sm">
                     <input
                       type="checkbox"
@@ -671,18 +697,20 @@ function MightyPageContent() {
                     />
                     {t('noTrumpToggle')}
                   </label>
-                  <button
-                    type="button"
-                    className={btnPrimary}
-                    onClick={() => handleBid(bidValue, bidNoTrumpToggle)}
-                    disabled={loading}
-                  >
-                    {t('bidButton')}
-                  </button>
-                  <button type="button" className={btnPrimary} onClick={handlePass} disabled={loading}>
-                    {t('passButton')}
-                  </button>
-                </>
+                  <div className="flex gap-2">
+                    <button
+                      type="button"
+                      className={btnPrimary}
+                      onClick={() => handleBid(bidValue, bidNoTrumpToggle)}
+                      disabled={loading || !isBidSelectionValid}
+                    >
+                      {t('bidButton')}
+                    </button>
+                    <button type="button" className={btnPrimary} onClick={handlePass} disabled={loading}>
+                      {t('passButton')}
+                    </button>
+                  </div>
+                </div>
               )}
 
               {/* Trump & Friend declaration controls */}


### PR DESCRIPTION
## 概要

マイティのビッドフェーズの入力を、素の `<input type="number">` から離散ボタングリッドへ変更しました。`CallBreakPage` / `TarneebPage` が採用しているパターンに統一しています。

- `minBid`〜20（`MightyMaxPoints`）のビッド値をタップ選択できるボタングリッド（`data-testid="mighty-bid-grid"`）
- 選択中のボタンに `aria-pressed` を付与
- 現在の最高ビッド以下、およびノートランプ選択時に上がった最低ビッド（`minBid + noTrumpExtra`）未満のボタンは `disabled`
- ビッド送信ボタンは選択値がバックエンド検証（`internal/domain/Mighty.go` の `PlayerBid`）に合致しない場合 `disabled`
- 既存の `handleBid(bidValue, bidNoTrumpToggle)` 呼び出しはそのまま利用（バックエンド変更なし）
- パスは従来どおり別ボタン（`bid 0`）
- i18n キー `bidSelectLabel` を ja/en 両方に追加

マッチさせたビッド範囲: `minBid`(13-16) 〜 `20`。ノートランプ時は `minBid + noTrumpExtra` 未満を無効化。

## 受け入れ条件

- [x] ビッドがボタングリッドで選択できる
- [x] 選択中の値に `aria-pressed` が付与される
- [x] `minBid`〜20の範囲外（最高ビッド以下・ノートランプ最低未満）は disabled になる
- [x] 既存の `handleBid` 呼び出しロジックが壊れない

## テスト

`frontend/src/pages/MightyPage.test.tsx` を更新（数値入力ベースのテストをグリッド操作へ書き換え、グリッド描画・`aria-pressed`・最高ビッド無効化・ノートランプ最低無効化の各テストを追加）。

- `bun run test -- --run MightyPage`: 61 passed
- `tsc -b`: pass
- `biome check`: pass
- design-tokens check: OK

Closes #3268