### PR TITLE
feat(oasispoker): add frontend heuristic hint for exchange and action phases

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -130,7 +130,7 @@ bun run build && bun run check && bun run test
 | `TutorialProvider` | `src/providers/TutorialProvider.tsx` | Context provider; renders overlay (used internally by TutorialWrapper) |
 | `TutorialOverlay` | `src/components/tutorial/TutorialOverlay.tsx` | Full-screen overlay with SVG mask spotlight |
 | `useTutorial` | `src/hooks/useTutorial.ts` | State management (step progression, localStorage, resume/restart) |
-| `useGameHint` | `src/hooks/useGameHint.ts` | Frontend hints; registry-driven via `hintFactories` (covers ~all games, currently 191). The supported set is the `HintGameName` union (`keyof typeof hintFactories`) — add a game by registering its factory there |
+| `useGameHint` | `src/hooks/useGameHint.ts` | Frontend hints; registry-driven via `hintFactories` (covers ~all games, currently 192). The supported set is the `HintGameName` union (`keyof typeof hintFactories`) — add a game by registering its factory there |
 | `TutorialSuggestDialog` | `src/components/tutorial/TutorialSuggestDialog.tsx` | First-visit dialog; controlled by `useFirstVisit` hook |
 | `TutorialProgressPanel` | `src/components/tutorial/TutorialProgressPanel.tsx` | Progress overview in NavBar |
 

--- a/frontend/src/hooks/useGameHint.ts
+++ b/frontend/src/hooks/useGameHint.ts
@@ -94,6 +94,7 @@ import type {
   NapResponse,
   NertzResponse,
   NinetyNineResponse,
+  OasisPokerResponse,
   OhHellResponse,
   OichoKabuResponse,
   OldMaidResponse,
@@ -272,6 +273,7 @@ import { getNapHint } from '../utils/hints/napHint';
 import { getNapoleonHint } from '../utils/hints/napoleonHint';
 import { getNertzHint } from '../utils/hints/nertzHint';
 import { getNinetyNineHint } from '../utils/hints/ninetynineHint';
+import { getOasisPokerHint } from '../utils/hints/oasispokerHint';
 import { getOhHellHint } from '../utils/hints/ohhellHint';
 import { getOichokabuHint } from '../utils/hints/oichokabuHint';
 import { getOldMaidHint } from '../utils/hints/oldmaidHint';
@@ -425,6 +427,7 @@ const hintFactories = {
   gofish: (s) => getGoFishHint(s as GoFishResponse),
   golf: (s) => getGolfHint(s as GolfResponse),
   caribbeanstud: (s) => getCaribbeanStudHint(s as CaribbeanStudResponse),
+  oasispoker: (s) => getOasisPokerHint(s as OasisPokerResponse),
   casinoholdem: (s) => getCasinoHoldemHint(s as CasinoHoldemResponse),
   texasholdembonus: (s) => getTexasHoldemBonusHint(s as TexasHoldemBonusResponse),
   ultimatetexasholdem: (s) => getUltimateTexasHoldemHint(s as UltimateTexasHoldemResponse),

--- a/frontend/src/i18n/locales/en/oasispoker.json
+++ b/frontend/src/i18n/locales/en/oasispoker.json
@@ -88,5 +88,12 @@
     "actionButtons": "Choose Call (2x ante) to face the dealer, or Fold to forfeit your ante.",
     "results": "Review your result and payouts."
   },
-  "hiddenCard": "Hidden card"
+  "hiddenCard": "Hidden card",
+  "hint": {
+    "pairOrBetter": "Pair or better — recommend Play",
+    "aceKingHigh": "Ace-King high — recommend Play",
+    "weakHand": "Weak hand — recommend Fold",
+    "exchangeKeep": "Pair or better — stand pat (no exchange)",
+    "exchangeImprove": "Weak hand — exchange to try to improve"
+  }
 }

--- a/frontend/src/i18n/locales/ja/oasispoker.json
+++ b/frontend/src/i18n/locales/ja/oasispoker.json
@@ -88,5 +88,12 @@
     "actionButtons": "コールでアンテの2倍を賭けるか、フォールドで降りるか選択してください。",
     "results": "結果と配当を確認してください。"
   },
-  "hiddenCard": "非公開のカード"
+  "hiddenCard": "非公開のカード",
+  "hint": {
+    "pairOrBetter": "ペア以上 — プレイ推奨",
+    "aceKingHigh": "A-K ハイ — プレイ推奨",
+    "weakHand": "弱い手札 — フォールド推奨",
+    "exchangeKeep": "ペア以上 — 交換せずスタンド推奨",
+    "exchangeImprove": "弱い手札 — カード交換で改善を狙う"
+  }
 }

--- a/frontend/src/pages/OasisPokerPage.test.tsx
+++ b/frontend/src/pages/OasisPokerPage.test.tsx
@@ -230,6 +230,39 @@ describe('OasisPokerPage', () => {
     await waitFor(() => expect(mockApi).toHaveBeenCalledWith('bet', 200, 10));
   });
 
+  it('shows a play hint in the action phase when hints are enabled (strong hand)', async () => {
+    const strongAction: OasisPokerResponse = { ...actionPhaseState, playerHandRank: 1 };
+    mockApi.mockResolvedValue(strongAction);
+    renderWithProviders(<OasisPokerPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'コール' })).toBeInTheDocument());
+
+    // No hint until the toggle is enabled.
+    expect(screen.queryByTestId('hint-tooltip')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText('ヒント表示'));
+    expect(screen.getByTestId('hint-tooltip')).toHaveTextContent('ペア以上 — プレイ推奨');
+  });
+
+  it('shows a fold hint in the action phase for a weak hand when hints are enabled', async () => {
+    // exchangePhaseState hand (10/J/K/5/7 offsuit) has rank 0 and no Ace-King pair.
+    const weakAction: OasisPokerResponse = { ...actionPhaseState, playerHandRank: 0 };
+    mockApi.mockResolvedValue(weakAction);
+    renderWithProviders(<OasisPokerPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'フォールド' })).toBeInTheDocument());
+
+    fireEvent.click(screen.getByLabelText('ヒント表示'));
+    expect(screen.getByTestId('hint-tooltip')).toHaveTextContent('弱い手札 — フォールド推奨');
+  });
+
+  it('shows an exchange hint in the exchange phase for a weak hand when hints are enabled', async () => {
+    mockApi.mockResolvedValue(exchangePhaseState);
+    renderWithProviders(<OasisPokerPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: '交換' })).toBeInTheDocument());
+
+    fireEvent.click(screen.getByLabelText('ヒント表示'));
+    expect(screen.getByTestId('hint-tooltip')).toHaveTextContent('弱い手札 — カード交換で改善を狙う');
+  });
+
   it('shows network error', async () => {
     mockApi.mockResolvedValueOnce(betPhaseState).mockRejectedValueOnce(new Error('Network'));
     renderWithProviders(<OasisPokerPage />);

--- a/frontend/src/pages/OasisPokerPage.tsx
+++ b/frontend/src/pages/OasisPokerPage.tsx
@@ -10,6 +10,7 @@ import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
+import { HintTooltip } from '../components/hint/HintTooltip';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { AnimatedCardBack } from '../components/motion/AnimatedCardBack';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
@@ -19,6 +20,7 @@ import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
+import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useMountReset } from '../hooks/useMountReset';
 import { useSound } from '../providers/SoundProvider';
@@ -89,6 +91,7 @@ function OasisPokerPageContent() {
   const { cardWidth } = useCardDimensions();
   const { playSound } = useSound();
   const { state, loading, error, exec: execApi, retry } = useGameApi(oasispokerApi.exec);
+  const { hint, hintEnabled, setHintEnabled } = useGameHint('oasispoker', state);
   // CLI mode
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('oasispoker');
   const cliConfig: CliGameConfig<OasisPokerResponse, Parameters<typeof oasispokerApi.exec>> = useMemo(
@@ -376,7 +379,23 @@ function OasisPokerPageContent() {
 
           <GameFooter className={`${gameTheme.oasispoker.footer} px-4 pt-3`}>
             <ErrorAlert message={error} onRetry={retry} />
-            <SettingsPanel title={t('settings.title')} groups={[]} />
+            {hintEnabled && hint && <HintTooltip reason={t(hint.reason)} confidence={hint.confidence} />}
+            <SettingsPanel
+              title={t('settings.title')}
+              groups={[
+                {
+                  items: [
+                    {
+                      type: 'checkbox',
+                      id: 'oasispoker-hint',
+                      label: tc('hint.toggle', { ns: 'tutorial' }),
+                      checked: hintEnabled,
+                      onToggle: setHintEnabled,
+                    },
+                  ],
+                },
+              ]}
+            />
             {isBetPhase && (
               <div className="flex flex-col items-center gap-2 pb-2" data-tutorial="oasis-bet-controls">
                 <ChipBetInput

--- a/frontend/src/utils/hints/oasispokerHint.test.ts
+++ b/frontend/src/utils/hints/oasispokerHint.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import type { Card, OasisPokerResponse } from '../../types/card';
+import { OasisPokerPhase } from '../../types/phases';
+import { getOasisPokerHint } from './oasispokerHint';
+
+const card = (design: Card['design'], value: number): Card => ({ design, value });
+
+function makeState(overrides: Partial<OasisPokerResponse> = {}): OasisPokerResponse {
+  return {
+    playerHand: [card('SPADE', 2), card('HEART', 5), card('DIAMOND', 8), card('CLOVER', 10), card('SPADE', 12)],
+    dealerHand: [],
+    phase: OasisPokerPhase.ACTION,
+    chips: 1000,
+    anteBet: 100,
+    jackpotBet: 0,
+    exchangeCount: 0,
+    exchangeFee: 0,
+    playBet: 0,
+    result: 0,
+    antePayout: 0,
+    playPayout: 0,
+    jackpotPayout: 0,
+    totalPayout: 0,
+    dealerQualified: false,
+    playerHandRank: 0,
+    dealerHandRank: 0,
+    message: '',
+    ...overrides,
+  };
+}
+
+describe('getOasisPokerHint', () => {
+  it('returns null in bet and end phases', () => {
+    expect(getOasisPokerHint(makeState({ phase: OasisPokerPhase.BET }))).toBeNull();
+    expect(getOasisPokerHint(makeState({ phase: OasisPokerPhase.END }))).toBeNull();
+  });
+
+  it('returns null when player hand is empty', () => {
+    expect(getOasisPokerHint(makeState({ playerHand: [] }))).toBeNull();
+  });
+
+  // --- Action phase ---
+  it('recommends play with pair or better (strong)', () => {
+    const hint = getOasisPokerHint(makeState({ phase: OasisPokerPhase.ACTION, playerHandRank: 1 }));
+    expect(hint?.targetAction).toBe('play');
+    expect(hint?.confidence).toBe('strong');
+    expect(hint?.reason).toBe('hint.pairOrBetter');
+  });
+
+  it('recommends play with Ace-King high (moderate)', () => {
+    const state = makeState({
+      phase: OasisPokerPhase.ACTION,
+      playerHand: [card('SPADE', 1), card('HEART', 13), card('DIAMOND', 8), card('CLOVER', 5), card('SPADE', 3)],
+      playerHandRank: 0,
+    });
+    const hint = getOasisPokerHint(state);
+    expect(hint?.targetAction).toBe('play');
+    expect(hint?.confidence).toBe('moderate');
+    expect(hint?.reason).toBe('hint.aceKingHigh');
+  });
+
+  it('recommends fold with a weak high-card hand', () => {
+    const hint = getOasisPokerHint(makeState({ phase: OasisPokerPhase.ACTION, playerHandRank: 0 }));
+    expect(hint?.targetAction).toBe('fold');
+    expect(hint?.reason).toBe('hint.weakHand');
+  });
+
+  // --- Exchange phase ---
+  it('recommends standing with a made hand of pair or better (strong)', () => {
+    const hint = getOasisPokerHint(makeState({ phase: OasisPokerPhase.EXCHANGE, playerHandRank: 1 }));
+    expect(hint?.targetAction).toBe('stand');
+    expect(hint?.confidence).toBe('strong');
+    expect(hint?.reason).toBe('hint.exchangeKeep');
+  });
+
+  it('recommends exchanging a weak hand (moderate)', () => {
+    const hint = getOasisPokerHint(makeState({ phase: OasisPokerPhase.EXCHANGE, playerHandRank: 0 }));
+    expect(hint?.targetAction).toBe('exchange');
+    expect(hint?.confidence).toBe('moderate');
+    expect(hint?.reason).toBe('hint.exchangeImprove');
+  });
+});

--- a/frontend/src/utils/hints/oasispokerHint.ts
+++ b/frontend/src/utils/hints/oasispokerHint.ts
@@ -1,0 +1,51 @@
+import type { Card, OasisPokerResponse } from '../../types/card';
+import type { HintResult } from '../../types/hint';
+import { OasisPokerPhase } from '../../types/phases';
+
+/** PokerHandOnePair = 1 (sync: internal/domain/PokerPlayer.go). */
+const RANK_ONE_PAIR = 1;
+
+/** Card value representing an Ace. */
+const ACE_VALUE = 1;
+
+/** Card value representing a King. */
+const KING_VALUE = 13;
+
+/**
+ * Returns an Oasis Poker hint for the exchange and action phases.
+ *
+ * Oasis Poker is a Caribbean Stud variant where the player may buy a card
+ * exchange before the play/fold decision. The heuristic is a simplified basic
+ * strategy (a suggestion, not a guarantee):
+ * - Exchange phase: keep (stand) a made hand of a pair or better; otherwise
+ *   exchange weak cards to try to improve, since only a made hand or Ace-King
+ *   beats a qualifying dealer.
+ * - Action phase: play with a pair or better, or with Ace-King high; fold otherwise.
+ */
+export function getOasisPokerHint(state: OasisPokerResponse): HintResult | null {
+  if (!state.playerHand || state.playerHand.length === 0) return null;
+
+  if (state.phase === OasisPokerPhase.EXCHANGE) {
+    if (state.playerHandRank >= RANK_ONE_PAIR) {
+      return { targetAction: 'stand', reason: 'hint.exchangeKeep', confidence: 'strong' };
+    }
+    return { targetAction: 'exchange', reason: 'hint.exchangeImprove', confidence: 'moderate' };
+  }
+
+  if (state.phase === OasisPokerPhase.ACTION) {
+    if (state.playerHandRank >= RANK_ONE_PAIR) {
+      return { targetAction: 'play', reason: 'hint.pairOrBetter', confidence: 'strong' };
+    }
+    if (hasAceKing(state.playerHand)) {
+      return { targetAction: 'play', reason: 'hint.aceKingHigh', confidence: 'moderate' };
+    }
+    return { targetAction: 'fold', reason: 'hint.weakHand', confidence: 'moderate' };
+  }
+
+  return null;
+}
+
+function hasAceKing(cards: Card[]): boolean {
+  const values = new Set(cards.map((c) => c.value));
+  return values.has(ACE_VALUE) && values.has(KING_VALUE);
+}


### PR DESCRIPTION
## Summary

Oasis Poker was the only Caribbean-Stud-family casino game missing the client-side heuristic hint that siblings (`caribbeanstud`, `highcardflush`, `casinoholdem`, `russianpoker`) already have. This adds `useGameHint('oasispoker', state)`, surfaced via the existing `HintTooltip` and a `SettingsPanel` on/off toggle.

## Heuristic (a suggestion, not a guarantee)

Mirrors the simplified Caribbean Stud basic strategy, extended for Oasis Poker's card-exchange option:

- **Exchange phase**: pair-or-better → **stand pat** (strong, don't pay the fee); weak hand → **exchange** to try to improve (moderate).
- **Action phase**: pair-or-better → **play** (strong); Ace-King high → **play** (moderate); otherwise **fold** (moderate).

Rank comes from `playerHandRank`, which the Web presenter populates in every phase.

## Files

- `frontend/src/utils/hints/oasispokerHint.ts` (+ test) — the factory, mirroring `caribbeanstudHint.ts`
- `frontend/src/hooks/useGameHint.ts` — register `oasispoker` in `hintFactories`
- `frontend/src/pages/OasisPokerPage.tsx` (+ test) — wire hook, `HintTooltip`, and settings toggle
- `frontend/src/i18n/locales/{ja,en}/oasispoker.json` — hint reason strings (ja+en parity)
- `frontend/CLAUDE.md` — bump the documented hint-factory count 191 → 192

## Test plan

- [x] `bun run test -- --run OasisPoker` (54 passed) — incl. strong→play, weak→fold, weak→exchange hint tests
- [x] `bun run test -- --run useGameHint.docCount oasispokerHint`
- [x] `bun run check` (exit 0)
- [x] `bun run build` (exit 0, tsc gate)

Frontend-only; no Go touched.

Closes #3271