### PR TITLE
feat(war): integrate win fanfare and battle sound effects

### DIFF
--- a/frontend/src/pages/WarPage.test.tsx
+++ b/frontend/src/pages/WarPage.test.tsx
@@ -1,4 +1,5 @@
 import { act, fireEvent, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { warApi } from '../api/gameApi';
 import { useCliMode } from '../hooks/useCliMode';
@@ -6,6 +7,17 @@ import { renderWithProviders } from '../test/renderWithProviders';
 import type { WarResponse } from '../types/card';
 import { WarPhase } from '../types/phases';
 import { WarPage } from './WarPage';
+
+const mockPlaySound = vi.fn();
+const mockSoundValue = { playSound: mockPlaySound, muted: false, toggleMute: vi.fn() };
+// Replace SoundProvider so the page's `useSound()` calls are captured. Leaf card
+// components read `useOptionalSound`; return null there so their incidental deal
+// SFX don't pollute the sound assertions below.
+vi.mock('../providers/SoundProvider', () => ({
+  SoundProvider: ({ children }: { children: ReactNode }) => children,
+  useSound: () => mockSoundValue,
+  useOptionalSound: () => null,
+}));
 
 vi.mock('../hooks/useCliMode', () => ({
   useCliMode: vi.fn(() => ({
@@ -69,6 +81,7 @@ const gameEndState: WarResponse = {
 };
 
 beforeEach(() => {
+  mockPlaySound.mockClear();
   mockExec.mockResolvedValue(baseState);
   mockUseCliMode.mockReturnValue({
     cliEnabled: false,
@@ -178,6 +191,35 @@ describe('WarPage', () => {
     mockExec.mockResolvedValueOnce(gameEndState);
     renderWithProviders(<WarPage />);
     await waitFor(() => expect(screen.getByTestId('step-button')).toBeDisabled());
+  });
+
+  it('plays the win fanfare when the human wins the game', async () => {
+    mockExec.mockResolvedValueOnce(gameEndState);
+    renderWithProviders(<WarPage />);
+    await waitFor(() => expect(mockPlaySound).toHaveBeenCalledWith('winFanfare'));
+  });
+
+  it('plays a card-place sound when a battle resolves', async () => {
+    // Mount reveals REVEAL; the next step settles the round into RESOLVED.
+    mockExec.mockResolvedValueOnce(baseState).mockResolvedValueOnce({
+      ...baseState,
+      phase: WarPhase.RESOLVED,
+      playerRevealed: { design: 'SPADE', value: 13 },
+      cpuRevealed: { design: 'HEART', value: 5 },
+      lastWinnerIdx: 0,
+    });
+    renderWithProviders(<WarPage />);
+    await waitFor(() => expect(screen.getByTestId('step-button')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('step-button'));
+    await waitFor(() => expect(mockPlaySound).toHaveBeenCalledWith('cardPlace'));
+  });
+
+  it('plays a tension cue when a tie triggers a war', async () => {
+    mockExec.mockResolvedValueOnce(baseState).mockResolvedValueOnce(warPhaseState);
+    renderWithProviders(<WarPage />);
+    await waitFor(() => expect(screen.getByTestId('step-button')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('step-button'));
+    await waitFor(() => expect(mockPlaySound).toHaveBeenCalledWith('chipClick'));
   });
 
   it('autoplay auto-advances via repeated step calls and stops at game end', async () => {

--- a/frontend/src/pages/WarPage.tsx
+++ b/frontend/src/pages/WarPage.tsx
@@ -20,6 +20,7 @@ import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useMountReset } from '../hooks/useMountReset';
+import { useSound } from '../providers/SoundProvider';
 import { gameTheme } from '../styles/gameTheme';
 import type { WarResponse } from '../types/card';
 import { WarPhase } from '../types/phases';
@@ -110,6 +111,7 @@ function WarPageContent() {
     useGamePageSetup('war');
   const { state, loading, error, exec: execApi, retry } = useGameApi(warApi.exec);
   const { cardWidth } = useCardDimensions();
+  const { playSound } = useSound();
   const [maxRounds, setMaxRounds] = useState(DEFAULT_MAX_ROUNDS);
   const {
     hint: frontendHint,
@@ -135,8 +137,30 @@ function WarPageContent() {
   }, []);
   const handleReset = useCallback(() => {
     setAutoPlaying(false);
+    playSound('shuffle');
     return execApi('reset', { maxRounds });
-  }, [execApi, maxRounds]);
+  }, [execApi, maxRounds, playSound]);
+
+  // Play a card-resolution SFX each time a battle settles (RESOLVED) and a
+  // tension cue when a tie triggers a war (WAR_BURY). Tracks the previous phase
+  // so the sound fires on the transition, not on every re-render, and skips the
+  // initial mount. Muting is honored inside `playSound`.
+  const prevPhaseRef = useRef<number | undefined>(undefined);
+  useEffect(() => {
+    const phase = state?.phase;
+    const prev = prevPhaseRef.current;
+    prevPhaseRef.current = phase;
+    if (phase === undefined || prev === undefined || prev === phase) return;
+    if (phase === WarPhase.RESOLVED) playSound('cardPlace');
+    else if (phase === WarPhase.WAR_BURY) playSound('chipClick');
+  }, [state?.phase, playSound]);
+
+  // Buzz once when a new error surfaces (e.g. a failed step/reset request).
+  const prevErrorRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (error && error !== prevErrorRef.current) playSound('errorBuzz');
+    prevErrorRef.current = error;
+  }, [error, playSound]);
 
   // Latest state/speed read from a self-scheduling autoplay loop without
   // re-subscribing the effect on every render.
@@ -230,6 +254,7 @@ function WarPageContent() {
       gamePath="/war"
       gameEndFlag={isGameEnd}
       winShow={humanWon}
+      onCelebrate={() => playSound('winFanfare')}
       loading={loading}
       confirmOpen={confirmOpen}
       confirmReset={confirmReset}


### PR DESCRIPTION
## Summary

Wires the shared `useSound` provider into **War** (`war`), which previously had no audio integration at all — `humanWon` produced silence.

## Changes (`frontend/src/pages/WarPage.tsx`)
- Import `useSound` and destructure `playSound`.
- `winFanfare` on the human's game win, via `GamePageShell`'s `onCelebrate`.
- `cardPlace` when a battle settles (`WarPhase.RESOLVED`).
- `chipClick` tension cue when a tie triggers a war (`WarPhase.WAR_BURY`).
- `shuffle` on reset; `errorBuzz` when a new request error surfaces.
- Phase-transition effect tracks the previous phase so sounds fire on the transition (not every render) and skip the initial mount. Muting is honored inside `playSound`.

Additive only — the autoplay/speed feature is untouched.

## Tests (`frontend/src/pages/WarPage.test.tsx`)
Mocked `SoundProvider` (Spoons pattern; `useOptionalSound` → null so leaf-card deal SFX don't pollute assertions). Added:
- plays `winFanfare` when the human wins
- plays `cardPlace` when a battle resolves
- plays `chipClick` when a tie triggers a war

## Acceptance criteria
- [x] `useSound` imported into `WarPage.tsx`
- [x] `winFanfare` plays on `humanWon`
- [x] card-resolution sound on `WarPhase.RESOLVED`
- [x] existing mute setting respected (handled inside `playSound`)

## Gate
- [x] `bun run check` (exit 0; no new warnings)
- [x] `bun run test -- --run War` (89 passed)
- [x] `bun run build` (tsc, exit 0)

Closes #3142