### PR TITLE
feat(fivehundred): show player names and lead marker on the current trick

### DIFF
--- a/frontend/src/i18n/locales/en/fivehundred.json
+++ b/frontend/src/i18n/locales/en/fivehundred.json
@@ -17,6 +17,7 @@
   "passed": "pass",
   "currentTrick": "Current trick",
   "trickEmpty": "(no cards yet)",
+  "lead": "Lead",
   "tricksLabel": "Tricks",
   "selectTricks": "Select tricks (6-10):",
   "misereButton": "Misere",

--- a/frontend/src/i18n/locales/ja/fivehundred.json
+++ b/frontend/src/i18n/locales/ja/fivehundred.json
@@ -17,6 +17,7 @@
   "passed": "パス",
   "currentTrick": "現在のトリック",
   "trickEmpty": "(まだカードがありません)",
+  "lead": "リード",
   "tricksLabel": "トリック数",
   "selectTricks": "トリック数を選択 (6-10):",
   "misereButton": "ミゼール",

--- a/frontend/src/pages/FiveHundredPage.test.tsx
+++ b/frontend/src/pages/FiveHundredPage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fiveHundredApi } from '../api/gameApi';
 import { renderWithProviders } from '../test/renderWithProviders';
@@ -206,6 +206,34 @@ describe('FiveHundredPage', () => {
     expect(playBtn).toBeEnabled();
     fireEvent.click(playBtn);
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', { cardIndex: 0, jokerSuit: undefined }));
+  });
+
+  it('labels each current-trick card with its player name and marks the lead card', async () => {
+    mockExec.mockResolvedValue(
+      makeState({
+        phase: 2,
+        currentPlayerIdx: 3,
+        // Player 2 (CPU) led the trick, then the human (player 0) followed.
+        currentTrick: [
+          { playerIdx: 2, card: card('SPADE', 10) },
+          { playerIdx: 0, card: card('HEART', 9) },
+        ],
+      }),
+    );
+    renderWithProviders(<FiveHundredPage />);
+
+    // Both cards carry a player-name label (scoped to the trick, not the CPU roster).
+    const trickCards = await screen.findAllByTestId('fh-trick-card');
+    expect(trickCards).toHaveLength(2);
+    expect(within(trickCards[0]).getByText(/CPU 2/)).toBeInTheDocument();
+    expect(within(trickCards[1]).getByText(/あなた/)).toBeInTheDocument();
+
+    // Exactly the lead (first) card shows the lead marker.
+    const leadBadges = screen.getAllByTestId('fh-trick-lead');
+    expect(leadBadges).toHaveLength(1);
+    expect(leadBadges[0]).toHaveTextContent('リード');
+    expect(trickCards[0]).toHaveAttribute('data-trick-lead', 'true');
+    expect(trickCards[1]).not.toHaveAttribute('data-trick-lead');
   });
 
   it('advances to the next trick', async () => {

--- a/frontend/src/pages/FiveHundredPage.tsx
+++ b/frontend/src/pages/FiveHundredPage.tsx
@@ -34,6 +34,7 @@ import {
   FIVEHUNDRED_OPEN_MISERE_VALUE,
   fivehundredBidValue,
 } from '../utils/fivehundredBidValue';
+import { playerName } from '../utils/playerUtils';
 
 const CPU_DIFFICULTY_SELECT = [
   { value: '0', label: 'Easy' },
@@ -253,9 +254,34 @@ function FiveHundredPageContent() {
                 {state.currentTrick.length === 0 ? (
                   <span className="text-ds-text-muted text-sm self-center">{t('trickEmpty')}</span>
                 ) : (
-                  state.currentTrick.map((tcard) => (
-                    <AnimatedCard key={tcard.playerIdx} card={tcard.card} width={cardWidth * 0.9} />
-                  ))
+                  // The first card in the trick was played by the lead player.
+                  state.currentTrick.map((tcard, i) => {
+                    const player = state.players[tcard.playerIdx];
+                    const isLead = i === 0;
+                    const isAlly = player !== undefined && player.team === humanTeam;
+                    return (
+                      <div
+                        key={tcard.playerIdx}
+                        className="relative text-center"
+                        data-testid="fh-trick-card"
+                        data-trick-lead={isLead || undefined}
+                      >
+                        {isLead && (
+                          <span
+                            data-testid="fh-trick-lead"
+                            className="absolute top-0 left-0 z-10 px-1 rounded bg-ds-accent text-ds-text-on-accent text-[8px] font-extrabold tracking-wider shadow-md pointer-events-none"
+                          >
+                            {t('lead')}
+                          </span>
+                        )}
+                        <AnimatedCard card={tcard.card} width={cardWidth * 0.9} />
+                        <div className={`text-xs mt-1 ${isAlly ? 'text-ds-info font-semibold' : 'text-ds-text-muted'}`}>
+                          {playerName(player?.id ?? tcard.playerIdx, player?.isHuman ?? false)}{' '}
+                          <span className="opacity-70">({t('teamShort', { team: player?.team ?? 0 })})</span>
+                        </div>
+                      </div>
+                    );
+                  })
                 )}
               </div>
             </div>


### PR DESCRIPTION
Closes #3364

## What
On the Five Hundred current-trick display, each played card now shows the name of the player who played it (localized `player.you` / `player.cpu`) plus its team tag, and the lead card is marked with a `Lead` / `リード` badge. This makes it clear who played what and who started the trick — key strategic info in the 4-player, 2-team game.

## How
- `FiveHundredPage.tsx`: replaced the bare `AnimatedCard` map in the `fh-trick` area with a labelled card that renders the player name + team-short under each card. The lead is derived as the first card in `currentTrick` (always the lead player, robust across phases). Ally cards (human's team) are tinted with `text-ds-info`. Additive only — empty-state and tutorial anchor unchanged; card width stays `cardWidth * 0.9`.
- Added `lead` i18n key to `ja` + `en` fivehundred locales (parity kept).
- `FiveHundredPage.test.tsx`: new test asserting each current-trick card shows its player's name (scoped via `within`) and only the lead card carries the marker.

## Testing
- [x] `bun run check` (biome) — pass
- [x] `bun run test -- --run FiveHundred` — 32 pass (incl. new test)
- [x] `bun run build` (tsc) — pass

## Checklist
- [x] Player name shown under each current-trick card
- [x] Lead player's card visually marked
- [x] Mobile layout intact (cardWidth×0.9 basis)
- [x] Test added for player-name display + lead marker
- [x] ja/en i18n parity
- [x] Frontend only; no Go changes