### PR TITLE
feat(threethirteen): show predicted post-discard deadwood

### DIFF
--- a/frontend/src/i18n/locales/en/threethirteen.json
+++ b/frontend/src/i18n/locales/en/threethirteen.json
@@ -32,7 +32,7 @@
   "drawDiscardButton": "Draw Discard",
   "discardButton": "Discard",
   "knockButton": "Knock",
-  "deadwoodLabel": "Deadwood: {{score}} pts",
+  "deadwoodLabel": "Predicted deadwood: {{score}} pts",
   "nextRound": "Next Round",
   "drawPhase": "Draw a card from the stock or discard pile",
   "discardPhase": "Discard a card, or discard it and knock",

--- a/frontend/src/i18n/locales/ja/threethirteen.json
+++ b/frontend/src/i18n/locales/ja/threethirteen.json
@@ -32,7 +32,7 @@
   "drawDiscardButton": "捨て札から引く",
   "discardButton": "捨てる",
   "knockButton": "ノック",
-  "deadwoodLabel": "デッドウッド: {{score}}点",
+  "deadwoodLabel": "予測デッドウッド: {{score}}点",
   "nextRound": "次のラウンド",
   "drawPhase": "山札または捨て札から1枚引いてください",
   "discardPhase": "手札から1枚捨てるか、その1枚を捨ててノックしてください",

--- a/frontend/src/pages/ThreeThirteenPage.test.tsx
+++ b/frontend/src/pages/ThreeThirteenPage.test.tsx
@@ -86,6 +86,42 @@ describe('ThreeThirteenPage', () => {
     await waitFor(() => expect(screen.getByTestId('threethirteen-deadwood-indicator')).toBeInTheDocument());
   });
 
+  it('shows predicted post-discard deadwood that changes with card selection', async () => {
+    // ♠5-6-7 form a run; ♥K is the odd card. Wild rank 2 does not match any card.
+    const meldHandState: ThreeThirteenResponse = {
+      ...discardPhaseState,
+      wildRank: 2,
+      players: [
+        {
+          id: 0,
+          isHuman: true,
+          cardCount: 4,
+          cards: [
+            { design: 'SPADE', value: 5 },
+            { design: 'SPADE', value: 6 },
+            { design: 'SPADE', value: 7 },
+            { design: 'HEART', value: 13 },
+          ],
+          deadwood: 10,
+          roundScore: 0,
+          cumulativeScore: 0,
+        },
+        discardPhaseState.players[1],
+      ],
+    };
+    mockExec.mockResolvedValue(meldHandState);
+    renderWithProviders(<ThreeThirteenPage />);
+
+    // No selection → best single discard drops ♥K, leaving the run → 0.
+    await waitFor(() =>
+      expect(screen.getByTestId('threethirteen-deadwood-indicator')).toHaveTextContent('予測デッドウッド: 0点'),
+    );
+
+    // Selecting a run card (♠5) breaks the meld → ♠6 + ♠7 + ♥K = 23.
+    fireEvent.click(screen.getByAltText('♠ 5').closest('button') as HTMLButtonElement);
+    expect(screen.getByTestId('threethirteen-deadwood-indicator')).toHaveTextContent('予測デッドウッド: 23点');
+  });
+
   it('badges wild-rank cards in the hand and on the discard top', async () => {
     // Aces wild: the ♠A in hand and the ♣A discard top both match wildRank 1.
     mockExec.mockResolvedValue({

--- a/frontend/src/pages/ThreeThirteenPage.tsx
+++ b/frontend/src/pages/ThreeThirteenPage.tsx
@@ -32,6 +32,7 @@ import { parseThreeThirteenCommand, THREETHIRTEEN_HELP } from '../utils/cli/comm
 import { formatThreeThirteenState } from '../utils/cli/formatters/threethirteenFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
 import { playerName } from '../utils/playerUtils';
+import { bestThreeThirteenDeadwoodValue, bestThreeThirteenDiscardValue } from '../utils/threethirteenDeadwood';
 
 const THREETHIRTEEN_PHASE_KEYS: Readonly<Record<number, string>> = {
   [ThreeThirteenPhase.DRAW]: 'draw',
@@ -141,6 +142,26 @@ function ThreeThirteenPageContent() {
     });
   }, [gameExec, hideActionLog, threeThirteenConfig.cpuDifficulty, threeThirteenConfig.playerCount]);
 
+  // Predicted post-discard deadwood, so the player can weigh a discard before
+  // committing. When one card is selected we project that exact discard;
+  // otherwise we show the best value reachable across every single discard.
+  // Wild-rank cards (state.wildRank) are matched into melds, so this mirrors the
+  // server's own scoring. Computed unconditionally (before the early return) to
+  // keep hook order stable; only surfaced during the DISCARD phase.
+  const predictedDeadwood = useMemo<number | null>(() => {
+    if (!state || state.phase !== ThreeThirteenPhase.DISCARD) return null;
+    const human = state.players.find((p) => p.isHuman);
+    if (!human || human.cards.length === 0) return null;
+    const cards = human.cards;
+    if (selectedCardIndices.length === 1) {
+      return bestThreeThirteenDeadwoodValue(
+        cards.filter((_, i) => i !== selectedCardIndices[0]),
+        state.wildRank,
+      );
+    }
+    return bestThreeThirteenDiscardValue(cards, state.wildRank);
+  }, [state, selectedCardIndices]);
+
   if (!state)
     return (
       <GameSkeleton
@@ -169,8 +190,9 @@ function ThreeThirteenPageContent() {
       </span>
     ) : null;
 
-  // Lowest cumulative score wins, so highlight the leader (fewest points).
-  const humanDeadwood = humanPlayer?.deadwood ?? null;
+  // Prefer the projected post-discard deadwood (predictedDeadwood) during the
+  // discard phase; fall back to the server's current-hand value otherwise.
+  const humanDeadwood = predictedDeadwood ?? humanPlayer?.deadwood ?? null;
 
   return (
     <GamePageShell

--- a/frontend/src/utils/threethirteenDeadwood.test.ts
+++ b/frontend/src/utils/threethirteenDeadwood.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import type { Card, CardDesign } from '../types/card';
+import {
+  bestThreeThirteenDeadwoodValue,
+  bestThreeThirteenDiscardValue,
+  calcThreeThirteenDeadwoodValue,
+  THREETHIRTEEN_WILD_DEADWOOD_VALUE,
+  threeThirteenCardValue,
+  threeThirteenIsWild,
+} from './threethirteenDeadwood';
+
+const c = (design: CardDesign, value: number): Card => ({ design, value });
+
+describe('threethirteenDeadwood', () => {
+  it('scores single card values (A=1, face, J/Q/K=10)', () => {
+    expect(threeThirteenCardValue(c('SPADE', 1))).toBe(1);
+    expect(threeThirteenCardValue(c('SPADE', 7))).toBe(7);
+    expect(threeThirteenCardValue(c('SPADE', 10))).toBe(10);
+    expect(threeThirteenCardValue(c('SPADE', 13))).toBe(10);
+  });
+
+  it('identifies the wild rank', () => {
+    expect(threeThirteenIsWild(c('SPADE', 4), 4)).toBe(true);
+    expect(threeThirteenIsWild(c('SPADE', 5), 4)).toBe(false);
+  });
+
+  it('counts a leftover wild as the wild penalty', () => {
+    // ♥3 (=3) + a wild (rank 4) left as deadwood → 3 + 20.
+    const total = calcThreeThirteenDeadwoodValue([c('HEART', 3), c('DIAMOND', 4)], 4);
+    expect(total).toBe(3 + THREETHIRTEEN_WILD_DEADWOOD_VALUE);
+  });
+
+  it('returns 0 deadwood for a natural set of three', () => {
+    const hand = [c('SPADE', 8), c('HEART', 8), c('CLOVER', 8)];
+    expect(bestThreeThirteenDeadwoodValue(hand, 4)).toBe(0);
+  });
+
+  it('completes a run with a wild card (deadwood 0)', () => {
+    // ♠5, ♠7 plus a wild (rank 4) filling the 6 → run 5-6-7, deadwood 0.
+    const hand = [c('SPADE', 5), c('SPADE', 7), c('HEART', 4)];
+    expect(bestThreeThirteenDeadwoodValue(hand, 4)).toBe(0);
+  });
+
+  it('completes a set with a wild card (deadwood 0)', () => {
+    // ♠9, ♥9 plus a wild (rank 2) → set of 9s, deadwood 0.
+    const hand = [c('SPADE', 9), c('HEART', 9), c('CLOVER', 2)];
+    expect(bestThreeThirteenDeadwoodValue(hand, 2)).toBe(0);
+  });
+
+  it('leaves the non-melding card as deadwood', () => {
+    // ♠5,♠6,♠7 form a run; ♥K (10) is unmatched → deadwood 10.
+    const hand = [c('SPADE', 5), c('SPADE', 6), c('SPADE', 7), c('HEART', 13)];
+    expect(bestThreeThirteenDeadwoodValue(hand, 2)).toBe(10);
+  });
+
+  it('treats Ace as high in a Q-K-A run', () => {
+    const hand = [c('SPADE', 12), c('SPADE', 13), c('SPADE', 1)];
+    expect(bestThreeThirteenDeadwoodValue(hand, 2)).toBe(0);
+  });
+
+  it('finds the best single discard', () => {
+    // Discarding ♥K leaves the ♠5-6-7 run → 0; any other discard is worse.
+    const hand = [c('SPADE', 5), c('SPADE', 6), c('SPADE', 7), c('HEART', 13)];
+    expect(bestThreeThirteenDiscardValue(hand, 2)).toBe(0);
+  });
+
+  it('returns 0 for empty hands', () => {
+    expect(bestThreeThirteenDeadwoodValue([], 4)).toBe(0);
+    expect(bestThreeThirteenDiscardValue([], 4)).toBe(0);
+  });
+});

--- a/frontend/src/utils/threethirteenDeadwood.ts
+++ b/frontend/src/utils/threethirteenDeadwood.ts
@@ -1,0 +1,165 @@
+import type { Card } from '../types/card';
+
+/**
+ * Deadwood penalty for a wild card left unmatched, mirroring
+ * `ThreeThirteenWildDeadwoodValue` in internal/domain/ThreeThirteen.go.
+ */
+export const THREETHIRTEEN_WILD_DEADWOOD_VALUE = 20;
+
+/** Minimum meld size (set or run), mirroring `ThreeThirteenMeldMinSize`. */
+const MELD_MIN_SIZE = 3;
+
+/** Whether `card` is this round's wild (its rank equals `wildRank`). */
+export function threeThirteenIsWild(card: Card, wildRank: number): boolean {
+  return card.value === wildRank;
+}
+
+/** Face value of a single card for scoring: A=1, 2-10=face, J/Q/K=10. */
+export function threeThirteenCardValue(card: Card): number {
+  return card.value >= 10 ? 10 : card.value;
+}
+
+/**
+ * Total deadwood points of a pile: face value per natural card, but a leftover
+ * wild counts as {@link THREETHIRTEEN_WILD_DEADWOOD_VALUE}. Mirrors
+ * `threeThirteenDeadwoodValue` in the domain.
+ */
+export function calcThreeThirteenDeadwoodValue(cards: readonly Card[], wildRank: number): number {
+  let total = 0;
+  for (const c of cards) {
+    total += threeThirteenIsWild(c, wildRank) ? THREETHIRTEEN_WILD_DEADWOOD_VALUE : threeThirteenCardValue(c);
+  }
+  return total;
+}
+
+/** Indexed handle so the meld search compares card identity, not value
+ * (duplicate ranks across the two decks would otherwise collide). */
+interface IndexedCard {
+  idx: number;
+  card: Card;
+}
+
+/**
+ * Minimum deadwood value obtainable by splitting `hand` into melds
+ * (wild-aware sets and runs) plus leftover deadwood. Ports
+ * `threeThirteenBestMelds` + `threeThirteenDeadwoodValue` from the domain but
+ * surfaces only the integer total that the UI needs.
+ */
+export function bestThreeThirteenDeadwoodValue(hand: readonly Card[], wildRank: number): number {
+  if (hand.length === 0) return 0;
+  return search(
+    hand.map((card, idx) => ({ idx, card })),
+    wildRank,
+  );
+}
+
+/**
+ * Minimum deadwood reachable after discarding exactly one card from `hand`,
+ * i.e. the best post-discard total. Mirrors `threeThirteenBestDiscardValue`.
+ * Returns 0 for an empty hand.
+ */
+export function bestThreeThirteenDiscardValue(hand: readonly Card[], wildRank: number): number {
+  if (hand.length === 0) return 0;
+  let best = -1;
+  for (let i = 0; i < hand.length; i++) {
+    const rest = hand.filter((_, j) => j !== i);
+    const v = bestThreeThirteenDeadwoodValue(rest, wildRank);
+    if (best < 0 || v < best) best = v;
+    if (best === 0) break;
+  }
+  return best;
+}
+
+/** Recursively split `remaining` into melds, returning the minimum deadwood value. */
+function search(remaining: IndexedCard[], wildRank: number): number {
+  const candidates = enumerateMelds(remaining, wildRank);
+  let best = calcThreeThirteenDeadwoodValue(
+    remaining.map((r) => r.card),
+    wildRank,
+  );
+  if (candidates.length === 0) return best;
+  for (const meld of candidates) {
+    const meldIdx = new Set(meld.map((m) => m.idx));
+    const rest = remaining.filter((r) => !meldIdx.has(r.idx));
+    const sub = search(rest, wildRank);
+    if (sub < best) best = sub;
+    if (best === 0) break; // perfect meld — optimal
+  }
+  return best;
+}
+
+/** Enumerate candidate melds (3-4 cards) constructible from `cards`, using
+ * wilds to substitute in sets or fill run gaps. Ports `threeThirteenAllMelds`. */
+function enumerateMelds(cards: IndexedCard[], wildRank: number): IndexedCard[][] {
+  const out: IndexedCard[][] = [];
+  const wilds: IndexedCard[] = [];
+  const naturals: IndexedCard[] = [];
+  for (const c of cards) {
+    if (threeThirteenIsWild(c.card, wildRank)) wilds.push(c);
+    else naturals.push(c);
+  }
+
+  // Sets: same-rank naturals topped up with wilds to reach 3-4 cards.
+  const byRank = new Map<number, IndexedCard[]>();
+  for (const c of naturals) {
+    const list = byRank.get(c.card.value) ?? [];
+    list.push(c);
+    byRank.set(c.card.value, list);
+  }
+  for (const group of byRank.values()) {
+    for (let size = MELD_MIN_SIZE; size <= MELD_MIN_SIZE + 1; size++) {
+      const needWild = Math.max(size - group.length, 0);
+      const natTake = size - needWild;
+      if (natTake < 1 || natTake > group.length || needWild > wilds.length) continue;
+      out.push([...group.slice(0, natTake), ...wilds.slice(0, needWild)]);
+    }
+  }
+
+  // Runs: same-suit consecutive ranks, wilds filling gaps (Ace low or high).
+  const bySuit = new Map<string, Map<number, IndexedCard>>();
+  for (const c of naturals) {
+    let byVal = bySuit.get(c.card.design);
+    if (!byVal) {
+      byVal = new Map<number, IndexedCard>();
+      bySuit.set(c.card.design, byVal);
+    }
+    if (!byVal.has(c.card.value)) byVal.set(c.card.value, c);
+  }
+  for (const byVal of bySuit.values()) {
+    out.push(...runsInSuit(byVal, wilds));
+  }
+  return out;
+}
+
+/** Enumerate 3-4 card runs within one suit, using wilds to bridge gaps and
+ * allowing Ace to play high (14). Ports `threeThirteenRunsIn`. */
+function runsInSuit(byVal: Map<number, IndexedCard>, wilds: IndexedCard[]): IndexedCard[][] {
+  const out: IndexedCard[][] = [];
+  // Ace (1) may also fill the high slot (14).
+  const view = new Map<number, IndexedCard>(byVal);
+  const ace = byVal.get(1);
+  if (ace) view.set(14, ace);
+
+  for (let size = MELD_MIN_SIZE; size <= MELD_MIN_SIZE + 1; size++) {
+    for (let start = 1; start + size - 1 <= 14; start++) {
+      const picked: IndexedCard[] = [];
+      let wildsUsed = 0;
+      let ok = true;
+      for (let v = start; v < start + size; v++) {
+        const found = view.get(v);
+        if (found) {
+          picked.push(found);
+        } else if (wildsUsed < wilds.length) {
+          picked.push(wilds[wildsUsed]);
+          wildsUsed++;
+        } else {
+          ok = false;
+          break;
+        }
+      }
+      // A run needs at least one natural (all-wild is not a valid run).
+      if (ok && wildsUsed < picked.length) out.push(picked);
+    }
+  }
+  return out;
+}


### PR DESCRIPTION
## 概要

スリー・サーティーンの DISCARD フェーズで、捨て札を選んだ後に手札のデッドウッド（未メルドの罰点）がいくつになるかを予測表示するようにしました。姉妹ゲーム Chinchón と同じライブ計算パターンです。

- カード未選択時: 「最良の 1 枚捨て」で到達できるデッドウッド値
- カード選択時: その 1 枚を捨てた後のデッドウッド値

## 実装

- `frontend/src/utils/threethirteenDeadwood.ts`（新規）: `internal/domain/ThreeThirteen.go` の best-meld 探索を移植したワイルド対応デッドウッド計算ユーティリティ。
  - ワイルドランク（`state.wildRank`、= round+2）のカードはセット／ラン内のメルドとして扱われ 0 点。
  - デッドウッドに残ったワイルドは 20 点（`ThreeThirteenWildDeadwoodValue` と一致）。
  - Ace は low / high 両対応、ラン・セットのワイルド補完を含む。
- `ThreeThirteenPage.tsx`: `useMemo` で予測デッドウッドを算出し、既存の `threethirteen-deadwood-indicator` に表示。サーバの静的値へフォールバック。
- i18n: `deadwoodLabel` を「予測デッドウッド / Predicted deadwood」に更新（ja/en）。

Chinchón の `chinchonDeadwood.ts` はワイルド非対応のため直接再利用できず、ドメインの探索アルゴリズムを移植しました。

## テスト

- `threethirteenDeadwood.test.ts`（新規）: 単体テスト。ワイルド込みメルド、ワイルド残留の 20 点、Ace-high ラン、最良の 1 枚捨て、空手札など。
- `ThreeThirteenPage.test.tsx`: カード選択で予測デッドウッドが 0点 → 23点 に変化することを検証するテストを追加。

## 受け入れ条件

- [x] カード選択に応じて予測デッドウッドが変化する
- [x] wildRank のカードが（メルド時）0 点として扱われる
- [x] ユーティリティに単体テスト（ワイルド込みメルド）を追加
- [x] 既存の deadwood 表示テストを更新

## ゲート

- [x] `bun run check`（exit 0、変更ファイルに警告なし）
- [x] `bun run test -- --run threethirteenDeadwood ThreeThirteenPage`（32 passed）
- [x] `bun run build`（tsc + vite、exit 0）

フロントエンドのみ。Go / CUI / internal-i18n は未変更。

Closes #3544
