### PR TITLE
feat(bigtwo): preview selected-card combo type before playing

### DIFF
--- a/frontend/src/i18n/locales/en/bigtwo.json
+++ b/frontend/src/i18n/locales/en/bigtwo.json
@@ -53,5 +53,7 @@
     "number": "Rank",
     "label": "Sort hand"
   },
-  "tablePlayLabel": "Play"
+  "tablePlayLabel": "Play",
+  "selectedPlayLabel": "Selected",
+  "invalidCombo": "Invalid combination"
 }

--- a/frontend/src/i18n/locales/ja/bigtwo.json
+++ b/frontend/src/i18n/locales/ja/bigtwo.json
@@ -53,5 +53,7 @@
     "number": "数字順",
     "label": "手札の並べ替え"
   },
-  "tablePlayLabel": "場の役"
+  "tablePlayLabel": "場の役",
+  "selectedPlayLabel": "選択中",
+  "invalidCombo": "無効な組み合わせ"
 }

--- a/frontend/src/pages/BigTwoPage.test.tsx
+++ b/frontend/src/pages/BigTwoPage.test.tsx
@@ -133,6 +133,47 @@ describe('BigTwoPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', [2]));
   });
 
+  it('previews the combo type of a single selected card', async () => {
+    renderWithProviders(<BigTwoPage />);
+    fireEvent.click(await screen.findByTestId('hand-card-0'));
+    const preview = screen.getByTestId('bt-selected-playtype');
+    expect(preview).toHaveTextContent('選択中');
+    expect(preview).toHaveTextContent('シングル');
+  });
+
+  it('previews a pair when two same-rank cards are selected', async () => {
+    mockExec.mockResolvedValue(
+      makeState({
+        players: [
+          player(0, true, [card('SPADE', 7), card('HEART', 7), card('DIAMOND', 3)]),
+          player(1, false, []),
+          player(2, false, []),
+          player(3, false, []),
+        ],
+      }),
+    );
+    renderWithProviders(<BigTwoPage />);
+    fireEvent.click(await screen.findByTestId('hand-card-0'));
+    fireEvent.click(screen.getByTestId('hand-card-1'));
+    expect(screen.getByTestId('bt-selected-playtype')).toHaveTextContent('ペア');
+    expect(screen.getByTestId('play-button')).toBeEnabled();
+  });
+
+  it('warns and disables play for an invalid combination', async () => {
+    renderWithProviders(<BigTwoPage />);
+    // Default hand is ♠3, ♥5, ♦7 — selecting two of them is not a valid pair.
+    fireEvent.click(await screen.findByTestId('hand-card-0'));
+    fireEvent.click(screen.getByTestId('hand-card-1'));
+    expect(screen.getByTestId('bt-selected-playtype')).toHaveTextContent('無効な組み合わせ');
+    expect(screen.getByTestId('play-button')).toBeDisabled();
+  });
+
+  it('hides the selection preview when nothing is selected', async () => {
+    renderWithProviders(<BigTwoPage />);
+    await screen.findByTestId('hand-card-0');
+    expect(screen.queryByTestId('bt-selected-playtype')).not.toBeInTheDocument();
+  });
+
   it('shows the table play-type label for the cards in play', async () => {
     mockExec.mockResolvedValue(
       makeState({

--- a/frontend/src/pages/BigTwoPage.tsx
+++ b/frontend/src/pages/BigTwoPage.tsx
@@ -24,7 +24,7 @@ import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { BigTwoResponse } from '../types/card';
 import type { TutorialStep } from '../types/tutorial';
-import { type BigTwoSortMode, bigTwoPlayTypeKey, sortedBigTwoHand } from '../utils/bigTwoSort';
+import { type BigTwoSortMode, bigTwoPlayTypeKey, classifyBigTwoPlay, sortedBigTwoHand } from '../utils/bigTwoSort';
 import {
   BIGTWO_HELP,
   type BigTwoCliArgs,
@@ -139,7 +139,12 @@ function BigTwoPageContent() {
   const humanWon = isGameEnd && state.players[0]?.rank === 1;
   const isHumanTurn = state.currentTurn === 0 && !isGameEnd;
   const human = state.players[0];
-  const canPlay = isHumanTurn && selectedIndices.length > 0;
+  // Preview the combo type of the currently-selected cards (client-side, mirrors
+  // the domain classifier). 0 = invalid combination; 1-8 map to a play-type key.
+  const selectedCards = selectedIndices.map((i) => human.cards[i]).filter(Boolean);
+  const selectedPlayType = classifyBigTwoPlay(selectedCards);
+  const selectedInvalid = selectedIndices.length > 0 && selectedPlayType === 0;
+  const canPlay = isHumanTurn && selectedIndices.length > 0 && !selectedInvalid;
   const phaseName = isGameEnd ? t('phase.end') : t('phase.play');
 
   return (
@@ -218,6 +223,27 @@ function BigTwoPageContent() {
                 <span>{tc('player.you')}</span>
                 {human.isFinished && <span className="font-bold">{t(`rank.${human.rank}`)}</span>}
               </div>
+              {isHumanTurn && selectedIndices.length > 0 && (
+                <div className="mb-1.5 flex items-center justify-center">
+                  {selectedInvalid ? (
+                    <span
+                      data-testid="bt-selected-playtype"
+                      role="status"
+                      className="rounded-full bg-ds-error/30 px-2 py-0.5 text-xs font-semibold text-ds-error"
+                    >
+                      {t('invalidCombo')}
+                    </span>
+                  ) : (
+                    <span
+                      data-testid="bt-selected-playtype"
+                      role="status"
+                      className="rounded-full bg-ds-info/30 px-2 py-0.5 text-xs font-semibold text-ds-text-primary"
+                    >
+                      {`${t('selectedPlayLabel')}: ${t(`playType.${bigTwoPlayTypeKey(selectedPlayType)}`)}`}
+                    </span>
+                  )}
+                </div>
+              )}
               {human.cards.length > 0 && (
                 <fieldset className="flex justify-center gap-1.5 mb-2 border-0 p-0 m-0">
                   <legend className="sr-only">{t('sort.label')}</legend>

--- a/frontend/src/utils/bigTwoSort.test.ts
+++ b/frontend/src/utils/bigTwoSort.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import type { Card } from '../types/card';
-import { bigTwoCardStrength, bigTwoPlayTypeKey, bigTwoValueStrength, sortedBigTwoHand } from './bigTwoSort';
+import {
+  bigTwoCardStrength,
+  bigTwoPlayTypeKey,
+  bigTwoValueStrength,
+  classifyBigTwoPlay,
+  sortedBigTwoHand,
+} from './bigTwoSort';
 
 const c = (design: Card['design'], value: number): Card => ({ design, value });
 
@@ -65,5 +71,63 @@ describe('bigTwoPlayTypeKey', () => {
   it('returns null for invalid/empty (0)', () => {
     expect(bigTwoPlayTypeKey(0)).toBeNull();
     expect(bigTwoPlayTypeKey(99)).toBeNull();
+  });
+});
+
+describe('classifyBigTwoPlay', () => {
+  it('classifies a single card', () => {
+    expect(classifyBigTwoPlay([c('SPADE', 5)])).toBe(1);
+  });
+
+  it('classifies a matching pair, rejects a mismatched pair', () => {
+    expect(classifyBigTwoPlay([c('SPADE', 7), c('HEART', 7)])).toBe(2);
+    expect(classifyBigTwoPlay([c('SPADE', 7), c('HEART', 8)])).toBe(0);
+  });
+
+  it('classifies a triple, rejects a mismatched triple', () => {
+    expect(classifyBigTwoPlay([c('SPADE', 9), c('HEART', 9), c('CLOVER', 9)])).toBe(3);
+    expect(classifyBigTwoPlay([c('SPADE', 9), c('HEART', 9), c('CLOVER', 10)])).toBe(0);
+  });
+
+  it('classifies a straight (mixed suits, consecutive)', () => {
+    expect(classifyBigTwoPlay([c('SPADE', 3), c('HEART', 4), c('CLOVER', 5), c('DIAMOND', 6), c('SPADE', 7)])).toBe(4);
+  });
+
+  it('classifies the Ace-high 10-J-Q-K-A straight', () => {
+    expect(classifyBigTwoPlay([c('SPADE', 10), c('HEART', 11), c('CLOVER', 12), c('DIAMOND', 13), c('SPADE', 1)])).toBe(
+      4,
+    );
+  });
+
+  it('rejects a run containing a 2 as a straight', () => {
+    expect(classifyBigTwoPlay([c('SPADE', 1), c('HEART', 2), c('CLOVER', 3), c('DIAMOND', 4), c('SPADE', 5)])).toBe(0);
+  });
+
+  it('classifies a flush (same suit, not consecutive)', () => {
+    expect(classifyBigTwoPlay([c('SPADE', 3), c('SPADE', 5), c('SPADE', 7), c('SPADE', 9), c('SPADE', 11)])).toBe(5);
+  });
+
+  it('classifies a full house', () => {
+    expect(classifyBigTwoPlay([c('SPADE', 8), c('HEART', 8), c('CLOVER', 8), c('DIAMOND', 4), c('SPADE', 4)])).toBe(6);
+  });
+
+  it('classifies four of a kind (plus kicker)', () => {
+    expect(classifyBigTwoPlay([c('SPADE', 6), c('HEART', 6), c('CLOVER', 6), c('DIAMOND', 6), c('SPADE', 9)])).toBe(7);
+  });
+
+  it('classifies a straight flush', () => {
+    expect(classifyBigTwoPlay([c('SPADE', 3), c('SPADE', 4), c('SPADE', 5), c('SPADE', 6), c('SPADE', 7)])).toBe(8);
+  });
+
+  it('returns 0 for empty, 4-card, and 6-card selections', () => {
+    expect(classifyBigTwoPlay([])).toBe(0);
+    expect(classifyBigTwoPlay([c('SPADE', 3), c('HEART', 3), c('CLOVER', 3), c('DIAMOND', 5)])).toBe(0);
+    expect(
+      classifyBigTwoPlay([c('SPADE', 3), c('HEART', 4), c('CLOVER', 5), c('DIAMOND', 6), c('SPADE', 7), c('HEART', 8)]),
+    ).toBe(0);
+  });
+
+  it('returns 0 for a 5-card selection that is neither straight, flush, nor a set', () => {
+    expect(classifyBigTwoPlay([c('SPADE', 3), c('HEART', 5), c('CLOVER', 7), c('DIAMOND', 9), c('SPADE', 11)])).toBe(0);
   });
 });

--- a/frontend/src/utils/bigTwoSort.ts
+++ b/frontend/src/utils/bigTwoSort.ts
@@ -42,6 +42,69 @@ export function sortedBigTwoHand(cards: readonly Card[], mode: BigTwoSortMode): 
   return [...items].sort((a, b) => cmp(a.card, b.card));
 }
 
+/**
+ * Checks whether 5 rank values (any order) form a Big Two straight.
+ *
+ * Mirrors `bigTwoCheckStraight` in `internal/domain/BigTwoEval.go`: a 2 can
+ * never be part of a straight, 10-J-Q-K-A is the only Ace-high run, and the
+ * Ace (value 1) never sits at the low end.
+ */
+function bigTwoIsStraight(values: readonly number[]): boolean {
+  const sorted = [...values].sort((a, b) => a - b);
+  if (sorted.includes(2)) return false;
+  // 10-J-Q-K-A (Ace high) — sorted numerically this is [1,10,11,12,13].
+  if (sorted[0] === 1 && sorted[1] === 10 && sorted[2] === 11 && sorted[3] === 12 && sorted[4] === 13) {
+    return true;
+  }
+  if (sorted[0] === 1) return false; // Ace can only be the high end (handled above).
+  for (let i = 1; i < 5; i++) {
+    if (sorted[i] !== sorted[i - 1] + 1) return false;
+  }
+  return true;
+}
+
+/** Classifies a 5-card selection into its Big Two play type number (5-8), or 0 if invalid. */
+function bigTwoClassify5(cards: readonly Card[]): number {
+  const values = cards.map((c) => c.value);
+  const isFlush = cards.every((c) => c.design === cards[0].design);
+  const isStraight = bigTwoIsStraight(values);
+
+  const freq = new Map<number, number>();
+  for (const v of values) freq.set(v, (freq.get(v) ?? 0) + 1);
+  const counts = [...freq.values()].sort((a, b) => b - a);
+
+  if (isFlush && isStraight) return 8; // straight flush
+  if (counts[0] === 4) return 7; // four of a kind (+ kicker)
+  if (counts[0] === 3 && counts[1] === 2) return 6; // full house
+  if (isFlush) return 5; // flush
+  if (isStraight) return 4; // straight
+  return 0;
+}
+
+/**
+ * Classifies a selection of cards into its Big Two play type number, mirroring
+ * `bigTwoClassifyPlay` in `internal/domain/BigTwoEval.go`.
+ *
+ * Returns 1=single, 2=pair, 3=triple, 4=straight, 5=flush, 6=full house,
+ * 7=four of a kind, 8=straight flush, or 0 for any invalid combination
+ * (including empty, 4-card, and 6+-card selections). This classifies the
+ * combination shape only — it does not check play legality against the table.
+ */
+export function classifyBigTwoPlay(cards: readonly Card[]): number {
+  switch (cards.length) {
+    case 1:
+      return 1;
+    case 2:
+      return cards[0].value === cards[1].value ? 2 : 0;
+    case 3:
+      return cards[0].value === cards[1].value && cards[1].value === cards[2].value ? 3 : 0;
+    case 5:
+      return bigTwoClassify5(cards);
+    default:
+      return 0;
+  }
+}
+
 /** i18n key suffix for a Big Two table play type (1-8), or `null` when none is on the table. */
 export function bigTwoPlayTypeKey(playType: number): string | null {
   switch (playType) {


### PR DESCRIPTION
## 概要

Big Two (大老二) で、選択中のカードがどの役（シングル/ペア/トリプル/ストレート/フラッシュ/フルハウス/フォーカード/ストレートフラッシュ）になるかを、サーバーに送る前にリアルタイムでプレビュー表示します。無効な組み合わせでは警告を表示し、プレイボタンを無効化します（`DaifugoPage` の `countMismatch` の先例に倣う）。

## 変更点

- `frontend/src/utils/bigTwoSort.ts`: ドメインの `bigTwoClassifyPlay`（`internal/domain/BigTwoEval.go`）を移植したクライアント側の純粋関数 `classifyBigTwoPlay` を追加。既存の `bigTwoPlayTypeKey` を再利用して i18n キーへマッピング。
- `frontend/src/pages/BigTwoPage.tsx`: 手札上部に「選択中: <役>」プレビューバッジ（`bt-selected-playtype`）を表示。無効時は警告＋プレイボタン無効化。
- `frontend/src/i18n/locales/{ja,en}/bigtwo.json`: `selectedPlayLabel` / `invalidCombo` キーを ja/en 揃えて追加。
- ユニットテスト: `bigTwoSort.test.ts`（全役 + 端ケース）、`BigTwoPage.test.tsx`（プレビュー表示/無効警告）。

Go には触れていません。色は ds トークン（`bg-ds-info/30`、`bg-ds-error/30`）のみ使用。

## 受け入れ条件

- [x] カード選択時に役タイプがリアルタイム表示される
- [x] 無効な組み合わせで警告表示とプレイボタン無効化が行われる
- [x] 判定ロジックのユニットテストを追加する
- [x] ja/en の翻訳キーを追加する

## ゲート

- `bun run check`: OK（新規指摘なし）
- `bun run test -- --run bigTwoSort BigTwoPage`: 36 passed
- `bun run build`: OK

Closes #2990
