### PR TITLE
feat(mississippistud): make paytable available in all phases

### DIFF
--- a/frontend/src/pages/MississippiStudPage.test.tsx
+++ b/frontend/src/pages/MississippiStudPage.test.tsx
@@ -143,6 +143,26 @@ describe('MississippiStudPage', () => {
     expect(screen.getByText('ペイテーブル')).toBeInTheDocument();
   });
 
+  it('shows the collapsible payout reference panel during a betting street', async () => {
+    mockApi.mockResolvedValue(thirdStreetState);
+    renderWithProviders(<MississippiStudPage />);
+    await waitFor(() => expect(screen.getByTestId('ms-play-1x')).toBeInTheDocument());
+    const paytable = screen.getByTestId('ms-paytable');
+    expect(paytable).toBeInTheDocument();
+    expect(paytable.tagName).toBe('DETAILS');
+    // Default closed so it does not crowd the betting layout.
+    expect(paytable).not.toHaveAttribute('open');
+    expect(paytable).toHaveTextContent('ペイテーブル');
+    expect(paytable).toHaveTextContent('ロイヤルフラッシュ: 500:1');
+  });
+
+  it('shows the payout reference panel in the end phase', async () => {
+    mockApi.mockResolvedValue(endPhaseWin);
+    renderWithProviders(<MississippiStudPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument());
+    expect(screen.getByTestId('ms-paytable')).toHaveTextContent('ペイテーブル');
+  });
+
   it('calls execApi with bet and default amount when ante button clicked', async () => {
     mockApi.mockResolvedValue(antePhaseState);
     renderWithProviders(<MississippiStudPage />);

--- a/frontend/src/pages/MississippiStudPage.tsx
+++ b/frontend/src/pages/MississippiStudPage.tsx
@@ -128,6 +128,36 @@ function MississippiStudPageContent() {
 
   const phaseName = t(PHASE_KEY[state.phase] ?? 'phase.ante');
 
+  // Paytable reference: collapsible and available in every phase so players can
+  // check it while deciding 1x/2x/3x/fold on the betting streets, not just at ante.
+  const paytable = (
+    <details data-testid="ms-paytable" className="bg-black/30 rounded-lg w-full max-w-sm">
+      <summary className="cursor-pointer select-none px-4 py-2 text-ds-text-primary font-bold text-sm">
+        {t('payoutRef.title')}
+      </summary>
+      <div className="px-4 pb-3 text-ds-text-muted text-sm space-y-2">
+        <ul className="space-y-0.5">
+          {(
+            [
+              'payRoyalFlush',
+              'payStraightFlush',
+              'payFourOfAKind',
+              'payFullHouse',
+              'payFlush',
+              'payStraight',
+              'payThreeOfAKind',
+              'payTwoPair',
+              'payHighPair',
+              'payMidPair',
+            ] as const
+          ).map((key) => (
+            <li key={key}>{t(`payoutRef.${key}`)}</li>
+          ))}
+        </ul>
+      </div>
+    </details>
+  );
+
   return (
     <GamePageShell
       title={tc('nav.mississippistud')}
@@ -171,31 +201,7 @@ function MississippiStudPageContent() {
         {isAntePhase && (
           <div className="flex flex-col items-center justify-center py-4 gap-4">
             <p className="text-ds-text-muted text-lg">{t('betGuide')}</p>
-            <details className="bg-black/30 rounded-lg w-full max-w-sm">
-              <summary className="cursor-pointer select-none px-4 py-2 text-ds-text-primary font-bold text-sm">
-                {t('payoutRef.title')}
-              </summary>
-              <div className="px-4 pb-3 text-ds-text-muted text-sm space-y-2">
-                <ul className="space-y-0.5">
-                  {(
-                    [
-                      'payRoyalFlush',
-                      'payStraightFlush',
-                      'payFourOfAKind',
-                      'payFullHouse',
-                      'payFlush',
-                      'payStraight',
-                      'payThreeOfAKind',
-                      'payTwoPair',
-                      'payHighPair',
-                      'payMidPair',
-                    ] as const
-                  ).map((key) => (
-                    <li key={key}>{t(`payoutRef.${key}`)}</li>
-                  ))}
-                </ul>
-              </div>
-            </details>
+            {paytable}
           </div>
         )}
 
@@ -271,6 +277,8 @@ function MississippiStudPageContent() {
             </span>
           </div>
         )}
+
+        {!isAntePhase && <div className="flex justify-center mb-2">{paytable}</div>}
 
         {isEndPhase && (
           <div className="text-ds-text-primary text-center text-sm mb-2" data-testid="payout-breakdown">


### PR DESCRIPTION
Closes #3260

## What
The Mississippi Stud payout/odds table was only rendered inside the ante-phase block, so players could not reference it during the 3rd–5th street decisions (1x/2x/3x/fold) or at the end — exactly when it matters most.

This extracts the payout-reference `<details>` panel into a single reusable element and renders it in **every** phase:
- **Ante**: unchanged (still shown under the bet guide).
- **Streets & End**: the same collapsible panel now appears (default collapsed) near the `bet-status` row, giving betting context without crowding the layout.

Paytable data source is unchanged (static reference data). The made-hand block (#4207) and existing ante display are preserved. No Go changes; no new i18n strings.

## Test plan
- [x] `bun run check` (exit 0; only pre-existing unrelated warnings)
- [x] `bun run test -- --run MississippiStud` (47 passed)
- [x] `bun run build` (tsc, exit 0)

New tests:
- `shows the collapsible payout reference panel during a betting street` — verifies `ms-paytable` renders in THIRD_STREET, is a default-closed `<details>`, and contains the paytable rows.
- `shows the payout reference panel in the end phase` — verifies it is reachable in the END phase.