### PR TITLE
feat(marias): show soloist-vs-defenders total in round result

### DIFF
--- a/frontend/src/i18n/locales/en/marias.json
+++ b/frontend/src/i18n/locales/en/marias.json
@@ -44,7 +44,9 @@
   "roundResult": {
     "title": "Round Result",
     "cardPoints": "{{name}} card points: {{points}}",
-    "marriage": "{{name}} marriage: {{points}}"
+    "marriage": "{{name}} marriage: {{points}}",
+    "soloistTotal": "Soloist: {{points}} pts",
+    "defenderTotal": "Defenders total: {{points}} pts"
   },
   "hintAvailable": "Hint",
   "hint": {

--- a/frontend/src/i18n/locales/ja/marias.json
+++ b/frontend/src/i18n/locales/ja/marias.json
@@ -44,7 +44,9 @@
   "roundResult": {
     "title": "ラウンド結果",
     "cardPoints": "{{name}} カード点: {{points}}",
-    "marriage": "{{name}} マリッジ: {{points}}"
+    "marriage": "{{name}} マリッジ: {{points}}",
+    "soloistTotal": "ソリスト: {{points}}点",
+    "defenderTotal": "ディフェンダー合計: {{points}}点"
   },
   "hintAvailable": "ヒント",
   "hint": {

--- a/frontend/src/pages/MariasPage.test.tsx
+++ b/frontend/src/pages/MariasPage.test.tsx
@@ -137,6 +137,30 @@ describe('MariasPage', () => {
     expect(screen.getByText('ラウンド結果')).toBeInTheDocument();
   });
 
+  it('shows the Soloist-vs-Defenders total comparison, highlighting the winning Soloist', async () => {
+    // Seat 0 is the Soloist: 55 + 40 = 95. Defenders (seats 1,2): 35 + 30 = 65.
+    mockExec.mockResolvedValue(roundEndState);
+    renderWithProviders(<MariasPage />);
+    const row = await screen.findByTestId('marias-side-totals');
+    const soloist = screen.getByText('ソリスト: 95点');
+    const defenders = screen.getByText('ディフェンダー合計: 65点');
+    expect(row).toContainElement(soloist);
+    expect(row).toContainElement(defenders);
+    // Soloist outscores the Defenders, so the Soloist side is emphasised.
+    expect(soloist).toHaveClass('text-ds-warning');
+    expect(defenders).not.toHaveClass('text-ds-warning');
+  });
+
+  it('highlights the Defenders when their combined total wins the round', async () => {
+    // Soloist (seat 0): 20 + 0 = 20. Defenders (seats 1,2): 50 + 50 = 100.
+    mockExec.mockResolvedValue(makeMariasState({ phase: 2, roundCardPoints: [20, 50, 50], roundMarriage: [0, 0, 0] }));
+    renderWithProviders(<MariasPage />);
+    const defenders = await screen.findByText('ディフェンダー合計: 100点');
+    const soloist = screen.getByText('ソリスト: 20点');
+    expect(defenders).toHaveClass('text-ds-warning');
+    expect(soloist).not.toHaveClass('text-ds-warning');
+  });
+
   it('renders the game end message', async () => {
     mockExec.mockResolvedValue(gameEndState);
     renderWithProviders(<MariasPage />);

--- a/frontend/src/pages/MariasPage.tsx
+++ b/frontend/src/pages/MariasPage.tsx
@@ -304,6 +304,34 @@ function MariasPageContent() {
                         )}
                       </div>
                     ))}
+                    {/* Soloist-vs-Defenders total comparison. Each side total is
+                        cardPoints + marriage; the Soloist wins the round only when
+                        their total strictly exceeds the two Defenders' combined total
+                        (matching the domain's ScoreRound). The winning side is emphasised. */}
+                    {(() => {
+                      const sideTotal = (soloist: boolean) =>
+                        state.players.reduce(
+                          (sum, p) =>
+                            p.isSoloist === soloist
+                              ? sum + (state.roundCardPoints[p.id] ?? 0) + (state.roundMarriage[p.id] ?? 0)
+                              : sum,
+                          0,
+                        );
+                      const soloistTotal = sideTotal(true);
+                      const defenderTotal = sideTotal(false);
+                      const soloistWon = soloistTotal > defenderTotal;
+                      return (
+                        <div className="mt-1 pt-1 border-t border-ds-border-subtle" data-testid="marias-side-totals">
+                          <span className={soloistWon ? 'text-ds-warning font-semibold' : ''}>
+                            {t('roundResult.soloistTotal', { points: soloistTotal })}
+                          </span>
+                          <span className="mx-1">/</span>
+                          <span className={soloistWon ? '' : 'text-ds-warning font-semibold'}>
+                            {t('roundResult.defenderTotal', { points: defenderTotal })}
+                          </span>
+                        </div>
+                      );
+                    })()}
                   </div>
                 )}
               </div>


### PR DESCRIPTION
## Summary

Mariáš is a Soloist-vs-two-Defenders game whose round outcome is decided by the Soloist's total against the Defenders' *combined* total, but the round-result panel only listed each player's card points + marriage individually — leaving the player to add up the defenders in their head.

This adds a comparison row to the bottom of the round-result panel:

> ソリスト: X点 / ディフェンダー合計: Y点

- Each side total = `roundCardPoints` + `roundMarriage`, split by `player.isSoloist`.
- The winning side is emphasised with `text-ds-warning font-semibold`.
- Winner logic mirrors the domain `Marias.ScoreRound`: the Soloist wins only when their total **strictly exceeds** the Defenders' combined total (ties favour the Defenders).

Frontend-only — no domain/API change. The needed data (`roundCardPoints`, `roundMarriage`, `isSoloist`) is already on `MariasResponse`.

## Acceptance criteria
- [x] Round result shows a Soloist-vs-Defenders total comparison row
- [x] Totals include marriage points
- [x] The winning side is visually emphasised
- [x] Tests added to `MariasPage.test.tsx`

## Test plan
- `bun run test -- --run MariasPage` — 14 passed (2 new: soloist-wins highlight, defenders-win highlight)
- `bun run check` — pass
- `bun run build` — pass

Closes #3427
