### PR TITLE
feat(koikoi): group captured cards by yaku category (光/種/短冊/カス)

### DIFF
--- a/frontend/src/i18n/locales/en/koikoi.json
+++ b/frontend/src/i18n/locales/en/koikoi.json
@@ -23,6 +23,13 @@
   "you": "You",
   "cpu": "CPU",
   "captured": "Captured: {{count}}",
+  "capturedEmpty": "No captured cards",
+  "category": {
+    "bright": "Bright",
+    "animal": "Animal",
+    "ribbon": "Ribbon",
+    "kasu": "Chaff"
+  },
   "score": "Score: {{score}}",
   "turnYours": "Your turn — pick a hand card to capture a field card.",
   "turnCpu": "CPU is playing…",

--- a/frontend/src/i18n/locales/ja/koikoi.json
+++ b/frontend/src/i18n/locales/ja/koikoi.json
@@ -23,6 +23,13 @@
   "you": "あなた",
   "cpu": "CPU",
   "captured": "捕獲: {{count}}",
+  "capturedEmpty": "獲得札なし",
+  "category": {
+    "bright": "光",
+    "animal": "種",
+    "ribbon": "短冊",
+    "kasu": "カス"
+  },
   "score": "得点: {{score}}",
   "turnYours": "あなたの手番です — 手札を1枚選んで場札を捕獲します。",
   "turnCpu": "CPU がプレイ中です…",

--- a/frontend/src/pages/KoiKoiPage.test.tsx
+++ b/frontend/src/pages/KoiKoiPage.test.tsx
@@ -169,4 +169,45 @@ describe('KoiKoiPage', () => {
     fireEvent.click(screen.getByTestId('field-card-0'));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', { cardIndex: 0, fieldIndex: 0 }));
   });
+
+  it('groups captured cards under their yaku-category headers', async () => {
+    const hana = (color: string) => ({
+      design: 'SPADE' as const,
+      value: 0,
+      glyph: '🎴',
+      label: 'x',
+      color,
+      deck: 'hanafuda',
+    });
+    // Clone players (makeKoiKoiState shallow-spreads a shared array) so this
+    // fixture never mutates the module-level base state used by other tests.
+    const base = makeKoiKoiState();
+    const state = makeKoiKoiState({
+      players: [
+        { ...base.players[0] },
+        // CPU captured spans three categories; kasu is absent, so its group must not render.
+        {
+          ...base.players[1],
+          captured: [hana('gold'), hana('purple'), hana('purple'), hana('red')],
+          capturedCount: 4,
+        },
+      ],
+    });
+    mockExec.mockResolvedValue(state);
+    renderWithProviders(<KoiKoiPage />);
+
+    const bright = await screen.findByTestId('koikoi-cpu-group-bright');
+    expect(bright).toHaveTextContent('光 · 1');
+    expect(screen.getByTestId('koikoi-cpu-group-animal')).toHaveTextContent('種 · 2');
+    expect(screen.getByTestId('koikoi-cpu-group-ribbon')).toHaveTextContent('短冊 · 1');
+    expect(screen.queryByTestId('koikoi-cpu-group-kasu')).not.toBeInTheDocument();
+  });
+
+  it('shows the empty-pile label when a player has captured nothing', async () => {
+    renderWithProviders(<KoiKoiPage />);
+    // Default state captures nothing for either player.
+    await waitFor(() => expect(screen.getByTestId('koikoi-human-captured')).toBeInTheDocument());
+    expect(screen.getAllByText('獲得札なし').length).toBeGreaterThanOrEqual(2);
+    expect(screen.queryByTestId('koikoi-human-group-bright')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/KoiKoiPage.tsx
+++ b/frontend/src/pages/KoiKoiPage.tsx
@@ -20,12 +20,13 @@ import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { CPU_DIFFICULTY_OPTIONS, TARGET_SCORE_OPTIONS, useKoiKoiGame } from '../hooks/useKoiKoiGame';
 import { btnPrimary, btnSuccess, btnWarning } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
-import type { KoiKoiResponse, KoiKoiYaku } from '../types/card';
+import type { Card, KoiKoiResponse, KoiKoiYaku } from '../types/card';
 import { KoiKoiPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { KOIKOI_HELP, parseKoiKoiCommand } from '../utils/cli/commands/koikoiCommands';
 import { formatKoiKoiState } from '../utils/cli/formatters/koikoiFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { groupCapturedByCategory, KOIKOI_CATEGORY_ORDER, type KoiKoiCategory } from '../utils/koikoiCategory';
 
 /** Koi-Koi (こいこい) tutorial step definitions. */
 const KOIKOI_TUTORIAL_STEPS: TutorialStep[] = [
@@ -39,6 +40,48 @@ const KOIKOI_TUTORIAL_STEPS: TutorialStep[] = [
     advanceOn: 'next',
   },
 ];
+
+/** Props for {@link CapturedCategories}. */
+interface CapturedCategoriesProps {
+  /** The player's captured hanafuda cards. */
+  captured: Card[];
+  /** Rendered width of each captured card, in pixels. */
+  cardWidth: number;
+  /** Localizes a category key (e.g. `bright`) to its display label. */
+  categoryLabel: (cat: KoiKoiCategory) => string;
+  /** Text shown when the pile is empty. */
+  emptyText: string;
+  /** Prefix for each group's `data-testid` (e.g. `koikoi-cpu`). */
+  testidPrefix: string;
+}
+
+/**
+ * Renders a player's captured cards grouped by yaku category (光 / 種 / 短冊 / カス),
+ * each group headed by its localized label and count. Empty categories are hidden.
+ * The row scrolls horizontally so it stays within narrow mobile widths.
+ */
+function CapturedCategories({ captured, cardWidth, categoryLabel, emptyText, testidPrefix }: CapturedCategoriesProps) {
+  if (captured.length === 0) {
+    return <div className="text-xs text-ds-text-muted min-h-[24px]">{emptyText}</div>;
+  }
+  const groups = groupCapturedByCategory(captured);
+  return (
+    <div className="flex gap-4 overflow-x-auto justify-center px-2 min-h-[24px]">
+      {KOIKOI_CATEGORY_ORDER.filter((cat) => groups[cat].length > 0).map((cat) => (
+        <div key={cat} className="flex flex-col items-center shrink-0" data-testid={`${testidPrefix}-group-${cat}`}>
+          <div className="text-[10px] text-ds-text-muted mb-0.5 whitespace-nowrap">
+            {categoryLabel(cat)} · {groups[cat].length}
+          </div>
+          <div className="flex gap-0.5">
+            {groups[cat].map((c, i) => (
+              <CardImage key={i} card={c} width={cardWidth * 0.42} />
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
 
 /** Renders the Koi-Koi (こいこい) game page: a 2-player hanafuda capture game with yaku scoring. */
 export const KoiKoiPage = withTutorial(KoiKoiPageContent, 'koikoi', KOIKOI_TUTORIAL_STEPS);
@@ -121,6 +164,9 @@ function KoiKoiPageContent() {
   /** Localizes a yaku key, falling back to the raw key. */
   const yakuName = (key: string): string => t(`yaku.${key}`, { defaultValue: key });
 
+  /** Localizes a captured-card category key (光 / 種 / 短冊 / カス). */
+  const categoryLabel = (cat: KoiKoiCategory): string => t(`category.${cat}`);
+
   /** Renders a compact "name (points)" list of yaku. */
   const yakuList = (yaku: KoiKoiYaku[]): string => yaku.map((y) => `${yakuName(y.key)} (${y.points})`).join('  ·  ');
 
@@ -181,11 +227,13 @@ function KoiKoiPageContent() {
             {cpu && (
               <div className="text-center" data-testid="koikoi-cpu">
                 <div className="text-xs text-ds-text-muted mb-1">{playerLine(t('cpu'), cpu)}</div>
-                <div className="flex gap-0.5 justify-center flex-wrap min-h-[24px]">
-                  {cpu.captured.map((c, i) => (
-                    <CardImage key={i} card={c} width={cardWidth * 0.42} />
-                  ))}
-                </div>
+                <CapturedCategories
+                  captured={cpu.captured}
+                  cardWidth={cardWidth}
+                  categoryLabel={categoryLabel}
+                  emptyText={t('capturedEmpty')}
+                  testidPrefix="koikoi-cpu"
+                />
               </div>
             )}
 
@@ -222,6 +270,19 @@ function KoiKoiPageContent() {
                 </div>
               )}
             </div>
+
+            {/* Human captured, grouped by yaku category */}
+            {human && (
+              <div className="text-center" data-testid="koikoi-human-captured">
+                <CapturedCategories
+                  captured={human.captured}
+                  cardWidth={cardWidth}
+                  categoryLabel={categoryLabel}
+                  emptyText={t('capturedEmpty')}
+                  testidPrefix="koikoi-human"
+                />
+              </div>
+            )}
 
             {/* Human hand */}
             <div className="text-center" data-tutorial="koikoi-hand">

--- a/frontend/src/utils/koikoiCategory.test.ts
+++ b/frontend/src/utils/koikoiCategory.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import type { Card } from '../types/card';
+import { groupCapturedByCategory, KOIKOI_CATEGORY_ORDER, koikoiCategory } from './koikoiCategory';
+
+/** Builds a minimal hanafuda card carrying the given ink color token. */
+const hana = (color: string): Card => ({ design: 'SPADE', value: 0, glyph: '🎴', label: 'x', color, deck: 'hanafuda' });
+
+describe('koikoiCategory', () => {
+  it('maps gold to bright', () => {
+    expect(koikoiCategory(hana('gold'))).toBe('bright');
+  });
+
+  it('maps purple to animal', () => {
+    expect(koikoiCategory(hana('purple'))).toBe('animal');
+  });
+
+  it('maps red and blue to ribbon', () => {
+    expect(koikoiCategory(hana('red'))).toBe('ribbon');
+    expect(koikoiCategory(hana('blue'))).toBe('ribbon');
+  });
+
+  it('maps black (and any unknown color) to kasu', () => {
+    expect(koikoiCategory(hana('black'))).toBe('kasu');
+    expect(koikoiCategory(hana('teal'))).toBe('kasu');
+    expect(koikoiCategory({ design: 'SPADE', value: 1 })).toBe('kasu');
+  });
+});
+
+describe('groupCapturedByCategory', () => {
+  it('returns all four keys even when empty', () => {
+    const groups = groupCapturedByCategory([]);
+    expect(Object.keys(groups).sort()).toEqual([...KOIKOI_CATEGORY_ORDER].sort());
+    for (const cat of KOIKOI_CATEGORY_ORDER) {
+      expect(groups[cat]).toEqual([]);
+    }
+  });
+
+  it('buckets cards into their categories preserving order', () => {
+    const cards = [hana('black'), hana('gold'), hana('purple'), hana('black'), hana('red')];
+    const groups = groupCapturedByCategory(cards);
+    expect(groups.bright).toHaveLength(1);
+    expect(groups.animal).toHaveLength(1);
+    expect(groups.ribbon).toHaveLength(1);
+    expect(groups.kasu).toHaveLength(2);
+  });
+});

--- a/frontend/src/utils/koikoiCategory.ts
+++ b/frontend/src/utils/koikoiCategory.ts
@@ -1,0 +1,47 @@
+import type { Card } from '../types/card';
+
+/**
+ * Koi-Koi (こいこい / hanafuda) yaku categories, mirroring the Go domain's
+ * `KoiKoiCategory` (光 / 種 / 短冊 / カス). See `internal/domain/KoiKoi.go`.
+ */
+export type KoiKoiCategory = 'bright' | 'animal' | 'ribbon' | 'kasu';
+
+/** Display order for the four categories: Bright → Animal → Ribbon → Chaff. */
+export const KOIKOI_CATEGORY_ORDER: readonly KoiKoiCategory[] = ['bright', 'animal', 'ribbon', 'kasu'];
+
+/**
+ * Classifies a captured hanafuda card into its yaku category.
+ *
+ * The wire `design`/`value` fields cannot carry the month (the backend collapses
+ * months 5–12 to `"JOKER"` via `cardDesignToString`), so the month is not
+ * recoverable on the frontend. Instead we read the `color` ink token the backend
+ * derives *directly* from `domain.KoiKoiCardCategory` in `KoiKoiWebPresenter.
+ * koikoiFace`: gold→bright, purple→animal, red/blue→ribbon, black→chaff. This
+ * keeps the frontend classification in lockstep with the domain SSoT rather than
+ * re-inventing the 48-card table.
+ */
+export function koikoiCategory(card: Card): KoiKoiCategory {
+  switch (card.color) {
+    case 'gold':
+      return 'bright';
+    case 'purple':
+      return 'animal';
+    case 'red':
+    case 'blue':
+      return 'ribbon';
+    default:
+      return 'kasu';
+  }
+}
+
+/**
+ * Groups captured cards by {@link koikoiCategory}, preserving input order within
+ * each group. Every category key is always present (possibly with an empty array).
+ */
+export function groupCapturedByCategory(cards: Card[]): Record<KoiKoiCategory, Card[]> {
+  const groups: Record<KoiKoiCategory, Card[]> = { bright: [], animal: [], ribbon: [], kasu: [] };
+  for (const card of cards) {
+    groups[koikoiCategory(card)].push(card);
+  }
+  return groups;
+}


### PR DESCRIPTION
## 概要

こいこいの獲得札を役カテゴリ別（光 / 種 / 短冊 / カス）に整列表示します。従来は `p.captured.map(...)` で単純に一列（`flex-wrap`）に並べるだけで、どの札がどのカテゴリかが読み取れませんでした。本 PR ではカテゴリ小見出し＋枚数付きでグルーピング表示します。

さらに、これまで画面に一切表示されていなかった **人間プレイヤーの獲得札** も同じ形式で表示するようにしました。

## カテゴリ判定の根拠（発明せず既存の SSoT を参照）

ワイヤ上の `design`/`value` からは月を復元できません（バックエンドの `cardDesignToString` が 5〜12月を `"JOKER"` に潰すため）。代わりに、`KoiKoiWebPresenter.koikoiFace` が `domain.KoiKoiCardCategory` から直接導出して送出している `color` インク・トークンで分類します:

- `gold` → 光 (Bright)
- `purple` → 種 (Animal)
- `red` / `blue` → 短冊 (Ribbon)
- `black`（その他） → カス (Chaff)

これによりドメインの分類と完全に一致し、48枚テーブルを再実装しません。

## 変更点

- `frontend/src/utils/koikoiCategory.ts`（新規, +単体テスト）— `koikoiCategory` / `groupCapturedByCategory` / `KOIKOI_CATEGORY_ORDER`
- `frontend/src/pages/KoiKoiPage.tsx` — `CapturedCategories` 表示コンポーネントを追加し、CPU・人間の獲得札に適用
- `frontend/src/i18n/locales/{ja,en}/koikoi.json` — `category.*` ラベルと `capturedEmpty`

## 受け入れ条件

- [x] 獲得札が4カテゴリに分かれて表示される
- [x] 各カテゴリの枚数が分かる（`ラベル · 枚数`）
- [x] 空カテゴリは非表示（獲得札ゼロ時は「獲得札なし」を表示）
- [x] モバイル幅で横スクロール（`overflow-x-auto` + `shrink-0`）に収まる

## テスト

- `frontend/src/utils/koikoiCategory.test.ts` — 色→カテゴリのマッピングとグルーピング
- `frontend/src/pages/KoiKoiPage.test.tsx` — `groups captured cards under their yaku-category headers` / `shows the empty-pile label when a player has captured nothing`

## ゲート

- `biome check`: pass
- `bun run test -- --run KoiKoiPage koikoiCategory`: 21 passed
- `bun run build`（tsc）: pass

フロントエンドのみ（こいこいは extra WASM ワーカー。Go/CUI/内部 i18n は非変更）。

Closes #3517

🤖 Generated with [Claude Code](https://claude.com/claude-code)
