### PR TITLE
fix(egyptianratscrew): apply 44px minimum tap target to step/slap buttons

### DIFF
--- a/frontend/src/pages/EgyptianRatscrewPage.test.tsx
+++ b/frontend/src/pages/EgyptianRatscrewPage.test.tsx
@@ -189,6 +189,18 @@ describe('EgyptianRatscrewPage', () => {
     expect(slap.className).toMatch(/animate-pulse/);
   });
 
+  it('gives the step and slap buttons a 44x44px minimum tap target', async () => {
+    mockExec.mockResolvedValueOnce(slappableState);
+    renderWithProviders(<EgyptianRatscrewPage />);
+    await waitFor(() => expect(screen.getByTestId('slap-button')).toBeInTheDocument());
+    const slap = screen.getByTestId('slap-button');
+    expect(slap.className).toContain('min-h-[44px]');
+    expect(slap.className).toContain('min-w-[44px]');
+    const step = screen.getByTestId('step-button');
+    expect(step.className).toContain('min-h-[44px]');
+    expect(step.className).toContain('min-w-[44px]');
+  });
+
   it('shows a pair slap-reason badge while slappable', async () => {
     mockExec.mockResolvedValueOnce({ ...slappableState, lastSlapReason: EgyptianRatscrewSlapReason.PAIR });
     renderWithProviders(<EgyptianRatscrewPage />);

--- a/frontend/src/pages/EgyptianRatscrewPage.tsx
+++ b/frontend/src/pages/EgyptianRatscrewPage.tsx
@@ -381,7 +381,7 @@ function EgyptianRatscrewPageContent() {
                 type="button"
                 onClick={handleStep}
                 disabled={loading || isGameEnd || !state.isHumanTurn}
-                className="px-6 py-2 rounded-lg bg-ds-info hover:bg-ds-info text-white font-medium disabled:opacity-40 disabled:cursor-not-allowed"
+                className="min-h-[44px] min-w-[44px] px-6 py-2 rounded-lg bg-ds-info hover:bg-ds-info text-white font-medium disabled:opacity-40 disabled:cursor-not-allowed"
                 data-testid="step-button"
                 data-tutorial="er-step-button"
               >
@@ -392,7 +392,7 @@ function EgyptianRatscrewPageContent() {
                 type="button"
                 onClick={handleSlap}
                 disabled={loading || isGameEnd || state.centerPileSize === 0}
-                className={`px-6 py-2 rounded-lg text-white font-bold disabled:opacity-40 disabled:cursor-not-allowed ${
+                className={`min-h-[44px] min-w-[44px] px-6 py-2 rounded-lg text-white font-bold disabled:opacity-40 disabled:cursor-not-allowed ${
                   state.isSlappable
                     ? 'bg-ds-warning hover:bg-ds-warning-hover animate-pulse'
                     : 'bg-ds-error hover:bg-ds-error'


### PR DESCRIPTION
Closes #3227

## 概要
Egyptian Ratscrew の step / slap ボタンに `min-h-[44px] min-w-[44px]` を付与し、WCAG 2.5.5 AAA (DESIGN.md) の 44×44px 最小タッチターゲットを満たす。ほぼ同一 UI の `SlapjackPage.tsx` が既に採用しているスタイルにそろえた。

## 変更点
- `EgyptianRatscrewPage.tsx`: step-button / slap-button の className に `min-h-[44px] min-w-[44px]` を追加（既存の `px-6 py-2` レイアウト・挙動・testid・ラベルは維持）。
- `EgyptianRatscrewPage.test.tsx`: 両ボタンが最小タップ幅クラスを持つことを検証するテストを追加。

## テスト計画
- [x] `bun run check` (biome lint + format) 通過
- [x] `bun run test -- --run EgyptianRatscrew` 通過 (33 tests)
- [x] `bun run build` (tsc) 通過
- [x] 追加テスト `gives the step and slap buttons a 44x44px minimum tap target`

## 受け入れ条件
- [x] step/slap ボタンが 44×44px 以上のタッチターゲットを持つ
- [x] Slapjack のボタンスタイルと視覚的に一貫
- [x] モバイルでボタンが折り返さず操作しやすい（既存レイアウト維持）
- [x] 既存の data-testid を維持しテスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)