### PR TITLE
feat(blackhole): emphasize the backend-recommended fan on the board

### DIFF
--- a/frontend/src/i18n/locales/en/blackhole.json
+++ b/frontend/src/i18n/locales/en/blackhole.json
@@ -28,6 +28,8 @@
   "holeAria": "Black hole: {{card}}",
   "holeEmptyAria": "Black hole: empty",
   "hintPlayable": "playable",
+  "hintRecommended": "recommended",
+  "hintRecommendedAnnounce": "Recommended: {{card}} (fan {{fan}})",
   "hintLegalFans": "Playable: {{list}}",
   "hintNoLegal": "No playable card",
   "acceptableRanks": "Playable ranks: {{ranks}}",

--- a/frontend/src/i18n/locales/ja/blackhole.json
+++ b/frontend/src/i18n/locales/ja/blackhole.json
@@ -28,6 +28,8 @@
   "holeAria": "ブラックホール: {{card}}",
   "holeEmptyAria": "ブラックホール: 空",
   "hintPlayable": "置けます",
+  "hintRecommended": "おすすめ",
+  "hintRecommendedAnnounce": "おすすめ: {{card}}（ファン{{fan}}）",
   "hintLegalFans": "置けるカード: {{list}}",
   "hintNoLegal": "置けるカードがありません",
   "acceptableRanks": "受け入れ可能: {{ranks}}",

--- a/frontend/src/pages/BlackHolePage.test.tsx
+++ b/frontend/src/pages/BlackHolePage.test.tsx
@@ -106,9 +106,38 @@ describe('BlackHolePage', () => {
     expect(screen.getByTestId('card-0-1').className).toContain('ring-ds-success');
     // The non-adjacent fan top is never marked.
     expect(otherTop).not.toHaveAttribute('data-hinted-legal');
+    // With no backend recommendation, it falls back to the plain legal highlight.
+    expect(screen.getByTestId('card-0-1')).not.toHaveAttribute('data-hinted-recommended');
     // Non-visual channels: aria-label gains "置けます" and the live region lists it.
     expect(screen.getByTestId('card-0-1')).toHaveAttribute('aria-label', '♣ 6（ファン1） · 置けます');
     expect(screen.getByTestId('bh-hint-announce')).toHaveTextContent('置けるカード: ♣ 6（ファン1）');
+  });
+
+  it('strongly emphasises the backend-recommended fan, distinct from other legal fans', async () => {
+    // Hole top 7 → fan0 top ♣6 and fan2 top ♠8 are both legal; the backend
+    // recommends fan 2.
+    const state = makeState({ blackHole: [card('SPADE', 7)], hint: { fan: 2 } });
+    state.fans[2] = [card('SPADE', 8)];
+    mockExec.mockResolvedValue(state);
+    renderWithProviders(<BlackHolePage />);
+    await screen.findByTestId('hint-button');
+    fireEvent.click(screen.getByTestId('hint-button'));
+
+    // The recommended fan carries both the legal ring and the distinct gold outline.
+    const recommended = await screen.findByTestId('card-2-0');
+    await waitFor(() => expect(recommended).toHaveAttribute('data-hinted-recommended', 'true'));
+    expect(recommended).toHaveAttribute('data-hinted-legal', 'true');
+    expect(recommended.className).toContain('outline-ds-warning');
+    expect(recommended).toHaveAttribute('aria-label', '♠ 8（ファン3） · おすすめ · 置けます');
+
+    // The other legal fan is highlighted but NOT recommended (two-tier).
+    const otherLegal = screen.getByTestId('card-0-1');
+    expect(otherLegal).toHaveAttribute('data-hinted-legal', 'true');
+    expect(otherLegal).not.toHaveAttribute('data-hinted-recommended');
+    expect(otherLegal.className).not.toContain('outline-ds-warning');
+
+    // The live region leads with the recommendation.
+    expect(screen.getByTestId('bh-hint-announce')).toHaveTextContent('おすすめ: ♠ 8（ファン3）');
   });
 
   it('labels fan cards and the black hole for screen readers', async () => {

--- a/frontend/src/pages/BlackHolePage.tsx
+++ b/frontend/src/pages/BlackHolePage.tsx
@@ -122,11 +122,22 @@ function BlackHolePageContent() {
   // A/K ends only one neighbour survives the clamp, so a single rank is shown.
   const acceptableRanks = holeTop ? [holeTop.value - 1, holeTop.value + 1].filter((v) => v >= 1 && v <= 13) : [];
 
-  // Spoken hint result: list the playable fan-top cards (or "none"), shown only
-  // while the visual highlight is active.
-  const hintAnnounce = !showLegalHint
-    ? ''
-    : legalFans.size > 0
+  // The backend's strategic recommendation (single "best" fan to dig, e.g. one
+  // that avoids getting stuck). `state.hint` is only populated by a `hint`
+  // request and is cleared on the next move, so gate it on `showLegalHint` to
+  // match the legal-highlight window. It is a stronger, distinct emphasis layered
+  // on top of the ±1 legal highlight (the recommended fan is always legal).
+  const recommendedFan = showLegalHint ? (state.hint?.fan ?? null) : null;
+  const recommendedTop =
+    recommendedFan !== null && state.fans[recommendedFan]?.length
+      ? state.fans[recommendedFan][state.fans[recommendedFan].length - 1]
+      : null;
+
+  // Spoken hint result: lead with the backend's recommended card (when any),
+  // then list every playable fan-top (or "none"), shown only while the visual
+  // highlight is active.
+  const legalFansAnnounce =
+    legalFans.size > 0
       ? t('hintLegalFans', {
           list: [...legalFans]
             .map((idx) => {
@@ -137,6 +148,11 @@ function BlackHolePageContent() {
             .join('、'),
         })
       : t('hintNoLegal');
+  const hintAnnounce = !showLegalHint
+    ? ''
+    : recommendedTop && recommendedFan !== null
+      ? `${t('hintRecommendedAnnounce', { card: cardAlt(recommendedTop), fan: recommendedFan + 1 })} · ${legalFansAnnounce}`
+      : legalFansAnnounce;
 
   const renderFan = (fan: (typeof state.fans)[number], idx: number) => (
     <div
@@ -155,18 +171,27 @@ function BlackHolePageContent() {
         fan.map((c, i) => {
           const isTop = i === fan.length - 1;
           const isHintedLegal = showLegalHint && isTop && legalFans.has(idx);
+          // The backend's recommended fan gets an additive, distinct emphasis
+          // (a gold outline + ★ badge) layered on top of the green legal ring.
+          const isRecommended = recommendedFan === idx && isTop;
           const cardLabel = t('fanCardAria', { card: cardAlt(c), fan: idx + 1 });
+          const marks = [isRecommended ? t('hintRecommended') : '', isHintedLegal ? t('hintPlayable') : '']
+            .filter(Boolean)
+            .join(' · ');
           return (
             <button
               type="button"
               key={`fan-${idx}-${i}`}
-              className={`relative rounded ${isHintedLegal ? 'ring-2 ring-ds-success motion-safe:animate-pulse' : ''}`}
+              className={`relative rounded ${isHintedLegal ? 'ring-2 ring-ds-success motion-safe:animate-pulse' : ''} ${
+                isRecommended ? 'outline outline-2 outline-offset-2 outline-ds-warning' : ''
+              }`}
               style={{ marginTop: i === 0 ? 0 : -Math.round(w * 1.05) }}
               onClick={canAct && isTop ? () => playFan(idx) : undefined}
               disabled={!canAct || !isTop}
               data-testid={`card-${idx}-${i}`}
               data-hinted-legal={isHintedLegal ? 'true' : undefined}
-              aria-label={isHintedLegal ? `${cardLabel} · ${t('hintPlayable')}` : cardLabel}
+              data-hinted-recommended={isRecommended ? 'true' : undefined}
+              aria-label={marks ? `${cardLabel} · ${marks}` : cardLabel}
             >
               <CardImage card={c} width={w} />
               {/* Colour-independent hint marker (a ✓ badge) alongside the ring. */}
@@ -176,6 +201,15 @@ function BlackHolePageContent() {
                   className="absolute -top-1 -right-1 rounded-full bg-ds-success text-white text-[10px] leading-none px-1 py-0.5"
                 >
                   ✓
+                </span>
+              )}
+              {/* Distinct recommended marker (a ★ badge) for the backend's pick. */}
+              {isRecommended && (
+                <span
+                  aria-hidden="true"
+                  className="absolute -bottom-1 -left-1 rounded-full bg-ds-warning text-white text-[10px] leading-none px-1 py-0.5"
+                >
+                  ★
                 </span>
               )}
             </button>

--- a/internal/adapter/presenter/BlackHoleWebPresenter.go
+++ b/internal/adapter/presenter/BlackHoleWebPresenter.go
@@ -47,10 +47,16 @@ func (p *BlackHoleWebPresenter) Output(g interfaces.BlackHoleGame, lastErr error
 }
 
 // HintOutput ヒントをJSON出力する。
+//
+// The board (fans + black hole) is included so the client can keep rendering the
+// tableau after a hint request: the Black Hole page replaces its whole state from
+// this response, so an empty board would blank the tableau. The recommended fan is
+// surfaced via Hint for a two-tier highlight (strong ring on the recommended fan,
+// weaker ring on the other legal fans).
 func (p *BlackHoleWebPresenter) HintOutput(g interfaces.BlackHoleGame) string {
 	resObj := p.buildBaseOutput(g)
-	resObj.Fans = make([][]*controller.WebOutputCard, 0)
-	resObj.BlackHole = make([]*controller.WebOutputCard, 0)
+	resObj.Fans = blackHoleFansOutput(g.GetFans())
+	resObj.BlackHole = cardsToOutputOrEmpty(g.GetBlackHole())
 	if hint := g.GetHint(); hint != nil {
 		resObj.Hint = &controller.BlackHoleWebOutputHint{Fan: hint.Fan}
 		resObj.MessageCode = "blackhole.hintAvailable"

--- a/internal/adapter/presenter/BlackHoleWebPresenter_test.go
+++ b/internal/adapter/presenter/BlackHoleWebPresenter_test.go
@@ -35,10 +35,27 @@ func TestBlackHoleWebPresenter_Output(t *testing.T) {
 		assert.Contains(t, p.Output(bhState(t, `{"ph":2}`), nil), "blackhole.gameOver")
 	})
 
-	t.Run("hint output", func(t *testing.T) {
+	t.Run("hint output carries recommended fan and full board", func(t *testing.T) {
+		// Hole top 5, fan0 top 6 (±1) -> the domain recommends fan 0.
 		js := `{"bh":[{"d":1,"v":5,"w":true}],"fn":[[{"d":2,"v":6,"w":true}]],"ph":0}`
-		assert.Contains(t, p.HintOutput(bhState(t, js)), "blackhole.hintAvailable")
-		assert.Contains(t, p.HintOutput(bhState(t, `{"ph":2}`)), "blackhole.noHint")
+		out := p.HintOutput(bhState(t, js))
+		for _, frag := range []string{
+			"blackhole.hintAvailable",
+			`"hint":{"fan":0}`,
+			`"fans":[[`, // the board is preserved so the tableau does not blank out
+			`"blackHole":[`,
+		} {
+			assert.Contains(t, out, frag)
+		}
+	})
+
+	t.Run("hint output without a playable move still keeps the board", func(t *testing.T) {
+		// Hole top 5, fan0 top 10 (not ±1) -> no recommendation.
+		js := `{"bh":[{"d":1,"v":5,"w":true}],"fn":[[{"d":2,"v":10,"w":true}]],"ph":0}`
+		out := p.HintOutput(bhState(t, js))
+		assert.Contains(t, out, "blackhole.noHint")
+		assert.NotContains(t, out, `"hint":`)
+		assert.Contains(t, out, `"fans":[[`)
 	})
 
 	t.Run("action log is valid JSON", func(t *testing.T) {


### PR DESCRIPTION
Closes #3587

## What
Black Hole's hint button now emphasises the backend's **strategic recommendation** (the fan `GetHint` picks to dig next), not just the uniform ±1 legal ring. Two-tier board highlight:

- **Recommended fan** (backend `hint.fan`): distinct gold `outline-ds-warning` + ★ badge, layered on top of the legal ring.
- **Other legal fans**: unchanged green `ring-ds-success` + ✓.
- No recommendation → falls back to the existing legal highlight.

## Why / notable finding
`BlackHoleWebPresenter.HintOutput` previously returned an **empty board** (`"fans":[]`, `"blackHole":[]`). Because `BlackHolePage` uses `useGameApi` and replaces its entire state from each response (unlike Klondike's separate hint hook), a real `hint` request would blank the tableau in production — the pre-existing legal highlight only "worked" because tests mock a full state. `HintOutput` now includes the full board alongside the hint, fixing that latent bug and letting the page read `state.hint.fan`.

Presenter-only backend change (WASM-neutral; `blackhole` is on the `solo` worker and the presenter already carries the `!js || !wasm || solo` tag). The no-wrap legal highlight is untouched.

## Changes
- `internal/adapter/presenter/BlackHoleWebPresenter.go` — `HintOutput` includes fans + black hole.
- `internal/adapter/presenter/BlackHoleWebPresenter_test.go` — asserts board preserved + `hint.fan`, and no-hint keeps board.
- `frontend/src/pages/BlackHolePage.tsx` — recommended-fan emphasis (outline + ★ badge + aria + live region), gated on the same hint window.
- `frontend/src/pages/BlackHolePage.test.tsx` — two-tier emphasis + fallback tests.
- `frontend/src/i18n/locales/{ja,en}/blackhole.json` — `hintRecommended`, `hintRecommendedAnnounce`.

## Acceptance criteria
- [x] Hint distinguishes the recommended fan from other legal fans
- [x] Falls back to the plain legal highlight when there is no recommendation
- [x] WebPresenter hint-output test added
- [x] Page highlight-branch test added

## Test plan
- [x] `go test -tags test ./internal/adapter/presenter/` — pass
- [x] `golangci-lint run ./internal/adapter/presenter/...` — 0 issues
- [x] `bun run check` — pass
- [x] `bun run test -- --run BlackHolePage` — 15 pass
- [x] `bun run build` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)