### PR TITLE
feat(klondike): persist local win-rate, best-time, and fewest-moves stats

### DIFF
--- a/frontend/src/hooks/useKlondikeStats.test.ts
+++ b/frontend/src/hooks/useKlondikeStats.test.ts
@@ -1,0 +1,166 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  applyKlondikeResult,
+  emptyKlondikeStat,
+  KLONDIKE_STATS_KEY,
+  klondikeVariantKey,
+  klondikeWinRate,
+  readKlondikeStats,
+  useKlondikeStats,
+} from './useKlondikeStats';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('klondikeVariantKey', () => {
+  it('joins draw count and scoring mode', () => {
+    expect(klondikeVariantKey(1, 0)).toBe('1:0');
+    expect(klondikeVariantKey(3, 1)).toBe('3:1');
+  });
+});
+
+describe('applyKlondikeResult (pure reducer)', () => {
+  it('a win increments plays and wins and sets initial best time/fewest moves', () => {
+    const { stats, update } = applyKlondikeResult(
+      {},
+      { drawCount: 1, scoringMode: 0, won: true, timeSeconds: 120, moves: 90 },
+    );
+    expect(stats['1:0']).toEqual({ plays: 1, wins: 1, bestTimeSeconds: 120, fewestMoves: 90 });
+    expect(update).toEqual({ newBestTime: true, newFewestMoves: true });
+  });
+
+  it('a loss increments plays only and leaves bests null', () => {
+    const { stats, update } = applyKlondikeResult(
+      {},
+      { drawCount: 3, scoringMode: 1, won: false, timeSeconds: 200, moves: 40 },
+    );
+    expect(stats['3:1']).toEqual({ plays: 1, wins: 0, bestTimeSeconds: null, fewestMoves: null });
+    expect(update).toEqual({ newBestTime: false, newFewestMoves: false });
+  });
+
+  it('a faster win with fewer moves updates both bests', () => {
+    const first = applyKlondikeResult(
+      {},
+      { drawCount: 1, scoringMode: 0, won: true, timeSeconds: 300, moves: 120 },
+    ).stats;
+    const { stats, update } = applyKlondikeResult(first, {
+      drawCount: 1,
+      scoringMode: 0,
+      won: true,
+      timeSeconds: 180,
+      moves: 95,
+    });
+    expect(stats['1:0']).toEqual({ plays: 2, wins: 2, bestTimeSeconds: 180, fewestMoves: 95 });
+    expect(update).toEqual({ newBestTime: true, newFewestMoves: true });
+  });
+
+  it('a slower win with more moves keeps existing bests', () => {
+    const first = applyKlondikeResult(
+      {},
+      { drawCount: 1, scoringMode: 0, won: true, timeSeconds: 180, moves: 95 },
+    ).stats;
+    const { stats, update } = applyKlondikeResult(first, {
+      drawCount: 1,
+      scoringMode: 0,
+      won: true,
+      timeSeconds: 300,
+      moves: 120,
+    });
+    expect(stats['1:0']).toEqual({ plays: 2, wins: 2, bestTimeSeconds: 180, fewestMoves: 95 });
+    expect(update).toEqual({ newBestTime: false, newFewestMoves: false });
+  });
+
+  it('ignores a non-positive clear time for the best-time record', () => {
+    const { stats, update } = applyKlondikeResult(
+      {},
+      { drawCount: 1, scoringMode: 0, won: true, timeSeconds: 0, moves: 80 },
+    );
+    expect(stats['1:0'].bestTimeSeconds).toBeNull();
+    expect(stats['1:0'].fewestMoves).toBe(80);
+    expect(update).toEqual({ newBestTime: false, newFewestMoves: true });
+  });
+
+  it('keeps variants separate by draw count and scoring mode', () => {
+    const s1 = applyKlondikeResult({}, { drawCount: 1, scoringMode: 0, won: true, timeSeconds: 100, moves: 80 }).stats;
+    const s2 = applyKlondikeResult(s1, {
+      drawCount: 3,
+      scoringMode: 1,
+      won: false,
+      timeSeconds: 50,
+      moves: 30,
+    }).stats;
+    expect(s2['1:0']).toEqual({ plays: 1, wins: 1, bestTimeSeconds: 100, fewestMoves: 80 });
+    expect(s2['3:1']).toEqual({ plays: 1, wins: 0, bestTimeSeconds: null, fewestMoves: null });
+  });
+});
+
+describe('klondikeWinRate', () => {
+  it('is 0 with no plays', () => {
+    expect(klondikeWinRate(emptyKlondikeStat())).toBe(0);
+  });
+
+  it('rounds to a whole percentage', () => {
+    expect(klondikeWinRate({ plays: 3, wins: 1, bestTimeSeconds: null, fewestMoves: null })).toBe(33);
+  });
+});
+
+describe('readKlondikeStats', () => {
+  it('returns {} when nothing stored', () => {
+    expect(readKlondikeStats()).toEqual({});
+  });
+
+  it('ignores malformed json', () => {
+    localStorage.setItem(KLONDIKE_STATS_KEY, 'not-json');
+    expect(readKlondikeStats()).toEqual({});
+  });
+
+  it('drops invalid entries but keeps valid ones', () => {
+    localStorage.setItem(
+      KLONDIKE_STATS_KEY,
+      JSON.stringify({
+        '1:0': { plays: 2, wins: 1, bestTimeSeconds: 120, fewestMoves: 90 },
+        '3:1': { bogus: true },
+      }),
+    );
+    const stats = readKlondikeStats();
+    expect(stats['1:0']).toEqual({ plays: 2, wins: 1, bestTimeSeconds: 120, fewestMoves: 90 });
+    expect(stats['3:1']).toBeUndefined();
+  });
+});
+
+describe('useKlondikeStats', () => {
+  it('records a win, persists it, and reads it back', () => {
+    const { result } = renderHook(() => useKlondikeStats());
+    act(() => {
+      result.current.recordResult({ drawCount: 1, scoringMode: 0, won: true, timeSeconds: 150, moves: 100 });
+    });
+    expect(result.current.getStat(1, 0)).toEqual({ plays: 1, wins: 1, bestTimeSeconds: 150, fewestMoves: 100 });
+    expect(readKlondikeStats()['1:0']).toEqual({ plays: 1, wins: 1, bestTimeSeconds: 150, fewestMoves: 100 });
+  });
+
+  it('records a loss incrementing plays only', () => {
+    const { result } = renderHook(() => useKlondikeStats());
+    act(() => {
+      result.current.recordResult({ drawCount: 3, scoringMode: 1, won: false, timeSeconds: 80, moves: 40 });
+    });
+    const stat = result.current.getStat(3, 1);
+    expect(stat.plays).toBe(1);
+    expect(stat.wins).toBe(0);
+  });
+
+  it('returns a best-update flag when a personal best is beaten', () => {
+    const { result } = renderHook(() => useKlondikeStats());
+    let update = { newBestTime: false, newFewestMoves: false };
+    act(() => {
+      update = result.current.recordResult({ drawCount: 1, scoringMode: 0, won: true, timeSeconds: 90, moves: 70 });
+    });
+    expect(update).toEqual({ newBestTime: true, newFewestMoves: true });
+  });
+
+  it('getStat returns an empty stat for an untouched variant', () => {
+    const { result } = renderHook(() => useKlondikeStats());
+    expect(result.current.getStat(3, 1)).toEqual(emptyKlondikeStat());
+  });
+});

--- a/frontend/src/hooks/useKlondikeStats.ts
+++ b/frontend/src/hooks/useKlondikeStats.ts
@@ -1,0 +1,137 @@
+import { useCallback, useState } from 'react';
+
+/** localStorage key for per-variant Klondike play statistics. */
+export const KLONDIKE_STATS_KEY = 'klondike_stats';
+
+/** Aggregated play statistics for a single Klondike variant (drawCount × scoringMode). */
+export interface KlondikeVariantStat {
+  /** Total finished games (wins + losses). */
+  plays: number;
+  /** Games cleared. */
+  wins: number;
+  /** Fastest clear time in seconds, or null if never won. */
+  bestTimeSeconds: number | null;
+  /** Fewest moves across cleared games, or null if never won. */
+  fewestMoves: number | null;
+}
+
+/** Outcome of a single finished Klondike game. */
+export interface KlondikeResult {
+  drawCount: number;
+  scoringMode: number;
+  won: boolean;
+  timeSeconds: number;
+  moves: number;
+}
+
+/** Map of variant key (`drawCount:scoringMode`) to its aggregated stats. */
+export type KlondikeStats = Record<string, KlondikeVariantStat>;
+
+/** Builds the variant key from a draw count and scoring mode. */
+export function klondikeVariantKey(drawCount: number, scoringMode: number): string {
+  return `${drawCount}:${scoringMode}`;
+}
+
+/** Returns a zeroed stat record. */
+export function emptyKlondikeStat(): KlondikeVariantStat {
+  return { plays: 0, wins: 0, bestTimeSeconds: null, fewestMoves: null };
+}
+
+function isValidStat(value: unknown): value is KlondikeVariantStat {
+  if (typeof value !== 'object' || value === null) return false;
+  const s = value as Record<string, unknown>;
+  const numOrNull = (v: unknown) => v === null || typeof v === 'number';
+  return (
+    typeof s.plays === 'number' &&
+    typeof s.wins === 'number' &&
+    numOrNull(s.bestTimeSeconds) &&
+    numOrNull(s.fewestMoves)
+  );
+}
+
+/** Reads and validates the stats map from localStorage; returns {} on any error. */
+export function readKlondikeStats(): KlondikeStats {
+  try {
+    const raw = localStorage.getItem(KLONDIKE_STATS_KEY);
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== 'object' || parsed === null) return {};
+    const out: KlondikeStats = {};
+    for (const [key, val] of Object.entries(parsed as Record<string, unknown>)) {
+      if (isValidStat(val)) out[key] = val;
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+/** Whether a recorded result set a new personal best (for celebration feedback). */
+export interface KlondikeBestUpdate {
+  newBestTime: boolean;
+  newFewestMoves: boolean;
+}
+
+/**
+ * Pure reducer: folds a finished-game result into the stats map and reports whether
+ * it set a new personal best. Best time / fewest moves only advance on a win.
+ */
+export function applyKlondikeResult(
+  stats: KlondikeStats,
+  result: KlondikeResult,
+): { stats: KlondikeStats; update: KlondikeBestUpdate } {
+  const key = klondikeVariantKey(result.drawCount, result.scoringMode);
+  const prev = stats[key] ?? emptyKlondikeStat();
+  const next: KlondikeVariantStat = {
+    plays: prev.plays + 1,
+    wins: prev.wins + (result.won ? 1 : 0),
+    bestTimeSeconds: prev.bestTimeSeconds,
+    fewestMoves: prev.fewestMoves,
+  };
+  const update: KlondikeBestUpdate = { newBestTime: false, newFewestMoves: false };
+  if (result.won) {
+    if (result.timeSeconds > 0 && (prev.bestTimeSeconds === null || result.timeSeconds < prev.bestTimeSeconds)) {
+      next.bestTimeSeconds = result.timeSeconds;
+      update.newBestTime = true;
+    }
+    if (prev.fewestMoves === null || result.moves < prev.fewestMoves) {
+      next.fewestMoves = result.moves;
+      update.newFewestMoves = true;
+    }
+  }
+  return { stats: { ...stats, [key]: next }, update };
+}
+
+/** Win rate as a whole-number percentage (0 when no games played). */
+export function klondikeWinRate(stat: KlondikeVariantStat): number {
+  if (stat.plays === 0) return 0;
+  return Math.round((stat.wins / stat.plays) * 100);
+}
+
+/**
+ * Hook that persists per-variant Klondike statistics in localStorage and records
+ * finished games. `recordResult` returns which personal bests were beaten so the
+ * page can surface a badge.
+ */
+export function useKlondikeStats() {
+  const [stats, setStats] = useState<KlondikeStats>(readKlondikeStats);
+
+  const recordResult = useCallback((result: KlondikeResult): KlondikeBestUpdate => {
+    const { stats: next, update } = applyKlondikeResult(readKlondikeStats(), result);
+    setStats(next);
+    try {
+      localStorage.setItem(KLONDIKE_STATS_KEY, JSON.stringify(next));
+    } catch {
+      /* storage unavailable / quota exceeded */
+    }
+    return update;
+  }, []);
+
+  const getStat = useCallback(
+    (drawCount: number, scoringMode: number): KlondikeVariantStat =>
+      stats[klondikeVariantKey(drawCount, scoringMode)] ?? emptyKlondikeStat(),
+    [stats],
+  );
+
+  return { stats, getStat, recordResult };
+}

--- a/frontend/src/i18n/locales/en/klondike.json
+++ b/frontend/src/i18n/locales/en/klondike.json
@@ -48,5 +48,11 @@
     "revealFaceDown": "Move cards to reveal a face-down card underneath",
     "moveKingToEmpty": "A King can be moved to an empty column",
     "drawFromStock": "No obvious moves — try drawing from the stock"
+  },
+  "stats": {
+    "winRate": "Win rate {{rate}}%",
+    "bestTime": "Best {{time}}",
+    "fewestMoves": "{{moves}} moves",
+    "newBest": "New personal best!"
   }
 }

--- a/frontend/src/i18n/locales/ja/klondike.json
+++ b/frontend/src/i18n/locales/ja/klondike.json
@@ -48,5 +48,11 @@
     "revealFaceDown": "カードを動かして裏向きのカードをめくりましょう",
     "moveKingToEmpty": "キングを空の列に移動できます",
     "drawFromStock": "すぐにできる手がありません — 山札から引いてみましょう"
+  },
+  "stats": {
+    "winRate": "勝率 {{rate}}%",
+    "bestTime": "ベスト {{time}}",
+    "fewestMoves": "最少 {{moves}}手",
+    "newBest": "自己ベスト更新！"
   }
 }

--- a/frontend/src/pages/KlondikePage.test.tsx
+++ b/frontend/src/pages/KlondikePage.test.tsx
@@ -1107,4 +1107,38 @@ describe('KlondikePage', () => {
       );
     });
   });
+
+  describe('local statistics (#3031)', () => {
+    it('renders the stats panel with a win rate readout', async () => {
+      localStorage.removeItem('klondike_stats');
+      renderWithProviders(<KlondikePage />);
+      const panel = await screen.findByTestId('kl-stats-panel');
+      expect(panel).toHaveTextContent(/勝率/);
+    });
+
+    it('records a cleared game and shows the personal-best badge', async () => {
+      localStorage.removeItem('klondike_stats');
+      mockExec.mockResolvedValue(gameClearState);
+      renderWithProviders(<KlondikePage />);
+      // Win recorded once on GAME_CLEAR; first clear beats the (empty) fewest-moves best.
+      expect(await screen.findByTestId('kl-best-badge')).toBeInTheDocument();
+      await waitFor(() => {
+        const raw = localStorage.getItem('klondike_stats');
+        expect(raw).not.toBeNull();
+        const stats = JSON.parse(raw ?? '{}');
+        expect(stats['1:0']).toMatchObject({ plays: 1, wins: 1, fewestMoves: 5 });
+      });
+    });
+
+    it('records a lost game as a play without a win', async () => {
+      localStorage.removeItem('klondike_stats');
+      mockExec.mockResolvedValue(gameOverState);
+      renderWithProviders(<KlondikePage />);
+      await waitFor(() => {
+        const stats = JSON.parse(localStorage.getItem('klondike_stats') ?? '{}');
+        expect(stats['1:0']).toMatchObject({ plays: 1, wins: 0, fewestMoves: null });
+      });
+      expect(screen.queryByTestId('kl-best-badge')).not.toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/src/pages/KlondikePage.tsx
+++ b/frontend/src/pages/KlondikePage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { KlondikeMoveZone, klondikeApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { AutoCompleteReadyBadge } from '../components/AutoCompleteReadyBadge';
@@ -25,6 +25,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useKlondikeGame } from '../hooks/useKlondikeGame';
+import { klondikeWinRate, useKlondikeStats } from '../hooks/useKlondikeStats';
 import { useKlondikeTimer } from '../hooks/useKlondikeTimer';
 import { useSolitaireDragDrop } from '../hooks/useSolitaireDragDrop';
 import { useSound } from '../providers/SoundProvider';
@@ -164,6 +165,35 @@ function KlondikePageContent() {
   const [drawCountSetting, setDrawCountSetting] = useState(1);
   const [scoringModeSetting, setScoringModeSetting] = useState(0);
 
+  // Per-variant (drawCount × scoringMode) play statistics persisted in localStorage (#3031).
+  const { getStat, recordResult } = useKlondikeStats();
+  // Badge shown on the clear screen when a game beats a stored personal best.
+  const [bestUpdate, setBestUpdate] = useState<{ newBestTime: boolean; newFewestMoves: boolean } | null>(null);
+  // Guard so a completed game is recorded exactly once (phase stays ended across re-renders).
+  const recordedRef = useRef(false);
+  const currentPhase = state?.phase;
+  const currentDraw = state?.drawCount;
+  const currentScoring = state?.scoringMode;
+  const currentMoves = state?.moveCount;
+  useEffect(() => {
+    const ended = currentPhase === KlondikePhase.GAME_CLEAR || currentPhase === KlondikePhase.GAME_OVER;
+    if (!ended) {
+      recordedRef.current = false;
+      return;
+    }
+    if (recordedRef.current) return;
+    recordedRef.current = true;
+    const won = currentPhase === KlondikePhase.GAME_CLEAR;
+    const update = recordResult({
+      drawCount: currentDraw ?? 1,
+      scoringMode: currentScoring ?? 0,
+      won,
+      timeSeconds: elapsedSeconds,
+      moves: currentMoves ?? 0,
+    });
+    setBestUpdate(won ? update : null);
+  }, [currentPhase, currentDraw, currentScoring, currentMoves, elapsedSeconds, recordResult]);
+
   // Drag-and-drop: dispatches the same move command as click-based selection.
   const dispatchMove = useCallback(
     (source: KlondikeMoveZone, target: KlondikeMoveZone) => {
@@ -217,6 +247,7 @@ function KlondikePageContent() {
   const isGameOver = state.phase === KlondikePhase.GAME_OVER;
   const isEnded = isGameClear || isGameOver;
   const isVegas = state.scoringMode === KlondikeScoringMode.VEGAS;
+  const currentStat = getStat(state.drawCount, state.scoringMode);
 
   const isSourceSelected = (zone: string, col?: number, cardIndex?: number) =>
     selectedSource !== null &&
@@ -552,6 +583,17 @@ function KlondikePageContent() {
               messageParams={state.messageParams}
             />
 
+            {/* Personal-best badge on the clear screen (#3031). */}
+            {isGameClear && bestUpdate && (bestUpdate.newBestTime || bestUpdate.newFewestMoves) && (
+              <div
+                data-testid="kl-best-badge"
+                role="status"
+                className="text-center text-ds-success font-semibold text-sm mb-2"
+              >
+                {t('stats.newBest')}
+              </div>
+            )}
+
             {/* Action log */}
             <ActionLogSection
               isEndPhase={isEnded}
@@ -687,6 +729,16 @@ function KlondikePageContent() {
                 <option value={0}>{t('scoringNone')}</option>
                 <option value={1}>{t('scoringVegas')}</option>
               </select>
+              {/* Per-variant stats: win rate + best time / fewest moves (#3031). */}
+              <div data-testid="kl-stats-panel" className="w-full text-game-text-muted text-xs">
+                {t('stats.winRate', { rate: klondikeWinRate(currentStat) })} ({currentStat.wins}/{currentStat.plays})
+                {currentStat.bestTimeSeconds !== null && (
+                  <> · {t('stats.bestTime', { time: formatTime(currentStat.bestTimeSeconds) })}</>
+                )}
+                {currentStat.fewestMoves !== null && (
+                  <> · {t('stats.fewestMoves', { moves: currentStat.fewestMoves })}</>
+                )}
+              </div>
               <GameResetButton
                 isGameEnd={isEnded}
                 onReset={handleManualReset}


### PR DESCRIPTION
## Summary

Persists local Klondike statistics — win rate, best clear time, and fewest moves — in localStorage and displays them in the game footer. Closes #3031.

- New `useKlondikeStats` hook (mirrors the `useSpiderStats` pattern): try/catch-guarded localStorage persist + a pure `applyKlondikeResult` reducer + validated `readKlondikeStats`.
- Stats are keyed per variant (`drawCount:scoringMode`), so 1-card/3-card × None/Vegas are tracked separately.
- `KlondikePage` records the finished game exactly once on GAME_CLEAR / GAME_OVER (ref-guarded effect), reusing the existing `useKlondikeTimer` elapsed seconds as the time basis.
- Footer stats panel (`data-testid="kl-stats-panel"`) shows win rate + best time / fewest moves for the current variant; a personal-best badge (`data-testid="kl-best-badge"`) celebrates a new best on the clear screen.
- i18n: added a `stats` block to `ja`/`en` klondike locale files.
- Frontend-only; no Go changes.

## Test plan

- [x] `bun run test -- --run useKlondikeStats KlondikePage` (120 passed)
- [x] `bun run check` (exit 0; warnings pre-existing in unrelated files)
- [x] `bun run build` (tsc gate, exit 0)
- [x] Hook unit tests cover: win increments wins + sets best time/fewest moves, loss increments plays only, faster/slower win best-update logic, non-positive time guard, variant separation, malformed-JSON handling, persist/read-back
- [x] Page tests cover: stats panel renders, cleared game records + shows best badge, lost game records a play without a win/badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
