### PR TITLE
feat(bigohilo): add scoop celebration badge when a player wins both hi and lo

### DIFF
--- a/frontend/src/i18n/locales/en/bigohilo.json
+++ b/frontend/src/i18n/locales/en/bigohilo.json
@@ -6,6 +6,10 @@
     "winner": "{{name}} (+{{amount}})",
     "hiTakesAll": "No qualifying low — Hi scoops the pot"
   },
+  "scoop": {
+    "badge": "🏆 Scoop! {{name}} takes both Hi & Lo (+{{total}})",
+    "youBadge": "🏆 Scoop! You take both Hi & Lo (+{{total}})"
+  },
   "phase": {
     "preFlop": "Pre-Flop",
     "flop": "Flop",

--- a/frontend/src/i18n/locales/ja/bigohilo.json
+++ b/frontend/src/i18n/locales/ja/bigohilo.json
@@ -6,6 +6,10 @@
     "winner": "{{name}} (+{{amount}})",
     "hiTakesAll": "ロー該当者なし — ハイが総取り"
   },
+  "scoop": {
+    "badge": "🏆 スクープ! {{name}} がハイ・ロー総取り (+{{total}})",
+    "youBadge": "🏆 スクープ達成! ハイ・ローを総取り (+{{total}})"
+  },
   "phase": {
     "preFlop": "プリフロップ",
     "flop": "フロップ",

--- a/frontend/src/pages/BigOHiLoPage.test.tsx
+++ b/frontend/src/pages/BigOHiLoPage.test.tsx
@@ -426,6 +426,53 @@ describe('BigOHiLoPage', () => {
     expect(screen.getByTestId('bigohilo-hi-takes-all')).toBeInTheDocument();
   });
 
+  it('shows a scoop badge when one player wins both Hi and Lo', async () => {
+    const scoopState: OmahaResponse = {
+      ...showdownState,
+      roundResults: [
+        { ...showdownState.roundResults[0], wonAmount: 300, hiWonAmount: 200, lowWonAmount: 100 },
+        { ...showdownState.roundResults[1], wonAmount: 0, hiWonAmount: 0, lowWonAmount: 0 },
+      ],
+    };
+    mockExec.mockResolvedValue(scoopState);
+    renderWithProviders(<BigOHiLoPage />);
+    const badge = await screen.findByTestId('bigohilo-scoop-badge');
+    // Human (playerIdx 0) scooped: personalized message + emphasis marker.
+    expect(badge).toHaveTextContent('スクープ達成');
+    expect(badge).toHaveTextContent('300');
+    expect(badge).toHaveAttribute('data-scoop-human', 'true');
+  });
+
+  it('shows a CPU name in the scoop badge when a CPU scoops', async () => {
+    const scoopState: OmahaResponse = {
+      ...showdownState,
+      roundResults: [
+        { ...showdownState.roundResults[0], wonAmount: 0, hiWonAmount: 0, lowWonAmount: 0 },
+        { ...showdownState.roundResults[1], wonAmount: 300, hiWonAmount: 250, lowWonAmount: 50 },
+      ],
+    };
+    mockExec.mockResolvedValue(scoopState);
+    renderWithProviders(<BigOHiLoPage />);
+    const badge = await screen.findByTestId('bigohilo-scoop-badge');
+    expect(badge).toHaveTextContent('スクープ');
+    expect(badge).toHaveTextContent('300');
+    expect(badge).not.toHaveAttribute('data-scoop-human');
+  });
+
+  it('does not show a scoop badge on a split win (different Hi and Lo winners)', async () => {
+    const splitState: OmahaResponse = {
+      ...showdownState,
+      roundResults: [
+        { ...showdownState.roundResults[0], hiWonAmount: 200, lowWonAmount: 0 },
+        { ...showdownState.roundResults[1], wonAmount: 100, hiWonAmount: 0, lowWonAmount: 100 },
+      ],
+    };
+    mockExec.mockResolvedValue(splitState);
+    renderWithProviders(<BigOHiLoPage />);
+    await waitFor(() => expect(screen.getByTestId('bigohilo-split')).toBeInTheDocument());
+    expect(screen.queryByTestId('bigohilo-scoop-badge')).not.toBeInTheDocument();
+  });
+
   it('does not show CPU hand name badge when CPU is folded in showdown', async () => {
     mockExec.mockResolvedValue(showdownState);
     renderWithProviders(<BigOHiLoPage />);

--- a/frontend/src/pages/BigOHiLoPage.tsx
+++ b/frontend/src/pages/BigOHiLoPage.tsx
@@ -367,9 +367,39 @@ function BigOHiLoPageContent() {
                     : [],
                 );
                 if (hiWinners.length === 0 && loWinners.length === 0) return null;
+                // A scoop is when one player wins BOTH the Hi and the Lo halves.
+                const scoopers = state.roundResults.flatMap((r) =>
+                  r.hiWonAmount && r.lowWonAmount
+                    ? [
+                        {
+                          isHuman: r.playerIdx === humanPlayer?.id,
+                          name: findPlayerName(state.players, r.playerIdx),
+                          total: r.hiWonAmount + r.lowWonAmount,
+                        },
+                      ]
+                    : [],
+                );
                 return (
                   <div className="mb-2 text-center text-sm" data-testid="bigohilo-split">
                     <div className="mb-1 text-ds-text-muted">{t('hiLo.title')}</div>
+                    {scoopers.length > 0 && (
+                      <div className="mb-1.5 flex flex-wrap justify-center gap-2" role="status">
+                        {scoopers.map((s) => (
+                          <span
+                            key={`scoop-${s.name}`}
+                            data-testid="bigohilo-scoop-badge"
+                            data-scoop-human={s.isHuman || undefined}
+                            className={`inline-block rounded-full border border-ds-accent bg-ds-accent px-3 py-0.5 font-bold text-ds-text-on-accent ${
+                              s.isHuman ? 'motion-safe:animate-pulse ring-2 ring-ds-accent ring-offset-1' : ''
+                            }`}
+                          >
+                            {s.isHuman
+                              ? t('scoop.youBadge', { total: s.total })
+                              : t('scoop.badge', { name: s.name, total: s.total })}
+                          </span>
+                        ))}
+                      </div>
+                    )}
                     <div className="flex flex-wrap justify-center gap-2">
                       {hiWinners.map((w) => (
                         <span


### PR DESCRIPTION
## Summary

Adds a special celebration when a player **scoops** (wins BOTH the Hi and the Lo halves of the pot) in 5-Card Omaha Hi-Lo (Big O).

Previously the showdown only showed separate green Hi / blue Lo badges, so a scoop — the most valuable Hi-Lo outcome — looked like any ordinary two-badge win.

### What changed
- **Scoop detection** (frontend-only, derived): a `roundResults` entry with `hiWonAmount > 0 && lowWonAmount > 0` is a scoop. `playerIdx === humanPlayer.id` identifies a human scoop.
- **Dedicated badge** rendered above the existing Hi/Lo split badges: `🏆 スクープ!` with the winner's name and combined total, using design-system accent tokens (`bg-ds-accent` / `text-ds-text-on-accent`).
- **Human emphasis**: when the human scoops, a personalized message plus `motion-safe:animate-pulse` + ring, announced via `role="status"`. (`winFanfare` already fires on game end via `GamePageShell.onCelebrate`.)
- **i18n**: added `scoop.badge` / `scoop.youBadge` keys to `ja` and `en`.
- Existing Hi/Lo highlights are untouched.

### Acceptance criteria
- [x] Dedicated badge shown on a scoop
- [x] Not shown on a single-half win (split)
- [x] ja/en translation keys added
- [x] Unit tests added

## Test plan
- [x] `bun run test -- --run BigOHiLoPage` — 118 passed (3 new: human scoop, CPU scoop, split → no badge)
- [x] `bun run check` — exit 0, no warnings in changed files
- [x] `bun run build` — tsc + vite build OK
- [ ] Manual: showdown where the human wins both halves shows the pulsing 🏆 badge

Closes #3011
