### PR TITLE
feat(watten): preview top trumps from the Schlag/Critical declaration

### DIFF
--- a/frontend/src/i18n/locales/en/watten.json
+++ b/frontend/src/i18n/locales/en/watten.json
@@ -40,6 +40,20 @@
   "chooseSchlag": "Schlag rank",
   "chooseCritical": "Trump suit",
   "declareButton": "Declare",
+  "trumpRing": "Top trump",
+  "trumpPanel": {
+    "title": "Top-trump preview",
+    "rule": "Once declared, the ranking runs Max (♥K) > Belli (♦K) > Spitz (♦7), then the cards of the Schlag rank, then the remaining critical-suit cards. Below are your hand's top trumps for the current choice.",
+    "summary": "Your top trumps: {{count}}",
+    "none": "Pick a Schlag rank and critical suit to see which of your cards become top trumps. (The permanent trumps always count.)"
+  },
+  "trumpCat": {
+    "max": "Max (♥K)",
+    "belli": "Belli (♦K)",
+    "spitz": "Spitz (♦7)",
+    "schlag": "Schlag",
+    "critical": "Critical suit"
+  },
   "playButton": "Play",
   "raiseButton": "Raise (Watten)",
   "respondPhase": "Stake raised to {{stake}} — hold or fold.",

--- a/frontend/src/i18n/locales/ja/watten.json
+++ b/frontend/src/i18n/locales/ja/watten.json
@@ -40,6 +40,20 @@
   "chooseSchlag": "Schlag ランク",
   "chooseCritical": "切り札スート",
   "declareButton": "宣言",
+  "trumpRing": "強札（トランプ）",
+  "trumpPanel": {
+    "title": "強札プレビュー",
+    "rule": "宣言すると、永久最強札 Max（♥K）＞ Belli（♦K）＞ Spitz（♦7）に続き、Schlag ランクの札、切り札スートの残り札の順で強くなります。下はいまの選択での手札の強札です。",
+    "summary": "あなたの強札: {{count}}枚",
+    "none": "Schlag ランクと切り札スートを選ぶと、強くなる手札がここに表示されます。（永久最強札は常に有効です）"
+  },
+  "trumpCat": {
+    "max": "Max（♥K）",
+    "belli": "Belli（♦K）",
+    "spitz": "Spitz（♦7）",
+    "schlag": "Schlag",
+    "critical": "切り札スート"
+  },
   "playButton": "出す",
   "raiseButton": "レイズ（Watten）",
   "respondPhase": "ステーク {{stake}}点にレイズされました — hold か fold を選びます。",

--- a/frontend/src/pages/WattenPage.test.tsx
+++ b/frontend/src/pages/WattenPage.test.tsx
@@ -95,6 +95,30 @@ describe('WattenPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('declare', 13, 3));
   });
 
+  it('previews the top-trump panel with the permanent trumps in the declare phase', async () => {
+    mockExec.mockResolvedValue(declarePhaseState);
+    renderWithProviders(<WattenPage />);
+    // Panel + rule explanation render.
+    await waitFor(() => expect(screen.getByTestId('watten-trump-panel')).toBeInTheDocument());
+    expect(screen.getByText('強札プレビュー')).toBeInTheDocument();
+    // Base hand (♥K, ♦7, ♠A): Max + Spitz are permanent trumps → count 2 before any pick.
+    expect(screen.getByTestId('watten-trump-count')).toHaveTextContent('あなたの強札: 2枚');
+    // The permanent trumps are ringed in the hand.
+    expect(screen.getByRole('button', { name: '♥ K' })).toHaveAttribute('data-trump', 'true');
+  });
+
+  it('updates the top-trump preview and hand ring when a Schlag rank is picked', async () => {
+    mockExec.mockResolvedValue(declarePhaseState);
+    renderWithProviders(<WattenPage />);
+    await waitFor(() => expect(screen.getByTestId('watten-trump-count')).toHaveTextContent('2枚'));
+    // ♠A is plain until Schlag = A is chosen.
+    expect(screen.getByRole('button', { name: '♠ A' })).not.toHaveAttribute('data-trump');
+    fireEvent.click(screen.getByRole('button', { name: 'A' }));
+    // ♠A now becomes a Schlag trump → count rises to 3 and the card is ringed.
+    expect(screen.getByTestId('watten-trump-count')).toHaveTextContent('あなたの強札: 3枚');
+    expect(screen.getByRole('button', { name: '♠ A' })).toHaveAttribute('data-trump', 'true');
+  });
+
   it('selecting a card then playing dispatches play', async () => {
     renderWithProviders(<WattenPage />);
     const card = await screen.findByAltText('♥ K');

--- a/frontend/src/pages/WattenPage.tsx
+++ b/frontend/src/pages/WattenPage.tsx
@@ -27,10 +27,12 @@ import { gameTheme } from '../styles/gameTheme';
 import type { WattenResponse } from '../types/card';
 import { WattenPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { cardAlt } from '../utils/cardAlt';
 import { parseWattenCommand, WATTEN_HELP } from '../utils/cli/commands/wattenCommands';
 import { formatWattenState } from '../utils/cli/formatters/wattenFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
 import { playerName } from '../utils/playerUtils';
+import { wattenTrumpCards } from '../utils/wattenTrumps';
 
 /** Watten tutorial step definitions. */
 const WATTEN_TUTORIAL_STEPS: TutorialStep[] = [
@@ -174,6 +176,15 @@ function WattenPageContent() {
 
   const schlagText = state.schlagRank > 0 ? schlagLabel(state.schlagRank) : t('schlagNone');
   const criticalText = state.criticalSuit >= 1 ? t(SUIT_KEYS[state.criticalSuit] ?? 'suitNone') : t('suitNone');
+
+  // Effective Schlag/critical for the top-trump preview: the dealer's pending
+  // pick during the Declare phase, otherwise whatever the server has recorded.
+  // This drives both the in-hand ring and the explanatory panel, so the
+  // highlight stays consistent from declaration through the play phase.
+  const effectiveRank = selectedRank ?? state.schlagRank;
+  const effectiveSuit = selectedSuit ?? state.criticalSuit;
+  const humanTrumps = humanPlayer ? wattenTrumpCards(humanPlayer.cards, effectiveRank, effectiveSuit) : [];
+  const trumpIndices = humanTrumps.map((tc) => tc.index);
 
   const handleManualReset = () => {
     hideActionLog();
@@ -355,6 +366,31 @@ function WattenPageContent() {
                 {t('declarePhase')}
               </div>
             )}
+            {canDeclare && (
+              <div className="mb-2 p-2 rounded bg-black/30 text-ds-text-muted text-sm" data-testid="watten-trump-panel">
+                <div className="text-ds-text-primary mb-1">{t('trumpPanel.title')}</div>
+                <p className="mb-2 text-xs leading-relaxed">{t('trumpPanel.rule')}</p>
+                {humanTrumps.length > 0 ? (
+                  <>
+                    <div className="text-ds-accent font-semibold mb-1" data-testid="watten-trump-count">
+                      {t('trumpPanel.summary', { count: humanTrumps.length })}
+                    </div>
+                    <ul className="flex flex-wrap gap-x-3 gap-y-0.5">
+                      {humanTrumps.map((tc) => (
+                        <li key={`${tc.card.design}-${tc.card.value}`} className="whitespace-nowrap">
+                          <span className="text-ds-text-primary">{cardAlt(tc.card)}</span>{' '}
+                          <span className="text-ds-text-muted">— {t(`trumpCat.${tc.category}`)}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </>
+                ) : (
+                  <div className="text-xs" data-testid="watten-trump-count">
+                    {t('trumpPanel.none')}
+                  </div>
+                )}
+              </div>
+            )}
             {humanPlayer && (
               <PlayerHandSection
                 humanPlayer={humanPlayer}
@@ -363,6 +399,8 @@ function WattenPageContent() {
                 cardWidth={cardWidth}
                 isMobile={isMobile}
                 dataTutorialPrefix="watten"
+                trumpIndices={trumpIndices.length > 0 ? trumpIndices : undefined}
+                trumpTitle={t('trumpRing')}
               />
             )}
 

--- a/frontend/src/utils/wattenTrumps.test.ts
+++ b/frontend/src/utils/wattenTrumps.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import type { Card } from '../types/card';
+import { wattenTrumpCards, wattenTrumpInfo } from './wattenTrumps';
+
+const c = (design: Card['design'], value: number): Card => ({ design, value });
+
+describe('wattenTrumpInfo', () => {
+  it('classifies the three permanent trumps regardless of declaration', () => {
+    expect(wattenTrumpInfo(c('HEART', 13), 0, 0)).toEqual({ category: 'max', rank: 1000 });
+    expect(wattenTrumpInfo(c('DIAMOND', 13), 0, 0)).toEqual({ category: 'belli', rank: 999 });
+    expect(wattenTrumpInfo(c('DIAMOND', 7), 0, 0)).toEqual({ category: 'spitz', rank: 998 });
+  });
+
+  it('classifies Schlag-rank cards, tie-broken by suit ♥>♦>♠>♣', () => {
+    // Schlag = 8; ♥8 must outrank ♣8.
+    const heart8 = wattenTrumpInfo(c('HEART', 8), 8, 0);
+    const club8 = wattenTrumpInfo(c('CLOVER', 8), 8, 0);
+    expect(heart8?.category).toBe('schlag');
+    expect(club8?.category).toBe('schlag');
+    expect((heart8?.rank ?? 0) > (club8?.rank ?? 0)).toBe(true);
+  });
+
+  it('classifies remaining critical-suit cards below Schlag cards', () => {
+    // Critical suit = ♠ (code 1); a ♠A is a critical trump but weaker than any Schlag card.
+    const spadeA = wattenTrumpInfo(c('SPADE', 1), 8, 1);
+    expect(spadeA?.category).toBe('critical');
+    expect(spadeA?.rank).toBeLessThan(900);
+    expect(spadeA?.rank).toBeGreaterThanOrEqual(800);
+  });
+
+  it('gives permanent trumps priority over Schlag/critical matches', () => {
+    // ♥K is Max even when Schlag rank is K (13) and critical suit is ♥ (3).
+    expect(wattenTrumpInfo(c('HEART', 13), 13, 3)).toEqual({ category: 'max', rank: 1000 });
+  });
+
+  it('returns null for plain (non-trump) cards', () => {
+    expect(wattenTrumpInfo(c('SPADE', 9), 8, 3)).toBeNull();
+  });
+
+  it('treats an unset critical suit (0 or -1) as no critical trumps', () => {
+    expect(wattenTrumpInfo(c('SPADE', 9), 0, 0)).toBeNull();
+    expect(wattenTrumpInfo(c('SPADE', 9), 0, -1)).toBeNull();
+  });
+});
+
+describe('wattenTrumpCards', () => {
+  const hand: Card[] = [
+    c('SPADE', 1), // ♠A
+    c('HEART', 13), // ♥K = Max
+    c('SPADE', 8), // ♠8
+    c('DIAMOND', 7), // ♦7 = Spitz
+    c('CLOVER', 9), // ♣9 plain (not the Schlag rank, not the critical suit)
+  ];
+
+  it('returns only trumps, sorted strongest first, with indices preserved', () => {
+    // Schlag = 8, critical suit = ♠ (code 1).
+    const trumps = wattenTrumpCards(hand, 8, 1);
+    expect(trumps.map((t) => t.category)).toEqual(['max', 'spitz', 'schlag', 'critical']);
+    // ♠A is a critical trump at index 0; ♣9 stays plain and is excluded.
+    expect(trumps.map((t) => t.index)).toEqual([1, 3, 2, 0]);
+  });
+
+  it('previews only permanent trumps before any declaration', () => {
+    const trumps = wattenTrumpCards(hand, 0, 0);
+    expect(trumps.map((t) => t.category)).toEqual(['max', 'spitz']);
+  });
+});

--- a/frontend/src/utils/wattenTrumps.ts
+++ b/frontend/src/utils/wattenTrumps.ts
@@ -1,0 +1,124 @@
+import type { Card, CardDesign } from '../types/card';
+
+/**
+ * The trump category a Watten card falls into once a Schlag rank and critical
+ * (trump) suit are declared. Ordered from strongest to weakest tier:
+ *
+ * - `max`      — ♥K, the permanent highest trump ("Max"/Guater).
+ * - `belli`    — ♦K, the permanent second trump.
+ * - `spitz`    — ♦7, the permanent third trump.
+ * - `schlag`   — any card of the declared Schlag rank (except the three above).
+ * - `critical` — any remaining card of the declared critical suit.
+ *
+ * Mirrors the ranking in `internal/domain/Watten.go` (`cardRank`/`isTrump`).
+ */
+export type WattenTrumpCategory = 'max' | 'belli' | 'spitz' | 'schlag' | 'critical';
+
+/** A card in the human's hand that is a trump, with its category and strength. */
+export interface WattenTrumpCard {
+  /** The card itself. */
+  card: Card;
+  /** Index of the card within the source hand array. */
+  index: number;
+  /** Which trump tier the card belongs to. */
+  category: WattenTrumpCategory;
+  /** Trick-comparison strength (higher = stronger), mirroring the domain. */
+  rank: number;
+}
+
+/** Maps a numeric critical-suit code (1=♠ 2=♣ 3=♥ 4=♦) to a card design. */
+const SUIT_CODE_TO_DESIGN: Readonly<Record<number, CardDesign>> = {
+  1: 'SPADE',
+  2: 'CLOVER',
+  3: 'HEART',
+  4: 'DIAMOND',
+};
+
+/** Fixed suit order for tie-breaking Schlag cards: ♥>♦>♠>♣ (mirrors domain). */
+function schlagSuitOrder(design: CardDesign): number {
+  switch (design) {
+    case 'HEART':
+      return 3;
+    case 'DIAMOND':
+      return 2;
+    case 'SPADE':
+      return 1;
+    default:
+      return 0;
+  }
+}
+
+/** Value strength A>K>Q>J>10>9>8>7 for critical-suit / plain cards (mirrors domain). */
+function wattenValueRank(value: number): number {
+  switch (value) {
+    case 1: // A
+      return 8;
+    case 13: // K
+      return 7;
+    case 12: // Q
+      return 6;
+    case 11: // J
+      return 5;
+    case 10:
+      return 4;
+    case 9:
+      return 3;
+    case 8:
+      return 2;
+    case 7:
+      return 1;
+    default:
+      return 0;
+  }
+}
+
+/**
+ * Classifies a single card given the declared Schlag rank and critical suit,
+ * returning its trump category and trick-comparison strength, or `null` when
+ * the card is a plain (non-trump) card.
+ *
+ * A Schlag rank of 0 (or a critical suit outside 1..4) is treated as "not yet
+ * declared" for that dimension, so the classification updates live as the
+ * dealer picks each choice. The three permanent trumps (Max ♥K, Belli ♦K,
+ * Spitz ♦7) are trumps regardless of the declaration.
+ *
+ * @param card - The card to classify.
+ * @param schlagRank - Declared Schlag rank (1=A, 7..13), or 0 when unset.
+ * @param criticalSuit - Declared critical suit code (1=♠ 2=♣ 3=♥ 4=♦), or 0/-1 when unset.
+ * @returns The card's category and rank, or `null` when it is not a trump.
+ */
+export function wattenTrumpInfo(
+  card: Card,
+  schlagRank: number,
+  criticalSuit: number,
+): { category: WattenTrumpCategory; rank: number } | null {
+  if (card.design === 'HEART' && card.value === 13) return { category: 'max', rank: 1000 };
+  if (card.design === 'DIAMOND' && card.value === 13) return { category: 'belli', rank: 999 };
+  if (card.design === 'DIAMOND' && card.value === 7) return { category: 'spitz', rank: 998 };
+  if (schlagRank > 0 && card.value === schlagRank) {
+    return { category: 'schlag', rank: 900 + schlagSuitOrder(card.design) };
+  }
+  if (SUIT_CODE_TO_DESIGN[criticalSuit] === card.design) {
+    return { category: 'critical', rank: 800 + wattenValueRank(card.value) };
+  }
+  return null;
+}
+
+/**
+ * Returns the trump cards within a hand for the given Schlag rank and critical
+ * suit, sorted strongest-first, so a Watten dealer can preview which of their
+ * cards become the top trumps ("critical" cards) before declaring.
+ *
+ * @param cards - The hand to scan.
+ * @param schlagRank - Declared Schlag rank (1=A, 7..13), or 0 when unset.
+ * @param criticalSuit - Declared critical suit code (1=♠ 2=♣ 3=♥ 4=♦), or 0/-1 when unset.
+ * @returns Trump cards with their index, category, and strength, strongest first.
+ */
+export function wattenTrumpCards(cards: Card[], schlagRank: number, criticalSuit: number): WattenTrumpCard[] {
+  const trumps: WattenTrumpCard[] = [];
+  cards.forEach((card, index) => {
+    const info = wattenTrumpInfo(card, schlagRank, criticalSuit);
+    if (info) trumps.push({ card, index, category: info.category, rank: info.rank });
+  });
+  return trumps.sort((a, b) => b.rank - a.rank);
+}


### PR DESCRIPTION
## Summary

Visualizes and explains the Watten **Schlag/Critical** declaration so the human dealer understands its impact on the hand before declaring. Previously `WattenPage` let you pick a Schlag rank + critical suit but nothing showed *which* of your cards become the top trumps ("critical" cards). Now the declare phase gets a live **top-trump preview**.

Frontend-only (Watten is on the `extra` WASM worker) — no Go/CUI/internal-i18n touched.

### What changed
- **New pure helper** `frontend/src/utils/wattenTrumps.ts` — `wattenTrumpCards()` / `wattenTrumpInfo()` classify each hand card into its trump tier (Max ♥K > Belli ♦K > Spitz ♦7 > Schlag rank > Critical suit) and strength, sorted strongest-first. Rules mirror `internal/domain/Watten.go` (`cardRank`/`isTrump`, `schlagSuitOrder`, `wattenValueRank`) — read-only, verified against the domain.
- **`WattenPage.tsx`** — during the declare phase, an explanatory panel (`data-testid="watten-trump-panel"`) shows the ranking rule, a summary count (`data-testid="watten-trump-count"`, e.g. "あなたの強札: 3枚"), and the list of your current top trumps with tier labels. The resulting cards are ringed in the hand via `PlayerHandSection`'s existing additive `trumpIndices`/`trumpTitle` props. The preview updates live as the rank/suit are picked and, because it falls back to the server's declared values, the ring stays consistent through the play phase (header agreement).
- **i18n** — added `trumpRing`, `trumpPanel.*`, `trumpCat.*` to `ja`/`en` watten.json.

### How the critical cards are derived
Independently per dimension: a card is a trump if it is a permanent trump (♥K/♦K/♦7), or its value equals the (pending or declared) Schlag rank, or its suit equals the critical suit. Permanent trumps take priority and are shown even before any pick; unset dimensions (0/-1) are ignored so the preview reflects partial selections.

## Acceptance criteria
- [x] 宣言選択に応じて手札の強札がプレビュー強調される (hand ring updates per selection)
- [x] 確定前に強札枚数のサマリが表示される (count shown before confirm)
- [x] 宣言確定後もヘッダ表示と整合する (falls back to declared state → consistent in play phase)
- [x] `WattenPage.test.tsx` にプレビュー強調テストを追加

## Tests
- `frontend/src/utils/wattenTrumps.test.ts` — tier classification, suit tie-break, permanent-trump priority, sorting, unset dimensions (8 cases).
- `frontend/src/pages/WattenPage.test.tsx` — `previews the top-trump panel with the permanent trumps in the declare phase` + `updates the top-trump preview and hand ring when a Schlag rank is picked`.

## Gates
- `bun run check` ✅ (only pre-existing warnings)
- `bun run test -- --run WattenPage wattenTrumps` ✅ 21 passed
- `bun run build` (tsc) ✅

Closes #3489

🤖 Generated with [Claude Code](https://claude.com/claude-code)
