### PR TITLE
feat(pyramid): persist and display fewest-moves best record

### DIFF
--- a/frontend/src/hooks/usePyramidStats.test.ts
+++ b/frontend/src/hooks/usePyramidStats.test.ts
@@ -1,0 +1,81 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  applyPyramidResult,
+  emptyPyramidStats,
+  PYRAMID_STATS_KEY,
+  readPyramidStats,
+  usePyramidStats,
+} from './usePyramidStats';
+
+describe('applyPyramidResult', () => {
+  it('records a clear and a new fewest-moves record', () => {
+    const { stats, newBest } = applyPyramidResult(emptyPyramidStats(), { won: true, moves: 42 });
+    expect(stats).toEqual({ plays: 1, wins: 1, fewestMoves: 42 });
+    expect(newBest).toBe(true);
+  });
+
+  it('updates the record only when the clear used fewer moves', () => {
+    const { stats, newBest } = applyPyramidResult({ plays: 1, wins: 1, fewestMoves: 30 }, { won: true, moves: 25 });
+    expect(stats).toEqual({ plays: 2, wins: 2, fewestMoves: 25 });
+    expect(newBest).toBe(true);
+  });
+
+  it('does not worsen an existing record for a slower clear', () => {
+    const { stats, newBest } = applyPyramidResult({ plays: 1, wins: 1, fewestMoves: 30 }, { won: true, moves: 55 });
+    expect(stats).toEqual({ plays: 2, wins: 2, fewestMoves: 30 });
+    expect(newBest).toBe(false);
+  });
+
+  it('counts a loss without touching the fewest-moves record', () => {
+    const { stats, newBest } = applyPyramidResult({ plays: 1, wins: 1, fewestMoves: 30 }, { won: false, moves: 12 });
+    expect(stats).toEqual({ plays: 2, wins: 1, fewestMoves: 30 });
+    expect(newBest).toBe(false);
+  });
+
+  it('ignores a zero-move clear for the record', () => {
+    const { stats, newBest } = applyPyramidResult(emptyPyramidStats(), { won: true, moves: 0 });
+    expect(stats).toEqual({ plays: 1, wins: 1, fewestMoves: null });
+    expect(newBest).toBe(false);
+  });
+});
+
+describe('readPyramidStats', () => {
+  afterEach(() => localStorage.clear());
+
+  it('returns an empty record when nothing is stored', () => {
+    expect(readPyramidStats()).toEqual(emptyPyramidStats());
+  });
+
+  it('returns an empty record for malformed JSON', () => {
+    localStorage.setItem(PYRAMID_STATS_KEY, '{not json');
+    expect(readPyramidStats()).toEqual(emptyPyramidStats());
+  });
+
+  it('returns an empty record for a structurally invalid value', () => {
+    localStorage.setItem(PYRAMID_STATS_KEY, JSON.stringify({ plays: 'x' }));
+    expect(readPyramidStats()).toEqual(emptyPyramidStats());
+  });
+});
+
+describe('usePyramidStats', () => {
+  afterEach(() => localStorage.clear());
+
+  it('persists a recorded result and reads it back on remount', () => {
+    const { result } = renderHook(() => usePyramidStats());
+    let newBest = false;
+    act(() => {
+      newBest = result.current.recordResult({ won: true, moves: 40 });
+    });
+    expect(newBest).toBe(true);
+    expect(result.current.stats).toEqual({ plays: 1, wins: 1, fewestMoves: 40 });
+    expect(JSON.parse(localStorage.getItem(PYRAMID_STATS_KEY) ?? '{}')).toEqual({
+      plays: 1,
+      wins: 1,
+      fewestMoves: 40,
+    });
+
+    const { result: reread } = renderHook(() => usePyramidStats());
+    expect(reread.current.stats).toEqual({ plays: 1, wins: 1, fewestMoves: 40 });
+  });
+});

--- a/frontend/src/hooks/usePyramidStats.ts
+++ b/frontend/src/hooks/usePyramidStats.ts
@@ -1,0 +1,91 @@
+import { useCallback, useState } from 'react';
+
+/** localStorage key for Pyramid Solitaire best-record statistics. */
+export const PYRAMID_STATS_KEY = 'trumpcards-pyramid-stats';
+
+/** Persisted best-record statistics for Pyramid. */
+export interface PyramidStats {
+  /** Games finished (cleared or given up / stuck). */
+  plays: number;
+  /** Games cleared. */
+  wins: number;
+  /** Fewest moves across cleared games, or null if never cleared. */
+  fewestMoves: number | null;
+}
+
+/** Outcome of a single finished Pyramid game. */
+export interface PyramidResult {
+  won: boolean;
+  moves: number;
+}
+
+/** Returns a zeroed stats record. */
+export function emptyPyramidStats(): PyramidStats {
+  return { plays: 0, wins: 0, fewestMoves: null };
+}
+
+function isValidStats(value: unknown): value is PyramidStats {
+  if (typeof value !== 'object' || value === null) return false;
+  const s = value as Record<string, unknown>;
+  return (
+    typeof s.plays === 'number' &&
+    typeof s.wins === 'number' &&
+    (s.fewestMoves === null || typeof s.fewestMoves === 'number')
+  );
+}
+
+/** Reads and validates the stats from localStorage; returns a zeroed record on any error. */
+export function readPyramidStats(): PyramidStats {
+  try {
+    const raw = localStorage.getItem(PYRAMID_STATS_KEY);
+    if (!raw) return emptyPyramidStats();
+    const parsed: unknown = JSON.parse(raw);
+    if (!isValidStats(parsed)) return emptyPyramidStats();
+    return parsed;
+  } catch {
+    return emptyPyramidStats();
+  }
+}
+
+/**
+ * Pure reducer: folds a finished-game result into the stats and reports whether it
+ * set a new fewest-moves record. Fewest moves only advances on a positive-move clear.
+ */
+export function applyPyramidResult(
+  stats: PyramidStats,
+  result: PyramidResult,
+): { stats: PyramidStats; newBest: boolean } {
+  const next: PyramidStats = {
+    plays: stats.plays + 1,
+    wins: stats.wins + (result.won ? 1 : 0),
+    fewestMoves: stats.fewestMoves,
+  };
+  let newBest = false;
+  if (result.won && result.moves > 0 && (stats.fewestMoves === null || result.moves < stats.fewestMoves)) {
+    next.fewestMoves = result.moves;
+    newBest = true;
+  }
+  return { stats: next, newBest };
+}
+
+/**
+ * Hook that persists Pyramid best-record statistics in localStorage and records
+ * finished games. `recordResult` returns whether the game set a new fewest-moves
+ * record so the page can surface a badge. Modeled on `useTriPeaksStats`.
+ */
+export function usePyramidStats() {
+  const [stats, setStats] = useState<PyramidStats>(readPyramidStats);
+
+  const recordResult = useCallback((result: PyramidResult): boolean => {
+    const { stats: next, newBest } = applyPyramidResult(readPyramidStats(), result);
+    setStats(next);
+    try {
+      localStorage.setItem(PYRAMID_STATS_KEY, JSON.stringify(next));
+    } catch {
+      /* storage unavailable / quota exceeded */
+    }
+    return newBest;
+  }, []);
+
+  return { stats, recordResult };
+}

--- a/frontend/src/i18n/locales/en/pyramid.json
+++ b/frontend/src/i18n/locales/en/pyramid.json
@@ -33,6 +33,10 @@
     "resetButton": "Press the reset button to start a new game."
   },
   "landscapeBanner": "Rotate to landscape for easier play",
+  "bestMoves": "Best",
+  "bestMovesValue": "{{moves}} moves",
+  "newBestMoves": "New record! Cleared in {{moves}} moves",
+  "clears": "Cleared {{wins}}/{{plays}}",
   "frontendHint": {
     "removeKing": "An exposed King can be removed directly",
     "removePair": "There is a pair of exposed cards that sums to 13",

--- a/frontend/src/i18n/locales/ja/pyramid.json
+++ b/frontend/src/i18n/locales/ja/pyramid.json
@@ -33,6 +33,10 @@
     "resetButton": "リセットボタンで新しいゲームを始められます。"
   },
   "landscapeBanner": "横向きにすると操作しやすくなります",
+  "bestMoves": "ベスト",
+  "bestMovesValue": "{{moves}} 手",
+  "newBestMoves": "新記録！ {{moves}} 手でクリア",
+  "clears": "クリア {{wins}}/{{plays}}",
   "frontendHint": {
     "removeKing": "露出したキングはそのまま除去できます",
     "removePair": "合計13になる露出カードのペアがあります",

--- a/frontend/src/pages/PyramidPage.test.tsx
+++ b/frontend/src/pages/PyramidPage.test.tsx
@@ -1,7 +1,8 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { actionLogApi, pyramidApi } from '../api/gameApi';
 import { useGameHint } from '../hooks/useGameHint';
+import { PYRAMID_STATS_KEY } from '../hooks/usePyramidStats';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, CardDesign, PyramidCard, PyramidResponse } from '../types/card';
 import { PyramidPage } from './PyramidPage';
@@ -632,5 +633,52 @@ describe('PyramidPage', () => {
     mockExec.mockResolvedValue(playingState);
     fireEvent.click(screen.getByTestId('stalemate-escape-button'));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('undo_n', undefined, undefined, 4));
+  });
+});
+
+// --- Best-record persistence (#3083) ---
+
+describe('PyramidPage best-record', () => {
+  // Clear only the stats key so we don't disturb tutorial-suggest state used by other tests.
+  beforeEach(() => localStorage.removeItem(PYRAMID_STATS_KEY));
+  afterEach(() => localStorage.removeItem(PYRAMID_STATS_KEY));
+
+  it('records the fewest-moves clear and shows the badge, panel, and header chip', async () => {
+    // gameClearState.moveCount is 5.
+    mockExec.mockResolvedValue(gameClearState);
+    renderWithProviders(<PyramidPage />);
+
+    await waitFor(() => expect(screen.getByTestId('py-best-badge')).toBeInTheDocument());
+    expect(screen.getByTestId('py-best-badge')).toHaveTextContent('新記録');
+    expect(screen.getByTestId('py-best-badge')).toHaveTextContent('5');
+    expect(screen.getByTestId('py-stats-panel')).toHaveTextContent('5 手');
+    expect(screen.getByTestId('py-stats-panel')).toHaveTextContent('クリア 1/1');
+    expect(screen.getByTestId('py-best-moves')).toHaveTextContent('5 手');
+    // Persisted for next time.
+    expect(JSON.parse(localStorage.getItem(PYRAMID_STATS_KEY) ?? '{}')).toEqual({
+      plays: 1,
+      wins: 1,
+      fewestMoves: 5,
+    });
+  });
+
+  it('keeps a better existing record and shows no new-best badge for a slower clear', async () => {
+    localStorage.setItem(PYRAMID_STATS_KEY, JSON.stringify({ plays: 1, wins: 1, fewestMoves: 3 }));
+    mockExec.mockResolvedValue(gameClearState); // 5 moves > existing best 3
+    renderWithProviders(<PyramidPage />);
+
+    await waitFor(() => expect(screen.getByTestId('py-stats-panel')).toHaveTextContent('3 手'));
+    expect(screen.queryByTestId('py-best-badge')).not.toBeInTheDocument();
+    expect(screen.getByTestId('py-stats-panel')).toHaveTextContent('クリア 2/2');
+  });
+
+  it('counts a loss without recording a fewest-moves value', async () => {
+    mockExec.mockResolvedValue(gameOverState);
+    renderWithProviders(<PyramidPage />);
+
+    await waitFor(() => expect(screen.getByTestId('py-stats-panel')).toHaveTextContent('クリア 0/1'));
+    expect(screen.getByTestId('py-stats-panel')).toHaveTextContent('—');
+    expect(screen.queryByTestId('py-best-moves')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('py-best-badge')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/PyramidPage.tsx
+++ b/frontend/src/pages/PyramidPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { pyramidApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
@@ -23,6 +23,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePyramidGame } from '../hooks/usePyramidGame';
+import { usePyramidStats } from '../hooks/usePyramidStats';
 import { useSound } from '../providers/SoundProvider';
 import { btnDanger, btnPrimary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -154,6 +155,24 @@ function PyramidPageContent() {
     handleReset();
   }, [handleReset, hideActionLog]);
 
+  // Best-record persistence in localStorage (issue #3083).
+  const { stats, recordResult } = usePyramidStats();
+  const [newBestMoves, setNewBestMoves] = useState(false);
+  // Guard so each finished game is recorded exactly once (phase stays ended across re-renders).
+  const recordedRef = useRef(false);
+  const endPhase = state?.phase;
+  const endMoveCount = state?.moveCount ?? 0;
+  useEffect(() => {
+    const ended = endPhase === PyramidPhase.GAME_CLEAR || endPhase === PyramidPhase.GAME_OVER;
+    if (!ended) {
+      recordedRef.current = false;
+      return;
+    }
+    if (recordedRef.current) return;
+    recordedRef.current = true;
+    setNewBestMoves(recordResult({ won: endPhase === PyramidPhase.GAME_CLEAR, moves: endMoveCount }));
+  }, [endPhase, endMoveCount, recordResult]);
+
   if (!state)
     return <GameSkeleton gameKey="pyramid" layout={{ kind: 'tiered-rows', rows: [1, 2, 3, 4], stockWaste: true }} />;
 
@@ -217,6 +236,11 @@ function PyramidPageContent() {
           <span>
             {t('moveCount')}: {state.moveCount}
           </span>
+          {stats.fewestMoves !== null && (
+            <span data-testid="py-best-moves">
+              {t('bestMoves')}: {t('bestMovesValue', { moves: stats.fewestMoves })}
+            </span>
+          )}
           <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
         </>
       }
@@ -390,6 +414,28 @@ function PyramidPageContent() {
               messageCode={state.messageCode}
               messageParams={state.messageParams}
             />
+
+            {/* New fewest-moves record badge on the clear screen (#3083). */}
+            {isGameClear && newBestMoves && (
+              <div
+                data-testid="py-best-badge"
+                role="status"
+                className="text-center text-ds-success font-semibold text-sm mb-2"
+              >
+                {t('newBestMoves', { moves: state.moveCount })}
+              </div>
+            )}
+
+            {/* Best-record panel: fewest moves + clear tally (#3083). */}
+            <div data-testid="py-stats-panel" className="text-game-text-muted text-xs text-center mb-2">
+              {t('bestMoves')}: {stats.fewestMoves !== null ? t('bestMovesValue', { moves: stats.fewestMoves }) : '—'}
+              {stats.plays > 0 && (
+                <>
+                  {' · '}
+                  {t('clears', { wins: stats.wins, plays: stats.plays })}
+                </>
+              )}
+            </div>
 
             {/* Action log */}
             <ActionLogSection


### PR DESCRIPTION
## 概要 / Summary

ピラミッド（Pyramid）に最少手数クリア記録（ベストレコード）の保存・表示を追加します。フロントエンドのみ（`localStorage` 永続化）で、Go には一切変更なし。

`useTriPeaksStats` / `useSpiderStats` の既存パターンを踏襲した専用フック `usePyramidStats` を新設し、`PyramidPage` に組み込みました。

## 変更点

- **`usePyramidStats`** (`frontend/src/hooks/usePyramidStats.ts`): `localStorage`（キー `trumpcards-pyramid-stats`）に `{ plays, wins, fewestMoves }` を保存。try/catch でガードした永続化 + 純粋関数リデューサ `applyPyramidResult`。手数が正のクリア時のみ `fewestMoves` を更新。
- **`PyramidPage`**: `GAME_CLEAR` / `GAME_OVER` 遷移時に `recordResult` を呼び、ref ガードで 1 ゲームにつき 1 回だけ記録。
  - ヘッダーに「ベスト: N 手」チップ（`data-testid="py-best-moves"`）
  - メッセージ下にベストレコードパネル（最少手数 + クリア数、`data-testid="py-stats-panel"`）
  - 新記録更新時にクリア画面で強調バッジ（`role="status"`, `data-testid="py-best-badge"`）
- i18n: ja/en に `bestMoves` / `bestMovesValue` / `newBestMoves` / `clears` を追加（キー数一致を確認済み）。

## 受け入れ条件

- [x] クリア時に手数が localStorage に保存され、次回以降ヘッダーに表示される
- [x] より少ない手数でクリアした場合のみ更新される
- [x] 新記録時に視覚フィードバック（バッジ強調）が出る
- [x] フックのユニットテストとページテストを追加

## テスト / Gates

- `bun run test -- --run usePyramidStats PyramidPage` → 67 passed
- `bun run check` → 通過（新規警告なし）
- `bun run build`（tsc）→ 通過

Closes #3083

🤖 Generated with [Claude Code](https://claude.com/claude-code)
