### PR TITLE
feat(rummy500): pre-validate meld selection on the front side

### DIFF
--- a/frontend/src/i18n/locales/en/rummy500.json
+++ b/frontend/src/i18n/locales/en/rummy500.json
@@ -23,6 +23,7 @@
   "laidMelds": "Laid melds",
   "drawStockButton": "Draw from stock",
   "meldButton": "Meld",
+  "invalidMeld": "Not a valid set or run",
   "layoffMeldTarget": "Select {{owner}}'s meld {{idx}} as lay-off target",
   "layoffTargetLabel": "Lay-off target: {{owner}} #{{idx}}",
   "layoffTargetNone": "Lay-off target: click a meld above",

--- a/frontend/src/i18n/locales/ja/rummy500.json
+++ b/frontend/src/i18n/locales/ja/rummy500.json
@@ -23,6 +23,7 @@
   "laidMelds": "場のメルド",
   "drawStockButton": "山札から引く",
   "meldButton": "メルドする",
+  "invalidMeld": "セットまたはランになっていません",
   "layoffMeldTarget": "{{owner}} のメルド {{idx}} をレイオフ先に選択",
   "layoffTargetLabel": "レイオフ先: {{owner}} #{{idx}}",
   "layoffTargetNone": "レイオフ先: 上のメルドをクリック",

--- a/frontend/src/pages/Rummy500Page.test.tsx
+++ b/frontend/src/pages/Rummy500Page.test.tsx
@@ -68,6 +68,23 @@ const playPhaseState: Rummy500Response = {
   ],
 };
 
+const playPhaseInvalidHandState: Rummy500Response = {
+  ...drawPhaseState,
+  phase: 1,
+  players: [
+    {
+      ...drawPhaseState.players[0],
+      cardCount: 3,
+      cards: [
+        { design: 'SPADE', value: 3 },
+        { design: 'HEART', value: 8 },
+        { design: 'CLOVER', value: 11 },
+      ],
+    },
+    drawPhaseState.players[1],
+  ],
+};
+
 const roundEndState: Rummy500Response = {
   ...drawPhaseState,
   phase: 2,
@@ -237,6 +254,36 @@ describe('Rummy500Page', () => {
     await waitFor(() => {
       expect(screen.getByRole('button', { name: /メルドする/ })).toBeDisabled();
     });
+  });
+
+  it('enables the meld button and shows no warning for a valid set selection', async () => {
+    // playPhaseState hand is ♠7 ♥7 ♣7 — a valid same-rank set.
+    mockExec.mockResolvedValue(playPhaseState);
+    renderWithProviders(<Rummy500Page />);
+    const meldBtn = await screen.findByRole('button', { name: /メルドする/ });
+    // No cards selected yet → disabled and no warning.
+    expect(meldBtn).toBeDisabled();
+    expect(screen.queryByTestId('r5-invalid-meld')).not.toBeInTheDocument();
+
+    const handCards = document.querySelectorAll('[data-tutorial="r5-player-hand"] button');
+    for (const c of handCards) fireEvent.click(c);
+
+    await waitFor(() => expect(screen.getByRole('button', { name: /メルドする/ })).toBeEnabled());
+    expect(screen.queryByTestId('r5-invalid-meld')).not.toBeInTheDocument();
+  });
+
+  it('warns and disables the meld button for an invalid 3-card selection', async () => {
+    // playPhaseInvalidHandState hand is ♠3 ♥8 ♣11 — neither a set nor a run.
+    mockExec.mockResolvedValue(playPhaseInvalidHandState);
+    renderWithProviders(<Rummy500Page />);
+    await screen.findByRole('button', { name: /メルドする/ });
+
+    const handCards = document.querySelectorAll('[data-tutorial="r5-player-hand"] button');
+    for (const c of handCards) fireEvent.click(c);
+
+    await waitFor(() => expect(screen.getByTestId('r5-invalid-meld')).toBeInTheDocument());
+    expect(screen.getByTestId('r5-invalid-meld')).toHaveTextContent('セットまたはランになっていません');
+    expect(screen.getByRole('button', { name: /メルドする/ })).toBeDisabled();
   });
 
   it('drawstock button triggers exec', async () => {

--- a/frontend/src/pages/Rummy500Page.tsx
+++ b/frontend/src/pages/Rummy500Page.tsx
@@ -29,6 +29,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import { playerName } from '../utils/playerUtils';
 import { rummy500HandPenalty } from '../utils/rummy500HandPenalty';
+import { classifyRummy500Meld } from '../utils/rummy500MeldValidator';
 import { rummy500PickupCount } from '../utils/rummy500PickupCount';
 
 const RUMMY500_PHASE_KEYS: Readonly<Record<number, string>> = {
@@ -125,6 +126,15 @@ function Rummy500PageContent() {
   const isRoundEnd = state.phase === Rummy500Phase.ROUND_END;
   const isGameEnd = state.phase === Rummy500Phase.GAME_END || state.gameEndFlag;
   const isHumanTurn = (isDrawPhase || isPlayPhase) && state.players[state.currentPlayerIdx]?.isHuman === true;
+
+  // Front-side meld pre-validation: mirror the backend set/run rules so the Meld
+  // button stays disabled (and a warning shows) for an invalid 3+ card selection,
+  // instead of only learning it is invalid from a server error. See issue #3320.
+  const selectedMeldCards = selectedCardIndices
+    .map((i) => humanPlayer?.cards[i])
+    .filter((c): c is NonNullable<typeof c> => c !== undefined);
+  const meldValid = classifyRummy500Meld(selectedMeldCards).valid;
+  const showInvalidMeld = selectedCardIndices.length >= 3 && !meldValid;
 
   return (
     <GamePageShell
@@ -340,11 +350,20 @@ function Rummy500PageContent() {
           )}
           {isPlayPhase && isHumanTurn && (
             <>
+              {showInvalidMeld && (
+                <p
+                  role="status"
+                  data-testid="r5-invalid-meld"
+                  className="w-full text-center font-medium text-ds-warning text-xs"
+                >
+                  {t('invalidMeld')}
+                </p>
+              )}
               <button
                 type="button"
                 className={btnPrimary}
                 onClick={handleMeld}
-                disabled={loading || selectedCardIndices.length < 3}
+                disabled={loading || selectedCardIndices.length < 3 || !meldValid}
                 data-tutorial="r5-meld-button"
               >
                 {t('meldButton')}

--- a/frontend/src/utils/rummy500MeldValidator.test.ts
+++ b/frontend/src/utils/rummy500MeldValidator.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import type { Card } from '../types/card';
+import { classifyRummy500Meld } from './rummy500MeldValidator';
+
+/** Builds a Card with the given suit design and rank value. */
+function card(design: Card['design'], value: number): Card {
+  return { design, value };
+}
+
+describe('classifyRummy500Meld', () => {
+  it('accepts a same-rank triple across distinct suits as a set', () => {
+    const result = classifyRummy500Meld([card('SPADE', 7), card('HEART', 7), card('CLOVER', 7)]);
+    expect(result).toEqual({ valid: true, kind: 'set' });
+  });
+
+  it('accepts a four-card set across all four suits', () => {
+    const result = classifyRummy500Meld([
+      card('SPADE', 10),
+      card('HEART', 10),
+      card('CLOVER', 10),
+      card('DIAMOND', 10),
+    ]);
+    expect(result).toEqual({ valid: true, kind: 'set' });
+  });
+
+  it('accepts a same-suit consecutive run', () => {
+    const result = classifyRummy500Meld([card('DIAMOND', 4), card('DIAMOND', 5), card('DIAMOND', 6)]);
+    expect(result).toEqual({ valid: true, kind: 'run' });
+  });
+
+  it('accepts a low-ace run (A-2-3)', () => {
+    const result = classifyRummy500Meld([card('HEART', 1), card('HEART', 2), card('HEART', 3)]);
+    expect(result).toEqual({ valid: true, kind: 'run' });
+  });
+
+  it('accepts a high-ace run (Q-K-A)', () => {
+    const result = classifyRummy500Meld([card('SPADE', 12), card('SPADE', 13), card('SPADE', 1)]);
+    expect(result).toEqual({ valid: true, kind: 'run' });
+  });
+
+  it('rejects a two-card selection as too few', () => {
+    const result = classifyRummy500Meld([card('SPADE', 7), card('HEART', 7)]);
+    expect(result).toEqual({ valid: false, kind: null });
+  });
+
+  it('rejects a mixed non-meld selection', () => {
+    const result = classifyRummy500Meld([card('SPADE', 3), card('HEART', 8), card('CLOVER', 11)]);
+    expect(result).toEqual({ valid: false, kind: null });
+  });
+
+  it('rejects a five-card same-rank selection (set max is 4)', () => {
+    const result = classifyRummy500Meld([
+      card('SPADE', 5),
+      card('HEART', 5),
+      card('CLOVER', 5),
+      card('DIAMOND', 5),
+      card('SPADE', 5),
+    ]);
+    expect(result).toEqual({ valid: false, kind: null });
+  });
+
+  it('rejects a set with a duplicate suit', () => {
+    const result = classifyRummy500Meld([card('SPADE', 9), card('SPADE', 9), card('HEART', 9)]);
+    expect(result).toEqual({ valid: false, kind: null });
+  });
+
+  it('rejects a run that spans suits', () => {
+    const result = classifyRummy500Meld([card('DIAMOND', 4), card('HEART', 5), card('DIAMOND', 6)]);
+    expect(result).toEqual({ valid: false, kind: null });
+  });
+
+  it('rejects a non-consecutive same-suit selection (gap)', () => {
+    const result = classifyRummy500Meld([card('CLOVER', 4), card('CLOVER', 5), card('CLOVER', 7)]);
+    expect(result).toEqual({ valid: false, kind: null });
+  });
+
+  it('rejects a run with a duplicate rank', () => {
+    const result = classifyRummy500Meld([card('CLOVER', 5), card('CLOVER', 5), card('CLOVER', 6)]);
+    expect(result).toEqual({ valid: false, kind: null });
+  });
+
+  it('accepts a long five-card run', () => {
+    const result = classifyRummy500Meld([
+      card('CLOVER', 8),
+      card('CLOVER', 9),
+      card('CLOVER', 10),
+      card('CLOVER', 11),
+      card('CLOVER', 12),
+    ]);
+    expect(result).toEqual({ valid: true, kind: 'run' });
+  });
+});

--- a/frontend/src/utils/rummy500MeldValidator.ts
+++ b/frontend/src/utils/rummy500MeldValidator.ts
@@ -1,0 +1,80 @@
+import type { Card } from '../types/card';
+
+/**
+ * The kind of a valid Rummy 500 meld.
+ *
+ * - `set`: 3 or 4 cards of the same rank, each a distinct suit.
+ * - `run`: 3+ cards of the same suit in consecutive rank order.
+ */
+export type Rummy500MeldKind = 'set' | 'run';
+
+/** Result of classifying a selection of cards against the Rummy 500 meld rules. */
+export interface Rummy500MeldResult {
+  /** Whether the selection forms a valid set or run. */
+  valid: boolean;
+  /** The meld kind when valid; `null` when the selection is not a valid meld. */
+  kind: Rummy500MeldKind | null;
+}
+
+/**
+ * Whether a sorted list of integers increases by exactly 1 at each step.
+ * Mirrors the backend `isConsecutive` helper.
+ */
+function isConsecutive(values: number[]): boolean {
+  for (let i = 1; i < values.length; i++) {
+    if (values[i] !== values[i - 1] + 1) return false;
+  }
+  return true;
+}
+
+/**
+ * A valid set: 3 or 4 cards of the same rank, each a distinct suit.
+ * Mirrors the backend `rummy500IsValidSet`.
+ */
+function isValidSet(cards: Card[]): boolean {
+  if (cards.length < 3 || cards.length > 4) return false;
+  const rank = cards[0].value;
+  const seenSuits = new Set<string>();
+  for (const c of cards) {
+    if (c.value !== rank) return false;
+    if (seenSuits.has(c.design)) return false;
+    seenSuits.add(c.design);
+  }
+  return true;
+}
+
+/**
+ * A valid run: 3+ cards of the same suit with distinct, consecutive ranks.
+ * The Ace (value 1) may be low (A-2-3) or high (Q-K-A, treated as 14).
+ * Mirrors the backend `rummy500IsValidRun`.
+ */
+function isValidRun(cards: Card[]): boolean {
+  if (cards.length < 3) return false;
+  const suit = cards[0].design;
+  if (cards.some((c) => c.design !== suit)) return false;
+
+  const values = cards.map((c) => c.value).sort((a, b) => a - b);
+  // Duplicates are not allowed in a run.
+  for (let i = 1; i < values.length; i++) {
+    if (values[i] === values[i - 1]) return false;
+  }
+  if (isConsecutive(values)) return true;
+  // Re-evaluate with the Ace as high (14) when one is present.
+  if (values[0] === 1) {
+    const high = [...values.slice(1), 14].sort((a, b) => a - b);
+    if (isConsecutive(high)) return true;
+  }
+  return false;
+}
+
+/**
+ * Classifies a card selection against the Rummy 500 meld rules (set or run),
+ * mirroring the backend `Rummy500IsValidMeld`. Fewer than 3 cards is always
+ * invalid. Used to pre-warn the player before submitting a meld to the server.
+ */
+export function classifyRummy500Meld(cards: Card[]): Rummy500MeldResult {
+  if (cards.length < 3) return { valid: false, kind: null };
+  if (isValidSet(cards)) return { valid: true, kind: 'set' };
+  if (isValidRun(cards)) return { valid: true, kind: 'run' };
+  return { valid: false, kind: null };
+}


### PR DESCRIPTION
## 概要

500ラム（Rummy 500）のメルド選択に、送信前のフロント側バリデーションを追加します。従来はメルドボタンが `selectedCardIndices.length < 3` のみで判定されており、セット/ランにならない組み合わせでもボタンを押せてサーバーエラーで初めて無効と分かる状態でした。TienLen の `isValidTienLenCombo` 相当のクライアント側検証を提供します。

## 変更点

- **`frontend/src/utils/rummy500MeldValidator.ts`（新規）**: バックエンド `Rummy500IsValidMeld` を厳密にミラーした純関数 `classifyRummy500Meld` を実装。
  - セット: 3〜4枚・同ランク・全て別スート（`rummy500IsValidSet` に一致）
  - ラン: 3枚以上・同スート・重複なし・連番。エースは低（A-2-3）または高（Q-K-A=14）として評価（`rummy500IsValidRun` に一致）
  - 3枚未満は常に無効
- **`Rummy500Page.tsx`**: 選択カードを検証し、3枚以上かつ無効な場合はメルドボタンを disabled にし、`role="status"` の警告文（`r5-invalid-meld`）をフッターに表示。additive・warn-only（サーバー側検証は従来どおり最終判定）。
- **i18n**: `invalidMeld` キーを ja/en 双方に追加。

## テスト

- `rummy500MeldValidator.test.ts`（新規）: 同ランク3枚→セット有効 / 同スート連番→ラン有効 / 低エース・高エースのラン / 2枚→無効 / 混成非メルド→無効 / セット5枚超・スート重複・スート跨ぎ・連番欠け・ランク重複→無効。
- `Rummy500Page.test.tsx`: 有効セット選択でメルド有効＆警告なし / 無効3枚選択で警告表示＆ボタン無効。

## 受け入れ条件

- [x] 有効なセット/ランのみメルドボタンが有効になる
- [x] 無効選択時に警告メッセージが表示される
- [x] バリデータ関数の単体テスト（セット/ラン/エース扱いの境界）を追加
- [x] 既存のサーバー側検証と判定が一致する（ドメイン `Rummy500IsValidMeld` をミラー）

## ゲート

- `bun run check` OK（exit 0、rummy500 関連の警告なし）
- `bun run test -- --run rummy500MeldValidator Rummy500Page` 28 passed
- `bun run build`（tsc）OK

Closes #3320

🤖 Generated with [Claude Code](https://claude.com/claude-code)