### PR TITLE
feat(carioca): preview whether a meld will accept a layoff card

### DIFF
--- a/frontend/src/i18n/locales/en/carioca.json
+++ b/frontend/src/i18n/locales/en/carioca.json
@@ -34,6 +34,8 @@
   "layoff": "Lay off",
   "meldAria": "{{player}}'s meld {{meld}}",
   "layoffTargetSummary": "→ Lay off to: {{player}} meld {{meld}}",
+  "layoffAcceptable": "This card fits",
+  "layoffNotAcceptable": "This card doesn't fit",
   "discard": "Discard card",
   "nextRound": "Next round",
   "viewLog": "View log",

--- a/frontend/src/i18n/locales/ja/carioca.json
+++ b/frontend/src/i18n/locales/ja/carioca.json
@@ -34,6 +34,8 @@
   "layoff": "レイオフ",
   "meldAria": "{{player}}のメルド{{meld}}",
   "layoffTargetSummary": "→ レイオフ先: {{player}} メルド{{meld}}",
+  "layoffAcceptable": "この札を付けられます",
+  "layoffNotAcceptable": "この札は付けられません",
   "discard": "カードを捨てる",
   "nextRound": "次のラウンドへ",
   "viewLog": "棋譜を表示",

--- a/frontend/src/pages/CariocaPage.test.tsx
+++ b/frontend/src/pages/CariocaPage.test.tsx
@@ -386,6 +386,76 @@ describe('CariocaPage', () => {
     expect(screen.getByTestId('ca-submit-contract')).toBeDisabled();
   });
 
+  it('marks a meld green for a card that fits and red for one that does not', async () => {
+    // Human contract met (no own melds) + opponent 1 has a trío of 5s to lay off onto.
+    const metState: CariocaResponse = {
+      ...playState,
+      players: [
+        { ...playState.players[0], contractMet: true },
+        {
+          ...playState.players[1],
+          contractMet: true,
+          melds: [{ cards: [card('SPADE', 5), card('HEART', 5), card('DIAMOND', 5)] }],
+        },
+        playState.players[2],
+      ],
+    };
+    mockExec.mockResolvedValue(metState);
+    renderWithProviders(<CariocaPage />);
+    const meld = await screen.findByTestId('ca-meld-1-0');
+    // No preview before a card is staged.
+    expect(meld).not.toHaveAttribute('data-layoff-accepts');
+
+    // Hand card buttons carry an image but (unlike meld buttons) no ca-meld test id.
+    const handCards = screen
+      .getAllByRole('button')
+      .filter((b) => b.querySelector('img') && !b.getAttribute('data-testid')?.startsWith('ca-meld'));
+
+    // baseHand[0] is the 5♠ — a valid fourth card for the 5-set.
+    fireEvent.click(handCards[0]);
+    expect(meld).toHaveAttribute('data-layoff-accepts', 'true');
+    expect(meld).toHaveClass('ring-ds-success');
+
+    // Toggle it off and pick baseHand[3] (K♣) — a mismatch that the set rejects.
+    fireEvent.click(handCards[0]);
+    fireEvent.click(handCards[3]);
+    expect(meld).toHaveAttribute('data-layoff-accepts', 'false');
+    expect(meld).toHaveClass('ring-ds-error');
+  });
+
+  it('annotates the layoff summary with whether the staged card fits the target meld', async () => {
+    const metState: CariocaResponse = {
+      ...playState,
+      players: [
+        { ...playState.players[0], contractMet: true },
+        {
+          ...playState.players[1],
+          contractMet: true,
+          melds: [{ cards: [card('SPADE', 5), card('HEART', 5), card('DIAMOND', 5)] }],
+        },
+        playState.players[2],
+      ],
+    };
+    mockExec.mockResolvedValue(metState);
+    renderWithProviders(<CariocaPage />);
+    const meld = await screen.findByTestId('ca-meld-1-0');
+    fireEvent.click(meld); // target this meld
+
+    const handCards = screen
+      .getAllByRole('button')
+      .filter((b) => b.querySelector('img') && !b.getAttribute('data-testid')?.startsWith('ca-meld'));
+
+    // Stage the 5♠ — the summary should report the card fits.
+    fireEvent.click(handCards[0]);
+    const acceptance = screen.getByTestId('ca-layoff-acceptance');
+    expect(acceptance).toHaveAttribute('data-accepts', 'true');
+
+    // Switch to the K♣ — the summary flips to "doesn't fit".
+    fireEvent.click(handCards[0]);
+    fireEvent.click(handCards[3]);
+    expect(screen.getByTestId('ca-layoff-acceptance')).toHaveAttribute('data-accepts', 'false');
+  });
+
   it('shows winner banner at game end', async () => {
     const endState: CariocaResponse = {
       ...drawState,

--- a/frontend/src/pages/CariocaPage.tsx
+++ b/frontend/src/pages/CariocaPage.tsx
@@ -19,7 +19,7 @@ import { btnDanger, btnOutline, btnPrimary, focusRingWhite } from '../styles/but
 import { gameTheme } from '../styles/gameTheme';
 import type { Card, CariocaContractSlot, CariocaResponse } from '../types/card';
 import type { TutorialStep } from '../types/tutorial';
-import { describeCariocaSlotShortfall, evaluateCariocaContractSlot } from '../utils/cariocaUtils';
+import { canLayoffCariocaMeld, describeCariocaSlotShortfall, evaluateCariocaContractSlot } from '../utils/cariocaUtils';
 
 /** Phase identifiers for Carioca. */
 const CA_PHASE = {
@@ -100,6 +100,18 @@ function CariocaPageContent() {
       ? tc('player.you')
       : tc('player.cpu', { id: layoffTargetPlayer.id })
     : null;
+
+  // The single card the human has staged for a layoff (only meaningful once their own
+  // contract is met and exactly one card is selected). Drives the acceptance preview.
+  const layoffCard =
+    humanPlayer?.contractMet === true && selectedCards.length === 1 ? humanPlayer.cards[selectedCards[0]] : undefined;
+
+  // Whether the staged card can actually be laid off onto the currently targeted meld.
+  // `null` = no preview (no card staged); true/false = accepted/rejected.
+  const layoffTargetMeld =
+    layoffTargetPlayer && layoffTarget ? layoffTargetPlayer.melds[layoffTarget.meldIdx] : undefined;
+  const layoffTargetAccepts =
+    layoffTargetMeld && layoffCard ? canLayoffCariocaMeld(layoffTargetMeld.cards, layoffCard) : null;
 
   const toggleCard = useCallback((idx: number) => {
     setSelectedCards((prev) => (prev.includes(idx) ? prev.filter((i) => i !== idx) : [...prev, idx]));
@@ -293,6 +305,17 @@ function CariocaPageContent() {
                   const playerLabel = p.isHuman ? tc('player.you') : tc('player.cpu', { id: p.id });
                   // The meld is only a selectable layoff target once both contracts are met.
                   const canLayoff = humanPlayer?.contractMet === true && p.contractMet;
+                  // Preview: does the staged card fit this meld? `null` when no preview applies.
+                  const accepts = canLayoff && layoffCard ? canLayoffCariocaMeld(m.cards, layoffCard) : null;
+                  // The selection highlight (warning) wins; otherwise the acceptance preview
+                  // marks the meld green (accepts) or dims + reds it (rejects).
+                  const previewRing = isLayoffTarget
+                    ? 'ring-2 ring-ds-warning bg-ds-warning/20'
+                    : accepts === true
+                      ? 'ring-2 ring-ds-success'
+                      : accepts === false
+                        ? 'ring-2 ring-ds-error opacity-50'
+                        : '';
                   return (
                     <button
                       type="button"
@@ -305,9 +328,9 @@ function CariocaPageContent() {
                       aria-label={t('meldAria', { player: playerLabel, meld: mi + 1 })}
                       // Only expose the toggle semantics when the meld is actually actionable.
                       aria-pressed={canLayoff ? isLayoffTarget : undefined}
-                      className={`flex flex-wrap gap-1 mb-1 px-1 rounded ${focusRingWhite} ${
-                        isLayoffTarget ? 'ring-2 ring-ds-warning bg-ds-warning/20' : ''
-                      }`}
+                      data-testid={`ca-meld-${p.id}-${mi}`}
+                      data-layoff-accepts={accepts === null ? undefined : String(accepts)}
+                      className={`flex flex-wrap gap-1 mb-1 px-1 rounded ${focusRingWhite} ${previewRing}`}
                     >
                       {m.cards.map((c, ci) => (
                         <AnimatedCard key={`${p.id}-${mi}-${ci}`} card={c} width={cardWidth * 0.6} />
@@ -437,6 +460,15 @@ function CariocaPageContent() {
           {layoffTarget && layoffTargetLabel && (
             <span data-testid="ca-layoff-target" className="text-xs text-ds-warning font-medium">
               {t('layoffTargetSummary', { player: layoffTargetLabel, meld: layoffTarget.meldIdx + 1 })}
+              {layoffTargetAccepts !== null && (
+                <span
+                  data-testid="ca-layoff-acceptance"
+                  data-accepts={String(layoffTargetAccepts)}
+                  className={`ml-1 ${layoffTargetAccepts ? 'text-ds-success' : 'text-ds-error'}`}
+                >
+                  {layoffTargetAccepts ? t('layoffAcceptable') : t('layoffNotAcceptable')}
+                </span>
+              )}
             </span>
           )}
         </div>

--- a/frontend/src/utils/cariocaUtils.test.ts
+++ b/frontend/src/utils/cariocaUtils.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import type { Card, ContractRummyContractSlot } from '../types/card';
-import { describeCariocaSlotShortfall, evaluateCariocaContractSlot, isCariocaRun, isCariocaSet } from './cariocaUtils';
+import {
+  canLayoffCariocaMeld,
+  describeCariocaSlotShortfall,
+  evaluateCariocaContractSlot,
+  isCariocaRun,
+  isCariocaSet,
+} from './cariocaUtils';
 import { CONTRACT_SLOT_RUN, CONTRACT_SLOT_SET } from './contractRummyUtils';
 
 const card = (design: Card['design'], value: number): Card => ({ design, value });
@@ -164,5 +170,45 @@ describe('describeCariocaSlotShortfall', () => {
     expect(
       describeCariocaSlotShortfall(runSlot, [card('SPADE', 2), card('SPADE', 3), card('SPADE', 4), card('SPADE', 9)]),
     ).toEqual({ code: 'runNotConsecutive' });
+  });
+});
+
+describe('canLayoffCariocaMeld', () => {
+  it('accepts a matching-rank card onto a set', () => {
+    // A trío of 5s accepts a fourth 5 (still a valid set).
+    expect(canLayoffCariocaMeld([card('SPADE', 5), card('HEART', 5), card('DIAMOND', 5)], card('CLOVER', 5))).toBe(
+      true,
+    );
+  });
+
+  it('rejects a mismatched-rank card onto a set', () => {
+    expect(canLayoffCariocaMeld([card('SPADE', 5), card('HEART', 5), card('DIAMOND', 5)], card('CLOVER', 8))).toBe(
+      false,
+    );
+  });
+
+  it('accepts a card that extends a run at either end (same suit)', () => {
+    const run = [card('SPADE', 3), card('SPADE', 4), card('SPADE', 5), card('SPADE', 6)];
+    expect(canLayoffCariocaMeld(run, card('SPADE', 7))).toBe(true); // high end
+    expect(canLayoffCariocaMeld(run, card('SPADE', 2))).toBe(true); // low end
+  });
+
+  it('rejects a same-suit card that does not extend the run', () => {
+    const run = [card('SPADE', 3), card('SPADE', 4), card('SPADE', 5), card('SPADE', 6)];
+    expect(canLayoffCariocaMeld(run, card('SPADE', 9))).toBe(false);
+  });
+
+  it('rejects an off-suit card onto a run', () => {
+    const run = [card('SPADE', 3), card('SPADE', 4), card('SPADE', 5), card('SPADE', 6)];
+    expect(canLayoffCariocaMeld(run, card('HEART', 7))).toBe(false);
+  });
+
+  it('rejects a layoff onto an empty meld', () => {
+    expect(canLayoffCariocaMeld([], card('SPADE', 5))).toBe(false);
+  });
+
+  it('rejects a second joker when the run already contains one', () => {
+    const run = [card('SPADE', 3), joker(), card('SPADE', 5), card('SPADE', 6)];
+    expect(canLayoffCariocaMeld(run, joker())).toBe(false);
   });
 });

--- a/frontend/src/utils/cariocaUtils.ts
+++ b/frontend/src/utils/cariocaUtils.ts
@@ -108,6 +108,18 @@ export function isCariocaRun(cards: Card[]): boolean {
 }
 
 /**
+ * Returns true iff `card` can be laid off onto an existing on-table `meldCards` meld.
+ * Mirrors the Go domain's `canAddToCariocaMeld`: the meld plus the card must still form a
+ * valid set (same rank) or run (same suit, consecutive), with at most one joker across the
+ * combined meld. An empty meld never accepts a layoff.
+ */
+export function canLayoffCariocaMeld(meldCards: Card[], card: Card): boolean {
+  if (meldCards.length === 0) return false;
+  const combined = [...meldCards, card];
+  return isCariocaSet(combined) || isCariocaRun(combined);
+}
+
+/**
  * Evaluate a single Carioca contract slot against the cards placed into it, treating a
  * joker as a wildcard. Drop-in replacement for `evaluateContractSlot` (same return shape).
  */


### PR DESCRIPTION
## 概要

カリオカのレイオフで、選択中の1枚が対象メルドに実際に付けられるかを送信前にフロントでプレビューします。無効なカードで API エラーに跳ね返される前に、可否が視覚的に分かります。

## 変更点

- `cariocaUtils.ts` に純粋関数 `canLayoffCariocaMeld(meldCards, card)` を追加。Go ドメインの `canAddToCariocaMeld` を反映し、既存の joker 対応 `isCariocaSet`/`isCariocaRun` を再利用（メルド+札がセット/ランとして有効か）。
- `CariocaPage.tsx`:
  - 手札から1枚選択中、各メルドを付けられる=`ring-ds-success`、付けられない=`ring-ds-error opacity-50` で表示（`data-layoff-accepts` 属性付き）。
  - フッターの `layoffTargetSummary` に「この札を付けられます/付けられません」を併記（`ca-layoff-acceptance`、色は `text-ds-success`/`text-ds-error`）。
  - 既存のレイオフ操作はブロックしない（追加表示のみ）。
- i18n キー `layoffAcceptable` / `layoffNotAcceptable` を ja/en 両方に key-for-key 追加。
- ユニットテスト追加（`cariocaUtils.test.ts` に helper の可否ケース、`CariocaPage.test.tsx` に緑/赤マーク＆サマリ表示テスト）。

配色はデザインシステムトークン（`ds-success`/`ds-error`）のみを使用。

## 受け入れ条件

- [x] 選択札を付けられないメルドが視覚的に無効化される（赤リング＋減光）
- [x] レイオフ可否がサマリに表示される
- [x] 判定ロジックを cariocaUtils に追加しユニットテスト
- [x] `CariocaPage.test.tsx` に可否表示テストを追加

## テスト

- `bun run test -- --run CariocaPage cariocaUtils` … 57 passed
- `bun run check` … design-tokens OK
- `bun run build` … 成功

Closes #3493
