### PR TITLE
feat(belote): highlight legal-to-play cards during the play phase

### DIFF
--- a/frontend/src/pages/BelotePage.test.tsx
+++ b/frontend/src/pages/BelotePage.test.tsx
@@ -306,4 +306,61 @@ describe('BelotePage', () => {
     fireEvent.click(await screen.findByRole('button', { name: 'ヒント' }));
     await waitFor(() => expect(screen.getByText(/を宣言/)).toBeInTheDocument());
   });
+
+  it('rings only the legal follow-suit card during the human play turn', async () => {
+    // Trump ♠(1). Opponent leads ♥; the human holds ♥10 so must follow ♥.
+    // Only ♥10 is legal; ♠J and ♣9 are illegal.
+    mockExec.mockResolvedValue(
+      makeState({
+        phase: BelotePhase.PLAY,
+        trumpSuit: 1,
+        currentPlayerIdx: 0,
+        makerTeam: 0,
+        currentTrick: [{ playerIdx: 1, card: card('HEART', 13) }],
+      }),
+    );
+    renderWithProviders(<BelotePage />);
+    const legalCard = await screen.findByRole('button', { name: '♥ 10' });
+    const illegalCard = screen.getByRole('button', { name: '♠ J' });
+    expect(legalCard).toHaveAttribute('data-legal', 'true');
+    expect(illegalCard).not.toHaveAttribute('data-legal');
+  });
+
+  it('keeps an illegal card clickable so the backend still validates the play', async () => {
+    // Same setup: ♠J is illegal (must follow ♥) but must remain selectable —
+    // the highlight is additive only and never blocks clicks (see hearts #3977).
+    mockExec.mockResolvedValue(
+      makeState({
+        phase: BelotePhase.PLAY,
+        trumpSuit: 1,
+        currentPlayerIdx: 0,
+        makerTeam: 0,
+        currentTrick: [{ playerIdx: 1, card: card('HEART', 13) }],
+      }),
+    );
+    renderWithProviders(<BelotePage />);
+    const illegalCard = await screen.findByRole('button', { name: '♠ J' });
+    expect(illegalCard).not.toHaveAttribute('aria-disabled');
+    // The Play button is disabled until a card is selected.
+    expect(screen.getByRole('button', { name: '出す' })).toBeDisabled();
+    fireEvent.click(illegalCard);
+    // Clicking the illegal card selects it and enables Play — no client-side block.
+    expect(illegalCard).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: '出す' })).not.toBeDisabled();
+  });
+
+  it('does not ring any card during a CPU play turn', async () => {
+    mockExec.mockResolvedValue(
+      makeState({
+        phase: BelotePhase.PLAY,
+        trumpSuit: 1,
+        currentPlayerIdx: 1,
+        makerTeam: 0,
+        currentTrick: [{ playerIdx: 1, card: card('HEART', 13) }],
+      }),
+    );
+    renderWithProviders(<BelotePage />);
+    const humanCard = await screen.findByRole('button', { name: '♥ 10' });
+    expect(humanCard).not.toHaveAttribute('data-legal');
+  });
 });

--- a/frontend/src/pages/BelotePage.tsx
+++ b/frontend/src/pages/BelotePage.tsx
@@ -24,6 +24,7 @@ import { lgCardAreaConstraint } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
 import { BelotePhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { beloteLegalPlayIndices } from '../utils/beloteLegal';
 import { playerName } from '../utils/playerUtils';
 
 /** Belote tutorial step definitions. */
@@ -164,6 +165,13 @@ function BelotePageContent() {
   const humanIdx = state.players.findIndex((p) => p.isHuman);
   const isHumanBidTurn = (isBidPickUp || isBidCallTrump) && state.bidPlayerIdx === humanIdx;
   const isHumanTurn = isPlayPhase && state.players[state.currentPlayerIdx]?.isHuman === true;
+  // Legal-play highlight: compute the follow-suit / trump-obligation legal set
+  // on the human's play turn only (mirrors internal/domain/Belote.go validatePlay).
+  // Ring-only, additive — illegal cards stay clickable and the backend still validates.
+  const legalPlayIndices =
+    isHumanTurn && humanPlayer
+      ? beloteLegalPlayIndices(humanPlayer.cards, state.currentTrick, state.trumpSuit, humanIdx)
+      : undefined;
   const faceUpSuit = state.faceUpCard?.design;
   const allSuits = [1, 2, 3, 4];
   const faceUpSuitNum =
@@ -396,6 +404,7 @@ function BelotePageContent() {
             cardWidth={cardWidth}
             isMobile={isMobile}
             dataTutorialPrefix="be"
+            legalIndices={legalPlayIndices}
           />
         )}
 

--- a/frontend/src/utils/beloteLegal.test.ts
+++ b/frontend/src/utils/beloteLegal.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+import type { BeloteTrickCard, Card } from '../types/card';
+import { beloteLegalPlayIndices, isBeloteLegalPlay } from './beloteLegal';
+
+// Trump is HEART (suit number 3) throughout unless noted.
+const TRUMP = 3;
+
+/** Builds a trick card played by the given seat. */
+function played(playerIdx: number, design: Card['design'], value: number): BeloteTrickCard {
+  return { playerIdx, card: { design, value } };
+}
+
+describe('isBeloteLegalPlay', () => {
+  it('allows any card when leading (empty trick)', () => {
+    const hand: Card[] = [
+      { design: 'SPADE', value: 7 },
+      { design: 'HEART', value: 11 },
+    ];
+    for (const card of hand) {
+      expect(isBeloteLegalPlay(card, hand, [], TRUMP, 0)).toBe(true);
+    }
+  });
+
+  it('requires following a non-trump lead suit when the hand holds it', () => {
+    const hand: Card[] = [
+      { design: 'SPADE', value: 7 },
+      { design: 'SPADE', value: 8 },
+      { design: 'CLOVER', value: 9 },
+      { design: 'HEART', value: 11 },
+    ];
+    const trick = [played(1, 'SPADE', 12)];
+    expect(isBeloteLegalPlay(hand[0], hand, trick, TRUMP, 0)).toBe(true); // ♠7 follows
+    expect(isBeloteLegalPlay(hand[1], hand, trick, TRUMP, 0)).toBe(true); // ♠8 follows
+    expect(isBeloteLegalPlay(hand[2], hand, trick, TRUMP, 0)).toBe(false); // ♣9 illegal
+    expect(isBeloteLegalPlay(hand[3], hand, trick, TRUMP, 0)).toBe(false); // ♥J illegal
+  });
+
+  it('forces a trump when void of the lead suit and holding trump (obligation à couper)', () => {
+    const hand: Card[] = [
+      { design: 'CLOVER', value: 9 },
+      { design: 'HEART', value: 11 },
+      { design: 'HEART', value: 7 },
+    ];
+    const trick = [played(1, 'SPADE', 12)]; // opponent leads, no trump yet
+    expect(isBeloteLegalPlay(hand[0], hand, trick, TRUMP, 0)).toBe(false); // ♣9 illegal (must trump)
+    expect(isBeloteLegalPlay(hand[1], hand, trick, TRUMP, 0)).toBe(true); // ♥J legal
+    expect(isBeloteLegalPlay(hand[2], hand, trick, TRUMP, 0)).toBe(true); // ♥7 legal (no trump in trick yet)
+  });
+
+  it('forces over-trumping when able (obligation à monter)', () => {
+    const hand: Card[] = [
+      { design: 'HEART', value: 11 }, // trump rank 8 — beats 9
+      { design: 'HEART', value: 7 }, // trump rank 1 — cannot beat
+      { design: 'CLOVER', value: 5 },
+    ];
+    // Opponent 1 leads spade; opponent 3 trumps with ♥9 (trump rank 7). Seat 0 is void of spade.
+    const trick = [played(1, 'SPADE', 12), played(3, 'HEART', 9)];
+    expect(isBeloteLegalPlay(hand[0], hand, trick, TRUMP, 0)).toBe(true); // ♥J over-trumps
+    expect(isBeloteLegalPlay(hand[1], hand, trick, TRUMP, 0)).toBe(false); // ♥7 fails to over-trump
+    expect(isBeloteLegalPlay(hand[2], hand, trick, TRUMP, 0)).toBe(false); // ♣5 illegal
+  });
+
+  it('waives the trump obligation when the partner is currently winning', () => {
+    const hand: Card[] = [
+      { design: 'CLOVER', value: 5 },
+      { design: 'HEART', value: 11 },
+    ];
+    // Seat 0's partner is seat 2, who leads/holds the winning ♠A over seat 1's ♠7.
+    const trick = [played(1, 'SPADE', 7), played(2, 'SPADE', 1)];
+    for (const card of hand) {
+      expect(isBeloteLegalPlay(card, hand, trick, TRUMP, 0)).toBe(true);
+    }
+  });
+
+  it('allows any card when void of both the lead suit and trump', () => {
+    const hand: Card[] = [
+      { design: 'CLOVER', value: 5 },
+      { design: 'DIAMOND', value: 9 },
+    ];
+    const trick = [played(1, 'SPADE', 12)];
+    for (const card of hand) {
+      expect(isBeloteLegalPlay(card, hand, trick, TRUMP, 0)).toBe(true);
+    }
+  });
+
+  it('requires following a trump lead and over-trumping when able', () => {
+    const hand: Card[] = [
+      { design: 'HEART', value: 11 }, // trump rank 8
+      { design: 'HEART', value: 8 }, // trump rank 2
+      { design: 'CLOVER', value: 5 },
+    ];
+    const trick = [played(1, 'HEART', 7)]; // trump lead, rank 1
+    expect(isBeloteLegalPlay(hand[0], hand, trick, TRUMP, 0)).toBe(true); // ♥J beats rank 1
+    expect(isBeloteLegalPlay(hand[1], hand, trick, TRUMP, 0)).toBe(true); // ♥8 beats rank 1
+    expect(isBeloteLegalPlay(hand[2], hand, trick, TRUMP, 0)).toBe(false); // ♣5 must follow trump
+  });
+
+  it('allows any card on a trump lead when void of trump', () => {
+    const hand: Card[] = [
+      { design: 'SPADE', value: 7 },
+      { design: 'CLOVER', value: 9 },
+    ];
+    const trick = [played(1, 'HEART', 7)];
+    for (const card of hand) {
+      expect(isBeloteLegalPlay(card, hand, trick, TRUMP, 0)).toBe(true);
+    }
+  });
+});
+
+describe('beloteLegalPlayIndices', () => {
+  it('returns every index when leading', () => {
+    const hand: Card[] = [
+      { design: 'SPADE', value: 7 },
+      { design: 'HEART', value: 11 },
+      { design: 'CLOVER', value: 9 },
+    ];
+    expect(beloteLegalPlayIndices(hand, [], TRUMP, 0)).toEqual([0, 1, 2]);
+  });
+
+  it('returns only the follow-suit indices', () => {
+    const hand: Card[] = [
+      { design: 'SPADE', value: 7 },
+      { design: 'CLOVER', value: 9 },
+      { design: 'SPADE', value: 8 },
+    ];
+    const trick = [played(1, 'SPADE', 12)];
+    expect(beloteLegalPlayIndices(hand, trick, TRUMP, 0)).toEqual([0, 2]);
+  });
+
+  it('returns only the over-trumping index under the monter obligation', () => {
+    const hand: Card[] = [
+      { design: 'HEART', value: 11 },
+      { design: 'HEART', value: 7 },
+      { design: 'CLOVER', value: 5 },
+    ];
+    const trick = [played(1, 'SPADE', 12), played(3, 'HEART', 9)];
+    expect(beloteLegalPlayIndices(hand, trick, TRUMP, 0)).toEqual([0]);
+  });
+});

--- a/frontend/src/utils/beloteLegal.ts
+++ b/frontend/src/utils/beloteLegal.ts
@@ -1,0 +1,221 @@
+import type { BeloteTrickCard, Card } from '../types/card';
+
+/**
+ * Converts a card's suit design string into the 1-4 suit number the Belote
+ * domain uses (`internal/domain/Belote.go`): SPADE=1, CLOVER=2, HEART=3,
+ * DIAMOND=4. Any other design (e.g. JOKER, empty) maps to 0.
+ */
+function suitToNum(design: Card['design']): number {
+  switch (design) {
+    case 'SPADE':
+      return 1;
+    case 'CLOVER':
+      return 2;
+    case 'HEART':
+      return 3;
+    case 'DIAMOND':
+      return 4;
+    default:
+      return 0;
+  }
+}
+
+/**
+ * Trump-suit strength ordering. Mirrors `beloteTrumpRank` in the Go domain:
+ * J(11) > 9 > A(1) > 10 > K(13) > Q(12) > 8 > 7.
+ */
+function beloteTrumpRank(value: number): number {
+  switch (value) {
+    case 11:
+      return 8;
+    case 9:
+      return 7;
+    case 1:
+      return 6;
+    case 10:
+      return 5;
+    case 13:
+      return 4;
+    case 12:
+      return 3;
+    case 8:
+      return 2;
+    case 7:
+      return 1;
+    default:
+      return 0;
+  }
+}
+
+/**
+ * Non-trump strength ordering. Mirrors `beloteNonTrumpRank` in the Go domain:
+ * A(1) > 10 > K(13) > Q(12) > J(11) > 9 > 8 > 7.
+ */
+function beloteNonTrumpRank(value: number): number {
+  switch (value) {
+    case 1:
+      return 8;
+    case 10:
+      return 7;
+    case 13:
+      return 6;
+    case 12:
+      return 5;
+    case 11:
+      return 4;
+    case 9:
+      return 3;
+    case 8:
+      return 2;
+    case 7:
+      return 1;
+    default:
+      return 0;
+  }
+}
+
+/** Absolute rank of a card within a trick. Mirrors `cardRank` in the Go domain. */
+function cardRank(card: Card, trumpSuit: number): number {
+  if (suitToNum(card.design) === trumpSuit) {
+    return 200 + beloteTrumpRank(card.value);
+  }
+  return 100 + beloteNonTrumpRank(card.value);
+}
+
+/** Whether the hand holds at least one card of the given suit number. */
+function handHasSuit(hand: Card[], suit: number): boolean {
+  return hand.some((c) => suitToNum(c.design) === suit);
+}
+
+/** Highest trump rank currently in the trick, or 0 if none. Mirrors `highestTrumpInTrick`. */
+function highestTrumpInTrick(trick: BeloteTrickCard[], trumpSuit: number): number {
+  let best = 0;
+  for (const tc of trick) {
+    if (suitToNum(tc.card.design) !== trumpSuit) continue;
+    const r = beloteTrumpRank(tc.card.value);
+    if (r > best) best = r;
+  }
+  return best;
+}
+
+/** Whether the hand can beat the given trump rank. Mirrors `playerCanBeatTrump`. */
+function handCanBeatTrump(hand: Card[], trumpSuit: number, rank: number): boolean {
+  return hand.some((c) => suitToNum(c.design) === trumpSuit && beloteTrumpRank(c.value) > rank);
+}
+
+/** Whether the trick already contains a trump card. Mirrors `trickContainsTrump`. */
+function trickContainsTrump(trick: BeloteTrickCard[], trumpSuit: number): boolean {
+  return trick.some((tc) => suitToNum(tc.card.design) === trumpSuit);
+}
+
+/** Player index currently winning the trick. Mirrors `currentLeader` in the Go domain. */
+function currentLeader(trick: BeloteTrickCard[], trumpSuit: number): number {
+  if (trick.length === 0) return -1;
+  let winner = trick[0].playerIdx;
+  let winnerRank = cardRank(trick[0].card, trumpSuit);
+  let winnerSuit = suitToNum(trick[0].card.design);
+  for (const tc of trick.slice(1)) {
+    const suit = suitToNum(tc.card.design);
+    const rank = cardRank(tc.card, trumpSuit);
+    if (suit === trumpSuit && winnerSuit !== trumpSuit) {
+      winner = tc.playerIdx;
+      winnerRank = rank;
+      winnerSuit = suit;
+      continue;
+    }
+    if (suit === winnerSuit && rank > winnerRank) {
+      winner = tc.playerIdx;
+      winnerRank = rank;
+    }
+  }
+  return winner;
+}
+
+/**
+ * Whether `card` may be legally played from `hand` given the current trick.
+ *
+ * Replicates the exact rule of the Go domain's `validatePlay`
+ * (`internal/domain/Belote.go`): follow-suit obligation, trump obligation
+ * (obligation à couper) when void of the lead suit, and over-trump obligation
+ * (obligation à monter). The trump/over-trump obligations are waived when the
+ * player's partner is currently winning the trick.
+ *
+ * @param card - Candidate card from the player's hand.
+ * @param hand - The full hand the card belongs to.
+ * @param trick - Cards played so far in the current trick.
+ * @param trumpSuit - The trump suit number (1-4), or 0 for no trump.
+ * @param playerIdx - The seat index of the player (used for the partner check).
+ * @returns `true` when the card can be legally played.
+ */
+export function isBeloteLegalPlay(
+  card: Card,
+  hand: Card[],
+  trick: BeloteTrickCard[],
+  trumpSuit: number,
+  playerIdx: number,
+): boolean {
+  if (trick.length === 0) return true;
+
+  const leadSuit = suitToNum(trick[0].card.design);
+  const hasLead = handHasSuit(hand, leadSuit);
+  const cardSuit = suitToNum(card.design);
+
+  if (leadSuit === trumpSuit) {
+    // Lead is trump: must follow with trump, over-trumping when able.
+    if (hasLead) {
+      if (cardSuit !== trumpSuit) return false;
+      const highest = highestTrumpInTrick(trick, trumpSuit);
+      const canOverTrump = handCanBeatTrump(hand, trumpSuit, highest);
+      if (canOverTrump && beloteTrumpRank(card.value) <= highest) return false;
+      return true;
+    }
+    // Void of trump: any card allowed.
+    return true;
+  }
+
+  // Lead is non-trump.
+  if (hasLead) {
+    return cardSuit === leadSuit;
+  }
+
+  // Cannot follow suit.
+  const hasTrump = handHasSuit(hand, trumpSuit);
+  const partnerIdx = (playerIdx + 2) % 4;
+  const partnerWinning = currentLeader(trick, trumpSuit) === partnerIdx;
+
+  if (hasTrump && !partnerWinning) {
+    // Trump obligation.
+    if (cardSuit !== trumpSuit) return false;
+    // Over-trump obligation when the trick already holds trump.
+    if (trickContainsTrump(trick, trumpSuit)) {
+      const highest = highestTrumpInTrick(trick, trumpSuit);
+      const canOverTrump = handCanBeatTrump(hand, trumpSuit, highest);
+      if (canOverTrump && beloteTrumpRank(card.value) <= highest) return false;
+    }
+    return true;
+  }
+  // No trump or partner currently winning: any card allowed.
+  return true;
+}
+
+/**
+ * Indices of the cards in `hand` that are legal to play given the current trick.
+ *
+ * @param hand - The player's hand.
+ * @param trick - Cards played so far in the current trick.
+ * @param trumpSuit - The trump suit number (1-4), or 0 for no trump.
+ * @param playerIdx - The seat index of the player (used for the partner check).
+ * @returns The subset of hand indices that {@link isBeloteLegalPlay} accepts.
+ */
+export function beloteLegalPlayIndices(
+  hand: Card[],
+  trick: BeloteTrickCard[],
+  trumpSuit: number,
+  playerIdx: number,
+): number[] {
+  const indices: number[] = [];
+  hand.forEach((card, idx) => {
+    if (isBeloteLegalPlay(card, hand, trick, trumpSuit, playerIdx)) indices.push(idx);
+  });
+  return indices;
+}


### PR DESCRIPTION
## 概要

Belote のプレイフェーズで、人間プレイヤーのターン時に「合法手のカード」へ加算的な成功リング（`ring-ds-success`）を重ねて可視化する。フォロー義務・トランプ切り義務（obligation à couper）・オーバートランプ義務（obligation à monter）を、Play を押してサーバーに弾かれる前に手札上で判別できるようにする。

Closes #3262

## 実装方針

- **バックエンドは変更なし**（`BeloteResponse` は合法手インデックスを公開していないため、フロントで算出）。
- 新規の純粋関数ヘルパー `frontend/src/utils/beloteLegal.ts`（`beloteLegalPlayIndices`）を追加。`internal/domain/Belote.go` の `validatePlay` / `getValidPlayIndices` をそのまま移植：
  - フォロー義務、トランプ義務、オーバートランプ義務、**パートナーが現勝者のときは義務免除** の分岐を厳密に再現。
  - `beloteTrumpRank` / `beloteNonTrumpRank` / `cardRank` / `currentLeader` もドメインと一致。
- **リングのみ・クリックは絶対にブロックしない**。既存 `PlayerHandSection` の追加専用 `legalIndices` prop を利用（`validIndices` は使わない → hearts #3977 のクリック無効化リグレッションを回避）。バックエンドが引き続き検証を担う。
- 合法手情報は **人間のプレイターンのみ** 計算・送出（CPU ターン・他フェーズでは `undefined`）。
- 色はデザイントークン（`ring-ds-success`）のみ。i18n の新規テキストなし。

## テスト

- `frontend/src/utils/beloteLegal.test.ts` — ヘルパーの全分岐（リード時・フォロー義務・トランプ義務・オーバートランプ義務・パートナー勝ちの免除・トランプリード・両ボイド）。
- `frontend/src/pages/BelotePage.test.tsx` — 合法カードのみリング表示 / **違法カードがクリック可能なままである（`aria-disabled` なし・選択で Play が有効化）** / CPU ターンではリングなし。

## 受け入れ条件

- [x] 合法手が視覚的に強調される（成功リング）
- [x] 違法カードはクリック可能なまま（バックエンドが検証・クリックをブロックしない）
- [x] 合法手情報は CPU ターンや他フェーズでは送信されない
- [x] ページとヘルパー双方のテストを追加
- [x] デザイントークンのみ使用（`ring-ds-success`）

## ゲート

- `bun run check` ✅（design-tokens OK）
- `bun run test -- --run beloteLegal BelotePage` ✅（35 passed）
- `bun run build`（tsc）✅

## 備考

元 issue はバックエンド（`BeloteWebPresenter`）で `validPlayIndices` を出力し違法カードを淡色化・選択不可にする案だったが、クリックを無効化するとサーバー検証まで到達せず E2E タイムアウト（hearts #3977）を招くため、**加算的リングのみ・クリック維持** の方針を採用した。
