### PR TITLE
fix(shithead): reset via api instead of reloading the page

### DIFF
--- a/frontend/src/hooks/useShitheadGame.ts
+++ b/frontend/src/hooks/useShitheadGame.ts
@@ -52,6 +52,10 @@ export function useShitheadGame() {
     [dispatch],
   );
 
+  const handleReset = useCallback(() => {
+    dispatch('reset', { config: DEFAULT_SHITHEAD_CONFIG });
+  }, [dispatch]);
+
   return {
     state,
     loading,
@@ -65,6 +69,7 @@ export function useShitheadGame() {
     handlePlay,
     handlePickup,
     handleResetWithConfig,
+    handleReset,
     retry,
   };
 }

--- a/frontend/src/pages/ShitheadPage.test.tsx
+++ b/frontend/src/pages/ShitheadPage.test.tsx
@@ -330,6 +330,37 @@ describe('ShitheadPage', () => {
     expect(first).not.toHaveAttribute('aria-pressed');
   });
 
+  it('resets via the API instead of reloading the page when the reset button is clicked', async () => {
+    // Guard against a regression to window.location.reload(): spy on it and
+    // assert it is never called, while the reset command drives a fresh game.
+    const reloadSpy = vi.fn();
+    const originalLocation = window.location;
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...originalLocation, reload: reloadSpy },
+    });
+    try {
+      mockExec.mockResolvedValue(gameEndState);
+      renderWithProviders(
+        <MemoryRouter initialEntries={['/shithead']}>
+          <ShitheadPage />
+        </MemoryRouter>,
+      );
+      // At game end the button reads "次のゲーム" and fires the reset immediately.
+      const resetButton = await screen.findByRole('button', { name: '次のゲーム' });
+      mockExec.mockClear();
+      mockExec.mockResolvedValue(humanTurnState);
+      fireEvent.click(resetButton);
+      await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', { config: baseConfig }));
+      expect(reloadSpy).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: originalLocation,
+      });
+    }
+  });
+
   it('renders a joker discard top as a card image with an accessible label', async () => {
     mockExec.mockResolvedValue({
       ...humanTurnState,

--- a/frontend/src/pages/ShitheadPage.tsx
+++ b/frontend/src/pages/ShitheadPage.tsx
@@ -61,8 +61,18 @@ export const ShitheadPage = withTutorial(ShitheadPageContent, 'shithead', SHITHE
 function ShitheadPageContent() {
   const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
     useGamePageSetup('shithead');
-  const { state, loading, error, selectedCardIndices, toggleCard, handlePlay, handlePickup, retry, dispatch } =
-    useShitheadGame();
+  const {
+    state,
+    loading,
+    error,
+    selectedCardIndices,
+    toggleCard,
+    handlePlay,
+    handlePickup,
+    handleReset,
+    retry,
+    dispatch,
+  } = useShitheadGame();
   const { cardWidth } = useCardDimensions();
   const { hint, hintEnabled, setHintEnabled } = useGameHint('shithead', state);
   const cliMode = useCliMode('shithead');
@@ -84,8 +94,8 @@ function ShitheadPageContent() {
 
   const handleManualReset = useCallback(() => {
     hideActionLog();
-    window.location.reload();
-  }, [hideActionLog]);
+    handleReset();
+  }, [hideActionLog, handleReset]);
 
   // Hook order must stay stable across renders — compute the lookup above the
   // skeleton guard. buildMagicLookup safely handles a null config.


### PR DESCRIPTION
## 概要

Shithead のリセット処理を `window.location.reload()` から API 経由のリセットに置き換える。

これまで `handleManualReset` はページ全体を再読み込みしており、SPA の状態（CLI モードのログ、ヒントトグル、チュートリアル進行）が破棄され、画面のちらつきと再フェッチのオーバーヘッドが発生していた。他ゲーム（Slapjack は `execApi('reset')`、Nertz は `apiCall('reset')`）と挙動が不一致だった。

## 変更内容

- `useShitheadGame` に `handleReset` を追加。`dispatch('reset', { config: DEFAULT_SHITHEAD_CONFIG })` を発行する。選択カードのクリアはフックの `onSuccess` が担う。
- `ShitheadPage.handleManualReset` を `hideActionLog()` + `handleReset()` に変更（`window.location.reload()` を撤去）。
- リセット時にページ再読み込みせず API 経由で新規ゲームを開始し、`window.location.reload` が呼ばれないことを検証するテストを追加。

## 受け入れ条件

- [x] リセット時にページ再読み込みが発生せず、API 経由で新規ゲームが開始される
- [x] リセット後に `selectedCardIndices` が空になる（フックの `onSuccess` が `clearSelection` を呼ぶ）
- [x] CLI モードのトグル状態やヒント設定がリセット後も維持される（SPA 状態を破棄しないため）
- [x] `ShitheadPage.test.tsx` にリセット動作のテストを追加

## テスト

- `frontend/src/pages/ShitheadPage.test.tsx`: `resets via the API instead of reloading the page when the reset button is clicked`
- `bun run check` / `bun run test -- --run Shithead`（46 passed）/ `bun run build` すべてパス

Closes #3218