### PR TITLE
feat(calculation): show foundation upcoming ranks in a tappable details

### DIFF
--- a/frontend/src/i18n/locales/en/calculation.json
+++ b/frontend/src/i18n/locales/en/calculation.json
@@ -24,6 +24,8 @@
   "nextRankBadge": "Next: {{rank}}",
   "nextRankAria": "Next required card {{rank}}",
   "upcomingRanksTooltip": "Upcoming cards: {{sequence}}",
+  "upcomingRanksToggle": "Upcoming ranks",
+  "upcomingRanksDetailAria": "Upcoming ranks for foundation {{idx}}: {{sequence}}",
   "wasteRanksTooltip": "Waste {{idx}} (top 3): {{ranks}}",
   "wasteEmptyAria": "Waste {{idx}}: empty",
   "stockTopAria": "Stock top: {{card}}",

--- a/frontend/src/i18n/locales/ja/calculation.json
+++ b/frontend/src/i18n/locales/ja/calculation.json
@@ -24,6 +24,8 @@
   "nextRankBadge": "次:{{rank}}",
   "nextRankAria": "次に置くべきカード {{rank}}",
   "upcomingRanksTooltip": "今後の必要カード: {{sequence}}",
+  "upcomingRanksToggle": "先読みランク一覧",
+  "upcomingRanksDetailAria": "ファンデーション{{idx}}の先読みランク一覧: {{sequence}}",
   "wasteRanksTooltip": "ウェイスト{{idx}}（上3枚）: {{ranks}}",
   "wasteEmptyAria": "ウェイスト{{idx}}: 空",
   "stockTopAria": "山札のトップ: {{card}}",

--- a/frontend/src/pages/CalculationPage.test.tsx
+++ b/frontend/src/pages/CalculationPage.test.tsx
@@ -347,6 +347,26 @@ describe('CalculationPage', () => {
     expect(screen.getByTestId('calc-foundation-next-1')).toHaveTextContent('次:4');
   });
 
+  it('exposes the full upcoming-rank sequence as visible, tappable text (not only a title attr)', async () => {
+    renderWithProviders(<CalculationPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    // F0 seeded with A, step +1 ⇒ upcoming full sequence starts at 2.
+    const details = screen.getByTestId('calc-foundation-upcoming-details-0');
+    expect(details).toBeInTheDocument();
+    // The full sequence is rendered as real DOM text, reachable on touch devices
+    // by tapping the <summary> (native <details> disclosure — no hover needed).
+    const summary = details.querySelector('summary');
+    expect(summary).not.toBeNull();
+    if (summary) {
+      fireEvent.click(summary);
+    }
+    const full = screen.getByTestId('calc-foundation-upcoming-full-0');
+    expect(full).toBeVisible();
+    // Sequence must be the complete run to K (13), joined with arrows.
+    expect(full.textContent).toContain('→');
+    expect(full).toHaveAccessibleName(/2/);
+  });
+
   it('shows the seed rank on an empty foundation (no top card yet)', async () => {
     mockExec.mockResolvedValue({
       ...playingState,

--- a/frontend/src/pages/CalculationPage.tsx
+++ b/frontend/src/pages/CalculationPage.tsx
@@ -404,54 +404,73 @@ function CalculationPageContent() {
                 const upcomingRanks = calculationUpcomingRanks(idx, top?.value, pile.length);
                 const upcomingLabel = upcomingRanks.map(valueName).join(' → ');
                 return (
-                  <button
-                    key={`f-${idx.toString()}`}
-                    type="button"
-                    className={`flex flex-col items-center p-1 rounded ${focusRingWhite} ${isHint ? 'ring-2 ring-ds-success animate-pulse' : ''} ${source ? 'cursor-pointer' : 'cursor-default'}`}
-                    onClick={() => playToFoundation(idx)}
-                    disabled={!isPlaying || loading || source === null}
-                    title={upcomingLabel ? t('upcomingRanksTooltip', { sequence: upcomingLabel }) : undefined}
-                    aria-label={
-                      nextRankLabel
-                        ? `${t('foundation')} ${idx} ${STEP_LABELS[idx]} ${t('nextRankAria', { rank: nextRankLabel })}`
-                        : `${t('foundation')} ${idx} ${STEP_LABELS[idx]} ${t('foundationCompleteAria')}`
-                    }
-                  >
-                    <span className="text-[11px] mb-0.5 text-ds-text-muted">
-                      F{idx} {STEP_LABELS[idx]}
-                    </span>
-                    <div className="relative" style={{ width: cardWidth, height: cardHeight }}>
-                      {top ? (
-                        <AnimatedCard card={top} width={cardWidth} />
-                      ) : (
-                        <div
-                          style={{ width: cardWidth, height: cardHeight }}
-                          className="rounded border-2 border-dashed border-white/30 flex items-center justify-center text-ds-text-muted text-xs"
-                        >
-                          {t('empty')}
-                        </div>
-                      )}
-                      {nextRankLabel && (
+                  <div key={`f-${idx.toString()}`} className="flex flex-col items-center">
+                    <button
+                      type="button"
+                      className={`flex flex-col items-center p-1 rounded ${focusRingWhite} ${isHint ? 'ring-2 ring-ds-success animate-pulse' : ''} ${source ? 'cursor-pointer' : 'cursor-default'}`}
+                      onClick={() => playToFoundation(idx)}
+                      disabled={!isPlaying || loading || source === null}
+                      title={upcomingLabel ? t('upcomingRanksTooltip', { sequence: upcomingLabel }) : undefined}
+                      aria-label={
+                        nextRankLabel
+                          ? `${t('foundation')} ${idx} ${STEP_LABELS[idx]} ${t('nextRankAria', { rank: nextRankLabel })}`
+                          : `${t('foundation')} ${idx} ${STEP_LABELS[idx]} ${t('foundationCompleteAria')}`
+                      }
+                    >
+                      <span className="text-[11px] mb-0.5 text-ds-text-muted">
+                        F{idx} {STEP_LABELS[idx]}
+                      </span>
+                      <div className="relative" style={{ width: cardWidth, height: cardHeight }}>
+                        {top ? (
+                          <AnimatedCard card={top} width={cardWidth} />
+                        ) : (
+                          <div
+                            style={{ width: cardWidth, height: cardHeight }}
+                            className="rounded border-2 border-dashed border-white/30 flex items-center justify-center text-ds-text-muted text-xs"
+                          >
+                            {t('empty')}
+                          </div>
+                        )}
+                        {nextRankLabel && (
+                          <span
+                            data-testid={`calc-foundation-next-${idx}`}
+                            aria-hidden="true"
+                            className="absolute -top-1 -right-1 px-1.5 py-0.5 rounded-md bg-black/60 text-ds-text-on-accent text-[10px] font-bold leading-none ring-1 ring-white/30"
+                          >
+                            {t('nextRankBadge', { rank: nextRankLabel })}
+                          </span>
+                        )}
+                      </div>
+                      <span className="text-[11px] text-ds-text-muted mt-0.5">{pile.length}/13</span>
+                      {upcomingRanks.length > 1 && (
                         <span
-                          data-testid={`calc-foundation-next-${idx}`}
+                          data-testid={`calc-foundation-upcoming-${idx}`}
                           aria-hidden="true"
-                          className="absolute -top-1 -right-1 px-1.5 py-0.5 rounded-md bg-black/60 text-ds-text-on-accent text-[10px] font-bold leading-none ring-1 ring-white/30"
+                          className="mt-0.5 text-[10px] leading-none text-ds-text-muted opacity-60"
                         >
-                          {t('nextRankBadge', { rank: nextRankLabel })}
+                          {upcomingRanks.slice(1, 5).map(valueName).join('·')}
                         </span>
                       )}
-                    </div>
-                    <span className="text-[11px] text-ds-text-muted mt-0.5">{pile.length}/13</span>
+                    </button>
                     {upcomingRanks.length > 1 && (
-                      <span
-                        data-testid={`calc-foundation-upcoming-${idx}`}
-                        aria-hidden="true"
-                        className="mt-0.5 text-[10px] leading-none text-ds-text-muted opacity-60"
-                      >
-                        {upcomingRanks.slice(1, 5).map(valueName).join('·')}
-                      </span>
+                      <details className="mt-0.5" data-testid={`calc-foundation-upcoming-details-${idx}`}>
+                        <summary className="cursor-pointer list-none text-[10px] text-ds-text-muted underline decoration-dotted">
+                          {t('upcomingRanksToggle')}
+                        </summary>
+                        <span
+                          role="note"
+                          data-testid={`calc-foundation-upcoming-full-${idx}`}
+                          className="mt-0.5 block max-w-[6rem] break-words text-center text-[10px] leading-tight text-ds-text-muted"
+                          aria-label={t('upcomingRanksDetailAria', {
+                            idx,
+                            sequence: upcomingLabel,
+                          })}
+                        >
+                          {upcomingLabel}
+                        </span>
+                      </details>
                     )}
-                  </button>
+                  </div>
                 );
               })}
             </div>


### PR DESCRIPTION
## 概要

カルキュレーションのファンデーションボタンでは、先読みランクの完全なシーケンス（`upcomingRanksTooltip`）が `title` 属性のみで提供されており、マウスホバーでしか表示されないため、タッチ端末のユーザーはアクセスできませんでした。

各ファンデーションの下に、タップで展開できるネイティブの `<details>` ディスクロージャを追加し、完全な先読みシーケンスをホバーなしで確認できるようにしました。既存のホバー用 `title` ツールチップとボタン内の省略プレビュー（`slice(1,5)`）はそのまま維持しています。

## 変更点

- `CalculationPage.tsx`: 各ファンデーションボタンを `div` でラップし、`<details><summary>先読みランク一覧</summary>…</details>` を追加。全シーケンスを `role="note"` + `aria-label` でスクリーンリーダーにも提供。
- `calculation.json` (ja/en): `upcomingRanksToggle` / `upcomingRanksDetailAria` キーを追加。
- `CalculationPage.test.tsx`: サマリーをタップして全シーケンスが可視テキストとして表示されることを検証するテストを追加。

## 受け入れ条件

- [x] タッチ端末で先読みランクの全シーケンスを確認する手段が提供される（`<details>` のタップ展開）
- [x] 既存のマウスホバーによる title ツールチップは維持する
- [x] `CalculationPage.test.tsx` にタッチ操作での表示テストを追加

## テスト

- `bun run check`（biome + design-token）: OK
- `bun run test -- --run CalculationPage`: 35 passed
- `bun run build`（tsc）: OK

Closes #3210
