### PR TITLE
feat(clocksolitaire): animate autoplay as step-by-step placements

### DIFF
--- a/frontend/e2e/clocksolitaire.spec.ts
+++ b/frontend/e2e/clocksolitaire.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { navigateTo, waitForLoaded } from './helpers';
+import { navigateTo, TIMEOUT_LOADED, waitForLoaded } from './helpers';
 
 test.describe('Clock Solitaire E2E', () => {
   test('navigates and plays steps', async ({ page }) => {
@@ -16,15 +16,22 @@ test.describe('Clock Solitaire E2E', () => {
   });
 
   test('autoplay completes the game', async ({ page }) => {
+    // Autoplay now animates each move via a client-side stepped loop; seed the
+    // fastest speed so the full run stays well within the wait budget.
+    await page.addInitScript(() => {
+      window.localStorage.setItem('clocksolitaire:autoPlaySpeed', 'fast');
+    });
     await navigateTo(page, '/clocksolitaire');
 
     // Click autoplay
     const autoplayButton = page.getByRole('button', { name: 'オートプレイ' });
     await expect(autoplayButton).toBeVisible();
     await autoplayButton.click();
-    await waitForLoaded(page);
 
-    // After autoplay, step/autoplay buttons should not be visible
-    await expect(page.getByRole('button', { name: 'ステップ' })).not.toBeVisible();
+    // The stepped autoplay animates every placement until the game ends, at
+    // which point the step/autoplay controls are removed. Wait for completion.
+    await expect(page.getByRole('button', { name: 'ステップ' })).not.toBeVisible({
+      timeout: TIMEOUT_LOADED,
+    });
   });
 });

--- a/frontend/src/i18n/locales/en/clocksolitaire.json
+++ b/frontend/src/i18n/locales/en/clocksolitaire.json
@@ -8,7 +8,15 @@
   "stepCount": "Steps",
   "step": "Step",
   "autoplay": "Auto Play",
+  "stopAutoplay": "Stop",
   "currentCard": "Current Card",
+  "settings": {
+    "speed": "Animation Speed",
+    "speedHelp": "Choose how fast each card's landing animation plays during auto play. Faster races through the placements.",
+    "speedSlow": "Slow",
+    "speedNormal": "Normal",
+    "speedFast": "Fast"
+  },
   "center": "Center(K)",
   "playing": "Playing",
   "gameClear": "Game Clear! Steps: {{stepCount}}",

--- a/frontend/src/i18n/locales/ja/clocksolitaire.json
+++ b/frontend/src/i18n/locales/ja/clocksolitaire.json
@@ -8,7 +8,15 @@
   "stepCount": "ステップ数",
   "step": "ステップ",
   "autoplay": "オートプレイ",
+  "stopAutoplay": "停止",
   "currentCard": "手持ちカード",
+  "settings": {
+    "speed": "演出速度",
+    "speedHelp": "オートプレイ中に1手ごとの着地演出をどれくらいの速さで再生するかを選びます。速いほど一気に配置が進みます。",
+    "speedSlow": "ゆっくり",
+    "speedNormal": "普通",
+    "speedFast": "高速"
+  },
   "center": "中央(K)",
   "playing": "プレイ中",
   "gameClear": "ゲームクリア！ ステップ数: {{stepCount}}",

--- a/frontend/src/pages/ClockSolitairePage.test.tsx
+++ b/frontend/src/pages/ClockSolitairePage.test.tsx
@@ -1,5 +1,5 @@
-import { screen, waitFor } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { clocksolitaireApi } from '../api/gameApi';
 import { useCliMode } from '../hooks/useCliMode';
 import { renderWithProviders } from '../test/renderWithProviders';
@@ -78,6 +78,10 @@ const gameOverState: ClockSolitaireResponse = {
 beforeEach(() => {
   vi.clearAllMocks();
   mockExec.mockResolvedValue(playingState);
+});
+
+afterEach(() => {
+  localStorage.removeItem('clocksolitaire:autoPlaySpeed');
 });
 
 describe('ClockSolitairePage', () => {
@@ -249,5 +253,95 @@ describe('ClockSolitairePage', () => {
     renderWithProviders(<ClockSolitairePage />);
     await waitFor(() => expect(screen.getByText(/ステップ数/)).toBeInTheDocument());
     expect(document.querySelectorAll('[data-flight-target="true"]')).toHaveLength(0);
+  });
+
+  it('autoplay auto-advances via repeated step calls and stops at game clear', async () => {
+    restoreCliModeDefault();
+    vi.useFakeTimers();
+    try {
+      // reset (mount) → playing, then two client-driven steps; the second clears the game.
+      mockExec
+        .mockReset()
+        .mockResolvedValueOnce(playingState) // reset on mount
+        .mockResolvedValueOnce(playingState) // step 1
+        .mockResolvedValueOnce(gameClearState) // step 2 → game clear
+        .mockResolvedValue(gameClearState);
+      renderWithProviders(<ClockSolitairePage />);
+      // Flush the mount reset.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      fireEvent.click(screen.getByTestId('cs-autoplay-button'));
+      // Two normal-speed ticks (450ms each) place two cards, then the game clears.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(450);
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(450);
+      });
+      // Any further ticks must not fire more steps once the game has ended.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2000);
+      });
+      const stepCalls = mockExec.mock.calls.filter(([cmd]) => cmd === 'step');
+      expect(stepCalls).toHaveLength(2);
+      // Client-driven autoplay never hits the single-shot server command.
+      expect(mockExec).not.toHaveBeenCalledWith('autoplay');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('faster speed shortens the auto-advance interval', async () => {
+    restoreCliModeDefault();
+    vi.useFakeTimers();
+    try {
+      mockExec.mockReset().mockResolvedValue(playingState);
+      renderWithProviders(<ClockSolitairePage />);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      // Switch to fast (150ms delay) before starting autoplay.
+      fireEvent.change(screen.getByTestId('autoplay-speed-select'), { target: { value: 'fast' } });
+      fireEvent.click(screen.getByTestId('cs-autoplay-button'));
+      // 150ms is enough at fast speed but would be too short at the 450ms normal delay.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(150);
+      });
+      expect(mockExec).toHaveBeenCalledWith('step');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('renders the animation speed selector persisted to localStorage', async () => {
+    restoreCliModeDefault();
+    renderWithProviders(<ClockSolitairePage />);
+    const select = (await screen.findByTestId('autoplay-speed-select')) as HTMLSelectElement;
+    expect(select.value).toBe('normal');
+    fireEvent.change(select, { target: { value: 'slow' } });
+    expect(select.value).toBe('slow');
+    expect(localStorage.getItem('clocksolitaire:autoPlaySpeed')).toBe('slow');
+  });
+
+  it('toggles the autoplay button label and disables step while autoplaying', async () => {
+    restoreCliModeDefault();
+    vi.useFakeTimers();
+    try {
+      mockExec.mockReset().mockResolvedValue(playingState);
+      renderWithProviders(<ClockSolitairePage />);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      const autoBtn = screen.getByTestId('cs-autoplay-button');
+      expect(autoBtn).toHaveTextContent('オートプレイ');
+      expect(screen.getByTestId('cs-step-button')).not.toBeDisabled();
+      fireEvent.click(autoBtn);
+      expect(autoBtn).toHaveTextContent('停止');
+      expect(autoBtn).toHaveAttribute('aria-pressed', 'true');
+      expect(screen.getByTestId('cs-step-button')).toBeDisabled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/frontend/src/pages/ClockSolitairePage.tsx
+++ b/frontend/src/pages/ClockSolitairePage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { clocksolitaireApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
@@ -66,14 +66,90 @@ const CLOCK_POSITIONS = Array.from({ length: 12 }, (_, i) => {
 /** Labels for clock positions (1-12). */
 const CLOCK_LABELS = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12'];
 
+/** Autoplay animation speed presets. */
+type AutoPlaySpeed = 'slow' | 'normal' | 'fast';
+
+/**
+ * Delay (ms) between auto-advanced `step` calls per speed preset. A larger delay
+ * gives each card's `isFlightTarget` landing highlight more time to play out; a
+ * smaller delay races to the finish.
+ */
+const AUTOPLAY_DELAY_MS: Record<AutoPlaySpeed, number> = {
+  slow: 900,
+  normal: 450,
+  fast: 150,
+};
+
+const AUTOPLAY_SPEED_STORAGE_KEY = 'clocksolitaire:autoPlaySpeed';
+
+/** Read the persisted autoplay speed, falling back to `normal` when unset/invalid. */
+function loadAutoPlaySpeed(): AutoPlaySpeed {
+  try {
+    const v = localStorage.getItem(AUTOPLAY_SPEED_STORAGE_KEY);
+    if (v === 'slow' || v === 'normal' || v === 'fast') return v;
+  } catch {
+    // localStorage may be unavailable (private mode / SSR); fall through to default.
+  }
+  return 'normal';
+}
+
 /** Clock Solitaire page content component. */
 function ClockSolitairePageContent() {
   const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
     useGamePageSetup('clocksolitaire');
   const { state, loading, error, exec: execApi, retry } = useGameApi(clocksolitaireApi.exec);
-  const handleReset = useCallback(() => execApi('reset'), [execApi]);
+
+  const [autoPlaySpeed, setAutoPlaySpeed] = useState<AutoPlaySpeed>(loadAutoPlaySpeed);
+  const [autoPlaying, setAutoPlaying] = useState(false);
+
   const handleStep = useCallback(() => execApi('step'), [execApi]);
-  const handleAutoPlay = useCallback(() => execApi('autoplay'), [execApi]);
+  // Autoplay is driven client-side as a timed sequence of `step` calls (see the
+  // effect below) so each card's landing highlight plays out; the button toggles it.
+  const handleAutoPlay = useCallback(() => setAutoPlaying((prev) => !prev), []);
+  const handleSelectSpeed = useCallback((v: string) => {
+    const speed: AutoPlaySpeed = v === 'slow' || v === 'fast' ? v : 'normal';
+    setAutoPlaySpeed(speed);
+    try {
+      localStorage.setItem(AUTOPLAY_SPEED_STORAGE_KEY, speed);
+    } catch {
+      // Persistence is best-effort; ignore storage failures.
+    }
+  }, []);
+  const handleReset = useCallback(() => {
+    setAutoPlaying(false);
+    return execApi('reset');
+  }, [execApi]);
+
+  // Latest state/speed read from a self-scheduling autoplay loop without
+  // re-subscribing the effect on every render.
+  const stateRef = useRef(state);
+  stateRef.current = state;
+  const speedRef = useRef(autoPlaySpeed);
+  speedRef.current = autoPlaySpeed;
+
+  // Drive autoplay client-side: recursively `step` on a speed-scaled timer so each
+  // card's `isFlightTarget` landing highlight plays out, stopping as soon as the
+  // game reaches GAME_CLEAR / GAME_OVER.
+  useEffect(() => {
+    if (!autoPlaying) return;
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout>;
+    const tick = async () => {
+      const s = stateRef.current;
+      if (!s || s.phase !== ClockSolitairePhase.PLAYING) {
+        setAutoPlaying(false);
+        return;
+      }
+      await execApi('step');
+      if (cancelled) return;
+      timer = setTimeout(() => void tick(), AUTOPLAY_DELAY_MS[speedRef.current]);
+    };
+    timer = setTimeout(() => void tick(), AUTOPLAY_DELAY_MS[speedRef.current]);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [autoPlaying, execApi]);
 
   useMountReset(execApi);
   const { cardWidth, cardHeight } = useCardDimensions();
@@ -324,6 +400,20 @@ function ClockSolitairePageContent() {
               {
                 items: [
                   {
+                    type: 'select' as const,
+                    id: 'autoPlaySpeed',
+                    testId: 'autoplay-speed-select',
+                    label: t('settings.speed'),
+                    tooltip: t('settings.speedHelp'),
+                    value: autoPlaySpeed,
+                    options: [
+                      { value: 'slow', label: t('settings.speedSlow') },
+                      { value: 'normal', label: t('settings.speedNormal') },
+                      { value: 'fast', label: t('settings.speedFast') },
+                    ],
+                    onSelect: handleSelectSpeed,
+                  },
+                  {
                     type: 'checkbox' as const,
                     id: 'frontendHint',
                     label: tc('hint.toggle', { ns: 'tutorial' }),
@@ -343,7 +433,8 @@ function ClockSolitairePageContent() {
                     type="button"
                     className={`${btnPrimary} ${focusRingWhite}`}
                     onClick={handleStep}
-                    disabled={loading}
+                    disabled={loading || autoPlaying}
+                    data-testid="cs-step-button"
                   >
                     {t('step')}
                   </button>
@@ -351,9 +442,10 @@ function ClockSolitairePageContent() {
                     type="button"
                     className={`${btnSuccess} ${focusRingWhite}`}
                     onClick={handleAutoPlay}
-                    disabled={loading}
+                    aria-pressed={autoPlaying}
+                    data-testid="cs-autoplay-button"
                   >
-                    {t('autoplay')}
+                    {autoPlaying ? t('stopAutoplay') : t('autoplay')}
                   </button>
                 </div>
               )}


### PR DESCRIPTION
Closes #3122

## 概要
クロックソリティアのオートプレイを、サーバーの `autoplay` を1回呼んで最終状態に飛ぶ方式から、フロント側で `step` を一定間隔で連続呼び出しする自己スケジューリングループに変更しました。これにより1手ごとの `isFlightTarget` 着地演出（`ring-2 ring-ds-warning animate-pulse`）が再生され、通常のステップ操作と演出の一貫性が取れます。WarPage (#4127) と同じパターンを踏襲しています。

## 変更点
- オートプレイを client-side の `setTimeout` 自己スケジューリングループ（`step` の連続呼び出し）に変換
- `GAME_CLEAR` / `GAME_OVER` に到達したら即座に停止
- オートプレイボタンを開始/停止トグル化（`aria-pressed`）、オートプレイ中はステップボタンを無効化
- 演出速度セレクタ（ゆっくり/普通/高速）を共有 `SettingsPanel` に追加し、`localStorage` に永続化
- リセット時に進行中のオートプレイを停止
- 既存の `autoplay` サーバーAPI・CLI コマンドは変更なし（フロントのみ対応）

## 受け入れ条件
- [x] オートプレイ中も1手ごとに `isFlightTarget` の着地演出が再生される
- [x] 演出速度をユーザーが調整できる（slow/normal/fast、localStorage 永続化）
- [x] 途中で `GAME_OVER`/`GAME_CLEAR` になった場合は即座に停止する
- [x] 既存の `autoplay` API コール自体は変更不要（フロント側のみ）

## テスト
- `frontend/src/pages/ClockSolitairePage.test.tsx` にフェイクタイマーで以下を追加（計25 tests green）
  - `autoplay auto-advances via repeated step calls and stops at game clear`
  - `faster speed shortens the auto-advance interval`
  - `renders the animation speed selector persisted to localStorage`
  - `toggles the autoplay button label and disables step while autoplaying`

## Gate
- [x] `bun run check`
- [x] `bun run test -- --run ClockSolitairePage`
- [x] `bun run build`
