### PR TITLE
feat(ofc): disable full-row place buttons and allow direct board-row placement

### DIFF
--- a/frontend/src/i18n/locales/en/openfacechinese.json
+++ b/frontend/src/i18n/locales/en/openfacechinese.json
@@ -47,6 +47,7 @@
     "place": "Pick the row to place the dealt card. Once placed, a card cannot be moved.",
     "resetButton": "Press this button to restart the game from the beginning."
   },
+  "placeRowAria": "Place on {{label}}",
   "rowAriaEmpty": "{{label}} {{count}} cards",
   "rowAriaFilled": "{{label}} {{count}} cards: {{cards}}",
   "pendingAnnounce": "To place: {{card}}"

--- a/frontend/src/i18n/locales/ja/openfacechinese.json
+++ b/frontend/src/i18n/locales/ja/openfacechinese.json
@@ -47,6 +47,7 @@
     "place": "配られたカードを置く段を選びましょう。一度置いたカードは動かせません。",
     "resetButton": "ゲームを最初からやり直すにはこのボタンを押します。"
   },
+  "placeRowAria": "{{label}} に置く",
   "rowAriaEmpty": "{{label}} {{count}}枚",
   "rowAriaFilled": "{{label}} {{count}}枚: {{cards}}",
   "pendingAnnounce": "配置待ち: {{card}}"

--- a/frontend/src/pages/OpenFaceChinesePage.test.tsx
+++ b/frontend/src/pages/OpenFaceChinesePage.test.tsx
@@ -4,7 +4,7 @@ import { openfacechineseApi } from '../api/gameApi';
 import { useCliMode } from '../hooks/useCliMode';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, OpenFaceChinesePlayer, OpenFaceChineseResponse } from '../types/card';
-import { OpenFaceChinesePage } from './OpenFaceChinesePage';
+import { isOfcRowFull, OpenFaceChinesePage } from './OpenFaceChinesePage';
 
 vi.mock('../api/gameApi', () => ({
   openfacechineseApi: { exec: vi.fn() },
@@ -206,5 +206,73 @@ describe('OpenFaceChinesePage', () => {
     renderWithProviders(<OpenFaceChinesePage />);
     const hint = await screen.findByTestId('ofc-hint');
     expect(hint).toHaveTextContent('強い組み合わせはボトムに寄せましょう');
+  });
+
+  it('disables the place button for a full row', async () => {
+    // Human top row already holds its 3-card maximum.
+    mockExec.mockResolvedValue(
+      makeState({
+        players: [
+          makePlayer({ front: [card('SPADE', 2), card('HEART', 3), card('CLOVER', 4)] }),
+          makePlayer({ id: 1, isHuman: false }),
+        ],
+      }),
+    );
+    renderWithProviders(<OpenFaceChinesePage />);
+    await waitFor(() => expect(screen.getByTestId('place-front')).toBeDisabled());
+    // Non-full rows stay enabled.
+    expect(screen.getByTestId('place-middle')).not.toBeDisabled();
+    expect(screen.getByTestId('place-back')).not.toBeDisabled();
+  });
+
+  it('places the pending card by tapping a non-full board row', async () => {
+    renderWithProviders(<OpenFaceChinesePage />);
+    const row = await screen.findByTestId('ofc-place-row-middle-0');
+    mockExec.mockClear();
+    fireEvent.click(row);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('place', { row: 1 }));
+  });
+
+  it('sends nothing when a full board row is tapped', async () => {
+    mockExec.mockResolvedValue(
+      makeState({
+        players: [
+          makePlayer({ front: [card('SPADE', 2), card('HEART', 3), card('CLOVER', 4)] }),
+          makePlayer({ id: 1, isHuman: false }),
+        ],
+      }),
+    );
+    renderWithProviders(<OpenFaceChinesePage />);
+    const row = await screen.findByTestId('ofc-place-row-front-0');
+    expect(row).toBeDisabled();
+    mockExec.mockClear();
+    fireEvent.click(row);
+    expect(mockExec).not.toHaveBeenCalledWith('place', expect.anything());
+  });
+
+  it('does not make CPU board rows tappable', async () => {
+    renderWithProviders(<OpenFaceChinesePage />);
+    await waitFor(() => expect(screen.getByTestId('player-1')).toBeInTheDocument());
+    expect(screen.queryByTestId('ofc-place-row-front-1')).not.toBeInTheDocument();
+  });
+});
+
+describe('isOfcRowFull', () => {
+  const p = (front: Card[], middle: Card[], back: Card[]): OpenFaceChinesePlayer => makePlayer({ front, middle, back });
+  const c = card('SPADE', 1);
+
+  it('returns false for a null player', () => {
+    expect(isOfcRowFull(null, 0)).toBe(false);
+  });
+
+  it('detects a full front row (capacity 3)', () => {
+    expect(isOfcRowFull(p([c, c, c], [], []), 0)).toBe(true);
+    expect(isOfcRowFull(p([c, c], [], []), 0)).toBe(false);
+  });
+
+  it('detects full middle and back rows (capacity 5)', () => {
+    expect(isOfcRowFull(p([], [c, c, c, c, c], []), 1)).toBe(true);
+    expect(isOfcRowFull(p([], [], [c, c, c, c, c]), 2)).toBe(true);
+    expect(isOfcRowFull(p([], [c, c, c, c], []), 1)).toBe(false);
   });
 });

--- a/frontend/src/pages/OpenFaceChinesePage.tsx
+++ b/frontend/src/pages/OpenFaceChinesePage.tsx
@@ -32,6 +32,17 @@ const ROW_FRONT = 0;
 const ROW_MIDDLE = 1;
 const ROW_BACK = 2;
 
+/** Maximum number of cards each board row holds (front=3, middle=5, back=5). Mirrors the domain. */
+const ROW_CAPACITIES = [3, 5, 5] as const;
+
+/** Returns true when the given row of a player's board is already full and cannot accept a card. */
+export function isOfcRowFull(player: OpenFaceChinesePlayer | null, row: number): boolean {
+  if (!player) return false;
+  const rows = [player.front, player.middle, player.back];
+  const cards = rows[row];
+  return cards !== undefined && cards.length >= ROW_CAPACITIES[row];
+}
+
 /** Open Face Chinese Poker (OFC) tutorial step definitions. */
 const OFC_TUTORIAL_STEPS: TutorialStep[] = [
   {
@@ -109,6 +120,9 @@ function OpenFaceChinesePageContent() {
   const human = state.players.find((p) => p.isHuman) ?? null;
   const humanWon = isGameEnd && human !== null && state.winnerIdx === human.id;
   const canPlace = isPlacing && state.isHumanTurn && Boolean(state.currentCard);
+  const frontFull = isOfcRowFull(human, ROW_FRONT);
+  const middleFull = isOfcRowFull(human, ROW_MIDDLE);
+  const backFull = isOfcRowFull(human, ROW_BACK);
 
   const handleReset = () => {
     hideActionLog();
@@ -122,33 +136,61 @@ function OpenFaceChinesePageContent() {
 
   const playerName = (player: OpenFaceChinesePlayer) => (player.isHuman ? t('you') : t('cpu', { n: player.id }));
 
-  /** Renders a single row of a player's board, padding empty slots up to `capacity`. */
-  const renderRow = (label: string, cards: Card[], capacity: number, keyPrefix: string) => {
+  /**
+   * Renders a single row of a player's board, padding empty slots up to `capacity`.
+   * When `place` is supplied (the human's own rows during placing), the slot area
+   * becomes a tap target that places the pending card into that row via the same
+   * `place` action the dedicated buttons use; a full row is rendered inactive.
+   */
+  const renderRow = (
+    label: string,
+    cards: Card[],
+    capacity: number,
+    keyPrefix: string,
+    place?: { row: number; full: boolean },
+  ) => {
     // A fieldset+legend names the whole row for SR (count + card contents), since
     // the empty slots are decorative and biome forbids role="group" on a div.
     const cardNames = cards.map(cardAlt).join(', ');
     const rowAria = cardNames
       ? t('rowAriaFilled', { label, count: cards.length, cards: cardNames })
       : t('rowAriaEmpty', { label, count: cards.length });
+    const slots = (
+      <div className="flex gap-1 flex-wrap">
+        {cards.map((c, i) => (
+          <CardImage key={`${keyPrefix}-${i}`} card={c} width={Math.round(cardWidth * 0.62)} />
+        ))}
+        {Array.from({ length: Math.max(0, capacity - cards.length) }).map((_, i) => (
+          <div
+            key={`${keyPrefix}-empty-${i}`}
+            className="rounded border border-dashed border-white/20 bg-black/20"
+            style={{ width: Math.round(cardWidth * 0.62), height: Math.round(cardWidth * 0.62 * 1.4) }}
+            aria-hidden="true"
+          />
+        ))}
+      </div>
+    );
     return (
       <fieldset className="flex flex-col gap-1 border-0 p-0 m-0" data-testid={`ofc-row-${keyPrefix}`}>
         <legend className="sr-only">{rowAria}</legend>
         <span className="text-ds-text-muted text-[11px]" aria-hidden="true">
           {label}
         </span>
-        <div className="flex gap-1 flex-wrap">
-          {cards.map((c, i) => (
-            <CardImage key={`${keyPrefix}-${i}`} card={c} width={Math.round(cardWidth * 0.62)} />
-          ))}
-          {Array.from({ length: Math.max(0, capacity - cards.length) }).map((_, i) => (
-            <div
-              key={`${keyPrefix}-empty-${i}`}
-              className="rounded border border-dashed border-white/20 bg-black/20"
-              style={{ width: Math.round(cardWidth * 0.62), height: Math.round(cardWidth * 0.62 * 1.4) }}
-              aria-hidden="true"
-            />
-          ))}
-        </div>
+        {place ? (
+          <button
+            type="button"
+            className="rounded p-1 text-left enabled:cursor-pointer enabled:hover:ring-1 enabled:hover:ring-ds-warning enabled:focus-visible:ring-1 enabled:focus-visible:ring-ds-warning disabled:opacity-50 disabled:cursor-not-allowed"
+            onClick={() => handlePlace(place.row)}
+            disabled={loading || place.full}
+            aria-disabled={place.full}
+            aria-label={t('placeRowAria', { label })}
+            data-testid={`ofc-place-row-${keyPrefix}`}
+          >
+            {slots}
+          </button>
+        ) : (
+          slots
+        )}
       </fieldset>
     );
   };
@@ -200,7 +242,8 @@ function OpenFaceChinesePageContent() {
                     type="button"
                     className={btnSuccess}
                     onClick={() => handlePlace(ROW_FRONT)}
-                    disabled={loading}
+                    disabled={loading || frontFull}
+                    aria-disabled={frontFull}
                     data-testid="place-front"
                   >
                     {t('place.front')}
@@ -209,7 +252,8 @@ function OpenFaceChinesePageContent() {
                     type="button"
                     className={btnSuccess}
                     onClick={() => handlePlace(ROW_MIDDLE)}
-                    disabled={loading}
+                    disabled={loading || middleFull}
+                    aria-disabled={middleFull}
                     data-testid="place-middle"
                   >
                     {t('place.middle')}
@@ -218,7 +262,8 @@ function OpenFaceChinesePageContent() {
                     type="button"
                     className={btnSuccess}
                     onClick={() => handlePlace(ROW_BACK)}
-                    disabled={loading}
+                    disabled={loading || backFull}
+                    aria-disabled={backFull}
                     data-testid="place-back"
                   >
                     {t('place.back')}
@@ -262,9 +307,27 @@ function OpenFaceChinesePageContent() {
                     </div>
                   </div>
                   <div className="flex flex-col gap-2">
-                    {renderRow(t('rows.front'), p.front, 3, `front-${p.id}`)}
-                    {renderRow(t('rows.middle'), p.middle, 5, `middle-${p.id}`)}
-                    {renderRow(t('rows.back'), p.back, 5, `back-${p.id}`)}
+                    {renderRow(
+                      t('rows.front'),
+                      p.front,
+                      3,
+                      `front-${p.id}`,
+                      canPlace && p.isHuman ? { row: ROW_FRONT, full: frontFull } : undefined,
+                    )}
+                    {renderRow(
+                      t('rows.middle'),
+                      p.middle,
+                      5,
+                      `middle-${p.id}`,
+                      canPlace && p.isHuman ? { row: ROW_MIDDLE, full: middleFull } : undefined,
+                    )}
+                    {renderRow(
+                      t('rows.back'),
+                      p.back,
+                      5,
+                      `back-${p.id}`,
+                      canPlace && p.isHuman ? { row: ROW_BACK, full: backFull } : undefined,
+                    )}
                   </div>
                   {isRoundEnd && (
                     <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs">


### PR DESCRIPTION
Closes #3571

## What
Open Face Chinese Poker (OFC) placement UX improvements — fully additive, no game-rule or backend changes.

1. **Full-row place buttons are disabled.** Each `place-front/middle/back` button now reflects the human's row capacity (front=3, middle=5, back=5, verified against `internal/domain/OpenFaceChinesePlayer.go`). A full row's button gets `disabled` + `aria-disabled`, so a doomed placement is no longer possible only to fail server-side.
2. **Direct board-row placement.** The human's own board rows are now tap targets during placing: tapping a row fires the exact same `place` action the dedicated buttons use (`ofc-place-row-{front,middle,back}-<id>`). CPU rows stay non-interactive; a full row is rendered inactive (disabled) and sends nothing on tap.

A small pure helper `isOfcRowFull(player, row)` encapsulates the capacity check and is unit-tested directly.

## Acceptance criteria
- [x] 満杯のローの配置ボタンが無効化される
- [x] 自分のボードのローをクリックして配置できる
- [x] 満杯ロークリック時は何も送信されない
- [x] `OpenFaceChinesePage.test.tsx` に満杯無効化・直接配置のテストを追加

## Tests
Added: `disables the place button for a full row`, `places the pending card by tapping a non-full board row`, `sends nothing when a full board row is tapped`, `does not make CPU board rows tappable`, plus an `isOfcRowFull` unit-test block. All 36 OFC tests pass.

## Gates
- `bun run check` ✅
- `bun run test -- --run OpenFaceChinese` ✅ (36 passed)
- `bun run build` (tsc) ✅

i18n: added `placeRowAria` key to ja + en locales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)