### PR TITLE
refactor(calculation): dedup foundation-cap magic number into constant

### DIFF
--- a/frontend/src/pages/CalculationPage.test.tsx
+++ b/frontend/src/pages/CalculationPage.test.tsx
@@ -345,6 +345,8 @@ describe('CalculationPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
     expect(screen.queryByTestId('calc-foundation-next-0')).not.toBeInTheDocument();
     expect(screen.getByTestId('calc-foundation-next-1')).toHaveTextContent('次:4');
+    // The count readout reflects the foundation-cap constant (13/13) for a full pile.
+    expect(screen.getByText('13/13')).toBeInTheDocument();
   });
 
   it('exposes the full upcoming-rank sequence as visible, tappable text (not only a title attr)', async () => {

--- a/frontend/src/pages/CalculationPage.tsx
+++ b/frontend/src/pages/CalculationPage.tsx
@@ -167,7 +167,9 @@ function formatCalculationState(state: CalculationResponse): string {
     `Foundations: ${state.foundations
       .map((pile, i) => {
         const top = pile[pile.length - 1];
-        return top ? `F${i}(${STEP_LABELS[i]}):${top.design[0]}${top.value}(${pile.length}/13)` : `F${i}:-`;
+        return top
+          ? `F${i}(${STEP_LABELS[i]}):${top.design[0]}${top.value}(${pile.length}/${FOUNDATION_PILE_FULL})`
+          : `F${i}:-`;
       })
       .join(' ')}`,
   );
@@ -441,7 +443,9 @@ function CalculationPageContent() {
                           </span>
                         )}
                       </div>
-                      <span className="text-[11px] text-ds-text-muted mt-0.5">{pile.length}/13</span>
+                      <span className="text-[11px] text-ds-text-muted mt-0.5">
+                        {pile.length}/{FOUNDATION_PILE_FULL}
+                      </span>
                       {upcomingRanks.length > 1 && (
                         <span
                           data-testid={`calc-foundation-upcoming-${idx}`}


### PR DESCRIPTION
## Summary

The foundation-pile max count \`13\` was still hardcoded as a magic number in two spots in \`CalculationPage.tsx\`, duplicating the existing \`FOUNDATION_PILE_FULL = 13\` constant already used by \`calculationNextRank\`:

- the CUI/CLI foundation formatter (\`F${i}(...)(${pile.length}/13)\`)
- the foundation count readout \`<span>{pile.length}/13</span>\`

Both now reference \`FOUNDATION_PILE_FULL\`, giving the foundation cap a single source of truth within the page. No behavior change — the rendered output is identical.

Note: this is the frontend-only, low-risk slice of the issue. Rank literals meaning "King = 13" and unrelated \`13\`s were verified and left untouched. The broader server-sourced-value / cross-layer consistency test proposed in the issue is out of scope here (would touch Go).

## Changes
- \`frontend/src/pages/CalculationPage.tsx\` — replace 2 foundation-cap \`13\` literals with \`FOUNDATION_PILE_FULL\`
- \`frontend/src/pages/CalculationPage.test.tsx\` — assert the full-pile count readout renders \`13/13\` (proves the refactored display still works)

## Test plan
- [x] \`bun run check\` (biome lint + format + design-tokens) — passes
- [x] \`bun run test -- --run Calculation\` — 40 passed
- [x] \`bun run build\` (tsc) — passes

Closes #3209