### PR TITLE
feat(tarneeb): show redeal count in the round info area

### DIFF
--- a/frontend/src/i18n/locales/en/tarneeb.json
+++ b/frontend/src/i18n/locales/en/tarneeb.json
@@ -27,6 +27,7 @@
     "diamond": "Diamond"
   },
   "highestBid": "Current high bid",
+  "redeal": "Redeals: {{count}}",
   "cards": "{{count}} cards",
   "bid": "bid {{n}}",
   "bidNone": "no bid",

--- a/frontend/src/i18n/locales/ja/tarneeb.json
+++ b/frontend/src/i18n/locales/ja/tarneeb.json
@@ -27,6 +27,7 @@
     "diamond": "ダイヤ"
   },
   "highestBid": "現在の最高ビッド",
+  "redeal": "リディール {{count}}回",
   "cards": "{{count}}枚",
   "bid": "ビッド {{n}}",
   "bidNone": "未ビッド",

--- a/frontend/src/pages/TarneebPage.test.tsx
+++ b/frontend/src/pages/TarneebPage.test.tsx
@@ -75,6 +75,20 @@ describe('TarneebPage', () => {
     expect(screen.queryByRole('button', { name: 'trump-1' })).not.toBeInTheDocument();
   });
 
+  it('shows the redeal count in the round info when a redeal has occurred', async () => {
+    mockExec.mockResolvedValue(makeState({ redealCount: 2 }));
+    renderWithProviders(<TarneebPage />);
+    const redeal = await screen.findByTestId('tarneeb-redeal-count');
+    expect(redeal).toHaveTextContent('リディール 2回');
+  });
+
+  it('hides the redeal count when no redeal has occurred', async () => {
+    mockExec.mockResolvedValue(makeState({ redealCount: 0 }));
+    renderWithProviders(<TarneebPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined, undefined, expect.any(Object)));
+    expect(screen.queryByTestId('tarneeb-redeal-count')).not.toBeInTheDocument();
+  });
+
   it('labels the human team and opponents and shows round tricks + total per team', async () => {
     const { container } = renderWithProviders(<TarneebPage />);
     await waitFor(() => expect(container.querySelector('[data-tutorial="tn-score-table"] table')).not.toBeNull());

--- a/frontend/src/pages/TarneebPage.tsx
+++ b/frontend/src/pages/TarneebPage.tsx
@@ -275,9 +275,12 @@ function TarneebPageContent() {
                 {t('trump')}: {TRUMP_LABELS[state.trumpSuit] ?? t('trumpUndeclared')}
               </span>
               {state.highestBid > 0 && (
-                <span>
+                <span className="mr-4">
                   {t('highestBid')}: {state.highestBid}
                 </span>
+              )}
+              {state.redealCount > 0 && (
+                <span data-testid="tarneeb-redeal-count">{t('redeal', { count: state.redealCount })}</span>
               )}
             </div>
 


### PR DESCRIPTION
## Summary

The redeal count (how many times a hand was redealt when everyone passes) was tracked by the domain and shown in the CUI (`TarneebCuiPresenter` via `tarneeb.redealLine`) but never surfaced in the Web UI. This adds a frontend-only display of the existing `redealCount` field from `TarneebResponse` in the round-info area.

- Displays "リディール N回" / "Redeals: N" next to round/trick/trump/highest-bid.
- Only shown when `redealCount > 0` (hidden at 0), matching the CUI's `> 0` guard.
- Reuses the already-exposed `redealCount` field (set by `TarneebWebPresenter` via `GetRedealCount()`); no Go changes.

## Changes

- `frontend/src/pages/TarneebPage.tsx`: additive `<span data-testid="tarneeb-redeal-count">` in the round-info row.
- `frontend/src/i18n/locales/{ja,en}/tarneeb.json`: new `redeal` key (ja + en parity).
- `frontend/src/pages/TarneebPage.test.tsx`: tests for shown-when-N and hidden-when-0.

## Test plan

- [x] `bun run check` (biome) passes
- [x] `bun run test -- --run Tarneeb` passes (19 tests, incl. new redeal tests)
- [x] `bun run build` (tsc) passes

Closes #3305