### PR TITLE
feat(scorpion): surface deal-blocked reason as visible aria-live text

### DIFF
--- a/frontend/src/pages/ScorpionPage.test.tsx
+++ b/frontend/src/pages/ScorpionPage.test.tsx
@@ -185,6 +185,33 @@ describe('ScorpionPage', () => {
     expect(screen.getByRole('button', { name: '配る' })).toHaveAttribute('title', '空の列をすべて埋めないと配れません');
   });
 
+  it('shows the deal-blocked reason as visible text when an empty column exists', async () => {
+    const stateWithEmptyCol: ScorpionResponse = {
+      ...playingState,
+      tableau: [
+        [{ card: card('SPADE', 13), faceUp: true }],
+        [],
+        [{ card: card('CLOVER', 5), faceUp: true }],
+        [{ card: card('DIAMOND', 10), faceUp: true }],
+        [{ card: card('SPADE', 3), faceUp: true }],
+        [{ card: card('HEART', 7), faceUp: true }],
+        [{ card: card('CLOVER', 2), faceUp: true }],
+      ],
+    };
+    mockExec.mockResolvedValue(stateWithEmptyCol);
+    renderWithProviders(<ScorpionPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: '配る' })).toBeInTheDocument());
+    const reason = screen.getByTestId('sc-deal-blocked-reason');
+    expect(reason).toHaveTextContent('空の列をすべて埋めないと配れません');
+    expect(reason).toHaveAttribute('role', 'status');
+  });
+
+  it('does not show the deal-blocked reason when every column is filled', async () => {
+    renderWithProviders(<ScorpionPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    expect(screen.queryByTestId('sc-deal-blocked-reason')).not.toBeInTheDocument();
+  });
+
   it('autocomplete button triggers autocomplete command', async () => {
     renderWithProviders(<ScorpionPage />);
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));

--- a/frontend/src/pages/ScorpionPage.tsx
+++ b/frontend/src/pages/ScorpionPage.tsx
@@ -506,6 +506,19 @@ function ScorpionPageContent() {
               <HintTooltip reason={t(frontendHint.reason)} confidence={frontendHint.confidence} />
             )}
 
+            {/* Deal-blocked reason as visible, screen-reader-announced text — the
+                native `title` tooltip alone is invisible on touch devices (#3186). */}
+            {isPlaying && dealBlockedByEmpty && (
+              <div
+                className="text-sm text-ds-warning bg-ds-surface/90 border border-ds-warning rounded px-3 py-1.5 mt-1"
+                role="status"
+                aria-live="polite"
+                data-testid="sc-deal-blocked-reason"
+              >
+                {t('cannotDealEmptyColExists')}
+              </div>
+            )}
+
             <ActionLogSection
               isEndPhase={isEnded}
               actionLog={actionLog}


### PR DESCRIPTION
## 概要

スコーピオンの山札配布ガードは、配布不可の理由を配布ボタンの `title` 属性（ネイティブツールチップ）でのみ提示していた。`title` はマウスホバー時にしか表示されないため、タッチデバイスやスクリーンリーダーの利用者には理由が伝わらなかった (#3186)。

配布不可時に `role="status"` + `aria-live="polite"` の可視ヘルパー行を追加し、`cannotDealEmptyColExists`（既存 i18n キー、ja/en 両方に既存）をテキストで明示する。既存のシェイクアニメーションと `title` ツールチップはそのまま維持。

## 変更点

- `ScorpionPage.tsx`: 配布不可（`isPlaying && dealBlockedByEmpty`）のとき、理由を可視テキストで表示する `role="status"` ヘルパー行を追加（`data-testid="sc-deal-blocked-reason"`、色は ds トークンのみ使用）
- `ScorpionPage.test.tsx`: 空列がある時に理由テキストが表示されること／全列が埋まっている時は表示されないことを検証するテストを追加

## 受け入れ条件

- [x] タッチデバイスでも配布不可の理由がテキストで確認できる（可視 `role="status"` テキスト）
- [x] 既存のシェイクアニメーションは維持する
- [x] `ScorpionPage.test.tsx` にメッセージ表示のテストを追加

## 検証

- `bun run test -- --run ScorpionPage` → 42 passed
- `bun run check` → exit 0（design-tokens OK）
- `bun run build` → exit 0

Closes #3186