### PR TITLE
feat(letitride): add min/step guardrails to the bet input

### DIFF
--- a/frontend/src/pages/LetItRidePage.test.tsx
+++ b/frontend/src/pages/LetItRidePage.test.tsx
@@ -127,6 +127,48 @@ describe('LetItRidePage', () => {
     expect(screen.getByRole('button', { name: 'ベット' })).toBeInTheDocument();
   });
 
+  it('applies min=10 and step=10 guardrails to the bet input', async () => {
+    mockApi.mockResolvedValue(betPhaseState);
+    renderWithProviders(<LetItRidePage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'ベット' })).toBeInTheDocument());
+    const input = screen.getByLabelText('ベット') as HTMLInputElement;
+    expect(input).toHaveAttribute('min', '10');
+    expect(input).toHaveAttribute('step', '10');
+    // max is capped at 1/3 of the chip balance (1000 → 333).
+    expect(input).toHaveAttribute('max', '333');
+  });
+
+  it('clamps a below-min bet up to the minimum of 10', async () => {
+    mockApi.mockResolvedValue(betPhaseState);
+    renderWithProviders(<LetItRidePage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'ベット' })).toBeInTheDocument());
+    const input = screen.getByLabelText('ベット') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '5' } });
+    expect(input.value).toBe('10');
+  });
+
+  it('clamps an over-max bet down to the chip-capped maximum', async () => {
+    mockApi.mockResolvedValue(betPhaseState);
+    renderWithProviders(<LetItRidePage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'ベット' })).toBeInTheDocument());
+    const input = screen.getByLabelText('ベット') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '99999' } });
+    // 1000 / 3 floored = 333.
+    expect(input.value).toBe('333');
+  });
+
+  it('submits a valid clamped bet amount', async () => {
+    mockApi.mockResolvedValue(betPhaseState);
+    renderWithProviders(<LetItRidePage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'ベット' })).toBeInTheDocument());
+    const input = screen.getByLabelText('ベット') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '200' } });
+    expect(input.value).toBe('200');
+    mockApi.mockClear();
+    fireEvent.click(screen.getByRole('button', { name: 'ベット' }));
+    await waitFor(() => expect(mockApi).toHaveBeenCalledWith('bet', 200));
+  });
+
   it('shows payout reference panel in bet phase', async () => {
     mockApi.mockResolvedValue(betPhaseState);
     renderWithProviders(<LetItRidePage />);

--- a/frontend/src/pages/LetItRidePage.tsx
+++ b/frontend/src/pages/LetItRidePage.tsx
@@ -369,6 +369,8 @@ function LetItRidePageContent() {
                   label={t('label.bet')}
                   value={betAmount}
                   onChange={setBetAmount}
+                  min={10}
+                  step={10}
                   max={Math.floor(state.chips / 3)}
                 />
                 <button type="button" className={btnPrimary} onClick={handleBet} disabled={loading}>


### PR DESCRIPTION
## 概要

レット・イット・ライドのベット入力 (`letitride-bet-amount`) に下限・刻み幅の制約が無く、`ChipBetInput` のデフォルト任せになっていた。他のカジノゲーム（Caribbean Stud / Texas Hold'em Bonus）と同様に `min={10} step={10}` を明示的に渡し、極端に小さい／大きいベット額を防止する。

## 変更点

- `LetItRidePage.tsx`: `ChipBetInput` に `min={10} step={10}` を追加。`max={Math.floor(state.chips / 3)}`（3倍控除による1口上限）は維持。
- `LetItRidePage.test.tsx`: 下限/上限クランプおよび有効ベットの送信を検証するテストを追加。

## 受け入れ条件

- [x] `letitride-bet-amount` の `ChipBetInput` に `min={10} step={10}` が追加される
- [x] `max={Math.floor(state.chips / 3)}` は維持する
- [x] 極端に小さい/大きいベット額が設定できないことをテストで確認する
- [x] 既存の `betAmount` の初期値（100）との整合を確認する（100 は 10 の倍数かつ min 以上）

## テスト

- `bun run test -- --run LetItRide` → 79 passed
- `bun run check` → exit 0（既存の holdem テスト警告のみ、本変更由来なし）
- `bun run build` → 成功

Closes #3163

## 備考

- フロントエンドのみ。Go には触れていない。
- `showSteppers` は未使用（デフォルト false）のため steppers の aria-label は描画されず、E2E スペック（`letitride.spec.ts`）とのボタン名衝突は発生しない。スペック変更なし。
- i18n 変更なし（コードのみの変更）。