### PR TITLE
fix(sultan): distinguish the 8 foundation piles with suit + position labels

### DIFF
--- a/frontend/src/i18n/locales/en/sultan.json
+++ b/frontend/src/i18n/locales/en/sultan.json
@@ -15,6 +15,8 @@
   "giveup": "Give Up",
   "empty": "Empty",
   "emptyDivanSlot": "Empty divan slot {{idx}}",
+  "foundationSlot": "Foundation {{idx}}, top {{top}}",
+  "emptyFoundationSlot": "Foundation {{idx}}, empty (build from K)",
   "landscapeBanner": "Landscape mode recommended",
   "hint": "Hint",
   "autoComplete": "Auto Complete",

--- a/frontend/src/i18n/locales/ja/sultan.json
+++ b/frontend/src/i18n/locales/ja/sultan.json
@@ -15,6 +15,8 @@
   "giveup": "ギブアップ",
   "empty": "空",
   "emptyDivanSlot": "空のディヴァン枠 {{idx}}",
+  "foundationSlot": "組札{{idx}} 一番上 {{top}}",
+  "emptyFoundationSlot": "組札{{idx}} 空（Kから積む）",
   "landscapeBanner": "横向き表示推奨",
   "hint": "ヒント",
   "autoComplete": "自動完成",

--- a/frontend/src/pages/SultanPage.test.tsx
+++ b/frontend/src/pages/SultanPage.test.tsx
@@ -140,15 +140,40 @@ describe('SultanPage', () => {
     expect(imgs.length).toBeGreaterThanOrEqual(8);
   });
 
-  it('renders empty foundation placeholder with K', async () => {
+  it('labels each foundation with its position number and suit so they are distinguishable', async () => {
+    renderWithProviders(<SultanPage />);
+    await waitFor(() => expect(screen.getByText('ウェイスト')).toBeInTheDocument());
+    // Position number + King-base suit disambiguates the two piles per suit.
+    expect(screen.getByTestId('sultan-foundation-label-0')).toHaveTextContent('1 ♠');
+    expect(screen.getByTestId('sultan-foundation-label-1')).toHaveTextContent('2 ♠');
+    expect(screen.getByTestId('sultan-foundation-label-4')).toHaveTextContent('5 ♥');
+    expect(screen.getByTestId('sultan-foundation-label-7')).toHaveTextContent('8 ♦');
+    // Each foundation cell carries a distinct aria-label (not a uniform "K").
+    const labels = [1, 2, 3, 4, 5, 6, 7, 8].map(
+      (n) => screen.getByTestId(`sultan-foundation-label-${(n - 1).toString()}`).textContent,
+    );
+    expect(new Set(labels).size).toBe(8);
+  });
+
+  it('exposes a numbered aria-label for each foundation card', async () => {
+    renderWithProviders(<SultanPage />);
+    await waitFor(() => expect(screen.getByText('ウェイスト')).toBeInTheDocument());
+    // Two spade piles both top a King, but their aria-labels differ by position.
+    expect(screen.getByRole('img', { name: '組札1 一番上 ♠ K' })).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: '組札2 一番上 ♠ K' })).toBeInTheDocument();
+  });
+
+  it('renders empty foundation placeholder with position number and K build hint', async () => {
     mockExec.mockResolvedValue({
       ...playingState,
       foundation: [[], [], [], [], [], [], [], []],
     });
     renderWithProviders(<SultanPage />);
     await waitFor(() => expect(screen.getByText('ウェイスト')).toBeInTheDocument());
-    const kElements = screen.getAllByText('K');
-    expect(kElements.length).toBeGreaterThanOrEqual(1);
+    // "K" build hint is retained, and each empty slot is announced by position.
+    expect(screen.getAllByText('K').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByRole('img', { name: '組札1 空（Kから積む）' })).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: '組札8 空（Kから積む）' })).toBeInTheDocument();
   });
 
   it('renders divan slots, empty ones show placeholder', async () => {

--- a/frontend/src/pages/SultanPage.tsx
+++ b/frontend/src/pages/SultanPage.tsx
@@ -30,6 +30,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import { parseSultanCommand, SULTAN_HELP } from '../utils/cli/commands/sultanCommands';
 import { formatSultanState } from '../utils/cli/formatters/sultanFormatter';
+import { sultanFoundationInfo } from '../utils/sultanFoundation';
 
 /**
  * Maximum number of waste redeals allowed in Sultan of Turkey.
@@ -260,26 +261,45 @@ function SultanPageContent() {
 
               {/* Foundation piles (8 King-based piles) */}
               <div className="flex gap-1 sm:gap-2 flex-wrap" data-tutorial="sultan-foundation">
-                {state.foundation.map((pile, idx) => (
-                  <div key={`f-${idx.toString()}`} className="text-center">
-                    <div className="text-game-text-muted text-xs mb-1">{idx + 1}</div>
-                    {pile.length > 0 ? (
-                      <AnimatedCard
-                        card={pile[pile.length - 1]}
-                        width={sultan.cw}
-                        draggable={false}
-                        dealDelay={isAutoCompleting ? idx * 0.15 : 0}
-                      />
-                    ) : (
+                {state.foundation.map((pile, idx) => {
+                  const info = sultanFoundationInfo(pile);
+                  return (
+                    <div key={`f-${idx.toString()}`} className="text-center">
                       <div
-                        style={{ width: sultan.cw, height: sultan.ch }}
-                        className="rounded border-2 border-dashed border-white/30 text-game-text-muted text-xs flex items-center justify-center"
+                        className="text-game-text-muted text-xs mb-1"
+                        data-testid={`sultan-foundation-label-${idx.toString()}`}
                       >
-                        K
+                        {info.suit ? `${idx + 1} ${info.suit}` : idx + 1}
                       </div>
-                    )}
-                  </div>
-                ))}
+                      {pile.length > 0 ? (
+                        <div
+                          role="img"
+                          aria-label={t('foundationSlot', {
+                            idx: idx + 1,
+                            top: cardAlt(pile[pile.length - 1]),
+                          })}
+                        >
+                          <AnimatedCard
+                            card={pile[pile.length - 1]}
+                            width={sultan.cw}
+                            draggable={false}
+                            dealDelay={isAutoCompleting ? idx * 0.15 : 0}
+                          />
+                        </div>
+                      ) : (
+                        <div
+                          role="img"
+                          aria-label={t('emptyFoundationSlot', { idx: idx + 1 })}
+                          style={{ width: sultan.cw, height: sultan.ch }}
+                          className="rounded border-2 border-dashed border-white/30 text-game-text-muted text-xs flex flex-col items-center justify-center leading-tight"
+                        >
+                          <span>{idx + 1}</span>
+                          <span>K</span>
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
               </div>
             </div>
 

--- a/frontend/src/utils/sultanFoundation.test.ts
+++ b/frontend/src/utils/sultanFoundation.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import type { Card } from '../types/card';
+import { SULTAN_FOUNDATION_FULL, sultanFoundationInfo } from './sultanFoundation';
+
+const card = (design: Card['design'], value: number): Card => ({ design, value });
+
+describe('sultanFoundationInfo', () => {
+  it('reads the suit from the King base of a fresh pile', () => {
+    const info = sultanFoundationInfo([card('SPADE', 13)]);
+    expect(info.suit).toBe('♠');
+    expect(info.design).toBe('SPADE');
+    expect(info.count).toBe(1);
+    expect(info.complete).toBe(false);
+  });
+
+  it('keeps the King base suit as the pile grows', () => {
+    const info = sultanFoundationInfo([card('HEART', 13), card('HEART', 1), card('HEART', 2)]);
+    expect(info.suit).toBe('♥');
+    expect(info.design).toBe('HEART');
+    expect(info.count).toBe(3);
+    expect(info.complete).toBe(false);
+  });
+
+  it('marks a pile of 13 cards as complete', () => {
+    const pile = Array.from({ length: SULTAN_FOUNDATION_FULL }, () => card('DIAMOND', 13));
+    const info = sultanFoundationInfo(pile);
+    expect(info.complete).toBe(true);
+    expect(info.suit).toBe('♦');
+  });
+
+  it('reports no suit for an empty pile', () => {
+    const info = sultanFoundationInfo([]);
+    expect(info.suit).toBe('');
+    expect(info.design).toBeNull();
+    expect(info.count).toBe(0);
+    expect(info.complete).toBe(false);
+  });
+});

--- a/frontend/src/utils/sultanFoundation.ts
+++ b/frontend/src/utils/sultanFoundation.ts
@@ -1,0 +1,37 @@
+import type { Card } from '../types/card';
+import { suitSymbol } from './cardAlt';
+
+/**
+ * Number of cards on a completed Sultan foundation (King + A..Q = 13).
+ * Mirrors the backend `domain.SultanFoundationFull`.
+ */
+export const SULTAN_FOUNDATION_FULL = 13;
+
+/** Display metadata for a single Sultan foundation pile. */
+export interface SultanFoundationInfo {
+  /** Suit symbol (♠♥♦♣) of the King base, or an empty string when the pile has no base. */
+  suit: string;
+  /** Suit design of the King base, or null when the pile is empty. */
+  design: Card['design'] | null;
+  /** Number of cards on the pile (>=1 once the King base is placed). */
+  count: number;
+  /** True once the pile holds all 13 cards (K + A..Q). */
+  complete: boolean;
+}
+
+/**
+ * Derive display metadata for a Sultan foundation pile.
+ *
+ * Every Sultan foundation is seeded with a King (two decks → two piles per
+ * suit) and builds K→A→2…→Q in that suit, so the pile's target suit is read
+ * from its base card (`pile[0]`). An empty pile (no King base) reports no suit.
+ */
+export function sultanFoundationInfo(pile: Card[]): SultanFoundationInfo {
+  const base = pile.length > 0 ? pile[0] : null;
+  return {
+    suit: base ? suitSymbol(base.design) : '',
+    design: base ? base.design : null,
+    count: pile.length,
+    complete: pile.length >= SULTAN_FOUNDATION_FULL,
+  };
+}


### PR DESCRIPTION
Closes #3294

## Problem
The 8 King-based foundation piles were labelled only with a bare position number (`idx + 1`) and, when empty, a uniform `"K"` placeholder. Since two decks give two foundations per suit, the piles were hard to tell apart — visually and for screen-reader users the foundation cards carried no distinguishing label at all.

## Fix (frontend-only, Sultan-scoped)
- **Suit + position label** above each foundation: e.g. `1 ♠`, `2 ♠`, `5 ♥`, `8 ♦`. The suit is read from the pile's King base (`pile[0]`), matching Sultan's rule that each foundation builds K→A→2…→Q in a fixed suit.
- **Distinct aria-label per foundation card** (`role="img"`, `組札{n} 一番上 {top}`) so the two same-suit piles differ by position for assistive tech.
- **Empty placeholder** now shows the position number *and* keeps the `K` build hint, with a numbered aria-label (`組札{n} 空（Kから積む）`). (This branch is only reachable via synthetic state — the domain always seeds a King — but the issue and its test exercise it.)
- New pure helper `sultanFoundationInfo(pile)` (suit/design/count/complete) with unit tests.
- Added `foundationSlot` / `emptyFoundationSlot` i18n keys (ja + en parity).

No shared placeholder components were touched; all changes are Sultan-scoped. Rules verified against `internal/domain/Sultan.go` (READ-ONLY, no Go changed).

## Test plan
- [x] `bun run check` (biome + design-tokens) — clean
- [x] `bun run test -- --run Sultan` — 67 passing (added: `labels each foundation with its position number and suit so they are distinguishable`, `exposes a numbered aria-label for each foundation card`, updated the empty-placeholder test; plus `sultanFoundation.test.ts`)
- [x] `bun run build` (tsc) — succeeds