### PR TITLE
feat(streetsandalleys): show keyboard shortcut badges on control buttons

### DIFF
--- a/frontend/src/i18n/locales/en/streetsandalleys.json
+++ b/frontend/src/i18n/locales/en/streetsandalleys.json
@@ -37,5 +37,11 @@
   "hintReason": {
     "toFoundation": "Send this card to the foundation to free up the column.",
     "toTableau": "Apply the suggested tableau move to unlock buried cards."
+  },
+  "kbd": {
+    "undo": "Z",
+    "hint": "H",
+    "autoComplete": "A",
+    "giveUp": "G"
   }
 }

--- a/frontend/src/i18n/locales/ja/streetsandalleys.json
+++ b/frontend/src/i18n/locales/ja/streetsandalleys.json
@@ -37,5 +37,11 @@
   "hintReason": {
     "toFoundation": "このカードを組札に上げると後の展開が楽になります",
     "toTableau": "示唆された場札への移動でロックされたカードを動かしましょう"
+  },
+  "kbd": {
+    "undo": "Z",
+    "hint": "H",
+    "autoComplete": "A",
+    "giveUp": "G"
   }
 }

--- a/frontend/src/pages/StreetsAndAlleysPage.test.tsx
+++ b/frontend/src/pages/StreetsAndAlleysPage.test.tsx
@@ -154,6 +154,24 @@ describe('StreetsAndAlleysPage', () => {
     await waitFor(() => expect(screen.getByRole('button', { name: 'ギブアップ' })).toBeInTheDocument());
   });
 
+  it('advertises the keyboard shortcuts on the control buttons', async () => {
+    mockExec.mockResolvedValue(playingState);
+    renderWithProviders(<StreetsAndAlleysPage />);
+    const undo = await screen.findByRole('button', { name: '元に戻す' });
+    expect(undo).toHaveAttribute('aria-keyshortcuts', 'z');
+    expect(undo.querySelector('kbd')?.textContent).toBe('Z');
+    const hint = screen.getByRole('button', { name: 'ヒント' });
+    expect(hint).toHaveAttribute('aria-keyshortcuts', 'h');
+    expect(hint.querySelector('kbd')?.textContent).toBe('H');
+    const autoComplete = screen.getByRole('button', { name: '自動完成' });
+    expect(autoComplete).toHaveAttribute('aria-keyshortcuts', 'a');
+    expect(autoComplete.querySelector('kbd')?.textContent).toBe('A');
+    // KbdBadge text is aria-hidden, so the giveup button's accessible name stays clean.
+    const giveUp = screen.getByRole('button', { name: 'ギブアップ' });
+    expect(giveUp).toHaveAttribute('aria-keyshortcuts', 'g');
+    expect(giveUp.querySelector('kbd')?.textContent).toBe('G');
+  });
+
   it('hides giveup button when game cleared', async () => {
     mockExec.mockResolvedValue(gameClearState);
     renderWithProviders(<StreetsAndAlleysPage />);

--- a/frontend/src/pages/StreetsAndAlleysPage.tsx
+++ b/frontend/src/pages/StreetsAndAlleysPage.tsx
@@ -11,6 +11,7 @@ import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
 import { HintTooltip } from '../components/hint/HintTooltip';
+import { KbdBadge } from '../components/KbdBadge';
 import { LandscapeBanner } from '../components/LandscapeBanner';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { StalemateEscapeButton } from '../components/StalemateEscapeButton';
@@ -430,8 +431,10 @@ function StreetsAndAlleysPageContent() {
                     className={btnPrimary}
                     onClick={game.handleUndo}
                     disabled={loading || isAutoCompleting || !state.canUndo}
+                    aria-keyshortcuts="z"
                   >
                     {t('undo')}
+                    <KbdBadge label={t('kbd.undo')} />
                   </button>
                   {state.isStalemate && (
                     <StalemateEscapeButton
@@ -445,8 +448,10 @@ function StreetsAndAlleysPageContent() {
                     className={btnSuccess}
                     onClick={game.handleHint}
                     disabled={loading || isAutoCompleting}
+                    aria-keyshortcuts="h"
                   >
                     {t('hint')}
+                    <KbdBadge label={t('kbd.hint')} />
                   </button>
                   <button
                     type="button"
@@ -455,16 +460,20 @@ function StreetsAndAlleysPageContent() {
                     disabled={loading || isAutoCompleting || !autoCompleteReady}
                     data-testid="autocomplete-button"
                     title={autoCompleteReady ? undefined : t('autoCompleteNotReady')}
+                    aria-keyshortcuts="a"
                   >
                     {t('autoComplete')}
+                    <KbdBadge label={t('kbd.autoComplete')} />
                   </button>
                   <button
                     type="button"
                     className={btnDanger}
                     onClick={confirmGiveUpAction}
                     disabled={loading || isAutoCompleting}
+                    aria-keyshortcuts="g"
                   >
                     {t('giveup')}
+                    <KbdBadge label={t('kbd.giveUp')} />
                   </button>
                 </div>
               )}


### PR DESCRIPTION
## 概要
ストリート・アンド・アレイズのプレイ中に有効なキーボードショートカット（`useActionKeyboardNav` に登録済み）がUI上に表示されておらず、プレイヤーが発見できない問題を解消する。`GameFooter` 内のコントロールボタン群（`data-tutorial="sa-controls"`）の各ボタンに、対応キーの `KbdBadge` チップと `aria-keyshortcuts` を併記した。

既存の `BakersDozenPage` と同一パターン（`KbdBadge` + `aria-keyshortcuts`）を踏襲。

## 追加したショートカット表記
| ボタン | キー |
|--------|------|
| 元に戻す (undo) | `Z` |
| ヒント (hint) | `H` |
| 自動完成 (autoComplete) | `A` |
| ギブアップ (giveup) | `G` |

## 変更内容
- `StreetsAndAlleysPage.tsx`: 4つのコントロールボタンに `aria-keyshortcuts` と `<KbdBadge>` を追加
- `i18n/locales/{ja,en}/streetsandalleys.json`: `kbd` キー（undo/hint/autoComplete/giveUp）を日英キー同一で追加
- `StreetsAndAlleysPage.test.tsx`: 各ボタンの `aria-keyshortcuts` と `kbd` チップ表記を検証するテストを追加

## 受け入れ条件
- [x] 主要操作ボタンにキーボードショートカットの表記が追加される
- [x] 既存のボタン機能・スタイルを破壊しない
- [x] i18nキーを用いて日英両対応する
- [x] コンポーネントテストで表記の存在を検証する

## テスト
- `bun run check`（biome + design-token validator）: pass
- `bun run test -- --run StreetsAndAlleysPage`: 18 passed（新規 `advertises the keyboard shortcuts on the control buttons` を含む）
- `bun run build`: pass

Closes #3278