### PR TITLE
feat(kemps): highlight same-rank field cards on hand selection

### DIFF
--- a/frontend/src/i18n/locales/en/kemps.json
+++ b/frontend/src/i18n/locales/en/kemps.json
@@ -53,5 +53,6 @@
   },
   "selectHandCardAria": "Select {{card}}",
   "swapCardAria": "Swap with {{card}}",
+  "swapCardRankMatchAria": "Swap with {{card}} (same rank as the selected hand card)",
   "swapPending": "A hand card is selected; choose a field card to swap with."
 }

--- a/frontend/src/i18n/locales/ja/kemps.json
+++ b/frontend/src/i18n/locales/ja/kemps.json
@@ -53,5 +53,6 @@
   },
   "selectHandCardAria": "{{card}} を選択",
   "swapCardAria": "{{card}} と交換",
+  "swapCardRankMatchAria": "{{card}} と交換（選択中の手札と同じランク）",
   "swapPending": "手札のカードを選択済みです。交換する場のカードを選んでください。"
 }

--- a/frontend/src/pages/KempsPage.test.tsx
+++ b/frontend/src/pages/KempsPage.test.tsx
@@ -69,6 +69,15 @@ function makeState(overrides: Partial<KempsResponse> = {}): KempsResponse {
 }
 
 const exchangeState = makeState();
+// Field shares rank 2 with the human's ♥2 hand card at indices 0 and 2 (#3554).
+const rankMatchState = makeState({
+  field: [
+    { design: 'SPADE', value: 2 },
+    { design: 'HEART', value: 6 },
+    { design: 'CLOVER', value: 2 },
+    { design: 'DIAMOND', value: 8 },
+  ],
+});
 const declareState = makeState({ phase: 1, isHumanTurn: false, fourHolderIdx: 2 });
 const roundEndState = makeState({ phase: 2, isHumanTurn: false, roundResult: 1, roundWinnerTeam: 0 });
 const gameEndState = makeState({ phase: 3, gameEndFlag: true, winnerTeam: 0, isHumanTurn: false, teamScores: [5, 2] });
@@ -109,6 +118,32 @@ describe('KempsPage', () => {
     mockExec.mockClear();
     fireEvent.click(clover7);
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('swap', { handIndex: 1, fieldIndex: 2 }));
+  });
+
+  it('highlights same-rank field cards when a hand card is selected and clears on deselect', async () => {
+    mockExec.mockResolvedValue(rankMatchState);
+    renderWithProviders(<KempsPage />);
+    // Select ♥2 — field indices 0 and 2 (both rank 2) should be marked as matches.
+    const heart2 = await screen.findByRole('button', { name: '♥ 2 を選択' });
+    fireEvent.click(heart2);
+    expect(screen.getByTestId('kemps-field-0')).toHaveAttribute('data-rank-match', 'true');
+    expect(screen.getByTestId('kemps-field-2')).toHaveAttribute('data-rank-match', 'true');
+    // The non-matching field cards are not highlighted.
+    expect(screen.getByTestId('kemps-field-1')).toHaveAttribute('data-rank-match', 'false');
+    expect(screen.getByTestId('kemps-field-3')).toHaveAttribute('data-rank-match', 'false');
+    // Deselecting the hand card removes the field swap buttons (and their highlight).
+    fireEvent.click(screen.getByRole('button', { name: '♥ 2 を選択' }));
+    expect(screen.queryByTestId('kemps-field-0')).not.toBeInTheDocument();
+  });
+
+  it('does not highlight field cards when no hand rank matches the selection', async () => {
+    // Default field [♠5 ♥6 ♣7 ♦8] shares no rank with the ♠1 hand card.
+    renderWithProviders(<KempsPage />);
+    const spadeAce = await screen.findByRole('button', { name: '♠ A を選択' });
+    fireEvent.click(spadeAce);
+    for (const i of [0, 1, 2, 3]) {
+      expect(screen.getByTestId(`kemps-field-${i}`)).toHaveAttribute('data-rank-match', 'false');
+    }
   });
 
   it('does not show field swap buttons until a hand card is selected', async () => {

--- a/frontend/src/pages/KempsPage.tsx
+++ b/frontend/src/pages/KempsPage.tsx
@@ -150,6 +150,11 @@ function KempsPageContent() {
   const isGameEnd = state.phase === KempsPhase.GAME_END || state.gameEndFlag;
   const isHumanTurn = state.isHumanTurn;
   const canSwap = isExchange && isHumanTurn && !isGameEnd;
+  // Rank of the currently selected hand card; field cards sharing this rank are
+  // highlighted to help the human spot four-of-a-kind swaps (#3554). Null unless a
+  // swap is possible and a hand card is selected, so nothing is highlighted otherwise.
+  const selectedRank =
+    canSwap && selectedHand !== null && humanPlayer ? (humanPlayer.hand[selectedHand]?.value ?? null) : null;
   const humanTeam = humanPlayer ? humanPlayer.team : 0;
   const humanWon = isGameEnd && state.winnerTeam === humanTeam;
 
@@ -251,16 +256,22 @@ function KempsPageContent() {
               <div className="flex gap-1 flex-wrap">
                 {state.field.map((c, i) => {
                   const card = <CardImage key={`field-${c.design}-${c.value}-${i}`} card={c} width={cardWidth} />;
+                  const rankMatch = selectedRank !== null && c.value === selectedRank;
                   return canSwap && selectedHand !== null ? (
                     <button
                       type="button"
                       key={`field-btn-${c.design}-${c.value}-${i}`}
                       onClick={() => handleFieldClick(i)}
                       disabled={loading}
-                      className="p-0 bg-transparent border-0 cursor-pointer disabled:cursor-not-allowed"
-                      aria-label={t('swapCardAria', { card: cardAlt(c) })}
+                      className={`p-0 bg-transparent border-0 cursor-pointer disabled:cursor-not-allowed rounded ${rankMatch ? 'ring-2 ring-ds-success' : 'ring-0'}`}
+                      aria-label={
+                        rankMatch
+                          ? t('swapCardRankMatchAria', { card: cardAlt(c) })
+                          : t('swapCardAria', { card: cardAlt(c) })
+                      }
                       aria-describedby="kemps-swap-pending"
                       data-testid={`kemps-field-${i}`}
+                      data-rank-match={rankMatch ? 'true' : 'false'}
                     >
                       {card}
                     </button>


### PR DESCRIPTION
## 概要

ケムプスの EXCHANGE フェーズで、手札カードを選択すると、その**同じランク**の場（フィールド）カードに success 色のリングを表示するようにしました。4 枚集め（four-of-a-kind）を狙う交換判断を視覚的に補助します。

レスポンスに既に含まれる自分の手札と場のカードのランクのみを使うフロントエンド実装で、バックエンドは一切変更しません。対戦の公平性は損ないません。

## 実装

- `selectedRank`: 選択中の手札カードのランク（`canSwap && selectedHand !== null` のときのみ）を導出。
- 各フィールドボタンで `c.value === selectedRank` のとき `ring-2 ring-ds-success` を付与し、`data-rank-match` 属性と同ランク向けの aria-label（`swapCardRankMatchAria`、ja/en 両方に追加）を設定。
- 交換不可の場面ではフィールドはボタン化されず、ハイライトも一切出ません。交換後は `selectedHand` が `null` に戻り再計算されます。

## 受け入れ条件

- [x] 手札選択時に有望なフィールドカードが強調される
- [x] 交換後に強調が再計算される（`selectedHand` リセットで再導出）
- [x] canSwap でない場面では強調されない
- [x] ランク一致ロジックのテストを追加

## テスト

- `bun run test -- --run KempsPage`（18 passed）
  - `highlights same-rank field cards when a hand card is selected and clears on deselect`
  - `does not highlight field cards when no hand rank matches the selection`
- `bun run build`（tsc + vite 成功）
- `biome check --write`（クリーン）

Closes #3554
