### PR TITLE
fix(bakersgame): replace misleading K placeholder on empty tableau columns

### DIFF
--- a/frontend/src/i18n/locales/en/bakersgame.json
+++ b/frontend/src/i18n/locales/en/bakersgame.json
@@ -34,5 +34,6 @@
     "useEmptyColumn": "An empty column is available — use it for reorganization",
     "useFreeCells": "Consider moving a card to a free cell to open up moves"
   },
-  "emptyTableauColumnAriaLabel": "Empty tableau column {{idx}} (move target)"
+  "emptyTableauColumnLabel": "Any",
+  "emptyTableauColumnAriaLabel": "Empty tableau column {{idx}} (any card can be placed)"
 }

--- a/frontend/src/i18n/locales/ja/bakersgame.json
+++ b/frontend/src/i18n/locales/ja/bakersgame.json
@@ -34,5 +34,6 @@
     "useEmptyColumn": "空の列があります — 整理に活用しましょう",
     "useFreeCells": "フリーセルにカードを移動して手を広げましょう"
   },
-  "emptyTableauColumnAriaLabel": "空のタブロー列 {{idx}}（カードの移動先）"
+  "emptyTableauColumnLabel": "任意",
+  "emptyTableauColumnAriaLabel": "空のタブロー列 {{idx}}（任意のカードを置けます）"
 }

--- a/frontend/src/pages/BakersGamePage.test.tsx
+++ b/frontend/src/pages/BakersGamePage.test.tsx
@@ -87,17 +87,24 @@ describe('BakersGamePage', () => {
     await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
   });
 
-  it('renders empty tableau columns with K placeholder', async () => {
+  it('renders empty tableau columns with a neutral any-card placeholder, not a King-only "K"', async () => {
     renderWithProviders(<BakersGamePage />);
     await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
-    const kElements = screen.getAllByText('K');
-    expect(kElements.length).toBeGreaterThanOrEqual(1);
+    // Baker's Game empty columns accept ANY card, so the placeholder must not
+    // suggest a King-only rule (the old "K" label borrowed from Klondike).
+    const anyElements = screen.getAllByText('任意');
+    expect(anyElements.length).toBeGreaterThanOrEqual(1);
+    const placeholderButtons = screen.getAllByRole('button').filter((btn) => btn.textContent === 'K');
+    expect(placeholderButtons).toHaveLength(0);
   });
 
   it('labels empty tableau columns for screen readers', async () => {
     renderWithProviders(<BakersGamePage />);
-    // playingState columns 2-7 are empty → each empty-column button is labelled.
-    await waitFor(() => expect(screen.getByLabelText('空のタブロー列 2（カードの移動先）')).toBeInTheDocument());
+    // playingState columns 2-7 are empty → each empty-column button is labelled
+    // to convey that any card may be placed.
+    await waitFor(() =>
+      expect(screen.getByLabelText('空のタブロー列 2（任意のカードを置けます）')).toBeInTheDocument(),
+    );
   });
 
   // --- Foundation ---
@@ -300,10 +307,10 @@ describe('BakersGamePage', () => {
     fireEvent.click(cardButton);
     await waitFor(() => expect(cardButton.className).toContain('ring-2'));
 
-    // Click empty tableau column (K placeholder)
+    // Click empty tableau column (any-card placeholder)
     mockExec.mockClear();
     mockExec.mockResolvedValue(playingState);
-    const kButtons = screen.getAllByRole('button').filter((btn) => btn.textContent === 'K');
+    const kButtons = screen.getAllByRole('button').filter((btn) => btn.textContent === '任意');
     if (kButtons.length > 0) {
       fireEvent.click(kButtons[0]);
       await waitFor(() => expect(mockExec).toHaveBeenCalledWith('move', expect.any(Object), expect.any(Object)));
@@ -589,7 +596,7 @@ describe('BakersGamePage', () => {
     renderWithProviders(<BakersGamePage />);
     await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
 
-    const kButtons = screen.getAllByRole('button').filter((btn) => btn.textContent === 'K');
+    const kButtons = screen.getAllByRole('button').filter((btn) => btn.textContent === '任意');
     for (const btn of kButtons) {
       expect(btn).toBeDisabled();
     }
@@ -835,8 +842,8 @@ describe('BakersGamePage', () => {
       const dataTransfer = buildDataTransfer();
       fireEvent.dragStart(sourceButton, { dataTransfer });
 
-      // Find an empty tableau column (K placeholder)
-      const kButtons = screen.getAllByRole('button').filter((btn) => btn.textContent === 'K');
+      // Find an empty tableau column (any-card placeholder)
+      const kButtons = screen.getAllByRole('button').filter((btn) => btn.textContent === '任意');
       expect(kButtons.length).toBeGreaterThan(0);
       const dropZone = kButtons[0].closest('div');
       mockExec.mockClear();

--- a/frontend/src/pages/BakersGamePage.tsx
+++ b/frontend/src/pages/BakersGamePage.tsx
@@ -365,7 +365,7 @@ function BakersGamePageContent() {
                               className={`w-full rounded border-2 border-dashed border-white/20 text-game-text-muted text-xs flex items-center justify-center ${focusRingWhite}`}
                               aria-label={t('emptyTableauColumnAriaLabel', { idx: String(colIdx) })}
                             >
-                              K
+                              {t('emptyTableauColumnLabel')}
                             </button>
                           ) : (
                             col.map((card: Card | null, cardIdx: number) => {


### PR DESCRIPTION
## 概要
Baker's Game（`bakersgame`）の空タブロー列プレースホルダが Klondike 系の流儀を誤って持ち込んだ「K」表記になっており、「King しか置けない」という誤解を与えていた。Baker's Game は FreeCell 系で、空列には任意のカードを 1 枚置ける。

`supermoveLimit`（`(1 + freeCells) * 2^emptyCols`）や domain のヒント優先度5（非King カードを空列へ移動するフォールバック, `FreeCell.go`）も、空列を任意カード置き場として扱っている。King 限定のルールは存在しない。

## 変更内容
- `BakersGamePage.tsx`: 空タブロー列の可視ラベルを `K` → `{t('emptyTableauColumnLabel')}`（`任意` / `Any`）に変更
- `emptyTableauColumnAriaLabel` を「任意のカードを置けます」/「any card can be placed」に更新（ja/en 両対応）
- ファウンデーションの `A` プレースホルダは変更なし
- `BakersGamePage.test.tsx`: 空列が King 限定を示唆する `K` を表示しないこと、`任意` を表示すること、新 aria-label を検証

フロントエンドのみ。Klondike など King ルールのゲームには一切影響しない（Baker's Game ページ限定の変更）。

## 受け入れ条件
- [x] 空タブロー列に King 限定を示唆する表示がなくなる
- [x] aria-label が任意カード可の説明になる（ja/en）
- [x] ファウンデーションの A プレースホルダは変更されない
- [x] `BakersGamePage.test.tsx` の該当アサーション更新

## テスト
- `bun run check` ✅（biome）
- `bun run test -- --run BakersGamePage` ✅（66 tests passed）
- `bun run build` ✅（tsc）

Closes #3394