### PR TITLE
feat(cruel): highlight foundation drop-target by matching suit

### DIFF
--- a/frontend/src/pages/CruelPage.test.tsx
+++ b/frontend/src/pages/CruelPage.test.tsx
@@ -205,6 +205,42 @@ describe('CruelPage', () => {
     expect(screen.getByText('空')).toBeInTheDocument();
   });
 
+  it('highlights only the suit-matching foundation when a card is click-selected (#3040)', async () => {
+    renderWithProviders(<CruelPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+
+    // Column 0 is fourColumn('SPADE', 2) → its top card is ♠5. Selecting it should
+    // mark only foundation pile 0 (♠) as the suit target, leaving ♣/♥/♦ unmarked.
+    fireEvent.click(screen.getByRole('button', { name: '♠ 5' }));
+
+    await waitFor(() => expect(screen.getByTestId('cruel-foundation-0')).toHaveAttribute('data-suit-target', 'true'));
+    expect(screen.getByTestId('cruel-foundation-1')).not.toHaveAttribute('data-suit-target');
+    expect(screen.getByTestId('cruel-foundation-2')).not.toHaveAttribute('data-suit-target');
+    expect(screen.getByTestId('cruel-foundation-3')).not.toHaveAttribute('data-suit-target');
+    // The matching pile gets the design-token ring; non-matching piles do not.
+    expect(screen.getByTestId('cruel-foundation-0').className).toContain('ring-ds-info');
+    expect(screen.getByTestId('cruel-foundation-3').className).not.toContain('ring-ds-info');
+  });
+
+  it('highlights the ♦ foundation when a diamond card is selected (#3040)', async () => {
+    renderWithProviders(<CruelPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+
+    // Column 3 is fourColumn('DIAMOND', 2) → top card ♦5 maps to foundation pile 3 (♦).
+    fireEvent.click(screen.getByRole('button', { name: '♦ 5' }));
+
+    await waitFor(() => expect(screen.getByTestId('cruel-foundation-3')).toHaveAttribute('data-suit-target', 'true'));
+    expect(screen.getByTestId('cruel-foundation-0')).not.toHaveAttribute('data-suit-target');
+  });
+
+  it('marks no foundation as a suit target when nothing is selected (#3040)', async () => {
+    renderWithProviders(<CruelPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    for (let i = 0; i < 4; i += 1) {
+      expect(screen.getByTestId(`cruel-foundation-${i}`)).not.toHaveAttribute('data-suit-target');
+    }
+  });
+
   it('renders foundation suit labels above placed Aces', async () => {
     const stateWithEmptyFoundation: CruelResponse = {
       ...playingState,

--- a/frontend/src/pages/CruelPage.tsx
+++ b/frontend/src/pages/CruelPage.tsx
@@ -38,6 +38,17 @@ import { formatCruelState } from '../utils/cli/formatters/cruelFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
 
 const FOUNDATION_SUITS = ['♠', '♣', '♥', '♦'] as const;
+/**
+ * Maps a card design to its 0-based foundation index, matching the foundation
+ * row order (`♠`=0, `♣`=1, `♥`=2, `♦`=3) and mirroring the backend's suit layout.
+ * Used to highlight only the foundation pile whose suit matches the moving card.
+ */
+const DESIGN_TO_FOUNDATION_INDEX: Record<string, number> = {
+  SPADE: 0,
+  CLOVER: 1,
+  HEART: 2,
+  DIAMOND: 3,
+};
 const noop = () => {};
 
 /** Cruel tutorial step definitions. */
@@ -273,6 +284,16 @@ function CruelPageContent() {
   const isSourceSelected = (zone: string, col?: number) =>
     selectedSource !== null && selectedSource.zone === zone && selectedSource.col === col;
 
+  // Suit of the card currently being moved (a dragged card takes priority over a
+  // click-selected one). Cruel only ever moves a column's top card, so the moving
+  // card is the last card of the source tableau column. Deriving its foundation
+  // index lets us light only the matching pile instead of all four at once (#3040).
+  const movingCol = dnd.dragSource?.col ?? selectedSource?.col;
+  const movingColCards = movingCol !== undefined ? state.tableau[movingCol] : undefined;
+  const movingCard =
+    movingColCards && movingColCards.length > 0 ? movingColCards[movingColCards.length - 1].card : null;
+  const activeFoundationIdx = movingCard ? DESIGN_TO_FOUNDATION_INDEX[movingCard.design] : undefined;
+
   return (
     <GamePageShell
       title={tc('nav.cruel')}
@@ -325,19 +346,25 @@ function CruelPageContent() {
               {state.foundation.map((pile, i) => {
                 const topCard = pile.length > 0 ? pile[pile.length - 1] : null;
                 const isTarget = selectedSource !== null;
+                // Only the pile whose suit matches the card being moved (dragged or
+                // click-selected) is highlighted, so the player sees where it lands (#3040).
+                const suitMatch = activeFoundationIdx === i;
+                const showSuitTarget = suitMatch && (dnd.isDragging || isTarget);
                 return (
                   <DropZone
                     key={i}
                     onDrop={dnd.handleDrop({ zone: 'foundation' })}
                     onDragOver={dnd.handleDragOver({ zone: 'foundation' })}
                     onDragLeave={dnd.handleDragLeave}
-                    isDropTarget={dnd.isDropTarget({ zone: 'foundation' })}
+                    isDropTarget={dnd.isDropTarget({ zone: 'foundation' }) && suitMatch}
                   >
                     <button
                       type="button"
+                      data-testid={`cruel-foundation-${i}`}
+                      data-suit-target={showSuitTarget ? 'true' : undefined}
                       className={`${focusRingWhite} rounded-lg transition-colors ${
-                        isTarget ? 'hover:ring-2 hover:ring-ds-warning cursor-pointer' : ''
-                      }`}
+                        showSuitTarget ? 'ring-2 ring-ds-info' : ''
+                      } ${isTarget && suitMatch ? 'hover:ring-2 hover:ring-ds-warning cursor-pointer' : ''}`}
                       onClick={() => isTarget && handleSelectTarget('foundation')}
                       disabled={!isPlaying || !isTarget}
                       aria-label={


### PR DESCRIPTION
## 概要

クルーエルのファンデーション行は 4 パイルすべてが同一ゾーン `{ zone: 'foundation' }` を共有しているため、カードをドラッグ/選択すると 4 パイル全部が同時にハイライトされ、どのスートのパイルに載るのか分からなかった。

移動中のカード（ドラッグまたはクリック選択された列の先頭カード）のスートを算出し、スートが一致するファンデーションのパイルだけをハイライトするようにした。既存の move フロー（`zone:'foundation'` への drop）には一切手を加えていない純粋な追加変更。

## 変更点

- `CruelPage.tsx`: `DESIGN_TO_FOUNDATION_INDEX`（♠=0/♣=1/♥=2/♦=3、`freeCellFoundationTarget` と同一のマッピング）で移動中カードのスートを算出。ドラッグ中は `dnd.dragSource`、クリック選択時は `selectedSource` を参照（ドラッグ優先）。
- スート一致パイルのみ `ring-ds-info` の常時リング（`data-suit-target`）を点灯し、`DropZone` の `isDropTarget` も `suitMatch` でゲート。クリック選択時の hover リング（`ring-ds-warning`）も一致パイルのみに限定。
- 色はすべてデザインシステムトークン（`ring-ds-info` / `ring-ds-warning`）。raw Tailwind palette は不使用。
- テスト追加（`CruelPage.test.tsx`、計 22 passed）。

## 受け入れ条件

- [x] ドラッグ中、スートの合うファンデーションのみ強調される
- [x] クリック選択時も同様に該当パイルのみリングが出る
- [x] ドロップ動作（zone:'foundation' への move）は従来どおり成功する（onClick/onDrop/disabled は不変）
- [x] `CruelPage.test.tsx` に強調分岐のテストを追加

## テスト計画

- [x] `bun run test -- --run CruelPage`（22 passed）
- [x] `bun run check`（biome + design-token 検証 OK）
- [x] `bun run build`（tsc 通過）

Closes #3040
