### PR TITLE
feat(basra): celebrate a basra sweep with a badge and counter emphasis

### DIFF
--- a/frontend/src/i18n/locales/en/basra.json
+++ b/frontend/src/i18n/locales/en/basra.json
@@ -21,6 +21,8 @@
   "cards": "{{count}} cards",
   "captured": "Captured: {{count}}",
   "basra": "Basra: {{count}}",
+  "basraBadge": "Basra! Table swept",
+  "basraBadgeOwn": "Basra! You swept it",
   "turnYours": "Your turn — pick a hand card, then tap table cards to capture (or none to trail).",
   "turnCpu": "CPU {{id}} is playing…",
   "playButton": "Play",

--- a/frontend/src/i18n/locales/ja/basra.json
+++ b/frontend/src/i18n/locales/ja/basra.json
@@ -21,6 +21,8 @@
   "cards": "{{count}}枚",
   "captured": "捕獲: {{count}}",
   "basra": "バスラ: {{count}}",
+  "basraBadge": "バスラ！場を一掃",
+  "basraBadgeOwn": "バスラ！あなたが一掃",
   "turnYours": "あなたの手番です — 手札を1枚選び、捕獲する場札をタップ（何も選ばなければトレイル）。",
   "turnCpu": "CPU {{id}} がプレイ中です…",
   "playButton": "出す",

--- a/frontend/src/pages/BasraPage.test.tsx
+++ b/frontend/src/pages/BasraPage.test.tsx
@@ -121,4 +121,41 @@ describe('BasraPage', () => {
     fireEvent.click(nextBtn);
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('nextround'));
   });
+
+  // Drives a play action whose response bumps `seat`'s basraCount, simulating a sweep.
+  const withBasra = (seat: number) =>
+    makeBasraState({
+      players: playPhaseState.players.map((p) => (p.id === seat ? { ...p, basraCount: 1 } : p)),
+    });
+
+  it('does not show the Basra celebration badge on a steady play state', async () => {
+    renderWithProviders(<BasraPage />);
+    await screen.findByTestId('hand-card-0');
+    expect(screen.queryByTestId('basra-celebration')).not.toBeInTheDocument();
+    expect(screen.getByTestId('basra-count-0')).not.toHaveAttribute('data-emphasised');
+  });
+
+  it('celebrates and emphasises the counter when the human achieves a Basra', async () => {
+    renderWithProviders(<BasraPage />);
+    const handCard = await screen.findByTestId('hand-card-0');
+    fireEvent.click(handCard);
+    mockExec.mockResolvedValue(withBasra(0));
+    fireEvent.click(screen.getByRole('button', { name: '出す' }));
+    const badge = await screen.findByTestId('basra-celebration');
+    expect(badge).toHaveAttribute('role', 'status');
+    expect(badge).toHaveTextContent('あなた');
+    expect(screen.getByTestId('basra-count-0')).toHaveAttribute('data-emphasised', 'true');
+  });
+
+  it('celebrates a CPU Basra with the neutral badge and emphasises that seat', async () => {
+    renderWithProviders(<BasraPage />);
+    const handCard = await screen.findByTestId('hand-card-0');
+    fireEvent.click(handCard);
+    mockExec.mockResolvedValue(withBasra(1));
+    fireEvent.click(screen.getByRole('button', { name: '出す' }));
+    const badge = await screen.findByTestId('basra-celebration');
+    expect(badge).toHaveTextContent('場を一掃');
+    expect(screen.getByTestId('basra-count-1')).toHaveAttribute('data-emphasised', 'true');
+    expect(screen.getByTestId('basra-count-0')).not.toHaveAttribute('data-emphasised');
+  });
 });

--- a/frontend/src/pages/BasraPage.tsx
+++ b/frontend/src/pages/BasraPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type { basraApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
@@ -19,6 +19,7 @@ import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useSound } from '../providers/SoundProvider';
 import { btnPrimary, btnSuccess } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { BasraResponse } from '../types/card';
@@ -82,11 +83,46 @@ function BasraPageContent() {
     handleResetWithConfig,
   } = useBasraGame();
   const { cardWidth } = useCardDimensions();
+  const { playSound } = useSound();
   const {
     hint: frontendHint,
     hintEnabled: frontendHintEnabled,
     setHintEnabled: setFrontendHintEnabled,
   } = useGameHint('basra', state);
+
+  // Celebrate a Basra (clearing the whole table with a single non-Jack card) the
+  // instant any player's basraCount rises — the sweep is the game's namesake score
+  // but was easy to miss amid fast CPU turns and the GameMessageBox (#3626).
+  // basraCount accumulates over the game, so a rising edge marks a fresh sweep; a
+  // reset drops every count back to 0, which clears any stale badge (no false re-fire).
+  const [basraCelebration, setBasraCelebration] = useState<{ key: number; own: boolean; seat: number } | null>(null);
+  const prevBasraRef = useRef<number[] | null>(null);
+  useEffect(() => {
+    if (!state) return;
+    const current = state.players.map((p) => p.basraCount);
+    const prev = prevBasraRef.current;
+    prevBasraRef.current = current;
+    if (prev === null || prev.length !== current.length) {
+      // First render or a player-count change: seed the baseline without firing.
+      if (prev !== null) setBasraCelebration(null);
+      return;
+    }
+    let seat = -1;
+    let dropped = false;
+    for (let i = 0; i < current.length; i++) {
+      const delta = current[i] - prev[i];
+      if (delta > 0) seat = i;
+      else if (delta < 0) dropped = true;
+    }
+    if (seat >= 0) {
+      const own = state.players[seat]?.isHuman ?? false;
+      setBasraCelebration((c) => ({ key: (c?.key ?? 0) + 1, own, seat }));
+      playSound('winFanfare', { pitchVariation: 0.05 });
+    } else if (dropped) {
+      // A reset / next game drops basraCount back to 0; clear the stale badge.
+      setBasraCelebration(null);
+    }
+  }, [state, playSound]);
 
   // Fetch a fresh game on mount.
   // biome-ignore lint/correctness/useExhaustiveDependencies: run once on mount.
@@ -127,9 +163,9 @@ function BasraPageContent() {
 
   const winnerNames = state.winners.map((i) => (state.players[i]?.isHuman ? t('you') : t('cpu', { id: i }))).join(', ');
 
-  const humanStats = human
-    ? `${t('cards', { count: human.cardCount })} · ${t('captured', { count: human.capturedCount })} · ${t('basra', { count: human.basraCount })}`
-    : '';
+  // A player's Basra counter is emphasised while their most recent sweep is celebrated.
+  const basraEmphasisClass =
+    'inline-block rounded px-1 ring-2 ring-ds-accent text-ds-accent font-bold motion-safe:animate-pulse';
 
   return (
     <GamePageShell
@@ -164,7 +200,13 @@ function BasraPageContent() {
                   <div key={p.id} className="text-center">
                     <div className="text-xs text-ds-text-muted mb-1">
                       {t('cpu', { id: p.id })} — {t('captured', { count: p.capturedCount })} ·{' '}
-                      {t('basra', { count: p.basraCount })}
+                      <span
+                        className={basraCelebration?.seat === p.id ? basraEmphasisClass : undefined}
+                        data-testid={`basra-count-${p.id}`}
+                        data-emphasised={basraCelebration?.seat === p.id || undefined}
+                      >
+                        {t('basra', { count: p.basraCount })}
+                      </span>
                     </div>
                     <div className="flex gap-0.5 justify-center">
                       {Array.from({ length: Math.min(p.cardCount, 8) }, (_, i) => (
@@ -176,7 +218,20 @@ function BasraPageContent() {
             </div>
 
             {/* Table cards */}
-            <div className="py-3 bg-black/20 rounded-lg" data-tutorial="basra-table-cards">
+            <div className="relative py-3 bg-black/20 rounded-lg" data-tutorial="basra-table-cards">
+              {basraCelebration && (
+                <div
+                  key={basraCelebration.key}
+                  className="absolute inset-x-0 -top-3 z-10 flex justify-center motion-safe:animate-bounce pointer-events-none"
+                  role="status"
+                  aria-live="polite"
+                  data-testid="basra-celebration"
+                >
+                  <span className="rounded-full px-3 py-1 text-sm font-bold shadow-lg bg-ds-accent text-ds-text-on-accent ring-2 ring-ds-accent">
+                    {basraCelebration.own ? t('basraBadgeOwn') : t('basraBadge')}
+                  </span>
+                </div>
+              )}
               <div className="text-center text-xs text-ds-text-muted mb-2">{t('table')}</div>
               <div className="flex justify-center gap-2 min-h-[60px] flex-wrap">
                 {state.tableCards.length === 0 ? (
@@ -236,7 +291,20 @@ function BasraPageContent() {
             {/* Human hand */}
             <div className="text-center" data-tutorial="basra-player-hand">
               <div className="text-xs text-ds-text-muted mb-1">
-                {t('you')} — {humanStats}
+                {t('you')}
+                {human && (
+                  <>
+                    {' — '}
+                    {t('cards', { count: human.cardCount })} · {t('captured', { count: human.capturedCount })} ·{' '}
+                    <span
+                      className={basraCelebration?.seat === human.id ? basraEmphasisClass : undefined}
+                      data-testid={`basra-count-${human.id}`}
+                      data-emphasised={basraCelebration?.seat === human.id || undefined}
+                    >
+                      {t('basra', { count: human.basraCount })}
+                    </span>
+                  </>
+                )}
               </div>
               <div className="flex flex-wrap justify-center gap-2">
                 {human?.cards.map((c, i) => (


### PR DESCRIPTION
## 概要

バスラ（場札を単一の非ジャック札で一掃するボーナス役、ゲーム名の由来）が成立した瞬間の演出を追加。CPUの高速なターンや `GameMessageBox` に埋もれて見逃しやすかった核心得点を、その場でフィードバックする。

各プレイヤーの `basraCount` の「立ち上がりエッジ」を present state から検出（ScoponePage #3464 と同じパターン）。バックエンド変更なし。

## 変更内容

- バスラ成立時に対象席の `basraCount` が増えた瞬間、場札エリア上部に `role="status"` のお祝いバッジを表示（自分の成立/CPUの成立で文言を出し分け）
- 成立した席のバスラカウンタを ring + pulse で強調（`data-emphasised`）
- `winFanfare` 効果音を再生（サウンド有効時）
- リセット/新ゲームで全 `basraCount` が 0 に戻るとバッジは自動クリア（誤再発火なし）
- 色は全てデザインシステムトークン（`bg-ds-accent`, `text-ds-text-on-accent`, `ring-ds-accent`, `text-ds-accent`）

## 受け入れ条件

- [x] バスラ成立時にカウンタ強調アニメーションが出る
- [x] 成立時に効果音が鳴る（サウンド有効時 `winFanfare`）
- [x] 直近バスラ発生を present state（`basraCount` の立ち上がり）から検出（バックエンド変更なしで実現）
- [x] `BasraPage.test.tsx` に強調表示テストを追加（badge 表示/非表示・自分/CPU・カウンタ強調）

## テスト

- `frontend`: `bun run test -- --run BasraPage`（12 passed）, `bun run check`（design-tokens OK）, `bun run build`（tsc 通過）

Closes #3626
