### PR TITLE
feat(bridge): render bid history as a 4-column auction table

### DIFF
--- a/frontend/src/i18n/locales/en/bridge.json
+++ b/frontend/src/i18n/locales/en/bridge.json
@@ -46,6 +46,7 @@
   "vulnerable": "Vul",
   "notVulnerable": "Non-Vul",
   "bidHistory": "Bid History",
+  "auctionTableCaption": "Auction table. Columns are the players, rows are the bidding rounds, and each cell holds a bid, pass, or double.",
   "bidLevel": "Level",
   "bidSuit": "Suit",
   "dummyHand": "Dummy's Hand",

--- a/frontend/src/i18n/locales/ja/bridge.json
+++ b/frontend/src/i18n/locales/ja/bridge.json
@@ -46,6 +46,7 @@
   "vulnerable": "バル",
   "notVulnerable": "ノンバル",
   "bidHistory": "ビッド履歴",
+  "auctionTableCaption": "オークション表。列は各プレイヤー、行は巡目を表し、各セルにビッド・パス・ダブルが入ります。",
   "bidLevel": "レベル",
   "bidSuit": "スート",
   "dummyHand": "ダミーの手札",

--- a/frontend/src/pages/BridgePage.test.tsx
+++ b/frontend/src/pages/BridgePage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { bridgeApi } from '../api/gameApi';
 import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
@@ -119,6 +119,19 @@ const bidHistoryState: BridgeResponse = {
     { playerIdx: 0, bidType: 1, level: 1, suit: 5 },
     { playerIdx: 1, bidType: 0, level: 0, suit: 0 },
     { playerIdx: 2, bidType: 2, level: 0, suit: 0 },
+  ],
+};
+
+// A full opening round plus the winning 1NT contract for auction-table tests.
+const auctionTableState: BridgeResponse = {
+  ...bidPhaseState,
+  contractLevel: 1,
+  contractSuit: 5,
+  bidHistory: [
+    { playerIdx: 0, bidType: 1, level: 1, suit: 5 },
+    { playerIdx: 1, bidType: 0, level: 0, suit: 0 },
+    { playerIdx: 2, bidType: 2, level: 0, suit: 0 },
+    { playerIdx: 3, bidType: 0, level: 0, suit: 0 },
   ],
 };
 
@@ -444,6 +457,46 @@ describe('BridgePage', () => {
     await waitFor(() => {
       expect(screen.getByText('\u30d3\u30c3\u30c9\u5c65\u6b74')).toBeInTheDocument();
     });
+  });
+
+  it('renders the bid history as a 4-column auction table with column headers', async () => {
+    mockExec.mockResolvedValue(auctionTableState);
+    renderWithProviders(<BridgePage />);
+    await waitFor(() => expect(screen.getByTestId('bridge-auction-table')).toBeInTheDocument());
+    const table = within(screen.getByTestId('bridge-auction-table'));
+    // One column per seat, opener (human seat 0) first.
+    expect(table.getAllByRole('columnheader')).toHaveLength(4);
+    // Single opening round -> one body row.
+    expect(table.getAllByRole('row')).toHaveLength(2); // header row + 1 auction round
+  });
+
+  it('places each bid in its seat cell of the auction table', async () => {
+    mockExec.mockResolvedValue(auctionTableState);
+    renderWithProviders(<BridgePage />);
+    await waitFor(() => expect(screen.getByTestId('bridge-auction-table')).toBeInTheDocument());
+    const table = within(screen.getByTestId('bridge-auction-table'));
+    const cells = table.getAllByRole('cell');
+    expect(cells).toHaveLength(4);
+    expect(cells[0]).toHaveTextContent('1NT');
+    expect(cells[1]).toHaveTextContent('\u30d1\u30b9'); // Pass
+    expect(cells[2]).toHaveTextContent('\u30c0\u30d6\u30eb'); // Double
+    expect(cells[3]).toHaveTextContent('\u30d1\u30b9'); // seat 3 Pass
+  });
+
+  it('highlights the winning contract cell', async () => {
+    mockExec.mockResolvedValue(auctionTableState);
+    renderWithProviders(<BridgePage />);
+    await waitFor(() => expect(screen.getByTestId('bridge-auction-table')).toBeInTheDocument());
+    const winning = screen.getByTestId('bridge-auction-table').querySelectorAll('[data-winning-contract="true"]');
+    expect(winning).toHaveLength(1);
+    expect(winning[0]).toHaveTextContent('1NT');
+  });
+
+  it('hides the auction table when there are no bids', async () => {
+    mockExec.mockResolvedValue(bidPhaseState);
+    renderWithProviders(<BridgePage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: '\u30d3\u30c3\u30c9' })).toBeInTheDocument());
+    expect(screen.queryByTestId('bridge-auction-table')).not.toBeInTheDocument();
   });
 
   it('shows vulnerability info', async () => {

--- a/frontend/src/pages/BridgePage.tsx
+++ b/frontend/src/pages/BridgePage.tsx
@@ -29,6 +29,7 @@ import { gameTheme } from '../styles/gameTheme';
 import type { BridgeResponse } from '../types/card';
 import { BridgePhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { buildBridgeAuctionGrid, finalContractBid } from '../utils/bridgeAuction';
 import { canBid, canDouble, canRedouble } from '../utils/bridgeBidRules';
 import { cardAlt } from '../utils/cardAlt';
 import { BRIDGE_HELP, parseBridgeCommand } from '../utils/cli/commands/bridgeCommands';
@@ -203,6 +204,18 @@ function BridgePageContent() {
 
   const suitLabel = (suit: number) => (SUIT_DISPLAY[suit] ? t(SUIT_DISPLAY[suit]) : '');
 
+  // Render one auction cell: pass/double/redouble labels, or level+strain.
+  const bidCellLabel = (entry: { bidType: number; level: number; suit: number } | null) => {
+    if (!entry) return '';
+    if (entry.bidType === 0) return t('passButton');
+    if (entry.bidType === 2) return t('doubleButton');
+    if (entry.bidType === 3) return t('redoubleButton');
+    return `${entry.level}${suitLabel(entry.suit)}`;
+  };
+
+  const auctionGrid = buildBridgeAuctionGrid(state.bidHistory);
+  const winningBid = state.contractLevel > 0 ? finalContractBid(state.bidHistory) : null;
+
   const contractDisplay = () => {
     if (state.contractLevel <= 0) return null;
     const suit = suitLabel(state.contractSuit);
@@ -304,27 +317,53 @@ function BridgePageContent() {
                 {/* Bid phase instruction */}
                 {isHumanBidTurn && <div className="text-ds-warning text-center mb-2">{t('bidPhase')}</div>}
 
-                {/* Bid History */}
-                {state.bidHistory.length > 0 && (
+                {/* Bid History — traditional 4-column auction grid */}
+                {auctionGrid && (
                   <div className="my-2 p-2 rounded bg-black/30" data-tutorial="br-bid-history">
                     <div className="text-ds-text-muted text-sm mb-1">{t('bidHistory')}</div>
-                    <div className="flex flex-wrap gap-1">
-                      {state.bidHistory.map((entry, idx) => (
-                        <span key={idx} className="text-ds-text-primary text-xs bg-black/20 px-1 rounded">
-                          {playerName(
-                            state.players[entry.playerIdx]?.id ?? entry.playerIdx,
-                            state.players[entry.playerIdx]?.isHuman ?? false,
-                          )}
-                          :{' '}
-                          {entry.bidType === 0
-                            ? t('passButton')
-                            : entry.bidType === 2
-                              ? t('doubleButton')
-                              : entry.bidType === 3
-                                ? t('redoubleButton')
-                                : `${entry.level}${suitLabel(entry.suit)}`}
-                        </span>
-                      ))}
+                    <div className="overflow-x-auto">
+                      <table className="w-full text-xs text-ds-text-primary" data-testid="bridge-auction-table">
+                        <caption className="sr-only">{t('auctionTableCaption')}</caption>
+                        <thead>
+                          <tr>
+                            {auctionGrid.columns.map((seat) => {
+                              const seatPlayer = state.players[seat];
+                              const isHumanCol = seatPlayer?.isHuman === true;
+                              return (
+                                <th
+                                  key={seat}
+                                  scope="col"
+                                  className={`px-2 py-0.5 text-center font-semibold ${
+                                    isHumanCol ? 'text-ds-accent' : 'text-ds-text-muted'
+                                  }`}
+                                >
+                                  {playerName(seatPlayer?.id ?? seat, seatPlayer?.isHuman ?? false)}
+                                </th>
+                              );
+                            })}
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {auctionGrid.rows.map((row, rIdx) => (
+                            <tr key={rIdx}>
+                              {row.map((cell, cIdx) => {
+                                const isWinning = cell !== null && cell === winningBid;
+                                return (
+                                  <td
+                                    key={cIdx}
+                                    className={`px-2 py-0.5 text-center ${
+                                      isWinning ? 'rounded bg-ds-accent/30 font-bold text-ds-accent' : ''
+                                    }`}
+                                    data-winning-contract={isWinning ? 'true' : undefined}
+                                  >
+                                    {bidCellLabel(cell)}
+                                  </td>
+                                );
+                              })}
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
                     </div>
                   </div>
                 )}

--- a/frontend/src/utils/bridgeAuction.test.ts
+++ b/frontend/src/utils/bridgeAuction.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import type { BridgeBidEntry } from '../types/card';
+import { BRIDGE_SEAT_COUNT, buildBridgeAuctionGrid, finalContractBid } from './bridgeAuction';
+
+const bid = (playerIdx: number, bidType: number, level = 0, suit = 0): BridgeBidEntry => ({
+  playerIdx,
+  bidType,
+  level,
+  suit,
+});
+
+describe('buildBridgeAuctionGrid', () => {
+  it('returns null for an empty auction', () => {
+    expect(buildBridgeAuctionGrid([])).toBeNull();
+  });
+
+  it('aligns column 0 to the opening bidder and orders seats by bid order', () => {
+    // Opener is seat 2, so columns cycle 2 -> 3 -> 0 -> 1.
+    const grid = buildBridgeAuctionGrid([bid(2, 1, 1, 5)]);
+    expect(grid?.columns).toEqual([2, 3, 0, 1]);
+  });
+
+  it('places a full round of bids into the matching seat cells', () => {
+    const history = [bid(0, 1, 1, 5), bid(1, 0), bid(2, 2), bid(3, 0)];
+    const grid = buildBridgeAuctionGrid(history);
+    expect(grid?.columns).toEqual([0, 1, 2, 3]);
+    expect(grid?.rows).toHaveLength(1);
+    expect(grid?.rows[0]).toEqual(history);
+  });
+
+  it('wraps into a new row after every four bids and pads the trailing round with nulls', () => {
+    const history = [bid(0, 1, 1, 5), bid(1, 0), bid(2, 0), bid(3, 0), bid(0, 1, 2, 4)];
+    const grid = buildBridgeAuctionGrid(history);
+    expect(grid?.rows).toHaveLength(2);
+    expect(grid?.rows[0]).toEqual(history.slice(0, 4));
+    // Second round: only the opener has bid; remaining three seats are null.
+    expect(grid?.rows[1]).toEqual([history[4], null, null, null]);
+    expect(grid?.rows[1]).toHaveLength(BRIDGE_SEAT_COUNT);
+  });
+});
+
+describe('finalContractBid', () => {
+  it('returns null when there is no level bid', () => {
+    expect(finalContractBid([bid(0, 0), bid(1, 0)])).toBeNull();
+  });
+
+  it('returns the last level bid by reference', () => {
+    const first = bid(0, 1, 1, 5);
+    const last = bid(2, 1, 3, 4);
+    const result = finalContractBid([first, bid(1, 0), last, bid(3, 2)]);
+    expect(result).toBe(last);
+  });
+});

--- a/frontend/src/utils/bridgeAuction.ts
+++ b/frontend/src/utils/bridgeAuction.ts
@@ -1,0 +1,50 @@
+import type { BridgeBidEntry } from '../types/card';
+
+/** Number of seats (players) in a Bridge auction. */
+export const BRIDGE_SEAT_COUNT = 4;
+
+/** A Bridge auction shaped into the traditional one-column-per-seat grid. */
+export interface BridgeAuctionGrid {
+  /**
+   * Player index for each column, left-to-right. Column 0 is the opening
+   * bidder's seat, and subsequent columns follow the bidding order.
+   */
+  columns: number[];
+  /**
+   * Auction rows (bidding rounds). Each row has {@link BRIDGE_SEAT_COUNT}
+   * cells; a cell is the bid made by that column's seat, or `null` when the
+   * seat has not yet bid in the (final, in-progress) round.
+   */
+  rows: (BridgeBidEntry | null)[][];
+}
+
+/**
+ * Shapes a flat Bridge bid history into a 4-column auction grid aligned to the
+ * opening bidder's seat. Because bidding always advances one seat at a time,
+ * each column maps to a fixed seat and rows fill left-to-right in bid order.
+ * Returns `null` for an empty auction so callers can hide the table.
+ */
+export function buildBridgeAuctionGrid(bidHistory: BridgeBidEntry[]): BridgeAuctionGrid | null {
+  if (!bidHistory || bidHistory.length === 0) return null;
+  const firstSeat = bidHistory[0].playerIdx;
+  const columns = Array.from({ length: BRIDGE_SEAT_COUNT }, (_, i) => (firstSeat + i) % BRIDGE_SEAT_COUNT);
+  const rows: (BridgeBidEntry | null)[][] = [];
+  for (const entry of bidHistory) {
+    const col = (entry.playerIdx - firstSeat + BRIDGE_SEAT_COUNT) % BRIDGE_SEAT_COUNT;
+    if (col === 0) rows.push(Array<BridgeBidEntry | null>(BRIDGE_SEAT_COUNT).fill(null));
+    rows[rows.length - 1][col] = entry;
+  }
+  return { columns, rows };
+}
+
+/**
+ * Returns the final contract bid (the last level bid, `bidType === 1`) in the
+ * auction, or `null` when the auction contains no contract bid. The returned
+ * reference can be compared by identity to highlight the winning cell.
+ */
+export function finalContractBid(bidHistory: BridgeBidEntry[]): BridgeBidEntry | null {
+  for (let i = bidHistory.length - 1; i >= 0; i--) {
+    if (bidHistory[i].bidType === 1) return bidHistory[i];
+  }
+  return null;
+}


### PR DESCRIPTION
Closes #3100

## Summary
Replaces the flat, wrapping bid-history chips on the Bridge page with the traditional bridge **auction grid** — one column per seat, rows per bidding round, cells filled left-to-right in bid order. This makes it easy to see who has yet to bid and to follow a long auction.

## What changed
- New pure helper `frontend/src/utils/bridgeAuction.ts`:
  - `buildBridgeAuctionGrid(bidHistory)` — shapes the flat `bidHistory` into `{ columns, rows }`, aligned so column 0 is the opening bidder's seat. Returns `null` for an empty auction.
  - `finalContractBid(bidHistory)` — last level bid, used to highlight the winning contract cell by reference identity.
- `BridgePage.tsx` — renders the auction as a `<table>` (with `data-testid="bridge-auction-table"`), localized seat/player column headers, human column emphasized with `text-ds-accent`, winning-contract cell highlighted, wrapped in `overflow-x-auto`, and an `sr-only` `<caption>` for a11y.
- i18n: `auctionTableCaption` added to `ja` + `en` bridge locales (parity kept).

## Bid-history field used
`BridgeResponse.bidHistory: BridgeBidEntry[]` (each entry: `playerIdx`, `bidType` [0=pass,1=bid,2=double,3=redouble], `level`, `suit`). Bidding advances one seat at a time in the domain, so chunking into rows of 4 maps each column to a fixed seat cleanly.

## Tests
- `bridgeAuction.test.ts`: empty auction → null, column alignment to opener, full round into seat cells, row wrapping + null padding, `finalContractBid` reference.
- `BridgePage.test.tsx`: 4 column headers + row count, known bid sequence lands in correct cells, winning-contract cell highlighted, empty auction hides the table.

## Checklist
- [x] `bun run check` (biome) — clean
- [x] `bun run test -- --run bridgeAuction BridgePage` — 57 passing
- [x] `bun run build` (tsc) — clean
- [x] i18n ja/en parity
- [x] Frontend only; no Go touched