### PR TITLE
feat(badugi): note that bet-limit and meta-AI settings apply from the next hand

### DIFF
--- a/frontend/src/i18n/locales/en/badugi.json
+++ b/frontend/src/i18n/locales/en/badugi.json
@@ -22,7 +22,9 @@
   "subsetExchange": "exchange candidate",
   "settings": {
     "title": "Settings",
-    "cpuMetaAI": "Meta-AI (CPUs learn your style)"
+    "cpuMetaAI": "Meta-AI (CPUs learn your style)",
+    "bettingLimitHelp": "Changing the limit does not affect the current hand; it applies from the next reset (new hand).",
+    "cpuMetaAIHelp": "Changing Meta-AI does not affect the current hand; it applies from the next reset (new hand)."
   },
   "bestCards": "Best cards",
   "tutorial": {

--- a/frontend/src/i18n/locales/ja/badugi.json
+++ b/frontend/src/i18n/locales/ja/badugi.json
@@ -22,7 +22,9 @@
   "subsetExchange": "交換候補",
   "settings": {
     "title": "設定",
-    "cpuMetaAI": "メタAI（CPUがプレイスタイルを学習）"
+    "cpuMetaAI": "メタAI（CPUがプレイスタイルを学習）",
+    "bettingLimitHelp": "リミットの変更は現在のハンドには反映されず、次のリセット（新しいハンド）から適用されます。",
+    "cpuMetaAIHelp": "メタAIの変更は現在のハンドには反映されず、次のリセット（新しいハンド）から適用されます。"
   },
   "bestCards": "ベスト手札",
   "tutorial": {

--- a/frontend/src/pages/BadugiPage.test.tsx
+++ b/frontend/src/pages/BadugiPage.test.tsx
@@ -214,6 +214,24 @@ describe('BadugiPage', () => {
     );
   });
 
+  it('exposes next-hand application notes for the betting-limit and meta-AI settings', async () => {
+    mockExec.mockResolvedValue(baseState({ phase: BadugiPhase.END, gameEndFlag: true }));
+    renderWithProviders(<BadugiPage />);
+    const summary = await screen.findByText('設定');
+    fireEvent.click(summary);
+
+    // Each setting exposes a (?) help button that reveals a note explaining the
+    // change only takes effect from the next reset (new hand).
+    const helpButtons = await screen.findAllByRole('button', { name: '説明を表示' });
+    expect(helpButtons.length).toBeGreaterThanOrEqual(2);
+
+    fireEvent.click(helpButtons[0]);
+    expect(screen.getByText(/リミットの変更は現在のハンドには反映されず/)).toBeInTheDocument();
+
+    fireEvent.click(helpButtons[1]);
+    expect(screen.getByText(/メタAIの変更は現在のハンドには反映されず/)).toBeInTheDocument();
+  });
+
   it('shows the complete-Badugi banner and pulses the stand button when the hand is already a 4-card Badugi', async () => {
     // The default humanPlayer() has 4 distinct ranks AND 4 distinct suits → complete Badugi.
     mockExec.mockResolvedValue(baseState({ phase: BadugiPhase.DRAW, drawIndex: 1, currentTurn: 0 }));

--- a/frontend/src/pages/BadugiPage.tsx
+++ b/frontend/src/pages/BadugiPage.tsx
@@ -437,6 +437,7 @@ function BadugiPageContent() {
                       type: 'select',
                       id: 'badugiBettingLimit',
                       label: tc('betting.bettingLimit'),
+                      tooltip: t('settings.bettingLimitHelp'),
                       value: bettingLimit,
                       options: [
                         { value: 0, label: tc('betting.fixed') },
@@ -449,6 +450,7 @@ function BadugiPageContent() {
                       type: 'checkbox',
                       id: 'badugiCpuMetaAI',
                       label: t('settings.cpuMetaAI'),
+                      tooltip: t('settings.cpuMetaAIHelp'),
                       checked: cpuMetaAI,
                       onToggle: setCpuMetaAI,
                     },


### PR DESCRIPTION
Closes #3175

## 背景
`BadugiPage.tsx` の `SettingsPanel` にある `bettingLimit`（リミット）と `cpuMetaAI`（メタAI）は、`handleManualReset` 内でしか `reset` に渡されないため、進行中のハンド中に変更しても次のリセット（新しいハンド）まで反映されない。しかし UI 上にその旨の説明がなく、即時反映されると誤解されうる。

## 変更内容（フロントエンドのみ・純粋な追加）
- `SettingsPanel` の該当2項目（リミット / メタAI）に `tooltip`（(?) ヘルプ）を追加し、「現在のハンドには反映されず、次のリセット（新しいハンド）から適用されます」と説明。既存の nertz/trash の `settings.*Help` ツールチップ方式と同じパターン。
- i18n キーを追加（ja / en 両対応）: `settings.bettingLimitHelp`, `settings.cpuMetaAIHelp`。
- 設定の適用タイミングや reset 動作自体は一切変更していない（表示テキストのみ追加）。
- Go には触れていない。

## テスト
- 追加テスト: `exposes next-hand application notes for the betting-limit and meta-AI settings`（設定パネルを開き、各 (?) ヘルプから次ハンド適用の説明テキストが表示されることを検証）。

## 受け入れ条件
- [x] `bettingLimit` と `cpuMetaAI` の UI 要素に適用タイミングの説明が表示される
- [x] 既存の設定変更・リセット動作自体は変更しない
- [x] `BadugiPage.test.tsx` に説明テキストの表示を検証するテストを追加

## Gate
- [x] `bun run check`（exit 0）
- [x] `bun run test -- --run Badugi`（54 passed）
- [x] `bun run build`