### PR TITLE
feat(russianpoker): keyboard operation for card-exchange selection

### DIFF
--- a/frontend/src/i18n/locales/en/russianpoker.json
+++ b/frontend/src/i18n/locales/en/russianpoker.json
@@ -62,10 +62,12 @@
   "betError": "Ante must be at least 10, in steps of 10, and within your balance",
   "actionGuide": "Fold, Call, Exchange cards, or Buy a 6th card",
   "exchangeGuide": "Tap cards to select them, then press Exchange",
+  "exchangeKbdHint": "Keyboard: number keys (1-9, 0) select, Enter exchanges, Esc clears",
   "exchangeFeeInfo": "Fee: ante × {{ante}} per card = {{fee}}",
   "exchangeFeeHighRisk": "High-cost warning",
   "exchangeSelected": "Selected: {{count}}",
   "selectGuide": "Choose one card to discard from your 6 cards",
+  "selectKbdHint": "Keyboard: number keys (1-9, 0) pick the card to discard",
   "forceQualifyGuide": "Dealer does not qualify. Pay ante to force exchange dealer's highest card?",
   "forceQualifyCost": "Cost: {{cost}}",
   "payoutRef": {

--- a/frontend/src/i18n/locales/ja/russianpoker.json
+++ b/frontend/src/i18n/locales/ja/russianpoker.json
@@ -62,10 +62,12 @@
   "betError": "アンテは10以上、10単位で、残高以内で指定してください",
   "actionGuide": "フォールド、コール、カード交換、または6枚目購入を選択",
   "exchangeGuide": "交換したいカードをタップで選択し、「交換」を押してください",
+  "exchangeKbdHint": "キーボード: 数字キー(1〜9,0)で選択、Enterで交換、Escで選択解除",
   "exchangeFeeInfo": "手数料: 1枚あたりアンテ × {{ante}} = {{fee}}",
   "exchangeFeeHighRisk": "高コスト警告",
   "exchangeSelected": "選択中: {{count}}枚",
   "selectGuide": "6枚のカードから1枚を選んで捨ててください",
+  "selectKbdHint": "キーボード: 数字キー(1〜9,0)で捨てるカードを選べます",
   "forceQualifyGuide": "ディーラーが未クオリファイです。アンテ同額を払って最高カードを交換させますか？",
   "forceQualifyCost": "コスト: {{cost}}",
   "payoutRef": {

--- a/frontend/src/pages/RussianPokerPage.test.tsx
+++ b/frontend/src/pages/RussianPokerPage.test.tsx
@@ -93,6 +93,69 @@ describe('RussianPokerPage', () => {
     expect(line.querySelector('.text-ds-error')).not.toBeNull();
   });
 
+  it('toggles exchange selection with number keys in the action phase', async () => {
+    renderWithProviders(<RussianPokerPage />);
+    const line = await screen.findByTestId('russian-exchange-fee-line');
+    // Number key "1" selects the first card for exchange.
+    fireEvent.keyDown(document.body, { key: '1' });
+    expect(line).toHaveTextContent('選択中: 1枚');
+    // Pressing "1" again deselects it.
+    fireEvent.keyDown(document.body, { key: '1' });
+    expect(line).toHaveTextContent('選択中: 0枚');
+  });
+
+  it('advertises the number-key shortcut on each selectable card', async () => {
+    renderWithProviders(<RussianPokerPage />);
+    const firstCard = await screen.findByTestId('player-card-0');
+    expect(firstCard).toHaveAttribute('aria-keyshortcuts', '1');
+    expect(screen.getByTestId('player-card-4')).toHaveAttribute('aria-keyshortcuts', '5');
+  });
+
+  it('confirms the exchange with Enter after a keyboard selection', async () => {
+    renderWithProviders(<RussianPokerPage />);
+    await screen.findByTestId('russian-exchange-fee-line');
+    fireEvent.keyDown(document.body, { key: '2' });
+    fireEvent.keyDown(document.body, { key: 'Enter' });
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('exchange', undefined, [1]));
+  });
+
+  it('does not exchange on Enter when nothing is selected', async () => {
+    renderWithProviders(<RussianPokerPage />);
+    await screen.findByTestId('russian-exchange-fee-line');
+    mockExec.mockClear();
+    fireEvent.keyDown(document.body, { key: 'Enter' });
+    expect(mockExec).not.toHaveBeenCalledWith('exchange', undefined, expect.anything());
+  });
+
+  it('keeps the 6 key bound to buy6th without toggling a card', async () => {
+    renderWithProviders(<RussianPokerPage />);
+    const line = await screen.findByTestId('russian-exchange-fee-line');
+    fireEvent.keyDown(document.body, { key: '6' });
+    // 6 buys the sixth card; the 5-card hand has no index 5 to toggle.
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('buy6th'));
+    expect(line).toHaveTextContent('選択中: 0枚');
+  });
+
+  it('picks the discard directly with a number key in the select phase', async () => {
+    const selectState = makeState({
+      phase: RussianPokerPhase.SELECT,
+      playerHand: [
+        card('SPADE', 10),
+        card('HEART', 11),
+        card('DIAMOND', 12),
+        card('CLOVER', 3),
+        card('SPADE', 5),
+        card('HEART', 7),
+      ],
+    });
+    mockExec.mockResolvedValue(selectState);
+    renderWithProviders(<RussianPokerPage />);
+    await screen.findByTestId('russian-select-kbd-hint');
+    // Number key "3" discards the third card (index 2).
+    fireEvent.keyDown(document.body, { key: '3' });
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('select', undefined, undefined, 2));
+  });
+
   const betState = makeState({ phase: RussianPokerPhase.BET, playerHand: [], dealerHand: [], chips: 900 });
 
   it('renders the ante as a ChipBetInput with steppers', async () => {

--- a/frontend/src/pages/RussianPokerPage.tsx
+++ b/frontend/src/pages/RussianPokerPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { russianpokerApi } from '../api/gameApi';
 import { ActionLogPanel } from '../components/ActionLogPanel';
 import { CliTerminal } from '../components/cli/CliTerminal';
@@ -16,6 +16,7 @@ import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCardDimensions } from '../hooks/useCardDimensions';
+import { useCardKeyboardNav } from '../hooks/useCardKeyboardNav';
 import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
@@ -118,31 +119,45 @@ function RussianPokerPageContent() {
   const anteInvalid =
     Number.isNaN(anteAmount) || anteAmount < 10 || anteAmount % 10 !== 0 || anteAmount > (state?.chips ?? 0);
 
-  const toggleSelected = (idx: number) => {
+  const toggleSelected = useCallback((idx: number) => {
     setSelectedIndices((prev) =>
       prev.includes(idx) ? prev.filter((i) => i !== idx) : [...prev, idx].sort((a, b) => a - b),
     );
-  };
+  }, []);
+
+  const clearSelection = useCallback(() => setSelectedIndices([]), []);
+
+  /** No-op handler for keyboard-nav callbacks that a given phase does not use. */
+  const noop = useCallback(() => {}, []);
 
   const handleBet = () => {
     setSelectedIndices([]);
     execApi('bet', anteAmount);
   };
 
-  const handleExchange = () => {
+  const handleExchange = useCallback(() => {
     const toExchange = [...selectedIndices];
     setSelectedIndices([]);
     execApi('exchange', undefined, toExchange);
-  };
+  }, [selectedIndices, execApi]);
+
+  /** Confirm the exchange from the keyboard (Enter); no-op when nothing is selected. */
+  const handleExchangeConfirm = useCallback(() => {
+    if (selectedIndices.length === 0) return;
+    handleExchange();
+  }, [selectedIndices, handleExchange]);
 
   const handleBuy6th = () => {
     setSelectedIndices([]);
     execApi('buy6th');
   };
 
-  const handleSelect = (discardIdx: number) => {
-    execApi('select', undefined, undefined, discardIdx);
-  };
+  const handleSelect = useCallback(
+    (discardIdx: number) => {
+      execApi('select', undefined, undefined, discardIdx);
+    },
+    [execApi],
+  );
 
   const handlePlay = () => {
     setSelectedIndices([]);
@@ -186,6 +201,27 @@ function RussianPokerPageContent() {
   useActionKeyboardNav({
     bindings: actionBindings,
     enabled: !!state && !loading,
+  });
+
+  // ACTION phase: number keys 1-9/0 toggle which cards to exchange, Enter confirms
+  // the exchange, Escape clears the selection. Digit 6 falls through to buy6th (the
+  // hand has only 5 cards, so index 5 is out of range here — no conflict).
+  useCardKeyboardNav({
+    cardCount: state?.playerHand.length ?? 0,
+    onToggle: toggleSelected,
+    onConfirm: handleExchangeConfirm,
+    onClear: clearSelection,
+    enabled: isActionPhase && !loading,
+  });
+
+  // SELECT phase: number keys 1-9/0 pick the discard directly (6-card discard step).
+  useCardKeyboardNav({
+    cardCount: state?.playerHand.length ?? 0,
+    onToggle: noop,
+    onConfirm: noop,
+    onClear: noop,
+    onDirectPlay: handleSelect,
+    enabled: isSelectPhase && !loading,
   });
 
   if (!state) return <GameSkeleton gameKey="russianpoker" layout={{ kind: 'casino-table', sections: [5, 5] }} />;
@@ -297,12 +333,15 @@ function RussianPokerPageContent() {
                     const selected = selectedIndices.includes(i);
                     const selectable = isActionPhase;
                     const discardable = isSelectPhase;
+                    // Advertise the number-key shortcut (1-9, then 0 for the 10th card).
+                    const kbdShortcut = i < 9 ? String(i + 1) : i === 9 ? '0' : undefined;
                     return (
                       <button
                         key={`p-${i}`}
                         type="button"
                         aria-label={cardAlt(card)}
                         aria-pressed={selectable ? selected : undefined}
+                        aria-keyshortcuts={(selectable || discardable) && kbdShortcut ? kbdShortcut : undefined}
                         data-testid={`player-card-${i}`}
                         data-selected={selected ? 'true' : 'false'}
                         onClick={selectable ? () => toggleSelected(i) : discardable ? () => handleSelect(i) : undefined}
@@ -420,6 +459,9 @@ function RussianPokerPageContent() {
                   data-testid="russian-exchange-fee-line"
                 >
                   <p>{t('exchangeGuide')}</p>
+                  <p className="text-ds-text-muted text-xs" data-testid="russian-exchange-kbd-hint">
+                    {t('exchangeKbdHint')}
+                  </p>
                   <p
                     className={
                       selectedIndices.length >= 4
@@ -460,6 +502,9 @@ function RussianPokerPageContent() {
             {isSelectPhase && (
               <div className="flex flex-col items-center gap-2 pb-2">
                 <p className="text-ds-text-muted text-sm">{t('selectGuide')}</p>
+                <p className="text-ds-text-muted text-xs" data-testid="russian-select-kbd-hint">
+                  {t('selectKbdHint')}
+                </p>
               </div>
             )}
             {isPostActionPhase && (


### PR DESCRIPTION
## Summary

Adds keyboard operation for the card-exchange selection phase of Russian Poker (`russianpoker`), completing the bet -> exchange -> play flow so it can be driven entirely from the keyboard. Mirrors the shared `useCardKeyboardNav` hook used by Macau / 2-7 Triple Draw.

Builds on top of the just-merged #4194 (ante `ChipBetInput`) — those changes are preserved untouched.

### What changed
- **ACTION phase**: number keys `1`-`9`/`0` toggle which cards to exchange, `Enter` confirms the exchange, `Escape` clears the selection. Mouse/tap selection is unchanged (additive).
- **SELECT phase**: number keys pick the discard card directly (`select` command).
- **No conflict with existing `b`/`e`/`6`/`p`/`f`/`r`**: in ACTION the hand has 5 cards, so digit `6` is out of range for the card toggle and still falls through to `buy6th`; in SELECT the action shortcuts are all disabled.
- **Discoverability**: `aria-keyshortcuts` on each selectable/discardable card + a keyboard hint line under the exchange/select guides (ja + en parity).

### Acceptance criteria
- [x] ACTION phase: number keys toggle card selection
- [x] SELECT phase: keyboard selects the discard
- [x] No conflict with existing `b`/`e`/`6`/`p`/`f`/`r`
- [x] Tests added to `RussianPokerPage.test.tsx`

### Tests / gates
- `bun run test -- --run RussianPoker` — 20 passed (6 new keyboard tests)
- `bun run check` — pass (exit 0)
- `bun run build` (tsc) — pass

Closes #3326

🤖 Generated with [Claude Code](https://claude.com/claude-code)