### PR TITLE
feat(bouillotte): visualize the retourne's relation to the hand

### DIFF
--- a/frontend/src/i18n/locales/en/bouillotte.json
+++ b/frontend/src/i18n/locales/en/bouillotte.json
@@ -20,6 +20,10 @@
   "currentBet": "Current bet: {{amount}}",
   "roundBet": "Bet: {{amount}}",
   "retourneLabel": "Retourne (shared card)",
+  "retourneNote": {
+    "favori": "The retourne completes a brelan favori! (your pair + the shared card make three).",
+    "carre": "Your brelan matches the retourne's rank (carré) — a top-class hand!"
+  },
   "handLabel": "Your hand",
   "playersTitle": "Players",
   "bettingNotice": "Your turn — call, raise (vie), or fold.",

--- a/frontend/src/i18n/locales/ja/bouillotte.json
+++ b/frontend/src/i18n/locales/ja/bouillotte.json
@@ -20,6 +20,10 @@
   "currentBet": "現在のベット: {{amount}}",
   "roundBet": "賭け: {{amount}}",
   "retourneLabel": "ルトゥルヌ（共有カード）",
+  "retourneNote": {
+    "favori": "ルトゥルヌと合わせてブルラン・ファヴォリ成立！（手札のペア＋共有カードで3枚）",
+    "carre": "手札がブルラン、ルトゥルヌも同ランク（カレ）で最強クラス！"
+  },
   "handLabel": "あなたの手札",
   "playersTitle": "プレイヤー",
   "bettingNotice": "あなたの番です — コール・レイズ（ヴィ）・フォールドを選んでください。",

--- a/frontend/src/pages/BouillottePage.test.tsx
+++ b/frontend/src/pages/BouillottePage.test.tsx
@@ -177,4 +177,65 @@ describe('BouillottePage', () => {
     renderWithProviders(<BouillottePage />);
     await waitFor(() => expect(screen.getByText('ゲーム終了！ あなたの勝利です！')).toBeInTheDocument());
   });
+
+  it('highlights only the hand cards that share the retourne rank', async () => {
+    // Human hand K, J, 4 with a K retourne — only the first card matches.
+    renderWithProviders(<BouillottePage />);
+    await waitFor(() => expect(screen.getByTestId('hand-card-0')).toBeInTheDocument());
+    expect(screen.getByTestId('hand-card-0').className).toContain('ring-ds-accent');
+    expect(screen.getByTestId('hand-card-1').className).not.toContain('ring-ds-accent');
+    expect(screen.getByTestId('hand-card-2').className).not.toContain('ring-ds-accent');
+    // The retourne itself is ringed when the human holds a matching card.
+    expect(screen.getByTestId('retourne-card').className).toContain('ring-ds-accent');
+    // A single match forms no retourne-completed combo, so no note.
+    expect(screen.queryByTestId('retourne-note')).not.toBeInTheDocument();
+  });
+
+  it('shows the brelan favori note when the retourne completes a matching pair', async () => {
+    const favoriState = makeBouillotteState({
+      phase: 0,
+      isHumanTurn: true,
+      retourne: { design: 'DIAMOND', value: 12 },
+      players: [
+        {
+          id: 0,
+          isHuman: true,
+          chips: 190,
+          roundBet: 10,
+          folded: false,
+          out: false,
+          cardCount: 3,
+          cards: [
+            { design: 'SPADE', value: 12 },
+            { design: 'HEART', value: 12 },
+            { design: 'CLOVER', value: 8 },
+          ],
+          handName: 'brelan',
+          isWinner: false,
+        },
+        ...bettingState.players.slice(1),
+      ],
+    });
+    mockExec.mockResolvedValue(favoriState);
+    renderWithProviders(<BouillottePage />);
+    await waitFor(() => expect(screen.getByTestId('retourne-note')).toBeInTheDocument());
+    expect(screen.getByTestId('retourne-note').textContent).toContain('ブルラン・ファヴォリ');
+    expect(screen.getByTestId('hand-card-0').className).toContain('ring-ds-accent');
+    expect(screen.getByTestId('hand-card-1').className).toContain('ring-ds-accent');
+    expect(screen.getByTestId('hand-card-2').className).not.toContain('ring-ds-accent');
+  });
+
+  it('does not highlight any card when no hand card matches the retourne', async () => {
+    const noMatchState = makeBouillotteState({
+      phase: 0,
+      isHumanTurn: true,
+      retourne: { design: 'DIAMOND', value: 8 },
+    });
+    mockExec.mockResolvedValue(noMatchState);
+    renderWithProviders(<BouillottePage />);
+    await waitFor(() => expect(screen.getByTestId('hand-card-0')).toBeInTheDocument());
+    expect(screen.getByTestId('hand-card-0').className).not.toContain('ring-ds-accent');
+    expect(screen.getByTestId('retourne-card').className).not.toContain('ring-ds-accent');
+    expect(screen.queryByTestId('retourne-note')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/BouillottePage.tsx
+++ b/frontend/src/pages/BouillottePage.tsx
@@ -32,6 +32,7 @@ import { gameTheme } from '../styles/gameTheme';
 import type { BouillotteResponse } from '../types/card';
 import { BouillottePhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { analyzeRetourneMatch } from '../utils/bouillotteRetourne';
 import { BOUILLOTTE_HELP, parseBouillotteCommand } from '../utils/cli/commands/bouillotteCommands';
 import { formatBouillotteState } from '../utils/cli/formatters/bouillotteFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
@@ -122,6 +123,10 @@ function BouillottePageContent() {
 
   const humanPlayer = state.players.find((p) => p.isHuman);
   const humanIdx = state.players.findIndex((p) => p.isHuman);
+
+  // Which of the human's cards share the retourne's rank, and any combo it completes.
+  const retourneMatch = analyzeRetourneMatch(humanPlayer?.cards ?? [], state.retourne);
+  const matchingSet = new Set(retourneMatch.matchingIndices);
 
   const isBettingPhase = state.phase === BouillottePhase.BETTING;
   const isResultPhase = state.phase === BouillottePhase.RESULT;
@@ -226,7 +231,12 @@ function BouillottePageContent() {
             {state.retourne && (
               <div className="mb-2 flex flex-col items-center">
                 <div className="text-ds-text-muted text-xs mb-0.5">{t('retourneLabel')}</div>
-                <CardImage card={state.retourne} width={cardWidth} />
+                <span
+                  data-testid="retourne-card"
+                  className={matchingSet.size > 0 ? 'inline-block rounded-md ring-2 ring-ds-accent' : 'inline-block'}
+                >
+                  <CardImage card={state.retourne} width={cardWidth} />
+                </span>
               </div>
             )}
 
@@ -307,9 +317,20 @@ function BouillottePageContent() {
                 </div>
                 <div className="flex gap-1">
                   {humanPlayer.cards.map((c, i) => (
-                    <CardImage key={`human-${i}`} card={c} width={cardWidth} />
+                    <span
+                      key={`human-${i}`}
+                      data-testid={`hand-card-${i}`}
+                      className={matchingSet.has(i) ? 'inline-block rounded-md ring-2 ring-ds-accent' : 'inline-block'}
+                    >
+                      <CardImage card={c} width={cardWidth} />
+                    </span>
                   ))}
                 </div>
+                {retourneMatch.noteKey && (
+                  <div className="mt-1 text-xs font-semibold text-ds-accent" data-testid="retourne-note">
+                    {t(`retourneNote.${retourneMatch.noteKey}`)}
+                  </div>
+                )}
               </div>
             ) : (
               <div className="text-ds-text-muted text-sm mb-2" data-tutorial="bouillotte-hand">

--- a/frontend/src/utils/bouillotteRetourne.test.ts
+++ b/frontend/src/utils/bouillotteRetourne.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import type { Card } from '../types/card';
+import { analyzeRetourneMatch } from './bouillotteRetourne';
+
+const c = (design: Card['design'], value: number): Card => ({ design, value });
+
+describe('analyzeRetourneMatch', () => {
+  it('returns no matches when the retourne is absent', () => {
+    const hand = [c('SPADE', 13), c('HEART', 13), c('CLOVER', 4)];
+    expect(analyzeRetourneMatch(hand, null)).toEqual({ matchingIndices: [], noteKey: null });
+    expect(analyzeRetourneMatch(hand, undefined)).toEqual({ matchingIndices: [], noteKey: null });
+  });
+
+  it('flags the single hand card sharing the retourne rank without a combo note', () => {
+    const hand = [c('SPADE', 13), c('HEART', 11), c('CLOVER', 4)];
+    const result = analyzeRetourneMatch(hand, c('CLOVER', 13));
+    expect(result.matchingIndices).toEqual([0]);
+    expect(result.noteKey).toBeNull();
+  });
+
+  it('reports a favori when a matching pair is completed by the retourne', () => {
+    const hand = [c('SPADE', 12), c('HEART', 12), c('CLOVER', 8)];
+    const result = analyzeRetourneMatch(hand, c('DIAMOND', 12));
+    expect(result.matchingIndices).toEqual([0, 1]);
+    expect(result.noteKey).toBe('favori');
+  });
+
+  it('reports a carre when a hand brelan matches the retourne rank', () => {
+    const hand = [c('SPADE', 9), c('HEART', 9), c('CLOVER', 9)];
+    const result = analyzeRetourneMatch(hand, c('DIAMOND', 9));
+    expect(result.matchingIndices).toEqual([0, 1, 2]);
+    expect(result.noteKey).toBe('carre');
+  });
+
+  it('returns no matches when no hand card shares the retourne rank', () => {
+    const hand = [c('SPADE', 13), c('HEART', 11), c('CLOVER', 4)];
+    const result = analyzeRetourneMatch(hand, c('DIAMOND', 8));
+    expect(result.matchingIndices).toEqual([]);
+    expect(result.noteKey).toBeNull();
+  });
+});

--- a/frontend/src/utils/bouillotteRetourne.ts
+++ b/frontend/src/utils/bouillotteRetourne.ts
@@ -1,0 +1,38 @@
+import type { Card } from '../types/card';
+
+/** Combo an unpaired hand forms once the retourne is counted as a shared card. */
+export type RetourneNoteKey = 'favori' | 'carre';
+
+/** Analysis of how the shared retourne card relates to the human's hand. */
+export interface RetourneMatch {
+  /** Hand indices whose rank equals the retourne's rank. */
+  matchingIndices: number[];
+  /**
+   * Retourne-completed combo, or `null` when none:
+   * - `'favori'`: the hand holds a pair the retourne turns into a brelan.
+   * - `'carre'`: the hand is already a brelan and the retourne matches its rank.
+   */
+  noteKey: RetourneNoteKey | null;
+}
+
+/**
+ * Determines which of the human's hand cards share the retourne's rank and
+ * whether they combine into a retourne-completed brelan. Ranks are compared by
+ * card value (Bouillotte uses a standard deck, so equal value means equal rank).
+ * Returns no matches when the retourne has not yet been dealt.
+ *
+ * @param hand - The human player's cards.
+ * @param retourne - The shared turned-up card, or `null` before it is dealt.
+ * @returns The matching hand indices and any retourne-completed combo note key.
+ */
+export function analyzeRetourneMatch(hand: readonly Card[], retourne: Card | null | undefined): RetourneMatch {
+  if (!retourne) return { matchingIndices: [], noteKey: null };
+  const matchingIndices: number[] = [];
+  for (let i = 0; i < hand.length; i++) {
+    if (hand[i].value === retourne.value) matchingIndices.push(i);
+  }
+  let noteKey: RetourneNoteKey | null = null;
+  if (matchingIndices.length === 2) noteKey = 'favori';
+  else if (matchingIndices.length >= 3) noteKey = 'carre';
+  return { matchingIndices, noteKey };
+}


### PR DESCRIPTION
## 概要

ブイヨットの `retourne`（共有表向き札）と役の関連を可視化する。retourne と同ランクの手札を強調し、retourne を絡めた役成立の補足を役名の横に表示する。additive（既存操作を阻害しない）なフロントエンドのみの変更。

Closes #3480

## 変更内容

- `analyzeRetourneMatch`（純粋関数）を新設。手札のうち retourne と同ランクのインデックスと、retourne が完成させる役（`favori` = 手札ペア＋retourne、`carre` = 手札ブルラン＋retourne 同ランク）を返す。ドメイン `Bouillotte.go` の役判定（ファヴォリ/カレ）に準拠（読み取りのみ）。
- `BouillottePage.tsx`: 手札の一致カードと retourne カードに `ring-ds-accent` の枠を付与、`favori`/`carre` 時に補足ノートを表示。
- i18n（ja/en）に `retourneNote.favori` / `retourneNote.carre` を追加。

## テスト

- `frontend/src/utils/bouillotteRetourne.test.ts`（5 件）: なし/1枚一致/favori/carre/不一致
- `frontend/src/pages/BouillottePage.test.tsx`（追加 3 件）: 一致カードのみ強調、favori ノート表示、不一致時は非強調

## 受け入れ条件

- [x] retourne と同ランクの手札が強調される
- [x] retourne を絡めた役成立の補足が表示される
- [x] 役名表示 `handName` と整合する（ファヴォリ/カレはドメインでは brelan に集約されるため補足として明示）
- [x] `BouillottePage.test.tsx` に強調テストを追加

## ゲート

- [x] `bun run check`（exit 0）
- [x] `bun run test -- --run BouillottePage`（14 passed）
- [x] `bun run test -- --run bouillotteRetourne`（5 passed）
- [x] `bun run build`（tsc OK）

Go/CUI/internal-i18n は未変更（bouillotte は `extra` WASM worker、フロントエンドのみ）。
