### PR TITLE
feat(bakersgame): double-click a card to auto-move to foundation or free cell

### DIFF
--- a/frontend/src/hooks/useBakersGameGame.ts
+++ b/frontend/src/hooks/useBakersGameGame.ts
@@ -51,6 +51,19 @@ export function useBakersGameGame() {
     [selectedSource, base],
   );
 
+  // Double-click / double-tap shortcut: dispatch a pre-computed auto-move (a
+  // foundation move, or an empty-free-cell fallback) for the given source
+  // without the two-step target click, and clear any pending selection so it
+  // stays in lockstep.
+  const handleAutoMove = useCallback(
+    (source: FreeCellMoveZone, target: FreeCellMoveZone) => {
+      base.setHint(null);
+      void base.apiCall('move', source, target);
+      setSelectedSource(null);
+    },
+    [base],
+  );
+
   return {
     state: base.state,
     loading: base.loading,
@@ -67,6 +80,7 @@ export function useBakersGameGame() {
     handleUndoEscape,
     handleSelectSource,
     handleSelectTarget,
+    handleAutoMove,
     isAutoCompleting: base.isAutoCompleting,
     retry: base.retry,
   };

--- a/frontend/src/pages/BakersGamePage.test.tsx
+++ b/frontend/src/pages/BakersGamePage.test.tsx
@@ -860,4 +860,98 @@ describe('BakersGamePage', () => {
       );
     });
   });
+
+  // --- Double-click / double-tap auto-move ---
+
+  describe('double-click auto-move', () => {
+    it('double-clicking a tableau top card that can reach a foundation issues the foundation move', async () => {
+      mockExec.mockResolvedValue({
+        ...playingState,
+        tableau: [[card('SPADE', 2)], [], [], [], [], [], [], []],
+        foundation: [[card('SPADE', 1)], [], [], []],
+      });
+      renderWithProviders(<BakersGamePage />);
+      const cardButton = (await screen.findByAltText('♠ 2')).closest('button') as HTMLButtonElement;
+
+      mockExec.mockClear();
+      mockExec.mockResolvedValue(playingState);
+      fireEvent.doubleClick(cardButton);
+      await waitFor(() =>
+        expect(mockExec).toHaveBeenCalledWith('move', expect.objectContaining({ zone: 'tableau', col: 0 }), {
+          zone: 'foundation',
+          col: 0,
+        }),
+      );
+    });
+
+    it('double-clicking a free-cell card that can reach a foundation issues the foundation move', async () => {
+      mockExec.mockResolvedValue({
+        ...playingState,
+        freeCells: [card('SPADE', 1), null, null, null],
+        foundation: [[], [], [], []],
+      });
+      renderWithProviders(<BakersGamePage />);
+      const cardButton = (await screen.findByAltText('♠ A')).closest('button') as HTMLButtonElement;
+
+      mockExec.mockClear();
+      mockExec.mockResolvedValue(playingState);
+      fireEvent.doubleClick(cardButton);
+      await waitFor(() =>
+        expect(mockExec).toHaveBeenCalledWith('move', { zone: 'freecell', cell: 0 }, { zone: 'foundation', col: 0 }),
+      );
+    });
+
+    it('double-clicking a card with no foundation move falls back to an empty free cell', async () => {
+      mockExec.mockResolvedValue({
+        ...playingState,
+        tableau: [[card('SPADE', 13)], [], [], [], [], [], [], []],
+        freeCells: [null, null, null, null],
+        foundation: [[], [], [], []],
+      });
+      renderWithProviders(<BakersGamePage />);
+      const cardButton = (await screen.findByAltText('♠ K')).closest('button') as HTMLButtonElement;
+
+      mockExec.mockClear();
+      mockExec.mockResolvedValue(playingState);
+      fireEvent.doubleClick(cardButton);
+      await waitFor(() =>
+        expect(mockExec).toHaveBeenCalledWith('move', expect.objectContaining({ zone: 'tableau', col: 0 }), {
+          zone: 'freecell',
+          cell: 0,
+        }),
+      );
+    });
+
+    it('double-clicking a card with no legal auto-move issues no move', async () => {
+      mockExec.mockResolvedValue({
+        ...playingState,
+        tableau: [[card('SPADE', 13)], [], [], [], [], [], [], []],
+        freeCells: [card('HEART', 5), card('CLOVER', 6), card('DIAMOND', 7), card('SPADE', 8)],
+        foundation: [[], [], [], []],
+      });
+      renderWithProviders(<BakersGamePage />);
+      const cardButton = (await screen.findByAltText('♠ K')).closest('button') as HTMLButtonElement;
+
+      mockExec.mockClear();
+      fireEvent.doubleClick(cardButton);
+      await Promise.resolve();
+      expect(mockExec).not.toHaveBeenCalledWith('move', expect.anything(), expect.anything());
+    });
+
+    it('single-clicking a card still selects it without issuing a move (no regression)', async () => {
+      mockExec.mockResolvedValue({
+        ...playingState,
+        tableau: [[card('SPADE', 2)], [], [], [], [], [], [], []],
+        foundation: [[card('SPADE', 1)], [], [], []],
+      });
+      renderWithProviders(<BakersGamePage />);
+      const cardButton = (await screen.findByAltText('♠ 2')).closest('button') as HTMLButtonElement;
+
+      mockExec.mockClear();
+      fireEvent.click(cardButton);
+      await Promise.resolve();
+      expect(mockExec).not.toHaveBeenCalledWith('move', expect.anything(), expect.anything());
+      expect(cardButton).toHaveAttribute('aria-pressed', 'true');
+    });
+  });
 });

--- a/frontend/src/pages/BakersGamePage.tsx
+++ b/frontend/src/pages/BakersGamePage.tsx
@@ -30,6 +30,7 @@ import { gameTheme } from '../styles/gameTheme';
 import type { Card, FreeCellResponse } from '../types/card';
 import { FreeCellPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { bakersGameAutoMoveTarget } from '../utils/bakersGameAutoMoveTarget';
 import { cardAlt } from '../utils/cardAlt';
 import { FREECELL_HELP, parseFreecellCommand } from '../utils/cli/commands/freecellCommands';
 import { formatFreecellState } from '../utils/cli/formatters/freecellFormatter';
@@ -108,6 +109,7 @@ function BakersGamePageContent() {
     handleUndoEscape,
     handleSelectSource,
     handleSelectTarget,
+    handleAutoMove,
     isAutoCompleting,
   } = useBakersGameGame();
   const {
@@ -142,6 +144,21 @@ function BakersGamePageContent() {
     isPlaying: !!isPlayingForKbd,
     disabled: loading,
   });
+
+  // Double-click / double-tap shortcut: auto-send an exposed card (a tableau
+  // top card or a free-cell card) to its foundation, falling back to an empty
+  // free cell, when a legal target exists; otherwise do nothing (no error,
+  // selection untouched). Disabled while auto-completing.
+  const handleAutoMoveShortcut = useCallback(
+    (source: FreeCellMoveZone, card: Card) => {
+      if (!state || isAutoCompleting) return;
+      const target = bakersGameAutoMoveTarget(card, state.foundation, state.freeCells);
+      if (!target) return;
+      handleAutoMove(source, target);
+      playSound('cardPlace');
+    },
+    [state, isAutoCompleting, handleAutoMove, playSound],
+  );
 
   const handleManualReset = useCallback(() => {
     hideActionLog();
@@ -253,7 +270,14 @@ function BakersGamePageContent() {
                         {card ? (
                           <button
                             type="button"
-                            onClick={() => handleSelectSource(freeCellZone)}
+                            onClick={(e) => {
+                              // The second click of a double-click also fires
+                              // onClick (detail === 2); ignore it so onDoubleClick
+                              // owns the auto-move and selection stays put.
+                              if (e.detail >= 2) return;
+                              handleSelectSource(freeCellZone);
+                            }}
+                            onDoubleClick={() => handleAutoMoveShortcut(freeCellZone, card)}
                             disabled={!isPlaying || loading}
                             aria-label={cardAlt(card)}
                             aria-pressed={isSourceSelected('freecell', undefined, idx)}
@@ -390,13 +414,24 @@ function BakersGamePageContent() {
                                   {card ? (
                                     <button
                                       type="button"
-                                      onClick={() => {
+                                      onClick={(e) => {
+                                        // The second click of a double-click also
+                                        // fires onClick (detail === 2); ignore it so
+                                        // onDoubleClick owns the auto-move without
+                                        // issuing a stray self-target move.
+                                        if (e.detail >= 2) return;
                                         if (selectedSource) {
                                           handleSelectTarget(tableauColZone);
                                         } else {
                                           handleSelectSource(cardZone);
                                         }
                                       }}
+                                      onDoubleClick={
+                                        // Only the exposed top card of a column can auto-move.
+                                        cardIdx === col.length - 1
+                                          ? () => handleAutoMoveShortcut(cardZone, card)
+                                          : undefined
+                                      }
                                       disabled={!isPlaying || loading}
                                       aria-label={cardAlt(card)}
                                       aria-pressed={isSourceSelected('tableau', colIdx, undefined, cardIdx)}

--- a/frontend/src/utils/bakersGameAutoMoveTarget.test.ts
+++ b/frontend/src/utils/bakersGameAutoMoveTarget.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import type { Card, CardDesign } from '../types/card';
+import { bakersGameAutoMoveTarget } from './bakersGameAutoMoveTarget';
+
+const card = (design: CardDesign, value: number): Card => ({ design, value });
+const emptyFreeCells: (Card | null)[] = [null, null, null, null];
+const emptyFoundation: Card[][] = [[], [], [], []];
+
+describe('bakersGameAutoMoveTarget', () => {
+  it('targets the matching foundation for an Ace on an empty pile', () => {
+    expect(bakersGameAutoMoveTarget(card('SPADE', 1), emptyFoundation, emptyFreeCells)).toEqual({
+      zone: 'foundation',
+      col: 0,
+    });
+  });
+
+  it('targets the foundation for the next ascending same-suit rank', () => {
+    const foundation: Card[][] = [[], [], [card('HEART', 1)], []];
+    expect(bakersGameAutoMoveTarget(card('HEART', 2), foundation, emptyFreeCells)).toEqual({
+      zone: 'foundation',
+      col: 2,
+    });
+  });
+
+  it('prefers the foundation over an empty free cell when both are legal', () => {
+    // ♠A can go to foundation 0; the fallback free cell must not win.
+    expect(bakersGameAutoMoveTarget(card('SPADE', 1), emptyFoundation, emptyFreeCells)).toEqual({
+      zone: 'foundation',
+      col: 0,
+    });
+  });
+
+  it('falls back to the first empty free cell when no foundation move exists', () => {
+    // ♠K on an empty spade pile is not foundation-playable.
+    expect(bakersGameAutoMoveTarget(card('SPADE', 13), emptyFoundation, [card('HEART', 5), null, null, null])).toEqual({
+      zone: 'freecell',
+      cell: 1,
+    });
+  });
+
+  it('returns null when no foundation move and no empty free cell exist', () => {
+    const fullCells: (Card | null)[] = [card('HEART', 5), card('CLOVER', 6), card('DIAMOND', 7), card('SPADE', 8)];
+    expect(bakersGameAutoMoveTarget(card('SPADE', 13), emptyFoundation, fullCells)).toBeNull();
+  });
+});

--- a/frontend/src/utils/bakersGameAutoMoveTarget.ts
+++ b/frontend/src/utils/bakersGameAutoMoveTarget.ts
@@ -1,0 +1,30 @@
+import type { FreeCellMoveZone } from '../api/gameApi';
+import type { Card } from '../types/card';
+import { freeCellFoundationTarget } from './freeCellFoundationTarget';
+
+/**
+ * Computes the double-click auto-move target for `card` in Baker's Game.
+ *
+ * The FreeCell-family convenience move: first try the matching foundation pile
+ * (same-suit ascending from Ace, via {@link freeCellFoundationTarget}); if no
+ * legal foundation move exists, fall back to the first empty free cell (which
+ * accepts any single card, mirroring the domain's `freeCells[cell] == nil`
+ * check in `FreeCell.MoveTableauToFreeCell`). Returns `null` when neither a
+ * foundation nor an empty free cell is available.
+ *
+ * @param card - The card being double-clicked (a tableau top card or a free-cell card).
+ * @param foundation - The four foundation piles (bottom card first).
+ * @param freeCells - The free-cell slots (`null` for empty).
+ * @returns A `move` target zone, or `null` if no legal auto-move exists.
+ */
+export function bakersGameAutoMoveTarget(
+  card: Card,
+  foundation: Card[][],
+  freeCells: (Card | null)[],
+): FreeCellMoveZone | null {
+  const foundationTarget = freeCellFoundationTarget(card, foundation);
+  if (foundationTarget) return foundationTarget;
+
+  const emptyCell = freeCells.findIndex((c) => c === null);
+  return emptyCell === -1 ? null : { zone: 'freecell', cell: emptyCell };
+}


### PR DESCRIPTION
## Summary
Adds the FreeCell-family double-click / double-tap convenience move to Baker's Game, matching the existing `FreeCellPage` behavior.

Double-clicking a tableau **top card** or a **free-cell card**:
1. First attempts a move to the matching **foundation** pile (same-suit ascending from Ace).
2. Falls back to an **empty free cell** when no foundation move exists.
3. Plays the `cardPlace` sound on success.
4. Is disabled while auto-completing; does nothing (no error, selection untouched) when no legal target exists.

Single-click selection and drag-and-drop are preserved — the second click of a double-click (`e.detail >= 2`) is ignored so `onDoubleClick` owns the auto-move.

## Changes
- `frontend/src/utils/bakersGameAutoMoveTarget.ts` (+ test) — pure helper: foundation-first, empty-free-cell fallback. Reuses `freeCellFoundationTarget`.
- `frontend/src/hooks/useBakersGameGame.ts` — `handleAutoMove(source, target)` dispatcher (mirrors FreeCell's `handleAutoFoundation`).
- `frontend/src/pages/BakersGamePage.tsx` — `onDoubleClick` wiring on tableau top cards and free-cell cards.
- `frontend/src/pages/BakersGamePage.test.tsx` — double-click auto-move tests.

Rules verified against the shared `internal/domain/FreeCell.go` (foundation = same-suit ascending from Ace; an empty free cell accepts any single card). No Go changes.

## Test plan
- [x] `bun run test -- --run BakersGamePage bakersGameAutoMoveTarget` (76 passed)
- [x] `bun run check` (0 errors)
- [x] `bun run build` (tsc gate passes)
- [x] Double-clicking a foundation-playable card moves it to the foundation
- [x] Fallback to an empty free cell when no foundation move exists
- [x] Non-movable card does nothing; single-click still selects

Closes #3395

🤖 Generated with [Claude Code](https://claude.com/claude-code)