### PR TITLE
feat(thirtyone): add keyboard shortcuts to action buttons

### DIFF
--- a/frontend/src/i18n/locales/en/thirtyone.json
+++ b/frontend/src/i18n/locales/en/thirtyone.json
@@ -6,6 +6,12 @@
     "discard": "Discard",
     "nextRound": "Next Round"
   },
+  "kbd": {
+    "drawStock": "S",
+    "drawDiscard": "D",
+    "knock": "K",
+    "discard": "X"
+  },
   "phase": {
     "draw": "Draw",
     "discard": "Discard",

--- a/frontend/src/i18n/locales/ja/thirtyone.json
+++ b/frontend/src/i18n/locales/ja/thirtyone.json
@@ -6,6 +6,12 @@
     "discard": "捨てる",
     "nextRound": "次のラウンド"
   },
+  "kbd": {
+    "drawStock": "S",
+    "drawDiscard": "D",
+    "knock": "K",
+    "discard": "X"
+  },
   "phase": {
     "draw": "ドロー",
     "discard": "ディスカード",

--- a/frontend/src/pages/ThirtyOnePage.test.tsx
+++ b/frontend/src/pages/ThirtyOnePage.test.tsx
@@ -245,6 +245,58 @@ describe('ThirtyOnePage', () => {
     expect(screen.queryByTestId('draw-stock-button')).not.toBeInTheDocument();
   });
 
+  it('advertises keyboard shortcuts on the action buttons', async () => {
+    renderWithProviders(<ThirtyOnePage />);
+    const drawStock = await screen.findByTestId('draw-stock-button');
+    expect(drawStock).toHaveAttribute('aria-keyshortcuts', 's');
+    expect(drawStock).toHaveTextContent('S');
+    expect(screen.getByTestId('draw-discard-button')).toHaveAttribute('aria-keyshortcuts', 'd');
+    expect(screen.getByTestId('knock-button')).toHaveAttribute('aria-keyshortcuts', 'k');
+    expect(screen.getByTestId('discard-button')).toHaveAttribute('aria-keyshortcuts', 'x');
+  });
+
+  it('draws from stock when the "s" key is pressed', async () => {
+    renderWithProviders(<ThirtyOnePage />);
+    await screen.findByTestId('draw-stock-button');
+    fireEvent.keyDown(document.body, { key: 's' });
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('drawstock'));
+  });
+
+  it('draws from the discard pile when the "d" key is pressed', async () => {
+    renderWithProviders(<ThirtyOnePage />);
+    await screen.findByTestId('draw-discard-button');
+    fireEvent.keyDown(document.body, { key: 'd' });
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('drawdiscard'));
+  });
+
+  it('knocks when the "k" key is pressed', async () => {
+    renderWithProviders(<ThirtyOnePage />);
+    await screen.findByTestId('knock-button');
+    fireEvent.keyDown(document.body, { key: 'k' });
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('knock'));
+  });
+
+  it('discards the selected card when the "x" key is pressed in the discard phase', async () => {
+    mockExec.mockResolvedValue(makeState({ phase: ThirtyOnePhase.DISCARD }));
+    renderWithProviders(<ThirtyOnePage />);
+    // The key is inert until a card is selected (mirrors the disabled button).
+    fireEvent.keyDown(document.body, { key: 'x' });
+    expect(mockExec).not.toHaveBeenCalledWith('discard', expect.anything());
+    fireEvent.click(await screen.findByTestId('hand-card-0'));
+    fireEvent.keyDown(document.body, { key: 'x' });
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('discard', 0));
+  });
+
+  it('ignores action keys when it is not the human turn', async () => {
+    mockExec.mockResolvedValue(makeState({ currentPlayerIdx: 1 }));
+    renderWithProviders(<ThirtyOnePage />);
+    await screen.findByTestId('draw-stock-button');
+    mockExec.mockClear();
+    fireEvent.keyDown(document.body, { key: 's' });
+    fireEvent.keyDown(document.body, { key: 'k' });
+    await waitFor(() => expect(mockExec).not.toHaveBeenCalled());
+  });
+
   it('shows a retry button when an action fails', async () => {
     renderWithProviders(<ThirtyOnePage />);
     const drawBtn = await screen.findByTestId('draw-stock-button');

--- a/frontend/src/pages/ThirtyOnePage.tsx
+++ b/frontend/src/pages/ThirtyOnePage.tsx
@@ -9,10 +9,12 @@ import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
 import { HintTooltip } from '../components/hint/HintTooltip';
+import { KbdBadge } from '../components/KbdBadge';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { AnimatedCardBack } from '../components/motion/AnimatedCardBack';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { withTutorial } from '../components/tutorial/withTutorial';
+import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
@@ -174,6 +176,38 @@ function ThirtyOnePageContent() {
   const humanCards = state?.players[0]?.cards;
   const suitTotals = useMemo(() => fiftyOneSuitScores(humanCards ?? []), [humanCards]);
   const bestSuit = useMemo(() => fiftyOneBestSuit(suitTotals), [suitTotals]);
+
+  // Keyboard shortcuts — must be registered before the early return so the hook
+  // order stays stable while state loads. Phase/turn flags use optional chaining
+  // for the same reason. Letter keys only (Enter/Space would double-fire on a
+  // focused button); each binding's `enabled` mirrors its button's disabled
+  // state, so keys are inert on invalid phases or when it is not the human turn.
+  const kbIsDraw = state?.phase === ThirtyOnePhase.DRAW;
+  const kbIsDiscard = state?.phase === ThirtyOnePhase.DISCARD;
+  const kbIsGameEnd = !!state?.gameEndFlag || state?.phase === ThirtyOnePhase.GAME_END;
+  const kbIsHumanTurn = state?.currentPlayerIdx === 0 && !kbIsGameEnd && (kbIsDraw || kbIsDiscard);
+  const kbCanKnock = kbIsHumanTurn && kbIsDraw && (state?.knockerIdx ?? -1) < 0;
+  const actionBindings = useMemo(
+    () => [
+      { key: 's', action: handleDrawStock, enabled: kbIsHumanTurn && kbIsDraw },
+      { key: 'd', action: handleDrawDiscard, enabled: kbIsHumanTurn && kbIsDraw && !!state?.discardTop },
+      { key: 'k', action: handleKnock, enabled: kbCanKnock },
+      { key: 'x', action: handleDiscard, enabled: kbIsHumanTurn && kbIsDiscard && selectedCardIdx !== null },
+    ],
+    [
+      handleDrawStock,
+      handleDrawDiscard,
+      handleKnock,
+      handleDiscard,
+      kbIsHumanTurn,
+      kbIsDraw,
+      kbIsDiscard,
+      kbCanKnock,
+      state?.discardTop,
+      selectedCardIdx,
+    ],
+  );
+  useActionKeyboardNav({ bindings: actionBindings, enabled: !cliEnabled && !loading });
 
   if (!state || state.players.length < 4)
     return <GameSkeleton gameKey="thirtyone" layout={{ kind: 'centered', rows: [3, 3] }} />;
@@ -423,8 +457,10 @@ function ThirtyOnePageContent() {
                 disabled={loading || !isHumanTurn || !isDraw}
                 className="px-4 py-2 rounded-lg bg-ds-info text-white font-medium disabled:opacity-40 disabled:cursor-not-allowed text-sm"
                 data-testid="draw-stock-button"
+                aria-keyshortcuts="s"
               >
                 {t('button.drawStock')}
+                <KbdBadge label={t('kbd.drawStock')} />
               </button>
               <button
                 type="button"
@@ -432,8 +468,10 @@ function ThirtyOnePageContent() {
                 disabled={loading || !isHumanTurn || !isDraw || !state.discardTop}
                 className="px-4 py-2 rounded-lg bg-ds-info text-white font-medium disabled:opacity-40 disabled:cursor-not-allowed text-sm"
                 data-testid="draw-discard-button"
+                aria-keyshortcuts="d"
               >
                 {t('button.drawDiscard')}
+                <KbdBadge label={t('kbd.drawDiscard')} />
               </button>
               <button
                 type="button"
@@ -441,8 +479,10 @@ function ThirtyOnePageContent() {
                 disabled={loading || !canKnock}
                 className="px-4 py-2 rounded-lg bg-ds-warning text-white font-medium disabled:opacity-40 disabled:cursor-not-allowed text-sm"
                 data-testid="knock-button"
+                aria-keyshortcuts="k"
               >
                 {t('button.knock')}
+                <KbdBadge label={t('kbd.knock')} />
               </button>
               <button
                 type="button"
@@ -450,8 +490,10 @@ function ThirtyOnePageContent() {
                 disabled={loading || !isHumanTurn || !isDiscard || selectedCardIdx === null}
                 className="px-4 py-2 rounded-lg bg-ds-success text-white font-medium disabled:opacity-40 disabled:cursor-not-allowed text-sm"
                 data-testid="discard-button"
+                aria-keyshortcuts="x"
               >
                 {t('button.discard')}
+                <KbdBadge label={t('kbd.discard')} />
               </button>
               {isRoundEnd && (
                 <button


### PR DESCRIPTION
## 概要

サーティワン (`thirtyone`) のアクションボタンにキーボードショートカットを追加しました。既存の `useActionKeyboardNav` + `KbdBadge` パターンをカジノ系/ソリティア系ページと同じ形で流用しています。フロントエンドのみ、バックエンド変更なし。

## バインドしたキー

| キー | アクション | 有効条件 |
|------|-----------|----------|
| `s` | 山札から引く | DRAW フェーズ・自分の手番 |
| `d` | 捨て札から引く | DRAW フェーズ・自分の手番・捨て札トップあり |
| `k` | ノック | DRAW フェーズ・まだ誰もノックしていない |
| `x` | 選択カードを捨てる | DISCARD フェーズ・カード選択済み |

- 各ボタンに `aria-keyshortcuts` と `<KbdBadge>` チップを付与（発見可能性）。
- `useActionKeyboardNav` は早期 return より前で呼び出し、フックの呼び出し順を安定化。バインディングは `useMemo` でメモ化。
- 各バインディングの `enabled` は対応するボタンの `disabled` 条件を反映。無効フェーズ・非手番ではキーは反応しません。
- `Enter`/`Space` はフォーカス中ボタンの二重発火を避けるため意図的に未バインド。カード選択の数字キーは追加せず（軽量スコープ）、レターキーとの衝突なし。

## 受け入れ条件

- [x] DRAW フェーズで s/d キーによりドローできる
- [x] DISCARD フェーズでカード選択後、実行キー (`x`) で捨てられる
- [x] 無効フェーズ・非手番ではキーが反応しない
- [x] `ThirtyOnePage.test.tsx` にキー操作のテストを追加
- [x] ja/en 両方に `kbd.*` キーを追加

## テスト

- `frontend/src/pages/ThirtyOnePage.test.tsx` に 6 件のキーボード操作テストを追加（合計 28 件全パス）。
- `bun run check` / `bun run test -- --run ThirtyOnePage` / `bun run build` すべてパス。

Closes #3356
