### PR TITLE
feat(durak): integrate sound effects into player actions

### DIFF
--- a/frontend/src/pages/DurakPage.test.tsx
+++ b/frontend/src/pages/DurakPage.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { durakApi } from '../api/gameApi';
 import { renderWithProviders } from '../test/renderWithProviders';
@@ -8,6 +9,16 @@ import { DurakPage } from './DurakPage';
 vi.mock('../api/gameApi', () => ({
   durakApi: { exec: vi.fn() },
   actionLogApi: { durak: vi.fn() },
+}));
+
+// Mock the sound provider so we can assert playback without loading audio. The
+// page renders AnimatedCard, which calls useOptionalSound, so both hooks are stubbed.
+const mockPlaySound = vi.fn();
+const mockSoundValue = { playSound: mockPlaySound, muted: false, toggleMute: vi.fn() };
+vi.mock('../providers/SoundProvider', () => ({
+  SoundProvider: ({ children }: { children: ReactNode }) => children,
+  useSound: () => mockSoundValue,
+  useOptionalSound: () => mockSoundValue,
 }));
 
 const mockExec = vi.mocked(durakApi.exec);
@@ -71,6 +82,7 @@ const gameEndState: DurakResponse = {
 
 beforeEach(() => {
   mockExec.mockResolvedValue(baseState);
+  mockPlaySound.mockClear();
 });
 
 afterEach(() => {
@@ -302,6 +314,40 @@ describe('DurakPage', () => {
     expect(attack.className).not.toContain('animate-pulse');
     // Defended ARIA label names both attack and defense cards.
     expect(screen.getByTestId('dk-pair-0')).toHaveAttribute('aria-label', '防御済みペア: ♣ 7 を ♥ 9 で防御');
+  });
+
+  it('plays a card-place sound when attacking', async () => {
+    renderWithProviders(<DurakPage />);
+    await waitFor(() => expect(screen.getByAltText('♠ A')).toBeInTheDocument());
+    fireEvent.click(screen.getByAltText('♠ A'));
+    fireEvent.click(screen.getByRole('button', { name: '攻撃' }));
+    expect(mockPlaySound).toHaveBeenCalledWith('cardPlace');
+  });
+
+  it('plays a card-place sound when defending', async () => {
+    mockExec.mockResolvedValue(defendPhaseState);
+    renderWithProviders(<DurakPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: '防御' })).toBeInTheDocument());
+    // Select a hand card and a table pair so the defend button is enabled.
+    fireEvent.click(screen.getByAltText('♠ A'));
+    fireEvent.click(screen.getByTestId('dk-pair-0'));
+    fireEvent.click(screen.getByRole('button', { name: '防御' }));
+    expect(mockPlaySound).toHaveBeenCalledWith('cardPlace');
+  });
+
+  it('plays an error buzz when taking the table (disadvantageous action)', async () => {
+    mockExec.mockResolvedValue(defendPhaseState);
+    renderWithProviders(<DurakPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: '引き取り' })).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { name: '引き取り' }));
+    expect(mockPlaySound).toHaveBeenCalledWith('errorBuzz');
+  });
+
+  it('plays a win fanfare when the human wins', async () => {
+    mockExec.mockResolvedValue(gameEndState);
+    renderWithProviders(<DurakPage />);
+    await waitFor(() => expect(screen.getByTestId('win-celebration')).toBeInTheDocument());
+    await waitFor(() => expect(mockPlaySound).toHaveBeenCalledWith('winFanfare'));
   });
 
   it('shows 次のゲーム at game-end and fires reset directly (no confirm)', async () => {

--- a/frontend/src/pages/DurakPage.tsx
+++ b/frontend/src/pages/DurakPage.tsx
@@ -120,6 +120,21 @@ function DurakPageContent() {
     void gameExec('reset', undefined, undefined, durakConfig);
   }, [gameExec, hideActionLog, durakConfig]);
 
+  // Play a card-place sound when the human commits an attack or defense card, and
+  // an error buzz for the disadvantageous "take" action (defender scoops the table).
+  const handleAttackWithSound = useCallback(() => {
+    playSound('cardPlace');
+    handleAttack();
+  }, [playSound, handleAttack]);
+  const handleDefendWithSound = useCallback(() => {
+    playSound('cardPlace');
+    handleDefend();
+  }, [playSound, handleDefend]);
+  const handleTakeWithSound = useCallback(() => {
+    playSound('errorBuzz');
+    handleTake();
+  }, [playSound, handleTake]);
+
   if (!state)
     return (
       <GameSkeleton
@@ -418,7 +433,7 @@ function DurakPageContent() {
                   type="button"
                   className={`${btnDanger} min-w-[90px]`}
                   disabled={loading || selectedCardIdx === null}
-                  onClick={handleAttack}
+                  onClick={handleAttackWithSound}
                 >
                   {t('attackButton')}
                 </button>
@@ -428,7 +443,7 @@ function DurakPageContent() {
                   type="button"
                   className={`${btnSuccess} min-w-[90px]`}
                   disabled={loading || selectedCardIdx === null || selectedAttackIdx === null}
-                  onClick={handleDefend}
+                  onClick={handleDefendWithSound}
                 >
                   {t('defendButton')}
                 </button>
@@ -444,7 +459,12 @@ function DurakPageContent() {
                 </button>
               )}
               {showTakeBtn && (
-                <button type="button" className={`${btnPrimary} min-w-[90px]`} disabled={loading} onClick={handleTake}>
+                <button
+                  type="button"
+                  className={`${btnPrimary} min-w-[90px]`}
+                  disabled={loading}
+                  onClick={handleTakeWithSound}
+                >
                   {t('takeButton')}
                 </button>
               )}


### PR DESCRIPTION
Closes #3125

## Summary
Wires the shared `useSound` provider into Durak's play actions so the game gives audio feedback like other games. `onCelebrate`/`winFanfare` was already present; this adds the missing per-action sounds.

- `cardPlace` on `handleAttack` and `handleDefend` (a card is committed to the table)
- `errorBuzz` on `handleTake` (defender scoops the table — the disadvantageous action)
- `winFanfare` via `onCelebrate` on human win (pre-existing, unchanged)
- Mute is honored by `SoundProvider` and toggled through the existing settings; no new assets added

Mirrors the sibling pattern from `PrsiPage`/`MaoPage`.

## Test plan
- [x] `bun run test -- --run Durak` (59 pass), incl. new: attack→cardPlace, defend→cardPlace, take→errorBuzz, win→winFanfare
- [x] `bun run check` (biome clean)
- [x] `bun run build` (tsc gate passes)

## Acceptance criteria
- [x] `handleAttack`/`handleDefend` play `cardPlace`
- [x] `GamePageShell` receives `onCelebrate`; human win plays `winFanfare`
- [x] `handleTake` plays `errorBuzz`
- [x] Sound on/off works via existing `SettingsPanel`/`SoundProvider` mute

🤖 Generated with [Claude Code](https://claude.com/claude-code)