### PR TITLE
feat(courtpiece): live team trick tally toward the 7-trick target during play

### DIFF
--- a/frontend/src/i18n/locales/en/courtpiece.json
+++ b/frontend/src/i18n/locales/en/courtpiece.json
@@ -47,6 +47,10 @@
     "heart": "♥ Hearts",
     "diamond": "♦ Diamonds"
   },
+  "liveTricks": {
+    "title": "This round",
+    "team": "{{team}} {{tricks}}/{{target}}"
+  },
   "roundResult": {
     "title": "Round Result (tricks won)",
     "teamA": "Team A: {{tricks}} tricks",

--- a/frontend/src/i18n/locales/ja/courtpiece.json
+++ b/frontend/src/i18n/locales/ja/courtpiece.json
@@ -47,6 +47,10 @@
     "heart": "♥ ハート",
     "diamond": "♦ ダイヤ"
   },
+  "liveTricks": {
+    "title": "今ラウンド",
+    "team": "{{team}} {{tricks}}/{{target}}"
+  },
   "roundResult": {
     "title": "ラウンド結果（獲得トリック）",
     "teamA": "チームA: {{tricks}}トリック",

--- a/frontend/src/pages/CourtPiecePage.test.tsx
+++ b/frontend/src/pages/CourtPiecePage.test.tsx
@@ -188,6 +188,58 @@ describe('CourtPiecePage', () => {
     await waitFor(() => expect(screen.getByRole('button', { name: '次のトリック' })).toBeInTheDocument());
   });
 
+  it('shows the live team-trick tally toward the 7-trick target during play', async () => {
+    mockExec.mockResolvedValue(
+      makeCourtPieceState({
+        phase: 1,
+        trumpSuit: 3,
+        currentPlayerIdx: 0,
+        players: [
+          { id: 0, isHuman: true, team: 0, cardCount: 9, cards: [], roundScore: 0, cumulativeScore: 0, trickCount: 3 },
+          { id: 1, isHuman: false, team: 1, cardCount: 9, cards: [], roundScore: 0, cumulativeScore: 0, trickCount: 1 },
+          { id: 2, isHuman: false, team: 0, cardCount: 9, cards: [], roundScore: 0, cumulativeScore: 0, trickCount: 1 },
+          { id: 3, isHuman: false, team: 1, cardCount: 9, cards: [], roundScore: 0, cumulativeScore: 0, trickCount: 1 },
+        ],
+      }),
+    );
+    renderWithProviders(<CourtPiecePage />);
+    // Team 0 = seats 0(3) + 2(1) = 4 tricks; team 1 = seats 1(1) + 3(1) = 2 tricks.
+    const teamA = await screen.findByTestId('cp-live-tricks-team-0');
+    expect(teamA).toHaveTextContent('チームA 4/7');
+    expect(screen.getByTestId('cp-live-tricks-team-1')).toHaveTextContent('チームB 2/7');
+    // Neither team has reached the target, so no accent emphasis.
+    expect(teamA.className).not.toContain('text-ds-accent');
+  });
+
+  it('emphasizes a team that has reached the 7-trick target during play', async () => {
+    mockExec.mockResolvedValue(
+      makeCourtPieceState({
+        phase: 1,
+        trumpSuit: 3,
+        currentPlayerIdx: 0,
+        players: [
+          { id: 0, isHuman: true, team: 0, cardCount: 2, cards: [], roundScore: 0, cumulativeScore: 0, trickCount: 4 },
+          { id: 1, isHuman: false, team: 1, cardCount: 2, cards: [], roundScore: 0, cumulativeScore: 0, trickCount: 2 },
+          { id: 2, isHuman: false, team: 0, cardCount: 2, cards: [], roundScore: 0, cumulativeScore: 0, trickCount: 3 },
+          { id: 3, isHuman: false, team: 1, cardCount: 2, cards: [], roundScore: 0, cumulativeScore: 0, trickCount: 2 },
+        ],
+      }),
+    );
+    renderWithProviders(<CourtPiecePage />);
+    // Team 0 = 4 + 3 = 7 tricks (target reached); team 1 = 4.
+    const teamA = await screen.findByTestId('cp-live-tricks-team-0');
+    expect(teamA).toHaveTextContent('チームA 7/7');
+    expect(teamA.className).toContain('text-ds-accent');
+    expect(screen.getByTestId('cp-live-tricks-team-1').className).not.toContain('text-ds-accent');
+  });
+
+  it('hides the live team-trick tally once the round ends', async () => {
+    mockExec.mockResolvedValue(roundEndState);
+    renderWithProviders(<CourtPiecePage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: '次のラウンド' })).toBeInTheDocument());
+    expect(screen.queryByTestId('cp-live-tricks')).not.toBeInTheDocument();
+  });
+
   it('renders round end with the next round button and the round result', async () => {
     mockExec.mockResolvedValue(roundEndState);
     renderWithProviders(<CourtPiecePage />);

--- a/frontend/src/pages/CourtPiecePage.tsx
+++ b/frontend/src/pages/CourtPiecePage.tsx
@@ -41,6 +41,9 @@ import { playerName } from '../utils/playerUtils';
 /** Suit symbols indexed by suit number (1=♠ 2=♣ 3=♥ 4=♦; index 0 = undeclared). */
 const SUIT_SYMBOLS = ['', '♠', '♣', '♥', '♦'] as const;
 
+/** Tricks a team must take within a 13-trick round to win it (Sar); mirrors CourtPieceTricksToWin in internal/domain/CourtPiece.go. */
+const COURT_PIECE_TRICKS_TO_WIN = 7;
+
 /** Court Piece (Rang) tutorial step definitions. */
 const COURT_PIECE_TUTORIAL_STEPS: TutorialStep[] = [
   { target: '[data-tutorial="courtpiece-info"]', messageKey: 'tutorial.info', placement: 'bottom', advanceOn: 'next' },
@@ -250,6 +253,31 @@ function CourtPiecePageContent() {
                   <div className="mt-1">
                     {t('yourTeam')}: {humanTeam === 0 ? t('team.a') : t('team.b')}
                   </div>
+                  {/* Live running trick tally toward the 7-trick round target (during play). */}
+                  {(isPlayPhase || isTrickEnd) && (
+                    <div className="mt-1 pt-1 border-t border-white/10" data-testid="cp-live-tricks">
+                      <span className="text-ds-text-primary">{t('liveTricks.title')}: </span>
+                      {([0, 1] as const).map((team, i) => {
+                        const tricks = teamTricks(team);
+                        const reached = tricks >= COURT_PIECE_TRICKS_TO_WIN;
+                        return (
+                          <span key={team}>
+                            {i > 0 && ' · '}
+                            <span
+                              className={reached ? 'text-ds-accent font-semibold' : ''}
+                              data-testid={`cp-live-tricks-team-${team}`}
+                            >
+                              {t('liveTricks.team', {
+                                team: team === 0 ? t('team.a') : t('team.b'),
+                                tricks,
+                                target: COURT_PIECE_TRICKS_TO_WIN,
+                              })}
+                            </span>
+                          </span>
+                        );
+                      })}
+                    </div>
+                  )}
                 </div>
 
                 {/* Players grouped by team, with the caller badge */}


### PR DESCRIPTION
## Summary

Court Piece is won by taking 7 of 13 tricks in a round (Sar), but the sidebar only showed per-player `trickCount`, forcing players to sum team totals by hand. This adds a live running tally to the team-score panel during the play / trick-end phases:

> 今ラウンド: チームA 4/7 · チームB 2/7

- Reuses the existing `teamTricks(team)` helper (team 0 = seats 0&2, team 1 = seats 1&3).
- The 7-trick target mirrors `CourtPieceTricksToWin` in `internal/domain/CourtPiece.go` (READ-ONLY; no Go touched).
- A team that reaches the target is emphasized in the accent color.
- Only shown during PLAY / TRICK_END; the existing round-result block (ROUND_END / GAME_END) is unchanged, and the recently-added legal-card highlight is untouched.

## Files
- `frontend/src/pages/CourtPiecePage.tsx`
- `frontend/src/pages/CourtPiecePage.test.tsx`
- `frontend/src/i18n/locales/{ja,en}/courtpiece.json`

## Acceptance criteria
- [x] Team trick totals shown with the 7 target during play
- [x] Visual emphasis when a team reaches 7
- [x] ja/en locale strings added
- [x] Tests added to `CourtPiecePage.test.tsx`

## Test plan
- [x] `bun run test -- --run CourtPiecePage` (15 passed)
- [x] `bun run check` (no new warnings; design-tokens OK)
- [x] `bun run build` (tsc) passes

Closes #3449