### PR TITLE
feat(chinchon): expose knock threshold in settings panel

### DIFF
--- a/frontend/src/hooks/useChinchonGame.ts
+++ b/frontend/src/hooks/useChinchonGame.ts
@@ -23,6 +23,9 @@ export const CPU_DIFFICULTY_OPTIONS = [
 /** Available player count options for Chinchón. */
 export const PLAYER_COUNT_OPTIONS = [2, 3, 4] as const;
 
+/** Available knock (deadwood) threshold options for Chinchón. */
+export const KNOCK_THRESHOLD_OPTIONS = [0, 3, 5, 10] as const;
+
 /** Available elimination limit options for Chinchón. */
 export const ELIMINATION_LIMIT_OPTIONS = [50, 100, 150, 200] as const;
 

--- a/frontend/src/i18n/locales/en/chinchon.json
+++ b/frontend/src/i18n/locales/en/chinchon.json
@@ -11,6 +11,7 @@
     "cpuDifficulty": "CPU Difficulty",
     "playerCount": "Players",
     "eliminationLimit": "Elimination Limit",
+    "knockThreshold": "Knock Limit",
     "easy": "Easy",
     "normal": "Normal",
     "hard": "Hard"

--- a/frontend/src/i18n/locales/ja/chinchon.json
+++ b/frontend/src/i18n/locales/ja/chinchon.json
@@ -11,6 +11,7 @@
     "cpuDifficulty": "CPU難易度",
     "playerCount": "プレイヤー人数",
     "eliminationLimit": "脱落点数",
+    "knockThreshold": "ノック上限",
     "easy": "Easy",
     "normal": "Normal",
     "hard": "Hard"

--- a/frontend/src/pages/ChinchonPage.test.tsx
+++ b/frontend/src/pages/ChinchonPage.test.tsx
@@ -379,6 +379,23 @@ describe('ChinchonPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined, { ...RESET_CONFIG, playerCount: 4 }));
   });
 
+  it('settings panel changes knockThreshold sent on reset', async () => {
+    renderWithProviders(<ChinchonPage />);
+    await waitFor(() => expect(screen.getByText('スコア')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText('設定'));
+    fireEvent.change(screen.getByTestId('chinchon-knock-threshold-select'), { target: { value: '10' } });
+
+    mockExec.mockClear();
+    mockExec.mockResolvedValue(drawPhaseState);
+    fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
+
+    await waitFor(() =>
+      expect(mockExec).toHaveBeenCalledWith('reset', undefined, { ...RESET_CONFIG, knockThreshold: 10 }),
+    );
+  });
+
   it('does not show draw buttons when not human turn', async () => {
     mockExec.mockResolvedValue(cpuTurnState);
     renderWithProviders(<ChinchonPage />);

--- a/frontend/src/pages/ChinchonPage.tsx
+++ b/frontend/src/pages/ChinchonPage.tsx
@@ -17,6 +17,7 @@ import { useCardKeyboardNav } from '../hooks/useCardKeyboardNav';
 import {
   CPU_DIFFICULTY_OPTIONS,
   ELIMINATION_LIMIT_OPTIONS,
+  KNOCK_THRESHOLD_OPTIONS,
   PLAYER_COUNT_OPTIONS,
   useChinchonGame,
 } from '../hooks/useChinchonGame';
@@ -286,6 +287,15 @@ function ChinchonPageContent() {
                     value: chinchonConfig.eliminationLimit,
                     options: ELIMINATION_LIMIT_OPTIONS.map((v) => ({ value: v, label: String(v) })),
                     onSelect: (v) => handleConfigChange('eliminationLimit', v),
+                  },
+                  {
+                    type: 'select',
+                    id: 'knockThreshold',
+                    label: t('settings.knockThreshold'),
+                    value: chinchonConfig.knockThreshold,
+                    options: KNOCK_THRESHOLD_OPTIONS.map((v) => ({ value: v, label: String(v) })),
+                    onSelect: (v) => handleConfigChange('knockThreshold', v),
+                    testId: 'chinchon-knock-threshold-select',
                   },
                 ],
               },


### PR DESCRIPTION
Closes #3476

## What
Adds a **knock threshold** (deadwood limit) select to the Chinchón in-game SettingsPanel so players can change it from the GUI. Previously only cpuDifficulty / playerCount / eliminationLimit were exposed, even though `knockThreshold` was already sent to the server on reset and drives the `deadwoodLabel` display.

## How
This is **frontend-only** — no backend/WASM changes. `knockThreshold` was already wired end-to-end: `handleManualReset` sends `chinchonConfig.knockThreshold`, `useGameConfig` holds it, and `state.config.knockThreshold` feeds the deadwood indicator. This PR just adds the missing UI control.

- `useChinchonGame.ts`: export `KNOCK_THRESHOLD_OPTIONS` (`[0, 3, 5, 10]`)
- `ChinchonPage.tsx`: add a `select` item to the SettingsPanel group (appended after `eliminationLimit`, keeping existing select ordering stable), reusing `handleConfigChange('knockThreshold', v)`
- i18n: add `settings.knockThreshold` label to ja (`ノック上限`) + en (`Knock Limit`)
- Test: `settings panel changes knockThreshold sent on reset` verifies the select updates the value passed to the `reset` API call

## Acceptance criteria
- [x] ノック閾値を設定パネルから選択できる
- [x] reset 後の deadwoodLabel に新閾値が反映される (threshold flows via existing `state.config.knockThreshold`)
- [x] フックテストで config 送信内容を検証 (page test asserts reset payload)
- [x] ja/en に設定ラベルキーを追加

## Gates
- `bun run check` ✅
- `bun run test -- --run ChinchonPage` ✅ (32 passed)
- `bun run build` ✅