### PR TITLE
feat(ninetynine): add server-hint button to the web page

### DIFF
--- a/frontend/src/i18n/locales/en/ninetynine.json
+++ b/frontend/src/i18n/locales/en/ninetynine.json
@@ -58,6 +58,15 @@
   },
   "hintBury": "Recommended bury",
   "hintPlay": "Recommended card",
+  "hintApply": "Apply",
+  "hintReason": {
+    "strategic_bury": "Bury to set a reachable bid",
+    "lead_strong": "Lead with a strong card",
+    "lead_low": "Lead with a low card",
+    "follow_suit": "Follow the led suit",
+    "trump_cut": "Cut with a trump",
+    "discard_high": "Discard a high card"
+  },
   "suitName": {
     "1": "Spades",
     "2": "Clubs",

--- a/frontend/src/i18n/locales/ja/ninetynine.json
+++ b/frontend/src/i18n/locales/ja/ninetynine.json
@@ -58,6 +58,15 @@
   },
   "hintBury": "推奨の埋めカード",
   "hintPlay": "推奨カード",
+  "hintApply": "適用",
+  "hintReason": {
+    "strategic_bury": "到達可能なビッドになるよう埋める",
+    "lead_strong": "強いカードでリード",
+    "lead_low": "低いカードでリード",
+    "follow_suit": "リードスートに追随",
+    "trump_cut": "切り札でカット",
+    "discard_high": "高いカードを捨てる"
+  },
   "suitName": {
     "1": "スペード",
     "2": "クラブ",

--- a/frontend/src/pages/NinetyNinePage.test.tsx
+++ b/frontend/src/pages/NinetyNinePage.test.tsx
@@ -367,6 +367,54 @@ describe('NinetyNinePage', () => {
     await waitFor(() => expect(actionLogApi.ninetynine).toHaveBeenCalledTimes(1));
   });
 
+  it('play-phase hint fetches and shows the recommended card with its reason', async () => {
+    renderWithProviders(<NinetyNinePage />);
+    await waitFor(() => expect(screen.getByTestId('nn-hint-button')).toBeInTheDocument());
+
+    mockExec.mockResolvedValueOnce({ ...playPhaseState, hint: { cardIndex: 1, reason: 'follow_suit' } });
+    fireEvent.click(screen.getByTestId('nn-hint-button'));
+
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('hint'));
+    expect(screen.getByTestId('nn-server-hint')).toHaveTextContent('推奨カード: [1] (リードスートに追随)');
+  });
+
+  it('bid-phase hint shows the bury recommendation and Apply selects those three cards', async () => {
+    mockExec.mockResolvedValue(bidPhaseState);
+    renderWithProviders(<NinetyNinePage />);
+    await waitFor(() => expect(screen.getByTestId('nn-hint-button')).toBeInTheDocument());
+
+    mockExec.mockResolvedValueOnce({ ...bidPhaseState, hint: { buryIndices: [0, 1, 2], reason: 'strategic_bury' } });
+    fireEvent.click(screen.getByTestId('nn-hint-button'));
+
+    await waitFor(() => expect(screen.getByTestId('nn-server-hint')).toBeInTheDocument());
+    expect(screen.getByTestId('nn-server-hint')).toHaveTextContent('到達可能なビッドになるよう埋める');
+
+    // Applying the bury hint replaces the selection with the recommended 3 cards,
+    // so the Bury button becomes ready (no aria-disabled).
+    fireEvent.click(screen.getByTestId('nn-hint-apply'));
+    expect(screen.getByTestId('nn-bury-progress')).toHaveTextContent('3枚選択しました。埋めるボタンで確定できます');
+    expect(screen.getByRole('button', { name: '3枚埋める' })).not.toHaveAttribute('aria-disabled');
+  });
+
+  it('shows a network error when the hint request fails', async () => {
+    renderWithProviders(<NinetyNinePage />);
+    await waitFor(() => expect(screen.getByTestId('nn-hint-button')).toBeInTheDocument());
+
+    mockExec.mockRejectedValueOnce(new Error('boom'));
+    fireEvent.click(screen.getByTestId('nn-hint-button'));
+
+    await waitFor(() =>
+      expect(screen.getByText('通信エラーが発生しました。もう一度お試しください。')).toBeInTheDocument(),
+    );
+  });
+
+  it('does not show the hint button on a cpu turn', async () => {
+    mockExec.mockResolvedValue(cpuTurnState);
+    renderWithProviders(<NinetyNinePage />);
+    await waitFor(() => expect(screen.getByText('CPU 1')).toBeInTheDocument());
+    expect(screen.queryByTestId('nn-hint-button')).not.toBeInTheDocument();
+  });
+
   it('renders accessible h1 heading and tutorial button', async () => {
     renderWithProviders(<NinetyNinePage />);
     await waitFor(() => {

--- a/frontend/src/pages/NinetyNinePage.tsx
+++ b/frontend/src/pages/NinetyNinePage.tsx
@@ -16,6 +16,7 @@ import { RoundScoreAnnouncement } from '../components/RoundScoreAnnouncement';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { TrickDisplay } from '../components/TrickDisplay';
 import { withTutorial } from '../components/tutorial/withTutorial';
+import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCardSelection } from '../hooks/useCardSelection';
 import { useCliGame } from '../hooks/useCliGame';
@@ -29,7 +30,7 @@ import { btnPrimary, btnSuccess } from '../styles/buttonStyles';
 import { focusRingCard, selectedCardStyle } from '../styles/cardStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
-import type { NinetyNineResponse } from '../types/card';
+import type { NinetyNineHint, NinetyNineResponse } from '../types/card';
 import { NinetyNinePhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
@@ -111,10 +112,19 @@ function NinetyNinePageContent() {
   const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
     useGamePageSetup('ninetynine');
   const { playSound } = useSound();
-  const { selected: selectedCardIndices, toggle: toggleCard, clear: clearSelection } = useCardSelection();
+  const { selected: selectedCardIndices, toggle: toggleCard, clear: clearSelection, setSelected } = useCardSelection();
   const [config, setConfig] = useState<{ cpuDifficulty: number; targetScore: number }>({ ...DEFAULT_CONFIG });
 
-  const onSuccess = useCallback(() => clearSelection(), [clearSelection]);
+  // Server-computed hint (fetched via the `hint` command). Separate from the
+  // frontend `useGameHint` toggle below. Any successful game action clears it.
+  const [serverHint, setServerHint] = useState<NinetyNineHint | null>(null);
+  const [hintError, setHintError] = useState<string | null>(null);
+  const [hintLoading, setHintLoading] = useState(false);
+
+  const onSuccess = useCallback(() => {
+    clearSelection();
+    setServerHint(null);
+  }, [clearSelection]);
   const { state, loading, error, exec, retry } = useGameApi(ninetyNineApi.exec, { onSuccess });
 
   const configRef = useRef(config);
@@ -156,6 +166,28 @@ function NinetyNinePageContent() {
     if (selectedCardIndices.length !== 1) return;
     void exec('play', undefined, selectedCardIndices[0]);
   }, [exec, selectedCardIndices]);
+
+  // The `hint` command returns full game state plus a nested `hint` object, so
+  // it is fetched directly and the hint stored separately rather than through
+  // `exec`, whose onSuccess would immediately clear the freshly-fetched hint.
+  const handleHint = useCallback(async () => {
+    setHintLoading(true);
+    try {
+      const res = await ninetyNineApi.exec('hint');
+      setServerHint(res.hint ?? null);
+      setHintError(null);
+    } catch {
+      setHintError(NETWORK_ERROR_MESSAGE());
+    } finally {
+      setHintLoading(false);
+    }
+  }, []);
+
+  // Apply the bury hint: replace the current selection with the recommended
+  // three cards so the player can confirm with the Bury button in one tap.
+  const handleApplyBury = useCallback(() => {
+    if (serverHint?.buryIndices) setSelected([...serverHint.buryIndices]);
+  }, [serverHint, setSelected]);
 
   const handleNextTrick = useCallback(() => void exec('next'), [exec]);
   const handleNextRound = useCallback(() => void exec('nextround'), [exec]);
@@ -428,12 +460,49 @@ function NinetyNinePageContent() {
                 </div>
               ))}
 
-            <ErrorAlert message={error} onRetry={retry} />
+            <ErrorAlert message={error ?? hintError} onRetry={retry} />
+
+            {serverHint && (
+              <div className="text-ds-warning text-sm mb-2" data-testid="nn-server-hint">
+                {serverHint.buryIndices && serverHint.buryIndices.length > 0 ? (
+                  <div className="flex flex-wrap gap-2 items-center">
+                    <span>
+                      {t('hintBury')}:{' '}
+                      {serverHint.buryIndices
+                        .map((i) => {
+                          const c = humanPlayer?.cards[i];
+                          return c ? cardAlt(c) : `[${i}]`;
+                        })
+                        .join(' ')}{' '}
+                      ({t(`hintReason.${serverHint.reason}`)})
+                    </span>
+                    <button type="button" className={btnSuccess} onClick={handleApplyBury} data-testid="nn-hint-apply">
+                      {t('hintApply')}
+                    </button>
+                  </div>
+                ) : serverHint.cardIndex != null ? (
+                  <span>
+                    {t('hintPlay')}: [{serverHint.cardIndex}] ({t(`hintReason.${serverHint.reason}`)})
+                  </span>
+                ) : null}
+              </div>
+            )}
 
             {frontendHintEnabled && frontendHint && (
               <HintTooltip reason={t(frontendHint.reason)} confidence={frontendHint.confidence} />
             )}
             <div className="flex gap-2 items-center" data-tutorial="nn-play-button">
+              {(isHumanBidTurn || isHumanTurn) && (
+                <button
+                  type="button"
+                  className={btnSuccess}
+                  onClick={handleHint}
+                  disabled={loading || hintLoading}
+                  data-testid="nn-hint-button"
+                >
+                  {tc('button.hint')}
+                </button>
+              )}
               {isHumanBidTurn && (
                 // Use aria-disabled (not the HTML `disabled` attribute) for the
                 // not-enough-cards state so the button stays focusable and a screen


### PR DESCRIPTION
## Summary

Adds a server-hint button to the Ninety-Nine web page, bringing it to parity with Oh Hell / Pinochle. The backend already exposed the hint via the `hint` command (`HintOutput` in `NinetyNineWebPresenter.go`); this wires the frontend to fetch and display it. Frontend-only — no Go changes.

The response nests the hint under the `hint` field (like Oh Hell, via `res.hint`), so it is fetched directly through `ninetyNineApi.exec('hint')` and stored in separate `serverHint`/`hintError`/`hintLoading` state rather than through `useGameApi.exec` — that keeps the rendered game state intact. Any successful game action clears the hint (`onSuccess`).

## Behavior

- ヒント button (`btnSuccess`) shown only on the human's bid or play turn.
- **Bid phase**: shows the recommended 3 bury cards + reason, plus an "適用 / Apply" button that replaces the current selection with those three indices (one tap → Bury button becomes ready).
- **Play phase**: shows the recommended card index + reason.
- Reasons translated via a new `hintReason` block (server keys: `strategic_bury`, `lead_strong`, `lead_low`, `follow_suit`, `trump_cut`, `discard_high`).
- Network failures surface through `ErrorAlert` (`error ?? hintError`).

## Files

- `frontend/src/pages/NinetyNinePage.tsx`
- `frontend/src/pages/NinetyNinePage.test.tsx`
- `frontend/src/i18n/locales/{ja,en}/ninetynine.json`

## Checklist

- [x] ビッドフェーズのヒントで推奨 3 枚と理由が表示される
- [x] プレイフェーズのヒントで推奨カードと理由が表示される
- [x] 埋めヒントの「適用」で選択状態が推奨 3 枚になる
- [x] ページテストでヒント API 呼び出しと表示を検証
- [x] ja/en i18n parity
- [x] `bun run check`, `bun run test -- --run NinetyNine` (58 passed), `bun run build` all pass

Closes #3098