### PR TITLE
feat(freecell): auto-send a card to its foundation on double-click

### DIFF
--- a/frontend/src/hooks/useFreeCellGame.ts
+++ b/frontend/src/hooks/useFreeCellGame.ts
@@ -47,6 +47,18 @@ export function useFreeCellGame() {
     [selectedSource, base],
   );
 
+  // Double-click / double-tap shortcut: dispatch a pre-computed foundation
+  // move for the given source without requiring the two-step target click, and
+  // clear any pending selection so it stays in lockstep.
+  const handleAutoFoundation = useCallback(
+    (source: FreeCellMoveZone, target: FreeCellMoveZone) => {
+      base.setHint(null);
+      void base.apiCall('move', source, target);
+      setSelectedSource(null);
+    },
+    [base],
+  );
+
   return {
     state: base.state,
     loading: base.loading,
@@ -63,6 +75,7 @@ export function useFreeCellGame() {
     handleUndoEscape,
     handleSelectSource,
     handleSelectTarget,
+    handleAutoFoundation,
     isAutoCompleting: base.isAutoCompleting,
     retry: base.retry,
   };

--- a/frontend/src/pages/FreeCellPage.test.tsx
+++ b/frontend/src/pages/FreeCellPage.test.tsx
@@ -345,6 +345,79 @@ describe('FreeCellPage', () => {
     }
   });
 
+  // --- Double-click / double-tap foundation shortcut ---
+
+  it('double-clicking a tableau top card that can reach a foundation issues the foundation move', async () => {
+    mockExec.mockResolvedValue({
+      ...playingState,
+      tableau: [[card('SPADE', 2)], [], [], [], [], [], [], []],
+      foundation: [[card('SPADE', 1)], [], [], []],
+    });
+    renderWithProviders(<FreeCellPage />);
+    const cardImg = await screen.findByAltText('♠ 2');
+    const cardButton = cardImg.closest('button') as HTMLButtonElement;
+
+    mockExec.mockClear();
+    mockExec.mockResolvedValue(playingState);
+    fireEvent.doubleClick(cardButton);
+    await waitFor(() =>
+      expect(mockExec).toHaveBeenCalledWith('move', expect.objectContaining({ zone: 'tableau', col: 0 }), {
+        zone: 'foundation',
+        col: 0,
+      }),
+    );
+  });
+
+  it('double-clicking a tableau top card with no legal foundation target issues no move', async () => {
+    mockExec.mockResolvedValue({
+      ...playingState,
+      tableau: [[card('SPADE', 13)], [], [], [], [], [], [], []],
+      foundation: [[], [], [], []],
+    });
+    renderWithProviders(<FreeCellPage />);
+    const cardImg = await screen.findByAltText('♠ K');
+    const cardButton = cardImg.closest('button') as HTMLButtonElement;
+
+    mockExec.mockClear();
+    fireEvent.doubleClick(cardButton);
+    await Promise.resolve();
+    expect(mockExec).not.toHaveBeenCalledWith('move', expect.anything(), expect.anything());
+  });
+
+  it('double-clicking a free-cell card that can reach a foundation issues the foundation move', async () => {
+    mockExec.mockResolvedValue({
+      ...playingState,
+      freeCells: [card('SPADE', 1), null, null, null],
+      foundation: [[], [], [], []],
+    });
+    renderWithProviders(<FreeCellPage />);
+    const cardImg = await screen.findByAltText('♠ A');
+    const cardButton = cardImg.closest('button') as HTMLButtonElement;
+
+    mockExec.mockClear();
+    mockExec.mockResolvedValue(playingState);
+    fireEvent.doubleClick(cardButton);
+    await waitFor(() =>
+      expect(mockExec).toHaveBeenCalledWith('move', { zone: 'freecell', cell: 0 }, { zone: 'foundation', col: 0 }),
+    );
+  });
+
+  it('single-clicking a card still selects it without issuing a move (no regression)', async () => {
+    mockExec.mockResolvedValue({
+      ...playingState,
+      tableau: [[card('SPADE', 2)], [], [], [], [], [], [], []],
+      foundation: [[card('SPADE', 1)], [], [], []],
+    });
+    renderWithProviders(<FreeCellPage />);
+    const cardImg = await screen.findByAltText('♠ 2');
+    const cardButton = cardImg.closest('button') as HTMLButtonElement;
+
+    mockExec.mockClear();
+    fireEvent.click(cardButton);
+    await waitFor(() => expect(cardButton.className).toContain('ring-2'));
+    expect(mockExec).not.toHaveBeenCalledWith('move', expect.anything(), expect.anything());
+  });
+
   // --- End phases ---
 
   it('game clear phase shows action log section', async () => {

--- a/frontend/src/pages/FreeCellPage.tsx
+++ b/frontend/src/pages/FreeCellPage.tsx
@@ -36,6 +36,7 @@ import { FREECELL_HELP, parseFreecellCommand } from '../utils/cli/commands/freec
 import { formatFreecellState } from '../utils/cli/formatters/freecellFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
 import { freeCellAutoCompleteReady } from '../utils/freeCellAutoComplete';
+import { freeCellFoundationTarget } from '../utils/freeCellFoundationTarget';
 
 const FOUNDATION_SUITS = ['♠', '♣', '♥', '♦'] as const;
 
@@ -110,6 +111,7 @@ function FreeCellPageContent() {
     handleUndoEscape,
     handleSelectSource,
     handleSelectTarget,
+    handleAutoFoundation,
     isAutoCompleting,
   } = useFreeCellGame();
   const {
@@ -138,6 +140,19 @@ function FreeCellPageContent() {
       void exec('move', source, target);
     },
     [exec],
+  );
+
+  // Double-click / double-tap shortcut: auto-send an exposed card (a tableau
+  // top card or a free-cell card) to its foundation when a legal target
+  // exists; otherwise do nothing (no error, selection untouched).
+  const handleFoundationShortcut = useCallback(
+    (source: FreeCellMoveZone, card: Card) => {
+      if (!state) return;
+      const target = freeCellFoundationTarget(card, state.foundation);
+      if (!target) return;
+      handleAutoFoundation(source, target);
+    },
+    [state, handleAutoFoundation],
   );
   const dnd = useSolitaireDragDrop<FreeCellMoveZone>({
     onMove: dispatchMove,
@@ -255,7 +270,14 @@ function FreeCellPageContent() {
                         {card ? (
                           <button
                             type="button"
-                            onClick={() => handleSelectSource(freeCellZone)}
+                            onClick={(e) => {
+                              // The second click of a double-click also fires
+                              // onClick (detail === 2); ignore it so onDoubleClick
+                              // owns the foundation shortcut and selection stays put.
+                              if (e.detail >= 2) return;
+                              handleSelectSource(freeCellZone);
+                            }}
+                            onDoubleClick={() => handleFoundationShortcut(freeCellZone, card)}
                             disabled={!isPlaying || loading}
                             aria-label={cardAlt(card)}
                             aria-pressed={isSourceSelected('freecell', undefined, idx)}
@@ -389,13 +411,25 @@ function FreeCellPageContent() {
                                   {card ? (
                                     <button
                                       type="button"
-                                      onClick={() => {
+                                      onClick={(e) => {
+                                        // The second click of a double-click also
+                                        // fires onClick (detail === 2); ignore it so
+                                        // onDoubleClick owns the foundation shortcut
+                                        // without issuing a stray self-target move.
+                                        if (e.detail >= 2) return;
                                         if (selectedSource) {
                                           handleSelectTarget(tableauColZone);
                                         } else {
                                           handleSelectSource(cardZone);
                                         }
                                       }}
+                                      onDoubleClick={
+                                        // Only the exposed top card of a column can
+                                        // move to a foundation.
+                                        cardIdx === col.length - 1
+                                          ? () => handleFoundationShortcut(cardZone, card)
+                                          : undefined
+                                      }
                                       disabled={!isPlaying || loading}
                                       aria-label={cardAlt(card)}
                                       aria-pressed={isSourceSelected('tableau', colIdx, undefined, cardIdx)}

--- a/frontend/src/utils/freeCellFoundationTarget.test.ts
+++ b/frontend/src/utils/freeCellFoundationTarget.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import type { Card, CardDesign } from '../types/card';
+import { freeCellFoundationTarget } from './freeCellFoundationTarget';
+
+const card = (design: CardDesign, value: number): Card => ({ design, value });
+const emptyFoundation = (): Card[][] => [[], [], [], []];
+
+describe('freeCellFoundationTarget', () => {
+  it('sends an Ace to its empty foundation pile', () => {
+    expect(freeCellFoundationTarget(card('SPADE', 1), emptyFoundation())).toEqual({ zone: 'foundation', col: 0 });
+    expect(freeCellFoundationTarget(card('CLOVER', 1), emptyFoundation())).toEqual({ zone: 'foundation', col: 1 });
+    expect(freeCellFoundationTarget(card('HEART', 1), emptyFoundation())).toEqual({ zone: 'foundation', col: 2 });
+    expect(freeCellFoundationTarget(card('DIAMOND', 1), emptyFoundation())).toEqual({ zone: 'foundation', col: 3 });
+  });
+
+  it('rejects a non-Ace on an empty pile', () => {
+    expect(freeCellFoundationTarget(card('SPADE', 2), emptyFoundation())).toBeNull();
+    expect(freeCellFoundationTarget(card('HEART', 13), emptyFoundation())).toBeNull();
+  });
+
+  it('sends the next rank up onto a matching-suit pile', () => {
+    const foundation: Card[][] = [[card('SPADE', 1)], [], [card('HEART', 1), card('HEART', 2)], []];
+    expect(freeCellFoundationTarget(card('SPADE', 2), foundation)).toEqual({ zone: 'foundation', col: 0 });
+    expect(freeCellFoundationTarget(card('HEART', 3), foundation)).toEqual({ zone: 'foundation', col: 2 });
+  });
+
+  it('rejects a card whose rank is not exactly one above the pile top', () => {
+    const foundation: Card[][] = [[card('SPADE', 1)], [], [], []];
+    expect(freeCellFoundationTarget(card('SPADE', 3), foundation)).toBeNull();
+    expect(freeCellFoundationTarget(card('SPADE', 1), foundation)).toBeNull();
+  });
+
+  it('rejects a card when its own suit pile is not ready even if another suit would accept it', () => {
+    // Spade pile empty (needs an Ace), so the 2♠ has no legal target regardless
+    // of the heart pile's contents — the target pile is chosen by suit.
+    const foundation: Card[][] = [[], [], [card('HEART', 1)], []];
+    expect(freeCellFoundationTarget(card('SPADE', 2), foundation)).toBeNull();
+  });
+
+  it('returns null for a card with an unknown design', () => {
+    expect(freeCellFoundationTarget({ design: 'JOKER', value: 1 }, emptyFoundation())).toBeNull();
+  });
+});

--- a/frontend/src/utils/freeCellFoundationTarget.ts
+++ b/frontend/src/utils/freeCellFoundationTarget.ts
@@ -1,0 +1,35 @@
+import type { FreeCellMoveZone } from '../api/gameApi';
+import type { Card } from '../types/card';
+
+/**
+ * Maps a card design to its 0-based foundation index, matching the foundation
+ * layout (`♠`=0, `♣`=1, `♥`=2, `♦`=3). Mirrors the backend's
+ * `card.GetDesign() - 1` in `FreeCell.MoveTableauToFoundation`.
+ */
+const DESIGN_TO_FOUNDATION_INDEX: Record<string, number> = {
+  SPADE: 0,
+  CLOVER: 1,
+  HEART: 2,
+  DIAMOND: 3,
+};
+
+/**
+ * Computes the legal foundation move target for `card` given the current
+ * `foundation` piles, or `null` when no legal foundation move exists.
+ *
+ * Mirrors the domain's `canPlaceOnFoundation`: an empty pile accepts only an
+ * Ace (`value === 1`); otherwise the card's suit must match the pile and its
+ * rank must be exactly one higher than the pile's top card. The pile is
+ * selected by suit, so a matching pile is always the same suit.
+ *
+ * @param card - The card being double-clicked (a tableau top card or a free-cell card).
+ * @param foundation - The four foundation piles (bottom card first).
+ * @returns A `{ zone: 'foundation', col }` move target, or `null` if illegal.
+ */
+export function freeCellFoundationTarget(card: Card, foundation: Card[][]): FreeCellMoveZone | null {
+  const fIdx = DESIGN_TO_FOUNDATION_INDEX[card.design];
+  if (fIdx === undefined || fIdx >= foundation.length) return null;
+  const pile = foundation[fIdx];
+  const placeable = pile.length === 0 ? card.value === 1 : card.value === pile[pile.length - 1].value + 1;
+  return placeable ? { zone: 'foundation', col: fIdx } : null;
+}


### PR DESCRIPTION
## 概要

フリーセルで、tableau の最上段カードと freeCells 上のカードを**ダブルクリック / ダブルタップ**すると、合法なファンデーション移動先が存在する場合に既存の `move` コマンドを直接発行して自動送りする機能を追加しました。終盤の単純なファンデーション送りが 2 クリック → 1 ジェスチャーに短縮されます。

## 実装

- 新規の純粋関数 `freeCellFoundationTarget(card, foundation)` をフロントに追加し、**現在のレスポンス state から**合法なファンデーション移動先を算出（バックエンド `canPlaceOnFoundation` を鏡写し: 空パイルは A のみ、それ以外は同スートで 1 ランク上）。新規 API は追加せず、既存の `exec('move', source, { zone: 'foundation', col })` を再利用。
- tableau は**最上段カードのみ**にショートカットを付与（バックエンド `MoveTableauToFoundation` は列の最上段カードのみ移動するため）。
- 非合法時は**何もしない**（エラートーストなし・選択状態そのまま）。
- ダブルクリック時に走る 2 回目の `onClick`（`event.detail === 2`）を無視し、シングルクリックの既存選択挙動が回帰しないようにガード。

## テスト

- `frontend/src/utils/freeCellFoundationTarget.test.ts`（新規・純粋関数のユニットテスト）
- `frontend/src/pages/FreeCellPage.test.tsx`（ダブルクリック → move 発行 / 非合法 → 未発行 / freeCell カード / シングルクリック回帰なし）

Gate: `biome check`・`bun run test -- --run FreeCell`（128 passed）・`bun run build`（tsc）すべてグリーン。

## 受け入れ条件

- [x] tableau 最上段カードのダブルクリックで foundation 移動が試行される
- [x] freeCell 上のカードでも同様に動作する
- [x] 非合法時に選択状態が壊れない
- [x] シングルクリックの既存選択挙動が回帰しない（テスト追加）

Closes #3034
