### PR TITLE
feat(chinesepoker): replace bet input with ChipBetInput and validate

### DIFF
--- a/frontend/e2e/chinesepoker.spec.ts
+++ b/frontend/e2e/chinesepoker.spec.ts
@@ -130,7 +130,7 @@ test.describe('Chinese Poker E2E', () => {
     await navigateTo(page, '/chinesepoker');
 
     // BET phase: click ベット
-    const betButton = page.getByRole('button', { name: 'ベット' });
+    const betButton = page.getByRole('button', { name: 'ベット', exact: true });
     await expect(betButton).toBeVisible();
     await betButton.click();
     await waitForLoaded(page);
@@ -171,6 +171,6 @@ test.describe('Chinese Poker E2E', () => {
     // Reset back to bet phase
     await resetButton.click();
     await waitForLoaded(page);
-    await expect(page.getByRole('button', { name: 'ベット' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'ベット', exact: true })).toBeVisible();
   });
 });

--- a/frontend/src/i18n/locales/en/chinesepoker.json
+++ b/frontend/src/i18n/locales/en/chinesepoker.json
@@ -53,6 +53,7 @@
     "title": "Settings"
   },
   "betGuide": "Enter your bet amount",
+  "betError": "Bet must be at least 10, in steps of 10, and within your balance",
   "selectCards": "Select 3 cards for Front and 5 cards for Middle",
   "selectedFront": "Front: {{count}} / 3",
   "selectedMiddle": "Middle: {{count}} / 5",

--- a/frontend/src/i18n/locales/ja/chinesepoker.json
+++ b/frontend/src/i18n/locales/ja/chinesepoker.json
@@ -53,6 +53,7 @@
     "title": "設定"
   },
   "betGuide": "ベット額を入力してください",
+  "betError": "ベットは10以上、10単位で、残高以内で指定してください",
   "selectCards": "フロント3枚とミドル5枚を選んでください",
   "selectedFront": "フロント: {{count}} / 3",
   "selectedMiddle": "ミドル: {{count}} / 5",

--- a/frontend/src/pages/ChinesePokerPage.test.tsx
+++ b/frontend/src/pages/ChinesePokerPage.test.tsx
@@ -168,6 +168,28 @@ describe('ChinesePokerPage', () => {
     expect(mockExec).toHaveBeenCalledWith('bet', 100);
   });
 
+  it('submits the edited bet amount via the ChipBetInput', async () => {
+    mockExec.mockResolvedValue(betPhaseState);
+    renderWithProviders(<ChinesePokerPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'ベット' })).toBeInTheDocument());
+    fireEvent.change(screen.getByLabelText('ベット'), { target: { value: '200' } });
+    fireEvent.click(screen.getByRole('button', { name: 'ベット' }));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('bet', 200));
+  });
+
+  it('disables the bet button, blocks the b key, and shows an error for an out-of-range bet', async () => {
+    mockExec.mockResolvedValue(betPhaseState);
+    renderWithProviders(<ChinesePokerPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'ベット' })).toBeInTheDocument());
+    // 15 is not a multiple of 10 → invalid.
+    fireEvent.change(screen.getByLabelText('ベット'), { target: { value: '15' } });
+    expect(screen.getByRole('button', { name: 'ベット' })).toBeDisabled();
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    mockExec.mockClear();
+    fireEvent.keyDown(document, { key: 'b' });
+    expect(mockExec).not.toHaveBeenCalled();
+  });
+
   // Assign the cards at the given indices in order: the first 3 become the front
   // row, the next 5 the middle row, and the remaining 5 stay in the back row.
   const assignFrontMiddle = (frontMid: number[]) => {

--- a/frontend/src/pages/ChinesePokerPage.tsx
+++ b/frontend/src/pages/ChinesePokerPage.tsx
@@ -3,6 +3,7 @@ import { chinesepokerApi } from '../api/gameApi';
 import { ActionLogPanel } from '../components/ActionLogPanel';
 import { CliTerminal } from '../components/cli/CliTerminal';
 import { CliToggle } from '../components/cli/CliToggle';
+import { ChipBetInput } from '../components/common/ChipBetInput';
 import { SettingsPanel } from '../components/common/SettingsPanel';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
@@ -123,6 +124,10 @@ function ChinesePokerPageContent() {
   const isSetHandsPhase = state?.phase === ChinesePokerPhase.SET_HANDS;
   const isEndPhase = state?.phase === ChinesePokerPhase.END;
 
+  // Validate the staged bet: must be a positive multiple of 10 within the balance.
+  const betInvalid =
+    Number.isNaN(betAmount) || betAmount < 10 || betAmount % 10 !== 0 || betAmount > (state?.chips ?? 0);
+
   const frontIndices = useMemo(
     () => assignments.map((a, i) => (a === 'front' ? i : -1)).filter((i) => i >= 0),
     [assignments],
@@ -167,7 +172,7 @@ function ChinesePokerPageContent() {
 
   const actionBindings = useMemo(
     () => [
-      { key: 'b', action: () => execApi('bet', betAmount), enabled: isBetPhase },
+      { key: 'b', action: () => execApi('bet', betAmount), enabled: isBetPhase && !betInvalid },
       {
         key: 's',
         action: () => {
@@ -177,7 +182,7 @@ function ChinesePokerPageContent() {
       },
       { key: 'r', action: () => execApi('reset'), enabled: isEndPhase },
     ],
-    [execApi, betAmount, frontIndices, middleIndices, isBetPhase, isSetHandsPhase, isEndPhase, canSet],
+    [execApi, betAmount, betInvalid, frontIndices, middleIndices, isBetPhase, isSetHandsPhase, isEndPhase, canSet],
   );
 
   useActionKeyboardNav({ bindings: actionBindings, enabled: !!state && !loading });
@@ -428,22 +433,25 @@ function ChinesePokerPageContent() {
             />
             {isBetPhase && (
               <div className="flex flex-col items-center gap-2 pb-2" data-tutorial="cp-bet-controls">
-                <div className="flex items-center gap-2">
-                  <label htmlFor="cp-bet-amount" className="text-ds-text-primary text-sm">
-                    {t('label.bet')}
-                  </label>
-                  <input
-                    id="cp-bet-amount"
-                    type="number"
-                    min={10}
-                    max={state.chips}
-                    step={10}
-                    value={betAmount}
-                    onChange={(e) => setBetAmount(Number(e.target.value))}
-                    className="w-24 px-2 py-1 rounded text-sm"
-                  />
-                </div>
-                <button type="button" className={btnPrimary} onClick={handleBet} disabled={loading}>
+                <ChipBetInput
+                  id="cp-bet-amount"
+                  label={t('label.bet')}
+                  value={betAmount}
+                  onChange={setBetAmount}
+                  min={10}
+                  max={state.chips}
+                  step={10}
+                  disabled={loading}
+                  showSteppers
+                  invalid={betInvalid}
+                  describedBy={betInvalid ? 'cp-bet-error' : undefined}
+                />
+                {betInvalid && (
+                  <p id="cp-bet-error" role="alert" className="text-ds-error text-xs">
+                    {t('betError')}
+                  </p>
+                )}
+                <button type="button" className={btnPrimary} onClick={handleBet} disabled={loading || betInvalid}>
                   {t('button.bet')}
                 </button>
               </div>


### PR DESCRIPTION
## Summary
Replaces the raw `<input type="number">` in the Chinese Poker BET phase with the shared `ChipBetInput` component (stepper, invalid styling, aria wiring), mirroring `FourCardPokerPage`.

- Computes `betInvalid = NaN || <10 || not a multiple of 10 || > balance`.
- Disables the bet button and the `b` keyboard shortcut while invalid.
- Shows a `role="alert"` error message (`betError`, ja+en) when invalid.

## Acceptance criteria
- [x] Bet input becomes a stepper-equipped `ChipBetInput`
- [x] Invalid values disable the bet button and the `b` key
- [x] Error message is shown
- [x] Validation tests added to `ChinesePokerPage.test.tsx`

## Test plan
- [x] `bun run check`
- [x] `bun run test -- --run ChinesePoker` (53 passed)
- [x] `bun run build`

Closes #3331