### PR TITLE
feat(osmosis): add keyboard shortcuts to action buttons

### DIFF
--- a/frontend/src/i18n/locales/en/osmosis.json
+++ b/frontend/src/i18n/locales/en/osmosis.json
@@ -31,6 +31,13 @@
   "frontendHint": {
     "moveToFoundation": "A card can seep into a foundation"
   },
+  "kbd": {
+    "draw": "D",
+    "hint": "H",
+    "autoComplete": "A",
+    "undo": "Z",
+    "giveUp": "G"
+  },
   "tutorial": {
     "foundation": "Four vertical foundation rows. The top row collects one suit in any order; lower rows accept only ranks already present in the row directly above (osmosis).",
     "reserve": "Four reserve columns. Move the top card of any column to a foundation.",

--- a/frontend/src/i18n/locales/ja/osmosis.json
+++ b/frontend/src/i18n/locales/ja/osmosis.json
@@ -31,6 +31,13 @@
   "frontendHint": {
     "moveToFoundation": "組札へ浸透できるカードがあります"
   },
+  "kbd": {
+    "draw": "D",
+    "hint": "H",
+    "autoComplete": "A",
+    "undo": "Z",
+    "giveUp": "G"
+  },
   "tutorial": {
     "foundation": "縦4段の組札です。最上段は同じスートを順不同で集め、下段は「すぐ上の段にあるランク」だけを積めます（浸透）。",
     "reserve": "4列のリザーブです。各列の一番上のカードを組札へ移動できます。",

--- a/frontend/src/pages/OsmosisPage.test.tsx
+++ b/frontend/src/pages/OsmosisPage.test.tsx
@@ -162,6 +162,74 @@ describe('OsmosisPage', () => {
     expect(screen.getByRole('button', { name: '元に戻す' })).toBeDisabled();
   });
 
+  it('advertises the keyboard shortcuts on the action buttons', async () => {
+    renderWithProviders(<OsmosisPage />);
+    const draw = await screen.findByRole('button', { name: '引く' });
+    expect(draw).toHaveAttribute('aria-keyshortcuts', 'd');
+    expect(draw.querySelector('kbd')?.textContent).toBe('D');
+    // KbdBadge text is aria-hidden, so button accessible names stay clean.
+    expect(screen.getByRole('button', { name: 'ヒント' })).toHaveAttribute('aria-keyshortcuts', 'h');
+    expect(screen.getByRole('button', { name: '自動完成' })).toHaveAttribute('aria-keyshortcuts', 'a');
+    expect(screen.getByRole('button', { name: '元に戻す' })).toHaveAttribute('aria-keyshortcuts', 'z');
+    expect(screen.getByRole('button', { name: 'ギブアップ' })).toHaveAttribute('aria-keyshortcuts', 'g');
+  });
+
+  it('fires draw when the d key is pressed while playing', async () => {
+    renderWithProviders(<OsmosisPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    mockExec.mockClear();
+    fireEvent.keyDown(document.body, { key: 'd' });
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('draw'));
+  });
+
+  it('fires hint when the h key is pressed', async () => {
+    renderWithProviders(<OsmosisPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    mockExec.mockClear();
+    fireEvent.keyDown(document.body, { key: 'h' });
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('hint'));
+  });
+
+  it('fires autocomplete when the a key is pressed', async () => {
+    renderWithProviders(<OsmosisPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    mockExec.mockClear();
+    fireEvent.keyDown(document.body, { key: 'a' });
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('autocomplete'));
+  });
+
+  it('fires undo when the z key is pressed', async () => {
+    mockExec.mockResolvedValue({ ...playingState, canUndo: true });
+    renderWithProviders(<OsmosisPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    mockExec.mockClear();
+    fireEvent.keyDown(document.body, { key: 'z' });
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('undo'));
+  });
+
+  it('routes the g key through the give-up confirm dialog', async () => {
+    renderWithProviders(<OsmosisPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    mockExec.mockClear();
+    fireEvent.keyDown(document.body, { key: 'g' });
+    // The key must not dispatch giveup directly — it opens the confirm dialog first.
+    expect(mockExec).not.toHaveBeenCalledWith('giveup');
+    expect(screen.getByText('投了確認')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('giveup'));
+  });
+
+  it('does not fire shortcuts once the game has ended', async () => {
+    mockExec.mockResolvedValue(gameOverState);
+    renderWithProviders(<OsmosisPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    mockExec.mockClear();
+    fireEvent.keyDown(document.body, { key: 'd' });
+    fireEvent.keyDown(document.body, { key: 'h' });
+    expect(mockExec).not.toHaveBeenCalledWith('draw');
+    expect(mockExec).not.toHaveBeenCalledWith('hint');
+  });
+
   it('shows game clear phase', async () => {
     mockExec.mockResolvedValue(gameClearState);
     renderWithProviders(<OsmosisPage />);

--- a/frontend/src/pages/OsmosisPage.tsx
+++ b/frontend/src/pages/OsmosisPage.tsx
@@ -10,10 +10,12 @@ import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
 import { HintTooltip } from '../components/hint/HintTooltip';
+import { KbdBadge } from '../components/KbdBadge';
 import { LandscapeBanner } from '../components/LandscapeBanner';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { AnimatedCardBack } from '../components/motion/AnimatedCardBack';
 import { withTutorial } from '../components/tutorial/withTutorial';
+import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
@@ -149,6 +151,25 @@ function OsmosisPageContent() {
     : phase === OsmosisPhase.GAME_OVER
       ? t('phase.gameOver')
       : t('phase.playing');
+
+  // Bind letter-key shortcuts to the play-phase actions. Memoize so the effect
+  // doesn't re-subscribe every render, and call the hook before any early return
+  // to keep hook order stable. Enter/Space are intentionally NOT bound — they
+  // natively activate a focused button and would double-fire.
+  const actionBindings = useMemo(
+    () => [
+      { key: 'd', action: handleDraw },
+      { key: 'h', action: handleHint },
+      { key: 'a', action: handleAutoComplete },
+      { key: 'z', action: handleUndo },
+      { key: 'g', action: confirmGiveUpAction },
+    ],
+    [handleDraw, handleHint, handleAutoComplete, handleUndo, confirmGiveUpAction],
+  );
+  useActionKeyboardNav({
+    bindings: actionBindings,
+    enabled: state != null && isPlaying && !loading,
+  });
 
   if (error) return <ErrorAlert message={error} onRetry={retry} />;
   if (!state) return null;
@@ -375,40 +396,50 @@ function OsmosisPageContent() {
                     className={`${btnPrimary} ${focusRingWhite}`}
                     onClick={handleDraw}
                     disabled={loading}
+                    aria-keyshortcuts="d"
                   >
                     {t('draw')}
+                    <KbdBadge label={t('kbd.draw')} />
                   </button>
                   <button
                     type="button"
                     className={`${btnSuccess} ${focusRingWhite}`}
                     onClick={handleHint}
                     disabled={loading}
+                    aria-keyshortcuts="h"
                   >
                     {t('hint')}
+                    <KbdBadge label={t('kbd.hint')} />
                   </button>
                   <button
                     type="button"
                     className={`${btnSuccess} ${focusRingWhite}`}
                     onClick={handleAutoComplete}
                     disabled={loading}
+                    aria-keyshortcuts="a"
                   >
                     {t('autoComplete')}
+                    <KbdBadge label={t('kbd.autoComplete')} />
                   </button>
                   <button
                     type="button"
                     className={`${btnOutline} ${focusRingWhite}`}
                     onClick={handleUndo}
                     disabled={!state.canUndo || loading}
+                    aria-keyshortcuts="z"
                   >
                     {t('undo')}
+                    <KbdBadge label={t('kbd.undo')} />
                   </button>
                   <button
                     type="button"
                     className={`${btnDanger} ${focusRingWhite}`}
                     onClick={confirmGiveUpAction}
                     disabled={loading}
+                    aria-keyshortcuts="g"
                   >
                     {t('giveup')}
+                    <KbdBadge label={t('kbd.giveUp')} />
                   </button>
                 </>
               )}


### PR DESCRIPTION
## 概要

オズモシス（`osmosis`）のアクションボタンに `useActionKeyboardNav` によるキーボードショートカットを追加しました。同系統の `BakersDozenPage` のパターンをそのまま踏襲しています。

## 変更内容

- `useActionKeyboardNav` を導入し、PLAYING フェーズかつ非ローディング時のみ有効化
  - `d` = 引く（draw）
  - `h` = ヒント（hint）
  - `a` = 自動完成（autocomplete）
  - `z` = 元に戻す（undo）
  - `g` = ギブアップ（confirm ダイアログ経由）
- 各ボタンに `aria-keyshortcuts` 属性と `KbdBadge` チップを付与（発見性の向上）
- `kbd.*` i18n キーを ja/en 両方に追加（ラベルは大文字）
- フックは早期リターン前に呼び出し、バインディングを `useMemo` でメモ化（フック順序を安定化・再購読を防止）
- `Enter`/`Space` はバインドしない（フォーカス中ボタンの二重発火を防ぐため）

## 受け入れ条件

- [x] PLAYING フェーズ中に d / h / a / z / g キーで各アクションが発火する
- [x] g キーはギブアップ確認ダイアログを経由する
- [x] CLI モード有効時・入力フォーカス時はキーバインドが無効（`useActionKeyboardNav` の `IGNORED_TAGS` ガード）
- [x] `OsmosisPage.test.tsx` にキー操作テストを追加

## テスト

- `bun run test -- --run OsmosisPage`（25 件パス）
- `bun run check`（biome + design-token 検証）
- `bun run build`（tsc）

Closes #3362
