### PR TITLE
feat(anaconda): stage the roll-phase reveal with one-at-a-time emphasis

### DIFF
--- a/frontend/src/pages/AnacondaPage.test.tsx
+++ b/frontend/src/pages/AnacondaPage.test.tsx
@@ -1,8 +1,9 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { anacondaApi } from '../api/gameApi';
 import { renderWithProviders } from '../test/renderWithProviders';
 import { makeAnacondaState } from '../test/stateFactories';
+import type { AnacondaResponse, Card } from '../types/card';
 import { AnacondaPage } from './AnacondaPage';
 
 vi.mock('../api/gameApi', () => ({
@@ -174,5 +175,76 @@ describe('AnacondaPage', () => {
     fireEvent.click(cards[5]);
     expect(screen.getByTestId('anaconda-selection-feedback')).toHaveTextContent('1 枚外してください（6/5）');
     expect(screen.getByRole('button', { name: 'キープ' })).toBeDisabled();
+  });
+
+  const card = (design: Card['design'], value: number): Card => ({ design, value });
+
+  /** A roll-phase state where CPU seat 1 has `revealed` exposed cards. */
+  function rollRevealState(revealed: number): AnacondaResponse {
+    const cpuCards = [
+      card('SPADE', 14),
+      card('HEART', 13),
+      card('CLOVER', 5),
+      card('DIAMOND', 9),
+      card('SPADE', 2),
+    ].slice(0, revealed);
+    const base = makeAnacondaState({
+      phase: 2,
+      rollIndex: revealed,
+      isHumanTurn: true,
+      canRaise: true,
+      currentBet: 10,
+    });
+    return {
+      ...base,
+      players: base.players.map((p) => (p.id === 1 ? { ...p, cards: cpuCards } : p)),
+    };
+  }
+
+  it('renders exposed cards for revealed slots and face-down placeholders for unrevealed ones by rollIndex', async () => {
+    mockExec.mockResolvedValue(rollRevealState(3));
+    renderWithProviders(<AnacondaPage />);
+    await waitFor(() => expect(screen.getByTestId('anaconda-roll-1')).toBeInTheDocument());
+    // 3 revealed slots present, remaining 2 (of KEEP_SIZE=5) are placeholders.
+    expect(screen.getByTestId('anaconda-reveal-1-0')).toBeInTheDocument();
+    expect(screen.getByTestId('anaconda-reveal-1-2')).toBeInTheDocument();
+    expect(screen.queryByTestId('anaconda-reveal-1-3')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('anaconda-reveal-1-4')).not.toBeInTheDocument();
+    expect(screen.getByTestId('anaconda-roll-1').children).toHaveLength(5);
+  });
+
+  it('advances the roll-reveal emphasis one card at a time through the exposed cards', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      mockExec.mockResolvedValue(rollRevealState(3));
+      renderWithProviders(<AnacondaPage />);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      await waitFor(() => expect(screen.getByTestId('anaconda-reveal-1-0')).toBeInTheDocument());
+
+      // Step 1: the first exposed card is emphasized.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(450);
+      });
+      expect(screen.getByTestId('anaconda-reveal-1-0')).toHaveAttribute('data-emphasized', 'true');
+      expect(screen.getByTestId('anaconda-reveal-1-1')).not.toHaveAttribute('data-emphasized');
+
+      // Step 2: the emphasis advances to the second card.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(450);
+      });
+      expect(screen.getByTestId('anaconda-reveal-1-1')).toHaveAttribute('data-emphasized', 'true');
+      expect(screen.getByTestId('anaconda-reveal-1-0')).not.toHaveAttribute('data-emphasized');
+
+      // Step 3: the emphasis lands on the most recently revealed card.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(450);
+      });
+      expect(screen.getByTestId('anaconda-reveal-1-2')).toHaveAttribute('data-emphasized', 'true');
+      expect(screen.getByTestId('anaconda-reveal-1-1')).not.toHaveAttribute('data-emphasized');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/frontend/src/pages/AnacondaPage.tsx
+++ b/frontend/src/pages/AnacondaPage.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import type { anacondaApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
-import { CardImage } from '../components/CardImage';
+import { CardBack, CardImage } from '../components/CardImage';
 import { CliTerminal } from '../components/cli/CliTerminal';
 import { CliToggle } from '../components/cli/CliToggle';
 import { SettingsPanel } from '../components/common/SettingsPanel';
@@ -76,6 +76,9 @@ const ANACONDA_PHASE_KEYS: Readonly<Record<number, string>> = {
 /** Number of cards a player keeps at the Set phase. */
 const KEEP_SIZE = 5;
 
+/** Milliseconds between successive card emphases during the staged Roll reveal. */
+const ROLL_REVEAL_STEP_MS = 450;
+
 /** Renders the Anaconda (Pass the Trash) game page: a multi-phase poker pot game. */
 export const AnacondaPage = withTutorial(AnacondaPageContent, 'anaconda', ANACONDA_TUTORIAL_STEPS);
 
@@ -127,6 +130,34 @@ function AnacondaPageContent() {
   } = useGameHint('anaconda', state);
   const { cardWidth } = useCardDimensions();
   const phaseNames = usePhaseNames('anaconda', ANACONDA_PHASE_KEYS);
+
+  // Staged Roll reveal: during the showdown "roll" phase, sweep an emphasis ring
+  // across the exposed cards one at a time so the reveal progression is visible,
+  // finishing on the most recently revealed card. Present-state only (no server
+  // round-trip); reduced-motion users jump straight to the final emphasis.
+  const isRollReveal = state?.phase === AnacondaPhase.ROLL;
+  const rollIndex = state?.rollIndex ?? 0;
+  const [revealStep, setRevealStep] = useState(0);
+  useEffect(() => {
+    if (!isRollReveal || rollIndex <= 0) {
+      setRevealStep(0);
+      return;
+    }
+    if (window.matchMedia?.('(prefers-reduced-motion: reduce)').matches) {
+      setRevealStep(rollIndex);
+      return;
+    }
+    setRevealStep(0);
+    const timers: ReturnType<typeof setTimeout>[] = [];
+    for (let step = 1; step <= rollIndex; step++) {
+      timers.push(setTimeout(() => setRevealStep(step), step * ROLL_REVEAL_STEP_MS));
+    }
+    return () => {
+      for (const timer of timers) clearTimeout(timer);
+    };
+  }, [isRollReveal, rollIndex]);
+  // Slot index of the card currently emphasized by the staged sweep (-1 = none yet).
+  const emphasizedRevealIdx = revealStep - 1;
 
   if (!state)
     return <GameSkeleton gameKey="anaconda" layout={{ kind: 'trick-taking', trickArea: true, footerHandSize: 5 }} />;
@@ -315,8 +346,45 @@ function AnacondaPageContent() {
               ))}
             </div>
 
-            {/* Revealed CPU hands during Roll / at Result */}
-            {(isRollPhase || isResultPhase) && (
+            {/* Revealed CPU hands during Roll: staged one-at-a-time emphasis with
+                face-down placeholders for the not-yet-exposed slots. */}
+            {isRollPhase && (
+              <div className="mb-2 p-2 rounded bg-black/30">
+                {state.players
+                  .filter((p) => !p.isHuman && !p.out && !p.folded)
+                  .map((p) => (
+                    <div key={p.id} className="mb-1">
+                      <div className="text-ds-text-muted text-xs mb-0.5">
+                        {playerLabel(p.id, p.isHuman)}
+                        {p.handName ? ` — ${handName(p.handName)}` : ''}
+                      </div>
+                      <div className="flex gap-1" data-testid={`anaconda-roll-${p.id}`}>
+                        {Array.from({ length: KEEP_SIZE }, (_, i) => {
+                          if (i >= p.cards.length) {
+                            return <CardBack key={`ph-${p.id}-${i}`} width={cardWidth} />;
+                          }
+                          const emphasized = i === emphasizedRevealIdx;
+                          return (
+                            <div
+                              key={`${p.id}-${i}`}
+                              data-testid={`anaconda-reveal-${p.id}-${i}`}
+                              data-emphasized={emphasized ? 'true' : undefined}
+                              className={`rounded transition-transform ${
+                                emphasized ? '-translate-y-1 ring-2 ring-ds-success motion-safe:animate-pulse' : ''
+                              }`}
+                            >
+                              <CardImage card={p.cards[i]} width={cardWidth} />
+                            </div>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  ))}
+              </div>
+            )}
+
+            {/* Fully revealed CPU hands at Result. */}
+            {isResultPhase && (
               <div className="mb-2 p-2 rounded bg-black/30">
                 {state.players
                   .filter((p) => !p.isHuman && p.cards.length > 0)


### PR DESCRIPTION
## Summary

Emphasizes the Anaconda Roll (showdown reveal) phase so players can feel the reveal progression before each betting decision.

During the Roll phase, for every active CPU:
- Renders the exposed cards (`GetRevealedCards` = `rollIndex` cards) face-up and the remaining slots (up to the kept 5) as face-down placeholders, so how-many-are-left is visible at a glance.
- Sweeps an emphasis ring/lift across the exposed cards one at a time via a `revealStep` state + timers (present-state only, no server round-trip), landing on the most recently revealed card — the Baccarat/IndianPoker reveal pattern already used in the repo.
- Respects `prefers-reduced-motion` (jumps straight to the final emphasis, no sweep) and never blocks Call/Raise/Fold interaction.

The Result phase rendering (all 5 cards face-up) is unchanged.

Frontend-only; no Go / CUI / internal-i18n touched. No new user-facing text (placeholders reuse the existing `CardBack` component), so no i18n changes were needed.

## Acceptance criteria
- [x] The most recently revealed card is emphasized
- [x] The unrevealed count is shown via face-down placeholders
- [x] Revealed vs. unrevealed slots are drawn based on `rollIndex`
- [x] Added roll-emphasis tests to `AnacondaPage.test.tsx`

## Test plan
- [x] `bun run check`
- [x] `bun run test -- --run AnacondaPage` (17 passed, incl. 2 new: placeholder/split by rollIndex + staged emphasis advancement via fake timers)
- [x] `bun run build` (tsc)

Closes #3499
