### PR TITLE
feat(spiderette): add frontend heuristic hint via hint registry

### DIFF
--- a/frontend/src/i18n/locales/en/spiderette.json
+++ b/frontend/src/i18n/locales/en/spiderette.json
@@ -32,5 +32,12 @@
     "controls": "Control buttons: Undo, Hint, Auto-complete.",
     "resetButton": "Press the reset button to start a new game."
   },
-  "landscapeBanner": "Rotate to landscape for easier play"
+  "landscapeBanner": "Rotate to landscape for easier play",
+  "frontendHint": {
+    "completeSuit": "A suit sequence is nearly complete — focus on finishing it",
+    "buildSameSuit": "A same-suit build move is available",
+    "revealFaceDown": "Move cards to reveal face-down cards underneath",
+    "useEmptyColumn": "An empty column is available — use it to reorganize",
+    "dealFromStock": "No obvious moves — try dealing from the stock"
+  }
 }

--- a/frontend/src/i18n/locales/ja/spiderette.json
+++ b/frontend/src/i18n/locales/ja/spiderette.json
@@ -32,5 +32,12 @@
     "controls": "元に戻す、ヒント、自動完了などの操作ボタンです。",
     "resetButton": "リセットボタンで新しいゲームを始められます。"
   },
-  "landscapeBanner": "横向きにすると操作しやすくなります"
+  "landscapeBanner": "横向きにすると操作しやすくなります",
+  "frontendHint": {
+    "completeSuit": "スート列がほぼ完成しています — 完成を目指しましょう",
+    "buildSameSuit": "同スートで積み重ねられるカードがあります",
+    "revealFaceDown": "カードを動かして裏向きのカードをめくりましょう",
+    "useEmptyColumn": "空の列があります — 整理に活用しましょう",
+    "dealFromStock": "すぐにできる手がありません — 山札から配ってみましょう"
+  }
 }

--- a/frontend/src/pages/SpiderettePage.test.tsx
+++ b/frontend/src/pages/SpiderettePage.test.tsx
@@ -98,6 +98,28 @@ describe('SpiderettePage', () => {
     expect(status.textContent).toContain('場札');
   });
 
+  it('hides the frontend hint tooltip when hints are disabled', async () => {
+    vi.mocked(useGameHint).mockReturnValue({
+      hint: { targetAction: 'move', reason: 'frontendHint.buildSameSuit', confidence: 'strong' },
+      hintEnabled: false,
+      setHintEnabled: vi.fn(),
+    });
+    renderWithProviders(<SpiderettePage />);
+    await screen.findByTestId('spdt-card-1-1');
+    expect(screen.queryByTestId('hint-tooltip')).not.toBeInTheDocument();
+  });
+
+  it('shows the frontend hint tooltip when hints are enabled', async () => {
+    vi.mocked(useGameHint).mockReturnValue({
+      hint: { targetAction: 'move', reason: 'frontendHint.buildSameSuit', confidence: 'strong' },
+      hintEnabled: true,
+      setHintEnabled: vi.fn(),
+    });
+    renderWithProviders(<SpiderettePage />);
+    const tooltip = await screen.findByTestId('hint-tooltip');
+    expect(tooltip).toHaveTextContent('同スートで積み重ねられるカードがあります');
+  });
+
   it('announces the empty-column deal guard to screen readers', async () => {
     renderWithProviders(<SpiderettePage />);
     // playingState has empty columns and stock remaining, so a deal is guarded.

--- a/frontend/src/pages/SpiderettePage.tsx
+++ b/frontend/src/pages/SpiderettePage.tsx
@@ -10,6 +10,7 @@ import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
+import { HintTooltip } from '../components/hint/HintTooltip';
 import { LandscapeBanner } from '../components/LandscapeBanner';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { AnimatedCardBack } from '../components/motion/AnimatedCardBack';
@@ -19,6 +20,7 @@ import { withTutorial } from '../components/tutorial/withTutorial';
 import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
+import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useResponsiveTableau } from '../hooks/useResponsiveTableau';
 import { useSolitaireDragDrop } from '../hooks/useSolitaireDragDrop';
@@ -102,6 +104,12 @@ function SpiderettePageContent() {
     isAutoCompleting,
   } = game;
   const runCmd = game.exec;
+
+  const {
+    hint: frontendHint,
+    hintEnabled: frontendHintEnabled,
+    setHintEnabled: setFrontendHintEnabled,
+  } = useGameHint('spiderette', state);
 
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('spiderette');
   const cliConfig: CliGameConfig<SpideretteResponse, Parameters<typeof spideretteApi.exec>> = useMemo(
@@ -352,6 +360,11 @@ function SpiderettePageContent() {
                 {t('hintAvailable')}: {t('tableau')} {hint.fromCol} [{hint.cardIndex}] → {t('tableau')} {hint.toCol}
               </div>
             )}
+            {frontendHintEnabled && frontendHint && (
+              <div className="flex justify-center">
+                <HintTooltip reason={t(frontendHint.reason)} confidence={frontendHint.confidence} />
+              </div>
+            )}
 
             {/* Announce the empty-column deal guard for screen readers; the key
             forces a remount on each blocked attempt so it re-announces, mirroring
@@ -381,7 +394,22 @@ function SpiderettePageContent() {
             />
           </div>
 
-          <SettingsPanel title={tc('settings.title')} groups={[]} />
+          <SettingsPanel
+            title={tc('settings.title')}
+            groups={[
+              {
+                items: [
+                  {
+                    type: 'checkbox' as const,
+                    id: 'frontendHint',
+                    label: tc('hint.toggle', { ns: 'tutorial' }),
+                    checked: frontendHintEnabled,
+                    onToggle: setFrontendHintEnabled,
+                  },
+                ],
+              },
+            ]}
+          />
 
           <GameFooter className={`${gameTheme.spiderette.footer} px-4 py-2.5`}>
             <ErrorAlert message={error ?? hintError} onRetry={retry} />

--- a/frontend/src/utils/hints/spideretteHint.test.ts
+++ b/frontend/src/utils/hints/spideretteHint.test.ts
@@ -1,22 +1,106 @@
 import { describe, expect, it } from 'vitest';
+import type { Card, SpideretteResponse, SpideretteTableauCard } from '../../types/card';
+import { SpiderettePhase } from '../../types/phases';
 import { getSpideretteHint } from './spideretteHint';
 
+const S: Card['design'] = 'SPADE';
+const H: Card['design'] = 'HEART';
+const D: Card['design'] = 'DIAMOND';
+const C: Card['design'] = 'CLOVER';
+
+function tc(design: Card['design'], value: number, faceUp = true): SpideretteTableauCard {
+  return { card: { design, value }, faceUp };
+}
+
+function makeState(overrides: Partial<SpideretteResponse> = {}): SpideretteResponse {
+  return {
+    tableau: [[tc(S, 10), tc(S, 9), tc(S, 8)], [tc(H, 5, false), tc(H, 7), tc(H, 6)], [], [], [], [], []],
+    stockCount: 20,
+    completedSuits: 0,
+    phase: SpiderettePhase.PLAYING,
+    moveCount: 0,
+    canUndo: false,
+    isStalemate: false,
+    score: 500,
+    message: '',
+    ...overrides,
+  };
+}
+
 describe('getSpideretteHint', () => {
-  it('returns null for any state (intentional stub)', () => {
+  it('returns null for null/undefined state', () => {
     expect(getSpideretteHint(null)).toBeNull();
     expect(getSpideretteHint(undefined)).toBeNull();
-    expect(
-      getSpideretteHint({
-        tableau: [],
-        stockCount: 0,
-        completedSuits: 0,
-        score: 500,
-        phase: 0,
-        moveCount: 0,
-        canUndo: false,
-        isStalemate: false,
-        message: '',
-      }),
-    ).toBeNull();
+  });
+
+  it('returns null when game is cleared', () => {
+    expect(getSpideretteHint(makeState({ phase: SpiderettePhase.GAME_CLEAR }))).toBeNull();
+  });
+
+  it('returns null when game is over', () => {
+    expect(getSpideretteHint(makeState({ phase: SpiderettePhase.GAME_OVER }))).toBeNull();
+  });
+
+  it('suggests completing suit for near-complete sequence', () => {
+    // Build a 10-card same-suit descending sequence (K→4).
+    const longSeq: SpideretteTableauCard[] = [];
+    for (let v = 13; v >= 4; v--) {
+      longSeq.push(tc(S, v));
+    }
+    const state = makeState({
+      tableau: [longSeq, [tc(H, 5)], [], [], [], [], []],
+    });
+    const hint = getSpideretteHint(state);
+    expect(hint?.reason).toBe('frontendHint.completeSuit');
+    expect(hint?.confidence).toBe('strong');
+  });
+
+  it('suggests same-suit build move', () => {
+    const state = makeState({
+      tableau: [[tc(S, 8)], [tc(S, 9)], [], [], [], [], []],
+      stockCount: 0,
+    });
+    const hint = getSpideretteHint(state);
+    expect(hint?.reason).toBe('frontendHint.buildSameSuit');
+    expect(hint?.confidence).toBe('strong');
+  });
+
+  it('suggests revealing face-down cards', () => {
+    const state = makeState({
+      tableau: [[tc(S, 5, false), tc(H, 4)], [tc(D, 10)], [], [], [], [], []],
+      stockCount: 0,
+    });
+    const hint = getSpideretteHint(state);
+    expect(hint?.reason).toBe('frontendHint.revealFaceDown');
+    expect(hint?.confidence).toBe('moderate');
+  });
+
+  it('suggests using empty column', () => {
+    const state = makeState({
+      tableau: [[tc(S, 5)], [tc(H, 10)], [], [], [], [], []],
+      stockCount: 0,
+    });
+    const hint = getSpideretteHint(state);
+    expect(hint?.reason).toBe('frontendHint.useEmptyColumn');
+    expect(hint?.confidence).toBe('moderate');
+  });
+
+  it('suggests dealing from stock as fallback', () => {
+    // Values chosen so no same-suit adjacency exists and every column is filled.
+    const state = makeState({
+      tableau: [[tc(S, 1)], [tc(H, 1)], [tc(D, 1)], [tc(C, 1)], [tc(S, 13)], [tc(H, 13)], [tc(D, 13)]],
+      stockCount: 10,
+    });
+    const hint = getSpideretteHint(state);
+    expect(hint?.reason).toBe('frontendHint.dealFromStock');
+    expect(hint?.confidence).toBe('moderate');
+  });
+
+  it('returns null when no moves and no stock', () => {
+    const state = makeState({
+      tableau: [[tc(S, 1)], [tc(H, 1)], [tc(D, 1)], [tc(C, 1)], [tc(S, 13)], [tc(H, 13)], [tc(D, 13)]],
+      stockCount: 0,
+    });
+    expect(getSpideretteHint(state)).toBeNull();
   });
 });

--- a/frontend/src/utils/hints/spideretteHint.ts
+++ b/frontend/src/utils/hints/spideretteHint.ts
@@ -1,14 +1,129 @@
-import type { SpideretteResponse } from '../../types/card';
+import type { Card, SpideretteResponse, SpideretteTableauCard } from '../../types/card';
 import type { HintResult } from '../../types/hint';
+import { SpiderettePhase } from '../../types/phases';
+
+/** Threshold for a near-complete sequence (10 of 13 cards K→A in the same suit). */
+const NEAR_COMPLETE_THRESHOLD = 10;
 
 /**
- * Frontend strategic hint for Spiderette is intentionally a `null` stub.
+ * Frontend strategic hint for Spiderette, mirroring the Spider heuristics.
  *
- * The backend already returns the next-mechanical-move hint via the API; a
- * frontend strategic hint would duplicate that without adding meaningful
- * judgement, since Spiderette has no scoring or memory dimension beyond what
- * the backend already evaluates.
+ * Spiderette is a single-deck Spider variant (Klondike deal, Spider rules), so
+ * the same "build a same-suit descending run, then complete a suit" priorities
+ * apply. Returns a {@link HintResult} or null when no suggestion is available.
  */
-export function getSpideretteHint(_state: SpideretteResponse | null | undefined): HintResult | null {
+export function getSpideretteHint(state: SpideretteResponse | null | undefined): HintResult | null {
+  if (!state || state.phase !== SpiderettePhase.PLAYING) return null;
+
+  // Priority 1: Near-complete same-suit sequence
+  if (hasNearCompleteSequence(state.tableau)) {
+    return { targetAction: 'move', reason: 'frontendHint.completeSuit', confidence: 'strong' };
+  }
+
+  // Priority 2: Same-suit build move available
+  if (hasSameSuitBuildMove(state.tableau)) {
+    return { targetAction: 'move', reason: 'frontendHint.buildSameSuit', confidence: 'strong' };
+  }
+
+  // Priority 3: Face-down cards to reveal
+  if (hasFaceDownToReveal(state.tableau)) {
+    return { targetAction: 'move', reason: 'frontendHint.revealFaceDown', confidence: 'moderate' };
+  }
+
+  // Priority 4: Empty column available
+  if (state.tableau.some((col) => col.length === 0)) {
+    return { targetAction: 'move', reason: 'frontendHint.useEmptyColumn', confidence: 'moderate' };
+  }
+
+  // Priority 5: Deal from stock
+  if (state.stockCount > 0) {
+    return { targetAction: 'deal', reason: 'frontendHint.dealFromStock', confidence: 'moderate' };
+  }
+
   return null;
+}
+
+/** Check if any column has a same-suit descending sequence of NEAR_COMPLETE_THRESHOLD or more. */
+function hasNearCompleteSequence(tableau: SpideretteTableauCard[][]): boolean {
+  for (const col of tableau) {
+    if (getSameSuitSequenceLength(col) >= NEAR_COMPLETE_THRESHOLD) return true;
+  }
+  return false;
+}
+
+/** Check if a face-up card from one column can be moved to another to extend a same-suit sequence. */
+function hasSameSuitBuildMove(tableau: SpideretteTableauCard[][]): boolean {
+  for (const col of tableau) {
+    if (col.length === 0) continue;
+    const bottom = getBottomOfSameSuitRun(col);
+    if (!bottom) continue;
+
+    for (const target of tableau) {
+      if (target === col || target.length === 0) continue;
+      const targetTop = target[target.length - 1];
+      if (!targetTop.card || !targetTop.faceUp) continue;
+      if (targetTop.card.design === bottom.design && targetTop.card.value === bottom.value + 1) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/** Check if any column has face-down cards that could be revealed by moving face-up cards away. */
+function hasFaceDownToReveal(tableau: SpideretteTableauCard[][]): boolean {
+  for (const col of tableau) {
+    if (col.length < 2) continue;
+    const hasFaceDown = col.some((c) => !c.faceUp && c.card);
+    const topIsFaceUp = col[col.length - 1].faceUp;
+    if (hasFaceDown && topIsFaceUp) return true;
+  }
+  return false;
+}
+
+/** Get the length of the same-suit descending sequence from the bottom of face-up cards. */
+function getSameSuitSequenceLength(col: SpideretteTableauCard[]): number {
+  if (col.length === 0 || !col[col.length - 1].faceUp) return 0;
+  let count = 1;
+  for (let i = col.length - 1; i > 0; i--) {
+    const current = col[i];
+    const above = col[i - 1];
+    if (
+      !current.faceUp ||
+      !above.faceUp ||
+      !current.card ||
+      !above.card ||
+      current.card.design !== above.card.design ||
+      above.card.value !== current.card.value + 1
+    ) {
+      break;
+    }
+    count++;
+  }
+  return count;
+}
+
+/** Get the card at the bottom of the same-suit run from the top of a column. */
+function getBottomOfSameSuitRun(col: SpideretteTableauCard[]): { design: Card['design']; value: number } | null {
+  if (col.length === 0) return null;
+  const top = col[col.length - 1];
+  if (!top.faceUp || !top.card) return null;
+
+  let bottomIdx = col.length - 1;
+  for (let i = col.length - 1; i > 0; i--) {
+    const current = col[i];
+    const above = col[i - 1];
+    if (
+      !above.faceUp ||
+      !above.card ||
+      !current.card ||
+      current.card.design !== above.card.design ||
+      above.card.value !== current.card.value + 1
+    ) {
+      break;
+    }
+    bottomIdx = i - 1;
+  }
+  const bottomCard = col[bottomIdx].card;
+  return bottomCard ? { design: bottomCard.design, value: bottomCard.value } : null;
 }


### PR DESCRIPTION
## Summary

Adds a frontend-completed heuristic hint for Spiderette, mirroring the proven Spider hint pattern via the `useGameHint` registry + `HintTooltip`, per issue #3265. Previously `getSpideretteHint` was a `null` stub and `SpiderettePage`'s `SettingsPanel` had an empty `groups` array with no hint toggle.

## Changes

- **`spideretteHint.ts`**: Converted the stub into a real heuristic that mirrors `getSpiderHint` (Spiderette is a single-deck Spider variant with identical same-suit-descending rules). Priority order:
  1. Complete a near-complete same-suit run (>=10 cards) — strong
  2. Same-suit build move available — strong
  3. Reveal face-down cards — moderate
  4. Use an empty column — moderate
  5. Deal from stock — moderate
- **`SpiderettePage.tsx`**: Wired `useGameHint('spiderette', state)`, rendered a `HintTooltip` (toggle-gated) below the board, and populated `SettingsPanel` `groups` with a hint on/off checkbox. Coexists with the existing server-side hint (distinct variable `frontendHint`).
- **i18n**: Added `frontendHint.*` keys to ja + en `spiderette.json` (parity).
- **Tests**: `spideretteHint.test.ts` covers all five priorities + null/cleared/over states; `SpiderettePage.test.tsx` verifies toggle-gated tooltip visibility.

The `hintFactories` count is unchanged (spiderette was already registered as a stub), so `frontend/CLAUDE.md`'s count (193) and the `docCount` test stay valid.

## Test plan

- [x] `bun run check` (exit 0; warnings are pre-existing, unrelated files)
- [x] `bun run test -- --run Spiderette` (36 passed)
- [x] `bun run build` (tsc gate, exit 0)
- [x] `useGameHint.docCount` test passes (count unchanged)
- [ ] Backend untouched (frontend-only, WASM-neutral)

Closes #3265

🤖 Generated with [Claude Code](https://claude.com/claude-code)