### PR TITLE
feat(tienlen): show selected combo type name near the play button

### DIFF
--- a/frontend/src/i18n/locales/en/tienlen.json
+++ b/frontend/src/i18n/locales/en/tienlen.json
@@ -12,6 +12,9 @@
   "playButton": "Play Selected",
   "passButton": "Pass",
   "invalidCombo": "Not a valid combination (single, pair, triple, straight, double-sequence, or four of a kind)",
+  "selectedPlayLabel": "Selected",
+  "comboBadge": "{{type}} ({{count}} cards)",
+  "bombLabel": "Bomb",
   "phase": {
     "play": "Play",
     "end": "End"

--- a/frontend/src/i18n/locales/ja/tienlen.json
+++ b/frontend/src/i18n/locales/ja/tienlen.json
@@ -12,6 +12,9 @@
   "playButton": "選択したカードを出す",
   "passButton": "パス",
   "invalidCombo": "有効な組み合わせではありません（シングル・ペア・トリオ・ストレート・連続ペア・フォーカード）",
+  "selectedPlayLabel": "選択中",
+  "comboBadge": "{{type}}（{{count}}枚）",
+  "bombLabel": "爆弾",
   "phase": {
     "play": "プレイ",
     "end": "終了"

--- a/frontend/src/pages/TienLenPage.test.tsx
+++ b/frontend/src/pages/TienLenPage.test.tsx
@@ -87,6 +87,57 @@ describe('TienLenPage', () => {
     fireEvent.click(screen.getByTestId('hand-card-1'));
     expect(screen.getByTestId('play-button')).toBeDisabled();
     expect(screen.getByTestId('tl-invalid-combo')).toBeInTheDocument();
+    // The combo-type badge is only shown for valid selections.
+    expect(screen.queryByTestId('tl-combo-type')).not.toBeInTheDocument();
+  });
+
+  it('shows the combo type name for a single-card selection', async () => {
+    renderWithProviders(<TienLenPage />);
+    fireEvent.click(await screen.findByTestId('hand-card-0'));
+    const badge = screen.getByTestId('tl-combo-type');
+    expect(badge).toHaveTextContent('シングル'); // playType.single (ja locale)
+    expect(badge).toHaveTextContent('1枚');
+  });
+
+  it('shows the combo type name for a pair selection', async () => {
+    mockExec.mockResolvedValue(
+      makeState({
+        players: [
+          player(0, true, [card('SPADE', 7), card('HEART', 7)]),
+          player(1, false, []),
+          player(2, false, []),
+          player(3, false, []),
+        ],
+      }),
+    );
+    renderWithProviders(<TienLenPage />);
+    fireEvent.click(await screen.findByTestId('hand-card-0'));
+    fireEvent.click(screen.getByTestId('hand-card-1'));
+    const badge = screen.getByTestId('tl-combo-type');
+    expect(badge).toHaveTextContent('ペア'); // playType.pair
+    expect(badge).toHaveTextContent('2枚');
+  });
+
+  it('highlights a four-of-a-kind bomb', async () => {
+    mockExec.mockResolvedValue(
+      makeState({
+        players: [
+          player(0, true, [card('SPADE', 7), card('HEART', 7), card('CLOVER', 7), card('DIAMOND', 7)]),
+          player(1, false, []),
+          player(2, false, []),
+          player(3, false, []),
+        ],
+      }),
+    );
+    renderWithProviders(<TienLenPage />);
+    fireEvent.click(await screen.findByTestId('hand-card-0'));
+    fireEvent.click(screen.getByTestId('hand-card-1'));
+    fireEvent.click(screen.getByTestId('hand-card-2'));
+    fireEvent.click(screen.getByTestId('hand-card-3'));
+    const badge = screen.getByTestId('tl-combo-type');
+    expect(badge).toHaveTextContent('フォーカード'); // playType.fourOfAKind
+    expect(badge).toHaveTextContent('爆弾'); // bombLabel emphasis
+    expect(badge).toHaveClass('text-ds-warning');
   });
 
   it('passes when the pass button is clicked', async () => {

--- a/frontend/src/pages/TienLenPage.tsx
+++ b/frontend/src/pages/TienLenPage.tsx
@@ -29,7 +29,7 @@ import {
   type TienLenCliArgs,
 } from '../utils/cli/commands/tienlenCommands';
 import type { CliGameConfig } from '../utils/cli/types';
-import { isValidTienLenCombo } from '../utils/tienLenComboValidator';
+import { classifyTienLenCombo } from '../utils/tienLenComboValidator';
 
 // Values match the Go domain constants: 0=Normal, 1=Easy, 2=Hard
 // (see TienLenConfig.go / TienLenCuiController help text).
@@ -132,9 +132,12 @@ function TienLenPageContent() {
   const isHumanTurn = state.currentTurn === 0 && !isGameEnd;
   const human = state.players[0];
   const selectedCards = selectedIndices.map((i) => human.cards[i]).filter((c): c is NonNullable<typeof c> => c != null);
-  const hasValidCombo = isValidTienLenCombo(selectedCards);
+  const selectedCombo = classifyTienLenCombo(selectedCards);
+  const hasValidCombo = selectedCards.length > 0 && selectedCombo !== 'invalid';
+  const isBomb = selectedCombo === 'threePairRun' || selectedCombo === 'fourOfAKind';
   const canPlay = isHumanTurn && selectedIndices.length > 0 && hasValidCombo;
   const showInvalidCombo = isHumanTurn && selectedIndices.length > 0 && !hasValidCombo;
+  const showComboType = isHumanTurn && selectedIndices.length > 0 && hasValidCombo;
   const phaseName = isGameEnd ? t('phase.end') : t('phase.play');
 
   return (
@@ -267,6 +270,19 @@ function TienLenPageContent() {
           <ReplaySpeedSettingsPanel />
 
           <GameFooter className={`${gameTheme.tienlen.footer} px-4 py-2.5`}>
+            {showComboType && (
+              <p
+                role="status"
+                data-testid="tl-combo-type"
+                className={`mb-1 text-center text-xs font-semibold ${isBomb ? 'text-ds-warning' : 'text-ds-info'}`}
+              >
+                {`${t('selectedPlayLabel')}: ${t('comboBadge', {
+                  type: t(`playType.${selectedCombo}`),
+                  count: selectedCards.length,
+                })}`}
+                {isBomb && ` · ${t('bombLabel')}`}
+              </p>
+            )}
             {showInvalidCombo && (
               <p
                 role="status"


### PR DESCRIPTION
## Summary
Displays the TYPE NAME of the currently-selected card combination as the player picks cards in Tien Len, so they can see what they're about to play (single / pair / triple / straight / three-consecutive-pairs / four-of-a-kind), with the number of cards and a bomb emphasis for chops.

The Big Two page already surfaces a "selected play type" badge; this mirrors that pattern for Tien Len. The client-side classifier (`classifyTienLenCombo` in `tienLenComboValidator.ts`) already mirrors the Go domain `tienLenClassifyPlay` exactly — this PR only wires its result into the UI.

## Changes
- `TienLenPage.tsx`: compute the combo once via `classifyTienLenCombo`; render an additive `tl-combo-type` status badge above the play/pass row when the selection is a valid combo. Bombs (four-of-a-kind, three-consecutive-pairs) are highlighted with `text-ds-warning` + a "Bomb" tag. The existing `tl-invalid-combo` warning and play-button gating are unchanged.
- i18n (`ja`/`en` parity): add `selectedPlayLabel`, `comboBadge`, `bombLabel`. `playType.*` keys already existed.
- Tests: page tests for single, pair, and four-of-a-kind bomb badges + assertion that the badge is hidden for invalid selections. The validator's type-discrimination tests already existed.

## Combo types covered (mirrors domain exactly)
single, pair, triple, straight (3+ consecutive, mixed suits, no 2), threePairRun (3 consecutive pairs, chop/bomb), fourOfAKind (bomb); anything else → `invalid` (no badge, existing warning shown).

## Test plan
- [x] `bun run check` (exit 0)
- [x] `bun run test -- --run TienLen` (32 passed)
- [x] `bun run build` (tsc gate passes)
- [x] Frontend-only; no Go touched

Closes #3359