### PR TITLE
feat(burraco): surface full discard pile in an expandable viewer

### DIFF
--- a/frontend/src/i18n/locales/en/burraco.json
+++ b/frontend/src/i18n/locales/en/burraco.json
@@ -1,5 +1,8 @@
 {
   "discardTop": "Discard",
+  "discardPileViewer": "View discard pile ({{count}} cards)",
+  "discardPileEmpty": "The discard pile is empty.",
+  "discardPileOrderHint": "Ordered oldest first (bottom → top).",
   "phase": {
     "draw": "Draw",
     "meld": "Meld",

--- a/frontend/src/i18n/locales/ja/burraco.json
+++ b/frontend/src/i18n/locales/ja/burraco.json
@@ -1,5 +1,8 @@
 {
   "discardTop": "捨て札",
+  "discardPileViewer": "捨て札の山を見る ({{count}}枚)",
+  "discardPileEmpty": "捨て札の山は空です。",
+  "discardPileOrderHint": "古い順（下 → 上）に並んでいます。",
   "phase": {
     "draw": "ドロー",
     "meld": "メルド",

--- a/frontend/src/pages/BurracoPage.test.tsx
+++ b/frontend/src/pages/BurracoPage.test.tsx
@@ -63,6 +63,7 @@ const drawPhaseState: BurracoResponse = {
   roundNumber: 1,
   currentPlayerIdx: 0,
   discardTop: { design: 'SPADE', value: 5 },
+  discardPile: [{ design: 'SPADE', value: 5 }],
   drawPileCount: 67,
   discardPileCount: 1,
   pozzettoCount: 2,
@@ -125,6 +126,30 @@ describe('BurracoPage', () => {
     renderWithProviders(<BurracoPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: '山札から引く' })).toBeInTheDocument());
     expect(screen.getByRole('button', { name: '捨て札を取る' })).toBeInTheDocument();
+  });
+
+  it('renders the discard pile viewer with all pile cards', async () => {
+    mockExec.mockResolvedValue({
+      ...drawPhaseState,
+      discardPile: [
+        { design: 'SPADE', value: 3 },
+        { design: 'HEART', value: 7 },
+        { design: 'CLOVER', value: 10 },
+      ],
+      discardPileCount: 3,
+    });
+    renderWithProviders(<BurracoPage />);
+    const viewer = await screen.findByTestId('ca-discard-pile-viewer');
+    expect(viewer).toBeInTheDocument();
+    expect(screen.getByTestId('ca-discard-pile-cards').querySelectorAll('img')).toHaveLength(3);
+  });
+
+  it('shows an empty message when the discard pile is empty', async () => {
+    mockExec.mockResolvedValue({ ...drawPhaseState, discardTop: null, discardPile: [], discardPileCount: 0 });
+    renderWithProviders(<BurracoPage />);
+    await screen.findByTestId('ca-discard-pile-viewer');
+    expect(screen.getByText('捨て札の山は空です。')).toBeInTheDocument();
+    expect(screen.queryByTestId('ca-discard-pile-cards')).not.toBeInTheDocument();
   });
 
   it('calls drawstock command when button clicked', async () => {

--- a/frontend/src/pages/BurracoPage.tsx
+++ b/frontend/src/pages/BurracoPage.tsx
@@ -300,6 +300,34 @@ function BurracoPageContent() {
                   </div>
                 )}
 
+                {/* Full discard pile viewer: in Burraco the whole pile is taken at once,
+                    so its contents are decision-critical public information. */}
+                <details
+                  className="my-3 rounded bg-black/30 p-2"
+                  data-testid="ca-discard-pile-viewer"
+                  open={isDrawPhase}
+                >
+                  <summary className="cursor-pointer select-none text-sm text-ds-text-muted">
+                    {t('discardPileViewer', { count: state.discardPile.length })}
+                  </summary>
+                  {state.discardPile.length === 0 ? (
+                    <div className="mt-2 text-xs text-ds-text-muted">{t('discardPileEmpty')}</div>
+                  ) : (
+                    <>
+                      <div className="mt-1 text-xs text-ds-text-muted">{t('discardPileOrderHint')}</div>
+                      <div className="mt-2 flex flex-wrap gap-1" data-testid="ca-discard-pile-cards">
+                        {state.discardPile.map((card, di) => (
+                          <AnimatedCard
+                            key={`discard-${card.design}-${card.value}-${di}`}
+                            card={card}
+                            width={cardWidth * 0.6}
+                          />
+                        ))}
+                      </div>
+                    </>
+                  )}
+                </details>
+
                 {/* Player melds */}
                 {state.players.map((p, pi) => {
                   if (p.melds.length === 0 && p.red3s.length === 0) return null;

--- a/frontend/src/types/card.ts
+++ b/frontend/src/types/card.ts
@@ -7367,6 +7367,9 @@ export interface BurracoResponse extends BaseGameResponse {
   roundNumber: number;
   currentPlayerIdx: number;
   discardTop: Card | null;
+  /** The full discard pile, oldest (bottom) first. In Burraco the whole pile is
+   * taken at once, so its contents are public information for all players. */
+  discardPile: Card[];
   drawPileCount: number;
   discardPileCount: number;
   pozzettoCount: number;

--- a/frontend/src/utils/hints/burracoHint.test.ts
+++ b/frontend/src/utils/hints/burracoHint.test.ts
@@ -32,6 +32,7 @@ function makeState(overrides: Partial<BurracoResponse> = {}): BurracoResponse {
     roundNumber: 1,
     currentPlayerIdx: 0,
     discardTop: null,
+    discardPile: [],
     drawPileCount: 40,
     discardPileCount: 0,
     pozzettoCount: 2,

--- a/internal/adapter/controller/BurracoWebController.go
+++ b/internal/adapter/controller/BurracoWebController.go
@@ -56,6 +56,7 @@ type BurracoWebOutput struct {
 	RoundNumber      int                       `json:"roundNumber"`
 	CurrentPlayerIdx int                       `json:"currentPlayerIdx"`
 	DiscardTop       *WebOutputCard            `json:"discardTop"`
+	DiscardPile      []*WebOutputCard          `json:"discardPile"`
 	DrawPileCount    int                       `json:"drawPileCount"`
 	DiscardPileCount int                       `json:"discardPileCount"`
 	PozzettoCount    int                       `json:"pozzettoCount"`

--- a/internal/adapter/presenter/BurracoWebPresenter.go
+++ b/internal/adapter/presenter/BurracoWebPresenter.go
@@ -29,6 +29,14 @@ func (p *BurracoWebPresenter) Output(g interfaces.BurracoGame, lastErr error) st
 		resObj.DiscardTop = cardToOutput(top)
 	}
 
+	// 捨て札パイル全体を古い順（下から上）に公開する。ブラーコでは山ごと引き取るため
+	// パイルの中身は全プレイヤーに見えている情報であり、取得判断の核心となる。
+	pile := g.GetDiscardPile()
+	resObj.DiscardPile = make([]*controller.WebOutputCard, 0, len(pile))
+	for _, card := range pile {
+		resObj.DiscardPile = append(resObj.DiscardPile, cardToOutput(card))
+	}
+
 	cfg := g.GetConfig()
 	resObj.Config = controller.BurracoWebOutputConfig{
 		CpuDifficulty: int(cfg.CpuDifficulty),

--- a/internal/adapter/presenter/BurracoWebPresenter_test.go
+++ b/internal/adapter/presenter/BurracoWebPresenter_test.go
@@ -23,6 +23,7 @@ func setupBurracoWebMock() *interfaces.MockBurracoGame {
 	m.On("GetPozzettoCount").Return(2)
 	m.On("GetIsFrozen").Return(false)
 	m.On("GetDiscardTop").Return((*domain.Card)(nil))
+	m.On("GetDiscardPile").Return(([]*domain.Card)(nil))
 	m.On("GetGameEndFlag").Return(false)
 	m.On("GetPhase").Return(domain.BurracoPhaseDraw)
 	m.On("GetCurrentPlayerIdx").Return(0)
@@ -141,6 +142,42 @@ func TestBurracoWebPresenter_Output(t *testing.T) {
 		assert.NotNil(t, resObj.DiscardTop)
 		assert.Equal(t, "HEART", resObj.DiscardTop.Design)
 		assert.Equal(t, 7, resObj.DiscardTop.Value)
+	})
+
+	t.Run("discard pile populated in oldest-first order", func(t *testing.T) {
+		m, _ := setupBurracoWebMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetDiscardPile")
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetDiscardPileCount")
+		pile := []*domain.Card{
+			domain.NewCard(domain.CardDesignSpade, 3, false),
+			domain.NewCard(domain.CardDesignHeart, 7, false),
+			domain.NewCard(domain.CardDesignClover, 10, false),
+		}
+		m.On("GetDiscardPile").Return(pile)
+		m.On("GetDiscardPileCount").Return(len(pile))
+
+		result := p.Output(m, nil)
+		var resObj controller.BurracoWebOutput
+		_ = json.Unmarshal([]byte(result), &resObj)
+
+		assert.Len(t, resObj.DiscardPile, 3)
+		assert.Equal(t, 3, resObj.DiscardPileCount)
+		assert.Equal(t, "SPADE", resObj.DiscardPile[0].Design)
+		assert.Equal(t, 3, resObj.DiscardPile[0].Value)
+		assert.Equal(t, "HEART", resObj.DiscardPile[1].Design)
+		assert.Equal(t, "CLOVER", resObj.DiscardPile[2].Design)
+		assert.Equal(t, 10, resObj.DiscardPile[2].Value)
+	})
+
+	t.Run("empty discard pile yields empty array", func(t *testing.T) {
+		m, _ := setupBurracoWebMockWithPlayers()
+
+		result := p.Output(m, nil)
+		var resObj controller.BurracoWebOutput
+		_ = json.Unmarshal([]byte(result), &resObj)
+
+		assert.NotNil(t, resObj.DiscardPile)
+		assert.Len(t, resObj.DiscardPile, 0)
 	})
 
 	t.Run("frozen pile flag", func(t *testing.T) {

--- a/internal/domain/interfaces/canasta.go
+++ b/internal/domain/interfaces/canasta.go
@@ -43,6 +43,8 @@ type CanastaGame interface {
 	GetCurrentPlayerIdx() int
 	// GetDiscardTop 捨て札の一番上のカードを取得する
 	GetDiscardTop() *domain.Card
+	// GetDiscardPile 捨て札の山全体を古い順（下から上）に取得する
+	GetDiscardPile() []*domain.Card
 	// GetDrawPileCount 山札の残り枚数を取得する
 	GetDrawPileCount() int
 	// GetDiscardPileCount 捨て札の枚数を取得する

--- a/internal/domain/interfaces/canasta_mock.go
+++ b/internal/domain/interfaces/canasta_mock.go
@@ -44,6 +44,9 @@ func (m *MockCanastaGame) GetCurrentPlayerIdx() int { return m.Called().Int(0) }
 func (m *MockCanastaGame) GetDiscardTop() *domain.Card {
 	return m.Called().Get(0).(*domain.Card)
 }
+func (m *MockCanastaGame) GetDiscardPile() []*domain.Card {
+	return m.Called().Get(0).([]*domain.Card)
+}
 func (m *MockCanastaGame) GetDrawPileCount() int    { return m.Called().Int(0) }
 func (m *MockCanastaGame) GetDiscardPileCount() int { return m.Called().Int(0) }
 func (m *MockCanastaGame) GetPozzettoCount() int    { return m.Called().Int(0) }


### PR DESCRIPTION
## Summary

The Burraco Web UI only showed the discard pile's top card and count, forcing players to remember the rest. Since taking the discard pile in Burraco means taking the **whole** pile at once, the full contents are decision-critical, public information. This PR surfaces the entire pile in an accessible, expandable viewer.

## Changes

**Backend (Go)**
- Add `GetDiscardPile() []*domain.Card` to the `CanastaGame` (= `BurracoGame`) interface and its mock (read-only getter; no game-logic change — the domain already retained the pile).
- Add `discardPile` (`[]*WebOutputCard`, same card DTO shape as `discardTop`) to `BurracoWebOutput`.
- Populate it in `BurracoWebPresenter.Output`, oldest-first (bottom → top).
- Presenter tests: pile populated in order + empty-pile yields empty array.

**Frontend (TS/React)**
- Add `discardPile: Card[]` to `BurracoResponse`.
- Render an accessible `<details>` viewer (`data-testid="ca-discard-pile-viewer"`), default-open during the draw phase, listing every pile card oldest-first with an empty-state message.
- ja/en i18n keys added key-for-key.
- Page tests for the populated viewer and the empty state.
- Frozen badge and top-card display are unchanged.

## Acceptance criteria
- [x] Expanding the discard area shows all pile cards oldest-first
- [x] `BurracoWebPresenter.go` returns a `discardPile` array; `BurracoResponse` updated
- [x] Frozen badge / top-card display still work
- [x] Presenter and page tests updated

## Test plan
- [x] `go test -tags test ./internal/...`
- [x] `golangci-lint run` (changed packages) — 0 issues
- [x] `bun run check`
- [x] `bun run test -- --run BurracoPage` — 23 passed
- [x] `bun run build` (tsc gate)

Closes #3371