### PR TITLE
feat(bezique): highlight legal cards during the endgame follow

### DIFF
--- a/frontend/src/pages/BeziquePage.test.tsx
+++ b/frontend/src/pages/BeziquePage.test.tsx
@@ -36,6 +36,16 @@ const gameEndState = makeBeziqueState({
   message: 'ゲーム終了！ あなたの勝利です (1010-820)！',
 });
 const endgameState = makeBeziqueState({ phase: 0, currentPlayerIdx: 0, stockRemaining: 0, isEndgame: true });
+// Endgame human FOLLOW turn: opponent led ♠K; hand is ♠Q / ♦J / ♥A, trump ♥.
+// Holding ♠ forces following ♠ (♠Q cannot beat ♠K, so it is the only legal card).
+const endgameFollowState = makeBeziqueState({
+  phase: 0,
+  currentPlayerIdx: 0,
+  stockRemaining: 0,
+  isEndgame: true,
+  trumpSuit: 3,
+  currentTrick: [{ playerIdx: 1, card: { design: 'SPADE', value: 13 } }],
+});
 
 beforeEach(() => {
   mockExec.mockReset();
@@ -148,6 +158,39 @@ describe('BeziquePage', () => {
     mockExec.mockResolvedValue(endgameState);
     renderWithProviders(<BeziquePage />);
     await waitFor(() => expect(screen.getByText(/フェーズ2/)).toBeInTheDocument());
+  });
+
+  it('rings only the legal cards during an endgame follow turn', async () => {
+    mockExec.mockResolvedValue(endgameFollowState);
+    renderWithProviders(<BeziquePage />);
+    const legal = (await screen.findByAltText('♠ Q')).closest('button');
+    const illegalDiamond = screen.getByAltText('♦ J').closest('button');
+    const illegalHeart = screen.getByAltText('♥ A').closest('button');
+    // ♠Q is the only legal follow → it alone carries the success ring marker.
+    expect(legal).toHaveAttribute('data-legal', 'true');
+    expect(illegalDiamond).not.toHaveAttribute('data-legal');
+    expect(illegalHeart).not.toHaveAttribute('data-legal');
+  });
+
+  it('keeps an illegal card clickable during the endgame (backend still validates)', async () => {
+    mockExec.mockResolvedValue(endgameFollowState);
+    renderWithProviders(<BeziquePage />);
+    const illegal = (await screen.findByAltText('♦ J')).closest('button');
+    // Ring-only highlighting must never block clicks: the card stays enabled.
+    expect(illegal).not.toHaveAttribute('aria-disabled');
+    fireEvent.click(illegal as HTMLElement);
+    expect(illegal).toHaveAttribute('aria-pressed', 'true');
+    mockExec.mockClear();
+    mockExec.mockResolvedValue(endgameFollowState);
+    fireEvent.click(screen.getByRole('button', { name: '出す' }));
+    // ♦J is index 1 in the hand; the play still dispatches so the server can reject it.
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', { cardIndex: 1 }));
+  });
+
+  it('does not ring any card before the endgame (all cards legal)', async () => {
+    renderWithProviders(<BeziquePage />);
+    const card = (await screen.findByAltText('♠ Q')).closest('button');
+    expect(card).not.toHaveAttribute('data-legal');
   });
 
   it('renders the game end message', async () => {

--- a/frontend/src/pages/BeziquePage.tsx
+++ b/frontend/src/pages/BeziquePage.tsx
@@ -27,6 +27,7 @@ import { gameTheme } from '../styles/gameTheme';
 import type { BeziqueMeld, BeziqueResponse } from '../types/card';
 import { BeziquePhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { beziqueEndgameLegalIndices, beziqueSuitDesign } from '../utils/beziqueLegal';
 import { cardLabel } from '../utils/cardUtils';
 import { BEZIQUE_HELP, parseBeziqueCommand } from '../utils/cli/commands/beziqueCommands';
 import { formatBeziqueState } from '../utils/cli/formatters/beziqueFormatter';
@@ -136,6 +137,16 @@ function BeziquePageContent() {
   const canPlay = isHumanPlayTurn;
 
   const trumpSymbol = state.trumpSuit >= 1 && state.trumpSuit <= 4 ? SUIT_SYMBOLS[state.trumpSuit] : t('noTrump');
+
+  // During the endgame (phase 2) the follower must follow suit and win if able.
+  // Ring the legal-to-play cards so the human sees the constraint before playing.
+  // Only meaningful when following a lead: while leading (or before the endgame)
+  // every card is legal, so no highlight is shown. The backend still validates.
+  const leadCard = state.currentTrick[0]?.card ?? null;
+  const legalIndices =
+    isHumanPlayTurn && state.isEndgame && leadCard != null && humanPlayer != null
+      ? beziqueEndgameLegalIndices(humanPlayer.cards, leadCard, beziqueSuitDesign(state.trumpSuit))
+      : undefined;
 
   /** Builds a localized label for one declarable meld. */
   const meldLabel = (m: BeziqueMeld): string => {
@@ -311,6 +322,7 @@ function BeziquePageContent() {
                 isMobile={isMobile}
                 dataTutorialPrefix="bezique"
                 restrictedTooltip={t('playButton')}
+                legalIndices={legalIndices}
               />
             )}
 

--- a/frontend/src/utils/beziqueLegal.test.ts
+++ b/frontend/src/utils/beziqueLegal.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import type { Card } from '../types/card';
+import { beziqueEndgameLegalIndices, beziqueSuitDesign, isBeziqueEndgameLegalPlay } from './beziqueLegal';
+
+const c = (design: Card['design'], value: number): Card => ({ design, value });
+
+describe('beziqueSuitDesign', () => {
+  it('maps the 1-4 ordinals to their design strings', () => {
+    expect(beziqueSuitDesign(1)).toBe('SPADE');
+    expect(beziqueSuitDesign(2)).toBe('CLOVER');
+    expect(beziqueSuitDesign(3)).toBe('HEART');
+    expect(beziqueSuitDesign(4)).toBe('DIAMOND');
+  });
+
+  it('returns null for an out-of-range ordinal (no trump fixed)', () => {
+    expect(beziqueSuitDesign(0)).toBeNull();
+    expect(beziqueSuitDesign(5)).toBeNull();
+  });
+});
+
+describe('isBeziqueEndgameLegalPlay', () => {
+  it('requires following the led suit when the follower holds it', () => {
+    // Hand holds ♠; lead is ♠. Only the ♠ card follows.
+    const hand = [c('SPADE', 12), c('DIAMOND', 11), c('HEART', 1)];
+    const lead = c('SPADE', 13); // ♠K (higher than ♠Q → no in-suit winner)
+    expect(isBeziqueEndgameLegalPlay(hand[0], hand, lead, 'HEART')).toBe(true); // ♠Q follows
+    expect(isBeziqueEndgameLegalPlay(hand[1], hand, lead, 'HEART')).toBe(false); // ♦J off-suit
+    expect(isBeziqueEndgameLegalPlay(hand[2], hand, lead, 'HEART')).toBe(false); // ♥A off-suit
+  });
+
+  it('forces a beating card when the follower can win in the led suit', () => {
+    // Hand holds ♠A and ♠7; lead ♠K. Only ♠A beats ♠K, so ♠7 is illegal.
+    const hand = [c('SPADE', 1), c('SPADE', 7), c('DIAMOND', 11)];
+    const lead = c('SPADE', 13);
+    expect(isBeziqueEndgameLegalPlay(hand[0], hand, lead, 'HEART')).toBe(true); // ♠A beats ♠K
+    expect(isBeziqueEndgameLegalPlay(hand[1], hand, lead, 'HEART')).toBe(false); // ♠7 cannot beat
+  });
+
+  it('allows any in-suit card when none can beat the lead', () => {
+    // Hand holds ♠Q and ♠7; lead ♠A (unbeatable). Both ♠ cards are legal.
+    const hand = [c('SPADE', 12), c('SPADE', 7)];
+    const lead = c('SPADE', 1);
+    expect(isBeziqueEndgameLegalPlay(hand[0], hand, lead, 'HEART')).toBe(true);
+    expect(isBeziqueEndgameLegalPlay(hand[1], hand, lead, 'HEART')).toBe(true);
+  });
+
+  it('requires trumping when void in the led suit but holding trump', () => {
+    // Void in ♠ (lead), holds ♥ (trump). Must play a trump.
+    const hand = [c('HEART', 7), c('DIAMOND', 11)];
+    const lead = c('SPADE', 13);
+    expect(isBeziqueEndgameLegalPlay(hand[0], hand, lead, 'HEART')).toBe(true); // ♥ trump
+    expect(isBeziqueEndgameLegalPlay(hand[1], hand, lead, 'HEART')).toBe(false); // ♦ neither
+  });
+
+  it('allows any card when void in both the led suit and trump', () => {
+    const hand = [c('DIAMOND', 11), c('CLOVER', 12)];
+    const lead = c('SPADE', 13);
+    expect(isBeziqueEndgameLegalPlay(hand[0], hand, lead, 'HEART')).toBe(true);
+    expect(isBeziqueEndgameLegalPlay(hand[1], hand, lead, 'HEART')).toBe(true);
+  });
+
+  it('a higher trump must overtrump a trump lead', () => {
+    // Lead is a trump ♥10; hand holds ♥A (beats) and ♥7 (loses). Must overtrump.
+    const hand = [c('HEART', 1), c('HEART', 7)];
+    const lead = c('HEART', 10);
+    expect(isBeziqueEndgameLegalPlay(hand[0], hand, lead, 'HEART')).toBe(true); // ♥A > ♥10
+    expect(isBeziqueEndgameLegalPlay(hand[1], hand, lead, 'HEART')).toBe(false); // ♥7 < ♥10
+  });
+});
+
+describe('beziqueEndgameLegalIndices', () => {
+  it('returns only the legal indices for the follower', () => {
+    const hand = [c('SPADE', 12), c('DIAMOND', 11), c('HEART', 1)];
+    const lead = c('SPADE', 13);
+    expect(beziqueEndgameLegalIndices(hand, lead, 'HEART')).toEqual([0]);
+  });
+
+  it('returns every index when void in both led suit and trump', () => {
+    const hand = [c('DIAMOND', 11), c('CLOVER', 12)];
+    const lead = c('SPADE', 13);
+    expect(beziqueEndgameLegalIndices(hand, lead, 'HEART')).toEqual([0, 1]);
+  });
+});

--- a/frontend/src/utils/beziqueLegal.ts
+++ b/frontend/src/utils/beziqueLegal.ts
@@ -1,0 +1,120 @@
+import type { Card, CardDesign } from '../types/card';
+
+/**
+ * Maps a Bezique trump-suit ordinal (1=♠ 2=♣ 3=♥ 4=♦ — the domain's
+ * `CardDesign` constants in `internal/domain/Card.go`) to the card `design`
+ * string sent on the wire. Returns `null` for an out-of-range ordinal (e.g. 0
+ * before a trump has been fixed), which callers treat as "no trump".
+ *
+ * @param suit - The trump-suit ordinal from `BeziqueResponse.trumpSuit`.
+ * @returns The matching `CardDesign`, or `null` when the ordinal is not 1-4.
+ */
+export function beziqueSuitDesign(suit: number): CardDesign | null {
+  switch (suit) {
+    case 1:
+      return 'SPADE';
+    case 2:
+      return 'CLOVER';
+    case 3:
+      return 'HEART';
+    case 4:
+      return 'DIAMOND';
+    default:
+      return null;
+  }
+}
+
+/**
+ * In-suit rank strength (higher beats lower): A > 10 > K > Q > J > 9 > 8 > 7.
+ * Mirrors `BeziqueRankOrder` in `internal/domain/Bezique.go`.
+ *
+ * @param value - The card's numeric value (1=A, 11=J, 12=Q, 13=K).
+ * @returns A comparable strength score within a suit.
+ */
+function beziqueRank(value: number): number {
+  switch (value) {
+    case 1:
+      return 8; // A
+    case 10:
+      return 7;
+    case 13:
+      return 6; // K
+    case 12:
+      return 5; // Q
+    case 11:
+      return 4; // J
+    default:
+      return value - 6; // 9→3, 8→2, 7→1
+  }
+}
+
+/**
+ * Whether `challenger` beats `currentBest` given the led suit and trump suit.
+ * Mirrors `beziqueBeats` in `internal/domain/Bezique.go`: any trump beats any
+ * non-trump, a non-lead non-trump card cannot win, and an exact tie is kept by
+ * the earlier (led) card.
+ *
+ * @param challenger - The candidate card.
+ * @param currentBest - The card currently winning the trick (the lead card).
+ * @param leadSuit - The suit that was led.
+ * @param trump - The trump suit design, or `null` when there is no trump.
+ * @returns `true` when `challenger` would win over `currentBest`.
+ */
+function beziqueBeats(challenger: Card, currentBest: Card, leadSuit: CardDesign, trump: CardDesign | null): boolean {
+  const cTrump = challenger.design === trump;
+  const bTrump = currentBest.design === trump;
+  if (cTrump && bTrump) return beziqueRank(challenger.value) > beziqueRank(currentBest.value);
+  if (cTrump) return true;
+  if (bTrump) return false;
+  if (challenger.design !== leadSuit) return false;
+  if (currentBest.design !== leadSuit) return true;
+  return beziqueRank(challenger.value) > beziqueRank(currentBest.value);
+}
+
+/**
+ * Whether `card` may be legally played by the follower during the Bezique
+ * endgame (phase 2), when strict follow-suit + win-if-able rules apply. Mirrors
+ * `Bezique.cardSatisfiesFollow` in `internal/domain/Bezique.go`:
+ *
+ * - Holding the led suit: the card must follow it, and if the hand can beat the
+ *   lead in that suit the card must be one that beats it.
+ * - Void in the led suit but holding trump: the card must be a trump.
+ * - Void in both: any card is legal.
+ *
+ * This governs only the follower (a non-empty trick); the leader may play any
+ * card, so callers should skip this check when leading.
+ *
+ * @param card - The candidate card from the follower's hand.
+ * @param hand - The follower's full hand.
+ * @param leadCard - The opponent's led card (the first card in the trick).
+ * @param trump - The trump suit design, or `null` when there is no trump.
+ * @returns `true` when the card satisfies the endgame follow rule.
+ */
+export function isBeziqueEndgameLegalPlay(card: Card, hand: Card[], leadCard: Card, trump: CardDesign | null): boolean {
+  const leadSuit = leadCard.design;
+  if (hand.some((c) => c.design === leadSuit)) {
+    if (card.design !== leadSuit) return false;
+    const hasWinner = hand.some((c) => c.design === leadSuit && beziqueBeats(c, leadCard, leadSuit, trump));
+    return hasWinner ? beziqueBeats(card, leadCard, leadSuit, trump) : true;
+  }
+  if (trump != null && hand.some((c) => c.design === trump)) {
+    return card.design === trump;
+  }
+  return true;
+}
+
+/**
+ * Indices of the follower's hand cards that are legal to play during the
+ * Bezique endgame, for highlighting. See {@link isBeziqueEndgameLegalPlay}.
+ *
+ * @param hand - The follower's full hand.
+ * @param leadCard - The opponent's led card (the first card in the trick).
+ * @param trump - The trump suit design, or `null` when there is no trump.
+ * @returns The legal-to-play indices into `hand`.
+ */
+export function beziqueEndgameLegalIndices(hand: Card[], leadCard: Card, trump: CardDesign | null): number[] {
+  return hand.reduce<number[]>((acc, card, idx) => {
+    if (isBeziqueEndgameLegalPlay(card, hand, leadCard, trump)) acc.push(idx);
+    return acc;
+  }, []);
+}


### PR DESCRIPTION
## 概要

ベジークのエンドゲーム（フェーズ2＝山札切れ後のマストフォロー）で、人間プレイヤーが追随する際に「出せる（合法な）カード」を加算的なリング（`ring-ds-success`）でハイライトします。従来はエンドゲームでも全カードが同じ見た目で、違反カードを出してから API エラーで気付く体験でした。

## 実装方針（フロントエンドのみ・加算表示）

- `PlayerHandSection` の **加算専用 `legalIndices` prop** を利用（リングを重ねるだけ）。`validIndices`/`restrictedTooltip` は**使わず**、クリックは一切ブロックしません。バックエンドが引き続き検証します。
- 合法手はレスポンス（リードカード・切り札・手札）からフロントで算出。純関数 `frontend/src/utils/beziqueLegal.ts` が `internal/domain/Bezique.go` の `cardSatisfiesFollow` / `beziqueBeats` / `BeziqueRankOrder` を忠実に再現します（同スート保持なら追随＋勝てるなら勝つ、なければ切り札、両方無ければ任意）。
- ハイライトは **エンドゲーム中に追随するとき（`isEndgame` かつ場にリードカードがある）** のみ表示。リード時やフェーズ1では全カードが合法なのでハイライトしません。
- バックエンド（Go）は変更なし。

## テスト

- `frontend/src/utils/beziqueLegal.test.ts`: 追随・勝つ義務・切り札強制・両方ボイド・オーバートランプ等の純関数テスト。
- `frontend/src/pages/BeziquePage.test.tsx`:
  - `rings only the legal cards during an endgame follow turn`
  - `keeps an illegal card clickable during the endgame (backend still validates)`（違反カードが `aria-disabled` にならずクリック→`play` が dispatch されることを検証）
  - `does not ring any card before the endgame (all cards legal)`

## ゲート

- `bun run check`（biome + デザイントークン検証）: OK
- `bun run test -- --run BeziquePage` および helper: 26 passed
- `bun run build`（tsc）: OK

## 受け入れ条件

- [x] エンドゲーム中、合法カードのみハイライトされる
- [x] 山札がある間（＝エンドゲーム前・リード時）はハイライトなし＝全カード有効扱い
- [x] リングのみの加算表示・クリックはブロックしない（違反カードもクリック可、バックエンド検証維持）
- [x] フロントのテストを追加
- [x] デザイントークン（`ring-ds-success`）を使用

注: 本 PR は present data からの軽量なリング表示のみで、issue 記載の WebPresenter/型拡張は行いません（バックエンド変更なしで要件を満たすため）。

Closes #3451
