### PR TITLE
feat(watten): show raise/respond stake-escalation history

### DIFF
--- a/frontend/src/i18n/locales/en/watten.json
+++ b/frontend/src/i18n/locales/en/watten.json
@@ -57,6 +57,14 @@
   "playButton": "Play",
   "raiseButton": "Raise (Watten)",
   "respondPhase": "Stake raised to {{stake}} — hold or fold.",
+  "respondLoss": "Folding concedes {{stake}} points to the opponent team.",
+  "stakeHistory": {
+    "title": "Stake history",
+    "start": "Start {{stake}}",
+    "raise": "{{player}} raise →{{stake}}",
+    "hold": "{{player}} hold ({{stake}})",
+    "fold": "{{player}} fold ({{stake}})"
+  },
   "holdButton": "Hold",
   "foldButton": "Fold",
   "nextRound": "Next deal",

--- a/frontend/src/i18n/locales/ja/watten.json
+++ b/frontend/src/i18n/locales/ja/watten.json
@@ -57,6 +57,14 @@
   "playButton": "出す",
   "raiseButton": "レイズ（Watten）",
   "respondPhase": "ステーク {{stake}}点にレイズされました — hold か fold を選びます。",
+  "respondLoss": "fold すると相手チームに {{stake}}点を献上します。",
+  "stakeHistory": {
+    "title": "ステーク推移",
+    "start": "開始 {{stake}}",
+    "raise": "{{player}} レイズ→{{stake}}",
+    "hold": "{{player}} hold（{{stake}}）",
+    "fold": "{{player}} fold（{{stake}}）"
+  },
   "holdButton": "hold（受ける）",
   "foldButton": "fold（降りる）",
   "nextRound": "次のディール",

--- a/frontend/src/pages/WattenPage.test.tsx
+++ b/frontend/src/pages/WattenPage.test.tsx
@@ -1,8 +1,9 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { wattenApi } from '../api/gameApi';
+import { actionLogApi, wattenApi } from '../api/gameApi';
 import { renderWithProviders } from '../test/renderWithProviders';
 import { makeWattenState } from '../test/stateFactories';
+import type { ActionLogEntry } from '../types/card';
 import { WattenPage } from './WattenPage';
 
 vi.mock('../api/gameApi', () => ({
@@ -11,6 +12,12 @@ vi.mock('../api/gameApi', () => ({
 }));
 
 const mockExec = vi.mocked(wattenApi.exec);
+const mockActionLog = vi.mocked(actionLogApi.watten);
+
+/** Builds a minimal action-log entry for tests. */
+function logEntry(turnNumber: number, actionType: string, playerIdx: number): ActionLogEntry {
+  return { turnNumber, playerIdx, actionType, detail: '' };
+}
 
 const playPhaseState = makeWattenState();
 const declarePhaseState = makeWattenState({
@@ -43,6 +50,8 @@ const cpuTurnState = makeWattenState({ phase: 1, currentPlayerIdx: 1, canRaise: 
 beforeEach(() => {
   mockExec.mockReset();
   mockExec.mockResolvedValue(playPhaseState);
+  mockActionLog.mockReset();
+  mockActionLog.mockResolvedValue({ entries: [] });
 });
 
 describe('WattenPage', () => {
@@ -172,5 +181,43 @@ describe('WattenPage', () => {
     await waitFor(() => expect(screen.getByAltText('♥ K')).toBeInTheDocument());
     expect(screen.queryByRole('button', { name: '出す' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /レイズ/ })).not.toBeInTheDocument();
+  });
+
+  it('renders the stake-escalation mini-history in order when the action log has raises', async () => {
+    mockActionLog.mockResolvedValue({
+      entries: [
+        logEntry(1, 'declare', 0),
+        logEntry(2, 'raise', 1),
+        logEntry(3, 'hold', 0),
+        logEntry(4, 'raise', 0),
+        logEntry(5, 'hold', 1),
+      ],
+    });
+    renderWithProviders(<WattenPage />);
+    const panel = await screen.findByTestId('watten-stake-history');
+    expect(panel).toHaveTextContent('開始 2');
+    expect(panel).toHaveTextContent('CPU 1 レイズ→3');
+    expect(panel).toHaveTextContent('あなた hold（3）');
+    expect(panel).toHaveTextContent('あなた レイズ→4');
+    expect(panel).toHaveTextContent('CPU 1 hold（4）');
+    // Ordering: the first CPU raise precedes the human's later raise.
+    expect(panel.textContent?.indexOf('CPU 1 レイズ→3')).toBeLessThan(
+      panel.textContent?.indexOf('あなた レイズ→4') ?? -1,
+    );
+  });
+
+  it('does not render the mini-history when the action log has no escalation', async () => {
+    mockActionLog.mockResolvedValue({ entries: [logEntry(1, 'declare', 0), logEntry(2, 'play', 0)] });
+    renderWithProviders(<WattenPage />);
+    await waitFor(() => expect(screen.getByAltText('♥ K')).toBeInTheDocument());
+    expect(screen.queryByTestId('watten-stake-history')).not.toBeInTheDocument();
+  });
+
+  it('shows the fold-loss amount during the respond phase', async () => {
+    mockExec.mockResolvedValue(respondPhaseState);
+    renderWithProviders(<WattenPage />);
+    const loss = await screen.findByTestId('watten-respond-loss');
+    // respondPhaseState keeps the default confirmed stake of 2.
+    expect(loss).toHaveTextContent('fold すると相手チームに 2点を献上します。');
   });
 });

--- a/frontend/src/pages/WattenPage.tsx
+++ b/frontend/src/pages/WattenPage.tsx
@@ -14,6 +14,7 @@ import { PlayerHandSection } from '../components/PlayerHandSection';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { TrickDisplay } from '../components/TrickDisplay';
 import { withTutorial } from '../components/tutorial/withTutorial';
+import { useActionLog } from '../hooks/useActionLog';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
@@ -31,7 +32,8 @@ import { cardAlt } from '../utils/cardAlt';
 import { parseWattenCommand, WATTEN_HELP } from '../utils/cli/commands/wattenCommands';
 import { formatWattenState } from '../utils/cli/formatters/wattenFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
-import { playerName } from '../utils/playerUtils';
+import { findPlayerName, playerName } from '../utils/playerUtils';
+import { buildWattenStakeHistory, WATTEN_BASE_STAKE } from '../utils/wattenStakeHistory';
 import { wattenTrumpCards } from '../utils/wattenTrumps';
 
 /** Watten tutorial step definitions. */
@@ -156,6 +158,19 @@ function WattenPageContent() {
   } = useGameHint('watten', state);
   const { cardWidth, isMobile } = useCardDimensions();
   const phaseNames = usePhaseNames('watten', WATTEN_PHASE_KEYS);
+
+  // Dedicated action-log fetch used only to reconstruct the stake-escalation
+  // mini-history. Kept separate from the page's shared action-log panel so the
+  // history stays fresh during play (the shared log is opened manually at end).
+  const { actionLog: stakeLog, showActionLog: refreshStakeLog } = useActionLog('watten');
+  // Re-fetch the log whenever a stake-relevant field changes so the mini-history
+  // tracks the latest raise/respond exchange; these fields are triggers, not
+  // values read inside the effect body.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: stake fields are re-fetch triggers, not deps read in the callback.
+  useEffect(() => {
+    void refreshStakeLog();
+  }, [refreshStakeLog, state?.stake, state?.pendingStake, state?.raiseCount, state?.roundNumber]);
+  const stakeHistory = useMemo(() => buildWattenStakeHistory(stakeLog), [stakeLog]);
 
   if (!state)
     return <GameSkeleton gameKey="watten" layout={{ kind: 'trick-taking', trickArea: true, footerHandSize: 5 }} />;
@@ -307,6 +322,32 @@ function WattenPageContent() {
                     </tbody>
                   </table>
                 </div>
+
+                {/* Stake-escalation mini-history (raise/hold/fold sequence) */}
+                {stakeHistory.length > 0 && (
+                  <div
+                    className="mb-2 p-2 rounded bg-black/30 text-ds-text-muted text-sm"
+                    data-testid="watten-stake-history"
+                  >
+                    <div className="text-ds-text-primary mb-1">{t('stakeHistory.title')}</div>
+                    <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1">
+                      <span>{t('stakeHistory.start', { stake: WATTEN_BASE_STAKE })}</span>
+                      {stakeHistory.map((ev) => (
+                        <span key={ev.key} className="flex items-center gap-x-1.5">
+                          <span aria-hidden="true" className="text-ds-text-muted">
+                            →
+                          </span>
+                          <span className={ev.type === 'fold' ? 'text-ds-warning' : 'text-ds-accent'}>
+                            {t(`stakeHistory.${ev.type}`, {
+                              player: findPlayerName(state.players, ev.playerIdx),
+                              stake: ev.stake,
+                            })}
+                          </span>
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                )}
 
                 {/* Players: cards / tricks */}
                 {isMobile ? (
@@ -479,6 +520,9 @@ function WattenPageContent() {
               {canRespond && (
                 <>
                   <span className="text-ds-text-muted text-sm">{t('respondPhase', { stake: state.pendingStake })}</span>
+                  <span className="text-ds-warning text-sm" data-testid="watten-respond-loss">
+                    {t('respondLoss', { stake: state.stake })}
+                  </span>
                   <button type="button" className={btnPrimary} onClick={() => handleRespond(true)} disabled={loading}>
                     {t('holdButton')}
                   </button>

--- a/frontend/src/utils/wattenStakeHistory.test.ts
+++ b/frontend/src/utils/wattenStakeHistory.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import type { ActionLogEntry } from '../types/card';
+import { buildWattenStakeHistory, WATTEN_BASE_STAKE } from './wattenStakeHistory';
+
+/** Builds a minimal action-log entry for tests. */
+function entry(turnNumber: number, actionType: string, playerIdx: number): ActionLogEntry {
+  return { turnNumber, playerIdx, actionType, detail: '' };
+}
+
+describe('buildWattenStakeHistory', () => {
+  it('returns an empty array for null, undefined, or empty input', () => {
+    expect(buildWattenStakeHistory(null)).toEqual([]);
+    expect(buildWattenStakeHistory(undefined)).toEqual([]);
+    expect(buildWattenStakeHistory([])).toEqual([]);
+  });
+
+  it('returns an empty array when the deal has no raise/respond events', () => {
+    const log = [entry(1, 'declare', 0), entry(2, 'play', 0), entry(3, 'trick_win', 2)];
+    expect(buildWattenStakeHistory(log)).toEqual([]);
+  });
+
+  it('reconstructs a raise then hold escalation in order', () => {
+    const log = [entry(1, 'declare', 0), entry(2, 'raise', 1), entry(3, 'hold', 0)];
+    expect(buildWattenStakeHistory(log)).toEqual([
+      { key: 2, type: 'raise', playerIdx: 1, stake: 3 },
+      { key: 3, type: 'hold', playerIdx: 0, stake: 3 },
+    ]);
+  });
+
+  it('reconstructs successive accepted raises with rising stakes', () => {
+    const log = [
+      entry(1, 'declare', 0),
+      entry(2, 'raise', 1),
+      entry(3, 'hold', 0),
+      entry(4, 'raise', 0),
+      entry(5, 'hold', 1),
+    ];
+    expect(buildWattenStakeHistory(log)).toEqual([
+      { key: 2, type: 'raise', playerIdx: 1, stake: 3 },
+      { key: 3, type: 'hold', playerIdx: 0, stake: 3 },
+      { key: 4, type: 'raise', playerIdx: 0, stake: 4 },
+      { key: 5, type: 'hold', playerIdx: 1, stake: 4 },
+    ]);
+  });
+
+  it('reports a fold at the last settled stake (before the rejected raise)', () => {
+    const log = [entry(1, 'declare', 0), entry(2, 'raise', 1), entry(3, 'fold', 0)];
+    expect(buildWattenStakeHistory(log)).toEqual([
+      { key: 2, type: 'raise', playerIdx: 1, stake: 3 },
+      { key: 3, type: 'fold', playerIdx: 0, stake: WATTEN_BASE_STAKE },
+    ]);
+  });
+
+  it('includes a still-pending raise that has no response yet', () => {
+    const log = [entry(1, 'declare', 0), entry(2, 'raise', 1)];
+    expect(buildWattenStakeHistory(log)).toEqual([{ key: 2, type: 'raise', playerIdx: 1, stake: 3 }]);
+  });
+
+  it('only reflects the current deal (entries after the last declare)', () => {
+    const log = [
+      entry(1, 'declare', 0),
+      entry(2, 'raise', 1),
+      entry(3, 'hold', 0),
+      entry(4, 'deal_score', -1),
+      entry(5, 'declare', 1),
+      entry(6, 'raise', 0),
+    ];
+    expect(buildWattenStakeHistory(log)).toEqual([{ key: 6, type: 'raise', playerIdx: 0, stake: 3 }]);
+  });
+
+  it('honours a custom base stake', () => {
+    const log = [entry(1, 'declare', 0), entry(2, 'raise', 1)];
+    expect(buildWattenStakeHistory(log, 5)).toEqual([{ key: 2, type: 'raise', playerIdx: 1, stake: 6 }]);
+  });
+});

--- a/frontend/src/utils/wattenStakeHistory.ts
+++ b/frontend/src/utils/wattenStakeHistory.ts
@@ -1,0 +1,64 @@
+import type { ActionLogEntry } from '../types/card';
+
+/** Base stake every Watten deal starts at (mirrors the domain `WattenBaseStake`). */
+export const WATTEN_BASE_STAKE = 2;
+
+/** A single stake-escalation event reconstructed from the action log. */
+export interface WattenStakeEvent {
+  /** Stable key for React lists (the source entry's turn number). */
+  key: number;
+  /** Which escalation action occurred. */
+  type: 'raise' | 'hold' | 'fold';
+  /** Seat index of the player who acted. */
+  playerIdx: number;
+  /** Stake value after this event (the proposed stake for a raise, the settled stake for hold/fold). */
+  stake: number;
+}
+
+/**
+ * Reconstructs the current deal's raise/respond escalation from the action log.
+ *
+ * Only the current deal is considered (entries after the last `declare`). The
+ * stake value at each event is derived deterministically from the base stake and
+ * the raise/hold/fold sequence — a raise proposes `running + 1`, a hold settles at
+ * that proposal, and a fold concedes the last settled stake — so no prose parsing
+ * is needed. Returns an empty array when there was no escalation.
+ *
+ * @param entries - Action-log entries (or null/undefined when not yet loaded).
+ * @param baseStake - Stake each deal opens at (defaults to {@link WATTEN_BASE_STAKE}).
+ * @returns Ordered stake-escalation events for the current deal.
+ */
+export function buildWattenStakeHistory(
+  entries: ActionLogEntry[] | null | undefined,
+  baseStake = WATTEN_BASE_STAKE,
+): WattenStakeEvent[] {
+  if (!entries || entries.length === 0) return [];
+
+  // Restrict to the current deal: everything after the most recent declare.
+  let start = 0;
+  for (let i = entries.length - 1; i >= 0; i--) {
+    if (entries[i].actionType === 'declare') {
+      start = i + 1;
+      break;
+    }
+  }
+
+  const events: WattenStakeEvent[] = [];
+  let running = baseStake;
+  let pending = 0;
+  for (let i = start; i < entries.length; i++) {
+    const e = entries[i];
+    if (e.actionType === 'raise') {
+      pending = running + 1;
+      events.push({ key: e.turnNumber, type: 'raise', playerIdx: e.playerIdx, stake: pending });
+    } else if (e.actionType === 'hold') {
+      if (pending > 0) running = pending;
+      pending = 0;
+      events.push({ key: e.turnNumber, type: 'hold', playerIdx: e.playerIdx, stake: running });
+    } else if (e.actionType === 'fold') {
+      pending = 0;
+      events.push({ key: e.turnNumber, type: 'fold', playerIdx: e.playerIdx, stake: running });
+    }
+  }
+  return events;
+}


### PR DESCRIPTION
Closes #3490

## What

Adds a stake-progression mini-history to the Watten (ヴァッテン) info sidebar and clarifies the fold cost during the respond phase, so the raise/bluff exchange — the heart of Watten — is now traceable.

## How

- **History source: the action log.** The domain records `raise`/`hold`/`fold` entries (via `appendLog`), so the escalation sequence is faithfully available. State alone only exposes the aggregate `raiseCount`, and `runCpu()` loops several CPU actions into one poll, so state-diffs would lose intermediate raises — the action log is the only faithful source.
- New pure helper `buildWattenStakeHistory(entries)` reconstructs the **current deal's** escalation (entries after the last `declare`). Stake values are derived deterministically from the base stake (2) and the raise/hold/fold order (raise proposes `running+1`, hold settles there, fold concedes the last settled stake) — no prose parsing of server strings.
- The page fetches a dedicated copy of the action log (a second `useActionLog('watten')` instance), refreshed whenever a stake-relevant field changes, decoupled from the manually-opened shared action-log panel.
- Sidebar renders `開始 2 → CPU 1 レイズ→3 → あなた hold（3）…` (fold events highlighted). Respond phase adds a `respondLoss` line stating the points conceded on fold.
- ja/en i18n added (`stakeHistory.*`, `respondLoss`), key-for-key in parity.

## Tests

- `frontend/src/utils/wattenStakeHistory.test.ts` — pure helper: empty input, no-escalation, raise→hold, successive rising raises, fold-at-settled-stake, still-pending raise, current-deal-only segmentation, custom base stake.
- `frontend/src/pages/WattenPage.test.tsx` — history renders raise/hold/fold in order; renders nothing without escalation; respond phase shows the fold-loss amount.

## Gate
- [x] `bun run check` (biome)
- [x] `bun run test` (WattenPage + wattenStakeHistory, 24 passing)
- [x] `bun run build` (tsc -b + vite build)
- [x] ja/en i18n parity

Frontend-only; no Go changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)