### PR TITLE
fix(fivecardstud): limit win celebration to human pot wins

### DIFF
--- a/frontend/src/pages/FiveCardStudPage.test.tsx
+++ b/frontend/src/pages/FiveCardStudPage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fiveCardStudApi } from '../api/gameApi';
 import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
@@ -137,6 +137,35 @@ const showdownState: FiveCardStudResponse = {
   dealerIdx: 2,
   currentTurn: -1,
   phase: 5,
+  roundResults: [
+    { playerIdx: 0, handRank: 1, handName: 'ワンペア', kickers: 'A', bestHand: [], wonAmount: 0, mucked: false },
+    { playerIdx: 1, handRank: 2, handName: 'ツーペア', kickers: '8', bestHand: [], wonAmount: 200, mucked: false },
+  ],
+  message: 'CPU 1 の勝ち',
+};
+
+/** END (phase 6) where the human takes the pot (positive wonAmount). */
+const endHumanWinState: FiveCardStudResponse = {
+  ...showdownState,
+  phase: 6,
+  gameEndFlag: true,
+  players: [
+    humanPlayer({ handName: 'ツーペア', chips: 1200 }),
+    cpuPlayer(1, { handName: 'ワンペア', holeCards: [{ design: 'SPADE', value: 5 }] }),
+    cpuPlayer(2, { folded: true }),
+  ],
+  roundResults: [
+    { playerIdx: 0, handRank: 2, handName: 'ツーペア', kickers: 'A', bestHand: [], wonAmount: 200, mucked: false },
+    { playerIdx: 1, handRank: 1, handName: 'ワンペア', kickers: '5', bestHand: [], wonAmount: 0, mucked: false },
+  ],
+  message: 'あなたの勝ち',
+};
+
+/** END (phase 6) where a CPU wins and the human gets nothing. */
+const endHumanLossState: FiveCardStudResponse = {
+  ...showdownState,
+  phase: 6,
+  gameEndFlag: true,
   roundResults: [
     { playerIdx: 0, handRank: 1, handName: 'ワンペア', kickers: 'A', bestHand: [], wonAmount: 0, mucked: false },
     { playerIdx: 1, handRank: 2, handName: 'ツーペア', kickers: '8', bestHand: [], wonAmount: 200, mucked: false },
@@ -335,5 +364,20 @@ describe('FiveCardStudPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
     fireEvent.click(screen.getByRole('button', { name: '確認' }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined, { cpuMetaAI: true }));
+  });
+
+  it('plays the win celebration when the human wins the pot', async () => {
+    mockExec.mockResolvedValue(endHumanWinState);
+    renderWithProviders(<FiveCardStudPage />);
+    expect(await screen.findByTestId('win-celebration')).toBeInTheDocument();
+  });
+
+  it('does not celebrate when the human loses the hand', async () => {
+    mockExec.mockResolvedValue(endHumanLossState);
+    renderWithProviders(<FiveCardStudPage />);
+    await waitFor(() => expect(screen.queryByTestId('skeleton')).not.toBeInTheDocument());
+    // Outwait the celebration's 400ms delay so a wrongly-fired overlay would be visible.
+    await act(() => new Promise((resolve) => setTimeout(resolve, 600)));
+    expect(screen.queryByTestId('win-celebration')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/FiveCardStudPage.tsx
+++ b/frontend/src/pages/FiveCardStudPage.tsx
@@ -161,6 +161,11 @@ function FiveCardStudPageContent() {
   // Door cards revealed so far: Second Street shows 1, then +1 each street up to 4 on Fifth Street.
   const doorCount = Math.min(Math.max(phase - FiveCardStudPhase.SECOND_STREET + 1, 1), 4);
 
+  // Celebrate only when the human wins the pot (positive wonAmount at showdown), not on a fold/loss.
+  const humanWon =
+    phase === FiveCardStudPhase.END &&
+    (state?.roundResults?.some((r) => r.playerIdx === humanIdx && r.wonAmount > 0) ?? false);
+
   const actionBindings = useMemo(
     () => [
       { key: 'c', action: () => execApi('call', undefined, undefined, getElapsed()), enabled: hasOutstandingBet },
@@ -199,7 +204,7 @@ function FiveCardStudPageContent() {
       isHumanTurn={canAct}
       gamePath="/fivecardstud"
       gameEndFlag={phase === FiveCardStudPhase.SHOWDOWN || phase === FiveCardStudPhase.END}
-      winShow={phase === FiveCardStudPhase.END}
+      winShow={humanWon}
       onCelebrate={() => playSound('winFanfare')}
       loading={loading}
       confirmOpen={confirmOpen}


### PR DESCRIPTION
## 概要

Five Card Stud のページでは `winShow={phase === END}` になっていたため、人間がフォールド／敗北してハンドを終えた場合でも紙吹雪の勝利演出と `winFanfare` サウンドが発火していた。他のカジノ系ページ（例: SpoonsPage の `humanWon`）と整合するよう、人間の勝利時のみ演出を出すよう修正した。

## 変更内容

- `state.roundResults` から人間プレイヤー（`playerIdx === humanIdx`）の `wonAmount > 0` を判定する `humanWon` を導出
- `winShow={humanWon}`（END フェーズ かつ 人間がポット獲得時のみ true）に変更
- ページテストで勝利／敗北の両ケースを検証

## テスト計画

- [x] `bun run check`（既存の警告のみ、本変更起因のエラーなし）
- [x] `bun run test -- --run FiveCardStudPage`（21 tests passed）
- [x] `bun run build`（tsc gate 通過）
- [x] 人間がポット獲得時のみ勝利演出が出る
- [x] 人間フォールド／敗北時は winFanfare が鳴らない

Closes #3565