### PR TITLE
feat(scopone): celebrate a scopa sweep with a badge and sound

### DIFF
--- a/frontend/src/i18n/locales/en/scopone.json
+++ b/frontend/src/i18n/locales/en/scopone.json
@@ -20,7 +20,9 @@
     "yourTeam": "Your Team",
     "cpuStats": "Hand {{cards}} / Captured {{captured}} / Scopa {{scopa}}",
     "humanStats": "Hand {{cards}} / Captured {{captured}} / Scopa {{scopa}}",
-    "teamScore": "Team {{team}}: {{score}} pt"
+    "teamScore": "Team {{team}}: {{score}} pt",
+    "scopaBadge": "Scopa!",
+    "scopaBadgeOwn": "Scopa! Your team"
   },
   "button": {
     "take": "Take",

--- a/frontend/src/i18n/locales/ja/scopone.json
+++ b/frontend/src/i18n/locales/ja/scopone.json
@@ -20,7 +20,9 @@
     "yourTeam": "あなたのチーム",
     "cpuStats": "手札{{cards}}枚 / 捕獲{{captured}}枚 / スコパ{{scopa}}",
     "humanStats": "手札{{cards}}枚 / 捕獲{{captured}}枚 / スコパ{{scopa}}",
-    "teamScore": "チーム{{team}}: {{score}}pt"
+    "teamScore": "チーム{{team}}: {{score}}pt",
+    "scopaBadge": "スコパ！",
+    "scopaBadgeOwn": "スコパ！ あなたのチーム"
   },
   "button": {
     "take": "取る",

--- a/frontend/src/pages/ScoponePage.test.tsx
+++ b/frontend/src/pages/ScoponePage.test.tsx
@@ -189,4 +189,88 @@ describe('ScoponePage', () => {
     await waitFor(() => expect(screen.getByRole('textbox')).toBeInTheDocument());
     localStorage.removeItem('cli-mode-scopone');
   });
+
+  // Builds a 4-player Scopone state with a given scopaCount for one player.
+  const stateWithScopa = (playerId: number, scopaCount: number) =>
+    makeScoponeState({
+      players: [
+        {
+          id: 0,
+          isHuman: true,
+          team: 0,
+          handCount: 3,
+          cards: makeScoponeState().players[0].cards,
+          capturedCount: 0,
+          scopaCount: playerId === 0 ? scopaCount : 0,
+        },
+        {
+          id: 1,
+          isHuman: false,
+          team: 1,
+          handCount: 3,
+          cards: [],
+          capturedCount: 0,
+          scopaCount: playerId === 1 ? scopaCount : 0,
+        },
+        {
+          id: 2,
+          isHuman: false,
+          team: 0,
+          handCount: 3,
+          cards: [],
+          capturedCount: 0,
+          scopaCount: playerId === 2 ? scopaCount : 0,
+        },
+        {
+          id: 3,
+          isHuman: false,
+          team: 1,
+          handCount: 3,
+          cards: [],
+          capturedCount: 0,
+          scopaCount: playerId === 3 ? scopaCount : 0,
+        },
+      ],
+    });
+
+  it('does not show the scopa badge on initial load', async () => {
+    mockExec.mockResolvedValue(stateWithScopa(0, 2));
+    renderWithProviders(<ScoponePage />);
+    await waitFor(() => expect(screen.getByTestId('hand-card-0')).toBeInTheDocument());
+    expect(screen.queryByTestId('scopone-scopa-celebration')).not.toBeInTheDocument();
+  });
+
+  it('shows the scopa badge when a player scopaCount increases', async () => {
+    renderWithProviders(<ScoponePage />);
+    await waitFor(() => expect(screen.getByTestId('hand-card-0')).toBeInTheDocument());
+
+    // A subsequent play resolves a state where the human (team 0) swept the table.
+    mockExec.mockResolvedValue(stateWithScopa(0, 1));
+    fireEvent.click(screen.getByTestId('hand-card-0'));
+    fireEvent.click(screen.getByTestId('table-card-0'));
+    fireEvent.click(screen.getByTestId('take-button'));
+
+    const badge = await screen.findByTestId('scopone-scopa-celebration');
+    expect(badge).toBeInTheDocument();
+    // Own-team sweep uses the emphasised label.
+    expect(badge).toHaveTextContent('スコパ！ あなたのチーム');
+  });
+
+  it('clears the scopa badge after scopaCount resets to zero', async () => {
+    renderWithProviders(<ScoponePage />);
+    await waitFor(() => expect(screen.getByTestId('hand-card-0')).toBeInTheDocument());
+
+    mockExec.mockResolvedValue(stateWithScopa(0, 1));
+    fireEvent.click(screen.getByTestId('hand-card-0'));
+    fireEvent.click(screen.getByTestId('table-card-0'));
+    fireEvent.click(screen.getByTestId('take-button'));
+    await screen.findByTestId('scopone-scopa-celebration');
+
+    // A next round drops scopaCount back to 0 — the badge must disappear. Use Lay
+    // (no table selection needed) since the prior play cleared the selection.
+    mockExec.mockResolvedValue(stateWithScopa(0, 0));
+    fireEvent.click(screen.getByTestId('hand-card-0'));
+    fireEvent.click(screen.getByTestId('lay-button'));
+    await waitFor(() => expect(screen.queryByTestId('scopone-scopa-celebration')).not.toBeInTheDocument());
+  });
 });

--- a/frontend/src/pages/ScoponePage.tsx
+++ b/frontend/src/pages/ScoponePage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
 import { CliToggle } from '../components/cli/CliToggle';
@@ -16,6 +16,7 @@ import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useScoponeGame } from '../hooks/useScoponeGame';
+import { useSound } from '../providers/SoundProvider';
 import { gameTheme } from '../styles/gameTheme';
 import type { ScoponeResponse } from '../types/card';
 import type { TutorialStep } from '../types/tutorial';
@@ -103,6 +104,45 @@ function ScoponePageContent() {
     retry,
   } = useScoponeGame();
   const { cardWidth } = useCardDimensions();
+  const { playSound } = useSound();
+
+  // Celebrate a Scopa (clean sweep of the table) the instant any player's scopaCount
+  // rises — the sweep is the game's highlight but was easy to miss amid fast CPU turns
+  // (#3464). Tracked per-player so a partner-team sweep can be emphasised. scopaCount
+  // resets to 0 each round, so a drop clears any stale badge (no false re-fire).
+  const [scopaCelebration, setScopaCelebration] = useState<{ key: number; own: boolean } | null>(null);
+  const prevScopaRef = useRef<number[] | null>(null);
+  useEffect(() => {
+    if (!state) return;
+    const current = state.players.map((p) => p.scopaCount);
+    const prev = prevScopaRef.current;
+    prevScopaRef.current = current;
+    if (prev === null || prev.length !== current.length) {
+      // First render or a player-count change: seed the baseline without firing.
+      if (prev !== null) setScopaCelebration(null);
+      return;
+    }
+    const humanTeam = state.players.find((p) => p.isHuman)?.team ?? -1;
+    let gain = false;
+    let own = false;
+    let dropped = false;
+    for (let i = 0; i < current.length; i++) {
+      const delta = current[i] - prev[i];
+      if (delta > 0) {
+        gain = true;
+        if (state.players[i].team === humanTeam) own = true;
+      } else if (delta < 0) {
+        dropped = true;
+      }
+    }
+    if (gain) {
+      setScopaCelebration((c) => ({ key: (c?.key ?? 0) + 1, own }));
+      playSound('chipClick', { pitchVariation: 0.1 });
+    } else if (dropped) {
+      // A reset / next round drops scopaCount back to 0; clear the stale badge.
+      setScopaCelebration(null);
+    }
+  }, [state, playSound]);
 
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('scopone');
   const cliConfig: CliGameConfig<ScoponeResponse, ScoponeCliArgs> = useMemo(
@@ -200,7 +240,25 @@ function ScoponePageContent() {
             </div>
 
             {/* Table cards */}
-            <div className="py-3 bg-black/20 rounded-lg" data-tutorial="sp-table-cards">
+            <div className="relative py-3 bg-black/20 rounded-lg" data-tutorial="sp-table-cards">
+              {scopaCelebration && (
+                <div
+                  key={scopaCelebration.key}
+                  className="absolute inset-x-0 -top-3 z-10 flex justify-center motion-safe:animate-bounce pointer-events-none"
+                  role="status"
+                  data-testid="scopone-scopa-celebration"
+                >
+                  <span
+                    className={`rounded-full px-3 py-0.5 text-sm font-bold shadow-lg ${
+                      scopaCelebration.own
+                        ? 'bg-ds-accent text-ds-text-on-accent ring-2 ring-ds-accent'
+                        : 'bg-ds-info text-white'
+                    }`}
+                  >
+                    {scopaCelebration.own ? t('label.scopaBadgeOwn') : t('label.scopaBadge')}
+                  </span>
+                </div>
+              )}
               <div className="text-center text-xs text-ds-text-muted mb-2">{t('label.tableCards')}</div>
               <div className="flex justify-center gap-2 min-h-[60px] flex-wrap">
                 {state.tableCards.length === 0 ? (


### PR DESCRIPTION
## 概要

スコポーネでスコパ（場を空にする取り）が発生した瞬間を祝う演出を追加します。従来は `p.scopaCount` が統計テキストとして増えるだけで達成に気づけませんでした。Pişti（#2692）で確立したパターンを踏襲し、各プレイヤーの `scopaCount` の増加エッジを `useRef` で検知して、テーブル上部に `role="status"` のバッジをポップ表示し、`chipClick` の効果音を鳴らします。

- 人間／パートナーチーム（同一 team）のスコパは強調色（`bg-ds-accent`）＋専用ラベルで強調
- 相手チームは中立色（`bg-ds-info`）
- `scopaCount` はラウンドごとに 0 にリセットされるため、減少を検知してバッジを消去（誤再発火なし）
- アニメーションは `motion-safe:animate-bounce` で reduced-motion に配慮
- 色はデザインシステムトークンのみ使用（`bg-ds-*` / `text-ds-*` / `ring-ds-*`）

## 受け入れ条件

- [x] scopaCount 増加時にバッジと効果音が発火する
- [x] reset / nextRound で前回値がクリアされ誤発火しない
- [x] motion-safe プレフィックスで reduced-motion に配慮
- [x] 増加検知ロジックのテストを追加

## テスト

- `bun run test -- --run ScoponePage` — 20 tests pass（新規3件: 初期表示でバッジ非表示 / scopaCount 増加でバッジ表示 / リセットでバッジ消去）
- `bun run check` — biome + design-token validator OK
- `bun run build` — tsc + vite OK

Closes #3464
