### PR TITLE
feat(sedma): show live captured card-points during play

### DIFF
--- a/frontend/src/i18n/locales/en/sedma.json
+++ b/frontend/src/i18n/locales/en/sedma.json
@@ -30,6 +30,7 @@
   "playButton": "Play",
   "nextTrick": "Next Trick",
   "nextRound": "Next Round",
+  "roundPointsTitle": "Card points captured (this round)",
   "roundResult": {
     "title": "Round Result",
     "teamA": "Team A card points: {{points}}",

--- a/frontend/src/i18n/locales/ja/sedma.json
+++ b/frontend/src/i18n/locales/ja/sedma.json
@@ -30,6 +30,7 @@
   "playButton": "出す",
   "nextTrick": "次のトリック",
   "nextRound": "次のラウンド",
+  "roundPointsTitle": "獲得カード点（現ラウンド）",
   "roundResult": {
     "title": "ラウンド結果",
     "teamA": "チームAのカード点: {{points}}",

--- a/frontend/src/pages/SedmaPage.test.tsx
+++ b/frontend/src/pages/SedmaPage.test.tsx
@@ -75,6 +75,22 @@ describe('SedmaPage', () => {
     await waitFor(() => expect(screen.getByRole('button', { name: '次のトリック' })).toBeInTheDocument());
   });
 
+  it('shows the live captured card points during play', async () => {
+    mockExec.mockResolvedValue(makeSedmaState({ roundCardPoints: [40, 20] }));
+    renderWithProviders(<SedmaPage />);
+    const panel = await screen.findByTestId('sedma-round-points');
+    expect(panel).toHaveTextContent('獲得カード点（現ラウンド）');
+    expect(panel).toHaveTextContent('チームAのカード点: 40');
+    expect(panel).toHaveTextContent('チームBのカード点: 20');
+  });
+
+  it('hides the live captured card points once the round ends', async () => {
+    mockExec.mockResolvedValue(roundEndState);
+    renderWithProviders(<SedmaPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: '次のラウンド' })).toBeInTheDocument());
+    expect(screen.queryByTestId('sedma-round-points')).not.toBeInTheDocument();
+  });
+
   it('renders round end with the next round button and the round result', async () => {
     mockExec.mockResolvedValue(roundEndState);
     renderWithProviders(<SedmaPage />);

--- a/frontend/src/pages/SedmaPage.tsx
+++ b/frontend/src/pages/SedmaPage.tsx
@@ -264,6 +264,20 @@ function SedmaPageContent() {
                   <div className="mb-2 p-2 rounded bg-black/30">{state.players.map(renderPlayerRow)}</div>
                 )}
 
+                {/* Live captured card points during play (A and 10 = 10 pts each, +10
+                    last-trick bonus); the round-result block below takes over at round end. */}
+                {!(isRoundEnd || isGameEnd) && (
+                  <div
+                    className="my-3 p-2 rounded bg-black/30 text-ds-text-muted text-sm"
+                    data-testid="sedma-round-points"
+                    role="status"
+                  >
+                    <div className="mb-1 text-ds-text-primary">{t('roundPointsTitle')}</div>
+                    <div>{t('roundResult.teamA', { points: state.roundCardPoints[0] ?? 0 })}</div>
+                    <div>{t('roundResult.teamB', { points: state.roundCardPoints[1] ?? 0 })}</div>
+                  </div>
+                )}
+
                 {/* Round result */}
                 {(isRoundEnd || isGameEnd) && (
                   <div className="my-3 p-2 rounded bg-black/30 text-ds-text-muted text-sm">


### PR DESCRIPTION
## 概要
セドマのプレイ中に、各チームが現ラウンドで獲得したカード点（A と 10 が各10点、+ラストトリック10点）をサイドバーにライブ表示する。ROUND_END までカード点が見えず7でのキャプチャ判断が立てにくい問題を解消する。

## 実装
- `SedmaWebPresenter.go` は `buildBase` で毎回 `RoundCardPoints` を出力済みのため **フロントエンドのみ** で対応（Go 変更なし）。
- `SedmaPage.tsx` の情報サイドバーに `!(isRoundEnd || isGameEnd)` のときだけ表示する `sedma-round-points` パネルを追加（TwentyNinePage の `tn29-round-points` と同じパターン、`role="status"`）。ラウンド終了時は既存の `roundResult` ブロックに切り替わる。
- ja/en に `roundPointsTitle` ラベルを追加（点数行は既存の `roundResult.teamA/teamB` を再利用）。

## テスト
- `SedmaPage.test.tsx` に2件追加:
  - プレイ中にライブ獲得カード点が表示される
  - ラウンド終了時はライブパネルが消える
- `bun run test -- --run SedmaPage` 12件パス、`bun run check`（exit 0）、`bun run build`（tsc）パス。i18n parity OK。

## 受け入れ条件
- [x] プレイ中にチーム別の獲得カードポイントが表示される
- [x] ラウンド終了時は既存の roundResult に切り替わる
- [x] ja/en 両ロケールにラベルを追加
- [x] SedmaPage.test.tsx にテストを追加

Closes #3430