### PR TITLE
feat(hachihachi): populate hint in Output so the frontend hint toggle works

### DIFF
--- a/frontend/src/pages/HachiHachiPage.test.tsx
+++ b/frontend/src/pages/HachiHachiPage.test.tsx
@@ -37,6 +37,7 @@ const gameEndState = makeHachiHachiState({
 });
 
 beforeEach(() => {
+  localStorage.clear();
   mockExec.mockReset();
   mockExec.mockResolvedValue(playState);
 });
@@ -141,6 +142,21 @@ describe('HachiHachiPage', () => {
     mockExec.mockClear();
     fireEvent.click(card);
     expect(mockExec).not.toHaveBeenCalled();
+  });
+
+  it('offers the frontend hint toggle, off by default with no tooltip', async () => {
+    renderWithProviders(<HachiHachiPage />);
+    const toggle = await screen.findByLabelText('ヒント表示');
+    expect(toggle).not.toBeChecked();
+    expect(screen.queryByTestId('hint-tooltip')).not.toBeInTheDocument();
+  });
+
+  it('shows the hint tooltip when the toggle is enabled and state.hint is set', async () => {
+    localStorage.setItem('hint_enabled_hachihachi', 'true');
+    mockExec.mockResolvedValue(makeHachiHachiState({ hint: { cardIndex: 0, fieldIndex: 0, reason: 'capture' } }));
+    renderWithProviders(<HachiHachiPage />);
+    const tooltip = await screen.findByTestId('hint-tooltip');
+    expect(tooltip).toHaveTextContent('価値の高い場札を捕獲する');
   });
 
   it('ignores a field click that is not a capture candidate', async () => {

--- a/internal/adapter/presenter/HachiHachiWebPresenter.go
+++ b/internal/adapter/presenter/HachiHachiWebPresenter.go
@@ -55,7 +55,24 @@ func (p *HachiHachiWebPresenter) Output(g interfaces.HachiHachiGame, lastErr err
 		resObj.MessageCode = "hachihachi.result.scores"
 		resObj.MessageParams = map[string]string{"scores": p.encodeScoresParam(g)}
 	}
+	// 人間の手番 (プレイフェーズ) ではヒントを埋め、フロントエンドのヒントトグルを
+	// 機能させる。GetHint は CPU 手番・ゲーム終了・対象外フェーズでは nil を返すため、
+	// その場合 Hint は設定されない。
+	p.applyHint(resObj, g)
 	return marshalOrError(resObj)
+}
+
+// applyHint は人間の手番であればヒント情報を出力オブジェクトへ埋める。
+// g.GetHint() は CPU 手番・ゲーム終了・対象外フェーズでは nil を返すため、
+// その場合 Hint は設定されず、omitempty により JSON からも省かれる。
+func (p *HachiHachiWebPresenter) applyHint(resObj *controller.HachiHachiWebOutput, g interfaces.HachiHachiGame) {
+	if hint := g.GetHint(); hint != nil {
+		resObj.Hint = &controller.HachiHachiWebOutputHint{
+			CardIndex:  hint.CardIndex,
+			FieldIndex: hint.FieldIndex,
+			Reason:     hint.Reason,
+		}
+	}
 }
 
 // buildBase は基本フィールドを埋めた出力オブジェクトを生成する。
@@ -180,13 +197,7 @@ func (p *HachiHachiWebPresenter) buildResultMessage(g interfaces.HachiHachiGame)
 // HintOutput はヒント情報を JSON 出力する。
 func (p *HachiHachiWebPresenter) HintOutput(g interfaces.HachiHachiGame) string {
 	resObj := p.buildBase(g)
-	if hint := g.GetHint(); hint != nil {
-		resObj.Hint = &controller.HachiHachiWebOutputHint{
-			CardIndex:  hint.CardIndex,
-			FieldIndex: hint.FieldIndex,
-			Reason:     hint.Reason,
-		}
-	}
+	p.applyHint(resObj, g)
 	return marshalOrError(resObj)
 }
 

--- a/internal/adapter/presenter/HachiHachiWebPresenter_test.go
+++ b/internal/adapter/presenter/HachiHachiWebPresenter_test.go
@@ -49,6 +49,40 @@ func TestHachiHachiWebPresenter_Output(t *testing.T) {
 	assert.Contains(t, decoded, "captureOptions")
 }
 
+// TestHachiHachiWebPresenter_Output_HintOnHumanTurn は通常の Output() が人間の手番
+// (プレイフェーズ) でヒントを埋めることを検証する (#3522: フロントエンドのヒントトグルが
+// 機能する前提条件)。
+func TestHachiHachiWebPresenter_Output_HintOnHumanTurn(t *testing.T) {
+	g := domain.NewDefaultHachiHachi()
+	g.Reset()
+	g.SetCurrentTurn(0) // player 0 は人間
+
+	p := new(presenter.HachiHachiWebPresenter)
+	var decoded struct {
+		Hint *struct {
+			CardIndex  int    `json:"cardIndex"`
+			FieldIndex int    `json:"fieldIndex"`
+			Reason     string `json:"reason"`
+		} `json:"hint"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(p.Output(g, nil)), &decoded))
+	require.NotNil(t, decoded.Hint, "human play turn must include a hint")
+	assert.NotEmpty(t, decoded.Hint.Reason)
+}
+
+// TestHachiHachiWebPresenter_Output_NoHintOnCpuTurn は CPU の手番では Output() が
+// ヒントを出力しない (omitempty で省かれる) ことを検証する (#3522)。
+func TestHachiHachiWebPresenter_Output_NoHintOnCpuTurn(t *testing.T) {
+	g := domain.NewDefaultHachiHachi()
+	g.Reset()
+	g.SetCurrentTurn(1) // player 1 は CPU
+
+	p := new(presenter.HachiHachiWebPresenter)
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal([]byte(p.Output(g, nil)), &decoded))
+	assert.NotContains(t, decoded, "hint", "cpu turn must not include a hint")
+}
+
 // TestHachiHachiWebPresenter_ProceduralFaces は花札の札が deck:"hanafuda" + 絵文字グリフ +
 // ラベルで手続き描画用にシリアライズされることを検証する (ADR-0033)。
 func TestHachiHachiWebPresenter_ProceduralFaces(t *testing.T) {


### PR DESCRIPTION
## 概要

八八 (Hachi-Hachi) のフロントエンド「ヒント表示」トグルが死に機能だった問題を修正します。

`HachiHachiWebPresenter.Output()` は `Hint` フィールドを埋めておらず、別経路の `HintOutput()` だけが埋めていました。その結果 `state.hint` が常に undefined となり、フロントエンドのヒントトグルを ON にしても何も表示されませんでした。

## 変更内容

- **Go (presenter のみ / WASM 中立):** 共有ヘルパー `applyHint` を切り出し、`Output()`（人間のプレイ手番）と `HintOutput()` の両方から呼ぶよう de-duplicate。`GetHint()` は CPU 手番・ゲーム終了・対象外フェーズでは nil を返すため、それらでは `omitempty` により JSON からも省かれる。ドメイン・CUI・内部 i18n には一切触れていない（hachihachi は `extra` ワーカーで容量が逼迫しているため）。
- **フロントエンド:** ヒントパイプライン（`useGameHint` → `getHachiHachiHint` → `HintTooltip`）と i18n reason キー（`capture` / `discard_low`）は既にドメインの reason 文字列と一致しており、ソース変更は不要だった。テストのみ追加。

## テスト

- `TestHachiHachiWebPresenter_Output_HintOnHumanTurn` — 人間のプレイ手番で `Output()` が hint を含むことを検証
- `TestHachiHachiWebPresenter_Output_NoHintOnCpuTurn` — CPU 手番では hint が省かれることを検証
- `HachiHachiPage.test.tsx` — トグル OFF 既定でツールチップ非表示 / トグル ON + `state.hint` でツールチップ表示

## 受け入れ条件

- [x] `Output()` が人間手番で Hint を JSON に含める
- [x] トグル ON でプレイフェーズにヒントが出る
- [x] CPU 手番ではヒントを出さない
- [x] `HachiHachiWebPresenter_test.go` に検証を追加

## ゲート結果

- [x] `goimports -w` / `golangci-lint run ./internal/adapter/...` — 0 issues
- [x] `go test -tags test ./internal/...` — pass
- [x] `bun run check` — pass
- [x] `bun run test -- --run HachiHachiPage` — 15 passed
- [x] `bun run build` — success

Closes #3522