### PR TITLE
feat(twentynine): show highest bidder name during bidding

### DIFF
--- a/frontend/src/i18n/locales/en/twentynine.json
+++ b/frontend/src/i18n/locales/en/twentynine.json
@@ -42,6 +42,8 @@
   "nextRound": "Next Round",
   "target": "Target: {{points}} game pts",
   "bidPrompt": "Place a bid (only a higher bid is allowed):",
+  "bidHighest": "Highest bid: {{bid}} ({{player}})",
+  "bidNone": "No bids yet",
   "bidDisabledReason": "Must exceed the current highest bid of {{currentBid}}",
   "bid": {
     "pass": "Pass",

--- a/frontend/src/i18n/locales/ja/twentynine.json
+++ b/frontend/src/i18n/locales/ja/twentynine.json
@@ -42,6 +42,8 @@
   "nextRound": "次のラウンド",
   "target": "目標: {{points}}ゲーム点",
   "bidPrompt": "入札してください（上回る入札のみ可）:",
+  "bidHighest": "現在の最高ビッド: {{bid}}（{{player}}）",
+  "bidNone": "まだ入札なし",
   "bidDisabledReason": "現在の最高ビッド {{currentBid}} を超える必要があります",
   "bid": {
     "pass": "パス",

--- a/frontend/src/pages/TwentyNinePage.test.tsx
+++ b/frontend/src/pages/TwentyNinePage.test.tsx
@@ -90,6 +90,31 @@ describe('TwentyNinePage', () => {
     expect(screen.getByTestId('bid-28')).toBeInTheDocument();
   });
 
+  it('shows "no bids yet" when no one has bid during the bid phase', async () => {
+    renderWithProviders(<TwentyNinePage />);
+    const readout = await screen.findByTestId('tn29-highest-bid');
+    expect(readout).toHaveTextContent('まだ入札なし');
+  });
+
+  it('shows the current highest bid and the bidder name during the bid phase', async () => {
+    // CPU 2 (seat index 2) holds the highest bid of 20.
+    mockExec.mockResolvedValue(makeTwentyNineState({ bids: [0, 0, 20, 0] }));
+    renderWithProviders(<TwentyNinePage />);
+    const readout = await screen.findByTestId('tn29-highest-bid');
+    expect(readout).toHaveTextContent('現在の最高ビッド: 20（CPU 2）');
+  });
+
+  it('updates the highest-bid readout as bids change', async () => {
+    renderWithProviders(<TwentyNinePage />);
+    await waitFor(() => expect(screen.getByTestId('tn29-highest-bid')).toHaveTextContent('まだ入札なし'));
+    // The next server response reflects the human's own bid of 16.
+    mockExec.mockResolvedValue(makeTwentyNineState({ bids: [16, 0, 0, 0] }));
+    fireEvent.click(screen.getByTestId('bid-20'));
+    await waitFor(() =>
+      expect(screen.getByTestId('tn29-highest-bid')).toHaveTextContent('現在の最高ビッド: 16（あなた）'),
+    );
+  });
+
   it('dispatches a bid when a bid button is clicked', async () => {
     renderWithProviders(<TwentyNinePage />);
     const bid16 = await screen.findByTestId('bid-16');

--- a/frontend/src/pages/TwentyNinePage.tsx
+++ b/frontend/src/pages/TwentyNinePage.tsx
@@ -164,6 +164,9 @@ function TwentyNinePageContent() {
 
   // The current highest (non-pass) bid; a new non-pass bid must beat it.
   const highestBid = Math.max(0, ...state.bids);
+  // The seat holding that highest bid, so the bidder's name can be surfaced during bidding.
+  const highestBidder = highestBid > 0 ? state.players[state.bids.indexOf(highestBid)] : undefined;
+  const highestBidderName = highestBidder ? playerName(highestBidder.id, highestBidder.isHuman) : '';
 
   const contractLabel = state.contract === 0 ? t('contractUndecided') : String(state.contract);
 
@@ -367,6 +370,9 @@ function TwentyNinePageContent() {
               {isBidPhase && isHumanBidTurn && (
                 <>
                   <span className="text-xs text-ds-text-muted self-center mr-1">{t('bidPrompt')}</span>
+                  <span className="text-xs text-ds-text-muted self-center mr-1" data-testid="tn29-highest-bid">
+                    {highestBid > 0 ? t('bidHighest', { bid: highestBid, player: highestBidderName }) : t('bidNone')}
+                  </span>
                   {BIDS.map((b) => {
                     // Pass (0) is always allowed; a non-pass bid must beat the current highest.
                     const tooLow = b.value !== 0 && b.value <= highestBid;


### PR DESCRIPTION
## Summary

During the Twenty-Nine (29) bid phase, the Web UI computed `highestBid` only to disable losing bid buttons — it never showed the current highest bid or who held it. The CUI (`TwentyNineCuiPresenter`) and the sibling `FortyFivesPage` already surface this. This adds a matching readout so the player knows who leads the bidding.

## Changes

- `TwentyNinePage.tsx`: resolve the highest bidder from `state.bids.indexOf(highestBid)` and add a `data-testid="tn29-highest-bid"` span next to the bid prompt showing `bidHighest` (bid + name via the `playerName` helper) or `bidNone` when nobody has bid.
- `i18n ja/en twentynine.json`: add `bidHighest` / `bidNone` keys.
- `TwentyNinePage.test.tsx`: add tests for the no-bid state, the highest-bid + bidder-name display, and the readout updating as bids change.

Bidder identity comes from the existing `bids: number[]` array (seat-indexed) already in `TwentyNineResponse` — frontend-only, no Go changes.

## Test plan

- [x] `bun run check`
- [x] `bun run test -- --run TwentyNinePage` (18 passed)
- [x] `bun run build`

Closes #3419