### PR TITLE
feat(slapjack): add sound effects for slap outcome and card flips

### DIFF
--- a/frontend/src/pages/SlapjackPage.test.tsx
+++ b/frontend/src/pages/SlapjackPage.test.tsx
@@ -26,6 +26,16 @@ vi.mock('../api/gameApi', () => ({
   actionLogApi: { slapjack: vi.fn() },
 }));
 
+const mockPlaySound = vi.fn();
+const mockSoundValue = { playSound: mockPlaySound, muted: false, toggleMute: vi.fn() };
+vi.mock('../providers/SoundProvider', () => ({
+  SoundProvider: ({ children }: { children: React.ReactNode }) => children,
+  useSound: () => mockSoundValue,
+  // AnimatedCard consumes useOptionalSound; return null so cards stay silent
+  // and only the page's explicit playSound calls are asserted.
+  useOptionalSound: () => null,
+}));
+
 const mockExec = vi.mocked(slapjackApi.exec);
 
 const baseState: SlapjackResponse = {
@@ -68,6 +78,7 @@ const gameEndState: SlapjackResponse = {
 };
 
 beforeEach(() => {
+  mockPlaySound.mockClear();
   mockExec.mockResolvedValue(baseState);
   mockUseCliMode.mockReturnValue({
     cliEnabled: false,
@@ -251,5 +262,45 @@ describe('SlapjackPage', () => {
     mockExec.mockClear();
     fireEvent.keyDown(window, { key: 'Enter' });
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('step'));
+  });
+
+  it('plays a card sound when the human flips via the step button', async () => {
+    renderWithProviders(<SlapjackPage />);
+    await waitFor(() => expect(screen.getByTestId('step-button')).toBeInTheDocument());
+    mockPlaySound.mockClear();
+    fireEvent.click(screen.getByTestId('step-button'));
+    expect(mockPlaySound).toHaveBeenCalledWith('cardPlace');
+  });
+
+  it('plays a fanfare on the human’s correct slap', async () => {
+    mockExec.mockResolvedValueOnce({
+      ...baseState,
+      lastEventKind: SlapjackEventKind.SLAP_CORRECT,
+      lastEventPlayerIdx: 0,
+    });
+    renderWithProviders(<SlapjackPage />);
+    await waitFor(() => expect(mockPlaySound).toHaveBeenCalledWith('winFanfare'));
+  });
+
+  it('plays an error buzz on the human’s false slap', async () => {
+    mockExec.mockResolvedValueOnce({
+      ...baseState,
+      lastEventKind: SlapjackEventKind.SLAP_WRONG,
+      lastEventPlayerIdx: 0,
+    });
+    renderWithProviders(<SlapjackPage />);
+    await waitFor(() => expect(mockPlaySound).toHaveBeenCalledWith('errorBuzz'));
+  });
+
+  it('stays silent for a CPU slap event (only the human’s slaps make sound)', async () => {
+    mockExec.mockResolvedValueOnce({
+      ...baseState,
+      lastEventKind: SlapjackEventKind.SLAP_CORRECT,
+      lastEventPlayerIdx: 1,
+    });
+    renderWithProviders(<SlapjackPage />);
+    await waitFor(() => expect(screen.getByTestId('slap-button')).toBeInTheDocument());
+    expect(mockPlaySound).not.toHaveBeenCalledWith('winFanfare');
+    expect(mockPlaySound).not.toHaveBeenCalledWith('errorBuzz');
   });
 });

--- a/frontend/src/pages/SlapjackPage.tsx
+++ b/frontend/src/pages/SlapjackPage.tsx
@@ -25,6 +25,7 @@ import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useMountReset } from '../hooks/useMountReset';
 import { useReflexShortcuts } from '../hooks/useReflexShortcuts';
 import i18n from '../i18n';
+import { useSound } from '../providers/SoundProvider';
 import { gameTheme } from '../styles/gameTheme';
 import type { SlapjackResponse } from '../types/card';
 import { SlapjackEventKind, SlapjackPhase } from '../types/phases';
@@ -70,13 +71,19 @@ function SlapjackPageContent() {
     useGamePageSetup('slapjack');
   const { state, loading, error, exec: execApi, retry } = useGameApi(slapjackApi.exec);
   const { cardWidth } = useCardDimensions();
+  const { playSound } = useSound();
   const {
     hint: frontendHint,
     hintEnabled: frontendHintEnabled,
     setHintEnabled: setFrontendHintEnabled,
   } = useGameHint('slapjack', state);
 
-  const handleStep = useCallback(() => execApi('step'), [execApi]);
+  // Flipping the next card onto the arena is the human's tap — give it a card
+  // sound (respects the global mute via SoundProvider).
+  const handleStep = useCallback(() => {
+    playSound('cardPlace');
+    return execApi('step');
+  }, [execApi, playSound]);
   const handleSlap = useCallback(() => execApi('slap'), [execApi]);
   const handleReset = useCallback(() => execApi('reset'), [execApi]);
 
@@ -111,9 +118,15 @@ function SlapjackPageContent() {
       setSlapBurst((prevBurst) => ({ key: prevBurst.key + 1, outcome, label }));
       const slapper = player === 0 ? tc('player.you') : tc('player.cpu', { id: player });
       setSlapAnnounce(t(`slapjack.slapAnnounce.${outcome}`, { player: slapper }));
+      // Sound only for the human's own slap so a fanfare never celebrates the
+      // CPU (and a buzz never blames the player for the CPU's miss). Mute is
+      // handled globally by SoundProvider.
+      if (player === 0) {
+        playSound(outcome === 'correct' ? 'winFanfare' : 'errorBuzz');
+      }
       prevSlapEventRef.current = { kind, player };
     }
-  }, [state, t, tc]);
+  }, [state, t, tc, playSound]);
 
   useMountReset(execApi);
 
@@ -176,6 +189,7 @@ function SlapjackPageContent() {
       gamePath="/slapjack"
       gameEndFlag={isGameEnd}
       winShow={humanWon}
+      onCelebrate={() => playSound('winFanfare')}
       loading={loading}
       confirmOpen={confirmOpen}
       confirmReset={confirmReset}


### PR DESCRIPTION
Closes #3223

## Summary
Slapjack was fully silent — slap success/failure and card flips relied only on the `SlapBurst` visual. This wires `useSound` (following the prsi #4228 pattern) so the reflex game gives audio feedback, respecting the global `SoundProvider` mute.

## Changes
- **Card flip (`handleStep`)** → `cardPlace`.
- **Correct slap** (`SLAP_CORRECT`) → `winFanfare`; **false slap** (`SLAP_WRONG`) → `errorBuzz`, played in the existing `prevSlapEventRef` outcome effect.
- Slap sounds are **gated to the human** (`lastEventPlayerIdx === 0`) so a fanfare never celebrates the CPU's slap and a buzz never blames the player for the CPU's miss. The `SlapBurst` visual still fires for both players (unchanged).
- **Win celebration** → `winFanfare` via `GamePageShell`'s `onCelebrate`.

## How slap success/failure is distinguished
From the response state: `state.lastEventKind` is `SlapjackEventKind.SLAP_CORRECT` vs `SLAP_WRONG`, with `state.lastEventPlayerIdx` identifying the slapper.

## Tests (`SlapjackPage.test.tsx`)
Added a `SoundProvider` mock (exports `useSound` + `useOptionalSound` returning null, since the page renders `AnimatedCard`) and 4 cases:
- human flip → `cardPlace`
- human correct slap → `winFanfare`
- human false slap → `errorBuzz`
- CPU slap → no sound

## Checklist
- [x] `bun run check` (biome) — no Slapjack findings
- [x] `bun run test -- --run Slapjack` — 36 passed
- [x] `bun run build` (tsc) — passes
- [x] Frontend-only; no Go, no new asset files