### PR TITLE
feat(spidersolitaire): persist per-difficulty play stats in localStorage

### DIFF
--- a/frontend/src/hooks/useSpiderStats.test.ts
+++ b/frontend/src/hooks/useSpiderStats.test.ts
@@ -1,0 +1,116 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  applySpiderResult,
+  emptySpiderStat,
+  readSpiderStats,
+  SPIDER_STATS_KEY,
+  spiderWinRate,
+  useSpiderStats,
+} from './useSpiderStats';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('applySpiderResult (pure reducer)', () => {
+  it('a win increments plays and wins and sets initial best score/fewest moves', () => {
+    const { stats, update } = applySpiderResult({}, { difficulty: 1, won: true, score: 500, moves: 42 });
+    expect(stats['1']).toEqual({ plays: 1, wins: 1, bestScore: 500, fewestMoves: 42 });
+    expect(update).toEqual({ newBestScore: true, newFewestMoves: true });
+  });
+
+  it('a loss increments plays only and leaves bests null', () => {
+    const { stats, update } = applySpiderResult({}, { difficulty: 2, won: false, score: 120, moves: 90 });
+    expect(stats['2']).toEqual({ plays: 1, wins: 0, bestScore: null, fewestMoves: null });
+    expect(update).toEqual({ newBestScore: false, newFewestMoves: false });
+  });
+
+  it('a better win updates best score and fewest moves', () => {
+    const first = applySpiderResult({}, { difficulty: 1, won: true, score: 400, moves: 60 }).stats;
+    const { stats, update } = applySpiderResult(first, { difficulty: 1, won: true, score: 550, moves: 45 });
+    expect(stats['1']).toEqual({ plays: 2, wins: 2, bestScore: 550, fewestMoves: 45 });
+    expect(update).toEqual({ newBestScore: true, newFewestMoves: true });
+  });
+
+  it('a worse win keeps existing bests', () => {
+    const first = applySpiderResult({}, { difficulty: 1, won: true, score: 550, moves: 45 }).stats;
+    const { stats, update } = applySpiderResult(first, { difficulty: 1, won: true, score: 300, moves: 80 });
+    expect(stats['1']).toEqual({ plays: 2, wins: 2, bestScore: 550, fewestMoves: 45 });
+    expect(update).toEqual({ newBestScore: false, newFewestMoves: false });
+  });
+
+  it('keeps difficulties separate', () => {
+    const s1 = applySpiderResult({}, { difficulty: 1, won: true, score: 500, moves: 40 }).stats;
+    const s2 = applySpiderResult(s1, { difficulty: 4, won: false, score: 100, moves: 30 }).stats;
+    expect(s2['1']).toEqual({ plays: 1, wins: 1, bestScore: 500, fewestMoves: 40 });
+    expect(s2['4']).toEqual({ plays: 1, wins: 0, bestScore: null, fewestMoves: null });
+  });
+});
+
+describe('spiderWinRate', () => {
+  it('is 0 with no plays', () => {
+    expect(spiderWinRate(emptySpiderStat())).toBe(0);
+  });
+
+  it('rounds to a whole percentage', () => {
+    expect(spiderWinRate({ plays: 3, wins: 1, bestScore: null, fewestMoves: null })).toBe(33);
+  });
+});
+
+describe('readSpiderStats', () => {
+  it('returns {} when nothing stored', () => {
+    expect(readSpiderStats()).toEqual({});
+  });
+
+  it('ignores malformed json', () => {
+    localStorage.setItem(SPIDER_STATS_KEY, 'not-json');
+    expect(readSpiderStats()).toEqual({});
+  });
+
+  it('drops invalid entries but keeps valid ones', () => {
+    localStorage.setItem(
+      SPIDER_STATS_KEY,
+      JSON.stringify({ '1': { plays: 2, wins: 1, bestScore: 500, fewestMoves: 40 }, '2': { bogus: true } }),
+    );
+    const stats = readSpiderStats();
+    expect(stats['1']).toEqual({ plays: 2, wins: 1, bestScore: 500, fewestMoves: 40 });
+    expect(stats['2']).toBeUndefined();
+  });
+});
+
+describe('useSpiderStats', () => {
+  it('records a win, persists it, and reads it back', () => {
+    const { result } = renderHook(() => useSpiderStats());
+    act(() => {
+      result.current.recordResult({ difficulty: 1, won: true, score: 480, moves: 55 });
+    });
+    expect(result.current.getStat(1)).toEqual({ plays: 1, wins: 1, bestScore: 480, fewestMoves: 55 });
+    // Persisted to localStorage
+    expect(readSpiderStats()['1']).toEqual({ plays: 1, wins: 1, bestScore: 480, fewestMoves: 55 });
+  });
+
+  it('records a loss incrementing losses (plays) only', () => {
+    const { result } = renderHook(() => useSpiderStats());
+    act(() => {
+      result.current.recordResult({ difficulty: 2, won: false, score: 90, moves: 70 });
+    });
+    const stat = result.current.getStat(2);
+    expect(stat.plays).toBe(1);
+    expect(stat.wins).toBe(0);
+  });
+
+  it('returns a best-update flag when a personal best is beaten', () => {
+    const { result } = renderHook(() => useSpiderStats());
+    let update = { newBestScore: false, newFewestMoves: false };
+    act(() => {
+      update = result.current.recordResult({ difficulty: 4, won: true, score: 300, moves: 100 });
+    });
+    expect(update).toEqual({ newBestScore: true, newFewestMoves: true });
+  });
+
+  it('getStat returns an empty stat for an untouched difficulty', () => {
+    const { result } = renderHook(() => useSpiderStats());
+    expect(result.current.getStat(4)).toEqual(emptySpiderStat());
+  });
+});

--- a/frontend/src/hooks/useSpiderStats.ts
+++ b/frontend/src/hooks/useSpiderStats.ts
@@ -1,0 +1,127 @@
+import { useCallback, useState } from 'react';
+
+/** localStorage key for per-difficulty Spider Solitaire play statistics. */
+export const SPIDER_STATS_KEY = 'trumpcards-spider-stats';
+
+/** Aggregated play statistics for a single Spider difficulty. */
+export interface SpiderDifficultyStat {
+  /** Total finished games (wins + losses). */
+  plays: number;
+  /** Games cleared. */
+  wins: number;
+  /** Highest score across cleared games, or null if never won. */
+  bestScore: number | null;
+  /** Fewest moves across cleared games, or null if never won. */
+  fewestMoves: number | null;
+}
+
+/** Outcome of a single finished Spider game. */
+export interface SpiderResult {
+  difficulty: number;
+  won: boolean;
+  score: number;
+  moves: number;
+}
+
+/** Map of difficulty (as string key) to its aggregated stats. */
+export type SpiderStats = Record<string, SpiderDifficultyStat>;
+
+/** Returns a zeroed stat record. */
+export function emptySpiderStat(): SpiderDifficultyStat {
+  return { plays: 0, wins: 0, bestScore: null, fewestMoves: null };
+}
+
+function isValidStat(value: unknown): value is SpiderDifficultyStat {
+  if (typeof value !== 'object' || value === null) return false;
+  const s = value as Record<string, unknown>;
+  const numOrNull = (v: unknown) => v === null || typeof v === 'number';
+  return (
+    typeof s.plays === 'number' && typeof s.wins === 'number' && numOrNull(s.bestScore) && numOrNull(s.fewestMoves)
+  );
+}
+
+/** Reads and validates the stats map from localStorage; returns {} on any error. */
+export function readSpiderStats(): SpiderStats {
+  try {
+    const raw = localStorage.getItem(SPIDER_STATS_KEY);
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== 'object' || parsed === null) return {};
+    const out: SpiderStats = {};
+    for (const [key, val] of Object.entries(parsed as Record<string, unknown>)) {
+      if (isValidStat(val)) out[key] = val;
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+/** Whether a recorded result set a new personal best (for celebration feedback). */
+export interface SpiderBestUpdate {
+  newBestScore: boolean;
+  newFewestMoves: boolean;
+}
+
+/**
+ * Pure reducer: folds a finished-game result into the stats map and reports whether
+ * it set a new personal best. Best score / fewest moves only advance on a win.
+ */
+export function applySpiderResult(
+  stats: SpiderStats,
+  result: SpiderResult,
+): { stats: SpiderStats; update: SpiderBestUpdate } {
+  const key = String(result.difficulty);
+  const prev = stats[key] ?? emptySpiderStat();
+  const next: SpiderDifficultyStat = {
+    plays: prev.plays + 1,
+    wins: prev.wins + (result.won ? 1 : 0),
+    bestScore: prev.bestScore,
+    fewestMoves: prev.fewestMoves,
+  };
+  const update: SpiderBestUpdate = { newBestScore: false, newFewestMoves: false };
+  if (result.won) {
+    if (prev.bestScore === null || result.score > prev.bestScore) {
+      next.bestScore = result.score;
+      update.newBestScore = true;
+    }
+    if (prev.fewestMoves === null || result.moves < prev.fewestMoves) {
+      next.fewestMoves = result.moves;
+      update.newFewestMoves = true;
+    }
+  }
+  return { stats: { ...stats, [key]: next }, update };
+}
+
+/** Win rate as a whole-number percentage (0 when no games played). */
+export function spiderWinRate(stat: SpiderDifficultyStat): number {
+  if (stat.plays === 0) return 0;
+  return Math.round((stat.wins / stat.plays) * 100);
+}
+
+/**
+ * Hook that persists per-difficulty Spider statistics in localStorage and records
+ * finished games. `recordResult` returns which personal bests were beaten so the
+ * page can surface a badge.
+ */
+export function useSpiderStats() {
+  const [stats, setStats] = useState<SpiderStats>(readSpiderStats);
+
+  const recordResult = useCallback((result: SpiderResult): SpiderBestUpdate => {
+    const { stats: next, update } = applySpiderResult(readSpiderStats(), result);
+    setStats(next);
+    try {
+      localStorage.setItem(SPIDER_STATS_KEY, JSON.stringify(next));
+    } catch {
+      /* storage unavailable / quota exceeded */
+    }
+    return update;
+  }, []);
+
+  const getStat = useCallback(
+    (difficulty: number): SpiderDifficultyStat => stats[String(difficulty)] ?? emptySpiderStat(),
+    [stats],
+  );
+
+  return { stats, getStat, recordResult };
+}

--- a/frontend/src/i18n/locales/en/spider.json
+++ b/frontend/src/i18n/locales/en/spider.json
@@ -45,5 +45,11 @@
     "useEmptyColumn": "An empty column is available — use it to reorganize",
     "dealFromStock": "No obvious moves — try dealing from the stock"
   },
-  "suitCompleted": "Suit complete!"
+  "suitCompleted": "Suit complete!",
+  "stats": {
+    "winRate": "Win rate {{rate}}%",
+    "best": "Best {{score}}",
+    "fewestMoves": "{{moves}} moves",
+    "newBest": "New personal best!"
+  }
 }

--- a/frontend/src/i18n/locales/ja/spider.json
+++ b/frontend/src/i18n/locales/ja/spider.json
@@ -45,5 +45,11 @@
     "useEmptyColumn": "空の列があります — 整理に活用しましょう",
     "dealFromStock": "すぐにできる手がありません — 山札から配ってみましょう"
   },
-  "suitCompleted": "スート完成！"
+  "suitCompleted": "スート完成！",
+  "stats": {
+    "winRate": "勝率 {{rate}}%",
+    "best": "ベスト {{score}}",
+    "fewestMoves": "最少 {{moves}}手",
+    "newBest": "自己ベスト更新！"
+  }
 }

--- a/frontend/src/pages/SpiderPage.test.tsx
+++ b/frontend/src/pages/SpiderPage.test.tsx
@@ -79,6 +79,10 @@ const gameOverState: SpiderResponse = {
 };
 
 beforeEach(() => {
+  localStorage.clear();
+  // Re-suppress the first-visit tutorial dialog: the global setup sets this in its
+  // own beforeEach, which runs before ours, so our clear() would otherwise wipe it.
+  localStorage.setItem('tutorial_no_suggest', 'true');
   mockExec.mockResolvedValue(playingState);
   vi.mocked(useGameHint).mockReturnValue({ hint: null, hintEnabled: false, setHintEnabled: vi.fn() });
   playSoundMock.mockClear();
@@ -807,6 +811,61 @@ describe('SpiderPage', () => {
           expect.objectContaining({ zone: 'tableau' }),
         ),
       );
+    });
+  });
+
+  describe('per-difficulty stats (#3062)', () => {
+    it('renders the stats panel with a zeroed win rate initially', async () => {
+      renderWithProviders(<SpiderPage />);
+      const panel = await screen.findByTestId('spd-stats-panel');
+      expect(panel).toHaveTextContent('勝率 0% (0/0)');
+    });
+
+    it('records a win to localStorage and shows the best badge', async () => {
+      mockExec.mockResolvedValue(gameClearState);
+      renderWithProviders(<SpiderPage />);
+      await waitFor(() => {
+        const stored = JSON.parse(localStorage.getItem('trumpcards-spider-stats') ?? '{}');
+        expect(stored['1']).toEqual({ plays: 1, wins: 1, bestScore: 500, fewestMoves: 5 });
+      });
+      // Win rate reflects the recorded game and the personal-best badge appears.
+      expect(await screen.findByTestId('spd-stats-panel')).toHaveTextContent('勝率 100% (1/1)');
+      expect(screen.getByTestId('spd-best-badge')).toBeInTheDocument();
+    });
+
+    it('records a loss (plays only) and shows no best badge', async () => {
+      mockExec.mockResolvedValue(gameOverState);
+      renderWithProviders(<SpiderPage />);
+      await waitFor(() => {
+        const stored = JSON.parse(localStorage.getItem('trumpcards-spider-stats') ?? '{}');
+        expect(stored['1']).toEqual({ plays: 1, wins: 0, bestScore: null, fewestMoves: null });
+      });
+      expect(await screen.findByTestId('spd-stats-panel')).toHaveTextContent('勝率 0% (0/1)');
+      expect(screen.queryByTestId('spd-best-badge')).not.toBeInTheDocument();
+    });
+
+    it('reads back previously stored stats for the current difficulty', async () => {
+      localStorage.setItem(
+        'trumpcards-spider-stats',
+        JSON.stringify({ '1': { plays: 4, wins: 3, bestScore: 620, fewestMoves: 33 } }),
+      );
+      renderWithProviders(<SpiderPage />);
+      const panel = await screen.findByTestId('spd-stats-panel');
+      expect(panel).toHaveTextContent('勝率 75% (3/4)');
+      expect(panel).toHaveTextContent('ベスト 620');
+      expect(panel).toHaveTextContent('最少 33手');
+    });
+
+    it('keeps difficulties separate (difficulty 2 stats hidden while on difficulty 1)', async () => {
+      localStorage.setItem(
+        'trumpcards-spider-stats',
+        JSON.stringify({ '2': { plays: 5, wins: 5, bestScore: 900, fewestMoves: 10 } }),
+      );
+      renderWithProviders(<SpiderPage />);
+      const panel = await screen.findByTestId('spd-stats-panel');
+      // Playing state is difficulty 1, so difficulty 2's best must not leak in.
+      expect(panel).toHaveTextContent('勝率 0% (0/0)');
+      expect(panel).not.toHaveTextContent('ベスト 900');
     });
   });
 });

--- a/frontend/src/pages/SpiderPage.tsx
+++ b/frontend/src/pages/SpiderPage.tsx
@@ -26,6 +26,7 @@ import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useResponsiveTableau } from '../hooks/useResponsiveTableau';
 import { useSolitaireDragDrop } from '../hooks/useSolitaireDragDrop';
 import { useSpiderGame } from '../hooks/useSpiderGame';
+import { spiderWinRate, useSpiderStats } from '../hooks/useSpiderStats';
 import { useSound } from '../providers/SoundProvider';
 import { btnDanger, btnPrimary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -193,6 +194,34 @@ function SpiderPageContent() {
   );
 
   const currentDifficulty = state?.difficulty ?? 1;
+
+  // Per-difficulty play statistics persisted in localStorage (#3062).
+  const { getStat, recordResult } = useSpiderStats();
+  const currentStat = getStat(currentDifficulty);
+  // Badge shown on the clear screen when a game beats a stored personal best.
+  const [bestUpdate, setBestUpdate] = useState<{ newBestScore: boolean; newFewestMoves: boolean } | null>(null);
+  // Guard so a completed game is recorded exactly once (phase stays ended across re-renders).
+  const recordedRef = useRef(false);
+  const currentPhase = state?.phase;
+  const currentScore = state?.score;
+  const currentMoves = state?.moveCount;
+  useEffect(() => {
+    const ended = currentPhase === SpiderPhase.GAME_CLEAR || currentPhase === SpiderPhase.GAME_OVER;
+    if (!ended) {
+      recordedRef.current = false;
+      return;
+    }
+    if (recordedRef.current) return;
+    recordedRef.current = true;
+    const won = currentPhase === SpiderPhase.GAME_CLEAR;
+    const update = recordResult({
+      difficulty: currentDifficulty,
+      won,
+      score: currentScore ?? 0,
+      moves: currentMoves ?? 0,
+    });
+    setBestUpdate(won ? update : null);
+  }, [currentPhase, currentDifficulty, currentScore, currentMoves, recordResult]);
 
   const actionBindings = useMemo(
     () => [
@@ -441,6 +470,17 @@ function SpiderPageContent() {
               messageParams={state.messageParams}
             />
 
+            {/* Personal-best badge on the clear screen (#3062). */}
+            {isGameClear && bestUpdate && (bestUpdate.newBestScore || bestUpdate.newFewestMoves) && (
+              <div
+                data-testid="spd-best-badge"
+                role="status"
+                className="text-center text-ds-success font-semibold text-sm mb-2"
+              >
+                {t('stats.newBest')}
+              </div>
+            )}
+
             {/* Action log */}
             <ActionLogSection
               isEndPhase={isEnded}
@@ -548,6 +588,14 @@ function SpiderPageContent() {
                   <option value={2}>{t('difficulty2')}</option>
                   <option value={4}>{t('difficulty4')}</option>
                 </select>
+                {/* Per-difficulty stats: win rate + best score/fewest moves (#3062). */}
+                <div data-testid="spd-stats-panel" className="text-game-text-muted text-xs mt-1">
+                  {t('stats.winRate', { rate: spiderWinRate(currentStat) })} ({currentStat.wins}/{currentStat.plays})
+                  {currentStat.bestScore !== null && <> · {t('stats.best', { score: currentStat.bestScore })}</>}
+                  {currentStat.fewestMoves !== null && (
+                    <> · {t('stats.fewestMoves', { moves: currentStat.fewestMoves })}</>
+                  )}
+                </div>
               </div>
               <GameResetButton
                 isGameEnd={isEnded}


### PR DESCRIPTION
## 概要

スパイダーソリティアに、難易度別（1/2/4スート）のプレイ統計を localStorage で永続化する機能を追加しました（フロントエンドのみ、バックエンド変更なし）。

`useLocalStorageToggle` / `useFavoriteGames` の localStorage 永続化パターンを踏襲した新規フック `useSpiderStats` を追加しています。

## 変更内容

- **`useSpiderStats` フック** — 難易度別のプレイ数・勝利数・ベストスコア（最高）・最少手数を保存/読み出し。純粋関数 `applySpiderResult` に集計ロジックを分離しテスト容易化。
- **記録タイミング** — `GAME_CLEAR` / `GAME_OVER` 遷移時に1回だけ記録（ref ガードで再レンダー時の二重計上を防止）。ベスト/最少手数は勝利時のみ更新。
- **表示** — 難易度セレクタ付近に「勝率 {p}% (勝/計) · ベスト {score} · 最少 {n}手」を表示（`data-testid="spd-stats-panel"`）。クリア時に自己ベスト更新なら `spd-best-badge` を表示。
- **安全性** — localStorage アクセスは全て try/catch でガード（SSR/クォータ対策）、不正 JSON/エントリは破棄。
- **i18n** — ja/en に `stats.*` キーを追加（キー整合を確認済み）。

既存の movable-run ホバー機能には手を加えていません。

## テスト

- `frontend/src/hooks/useSpiderStats.test.ts` — reducer・勝率計算・読み出し・フック（勝ち→加算+ベスト更新 / 負け→playsのみ / 難易度分離 / ベスト更新フラグ）
- `frontend/src/pages/SpiderPage.test.tsx` — 統計パネル描画、勝利記録+バッジ、敗北記録（バッジ無し）、読み戻し、難易度分離

## テスト計画

- [x] `bun run test -- --run useSpiderStats SpiderPage`（82 passed）
- [x] `bun run check`（Biome: エラー無し）
- [x] `bun run build`（tsc 通過）
- [x] ja/en i18n キー整合

Closes #3062
