### PR TITLE
feat(tienlen): show which player played the current table combo

### DIFF
--- a/frontend/src/i18n/locales/en/tienlen.json
+++ b/frontend/src/i18n/locales/en/tienlen.json
@@ -9,6 +9,7 @@
   "selectToPlay": "Click cards to select",
   "tableCards": "Table",
   "tableEmpty": "(empty)",
+  "tablePlayedBy": "Played by {{name}}",
   "playButton": "Play Selected",
   "passButton": "Pass",
   "invalidCombo": "Not a valid combination (single, pair, triple, straight, double-sequence, or four of a kind)",

--- a/frontend/src/i18n/locales/ja/tienlen.json
+++ b/frontend/src/i18n/locales/ja/tienlen.json
@@ -9,6 +9,7 @@
   "selectToPlay": "カードを選択して出す",
   "tableCards": "場のカード",
   "tableEmpty": "(なし)",
+  "tablePlayedBy": "{{name}} の出したカード",
   "playButton": "選択したカードを出す",
   "passButton": "パス",
   "invalidCombo": "有効な組み合わせではありません（シングル・ペア・トリオ・ストレート・連続ペア・フォーカード）",

--- a/frontend/src/pages/TienLenPage.test.tsx
+++ b/frontend/src/pages/TienLenPage.test.tsx
@@ -140,6 +140,26 @@ describe('TienLenPage', () => {
     expect(badge).toHaveClass('text-ds-warning');
   });
 
+  it('labels the table combo with the CPU player who played it', async () => {
+    mockExec.mockResolvedValue(
+      makeState({
+        tableCards: [card('SPADE', 3)],
+        lastPlayPlayerIdx: 2,
+        currentTurn: 0,
+      }),
+    );
+    renderWithProviders(<TienLenPage />);
+    const owner = await screen.findByTestId('tl-table-owner');
+    expect(owner).toHaveTextContent('CPU 2'); // findPlayerName for a non-human player
+  });
+
+  it('does not show the table owner label when the table is empty (new round lead)', async () => {
+    mockExec.mockResolvedValue(makeState({ tableCards: [], lastPlayPlayerIdx: -1 }));
+    renderWithProviders(<TienLenPage />);
+    await screen.findByTestId('pass-button');
+    expect(screen.queryByTestId('tl-table-owner')).not.toBeInTheDocument();
+  });
+
   it('passes when the pass button is clicked', async () => {
     renderWithProviders(<TienLenPage />);
     fireEvent.click(await screen.findByTestId('pass-button'));

--- a/frontend/src/pages/TienLenPage.tsx
+++ b/frontend/src/pages/TienLenPage.tsx
@@ -29,6 +29,7 @@ import {
   type TienLenCliArgs,
 } from '../utils/cli/commands/tienlenCommands';
 import type { CliGameConfig } from '../utils/cli/types';
+import { findPlayerName } from '../utils/playerUtils';
 import { classifyTienLenCombo } from '../utils/tienLenComboValidator';
 
 // Values match the Go domain constants: 0=Normal, 1=Easy, 2=Hard
@@ -192,6 +193,11 @@ function TienLenPageContent() {
             {/* Table cards */}
             <div className="py-3 bg-black/20 rounded-lg" data-tutorial="tl-table-cards">
               <div className="text-center text-xs text-ds-text-muted mb-2">{t('tableCards')}</div>
+              {state.tableCards.length > 0 && state.lastPlayPlayerIdx >= 0 && (
+                <div className="text-center text-xs font-semibold text-ds-info mb-2" data-testid="tl-table-owner">
+                  {t('tablePlayedBy', { name: findPlayerName(state.players, state.lastPlayPlayerIdx) })}
+                </div>
+              )}
               <div className="flex justify-center gap-2 min-h-[60px]">
                 {state.tableCards.length === 0 ? (
                   <span className="text-ds-text-muted text-sm self-center">{t('tableEmpty')}</span>


### PR DESCRIPTION
## 概要
ティエンレンのテーブル表示（`tl-table-cards`）に、現在場に出ているコンボを**誰が出したか**のラベルを追加します。手番のプレイヤーは誰を上回る必要があるのかが一目で分かるようになります。

レスポンスの既存フィールド `lastPlayPlayerIdx`（ドメインの「最後にカードを出したプレイヤーインデックス」。テーブルリセット時は `-1`）を利用し、ローカライズ済みプレイヤー名ユーティリティ `findPlayerName(players, idx)` でラベルを表示します。Go 側は変更していません（フィールドは既に公開済み）。

- テーブルにカードがあり `lastPlayPlayerIdx >= 0` のときのみ「CPU 2 の出したカード / Played by CPU 2」を追加表示（`data-testid="tl-table-owner"`）
- テーブルが空（新ラウンドのリード）のときはラベル非表示
- PR #4180 のコンボ種別バッジやプレイ操作のゲーティングには一切手を加えていません

## 変更ファイル
- `frontend/src/pages/TienLenPage.tsx`
- `frontend/src/pages/TienLenPage.test.tsx`
- `frontend/src/i18n/locales/{ja,en}/tienlen.json`（`tablePlayedBy` キーを追加、ja+en パリティ）

## テスト
- 追加: `labels the table combo with the CPU player who played it`
- 追加: `does not show the table owner label when the table is empty (new round lead)`

## Gate
- [x] `bun run check`
- [x] `bun run test -- --run TienLen`（34 passed）
- [x] `bun run build`（tsc）

Closes #3358