### PR TITLE
feat(frenchtarot): show bouts held in hand in the info sidebar

### DIFF
--- a/frontend/src/i18n/locales/en/frenchtarot.json
+++ b/frontend/src/i18n/locales/en/frenchtarot.json
@@ -32,6 +32,14 @@
   "currentTrick": "Current Trick",
   "players": "Players",
   "chienLabel": "Chien (revealed)",
+  "bouts": {
+    "title": "Bouts held ({{count}}/3)",
+    "twentyOne": "21",
+    "petit": "Petit (trump 1)",
+    "excuse": "Excuse",
+    "none": "None",
+    "target": "Target with {{count}} bout(s): {{points}} pts"
+  },
   "you": "You",
   "cpu": "CPU {{id}}",
   "declarerBadge": "Declarer",

--- a/frontend/src/i18n/locales/ja/frenchtarot.json
+++ b/frontend/src/i18n/locales/ja/frenchtarot.json
@@ -32,6 +32,14 @@
   "currentTrick": "現在のトリック",
   "players": "プレイヤー",
   "chienLabel": "シアン（公開）",
+  "bouts": {
+    "title": "保有ブー（{{count}}/3）",
+    "twentyOne": "21",
+    "petit": "プティ（切り札1）",
+    "excuse": "エクスキューズ",
+    "none": "なし",
+    "target": "{{count}}ブーの必要点: {{points}} 点"
+  },
   "you": "あなた",
   "cpu": "CPU {{id}}",
   "declarerBadge": "デクレアラー",

--- a/frontend/src/pages/FrenchTarotPage.test.tsx
+++ b/frontend/src/pages/FrenchTarotPage.test.tsx
@@ -134,6 +134,53 @@ describe('FrenchTarotPage', () => {
     expect(screen.getAllByText('デクレアラー').length).toBeGreaterThan(0);
   });
 
+  it('shows the bouts held in hand (the 21 and the Excuse) and excludes a suit Ace', async () => {
+    // The default hand holds the 21 (purple trump) + the Excuse (gold), plus a black CLOVER Ace
+    // (value 1) that must NOT be counted as the Petit.
+    renderWithProviders(<FrenchTarotPage />);
+    const panel = await screen.findByTestId('frenchtarot-bouts');
+    expect(panel).toHaveTextContent('保有ブー（2/3）');
+    expect(screen.getByTestId('frenchtarot-bout-twentyOne')).toBeInTheDocument();
+    expect(screen.getByTestId('frenchtarot-bout-excuse')).toBeInTheDocument();
+    expect(screen.queryByTestId('frenchtarot-bout-petit')).not.toBeInTheDocument();
+    // 2 bouts → target 41.
+    expect(panel).toHaveTextContent('41');
+  });
+
+  it('shows no bouts when the hand holds none', async () => {
+    mockExec.mockResolvedValue(
+      makeFrenchTarotState({
+        players: [
+          {
+            id: 0,
+            isHuman: true,
+            cardCount: 3,
+            cards: [
+              { design: 'HEART' as const, value: 13, glyph: '♥', label: 'D', color: 'red', deck: 'tarot' },
+              { design: 'CLOVER' as const, value: 1, glyph: '♣', label: '1', color: 'black', deck: 'tarot' },
+              { design: 'JOKER' as const, value: 5, glyph: '✦', label: '5', color: 'purple', deck: 'tarot' },
+            ],
+            trickCount: 0,
+            cardPoints: 0,
+            score: 0,
+            isDeclarer: true,
+          },
+          { id: 1, isHuman: false, cardCount: 3, cards: [], trickCount: 0, cardPoints: 0, score: 0, isDeclarer: false },
+          { id: 2, isHuman: false, cardCount: 3, cards: [], trickCount: 0, cardPoints: 0, score: 0, isDeclarer: false },
+          { id: 3, isHuman: false, cardCount: 3, cards: [], trickCount: 0, cardPoints: 0, score: 0, isDeclarer: false },
+        ],
+        playableIndices: [0, 1, 2],
+      }),
+    );
+    renderWithProviders(<FrenchTarotPage />);
+    const panel = await screen.findByTestId('frenchtarot-bouts');
+    expect(panel).toHaveTextContent('保有ブー（0/3）');
+    expect(panel).toHaveTextContent('なし');
+    expect(screen.queryByTestId('frenchtarot-bout-twentyOne')).not.toBeInTheDocument();
+    // 0 bouts → target 56.
+    expect(panel).toHaveTextContent('56');
+  });
+
   it('renders the bid phase with Pass and the four contract buttons', async () => {
     mockExec.mockResolvedValue(bidPhaseState);
     renderWithProviders(<FrenchTarotPage />);

--- a/frontend/src/pages/FrenchTarotPage.tsx
+++ b/frontend/src/pages/FrenchTarotPage.tsx
@@ -36,6 +36,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { FRENCH_TAROT_HELP, parseFrenchTarotCommand } from '../utils/cli/commands/frenchtarotCommands';
 import { formatFrenchTarotState } from '../utils/cli/formatters/frenchtarotFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { frenchTarotTarget, heldBouts } from '../utils/frenchTarotBouts';
 import { playerName } from '../utils/playerUtils';
 
 /** French Tarot tutorial step definitions. */
@@ -174,6 +175,9 @@ function FrenchTarotPageContent() {
   const canDiscard = isChienPhase && state.isHumanDiscard;
   const canPlay = isPlayPhase && isHumanTurn;
 
+  // Bouts (oudlers) the human currently holds in hand: the 21, the Petit (trump 1), and the Excuse.
+  const heldBoutList = humanPlayer ? heldBouts(humanPlayer.cards) : [];
+
   const contractLabel = t(CONTRACT_KEYS[state.contract] ?? 'contractNone');
   const highestBidLabel = state.highestBid > 0 ? t(CONTRACT_KEYS[state.highestBid] ?? 'contractNone') : t('bidNone');
 
@@ -296,6 +300,36 @@ function FrenchTarotPageContent() {
                     </div>
                   ))}
                 </div>
+
+                {/* Bouts (oudlers) held in the human's hand — drive the contract's point target. */}
+                {humanPlayer && humanPlayer.cards.length > 0 && (
+                  <div className="mb-2 p-2 rounded bg-black/30" data-testid="frenchtarot-bouts">
+                    <div className="text-ds-text-muted text-sm mb-1">
+                      {t('bouts.title', { count: heldBoutList.length })}
+                    </div>
+                    {heldBoutList.length > 0 ? (
+                      <div className="flex flex-wrap gap-1">
+                        {heldBoutList.map((b) => (
+                          <span
+                            key={b}
+                            className="px-1.5 py-0.5 rounded bg-ds-warning/30 text-ds-warning text-xs"
+                            data-testid={`frenchtarot-bout-${b}`}
+                          >
+                            {t(`bouts.${b}`)}
+                          </span>
+                        ))}
+                      </div>
+                    ) : (
+                      <div className="text-ds-text-muted text-sm">{t('bouts.none')}</div>
+                    )}
+                    <div className="text-ds-text-muted text-xs mt-1">
+                      {t('bouts.target', {
+                        count: heldBoutList.length,
+                        points: frenchTarotTarget(heldBoutList.length),
+                      })}
+                    </div>
+                  </div>
+                )}
 
                 {/* Players: cards / tricks / captured points */}
                 {isMobile ? (

--- a/frontend/src/utils/frenchTarotBouts.test.ts
+++ b/frontend/src/utils/frenchTarotBouts.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import type { Card } from '../types/card';
+import { frenchTarotTarget, heldBouts } from './frenchTarotBouts';
+
+const trump = (value: number): Card => ({
+  design: 'JOKER',
+  value,
+  glyph: '✦',
+  label: String(value),
+  color: 'purple',
+  deck: 'tarot',
+});
+const excuse = (): Card => ({ design: 'JOKER', value: 0, glyph: '★', label: 'Excuse', color: 'gold', deck: 'tarot' });
+const suit = (value: number): Card => ({
+  design: 'CLOVER',
+  value,
+  glyph: '♣',
+  label: String(value),
+  color: 'black',
+  deck: 'tarot',
+});
+
+describe('heldBouts', () => {
+  it('detects the 21 and the Excuse and returns them in canonical order', () => {
+    expect(heldBouts([excuse(), suit(5), trump(21)])).toEqual(['twentyOne', 'excuse']);
+  });
+
+  it('detects the Petit (trump valued 1) but not a suit Ace also valued 1', () => {
+    expect(heldBouts([trump(1), suit(1)])).toEqual(['petit']);
+  });
+
+  it('returns all three bouts when the whole set is held', () => {
+    expect(heldBouts([trump(1), trump(21), excuse()])).toEqual(['twentyOne', 'petit', 'excuse']);
+  });
+
+  it('returns an empty array when no bouts are held', () => {
+    expect(heldBouts([suit(1), suit(14), trump(5), trump(20)])).toEqual([]);
+  });
+});
+
+describe('frenchTarotTarget', () => {
+  it('maps bout count to the required card-point target', () => {
+    expect(frenchTarotTarget(0)).toBe(56);
+    expect(frenchTarotTarget(1)).toBe(51);
+    expect(frenchTarotTarget(2)).toBe(41);
+    expect(frenchTarotTarget(3)).toBe(36);
+  });
+
+  it('treats negative counts as zero bouts', () => {
+    expect(frenchTarotTarget(-1)).toBe(56);
+  });
+});

--- a/frontend/src/utils/frenchTarotBouts.ts
+++ b/frontend/src/utils/frenchTarotBouts.ts
@@ -1,0 +1,63 @@
+import type { Card } from '../types/card';
+
+/**
+ * The three French Tarot bouts (oudlers): the 21 (highest trump), the Petit (trump 1),
+ * and the Excuse (the Fool). The number of bouts a side captures sets the card-point
+ * target required for a made contract, so knowing which bouts you hold is central to play.
+ */
+export type FrenchTarotBout = 'twentyOne' | 'petit' | 'excuse';
+
+/**
+ * True when the card is a trump (atout). Trumps are drawn in `purple` by the French Tarot
+ * face descriptor (see `FrenchTarotWebPresenter.frenchTarotFace`); their `design` field is
+ * the generic "JOKER" sentinel, so `color` is the reliable discriminator.
+ */
+function isTrump(card: Card): boolean {
+  return card.color === 'purple';
+}
+
+/** True when the card is the Excuse (the Fool), drawn in `gold`. */
+function isExcuse(card: Card): boolean {
+  return card.color === 'gold';
+}
+
+/** The three bouts in canonical display order. */
+const BOUT_ORDER: readonly FrenchTarotBout[] = ['twentyOne', 'petit', 'excuse'];
+
+/** True when the given card is the named bout. */
+function cardIsBout(card: Card, bout: FrenchTarotBout): boolean {
+  switch (bout) {
+    case 'twentyOne':
+      return isTrump(card) && card.value === 21;
+    case 'petit':
+      return isTrump(card) && card.value === 1;
+    case 'excuse':
+      return isExcuse(card);
+  }
+}
+
+/**
+ * Returns which bouts are present in the given hand, in canonical display order
+ * (21, Petit, Excuse). Note the Petit is the trump valued 1 — a suit Ace (also valued 1
+ * but not purple) is correctly excluded.
+ *
+ * @param cards - The hand to inspect.
+ * @returns The bouts held, in canonical order (possibly empty).
+ */
+export function heldBouts(cards: readonly Card[]): FrenchTarotBout[] {
+  return BOUT_ORDER.filter((bout) => cards.some((card) => cardIsBout(card, bout)));
+}
+
+/**
+ * The card-point target required for a made contract given the number of bouts the declarer
+ * captures (0→56, 1→51, 2→41, 3→36). Mirrors the domain `frenchTarotTarget`.
+ *
+ * @param bouts - The number of bouts captured (0-3).
+ * @returns The required card-point target (half-points).
+ */
+export function frenchTarotTarget(bouts: number): number {
+  if (bouts <= 0) return 56;
+  if (bouts === 1) return 51;
+  if (bouts === 2) return 41;
+  return 36;
+}


### PR DESCRIPTION
## Summary

Adds an info-sidebar panel to the French Tarot page showing which of the three **bouts (oudlers)** the human currently holds in hand — the **21** (highest trump), the **Petit** (trump 1), and the **Excuse** (the Fool) — with the card-point target that number of bouts implies (0→56, 1→51, 2→41, 3→36). Bouts set the contract's point requirement, so this is core play information.

Frontend-only (frenchtarot is on the `extra` worker, WASM-neutral). No Go changes.

## Bout encoding (verified against domain, read-only)

The domain represents bouts as: trump = `design 5`, Excuse = `design 6`/`value 0`, Petit = trump `value 1`, 21 = trump `value 21` (`internal/domain/FrenchTarot.go`). The web presenter (`FrenchTarotWebPresenter.frenchTarotFace`) draws trumps **purple** and the Excuse **gold** (the `design` field collapses to the "JOKER" sentinel, so `color` is the reliable discriminator). Detection therefore uses:

- **21** — `color === 'purple' && value === 21`
- **Petit** — `color === 'purple' && value === 1` (a black suit Ace, also value 1, is correctly excluded)
- **Excuse** — `color === 'gold'`

The `frenchTarotTarget` helper mirrors the domain `frenchTarotTarget`.

## Changes

- `frontend/src/utils/frenchTarotBouts.ts` (new) — pure `heldBouts()` + `frenchTarotTarget()` helpers
- `frontend/src/utils/frenchTarotBouts.test.ts` (new) — 6 unit tests
- `frontend/src/pages/FrenchTarotPage.tsx` — additive `data-testid="frenchtarot-bouts"` panel in the info sidebar
- `frontend/src/pages/FrenchTarotPage.test.tsx` — 2 new page tests
- `frontend/src/i18n/locales/{ja,en}/frenchtarot.json` — `bouts.*` keys

## Test plan

- [x] `bun run check` (biome + design-tokens)
- [x] `bun run test -- --run FrenchTarotPage` (21 passed)
- [x] `bun run test -- --run frenchTarotBouts` (6 passed)
- [x] `bun run build` (tsc gate)
- [x] Hand holding the 21 + Excuse shows those 2 bouts (and excludes a value-1 suit Ace); a hand with none shows 0 / "None"

Closes #3526
