### PR TITLE
fix(trenteetquarante): unbreak develop — scope refait test to result banner

### DIFF
--- a/frontend/src/pages/TrenteEtQuarantePage.test.tsx
+++ b/frontend/src/pages/TrenteEtQuarantePage.test.tsx
@@ -173,7 +173,9 @@ describe('TrenteEtQuarantePage', () => {
   it('omits the margin line on a refait (tie at 31)', async () => {
     mockApi.mockResolvedValue(refaitState);
     renderWithProviders(<TrenteEtQuarantePage />);
-    await waitFor(() => expect(screen.getByText(/ルフェ/)).toBeInTheDocument());
+    // Scope to the result banner: the refait rule-explainer summary also mentions Refait,
+    // so a bare getByText(/ルフェ/) would match multiple elements.
+    await waitFor(() => expect(screen.getByTestId('teq-result')).toHaveTextContent(/ルフェ/));
     expect(screen.queryByTestId('teq-margin')).not.toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Problem
`TrenteEtQuarantePage.test.tsx > omits the margin line on a refait` fails **deterministically on develop**, blocking Frontend Tests for every open PR.

## Cause
The refait rule-explainer (`teq-refait-explainer`, added by #4082) also contains ルフェ (Refait). The test's `await waitFor(() => getByText(/ルフェ/))` therefore matched **multiple** elements and threw, timing out. #4082 scoped its sibling refait test to `teq-result` but missed this one (added by #4080).

## Fix
Scope the wait to the result banner (`getByTestId('teq-result')`), matching the sibling test. Test-only change.

## Verification
`bun run test -- --run TrenteEtQuarantePage` → 14/14 pass.