### PR TITLE
feat(pigtail): flip the drawn card face-up onto the board

### DIFF
--- a/frontend/src/pages/PigsTailPage.test.tsx
+++ b/frontend/src/pages/PigsTailPage.test.tsx
@@ -182,6 +182,39 @@ describe('PigsTailPage', () => {
     await waitFor(() => expect(screen.queryByTestId('pt-center-history')).not.toBeInTheDocument());
   });
 
+  it('flips the drawn card face-up in the reveal area on a draw', async () => {
+    mockExec.mockResolvedValue({
+      ...baseState,
+      lastDrawCard: { design: 'SPADE', value: 1 },
+      lastPenalty: false,
+    });
+    renderWithProviders(<PigsTailPage />);
+    const reveal = await screen.findByTestId('pt-draw-reveal');
+    // The card face (AnimatedCard) is rendered, not just a text label.
+    expect(reveal.querySelector('[data-testid="animated-card"]')).not.toBeNull();
+    // The flip wrapper carries the motion-safe flip animation class.
+    expect(reveal.querySelector('.motion-safe\\:animate-flipIn')).not.toBeNull();
+    expect(reveal).toHaveTextContent('セーフ');
+  });
+
+  it('adds a red highlight ring to the drawn card on a penalty', async () => {
+    mockExec.mockResolvedValue({
+      ...baseState,
+      lastDrawCard: { design: 'HEART', value: 3 },
+      lastPenalty: true,
+    });
+    renderWithProviders(<PigsTailPage />);
+    const reveal = await screen.findByTestId('pt-draw-reveal');
+    expect(reveal.querySelector('.ring-ds-error')).not.toBeNull();
+    expect(reveal).toHaveTextContent('ペナルティ');
+  });
+
+  it('does not render the draw reveal before any card is drawn', async () => {
+    renderWithProviders(<PigsTailPage />);
+    await waitFor(() => expect(screen.getByTestId('circular-deck')).toBeInTheDocument());
+    expect(screen.queryByTestId('pt-draw-reveal')).not.toBeInTheDocument();
+  });
+
   it('draw button is disabled on game end', async () => {
     mockExec.mockResolvedValue(gameEndState);
     renderWithProviders(<PigsTailPage />);

--- a/frontend/src/pages/PigsTailPage.tsx
+++ b/frontend/src/pages/PigsTailPage.tsx
@@ -9,6 +9,7 @@ import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
 import { HintTooltip } from '../components/hint/HintTooltip';
+import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useCliGame } from '../hooks/useCliGame';
@@ -149,6 +150,9 @@ function PigsTailPageContent() {
   const isHumanTurn = !isGameEnd && state.players[state.currentTurn]?.isHuman === true;
   const currentPhaseName = isGameEnd ? phaseNames[PIGTAIL_PHASE_END] : phaseNames[PIGTAIL_PHASE_PLAY];
   const loserIsHuman = isGameEnd && state.loserIdx >= 0 && state.players[state.loserIdx]?.isHuman === true;
+  // Signature of the current draw; changing it remounts the reveal card so the
+  // flip animation re-fires on every new draw (each draw changes circleCount).
+  const drawSig = `${state.circleCount}-${state.centerCount}-${state.lastDrawCard ? `${state.lastDrawCard.design}${state.lastDrawCard.value}` : 'none'}`;
 
   return (
     <GamePageShell
@@ -221,12 +225,22 @@ function PigsTailPageContent() {
               </div>
             </div>
 
-            {/* Last action indicator */}
+            {/* Drawn-card reveal: flips the just-drawn card face-up onto the board
+                so the player can see what was drawn, with a red highlight on penalty. */}
             {state.lastDrawCard && (
-              <div
-                className={`text-center text-sm font-medium ${state.lastPenalty ? 'text-ds-error' : 'text-ds-success'}`}
-              >
-                {state.lastPenalty ? t('label.penalty') : t('label.safe')}
+              <div className="flex flex-col items-center gap-1" data-testid="pt-draw-reveal">
+                <div key={drawSig} className="motion-safe:animate-flipIn">
+                  <div
+                    className={
+                      state.lastPenalty ? 'rounded-lg ring-2 ring-ds-error shadow-lg shadow-ds-error/50' : undefined
+                    }
+                  >
+                    <AnimatedCard card={state.lastDrawCard} width={48} silent />
+                  </div>
+                </div>
+                <div className={`text-sm font-medium ${state.lastPenalty ? 'text-ds-error' : 'text-ds-success'}`}>
+                  {state.lastPenalty ? t('label.penalty') : t('label.safe')}
+                </div>
               </div>
             )}
 


### PR DESCRIPTION
## 概要 / Summary

Pig's Tail (`pigtail`, ぶたのしっぽ) で山札から引いたカードを、盤面にフリップ表示するようにしました。これまで引いたカードは「♠A」形式のテキストとセーフ/ペナルティのラベルでしか分からず、最も重要な「何を引いたか」の瞬間にカードフェイスが描画されていませんでした。

`state.lastDrawCard` を中央エリア下の専用リビールエリアに `AnimatedCard`（カードフェイス画像）で表示し、引くたびに `motion-safe:animate-flipIn` のフリップアニメーションを再発火させます（ドロー署名を `key` にしてリマウント）。ペナルティ時はカードに赤系のリング強調（`ring-ds-error` + colored shadow）が付きます。

OldMaidPage の既存フリップパターン（`animate-flipIn` + `AnimatedCard`）とレスポンス既存フィールドを再利用したフロントエンドのみの変更です。既存のドロー位置ハイライト（`pt-center-history` / penalty flash）には手を加えていません。

## 受け入れ条件 / Acceptance criteria

- [x] 引いたカードがカードフェイス画像で表示される（`AnimatedCard`）
- [x] 新しいドローのたびにアニメーションが発火する（`key={drawSig}` リマウント）
- [x] ペナルティ時はカードに赤系の強調が付く（`ring-ds-error` + shadow）
- [x] ページテストでカード描画の切り替えを検証（3 テスト追加）

## テスト / Tests

- `bun run check` — pass (exit 0)
- `bun run test -- --run PigsTailPage` — 21 passed（+3 新規: flip reveal / penalty ring / no-reveal-before-draw）
- `bun run build` (tsc) — pass
- 回帰確認: `bun run test -- --run OldMaidPage` — pass

Closes #3115