### PR TITLE
feat(pitch): add previous-trick review panel

### DIFF
--- a/frontend/src/i18n/locales/en/pitch.json
+++ b/frontend/src/i18n/locales/en/pitch.json
@@ -31,6 +31,9 @@
   "bidPass": "Pass",
   "bidNone": "Not bid",
   "currentTrick": "Current trick",
+  "previousTrick": "Previous Trick",
+  "previousTrickEmpty": "No previous trick yet this round",
+  "previousTrickWinner": "Won by {{name}}",
   "leadBadge": "Lead",
   "trickLegend": {
     "lead": "Lead suit",

--- a/frontend/src/i18n/locales/ja/pitch.json
+++ b/frontend/src/i18n/locales/ja/pitch.json
@@ -31,6 +31,9 @@
   "bidPass": "パス",
   "bidNone": "未ビッド",
   "currentTrick": "現在のトリック",
+  "previousTrick": "前のトリック",
+  "previousTrickEmpty": "このラウンドにはまだ前のトリックがありません",
+  "previousTrickWinner": "{{name}} が獲得",
   "leadBadge": "リード",
   "trickLegend": {
     "lead": "リードスート",

--- a/frontend/src/pages/PitchPage.test.tsx
+++ b/frontend/src/pages/PitchPage.test.tsx
@@ -57,6 +57,8 @@ const bidState: PitchResponse = {
   bidWinnerIdx: -1,
   trumpSuit: 0,
   currentTrick: [],
+  lastTrick: [],
+  lastTrickWinner: -1,
   gameEndFlag: false,
   winnerIdx: -1,
   leadPlayerIdx: -1,
@@ -286,5 +288,31 @@ describe('PitchPage', () => {
     expect(screen.getByTestId('pitch-game-pips-popover')).toBeInTheDocument();
     fireEvent.mouseDown(document.body);
     expect(screen.queryByTestId('pitch-game-pips-popover')).not.toBeInTheDocument();
+  });
+
+  it('previous-trick panel shows the just-completed trick and its winner', async () => {
+    const lastTrickState: PitchResponse = {
+      ...playState,
+      trickNumber: 2,
+      lastTrick: [
+        { playerIdx: 0, card: makeCard('HEART', 9) },
+        { playerIdx: 1, card: makeCard('HEART', 4) },
+        { playerIdx: 2, card: makeCard('SPADE', 12) },
+        { playerIdx: 3, card: makeCard('HEART', 2) },
+      ],
+      lastTrickWinner: 2,
+    };
+    mockApi.mockResolvedValue(lastTrickState);
+    renderWithProviders(<PitchPage />);
+    await waitFor(() => expect(screen.getByTestId('pt-previous-trick')).toBeInTheDocument());
+    // The winner label is rendered (CPU 2 won the trick) and the empty placeholder is not.
+    expect(screen.getByTestId('pt-previous-trick')).toHaveTextContent(/獲得/);
+    expect(screen.queryByTestId('pt-previous-trick-empty')).not.toBeInTheDocument();
+  });
+
+  it('previous-trick panel is empty on the round first trick', async () => {
+    mockApi.mockResolvedValue(playState); // trickNumber 1, lastTrick []
+    renderWithProviders(<PitchPage />);
+    await waitFor(() => expect(screen.getByTestId('pt-previous-trick-empty')).toBeInTheDocument());
   });
 });

--- a/frontend/src/pages/PitchPage.tsx
+++ b/frontend/src/pages/PitchPage.tsx
@@ -13,6 +13,7 @@ import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { KbdBadge } from '../components/KbdBadge';
+import { TrickDisplay } from '../components/TrickDisplay';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCardDimensions } from '../hooks/useCardDimensions';
@@ -401,6 +402,35 @@ function PitchPageContent() {
                 </>
               )}
             </div>
+
+            {/* Previous trick reviewer: lets the player recount the just-completed trick */}
+            <details className="mb-3 p-2 rounded border border-ds-border-subtle" data-testid="pt-previous-trick">
+              <summary className="cursor-pointer select-none text-ds-text-muted text-sm">{t('previousTrick')}</summary>
+              <div className="mt-2">
+                {state.lastTrick.length > 0 ? (
+                  <TrickDisplay
+                    currentTrick={state.lastTrick}
+                    players={state.players}
+                    cardWidth={Math.round(cardWidth * 0.7)}
+                    label={
+                      state.lastTrickWinner >= 0
+                        ? t('previousTrickWinner', {
+                            name: playerName(
+                              state.lastTrickWinner,
+                              state.players[state.lastTrickWinner]?.isHuman === true,
+                            ),
+                          })
+                        : t('previousTrick')
+                    }
+                    winnerIdx={state.lastTrickWinner >= 0 ? state.lastTrickWinner : undefined}
+                  />
+                ) : (
+                  <div className="text-ds-text-muted text-sm" data-testid="pt-previous-trick-empty">
+                    {t('previousTrickEmpty')}
+                  </div>
+                )}
+              </div>
+            </details>
 
             {/* Player hand (always visible) */}
             {human && human.cards.length > 0 && (

--- a/frontend/src/types/card.ts
+++ b/frontend/src/types/card.ts
@@ -4482,6 +4482,10 @@ export interface PitchResponse extends BaseGameResponse {
   bidWinnerIdx: number;
   trumpSuit: number;
   currentTrick: PitchTrickCard[];
+  /** Cards of the just-completed trick (empty on the round's first trick). */
+  lastTrick: PitchTrickCard[];
+  /** Winner index of the just-completed trick, or -1 when none. */
+  lastTrickWinner: number;
   gameEndFlag: boolean;
   winnerIdx: number;
   leadPlayerIdx: number;

--- a/frontend/src/utils/hints/pitchHint.test.ts
+++ b/frontend/src/utils/hints/pitchHint.test.ts
@@ -33,6 +33,8 @@ const makeState = (override: Partial<PitchResponse> = {}): PitchResponse => ({
   bidWinnerIdx: -1,
   trumpSuit: 0,
   currentTrick: [],
+  lastTrick: [],
+  lastTrickWinner: -1,
   gameEndFlag: false,
   winnerIdx: -1,
   leadPlayerIdx: -1,

--- a/internal/adapter/controller/PitchWebController.go
+++ b/internal/adapter/controller/PitchWebController.go
@@ -60,6 +60,8 @@ type PitchWebOutput struct {
 	BidWinnerIdx     int                        `json:"bidWinnerIdx"`
 	TrumpSuit        int                        `json:"trumpSuit"`
 	CurrentTrick     []*PitchWebOutputTrickCard `json:"currentTrick"`
+	LastTrick        []*PitchWebOutputTrickCard `json:"lastTrick"`
+	LastTrickWinner  int                        `json:"lastTrickWinner"`
 	GameEndFlag      bool                       `json:"gameEndFlag"`
 	WinnerIdx        int                        `json:"winnerIdx"`
 	LeadPlayerIdx    int                        `json:"leadPlayerIdx"`
@@ -99,11 +101,13 @@ var NewPitchWebController, NewPitchWebControllerWithProvider = webControllerPair
 
 func newPitchDefaultOutput(msg string) *PitchWebOutput {
 	return &PitchWebOutput{
-		Players:       make([]*PitchWebOutputPlayer, 0),
-		CurrentTrick:  make([]*PitchWebOutputTrickCard, 0),
-		WinnerIdx:     -1,
-		BidWinnerIdx:  -1,
-		WebOutputBase: WebOutputBase{Message: msg},
+		Players:         make([]*PitchWebOutputPlayer, 0),
+		CurrentTrick:    make([]*PitchWebOutputTrickCard, 0),
+		LastTrick:       make([]*PitchWebOutputTrickCard, 0),
+		LastTrickWinner: -1,
+		WinnerIdx:       -1,
+		BidWinnerIdx:    -1,
+		WebOutputBase:   WebOutputBase{Message: msg},
 	}
 }
 

--- a/internal/adapter/controller/PitchWebController_test.go
+++ b/internal/adapter/controller/PitchWebController_test.go
@@ -16,11 +16,13 @@ import (
 
 func mustPitchOutputJSON(msg string) string {
 	out := &controller.PitchWebOutput{
-		Players:       []*controller.PitchWebOutputPlayer{},
-		CurrentTrick:  []*controller.PitchWebOutputTrickCard{},
-		WinnerIdx:     -1,
-		BidWinnerIdx:  -1,
-		WebOutputBase: controller.WebOutputBase{Message: msg},
+		Players:         []*controller.PitchWebOutputPlayer{},
+		CurrentTrick:    []*controller.PitchWebOutputTrickCard{},
+		LastTrick:       []*controller.PitchWebOutputTrickCard{},
+		LastTrickWinner: -1,
+		WinnerIdx:       -1,
+		BidWinnerIdx:    -1,
+		WebOutputBase:   controller.WebOutputBase{Message: msg},
 	}
 	b, err := json.Marshal(out)
 	if err != nil {

--- a/internal/adapter/presenter/PitchWebPresenter.go
+++ b/internal/adapter/presenter/PitchWebPresenter.go
@@ -39,6 +39,7 @@ func (p *PitchWebPresenter) buildBase(s interfaces.PitchGame) *controller.PitchW
 	}
 
 	resObj.CurrentTrick = p.buildTrickOutput(s.GetCurrentTrick())
+	resObj.LastTrick, resObj.LastTrickWinner = p.buildLastTrickOutput(s)
 	resObj.Players = p.buildPlayersOutput(s)
 
 	// human の有効プレイインデックスを供給
@@ -59,6 +60,52 @@ func (p *PitchWebPresenter) buildTrickOutput(trick []*domain.PitchTrickCard) []*
 	return buildTrickCards(trick, func(tc *domain.PitchTrickCard) *controller.PitchWebOutputTrickCard {
 		return &controller.PitchWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
 	})
+}
+
+// buildLastTrickOutput は直前に解決されたトリック（誰が何を出し誰が取ったか）を
+// アクションログから再構築する。ドメインは専用の lastTrick フィールドを持たないが、
+// 各トリックの "play" ログ（プレイヤーと札）と "trick_win" ログ（勝者）から
+// 現ラウンドの直近トリックを復元できる。ラウンド開始直後（プレイフェーズのトリック 1
+// で、この局のトリックがまだ確定していない）は空スライスと -1 を返す。
+func (p *PitchWebPresenter) buildLastTrickOutput(s interfaces.PitchGame) ([]*controller.PitchWebOutputTrickCard, int) {
+	empty := make([]*controller.PitchWebOutputTrickCard, 0)
+	// ラウンド最初のトリックがプレイ中は、この局に確定済みトリックが無いため空を返す。
+	if s.GetPhase() == domain.PitchPhasePlay && s.GetTrickNumber() <= 1 {
+		return empty, -1
+	}
+
+	log := s.GetActionLog()
+	winIdx := -1
+	for i := len(log) - 1; i >= 0; i-- {
+		if log[i] != nil && log[i].ActionType == "trick_win" {
+			winIdx = i
+			break
+		}
+	}
+	if winIdx < 0 {
+		return empty, -1
+	}
+
+	// trick_win 直前の "play" ログ（プレイ順）が、そのトリックの各札に対応する。
+	var plays []*domain.ActionLogEntry
+	for i := 0; i < winIdx; i++ {
+		if e := log[i]; e != nil && e.ActionType == "play" && len(e.Cards) > 0 {
+			plays = append(plays, e)
+		}
+	}
+	if len(plays) < domain.PitchPlayerCnt {
+		return empty, -1
+	}
+	plays = plays[len(plays)-domain.PitchPlayerCnt:]
+
+	out := make([]*controller.PitchWebOutputTrickCard, 0, len(plays))
+	for _, e := range plays {
+		out = append(out, &controller.PitchWebOutputTrickCard{
+			PlayerIdx: e.PlayerIdx,
+			Card:      cardToOutput(e.Cards[0]),
+		})
+	}
+	return out, log[winIdx].PlayerIdx
 }
 
 // buildPlayersOutput プレイヤー情報を構築

--- a/internal/adapter/presenter/PitchWebPresenter_test.go
+++ b/internal/adapter/presenter/PitchWebPresenter_test.go
@@ -129,6 +129,80 @@ func TestPitchWebPresenter_HintOutput(t *testing.T) {
 	})
 }
 
+// setupPitchWebMockCustom builds a fully-wired mock with a caller-controlled
+// phase, trick number and action log so the last-trick reconstruction can be
+// exercised deterministically.
+func setupPitchWebMockCustom(phase domain.PitchPhase, trickNumber int, log []*domain.ActionLogEntry) *interfaces.MockPitchGame {
+	m := new(interfaces.MockPitchGame)
+	m.On("GetRoundNumber").Return(1)
+	m.On("GetTrickNumber").Return(trickNumber)
+	m.On("GetDealerIdx").Return(3)
+	m.On("GetCurrentBid").Return(0)
+	m.On("GetTrumpSuit").Return(domain.CardDesignSpade)
+	m.On("GetBidWinnerIdx").Return(0)
+	m.On("GetCurrentTrick").Return([]*domain.PitchTrickCard(nil))
+	m.On("GetGameEndFlag").Return(false)
+	m.On("GetPhase").Return(phase)
+	m.On("GetCurrentPlayerIdx").Return(0)
+	m.On("GetBidPlayerIdx").Return(0)
+	m.On("GetWinnerIdx").Return(-1)
+	m.On("GetLeadPlayerIdx").Return(0)
+	m.On("GetConfig").Return(domain.DefaultPitchConfig())
+	m.On("GetActionLog").Return(log)
+	m.On("GetValidPlayIndices", 0).Return([]int{0})
+	players := makePitchPlayers()
+	m.On("GetPlayerCnt").Return(4)
+	for i := 0; i < 4; i++ {
+		m.On("GetPlayer", i).Return(players[i])
+	}
+	return m
+}
+
+func TestPitchWebPresenter_LastTrick(t *testing.T) {
+	p := new(presenter.PitchWebPresenter)
+
+	t.Run("reconstructs the just-completed trick with its winner", func(t *testing.T) {
+		log := []*domain.ActionLogEntry{
+			{TurnNumber: 1, PlayerIdx: 0, ActionType: "play", Cards: []*domain.Card{domain.NewCard(domain.CardDesignSpade, 5, false)}},
+			{TurnNumber: 1, PlayerIdx: 1, ActionType: "play", Cards: []*domain.Card{domain.NewCard(domain.CardDesignSpade, 10, false)}},
+			{TurnNumber: 1, PlayerIdx: 2, ActionType: "play", Cards: []*domain.Card{domain.NewCard(domain.CardDesignSpade, 1, false)}},
+			{TurnNumber: 1, PlayerIdx: 3, ActionType: "play", Cards: []*domain.Card{domain.NewCard(domain.CardDesignHeart, 2, false)}},
+			{TurnNumber: 1, PlayerIdx: 2, ActionType: "trick_win", Cards: nil},
+		}
+		// After pressing "next": play phase, trick 2, current trick cleared.
+		m := setupPitchWebMockCustom(domain.PitchPhasePlay, 2, log)
+		result := p.Output(m, nil)
+		var resObj controller.PitchWebOutput
+		assert.NoError(t, json.Unmarshal([]byte(result), &resObj))
+		assert.Len(t, resObj.LastTrick, 4)
+		assert.Equal(t, 0, resObj.LastTrick[0].PlayerIdx)
+		assert.Equal(t, 3, resObj.LastTrick[3].PlayerIdx)
+		assert.Equal(t, 2, resObj.LastTrickWinner)
+	})
+
+	t.Run("hidden on the round's first trick", func(t *testing.T) {
+		m := setupPitchWebMockCustom(domain.PitchPhasePlay, 1, nil)
+		result := p.Output(m, nil)
+		var resObj controller.PitchWebOutput
+		assert.NoError(t, json.Unmarshal([]byte(result), &resObj))
+		assert.Empty(t, resObj.LastTrick)
+		assert.Equal(t, -1, resObj.LastTrickWinner)
+	})
+
+	t.Run("empty when no trick_win logged yet", func(t *testing.T) {
+		// TrickEnd phase but the log has no trick_win (e.g. partial play): empty.
+		log := []*domain.ActionLogEntry{
+			{TurnNumber: 1, PlayerIdx: 0, ActionType: "play", Cards: []*domain.Card{domain.NewCard(domain.CardDesignSpade, 5, false)}},
+		}
+		m := setupPitchWebMockCustom(domain.PitchPhaseTrickEnd, 2, log)
+		result := p.Output(m, nil)
+		var resObj controller.PitchWebOutput
+		assert.NoError(t, json.Unmarshal([]byte(result), &resObj))
+		assert.Empty(t, resObj.LastTrick)
+		assert.Equal(t, -1, resObj.LastTrickWinner)
+	})
+}
+
 func TestPitchWebPresenter_ActionLogOutput(t *testing.T) {
 	p := new(presenter.PitchWebPresenter)
 	m := new(interfaces.MockPitchGame)


### PR DESCRIPTION
Closes #3240

## What
Adds a "previous trick" (直前トリックの確認 / ラストトリック) review to Pitch: a collapsible panel that shows the cards of the just-completed trick and who won it, so players tracking High/Low/Jack/Game scoring can check "has the Jack been played yet?" after advancing past a trick.

## Path B (WASM-neutral presenter)
`PitchResponse` did not expose the last trick, so this adds it in the **adapter layer only** (no domain / usecase / CUI changes):

- `internal/adapter/controller/PitchWebController.go` — new `lastTrick` + `lastTrickWinner` output fields (default `[]` / `-1`).
- `internal/adapter/presenter/PitchWebPresenter.go` — `buildLastTrickOutput` reconstructs the last resolved trick from the action log (the 4 `"play"` entries before the most recent `"trick_win"` entry), mirroring the existing `TressetteWebPresenter` / `JassWebPresenter` pattern. Returns empty + `-1` on the round's first trick so it clears at round start. Uses `GetActionLog()` (already on the interface); the domain is untouched.

Pitch ships in the **classic** Cloudflare worker; `GOOS=js GOARCH=wasm go build -tags classic` succeeds (WASM_OK).

## Frontend
- `PitchResponse` type gains `lastTrick` / `lastTrickWinner`.
- `PitchPage.tsx` renders a `<details>` panel (`data-testid="pt-previous-trick"`) reusing `TrickDisplay` with the `winnerIdx` crown; empty state shows a placeholder.
- ja + en i18n keys (`previousTrick`, `previousTrickEmpty`, `previousTrickWinner`).

## Tests
- Presenter: reconstructs the trick + winner; hidden on first trick; empty when no `trick_win` logged.
- Controller: updated default-output body expectation.
- Page: panel shows cards + winner when a last trick is present; shows empty placeholder on the round's first trick.

## Checklist
- [x] Path B (WASM-neutral, adapter-only; domain/usecase/CUI untouched)
- [x] `go test -tags test ./internal/adapter/presenter/ ./internal/adapter/controller/ -run Pitch` passes
- [x] `golangci-lint` 0 issues; `goimports` applied
- [x] WASM classic build OK
- [x] `bun run check` / `bun run test -- --run Pitch` (42 passed) / `bun run build` pass
- [x] ja + en i18n parity