### PR TITLE
feat(twotenjack): surface the backend hint via a hint button

### DIFF
--- a/frontend/src/i18n/locales/en/twotenjack.json
+++ b/frontend/src/i18n/locales/en/twotenjack.json
@@ -55,5 +55,7 @@
     "trump_cut": "Cut the trick with a trump",
     "discard": "Cannot win — discard a low card"
   },
-  "scoresCaption": "Score summary by team"
+  "scoresCaption": "Score summary by team",
+  "hintDeclare": "Suggested trump",
+  "hintPlay": "Suggested play"
 }

--- a/frontend/src/i18n/locales/ja/twotenjack.json
+++ b/frontend/src/i18n/locales/ja/twotenjack.json
@@ -55,5 +55,7 @@
     "trump_cut": "切り札で刈り取るのが最適",
     "discard": "勝てないトリックなので弱いカードで逃す"
   },
-  "scoresCaption": "チーム別の得点集計"
+  "scoresCaption": "チーム別の得点集計",
+  "hintDeclare": "推奨トランプ",
+  "hintPlay": "推奨プレイ"
 }

--- a/frontend/src/pages/TwoTenJackPage.test.tsx
+++ b/frontend/src/pages/TwoTenJackPage.test.tsx
@@ -335,6 +335,53 @@ describe('TwoTenJackPage', () => {
     await waitFor(() => expect(screen.getByTestId('hint-tooltip')).toBeInTheDocument());
   });
 
+  it('fetches and displays a server play recommendation when the hint button is clicked', async () => {
+    renderWithProviders(<TwoTenJackPage />);
+    await waitFor(() => expect(screen.getByAltText('♠ A')).toBeInTheDocument());
+
+    const hintState = makeTwoTenJackState({ hint: { reason: 'lead', cardIndex: 0 } });
+    mockExec.mockResolvedValue(hintState);
+    fireEvent.click(screen.getByTestId('tt-hint-button'));
+
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('hint'));
+    await waitFor(() => {
+      const el = screen.getByTestId('tt-hint');
+      expect(el).toHaveTextContent('推奨プレイ');
+      expect(el).toHaveTextContent('[0]');
+    });
+  });
+
+  it('fetches and displays a server trump recommendation during the declare phase', async () => {
+    mockExec.mockResolvedValue(declarePhaseState);
+    renderWithProviders(<TwoTenJackPage />);
+    await waitFor(() => expect(screen.getByTestId('tt-declare-prompt')).toBeInTheDocument());
+
+    const hintState = makeTwoTenJackState({
+      phase: 0,
+      declarerIdx: 0,
+      trumpSuit: -1,
+      hint: { reason: 'strategic_trump', trumpSuit: 1 },
+    });
+    mockExec.mockResolvedValue(hintState);
+    fireEvent.click(screen.getByTestId('tt-hint-button'));
+
+    await waitFor(() => {
+      const el = screen.getByTestId('tt-hint');
+      expect(el).toHaveTextContent('推奨トランプ');
+      expect(el).toHaveTextContent('♠');
+    });
+  });
+
+  it('shows the hint error in the ErrorAlert when the hint request fails', async () => {
+    renderWithProviders(<TwoTenJackPage />);
+    await waitFor(() => expect(screen.getByAltText('♠ A')).toBeInTheDocument());
+
+    mockExec.mockRejectedValueOnce(new Error('network'));
+    fireEvent.click(screen.getByTestId('tt-hint-button'));
+
+    await waitFor(() => expect(screen.getByText(NETWORK_ERROR_MESSAGE())).toBeInTheDocument());
+  });
+
   it('renders CPU info as collapsible details on mobile', async () => {
     const originalWidth = window.innerWidth;
     Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 375 });

--- a/frontend/src/pages/TwoTenJackPage.tsx
+++ b/frontend/src/pages/TwoTenJackPage.tsx
@@ -31,6 +31,7 @@ import { gameTheme } from '../styles/gameTheme';
 import type { TwoTenJackResponse } from '../types/card';
 import { TwoTenJackPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { cardAlt } from '../utils/cardAlt';
 import { parseTwoTenJackCommand, TWOTENJACK_HELP } from '../utils/cli/commands/twoTenJackCommands';
 import { formatTwoTenJackState } from '../utils/cli/formatters/twoTenJackFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
@@ -101,6 +102,10 @@ function TwoTenJackPageContent() {
     state,
     loading,
     error,
+    hint,
+    hintError,
+    hintLoading,
+    handleHint,
     exec: dispatch,
     retry,
     twoTenJackConfig,
@@ -406,12 +411,36 @@ function TwoTenJackPageContent() {
                 cardWidth={cardWidth}
                 isMobile={isMobile}
                 dataTutorialPrefix="tt"
+                highlightIndices={isHumanTurn && hint?.cardIndex !== undefined ? [hint.cardIndex] : undefined}
               />
             )}
 
-            <ErrorAlert message={error} onRetry={retry} />
+            <ErrorAlert message={error ?? hintError} onRetry={retry} />
+
+            {hint && (
+              <div className="text-ds-warning text-sm mb-2" data-testid="tt-hint">
+                {hint.trumpSuit !== undefined
+                  ? `${t('hintDeclare')}: ${trumpSymbol(hint.trumpSuit)} (${t(`hint.${hint.reason}`)})`
+                  : (() => {
+                      const card = hint.cardIndex !== undefined ? humanPlayer?.cards[hint.cardIndex] : undefined;
+                      const name = card ? cardAlt(card) : '-';
+                      return `${t('hintPlay')}: ${name} [${hint.cardIndex ?? '-'}] (${t(`hint.${hint.reason}`)})`;
+                    })()}
+              </div>
+            )}
 
             <div className="flex gap-2 items-center flex-wrap" data-tutorial="tt-play-button">
+              {(isHumanDeclarer || isHumanTurn) && (
+                <button
+                  type="button"
+                  className={btnSuccess}
+                  onClick={handleHint}
+                  disabled={loading || hintLoading}
+                  data-testid="tt-hint-button"
+                >
+                  {tc('button.hint')}
+                </button>
+              )}
               {isHumanDeclarer && (
                 <span data-testid="tt-declare-prompt" className="text-ds-warning text-sm font-medium w-full sm:w-auto">
                   {t('declarePrompt')}


### PR DESCRIPTION
Closes #3133

## Summary
Wires the existing backend hint (`TwoTenJack.GetHint` → `TwoTenJackWebPresenter.HintOutput`, dispatched via the `hint` web command) into `TwoTenJackPage`, mirroring the sibling trick-taking pages (CatchTen / Whist). The `handleHint`/`hint`/`hintLoading`/`hintError` values were already exposed by `useTwoTenJackGame` (via `useTrickGameBase`) but the page never consumed them, so the toggle-gated frontend heuristic (`useGameHint`) — which reads `state.hint`, never populated by the normal `Output()` — was the only hint path and stayed dark.

Frontend-only change; no Go touched.

## Changes
- `TwoTenJackPage.tsx`: destructure `hint`/`hintError`/`hintLoading`/`handleHint`; add a `ヒント` button shown in the declare phase (human declarer) and play phase (human turn); render the recommended trump suit (`hint.trumpSuit`) or card (`hint.cardIndex`); highlight the suggested card in the hand; route `hintError` through `ErrorAlert`.
- i18n: add `hintDeclare` / `hintPlay` keys to `ja` + `en` twotenjack locales (reason strings reuse the existing `hint.*` block).
- Tests: server play-hint fetch/display, declare trump-hint fetch/display, and hint-error surfacing.

## Acceptance criteria
- [x] `useTwoTenJackGame` exposes `handleHint`/`hint`/`hintLoading`/`hintError` (already present; now consumed)
- [x] Declare phase shows `hint.TrumpSuit`, play phase shows `hint.CardIndex`
- [x] `ヒント` button in the same position/style as Whist/CatchTen
- [x] `hintError` displayed via `ErrorAlert`

## Test plan
- [x] `bun run check`
- [x] `bun run test -- --run TwoTenJack` (54 passed)
- [x] `bun run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)