### PR TITLE
feat(euchre): ring the human's legal-to-play cards in the play phase

### DIFF
--- a/frontend/src/pages/EuchrePage.test.tsx
+++ b/frontend/src/pages/EuchrePage.test.tsx
@@ -469,6 +469,48 @@ describe('EuchrePage', () => {
     expect(cardBtn2).toHaveAttribute('aria-label', '\u2665 J');
   });
 
+  it('rings every card as legal when leading the trick', async () => {
+    // playPhaseState has an empty currentTrick → the human leads → all legal.
+    renderWithProviders(<EuchrePage />);
+    await waitFor(() => expect(screen.getByAltText('♠ A')).toBeInTheDocument());
+
+    const spadeBtn = screen.getByAltText('♠ A').closest('button') as HTMLButtonElement;
+    const heartBtn = screen.getByAltText('♥ J').closest('button') as HTMLButtonElement;
+    expect(spadeBtn).toHaveAttribute('data-legal', 'true');
+    expect(heartBtn).toHaveAttribute('data-legal', 'true');
+  });
+
+  it('rings only the legal follow-suit card and leaves clicks unblocked', async () => {
+    // Lead a spade with trump = spade → the human (♠A, ♥J) must follow spade,
+    // so only ♠A is legal; ♥J is not ringed but must still be clickable.
+    const followState: EuchreResponse = {
+      ...playPhaseState,
+      currentTrick: [{ playerIdx: 3, card: { design: 'SPADE', value: 12 } }],
+    };
+    mockExec.mockResolvedValue(followState);
+    renderWithProviders(<EuchrePage />);
+    await waitFor(() => expect(screen.getByAltText('♠ A')).toBeInTheDocument());
+
+    const spadeBtn = screen.getByAltText('♠ A').closest('button') as HTMLButtonElement;
+    const heartBtn = screen.getByAltText('♥ J').closest('button') as HTMLButtonElement;
+    expect(spadeBtn).toHaveAttribute('data-legal', 'true');
+    expect(heartBtn).not.toHaveAttribute('data-legal');
+
+    // Highlight is additive — the illegal card can still be selected (no block).
+    fireEvent.click(heartBtn);
+    expect(heartBtn).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('does not ring cards when it is not the human play turn', async () => {
+    // Trick-end phase is not a human play turn → no legal ring.
+    mockExec.mockResolvedValue(trickEndState);
+    renderWithProviders(<EuchrePage />);
+    await waitFor(() => expect(screen.getByAltText('♠ A')).toBeInTheDocument());
+
+    const spadeBtn = screen.getByAltText('♠ A').closest('button') as HTMLButtonElement;
+    expect(spadeBtn).not.toHaveAttribute('data-legal');
+  });
+
   it('reset button calls apiExec', async () => {
     renderWithProviders(<EuchrePage />);
     await waitFor(() => expect(screen.getByRole('button', { name: '\u30ea\u30bb\u30c3\u30c8' })).not.toBeDisabled());

--- a/frontend/src/pages/EuchrePage.tsx
+++ b/frontend/src/pages/EuchrePage.tsx
@@ -35,6 +35,7 @@ import { EUCHRE_HELP, parseEuchreCommand } from '../utils/cli/commands/euchreCom
 import { formatEuchreState } from '../utils/cli/formatters/euchreFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
 import { bowerRole } from '../utils/euchreBower';
+import { euchreLegalPlayIndices } from '../utils/euchreLegalPlay';
 import { euchreSittingOutIdx } from '../utils/euchreSittingOut';
 import { playerName } from '../utils/playerUtils';
 
@@ -202,6 +203,16 @@ function EuchrePageContent() {
   const isGameEnd = state.phase === EuchrePhase.GAME_END || state.gameEndFlag;
   const isHumanTurn = isPlayPhase && state.players[state.currentPlayerIdx]?.isHuman === true;
   const isHumanBidTurn = (isPickUpPhase || isCallTrumpPhase) && state.players[state.bidPlayerIdx]?.isHuman === true;
+
+  // On the human's play turn, mirror the server's follow-suit rule
+  // (internal/domain/Euchre.go validatePlay) so legal cards get an additive
+  // success ring. Highlight only — clicks are never blocked; the backend still
+  // validates the actual play. The effective-suit check counts the left bower
+  // as trump, matching the domain so the ring is intuitive.
+  const legalPlayIndices =
+    isHumanTurn && humanPlayer
+      ? euchreLegalPlayIndices(humanPlayer.cards, state.currentTrick[0]?.card, state.trumpSuit)
+      : undefined;
   const isHumanDiscard = isDiscardPhase && state.players[state.dealerIdx]?.isHuman === true;
 
   const suitName = (suit: number) => (SUIT_NAMES[suit] ? t(SUIT_NAMES[suit]) : '');
@@ -459,6 +470,10 @@ function EuchrePageContent() {
                   // the left bower (a same-color Jack that plays as trump despite
                   // its printed suit). Badge only — never blocks card selection.
                   const role = bowerRole(card, state.trumpSuit);
+                  // Additive success ring on legal-to-play cards (never blocks
+                  // clicks). Uses `outline` so it stacks on top of the inline
+                  // selection border/shadow instead of being clobbered by them.
+                  const isLegal = legalPlayIndices?.includes(idx) ?? false;
                   return (
                     <button
                       type="button"
@@ -466,12 +481,14 @@ function EuchrePageContent() {
                       onClick={() => toggleCard(idx)}
                       aria-label={cardAlt(card)}
                       aria-pressed={selectedCardIndices.includes(idx)}
+                      data-legal={isLegal ? 'true' : undefined}
                       className={`relative transition-transform ${focusRingCard}`}
                       style={{
                         background: 'none',
                         padding: 0,
                         borderRadius: 8,
                         ...selectedCardStyle(selectedCardIndices.includes(idx)),
+                        ...(isLegal ? { outline: '2px solid var(--color-ds-success)', outlineOffset: '1px' } : {}),
                         boxSizing: 'border-box',
                         ...(isMobile ? { minWidth: solitaireMinColWidth, flexShrink: 0 } : {}),
                       }}

--- a/frontend/src/utils/euchreLegalPlay.test.ts
+++ b/frontend/src/utils/euchreLegalPlay.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import type { Card } from '../types/card';
+import { euchreEffectiveSuit, euchreLegalPlayIndices } from './euchreLegalPlay';
+
+const c = (design: Card['design'], value: number): Card => ({ design, value });
+
+describe('euchreEffectiveSuit', () => {
+  it('returns the printed suit for a non-bower card', () => {
+    expect(euchreEffectiveSuit(c('HEART', 1), 1)).toBe(3);
+  });
+
+  it('treats the left bower (same-color Jack) as the trump suit', () => {
+    // trump = SPADE(1); same-color = CLOVER(2). Jack of clubs is the left bower.
+    expect(euchreEffectiveSuit(c('CLOVER', 11), 1)).toBe(1);
+  });
+
+  it('keeps the right bower on its printed (trump) suit', () => {
+    expect(euchreEffectiveSuit(c('SPADE', 11), 1)).toBe(1);
+  });
+
+  it('does not treat an off-color Jack as trump', () => {
+    expect(euchreEffectiveSuit(c('HEART', 11), 1)).toBe(3);
+  });
+
+  it('uses the printed suit when no trump is set', () => {
+    expect(euchreEffectiveSuit(c('CLOVER', 11), 0)).toBe(2);
+  });
+});
+
+describe('euchreLegalPlayIndices', () => {
+  const hand = [c('SPADE', 1), c('HEART', 11), c('DIAMOND', 9)];
+
+  it('marks every card legal when leading (no lead card)', () => {
+    expect(euchreLegalPlayIndices(hand, null, 1)).toEqual([0, 1, 2]);
+  });
+
+  it('restricts to the led suit when the player can follow', () => {
+    // Lead HEART, trump SPADE → only HEART(idx 1) follows.
+    expect(euchreLegalPlayIndices(hand, c('HEART', 1), 1)).toEqual([1]);
+  });
+
+  it('marks every card legal when the player cannot follow', () => {
+    // Lead CLOVER, trump DIAMOND → hand has no clover, all legal.
+    expect(euchreLegalPlayIndices(hand, c('CLOVER', 1), 4)).toEqual([0, 1, 2]);
+  });
+
+  it('treats the left bower as trump for follow-suit', () => {
+    // trump SPADE(1); left bower = Jack of CLOVER(2). Lead a plain spade.
+    const h = [c('CLOVER', 11), c('HEART', 1)];
+    // Lead SPADE → left bower (idx 0) counts as trump/spade and must follow.
+    expect(euchreLegalPlayIndices(h, c('SPADE', 14), 1)).toEqual([0]);
+  });
+});

--- a/frontend/src/utils/euchreLegalPlay.ts
+++ b/frontend/src/utils/euchreLegalPlay.ts
@@ -1,0 +1,44 @@
+import type { Card } from '../types/card';
+import { sameColorSuit } from './euchreBower';
+
+/** Card design string → Euchre suit number (matches the domain's CardDesign constants). */
+const DESIGN_TO_SUIT: Readonly<Record<string, number>> = {
+  SPADE: 1,
+  CLOVER: 2,
+  HEART: 3,
+  DIAMOND: 4,
+  JOKER: 0,
+};
+
+/** Numeric value of a Jack, the only rank that can be a bower. */
+const JACK_VALUE = 11;
+
+/**
+ * Returns the effective suit of a card under the given trump, mirroring the
+ * domain's `Euchre.effectiveSuit`: the left bower (a Jack of the same-color
+ * suit as trump) counts as the trump suit; every other card keeps its printed
+ * suit. When `trumpSuit <= 0` (no trump set) the printed suit is always used.
+ */
+export function euchreEffectiveSuit(card: Card, trumpSuit: number): number {
+  const suit = DESIGN_TO_SUIT[card.design] ?? 0;
+  if (trumpSuit > 0 && card.value === JACK_VALUE && suit === sameColorSuit(trumpSuit)) {
+    return trumpSuit;
+  }
+  return suit;
+}
+
+/**
+ * Computes the indices of the human hand that are legal to play, mirroring the
+ * domain's `Euchre.validatePlay` follow-suit rule: when leading (no lead card),
+ * every card is legal; otherwise the player must follow the lead's effective
+ * suit if able, so only matching cards are legal — but if the player holds none
+ * of that suit, every card becomes legal. Effective suit accounts for the left
+ * bower playing as trump.
+ */
+export function euchreLegalPlayIndices(hand: Card[], leadCard: Card | null | undefined, trumpSuit: number): number[] {
+  const all = hand.map((_, i) => i);
+  if (!leadCard) return all;
+  const leadSuit = euchreEffectiveSuit(leadCard, trumpSuit);
+  const following = all.filter((i) => euchreEffectiveSuit(hand[i], trumpSuit) === leadSuit);
+  return following.length > 0 ? following : all;
+}


### PR DESCRIPTION
## 概要

プレイフェーズの人間の手番で、合法（出せる）カードに追加的なサクセスリング（`ring-ds-success` 相当の outline）を表示します。フォロー義務（マストフォロー）の判定はドメイン（`internal/domain/Euchre.go` の `validatePlay`）をフロント側にミラーし、左バウアーが切り札として扱われるケースも反映します。

**ハイライト専用**であり、クリックは一切ブロックしません（`legalIndices` 相当のパターン。`validIndices` によるクリック抑止は使っていません）。実際のプレイ検証はバックエンドがそのまま担います。

## 変更内容

- `frontend/src/utils/euchreLegalPlay.ts` — 実効スート（左バウアー=切り札）と合法カードインデックスの算出ユーティリティを追加
- `frontend/src/pages/EuchrePage.tsx` — 手札ボタンに追加的な outline リングを配線（`data-legal` 属性付き、クリック非ブロック）
- テスト追加（ユーティリティ + ページ）

## 受け入れ条件

- [x] 人間のプレイ手番で合法カードがハイライトされる（クリックは全カード可能・ブロックしない方針）
- [x] リード時（トリック先頭）は全カードが有効（=全カードにリング）
- [x] 左バウアーを含むフォロー判定がドメインと一致する（テストで検証）
- [x] ページ・ユーティリティ双方のテスト追加

> 備考: 本 PR は追加的なハイライトのみでバックエンド非変更のため、issue 記載の WebPresenter への `validPlayIndices` 追加ではなく、既存 `legalIndices` パターン（ハイライトのみ・クリック非ブロック）で実装しています。

## テスト

- `bun run check`（biome + design-token 検証）: PASS
- `bun run build`（tsc + vite）: PASS
- `bun run test -- --run euchreLegalPlay EuchrePage`: 81 passed

Closes #3079
