### PR TITLE
feat(wizard): add bid-vs-actual accuracy summary at round end

### DIFF
--- a/frontend/src/i18n/locales/en/wizard.json
+++ b/frontend/src/i18n/locales/en/wizard.json
@@ -33,6 +33,12 @@
     "under": "(under)",
     "exact": "(exact)"
   },
+  "bidAccuracy": {
+    "title": "Bid accuracy (previous round)",
+    "made": "Made",
+    "over": "+{{delta}} over",
+    "under": "{{delta}} under"
+  },
   "currentTrick": "Current Trick",
   "scores": "Scores",
   "scoresPlayer": "Player",

--- a/frontend/src/i18n/locales/ja/wizard.json
+++ b/frontend/src/i18n/locales/ja/wizard.json
@@ -33,6 +33,12 @@
     "under": "(アンダー)",
     "exact": "(ぴったり)"
   },
+  "bidAccuracy": {
+    "title": "ビッド的中サマリー（前ラウンド）",
+    "made": "的中",
+    "over": "+{{delta}} 超過",
+    "under": "{{delta}} 不足"
+  },
   "currentTrick": "現在のトリック",
   "scores": "スコア",
   "scoresPlayer": "プレイヤー",

--- a/frontend/src/pages/WizardPage.test.tsx
+++ b/frontend/src/pages/WizardPage.test.tsx
@@ -126,6 +126,18 @@ const cpuTurnState: WizardResponse = {
   currentPlayerIdx: 1,
 };
 
+/** Round end where the human made their bid exactly and CPUs over/undershoot. */
+const bidAccuracyRoundEndState: WizardResponse = {
+  ...playPhaseState,
+  phase: 3,
+  players: [
+    { ...playPhaseState.players[0], bid: 3, trickCount: 3 },
+    { ...playPhaseState.players[1], bid: 2, trickCount: 4 },
+    { ...playPhaseState.players[2], bid: 2, trickCount: 1 },
+    { ...playPhaseState.players[3], bid: 1, trickCount: 2 },
+  ],
+};
+
 beforeEach(() => {
   mockExec.mockResolvedValue(playPhaseState);
 });
@@ -337,6 +349,25 @@ describe('WizardPage', () => {
     mockExec.mockResolvedValue(roundEndState);
     renderWithProviders(<WizardPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: '次のラウンド' })).toBeInTheDocument());
+  });
+
+  it('shows bid-accuracy summary at round end with made/over/under outcomes', async () => {
+    mockExec.mockResolvedValue(bidAccuracyRoundEndState);
+    renderWithProviders(<WizardPage />);
+    await waitFor(() => expect(screen.getByTestId('wiz-bid-accuracy')).toBeInTheDocument());
+    // Human bid 3, took 3 -> exact hit.
+    expect(screen.getByText('的中')).toBeInTheDocument();
+    // CPU 1 bid 2, took 4 -> +2 overshoot delta.
+    expect(screen.getByText('+2 超過')).toBeInTheDocument();
+    // CPU 2 bid 2, took 1 -> -1 undershoot delta.
+    expect(screen.getByText('-1 不足')).toBeInTheDocument();
+  });
+
+  it('does not show the bid-accuracy summary during play', async () => {
+    mockExec.mockResolvedValue(playPhaseState);
+    renderWithProviders(<WizardPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'リセット' })).not.toBeDisabled());
+    expect(screen.queryByTestId('wiz-bid-accuracy')).not.toBeInTheDocument();
   });
 
   it('shows game end with action log button', async () => {

--- a/frontend/src/pages/WizardPage.tsx
+++ b/frontend/src/pages/WizardPage.tsx
@@ -40,6 +40,7 @@ import { formatWizardState } from '../utils/cli/formatters/wizardFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
 import { ohHellBidSummary } from '../utils/ohHellBid';
 import { playerName } from '../utils/playerUtils';
+import { type WizardBidOutcome, wizardBidAccuracy } from '../utils/wizardBidAccuracy';
 import { isWizardLegalPlay } from '../utils/wizardLegal';
 
 /** DOM id linking each illegal card button to the shared screen-reader reason text. */
@@ -90,6 +91,12 @@ function progressChipColors(bid: number, won: number, remainingTricks: number): 
   if (won === bid) return badgeSuccessColors;
   if (won > bid) return badgeWarningColors;
   return bid - won > remainingTricks ? badgeErrorColors : badgeInfoColors;
+}
+
+/** Badge color tokens for a bid-accuracy outcome pill: green made, yellow overshot, red undershot. */
+function bidAccuracyPillColors(outcome: WizardBidOutcome): string {
+  if (outcome === 'made') return badgeSuccessColors;
+  return outcome === 'over' ? badgeWarningColors : badgeErrorColors;
 }
 
 const WIZARD_PHASE_KEYS: Readonly<Record<number, string>> = {
@@ -215,6 +222,16 @@ function WizardPageContent() {
           return acc;
         }, [])
       : undefined;
+
+  // At round/game end, `state.players` still carries the finished round's bid and
+  // trickCount, so we can summarize how far each player's actual tricks landed
+  // from their declared bid before the next deal resets them.
+  const showBidAccuracy = isRoundEnd || isGameEnd;
+  const bidAccuracyEntries = showBidAccuracy
+    ? wizardBidAccuracy(
+        state.players.map((p) => ({ name: playerName(p.id, p.isHuman), bid: p.bid, trickCount: p.trickCount })),
+      )
+    : [];
 
   return (
     <GamePageShell
@@ -451,6 +468,33 @@ function WizardPageContent() {
                     cumulativeScore: p.cumulativeScore,
                   }))}
                 />
+
+                {/* Bid-vs-actual accuracy summary for the just-finished round. */}
+                {showBidAccuracy && bidAccuracyEntries.length > 0 && (
+                  <div className="my-3 p-2 rounded bg-black/30" data-testid="wiz-bid-accuracy">
+                    <div className="text-ds-text-muted text-sm mb-1">{t('bidAccuracy.title')}</div>
+                    <ul className="flex flex-col gap-1">
+                      {bidAccuracyEntries.map((e) => (
+                        <li
+                          key={e.name}
+                          className="flex items-center justify-between gap-2 text-sm text-ds-text-muted"
+                          data-testid={`wiz-bid-accuracy-row-${e.outcome}`}
+                        >
+                          <span className="truncate">
+                            {e.name}: {t('scoresBid')} {e.bid} / {t('scoresTricks')} {e.trickCount}
+                          </span>
+                          <span
+                            className={`shrink-0 rounded-full px-2 py-0.5 text-xs font-medium ${bidAccuracyPillColors(e.outcome)}`}
+                          >
+                            {e.outcome === 'made'
+                              ? t('bidAccuracy.made')
+                              : t(`bidAccuracy.${e.outcome}`, { delta: e.delta })}
+                          </span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
               </div>
             </div>
 

--- a/frontend/src/utils/wizardBidAccuracy.test.ts
+++ b/frontend/src/utils/wizardBidAccuracy.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { wizardBidAccuracy } from './wizardBidAccuracy';
+
+describe('wizardBidAccuracy', () => {
+  it('marks a player who bid 3 and took 3 as made with zero delta', () => {
+    const [entry] = wizardBidAccuracy([{ name: 'You', bid: 3, trickCount: 3 }]);
+    expect(entry.outcome).toBe('made');
+    expect(entry.delta).toBe(0);
+  });
+
+  it('reports a +2 delta and over outcome for a player who bid 2 but took 4', () => {
+    const [entry] = wizardBidAccuracy([{ name: 'CPU 1', bid: 2, trickCount: 4 }]);
+    expect(entry.outcome).toBe('over');
+    expect(entry.delta).toBe(2);
+  });
+
+  it('reports a -1 delta and under outcome for a player who bid 2 but took 1', () => {
+    const [entry] = wizardBidAccuracy([{ name: 'CPU 2', bid: 2, trickCount: 1 }]);
+    expect(entry.outcome).toBe('under');
+    expect(entry.delta).toBe(-1);
+  });
+
+  it('handles a bid of 0 that is met exactly', () => {
+    const [entry] = wizardBidAccuracy([{ name: 'CPU 3', bid: 0, trickCount: 0 }]);
+    expect(entry.outcome).toBe('made');
+    expect(entry.delta).toBe(0);
+  });
+
+  it('skips players that never placed a bid', () => {
+    const entries = wizardBidAccuracy([
+      { name: 'You', bid: -1, trickCount: 0 },
+      { name: 'CPU 1', bid: 1, trickCount: 1 },
+    ]);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.name).toBe('CPU 1');
+  });
+
+  it('preserves player order and computes an entry per bidder', () => {
+    const entries = wizardBidAccuracy([
+      { name: 'You', bid: 3, trickCount: 3 },
+      { name: 'CPU 1', bid: 2, trickCount: 4 },
+    ]);
+    expect(entries.map((e) => e.name)).toEqual(['You', 'CPU 1']);
+    expect(entries.map((e) => e.outcome)).toEqual(['made', 'over']);
+  });
+});

--- a/frontend/src/utils/wizardBidAccuracy.ts
+++ b/frontend/src/utils/wizardBidAccuracy.ts
@@ -1,0 +1,38 @@
+/** Bid-vs-actual outcome bucket for one player's just-completed round. */
+export type WizardBidOutcome = 'made' | 'over' | 'under';
+
+/** One player's bid-vs-actual accuracy summary for the completed round. */
+export interface WizardBidAccuracyEntry {
+  name: string;
+  bid: number;
+  trickCount: number;
+  /** Actual tricks minus bid: 0 = exact, positive = overshot, negative = undershot. */
+  delta: number;
+  outcome: WizardBidOutcome;
+}
+
+/** Minimal player shape needed to compute a bid-accuracy entry. */
+export interface WizardBidAccuracyPlayer {
+  name: string;
+  bid: number;
+  trickCount: number;
+}
+
+/**
+ * Summarizes how each player's actual tricks won compares to their bid for the
+ * just-completed Wizard round. Players who never placed a bid (`bid < 0`) are
+ * skipped, since there is no contract to measure against.
+ *
+ * @param players - Players carrying the round's `bid` and `trickCount`.
+ * @returns One entry per bidding player: the signed `delta` (tricks − bid) and
+ *   whether they made their contract exactly, overshot, or undershot it.
+ */
+export function wizardBidAccuracy(players: readonly WizardBidAccuracyPlayer[]): WizardBidAccuracyEntry[] {
+  return players
+    .filter((p) => p.bid >= 0)
+    .map((p) => {
+      const delta = p.trickCount - p.bid;
+      const outcome: WizardBidOutcome = delta === 0 ? 'made' : delta > 0 ? 'over' : 'under';
+      return { name: p.name, bid: p.bid, trickCount: p.trickCount, delta, outcome };
+    });
+}


### PR DESCRIPTION
## 概要
ウィザードのラウンド終了時（`ROUND_END` / ゲーム終了）に、各プレイヤーの宣言（bid）と実際に獲得したトリック数（trickCount）の差分を可視化するサマリーパネルを追加します。CPU の癖や自分の傾向を振り返れるようにします。

バックエンドは一切変更していません。ラウンド終了時点では `state.players` が終了したラウンドの `bid` と `trickCount` をまだ保持しているため、既存レスポンスだけで算出できます。

## 変更内容
- `frontend/src/utils/wizardBidAccuracy.ts`（新規・純粋関数）: プレイヤーごとに `delta = trickCount - bid` と `outcome`（`made` / `over` / `under`）を算出。未ビッド（`bid < 0`）はスキップ。
- `frontend/src/pages/WizardPage.tsx`: `RoundScoreAnnouncement` の直下に加算的なサマリーパネル（`data-testid="wiz-bid-accuracy"`）を追加。的中=緑・超過=黄・不足=赤のバッジトークンで色分け。
- i18n: `bidAccuracy.*` キーを ja / en 双方に追加（パリティ確認済み）。
- テスト: 純粋関数のユニットテストとページテスト（bid 3→3=的中、bid 2→4=+2 超過、bid 2→1=-1 不足、プレイ中は非表示）。

## 受け入れ条件
- [x] ラウンド終了時に各プレイヤーの bid−trickCount 差分が表示される
- [x] 的中(0)・超過(+)・不足(-)で色が変わる
- [x] モバイルの `details` とは独立したサイドバー配置で崩れない（`overflow` セーフなリスト表示）
- [x] i18n キーを ja/en 双方に追加

## テスト
- `bun run check` パス（Biome lint + format + design-tokens）
- `bun run test -- --run wizardBidAccuracy WizardPage` 57 件パス
- `bun run build`（tsc + vite）パス

Closes #3508