### PR TITLE
feat(mus): show a Pares/Juego hand-summary panel to inform betting

### DIFF
--- a/frontend/src/i18n/locales/en/mus.json
+++ b/frontend/src/i18n/locales/en/mus.json
@@ -78,5 +78,17 @@
   },
   "envidoStepperLabel": "Envido bet amount",
   "envidoIncrease": "Increase envido by 1",
-  "envidoDecrease": "Decrease envido by 1"
+  "envidoDecrease": "Decrease envido by 1",
+  "handSummary": {
+    "title": "Hand summary",
+    "pares": "Pares",
+    "juego": "Juego",
+    "paresNone": "None",
+    "paresPar": "Par (one pair)",
+    "paresMedias": "Medias (three)",
+    "paresDuples": "Duples (two pairs)",
+    "juegoBest": "31 ★ (best)",
+    "juegoYes": "{{points}} (has Juego)",
+    "juegoPunto": "Punto {{points}} (no Juego)"
+  }
 }

--- a/frontend/src/i18n/locales/ja/mus.json
+++ b/frontend/src/i18n/locales/ja/mus.json
@@ -78,5 +78,17 @@
   },
   "envidoStepperLabel": "エンビードの賭け額",
   "envidoIncrease": "エンビードを1増やす",
-  "envidoDecrease": "エンビードを1減らす"
+  "envidoDecrease": "エンビードを1減らす",
+  "handSummary": {
+    "title": "手札評価",
+    "pares": "パレス",
+    "juego": "フエゴ",
+    "paresNone": "なし",
+    "paresPar": "ペア",
+    "paresMedias": "メディアス（3枚）",
+    "paresDuples": "デュプレス（2ペア）",
+    "juegoBest": "31点 ★（最強）",
+    "juegoYes": "{{points}}点（フエゴあり）",
+    "juegoPunto": "プント {{points}}点（フエゴなし）"
+  }
 }

--- a/frontend/src/pages/MusPage.test.tsx
+++ b/frontend/src/pages/MusPage.test.tsx
@@ -146,4 +146,51 @@ describe('MusPage', () => {
     await waitFor(() => expect(screen.getByText('アマラコ')).toBeInTheDocument());
     expect(screen.queryByRole('button', { name: 'パソ（パス）' })).not.toBeInTheDocument();
   });
+
+  it('shows the hand-summary panel with Pares and Juego (default hand: par of Q, Punto 28)', async () => {
+    renderWithProviders(<MusPage />);
+    await waitFor(() => expect(screen.getByTestId('mus-hand-summary')).toBeInTheDocument());
+    expect(screen.getByText('手札評価')).toBeInTheDocument();
+    // A(1) + Q(12) + Q(12) + 7 -> pair of queens, points 28 (< 31 -> Punto).
+    expect(screen.getByTestId('mus-summary-pares')).toHaveTextContent('パレス: ペア');
+    expect(screen.getByTestId('mus-summary-juego')).toHaveTextContent('プント 28点');
+  });
+
+  it('highlights the Pares row during the Pares betting round', async () => {
+    mockExec.mockResolvedValue(makeMusState({ phase: 4 }));
+    renderWithProviders(<MusPage />);
+    await waitFor(() => expect(screen.getByTestId('mus-summary-pares')).toBeInTheDocument());
+    expect(screen.getByTestId('mus-summary-pares').className).toContain('font-semibold');
+    expect(screen.getByTestId('mus-summary-juego').className).not.toContain('font-semibold');
+  });
+
+  it('shows the best-hand marker for a 31-point Juego', async () => {
+    const juego31 = makeMusState({
+      phase: 5,
+      players: [
+        {
+          id: 0,
+          isHuman: true,
+          cardCount: 4,
+          cards: [
+            { design: 'SPADE', value: 13 },
+            { design: 'CLOVER', value: 13 },
+            { design: 'HEART', value: 13 },
+            { design: 'DIAMOND', value: 1 },
+          ],
+          teamScore: 5,
+        },
+        { id: 1, isHuman: false, cardCount: 4, cards: [], teamScore: 3 },
+        { id: 2, isHuman: false, cardCount: 4, cards: [], teamScore: 5 },
+        { id: 3, isHuman: false, cardCount: 4, cards: [], teamScore: 3 },
+      ],
+    });
+    mockExec.mockResolvedValue(juego31);
+    renderWithProviders(<MusPage />);
+    await waitFor(() => expect(screen.getByTestId('mus-summary-juego')).toBeInTheDocument());
+    // Three Kings = medias; 10+10+10+1 = 31 -> best.
+    expect(screen.getByTestId('mus-summary-pares')).toHaveTextContent('パレス: メディアス');
+    expect(screen.getByTestId('mus-summary-juego')).toHaveTextContent('31点 ★');
+    expect(screen.getByTestId('mus-summary-juego').className).toContain('font-semibold');
+  });
 });

--- a/frontend/src/pages/MusPage.tsx
+++ b/frontend/src/pages/MusPage.tsx
@@ -29,7 +29,11 @@ import type { TutorialStep } from '../types/tutorial';
 import { MUS_HELP, parseMusCommand } from '../utils/cli/commands/musCommands';
 import { formatMusState } from '../utils/cli/formatters/musFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { evalMusHand } from '../utils/musHandEval';
 import { playerName } from '../utils/playerUtils';
+
+/** i18n value keys for each Pares category (0=none, 1=par, 2=medias, 3=duples). */
+const PARES_VALUE_KEYS: readonly string[] = ['paresNone', 'paresPar', 'paresMedias', 'paresDuples'];
 
 /** Mus tutorial step definitions. */
 const MUS_TUTORIAL_STEPS: TutorialStep[] = [
@@ -285,6 +289,35 @@ function MusPageContent() {
                 dataTutorialPrefix="mus"
               />
             )}
+
+            {humanPlayer &&
+              humanPlayer.cards.length === 4 &&
+              (() => {
+                const evalResult = evalMusHand(humanPlayer.cards);
+                const paresValue = t(`handSummary.${PARES_VALUE_KEYS[evalResult.paresCategory]}`);
+                const juegoValue =
+                  evalResult.points === 31
+                    ? t('handSummary.juegoBest')
+                    : evalResult.hasJuego
+                      ? t('handSummary.juegoYes', { points: evalResult.points })
+                      : t('handSummary.juegoPunto', { points: evalResult.points });
+                const paresActive = state.phase === MusPhase.PARES;
+                const juegoActive = state.phase === MusPhase.JUEGO;
+                return (
+                  <div
+                    className="mt-2 p-2 rounded bg-black/30 text-ds-text-muted text-sm"
+                    data-testid="mus-hand-summary"
+                  >
+                    <div className="mb-1 text-ds-text-primary">{t('handSummary.title')}</div>
+                    <div className={paresActive ? 'text-ds-warning font-semibold' : ''} data-testid="mus-summary-pares">
+                      {t('handSummary.pares')}: {paresValue}
+                    </div>
+                    <div className={juegoActive ? 'text-ds-warning font-semibold' : ''} data-testid="mus-summary-juego">
+                      {t('handSummary.juego')}: {juegoValue}
+                    </div>
+                  </div>
+                );
+              })()}
 
             <ErrorAlert message={error} onRetry={retry} />
 

--- a/frontend/src/utils/musHandEval.test.ts
+++ b/frontend/src/utils/musHandEval.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import type { Card } from '../types/card';
+import {
+  evalMusHand,
+  MUS_JUEGO_THRESHOLD,
+  musCardPoints,
+  musCardRank,
+  musJuegoPoints,
+  musParesCategory,
+} from './musHandEval';
+
+/** Build a card of the given value (suit is irrelevant to Mus evaluation). */
+const c = (value: number, design: Card['design'] = 'SPADE'): Card => ({ design, value });
+
+describe('musCardRank', () => {
+  it('maps A(1)..7 to themselves', () => {
+    expect(musCardRank(1)).toBe(1);
+    expect(musCardRank(7)).toBe(7);
+  });
+  it('maps face cards J/Q/K to 8/9/10', () => {
+    expect(musCardRank(11)).toBe(8);
+    expect(musCardRank(12)).toBe(9);
+    expect(musCardRank(13)).toBe(10);
+  });
+});
+
+describe('musCardPoints', () => {
+  it('scores A..7 at face value', () => {
+    expect(musCardPoints(1)).toBe(1);
+    expect(musCardPoints(7)).toBe(7);
+  });
+  it('scores J/Q/K as 10', () => {
+    expect(musCardPoints(11)).toBe(10);
+    expect(musCardPoints(12)).toBe(10);
+    expect(musCardPoints(13)).toBe(10);
+  });
+});
+
+describe('musJuegoPoints', () => {
+  it('sums the point values of the hand', () => {
+    expect(musJuegoPoints([c(13), c(13), c(13), c(1)])).toBe(31); // 10+10+10+1
+    expect(musJuegoPoints([c(1), c(12), c(12), c(7)])).toBe(28); // 1+10+10+7
+  });
+});
+
+describe('musParesCategory', () => {
+  it('returns 0 (none) when all ranks differ', () => {
+    expect(musParesCategory([c(1), c(2), c(3), c(4)])).toBe(0);
+  });
+  it('returns 1 (par) for a single pair', () => {
+    expect(musParesCategory([c(12), c(12), c(1), c(7)])).toBe(1);
+  });
+  it('returns 2 (medias) for three of a kind', () => {
+    expect(musParesCategory([c(5), c(5), c(5), c(2)])).toBe(2);
+  });
+  it('returns 3 (duples) for two pairs', () => {
+    expect(musParesCategory([c(3), c(3), c(7), c(7)])).toBe(3);
+  });
+  it('returns 3 (duples) for four of a kind', () => {
+    expect(musParesCategory([c(4), c(4), c(4), c(4)])).toBe(3);
+  });
+  it('treats face cards of equal rank as a pair (J is not K)', () => {
+    // Two Kings (13,13) form a pair; the two others (11,12) are distinct ranks.
+    expect(musParesCategory([c(13), c(13), c(11), c(12)])).toBe(1);
+  });
+});
+
+describe('evalMusHand', () => {
+  it('flags Juego with the best hand at 31 points', () => {
+    const e = evalMusHand([c(13), c(13), c(13), c(1)]);
+    expect(e.points).toBe(31);
+    expect(e.hasJuego).toBe(true);
+    expect(e.paresCategory).toBe(2); // three Kings = medias
+  });
+
+  it('flags Juego at 40 points (four ten-value cards)', () => {
+    const e = evalMusHand([c(13), c(12), c(11), c(13)]);
+    expect(e.points).toBe(40);
+    expect(e.hasJuego).toBe(true);
+    expect(e.points).toBeGreaterThanOrEqual(MUS_JUEGO_THRESHOLD);
+  });
+
+  it('reports Punto (no Juego) below the threshold', () => {
+    const e = evalMusHand([c(1), c(12), c(12), c(7)]);
+    expect(e.points).toBe(28);
+    expect(e.hasJuego).toBe(false);
+    expect(e.paresCategory).toBe(1); // pair of Queens = par
+  });
+
+  it('reports no pares and no juego for a low scattered hand', () => {
+    const e = evalMusHand([c(1), c(2), c(4), c(6)]);
+    expect(e.paresCategory).toBe(0);
+    expect(e.points).toBe(13);
+    expect(e.hasJuego).toBe(false);
+  });
+});

--- a/frontend/src/utils/musHandEval.ts
+++ b/frontend/src/utils/musHandEval.ts
@@ -1,0 +1,99 @@
+import type { Card } from '../types/card';
+
+/** Points threshold at or above which a hand "has Juego". Mirrors `MusJuegoThreshold` in internal/domain/Mus.go. */
+export const MUS_JUEGO_THRESHOLD = 31;
+
+/**
+ * Pares (pair) category of a Mus hand.
+ * `0` = none, `1` = par (one pair), `2` = medias (three of a kind), `3` = duples (two pairs / four of a kind).
+ * Mirrors the return values of `musParesCategory` in internal/domain/Mus.go.
+ */
+export type MusParesCategory = 0 | 1 | 2 | 3;
+
+/**
+ * Grande/Chica card rank: A=1..7, Sota(J)=8, Caballo(Q)=9, Rey(K)=10.
+ * Used to group cards for Pares detection. Mirrors `musCardRank` in internal/domain/Mus.go.
+ */
+export function musCardRank(value: number): number {
+  switch (value) {
+    case 11: // Sota (J)
+      return 8;
+    case 12: // Caballo (Q)
+      return 9;
+    case 13: // Rey (K)
+      return 10;
+    default: // A(1)..7 (and any other value maps to itself)
+      return value;
+  }
+}
+
+/**
+ * Juego point value of a single card: A=1, 2..7 = face value, J/Q/K = 10.
+ * Mirrors `musCardPoints` in internal/domain/Mus.go.
+ */
+export function musCardPoints(value: number): number {
+  switch (value) {
+    case 11:
+    case 12:
+    case 13:
+      return 10;
+    default:
+      return value;
+  }
+}
+
+/**
+ * Classify the Pares (pair) type of a hand by its card ranks.
+ * Mirrors `musParesCategory` in internal/domain/Mus.go: four of a kind or two
+ * distinct pairs count as duples, three of a kind as medias, a single pair as par.
+ */
+export function musParesCategory(cards: readonly Card[]): MusParesCategory {
+  const counts = new Map<number, number>();
+  for (const c of cards) {
+    const r = musCardRank(c.value);
+    counts.set(r, (counts.get(r) ?? 0) + 1);
+  }
+  let pairs = 0;
+  let triples = 0;
+  let quads = 0;
+  for (const count of counts.values()) {
+    if (count === 2) pairs++;
+    else if (count === 3) triples++;
+    else if (count === 4) quads++;
+  }
+  if (quads > 0 || pairs >= 2) return 3; // duples
+  if (triples > 0) return 2; // medias
+  if (pairs === 1) return 1; // par
+  return 0;
+}
+
+/** Sum of the Juego point values of a hand. */
+export function musJuegoPoints(cards: readonly Card[]): number {
+  let sum = 0;
+  for (const c of cards) sum += musCardPoints(c.value);
+  return sum;
+}
+
+/** Front-end evaluation of the human's Mus hand, used to render a betting-aid summary. */
+export interface MusHandEval {
+  /** Pares category: 0 none, 1 par, 2 medias, 3 duples. */
+  paresCategory: MusParesCategory;
+  /** Total Juego points (A=1..7, J/Q/K=10). */
+  points: number;
+  /** Whether the hand reaches the Juego threshold (>=31); otherwise it plays for Punto. */
+  hasJuego: boolean;
+}
+
+/**
+ * Evaluate a Mus hand into its Pares category and Juego points, purely on the
+ * client, so the human can see how their hand rates before betting. Mirrors the
+ * evaluation rules in internal/domain/Mus.go (READ-ONLY reference; no Go change).
+ */
+export function evalMusHand(cards: readonly Card[]): MusHandEval {
+  const points = musJuegoPoints(cards);
+  return {
+    paresCategory: musParesCategory(cards),
+    points,
+    hasJuego: points >= MUS_JUEGO_THRESHOLD,
+  };
+}


### PR DESCRIPTION
## Summary

Adds a front-end **hand-evaluation summary** to the Mus page so the human can see how their hand rates before choosing a bet action. Previously the page asked for Grande/Chica/Pares/Juego bet decisions without showing any evaluation of the player's own 4 cards, which makes the Basque scoring (face cards = 10, three of a kind = medias, etc.) hard for beginners.

A small panel next to the player's hand shows:
- **Pares**: none / par (one pair) / medias (three) / duples (two pairs)
- **Juego**: total points, with `31 ★` for the best hand, `(has Juego)` for 32–40, or `Punto NN` when below 31

The row matching the current betting round (Pares or Juego) is highlighted.

## Rules mirrored (READ-ONLY from `internal/domain/Mus.go`)
- `musCardRank`: A(1)..7 → self, J=8, Q=9, K=10
- `musCardPoints`: J/Q/K = 10, else face value
- `musParesCategory`: four-of-a-kind or ≥2 pairs → duples; three → medias; one pair → par; else none
- Juego = sum of points; ≥31 has Juego (31 best), else Punto. No Go code was touched.

## Changes
- `frontend/src/utils/musHandEval.ts` (new) — pure eval helper + `evalMusHand`
- `frontend/src/utils/musHandEval.test.ts` (new) — unit tests (par/medias/duples/none, juego-31/40, punto)
- `frontend/src/pages/MusPage.tsx` — additive summary panel with `data-testid`s, round highlight
- `frontend/src/pages/MusPage.test.tsx` — panel rendering + highlight + best-hand tests
- `frontend/src/i18n/locales/{ja,en}/mus.json` — `handSummary` keys

## Test plan
- [x] `bun run check` (biome + design tokens)
- [x] `bun run test -- --run MusPage musHandEval` (30 passed)
- [x] `bun run build` (tsc)

Closes #3406
