### PR TITLE
feat(scarto): show average-difference settlement breakdown at round end

### DIFF
--- a/frontend/src/i18n/locales/en/scarto.json
+++ b/frontend/src/i18n/locales/en/scarto.json
@@ -39,7 +39,9 @@
   "roundResult": {
     "title": "Deal result",
     "outcome": "Your result: {{outcome}}",
-    "playerLine": "{{name}}: {{delta}} (total {{score}})"
+    "playerLine": "{{name}}: {{delta}} (total {{score}})",
+    "average": "Table average: {{avg}} pts",
+    "earnedLine": "{{name}}: earned {{points}} pts (vs avg {{diff}})"
   },
   "hintAvailable": "Hint",
   "hint": {

--- a/frontend/src/i18n/locales/ja/scarto.json
+++ b/frontend/src/i18n/locales/ja/scarto.json
@@ -39,7 +39,9 @@
   "roundResult": {
     "title": "ディール結果",
     "outcome": "あなたの結果: {{outcome}}",
-    "playerLine": "{{name}}: {{delta}}（累計 {{score}}）"
+    "playerLine": "{{name}}: {{delta}}（累計 {{score}}）",
+    "average": "全体平均: {{avg}}点",
+    "earnedLine": "{{name}}: 獲得 {{points}}点（平均差 {{diff}}）"
   },
   "hintAvailable": "ヒント",
   "hint": {

--- a/frontend/src/pages/ScartoPage.test.tsx
+++ b/frontend/src/pages/ScartoPage.test.tsx
@@ -78,6 +78,20 @@ const roundEndState = makeScartoState({
   dealScores: [6, -2, -4],
 });
 
+// Round end with captured card-points that make the average-difference settlement
+// meaningful: totals 70+60+52 = 182, mean ≈ 60.7, so dealScores = 3·points − 182.
+const settlementState = makeScartoState({
+  phase: 3,
+  isHumanTurn: false,
+  outcome: 1,
+  dealScores: [28, -2, -34],
+  players: [
+    { id: 0, isHuman: true, cardCount: 0, cards: [], trickCount: 5, cardPoints: 70, score: 28, isDealer: false },
+    { id: 1, isHuman: false, cardCount: 0, cards: [], trickCount: 4, cardPoints: 60, score: -2, isDealer: false },
+    { id: 2, isHuman: false, cardCount: 0, cards: [], trickCount: 3, cardPoints: 52, score: -34, isDealer: true },
+  ],
+});
+
 const gameEndState = makeScartoState({
   phase: 4,
   isHumanTurn: false,
@@ -194,6 +208,20 @@ describe('ScartoPage', () => {
     renderWithProviders(<ScartoPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: '次のディール' })).toBeInTheDocument());
     expect(screen.getByTestId('scarto-result')).toBeInTheDocument();
+  });
+
+  it('shows the average-difference settlement breakdown at round end', async () => {
+    mockExec.mockResolvedValue(settlementState);
+    renderWithProviders(<ScartoPage />);
+    const breakdown = await screen.findByTestId('scarto-breakdown');
+    // Table average of captured card-points (182 / 3 ≈ 60.7).
+    expect(breakdown).toHaveTextContent('全体平均: 60.7点');
+    // Each seat's earned card-points.
+    expect(breakdown).toHaveTextContent('獲得 70点');
+    expect(breakdown).toHaveTextContent('獲得 60点');
+    expect(breakdown).toHaveTextContent('獲得 52点');
+    // The displayed delta matches dealScores (existing per-player settlement line).
+    expect(screen.getByTestId('scarto-result')).toHaveTextContent('+28');
   });
 
   it('dispatches nextround from round end', async () => {

--- a/frontend/src/pages/ScartoPage.tsx
+++ b/frontend/src/pages/ScartoPage.tsx
@@ -87,6 +87,17 @@ function isUndiscardable(card: Card): boolean {
   return card?.color === 'purple' || card?.color === 'gold' || (card?.value ?? 0) >= 11;
 }
 
+/** Formats a card-point number with up to one decimal place, dropping a trailing `.0`. */
+function formatPoints(n: number): string {
+  return Number.isInteger(n) ? String(n) : n.toFixed(1);
+}
+
+/** Formats a signed difference, prefixing a leading `+` for positive values. */
+function formatSigned(n: number): string {
+  const s = formatPoints(n);
+  return n > 0 ? `+${s}` : s;
+}
+
 /** Renders the Scarto (スカルト) game page: a 3-player 78-card Italian tarocchi trick-taker with a dealer scarto (discard) and trump-priority tricks — no bidding, chien, or partnership. */
 export const ScartoPage = withTutorial(ScartoPageContent, 'scarto', SCARTO_TUTORIAL_STEPS);
 
@@ -153,6 +164,11 @@ function ScartoPageContent() {
 
   const canScarto = isScartoPhase && state.isHumanScarto;
   const canPlay = isPlayPhase && isHumanTurn;
+
+  // Scarto settles each deal against the mean: dealScore_i = N × (cardPoints_i − average),
+  // so surfacing the table average and each seat's captured card-points explains the ± delta.
+  const totalCardPoints = state.players.reduce((sum, p) => sum + p.cardPoints, 0);
+  const averageCardPoints = state.players.length > 0 ? totalCardPoints / state.players.length : 0;
 
   // During the scarto, restrict selection to buryable pips (no trumps / Excuse / counting cards).
   const discardableIndices =
@@ -299,6 +315,19 @@ function ScartoPageContent() {
                         </div>
                       );
                     })}
+                    {/* Average-difference breakdown: each seat's captured points vs. the table mean. */}
+                    <div className="mt-1 pt-1 border-t border-white/10" data-testid="scarto-breakdown">
+                      <div>{t('roundResult.average', { avg: formatPoints(averageCardPoints) })}</div>
+                      {state.players.map((p) => (
+                        <div key={p.id}>
+                          {t('roundResult.earnedLine', {
+                            name: playerName(p.id, p.isHuman),
+                            points: p.cardPoints,
+                            diff: formatSigned(p.cardPoints - averageCardPoints),
+                          })}
+                        </div>
+                      ))}
+                    </div>
                   </div>
                 )}
               </div>


### PR DESCRIPTION
## 概要

スカルトのディール結果に、平均差引き精算の内訳を表示します。スカルトは各プレイヤーの取り札点を全体平均と比較したゼロサム精算 (`dealScore_i = N × (cardPoints_i − 平均)`) で採点するため、±デルタだけでは根拠が伝わりませんでした。既存の `players[].cardPoints` から全体平均と各席の獲得点・平均差をフロントエンドで算出して併記します。**バックエンド変更なし。**

## 変更点

- `ScartoPage.tsx`: ディール結果ブロックに内訳 (`data-testid="scarto-breakdown"`) を追加。全体平均 + 各プレイヤーの獲得カード点と平均差を表示。数値整形ヘルパー `formatPoints` / `formatSigned` を追加。
- `i18n` (ja/en): `roundResult.average`, `roundResult.earnedLine` を追加。
- `ScartoPage.test.tsx`: 内訳の平均・獲得点・デルタ一致を検証するテストを追加。

## 受け入れ条件

- [x] 各プレイヤーの獲得カード点が表示される
- [x] 全体平均点が表示される
- [x] 表示デルタが dealScores と一致する（既存の playerLine が dealScores を表示）
- [x] i18n キーを ja/en に追加

## 精算ルールの確認

`internal/domain/Scarto.go` (READ-ONLY) を確認: `scartoSettleDeal` は `score_i = N·half_i − Σhalf`、`GetCardPoints(i)` はこの `half_i` を返す。よって `dealScores[i] = N × (cardPoints_i − 平均)` が成立し、平均は `cardPoints` から算出可能（バックエンド変更不要）。

## テスト

- `bun run check` ✅ (exit 0)
- `bun run test -- --run ScartoPage` ✅ (18 passed)、新規: `shows the average-difference settlement breakdown at round end`
- `bun run build` ✅ (tsc)

Closes #3532
