### PR TITLE
refactor(casinoholdem): move hint toggle into shared SettingsPanel

### DIFF
--- a/frontend/src/pages/CasinoHoldemPage.test.tsx
+++ b/frontend/src/pages/CasinoHoldemPage.test.tsx
@@ -112,12 +112,23 @@ describe('CasinoHoldemPage', () => {
     expect(screen.getByTestId('skeleton')).toBeInTheDocument();
   });
 
-  it('gives the hint-toggle checkbox a keyboard focus ring', async () => {
-    mockApi.mockResolvedValue(betPhaseState);
+  it('toggles the hint tooltip through the settings panel', async () => {
+    mockApi.mockResolvedValue({ ...flopState, playerHandRank: 1 });
     renderWithProviders(<CasinoHoldemPage />);
-    const checkbox = await screen.findByRole('checkbox', { name: 'ヒント表示' });
-    // Matches the focus-ring style used by the page's other interactive controls.
-    expect(checkbox.className).toContain('focus-visible:ring');
+    await waitFor(() => expect(screen.getByRole('button', { name: /コール/ })).toBeInTheDocument());
+
+    // Hint is off by default, so no tooltip renders.
+    expect(screen.queryByTestId('hint-tooltip')).not.toBeInTheDocument();
+
+    // Open the shared settings panel and enable the hint via its checkbox.
+    fireEvent.click(screen.getByText('設定'));
+    const checkbox = screen.getByRole('checkbox', { name: 'ヒント表示' });
+    fireEvent.click(checkbox);
+    await waitFor(() => expect(screen.getByTestId('hint-tooltip')).toBeInTheDocument());
+
+    // Disabling it hides the hint again.
+    fireEvent.click(checkbox);
+    await waitFor(() => expect(screen.queryByTestId('hint-tooltip')).not.toBeInTheDocument());
   });
 
   it('shows flop with call and fold buttons', async () => {

--- a/frontend/src/pages/CasinoHoldemPage.tsx
+++ b/frontend/src/pages/CasinoHoldemPage.tsx
@@ -24,7 +24,7 @@ import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useMountReset } from '../hooks/useMountReset';
 import { useSound } from '../providers/SoundProvider';
-import { btnDanger, btnPrimary, btnSecondary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
+import { btnDanger, btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { CasinoHoldemResponse } from '../types/card';
@@ -186,16 +186,6 @@ function CasinoHoldemPageContent() {
               messageParams={state.messageParams}
             />
 
-            <label className="flex items-center gap-1 text-ds-text-primary text-xs justify-center mb-2 cursor-pointer">
-              <input
-                type="checkbox"
-                checked={frontendHintEnabled}
-                onChange={(e) => setFrontendHintEnabled(e.target.checked)}
-                className={`${focusRingWhite} rounded cursor-pointer`}
-              />
-              {tc('hint.toggle', { ns: 'tutorial' })}
-            </label>
-
             {frontendHintEnabled && frontendHint && (
               <HintTooltip reason={t(frontendHint.reason)} confidence={frontendHint.confidence} />
             )}
@@ -337,7 +327,22 @@ function CasinoHoldemPageContent() {
 
           <GameFooter className={`${gameTheme.casinoholdem.footer} px-4 pt-3`}>
             <ErrorAlert message={error} onRetry={retry} />
-            <SettingsPanel title={t('settings.title')} groups={[]} />
+            <SettingsPanel
+              title={t('settings.title')}
+              groups={[
+                {
+                  items: [
+                    {
+                      type: 'checkbox',
+                      id: 'frontendHint',
+                      label: tc('hint.toggle', { ns: 'tutorial' }),
+                      checked: frontendHintEnabled,
+                      onToggle: setFrontendHintEnabled,
+                    },
+                  ],
+                },
+              ]}
+            />
             {isBetPhase && (
               <div className="flex flex-col items-center gap-2 pb-2" data-tutorial="ch-bet-controls">
                 <ChipBetInput


### PR DESCRIPTION
## Summary
The Casino Hold'em hint on/off toggle was hand-rolled as a bespoke `<label><input type="checkbox">` outside the shared `SettingsPanel`, while `SettingsPanel` was rendered with an empty `groups={[]}`. This refactor registers the hint toggle as a `SettingsPanel` checkbox item — mirroring `BeleagueredCastlePage` and `CallBreakPage` — and removes the custom UI, so the control looks and behaves like every other game's settings.

Hint on/off behavior and its `localStorage` persistence (`hint_enabled_casinoholdem`) are unchanged; only the rendering location moved.

## Changes
- `CasinoHoldemPage.tsx`: remove bespoke hint checkbox `<label>` + unused `focusRingWhite` import; populate `SettingsPanel` `groups` with a `frontendHint` checkbox item.
- `CasinoHoldemPage.test.tsx`: replace the now-obsolete focus-ring test with a test that toggles the hint via the SettingsPanel checkbox and asserts the HintTooltip shows/hides.

## Acceptance criteria
- [x] Hint toggle renders via `SettingsPanel` `groups`
- [x] Bespoke checkbox implementation removed
- [x] Appearance/behavior unified with other games' SettingsPanel
- [x] Component test verifies toggling through SettingsPanel

## Gates
- [x] `bun run check` (exit 0)
- [x] `bun run test -- --run CasinoHoldem` (44 passed)
- [x] `bun run build` (exit 0)

Closes #3298