### PR TITLE
feat(pinochle): add server-hint button to the web page

### DIFF
--- a/frontend/src/hooks/usePinochleGame.test.ts
+++ b/frontend/src/hooks/usePinochleGame.test.ts
@@ -173,15 +173,66 @@ describe('usePinochleGame', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('nextround'));
   });
 
-  it('handleHint calls exec with hint command', async () => {
+  it('handleHint fetches the server hint and stores it without touching game state', async () => {
     mockExec.mockResolvedValue(basePinochleState);
     const { result } = renderHook(() => usePinochleGame(), { wrapper: createWrapper() });
     await waitFor(() => expect(result.current.state).not.toBeNull());
 
     mockExec.mockClear();
+    // The hint command returns only the bare hint object (top-level fields).
+    mockExec.mockResolvedValue({ bidAmount: 25, reason: 'hint_bid' } as unknown as PinochleResponse);
+    await act(async () => {
+      await result.current.handleHint();
+    });
+
+    expect(mockExec).toHaveBeenCalledWith('hint');
+    expect(result.current.hint).toEqual({ bidAmount: 25, reason: 'hint_bid' });
+    expect(result.current.hintError).toBeNull();
+    // Game state is unaffected by a hint fetch.
+    expect(result.current.state).toEqual(basePinochleState);
+  });
+
+  it('handleHint ignores an empty (no-reason) hint response', async () => {
     mockExec.mockResolvedValue(basePinochleState);
-    act(() => result.current.handleHint());
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('hint'));
+    const { result } = renderHook(() => usePinochleGame(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.state).not.toBeNull());
+
+    mockExec.mockClear();
+    mockExec.mockResolvedValue({ message: 'ヒントなし' } as unknown as PinochleResponse);
+    await act(async () => {
+      await result.current.handleHint();
+    });
+    expect(result.current.hint).toBeNull();
+  });
+
+  it('handleHint sets hintError when the request fails', async () => {
+    mockExec.mockResolvedValue(basePinochleState);
+    const { result } = renderHook(() => usePinochleGame(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.state).not.toBeNull());
+
+    mockExec.mockClear();
+    mockExec.mockRejectedValueOnce(new Error('network'));
+    await act(async () => {
+      await result.current.handleHint();
+    });
+    expect(result.current.hintError).not.toBeNull();
+    expect(result.current.hint).toBeNull();
+  });
+
+  it('clears the hint after a subsequent game action succeeds', async () => {
+    mockExec.mockResolvedValue(basePinochleState);
+    const { result } = renderHook(() => usePinochleGame(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.state).not.toBeNull());
+
+    mockExec.mockResolvedValue({ suit: 1, reason: 'hint_trump' } as unknown as PinochleResponse);
+    await act(async () => {
+      await result.current.handleHint();
+    });
+    expect(result.current.hint).not.toBeNull();
+
+    mockExec.mockResolvedValue(basePinochleState);
+    act(() => result.current.handleCallTrump(1));
+    await waitFor(() => expect(result.current.hint).toBeNull());
   });
 
   it('handleReset calls exec with reset command and current config', async () => {

--- a/frontend/src/hooks/usePinochleGame.ts
+++ b/frontend/src/hooks/usePinochleGame.ts
@@ -1,8 +1,23 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { pinochleApi } from '../api/gameApi';
+import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
 import type { PinochleConfig } from '../types/card';
 import { useGameApi } from './useGameApi';
 import { useGameConfig } from './useGameConfig';
+
+/**
+ * Server-computed hint returned by the Pinochle `hint` command. Exactly one of
+ * the value fields is set depending on the current phase: `bidAmount` or `pass`
+ * during bidding, `suit` when declaring trump, and `cardIndex` during play.
+ * `reason` is an i18n key under the `hintReason` namespace.
+ */
+export interface PinochleHint {
+  cardIndex?: number;
+  bidAmount?: number;
+  pass?: boolean;
+  suit?: number;
+  reason: string;
+}
 
 /** Default Pinochle game configuration. */
 export const DEFAULT_PINOCHLE_CONFIG: PinochleConfig = {
@@ -24,7 +39,13 @@ export const POINT_LIMIT_OPTIONS = [500, 1000, 1500, 2000, 3000] as const;
 export function usePinochleGame() {
   const { config: pinochleConfig, handleConfigChange } = useGameConfig<PinochleConfig>(DEFAULT_PINOCHLE_CONFIG);
 
-  const { state, loading, error, exec: rawExec, retry } = useGameApi(pinochleApi.exec);
+  const [hint, setHint] = useState<PinochleHint | null>(null);
+  const [hintError, setHintError] = useState<string | null>(null);
+  const [hintLoading, setHintLoading] = useState(false);
+
+  // Any successful game action invalidates the previous hint.
+  const onSuccess = useCallback(() => setHint(null), []);
+  const { state, loading, error, exec: rawExec, retry } = useGameApi(pinochleApi.exec, { onSuccess });
 
   const gameExec = useCallback((...args: Parameters<typeof rawExec>) => rawExec(...args), [rawExec]);
 
@@ -73,14 +94,32 @@ export function usePinochleGame() {
     gameExec('nextround');
   }, [gameExec]);
 
-  const handleHint = useCallback(() => {
-    gameExec('hint');
-  }, [gameExec]);
+  // The `hint` command returns only the hint object (not full game state), so
+  // it is fetched directly and stored separately rather than via gameExec,
+  // which would otherwise clobber the rendered game state.
+  const handleHint = useCallback(async () => {
+    setHintLoading(true);
+    try {
+      const res = await pinochleApi.exec('hint');
+      // Server marshals the bare hint fields at the top level (cardIndex,
+      // bidAmount, pass, suit, reason); when no hint applies `reason` is absent.
+      const raw = res as unknown as Partial<PinochleHint>;
+      setHint(raw.reason ? (raw as PinochleHint) : null);
+      setHintError(null);
+    } catch {
+      setHintError(NETWORK_ERROR_MESSAGE());
+    } finally {
+      setHintLoading(false);
+    }
+  }, []);
 
   return {
     state,
     loading,
     error,
+    hint,
+    hintError,
+    hintLoading,
     exec: rawExec,
     pinochleConfig,
     handleConfigChange,

--- a/frontend/src/i18n/locales/en/pinochle.json
+++ b/frontend/src/i18n/locales/en/pinochle.json
@@ -61,6 +61,11 @@
     "hint_trump": "This suit is optimal for trump",
     "hint_play": "This card is the best play"
   },
+  "serverHintPass": "Recommended: Pass",
+  "serverHintBid": "Recommended bid: {{n}}",
+  "serverHintTrump": "Recommended trump: {{suit}}",
+  "serverHintPlay": "Recommended play: {{card}} [{{idx}}]",
+  "applyBid": "Apply",
   "tutorial": {
     "gameInfo": "Shows the round/trick number, team scores, trump suit, and highest bid.",
     "playerInfo": "Each player's team, bid, meld score, and tricks taken.",

--- a/frontend/src/i18n/locales/ja/pinochle.json
+++ b/frontend/src/i18n/locales/ja/pinochle.json
@@ -61,6 +61,11 @@
     "hint_trump": "このスートをトランプに宣言するのが最適です",
     "hint_play": "このカードをプレイするのが最適です"
   },
+  "serverHintPass": "推奨: パス",
+  "serverHintBid": "推奨ビッド: {{n}}",
+  "serverHintTrump": "推奨トランプ: {{suit}}",
+  "serverHintPlay": "推奨プレイ: {{card}} [{{idx}}]",
+  "applyBid": "反映",
   "tutorial": {
     "gameInfo": "ラウンド・トリック番号、両チームの得点、切り札、最高ビッドを確認できます。",
     "playerInfo": "各プレイヤーのチーム・ビッド・メルド得点・獲得トリック数が表示されます。",

--- a/frontend/src/pages/PinochlePage.test.tsx
+++ b/frontend/src/pages/PinochlePage.test.tsx
@@ -483,6 +483,68 @@ describe('PinochlePage', () => {
     await waitFor(() => expect(screen.getByTestId('hint-tooltip')).toBeInTheDocument());
   });
 
+  it('shows a server-hint button on the human bid turn', async () => {
+    renderWithProviders(<PinochlePage />);
+    await waitFor(() => expect(screen.getByTestId('pn-hint-button')).toBeInTheDocument());
+  });
+
+  it('fetches and displays the recommended bid, and applies it to the input', async () => {
+    renderWithProviders(<PinochlePage />);
+    await waitFor(() => expect(screen.getByTestId('pn-hint-button')).toBeInTheDocument());
+
+    mockExec.mockClear();
+    mockExec.mockResolvedValue({ bidAmount: 30, reason: 'hint_bid' } as unknown as PinochleResponse);
+    fireEvent.click(screen.getByTestId('pn-hint-button'));
+
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('hint'));
+    const hintBox = await screen.findByTestId('pn-server-hint');
+    expect(hintBox).toHaveTextContent('推奨ビッド: 30');
+
+    // Applying the hint updates the bid input value.
+    fireEvent.click(screen.getByTestId('pn-hint-apply-bid'));
+    expect(screen.getByLabelText('ビッド額（最低 20）')).toHaveDisplayValue('30');
+  });
+
+  it('displays a pass recommendation from the server hint', async () => {
+    renderWithProviders(<PinochlePage />);
+    await waitFor(() => expect(screen.getByTestId('pn-hint-button')).toBeInTheDocument());
+
+    mockExec.mockClear();
+    mockExec.mockResolvedValue({ pass: true, reason: 'hint_pass' } as unknown as PinochleResponse);
+    fireEvent.click(screen.getByTestId('pn-hint-button'));
+
+    const hintBox = await screen.findByTestId('pn-server-hint');
+    expect(hintBox).toHaveTextContent('推奨: パス');
+    // No apply-bid button for a pass recommendation.
+    expect(screen.queryByTestId('pn-hint-apply-bid')).not.toBeInTheDocument();
+  });
+
+  it('displays a card recommendation on the human play turn', async () => {
+    mockExec.mockResolvedValue(playPhaseState);
+    renderWithProviders(<PinochlePage />);
+    await waitFor(() => expect(screen.getByTestId('pn-hint-button')).toBeInTheDocument());
+
+    mockExec.mockClear();
+    mockExec.mockResolvedValue({ cardIndex: 1, reason: 'hint_play' } as unknown as PinochleResponse);
+    fireEvent.click(screen.getByTestId('pn-hint-button'));
+
+    const hintBox = await screen.findByTestId('pn-server-hint');
+    expect(hintBox).toHaveTextContent('推奨プレイ');
+    expect(hintBox).toHaveTextContent('[1]');
+  });
+
+  it('shows an error alert when the hint request fails', async () => {
+    renderWithProviders(<PinochlePage />);
+    await waitFor(() => expect(screen.getByTestId('pn-hint-button')).toBeInTheDocument());
+
+    mockExec.mockClear();
+    mockExec.mockRejectedValueOnce(new Error('network'));
+    fireEvent.click(screen.getByTestId('pn-hint-button'));
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+    expect(screen.queryByTestId('pn-server-hint')).not.toBeInTheDocument();
+  });
+
   it('shows 次のゲーム at game-end and fires reset directly (no confirm)', async () => {
     mockExec.mockResolvedValue(gameEndState);
     renderWithProviders(<PinochlePage />);

--- a/frontend/src/pages/PinochlePage.tsx
+++ b/frontend/src/pages/PinochlePage.tsx
@@ -115,6 +115,10 @@ function PinochlePageContent() {
     handlePlay,
     handleNextTrick,
     handleNextRound,
+    hint,
+    hintError,
+    hintLoading,
+    handleHint,
   } = usePinochleGame();
 
   const { cardWidth } = useCardDimensions();
@@ -448,9 +452,59 @@ function PinochlePageContent() {
               </div>
             )}
 
-            <ErrorAlert message={error} onRetry={retry} />
+            <ErrorAlert message={error ?? hintError} onRetry={retry} />
+
+            {/* Server hint result (bid amount / pass / trump suit / play card) */}
+            {hint?.reason && (
+              <div
+                className="text-ds-warning text-sm mb-2 flex items-center gap-2 flex-wrap"
+                data-testid="pn-server-hint"
+              >
+                <span>
+                  {hint.pass
+                    ? t('serverHintPass')
+                    : hint.bidAmount !== undefined
+                      ? t('serverHintBid', { n: hint.bidAmount })
+                      : hint.suit !== undefined
+                        ? t('serverHintTrump', { suit: SUIT_LABELS[hint.suit] ?? '-' })
+                        : hint.cardIndex !== undefined
+                          ? t('serverHintPlay', {
+                              card: humanPlayer?.cards[hint.cardIndex]
+                                ? cardAlt(humanPlayer.cards[hint.cardIndex])
+                                : '-',
+                              idx: hint.cardIndex,
+                            })
+                          : ''}{' '}
+                  ({t(`hintReason.${hint.reason}`)})
+                </span>
+                {isBidTurn && hint.bidAmount !== undefined && (
+                  <button
+                    type="button"
+                    className={btnOutline}
+                    data-testid="pn-hint-apply-bid"
+                    onClick={() => hint.bidAmount !== undefined && setBidAmount(hint.bidAmount)}
+                    disabled={loading}
+                  >
+                    {t('applyBid')}
+                  </button>
+                )}
+              </div>
+            )}
 
             <div className="flex gap-2 items-center flex-wrap" data-tutorial="pn-action-buttons">
+              {/* Server hint */}
+              {(isBidTurn || isTrumpTurn || isPlayTurn) && (
+                <button
+                  type="button"
+                  className={btnSuccess}
+                  data-testid="pn-hint-button"
+                  onClick={handleHint}
+                  disabled={loading || hintLoading}
+                >
+                  {tc('button.hint')}
+                </button>
+              )}
+
               {/* Bid */}
               {isBidTurn && (
                 <>


### PR DESCRIPTION
## 概要

ピノクルの Web 版にサーバーヒントボタンを追加します。バックエンド（`PinochleWebPresenter.HintOutput` / `Pinochle.Hint`）はビッド額・パス・トランプ・プレイ推奨まで揃ったヒントを返せますが、`PinochlePage.tsx` にはそれを呼ぶ UI がなく、CUI プレイヤーだけが支援を受けられる状態でした。

Closes #3110

## 変更点

- **`usePinochleGame.ts`**: `handleHint` を修正。従来は `gameExec('hint')` でゲーム状態を上書きしてしまい、しかもページからは一度も呼ばれていませんでした。`hint` コマンドは（全状態ではなく）ヒントオブジェクトのみを返すため、`pinochleApi.exec('hint')` を直接呼び、`hint` / `hintError` / `hintLoading` を独立した state として保持します。ヒントは任意のゲーム操作成功時（`onSuccess`）にクリアします。エクスポート型 `PinochleHint` を追加。
- **`PinochlePage.tsx`**: 人間のビッド/トランプ/プレイ手番に `btnSuccess` のヒントボタンを表示。結果を黄色テキスト（`text-ds-warning`）で表示（推奨ビッド額 / パス / トランプスート / プレイカード + 理由）。ビッドヒントには入力欄へワンタップ反映する「反映」ボタンを追加。ヒント取得エラーは `ErrorAlert` に流します。
- **i18n**: `serverHintPass` / `serverHintBid` / `serverHintTrump` / `serverHintPlay` / `applyBid` を ja・en に追加（既存の `hintReason.*` を理由文に再利用）。

## ヒントの取得元

サーバーの `hint` コマンド（`PinochleWebController` → `dispatchHintAndLog` → `PinochleWebPresenter.HintOutput`）。フェーズに応じて `bidAmount`/`pass`（ビッド）、`suit`（トランプ）、`cardIndex`（プレイ）のいずれかと `reason`（i18n キー）を返します。

## テスト

フロントのみ。フック・ページ双方にテストを追加。

- [x] `cd frontend && bun run check`（exit 0、警告は既存の無関係ファイルのみ）
- [x] `cd frontend && bun run test -- --run Pinochle`（64 passed）
- [x] `cd frontend && bun run build`（tsc + vite OK）

### 受け入れ条件

- [x] ビッド手番のヒントで推奨額またはパスが表示される
- [x] トランプ手番でスート推奨、プレイ手番でカード推奨が表示される
- [x] ビッドヒントの適用で入力値が更新される
- [x] フック・ページ双方のテストを追加

Go は一切変更していません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)