### PR TITLE
feat(kemps): emphasize the Kemps call button on four of a kind

### DIFF
--- a/frontend/src/i18n/locales/en/kemps.json
+++ b/frontend/src/i18n/locales/en/kemps.json
@@ -24,6 +24,7 @@
   },
   "partnerSignaling": "Your partner is signaling! Declare Kemps!",
   "opponentSignaling": "Someone on the opposing team may be signaling…",
+  "fourOfAKindReady": "You have four of a kind! You can declare Kemps!",
   "kempsButton": "Kemps!",
   "counterButton": "Counter-Kemps! ({{name}})",
   "declineButton": "Decline",

--- a/frontend/src/i18n/locales/ja/kemps.json
+++ b/frontend/src/i18n/locales/ja/kemps.json
@@ -24,6 +24,7 @@
   },
   "partnerSignaling": "パートナーが合図を送っています！「ケムプス！」を宣言しましょう。",
   "opponentSignaling": "相手チームの誰かが合図しているかもしれません…。",
+  "fourOfAKindReady": "フォーオブアカインドが成立しました！「ケムプス！」を宣言できます。",
   "kempsButton": "ケムプス！",
   "counterButton": "カウンター・ケムプス！（{{name}}）",
   "declineButton": "宣言しない",

--- a/frontend/src/pages/KempsPage.test.tsx
+++ b/frontend/src/pages/KempsPage.test.tsx
@@ -177,6 +177,80 @@ describe('KempsPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('kemps'));
   });
 
+  it('emphasizes the Kemps button and announces readiness when the human holds four of a kind', async () => {
+    // Human holds four of a kind and the declare window is open.
+    mockExec.mockResolvedValue(
+      makeState({
+        phase: 1,
+        isHumanTurn: false,
+        fourHolderIdx: 0,
+        players: [
+          makePlayer({
+            name: 'You',
+            isHuman: true,
+            team: 0,
+            hasFourOfAKind: true,
+            hand: [
+              { design: 'SPADE', value: 7 },
+              { design: 'HEART', value: 7 },
+              { design: 'CLOVER', value: 7 },
+              { design: 'DIAMOND', value: 7 },
+            ],
+          }),
+          makePlayer({ team: 1 }),
+          makePlayer({ team: 0 }),
+          makePlayer({ team: 1 }),
+        ],
+      }),
+    );
+    renderWithProviders(<KempsPage />);
+    const btn = await screen.findByTestId('kemps-declare-button');
+    expect(btn).toHaveAttribute('data-emphasized', 'true');
+    expect(btn.className).toContain('ring-ds-success');
+    expect(btn.className).toContain('animate-pulse');
+    // The readiness is announced in a live region.
+    const ready = screen.getByTestId('kemps-four-ready');
+    expect(ready).toHaveAttribute('role', 'status');
+    expect(ready).toHaveAttribute('aria-live', 'polite');
+  });
+
+  it('does not emphasize the Kemps button when the human lacks four of a kind', async () => {
+    // declareState keeps the human without four of a kind (partner holds it).
+    mockExec.mockResolvedValue(declareState);
+    renderWithProviders(<KempsPage />);
+    const btn = await screen.findByTestId('kemps-declare-button');
+    expect(btn).toHaveAttribute('data-emphasized', 'false');
+    expect(btn.className).not.toContain('ring-ds-success');
+    expect(screen.queryByTestId('kemps-four-ready')).not.toBeInTheDocument();
+  });
+
+  it('announces four-of-a-kind readiness during the exchange phase', async () => {
+    // Emphasis notice appears even before the declare window opens.
+    mockExec.mockResolvedValue(
+      makeState({
+        players: [
+          makePlayer({
+            name: 'You',
+            isHuman: true,
+            team: 0,
+            hasFourOfAKind: true,
+            hand: [
+              { design: 'SPADE', value: 9 },
+              { design: 'HEART', value: 9 },
+              { design: 'CLOVER', value: 9 },
+              { design: 'DIAMOND', value: 9 },
+            ],
+          }),
+          makePlayer({ team: 1 }),
+          makePlayer({ team: 0 }),
+          makePlayer({ team: 1 }),
+        ],
+      }),
+    );
+    renderWithProviders(<KempsPage />);
+    expect(await screen.findByTestId('kemps-four-ready')).toBeInTheDocument();
+  });
+
   it('dispatches counter against an opponent seat', async () => {
     mockExec.mockResolvedValue(declareState);
     renderWithProviders(<KempsPage />);

--- a/frontend/src/pages/KempsPage.tsx
+++ b/frontend/src/pages/KempsPage.tsx
@@ -144,6 +144,11 @@ function KempsPageContent() {
     return <GameSkeleton gameKey="kemps" layout={{ kind: 'trick-taking', trickArea: true, footerHandSize: 4 }} />;
 
   const humanPlayer = state.players.find((p) => p.isHuman);
+  // The backend flags four-of-a-kind for the human only; when set, the Kemps
+  // call button is emphasised so the player does not miss the declare chance
+  // while focused on field swaps (#3553). The flag clears the moment a swap
+  // breaks the quad, so the emphasis follows the current hand automatically.
+  const humanHasFour = !!humanPlayer?.hasFourOfAKind;
   const isExchange = state.phase === KempsPhase.EXCHANGE;
   const isDeclare = state.phase === KempsPhase.DECLARE;
   const isRoundEnd = state.phase === KempsPhase.ROUND_END;
@@ -304,6 +309,19 @@ function KempsPageContent() {
               </div>
             )}
 
+            {/* Four-of-a-kind readiness — announced (and shown during EXCHANGE)
+                so the human notices the quad before the declare window. */}
+            {humanHasFour && !isGameEnd && (
+              <div
+                className="my-2 p-2 rounded bg-ds-success/20 text-ds-success text-sm font-semibold"
+                role="status"
+                aria-live="polite"
+                data-testid="kemps-four-ready"
+              >
+                {t('fourOfAKindReady')}
+              </div>
+            )}
+
             <GameMessageBox
               message={state.message}
               messageCode={state.messageCode}
@@ -387,7 +405,14 @@ function KempsPageContent() {
 
               {isDeclare && !isGameEnd && (
                 <>
-                  <button type="button" className={btnWarning} onClick={() => exec('kemps')} disabled={loading}>
+                  <button
+                    type="button"
+                    className={`${btnWarning}${humanHasFour ? ' ring-2 ring-ds-success motion-safe:animate-pulse' : ''}`}
+                    onClick={() => exec('kemps')}
+                    disabled={loading}
+                    data-testid="kemps-declare-button"
+                    data-emphasized={humanHasFour ? 'true' : 'false'}
+                  >
                     {t('kempsButton')}
                   </button>
                   {opponentSeats.map(({ p, idx }) => (


### PR DESCRIPTION
## 概要
Kemps で人間プレイヤーがフォーオブアカインド（`hasFourOfAKind`）を保持しているとき、DECLARE フェーズの「ケムプス！」ボタンを強調し、成立を `role="status"` のライブリージョンで通知します。フィールド交換に集中していて宣言チャンスを見落とす問題を解消します。ChinchonPage の `canKnockNow` によるノック強調（ring + pulse）と同じ確立パターンです。

## 変更内容
- `hasFourOfAKind`（バックエンドが人間のみに付与）が true のとき、kempsButton に `ring-2 ring-ds-success motion-safe:animate-pulse` を付与（デザイントークンのみ）
- 成立時に `role="status"` の通知行を表示（EXCHANGE 中も表示して早めに気付けるように）
- 交換で成立が崩れると `hasFourOfAKind` が false になり強調・通知は自動的に消える（追加ロジック不要）
- i18n キー `fourOfAKindReady` を ja/en 両方に追加
- `data-emphasized` / `data-testid="kemps-declare-button"` / `data-testid="kemps-four-ready"` を追加

## 受け入れ条件
- [x] 4 枚成立時に Kemps ボタンが強調される
- [x] 成立解除（交換で崩れた）時に強調が消える
- [x] role="status" で成立が読み上げられる
- [x] ページテストで強調の有無を検証

## テスト
- `bun run check`（biome + design-token 検証）: OK（design-tokens OK、既存の無関係な警告のみ）
- `bun run test -- --run KempsPage`: 21 passed
- `bun run build`（tsc）: OK

Closes #3553
