### PR TITLE
feat(prsi): add sound effects for card play, draw, and errors

### DIFF
--- a/frontend/src/pages/PrsiPage.test.tsx
+++ b/frontend/src/pages/PrsiPage.test.tsx
@@ -11,6 +11,16 @@ vi.mock('../api/gameApi', () => ({
   actionLogApi: { prsi: vi.fn() },
 }));
 
+const mockPlaySound = vi.fn();
+const mockSoundValue = { playSound: mockPlaySound, muted: false, toggleMute: vi.fn() };
+vi.mock('../providers/SoundProvider', () => ({
+  SoundProvider: ({ children }: { children: React.ReactNode }) => children,
+  useSound: () => mockSoundValue,
+  // AnimatedCard consumes useOptionalSound; return null so cards stay silent
+  // and only the page's explicit playSound calls are asserted.
+  useOptionalSound: () => null,
+}));
+
 const mockExec = vi.mocked(prsiApi.exec);
 
 const playPhaseState: PrsiResponse = {
@@ -73,6 +83,7 @@ const noDiscardState: PrsiResponse = {
 
 beforeEach(() => {
   mockExec.mockResolvedValue(playPhaseState);
+  mockPlaySound.mockReset();
 });
 
 describe('PrsiPage', () => {
@@ -365,5 +376,60 @@ describe('PrsiPage', () => {
   it('renders accessible h1 heading', async () => {
     renderWithProviders(<PrsiPage />);
     await waitFor(() => expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument());
+  });
+
+  it('plays the card-place sound when a card is played', async () => {
+    renderWithProviders(<PrsiPage />);
+    await waitFor(() => expect(screen.getByAltText('♠ A')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByAltText('♠ A').closest('button') as HTMLButtonElement);
+    mockPlaySound.mockClear();
+    fireEvent.click(screen.getByRole('button', { name: '出す' }));
+
+    expect(mockPlaySound).toHaveBeenCalledWith('cardPlace');
+  });
+
+  it('plays the shuffle sound when a card is drawn', async () => {
+    renderWithProviders(<PrsiPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: '引く' })).toBeInTheDocument());
+
+    mockPlaySound.mockClear();
+    fireEvent.click(screen.getByRole('button', { name: '引く' }));
+
+    expect(mockPlaySound).toHaveBeenCalledWith('shuffle');
+  });
+
+  it('plays the shuffle sound when drawing via the stock pile', async () => {
+    renderWithProviders(<PrsiPage />);
+    const stock = await screen.findByTestId('prsi-stock');
+
+    mockPlaySound.mockClear();
+    fireEvent.click(stock);
+
+    expect(mockPlaySound).toHaveBeenCalledWith('shuffle');
+  });
+
+  it('does not play the card-place sound when no single card is selected', async () => {
+    renderWithProviders(<PrsiPage />);
+    await waitFor(() => expect(screen.getByAltText('♠ A')).toBeInTheDocument());
+
+    // No card selected: keyboard Enter triggers play, which must stay silent.
+    mockPlaySound.mockClear();
+    fireEvent.keyDown(document, { key: 'Enter' });
+
+    expect(mockPlaySound).not.toHaveBeenCalledWith('cardPlace');
+  });
+
+  it('plays the error buzz when an action fails', async () => {
+    renderWithProviders(<PrsiPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'リセット' })).not.toBeDisabled());
+
+    mockExec.mockReset();
+    mockExec.mockRejectedValue(new Error('network error'));
+    mockPlaySound.mockClear();
+    fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
+
+    await waitFor(() => expect(mockPlaySound).toHaveBeenCalledWith('errorBuzz'));
   });
 });

--- a/frontend/src/pages/PrsiPage.tsx
+++ b/frontend/src/pages/PrsiPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import type { prsiApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
@@ -92,6 +92,32 @@ function PrsiPageContent() {
   } = useGameHint('prsi', state);
   const { cardWidth } = useCardDimensions();
   const { playSound } = useSound();
+
+  // Play a distinct buzz the moment an illegal move / network error surfaces,
+  // so the failure is audible (respects the global mute via SoundProvider).
+  const prevErrorRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (error && error !== prevErrorRef.current) {
+      playSound('errorBuzz');
+    }
+    prevErrorRef.current = error;
+  }, [error, playSound]);
+
+  // Card-operation SFX: place a card on play, shuffle on draw. Fired on the
+  // human's own action only (the play/draw controls render solely on the
+  // human turn), mirroring SpiteAndMalicePage's fire-and-forget approach.
+  const handlePlayWithSound = useCallback(() => {
+    if (selectedCardIndices.length === 1) {
+      playSound('cardPlace');
+    }
+    handlePlay();
+  }, [handlePlay, playSound, selectedCardIndices]);
+
+  const handleDrawWithSound = useCallback(() => {
+    playSound('shuffle');
+    handleDraw();
+  }, [handleDraw, playSound]);
+
   // CLI mode
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('prsi');
   const cliConfig: CliGameConfig<PrsiResponse, Parameters<typeof prsiApi.exec>> = useMemo(
@@ -110,8 +136,8 @@ function PrsiPageContent() {
   const humanCardCountForKbd = state?.players.find((p) => p.isHuman)?.cards?.length ?? 0;
 
   const confirmAction = useCallback(() => {
-    handlePlay();
-  }, [handlePlay]);
+    handlePlayWithSound();
+  }, [handlePlayWithSound]);
 
   const handleManualReset = useCallback(() => {
     hideActionLog();
@@ -213,7 +239,7 @@ function PrsiPageContent() {
                     <button
                       type="button"
                       data-testid="prsi-stock"
-                      onClick={handleDraw}
+                      onClick={handleDrawWithSound}
                       disabled={!isHumanTurn || loading || state.drawPileCount === 0}
                       aria-label={t('stockAria', { count: state.drawPileCount })}
                       className={`relative ${focusRingCard} ${
@@ -326,12 +352,12 @@ function PrsiPageContent() {
                   <button
                     type="button"
                     className={btnPrimary}
-                    onClick={handlePlay}
+                    onClick={handlePlayWithSound}
                     disabled={loading || selectedCardIndices.length !== 1}
                   >
                     {t('playButton')}
                   </button>
-                  <button type="button" className={btnPrimary} onClick={handleDraw} disabled={loading}>
+                  <button type="button" className={btnPrimary} onClick={handleDrawWithSound} disabled={loading}>
                     {t('drawButton')}
                   </button>
                 </div>


### PR DESCRIPTION
## Summary

Prší (`prsi`) previously imported `useSound` only to pass `winFanfare` to the celebration overlay — play, draw, and error actions were silent. This wires the existing `SoundProvider` into the high-frequency card operations, mirroring `SpiteAndMalicePage`'s fire-and-forget pattern.

- **Play** a card → `cardPlace` (gated on exactly one selected card, matching `handlePlay`'s own guard; covers both the button and the keyboard-Enter path via `confirmAction`)
- **Draw** a card → `shuffle` (both the draw button and the clickable stock pile)
- **Error** (illegal move / network failure) → `errorBuzz`, fired via a `useEffect` that detects the `error` transition

All playback goes through `SoundProvider`, so the existing mute / SoundToggle setting is respected. No new audio assets — only existing sound keys. No behavior change beyond sound; `data-testid` attributes unaffected.

## Test plan
- [x] `bun run check` (biome lint + format) — passes, no prsi issues
- [x] `bun run test -- --run src/pages/PrsiPage.test.tsx` — 39/39 pass
- [x] `bun run build` (tsc) — passes
- [x] New tests mock `SoundProvider` (`useSound` + `useOptionalSound`) and assert `playSound` is called with `cardPlace` / `shuffle` / `errorBuzz`, and NOT called when no single card is selected

Closes #3596

🤖 Generated with [Claude Code](https://claude.com/claude-code)