### PR TITLE
test(skat): guard reset button against a window.location.reload regression

### DIFF
--- a/frontend/src/pages/SkatPage.test.tsx
+++ b/frontend/src/pages/SkatPage.test.tsx
@@ -227,6 +227,38 @@ describe('SkatPage', () => {
     );
   });
 
+  it('resets via the API instead of reloading the page when the reset button is clicked', async () => {
+    // Guard against a regression to window.location.reload(): spy on it and
+    // assert it is never called, while the reset command drives a fresh game.
+    const reloadSpy = vi.fn();
+    const originalLocation = window.location;
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...originalLocation, reload: reloadSpy },
+    });
+    try {
+      renderWithProviders(
+        <MemoryRouter initialEntries={['/skat']}>
+          <SkatPage />
+        </MemoryRouter>,
+      );
+      await waitFor(() => expect(screen.getByRole('button', { name: '18でコールする' })).toBeInTheDocument());
+
+      mockExec.mockClear();
+      fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
+      fireEvent.click(screen.getByRole('button', { name: '確認' }));
+      await waitFor(() =>
+        expect(mockExec).toHaveBeenCalledWith('reset', { config: { cpuDifficulty: 1, targetScore: 500 } }),
+      );
+      expect(reloadSpy).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: originalLocation,
+      });
+    }
+  });
+
   it('renders bid controls with "call 18" button when no current bid', async () => {
     renderWithProviders(
       <MemoryRouter initialEntries={['/skat']}>


### PR DESCRIPTION
## Summary

Issue #3215 asked to replace a `window.location.reload()` reset with an API-driven reset (like the Shithead fix #4203). On inspection, **Skat's reset is already API-driven**: `SkatPage.handleManualReset` calls `useSkatGame.reset()`, which dispatches `dispatch('reset', { config: skatConfig })` through `useGameApi`. There is no `window.location.reload()` anywhere in `SkatPage.tsx` or `useSkatGame.ts` (a prior refactor already migrated it).

The remaining gap was the issue's third acceptance criterion: an explicit test verifying the reset button drives the API rather than a page reload. This PR adds that regression-guard test.

## Changes

- `frontend/src/pages/SkatPage.test.tsx`: new test `resets via the API instead of reloading the page when the reset button is clicked` — spies on `window.location.reload`, clicks リセット + 確認, asserts `exec('reset', { config })` is called and `reload` is never called. Mirrors the Shithead pattern (#4203), adapted for Skat's reset-confirm dialog.

## Acceptance criteria

- [x] Reset completes via an API call without a page reload (already implemented; now locked in by test)
- [x] Post-reset initial state matches current behavior (unchanged)
- [x] `SkatPage.test.tsx` has a test asserting the reset API call

## Gates
- [x] `bun run check` (exit 0; warnings are pre-existing in unrelated files)
- [x] `bun run test -- --run Skat` (81 passed)
- [x] `bun run build` (exit 0)

No Go changes.

Closes #3215