### PR TITLE
feat(omaha): show live best-hand preview during play

### DIFF
--- a/frontend/src/i18n/locales/en/omaha.json
+++ b/frontend/src/i18n/locales/en/omaha.json
@@ -13,6 +13,19 @@
   "yourHand": "Your Hand",
   "mandatoryRule": "Rule: 2 hole + 3 board",
   "mandatoryRuleAria": "Omaha rule: you must use exactly 2 hole cards and exactly 3 board cards",
+  "livePreview": "Current hand:",
+  "hand": {
+    "highCard": "High Card",
+    "onePair": "One Pair",
+    "twoPair": "Two Pair",
+    "threeOfAKind": "Three of a Kind",
+    "straight": "Straight",
+    "flush": "Flush",
+    "fullHouse": "Full House",
+    "fourOfAKind": "Four of a Kind",
+    "straightFlush": "Straight Flush",
+    "royalFlush": "Royal Flush"
+  },
   "handNumber": "Hand #{{count}} (Level up: every {{level}} hands)",
   "rebuy": {
     "prompt": "Rebuy? ({{chips}} chips, {{used}}/{{max}} used)",

--- a/frontend/src/i18n/locales/ja/omaha.json
+++ b/frontend/src/i18n/locales/ja/omaha.json
@@ -13,6 +13,19 @@
   "yourHand": "あなたの手札",
   "mandatoryRule": "ルール: 手札から2枚 + 場札から3枚",
   "mandatoryRuleAria": "オマハのルール: 手札ちょうど2枚と場札ちょうど3枚を使います",
+  "livePreview": "現在の役:",
+  "hand": {
+    "highCard": "ハイカード",
+    "onePair": "ワンペア",
+    "twoPair": "ツーペア",
+    "threeOfAKind": "スリーカード",
+    "straight": "ストレート",
+    "flush": "フラッシュ",
+    "fullHouse": "フルハウス",
+    "fourOfAKind": "フォーカード",
+    "straightFlush": "ストレートフラッシュ",
+    "royalFlush": "ロイヤルフラッシュ"
+  },
   "handNumber": "ハンド#{{count}} (レベルアップ:{{level}}ハンド毎)",
   "rebuy": {
     "prompt": "リバイしますか? ({{chips}}チップ, {{used}}/{{max}}回使用済)",

--- a/frontend/src/pages/OmahaPage.test.tsx
+++ b/frontend/src/pages/OmahaPage.test.tsx
@@ -317,6 +317,57 @@ describe('OmahaPage', () => {
     expect(screen.getByAltText('♦ 8')).toBeInTheDocument();
   });
 
+  // ---- Live best-hand preview (#3001) ----
+  it('shows the live best-hand preview badge post-flop (two pair)', async () => {
+    // Hole A♠ K♥ T♦ 5♣ + board T♠ 5♥ 8♦ -> best 2+3 = tens & fives (two pair).
+    mockExec.mockResolvedValue(flopState);
+    renderWithProviders(<OmahaPage />);
+    const badge = await screen.findByTestId('omaha-live-besthand');
+    expect(badge).toHaveTextContent('現在の役');
+    expect(screen.getByTestId('omaha-live-besthand-name')).toHaveTextContent('ツーペア');
+  });
+
+  it('updates the live best-hand preview as more board cards appear (full house on turn)', async () => {
+    // A third ten on the turn -> hole T♦ 5♣ + board T♠ T♣ 5♥ = tens full of fives.
+    mockExec.mockResolvedValue({
+      ...flopState,
+      phase: 3,
+      communityCards: [
+        { design: 'SPADE', value: 10 },
+        { design: 'HEART', value: 5 },
+        { design: 'DIAMOND', value: 8 },
+        { design: 'CLOVER', value: 10 },
+      ],
+    });
+    renderWithProviders(<OmahaPage />);
+    const name = await screen.findByTestId('omaha-live-besthand-name');
+    expect(name).toHaveTextContent('フルハウス');
+  });
+
+  it('does not show the live best-hand preview pre-flop (no board cards)', async () => {
+    mockExec.mockResolvedValue(preFlopState);
+    renderWithProviders(<OmahaPage />);
+    await waitFor(() => expect(screen.getByText('コミュニティカード')).toBeInTheDocument());
+    expect(screen.queryByTestId('omaha-live-besthand')).not.toBeInTheDocument();
+  });
+
+  it('does not show the live best-hand preview at showdown', async () => {
+    mockExec.mockResolvedValue(showdownState);
+    renderWithProviders(<OmahaPage />);
+    await waitFor(() => expect(screen.getByAltText('♠ 10')).toBeInTheDocument());
+    expect(screen.queryByTestId('omaha-live-besthand')).not.toBeInTheDocument();
+  });
+
+  it('does not show the live best-hand preview when the human has folded', async () => {
+    mockExec.mockResolvedValue({
+      ...flopState,
+      players: [humanPlayer({ folded: true }), cpuPlayer(1), cpuPlayer(2), cpuPlayer(3)],
+    });
+    renderWithProviders(<OmahaPage />);
+    await waitFor(() => expect(screen.getByAltText('♠ 10')).toBeInTheDocument());
+    expect(screen.queryByTestId('omaha-live-besthand')).not.toBeInTheDocument();
+  });
+
   // ---- CPU players ----
   it('renders CPU player info with playStyleName and chips', async () => {
     mockExec.mockResolvedValue(preFlopState);

--- a/frontend/src/pages/OmahaPage.tsx
+++ b/frontend/src/pages/OmahaPage.tsx
@@ -45,6 +45,7 @@ import { formatOmahaState } from '../utils/cli/formatters/omahaFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
 import { omahaBestFive } from '../utils/omahaBestFive';
 import { findPlayerName } from '../utils/playerUtils';
+import { evaluateFiveCardHand, pokerHandKey } from '../utils/pokerSquaresUtils';
 
 /** Omaha Hold'em tutorial step definitions. */
 const OH_TUTORIAL_STEPS: TutorialStep[] = [
@@ -174,6 +175,19 @@ function OmahaPageContent() {
     if (!best) return empty;
     return { holeSet: new Set(best.holeIdx), boardSet: new Set(best.boardIdx) };
   }, [isShowdown, humanPlayer, state?.communityCards]);
+  // During play (flop..river), preview the human's current best hand name under
+  // Omaha's must-use-exactly-2-hole + 3-board rule. Returns null pre-flop (fewer
+  // than 3 board cards) or at showdown (where the winning hand is already shown).
+  const liveBestHandKey = useMemo(() => {
+    if (!isActive || isShowdown || !humanPlayer || humanPlayer.folded) return null;
+    const hole = humanPlayer.cards ?? [];
+    const board = state?.communityCards ?? [];
+    const best = omahaBestFive(hole, board);
+    if (!best) return null;
+    const five = [...best.holeIdx.map((i) => hole[i]), ...best.boardIdx.map((i) => board[i])];
+    const rank = evaluateFiveCardHand(five);
+    return rank == null ? null : pokerHandKey(rank);
+  }, [isActive, isShowdown, humanPlayer, state?.communityCards]);
   const humanFolded = humanPlayer?.folded ?? false;
   const humanAllIn = humanPlayer?.allIn ?? false;
   const canAct = isActive && !humanFolded && !humanAllIn && state?.currentTurn === humanPlayer?.id;
@@ -385,6 +399,17 @@ function OmahaPageContent() {
                   <span aria-hidden="true">🎯</span>
                   {t('mandatoryRule')}
                 </div>
+                {liveBestHandKey && (
+                  <div className="mb-1" data-testid="omaha-live-besthand">
+                    <span className="text-ds-text-primary text-xs">{t('livePreview')}</span>
+                    <span
+                      className={`inline-block ml-1.5 text-xs font-bold rounded px-2 py-0.5 ${handNameBadgeClass}`}
+                      data-testid="omaha-live-besthand-name"
+                    >
+                      {t(`hand.${liveBestHandKey}`)}
+                    </span>
+                  </div>
+                )}
                 <div className="flex flex-wrap gap-1.5 mb-2" data-tutorial="oh-combination-rule">
                   {humanPlayer.cards?.length
                     ? humanPlayer.cards.map((card, idx) => {


### PR DESCRIPTION
## Summary

During play (flop → river), the Omaha page now shows a **live best-hand preview** badge in the human hand header — e.g. "現在の役: ツーペア" — computed entirely client-side from the human's 4 hole cards + the community cards revealed so far, under Omaha's must-use-exactly-2-hole + 3-board rule. This helps beginners avoid the classic mistake of reading a hand off the board alone.

The badge updates automatically as more board cards appear (e.g. two pair on the flop → full house on the turn).

## Implementation

- **Reuses `omahaBestFive`** (the same util used at showdown and by OmahaHiLo/BigO) to pick the winning 2-hole + 3-board combination.
- **Reuses `evaluateFiveCardHand` + `pokerHandKey`** (from `pokerSquaresUtils`, same pattern as PineapplePage) to name those 5 cards.
- Hidden pre-flop (fewer than 3 board cards → `omahaBestFive` returns null), at showdown (the winning hand is already highlighted there), and when the human has folded.
- Frontend-only, additive readout; does not block interaction. Uses `handNameBadgeClass` + design tokens.
- New i18n keys (`livePreview` + `hand.*`) added to both `ja` and `en` omaha locales (key parity verified).

## Test plan

- [x] `bun run test -- --run OmahaPage` (117 passing, incl. 5 new preview tests)
- [x] `bun run check` (exit 0)
- [x] `bun run build` (tsc, exit 0)
- [x] i18n ja/en key parity verified

New tests: shows badge post-flop (two pair), updates on turn (full house), hidden pre-flop, hidden at showdown, hidden when folded.

Closes #3001
