### PR TITLE
feat(sevencardstud): show live best-hand strength during the streets

### DIFF
--- a/frontend/src/i18n/locales/en/sevencardstud.json
+++ b/frontend/src/i18n/locales/en/sevencardstud.json
@@ -13,6 +13,7 @@
   "doorCards": "Door Cards",
   "holeCards": "Hole Cards",
   "yourHand": "Your Hand",
+  "currentHand": "Current Hand",
   "anteBringIn": "Ante/Bring-in",
   "handNumber": "Hand #{{count}} (Level up: every {{level}} hands)",
   "rebuy": {
@@ -54,5 +55,17 @@
     "strongHandRank": "Strong hand — raise recommended",
     "decentHandRank": "Decent hand — call recommended",
     "weakHandRank": "Weak hand — fold recommended"
+  },
+  "hand": {
+    "highCard": "High Card",
+    "onePair": "One Pair",
+    "twoPair": "Two Pair",
+    "threeOfAKind": "Three of a Kind",
+    "straight": "Straight",
+    "flush": "Flush",
+    "fullHouse": "Full House",
+    "fourOfAKind": "Four of a Kind",
+    "straightFlush": "Straight Flush",
+    "royalFlush": "Royal Flush"
   }
 }

--- a/frontend/src/i18n/locales/ja/sevencardstud.json
+++ b/frontend/src/i18n/locales/ja/sevencardstud.json
@@ -13,6 +13,7 @@
   "doorCards": "ドアカード",
   "holeCards": "ホールカード",
   "yourHand": "あなたの手札",
+  "currentHand": "現在の役",
   "anteBringIn": "アンティ/ブリングイン",
   "handNumber": "ハンド#{{count}} (レベルアップ:{{level}}ハンド毎)",
   "rebuy": {
@@ -54,5 +55,17 @@
     "strongHandRank": "強いハンド — レイズ推奨",
     "decentHandRank": "まずまずのハンド — コール推奨",
     "weakHandRank": "弱いハンド — フォールド推奨"
+  },
+  "hand": {
+    "highCard": "ハイカード",
+    "onePair": "ワンペア",
+    "twoPair": "ツーペア",
+    "threeOfAKind": "スリーカード",
+    "straight": "ストレート",
+    "flush": "フラッシュ",
+    "fullHouse": "フルハウス",
+    "fourOfAKind": "フォーカード",
+    "straightFlush": "ストレートフラッシュ",
+    "royalFlush": "ロイヤルフラッシュ"
   }
 }

--- a/frontend/src/pages/SevenCardStudPage.test.tsx
+++ b/frontend/src/pages/SevenCardStudPage.test.tsx
@@ -242,6 +242,37 @@ describe('SevenCardStudPage', () => {
     await waitFor(() => expect(screen.getAllByText('ドアカード').length).toBeGreaterThanOrEqual(1));
   });
 
+  // ---- live current-hand strength (issue #3118) ----
+  it('shows the human live best-hand strength during the streets', async () => {
+    const pairedHuman = humanPlayer({
+      holeCards: [
+        { design: 'SPADE', value: 7 },
+        { design: 'HEART', value: 7 },
+        { design: 'DIAMOND', value: 10 },
+      ],
+      doorCards: [{ design: 'CLOVER', value: 2 }],
+    });
+    mockExec.mockResolvedValue({ ...thirdStreetState, players: [pairedHuman, cpuPlayer(1)] });
+    renderWithProviders(<SevenCardStudPage />);
+    const badge = await screen.findByTestId('scs-current-hand');
+    expect(badge).toHaveTextContent('現在の役: ワンペア');
+  });
+
+  it('does not show the live strength badge at showdown (server handName takes over)', async () => {
+    mockExec.mockResolvedValue(showdownState);
+    renderWithProviders(<SevenCardStudPage />);
+    await waitFor(() => expect(screen.getByText('結果:')).toBeInTheDocument());
+    expect(screen.queryByTestId('scs-current-hand')).not.toBeInTheDocument();
+  });
+
+  it('does not show the live strength badge when the human has folded', async () => {
+    const foldedHuman = humanPlayer({ folded: true });
+    mockExec.mockResolvedValue({ ...thirdStreetState, players: [foldedHuman, cpuPlayer(1)] });
+    renderWithProviders(<SevenCardStudPage />);
+    await waitFor(() => expect(screen.getByText(/あなたの手札/)).toBeInTheDocument());
+    expect(screen.queryByTestId('scs-current-hand')).not.toBeInTheDocument();
+  });
+
   it('shows CPU hole cards face-up during showdown when not folded', async () => {
     mockExec.mockResolvedValue(showdownState);
     renderWithProviders(<SevenCardStudPage />);

--- a/frontend/src/pages/SevenCardStudPage.tsx
+++ b/frontend/src/pages/SevenCardStudPage.tsx
@@ -39,6 +39,7 @@ import { SevenCardStudPhase, SevenCardStudRebuyPhaseType } from '../types/phases
 import type { TutorialStep } from '../types/tutorial';
 import type { CliGameConfig, CliParseResult } from '../utils/cli/types';
 import { findPlayerName } from '../utils/playerUtils';
+import { evaluateBestHand, pokerHandKey } from '../utils/pokerSquaresUtils';
 
 /** Seven Card Stud tutorial step definitions. */
 const SCS_TUTORIAL_STEPS: TutorialStep[] = [
@@ -212,6 +213,17 @@ function SevenCardStudPageContent() {
   const humanIdx = state?.players?.findIndex((p) => p.isHuman) ?? 0;
   const humanRebuyCount = state?.rebuyCounts?.[humanIdx] ?? 0;
   const cpuPlayers = useMemo(() => state?.players?.filter((p) => !p.isHuman) ?? [], [state?.players]);
+
+  // Live best-hand strength for the human, computed from their visible door +
+  // hole cards (best 5 of up to 7). Shown during the streets to aid betting
+  // decisions; the server-supplied `handName` takes over at showdown. Only the
+  // human's cards are used, so no opponent information leaks.
+  const currentHandKey = useMemo(() => {
+    if (!humanPlayer) return null;
+    const cards = [...(humanPlayer.doorCards ?? []), ...(humanPlayer.holeCards ?? [])];
+    const rank = evaluateBestHand(cards);
+    return rank == null ? null : pokerHandKey(rank);
+  }, [humanPlayer]);
 
   const actionBindings = useMemo(
     () => [
@@ -403,6 +415,14 @@ function SevenCardStudPageContent() {
                   {isShowdown && !humanPlayer.folded && humanPlayer.handName && (
                     <span className={`inline-block ml-2 text-xs font-bold rounded px-2 py-0.5 ${handNameBadgeClass}`}>
                       {humanPlayer.handName}
+                    </span>
+                  )}
+                  {isActive && !humanPlayer.folded && currentHandKey && (
+                    <span
+                      data-testid="scs-current-hand"
+                      className="inline-block ml-2 text-xs rounded px-2 py-0.5 bg-black/25 text-ds-text-muted"
+                    >
+                      {t('currentHand')}: {t(`hand.${currentHandKey}`)}
                     </span>
                   )}
                 </div>

--- a/frontend/src/utils/pokerSquaresUtils.test.ts
+++ b/frontend/src/utils/pokerSquaresUtils.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { Card, CardDesign } from '../types/card';
 import {
+  evaluateBestHand,
   evaluateFiveCardHand,
   evaluatePartialHand,
   PokerHand,
@@ -228,5 +229,60 @@ describe('pokerHandKey', () => {
     expect(pokerHandKey(PokerHand.FourOfAKind)).toBe('fourOfAKind');
     expect(pokerHandKey(PokerHand.StraightFlush)).toBe('straightFlush');
     expect(pokerHandKey(PokerHand.RoyalFlush)).toBe('royalFlush');
+  });
+});
+
+describe('evaluateBestHand', () => {
+  it('returns null for an empty card list', () => {
+    expect(evaluateBestHand([])).toBeNull();
+  });
+
+  it('names a made pair from three street cards', () => {
+    expect(evaluateBestHand([card('SPADE', 7), card('HEART', 7), card('DIAMOND', 2)])).toBe(PokerHand.OnePair);
+  });
+
+  it('defaults to high card when fewer than five cards make nothing', () => {
+    expect(evaluateBestHand([card('SPADE', 7), card('HEART', 9), card('DIAMOND', 2)])).toBe(PokerHand.HighCard);
+  });
+
+  it('picks the best five of six cards (flush)', () => {
+    expect(
+      evaluateBestHand([
+        card('SPADE', 2),
+        card('SPADE', 5),
+        card('SPADE', 8),
+        card('SPADE', 11),
+        card('SPADE', 13),
+        card('HEART', 4),
+      ]),
+    ).toBe(PokerHand.Flush);
+  });
+
+  it('picks the best five of seven cards (full house over trips)', () => {
+    expect(
+      evaluateBestHand([
+        card('SPADE', 9),
+        card('HEART', 9),
+        card('DIAMOND', 9),
+        card('CLOVER', 4),
+        card('SPADE', 4),
+        card('HEART', 2),
+        card('DIAMOND', 12),
+      ]),
+    ).toBe(PokerHand.FullHouse);
+  });
+
+  it('finds a straight spanning seven cards', () => {
+    expect(
+      evaluateBestHand([
+        card('SPADE', 3),
+        card('HEART', 4),
+        card('DIAMOND', 5),
+        card('CLOVER', 6),
+        card('SPADE', 7),
+        card('HEART', 13),
+        card('DIAMOND', 2),
+      ]),
+    ).toBe(PokerHand.Straight);
   });
 });

--- a/frontend/src/utils/pokerSquaresUtils.ts
+++ b/frontend/src/utils/pokerSquaresUtils.ts
@@ -104,6 +104,41 @@ export function evaluatePartialHand(cards: readonly Card[]): PokerHandRank | nul
   return null;
 }
 
+/**
+ * Evaluate the best 5-card poker hand reachable from up to seven cards.
+ *
+ * Composes {@link evaluateFiveCardHand} over every C(n, 5) combination once at
+ * least five cards are present (n is tiny — at most C(7,5)=21 combinations — so
+ * the brute-force scan is cheap). With one to four cards it falls back to
+ * {@link evaluatePartialHand}, defaulting to {@link PokerHand.HighCard} when no
+ * multiple is made yet, so a live readout always has a name to show. Returns
+ * `null` only for an empty card list.
+ */
+export function evaluateBestHand(cards: readonly Card[]): PokerHandRank | null {
+  if (cards.length === 0) return null;
+  if (cards.length < 5) return evaluatePartialHand(cards) ?? PokerHand.HighCard;
+  let best: PokerHandRank | null = null;
+  for (const combo of fiveCardCombinations(cards)) {
+    const rank = evaluateFiveCardHand(combo);
+    if (rank !== null && (best === null || rank > best)) best = rank;
+  }
+  return best;
+}
+
+/** Yield every 5-card combination of the given cards (n is small: n ≤ 7). */
+function* fiveCardCombinations(cards: readonly Card[]): Generator<Card[]> {
+  const n = cards.length;
+  const idx = [0, 1, 2, 3, 4];
+  while (true) {
+    yield idx.map((i) => cards[i]);
+    let k = 4;
+    while (k >= 0 && idx[k] === n - 5 + k) k--;
+    if (k < 0) return;
+    idx[k]++;
+    for (let j = k + 1; j < 5; j++) idx[j] = idx[j - 1] + 1;
+  }
+}
+
 function countByValue(sortedValues: readonly number[]): Record<number, number> {
   const out: Record<number, number> = {};
   for (const v of sortedValues) out[v] = (out[v] ?? 0) + 1;


### PR DESCRIPTION
## Summary
Seven Card Stud previously only showed the human's hand name (`p.handName`) at showdown, even though the streets are exactly when knowing your current made hand matters most. This adds a live best-hand-strength readout for the human throughout 3rd–7th street.

- Computes the human's current best 5-card hand from their visible **door + hole** cards (best 5 of up to 7) client-side.
- Renders it as a **muted** badge (`data-testid="scs-current-hand"`) in the player area next to "your hand", e.g. `現在の役: ワンペア`.
- Updates automatically as each street deals more cards (memoised on `humanPlayer`).
- Only the human's own cards are used — **no opponent info leaks**.
- The server-supplied `handName` badge still takes over at showdown (the live badge is gated to the active streets), and it is hidden when the human has folded.

## Implementation
- Added a pure `evaluateBestHand(cards)` composer to `pokerSquaresUtils.ts` that **reuses the existing `evaluateFiveCardHand`** over every C(n,5) combination (n ≤ 7, ≤ 21 combos — cheap), falling back to `evaluatePartialHand` (defaulting to high card) for the 3–4 card early streets. Names are mapped via the existing `pokerHandKey`.
- Added `currentHand` label + a `hand.*` block to `ja`/`en` `sevencardstud.json` (reusing the standard poker hand-name key set used by other poker pages).
- Frontend only — no Go / CUI / internal-i18n changes.

## Tests
- `pokerSquaresUtils.test.ts`: `evaluateBestHand` — empty list, made pair from 3 cards, high-card default, best-5-of-6 flush, best-5-of-7 full house, 7-card straight.
- `SevenCardStudPage.test.tsx`: badge shows the correct live hand name during the streets; hidden at showdown; hidden when folded.

## Gates (all pass, from `frontend/`)
- [x] `bun run check`
- [x] `bun run test -- --run SevenCardStudPage` (55 passed)
- [x] `bun run test -- --run pokerSquaresUtils` (29 passed)
- [x] `bun run build` (tsc)

Closes #3118