### PR TITLE
feat(oldmaid): highlight where a drawn card lands in the human hand

### DIFF
--- a/frontend/src/components/oldmaid/OldMaidPlayerArea.tsx
+++ b/frontend/src/components/oldmaid/OldMaidPlayerArea.tsx
@@ -29,6 +29,13 @@ interface PlayerAreaProps {
   onToggleSuspect?: () => void;
   onDraw: (drawIdx: number) => void;
   onReorder?: (indices: number[]) => void;
+  /**
+   * Index of the card the human just drew into this hand. When >= 0, that card
+   * is briefly ring-highlighted so the player can track where it landed
+   * (issue #2984). Animation is gated behind `motion-safe` for reduced-motion
+   * users. Ignored for non-human areas.
+   */
+  drawnCardIdx?: number;
   /** When true, non-target CPU players hide card back images to save space. */
   compactNonTarget?: boolean;
   /**
@@ -50,6 +57,7 @@ export function OldMaidPlayerArea({
   onToggleSuspect,
   onDraw,
   onReorder,
+  drawnCardIdx = -1,
   compactNonTarget,
   bubble,
 }: PlayerAreaProps) {
@@ -187,22 +195,31 @@ export function OldMaidPlayerArea({
       >
         {player.isFinished ? null : player.isHuman ? (
           player.cards?.map((card, i) => {
+            const isDrawnHere = i === drawnCardIdx;
             if (!onReorder) {
               return (
                 <CardImage
                   key={`${card.design}-${card.value}`}
                   card={card}
                   width={cardWidth}
-                  className={focusedCardIdx === i ? 'ring-2 ring-ds-info' : undefined}
+                  className={
+                    isDrawnHere
+                      ? 'ring-2 ring-ds-accent motion-safe:animate-pulse'
+                      : focusedCardIdx === i
+                        ? 'ring-2 ring-ds-info'
+                        : undefined
+                  }
                 />
               );
             }
             const isSelectedForMove = selectedForMove === i;
             const ringClass = isSelectedForMove
               ? 'ring-2 ring-ds-warning -translate-y-2'
-              : focusedCardIdx === i
-                ? 'ring-2 ring-ds-info'
-                : '';
+              : isDrawnHere
+                ? 'ring-2 ring-ds-accent motion-safe:animate-pulse'
+                : focusedCardIdx === i
+                  ? 'ring-2 ring-ds-info'
+                  : '';
             const tapAriaLabel = (() => {
               if (selectedForMove === null) {
                 return t('reorder.selectCardToMove', { card: cardAlt(card) });
@@ -222,6 +239,7 @@ export function OldMaidPlayerArea({
                 onClick={() => handleCardTap(i)}
                 aria-pressed={isSelectedForMove}
                 aria-label={tapAriaLabel}
+                data-drawn-highlight={isDrawnHere ? 'true' : undefined}
                 className={`bg-transparent p-0 border-0 cursor-pointer leading-none transition-transform ${ringClass}`}
                 draggable={!gameEndFlag}
                 onDragStart={(e: React.DragEvent) => {

--- a/frontend/src/pages/OldMaidPage.test.tsx
+++ b/frontend/src/pages/OldMaidPage.test.tsx
@@ -1345,4 +1345,57 @@ describe('OldMaidPage', () => {
     await startGame();
     await waitFor(() => expect(screen.getByTestId('phase-indicator')).toHaveTextContent('終了'));
   });
+
+  // -- Drawn-card landing highlight (issue #2984) --
+
+  it('ring-highlights the position where the human just drew a card', async () => {
+    // Human (id 0) drew HEART-2, which now sits at index 1 of their hand.
+    mockExec.mockResolvedValue({
+      ...humanTurnState,
+      hasDrawn: true,
+      lastDrawPlayerIdx: 0,
+      lastDrawFromIdx: 1,
+      lastDrawCard: { design: 'HEART', value: 2 },
+    });
+    await startGame();
+    const container = await screen.findByTestId('human-card-container');
+    const highlighted = within(container)
+      .getAllByRole('button')
+      .filter((b) => b.dataset.drawnHighlight === 'true');
+    expect(highlighted).toHaveLength(1);
+    // Second card (index 1) is the drawn HEART-2.
+    expect(within(container).getAllByRole('button')[1]).toBe(highlighted[0]);
+    // Animation is gated behind motion-safe so reduced-motion users get no pulse.
+    expect(highlighted[0].className).toContain('ring-ds-accent');
+    expect(highlighted[0].className).toContain('motion-safe:animate-pulse');
+  });
+
+  it('does not highlight when a CPU drew from another player', async () => {
+    // CPU 1 drew from CPU 2 (no human involvement): nothing to highlight.
+    mockExec.mockResolvedValue(cpuTurnState);
+    await startGame();
+    const container = await screen.findByTestId('human-card-container');
+    const highlighted = within(container)
+      .getAllByRole('button')
+      .filter((b) => b.dataset.drawnHighlight === 'true');
+    expect(highlighted).toHaveLength(0);
+  });
+
+  it('does not highlight when the human draw was discarded as a pair', async () => {
+    // Human drew a card not present in their hand (it paired off and was discarded).
+    mockExec.mockResolvedValue({
+      ...humanTurnState,
+      hasDrawn: true,
+      lastDrawPlayerIdx: 0,
+      lastDrawFromIdx: 1,
+      lastDrawCard: { design: 'CLOVER', value: 9 },
+      lastDiscardedPairs: 1,
+    });
+    await startGame();
+    const container = await screen.findByTestId('human-card-container');
+    const highlighted = within(container)
+      .getAllByRole('button')
+      .filter((b) => b.dataset.drawnHighlight === 'true');
+    expect(highlighted).toHaveLength(0);
+  });
 });

--- a/frontend/src/pages/OldMaidPage.tsx
+++ b/frontend/src/pages/OldMaidPage.tsx
@@ -172,6 +172,16 @@ function OldMaidPageContent() {
   const cpuPlayers = state.players.filter((p) => !p.isHuman);
   const humanPlayer = state.players.find((p) => p.isHuman);
 
+  // When the human just drew a card into their own hand, locate where it landed
+  // so the footer hand can briefly ring-highlight that position (issue #2984).
+  // Returns -1 when the card was immediately discarded as a pair (not in hand),
+  // when the drawer was not the human, or at game end.
+  const drawnCard = state.lastDrawCard;
+  const humanDrawnCardIdx =
+    humanPlayer && drawnCard && !state.gameEndFlag && state.hasDrawn && state.lastDrawPlayerIdx === humanPlayer.id
+      ? (humanPlayer.cards ?? []).findIndex((c) => c.design === drawnCard.design && c.value === drawnCard.value)
+      : -1;
+
   const statusLines: string[] = [];
   if (!state.gameEndFlag && state.hasDrawn) {
     const from = findPlayerName(state.players, state.lastDrawPlayerIdx);
@@ -366,6 +376,7 @@ function OldMaidPageContent() {
                   gameEndFlag={state.gameEndFlag}
                   loading={loading}
                   highlightedCardIdx={-1}
+                  drawnCardIdx={humanDrawnCardIdx}
                   onDraw={(drawIdx) => gameExec('draw', drawIdx)}
                   onReorder={handleReorder}
                 />


### PR DESCRIPTION
## 概要

ババ抜き（Old Maid）で、自分（人間）が相手から札を引いて自分の手札に加わったとき、その札が手札のどの位置に入ったかを一瞬リングでハイライトし、追跡しやすくする。純粋な追加表示でクリックを妨げない。

`state.lastDrawPlayerIdx === human.id` かつ `state.lastDrawCard` が手札内に存在する場合のみ、フッターの手札の該当位置に `ring-ds-accent` + `motion-safe:animate-pulse` を付与する（既存状態のみ利用、バックエンド変更なし）。

## 受け入れ条件

- [x] 人間が相手から引いて自分の手札に入ったとき、その位置に視覚フィードバックが出る
- [x] `prefers-reduced-motion` 環境ではアニメーション（pulse）を抑制する（`motion-safe:` で制御、リング自体は静的表示）
- [x] 他プレイヤー間の引き（人間が引き手でない）では表示されない
- [x] 引いた札がペアで即捨てられて手札に無い場合は表示されない
- [x] ユニットテストを追加（`OldMaidPage.test.tsx`）

## 補足

issue本文はCPUが人間から「抜いた」位置の表示も挙げていますが、抜かれた後の位置は現状態からは特定不能（札は既に手札から消えている）なため、現状態から一意に特定できる「人間が引いた札の着地位置」を軽量な追加表示として実装しました。デザイントークン（`ring-ds-accent`）のみ使用。

## テスト

- `bun run check`（biome + design-token 検証）: OK
- `bun run test -- --run OldMaidPage`: 103 passed（新規3件含む）
- `bun run build`（tsc + vite）: OK

新規テスト:
- `ring-highlights the position where the human just drew a card`
- `does not highlight when a CPU drew from another player`
- `does not highlight when the human draw was discarded as a pair`

Closes #2984
