### PR TITLE
feat(speed): show elapsed and per-difficulty best time

### DIFF
--- a/frontend/src/hooks/useSpeedTimer.test.ts
+++ b/frontend/src/hooks/useSpeedTimer.test.ts
@@ -1,0 +1,148 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useSpeedTimer } from './useSpeedTimer';
+
+const KEY = (d: number) => `speed_best_time_${d}`;
+
+describe('useSpeedTimer', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('starts at 0 elapsed with no best when nothing persisted', () => {
+    const { result } = renderHook(() => useSpeedTimer(false, false, false, 0));
+    expect(result.current.elapsedMs).toBe(0);
+    expect(result.current.bestMs).toBeNull();
+    expect(result.current.isNewBest).toBe(false);
+  });
+
+  it('advances elapsed while running (Date.now based)', () => {
+    const { result } = renderHook(() => useSpeedTimer(true, false, false, 0));
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+    expect(result.current.elapsedMs).toBe(3000);
+  });
+
+  it('freezes elapsed at the final time when the game ends', () => {
+    const { result, rerender } = renderHook(({ running, ended, won }) => useSpeedTimer(running, ended, won, 0), {
+      initialProps: { running: true, ended: false, won: false },
+    });
+    act(() => {
+      vi.advanceTimersByTime(4200);
+    });
+    rerender({ running: false, ended: true, won: true });
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(result.current.elapsedMs).toBe(4200);
+  });
+
+  it('records the best time and flags a new best on a human win', () => {
+    const { result, rerender } = renderHook(({ running, ended, won }) => useSpeedTimer(running, ended, won, 1), {
+      initialProps: { running: true, ended: false, won: false },
+    });
+    act(() => {
+      vi.advanceTimersByTime(8000);
+    });
+    rerender({ running: false, ended: true, won: true });
+    expect(result.current.isNewBest).toBe(true);
+    expect(result.current.bestMs).toBe(8000);
+    expect(localStorage.getItem(KEY(1))).toBe('8000');
+  });
+
+  it('does not record the best time on a loss', () => {
+    const { result, rerender } = renderHook(({ running, ended, won }) => useSpeedTimer(running, ended, won, 1), {
+      initialProps: { running: true, ended: false, won: false },
+    });
+    act(() => {
+      vi.advanceTimersByTime(6000);
+    });
+    rerender({ running: false, ended: true, won: false });
+    expect(result.current.isNewBest).toBe(false);
+    expect(result.current.bestMs).toBeNull();
+    expect(localStorage.getItem(KEY(1))).toBeNull();
+  });
+
+  it('reads an existing best from localStorage', () => {
+    localStorage.setItem(KEY(2), '5000');
+    const { result } = renderHook(() => useSpeedTimer(false, false, false, 2));
+    expect(result.current.bestMs).toBe(5000);
+  });
+
+  it('updates the best only when the new win is faster', () => {
+    localStorage.setItem(KEY(0), '10000');
+    // Slower win: 12s > 10s stored -> no update.
+    const slow = renderHook(({ running, ended, won }) => useSpeedTimer(running, ended, won, 0), {
+      initialProps: { running: true, ended: false, won: false },
+    });
+    act(() => {
+      vi.advanceTimersByTime(12000);
+    });
+    slow.rerender({ running: false, ended: true, won: true });
+    expect(slow.result.current.isNewBest).toBe(false);
+    expect(localStorage.getItem(KEY(0))).toBe('10000');
+
+    // Faster win: 7s < 10s stored -> update.
+    const fast = renderHook(({ running, ended, won }) => useSpeedTimer(running, ended, won, 0), {
+      initialProps: { running: true, ended: false, won: false },
+    });
+    act(() => {
+      vi.advanceTimersByTime(7000);
+    });
+    fast.rerender({ running: false, ended: true, won: true });
+    expect(fast.result.current.isNewBest).toBe(true);
+    expect(localStorage.getItem(KEY(0))).toBe('7000');
+  });
+
+  it('restarts the timer when a new game begins (running rises again)', () => {
+    const { result, rerender } = renderHook(({ running, ended, won }) => useSpeedTimer(running, ended, won, 0), {
+      initialProps: { running: true, ended: false, won: false },
+    });
+    act(() => {
+      vi.advanceTimersByTime(9000);
+    });
+    rerender({ running: false, ended: true, won: true });
+    expect(result.current.elapsedMs).toBe(9000);
+
+    // Reset -> fresh PLAY state: elapsed resets to 0 and isNewBest clears.
+    rerender({ running: true, ended: false, won: false });
+    expect(result.current.elapsedMs).toBe(0);
+    expect(result.current.isNewBest).toBe(false);
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+    expect(result.current.elapsedMs).toBe(1500);
+  });
+
+  it('records only once per game even if ended re-renders', () => {
+    const { rerender } = renderHook(({ running, ended, won }) => useSpeedTimer(running, ended, won, 3), {
+      initialProps: { running: true, ended: false, won: false },
+    });
+    act(() => {
+      vi.advanceTimersByTime(4000);
+    });
+    rerender({ running: false, ended: true, won: true });
+    expect(localStorage.getItem(KEY(3))).toBe('4000');
+    // A faster time is manually stored; a stray re-render must not overwrite it.
+    localStorage.setItem(KEY(3), '1000');
+    rerender({ running: false, ended: true, won: true });
+    expect(localStorage.getItem(KEY(3))).toBe('1000');
+  });
+
+  it('reloads the best when the difficulty changes', () => {
+    localStorage.setItem(KEY(0), '3000');
+    localStorage.setItem(KEY(1), '9000');
+    const { result, rerender } = renderHook(({ d }) => useSpeedTimer(false, false, false, d), {
+      initialProps: { d: 0 },
+    });
+    expect(result.current.bestMs).toBe(3000);
+    rerender({ d: 1 });
+    expect(result.current.bestMs).toBe(9000);
+  });
+});

--- a/frontend/src/hooks/useSpeedTimer.ts
+++ b/frontend/src/hooks/useSpeedTimer.ts
@@ -1,0 +1,97 @@
+import { useEffect, useRef, useState } from 'react';
+
+/** localStorage key prefix for per-difficulty Speed best times (milliseconds). */
+const BEST_TIME_KEY_PREFIX = 'speed_best_time_';
+
+/** Reads the persisted best time (ms) for a CPU difficulty, or null when absent/invalid. */
+function readBestTime(difficulty: number): number | null {
+  try {
+    const raw = localStorage.getItem(`${BEST_TIME_KEY_PREFIX}${difficulty}`);
+    if (raw === null) return null;
+    const n = Number.parseInt(raw, 10);
+    return Number.isFinite(n) && n > 0 ? n : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Persists the best time (ms) for a CPU difficulty; failures are swallowed. */
+function writeBestTime(difficulty: number, ms: number): void {
+  try {
+    localStorage.setItem(`${BEST_TIME_KEY_PREFIX}${difficulty}`, String(ms));
+  } catch {
+    // Ignore quota / disabled-storage errors — best time is a nice-to-have.
+  }
+}
+
+/** Elapsed/best-time state returned by {@link useSpeedTimer}. */
+export interface SpeedTimerState {
+  /** Milliseconds elapsed for the current game (frozen once the game ends). */
+  elapsedMs: number;
+  /** Persisted best (fastest) time in ms for the current difficulty, or null. */
+  bestMs: number | null;
+  /** True when the just-finished win beat the previous best for this difficulty. */
+  isNewBest: boolean;
+}
+
+/**
+ * Tracks the elapsed time of a Speed game and persists the per-difficulty best
+ * (fastest) time on a human win.
+ *
+ * Elapsed time is measured from a `Date.now()` start stamp so it stays accurate
+ * even while the tab is backgrounded (the interval only refreshes the readout).
+ * The timer restarts whenever `running` rises from false to true (a fresh game
+ * or a reset), and freezes at the exact final time when `ended` becomes true.
+ * The best time is recorded at most once per game via a ref guard.
+ */
+export function useSpeedTimer(running: boolean, ended: boolean, won: boolean, difficulty: number): SpeedTimerState {
+  const [elapsedMs, setElapsedMs] = useState(0);
+  const [bestMs, setBestMs] = useState<number | null>(() => readBestTime(difficulty));
+  const [isNewBest, setIsNewBest] = useState(false);
+
+  const startRef = useRef<number | null>(null);
+  const prevRunningRef = useRef(false);
+  const recordedRef = useRef(false);
+
+  // Reload the persisted best whenever the difficulty changes.
+  useEffect(() => {
+    setBestMs(readBestTime(difficulty));
+  }, [difficulty]);
+
+  // Restart-on-rising-edge + live tick while running.
+  useEffect(() => {
+    if (running && !prevRunningRef.current) {
+      startRef.current = Date.now();
+      recordedRef.current = false;
+      setElapsedMs(0);
+      setIsNewBest(false);
+    }
+    prevRunningRef.current = running;
+
+    if (!running) return;
+    const tick = () => {
+      if (startRef.current !== null) setElapsedMs(Date.now() - startRef.current);
+    };
+    tick();
+    const id = setInterval(tick, 500);
+    return () => clearInterval(id);
+  }, [running]);
+
+  // Freeze the final time and record the best (once) when the game ends.
+  useEffect(() => {
+    if (!ended || recordedRef.current || startRef.current === null) return;
+    recordedRef.current = true;
+    const finalMs = Date.now() - startRef.current;
+    setElapsedMs(finalMs);
+    if (won) {
+      const prevBest = readBestTime(difficulty);
+      if (prevBest === null || finalMs < prevBest) {
+        writeBestTime(difficulty, finalMs);
+        setBestMs(finalMs);
+        setIsNewBest(true);
+      }
+    }
+  }, [ended, won, difficulty]);
+
+  return { elapsedMs, bestMs, isNewBest };
+}

--- a/frontend/src/i18n/locales/en/speed.json
+++ b/frontend/src/i18n/locales/en/speed.json
@@ -16,6 +16,10 @@
   "flipCenterPile": "Flip center pile {{n}}",
   "stuckMessage": "Stuck! Press flip to turn over new center cards.",
   "autoFlipInline": "Auto-flip",
+  "timer": "Time",
+  "bestTime": "Best",
+  "clearTime": "Clear time {{time}}",
+  "newBest": "New best! {{time}}",
   "autoFlipCountdownAria": "Auto-flip countdown",
   "autoFlipCountdownRemaining": "Auto-flip in {{n}} second(s)",
   "settings": {

--- a/frontend/src/i18n/locales/ja/speed.json
+++ b/frontend/src/i18n/locales/ja/speed.json
@@ -16,6 +16,10 @@
   "flipCenterPile": "台札{{n}}をめくる",
   "stuckMessage": "膠着状態です。めくるボタンを押してください。",
   "autoFlipInline": "自動でめくる",
+  "timer": "経過",
+  "bestTime": "ベスト",
+  "clearTime": "クリアタイム {{time}}",
+  "newBest": "ベスト更新! {{time}}",
   "autoFlipCountdownAria": "自動めくりカウントダウン",
   "autoFlipCountdownRemaining": "あと {{n}} 秒で自動めくり",
   "settings": {

--- a/frontend/src/pages/SpeedPage.test.tsx
+++ b/frontend/src/pages/SpeedPage.test.tsx
@@ -508,3 +508,66 @@ describe('SpeedPage auto-flip timer', () => {
     expect(mockExec).not.toHaveBeenCalledWith('flip');
   });
 });
+
+describe('SpeedPage elapsed / best time', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.removeItem('speed_best_time_1');
+    mockExec.mockResolvedValue(playState);
+  });
+
+  afterEach(() => {
+    localStorage.removeItem('speed_best_time_1');
+  });
+
+  it('shows the elapsed timer readout in the header during play', async () => {
+    renderWithProviders(<SpeedPage />);
+    await waitFor(() => expect(screen.getByTestId('speed-timer')).toBeInTheDocument());
+    expect(screen.getByTestId('speed-timer')).toHaveTextContent('経過: 00:00');
+  });
+
+  it('shows the persisted best time for the current difficulty', async () => {
+    localStorage.setItem('speed_best_time_1', '65000'); // 01:05
+    renderWithProviders(<SpeedPage />);
+    await waitFor(() => expect(screen.getByTestId('speed-best-time')).toBeInTheDocument());
+    expect(screen.getByTestId('speed-best-time')).toHaveTextContent('01:05');
+  });
+
+  it('does not render a best-time readout when none is stored', async () => {
+    renderWithProviders(<SpeedPage />);
+    await waitFor(() => expect(screen.getByTestId('speed-timer')).toBeInTheDocument());
+    expect(screen.queryByTestId('speed-best-time')).not.toBeInTheDocument();
+  });
+
+  it('records and announces a new best time on a human win', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    mockExec.mockResolvedValueOnce(playState).mockResolvedValue(gameEndState);
+    renderWithProviders(<SpeedPage />);
+    await waitFor(() => expect(screen.getByText('手札')).toBeInTheDocument());
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000);
+    });
+    // Smart-click SPADE 4 auto-plays to pile 0; the response ends the game as a human win.
+    fireEvent.click(screen.getByRole('button', { name: '♠ 4 (今すぐ出せる)' }));
+    await waitFor(() => expect(screen.getByTestId('speed-clear-time')).toBeInTheDocument());
+    expect(screen.getByTestId('speed-clear-time')).toHaveTextContent('ベスト更新');
+    expect(Number(localStorage.getItem('speed_best_time_1'))).toBeGreaterThanOrEqual(3000);
+    vi.useRealTimers();
+  });
+
+  it('keeps a faster stored best when the new win is slower', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    localStorage.setItem('speed_best_time_1', '1000');
+    mockExec.mockResolvedValueOnce(playState).mockResolvedValue(gameEndState);
+    renderWithProviders(<SpeedPage />);
+    await waitFor(() => expect(screen.getByText('手札')).toBeInTheDocument());
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000);
+    });
+    fireEvent.click(screen.getByRole('button', { name: '♠ 4 (今すぐ出せる)' }));
+    await waitFor(() => expect(screen.getByTestId('speed-clear-time')).toBeInTheDocument());
+    expect(screen.getByTestId('speed-clear-time')).not.toHaveTextContent('ベスト更新');
+    expect(localStorage.getItem('speed_best_time_1')).toBe('1000');
+    vi.useRealTimers();
+  });
+});

--- a/frontend/src/pages/SpeedPage.tsx
+++ b/frontend/src/pages/SpeedPage.tsx
@@ -21,6 +21,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { AUTO_FLIP_DELAY_MS, CPU_DIFFICULTY_OPTIONS, useSpeedGame } from '../hooks/useSpeedGame';
+import { useSpeedTimer } from '../hooks/useSpeedTimer';
 import { useSound } from '../providers/SoundProvider';
 import { btnOutline } from '../styles/buttonStyles';
 import { focusRingCard, playableRingStyle, selectedCardStyle } from '../styles/cardStyles';
@@ -76,6 +77,17 @@ function SpeedPageContent() {
   } = useGameHint('speed', state);
   const { cardWidth } = useCardDimensions();
   const { playSound } = useSound();
+  // Elapsed / best-time tracking. Signals are derived here (before the skeleton
+  // early-return) so the timer hook is always called in a stable order. The
+  // timer runs during the PLAY and STUCK phases and freezes when the game ends.
+  const timerRunning = (state?.phase === SpeedPhase.PLAY || state?.phase === SpeedPhase.STUCK) && !state?.gameEndFlag;
+  const timerEnded = state?.phase === SpeedPhase.GAME_END || !!state?.gameEndFlag;
+  const { elapsedMs, bestMs, isNewBest } = useSpeedTimer(
+    timerRunning,
+    timerEnded,
+    state?.winnerIdx === 0,
+    speedConfig.cpuDifficulty,
+  );
   // CLI mode
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('speed');
   const cliConfig: CliGameConfig<SpeedResponse, Parameters<typeof speedApi.exec>> = useMemo(
@@ -147,6 +159,14 @@ function SpeedPageContent() {
   const cpuPlayer = state.players[1];
   const humanWon = state.winnerIdx === 0;
 
+  // Format milliseconds as mm:ss for the timer / best-time readouts.
+  const formatTime = (ms: number) => {
+    const total = Math.floor(ms / 1000);
+    const m = Math.floor(total / 60);
+    const s = total % 60;
+    return `${m.toString().padStart(2, '0')}:${s.toString().padStart(2, '0')}`;
+  };
+
   const phaseName = state.gameEndFlag
     ? t('phase.gameEnd')
     : state.phase === SpeedPhase.STUCK
@@ -168,6 +188,18 @@ function SpeedPageContent() {
       confirmReset={confirmReset}
       cancelReset={cancelReset}
       headerExtra={<CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />}
+      headerEnd={
+        <>
+          <span data-testid="speed-timer">
+            {t('timer')}: {formatTime(elapsedMs)}
+          </span>
+          {bestMs !== null && (
+            <span className="ml-3" data-testid="speed-best-time">
+              {t('bestTime')}: {formatTime(bestMs)}
+            </span>
+          )}
+        </>
+      }
     >
       {cliEnabled ? (
         <CliTerminal logEntries={logEntries} onCommand={handleCommand} disabled={loading} />
@@ -175,6 +207,17 @@ function SpeedPageContent() {
         <>
           {error && <ErrorAlert message={error} onRetry={retry} />}
           <GameMessageBox message={state.message} messageCode={state.messageCode} messageParams={state.messageParams} />
+          {isGameEnd && humanWon && (
+            <p
+              className={`text-center text-sm font-bold ${isNewBest ? 'text-ds-success' : 'text-ds-text-muted'}`}
+              data-testid="speed-clear-time"
+              role="status"
+            >
+              {isNewBest
+                ? t('newBest', { time: formatTime(elapsedMs) })
+                : t('clearTime', { time: formatTime(elapsedMs) })}
+            </p>
+          )}
           <div className="flex-1 flex flex-col gap-3 min-h-0">
             {/* CPU area */}
             <div className="flex items-center justify-center gap-2">


### PR DESCRIPTION
## 概要

スピードにゲームの経過タイム計測と難易度別ベストタイムの表示を追加します（フロントエンドのみ）。

## 変更点

- `useSpeedTimer` フックを新規追加
  - `Date.now()` の開始時刻ベースで経過時間を計測（タブ非表示中も破綻しない）。表示更新は 500ms 間隔。
  - `running` の false→true 立ち上がり（新規ゲーム/リセット）でタイマーを再スタート、ゲーム終了で確定タイムに固定。
  - 人間勝利時に難易度別ベストタイムを `localStorage`（`speed_best_time_<difficulty>`）に保存。`try/catch` ガード + ref ガードで1ゲーム1回のみ記録。
- `SpeedPage.tsx`
  - ヘッダー（`headerEnd`）に `経過: mm:ss` と、記録があれば `ベスト: mm:ss` を表示。
  - 勝利画面に「クリアタイム」/「ベスト更新!」を表示。
  - 既存のプレイ可能カードのリングハイライトには手を加えていません。
- i18n（ja/en）に `timer` / `bestTime` / `clearTime` / `newBest` キーを追加。

## テスト

- `useSpeedTimer.test.ts`（フェイクタイマー）: 経過加算 / 終了時の確定 / 勝利で記録・更新フラグ / 敗北で非記録 / 速いときのみ更新 / リセット再スタート / 1回のみ記録 / 難易度変更で再読込。
- `SpeedPage.test.tsx`: ヘッダーの経過表示 / 保存済みベスト表示 / 未保存時は非表示 / 勝利でベスト更新表示・保存 / 遅い勝利では上書きしない。

## 受け入れ条件

- [x] プレイ中に経過時間がヘッダーに表示される
- [x] 人間勝利時に難易度別ベストタイムが保存・表示される
- [x] リセットでタイマーが再スタートする
- [x] タイマーフックのユニットテストとページテストを追加

## ゲート

- [x] `bun run check`（exit 0）
- [x] `bun run build`（tsc）
- [x] `bun run test -- --run SpeedPage`（54 passed）+ `useSpeedTimer`（10 passed）

Closes #3105
