### PR TITLE
feat(acesup): add discard-all button for batch card removal

### DIFF
--- a/frontend/src/hooks/useAcesUpGame.test.ts
+++ b/frontend/src/hooks/useAcesUpGame.test.ts
@@ -4,8 +4,13 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { acesupApi } from '../api/gameApi';
-import type { AcesUpResponse } from '../types/card';
+import type { AcesUpCard, AcesUpResponse, Card } from '../types/card';
 import { useAcesUpGame } from './useAcesUpGame';
+
+/** Builds a minimal Aces Up top card; only the `removable` flag is exercised here. */
+function topCard(removable: boolean): AcesUpCard {
+  return { card: {} as Card, top: true, removable, movable: false };
+}
 
 vi.mock('../api/gameApi', () => ({
   acesupApi: { exec: vi.fn() },
@@ -145,6 +150,80 @@ describe('useAcesUpGame', () => {
     });
 
     expect(result.current.hint).toBeNull();
+  });
+
+  it('handleRemoveAll discards every removable card, chaining newly exposed ones', async () => {
+    // Start: col 0 removable, col 1 not. Removing col 0 exposes a card that
+    // makes col 1 removable — a chain the batch loop must sweep up sequentially.
+    const start: AcesUpResponse = {
+      ...defaultState,
+      columns: [[topCard(true)], [topCard(false)], [], []],
+    };
+    const afterFirst: AcesUpResponse = {
+      ...defaultState,
+      columns: [[], [topCard(true)], [], []],
+    };
+    const afterSecond: AcesUpResponse = {
+      ...defaultState,
+      columns: [[], [], [], []],
+    };
+
+    mockExec.mockResolvedValue(start);
+    const { result } = renderHook(() => useAcesUpGame(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.state).toEqual(start));
+
+    mockExec.mockClear();
+    mockExec.mockResolvedValueOnce(afterFirst).mockResolvedValueOnce(afterSecond);
+
+    await act(async () => {
+      await result.current.handleRemoveAll();
+    });
+
+    expect(mockExec).toHaveBeenCalledTimes(2);
+    expect(mockExec).toHaveBeenNthCalledWith(1, 'remove', 0);
+    expect(mockExec).toHaveBeenNthCalledWith(2, 'remove', 1);
+    expect(result.current.state).toEqual(afterSecond);
+    expect(result.current.isRemovingAll).toBe(false);
+  });
+
+  it('handleRemoveAll is a no-op when no card is removable', async () => {
+    const start: AcesUpResponse = {
+      ...defaultState,
+      columns: [[topCard(false)], [], [], []],
+    };
+    mockExec.mockResolvedValue(start);
+    const { result } = renderHook(() => useAcesUpGame(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.state).toEqual(start));
+
+    mockExec.mockClear();
+    await act(async () => {
+      await result.current.handleRemoveAll();
+    });
+
+    expect(mockExec).not.toHaveBeenCalled();
+  });
+
+  it('handleRemoveAll surfaces a network error through exec', async () => {
+    const start: AcesUpResponse = {
+      ...defaultState,
+      columns: [[topCard(true)], [topCard(false)], [], []],
+    };
+    mockExec.mockResolvedValue(start);
+    const { result } = renderHook(() => useAcesUpGame(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.state).toEqual(start));
+
+    mockExec.mockClear();
+    // First direct remove throws; the fallback re-issue via exec also rejects,
+    // which useGameApi catches and turns into an error message.
+    mockExec.mockRejectedValue(new Error('Network error'));
+
+    await act(async () => {
+      await result.current.handleRemoveAll();
+    });
+
+    expect(mockExec).toHaveBeenCalledWith('remove', 0);
+    await waitFor(() => expect(result.current.error).toBeTruthy());
+    expect(result.current.isRemovingAll).toBe(false);
   });
 
   it('handleHint sets hintError on failure', async () => {

--- a/frontend/src/hooks/useAcesUpGame.ts
+++ b/frontend/src/hooks/useAcesUpGame.ts
@@ -1,14 +1,29 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { acesupApi } from '../api/gameApi';
 import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
-import type { AcesUpHint } from '../types/card';
+import type { AcesUpCard, AcesUpHint, AcesUpResponse } from '../types/card';
 import { useGameApi } from './useGameApi';
+
+/** Upper bound on batch-removal iterations (one per non-ace card) to guard against loops. */
+const MAX_REMOVE_ALL_STEPS = 52;
+
+/** Index of the first column whose top card is currently removable, or -1 if none. */
+function firstRemovableCol(columns: AcesUpCard[][]): number {
+  return columns.findIndex((col) => col.length > 0 && col[col.length - 1]?.removable === true);
+}
 
 /** Hook that manages Aces Up game state, hints, deal/remove/move actions. */
 export function useAcesUpGame() {
-  const { state, loading, error, exec, retry } = useGameApi(acesupApi.exec);
+  const { state, setState, loading, error, exec, retry } = useGameApi(acesupApi.exec);
   const [hint, setHint] = useState<AcesUpHint | null>(null);
   const [hintError, setHintError] = useState<string | null>(null);
+  const [isRemovingAll, setIsRemovingAll] = useState(false);
+  // Mirror `state` in a ref so handleRemoveAll can read the freshest board at
+  // click time without listing `state` in its deps (keeps the callback stable),
+  // plus a re-entry guard so rapid double-clicks can't start two batch loops.
+  const stateRef = useRef<AcesUpResponse | null>(state);
+  stateRef.current = state;
+  const removingAllRef = useRef(false);
 
   useEffect(() => {
     exec('reset');
@@ -69,6 +84,41 @@ export function useAcesUpGame() {
     [exec],
   );
 
+  /**
+   * Discards every currently-removable top card in one action. Removability is
+   * order-dependent (a card can be discarded only while a higher card of the
+   * same suit sits on top of another column), so this drives the existing
+   * single `remove` action sequentially, re-reading the fresh board after each
+   * discard and stopping once nothing is removable — which also sweeps up cards
+   * that only become removable once the ones above them are gone. The re-entry
+   * guard blocks a second concurrent loop, and `isRemovingAll` lets the page
+   * disable its controls while the batch runs.
+   */
+  const handleRemoveAll = useCallback(async () => {
+    if (removingAllRef.current) return;
+    removingAllRef.current = true;
+    setIsRemovingAll(true);
+    setHint(null);
+    let col = -1;
+    try {
+      let columns = stateRef.current?.columns;
+      for (let step = 0; step < MAX_REMOVE_ALL_STEPS && columns; step++) {
+        col = firstRemovableCol(columns);
+        if (col < 0) break;
+        const res = await acesupApi.exec('remove', col);
+        setState(res);
+        columns = res.columns;
+      }
+    } catch {
+      // Re-issue the failing removal through the shared exec so the network
+      // failure surfaces via the standard error/retry channel.
+      if (col >= 0) await exec('remove', col);
+    } finally {
+      removingAllRef.current = false;
+      setIsRemovingAll(false);
+    }
+  }, [exec, setState]);
+
   return {
     state,
     loading,
@@ -83,7 +133,9 @@ export function useAcesUpGame() {
     handleUndo,
     handleUndoEscape,
     handleRemove,
+    handleRemoveAll,
     handleMove,
+    isRemovingAll,
     retry,
   };
 }

--- a/frontend/src/i18n/locales/en/acesup.json
+++ b/frontend/src/i18n/locales/en/acesup.json
@@ -12,6 +12,7 @@
   "combo": "Combo ×{{count}}",
   "draw": "Deal",
   "remove": "Remove",
+  "removeAll": "Discard All",
   "move": "Move",
   "giveup": "Give Up",
   "hint": "Hint",

--- a/frontend/src/i18n/locales/ja/acesup.json
+++ b/frontend/src/i18n/locales/ja/acesup.json
@@ -12,6 +12,7 @@
   "combo": "コンボ ×{{count}}",
   "draw": "配る",
   "remove": "除去",
+  "removeAll": "まとめて捨てる",
   "move": "移動",
   "giveup": "ギブアップ",
   "hint": "ヒント",

--- a/frontend/src/pages/AcesUpPage.test.tsx
+++ b/frontend/src/pages/AcesUpPage.test.tsx
@@ -142,6 +142,36 @@ describe('AcesUpPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('remove', 0));
   });
 
+  it('clicking discard-all dispatches remove for every removable card', async () => {
+    renderWithProviders(<AcesUpPage />);
+    await waitFor(() => expect(screen.getByText(/山札/)).toBeInTheDocument());
+
+    mockExec.mockClear();
+    // After the first removal nothing is removable, so the batch loop stops.
+    const cleared: AcesUpResponse = { ...playingState, columns: [[], [], [], []] };
+    mockExec.mockResolvedValueOnce(cleared);
+
+    fireEvent.click(screen.getByTestId('acesup-remove-all'));
+
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('remove', 0));
+    expect(mockExec).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables discard-all when no card is removable', async () => {
+    mockExec.mockResolvedValue({
+      ...playingState,
+      columns: [
+        [makeCard(card('SPADE', 5), { top: true })],
+        [makeCard(card('SPADE', 9), { top: true, movable: true })],
+        [],
+        [makeCard(card('DIAMOND', 6), { top: true })],
+      ],
+    });
+    renderWithProviders(<AcesUpPage />);
+    await waitFor(() => expect(screen.getByTestId('acesup-remove-all')).toBeInTheDocument());
+    expect(screen.getByTestId('acesup-remove-all')).toBeDisabled();
+  });
+
   it('clicking a move button dispatches move', async () => {
     renderWithProviders(<AcesUpPage />);
     await waitFor(() => expect(screen.getByText(/山札/)).toBeInTheDocument());

--- a/frontend/src/pages/AcesUpPage.tsx
+++ b/frontend/src/pages/AcesUpPage.tsx
@@ -103,9 +103,16 @@ function AcesUpPageContent() {
     handleUndo,
     handleUndoEscape,
     handleRemove,
+    handleRemoveAll,
     handleMove,
+    isRemovingAll,
   } = useAcesUpGame();
   const { cardHeight, cardWidth, isMobile } = useCardDimensions();
+
+  // The batch loop bypasses useGameApi's `loading` flag (it calls the API
+  // directly), so combine both to gate every interactive control while a batch
+  // discard is in flight (issue #3347).
+  const busy = loading || isRemovingAll;
 
   // CLI mode
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('acesup');
@@ -143,7 +150,7 @@ function AcesUpPageContent() {
     ],
     [handleDraw, handleHint, confirmGiveUpAction, handleUndo],
   );
-  useActionKeyboardNav({ bindings: actionBindings, enabled: !!isPlayingForKbd && !loading });
+  useActionKeyboardNav({ bindings: actionBindings, enabled: !!isPlayingForKbd && !busy });
 
   // Drag a movable top card onto an empty column to move it (the "Move [n]" buttons
   // remain as keyboard/tap-friendly fallbacks; D&D is additive, never required).
@@ -151,7 +158,7 @@ function AcesUpPageContent() {
   const dnd = useSolitaireDragDrop<{ zone: string; col: number }>({
     onMove: (source) => handleMove(source.col),
     isPlaying: state?.phase === AcesUpPhase.PLAYING,
-    disabled: loading,
+    disabled: busy,
   });
 
   if (!state)
@@ -161,6 +168,7 @@ function AcesUpPageContent() {
   const isGameClear = state.phase === AcesUpPhase.GAME_CLEAR;
   const isGameOver = state.phase === AcesUpPhase.GAME_OVER;
   const isEnded = isGameClear || isGameOver;
+  const hasRemovable = state.columns.some((col) => col.length > 0 && col[col.length - 1]?.removable === true);
 
   const cardGap = 6;
   const ROW_OVERLAP_RATIO = isMobile ? 0.45 : 0.4;
@@ -246,9 +254,9 @@ function AcesUpPageContent() {
                                 <button
                                   type="button"
                                   onClick={() => handleRemove(colIdx)}
-                                  disabled={!isPlaying || loading || !c.removable}
+                                  disabled={!isPlaying || busy || !c.removable}
                                   aria-label={cardAlt(c.card)}
-                                  draggable={isPlaying && !loading && c.movable === true}
+                                  draggable={isPlaying && !busy && c.movable === true}
                                   onDragStart={dnd.handleDragStart(columnZone)}
                                   onDragEnd={dnd.handleDragEnd}
                                   className={`p-0 border-0 bg-transparent cursor-pointer rounded ${focusRingWhite} ${
@@ -279,7 +287,7 @@ function AcesUpPageContent() {
                       type="button"
                       className={`${btnSecondary} mt-1 text-xs`}
                       onClick={() => handleMove(colIdx)}
-                      disabled={!isPlaying || loading || !topCard?.movable}
+                      disabled={!isPlaying || busy || !topCard?.movable}
                     >
                       {t('move')} [{colIdx}]
                     </button>
@@ -297,7 +305,7 @@ function AcesUpPageContent() {
                 {state.stockCount > 0 ? (
                   <AnimatedCardBack
                     width={cardWidth}
-                    onClick={isPlaying ? handleDraw : undefined}
+                    onClick={isPlaying && !busy ? handleDraw : undefined}
                     ariaLabel={t('draw')}
                   />
                 ) : (
@@ -368,29 +376,33 @@ function AcesUpPageContent() {
                     type="button"
                     className={btnPrimary}
                     onClick={handleDraw}
-                    disabled={loading || state.stockCount === 0}
+                    disabled={busy || state.stockCount === 0}
                   >
                     {t('draw')}
                   </button>
                   <button
                     type="button"
-                    className={btnPrimary}
-                    onClick={handleUndo}
-                    disabled={loading || !state.canUndo}
+                    className={btnSecondary}
+                    onClick={handleRemoveAll}
+                    disabled={busy || !hasRemovable}
+                    data-testid="acesup-remove-all"
                   >
+                    {t('removeAll')}
+                  </button>
+                  <button type="button" className={btnPrimary} onClick={handleUndo} disabled={busy || !state.canUndo}>
                     {t('undo')}
                   </button>
                   {state.isStalemate && (
                     <StalemateEscapeButton
                       undoToEscape={state.undoToEscape ?? 0}
                       onEscape={handleUndoEscape}
-                      disabled={loading}
+                      disabled={busy}
                     />
                   )}
-                  <button type="button" className={btnSuccess} onClick={handleHint} disabled={loading}>
+                  <button type="button" className={btnSuccess} onClick={handleHint} disabled={busy}>
                     {t('hint')}
                   </button>
-                  <button type="button" className={btnDanger} onClick={confirmGiveUpAction} disabled={loading}>
+                  <button type="button" className={btnDanger} onClick={confirmGiveUpAction} disabled={busy}>
                     {t('giveup')}
                   </button>
                 </div>
@@ -399,7 +411,7 @@ function AcesUpPageContent() {
                 isGameEnd={isEnded}
                 onReset={handleManualReset}
                 requestConfirm={requestConfirm}
-                loading={loading}
+                loading={busy}
                 dataTutorial="acesup-reset-button"
               />
             </div>


### PR DESCRIPTION
## Summary
Adds a **「まとめて捨てる」/ "Discard All"** button to the Aces Up (四つ葉のクローバー) controls so players can discard every currently-removable top card in one action, instead of clicking each column repeatedly (mirrors the batch-assist EightOff/Penguin already have).

## Removals are order-dependent → sequential driver (not a naive batch)
In the domain, `canRemove(col)` compares a column's top card against the **other** columns' top cards (same suit, higher rank). Removing one column's top card can therefore change whether another column is removable, so a naive "remove every currently-flagged card at once" would be wrong.

`handleRemoveAll` drives the **existing single `remove` action sequentially**: it re-reads the fresh board returned after each discard, finds the next removable column, and stops once nothing is removable. This also chains — cards that only become removable after the ones above them are gone get swept up. A re-entry guard blocks concurrent loops, and an `isRemovingAll` flag (combined with `loading` into a `busy` gate) disables the page controls while the batch runs. No server changes.

## Changes
- `frontend/src/hooks/useAcesUpGame.ts` — add `handleRemoveAll` sequential driver + `isRemovingAll` state
- `frontend/src/pages/AcesUpPage.tsx` — add the Discard All button (`data-testid="acesup-remove-all"`), disabled when no card is removable; gate all controls on `busy`
- `frontend/src/i18n/locales/{ja,en}/acesup.json` — add `removeAll` key (ja/en parity)
- Tests added to `useAcesUpGame.test.ts` (chaining, no-op, network-error surfacing) and `AcesUpPage.test.tsx` (click dispatches remove, disabled when nothing removable)

## Test plan
- [x] `bun run check` (exit 0; warnings are pre-existing in unrelated files)
- [x] `bun run test -- --run useAcesUpGame AcesUpPage` — 40 passed
- [x] `bun run build` (tsc gate) — passes
- [x] Single-card removal preserved; batch button is additive
- [x] ja/en i18n parity

Closes #3347