### PR TITLE
feat(easthaven): render hint as a full move-from-to sentence

### DIFF
--- a/frontend/src/i18n/locales/en/easthaven.json
+++ b/frontend/src/i18n/locales/en/easthaven.json
@@ -21,6 +21,7 @@
   "playing": "Playing",
   "noHint": "No hint available",
   "hintAvailable": "A hint is available",
+  "hintSentence": "Move: {{card}} in column {{fromCol}} → {{dest}}",
   "foundationAriaLabel": "{{suit}} foundation, {{count}} cards",
   "emptyFoundationAriaLabel": "Empty foundation ({{suit}})",
   "stalemate": "No moves left",

--- a/frontend/src/i18n/locales/ja/easthaven.json
+++ b/frontend/src/i18n/locales/ja/easthaven.json
@@ -21,6 +21,7 @@
   "playing": "プレイ中",
   "noHint": "ヒントはありません",
   "hintAvailable": "ヒントがあります",
+  "hintSentence": "移動: 列 {{fromCol}} の {{card}} → {{dest}}",
   "foundationAriaLabel": "{{suit}} 組札 {{count}}枚",
   "emptyFoundationAriaLabel": "空の組札 ({{suit}})",
   "stalemate": "手詰まりです",

--- a/frontend/src/pages/EasthavenPage.test.tsx
+++ b/frontend/src/pages/EasthavenPage.test.tsx
@@ -262,11 +262,31 @@ describe('EasthavenPage', () => {
     );
   });
 
-  it('renders a hint banner from state.hint', async () => {
+  it('renders a full from→to sentence for a to-foundation hint', async () => {
+    // tableau[0][1] is ♠ K, so the sentence names the source column, card, and dest.
     mockExec.mockResolvedValue({ ...playingState, hint: { fromCol: 0, cardIndex: 1, toZone: 'foundation', toCol: 0 } });
     renderWithProviders(<EasthavenPage />);
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
-    expect(screen.getAllByText('組札').length).toBeGreaterThan(0);
+    const hint = await screen.findByTestId('eh-hint');
+    expect(hint).toHaveTextContent('移動: 列 0 の ♠ K → 組札');
+  });
+
+  it('renders a full from→to sentence for a to-tableau hint', async () => {
+    // toZone 'tableau' exercises the dest branch that names the destination column.
+    mockExec.mockResolvedValue({ ...playingState, hint: { fromCol: 1, cardIndex: 0, toZone: 'tableau', toCol: 3 } });
+    renderWithProviders(<EasthavenPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    const hint = await screen.findByTestId('eh-hint');
+    expect(hint).toHaveTextContent('移動: 列 1 の ♥ 8 → 場札 3');
+  });
+
+  it('renders the hint sentence without a card name when the source card is face-down', async () => {
+    // tableau[0][0] is a face-down (card: null) slot, hitting the empty-card-name branch.
+    mockExec.mockResolvedValue({ ...playingState, hint: { fromCol: 0, cardIndex: 0, toZone: 'foundation', toCol: 0 } });
+    renderWithProviders(<EasthavenPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    const hint = await screen.findByTestId('eh-hint');
+    expect(hint).toHaveTextContent('移動: 列 0 の → 組札');
   });
 
   it('deal is guarded (no deal call) while an empty column exists', async () => {

--- a/frontend/src/pages/EasthavenPage.tsx
+++ b/frontend/src/pages/EasthavenPage.tsx
@@ -279,6 +279,17 @@ function EasthavenPageContent() {
   const isEnded = isGameClear || isGameOver;
   const autoCompleteReady = isTableauAllFaceUp(state.tableau) && state.stockCount === 0;
 
+  // Compose the hint into a full "move <card> in column N → <dest>" sentence so
+  // the aria-live announcement and visible box read completely, even when the
+  // ring-flash source card is scrolled out of view (issue #3388).
+  const hintDest = state.hint
+    ? state.hint.toZone === 'foundation'
+      ? t('foundation')
+      : `${t('tableau')} ${state.hint.toCol}`
+    : '';
+  const hintCard = state.hint ? state.tableau[state.hint.fromCol]?.[state.hint.cardIndex]?.card : null;
+  const hintCardName = hintCard ? cardAlt(hintCard) : '';
+
   const isSourceSelected = (zone: string, col?: number, cardIndex?: number) =>
     selectedSource !== null &&
     selectedSource.zone === zone &&
@@ -516,8 +527,9 @@ function EasthavenPageContent() {
                 className="text-sm text-ds-accent bg-ds-surface/90 border border-ds-accent rounded px-3 py-1.5 mt-1"
                 role="status"
                 aria-live="polite"
+                data-testid="eh-hint"
               >
-                {state.hint.toZone === 'foundation' ? t('foundation') : `${t('tableau')} ${state.hint.toCol}`}
+                {t('hintSentence', { fromCol: state.hint.fromCol, card: hintCardName, dest: hintDest })}
               </div>
             )}
             {frontendHintEnabled && frontendHint && (


### PR DESCRIPTION
## 概要
イーストヘイブンのヒント表示ボックス（`role="status"` / `aria-live="polite"`）を「移動先だけ」ではなく「移動: 列 N の <カード名> → <移動先>」という完全な文で表示するようにしました。移動元の列・カード名・移動先がすべてテキストに含まれるため、リング点滅の移動元カードがスクロールで見えない場合でも読み上げ・視覚の両方で意味が取れます。CUI 側（`HintOutput`）の完全文出力に Web を揃えます。

## 変更点
- `EasthavenPage.tsx`: `hintDest` / `hintCardName`（`cardAlt` で取得）を算出し、ヒントボックスを `t('hintSentence', ...)` の完全文に変更。`data-testid="eh-hint"` を付与。リング点滅表示は従来どおり併用。
- `i18n/locales/{ja,en}/easthaven.json`: `hintSentence` キーを追加。
- `EasthavenPage.test.tsx`: to-foundation / to-tableau の両移動先分岐、および移動元が裏向き（カード名なし）の分岐をカバーするテストを追加・更新。

## 受け入れ条件
- [x] ヒントに移動元列・カード名・移動先がすべて含まれる
- [x] `aria-live="polite"` による読み上げが完全な文になる
- [x] リング点滅表示は従来通り併用される
- [x] `EasthavenPage.test.tsx` のヒント表示テスト更新

## テスト
- `bun run test -- --run EasthavenPage` — 26 passed
- `bun run check` — exit 0
- `bun run build` — 成功

Closes #3388