### PR TITLE
feat(doudizhu): pre-warn invalid card-combo plays on the frontend

### DIFF
--- a/frontend/src/i18n/locales/en/doudizhu.json
+++ b/frontend/src/i18n/locales/en/doudizhu.json
@@ -51,5 +51,25 @@
     "playLowest": "Play your lowest card to conserve strong cards",
     "bomb": "Use a bomb to take control",
     "pass": "Pass — save your strong cards"
+  },
+  "combo": {
+    "selectedLabel": "Selected",
+    "badge": "{{type}} ({{count}} cards)",
+    "notCombo": "Not a valid combination — check your selection",
+    "noBeat": "This combo cannot beat the current table play",
+    "type": {
+      "single": "Single",
+      "pair": "Pair",
+      "trio": "Trio",
+      "trioSingle": "Trio + single",
+      "trioPair": "Trio + pair",
+      "straight": "Straight",
+      "consecutivePair": "Consecutive pairs",
+      "airplane": "Airplane",
+      "airplaneSingle": "Airplane + singles",
+      "airplanePair": "Airplane + pairs",
+      "bomb": "Bomb",
+      "rocket": "Rocket"
+    }
   }
 }

--- a/frontend/src/i18n/locales/ja/doudizhu.json
+++ b/frontend/src/i18n/locales/ja/doudizhu.json
@@ -51,5 +51,25 @@
     "playLowest": "弱いカードから出して強いカードを温存",
     "bomb": "爆弾で場を制する",
     "pass": "パス — 強いカードを温存"
+  },
+  "combo": {
+    "selectedLabel": "選択中",
+    "badge": "{{type}}（{{count}}枚）",
+    "notCombo": "有効な役になっていません — 選択を確認してください",
+    "noBeat": "この役では場のカードに勝てません",
+    "type": {
+      "single": "単張",
+      "pair": "対子",
+      "trio": "三条",
+      "trioSingle": "三帯一",
+      "trioPair": "三帯二",
+      "straight": "順子",
+      "consecutivePair": "連対",
+      "airplane": "飛機",
+      "airplaneSingle": "飛機帯単",
+      "airplanePair": "飛機帯対",
+      "bomb": "爆弾",
+      "rocket": "ロケット"
+    }
   }
 }

--- a/frontend/src/pages/DoudizhuPage.test.tsx
+++ b/frontend/src/pages/DoudizhuPage.test.tsx
@@ -273,6 +273,91 @@ describe('DoudizhuPage', () => {
     });
   });
 
+  it('warns that a mismatched selection is not a valid combo', async () => {
+    mockExec.mockResolvedValue({
+      ...defaultState,
+      players: [
+        {
+          id: 0,
+          isHuman: true,
+          isFinished: false,
+          isLandlord: true,
+          cardCount: 2,
+          cards: [
+            { design: 'SPADE', value: 5 },
+            { design: 'HEART', value: 9 },
+          ],
+        },
+        { id: 1, isHuman: false, isFinished: false, isLandlord: false, cardCount: 17, cards: [] },
+        { id: 2, isHuman: false, isFinished: false, isLandlord: false, cardCount: 17, cards: [] },
+      ],
+    });
+    renderWithProviders(<DoudizhuPage />);
+    fireEvent.click(await screen.findByRole('button', { name: '♠ 5' }));
+    fireEvent.click(screen.getByRole('button', { name: '♥ 9' }));
+    expect(await screen.findByTestId('ddz-invalid-combo')).toBeInTheDocument();
+  });
+
+  it('warns that a valid-but-too-low combo cannot beat the table', async () => {
+    mockExec.mockResolvedValue({
+      ...defaultState,
+      tableCards: [
+        { design: 'SPADE', value: 8 },
+        { design: 'HEART', value: 8 },
+        { design: 'DIAMOND', value: 8 },
+      ],
+      tableCombo: 'trio',
+      players: [
+        {
+          id: 0,
+          isHuman: true,
+          isFinished: false,
+          isLandlord: false,
+          cardCount: 3,
+          cards: [
+            { design: 'SPADE', value: 5 },
+            { design: 'HEART', value: 5 },
+            { design: 'DIAMOND', value: 5 },
+          ],
+        },
+        { id: 1, isHuman: false, isFinished: false, isLandlord: true, cardCount: 17, cards: [] },
+        { id: 2, isHuman: false, isFinished: false, isLandlord: false, cardCount: 17, cards: [] },
+      ],
+    });
+    renderWithProviders(<DoudizhuPage />);
+    fireEvent.click(await screen.findByRole('button', { name: '♠ 5' }));
+    fireEvent.click(screen.getByRole('button', { name: '♥ 5' }));
+    fireEvent.click(screen.getByRole('button', { name: '♦ 5' }));
+    expect(await screen.findByTestId('ddz-no-beat')).toBeInTheDocument();
+  });
+
+  it('shows the combo type for a valid beating play', async () => {
+    mockExec.mockResolvedValue({
+      ...defaultState,
+      tableCards: [{ design: 'CLOVER', value: 13 }],
+      tableCombo: 'single',
+      players: [
+        {
+          id: 0,
+          isHuman: true,
+          isFinished: false,
+          isLandlord: false,
+          cardCount: 1,
+          cards: [{ design: 'SPADE', value: 2 }],
+        },
+        { id: 1, isHuman: false, isFinished: false, isLandlord: true, cardCount: 17, cards: [] },
+        { id: 2, isHuman: false, isFinished: false, isLandlord: false, cardCount: 17, cards: [] },
+      ],
+    });
+    renderWithProviders(<DoudizhuPage />);
+    fireEvent.click(await screen.findByRole('button', { name: '♠ 2' }));
+    const badge = await screen.findByTestId('ddz-combo-type');
+    // "選択中: 単張（1枚）" — single, and no warning is shown.
+    expect(badge).toHaveTextContent('単張');
+    expect(screen.queryByTestId('ddz-invalid-combo')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('ddz-no-beat')).not.toBeInTheDocument();
+  });
+
   it('opens the reset confirmation and resets on confirm', async () => {
     renderWithProviders(<DoudizhuPage />);
     const resetButton = await screen.findByRole('button', { name: 'リセット' });

--- a/frontend/src/pages/DoudizhuPage.tsx
+++ b/frontend/src/pages/DoudizhuPage.tsx
@@ -26,6 +26,7 @@ import type { DoudizhuResponse } from '../types/card';
 import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import type { CliGameConfig, CliParseResult } from '../utils/cli/types';
+import { classifyDoudizhuCombo, doudizhuInvalidReason } from '../utils/doudizhuComboValidator';
 
 type ApiArgs = {
   command: string;
@@ -187,6 +188,20 @@ function DoudizhuPageContent() {
     return t(`phase.${phase}`, { defaultValue: phase });
   }, [state, phase, isGameEnd, t]);
 
+  // Classify the current selection and pre-validate it against the table so the
+  // player sees why a play is illegal before submitting (backend still validates).
+  const selectionHint = useMemo(() => {
+    const cards = humanPlayer?.cards ?? [];
+    const selected = Array.from(selectedCards)
+      .sort((a, b) => a - b)
+      .map((i) => cards[i])
+      .filter((card): card is NonNullable<typeof card> => card != null);
+    if (phase !== 'play' || !isHumanTurn || selected.length === 0) return null;
+    const combo = classifyDoudizhuCombo(selected);
+    const reason = doudizhuInvalidReason(selected, state?.tableCards ?? []);
+    return { combo, reason, count: selected.length };
+  }, [humanPlayer, selectedCards, phase, isHumanTurn, state?.tableCards]);
+
   if (!state) return <GameSkeleton gameKey="doudizhu" layout={{ kind: 'card-grid', count: 17, cols: 'grid-cols-6' }} />;
 
   return (
@@ -303,6 +318,28 @@ function DoudizhuPageContent() {
                   );
                 })}
               </div>
+              {selectionHint && (
+                <div className="mt-2 text-center text-xs" data-testid="ddz-combo-hint">
+                  {selectionHint.reason === 'notCombo' ? (
+                    <p role="status" data-testid="ddz-invalid-combo" className="font-medium text-ds-warning">
+                      {t('combo.notCombo')}
+                    </p>
+                  ) : selectionHint.reason === 'noBeat' ? (
+                    <p role="status" data-testid="ddz-no-beat" className="font-medium text-ds-warning">
+                      {t('combo.noBeat')}
+                    </p>
+                  ) : (
+                    selectionHint.combo && (
+                      <p role="status" data-testid="ddz-combo-type" className="font-semibold text-ds-info">
+                        {`${t('combo.selectedLabel')}: ${t('combo.badge', {
+                          type: t(`combo.type.${selectionHint.combo.type}`),
+                          count: selectionHint.count,
+                        })}`}
+                      </p>
+                    )
+                  )}
+                </div>
+              )}
               {phase === 'play' && isHumanTurn && (
                 <div className="flex justify-center gap-2 mt-2">
                   <button type="button" className={btnPrimary} onClick={handlePlay} disabled={selectedCards.size === 0}>

--- a/frontend/src/utils/doudizhuComboValidator.test.ts
+++ b/frontend/src/utils/doudizhuComboValidator.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest';
+import type { Card } from '../types/card';
+import {
+  canBeatDoudizhu,
+  classifyDoudizhuCombo,
+  type DoudizhuCombo,
+  doudizhuCardStrength,
+  doudizhuInvalidReason,
+} from './doudizhuComboValidator';
+
+/** Builds a standard-suit card of the given rank value. */
+const c = (value: number, design: Card['design'] = 'SPADE'): Card => ({ design, value });
+/** Small joker (value 1) and big joker (value 2). */
+const smallJoker: Card = { design: 'JOKER', value: 1 };
+const bigJoker: Card = { design: 'JOKER', value: 2 };
+
+describe('doudizhuCardStrength', () => {
+  it('orders 3 < K < A < 2 < small joker < big joker', () => {
+    expect(doudizhuCardStrength(c(3))).toBe(3);
+    expect(doudizhuCardStrength(c(13))).toBe(13);
+    expect(doudizhuCardStrength(c(1))).toBe(14); // Ace
+    expect(doudizhuCardStrength(c(2))).toBe(15); // 2
+    expect(doudizhuCardStrength(smallJoker)).toBe(16);
+    expect(doudizhuCardStrength(bigJoker)).toBe(17);
+  });
+});
+
+describe('classifyDoudizhuCombo', () => {
+  it('returns null for an empty selection', () => {
+    expect(classifyDoudizhuCombo([])).toBeNull();
+  });
+
+  it('classifies a single', () => {
+    expect(classifyDoudizhuCombo([c(7)])).toEqual({ type: 'single', rank: 7, length: 1 });
+  });
+
+  it('classifies a pair and rejects a mismatched two-card selection', () => {
+    expect(classifyDoudizhuCombo([c(9, 'SPADE'), c(9, 'HEART')])).toEqual({ type: 'pair', rank: 9, length: 1 });
+    expect(classifyDoudizhuCombo([c(9), c(10)])).toBeNull();
+  });
+
+  it('classifies a trio, trio+single, and trio+pair', () => {
+    expect(classifyDoudizhuCombo([c(5), c(5), c(5)])).toEqual({ type: 'trio', rank: 5, length: 1 });
+    expect(classifyDoudizhuCombo([c(5), c(5), c(5), c(8)])).toEqual({ type: 'trioSingle', rank: 5, length: 1 });
+    expect(classifyDoudizhuCombo([c(5), c(5), c(5), c(8), c(8)])).toEqual({ type: 'trioPair', rank: 5, length: 1 });
+  });
+
+  it('classifies a bomb and a rocket', () => {
+    expect(classifyDoudizhuCombo([c(6), c(6), c(6), c(6)])).toEqual({ type: 'bomb', rank: 6, length: 1 });
+    expect(classifyDoudizhuCombo([smallJoker, bigJoker])).toEqual({ type: 'rocket', rank: 17, length: 1 });
+  });
+
+  it('classifies a 5-card straight but rejects one containing a 2', () => {
+    expect(classifyDoudizhuCombo([c(3), c(4), c(5), c(6), c(7)])).toEqual({ type: 'straight', rank: 3, length: 5 });
+    // A(14) and 2(15) cannot be part of a straight
+    expect(classifyDoudizhuCombo([c(1), c(13), c(12), c(11), c(10)])).toMatchObject({ type: 'straight' });
+    expect(classifyDoudizhuCombo([c(2), c(3), c(4), c(5), c(6)])).toBeNull();
+  });
+
+  it('classifies consecutive pairs (3 pairs) but rejects only 2 pairs', () => {
+    const threePairs = [c(4), c(4), c(5), c(5), c(6), c(6)];
+    expect(classifyDoudizhuCombo(threePairs)).toEqual({ type: 'consecutivePair', rank: 4, length: 3 });
+    expect(classifyDoudizhuCombo([c(4), c(4), c(5), c(5)])).toBeNull();
+  });
+
+  it('classifies an airplane and airplane with wings', () => {
+    // two consecutive trios (555 666)
+    expect(classifyDoudizhuCombo([c(5), c(5), c(5), c(6), c(6), c(6)])).toEqual({
+      type: 'airplane',
+      rank: 5,
+      length: 2,
+    });
+    // airplane + single wings (555 666 + 3 8)
+    expect(classifyDoudizhuCombo([c(5), c(5), c(5), c(6), c(6), c(6), c(3), c(8)])).toEqual({
+      type: 'airplaneSingle',
+      rank: 5,
+      length: 2,
+    });
+    // airplane + pair wings (555 666 + 33 88)
+    expect(classifyDoudizhuCombo([c(5), c(5), c(5), c(6), c(6), c(6), c(3), c(3), c(8), c(8)])).toEqual({
+      type: 'airplanePair',
+      rank: 5,
+      length: 2,
+    });
+  });
+
+  it('rejects a garbage selection', () => {
+    expect(classifyDoudizhuCombo([c(3), c(7), c(11)])).toBeNull();
+  });
+});
+
+/** Classifies cards, throwing if the selection is not a valid combo (test helper). */
+function combo(cards: Card[]): DoudizhuCombo {
+  const result = classifyDoudizhuCombo(cards);
+  if (!result) throw new Error('expected a valid combo');
+  return result;
+}
+
+describe('canBeatDoudizhu', () => {
+  const trio5 = combo([c(5), c(5), c(5)]);
+  const trio8 = combo([c(8), c(8), c(8)]);
+  const pair9 = combo([c(9), c(9)]);
+  const bomb6 = combo([c(6), c(6), c(6), c(6)]);
+  const bomb9 = combo([c(9), c(9), c(9), c(9)]);
+  const rocket = combo([smallJoker, bigJoker]);
+
+  it('requires same type and higher rank', () => {
+    expect(canBeatDoudizhu(trio8, trio5)).toBe(true);
+    expect(canBeatDoudizhu(trio5, trio8)).toBe(false);
+  });
+
+  it('rejects a different type', () => {
+    expect(canBeatDoudizhu(pair9, trio5)).toBe(false);
+  });
+
+  it('lets a bomb beat a non-bomb and a higher bomb beat a lower bomb', () => {
+    expect(canBeatDoudizhu(bomb6, trio8)).toBe(true);
+    expect(canBeatDoudizhu(bomb9, bomb6)).toBe(true);
+    expect(canBeatDoudizhu(bomb6, bomb9)).toBe(false);
+  });
+
+  it('lets a rocket beat everything, including a bomb', () => {
+    expect(canBeatDoudizhu(rocket, bomb9)).toBe(true);
+    expect(canBeatDoudizhu(bomb9, rocket)).toBe(false);
+  });
+});
+
+describe('doudizhuInvalidReason', () => {
+  it('returns notCombo for a wrong-count / not-a-combo selection', () => {
+    // two mismatched cards do not form a pair
+    expect(doudizhuInvalidReason([c(9), c(10)], [])).toBe('notCombo');
+  });
+
+  it('returns noBeat for a valid combo that is too low to beat the table', () => {
+    const table = [c(8), c(8), c(8)]; // trio of 8
+    const selection = [c(5), c(5), c(5)]; // trio of 5 — valid type, too low
+    expect(doudizhuInvalidReason(selection, table)).toBe('noBeat');
+  });
+
+  it('returns null for a valid beating play', () => {
+    const table = [c(5), c(5), c(5)];
+    const selection = [c(8), c(8), c(8)];
+    expect(doudizhuInvalidReason(selection, table)).toBeNull();
+  });
+
+  it('returns null for any valid combo on a fresh lead (empty table)', () => {
+    expect(doudizhuInvalidReason([c(3), c(4), c(5), c(6), c(7)], [])).toBeNull();
+  });
+});

--- a/frontend/src/utils/doudizhuComboValidator.ts
+++ b/frontend/src/utils/doudizhuComboValidator.ts
@@ -1,0 +1,207 @@
+import type { Card } from '../types/card';
+
+/**
+ * Dou Dizhu play categories, mirroring the Go domain `DoudizhuComboType`
+ * (single / pair / trio / trio+kicker / straight / consecutive-pairs /
+ * airplane / airplane+wings / bomb / rocket).
+ */
+export type DoudizhuComboType =
+  | 'single'
+  | 'pair'
+  | 'trio'
+  | 'trioSingle'
+  | 'trioPair'
+  | 'straight'
+  | 'consecutivePair'
+  | 'airplane'
+  | 'airplaneSingle'
+  | 'airplanePair'
+  | 'bomb'
+  | 'rocket';
+
+/** A classified Dou Dizhu combo: its type plus the comparison rank and chain length. */
+export interface DoudizhuCombo {
+  type: DoudizhuComboType;
+  /** Primary comparison rank (trio value, straight start, etc.). */
+  rank: number;
+  /** Chain length for straights / consecutive pairs / airplanes; 1 otherwise. */
+  length: number;
+}
+
+const STRENGTH_SMALL_JOKER = 16;
+const STRENGTH_BIG_JOKER = 17;
+
+/**
+ * Card strength, mirroring the Go domain `DoudizhuCardStrength`:
+ * 3..K = 3..13, A = 14, 2 = 15, small joker = 16, big joker = 17.
+ */
+export function doudizhuCardStrength(card: Card): number {
+  if (card.design === 'JOKER') {
+    return card.value >= 2 ? STRENGTH_BIG_JOKER : STRENGTH_SMALL_JOKER;
+  }
+  if (card.value === 1) return 14;
+  if (card.value === 2) return 15;
+  return card.value;
+}
+
+interface RankCount {
+  strength: number;
+  count: number;
+}
+
+/** Frequency of each strength, sorted by count desc then strength asc (mirrors the domain). */
+function rankCounts(cards: Card[]): RankCount[] {
+  const freq = new Map<number, number>();
+  for (const c of cards) {
+    const s = doudizhuCardStrength(c);
+    freq.set(s, (freq.get(s) ?? 0) + 1);
+  }
+  const result: RankCount[] = [];
+  for (const [strength, count] of freq) result.push({ strength, count });
+  result.sort((a, b) => (a.count !== b.count ? b.count - a.count : a.strength - b.strength));
+  return result;
+}
+
+/** Both cards jokers = rocket (火箭). */
+function isRocket(cards: Card[]): boolean {
+  return cards.length === 2 && cards.every((c) => c.design === 'JOKER');
+}
+
+/** Chainable ranks are 3..A (strength 3..14); 2 and jokers cannot form chains. */
+function isChainable(strength: number): boolean {
+  return strength >= 3 && strength <= 14;
+}
+
+function classifyTrioKicker(ranks: RankCount[], n: number): DoudizhuCombo | null {
+  const trio = ranks.find((r) => r.count === 3);
+  if (!trio) return null;
+  const kickerCount = n - 3;
+  if (kickerCount === 1) return { type: 'trioSingle', rank: trio.strength, length: 1 };
+  if (kickerCount === 2 && ranks.some((r) => r.strength !== trio.strength && r.count === 2)) {
+    return { type: 'trioPair', rank: trio.strength, length: 1 };
+  }
+  return null;
+}
+
+function classifyStraight(ranks: RankCount[], n: number): DoudizhuCombo | null {
+  if (n < 5) return null;
+  if (!ranks.every((r) => r.count === 1 && isChainable(r.strength))) return null;
+  const strengths = ranks.map((r) => r.strength).sort((a, b) => a - b);
+  if (strengths.length !== n) return null;
+  for (let i = 1; i < strengths.length; i++) {
+    if (strengths[i] - strengths[i - 1] !== 1) return null;
+  }
+  return { type: 'straight', rank: strengths[0], length: n };
+}
+
+function classifyConsecutivePair(ranks: RankCount[], n: number): DoudizhuCombo | null {
+  if (n < 6 || n % 2 !== 0) return null;
+  const pairCount = n / 2;
+  if (pairCount < 3) return null;
+  if (!ranks.every((r) => r.count === 2 && isChainable(r.strength))) return null;
+  const strengths = ranks.map((r) => r.strength).sort((a, b) => a - b);
+  if (strengths.length !== pairCount) return null;
+  for (let i = 1; i < strengths.length; i++) {
+    if (strengths[i] - strengths[i - 1] !== 1) return null;
+  }
+  return { type: 'consecutivePair', rank: strengths[0], length: pairCount };
+}
+
+function findLongestConsecutive(sorted: number[]): number[] {
+  if (sorted.length === 0) return [];
+  let best = [sorted[0]];
+  let current = [sorted[0]];
+  for (let i = 1; i < sorted.length; i++) {
+    current = sorted[i] === sorted[i - 1] + 1 ? [...current, sorted[i]] : [sorted[i]];
+    if (current.length > best.length) best = [...current];
+  }
+  return best;
+}
+
+function classifyAirplane(ranks: RankCount[], n: number): DoudizhuCombo | null {
+  const trios = ranks
+    .filter((r) => r.count === 3 && isChainable(r.strength))
+    .map((r) => r.strength)
+    .sort((a, b) => a - b);
+  if (trios.length < 2) return null;
+
+  const chain = findLongestConsecutive(trios);
+  if (chain.length < 2) return null;
+  const chainLen = chain.length;
+
+  if (n === chainLen * 3) return { type: 'airplane', rank: chain[0], length: chainLen };
+  if (n === chainLen * 4) return { type: 'airplaneSingle', rank: chain[0], length: chainLen };
+  if (n === chainLen * 5) {
+    const inChain = (strength: number) => chain.includes(strength);
+    for (const r of ranks) {
+      const rem = inChain(r.strength) ? r.count - 3 : r.count;
+      if (rem % 2 !== 0) return null;
+    }
+    return { type: 'airplanePair', rank: chain[0], length: chainLen };
+  }
+  return null;
+}
+
+/**
+ * Classifies a selection of cards into its Dou Dizhu combo, mirroring the Go
+ * domain `DoudizhuClassifyCombo`. Returns `null` for an invalid selection.
+ */
+export function classifyDoudizhuCombo(cards: Card[]): DoudizhuCombo | null {
+  const n = cards.length;
+  if (n === 0) return null;
+
+  if (n === 2 && isRocket(cards)) return { type: 'rocket', rank: STRENGTH_BIG_JOKER, length: 1 };
+
+  const ranks = rankCounts(cards);
+
+  if (n === 1) return { type: 'single', rank: doudizhuCardStrength(cards[0]), length: 1 };
+  if (n === 2) return ranks[0].count === 2 ? { type: 'pair', rank: ranks[0].strength, length: 1 } : null;
+  if (n === 3 && ranks[0].count === 3) return { type: 'trio', rank: ranks[0].strength, length: 1 };
+  if (n === 4) {
+    if (ranks.length === 1 && ranks[0].count === 4) return { type: 'bomb', rank: ranks[0].strength, length: 1 };
+    const combo = classifyTrioKicker(ranks, n);
+    if (combo) return combo;
+  }
+  if (n === 5) {
+    const combo = classifyTrioKicker(ranks, n);
+    if (combo) return combo;
+  }
+
+  return classifyStraight(ranks, n) ?? classifyConsecutivePair(ranks, n) ?? classifyAirplane(ranks, n);
+}
+
+/**
+ * Whether `play` beats `table`, mirroring the Go domain `DoudizhuCanBeat`.
+ * Rocket beats everything; a bomb beats any non-bomb/non-rocket; otherwise the
+ * types and chain lengths must match and `play` must outrank `table`.
+ */
+export function canBeatDoudizhu(play: DoudizhuCombo, table: DoudizhuCombo): boolean {
+  if (play.type === 'rocket') return true;
+  if (play.type === 'bomb') {
+    if (table.type === 'bomb') return play.rank > table.rank;
+    if (table.type === 'rocket') return false;
+    return true;
+  }
+  if (play.type !== table.type) return false;
+  if (play.length !== table.length) return false;
+  return play.rank > table.rank;
+}
+
+/** Why a Dou Dizhu selection cannot be played, or `null` when it is playable. */
+export type DoudizhuInvalidReason = 'notCombo' | 'noBeat';
+
+/**
+ * Pre-validates a selection against the current table before submitting.
+ * Returns `'notCombo'` when the cards form no legal combo, `'noBeat'` when they
+ * form a valid combo that cannot beat the table, or `null` when playable
+ * (either a fresh lead or a beating play). Mirrors the Go domain gate in
+ * `Doudizhu.PlayerPlay`.
+ */
+export function doudizhuInvalidReason(selected: Card[], tableCards: Card[]): DoudizhuInvalidReason | null {
+  const combo = classifyDoudizhuCombo(selected);
+  if (!combo) return 'notCombo';
+  if (tableCards.length === 0) return null;
+  const table = classifyDoudizhuCombo(tableCards);
+  if (!table) return null;
+  return canBeatDoudizhu(combo, table) ? null : 'noBeat';
+}


### PR DESCRIPTION
## Summary

The Dou Dizhu play button was gated only by `selectedCards.size === 0`, so any selection that is not a legal combo (or cannot beat the table) was submitted and only rejected by a server error. This adds a **pure, warn-only** client-side pre-validation that mirrors the Go domain, following the TienLen / zheng combo-validator pattern.

- New `frontend/src/utils/doudizhuComboValidator.ts` — faithfully mirrors the domain (`DoudizhuClassifyCombo` / `DoudizhuCanBeat` in `internal/domain/DoudizhuEval.go`), including card strength (3 < K < A < 2 < small joker < big joker), rank-count classification, and the beat rules.
- `DoudizhuPage.tsx` classifies the current selection and, on the human's play turn, shows:
  - `Selected: <type> (<n> cards)` for a valid, playable combo (info),
  - a **"not a valid combination"** warning when the cards form no legal combo, or
  - a **"cannot beat the current table"** warning when the combo is valid but too low / wrong type.
- **Warn-only**: the existing `disabled={selectedCards.size === 0}` gate is unchanged and the backend remains the source of truth — a classifier mismatch can never wrongly block a legal move.

## Combo types covered

All of them: single, pair, trio, trio+single, trio+pair, straight (5+), consecutive pairs (3+), airplane, airplane+singles, airplane+pairs, bomb, rocket. Fresh leads (empty table) accept any valid combo; non-empty tables require a beating play.

## Checklist
- [x] Invalid selection shows a specific warning (`ddz-invalid-combo` / `ddz-no-beat`)
- [x] Valid selection shows the combo type (`ddz-combo-type`)
- [x] Validator unit tests per combo type + boundaries (18 cases)
- [x] Page tests: wrong-count → invalid, valid-too-low → doesn't-beat, valid beating → type shown
- [x] Rules verified against the Go domain (no invented rules)
- [x] ja/en i18n parity
- [x] `bun run check`, `bun run test -- --run DouDizhu` (43 passed), `bun run build` all pass
- [x] Frontend only — no Go touched

Closes #3338

🤖 Generated with [Claude Code](https://claude.com/claude-code)