### PR TITLE
feat(faro): tap the call cards to set their order

### DIFF
--- a/frontend/src/pages/FaroPage.test.tsx
+++ b/frontend/src/pages/FaroPage.test.tsx
@@ -168,16 +168,53 @@ describe('FaroPage', () => {
     await waitFor(() => expect(screen.getByText('スプリット（バンクが半分回収）')).toBeInTheDocument());
   });
 
-  it('submits a call once all three ranks are ordered', async () => {
+  it('submits a call once all three ranks are ordered by tapping the card images', async () => {
     mockExec.mockResolvedValue(callState);
     renderWithProviders(<FaroPage />);
-    await screen.findByTestId('call-rank-3-0');
-    fireEvent.click(screen.getByTestId('call-rank-3-0'));
-    fireEvent.click(screen.getByTestId('call-rank-9-1'));
-    fireEvent.click(screen.getByTestId('call-rank-12-2'));
+    await screen.findByTestId('call-card-3-0');
+    fireEvent.click(screen.getByTestId('call-card-3-0'));
+    fireEvent.click(screen.getByTestId('call-card-9-1'));
+    fireEvent.click(screen.getByTestId('call-card-12-2'));
     mockExec.mockClear();
     fireEvent.click(screen.getByRole('button', { name: 'コールする' }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('call', { order: [3, 9, 12] }));
+  });
+
+  it('shows an order badge and marks the tapped card as pressed', async () => {
+    mockExec.mockResolvedValue(callState);
+    renderWithProviders(<FaroPage />);
+    const secondCard = await screen.findByTestId('call-card-9-1');
+    // Nothing selected yet: no badges and no pressed cards.
+    expect(screen.queryByTestId('call-order-badge-9-1')).not.toBeInTheDocument();
+    expect(secondCard).toHaveAttribute('aria-pressed', 'false');
+
+    fireEvent.click(screen.getByTestId('call-card-3-0'));
+    fireEvent.click(secondCard);
+    // The second tap becomes position 2.
+    expect(screen.getByTestId('call-order-badge-9-1')).toHaveTextContent('2');
+    expect(secondCard).toHaveAttribute('aria-pressed', 'true');
+
+    // Tapping again clears the selection and its badge.
+    fireEvent.click(secondCard);
+    expect(screen.queryByTestId('call-order-badge-9-1')).not.toBeInTheDocument();
+    expect(secondCard).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('selects duplicate ranks independently by index', async () => {
+    mockExec.mockResolvedValue(
+      makeState({ phase: 3, callCards: [card('SPADE', 5), card('HEART', 5), card('DIAMOND', 9)] }),
+    );
+    renderWithProviders(<FaroPage />);
+    // Tap the second 5 first, then the first 5, then the 9.
+    await screen.findByTestId('call-card-5-1');
+    fireEvent.click(screen.getByTestId('call-card-5-1'));
+    fireEvent.click(screen.getByTestId('call-card-5-0'));
+    fireEvent.click(screen.getByTestId('call-card-9-2'));
+    expect(screen.getByTestId('call-order-badge-5-1')).toHaveTextContent('1');
+    expect(screen.getByTestId('call-order-badge-5-0')).toHaveTextContent('2');
+    mockExec.mockClear();
+    fireEvent.click(screen.getByRole('button', { name: 'コールする' }));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('call', { order: [5, 5, 9] }));
   });
 
   it('skips the call without an order', async () => {

--- a/frontend/src/pages/FaroPage.tsx
+++ b/frontend/src/pages/FaroPage.tsx
@@ -17,7 +17,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
-import { btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
+import { btnPrimary, btnSecondary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { FaroResponse } from '../types/card';
 import { FaroPhase } from '../types/phases';
@@ -360,29 +360,37 @@ function FaroPageContent() {
                 <div className="text-ds-text-primary text-sm mb-1">{t('callTitle')}</div>
                 <div className="text-ds-text-muted text-xs mb-2">{t('callHint')}</div>
                 <div className="flex flex-wrap justify-center gap-3 mb-2">
-                  {state.callCards.map((c, i) => (
-                    <CardImage key={`call-card-${i}`} card={c} width={cardWidth} />
-                  ))}
-                </div>
-                <div className="flex flex-wrap justify-center gap-2 mb-2">
                   {state.callCards.map((card, i) => {
                     const pos = callOrder.indexOf(i);
                     const isSelected = pos >= 0;
                     return (
                       <button
-                        key={`call-rank-${card.value}-${i}`}
+                        key={`call-card-${card.value}-${i}`}
                         type="button"
                         onClick={() => toggleCallCard(i)}
                         disabled={loading}
-                        className={`px-3 py-2 rounded border text-sm font-semibold transition-all ${
+                        aria-pressed={isSelected}
+                        className={`relative rounded-md border-2 transition-all ${focusRingWhite} ${
                           isSelected
-                            ? 'border-ds-warning bg-ds-warning/20 text-ds-warning'
-                            : 'border-white/30 bg-black/30 text-ds-text-primary'
+                            ? 'border-ds-warning -translate-y-1'
+                            : 'border-transparent hover:border-white/40 hover:-translate-y-0.5'
+                        } ${loading ? 'cursor-default' : 'cursor-pointer'}`}
+                        style={{ background: 'none', padding: 0, lineHeight: 0 }}
+                        data-testid={`call-card-${card.value}-${i}`}
+                        aria-label={`${t('rankName')} ${rankLabel(card.value)}${
+                          isSelected ? `, ${t('callSlot', { n: pos + 1 })}` : ''
                         }`}
-                        data-testid={`call-rank-${card.value}-${i}`}
                       >
-                        {rankLabel(card.value)}
-                        {isSelected ? ` (${t('callSlot', { n: pos + 1 })})` : ''}
+                        <CardImage card={card} width={cardWidth} />
+                        {isSelected && (
+                          <span
+                            className="absolute -top-2 -right-2 flex h-6 w-6 items-center justify-center rounded-full bg-ds-warning text-black text-xs font-bold shadow"
+                            aria-hidden="true"
+                            data-testid={`call-order-badge-${card.value}-${i}`}
+                          >
+                            {pos + 1}
+                          </span>
+                        )}
                       </button>
                     );
                   })}


### PR DESCRIPTION
## 概要
ファロの CALL フェーズで、順序指定用の別ボタン列を廃止し、カード画像を直接タップして順序を指定できるようにした（#3568）。

これまでは残り3枚を `CardImage` の列で表示した直後に、同じランクの文字だけを並べた別のボタン列（`call-rank-*`）で `toggleCallCard` を呼んでいたため、どのカードを何番目に選んだかが視覚的に追いにくかった。カード画像そのものをボタン化し、選択済みカードの右上に「1」「2」「3」の順序バッジをオーバーレイ表示するように統合した。

## 変更点
- カード画像を `<button>` でラップし、タップで順序トグル（既存の index ベース `callOrder` ロジックをそのまま流用）
- 選択済みカードの右上に順序バッジ（`call-order-badge-<value>-<i>`）を表示
- 下段のランクボタン列（`call-rank-*`）を削除
- a11y: `aria-pressed` と、ランク名＋選択位置を読み上げる `aria-label`、`focusRingWhite` によるキーボードフォーカスリング
- 同ランク複数枚でも index 単位で正しく選択（既存ロジックを維持）

## 受け入れ条件
- [x] CALL フェーズでカード画像タップにより順序を指定・解除できる
- [x] 選択済みカードに選択順バッジが表示される
- [x] 同ランクが複数枚あってもインデックス単位で正しく選択できる
- [x] `FaroPage.test.tsx` にカードタップでの順序指定テストを追加

## テスト
- `bun run check` — Faro 関連の警告なし（既存の警告は他ファイル）
- `bun run test -- --run Faro` — 44 tests passed
- `bun run build` — success

Closes #3568