### PR TITLE
feat(spoons): visualize remaining spoons as icons

### DIFF
--- a/frontend/src/i18n/locales/en/spoons.json
+++ b/frontend/src/i18n/locales/en/spoons.json
@@ -3,6 +3,8 @@
   "cpu": "CPU {{id}}",
   "round": "Round {{n}}",
   "spoonsRemaining": "Spoons left: {{count}}",
+  "spoonsLabel": "Spoons",
+  "spoonGrabbedBy": "Grabbed by {{name}}",
   "drawPile": "Draw pile: {{count}}",
   "playersTitle": "Players",
   "handLabel": "Your hand",

--- a/frontend/src/i18n/locales/ja/spoons.json
+++ b/frontend/src/i18n/locales/ja/spoons.json
@@ -3,6 +3,8 @@
   "cpu": "CPU {{id}}",
   "round": "ラウンド {{n}}",
   "spoonsRemaining": "残りスプーン: {{count}}",
+  "spoonsLabel": "スプーン",
+  "spoonGrabbedBy": "{{name}} が取得",
   "drawPile": "山札: {{count}}",
   "playersTitle": "プレイヤー",
   "handLabel": "あなたの手札",

--- a/frontend/src/pages/SpoonsPage.test.tsx
+++ b/frontend/src/pages/SpoonsPage.test.tsx
@@ -91,11 +91,42 @@ describe('SpoonsPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
   });
 
-  it('shows round, spoons remaining and draw pile info', async () => {
+  it('shows round and draw pile info', async () => {
     renderWithProviders(<SpoonsPage />);
     await waitFor(() => expect(screen.getByText(/ラウンド 1/)).toBeInTheDocument());
-    expect(screen.getByText(/残りスプーン: 3/)).toBeInTheDocument();
     expect(screen.getByText(/山札: 36/)).toBeInTheDocument();
+  });
+
+  it('renders one spoon icon per remaining spoon with an accessible count label', async () => {
+    renderWithProviders(<SpoonsPage />);
+    // 3 spoons remaining → 3 available icons, none grabbed yet.
+    await waitFor(() => expect(screen.getAllByTestId('spoons-icon-available')).toHaveLength(3));
+    expect(screen.queryAllByTestId('spoons-icon-grabbed')).toHaveLength(0);
+    // Screen readers still get the number via the row's aria-label.
+    expect(screen.getByTestId('spoons-icon-row')).toHaveAttribute('aria-label', '残りスプーン: 3');
+  });
+
+  it('shows grabbed spoons grayed out with the grabber name', async () => {
+    // One CPU grabbed a spoon: 2 remaining + 1 grabbed = 3 spoons in play.
+    mockExec.mockResolvedValue(
+      makeState({
+        phase: 1,
+        grabWindowOpen: true,
+        spoonsRemaining: 2,
+        firstGrabberIdx: 1,
+        players: [
+          makePlayer({ name: 'You', isHuman: true }),
+          makePlayer({ hasSpoon: true }),
+          makePlayer(),
+          makePlayer(),
+        ],
+      }),
+    );
+    renderWithProviders(<SpoonsPage />);
+    await waitFor(() => expect(screen.getAllByTestId('spoons-icon-available')).toHaveLength(2));
+    const grabbed = screen.getAllByTestId('spoons-icon-grabbed');
+    expect(grabbed).toHaveLength(1);
+    expect(grabbed[0]).toHaveTextContent('CPU 1 が取得');
   });
 
   it('renders the human hand as pass buttons naming each card', async () => {

--- a/frontend/src/pages/SpoonsPage.tsx
+++ b/frontend/src/pages/SpoonsPage.tsx
@@ -165,6 +165,17 @@ function SpoonsPageContent() {
 
   const playerLabel = (id: number, isHuman: boolean): string => (isHuman ? t('you') : t('cpu', { id }));
 
+  // Build the spoon-icon row: one available icon per remaining spoon, plus one
+  // grayed-out icon per player who already grabbed (labeled with the grabber).
+  // The full-row total = remaining + grabbed = the number of spoons in play.
+  const grabbers = state.players
+    .map((p, idx) => ({ idx, isHuman: p.isHuman, hasSpoon: p.hasSpoon }))
+    .filter((g) => g.hasSpoon);
+  const spoonsInPlay = state.spoonsRemaining + grabbers.length;
+  // motion-safe pulse only while spoons can still be grabbed, echoing the grab
+  // button's urgency cue; respects prefers-reduced-motion via motion-safe:.
+  const spoonPulse = state.grabWindowOpen && !isGameEnd ? ' motion-safe:animate-pulse' : '';
+
   const handleManualReset = () => {
     hideActionLog();
     exec('reset', { config: { cpuDifficulty } });
@@ -213,8 +224,47 @@ function SpoonsPageContent() {
           <div className={`flex-1 overflow-y-auto pt-3 px-4 lg:px-8 ${lgCardAreaConstraint}`}>
             <div className="text-ds-text-primary text-center mb-2" data-tutorial="spoons-info">
               <span className="mr-4">{t('round', { n: state.roundNumber })}</span>
-              <span className="mr-4">{t('spoonsRemaining', { count: state.spoonsRemaining })}</span>
               <span>{t('drawPile', { count: state.drawPileSize })}</span>
+            </div>
+
+            {/* Spoons on the table, visualized as icons (grabbed ones grayed out). */}
+            <div className="flex flex-wrap items-center justify-center gap-x-3 gap-y-1 mb-3">
+              <span className="text-ds-text-muted text-sm">{t('spoonsLabel')}</span>
+              {spoonsInPlay > 0 ? (
+                <div
+                  className="flex flex-wrap items-center gap-1.5"
+                  data-testid="spoons-icon-row"
+                  role="img"
+                  aria-label={t('spoonsRemaining', { count: state.spoonsRemaining })}
+                >
+                  {Array.from({ length: state.spoonsRemaining }, (_, i) => (
+                    <span
+                      key={`spoon-avail-${i}`}
+                      data-testid="spoons-icon-available"
+                      aria-hidden="true"
+                      className={`text-lg leading-none${spoonPulse}`}
+                    >
+                      🥄
+                    </span>
+                  ))}
+                  {grabbers.map((g) => (
+                    <span
+                      key={`spoon-grabbed-${g.idx}`}
+                      data-testid="spoons-icon-grabbed"
+                      className="inline-flex items-center gap-0.5 text-ds-text-muted text-xs"
+                    >
+                      <span aria-hidden="true" className="text-lg leading-none opacity-40 grayscale">
+                        🥄
+                      </span>
+                      {t('spoonGrabbedBy', { name: playerLabel(g.idx, g.isHuman) })}
+                    </span>
+                  ))}
+                </div>
+              ) : (
+                <span className="text-ds-text-muted text-sm" data-testid="spoons-icon-row">
+                  {t('spoonsRemaining', { count: state.spoonsRemaining })}
+                </span>
+              )}
             </div>
 
             {/* Players */}


### PR DESCRIPTION
## 概要
スプーン残数を数字テキストから **スプーンアイコンの横並び** に置き換え、取得済みスプーンは取得者名付きでグレーアウト表示する。grab ウィンドウが開いている間はアイコンが motion-safe でパルスし、聴覚（チャイム）と視覚の両方で grab レースを伝える。

## 変更内容
- `SpoonsPage.tsx`: `spoonsRemaining` 数字表示 → アイコン行（残数分 🥄 + 取得済み枠を取得者名付きグレーアウト）。既存の同ランク手札カラーリング機能はそのまま維持。
- アクセシビリティ: アイコン行に `role="img"` + `aria-label`（残数を含む）、各アイコンは `aria-hidden`。
- アニメーション: grab ウィンドウ中のみ `motion-safe:animate-pulse`（reduced-motion 配慮）。
- 色はすべてデザインシステムトークン（`text-ds-text-muted` 等）。生の Tailwind パレット不使用。
- i18n: ja/en に `spoonsLabel` / `spoonGrabbedBy` を key-for-key 追加。
- テスト: 残数 N → アイコン N 個 + aria-label 検証、取得済みスプーンの取得者名検証を追加。

## 受け入れ条件
- [x] 残数分のスプーンアイコンが表示される
- [x] 取得済みスプーンに取得者が表示される
- [x] 取得時にアニメーションが発火（reduced-motion 配慮）
- [x] ページテストでアイコン数を検証

## 確認
- `bun run check`（biome + design-token 検証）: OK
- `bun run test -- --run SpoonsPage`: 22 passed
- `bun run build`（tsc）: OK
- フロントエンドのみ / Go 変更なし

Closes #3550