### PR TITLE
feat(gaps): add keyboard shortcuts to action buttons

### DIFF
--- a/frontend/src/i18n/locales/en/gaps.json
+++ b/frontend/src/i18n/locales/en/gaps.json
@@ -12,6 +12,12 @@
   "redealKeepLabel": "Redeal ({{used}}/{{total}}) — keeps {{locked}}",
   "giveup": "Give Up",
   "hint": "Hint",
+  "kbd": {
+    "undo": "Z",
+    "redeal": "D",
+    "hint": "H",
+    "giveUp": "G"
+  },
   "gap": "Gap",
   "gapAriaNeeded": "Gap (place {{card}})",
   "gapAriaAnySuit": "Gap (place any suit {{value}})",

--- a/frontend/src/i18n/locales/ja/gaps.json
+++ b/frontend/src/i18n/locales/ja/gaps.json
@@ -12,6 +12,12 @@
   "redealKeepLabel": "再配り ({{used}}/{{total}}) — {{locked}}枚維持",
   "giveup": "ギブアップ",
   "hint": "ヒント",
+  "kbd": {
+    "undo": "Z",
+    "redeal": "D",
+    "hint": "H",
+    "giveUp": "G"
+  },
   "gap": "空き",
   "gapAriaNeeded": "空き（{{card}} を置けます）",
   "gapAriaAnySuit": "空き（任意のスートの {{value}} を置けます）",

--- a/frontend/src/pages/GapsPage.test.tsx
+++ b/frontend/src/pages/GapsPage.test.tsx
@@ -61,6 +61,7 @@ const withHintState: GapsResponse = {
 };
 
 beforeEach(() => {
+  localStorage.clear();
   mockedRun.mockResolvedValue(playingState);
   vi.mocked(useGameHint).mockReturnValue({ hint: null, hintEnabled: false, setHintEnabled: vi.fn() });
 });
@@ -181,6 +182,79 @@ describe('GapsPage', () => {
     await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
     expect(screen.getByTestId('gaps-locked-0-0')).toBeInTheDocument();
     expect(screen.getByTestId('gaps-locked-0-11')).toBeInTheDocument();
+  });
+
+  it('advertises keyboard shortcuts on the action buttons via aria-keyshortcuts and a kbd chip', async () => {
+    mockedRun.mockResolvedValue({ ...playingState, canUndo: true });
+    renderWithProviders(<GapsPage />);
+    const undoBtn = await screen.findByRole('button', { name: '元に戻す' });
+    expect(undoBtn).toHaveAttribute('aria-keyshortcuts', 'z');
+    expect(undoBtn.querySelector('kbd')).toHaveTextContent('Z');
+    expect(screen.getByTestId('gaps-redeal-button')).toHaveAttribute('aria-keyshortcuts', 'd');
+    expect(screen.getByRole('button', { name: 'ヒント' })).toHaveAttribute('aria-keyshortcuts', 'h');
+    expect(screen.getByRole('button', { name: 'ギブアップ' })).toHaveAttribute('aria-keyshortcuts', 'g');
+  });
+
+  it('fires undo when the z key is pressed (only while canUndo)', async () => {
+    mockedRun.mockResolvedValue({ ...playingState, canUndo: true });
+    renderWithProviders(<GapsPage />);
+    await screen.findByRole('button', { name: '元に戻す' });
+    mockedRun.mockClear();
+    fireEvent.keyDown(document.body, { key: 'z' });
+    await waitFor(() => expect(mockedRun).toHaveBeenCalledWith('undo'));
+  });
+
+  it('does not fire undo via the z key when canUndo is false', async () => {
+    renderWithProviders(<GapsPage />);
+    await screen.findByRole('button', { name: '元に戻す' });
+    mockedRun.mockClear();
+    fireEvent.keyDown(document.body, { key: 'z' });
+    expect(mockedRun).not.toHaveBeenCalledWith('undo');
+  });
+
+  it('fires redeal when the d key is pressed', async () => {
+    renderWithProviders(<GapsPage />);
+    await screen.findByTestId('gaps-redeal-button');
+    mockedRun.mockClear();
+    fireEvent.keyDown(document.body, { key: 'd' });
+    await waitFor(() => expect(mockedRun).toHaveBeenCalledWith('redeal'));
+  });
+
+  it('does not fire redeal via the d key when no redeals remain', async () => {
+    mockedRun.mockResolvedValue({ ...playingState, redealsRemaining: 0, redealsUsed: 3 });
+    renderWithProviders(<GapsPage />);
+    await screen.findByTestId('gaps-redeal-button');
+    mockedRun.mockClear();
+    fireEvent.keyDown(document.body, { key: 'd' });
+    expect(mockedRun).not.toHaveBeenCalledWith('redeal');
+  });
+
+  it('fires hint when the h key is pressed', async () => {
+    renderWithProviders(<GapsPage />);
+    await screen.findByRole('button', { name: 'ヒント' });
+    mockedRun.mockClear();
+    fireEvent.keyDown(document.body, { key: 'h' });
+    await waitFor(() => expect(mockedRun).toHaveBeenCalledWith('hint'));
+  });
+
+  it('routes the g key through the give-up confirm dialog', async () => {
+    renderWithProviders(<GapsPage />);
+    await screen.findByRole('button', { name: 'ギブアップ' });
+    mockedRun.mockClear();
+    fireEvent.keyDown(document.body, { key: 'g' });
+    expect(mockedRun).not.toHaveBeenCalledWith('giveup');
+    expect(screen.getByText('投了確認')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
+    await waitFor(() => expect(mockedRun).toHaveBeenCalledWith('giveup'));
+  });
+
+  it('does not fire shortcuts once the game has ended', async () => {
+    mockedRun.mockResolvedValue(gameClearState);
+    renderWithProviders(<GapsPage />);
+    await waitFor(() => expect(screen.queryByRole('button', { name: 'ヒント' })).not.toBeInTheDocument());
+    mockedRun.mockClear();
+    fireEvent.keyDown(document.body, { key: 'h' });
+    expect(mockedRun).not.toHaveBeenCalledWith('hint');
   });
 
   it('does not lock a row whose leftmost card is not a 2', async () => {

--- a/frontend/src/pages/GapsPage.tsx
+++ b/frontend/src/pages/GapsPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { type GapsMoveZone, gapsApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { SettingsPanel } from '../components/common/SettingsPanel';
@@ -8,10 +8,12 @@ import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
 import { HintTooltip } from '../components/hint/HintTooltip';
+import { KbdBadge } from '../components/KbdBadge';
 import { LandscapeBanner } from '../components/LandscapeBanner';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { withTutorial } from '../components/tutorial/withTutorial';
+import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
@@ -135,6 +137,26 @@ function GapsPageContent() {
     onMove: dispatchMove,
     isPlaying: !!isPlaying,
     disabled: loading,
+  });
+
+  // Keyboard shortcuts mirror the sibling solitaire pages (EightOff / Baker's
+  // Dozen). Bind letter keys only — Enter/Space would double-fire on a focused
+  // button. Undo/redeal expose per-binding `enabled` so a disabled action's key
+  // is inert, matching the button's own disabled state.
+  const canUndo = !!state?.canUndo;
+  const canRedeal = (state?.redealsRemaining ?? 0) > 0;
+  const actionBindings = useMemo(
+    () => [
+      { key: 'z', action: handleUndo, enabled: canUndo },
+      { key: 'd', action: handleRedeal, enabled: canRedeal },
+      { key: 'h', action: handleHint },
+      { key: 'g', action: confirmGiveUpAction },
+    ],
+    [handleUndo, handleRedeal, handleHint, confirmGiveUpAction, canUndo, canRedeal],
+  );
+  useActionKeyboardNav({
+    bindings: actionBindings,
+    enabled: !!isPlaying && !loading,
   });
 
   if (!state) return <GameSkeleton gameKey="gaps" layout={{ kind: 'tiered-rows', rows: [13, 13, 13, 13] }} />;
@@ -321,8 +343,15 @@ function GapsPageContent() {
         <div className="flex gap-2 items-center flex-wrap">
           {isPlaying && (
             <div data-tutorial="gaps-controls" className="flex gap-2 flex-wrap">
-              <button type="button" className={btnPrimary} onClick={handleUndo} disabled={loading || !state.canUndo}>
+              <button
+                type="button"
+                className={btnPrimary}
+                onClick={handleUndo}
+                disabled={loading || !state.canUndo}
+                aria-keyshortcuts="z"
+              >
                 {t('undo')}
+                <KbdBadge label={t('kbd.undo')} />
               </button>
               <button
                 type="button"
@@ -330,18 +359,34 @@ function GapsPageContent() {
                 onClick={handleRedeal}
                 disabled={loading || state.redealsRemaining <= 0}
                 data-testid="gaps-redeal-button"
+                aria-keyshortcuts="d"
               >
                 {t('redealKeepLabel', {
                   used: state.redealsUsed,
                   total: state.redealsUsed + state.redealsRemaining,
                   locked: lockedTotal,
                 })}
+                <KbdBadge label={t('kbd.redeal')} />
               </button>
-              <button type="button" className={btnSuccess} onClick={handleHint} disabled={loading}>
+              <button
+                type="button"
+                className={btnSuccess}
+                onClick={handleHint}
+                disabled={loading}
+                aria-keyshortcuts="h"
+              >
                 {t('hint')}
+                <KbdBadge label={t('kbd.hint')} />
               </button>
-              <button type="button" className={btnDanger} onClick={confirmGiveUpAction} disabled={loading}>
+              <button
+                type="button"
+                className={btnDanger}
+                onClick={confirmGiveUpAction}
+                disabled={loading}
+                aria-keyshortcuts="g"
+              >
                 {t('giveup')}
+                <KbdBadge label={t('kbd.giveUp')} />
               </button>
             </div>
           )}


### PR DESCRIPTION
## 概要
ギャップス（Gaps / Montana）のフッター操作ボタンにキーボードショートカットを追加しました。同系ソリティア（Baker's Dozen / Eight Off）の `useActionKeyboardNav` + `KbdBadge` パターンをそのまま踏襲しています。

- `z` = Undo（`state.canUndo` 時のみ）
- `d` = 再配布（`redealsRemaining > 0` 時のみ）
- `h` = ヒント
- `g` = ギブアップ（`requestGiveUpConfirm` 経由の確認ダイアログを通す / issue #2099 準拠）

各ボタンに `aria-keyshortcuts` と発見可能な `<kbd>` チップ（`KbdBadge`）を付与し、`kbd.*` ラベルを ja/en 両ロケールに追加しました。`useActionKeyboardNav` は早期 return より前で呼び出し、フックの順序を維持しています（`enabled = isPlaying && !loading`）。バインドは文字キーのみで、Enter/Space は使いません（フォーカス済みボタンとの二重発火回避）。

## 受け入れ条件
- [x] z/d/h/g キーが PLAYING フェーズで機能する
- [x] `canUndo=false` や `redealsRemaining<=0` のとき対応キーが無効
- [x] g キーは確認ダイアログを経由する
- [x] `GapsPage.test.tsx` にキー操作のテストを追加

## テスト
- `frontend/src/pages/GapsPage.test.tsx`（24 tests, all passing）
- `bun run check` / `bun run build` / `bun run test -- --run GapsPage` すべてパス

Closes #3315
