### PR TITLE
feat(briscola): render cards with AnimatedCard for animation parity

### DIFF
--- a/frontend/src/pages/BriscolaPage.test.tsx
+++ b/frontend/src/pages/BriscolaPage.test.tsx
@@ -78,6 +78,13 @@ describe('BriscolaPage', () => {
     expect(screen.getByRole('button', { name: '♦ J を出す' })).toBeInTheDocument();
   });
 
+  it('renders hand and trump cards with the AnimatedCard component', async () => {
+    renderWithProviders(<BriscolaPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: '♠ A を出す' })).toBeInTheDocument());
+    // 3 hand cards + 1 face-up trump card are rendered as animated cards.
+    expect(screen.getAllByTestId('animated-card')).toHaveLength(4);
+  });
+
   it('fires play with the selected card index when a card is clicked', async () => {
     renderWithProviders(<BriscolaPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: '♥ 5 を出す' })).toBeInTheDocument());

--- a/frontend/src/pages/BriscolaPage.tsx
+++ b/frontend/src/pages/BriscolaPage.tsx
@@ -1,10 +1,10 @@
 import { useCallback, useEffect, useState } from 'react';
 import { briscolaApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
-import { CardImage } from '../components/CardImage';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
+import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { AnimatedCardBack } from '../components/motion/AnimatedCardBack';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { TrickDisplay } from '../components/TrickDisplay';
@@ -183,7 +183,7 @@ function BriscolaPageContent() {
                     transformOrigin: 'left center',
                   }}
                 >
-                  <CardImage card={state.trumpCard} width={Math.round(cardWidth * 0.7)} />
+                  <AnimatedCard card={state.trumpCard} width={Math.round(cardWidth * 0.7)} />
                 </div>
                 {/* Card-back stack — width tapers down as cards are drawn so the
                     physical "thinning deck" reads at a glance. */}
@@ -252,7 +252,7 @@ function BriscolaPageContent() {
                     selectedIdx === idx ? 'ring-2 ring-ds-accent -translate-y-1 transition-transform' : ''
                   }`}
                 >
-                  <CardImage card={card} width={cardWidth} />
+                  <AnimatedCard card={card} width={cardWidth} />
                 </button>
               ))}
             </div>


### PR DESCRIPTION
## Summary
Briscola rendered its cards with the static \`CardImage\` component while every other trick-taking game (Mighty, CallBreak, Tarneeb) uses \`AnimatedCard\`, so it lacked the deal/slide animations. This swaps the two \`CardImage\` usages to \`AnimatedCard\` for visual consistency.

## Changes (frontend only)
- \`BriscolaPage.tsx\`:
  - Face-up **trump card** (in the stock area) → \`AnimatedCard\`
  - **Human hand cards** (inside the play buttons) → \`AnimatedCard\`
  - Dropped the now-unused \`CardImage\` import; added \`AnimatedCard\` import
- Mirrors the exact sibling pattern from \`MightyPage.tsx\`: \`<AnimatedCard card={card} width={cardWidth} />\` inside the existing button, so \`onClick\` (\`handlePlay\`), \`aria-label\`, \`aria-pressed\`, keyboard nav, and selection styling are all preserved on the button (unchanged).
- The thinning-deck \`AnimatedCardBack\` stack (stock "厚みが減る" effect) is untouched.

## Acceptance criteria
- [x] Trump card + hand cards render via AnimatedCard
- [x] Existing click handling (\`handlePlay\`) preserved
- [x] Stock thinning effect (AnimatedCardBack) not broken
- [x] Component test verifies the card-rendering change

## Testing
- \`bun run check\` — exit 0
- \`bun run test -- --run Briscola\` — 18 passed (added \`renders hand and trump cards with the AnimatedCard component\`)
- \`bun run build\` — exit 0

Closes #3311