### PR TITLE
fix(cassino): consolidate to a single hint source

### DIFF
--- a/frontend/src/pages/CassinoPage.test.tsx
+++ b/frontend/src/pages/CassinoPage.test.tsx
@@ -384,6 +384,51 @@ describe('CassinoPage', () => {
     expect(screen.queryByTestId('cs-suggest-button')).not.toBeInTheDocument();
   });
 
+  it('shows the advisory hint tooltip when hints are enabled and no selection-based suggestion is active', async () => {
+    localStorage.setItem('hint_enabled_cassino', 'true');
+    renderWithProviders(<CassinoPage />);
+    // No hand card selected → no concrete suggestion → the single advisory hint shows.
+    await waitFor(() => expect(screen.getByTestId('hint-tooltip')).toBeInTheDocument());
+    expect(screen.queryByTestId('cs-suggest-button')).not.toBeInTheDocument();
+    localStorage.removeItem('hint_enabled_cassino');
+  });
+
+  it('consolidates guidance to a single source: the suggestion supersedes the advisory hint tooltip', async () => {
+    localStorage.setItem('hint_enabled_cassino', 'true');
+    mockExec.mockResolvedValue(
+      makeState({
+        players: [
+          {
+            id: 0,
+            isHuman: true,
+            cardCount: 2,
+            cards: [card('SPADE', 9), card('CLOVER', 2)],
+            capturedCount: 0,
+            sweepCount: 0,
+            totalScore: 0,
+          },
+          { id: 1, isHuman: false, cardCount: 4, cards: [], capturedCount: 0, sweepCount: 0, totalScore: 0 },
+          { id: 2, isHuman: false, cardCount: 4, cards: [], capturedCount: 0, sweepCount: 0, totalScore: 0 },
+          { id: 3, isHuman: false, cardCount: 4, cards: [], capturedCount: 0, sweepCount: 0, totalScore: 0 },
+        ],
+        tableCards: [card('SPADE', 4), card('HEART', 5)],
+      }),
+    );
+    renderWithProviders(<CassinoPage />);
+    // With hints enabled and nothing selected, the advisory tooltip is the sole hint.
+    await waitFor(() => expect(screen.getByTestId('hint-tooltip')).toBeInTheDocument());
+
+    // Selecting cards that sum to the played card produces a concrete take suggestion.
+    fireEvent.click(screen.getByTestId('hand-card-0'));
+    fireEvent.click(screen.getByTestId('table-card-0'));
+    fireEvent.click(screen.getByTestId('table-card-1'));
+
+    // The actionable suggestion now supersedes the advisory tooltip: exactly one hint shows.
+    await waitFor(() => expect(screen.getByTestId('cs-suggest-button')).toBeInTheDocument());
+    expect(screen.queryByTestId('hint-tooltip')).not.toBeInTheDocument();
+    localStorage.removeItem('hint_enabled_cassino');
+  });
+
   it('renders CLI terminal when CLI mode is enabled via localStorage', async () => {
     localStorage.setItem('cli-mode-cassino', 'true');
     renderWithProviders(<CassinoPage />);

--- a/frontend/src/pages/CassinoPage.tsx
+++ b/frontend/src/pages/CassinoPage.tsx
@@ -349,7 +349,15 @@ function CassinoPageContent() {
               messageCode={state.messageCode}
               messageParams={state.messageParams}
             />
-            {frontendHintEnabled && frontendHint && (
+            {/*
+             * Single hint surface: the registry-driven advisory hint (`getCassinoHint`,
+             * mirroring the domain heuristic) and the selection-derived one-click
+             * suggestion are mutually exclusive. When the player's current selection
+             * already forms a concrete take/build, that actionable suggestion supersedes
+             * the generic advisory so only ONE piece of guidance is ever shown and the
+             * two can never contradict each other.
+             */}
+            {frontendHintEnabled && frontendHint && !suggestion && (
               <HintTooltip reason={t(frontendHint.reason)} confidence={frontendHint.confidence} />
             )}
           </div>


### PR DESCRIPTION
## Summary

Closes #3202.

`CassinoPage.tsx` previously rendered **two independent guidance mechanisms** that could contradict each other:

1. **Advisory hint** — `getCassinoHint` (the shared registry hint that mirrors the domain heuristic) rendered via `HintTooltip`, gated by the hint toggle.
2. **Selection suggestion** — `suggestCassinoAction` (`cassinoUtils.ts`) rendered as the pulsing `cs-suggest-button` with one-click execute.

Because the two are computed by different logic, they could recommend conflicting actions simultaneously (e.g. tooltip says "trail" while the button says "Take (9)"), leaving the player unsure which to trust.

## Change

Consolidate the display to a **single guidance element at any time**: the concrete, selection-derived suggestion supersedes the generic advisory tooltip. When the player's current selection already forms a valid take/build, only the actionable suggestion shows; otherwise the advisory `HintTooltip` shows. They can therefore never coexist or contradict.

- **Kept (authoritative advisory source):** `getCassinoHint` → `HintTooltip` (mirrors the domain heuristic, part of the shared hint registry).
- **Kept (action shortcut):** `suggestCassinoAction` one-click execute button — unchanged behavior, still always available for the player's own selection.
- **Consolidation:** the advisory tooltip is suppressed while a concrete suggestion is active (`&& !suggestion`).
- Hint toggle UX preserved; no i18n keys removed; no Go touched.

## Test plan

- [x] `bun run check` (biome + design-tokens) — passes
- [x] `bun run test -- --run Cassino` — 84 passed
- [x] `bun run build` (tsc) — passes
- New tests in `CassinoPage.test.tsx`:
  - `shows the advisory hint tooltip when hints are enabled and no selection-based suggestion is active`
  - `consolidates guidance to a single source: the suggestion supersedes the advisory hint tooltip`

🤖 Generated with [Claude Code](https://claude.com/claude-code)