### PR TITLE
feat(dragontiger): add one-click rebet at end phase

### DIFF
--- a/frontend/src/i18n/locales/en/dragontiger.json
+++ b/frontend/src/i18n/locales/en/dragontiger.json
@@ -13,7 +13,11 @@
     "betTiger": "Tiger",
     "betTie": "Tie (8:1)",
     "reset": "Reset",
-    "clearHistory": "Clear history"
+    "clearHistory": "Clear history",
+    "rebet": "Rebet ({{type}} {{amount}})"
+  },
+  "kbd": {
+    "rebet": "E"
   },
   "phase": {
     "bet": "BET",

--- a/frontend/src/i18n/locales/ja/dragontiger.json
+++ b/frontend/src/i18n/locales/ja/dragontiger.json
@@ -13,7 +13,11 @@
     "betTiger": "タイガー",
     "betTie": "タイ (8:1)",
     "reset": "リセット",
-    "clearHistory": "履歴クリア"
+    "clearHistory": "履歴クリア",
+    "rebet": "再ベット ({{type}} {{amount}})"
+  },
+  "kbd": {
+    "rebet": "E"
   },
   "phase": {
     "bet": "ベット",

--- a/frontend/src/pages/DragonTigerPage.test.tsx
+++ b/frontend/src/pages/DragonTigerPage.test.tsx
@@ -230,4 +230,57 @@ describe('DragonTigerPage', () => {
     expect(diff).toHaveClass('text-ds-error');
     expect(screen.getByTestId('payout-result')).toHaveTextContent('返還'); // tieRefund text
   });
+
+  it('shows a Rebet button at end-phase after a bet, replaying the same amount and target', async () => {
+    renderWithProviders(<DragonTigerPage />);
+    const dragonBtn = await screen.findByRole('button', { name: 'ドラゴン' });
+    mockApi.mockClear();
+    mockApi.mockResolvedValue(dragonWinState); // bet Dragon 100 → END
+    fireEvent.click(dragonBtn);
+    await waitFor(() => expect(mockApi).toHaveBeenCalledWith('bet', 100, DragonTigerBetType.DRAGON));
+    const rebet = await screen.findByTestId('dt-rebet-button');
+    // The button advertises the previous target (Dragon) and amount (100).
+    expect(rebet).toHaveTextContent('ドラゴン');
+    expect(rebet).toHaveTextContent('100');
+    expect(rebet).toHaveAttribute('aria-keyshortcuts', 'e');
+
+    mockApi.mockClear();
+    mockApi.mockResolvedValueOnce(betState);
+    mockApi.mockResolvedValueOnce(dragonWinState);
+    fireEvent.click(rebet);
+    await waitFor(() => expect(mockApi).toHaveBeenCalledWith('reset'));
+    await waitFor(() => expect(mockApi).toHaveBeenCalledWith('bet', 100, DragonTigerBetType.DRAGON));
+  });
+
+  it('does not show the Rebet button at end-phase when no prior bet exists (state seeded at END)', async () => {
+    mockApi.mockResolvedValueOnce(dragonWinState); // mount lands directly at END, no bet snapshotted
+    renderWithProviders(<DragonTigerPage />);
+    await screen.findByTestId('payout-breakdown');
+    expect(screen.queryByTestId('dt-rebet-button')).not.toBeInTheDocument();
+  });
+
+  it('hides the Rebet button when chips are insufficient to replay', async () => {
+    renderWithProviders(<DragonTigerPage />);
+    const dragonBtn = await screen.findByRole('button', { name: 'ドラゴン' });
+    // End state with only 50 chips left — cannot afford the 100 rebet.
+    mockApi.mockResolvedValue({ ...dragonWinState, chips: 50 });
+    fireEvent.click(dragonBtn);
+    await screen.findByTestId('payout-breakdown');
+    expect(screen.queryByTestId('dt-rebet-button')).not.toBeInTheDocument();
+  });
+
+  it("the 'e' keyboard shortcut replays the last bet at end phase", async () => {
+    renderWithProviders(<DragonTigerPage />);
+    const tigerBtn = await screen.findByRole('button', { name: 'タイガー' });
+    mockApi.mockResolvedValue(tigerWinOnTigerBetState); // bet Tiger 100 → END
+    fireEvent.click(tigerBtn);
+    await screen.findByTestId('dt-rebet-button');
+
+    mockApi.mockClear();
+    mockApi.mockResolvedValueOnce(betState);
+    mockApi.mockResolvedValueOnce(tigerWinOnTigerBetState);
+    fireEvent.keyDown(document, { key: 'e' });
+    await waitFor(() => expect(mockApi).toHaveBeenCalledWith('reset'));
+    await waitFor(() => expect(mockApi).toHaveBeenCalledWith('bet', 100, DragonTigerBetType.TIGER));
+  });
 });

--- a/frontend/src/pages/DragonTigerPage.tsx
+++ b/frontend/src/pages/DragonTigerPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { dragontigerApi } from '../api/gameApi';
 import { ActionLogPanel } from '../components/ActionLogPanel';
 import { CliTerminal } from '../components/cli/CliTerminal';
@@ -10,6 +10,7 @@ import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
+import { KbdBadge } from '../components/KbdBadge';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { RoadmapTrendBar } from '../components/RoadmapTrendBar';
 import { withTutorial } from '../components/tutorial/withTutorial';
@@ -50,6 +51,9 @@ function DragonTigerPageContent() {
     useGamePageSetup('dragontiger');
 
   const [betAmount, setBetAmount] = useState(100);
+  // Snapshot of the last submitted bet (amount + target) so the player can
+  // replay the same wager at end phase with a single action (#3242).
+  const [lastBet, setLastBet] = useState<{ amount: number; type: number } | null>(null);
   const { cardWidth } = useCardDimensions();
   const { playSound } = useSound();
   const { state, loading, error, exec: execApi, retry } = useGameApi(dragontigerApi.exec);
@@ -71,14 +75,35 @@ function DragonTigerPageContent() {
   const isBetPhase = state?.phase === DragonTigerPhase.BET;
   const isEndPhase = state?.phase === DragonTigerPhase.END;
 
+  const handleBet = useCallback(
+    (betType: number) => {
+      setLastBet({ amount: betAmount, type: betType });
+      return execApi('bet', betAmount, betType);
+    },
+    [execApi, betAmount],
+  );
+  // A rebet is possible only when a prior bet exists and the player can still
+  // afford it against the current chip balance.
+  const canRebet = lastBet !== null && lastBet.amount > 0 && !!state && lastBet.amount <= state.chips;
+  const handleRebet = useCallback(async () => {
+    if (lastBet === null) return;
+    await execApi('reset');
+    await execApi('bet', lastBet.amount, lastBet.type);
+  }, [execApi, lastBet]);
+
   const actionBindings = useMemo(
     () => [
-      { key: 'd', action: () => execApi('bet', betAmount, DragonTigerBetType.DRAGON), enabled: isBetPhase },
-      { key: 't', action: () => execApi('bet', betAmount, DragonTigerBetType.TIGER), enabled: isBetPhase },
-      { key: 'e', action: () => execApi('bet', betAmount, DragonTigerBetType.TIE), enabled: isBetPhase },
+      { key: 'd', action: () => handleBet(DragonTigerBetType.DRAGON), enabled: isBetPhase },
+      { key: 't', action: () => handleBet(DragonTigerBetType.TIGER), enabled: isBetPhase },
+      // 'e' bets Tie during the bet phase, then replays the last wager at end phase.
+      {
+        key: 'e',
+        action: () => (isEndPhase ? handleRebet() : handleBet(DragonTigerBetType.TIE)),
+        enabled: isBetPhase || (isEndPhase && canRebet),
+      },
       { key: 'r', action: () => execApi('reset'), enabled: isEndPhase },
     ],
-    [execApi, betAmount, isBetPhase, isEndPhase],
+    [execApi, handleBet, handleRebet, isBetPhase, isEndPhase, canRebet],
   );
   useActionKeyboardNav({ bindings: actionBindings, enabled: !!state && !loading });
 
@@ -90,7 +115,6 @@ function DragonTigerPageContent() {
     );
   }
 
-  const handleBet = (betType: number) => execApi('bet', betAmount, betType);
   const handleReset = () => execApi('reset');
   const handleClearHistory = () => execApi('clear');
 
@@ -282,6 +306,28 @@ function DragonTigerPageContent() {
             )}
             {isEndPhase && (
               <div className="flex justify-center gap-2 pb-2 flex-wrap">
+                {canRebet && lastBet !== null && (
+                  <button
+                    type="button"
+                    className={btnPrimary}
+                    onClick={handleRebet}
+                    disabled={loading}
+                    data-testid="dt-rebet-button"
+                    aria-keyshortcuts="e"
+                  >
+                    {t('button.rebet', {
+                      type: t(
+                        lastBet.type === DragonTigerBetType.DRAGON
+                          ? 'payout.dragon'
+                          : lastBet.type === DragonTigerBetType.TIGER
+                            ? 'payout.tiger'
+                            : 'payout.tie',
+                      ),
+                      amount: lastBet.amount,
+                    })}
+                    <KbdBadge label={t('kbd.rebet')} />
+                  </button>
+                )}
                 <GameResetButton
                   isGameEnd={isEndPhase}
                   onReset={handleReset}


### PR DESCRIPTION
## Summary
Adds a "rebet" feature to Dragon Tiger (#3242). Dragon Tiger rounds are extremely short (bet → immediate result) and players often replay the same wager, but each round previously required a 3-step reset → amount → target flow. This adds a single-click replay.

- Remembers the last submitted bet — amount **and** target (`DragonTigerBetType`) — in client-side state (`lastBet`), snapshotted in `handleBet`.
- Adds an end-phase **Rebet** button (`data-testid="dt-rebet-button"`) that replays it via `reset` then `bet` in one action. Label shows the previous target + amount (e.g. `再ベット (ドラゴン 100)`).
- Bound to the `e` key (dual-purpose: Tie bet during BET phase, rebet during END phase — phases are mutually exclusive).
- Hidden/disabled when no prior bet exists or chips are insufficient to replay.
- ja/en i18n parity (`button.rebet`, `kbd.rebet`).

Frontend-only; no Go changes.

## Test plan
- [x] `bun run check` (Biome lint + format + design-tokens) passes
- [x] `bun run test -- --run DragonTiger` — 37 passed, incl. new rebet tests:
  - shows Rebet button at end phase and replays same amount + target
  - no button when no prior bet exists
  - button hidden when chips insufficient
  - `e` keyboard shortcut replays the last bet at end phase
- [x] `bun run build` (tsc) passes

Closes #3242

🤖 Generated with [Claude Code](https://claude.com/claude-code)