### PR TITLE
feat(koenigrufen): organize secret-partner clues while the called king is hidden

### DIFF
--- a/frontend/src/i18n/locales/en/koenigrufen.json
+++ b/frontend/src/i18n/locales/en/koenigrufen.json
@@ -38,6 +38,10 @@
   "partnerBadge": "Partner",
   "calledKing": "Called King: {{suit}}",
   "partnerRevealed": "Partner: {{name}}",
+  "partnerClue": {
+    "unknown": "Whoever holds the {{suit}} King is the declarer's secret partner (still unknown)",
+    "youArePartner": "You hold that King — you are the declarer's secret partner"
+  },
   "bidPass": "Pass",
   "bidRufer": "Rufer",
   "bidPhase": "Auction — declare the Rufer (King-calling) contract, or pass.",

--- a/frontend/src/i18n/locales/ja/koenigrufen.json
+++ b/frontend/src/i18n/locales/ja/koenigrufen.json
@@ -38,6 +38,10 @@
   "partnerBadge": "パートナー",
   "calledKing": "呼ばれた王: {{suit}}",
   "partnerRevealed": "パートナー: {{name}}",
+  "partnerClue": {
+    "unknown": "{{suit}}の王を持つプレイヤーが宣言者の秘密のパートナー（まだ不明）",
+    "youArePartner": "あなたがその王を持っています — あなたが宣言者の秘密のパートナーです"
+  },
   "bidPass": "パス",
   "bidRufer": "ルーファー",
   "bidPhase": "オークション — ルーファー（王呼び）を宣言するか、パスします。",

--- a/frontend/src/pages/KoenigrufenPage.test.tsx
+++ b/frontend/src/pages/KoenigrufenPage.test.tsx
@@ -392,10 +392,87 @@ describe('KoenigrufenPage', () => {
     expect(screen.getAllByText('パートナー').length).toBeGreaterThan(0);
   });
 
-  it('does not reveal the partner before partnerRevealed is true', async () => {
+  it('does not reveal the partner before partnerRevealed is true, but shows the called-King clue', async () => {
     renderWithProviders(<KoenigrufenPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: 'K ♥' })).toBeInTheDocument());
+    // The revealed-partner label must not appear yet.
     expect(screen.queryByText('パートナー')).not.toBeInTheDocument();
+    // Instead, the organized clue tells the human what they legitimately know.
+    const clue = screen.getByTestId('koenigrufen-partner-clue');
+    expect(clue).toHaveTextContent('の王を持つプレイヤーが宣言者の秘密のパートナー（まだ不明）');
+    // The human here is the declarer (does not hold the called King), so no "you are the partner" line.
+    expect(screen.queryByTestId('koenigrufen-partner-clue-you')).not.toBeInTheDocument();
+  });
+
+  it('tells the human they are the secret partner when they hold the called King', async () => {
+    const partnerState = makeKoenigrufenState({
+      calledKing: 4,
+      partnerRevealed: false,
+      isHumanTurn: false,
+      players: [
+        {
+          id: 0,
+          isHuman: true,
+          cardCount: 12,
+          // The human is a defender-seat holder of the called Diamond King → they are the secret partner.
+          cards: [suit(8, 'DIAMOND', '♦', 'K'), suit(3, 'SPADE', '♠', '3')],
+          trickCount: 0,
+          cardPoints: 0,
+          score: 0,
+          isDeclarer: false,
+          isPartner: false,
+        },
+        {
+          id: 1,
+          isHuman: false,
+          cardCount: 12,
+          cards: [],
+          trickCount: 0,
+          cardPoints: 0,
+          score: 0,
+          isDeclarer: true,
+          isPartner: false,
+        },
+        {
+          id: 2,
+          isHuman: false,
+          cardCount: 12,
+          cards: [],
+          trickCount: 0,
+          cardPoints: 0,
+          score: 0,
+          isDeclarer: false,
+          isPartner: false,
+        },
+        {
+          id: 3,
+          isHuman: false,
+          cardCount: 12,
+          cards: [],
+          trickCount: 0,
+          cardPoints: 0,
+          score: 0,
+          isDeclarer: false,
+          isPartner: false,
+        },
+      ],
+    });
+    mockExec.mockResolvedValue(partnerState);
+    renderWithProviders(<KoenigrufenPage />);
+    await waitFor(() => expect(screen.getByTestId('koenigrufen-partner-clue-you')).toBeInTheDocument());
+    expect(screen.getByTestId('koenigrufen-partner-clue-you')).toHaveTextContent('あなたがその王を持っています');
+    // Still must not leak the seat index as a revealed partner.
+    expect(screen.queryByText('パートナー')).not.toBeInTheDocument();
+  });
+
+  it('switches to the revealed-partner label once partnerRevealed is true', async () => {
+    const revealedState = makeKoenigrufenState({ partnerRevealed: true, partnerIdx: 2 });
+    mockExec.mockResolvedValue(revealedState);
+    renderWithProviders(<KoenigrufenPage />);
+    await waitFor(() => expect(screen.getByTestId('koenigrufen-called-king')).toBeInTheDocument());
+    // The unknown clue is gone; the partner is now named.
+    expect(screen.queryByTestId('koenigrufen-partner-clue')).not.toBeInTheDocument();
+    expect(screen.getByText(/パートナー: /)).toBeInTheDocument();
   });
 
   it('renders the game end message', async () => {

--- a/frontend/src/pages/KoenigrufenPage.tsx
+++ b/frontend/src/pages/KoenigrufenPage.tsx
@@ -206,6 +206,21 @@ function KoenigrufenPageContent() {
 
   const contractLabel = t(CONTRACT_KEYS[state.contract] ?? 'contractNone');
 
+  // Called-King clue derivation. Uses only information the human legitimately holds:
+  // the public called suit and the human's own hand — never the hidden partnerIdx.
+  const calledSuitLabel =
+    state.calledKing >= 1
+      ? `${SUIT_GLYPHS[state.calledKing] ?? ''} ${t(SUIT_KEYS[state.calledKing] ?? '-')}`.trim()
+      : '';
+  // The human knows they are the secret partner when they hold the called King themselves
+  // (the frontend never lets the human declarer call a King they hold, so this is unambiguous).
+  const humanHoldsCalledKing =
+    state.calledKing >= 1 &&
+    !humanPlayer?.isDeclarer &&
+    !!humanPlayer?.cards.some(
+      (c) => isKing(c) && CALL_SUITS.find((s) => s.design === c.design)?.suit === state.calledKing,
+    );
+
   // King suits the human declarer already holds cannot be called.
   const heldKingSuits = new Set<number>(
     humanPlayer
@@ -306,21 +321,29 @@ function KoenigrufenPageContent() {
 
               {/* Right: info sidebar */}
               <div data-tutorial="koenigrufen-info">
-                {/* Called King (public once named) */}
+                {/* Called King (public once named) + secret-partner clues */}
                 {state.calledKing >= 1 && (
                   <div
                     className="mb-2 p-2 rounded bg-black/30 text-ds-text-muted text-sm"
                     data-testid="koenigrufen-called-king"
                   >
-                    {t('calledKing', {
-                      suit: `${SUIT_GLYPHS[state.calledKing] ?? ''} ${t(SUIT_KEYS[state.calledKing] ?? '-')}`.trim(),
-                    })}
-                    {state.partnerRevealed && state.partnerIdx >= 0 && (
+                    {t('calledKing', { suit: calledSuitLabel })}
+                    {state.partnerRevealed && state.partnerIdx >= 0 ? (
                       <span className="ml-2">
                         {t('partnerRevealed', {
                           name: playerName(state.partnerIdx, state.partnerIdx === humanIdx),
                         })}
                       </span>
+                    ) : (
+                      // Partner not yet revealed: organize the clues the human legitimately has.
+                      <div className="mt-1" data-testid="koenigrufen-partner-clue">
+                        <div>{t('partnerClue.unknown', { suit: calledSuitLabel })}</div>
+                        {humanHoldsCalledKing && (
+                          <div className="text-ds-warning font-semibold" data-testid="koenigrufen-partner-clue-you">
+                            {t('partnerClue.youArePartner')}
+                          </div>
+                        )}
+                      </div>
                     )}
                   </div>
                 )}


### PR DESCRIPTION
## 概要

ケーニッヒルーフェン (`koenigrufen`) の「呼んだ王がまだ場に出ていない」間、秘密パートナーについて人間が正当に知りうる手掛かりを整理して表示する。

これまでは呼ばれた王のスート (`呼ばれた王: ♦`) だけを出し、「その王を持つ人が味方」「まだ誰かは不明」という核心を明示していなかった。本PRでは:

- `calledKing >= 1 && !partnerRevealed` のとき、説明バッジ「{スート}の王を持つプレイヤーが宣言者の秘密のパートナー（まだ不明）」を表示。
- 人間自身がその呼ばれた王を手札に持つ場合（＝人間が秘密のパートナー）、「あなたがその王を持っています — あなたが宣言者の秘密のパートナーです」を追加表示。人間の手札という正当な情報のみから導出。
- `partnerRevealed` になったら従来のパートナー名表示に切り替え。

### 秘密の非漏洩

手掛かりは **公開情報（呼ばれた王のスート）と人間自身の手札** のみから導出。隠された `partnerIdx` は一切参照・漏洩しない。人間が宣言者の場合は「あなたがパートナー」表示を出さない (`!isDeclarer` ガード) ため、宣言者が自分の王を呼んだ特殊ケースでも矛盾しない。

## 変更ファイル

- `frontend/src/pages/KoenigrufenPage.tsx` — 手掛かり導出 + 表示
- `frontend/src/pages/KoenigrufenPage.test.tsx` — テスト追加
- `frontend/src/i18n/locales/{ja,en}/koenigrufen.json` — `partnerClue.unknown` / `partnerClue.youArePartner`

## テスト

- `does not reveal the partner before partnerRevealed is true, but shows the called-King clue` — 未判明時にバッジが出て、パートナーは特定されない
- `tells the human they are the secret partner when they hold the called King` — 人間が呼ばれた王を持つ場合の手掛かり
- `switches to the revealed-partner label once partnerRevealed is true` — 判明後の切り替え

## Gate

- [x] `bun run check`
- [x] `bun run test -- --run KoenigrufenPage` (25 passed)
- [x] `bun run build`

Closes #3528
