### PR TITLE
feat(fiftyone): integrate sound effects

### DIFF
--- a/frontend/src/pages/FiftyOnePage.test.tsx
+++ b/frontend/src/pages/FiftyOnePage.test.tsx
@@ -20,6 +20,14 @@ vi.mock('../api/gameApi', () => ({
   fiftyoneApi: { exec: (...args: unknown[]) => mockExec(...args) },
 }));
 
+const mockPlaySound = vi.fn();
+const mockSoundValue = { playSound: mockPlaySound, muted: false, toggleMute: vi.fn() };
+vi.mock('../providers/SoundProvider', () => ({
+  SoundProvider: ({ children }: { children: React.ReactNode }) => children,
+  useSound: () => mockSoundValue,
+  useOptionalSound: () => mockSoundValue,
+}));
+
 const baseState: FiftyOneResponse = {
   players: [
     {
@@ -177,6 +185,43 @@ describe('FiftyOnePage', () => {
     renderWithProviders(<FiftyOnePage />);
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
     expect(screen.queryByText(/を選択してください/)).not.toBeInTheDocument();
+  });
+
+  it('plays a card-place sound when exchanging all cards', async () => {
+    const { FiftyOnePage } = await import('./FiftyOnePage');
+    renderWithProviders(<FiftyOnePage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+
+    fireEvent.click(screen.getByTestId('exchange-all-button'));
+    expect(mockPlaySound).toHaveBeenCalledWith('cardPlace');
+  });
+
+  it('plays a card-place sound when exchanging a single selected card', async () => {
+    const { FiftyOnePage } = await import('./FiftyOnePage');
+    renderWithProviders(<FiftyOnePage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+
+    fireEvent.click(screen.getByRole('button', { name: '♠ A' }));
+    fireEvent.click(screen.getByRole('button', { name: '♠ K' }));
+    mockPlaySound.mockClear();
+    fireEvent.click(screen.getByTestId('exchange-button'));
+    expect(mockPlaySound).toHaveBeenCalledWith('cardPlace');
+  });
+
+  it('plays a chip-click sound when calling stop', async () => {
+    const { FiftyOnePage } = await import('./FiftyOnePage');
+    renderWithProviders(<FiftyOnePage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+
+    fireEvent.click(screen.getByTestId('stop-button'));
+    expect(mockPlaySound).toHaveBeenCalledWith('chipClick');
+  });
+
+  it('plays an error buzz when the api call fails', async () => {
+    mockExec.mockRejectedValueOnce(new Error('boom'));
+    const { FiftyOnePage } = await import('./FiftyOnePage');
+    renderWithProviders(<FiftyOnePage />);
+    await waitFor(() => expect(mockPlaySound).toHaveBeenCalledWith('errorBuzz'));
   });
 
   it('renders suit score badges and highlights the leading suit', async () => {

--- a/frontend/src/pages/FiftyOnePage.tsx
+++ b/frontend/src/pages/FiftyOnePage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { fiftyoneApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
@@ -20,6 +20,7 @@ import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useMountReset } from '../hooks/useMountReset';
+import { useSound } from '../providers/SoundProvider';
 import { gameTheme } from '../styles/gameTheme';
 import type { FiftyOneResponse } from '../types/card';
 import { FiftyOnePhase } from '../types/phases';
@@ -72,6 +73,7 @@ function FiftyOnePageContent() {
   const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
     useGamePageSetup('fiftyone');
   const { state, loading, error, exec: execApi, retry } = useGameApi(fiftyoneApi.exec);
+  const { playSound } = useSound();
   const { cardWidth } = useCardDimensions();
   const [cpuDifficulty, setCpuDifficulty] = useState(1);
   const [selectedHandIdx, setSelectedHandIdx] = useState<number | null>(null);
@@ -86,21 +88,33 @@ function FiftyOnePageContent() {
 
   const handleExchange = useCallback(() => {
     if (selectedHandIdx !== null && selectedTableIdx !== null) {
+      playSound('cardPlace');
       execApi('play', { handIdx: selectedHandIdx, tableIdx: selectedTableIdx });
       setSelectedHandIdx(null);
       setSelectedTableIdx(null);
     }
-  }, [execApi, selectedHandIdx, selectedTableIdx]);
+  }, [execApi, playSound, selectedHandIdx, selectedTableIdx]);
 
   const handleExchangeAll = useCallback(() => {
+    playSound('cardPlace');
     execApi('exchangeall');
     setSelectedHandIdx(null);
     setSelectedTableIdx(null);
-  }, [execApi]);
+  }, [execApi, playSound]);
 
-  const handleStop = useCallback(() => execApi('stop'), [execApi]);
+  const handleStop = useCallback(() => {
+    playSound('chipClick');
+    return execApi('stop');
+  }, [execApi, playSound]);
 
   useMountReset(execApi);
+
+  // Buzz once on the error appearance edge so a fast follow-up doesn't swallow it.
+  const prevErrorRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (error && !prevErrorRef.current) playSound('errorBuzz');
+    prevErrorRef.current = error;
+  }, [error, playSound]);
 
   // CLI mode
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('fiftyone');
@@ -175,6 +189,7 @@ function FiftyOnePageContent() {
       gamePath="/fiftyone"
       gameEndFlag={isGameEnd}
       winShow={humanWon}
+      onCelebrate={() => playSound('winFanfare')}
       loading={loading}
       confirmOpen={confirmOpen}
       confirmReset={confirmReset}


### PR DESCRIPTION
## Summary
Wires `useSound` into `FiftyOnePage`, mirroring the just-merged Prší / Baker's Dozen pattern, so Fifty-One finally has audio feedback like other games.

Sound keys:
- `cardPlace` — on `handleExchange` (single card) and `handleExchangeAll`
- `chipClick` — on `handleStop` (dedicated stop-declaration cue)
- `winFanfare` — on human win, via `GamePageShell`'s `onCelebrate`
- `errorBuzz` — on the api-error appearance edge (`prevErrorRef` effect)

All playback respects the global mute in `SoundProvider` / `SettingsPanel`.

## Acceptance criteria
- [x] `handleExchange` / `handleExchangeAll` play a sound
- [x] `handleStop` plays a dedicated sound (`chipClick`)
- [x] `winFanfare` plays on human win
- [x] Mute via `SettingsPanel` still applies (handled by `SoundProvider`)

## Test plan
- [x] Added page tests: exchange-all → `cardPlace`, single exchange → `cardPlace`, stop → `chipClick`, api error → `errorBuzz` (SoundProvider mocked exporting both `useSound` and `useOptionalSound`)
- [x] `bun run test -- --run FiftyOne` (31 passed)
- [x] `bun run check` (exit 0)
- [x] `bun run build` (tsc gate, exit 0)

Frontend-only. No Go or audio-asset changes.

Closes #3149