### PR TITLE
feat(speed): highlight playable hand cards with a success ring

### DIFF
--- a/frontend/src/i18n/locales/en/speed.json
+++ b/frontend/src/i18n/locales/en/speed.json
@@ -6,6 +6,7 @@
     "gameEnd": "Game End"
   },
   "yourHand": "Your Hand",
+  "playable": "playable now",
   "cpuHand": "CPU Hand",
   "drawPile": "Draw Pile",
   "selectCard": "Select a card from your hand",

--- a/frontend/src/i18n/locales/ja/speed.json
+++ b/frontend/src/i18n/locales/ja/speed.json
@@ -6,6 +6,7 @@
     "gameEnd": "ゲーム終了"
   },
   "yourHand": "手札",
+  "playable": "今すぐ出せる",
   "cpuHand": "CPU手札",
   "drawPile": "山札",
   "selectCard": "手札からカードを選択",

--- a/frontend/src/pages/SpeedPage.test.tsx
+++ b/frontend/src/pages/SpeedPage.test.tsx
@@ -200,8 +200,9 @@ describe('SpeedPage', () => {
   it('auto-plays a card via smart-click when only one valid pile exists', async () => {
     renderWithProviders(<SpeedPage />);
     await waitFor(() => expect(screen.getByText('手札')).toBeInTheDocument());
-    // SPADE 4 is adjacent to pile 0 (value 5) only → smart-click auto-plays
-    fireEvent.click(screen.getByRole('button', { name: '♠ 4' }));
+    // SPADE 4 is adjacent to pile 0 (value 5) only → smart-click auto-plays.
+    // It is also playable, so its aria-label carries the "playable now" suffix.
+    fireEvent.click(screen.getByRole('button', { name: '♠ 4 (今すぐ出せる)' }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', 0, 0));
   });
 
@@ -407,6 +408,39 @@ describe('SpeedPage', () => {
     renderWithProviders(<SpeedPage />);
     await waitFor(() => expect(screen.getByText('手札')).toBeInTheDocument());
     expect(screen.queryByTestId('stuck-emphasis-container')).not.toBeInTheDocument();
+  });
+
+  it('marks playable hand cards with a success ring in play phase', async () => {
+    renderWithProviders(<SpeedPage />);
+    await waitFor(() => expect(screen.getByText('手札')).toBeInTheDocument());
+    // Center piles 5/9 → SPADE 4 (5-1) and HEART 8 (9-1) are playable; CLOVER 11
+    // and DIAMOND 2 are not.
+    const playable = screen.getByRole('button', { name: '♠ 4 (今すぐ出せる)' });
+    expect(playable).toHaveAttribute('data-playable', 'true');
+    expect(playable.style.outline).toContain('var(--color-ds-success)');
+
+    const notPlayable = screen.getByRole('button', { name: '♦ 2' });
+    expect(notPlayable).not.toHaveAttribute('data-playable');
+    expect(notPlayable.style.outline).toBe('');
+  });
+
+  it('keeps a non-highlighted hand card clickable (ring does not block clicks)', async () => {
+    renderWithProviders(<SpeedPage />);
+    await waitFor(() => expect(screen.getByText('手札')).toBeInTheDocument());
+    // DIAMOND 2 is not highlighted (not adjacent to either pile) but must stay
+    // interactive — clicking it toggles selection rather than being blocked.
+    const notPlayable = screen.getByRole('button', { name: '♦ 2' });
+    expect(notPlayable).toBeEnabled();
+    fireEvent.click(notPlayable);
+    expect(notPlayable).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('removes the playable ring in stuck phase', async () => {
+    mockExec.mockResolvedValue(stuckState);
+    renderWithProviders(<SpeedPage />);
+    await waitFor(() => expect(screen.getByText('めくる')).toBeInTheDocument());
+    // No hand card carries the playable marker once play is halted.
+    expect(document.querySelector('[data-playable="true"]')).toBeNull();
   });
 });
 

--- a/frontend/src/pages/SpeedPage.tsx
+++ b/frontend/src/pages/SpeedPage.tsx
@@ -23,7 +23,7 @@ import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { AUTO_FLIP_DELAY_MS, CPU_DIFFICULTY_OPTIONS, useSpeedGame } from '../hooks/useSpeedGame';
 import { useSound } from '../providers/SoundProvider';
 import { btnOutline } from '../styles/buttonStyles';
-import { focusRingCard, selectedCardStyle } from '../styles/cardStyles';
+import { focusRingCard, playableRingStyle, selectedCardStyle } from '../styles/cardStyles';
 import type { SpeedResponse } from '../types/card';
 import { SpeedPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
@@ -31,6 +31,7 @@ import { cardAlt } from '../utils/cardAlt';
 import { parseSpeedCommand, SPEED_HELP } from '../utils/cli/commands/speedCommands';
 import { formatSpeedState } from '../utils/cli/formatters/speedFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { isSpeedPlayable } from '../utils/hints/speedHint';
 
 const SPEED_TUTORIAL_STEPS: TutorialStep[] = [
   {
@@ -237,20 +238,30 @@ function SpeedPageContent() {
                 </span>
               </div>
               <div className="flex gap-1 flex-wrap justify-center">
-                {humanPlayer.cards.map((card, idx) => (
-                  <button
-                    type="button"
-                    key={`${card.design}-${card.value}-${idx}`}
-                    onClick={() => handleSmartClick(idx, humanPlayer.cards, state.centerPiles)}
-                    disabled={!isPlayPhase || loading}
-                    aria-label={cardAlt(card)}
-                    aria-pressed={selectedCardIndices.includes(idx)}
-                    className={`transition-transform ${focusRingCard}`}
-                    style={selectedCardStyle(selectedCardIndices.includes(idx))}
-                  >
-                    <AnimatedCard card={card} width={cardWidth} />
-                  </button>
-                ))}
+                {humanPlayer.cards.map((card, idx) => {
+                  // Highlight cards playable right now (rank ±1 of either center
+                  // pile, K↔A wrap). Ring-only: the button stays clickable so the
+                  // backend still validates the play.
+                  const playable = isPlayPhase && isSpeedPlayable(card.value, state.centerPiles);
+                  return (
+                    <button
+                      type="button"
+                      key={`${card.design}-${card.value}-${idx}`}
+                      onClick={() => handleSmartClick(idx, humanPlayer.cards, state.centerPiles)}
+                      disabled={!isPlayPhase || loading}
+                      aria-label={playable ? `${cardAlt(card)} (${t('playable')})` : cardAlt(card)}
+                      aria-pressed={selectedCardIndices.includes(idx)}
+                      data-playable={playable ? 'true' : undefined}
+                      className={`transition-transform ${focusRingCard}`}
+                      style={{
+                        ...selectedCardStyle(selectedCardIndices.includes(idx)),
+                        ...(playable ? playableRingStyle() : {}),
+                      }}
+                    >
+                      <AnimatedCard card={card} width={cardWidth} />
+                    </button>
+                  );
+                })}
               </div>
             </div>
 

--- a/frontend/src/styles/cardStyles.ts
+++ b/frontend/src/styles/cardStyles.ts
@@ -80,6 +80,21 @@ export function meldCardStyle(isMelded: boolean): React.CSSProperties {
 }
 
 /**
+ * Return inline styles for an additive "playable right now" success ring.
+ * Uses `outline` (not `border`/`boxShadow`) so it stacks on top of the
+ * selection border and any inline `boxShadow` without clobbering them — a
+ * playable card can also be selected and still show its ring. Uses the
+ * `--color-ds-success` design token. Applied e.g. to Speed hand cards.
+ */
+export function playableRingStyle(): React.CSSProperties {
+  return {
+    outline: '2px solid var(--color-ds-success)',
+    outlineOffset: '1px',
+    borderRadius: 8,
+  };
+}
+
+/**
  * Return adjusted overlap margin for a card that is adjacent to a selected card on mobile.
  * Reduces the negative overlap by EXPANSION_GAP_PX, effectively widening the visible area.
  * Returns the original overlap when the card is not adjacent to a selection.

--- a/frontend/src/utils/hints/speedHint.test.ts
+++ b/frontend/src/utils/hints/speedHint.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { Card, SpeedResponse } from '../../types/card';
 import { SpeedPhase } from '../../types/phases';
-import { getSpeedHint } from './speedHint';
+import { getSpeedHint, isSpeedPlayable } from './speedHint';
 
 const card = (design: Card['design'], value: number): Card => ({ design, value });
 
@@ -69,5 +69,31 @@ describe('getSpeedHint', () => {
     expect(result?.targetAction).toBe('play');
     expect(result?.reason).toBe('hint.hasPlayable');
     expect(result?.confidence).toBe('strong');
+  });
+});
+
+describe('isSpeedPlayable', () => {
+  const piles = [card('HEART', 6), card('SPADE', 9)];
+
+  it('returns true for a card one below a pile top', () => {
+    expect(isSpeedPlayable(5, piles)).toBe(true); // 6 - 1
+  });
+
+  it('returns true for a card one above a pile top', () => {
+    expect(isSpeedPlayable(10, piles)).toBe(true); // 9 + 1
+  });
+
+  it('returns false for a non-adjacent card', () => {
+    expect(isSpeedPlayable(3, piles)).toBe(false);
+  });
+
+  it('handles King-Ace wrap-around', () => {
+    expect(isSpeedPlayable(1, [card('HEART', 13), card('SPADE', 5)])).toBe(true); // A next to K
+    expect(isSpeedPlayable(13, [card('HEART', 1), card('SPADE', 5)])).toBe(true); // K next to A
+  });
+
+  it('ignores null piles safely', () => {
+    expect(isSpeedPlayable(5, [null as unknown as Card, card('SPADE', 6)])).toBe(true);
+    expect(isSpeedPlayable(5, [null as unknown as Card])).toBe(false);
   });
 });

--- a/frontend/src/utils/hints/speedHint.ts
+++ b/frontend/src/utils/hints/speedHint.ts
@@ -12,7 +12,7 @@ export function getSpeedHint(state: SpeedResponse): HintResult | null {
   if (state.gameEndFlag) return null;
   if (state.phase !== SpeedPhase.PLAY) return null;
 
-  const hasPlayable = human.cards.some((c) => canPlayOnAnyPile(c, state.centerPiles));
+  const hasPlayable = human.cards.some((c) => isSpeedPlayable(c.value, state.centerPiles));
 
   if (hasPlayable) {
     return { targetAction: 'play', reason: 'hint.hasPlayable', confidence: 'strong' };
@@ -21,9 +21,14 @@ export function getSpeedHint(state: SpeedResponse): HintResult | null {
   return { targetAction: 'wait', reason: 'hint.noPlayable', confidence: 'moderate' };
 }
 
-/** Check if a card can be played on any center pile (value +/- 1, with wrap-around). */
-function canPlayOnAnyPile(card: Card, centerPiles: Card[]): boolean {
-  return centerPiles.some((pile) => isAdjacent(card.value, pile.value));
+/**
+ * Returns true if a card of the given rank can be played onto at least one
+ * center pile right now (rank ±1, with King↔Ace wrap-around). Mirrors the
+ * backend `Speed.CanPlay` / `isAdjacentRank` rule so the highlight matches
+ * what the server will accept.
+ */
+export function isSpeedPlayable(cardValue: number, centerPiles: Card[]): boolean {
+  return centerPiles.some((pile) => pile != null && isAdjacent(cardValue, pile.value));
 }
 
 /** Check if two values are adjacent (with King-Ace wrap-around). */


### PR DESCRIPTION
## 概要
スピードの手札で、今すぐ台札に出せるカード（台札トップの±1、K↔A ラップ）に緑リング（`ds-success` トークン）を付与します。反射神経ゲームなので、文章ヒントより即時の視覚ハイライトが有効です。

`TriPeaksPage` の `isPlayable`（`ring-ds-success`）と同じ発想。`speedHint.ts` の隣接判定を `isSpeedPlayable(cardValue, centerPiles)` として切り出して流用し、バックエンドの `Speed.CanPlay` / `isAdjacentRank` と一致させています。

## 実装
- `speedHint.ts`: `isSpeedPlayable` をエクスポート（既存ヒントロジックも再利用）。
- `cardStyles.ts`: `playableRingStyle()` を追加。`outline` を使い、選択ボーダー/boxShadow を潰さず加算的に重ねる。
- `SpeedPage.tsx`: PLAY フェーズの手札に緑リング＋`data-playable` 属性＋`aria-label` 補足（「今すぐ出せる」/ "playable now"）。
- **リングのみ**: `validIndices` によるクリック抑止は使わず、非ハイライトのカードもクリック可能なまま（バックエンドが最終検証）。
- i18n `playable` キーを ja/en 両方に追加。

## 受け入れ条件
- [x] PLAY フェーズで台札 ±1（K-A ラップ含む）の手札に緑リングが付く
- [x] 台札が更新されるたびにリングが即時再計算される（レンダー毎に算出）
- [x] STUCK フェーズではリングが消える
- [x] 判定ユーティリティとページのテストを追加
- [x] 非ハイライトのカードもクリック可能（クリック抑止なし）

## テスト
`cd frontend && bun run check && bun run test -- --run SpeedPage speedHint && bun run build` すべて green（60 tests）。

Closes #3103
