### PR TITLE
feat(memory): arrow-key board navigation and flip-result live region

### DIFF
--- a/frontend/src/i18n/locales/en/memory.json
+++ b/frontend/src/i18n/locales/en/memory.json
@@ -29,6 +29,10 @@
   "flipPrompt2": "Flip the second card",
   "matched": "It's a match!",
   "mismatched": "No match",
+  "announce": {
+    "match": "{{first}} / {{second}} — match",
+    "mismatch": "{{first}} / {{second}} — no match"
+  },
   "landscapeBanner": "Rotate to landscape for a better experience",
   "tutorial": {
     "scoreTable": "Each player's pair count is shown here. The player with the most pairs wins.",

--- a/frontend/src/i18n/locales/ja/memory.json
+++ b/frontend/src/i18n/locales/ja/memory.json
@@ -29,6 +29,10 @@
   "flipPrompt2": "2枚目をめくってください",
   "matched": "ペアが揃いました！",
   "mismatched": "残念、不一致です",
+  "announce": {
+    "match": "{{first}} / {{second}} — 一致",
+    "mismatch": "{{first}} / {{second}} — 不一致"
+  },
   "landscapeBanner": "横向きにすると快適にプレイできます",
   "tutorial": {
     "scoreTable": "各プレイヤーのペア数が表示されます。最も多くペアを集めた人が勝ちです。",

--- a/frontend/src/pages/MemoryPage.test.tsx
+++ b/frontend/src/pages/MemoryPage.test.tsx
@@ -576,4 +576,84 @@ describe('MemoryPage', () => {
     renderWithProviders(<MemoryPage />);
     await waitFor(() => expect(screen.getByTestId('hint-tooltip')).toBeInTheDocument());
   });
+
+  // --- Keyboard grid navigation (#3029) ---
+  // matchMedia is mocked to matches:false in test setup, so the grid resolves to
+  // 7 columns (the base breakpoint).
+
+  it('gives the first board cell the roving tab-stop', async () => {
+    renderWithProviders(<MemoryPage />);
+    await waitFor(() => expect(screen.getByText(/あなた: 0/)).toBeInTheDocument());
+    expect(screen.getByTestId('board-0')).toHaveAttribute('tabindex', '0');
+    expect(screen.getByTestId('board-1')).toHaveAttribute('tabindex', '-1');
+  });
+
+  it('ArrowRight moves focus to the next cell', async () => {
+    renderWithProviders(<MemoryPage />);
+    await waitFor(() => expect(screen.getByText(/あなた: 0/)).toBeInTheDocument());
+    fireEvent.keyDown(screen.getByTestId('board-0'), { key: 'ArrowRight' });
+    expect(screen.getByTestId('board-1')).toHaveFocus();
+    expect(screen.getByTestId('board-1')).toHaveAttribute('tabindex', '0');
+    expect(screen.getByTestId('board-0')).toHaveAttribute('tabindex', '-1');
+  });
+
+  it('ArrowDown moves focus down one row (by column count)', async () => {
+    renderWithProviders(<MemoryPage />);
+    await waitFor(() => expect(screen.getByText(/あなた: 0/)).toBeInTheDocument());
+    fireEvent.keyDown(screen.getByTestId('board-0'), { key: 'ArrowDown' });
+    expect(screen.getByTestId('board-7')).toHaveFocus();
+  });
+
+  it('ArrowLeft at the left edge keeps focus clamped', async () => {
+    renderWithProviders(<MemoryPage />);
+    await waitFor(() => expect(screen.getByText(/あなた: 0/)).toBeInTheDocument());
+    const first = screen.getByTestId('board-0');
+    first.focus();
+    fireEvent.keyDown(first, { key: 'ArrowLeft' });
+    expect(first).toHaveFocus();
+    expect(first).toHaveAttribute('tabindex', '0');
+  });
+
+  it('arrow navigation skips taken cells', async () => {
+    // board-1 is taken, so ArrowRight from board-0 lands on board-2.
+    mockExec.mockResolvedValue({
+      ...flip1State,
+      board: makeBoard({ 1: { taken: true } }),
+    });
+    renderWithProviders(<MemoryPage />);
+    await waitFor(() => expect(screen.getByText(/あなた: 0/)).toBeInTheDocument());
+    fireEvent.keyDown(screen.getByTestId('board-0'), { key: 'ArrowRight' });
+    expect(screen.getByTestId('board-2')).toHaveFocus();
+  });
+
+  // --- Flip-result live region (#3029) ---
+
+  it('announces a match result in the polite live region', async () => {
+    mockExec.mockResolvedValue(resultMatchState);
+    renderWithProviders(<MemoryPage />);
+    const region = await screen.findByTestId('mem-flip-announce');
+    expect(region).toHaveAttribute('aria-live', 'polite');
+    expect(region).toHaveAttribute('role', 'status');
+    await waitFor(() => expect(region).toHaveTextContent('♠ A / ♥ A — 一致'));
+  });
+
+  it('announces a mismatch result in the polite live region', async () => {
+    mockExec.mockResolvedValue({
+      ...resultMatchState,
+      lastMatchResult: false,
+      board: makeBoard({
+        0: { faceUp: true, card: { design: 'SPADE' as const, value: 1 } },
+        1: { faceUp: true, card: { design: 'HEART' as const, value: 5 } },
+      }),
+    });
+    renderWithProviders(<MemoryPage />);
+    const region = await screen.findByTestId('mem-flip-announce');
+    await waitFor(() => expect(region).toHaveTextContent('♠ A / ♥ 5 — 不一致'));
+  });
+
+  it('keeps the live region empty outside the result phase', async () => {
+    renderWithProviders(<MemoryPage />);
+    await waitFor(() => expect(screen.getByText(/あなた: 0/)).toBeInTheDocument());
+    expect(screen.getByTestId('mem-flip-announce')).toHaveTextContent('');
+  });
 });

--- a/frontend/src/pages/MemoryPage.tsx
+++ b/frontend/src/pages/MemoryPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { type KeyboardEvent as ReactKeyboardEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { memoryApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
@@ -32,6 +32,7 @@ import { cardAlt } from '../utils/cardAlt';
 import { MEMORY_HELP, parseMemoryCommand } from '../utils/cli/commands/memoryCommands';
 import { formatMemoryState } from '../utils/cli/formatters/memoryFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { type GridDir, moveFocus } from '../utils/gridNav';
 import { playerName } from '../utils/playerUtils';
 
 /** Memory tutorial step definitions. */
@@ -68,6 +69,27 @@ const MEMORY_PHASE_KEYS: Readonly<Record<number, string>> = {
   [MemoryPhase.RESULT]: 'result',
   [MemoryPhase.GAME_END]: 'gameEnd',
 };
+
+/** Maps arrow keys to a grid navigation direction. */
+const ARROW_DIRS: Readonly<Record<string, GridDir>> = {
+  ArrowLeft: 'left',
+  ArrowRight: 'right',
+  ArrowUp: 'up',
+  ArrowDown: 'down',
+};
+
+/**
+ * Column count of the board grid at the current breakpoint, mirroring the
+ * Tailwind `grid-cols-*` classes (7 / 8 / 10 / 13). Falls back to 13 when
+ * `matchMedia` is unavailable (SSR).
+ */
+function boardColumns(): number {
+  if (typeof window === 'undefined' || !window.matchMedia) return 13;
+  if (window.matchMedia('(min-width: 1024px)').matches) return 13;
+  if (window.matchMedia('(min-width: 768px)').matches) return 10;
+  if (window.matchMedia('(min-width: 640px)').matches) return 8;
+  return 7;
+}
 
 /** Renders the Memory card matching game page with board grid and scores. */
 export const MemoryPage = withTutorial(MemoryPageContent, 'memory', MEM_TUTORIAL_STEPS);
@@ -144,6 +166,62 @@ function MemoryPageContent() {
       return changed ? next : prev;
     });
   }, [state]);
+
+  // Roving-focus board navigation (#3029): arrow keys move a single focus index
+  // across the card grid; Enter/Space still natively activate the focused button.
+  const boardRef = useRef<HTMLDivElement>(null);
+  const [focusedIdx, setFocusedIdx] = useState(0);
+  const [cols, setCols] = useState<number>(() => boardColumns());
+
+  useEffect(() => {
+    const onResize = () => setCols(boardColumns());
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, []);
+
+  // Keep the roving tab-stop on a flippable cell: taken (removed) and face-up
+  // cards are disabled/hidden and cannot hold focus.
+  useEffect(() => {
+    const board = state?.board;
+    if (!board) return;
+    const cur = board[focusedIdx];
+    if (cur && !cur.taken && !cur.faceUp) return;
+    const firstIdx = board.findIndex((c) => !c.taken && !c.faceUp);
+    if (firstIdx >= 0) setFocusedIdx(firstIdx);
+  }, [state?.board, focusedIdx]);
+
+  const focusCell = useCallback((idx: number) => {
+    setFocusedIdx(idx);
+    boardRef.current?.querySelector<HTMLButtonElement>(`[data-testid="board-${idx.toString()}"]`)?.focus();
+  }, []);
+
+  const handleBoardKeyDown = useCallback(
+    (e: ReactKeyboardEvent<HTMLDivElement>) => {
+      const dir = ARROW_DIRS[e.key];
+      const board = state?.board;
+      if (!dir || !board) return;
+      e.preventDefault();
+      const skip = (i: number) => {
+        const bc = board[i];
+        return !bc || bc.taken || bc.faceUp;
+      };
+      const target = moveFocus(focusedIdx, dir, cols, board.length, skip);
+      if (target !== focusedIdx) focusCell(target);
+    },
+    [state?.board, cols, focusedIdx, focusCell],
+  );
+
+  // Announce the flip outcome (card faces + match/mismatch) to screen readers.
+  const flipAnnounce = useMemo(() => {
+    if (!state || state.phase !== MemoryPhase.RESULT) return '';
+    const c1 = state.board[state.firstFlipPos]?.card;
+    const c2 = state.board[state.secondFlipPos]?.card;
+    if (!c1 || !c2) return '';
+    return t(state.lastMatchResult ? 'announce.match' : 'announce.mismatch', {
+      first: cardAlt(c1),
+      second: cardAlt(c2),
+    });
+  }, [state, t]);
 
   const handleManualReset = useCallback(() => {
     hideActionLog();
@@ -296,7 +374,12 @@ function MemoryPageContent() {
               className="my-3 lg:my-1 p-1 rounded bg-black/40 lg:flex-1 lg:min-h-0 lg:overflow-hidden"
               data-tutorial="mem-board"
             >
-              <div className="grid grid-cols-7 gap-0.5 sm:gap-1 sm:grid-cols-8 md:grid-cols-10 lg:grid-cols-13 lg:grid-rows-4 lg:h-full">
+              {/* biome-ignore lint/a11y/noStaticElementInteractions: keydown only routes arrow keys for roving focus; the real controls are the child <button>s */}
+              <div
+                ref={boardRef}
+                onKeyDown={handleBoardKeyDown}
+                className="grid grid-cols-7 gap-0.5 sm:gap-1 sm:grid-cols-8 md:grid-cols-10 lg:grid-cols-13 lg:grid-rows-4 lg:h-full"
+              >
                 {state.board.map((bc, idx) => {
                   const wasVisited = !bc.faceUp && !bc.taken && visited.has(idx);
                   return (
@@ -312,6 +395,7 @@ function MemoryPageContent() {
                             : t('cardFaceDown', { position: idx + 1 })
                       }
                       disabled={loading || !isHumanTurn || bc.taken || bc.faceUp}
+                      tabIndex={idx === focusedIdx ? 0 : -1}
                       onClick={() => handleFlip(idx)}
                       className={`memory-card relative aspect-[2/3] min-h-[44px] min-w-[44px] lg:aspect-auto rounded ${focusRingWhite} ${
                         bc.taken
@@ -347,6 +431,11 @@ function MemoryPageContent() {
                 })}
               </div>
             </div>
+
+            {/* Polite live region announcing flip results to screen readers (#3029) */}
+            <span className="sr-only" role="status" aria-live="polite" data-testid="mem-flip-announce">
+              {flipAnnounce}
+            </span>
 
             {frontendHintEnabled && frontendHint && (
               <div className="flex justify-center">

--- a/frontend/src/utils/gridNav.test.ts
+++ b/frontend/src/utils/gridNav.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { moveFocus } from './gridNav';
+
+// 4x3 grid (cols=4, total=12):
+//  0  1  2  3
+//  4  5  6  7
+//  8  9 10 11
+describe('moveFocus', () => {
+  const cols = 4;
+  const total = 12;
+
+  it('moves right/left within a row', () => {
+    expect(moveFocus(5, 'right', cols, total)).toBe(6);
+    expect(moveFocus(5, 'left', cols, total)).toBe(4);
+  });
+
+  it('moves up/down by one column width', () => {
+    expect(moveFocus(5, 'down', cols, total)).toBe(9);
+    expect(moveFocus(5, 'up', cols, total)).toBe(1);
+  });
+
+  it('clamps at the left edge', () => {
+    expect(moveFocus(4, 'left', cols, total)).toBe(4);
+    expect(moveFocus(0, 'left', cols, total)).toBe(0);
+  });
+
+  it('clamps at the right edge', () => {
+    expect(moveFocus(3, 'right', cols, total)).toBe(3);
+    expect(moveFocus(7, 'right', cols, total)).toBe(7);
+  });
+
+  it('clamps at the top edge', () => {
+    expect(moveFocus(2, 'up', cols, total)).toBe(2);
+  });
+
+  it('clamps at the bottom edge', () => {
+    expect(moveFocus(9, 'down', cols, total)).toBe(9);
+  });
+
+  it('does not run past the last cell on a partial final row', () => {
+    // total=10, cols=4 -> last row is 8,9 only
+    expect(moveFocus(9, 'right', cols, 10)).toBe(9);
+    expect(moveFocus(6, 'down', cols, 10)).toBe(6);
+    expect(moveFocus(5, 'down', cols, 10)).toBe(9);
+  });
+
+  it('skips cells flagged by isSkipped', () => {
+    // 5 is skipped, so moving right from 4 lands on 6
+    const skip = (i: number) => i === 5;
+    expect(moveFocus(4, 'right', cols, total, skip)).toBe(6);
+  });
+
+  it('skips multiple consecutive cells', () => {
+    const skip = (i: number) => i === 5 || i === 6;
+    expect(moveFocus(4, 'right', cols, total, skip)).toBe(7);
+  });
+
+  it('stays put when only skipped cells lie ahead before an edge', () => {
+    const skip = (i: number) => i === 6 || i === 7;
+    expect(moveFocus(5, 'right', cols, total, skip)).toBe(5);
+  });
+
+  it('returns index for a degenerate grid', () => {
+    expect(moveFocus(0, 'right', 0, total)).toBe(0);
+    expect(moveFocus(0, 'right', cols, 0)).toBe(0);
+  });
+});

--- a/frontend/src/utils/gridNav.ts
+++ b/frontend/src/utils/gridNav.ts
@@ -1,0 +1,57 @@
+/** Cardinal direction for 2D grid keyboard navigation. */
+export type GridDir = 'left' | 'right' | 'up' | 'down';
+
+/**
+ * Step one cell from `index` in `dir` within a `cols`-wide grid of `total`
+ * cells. Returns the neighbour index, or `null` when the move would leave the
+ * grid (past a row/column edge or beyond the last cell).
+ */
+function step(index: number, dir: GridDir, cols: number, total: number): number | null {
+  const col = index % cols;
+  switch (dir) {
+    case 'left':
+      return col > 0 ? index - 1 : null;
+    case 'right': {
+      const next = index + 1;
+      return col < cols - 1 && next < total ? next : null;
+    }
+    case 'up': {
+      const next = index - cols;
+      return next >= 0 ? next : null;
+    }
+    case 'down': {
+      const next = index + cols;
+      return next < total ? next : null;
+    }
+  }
+}
+
+/**
+ * Move focus across a 2D card grid, clamped at the edges and skipping cells for
+ * which `isSkipped` returns true (e.g. taken or face-up cards). Advances one
+ * step at a time in `dir`, hopping over skipped cells, and returns the new focus
+ * index — or the original `index` when no landable cell exists in that
+ * direction.
+ *
+ * @param index Current focus index (0-based).
+ * @param dir Direction to move.
+ * @param cols Number of columns in the grid.
+ * @param total Total number of cells.
+ * @param isSkipped Predicate marking non-focusable cells; defaults to none.
+ */
+export function moveFocus(
+  index: number,
+  dir: GridDir,
+  cols: number,
+  total: number,
+  isSkipped: (i: number) => boolean = () => false,
+): number {
+  if (cols <= 0 || total <= 0) return index;
+  let cur = index;
+  for (;;) {
+    const next = step(cur, dir, cols, total);
+    if (next === null) return index;
+    if (!isSkipped(next)) return next;
+    cur = next;
+  }
+}


### PR DESCRIPTION
## Summary

Adds keyboard accessibility to the Memory (神経衰弱 / Concentration) board per #3029:

- **Arrow-key 2D navigation**: a single roving `tabindex` moves focus across the
  card grid — Left/Right by ±1, Up/Down by the column count — clamped at edges
  and skipping taken/face-up (non-flippable) cells. Enter/Space still natively
  activate the focused `<button>` (existing flip handler unchanged, no
  double-fire).
- **Flip-result live region**: a `role="status" aria-live="polite"` region
  announces the outcome during the RESULT phase, e.g. `♠ A / ♥ A — 一致` /
  `♠ A / ♥ 5 — 不一致`, localized in ja/en.
- **New pure helper** `moveFocus(index, dir, cols, total, isSkipped)` isolates
  the grid index math (fully unit-tested).

Mouse-click flipping is untouched.

## Files
- `frontend/src/utils/gridNav.ts` (+ `.test.ts`) — pure index-math helper
- `frontend/src/pages/MemoryPage.tsx` (+ `.test.tsx`) — roving focus, keydown router, live region
- `frontend/src/i18n/locales/{ja,en}/memory.json` — `announce.match` / `announce.mismatch`

## Test plan
- [x] `bun run test -- --run MemoryPage src/utils/gridNav` (69 passed)
- [x] `bun run check`
- [x] `bun run build` (tsc)
- [ ] Manual SR pass on the board

Closes #3029
