### PR TITLE
feat(piquet): add action-log panel and view toggle

### DIFF
--- a/frontend/src/pages/PiquetPage.test.tsx
+++ b/frontend/src/pages/PiquetPage.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { piquetApi } from '../api/gameApi';
+import { actionLogApi, piquetApi } from '../api/gameApi';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { PiquetResponse } from '../types/card';
 import { PiquetDeclarationKind, PiquetExchangeTurn, PiquetPhase } from '../types/phases';
@@ -12,6 +12,7 @@ vi.mock('../api/gameApi', () => ({
 }));
 
 const mockExec = vi.mocked(piquetApi.exec);
+const mockActionLog = vi.mocked(actionLogApi.piquet);
 
 function makeState(overrides: Partial<PiquetResponse> = {}): PiquetResponse {
   return {
@@ -274,5 +275,24 @@ describe('PiquetPage', () => {
     renderWithProviders(<PiquetPage />);
     const hint = await screen.findByTestId('piquet-hint');
     expect(hint).toHaveTextContent('1, 2');
+  });
+
+  it('does not show the action log view button before the partie ends', async () => {
+    mockExec.mockResolvedValue(makeState({ phase: PiquetPhase.PLAY }));
+    renderWithProviders(<PiquetPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalled());
+    expect(screen.queryByRole('button', { name: '棋譜を見る' })).not.toBeInTheDocument();
+  });
+
+  it('shows the action log view button at game end and renders fetched entries on click', async () => {
+    mockExec.mockResolvedValue(makeState({ phase: PiquetPhase.GAME_END, gameEndFlag: true, winnerIdx: 0 }));
+    mockActionLog.mockResolvedValue({
+      entries: [{ turnNumber: 1, playerIdx: 0, actionType: 'play', detail: 'plays a card' }],
+    });
+    renderWithProviders(<PiquetPage />);
+    const viewBtn = await screen.findByRole('button', { name: '棋譜を見る' });
+    fireEvent.click(viewBtn);
+    await waitFor(() => expect(mockActionLog).toHaveBeenCalled());
+    expect(await screen.findByText(/plays a card/)).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/PiquetPage.tsx
+++ b/frontend/src/pages/PiquetPage.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { ActionLogSection } from '../components/ActionLogSection';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
@@ -52,7 +53,8 @@ function declKindLabel(kind: number): string {
 export const PiquetPage = withTutorial(PiquetPageContent, 'piquet', PIQUET_TUTORIAL_STEPS);
 
 function PiquetPageContent() {
-  const { t, tc, confirmOpen, requestConfirm, confirmReset, cancelReset } = useGamePageSetup('piquet');
+  const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
+    useGamePageSetup('piquet');
   const game = usePiquetGame();
   const { state, loading, error, retry } = game;
   const { cardWidth } = useCardDimensions();
@@ -250,6 +252,13 @@ function PiquetPageContent() {
           {state.winnerIdx === -1 ? t('partieDraw') : t('partieWinner', { idx: state.winnerIdx })}
         </div>
       ) : null}
+
+      <ActionLogSection
+        isEndPhase={inGameEndPhase}
+        actionLog={actionLog}
+        showActionLog={showActionLog}
+        hideActionLog={hideActionLog}
+      />
     </GamePageShell>
   );
 }


### PR DESCRIPTION
Closes #3295

## Summary
Piquet was the only game missing the shared action-log panel. The domain + `PiquetWebPresenter.ActionLogOutput` (and the `actionLogApi.piquet` endpoint) already emit the log server-side; the page just never surfaced it. This wires the existing `<ActionLogSection>` into `PiquetPage`.

**Path A (pure frontend).** No Go / WASM changes. Action log is fetched by `useGamePageSetup('piquet')` → `useActionLog` → `actionLogApi.piquet()`; nothing in the response state schema changed.

## Changes
- `frontend/src/pages/PiquetPage.tsx`: destructure `actionLog` / `showActionLog` / `hideActionLog` from `useGamePageSetup`, render `<ActionLogSection isEndPhase={inGameEndPhase} …>` at the bottom of the shell.
- `frontend/src/pages/PiquetPage.test.tsx`: assert the "view log" button is hidden mid-game, shown at game end, and that clicking it fetches + renders the log entries.

## Checklist
- [x] Path A — frontend only, WASM-neutral (no Go touched)
- [x] Action-log entries render on demand; empty/mid-game state hides the panel
- [x] Existing i18n reused (`common.actionLog.*`) — ja/en parity already present
- [x] `bun run check` clean (pre-existing holdem warnings only)
- [x] `bun run test -- --run Piquet` — 63 passed
- [x] `bun run build` (tsc) green