### PR TITLE
feat(basra): preview captured table cards on hand-card selection

### DIFF
--- a/frontend/src/i18n/locales/en/basra.json
+++ b/frontend/src/i18n/locales/en/basra.json
@@ -27,6 +27,7 @@
   "turnCpu": "CPU {{id}} is playing…",
   "playButton": "Play",
   "captureButton": "Capture",
+  "captureButtonCount": "Capture {{count}}",
   "trailButton": "Trail",
   "newGame": "New Game",
   "result": {

--- a/frontend/src/i18n/locales/ja/basra.json
+++ b/frontend/src/i18n/locales/ja/basra.json
@@ -27,6 +27,7 @@
   "turnCpu": "CPU {{id}} がプレイ中です…",
   "playButton": "出す",
   "captureButton": "捕獲",
+  "captureButtonCount": "{{count}}枚捕獲",
   "trailButton": "トレイル",
   "newGame": "新しいゲーム",
   "result": {

--- a/frontend/src/pages/BasraPage.test.tsx
+++ b/frontend/src/pages/BasraPage.test.tsx
@@ -68,7 +68,7 @@ describe('BasraPage', () => {
     fireEvent.click(screen.getByTestId('table-card-0'));
     mockExec.mockClear();
     mockExec.mockResolvedValue(playPhaseState);
-    fireEvent.click(screen.getByRole('button', { name: '捕獲' }));
+    fireEvent.click(screen.getByRole('button', { name: '1枚捕獲' }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', { cardIndex: 0, tableIndices: [0] }));
   });
 
@@ -90,12 +90,43 @@ describe('BasraPage', () => {
 
   it('trailing (no table cards) dispatches play with an empty capture set', async () => {
     renderWithProviders(<BasraPage />);
-    const handCard = await screen.findByTestId('hand-card-1');
+    // Hand card 3 (♣3) matches nothing on the table [♠5, ♥9], so it can only trail.
+    const handCard = await screen.findByTestId('hand-card-3');
     fireEvent.click(handCard);
     mockExec.mockClear();
     mockExec.mockResolvedValue(playPhaseState);
-    fireEvent.click(screen.getByRole('button', { name: '出す' }));
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', { cardIndex: 1, tableIndices: [] }));
+    fireEvent.click(screen.getByRole('button', { name: 'トレイル' }));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', { cardIndex: 3, tableIndices: [] }));
+  });
+
+  it('previews the capture set and shows the captured count on the button', async () => {
+    renderWithProviders(<BasraPage />);
+    // Selecting hand card 0 (♥5) previews table card 0 (♠5, same rank) as capturable.
+    fireEvent.click(await screen.findByTestId('hand-card-0'));
+    expect(screen.getByTestId('table-card-0')).toHaveAttribute('data-capture-candidate', 'true');
+    expect(screen.getByTestId('table-card-1')).not.toHaveAttribute('data-capture-candidate');
+    // Selecting it makes the action button report the captured count.
+    fireEvent.click(screen.getByTestId('table-card-0'));
+    expect(screen.getByRole('button', { name: '1枚捕獲' })).toBeInTheDocument();
+  });
+
+  it('previews a Jack as a full board sweep and labels the button with the swept count', async () => {
+    renderWithProviders(<BasraPage />);
+    // Hand card 1 (♠J) sweeps every non-Jack table card ([♠5, ♥9]) — a 2-card sweep,
+    // previewed without any manual table selection.
+    fireEvent.click(await screen.findByTestId('hand-card-1'));
+    expect(screen.getByTestId('table-card-0')).toHaveAttribute('data-capture-candidate', 'true');
+    expect(screen.getByTestId('table-card-1')).toHaveAttribute('data-capture-candidate', 'true');
+    expect(screen.getByRole('button', { name: '2枚捕獲' })).toBeInTheDocument();
+  });
+
+  it('offers only the trail button for a hand card that captures nothing', async () => {
+    renderWithProviders(<BasraPage />);
+    // Hand card 3 (♣3) captures nothing: no candidates highlighted, trail button only.
+    fireEvent.click(await screen.findByTestId('hand-card-3'));
+    expect(screen.getByTestId('table-card-0')).not.toHaveAttribute('data-capture-candidate');
+    expect(screen.getByRole('button', { name: 'トレイル' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /捕獲/ })).not.toBeInTheDocument();
   });
 
   it('does not show the play button on a CPU turn', async () => {

--- a/frontend/src/pages/BasraPage.tsx
+++ b/frontend/src/pages/BasraPage.tsx
@@ -25,6 +25,7 @@ import { gameTheme } from '../styles/gameTheme';
 import type { BasraResponse } from '../types/card';
 import { BasraPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { basraFindCaptures, resolveBasraAction } from '../utils/basraCaptures';
 import { cardAlt } from '../utils/cardAlt';
 import { BASRA_HELP, parseBasraCommand } from '../utils/cli/commands/basraCommands';
 import { formatBasraState } from '../utils/cli/formatters/basraFormatter';
@@ -156,9 +157,13 @@ function BasraPageContent() {
   const humanWon = isGameEnd && state.winners.includes(0);
   const phaseName = isGameEnd ? t('phase.gameEnd') : t('phase.play');
 
-  // Table indices the currently-selected hand card can capture (backend hint).
-  const captureCandidates =
-    handIndex !== null && isHumanTurn ? new Set(state.captureOptions[handIndex] ?? []) : new Set<number>();
+  // Preview which table cards the selected hand card would capture. Derived on the
+  // frontend (basraFindCaptures) so the highlight matches the domain rule exactly —
+  // including the Jack sweep, which the backend captureOptions hint omits for a Jack.
+  const selectedHandCard = handIndex !== null && isHumanTurn ? (human?.cards[handIndex] ?? null) : null;
+  const previewCaptures = selectedHandCard ? basraFindCaptures(selectedHandCard, state.tableCards) : [];
+  const captureCandidates = new Set(previewCaptures);
+  const captureAction = resolveBasraAction(selectedHandCard, previewCaptures, tableIndices);
   const canPlay = isHumanTurn && handIndex !== null;
 
   const winnerNames = state.winners.map((i) => (state.players[i]?.isHuman ? t('you') : t('cpu', { id: i }))).join(', ');
@@ -401,7 +406,11 @@ function BasraPageContent() {
             <div className="flex gap-2 justify-center flex-wrap items-center" data-tutorial="basra-actions">
               {!isGameEnd && isHumanTurn && (
                 <button type="button" className={btnPrimary} onClick={playCard} disabled={loading || !canPlay}>
-                  {tableIndices.length > 0 ? t('captureButton') : t('playButton')}
+                  {captureAction.kind === 'sweep' || captureAction.kind === 'capture'
+                    ? t('captureButtonCount', { count: captureAction.count })
+                    : captureAction.kind === 'trail'
+                      ? t('trailButton')
+                      : t('playButton')}
                 </button>
               )}
               {isGameEnd && (

--- a/frontend/src/utils/basraCaptures.test.ts
+++ b/frontend/src/utils/basraCaptures.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import type { Card } from '../types/card';
+import { basraFindCaptures, isBasraJack, resolveBasraAction } from './basraCaptures';
+
+/** Builds a card with the given rank value (suit is irrelevant to capture logic). */
+const c = (value: number, design: Card['design'] = 'SPADE'): Card => ({ design, value });
+
+describe('basraFindCaptures', () => {
+  it('captures a same-rank table card with a number card', () => {
+    // A 5 captures the table 5 by matching rank.
+    expect(basraFindCaptures(c(5), [c(5), c(9)])).toEqual([0]);
+  });
+
+  it('captures a two-card subset summing to the played value', () => {
+    // A 5 captures 2 + 3 (indices 0 and 1); the 9 is untouched.
+    expect(basraFindCaptures(c(5), [c(2), c(3), c(9)])).toEqual([0, 1]);
+  });
+
+  it('greedily captures both a same-rank single and a summing subset', () => {
+    // A 5 takes the table 5 (index 0) AND the 2 + 3 pair (indices 1, 2).
+    expect(basraFindCaptures(c(5), [c(5), c(2), c(3)])).toEqual([0, 1, 2]);
+  });
+
+  it('captures nothing when no rank matches and no subset sums (trail)', () => {
+    expect(basraFindCaptures(c(3), [c(5), c(9)])).toEqual([]);
+  });
+
+  it('sweeps every non-Jack table card when a Jack is played', () => {
+    // The Jack (value 11) sweeps indices 0 and 2 but leaves the table Jack (index 1).
+    expect(basraFindCaptures(c(11), [c(5), c(11), c(9)])).toEqual([0, 2]);
+  });
+
+  it('captures faces (Q/K) by matching rank only, never by sum', () => {
+    // A Queen (12) captures the table Queen only; 5 + 7 never sums into a face.
+    expect(basraFindCaptures(c(12), [c(12), c(5), c(7)])).toEqual([0]);
+  });
+
+  it('captures only other Aces with an Ace (value 1)', () => {
+    expect(basraFindCaptures(c(1), [c(1), c(1), c(9)])).toEqual([0, 1]);
+  });
+});
+
+describe('isBasraJack', () => {
+  it('is true only for value-11 cards', () => {
+    expect(isBasraJack(c(11))).toBe(true);
+    expect(isBasraJack(c(12))).toBe(false);
+    expect(isBasraJack(null)).toBe(false);
+  });
+});
+
+describe('resolveBasraAction', () => {
+  it('is idle when no card is selected', () => {
+    expect(resolveBasraAction(null, [], [])).toEqual({ kind: 'idle', count: 0 });
+  });
+
+  it('sweeps for a Jack, counting every capturable card regardless of selection', () => {
+    expect(resolveBasraAction(c(11), [0, 1], [])).toEqual({ kind: 'sweep', count: 2 });
+  });
+
+  it('captures the selected table cards for a non-Jack selection', () => {
+    expect(resolveBasraAction(c(5), [0, 1], [0])).toEqual({ kind: 'capture', count: 1 });
+  });
+
+  it('is capturable (awaiting selection) when captures exist but none are picked', () => {
+    expect(resolveBasraAction(c(5), [0], [])).toEqual({ kind: 'capturable', count: 1 });
+  });
+
+  it('trails when a non-Jack card can capture nothing', () => {
+    expect(resolveBasraAction(c(3), [], [])).toEqual({ kind: 'trail', count: 0 });
+  });
+});

--- a/frontend/src/utils/basraCaptures.ts
+++ b/frontend/src/utils/basraCaptures.ts
@@ -1,0 +1,131 @@
+import type { Card } from '../types/card';
+
+/**
+ * Pure Basra (Bastra) capture logic, mirroring the backend domain rule
+ * (`internal/domain/Basra.go`) so the web GUI can preview — before the human
+ * commits a play — exactly which table cards a selected hand card would capture.
+ *
+ * Card values follow the shared {@link Card} convention (`value`): Ace = 1,
+ * number cards 2–10, Jack = 11, Queen = 12, King = 13.
+ */
+
+/** The value of a Jack — Basra's board-sweeping card. */
+const BASRA_JACK_VALUE = 11;
+
+/** True when the card is a Jack (the sweep card in Basra). */
+export function isBasraJack(card: Card | null | undefined): boolean {
+  return !!card && card.value === BASRA_JACK_VALUE;
+}
+
+/** True when the card is a face card (J/Q/K); faces never join numeric sum groups. */
+function isBasraFace(card: Card): boolean {
+  return card.value >= 11;
+}
+
+/**
+ * Recursively searches `avail` (indices into `tableCards`) for the first subset of
+ * two or more cards whose values sum to `target`. Mirrors `basraSubsetSum`.
+ */
+function subsetSum(tableCards: Card[], avail: number[], start: number, target: number, acc: number[]): number[] | null {
+  if (target === 0) {
+    return acc.length >= 2 ? [...acc] : null;
+  }
+  for (let i = start; i < avail.length; i++) {
+    const v = tableCards[avail[i]].value;
+    if (v > target) continue;
+    const res = subsetSum(tableCards, avail, i + 1, target - v, [...acc, avail[i]]);
+    if (res !== null) return res;
+  }
+  return null;
+}
+
+/**
+ * Finds one capturing group for a number card of value `target`: a same-rank single
+ * is preferred, otherwise a subset of two or more number cards summing to `target`.
+ * `used` marks table indices already claimed by earlier groups. Mirrors
+ * `basraFindOneGroup`. Returns `null` when no further group exists.
+ */
+function findOneGroup(tableCards: Card[], target: number, used: boolean[]): number[] | null {
+  for (let i = 0; i < tableCards.length; i++) {
+    if (used[i] || isBasraFace(tableCards[i])) continue;
+    if (tableCards[i].value === target) return [i];
+  }
+  const avail: number[] = [];
+  for (let i = 0; i < tableCards.length; i++) {
+    if (used[i] || isBasraFace(tableCards[i])) continue;
+    if (tableCards[i].value < target) avail.push(i);
+  }
+  return subsetSum(tableCards, avail, 0, target, []);
+}
+
+/**
+ * Returns the maximal set of table indices the played card would capture, mirroring
+ * `Basra.basraFindCaptures`:
+ *  - a Jack sweeps every non-Jack table card;
+ *  - a Queen/King captures same-rank table cards only (no sums);
+ *  - a number card captures same-rank cards and any table subset summing to its value,
+ *    greedily extracting multiple groups.
+ *
+ * The result is sorted ascending. An empty array means the card captures nothing and
+ * would trail.
+ */
+export function basraFindCaptures(playedCard: Card, tableCards: Card[]): number[] {
+  if (isBasraJack(playedCard)) {
+    const out: number[] = [];
+    for (let i = 0; i < tableCards.length; i++) {
+      if (!isBasraJack(tableCards[i])) out.push(i);
+    }
+    return out;
+  }
+  const pv = playedCard.value;
+  if (isBasraFace(playedCard)) {
+    const out: number[] = [];
+    for (let i = 0; i < tableCards.length; i++) {
+      if (tableCards[i].value === pv) out.push(i);
+    }
+    return out;
+  }
+  const used = new Array<boolean>(tableCards.length).fill(false);
+  const captured: number[] = [];
+  for (;;) {
+    const group = findOneGroup(tableCards, pv, used);
+    if (group === null) break;
+    for (const idx of group) {
+      used[idx] = true;
+      captured.push(idx);
+    }
+  }
+  captured.sort((a, b) => a - b);
+  return captured;
+}
+
+/** The action the Basra footer button will perform for the current selection. */
+export type BasraActionKind = 'idle' | 'sweep' | 'capture' | 'capturable' | 'trail';
+
+/** Resolved action + the number of table cards it would capture. */
+export interface BasraAction {
+  kind: BasraActionKind;
+  /** Table cards captured by the action (0 for `idle`/`trail`/`capturable`-preview). */
+  count: number;
+}
+
+/**
+ * Resolves what playing the selected hand card will do, mirroring `Basra.applyPlay`:
+ *  - no card selected → `idle`;
+ *  - a Jack → `sweep` (captures every non-Jack table card; selection is ignored);
+ *  - a non-Jack with table cards selected → `capture` (captures the selection);
+ *  - a non-Jack with a capture available but nothing selected → `capturable` (the
+ *    human still needs to tap the highlighted cards; pressing now would trail);
+ *  - otherwise → `trail`.
+ *
+ * @param card selected hand card, or `null` when none is chosen
+ * @param captures maximal capturable table indices for `card` ({@link basraFindCaptures})
+ * @param selectedTableIndices table indices the human has toggled for capture
+ */
+export function resolveBasraAction(card: Card | null, captures: number[], selectedTableIndices: number[]): BasraAction {
+  if (!card) return { kind: 'idle', count: 0 };
+  if (isBasraJack(card)) return { kind: 'sweep', count: captures.length };
+  if (selectedTableIndices.length > 0) return { kind: 'capture', count: selectedTableIndices.length };
+  if (captures.length > 0) return { kind: 'capturable', count: captures.length };
+  return { kind: 'trail', count: 0 };
+}


### PR DESCRIPTION
Closes #3627

## What
When the human selects a hand card in Basra, the page now previews **which table cards that card would capture** and reflects the outcome on the action button.

- Same-rank matches, summing subsets (e.g. a 5 taking 2+3), and full **Jack sweeps** are all highlighted on the table (`data-capture-candidate` + existing ✓ badge / aria).
- The footer button is now dynamic:
  - **`N枚捕獲` / `Capture N`** for a capture (count = selected cards) or a Jack sweep (count = all non-Jack table cards).
  - **`トレイル` / `Trail`** when the selected card can capture nothing (only the trail action is offered).
  - `出す` / `Play` while a capturable card awaits a table selection.

## How
- New pure helper `frontend/src/utils/basraCaptures.ts`:
  - `basraFindCaptures(playedCard, tableCards)` mirrors the domain rule (`internal/domain/Basra.go` → `basraFindCaptures`) exactly: Jack sweep (excludes other Jacks), Q/K same-rank only, number-card greedy same-rank + subset-sum groups.
  - `resolveBasraAction(...)` mirrors `applyPlay` to classify the action (`idle` / `sweep` / `capture` / `capturable` / `trail`) and its count.
- `BasraPage.tsx` now derives the preview highlight and the button label from the helper instead of the backend `captureOptions` hint. This is deliberate: `captureOptions` **omits the Jack's sweep** (the backend never lists a Jack's captures), so a frontend re-derivation is required to preview a Jack correctly — and it is provably identical to the domain output for every other card.
- Added i18n key `captureButtonCount` (ja `{{count}}枚捕獲`, en `Capture {{count}}`), ja/en in parity.

## Capture rules mirrored
- Jack (value 11): sweeps every non-Jack table card.
- Queen / King (12 / 13): same-rank capture only, never sums.
- Number card (A=1 … 10): same-rank singles **plus** any subset summing to its value, greedily across multiple groups.
- No match / no sum: trail.

No backend/Go changes.

## Test plan
- [x] `frontend/src/utils/basraCaptures.test.ts` — unit tests for same-rank, sum-subset, greedy multi-group, Jack sweep (excludes table Jack), face same-rank, Ace, no-capture, and every `resolveBasraAction` branch.
- [x] `BasraPage.test.tsx` — selection→preview + capture count, Jack full-sweep preview + count, trail-only for a non-capturing card.
- [x] `bun run check` (biome) passes
- [x] `bun run test -- --run basraCaptures BasraPage` — 28 passed
- [x] `bun run build` (tsc) passes