### PR TITLE
feat(easthaven): auto-move a top card to its foundation on double-click

### DIFF
--- a/frontend/src/pages/EasthavenPage.test.tsx
+++ b/frontend/src/pages/EasthavenPage.test.tsx
@@ -262,6 +262,47 @@ describe('EasthavenPage', () => {
     );
   });
 
+  it('double-clicking a foundation-playable top card auto-moves it to the foundation', async () => {
+    const aceState: EasthavenResponse = {
+      ...playingState,
+      tableau: [
+        [
+          { card: null, faceUp: false },
+          { card: card('SPADE', 13), faceUp: true },
+        ],
+        [{ card: card('HEART', 8), faceUp: true }],
+        [{ card: card('CLOVER', 5), faceUp: true }],
+        [{ card: card('DIAMOND', 10), faceUp: true }],
+        [{ card: card('SPADE', 1), faceUp: true }], // ♠A → playable onto the empty ♠ foundation
+        [{ card: card('HEART', 7), faceUp: true }],
+        [{ card: card('CLOVER', 2), faceUp: true }],
+      ],
+    };
+    mockExec.mockResolvedValue(aceState);
+    renderWithProviders(<EasthavenPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    mockExec.mockClear();
+    mockExec.mockResolvedValue(aceState);
+    fireEvent.doubleClick(screen.getByRole('button', { name: '♠ A' }));
+    await waitFor(() =>
+      expect(mockExec).toHaveBeenCalledWith(
+        'move',
+        expect.objectContaining({ zone: 'tableau', col: 4 }),
+        expect.objectContaining({ zone: 'foundation', col: 0 }),
+      ),
+    );
+  });
+
+  it('double-clicking a non-foundation-playable top card does nothing', async () => {
+    mockExec.mockResolvedValue(playingState);
+    renderWithProviders(<EasthavenPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    mockExec.mockClear();
+    // ♥8 has no legal foundation target (the empty ♥ pile needs an Ace first).
+    fireEvent.doubleClick(screen.getByRole('button', { name: '♥ 8' }));
+    expect(mockExec).not.toHaveBeenCalledWith('move', expect.anything(), expect.anything());
+  });
+
   it('renders a full from→to sentence for a to-foundation hint', async () => {
     // tableau[0][1] is ♠ K, so the sentence names the source column, card, and dest.
     mockExec.mockResolvedValue({ ...playingState, hint: { fromCol: 0, cardIndex: 1, toZone: 'foundation', toCol: 0 } });

--- a/frontend/src/pages/EasthavenPage.tsx
+++ b/frontend/src/pages/EasthavenPage.tsx
@@ -30,13 +30,14 @@ import i18n from '../i18n';
 import { useSound } from '../providers/SoundProvider';
 import { btnDanger, btnOutline, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
-import type { EasthavenResponse } from '../types/card';
+import type { Card, EasthavenResponse } from '../types/card';
 import { EasthavenPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import { easthavenHelp, parseEasthavenCommand } from '../utils/cli/commands/easthavenCommands';
 import { formatEasthavenState } from '../utils/cli/formatters/easthavenFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { easthavenFoundationTarget } from '../utils/easthavenFoundationTarget';
 import { isTableauAllFaceUp } from '../utils/solitaireUtils';
 
 const FOUNDATION_SUITS = ['♠', '♣', '♥', '♦'] as const;
@@ -249,6 +250,21 @@ function EasthavenPageContent() {
       playSound('cardPlace');
     },
     [apiExec, selectedSource, playSound],
+  );
+
+  // Double-click / double-tap shortcut: auto-send a column's exposed top card
+  // to its foundation when a legal target exists; otherwise do nothing (no
+  // error, selection untouched). Mirrors the FreeCell foundation shortcut.
+  const handleFoundationShortcut = useCallback(
+    (col: number, card: Card) => {
+      if (!state) return;
+      const target = easthavenFoundationTarget(card, state.foundation);
+      if (!target) return;
+      void apiExec('move', { zone: 'tableau', col }, target);
+      setSelectedSource(null);
+      playSound('cardPlace');
+    },
+    [state, apiExec, playSound],
   );
 
   const isPlayingForKbd = state?.phase === EasthavenPhase.PLAYING;
@@ -478,7 +494,12 @@ function EasthavenPageContent() {
                                       } ${hintTo ? 'ring-2 ring-ds-success motion-safe:animate-pulse' : ''} ${
                                         inHoverBlock && !isSelected ? 'ring-2 ring-ds-accent/70' : ''
                                       }`}
-                                      onClick={() => {
+                                      onClick={(e) => {
+                                        // The second click of a double-click also
+                                        // fires onClick (detail === 2); ignore it so
+                                        // onDoubleClick owns the foundation shortcut
+                                        // without issuing a stray select/target move.
+                                        if (e.detail >= 2) return;
                                         if (selectedSource) {
                                           if (isSelected) {
                                             setSelectedSource(null);
@@ -491,8 +512,16 @@ function EasthavenPageContent() {
                                           handleSelectSource('tableau', colIdx, cardIdx);
                                         }
                                       }}
+                                      onDoubleClick={
+                                        // Only a column's exposed top card can move
+                                        // straight to a foundation.
+                                        isLast && tcard.card
+                                          ? () => handleFoundationShortcut(colIdx, tcard.card as Card)
+                                          : undefined
+                                      }
                                       disabled={!isPlaying}
                                       aria-label={tcard.card ? cardAlt(tcard.card) : ''}
+                                      data-testid={isLast ? `eh-tableau-top-${colIdx.toString()}` : undefined}
                                     >
                                       {tcard.card && <AnimatedCard card={tcard.card} width={eh.cw} />}
                                     </button>

--- a/frontend/src/utils/easthavenFoundationTarget.test.ts
+++ b/frontend/src/utils/easthavenFoundationTarget.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import type { Card, CardDesign } from '../types/card';
+import { easthavenFoundationTarget } from './easthavenFoundationTarget';
+
+const card = (design: CardDesign, value: number): Card => ({ design, value });
+const emptyFoundation = (): Card[][] => [[], [], [], []];
+
+describe('easthavenFoundationTarget', () => {
+  it('sends an Ace to its empty foundation pile', () => {
+    expect(easthavenFoundationTarget(card('SPADE', 1), emptyFoundation())).toEqual({ zone: 'foundation', col: 0 });
+    expect(easthavenFoundationTarget(card('CLOVER', 1), emptyFoundation())).toEqual({ zone: 'foundation', col: 1 });
+    expect(easthavenFoundationTarget(card('HEART', 1), emptyFoundation())).toEqual({ zone: 'foundation', col: 2 });
+    expect(easthavenFoundationTarget(card('DIAMOND', 1), emptyFoundation())).toEqual({ zone: 'foundation', col: 3 });
+  });
+
+  it('rejects a non-Ace on an empty pile', () => {
+    expect(easthavenFoundationTarget(card('SPADE', 2), emptyFoundation())).toBeNull();
+    expect(easthavenFoundationTarget(card('HEART', 13), emptyFoundation())).toBeNull();
+  });
+
+  it('sends the next rank up onto a matching-suit pile', () => {
+    const foundation: Card[][] = [[card('SPADE', 1)], [], [card('HEART', 1), card('HEART', 2)], []];
+    expect(easthavenFoundationTarget(card('SPADE', 2), foundation)).toEqual({ zone: 'foundation', col: 0 });
+    expect(easthavenFoundationTarget(card('HEART', 3), foundation)).toEqual({ zone: 'foundation', col: 2 });
+  });
+
+  it('rejects a card whose rank is not exactly one above the pile top', () => {
+    const foundation: Card[][] = [[card('SPADE', 1)], [], [], []];
+    expect(easthavenFoundationTarget(card('SPADE', 3), foundation)).toBeNull();
+    expect(easthavenFoundationTarget(card('SPADE', 1), foundation)).toBeNull();
+  });
+
+  it('rejects a card when its own suit pile is not ready even if another suit would accept it', () => {
+    // Spade pile empty (needs an Ace), so the 2♠ has no legal target regardless
+    // of the heart pile's contents — the target pile is chosen by suit.
+    const foundation: Card[][] = [[], [], [card('HEART', 1)], []];
+    expect(easthavenFoundationTarget(card('SPADE', 2), foundation)).toBeNull();
+  });
+
+  it('returns null for a card with an unknown design', () => {
+    expect(easthavenFoundationTarget({ design: 'JOKER', value: 1 }, emptyFoundation())).toBeNull();
+  });
+});

--- a/frontend/src/utils/easthavenFoundationTarget.ts
+++ b/frontend/src/utils/easthavenFoundationTarget.ts
@@ -1,0 +1,35 @@
+import type { EasthavenMoveZone } from '../api/gameApi';
+import type { Card } from '../types/card';
+
+/**
+ * Maps a card design to its 0-based foundation index, matching the foundation
+ * layout (`♠`=0, `♣`=1, `♥`=2, `♦`=3). Mirrors the backend's
+ * `card.GetDesign() - 1` in `Easthaven.MoveTableauToFoundation`.
+ */
+const DESIGN_TO_FOUNDATION_INDEX: Record<string, number> = {
+  SPADE: 0,
+  CLOVER: 1,
+  HEART: 2,
+  DIAMOND: 3,
+};
+
+/**
+ * Computes the legal foundation move target for `card` given the current
+ * `foundation` piles, or `null` when no legal foundation move exists.
+ *
+ * Mirrors the domain's `canPlaceOnFoundation`: an empty pile accepts only an
+ * Ace (`value === 1`); otherwise the card's suit must match the pile and its
+ * rank must be exactly one higher than the pile's top card. The pile is
+ * selected by suit, so a matching pile is always the same suit.
+ *
+ * @param card - The exposed tableau top card being double-clicked.
+ * @param foundation - The four foundation piles (bottom card first).
+ * @returns A `{ zone: 'foundation', col }` move target, or `null` if illegal.
+ */
+export function easthavenFoundationTarget(card: Card, foundation: Card[][]): EasthavenMoveZone | null {
+  const fIdx = DESIGN_TO_FOUNDATION_INDEX[card.design];
+  if (fIdx === undefined || fIdx >= foundation.length) return null;
+  const pile = foundation[fIdx];
+  const placeable = pile.length === 0 ? card.value === 1 : card.value === pile[pile.length - 1].value + 1;
+  return placeable ? { zone: 'foundation', col: fIdx } : null;
+}


### PR DESCRIPTION
## Summary

Adds the standard solitaire convenience move to East Haven: double-clicking (or double-tapping) a tableau column's exposed **top** card auto-sends it to the matching foundation when a legal target exists. Previously this required either the two-step select-source → select-foundation flow or drag-and-drop.

Frontend-only; no Go changes. The backend `MoveTableauToFoundation(col)` already resolves the correct foundation pile and validates placement, so the click just issues the existing `move` action. To avoid round-tripping an error for a non-playable card, the double-click is gated client-side by a new pure helper that reproduces the domain `canPlaceOnFoundation` rule.

Mirrors the existing FreeCell foundation shortcut (`freeCellFoundationTarget` + `handleFoundationShortcut`).

## Changes
- `frontend/src/utils/easthavenFoundationTarget.ts` (+ test) — pure helper: given a card + foundation piles, returns the legal `{ zone: 'foundation', col }` target or `null` (empty pile accepts only an Ace; otherwise same suit and rank exactly one higher).
- `frontend/src/pages/EasthavenPage.tsx` — `handleFoundationShortcut` + `onDoubleClick` on each column's last card; single-click selection preserved via an `e.detail >= 2` guard so the second click of a double-click doesn't fire a stray select/target. Adds a `data-testid` on the top card.
- `frontend/src/pages/EasthavenPage.test.tsx` — double-click a foundation-playable top card issues the move to the correct foundation; a non-playable top card does nothing.

## Acceptance criteria
- [x] Double-clicking a column top card attempts a foundation move
- [x] Non-playable cards do nothing (no error, selection untouched)
- [x] Single-click selection unaffected
- [x] Double-click tests added to `EasthavenPage.test.tsx`

## Gates
- [x] `bun run check` (biome + design-tokens)
- [x] `bun run test -- --run easthavenFoundationTarget EasthavenPage` (34 passed)
- [x] `bun run build` (tsc)

Closes #3389