### PR TITLE
feat(highcardflush): preview resulting bet amount on raise buttons

### DIFF
--- a/frontend/src/i18n/locales/en/highcardflush.json
+++ b/frontend/src/i18n/locales/en/highcardflush.json
@@ -13,9 +13,7 @@
   },
   "button": {
     "bet": "Bet",
-    "raise1x": "Raise x1",
-    "raise2x": "Raise x2",
-    "raise3x": "Raise x3",
+    "raiseAmount": "Raise x{{multiplier}} ({{amount}})",
     "fold": "Fold",
     "reset": "Reset"
   },

--- a/frontend/src/i18n/locales/ja/highcardflush.json
+++ b/frontend/src/i18n/locales/ja/highcardflush.json
@@ -13,9 +13,7 @@
   },
   "button": {
     "bet": "ベット",
-    "raise1x": "レイズ x1",
-    "raise2x": "レイズ x2",
-    "raise3x": "レイズ x3",
+    "raiseAmount": "レイズ x{{multiplier}}（{{amount}}）",
     "fold": "フォールド",
     "reset": "リセット"
   },

--- a/frontend/src/pages/HighCardFlushPage.test.tsx
+++ b/frontend/src/pages/HighCardFlushPage.test.tsx
@@ -145,27 +145,52 @@ describe('HighCardFlushPage', () => {
     await waitFor(() => expect(screen.getByText('チップ: 1000')).toBeInTheDocument());
 
     fireEvent.click(screen.getByRole('button', { name: 'ベット' }));
-    await waitFor(() => expect(screen.getByRole('button', { name: 'レイズ x2' })).toBeInTheDocument());
-    expect(screen.getByRole('button', { name: 'レイズ x1' })).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'レイズ x3' })).not.toBeInTheDocument();
+    await waitFor(() => expect(screen.getByRole('button', { name: /レイズ x2/ })).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: /レイズ x1/ })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /レイズ x3/ })).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'フォールド' })).toBeInTheDocument();
+  });
+
+  it('previews the resulting bet amount (anteBet × multiplier) on each raise button', async () => {
+    // actionPhase5Flush has anteBet=100, maxRaiseMultiplier=2 → x1 = 100, x2 = 200.
+    mockExec.mockResolvedValue(actionPhase5Flush);
+    renderWithProviders(<HighCardFlushPage />);
+    await waitFor(() => expect(screen.getByTestId('raise-1x')).toBeInTheDocument());
+    expect(screen.getByTestId('raise-1x')).toHaveTextContent('レイズ x1（100）');
+    expect(screen.getByTestId('raise-2x')).toHaveTextContent('レイズ x2（200）');
+    expect(screen.queryByTestId('raise-3x')).not.toBeInTheDocument();
+  });
+
+  it('scales the previewed bet amount with a larger ante', async () => {
+    // anteBet=300, maxRaiseMultiplier=3 → x1 = 300, x2 = 600, x3 = 900.
+    mockExec.mockResolvedValue({
+      ...actionPhase5Flush,
+      anteBet: 300,
+      playerFlushLen: 6,
+      maxRaiseMultiplier: 3,
+    });
+    renderWithProviders(<HighCardFlushPage />);
+    await waitFor(() => expect(screen.getByTestId('raise-3x')).toBeInTheDocument());
+    expect(screen.getByTestId('raise-1x')).toHaveTextContent('レイズ x1（300）');
+    expect(screen.getByTestId('raise-2x')).toHaveTextContent('レイズ x2（600）');
+    expect(screen.getByTestId('raise-3x')).toHaveTextContent('レイズ x3（900）');
   });
 
   it('calls raise API on raise button click', async () => {
     mockExec.mockResolvedValueOnce(actionPhase5Flush).mockResolvedValueOnce(endPhasePlayerWins);
     renderWithProviders(<HighCardFlushPage />);
-    await waitFor(() => expect(screen.getByRole('button', { name: 'レイズ x2' })).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole('button', { name: /レイズ x2/ })).toBeInTheDocument());
 
-    fireEvent.click(screen.getByRole('button', { name: 'レイズ x2' }));
+    fireEvent.click(screen.getByRole('button', { name: /レイズ x2/ }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('raise', undefined, undefined, undefined, 2));
   });
 
   it('shows end phase with player wins and payout breakdown', async () => {
     mockExec.mockResolvedValueOnce(actionPhase5Flush).mockResolvedValueOnce(endPhasePlayerWins);
     renderWithProviders(<HighCardFlushPage />);
-    await waitFor(() => expect(screen.getByRole('button', { name: 'レイズ x1' })).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole('button', { name: /レイズ x1/ })).toBeInTheDocument());
 
-    fireEvent.click(screen.getByRole('button', { name: 'レイズ x1' }));
+    fireEvent.click(screen.getByRole('button', { name: /レイズ x1/ }));
     await waitFor(() => expect(screen.getByTestId('payout-breakdown')).toBeInTheDocument());
     expect(screen.getByText(/合計: 400/)).toBeInTheDocument();
   });
@@ -182,7 +207,7 @@ describe('HighCardFlushPage', () => {
   it('keyboard shortcut "1" triggers raise 1x during action phase', async () => {
     mockExec.mockResolvedValue(actionPhase5Flush);
     renderWithProviders(<HighCardFlushPage />);
-    await waitFor(() => expect(screen.getByRole('button', { name: 'レイズ x1' })).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole('button', { name: /レイズ x1/ })).toBeInTheDocument());
 
     fireEvent.keyDown(document, { key: '1' });
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('raise', undefined, undefined, undefined, 1));
@@ -258,8 +283,8 @@ describe('HighCardFlushPage', () => {
       maxRaiseMultiplier: 3,
     });
     renderWithProviders(<HighCardFlushPage />);
-    await waitFor(() => expect(screen.getByRole('button', { name: 'レイズ x3' })).toBeInTheDocument());
-    expect(screen.getByRole('button', { name: 'レイズ x2' })).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByRole('button', { name: /レイズ x3/ })).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: /レイズ x2/ })).toBeInTheDocument();
   });
 
   it('lifts and glows the cards in the longest flush, dims off-suit cards', async () => {
@@ -267,7 +292,7 @@ describe('HighCardFlushPage', () => {
     renderWithProviders(<HighCardFlushPage />);
     await waitFor(() => expect(screen.getByText('チップ: 1000')).toBeInTheDocument());
     fireEvent.click(screen.getByRole('button', { name: 'ベット' }));
-    await waitFor(() => expect(screen.getByRole('button', { name: 'レイズ x2' })).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole('button', { name: /レイズ x2/ })).toBeInTheDocument());
     // actionPhase5Flush has 5 SPADE + 1 HEART + 1 CLOVER → SPADE is the longest flush.
     const flushCards = document.querySelectorAll('[data-flush-card="true"]');
     const offCards = document.querySelectorAll('[data-flush-card="false"]');
@@ -285,7 +310,7 @@ describe('HighCardFlushPage', () => {
     renderWithProviders(<HighCardFlushPage />);
     await waitFor(() => expect(screen.getByText('チップ: 1000')).toBeInTheDocument());
     fireEvent.click(screen.getByRole('button', { name: 'ベット' }));
-    await waitFor(() => expect(screen.getByRole('button', { name: 'レイズ x2' })).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole('button', { name: /レイズ x2/ })).toBeInTheDocument());
     // Scope by data-card-section so we don't rely on alt-text matching (which
     // would silently start testing the wrong element if AnimatedCard's alt
     // format ever changes).

--- a/frontend/src/pages/HighCardFlushPage.tsx
+++ b/frontend/src/pages/HighCardFlushPage.tsx
@@ -405,20 +405,19 @@ function HighCardFlushPageContent() {
                   {t('label.flushLen')}: {state.playerFlushLen} · {t('label.multiplier')} ≤ {maxMultiplier}
                 </div>
                 <div className="flex flex-wrap justify-center gap-2">
-                  {maxMultiplier >= 1 && (
-                    <button type="button" className={btnSuccess} onClick={raise(1)} disabled={loading}>
-                      {t('button.raise1x')}
-                    </button>
-                  )}
-                  {maxMultiplier >= 2 && (
-                    <button type="button" className={btnSuccess} onClick={raise(2)} disabled={loading}>
-                      {t('button.raise2x')}
-                    </button>
-                  )}
-                  {maxMultiplier >= 3 && (
-                    <button type="button" className={btnSuccess} onClick={raise(3)} disabled={loading}>
-                      {t('button.raise3x')}
-                    </button>
+                  {[1, 2, 3].map((m) =>
+                    maxMultiplier >= m ? (
+                      <button
+                        key={m}
+                        type="button"
+                        className={btnSuccess}
+                        onClick={raise(m)}
+                        disabled={loading}
+                        data-testid={`raise-${m}x`}
+                      >
+                        {t('button.raiseAmount', { multiplier: m, amount: state.anteBet * m })}
+                      </button>
+                    ) : null,
                   )}
                   <button type="button" className={btnDanger} onClick={handleFold} disabled={loading}>
                     {t('button.fold')}


### PR DESCRIPTION
## 概要

ハイカードフラッシュのレイズボタンが倍率のみを表示し、実際の賭け金（アンテ × 倍率）が分からない問題を解消する。各レイズボタンのラベルに結果ベット額を併記した。

倍率ルールはドメイン（`internal/domain/HighCardFlush.go` の `Raise`: `raise := hcf.anteBet * multiplier`）に一致。プレビュー額はレスポンスの `anteBet` から `state.anteBet * m` でフロントエンド計算（バックエンド変更なし）。

## 変更点

- `HighCardFlushPage.tsx`: 3つの重複したレイズボタンを `[1,2,3].map` に集約し、ラベルを `button.raiseAmount`（`{{multiplier}}`/`{{amount}}` 補間）へ変更。`maxMultiplier` による表示/非表示ロジックは維持。`data-testid="raise-{m}x"` を付与。
- i18n（ja/en キー対応）: `button.raiseAmount` を追加、未使用になった `button.raise1x/2x/3x` を削除。
- テスト: ベット額プレビューを検証する2ケースを追加、既存のボタン名マッチャを正規表現化。

## 受け入れ条件

- [x] 各レイズボタンに実際のベット額が表示される
- [x] `maxMultiplier` による表示/非表示ロジックは維持する
- [x] レイアウト崩れが起きない（既存の flex-wrap 構造・btnSuccess のまま）
- [x] コンポーネントテストで金額表示を検証する

## ゲート

- `bun run check` (biome + design-token): exit 0
- `bun run test -- --run HighCardFlushPage`: 22 passed
- `bun run build` (tsc): OK

Closes #3309
