### PR TITLE
feat(irishpoker): stage per-candidate discard preview at first pick

### DIFF
--- a/frontend/src/i18n/locales/en/irishpoker.json
+++ b/frontend/src/i18n/locales/en/irishpoker.json
@@ -22,6 +22,7 @@
     "selectedCount": "{{n}}/{{total}} selected",
     "keepLabel": "Keep",
     "previewHand": "Tentative hand",
+    "candidateHand": "If also discarded",
     "limitReached": "You can select up to {{count}} card(s). Deselect one first.",
     "limitDescription": "You can select at most {{count}} card(s) to discard."
   },

--- a/frontend/src/i18n/locales/ja/irishpoker.json
+++ b/frontend/src/i18n/locales/ja/irishpoker.json
@@ -22,6 +22,7 @@
     "selectedCount": "{{n}}/{{total}} 枚選択済み",
     "keepLabel": "残す札",
     "previewHand": "暫定役",
+    "candidateHand": "この札も捨てると",
     "limitReached": "選択できるのは{{count}}枚までです。先に選択を解除してください",
     "limitDescription": "ディスカードで選択できるのは最大{{count}}枚です"
   },

--- a/frontend/src/pages/PineapplePage.test.tsx
+++ b/frontend/src/pages/PineapplePage.test.tsx
@@ -407,6 +407,119 @@ describe('PineapplePage', () => {
     expect(preview).toHaveTextContent('ワンペア');
   });
 
+  it('annotates each remaining Irish Poker card once the first discard is chosen', async () => {
+    const irishDiscardState: PineappleResponse = {
+      ...discardState,
+      initialDealCount: 4,
+      players: [
+        humanPlayer({
+          cards: [
+            { design: 'SPADE', value: 1 },
+            { design: 'HEART', value: 1 },
+            { design: 'DIAMOND', value: 5 },
+            { design: 'CLOVER', value: 8 },
+          ],
+        }),
+        cpuPlayer(1),
+        cpuPlayer(2),
+        cpuPlayer(3),
+      ],
+      communityCards: [
+        { design: 'SPADE', value: 10 },
+        { design: 'HEART', value: 5 },
+        { design: 'DIAMOND', value: 8 },
+      ],
+      discardDone: [false, true, true, true],
+    };
+    mockIrishExec.mockResolvedValue(irishDiscardState);
+    renderWithProviders(<PineapplePage variant="irishpoker" />);
+    await waitFor(() => expect(screen.getByTestId('discard-controls')).toBeInTheDocument());
+
+    // Choose only the FIRST discard (♦5): a staged preview should appear for each
+    // of the three still-selectable cards (the candidate second discards).
+    fireEvent.click(screen.getByAltText('♦ 5').closest('button') as HTMLButtonElement);
+
+    const labels = await screen.findAllByTestId('irishpoker-discard-candidate');
+    expect(labels).toHaveLength(3); // one per remaining card, excluding the chosen one
+    // Every kept pair (Aces or eights) makes at least one pair with the board.
+    for (const label of labels) expect(label).toHaveTextContent('ワンペア');
+    // The full two-card kept preview is not shown yet (only one card selected).
+    expect(screen.queryByTestId('irishpoker-discard-preview')).not.toBeInTheDocument();
+  });
+
+  it('switches from staged candidates to the kept preview at the second Irish Poker discard', async () => {
+    const irishDiscardState: PineappleResponse = {
+      ...discardState,
+      initialDealCount: 4,
+      players: [
+        humanPlayer({
+          cards: [
+            { design: 'SPADE', value: 1 },
+            { design: 'HEART', value: 1 },
+            { design: 'DIAMOND', value: 5 },
+            { design: 'CLOVER', value: 8 },
+          ],
+        }),
+        cpuPlayer(1),
+        cpuPlayer(2),
+        cpuPlayer(3),
+      ],
+      communityCards: [
+        { design: 'SPADE', value: 10 },
+        { design: 'HEART', value: 5 },
+        { design: 'DIAMOND', value: 8 },
+      ],
+      discardDone: [false, true, true, true],
+    };
+    mockIrishExec.mockResolvedValue(irishDiscardState);
+    renderWithProviders(<PineapplePage variant="irishpoker" />);
+    await waitFor(() => expect(screen.getByTestId('discard-controls')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByAltText('♦ 5').closest('button') as HTMLButtonElement);
+    expect(await screen.findAllByTestId('irishpoker-discard-candidate')).toHaveLength(3);
+
+    // Selecting the second discard hands off to the full kept-cards preview.
+    fireEvent.click(screen.getByAltText('♣ 8').closest('button') as HTMLButtonElement);
+    expect(await screen.findByTestId('irishpoker-discard-preview')).toBeInTheDocument();
+    expect(screen.queryAllByTestId('irishpoker-discard-candidate')).toHaveLength(0);
+
+    // Deselecting one card returns to the staged, per-candidate previews.
+    fireEvent.click(screen.getByAltText('♣ 8').closest('button') as HTMLButtonElement);
+    expect(await screen.findAllByTestId('irishpoker-discard-candidate')).toHaveLength(3);
+    expect(screen.queryByTestId('irishpoker-discard-preview')).not.toBeInTheDocument();
+  });
+
+  it('does not stage Irish Poker candidate previews before any card is chosen', async () => {
+    const irishDiscardState: PineappleResponse = {
+      ...discardState,
+      initialDealCount: 4,
+      players: [
+        humanPlayer({
+          cards: [
+            { design: 'SPADE', value: 1 },
+            { design: 'HEART', value: 1 },
+            { design: 'DIAMOND', value: 5 },
+            { design: 'CLOVER', value: 8 },
+          ],
+        }),
+        cpuPlayer(1),
+        cpuPlayer(2),
+        cpuPlayer(3),
+      ],
+      communityCards: [
+        { design: 'SPADE', value: 10 },
+        { design: 'HEART', value: 5 },
+        { design: 'DIAMOND', value: 8 },
+      ],
+      discardDone: [false, true, true, true],
+    };
+    mockIrishExec.mockResolvedValue(irishDiscardState);
+    renderWithProviders(<PineapplePage variant="irishpoker" />);
+    await waitFor(() => expect(screen.getByTestId('discard-controls')).toBeInTheDocument());
+    // No discard chosen yet → no staged candidate annotations.
+    expect(screen.queryByTestId('irishpoker-discard-candidate')).not.toBeInTheDocument();
+  });
+
   it('evaluates the best five when the board has more than three cards', async () => {
     const irishRiverState: PineappleResponse = {
       ...discardState,

--- a/frontend/src/pages/PineapplePage.tsx
+++ b/frontend/src/pages/PineapplePage.tsx
@@ -272,6 +272,26 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
       return rank == null ? null : pokerHandKey(rank);
     });
   }, [variant, isDiscardPhase, humanPlayer, state?.communityCards]);
+  // Irish Poker discards 2 of 4 hole cards. Once the FIRST card is chosen, annotate
+  // each still-selectable card with the best hand the OTHER two kept cards would make
+  // with the board if that card became the second discard — turning the C(3,1)=3
+  // remaining choices into a side-by-side comparison before the pair is committed.
+  // (At 2 selected, the full `discardPreview` above takes over instead.)
+  const irishCandidatePreviews = useMemo<(string | null)[] | null>(() => {
+    if (variant !== 'irishpoker' || !isDiscardPhase) return null;
+    if (selectedDiscards.length !== discardCount - 1) return null;
+    const hole = humanPlayer?.cards ?? [];
+    const board = state?.communityCards ?? [];
+    return hole.map((_, idx) => {
+      // The already-selected card is marked as selected, not annotated.
+      if (selectedDiscards.includes(idx)) return null;
+      const kept = hole.filter((_, i) => i !== idx && !selectedDiscards.includes(i));
+      const all = [...kept, ...board];
+      const picked = holdemBestFive(all);
+      const rank = picked ? evaluateFiveCardHand(picked.map((i) => all[i])) : null;
+      return rank == null ? null : pokerHandKey(rank);
+    });
+  }, [variant, isDiscardPhase, humanPlayer, state?.communityCards, selectedDiscards, discardCount]);
   // Plain Pineapple discards 1 of 3 preflop (before any board), so a board-based
   // preview is impossible. Instead annotate each hole card with the qualitative
   // shape (pair / suited / connector / high card) the OTHER two would keep, a
@@ -541,6 +561,7 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
                         const inBest = showdownBest5.holeSet.has(idx);
                         const dim = showdownBest5.holeSet.size > 0 && !inBest;
                         const candKey = candidatePreviews?.[idx] ?? null;
+                        const irishCandKey = irishCandidatePreviews?.[idx] ?? null;
                         const keepFeatures = keepFeaturePreviews?.[idx] ?? null;
                         return (
                           <div key={`${card.design}-${card.value}`} className="flex flex-col items-center">
@@ -561,6 +582,14 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
                                 data-testid="cp-discard-candidate"
                               >
                                 {`${t('discard.candidateHand')}: ${t(`hand.${candKey}`)}`}
+                              </span>
+                            )}
+                            {irishCandKey && (
+                              <span
+                                className="mt-0.5 text-[10px] text-ds-text-muted"
+                                data-testid="irishpoker-discard-candidate"
+                              >
+                                {`${t('discard.candidateHand')}: ${t(`hand.${irishCandKey}`)}`}
                               </span>
                             )}
                             {keepFeatures && (


### PR DESCRIPTION
## Summary

Irish Poker deals 4 hole cards and discards 2 after the flop betting round. Previously, the discard preview (`discardPreview`) only appeared once **both** cards were selected — at the first pick the player got zero feedback and had to mentally evaluate the C(4,2)=6 options.

This adds a **staged preview**: as soon as the first discard is chosen, each of the three still-selectable cards is annotated with the best hand the *other two kept cards* would make with the board if that card became the second discard. At two cards selected, the existing full kept-cards preview takes over; deselecting a card returns to the staged annotations.

- **Additive only** — the discard command/flow is unchanged.
- **Scoped to `irishpoker`** — pineapple and crazypineapple (which share `PineapplePage.tsx`) are untouched; all their tests still pass.
- Reuses `holdemBestFive` + `evaluateFiveCardHand` + `pokerHandKey` (no new evaluation logic).
- New i18n key `discard.candidateHand` (ja/en).

## Acceptance criteria
- [x] 1枚選択時に残り候補ごとのプレビューが表示される (`irishpoker-discard-candidate` × 3)
- [x] 2枚選択時は既存の `discardPreview` 表示に切り替わる
- [x] 選択解除で表示が更新される
- [x] プレビュー計算のユニットテストを追加する

## Tests
Added to `PineapplePage.test.tsx`:
- `annotates each remaining Irish Poker card once the first discard is chosen`
- `switches from staged candidates to the kept preview at the second Irish Poker discard`
- `does not stage Irish Poker candidate previews before any card is chosen`

## Gates
- `bun run check` ✅
- `bun run test -- --run Pineapple` ✅ (71 passed)
- `bun run test -- --run IrishPoker` ✅ (7 passed)
- `bun run build` (tsc) ✅

Closes #3024

🤖 Generated with [Claude Code](https://claude.com/claude-code)