### PR TITLE
feat(cuckoo): show round lowest value in web result panel

### DIFF
--- a/frontend/src/i18n/locales/en/cuckoo.json
+++ b/frontend/src/i18n/locales/en/cuckoo.json
@@ -24,6 +24,7 @@
   "nextRound": "Next round",
   "roundLoser": "{{name}} held the lowest card and lost a life.",
   "roundLosersTitle": "This round's losers",
+  "roundLowestValue": "Lowest value: {{value}}",
   "settings": {
     "title": "Settings",
     "cpuDifficulty": "CPU difficulty",

--- a/frontend/src/i18n/locales/ja/cuckoo.json
+++ b/frontend/src/i18n/locales/ja/cuckoo.json
@@ -24,6 +24,7 @@
   "nextRound": "次のラウンドへ",
   "roundLoser": "{{name}} が最も低いカードでライフを失いました。",
   "roundLosersTitle": "今ラウンドの敗者",
+  "roundLowestValue": "最低値: {{value}}",
   "settings": {
     "title": "設定",
     "cpuDifficulty": "CPU難易度",

--- a/frontend/src/pages/CuckooPage.test.tsx
+++ b/frontend/src/pages/CuckooPage.test.tsx
@@ -137,6 +137,19 @@ describe('CuckooPage', () => {
     expect(losers).toHaveAttribute('aria-live', 'polite');
   });
 
+  it('shows the round lowest value at round end', async () => {
+    mockExec.mockResolvedValue(roundEndState);
+    renderWithProviders(<CuckooPage />);
+    const lowest = await screen.findByTestId('cuckoo-round-lowest');
+    expect(lowest).toHaveTextContent('最低値: 5');
+  });
+
+  it('hides the round lowest value when undecided', async () => {
+    renderWithProviders(<CuckooPage />);
+    await waitFor(() => expect(screen.getByText(/プレイヤー/)).toBeInTheDocument());
+    expect(screen.queryByTestId('cuckoo-round-lowest')).not.toBeInTheDocument();
+  });
+
   it('dispatches keep on the human turn', async () => {
     renderWithProviders(<CuckooPage />);
     const btn = await screen.findByRole('button', { name: 'キープ' });

--- a/frontend/src/pages/CuckooPage.tsx
+++ b/frontend/src/pages/CuckooPage.tsx
@@ -242,6 +242,11 @@ function CuckooPageContent() {
                 aria-live="polite"
               >
                 <div className="mb-1">{t('roundLosersTitle')}</div>
+                {state.roundLowest >= 1 && (
+                  <div className="mb-1 font-semibold" data-testid="cuckoo-round-lowest">
+                    {t('roundLowestValue', { value: state.roundLowest })}
+                  </div>
+                )}
                 {state.roundLosers.map((idx) => (
                   <div key={`loser-${idx}`}>{t('roundLoser', { name: playerLabel(idx, idx === 0) })}</div>
                 ))}

--- a/internal/adapter/presenter/CuckooWebPresenter_test.go
+++ b/internal/adapter/presenter/CuckooWebPresenter_test.go
@@ -61,6 +61,7 @@ func TestCuckooWebPresenter_Output(t *testing.T) {
 		assert.Nil(t, out.Players[1].Card)    // opponent hidden
 		assert.True(t, out.Players[0].IsCurrentTurn)
 		assert.Equal(t, "cuckoo.turnPhase", out.MessageCode)
+		assert.Equal(t, -1, out.RoundLowest) // undecided outside round end
 	})
 
 	t.Run("error message", func(t *testing.T) {
@@ -69,13 +70,19 @@ func TestCuckooWebPresenter_Output(t *testing.T) {
 		assert.Equal(t, "boom", out.Message)
 	})
 
-	t.Run("round end reveals all", func(t *testing.T) {
+	t.Run("round end reveals all and lowest value", func(t *testing.T) {
 		m, _ := setupCuckooWebMock()
 		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
 		m.On("GetPhase").Return(domain.CuckooPhaseRoundEnd)
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetRoundLowest")
+		m.On("GetRoundLowest").Return(5)
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetRoundLosers")
+		m.On("GetRoundLosers").Return([]int{0})
 		out := parseCuckooOutput(t, p.Output(m, nil))
 		assert.NotNil(t, out.Players[1].Card)
 		assert.Equal(t, "cuckoo.roundEnd", out.MessageCode)
+		assert.Equal(t, 5, out.RoundLowest) // populated at round end
+		assert.Equal(t, []int{0}, out.RoundLosers)
 	})
 
 	t.Run("game end human win", func(t *testing.T) {


### PR DESCRIPTION
## Summary
Cuckoo's Web losers panel (`cuckoo-losers`) only listed the losing players by name, so the *why* — the lowest card value that cost them a life — was invisible, unlike the CUI which already prints `GetRoundLowest()` at round end.

The domain retains the round's lowest value (`roundLowest`, `-1` until decided) and `CuckooWebPresenter` already emits it in the response; the value was simply never rendered. This PR surfaces it.

## Changes
- `CuckooPage.tsx`: render `roundLowest` in the losers panel (gated on a decided value `>= 1`), with `data-testid="cuckoo-round-lowest"`, inside the existing `role="status"` live region.
- i18n `roundLowestValue` key added key-for-key (ja: `最低値: {{value}}`, en: `Lowest value: {{value}}`).
- `CuckooWebPresenter_test.go`: assert `roundLowest` is populated at round end (`5`) and `-1` outside round end — both branches.
- `CuckooPage.test.tsx`: assert the value renders at round end and is hidden when undecided.

No game logic or Go production code changed — the presenter already emitted the field.

## Test plan
- [x] `golangci-lint run` clean (presenter)
- [x] `go test -tags test ./internal/adapter/presenter/...`
- [x] `bun run check`
- [x] `bun run test -- --run CuckooPage` (22 passed)
- [x] `bun run build`

Closes #3557
