### PR TITLE
feat(spider): highlight movable same-suit run on tableau card hover

### DIFF
--- a/frontend/src/pages/SpiderPage.test.tsx
+++ b/frontend/src/pages/SpiderPage.test.tsx
@@ -661,6 +661,105 @@ describe('SpiderPage', () => {
     await waitFor(() => expect(screen.getByTestId('stalemate-escape-button')).toBeInTheDocument());
   });
 
+  describe('movable-run hover highlight (#3061)', () => {
+    // Col 0 is a valid same-suit descending run (♠K ♠Q ♠J); col 1 breaks at the first
+    // card (♣7 then ♥6 — suit mismatch) so ♣7 is not movable while ♥6 rings itself.
+    const runState: SpiderResponse = {
+      ...playingState,
+      tableau: makeTableau([
+        [
+          { card: card('SPADE', 13), faceUp: true },
+          { card: card('SPADE', 12), faceUp: true },
+          { card: card('SPADE', 11), faceUp: true },
+        ],
+        [
+          { card: card('CLOVER', 7), faceUp: true },
+          { card: card('HEART', 6), faceUp: true },
+        ],
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+      ]),
+    };
+
+    const btnFor = (alt: string) => screen.getByAltText(alt).closest('button') as HTMLButtonElement;
+
+    it('rings the whole same-suit descending run on hover and clears on leave', async () => {
+      mockExec.mockResolvedValue(runState);
+      renderWithProviders(<SpiderPage />);
+      await waitFor(() => expect(screen.getByAltText('♠ K')).toBeInTheDocument());
+
+      const top = btnFor('♠ K');
+      fireEvent.mouseEnter(top);
+      await waitFor(() => expect(btnFor('♠ K')).toHaveAttribute('data-movable-run', 'true'));
+      expect(btnFor('♠ Q')).toHaveAttribute('data-movable-run', 'true');
+      expect(btnFor('♠ J')).toHaveAttribute('data-movable-run', 'true');
+      expect(btnFor('♠ K').className).toContain('ring-ds-success');
+
+      fireEvent.mouseLeave(top);
+      await waitFor(() => expect(btnFor('♠ K')).not.toHaveAttribute('data-movable-run'));
+    });
+
+    it('rings only the valid suffix when hovering a mid-run card', async () => {
+      mockExec.mockResolvedValue(runState);
+      renderWithProviders(<SpiderPage />);
+      await waitFor(() => expect(screen.getByAltText('♠ Q')).toBeInTheDocument());
+
+      fireEvent.mouseEnter(btnFor('♠ Q'));
+      await waitFor(() => expect(btnFor('♠ Q')).toHaveAttribute('data-movable-run', 'true'));
+      expect(btnFor('♠ J')).toHaveAttribute('data-movable-run', 'true');
+      // ♠K is above the hovered card, so it is not part of the run.
+      expect(btnFor('♠ K')).not.toHaveAttribute('data-movable-run');
+    });
+
+    it('does not ring a card whose tail is a broken sequence', async () => {
+      mockExec.mockResolvedValue(runState);
+      renderWithProviders(<SpiderPage />);
+      await waitFor(() => expect(screen.getByAltText('♣ 7')).toBeInTheDocument());
+
+      // Hovering ♣7 would drag ♥6 with it — a broken sequence — so no ring appears.
+      fireEvent.mouseEnter(btnFor('♣ 7'));
+      await waitFor(() => expect(btnFor('♥ 6')).toBeInTheDocument());
+      expect(btnFor('♣ 7')).not.toHaveAttribute('data-movable-run');
+      expect(btnFor('♥ 6')).not.toHaveAttribute('data-movable-run');
+
+      // The lone bottom card still rings itself.
+      fireEvent.mouseEnter(btnFor('♥ 6'));
+      await waitFor(() => expect(btnFor('♥ 6')).toHaveAttribute('data-movable-run', 'true'));
+    });
+
+    it('highlights the run on keyboard focus too', async () => {
+      mockExec.mockResolvedValue(runState);
+      renderWithProviders(<SpiderPage />);
+      await waitFor(() => expect(screen.getByAltText('♠ K')).toBeInTheDocument());
+
+      fireEvent.focus(btnFor('♠ K'));
+      await waitFor(() => expect(btnFor('♠ K')).toHaveAttribute('data-movable-run', 'true'));
+      expect(btnFor('♠ J')).toHaveAttribute('data-movable-run', 'true');
+
+      fireEvent.blur(btnFor('♠ K'));
+      await waitFor(() => expect(btnFor('♠ K')).not.toHaveAttribute('data-movable-run'));
+    });
+
+    it('keeps the selection ring (warning) when a hovered card is the selected source', async () => {
+      mockExec.mockResolvedValue(runState);
+      renderWithProviders(<SpiderPage />);
+      await waitFor(() => expect(screen.getByAltText('♠ K')).toBeInTheDocument());
+
+      fireEvent.click(btnFor('♠ K'));
+      await waitFor(() => expect(btnFor('♠ K')).toHaveAttribute('aria-pressed', 'true'));
+      fireEvent.mouseEnter(btnFor('♠ K'));
+      // Selection ring takes priority over the hover ring on the selected card.
+      expect(btnFor('♠ K').className).toContain('ring-ds-warning');
+      expect(btnFor('♠ K').className).not.toContain('ring-ds-success');
+    });
+  });
+
   describe('drag and drop', () => {
     function buildDataTransfer() {
       const store: Record<string, string> = {};

--- a/frontend/src/pages/SpiderPage.tsx
+++ b/frontend/src/pages/SpiderPage.tsx
@@ -36,7 +36,7 @@ import { cardAlt } from '../utils/cardAlt';
 import { parseSpiderCommand, SPIDER_HELP } from '../utils/cli/commands/spiderCommands';
 import { formatSpiderState } from '../utils/cli/formatters/spiderFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
-import { isTableauAllFaceUp } from '../utils/solitaireUtils';
+import { isTableauAllFaceUp, spiderMovableRun } from '../utils/solitaireUtils';
 
 /** Spider Solitaire tutorial step definitions. */
 const SPD_TUTORIAL_STEPS: TutorialStep[] = [
@@ -149,6 +149,10 @@ function SpiderPageContent() {
   const { handleCommand } = useCliGame(exec, cliConfig, state, { addInput, addOutput, addError, clearLog });
 
   const isPlayingForKbd = state?.phase === SpiderPhase.PLAYING;
+
+  // Movable-run hover preview: highlights the same-suit descending run that would move as a
+  // unit when a tableau card is grabbed (#3061). Purely additive — never gates clicks/drags.
+  const [hoveredRun, setHoveredRun] = useState<{ col: number; indices: number[] } | null>(null);
 
   // Empty-column deal guard: surfaces a shake animation + tooltip instead of failing silently.
   const [emptyDealAttemptKey, setEmptyDealAttemptKey] = useState(0);
@@ -350,6 +354,12 @@ function SpiderPageContent() {
                                 col: colIdx,
                                 cardIndex: cardIdx,
                               };
+                              const inMovableRun = hoveredRun?.col === colIdx && hoveredRun.indices.includes(cardIdx);
+                              const ringClass = isSourceSelected(colIdx, cardIdx)
+                                ? 'ring-2 ring-ds-warning'
+                                : inMovableRun
+                                  ? 'ring-2 ring-ds-success'
+                                  : '';
                               return (
                                 <div
                                   key={`tc-${colIdx.toString()}-${cardIdx.toString()}`}
@@ -359,6 +369,15 @@ function SpiderPageContent() {
                                   {tc.faceUp && tc.card ? (
                                     <button
                                       type="button"
+                                      onMouseEnter={() =>
+                                        setHoveredRun({ col: colIdx, indices: spiderMovableRun(col, cardIdx) })
+                                      }
+                                      onMouseLeave={() => setHoveredRun(null)}
+                                      onFocus={() =>
+                                        setHoveredRun({ col: colIdx, indices: spiderMovableRun(col, cardIdx) })
+                                      }
+                                      onBlur={() => setHoveredRun(null)}
+                                      data-movable-run={inMovableRun ? 'true' : undefined}
                                       onClick={() => {
                                         if (selectedSource) {
                                           // If clicking a different column, treat as move target
@@ -378,7 +397,7 @@ function SpiderPageContent() {
                                       draggable={isPlaying && !loading}
                                       onDragStart={dnd.handleDragStart(cardZone)}
                                       onDragEnd={dnd.handleDragEnd}
-                                      className={`p-0 border-0 bg-transparent cursor-pointer w-full rounded ${focusRingWhite} ${isSourceSelected(colIdx, cardIdx) ? 'ring-2 ring-ds-warning' : ''} ${dnd.isDragSource(cardZone) ? 'opacity-50' : ''}`}
+                                      className={`p-0 border-0 bg-transparent cursor-pointer w-full rounded ${focusRingWhite} ${ringClass} ${dnd.isDragSource(cardZone) ? 'opacity-50' : ''}`}
                                     >
                                       <AnimatedCard
                                         card={tc.card}

--- a/frontend/src/utils/solitaireUtils.test.ts
+++ b/frontend/src/utils/solitaireUtils.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { isTableauAllFaceUp } from './solitaireUtils';
+import { isTableauAllFaceUp, spiderMovableRun } from './solitaireUtils';
+
+/** Builds a face-up Spider tableau card from suit (`design`) + rank (`value`). */
+const up = (design: string, value: number) => ({ card: { design, value }, faceUp: true });
+/** Builds a face-down Spider tableau card (face hidden). */
+const down = (design: string, value: number) => ({ card: { design, value }, faceUp: false });
 
 describe('isTableauAllFaceUp', () => {
   it('returns true for an empty tableau', () => {
@@ -16,5 +21,53 @@ describe('isTableauAllFaceUp', () => {
 
   it('returns true when columns are empty arrays', () => {
     expect(isTableauAllFaceUp([[], [], []])).toBe(true);
+  });
+});
+
+describe('spiderMovableRun', () => {
+  it('rings the whole tail when it is a same-suit descending run to the bottom', () => {
+    // ♠10 ♠9 ♠8 all face-up.
+    const col = [up('spade', 10), up('spade', 9), up('spade', 8)];
+    expect(spiderMovableRun(col, 0)).toEqual([0, 1, 2]);
+  });
+
+  it('rings only the valid suffix when a hovered card starts a shorter run', () => {
+    const col = [up('spade', 10), up('spade', 9), up('spade', 8)];
+    expect(spiderMovableRun(col, 1)).toEqual([1, 2]);
+  });
+
+  it('rings only itself for the bottom card', () => {
+    const col = [up('spade', 10), up('spade', 9), up('spade', 8)];
+    expect(spiderMovableRun(col, 2)).toEqual([2]);
+  });
+
+  it('returns empty when the tail breaks below the hovered card (suit mismatch)', () => {
+    // ♠10 then ♥9 ♥8: grabbing ♠10 drags a broken sequence, so it is not movable.
+    const col = [up('spade', 10), up('heart', 9), up('heart', 8)];
+    expect(spiderMovableRun(col, 0)).toEqual([]);
+    // The valid heart suffix still rings on its own.
+    expect(spiderMovableRun(col, 1)).toEqual([1, 2]);
+  });
+
+  it('returns empty when the ranks are not strictly descending by one', () => {
+    const col = [up('spade', 10), up('spade', 8)];
+    expect(spiderMovableRun(col, 0)).toEqual([]);
+  });
+
+  it('returns empty for a face-down hovered card', () => {
+    const col = [down('spade', 10), up('spade', 9)];
+    expect(spiderMovableRun(col, 0)).toEqual([]);
+  });
+
+  it('returns empty when a card below the hovered card is face-down', () => {
+    const col = [up('spade', 10), down('spade', 9)];
+    expect(spiderMovableRun(col, 0)).toEqual([]);
+  });
+
+  it('returns empty for out-of-range or null-card indices', () => {
+    const col = [up('spade', 10)];
+    expect(spiderMovableRun(col, -1)).toEqual([]);
+    expect(spiderMovableRun(col, 5)).toEqual([]);
+    expect(spiderMovableRun([{ card: null, faceUp: true }], 0)).toEqual([]);
   });
 });

--- a/frontend/src/utils/solitaireUtils.ts
+++ b/frontend/src/utils/solitaireUtils.ts
@@ -21,3 +21,40 @@ export function isTableauAllFaceUp(tableau: readonly (readonly TableauCardLike[]
   }
   return true;
 }
+
+/** Minimal card shape for movable-run detection: suit (`design`) + rank (`value`). */
+interface SuitRankCard {
+  design: string;
+  value: number;
+}
+
+/** Tableau card with a nullable face and a face-up flag (Spider column shape). */
+interface RunTableauCard {
+  card: SuitRankCard | null;
+  faceUp: boolean;
+}
+
+/**
+ * Computes the contiguous same-suit descending run that moves as a single unit when the
+ * card at `index` is grabbed in a Spider-style tableau column. Grabbing a card in Spider
+ * always takes every card below it, so the grab is only legal when the entire tail
+ * `[index .. bottom]` is face-up, all the same suit, and strictly descending by one rank
+ * (mirroring the backend's `isValidSpiderSequence`). Returns the indices of that tail when
+ * it forms a valid movable run, or an empty array when the card is face-down, missing, or
+ * the tail is broken (i.e. not movable, so no highlight should appear).
+ */
+export function spiderMovableRun(column: readonly RunTableauCard[], index: number): number[] {
+  if (index < 0 || index >= column.length) return [];
+  const start = column[index];
+  if (!start.faceUp || !start.card) return [];
+  for (let i = index + 1; i < column.length; i++) {
+    const prev = column[i - 1].card;
+    const curr = column[i];
+    if (!curr.faceUp || !curr.card || !prev) return [];
+    if (curr.card.design !== prev.design) return [];
+    if (curr.card.value !== prev.value - 1) return [];
+  }
+  const run: number[] = [];
+  for (let i = index; i < column.length; i++) run.push(i);
+  return run;
+}


### PR DESCRIPTION
## 概要
スパイダーソリティアで、tableau のカードをホバー／フォーカスした際に、そのカードから列末尾までの「同スート降順・全表向き」の連続ラン（掴んだときに一緒に動く単位）を緑リング (`ring-ds-success`) で強調表示します。連続が切れていて移動できない位置ではリングを出しません。純粋にフロント側の追加表示で、既存のクリック／ドラッグ／移動の挙動は一切変更していません。

## 実装
- `frontend/src/utils/solitaireUtils.ts`: 純関数 `spiderMovableRun(column, index)` を追加。バックエンドの `isValidSpiderSequence`（同 `design`、`value == prev-1`、全 `faceUp`）を鏡写しにし、末尾までが有効なランのときインデックス配列を返し、壊れていれば空配列を返す。
- `frontend/src/pages/SpiderPage.tsx`: `hoveredRun` state を追加。カードボタンに `onMouseEnter/Leave` + `onFocus/Blur` を付与し、ラン内カードに `ring-ds-success`（選択中カードの `ring-ds-warning` を優先）と `data-movable-run` を付与。

## テスト
- `solitaireUtils.test.ts`: `spiderMovableRun` の単体テスト（全ラン／有効サフィックス／末尾のみ／スート断絶／降順断絶／伏せカード／範囲外・null）。
- `SpiderPage.test.tsx`: ホバーで全ランがリング表示・離脱で解除、途中カードは有効サフィックスのみ、断絶した先頭はリングなし、キーボードフォーカスでも機能、選択中カードは警告リング優先。

## ゲート
- `bun run check`（biome + デザイントークン検証）: OK
- `bun run test -- --run SpiderPage`（63 pass）/ `--run solitaireUtils`（12 pass）
- `bun run build`（tsc）: OK

## 受け入れ条件
- [x] ホバー中、同スート降順ランの範囲が緑リングで強調される
- [x] 連続が切れる位置ではリングが出ない
- [x] キーボードフォーカスでも同じ強調が機能する
- [x] ラン判定ユーティリティの単体テストを追加（C1 80%+）

Closes #3061