### PR TITLE
feat(beggarmyneighbour): show held-card totals and round progress

### DIFF
--- a/frontend/src/i18n/locales/en/beggarmyneighbour.json
+++ b/frontend/src/i18n/locales/en/beggarmyneighbour.json
@@ -28,6 +28,11 @@
     "payPenalty": "Pay your penalty card",
     "collectPile": "Collect the central pile"
   },
+  "readout": {
+    "cardCount": "{{count}} cards",
+    "roundProgress": "Round {{played}} / {{max}}",
+    "countBarLabel": "Held cards: you {{you}}, CPU {{cpu}}"
+  },
   "tutorial": {
     "cpuPile": "CPU's card pile. Shows remaining card count.",
     "centralPile": "The central pile. Penalty cards cause it to grow.",

--- a/frontend/src/i18n/locales/ja/beggarmyneighbour.json
+++ b/frontend/src/i18n/locales/ja/beggarmyneighbour.json
@@ -28,6 +28,11 @@
     "payPenalty": "ペナルティを支払いましょう",
     "collectPile": "場の山を回収しましょう"
   },
+  "readout": {
+    "cardCount": "計 {{count}} 枚",
+    "roundProgress": "ラウンド {{played}} / {{max}}",
+    "countBarLabel": "持ち札 あなた {{you}} 枚、CPU {{cpu}} 枚"
+  },
   "tutorial": {
     "cpuPile": "CPUの山札です。残り枚数が表示されます。",
     "centralPile": "場の山です。ペナルティが発生すると積み重なります。",

--- a/frontend/src/pages/BeggarMyNeighbourPage.test.tsx
+++ b/frontend/src/pages/BeggarMyNeighbourPage.test.tsx
@@ -214,6 +214,47 @@ describe('BeggarMyNeighbourPage', () => {
     await waitFor(() => expect(screen.queryByTestId('step-button')).not.toBeInTheDocument());
   });
 
+  it('shows each player held-card total in the summary readout', async () => {
+    mockExec.mockResolvedValueOnce({
+      ...baseState,
+      players: [
+        { id: 0, isHuman: true, drawPileSize: 30, discardPileSize: 9, totalCards: 39 },
+        { id: 1, isHuman: false, drawPileSize: 10, discardPileSize: 3, totalCards: 13 },
+      ],
+    });
+    renderWithProviders(<BeggarMyNeighbourPage />);
+    const counts = await screen.findByTestId('bmn-card-counts');
+    expect(counts).toHaveTextContent(/あなた.*計 39 枚/);
+    expect(counts).toHaveTextContent(/CPU.*計 13 枚/);
+  });
+
+  it('reflects the held-card ratio in the count bar', async () => {
+    mockExec.mockResolvedValueOnce({
+      ...baseState,
+      players: [
+        { id: 0, isHuman: true, drawPileSize: 30, discardPileSize: 9, totalCards: 39 },
+        { id: 1, isHuman: false, drawPileSize: 10, discardPileSize: 3, totalCards: 13 },
+      ],
+    });
+    renderWithProviders(<BeggarMyNeighbourPage />);
+    // 39 / (39 + 13) = 75%.
+    const bar = await screen.findByTestId('bmn-count-bar');
+    expect(bar).toHaveAttribute('data-you-pct', '75');
+    expect(bar).toHaveAttribute('role', 'img');
+    expect(bar).toHaveAccessibleName('持ち札 あなた 39 枚、CPU 13 枚');
+  });
+
+  it('shows round progress toward the max-rounds cap', async () => {
+    mockExec.mockResolvedValueOnce({
+      ...baseState,
+      roundsPlayed: 250,
+      config: { maxRounds: 1000 },
+    });
+    renderWithProviders(<BeggarMyNeighbourPage />);
+    const progress = await screen.findByTestId('bmn-round-progress');
+    expect(progress).toHaveTextContent('ラウンド 250 / 1000');
+  });
+
   it('exposes accessible help for the max-rounds setting', async () => {
     renderWithProviders(<BeggarMyNeighbourPage />);
     await waitFor(() => expect(screen.getByText('最大ラウンド数')).toBeInTheDocument());

--- a/frontend/src/pages/BeggarMyNeighbourPage.tsx
+++ b/frontend/src/pages/BeggarMyNeighbourPage.tsx
@@ -128,6 +128,14 @@ function BeggarMyNeighbourPageContent() {
   const human = state.players[0];
   const cpu = state.players[1];
 
+  // Held-card totals and the who-is-winning ratio (out of the 52-card deck).
+  const heldTotal = human.totalCards + cpu.totalCards;
+  const youPct = heldTotal > 0 ? Math.round((human.totalCards / heldTotal) * 100) : 50;
+  const cpuPct = 100 - youPct;
+  // Round progress toward the draw-cutoff cap.
+  const roundCap = state.config.maxRounds;
+  const roundPct = roundCap > 0 ? Math.min(100, Math.round((state.roundsPlayed / roundCap) * 100)) : 0;
+
   const phaseName = isGameEnd
     ? t('phase.end')
     : state.phase === BeggarMyNeighbourPhase.PAY_PENALTY
@@ -168,6 +176,40 @@ function BeggarMyNeighbourPageContent() {
             {/* Announce the phase (and penalty countdown) to screen readers. */}
             <div className="sr-only" role="status" aria-live="polite" data-testid="bmn-phase-announce">
               {phaseAnnouncement}
+            </div>
+
+            {/* Held-card totals + round progress so the standings and how close the
+                draw-cutoff is are visible without mental arithmetic. */}
+            <div className="space-y-2 px-2" data-testid="bmn-summary">
+              {/* Round progress toward the max-rounds cap. */}
+              <div className="flex items-center gap-2">
+                <div className="text-xs text-ds-text-muted whitespace-nowrap" data-testid="bmn-round-progress">
+                  {t('readout.roundProgress', { played: state.roundsPlayed, max: roundCap })}
+                </div>
+                <div className="flex-1 h-1.5 bg-black/30 rounded-full overflow-hidden" aria-hidden="true">
+                  <div className="h-full bg-ds-info" style={{ width: `${roundPct}%` }} />
+                </div>
+              </div>
+
+              {/* Held-card counts and the who-is-ahead ratio bar. */}
+              <div className="flex justify-between text-xs text-ds-text-primary" data-testid="bmn-card-counts">
+                <span>
+                  {tc('player.you')}: {t('readout.cardCount', { count: human.totalCards })}
+                </span>
+                <span>
+                  {tc('player.cpu', { id: 1 })}: {t('readout.cardCount', { count: cpu.totalCards })}
+                </span>
+              </div>
+              <div
+                className="flex h-2 rounded-full overflow-hidden"
+                role="img"
+                aria-label={t('readout.countBarLabel', { you: human.totalCards, cpu: cpu.totalCards })}
+                data-testid="bmn-count-bar"
+                data-you-pct={youPct}
+              >
+                <div className="bg-ds-success h-full" style={{ width: `${youPct}%` }} />
+                <div className="bg-ds-warning h-full" style={{ width: `${cpuPct}%` }} />
+              </div>
             </div>
 
             {/* CPU pile */}


### PR DESCRIPTION
## 概要

ビガー・マイ・ネイバーのページに、各プレイヤーの総持ち札数と、どちらが優勢かが分かる比率バー（52枚中の割合）、および経過ラウンド/上限の進行表示を追加しました。これまで山札・捨札を別々に暗算する必要があり、引き分け打ち切り（`maxRounds`）までの進行も分からなかった問題を解消します。

フロントエンドのみの変更です。WebPresenter は既に `totalCards` / `roundsPlayed` / `config.maxRounds` を返しているため、Go 側の変更は不要でした。

## 変更内容

- 各プレイヤー行に合計枚数（例: 「計39枚」）を表示（`data-testid="bmn-card-counts"`）
- 持ち札比率を視覚バーで表示（`role="img"` + aria-label、`data-testid="bmn-count-bar"`）
- 経過ラウンド / 上限とその進行バーをヘッダー付近に表示（`data-testid="bmn-round-progress"` / `bmn-summary"`）
- i18n キー `readout.*` を ja/en 両方に追加（key-for-key）
- Page テストを3件追加

## 受け入れ条件

- [x] 両プレイヤーの合計枚数が表示される
- [x] 枚数比率が視覚バーで表示される
- [x] 経過ラウンド/上限が表示される
- [x] ページ側のテストを追加（WebPresenter は既存フィールドを返すため Go 変更なし）

## テスト

- `cd frontend && bun run test -- --run BeggarMyNeighbourPage` → 20 passed
- `cd frontend && bunx biome check` → clean
- `cd frontend && bun run build`（tsc）→ pass

Closes #3590
