### PR TITLE
feat(gostop): make the frontend hint toggle actually work

### DIFF
--- a/frontend/src/pages/GoStopPage.test.tsx
+++ b/frontend/src/pages/GoStopPage.test.tsx
@@ -176,4 +176,22 @@ describe('GoStopPage', () => {
     fireEvent.click(screen.getByTestId('field-card-0'));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', { cardIndex: 0, fieldIndex: 0 }));
   });
+
+  it('renders the backend hint tooltip when the hint toggle is enabled (#3519)', async () => {
+    // #3519: the toggle was dead because state.hint was always undefined; Output() now populates it.
+    localStorage.setItem('hint_enabled_gostop', 'true');
+    mockExec.mockResolvedValue(makeGoStopState({ hint: { cardIndex: 0, fieldIndex: -1, go: -1, reason: 'capture' } }));
+    renderWithProviders(<GoStopPage />);
+    await waitFor(() => expect(screen.getByTestId('hint-tooltip')).toBeInTheDocument());
+    localStorage.removeItem('hint_enabled_gostop');
+  });
+
+  it('hides the hint tooltip when no hint is present even with the toggle enabled', async () => {
+    localStorage.setItem('hint_enabled_gostop', 'true');
+    mockExec.mockResolvedValue(makeGoStopState({ hint: null }));
+    renderWithProviders(<GoStopPage />);
+    await screen.findByTestId('hand-card-0');
+    expect(screen.queryByTestId('hint-tooltip')).not.toBeInTheDocument();
+    localStorage.removeItem('hint_enabled_gostop');
+  });
 });

--- a/internal/adapter/presenter/GoStopWebPresenter.go
+++ b/internal/adapter/presenter/GoStopWebPresenter.go
@@ -55,8 +55,25 @@ func (p *GoStopWebPresenter) Output(g interfaces.GoStopGame, lastErr error) stri
 		resObj.Message = p.buildResultMessage(g)
 		resObj.MessageCode = "gostop.result.scores"
 		resObj.MessageParams = map[string]string{"scores": p.encodeScoresParam(g)}
+	} else {
+		// 人間手番のプレイ/決断フェーズでは通常出力にもヒントを載せる。
+		// GetHint は CPU 手番/ゲーム終了時に nil を返すため、その場合 Hint は付かない。
+		p.applyHint(resObj, g)
 	}
 	return marshalOrError(resObj)
+}
+
+// applyHint は人間手番であればドメインのヒントを出力オブジェクトへ写す。CPU 手番や
+// 終了時など GetHint が nil を返すケースでは Hint フィールドを設定しない。
+func (p *GoStopWebPresenter) applyHint(resObj *controller.GoStopWebOutput, g interfaces.GoStopGame) {
+	if hint := g.GetHint(); hint != nil {
+		resObj.Hint = &controller.GoStopWebOutputHint{
+			CardIndex:  hint.CardIndex,
+			FieldIndex: hint.FieldIndex,
+			Go:         hint.Go,
+			Reason:     hint.Reason,
+		}
+	}
 }
 
 // breakdownToWeb は domain の得点内訳を Web 出力型へ変換する。
@@ -195,14 +212,7 @@ func (p *GoStopWebPresenter) buildResultMessage(g interfaces.GoStopGame) string 
 // HintOutput はヒント情報を JSON 出力する。
 func (p *GoStopWebPresenter) HintOutput(g interfaces.GoStopGame) string {
 	resObj := p.buildBase(g)
-	if hint := g.GetHint(); hint != nil {
-		resObj.Hint = &controller.GoStopWebOutputHint{
-			CardIndex:  hint.CardIndex,
-			FieldIndex: hint.FieldIndex,
-			Go:         hint.Go,
-			Reason:     hint.Reason,
-		}
-	}
+	p.applyHint(resObj, g)
 	return marshalOrError(resObj)
 }
 

--- a/internal/adapter/presenter/GoStopWebPresenter_test.go
+++ b/internal/adapter/presenter/GoStopWebPresenter_test.go
@@ -91,6 +91,57 @@ func TestGoStopWebPresenter_GameEnd(t *testing.T) {
 	assert.Equal(t, "gostop.result.scores", decoded["messageCode"])
 }
 
+// humanCpuIdx は人間/CPU の座席インデックスを返すヘルパ。
+func humanCpuIdx(g interface {
+	GetPlayerCnt() int
+	GetPlayer(int) *domain.GoStopPlayer
+}) (human, cpu int) {
+	human, cpu = -1, -1
+	for i := 0; i < g.GetPlayerCnt(); i++ {
+		if g.GetPlayer(i).GetIsHuman() {
+			human = i
+		} else {
+			cpu = i
+		}
+	}
+	return human, cpu
+}
+
+// TestGoStopWebPresenter_OutputHint は通常 Output() が人間手番でヒントを含み、CPU 手番では
+// 含まないことを検証する (#3519: 死んでいたヒントトグルを機能させる)。
+func TestGoStopWebPresenter_OutputHint(t *testing.T) {
+	g := domain.NewDefaultGoStop()
+	g.Reset()
+	human, cpu := humanCpuIdx(g)
+	require.GreaterOrEqual(t, human, 0)
+	require.GreaterOrEqual(t, cpu, 0)
+	p := new(presenter.GoStopWebPresenter)
+
+	// 人間手番のプレイフェーズ: hint が載る。
+	g.SetCurrentTurn(human)
+	g.SetPhase(domain.GoStopPhasePlay)
+	var withHint struct {
+		Hint *struct {
+			Reason string `json:"reason"`
+		} `json:"hint"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(p.Output(g, nil)), &withHint))
+	require.NotNil(t, withHint.Hint)
+	assert.NotEmpty(t, withHint.Hint.Reason)
+
+	// CPU 手番: hint は載らない。
+	g.SetCurrentTurn(cpu)
+	var cpuTurn map[string]any
+	require.NoError(t, json.Unmarshal([]byte(p.Output(g, nil)), &cpuTurn))
+	assert.NotContains(t, cpuTurn, "hint")
+
+	// エラー時: hint は載らない。
+	g.SetCurrentTurn(human)
+	var errOut map[string]any
+	require.NoError(t, json.Unmarshal([]byte(p.Output(g, errors.New("boom"))), &errOut))
+	assert.NotContains(t, errOut, "hint")
+}
+
 func TestGoStopWebPresenter_HintOutput(t *testing.T) {
 	g := domain.NewDefaultGoStop()
 	g.Reset()


### PR DESCRIPTION
Closes #3519

## Problem
The Go-Stop frontend hint toggle was a dead feature. `GoStopPage.tsx` already wires the `frontendHint` checkbox through `useGameHint('gostop', state)` → `getGoStopHint` → `HintTooltip`, but `getGoStopHint` only re-maps `state.hint`. `GoStopWebPresenter.Output()` never set the `Hint` field (only the separate `HintOutput()` path did), so `state.hint` was always `undefined` and toggling the checkbox did nothing.

## Fix (presenter-only, WASM-neutral)
- Extract a shared `applyHint` helper that copies `g.GetHint()` onto the output. `HintOutput()` now reuses it (removes duplication).
- Call `applyHint` in `Output()` on the human's play/decision turn. The domain `GetHint()` is already fully human-turn gated (returns `nil` at game end, on CPU turns, and outside play/decision), so no hint leaks on CPU turns or in error/end responses.
- No domain change — the `extra` WASM worker is untouched.

## Tests
- **Go** `TestGoStopWebPresenter_OutputHint` (`GoStopWebPresenter_test.go`): asserts `Output()` includes a `hint` with a non-empty reason on the human play turn, and omits `hint` on the CPU turn and on error responses (both branches covered).
- **Frontend** `GoStopPage.test.tsx`: two new cases — tooltip renders when the toggle is enabled and `state.hint` is present (#3519), and stays hidden when no hint is present.

## Acceptance criteria
- [x] `Output()` includes Hint on the human turn
- [x] Toggle ON shows a hint during play / decision phases
- [x] No hint on CPU turns
- [x] Verification added to `GoStopWebPresenter_test.go`

## Gate
- [x] `goimports` + `golangci-lint run ./internal/adapter/...` (0 issues)
- [x] `go test -tags test ./internal/...` (all pass)
- [x] `bun run check` + `bun run test -- --run GoStopPage` (13 pass) + `bun run build`