### PR TITLE
feat(acesup): surface discard pile top card on the board

### DIFF
--- a/frontend/src/i18n/locales/en/acesup.json
+++ b/frontend/src/i18n/locales/en/acesup.json
@@ -7,6 +7,7 @@
   "title": "Aces Up",
   "stock": "Stock",
   "discard": "Removed",
+  "discardPile": "Discards",
   "moveCount": "Moves",
   "combo": "Combo ×{{count}}",
   "draw": "Deal",

--- a/frontend/src/i18n/locales/ja/acesup.json
+++ b/frontend/src/i18n/locales/ja/acesup.json
@@ -7,6 +7,7 @@
   "title": "四つ葉のクローバー",
   "stock": "山札",
   "discard": "除去済み",
+  "discardPile": "捨て札",
   "moveCount": "手数",
   "combo": "コンボ ×{{count}}",
   "draw": "配る",

--- a/frontend/src/pages/AcesUpPage.test.tsx
+++ b/frontend/src/pages/AcesUpPage.test.tsx
@@ -32,6 +32,7 @@ const playingState: AcesUpResponse = {
   columns: makeColumns(),
   stockCount: 44,
   discardCount: 4,
+  discardTop: card('CLOVER', 7),
   phase: 0,
   moveCount: 3,
   canUndo: true,
@@ -82,6 +83,26 @@ describe('AcesUpPage', () => {
     await waitFor(() => expect(screen.getByText(/山札/)).toBeInTheDocument());
     const colDivs = document.querySelectorAll('[data-tutorial="acesup-columns"] > div');
     expect(colDivs.length).toBe(4);
+  });
+
+  it('renders the discard pile with progress and the top card', async () => {
+    renderWithProviders(<AcesUpPage />);
+    await waitFor(() => expect(screen.getByTestId('acesup-discard-pile')).toBeInTheDocument());
+    // Progress readout: discardCount out of the 48-card goal.
+    expect(screen.getByText(/捨て札/)).toBeInTheDocument();
+    expect(screen.getByText(/\(4\/48\)/)).toBeInTheDocument();
+    // The most recently removed card is shown face-up.
+    expect(screen.getByTestId('acesup-discard-top')).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: /♣ 7/ })).toBeInTheDocument();
+  });
+
+  it('renders an empty discard placeholder when nothing has been removed', async () => {
+    mockExec.mockResolvedValue({ ...playingState, discardCount: 0, discardTop: null });
+    renderWithProviders(<AcesUpPage />);
+    await waitFor(() => expect(screen.getByTestId('acesup-discard-pile')).toBeInTheDocument());
+    expect(screen.getByTestId('acesup-discard-empty')).toBeInTheDocument();
+    expect(screen.getByText(/\(0\/48\)/)).toBeInTheDocument();
+    expect(screen.queryByTestId('acesup-discard-top')).not.toBeInTheDocument();
   });
 
   it('renders empty column placeholder', async () => {

--- a/frontend/src/pages/AcesUpPage.tsx
+++ b/frontend/src/pages/AcesUpPage.tsx
@@ -65,6 +65,9 @@ const ACESUP_TUTORIAL_STEPS: TutorialStep[] = [
 
 const COL_COUNT = 4;
 
+/** Number of non-ace cards that must be discarded to win (52 - 4 aces). */
+const DISCARD_GOAL = 48;
+
 /** Renders the Aces Up game page with 4 columns, deal/remove/move controls. */
 export const AcesUpPage = withTutorial(AcesUpPageContent, 'acesup', ACESUP_TUTORIAL_STEPS);
 /** Inner content of the Aces Up page, wrapped by TutorialProvider. */
@@ -285,7 +288,7 @@ function AcesUpPageContent() {
               })}
             </div>
 
-            {/* Stock */}
+            {/* Stock + discard pile */}
             <div className="flex gap-4 justify-center mb-3" data-tutorial="acesup-stock">
               <div className="text-center">
                 <div className="text-game-text-muted text-xs mb-1">
@@ -299,6 +302,28 @@ function AcesUpPageContent() {
                   />
                 ) : (
                   <div
+                    style={{ width: cardWidth, height: cardHeight }}
+                    className="rounded border-2 border-dashed border-white/30 text-game-text-muted text-xs flex items-center justify-center"
+                  >
+                    {t('empty')}
+                  </div>
+                )}
+              </div>
+              <div className="text-center" data-testid="acesup-discard-pile">
+                <div className="text-game-text-muted text-xs mb-1">
+                  {t('discardPile')} ({state.discardCount}/{DISCARD_GOAL})
+                </div>
+                {state.discardTop ? (
+                  <div data-testid="acesup-discard-top">
+                    <AnimatedCard
+                      key={`discard-${state.discardCount.toString()}`}
+                      card={state.discardTop}
+                      width={cardWidth}
+                    />
+                  </div>
+                ) : (
+                  <div
+                    data-testid="acesup-discard-empty"
                     style={{ width: cardWidth, height: cardHeight }}
                     className="rounded border-2 border-dashed border-white/30 text-game-text-muted text-xs flex items-center justify-center"
                   >

--- a/frontend/src/types/card.ts
+++ b/frontend/src/types/card.ts
@@ -7569,6 +7569,8 @@ export interface AcesUpResponse extends BaseGameResponse {
   columns: AcesUpCard[][];
   stockCount: number;
   discardCount: number;
+  /** The most recently removed card (top of the discard pile); absent when nothing has been discarded. */
+  discardTop?: Card | null;
   phase: number;
   moveCount: number;
   canUndo: boolean;

--- a/internal/adapter/controller/AcesUpWebController.go
+++ b/internal/adapter/controller/AcesUpWebController.go
@@ -33,7 +33,9 @@ type AcesUpWebOutput struct {
 	Columns      [][]*AcesUpWebOutputCard `json:"columns"`
 	StockCount   int                      `json:"stockCount"`
 	DiscardCount int                      `json:"discardCount"`
-	Hint         *AcesUpWebOutputHint     `json:"hint,omitempty"`
+	// DiscardTop は直近に除去した札（捨て札パイルの一番上）。捨て札が空なら省略。
+	DiscardTop *WebOutputCard       `json:"discardTop,omitempty"`
+	Hint       *AcesUpWebOutputHint `json:"hint,omitempty"`
 	SolitaireWebOutputBase
 	WebOutputBase
 }

--- a/internal/adapter/presenter/AcesUpWebPresenter.go
+++ b/internal/adapter/presenter/AcesUpWebPresenter.go
@@ -19,6 +19,7 @@ func (pr *AcesUpWebPresenter) Output(g interfaces.AcesUpGame, lastErr error) str
 	populateSolitaireBase(&resObj.SolitaireWebOutputBase, g, int(g.GetPhase()))
 	resObj.StockCount = g.GetStockCount()
 	resObj.DiscardCount = g.GetDiscardCount()
+	resObj.DiscardTop = cardToOutput(g.GetDiscardTop())
 	resObj.Columns = acesUpColumns(g)
 
 	if lastErr != nil {

--- a/internal/adapter/presenter/AcesUpWebPresenter_test.go
+++ b/internal/adapter/presenter/AcesUpWebPresenter_test.go
@@ -31,6 +31,7 @@ func setupAcesUpWebMockDefaults(g *interfaces.MockAcesUpGame) {
 	g.On("GetMoveCount").Return(0).Maybe()
 	g.On("GetStockCount").Return(44).Maybe()
 	g.On("GetDiscardCount").Return(4).Maybe()
+	g.On("GetDiscardTop").Return(domain.NewCard(domain.CardDesignClover, 7, false)).Maybe()
 	g.On("CanUndo").Return(false).Maybe()
 	g.On("IsStalemate").Return(false).Maybe()
 	g.On("UndoToEscape").Return(0).Maybe()
@@ -57,6 +58,10 @@ func TestAcesUpWebPresenterOutput_Playing(t *testing.T) {
 	assert.Equal(t, 0, out.Phase)
 	assert.Equal(t, 44, out.StockCount)
 	assert.Equal(t, 4, out.DiscardCount)
+	// The discard pile top card is surfaced for the on-board discard display.
+	assert.NotNil(t, out.DiscardTop)
+	assert.Equal(t, "CLOVER", out.DiscardTop.Design)
+	assert.Equal(t, 7, out.DiscardTop.Value)
 	assert.Equal(t, "acesup.playing", out.MessageCode)
 	assert.Len(t, out.Columns, domain.AcesUpColCnt)
 	// col0 top is removable
@@ -67,6 +72,32 @@ func TestAcesUpWebPresenterOutput_Playing(t *testing.T) {
 	// col3 has two cards, only the last is top
 	assert.False(t, out.Columns[3][0].Top)
 	assert.True(t, out.Columns[3][1].Top)
+}
+
+func TestAcesUpWebPresenterOutput_EmptyDiscard(t *testing.T) {
+	g := new(interfaces.MockAcesUpGame)
+	setupAcesUpWebMockDefaults(g)
+	// Override the discard top to nil (no cards removed yet).
+	g.ExpectedCalls = nil
+	g.On("GetPhase").Return(domain.AcesUpPhasePlaying).Maybe()
+	g.On("GetMoveCount").Return(0).Maybe()
+	g.On("GetStockCount").Return(48).Maybe()
+	g.On("GetDiscardCount").Return(0).Maybe()
+	g.On("GetDiscardTop").Return((*domain.Card)(nil)).Maybe()
+	g.On("CanUndo").Return(false).Maybe()
+	g.On("IsStalemate").Return(false).Maybe()
+	g.On("UndoToEscape").Return(0).Maybe()
+	g.On("GetColumns").Return(sampleAcesUpColumns()).Maybe()
+	for c := range domain.AcesUpColCnt {
+		g.On("CanRemove", c).Return(false).Maybe()
+		g.On("CanMove", c).Return(false).Maybe()
+	}
+	p := &AcesUpWebPresenter{}
+
+	out := parseAcesUpOutput(t, p.Output(g, nil))
+	// With an empty discard pile, the omitempty field is absent.
+	assert.Nil(t, out.DiscardTop)
+	assert.Equal(t, 0, out.DiscardCount)
 }
 
 func TestAcesUpWebPresenterOutput_Error(t *testing.T) {
@@ -84,6 +115,7 @@ func TestAcesUpWebPresenterOutput_Stalemate(t *testing.T) {
 	g.On("GetMoveCount").Return(5).Maybe()
 	g.On("GetStockCount").Return(0).Maybe()
 	g.On("GetDiscardCount").Return(10).Maybe()
+	g.On("GetDiscardTop").Return(domain.NewCard(domain.CardDesignHeart, 3, false)).Maybe()
 	g.On("CanUndo").Return(true).Maybe()
 	g.On("IsStalemate").Return(true).Maybe()
 	g.On("UndoToEscape").Return(-1).Maybe()
@@ -101,6 +133,7 @@ func TestAcesUpWebPresenterOutput_GameClear(t *testing.T) {
 	g.On("GetMoveCount").Return(20).Maybe()
 	g.On("GetStockCount").Return(0).Maybe()
 	g.On("GetDiscardCount").Return(48).Maybe()
+	g.On("GetDiscardTop").Return(domain.NewCard(domain.CardDesignClover, 5, false)).Maybe()
 	g.On("CanUndo").Return(false).Maybe()
 	g.On("IsStalemate").Return(false).Maybe()
 	g.On("UndoToEscape").Return(0).Maybe()
@@ -119,6 +152,7 @@ func TestAcesUpWebPresenterOutput_GameOver(t *testing.T) {
 	g.On("GetMoveCount").Return(5).Maybe()
 	g.On("GetStockCount").Return(0).Maybe()
 	g.On("GetDiscardCount").Return(2).Maybe()
+	g.On("GetDiscardTop").Return(domain.NewCard(domain.CardDesignSpade, 4, false)).Maybe()
 	g.On("CanUndo").Return(false).Maybe()
 	g.On("IsStalemate").Return(false).Maybe()
 	g.On("UndoToEscape").Return(0).Maybe()

--- a/internal/domain/AcesUp.go
+++ b/internal/domain/AcesUp.go
@@ -274,6 +274,14 @@ func (a *AcesUp) GetStockCount() int { return len(a.stock) }
 // GetDiscardCount 除去済み枚数取得
 func (a *AcesUp) GetDiscardCount() int { return len(a.discard) }
 
+// GetDiscardTop 捨て札の一番上（直近に除去した札）を返す。捨て札が空なら nil。
+func (a *AcesUp) GetDiscardTop() *Card {
+	if len(a.discard) == 0 {
+		return nil
+	}
+	return a.discard[len(a.discard)-1]
+}
+
 // GetColumns 場札の列を取得
 func (a *AcesUp) GetColumns() [AcesUpColCnt][]*Card { return a.columns }
 

--- a/internal/domain/interfaces/acesup.go
+++ b/internal/domain/interfaces/acesup.go
@@ -38,6 +38,8 @@ type AcesUpGame interface {
 	GetStockCount() int
 	// GetDiscardCount 除去済みの枚数を取得する
 	GetDiscardCount() int
+	// GetDiscardTop 捨て札の一番上（直近に除去した札）を取得する
+	GetDiscardTop() *domain.Card
 	// GetColumns 場札の列を取得する
 	GetColumns() [domain.AcesUpColCnt][]*domain.Card
 	// CanRemove 指定列の一番上のカードが除去可能かを返す

--- a/internal/domain/interfaces/acesup_mock.go
+++ b/internal/domain/interfaces/acesup_mock.go
@@ -85,6 +85,16 @@ func (_m *MockAcesUpGame) GetDiscardCount() int {
 	return ret.Get(0).(int)
 }
 
+// GetDiscardTop mocks the GetDiscardTop call.
+func (_m *MockAcesUpGame) GetDiscardTop() *domain.Card {
+	ret := _m.Called()
+	r0 := ret.Get(0)
+	if r0 == nil {
+		return nil
+	}
+	return r0.(*domain.Card)
+}
+
 func (_m *MockAcesUpGame) GetColumns() [domain.AcesUpColCnt][]*domain.Card {
 	ret := _m.Called()
 	return ret.Get(0).([domain.AcesUpColCnt][]*domain.Card)


### PR DESCRIPTION
## Summary

Aces Up previously showed discard progress only as a header text count (`除去済み: N`); the board itself surfaced no removed cards. This PR surfaces the discard pile as a real card so players get visual feedback on the win goal (discard all 48 non-ace cards).

The domain already retained the discarded cards (`discard []*Card`) but exposed only `GetDiscardCount()`. This adds a `GetDiscardTop()` getter and threads the top card through the interface, presenter, and web output DTO — no domain game logic changed.

## Changes

**Backend (Go)**
- `internal/domain/AcesUp.go`: add `GetDiscardTop()` (returns top of discard pile, nil when empty).
- `internal/domain/interfaces/acesup.go` + `acesup_mock.go`: add the getter to the interface and testify mock.
- `internal/adapter/controller/AcesUpWebController.go`: add `DiscardTop *WebOutputCard` (`discardTop,omitempty`) — reuses the existing shared card DTO.
- `internal/adapter/presenter/AcesUpWebPresenter.go`: populate `DiscardTop` in `Output` via `cardToOutput` (nil-safe).

**Frontend (TS/React)**
- `frontend/src/types/card.ts`: add `discardTop?: Card | null` to `AcesUpResponse`.
- `frontend/src/pages/AcesUpPage.tsx`: render a discard pile beside the stock — face-up top card with an accessible alt, plus a `removed/48` progress badge; empty placeholder when nothing discarded.
- `frontend/src/i18n/locales/{ja,en}/acesup.json`: add `discardPile` key (捨て札 / Discards).

## Test plan

- [x] `go test -tags test ./internal/adapter/... ./internal/domain/...` — pass
- [x] `golangci-lint run` — 0 issues
- [x] Presenter test `TestAcesUpWebPresenterOutput_Playing` asserts `DiscardTop` populated; new `TestAcesUpWebPresenterOutput_EmptyDiscard` asserts nil when empty
- [x] `bun run test -- --run AcesUpPage` — 23 pass (added pile-with-card + empty-pile tests)
- [x] `bun run build` (tsc + vite) — pass
- [x] `bun run check` (biome + design-tokens) — pass

Closes #3346
