### PR TITLE
feat(spoons): color-code same-rank hand groups

### DIFF
--- a/frontend/src/pages/SpoonsPage.test.tsx
+++ b/frontend/src/pages/SpoonsPage.test.tsx
@@ -114,6 +114,68 @@ describe('SpoonsPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('pass', { cardIndex: 2 }));
   });
 
+  it('color-codes same-rank hand cards into groups and leaves singletons neutral', async () => {
+    // Hand: 7♠ 7♥ 3♣ K♦ — the two 7s share a group color; 3 and K are neutral.
+    mockExec.mockResolvedValue(
+      makeState({
+        players: [
+          makePlayer({
+            name: 'You',
+            isHuman: true,
+            hand: [
+              { design: 'SPADE', value: 7 },
+              { design: 'HEART', value: 7 },
+              { design: 'CLOVER', value: 3 },
+              { design: 'DIAMOND', value: 13 },
+            ],
+          }),
+          makePlayer(),
+          makePlayer(),
+          makePlayer(),
+        ],
+      }),
+    );
+    renderWithProviders(<SpoonsPage />);
+    const c0 = await screen.findByTestId('spoons-pass-0');
+    const c1 = screen.getByTestId('spoons-pass-1');
+    const c2 = screen.getByTestId('spoons-pass-2');
+    const c3 = screen.getByTestId('spoons-pass-3');
+    // The pair shares a non-"none" group color.
+    expect(c0).toHaveAttribute('data-rank-group', c1.getAttribute('data-rank-group') ?? '');
+    expect(c0.getAttribute('data-rank-group')).not.toBe('none');
+    // Singletons carry no group color and are not reach.
+    expect(c2).toHaveAttribute('data-rank-group', 'none');
+    expect(c3).toHaveAttribute('data-rank-group', 'none');
+    expect(c0).toHaveAttribute('data-rank-reach', 'false');
+  });
+
+  it('flags a three-of-a-kind hand as a reach', async () => {
+    mockExec.mockResolvedValue(
+      makeState({
+        players: [
+          makePlayer({
+            name: 'You',
+            isHuman: true,
+            hand: [
+              { design: 'SPADE', value: 8 },
+              { design: 'HEART', value: 8 },
+              { design: 'CLOVER', value: 8 },
+              { design: 'DIAMOND', value: 2 },
+            ],
+          }),
+          makePlayer(),
+          makePlayer(),
+          makePlayer(),
+        ],
+      }),
+    );
+    renderWithProviders(<SpoonsPage />);
+    const c0 = await screen.findByTestId('spoons-pass-0');
+    expect(c0).toHaveAttribute('data-rank-reach', 'true');
+    expect(c0.getAttribute('data-rank-group')).not.toBe('none');
+    expect(screen.getByTestId('spoons-pass-3')).toHaveAttribute('data-rank-reach', 'false');
+  });
+
   it('does not render pass buttons when it is not the human turn', async () => {
     mockExec.mockResolvedValue(makeState({ currentPlayerIdx: 1, isHumanTurn: false }));
     renderWithProviders(<SpoonsPage />);

--- a/frontend/src/pages/SpoonsPage.tsx
+++ b/frontend/src/pages/SpoonsPage.tsx
@@ -29,6 +29,19 @@ import { cardAlt } from '../utils/cardAlt';
 import { parseSpoonsCommand, SPOONS_HELP } from '../utils/cli/commands/spoonsCommands';
 import { formatSpoonsState } from '../utils/cli/formatters/spoonsFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { computeSpoonsRankGroups } from '../utils/spoonsRankGroups';
+
+/**
+ * Ring color classes for same-rank hand groups, indexed by group color index.
+ * Purely a visual aid; assignment is deterministic (by ascending rank) so the
+ * same pair always keeps the same color across passes.
+ */
+const SPOONS_GROUP_RING_CLASSES = [
+  'ring-2 ring-sky-400',
+  'ring-2 ring-amber-400',
+  'ring-2 ring-emerald-400',
+  'ring-2 ring-fuchsia-400',
+] as const;
 
 /** CPU difficulty options for the Spoons settings panel. */
 const CPU_DIFFICULTY_OPTIONS = [
@@ -259,24 +272,53 @@ function SpoonsPageContent() {
                   {canPass ? ` — ${t('passNotice')}` : ''}
                 </div>
                 <div className="flex gap-1 flex-wrap">
-                  {humanPlayer.hand.map((c, i) => {
-                    const card = <CardImage key={`hand-${c.design}-${c.value}-${i}`} card={c} width={cardWidth} />;
-                    return canPass ? (
-                      <button
-                        type="button"
-                        key={`pass-${c.design}-${c.value}-${i}`}
-                        onClick={() => exec('pass', { cardIndex: i })}
-                        disabled={loading}
-                        className="p-0 bg-transparent border-0 cursor-pointer disabled:cursor-not-allowed"
-                        aria-label={t('passCardAria', { card: cardAlt(c) })}
-                        data-testid={`spoons-pass-${i}`}
-                      >
-                        {card}
-                      </button>
-                    ) : (
-                      card
-                    );
-                  })}
+                  {(() => {
+                    const rankGroups = computeSpoonsRankGroups(humanPlayer.hand);
+                    return humanPlayer.hand.map((c, i) => {
+                      const group = rankGroups[i];
+                      const { colorIndex } = group;
+                      const isGrouped = colorIndex !== null;
+                      const isReach = isGrouped && group.count >= 3;
+                      // Ring only for cards in a same-rank group of 2+; singletons stay neutral.
+                      const ringClass = isGrouped
+                        ? `${SPOONS_GROUP_RING_CLASSES[colorIndex % SPOONS_GROUP_RING_CLASSES.length]}${isReach ? ' motion-safe:animate-pulse' : ''}`
+                        : '';
+                      const card = (
+                        <CardImage
+                          key={`hand-${c.design}-${c.value}-${i}`}
+                          card={c}
+                          width={cardWidth}
+                          className={ringClass}
+                        />
+                      );
+                      const groupProps = {
+                        'data-rank-group': isGrouped ? String(group.colorIndex) : 'none',
+                        'data-rank-reach': isReach ? 'true' : 'false',
+                      };
+                      return canPass ? (
+                        <button
+                          type="button"
+                          key={`pass-${c.design}-${c.value}-${i}`}
+                          onClick={() => exec('pass', { cardIndex: i })}
+                          disabled={loading}
+                          className="p-0 bg-transparent border-0 cursor-pointer disabled:cursor-not-allowed"
+                          aria-label={t('passCardAria', { card: cardAlt(c) })}
+                          data-testid={`spoons-pass-${i}`}
+                          {...groupProps}
+                        >
+                          {card}
+                        </button>
+                      ) : (
+                        <span
+                          key={`hand-wrap-${c.design}-${c.value}-${i}`}
+                          data-testid={`spoons-hand-${i}`}
+                          {...groupProps}
+                        >
+                          {card}
+                        </span>
+                      );
+                    });
+                  })()}
                 </div>
               </div>
             ) : (

--- a/frontend/src/pages/SpoonsPage.tsx
+++ b/frontend/src/pages/SpoonsPage.tsx
@@ -37,10 +37,10 @@ import { computeSpoonsRankGroups } from '../utils/spoonsRankGroups';
  * same pair always keeps the same color across passes.
  */
 const SPOONS_GROUP_RING_CLASSES = [
-  'ring-2 ring-sky-400',
-  'ring-2 ring-amber-400',
-  'ring-2 ring-emerald-400',
-  'ring-2 ring-fuchsia-400',
+  'ring-2 ring-ds-info',
+  'ring-2 ring-ds-warning',
+  'ring-2 ring-ds-success',
+  'ring-2 ring-ds-accent',
 ] as const;
 
 /** CPU difficulty options for the Spoons settings panel. */

--- a/frontend/src/utils/spoonsRankGroups.test.ts
+++ b/frontend/src/utils/spoonsRankGroups.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import type { Card } from '../types/card';
+import { computeSpoonsRankGroups } from './spoonsRankGroups';
+
+const card = (value: number, design: Card['design'] = 'SPADE'): Card => ({ design, value });
+
+describe('computeSpoonsRankGroups', () => {
+  it('returns null colorIndex for a hand of all singletons', () => {
+    const groups = computeSpoonsRankGroups([card(2), card(5), card(9), card(13)]);
+    expect(groups.map((g) => g.colorIndex)).toEqual([null, null, null, null]);
+    expect(groups.every((g) => g.count === 1)).toBe(true);
+  });
+
+  it('assigns a shared color to a pair and none to singletons', () => {
+    // Hand: 7♠ 7♥ 3♣ K♦ — the two 7s form a group, others are singletons.
+    const groups = computeSpoonsRankGroups([
+      card(7, 'SPADE'),
+      card(7, 'HEART'),
+      card(3, 'CLOVER'),
+      card(13, 'DIAMOND'),
+    ]);
+    expect(groups[0].colorIndex).toBe(0);
+    expect(groups[1].colorIndex).toBe(0);
+    expect(groups[0].colorIndex).toBe(groups[1].colorIndex);
+    expect(groups[2].colorIndex).toBeNull();
+    expect(groups[3].colorIndex).toBeNull();
+    expect(groups.map((g) => g.count)).toEqual([2, 2, 1, 1]);
+  });
+
+  it('gives two pairs distinct color indices, deterministic by ascending rank', () => {
+    // Hand order puts the higher pair first; lower rank must still get index 0.
+    const groups = computeSpoonsRankGroups([card(10), card(4), card(10), card(4)]);
+    // Rank 4 (lower) -> index 0, rank 10 (higher) -> index 1.
+    expect(groups[0].colorIndex).toBe(1); // 10
+    expect(groups[1].colorIndex).toBe(0); // 4
+    expect(groups[2].colorIndex).toBe(1); // 10
+    expect(groups[3].colorIndex).toBe(0); // 4
+    expect(groups.map((g) => g.count)).toEqual([2, 2, 2, 2]);
+  });
+
+  it('flags a three-of-a-kind (reach) with count 3 sharing one color', () => {
+    const groups = computeSpoonsRankGroups([card(8), card(8), card(8), card(2)]);
+    expect(groups.slice(0, 3).every((g) => g.colorIndex === 0)).toBe(true);
+    expect(groups.slice(0, 3).every((g) => g.count === 3)).toBe(true);
+    expect(groups[3].colorIndex).toBeNull();
+    expect(groups[3].count).toBe(1);
+  });
+
+  it('handles an empty hand', () => {
+    expect(computeSpoonsRankGroups([])).toEqual([]);
+  });
+});

--- a/frontend/src/utils/spoonsRankGroups.ts
+++ b/frontend/src/utils/spoonsRankGroups.ts
@@ -1,0 +1,45 @@
+import type { Card } from '../types/card';
+
+/**
+ * Per-card grouping info for a Spoons hand, computed purely on the frontend by
+ * same-rank (`value`) equality. Cards whose rank appears 2+ times in the hand
+ * form a group and share a `colorIndex`; singleton ranks get `colorIndex: null`.
+ */
+export interface SpoonsRankGroup {
+  /**
+   * Deterministic group color index (0-based) for ranks with 2+ cards, or
+   * `null` for singleton ranks. Assigned by ascending rank so the mapping is
+   * stable regardless of card order in the hand.
+   */
+  colorIndex: number | null;
+  /** Number of cards in the hand sharing this card's rank (always >= 1). */
+  count: number;
+}
+
+/**
+ * Computes same-rank group info for each card in a Spoons hand, returned as an
+ * array parallel to `hand`. Ranks appearing 2+ times are assigned a stable
+ * `colorIndex` (by ascending rank); singletons get `null`. This lets the UI
+ * color-code cards so the player can see how close they are to four-of-a-kind.
+ */
+export function computeSpoonsRankGroups(hand: Card[]): SpoonsRankGroup[] {
+  const counts = new Map<number, number>();
+  for (const card of hand) {
+    counts.set(card.value, (counts.get(card.value) ?? 0) + 1);
+  }
+
+  // Ranks with 2+ cards get a stable color index, assigned by ascending rank.
+  const groupedRanks = [...counts.entries()]
+    .filter(([, count]) => count >= 2)
+    .map(([rank]) => rank)
+    .sort((a, b) => a - b);
+  const colorIndexByRank = new Map<number, number>();
+  for (const [i, rank] of groupedRanks.entries()) {
+    colorIndexByRank.set(rank, i);
+  }
+
+  return hand.map((card) => ({
+    colorIndex: colorIndexByRank.has(card.value) ? (colorIndexByRank.get(card.value) as number) : null,
+    count: counts.get(card.value) ?? 1,
+  }));
+}


### PR DESCRIPTION
## 概要

スプーンの手札を、フロントでランク集計して同ランク（2枚以上）のカードに同色リングを付け、3枚揃い（リーチ）は pulse で強調する純フロント実装。四枚集めまでの近さが一目で分かるようになる。CPU への情報漏れはなく、バックエンド変更なし。

- 集計は純粋関数 `computeSpoonsRankGroups`（`frontend/src/utils/spoonsRankGroups.ts`）に切り出し。色は昇順ランクで決定論的に割り当てるため、パスで手札が入れ替わっても同じペアは同じ色を保つ。
- リングは `CardImage` の `className` に適用。単独ランクは中立（リングなし）。クリック（パス）操作はブロックしない。
- テスト用に `data-rank-group` / `data-rank-reach` 属性を付与。

## 受け入れ条件

- [x] 同ランク 2 枚以上が同色リングで表示される
- [x] 3 枚揃いのランクが強調される（`motion-safe:animate-pulse`）
- [x] パスでカードが入れ替わると即時再計算される（render 内で毎回集計）
- [x] 集計ロジックのテストを追加（`spoonsRankGroups.test.ts` + `SpoonsPage.test.tsx`）

## テスト

- `frontend/src/utils/spoonsRankGroups.test.ts`（単独/ペア/2ペア/スリーカード/空手札）
- `frontend/src/pages/SpoonsPage.test.tsx`（ペアの同色・単独中立、スリーカードのリーチ）
- Gates: `bunx biome check`, `bun run test -- --run SpoonsPage spoonsRankGroups`（25 passed）, `bun run build`（tsc）すべてパス

Closes #3551
