### PR TITLE
feat(trenteetquarante): visualize the 31-crossing point of each row

### DIFF
--- a/frontend/src/i18n/locales/en/trenteetquarante.json
+++ b/frontend/src/i18n/locales/en/trenteetquarante.json
@@ -9,7 +9,8 @@
     "noirRow": "Noir",
     "rougeRow": "Rouge",
     "total": "Total",
-    "winner": "Winner"
+    "winner": "Winner",
+    "crossing": "Reaches 31"
   },
   "betType": {
     "noir": "Noir",
@@ -34,7 +35,8 @@
     "win": "You win!",
     "lose": "You lose",
     "push": "Push — your stake is returned.",
-    "refait": "Refait — a tie at 31. Half your stake is lost."
+    "refait": "Refait — a tie at 31. Half your stake is lost.",
+    "margin": "{{winner}} wins by {{diff}} ({{winnerTotal}} vs {{loserTotal}})"
   },
   "payout": {
     "total": "Net payout"

--- a/frontend/src/i18n/locales/ja/trenteetquarante.json
+++ b/frontend/src/i18n/locales/ja/trenteetquarante.json
@@ -9,7 +9,8 @@
     "noirRow": "ノワール",
     "rougeRow": "ルージュ",
     "total": "合計",
-    "winner": "勝ち列"
+    "winner": "勝ち列",
+    "crossing": "31到達"
   },
   "betType": {
     "noir": "ノワール",
@@ -34,7 +35,8 @@
     "win": "勝利！",
     "lose": "敗北",
     "push": "プッシュ — 賭け金は返却されます。",
-    "refait": "ルフェ — 31での引き分け。賭け金の半分を失います。"
+    "refait": "ルフェ — 31での引き分け。賭け金の半分を失います。",
+    "margin": "{{winner}} が {{diff}} 点差で勝ち（{{winnerTotal}} 対 {{loserTotal}}）"
   },
   "payout": {
     "total": "収支"

--- a/frontend/src/pages/TrenteEtQuarantePage.test.tsx
+++ b/frontend/src/pages/TrenteEtQuarantePage.test.tsx
@@ -62,8 +62,28 @@ const refaitState = makeTrenteEtQuaranteState({
   gameEndFlag: true,
 });
 
+// Rows whose cumulative pip totals genuinely cross 31, so the running-total
+// display and the crossing marker can be asserted. Noir: 10,20,30,31 (crosses
+// on the 4th card at 31). Rouge: 10,20,30,39 (crosses on the 4th card at 39).
+const crossState = makeTrenteEtQuaranteState({
+  phase: TrenteEtQuarantePhase.RESULT,
+  stake: 100,
+  currentBet: TrenteEtQuaranteBetType.NOIR,
+  noirRow: [card('SPADE', 10), card('CLOVER', 11), card('SPADE', 12), card('CLOVER', 1)],
+  rougeRow: [card('HEART', 10), card('DIAMOND', 10), card('HEART', 10), card('DIAMOND', 9)],
+  noirTotal: 31,
+  rougeTotal: 39,
+  winningRow: 0, // Noir (lower total) wins
+  firstCardRed: false,
+  result: 1,
+  payout: 200,
+  gameEndFlag: true,
+  message: '',
+});
+
 beforeEach(() => {
   vi.clearAllMocks();
+  localStorage.clear();
   mockApi.mockResolvedValue(betState);
 });
 
@@ -114,6 +134,47 @@ describe('TrenteEtQuarantePage', () => {
     await waitFor(() => expect(screen.getByTestId('teq-result')).toBeInTheDocument());
     expect(screen.getByTestId('teq-next-round-button')).toBeInTheDocument();
     expect(screen.getByTestId('teq-result')).toHaveTextContent('200');
+  });
+
+  it('shows the running cumulative total beneath each dealt card', async () => {
+    mockApi.mockResolvedValue(crossState);
+    renderWithProviders(<TrenteEtQuarantePage />);
+    await waitFor(() => expect(screen.getByTestId('teq-cumulative-noir-0')).toBeInTheDocument());
+    // Noir cumulative: 10, 20, 30, 31.
+    expect(screen.getByTestId('teq-cumulative-noir-0')).toHaveTextContent('10');
+    expect(screen.getByTestId('teq-cumulative-noir-1')).toHaveTextContent('20');
+    expect(screen.getByTestId('teq-cumulative-noir-2')).toHaveTextContent('30');
+    expect(screen.getByTestId('teq-cumulative-noir-3')).toHaveTextContent('31');
+    // Rouge cumulative: 10, 20, 30, 39.
+    expect(screen.getByTestId('teq-cumulative-rouge-3')).toHaveTextContent('39');
+  });
+
+  it('marks the 31-crossing card in each row exactly once', async () => {
+    mockApi.mockResolvedValue(crossState);
+    renderWithProviders(<TrenteEtQuarantePage />);
+    await waitFor(() => expect(screen.getByTestId('teq-crossing-noir')).toBeInTheDocument());
+    // Only one crossing marker per row, and it sits on the finalizing (4th) card.
+    expect(screen.getAllByTestId('teq-crossing-noir')).toHaveLength(1);
+    expect(screen.getAllByTestId('teq-crossing-rouge')).toHaveLength(1);
+    expect(screen.getByTestId('teq-cumulative-noir-3')).toContainElement(screen.getByTestId('teq-crossing-noir'));
+  });
+
+  it('emphasizes the winning row total and the margin over the losing row', async () => {
+    mockApi.mockResolvedValue(crossState);
+    renderWithProviders(<TrenteEtQuarantePage />);
+    await waitFor(() => expect(screen.getByTestId('teq-margin')).toBeInTheDocument());
+    const margin = screen.getByTestId('teq-margin');
+    expect(margin).toHaveTextContent('ノワール'); // winner label
+    expect(margin).toHaveTextContent('8'); // 39 - 31 point difference
+    expect(margin).toHaveTextContent('31');
+    expect(margin).toHaveTextContent('39');
+  });
+
+  it('omits the margin line on a refait (tie at 31)', async () => {
+    mockApi.mockResolvedValue(refaitState);
+    renderWithProviders(<TrenteEtQuarantePage />);
+    await waitFor(() => expect(screen.getByText(/ルフェ/)).toBeInTheDocument());
+    expect(screen.queryByTestId('teq-margin')).not.toBeInTheDocument();
   });
 
   it('shows the refait message on a tie at 31', async () => {

--- a/frontend/src/pages/TrenteEtQuarantePage.tsx
+++ b/frontend/src/pages/TrenteEtQuarantePage.tsx
@@ -30,6 +30,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { parseTrenteEtQuaranteCommand, TRENTEETQUARANTE_HELP } from '../utils/cli/commands/trenteetquaranteCommands';
 import { formatTrenteEtQuaranteState } from '../utils/cli/formatters/trenteetquaranteFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { buildTrenteEtQuaranteRow } from '../utils/trenteEtQuaranteRow';
 
 const TEQ_TUTORIAL_STEPS: TutorialStep[] = [
   {
@@ -177,15 +178,19 @@ function TrenteEtQuarantePageContent() {
             {hasRows && (
               <div className="mb-4 flex flex-col gap-4" data-tutorial="teq-results">
                 <CardRow
+                  testId="noir"
                   label={`${t('label.noirRow')} (${state.noirTotal})`}
                   cards={state.noirRow}
                   cardWidth={cardWidth}
+                  crossingLabel={t('label.crossing')}
                   highlight={isResultPhase && !state.refait && state.winningRow === TrenteEtQuaranteWinningRow.NOIR}
                 />
                 <CardRow
+                  testId="rouge"
                   label={`${t('label.rougeRow')} (${state.rougeTotal})`}
                   cards={state.rougeRow}
                   cardWidth={cardWidth}
+                  crossingLabel={t('label.crossing')}
                   highlight={isResultPhase && !state.refait && state.winningRow === TrenteEtQuaranteWinningRow.ROUGE}
                 />
               </div>
@@ -198,6 +203,22 @@ function TrenteEtQuarantePageContent() {
                 ) : (
                   <div className="font-bold">
                     {state.result > 0 ? t('result.win') : state.result < 0 ? t('result.lose') : ''}
+                  </div>
+                )}
+                {!state.refait && state.winningRow !== TrenteEtQuaranteWinningRow.NONE && (
+                  <div className="text-ds-success" data-testid="teq-margin">
+                    {(() => {
+                      const noirWon = state.winningRow === TrenteEtQuaranteWinningRow.NOIR;
+                      const winnerName = noirWon ? t('label.noirRow') : t('label.rougeRow');
+                      const winnerTotal = noirWon ? state.noirTotal : state.rougeTotal;
+                      const loserTotal = noirWon ? state.rougeTotal : state.noirTotal;
+                      return t('result.margin', {
+                        winner: winnerName,
+                        diff: loserTotal - winnerTotal,
+                        winnerTotal,
+                        loserTotal,
+                      });
+                    })()}
                   </div>
                 )}
                 <div>
@@ -308,26 +329,50 @@ function TrenteEtQuarantePageContent() {
   );
 }
 
-/** Renders one labelled row of dealt cards, optionally highlighted as the winning row. */
+/**
+ * Renders one labelled row of dealt cards, optionally highlighted as the winning
+ * row. Each card shows the running row total beneath it, and the card that first
+ * pushes the total to 31 or more is marked as the finalizing (crossing) card.
+ */
 function CardRow({
+  testId,
   label,
   cards,
   cardWidth,
+  crossingLabel,
   highlight,
 }: {
+  testId: string;
   label: string;
   cards: Card[];
   cardWidth: number;
+  crossingLabel: string;
   highlight: boolean;
 }) {
+  const steps = buildTrenteEtQuaranteRow(cards);
   return (
-    <div className={highlight ? 'rounded-lg ring-2 ring-ds-success p-2' : 'p-2'}>
+    <div className={highlight ? 'rounded-lg ring-2 ring-ds-success p-2' : 'p-2'} data-testid={`teq-row-${testId}`}>
       <div className={`text-center font-bold mb-1 ${highlight ? 'text-ds-success' : 'text-ds-text-primary'}`}>
         {label}
       </div>
       <div className="flex justify-center gap-2 flex-wrap">
-        {cards.map((card, i) => (
-          <AnimatedCard key={`${card.design}-${card.value}-${i}`} card={card} width={cardWidth} />
+        {steps.map((step, i) => (
+          <div key={`${step.card.design}-${step.card.value}-${i}`} className="flex flex-col items-center gap-1">
+            <div className={step.crossing ? 'rounded-md ring-2 ring-ds-warning' : ''}>
+              <AnimatedCard card={step.card} width={cardWidth} />
+            </div>
+            <span
+              className={`text-xs leading-none tabular-nums ${step.crossing ? 'font-bold text-ds-warning' : 'text-ds-text-muted'}`}
+              data-testid={`teq-cumulative-${testId}-${i}`}
+            >
+              {step.cumulative}
+              {step.crossing && (
+                <span className="ml-0.5" data-testid={`teq-crossing-${testId}`} title={crossingLabel}>
+                  ▲
+                </span>
+              )}
+            </span>
+          </div>
         ))}
       </div>
     </div>

--- a/frontend/src/utils/trenteEtQuaranteRow.test.ts
+++ b/frontend/src/utils/trenteEtQuaranteRow.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import type { Card } from '../types/card';
+import { buildTrenteEtQuaranteRow, TRENTE_ET_QUARANTE_TARGET, trenteEtQuaranteCardValue } from './trenteEtQuaranteRow';
+
+const card = (value: number): Card => ({ design: 'SPADE', value });
+
+describe('trenteEtQuaranteCardValue', () => {
+  it('counts A as 1 and pips at face value', () => {
+    expect(trenteEtQuaranteCardValue(1)).toBe(1);
+    expect(trenteEtQuaranteCardValue(7)).toBe(7);
+    expect(trenteEtQuaranteCardValue(10)).toBe(10);
+  });
+
+  it('counts J/Q/K as 10', () => {
+    expect(trenteEtQuaranteCardValue(11)).toBe(10);
+    expect(trenteEtQuaranteCardValue(12)).toBe(10);
+    expect(trenteEtQuaranteCardValue(13)).toBe(10);
+  });
+});
+
+describe('buildTrenteEtQuaranteRow', () => {
+  it('accumulates the running total across cards', () => {
+    const steps = buildTrenteEtQuaranteRow([card(10), card(10), card(13)]);
+    expect(steps.map((s) => s.cumulative)).toEqual([10, 20, 30]);
+  });
+
+  it('flags the first card to reach 31 as the crossing card', () => {
+    // 10 + 10 + 10 + 5 = 35; the fourth card crosses 31.
+    const steps = buildTrenteEtQuaranteRow([card(10), card(11), card(12), card(5)]);
+    expect(steps.map((s) => s.crossing)).toEqual([false, false, false, true]);
+    const crossing = steps.find((s) => s.crossing);
+    expect(crossing?.cumulative).toBeGreaterThanOrEqual(TRENTE_ET_QUARANTE_TARGET);
+    expect(crossing?.cumulative).toBe(35);
+  });
+
+  it('marks only one crossing card even when later totals stay above 31', () => {
+    const steps = buildTrenteEtQuaranteRow([card(10), card(10), card(10), card(4)]);
+    // 10,20,30,34 — third card (30) does not cross, fourth (34) does.
+    expect(steps.filter((s) => s.crossing)).toHaveLength(1);
+    expect(steps[3].crossing).toBe(true);
+  });
+
+  it('handles an exact landing on 31', () => {
+    const steps = buildTrenteEtQuaranteRow([card(10), card(11), card(1)]);
+    // 10, 20, 21 — never reaches 31, so no crossing.
+    expect(steps.some((s) => s.crossing)).toBe(false);
+    const crossed = buildTrenteEtQuaranteRow([card(10), card(11), card(11), card(1)]);
+    // 10, 20, 30, 31 — the fourth card lands exactly on 31.
+    expect(crossed[3].crossing).toBe(true);
+    expect(crossed[3].cumulative).toBe(31);
+  });
+
+  it('returns an empty breakdown for no cards', () => {
+    expect(buildTrenteEtQuaranteRow([])).toEqual([]);
+  });
+});

--- a/frontend/src/utils/trenteEtQuaranteRow.ts
+++ b/frontend/src/utils/trenteEtQuaranteRow.ts
@@ -1,0 +1,42 @@
+import type { Card } from '../types/card';
+
+/**
+ * Lower bound at which a Trente et Quarante row stops being dealt. The dealer
+ * keeps adding cards until the running total reaches this value (31–40).
+ */
+export const TRENTE_ET_QUARANTE_TARGET = 31;
+
+/**
+ * Pip value of a single card in Trente et Quarante: A = 1, 2–10 = face value,
+ * J/Q/K = 10. Mirrors `trenteEtQuaranteCardValue` in the Go domain.
+ */
+export function trenteEtQuaranteCardValue(value: number): number {
+  return value > 10 ? 10 : value;
+}
+
+/** One dealt card paired with the running row total after it was played. */
+export interface TrenteEtQuaranteRowStep {
+  /** The dealt card. */
+  card: Card;
+  /** Cumulative pip total of the row up to and including this card. */
+  cumulative: number;
+  /** True for the card that first pushed the row total to 31 or more. */
+  crossing: boolean;
+}
+
+/**
+ * Build the running-total breakdown for a row of dealt cards. Each step carries
+ * the cumulative total after that card, and the first card whose cumulative
+ * total reaches {@link TRENTE_ET_QUARANTE_TARGET} is flagged as the crossing
+ * card (the point at which the row's total is finalized).
+ */
+export function buildTrenteEtQuaranteRow(cards: Card[]): TrenteEtQuaranteRowStep[] {
+  let cumulative = 0;
+  let crossed = false;
+  return cards.map((card) => {
+    cumulative += trenteEtQuaranteCardValue(card.value);
+    const crossing = !crossed && cumulative >= TRENTE_ET_QUARANTE_TARGET;
+    if (crossing) crossed = true;
+    return { card, cumulative, crossing };
+  });
+}


### PR DESCRIPTION
## 概要

トラント・エ・カラント（`trenteetquarante`）で、各行（ノワール/ルージュ）が **合計 31 を超えて確定する到達点** を視覚化しました。ディールの流れと「なぜその行が勝ったのか」を追えるようになります。

## 変更内容

- 各カードの下に **累積合計** を小さく表示（等幅数字）。
- 合計が初めて 31 以上に達した **境界カード** にマーカー（`ring-ds-warning` + ▲ラベル）を付与。
- 結果フェーズで **勝ち行の合計と敗け行との差** を強調表示（`teq-margin`、Refait 時は非表示）。
- 純粋ヘルパー `buildTrenteEtQuaranteRow` を新設。ピップ値（A=1, 2〜10=数字, J/Q/K=10）と境界判定は Go ドメイン `trenteEtQuaranteCardValue` / 31 到達ロジックに一致。
- i18n キー `label.crossing` / `result.margin` を ja・en 両方に追加（key-for-key）。

## 受け入れ条件

- [x] 各カードに累積合計が表示される
- [x] 31 超過の境界カードにマーカーが付く
- [x] 勝ち行の合計と敗け行との差が結果に表示される
- [x] `TrenteEtQuarantePage.test.tsx` に累積表示テストを追加

## テスト

- 新規 `trenteEtQuaranteRow.test.ts`（累積・境界判定・端点ケース）
- `TrenteEtQuarantePage.test.tsx` に累積表示・境界マーカー・マージン表示・Refait 非表示の4テストを追加
- ゲート: `bun run check`（biome + design-token 検証）/ `bun run build`（tsc）/ `bun run test` すべて green。色は design-system トークンのみ使用。

Closes #3631

🤖 Generated with [Claude Code](https://claude.com/claude-code)
