### PR TITLE
feat(crazypineapple): recommend the optimal discard in the discard phase

### DIFF
--- a/frontend/src/i18n/locales/en/crazypineapple.json
+++ b/frontend/src/i18n/locales/en/crazypineapple.json
@@ -21,6 +21,7 @@
     "confirmYes": "Confirm",
     "confirmNo": "Cancel",
     "candidateHand": "If discarded",
+    "recommended": "Recommended",
     "limitReached": "You can select up to {{count}} card(s). Deselect one first.",
     "limitDescription": "You can select at most {{count}} card(s) to discard."
   },

--- a/frontend/src/i18n/locales/ja/crazypineapple.json
+++ b/frontend/src/i18n/locales/ja/crazypineapple.json
@@ -21,6 +21,7 @@
     "confirmYes": "確定",
     "confirmNo": "キャンセル",
     "candidateHand": "捨てると",
+    "recommended": "おすすめ",
     "limitReached": "選択できるのは{{count}}枚までです。先に選択を解除してください",
     "limitDescription": "ディスカードで選択できるのは最大{{count}}枚です"
   },

--- a/frontend/src/pages/PineapplePage.test.tsx
+++ b/frontend/src/pages/PineapplePage.test.tsx
@@ -626,6 +626,106 @@ describe('PineapplePage', () => {
     expect(labels[0]).toHaveTextContent('ワンペア');
   });
 
+  it('flags the single optimal Crazy Pineapple discard with a recommended badge', async () => {
+    // hole 10♠ 10♥ 2♦, board 10♣ 5♥ 8♦.
+    // Discard 2♦ → keep 10♠ 10♥ → three tens (best). The two 10-discards only
+    // leave a pair of tens, so only the 2♦ discard is recommended.
+    const crazyDiscardState: PineappleResponse = {
+      ...discardState,
+      initialDealCount: 3,
+      players: [
+        humanPlayer({
+          cards: [
+            { design: 'SPADE', value: 10 },
+            { design: 'HEART', value: 10 },
+            { design: 'DIAMOND', value: 2 },
+          ],
+        }),
+        cpuPlayer(1),
+        cpuPlayer(2),
+        cpuPlayer(3),
+      ],
+      communityCards: [
+        { design: 'CLOVER', value: 10 },
+        { design: 'HEART', value: 5 },
+        { design: 'DIAMOND', value: 8 },
+      ],
+      discardDone: [false, true, true, true],
+    };
+    mockCrazyExec.mockResolvedValue(crazyDiscardState);
+    renderWithProviders(<PineapplePage variant="crazypineapple" />);
+    await waitFor(() => expect(screen.getByTestId('discard-controls')).toBeInTheDocument());
+    const badges = screen.getAllByTestId('cp-discard-recommended');
+    expect(badges).toHaveLength(1); // only the strongest keep is recommended
+    expect(badges[0]).toHaveTextContent('おすすめ');
+    // The recommended card (3rd, discarding 2♦) keeps three of a kind.
+    const labels = screen.getAllByTestId('cp-discard-candidate');
+    expect(labels[2]).toHaveTextContent('スリーカード');
+  });
+
+  it('flags every tied-best Crazy Pineapple discard as recommended', async () => {
+    // hole A♠ A♥ 5♦, board 10♠ 5♥ 8♦. Every discard leaves exactly one pair,
+    // so all three tie for the best rank and all get the badge.
+    const crazyDiscardState: PineappleResponse = {
+      ...discardState,
+      initialDealCount: 3,
+      players: [
+        humanPlayer({
+          cards: [
+            { design: 'SPADE', value: 1 },
+            { design: 'HEART', value: 1 },
+            { design: 'DIAMOND', value: 5 },
+          ],
+        }),
+        cpuPlayer(1),
+        cpuPlayer(2),
+        cpuPlayer(3),
+      ],
+      communityCards: [
+        { design: 'SPADE', value: 10 },
+        { design: 'HEART', value: 5 },
+        { design: 'DIAMOND', value: 8 },
+      ],
+      discardDone: [false, true, true, true],
+    };
+    mockCrazyExec.mockResolvedValue(crazyDiscardState);
+    renderWithProviders(<PineapplePage variant="crazypineapple" />);
+    await waitFor(() => expect(screen.getByTestId('discard-controls')).toBeInTheDocument());
+    expect(screen.getAllByTestId('cp-discard-recommended')).toHaveLength(3);
+  });
+
+  it('shows no Crazy Pineapple recommended badge when the board is too small', async () => {
+    const crazyNoBoardState: PineappleResponse = {
+      ...discardState,
+      initialDealCount: 3,
+      players: [
+        humanPlayer({
+          cards: [
+            { design: 'SPADE', value: 1 },
+            { design: 'HEART', value: 1 },
+            { design: 'DIAMOND', value: 5 },
+          ],
+        }),
+        cpuPlayer(1),
+        cpuPlayer(2),
+        cpuPlayer(3),
+      ],
+      communityCards: [],
+      discardDone: [false, true, true, true],
+    };
+    mockCrazyExec.mockResolvedValue(crazyNoBoardState);
+    renderWithProviders(<PineapplePage variant="crazypineapple" />);
+    await waitFor(() => expect(screen.getByTestId('discard-controls')).toBeInTheDocument());
+    expect(screen.queryByTestId('cp-discard-recommended')).not.toBeInTheDocument();
+  });
+
+  it('does not show a recommended badge for the plain Pineapple variant', async () => {
+    mockExec.mockResolvedValue(discardState);
+    renderWithProviders(<PineapplePage />);
+    await waitFor(() => expect(screen.getByTestId('discard-controls')).toBeInTheDocument());
+    expect(screen.queryByTestId('cp-discard-recommended')).not.toBeInTheDocument();
+  });
+
   it('omits Crazy Pineapple candidate labels when the board is too small to evaluate', async () => {
     const crazyNoBoardState: PineappleResponse = {
       ...discardState,

--- a/frontend/src/pages/PineapplePage.tsx
+++ b/frontend/src/pages/PineapplePage.tsx
@@ -48,7 +48,7 @@ import type { CliGameConfig } from '../utils/cli/types';
 import { holdemBestFive } from '../utils/holdemBestFive';
 import { type PineappleKeepFeature, pineappleKeepFeatures } from '../utils/pineappleDiscardHint';
 import { findPlayerName } from '../utils/playerUtils';
-import { evaluateFiveCardHand, pokerHandKey } from '../utils/pokerSquaresUtils';
+import { evaluateFiveCardHand, type PokerHandRank, pokerHandKey } from '../utils/pokerSquaresUtils';
 
 /** Pineapple Poker tutorial step definitions. */
 const PN_TUTORIAL_STEPS: TutorialStep[] = [
@@ -260,8 +260,10 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
   }, [variant, isDiscardPhase, humanPlayer, state?.communityCards, selectedDiscards, discardCount]);
   // Crazy Pineapple discards 1 of 3 after the flop; annotate each hole card with
   // the best hand the OTHER two would make with the board if that card is the
-  // one discarded, so the player can compare keeps before committing.
-  const candidatePreviews = useMemo<(string | null)[] | null>(() => {
+  // one discarded, so the player can compare keeps before committing. Each entry
+  // carries both the i18n hand key and the raw rank, so the strongest keep can be
+  // flagged as recommended below.
+  const candidatePreviews = useMemo<({ handKey: string; rank: PokerHandRank } | null)[] | null>(() => {
     if (variant !== 'crazypineapple' || !isDiscardPhase) return null;
     const hole = humanPlayer?.cards ?? [];
     const board = state?.communityCards ?? [];
@@ -269,9 +271,25 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
       const all = [...hole.filter((_, i) => i !== discardIdx), ...board];
       const picked = holdemBestFive(all);
       const rank = picked ? evaluateFiveCardHand(picked.map((i) => all[i])) : null;
-      return rank == null ? null : pokerHandKey(rank);
+      return rank == null ? null : { handKey: pokerHandKey(rank), rank };
     });
   }, [variant, isDiscardPhase, humanPlayer, state?.communityCards]);
+  // The Crazy Pineapple discard(s) whose removal leaves the strongest resulting
+  // hand — flagged with a "recommended" badge and ring. When several discards
+  // tie for the best rank, all of them are flagged.
+  const recommendedDiscards = useMemo<Set<number>>(() => {
+    const out = new Set<number>();
+    if (!candidatePreviews) return out;
+    let best = -1;
+    for (const p of candidatePreviews) {
+      if (p && p.rank > best) best = p.rank;
+    }
+    if (best < 0) return out;
+    candidatePreviews.forEach((p, i) => {
+      if (p && p.rank === best) out.add(i);
+    });
+    return out;
+  }, [candidatePreviews]);
   // Irish Poker discards 2 of 4 hole cards. Once the FIRST card is chosen, annotate
   // each still-selectable card with the best hand the OTHER two kept cards would make
   // with the board if that card became the second discard — turning the C(3,1)=3
@@ -560,7 +578,8 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
                         const isSelected = selectedDiscards.includes(idx);
                         const inBest = showdownBest5.holeSet.has(idx);
                         const dim = showdownBest5.holeSet.size > 0 && !inBest;
-                        const candKey = candidatePreviews?.[idx] ?? null;
+                        const candKey = candidatePreviews?.[idx]?.handKey ?? null;
+                        const isRecommendedDiscard = recommendedDiscards.has(idx);
                         const irishCandKey = irishCandidatePreviews?.[idx] ?? null;
                         const keepFeatures = keepFeaturePreviews?.[idx] ?? null;
                         return (
@@ -569,7 +588,7 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
                               type="button"
                               onClick={() => toggleDiscard(idx)}
                               aria-pressed={canDiscard ? isSelected : undefined}
-                              className={`${canDiscard ? 'cursor-pointer' : 'cursor-default'} ${inBest ? 'rounded-lg ring-2 ring-ds-success motion-safe:animate-pulse' : ''} ${dim ? 'opacity-50' : ''}`}
+                              className={`${canDiscard ? 'cursor-pointer' : 'cursor-default'} ${inBest ? 'rounded-lg ring-2 ring-ds-success motion-safe:animate-pulse' : ''} ${isRecommendedDiscard ? 'rounded-lg ring-2 ring-ds-info' : ''} ${dim ? 'opacity-50' : ''}`}
                               disabled={!canDiscard}
                               style={selectedCardStyle(canDiscard && isSelected)}
                               data-testid={inBest ? 'pn-best5-card' : undefined}
@@ -582,6 +601,14 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
                                 data-testid="cp-discard-candidate"
                               >
                                 {`${t('discard.candidateHand')}: ${t(`hand.${candKey}`)}`}
+                              </span>
+                            )}
+                            {isRecommendedDiscard && (
+                              <span
+                                className="mt-0.5 rounded-full bg-ds-info/20 px-1.5 text-[10px] font-semibold text-ds-info"
+                                data-testid="cp-discard-recommended"
+                              >
+                                {t('discard.recommended')}
                               </span>
                             )}
                             {irishCandKey && (


### PR DESCRIPTION
## 概要

クレイジーパイナップルの捨て札フェーズで、**最も強い残り役を作れる捨て札候補**に「おすすめ」バッジと強調枠（`ring-ds-info`）を付けて、初心者が役の強弱を知らなくても最適な捨て札を選べるようにする。

`candidatePreviews` が各カードを捨てた場合の残り2枚+ボードのベストハンドを既に評価しているので、そのランク値を再利用して最大ランクの捨て札候補を推奨対象とする。同率最強が複数ある場合は全てに付与する。

## 変更点

- `frontend/src/pages/PineapplePage.tsx`
  - `candidatePreviews` を `{ handKey, rank }` を返すよう拡張し、`recommendedDiscards`（最強ランクの捨て札インデックス集合）を導出
  - 推奨カードに `ring-ds-info` の枠と `cp-discard-recommended` バッジを追加
  - `variant === 'crazypineapple'` のみに限定（pineapple / irishpoker は非影響）
- `frontend/src/i18n/locales/{ja,en}/crazypineapple.json`: `discard.recommended`（おすすめ / Recommended）を追加
- `frontend/src/pages/PineapplePage.test.tsx`: 単独最強・同率複数・ボード不足時の非表示・plain Pineapple 非表示のテストを追加

## 受け入れ条件

- [x] 最適候補に推奨バッジが表示される
- [x] 同率最強が複数ある場合は全てに付く
- [x] 既存の役名ラベル表示は維持される
- [x] 推奨判定のユニットテストを追加する

## テスト

- `bun run test -- --run Pineapple` … 75 passed
- `bun run check` … EXIT 0
- `bun run build` … EXIT 0

Closes #3019
