### PR TITLE
fix(reddog): extract minimum bet into a tested frontend ssot

### DIFF
--- a/frontend/src/pages/RedDogPage.test.tsx
+++ b/frontend/src/pages/RedDogPage.test.tsx
@@ -128,6 +128,13 @@ describe('RedDogPage', () => {
     await waitFor(() => expect(mockApi).toHaveBeenCalledWith('raise', 100));
   });
 
+  it('disables the raise button when chips fall below the minimum bet', async () => {
+    mockApi.mockResolvedValue({ ...spreadState, chips: 5 });
+    renderWithProviders(<RedDogPage />);
+    const raiseBtn = await screen.findByRole('button', { name: /レイズ/ });
+    expect(raiseBtn).toBeDisabled();
+  });
+
   it('renders end phase with reset and payout', async () => {
     mockApi.mockResolvedValue(winState);
     renderWithProviders(<RedDogPage />);

--- a/frontend/src/pages/RedDogPage.tsx
+++ b/frontend/src/pages/RedDogPage.tsx
@@ -31,10 +31,8 @@ import type { TutorialStep } from '../types/tutorial';
 import { parseReddogCommand, REDDOG_HELP } from '../utils/cli/commands/reddogCommands';
 import { formatReddogState } from '../utils/cli/formatters/reddogFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { canRedDogRaise } from '../utils/reddogBet';
 import { rankLabel, redDogRank, reddogWinningRanks } from '../utils/reddogWinningRanks';
-
-/** Minimum bet amount matching backend RedDogMinBet. */
-const REDDOG_MIN_BET = 10;
 
 const RD_TUTORIAL_STEPS: TutorialStep[] = [
   {
@@ -260,7 +258,7 @@ function RedDogPageContent() {
                     type="button"
                     className={btnSuccess}
                     onClick={handleRaise}
-                    disabled={loading || state.chips < REDDOG_MIN_BET}
+                    disabled={loading || !canRedDogRaise(state.chips)}
                   >
                     {t('button.raise')}
                   </button>

--- a/frontend/src/utils/reddogBet.test.ts
+++ b/frontend/src/utils/reddogBet.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { canRedDogRaise, REDDOG_MIN_BET } from './reddogBet';
+
+describe('reddogBet', () => {
+  it('exposes the backend minimum bet value', () => {
+    expect(REDDOG_MIN_BET).toBe(10);
+  });
+
+  it('allows a raise when chips meet or exceed the minimum bet', () => {
+    expect(canRedDogRaise(REDDOG_MIN_BET)).toBe(true);
+    expect(canRedDogRaise(REDDOG_MIN_BET + 1)).toBe(true);
+    expect(canRedDogRaise(1000)).toBe(true);
+  });
+
+  it('blocks a raise when chips fall below the minimum bet', () => {
+    expect(canRedDogRaise(REDDOG_MIN_BET - 1)).toBe(false);
+    expect(canRedDogRaise(0)).toBe(false);
+  });
+});

--- a/frontend/src/utils/reddogBet.ts
+++ b/frontend/src/utils/reddogBet.ts
@@ -1,0 +1,15 @@
+/**
+ * Minimum bet amount for Red Dog. Mirrors the backend `RedDogMinBet`
+ * constant defined in `internal/domain/RedDog.go`. Kept in a single place so
+ * the raise-affordability check has one frontend source of truth and cannot
+ * silently diverge from the server-side validation.
+ */
+export const REDDOG_MIN_BET = 10;
+
+/**
+ * Reports whether the player can afford the minimum raise given their current
+ * chip count. Mirrors the backend guard `chips < RedDogMinBet`.
+ */
+export function canRedDogRaise(chips: number): boolean {
+  return chips >= REDDOG_MIN_BET;
+}


### PR DESCRIPTION
## Summary

The Red Dog minimum bet was a bare literal (`const REDDOG_MIN_BET = 10;`) inside `RedDogPage.tsx`, manually duplicating the backend `RedDogMinBet` constant (`internal/domain/RedDog.go`). If the backend value changed, the raise-button disable logic (`state.chips < REDDOG_MIN_BET`) could silently diverge from server-side validation, surfacing confusing errors to the user.

The `RedDogResponse` API payload does not expose a min-bet field, and this change is frontend-only (no Go touched), so the pragmatic fix is a single tested frontend source of truth — mirroring the existing `blackjackBet.ts` / `BJ_MIN_BET` pattern.

## Changes

- Add `frontend/src/utils/reddogBet.ts` exporting `REDDOG_MIN_BET` and a `canRedDogRaise(chips)` helper, with a TSDoc comment linking to the Go source constant.
- `RedDogPage.tsx` now imports the constant/helper instead of defining a local literal; the raise button uses `!canRedDogRaise(state.chips)`.
- Add `reddogBet.test.ts` covering the raise-affordability boundary (below / at / above the minimum).
- Add a page test asserting the raise button is disabled when chips fall below the minimum bet.

## Acceptance criteria

- [x] Minimum bet lives in a single frontend SSoT with a comment referencing the Go source (`RedDogMinBet`); response does not expose it and Go is out of scope.
- [x] The `REDDOG_MIN_BET` inline literal is removed from the page; consistency is covered by tests.
- [x] Existing raise-button disable logic works with the new value.

## Gates

- `bun run check` — pass (exit 0; only pre-existing unrelated warnings)
- `bun run test -- --run RedDog` — 52 tests pass
- `bun run build` — pass

Closes #3174