### PR TITLE
feat(mao): add say-word attempt history panel

### DIFF
--- a/frontend/src/i18n/locales/en/mao.json
+++ b/frontend/src/i18n/locales/en/mao.json
@@ -43,6 +43,11 @@
   "ruleHintLabel": "Hint",
   "sayWordButton": "Say word",
   "sayWordPlaceholder": "Type the word to say…",
+  "sayWordHistory": {
+    "title": "Say-word history ({{count}})",
+    "correct": "OK",
+    "penalty": "Penalty"
+  },
   "playPhase": "Play a card or draw from the stock",
   "chooseSuitPhase": "Choose a suit",
   "mustDeclarePhase": "One card left! Declare \"Mao!\"",

--- a/frontend/src/i18n/locales/ja/mao.json
+++ b/frontend/src/i18n/locales/ja/mao.json
@@ -43,6 +43,11 @@
   "ruleHintLabel": "ヒント",
   "sayWordButton": "発言する",
   "sayWordPlaceholder": "唱える言葉を入力…",
+  "sayWordHistory": {
+    "title": "発話履歴 ({{count}})",
+    "correct": "正解",
+    "penalty": "ペナルティ"
+  },
   "playPhase": "カードを出すか、山札から引いてください",
   "chooseSuitPhase": "スートを選択してください",
   "mustDeclarePhase": "手札が残り1枚！「マオ！」と宣言してください",

--- a/frontend/src/pages/MaoPage.test.tsx
+++ b/frontend/src/pages/MaoPage.test.tsx
@@ -224,6 +224,51 @@ describe('MaoPage', () => {
     await waitFor(() => expect(screen.getByRole('button', { name: '発言する' })).toBeDisabled());
   });
 
+  it('hides the say-word history panel until a word is spoken', async () => {
+    renderWithProviders(<MaoPage />);
+    await waitFor(() => expect(screen.getByTestId('mao-rule-panel')).toBeInTheDocument());
+    expect(screen.queryByTestId('mao-sayword-history')).not.toBeInTheDocument();
+  });
+
+  it('logs a say-word attempt with an accepted outcome and the board card', async () => {
+    renderWithProviders(<MaoPage />);
+    const input = await screen.findByLabelText('唱える言葉を入力…');
+    fireEvent.change(input, { target: { value: 'mao' } });
+    // Response reports no penalty → the attempt was accepted.
+    mockExec.mockResolvedValueOnce({ ...playPhaseState, rulePenalty: false, correctCount: 1 });
+    fireEvent.click(screen.getByRole('button', { name: '発言する' }));
+    const row = await screen.findByTestId('mao-sayword-history-row');
+    expect(row).toHaveTextContent('mao');
+    // Board captured from the discard top at submit time (HEART 7).
+    expect(row).toHaveTextContent('♥ 7');
+    expect(screen.getByTestId('sayword-outcome-correct')).toHaveTextContent('正解');
+    expect(screen.queryByTestId('sayword-outcome-penalty')).not.toBeInTheDocument();
+  });
+
+  it('color-codes a penalty say-word attempt in the history panel', async () => {
+    renderWithProviders(<MaoPage />);
+    const input = await screen.findByLabelText('唱える言葉を入力…');
+    fireEvent.change(input, { target: { value: 'oops' } });
+    mockExec.mockResolvedValueOnce({ ...playPhaseState, rulePenalty: true });
+    fireEvent.click(screen.getByRole('button', { name: '発言する' }));
+    const outcome = await screen.findByTestId('sayword-outcome-penalty');
+    expect(outcome).toHaveTextContent('ペナルティ');
+    expect(outcome.className).toContain('text-ds-error');
+  });
+
+  it('clears the say-word history on reset', async () => {
+    mockExec.mockResolvedValue(gameEndState);
+    renderWithProviders(<MaoPage />);
+    const input = await screen.findByLabelText('唱える言葉を入力…');
+    fireEvent.change(input, { target: { value: 'mao' } });
+    mockExec.mockResolvedValueOnce({ ...gameEndState, rulePenalty: false });
+    fireEvent.click(screen.getByRole('button', { name: '発言する' }));
+    await screen.findByTestId('mao-sayword-history-row');
+    // At game end the reset button fires immediately (no confirm dialog) and wipes the log.
+    fireEvent.click(screen.getByRole('button', { name: '次のゲーム' }));
+    await waitFor(() => expect(screen.queryByTestId('mao-sayword-history')).not.toBeInTheDocument());
+  });
+
   it('shows a penalty notice when rulePenalty is true', async () => {
     mockExec.mockResolvedValue({ ...playPhaseState, rulePenalty: true });
     renderWithProviders(<MaoPage />);

--- a/frontend/src/pages/MaoPage.tsx
+++ b/frontend/src/pages/MaoPage.tsx
@@ -24,13 +24,14 @@ import { btnDanger, btnPrimary, btnSecondary, btnSuccess } from '../styles/butto
 import { focusRingCard, selectedCardStyle } from '../styles/cardStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
-import type { MaoResponse } from '../types/card';
+import type { Card, MaoResponse } from '../types/card';
 import { CrazyEightsSuit, MaoPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import { MAO_HELP, parseMaoCommand } from '../utils/cli/commands/maoCommands';
 import { formatMaoState } from '../utils/cli/formatters/maoFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { appendSayWordAttempt, type MaoSayWordAttempt } from '../utils/maoSayWordHistory';
 import { playerName } from '../utils/playerUtils';
 
 const MAO_PHASE_KEYS: Readonly<Record<number, string>> = {
@@ -124,6 +125,14 @@ function MaoPageContent() {
   const { cardWidth } = useCardDimensions();
   const { playSound } = useSound();
   const [wordInput, setWordInput] = useState('');
+  // Local log of say-word attempts and their outcome; the server never returns
+  // this history, but the player types the word and the response's rulePenalty
+  // flag reveals whether it broke the hidden rule.
+  const [sayWordHistory, setSayWordHistory] = useState<MaoSayWordAttempt[]>([]);
+  // Holds a submitted word until its response arrives; prevState pins the state
+  // object present at submit time so the outcome is read from the *response*,
+  // not from an interim re-render.
+  const pendingWordRef = useRef<{ word: string; board: Card | null; prevState: MaoResponse | null } | null>(null);
   // CLI mode
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('mao');
   const cliConfig: CliGameConfig<MaoResponse, Parameters<typeof maoApi.exec>> = useMemo(
@@ -146,18 +155,40 @@ function MaoPageContent() {
   }, [handlePlay]);
 
   const submitWord = useCallback(() => {
-    handleDeclareWord(wordInput);
+    const trimmed = wordInput.trim();
+    if (trimmed.length === 0) return;
+    pendingWordRef.current = { word: trimmed, board: state?.discardTop ?? null, prevState: state };
+    handleDeclareWord(trimmed);
     setWordInput('');
-  }, [handleDeclareWord, wordInput]);
+  }, [handleDeclareWord, wordInput, state]);
+
+  // When the say-word response lands (a new state object), record the attempt
+  // together with the outcome the server reported for it.
+  useEffect(() => {
+    const pending = pendingWordRef.current;
+    if (!state || !pending || state === pending.prevState) return;
+    pendingWordRef.current = null;
+    setSayWordHistory((h) =>
+      appendSayWordAttempt(h, { word: pending.word, board: pending.board, penalty: state.rulePenalty }),
+    );
+  }, [state]);
 
   const handleManualReset = useCallback(() => {
     hideActionLog();
     setWordInput('');
+    setSayWordHistory([]);
+    pendingWordRef.current = null;
     void gameExec('reset', undefined, undefined, {
       cpuDifficulty: maoConfig.cpuDifficulty,
       pointLimit: maoConfig.pointLimit,
     });
   }, [gameExec, hideActionLog, maoConfig.cpuDifficulty, maoConfig.pointLimit]);
+
+  const handleNextRoundWithHistory = useCallback(() => {
+    setSayWordHistory([]);
+    pendingWordRef.current = null;
+    handleNextRound();
+  }, [handleNextRound]);
 
   useCardKeyboardNav({
     cardCount: humanCardCountForKbd,
@@ -427,6 +458,33 @@ function MaoPageContent() {
                   {t('sayWordButton')}
                 </button>
               </div>
+
+              {/* Attempt log: track which words were tried and how the hidden rule reacted. */}
+              {sayWordHistory.length > 0 && (
+                <details className="rounded bg-black/20 px-2 py-1" data-testid="mao-sayword-history">
+                  <summary className="cursor-pointer select-none text-ds-text-muted">
+                    {t('sayWordHistory.title', { count: sayWordHistory.length })}
+                  </summary>
+                  <ul className="mt-1 flex flex-col gap-1">
+                    {sayWordHistory.map((attempt, idx) => (
+                      <li
+                        key={`${attempt.word}-${idx}`}
+                        className="flex items-center gap-2 flex-wrap"
+                        data-testid="mao-sayword-history-row"
+                      >
+                        <span className="text-ds-text-primary font-medium">“{attempt.word}”</span>
+                        {attempt.board && <span className="text-ds-text-muted">{cardAlt(attempt.board)}</span>}
+                        <span
+                          className={`font-semibold ${attempt.penalty ? 'text-ds-error' : 'text-ds-success'}`}
+                          data-testid={attempt.penalty ? 'sayword-outcome-penalty' : 'sayword-outcome-correct'}
+                        >
+                          {attempt.penalty ? t('sayWordHistory.penalty') : t('sayWordHistory.correct')}
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                </details>
+              )}
             </div>
 
             <div className="flex gap-2 items-center flex-wrap" data-tutorial="mao-magic">
@@ -495,7 +553,7 @@ function MaoPageContent() {
                 </div>
               )}
               {isRoundEnd && (
-                <button type="button" className={btnSuccess} onClick={handleNextRound} disabled={loading}>
+                <button type="button" className={btnSuccess} onClick={handleNextRoundWithHistory} disabled={loading}>
                   {t('nextRound')}
                 </button>
               )}

--- a/frontend/src/utils/maoSayWordHistory.test.ts
+++ b/frontend/src/utils/maoSayWordHistory.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import type { Card } from '../types/card';
+import { appendSayWordAttempt, MAX_SAY_WORD_HISTORY, type MaoSayWordAttempt } from './maoSayWordHistory';
+
+const board: Card = { design: 'HEART', value: 7 };
+
+describe('appendSayWordAttempt', () => {
+  it('appends a new attempt to the end (newest last)', () => {
+    const first: MaoSayWordAttempt = { word: 'mao', board, penalty: false };
+    const second: MaoSayWordAttempt = { word: 'no mao', board: null, penalty: true };
+    const afterFirst = appendSayWordAttempt([], first);
+    const afterSecond = appendSayWordAttempt(afterFirst, second);
+    expect(afterFirst).toEqual([first]);
+    expect(afterSecond).toEqual([first, second]);
+  });
+
+  it('does not mutate the input history', () => {
+    const history: MaoSayWordAttempt[] = [{ word: 'mao', board, penalty: false }];
+    const result = appendSayWordAttempt(history, { word: 'again', board, penalty: true });
+    expect(history).toHaveLength(1);
+    expect(result).toHaveLength(2);
+  });
+
+  it('caps the history at the max, dropping the oldest entries', () => {
+    let history: MaoSayWordAttempt[] = [];
+    for (let i = 0; i < MAX_SAY_WORD_HISTORY + 5; i++) {
+      history = appendSayWordAttempt(history, { word: `w${i}`, board: null, penalty: false });
+    }
+    expect(history).toHaveLength(MAX_SAY_WORD_HISTORY);
+    // Oldest five (w0..w4) dropped; first retained is w5, last is the newest.
+    expect(history[0].word).toBe('w5');
+    expect(history[history.length - 1].word).toBe(`w${MAX_SAY_WORD_HISTORY + 4}`);
+  });
+
+  it('respects a custom max', () => {
+    const history = appendSayWordAttempt(
+      [
+        { word: 'a', board: null, penalty: false },
+        { word: 'b', board: null, penalty: false },
+      ],
+      { word: 'c', board: null, penalty: true },
+      2,
+    );
+    expect(history.map((h) => h.word)).toEqual(['b', 'c']);
+  });
+});

--- a/frontend/src/utils/maoSayWordHistory.ts
+++ b/frontend/src/utils/maoSayWordHistory.ts
@@ -1,0 +1,28 @@
+import type { Card } from '../types/card';
+
+/** A single recorded "say word" attempt in Mao: the spoken word, the board
+ * (the discard-pile top card at the moment of speaking), and whether it drew a
+ * hidden-rule penalty. */
+export interface MaoSayWordAttempt {
+  /** The word the player tried saying. */
+  word: string;
+  /** The discard-pile top card when the word was spoken (null if the pile was empty). */
+  board: Card | null;
+  /** True when the attempt broke the hidden rule (penalty); false when it was accepted. */
+  penalty: boolean;
+}
+
+/** Maximum number of say-word attempts retained in the local history. */
+export const MAX_SAY_WORD_HISTORY = 50;
+
+/** Append a say-word attempt to the history (newest last), capping the length
+ * to {@link MAX_SAY_WORD_HISTORY} by dropping the oldest entries. Returns a new
+ * array; the input is never mutated. */
+export function appendSayWordAttempt(
+  history: readonly MaoSayWordAttempt[],
+  attempt: MaoSayWordAttempt,
+  max: number = MAX_SAY_WORD_HISTORY,
+): MaoSayWordAttempt[] {
+  const next = [...history, attempt];
+  return next.length > max ? next.slice(next.length - max) : next;
+}


### PR DESCRIPTION
## Summary
Adds a **say-word attempt history** panel to the Mao page so players can track which words they tried and how the hidden rule reacted — no more keeping notes on paper.

Each attempt records:
- the **word** the player spoke,
- the **board** (discard-pile top card at the moment of speaking), and
- the **outcome**: accepted (green, `text-ds-success`) vs hidden-rule **penalty** (red, `text-ds-error`), derived from the response's `rulePenalty` flag.

The log lives entirely in **local page state** — the server never returns say-word history, but the player types the word and the response reveals the outcome. It renders as a collapsible `<details>` list inside the existing `mao-rule-panel`, is **hidden while empty**, and **clears on reset and on next round**.

## Implementation
- New pure helper `src/utils/maoSayWordHistory.ts` (`appendSayWordAttempt`, capped at 50) with unit tests.
- `MaoPage.tsx`: local `sayWordHistory` state; a pending-word ref pins the state object at submit time so the outcome is read from the *response*, not an interim re-render.
- FRONTEND i18n only (ja + en parity): `sayWordHistory.{title,correct,penalty}`.
- No Go changes.

## Test plan
- [x] `bun run check` (biome + design-tokens) — exit 0
- [x] `bun run build` (tsc) — exit 0
- [x] `bun run test -- --run Mao` — 53 passed
- [x] New helper tests: append/cap/immutability
- [x] Page tests: hidden until spoken, accepted outcome + board card, penalty color-coded, cleared on reset

Closes #3548

🤖 Generated with [Claude Code](https://claude.com/claude-code)