### PR TITLE
feat(scarto): explain per-card why a card cannot be discarded in the scarto

### DIFF
--- a/frontend/src/i18n/locales/en/scarto.json
+++ b/frontend/src/i18n/locales/en/scarto.json
@@ -29,6 +29,12 @@
   "scartoPhase": "Scarto — bury {{total}} low cards from your hand ({{count}}/{{total}} selected). Trumps, the Excuse, and counting cards (Kings and courts) cannot be buried.",
   "scartoWaiting": "Waiting for the dealer's scarto (discard)…",
   "scartoRestricted": "This card cannot be buried (trump / Excuse / counting card).",
+  "scartoUndiscardable": {
+    "excuse": "The Excuse (Matto) cannot be buried.",
+    "bout": "Bouts (the trump 1 and the 21) cannot be buried.",
+    "trump": "Trumps cannot normally be buried (only when too few pips remain).",
+    "court": "Counting cards (Kings and courts) cannot be buried."
+  },
   "discardButton": "Bury ({{count}}/{{total}})",
   "playButton": "Play",
   "nextTrick": "Next trick",

--- a/frontend/src/i18n/locales/ja/scarto.json
+++ b/frontend/src/i18n/locales/ja/scarto.json
@@ -29,6 +29,12 @@
   "scartoPhase": "スカルト — 手札から低い{{total}}枚を選んで伏せて捨てます（{{count}}/{{total}} 枚選択中）。切り札・エクスキューズ・得点札（K・コート札）は捨てられません。",
   "scartoWaiting": "親のスカルト（捨て札）を待っています…",
   "scartoRestricted": "このカードは捨てられません（切り札・エクスキューズ・得点札）。",
+  "scartoUndiscardable": {
+    "excuse": "エクスキューズ（マット）は捨てられません。",
+    "bout": "ブー（切り札の1・21）は捨てられません。",
+    "trump": "切り札は（やむを得ない場合を除き）捨てられません。",
+    "court": "得点札（K・コート札）は捨てられません。"
+  },
   "discardButton": "捨てる（{{count}}/{{total}}）",
   "playButton": "出す",
   "nextTrick": "次のトリック",

--- a/frontend/src/pages/ScartoPage.test.tsx
+++ b/frontend/src/pages/ScartoPage.test.tsx
@@ -164,6 +164,27 @@ describe('ScartoPage', () => {
     expect(screen.getByRole('button', { name: 'Excuse ★' })).toHaveAttribute('aria-disabled', 'true');
   });
 
+  it('surfaces distinct un-buriable reasons for the King and the Excuse in the scarto phase', async () => {
+    mockExec.mockResolvedValue(scartoPhaseState);
+    renderWithProviders(<ScartoPage />);
+    await screen.findByTestId('scarto-discard-prompt');
+    // The King (counting card) exposes the court-specific reason on its tooltip.
+    const kingBtn = screen.getByRole('button', { name: 'R ♠' });
+    expect(kingBtn).toHaveAttribute('title', '得点札（K・コート札）は捨てられません。');
+    // The Excuse exposes a different, excuse-specific reason.
+    const excuseBtn = screen.getByRole('button', { name: 'Excuse ★' });
+    expect(excuseBtn).toHaveAttribute('title', 'エクスキューズ（マット）は捨てられません。');
+    // The two reasons differ.
+    expect(kingBtn.getAttribute('title')).not.toBe(excuseBtn.getAttribute('title'));
+  });
+
+  it('shows no un-buriable tooltip on a freely buriable low pip in the scarto phase', async () => {
+    mockExec.mockResolvedValue(scartoPhaseState);
+    renderWithProviders(<ScartoPage />);
+    await screen.findByTestId('scarto-discard-prompt');
+    expect(screen.getByRole('button', { name: '2 ♥' })).not.toHaveAttribute('title');
+  });
+
   it('keeps the bury button disabled until exactly 3 cards are chosen', async () => {
     mockExec.mockResolvedValue(scartoPhaseState);
     renderWithProviders(<ScartoPage />);

--- a/frontend/src/pages/ScartoPage.tsx
+++ b/frontend/src/pages/ScartoPage.tsx
@@ -36,6 +36,7 @@ import { parseScartoCommand, SCARTO_HELP } from '../utils/cli/commands/scartoCom
 import { formatScartoState } from '../utils/cli/formatters/scartoFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
 import { playerName } from '../utils/playerUtils';
+import { scartoUndiscardableReason } from '../utils/scartoDiscard';
 
 /** Scarto tutorial step definitions. */
 const SCARTO_TUTORIAL_STEPS: TutorialStep[] = [
@@ -177,6 +178,17 @@ function ScartoPageContent() {
       : undefined;
 
   const handValidIndices = canPlay ? state.playableIndices : canScarto ? discardableIndices : undefined;
+
+  // During the scarto, explain per-card why an un-buriable card cannot be
+  // discarded (trump / Excuse / bout / counting card) via the card tooltip.
+  // Purely additive — it never blocks selection; the backend still rejects
+  // illegal discards.
+  const scartoTitleFor = (idx: number): string | undefined => {
+    const card = humanPlayer?.cards[idx];
+    if (!card) return undefined;
+    const reason = scartoUndiscardableReason(card);
+    return reason ? t(`scartoUndiscardable.${reason}`) : undefined;
+  };
 
   const handleManualReset = () => {
     hideActionLog();
@@ -373,6 +385,7 @@ function ScartoPageContent() {
                 dataTutorialPrefix="scarto"
                 validIndices={handValidIndices}
                 restrictedTooltip={canScarto ? t('scartoRestricted') : t('playButton')}
+                cardTitleFor={canScarto ? scartoTitleFor : undefined}
               />
             )}
 

--- a/frontend/src/utils/scartoDiscard.test.ts
+++ b/frontend/src/utils/scartoDiscard.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import type { Card } from '../types/card';
+import { scartoUndiscardableReason } from './scartoDiscard';
+
+/** Builds a minimal Scarto card face for classification tests. */
+function card(value: number, color?: string): Card {
+  return { design: 'JOKER', value, color } as unknown as Card;
+}
+
+describe('scartoUndiscardableReason', () => {
+  it('flags the Excuse (gold) as un-buriable', () => {
+    expect(scartoUndiscardableReason(card(0, 'gold'))).toBe('excuse');
+  });
+
+  it('flags the bouts Petit (trump 1) and the 21 as un-buriable', () => {
+    expect(scartoUndiscardableReason(card(1, 'purple'))).toBe('bout');
+    expect(scartoUndiscardableReason(card(21, 'purple'))).toBe('bout');
+  });
+
+  it('flags an ordinary trump (purple, non-bout) as un-buriable', () => {
+    expect(scartoUndiscardableReason(card(7, 'purple'))).toBe('trump');
+    // A trump of value 14 is still an ordinary trump, not a court.
+    expect(scartoUndiscardableReason(card(14, 'purple'))).toBe('trump');
+  });
+
+  it('flags a counting card (court/King, value ≥ 11, non-tarot) as un-buriable', () => {
+    expect(scartoUndiscardableReason(card(11, 'red'))).toBe('court');
+    expect(scartoUndiscardableReason(card(14, 'black'))).toBe('court');
+  });
+
+  it('returns null for a freely buriable low pip', () => {
+    expect(scartoUndiscardableReason(card(2, 'red'))).toBeNull();
+    expect(scartoUndiscardableReason(card(10, 'black'))).toBeNull();
+  });
+});

--- a/frontend/src/utils/scartoDiscard.ts
+++ b/frontend/src/utils/scartoDiscard.ts
@@ -1,0 +1,34 @@
+import type { Card } from '../types/card';
+
+/**
+ * Reason a Scarto card may not be buried in the dealer's scarto (discard).
+ *
+ * - `excuse` — the Excuse (Matto); never buriable.
+ * - `bout` — a bout trump (Petit = trump 1, or the 21); never buriable.
+ * - `trump` — an ordinary trump (atout); only buriable when unavoidable.
+ * - `court` — a counting card (Valet/Cavalier/Dame/Roi, value ≥ 11); never buriable.
+ */
+export type ScartoUndiscardableReason = 'excuse' | 'bout' | 'trump' | 'court';
+
+/** Minimum suit-card value that counts as a court (Valet 11 … Roi 14). Mirrors domain `ScartoCourtMin`. */
+const SCARTO_COURT_MIN = 11;
+
+/**
+ * Classifies why a card cannot (normally) be buried in the Scarto discard, or
+ * returns `null` for a freely buriable pip.
+ *
+ * Mirrors the backend rule (domain `validateScarto` / `scartoDiscardable`): the
+ * Excuse and counting cards (Kings and courts, value ≥ 11) are never buriable,
+ * the bouts (Petit = trump 1 and the 21) are never buriable, and ordinary trumps
+ * may only be buried when the player holds fewer than three freely buriable pips.
+ * Detection is color-based on the serialized tarot face — the Excuse is gold and
+ * trumps (atouts) are purple, while a court is a non-tarot suit card of value ≥ 11.
+ */
+export function scartoUndiscardableReason(card: Card): ScartoUndiscardableReason | null {
+  if (card.color === 'gold') return 'excuse';
+  if (card.color === 'purple') {
+    return card.value === 1 || card.value === 21 ? 'bout' : 'trump';
+  }
+  if (card.value >= SCARTO_COURT_MIN) return 'court';
+  return null;
+}


### PR DESCRIPTION
## Summary

During the Scarto (discard) phase, every un-buriable card showed the same uniform `scartoRestricted` tooltip, so it was unclear why a trump vs the Excuse vs a counting card cannot be buried. This adds a per-card reason tooltip.

- New pure classifier `frontend/src/utils/scartoDiscard.ts` (`scartoUndiscardableReason`) mirroring the domain rule in `internal/domain/Scarto.go` (`validateScarto` / `scartoDiscardable`):
  - `excuse` — the Excuse (gold), never buriable
  - `bout` — the bouts (trump 1 / 21), never buriable
  - `trump` — an ordinary trump (purple), only when unavoidable
  - `court` — a counting card (Kings/courts, value ≥ 11 = `ScartoCourtMin`), never buriable
- `ScartoPage.tsx` passes the reason through the existing shared `cardTitleFor` prop (added in #4155) only during the scarto phase.
- Additive and non-blocking: selection restriction and the `SCARTO_DISCARD_COUNT` completion judgment are unchanged; the backend still rejects illegal discards.
- i18n keys `scartoUndiscardable.{excuse,bout,trump,court}` added to ja + en.

Frontend-only; `scarto` is on the `solo` worker (WASM-neutral). No Go changes.

## Test plan

- [x] `bun run check` (biome + design-tokens) — pre-existing warnings only, none in changed files
- [x] `bun run test -- --run ScartoPage scartoDiscard` — 25 passed
- [x] `bun run build` (tsc) — clean
- [x] King and Excuse surface distinct reasons; a freely-discardable low pip shows no tooltip

Closes #3531