### PR TITLE
feat(sueca): show live captured card points during play

### DIFF
--- a/frontend/src/i18n/locales/en/sueca.json
+++ b/frontend/src/i18n/locales/en/sueca.json
@@ -38,6 +38,10 @@
   "playButton": "Play",
   "nextTrick": "Next Trick",
   "nextRound": "Next Round",
+  "livePoints": {
+    "title": "Captured Card Points",
+    "team": "{{team}}: {{points}} / {{target}}"
+  },
   "roundResult": {
     "title": "Round Result",
     "teamA": "Team A card points: {{points}}",

--- a/frontend/src/i18n/locales/ja/sueca.json
+++ b/frontend/src/i18n/locales/ja/sueca.json
@@ -38,6 +38,10 @@
   "playButton": "出す",
   "nextTrick": "次のトリック",
   "nextRound": "次のラウンド",
+  "livePoints": {
+    "title": "獲得カード点",
+    "team": "{{team}}: {{points}} / {{target}}"
+  },
   "roundResult": {
     "title": "ラウンド結果",
     "teamA": "チームAのカード点: {{points}}",

--- a/frontend/src/pages/SuecaPage.test.tsx
+++ b/frontend/src/pages/SuecaPage.test.tsx
@@ -111,6 +111,22 @@ describe('SuecaPage', () => {
     await waitFor(() => expect(screen.getByTestId('sueca-trick-winner')).toHaveTextContent('チームB がトリック獲得'));
   });
 
+  it('shows the live captured card points against the 61 win line during play', async () => {
+    mockExec.mockResolvedValue(makeSuecaState({ roundCardPoints: [45, 20] }));
+    renderWithProviders(<SuecaPage />);
+    const panel = await screen.findByTestId('sueca-round-points');
+    expect(panel).toHaveTextContent('チームA: 45 / 61');
+    expect(panel).toHaveTextContent('チームB: 20 / 61');
+    expect(panel).toHaveAttribute('role', 'status');
+  });
+
+  it('hides the live points panel once the round ends (round result takes over)', async () => {
+    mockExec.mockResolvedValue(roundEndState);
+    renderWithProviders(<SuecaPage />);
+    await waitFor(() => expect(screen.getByText('ラウンド結果')).toBeInTheDocument());
+    expect(screen.queryByTestId('sueca-round-points')).not.toBeInTheDocument();
+  });
+
   it('renders round end with the next round button and the round result', async () => {
     mockExec.mockResolvedValue(roundEndState);
     renderWithProviders(<SuecaPage />);

--- a/frontend/src/pages/SuecaPage.tsx
+++ b/frontend/src/pages/SuecaPage.tsx
@@ -32,6 +32,9 @@ import { formatSuecaState } from '../utils/cli/formatters/suecaFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
 import { playerName } from '../utils/playerUtils';
 
+/** Card points needed to win a Sueca round (majority of the 120 total). */
+const SUECA_WIN_POINTS = 61;
+
 /** Suit symbols indexed by suit number (1=♠ 2=♣ 3=♥ 4=♦; index 0 unused). */
 const SUIT_SYMBOLS = ['', '♠', '♣', '♥', '♦'] as const;
 /** Suit id → `suitName.*` i18n key (1=♠ .. 4=♦). */
@@ -264,6 +267,34 @@ function SuecaPageContent() {
                         {t('tricks', { count: p.trickCount })}
                       </div>
                     ))}
+                  </div>
+                )}
+
+                {/* Live captured card points during play; the round-result block
+                    below takes over once the round ends. Progress is shown against
+                    the 61-point round-win line. */}
+                {!(isRoundEnd || isGameEnd) && (
+                  <div
+                    className="my-3 p-2 rounded bg-black/30 text-ds-text-muted text-sm"
+                    role="status"
+                    aria-live="polite"
+                    data-testid="sueca-round-points"
+                  >
+                    <div className="mb-1 text-ds-text-primary">{t('livePoints.title')}</div>
+                    <div>
+                      {t('livePoints.team', {
+                        team: t('team.a'),
+                        points: state.roundCardPoints[0] ?? 0,
+                        target: SUECA_WIN_POINTS,
+                      })}
+                    </div>
+                    <div>
+                      {t('livePoints.team', {
+                        team: t('team.b'),
+                        points: state.roundCardPoints[1] ?? 0,
+                        target: SUECA_WIN_POINTS,
+                      })}
+                    </div>
                   </div>
                 )}
 


### PR DESCRIPTION
## 概要

スエカのプレイ中に、両チームの獲得カードポイントをライブ表示するサイドバーパネルを追加しました。61 点の勝利ラインに対する進捗が「チームA: 45 / 61」の形式で分かります。

TwentyNine の `tn29-round-points` パネルと同じパターンです。`roundCardPoints` はドメインで各トリック解決時に加算され (`Sueca.ResolveTrick`)、`SuecaWebPresenter` が常時出力しているため、**フロントエンドのみの変更**です。ラウンド終了時は既存の roundResult 表示に切り替わります。

## 変更内容

- `SuecaPage.tsx`: `!(isRoundEnd || isGameEnd)` のときに `data-testid="sueca-round-points"` のライブ表示パネルを追加。61 点定数 `SUECA_WIN_POINTS` を併記。`role="status"` `aria-live="polite"`。
- `SuecaPage.test.tsx`: ライブ表示 / ラウンド終了時の切り替えのテストを追加。
- `i18n/locales/{ja,en}/sueca.json`: `livePoints` キーを追加。

## 受け入れ条件

- [x] プレイ中にチーム別獲得カードポイントが表示される
- [x] 61 点の目標値が併記される
- [x] ラウンド終了時は既存の roundResult 表示に切り替わる
- [x] SuecaPage.test.tsx にライブ表示のテストを追加

## テスト

- `bun run check` OK
- `bun run test -- --run SuecaPage` 15 passed
- `bun run build` (tsc) OK

Closes #3412
