### PR TITLE
feat(fortyandeight): highlight eligible foundations for selected card

### DIFF
--- a/frontend/src/pages/FortyAndEightPage.test.tsx
+++ b/frontend/src/pages/FortyAndEightPage.test.tsx
@@ -89,6 +89,20 @@ const withFoundationState: FortyAndEightResponse = {
   foundation: [[card('SPADE', 1)], [], [card('HEART', 1), card('HEART', 2)], [], [], [], [], []],
 };
 
+// Waste holds an Ace, so selecting it makes every empty foundation eligible (#3288).
+const aceWasteState: FortyAndEightResponse = {
+  ...playingState,
+  waste: [card('SPADE', 1)],
+  foundation: [[], [], [], [], [], [], [], []],
+};
+
+// Waste holds ♠2 and foundation pile 0 tops out at ♠A, so only pile 0 is a legal target (#3288).
+const singleTargetState: FortyAndEightResponse = {
+  ...playingState,
+  waste: [card('SPADE', 2)],
+  foundation: [[card('SPADE', 1)], [], [], [], [], [], [], []],
+};
+
 const withHintState: FortyAndEightResponse = {
   ...playingState,
   hint: { fromZone: 'waste', fromCol: -1, cardIndex: -1, toZone: 'tableau', toCol: 3 },
@@ -326,6 +340,39 @@ describe('FortyAndEightPage', () => {
     fireEvent.click(wasteButton);
 
     expect(tableauButton.className).toContain('ring-2');
+  });
+
+  it('highlights every empty foundation when an Ace source is selected', async () => {
+    mockExec.mockResolvedValue(aceWasteState);
+    const { container } = renderWithProviders(<FortyAndEightPage />);
+    await waitFor(() => expect(screen.getByText('ウェイスト')).toBeInTheDocument());
+
+    // No source selected yet -> no highlight.
+    expect(container.querySelectorAll('[data-eligible-foundation="true"]')).toHaveLength(0);
+
+    const wasteButton = screen.getByAltText('♠ A').closest('button') as HTMLButtonElement;
+    fireEvent.click(wasteButton);
+
+    // Ace is placeable on all 8 empty foundations.
+    await waitFor(() => expect(container.querySelectorAll('[data-eligible-foundation="true"]')).toHaveLength(8));
+    for (const el of container.querySelectorAll('[data-eligible-foundation="true"]')) {
+      expect(el.className).toContain('ring-ds-info');
+    }
+  });
+
+  it('highlights only the single legal foundation and leaves invalid piles unhighlighted', async () => {
+    mockExec.mockResolvedValue(singleTargetState);
+    const { container } = renderWithProviders(<FortyAndEightPage />);
+    await waitFor(() => expect(screen.getByText('ウェイスト')).toBeInTheDocument());
+
+    const wasteButton = screen.getByAltText('♠ 2').closest('button') as HTMLButtonElement;
+    fireEvent.click(wasteButton);
+
+    // ♠2 only fits on pile 0 (top ♠A); the 7 empty piles reject a non-Ace.
+    await waitFor(() => expect(container.querySelectorAll('[data-eligible-foundation="true"]')).toHaveLength(1));
+    const highlighted = container.querySelector('[data-eligible-foundation="true"]') as HTMLElement;
+    expect(highlighted).toHaveAttribute('aria-label', expect.stringContaining('組札'));
+    expect(highlighted.className).toContain('ring-ds-info');
   });
 
   it('clicking tableau card when source selected dispatches move', async () => {

--- a/frontend/src/pages/FortyAndEightPage.tsx
+++ b/frontend/src/pages/FortyAndEightPage.tsx
@@ -33,6 +33,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import { FORTYANDEIGHT_HELP, parseFortyandeightCommand } from '../utils/cli/commands/fortyandeightCommands';
 import { formatFortyandeightState } from '../utils/cli/formatters/fortyandeightFormatter';
+import { fortyAndEightFoundationTargets } from '../utils/fortyAndEightFoundationTargets';
 import { isTableauAllFaceUp } from '../utils/solitaireUtils';
 
 const FOUNDATION_SUITS = ['♠', '♠', '♣', '♣', '♥', '♥', '♦', '♦'] as const;
@@ -140,6 +141,25 @@ function FortyAndEightPageContent() {
     [state?.tableau],
   );
   const f8 = useResponsiveTableau(8, { maxColCards });
+
+  // Resolve the actual card behind the currently selected source zone so we can
+  // highlight the foundation piles it may legally move to (#3288).
+  const selectedCard = useMemo(() => {
+    if (!state || !selectedSource) return null;
+    if (selectedSource.zone === 'waste') return state.waste[state.waste.length - 1] ?? null;
+    if (
+      selectedSource.zone === 'tableau' &&
+      selectedSource.col !== undefined &&
+      selectedSource.cardIndex !== undefined
+    ) {
+      return state.tableau[selectedSource.col]?.[selectedSource.cardIndex]?.card ?? null;
+    }
+    return null;
+  }, [state, selectedSource]);
+  const eligibleFoundations = useMemo(
+    () => fortyAndEightFoundationTargets(selectedCard, state?.foundation ?? []),
+    [selectedCard, state?.foundation],
+  );
 
   const isPlayingForKbd = state?.phase === FortyAndEightPhase.PLAYING;
 
@@ -294,6 +314,7 @@ function FortyAndEightPageContent() {
               <div className="flex gap-1 sm:gap-2 flex-wrap" data-tutorial="f8-foundation">
                 {state.foundation.map((pile, idx) => {
                   const foundationZone: FortyAndEightMoveZone = { zone: 'foundation', col: idx };
+                  const isEligible = eligibleFoundations.has(idx);
                   return (
                     <div key={`f-${idx.toString()}`} className="text-center">
                       <div className="text-game-text-muted text-xs mb-1">{FOUNDATION_SUITS[idx]}</div>
@@ -315,7 +336,8 @@ function FortyAndEightPageContent() {
                               pile: (idx % 2) + 1,
                               count: pile.length,
                             })}
-                            className={`p-0 border-0 bg-transparent cursor-pointer rounded ${focusRingWhite}`}
+                            data-eligible-foundation={isEligible ? 'true' : undefined}
+                            className={`p-0 border-0 bg-transparent cursor-pointer rounded ${focusRingWhite} ${isEligible ? 'ring-2 ring-ds-info' : ''}`}
                           >
                             <AnimatedCard
                               card={pile[pile.length - 1]}
@@ -333,8 +355,9 @@ function FortyAndEightPageContent() {
                               suit: FOUNDATION_SUITS[idx],
                               pile: (idx % 2) + 1,
                             })}
+                            data-eligible-foundation={isEligible ? 'true' : undefined}
                             style={{ width: f8.cw, height: f8.ch }}
-                            className={`rounded border-2 border-dashed border-white/30 text-game-text-muted text-xs flex items-center justify-center ${focusRingWhite}`}
+                            className={`rounded border-2 border-dashed border-white/30 text-game-text-muted text-xs flex items-center justify-center ${focusRingWhite} ${isEligible ? 'ring-2 ring-ds-info' : ''}`}
                           >
                             A
                           </button>

--- a/frontend/src/utils/fortyAndEightFoundationTargets.test.ts
+++ b/frontend/src/utils/fortyAndEightFoundationTargets.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import type { Card } from '../types/card';
+import { fortyAndEightFoundationTargets } from './fortyAndEightFoundationTargets';
+
+const card = (design: Card['design'], value: number): Card => ({ design, value });
+
+describe('fortyAndEightFoundationTargets', () => {
+  it('returns an empty set when no card is selected', () => {
+    expect(fortyAndEightFoundationTargets(null, [[], [], [], [], [], [], [], []]).size).toBe(0);
+    expect(fortyAndEightFoundationTargets(undefined, [[]]).size).toBe(0);
+  });
+
+  it('marks every empty pile eligible for an Ace', () => {
+    const foundation: Card[][] = [[], [], [card('HEART', 2)]];
+    const targets = fortyAndEightFoundationTargets(card('SPADE', 1), foundation);
+    expect(targets.has(0)).toBe(true);
+    expect(targets.has(1)).toBe(true);
+    // Non-empty pile does not accept an Ace.
+    expect(targets.has(2)).toBe(false);
+  });
+
+  it('does not mark empty piles for a non-Ace', () => {
+    const targets = fortyAndEightFoundationTargets(card('SPADE', 5), [[], []]);
+    expect(targets.size).toBe(0);
+  });
+
+  it('accepts a same-suit card exactly one rank above the pile top', () => {
+    const foundation: Card[][] = [[card('SPADE', 1), card('SPADE', 2)], [card('HEART', 1)]];
+    const targets = fortyAndEightFoundationTargets(card('SPADE', 3), foundation);
+    expect(targets.has(0)).toBe(true);
+    expect(targets.has(1)).toBe(false);
+  });
+
+  it('rejects a wrong-suit or wrong-rank card', () => {
+    const foundation: Card[][] = [[card('SPADE', 1)]];
+    expect(fortyAndEightFoundationTargets(card('HEART', 2), foundation).size).toBe(0); // wrong suit
+    expect(fortyAndEightFoundationTargets(card('SPADE', 3), foundation).size).toBe(0); // skips a rank
+  });
+
+  it('can mark multiple non-empty piles of the same suit', () => {
+    const foundation: Card[][] = [[card('SPADE', 1)], [card('SPADE', 1)]];
+    const targets = fortyAndEightFoundationTargets(card('SPADE', 2), foundation);
+    expect(targets.has(0)).toBe(true);
+    expect(targets.has(1)).toBe(true);
+  });
+});

--- a/frontend/src/utils/fortyAndEightFoundationTargets.ts
+++ b/frontend/src/utils/fortyAndEightFoundationTargets.ts
@@ -1,0 +1,28 @@
+import type { Card } from '../types/card';
+
+/**
+ * Computes the set of foundation pile indices that `card` can legally move to,
+ * given the current `foundation` piles.
+ *
+ * Mirrors the domain's `FortyAndEight.canPlaceOnFoundation`: an empty pile
+ * accepts only an Ace (`value === 1`); a non-empty pile accepts a card of the
+ * same suit whose rank is exactly one higher than the pile's top card. Unlike
+ * suit-fixed solitaires, Forty and Eight's eight foundations are not bound to a
+ * suit, so an Ace is eligible for every empty pile.
+ *
+ * @param card - The selected source card (waste top card or a tableau card), or `null`.
+ * @param foundation - The eight foundation piles (bottom card first).
+ * @returns A set of 0-based foundation indices the card can be placed on (empty when none).
+ */
+export function fortyAndEightFoundationTargets(card: Card | null | undefined, foundation: Card[][]): Set<number> {
+  const targets = new Set<number>();
+  if (!card) return targets;
+  foundation.forEach((pile, idx) => {
+    const placeable =
+      pile.length === 0
+        ? card.value === 1
+        : card.design === pile[pile.length - 1].design && card.value === pile[pile.length - 1].value + 1;
+    if (placeable) targets.add(idx);
+  });
+  return targets;
+}


### PR DESCRIPTION
## 概要
フォーティ・アンド・エイトで、カード選択時に移動可能なfoundation（組札）を視覚的に強調します（#3288）。8つのfoundationを持つため有効な移動先が分かりづらい問題を解消します。

`selectedSource`（ウェイスト or タブロー）の実カードを解決し、置けるfoundationパイルに `ring-2 ring-ds-info` を付与します。純粋に追加のみで、既存の `handleSelectTarget` やクリック/ドラッグ挙動は変更しません。

## ルール（ドメインと一致）
`internal/domain/FortyAndEight.go` の `canPlaceOnFoundation` を踏襲:
- 空のパイル: エース（value===1）のみ配置可（8つの空パイル全てが対象）
- 非空パイル: 同スートかつトップより1ランク上

## 変更点
- `frontend/src/utils/fortyAndEightFoundationTargets.ts` — 純粋ヘルパー（+ unit test）
- `frontend/src/pages/FortyAndEightPage.tsx` — `useMemo` で有効index集合を算出し、空/非空 両foundationボタンにリング + `data-eligible-foundation` 属性を付与
- ページ/ユーティリティのテスト追加

デザイントークン（`ring-ds-info`）のみ使用。ユーザー向けテキスト追加なしのためi18n変更なし。

## 受け入れ条件
- [x] 選択したカードに対する有効な移動先foundationが視覚的に強調される
- [x] 無効なパイルには強調が付かない
- [x] 既存の `handleSelectTarget` ロジックに影響しない
- [x] コンポーネントテストで強調表示の条件を検証する

## テスト
- `bun run test -- --run fortyAndEightFoundationTargets FortyAndEightPage` — 46 passed
- `bun run check` — OK（design-tokens OK）
- `bun run build` — success

Closes #3288