### PR TITLE
feat(rook): highlight recommended weak discards during nest exchange

### DIFF
--- a/frontend/src/i18n/locales/en/rook.json
+++ b/frontend/src/i18n/locales/en/rook.json
@@ -29,6 +29,7 @@
   "bidButton": "Bid",
   "passButton": "Pass",
   "nestExchangeHint": "Discard 5 of your 18 cards (hand + nest) and declare a trump color.",
+  "recommendedDiscardHint": "Cards with a faint outline are recommended discards (you may ignore them).",
   "selectTrump": "Trump color:",
   "exchangeButton": "Exchange ({{count}}/5)",
   "playButton": "Play",

--- a/frontend/src/i18n/locales/ja/rook.json
+++ b/frontend/src/i18n/locales/ja/rook.json
@@ -29,6 +29,7 @@
   "bidButton": "ビッド",
   "passButton": "パス",
   "nestExchangeHint": "ネストを含む18枚から5枚を捨て、切り札色を宣言してください。",
+  "recommendedDiscardHint": "淡い枠の付いた札は推奨の捨て札です（従わなくても構いません）。",
   "selectTrump": "切り札色:",
   "exchangeButton": "交換 ({{count}}/5)",
   "playButton": "出す",

--- a/frontend/src/pages/RookPage.test.tsx
+++ b/frontend/src/pages/RookPage.test.tsx
@@ -176,6 +176,63 @@ describe('RookPage', () => {
     );
   });
 
+  it('highlights the backend-recommended discard cards during nest exchange when hints are enabled', async () => {
+    localStorage.setItem('hint_enabled_rook', 'true');
+    const cards = [card('5', 5), card('6', 6), card('7', 7), card('8', 8), card('9', 9), card('10', 10)];
+    const exchangeState = makeState({
+      phase: 1,
+      declarerIdx: 0,
+      contractBid: 75,
+      players: [
+        player(0, true, cards, { isDeclarer: true }),
+        player(1, false, []),
+        player(2, false, []),
+        player(3, false, []),
+      ] as RookResponse['players'],
+    });
+    mockExec.mockImplementation((cmd) =>
+      cmd === 'hint'
+        ? Promise.resolve({ ...exchangeState, hint: { discardIndices: [1, 3], reason: 'discard_weakest' } })
+        : Promise.resolve(exchangeState),
+    );
+    renderWithProviders(<RookPage />);
+
+    // The backend hint command is queried to obtain the weak cards.
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('hint'));
+    await waitFor(() => expect(screen.getByTestId('hand-card-1')).toHaveAttribute('data-recommended-discard', 'true'));
+    const c1 = screen.getByTestId('hand-card-1');
+    const c3 = screen.getByTestId('hand-card-3');
+    expect(c1.className).toContain('ring-ds-warning');
+    expect(c3).toHaveAttribute('data-recommended-discard', 'true');
+    // Non-recommended cards carry no discard highlight.
+    expect(screen.getByTestId('hand-card-0')).not.toHaveAttribute('data-recommended-discard');
+    // A non-colour cue explains the pale outline.
+    expect(screen.getByTestId('rook-discard-hint')).toBeInTheDocument();
+  });
+
+  it('shows no discard highlight during nest exchange when hints are disabled', async () => {
+    const cards = [card('5', 5), card('6', 6), card('7', 7), card('8', 8), card('9', 9), card('10', 10)];
+    mockExec.mockResolvedValue(
+      makeState({
+        phase: 1,
+        declarerIdx: 0,
+        contractBid: 75,
+        players: [
+          player(0, true, cards, { isDeclarer: true }),
+          player(1, false, []),
+          player(2, false, []),
+          player(3, false, []),
+        ] as RookResponse['players'],
+      }),
+    );
+    renderWithProviders(<RookPage />);
+    await screen.findByTestId('exchange-button');
+    expect(screen.getByTestId('hand-card-0')).not.toHaveAttribute('data-recommended-discard');
+    expect(screen.queryByTestId('rook-discard-hint')).not.toBeInTheDocument();
+    // No hint request is issued while hints are off.
+    expect(mockExec).not.toHaveBeenCalledWith('hint');
+  });
+
   it('plays a selected card in the play phase', async () => {
     mockExec.mockResolvedValue(makeState({ phase: 2, currentPlayerIdx: 0, contractBid: 75, trumpColor: 1 }));
     renderWithProviders(<RookPage />);

--- a/frontend/src/pages/RookPage.tsx
+++ b/frontend/src/pages/RookPage.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { rookApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
 import { CliToggle } from '../components/cli/CliToggle';
@@ -101,6 +102,36 @@ function RookPageContent() {
 
   const [bidValue, setBidValue] = useState(ROOK_MIN_BID);
   const [trumpChoice, setTrumpChoice] = useState<number | null>(null);
+
+  // Recommended weak cards to discard during the nest exchange. The backend
+  // computes the authoritative list (Rook.go GetHint → "discard_weakest",
+  // surfaced via the `hint` command); the frontend has no equivalent model, so
+  // we fetch it here rather than invent one. Gated on the hint toggle: disabling
+  // hints clears the highlight. Fetched with rookApi directly (not the game
+  // hook's exec) so it never disturbs the main state or the player's selection.
+  const [recommendedDiscards, setRecommendedDiscards] = useState<number[] | null>(null);
+  // `inHumanExchange` flips false during the intervening play phase, so it
+  // re-triggers the fetch for each round's exchange without a round dependency.
+  const inHumanExchange = state?.phase === RookPhase.NEST_EXCHANGE && state?.declarerIdx === 0;
+
+  useEffect(() => {
+    if (!inHumanExchange || !frontendHintEnabled) {
+      setRecommendedDiscards(null);
+      return;
+    }
+    let cancelled = false;
+    rookApi
+      .exec('hint')
+      .then((res) => {
+        if (!cancelled) setRecommendedDiscards(res.hint?.discardIndices ?? null);
+      })
+      .catch(() => {
+        if (!cancelled) setRecommendedDiscards(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [inHumanExchange, frontendHintEnabled]);
 
   // CLI mode
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('rook');
@@ -284,17 +315,25 @@ function RookPageContent() {
                 {human.isDeclarer && <span className="font-bold text-ds-warning"> ★</span>}
               </div>
               {isHumanExchange && <div className="text-xs text-ds-info mb-1">{t('nestExchangeHint')}</div>}
+              {isHumanExchange && recommendedDiscards && recommendedDiscards.length > 0 && (
+                <div className="text-xs text-ds-warning mb-1" data-testid="rook-discard-hint">
+                  {t('recommendedDiscardHint')}
+                </div>
+              )}
               <div className="flex flex-wrap justify-center gap-2">
                 {human.cards.map((c, i) => {
                   const selected = selectedCardIndices.includes(i);
                   const selectable = isHumanPlayTurn || isHumanExchange;
-                  const cardClass = selected
-                    ? selectable
-                      ? 'rounded transition-all ring-2 ring-ds-info -translate-y-2 cursor-pointer hover:opacity-90'
-                      : 'rounded transition-all ring-2 ring-ds-info -translate-y-2 cursor-default'
-                    : selectable
-                      ? 'rounded transition-all cursor-pointer hover:opacity-90'
-                      : 'rounded transition-all cursor-default';
+                  // A pale ring marks the backend's recommended discards, but an
+                  // explicit selection (info ring) always takes visual priority.
+                  const recommendedDiscard = isHumanExchange && !selected && !!recommendedDiscards?.includes(i);
+                  const cursorClass = selectable ? 'cursor-pointer hover:opacity-90' : 'cursor-default';
+                  const ringClass = selected
+                    ? 'ring-2 ring-ds-info -translate-y-2'
+                    : recommendedDiscard
+                      ? 'ring-2 ring-ds-warning/70'
+                      : '';
+                  const cardClass = `rounded transition-all ${ringClass} ${cursorClass}`.replace(/\s+/g, ' ').trim();
                   return (
                     <button
                       key={i}
@@ -303,6 +342,7 @@ function RookPageContent() {
                       disabled={!selectable}
                       className={cardClass}
                       data-testid={`hand-card-${i}`}
+                      data-recommended-discard={recommendedDiscard ? 'true' : undefined}
                     >
                       <AnimatedCard card={c} width={cardWidth} />
                     </button>


### PR DESCRIPTION
## 概要

ルークのネスト交換フェーズ（落札者が手札5枚を捨てる）で、バックエンドが算出する推奨捨て札（弱札）に淡い枠（`ring-ds-warning/70`）を付けて可視化します。従来のトランプ色選択・5枚選択判定はそのままです。

Closes #3513

## 弱札の出所（authoritative source）

推奨捨て札は `internal/domain/Rook.go` の `GetHint` が `RookPhaseNestExchange` で返す `DiscardIndices`（reason: `discard_weakest`）。これは `RookWebPresenter.HintOutput`（`hint` コマンド）経由でフロントに公開されており、`RookResponse.hint.discardIndices` として取得できます。フロントの `getRookHint` は意図的な null スタブで、`cpuSelectDiscards`（トランプ推定＋点数評価に依存）をクライアントで再現すると「捏造」になるため、権威ある値を `hint` コマンドで取得する方針にしました。

## 実装（フロントのみ）

- `RookPage.tsx`
  - ヒントトグルON かつ 人間の交換フェーズのとき `rookApi.exec('hint')` を直接呼び、`hint.discardIndices` を取得（ゲーム本体の state / 選択状態を汚さない）。トグルOFF・非交換フェーズでは何も出さない。
  - 手札レンダリングで推奨札に淡い枠 + `data-recommended-discard` を付与。選択（`ring-ds-info`）が視覚的に優先。
  - 色だけに頼らないよう、推奨がある間は説明テキスト行（`recommendedDiscardHint`）を表示。
- i18n: ja/en に `recommendedDiscardHint` を追加（パリティOK）。

## 受け入れ条件

- [x] 交換フェーズで推奨捨て札インデックスが枠表示される
- [x] ヒント無効時は何も表示しない（`hint` コマンドも呼ばない）
- [x] 5枚選択の完了判定は従来通り（変更なし）
- [x] Rook レスポンスに `discardIndices` が載ることを確認（`hint` コマンド経由）

## テスト

- `highlights the backend-recommended discard cards during nest exchange when hints are enabled`
- `shows no discard highlight during nest exchange when hints are disabled`

## ゲート

- `bun run check`：pass（新規warningなし）
- `bun run test -- --run Rook`：39 passed
- `bun run build`（tsc）：pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)