### PR TITLE
feat(gostop): preview near-complete yaku at the go/stop decision

### DIFF
--- a/frontend/src/i18n/locales/en/gostop.json
+++ b/frontend/src/i18n/locales/en/gostop.json
@@ -43,6 +43,16 @@
     "go": "Go",
     "stop": "Stop"
   },
+  "preview": {
+    "title": "Yaku a step away",
+    "item": "{{name}}: {{remaining}} to go",
+    "samgwang": "3 Brights",
+    "sagwang": "4 Brights",
+    "ogwang": "5 Brights",
+    "tti": "Tti (5)",
+    "yeol": "Yeol (5)",
+    "pi": "Pi (10)"
+  },
   "roundResult": {
     "title": "Round Result",
     "winner": "Winner: {{name}}",

--- a/frontend/src/i18n/locales/ja/gostop.json
+++ b/frontend/src/i18n/locales/ja/gostop.json
@@ -43,6 +43,16 @@
     "go": "ゴー",
     "stop": "ストップ"
   },
+  "preview": {
+    "title": "あと少しで成立する役",
+    "item": "{{name}} あと{{remaining}}枚",
+    "samgwang": "三光",
+    "sagwang": "四光",
+    "ogwang": "五光",
+    "tti": "띠(5枚)",
+    "yeol": "열끗(5枚)",
+    "pi": "피(10枚)"
+  },
   "roundResult": {
     "title": "ラウンド結果",
     "winner": "勝者: {{name}}",

--- a/frontend/src/pages/GoStopPage.test.tsx
+++ b/frontend/src/pages/GoStopPage.test.tsx
@@ -110,6 +110,61 @@ describe('GoStopPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('stop'));
   });
 
+  it('previews a near-complete yaku with the remaining count on the decision panel', async () => {
+    // brightCount 2 -> one card from samgwang (三光).
+    mockExec.mockResolvedValue(
+      makeGoStopState({
+        phase: 1,
+        pendingPoints: 3,
+        pendingBreakdown: {
+          gwang: 0,
+          godori: 0,
+          tti: 0,
+          yeol: 0,
+          pi: 0,
+          base: 0,
+          goCount: 0,
+          goMult: 1,
+          goScore: 0,
+          brightCount: 2,
+          ribbonCount: 0,
+          animalCount: 0,
+          piCount: 0,
+        },
+      }),
+    );
+    renderWithProviders(<GoStopPage />);
+    await waitFor(() => expect(screen.getByTestId('gostop-yaku-preview')).toBeInTheDocument());
+    expect(screen.getByTestId('gostop-yaku-preview-gwang')).toHaveTextContent('三光 あと1枚');
+  });
+
+  it('hides the yaku preview when the hand is far from every threshold', async () => {
+    mockExec.mockResolvedValue(
+      makeGoStopState({
+        phase: 1,
+        pendingPoints: 0,
+        pendingBreakdown: {
+          gwang: 0,
+          godori: 0,
+          tti: 0,
+          yeol: 0,
+          pi: 0,
+          base: 0,
+          goCount: 0,
+          goMult: 1,
+          goScore: 0,
+          brightCount: 0,
+          ribbonCount: 0,
+          animalCount: 0,
+          piCount: 0,
+        },
+      }),
+    );
+    renderWithProviders(<GoStopPage />);
+    await waitFor(() => expect(screen.getByTestId('gostop-decision')).toBeInTheDocument());
+    expect(screen.queryByTestId('gostop-yaku-preview')).not.toBeInTheDocument();
+  });
+
   it('shows the next-round button at round end with a bak badge and dispatches nextround', async () => {
     mockExec.mockResolvedValue(roundEndState);
     renderWithProviders(<GoStopPage />);

--- a/frontend/src/pages/GoStopPage.tsx
+++ b/frontend/src/pages/GoStopPage.tsx
@@ -26,6 +26,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { GOSTOP_HELP, parseGoStopCommand } from '../utils/cli/commands/gostopCommands';
 import { formatGoStopState } from '../utils/cli/formatters/gostopFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { computeNearYaku } from '../utils/gostopYaku';
 
 /** Go-Stop (ゴーストップ) tutorial step definitions. */
 const GOSTOP_TUTORIAL_STEPS: TutorialStep[] = [
@@ -166,6 +167,9 @@ function GoStopPageContent() {
 
   const winnerName = state.winner < 0 ? '' : state.winner === (human?.id ?? 0) ? t('you') : t('cpu');
 
+  // Yaku that are a few cards from completing if the player calls Go and plays on.
+  const pendingNearYaku = isDecisionPhase ? computeNearYaku(state.pendingBreakdown) : [];
+
   return (
     <GamePageShell
       title={tc('nav.gostop')}
@@ -283,6 +287,22 @@ function GoStopPageContent() {
                   {t('decision.points', { points: state.pendingPoints })}
                 </div>
                 {breakdownChips(state.pendingBreakdown)}
+                {pendingNearYaku.length > 0 && (
+                  <div className="mt-1" data-testid="gostop-yaku-preview">
+                    <div className="text-[10px] text-ds-text-muted mb-0.5">{t('preview.title')}</div>
+                    <div className="flex gap-1 justify-center flex-wrap text-[10px]">
+                      {pendingNearYaku.map((y) => (
+                        <span
+                          key={y.category}
+                          className="px-1.5 py-0.5 rounded bg-ds-info/20 text-ds-info"
+                          data-testid={`gostop-yaku-preview-${y.category}`}
+                        >
+                          {t('preview.item', { name: t(`preview.${y.target}`), remaining: y.remaining })}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                )}
                 <div className="flex gap-3 justify-center mt-2">
                   <button type="button" className={btnWarning} onClick={callGo} disabled={loading}>
                     {t('decision.go')}

--- a/frontend/src/utils/gostopYaku.test.ts
+++ b/frontend/src/utils/gostopYaku.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import type { GoStopBreakdown } from '../types/card';
+import { computeNearYaku } from './gostopYaku';
+
+/** Builds a breakdown with all category counts zeroed, overriding only the counts under test. */
+function bd(overrides: Partial<GoStopBreakdown>): GoStopBreakdown {
+  return {
+    gwang: 0,
+    godori: 0,
+    tti: 0,
+    yeol: 0,
+    pi: 0,
+    base: 0,
+    goCount: 0,
+    goMult: 1,
+    goScore: 0,
+    brightCount: 0,
+    ribbonCount: 0,
+    animalCount: 0,
+    piCount: 0,
+    ...overrides,
+  };
+}
+
+describe('computeNearYaku', () => {
+  it('returns nothing for a null breakdown', () => {
+    expect(computeNearYaku(null)).toEqual([]);
+  });
+
+  it('flags a hand one card away from samgwang (3 brights)', () => {
+    const near = computeNearYaku(bd({ brightCount: 2 }));
+    expect(near).toEqual([{ category: 'gwang', target: 'samgwang', current: 2, remaining: 1 }]);
+  });
+
+  it('advances the gwang target to sagwang once 3 brights are held', () => {
+    const near = computeNearYaku(bd({ brightCount: 3 }));
+    expect(near).toEqual([{ category: 'gwang', target: 'sagwang', current: 3, remaining: 1 }]);
+  });
+
+  it('advances the gwang target to ogwang once 4 brights are held', () => {
+    const near = computeNearYaku(bd({ brightCount: 4 }));
+    expect(near).toEqual([{ category: 'gwang', target: 'ogwang', current: 4, remaining: 1 }]);
+  });
+
+  it('emits no gwang entry when all five brights are already captured', () => {
+    expect(computeNearYaku(bd({ brightCount: 5 }))).toEqual([]);
+  });
+
+  it('flags tti, yeol and pi one card from their thresholds', () => {
+    const near = computeNearYaku(bd({ ribbonCount: 4, animalCount: 4, piCount: 9 }));
+    expect(near).toEqual([
+      { category: 'tti', target: 'tti', current: 4, remaining: 1 },
+      { category: 'yeol', target: 'yeol', current: 4, remaining: 1 },
+      { category: 'pi', target: 'pi', current: 9, remaining: 1 },
+    ]);
+  });
+
+  it('includes a two-card-away yaku but drops one farther than the preview window', () => {
+    // brightCount 1 -> 2 away from samgwang (within window); ribbonCount 2 -> 3 away (excluded).
+    const near = computeNearYaku(bd({ brightCount: 1, ribbonCount: 2 }));
+    expect(near).toEqual([{ category: 'gwang', target: 'samgwang', current: 1, remaining: 2 }]);
+  });
+
+  it('shows nothing when every category is far from a threshold', () => {
+    expect(computeNearYaku(bd({ brightCount: 0, ribbonCount: 0, animalCount: 0, piCount: 0 }))).toEqual([]);
+  });
+
+  it('does not flag categories already at or past their threshold', () => {
+    expect(computeNearYaku(bd({ ribbonCount: 5, animalCount: 6, piCount: 12 }))).toEqual([]);
+  });
+});

--- a/frontend/src/utils/gostopYaku.ts
+++ b/frontend/src/utils/gostopYaku.ts
@@ -1,0 +1,80 @@
+import type { GoStopBreakdown } from '../types/card';
+
+/**
+ * Maximum distance, in cards, from a scoring threshold at which a yaku is
+ * previewed as "near-complete". A hand farther than this from every threshold
+ * shows no preview, keeping the Go/Stop panel focused on realistic upgrades.
+ */
+export const GOSTOP_YAKU_PREVIEW_DISTANCE = 2;
+
+/** Category of a Go-Stop yaku whose progress is unambiguous from a captured-card count. */
+export type GoStopYakuCategory = 'gwang' | 'tti' | 'yeol' | 'pi';
+
+/** A scoring combination (yaku) the player is a few cards away from completing. */
+export interface GoStopNearYaku {
+  /** Breakdown category the progress belongs to. */
+  category: GoStopYakuCategory;
+  /** i18n sub-key naming the yaku that completes at the next threshold. */
+  target: string;
+  /** Cards of this category captured so far. */
+  current: number;
+  /** Cards still needed to reach the next scoring threshold. */
+  remaining: number;
+}
+
+// Bright (光/광) thresholds and the yaku each one completes. Mirrors the domain
+// scoring in internal/domain/GoStop.go: 3 = 삼광, 4 = 사광, 5 = 오광.
+const GWANG_THRESHOLDS: { count: number; target: string }[] = [
+  { count: 3, target: 'samgwang' },
+  { count: 4, target: 'sagwang' },
+  { count: 5, target: 'ogwang' },
+];
+
+// Count-only threshold for the ribbon (띠), animal (열끗) and junk (피) categories.
+// Named-ribbon sets (홍단/청단/초단) and 고도리 depend on specific months, which a
+// plain count cannot determine, so they are intentionally excluded.
+const TTI_THRESHOLD = 5;
+const YEOL_THRESHOLD = 5;
+const PI_THRESHOLD = 10;
+
+/** Builds a near-yaku entry when the remaining distance is within the preview window. */
+function nearEntry(
+  category: GoStopYakuCategory,
+  target: string,
+  current: number,
+  threshold: number,
+): GoStopNearYaku | null {
+  const remaining = threshold - current;
+  if (remaining < 1 || remaining > GOSTOP_YAKU_PREVIEW_DISTANCE) return null;
+  return { category, target, current, remaining };
+}
+
+/**
+ * Computes the yaku a player is close to completing from a scoring breakdown,
+ * using only the unambiguous captured-card counts (bright/ribbon/animal/junk).
+ *
+ * Thresholds match the Go-Stop domain scoring exactly; month-specific yaku
+ * (고도리, 홍단, 청단, 초단) are omitted because a count cannot prove them.
+ * Categories already at their maximum threshold produce no entry.
+ */
+export function computeNearYaku(bd: GoStopBreakdown | null): GoStopNearYaku[] {
+  if (!bd) return [];
+  const out: GoStopNearYaku[] = [];
+
+  const nextGwang = GWANG_THRESHOLDS.find((th) => th.count > bd.brightCount);
+  if (nextGwang) {
+    const entry = nearEntry('gwang', nextGwang.target, bd.brightCount, nextGwang.count);
+    if (entry) out.push(entry);
+  }
+
+  const tti = nearEntry('tti', 'tti', bd.ribbonCount, TTI_THRESHOLD);
+  if (tti) out.push(tti);
+
+  const yeol = nearEntry('yeol', 'yeol', bd.animalCount, YEOL_THRESHOLD);
+  if (yeol) out.push(yeol);
+
+  const pi = nearEntry('pi', 'pi', bd.piCount, PI_THRESHOLD);
+  if (pi) out.push(pi);
+
+  return out;
+}


### PR DESCRIPTION
## 概要
Go/Stop の判断パネルに「あと少しで成立する役」を予告表示する。Go を宣言して続行した場合に、どのカテゴリがあと何枚で加点になるかを提示し、Go-vs-Stop のリスク・リターン判断を助ける。

Closes #3520

## 実装
- 新規 pure helper `frontend/src/utils/gostopYaku.ts` — `pendingBreakdown` の**枚数カウント**（`brightCount`/`ribbonCount`/`animalCount`/`piCount`）から、次の得点閾値まで数枚以内の役を算出する（プレビュー距離は最大2枚）。
- カテゴリはワイヤの `design` が "JOKER" に潰れるが、**枚数はブレイクダウンに直接露出している**ため色検出は不要。
- 閾値は `internal/domain/GoStop.go` のスコア定義に厳密一致:
  - 光: 3枚=三光 / 4枚=四光 / 5枚=五光（最大の5枚到達時は非表示）
  - 띠: 5枚 / 열끗: 5枚 / 피: 10枚
- **月依存の役（고도리・홍단・청단・초단）は枚数のみでは判定不能なので意図的に除外**（役の捏造なし）。
- `GoStopPage.tsx` 判断パネルに `data-testid="gostop-yaku-preview"` の追加情報パネルを表示（デザインシステムトークンのみ使用、既存の得点/chip 表示は維持）。
- i18n キー `preview.*` を ja/en 両方に追加。

## テスト
- `frontend/src/utils/gostopYaku.test.ts` — 1枚差で正しい残数フラグ / 最大到達で非表示 / 遠い手で空 / 閾値超過で非表示 など。
- `frontend/src/pages/GoStopPage.test.tsx` — 判断パネルで「三光 あと1枚」を表示 / 全カテゴリが遠い場合はプレビュー非表示。

## チェックリスト
- [x] `bun run check`（biome）パス
- [x] `bun run test -- --run gostopYaku GoStopPage`（24 tests）パス
- [x] `bun run build`（tsc）パス
- [x] i18n ja/en パリティ
- [x] フロントエンドのみ・Go 未変更・WASM 中立（`extra` ワーカー）

🤖 Generated with [Claude Code](https://claude.com/claude-code)