### PR TITLE
feat(michigan): guide boodle betting with collectible and claimed marks

### DIFF
--- a/frontend/src/i18n/locales/en/michigan.json
+++ b/frontend/src/i18n/locales/en/michigan.json
@@ -39,6 +39,8 @@
   "betMinusAria": "Remove a chip from boodle {{index}}",
   "betPlusAria": "Add a chip to boodle {{index}}",
   "placeBets": "Place bets",
+  "betCollectible": "Collectible",
+  "betClaimedWarning": "Already won",
   "playPrompt": "Play a card in an ascending same-suit run.",
   "playCardAria": "Play hand card {{index}}",
   "nextRound": "Next Round",

--- a/frontend/src/i18n/locales/ja/michigan.json
+++ b/frontend/src/i18n/locales/ja/michigan.json
@@ -39,6 +39,8 @@
   "betMinusAria": "ブードル {{index}} からチップを 1 枚減らす",
   "betPlusAria": "ブードル {{index}} にチップを 1 枚足す",
   "placeBets": "賭ける",
+  "betCollectible": "回収可能",
+  "betClaimedWarning": "獲得済み・賭け注意",
   "playPrompt": "同じスートの昇順でカードを出してください。",
   "playCardAria": "手札 {{index}} を出す",
   "nextRound": "次のラウンド",

--- a/frontend/src/pages/MichiganPage.test.tsx
+++ b/frontend/src/pages/MichiganPage.test.tsx
@@ -128,6 +128,63 @@ describe('MichiganPage', () => {
     await waitFor(() => expect(screen.getByRole('button', { name: '賭ける' })).toBeEnabled());
   });
 
+  it('marks a boodle as collectible when the human holds its matching card', async () => {
+    // Boodle 0 is A♥ (HEART 1); give the human that card so it becomes recoverable.
+    const collectibleState = makeMichiganState({
+      phase: 0,
+      isHumanTurn: true,
+      humanBetPlaced: false,
+      players: [
+        {
+          id: 0,
+          isHuman: true,
+          chips: 192,
+          roundBet: 8,
+          cardCount: 2,
+          cards: [
+            { design: 'HEART', value: 1 }, // matches boodle 0 (A♥)
+            { design: 'SPADE', value: 2 },
+          ],
+          isCurrent: true,
+          isWinner: false,
+        },
+        { id: 1, isHuman: false, chips: 192, roundBet: 8, cardCount: 5, cards: [], isCurrent: false, isWinner: false },
+        { id: 2, isHuman: false, chips: 192, roundBet: 8, cardCount: 5, cards: [], isCurrent: false, isWinner: false },
+        { id: 3, isHuman: false, chips: 192, roundBet: 8, cardCount: 5, cards: [], isCurrent: false, isWinner: false },
+      ],
+    });
+    mockExec.mockResolvedValue(collectibleState);
+    renderWithProviders(<MichiganPage />);
+    expect(await screen.findByTestId('bet-collectible-0')).toHaveTextContent('回収可能');
+    // Boodle 1 (K♣) is not held, so no collectible mark there.
+    expect(screen.queryByTestId('bet-collectible-1')).not.toBeInTheDocument();
+  });
+
+  it('shows no collectible marks when the human holds none of the boodle cards', async () => {
+    renderWithProviders(<MichiganPage />); // default betState hand matches no boodle
+    await screen.findByRole('button', { name: '賭ける' });
+    expect(screen.queryByTestId('bet-collectible-0')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('bet-collectible-1')).not.toBeInTheDocument();
+  });
+
+  it('warns on a boodle whose chips have already been claimed', async () => {
+    const claimedState = makeMichiganState({
+      phase: 0,
+      isHumanTurn: true,
+      humanBetPlaced: false,
+      boodles: [
+        { card: { design: 'HEART', value: 1 }, chips: 2, claimedBy: -1 },
+        { card: { design: 'CLOVER', value: 13 }, chips: 2, claimedBy: 2 }, // claimed
+        { card: { design: 'DIAMOND', value: 12 }, chips: 2, claimedBy: -1 },
+        { card: { design: 'SPADE', value: 11 }, chips: 2, claimedBy: -1 },
+      ],
+    });
+    mockExec.mockResolvedValue(claimedState);
+    renderWithProviders(<MichiganPage />);
+    expect(await screen.findByTestId('bet-claimed-warning-1')).toHaveTextContent('獲得済み・賭け注意');
+    expect(screen.queryByTestId('bet-claimed-warning-0')).not.toBeInTheDocument();
+  });
+
   it('hides the place-bets button when it is not the human turn', async () => {
     mockExec.mockResolvedValue(cpuTurnState);
     renderWithProviders(<MichiganPage />);

--- a/frontend/src/pages/MichiganPage.tsx
+++ b/frontend/src/pages/MichiganPage.tsx
@@ -35,6 +35,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { MICHIGAN_HELP, parseMichiganCommand } from '../utils/cli/commands/michiganCommands';
 import { formatMichiganState } from '../utils/cli/formatters/michiganFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { michiganBoodleGuides } from '../utils/michiganBoodleGuide';
 import { michiganNextPlayable } from '../utils/michiganPlayable';
 
 /** Number of center boodle cards (always 4: A♥, K♣, Q♦, J♠). */
@@ -155,6 +156,10 @@ function MichiganPageContent() {
   const betSum = bets.reduce((a, b) => a + b, 0);
   const betRemaining = state.betBudget - betSum;
   const canPlaceBets = betRemaining === 0;
+
+  // Per-boodle betting guidance: which boodles the human can recover (holds the
+  // matching card) and which are already claimed, so bets can be biased sensibly.
+  const boodleGuides = michiganBoodleGuides(state.boodles, humanPlayer?.cards ?? []);
 
   const adjustBet = (index: number, delta: number) => {
     setBets((prev) => {
@@ -404,29 +409,47 @@ function MichiganPageContent() {
                   <div className="text-ds-text-primary text-sm">
                     {t('betPrompt', { budget: state.betBudget })} · {t('betRemaining', { amount: betRemaining })}
                   </div>
-                  <div className="flex flex-wrap gap-3 items-center">
+                  <div className="flex flex-wrap gap-3 items-start">
                     {state.boodles.map((b, i) => (
-                      <div key={`bet-${i}`} className="flex items-center gap-1">
+                      <div
+                        key={`bet-${i}`}
+                        className="flex flex-col items-center gap-1"
+                        data-testid={`bet-boodle-${i}`}
+                      >
                         <CardImage card={b.card} width={Math.round(cardWidth * 0.6)} />
-                        <button
-                          type="button"
-                          className={btnDanger}
-                          onClick={() => adjustBet(i, -1)}
-                          disabled={loading || (bets[i] ?? 0) <= 0}
-                          aria-label={t('betMinusAria', { index: i })}
-                        >
-                          −
-                        </button>
-                        <span className="w-6 text-center text-ds-text-primary">{bets[i] ?? 0}</span>
-                        <button
-                          type="button"
-                          className={btnSuccess}
-                          onClick={() => adjustBet(i, 1)}
-                          disabled={loading || betRemaining <= 0}
-                          aria-label={t('betPlusAria', { index: i })}
-                        >
-                          +
-                        </button>
+                        <div className="flex flex-col items-center gap-0.5 min-h-[1rem]">
+                          {boodleGuides[i]?.collectible && (
+                            <span className="text-ds-success text-xs" data-testid={`bet-collectible-${i}`}>
+                              {t('betCollectible')}
+                            </span>
+                          )}
+                          {boodleGuides[i]?.claimed && (
+                            <span className="text-ds-warning text-xs" data-testid={`bet-claimed-warning-${i}`}>
+                              {t('betClaimedWarning')}
+                            </span>
+                          )}
+                        </div>
+                        <div className="flex items-center gap-1">
+                          <button
+                            type="button"
+                            className={btnDanger}
+                            onClick={() => adjustBet(i, -1)}
+                            disabled={loading || (bets[i] ?? 0) <= 0}
+                            aria-label={t('betMinusAria', { index: i })}
+                          >
+                            −
+                          </button>
+                          <span className="w-6 text-center text-ds-text-primary">{bets[i] ?? 0}</span>
+                          <button
+                            type="button"
+                            className={btnSuccess}
+                            onClick={() => adjustBet(i, 1)}
+                            disabled={loading || betRemaining <= 0}
+                            aria-label={t('betPlusAria', { index: i })}
+                          >
+                            +
+                          </button>
+                        </div>
                       </div>
                     ))}
                   </div>

--- a/frontend/src/utils/michiganBoodleGuide.test.ts
+++ b/frontend/src/utils/michiganBoodleGuide.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import type { Card, MichiganBoodle } from '../types/card';
+import { michiganBoodleGuides } from './michiganBoodleGuide';
+
+const boodles: MichiganBoodle[] = [
+  { card: { design: 'HEART', value: 1 }, chips: 2, claimedBy: -1 }, // A♥
+  { card: { design: 'CLOVER', value: 13 }, chips: 2, claimedBy: 1 }, // K♣ (claimed)
+  { card: { design: 'DIAMOND', value: 12 }, chips: 2, claimedBy: -1 }, // Q♦
+  { card: { design: 'SPADE', value: 11 }, chips: 2, claimedBy: -1 }, // J♠
+];
+
+describe('michiganBoodleGuides', () => {
+  it('marks a boodle collectible only when the hand holds its exact card', () => {
+    const hand: Card[] = [
+      { design: 'HEART', value: 1 }, // matches boodle 0
+      { design: 'DIAMOND', value: 12 }, // matches boodle 2
+      { design: 'SPADE', value: 2 }, // no boodle match (wrong value)
+    ];
+    const guides = michiganBoodleGuides(boodles, hand);
+    expect(guides.map((g) => g.collectible)).toEqual([true, false, true, false]);
+  });
+
+  it('flags a boodle as claimed when claimedBy is a seat index', () => {
+    const guides = michiganBoodleGuides(boodles, []);
+    expect(guides.map((g) => g.claimed)).toEqual([false, true, false, false]);
+  });
+
+  it('reports no collectible boodles for an empty hand', () => {
+    const guides = michiganBoodleGuides(boodles, []);
+    expect(guides.every((g) => !g.collectible)).toBe(true);
+  });
+
+  it('requires both matching design and value (design-only near-miss is not collectible)', () => {
+    const hand: Card[] = [{ design: 'HEART', value: 5 }]; // HEART but not A♥
+    const guides = michiganBoodleGuides(boodles, hand);
+    expect(guides[0]?.collectible).toBe(false);
+  });
+});

--- a/frontend/src/utils/michiganBoodleGuide.ts
+++ b/frontend/src/utils/michiganBoodleGuide.ts
@@ -1,0 +1,35 @@
+import type { Card, MichiganBoodle } from '../types/card';
+
+/** Per-boodle betting guidance derived from the human's hand and each boodle's claim state. */
+export interface MichiganBoodleGuide {
+  /**
+   * Whether the human holds a card matching this boodle (same design and value),
+   * so chips staked here are recoverable when that card is played.
+   */
+  collectible: boolean;
+  /** Whether this boodle's chips have already been claimed by a player. */
+  claimed: boolean;
+}
+
+/**
+ * Computes betting guidance for each Michigan boodle so the player can bias their
+ * chip distribution toward promising boodles rather than always splitting evenly.
+ *
+ * A boodle is "collectible" when the human's hand contains its exact card
+ * (matching {@link Card.design} and {@link Card.value}); it is "claimed" once a
+ * player has already taken its chips (`claimedBy >= 0`). Guidance is purely
+ * advisory and never blocks betting.
+ *
+ * @param boodles - The four center boodle cards with their claim state.
+ * @param handCards - The human's current hand (empty CPU hands yield no matches).
+ * @returns One guide per boodle, index-aligned with `boodles`.
+ */
+export function michiganBoodleGuides(
+  boodles: readonly MichiganBoodle[],
+  handCards: readonly Card[],
+): MichiganBoodleGuide[] {
+  return boodles.map((boodle) => ({
+    collectible: handCards.some((c) => c.design === boodle.card.design && c.value === boodle.card.value),
+    claimed: boodle.claimedBy >= 0,
+  }));
+}


### PR DESCRIPTION
## 概要

ミシガンのブードル賭けフェーズで、各ブードルの回収見込みを視覚的にガイドし、傾斜配分を促す。既存の均等分配 (`evenSplit`) と `betRemaining` 確定ロジックはそのまま。

- 手札にブードル札 (design+value 一致) を持つ場合、賭け UI にその横へ **回収可能** マーク (`text-ds-success`) を表示
- そのブードルが既に claimed 済み (`claimedBy >= 0`) の場合は **獲得済み・賭け注意** 警告 (`text-ds-warning`) を表示
- 純粋関数 `michiganBoodleGuides(boodles, handCards)` に判定を切り出し (CUI 側 `michiganBetHintStr` と同じ照合ロジック)
- 賭けは一切ブロックしない加算的な表示。直近の playable-next ハイライト機能には非干渉

## 受け入れ条件

- [x] 手札に該当ブードル札があると回収可能マークが出る
- [x] claimed 済みブードルに賭け警告が出る
- [x] betRemaining の既存確定ロジックを壊さない
- [x] `MichiganPage.test.tsx` にマーク表示テストを追加

## テスト / ゲート

- `frontend/src/utils/michiganBoodleGuide.test.ts` (純粋関数の照合・claimed・空手札)
- `MichiganPage.test.tsx`: 回収可能マーク表示 / 非表示 / claimed 警告
- `bun run check` (biome + design-token 検証) / `bun run test -- --run MichiganPage michiganBoodleGuide` (24 passed) / `bun run build` (tsc) すべて green
- 色は design-system トークン (`text-ds-success` / `text-ds-warning`) のみ使用
- i18n キー `betCollectible` / `betClaimedWarning` を ja/en へ key-for-key 追加

Closes #3486
