### PR TITLE
feat(doubleklondike): fan out the top 3 waste cards

### DIFF
--- a/frontend/src/pages/DoubleKlondikePage.test.tsx
+++ b/frontend/src/pages/DoubleKlondikePage.test.tsx
@@ -85,6 +85,37 @@ describe('DoubleKlondikePage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('mwt', { col: 0 }));
   });
 
+  it('fans out the top 3 waste cards, keeping only the top selectable', async () => {
+    mockExec.mockResolvedValue(
+      makeState({ waste: [card('CLOVER', 2), card('SPADE', 3), card('HEART', 4), card('DIAMOND', 5)] }),
+    );
+    renderWithProviders(<DoubleKlondikePage />);
+    // The top card stays interactive as the `waste` source button.
+    await screen.findByTestId('waste');
+    // The two cards beneath it are shown for visibility only (not selectable).
+    expect(screen.getByTestId('waste-under-0')).toBeInTheDocument();
+    expect(screen.getByTestId('waste-under-1')).toBeInTheDocument();
+    // Only 3 of the 4 waste cards are rendered (the fan is capped at 3).
+    expect(screen.queryByTestId('waste-under-2')).not.toBeInTheDocument();
+    // The under-cards are plain divs, not buttons.
+    expect(screen.getAllByTestId('waste', { exact: true }).length).toBe(1);
+  });
+
+  it('shows fewer waste cards when fewer than 3 are present', async () => {
+    mockExec.mockResolvedValue(makeState({ waste: [card('CLOVER', 2), card('SPADE', 3)] }));
+    renderWithProviders(<DoubleKlondikePage />);
+    await screen.findByTestId('waste');
+    expect(screen.getByTestId('waste-under-0')).toBeInTheDocument();
+    expect(screen.queryByTestId('waste-under-1')).not.toBeInTheDocument();
+  });
+
+  it('shows an empty waste placeholder when the waste is empty', async () => {
+    mockExec.mockResolvedValue(makeState({ waste: [] }));
+    renderWithProviders(<DoubleKlondikePage />);
+    await waitFor(() => expect(screen.getByTestId('waste-empty')).toBeInTheDocument());
+    expect(screen.queryByTestId('waste')).not.toBeInTheDocument();
+  });
+
   it('moves the waste card onto a foundation', async () => {
     renderWithProviders(<DoubleKlondikePage />);
     fireEvent.click(await screen.findByTestId('waste'));

--- a/frontend/src/pages/DoubleKlondikePage.tsx
+++ b/frontend/src/pages/DoubleKlondikePage.tsx
@@ -132,6 +132,8 @@ function DoubleKlondikePageContent() {
   };
 
   const cardH = Math.round(w * 1.4);
+  // Fan the most-recent up to 3 waste cards so a 3-card draw stays visible.
+  const wasteFan = Math.round(w * 0.4);
 
   const renderTableau = (column: (typeof state.tableau)[number], col: number) => (
     <div
@@ -168,7 +170,8 @@ function DoubleKlondikePageContent() {
     </div>
   );
 
-  const wasteTop = state.waste.length > 0 ? state.waste[state.waste.length - 1] : null;
+  // The most-recent up to 3 waste cards, oldest-first; only the last is playable.
+  const wasteDisplay = state.waste.slice(-3);
 
   return (
     <GamePageShell
@@ -201,24 +204,47 @@ function DoubleKlondikePageContent() {
           >
             {state.stockCount}
           </button>
-          <button
-            type="button"
-            className={`rounded ${selected?.zone === 'waste' ? 'ring-2 ring-ds-warning' : ''}`}
-            style={{ width: w, height: cardH }}
-            onClick={canAct ? clickWaste : undefined}
-            disabled={!canAct || !wasteTop}
-            title={t('waste')}
-            data-testid="waste"
-          >
-            {wasteTop ? (
-              <CardImage card={wasteTop} width={w} />
-            ) : (
-              <div
-                className="rounded border border-dashed border-white/25 bg-black/20"
-                style={{ width: w, height: cardH }}
-              />
-            )}
-          </button>
+          {wasteDisplay.length > 0 ? (
+            <div
+              className="relative"
+              style={{ width: w + (wasteDisplay.length - 1) * wasteFan, height: cardH }}
+              data-testid="waste-fan"
+            >
+              {wasteDisplay.map((c, i) => {
+                const isTop = i === wasteDisplay.length - 1;
+                return isTop ? (
+                  <button
+                    key={`waste-${i.toString()}`}
+                    type="button"
+                    className={`absolute top-0 rounded ${selected?.zone === 'waste' ? 'ring-2 ring-ds-warning' : ''}`}
+                    style={{ left: i * wasteFan }}
+                    onClick={canAct ? clickWaste : undefined}
+                    disabled={!canAct}
+                    title={t('waste')}
+                    data-testid="waste"
+                  >
+                    <CardImage card={c} width={w} />
+                  </button>
+                ) : (
+                  <div
+                    key={`waste-${i.toString()}`}
+                    className="absolute top-0 rounded opacity-60"
+                    style={{ left: i * wasteFan }}
+                    aria-hidden="true"
+                    data-testid={`waste-under-${i.toString()}`}
+                  >
+                    <CardImage card={c} width={w} />
+                  </div>
+                );
+              })}
+            </div>
+          ) : (
+            <div
+              className="rounded border border-dashed border-white/25 bg-black/20"
+              style={{ width: w, height: cardH }}
+              data-testid="waste-empty"
+            />
+          )}
           <div className="ml-auto grid grid-cols-4 gap-1">
             {state.foundation.map((f, i) => {
               const top = f.length > 0 ? f[f.length - 1] : null;


### PR DESCRIPTION
## Summary
When Double Klondike deals 3 cards from the stock (3-draw mode), the waste pile now fans out the most-recent up to 3 cards horizontally so all three are visible, instead of only the top card. This lets the player plan a pass through the stock.

Only the top card stays interactive as the move source (`clickWaste`); the cards beneath are display-only (`aria-hidden`, dimmed). Move/click logic is unchanged.

## Changes
- `DoubleKlondikePage.tsx`: render `state.waste.slice(-3)` as an absolutely-positioned fan; top card keeps `data-testid="waste"` + selection ring; under-cards get `data-testid="waste-under-N"`; empty waste keeps a placeholder (`data-testid="waste-empty"`).
- `DoubleKlondikePage.test.tsx`: added tests for 3-card fan + top-only selectable, fewer-than-3 case, and empty waste.

## Acceptance criteria
- [x] Waste shows the most-recent 3 cards fanned
- [x] Only the top card is selectable
- [x] Fewer than 3 cards → only that many shown
- [x] Tests added for fan display + selection restriction

## Gates
- [x] `bun run check`
- [x] `bun run test -- --run DoubleKlondikePage` (15 passed)
- [x] `bun run build` (tsc)

Frontend-only; no Go changes. WASM-neutral.

Closes #3584