### PR TITLE
feat(loo): show pot reward and loo risk at the play/pass decision

### DIFF
--- a/frontend/src/i18n/locales/en/loo.json
+++ b/frontend/src/i18n/locales/en/loo.json
@@ -22,6 +22,11 @@
   "decideCpu": "CPU {{id}} is deciding…",
   "decidePlay": "Play",
   "decidePass": "Pass",
+  "potRisk": {
+    "label": "If you play",
+    "win": "Win: up to +{{pot}} ( +{{perTrick}} per trick )",
+    "loss": "No trick: -{{penalty}} into the pot (looed)"
+  },
   "statusPlay": "In",
   "statusPass": "Out",
   "cards": "{{count}} cards",

--- a/frontend/src/i18n/locales/ja/loo.json
+++ b/frontend/src/i18n/locales/ja/loo.json
@@ -22,6 +22,11 @@
   "decideCpu": "CPU {{id}} が参加判断中です…",
   "decidePlay": "参加",
   "decidePass": "降りる",
+  "potRisk": {
+    "label": "参加した場合の想定損益",
+    "win": "勝てば最大 +{{pot}} 獲得（1トリックにつき +{{perTrick}}）",
+    "loss": "0トリックだと -{{penalty}} をポットへ支払い（looed）"
+  },
   "statusPlay": "参加",
   "statusPass": "降り",
   "cards": "{{count}}枚",

--- a/frontend/src/pages/LooPage.test.tsx
+++ b/frontend/src/pages/LooPage.test.tsx
@@ -102,6 +102,23 @@ describe('LooPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('decide', { play: false }));
   });
 
+  it('shows the pot reward and loo risk at the decide phase', async () => {
+    // Default deal pot/potStart = 12 → win up to +12 (+2 per trick), loo penalty -12.
+    mockExec.mockResolvedValue(decidePhaseState);
+    renderWithProviders(<LooPage />);
+    const potRisk = await screen.findByTestId('loo-pot-risk');
+    expect(potRisk).toHaveTextContent('+12');
+    expect(potRisk).toHaveTextContent('+2');
+    expect(potRisk).toHaveTextContent('-12');
+  });
+
+  it('does not show the pot-risk block outside the human decide turn', async () => {
+    mockExec.mockResolvedValue(playPhaseState);
+    renderWithProviders(<LooPage />);
+    await waitFor(() => expect(screen.getByAltText('♥ Q')).toBeInTheDocument());
+    expect(screen.queryByTestId('loo-pot-risk')).not.toBeInTheDocument();
+  });
+
   it('shows a CPU decide notice on a CPU decide turn', async () => {
     mockExec.mockResolvedValue(cpuDecideState);
     renderWithProviders(<LooPage />);

--- a/frontend/src/pages/LooPage.tsx
+++ b/frontend/src/pages/LooPage.tsx
@@ -30,6 +30,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { LOO_HELP, parseLooCommand } from '../utils/cli/commands/looCommands';
 import { formatLooState } from '../utils/cli/formatters/looFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { computeLooPotRisk } from '../utils/looPotRisk';
 import { playerName } from '../utils/playerUtils';
 
 /** Suit symbols indexed by suit number (1=♠ 2=♣ 3=♥ 4=♦; 0 = unset). */
@@ -325,6 +326,20 @@ function LooPageContent() {
                 {t('decidePrompt')}
               </div>
             )}
+            {canDecide &&
+              (() => {
+                const { pot, looPenalty, perTrick } = computeLooPotRisk(state.pot, state.potStart);
+                return (
+                  <div
+                    className="mb-2 mx-auto max-w-md p-2 rounded bg-black/30 text-center text-sm"
+                    data-testid="loo-pot-risk"
+                  >
+                    <div className="text-ds-text-muted mb-0.5">{t('potRisk.label')}</div>
+                    <div className="text-ds-accent">{t('potRisk.win', { pot, perTrick })}</div>
+                    <div className="text-ds-error">{t('potRisk.loss', { penalty: looPenalty })}</div>
+                  </div>
+                );
+              })()}
             {humanPlayer && (
               <PlayerHandSection
                 humanPlayer={humanPlayer}

--- a/frontend/src/utils/looPotRisk.test.ts
+++ b/frontend/src/utils/looPotRisk.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { computeLooPotRisk } from './looPotRisk';
+
+describe('computeLooPotRisk', () => {
+  it('derives the loo penalty from potStart and the per-trick share from potStart/5', () => {
+    // Default deal: 4 players ante 3 → pot 12, potStart 12.
+    expect(computeLooPotRisk(12, 12)).toEqual({ pot: 12, looPenalty: 12, perTrick: 2 });
+  });
+
+  it('floors the per-trick share when potStart is not divisible by 5', () => {
+    // potStart 18 → 18/5 = 3.6 → floored to 3; penalty stays the full 18.
+    expect(computeLooPotRisk(18, 18)).toEqual({ pot: 18, looPenalty: 18, perTrick: 3 });
+  });
+
+  it('keeps the shown pot independent of the potStart-based risk figures', () => {
+    // Pot can differ from potStart mid-deal; the penalty always tracks potStart.
+    expect(computeLooPotRisk(20, 15)).toEqual({ pot: 20, looPenalty: 15, perTrick: 3 });
+  });
+
+  it('clamps negative inputs to zero', () => {
+    expect(computeLooPotRisk(-5, -5)).toEqual({ pot: 0, looPenalty: 0, perTrick: 0 });
+  });
+
+  it('yields a zero per-trick share for a pot smaller than one share', () => {
+    expect(computeLooPotRisk(4, 4)).toEqual({ pot: 4, looPenalty: 4, perTrick: 0 });
+  });
+});

--- a/frontend/src/utils/looPotRisk.ts
+++ b/frontend/src/utils/looPotRisk.ts
@@ -1,0 +1,41 @@
+/** Number of tricks fought per Loo deal (Five-card Loo). */
+const LOO_TRICK_COUNT = 5;
+
+/** Pot/risk figures for the Loo Play/Pass decision. */
+export interface LooPotRisk {
+  /** Chips currently in the pot at stake this deal (equals `potStart` at the decide phase). */
+  pot: number;
+  /**
+   * Chips a "looed" participant (played but took no trick) pays into the next
+   * deal's pot. The domain penalty is exactly `potStart`.
+   */
+  looPenalty: number;
+  /**
+   * Chips won per trick captured — one fifth of `potStart`, floored, matching
+   * the domain's `share := potStart / LooTrickCount` integer division.
+   */
+  perTrick: number;
+}
+
+/**
+ * Computes the pot reward and loo risk facing the human at the Loo Play/Pass
+ * decision.
+ *
+ * A participant wins `floor(potStart / 5)` chips per trick captured (up to the
+ * whole pot across all five tricks), while a participant who plays but takes no
+ * trick is "looed" and pays a penalty of `potStart` into the next deal's pot.
+ * This is neutral informational display, not advice.
+ *
+ * @param pot - Chips currently in the pot (equals `potStart` at the decide phase).
+ * @param potStart - Pot size at the start of the deal; sizes both the per-trick payout and the loo penalty.
+ * @returns The pot/risk figures for display.
+ */
+export function computeLooPotRisk(pot: number, potStart: number): LooPotRisk {
+  const safePot = Math.max(0, pot);
+  const safeStart = Math.max(0, potStart);
+  return {
+    pot: safePot,
+    looPenalty: safeStart,
+    perTrick: Math.floor(safeStart / LOO_TRICK_COUNT),
+  };
+}


### PR DESCRIPTION
## Summary

At the Loo (Lanterloo) Play/Pass decision, the pot was shown only in the header — the gambling stakes (what you win vs. what a "looed" player pays) were not visible where the decision is made. This adds a neutral pot/risk readout to the decide prompt.

- New pure helper `frontend/src/utils/looPotRisk.ts` (`computeLooPotRisk`) mirrors the proven `bouillottePotOdds.ts` pattern.
- Computed purely from the exposed `state.pot` / `state.potStart` fields — matches the domain exactly, nothing invented:
  - **Loo penalty** = `potStart` (domain `penalty := potStart`).
  - **Per-trick reward** = `floor(potStart / 5)` (domain `share := potStart / LooTrickCount`).
  - **Max win** = the whole pot (all five tricks).
- Displayed in a `data-testid="loo-pot-risk"` block, only on the human's decide turn, above the Play/Pass buttons, using design-system tokens. Sits alongside the existing `state.hint` decision recommendation.
- Frontend-only. No Go touched.
- i18n: `potRisk.{label,win,loss}` added to ja + en (parity).

## Test plan

- [x] `bun run check` (biome) — pass (only pre-existing warnings, none in touched files)
- [x] `bun run test -- --run Loo` — 71 passed (adds `computeLooPotRisk` helper tests + LooPage decide/non-decide display tests)
- [x] `bun run build` (tsc) — pass

Closes #3623