### PR TITLE
fix(reddog): remove empty settings panel from footer

### DIFF
--- a/frontend/src/pages/RedDogPage.test.tsx
+++ b/frontend/src/pages/RedDogPage.test.tsx
@@ -142,6 +142,13 @@ describe('RedDogPage', () => {
     expect(screen.getByText(/200/)).toBeInTheDocument();
   });
 
+  it('does not render an empty settings panel', async () => {
+    mockApi.mockResolvedValue(betState);
+    renderWithProviders(<RedDogPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: /ベット/ })).toBeInTheDocument());
+    expect(screen.queryByText('設定')).not.toBeInTheDocument();
+  });
+
   it('reads from useCliMode', async () => {
     mockApi.mockResolvedValue(betState);
     renderWithProviders(<RedDogPage />);

--- a/frontend/src/pages/RedDogPage.tsx
+++ b/frontend/src/pages/RedDogPage.tsx
@@ -4,7 +4,6 @@ import { ActionLogPanel } from '../components/ActionLogPanel';
 import { CliTerminal } from '../components/cli/CliTerminal';
 import { CliToggle } from '../components/cli/CliToggle';
 import { ChipBetInput } from '../components/common/ChipBetInput';
-import { SettingsPanel } from '../components/common/SettingsPanel';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
@@ -229,7 +228,6 @@ function RedDogPageContent() {
 
           <GameFooter className={`${gameTheme.reddog.footer} px-4 pt-3`}>
             <ErrorAlert message={error} onRetry={retry} />
-            <SettingsPanel title={tc('settings.title')} groups={[]} />
             {isBetPhase && (
               <div className="flex flex-col items-center gap-2 pb-2" data-tutorial="rd-bet-controls">
                 <ChipBetInput


### PR DESCRIPTION
## Summary
Red Dog's footer rendered `<SettingsPanel title={tc('settings.title')} groups={[]} />` — an empty collapsible panel that showed nothing when opened. The hint on/off toggle is implemented separately as a raw checkbox, so the panel had no content to configure. This removes the meaningless empty panel and its now-unused import.

## Changes
- Remove empty `SettingsPanel` from `RedDogPage.tsx` footer
- Remove now-unused `SettingsPanel` import
- Add a test asserting the settings panel is no longer rendered
- Hint toggle behavior is unchanged (still the standalone checkbox)

## Test plan
- [x] `bun run check` passes
- [x] `bun run test -- --run RedDog` passes (53 tests)
- [x] `bun run build` passes (tsc)
- [x] New test: `does not render an empty settings panel`

Closes #3172

🤖 Generated with [Claude Code](https://claude.com/claude-code)