### PR TITLE
feat(labellelucie): guide give-up on redeal-exhausted deadlock

### DIFF
--- a/frontend/src/i18n/locales/en/labellelucie.json
+++ b/frontend/src/i18n/locales/en/labellelucie.json
@@ -9,6 +9,7 @@
   "fan": "Fan",
   "redealsLeft": "Redeals left: {{count}}",
   "stuckRedeal": "Stuck — redeal recommended",
+  "stuckDeadlock": "No moves left — give up?",
   "redealsLeftBadge": "{{count}} left",
   "moveCount": "Moves: {{count}}",
   "redeal": "Gather & redeal",

--- a/frontend/src/i18n/locales/ja/labellelucie.json
+++ b/frontend/src/i18n/locales/ja/labellelucie.json
@@ -9,6 +9,7 @@
   "fan": "扇",
   "redealsLeft": "残りシャッフル: {{count}}",
   "stuckRedeal": "手詰まり: 再ディール推奨",
+  "stuckDeadlock": "これ以上動かせる手がありません。ギブアップしますか？",
   "redealsLeftBadge": "残り{{count}}回",
   "moveCount": "手数: {{count}}",
   "redeal": "集めて配り直す",

--- a/frontend/src/pages/LaBelleLuciePage.test.tsx
+++ b/frontend/src/pages/LaBelleLuciePage.test.tsx
@@ -63,6 +63,49 @@ describe('LaBelleLuciePage', () => {
     expect(screen.queryByTestId('ll-stuck-banner')).not.toBeInTheDocument();
   });
 
+  it('shows the deadlock banner and pulses give up when redeals are exhausted with no move', async () => {
+    // No legal move AND no redeals left -> true deadlock.
+    mockExec.mockResolvedValue(
+      makeState({
+        fans: [[card('SPADE', 5)], [card('HEART', 9)], [card('CLOVER', 2)]],
+        foundation: [[], [], [], []],
+        redealsLeft: 0,
+      }),
+    );
+    renderWithProviders(<LaBelleLuciePage />);
+    await waitFor(() => expect(screen.getByTestId('ll-deadlock-banner')).toBeInTheDocument());
+    // The redeal-recommendation banner must not show when redeals are gone.
+    expect(screen.queryByTestId('ll-stuck-banner')).not.toBeInTheDocument();
+    expect(screen.getByTestId('giveup-button').className).toContain('animate-pulse');
+  });
+
+  it('hides the deadlock banner when a legal move exists even with no redeals', async () => {
+    // Redeals exhausted but a move (SPADE 8 stacks under SPADE 9) still exists.
+    mockExec.mockResolvedValue(
+      makeState({
+        fans: [[card('SPADE', 9)], [card('SPADE', 8)], [card('DIAMOND', 1)]],
+        redealsLeft: 0,
+      }),
+    );
+    renderWithProviders(<LaBelleLuciePage />);
+    await waitFor(() => expect(screen.getByTestId('fan-0')).toBeInTheDocument());
+    expect(screen.queryByTestId('ll-deadlock-banner')).not.toBeInTheDocument();
+    expect(screen.getByTestId('giveup-button').className).not.toContain('animate-pulse');
+  });
+
+  it('hides the deadlock banner while redeals remain', async () => {
+    // No move, but redeals remain -> stuck banner, not the deadlock banner.
+    mockExec.mockResolvedValue(
+      makeState({
+        fans: [[card('SPADE', 5)], [card('HEART', 9)], [card('CLOVER', 2)]],
+        redealsLeft: 2,
+      }),
+    );
+    renderWithProviders(<LaBelleLuciePage />);
+    await waitFor(() => expect(screen.getByTestId('ll-stuck-banner')).toBeInTheDocument());
+    expect(screen.queryByTestId('ll-deadlock-banner')).not.toBeInTheDocument();
+  });
+
   it('renders fans and foundations', async () => {
     renderWithProviders(<LaBelleLuciePage />);
     await waitFor(() => expect(screen.getByTestId('fan-0')).toBeInTheDocument());

--- a/frontend/src/pages/LaBelleLuciePage.tsx
+++ b/frontend/src/pages/LaBelleLuciePage.tsx
@@ -88,9 +88,13 @@ function LaBelleLuciePageContent() {
   const isOver = state.phase === LaBelleLuciePhase.GAME_OVER;
   const isEnd = isClear || isOver;
   const canAct = !isEnd;
+  const hasLegalMove = labelleLucieHasLegalMove(state.fans, state.foundation);
   // No legal move left but redeals remain: recommend a redeal before the
   // player wastes time hunting for a move that does not exist.
-  const stuck = canAct && state.redealsLeft > 0 && !labelleLucieHasLegalMove(state.fans, state.foundation);
+  const stuck = canAct && state.redealsLeft > 0 && !hasLegalMove;
+  // No legal move left and redeals are exhausted: a true deadlock. Guide the
+  // player to give up instead of hunting for a move that cannot exist.
+  const deadlocked = canAct && state.redealsLeft <= 0 && !hasLegalMove;
   const phaseName = phaseNames[state.phase] ?? '';
 
   const handleReset = () => {
@@ -242,6 +246,15 @@ function LaBelleLuciePageContent() {
             </span>
           </div>
         )}
+        {deadlocked && (
+          <div
+            className="mt-1 flex items-center gap-2 text-ds-danger text-sm font-medium"
+            role="status"
+            data-testid="ll-deadlock-banner"
+          >
+            <span>{t('stuckDeadlock')}</span>
+          </div>
+        )}
         {canAct && (
           <div className="mt-1 text-ds-text-primary text-xs">
             {selected === null ? t('selectSource') : t('selectDestination')}
@@ -308,7 +321,7 @@ function LaBelleLuciePageContent() {
           {canAct && (
             <button
               type="button"
-              className={btnSecondary}
+              className={`${btnSecondary}${deadlocked ? ' motion-safe:animate-pulse' : ''}`}
               onClick={() => exec('giveup')}
               disabled={loading}
               data-testid="giveup-button"


### PR DESCRIPTION
## Summary

When La Belle Lucie has **no legal move left and all redeals are exhausted** (`redealsLeft === 0`), the board is a true deadlock — but previously nothing was shown, so the player kept hunting for a move that cannot exist or had to notice the give-up button on their own.

This extends the existing stuck detection (which already fires the "redeal recommended" banner while `redealsLeft > 0`) with a symmetric deadlock case:

- New `ll-deadlock-banner` (`role="status"`, `text-ds-danger`) showing "No moves left — give up?".
- The give-up button pulses with `motion-safe:animate-pulse` when deadlocked, mirroring the redeal button's pulse in the stuck case.
- Reuses the existing `labelleLucieHasLegalMove` util (faithful mirror of the domain's legal-move check) and the exposed `redealsLeft` — no backend changes.

Frontend-only, additive. Design-system tokens only. ja/en i18n parity.

## Acceptance criteria

- [x] Deadlock banner shows when redeals are 0 and no legal move remains
- [x] Give-up button is emphasized (pulses) while deadlocked
- [x] Banner hidden while any legal move exists (even with 0 redeals)
- [x] Banner hidden while redeals remain (stuck/redeal banner shows instead)
- [x] Both branches tested in `LaBelleLuciePage.test.tsx`

## Test plan

- `bun run check` — pass (only pre-existing warnings in unrelated files; design-tokens OK)
- `bun run test -- --run LaBelleLucie` — 21 passed
- `bun run build` — pass (tsc gate)

Closes #3578