### PR TITLE
feat(handandfoot): show selected meld point total and initial-meld minimum during meld phase

### DIFF
--- a/frontend/src/i18n/locales/en/handandfoot.json
+++ b/frontend/src/i18n/locales/en/handandfoot.json
@@ -34,6 +34,10 @@
   "drawStockButton": "Draw from stock",
   "drawDiscardButton": "Pick up discard",
   "meldButton": "Meld",
+  "meldPoints": {
+    "initial": "Min initial meld: {{min}} / selected: {{points}}",
+    "selected": "Selected: {{points}}"
+  },
   "skipMeldButton": "Skip",
   "discardButton": "Discard",
   "goOutButton": "Go out",

--- a/frontend/src/i18n/locales/ja/handandfoot.json
+++ b/frontend/src/i18n/locales/ja/handandfoot.json
@@ -34,6 +34,10 @@
   "drawStockButton": "山札から引く",
   "drawDiscardButton": "捨て札を取る",
   "meldButton": "メルドする",
+  "meldPoints": {
+    "initial": "初回メルド最低点: {{min}} / 選択合計: {{points}}",
+    "selected": "選択合計: {{points}}"
+  },
   "skipMeldButton": "スキップ",
   "discardButton": "捨てる",
   "goOutButton": "上がる",

--- a/frontend/src/pages/HandAndFootPage.test.tsx
+++ b/frontend/src/pages/HandAndFootPage.test.tsx
@@ -189,6 +189,55 @@ describe('HandAndFootPage', () => {
     expect(screen.getByRole('button', { name: 'スキップ' })).toBeInTheDocument();
   });
 
+  it('shows the initial-meld minimum and updates the running total as cards are selected', async () => {
+    // Team 0 has no melds and cumulative score 0 -> initial-meld minimum is 50.
+    mockExec.mockResolvedValue(meldPhaseState);
+    renderWithProviders(<HandAndFootPage />);
+    await waitFor(() => expect(screen.getByTestId('hf-meld-points')).toBeInTheDocument());
+    const readout = screen.getByTestId('hf-meld-points');
+    // Nothing selected: total 0, below the 50 minimum -> warning styling.
+    expect(readout).toHaveTextContent('初回メルド最低点: 50 / 選択合計: 0');
+    expect(readout.className).toContain('text-ds-warning');
+
+    // Select the two 10s (10 points each) -> running total 20.
+    fireEvent.click(screen.getByRole('button', { name: '♠ 10' }));
+    fireEvent.click(screen.getByRole('button', { name: '♣ 10' }));
+    await waitFor(() => expect(screen.getByTestId('hf-meld-points')).toHaveTextContent('選択合計: 20'));
+    expect(screen.getByTestId('hf-meld-points')).toHaveTextContent('初回メルド最低点: 50 / 選択合計: 20');
+  });
+
+  it('highlights the readout in success when the selection meets the minimum', async () => {
+    // Negative cumulative score -> minimum 15; selecting the two 10s totals 20.
+    mockExec.mockResolvedValue({
+      ...meldPhaseState,
+      players: [{ ...basePlayers[0], cumulativeScore: -10 }, basePlayers[1]],
+    });
+    renderWithProviders(<HandAndFootPage />);
+    await waitFor(() => expect(screen.getByTestId('hf-meld-points')).toBeInTheDocument());
+    // Nothing selected yet: 0 < 15 -> warning.
+    expect(screen.getByTestId('hf-meld-points').className).toContain('text-ds-warning');
+    fireEvent.click(screen.getByRole('button', { name: '♠ 10' }));
+    fireEvent.click(screen.getByRole('button', { name: '♣ 10' }));
+    await waitFor(() => expect(screen.getByTestId('hf-meld-points')).toHaveTextContent('選択合計: 20'));
+    expect(screen.getByTestId('hf-meld-points').className).toContain('text-ds-success');
+  });
+
+  it('shows only the selected total once the team has already opened', async () => {
+    mockExec.mockResolvedValue({
+      ...meldPhaseState,
+      teams: [
+        { team: 0, melds: [{ cards: [], isNatural: true, isCanasta: false, rank: 7 }], red3Count: 0, red3s: [] },
+        { team: 1, melds: [], red3Count: 0, red3s: [] },
+      ],
+    });
+    renderWithProviders(<HandAndFootPage />);
+    await waitFor(() => expect(screen.getByTestId('hf-meld-points')).toBeInTheDocument());
+    const readout = screen.getByTestId('hf-meld-points');
+    expect(readout).toHaveTextContent('選択合計: 0');
+    expect(readout).not.toHaveTextContent('初回メルド最低点');
+    expect(readout.className).toContain('text-ds-text-muted');
+  });
+
   it('calls skipmeld command when skip button clicked', async () => {
     mockExec.mockResolvedValue(meldPhaseState);
     renderWithProviders(<HandAndFootPage />);

--- a/frontend/src/pages/HandAndFootPage.tsx
+++ b/frontend/src/pages/HandAndFootPage.tsx
@@ -27,6 +27,7 @@ import { gameTheme } from '../styles/gameTheme';
 import type { HandAndFootResponse } from '../types/card';
 import { HandAndFootPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { canastaMinMeld, canastaSelectionPoints } from '../utils/canastaScore';
 import { cardAlt } from '../utils/cardAlt';
 import { HANDANDFOOT_HELP, parseHandAndFootCommand } from '../utils/cli/commands/handandfootCommands';
 import { formatHandAndFootState } from '../utils/cli/formatters/handandfootFormatter';
@@ -130,6 +131,24 @@ function HandAndFootPageContent() {
     if (blackCanastas < 1) return { canGoOut: false, reasonKey: 'goOutReason.needBlackCanasta' };
     return { canGoOut: true, reasonKey: 'goOutReason.ready' };
   }, [isDiscardPhase, humanPlayer, state?.teams]);
+
+  // Meld phase: show the selected cards' running point total and, until the
+  // team has opened (no melds yet), the initial-meld minimum so the player can
+  // tell if the selection qualifies. Point values + minimum bands mirror the
+  // shared Canasta-family scoring (the backend uses CanastaCardValue); the web
+  // build does not enforce the minimum, so this is a display-only readout.
+  const meldPointInfo = useMemo(() => {
+    if (!isMeldPhase || !humanPlayer) return null;
+    const selectedCards = selectedCardIndices
+      .map((i) => humanPlayer.cards[i])
+      .filter((c): c is NonNullable<typeof c> => !!c);
+    const selectedPoints = canastaSelectionPoints(selectedCards);
+    const team = state?.teams.find((tm) => tm.team === humanPlayer.team);
+    const needInitial = (team?.melds.length ?? 0) === 0;
+    const minMeld = canastaMinMeld(humanPlayer.cumulativeScore);
+    const met = selectedPoints >= minMeld;
+    return { selectedPoints, needInitial, minMeld, met, below: needInitial && !met };
+  }, [isMeldPhase, humanPlayer, selectedCardIndices, state?.teams]);
 
   const handleManualReset = useCallback(() => {
     hideActionLog();
@@ -418,11 +437,32 @@ function HandAndFootPageContent() {
               )}
               {isMeldPhase && isHumanTurn && (
                 <>
+                  {meldPointInfo && (
+                    <div
+                      id="hf-meld-points"
+                      data-testid="hf-meld-points"
+                      className={`w-full text-xs ${
+                        meldPointInfo.below
+                          ? 'text-ds-warning'
+                          : meldPointInfo.needInitial
+                            ? 'text-ds-success'
+                            : 'text-ds-text-muted'
+                      }`}
+                    >
+                      {meldPointInfo.needInitial
+                        ? t('meldPoints.initial', {
+                            min: meldPointInfo.minMeld,
+                            points: meldPointInfo.selectedPoints,
+                          })
+                        : t('meldPoints.selected', { points: meldPointInfo.selectedPoints })}
+                    </div>
+                  )}
                   <button
                     type="button"
                     className={btnPrimary}
                     onClick={handleMeldSelected}
                     disabled={loading || selectedCardIndices.length < 3}
+                    aria-describedby={meldPointInfo?.below ? 'hf-meld-points' : undefined}
                   >
                     {t('meldButton')}
                   </button>


### PR DESCRIPTION
## Summary

During the MELD phase of Hand and Foot, the page previously only disabled the meld button when fewer than 3 cards were selected — the player got no feedback on whether their selection met the initial-meld point minimum until the server rejected it. This adds a live, display-only readout next to the meld actions:

- Shows the running point total of the currently selected cards, updated on every selection.
- Until the team has opened (no melds on the table yet), also shows the initial-meld minimum and colour-codes the readout: **warning** when below the minimum, **success** once it is met.
- Once the team has already opened, shows only the selected total (muted styling).

This is display-only and does not change meld enforcement (the Hand and Foot domain intentionally does not enforce the initial-meld minimum — see its GoDoc).

## Point values & threshold source

- Card point values reuse `frontend/src/utils/canastaScore.ts` (`canastaSelectionPoints`), which mirrors the backend `CanastaCardValue` exactly (Joker 50; A/2 20; 8–K 10; 4–7 & black-3 5). Hand and Foot's domain uses the same `CanastaCardValue`.
- The initial-meld minimum uses the shared `canastaMinMeld(cumulativeScore)` band table (15/50/90/120), the established Canasta-family minimum already used by the Canasta and Samba pages. Hand and Foot is documented as following the Canasta implementation; `cumulativeScore` is exposed per player in the response.
- "Team opened" is derived from whether the human's team has any melds (`teams[].melds.length`).

No Go was touched. No point values were invented.

## Test plan

- [x] `bun run check` (biome lint + format + design-tokens)
- [x] `bun run test -- --run HandAndFoot` (39 passed) — new tests cover: initial-meld min + running total updates on selection; success styling when the selection meets the minimum; selected-only readout after the team has opened
- [x] `bun run build` (tsc)

Closes #3469