### PR TITLE
feat(eightoff): auto-send top cards to foundation on double-click

### DIFF
--- a/frontend/src/pages/EightOffPage.test.tsx
+++ b/frontend/src/pages/EightOffPage.test.tsx
@@ -863,6 +863,81 @@ describe('EightOffPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('undo_n', undefined, undefined, 3));
   });
 
+  // --- Double-click foundation shortcut ---
+
+  describe('double-click foundation shortcut', () => {
+    const tableauAceTop: EightOffResponse = {
+      ...playingState,
+      tableau: [[card('SPADE', 1)], [card('HEART', 12)], [], [], [], [], [], []],
+      foundation: [[], [], [], []],
+    };
+
+    const freeCellPlayable: EightOffResponse = {
+      ...playingState,
+      freeCells: [card('DIAMOND', 7), null, null, null, null, null, null, null],
+      foundation: [[], [], [], [card('DIAMOND', 6)]],
+    };
+
+    it('double-clicking a foundation-playable tableau top card auto-sends it to the foundation', async () => {
+      mockExec.mockResolvedValue(tableauAceTop);
+      renderWithProviders(<EightOffPage />);
+      await waitFor(() => expect(screen.getByAltText('♠ A')).toBeInTheDocument());
+
+      mockExec.mockClear();
+      mockExec.mockResolvedValue(playingState);
+      const cardButton = screen.getByAltText('♠ A').closest('button') as HTMLButtonElement;
+      fireEvent.doubleClick(cardButton);
+
+      await waitFor(() =>
+        expect(mockExec).toHaveBeenCalledWith(
+          'move',
+          expect.objectContaining({ zone: 'tableau', col: 0, cardIndex: 0 }),
+          { zone: 'foundation', col: 0 },
+        ),
+      );
+    });
+
+    it('double-clicking a foundation-playable free-cell card auto-sends it to the foundation', async () => {
+      mockExec.mockResolvedValue(freeCellPlayable);
+      renderWithProviders(<EightOffPage />);
+      await waitFor(() => expect(screen.getByAltText('♦ 7')).toBeInTheDocument());
+
+      mockExec.mockClear();
+      mockExec.mockResolvedValue(playingState);
+      const cardButton = screen.getByAltText('♦ 7').closest('button') as HTMLButtonElement;
+      fireEvent.doubleClick(cardButton);
+
+      await waitFor(() =>
+        expect(mockExec).toHaveBeenCalledWith('move', expect.objectContaining({ zone: 'freecell', cell: 0 }), {
+          zone: 'foundation',
+          col: 3,
+        }),
+      );
+    });
+
+    it('double-clicking a non-foundation-playable tableau top card does nothing', async () => {
+      // playingState: tableau[0] top is ♠ K with an empty foundation → no legal target.
+      renderWithProviders(<EightOffPage />);
+      await waitFor(() => expect(screen.getByAltText('♠ K')).toBeInTheDocument());
+
+      mockExec.mockClear();
+      const cardButton = screen.getByAltText('♠ K').closest('button') as HTMLButtonElement;
+      fireEvent.doubleClick(cardButton);
+
+      expect(mockExec).not.toHaveBeenCalledWith('move', expect.anything(), expect.anything());
+    });
+
+    it('ignores the trailing single-click of a double-click (detail >= 2) so no stray selection occurs', async () => {
+      mockExec.mockResolvedValue(tableauAceTop);
+      renderWithProviders(<EightOffPage />);
+      await waitFor(() => expect(screen.getByAltText('♠ A')).toBeInTheDocument());
+
+      const cardButton = screen.getByAltText('♠ A').closest('button') as HTMLButtonElement;
+      fireEvent.click(cardButton, { detail: 2 });
+      expect(cardButton).toHaveAttribute('aria-pressed', 'false');
+    });
+  });
+
   describe('drag and drop', () => {
     function buildDataTransfer() {
       const store: Record<string, string> = {};

--- a/frontend/src/pages/EightOffPage.tsx
+++ b/frontend/src/pages/EightOffPage.tsx
@@ -34,6 +34,7 @@ import { cardAlt } from '../utils/cardAlt';
 import { EIGHTOFF_HELP, parseEightOffCommand } from '../utils/cli/commands/eightoffCommands';
 import { formatEightoffState } from '../utils/cli/formatters/eightoffFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { eightOffFoundationTarget } from '../utils/eightOffFoundationTarget';
 
 const FOUNDATION_SUITS = ['♠', '♣', '♥', '♦'] as const;
 
@@ -172,6 +173,21 @@ function EightOffPageContent() {
     },
     [exec],
   );
+
+  // Double-click / double-tap shortcut: auto-send an exposed card (a column's
+  // top card or a free-cell card) straight to its foundation when a legal target
+  // exists; otherwise do nothing (single-click selection is left untouched).
+  // Mirrors the FreeCell / Easthaven foundation shortcut.
+  const handleFoundationShortcut = useCallback(
+    (source: EightOffMoveZone, card: Card) => {
+      if (!state) return;
+      const target = eightOffFoundationTarget(card, state.foundation);
+      if (!target) return;
+      dispatchMove(source, target);
+      playSound('cardPlace');
+    },
+    [state, dispatchMove, playSound],
+  );
   const dnd = useSolitaireDragDrop<EightOffMoveZone>({
     onMove: dispatchMove,
     isPlaying: !!isPlayingForKbd,
@@ -294,7 +310,14 @@ function EightOffPageContent() {
                         {card ? (
                           <button
                             type="button"
-                            onClick={() => handleSelectSource(freeCellZone)}
+                            onClick={(e) => {
+                              // The second click of a double-click also fires
+                              // onClick (detail === 2); ignore it so onDoubleClick
+                              // owns the foundation shortcut without a stray select.
+                              if (e.detail >= 2) return;
+                              handleSelectSource(freeCellZone);
+                            }}
+                            onDoubleClick={() => handleFoundationShortcut(freeCellZone, card)}
                             disabled={!isPlaying || loading}
                             aria-label={cardAlt(card)}
                             aria-pressed={isSourceSelected('freecell', undefined, idx)}
@@ -418,6 +441,7 @@ function EightOffPageContent() {
                               };
                               const stackSize = col.length - cardIdx;
                               const exceedsSupermove = stackSize > supermoveLimit;
+                              const isTopCard = cardIdx === col.length - 1;
                               const isInHoveredBlock =
                                 hoveredStack !== null &&
                                 hoveredStack.col === colIdx &&
@@ -432,13 +456,23 @@ function EightOffPageContent() {
                                   {card ? (
                                     <button
                                       type="button"
-                                      onClick={() => {
+                                      onClick={(e) => {
+                                        // The second click of a double-click also
+                                        // fires onClick (detail === 2); ignore it so
+                                        // onDoubleClick owns the foundation shortcut
+                                        // without a stray select/target move.
+                                        if (e.detail >= 2) return;
                                         if (selectedSource) {
                                           handleSelectTarget(tableauColZone);
                                         } else {
                                           handleSelectSource(cardZone);
                                         }
                                       }}
+                                      onDoubleClick={
+                                        // Only a column's exposed top card can move
+                                        // straight to a foundation.
+                                        isTopCard ? () => handleFoundationShortcut(cardZone, card) : undefined
+                                      }
                                       disabled={!isPlaying || loading}
                                       aria-label={cardAlt(card)}
                                       data-testid={`eo-tableau-${colIdx.toString()}-${cardIdx.toString()}`}

--- a/frontend/src/utils/eightOffFoundationTarget.test.ts
+++ b/frontend/src/utils/eightOffFoundationTarget.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import type { Card } from '../types/card';
+import { eightOffFoundationTarget } from './eightOffFoundationTarget';
+
+const c = (design: Card['design'], value: number): Card => ({ design, value });
+
+describe('eightOffFoundationTarget', () => {
+  it('sends an Ace to its empty suit pile', () => {
+    expect(eightOffFoundationTarget(c('HEART', 1), [[], [], [], []])).toEqual({ zone: 'foundation', col: 2 });
+  });
+
+  it('sends the next rank onto a matching-suit pile', () => {
+    const foundation = [[c('SPADE', 1)], [], [], []];
+    expect(eightOffFoundationTarget(c('SPADE', 2), foundation)).toEqual({ zone: 'foundation', col: 0 });
+  });
+
+  it('returns null for a non-Ace on an empty pile', () => {
+    expect(eightOffFoundationTarget(c('CLOVER', 5), [[], [], [], []])).toBeNull();
+  });
+
+  it('returns null when the rank is not exactly one higher', () => {
+    const foundation = [[], [c('CLOVER', 1)], [], []];
+    expect(eightOffFoundationTarget(c('CLOVER', 3), foundation)).toBeNull();
+  });
+
+  it('returns null when the suit does not match the target pile top', () => {
+    // Diamond maps to pile index 3, which is empty and only accepts an Ace.
+    const foundation = [[c('SPADE', 1)], [], [], []];
+    expect(eightOffFoundationTarget(c('DIAMOND', 2), foundation)).toBeNull();
+  });
+
+  it('returns null for an unknown design', () => {
+    expect(eightOffFoundationTarget(c('JOKER' as Card['design'], 1), [[], [], [], []])).toBeNull();
+  });
+});

--- a/frontend/src/utils/eightOffFoundationTarget.ts
+++ b/frontend/src/utils/eightOffFoundationTarget.ts
@@ -1,0 +1,36 @@
+import type { EightOffMoveZone } from '../api/gameApi';
+import type { Card } from '../types/card';
+
+/**
+ * Maps a card design to its 0-based foundation index, matching the foundation
+ * layout (`♠`=0, `♣`=1, `♥`=2, `♦`=3). Mirrors the backend's
+ * `card.GetDesign() - 1` in `EightOff.MoveTableauToFoundation` /
+ * `EightOff.MoveFreeCellToFoundation`.
+ */
+const DESIGN_TO_FOUNDATION_INDEX: Record<string, number> = {
+  SPADE: 0,
+  CLOVER: 1,
+  HEART: 2,
+  DIAMOND: 3,
+};
+
+/**
+ * Computes the legal foundation move target for `card` given the current
+ * `foundation` piles, or `null` when no legal foundation move exists.
+ *
+ * Mirrors the domain's `canPlaceOnFoundation`: an empty pile accepts only an
+ * Ace (`value === 1`); otherwise the card's suit must match the pile and its
+ * rank must be exactly one higher than the pile's top card. The pile is
+ * selected by suit, so a matching pile is always the same suit.
+ *
+ * @param card - The card being double-clicked (a tableau top card or a free-cell card).
+ * @param foundation - The four foundation piles (bottom card first).
+ * @returns A `{ zone: 'foundation', col }` move target, or `null` if illegal.
+ */
+export function eightOffFoundationTarget(card: Card, foundation: Card[][]): EightOffMoveZone | null {
+  const fIdx = DESIGN_TO_FOUNDATION_INDEX[card.design];
+  if (fIdx === undefined || fIdx >= foundation.length) return null;
+  const pile = foundation[fIdx];
+  const placeable = pile.length === 0 ? card.value === 1 : card.value === pile[pile.length - 1].value + 1;
+  return placeable ? { zone: 'foundation', col: fIdx } : null;
+}


### PR DESCRIPTION
## Summary

Adds the FreeCell-family double-click / double-tap convenience move to **Eight Off** (`eightoff`): double-clicking a tableau column's exposed top card, or a free-cell card, auto-sends it straight to its foundation when a legal target exists. Non-playable cards do nothing and single-click selection is untouched.

## Changes

- **`frontend/src/utils/eightOffFoundationTarget.ts`** (new) — pure helper returning the valid `{ zone: 'foundation', col }` target for a card, or `null`. Mirrors the domain's `EightOff.canPlaceOnFoundation` (Ace on an empty pile; otherwise same-suit and exactly one rank higher) and the existing `easthavenFoundationTarget` / `freeCellFoundationTarget` helpers.
- **`frontend/src/pages/EightOffPage.tsx`** — `handleFoundationShortcut` dispatches the auto-move; `onDoubleClick` wired on the tableau top card and free-cell card buttons; `e.detail >= 2` guard on their `onClick` handlers so the double-click's trailing single click doesn't issue a stray select/target move.
- Tests added for the helper (`eightOffFoundationTarget.test.ts`) and the page (`EightOffPage.test.tsx`).

## Verification

- [x] Double-clicking a foundation-playable tableau top card issues `move` → foundation
- [x] Same works for a foundation-playable free-cell card
- [x] Double-clicking a non-playable top card issues no move (selection intact)
- [x] `e.detail >= 2` trailing click does not create a stray selection
- [x] `bun run check` (Biome + design tokens) passes
- [x] `bun run test -- --run EightOff` — 93 passed
- [x] `bun run build` (tsc) passes

Frontend-only; no Go changes.

Closes #3322

🤖 Generated with [Claude Code](https://claude.com/claude-code)