### PR TITLE
feat(koikoi): make the frontend hint toggle actually work

### DIFF
--- a/frontend/src/i18n/locales/en/koikoi.json
+++ b/frontend/src/i18n/locales/en/koikoi.json
@@ -60,10 +60,10 @@
     "tsukimi": "Moon Viewing"
   },
   "hint": {
-    "koikoi_capture": "Capture the higher-value field card",
-    "koikoi_play": "Play a card from your hand",
-    "koikoi_continue": "Call koi-koi to build a bigger yaku",
-    "koikoi_stop": "Call shobu to lock in your points"
+    "capture": "Capture the higher-value field card",
+    "discard_low": "Discard a low-value card",
+    "koikoi_lowyaku": "Call koi-koi to build a bigger yaku",
+    "stop_secure": "Call shobu to lock in your points"
   },
   "tutorial": {
     "field": "These are the field cards. A played hand card captures a field card of the same month (flower). When two cards match, you choose which to take.",

--- a/frontend/src/i18n/locales/ja/koikoi.json
+++ b/frontend/src/i18n/locales/ja/koikoi.json
@@ -60,10 +60,10 @@
     "tsukimi": "月見酒"
   },
   "hint": {
-    "koikoi_capture": "価値の高い場札を捕獲する",
-    "koikoi_play": "手札から札を出す",
-    "koikoi_continue": "こいこいして役を伸ばす",
-    "koikoi_stop": "勝負して得点を確定する"
+    "capture": "価値の高い場札を捕獲する",
+    "discard_low": "価値の低い札を場に出す",
+    "koikoi_lowyaku": "こいこいして役を伸ばす",
+    "stop_secure": "勝負して得点を確定する"
   },
   "tutorial": {
     "field": "場の札です。出した手札と同じ月（花）の場札を捕獲します。2枚が一致する場合はどちらを取るか選びます。",

--- a/frontend/src/pages/KoiKoiPage.test.tsx
+++ b/frontend/src/pages/KoiKoiPage.test.tsx
@@ -140,6 +140,23 @@ describe('KoiKoiPage', () => {
     expect(mockExec).not.toHaveBeenCalled();
   });
 
+  it('offers the frontend hint toggle, off by default with no tooltip', async () => {
+    renderWithProviders(<KoiKoiPage />);
+    const toggle = await screen.findByLabelText('ヒント表示');
+    expect(toggle).not.toBeChecked();
+    expect(screen.queryByTestId('hint-tooltip')).not.toBeInTheDocument();
+  });
+
+  it('shows the hint tooltip when the toggle is enabled and state.hint is set', async () => {
+    localStorage.setItem('hint_enabled_koikoi', 'true');
+    mockExec.mockResolvedValue(
+      makeKoiKoiState({ hint: { cardIndex: 0, fieldIndex: 0, koikoi: -1, reason: 'capture' } }),
+    );
+    renderWithProviders(<KoiKoiPage />);
+    const tooltip = await screen.findByTestId('hint-tooltip');
+    expect(tooltip).toHaveTextContent('価値の高い場札を捕獲する');
+  });
+
   it('ignores a field click that is not a capture candidate', async () => {
     mockExec.mockResolvedValue(makeKoiKoiState({ captureOptions: { 0: [0, 1] } }));
     renderWithProviders(<KoiKoiPage />);

--- a/frontend/src/utils/hints/koikoiHint.ts
+++ b/frontend/src/utils/hints/koikoiHint.ts
@@ -6,11 +6,12 @@ import type { HintResult } from '../../types/hint';
  * suggestion is available.
  *
  * Koi-Koi's hint is computed entirely by the Go backend and surfaced on the
- * response's `hint` field (with a `reason` i18n suffix such as `koikoi_capture`,
- * `koikoi_continue`, or `koikoi_stop`). This adapter re-maps that server hint
- * into the frontend HintResult shape so the shared {@link useGameHint} tooltip
- * can render it. During the KoiKoiDecision phase the hint points at the
- * koi-koi/shobu choice; during Play it points at which card to play.
+ * response's `hint` field (with a `reason` i18n suffix such as `capture`,
+ * `discard_low`, `koikoi_lowyaku`, or `stop_secure`). This adapter re-maps that
+ * server hint into the frontend HintResult shape so the shared
+ * {@link useGameHint} tooltip can render it. During the KoiKoiDecision phase the
+ * hint points at the koi-koi/shobu choice; during Play it points at which card
+ * to play.
  */
 export function getKoiKoiHint(state: KoiKoiResponse): HintResult | null {
   const hint = state.hint;

--- a/internal/adapter/presenter/KoiKoiWebPresenter.go
+++ b/internal/adapter/presenter/KoiKoiWebPresenter.go
@@ -57,7 +57,25 @@ func (p *KoiKoiWebPresenter) Output(g interfaces.KoiKoiGame, lastErr error) stri
 		resObj.MessageCode = "koikoi.result.scores"
 		resObj.MessageParams = map[string]string{"scores": p.encodeScoresParam(g)}
 	}
+	// 人間の手番 (プレイ／こいこい判断) ではヒントを埋め、フロントエンドのヒントトグルを
+	// 機能させる。GetHint は CPU 手番・ゲーム終了・対象外フェーズでは nil を返すため、
+	// その場合 Hint は設定されない。
+	p.applyHint(resObj, g)
 	return marshalOrError(resObj)
+}
+
+// applyHint は人間の手番であればヒント情報を出力オブジェクトへ埋める。
+// g.GetHint() は CPU 手番・ゲーム終了・対象外フェーズでは nil を返すため、
+// その場合 Hint は設定されず、omitempty により JSON からも省かれる。
+func (p *KoiKoiWebPresenter) applyHint(resObj *controller.KoiKoiWebOutput, g interfaces.KoiKoiGame) {
+	if hint := g.GetHint(); hint != nil {
+		resObj.Hint = &controller.KoiKoiWebOutputHint{
+			CardIndex:  hint.CardIndex,
+			FieldIndex: hint.FieldIndex,
+			KoiKoi:     hint.KoiKoi,
+			Reason:     hint.Reason,
+		}
+	}
 }
 
 // buildBase は基本フィールドを埋めた出力オブジェクトを生成する。
@@ -180,14 +198,7 @@ func (p *KoiKoiWebPresenter) buildResultMessage(g interfaces.KoiKoiGame) string 
 // HintOutput はヒント情報を JSON 出力する。
 func (p *KoiKoiWebPresenter) HintOutput(g interfaces.KoiKoiGame) string {
 	resObj := p.buildBase(g)
-	if hint := g.GetHint(); hint != nil {
-		resObj.Hint = &controller.KoiKoiWebOutputHint{
-			CardIndex:  hint.CardIndex,
-			FieldIndex: hint.FieldIndex,
-			KoiKoi:     hint.KoiKoi,
-			Reason:     hint.Reason,
-		}
-	}
+	p.applyHint(resObj, g)
 	return marshalOrError(resObj)
 }
 

--- a/internal/adapter/presenter/KoiKoiWebPresenter_test.go
+++ b/internal/adapter/presenter/KoiKoiWebPresenter_test.go
@@ -92,6 +92,41 @@ func TestKoiKoiWebPresenter_GameEnd(t *testing.T) {
 	assert.Equal(t, "koikoi.result.scores", decoded["messageCode"])
 }
 
+// TestKoiKoiWebPresenter_Output_HintOnHumanTurn は通常の Output() が人間の手番 (プレイ
+// フェーズ) でヒントを埋めることを検証する (#3516: フロントエンドのヒントトグルが機能する
+// 前提条件)。
+func TestKoiKoiWebPresenter_Output_HintOnHumanTurn(t *testing.T) {
+	g := domain.NewDefaultKoiKoi()
+	g.Reset()
+	g.SetCurrentTurn(0) // player 0 は人間
+
+	p := new(presenter.KoiKoiWebPresenter)
+	var decoded struct {
+		Hint *struct {
+			CardIndex  int    `json:"cardIndex"`
+			FieldIndex int    `json:"fieldIndex"`
+			KoiKoi     int    `json:"koikoi"`
+			Reason     string `json:"reason"`
+		} `json:"hint"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(p.Output(g, nil)), &decoded))
+	require.NotNil(t, decoded.Hint, "human play turn must include a hint")
+	assert.NotEmpty(t, decoded.Hint.Reason)
+}
+
+// TestKoiKoiWebPresenter_Output_NoHintOnCpuTurn は CPU の手番では Output() がヒントを
+// 出力しない (omitempty で省かれる) ことを検証する (#3516)。
+func TestKoiKoiWebPresenter_Output_NoHintOnCpuTurn(t *testing.T) {
+	g := domain.NewDefaultKoiKoi()
+	g.Reset()
+	g.SetCurrentTurn(1) // player 1 は CPU
+
+	p := new(presenter.KoiKoiWebPresenter)
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal([]byte(p.Output(g, nil)), &decoded))
+	assert.NotContains(t, decoded, "hint", "cpu turn must not include a hint")
+}
+
 func TestKoiKoiWebPresenter_HintOutput(t *testing.T) {
 	g := domain.NewDefaultKoiKoi()
 	g.Reset()


### PR DESCRIPTION
## Summary
The Koi-Koi frontend hint toggle was a dead feature. `KoiKoiWebPresenter.Output()` never set the `Hint` field on the response — only the separate `HintOutput()` path did — so `state.hint` was always `undefined` and toggling the hint on did nothing.

This is a **presenter-only** fix (no domain change; koikoi is on the near-limit `extra` WASM worker):

- Populate `Hint` in `Output()` on the human's turn via a shared `applyHint` helper. `GetHint()` already returns `nil` for CPU turns / game end / non-applicable phases, so no gating logic is duplicated.
- Refactor `HintOutput()` to reuse the same `applyHint` helper (removes duplication).
- Fix a latent i18n mismatch: the `hint` translation keys (`koikoi_capture/play/continue/stop`) never matched the domain's actual reason strings (`capture`, `discard_low`, `koikoi_lowyaku`, `stop_secure`), so `t('hint.<reason>')` would not have resolved even once the field was populated. Replaced the aspirational keys with the real ones in both ja/en locales.

The rest of the frontend pipeline (`useGameHint` → `getKoiKoiHint` → `HintTooltip`) was already wired; it just never received a hint.

## Acceptance criteria (#3516)
- [x] `Output()` includes the hint on the human's turn
- [x] Hint shows in play/decision phases when the toggle is on
- [x] No hint on the CPU's turn (`omitempty`)
- [x] `KoiKoiWebPresenter_test.go` verifies hint output (both branches)

## Tests
- Go: `TestKoiKoiWebPresenter_Output_HintOnHumanTurn`, `TestKoiKoiWebPresenter_Output_NoHintOnCpuTurn`
- Frontend: KoiKoiPage toggle-off (no tooltip) + toggle-on (tooltip renders translated reason)

## Gate
- `golangci-lint` on `internal/adapter/...`: 0 issues
- `go test -tags test ./internal/...`: pass
- `bun run check` / `bun run test` (KoiKoiPage, koikoiHint, koikoiFormatter: 26 pass) / `bun run build`: pass

Closes #3516