### PR TITLE
fix(bourre): render header trump suit as a symbol

### DIFF
--- a/frontend/src/pages/BourrePage.test.tsx
+++ b/frontend/src/pages/BourrePage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { bourreApi } from '../api/gameApi';
 import { renderWithProviders } from '../test/renderWithProviders';
@@ -78,6 +78,42 @@ describe('BourrePage', () => {
     await waitFor(() => {
       expect(mockExec).toHaveBeenCalledWith(expect.objectContaining({ command: 'reset' }));
     });
+  });
+
+  it('header renders the trump suit as a symbol, not the raw design string', async () => {
+    renderWithProviders(<BourrePage />); // default trumpSuit: SPADE
+    const trump = await screen.findByTestId('bourre-trump');
+    expect(trump).toHaveTextContent('♠');
+    expect(trump).not.toHaveTextContent('SPADE');
+  });
+
+  it('header colors a red trump suit (hearts) with the error token', async () => {
+    mockExec.mockResolvedValue(makeState({ trumpSuit: 'HEART' }));
+    renderWithProviders(<BourrePage />);
+    const trump = await screen.findByTestId('bourre-trump');
+    expect(within(trump).getByText('♥')).toHaveClass('text-ds-error');
+  });
+
+  it('header colors a red trump suit (diamonds) with the error token', async () => {
+    mockExec.mockResolvedValue(makeState({ trumpSuit: 'DIAMOND' }));
+    renderWithProviders(<BourrePage />);
+    const trump = await screen.findByTestId('bourre-trump');
+    expect(within(trump).getByText('♦')).toHaveClass('text-ds-error');
+  });
+
+  it('header does not color a black trump suit (clubs) with the error token', async () => {
+    mockExec.mockResolvedValue(makeState({ trumpSuit: 'CLOVER' }));
+    renderWithProviders(<BourrePage />);
+    const trump = await screen.findByTestId('bourre-trump');
+    expect(within(trump).getByText('♣')).not.toHaveClass('text-ds-error');
+  });
+
+  it('header shows a dash when the trump suit is unset', async () => {
+    mockExec.mockResolvedValue(makeState({ trumpSuit: 'JOKER' }));
+    renderWithProviders(<BourrePage />);
+    const trump = await screen.findByTestId('bourre-trump');
+    expect(trump).toHaveTextContent('-');
+    expect(trump).not.toHaveTextContent('JOKER');
   });
 
   it('renders CPU player areas after load', async () => {
@@ -370,5 +406,19 @@ describe('BourrePage', () => {
       expect(screen.getAllByText(/Unknown command/).length).toBeGreaterThan(0);
     });
     expect(mockExec).not.toHaveBeenCalled();
+  });
+
+  it('CLI formatter renders the trump suit as a symbol, not the raw design string', async () => {
+    localStorage.setItem('cli-mode-bourre', 'true');
+    // Distinct objects so useCliGame's [state] effect fires after the command re-renders.
+    mockExec.mockResolvedValueOnce(makeState({ phase: 'decide', trumpSuit: 'HEART' })); // mount reset
+    mockExec.mockResolvedValue(makeState({ phase: 'play', trumpSuit: 'HEART' })); // after command
+    renderWithProviders(<BourrePage />);
+    const input = await screen.findByRole('textbox');
+    fireEvent.change(input, { target: { value: 'n' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    const output = await screen.findByText(/Trump: ♥/);
+    expect(output).toBeInTheDocument();
+    expect(output).not.toHaveTextContent('HEART');
   });
 });

--- a/frontend/src/pages/BourrePage.tsx
+++ b/frontend/src/pages/BourrePage.tsx
@@ -22,6 +22,7 @@ import { btnPrimary, btnSecondary, btnWarning } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { BourreResponse } from '../types/card';
 import type { TutorialStep } from '../types/tutorial';
+import { isRedSuitDesign, isSuitDesign, suitSymbol } from '../utils/cardAlt';
 import type { CliGameConfig, CliParseResult } from '../utils/cli/types';
 import { playerName } from '../utils/playerUtils';
 
@@ -34,6 +35,11 @@ type ApiArgs = {
 };
 
 const BOURRE_PENALTY_WARN_THRESHOLD = 10;
+
+/** Plain-text trump-suit glyph for the CLI formatter: a suit symbol, or '-' when unset. */
+function trumpSuitText(design: string): string {
+  return isSuitDesign(design) ? suitSymbol(design) : '-';
+}
 
 const TUTORIAL_STEPS: TutorialStep[] = [
   { target: '[data-tutorial="bourre-hand"]', messageKey: 'tutorial.intro', placement: 'top', advanceOn: 'next' },
@@ -80,7 +86,7 @@ function parseBourreCommand(input: string): CliParseResult<[ApiArgs]> {
 }
 
 function formatBourreState(state: BourreResponse): string {
-  const lines: string[] = [`Phase: ${state.phase}`, `Pot: ${state.pot}  Trump: ${state.trumpSuit}`];
+  const lines: string[] = [`Phase: ${state.phase}`, `Pot: ${state.pot}  Trump: ${trumpSuitText(state.trumpSuit)}`];
   for (const p of state.players) {
     const name = p.isHuman ? 'You' : `CPU ${p.id}`;
     const status = p.isFinished ? 'out' : p.folded ? 'folded' : `${p.tricks} tricks`;
@@ -229,8 +235,15 @@ function BourrePageContent() {
             {t('label.pot')}: {state.pot}
             {state.carryPot > 0 ? ` (+${state.carryPot})` : ''}
           </span>
-          <span className="text-xs opacity-75">
-            {t('label.trump')}: {state.trumpSuit}
+          <span className="text-xs opacity-75" data-testid="bourre-trump">
+            {t('label.trump')}:{' '}
+            {isSuitDesign(state.trumpSuit) ? (
+              <span className={isRedSuitDesign(state.trumpSuit) ? 'text-ds-error' : undefined}>
+                {suitSymbol(state.trumpSuit)}
+              </span>
+            ) : (
+              '-'
+            )}
           </span>
           <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
         </div>

--- a/frontend/src/utils/cardAlt.test.ts
+++ b/frontend/src/utils/cardAlt.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import i18n from '../i18n';
 import type { CardDesign } from '../types/card';
-import { cardAlt, suitSymbol } from './cardAlt';
+import { cardAlt, isRedSuitDesign, isSuitDesign, suitSymbol } from './cardAlt';
 
 describe('cardAlt', () => {
   it('returns localized joker text for JOKER', () => {
@@ -49,5 +49,25 @@ describe('suitSymbol', () => {
 
   it('falls back to the raw design for unknown designs', () => {
     expect(suitSymbol('JOKER')).toBe('JOKER');
+  });
+});
+
+describe('isSuitDesign', () => {
+  it.each(['SPADE', 'CLOVER', 'HEART', 'DIAMOND'])('is true for the known suit %s', (design) => {
+    expect(isSuitDesign(design)).toBe(true);
+  });
+
+  it.each(['JOKER', '', 'UNKNOWN'])('is false for the non-suit %s', (design) => {
+    expect(isSuitDesign(design)).toBe(false);
+  });
+});
+
+describe('isRedSuitDesign', () => {
+  it.each(['HEART', 'DIAMOND'])('is true for the red suit %s', (design) => {
+    expect(isRedSuitDesign(design)).toBe(true);
+  });
+
+  it.each(['SPADE', 'CLOVER', 'JOKER', ''])('is false for %s', (design) => {
+    expect(isRedSuitDesign(design)).toBe(false);
   });
 });

--- a/frontend/src/utils/cardAlt.ts
+++ b/frontend/src/utils/cardAlt.ts
@@ -9,9 +9,21 @@ const DESIGN_SYMBOLS: Record<string, string> = {
   CLOVER: '♣',
 };
 
+const RED_DESIGNS = new Set(['HEART', 'DIAMOND']);
+
 /** Return the suit symbol for a card design (e.g. SPADE → ♠), or the raw design when unknown. */
-export function suitSymbol(design: Card['design']): string {
+export function suitSymbol(design: string): string {
   return DESIGN_SYMBOLS[design] ?? design;
+}
+
+/** True when a card design maps to a known suit symbol (SPADE/CLOVER/HEART/DIAMOND). */
+export function isSuitDesign(design: string): boolean {
+  return design in DESIGN_SYMBOLS;
+}
+
+/** True when a suit design renders in red (hearts / diamonds). */
+export function isRedSuitDesign(design: string): boolean {
+  return RED_DESIGNS.has(design);
 }
 
 /** Return accessible alt text for a card: procedural cards use their descriptor


### PR DESCRIPTION
## 概要 / Summary

Bourré (`bourre`) のヘッダーとページ内 CLI フォーマッタが、切り札スートを内部のデザイン文字列（例: `SPADE`）のまま表示していた問題を修正。スート記号（♠♣♥♦）に変換して表示する。

`BourreResponse.trumpSuit` はバックエンド（`cardDesignToString`）で `SPADE`/`CLOVER`/`HEART`/`DIAMOND` の文字列として送られ、未確定時は `JOKER` になる。既存の `suitSymbol`（`utils/cardAlt.ts`）で記号に変換し、♥♦ は `text-ds-error` で赤表示、未確定（非スート）時は `-` にフォールバックする。CinchPage の赤スート表示パターンを踏襲。

## 変更点 / Changes

- `utils/cardAlt.ts`: `suitSymbol` の引数を `string` に緩和（既存呼び出しは `CardDesign` を渡すので後方互換）。`isSuitDesign` / `isRedSuitDesign` ヘルパーを追加。
- `pages/BourrePage.tsx`: ヘッダーの切り札チップを記号＋赤色（♥♦）＋`-` フォールバックで描画（`data-testid="bourre-trump"`）。CLI の `formatBourreState` も `trumpSuitText` で記号表示に。
- テスト追加: `BourrePage.test.tsx`（ヘッダーが記号表示・赤スートに `text-ds-error`・黒スートは非赤・未確定は `-`・CLI フォーマッタが記号表示）、`cardAlt.test.ts`（`isSuitDesign` / `isRedSuitDesign`）。

フロントエンドのみ。Go には変更なし。

## 受け入れ条件 / Acceptance criteria

- [x] ヘッダーの切り札表示がスート記号になる
- [x] CLI フォーマッタ出力も記号表示になる
- [x] 未確定時（JOKER 等）の表示が `-` で破綻しない
- [x] `BourrePage.test.tsx` に表示変換テスト追加

## テスト計画 / Test plan

- [x] `bun run check`（Biome lint + format）
- [x] `bun run test -- --run BourrePage cardAlt`（54 passed）
- [x] `bun run build`（tsc）

Closes #3397
