### PR TITLE
feat(seahaventowers): add auto-complete ready badge and readiness gating

### DIFF
--- a/frontend/src/i18n/locales/en/seahaventowers.json
+++ b/frontend/src/i18n/locales/en/seahaventowers.json
@@ -11,6 +11,7 @@
   "giveup": "Give Up",
   "hint": "Hint",
   "autoComplete": "Auto Complete",
+  "autoCompleteNotReady": "Auto-complete guarantees a win once every column is in descending order.",
   "undo": "Undo",
   "moveCount": "Moves",
   "empty": "Empty",

--- a/frontend/src/i18n/locales/ja/seahaventowers.json
+++ b/frontend/src/i18n/locales/ja/seahaventowers.json
@@ -11,6 +11,7 @@
   "giveup": "ギブアップ",
   "hint": "ヒント",
   "autoComplete": "オートコンプリート",
+  "autoCompleteNotReady": "全列が同スート降順に整うとオートコンプリートで確実に完走できます",
   "undo": "元に戻す",
   "moveCount": "手数",
   "empty": "空",

--- a/frontend/src/pages/SeahavenTowersPage.test.tsx
+++ b/frontend/src/pages/SeahavenTowersPage.test.tsx
@@ -61,6 +61,13 @@ const withHintState: SeahavenTowersResponse = {
   hint: { fromZone: 'tableau', fromCol: 0, cardIndex: 0, toZone: 'tableau', toCol: 2 },
 };
 
+// A column that ascends bottom→top (5 sits below 9) is not a clean mop-up, so
+// auto-complete cannot guarantee a win: readiness is false.
+const notReadyState: SeahavenTowersResponse = {
+  ...playingState,
+  tableau: [[card('SPADE', 5), card('SPADE', 9)], [], [], [], [], [], [], [], [], []],
+};
+
 beforeEach(() => {
   mockExec.mockResolvedValue(playingState);
   vi.mocked(useGameHint).mockReturnValue({ hint: null, hintEnabled: false, setHintEnabled: vi.fn() });
@@ -181,6 +188,27 @@ describe('SeahavenTowersPage', () => {
     mockExec.mockResolvedValueOnce(playingState);
     fireEvent.click(screen.getByRole('button', { name: 'オートコンプリート' }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('autocomplete'));
+  });
+
+  it('shows the auto-complete ready badge and enables the button when all columns descend', async () => {
+    // playingState columns are single/empty cards → strictly descending → ready.
+    renderWithProviders(<SeahavenTowersPage />);
+    await waitFor(() => expect(screen.getByTestId('seahaventowers-autocomplete-ready-badge')).toBeInTheDocument());
+    const autoCompleteBtn = screen.getByTestId('autocomplete-button');
+    expect(autoCompleteBtn).toBeEnabled();
+    expect(autoCompleteBtn).not.toHaveAttribute('title');
+    expect(autoCompleteBtn.className).toContain('animate-pulse');
+  });
+
+  it('hides the badge, disables the button, and shows a tooltip when not ready', async () => {
+    mockExec.mockResolvedValue(notReadyState);
+    renderWithProviders(<SeahavenTowersPage />);
+    await waitFor(() => expect(screen.getByTestId('autocomplete-button')).toBeInTheDocument());
+    expect(screen.queryByTestId('seahaventowers-autocomplete-ready-badge')).not.toBeInTheDocument();
+    const autoCompleteBtn = screen.getByTestId('autocomplete-button');
+    expect(autoCompleteBtn).toBeDisabled();
+    expect(autoCompleteBtn).toHaveAttribute('title');
+    expect(autoCompleteBtn.className).not.toContain('animate-pulse');
   });
 
   it('give up button opens a confirm dialog and only dispatches giveup after confirm', async () => {

--- a/frontend/src/pages/SeahavenTowersPage.tsx
+++ b/frontend/src/pages/SeahavenTowersPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useState } from 'react';
 import type { SeahavenTowersMoveZone, seahaventowersApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
+import { AutoCompleteReadyBadge } from '../components/AutoCompleteReadyBadge';
 import { CliTerminal } from '../components/cli/CliTerminal';
 import { CliToggle } from '../components/cli/CliToggle';
 import { SettingsPanel } from '../components/common/SettingsPanel';
@@ -34,6 +35,7 @@ import { cardAlt } from '../utils/cardAlt';
 import { parseSeahavenTowersCommand, SEAHAVENTOWERS_HELP } from '../utils/cli/commands/seahaventowersCommands';
 import { formatSeahavenTowersState } from '../utils/cli/formatters/seahaventowersFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { freeCellAutoCompleteReady } from '../utils/freeCellAutoComplete';
 
 const FOUNDATION_SUITS = ['♠', '♣', '♥', '♦'] as const;
 
@@ -195,6 +197,13 @@ function SeahavenTowersPageContent() {
   const isGameClear = state.phase === SeahavenTowersPhase.GAME_CLEAR;
   const isGameOver = state.phase === SeahavenTowersPhase.GAME_OVER;
   const isEnded = isGameClear || isGameOver;
+
+  // "Auto-complete ready" readiness: like FreeCell, the server's auto-complete
+  // deterministically clears the board exactly when every tableau column is
+  // strictly rank-descending from bottom to top (the smallest unplayed card is
+  // then always an exposed top card). Seahaven's reserved cells hold single
+  // exposed cards and never block, so the FreeCell check applies unchanged.
+  const autoCompleteReady = freeCellAutoCompleteReady(state.tableau);
 
   // Seahaven Towers supermove limit: with only 2 reserved cells and Kings-only
   // empty columns, max-movable is (1 + emptyReservedCells). Empty tableau columns
@@ -538,12 +547,17 @@ function SeahavenTowersPageContent() {
                   </button>
                   <button
                     type="button"
-                    className={btnSuccess}
+                    className={`${btnSuccess}${
+                      autoCompleteReady && !loading && !isAutoCompleting ? ' animate-pulse ring-2 ring-ds-success' : ''
+                    }`}
                     onClick={handleAutoComplete}
-                    disabled={loading || isAutoCompleting}
+                    disabled={loading || isAutoCompleting || !autoCompleteReady}
+                    data-testid="autocomplete-button"
+                    title={autoCompleteReady ? undefined : t('autoCompleteNotReady')}
                   >
                     {t('autoComplete')}
                   </button>
+                  <AutoCompleteReadyBadge ready={autoCompleteReady} testId="seahaventowers-autocomplete-ready-badge" />
                   <button
                     type="button"
                     className={btnDanger}


### PR DESCRIPTION
## 概要
シーヘイブンタワーズのオートコンプリートに、FreeCell と同じ「準備完了」表示を追加しました。

- 既存の `freeCellAutoCompleteReady`（各列が下→上に厳密降順なら確実に完走できる、という軽量な O(n) 判定）をそのまま再利用。Seahaven のリザーブセルは FreeCell の空きセルと同様に単一の露出カードを保持するだけでブロックしないため、判定ロジックはそのまま適用できます。
- 準備完了時: オートコンプリートボタンが `ring-ds-success` の pulse リング＋`AutoCompleteReadyBadge`（`role="status"` / aria-live）でバッジ表示。
- 未準備時: ボタンを無効化し、理由 tooltip を表示。

## 受け入れ条件
- [x] 全列が降順に整った時にバッジと pulse が表示される
- [x] readiness 判定に単体テストを追加（既存 `freeCellAutoComplete.ts` の再利用 + ページ単体テスト2件）
- [x] 未準備時のボタンに理由 tooltip が出る
- [x] FreeCell と同じ視覚言語（バッジ/リング色 `ring-ds-success`）を使用

## テスト
- `bun run check`（biome + design-token 検証）: OK
- `bun run test -- --run SeahavenTowersPage`: 20 passed（新規2件: badge表示/enable、未準備でbadge非表示・disable・tooltip）
- `bun run build`（tsc）: OK

## 変更ファイル
- `frontend/src/pages/SeahavenTowersPage.tsx`（+ `.test.tsx`）
- `frontend/src/i18n/locales/{ja,en}/seahaventowers.json`（`autoCompleteNotReady` 追加）

Closes #3037
