### PR TITLE
feat(king): show per-contract acquired-point breakdown at deal end

### DIFF
--- a/frontend/src/i18n/locales/en/king.json
+++ b/frontend/src/i18n/locales/en/king.json
@@ -66,7 +66,10 @@
   "nextDeal": "Next Deal",
   "dealResult": {
     "title": "Deal Result",
-    "gained": "{{name}}: {{points}} pts"
+    "gained": "{{name}}: {{points}} pts",
+    "contractLine": "Contract: {{name}}",
+    "contractLineTrump": "Contract: {{name}} (trump: {{suit}})",
+    "basis": "Basis: {{desc}}"
   },
   "hintAvailable": "Hint",
   "hint": {

--- a/frontend/src/i18n/locales/ja/king.json
+++ b/frontend/src/i18n/locales/ja/king.json
@@ -66,7 +66,10 @@
   "nextDeal": "次のディール",
   "dealResult": {
     "title": "ディール結果",
-    "gained": "{{name}}: {{points}}点"
+    "gained": "{{name}}: {{points}}点",
+    "contractLine": "契約: {{name}}",
+    "contractLineTrump": "契約: {{name}}（切り札: {{suit}}）",
+    "basis": "失点根拠: {{desc}}"
   },
   "hintAvailable": "ヒント",
   "hint": {

--- a/frontend/src/pages/KingPage.test.tsx
+++ b/frontend/src/pages/KingPage.test.tsx
@@ -137,6 +137,33 @@ describe('KingPage', () => {
     expect(screen.getByTestId('king-deal-result')).toBeInTheDocument();
   });
 
+  it('shows the contract breakdown with the contract name, loss basis, and per-player points', async () => {
+    mockExec.mockResolvedValue(dealEndState);
+    renderWithProviders(<KingPage />);
+    await waitFor(() => expect(screen.getByTestId('king-deal-breakdown')).toBeInTheDocument());
+    // Contract 0 = No Tricks; its label and loss basis are rendered.
+    const breakdown = screen.getByTestId('king-deal-breakdown');
+    expect(breakdown).toHaveTextContent('契約: ノートリック');
+    expect(breakdown).toHaveTextContent('失点根拠: トリックを取るごとに失点。');
+    // Per-player point rows match the gained map from lastDealDetail.
+    expect(screen.getByTestId('king-deal-breakdown-row-0')).toHaveTextContent('-20点');
+    expect(screen.getByTestId('king-deal-breakdown-row-1')).toHaveTextContent('-30点');
+    expect(screen.getByTestId('king-deal-breakdown-row-2')).toHaveTextContent('-10点');
+  });
+
+  it('shows the trump suit in the breakdown for the King (Trump) contract', async () => {
+    mockExec.mockResolvedValue(
+      makeKingState({
+        phase: 'dealEnd',
+        lastDealDetail: { contract: 6, trumpSuit: 3, dealerIdx: 0, gained: { 0: -8, 1: 0, 2: 0, 3: 0 } },
+      }),
+    );
+    renderWithProviders(<KingPage />);
+    await waitFor(() => expect(screen.getByTestId('king-deal-breakdown')).toBeInTheDocument());
+    const breakdown = screen.getByTestId('king-deal-breakdown');
+    expect(breakdown).toHaveTextContent('契約: キング（切り札）（切り札: ♥）');
+  });
+
   it('renders the game end message', async () => {
     mockExec.mockResolvedValue(gameEndState);
     renderWithProviders(<KingPage />);

--- a/frontend/src/pages/KingPage.tsx
+++ b/frontend/src/pages/KingPage.tsx
@@ -273,15 +273,31 @@ function KingPageContent() {
                   </div>
                 )}
 
-                {/* Deal result: per-player gained points */}
+                {/* Deal result: contract played, its loss basis, and per-player gained points */}
                 {(isDealEnd || isGameEnd) && state.lastDealDetail && (
                   <div
                     className="my-3 p-2 rounded bg-black/30 text-ds-text-muted text-sm"
                     data-testid="king-deal-result"
                   >
                     <div className="mb-1 text-ds-text-primary">{t('dealResult.title')}</div>
+                    {/* Contract breakdown: which contract was played and why points moved */}
+                    <div className="mb-1.5 pb-1.5 border-b border-white/10" data-testid="king-deal-breakdown">
+                      <div className="text-ds-text-primary font-semibold">
+                        {state.lastDealDetail.contract === KING_TRUMP_CONTRACT && state.lastDealDetail.trumpSuit >= 1
+                          ? t('dealResult.contractLineTrump', {
+                              name: t(`contracts.${state.lastDealDetail.contract}`),
+                              suit: SUIT_SYMBOLS[state.lastDealDetail.trumpSuit] ?? '-',
+                            })
+                          : t('dealResult.contractLine', {
+                              name: t(`contracts.${state.lastDealDetail.contract}`),
+                            })}
+                      </div>
+                      <div className="text-xs opacity-80">
+                        {t('dealResult.basis', { desc: t(`contractDesc.${state.lastDealDetail.contract}`) })}
+                      </div>
+                    </div>
                     {state.players.map((p) => (
-                      <div key={p.id}>
+                      <div key={p.id} data-testid={`king-deal-breakdown-row-${p.id}`}>
                         {t('dealResult.gained', {
                           name: playerName(p.id, p.isHuman),
                           points: state.lastDealDetail?.gained[p.id] ?? 0,


### PR DESCRIPTION
## 概要

キングのディール結果表示に、そのディールで実行されたコントラクトの内訳を追加します。King は 1 ディール = 1 コントラクトなので、`lastDealDetail` の `contract` + `gained` が既にそのコントラクトの獲得点構成を表しており、それを可視化して学習性を高めます。

- ディール結果パネルに **コントラクト名** と **失点根拠**（`contractDesc`）を明細ヘッダーとして表示
- 既存の per-player gained 表示は維持（`data-testid` 付きの行として保持）
- 「キング（切り札）」コントラクトのときは選択された切り札スートも併記
- i18n キー（`dealResult.contractLine` / `contractLineTrump` / `basis`）を ja/en へ key-for-key で追加

バックエンド（`King.go` / `KingWebPresenter.go`）は変更していません。issue が挙げる「ハート枚数×点」等の失点“根拠の数値内訳”はレスポンスに存在せず、per-player の獲得点合計のみのため、フロントエンドで実現可能な範囲（コントラクト名 + そのコントラクト由来の per-player 点）に絞っています。

## テスト

- `frontend/src/pages/KingPage.test.tsx`
  - `shows the contract breakdown with the contract name, loss basis, and per-player points`
  - `shows the trump suit in the breakdown for the King (Trump) contract`

## ゲート

- `biome check --write` : 通過
- `bun run test -- --run KingPage` : 14 passed
- `bun run build`（tsc）: 通過

## 受け入れ条件

- [x] ディール結果にコントラクト名と失点根拠が表示される
- [x] 既存の per-player gained 表示は維持される
- [ ] ~~バックエンド `King.go` の deal 集計に内訳フィールドを追加~~ （レスポンスに既に contract + per-deal gained があるため不要。数値内訳の追加はスコープ外）
- [x] `KingPage.test.tsx` で内訳を検証

Closes #3617
