### PR TITLE
feat(golf): add client-side 9-hole cumulative scoring mode

### DIFF
--- a/frontend/src/hooks/useGolfNineHole.test.ts
+++ b/frontend/src/hooks/useGolfNineHole.test.ts
@@ -1,0 +1,115 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { GolfCard } from '../types/card';
+import {
+  countGolfRemaining,
+  emptyGolfNineHoleState,
+  GOLF_NINE_HOLE_KEY,
+  GOLF_TOTAL_HOLES,
+  golfCurrentHole,
+  golfNineHoleComplete,
+  golfNineHoleTotal,
+  readGolfNineHoleState,
+  recordGolfHole,
+  useGolfNineHole,
+} from './useGolfNineHole';
+
+const gc = (removed: boolean): GolfCard => ({ card: { design: 'SPADE', value: 5 }, removed, exposed: true });
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('countGolfRemaining', () => {
+  it('counts cards that are present and not removed', () => {
+    const layout: GolfCard[][] = [
+      [gc(false), gc(true), { card: null, removed: true, exposed: false }],
+      [gc(false), gc(false)],
+    ];
+    expect(countGolfRemaining(layout)).toBe(3);
+  });
+
+  it('is 0 when every card is removed (a cleared deal)', () => {
+    const layout: GolfCard[][] = [[gc(true), gc(true)], [gc(true)]];
+    expect(countGolfRemaining(layout)).toBe(0);
+  });
+});
+
+describe('recordGolfHole (pure accumulation)', () => {
+  it('sums two deals correctly into the scorecard', () => {
+    let state = emptyGolfNineHoleState();
+    state = recordGolfHole(state, 7);
+    state = recordGolfHole(state, 4);
+    expect(state.scores).toEqual([7, 4]);
+    expect(golfNineHoleTotal(state)).toBe(11);
+    expect(golfCurrentHole(state)).toBe(3);
+    expect(golfNineHoleComplete(state)).toBe(false);
+  });
+
+  it('caps at 9 holes and ignores extra records (no double-count past the round)', () => {
+    let state = emptyGolfNineHoleState();
+    for (let i = 0; i < GOLF_TOTAL_HOLES; i++) state = recordGolfHole(state, 2);
+    expect(golfNineHoleComplete(state)).toBe(true);
+    expect(golfCurrentHole(state)).toBe(GOLF_TOTAL_HOLES);
+    const before = state;
+    state = recordGolfHole(state, 99);
+    expect(state).toBe(before);
+    expect(golfNineHoleTotal(state)).toBe(18);
+  });
+
+  it('lower cumulative total is the better (winning) 9-hole result', () => {
+    const good = recordGolfHole(recordGolfHole(emptyGolfNineHoleState(), 1), 2);
+    const bad = recordGolfHole(recordGolfHole(emptyGolfNineHoleState(), 6), 8);
+    expect(golfNineHoleTotal(good)).toBeLessThan(golfNineHoleTotal(bad));
+  });
+});
+
+describe('readGolfNineHoleState', () => {
+  it('returns a zeroed state when nothing is stored', () => {
+    expect(readGolfNineHoleState()).toEqual({ enabled: false, scores: [] });
+  });
+
+  it('restores a persisted state', () => {
+    localStorage.setItem(GOLF_NINE_HOLE_KEY, JSON.stringify({ enabled: true, scores: [3, 5] }));
+    expect(readGolfNineHoleState()).toEqual({ enabled: true, scores: [3, 5] });
+  });
+
+  it('falls back to zeroed state on malformed JSON', () => {
+    localStorage.setItem(GOLF_NINE_HOLE_KEY, '{not json');
+    expect(readGolfNineHoleState()).toEqual({ enabled: false, scores: [] });
+  });
+
+  it('rejects an over-long scorecard', () => {
+    localStorage.setItem(
+      GOLF_NINE_HOLE_KEY,
+      JSON.stringify({ enabled: true, scores: new Array(GOLF_TOTAL_HOLES + 1).fill(1) }),
+    );
+    expect(readGolfNineHoleState()).toEqual({ enabled: false, scores: [] });
+  });
+});
+
+describe('useGolfNineHole', () => {
+  it('enabling starts a fresh persisted scorecard', () => {
+    const { result } = renderHook(() => useGolfNineHole());
+    act(() => result.current.setEnabled(true));
+    expect(result.current.nineHole).toEqual({ enabled: true, scores: [] });
+    expect(readGolfNineHoleState()).toEqual({ enabled: true, scores: [] });
+  });
+
+  it('recordHole accumulates and persists across deals', () => {
+    const { result } = renderHook(() => useGolfNineHole());
+    act(() => result.current.setEnabled(true));
+    act(() => result.current.recordHole(6));
+    act(() => result.current.recordHole(2));
+    expect(result.current.nineHole.scores).toEqual([6, 2]);
+    expect(readGolfNineHoleState().scores).toEqual([6, 2]);
+  });
+
+  it('resetCard clears scores but keeps the mode on', () => {
+    const { result } = renderHook(() => useGolfNineHole());
+    act(() => result.current.setEnabled(true));
+    act(() => result.current.recordHole(6));
+    act(() => result.current.resetCard());
+    expect(result.current.nineHole).toEqual({ enabled: true, scores: [] });
+  });
+});

--- a/frontend/src/hooks/useGolfNineHole.ts
+++ b/frontend/src/hooks/useGolfNineHole.ts
@@ -1,0 +1,136 @@
+import { useCallback, useState } from 'react';
+import type { GolfCard } from '../types/card';
+
+/** localStorage key for the Golf 9-hole (9-deal cumulative) scorecard. */
+export const GOLF_NINE_HOLE_KEY = 'trumpcards-golf-ninehole';
+
+/** Number of deals (holes) that make up a full 9-hole round. */
+export const GOLF_TOTAL_HOLES = 9;
+
+/**
+ * Persisted 9-hole state. `scores` holds the per-hole scores (cards left on the
+ * tableau at deal end — lower is better) recorded so far, in play order.
+ */
+export interface GolfNineHoleState {
+  /** Whether 9-hole mode is active. */
+  enabled: boolean;
+  /** Recorded per-hole scores (0..GOLF_TOTAL_HOLES entries). */
+  scores: number[];
+}
+
+/** Returns a zeroed 9-hole state (mode off, no holes played). */
+export function emptyGolfNineHoleState(): GolfNineHoleState {
+  return { enabled: false, scores: [] };
+}
+
+function isValidState(value: unknown): value is GolfNineHoleState {
+  if (typeof value !== 'object' || value === null) return false;
+  const s = value as Record<string, unknown>;
+  return (
+    typeof s.enabled === 'boolean' &&
+    Array.isArray(s.scores) &&
+    s.scores.length <= GOLF_TOTAL_HOLES &&
+    s.scores.every((n) => typeof n === 'number' && Number.isFinite(n))
+  );
+}
+
+/** Reads and validates the 9-hole state from localStorage; returns a zeroed state on any error. */
+export function readGolfNineHoleState(): GolfNineHoleState {
+  try {
+    const raw = localStorage.getItem(GOLF_NINE_HOLE_KEY);
+    if (!raw) return emptyGolfNineHoleState();
+    const parsed: unknown = JSON.parse(raw);
+    if (!isValidState(parsed)) return emptyGolfNineHoleState();
+    return parsed;
+  } catch {
+    return emptyGolfNineHoleState();
+  }
+}
+
+/** 1-based number of the hole currently being played, capped at GOLF_TOTAL_HOLES. */
+export function golfCurrentHole(state: GolfNineHoleState): number {
+  return Math.min(state.scores.length + 1, GOLF_TOTAL_HOLES);
+}
+
+/** True once all GOLF_TOTAL_HOLES holes have a recorded score. */
+export function golfNineHoleComplete(state: GolfNineHoleState): boolean {
+  return state.scores.length >= GOLF_TOTAL_HOLES;
+}
+
+/** Cumulative total across all recorded holes (lower is better). */
+export function golfNineHoleTotal(state: GolfNineHoleState): number {
+  return state.scores.reduce((sum, n) => sum + n, 0);
+}
+
+/**
+ * Pure reducer: appends a finished deal's score as the next hole. Once the round
+ * is full (GOLF_TOTAL_HOLES holes) further calls are no-ops, so an accidental
+ * double-record cannot inflate the card.
+ */
+export function recordGolfHole(state: GolfNineHoleState, score: number): GolfNineHoleState {
+  if (state.scores.length >= GOLF_TOTAL_HOLES) return state;
+  return { ...state, scores: [...state.scores, score] };
+}
+
+/**
+ * Counts the cards still on the tableau — the Golf deal score. Golf clears the
+ * board by removing cards to the waste, so cards left behind are the "strokes"
+ * for that hole (0 on a clear).
+ */
+export function countGolfRemaining(layout: GolfCard[][]): number {
+  return layout.reduce((sum, col) => sum + col.reduce((c, gc) => c + (gc.card && !gc.removed ? 1 : 0), 0), 0);
+}
+
+/**
+ * Hook that persists the Golf 9-hole scorecard in localStorage. Enabling (or
+ * disabling) the mode starts a fresh card; `recordHole` appends the just-finished
+ * deal's remaining-card score (capped at 9 holes); `resetCard` clears the scores
+ * while keeping the mode on. Modeled on `usePyramidStats`.
+ */
+export function useGolfNineHole() {
+  const [nineHole, setNineHole] = useState<GolfNineHoleState>(readGolfNineHoleState);
+
+  const persist = useCallback((next: GolfNineHoleState) => {
+    setNineHole(next);
+    try {
+      localStorage.setItem(GOLF_NINE_HOLE_KEY, JSON.stringify(next));
+    } catch {
+      /* storage unavailable / quota exceeded */
+    }
+  }, []);
+
+  const setEnabled = useCallback(
+    (enabled: boolean) => {
+      // Toggling the mode always starts a fresh scorecard.
+      persist({ enabled, scores: [] });
+    },
+    [persist],
+  );
+
+  const recordHole = useCallback((score: number) => {
+    setNineHole((prev) => {
+      const next = recordGolfHole(prev, score);
+      if (next === prev) return prev;
+      try {
+        localStorage.setItem(GOLF_NINE_HOLE_KEY, JSON.stringify(next));
+      } catch {
+        /* storage unavailable / quota exceeded */
+      }
+      return next;
+    });
+  }, []);
+
+  const resetCard = useCallback(() => {
+    setNineHole((prev) => {
+      const next: GolfNineHoleState = { enabled: prev.enabled, scores: [] };
+      try {
+        localStorage.setItem(GOLF_NINE_HOLE_KEY, JSON.stringify(next));
+      } catch {
+        /* storage unavailable / quota exceeded */
+      }
+      return next;
+    });
+  }, []);
+
+  return { nineHole, setEnabled, recordHole, resetCard };
+}

--- a/frontend/src/i18n/locales/en/golf.json
+++ b/frontend/src/i18n/locales/en/golf.json
@@ -36,5 +36,15 @@
     "canRemove": "An exposed card can be removed — it is adjacent to the waste top",
     "multipleRemovable": "Multiple cards can be removed — look for chain opportunities",
     "drawFromStock": "No removable cards — try drawing from the stock"
+  },
+  "nineHole": {
+    "label": "9-Hole Mode",
+    "progress": "Hole {{current}} / {{total}}",
+    "hole": "Hole",
+    "score": "Score",
+    "total": "Total",
+    "complete": "9 holes done! Total score: {{total}} (lower is better)",
+    "restart": "New scorecard",
+    "pending": "-"
   }
 }

--- a/frontend/src/i18n/locales/ja/golf.json
+++ b/frontend/src/i18n/locales/ja/golf.json
@@ -36,5 +36,15 @@
     "canRemove": "除去できるカードがあります — 捨て札と隣接しています",
     "multipleRemovable": "複数のカードが除去可能です — 連鎖を狙いましょう",
     "drawFromStock": "除去できるカードがありません — 山札から引いてみましょう"
+  },
+  "nineHole": {
+    "label": "9ホールモード",
+    "progress": "ホール {{current}} / {{total}}",
+    "hole": "ホール",
+    "score": "スコア",
+    "total": "合計",
+    "complete": "9ホール終了！ 合計スコア: {{total}}（少ないほど好成績）",
+    "restart": "新しいスコアカード",
+    "pending": "-"
   }
 }

--- a/frontend/src/pages/GolfPage.test.tsx
+++ b/frontend/src/pages/GolfPage.test.tsx
@@ -307,6 +307,56 @@ describe('GolfPage', () => {
     expect(badge.className).toContain('bg-ds-error');
   });
 
+  it('does not show the 9-hole scorecard by default', async () => {
+    renderWithProviders(<GolfPage />);
+    await waitFor(() => expect(screen.getByText('捨て札')).toBeInTheDocument());
+    expect(screen.queryByTestId('golf-scorecard')).not.toBeInTheDocument();
+  });
+
+  it('shows the scorecard when 9-hole mode is enabled via the settings toggle', async () => {
+    renderWithProviders(<GolfPage />);
+    await waitFor(() => expect(screen.getByText('捨て札')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('golf-ninehole-toggle'));
+    expect(screen.getByTestId('golf-scorecard')).toBeInTheDocument();
+    // Fresh card: hole 1 pending, total 0.
+    expect(screen.getByTestId('golf-scorecard-total')).toHaveTextContent('0');
+  });
+
+  it('records the finished deal once as the current hole (remaining cards = score)', async () => {
+    // 9-hole mode on; the test layout has all 35 cards present → hole score 35.
+    localStorage.setItem('trumpcards-golf-ninehole', JSON.stringify({ enabled: true, scores: [] }));
+    mockExec.mockResolvedValue(gameOverState);
+    renderWithProviders(<GolfPage />);
+    await waitFor(() => expect(screen.getByTestId('golf-hole-1')).toHaveTextContent('35'));
+    // Only hole 1 is recorded — no double-count on re-render.
+    expect(screen.getByTestId('golf-hole-2')).toHaveTextContent('-');
+    expect(screen.getByTestId('golf-scorecard-total')).toHaveTextContent('35');
+    expect(JSON.parse(localStorage.getItem('trumpcards-golf-ninehole') ?? '{}').scores).toEqual([35]);
+  });
+
+  it('shows the completion message and total after 9 holes', async () => {
+    localStorage.setItem(
+      'trumpcards-golf-ninehole',
+      JSON.stringify({ enabled: true, scores: [1, 2, 3, 4, 5, 6, 7, 8, 9] }),
+    );
+    renderWithProviders(<GolfPage />);
+    await waitFor(() => expect(screen.getByTestId('golf-scorecard')).toBeInTheDocument());
+    expect(screen.getByText(/合計スコア: 45/)).toBeInTheDocument();
+    expect(screen.getByTestId('golf-scorecard-restart')).toBeInTheDocument();
+  });
+
+  it('restart button clears the completed scorecard', async () => {
+    localStorage.setItem(
+      'trumpcards-golf-ninehole',
+      JSON.stringify({ enabled: true, scores: [1, 2, 3, 4, 5, 6, 7, 8, 9] }),
+    );
+    renderWithProviders(<GolfPage />);
+    await waitFor(() => expect(screen.getByTestId('golf-scorecard-restart')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('golf-scorecard-restart'));
+    expect(screen.getByTestId('golf-scorecard-total')).toHaveTextContent('0');
+    expect(screen.getByTestId('golf-hole-1')).toHaveTextContent('-');
+  });
+
   it('pulses the stock pile when a draw hint is active', async () => {
     mockExec.mockResolvedValue(playingState);
     renderWithProviders(<GolfPage />);

--- a/frontend/src/pages/GolfPage.tsx
+++ b/frontend/src/pages/GolfPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import type { golfApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
@@ -24,6 +24,14 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useGolfGame } from '../hooks/useGolfGame';
+import {
+  countGolfRemaining,
+  GOLF_TOTAL_HOLES,
+  golfCurrentHole,
+  golfNineHoleComplete,
+  golfNineHoleTotal,
+  useGolfNineHole,
+} from '../hooks/useGolfNineHole';
 import { useSound } from '../providers/SoundProvider';
 import { btnDanger, btnPrimary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -157,6 +165,24 @@ function GolfPageContent() {
 
   const combo = useChainCombo(state?.moveCount, state?.stockCount);
 
+  // 9-hole mode: accumulate each finished deal's remaining-card score across 9 deals (issue #3114).
+  const { nineHole, setEnabled: setNineHoleEnabled, recordHole, resetCard } = useGolfNineHole();
+  const nineHoleEnabled = nineHole.enabled;
+  const endPhase = state?.phase;
+  const endRemaining = state?.layout ? countGolfRemaining(state.layout) : 0;
+  // Guard so each finished deal is recorded exactly once (phase stays ended across re-renders).
+  const recordedRef = useRef(false);
+  useEffect(() => {
+    const ended = endPhase === GolfPhase.GAME_CLEAR || endPhase === GolfPhase.GAME_OVER;
+    if (!ended) {
+      recordedRef.current = false;
+      return;
+    }
+    if (recordedRef.current) return;
+    recordedRef.current = true;
+    if (nineHoleEnabled) recordHole(endRemaining);
+  }, [endPhase, endRemaining, nineHoleEnabled, recordHole]);
+
   if (!state)
     return (
       <GameSkeleton
@@ -229,6 +255,70 @@ function GolfPageContent() {
           <LandscapeBanner message={t('landscapeBanner')} />
 
           <div className="flex-1 overflow-y-auto pt-3 px-4 lg:px-8">
+            {/* 9-hole scorecard (issue #3114) */}
+            {nineHoleEnabled && (
+              <div data-testid="golf-scorecard" className="mb-3 max-w-2xl mx-auto">
+                <div className="flex items-center justify-between mb-1">
+                  <span className="text-game-text-muted text-xs">
+                    {golfNineHoleComplete(nineHole)
+                      ? t('nineHole.complete', { total: golfNineHoleTotal(nineHole) })
+                      : t('nineHole.progress', { current: golfCurrentHole(nineHole), total: GOLF_TOTAL_HOLES })}
+                  </span>
+                  {golfNineHoleComplete(nineHole) && (
+                    <button
+                      type="button"
+                      className={`${btnPrimary} text-xs`}
+                      onClick={resetCard}
+                      data-testid="golf-scorecard-restart"
+                    >
+                      {t('nineHole.restart')}
+                    </button>
+                  )}
+                </div>
+                <div className="overflow-x-auto">
+                  <table className="w-full text-center text-xs border-collapse">
+                    <thead>
+                      <tr className="text-game-text-muted">
+                        <th className="px-1 py-0.5 font-medium text-left">{t('nineHole.hole')}</th>
+                        {Array.from({ length: GOLF_TOTAL_HOLES }, (_, i) => (
+                          <th key={`h-${(i + 1).toString()}`} className="px-1 py-0.5 font-medium">
+                            {i + 1}
+                          </th>
+                        ))}
+                        <th className="px-1 py-0.5 font-medium text-ds-warning">{t('nineHole.total')}</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr>
+                        <td className="px-1 py-0.5 text-left text-game-text-muted">{t('nineHole.score')}</td>
+                        {Array.from({ length: GOLF_TOTAL_HOLES }, (_, i) => {
+                          const played = i < nineHole.scores.length;
+                          const isCurrent = i === nineHole.scores.length && !golfNineHoleComplete(nineHole);
+                          return (
+                            <td
+                              key={`s-${(i + 1).toString()}`}
+                              data-testid={`golf-hole-${(i + 1).toString()}`}
+                              className={`px-1 py-0.5 tabular-nums ${
+                                isCurrent ? 'text-ds-info font-bold' : played ? 'text-ds-text' : 'text-game-text-muted'
+                              }`}
+                            >
+                              {played ? nineHole.scores[i] : t('nineHole.pending')}
+                            </td>
+                          );
+                        })}
+                        <td
+                          data-testid="golf-scorecard-total"
+                          className="px-1 py-0.5 font-bold text-ds-warning tabular-nums"
+                        >
+                          {golfNineHoleTotal(nineHole)}
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            )}
+
             {/* Tableau: 7 columns */}
             <div data-tutorial="golf-columns" className="flex justify-center mb-3">
               {Array.from({ length: COL_COUNT }, (_, colIdx) => (
@@ -367,6 +457,14 @@ function GolfPageContent() {
                     label: tc('hint.toggle', { ns: 'tutorial' }),
                     checked: frontendHintEnabled,
                     onToggle: setFrontendHintEnabled,
+                  },
+                  {
+                    type: 'checkbox' as const,
+                    id: 'golfNineHole',
+                    label: t('nineHole.label'),
+                    checked: nineHoleEnabled,
+                    onToggle: setNineHoleEnabled,
+                    testId: 'golf-ninehole-toggle',
                   },
                 ],
               },


### PR DESCRIPTION
## Summary

Adds an optional **9-hole mode** to Golf Solitaire (issue #3114). The game's namesake is the golf-solitaire scoring where the cards left on the tableau at deal end are your "strokes"; 9-hole play sums those over 9 deals for a cumulative score (lower is better).

This is a **frontend-only** change — no Go touched. The per-deal score is derived from the existing `layout` in `GolfResponse` (cards present and not removed), so no backend config is needed.

## What changed

- **`useGolfNineHole` hook** (new): pure accumulation reducer (`recordGolfHole`, capped at 9 holes), score helpers, `countGolfRemaining(layout)`, and localStorage persistence so the scorecard survives a reload.
- **`GolfPage`**: records each finished deal exactly once per deal-end episode (ref guard, same pattern as `PyramidPage`), and renders a responsive (`overflow-x-auto`) hole-by-hole scorecard with per-hole scores, a running cumulative total, a completion message, and a "new scorecard" restart button. A settings-panel checkbox enables the mode (starting a fresh card).
- **i18n**: added `nineHole.*` keys to `ja` + `en` (parity verified).

## How accumulation works

Score for each hole = tableau cards still present at deal end (`GAME_CLEAR` = 0). A `recordedRef` flips true on the ended phase and resets when the next deal starts, so re-renders never double-count. `recordGolfHole` is a no-op past hole 9.

## Acceptance criteria

- [x] Each deal end records the remaining-card count as that hole's score
- [x] Hole progress (n/9) and a scorecard are displayed
- [x] 9-hole completion shows the cumulative total and a completion message
- [x] Mode/scorecard state is restored after reload (localStorage)

## Test plan

- [x] `bun run check` (Biome + design tokens)
- [x] `bun run test -- --run Golf` — 99 passed (incl. new hook + page tests: 2-deal sum, 9-hole cap/no-double-count, record-once, completion, restart)
- [x] `bun run build` (tsc gate)

Closes #3114