### PR TITLE
fix(nap): surface disabled bid-button reason via wrapping span tooltip

### DIFF
--- a/frontend/src/pages/NapPage.test.tsx
+++ b/frontend/src/pages/NapPage.test.tsx
@@ -115,9 +115,15 @@ describe('NapPage', () => {
     const info = await screen.findByTestId('nap-highest-bid');
     // A real highest bid is shown (not the "no bids yet" placeholder).
     expect(info).not.toHaveTextContent('まだ入札なし');
-    // Too-low bids carry a tooltip; valid bids do not.
-    expect(screen.getByTestId('bid-2')).toHaveAttribute('title');
-    expect(screen.getByTestId('bid-4')).not.toHaveAttribute('title');
+    // Too-low bids carry a tooltip on the wrapping span (browsers suppress tooltips on
+    // disabled buttons); valid bids do not.
+    const tooLowWrap = screen.getByTestId('bid-wrap-2');
+    expect(tooLowWrap).toHaveAttribute('title');
+    expect(tooLowWrap.getAttribute('title')).not.toBe('');
+    expect(screen.getByTestId('bid-wrap-4')).not.toHaveAttribute('title');
+    // The reason is also exposed to screen readers via aria-label on the disabled button.
+    expect(screen.getByTestId('bid-2')).toHaveAttribute('aria-label', expect.stringContaining(tooLowWrap.title));
+    expect(screen.getByTestId('bid-4')).not.toHaveAttribute('aria-label');
   });
 
   it('shows "no bids yet" before anyone has bid', async () => {

--- a/frontend/src/pages/NapPage.tsx
+++ b/frontend/src/pages/NapPage.tsx
@@ -396,21 +396,25 @@ function NapPageContent() {
                     // Pass (0) is always allowed; a non-pass bid must beat the current highest.
                     const tooLow = b.value !== NapContract.PASS && b.value <= highestBid;
                     const disabled = loading || tooLow;
+                    const reason = tooLow
+                      ? t('bidTooLow', { bid: highestBidLabelKey ? t(highestBidLabelKey) : '' })
+                      : undefined;
+                    // The title lives on the wrapping span: browsers suppress native tooltips and
+                    // hover events on disabled buttons, so hovering the span still surfaces the reason.
                     return (
-                      <button
-                        key={b.value}
-                        type="button"
-                        className="px-3 py-2 rounded-lg bg-ds-info text-white text-sm disabled:opacity-40"
-                        onClick={() => handleBid(b.value)}
-                        disabled={disabled}
-                        aria-disabled={disabled}
-                        title={
-                          tooLow ? t('bidTooLow', { bid: highestBidLabelKey ? t(highestBidLabelKey) : '' }) : undefined
-                        }
-                        data-testid={`bid-${b.value}`}
-                      >
-                        {t(b.key)}
-                      </button>
+                      <span key={b.value} title={reason} data-testid={`bid-wrap-${b.value}`}>
+                        <button
+                          type="button"
+                          className="px-3 py-2 rounded-lg bg-ds-info text-white text-sm disabled:opacity-40"
+                          onClick={() => handleBid(b.value)}
+                          disabled={disabled}
+                          aria-disabled={disabled}
+                          aria-label={reason ? `${t(b.key)} — ${reason}` : undefined}
+                          data-testid={`bid-${b.value}`}
+                        >
+                          {t(b.key)}
+                        </button>
+                      </span>
                     );
                   })}
                 </>


### PR DESCRIPTION
## Summary
Disabled Nap bid buttons set a `title` explaining why they were unavailable (`bidTooLow`), but browsers suppress native tooltips and hover events on `disabled` elements, so the hint was never shown to the user. This ports the `bid-wrap` span pattern already used by `FortyFivesPage` and `SoloWhistPage`.

## Changes
- `NapPage.tsx`: wrap each bid button in a `<span data-testid="bid-wrap-${value}" title={reason}>` so hovering the span surfaces the too-low reason; add an `aria-label` carrying the same reason on the disabled button for screen readers. Bid logic is unchanged.
- `NapPage.test.tsx`: assert the too-low bid's wrapping span exposes a non-empty `title`, an enabled bid does not, and the disabled button's `aria-label` contains the reason.

## Acceptance criteria
- [x] Hovering a disabled bid button surfaces the reason tooltip (via the wrapping span)
- [x] `aria-label` includes the reason text
- [x] Enabled bid buttons are unchanged (no title, no aria-label)
- [x] `NapPage.test.tsx` verifies the span title

## Gates
- `bun run check` — pass
- `bun run test -- --run NapPage` — 14 passed
- `bun run build` (tsc) — pass

Closes #3439