### PR TITLE
feat(yaniv): mark pickup-able discard positions in the draw phase

### DIFF
--- a/frontend/src/i18n/locales/en/yaniv.json
+++ b/frontend/src/i18n/locales/en/yaniv.json
@@ -19,6 +19,12 @@
     "hand": "Hand",
     "selectCard": "Select cards to discard (single / set / run)"
   },
+  "pickup": {
+    "hint": "You can only take a card from either end of the discard.",
+    "badge": "Take",
+    "endLabel": "Take this end card",
+    "disabledReason": "Middle cards can't be taken (only the two ends)"
+  },
   "settings": {
     "cpuDifficulty": "CPU Difficulty",
     "scoreLimit": "Elimination Score"

--- a/frontend/src/i18n/locales/ja/yaniv.json
+++ b/frontend/src/i18n/locales/ja/yaniv.json
@@ -19,6 +19,12 @@
     "hand": "手札",
     "selectCard": "捨てるカードを選択 (単札 / 同数の組 / 連番)"
   },
+  "pickup": {
+    "hint": "取れるのは捨て札の両端のカードのみです。",
+    "badge": "取れる",
+    "endLabel": "この端のカードを取る",
+    "disabledReason": "中間のカードは取れません（引けるのは両端のみ）"
+  },
   "settings": {
     "cpuDifficulty": "CPU難易度",
     "scoreLimit": "脱落スコア"

--- a/frontend/src/pages/YanivPage.test.tsx
+++ b/frontend/src/pages/YanivPage.test.tsx
@@ -177,6 +177,52 @@ describe('YanivPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('drawpickup', { end: 0 }));
   });
 
+  it('marks only the two ends of a discarded run as pickup-able in the draw phase', async () => {
+    mockExec.mockResolvedValue(
+      makeState({
+        phase: YanivPhase.DRAW,
+        pickupCards: [card('SPADE', 4), card('SPADE', 5), card('SPADE', 6)],
+      }),
+    );
+    renderWithProviders(<YanivPage />);
+    await screen.findByTestId('pickup-card-0');
+    // Guide text is shown for a multi-card discard.
+    expect(screen.getByTestId('pickup-hint')).toBeInTheDocument();
+    // Both ends carry a "take" badge; the middle card does not.
+    expect(screen.getByTestId('pickup-badge-0')).toBeInTheDocument();
+    expect(screen.getByTestId('pickup-badge-2')).toBeInTheDocument();
+    expect(screen.queryByTestId('pickup-badge-1')).not.toBeInTheDocument();
+    // The middle card is not clickable and is marked as such.
+    const middle = screen.getByTestId('pickup-card-1');
+    expect(middle).toBeDisabled();
+    expect(middle).toHaveAttribute('aria-disabled', 'true');
+    // Ends are actionable and take the correct discard end.
+    fireEvent.click(screen.getByTestId('pickup-card-2'));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('drawpickup', { end: 1 }));
+  });
+
+  it('marks the single card of a single-card discard as pickup-able', async () => {
+    mockExec.mockResolvedValue(makeState({ phase: YanivPhase.DRAW, pickupCards: [card('DIAMOND', 4)] }));
+    renderWithProviders(<YanivPage />);
+    await screen.findByTestId('pickup-card-0');
+    expect(screen.getByTestId('pickup-badge-0')).toBeInTheDocument();
+    // No middle-card guide for a lone card (no "ends only" ambiguity).
+    expect(screen.queryByTestId('pickup-hint')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('pickup-card-0'));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('drawpickup', { end: 0 }));
+  });
+
+  it('does not mark pickup cards outside the human draw turn', async () => {
+    mockExec.mockResolvedValue(
+      makeState({ phase: YanivPhase.DISCARD, pickupCards: [card('SPADE', 4), card('SPADE', 6)] }),
+    );
+    renderWithProviders(<YanivPage />);
+    await screen.findByTestId('pickup-card-0');
+    expect(screen.queryByTestId('pickup-badge-0')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('pickup-hint')).not.toBeInTheDocument();
+    expect(screen.getByTestId('pickup-card-0')).toBeDisabled();
+  });
+
   it('shows the next-round button at round end', async () => {
     mockExec.mockResolvedValue(makeState({ phase: YanivPhase.ROUND_END, callerIdx: 0 }));
     renderWithProviders(<YanivPage />);

--- a/frontend/src/pages/YanivPage.tsx
+++ b/frontend/src/pages/YanivPage.tsx
@@ -26,6 +26,7 @@ import { YanivPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import type { CliGameConfig, CliParseResult } from '../utils/cli/types';
 import { classifyYanivDiscard } from '../utils/yanivCombos';
+import { isPickupable } from '../utils/yanivPickup';
 
 type YanivArgs = Parameters<typeof yanivApi.exec>;
 
@@ -248,25 +249,43 @@ function YanivPageContent() {
               </div>
               <div className="text-center">
                 <div className="text-xs text-ds-text-muted mb-1">{t('label.discardPile')}</div>
+                {isDraw && isHumanTurn && pickup.length > 1 && (
+                  <div className="text-[10px] text-ds-info mb-1" data-testid="pickup-hint">
+                    {t('pickup.hint')}
+                  </div>
+                )}
                 <div className="flex gap-1 justify-center">
                   {pickup.length > 0 ? (
                     pickup.map((c, i) => {
-                      const isEnd = i === 0 || i === pickup.length - 1;
+                      const pickable = isPickupable(i, pickup.length);
+                      const active = pickable && isDraw && isHumanTurn;
+                      const blocked = !pickable && isDraw && isHumanTurn;
                       return (
-                        <button
-                          key={i}
-                          type="button"
-                          data-testid={`pickup-card-${i}`}
-                          onClick={() => isEnd && isDraw && isHumanTurn && handleDrawPickup(i === 0 ? 0 : 1)}
-                          disabled={!isEnd || !isDraw || !isHumanTurn || loading}
-                          className={
-                            isEnd && isDraw && isHumanTurn
-                              ? 'rounded ring-2 ring-ds-info cursor-pointer hover:opacity-90'
-                              : 'rounded opacity-70 cursor-default'
-                          }
-                        >
-                          <AnimatedCard card={c} width={cardWidth * 0.8} />
-                        </button>
+                        <div key={i} className="relative" title={blocked ? t('pickup.disabledReason') : undefined}>
+                          <button
+                            type="button"
+                            data-testid={`pickup-card-${i}`}
+                            onClick={() => active && handleDrawPickup(i === 0 ? 0 : 1)}
+                            disabled={!active || loading}
+                            aria-disabled={blocked || undefined}
+                            aria-label={active ? t('pickup.endLabel') : undefined}
+                            className={
+                              active
+                                ? 'rounded ring-2 ring-ds-info cursor-pointer hover:opacity-90'
+                                : 'rounded opacity-70 cursor-default'
+                            }
+                          >
+                            <AnimatedCard card={c} width={cardWidth * 0.8} />
+                          </button>
+                          {active && (
+                            <span
+                              data-testid={`pickup-badge-${i}`}
+                              className="absolute -top-1 -right-1 rounded bg-ds-info text-white text-[9px] font-bold px-1 pointer-events-none"
+                            >
+                              {t('pickup.badge')}
+                            </span>
+                          )}
+                        </div>
                       );
                     })
                   ) : (

--- a/frontend/src/utils/yanivPickup.test.ts
+++ b/frontend/src/utils/yanivPickup.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { isPickupable, pickupableIndices } from './yanivPickup';
+
+describe('pickupableIndices', () => {
+  it('returns nothing for an empty discard', () => {
+    expect(pickupableIndices(0)).toEqual([]);
+    expect(pickupableIndices(-1)).toEqual([]);
+  });
+
+  it('marks the single card of a single/one-card discard', () => {
+    expect(pickupableIndices(1)).toEqual([0]);
+  });
+
+  it('marks both ends of a two-card discard', () => {
+    expect(pickupableIndices(2)).toEqual([0, 1]);
+  });
+
+  it('marks only the two ends of a discarded run/set (middle excluded)', () => {
+    expect(pickupableIndices(3)).toEqual([0, 2]);
+    expect(pickupableIndices(5)).toEqual([0, 4]);
+  });
+});
+
+describe('isPickupable', () => {
+  it('treats the two ends of a run as pickup-able and the middle as not', () => {
+    expect(isPickupable(0, 4)).toBe(true);
+    expect(isPickupable(3, 4)).toBe(true);
+    expect(isPickupable(1, 4)).toBe(false);
+    expect(isPickupable(2, 4)).toBe(false);
+  });
+
+  it('treats the lone card of a single discard as pickup-able', () => {
+    expect(isPickupable(0, 1)).toBe(true);
+  });
+});

--- a/frontend/src/utils/yanivPickup.ts
+++ b/frontend/src/utils/yanivPickup.ts
@@ -1,0 +1,34 @@
+/**
+ * Yaniv discard-pickup rules.
+ *
+ * Mirrors the domain (`internal/domain/Yaniv.go`): after discarding, a player
+ * may take a card from the previous player's discarded bunch, but only from its
+ * two ends (`drawFromPickup` accepts `end` 0 = first or 1 = last). This holds
+ * uniformly for singles, sets, and runs — there is no "any card of a set" rule.
+ * For a single-card discard both ends collapse onto index 0.
+ */
+
+/**
+ * Returns the indices of the previous discard that are legally pickup-able,
+ * given the number of cards in that discard bunch.
+ *
+ * @param pickupCount - Number of cards in the previous discard (`pickupCards`).
+ * @returns Sorted unique indices that may be taken (empty when nothing to take).
+ */
+export function pickupableIndices(pickupCount: number): number[] {
+  if (pickupCount <= 0) return [];
+  if (pickupCount === 1) return [0];
+  return [0, pickupCount - 1];
+}
+
+/**
+ * Reports whether the card at `index` of a `pickupCount`-card discard bunch is
+ * legally pickup-able (i.e. is one of the two ends).
+ *
+ * @param index - Position within the previous discard bunch.
+ * @param pickupCount - Number of cards in the previous discard bunch.
+ * @returns True when the card at `index` may be taken.
+ */
+export function isPickupable(index: number, pickupCount: number): boolean {
+  return pickupableIndices(pickupCount).includes(index);
+}


### PR DESCRIPTION
## Summary
In Yaniv, after discarding you may take a card from the previous player's discarded bunch — but only from its **two ends**. The UI previously only distinguished ends with a subtle ring and dimmed the middle cards, and the rule itself was never written anywhere.

This PR makes the pickup-able positions explicit during the human draw phase, faithfully mirroring the domain.

## Pickup rule mirrored
`internal/domain/Yaniv.go` (`drawFromPickup`) accepts only `end` 0 (first) or 1 (last) of `pickupCards`, **uniformly for singles, sets, and runs** — there is no "any card of a set" branch. A single-card discard collapses both ends onto index 0. The new pure helper `pickupableIndices(n)` encodes exactly this: `[]` for 0, `[0]` for 1, `[0, n-1]` otherwise.

## Changes (frontend only, no Go touched)
- **`utils/yanivPickup.ts`** (new): pure `pickupableIndices` / `isPickupable` helpers with TSDoc.
- **`YanivPage.tsx`**: additive to the existing pickup action + #4191 discard validation —
  - ends-only guide line under the discard label (shown for multi-card discards in the human draw turn),
  - a "take" badge overlaid on each pickup-able end,
  - `aria-disabled` + reason `title` on non-pickable middle cards.
- **`i18n/{ja,en}/yaniv.json`**: new `pickup.{hint,badge,endLabel,disabledReason}` keys (ja/en parity).
- Tests for the helper and the page (run marks only its two ends; single-card marks the lone card; nothing marked outside the human draw turn).

## Acceptance criteria
- [x] Ends-only guide shown during the draw phase
- [x] Pickup-able end cards get a badge/emphasis
- [x] Middle cards get a reason `title` / aria attribute
- [x] `pickup.*` keys added to ja / en `yaniv.json`

## Gate
- [x] `bun run check`
- [x] `bun run test -- --run Yaniv` (47 passed)
- [x] `bun run build` (tsc)

Closes #3374