### PR TITLE
feat(bakersdozen): add card-move and reset sound effects

### DIFF
--- a/frontend/src/pages/BakersDozenPage.test.tsx
+++ b/frontend/src/pages/BakersDozenPage.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { bakersDozenApi } from '../api/gameApi';
 import { useGameHint } from '../hooks/useGameHint';
@@ -9,6 +10,15 @@ import { BakersDozenPage } from './BakersDozenPage';
 vi.mock('../api/gameApi', () => ({
   bakersDozenApi: { exec: vi.fn() },
   actionLogApi: { bakersdozen: vi.fn() },
+}));
+
+const mockPlaySound = vi.fn();
+vi.mock('../providers/SoundProvider', () => ({
+  SoundProvider: ({ children }: { children: ReactNode }) => children,
+  useSound: () => ({ playSound: mockPlaySound, muted: false, toggleMute: vi.fn() }),
+  // AnimatedCard consumes useOptionalSound; return null so cards stay silent
+  // and only the page's explicit playSound calls are asserted.
+  useOptionalSound: () => null,
 }));
 
 vi.mock('../hooks/useGameHint', () => ({
@@ -72,6 +82,7 @@ const gameOverState: BakersDozenResponse = {
 describe('BakersDozenPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockPlaySound.mockReset();
     vi.mocked(useGameHint).mockReturnValue({ hint: null, hintEnabled: false, setHintEnabled: vi.fn() });
   });
 
@@ -271,5 +282,38 @@ describe('BakersDozenPage', () => {
     mockExec.mockResolvedValue(playingState);
     renderWithProviders(<BakersDozenPage />);
     await waitFor(() => expect(mockExec.mock.calls.some((c) => c[0] === 'reset')).toBe(true));
+  });
+
+  it('plays the cardPlace sound when a move succeeds (moveCount advances)', async () => {
+    mockExec.mockResolvedValue(playingState);
+    renderWithProviders(<BakersDozenPage />);
+    const source = await screen.findByRole('button', { name: '♠ 5' });
+    fireEvent.click(source);
+    mockPlaySound.mockClear();
+    // The move resolves with an advanced moveCount, signalling a server-confirmed move.
+    mockExec.mockResolvedValue({ ...playingState, moveCount: 4 });
+    fireEvent.click(screen.getByRole('button', { name: '♥ 6' }));
+    await waitFor(() => expect(mockPlaySound).toHaveBeenCalledWith('cardPlace'));
+  });
+
+  it('stays silent (no cardPlace) and buzzes when a move fails', async () => {
+    mockExec.mockResolvedValueOnce(playingState); // initial reset succeeds
+    renderWithProviders(<BakersDozenPage />);
+    const source = await screen.findByRole('button', { name: '♠ 5' });
+    fireEvent.click(source);
+    mockPlaySound.mockClear();
+    mockExec.mockRejectedValue(new Error('illegal move')); // move rejects → moveCount unchanged
+    fireEvent.click(screen.getByRole('button', { name: '♥ 6' }));
+    await waitFor(() => expect(mockPlaySound).toHaveBeenCalledWith('errorBuzz'));
+    expect(mockPlaySound).not.toHaveBeenCalledWith('cardPlace');
+  });
+
+  it('plays the shuffle sound when starting a new game via reset', async () => {
+    mockExec.mockResolvedValue(gameOverState);
+    renderWithProviders(<BakersDozenPage />);
+    const nextBtn = await screen.findByRole('button', { name: '次のゲーム' });
+    mockPlaySound.mockClear();
+    fireEvent.click(nextBtn);
+    expect(mockPlaySound).toHaveBeenCalledWith('shuffle');
   });
 });

--- a/frontend/src/pages/BakersDozenPage.tsx
+++ b/frontend/src/pages/BakersDozenPage.tsx
@@ -112,6 +112,31 @@ function BakersDozenPageContent() {
     isAutoCompleting,
   } = useBakersDozenGame();
 
+  // Card-move SFX: play `cardPlace` whenever the server confirms a successful
+  // move by advancing moveCount. Keying off moveCount (rather than firing in the
+  // click handler) means illegal moves — which leave moveCount unchanged — stay
+  // silent, and each auto-complete batch that lands a card is also covered.
+  // Respects the global mute via SoundProvider.
+  const prevMoveCountRef = useRef<number | null>(null);
+  useEffect(() => {
+    const moveCount = state?.moveCount;
+    if (moveCount == null) return;
+    if (prevMoveCountRef.current !== null && moveCount > prevMoveCountRef.current) {
+      playSound('cardPlace');
+    }
+    prevMoveCountRef.current = moveCount;
+  }, [state?.moveCount, playSound]);
+
+  // Play a distinct buzz the moment an illegal move / network error surfaces,
+  // so the failure is audible (mirrors PrsiPage; respects the global mute).
+  const prevErrorRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (error && error !== prevErrorRef.current) {
+      playSound('errorBuzz');
+    }
+    prevErrorRef.current = error;
+  }, [error, playSound]);
+
   const {
     hint: frontendHint,
     hintEnabled: frontendHintEnabled,
@@ -179,7 +204,8 @@ function BakersDozenPageContent() {
   const handleManualReset = useCallback(() => {
     hideActionLog();
     handleReset();
-  }, [handleReset, hideActionLog]);
+    playSound('shuffle');
+  }, [handleReset, hideActionLog, playSound]);
 
   // Give-up is irreversible, so route both the button and the `g` key through
   // the confirm dialog — matching reset's guard (issue #2099).


### PR DESCRIPTION
## 概要

ベーカーズ・ダズン (`bakersdozen`) の操作フィードバックに効果音を追加します。これまで `BakersDozenPage.tsx` は `useSound` を import しつつ勝利時の `winFanfare` しか鳴らしておらず、兄弟のソリティア (`MonteCarloPage`) と比べて操作音のフィードバックが不足していました。

## 変更内容

- **カード移動成功時に `cardPlace`** — サーバが移動を確定 (`moveCount` が増加) したタイミングで再生。クリック移動・ドラッグ移動・オートコンプリートの連続配置すべてを一箇所でカバー。
- **移動失敗時は無音 + `errorBuzz`** — 不正な移動は `moveCount` が変わらないため `cardPlace` は鳴らず、エラー発生時は `errorBuzz` で失敗を可聴化 (`PrsiPage` を踏襲)。
- **リセット時に `shuffle`** — `handleManualReset` に追加 (`MonteCarloPage` を踏襲)。
- すべての効果音は `SoundProvider` 経由なので、グローバルなミュート設定に従います。

追加 Go 変更・音声アセット追加はありません (既存キーのみ使用)。

## 受け入れ条件

- [x] カード移動成功時に cardPlace 音が鳴る
- [x] リセット時に shuffle 音が鳴る
- [x] 移動エラー時には音が鳴らない
- [x] SoundProvider のミュート設定に従う
- [x] テストで playSound 呼び出しを検証する

## テスト

`frontend/src/pages/BakersDozenPage.test.tsx` に 3 ケース追加:
- `plays the cardPlace sound when a move succeeds (moveCount advances)`
- `stays silent (no cardPlace) and buzzes when a move fails`
- `plays the shuffle sound when starting a new game via reset`

## ゲート

- `bun run check` — pass (exit 0、既存の warning は無関係な holdem テスト)
- `bun run test -- --run BakersDozen` — 51 passed
- `bun run build` — pass

Closes #3231