### PR TITLE
feat(fortythieves): double-tap to auto-move a card to a foundation

### DIFF
--- a/frontend/src/hooks/useFortyThievesGame.ts
+++ b/frontend/src/hooks/useFortyThievesGame.ts
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useState } from 'react';
 import { type FortyThievesMoveZone, fortyThievesApi } from '../api/gameApi';
 import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
-import type { FortyThievesHint } from '../types/card';
+import type { Card, FortyThievesHint } from '../types/card';
+import { fortyThievesFoundationTarget } from '../utils/fortyThievesFoundationTarget';
 import { useAutoCompleteState } from './useAutoCompleteState';
 import { useGameApi } from './useGameApi';
 
@@ -89,6 +90,23 @@ export function useFortyThievesGame() {
     [selectedSource, exec],
   );
 
+  /**
+   * Double-click / double-tap shortcut: auto-send an exposed top card (from the
+   * waste or a tableau column) straight to a foundation when a legal target
+   * exists; otherwise do nothing (no error, selection cleared). Mirrors the
+   * Easthaven foundation shortcut. `source` is the card's own zone.
+   */
+  const handleFoundationShortcut = useCallback(
+    (source: FortyThievesMoveZone, card: Card) => {
+      const target = fortyThievesFoundationTarget(card, state?.foundation ?? []);
+      if (!target) return;
+      setHint(null);
+      exec('move', source, target);
+      setSelectedSource(null);
+    },
+    [state?.foundation, exec],
+  );
+
   return {
     state,
     loading,
@@ -106,6 +124,7 @@ export function useFortyThievesGame() {
     handleUndoEscape,
     handleSelectSource,
     handleSelectTarget,
+    handleFoundationShortcut,
     isAutoCompleting,
     retry,
   };

--- a/frontend/src/pages/FortyThievesPage.test.tsx
+++ b/frontend/src/pages/FortyThievesPage.test.tsx
@@ -396,6 +396,63 @@ describe('FortyThievesPage', () => {
     }
   });
 
+  it('double-clicking a foundation-playable tableau top card sends it to a foundation', async () => {
+    const aceState: FortyThievesResponse = {
+      ...playingState,
+      tableau: makeTableau([[{ card: card('SPADE', 1), faceUp: true }]]),
+      waste: [],
+      foundation: [[], [], [], [], [], [], [], []],
+    };
+    mockExec.mockResolvedValue(aceState);
+    renderWithProviders(<FortyThievesPage />);
+    await waitFor(() => expect(screen.getByTestId('ft-tableau-top-0')).toBeInTheDocument());
+
+    mockExec.mockClear();
+    mockExec.mockResolvedValue(aceState);
+    fireEvent.dblClick(screen.getByTestId('ft-tableau-top-0'));
+
+    await waitFor(() =>
+      expect(mockExec).toHaveBeenCalledWith(
+        'move',
+        { zone: 'tableau', col: 0, cardIndex: 0 },
+        { zone: 'foundation', col: 0 },
+      ),
+    );
+  });
+
+  it('double-clicking a foundation-playable waste card sends it to a foundation', async () => {
+    const aceWasteState: FortyThievesResponse = {
+      ...playingState,
+      tableau: makeTableau([]),
+      waste: [card('SPADE', 1)],
+      foundation: [[], [], [], [], [], [], [], []],
+    };
+    mockExec.mockResolvedValue(aceWasteState);
+    renderWithProviders(<FortyThievesPage />);
+    await waitFor(() => expect(screen.getByTestId('ft-waste-top')).toBeInTheDocument());
+
+    mockExec.mockClear();
+    mockExec.mockResolvedValue(aceWasteState);
+    fireEvent.dblClick(screen.getByTestId('ft-waste-top'));
+
+    await waitFor(() =>
+      expect(mockExec).toHaveBeenCalledWith('move', { zone: 'waste' }, { zone: 'foundation', col: 0 }),
+    );
+  });
+
+  it('double-clicking a card with no legal foundation target does nothing', async () => {
+    // playingState: tableau col 0 top is ♠K and waste top is ♣3 with every
+    // foundation empty, so neither card has a legal foundation move.
+    renderWithProviders(<FortyThievesPage />);
+    await waitFor(() => expect(screen.getByTestId('ft-waste-top')).toBeInTheDocument());
+
+    mockExec.mockClear();
+    fireEvent.dblClick(screen.getByTestId('ft-tableau-top-0'));
+    fireEvent.dblClick(screen.getByTestId('ft-waste-top'));
+
+    expect(mockExec).not.toHaveBeenCalledWith('move', expect.anything(), expect.anything());
+  });
+
   it('shows hint text after clicking hint', async () => {
     renderWithProviders(<FortyThievesPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: 'ヒント' })).toBeInTheDocument());

--- a/frontend/src/pages/FortyThievesPage.tsx
+++ b/frontend/src/pages/FortyThievesPage.tsx
@@ -28,6 +28,7 @@ import { useSolitaireDragDrop } from '../hooks/useSolitaireDragDrop';
 import { useSound } from '../providers/SoundProvider';
 import { btnDanger, btnPrimary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
+import type { Card } from '../types/card';
 import { FortyThievesPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
@@ -110,6 +111,7 @@ function FortyThievesPageContent() {
     handleUndoEscape,
     handleSelectSource,
     handleSelectTarget,
+    handleFoundationShortcut,
     isAutoCompleting,
   } = useFortyThievesGame();
 
@@ -285,16 +287,22 @@ function FortyThievesPageContent() {
                   {wasteDisplay.length > 0 ? (
                     <button
                       type="button"
-                      onClick={() => {
+                      onClick={(e) => {
+                        // The second click of a double-click also fires onClick
+                        // (detail === 2); ignore it so onDoubleClick owns the
+                        // foundation shortcut without leaving a stray selection.
+                        if (e.detail >= 2) return;
                         if (selectedSource) return;
                         handleSelectSource({ zone: 'waste' });
                       }}
+                      onDoubleClick={() => handleFoundationShortcut({ zone: 'waste' }, wasteDisplay[0])}
                       disabled={!isPlaying || loading}
                       aria-label={cardAlt(wasteDisplay[0])}
                       aria-pressed={isSourceSelected('waste')}
                       draggable={isPlaying && !loading}
                       onDragStart={dnd.handleDragStart({ zone: 'waste' })}
                       onDragEnd={dnd.handleDragEnd}
+                      data-testid="ft-waste-top"
                       className={`p-0 border-0 bg-transparent cursor-pointer rounded ${focusRingWhite} ${isSourceSelected('waste') ? 'ring-2 ring-ds-warning' : isHintFromWaste ? HINT_RING : ''} ${dnd.isDragSource({ zone: 'waste' }) ? 'opacity-50' : ''}`}
                     >
                       <AnimatedCard card={wasteDisplay[0]} width={ft.cw} draggable={false} />
@@ -399,6 +407,9 @@ function FortyThievesPageContent() {
                               col: colIdx,
                               cardIndex: cardIdx,
                             };
+                            // Only a column's exposed top card can be sent
+                            // straight to a foundation (single-card move rule).
+                            const isLast = cardIdx === col.length - 1;
                             return (
                               <div
                                 key={`tc-${colIdx.toString()}-${cardIdx.toString()}`}
@@ -408,19 +419,31 @@ function FortyThievesPageContent() {
                                 {tc.faceUp && tc.card ? (
                                   <button
                                     type="button"
-                                    onClick={() => {
+                                    onClick={(e) => {
+                                      // The second click of a double-click also
+                                      // fires onClick (detail === 2); ignore it
+                                      // so onDoubleClick owns the foundation
+                                      // shortcut without a stray select/target.
+                                      if (e.detail >= 2) return;
                                       if (selectedSource) {
                                         handleSelectTarget(tableauColZone);
                                       } else {
                                         handleSelectSource(cardZone);
                                       }
                                     }}
+                                    onDoubleClick={
+                                      // Only the exposed top card can jump to a foundation.
+                                      isLast && tc.card
+                                        ? () => handleFoundationShortcut(cardZone, tc.card as Card)
+                                        : undefined
+                                    }
                                     disabled={!isPlaying || loading}
                                     aria-label={cardAlt(tc.card)}
                                     aria-pressed={isSourceSelected('tableau', colIdx, cardIdx)}
                                     draggable={isPlaying && !loading}
                                     onDragStart={dnd.handleDragStart(cardZone)}
                                     onDragEnd={dnd.handleDragEnd}
+                                    data-testid={isLast ? `ft-tableau-top-${colIdx.toString()}` : undefined}
                                     className={`p-0 border-0 bg-transparent cursor-pointer w-full rounded ${focusRingWhite} ${isSourceSelected('tableau', colIdx, cardIdx) ? 'ring-2 ring-ds-warning' : isHintFromTableau(colIdx, cardIdx) ? HINT_RING : ''} ${dnd.isDragSource(cardZone) ? 'opacity-50' : ''}`}
                                   >
                                     <AnimatedCard

--- a/frontend/src/utils/fortyThievesFoundationTarget.test.ts
+++ b/frontend/src/utils/fortyThievesFoundationTarget.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import type { Card, CardDesign } from '../types/card';
+import { fortyThievesFoundationTarget } from './fortyThievesFoundationTarget';
+
+const card = (design: CardDesign, value: number): Card => ({ design, value });
+const emptyFoundation = (): Card[][] => [[], [], [], [], [], [], [], []];
+
+describe('fortyThievesFoundationTarget', () => {
+  it('sends an Ace to the first empty foundation pile', () => {
+    // Piles are not suit-locked, so any Ace lands on pile 0 when all are empty.
+    expect(fortyThievesFoundationTarget(card('SPADE', 1), emptyFoundation())).toEqual({ zone: 'foundation', col: 0 });
+    expect(fortyThievesFoundationTarget(card('DIAMOND', 1), emptyFoundation())).toEqual({ zone: 'foundation', col: 0 });
+  });
+
+  it('rejects a non-Ace on an all-empty foundation', () => {
+    expect(fortyThievesFoundationTarget(card('SPADE', 2), emptyFoundation())).toBeNull();
+    expect(fortyThievesFoundationTarget(card('HEART', 13), emptyFoundation())).toBeNull();
+  });
+
+  it('sends the next rank up onto the matching-suit pile', () => {
+    const foundation: Card[][] = [[card('SPADE', 1)], [card('HEART', 1), card('HEART', 2)], [], [], [], [], [], []];
+    expect(fortyThievesFoundationTarget(card('SPADE', 2), foundation)).toEqual({ zone: 'foundation', col: 0 });
+    expect(fortyThievesFoundationTarget(card('HEART', 3), foundation)).toEqual({ zone: 'foundation', col: 1 });
+  });
+
+  it('rejects a card whose rank is not exactly one above its matching pile top', () => {
+    const foundation: Card[][] = [[card('SPADE', 1)], [], [], [], [], [], [], []];
+    // 3♠ needs a 2♠ on top; pile 0 holds A♠ and no empty pile accepts a non-Ace.
+    expect(fortyThievesFoundationTarget(card('SPADE', 3), foundation)).toBeNull();
+  });
+
+  it('routes a duplicate Ace to the next empty pile (two-deck game)', () => {
+    // A♠ is already on pile 0, so the second A♠ lands on the first empty pile.
+    const foundation: Card[][] = [[card('SPADE', 1)], [], [], [], [], [], [], []];
+    expect(fortyThievesFoundationTarget(card('SPADE', 1), foundation)).toEqual({ zone: 'foundation', col: 1 });
+  });
+
+  it('requires a matching suit even when a same-rank slot exists on another suit', () => {
+    const foundation: Card[][] = [[card('HEART', 1)], [], [], [], [], [], [], []];
+    // 2♠ cannot stack on the 1♥ pile, and no empty pile accepts a non-Ace.
+    expect(fortyThievesFoundationTarget(card('SPADE', 2), foundation)).toBeNull();
+  });
+
+  it('finds a later pile when earlier piles do not accept the card', () => {
+    // Ace already placed on pile 0; the 2♥ must skip to its matching suit pile.
+    const foundation: Card[][] = [[card('SPADE', 1)], [], [], [], [], [], [card('HEART', 1)], []];
+    expect(fortyThievesFoundationTarget(card('HEART', 2), foundation)).toEqual({ zone: 'foundation', col: 6 });
+  });
+});

--- a/frontend/src/utils/fortyThievesFoundationTarget.ts
+++ b/frontend/src/utils/fortyThievesFoundationTarget.ts
@@ -1,0 +1,32 @@
+import type { FortyThievesMoveZone } from '../api/gameApi';
+import type { Card } from '../types/card';
+
+/**
+ * Computes the legal foundation move target for `card` given the current
+ * `foundation` piles, or `null` when no legal foundation move exists.
+ *
+ * Mirrors the domain's `findFoundation` + `canPlaceOnFoundation` in
+ * `FortyThieves.go`: the eight foundation piles are NOT locked to a suit by
+ * index, so they are scanned in order and the first pile that accepts the card
+ * wins. An empty pile accepts only an Ace (`value === 1`); a non-empty pile
+ * requires the same suit and a rank exactly one higher than its top card.
+ *
+ * The backend recomputes the destination pile itself (`MoveTableauToFoundation`
+ * / `MoveWasteToFoundation` take no foundation index), so the returned `col`
+ * only needs to identify a legal move — its exact value is not sent as the
+ * destination. It is returned for symmetry with the tableau/foundation zone
+ * shape and for hint-ring reuse.
+ *
+ * @param card - The exposed waste or tableau top card being double-clicked.
+ * @param foundation - The eight foundation piles (bottom card first).
+ * @returns A `{ zone: 'foundation', col }` move target, or `null` if illegal.
+ */
+export function fortyThievesFoundationTarget(card: Card, foundation: Card[][]): FortyThievesMoveZone | null {
+  for (let i = 0; i < foundation.length; i++) {
+    const pile = foundation[i];
+    const top = pile.length > 0 ? pile[pile.length - 1] : null;
+    const placeable = top === null ? card.value === 1 : card.design === top.design && card.value === top.value + 1;
+    if (placeable) return { zone: 'foundation', col: i };
+  }
+  return null;
+}


### PR DESCRIPTION
## 概要

Forty Thieves で、ウェイスト／タブロー最上段のカードをダブルクリック（モバイルはダブルタップ）すると、可能な場合に自動でファウンデーションへ移動します。40枚デッキ・8ファウンデーションで頻出する「上がり」移動の2ステップ操作コストを解消します。

既存のクリック選択（source→target）とドラッグ＆ドロップはそのまま維持しています（追加的な変更）。

## 実装

- **純粋ヘルパー `fortyThievesFoundationTarget`** を追加。ドメインの `findFoundation` / `canPlaceOnFoundation`（`internal/domain/FortyThieves.go`）を忠実にミラー。ファウンデーションは添字でスート固定されていないため8山を順に走査し、最初に受け入れる山を返す。2デッキ構成のため、重複するエースは次の空き山へルーティングされる。バックエンドは移動先の山を自身で再計算する（`MoveTableauToFoundation` / `MoveWasteToFoundation` は山インデックスを取らない）ため、返す `col` は合法手の識別のみに使う。
- `useFortyThievesGame` に **`handleFoundationShortcut`** を追加。`handleSelectTarget` と同様にヒント・選択状態をクリアしてから move を発行。
- `FortyThievesPage.tsx` のウェイスト最上段カードと各列の最上段カードに **`onDoubleClick`** を配線。シングルクリック／ドラッグ経路は `e.detail >= 2` ガードで保護。
- 移動不可のカードは何も起きない（エラーにしない）。

Reuse: 直近マージ済みの easthaven / bakersgame / eightoff と同じ `handleFoundationShortcut` + `e.detail>=2` パターンを踏襲（`easthavenFoundationTarget.ts` をミラー）。バックエンド（Go）は変更なし。

## テスト

- `fortyThievesFoundationTarget.test.ts`（新規）: 空山へのエース、非エース拒否、次ランク昇順、ランク不一致拒否、重複エースの次山ルーティング、後方山の探索。
- `FortyThievesPage.test.tsx`（追加）:
  - `double-clicking a foundation-playable tableau top card sends it to a foundation`
  - `double-clicking a foundation-playable waste card sends it to a foundation`
  - `double-clicking a card with no legal foundation target does nothing`

## ゲート

- [x] `bun run check`（biome）: exit 0、変更ファイルに警告なし
- [x] `bun run test -- --run FortyThieves fortyThievesFoundationTarget`: 86 passed
- [x] `bun run build`（tsc）: 成功

Closes #3128