### PR TITLE
feat(caribbeanstud): add persistent session stats summary

### DIFF
--- a/frontend/src/hooks/useCaribbeanStudStats.test.ts
+++ b/frontend/src/hooks/useCaribbeanStudStats.test.ts
@@ -1,0 +1,133 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  CARIBBEANSTUD_HISTORY_KEY,
+  CARIBBEANSTUD_HISTORY_MAX,
+  CaribbeanStudOutcome,
+  type CaribbeanStudRecord,
+  outcomeFromResult,
+  readCaribbeanStudHistory,
+  tallyCaribbeanStudHistory,
+  useCaribbeanStudStats,
+} from './useCaribbeanStudStats';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('outcomeFromResult', () => {
+  it('maps a positive result to WIN', () => {
+    expect(outcomeFromResult(1)).toBe(CaribbeanStudOutcome.WIN);
+  });
+  it('maps a negative result to LOSS', () => {
+    expect(outcomeFromResult(-1)).toBe(CaribbeanStudOutcome.LOSS);
+  });
+  it('maps a zero result to PUSH', () => {
+    expect(outcomeFromResult(0)).toBe(CaribbeanStudOutcome.PUSH);
+  });
+});
+
+describe('tallyCaribbeanStudHistory', () => {
+  it('counts wins, losses, pushes, hands, and net chips', () => {
+    const tally = tallyCaribbeanStudHistory([
+      { outcome: CaribbeanStudOutcome.WIN, net: 300 },
+      { outcome: CaribbeanStudOutcome.LOSS, net: -100 },
+      { outcome: CaribbeanStudOutcome.WIN, net: 200 },
+      { outcome: CaribbeanStudOutcome.PUSH, net: 0 },
+    ]);
+    expect(tally).toEqual({ wins: 2, losses: 1, pushes: 1, hands: 4, net: 400 });
+  });
+  it('returns zeros for empty history', () => {
+    expect(tallyCaribbeanStudHistory([])).toEqual({ wins: 0, losses: 0, pushes: 0, hands: 0, net: 0 });
+  });
+});
+
+describe('readCaribbeanStudHistory', () => {
+  it('returns [] when nothing is stored', () => {
+    expect(readCaribbeanStudHistory()).toEqual([]);
+  });
+  it('returns [] on corrupt (non-JSON) data', () => {
+    localStorage.setItem(CARIBBEANSTUD_HISTORY_KEY, 'not json{');
+    expect(readCaribbeanStudHistory()).toEqual([]);
+  });
+  it('returns [] when the stored value is not an array', () => {
+    localStorage.setItem(CARIBBEANSTUD_HISTORY_KEY, JSON.stringify({ wins: 3 }));
+    expect(readCaribbeanStudHistory()).toEqual([]);
+  });
+  it('filters out records with invalid shape', () => {
+    localStorage.setItem(
+      CARIBBEANSTUD_HISTORY_KEY,
+      JSON.stringify([
+        { outcome: CaribbeanStudOutcome.WIN, net: 100 },
+        { outcome: 9, net: 100 }, // invalid outcome code
+        { outcome: CaribbeanStudOutcome.LOSS, net: 'x' }, // invalid net
+        { outcome: CaribbeanStudOutcome.PUSH, net: Number.NaN }, // non-finite net
+        42, // not an object
+      ]),
+    );
+    expect(readCaribbeanStudHistory()).toEqual([{ outcome: CaribbeanStudOutcome.WIN, net: 100 }]);
+  });
+});
+
+describe('useCaribbeanStudStats', () => {
+  it('recording a win increments the tally and net', () => {
+    const { result } = renderHook(() => useCaribbeanStudStats());
+    expect(result.current.tally).toEqual({ wins: 0, losses: 0, pushes: 0, hands: 0, net: 0 });
+    act(() => {
+      result.current.recordRound({ outcome: CaribbeanStudOutcome.WIN, net: 250 });
+    });
+    expect(result.current.tally).toEqual({ wins: 1, losses: 0, pushes: 0, hands: 1, net: 250 });
+  });
+
+  it('accumulates wins, losses, and pushes with signed net', () => {
+    const { result } = renderHook(() => useCaribbeanStudStats());
+    act(() => {
+      result.current.recordRound({ outcome: CaribbeanStudOutcome.WIN, net: 200 });
+    });
+    act(() => {
+      result.current.recordRound({ outcome: CaribbeanStudOutcome.LOSS, net: -300 });
+    });
+    act(() => {
+      result.current.recordRound({ outcome: CaribbeanStudOutcome.PUSH, net: 0 });
+    });
+    expect(result.current.tally).toEqual({ wins: 1, losses: 1, pushes: 1, hands: 3, net: -100 });
+  });
+
+  it('persists the history to localStorage', () => {
+    const { result } = renderHook(() => useCaribbeanStudStats());
+    act(() => {
+      result.current.recordRound({ outcome: CaribbeanStudOutcome.WIN, net: 120 });
+    });
+    const stored: CaribbeanStudRecord[] = JSON.parse(localStorage.getItem(CARIBBEANSTUD_HISTORY_KEY) ?? '[]');
+    expect(stored).toEqual([{ outcome: CaribbeanStudOutcome.WIN, net: 120 }]);
+  });
+
+  it('rehydrates the history from localStorage on mount', () => {
+    localStorage.setItem(CARIBBEANSTUD_HISTORY_KEY, JSON.stringify([{ outcome: CaribbeanStudOutcome.LOSS, net: -50 }]));
+    const { result } = renderHook(() => useCaribbeanStudStats());
+    expect(result.current.tally).toEqual({ wins: 0, losses: 1, pushes: 0, hands: 1, net: -50 });
+  });
+
+  it('clearHistory empties the tally and removes the storage key', () => {
+    const { result } = renderHook(() => useCaribbeanStudStats());
+    act(() => {
+      result.current.recordRound({ outcome: CaribbeanStudOutcome.WIN, net: 90 });
+    });
+    act(() => {
+      result.current.clearHistory();
+    });
+    expect(result.current.tally).toEqual({ wins: 0, losses: 0, pushes: 0, hands: 0, net: 0 });
+    expect(localStorage.getItem(CARIBBEANSTUD_HISTORY_KEY)).toBeNull();
+  });
+
+  it('caps the stored history at CARIBBEANSTUD_HISTORY_MAX', () => {
+    const { result } = renderHook(() => useCaribbeanStudStats());
+    act(() => {
+      for (let i = 0; i < CARIBBEANSTUD_HISTORY_MAX + 5; i++) {
+        result.current.recordRound({ outcome: CaribbeanStudOutcome.WIN, net: 10 });
+      }
+    });
+    expect(result.current.history).toHaveLength(CARIBBEANSTUD_HISTORY_MAX);
+    expect(result.current.tally.hands).toBe(CARIBBEANSTUD_HISTORY_MAX);
+  });
+});

--- a/frontend/src/hooks/useCaribbeanStudStats.ts
+++ b/frontend/src/hooks/useCaribbeanStudStats.ts
@@ -1,0 +1,118 @@
+import { useCallback, useMemo, useState } from 'react';
+
+/** localStorage key for the Caribbean Stud session round history. */
+export const CARIBBEANSTUD_HISTORY_KEY = 'trumpcards-caribbeanstud-history';
+
+/** Maximum number of recent round records retained in localStorage. */
+export const CARIBBEANSTUD_HISTORY_MAX = 200;
+
+/**
+ * Numeric outcome codes for a completed Caribbean Stud round. `WIN`/`LOSS` are the
+ * signed hand results; `PUSH` is a tie (dealer qualified and hands compared equal).
+ */
+export const CaribbeanStudOutcome = {
+  PUSH: 0,
+  WIN: 1,
+  LOSS: 2,
+} as const;
+
+/** A single outcome code (one of the `CaribbeanStudOutcome` values). */
+export type CaribbeanStudOutcomeCode = (typeof CaribbeanStudOutcome)[keyof typeof CaribbeanStudOutcome];
+
+/** One recorded round: its win/loss/push outcome plus the net chip delta. */
+export interface CaribbeanStudRecord {
+  outcome: CaribbeanStudOutcomeCode;
+  net: number;
+}
+
+/** Session tallies aggregated over a history slice. */
+export interface CaribbeanStudTally {
+  wins: number;
+  losses: number;
+  pushes: number;
+  /** Total rounds recorded (wins + losses + pushes). */
+  hands: number;
+  /** Cumulative net chip result across all recorded rounds. */
+  net: number;
+}
+
+/** Maps a round's signed `result` to an outcome code (>0 win, <0 loss, 0 push). */
+export function outcomeFromResult(result: number): CaribbeanStudOutcomeCode {
+  if (result > 0) return CaribbeanStudOutcome.WIN;
+  if (result < 0) return CaribbeanStudOutcome.LOSS;
+  return CaribbeanStudOutcome.PUSH;
+}
+
+function isOutcomeCode(value: unknown): value is CaribbeanStudOutcomeCode {
+  return (
+    value === CaribbeanStudOutcome.WIN || value === CaribbeanStudOutcome.LOSS || value === CaribbeanStudOutcome.PUSH
+  );
+}
+
+function isRecord(value: unknown): value is CaribbeanStudRecord {
+  if (typeof value !== 'object' || value === null) return false;
+  const r = value as Record<string, unknown>;
+  return isOutcomeCode(r.outcome) && typeof r.net === 'number' && Number.isFinite(r.net);
+}
+
+/** Reads and validates the round history from localStorage; returns [] on any error. */
+export function readCaribbeanStudHistory(): CaribbeanStudRecord[] {
+  try {
+    const raw = localStorage.getItem(CARIBBEANSTUD_HISTORY_KEY);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(isRecord);
+  } catch {
+    return [];
+  }
+}
+
+/** Folds a history slice into win / loss / push counts and cumulative net. */
+export function tallyCaribbeanStudHistory(history: readonly CaribbeanStudRecord[]): CaribbeanStudTally {
+  const tally: CaribbeanStudTally = { wins: 0, losses: 0, pushes: 0, hands: 0, net: 0 };
+  for (const rec of history) {
+    if (rec.outcome === CaribbeanStudOutcome.WIN) tally.wins += 1;
+    else if (rec.outcome === CaribbeanStudOutcome.LOSS) tally.losses += 1;
+    else tally.pushes += 1;
+    tally.hands += 1;
+    tally.net += rec.net;
+  }
+  return tally;
+}
+
+/**
+ * Hook that persists the Caribbean Stud session round history in localStorage.
+ * `recordRound` appends one finished round (the caller records each round only
+ * once), capping the stored history at `CARIBBEANSTUD_HISTORY_MAX`.
+ * `clearHistory` empties it. `tally` is the derived win / loss / push counts and
+ * cumulative net chips over the full history.
+ */
+export function useCaribbeanStudStats() {
+  const [history, setHistory] = useState<CaribbeanStudRecord[]>(readCaribbeanStudHistory);
+
+  const recordRound = useCallback((record: CaribbeanStudRecord) => {
+    setHistory((prev) => {
+      const next = [...prev, record].slice(-CARIBBEANSTUD_HISTORY_MAX);
+      try {
+        localStorage.setItem(CARIBBEANSTUD_HISTORY_KEY, JSON.stringify(next));
+      } catch {
+        /* storage unavailable / quota exceeded */
+      }
+      return next;
+    });
+  }, []);
+
+  const clearHistory = useCallback(() => {
+    setHistory([]);
+    try {
+      localStorage.removeItem(CARIBBEANSTUD_HISTORY_KEY);
+    } catch {
+      /* storage unavailable */
+    }
+  }, []);
+
+  const tally = useMemo(() => tallyCaribbeanStudHistory(history), [history]);
+
+  return { history, tally, recordRound, clearHistory };
+}

--- a/frontend/src/i18n/locales/en/caribbeanstud.json
+++ b/frontend/src/i18n/locales/en/caribbeanstud.json
@@ -82,5 +82,13 @@
     "aceKingHigh": "Ace-King high — call recommended",
     "weakHand": "Weak hand — fold recommended"
   },
-  "hiddenCard": "Hidden card"
+  "hiddenCard": "Hidden card",
+  "session": {
+    "title": "Session Stats",
+    "tally": "{{wins}}W {{losses}}L {{pushes}}P",
+    "hands": "{{hands}} hands",
+    "net": "Net",
+    "clear": "Clear history",
+    "note": "Kept across resets (cleared on page reload)"
+  }
 }

--- a/frontend/src/i18n/locales/ja/caribbeanstud.json
+++ b/frontend/src/i18n/locales/ja/caribbeanstud.json
@@ -82,5 +82,13 @@
     "aceKingHigh": "A-K ハイ — コール推奨",
     "weakHand": "弱い手札 — フォールド推奨"
   },
-  "hiddenCard": "非公開のカード"
+  "hiddenCard": "非公開のカード",
+  "session": {
+    "title": "セッション成績",
+    "tally": "{{wins}}勝 {{losses}}敗 {{pushes}}分",
+    "hands": "{{hands}}ハンド",
+    "net": "収支",
+    "clear": "履歴をクリア",
+    "note": "リセットしても保持されます（ページ再読み込みで消去）"
+  }
 }

--- a/frontend/src/pages/CaribbeanStudPage.test.tsx
+++ b/frontend/src/pages/CaribbeanStudPage.test.tsx
@@ -315,4 +315,71 @@ describe('CaribbeanStudPage', () => {
     renderWithProviders(<CaribbeanStudPage />);
     await waitFor(() => expect(screen.getByTestId('hint-tooltip')).toBeInTheDocument());
   });
+
+  describe('session stats', () => {
+    it('has no session summary before any round completes', async () => {
+      mockApi.mockResolvedValue(betPhaseState);
+      renderWithProviders(<CaribbeanStudPage />);
+      await waitFor(() => expect(screen.getByText('チップ: 1000')).toBeInTheDocument());
+      expect(screen.queryByTestId('csp-session-stats')).not.toBeInTheDocument();
+    });
+
+    it('records a win at END and shows the tally + positive net', async () => {
+      // net = totalPayout(1000) - (ante 100 + jackpot 0 + play 200) = +700
+      mockApi.mockResolvedValue(endPhasePlayerWins);
+      renderWithProviders(<CaribbeanStudPage />);
+      await waitFor(() => expect(screen.getByTestId('csp-session-stats')).toBeInTheDocument());
+      expect(screen.getByTestId('csp-session-tally')).toHaveTextContent('1勝 0敗 0分');
+      const netEl = screen.getByTestId('csp-session-net');
+      expect(netEl).toHaveTextContent('収支: +700');
+      expect(netEl).toHaveClass('text-ds-success');
+    });
+
+    it('records a loss at END and shows a negative net', async () => {
+      // net = totalPayout(0) - (ante 100 + jackpot 0 + play 200) = -300
+      mockApi.mockResolvedValue(endPhaseDealerWins);
+      renderWithProviders(<CaribbeanStudPage />);
+      await waitFor(() => expect(screen.getByTestId('csp-session-stats')).toBeInTheDocument());
+      expect(screen.getByTestId('csp-session-tally')).toHaveTextContent('0勝 1敗 0分');
+      const netEl = screen.getByTestId('csp-session-net');
+      expect(netEl).toHaveTextContent('収支: -300');
+      expect(netEl).toHaveClass('text-ds-error');
+    });
+
+    it('does not double-count the same END round on re-render', async () => {
+      mockApi.mockResolvedValue(endPhasePlayerWins);
+      renderWithProviders(<CaribbeanStudPage />);
+      await waitFor(() => expect(screen.getByTestId('csp-session-stats')).toBeInTheDocument());
+      expect(JSON.parse(localStorage.getItem('trumpcards-caribbeanstud-history') ?? '[]')).toHaveLength(1);
+      // Re-render the page while it stays at END (toggling the hint checkbox
+      // updates local state) — the record-once guard must not append again.
+      fireEvent.click(screen.getByRole('checkbox'));
+      await waitFor(() => expect(screen.getByTestId('csp-session-tally')).toHaveTextContent('1勝 0敗 0分'));
+      expect(JSON.parse(localStorage.getItem('trumpcards-caribbeanstud-history') ?? '[]')).toHaveLength(1);
+    });
+
+    it('rehydrates prior session stats from localStorage on mount', async () => {
+      localStorage.setItem(
+        'trumpcards-caribbeanstud-history',
+        JSON.stringify([
+          { outcome: 1, net: 500 },
+          { outcome: 2, net: -200 },
+        ]),
+      );
+      mockApi.mockResolvedValue(betPhaseState);
+      renderWithProviders(<CaribbeanStudPage />);
+      await waitFor(() => expect(screen.getByTestId('csp-session-stats')).toBeInTheDocument());
+      expect(screen.getByTestId('csp-session-tally')).toHaveTextContent('1勝 1敗 0分');
+      expect(screen.getByTestId('csp-session-net')).toHaveTextContent('収支: +300');
+    });
+
+    it('clears the session summary when the clear button is pressed', async () => {
+      mockApi.mockResolvedValue(endPhasePlayerWins);
+      renderWithProviders(<CaribbeanStudPage />);
+      await waitFor(() => expect(screen.getByTestId('csp-session-stats')).toBeInTheDocument());
+      fireEvent.click(screen.getByTestId('csp-session-clear'));
+      await waitFor(() => expect(screen.queryByTestId('csp-session-stats')).not.toBeInTheDocument());
+      expect(localStorage.getItem('trumpcards-caribbeanstud-history')).toBeNull();
+    });
+  });
 });

--- a/frontend/src/pages/CaribbeanStudPage.tsx
+++ b/frontend/src/pages/CaribbeanStudPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { caribbeanstudApi } from '../api/gameApi';
 import { ActionLogPanel } from '../components/ActionLogPanel';
 import { CliTerminal } from '../components/cli/CliTerminal';
@@ -17,6 +17,7 @@ import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCardDimensions } from '../hooks/useCardDimensions';
+import { outcomeFromResult, useCaribbeanStudStats } from '../hooks/useCaribbeanStudStats';
 import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
@@ -108,6 +109,27 @@ function CaribbeanStudPageContent() {
   const isActionPhase = state?.phase === CaribbeanStudPhase.ACTION;
   const isEndPhase = state?.phase === CaribbeanStudPhase.END;
 
+  // Session stats persisted in localStorage; survive game resets, cleared only
+  // by the explicit clear button (or a page reload).
+  const { tally, recordRound, clearHistory } = useCaribbeanStudStats();
+  // Record each finished round exactly once. The guard keys on the END-phase
+  // episode: it flips true when the round resolves and resets whenever the phase
+  // leaves END (a new round begins), so re-renders at END never double-count.
+  const recordedRef = useRef(false);
+  const phase = state?.phase;
+  const result = state?.result;
+  const net = state === null ? 0 : state.totalPayout - (state.anteBet + state.jackpotBet + state.playBet);
+  useEffect(() => {
+    if (phase === CaribbeanStudPhase.END) {
+      if (!recordedRef.current && result !== undefined) {
+        recordedRef.current = true;
+        recordRound({ outcome: outcomeFromResult(result), net });
+      }
+    } else {
+      recordedRef.current = false;
+    }
+  }, [phase, result, net, recordRound]);
+
   const actionBindings = useMemo(
     () => [
       {
@@ -185,6 +207,49 @@ function CaribbeanStudPageContent() {
               messageCode={state.messageCode}
               messageParams={state.messageParams}
             />
+
+            {tally.hands > 0 && (
+              <div
+                data-testid="csp-session-stats"
+                className="mx-auto mb-3 max-w-sm rounded-lg bg-black/30 px-4 py-2 text-center text-sm"
+              >
+                <div className="font-bold text-ds-text-primary mb-1">{t('session.title')}</div>
+                <div className="flex items-center justify-center gap-3 text-ds-text-muted">
+                  <span data-testid="csp-session-tally">
+                    {t('session.tally', {
+                      wins: tally.wins,
+                      losses: tally.losses,
+                      pushes: tally.pushes,
+                    })}
+                  </span>
+                  <span>{t('session.hands', { hands: tally.hands })}</span>
+                  <span
+                    data-testid="csp-session-net"
+                    className={
+                      tally.net > 0
+                        ? 'font-bold text-ds-success'
+                        : tally.net < 0
+                          ? 'font-bold text-ds-error'
+                          : 'font-bold text-ds-text-muted'
+                    }
+                  >
+                    {t('session.net')}: {tally.net > 0 ? `+${tally.net}` : tally.net}
+                  </span>
+                </div>
+                <div className="mt-1 flex items-center justify-center gap-3 text-xs text-ds-text-muted">
+                  <span>{t('session.note')}</span>
+                  <button
+                    type="button"
+                    className="underline hover:text-ds-text-primary"
+                    onClick={clearHistory}
+                    disabled={loading}
+                    data-testid="csp-session-clear"
+                  >
+                    {t('session.clear')}
+                  </button>
+                </div>
+              </div>
+            )}
 
             {frontendHintEnabled && frontendHint && (
               <HintTooltip reason={t(frontendHint.reason)} confidence={frontendHint.confidence} />


### PR DESCRIPTION
## Summary

Adds a session cumulative-stats display to Caribbean Stud Poker (`caribbeanstud`), addressing #3138. The page previously showed only the current chip balance, so W/L history and net swing were lost on every reset.

A new `useCaribbeanStudStats` localStorage hook accumulates each completed round's outcome (win/loss/push) and net chip delta, and a compact summary renders above the table:

- **Tally**: `{{wins}}W {{losses}}L {{pushes}}P`
- **Hands played** count
- **Cumulative net** chips, colored via design-system tokens (`ds-success` / `ds-error` / muted)
- **Clear-history** button + a note that stats survive resets but clear on page reload

### How it works
- **Outcome source**: at the END phase the response gives the signed hand `result` (win/loss/push) and the net chip delta is computed as `totalPayout - (anteBet + jackpotBet + playBet)` (all present on the END response).
- **Record-once**: a `useRef` guard keyed on the END-phase episode flips true when the round resolves and resets whenever the phase leaves END, so re-renders at END never double-count.
- **Persistence**: try/catch-guarded `localStorage`; corrupt / malformed data is filtered out and falls back to an empty history.

### Acceptance criteria
- [x] Tally win/loss + net locally on each END phase
- [x] Session stats shown in a dedicated panel
- [x] `handleReset` does not clear stats (only the explicit clear button / reload does)
- [x] Note states stats reset on page reload

## Files
- `frontend/src/hooks/useCaribbeanStudStats.ts` (+ `.test.ts`)
- `frontend/src/pages/CaribbeanStudPage.tsx` (+ `.test.tsx`)
- `frontend/src/i18n/locales/{ja,en}/caribbeanstud.json` (session keys, ja+en parity)

## Test plan
- [x] `bun run test -- --run CaribbeanStud` (70 passed)
- [x] `bun run check` (exit 0)
- [x] `bun run build` (tsc, exit 0)

Frontend-only; no Go changes.

Closes #3138