### PR TITLE
feat(rummy500): preview the pickup range when hovering a discard card

### DIFF
--- a/frontend/src/i18n/locales/en/rummy500.json
+++ b/frontend/src/i18n/locales/en/rummy500.json
@@ -33,6 +33,8 @@
   "playPhase": "Meld, lay off, then discard",
   "roundEnd": "Round complete",
   "drawDiscardHint": "Click any discard card to take it plus all cards above it",
+  "drawDiscardRangeLabel": "Take {{count}} card(s) from {{card}}",
+  "pickupBadge": "Take {{count}}",
   "handPenalty": "Hand penalty: -{{points}} pts",
   "handPenaltyHint": "If anyone else goes out, this is how many points you lose",
   "winner": {

--- a/frontend/src/i18n/locales/ja/rummy500.json
+++ b/frontend/src/i18n/locales/ja/rummy500.json
@@ -33,6 +33,8 @@
   "playPhase": "メルド・レイオフ・ディスカードを行ってください",
   "roundEnd": "ラウンド終了",
   "drawDiscardHint": "捨て札の任意のカードをクリックすると、そのカード以上をすべて引き取れます",
+  "drawDiscardRangeLabel": "{{card}} から{{count}}枚引き取る",
+  "pickupBadge": "{{count}}枚引き取る",
   "handPenalty": "手札ペナルティ: -{{points}}点",
   "handPenaltyHint": "誰かが上がった時、手札に残ったカードの合計がマイナス点になります",
   "winner": {

--- a/frontend/src/pages/Rummy500Page.test.tsx
+++ b/frontend/src/pages/Rummy500Page.test.tsx
@@ -102,14 +102,48 @@ describe('Rummy500Page', () => {
 
   it('clicking discard card in Draw phase calls drawdiscard', async () => {
     renderWithProviders(<Rummy500Page />);
-    await waitFor(() => {
-      expect(screen.getAllByLabelText(/\(0\)$/).length).toBeGreaterThan(0);
-    });
-    const card = screen.getAllByLabelText(/\(0\)$/)[0];
+    const card = await screen.findByTestId('disc-card-0');
     fireEvent.click(card);
     await waitFor(() => {
       expect(mockExec).toHaveBeenCalledWith('drawdiscard', undefined, undefined, undefined, 0);
     });
+  });
+
+  it('previews the whole take-range when hovering a mid-pile discard card', async () => {
+    renderWithProviders(<Rummy500Page />);
+    // drawPhaseState.discardPile has 2 cards: [♥3 (idx 0), ♣5 (idx 1, top)].
+    const bottom = await screen.findByTestId('disc-card-0');
+    const top = screen.getByTestId('disc-card-1');
+    // Nothing highlighted before hover.
+    expect(bottom).not.toHaveAttribute('data-in-pickup-range');
+    expect(top).not.toHaveAttribute('data-in-pickup-range');
+
+    fireEvent.mouseEnter(bottom);
+    // Hovering the bottom card highlights it AND every card above it (the whole pile).
+    expect(bottom).toHaveAttribute('data-in-pickup-range', 'true');
+    expect(top).toHaveAttribute('data-in-pickup-range', 'true');
+    // The badge announces the number of cards that would be taken (2).
+    const badge = screen.getByTestId('pickup-range-badge');
+    expect(badge).toHaveTextContent('2');
+    // The aria-label of the hovered card also carries the count.
+    expect(bottom).toHaveAttribute('aria-label', expect.stringContaining('2枚引き取る'));
+
+    fireEvent.mouseLeave(bottom);
+    expect(bottom).not.toHaveAttribute('data-in-pickup-range');
+    expect(top).not.toHaveAttribute('data-in-pickup-range');
+  });
+
+  it('previews only the top card when hovering the top of the discard pile', async () => {
+    renderWithProviders(<Rummy500Page />);
+    const bottom = await screen.findByTestId('disc-card-0');
+    const top = screen.getByTestId('disc-card-1');
+
+    fireEvent.focus(top);
+    // Hovering/focusing the top card previews just that one card.
+    expect(top).toHaveAttribute('data-in-pickup-range', 'true');
+    expect(bottom).not.toHaveAttribute('data-in-pickup-range');
+    expect(screen.getByTestId('pickup-range-badge')).toHaveTextContent('1');
+    expect(top).toHaveAttribute('aria-label', expect.stringContaining('1枚引き取る'));
   });
 
   it('shows meld + discard buttons in Play phase', async () => {

--- a/frontend/src/pages/Rummy500Page.tsx
+++ b/frontend/src/pages/Rummy500Page.tsx
@@ -29,6 +29,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import { playerName } from '../utils/playerUtils';
 import { rummy500HandPenalty } from '../utils/rummy500HandPenalty';
+import { rummy500PickupCount } from '../utils/rummy500PickupCount';
 
 const RUMMY500_PHASE_KEYS: Readonly<Record<number, string>> = {
   [Rummy500Phase.DRAW]: 'draw',
@@ -95,6 +96,10 @@ function Rummy500PageContent() {
   // means nothing is selected yet, so the Lay off button stays disabled. The owner's
   // display name is captured here (where isHuman is in scope) for the footer label.
   const [layoffTarget, setLayoffTarget] = useState<{ owner: number; meldIdx: number; ownerName: string } | null>(null);
+  // Index of the discard card currently hovered/focused during the Draw phase. Drawing from a
+  // chosen index takes that card plus every card above it, so we preview the whole take-range
+  // (from this index to the top) before the player commits. null means nothing is previewed.
+  const [hoveredDiscardIdx, setHoveredDiscardIdx] = useState<number | null>(null);
 
   const phaseNames = usePhaseNames('rummy500', RUMMY500_PHASE_KEYS);
 
@@ -186,19 +191,40 @@ function Rummy500PageContent() {
                 <div className="text-ds-text-muted text-xs">{t('discardEmpty')}</div>
               ) : (
                 <div className="flex flex-wrap gap-1">
-                  {state.discardPile.map((card, idx) => (
-                    <button
-                      type="button"
-                      key={`disc-${card.design}-${card.value}-${idx}`}
-                      onClick={() => isDrawPhase && isHumanTurn && !loading && handleDrawDiscard(idx)}
-                      disabled={!isDrawPhase || !isHumanTurn || loading}
-                      aria-label={`${cardAlt(card)} (${idx})`}
-                      className={`transition-transform ${focusRingCard}`}
-                      style={{ background: 'none', padding: 0, borderRadius: 8 }}
-                    >
-                      <AnimatedCard card={card} width={cardWidth * 0.7} />
-                    </button>
-                  ))}
+                  {state.discardPile.map((card, idx) => {
+                    const takeCount = rummy500PickupCount(state.discardPile.length, idx);
+                    const inPickupRange = hoveredDiscardIdx !== null && idx >= hoveredDiscardIdx;
+                    const isPickupAnchor = hoveredDiscardIdx === idx;
+                    return (
+                      <button
+                        type="button"
+                        key={`disc-${card.design}-${card.value}-${idx}`}
+                        onClick={() => isDrawPhase && isHumanTurn && !loading && handleDrawDiscard(idx)}
+                        onMouseEnter={() => setHoveredDiscardIdx(idx)}
+                        onMouseLeave={() => setHoveredDiscardIdx(null)}
+                        onFocus={() => setHoveredDiscardIdx(idx)}
+                        onBlur={() => setHoveredDiscardIdx(null)}
+                        disabled={!isDrawPhase || !isHumanTurn || loading}
+                        aria-label={t('drawDiscardRangeLabel', { card: cardAlt(card), count: takeCount })}
+                        data-testid={`disc-card-${idx}`}
+                        data-in-pickup-range={inPickupRange ? 'true' : undefined}
+                        className={`relative transition-transform ${focusRingCard} ${
+                          inPickupRange ? 'ring-2 ring-ds-warning -translate-y-1' : ''
+                        }`}
+                        style={{ background: 'none', padding: 0, borderRadius: 8 }}
+                      >
+                        <AnimatedCard card={card} width={cardWidth * 0.7} />
+                        {isPickupAnchor && (
+                          <span
+                            data-testid="pickup-range-badge"
+                            className="absolute -top-2 left-1/2 -translate-x-1/2 whitespace-nowrap rounded-full bg-ds-warning px-1.5 py-0.5 text-[10px] font-bold text-ds-text-on-accent shadow"
+                          >
+                            {t('pickupBadge', { count: takeCount })}
+                          </span>
+                        )}
+                      </button>
+                    );
+                  })}
                 </div>
               )}
             </div>

--- a/frontend/src/utils/rummy500PickupCount.test.ts
+++ b/frontend/src/utils/rummy500PickupCount.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { rummy500PickupCount } from './rummy500PickupCount';
+
+describe('rummy500PickupCount', () => {
+  it('takes only the top card when drawing from the last index', () => {
+    // A 4-card pile, drawing from the top (idx 3) takes just that one card.
+    expect(rummy500PickupCount(4, 3)).toBe(1);
+  });
+
+  it('takes the chosen card plus every card above it for a mid-pile index', () => {
+    // Drawing from idx 1 of a 4-card pile takes idx 1, 2 and 3 → 3 cards.
+    expect(rummy500PickupCount(4, 1)).toBe(3);
+  });
+
+  it('takes the whole pile when drawing from the bottom (idx 0)', () => {
+    expect(rummy500PickupCount(4, 0)).toBe(4);
+  });
+
+  it('returns 0 for out-of-range indices', () => {
+    expect(rummy500PickupCount(4, -1)).toBe(0);
+    expect(rummy500PickupCount(4, 4)).toBe(0);
+    expect(rummy500PickupCount(0, 0)).toBe(0);
+  });
+});

--- a/frontend/src/utils/rummy500PickupCount.ts
+++ b/frontend/src/utils/rummy500PickupCount.ts
@@ -1,0 +1,13 @@
+/**
+ * Number of cards taken when drawing from index `idx` of a Rummy 500 discard pile.
+ *
+ * Drawing from a chosen index takes that card plus every card above it (up to the
+ * top of the pile), matching the domain rule `discardPile[idx:]` in
+ * `internal/domain/Rummy500.go`. The pile is ordered oldest-first, so the top card
+ * is the last element and picking from `idx` yields `pileLength - idx` cards.
+ * Out-of-range indices return 0.
+ */
+export function rummy500PickupCount(pileLength: number, idx: number): number {
+  if (idx < 0 || idx >= pileLength) return 0;
+  return pileLength - idx;
+}


### PR DESCRIPTION
Closes #3319

## 概要
500ラムの DRAW フェーズで、捨て札の途中カードから引くと「そのカード以上をすべて引き取る」規則（ドメイン `discardPile[idx:]`）が事前に見えず、初見プレイヤーが1枚だけ取れると誤解しやすかった問題を解消する。捨て札カードのホバー/フォーカスで取得範囲全体をハイライトし、取得枚数をバッジと aria-label で可視化する（フロントエンドのみ、既存のドロー操作は不変）。

## 変更内容
- `Rummy500Page.tsx`: `hoveredDiscardIdx` state を追加。捨て札ボタンに `onMouseEnter`/`onMouseLeave`/`onFocus`/`onBlur` を付与し、ホバー中の idx 以降のカード全てに `ring-ds-warning` + 軽い持ち上げ（`-translate-y-1`）を適用。ホバー中のカードに「◯枚引き取る」バッジ（`bg-ds-warning`）を表示。aria-label を `{{card}} から{{count}}枚引き取る` 形式に変更し取得枚数を含めた。テスト用に `data-testid="disc-card-<idx>"` / `data-in-pickup-range` / `data-testid="pickup-range-badge"` を追加。
- `utils/rummy500PickupCount.ts`: 取得枚数を返す純関数（`pileLength - idx`、範囲外は0）+ 単体テスト。
- `Rummy500Page.test.tsx`: 中間カードホバーで範囲全体がハイライト、トップカードは自身のみ、の2ケースを追加。既存テストは新 `data-testid` に更新。
- i18n（ja/en）: `drawDiscardRangeLabel` / `pickupBadge` キーを追加。

Go/ドメイン/CUI/internal-i18n は未変更（500ラムは `extra` WASM ワーカー、フロントエンドのみ）。ドメインの取得規則は読み取りのみで確認。

## 受け入れ条件
- [x] 捨て札ホバー時に取得範囲全体がハイライトされる
- [x] 取得枚数がバッジまたはラベルで表示される
- [x] aria-label に取得枚数が含まれる
- [x] `Rummy500Page.test.tsx` に範囲ハイライトのテストを追加

## テスト
- `bun run check` — pass (exit 0, 既存警告のみ、変更ファイルは0警告)
- `bun run test -- --run Rummy500 rummy500PickupCount` — 33 passed
- `bun run build` (tsc) — pass
