### PR TITLE
feat(labellelucie): highlight the suggested move on hint

### DIFF
--- a/frontend/src/pages/LaBelleLuciePage.test.tsx
+++ b/frontend/src/pages/LaBelleLuciePage.test.tsx
@@ -116,4 +116,45 @@ describe('LaBelleLuciePage', () => {
     await waitFor(() => expect(screen.getByTestId('fan-0')).toBeInTheDocument());
     expect(screen.queryByTestId('redeal-button')).not.toBeInTheDocument();
   });
+
+  it('highlights the hint source and destination fans after a hint', async () => {
+    mockExec.mockResolvedValue(makeState({ hint: { fromFan: 1, toFan: 0, toFoundation: false } }));
+    renderWithProviders(<LaBelleLuciePage />);
+    await screen.findByTestId('hint-button');
+    // No highlight until the player asks for a hint.
+    expect(screen.getByTestId('fan-1')).not.toHaveAttribute('data-hint-source');
+    fireEvent.click(screen.getByTestId('hint-button'));
+    await waitFor(() => expect(screen.getByTestId('fan-1')).toHaveAttribute('data-hint-source', 'true'));
+    expect(screen.getByTestId('fan-0')).toHaveAttribute('data-hint-dest', 'true');
+    expect(screen.getByTestId('ll-foundation-row')).not.toHaveAttribute('data-hint-foundation');
+  });
+
+  it('highlights the foundation row for a to-foundation hint', async () => {
+    mockExec.mockResolvedValue(makeState({ hint: { fromFan: 2, toFan: -1, toFoundation: true } }));
+    renderWithProviders(<LaBelleLuciePage />);
+    await screen.findByTestId('hint-button');
+    fireEvent.click(screen.getByTestId('hint-button'));
+    await waitFor(() =>
+      expect(screen.getByTestId('ll-foundation-row')).toHaveAttribute('data-hint-foundation', 'true'),
+    );
+    expect(screen.getByTestId('fan-2')).toHaveAttribute('data-hint-source', 'true');
+    // No fan is marked as the destination when the move targets a foundation.
+    expect(screen.getByTestId('fan-0')).not.toHaveAttribute('data-hint-dest');
+  });
+
+  it('clears the hint highlight when the board changes', async () => {
+    mockExec
+      .mockResolvedValueOnce(makeState()) // mount reset
+      .mockResolvedValueOnce(makeState({ hint: { fromFan: 1, toFan: 0, toFoundation: false } })) // hint
+      .mockResolvedValue(makeState({ moveCount: 1 })); // subsequent move advances the board
+    renderWithProviders(<LaBelleLuciePage />);
+    await screen.findByTestId('hint-button');
+    fireEvent.click(screen.getByTestId('hint-button'));
+    await waitFor(() => expect(screen.getByTestId('fan-1')).toHaveAttribute('data-hint-source', 'true'));
+    // Perform a move: select fan-1 then drop on fan-0.
+    fireEvent.click(screen.getByTestId('fan-1'));
+    fireEvent.click(screen.getByTestId('fan-0'));
+    await waitFor(() => expect(screen.getByTestId('fan-1')).not.toHaveAttribute('data-hint-source'));
+    expect(screen.getByTestId('fan-0')).not.toHaveAttribute('data-hint-dest');
+  });
 });

--- a/frontend/src/pages/LaBelleLuciePage.tsx
+++ b/frontend/src/pages/LaBelleLuciePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { labellelucieApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CardImage } from '../components/CardImage';
@@ -54,18 +54,29 @@ function LaBelleLuciePageContent() {
     useGamePageSetup('labellelucie');
   const { state, loading, error, exec, retry } = useGameApi(labellelucieApi.exec);
   const [selected, setSelected] = useState<number | null>(null);
+  // Whether the last hint's suggested move is currently highlighted on the board.
+  // The move coordinates themselves come from `state.hint` (set by the server on a
+  // `hint` command); this flag just gates the rings so they only show after the
+  // player asks for a hint, then auto-dismiss.
+  const [showHint, setShowHint] = useState(false);
+  const hintTimerRef = useRef<number | null>(null);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: run once on mount.
   useEffect(() => {
     exec('reset');
   }, []);
 
-  // Clear a stale source selection whenever the board changes (redeal, undo,
-  // auto-complete) so a selected index can't point at a different fan.
+  // Clear a stale source selection (and any hint highlight) whenever the board
+  // changes (move, redeal, undo, auto-complete) so a selected/hinted index can't
+  // point at a different fan.
   // biome-ignore lint/correctness/useExhaustiveDependencies: deps are the change-trigger, not read in the body.
   useEffect(() => {
     setSelected(null);
+    setShowHint(false);
   }, [state?.moveCount, state?.redealsLeft]);
+
+  // Cancel a pending hint auto-dismiss timer on unmount.
+  useEffect(() => () => window.clearTimeout(hintTimerRef.current ?? undefined), []);
 
   const phaseNames = usePhaseNames('labellelucie', LL_PHASE_KEYS);
   const { cardWidth } = useCardDimensions();
@@ -85,8 +96,25 @@ function LaBelleLuciePageContent() {
   const handleReset = () => {
     hideActionLog();
     setSelected(null);
+    // A reset keeps moveCount/redealsLeft unchanged from a fresh board, so the
+    // board-change effect may not fire — clear any stale hint highlight here.
+    setShowHint(false);
+    window.clearTimeout(hintTimerRef.current ?? undefined);
     exec('reset');
   };
+
+  // Ask the server for a hint, then highlight the suggested move (source fan →
+  // destination fan/foundation) for a few seconds. Does not execute the move.
+  const handleHint = () => {
+    exec('hint');
+    setShowHint(true);
+    window.clearTimeout(hintTimerRef.current ?? undefined);
+    hintTimerRef.current = window.setTimeout(() => setShowHint(false), 4000);
+  };
+
+  // The move to highlight, only while the highlight is active.
+  const hint = showHint ? state.hint : undefined;
+  const hintFoundation = hint?.toFoundation === true;
 
   // Picking a fan: first click selects the source; second click moves to that fan.
   const pickFan = (idx: number) => {
@@ -110,31 +138,45 @@ function LaBelleLuciePageContent() {
   };
 
   /** Renders a fan as a small overlapping vertical pile; only the top is interactive. */
-  const renderFan = (fan: Card[], idx: number) => (
-    <button
-      type="button"
-      key={`fan-${idx}`}
-      className={`relative flex flex-col items-center rounded p-1 ${selected === idx ? 'ring-2 ring-ds-warning' : ''} ${canAct ? 'cursor-pointer' : ''}`}
-      style={{ minHeight: Math.round(w * 1.4) }}
-      onClick={canAct ? () => pickFan(idx) : undefined}
-      disabled={!canAct}
-      data-testid={`fan-${idx}`}
-    >
-      {fan.length === 0 ? (
-        <div
-          className="rounded border border-dashed border-white/25 bg-black/20"
-          style={{ width: w, height: Math.round(w * 1.4) }}
-          title={t('empty')}
-        />
-      ) : (
-        fan.map((c, i) => (
-          <div key={`fan-${idx}-${i}`} style={{ marginTop: i === 0 ? 0 : -Math.round(w * 1.0) }}>
-            <CardImage card={c} width={w} />
-          </div>
-        ))
-      )}
-    </button>
-  );
+  const renderFan = (fan: Card[], idx: number) => {
+    const isHintSource = hint?.fromFan === idx;
+    const isHintDest = hint !== undefined && !hintFoundation && hint.toFan === idx;
+    // Source ring (info) and destination ring (success) are additive hint cues.
+    // A selected fan keeps its own warning ring; hint rings take visual priority
+    // via later class order when both would apply to the same fan.
+    const hintRing = isHintSource
+      ? ' ring-2 ring-ds-info motion-safe:animate-pulse'
+      : isHintDest
+        ? ' ring-2 ring-ds-success motion-safe:animate-pulse'
+        : '';
+    return (
+      <button
+        type="button"
+        key={`fan-${idx}`}
+        className={`relative flex flex-col items-center rounded p-1 ${selected === idx ? 'ring-2 ring-ds-warning' : ''}${hintRing} ${canAct ? 'cursor-pointer' : ''}`}
+        style={{ minHeight: Math.round(w * 1.4) }}
+        onClick={canAct ? () => pickFan(idx) : undefined}
+        disabled={!canAct}
+        data-testid={`fan-${idx}`}
+        data-hint-source={isHintSource ? 'true' : undefined}
+        data-hint-dest={isHintDest ? 'true' : undefined}
+      >
+        {fan.length === 0 ? (
+          <div
+            className="rounded border border-dashed border-white/25 bg-black/20"
+            style={{ width: w, height: Math.round(w * 1.4) }}
+            title={t('empty')}
+          />
+        ) : (
+          fan.map((c, i) => (
+            <div key={`fan-${idx}-${i}`} style={{ marginTop: i === 0 ? 0 : -Math.round(w * 1.0) }}>
+              <CardImage card={c} width={w} />
+            </div>
+          ))
+        )}
+      </button>
+    );
+  };
 
   return (
     <GamePageShell
@@ -153,7 +195,11 @@ function LaBelleLuciePageContent() {
         {/* Foundations */}
         <div className="mb-3" data-tutorial="ll-foundation">
           <span className="text-ds-text-muted text-[11px]">{t('foundation')}</span>
-          <div className="flex gap-1 mt-0.5">
+          <div
+            className={`flex gap-1 mt-0.5 rounded${hintFoundation ? ' ring-2 ring-ds-success motion-safe:animate-pulse p-1' : ''}`}
+            data-testid="ll-foundation-row"
+            data-hint-foundation={hintFoundation ? 'true' : undefined}
+          >
             {state.foundation.map((pile, i) => (
               <button
                 type="button"
@@ -252,7 +298,7 @@ function LaBelleLuciePageContent() {
             <button
               type="button"
               className={btnPrimary}
-              onClick={() => exec('hint')}
+              onClick={handleHint}
               disabled={loading}
               data-testid="hint-button"
             >


### PR DESCRIPTION
## 概要

ラ・ベル・ルーシーのヒントボタンは移動候補をテキスト（移動元ファン番号→移動先）で返すだけで、盤面のどのファンを指しているかを番号から目視で探す必要があった。本PRはヒントレスポンス（`fromFan` / `toFan` / `toFoundation`）をページ側で受け取り、移動元・移動先を盤面上でリング強調する（`BlackHolePage` と同様のUX）。フロントエンドのみ。

## 変更点

- 移動元ファンに `ring-ds-info`、移動先ファンに `ring-ds-success` のリングを追加表示
- 移動先がファウンデーションの場合はファウンデーション行枠を `ring-ds-success` で強調
- ヒントは実行せず、数秒後・または盤面変化（移動 / リディール / アンドゥ / オートコンプリート）・リセットで自動解除
- `data-hint-source` / `data-hint-dest` / `data-hint-foundation` 属性でテスト可能に
- `LaBelleLuciePage.test.tsx` にハイライトのテスト3件を追加

## 受け入れ条件

- [x] ヒント実行で移動元・移動先ファンが視覚強調される
- [x] ファウンデーション行きヒントはファウンデーション枠を強調
- [x] 移動やリディールで強調が自動解除される
- [x] `LaBelleLuciePage.test.tsx` にハイライトのテストを追加

## テスト

- `bun run check` : pass
- `bun run test -- --run LaBelleLuciePage` : 13 passed
- `bun run build` : pass

Closes #3577
