### PR TITLE
feat(slapjack): use GameSkeleton and ErrorAlert for loading/error states

### DIFF
--- a/frontend/src/pages/SlapjackPage.test.tsx
+++ b/frontend/src/pages/SlapjackPage.test.tsx
@@ -86,6 +86,26 @@ describe('SlapjackPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
   });
 
+  it('renders the GameSkeleton while state is null', () => {
+    // Keep exec pending so `state` stays null and the loading guard renders.
+    mockExec.mockReturnValue(new Promise(() => {}));
+    renderWithProviders(<SlapjackPage />);
+    expect(screen.getByTestId('skeleton')).toBeInTheDocument();
+    expect(screen.queryByTestId('step-button')).not.toBeInTheDocument();
+  });
+
+  it('renders an ErrorAlert with a retry button when an action fails', async () => {
+    // Mount reset resolves so state loads; a subsequent action rejects.
+    mockExec.mockResolvedValueOnce(baseState);
+    renderWithProviders(<SlapjackPage />);
+    await waitFor(() => expect(screen.getByTestId('step-button')).toBeInTheDocument());
+    mockExec.mockRejectedValue(new Error('boom'));
+    fireEvent.click(screen.getByTestId('step-button'));
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent('通信エラー');
+    expect(screen.getByRole('button', { name: /再試行/i })).toBeInTheDocument();
+  });
+
   it('renders stock counts after state loads', async () => {
     renderWithProviders(<SlapjackPage />);
     await waitFor(() => expect(screen.getByTestId('step-button')).toBeInTheDocument());

--- a/frontend/src/pages/SlapjackPage.tsx
+++ b/frontend/src/pages/SlapjackPage.tsx
@@ -4,6 +4,7 @@ import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
 import { CliToggle } from '../components/cli/CliToggle';
 import { SettingsPanel } from '../components/common/SettingsPanel';
+import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
@@ -13,6 +14,7 @@ import { KbdBadge } from '../components/KbdBadge';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { AnimatedCardBack } from '../components/motion/AnimatedCardBack';
 import { SlapBurst, type SlapOutcome } from '../components/SlapBurst';
+import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCliGame } from '../hooks/useCliGame';
@@ -154,13 +156,7 @@ function SlapjackPageContent() {
   });
 
   if (!state || state.players.length < 2) {
-    return (
-      <div
-        className={`flex-1 flex flex-col min-h-0 ${gameTheme.slapjack.bg} items-center justify-center text-ds-text-muted`}
-      >
-        Loading…
-      </div>
-    );
+    return <GameSkeleton gameKey="slapjack" layout={{ kind: 'centered', rows: [1, 1, 1] }} />;
   }
 
   const isGameEnd = state.gameEndFlag || state.phase === SlapjackPhase.GAME_END;
@@ -191,11 +187,7 @@ function SlapjackPageContent() {
       ) : (
         <>
           <div className="flex-1 overflow-y-auto px-4 py-2 space-y-3">
-            {error && (
-              <button type="button" onClick={retry} className="text-ds-error underline">
-                {error}
-              </button>
-            )}
+            <ErrorAlert message={error} onRetry={retry} />
 
             {/* CPU pile */}
             <div className="flex items-center justify-center gap-4" data-tutorial="sj-cpu-pile">


### PR DESCRIPTION
## Summary
Replaces Slapjack's raw-text loading indicator and underlined error text with the shared, consistent components.

- Loading guard (`!state`) now renders `<GameSkeleton gameKey="slapjack" layout={{ kind: 'centered', rows: [1, 1, 1] }} />` — the `centered` layout mirrors the closest pile-game sibling (`WarPage`), with three stacked single-card rows matching Slapjack's CPU pile / center arena / player pile structure.
- Error display now uses the shared `<ErrorAlert message={error} onRetry={retry} />` (retry button, `role="alert"`), replacing the ad-hoc underlined `<button>`.

All existing behavior and testids are preserved.

## Test plan
- [x] Added `renders the GameSkeleton while state is null` — asserts `data-testid="skeleton"` renders and `step-button` does not.
- [x] Added `renders an ErrorAlert with a retry button when an action fails` — loads state, then a failing action surfaces the alert + retry button.
- [x] `bun run check` passes (no new warnings)
- [x] `bun run test -- --run Slapjack` — 32 passed
- [x] `bun run build` (tsc) passes

Closes #3224