### PR TITLE
feat(contractrummy): remove individual staged cards from a contract slot

### DIFF
--- a/frontend/src/i18n/locales/en/contractrummy.json
+++ b/frontend/src/i18n/locales/en/contractrummy.json
@@ -24,7 +24,7 @@
   "meldExtra": "Lay extra meld",
   "layoff": "Lay off",
   "meldAria": "{{player}}'s meld {{meld}}",
-  "cardInSlotAria": "in slot",
+  "cardInSlotRemoveAria": "{{card}} (in slot {{n}}, click to remove)",
   "layoffTargetSummary": "→ Lay off to: {{player}} meld {{meld}}",
   "discard": "Discard card",
   "nextRound": "Next round",

--- a/frontend/src/i18n/locales/ja/contractrummy.json
+++ b/frontend/src/i18n/locales/ja/contractrummy.json
@@ -24,7 +24,7 @@
   "meldExtra": "追加メルド",
   "layoff": "レイオフ",
   "meldAria": "{{player}}のメルド{{meld}}",
-  "cardInSlotAria": "スロット配置済み",
+  "cardInSlotRemoveAria": "{{card}}（スロット{{n}}に配置済み・クリックで取り外す）",
   "layoffTargetSummary": "→ レイオフ先: {{player}} メルド{{meld}}",
   "discard": "カードを捨てる",
   "nextRound": "次のラウンドへ",

--- a/frontend/src/pages/ContractRummyPage.test.tsx
+++ b/frontend/src/pages/ContractRummyPage.test.tsx
@@ -197,6 +197,68 @@ describe('ContractRummyPage', () => {
     expect(undoBtn).toBeDisabled();
   });
 
+  it('removes a single staged card from its slot without clearing the rest', async () => {
+    mockExec.mockResolvedValue(playState);
+    renderWithProviders(<ContractRummyPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: /Add to slot|スロットに追加/ })).toBeInTheDocument());
+
+    // Stage the three 5s (indices 0-2) into slot 0.
+    const cardButtons = screen.getAllByRole('button').filter((b) => b.querySelector('img'));
+    fireEvent.click(cardButtons[0]);
+    fireEvent.click(cardButtons[1]);
+    fireEvent.click(cardButtons[2]);
+    fireEvent.click(screen.getByRole('button', { name: /Add to slot|スロットに追加/ }));
+    await waitFor(() => expect(screen.getByTestId('cr-slot-progress-0')).toHaveAttribute('data-state', 'satisfied'));
+
+    // Remove just the first staged card — the slot keeps the other two.
+    fireEvent.click(screen.getByTestId('cr-slot-card-0'));
+    await waitFor(() => expect(screen.getByTestId('cr-slot-progress-0')).toHaveAttribute('data-state', 'partial'));
+    expect(screen.getByTestId('cr-slot-card-1')).toBeInTheDocument();
+    expect(screen.getByTestId('cr-slot-card-2')).toBeInTheDocument();
+    // The slot is not deleted, so slotsBuilt still reports one staged slot.
+    expect(screen.getByText(/Slots staged|組成済スロット/)).toBeInTheDocument();
+  });
+
+  it('makes a removed staged card selectable again', async () => {
+    mockExec.mockResolvedValue(playState);
+    renderWithProviders(<ContractRummyPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: /Add to slot|スロットに追加/ })).toBeInTheDocument());
+
+    const cardButtons = screen.getAllByRole('button').filter((b) => b.querySelector('img'));
+    fireEvent.click(cardButtons[0]);
+    fireEvent.click(cardButtons[1]);
+    fireEvent.click(cardButtons[2]);
+    fireEvent.click(screen.getByRole('button', { name: /Add to slot|スロットに追加/ }));
+    await waitFor(() => expect(screen.getByTestId('cr-slot-card-0')).toBeInTheDocument());
+
+    // Remove the ♠5 (index 0) from the slot; it returns to the hand as a plain, selectable card.
+    fireEvent.click(screen.getByTestId('cr-slot-card-0'));
+    const reselectable = await screen.findByRole('button', { name: '♠ 5' });
+    expect(reselectable).toHaveAttribute('aria-pressed', 'false');
+    fireEvent.click(reselectable);
+    await waitFor(() => expect(screen.getByRole('button', { name: '♠ 5' })).toHaveAttribute('aria-pressed', 'true'));
+  });
+
+  it('auto-deletes a staged slot once its last card is removed', async () => {
+    mockExec.mockResolvedValue(playState);
+    renderWithProviders(<ContractRummyPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: /Add to slot|スロットに追加/ })).toBeInTheDocument());
+
+    const cardButtons = screen.getAllByRole('button').filter((b) => b.querySelector('img'));
+    fireEvent.click(cardButtons[0]);
+    fireEvent.click(cardButtons[1]);
+    fireEvent.click(cardButtons[2]);
+    fireEvent.click(screen.getByRole('button', { name: /Add to slot|スロットに追加/ }));
+    await waitFor(() => expect(screen.getByText(/Slots staged|組成済スロット/)).toBeInTheDocument());
+
+    // Remove all three staged cards; the emptied slot disappears.
+    fireEvent.click(screen.getByTestId('cr-slot-card-0'));
+    fireEvent.click(screen.getByTestId('cr-slot-card-1'));
+    fireEvent.click(screen.getByTestId('cr-slot-card-2'));
+    await waitFor(() => expect(screen.queryByText(/Slots staged|組成済スロット/)).not.toBeInTheDocument());
+    expect(screen.getByTestId('cr-slot-progress-0')).toHaveAttribute('data-state', 'empty');
+  });
+
   it('toggles a card off when clicked twice', async () => {
     mockExec.mockResolvedValue(playState);
     renderWithProviders(<ContractRummyPage />);

--- a/frontend/src/pages/ContractRummyPage.tsx
+++ b/frontend/src/pages/ContractRummyPage.tsx
@@ -160,6 +160,12 @@ function ContractRummyPageContent() {
     setContractSlots((prev) => prev.slice(0, -1));
   }, []);
 
+  // Remove a single staged card from whichever slot holds it; drop the slot
+  // entirely once it becomes empty so slotsBuilt / per-slot progress stay in sync.
+  const handleRemoveCardFromSlot = useCallback((idx: number) => {
+    setContractSlots((prev) => prev.map((slot) => slot.filter((i) => i !== idx)).filter((slot) => slot.length > 0));
+  }, []);
+
   const handleSubmitContract = useCallback(() => {
     if (contractSlots.length === 0) return;
     void execApi('meldcontract', { indicesPerSlot: contractSlots });
@@ -363,19 +369,32 @@ function ContractRummyPageContent() {
               <div className="flex flex-wrap gap-1">
                 {humanPlayer.cards.map((c: Card, idx: number) => {
                   const isSelected = selectedCards.includes(idx);
-                  const isInSlot = contractSlots.some((slot) => slot.includes(idx));
+                  const slotOfCard = contractSlots.findIndex((slot) => slot.includes(idx));
+                  const isInSlot = slotOfCard !== -1;
                   return (
                     <button
                       type="button"
                       key={`${idx}-${c.design}-${c.value}`}
-                      onClick={() => toggleCard(idx)}
-                      disabled={isInSlot}
-                      aria-pressed={isSelected}
-                      aria-label={isInSlot ? `${cardAlt(c)} (${t('cardInSlotAria')})` : cardAlt(c)}
-                      className={`${focusRingWhite} ${isSelected ? 'ring-2 ring-ds-warning' : ''} ${
+                      // A staged card removes itself from its slot; an unstaged card toggles selection.
+                      onClick={() => (isInSlot ? handleRemoveCardFromSlot(idx) : toggleCard(idx))}
+                      aria-pressed={isInSlot ? undefined : isSelected}
+                      aria-label={
+                        isInSlot ? t('cardInSlotRemoveAria', { card: cardAlt(c), n: slotOfCard + 1 }) : cardAlt(c)
+                      }
+                      data-testid={isInSlot ? `cr-slot-card-${idx}` : undefined}
+                      data-slot={isInSlot ? slotOfCard + 1 : undefined}
+                      className={`relative ${focusRingWhite} ${isSelected ? 'ring-2 ring-ds-warning' : ''} ${
                         isInSlot ? 'opacity-40' : ''
                       }`}
                     >
+                      {isInSlot && (
+                        <span
+                          className={`absolute top-0 left-0 z-10 px-1 rounded-br text-[10px] font-bold ${badgeWarningColors}`}
+                          aria-hidden="true"
+                        >
+                          {slotOfCard + 1}
+                        </span>
+                      )}
                       <AnimatedCard card={c} width={cardWidth} />
                     </button>
                   );


### PR DESCRIPTION
Closes #3250

## 概要
コントラクト組み立て中、スロットに投入済みのカードを1枚単位で取り外せるようにしました。従来は投入済みカードが `disabled` + `opacity-40` でクリック不能となり、取り消しは「最後のスロットを丸ごと削除」しかありませんでした。

## 変更点 (フロントエンドのみ)
- 投入済みカードの `disabled` を外し、クリックで所属スロットから該当カードだけを取り除く（Kalooki #4169 の per-group 削除と同系のクライアント側 `number[][]` 操作）。
- スロットが空になったら自動でスロットを削除し、`slotsBuilt` 表示と `cr-slot-progress` バッジが再評価される。
- 投入済みカードに所属スロット番号バッジ（デザイントークン `badgeWarningColors`）を重ねて視認性を向上。
- 取り外したカードは通常カードとして再選択可能。
- aria-label を `cardInSlotRemoveAria`（ja+en）に更新し、取り外し操作を読み上げに反映。既存 meld-submit 経路（`meldcontract`）は不変。

## 受け入れ条件
- [x] 投入済みカードをクリックすると該当スロットから外れる
- [x] 空になったスロットは自動削除され slotsBuilt 表示が更新される
- [x] スロット進捗バッジ（cr-slot-progress）が正しく再評価される
- [x] `ContractRummyPage.test.tsx` にテストを追加

## テスト
`ContractRummyPage.test.tsx` に3件追加:
- removes a single staged card from its slot without clearing the rest
- makes a removed staged card selectable again
- auto-deletes a staged slot once its last card is removed

## ゲート
- `bun run check` OK
- `bun run test -- --run ContractRummy` → 60 passed
- `bun run build` (tsc) OK