### PR TITLE
feat(tarneeb): add per-player trick breakdown to team score table

### DIFF
--- a/frontend/src/i18n/locales/en/tarneeb.json
+++ b/frontend/src/i18n/locales/en/tarneeb.json
@@ -38,6 +38,8 @@
   "scoresTotal": "Total",
   "yourTeam": "Your team",
   "opponentTeam": "Opponents",
+  "breakdownTitle": "Per-player trick breakdown",
+  "breakdownTricks": "{{count}} tricks",
   "bidButton": "Bid",
   "passButton": "Pass",
   "bidSelectLabel": "Select your bid",

--- a/frontend/src/i18n/locales/ja/tarneeb.json
+++ b/frontend/src/i18n/locales/ja/tarneeb.json
@@ -38,6 +38,8 @@
   "scoresTotal": "累計",
   "yourTeam": "あなたのチーム",
   "opponentTeam": "相手チーム",
+  "breakdownTitle": "プレイヤー別トリック内訳",
+  "breakdownTricks": "{{count}}トリック",
   "bidButton": "ビッド",
   "passButton": "パス",
   "bidSelectLabel": "ビッド数を選択",

--- a/frontend/src/pages/TarneebPage.test.tsx
+++ b/frontend/src/pages/TarneebPage.test.tsx
@@ -103,6 +103,23 @@ describe('TarneebPage', () => {
     expect(within(oppRow).getByText('5')).toBeInTheDocument();
   });
 
+  it('shows a per-player trick breakdown grouped by team (#3306)', async () => {
+    const { container } = renderWithProviders(<TarneebPage />);
+    const breakdown = (await screen.findByTestId('tn-player-breakdown')) as HTMLDetailsElement;
+    // Both teams appear as breakdown groups.
+    const yourTeamGroup = within(breakdown).getByTestId('tn-breakdown-team-0');
+    const oppTeamGroup = within(breakdown).getByTestId('tn-breakdown-team-1');
+    expect(within(yourTeamGroup).getByText('あなたのチーム')).toBeInTheDocument();
+    expect(within(oppTeamGroup).getByText('相手チーム')).toBeInTheDocument();
+    // Each player's individual trick count is shown (players 0/2 → team 0, 1/3 → team 1).
+    expect(breakdown.querySelector('[data-testid="tn-breakdown-tricks-0"]')?.textContent).toBe('3トリック');
+    expect(breakdown.querySelector('[data-testid="tn-breakdown-tricks-2"]')?.textContent).toBe('1トリック');
+    expect(breakdown.querySelector('[data-testid="tn-breakdown-tricks-1"]')?.textContent).toBe('2トリック');
+    expect(breakdown.querySelector('[data-testid="tn-breakdown-tricks-3"]')?.textContent).toBe('0トリック');
+    // The aggregate team table is preserved alongside the breakdown.
+    expect(container.querySelector('[data-tutorial="tn-score-table"] table')).not.toBeNull();
+  });
+
   it('renders a bid button group from minBid to 13 and bids the selected value', async () => {
     renderWithProviders(<TarneebPage />);
     // minBid 7 → buttons 7..13, none below 7.

--- a/frontend/src/pages/TarneebPage.tsx
+++ b/frontend/src/pages/TarneebPage.tsx
@@ -38,6 +38,7 @@ import { parseTarneebCommand, TARNEEB_HELP } from '../utils/cli/commands/tarneeb
 import { formatTarneebState } from '../utils/cli/formatters/tarneebFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
 import { playerName } from '../utils/playerUtils';
+import { groupTarneebPlayersByTeam } from '../utils/tarneebTeams';
 
 /** Tutorial step definitions for the Tarneeb page. */
 const TARNEEB_TUTORIAL_STEPS: TutorialStep[] = [
@@ -194,6 +195,7 @@ function TarneebPageContent() {
     return <GameSkeleton gameKey="tarneeb" layout={{ kind: 'trick-taking', trickArea: true, footerHandSize: 5 }} />;
 
   const humanPlayer = state.players.find((p) => p.isHuman);
+  const teamBreakdown = groupTarneebPlayersByTeam(state.players, state.teamScores.length);
   const isBidPhase = state.phase === TarneebPhase.BID;
   const isTrumpPhase = state.phase === TarneebPhase.TRUMP_DECLARATION;
   const isPlayPhase = state.phase === TarneebPhase.PLAY;
@@ -352,9 +354,7 @@ function TarneebPageContent() {
                       <tbody>
                         {state.teamScores.map((score, i) => {
                           const isYourTeam = humanPlayer != null && humanPlayer.team === i;
-                          const roundTricks = state.players
-                            .filter((p) => p.team === i)
-                            .reduce((sum, p) => sum + p.trickCount, 0);
+                          const roundTricks = teamBreakdown[i]?.roundTricks ?? 0;
                           return (
                             <tr key={i} className={isYourTeam ? 'text-ds-accent' : ''}>
                               <td>{isYourTeam ? t('yourTeam') : t('opponentTeam')}</td>
@@ -367,6 +367,47 @@ function TarneebPageContent() {
                     </table>
                   </div>
                   <ScrollFadeHint />
+
+                  {/*
+                    Per-player trick breakdown (#3306). The aggregate table above only shows
+                    each team's combined tricks; this collapsible section reveals how many
+                    tricks each teammate (partner + CPUs) contributed. Kept in a <details> so
+                    it never crowds the mobile layout unless the player opens it.
+                  */}
+                  <details className="mt-2" data-testid="tn-player-breakdown">
+                    <summary className="cursor-pointer select-none text-ds-text-muted text-sm">
+                      {t('breakdownTitle')}
+                    </summary>
+                    <div className="mt-1 space-y-2">
+                      {teamBreakdown.map((tb) => {
+                        const isYourTeam = humanPlayer != null && humanPlayer.team === tb.team;
+                        return (
+                          <div key={tb.team} data-testid={`tn-breakdown-team-${tb.team}`}>
+                            <div
+                              className={`text-sm font-medium ${isYourTeam ? 'text-ds-accent' : 'text-ds-text-muted'}`}
+                            >
+                              {isYourTeam ? t('yourTeam') : t('opponentTeam')}
+                            </div>
+                            <ul className="pl-3">
+                              {tb.members.map((p) => (
+                                <li
+                                  key={p.id}
+                                  className={`text-sm flex justify-between gap-2 py-0.5 ${
+                                    isYourTeam ? 'text-ds-accent' : 'text-ds-text-muted'
+                                  }`}
+                                >
+                                  <span>{playerName(p.id, p.isHuman)}</span>
+                                  <span data-testid={`tn-breakdown-tricks-${p.id}`}>
+                                    {t('breakdownTricks', { count: p.trickCount })}
+                                  </span>
+                                </li>
+                              ))}
+                            </ul>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </details>
                 </div>
               </div>
             </div>

--- a/frontend/src/utils/tarneebTeams.test.ts
+++ b/frontend/src/utils/tarneebTeams.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import type { TarneebPlayerData } from '../types/card';
+import { groupTarneebPlayersByTeam } from './tarneebTeams';
+
+function player(id: number, team: number, trickCount: number): TarneebPlayerData {
+  return {
+    id,
+    isHuman: id === 0,
+    team,
+    cardCount: 0,
+    cards: [],
+    bid: -1,
+    roundScore: 0,
+    cumulativeScore: 0,
+    trickCount,
+  };
+}
+
+describe('groupTarneebPlayersByTeam', () => {
+  it('groups players by team and sums each team’s round tricks', () => {
+    const players = [player(0, 0, 3), player(1, 1, 2), player(2, 0, 1), player(3, 1, 0)];
+    const result = groupTarneebPlayersByTeam(players, 2);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].team).toBe(0);
+    expect(result[0].members.map((p) => p.id)).toEqual([0, 2]);
+    expect(result[0].roundTricks).toBe(4);
+    expect(result[1].team).toBe(1);
+    expect(result[1].members.map((p) => p.id)).toEqual([1, 3]);
+    expect(result[1].roundTricks).toBe(2);
+  });
+
+  it('returns an empty team with zero tricks when no player belongs to it', () => {
+    const result = groupTarneebPlayersByTeam([player(0, 0, 5)], 2);
+    expect(result[1].members).toEqual([]);
+    expect(result[1].roundTricks).toBe(0);
+  });
+});

--- a/frontend/src/utils/tarneebTeams.ts
+++ b/frontend/src/utils/tarneebTeams.ts
@@ -1,0 +1,26 @@
+import type { TarneebPlayerData } from '../types/card';
+
+/** A Tarneeb team with its member players and their aggregate round trick count. */
+export interface TarneebTeamBreakdown {
+  /** Team index (0 or 1). */
+  team: number;
+  /** Players belonging to this team, preserving their order in the source array. */
+  members: TarneebPlayerData[];
+  /** Total tricks the team took this round (sum of member `trickCount`s). */
+  roundTricks: number;
+}
+
+/**
+ * Group Tarneeb players by team, summing each team's round trick counts.
+ *
+ * Returns one entry per team index `0..teamCount-1` (teams with no members
+ * yield an empty `members` array and a `roundTricks` of 0), so the result can
+ * be indexed directly by team.
+ */
+export function groupTarneebPlayersByTeam(players: TarneebPlayerData[], teamCount: number): TarneebTeamBreakdown[] {
+  return Array.from({ length: teamCount }, (_, team) => {
+    const members = players.filter((p) => p.team === team);
+    const roundTricks = members.reduce((sum, p) => sum + p.trickCount, 0);
+    return { team, members, roundTricks };
+  });
+}


### PR DESCRIPTION
Closes #3306

## 背景
Tarneeb のチームスコア表はチーム単位の合計トリック数と累計スコアのみを表示し、チーム内の個々のプレイヤー（パートナー・CPU）が何トリック取ったかの内訳が見えなかった（`MightyPage`/`CallBreakPage` のプレイヤー単位表示と対照的）。

## 変更内容
- チームスコア表の直下に、折りたたみ可能な `<details>`「プレイヤー別トリック内訳」を追加。チームごとにメンバーとその個別トリック数（`p.trickCount`）を表示。
- グルーピングは純粋関数 `groupTarneebPlayersByTeam`（`src/utils/tarneebTeams.ts`）に切り出し。既存テーブルの `roundTricks` 集計もこの helper に統一（重複ロジック削減）。
- 既存のチーム集計表示（今ラウンド/累計）と #4186 のリディール表示はそのまま維持。additive な変更。
- 参照フィールド: `TarneebPlayerData` の `team` / `trickCount` / `id` / `isHuman`、`TarneebResponse.teamScores`。新規フィールドは発明していない。
- i18n: ja/en 両方に `breakdownTitle` / `breakdownTricks` を追加（パリティ維持）。
- 折りたたみ表示なのでモバイルでもレイアウトを圧迫しない。

## テスト
- `src/utils/tarneebTeams.test.ts`: グルーピングとチーム別トリック集計、空チームのエッジケース。
- `src/pages/TarneebPage.test.tsx`: `shows a per-player trick breakdown grouped by team (#3306)` — 各チームのメンバーと個別トリック数を検証、集計表が保持されることも確認。

## Gate（全て通過）
- [x] `bun run check`（exit 0、自分のファイルに指摘なし）
- [x] `bun run test -- --run Tarneeb`（3 files / 22 tests passed）
- [x] `bun run build`（tsc 通過）

## 受け入れ条件
- [x] チームスコア表にプレイヤー別の内訳が追加される
- [x] モバイルでは折りたたみ表示にしてレイアウトを圧迫しない
- [x] 既存のチーム集計表示は維持する
- [x] コンポーネントテストで内訳表示を検証する