### PR TITLE
feat(bezique): warn as the stock nears empty before the endgame

### DIFF
--- a/frontend/src/i18n/locales/en/bezique.json
+++ b/frontend/src/i18n/locales/en/bezique.json
@@ -19,6 +19,7 @@
   "trumpCard": "Trump card: {{card}}",
   "stock": "Stock: {{count}}",
   "noTrump": "undeclared",
+  "stockLowWarning": "Endgame approaching ({{count}} left in stock) — declare your melds soon.",
   "endgameNotice": "Phase 2 (endgame) — strict must-follow. No melds. Last trick scores +10.",
   "currentTrick": "Current Trick",
   "you": "You",

--- a/frontend/src/i18n/locales/ja/bezique.json
+++ b/frontend/src/i18n/locales/ja/bezique.json
@@ -19,6 +19,7 @@
   "trumpCard": "切り札カード: {{card}}",
   "stock": "山札: {{count}}枚",
   "noTrump": "未宣言",
+  "stockLowWarning": "まもなくエンドゲーム（山札残り{{count}}枚）— メルドはお早めに宣言を。",
   "endgameNotice": "フェーズ2（終盤）— マストフォロー。メルドは宣言できません。最終トリックは+10点。",
   "currentTrick": "現在のトリック",
   "you": "あなた",

--- a/frontend/src/pages/BeziquePage.test.tsx
+++ b/frontend/src/pages/BeziquePage.test.tsx
@@ -193,6 +193,28 @@ describe('BeziquePage', () => {
     expect(card).not.toHaveAttribute('data-legal');
   });
 
+  it('shows the low-stock endgame warning when the stock nears empty', async () => {
+    mockExec.mockResolvedValue(makeBeziqueState({ phase: 0, currentPlayerIdx: 0, stockRemaining: 3 }));
+    renderWithProviders(<BeziquePage />);
+    const warning = await screen.findByTestId('bezique-stock-warning');
+    expect(warning).toHaveTextContent('3');
+    expect(warning).toHaveAttribute('role', 'status');
+  });
+
+  it('does not show the low-stock warning while the stock is plentiful', async () => {
+    // Default fixture has stockRemaining 30 (well above the threshold).
+    renderWithProviders(<BeziquePage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: '出す' })).toBeInTheDocument());
+    expect(screen.queryByTestId('bezique-stock-warning')).not.toBeInTheDocument();
+  });
+
+  it('drops the low-stock warning once the endgame begins', async () => {
+    mockExec.mockResolvedValue(endgameState);
+    renderWithProviders(<BeziquePage />);
+    await waitFor(() => expect(screen.getByText(/フェーズ2/)).toBeInTheDocument());
+    expect(screen.queryByTestId('bezique-stock-warning')).not.toBeInTheDocument();
+  });
+
   it('renders the game end message', async () => {
     mockExec.mockResolvedValue(gameEndState);
     renderWithProviders(<BeziquePage />);

--- a/frontend/src/pages/BeziquePage.tsx
+++ b/frontend/src/pages/BeziquePage.tsx
@@ -42,6 +42,13 @@ const SUIT_KEYS = ['', 'spade', 'club', 'heart', 'diamond'] as const;
 /** Meld-name i18n key suffixes indexed by meld type (0=marriage … 5=four jacks). */
 const MELD_NAME_KEYS = ['marriage', 'bezique', 'fourAces', 'fourKings', 'fourQueens', 'fourJacks'] as const;
 
+/**
+ * Stock (talon) count at or below which the pre-endgame warning is shown. When the
+ * stock empties the game jumps to phase 2 (strict must-follow, no melds), so this
+ * gives the player a few turns' notice to finish declaring melds.
+ */
+const STOCK_LOW_THRESHOLD = 4;
+
 /** Bezique tutorial step definitions. */
 const BEZIQUE_TUTORIAL_STEPS: TutorialStep[] = [
   { target: '[data-tutorial="bezique-info"]', messageKey: 'tutorial.info', placement: 'bottom', advanceOn: 'next' },
@@ -138,6 +145,10 @@ function BeziquePageContent() {
 
   const trumpSymbol = state.trumpSuit >= 1 && state.trumpSuit <= 4 ? SUIT_SYMBOLS[state.trumpSuit] : t('noTrump');
 
+  // Warn as the stock nears empty (but before the endgame actually begins): once it
+  // hits 0 the game switches to phase 2 and the existing endgameNotice takes over.
+  const stockLow = !state.isEndgame && state.stockRemaining > 0 && state.stockRemaining <= STOCK_LOW_THRESHOLD;
+
   // During the endgame (phase 2) the follower must follow suit and win if able.
   // Ring the legal-to-play cards so the human sees the constraint before playing.
   // Only meaningful when following a lead: while leading (or before the endgame)
@@ -230,9 +241,22 @@ function BeziquePageContent() {
               <span className="mr-4">{t('deal', { n: state.roundNumber })}</span>
               <span className="mr-4">{t('trick', { n: state.trickNumber })}</span>
               <span className="mr-4">{t('trump', { suit: trumpSymbol })}</span>
-              <span className="mr-4">{t('stock', { count: state.stockRemaining })}</span>
+              <span className={`mr-4 ${stockLow ? 'text-ds-warning font-semibold motion-safe:animate-pulse' : ''}`}>
+                {t('stock', { count: state.stockRemaining })}
+              </span>
               <span>{t('target', { points: state.config.targetScore })}</span>
             </div>
+
+            {stockLow && (
+              <div
+                role="status"
+                aria-live="polite"
+                data-testid="bezique-stock-warning"
+                className="text-ds-warning text-center mb-2 text-sm font-semibold motion-safe:animate-pulse"
+              >
+                {t('stockLowWarning', { count: state.stockRemaining })}
+              </div>
+            )}
 
             {state.isEndgame && (
               <div className="text-ds-warning text-center mb-2 text-sm font-semibold">{t('endgameNotice')}</div>


### PR DESCRIPTION
## 概要
ベジークで山札（talon）が尽きるとフェーズ2（マストフォロー・メルド不可）へ突然移行するため、残数が少なくなった時点で事前警告を表示する。

## 変更内容
- 山札残数が閾値（`STOCK_LOW_THRESHOLD = 4`）以下になると、ヘッダーの stock 表示を `text-ds-warning` + `motion-safe:animate-pulse` に切り替え。
- `role="status"` / `aria-live="polite"` の補助バナー（`data-testid="bezique-stock-warning"`）で「まもなくエンドゲーム（残り{{count}}枚）」を表示。
- `isEndgame`（stockRemaining === 0）になると事前警告は消え、既存の `endgameNotice` に引き継ぐ。
- ja/en 両ロケールに `stockLowWarning` を key-for-key で追加。
- 閾値前後・エンドゲーム移行後のテストを追加。

閾値はドメイン（`Bezique.IsEndgame()` = 山札残 0 かつ切り札表示なし）に基づく。フロントエンドのみの変更で、バックエンドや既存のエンドゲーム合法カードハイライトには手を加えていない。

デザイントークン（`text-ds-warning`）のみ使用（生の Tailwind パレット不使用）。

## 受け入れ条件
- [x] 山札残数が閾値以下で警告スタイルに変わる
- [x] 事前警告テキストが表示され、エンドゲーム移行後は消える
- [x] ja/en 両ロケールに文言を追加
- [x] BeziquePage.test.tsx に閾値前後のテストを追加

## テスト
- `bun run check` OK（design-tokens: OK）
- `bun run test -- --run BeziquePage` 19 passed
- `bun run build` OK

Closes #3452
