### PR TITLE
feat(indianpoker): stage the showdown own-card reveal with a flip

### DIFF
--- a/frontend/src/pages/IndianPokerPage.test.tsx
+++ b/frontend/src/pages/IndianPokerPage.test.tsx
@@ -585,7 +585,8 @@ describe('IndianPokerPage', () => {
     mockExec.mockResolvedValue(endState);
     renderWithProviders(<IndianPokerPage />);
     await waitFor(() => expect(screen.getByText('終了')).toBeInTheDocument());
-    expect(screen.getByText('結果:')).toBeInTheDocument();
+    // Results appear after the staged own-card reveal completes (#3068).
+    await waitFor(() => expect(screen.getByText('結果:')).toBeInTheDocument());
   });
 
   // ---- bet amount used by raise ----
@@ -784,6 +785,57 @@ describe('IndianPokerPage', () => {
     mockExec.mockResolvedValue(initState);
     renderWithProviders(<IndianPokerPage />);
     await waitFor(() => expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument());
+  });
+
+  // ---- staged showdown reveal (#3068) ----
+  describe('staged showdown reveal', () => {
+    it('conceals the own card (no reveal wrapper) during betting', async () => {
+      mockExec.mockResolvedValue(bettingState);
+      renderWithProviders(<IndianPokerPage />);
+      await waitFor(() => expect(screen.getByText(/あなたのカード/)).toBeInTheDocument());
+      expect(screen.queryByTestId('indianpoker-own-reveal')).not.toBeInTheDocument();
+    });
+
+    it('flips the own card first and holds round results until the reveal completes', async () => {
+      vi.useFakeTimers();
+      try {
+        mockExec.mockResolvedValue(showdownState);
+        renderWithProviders(<IndianPokerPage />);
+        // Own-card reveal wrapper (and the flipped card) appears immediately at showdown.
+        await vi.waitFor(() => expect(screen.getByTestId('indianpoker-own-reveal')).toBeInTheDocument());
+        expect(screen.getByAltText('♥ 7')).toBeInTheDocument();
+        // Results stay hidden until the 600ms reveal delay elapses (no spoiler).
+        expect(screen.queryByText('結果:')).not.toBeInTheDocument();
+        // After the delay the results panel is revealed.
+        await vi.advanceTimersByTimeAsync(600);
+        await vi.waitFor(() => expect(screen.getByText('結果:')).toBeInTheDocument());
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('reveals card and results together immediately when reduced motion is preferred', async () => {
+      const original = window.matchMedia;
+      window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+        matches: query.includes('prefers-reduced-motion'),
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      }));
+      try {
+        mockExec.mockResolvedValue(showdownState);
+        renderWithProviders(<IndianPokerPage />);
+        await waitFor(() => expect(screen.getByTestId('indianpoker-own-reveal')).toBeInTheDocument());
+        // No staged delay: the results panel is present right away.
+        expect(screen.getByText('結果:')).toBeInTheDocument();
+      } finally {
+        window.matchMedia = original;
+      }
+    });
   });
 
   // --- Mobile layout tests ---

--- a/frontend/src/pages/IndianPokerPage.tsx
+++ b/frontend/src/pages/IndianPokerPage.tsx
@@ -1,3 +1,4 @@
+import { motion } from 'framer-motion';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { indianpokerApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
@@ -27,10 +28,12 @@ import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useMountReset } from '../hooks/useMountReset';
 import { usePhaseNames } from '../hooks/usePhaseNames';
+import { useReducedMotion } from '../hooks/useReducedMotion';
 import { useSound } from '../providers/SoundProvider';
 import { placeholderCardStyle } from '../styles/cardStyles';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
+import { flipSpring } from '../styles/motionPresets';
 import type { IndianPokerResponse } from '../types/card';
 import { IndianPokerPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
@@ -138,6 +141,31 @@ function IndianPokerPageContent() {
   const isBetting = phase === IndianPokerPhase.BETTING;
   const isShowdown = phase === IndianPokerPhase.SHOWDOWN || phase === IndianPokerPhase.END;
   const humanPlayer = state?.players?.find((p) => p.isHuman);
+
+  // Staged showdown reveal (#3068): 0 = concealed, 1 = own card flipped face-up,
+  // 2 = round results shown. In Indian Poker you never see your own card during play,
+  // so at showdown we flip it first and hold back the results panel for 600ms to avoid
+  // spoiling the outcome before the card is read. Keyed by hand + phase so each new
+  // showdown restarts the sequence. prefers-reduced-motion jumps straight to step 2.
+  const reduced = useReducedMotion();
+  const revealSignature = isShowdown ? `${state?.handCount ?? 0}:${phase}` : 'hidden';
+  const [revealStep, setRevealStep] = useState(0);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: revealSignature already encodes handCount and phase; listing raw state would re-fire the effect mid-hand.
+  useEffect(() => {
+    if (!isShowdown) {
+      setRevealStep(0);
+      return;
+    }
+    if (reduced) {
+      setRevealStep(2);
+      return;
+    }
+    setRevealStep(1);
+    playSound('cardPlace');
+    const timer = setTimeout(() => setRevealStep(2), 600);
+    return () => clearTimeout(timer);
+  }, [isShowdown, revealSignature, reduced, playSound]);
+
   const humanFolded = humanPlayer?.folded ?? false;
   const humanAllIn = humanPlayer?.allIn ?? false;
   const equity = useMemo(() => {
@@ -259,8 +287,10 @@ function IndianPokerPageContent() {
             {/* CPU actions: toast on mobile, inline log on desktop */}
             {isMobile ? <CpuActionToast actions={state.cpuActions} /> : <CpuActionLog actions={state.cpuActions} />}
 
-            {/* Round results */}
-            {isShowdown && <RoundResults results={roundResultsForDisplay} players={state.players ?? []} />}
+            {/* Round results — held back until the own-card reveal completes (#3068) */}
+            {isShowdown && revealStep >= 2 && (
+              <RoundResults results={roundResultsForDisplay} players={state.players ?? []} />
+            )}
 
             {/* Action log */}
             <ActionLogSection
@@ -291,7 +321,16 @@ function IndianPokerPageContent() {
                 </div>
                 <div className="flex flex-wrap gap-1.5 mb-2">
                   {isShowdown && humanPlayer.card ? (
-                    <AnimatedCard card={humanPlayer.card} width={cardWidth} style={placeholderCardStyle} />
+                    <motion.div
+                      key={revealSignature}
+                      className="[transform-style:preserve-3d]"
+                      initial={reduced ? false : { rotateY: 180, opacity: 0.5 }}
+                      animate={{ rotateY: 0, opacity: 1 }}
+                      transition={flipSpring}
+                      data-testid="indianpoker-own-reveal"
+                    >
+                      <AnimatedCard card={humanPlayer.card} width={cardWidth} style={placeholderCardStyle} silent />
+                    </motion.div>
                   ) : !humanPlayer.folded ? (
                     <AnimatedCardBack width={cardWidth} />
                   ) : null}


### PR DESCRIPTION
## Summary

Adds a staged showdown reveal to Indian Poker (#3068). In this game you never see your own card during play, so the moment it is revealed at showdown is the climax — but previously the card appeared instantly alongside `RoundResults`, spoiling the outcome before you could read it.

Now at showdown:
1. The own card flips face-up first (framer-motion `rotateY` flip, `flipSpring` preset) synced with a `cardPlace` sound.
2. `RoundResults` is held back 600ms so the winnings/outcome no longer spoil the reveal.
3. `prefers-reduced-motion` jumps straight to the results with no delay (via the existing `useReducedMotion` hook).

Frontend-only change — the own card is already present in `IndianPokerResponse` at showdown and absent (null) before, so no backend work is needed. Mirrors the #1892 Baccarat `revealStep` + `setTimeout` pattern.

## Files
- `frontend/src/pages/IndianPokerPage.tsx` — staged `revealStep` state/effect, flip wrapper on the own card, gate `RoundResults` behind `revealStep >= 2`.
- `frontend/src/pages/IndianPokerPage.test.tsx` — new `staged showdown reveal` tests; updated the END-phase test to await the staged results.

## Acceptance criteria
- [x] Own card revealed with a flip animation at showdown
- [x] `RoundResults` shown after the card reveal
- [x] `prefers-reduced-motion` shows results immediately (no delay)
- [x] Tests added for the staged display

## Test plan
- [x] `bun run check` (biome) — passes
- [x] `bun run test -- --run IndianPokerPage` — 70 passed
- [x] `bun run build` (tsc) — passes

Closes #3068
