### PR TITLE
feat(tonk): draw from discard by clicking the pile top card

### DIFF
--- a/frontend/e2e/tonk.spec.ts
+++ b/frontend/e2e/tonk.spec.ts
@@ -15,7 +15,7 @@ test.describe('Tonk E2E', () => {
     await expect(page.getByText('スコア', { exact: true }).first()).toBeVisible();
 
     const drawStockButton = page.getByRole('button', { name: '山札から引く' });
-    const drawDiscardButton = page.getByRole('button', { name: '捨て札から引く' });
+    const drawDiscardButton = page.getByRole('button', { name: '捨て札から引く', exact: true });
     const discardButton = page.getByRole('button', { name: '捨てる' });
     const knockButton = page.getByRole('button', { name: 'ノック' });
     const nextRoundButton = page.getByRole('button', { name: '次のラウンド' });

--- a/frontend/src/i18n/locales/en/tonk.json
+++ b/frontend/src/i18n/locales/en/tonk.json
@@ -25,6 +25,7 @@
   "scoresTotal": "Total",
   "drawStockButton": "Draw Stock",
   "drawDiscardButton": "Draw Discard",
+  "drawDiscardCardLabel": "Draw from discard: {{card}}",
   "discardButton": "Discard",
   "knockButton": "Knock",
   "knockUndercutWarning": "Opponent's hand is low — undercut risk is high",

--- a/frontend/src/i18n/locales/ja/tonk.json
+++ b/frontend/src/i18n/locales/ja/tonk.json
@@ -25,6 +25,7 @@
   "scoresTotal": "累計",
   "drawStockButton": "山札から引く",
   "drawDiscardButton": "捨て札から引く",
+  "drawDiscardCardLabel": "捨て札から引く: {{card}}",
   "discardButton": "捨てる",
   "knockButton": "ノック",
   "knockUndercutWarning": "相手の手札が少ないため、アンダーカットのリスクがあります",

--- a/frontend/src/pages/TonkPage.test.tsx
+++ b/frontend/src/pages/TonkPage.test.tsx
@@ -170,6 +170,30 @@ describe('TonkPage', () => {
     expect(screen.getByTestId('tonk-hand-2')).not.toHaveAttribute('data-meld');
   });
 
+  const drawPhaseState = () => makeState({ phase: TonkPhase.DRAW });
+
+  it('draws from the discard pile when its top card is clicked on the human draw turn', async () => {
+    mockExec.mockResolvedValue(drawPhaseState());
+    renderWithProviders(<TonkPage />);
+    const pile = await screen.findByTestId('tonk-discard-pile');
+    expect(pile).not.toBeDisabled();
+    expect(pile.className).toContain('ring-ds-info');
+    mockExec.mockClear();
+    fireEvent.click(pile);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('drawdiscard'));
+  });
+
+  it('does not draw from the discard pile when it is not the draw phase', async () => {
+    // Default makeState() is the DISCARD phase → the pile is inert/disabled.
+    renderWithProviders(<TonkPage />);
+    const pile = await screen.findByTestId('tonk-discard-pile');
+    expect(pile).toBeDisabled();
+    expect(pile.className).not.toContain('ring-ds-info');
+    mockExec.mockClear();
+    fireEvent.click(pile);
+    expect(mockExec).not.toHaveBeenCalledWith('drawdiscard');
+  });
+
   it('clears the warning when opponents drop back above the threshold', async () => {
     // First render: opponent at 2 → warning on.
     mockExec.mockResolvedValueOnce(

--- a/frontend/src/pages/TonkPage.tsx
+++ b/frontend/src/pages/TonkPage.tsx
@@ -250,14 +250,36 @@ function TonkPageContent() {
 
             <div className={lgTwoColGrid}>
               <div>
-                {state.discardTop && (
-                  <div className="my-3 p-3 rounded bg-black/40 flex items-center gap-3">
-                    <AnimatedCard card={state.discardTop} width={cardWidth} />
-                    <div className="text-ds-text-muted text-sm">
-                      <div>{t('discardTop')}</div>
-                    </div>
-                  </div>
-                )}
+                {state.discardTop &&
+                  (() => {
+                    // The discard pile top card doubles as a draw target: on the human's
+                    // draw turn, clicking it draws from the discard pile (same action as the
+                    // footer "draw from discard" button). Outside that phase it stays inert
+                    // but focusable-disabled so it never traps keyboard/tap focus.
+                    const canDrawDiscard = isDrawPhase && isHumanTurn;
+                    return (
+                      <div className="my-3 p-3 rounded bg-black/40 flex items-center gap-3">
+                        <button
+                          type="button"
+                          onClick={handleDrawDiscard}
+                          disabled={!canDrawDiscard || loading}
+                          aria-label={t('drawDiscardCardLabel', { card: cardAlt(state.discardTop) })}
+                          data-testid="tonk-discard-pile"
+                          className={`transition-transform ${focusRingCard} ${
+                            canDrawDiscard
+                              ? 'cursor-pointer ring-2 ring-ds-info motion-safe:hover:scale-105'
+                              : 'cursor-default'
+                          }`}
+                          style={{ background: 'none', padding: 0, border: 'none' }}
+                        >
+                          <AnimatedCard card={state.discardTop} width={cardWidth} />
+                        </button>
+                        <div className="text-ds-text-muted text-sm">
+                          <div>{t('discardTop')}</div>
+                        </div>
+                      </div>
+                    );
+                  })()}
 
                 {state.knockerMelds.length > 0 && (
                   <div className="my-3 p-2 rounded bg-black/30">


### PR DESCRIPTION
## 概要
トンクのドローフェーズで、捨て札トップのカードを直接クリック（タップ）してドローできるようにしました。カード表示とフッターの「捨て札から引く」ボタンが離れていた操作動線を改善します。

Closes #3232

## 変更内容
- 捨て札トップの `AnimatedCard` を `button` でラップし、`isDrawPhase && isHumanTurn` のときにクリックで `handleDrawDiscard`（既存のフッターボタンと同一アクション）を発火。
- 操作可能なあいだは `ring-2 ring-ds-info` + `motion-safe:hover:scale-105` で「引ける」ことを視覚的に提示。
- 他フェーズでは `disabled`（フォーカスも奪わない）。i18n の `aria-label`（`drawDiscardCardLabel`、ja/en 追加）とカード名を付与。
- テスト用に `data-testid="tonk-discard-pile"` を付与。
- 既存の「捨て札から引く」「山札から引く」ボタンはそのまま残し、二経路とも動作。

## 受け入れ条件
- [x] ドローフェーズ中、捨て札カードのクリックでドローできる
- [x] 操作可能な状態が視覚的に示される（ring/hover）
- [x] 他フェーズではクリック不可（disabled）で aria-label 付き
- [x] `TonkPage.test.tsx` にクリックドローのテストを追加

## テスト
`frontend/src/pages/TonkPage.test.tsx` に 2 ケース追加:
- 人間のドローターンで捨て札パイルをクリック → `exec('drawdiscard')` 発火
- ドローフェーズ以外（disabled）ではクリックしても発火しない

## Gate
- `bun run check` OK
- `bun run test -- --run Tonk` 35 passed
- `bun run build`（tsc）OK