### PR TITLE
feat(cego): guide the Cego exchange with a step-by-step stepper

### DIFF
--- a/frontend/src/i18n/locales/en/cego.json
+++ b/frontend/src/i18n/locales/en/cego.json
@@ -42,6 +42,13 @@
   "contractHandspielDesc": "Handspiel: skip the blind and play your dealt hand as is. Safer, but the upside is smaller.",
   "exchangePhase": "Cego exchange — pick the 1 card to keep ({{count}}/1 selected). The other 10 are laid down and you take the blind.",
   "exchangeKeep": "Choose the single card to keep.",
+  "exchangeGuide": {
+    "title": "Cego exchange steps (step {{step}}/{{total}})",
+    "step1": "Pick the {{keep}} card to keep from your hand ({{remaining}} more to select).",
+    "step2": "Lay down the other {{layDown}} cards face-down and take the {{count}}-card blind (Cego).",
+    "remaining": "Select {{remaining}} more card to exchange.",
+    "ready": "Ready — press Keep to confirm the exchange."
+  },
   "exchangeButton": "Keep ({{count}}/1)",
   "playButton": "Play",
   "nextTrick": "Next Trick",

--- a/frontend/src/i18n/locales/ja/cego.json
+++ b/frontend/src/i18n/locales/ja/cego.json
@@ -42,6 +42,13 @@
   "contractHandspielDesc": "ハントシュピール: 盲札を使わず、配られた手札のまま勝負します。堅実ですが得点の伸びは控えめです。",
   "exchangePhase": "場札交換 — 手元に残す1枚を選びます（{{count}}/1 枚選択中）。残り10枚を伏せて場札を取ります。",
   "exchangeKeep": "手元に残す1枚を選んでください。",
+  "exchangeGuide": {
+    "title": "場札交換の手順（ステップ {{step}}/{{total}}）",
+    "step1": "手札から残す{{keep}}枚を選ぶ（残り {{remaining}} 枚選択）。",
+    "step2": "残り{{layDown}}枚を伏せて、伏せ札（チェゴ）{{count}}枚を取る。",
+    "remaining": "あと {{remaining}} 枚選ぶと交換できます。",
+    "ready": "準備完了 — 「残す」を押すと場札交換を確定します。"
+  },
   "exchangeButton": "残す（{{count}}/1）",
   "playButton": "出す",
   "nextTrick": "次のトリック",

--- a/frontend/src/pages/CegoPage.test.tsx
+++ b/frontend/src/pages/CegoPage.test.tsx
@@ -252,6 +252,35 @@ describe('CegoPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('discard', { cardIndices: [1] }));
   });
 
+  it('shows the exchange guide with step 1 active while no keep card is selected', async () => {
+    mockExec.mockResolvedValue(exchangePhaseState);
+    renderWithProviders(<CegoPage />);
+    await screen.findByRole('button', { name: '2 ♥' });
+    const guide = screen.getByTestId('cego-exchange-guide');
+    expect(guide).toBeInTheDocument();
+    // Blind count (10) and lay-down count (10) are surfaced in the steps.
+    expect(guide).toHaveTextContent(/10/);
+    expect(screen.getByTestId('cego-exchange-step-1')).toHaveAttribute('aria-current', 'step');
+    expect(screen.getByTestId('cego-exchange-step-2')).not.toHaveAttribute('aria-current');
+    expect(screen.getByTestId('cego-exchange-status')).toHaveTextContent('あと 1 枚選ぶと交換できます。');
+  });
+
+  it('advances the exchange guide to step 2 once the keep card is selected', async () => {
+    mockExec.mockResolvedValue(exchangePhaseState);
+    renderWithProviders(<CegoPage />);
+    const card = await screen.findByRole('button', { name: '3 ♥' });
+    fireEvent.click(card);
+    expect(screen.getByTestId('cego-exchange-step-2')).toHaveAttribute('aria-current', 'step');
+    expect(screen.getByTestId('cego-exchange-step-1')).not.toHaveAttribute('aria-current');
+    expect(screen.getByTestId('cego-exchange-status')).toHaveTextContent('準備完了');
+  });
+
+  it('does not show the exchange guide outside the exchange phase', async () => {
+    renderWithProviders(<CegoPage />);
+    await screen.findByRole('button', { name: 'K ♥' });
+    expect(screen.queryByTestId('cego-exchange-guide')).not.toBeInTheDocument();
+  });
+
   it('selecting a card then playing dispatches play', async () => {
     renderWithProviders(<CegoPage />);
     const card = await screen.findByRole('button', { name: 'K ♥' });

--- a/frontend/src/pages/CegoPage.tsx
+++ b/frontend/src/pages/CegoPage.tsx
@@ -27,6 +27,7 @@ import { gameTheme } from '../styles/gameTheme';
 import type { CegoResponse } from '../types/card';
 import { CegoPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { cegoExchangeGuide } from '../utils/cegoExchangeGuide';
 import { CEGO_HELP, parseCegoCommand } from '../utils/cli/commands/cegoCommands';
 import { formatCegoState } from '../utils/cli/formatters/cegoFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
@@ -156,6 +157,10 @@ function CegoPageContent() {
   // During play the hand is restricted to the legal indices; during the Cego
   // exchange any single card may be kept, so no restriction is applied.
   const handValidIndices = canPlay ? state.playableIndices : undefined;
+
+  // Stepper guidance for the Cego exchange: pick 1 card to keep, then take the
+  // blind. Derived purely from the current selection count — no backend state.
+  const exchangeGuide = cegoExchangeGuide(selectedCardIndices.length, CEGO_KEEP_COUNT, humanPlayer?.cardCount ?? 0);
 
   const handleManualReset = () => {
     hideActionLog();
@@ -349,6 +354,37 @@ function CegoPageContent() {
             {canExchange && (
               <div className="mb-1 text-center text-sm text-ds-accent font-semibold" data-testid="cego-exchange-prompt">
                 {t('exchangePhase', { count: selectedCardIndices.length })}
+              </div>
+            )}
+            {canExchange && (
+              <div
+                className="mb-2 mx-auto max-w-xl p-2 rounded bg-black/30 text-ds-text-muted text-sm"
+                data-testid="cego-exchange-guide"
+              >
+                <div className="mb-1 text-ds-text-primary font-semibold">
+                  {t('exchangeGuide.title', { step: exchangeGuide.currentStep, total: exchangeGuide.totalSteps })}
+                </div>
+                <ol className="space-y-0.5">
+                  <li
+                    className={exchangeGuide.currentStep === 1 ? 'text-ds-accent font-semibold' : ''}
+                    data-testid="cego-exchange-step-1"
+                    aria-current={exchangeGuide.currentStep === 1 ? 'step' : undefined}
+                  >
+                    {t('exchangeGuide.step1', { keep: CEGO_KEEP_COUNT, remaining: exchangeGuide.remaining })}
+                  </li>
+                  <li
+                    className={exchangeGuide.currentStep === 2 ? 'text-ds-accent font-semibold' : ''}
+                    data-testid="cego-exchange-step-2"
+                    aria-current={exchangeGuide.currentStep === 2 ? 'step' : undefined}
+                  >
+                    {t('exchangeGuide.step2', { layDown: exchangeGuide.layDownCount, count: state.blindCount })}
+                  </li>
+                </ol>
+                <div className="mt-1" data-testid="cego-exchange-status">
+                  {exchangeGuide.ready
+                    ? t('exchangeGuide.ready')
+                    : t('exchangeGuide.remaining', { remaining: exchangeGuide.remaining })}
+                </div>
               </div>
             )}
             {humanPlayer && (

--- a/frontend/src/utils/cegoExchangeGuide.test.ts
+++ b/frontend/src/utils/cegoExchangeGuide.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { cegoExchangeGuide } from './cegoExchangeGuide';
+
+describe('cegoExchangeGuide', () => {
+  it('is on step 1 with the full keep count remaining when nothing is selected', () => {
+    const guide = cegoExchangeGuide(0, 1, 11);
+    expect(guide.currentStep).toBe(1);
+    expect(guide.totalSteps).toBe(2);
+    expect(guide.remaining).toBe(1);
+    expect(guide.ready).toBe(false);
+    expect(guide.layDownCount).toBe(10);
+  });
+
+  it('advances to step 2 once the required keep card is selected', () => {
+    const guide = cegoExchangeGuide(1, 1, 11);
+    expect(guide.currentStep).toBe(2);
+    expect(guide.remaining).toBe(0);
+    expect(guide.ready).toBe(true);
+    expect(guide.layDownCount).toBe(10);
+  });
+
+  it('clamps remaining at zero when more than the keep count is selected', () => {
+    const guide = cegoExchangeGuide(3, 1, 11);
+    expect(guide.remaining).toBe(0);
+    expect(guide.ready).toBe(true);
+    expect(guide.currentStep).toBe(2);
+  });
+
+  it('supports keep counts greater than one', () => {
+    const guide = cegoExchangeGuide(1, 2, 11);
+    expect(guide.remaining).toBe(1);
+    expect(guide.ready).toBe(false);
+    expect(guide.currentStep).toBe(1);
+    expect(guide.layDownCount).toBe(9);
+  });
+
+  it('clamps layDownCount at zero when the hand is smaller than the keep count', () => {
+    const guide = cegoExchangeGuide(0, 1, 0);
+    expect(guide.layDownCount).toBe(0);
+  });
+});

--- a/frontend/src/utils/cegoExchangeGuide.ts
+++ b/frontend/src/utils/cegoExchangeGuide.ts
@@ -1,0 +1,47 @@
+/**
+ * Cego exchange guidance.
+ *
+ * During the Cego contract the declarer keeps exactly one card, lays the rest of
+ * the hand face-down onto their point pile, and takes the hidden blind (Cego).
+ * This pure helper derives the current step of that multi-step procedure from the
+ * number of currently selected cards, so the page can render a stepper without
+ * introducing any new backend state.
+ */
+
+/** A step in the Cego exchange procedure, derived purely from selection counts. */
+export interface CegoExchangeGuide {
+  /** 1-based index of the step the player is on (1 = pick the keep card, 2 = take the blind). */
+  currentStep: number;
+  /** Total number of steps in the exchange procedure. */
+  totalSteps: number;
+  /** How many more cards still need to be selected before the exchange can be confirmed. */
+  remaining: number;
+  /** Whether the required number of keep-cards has been selected. */
+  ready: boolean;
+  /** How many cards are laid face-down (hand size minus the kept cards). */
+  layDownCount: number;
+}
+
+/** Total number of steps surfaced in the Cego exchange stepper. */
+const CEGO_EXCHANGE_TOTAL_STEPS = 2;
+
+/**
+ * Computes the current step of the Cego exchange from the live selection count.
+ *
+ * @param selectedCount - Number of cards the player has currently selected.
+ * @param keepCount - Number of cards that must be kept (the Cego keep count, normally 1).
+ * @param handCount - Number of cards in the declarer's hand before the exchange.
+ * @returns The derived {@link CegoExchangeGuide}.
+ */
+export function cegoExchangeGuide(selectedCount: number, keepCount: number, handCount: number): CegoExchangeGuide {
+  const remaining = Math.max(0, keepCount - selectedCount);
+  const ready = remaining === 0;
+  const layDownCount = Math.max(0, handCount - keepCount);
+  return {
+    currentStep: ready ? 2 : 1,
+    totalSteps: CEGO_EXCHANGE_TOTAL_STEPS,
+    remaining,
+    ready,
+    layDownCount,
+  };
+}


### PR DESCRIPTION
## Summary

The Cego exchange (`EXCHANGE` phase) previously only surfaced a selection-count prompt, leaving the Cego-specific "keep 1 card, take the hidden blind" procedure unexplained for first-time players. This PR adds an **additive instructional stepper** that walks the declarer through the exchange, driven purely by the live selection count — no change to the selection mechanic, completion judgment, or any backend state.

### What the guide surfaces

Confirmed against `internal/domain/Cego.go` (read-only): hand = 11 cards, keep 1 (`CegoKeepCount`), lay down 10, take the 10-card blind (`blindCount`).

- **Step 1** — Pick the 1 card to keep from your hand (shows how many more to select).
- **Step 2** — Lay down the other 10 cards face-down and take the {blindCount}-card blind (Cego).

The active step is highlighted (`aria-current="step"`) and advances from step 1 to step 2 the moment the required keep card is selected. A status line shows either "N more to select" or "Ready — press Keep".

## Changes

- New pure helper `frontend/src/utils/cegoExchangeGuide.ts` — derives `currentStep` / `remaining` / `ready` / `layDownCount` from selection count vs the keep count.
- `CegoPage.tsx` — renders the stepper panel (`data-testid="cego-exchange-guide"`) during the exchange phase only; design-system tokens only.
- ja/en i18n keys added at parity (`exchangeGuide.*`).

## Tests

- `cegoExchangeGuide.test.ts` — 5 cases (step transitions, remaining clamp, keep>1, lay-down clamp).
- `CegoPage.test.tsx` — guide shows step 1 active with nothing selected; advances to step 2 after selecting; not shown outside the exchange phase.

## Gates (all pass)

- [x] `bun run check`
- [x] `bun run test -- --run CegoPage cegoExchangeGuide` (31 passed)
- [x] `bun run build` (tsc)
- [x] ja/en i18n key parity

Frontend-only; no Go touched. Cego is on the `solo` worker (WASM-neutral).

Closes #3534