### PR TITLE
feat(flowergarden): lay the 16-card bouquet reserve out as a responsive grid

### DIFF
--- a/frontend/src/pages/FlowerGardenPage.test.tsx
+++ b/frontend/src/pages/FlowerGardenPage.test.tsx
@@ -102,6 +102,21 @@ describe('FlowerGardenPage', () => {
     }
   });
 
+  it('lays the 16-card bouquet out as a responsive grid (4 cols mobile, 8 cols sm+)', async () => {
+    mockExec.mockResolvedValue(playingState);
+    const { container } = renderWithProviders(<FlowerGardenPage />);
+    await waitFor(() => expect(screen.getByText('#0')).toBeInTheDocument());
+    // The reserve slots live in a responsive grid so all 16 stay visible on mobile
+    // instead of wrapping into a single cramped flex row (#3283).
+    const grid = container.querySelector('[data-tutorial="fg-reserve"] .grid');
+    expect(grid).not.toBeNull();
+    expect(grid).toHaveClass('grid-cols-4', 'sm:grid-cols-8');
+    // All 16 bouquet slots render inside the grid.
+    for (let i = 0; i < 16; i++) {
+      expect(screen.getByText(`#${i}`)).toBeInTheDocument();
+    }
+  });
+
   it('selecting a reserve card marks it as selected', async () => {
     mockExec.mockResolvedValue(playingState);
     renderWithProviders(<FlowerGardenPage />);

--- a/frontend/src/pages/FlowerGardenPage.tsx
+++ b/frontend/src/pages/FlowerGardenPage.tsx
@@ -334,10 +334,14 @@ function FlowerGardenPageContent() {
       ) : (
         <>
           <div className="flex-1 overflow-y-auto pt-3 px-2 sm:px-4 lg:px-8">
-            <div className="flex gap-2 sm:gap-3 items-start justify-center mb-3">
-              <div className="flex flex-wrap gap-1 sm:gap-2 items-start" data-tutorial="fg-reserve">
-                <span className="self-center text-game-text-muted text-xs mr-1">{t('reserve')}</span>
-                {state.reserve.map((_, idx) => renderReserveCell(idx))}
+            <div className="flex flex-wrap gap-2 sm:gap-3 items-start justify-center mb-3">
+              <div className="flex flex-col gap-1" data-tutorial="fg-reserve">
+                <span className="text-game-text-muted text-xs">{t('reserve')}</span>
+                {/* 16 bouquet cards laid out as a grid (4 cols on mobile, 8 on sm+) so every
+                    slot stays clearly visible instead of cramming into one wrapping row (#3283). */}
+                <div className="grid grid-cols-4 sm:grid-cols-8 gap-1 sm:gap-2 justify-items-center">
+                  {state.reserve.map((_, idx) => renderReserveCell(idx))}
+                </div>
               </div>
 
               <div className="flex items-start gap-1 sm:gap-2" data-tutorial="fg-foundation">


### PR DESCRIPTION
## Summary
The Flower Garden reserve ("bouquet") crammed all 16 cards into a single `flex flex-wrap` row that shared its line with the 4 foundations, so on mobile the cards wrapped into a dense, hard-to-scan block (issue #3283).

This lays the bouquet out in a **responsive grid** — 4 columns on mobile (4×4), 8 columns on `sm`+ (8×2) — and makes the reserve/foundation container `flex-wrap` so the foundations drop onto their own line on narrow screens instead of competing for width. Purely presentational: move logic, drag-and-drop, click handlers, `aria` labels, and the `#0`..`#15` slot numbering are all unchanged.

## Changes
- `frontend/src/pages/FlowerGardenPage.tsx` — reserve wrapped in a labelled `flex-col`; 16 cells now render inside `grid grid-cols-4 sm:grid-cols-8`; outer row made `flex-wrap`.
- `frontend/src/pages/FlowerGardenPage.test.tsx` — new test asserting the reserve grid has the responsive `grid-cols-4 sm:grid-cols-8` classes and all 16 slots render.

## Acceptance criteria
- [x] Bouquet displays neatly at mobile width (4×4 grid)
- [x] All 16 slots remain accessible/selectable (handlers untouched)
- [x] Desktop layout preserved/improved (8×2 grid, foundations wrap cleanly)
- [x] Responsive component test added

## Gates
- [x] `bun run check`
- [x] `bun run test -- --run FlowerGarden` (47 passed)
- [x] `bun run build`

Closes #3283