### PR TITLE
feat(rook): show highest bid and active bidders during bid turn

### DIFF
--- a/frontend/src/i18n/locales/en/rook.json
+++ b/frontend/src/i18n/locales/en/rook.json
@@ -19,6 +19,12 @@
   "pointsSuffix": " pts",
   "currentTrick": "Current trick",
   "trickEmpty": "(no cards yet)",
+  "bidStatus": {
+    "highest": "Highest bid: {{value}}",
+    "highestNone": "Highest bid: undecided",
+    "remaining": "Active bidders: {{n}}",
+    "passed": "Passed: {{names}}"
+  },
   "selectBid": "Select bid (70-120):",
   "bidButton": "Bid",
   "passButton": "Pass",

--- a/frontend/src/i18n/locales/ja/rook.json
+++ b/frontend/src/i18n/locales/ja/rook.json
@@ -19,6 +19,12 @@
   "pointsSuffix": "点",
   "currentTrick": "現在のトリック",
   "trickEmpty": "(まだカードがありません)",
+  "bidStatus": {
+    "highest": "現在最高: {{value}}点",
+    "highestNone": "現在最高: 未決定",
+    "remaining": "残り入札者: {{n}}人",
+    "passed": "パス済み: {{names}}"
+  },
   "selectBid": "ビッドを選択 (70-120):",
   "bidButton": "ビッド",
   "passButton": "パス",

--- a/frontend/src/pages/RookPage.test.tsx
+++ b/frontend/src/pages/RookPage.test.tsx
@@ -105,6 +105,40 @@ describe('RookPage', () => {
     expect(values).toEqual(['95', '100', '105', '110', '115', '120']);
   });
 
+  it('shows the bid status with the highest bid and active bidder count on the human bid turn', async () => {
+    mockExec.mockResolvedValue(
+      makeState({
+        highestBid: 80,
+        highestBidder: 2,
+        players: [
+          player(0, true, [card('5', 5)]),
+          player(1, false, [], { passed: true }),
+          player(2, false, []),
+          player(3, false, []),
+        ] as RookResponse['players'],
+      }),
+    );
+    renderWithProviders(<RookPage />);
+    const status = await screen.findByTestId('rook-bid-status');
+    expect(status).toHaveTextContent('現在最高: 80点');
+    expect(status).toHaveTextContent('残り入札者: 3人');
+    expect(status).toHaveTextContent('パス済み: CPU 1');
+  });
+
+  it('shows the bid status as undecided when no bid has been made yet', async () => {
+    renderWithProviders(<RookPage />);
+    const status = await screen.findByTestId('rook-bid-status');
+    expect(status).toHaveTextContent('現在最高: 未決定');
+    expect(status).toHaveTextContent('残り入札者: 4人');
+  });
+
+  it('hides the bid status outside the bid phase', async () => {
+    mockExec.mockResolvedValue(makeState({ phase: 2, currentPlayerIdx: 0, contractBid: 75, trumpColor: 1 }));
+    renderWithProviders(<RookPage />);
+    await screen.findByTestId('play-button');
+    expect(screen.queryByTestId('rook-bid-status')).not.toBeInTheDocument();
+  });
+
   it('passes when pass is clicked', async () => {
     renderWithProviders(<RookPage />);
     fireEvent.click(await screen.findByTestId('pass-button'));

--- a/frontend/src/pages/RookPage.tsx
+++ b/frontend/src/pages/RookPage.tsx
@@ -23,6 +23,8 @@ import { RookPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { formatRookState, parseRookCommand, ROOK_HELP, type RookCliArgs } from '../utils/cli/commands/rookCommands';
 import type { CliGameConfig } from '../utils/cli/types';
+import { playerName } from '../utils/playerUtils';
+import { rookBidStatus } from '../utils/rookBidStatus';
 
 const CPU_DIFFICULTY_SELECT = [
   { value: '0', label: 'Easy' },
@@ -163,6 +165,10 @@ function RookPageContent() {
   const bidOptions: number[] = [];
   for (let v = minSelectableBid; v <= ROOK_MAX_BID; v += ROOK_BID_STEP) bidOptions.push(v);
   const effectiveBid = bidOptions.includes(bidValue) ? bidValue : (bidOptions[0] ?? ROOK_MIN_BID);
+
+  // Bid-turn context: the standing high bid plus who is still in the auction.
+  const bidStatus = rookBidStatus(state.players);
+  const passedNames = bidStatus.passed.map((p) => playerName(p.id, p.isHuman)).join(', ');
 
   const handleExchange = () => {
     if (selectedCardIndices.length === ROOK_DISCARD_COUNT && trumpChoice !== null) {
@@ -352,6 +358,19 @@ function RookPageContent() {
             <div className="flex gap-2 justify-center flex-wrap items-center" data-tutorial="rook-actions">
               {isHumanBidTurn && (
                 <>
+                  <div
+                    className="w-full text-center text-xs text-ds-text-muted space-y-0.5"
+                    data-testid="rook-bid-status"
+                  >
+                    <div>
+                      {state.highestBid > 0
+                        ? t('bidStatus.highest', { value: state.highestBid })
+                        : t('bidStatus.highestNone')}
+                      {' · '}
+                      {t('bidStatus.remaining', { n: bidStatus.activeBidders })}
+                    </div>
+                    {passedNames && <div>{t('bidStatus.passed', { names: passedNames })}</div>}
+                  </div>
                   <label
                     htmlFor="rook-bid"
                     className="text-xs text-ds-text-muted self-center"

--- a/frontend/src/utils/rookBidStatus.test.ts
+++ b/frontend/src/utils/rookBidStatus.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import type { RookPlayerData } from '../types/card';
+import { rookBidStatus } from './rookBidStatus';
+
+const p = (id: number, isHuman: boolean, passed: boolean): RookPlayerData =>
+  ({ id, isHuman, passed }) as RookPlayerData;
+
+describe('rookBidStatus', () => {
+  it('counts every player as active when nobody has passed', () => {
+    const status = rookBidStatus([p(0, true, false), p(1, false, false), p(2, false, false), p(3, false, false)]);
+    expect(status.activeBidders).toBe(4);
+    expect(status.passed).toEqual([]);
+  });
+
+  it('lists passed players and reduces the active count', () => {
+    const status = rookBidStatus([p(0, true, false), p(1, false, true), p(2, false, false), p(3, false, true)]);
+    expect(status.activeBidders).toBe(2);
+    expect(status.passed).toEqual([
+      { id: 1, isHuman: false },
+      { id: 3, isHuman: false },
+    ]);
+  });
+
+  it('handles all players having passed', () => {
+    const status = rookBidStatus([p(0, true, true), p(1, false, true)]);
+    expect(status.activeBidders).toBe(0);
+    expect(status.passed).toHaveLength(2);
+  });
+});

--- a/frontend/src/utils/rookBidStatus.ts
+++ b/frontend/src/utils/rookBidStatus.ts
@@ -1,0 +1,25 @@
+import type { RookPlayerData } from '../types/card';
+
+/** A lightweight identifier for a player who has dropped out of the bidding. */
+export interface RookPassedPlayer {
+  id: number;
+  isHuman: boolean;
+}
+
+/** Bidding status derived from the Rook players, for the bid-turn readout. */
+export interface RookBidStatus {
+  /** Number of players still in the bidding (have not passed). */
+  activeBidders: number;
+  /** Players who have passed (dropped out of the bidding), in seat order. */
+  passed: RookPassedPlayer[];
+}
+
+/**
+ * Derive the current bidding status from the Rook players: how many are still
+ * in the auction and which ones have passed. Pure — formatting/i18n is left to
+ * the caller.
+ */
+export function rookBidStatus(players: RookPlayerData[]): RookBidStatus {
+  const passed = players.filter((p) => p.passed).map((p) => ({ id: p.id, isHuman: p.isHuman }));
+  return { activeBidders: players.length - passed.length, passed };
+}


### PR DESCRIPTION
## Summary
During the human bid turn in Rook, the footer only offered a bare list of bid values — the current highest bid and who was still in the auction were not visible without scanning the CPU info area. This adds an additive status readout above the bid selector so the human bids with full context.

The panel (`data-testid="rook-bid-status"`) shows:
- Current highest bid, or "undecided" (未決定) when no bid has been made yet
- Number of players still in the bidding (active bidders)
- Names of players who have passed (localized), when any

All values derive from existing `state.highestBid` and per-player `passed` fields — no backend change.

## Changes
- `frontend/src/utils/rookBidStatus.ts` (+ test) — pure helper deriving active-bidder count and passed players
- `frontend/src/pages/RookPage.tsx` — render the bid-status panel on the human bid turn only
- `frontend/src/i18n/locales/{ja,en}/rook.json` — new `bidStatus.*` keys (ja/en parity verified)
- `frontend/src/pages/RookPage.test.tsx` — panel shows highest bid + active count + passed names; shows "undecided" pre-bid; hidden outside the bid phase

## Test plan
- [x] `bun run test -- --run Rook` (37 passed)
- [x] `bun run check` (exit 0)
- [x] `bun run build` (exit 0)
- [x] ja/en i18n key parity

Closes #3515