### PR TITLE
feat(tichu): preview the combo type of the selected cards

### DIFF
--- a/frontend/src/i18n/locales/en/tichu.json
+++ b/frontend/src/i18n/locales/en/tichu.json
@@ -28,6 +28,19 @@
     "play": "Play",
     "end": "Result"
   },
+  "comboPreview": "Selected combo",
+  "invalidCombo": "Invalid combination (cannot be played as is)",
+  "combo": {
+    "single": "Single",
+    "pair": "Pair",
+    "triple": "Triple",
+    "fullHouse": "Full house",
+    "straight": "Straight",
+    "stairs": "Stairs",
+    "bomb": "Bomb",
+    "straightFlush": "Straight flush",
+    "dog": "Dog"
+  },
   "result": {
     "youWin": "Your team wins!",
     "youLose": "Opponents win",

--- a/frontend/src/i18n/locales/ja/tichu.json
+++ b/frontend/src/i18n/locales/ja/tichu.json
@@ -28,6 +28,19 @@
     "play": "プレイ",
     "end": "結果"
   },
+  "comboPreview": "選択中の役",
+  "invalidCombo": "無効な組み合わせ（このままでは出せません）",
+  "combo": {
+    "single": "シングル",
+    "pair": "ペア",
+    "triple": "スリーカード",
+    "fullHouse": "フルハウス",
+    "straight": "ストレート",
+    "stairs": "連続ペア",
+    "bomb": "ボム",
+    "straightFlush": "ストレートフラッシュ",
+    "dog": "犬"
+  },
   "result": {
     "youWin": "あなたのチームの勝利！",
     "youLose": "相手チームの勝利",

--- a/frontend/src/pages/TichuPage.test.tsx
+++ b/frontend/src/pages/TichuPage.test.tsx
@@ -262,6 +262,76 @@ describe('TichuPage', () => {
     });
   });
 
+  it('play phase: previews the combo type for a valid selection and warns on an invalid one', async () => {
+    mockExec.mockResolvedValue(
+      makeState({
+        players: [
+          player({
+            id: 0,
+            isHuman: true,
+            team: 0,
+            cardCount: 3,
+            cards: [
+              { design: 'SPADE', value: 9 },
+              { design: 'HEART', value: 9 },
+              { design: 'CLOVER', value: 8 },
+            ],
+          }),
+          player({ id: 1, team: 1 }),
+          player({ id: 2, team: 0 }),
+          player({ id: 3, team: 1 }),
+        ],
+      }),
+    );
+    const { container } = renderWithProviders(<TichuPage />);
+    await screen.findByRole('button', { name: '出す' });
+    const cards = container.querySelectorAll('[data-tutorial="tichu-hand"] button');
+
+    // Select the two nines -> a pair.
+    fireEvent.click(cards[0]);
+    fireEvent.click(cards[1]);
+    const preview = screen.getByTestId('tichu-combo-preview');
+    expect(preview).toHaveTextContent('ペア');
+
+    // Swap the second nine for the eight -> no legal combo, warning shown.
+    fireEvent.click(cards[1]);
+    fireEvent.click(cards[2]);
+    expect(screen.getByTestId('tichu-combo-invalid')).toBeInTheDocument();
+    // The Play button stays enabled — the warning is additive, the backend decides.
+    expect(screen.getByRole('button', { name: '出す' })).toBeEnabled();
+  });
+
+  it('play phase: previews a full house for a 3+2 selection', async () => {
+    mockExec.mockResolvedValue(
+      makeState({
+        players: [
+          player({
+            id: 0,
+            isHuman: true,
+            team: 0,
+            cardCount: 5,
+            cards: [
+              { design: 'SPADE', value: 7 },
+              { design: 'HEART', value: 7 },
+              { design: 'CLOVER', value: 7 },
+              { design: 'SPADE', value: 4 },
+              { design: 'HEART', value: 4 },
+            ],
+          }),
+          player({ id: 1, team: 1 }),
+          player({ id: 2, team: 0 }),
+          player({ id: 3, team: 1 }),
+        ],
+      }),
+    );
+    const { container } = renderWithProviders(<TichuPage />);
+    await screen.findByRole('button', { name: '出す' });
+    // The hand div also holds the Play button; only the first five buttons are cards.
+    const cards = container.querySelectorAll('[data-tutorial="tichu-hand"] button');
+    for (let i = 0; i < 5; i++) fireEvent.click(cards[i]);
+    expect(screen.getByTestId('tichu-combo-preview')).toHaveTextContent('フルハウス');
+  });
+
   it('toggles CLI mode', async () => {
     renderWithProviders(<TichuPage />);
     await waitFor(() => expect(screen.getByText(/CPU 1/)).toBeInTheDocument());

--- a/frontend/src/pages/TichuPage.tsx
+++ b/frontend/src/pages/TichuPage.tsx
@@ -29,6 +29,7 @@ import { cardAlt } from '../utils/cardAlt';
 import type { CliGameConfig, CliParseResult } from '../utils/cli/types';
 import { playerName } from '../utils/playerUtils';
 import { tichuBombIndices } from '../utils/tichuBomb';
+import { classifyTichuCombo } from '../utils/tichuCombo';
 
 type ApiArgs = {
   command: string;
@@ -146,6 +147,18 @@ function TichuPageContent() {
   const humanTeam = humanPlayer?.team ?? 0;
   const bombIndices = useMemo(() => tichuBombIndices(humanPlayer?.cards ?? []), [humanPlayer?.cards]);
   const humanWon = isGameEnd && !!state && state.scores[humanTeam] > state.scores[1 - humanTeam];
+
+  // Additive combo-type preview for the current selection (warn-only; the backend
+  // remains the source of truth and rejects any truly-illegal play — see #3392).
+  const selectedCombo = useMemo(() => {
+    const cards = humanPlayer?.cards ?? [];
+    const picked = Array.from(selectedCards)
+      .sort((a, b) => a - b)
+      .map((i) => cards[i])
+      .filter((c): c is NonNullable<typeof c> => c != null);
+    if (picked.length === 0) return null;
+    return classifyTichuCombo(picked);
+  }, [humanPlayer?.cards, selectedCards]);
 
   useEffect(() => {
     if (humanWon) playSound('winFanfare');
@@ -337,6 +350,23 @@ function TichuPageContent() {
                   );
                 })}
               </div>
+              {phase === 'play' && isHumanTurn && selectedCombo && (
+                <div className="mt-2 text-center text-xs" data-testid="tichu-combo-preview">
+                  {selectedCombo.type === 'invalid' ? (
+                    <span className="font-medium text-ds-warning" data-testid="tichu-combo-invalid">
+                      {t('invalidCombo')}
+                    </span>
+                  ) : (
+                    <span className="text-ds-text-secondary">
+                      {t('comboPreview')}:{' '}
+                      <span className="font-medium text-ds-accent">
+                        {t(`combo.${selectedCombo.type}`)}
+                        {selectedCombo.length > 0 ? ` (${selectedCombo.length})` : ''}
+                      </span>
+                    </span>
+                  )}
+                </div>
+              )}
               {phase === 'play' && isHumanTurn && (
                 <div className="flex justify-center gap-2 mt-2">
                   <button type="button" className={btnPrimary} onClick={handlePlay} disabled={selectedCards.size === 0}>

--- a/frontend/src/utils/tichuCombo.test.ts
+++ b/frontend/src/utils/tichuCombo.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+import type { Card } from '../types/card';
+import { classifyTichuCombo } from './tichuCombo';
+
+/** A normal suited card. */
+const c = (design: Card['design'], value: number): Card => ({ design, value });
+/** Tichu special cards (JOKER design): 1=Mahjong, 2=Dog, 3=Phoenix, 4=Dragon. */
+const MAHJONG = c('JOKER', 1);
+const DOG = c('JOKER', 2);
+const PHOENIX = c('JOKER', 3);
+const DRAGON = c('JOKER', 4);
+
+describe('classifyTichuCombo', () => {
+  it('returns invalid for an empty selection', () => {
+    expect(classifyTichuCombo([])).toEqual({ type: 'invalid', length: 0 });
+  });
+
+  it('classifies a single normal card', () => {
+    expect(classifyTichuCombo([c('SPADE', 7)])).toEqual({ type: 'single', length: 0 });
+  });
+
+  it('classifies the Mahjong as a single', () => {
+    expect(classifyTichuCombo([MAHJONG]).type).toBe('single');
+  });
+
+  it('classifies the Dragon alone as a single', () => {
+    expect(classifyTichuCombo([DRAGON]).type).toBe('single');
+  });
+
+  it('rejects the Dragon combined with other cards', () => {
+    expect(classifyTichuCombo([DRAGON, c('SPADE', 7)]).type).toBe('invalid');
+  });
+
+  it('classifies the Dog alone as a dog lead', () => {
+    expect(classifyTichuCombo([DOG])).toEqual({ type: 'dog', length: 0 });
+  });
+
+  it('rejects the Dog combined with other cards', () => {
+    expect(classifyTichuCombo([DOG, c('SPADE', 7)]).type).toBe('invalid');
+  });
+
+  it('classifies a pair', () => {
+    expect(classifyTichuCombo([c('SPADE', 9), c('HEART', 9)])).toEqual({ type: 'pair', length: 0 });
+  });
+
+  it('classifies a phoenix pair', () => {
+    expect(classifyTichuCombo([PHOENIX, c('HEART', 9)]).type).toBe('pair');
+  });
+
+  it('rejects a phoenix paired with the Mahjong', () => {
+    expect(classifyTichuCombo([PHOENIX, MAHJONG]).type).toBe('invalid');
+  });
+
+  it('rejects a mismatched two-card selection', () => {
+    expect(classifyTichuCombo([c('SPADE', 9), c('HEART', 8)]).type).toBe('invalid');
+  });
+
+  it('classifies a triple', () => {
+    expect(classifyTichuCombo([c('SPADE', 5), c('HEART', 5), c('CLOVER', 5)]).type).toBe('triple');
+  });
+
+  it('classifies a phoenix triple', () => {
+    expect(classifyTichuCombo([c('SPADE', 5), c('HEART', 5), PHOENIX]).type).toBe('triple');
+  });
+
+  it('rejects a mismatched three-card selection', () => {
+    expect(classifyTichuCombo([c('SPADE', 5), c('HEART', 5), c('CLOVER', 6)]).type).toBe('invalid');
+  });
+
+  it('classifies a full house (3 + 2)', () => {
+    const cards = [c('SPADE', 7), c('HEART', 7), c('CLOVER', 7), c('SPADE', 4), c('HEART', 4)];
+    expect(classifyTichuCombo(cards)).toEqual({ type: 'fullHouse', length: 0 });
+  });
+
+  it('classifies a phoenix full house from a triple + single', () => {
+    const cards = [c('SPADE', 7), c('HEART', 7), c('CLOVER', 7), c('SPADE', 4), PHOENIX];
+    expect(classifyTichuCombo(cards).type).toBe('fullHouse');
+  });
+
+  it('classifies a phoenix full house from two pairs', () => {
+    const cards = [c('SPADE', 7), c('HEART', 7), c('SPADE', 4), c('HEART', 4), PHOENIX];
+    expect(classifyTichuCombo(cards).type).toBe('fullHouse');
+  });
+
+  it('classifies a straight of five', () => {
+    const cards = [c('SPADE', 5), c('HEART', 6), c('CLOVER', 7), c('DIAMOND', 8), c('SPADE', 9)];
+    expect(classifyTichuCombo(cards)).toEqual({ type: 'straight', length: 5 });
+  });
+
+  it('classifies a phoenix straight that fills a gap', () => {
+    const cards = [c('SPADE', 5), c('HEART', 6), c('DIAMOND', 8), c('SPADE', 9), PHOENIX];
+    expect(classifyTichuCombo(cards)).toEqual({ type: 'straight', length: 5 });
+  });
+
+  it('classifies a phoenix straight that extends an end', () => {
+    const cards = [c('SPADE', 5), c('HEART', 6), c('CLOVER', 7), c('DIAMOND', 8), PHOENIX];
+    expect(classifyTichuCombo(cards)).toEqual({ type: 'straight', length: 5 });
+  });
+
+  it('classifies stairs (consecutive pairs)', () => {
+    const cards = [c('SPADE', 5), c('HEART', 5), c('CLOVER', 6), c('DIAMOND', 6)];
+    expect(classifyTichuCombo(cards)).toEqual({ type: 'stairs', length: 4 });
+  });
+
+  it('classifies phoenix stairs', () => {
+    const cards = [c('SPADE', 5), c('HEART', 5), c('CLOVER', 6), c('DIAMOND', 6), c('SPADE', 7), PHOENIX];
+    expect(classifyTichuCombo(cards)).toEqual({ type: 'stairs', length: 6 });
+  });
+
+  it('classifies a four-of-a-kind bomb', () => {
+    const cards = [c('SPADE', 8), c('HEART', 8), c('CLOVER', 8), c('DIAMOND', 8)];
+    expect(classifyTichuCombo(cards)).toEqual({ type: 'bomb', length: 4 });
+  });
+
+  it('classifies a straight flush', () => {
+    const cards = [c('SPADE', 5), c('SPADE', 6), c('SPADE', 7), c('SPADE', 8), c('SPADE', 9)];
+    expect(classifyTichuCombo(cards)).toEqual({ type: 'straightFlush', length: 5 });
+  });
+
+  it('rejects a selection with two phoenixes', () => {
+    expect(classifyTichuCombo([PHOENIX, PHOENIX, c('SPADE', 5)]).type).toBe('invalid');
+  });
+
+  it('rejects a four-card selection that forms no combo', () => {
+    const cards = [c('SPADE', 5), c('HEART', 6), c('CLOVER', 9), c('DIAMOND', 12)];
+    expect(classifyTichuCombo(cards).type).toBe('invalid');
+  });
+
+  it('treats an Ace as the highest natural rank in a straight', () => {
+    // 10-J-Q-K-A must be consecutive (Ace = 14).
+    const cards = [c('SPADE', 10), c('HEART', 11), c('CLOVER', 12), c('DIAMOND', 13), c('SPADE', 1)];
+    expect(classifyTichuCombo(cards)).toEqual({ type: 'straight', length: 5 });
+  });
+});

--- a/frontend/src/utils/tichuCombo.ts
+++ b/frontend/src/utils/tichuCombo.ts
@@ -1,0 +1,251 @@
+import type { Card } from '../types/card';
+
+/**
+ * The Tichu play categories, mirroring the domain `TichuComboType`
+ * (internal/domain/TichuEval.go). `invalid` covers any selection that does not
+ * form a legal combo.
+ */
+export type TichuComboType =
+  | 'single'
+  | 'pair'
+  | 'triple'
+  | 'fullHouse'
+  | 'straight'
+  | 'stairs'
+  | 'bomb'
+  | 'straightFlush'
+  | 'dog'
+  | 'invalid';
+
+/** A classified Tichu selection: its combo type and, for length-bearing combos, the card count. */
+export interface TichuComboResult {
+  type: TichuComboType;
+  /** Card count for straight / stairs / straight-flush / bomb combos; 0 otherwise. */
+  length: number;
+}
+
+// Tichu special cards use the JOKER design; the value identifies the special.
+// Mirrors internal/domain/TichuEval.go (Mahjong=1, Dog=2, Phoenix=3, Dragon=4).
+const TICHU_MAHJONG = 1;
+const TICHU_DOG = 2;
+const TICHU_PHOENIX = 3;
+const TICHU_DRAGON = 4;
+
+const TICHU_MAHJONG_RANK = 1;
+const TICHU_DRAGON_RANK = 15;
+
+/** Special-card kind for a card (0 for a normal suited card). */
+function specialKind(c: Card): number {
+  return c.design === 'JOKER' ? c.value : 0;
+}
+
+/**
+ * Tichu rank of a card used inside combos. Ace (value 1) is high (14); Mahjong=1,
+ * Dragon=15, Phoenix/Dog=-1. Mirrors `tichuRank` in TichuEval.go.
+ */
+function tichuRank(c: Card): number {
+  switch (specialKind(c)) {
+    case TICHU_MAHJONG:
+      return TICHU_MAHJONG_RANK;
+    case TICHU_DRAGON:
+      return TICHU_DRAGON_RANK;
+    case TICHU_PHOENIX:
+    case TICHU_DOG:
+      return -1;
+    default:
+      return c.value === 1 ? 14 : c.value;
+  }
+}
+
+function phoenixCount(cards: readonly Card[]): number {
+  return cards.filter((c) => specialKind(c) === TICHU_PHOENIX).length;
+}
+
+function nonPhoenix(cards: readonly Card[]): Card[] {
+  return cards.filter((c) => specialKind(c) !== TICHU_PHOENIX);
+}
+
+/** Rank -> count map over the non-phoenix cards. */
+function rankCounts(cards: readonly Card[]): Map<number, number> {
+  const m = new Map<number, number>();
+  for (const c of cards) {
+    const r = tichuRank(c);
+    m.set(r, (m.get(r) ?? 0) + 1);
+  }
+  return m;
+}
+
+/** Ascending distinct ranks from a rank-count map. */
+function sortedDistinctRanks(counts: Map<number, number>): number[] {
+  return [...counts.keys()].sort((a, b) => a - b);
+}
+
+const INVALID: TichuComboResult = { type: 'invalid', length: 0 };
+
+function tryPair(cards: readonly Card[], pcount: number): TichuComboResult | null {
+  const rest = nonPhoenix(cards);
+  if (pcount === 1) {
+    // Phoenix + one normal card; cannot pair with the Mahjong (rank 1).
+    const r = tichuRank(rest[0]);
+    if (r < TICHU_MAHJONG_RANK + 1) return null;
+    return { type: 'pair', length: 0 };
+  }
+  if (tichuRank(rest[0]) === tichuRank(rest[1]) && tichuRank(rest[0]) >= 2) {
+    return { type: 'pair', length: 0 };
+  }
+  return null;
+}
+
+function tryTriple(cards: readonly Card[], pcount: number): TichuComboResult | null {
+  const rest = nonPhoenix(cards);
+  const counts = rankCounts(rest);
+  if (pcount === 1) {
+    if (counts.size === 1 && tichuRank(rest[0]) >= 2) return { type: 'triple', length: 0 };
+    return null;
+  }
+  if (counts.size === 1 && tichuRank(rest[0]) >= 2) return { type: 'triple', length: 0 };
+  return null;
+}
+
+function tryBomb4(cards: readonly Card[], pcount: number): TichuComboResult | null {
+  if (pcount !== 0 || cards.length !== 4) return null;
+  const counts = rankCounts(cards);
+  if (counts.size === 1) {
+    const r = tichuRank(cards[0]);
+    if (r >= 2 && r <= 14) return { type: 'bomb', length: 4 };
+  }
+  return null;
+}
+
+function tryStraightFlush(cards: readonly Card[], pcount: number): TichuComboResult | null {
+  if (pcount !== 0 || cards.length < 5) return null;
+  let design = '';
+  for (const c of cards) {
+    if (c.design === 'JOKER') return null; // specials have no suit
+    if (design === '') design = c.design;
+    else if (c.design !== design) return null;
+  }
+  const counts = rankCounts(cards);
+  const ranks = sortedDistinctRanks(counts);
+  if (ranks.length !== cards.length) return null; // duplicate ranks
+  if (ranks[ranks.length - 1] - ranks[0] !== ranks.length - 1) return null; // not consecutive
+  return { type: 'straightFlush', length: cards.length };
+}
+
+function tryStraight(cards: readonly Card[], pcount: number): TichuComboResult | null {
+  if (cards.length < 5) return null;
+  const rest = nonPhoenix(cards);
+  const counts = rankCounts(rest);
+  const ranks = sortedDistinctRanks(counts);
+  if (ranks.length !== rest.length) return null; // duplicate ranks (a pair snuck in)
+  for (const r of ranks) {
+    if (r < 1 || r > 14) return null; // Dragon (15) cannot join a straight
+  }
+  if (pcount === 0) {
+    if (ranks[ranks.length - 1] - ranks[0] === ranks.length - 1) {
+      return { type: 'straight', length: cards.length };
+    }
+    return null;
+  }
+  // One phoenix: extend an end when gapless, or fill a single gap.
+  const lo = ranks[0];
+  const hi = ranks[ranks.length - 1];
+  const span = hi - lo;
+  if (span === ranks.length - 1) return { type: 'straight', length: cards.length }; // gapless -> extend
+  if (span === ranks.length) return { type: 'straight', length: cards.length }; // one gap -> fill
+  return null;
+}
+
+function tryStairs(cards: readonly Card[], pcount: number): TichuComboResult | null {
+  if (cards.length < 4 || cards.length % 2 !== 0) return null;
+  const rest = nonPhoenix(cards);
+  const counts = rankCounts(rest);
+  for (const r of counts.keys()) {
+    if (r < 2 || r > 14) return null; // Mahjong(1)/Dragon(15) cannot pair
+  }
+  const ranks = sortedDistinctRanks(counts);
+  if (ranks[ranks.length - 1] - ranks[0] !== ranks.length - 1) return null; // ranks not consecutive
+  let singles = 0;
+  for (const r of ranks) {
+    const c = counts.get(r) ?? 0;
+    if (c === 2) continue;
+    if (c === 1) singles++;
+    else return null;
+  }
+  if (pcount === 0) {
+    return singles === 0 ? { type: 'stairs', length: cards.length } : null;
+  }
+  // One phoenix: exactly one rank must be a lone single.
+  return singles === 1 ? { type: 'stairs', length: cards.length } : null;
+}
+
+function tryFullHouse(cards: readonly Card[], pcount: number): TichuComboResult | null {
+  if (cards.length !== 5) return null;
+  const rest = nonPhoenix(cards);
+  const counts = rankCounts(rest);
+  for (const r of counts.keys()) {
+    if (r < 2 || r > 14) return null;
+  }
+  if (pcount === 0) {
+    let trip = 0;
+    let pair = 0;
+    for (const [r, c] of counts) {
+      if (c === 3) trip = r;
+      else if (c === 2) pair = r;
+      else return null;
+    }
+    return trip !== 0 && pair !== 0 ? { type: 'fullHouse', length: 0 } : null;
+  }
+  // One phoenix (four normal cards).
+  const ranks = sortedDistinctRanks(counts);
+  if (ranks.length !== 2) return null;
+  const [r0, r1] = ranks;
+  const c0 = counts.get(r0) ?? 0;
+  const c1 = counts.get(r1) ?? 0;
+  if (c0 === 3 && c1 === 1) return { type: 'fullHouse', length: 0 };
+  if (c0 === 1 && c1 === 3) return { type: 'fullHouse', length: 0 };
+  if (c0 === 2 && c1 === 2) return { type: 'fullHouse', length: 0 };
+  return null;
+}
+
+/**
+ * Classifies a selection of cards into its Tichu combo type, faithfully mirroring
+ * the domain `ClassifyTichu` (internal/domain/TichuEval.go). Returns `invalid`
+ * for any selection that does not form a legal combo, and `null`-equivalent
+ * `invalid` for an empty selection. This is an ADDITIVE preview only — the
+ * backend remains the source of truth and rejects any truly-illegal play.
+ */
+export function classifyTichuCombo(cards: readonly Card[]): TichuComboResult {
+  const n = cards.length;
+  if (n === 0) return INVALID;
+
+  let hasDog = false;
+  let hasDragon = false;
+  for (const c of cards) {
+    const kind = specialKind(c);
+    if (kind === TICHU_DOG) hasDog = true;
+    else if (kind === TICHU_DRAGON) hasDragon = true;
+  }
+  const pcount = phoenixCount(cards);
+
+  // Dog: single lead only.
+  if (hasDog) return n === 1 ? { type: 'dog', length: 0 } : INVALID;
+  // Dragon: single only.
+  if (hasDragon) return n === 1 ? { type: 'single', length: 0 } : INVALID;
+
+  if (n === 1) return { type: 'single', length: 0 };
+  if (pcount > 1) return INVALID; // at most one phoenix
+
+  let result: TichuComboResult | null = null;
+  if (n === 2) result = tryPair(cards, pcount);
+  else if (n === 3) result = tryTriple(cards, pcount);
+  else {
+    result =
+      tryBomb4(cards, pcount) ??
+      tryStraightFlush(cards, pcount) ??
+      tryStraight(cards, pcount) ??
+      tryStairs(cards, pcount) ??
+      tryFullHouse(cards, pcount);
+  }
+  return result ?? INVALID;
+}


### PR DESCRIPTION
## 概要

ティチューでカードを選択したとき、その選択がどのコンボ（シングル / ペア / スリーカード / フルハウス / ストレート / 連続ペア / ボム / ストレートフラッシュ / 犬）を構成するかを Play ボタン付近にリアルタイムでプレビュー表示し、無効な選択には警告を出します。

ドメインの `ClassifyTichu`（`internal/domain/TichuEval.go`）を忠実にフロントへ移植した新ユーティリティ `frontend/src/utils/tichuCombo.ts` を追加しました。鳳凰（ワイルド）・龍・犬・麻雀の特殊カードも含めて判定します。

### 追加機能は「注意喚起のみ」
プレビューはあくまで**加算的な表示**で、Play ボタンは従来どおり `選択枚数 === 0` でのみ無効化します（フロントの分類器で `disabled` ゲートは追加していません）。特殊カードのエッジケースでドメインと分類が食い違っても正当なプレイをブロックしないためで、最終的な有効性判定はサーバ側が担います。

## 変更ファイル
- `frontend/src/utils/tichuCombo.ts`（新規：分類器）
- `frontend/src/utils/tichuCombo.test.ts`（新規：単体テスト）
- `frontend/src/pages/TichuPage.tsx`（プレビュー UI）
- `frontend/src/pages/TichuPage.test.tsx`（ページテスト）
- `frontend/src/i18n/locales/{ja,en}/tichu.json`（役名・警告の i18n キー）

## 受け入れ条件
- [x] カード選択中にコンボ種別がリアルタイム表示される
- [ ] ~~無効な組み合わせで Play ボタンが無効化される~~ → 意図的に**警告表示のみ**に変更（正当なプレイの誤ブロック回避のため。サーバ検証を信頼）
- [x] 判定ユーティリティに単体テスト（分岐カバレッジを網羅：全コンボ種別＋鳳凰系＋無効ケース）
- [x] サーバ側検証は従来どおり維持される

## テスト
- `bun run test -- --run tichuCombo TichuPage`：43 passed
- `bun run check`：exit 0（design-tokens OK）
- `bun run build`：成功（tsc 通過）

Closes #3392