### PR TITLE
fix(threecardbrag): clamp raise stepper to stake/chip bounds and sync with stake

### DIFF
--- a/frontend/src/i18n/locales/en/threecardbrag.json
+++ b/frontend/src/i18n/locales/en/threecardbrag.json
@@ -45,6 +45,8 @@
   "raisePrompt": "Raise to:",
   "raiseDecrease": "Decrease raise amount",
   "raiseIncrease": "Increase raise amount",
+  "raiseRange": "Range: {{min}}-{{max}}",
+  "raiseUnavailable": "Not enough chips to raise",
   "foldButton": "Fold",
   "showButton": "Show",
   "nextRound": "Next Deal",

--- a/frontend/src/i18n/locales/ja/threecardbrag.json
+++ b/frontend/src/i18n/locales/ja/threecardbrag.json
@@ -45,6 +45,8 @@
   "raisePrompt": "レイズ額:",
   "raiseDecrease": "レイズ額を減らす",
   "raiseIncrease": "レイズ額を増やす",
+  "raiseRange": "範囲: {{min}}〜{{max}}",
+  "raiseUnavailable": "チップ不足のためレイズできません",
   "foldButton": "フォールド",
   "showButton": "ショー",
   "nextRound": "次のディール",

--- a/frontend/src/pages/ThreeCardBragPage.test.tsx
+++ b/frontend/src/pages/ThreeCardBragPage.test.tsx
@@ -82,6 +82,210 @@ describe('ThreeCardBragPage', () => {
     expect(dec).toBeEnabled();
   });
 
+  it('shows the raise range (min-max) beside the stepper', async () => {
+    // Blind, stake 3, chips 40 -> min 4, max 40.
+    mockExec.mockResolvedValue(
+      makeThreeCardBragState({
+        phase: 0,
+        currentPlayerIdx: 0,
+        isHumanTurn: true,
+        stake: 3,
+        players: [
+          {
+            id: 0,
+            isHuman: true,
+            chips: 40,
+            seen: false,
+            folded: false,
+            out: false,
+            roundBet: 1,
+            cardCount: 3,
+            cards: [],
+          },
+          {
+            id: 1,
+            isHuman: false,
+            chips: 100,
+            seen: false,
+            folded: false,
+            out: false,
+            roundBet: 1,
+            cardCount: 3,
+            cards: [],
+          },
+          {
+            id: 2,
+            isHuman: false,
+            chips: 100,
+            seen: false,
+            folded: false,
+            out: false,
+            roundBet: 1,
+            cardCount: 3,
+            cards: [],
+          },
+          {
+            id: 3,
+            isHuman: false,
+            chips: 100,
+            seen: false,
+            folded: false,
+            out: false,
+            roundBet: 1,
+            cardCount: 3,
+            cards: [],
+          },
+        ],
+      }),
+    );
+    renderWithProviders(<ThreeCardBragPage />);
+    const range = await screen.findByTestId('tcb-raise-range');
+    expect(range).toHaveTextContent('範囲: 4〜40');
+    // Value syncs to the stake-based minimum.
+    expect(screen.getByTestId('tcb-raise-amount')).toHaveTextContent('4');
+  });
+
+  it('halves the max for a Seen player and clamps the amount within it', async () => {
+    // Seen, stake 2, chips 20 -> min 3, max 10.
+    mockExec.mockResolvedValue(
+      makeThreeCardBragState({
+        phase: 0,
+        currentPlayerIdx: 0,
+        isHumanTurn: true,
+        stake: 2,
+        players: [
+          {
+            id: 0,
+            isHuman: true,
+            chips: 20,
+            seen: true,
+            folded: false,
+            out: false,
+            roundBet: 1,
+            cardCount: 3,
+            cards: [],
+          },
+          {
+            id: 1,
+            isHuman: false,
+            chips: 100,
+            seen: false,
+            folded: false,
+            out: false,
+            roundBet: 1,
+            cardCount: 3,
+            cards: [],
+          },
+          {
+            id: 2,
+            isHuman: false,
+            chips: 100,
+            seen: false,
+            folded: false,
+            out: false,
+            roundBet: 1,
+            cardCount: 3,
+            cards: [],
+          },
+          {
+            id: 3,
+            isHuman: false,
+            chips: 100,
+            seen: false,
+            folded: false,
+            out: false,
+            roundBet: 1,
+            cardCount: 3,
+            cards: [],
+          },
+        ],
+      }),
+    );
+    renderWithProviders(<ThreeCardBragPage />);
+    const range = await screen.findByTestId('tcb-raise-range');
+    expect(range).toHaveTextContent('範囲: 3〜10');
+    const inc = screen.getByRole('button', { name: 'レイズ額を増やす' });
+    const amount = screen.getByTestId('tcb-raise-amount');
+    // Click far past the max; the amount must never exceed 10.
+    for (let i = 0; i < 20; i++) fireEvent.click(inc);
+    expect(amount).toHaveTextContent('10');
+    // The increase button is disabled once the max is reached.
+    expect(inc).toBeDisabled();
+  });
+
+  it('does not step below the stake-based minimum', async () => {
+    mockExec.mockResolvedValue(makeThreeCardBragState({ phase: 0, currentPlayerIdx: 0, isHumanTurn: true, stake: 5 }));
+    renderWithProviders(<ThreeCardBragPage />);
+    const amount = await screen.findByTestId('tcb-raise-amount');
+    expect(amount).toHaveTextContent('6'); // stake + 1
+    const dec = screen.getByRole('button', { name: 'レイズ額を減らす' });
+    expect(dec).toBeDisabled();
+    for (let i = 0; i < 10; i++) fireEvent.click(dec);
+    expect(amount).toHaveTextContent('6');
+  });
+
+  it('disables the raise button and shows unavailable when chips are too low', async () => {
+    // Seen, stake 2, chips 4 -> min 3, max 2 -> no legal raise.
+    mockExec.mockResolvedValue(
+      makeThreeCardBragState({
+        phase: 0,
+        currentPlayerIdx: 0,
+        isHumanTurn: true,
+        stake: 2,
+        players: [
+          {
+            id: 0,
+            isHuman: true,
+            chips: 4,
+            seen: true,
+            folded: false,
+            out: false,
+            roundBet: 1,
+            cardCount: 3,
+            cards: [],
+          },
+          {
+            id: 1,
+            isHuman: false,
+            chips: 100,
+            seen: false,
+            folded: false,
+            out: false,
+            roundBet: 1,
+            cardCount: 3,
+            cards: [],
+          },
+          {
+            id: 2,
+            isHuman: false,
+            chips: 100,
+            seen: false,
+            folded: false,
+            out: false,
+            roundBet: 1,
+            cardCount: 3,
+            cards: [],
+          },
+          {
+            id: 3,
+            isHuman: false,
+            chips: 100,
+            seen: false,
+            folded: false,
+            out: false,
+            roundBet: 1,
+            cardCount: 3,
+            cards: [],
+          },
+        ],
+      }),
+    );
+    renderWithProviders(<ThreeCardBragPage />);
+    const range = await screen.findByTestId('tcb-raise-range');
+    expect(range).toHaveTextContent('チップ不足のためレイズできません');
+    expect(screen.getByRole('button', { name: /レイズ \(/ })).toBeDisabled();
+  });
+
   it('dispatches fold when the Fold button is clicked', async () => {
     renderWithProviders(<ThreeCardBragPage />);
     const btn = await screen.findByRole('button', { name: 'フォールド' });

--- a/frontend/src/pages/ThreeCardBragPage.tsx
+++ b/frontend/src/pages/ThreeCardBragPage.tsx
@@ -35,6 +35,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { parseThreeCardBragCommand, THREE_CARD_BRAG_HELP } from '../utils/cli/commands/threeCardBragCommands';
 import { formatThreeCardBragState } from '../utils/cli/formatters/threeCardBragFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { clampThreeCardBragRaise, threeCardBragRaiseBounds } from '../utils/threeCardBragRaise';
 
 /** Three Card Brag tutorial step definitions. */
 const THREE_CARD_BRAG_TUTORIAL_STEPS: TutorialStep[] = [
@@ -108,11 +109,27 @@ function ThreeCardBragPageContent() {
   // Raise stake amount (local UI state).
   const [raiseStake, setRaiseStake] = useState(2);
 
+  // Raise bounds mirror the CUI (ThreeCardBragCuiPresenter.threeCardBragRaiseRangeStr):
+  // min = stake + 1; max = affordable ceiling (Seen players pay double, halving it).
+  const humanForBounds = state?.players.find((p) => p.isHuman);
+  const {
+    min: raiseMin,
+    max: raiseMax,
+    canRaise,
+  } = threeCardBragRaiseBounds(state?.stake ?? 0, humanForBounds?.chips ?? 0, humanForBounds?.seen ?? false);
+
   // Fetch a fresh game on mount.
   // biome-ignore lint/correctness/useExhaustiveDependencies: reset is stable per render of the hook; run once on mount.
   useEffect(() => {
     reset();
   }, []);
+
+  // Keep the raise amount synced to the current stake/chip bounds: when the
+  // stake rises (or chips/seen change) re-clamp so it never sits below min or
+  // above the affordable max.
+  useEffect(() => {
+    setRaiseStake((a) => clampThreeCardBragRaise(a, raiseMin, raiseMax));
+  }, [raiseMin, raiseMax]);
 
   // CLI mode
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('threecardbrag');
@@ -340,12 +357,12 @@ function ThreeCardBragPageContent() {
                   <button type="button" className={btnPrimary} onClick={handleBet} disabled={loading}>
                     {t('betButton', { amount: state.stake })}
                   </button>
-                  <div className="flex items-center gap-1">
+                  <div className="flex items-center gap-1" data-testid="tcb-raise-controls">
                     <button
                       type="button"
                       className={btnSecondary}
-                      onClick={() => setRaiseStake((a) => Math.max(state.stake + 1, a - 1))}
-                      disabled={loading}
+                      onClick={() => setRaiseStake((a) => clampThreeCardBragRaise(a - 1, raiseMin, raiseMax))}
+                      disabled={loading || !canRaise || raiseStake <= raiseMin}
                       aria-label={t('raiseDecrease')}
                     >
                       −
@@ -360,8 +377,8 @@ function ThreeCardBragPageContent() {
                     <button
                       type="button"
                       className={btnSecondary}
-                      onClick={() => setRaiseStake((a) => a + 1)}
-                      disabled={loading}
+                      onClick={() => setRaiseStake((a) => clampThreeCardBragRaise(a + 1, raiseMin, raiseMax))}
+                      disabled={loading || !canRaise || raiseStake >= raiseMax}
                       aria-label={t('raiseIncrease')}
                     >
                       ＋
@@ -370,10 +387,13 @@ function ThreeCardBragPageContent() {
                       type="button"
                       className={btnWarning}
                       onClick={() => handleRaise(raiseStake)}
-                      disabled={loading}
+                      disabled={loading || !canRaise || raiseStake < raiseMin || raiseStake > raiseMax}
                     >
                       {t('raiseButton', { amount: raiseStake })}
                     </button>
+                    <span className="text-ds-text-muted text-xs ml-1" data-testid="tcb-raise-range">
+                      {canRaise ? t('raiseRange', { min: raiseMin, max: raiseMax }) : t('raiseUnavailable')}
+                    </span>
                   </div>
                   <button type="button" className={btnDanger} onClick={handleFold} disabled={loading}>
                     {t('foldButton')}

--- a/frontend/src/utils/threeCardBragRaise.test.ts
+++ b/frontend/src/utils/threeCardBragRaise.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { clampThreeCardBragRaise, threeCardBragRaiseBounds } from './threeCardBragRaise';
+
+describe('threeCardBragRaiseBounds', () => {
+  it('sets min to stake + 1', () => {
+    expect(threeCardBragRaiseBounds(5, 100, false).min).toBe(6);
+  });
+
+  it('caps a Blind player at their full chip count', () => {
+    const b = threeCardBragRaiseBounds(2, 40, false);
+    expect(b.max).toBe(40);
+    expect(b.canRaise).toBe(true);
+  });
+
+  it('halves the ceiling for a Seen player (they pay double)', () => {
+    expect(threeCardBragRaiseBounds(2, 41, true).max).toBe(20);
+  });
+
+  it('reports canRaise=false when chips are too low', () => {
+    // Seen with 4 chips: max = 2, min = stake + 1 = 3 -> no legal raise.
+    const b = threeCardBragRaiseBounds(2, 4, true);
+    expect(b.max).toBe(2);
+    expect(b.canRaise).toBe(false);
+  });
+});
+
+describe('clampThreeCardBragRaise', () => {
+  it('clamps values below min up to min', () => {
+    expect(clampThreeCardBragRaise(1, 3, 50)).toBe(3);
+  });
+
+  it('clamps values above max down to max', () => {
+    expect(clampThreeCardBragRaise(99, 3, 50)).toBe(50);
+  });
+
+  it('leaves in-range values unchanged', () => {
+    expect(clampThreeCardBragRaise(10, 3, 50)).toBe(10);
+  });
+
+  it('returns min when no legal raise exists (max < min)', () => {
+    expect(clampThreeCardBragRaise(10, 5, 2)).toBe(5);
+  });
+});

--- a/frontend/src/utils/threeCardBragRaise.ts
+++ b/frontend/src/utils/threeCardBragRaise.ts
@@ -1,0 +1,45 @@
+/**
+ * Three Card Brag raise-amount bounds, mirroring the CUI guidance in
+ * `ThreeCardBragCuiPresenter.threeCardBragRaiseRangeStr`.
+ */
+export interface ThreeCardBragRaiseBounds {
+  /** Smallest legal raise (must exceed the current stake). */
+  min: number;
+  /** Largest raise the player can afford. */
+  max: number;
+  /** Whether any legal raise exists (`max >= min`). */
+  canRaise: boolean;
+}
+
+/**
+ * Computes the legal raise range for the human at a Brag betting turn.
+ *
+ * The minimum is always `stake + 1` (a raise must exceed the current stake).
+ * The maximum is the largest stake the player can afford to call: a Seen
+ * player pays double the stake, halving the affordable ceiling, so the cap is
+ * `floor(chips / 2)`; a Blind player's cap is their full chip count.
+ *
+ * @param stake - The current stake.
+ * @param chips - The human player's remaining chips.
+ * @param seen - Whether the human has looked at their hand (Seen vs Blind).
+ * @returns The `{ min, max, canRaise }` bounds.
+ */
+export function threeCardBragRaiseBounds(stake: number, chips: number, seen: boolean): ThreeCardBragRaiseBounds {
+  const min = stake + 1;
+  const max = seen ? Math.floor(chips / 2) : chips;
+  return { min, max, canRaise: max >= min };
+}
+
+/**
+ * Clamps a raise amount into the `[min, max]` range. When no legal raise
+ * exists (`max < min`), returns `min` so the value never drops below the stake.
+ *
+ * @param value - The candidate raise amount.
+ * @param min - The minimum legal raise.
+ * @param max - The maximum affordable raise.
+ * @returns The clamped raise amount.
+ */
+export function clampThreeCardBragRaise(value: number, min: number, max: number): number {
+  if (max < min) return min;
+  return Math.min(Math.max(value, min), max);
+}


### PR DESCRIPTION
## 概要
Three Card Brag のレイズ額ステッパーに範囲バリデーションとステーク同期を追加。従来は `raiseStake` が `useState(2)` 固定で、上限（所持チップ／シーン時は半分）の検証がなく、ステーク上昇後も古い値が残っていた。

## 変更内容
- **純粋ヘルパー** `frontend/src/utils/threeCardBragRaise.ts`（+テスト）: `stake`/`chips`/`seen` から `{ min, max, canRaise }` を算出し、値を範囲内へクランプ。CUI の `ThreeCardBragCuiPresenter.threeCardBragRaiseRangeStr` と同一のロジック。
  - `min = stake + 1`
  - `max = seen ? floor(chips / 2) : chips`（シーンはコールに倍額を払うため上限が半分）
  - `max < min` のときレイズ不可
- **`ThreeCardBragPage.tsx`**:
  - ステーク／チップ／seen 変化時に `raiseStake` を範囲へ再クランプ（下限 `stake+1` 未満・上限超過を防止）。
  - − ボタンは下限で、＋ ボタンは上限で disabled。
  - レイズボタンは範囲外・レイズ不可時に disabled。
  - ステッパー横に許容範囲 `min〜max`（不可時は「チップ不足」）を表示。
- i18n（ja/en 同期）: `raiseRange` / `raiseUnavailable` を追加。

## 受け入れ条件
- [x] ステーク上昇後に raiseStake が stake+1 未満にならない
- [x] 上限超過時にレイズボタンが disabled になる
- [x] seen/blind で上限計算が切り替わり範囲表示される
- [x] ページテストに範囲表示・disabled のケースを追加し green

## テスト
- `bun run check` / `bun run test -- --run ThreeCardBrag`（63 passed）/ `bun run build` すべて green
- 追加: ステッパーのクランプ（下限・上限）、ステーク変化での再同期、範囲外レイズの submit 防止

Closes #3457