### PR TITLE
feat(jass): visualize weis declaration totals in an accessible panel

### DIFF
--- a/frontend/src/i18n/locales/en/jass.json
+++ b/frontend/src/i18n/locales/en/jass.json
@@ -32,6 +32,13 @@
   "roundPoints": "Round: {{points}} pts",
   "weisPoints": "Weis: {{points}} pts",
   "stockPoints": "Stöck: {{points}} pts",
+  "weisPanel": {
+    "title": "Weis (meld) declarations",
+    "note": "Weis are melds declared during the round (3-card sequence 20 pts, 4-card sequence 50 pts, four-of-a-kind 100/150/200 pts, etc.). Only the team that declared the strongest Weis scores all of its Weis points for the round.",
+    "teamPoints": "{{points}} pts",
+    "scored": "Counted",
+    "you": " (You)"
+  },
   "schiebenButton": "Schieben",
   "playButton": "Play",
   "nextTrick": "Next Trick",

--- a/frontend/src/i18n/locales/ja/jass.json
+++ b/frontend/src/i18n/locales/ja/jass.json
@@ -32,6 +32,13 @@
   "roundPoints": "ラウンド: {{points}}点",
   "weisPoints": "Weis: {{points}}点",
   "stockPoints": "Stöck: {{points}}点",
+  "weisPanel": {
+    "title": "Weis（メルド）宣言",
+    "note": "Weis はラウンド中に宣言されるメルド（3枚シーケンス20点、4枚シーケンス50点、同位4枚100/150/200点など）のボーナスです。最も強い Weis を宣言したチームだけが、そのラウンドの自チーム Weis 点をすべて獲得します。",
+    "teamPoints": "{{points}}点",
+    "scored": "獲得",
+    "you": "（あなた）"
+  },
   "schiebenButton": "シーバー",
   "playButton": "出す",
   "nextTrick": "次のトリック",

--- a/frontend/src/pages/JassPage.test.tsx
+++ b/frontend/src/pages/JassPage.test.tsx
@@ -144,6 +144,40 @@ describe('JassPage', () => {
     await waitFor(() => expect(screen.getByText('チームスコア')).toBeInTheDocument());
   });
 
+  it('shows the Weis panel with per-team totals and a counted marker when Weis is declared', async () => {
+    mockExec.mockResolvedValue(makeState({ phase: JassPhase.TRICK_END, trumpSuit: 1, roundWeisPoints: [20, 0] }));
+    renderWithProviders(<JassPage />);
+    const panel = await screen.findByTestId('jass-weis-panel');
+    expect(panel).toBeInTheDocument();
+    expect(panel).toHaveTextContent('Weis（メルド）宣言');
+    // Human is on team 0, so the (You) marker appears on team 0.
+    expect(panel).toHaveTextContent('チーム0（あなた）');
+    expect(panel).toHaveTextContent('20点');
+    // Only the scoring team (team 0) gets the "獲得" marker.
+    expect(screen.getAllByText('獲得')).toHaveLength(1);
+  });
+
+  it('hides the Weis panel when the feature is disabled', async () => {
+    mockExec.mockResolvedValue(
+      makeState({
+        phase: JassPhase.TRICK_END,
+        trumpSuit: 1,
+        roundWeisPoints: [20, 0],
+        config: { cpuDifficulty: 1, targetScore: 1000, lastTrickBonus: 5, enableWeis: false },
+      }),
+    );
+    renderWithProviders(<JassPage />);
+    await waitFor(() => expect(screen.getByText('チームスコア')).toBeInTheDocument());
+    expect(screen.queryByTestId('jass-weis-panel')).not.toBeInTheDocument();
+  });
+
+  it('hides the Weis panel when no Weis points were declared', async () => {
+    mockExec.mockResolvedValue(makeState({ phase: JassPhase.TRICK_END, trumpSuit: 1, roundWeisPoints: [0, 0] }));
+    renderWithProviders(<JassPage />);
+    await waitFor(() => expect(screen.getByText('チームスコア')).toBeInTheDocument());
+    expect(screen.queryByTestId('jass-weis-panel')).not.toBeInTheDocument();
+  });
+
   it('translates a known hint reason', async () => {
     const playState = makeState({ phase: JassPhase.PLAY, trumpSuit: 1, currentPlayerIdx: 0 });
     mockExec.mockResolvedValue(playState);

--- a/frontend/src/pages/JassPage.tsx
+++ b/frontend/src/pages/JassPage.tsx
@@ -271,6 +271,39 @@ function JassPageContent() {
           </table>
         </div>
 
+        {/* Weis (meld) declaration panel — surfaces where the Weis bonus came from.
+            Only per-team totals are exposed by the API, so we visualize those faithfully:
+            each team's declared Weis total, a "counted" marker for the scoring team, and a
+            note explaining the meld mechanic. */}
+        {state.config.enableWeis && (state.roundWeisPoints[0] > 0 || state.roundWeisPoints[1] > 0) && (
+          <section
+            className="my-3 p-3 rounded bg-black/30 border border-ds-warning/40"
+            aria-label={t('weisPanel.title')}
+            data-testid="jass-weis-panel"
+          >
+            <h3 className="text-ds-warning text-sm font-semibold mb-2">{t('weisPanel.title')}</h3>
+            <ul className="flex flex-col gap-1">
+              {[0, 1].map((team) => (
+                <li key={team} className="flex items-center gap-2 text-sm text-ds-text-muted">
+                  <span>
+                    {t('team', { n: team })}
+                    {humanPlayer?.team === team ? t('weisPanel.you') : ''}
+                  </span>
+                  <span className="text-ds-warning font-medium">
+                    {t('weisPanel.teamPoints', { points: state.roundWeisPoints[team] })}
+                  </span>
+                  {state.roundWeisPoints[team] > 0 && (
+                    <span className="text-xs px-1.5 py-0.5 rounded bg-ds-warning/20 text-ds-warning">
+                      {t('weisPanel.scored')}
+                    </span>
+                  )}
+                </li>
+              ))}
+            </ul>
+            <p className="mt-2 text-xs text-ds-text-muted">{t('weisPanel.note')}</p>
+          </section>
+        )}
+
         <RoundScoreAnnouncement
           active={isRoundEnd || isGameEnd}
           entries={[


### PR DESCRIPTION
## Summary

Closes #3600.

The issue asked to visualize the Weis (meld) declaration contents so learners understand where the sudden Weis point total comes from, and to make the Weis feature more discoverable.

**Data scope note:** The Web API (`JassResponse`) exposes only per-team Weis totals (`roundWeisPoints: number[]`) — **not** the per-player meld contents (declarer / type / cards). Surfacing per-player meld details would require adding fields to `JassWebPresenter.go` / `Jass.go`, which is out of scope for this frontend-only change. So this PR does the best faithful visualization the available data supports.

## Changes (frontend only)

- **`JassPage.tsx`**: Added an accessible `<section>` Weis panel (`data-testid="jass-weis-panel"`, `aria-label`, heading) that renders when `config.enableWeis` is on and Weis points exist. It shows each team's declared Weis total, a "counted" marker for the scoring team, a "(You)" tag on the human's team, and a note explaining the meld mechanic. Uses design-system tokens only (`ds-warning`, `ds-text-muted`).
- **i18n** (`{ja,en}/jass.json`): Added the `weisPanel.*` keys (title, note, teamPoints, scored, you). ja/en key parity verified.
- **`JassPage.test.tsx`**: Added 3 tests — panel renders with per-team totals + counted marker + (You) tag; hidden when the feature is disabled; hidden when no Weis declared.

## Acceptance criteria mapping

- [x] Weis declaration details displayed — per-team totals + scoring-team marker (per-player meld type/cards not exposed by the API)
- [x] No UI shown when `enableWeis` is off
- [x] Displayed totals equal `roundWeisPoints`
- [x] Page tests added

## Test plan

- [x] `bun run check`
- [x] `bun run test -- --run JassPage` (14 passed)
- [x] `bun run build` (tsc)