### PR TITLE
feat(fourcardpoker): show dealer concealed cards as backs in action phase

### DIFF
--- a/frontend/src/i18n/locales/en/fourcardpoker.json
+++ b/frontend/src/i18n/locales/en/fourcardpoker.json
@@ -3,6 +3,7 @@
   "player": "Player",
   "dealer": "Dealer",
   "dealerUpcard": "Upcard only",
+  "hiddenCard": "Hidden card",
   "label": {
     "chips": "Chips",
     "ante": "Ante",

--- a/frontend/src/i18n/locales/ja/fourcardpoker.json
+++ b/frontend/src/i18n/locales/ja/fourcardpoker.json
@@ -3,6 +3,7 @@
   "player": "プレイヤー",
   "dealer": "ディーラー",
   "dealerUpcard": "アップカードのみ表示中",
+  "hiddenCard": "非公開のカード",
   "label": {
     "chips": "チップ",
     "ante": "アンテ",

--- a/frontend/src/pages/FourCardPokerPage.test.tsx
+++ b/frontend/src/pages/FourCardPokerPage.test.tsx
@@ -187,6 +187,21 @@ describe('FourCardPokerPage', () => {
     }
   });
 
+  it('renders the dealer concealed cards as backs during the action phase', async () => {
+    mockExec.mockResolvedValue(actionPhaseState);
+    renderWithProviders(<FourCardPokerPage />);
+    await screen.findByTestId('play-1x');
+    // Dealer holds 6 cards but only the upcard is revealed; the other 5 are backs.
+    expect(screen.getAllByRole('img', { name: '非公開のカード' })).toHaveLength(5);
+  });
+
+  it('reveals all dealer cards face-up (no backs) at the end phase', async () => {
+    mockExec.mockResolvedValue(endPhasePlayerWins);
+    renderWithProviders(<FourCardPokerPage />);
+    await waitFor(() => expect(screen.getByText('You Win!')).toBeInTheDocument());
+    expect(screen.queryByRole('img', { name: '非公開のカード' })).not.toBeInTheDocument();
+  });
+
   it('sends fold command', async () => {
     mockExec.mockResolvedValue(actionPhaseState);
     renderWithProviders(<FourCardPokerPage />);

--- a/frontend/src/pages/FourCardPokerPage.tsx
+++ b/frontend/src/pages/FourCardPokerPage.tsx
@@ -11,6 +11,7 @@ import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
+import { AnimatedCardBack } from '../components/motion/AnimatedCardBack';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
@@ -52,6 +53,10 @@ const FCP_TUTORIAL_STEPS: TutorialStep[] = [
     advanceOn: 'next',
   },
 ];
+
+/** Total cards the dealer is dealt; during the action phase only the upcard
+ * is revealed and the remaining cards are shown as concealed backs. */
+const DEALER_HAND_SIZE = 6;
 
 /** 4-card hand rank → i18n key (1=High Card, 8=Four of a Kind). */
 const HAND_RANK_KEYS: Record<number, string> = {
@@ -252,10 +257,20 @@ function FourCardPokerPageContent() {
                     <span className="ml-2 text-sm">({t(HAND_RANK_KEYS[state.dealerHandRank])})</span>
                   )}
                 </div>
-                <div className="flex justify-center gap-2">
+                <div className="flex justify-center gap-2 flex-wrap">
                   {state.dealerHand.map((card, i) => (
                     <AnimatedCard key={`d-${card.design}-${card.value}-${i}`} card={card} width={cardWidth} />
                   ))}
+                  {/* During the action phase the dealer holds 6 cards but only the
+                      upcard is revealed; render the remaining concealed cards as backs. */}
+                  {isActionPhase &&
+                    Array.from({ length: DEALER_HAND_SIZE - state.dealerHand.length }, (_, i) => (
+                      // role="img" + aria-label makes AT announce "hidden card"
+                      // instead of the generic card-back alt on the inner image.
+                      <span key={`d-back-${i}`} role="img" aria-label={t('hiddenCard')} className="inline-flex">
+                        <AnimatedCardBack width={cardWidth} />
+                      </span>
+                    ))}
                 </div>
               </div>
             )}


### PR DESCRIPTION
## 概要
Closes #3316

Four Card Poker のアクションフェーズでは、ディーラーは実際には6枚持っているのにUI上はアップカード1枚しか描画されておらず、伏せられた手札の存在がまったく表現されていなかった。CaribbeanStud / OasisPoker / RussianPoker と同じ確立済みの hidden-card パターンで、残り5枚を `AnimatedCardBack` の裏面として描画する。

## 変更内容
- `FourCardPokerPage.tsx`: アクションフェーズのディーラー行に、アップカード（表）＋ 裏面 ×5 を描画。裏面は `<span role="img" aria-label={t('hiddenCard')} className="inline-flex"><AnimatedCardBack/></span>` で包み、AT が「非公開のカード」と読み上げる。枚数は `DEALER_HAND_SIZE(6) - dealerHand.length` から算出。モバイル折り返し対応で行に `flex-wrap` を追加。
- `hiddenCard` i18n キーを ja/en の `fourcardpoker.json` に追加。
- END フェーズの全6枚表向き表示は従来どおり（裏面は出ない）。

## テスト
- `renders the dealer concealed cards as backs during the action phase` — アクション中に裏面5枚が描画されることを検証
- `reveals all dealer cards face-up (no backs) at the end phase` — END で裏面が出ないことを検証

## 確認
- [x] `bun run check`（Biome）
- [x] `bun run test -- --run FourCardPokerPage`（18 passed）
- [x] `bun run build`（tsc）
- [x] ACTION フェーズでディーラー側に裏面5枚が表示される
- [x] END フェーズで6枚全て表向き表示（既存挙動維持）
- [x] モバイル幅で折り返し対応