### PR TITLE
feat(bouillotte): show pot odds at the call/raise/fold decision

### DIFF
--- a/frontend/src/i18n/locales/en/bouillotte.json
+++ b/frontend/src/i18n/locales/en/bouillotte.json
@@ -38,8 +38,14 @@
     "highcard": "High card"
   },
   "callButton": "Call",
+  "callButtonAmount": "Call ({{amount}})",
   "raiseButton": "Raise (Vie)",
+  "raiseButtonAmount": "Raise / Vie ({{amount}})",
   "foldButton": "Fold",
+  "potOdds": {
+    "value": "Pot odds: call {{call}} into pot {{pot}} — {{percentage}}% ({{ratioPot}}:{{ratioCall}})",
+    "free": "No chips to call — you can stay in for free (check)."
+  },
   "nextRound": "Next Round",
   "roundResult": {
     "title": "Round Result",

--- a/frontend/src/i18n/locales/ja/bouillotte.json
+++ b/frontend/src/i18n/locales/ja/bouillotte.json
@@ -38,8 +38,14 @@
     "highcard": "ハイカード"
   },
   "callButton": "コール",
+  "callButtonAmount": "コール（{{amount}}）",
   "raiseButton": "レイズ（ヴィ）",
+  "raiseButtonAmount": "レイズ／ヴィ（{{amount}}）",
   "foldButton": "フォールド（降りる）",
+  "potOdds": {
+    "value": "ポットオッズ: ポット {{pot}} にコール {{call}} — {{percentage}}%（{{ratioPot}}:{{ratioCall}}）",
+    "free": "コール不要 — 追加投資なしで参加できます（チェック）。"
+  },
   "nextRound": "次のラウンド",
   "roundResult": {
     "title": "ラウンド結果",

--- a/frontend/src/pages/BouillottePage.test.tsx
+++ b/frontend/src/pages/BouillottePage.test.tsx
@@ -113,7 +113,7 @@ describe('BouillottePage', () => {
   it('shows the betting action buttons on the human betting turn', async () => {
     renderWithProviders(<BouillottePage />);
     await waitFor(() => expect(screen.getByRole('button', { name: 'コール' })).toBeInTheDocument());
-    expect(screen.getByRole('button', { name: 'レイズ（ヴィ）' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /レイズ／ヴィ/ })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'フォールド（降りる）' })).toBeInTheDocument();
   });
 
@@ -127,7 +127,7 @@ describe('BouillottePage', () => {
 
   it('dispatches bet raise when the Raise button is clicked', async () => {
     renderWithProviders(<BouillottePage />);
-    const btn = await screen.findByRole('button', { name: 'レイズ（ヴィ）' });
+    const btn = await screen.findByRole('button', { name: /レイズ／ヴィ/ });
     mockExec.mockClear();
     fireEvent.click(btn);
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('bet', 'raise'));
@@ -153,7 +153,7 @@ describe('BouillottePage', () => {
     mockExec.mockResolvedValue(makeBouillotteState({ phase: 0, isHumanTurn: true, canRaise: false }));
     renderWithProviders(<BouillottePage />);
     await waitFor(() => expect(screen.getByRole('button', { name: 'コール' })).toBeInTheDocument());
-    expect(screen.queryByRole('button', { name: 'レイズ（ヴィ）' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /レイズ／ヴィ/ })).not.toBeInTheDocument();
   });
 
   it('shows the next-round button at the result phase and dispatches nextround', async () => {
@@ -223,6 +223,34 @@ describe('BouillottePage', () => {
     expect(screen.getByTestId('hand-card-0').className).toContain('ring-ds-accent');
     expect(screen.getByTestId('hand-card-1').className).toContain('ring-ds-accent');
     expect(screen.getByTestId('hand-card-2').className).not.toContain('ring-ds-accent');
+  });
+
+  it('shows the pot odds and call amount when chips are owed to call', async () => {
+    // pot 40, currentBet 20, human roundBet 10 -> call 10 into pot 40:
+    // odds 10 / (40 + 10) = 20%, ratio 40:10 -> 4:1.
+    const oddsState = makeBouillotteState({
+      phase: 0,
+      isHumanTurn: true,
+      canRaise: true,
+      pot: 40,
+      currentBet: 20,
+    });
+    mockExec.mockResolvedValue(oddsState);
+    renderWithProviders(<BouillottePage />);
+    const odds = await screen.findByTestId('bouillotte-pot-odds');
+    expect(odds.textContent).toContain('20%');
+    expect(odds.textContent).toContain('4:1');
+    // The Call button spells out the required amount.
+    expect(screen.getByRole('button', { name: 'コール（10）' })).toBeInTheDocument();
+  });
+
+  it('shows the free-check state when nothing is owed to call', async () => {
+    // Default betting state: currentBet 10 equals the human's roundBet 10 -> call 0.
+    renderWithProviders(<BouillottePage />);
+    const odds = await screen.findByTestId('bouillotte-pot-odds');
+    expect(odds.textContent).toContain('コール不要');
+    // With nothing owed the Call button shows the plain label (no amount).
+    expect(screen.getByRole('button', { name: 'コール' })).toBeInTheDocument();
   });
 
   it('does not highlight any card when no hand card matches the retourne', async () => {

--- a/frontend/src/pages/BouillottePage.tsx
+++ b/frontend/src/pages/BouillottePage.tsx
@@ -32,6 +32,7 @@ import { gameTheme } from '../styles/gameTheme';
 import type { BouillotteResponse } from '../types/card';
 import { BouillottePhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { computeBouillottePotOdds } from '../utils/bouillottePotOdds';
 import { analyzeRetourneMatch } from '../utils/bouillotteRetourne';
 import { BOUILLOTTE_HELP, parseBouillotteCommand } from '../utils/cli/commands/bouillotteCommands';
 import { formatBouillotteState } from '../utils/cli/formatters/bouillotteFormatter';
@@ -123,6 +124,11 @@ function BouillottePageContent() {
 
   const humanPlayer = state.players.find((p) => p.isHuman);
   const humanIdx = state.players.findIndex((p) => p.isHuman);
+
+  // Pot odds and chip costs facing the human at the Call/Raise/Fold decision.
+  const humanRoundBet = humanPlayer?.roundBet ?? 0;
+  const potOdds = computeBouillottePotOdds(state.pot, state.currentBet, humanRoundBet);
+  const raiseCost = Math.max(0, state.currentBet + state.ante - humanRoundBet);
 
   // Which of the human's cards share the retourne's rank, and any combo it completes.
   const retourneMatch = analyzeRetourneMatch(humanPlayer?.cards ?? [], state.retourne);
@@ -344,15 +350,29 @@ function BouillottePageContent() {
               <HintTooltip reason={t(frontendHint.reason)} confidence={frontendHint.confidence} />
             )}
 
+            {isBettingPhase && isHumanTurn && !isGameEnd && (
+              <div className="mb-2 text-ds-text-muted text-sm" data-testid="bouillotte-pot-odds" aria-live="polite">
+                {potOdds.isFree
+                  ? t('potOdds.free')
+                  : t('potOdds.value', {
+                      call: potOdds.callAmount,
+                      pot: state.pot,
+                      percentage: potOdds.percentage,
+                      ratioPot: potOdds.ratioPot,
+                      ratioCall: potOdds.ratioCall,
+                    })}
+              </div>
+            )}
+
             <div className="flex flex-wrap gap-2 items-center" data-tutorial="bouillotte-action-buttons">
               {isBettingPhase && isHumanTurn && !isGameEnd && (
                 <>
                   <button type="button" className={btnPrimary} onClick={handleCall} disabled={loading}>
-                    {t('callButton')}
+                    {potOdds.isFree ? t('callButton') : t('callButtonAmount', { amount: potOdds.callAmount })}
                   </button>
                   {state.canRaise && (
                     <button type="button" className={btnSuccess} onClick={handleRaise} disabled={loading}>
-                      {t('raiseButton')}
+                      {t('raiseButtonAmount', { amount: raiseCost })}
                     </button>
                   )}
                   <button type="button" className={btnDanger} onClick={handleFold} disabled={loading}>

--- a/frontend/src/utils/bouillottePotOdds.test.ts
+++ b/frontend/src/utils/bouillottePotOdds.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { computeBouillottePotOdds } from './bouillottePotOdds';
+
+describe('computeBouillottePotOdds', () => {
+  it('computes percentage and simplified ratio for a known pot and call', () => {
+    // Human already wagered 10, must reach 20 -> call 10 into a pot of 40.
+    // Pot odds: 10 / (40 + 10) = 20%, ratio 40:10 -> 4:1.
+    const odds = computeBouillottePotOdds(40, 20, 10);
+    expect(odds).toEqual({
+      callAmount: 10,
+      isFree: false,
+      percentage: 20,
+      ratioPot: 4,
+      ratioCall: 1,
+    });
+  });
+
+  it('rounds the percentage to one decimal place', () => {
+    // call 10 into pot 20 -> 10 / 30 = 33.333...% -> 33.3%.
+    const odds = computeBouillottePotOdds(20, 20, 10);
+    expect(odds.percentage).toBe(33.3);
+    expect(odds.ratioPot).toBe(2);
+    expect(odds.ratioCall).toBe(1);
+  });
+
+  it('reports a free check when nothing is owed (call amount 0)', () => {
+    const odds = computeBouillottePotOdds(40, 10, 10);
+    expect(odds).toEqual({
+      callAmount: 0,
+      isFree: true,
+      percentage: 0,
+      ratioPot: 0,
+      ratioCall: 0,
+    });
+  });
+
+  it('treats an already-matched bet (roundBet > currentBet) as free', () => {
+    const odds = computeBouillottePotOdds(40, 10, 20);
+    expect(odds.isFree).toBe(true);
+    expect(odds.callAmount).toBe(0);
+  });
+
+  it('handles an empty pot: call is the whole resulting pot (100%)', () => {
+    const odds = computeBouillottePotOdds(0, 10, 0);
+    expect(odds.percentage).toBe(100);
+    expect(odds.ratioPot).toBe(0);
+    expect(odds.ratioCall).toBe(1);
+  });
+});

--- a/frontend/src/utils/bouillottePotOdds.ts
+++ b/frontend/src/utils/bouillottePotOdds.ts
@@ -1,0 +1,50 @@
+/** Pot-odds figures for the Bouillotte Call/Raise/Fold decision. */
+export interface BouillottePotOdds {
+  /** Chips the human must add to call (`currentBet - roundBet`, floored at 0). */
+  callAmount: number;
+  /** True when nothing is owed to stay in (a free check); no odds are shown. */
+  isFree: boolean;
+  /** Call cost as a share of the resulting pot, as a percentage rounded to 1 decimal. */
+  percentage: number;
+  /** Simplified pot side of the `pot : call` odds ratio. */
+  ratioPot: number;
+  /** Simplified call side of the `pot : call` odds ratio. */
+  ratioCall: number;
+}
+
+/** Greatest common divisor (non-negative integers) for simplifying the odds ratio. */
+function gcd(a: number, b: number): number {
+  return b === 0 ? a : gcd(b, a % b);
+}
+
+/**
+ * Computes the pot odds facing the human at the Bouillotte betting decision.
+ *
+ * The amount to call is `currentBet - roundBet` (chips already wagered this
+ * round). Pot odds are `call / (pot + call)`, i.e. the fraction of the resulting
+ * pot the call represents, expressed as a percentage and as a simplified
+ * `pot : call` ratio. When nothing is owed the result is a free check
+ * (`isFree`), for which no odds are meaningful.
+ *
+ * @param pot - Chips already in the pot (includes every player's wagers so far).
+ * @param currentBet - Total per-player contribution required to stay in.
+ * @param roundBet - Chips the human has already wagered this round.
+ * @returns The pot-odds figures for display.
+ */
+export function computeBouillottePotOdds(pot: number, currentBet: number, roundBet: number): BouillottePotOdds {
+  const callAmount = Math.max(0, currentBet - roundBet);
+  if (callAmount <= 0) {
+    return { callAmount: 0, isFree: true, percentage: 0, ratioPot: 0, ratioCall: 0 };
+  }
+  const safePot = Math.max(0, pot);
+  const total = safePot + callAmount;
+  const percentage = Math.round((callAmount / total) * 1000) / 10;
+  const divisor = gcd(safePot, callAmount) || 1;
+  return {
+    callAmount,
+    isFree: false,
+    percentage,
+    ratioPot: safePot / divisor,
+    ratioCall: callAmount / divisor,
+  };
+}


### PR DESCRIPTION
## Summary

Adds a neutral, informational **pot-odds display** to the Bouillotte betting phase so the human's Call/Raise/Fold decision has a numeric basis (issue #3481). This is a standard poker-odds computation shown from already-exposed state — no game advice, no backend changes.

- New pure helper `computeBouillottePotOdds(pot, currentBet, roundBet)` in `frontend/src/utils/bouillottePotOdds.ts`:
  - call amount = `currentBet - roundBet` (floored at 0)
  - pot odds = `call / (pot + call)` → percentage (1 decimal) + simplified `pot : call` ratio (via gcd)
  - zero call → `isFree` free-check state (no odds shown); handles empty pot (100%)
- `BouillottePage.tsx`: during the human betting turn, renders a `data-testid="bouillotte-pot-odds"` block (percentage + ratio, or the free-check message), and spells out the required chip amount on the **Call** and **Raise (Vie)** buttons.
- i18n: added `callButtonAmount`, `raiseButtonAmount`, and `potOdds.{value,free}` to ja + en (parity).

## How the odds are computed

All values come straight from the exposed response: `state.pot`, `state.currentBet`, and the human player's `roundBet`. Confirmed against `internal/domain/Bouillotte.go` (read-only): `need := currentBet - roundBet` is exactly the amount to call, and `pot` already includes every player's wagers. No Go changes.

## Tests

- `frontend/src/utils/bouillottePotOdds.test.ts` — known pot+call → 20% / 4:1, 1-decimal rounding, free-check on zero/already-matched call, empty-pot 100%.
- `frontend/src/pages/BouillottePage.test.tsx` — `shows the pot odds and call amount when chips are owed to call` (asserts `20%` + `4:1` + `コール（10）`) and `shows the free-check state when nothing is owed to call`.

## Checklist

- [x] `bun run check` (biome + design tokens)
- [x] `bun run test -- --run Bouillotte` (69 passed)
- [x] `bun run build` (tsc)
- [x] ja + en i18n parity
- [x] Design-system tokens only; no Go changes

Closes #3481