### PR TITLE
feat(canfield): render hint button result with highlight and text

### DIFF
--- a/frontend/src/i18n/locales/en/canfield.json
+++ b/frontend/src/i18n/locales/en/canfield.json
@@ -23,6 +23,7 @@
   "playing": "Playing",
   "noHint": "No hint available",
   "hintAvailable": "Hint available",
+  "hintAnnouncement": "Hint: move {{card}} to {{dest}}",
   "moveReserveToFoundation": "Reserve → Foundation",
   "moveReserveToTableau": "Reserve → Tableau",
   "moveWasteToFoundation": "Waste → Foundation",

--- a/frontend/src/i18n/locales/ja/canfield.json
+++ b/frontend/src/i18n/locales/ja/canfield.json
@@ -23,6 +23,7 @@
   "playing": "プレイ中",
   "noHint": "ヒントはありません",
   "hintAvailable": "ヒントがあります",
+  "hintAnnouncement": "ヒント: {{card}}を{{dest}}へ移動",
   "moveReserveToFoundation": "リザーブ→組札",
   "moveReserveToTableau": "リザーブ→場札",
   "moveWasteToFoundation": "ウェイスト→組札",

--- a/frontend/src/pages/CanfieldPage.test.tsx
+++ b/frontend/src/pages/CanfieldPage.test.tsx
@@ -130,6 +130,53 @@ describe('CanfieldPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('hint'));
   });
 
+  it('shows the hint source → destination text after clicking hint (tableau → foundation)', async () => {
+    renderWithProviders(<CanfieldPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    // The hint response carries the suggested move: tableau col 0 top card → foundation.
+    mockExec.mockResolvedValueOnce({
+      ...playingState,
+      hint: { fromZone: 'tableau', fromCol: 0, cardIndex: 0, toZone: 'foundation', toCol: 2 },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'ヒント' }));
+    const display = await screen.findByTestId('cf-hint-display');
+    // Visible line names both source (場札 0) and destination (組札).
+    await waitFor(() => expect(display).toHaveTextContent('場札 0'));
+    expect(display).toHaveTextContent('組札');
+    // Screen-reader announcement resolves the hinted card face + destination.
+    expect(screen.getByTestId('cf-hint-announcement')).toHaveTextContent('♠ 7');
+  });
+
+  it('announces a reserve → tableau hint using the reserve top card', async () => {
+    renderWithProviders(<CanfieldPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    mockExec.mockResolvedValueOnce({
+      ...playingState,
+      hint: { fromZone: 'reserve', fromCol: -1, cardIndex: -1, toZone: 'tableau', toCol: 1 },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'ヒント' }));
+    const display = await screen.findByTestId('cf-hint-display');
+    await waitFor(() => expect(display).toHaveTextContent('リザーブ'));
+    expect(display).toHaveTextContent('場札 1');
+    // Reserve top card is ♠ 3 in playingState.
+    expect(screen.getByTestId('cf-hint-announcement')).toHaveTextContent('♠ 3');
+  });
+
+  it('clears the hint display after the next move (response without a hint field)', async () => {
+    renderWithProviders(<CanfieldPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    mockExec.mockResolvedValueOnce({
+      ...playingState,
+      hint: { fromZone: 'waste', fromCol: -1, cardIndex: -1, toZone: 'foundation', toCol: 0 },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'ヒント' }));
+    await waitFor(() => expect(screen.getByTestId('cf-hint-display')).toHaveTextContent('ヒントがあります'));
+    // A subsequent move returns the plain state (no hint) → the display empties.
+    mockExec.mockResolvedValue(playingState);
+    fireEvent.click(screen.getByRole('button', { name: /ウェイスト→組札/ }));
+    await waitFor(() => expect(screen.getByTestId('cf-hint-display')).not.toHaveTextContent('ヒントがあります'));
+  });
+
   it('autocomplete button triggers autocomplete command', async () => {
     renderWithProviders(<CanfieldPage />);
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));

--- a/frontend/src/pages/CanfieldPage.tsx
+++ b/frontend/src/pages/CanfieldPage.tsx
@@ -29,9 +29,29 @@ import { gameTheme } from '../styles/gameTheme';
 import type { CanfieldResponse } from '../types/card';
 import { CanfieldPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { cardAlt } from '../utils/cardAlt';
 import { CANFIELD_HELP, parseCanfieldCommand } from '../utils/cli/commands/canfieldCommands';
 import { formatCanfieldState } from '../utils/cli/formatters/canfieldFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+
+/** Ring styling applied to the hinted source / target cards (mirrors Yukon / Forty Thieves). */
+const HINT_RING = 'ring-2 ring-ds-info motion-safe:animate-pulse';
+
+/**
+ * Formats a Canfield hint zone into human-readable text, mirroring
+ * `CanfieldCuiPresenter.HintOutput`. Tableau destinations include the 0-based
+ * column number so source and target are unambiguous.
+ */
+function formatCanfieldHintZone(
+  t: (key: string, opts?: Record<string, unknown>) => string,
+  zone: string,
+  col: number,
+): string {
+  if (zone === 'reserve') return t('reserve');
+  if (zone === 'waste') return t('waste');
+  if (zone === 'foundation') return t('foundation');
+  return `${t('tableau')} ${col}`;
+}
 
 /** Tutorial steps for the Canfield solitaire game. */
 const CF_TUTORIAL_STEPS: TutorialStep[] = [
@@ -184,6 +204,27 @@ function CanfieldPageContent() {
   const topWaste = state.waste.length > 0 ? state.waste[state.waste.length - 1] : null;
   const topReserve = state.reserve.length > 0 ? state.reserve[state.reserve.length - 1] : null;
 
+  // Server hint (populated by the "hint" button; cleared on the next move since
+  // regular responses omit the field). Resolve the hinted card + destination so
+  // the move can be highlighted with a ring and announced to screen readers,
+  // matching Yukon / Forty Thieves. The click handler itself needs no change.
+  const hint = state.hint ?? null;
+  const hintCard = hint
+    ? hint.fromZone === 'reserve'
+      ? topReserve
+      : hint.fromZone === 'waste'
+        ? topWaste
+        : (state.tableau[hint.fromCol]?.[hint.cardIndex]?.card ?? null)
+    : null;
+  const hintCardName = hintCard ? cardAlt(hintCard) : '';
+  const hintDest = hint ? formatCanfieldHintZone(t, hint.toZone, hint.toCol) : '';
+  const isHintFromReserve = hint?.fromZone === 'reserve';
+  const isHintFromWaste = hint?.fromZone === 'waste';
+  const isHintFromTableau = (col: number, idx: number) =>
+    hint != null && hint.fromZone === 'tableau' && hint.fromCol === col && hint.cardIndex === idx;
+  const isHintToFoundation = (col: number) => hint?.toZone === 'foundation' && hint.toCol === col;
+  const isHintToTableau = (col: number) => hint?.toZone === 'tableau' && hint.toCol === col;
+
   return (
     <GamePageShell
       title={tc('nav.canfield')}
@@ -255,7 +296,7 @@ function CanfieldPageContent() {
                     onDragLeave={dnd.handleDragLeave}
                   >
                     <div
-                      className="relative rounded border border-white/30"
+                      className={`relative rounded border border-white/30 ${isHintToFoundation(i) ? HINT_RING : ''}`}
                       style={{ width: cardWidth, height: cardHeight }}
                     >
                       {pile.length > 0 ? (
@@ -301,7 +342,7 @@ function CanfieldPageContent() {
                       draggable={isPlaying && !loading}
                       onDragStart={dnd.handleDragStart({ zone: 'waste' })}
                       onDragEnd={dnd.handleDragEnd}
-                      className={`p-0 border-0 bg-transparent cursor-pointer rounded ${focusRingWhite} ${dnd.isDragSource({ zone: 'waste' }) ? 'opacity-50' : ''}`}
+                      className={`p-0 border-0 bg-transparent cursor-pointer rounded ${focusRingWhite} ${isHintFromWaste ? HINT_RING : ''} ${dnd.isDragSource({ zone: 'waste' }) ? 'opacity-50' : ''}`}
                     >
                       <AnimatedCard card={topWaste} width={cardWidth} draggable={false} />
                     </button>
@@ -326,6 +367,7 @@ function CanfieldPageContent() {
                   handleDragStart={dnd.handleDragStart({ zone: 'reserve' })}
                   handleDragEnd={dnd.handleDragEnd}
                   isDragSource={dnd.isDragSource({ zone: 'reserve' })}
+                  isHintSource={!!isHintFromReserve}
                 />
                 <span className="mt-1 text-xs text-ds-text-muted">
                   {t('reserve')}: {state.reserve.length}
@@ -346,7 +388,10 @@ function CanfieldPageContent() {
                       onDrop={dnd.handleDrop(tZone)}
                       onDragLeave={dnd.handleDragLeave}
                     >
-                      <div className="relative" style={{ width: cardWidth, minHeight: cardHeight }}>
+                      <div
+                        className={`relative rounded ${isHintToTableau(i) ? HINT_RING : ''}`}
+                        style={{ width: cardWidth, minHeight: cardHeight }}
+                      >
                         {col.length === 0 ? (
                           <div
                             className="rounded border border-dashed border-white/30"
@@ -362,7 +407,7 @@ function CanfieldPageContent() {
                                   draggable={isPlaying && !loading}
                                   onDragStart={dnd.handleDragStart(cardZone)}
                                   onDragEnd={dnd.handleDragEnd}
-                                  className={`p-0 border-0 bg-transparent cursor-pointer rounded ${focusRingWhite} ${dnd.isDragSource(cardZone) ? 'opacity-50' : ''}`}
+                                  className={`p-0 border-0 bg-transparent cursor-pointer rounded ${focusRingWhite} ${isHintFromTableau(i, j) ? HINT_RING : ''} ${dnd.isDragSource(cardZone) ? 'opacity-50' : ''}`}
                                 >
                                   <AnimatedCard card={tc.card} width={cardWidth} draggable={false} />
                                 </button>
@@ -443,6 +488,21 @@ function CanfieldPageContent() {
               messageCode={state.messageCode}
               messageParams={state.messageParams}
             />
+            {/* Server hint display: a visible source → target line plus a screen-reader
+                announcement, mirroring CanfieldCuiPresenter.HintOutput. The hinted cards
+                are also ring-highlighted above. Clears automatically once the move is
+                played (the next response omits the hint field). */}
+            <div data-testid="cf-hint-display">
+              {hint && (
+                <div className="text-sm text-ds-text-muted">
+                  {t('hintAvailable')}: {formatCanfieldHintZone(t, hint.fromZone, hint.fromCol)} →{' '}
+                  {formatCanfieldHintZone(t, hint.toZone, hint.toCol)}
+                </div>
+              )}
+              <div className="sr-only" role="status" aria-live="polite" data-testid="cf-hint-announcement">
+                {hint ? t('hintAnnouncement', { card: hintCardName, dest: hintDest }) : ''}
+              </div>
+            </div>
             {frontendHintEnabled && frontendHint && (
               <HintTooltip reason={t(frontendHint.reason)} confidence={frontendHint.confidence} />
             )}
@@ -540,6 +600,7 @@ interface ReserveStackProps {
   handleDragStart: (e: DragEvent<HTMLElement>) => void;
   handleDragEnd: () => void;
   isDragSource: boolean;
+  isHintSource: boolean;
 }
 
 /** Reserve pile with visible stack-edge layers behind the top card.
@@ -555,6 +616,7 @@ function ReserveStack({
   handleDragStart,
   handleDragEnd,
   isDragSource,
+  isHintSource,
 }: ReserveStackProps) {
   const layers = Math.max(0, Math.min(count - 1, RESERVE_STACK_MAX_LAYERS));
   // Container is sized for the maximum stack so the top card sits at a
@@ -588,7 +650,7 @@ function ReserveStack({
             draggable={isPlaying && !loading}
             onDragStart={handleDragStart}
             onDragEnd={handleDragEnd}
-            className={`p-0 border-0 bg-transparent cursor-pointer rounded ${focusRingWhite} ${isDragSource ? 'opacity-50' : ''}`}
+            className={`p-0 border-0 bg-transparent cursor-pointer rounded ${focusRingWhite} ${isHintSource ? HINT_RING : ''} ${isDragSource ? 'opacity-50' : ''}`}
           >
             <AnimatedCard card={topCard} width={cardWidth} draggable={false} />
           </button>


### PR DESCRIPTION
## Summary
The Canfield "ヒント" (hint) button already dispatched the `hint` command and the server populated `state.hint` (`fromZone`/`fromCol`/`cardIndex`/`toZone`/`toCol`), but nothing in the page rendered it — clicking hint produced no visible feedback. This wires up the display, mirroring the existing `YukonPage`/`FortyThievesPage` treatment.

## Changes
- **Ring highlight** the hinted source card (reserve / waste / tableau) and target (foundation pile / tableau column) with the shared `ring-2 ring-ds-info motion-safe:animate-pulse` styling.
- **Visible text line** `ヒントがあります: <from> → <to>` naming source and destination zones (tableau destinations include the 0-based column), matching `CanfieldCuiPresenter.HintOutput`.
- **Screen-reader announcement** in an `sr-only` `role="status"` live region resolving the hinted card face + destination.
- The click handler is unchanged; `useGameApi` already sets `state.hint` from the `hint` response, and regular move responses omit the field, so the display **clears automatically** after the next move.
- Frontend-only: no Go changes. i18n `hintAnnouncement` key added to ja + en with parity.

## Test plan
- [x] `bun run check` (exit 0)
- [x] `bun run test -- --run Canfield` — 56 passed, incl. new tests: tableau→foundation text/announcement, reserve→tableau announcement, and hint-clears-after-next-move
- [x] `bun run build` (tsc) passes

Closes #3145