### PR TITLE
feat(videopoker): persist and display session stats

### DIFF
--- a/frontend/src/components/VideoPokerGameContent.test.tsx
+++ b/frontend/src/components/VideoPokerGameContent.test.tsx
@@ -378,4 +378,54 @@ describe('VideoPokerGameContent', () => {
     await waitFor(() => expect(screen.getByRole('button', { name: /ドロー/ })).toBeInTheDocument());
     expect(screen.queryByTestId('vp-wild-badge-0')).not.toBeInTheDocument();
   });
+
+  it('records a win into the session stats (win rate + net) and persists it', async () => {
+    // resultPhaseWin: bet 1, payout 5, Jacks or Better -> net +4, win rate 100%.
+    mockExec.mockResolvedValue(resultPhaseWin);
+    renderContent();
+    await waitFor(() => expect(screen.getByTestId('vp-stats-summary')).toBeInTheDocument());
+    const summary = screen.getByTestId('vp-stats-summary');
+    expect(summary).toHaveTextContent('1 ハンド');
+    expect(summary).toHaveTextContent('勝率 100%');
+    expect(summary).toHaveTextContent('収支 +4');
+    // The winning hand is tallied in the payout table's count column.
+    expect(screen.getByTestId('vp-payout-count-jacksOrBetter')).toHaveTextContent('1');
+    // And it is written to localStorage under the per-variant key.
+    const stored = JSON.parse(localStorage.getItem('vp_stats_videopoker') ?? '{}');
+    expect(stored).toMatchObject({ hands: 1, wins: 1, totalBet: 1, totalPayout: 5, handCounts: { jacksOrBetter: 1 } });
+  });
+
+  it('reads persisted stats back on mount', async () => {
+    localStorage.setItem(
+      'vp_stats_videopoker',
+      JSON.stringify({ hands: 4, wins: 1, totalBet: 4, totalPayout: 10, handCounts: { flush: 1 } }),
+    );
+    mockExec.mockResolvedValue(betPhaseState);
+    renderContent();
+    await waitFor(() => expect(screen.getByRole('button', { name: /ディール/ })).toBeInTheDocument());
+    const summary = screen.getByTestId('vp-stats-summary');
+    expect(summary).toHaveTextContent('4 ハンド');
+    expect(summary).toHaveTextContent('勝率 25%');
+    expect(summary).toHaveTextContent('収支 +6');
+    expect(screen.getByTestId('vp-payout-count-flush')).toHaveTextContent('1');
+  });
+
+  it('clears the session stats when the clear button is clicked', async () => {
+    mockExec.mockResolvedValue(resultPhaseWin);
+    renderContent();
+    await waitFor(() => expect(screen.getByTestId('vp-stats-clear')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('vp-stats-clear'));
+    await waitFor(() => expect(screen.getByTestId('vp-stats-summary')).toHaveTextContent(/まだプレイ記録がありません/));
+    const stored = JSON.parse(localStorage.getItem('vp_stats_videopoker') ?? '{}');
+    expect(stored).toMatchObject({ hands: 0, wins: 0 });
+  });
+
+  it('does not show the session stats panel for other variants (deuceswild)', async () => {
+    mockExec.mockResolvedValue({ ...resultPhaseWin, variantName: 'deuceswild' });
+    renderContent('deuceswild');
+    await waitFor(() => expect(screen.getByRole('button', { name: /次のゲーム/ })).toBeInTheDocument());
+    expect(screen.queryByTestId('vp-session-stats')).not.toBeInTheDocument();
+    // And nothing is written to any stats bucket for the disabled variant.
+    expect(localStorage.getItem('vp_stats_deuceswild')).toBeNull();
+  });
 });

--- a/frontend/src/components/VideoPokerGameContent.tsx
+++ b/frontend/src/components/VideoPokerGameContent.tsx
@@ -8,6 +8,7 @@ import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useLocalStorageToggle } from '../hooks/useLocalStorageToggle';
+import { useVideoPokerStats } from '../hooks/useVideoPokerStats';
 import { useSound } from '../providers/SoundProvider';
 import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
@@ -22,6 +23,7 @@ import {
   videoPokerPayoutCell,
   videoPokerPayoutRows,
 } from '../utils/videoPokerPayout';
+import { videoPokerNet, videoPokerWinRate } from '../utils/videoPokerStats';
 import { ActionLogPanel } from './ActionLogPanel';
 import { CliTerminal } from './cli/CliTerminal';
 import { CliToggle } from './cli/CliToggle';
@@ -67,11 +69,14 @@ function PayoutTable({
   gameName,
   betAmount,
   winningRowKey,
+  handCounts,
 }: {
   t: (key: string) => string;
   gameName: 'videopoker' | 'deuceswild' | 'jokerpoker';
   betAmount: number;
   winningRowKey: string | null;
+  /** Per-hand win counts to append as a trailing column, or null to hide the column. */
+  handCounts: Record<string, number> | null;
 }) {
   const [open, setOpen] = useLocalStorageToggle(`paytable_open_${gameName}`, true);
   const rows = videoPokerPayoutRows(gameName);
@@ -95,6 +100,7 @@ function PayoutTable({
                 {b}
               </th>
             ))}
+            {handCounts && <th className="px-1.5 py-0.5 text-right font-medium">{t('payoutTable.count')}</th>}
           </tr>
         </thead>
         <tbody>
@@ -113,6 +119,14 @@ function PayoutTable({
                     {videoPokerPayoutCell(row, b)}
                   </td>
                 ))}
+                {handCounts && (
+                  <td
+                    className="px-1.5 py-0.5 text-right text-ds-text-primary tabular-nums"
+                    data-testid={`vp-payout-count-${row.key}`}
+                  >
+                    {handCounts[row.key] ?? 0}
+                  </td>
+                )}
               </tr>
             );
           })}
@@ -175,6 +189,13 @@ export function VideoPokerGameContent({
   const isBetPhase = state?.phase === VideoPokerPhase.BET;
   const isDrawPhase = state?.phase === VideoPokerPhase.DRAW;
   const isResultPhase = state?.phase === VideoPokerPhase.RESULT;
+
+  // Session statistics (hands / win rate / net) are scoped to the base
+  // Jacks-or-Better variant so the shared component leaves Deuces Wild and
+  // Joker Poker untouched. Storage is still keyed per variant, so enabling the
+  // others later needs no data migration.
+  const statsEnabled = gameName === 'videopoker';
+  const { stats, clear: clearStats } = useVideoPokerStats(gameName, state, isResultPhase, statsEnabled);
 
   // Announce the draw outcome once per hand. Keying on the state reference (a
   // fresh object on every API result) re-fires the effect even for an identical
@@ -429,6 +450,7 @@ export function VideoPokerGameContent({
               gameName={gameName}
               betAmount={betAmount}
               winningRowKey={isResultPhase ? videoPokerHandNameToRowKey(state.handName) : null}
+              handCounts={statsEnabled ? stats.handCounts : null}
             />
 
             {actionLog && <ActionLogPanel entries={actionLog} onClose={hideActionLog} />}
@@ -457,6 +479,33 @@ export function VideoPokerGameContent({
                 <button type="button" className={btnSecondary} onClick={showActionLog} disabled={loading}>
                   {tc('actionLog.view')}
                 </button>
+              </div>
+            )}
+            {statsEnabled && (
+              <div
+                className="flex flex-wrap items-center justify-center gap-x-3 gap-y-1 pb-2 text-ds-text-muted text-xs lg:text-sm"
+                data-testid="vp-session-stats"
+              >
+                <span data-testid="vp-stats-summary">
+                  {stats.hands === 0
+                    ? tNs('stats.empty')
+                    : tNs('stats.summary', {
+                        hands: stats.hands,
+                        winRate: Math.round(videoPokerWinRate(stats) * 100),
+                        net: `${videoPokerNet(stats) >= 0 ? '+' : ''}${videoPokerNet(stats)}`,
+                      })}
+                </span>
+                {stats.hands > 0 && (
+                  <button
+                    type="button"
+                    className={btnSecondary}
+                    onClick={clearStats}
+                    disabled={loading}
+                    data-testid="vp-stats-clear"
+                  >
+                    {tNs('stats.clear')}
+                  </button>
+                )}
               </div>
             )}
             <div className="flex flex-wrap justify-center gap-x-4 pb-2">

--- a/frontend/src/hooks/useVideoPokerStats.ts
+++ b/frontend/src/hooks/useVideoPokerStats.ts
@@ -1,0 +1,64 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { VideoPokerResponse } from '../types/card';
+import { videoPokerHandNameToRowKey } from '../utils/videoPokerPayout';
+import {
+  emptyVideoPokerStats,
+  readVideoPokerStats,
+  recordVideoPokerResult,
+  type VideoPokerStats,
+  writeVideoPokerStats,
+} from '../utils/videoPokerStats';
+
+/** What {@link useVideoPokerStats} returns. */
+export interface UseVideoPokerStats {
+  /** Current session statistics for the variant. */
+  stats: VideoPokerStats;
+  /** Clears the session statistics (both in state and localStorage). */
+  clear: () => void;
+}
+
+/**
+ * Tracks and persists per-variant Video Poker session statistics.
+ *
+ * Records exactly one hand per RESULT-phase response: a ref keyed on the state
+ * object reference guards against double-counting when the effect re-runs
+ * without a fresh result. When `enabled` is false the hook is inert (no reads,
+ * writes, or recording) so sibling variants that share the component are
+ * unaffected.
+ */
+export function useVideoPokerStats(
+  gameName: string,
+  state: VideoPokerResponse | null,
+  isResultPhase: boolean,
+  enabled: boolean,
+): UseVideoPokerStats {
+  const [stats, setStats] = useState<VideoPokerStats>(() =>
+    enabled ? readVideoPokerStats(gameName) : emptyVideoPokerStats(),
+  );
+  const recordedRef = useRef<VideoPokerResponse | null>(null);
+
+  useEffect(() => {
+    if (!enabled || !isResultPhase || !state) return;
+    // Record once per result: the state object is a fresh reference per API
+    // response, so a repeated effect run for the same hand is skipped here.
+    if (recordedRef.current === state) return;
+    recordedRef.current = state;
+    setStats((prev) => {
+      const next = recordVideoPokerResult(prev, {
+        bet: state.betAmount,
+        payout: state.payout,
+        rowKey: videoPokerHandNameToRowKey(state.handName),
+      });
+      writeVideoPokerStats(gameName, next);
+      return next;
+    });
+  }, [enabled, isResultPhase, state, gameName]);
+
+  const clear = useCallback(() => {
+    const empty = emptyVideoPokerStats();
+    setStats(empty);
+    if (enabled) writeVideoPokerStats(gameName, empty);
+  }, [enabled, gameName]);
+
+  return { stats, clear };
+}

--- a/frontend/src/i18n/locales/en/videopoker.json
+++ b/frontend/src/i18n/locales/en/videopoker.json
@@ -30,6 +30,7 @@
   "payoutTable": {
     "title": "Payout Table",
     "hand": "Hand",
+    "count": "Hits",
     "name": {
       "royalFlush": "Royal Flush",
       "straightFlush": "Straight Flush",
@@ -41,6 +42,11 @@
       "twoPair": "Two Pair",
       "jacksOrBetter": "Jacks or Better"
     }
+  },
+  "stats": {
+    "summary": "{{hands}} hands / win rate {{winRate}}% / net {{net}}",
+    "empty": "No hands played yet",
+    "clear": "Clear stats"
   },
   "tutorial": {
     "betControls": "Place 1–5 coins to set your bet. Higher bets increase the Royal Flush bonus.",

--- a/frontend/src/i18n/locales/ja/videopoker.json
+++ b/frontend/src/i18n/locales/ja/videopoker.json
@@ -30,6 +30,7 @@
   "payoutTable": {
     "title": "配当表",
     "hand": "役",
+    "count": "回数",
     "name": {
       "royalFlush": "ロイヤルフラッシュ",
       "straightFlush": "ストレートフラッシュ",
@@ -41,6 +42,11 @@
       "twoPair": "ツーペア",
       "jacksOrBetter": "ジャックス・オア・ベター"
     }
+  },
+  "stats": {
+    "summary": "{{hands}} ハンド / 勝率 {{winRate}}% / 収支 {{net}}",
+    "empty": "まだプレイ記録がありません",
+    "clear": "統計クリア"
   },
   "tutorial": {
     "betControls": "1〜5コインを賭けます。5コインでロイヤルフラッシュのボーナスが増えます。",

--- a/frontend/src/utils/videoPokerStats.test.ts
+++ b/frontend/src/utils/videoPokerStats.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  emptyVideoPokerStats,
+  readVideoPokerStats,
+  recordVideoPokerResult,
+  videoPokerNet,
+  videoPokerStatsKey,
+  videoPokerWinRate,
+  writeVideoPokerStats,
+} from './videoPokerStats';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('emptyVideoPokerStats', () => {
+  it('returns a fresh zeroed object with its own handCounts map', () => {
+    const a = emptyVideoPokerStats();
+    const b = emptyVideoPokerStats();
+    expect(a).toEqual({ hands: 0, wins: 0, totalBet: 0, totalPayout: 0, handCounts: {} });
+    expect(a.handCounts).not.toBe(b.handCounts);
+  });
+});
+
+describe('recordVideoPokerResult', () => {
+  it('counts a win, its bet, its payout, and its hand key', () => {
+    const next = recordVideoPokerResult(emptyVideoPokerStats(), { bet: 5, payout: 25, rowKey: 'fourOfAKind' });
+    expect(next).toEqual({
+      hands: 1,
+      wins: 1,
+      totalBet: 5,
+      totalPayout: 25,
+      handCounts: { fourOfAKind: 1 },
+    });
+  });
+
+  it('counts a loss without incrementing wins or handCounts', () => {
+    const next = recordVideoPokerResult(emptyVideoPokerStats(), { bet: 3, payout: 0, rowKey: null });
+    expect(next.hands).toBe(1);
+    expect(next.wins).toBe(0);
+    expect(next.totalBet).toBe(3);
+    expect(next.totalPayout).toBe(0);
+    expect(next.handCounts).toEqual({});
+  });
+
+  it('does not mutate the input stats (pure reducer)', () => {
+    const prev = emptyVideoPokerStats();
+    const next = recordVideoPokerResult(prev, { bet: 1, payout: 2, rowKey: 'twoPair' });
+    expect(prev).toEqual(emptyVideoPokerStats());
+    expect(next).not.toBe(prev);
+    expect(next.handCounts).not.toBe(prev.handCounts);
+  });
+
+  it('accumulates repeated wins of the same hand', () => {
+    let stats = emptyVideoPokerStats();
+    stats = recordVideoPokerResult(stats, { bet: 1, payout: 5, rowKey: 'jacksOrBetter' });
+    stats = recordVideoPokerResult(stats, { bet: 2, payout: 10, rowKey: 'jacksOrBetter' });
+    expect(stats.hands).toBe(2);
+    expect(stats.wins).toBe(2);
+    expect(stats.handCounts).toEqual({ jacksOrBetter: 2 });
+  });
+
+  it('treats a payout with a null rowKey as a win but records no hand key', () => {
+    const next = recordVideoPokerResult(emptyVideoPokerStats(), { bet: 1, payout: 4, rowKey: null });
+    expect(next.wins).toBe(1);
+    expect(next.handCounts).toEqual({});
+  });
+});
+
+describe('videoPokerNet / videoPokerWinRate', () => {
+  it('computes net as payouts minus wagers (can be negative)', () => {
+    const stats = { hands: 3, wins: 1, totalBet: 9, totalPayout: 5, handCounts: {} };
+    expect(videoPokerNet(stats)).toBe(-4);
+  });
+
+  it('computes win rate as a 0..1 fraction, 0 when no hands', () => {
+    expect(videoPokerWinRate(emptyVideoPokerStats())).toBe(0);
+    expect(videoPokerWinRate({ hands: 4, wins: 1, totalBet: 4, totalPayout: 0, handCounts: {} })).toBe(0.25);
+  });
+});
+
+describe('localStorage persistence', () => {
+  it('round-trips stats through write then read, keyed per variant', () => {
+    const stats = recordVideoPokerResult(emptyVideoPokerStats(), { bet: 5, payout: 4000, rowKey: 'royalFlush' });
+    writeVideoPokerStats('videopoker', stats);
+    expect(localStorage.getItem(videoPokerStatsKey('videopoker'))).not.toBeNull();
+    expect(readVideoPokerStats('videopoker')).toEqual(stats);
+    // A different variant has its own independent bucket.
+    expect(readVideoPokerStats('deuceswild')).toEqual(emptyVideoPokerStats());
+  });
+
+  it('returns empty stats when nothing is stored', () => {
+    expect(readVideoPokerStats('videopoker')).toEqual(emptyVideoPokerStats());
+  });
+
+  it('returns empty stats on malformed JSON', () => {
+    localStorage.setItem(videoPokerStatsKey('videopoker'), '{not json');
+    expect(readVideoPokerStats('videopoker')).toEqual(emptyVideoPokerStats());
+  });
+
+  it('normalizes partial/invalid stored objects, dropping non-positive counts', () => {
+    localStorage.setItem(
+      videoPokerStatsKey('videopoker'),
+      JSON.stringify({ hands: 5, wins: 'x', totalPayout: 10, handCounts: { flush: 2, bogus: 0, bad: 'no' } }),
+    );
+    expect(readVideoPokerStats('videopoker')).toEqual({
+      hands: 5,
+      wins: 0,
+      totalBet: 0,
+      totalPayout: 10,
+      handCounts: { flush: 2 },
+    });
+  });
+
+  it('returns empty stats when the stored value is not an object', () => {
+    localStorage.setItem(videoPokerStatsKey('videopoker'), '42');
+    expect(readVideoPokerStats('videopoker')).toEqual(emptyVideoPokerStats());
+  });
+
+  it('swallows read errors (localStorage unavailable)', () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('blocked');
+    });
+    expect(readVideoPokerStats('videopoker')).toEqual(emptyVideoPokerStats());
+  });
+
+  it('swallows write errors (quota exceeded)', () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('quota');
+    });
+    expect(() => writeVideoPokerStats('videopoker', emptyVideoPokerStats())).not.toThrow();
+  });
+});

--- a/frontend/src/utils/videoPokerStats.ts
+++ b/frontend/src/utils/videoPokerStats.ts
@@ -1,0 +1,109 @@
+/**
+ * Video Poker session statistics: a pure reducer plus localStorage persistence
+ * helpers. Stats are aggregated per hand (one RESULT phase = one hand) and kept
+ * per variant under the `vp_stats_<gameName>` key so each game tallies
+ * independently. All persistence is try/catch-guarded so a full or unavailable
+ * localStorage never breaks the game.
+ */
+
+/** Aggregated session statistics for one Video Poker variant. */
+export interface VideoPokerStats {
+  /** Total hands played (RESULT phases reached). */
+  hands: number;
+  /** Hands that paid out (payout > 0). */
+  wins: number;
+  /** Total coins wagered across all hands. */
+  totalBet: number;
+  /** Total coins paid out across all hands. */
+  totalPayout: number;
+  /** Count of each winning hand, keyed by paytable row key. */
+  handCounts: Record<string, number>;
+}
+
+/** Outcome of a single hand, extracted from the RESULT-phase response. */
+export interface VideoPokerResult {
+  /** Coins wagered on this hand. */
+  bet: number;
+  /** Coins paid out (0 on a loss). */
+  payout: number;
+  /** Paytable row key of the winning hand, or null when the hand paid nothing. */
+  rowKey: string | null;
+}
+
+/** Returns a fresh, empty stats object (with its own `handCounts` map). */
+export function emptyVideoPokerStats(): VideoPokerStats {
+  return { hands: 0, wins: 0, totalBet: 0, totalPayout: 0, handCounts: {} };
+}
+
+/** Pure reducer: folds one hand result into the running stats, returning a new object. */
+export function recordVideoPokerResult(stats: VideoPokerStats, result: VideoPokerResult): VideoPokerStats {
+  const won = result.payout > 0;
+  const handCounts = { ...stats.handCounts };
+  if (won && result.rowKey) {
+    handCounts[result.rowKey] = (handCounts[result.rowKey] ?? 0) + 1;
+  }
+  return {
+    hands: stats.hands + 1,
+    wins: stats.wins + (won ? 1 : 0),
+    totalBet: stats.totalBet + result.bet,
+    totalPayout: stats.totalPayout + result.payout,
+    handCounts,
+  };
+}
+
+/** Net coins won or lost this session (payouts minus wagers). */
+export function videoPokerNet(stats: VideoPokerStats): number {
+  return stats.totalPayout - stats.totalBet;
+}
+
+/** Win rate as a 0..1 fraction (0 when no hands played). */
+export function videoPokerWinRate(stats: VideoPokerStats): number {
+  return stats.hands > 0 ? stats.wins / stats.hands : 0;
+}
+
+/** localStorage key for a variant's stats. */
+export function videoPokerStatsKey(gameName: string): string {
+  return `vp_stats_${gameName}`;
+}
+
+/** Coerces a possibly-malformed parsed value into a valid VideoPokerStats. */
+function normalizeStats(value: unknown): VideoPokerStats {
+  const base = emptyVideoPokerStats();
+  if (typeof value !== 'object' || value === null) return base;
+  const raw = value as Record<string, unknown>;
+  const num = (v: unknown): number => (typeof v === 'number' && Number.isFinite(v) ? v : 0);
+  const handCounts: Record<string, number> = {};
+  if (typeof raw.handCounts === 'object' && raw.handCounts !== null) {
+    for (const [key, v] of Object.entries(raw.handCounts as Record<string, unknown>)) {
+      const n = num(v);
+      if (n > 0) handCounts[key] = n;
+    }
+  }
+  return {
+    hands: num(raw.hands),
+    wins: num(raw.wins),
+    totalBet: num(raw.totalBet),
+    totalPayout: num(raw.totalPayout),
+    handCounts,
+  };
+}
+
+/** Reads a variant's stats from localStorage, returning empty stats if absent, invalid, or unavailable. */
+export function readVideoPokerStats(gameName: string): VideoPokerStats {
+  try {
+    const raw = localStorage.getItem(videoPokerStatsKey(gameName));
+    if (raw === null) return emptyVideoPokerStats();
+    return normalizeStats(JSON.parse(raw));
+  } catch {
+    return emptyVideoPokerStats();
+  }
+}
+
+/** Persists a variant's stats to localStorage; silently ignores quota/availability errors. */
+export function writeVideoPokerStats(gameName: string, stats: VideoPokerStats): void {
+  try {
+    localStorage.setItem(videoPokerStatsKey(gameName), JSON.stringify(stats));
+  } catch {
+    // localStorage may be full or unavailable (private mode); stats are best-effort.
+  }
+}


### PR DESCRIPTION
## Summary

Adds persistent session statistics to Video Poker (issue #3070): plays, win rate, and net profit are now tracked in `localStorage` and shown to the player, plus per-hand hit counts in the payout table.

Frontend-only. No Go changes.

## What changed

- **`utils/videoPokerStats.ts`** (new) — `VideoPokerStats` type, a pure `recordVideoPokerResult` reducer, `videoPokerNet` / `videoPokerWinRate` selectors, and try/catch-guarded `read`/`write` persistence keyed per variant (`vp_stats_<gameName>`). Malformed/partial stored JSON is normalized.
- **`hooks/useVideoPokerStats.ts`** (new) — records exactly one hand per RESULT-phase response (ref-guarded on the state object reference) and exposes `stats` + `clear`. Inert when disabled so sibling variants are untouched.
- **`components/VideoPokerGameContent.tsx`** — footer session-stats line (`{n} ハンド / 勝率 {p}% / 収支 {±k}`) with an independent clear button, and a per-hand hit-count column in the payout table. Scoped to the base `videopoker` variant (`gameName === 'videopoker'`); Deuces Wild and Joker Poker are unaffected (storage stays keyed per variant so enabling them later needs no migration).
- **i18n** — `stats.*` and `payoutTable.count` keys added to `ja` and `en` `videopoker.json`.

## Tests

- `videoPokerStats.test.ts` (new) — reducer (win/loss/repeat/pure), net & win-rate selectors, localStorage round-trip, malformed/partial JSON normalization, and read/write error swallowing.
- `VideoPokerGameContent.test.tsx` — a win updates win-rate + net + hit count and persists; stats read back on mount; clear button resets; stats panel hidden and nothing written for other variants.

## Verification

- [x] `bun run check` (biome) — exit 0
- [x] `bun run test -- --run VideoPoker` — 92 passed
- [x] `bun run build` (tsc) — passed
- [x] Sibling regression: `DeucesWildPage` / `JokerPokerPage` tests — 7 passed

Closes #3070
