### PR TITLE
feat(accordion): add autocomplete to auto-play recommended merges

### DIFF
--- a/frontend/src/i18n/locales/en/accordion.json
+++ b/frontend/src/i18n/locales/en/accordion.json
@@ -10,6 +10,7 @@
   "giveup": "Give up",
   "hint": "Hint",
   "undo": "Undo",
+  "autoComplete": "Auto Complete",
   "gameClear": "Game Clear! Moves: {{moveCount}}",
   "gameOver": "Game Over",
   "result": {
@@ -43,6 +44,7 @@
     "title": "Keyboard shortcuts",
     "move": "Move the pile selection",
     "merge": "Merge the selected pile 1 or 3 piles to the left",
+    "autoComplete": "Auto-play the recommended merges in sequence",
     "hint": "Show a hint",
     "undo": "Undo one move",
     "giveup": "Give up",

--- a/frontend/src/i18n/locales/ja/accordion.json
+++ b/frontend/src/i18n/locales/ja/accordion.json
@@ -10,6 +10,7 @@
   "giveup": "ギブアップ",
   "hint": "ヒント",
   "undo": "元に戻す",
+  "autoComplete": "自動完成",
   "gameClear": "ゲームクリア！ 手数: {{moveCount}}",
   "gameOver": "ゲームオーバー",
   "result": {
@@ -43,6 +44,7 @@
     "title": "キーボードショートカット",
     "move": "パイルの選択を移動",
     "merge": "選択中のパイルを1つ左／3つ左へ重ねる",
+    "autoComplete": "推奨手を自動で連続実行",
     "hint": "ヒントを表示",
     "undo": "1手戻す",
     "giveup": "ギブアップ",

--- a/frontend/src/pages/AccordionPage.test.tsx
+++ b/frontend/src/pages/AccordionPage.test.tsx
@@ -533,6 +533,98 @@ describe('AccordionPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('undo'));
   });
 
+  it('autocomplete button is disabled when no legal merge remains', async () => {
+    // playingState: SPADE1/HEART2/CLOVER3/DIAMOND4 → no suit/rank match anywhere.
+    renderWithProviders(<AccordionPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    expect(screen.getByTestId('ac-autocomplete')).toBeDisabled();
+  });
+
+  it('autocomplete button is enabled and advertises its shortcut when a merge is available', async () => {
+    // pile 3 (SPADE 9) merges onto pile 0 (SPADE 7) at offset 3.
+    mockExec.mockResolvedValue({
+      ...playingState,
+      piles: [
+        { cards: [card('SPADE', 7)], size: 1 },
+        { cards: [card('HEART', 2)], size: 1 },
+        { cards: [card('CLOVER', 3)], size: 1 },
+        { cards: [card('SPADE', 9)], size: 1 },
+      ],
+    });
+    renderWithProviders(<AccordionPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    const autoBtn = screen.getByTestId('ac-autocomplete');
+    expect(autoBtn).toBeEnabled();
+    expect(autoBtn).toHaveAttribute('aria-keyshortcuts', 'a');
+  });
+
+  it('autocomplete drives the recommended merges in sequence until none remain', async () => {
+    const stateA: AccordionResponse = {
+      ...playingState,
+      piles: [
+        { cards: [card('SPADE', 7)], size: 1 },
+        { cards: [card('HEART', 2)], size: 1 },
+        { cards: [card('CLOVER', 3)], size: 1 },
+        { cards: [card('SPADE', 9)], size: 1 }, // idx3→idx0 (suit) offset 3
+      ],
+    };
+    // After the offset-3 merge: idx1 (SPADE 3) → idx0 (SPADE 9) offset 1.
+    const stateB: AccordionResponse = {
+      ...playingState,
+      piles: [
+        { cards: [card('SPADE', 9)], size: 2 },
+        { cards: [card('SPADE', 3)], size: 1 },
+        { cards: [card('CLOVER', 3)], size: 1 },
+      ],
+      pileCount: 3,
+    };
+    // No further match (SPADE 3 vs CLOVER 5) → loop stops.
+    const stateC: AccordionResponse = {
+      ...playingState,
+      piles: [
+        { cards: [card('SPADE', 3)], size: 3 },
+        { cards: [card('CLOVER', 5)], size: 1 },
+      ],
+      pileCount: 2,
+    };
+    mockExec.mockResolvedValueOnce(stateA); // reset on mount
+    mockExec.mockResolvedValueOnce(stateB); // first merge
+    mockExec.mockResolvedValue(stateC); // second merge + rest
+
+    renderWithProviders(<AccordionPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    mockExec.mockClear();
+    fireEvent.click(screen.getByTestId('ac-autocomplete'));
+
+    await waitFor(() =>
+      expect(mockExec).toHaveBeenCalledWith('move', { zone: 'pile', index: 3 }, { zone: 'pile', index: 0 }),
+    );
+    await waitFor(() =>
+      expect(mockExec).toHaveBeenCalledWith('move', { zone: 'pile', index: 1 }, { zone: 'pile', index: 0 }),
+    );
+    // Exactly two merges, then the loop halts (stateC has no legal move).
+    expect(mockExec.mock.calls.filter((c) => c[0] === 'move')).toHaveLength(2);
+    await waitFor(() => expect(screen.getByTestId('ac-autocomplete')).toBeDisabled());
+  });
+
+  it('pressing "a" triggers autocomplete', async () => {
+    mockExec.mockResolvedValueOnce({
+      ...playingState,
+      piles: [
+        { cards: [card('SPADE', 7)], size: 1 },
+        { cards: [card('HEART', 2)], size: 1 },
+        { cards: [card('CLOVER', 3)], size: 1 },
+        { cards: [card('SPADE', 9)], size: 1 },
+      ],
+    });
+    mockExec.mockResolvedValue({ ...playingState, piles: [{ cards: [card('SPADE', 9)], size: 2 }], pileCount: 1 });
+    renderWithProviders(<AccordionPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    mockExec.mockClear();
+    fireEvent.keyDown(document, { key: 'a' });
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('move', expect.any(Object), expect.any(Object)));
+  });
+
   it('shows 次のゲーム at game-end and fires reset directly (no confirm)', async () => {
     mockExec.mockResolvedValue(gameOverState);
     renderWithProviders(<AccordionPage />);

--- a/frontend/src/pages/AccordionPage.tsx
+++ b/frontend/src/pages/AccordionPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import { type AccordionMoveZone, accordionApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
@@ -25,14 +25,17 @@ import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useMountReset } from '../hooks/useMountReset';
 import { useSound } from '../providers/SoundProvider';
-import { btnDanger, btnOutline, focusRingWhite } from '../styles/buttonStyles';
+import { btnDanger, btnOutline, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { AccordionResponse } from '../types/card';
 import { AccordionPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
-import { accordionLegalOffsets, accordionLegalTargets } from '../utils/accordionUtils';
+import { accordionLegalOffsets, accordionLegalTargets, accordionNextAutoMove } from '../utils/accordionUtils';
 import { cardAlt } from '../utils/cardAlt';
 import type { CliGameConfig, CliParseResult } from '../utils/cli/types';
+
+/** Upper bound on autocomplete merges (a 52-card deck needs at most 51) — loop guard (#3192). */
+const AC_MAX_AUTO_MERGES = 52;
 
 /** Accordion tutorial step definitions. */
 const AC_TUTORIAL_STEPS: TutorialStep[] = [
@@ -129,6 +132,7 @@ function AccordionPageContent() {
   const { playSound } = useSound();
   const {
     state,
+    setState,
     loading,
     error,
     exec: apiCall,
@@ -138,6 +142,14 @@ function AccordionPageContent() {
   useMountReset(apiCall);
 
   const [selectedIdx, setSelectedIdx] = useState<number | null>(null);
+  // Autocomplete drives the single `move` action in a loop (issue #3192), which
+  // bypasses useGameApi's `loading` flag, so `isAutoCompleting` gates the UI
+  // while the batch runs and `stateRef`/`autoCompletingRef` let the loop read
+  // the freshest board and block a second concurrent run (mirrors AcesUp #3347).
+  const [isAutoCompleting, setIsAutoCompleting] = useState(false);
+  const stateRef = useRef<AccordionResponse | null>(state);
+  stateRef.current = state;
+  const autoCompletingRef = useRef(false);
   // Tracks the pile under cursor/focus so we can paint legal -1/-3 targets
   // (same suit OR same rank) without waiting for click. Reset by mouseleave/blur
   // and on every state change (handled implicitly because piles re-key on size).
@@ -204,6 +216,45 @@ function AccordionPageContent() {
     [apiCall],
   );
 
+  /**
+   * Auto-plays every forced/recommended merge in one click (issue #3192). It
+   * drives the existing single `move` action sequentially, re-reading the fresh
+   * board after each merge and applying the next {@link accordionNextAutoMove}
+   * (the same offset-3-first heuristic the backend hint uses) until no legal
+   * merge remains. Terminates because each merge removes a pile; the re-entry
+   * guard blocks a second concurrent run.
+   */
+  const handleAutoComplete = useCallback(async () => {
+    if (autoCompletingRef.current) return;
+    autoCompletingRef.current = true;
+    setIsAutoCompleting(true);
+    setSelectedIdx(null);
+    let move = stateRef.current ? accordionNextAutoMove(stateRef.current.piles) : null;
+    try {
+      // Upper bound: a 52-pile deck can never need more than 51 merges.
+      for (let step = 0; step < AC_MAX_AUTO_MERGES && move; step++) {
+        const res = await accordionApi.exec(
+          'move',
+          { zone: 'pile', index: move.fromIdx },
+          { zone: 'pile', index: move.toIdx },
+        );
+        setState(res);
+        if (res.phase !== AccordionPhase.PLAYING) break;
+        move = accordionNextAutoMove(res.piles);
+      }
+      playSound('cardPlace');
+    } catch {
+      // Surface the failure through the shared exec so the standard
+      // error/retry channel handles it.
+      if (move) {
+        await apiCall('move', { zone: 'pile', index: move.fromIdx }, { zone: 'pile', index: move.toIdx });
+      }
+    } finally {
+      autoCompletingRef.current = false;
+      setIsAutoCompleting(false);
+    }
+  }, [apiCall, setState, playSound]);
+
   const dispatchMove = useCallback(
     (fromIdx: number, toIdx: number) => {
       const from: AccordionMoveZone = { zone: 'pile', index: fromIdx };
@@ -265,16 +316,20 @@ function AccordionPageContent() {
       { key: 'ArrowRight', action: () => moveSelection(1) },
       { key: '1', action: () => mergeFromSelection(1) },
       { key: '3', action: () => mergeFromSelection(3) },
+      { key: 'a', action: () => void handleAutoComplete() },
       { key: 'u', action: handleUndo },
       { key: 'h', action: handleHint },
       { key: 'g', action: confirmGiveUpAction },
       { key: 'Escape', action: () => setSelectedIdx(null) },
     ],
-    [moveSelection, mergeFromSelection, handleUndo, handleHint, confirmGiveUpAction],
+    [moveSelection, mergeFromSelection, handleAutoComplete, handleUndo, handleHint, confirmGiveUpAction],
   );
+  // The autocomplete loop bypasses useGameApi's `loading` flag, so gate every
+  // interactive control on `busy` (loading OR a batch in flight) — issue #3192.
+  const busy = loading || isAutoCompleting;
   useActionKeyboardNav({
     bindings: accordionBindings,
-    enabled: state?.phase === AccordionPhase.PLAYING && !loading,
+    enabled: state?.phase === AccordionPhase.PLAYING && !busy,
   });
 
   if (error) return <ErrorAlert message={error} onRetry={retry} />;
@@ -284,6 +339,9 @@ function AccordionPageContent() {
   const isGameClear = state.phase === AccordionPhase.GAME_CLEAR;
   const isGameOver = state.phase === AccordionPhase.GAME_OVER;
   const isEnded = isGameClear || isGameOver;
+  // Autocomplete is only useful while a legal merge remains; disable it (and skip
+  // the pulse cue) otherwise, mirroring the sibling solitaires' gating.
+  const hasAutoMove = isPlaying && accordionNextAutoMove(state.piles) !== null;
 
   const phaseName = isGameClear ? t('phase.gameClear') : isGameOver ? t('phase.gameOver') : t('phase.playing');
 
@@ -385,7 +443,7 @@ function AccordionPageContent() {
                       onMouseLeave={() => setHoveredIdx((cur) => (cur === idx ? null : cur))}
                       onFocus={isPlaying ? () => setHoveredIdx(idx) : undefined}
                       onBlur={() => setHoveredIdx((cur) => (cur === idx ? null : cur))}
-                      disabled={!isPlaying}
+                      disabled={!isPlaying || busy}
                       data-hover-target={isHoverTarget ? 'true' : 'false'}
                       data-legal-target={isLegalTarget ? 'true' : 'false'}
                       aria-label={`${baseLabel}${mergeSuffix}`}
@@ -475,9 +533,19 @@ function AccordionPageContent() {
                 <>
                   <button
                     type="button"
+                    className={`${btnSuccess}${hasAutoMove && !busy ? ' animate-pulse ring-2 ring-ds-success' : ''}`}
+                    onClick={() => void handleAutoComplete()}
+                    disabled={busy || !hasAutoMove}
+                    aria-keyshortcuts="a"
+                    data-testid="ac-autocomplete"
+                  >
+                    {t('autoComplete')}
+                  </button>
+                  <button
+                    type="button"
                     className={btnOutline}
                     onClick={handleHint}
-                    disabled={loading}
+                    disabled={busy}
                     aria-keyshortcuts="h"
                   >
                     {t('hint')}
@@ -486,7 +554,7 @@ function AccordionPageContent() {
                     type="button"
                     className={btnOutline}
                     onClick={handleUndo}
-                    disabled={loading || !state.canUndo}
+                    disabled={busy || !state.canUndo}
                     aria-keyshortcuts="u"
                   >
                     {t('undo')}
@@ -495,7 +563,7 @@ function AccordionPageContent() {
                     type="button"
                     className={btnDanger}
                     onClick={confirmGiveUpAction}
-                    disabled={loading}
+                    disabled={busy}
                     aria-keyshortcuts="g"
                   >
                     {t('giveup')}
@@ -504,7 +572,7 @@ function AccordionPageContent() {
                     <StalemateEscapeButton
                       undoToEscape={state.undoToEscape ?? -1}
                       onEscape={handleUndoEscape}
-                      disabled={loading}
+                      disabled={busy}
                     />
                   )}
                 </>
@@ -517,6 +585,7 @@ function AccordionPageContent() {
                 shortcuts={[
                   { keys: ['←', '→'], description: t('kbd.move') },
                   { keys: ['1', '3'], description: t('kbd.merge') },
+                  { keys: ['a'], description: t('kbd.autoComplete') },
                   { keys: ['h'], description: t('kbd.hint') },
                   { keys: ['u'], description: t('kbd.undo') },
                   { keys: ['g'], description: t('kbd.giveup') },

--- a/frontend/src/utils/accordionUtils.test.ts
+++ b/frontend/src/utils/accordionUtils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { AccordionPile, Card, CardDesign } from '../types/card';
-import { accordionLegalOffsets, accordionLegalTargets } from './accordionUtils';
+import { accordionLegalOffsets, accordionLegalTargets, accordionNextAutoMove } from './accordionUtils';
 
 const card = (design: CardDesign, value: number): Card => ({ design, value });
 const pile = (top: Card | undefined): AccordionPile => ({ cards: top ? [top] : [], size: top ? 1 : 0 });
@@ -54,5 +54,53 @@ describe('accordionLegalOffsets', () => {
 
   it('returns an empty array when no merge is legal', () => {
     expect(accordionLegalOffsets([pile(card('SPADE', 2)), pile(card('HEART', 9))], 1)).toEqual([]);
+  });
+});
+
+describe('accordionNextAutoMove', () => {
+  it('returns null when no merge is legal', () => {
+    const piles = [pile(card('SPADE', 2)), pile(card('HEART', 9))];
+    expect(accordionNextAutoMove(piles)).toBeNull();
+  });
+
+  it('returns null for an empty board', () => {
+    expect(accordionNextAutoMove([])).toBeNull();
+  });
+
+  it('prefers an offset-3 merge over an offset-1 merge (matches GetHint priority)', () => {
+    // idx3 (SPADE 7) matches idx0 (SPADE 5) by suit at offset 3, and idx2
+    // (HEART 8) at offset 1; the offset-3 move must win.
+    const piles = [pile(card('SPADE', 5)), pile(card('HEART', 2)), pile(card('SPADE', 8)), pile(card('SPADE', 7))];
+    expect(accordionNextAutoMove(piles)).toEqual({ fromIdx: 3, toIdx: 0 });
+  });
+
+  it('picks the left-most legal offset-3 source', () => {
+    const piles = [
+      pile(card('SPADE', 5)),
+      pile(card('HEART', 2)),
+      pile(card('CLOVER', 8)),
+      pile(card('SPADE', 7)),
+      pile(card('DIAMOND', 1)),
+      pile(card('CLOVER', 9)),
+      pile(card('CLOVER', 4)),
+    ];
+    // idx3→idx0 (suit SPADE) and idx6→idx3? no; idx6 CLOVER matches idx3? SPADE no.
+    // Left-most offset-3 match is idx3→idx0.
+    expect(accordionNextAutoMove(piles)).toEqual({ fromIdx: 3, toIdx: 0 });
+  });
+
+  it('falls back to an offset-1 merge when no offset-3 merge exists', () => {
+    const piles = [pile(card('SPADE', 5)), pile(card('SPADE', 9))];
+    expect(accordionNextAutoMove(piles)).toEqual({ fromIdx: 1, toIdx: 0 });
+  });
+
+  it('matches by rank as well as suit', () => {
+    const piles = [pile(card('SPADE', 7)), pile(card('HEART', 7))];
+    expect(accordionNextAutoMove(piles)).toEqual({ fromIdx: 1, toIdx: 0 });
+  });
+
+  it('skips piles with empty tops', () => {
+    const piles = [pile(undefined), pile(card('SPADE', 9))];
+    expect(accordionNextAutoMove(piles)).toBeNull();
   });
 });

--- a/frontend/src/utils/accordionUtils.ts
+++ b/frontend/src/utils/accordionUtils.ts
@@ -32,3 +32,34 @@ export function accordionLegalTargets(piles: readonly AccordionPile[], fromIdx: 
 export function accordionLegalOffsets(piles: readonly AccordionPile[], fromIdx: number): number[] {
   return accordionLegalTargets(piles, fromIdx).map((toIdx) => fromIdx - toIdx);
 }
+
+/** A single Accordion merge move: fold pile `fromIdx` onto pile `toIdx`. */
+export interface AccordionAutoMove {
+  fromIdx: number;
+  toIdx: number;
+}
+
+/**
+ * Returns the next merge move the autocomplete driver (#3192) should apply, or
+ * `null` when no legal merge remains. This mirrors the backend's `GetHint`
+ * heuristic exactly (`internal/domain/Accordion.go`): prefer offset-3 merges
+ * over offset-1 (moving three back keeps more future options open), and within
+ * each offset pick the left-most legal source pile. Following this same
+ * well-defined recommendation repeatedly lets the frontend auto-play the game
+ * without inventing its own move policy, and always terminates because every
+ * merge removes one pile.
+ */
+export function accordionNextAutoMove(piles: readonly AccordionPile[]): AccordionAutoMove | null {
+  // Offset 3 before offset 1 — matches GetHint's priority ordering.
+  for (const offset of [3, 1]) {
+    for (let fromIdx = offset; fromIdx < piles.length; fromIdx++) {
+      const from = piles[fromIdx]?.cards[0];
+      const to = piles[fromIdx - offset]?.cards[0];
+      if (!from || !to) continue;
+      if (to.design === from.design || to.value === from.value) {
+        return { fromIdx, toIdx: fromIdx - offset };
+      }
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
Closes #3192

## Summary
Sibling solitaires (Scorpion / Wasp / Calculation) all expose an **autocomplete** button that one-clicks through forced/recommended moves; Accordion lacked it. This adds the same affordance, frontend-only.

Because Accordion has no backend `autocomplete` action (and this change is frontend-only), the button drives the existing single `move` action in a sequential loop — the exact pattern used by AcesUp's batch-discard (#3347):

- A pure helper `accordionNextAutoMove(piles)` (in `accordionUtils.ts`) returns the next merge to apply, **mirroring the backend `GetHint` heuristic exactly** (`internal/domain/Accordion.go`): prefer offset-3 merges over offset-1, and within each offset pick the left-most legal source pile.
- `handleAutoComplete` applies that move, re-reads the fresh board from the response, computes the next move, and repeats until no legal merge remains (or the game ends). It terminates because every merge removes one pile.
- A re-entry guard (`autoCompletingRef`) plus an `isAutoCompleting` busy gate block concurrent runs and disable interactive controls while the batch is in flight.
- The button is disabled (and its pulse cue suppressed) when no legal merge is available; it advertises the `a` keyboard shortcut.

Following the game's own hint recommendation keeps the driver well-defined rather than inventing a move policy.

## Changes
- `frontend/src/utils/accordionUtils.ts` — new `accordionNextAutoMove` helper + `AccordionAutoMove` type
- `frontend/src/pages/AccordionPage.tsx` — autocomplete button (`btnSuccess`), `a` shortcut, sequential driver, busy gating
- `frontend/src/i18n/locales/{ja,en}/accordion.json` — `autoComplete` + `kbd.autoComplete` keys (ja+en parity)
- Tests: `accordionUtils.test.ts` (helper: priority ordering, fallback, empty/no-match) + `AccordionPage.test.tsx` (drives merges in sequence until none remain; disabled when no move; `a` key)

## Checklist
- [x] Autocomplete enabled only when a legal merge remains; disabled otherwise
- [x] Existing giveup / undo / hint behaviour untouched
- [x] Frontend tests added (helper + page)
- [x] i18n ja+en parity
- [x] `bun run check` / `bun run test -- --run Accordion` (71 pass) / `bun run build` all green
- [ ] Backend autocomplete test — N/A, frontend-only (no Go changes)

## Test plan
- `cd frontend && bun run test -- --run Accordion`
- `bun run check && bun run build`