### PR TITLE
fix(sevenbridge): reference shared gameTheme for page background

### DIFF
--- a/frontend/src/pages/SevenBridgePage.test.tsx
+++ b/frontend/src/pages/SevenBridgePage.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { sevenBridgeApi } from '../api/gameApi';
+import { gameTheme } from '../styles/gameTheme';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { SevenBridgeResponse } from '../types/card';
 import { SevenBridgePage } from './SevenBridgePage';
@@ -61,6 +62,14 @@ describe('SevenBridgePage', () => {
     mockExec.mockResolvedValue(drawState);
     renderWithProviders(<SevenBridgePage />);
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined, expect.any(Object)));
+  });
+
+  it('applies the shared gameTheme background instead of a hardcoded class', async () => {
+    mockExec.mockResolvedValue(drawState);
+    const { container } = renderWithProviders(<SevenBridgePage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalled());
+    expect(container.querySelector(`.${gameTheme.sevenbridge.bg}`)).toBeInTheDocument();
+    expect(container.querySelector('.bg-ds-bg')).not.toBeInTheDocument();
   });
 
   it('renders draw phase controls', async () => {

--- a/frontend/src/pages/SevenBridgePage.tsx
+++ b/frontend/src/pages/SevenBridgePage.tsx
@@ -23,6 +23,7 @@ import { useSound } from '../providers/SoundProvider';
 import { btnPrimary, btnSuccess } from '../styles/buttonStyles';
 import { focusRingCard, selectedCardStyle } from '../styles/cardStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
+import { gameTheme } from '../styles/gameTheme';
 import type { SevenBridgeResponse } from '../types/card';
 import { SevenBridgePhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
@@ -135,7 +136,7 @@ function SevenBridgePageContent() {
   return (
     <GamePageShell
       title={tc('nav.sevenbridge')}
-      gameThemeBg="bg-ds-bg"
+      gameThemeBg={gameTheme.sevenbridge.bg}
       phaseName={phaseNames[state?.phase ?? 0] ?? ''}
       isHumanTurn={!!isHumanTurn}
       gamePath="/sevenbridge"


### PR DESCRIPTION
## Summary
`SevenBridgePage.tsx` hardcoded `gameThemeBg="bg-ds-bg"` instead of referencing the SSoT in `src/styles/gameTheme.ts`, violating the design-system rule (`frontend/CLAUDE.md`) that every game page must reference its own `gameTheme` key rather than hardcode a background.

`sevenbridge` already had an entry in `gameTheme.ts` (`BLUE` → `bg-game-bg-blue`), so this points the page at `gameTheme.sevenbridge.bg` and drops the hardcoded class. No new theme entry was needed.

## Changes
- `SevenBridgePage.tsx`: import `gameTheme`, set `gameThemeBg={gameTheme.sevenbridge.bg}`, remove `bg-ds-bg`.
- `SevenBridgePage.test.tsx`: new test asserting the shared theme class is applied and `bg-ds-bg` is absent.

## Acceptance criteria
- [x] `gameThemeBg` uses `gameTheme.sevenbridge.bg` (SSoT reference)
- [x] `bg-ds-bg` hardcode removed
- [x] test verifies the theme reference

## Gates
- [x] `bun run check`
- [x] `bun run test -- --run SevenBridge` (37 passed)
- [x] `bun run build`

Closes #3197