### PR TITLE
feat(gaigel): highlight marriage-capable hand cards with a badge

### DIFF
--- a/frontend/src/i18n/locales/en/gaigel.json
+++ b/frontend/src/i18n/locales/en/gaigel.json
@@ -27,6 +27,7 @@
   "roundPoints": "Round: {{points}} pts",
   "marriagePoints": "Marriage: {{points}} pts",
   "marriageButton": "Marriage",
+  "marriageBadge": "Marriage available (King + Queen)",
   "declareMarriage": "Declare King + Queen for bonus points",
   "playButton": "Play",
   "nextTrick": "Next Trick",

--- a/frontend/src/i18n/locales/ja/gaigel.json
+++ b/frontend/src/i18n/locales/ja/gaigel.json
@@ -27,6 +27,7 @@
   "roundPoints": "ラウンド: {{points}}点",
   "marriagePoints": "マリッジ: {{points}}点",
   "marriageButton": "マリッジ",
+  "marriageBadge": "マリッジ可能 (キング+クイーン)",
   "declareMarriage": "キング+クイーンを宣言してボーナス点を獲得",
   "playButton": "出す",
   "nextTrick": "次のトリック",

--- a/frontend/src/pages/GaigelPage.test.tsx
+++ b/frontend/src/pages/GaigelPage.test.tsx
@@ -118,6 +118,31 @@ describe('GaigelPage', () => {
     expect(screen.queryByRole('button', { name: 'マリッジ' })).not.toBeInTheDocument();
   });
 
+  it('badges both King and Queen when a marriage is available on the human turn', async () => {
+    mockExec.mockResolvedValue(makeState({ marriageIndices: [0, 1] }));
+    renderWithProviders(<GaigelPage />);
+    await waitFor(() => expect(screen.getByTestId('card-role-badge-0')).toBeInTheDocument());
+    expect(screen.getByTestId('card-role-badge-1')).toBeInTheDocument();
+    // The non-marriage card (index 2) gets no badge.
+    expect(screen.queryByTestId('card-role-badge-2')).not.toBeInTheDocument();
+    expect(screen.getByTestId('card-role-badge-0')).toHaveTextContent('💍');
+  });
+
+  it('shows no marriage badge when no marriage is available', async () => {
+    renderWithProviders(<GaigelPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: '出す' })).toBeInTheDocument());
+    expect(screen.queryByTestId('card-role-badge-0')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('card-role-badge-1')).not.toBeInTheDocument();
+  });
+
+  it('shows no marriage badge when it is not the human turn', async () => {
+    mockExec.mockResolvedValue(makeState({ marriageIndices: [0, 1], currentPlayerIdx: 1 }));
+    renderWithProviders(<GaigelPage />);
+    await waitFor(() => expect(screen.getByText('チームスコア')).toBeInTheDocument());
+    expect(screen.queryByTestId('card-role-badge-0')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('card-role-badge-1')).not.toBeInTheDocument();
+  });
+
   it('shows reset button mid-game and opens confirm dialog', async () => {
     renderWithProviders(<GaigelPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: 'リセット' })).toBeInTheDocument());

--- a/frontend/src/pages/GaigelPage.tsx
+++ b/frontend/src/pages/GaigelPage.tsx
@@ -127,6 +127,14 @@ function GaigelPageContent() {
   const selectedIdx = selectedCardIndices.length === 1 ? selectedCardIndices[0] : -1;
   const canDeclareMarriage = isHumanTurn && selectedIdx >= 0 && state.marriageIndices.includes(selectedIdx);
 
+  // Surface a 💍 badge on hand cards that can start a marriage (King + Queen of
+  // the same suit, both currently held) so the 20/40-point opportunity is
+  // visible without probing each card. `marriageIndices` is scoped to the
+  // current player, so restrict it to the human's own lead turn.
+  const marriageIndices = isHumanTurn ? state.marriageIndices : [];
+  const marriageBadgeFor = (idx: number): { glyph: string; title: string } | null =>
+    marriageIndices.includes(idx) ? { glyph: '💍', title: t('marriageBadge') } : null;
+
   return (
     <GamePageShell
       title={tc('nav.gaigel')}
@@ -282,6 +290,7 @@ function GaigelPageContent() {
             cardWidth={cardWidth}
             isMobile={isMobile}
             dataTutorialPrefix="gg"
+            cardBadgeFor={marriageBadgeFor}
           />
         )}
 


### PR DESCRIPTION
## 概要

ガイゲルで、人間プレイヤーの手番中に手札のどのカードがマリッジ（K+Q 同スート）宣言の対象かを、選択する前から 💍 バッジで可視化します。20点/40点の得点機会の見逃しを防ぎます。

## 実装

- `GaigelPage.tsx` に `marriageBadgeFor` を追加し、既存の追加的な `cardBadgeFor` プロップ経由で 💍 バッジを表示（`PlayerHandSection` 本体は無変更）。
- バッジは人間の自分の手番（`isHumanTurn`）に限定。`state.marriageIndices` は現在プレイヤー基準のため。
- 純粋に追加的: 減光・無効化・クリック阻害なし。選択/プレイ動作に影響しません。

## マリッジ規則の確認（`internal/domain/Gaigel.go`）

- マリッジ = 同一スートの King(13) + Queen(12)。
- 切り札スートのマリッジは**ボーナス点のみ**異なる（40 vs 20）。成立条件は同じ。
- `GetMarriageIndices` は「リード時・自分の手番・未宣言スートで相方を手札に持つ K/Q」の**両インデックス**を返す。相方欠けなら両方とも返らない。
- バックエンドが既に算出済みのため、フロントは `marriageIndices` をそのままバッジ化。

## テスト

`GaigelPage.test.tsx` に追加（全10件パス）:
- K+Q 両方に💍バッジ（非対象カードにはバッジなし）
- マリッジ対象なし時はバッジなし
- 手番外（CPU番）時はバッジなし

## 受け入れ条件

- [x] マリッジ対象カードが手札上でバッジ表示される
- [x] 手番外・対象なし時はバッジが出ない
- [x] 既存の選択・プレイ動作に影響しない
- [x] `GaigelPage.test.tsx` を更新（ja/en i18n キーも追加）

Closes #3601
