### PR TITLE
feat(chinchon): color-code hand cards by meld vs deadwood

### DIFF
--- a/frontend/src/i18n/locales/en/chinchon.json
+++ b/frontend/src/i18n/locales/en/chinchon.json
@@ -32,6 +32,8 @@
   "knockButton": "Knock",
   "deadwoodLabel": "Deadwood: {{score}} pts (knock ≤ {{threshold}})",
   "deadwoodBreakdown": "Breakdown: {{breakdown}}",
+  "meldLegend": "Meld",
+  "deadwoodLegend": "Deadwood",
   "layoffButton": "Lay Off",
   "skipLayoffButton": "Skip",
   "nextRound": "Next Round",

--- a/frontend/src/i18n/locales/ja/chinchon.json
+++ b/frontend/src/i18n/locales/ja/chinchon.json
@@ -32,6 +32,8 @@
   "knockButton": "ノック",
   "deadwoodLabel": "デッドウッド: {{score}}点（ノック上限 {{threshold}}）",
   "deadwoodBreakdown": "内訳: {{breakdown}}",
+  "meldLegend": "メルド",
+  "deadwoodLegend": "デッドウッド",
   "layoffButton": "レイオフ",
   "skipLayoffButton": "スキップ",
   "nextRound": "次のラウンド",

--- a/frontend/src/pages/ChinchonPage.test.tsx
+++ b/frontend/src/pages/ChinchonPage.test.tsx
@@ -410,4 +410,58 @@ describe('ChinchonPage', () => {
     await waitFor(() => expect(actionLogApi.chinchon).toHaveBeenCalledTimes(1));
     expect(screen.getByText('棋譜')).toBeInTheDocument();
   });
+
+  // Hand with a ♠5-6-7 run (idx 0-2) plus ♥5, ♥6 deadwood (idx 3-4).
+  const meldHandState: ChinchonResponse = {
+    ...discardPhaseState,
+    players: [
+      {
+        ...discardPhaseState.players[0],
+        cards: [
+          { design: 'SPADE', value: 5 },
+          { design: 'SPADE', value: 6 },
+          { design: 'SPADE', value: 7 },
+          { design: 'HEART', value: 5 },
+          { design: 'HEART', value: 6 },
+        ],
+      },
+      ...discardPhaseState.players.slice(1),
+    ],
+  };
+
+  it('color-codes meld vs deadwood hand cards during the discard phase', async () => {
+    mockExec.mockResolvedValue(meldHandState);
+    renderWithProviders(<ChinchonPage />);
+    await waitFor(() => expect(screen.getByTestId('chinchon-hand-card-0')).toBeInTheDocument());
+
+    // Run members are melds; the two loose hearts are deadwood.
+    expect(screen.getByTestId('chinchon-hand-card-0')).toHaveAttribute('data-meld', 'meld');
+    expect(screen.getByTestId('chinchon-hand-card-1')).toHaveAttribute('data-meld', 'meld');
+    expect(screen.getByTestId('chinchon-hand-card-2')).toHaveAttribute('data-meld', 'meld');
+    expect(screen.getByTestId('chinchon-hand-card-3')).toHaveAttribute('data-meld', 'deadwood');
+    expect(screen.getByTestId('chinchon-hand-card-4')).toHaveAttribute('data-meld', 'deadwood');
+
+    // Legend distinguishes the two categories with a non-color cue (label text).
+    expect(screen.getByTestId('chinchon-meld-legend')).toHaveTextContent('メルド');
+    expect(screen.getByTestId('chinchon-meld-legend')).toHaveTextContent('デッドウッド');
+  });
+
+  it('re-splits the meld coloring when a discard candidate is selected', async () => {
+    mockExec.mockResolvedValue(meldHandState);
+    renderWithProviders(<ChinchonPage />);
+    await waitFor(() => expect(screen.getByTestId('chinchon-hand-card-1')).toBeInTheDocument());
+
+    // Projecting the discard of ♠5 breaks the run, so ♠6 is no longer a meld.
+    fireEvent.click(screen.getByTestId('chinchon-hand-card-0'));
+    expect(screen.getByTestId('chinchon-hand-card-1')).toHaveAttribute('data-meld', 'deadwood');
+    expect(screen.getByTestId('chinchon-hand-card-2')).toHaveAttribute('data-meld', 'deadwood');
+  });
+
+  it('does not color-code hand cards outside the discard phase', async () => {
+    mockExec.mockResolvedValue(drawPhaseState);
+    renderWithProviders(<ChinchonPage />);
+    await waitFor(() => expect(screen.getByTestId('chinchon-hand-card-0')).toBeInTheDocument());
+    expect(screen.getByTestId('chinchon-hand-card-0')).not.toHaveAttribute('data-meld');
+    expect(screen.queryByTestId('chinchon-meld-legend')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/ChinchonPage.tsx
+++ b/frontend/src/pages/ChinchonPage.tsx
@@ -26,7 +26,7 @@ import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
 import { btnPrimary, btnSuccess } from '../styles/buttonStyles';
-import { focusRingCard, selectedCardStyle } from '../styles/cardStyles';
+import { focusRingCard, meldCardStyle, selectedCardStyle } from '../styles/cardStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { ChinchonResponse } from '../types/card';
@@ -34,6 +34,7 @@ import { ChinchonPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import {
+  bestChinchonMeldSplit,
   type ChinchonDeadwoodBreakdown,
   chinchonDeadwoodBreakdown,
   chinchonMeldLabel,
@@ -192,6 +193,31 @@ function ChinchonPageContent() {
   }, [state, selectedCardIndices]);
   const liveDeadwood = liveDeadwoodBreakdown?.total ?? null;
   const canKnockNow = liveDeadwood != null && liveDeadwood <= knockThreshold;
+
+  // During DISCARD, color-code the human's hand by the best meld split so the
+  // player can see which cards form melds vs. deadwood. When a single discard
+  // is selected the split is projected onto the post-discard hand (the chosen
+  // card is excluded), so the coloring follows the selection and stays in sync
+  // with the deadwood indicator. Returned indices reference the *rendered*
+  // hand. Empty set outside DISCARD, so no coloring is applied.
+  const meldedIndices = useMemo<ReadonlySet<number>>(() => {
+    if (!state || state.phase !== ChinchonPhase.DISCARD) return new Set();
+    const human = state.players.find((p) => p.isHuman);
+    if (!human || human.cards.length === 0) return new Set();
+    const cards = human.cards;
+    if (selectedCardIndices.length !== 1) return bestChinchonMeldSplit(cards).meldedIndices;
+    const skip = selectedCardIndices[0];
+    const subMelded = bestChinchonMeldSplit(cards.filter((_, i) => i !== skip)).meldedIndices;
+    // Map post-discard sub-hand indices back to the rendered hand indices.
+    const result = new Set<number>();
+    let k = 0;
+    for (let i = 0; i < cards.length; i++) {
+      if (i === skip) continue;
+      if (subMelded.has(k)) result.add(i);
+      k++;
+    }
+    return result;
+  }, [state, selectedCardIndices]);
 
   if (!state)
     return (
@@ -400,6 +426,29 @@ function ChinchonPageContent() {
                 })}
               </div>
             )}
+            {isDiscardPhase && (
+              <div
+                data-testid="chinchon-meld-legend"
+                className="flex items-center gap-3 text-xs text-ds-text-muted mb-1"
+              >
+                <span className="flex items-center gap-1">
+                  <span
+                    aria-hidden="true"
+                    className="inline-block h-3 w-3 rounded-sm"
+                    style={{ outline: '2px solid var(--color-ds-success)', outlineOffset: '-2px' }}
+                  />
+                  {t('meldLegend')}
+                </span>
+                <span className="flex items-center gap-1">
+                  <span
+                    aria-hidden="true"
+                    className="inline-block h-3 w-3 rounded-sm"
+                    style={{ outline: '2px dashed rgba(148, 163, 184, 0.6)', outlineOffset: '-2px' }}
+                  />
+                  {t('deadwoodLegend')}
+                </span>
+              </div>
+            )}
             {humanPlayer && (
               <div className="flex flex-wrap gap-1 mb-2" data-tutorial="ch-player-hand">
                 {humanPlayer.cards.map((card, idx) => (
@@ -409,11 +458,14 @@ function ChinchonPageContent() {
                     onClick={() => toggleCard(idx)}
                     aria-label={cardAlt(card)}
                     aria-pressed={selectedCardIndices.includes(idx)}
+                    data-testid={`chinchon-hand-card-${idx}`}
+                    data-meld={isDiscardPhase ? (meldedIndices.has(idx) ? 'meld' : 'deadwood') : undefined}
                     className={`transition-transform ${focusRingCard}`}
                     style={{
                       background: 'none',
                       padding: 0,
                       borderRadius: 8,
+                      ...(isDiscardPhase ? meldCardStyle(meldedIndices.has(idx)) : undefined),
                       ...selectedCardStyle(selectedCardIndices.includes(idx)),
                       boxSizing: 'border-box',
                     }}

--- a/frontend/src/utils/chinchonDeadwood.test.ts
+++ b/frontend/src/utils/chinchonDeadwood.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { Card } from '../types/card';
 import {
   bestChinchonDeadwoodValue,
+  bestChinchonMeldSplit,
   calcChinchonDeadwoodValue,
   chinchonCardValue,
   chinchonDeadwoodBreakdown,
@@ -91,5 +92,38 @@ describe('chinchonDeadwoodBreakdown', () => {
   it('returns an empty breakdown when every card melds', () => {
     const hand = [c('SPADE', 5), c('HEART', 5), c('CLOVER', 5)];
     expect(chinchonDeadwoodBreakdown(hand)).toEqual({ cards: [], values: [], total: 0 });
+  });
+});
+
+describe('bestChinchonMeldSplit', () => {
+  it('marks the melded card indices and leaves deadwood out', () => {
+    // ♠5-♥5-♣5 set (idx 0,1,2) melds; ♦K(idx 3) and ♥3(idx 4) are deadwood.
+    const hand = [c('SPADE', 5), c('HEART', 5), c('CLOVER', 5), c('DIAMOND', 13), c('HEART', 3)];
+    const split = bestChinchonMeldSplit(hand);
+    expect([...split.meldedIndices].sort((a, b) => a - b)).toEqual([0, 1, 2]);
+    expect(split.meldedIndices.has(3)).toBe(false);
+    expect(split.meldedIndices.has(4)).toBe(false);
+    expect(split.deadwoodValue).toBe(13);
+  });
+
+  it('marks a same-suit run spanning the 7/J gap as melded', () => {
+    // ♠7-J-Q run (idx 0,1,2) melds; ♥A(idx 3) is deadwood.
+    const hand = [c('SPADE', 7), c('SPADE', 11), c('SPADE', 12), c('HEART', 1)];
+    const split = bestChinchonMeldSplit(hand);
+    expect([...split.meldedIndices].sort((a, b) => a - b)).toEqual([0, 1, 2]);
+    expect(split.deadwoodValue).toBe(1);
+  });
+
+  it('returns an empty set for an empty hand', () => {
+    const split = bestChinchonMeldSplit([]);
+    expect(split.meldedIndices.size).toBe(0);
+    expect(split.deadwoodValue).toBe(0);
+  });
+
+  it('marks every index as deadwood when no meld exists', () => {
+    const hand = [c('SPADE', 5), c('HEART', 13)];
+    const split = bestChinchonMeldSplit(hand);
+    expect(split.meldedIndices.size).toBe(0);
+    expect(split.deadwoodValue).toBe(15);
   });
 });

--- a/frontend/src/utils/chinchonDeadwood.ts
+++ b/frontend/src/utils/chinchonDeadwood.ts
@@ -81,6 +81,29 @@ export function chinchonDeadwoodBreakdown(hand: readonly Card[]): ChinchonDeadwo
   return { cards, values: cards.map(chinchonCardValue), total: best.value };
 }
 
+/** The best meld split of a hand: which card indices are absorbed by melds. */
+export interface ChinchonMeldSplit {
+  /** Indices (into `hand`) of cards that belong to a meld in the minimum-deadwood split. */
+  meldedIndices: ReadonlySet<number>;
+  /** Deadwood total of the split. */
+  deadwoodValue: number;
+}
+
+/**
+ * Find the minimum-deadwood split and report which hand indices are melded, so
+ * the UI can color-code melded vs. deadwood cards (mirrors Gin Rummy's
+ * `bestMeldSplit`). Shares the same search as the deadwood breakdown, so the
+ * coloring and the score always agree. Empty hand yields an empty set.
+ */
+export function bestChinchonMeldSplit(hand: readonly Card[]): ChinchonMeldSplit {
+  if (hand.length === 0) return { meldedIndices: new Set(), deadwoodValue: 0 };
+  const best = search(hand.map((card, idx) => ({ idx, card })));
+  const deadwoodIdx = new Set(best.deadwood.map((d) => d.idx));
+  const melded = new Set<number>();
+  for (let i = 0; i < hand.length; i++) if (!deadwoodIdx.has(i)) melded.add(i);
+  return { meldedIndices: melded, deadwoodValue: best.value };
+}
+
 function search(remaining: IndexedCard[]): { value: number; deadwood: IndexedCard[] } {
   const candidates = enumerateMelds(remaining);
   let best = { value: calcChinchonDeadwoodValue(remaining.map((r) => r.card)), deadwood: remaining };


### PR DESCRIPTION
## 概要

チンチョンの DISCARD フェーズで、人間プレイヤーの手札をメルド（ラン/セット）成立分とデッドウッドに色分け表示します。Gin Rummy の手札色分けと同じ仕組みで、どのカードがメルドに使われているか一目で分かるようにします。

## 実装

- `bestChinchonMeldSplit(hand)` を `chinchonDeadwood.ts` に追加。既存の最小デッドウッド探索（`search`）を再利用し、メルドに属するカードのインデックス集合を返す（Gin Rummy の `bestMeldSplit` を踏襲）。色分けとデッドウッド表示の計算が常に一致します。
- `ChinchonPage.tsx`: 共有の `meldCardStyle`（メルド=実線グリーン枠 / デッドウッド=破線グレー枠、いずれも ds トークン）を各手札ボタンに適用。`data-meld="meld|deadwood"` 属性も付与。
- **選択追随**: 捨て札候補を1枚選ぶと、その捨て札後の手札で再計算し色分けが更新されます。
- **色覚多様性への配慮**: 色だけでなく実線/破線の違い＋凡例（メルド/デッドウッドのラベル）で区別可能。
- i18n: `meldLegend` / `deadwoodLegend` を ja/en 両方に追加。

バックエンドは変更なし（フロントエンドのみ、純粋に加算的で操作はブロックしません）。

## 受け入れ条件

- [x] デッドウッドカードが視覚的に区別できる
- [x] 捨て札候補の選択に応じて色分けが更新される
- [x] 色以外（実線/破線＋凡例）でも区別でき色覚多様性に配慮
- [x] ページテストで色分け属性を検証

## テスト

- `chinchonDeadwood.test.ts`: `bestChinchonMeldSplit` のメルド判定（セット/ラン/空手/メルドなし）
- `ChinchonPage.test.tsx`:
  - `color-codes meld vs deadwood hand cards during the discard phase`
  - `re-splits the meld coloring when a discard candidate is selected`
  - `does not color-code hand cards outside the discard phase`

## ゲート

- `bun run check`（biome + design-token 検証）: PASS（ds トークンのみ使用）
- `bun run test -- --run ChinchonPage`: 31 passed
- `bun run test -- --run chinchonDeadwood`: 17 passed
- `bun run build`（tsc）: PASS

Closes #3475
