### PR TITLE
feat(kalooki): reveal cpu hands at round end

### DIFF
--- a/frontend/src/i18n/locales/en/kalooki.json
+++ b/frontend/src/i18n/locales/en/kalooki.json
@@ -19,6 +19,7 @@
   "openingHint": "Your first meld(s) must total at least {{n}} points",
   "stockLabel": "Stock",
   "discardLabel": "Discard",
+  "revealedHand": "Revealed hand",
   "yourHand": "Your hand",
   "cards": "Cards",
   "scoreLabel": "Total",

--- a/frontend/src/i18n/locales/ja/kalooki.json
+++ b/frontend/src/i18n/locales/ja/kalooki.json
@@ -19,6 +19,7 @@
   "openingHint": "最初のメルドは合計 {{n}} 点以上が必要です",
   "stockLabel": "山札",
   "discardLabel": "捨て札",
+  "revealedHand": "公開手札",
   "yourHand": "あなたの手札",
   "cards": "枚数",
   "scoreLabel": "累計",

--- a/frontend/src/pages/KalookiPage.test.tsx
+++ b/frontend/src/pages/KalookiPage.test.tsx
@@ -276,6 +276,30 @@ describe('KalookiPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('nextround'));
   });
 
+  it('keeps CPU hands hidden during the draw phase', async () => {
+    // drawState (from beforeEach) is phase 0 — CPU faces must not be revealed.
+    renderWithProviders(<KalookiPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    expect(screen.queryByTestId('kalooki-reveal-1')).not.toBeInTheDocument();
+  });
+
+  it('reveals CPU hands at round end', async () => {
+    const revealState: KalookiResponse = {
+      ...roundEndState,
+      players: [
+        roundEndState.players[0],
+        { ...cpu(1), cardCount: 2, cards: [card('SPADE', 5), card('HEART', 9)] },
+        cpu(2),
+      ],
+    };
+    mockExec.mockResolvedValue(revealState);
+    renderWithProviders(<KalookiPage />);
+    const reveal = await screen.findByTestId('kalooki-reveal-1');
+    expect(reveal.querySelectorAll('img')).toHaveLength(2);
+    // A CPU with no cards left (winner) shows no reveal block.
+    expect(screen.queryByTestId('kalooki-reveal-2')).not.toBeInTheDocument();
+  });
+
   it('shows the winner banner at game end', async () => {
     mockExec.mockResolvedValue({ ...drawState, phase: 3, gameEndFlag: true, winnerIdx: 0 });
     renderWithProviders(<KalookiPage />);

--- a/frontend/src/pages/KalookiPage.tsx
+++ b/frontend/src/pages/KalookiPage.tsx
@@ -356,6 +356,21 @@ function KalookiPageContent() {
                     })}
                   </div>
                 )}
+                {/* Reveal CPU hands at round end / game end so the human can verify penalty scores. */}
+                {!p.isHuman && (isRoundEnd || isGameEnd) && p.cards.length > 0 && (
+                  <div className="mt-2">
+                    <div className="text-xs opacity-75 mb-1">{t('revealedHand')}</div>
+                    <div className="flex flex-wrap gap-1" data-testid={`kalooki-reveal-${p.id}`}>
+                      {p.cards.map((c, ci) => (
+                        <AnimatedCard
+                          key={`reveal-${p.id}-${c.design}-${c.value}-${ci}`}
+                          card={c}
+                          width={cardWidth * 0.6}
+                        />
+                      ))}
+                    </div>
+                  </div>
+                )}
               </div>
             ))}
           </section>

--- a/internal/adapter/presenter/KalookiWebPresenter_test.go
+++ b/internal/adapter/presenter/KalookiWebPresenter_test.go
@@ -113,6 +113,41 @@ func TestKalookiWebPresenter_Output(t *testing.T) {
 		out := unmarshalKalooki(t, p.Output(m, nil))
 		assert.True(t, out.GameEndFlag)
 	})
+
+	t.Run("cpu hands hidden during play", func(t *testing.T) {
+		m, players := setupKalookiWebMock()
+		players[1].AddCard(domain.NewCard(domain.CardDesignSpade, 5, false))
+		players[1].AddCard(domain.NewCard(domain.CardDesignHeart, 9, false))
+
+		out := unmarshalKalooki(t, p.Output(m, nil))
+		// Draw phase: CPU card faces are hidden, only the count is exposed.
+		assert.Equal(t, 2, out.Players[1].CardCount)
+		assert.Empty(t, out.Players[1].Cards)
+	})
+
+	t.Run("cpu hands revealed at round end", func(t *testing.T) {
+		m := new(interfaces.MockKalookiGame)
+		players := []*domain.KalookiPlayer{domain.NewKalookiPlayer(true), domain.NewKalookiPlayer(false)}
+		players[1].AddCard(domain.NewCard(domain.CardDesignSpade, 5, false))
+		players[1].AddCard(domain.NewCard(domain.CardDesignHeart, 9, false))
+		m.On("GetOpeningThreshold").Return(51)
+		m.On("GetDrawPileCount").Return(20)
+		m.On("GetDiscardTop").Return((*domain.Card)(nil))
+		m.On("GetGameEndFlag").Return(false)
+		m.On("GetPhase").Return(domain.KalookiPhaseRoundEnd)
+		m.On("GetCurrentPlayerIdx").Return(0)
+		m.On("GetWinnerIdx").Return(-1)
+		m.On("GetConfig").Return(domain.DefaultKalookiConfig())
+		m.On("GetRoundWinnerIdx").Return(0)
+		m.On("GetPlayerCnt").Return(2)
+		m.On("GetPlayer", 0).Return(players[0])
+		m.On("GetPlayer", 1).Return(players[1])
+
+		out := unmarshalKalooki(t, p.Output(m, nil))
+		// Round end: CPU card faces are revealed so penalty scores can be verified.
+		assert.Equal(t, "kalooki.roundEnd", out.MessageCode)
+		assert.Len(t, out.Players[1].Cards, 2)
+	})
 }
 
 func TestKalookiWebPresenter_ActionLogOutput(t *testing.T) {


### PR DESCRIPTION
## 概要

カルーキのラウンド終了時（ROUND_END / GAME_END）に CPU プレイヤーの残り手札を公開表示するようにしました。`roundScore` は残り手札のペナルティ点で決まるため、点数の根拠を人間プレイヤーが確認できるようになります。

同系ラミー（Chinchon / ThreeThirteen）で確立済みの公開パターンに合わせています。

## 実装内容

- **プレゼンター（変更なし）**: `KalookiWebPresenter.Output` は既に ROUND_END / GAME_END 時のみ CPU の card faces を返しており、プレイ中は枚数のみ。今回のロジック追加は不要でした。
- **フロントエンド**: `KalookiPage.tsx` のプレイヤーカードブロックに `!p.isHuman && (isRoundEnd || isGameEnd) && p.cards.length > 0` ガードの公開ブロックを追加（`data-testid="kalooki-reveal-<id>"`）。
- **i18n**: `revealedHand`（公開手札 / Revealed hand）を ja/en に key-for-key で追加。
- **テスト**:
  - プレゼンター: `cpu hands hidden during play`（Draw フェーズで Cards 空）と `cpu hands revealed at round end`（ROUND_END で Cards 2 枚）の両分岐を検証。
  - ページ: `keeps CPU hands hidden during the draw phase` と `reveals CPU hands at round end`。

## 公開ゲート

`phase === ROUND_END || phase === GAME_END` かつ CPU プレイヤーのみ。プレイ中は従来どおり枚数（`cardCount`）のみ表示。

## テスト計画

- [x] `go test -tags test ./internal/adapter/presenter/...` パス
- [x] `golangci-lint run ./internal/adapter/presenter/...` 0 issues
- [x] `bun run test src/pages/KalookiPage.test.tsx` 23 passed
- [x] `bun run build` 成功
- [x] biome check パス

## 受け入れ条件

- [x] ROUND_END / GAME_END で CPU 手札が表示される
- [x] プレイ中は引き続き枚数のみ
- [x] presenter テストで公開タイミングを検証
- [x] ページテストに公開表示ケースを追加

Closes #3541
