### PR TITLE
feat(russianbank): cascade tableau columns to reveal all buried cards

### DIFF
--- a/frontend/src/pages/RussianBankPage.test.tsx
+++ b/frontend/src/pages/RussianBankPage.test.tsx
@@ -98,6 +98,19 @@ describe('RussianBankPage', () => {
     expect(src).toHaveTextContent('自リザーブ');
   });
 
+  it('renders every card in a multi-card tableau column as a cascade', async () => {
+    const column: Card[] = [card('SPADE', 10), card('HEART', 9), card('SPADE', 8), card('HEART', 7)];
+    mockExec.mockResolvedValue(makeState({ tableau: [column, [], [], []] }));
+    renderWithProviders(<RussianBankPage />);
+    await waitFor(() => expect(screen.getByTestId('tableau-0')).toBeInTheDocument());
+    // All four buried cards are rendered (not just the top one).
+    for (let ci = 0; ci < column.length; ci++) {
+      expect(screen.getByTestId(`tableau-0-card-${ci}`)).toBeInTheDocument();
+    }
+    // The column aria-label still names the top card as the actionable target.
+    expect(screen.getByTestId('tableau-0')).toHaveAttribute('aria-label', expect.stringContaining('タブロー1'));
+  });
+
   it('selects a source then moves it to a tableau column', async () => {
     renderWithProviders(<RussianBankPage />);
     const reserve = await screen.findByTestId('reserve-0');

--- a/frontend/src/pages/RussianBankPage.tsx
+++ b/frontend/src/pages/RussianBankPage.tsx
@@ -244,31 +244,49 @@ function RussianBankPageContent() {
         {/* Shared tableau */}
         <div className="mb-3">
           <span className="text-ds-text-muted text-[11px]">{t('tableauLabel')}</span>
-          <div className="flex gap-2 flex-wrap mt-0.5">
-            {state.tableau.map((col, i) => (
-              <button
-                type="button"
-                key={`tab-${i}`}
-                className={`rounded ${selected ? 'ring-1 ring-ds-success' : ''} ${canAct ? 'cursor-pointer' : ''}`}
-                onClick={canAct ? () => sendToTableau(i) : undefined}
-                disabled={!canAct}
-                data-testid={`tableau-${i}`}
-                aria-label={
-                  col.length > 0
-                    ? t('slotCardZone', { card: cardAlt(col[col.length - 1]), zone: t('srcTableau', { col: i + 1 }) })
-                    : t('slotEmptyZone', { zone: t('srcTableau', { col: i + 1 }) })
-                }
-              >
-                {col.length > 0 ? (
-                  <CardImage card={col[col.length - 1]} width={w} />
-                ) : (
-                  <div
-                    className="rounded border border-dashed border-white/25 bg-black/20"
-                    style={{ width: w, height: Math.round(w * 1.4) }}
-                  />
-                )}
-              </button>
-            ))}
+          <div className="flex gap-2 flex-wrap mt-0.5 items-start">
+            {state.tableau.map((col, i) => {
+              const n = col.length;
+              const cardH = Math.round(w * 1.4);
+              // Reveal every buried card's rank+suit corner via a vertical cascade
+              // instead of showing only the top card. The visible strip auto-compresses
+              // for tall columns so the pile never overruns the board / footer (#3574).
+              const baseStrip = Math.round(w * 0.34);
+              const maxColH = Math.round(cardH * 2.8);
+              const strip = n > 1 ? Math.min(baseStrip, Math.max(1, Math.round((maxColH - cardH) / (n - 1)))) : 0;
+              return (
+                <button
+                  type="button"
+                  key={`tab-${i}`}
+                  className={`relative flex flex-col items-center rounded ${selected ? 'ring-1 ring-ds-success' : ''} ${canAct ? 'cursor-pointer' : ''}`}
+                  onClick={canAct ? () => sendToTableau(i) : undefined}
+                  disabled={!canAct}
+                  data-testid={`tableau-${i}`}
+                  aria-label={
+                    n > 0
+                      ? t('slotCardZone', { card: cardAlt(col[n - 1]), zone: t('srcTableau', { col: i + 1 }) })
+                      : t('slotEmptyZone', { zone: t('srcTableau', { col: i + 1 }) })
+                  }
+                >
+                  {n === 0 ? (
+                    <div
+                      className="rounded border border-dashed border-white/25 bg-black/20"
+                      style={{ width: w, height: cardH }}
+                    />
+                  ) : (
+                    col.map((c, ci) => (
+                      <div
+                        key={`tab-${i}-card-${ci}`}
+                        data-testid={`tableau-${i}-card-${ci}`}
+                        style={{ marginTop: ci === 0 ? 0 : -(cardH - strip) }}
+                      >
+                        <CardImage card={c} width={w} />
+                      </div>
+                    ))
+                  )}
+                </button>
+              );
+            })}
           </div>
         </div>
 


### PR DESCRIPTION
## 概要
Russian Bank（クラペット）の共有タブロー各列を、最上段カードのみ描画する方式から、全カードを縦の重なり表示（カスケード）にする。列の下に埋まっているカードのランク・スートの角が見えるようになり、どの列を掘るかの移動計画が立てられる。

## 変更点
- `RussianBankPage.tsx`: タブロー列を `LaBelleLucie` の `renderFan` と同じ負マージン積層パターンで描画。列全体は従来どおり単一ボタンで `sendToTableau(i)` を呼ぶため、選択・移動動作は不変。
- 枚数が多い列は可視ストリップ幅を自動圧縮し、フッターと干渉しないよう最大高さを制限。
- 空列は従来どおり破線スロットを表示。
- `RussianBankPage.test.tsx`: 複数枚列の全カードが描画されることを検証するテストを追加（`tableau-0-card-{0..3}`）。

## 受け入れ条件
- [x] タブロー列の全カードが重なり表示で確認できる
- [x] 列クリックの選択・移動動作が従来と同一（`sendToTableau` / aria-label は最上段カードを対象のまま）
- [x] モバイル幅でもレイアウトが崩れない（`flex-wrap` + `items-start` + 高さ上限で圧縮）
- [x] `RussianBankPage.test.tsx` に複数枚表示のテストを追加

## テスト
- `bun run check` OK
- `bun run test -- --run RussianBankPage` 12 passed
- `bun run build` OK

Closes #3574