### PR TITLE
feat(scopa): show per-category score breakdown at round end

### DIFF
--- a/frontend/src/i18n/locales/en/scopa.json
+++ b/frontend/src/i18n/locales/en/scopa.json
@@ -24,6 +24,19 @@
     "humanStats": "Hand {{cards}} / Captured {{captured}} / Scopa {{scopa}} / Total {{score}} pt",
     "roundEnd": "Round over — review the score, then continue to the next round"
   },
+  "breakdown": {
+    "title": "Score breakdown",
+    "cards": "Carte (most cards)",
+    "denari": "Denari (most ♦)",
+    "primiera": "Primiera (most 7s)",
+    "settebello": "Settebello (7♦)",
+    "scopa": "Scopa",
+    "gained": "Points this round",
+    "winner": "{{name}} +{{points}}",
+    "tie": "Tie (no points)",
+    "scopaCount": "{{name}} ×{{count}} (+{{points}})",
+    "gainedValue": "{{name}} +{{points}}"
+  },
   "button": {
     "take": "Take",
     "lay": "Lay",

--- a/frontend/src/i18n/locales/ja/scopa.json
+++ b/frontend/src/i18n/locales/ja/scopa.json
@@ -24,6 +24,19 @@
     "humanStats": "手札{{cards}}枚 / 捕獲{{captured}}枚 / スコパ{{scopa}} / 累計{{score}}pt",
     "roundEnd": "ラウンド終了 — 得点を確認して「次のラウンド」へ進んでください"
   },
+  "breakdown": {
+    "title": "得点内訳",
+    "cards": "カルテ（最多カード）",
+    "denari": "デナリ（最多♦）",
+    "primiera": "プリメーラ（最多7）",
+    "settebello": "セッテベッロ（7♦）",
+    "scopa": "スコパ",
+    "gained": "このラウンドの獲得点",
+    "winner": "{{name}} +{{points}}",
+    "tie": "引き分け（点なし）",
+    "scopaCount": "{{name}} ×{{count}}（+{{points}}）",
+    "gainedValue": "{{name}} +{{points}}"
+  },
   "button": {
     "take": "取る",
     "lay": "場に置く",

--- a/frontend/src/pages/ScopaPage.test.tsx
+++ b/frontend/src/pages/ScopaPage.test.tsx
@@ -219,6 +219,61 @@ describe('ScopaPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('n'));
   });
 
+  it('hides the score breakdown during normal play', async () => {
+    renderWithProviders(<ScopaPage />);
+    await waitFor(() => expect(screen.getByTestId('hand-card-0')).toBeInTheDocument());
+    expect(screen.queryByTestId('sc-score-breakdown')).not.toBeInTheDocument();
+  });
+
+  it('renders the per-category score breakdown at round end', async () => {
+    mockExec.mockResolvedValue(
+      makeState({
+        phase: 'roundEnd',
+        currentTurn: 1,
+        lastRoundDetail: {
+          cards: { 0: 20, 1: 16 },
+          diamonds: { 0: 4, 1: 6 },
+          sevens: { 0: 3, 1: 1 },
+          hasSetteBello: 0,
+          scopas: { 0: 2, 1: 0 },
+          gained: { 0: 5, 1: 1 },
+        },
+      }),
+    );
+    renderWithProviders(<ScopaPage />);
+    await waitFor(() => expect(screen.getByTestId('sc-score-breakdown')).toBeInTheDocument());
+    // Carte (most cards) and settebello go to the human; denari goes to CPU 1.
+    expect(screen.getByTestId('sc-breakdown-cards')).toHaveTextContent('あなた +1');
+    expect(screen.getByTestId('sc-breakdown-denari')).toHaveTextContent('CPU 1 +1');
+    expect(screen.getByTestId('sc-breakdown-primiera')).toHaveTextContent('あなた +1');
+    expect(screen.getByTestId('sc-breakdown-settebello')).toHaveTextContent('あなた +1');
+    // Scopa sweeps and per-player round totals are listed too.
+    expect(screen.getByTestId('sc-breakdown-scopa')).toHaveTextContent('あなた ×2');
+    expect(screen.getByTestId('sc-breakdown-gained')).toHaveTextContent('あなた +5');
+    expect(screen.getByTestId('sc-breakdown-gained')).toHaveTextContent('CPU 1 +1');
+  });
+
+  it('marks a tied category as no-points in the breakdown', async () => {
+    mockExec.mockResolvedValue(
+      makeState({
+        phase: 'roundEnd',
+        currentTurn: 1,
+        lastRoundDetail: {
+          cards: { 0: 18, 1: 18 },
+          diamonds: { 0: 0, 1: 0 },
+          sevens: { 0: 0, 1: 0 },
+          hasSetteBello: -1,
+          scopas: { 0: 0, 1: 0 },
+          gained: { 0: 0, 1: 0 },
+        },
+      }),
+    );
+    renderWithProviders(<ScopaPage />);
+    await waitFor(() => expect(screen.getByTestId('sc-breakdown-cards')).toBeInTheDocument());
+    expect(screen.getByTestId('sc-breakdown-cards')).toHaveTextContent('引き分け（点なし）');
+    expect(screen.getByTestId('sc-breakdown-settebello')).toHaveTextContent('引き分け（点なし）');
+  });
+
   it('shows loading state when state has fewer than 2 players', async () => {
     mockExec.mockResolvedValue(
       makeState({

--- a/frontend/src/pages/ScopaPage.tsx
+++ b/frontend/src/pages/ScopaPage.tsx
@@ -28,6 +28,7 @@ import {
   type ScopaCliArgs,
 } from '../utils/cli/commands/scopaCommands';
 import type { CliGameConfig } from '../utils/cli/types';
+import { scopaScoreBreakdown } from '../utils/scopaScoreBreakdown';
 import { scopaTakeCandidates } from '../utils/scopaTakeCandidates';
 
 const DIFFICULTY_OPTIONS = [
@@ -147,6 +148,13 @@ function ScopaPageContent() {
         : t('label.noTakeCandidate')
       : '';
   const phaseName = isGameEnd ? t('phase.end') : t(`phase.${state.phase}`, t('phase.play'));
+  // Round-end score breakdown: only surfaced once the round is scored so the
+  // player can see why each point was awarded (carte/denari/primiera/settebello
+  // + scopa sweeps). The award data comes straight from the presenter's
+  // `lastRoundDetail`; scopa/gained rows read the per-player maps directly.
+  const roundDetail = state.lastRoundDetail;
+  const breakdownRows = roundDetail ? scopaScoreBreakdown(roundDetail) : [];
+  const playerName = (idx: number) => (idx === 0 ? tc('player.you') : tc('player.cpu', { id: idx }));
 
   return (
     <GamePageShell
@@ -273,6 +281,51 @@ function ScopaPageContent() {
                 data-testid="sc-round-end-banner"
               >
                 {t('label.roundEnd')}
+              </div>
+            )}
+
+            {isRoundEnd && roundDetail && (
+              <div className="bg-black/25 rounded-lg p-3 text-sm text-ds-text" data-testid="sc-score-breakdown">
+                <div className="text-center font-semibold mb-2">{t('breakdown.title')}</div>
+                <dl className="max-w-xs mx-auto space-y-1">
+                  {breakdownRows.map((row) => (
+                    <div key={row.key} className="flex justify-between gap-3" data-testid={`sc-breakdown-${row.key}`}>
+                      <dt className="text-ds-text-muted">{t(`breakdown.${row.key}`)}</dt>
+                      <dd className={row.winner < 0 ? 'text-ds-text-muted' : 'font-medium'}>
+                        {row.winner < 0
+                          ? t('breakdown.tie')
+                          : t('breakdown.winner', { name: playerName(row.winner), points: row.points })}
+                      </dd>
+                    </div>
+                  ))}
+                  <div className="flex justify-between gap-3" data-testid="sc-breakdown-scopa">
+                    <dt className="text-ds-text-muted">{t('breakdown.scopa')}</dt>
+                    <dd className="font-medium text-right">
+                      {state.players
+                        .map((p) => {
+                          const count = roundDetail.scopas[p.id] ?? 0;
+                          return t('breakdown.scopaCount', { name: playerName(p.id), count, points: count });
+                        })
+                        .join(' / ')}
+                    </dd>
+                  </div>
+                  <div
+                    className="flex justify-between gap-3 border-t border-ds-border/40 pt-1 mt-1"
+                    data-testid="sc-breakdown-gained"
+                  >
+                    <dt className="text-ds-text-muted">{t('breakdown.gained')}</dt>
+                    <dd className="font-semibold text-right">
+                      {state.players
+                        .map((p) =>
+                          t('breakdown.gainedValue', {
+                            name: playerName(p.id),
+                            points: roundDetail.gained[p.id] ?? 0,
+                          }),
+                        )
+                        .join(' / ')}
+                    </dd>
+                  </div>
+                </dl>
               </div>
             )}
 

--- a/frontend/src/utils/scopaScoreBreakdown.test.ts
+++ b/frontend/src/utils/scopaScoreBreakdown.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import type { ScopaScoreDetail } from '../types/card';
+import { scopaScoreBreakdown } from './scopaScoreBreakdown';
+
+function detail(overrides: Partial<ScopaScoreDetail> = {}): ScopaScoreDetail {
+  return {
+    cards: { 0: 0, 1: 0 },
+    diamonds: { 0: 0, 1: 0 },
+    sevens: { 0: 0, 1: 0 },
+    hasSetteBello: -1,
+    scopas: { 0: 0, 1: 0 },
+    gained: { 0: 0, 1: 0 },
+    ...overrides,
+  };
+}
+
+describe('scopaScoreBreakdown', () => {
+  it('returns the four award categories in a stable order', () => {
+    const rows = scopaScoreBreakdown(detail());
+    expect(rows.map((r) => r.key)).toEqual(['cards', 'denari', 'primiera', 'settebello']);
+  });
+
+  it('awards a category to the unique count leader with 1 point', () => {
+    const rows = scopaScoreBreakdown(
+      detail({ cards: { 0: 20, 1: 16 }, diamonds: { 0: 4, 1: 6 }, sevens: { 0: 3, 1: 1 } }),
+    );
+    const byKey = Object.fromEntries(rows.map((r) => [r.key, r]));
+    expect(byKey.cards).toEqual({ key: 'cards', winner: 0, points: 1 });
+    expect(byKey.denari).toEqual({ key: 'denari', winner: 1, points: 1 });
+    expect(byKey.primiera).toEqual({ key: 'primiera', winner: 0, points: 1 });
+  });
+
+  it('marks a tied count as unawarded (winner -1, 0 points)', () => {
+    const rows = scopaScoreBreakdown(detail({ cards: { 0: 18, 1: 18 } }));
+    const cards = rows.find((r) => r.key === 'cards');
+    expect(cards).toEqual({ key: 'cards', winner: -1, points: 0 });
+  });
+
+  it('marks an all-zero count as unawarded', () => {
+    const rows = scopaScoreBreakdown(detail({ diamonds: { 0: 0, 1: 0 } }));
+    const denari = rows.find((r) => r.key === 'denari');
+    expect(denari).toEqual({ key: 'denari', winner: -1, points: 0 });
+  });
+
+  it('takes the settebello winner directly from hasSetteBello', () => {
+    const wonRows = scopaScoreBreakdown(detail({ hasSetteBello: 1 }));
+    expect(wonRows.find((r) => r.key === 'settebello')).toEqual({ key: 'settebello', winner: 1, points: 1 });
+    const noneRows = scopaScoreBreakdown(detail({ hasSetteBello: -1 }));
+    expect(noneRows.find((r) => r.key === 'settebello')).toEqual({ key: 'settebello', winner: -1, points: 0 });
+  });
+});

--- a/frontend/src/utils/scopaScoreBreakdown.ts
+++ b/frontend/src/utils/scopaScoreBreakdown.ts
@@ -1,0 +1,68 @@
+import type { ScopaScoreDetail } from '../types/card';
+
+/**
+ * i18n suffix identifying a single-winner Scopa scoring category.
+ * Mirrors the domain award categories: most cards (carte), most coins
+ * (denari), most sevens (primiera-equivalent) and the seven of coins
+ * (settebello).
+ */
+export type ScopaCategoryKey = 'cards' | 'denari' | 'primiera' | 'settebello';
+
+/** One row of the Scopa round-end score breakdown for an award category. */
+export interface ScopaBreakdownRow {
+  /** i18n suffix key for the category label. */
+  key: ScopaCategoryKey;
+  /** Winning player index, or -1 when the category is tied / unawarded. */
+  winner: number;
+  /** Points awarded for this category (0 when tied / unawarded). */
+  points: number;
+}
+
+/** Points granted per single-winner category (mirrors the domain constants, all 1). */
+const CATEGORY_POINT = 1;
+
+/**
+ * Returns the sole player index holding the strict maximum count, or -1 when
+ * the maximum is shared (tie) or every count is zero. Mirrors the backend
+ * `uniqueMaxIndex` used by the Scopa scoring routine.
+ */
+function uniqueMaxIndex(counts: Record<number, number>): number {
+  let best = -1;
+  let bestVal = 0;
+  let tie = false;
+  for (const [k, v] of Object.entries(counts)) {
+    const idx = Number(k);
+    if (best === -1 || v > bestVal) {
+      best = idx;
+      bestVal = v;
+      tie = false;
+    } else if (v === bestVal) {
+      tie = true;
+    }
+  }
+  if (tie || bestVal === 0) {
+    return -1;
+  }
+  return best;
+}
+
+/** Builds the winner/points pair for a category given its winning index. */
+function award(winner: number): { winner: number; points: number } {
+  return { winner, points: winner >= 0 ? CATEGORY_POINT : 0 };
+}
+
+/**
+ * Derives the four single-winner Scopa award categories (carte, denari,
+ * primiera, settebello) from a round-end score detail. Each row names the
+ * winning player index (or -1 for a tie / unawarded category) and the points
+ * granted. Scopa sweeps and per-player totals are rendered separately because
+ * they are per-player counts rather than single-winner awards.
+ */
+export function scopaScoreBreakdown(detail: ScopaScoreDetail): ScopaBreakdownRow[] {
+  return [
+    { key: 'cards', ...award(uniqueMaxIndex(detail.cards)) },
+    { key: 'denari', ...award(uniqueMaxIndex(detail.diamonds)) },
+    { key: 'primiera', ...award(uniqueMaxIndex(detail.sevens)) },
+    { key: 'settebello', ...award(detail.hasSetteBello) },
+  ];
+}


### PR DESCRIPTION
## Summary
At round end, Scopa now shows a score breakdown by category so the player can see why the round's points moved — previously only `totalScore`/`capturedCount`/`scopaCount` were surfaced and the reasoning was left to the generic `GameMessageBox`.

The additive panel lists each award category with its winning (localized) player name and points:
- **Carte** — most cards
- **Denari** — most coins (♦)
- **Primiera** — most sevens (the domain's primiera-equivalent)
- **Settebello** — the 7♦
- **Scopa** — per-player sweep counts
- **Points this round** — per-player round total (`gained`)

Tied / unawarded categories are shown distinctly as "引き分け（点なし）" / "Tie (no points)".

## Implementation notes
- **Frontend-only.** The per-category award data already ships in the presenter's `lastRoundDetail` (`cards`, `diamonds`, `sevens`, `hasSetteBello`, `scopas`, `gained`) — no Go changes needed.
- New pure helper `frontend/src/utils/scopaScoreBreakdown.ts` derives each single-winner category's winner + points, mirroring the domain `uniqueMaxIndex` rule (tie / all-zero → unawarded). All category point values are 1 per the domain constants.
- Panel renders only when `phase === 'roundEnd'` and `lastRoundDetail` is present; hidden during normal play.
- Localized player names via `common.json` `player.you` / `player.cpu`.
- ja/en i18n keys added under `breakdown.*` (key-for-key parity verified).

## Test plan
- [x] `scopaScoreBreakdown` helper: winner/points, ties, all-zero, settebello (5 tests)
- [x] Page: breakdown hidden during play; renders per-category winners + scopa + gained at round end; tie shown as no-points (3 tests)
- [x] `bun run check` (biome + design tokens)
- [x] `bun run test -- --run Scopa` (58 passed)
- [x] `bun run build` (tsc gate)
- [x] ja/en i18n parity

Closes #3343