### PR TITLE
feat(spiteandmalice): expose CPU turn speed in the settings panel

### DIFF
--- a/frontend/src/i18n/locales/en/spiteandmalice.json
+++ b/frontend/src/i18n/locales/en/spiteandmalice.json
@@ -36,6 +36,13 @@
   "playing": "Playing",
   "noHint": "No hint",
   "hintAvailable": "Hint available",
+  "settings": {
+    "cpuSpeed": "CPU speed",
+    "cpuSpeedHelp": "Adjust how quickly the CPU takes its turn (Slow = 900ms / Normal = 500ms / Fast = 200ms).",
+    "speedSlow": "Slow",
+    "speedNormal": "Normal",
+    "speedFast": "Fast"
+  },
   "frontendHint": {
     "goalToFoundation": "You can play the top of your goal pile to a foundation",
     "handToFoundation": "You can play a card from your hand to a foundation",

--- a/frontend/src/i18n/locales/ja/spiteandmalice.json
+++ b/frontend/src/i18n/locales/ja/spiteandmalice.json
@@ -36,6 +36,13 @@
   "playing": "プレイ中",
   "noHint": "ヒントはありません",
   "hintAvailable": "ヒントがあります",
+  "settings": {
+    "cpuSpeed": "CPU速度",
+    "cpuSpeedHelp": "CPUが手番を進める速さを切り替えます（ゆっくり=900ms / ふつう=500ms / はやい=200ms）。",
+    "speedSlow": "ゆっくり",
+    "speedNormal": "ふつう",
+    "speedFast": "はやい"
+  },
   "frontendHint": {
     "goalToFoundation": "ゴールパイルのトップをファウンデーションに出せます",
     "handToFoundation": "手札からファウンデーションに出せます",

--- a/frontend/src/pages/SpiteAndMalicePage.test.tsx
+++ b/frontend/src/pages/SpiteAndMalicePage.test.tsx
@@ -260,4 +260,46 @@ describe('SpiteAndMalicePage', () => {
     const tooltip = await screen.findByTestId('hint-tooltip');
     expect(tooltip).toHaveTextContent('ゴールパイルのトップをファウンデーションに出せます');
   });
+
+  it('defaults the CPU speed select to normal when unset', async () => {
+    renderWithProviders(<SpiteAndMalicePage />);
+    const select = (await screen.findByTestId('sam-cpu-speed-select')) as HTMLSelectElement;
+    expect(select.value).toBe('normal');
+  });
+
+  it('loads the persisted CPU speed from localStorage on mount', async () => {
+    localStorage.setItem('spiteandmalice:cpuSpeed', 'fast');
+    renderWithProviders(<SpiteAndMalicePage />);
+    const select = (await screen.findByTestId('sam-cpu-speed-select')) as HTMLSelectElement;
+    expect(select.value).toBe('fast');
+  });
+
+  it('persists the chosen CPU speed to localStorage', async () => {
+    renderWithProviders(<SpiteAndMalicePage />);
+    const select = (await screen.findByTestId('sam-cpu-speed-select')) as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: 'slow' } });
+    expect(select.value).toBe('slow');
+    expect(localStorage.getItem('spiteandmalice:cpuSpeed')).toBe('slow');
+  });
+
+  it('uses the selected speed as the CPU turn wait', async () => {
+    vi.useFakeTimers();
+    try {
+      // 'fast' → 200ms delay. Verify the CPU turn fires only after the boundary.
+      localStorage.setItem('spiteandmalice:cpuSpeed', 'fast');
+      mockExec.mockResolvedValue(cpuTurnState);
+      renderWithProviders(<SpiteAndMalicePage />);
+      // Flush the mount reset + initial render so the CPU-turn effect subscribes.
+      await vi.advanceTimersByTimeAsync(0);
+      mockExec.mockClear();
+      // Just before the 200ms fast delay no CPU turn has fired yet.
+      await vi.advanceTimersByTimeAsync(199);
+      expect(mockExec).not.toHaveBeenCalledWith('cpu');
+      // Crossing 200ms fires the fast CPU turn.
+      await vi.advanceTimersByTimeAsync(1);
+      expect(mockExec).toHaveBeenCalledWith('cpu');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/frontend/src/pages/SpiteAndMalicePage.tsx
+++ b/frontend/src/pages/SpiteAndMalicePage.tsx
@@ -33,6 +33,33 @@ import { isGoalTopPlayableToFoundation } from '../utils/spiteAndMaliceUtils';
 
 const samRunner = spiteAndMaliceApi;
 
+/** CPU cadence presets — a shorter delay makes the CPU take its turn sooner. */
+type SamCpuSpeed = 'slow' | 'normal' | 'fast';
+
+/**
+ * CPU turn wait (ms) per speed preset. A smaller delay advances the CPU turn
+ * sooner; `normal` (500ms) preserves the historical default for backward
+ * compatibility.
+ */
+const SAM_CPU_DELAY_MS: Record<SamCpuSpeed, number> = {
+  slow: 900,
+  normal: 500,
+  fast: 200,
+};
+
+const SAM_CPU_SPEED_STORAGE_KEY = 'spiteandmalice:cpuSpeed';
+
+/** Read the persisted CPU speed, falling back to `normal` when unset/invalid. */
+function loadSamCpuSpeed(): SamCpuSpeed {
+  try {
+    const v = localStorage.getItem(SAM_CPU_SPEED_STORAGE_KEY);
+    if (v === 'slow' || v === 'normal' || v === 'fast') return v;
+  } catch {
+    // localStorage may be unavailable (private mode / SSR); fall through to default.
+  }
+  return 'normal';
+}
+
 const SAM_TUTORIAL_STEPS: TutorialStep[] = [
   { target: '[data-tutorial="sam-opponent"]', messageKey: 'tutorial.opponent', placement: 'bottom', advanceOn: 'next' },
   {
@@ -129,18 +156,32 @@ function SpiteAndMalicePageContent() {
   const apiCall = gameApi.exec;
 
   const [selection, setSelection] = useState<Selection>(null);
+  const [cpuSpeed, setCpuSpeed] = useState<SamCpuSpeed>(loadSamCpuSpeed);
+
+  const handleSelectCpuSpeed = useCallback((v: string) => {
+    const speed: SamCpuSpeed = v === 'slow' || v === 'fast' ? v : 'normal';
+    setCpuSpeed(speed);
+    try {
+      localStorage.setItem(SAM_CPU_SPEED_STORAGE_KEY, speed);
+    } catch {
+      // Persistence is best-effort; ignore storage failures.
+    }
+  }, []);
 
   useMountReset(apiCall);
 
+  // CPU turn driver: after a short delay, advance the CPU's turn. The delay is
+  // scaled by the chosen speed preset; changing the speed restarts the timer so
+  // the new cadence takes effect from the next CPU turn.
   useEffect(() => {
     if (!state) return;
     if (state.phase === SpiteAndMalicePhase.GAME_OVER) return;
     if (state.current !== 1) return;
     const timer = setTimeout(() => {
       void apiCall('cpu');
-    }, 500);
+    }, SAM_CPU_DELAY_MS[cpuSpeed]);
     return () => clearTimeout(timer);
-  }, [state, apiCall]);
+  }, [state, apiCall, cpuSpeed]);
 
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('spiteandmalice');
   const samCliConfig: CliGameConfig<SpiteAndMaliceResponse, ApiArgs> = useMemo(
@@ -276,6 +317,20 @@ function SpiteAndMalicePageContent() {
                     label: tc('hint.toggle', { ns: 'tutorial' }),
                     checked: hintEnabled,
                     onToggle: setHintEnabled,
+                  },
+                  {
+                    type: 'select' as const,
+                    id: 'samCpuSpeed',
+                    testId: 'sam-cpu-speed-select',
+                    label: t('settings.cpuSpeed'),
+                    tooltip: t('settings.cpuSpeedHelp'),
+                    value: cpuSpeed,
+                    options: [
+                      { value: 'slow', label: t('settings.speedSlow') },
+                      { value: 'normal', label: t('settings.speedNormal') },
+                      { value: 'fast', label: t('settings.speedFast') },
+                    ],
+                    onSelect: handleSelectCpuSpeed,
                   },
                 ],
               },


### PR DESCRIPTION
## Summary
The Spite and Malice CPU turn wait was a hard-coded 500ms with no way to adjust it. This exposes a **CPU speed** selector (Slow / Normal / Fast) in the existing SettingsPanel, mirroring the Nertz pattern just merged in #4213.

- New `SamCpuSpeed` type + `SAM_CPU_DELAY_MS` record (`slow: 900 / normal: 500 / fast: 200` ms)
- Selection persists to `localStorage` under `spiteandmalice:cpuSpeed`; falls back to `normal` when unset/invalid
- The CPU-turn `setTimeout` is scaled by the chosen preset, with `cpuSpeed` in the effect deps so a change takes effect from the next CPU turn
- Added as a `select` item on the page's existing SettingsPanel (`data-testid="sam-cpu-speed-select"`)
- i18n keys added under `settings.*` for both `ja` and `en` (parity)
- **Normal (500ms) remains the default** for backward compatibility

## Test plan
- [x] `bun run check` (biome + design-tokens) — exit 0
- [x] `bun run test -- --run SpiteAndMalice` — 36 passed
- [x] `bun run build` (tsc) — exit 0
- [x] New tests: default speed when unset, persisted load on mount, persistence on change, and `uses the selected speed as the CPU turn wait` (fake timers assert the 200ms fast boundary)

Closes #3212