### PR TITLE
feat(truco): add web hint display mirroring the CUI HintOutput

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -130,7 +130,7 @@ bun run build && bun run check && bun run test
 | `TutorialProvider` | `src/providers/TutorialProvider.tsx` | Context provider; renders overlay (used internally by TutorialWrapper) |
 | `TutorialOverlay` | `src/components/tutorial/TutorialOverlay.tsx` | Full-screen overlay with SVG mask spotlight |
 | `useTutorial` | `src/hooks/useTutorial.ts` | State management (step progression, localStorage, resume/restart) |
-| `useGameHint` | `src/hooks/useGameHint.ts` | Frontend hints; registry-driven via `hintFactories` (covers ~all games, currently 192). The supported set is the `HintGameName` union (`keyof typeof hintFactories`) — add a game by registering its factory there |
+| `useGameHint` | `src/hooks/useGameHint.ts` | Frontend hints; registry-driven via `hintFactories` (covers ~all games, currently 193). The supported set is the `HintGameName` union (`keyof typeof hintFactories`) — add a game by registering its factory there |
 | `TutorialSuggestDialog` | `src/components/tutorial/TutorialSuggestDialog.tsx` | First-visit dialog; controlled by `useFirstVisit` hook |
 | `TutorialProgressPanel` | `src/components/tutorial/TutorialProgressPanel.tsx` | Progress overview in NavBar |
 

--- a/frontend/src/hooks/useGameHint.ts
+++ b/frontend/src/hooks/useGameHint.ts
@@ -158,6 +158,7 @@ import type {
   TrenteEtQuaranteResponse,
   TressetteResponse,
   TriPeaksResponse,
+  TrucoResponse,
   TuteResponse,
   TwentyNineResponse,
   TwoTenJackResponse,
@@ -338,6 +339,7 @@ import { getTrashHint } from '../utils/hints/trashHint';
 import { getTrenteEtQuaranteHint } from '../utils/hints/trenteetquaranteHint';
 import { getTressetteHint } from '../utils/hints/tressetteHint';
 import { getTriPeaksHint } from '../utils/hints/tripeaksHint';
+import { getTrucoHint } from '../utils/hints/trucoHint';
 import { getTuteHint } from '../utils/hints/tuteHint';
 import { getTwentyNineHint } from '../utils/hints/twentyNineHint';
 import { getTwoTenJackHint } from '../utils/hints/twotenjackHint';
@@ -553,6 +555,7 @@ const hintFactories = {
   primero: (s) => getPrimeroHint(s as PrimeroResponse),
   michigan: (s) => getMichiganHint(s as MichiganResponse),
   pan: (s) => getPanHint(s as PanResponse),
+  truco: (s) => getTrucoHint(s as TrucoResponse),
 } satisfies Record<string, HintFn>;
 
 /** Supported game names for the hint system, derived from the registry. */

--- a/frontend/src/i18n/locales/en/truco.json
+++ b/frontend/src/i18n/locales/en/truco.json
@@ -41,6 +41,15 @@
     "cpuWin": "CPU wins ({{p0}}-{{p1}})"
   },
   "respondPrompt": "{{name}} called {{level}}. Respond.",
+  "hintReason": {
+    "leadStrong": "Lead with a strong card",
+    "leadLow": "Lead low to save your strong cards",
+    "followWin": "Play a stronger card to win this baza",
+    "followDump": "Dump a weak card and let this baza go",
+    "call": "Strong hand — declare Truco",
+    "accept": "Accept (Quiero) and play it out",
+    "decline": "Weak hand — decline (No Quiero)"
+  },
   "caller": {
     "you": "You",
     "cpu": "CPU"

--- a/frontend/src/i18n/locales/ja/truco.json
+++ b/frontend/src/i18n/locales/ja/truco.json
@@ -41,6 +41,15 @@
     "cpuWin": "CPUの勝ち ({{p0}}-{{p1}})"
   },
   "respondPrompt": "{{name}} が {{level}} を宣言しました。応答してください。",
+  "hintReason": {
+    "leadStrong": "強いカードでリードしましょう",
+    "leadLow": "弱いカードでリードして強い札を温存",
+    "followWin": "強い札を出してこのバサを取りましょう",
+    "followDump": "弱い札を捨ててこのバサは捨てましょう",
+    "call": "強い手です。Truco を宣言しましょう",
+    "accept": "受諾 (Quiero) して戦いましょう",
+    "decline": "手が弱いので拒否 (No Quiero) しましょう"
+  },
   "caller": {
     "you": "あなた",
     "cpu": "CPU"

--- a/frontend/src/pages/TrucoPage.test.tsx
+++ b/frontend/src/pages/TrucoPage.test.tsx
@@ -199,4 +199,36 @@ describe('TrucoPage', () => {
     fireEvent.click(screen.getByRole('button', { name: '確認' }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
   });
+
+  it('hides the hint tooltip by default and reveals a reasoned recommendation when the toggle is enabled', async () => {
+    localStorage.removeItem('hint_enabled_truco');
+    renderWithProviders(<TrucoPage />);
+    await waitFor(() => expect(screen.getByTestId('truco-hint-toggle')).toBeInTheDocument());
+    expect(screen.queryByTestId('hint-tooltip')).toBeNull();
+
+    fireEvent.click(screen.getByRole('checkbox'));
+    // Default hand leads with 1♠ (top matador) and canDeclareTruco → declare-Truco advice.
+    await waitFor(() =>
+      expect(screen.getByTestId('hint-tooltip')).toHaveTextContent('強い手です。Truco を宣言しましょう'),
+    );
+  });
+
+  it('shows the follow-to-win hint when a stronger card can beat the lead', async () => {
+    localStorage.setItem('hint_enabled_truco', 'true');
+    mockExec.mockResolvedValue(
+      makeState({
+        currentTrick: [{ playerIdx: 1, card: card('DIAMOND', 5) }],
+        canDeclareTruco: false,
+        players: [
+          { id: 0, isHuman: true, cardCount: 2, cards: [card('HEART', 4), card('HEART', 3)], trickCount: 0 },
+          { id: 1, isHuman: false, cardCount: 2, cards: [], trickCount: 0 },
+        ],
+      }),
+    );
+    renderWithProviders(<TrucoPage />);
+    await waitFor(() =>
+      expect(screen.getByTestId('hint-tooltip')).toHaveTextContent('強い札を出してこのバサを取りましょう'),
+    );
+    localStorage.removeItem('hint_enabled_truco');
+  });
 });

--- a/frontend/src/pages/TrucoPage.tsx
+++ b/frontend/src/pages/TrucoPage.tsx
@@ -5,12 +5,14 @@ import { CardImage } from '../components/CardImage';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
+import { HintTooltip } from '../components/hint/HintTooltip';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { TrickDisplay } from '../components/TrickDisplay';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useGameApi } from '../hooks/useGameApi';
+import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { btnDanger, btnPrimary, btnSuccess, btnWarning } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -50,6 +52,7 @@ function TrucoPageContent() {
     retry,
   } = useGameApi<TrucoResponse, Parameters<typeof trucoApi.exec>>(trucoApi.exec);
   const { cardWidth } = useCardDimensions();
+  const { hint, hintEnabled, setHintEnabled } = useGameHint('truco', state);
 
   useEffect(() => {
     void dispatch('reset');
@@ -214,6 +217,7 @@ function TrucoPageContent() {
         )}
 
         <GameMessageBox message={state.message} messageCode={state.messageCode} messageParams={state.messageParams} />
+        {hintEnabled && hint && <HintTooltip reason={t(hint.reason)} confidence={hint.confidence} />}
         <ErrorAlert message={error} onRetry={retry} />
 
         {human && human.cards.length > 0 && (
@@ -273,6 +277,10 @@ function TrucoPageContent() {
           <button type="button" className={btnPrimary} onClick={() => requestConfirm(handleReset)} disabled={loading}>
             {t('actions.reset')}
           </button>
+          <label className="flex items-center gap-1 text-ds-text-primary text-sm" data-testid="truco-hint-toggle">
+            <input type="checkbox" checked={hintEnabled} onChange={(e) => setHintEnabled(e.target.checked)} />
+            {tc('hint')}
+          </label>
         </div>
       </div>
 

--- a/frontend/src/utils/hints/trucoHint.test.ts
+++ b/frontend/src/utils/hints/trucoHint.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import type { Card, TrucoPlayerData, TrucoResponse, TrucoTrickCard } from '../../types/card';
+import { getTrucoHint, trucoCardStrength } from './trucoHint';
+
+const card = (value: number, design = 'SPADE'): Card => ({ design, value }) as unknown as Card;
+
+const player = (cards: Card[], overrides: Partial<TrucoPlayerData> = {}): TrucoPlayerData => ({
+  id: 0,
+  isHuman: true,
+  cardCount: cards.length,
+  cards,
+  trickCount: 0,
+  ...overrides,
+});
+
+/** PLAY=0, RESPOND=1, TRICK_END=2 (mirrors TrucoPhase). */
+const makeState = (overrides: Partial<TrucoResponse> = {}): TrucoResponse =>
+  ({
+    players: [player([card(4)]), player([], { id: 1, isHuman: false })],
+    phase: 0,
+    handNumber: 1,
+    trickNumber: 1,
+    currentPlayerIdx: 0,
+    responderIdx: -1,
+    currentTrick: [],
+    trickResults: [],
+    canDeclareTruco: false,
+    gameEndFlag: false,
+    ...overrides,
+  }) as unknown as TrucoResponse;
+
+const trick = (value: number, design = 'SPADE'): TrucoTrickCard =>
+  ({ playerIdx: 1, card: card(value, design) }) as unknown as TrucoTrickCard;
+
+describe('trucoCardStrength', () => {
+  it('ranks the four matadores above every common card', () => {
+    expect(trucoCardStrength(card(1, 'SPADE'))).toBe(14); // 1 de Espadas
+    expect(trucoCardStrength(card(1, 'CLOVER'))).toBe(13); // 1 de Bastos
+    expect(trucoCardStrength(card(7, 'SPADE'))).toBe(12); // 7 de Espadas
+    expect(trucoCardStrength(card(7, 'DIAMOND'))).toBe(11); // 7 de Oros
+    expect(trucoCardStrength(card(3, 'HEART'))).toBe(10); // strongest common
+    expect(trucoCardStrength(card(4, 'HEART'))).toBe(1); // weakest common
+  });
+
+  it('returns 0 for unused ranks and undefined', () => {
+    expect(trucoCardStrength(card(8))).toBe(0);
+    expect(trucoCardStrength(undefined)).toBe(0);
+  });
+});
+
+describe('getTrucoHint', () => {
+  it('returns null when there is no state or the game has ended', () => {
+    expect(getTrucoHint(null as unknown as TrucoResponse)).toBeNull();
+    expect(getTrucoHint(makeState({ gameEndFlag: true }))).toBeNull();
+  });
+
+  it('returns null when the hand is empty', () => {
+    expect(getTrucoHint(makeState({ players: [player([]), player([], { id: 1, isHuman: false })] }))).toBeNull();
+  });
+
+  it('recommends declaring Truco with a strong hand when allowed', () => {
+    const hint = getTrucoHint(makeState({ canDeclareTruco: true, players: [player([card(1, 'SPADE'), card(4)])] }));
+    expect(hint).toEqual({ targetAction: 'truco', reason: 'hintReason.call', confidence: 'strong' });
+  });
+
+  it('recommends leading strong when the chosen lead card is strong', () => {
+    const hint = getTrucoHint(makeState({ players: [player([card(1, 'SPADE')])] }));
+    expect(hint).toEqual({ targetAction: 'play', reason: 'hintReason.leadStrong', confidence: 'strong' });
+  });
+
+  it('recommends leading low with a weak hand', () => {
+    const hint = getTrucoHint(makeState({ players: [player([card(4)])] }));
+    expect(hint).toEqual({ targetAction: 'play', reason: 'hintReason.leadLow', confidence: 'moderate' });
+  });
+
+  it('recommends the cheapest winning card when following', () => {
+    const hint = getTrucoHint(
+      makeState({ currentTrick: [trick(5, 'DIAMOND')], players: [player([card(4), card(3, 'HEART')])] }),
+    );
+    expect(hint).toEqual({ targetAction: 'play', reason: 'hintReason.followWin', confidence: 'strong' });
+  });
+
+  it('recommends dumping a weak card when it cannot beat the lead', () => {
+    const hint = getTrucoHint(makeState({ currentTrick: [trick(3, 'HEART')], players: [player([card(4), card(5)])] }));
+    expect(hint).toEqual({ targetAction: 'play', reason: 'hintReason.followDump', confidence: 'moderate' });
+  });
+
+  it('returns null during PLAY when it is not the human turn', () => {
+    expect(getTrucoHint(makeState({ currentPlayerIdx: 1 }))).toBeNull();
+  });
+
+  it('recommends accepting a call with a strong hand', () => {
+    const hint = getTrucoHint(makeState({ phase: 1, responderIdx: 0, players: [player([card(3, 'HEART')])] }));
+    expect(hint).toEqual({ targetAction: 'accept', reason: 'hintReason.accept', confidence: 'strong' });
+  });
+
+  it('recommends declining a call with a weak hand', () => {
+    const hint = getTrucoHint(makeState({ phase: 1, responderIdx: 0, players: [player([card(4)])] }));
+    expect(hint).toEqual({ targetAction: 'decline', reason: 'hintReason.decline', confidence: 'moderate' });
+  });
+
+  it('returns null during RESPOND when the human is not the responder', () => {
+    expect(getTrucoHint(makeState({ phase: 1, responderIdx: 1 }))).toBeNull();
+  });
+
+  it('returns null in a non-decision phase (trick end)', () => {
+    expect(getTrucoHint(makeState({ phase: 2 }))).toBeNull();
+  });
+});

--- a/frontend/src/utils/hints/trucoHint.ts
+++ b/frontend/src/utils/hints/trucoHint.ts
@@ -1,0 +1,138 @@
+import type { Card, TrucoResponse, TrucoTrickCard } from '../../types/card';
+import type { HintResult } from '../../types/hint';
+import { TrucoPhase } from '../../types/phases';
+
+/**
+ * Strength of a single Truco card on the 40-card Spanish deck. Mirrors the
+ * backend `TrucoCardStrength` ranking exactly: the four matadores (1♠ > 1♣ >
+ * 7♠ > 7♦) sit above the common ladder (3 > 2 > 1 > K > Q > J > 7 > 6 > 5 > 4).
+ * Unused ranks (8/9/10) and nil cards return 0.
+ */
+export function trucoCardStrength(c: Card | undefined): number {
+  if (!c) return 0;
+  const { value: v, design: d } = c;
+  if (v === 1 && d === 'SPADE') return 14; // 1 de Espadas
+  if (v === 1 && d === 'CLOVER') return 13; // 1 de Bastos
+  if (v === 7 && d === 'SPADE') return 12; // 7 de Espadas
+  if (v === 7 && d === 'DIAMOND') return 11; // 7 de Oros
+  switch (v) {
+    case 3:
+      return 10;
+    case 2:
+      return 9;
+    case 1:
+      return 8;
+    case 13:
+      return 7;
+    case 12:
+      return 6;
+    case 11:
+      return 5;
+    case 7:
+      return 4;
+    case 6:
+      return 3;
+    case 5:
+      return 2;
+    case 4:
+      return 1;
+    default:
+      return 0;
+  }
+}
+
+/** Highest strength among the given hand. Mirrors backend `handTopStrength`. */
+function handTopStrength(cards: Card[]): number {
+  let top = 0;
+  for (const c of cards) {
+    const s = trucoCardStrength(c);
+    if (s > top) top = s;
+  }
+  return top;
+}
+
+/** Index of the weakest card in hand. Mirrors backend `cpuWeakestIdx`. */
+function weakestIdx(cards: Card[]): number {
+  let bestIdx = 0;
+  let bestStrength = trucoCardStrength(cards[0]);
+  for (let i = 1; i < cards.length; i++) {
+    const s = trucoCardStrength(cards[i]);
+    if (s < bestStrength) {
+      bestStrength = s;
+      bestIdx = i;
+    }
+  }
+  return bestIdx;
+}
+
+/**
+ * Index of the card the heuristic recommends playing. Mirrors backend
+ * `cpuSelectPlayCard`: when leading, dump the weakest card; when following,
+ * play the cheapest card that still beats the opponent, else dump the weakest.
+ */
+function selectPlayIdx(cards: Card[], trick: TrucoTrickCard[]): number {
+  const n = cards.length;
+  if (n <= 1) return 0;
+  if (trick.length === 0) return weakestIdx(cards);
+  const oppStrength = trucoCardStrength(trick[0]?.card);
+  let bestIdx = -1;
+  let bestStrength = 0;
+  for (let i = 0; i < n; i++) {
+    const s = trucoCardStrength(cards[i]);
+    if (s > oppStrength && (bestIdx < 0 || s < bestStrength)) {
+      bestIdx = i;
+      bestStrength = s;
+    }
+  }
+  return bestIdx >= 0 ? bestIdx : weakestIdx(cards);
+}
+
+/** Reason key for the recommended play. Mirrors backend `playHintReason`. */
+function playReason(card: Card | undefined, trick: TrucoTrickCard[]): string {
+  if (trick.length === 0) {
+    return trucoCardStrength(card) >= 11 ? 'hintReason.leadStrong' : 'hintReason.leadLow';
+  }
+  const opp = trick[0]?.card;
+  return trucoCardStrength(card) > trucoCardStrength(opp) ? 'hintReason.followWin' : 'hintReason.followDump';
+}
+
+/**
+ * Truco hint heuristic for the human player (the `isHuman` seat). Mirrors the
+ * backend `Truco.GetHint`:
+ *   - PLAY: recommend declaring Truco with a strong hand (top strength ≥ 11),
+ *     otherwise recommend the card `cpuSelectPlayCard` would play, with a
+ *     lead/follow reason.
+ *   - RESPOND: accept a pending call with a strong hand (top strength ≥ 10),
+ *     otherwise decline.
+ * Returns null outside the human's decision turns, when the game has ended, or
+ * when the hand is empty.
+ */
+export function getTrucoHint(state: TrucoResponse): HintResult | null {
+  if (!state || state.gameEndFlag) return null;
+  const humanIdx = state.players.findIndex((p) => p.isHuman);
+  if (humanIdx < 0) return null;
+  const human = state.players[humanIdx];
+  if (!human || human.cards.length === 0) return null;
+  const trick = state.currentTrick ?? [];
+
+  if (state.phase === TrucoPhase.PLAY) {
+    if (state.currentPlayerIdx !== humanIdx) return null;
+    if (state.canDeclareTruco && handTopStrength(human.cards) >= 11) {
+      return { targetAction: 'truco', reason: 'hintReason.call', confidence: 'strong' };
+    }
+    const idx = selectPlayIdx(human.cards, trick);
+    const reason = playReason(human.cards[idx], trick);
+    const confidence = reason === 'hintReason.leadStrong' || reason === 'hintReason.followWin' ? 'strong' : 'moderate';
+    return { targetAction: 'play', reason, confidence };
+  }
+
+  if (state.phase === TrucoPhase.RESPOND) {
+    if (state.responderIdx !== humanIdx) return null;
+    if (handTopStrength(human.cards) >= 10) {
+      return { targetAction: 'accept', reason: 'hintReason.accept', confidence: 'strong' };
+    }
+    return { targetAction: 'decline', reason: 'hintReason.decline', confidence: 'moderate' };
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary

Truco's `TrucoPage.tsx` did not use `useGameHint` / `HintTooltip`, so web players faced Truco's unusual 40-card strength order and accept/decline bluffing decisions with no assist — while many sibling pages (Scopa, Tien Len, Doudizhu, …) already ship a frontend hint. This adds a **frontend-only** hint (WASM-neutral, no Go change) that mirrors the CUI `TrucoCuiPresenter.HintOutput` / domain `Truco.GetHint`.

## Hint logic mirrored (from `internal/domain/Truco.go`)

- **PLAY** (human's turn): if `canDeclareTruco` and the hand's top strength ≥ 11 → recommend declaring Truco (`hintReason.call`). Otherwise recommend the card `cpuSelectPlayCard` would pick, with a reason from `playHintReason`:
  - leading: `leadStrong` (chosen card ≥ 11) / `leadLow`
  - following: `followWin` (beats the lead) / `followDump`
- **RESPOND** (human is responder): top strength ≥ 10 → `accept` (Quiero), else `decline` (No Quiero).
- `trucoCardStrength` replicates the exact backend ranking (matadores 1♠>1♣>7♠>7♦ over the common ladder).
- Returns null outside the human's decision turns, at game end, or with an empty hand.

Confidence: `leadStrong` / `followWin` / `call` / `accept` → strong; the rest → moderate.

## UI

- `useGameHint('truco', state)` + `<HintTooltip>` under the message box.
- Hint on/off checkbox in the action bar (`data-testid="truco-hint-toggle"`), **default OFF** (localStorage `hint_enabled_truco`), so existing play is unaffected.
- ja/en `hintReason.*` keys added with parity.

## Tests

- `frontend/src/utils/hints/trucoHint.test.ts` — strength ranking + every hint branch.
- `frontend/src/pages/TrucoPage.test.tsx` — tooltip hidden by default, revealed on toggle; follow-to-win reason.
- `useGameHint.docCount.test.ts` passes (doc bumped 192 → 193).

## Gates
- [x] `bun run check`
- [x] `bun run test -- --run trucoHint TrucoPage useGameHint.docCount` (33 passed)
- [x] `bun run build` (tsc)

Closes #3340