### PR TITLE
feat(nertz): expose CPU tick speed in the settings panel

### DIFF
--- a/frontend/src/i18n/locales/en/nertz.json
+++ b/frontend/src/i18n/locales/en/nertz.json
@@ -45,7 +45,12 @@
     "cpuDifficulty": "CPU difficulty",
     "easy": "Easy",
     "normal": "Normal",
-    "hard": "Hard"
+    "hard": "Hard",
+    "cpuSpeed": "CPU speed",
+    "cpuSpeedHelp": "Adjust how often the CPUs play a card. Faster ticks make the race harder (Slow = 1200ms / Normal = 700ms / Fast = 400ms).",
+    "speedSlow": "Slow",
+    "speedNormal": "Normal",
+    "speedFast": "Fast"
   },
   "tutorial": {
     "intro": "Nertz is a real-time competitive solitaire where several players race in parallel.",

--- a/frontend/src/i18n/locales/ja/nertz.json
+++ b/frontend/src/i18n/locales/ja/nertz.json
@@ -45,7 +45,12 @@
     "cpuDifficulty": "CPU難易度",
     "easy": "簡単",
     "normal": "普通",
-    "hard": "難しい"
+    "hard": "難しい",
+    "cpuSpeed": "CPU速度",
+    "cpuSpeedHelp": "CPUがカードを出す間隔を切り替えます。速いほど競争が厳しくなります（ゆっくり=1200ms / ふつう=700ms / はやい=400ms）。",
+    "speedSlow": "ゆっくり",
+    "speedNormal": "ふつう",
+    "speedFast": "はやい"
   },
   "tutorial": {
     "intro": "Nertzは複数プレイヤーが同時に進める対戦型ソリティアです。",

--- a/frontend/src/pages/NertzPage.test.tsx
+++ b/frontend/src/pages/NertzPage.test.tsx
@@ -459,6 +459,64 @@ describe('NertzPage', () => {
     expect(screen.getAllByTestId(/nertz-foundation-/)).toHaveLength(8);
   });
 
+  it('defaults the CPU speed select to normal when unset', async () => {
+    renderWithProviders(
+      <MemoryRouter initialEntries={['/nertz']}>
+        <NertzPage />
+      </MemoryRouter>,
+    );
+    const select = (await screen.findByTestId('nertz-cpu-speed-select')) as HTMLSelectElement;
+    expect(select.value).toBe('normal');
+  });
+
+  it('loads the persisted CPU speed from localStorage on mount', async () => {
+    localStorage.setItem('nertz:cpuSpeed', 'fast');
+    renderWithProviders(
+      <MemoryRouter initialEntries={['/nertz']}>
+        <NertzPage />
+      </MemoryRouter>,
+    );
+    const select = (await screen.findByTestId('nertz-cpu-speed-select')) as HTMLSelectElement;
+    expect(select.value).toBe('fast');
+  });
+
+  it('persists the chosen CPU speed to localStorage', async () => {
+    renderWithProviders(
+      <MemoryRouter initialEntries={['/nertz']}>
+        <NertzPage />
+      </MemoryRouter>,
+    );
+    const select = (await screen.findByTestId('nertz-cpu-speed-select')) as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: 'slow' } });
+    expect(select.value).toBe('slow');
+    expect(localStorage.getItem('nertz:cpuSpeed')).toBe('slow');
+  });
+
+  it('uses the selected speed as the CPU tick interval', async () => {
+    vi.useFakeTimers();
+    try {
+      // 'fast' → 400ms interval; 'slow' → 1200ms. Verify the boundary at 400ms.
+      localStorage.setItem('nertz:cpuSpeed', 'fast');
+      mockExec.mockResolvedValue(playingState);
+      renderWithProviders(
+        <MemoryRouter initialEntries={['/nertz']}>
+          <NertzPage />
+        </MemoryRouter>,
+      );
+      // Flush the mount reset + initial render so the interval effect subscribes.
+      await vi.advanceTimersByTimeAsync(0);
+      mockExec.mockClear();
+      // Just before the 400ms fast interval no tick has fired yet.
+      await vi.advanceTimersByTimeAsync(399);
+      expect(mockExec).not.toHaveBeenCalledWith('tick');
+      // Crossing 400ms fires the fast tick.
+      await vi.advanceTimersByTimeAsync(1);
+      expect(mockExec).toHaveBeenCalledWith('tick');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('does not attribute a later unrelated error to a previously-resolved foundation move', async () => {
     // Bug 1 from the gemini/Claude review: after a foundation move succeeds, the
     // pending-foundation ref must be cleared so a later unrelated error (e.g. a

--- a/frontend/src/pages/NertzPage.tsx
+++ b/frontend/src/pages/NertzPage.tsx
@@ -3,6 +3,7 @@ import { type NertzMoveZone, nertzApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
 import { CliToggle } from '../components/cli/CliToggle';
+import { SettingsPanel } from '../components/common/SettingsPanel';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
@@ -28,8 +29,32 @@ import { NERTZ_HELP, parseNertzCommand } from '../utils/cli/commands/nertzComman
 import { formatNertzState } from '../utils/cli/formatters/nertzFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
 
-/** CPU tick interval in milliseconds while the round is active. */
-const NERTZ_TICK_INTERVAL_MS = 700;
+/** CPU cadence presets — faster ticks make the CPUs harder to out-race. */
+type NertzCpuSpeed = 'slow' | 'normal' | 'fast';
+
+/**
+ * CPU tick interval (ms) per speed preset while the round is active. A smaller
+ * interval advances the CPUs more often, raising the real-time difficulty;
+ * `normal` (700ms) preserves the historical default for backward compatibility.
+ */
+const NERTZ_TICK_INTERVAL_MS: Record<NertzCpuSpeed, number> = {
+  slow: 1200,
+  normal: 700,
+  fast: 400,
+};
+
+const NERTZ_CPU_SPEED_STORAGE_KEY = 'nertz:cpuSpeed';
+
+/** Read the persisted CPU speed, falling back to `normal` when unset/invalid. */
+function loadNertzCpuSpeed(): NertzCpuSpeed {
+  try {
+    const v = localStorage.getItem(NERTZ_CPU_SPEED_STORAGE_KEY);
+    if (v === 'slow' || v === 'normal' || v === 'fast') return v;
+  } catch {
+    // localStorage may be unavailable (private mode / SSR); fall through to default.
+  }
+  return 'normal';
+}
 
 /** Duration to leave the collision shake/red-ring on a rejected foundation. */
 const NERTZ_COLLISION_FEEDBACK_MS = 500;
@@ -107,18 +132,31 @@ function NertzPageContent() {
   });
 
   const [selection, setSelection] = useState<Selection>(null);
+  const [cpuSpeed, setCpuSpeed] = useState<NertzCpuSpeed>(loadNertzCpuSpeed);
+
+  const handleSelectCpuSpeed = useCallback((v: string) => {
+    const speed: NertzCpuSpeed = v === 'slow' || v === 'fast' ? v : 'normal';
+    setCpuSpeed(speed);
+    try {
+      localStorage.setItem(NERTZ_CPU_SPEED_STORAGE_KEY, speed);
+    } catch {
+      // Persistence is best-effort; ignore storage failures.
+    }
+  }, []);
 
   useMountReset(apiCall);
 
-  // CPU tick driver: while the round is active, periodically advance CPUs.
+  // CPU tick driver: while the round is active, periodically advance CPUs. The
+  // interval is scaled by the chosen speed preset; changing the speed restarts
+  // the timer so the new cadence takes effect from the next tick.
   useEffect(() => {
     if (!state) return;
     if (state.phase !== NertzPhase.PLAYING) return;
     const id = window.setInterval(() => {
       void apiCall('tick');
-    }, NERTZ_TICK_INTERVAL_MS);
+    }, NERTZ_TICK_INTERVAL_MS[cpuSpeed]);
     return () => window.clearInterval(id);
-  }, [state, apiCall]);
+  }, [state, apiCall, cpuSpeed]);
 
   const human = state?.players[0];
   const isHumanTurn = state?.phase === NertzPhase.PLAYING;
@@ -567,6 +605,30 @@ function NertzPageContent() {
                 </div>
               </div>
             </div>
+
+            <SettingsPanel
+              title={tc('settings.title')}
+              groups={[
+                {
+                  items: [
+                    {
+                      type: 'select' as const,
+                      id: 'nertzCpuSpeed',
+                      testId: 'nertz-cpu-speed-select',
+                      label: t('settings.cpuSpeed'),
+                      tooltip: t('settings.cpuSpeedHelp'),
+                      value: cpuSpeed,
+                      options: [
+                        { value: 'slow', label: t('settings.speedSlow') },
+                        { value: 'normal', label: t('settings.speedNormal') },
+                        { value: 'fast', label: t('settings.speedFast') },
+                      ],
+                      onSelect: handleSelectCpuSpeed,
+                    },
+                  ],
+                },
+              ]}
+            />
 
             <ActionLogSection
               isEndPhase={isGameEnd || isRoundEnd}


### PR DESCRIPTION
## Summary
Adds a CPU speed selector to the Nertz / Pounce page so players can tune how fast the CPUs act (which, in a real-time race, is the difficulty knob).

- New **CPU speed** select in `SettingsPanel` with three presets: **Slow (1200ms) / Normal (700ms) / Fast (400ms)**.
- The chosen preset scales the CPU tick interval and takes effect from the next tick.
- Persisted to `localStorage` under `nertz:cpuSpeed`; restored on mount.
- **Normal (700ms)** remains the default → backward compatible.
- i18n labels added to `ja`/`en` `nertz.json` (parity kept).
- Frontend-only; no Go changes.

## Acceptance criteria
- [x] CPU tick interval adjustable in 3 steps via SettingsPanel
- [x] Change applies immediately (from the next interval)
- [x] Default is the current 700ms (backward compatible)
- [x] Setting labels added to `ja`/`en` `nertz.json`
- [x] Tests added to `NertzPage.test.tsx`

## Tests
Added to `NertzPage.test.tsx`:
- defaults the CPU speed select to normal when unset
- loads the persisted CPU speed from localStorage on mount
- persists the chosen CPU speed to localStorage
- uses the selected speed as the CPU tick interval (fake timers, 400ms boundary)

## Gates
- `bun run check` — pass
- `bun run test -- --run Nertz` — 48 passed
- `bun run build` (tsc) — pass

Closes #3221