### PR TITLE
refactor(allfours): adopt GameSkeleton and consolidate reset UI

### DIFF
--- a/frontend/src/pages/AllFoursPage.test.tsx
+++ b/frontend/src/pages/AllFoursPage.test.tsx
@@ -93,9 +93,37 @@ beforeEach(() => {
 });
 
 describe('AllFoursPage', () => {
+  it('renders the GameSkeleton while state is null', () => {
+    mockExec.mockReturnValue(new Promise(() => undefined));
+    renderWithProviders(<AllFoursPage />);
+    expect(screen.getByTestId('skeleton')).toBeInTheDocument();
+  });
+
   it('calls reset on mount', async () => {
     renderWithProviders(<AllFoursPage />);
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+  });
+
+  it('shows exactly one reset control mid-game that opens a confirm dialog', async () => {
+    renderWithProviders(<AllFoursPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'リセット' })).toBeInTheDocument());
+    // Only the consolidated GameResetButton remains — no duplicate reset button.
+    expect(screen.getAllByRole('button', { name: 'リセット' })).toHaveLength(1);
+    fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
+    expect(screen.getByRole('alertdialog')).toBeInTheDocument();
+  });
+
+  it('shows a single 次のゲーム reset control at game end (no duplicate reset button)', async () => {
+    mockExec.mockResolvedValueOnce(gameEndState);
+    renderWithProviders(<AllFoursPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument());
+    expect(screen.queryByRole('button', { name: 'リセット' })).not.toBeInTheDocument();
+  });
+
+  it('shows the action log via ActionLogSection at game end', async () => {
+    mockExec.mockResolvedValueOnce(gameEndState);
+    renderWithProviders(<AllFoursPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: '棋譜を見る' })).toBeInTheDocument());
   });
 
   it('shows stand and beg buttons in beg phase', async () => {

--- a/frontend/src/pages/AllFoursPage.tsx
+++ b/frontend/src/pages/AllFoursPage.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { allfoursApi } from '../api/gameApi';
-import { ActionLogPanel } from '../components/ActionLogPanel';
+import { ActionLogSection } from '../components/ActionLogSection';
 import { CardImage } from '../components/CardImage';
 import { CliTerminal } from '../components/cli/CliTerminal';
 import { CliToggle } from '../components/cli/CliToggle';
@@ -12,6 +12,7 @@ import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
 import { HintTooltip } from '../components/hint/HintTooltip';
+import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCliGame } from '../hooks/useCliGame';
@@ -21,7 +22,7 @@ import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useMountReset } from '../hooks/useMountReset';
 import { useSound } from '../providers/SoundProvider';
-import { btnDanger, btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
+import { btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { AllFoursResponse } from '../types/card';
 import { AllFoursPhase } from '../types/phases';
@@ -193,11 +194,7 @@ function AllFoursPageContent() {
   );
 
   if (!state) {
-    return (
-      <div className={`flex-1 flex items-center justify-center ${gameTheme.allfours.bg}`}>
-        <div className="text-ds-text-primary">Loading...</div>
-      </div>
-    );
+    return <GameSkeleton gameKey="allfours" layout={{ kind: 'trick-taking', trickArea: true, footerHandSize: 6 }} />;
   }
 
   const phaseName = t(`phase.${PHASE_KEYS[state.phase] ?? 'beg'}`);
@@ -335,7 +332,12 @@ function AllFoursPageContent() {
               </div>
             )}
 
-            {actionLog && <ActionLogPanel entries={actionLog} onClose={hideActionLog} />}
+            <ActionLogSection
+              isEndPhase={isGameEnd}
+              actionLog={actionLog}
+              showActionLog={showActionLog}
+              hideActionLog={hideActionLog}
+            />
           </div>
 
           <GameFooter className={`${gameTheme.allfours.footer} px-4 pt-3`}>
@@ -438,30 +440,17 @@ function AllFoursPageContent() {
                     ? t('result.humanWin')
                     : t('result.cpuWin', { cpuId: state.winnerIdx })}
                 </div>
-                <div className="flex justify-center gap-2">
-                  <GameResetButton
-                    isGameEnd={isGameEnd}
-                    onReset={handleManualReset}
-                    requestConfirm={requestConfirm}
-                    loading={loading}
-                  />
-                </div>
               </div>
             )}
 
             <div className="flex justify-center gap-2 pb-2">
-              <button
-                type="button"
-                data-tutorial="af-reset-button"
-                className={btnDanger}
-                onClick={() => requestConfirm(handleManualReset)}
-                disabled={loading}
-              >
-                {tc('button.reset')}
-              </button>
-              <button type="button" className={btnSecondary} onClick={showActionLog} disabled={loading}>
-                {tc('actionLog.view')}
-              </button>
+              <GameResetButton
+                isGameEnd={isGameEnd}
+                onReset={handleManualReset}
+                requestConfirm={requestConfirm}
+                loading={loading}
+                dataTutorial="af-reset-button"
+              />
             </div>
           </GameFooter>
         </>


### PR DESCRIPTION
## 概要

オールフォーズ（All Fours）ページを標準ページ構成に揃えるリファクタリング。`GameSkeleton` を導入し、重複していたリセットUIを1つに統合、棋譜表示を `ActionLogSection` へ移行した。ゲーム挙動・API呼び出しは一切変更していない。

Closes #3592

## 変更内容

- **ローディング**: 素の `<div>Loading...</div>` を共有 `GameSkeleton`（`trick-taking` レイアウト, `footerHandSize: 6`）に置き換え。
- **リセット統合**: 終局時の `GameResetButton` と常時表示の `btnDanger` リセットボタンが並んでいた重複を、常時1つの `GameResetButton`（`dataTutorial="af-reset-button"`）に統合。中盤は確認ダイアログ経由、終局時は「次のゲーム」で即実行という共有コンポーネントの標準挙動に統一。
- **棋譜**: `ActionLogPanel` 直呼び＋手書きの表示ボタンを廃止し、他のトリックテイキングページと同じ `ActionLogSection` に移行。
- 未使用となった `ActionLogPanel` / `btnDanger` の import を削除。

## 受け入れ条件

- [x] state null 時に GameSkeleton が表示される
- [x] リセットボタンが常に1つだけ表示される
- [x] ActionLogSection 経由で棋譜の表示/非表示ができる
- [x] `AllFoursPage.test.tsx` を新構成に合わせて更新

## テスト計画

- [x] `bun run check`（Biome + design-tokens）
- [x] `bun run test -- --run AllFoursPage`（15 tests passed）
- [x] `bun run build`（tsc）

フロントエンドのみの変更で Go・WASM には影響なし。