### PR TITLE
feat(catchten): trigger win celebration on human team win

### DIFF
--- a/frontend/src/pages/CatchTenPage.test.tsx
+++ b/frontend/src/pages/CatchTenPage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { catchtenApi } from '../api/gameApi';
 import { renderWithProviders } from '../test/renderWithProviders';
@@ -143,6 +143,29 @@ describe('CatchTenPage', () => {
     const team1Chips = screen.getAllByText('チーム 1').filter((el) => el.className.includes('text-ds-error'));
     expect(team0Chips.length).toBeGreaterThan(0);
     expect(team1Chips.length).toBeGreaterThan(0);
+  });
+
+  it('plays the win celebration when the human team wins', async () => {
+    mockExec.mockResolvedValue(gameEndState); // winnerTeam: 0 = human team
+    renderWithProviders(<CatchTenPage />);
+    expect(await screen.findByTestId('win-celebration')).toBeInTheDocument();
+  });
+
+  it('does not celebrate when the CPU team wins', async () => {
+    mockExec.mockResolvedValue(makeState({ phase: 3, gameEndFlag: true, winnerTeam: 1 }));
+    renderWithProviders(<CatchTenPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument());
+    // Outwait the celebration's 400ms delay so a wrongly-fired overlay would be visible.
+    await act(() => new Promise((resolve) => setTimeout(resolve, 600)));
+    expect(screen.queryByTestId('win-celebration')).not.toBeInTheDocument();
+  });
+
+  it('does not celebrate on a draw (winnerTeam -1)', async () => {
+    mockExec.mockResolvedValue(makeState({ phase: 3, gameEndFlag: true, winnerTeam: -1 }));
+    renderWithProviders(<CatchTenPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument());
+    await act(() => new Promise((resolve) => setTimeout(resolve, 600)));
+    expect(screen.queryByTestId('win-celebration')).not.toBeInTheDocument();
   });
 
   it('names the recommended card (suit + rank) in the hint text', async () => {

--- a/frontend/src/pages/CatchTenPage.tsx
+++ b/frontend/src/pages/CatchTenPage.tsx
@@ -25,6 +25,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
+import { useSound } from '../providers/SoundProvider';
 import { btnPrimary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -127,6 +128,12 @@ function CatchTenPageContent() {
     setHintEnabled: setFrontendHintEnabled,
   } = useGameHint('catchten', state);
   const { cardWidth, isMobile } = useCardDimensions();
+  const { playSound } = useSound();
+  // Memoized so WinCelebration's effect (which depends on onCelebrate) does not
+  // re-arm its timer — and replay the fanfare — on every post-win re-render.
+  const handleCelebrate = useCallback(() => {
+    playSound('winFanfare');
+  }, [playSound]);
 
   // CLI mode
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('catchten');
@@ -194,6 +201,11 @@ function CatchTenPageContent() {
   const isGameEnd = state.phase === CatchTenPhase.GAME_END || state.gameEndFlag;
   const isHumanTurn = isPlayPhase && state.players[state.currentPlayerIdx]?.isHuman === true;
 
+  // The human sits at seat 0, so team 0 is the human team. A draw
+  // (CatchTenDrawTeam → winnerTeam < 0) never satisfies this, so the
+  // celebration only fires for the human team's outright win.
+  const humanWon = isGameEnd && state.winnerTeam === 0;
+
   // Render a CPU player's stats as a definition list so screen readers
   // announce each field (hand size, team, cumulative/round score) as an
   // independent item instead of one long pipe-joined sentence. The visual `|`
@@ -250,6 +262,8 @@ function CatchTenPageContent() {
       isHumanTurn={isHumanTurn}
       gamePath="/catchten"
       gameEndFlag={!!state?.gameEndFlag}
+      winShow={humanWon}
+      onCelebrate={handleCelebrate}
       loading={loading}
       confirmOpen={confirmOpen}
       confirmReset={confirmReset}


### PR DESCRIPTION
## 概要

Catch the Ten（`catchten`）の勝利演出（`winShow`）が `GamePageShell` に未接続だったため、人間チームの勝利時にコンフェッティ演出も `winFanfare` サウンドも一切発火しませんでした。`DurakPage` / `TwoTenJackPage` と同じパターンで接続します。

## 変更内容

- `CatchTenPageContent` に `humanWon = isGameEnd && state.winnerTeam === 0` を算出（人間は座席0＝チーム0）
- `GamePageShell` に `winShow={humanWon}` と `onCelebrate={handleCelebrate}` を渡し、`winFanfare` サウンドと連動
- 引き分け（`CatchTenDrawTeam` → `winnerTeam < 0`）や CPU チーム勝利では演出は発火しない
- `useCallback` でメモ化し、勝利後の再レンダーでファンファーレが再生されないようにした

## テスト

`frontend/src/pages/CatchTenPage.test.tsx` に3件追加（計13件パス）:
- `plays the win celebration when the human team wins`
- `does not celebrate when the CPU team wins`
- `does not celebrate on a draw (winnerTeam -1)`

## 受け入れ条件

- [x] `humanWon` の算出ロジックを `CatchTenPageContent` に追加
- [x] `GamePageShell` に `winShow={humanWon}` を渡す
- [x] 引き分け（`CatchTenDrawTeam`）では演出が発火しないことを確認
- [x] `winFanfare` サウンド呼び出しと連動（`onCelebrate`）

## ゲート

- [x] `bun run check`（exit 0）
- [x] `bun run test -- --run CatchTenPage`（13 passed）
- [x] `bun run build`（tsc, exit 0）

Note: フロントエンドのみの変更です。issue に挙がっていた Go 側（`CatchTenCuiPresenter.go`）は winShow 接続に不要のため未変更。

Closes #3160
