### PR TITLE
feat(bigo): ring the 2 hole cards each cpu used at showdown

### DIFF
--- a/frontend/src/components/CpuPlayerCard.test.tsx
+++ b/frontend/src/components/CpuPlayerCard.test.tsx
@@ -180,6 +180,35 @@ describe('CpuPlayerCard', () => {
     expect(screen.queryByTestId('meta-ai-indicator')).not.toBeInTheDocument();
   });
 
+  it('rings the used hole cards when usedHoleIdx is provided at face-up', () => {
+    render(
+      <CpuPlayerCard player={makePlayer()} showCards={true} faceDownCount={2} showHandName={false} usedHoleIdx={[0]} />,
+    );
+    const used = screen.getAllByTestId('cpu-hole-used');
+    expect(used).toHaveLength(1);
+    expect(used[0].className).toContain('ring-ds-success');
+    // The used ring wraps the first card (♠ A), not the second.
+    expect(used[0].querySelector('img')).toHaveAttribute('alt', '♠ A');
+  });
+
+  it('does not ring any card when usedHoleIdx is absent', () => {
+    render(<CpuPlayerCard player={makePlayer()} showCards={true} faceDownCount={2} showHandName={false} />);
+    expect(screen.queryByTestId('cpu-hole-used')).not.toBeInTheDocument();
+  });
+
+  it('does not ring cards for a folded player even when usedHoleIdx is provided', () => {
+    render(
+      <CpuPlayerCard
+        player={makePlayer({ folded: true })}
+        showCards={true}
+        faceDownCount={2}
+        showHandName={false}
+        usedHoleIdx={[0, 1]}
+      />,
+    );
+    expect(screen.queryByTestId('cpu-hole-used')).not.toBeInTheDocument();
+  });
+
   it('does not render MetaAiIndicator when metaAi is disabled', () => {
     render(
       <CpuPlayerCard

--- a/frontend/src/components/CpuPlayerCard.tsx
+++ b/frontend/src/components/CpuPlayerCard.tsx
@@ -40,6 +40,14 @@ interface CpuPlayerCardProps {
   compactFaceDown?: boolean;
   /** Optional meta-AI data for visual feedback. */
   metaAi?: CpuMetaAiProp;
+  /**
+   * Indices into `player.cards` of the hole cards the player actually used in
+   * their best showdown hand (e.g. the 2 hole cards under the Omaha / Big O
+   * rule). When provided and the cards are shown face-up, those cards receive
+   * an additive success ring. Ignored for folded players (whose cards are not
+   * shown), so no explicit fold check is needed here.
+   */
+  usedHoleIdx?: readonly number[];
 }
 
 /** Renders a CPU player's info area with cards (face-up or face-down) and status. */
@@ -51,10 +59,12 @@ export function CpuPlayerCard({
   extraInfo,
   compactFaceDown,
   metaAi,
+  usedHoleIdx,
 }: CpuPlayerCardProps) {
   const { t } = useTranslation('common');
   const { cpuCardWidth } = useCardDimensions();
   const showFaceUp = showCards && !player.folded && player.cards.length > 0;
+  const usedHoleSet = usedHoleIdx ? new Set(usedHoleIdx) : undefined;
   const strategyStyle = metaAi?.enabled ? deriveStrategyStyle(metaAi) : undefined;
   return (
     <div className="relative mb-3 rounded-lg p-2 bg-black/20 border border-white/10">
@@ -89,14 +99,18 @@ export function CpuPlayerCard({
       </div>
       {showFaceUp ? (
         <div className="flex flex-wrap gap-1">
-          {player.cards.map((card) => (
-            <CardImage
-              key={`${card.design}-${card.value}`}
-              card={card}
-              width={cpuCardWidth}
-              style={{ border: '3px solid transparent' }}
-            />
-          ))}
+          {player.cards.map((card, idx) => {
+            const used = usedHoleSet?.has(idx) ?? false;
+            return (
+              <div
+                key={`${card.design}-${card.value}`}
+                className={`rounded-md ${used ? 'ring-2 ring-ds-success motion-safe:animate-pulse' : ''}`}
+                data-testid={used ? 'cpu-hole-used' : undefined}
+              >
+                <CardImage card={card} width={cpuCardWidth} style={{ border: '3px solid transparent' }} />
+              </div>
+            );
+          })}
         </div>
       ) : !compactFaceDown ? (
         <div className="flex flex-wrap gap-1">

--- a/frontend/src/pages/BigOPage.test.tsx
+++ b/frontend/src/pages/BigOPage.test.tsx
@@ -398,6 +398,23 @@ describe('BigOPage', () => {
     expect(container.querySelectorAll('[data-best5-board]')).toHaveLength(3);
   });
 
+  it('rings the 2 hole cards each non-folded CPU used at showdown', async () => {
+    mockExec.mockResolvedValue(showdownState);
+    renderWithProviders(<BigOPage />);
+    await waitFor(() => expect(screen.getByText('ツーペア')).toBeInTheDocument());
+    // Only CPU 1 is unfolded (CPU 2 folded), so exactly its 2 used hole cards are ringed.
+    const used = screen.getAllByTestId('cpu-hole-used');
+    expect(used).toHaveLength(2);
+    for (const el of used) expect(el.className).toContain('ring-ds-success');
+  });
+
+  it('does not ring any CPU hole cards outside showdown', async () => {
+    mockExec.mockResolvedValue(flopState);
+    renderWithProviders(<BigOPage />);
+    await waitFor(() => expect(screen.getByText(/CPU 1/)).toBeInTheDocument());
+    expect(screen.queryByTestId('cpu-hole-used')).not.toBeInTheDocument();
+  });
+
   it('does not show CPU hand name badge when CPU is folded in showdown', async () => {
     mockExec.mockResolvedValue(showdownState);
     renderWithProviders(<BigOPage />);

--- a/frontend/src/pages/BigOPage.tsx
+++ b/frontend/src/pages/BigOPage.tsx
@@ -282,26 +282,35 @@ function BigOPageContent() {
                   </div>
                 </>
               );
-              const cpuPlayerCards = cpuPlayers.map((player) => (
-                <CpuPlayerCard
-                  key={player.id}
-                  player={player}
-                  showCards={isShowdown}
-                  faceDownCount={5}
-                  showHandName={isShowdown}
-                  extraInfo={
-                    player.totalHands > 0 ? (
-                      <HudStats
-                        namespace="bigo"
-                        vpip={player.vpip}
-                        pfr={player.pfr}
-                        threeBet={player.threeBet}
-                        af={player.af}
-                      />
-                    ) : undefined
-                  }
-                />
-              ));
+              const cpuPlayerCards = cpuPlayers.map((player) => {
+                // At showdown, highlight the exactly-2 hole cards this CPU used
+                // in its best hand under Big O's must-use-2-hole + 3-board rule.
+                const cpuUsedHoleIdx =
+                  isShowdown && !player.folded
+                    ? (omahaBestFive(player.cards ?? [], state?.communityCards ?? [])?.holeIdx ?? undefined)
+                    : undefined;
+                return (
+                  <CpuPlayerCard
+                    key={player.id}
+                    player={player}
+                    showCards={isShowdown}
+                    faceDownCount={5}
+                    showHandName={isShowdown}
+                    usedHoleIdx={cpuUsedHoleIdx}
+                    extraInfo={
+                      player.totalHands > 0 ? (
+                        <HudStats
+                          namespace="bigo"
+                          vpip={player.vpip}
+                          pfr={player.pfr}
+                          threeBet={player.threeBet}
+                          af={player.af}
+                        />
+                      ) : undefined
+                    }
+                  />
+                );
+              });
 
               if (isLargeDesktop) {
                 return (


### PR DESCRIPTION
## 概要
5カードオマハ（Big O）のショーダウンで、公開されるCPUの5枚のうち **実際に使われた2枚のホールカード** が分からなかった。`CpuPlayerCard` に任意プロップ `usedHoleIdx` を追加し、既存の `omahaBestFive` で算出した使用2枚に加算的に成功リング（`ring-ds-success`）を付与する。

## 変更点
- `CpuPlayerCard.tsx`: 任意プロップ `usedHoleIdx?: readonly number[]` を追加。フェイスアップ時のみ、該当インデックスのカードを `ring-2 ring-ds-success motion-safe:animate-pulse` でリング表示（`data-testid="cpu-hole-used"`）。フォールド済みはカード非表示のため対象外、他ゲームの利用箇所はプロップ未指定で無影響。
- `BigOPage.tsx`: ショーダウン時、フォールドしていない各CPUについて `omahaBestFive(player.cards, communityCards)?.holeIdx` を計算して `usedHoleIdx` として渡す。
- テスト追加（コンポーネント3件 / ページ2件）。

## 受け入れ条件
- [x] ショーダウンでCPUの使用2枚が強調表示される
- [x] フォールド済みCPUには適用されない
- [x] 他ゲームの `CpuPlayerCard` 利用箇所に影響しない（オプション扱い）
- [x] ユニットテストを追加する

## テスト
- `frontend/src/components/CpuPlayerCard.test.tsx`（`rings the used hole cards when usedHoleIdx is provided at face-up` ほか）
- `frontend/src/pages/BigOPage.test.tsx`（`rings the 2 hole cards each non-folded CPU used at showdown` / `does not ring any CPU hole cards outside showdown`）
- ゲート: `bun run check` / `bun run test -- --run CpuPlayerCard BigOPage`（138 passed）/ `bun run build` すべてグリーン。

Closes #3008

🤖 Generated with [Claude Code](https://claude.com/claude-code)