### PR TITLE
feat(oichokabu): disclose the banker draw policy on the result screen

### DIFF
--- a/frontend/src/i18n/locales/en/oichokabu.json
+++ b/frontend/src/i18n/locales/en/oichokabu.json
@@ -32,6 +32,11 @@
   "payout": {
     "total": "Total payout"
   },
+  "dealerPolicy": {
+    "label": "Banker draw rule",
+    "drew": "Banker drew a third card (draws on rank {{threshold}} or below)",
+    "stood": "Banker stood on rank {{rank}} (draws on rank {{threshold}} or below)"
+  },
   "tutorial": {
     "betControls": "Enter your bet and place it",
     "actionButtons": "Draw a third card or stand to settle",

--- a/frontend/src/i18n/locales/ja/oichokabu.json
+++ b/frontend/src/i18n/locales/ja/oichokabu.json
@@ -32,6 +32,11 @@
   "payout": {
     "total": "合計配当"
   },
+  "dealerPolicy": {
+    "label": "親のドロー方針",
+    "drew": "親は目が規定値（{{threshold}}）以下だったため3枚目を引いた",
+    "stood": "親は目{{rank}}で規定値（{{threshold}}）を超えていたため引かなかった"
+  },
   "tutorial": {
     "betControls": "賭け金を入力してベットします",
     "actionButtons": "3枚目を引くか、このまま勝負するかを選びます",

--- a/frontend/src/pages/OichoKabuPage.test.tsx
+++ b/frontend/src/pages/OichoKabuPage.test.tsx
@@ -75,6 +75,15 @@ const winState: OichoKabuResponse = {
   message: 'You win!',
 };
 
+const bankerDrewState: OichoKabuResponse = {
+  ...winState,
+  bankerHand: [kabu(2), kabu(1), kabu(6)],
+  bankerRank: 9,
+  result: -1,
+  totalPayout: 0,
+  message: 'You lose',
+};
+
 beforeEach(() => {
   vi.clearAllMocks();
   mockApi.mockResolvedValue(betState);
@@ -152,6 +161,29 @@ describe('OichoKabuPage', () => {
     expect(screen.getByRole('img', { name: '親の目7' })).toBeInTheDocument();
     // The payout/result block is announced.
     expect(screen.getByTestId('payout-breakdown')).toHaveAttribute('role', 'status');
+  });
+
+  it('discloses the banker stand policy with its revealed rank at result', async () => {
+    mockApi.mockResolvedValue(winState); // 2-card banker, rank 7 (> threshold 6) => stood
+    renderWithProviders(<OichoKabuPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: /次のゲーム/ })).toBeInTheDocument());
+    const policy = screen.getByTestId('dealer-policy');
+    expect(policy).toHaveTextContent('親のドロー方針');
+    expect(policy).toHaveTextContent('親は目7で規定値（6）を超えていたため引かなかった');
+  });
+
+  it('discloses the banker draw policy when the banker took a third card', async () => {
+    mockApi.mockResolvedValue(bankerDrewState); // 3-card banker => drew
+    renderWithProviders(<OichoKabuPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: /次のゲーム/ })).toBeInTheDocument());
+    expect(screen.getByTestId('dealer-policy')).toHaveTextContent('親は目が規定値（6）以下だったため3枚目を引いた');
+  });
+
+  it('hides the banker draw policy before the result phase', async () => {
+    mockApi.mockResolvedValue(drawState);
+    renderWithProviders(<OichoKabuPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: /引く/ })).toBeInTheDocument());
+    expect(screen.queryByTestId('dealer-policy')).not.toBeInTheDocument();
   });
 
   it('reads from useCliMode', async () => {

--- a/frontend/src/pages/OichoKabuPage.tsx
+++ b/frontend/src/pages/OichoKabuPage.tsx
@@ -31,6 +31,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { OICHOKABU_HELP, parseOichokabuCommand } from '../utils/cli/commands/oichokabuCommands';
 import { formatOichokabuState } from '../utils/cli/formatters/oichokabuFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { oichokabuDealerPolicy } from '../utils/oichokabuDealerPolicy';
 
 const OK_TUTORIAL_STEPS: TutorialStep[] = [
   {
@@ -220,6 +221,14 @@ function OichoKabuPageContent() {
                 <div className="font-bold">
                   {t('payout.total')}: {state.totalPayout}
                 </div>
+                {(() => {
+                  const policy = oichokabuDealerPolicy(state.bankerHand.length, state.bankerRank);
+                  return (
+                    <div className="text-ds-text-muted text-xs mt-1" data-testid="dealer-policy">
+                      {t('dealerPolicy.label')}: {t(policy.i18nKey, policy.params)}
+                    </div>
+                  );
+                })()}
               </div>
             )}
 

--- a/frontend/src/utils/oichokabuDealerPolicy.test.ts
+++ b/frontend/src/utils/oichokabuDealerPolicy.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { OICHOKABU_BANKER_DRAW_THRESHOLD, oichokabuDealerPolicy } from './oichokabuDealerPolicy';
+
+describe('oichokabuDealerPolicy', () => {
+  it('mirrors the domain draw threshold', () => {
+    expect(OICHOKABU_BANKER_DRAW_THRESHOLD).toBe(6);
+  });
+
+  it('reports a draw when the banker holds three cards', () => {
+    const policy = oichokabuDealerPolicy(3, 8);
+    expect(policy.i18nKey).toBe('dealerPolicy.drew');
+    expect(policy.params).toEqual({ threshold: 6 });
+  });
+
+  it('reports a stand with the revealed rank when the banker holds two cards', () => {
+    const policy = oichokabuDealerPolicy(2, 7);
+    expect(policy.i18nKey).toBe('dealerPolicy.stood');
+    expect(policy.params).toEqual({ rank: 7, threshold: 6 });
+  });
+
+  it('treats a two-card hand at the threshold boundary as a stand disclosure', () => {
+    // The banker only ever stands on 2 cards when its rank was above the
+    // threshold; a two-card hand therefore always maps to the stood key.
+    const policy = oichokabuDealerPolicy(2, 9);
+    expect(policy.i18nKey).toBe('dealerPolicy.stood');
+    expect(policy.params.rank).toBe(9);
+  });
+});

--- a/frontend/src/utils/oichokabuDealerPolicy.ts
+++ b/frontend/src/utils/oichokabuDealerPolicy.ts
@@ -1,0 +1,39 @@
+/**
+ * Oicho-Kabu banker (dealer / 親) draw-policy disclosure.
+ *
+ * The banker follows a fixed house rule (see the domain constant
+ * `OichoKabuBankerDrawThreshold` in `internal/domain/OichoKabu.go`): starting
+ * from a two-card hand, it draws a third card only when its rank (目) is at or
+ * below the threshold, and stands otherwise. Because both sides are always
+ * dealt exactly two cards, a three-card banker hand means the banker drew, and
+ * a two-card banker hand means it stood — in which case the revealed rank is
+ * the same rank the banker used to make its decision.
+ */
+
+/**
+ * Banker draw threshold — mirrors the domain constant
+ * `OichoKabuBankerDrawThreshold` (the banker draws on rank 6 or below).
+ */
+export const OICHOKABU_BANKER_DRAW_THRESHOLD = 6;
+
+/** An i18n key plus its interpolation params describing the banker's decision. */
+export interface OichokabuDealerPolicy {
+  /** i18n key under the `dealerPolicy` namespace. */
+  i18nKey: string;
+  /** Interpolation params for the key. */
+  params: Record<string, number>;
+}
+
+/**
+ * Derive the banker's draw-policy disclosure from the revealed result state.
+ *
+ * @param bankerHandCount - Number of cards in the banker's final hand (2 = stood, 3 = drew).
+ * @param bankerRank - The banker's revealed rank (目). Only meaningful for the stood case.
+ * @returns The i18n key + params explaining why the banker drew or stood.
+ */
+export function oichokabuDealerPolicy(bankerHandCount: number, bankerRank: number): OichokabuDealerPolicy {
+  const drew = bankerHandCount > 2;
+  return drew
+    ? { i18nKey: 'dealerPolicy.drew', params: { threshold: OICHOKABU_BANKER_DRAW_THRESHOLD } }
+    : { i18nKey: 'dealerPolicy.stood', params: { rank: bankerRank, threshold: OICHOKABU_BANKER_DRAW_THRESHOLD } };
+}


### PR DESCRIPTION
Closes #3511

## What
Adds an additive one-line disclosure on the Oicho-Kabu result screen explaining the banker's (親's) draw decision, so the player understands why the banker drew or stood.

## Rule disclosed (matches the domain)
The banker follows a fixed house rule (`OichoKabuBankerDrawThreshold = 6` in `internal/domain/OichoKabu.go`): from its two-card hand it draws a third card only when its rank (目) is **6 or below**, and stands otherwise.

Since both sides are always dealt exactly two cards, the revealed banker hand size is a faithful signal:
- **3 cards → drew**: "親は目が規定値（6）以下だったため3枚目を引いた" / "Banker drew a third card (draws on rank 6 or below)"
- **2 cards → stood**: the shown rank *is* the decision rank, so it is stated exactly — "親は目{rank}で規定値（6）を超えていたため引かなかった" / "Banker stood on rank {rank} (draws on rank 6 or below)"

Frontend-only (Oicho-Kabu is on the `extra` worker; WASM-neutral). The threshold is mirrored as a frontend constant with a comment pointing at the domain SSoT — no Go touched, no threshold invented.

## Changes
- `frontend/src/utils/oichokabuDealerPolicy.ts` (+`.test.ts`) — pure helper returning `{ i18nKey, params }`
- `frontend/src/pages/OichoKabuPage.tsx` (+`.test.tsx`) — renders the `data-testid="dealer-policy"` line in the end-phase payout block
- `frontend/src/i18n/locales/{ja,en}/oichokabu.json` — `dealerPolicy.{label,drew,stood}` (ja+en parity)

## Acceptance criteria
- [x] Result screen shows the banker's draw/stand outcome and reason
- [x] Threshold references the domain constant as the single source of truth (mirrored frontend const, documented)
- [x] The "did not draw" case also shows a reason (with the revealed rank)
- [x] i18n keys added to ja + en

## Tests
- [x] `bun run check`
- [x] `bun run test -- --run Oichokabu` (41 passed)
- [x] `bun run build` (tsc)

Test names: `discloses the banker stand policy with its revealed rank at result`, `discloses the banker draw policy when the banker took a third card`, `hides the banker draw policy before the result phase`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)