### PR TITLE
feat(agnessorel): add auto-complete and stalemate detection to the web page

### DIFF
--- a/frontend/src/i18n/locales/en/agnes.json
+++ b/frontend/src/i18n/locales/en/agnes.json
@@ -14,6 +14,10 @@
   "giveup": "Give up",
   "hint": "Hint",
   "undo": "Undo",
+  "autoComplete": "Auto-complete",
+  "autoCompleteNotReady": "Available once the stock is empty and all cards are face up",
+  "stalemate": "No moves left. Undo a move or give up.",
+  "stalemateUndo": "Undo to escape",
   "empty": "empty",
   "gameClear": "Game cleared! Moves: {{moveCount}}",
   "gameOver": "Game over",
@@ -38,6 +42,7 @@
   "kbd": {
     "deal": "D",
     "hint": "H",
+    "autoComplete": "A",
     "undo": "Z",
     "giveup": "G"
   }

--- a/frontend/src/i18n/locales/ja/agnes.json
+++ b/frontend/src/i18n/locales/ja/agnes.json
@@ -14,6 +14,10 @@
   "giveup": "ギブアップ",
   "hint": "ヒント",
   "undo": "元に戻す",
+  "autoComplete": "オートコンプリート",
+  "autoCompleteNotReady": "山札を配り切り、全カードが表向きになると使えます",
+  "stalemate": "手詰まりです。元に戻すかギブアップしてください。",
+  "stalemateUndo": "元に戻して脱出",
   "empty": "空",
   "gameClear": "ゲームクリア！ 手数: {{moveCount}}",
   "gameOver": "ゲームオーバー",
@@ -38,6 +42,7 @@
   "kbd": {
     "deal": "D",
     "hint": "H",
+    "autoComplete": "A",
     "undo": "Z",
     "giveup": "G"
   }

--- a/frontend/src/pages/AgnesPage.test.tsx
+++ b/frontend/src/pages/AgnesPage.test.tsx
@@ -271,4 +271,112 @@ describe('AgnesPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
     expect(screen.queryByTestId('ag-col-actions-0')).not.toBeInTheDocument();
   });
+
+  // --- Auto-complete (issue #3289) ---
+
+  it('disables auto-complete while the stock is not empty', async () => {
+    renderWithProviders(<AgnesPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    expect(screen.getByTestId('ag-autocomplete-button')).toBeDisabled();
+  });
+
+  it('enables auto-complete once stock is empty and all cards are face up, then sweeps to foundation', async () => {
+    const ready: AgnesResponse = {
+      ...playingState,
+      stockCount: 0,
+      tableau: [[up('SPADE', 6)], [up('HEART', 9)]],
+      foundation: [[card('SPADE', 5)], [], [], []],
+    };
+    // After the sweep move, column 0 is empty and no foundation move remains.
+    const swept: AgnesResponse = {
+      ...ready,
+      tableau: [[], [up('HEART', 9)]],
+      foundation: [[card('SPADE', 5), card('SPADE', 6)], [], [], []],
+      canUndo: true,
+    };
+    mockExec.mockResolvedValue(ready);
+    renderWithProviders(<AgnesPage />);
+    await waitFor(() => expect(screen.getByTestId('ag-autocomplete-button')).toBeEnabled());
+    mockExec.mockClear();
+    mockExec.mockResolvedValueOnce(swept);
+    fireEvent.click(screen.getByTestId('ag-autocomplete-button'));
+    await waitFor(() =>
+      expect(mockExec).toHaveBeenCalledWith('move', { zone: 'tableau', col: 0 }, { zone: 'foundation' }),
+    );
+    // Loop stops after the swept state (no further foundation move): exactly one move.
+    await waitFor(() => expect(mockExec).toHaveBeenCalledTimes(1));
+  });
+
+  it('keyboard: "a" triggers auto-complete when ready', async () => {
+    const ready: AgnesResponse = {
+      ...playingState,
+      stockCount: 0,
+      tableau: [[up('SPADE', 6)]],
+      foundation: [[card('SPADE', 5)], [], [], []],
+    };
+    mockExec.mockResolvedValue(ready);
+    renderWithProviders(<AgnesPage />);
+    await waitFor(() => expect(screen.getByTestId('ag-autocomplete-button')).toBeEnabled());
+    mockExec.mockClear();
+    mockExec.mockResolvedValueOnce({
+      ...ready,
+      tableau: [[]],
+      foundation: [[card('SPADE', 5), card('SPADE', 6)], [], [], []],
+    });
+    fireEvent.keyDown(document.body, { key: 'a' });
+    await waitFor(() =>
+      expect(mockExec).toHaveBeenCalledWith('move', { zone: 'tableau', col: 0 }, { zone: 'foundation' }),
+    );
+  });
+
+  // --- Stalemate detection + undo-escape (issue #3289) ---
+
+  it('shows the stalemate banner when no legal move remains', async () => {
+    const stuck: AgnesResponse = {
+      ...playingState,
+      stockCount: 0,
+      tableau: [[up('SPADE', 8)], [up('HEART', 3)]],
+      foundation: [[], [], [], []],
+    };
+    mockExec.mockResolvedValue(stuck);
+    renderWithProviders(<AgnesPage />);
+    await waitFor(() => expect(screen.getByTestId('ag-stalemate-banner')).toBeInTheDocument());
+  });
+
+  it('does not show the stalemate banner while a legal move exists', async () => {
+    // Default playing state still has stock, so a deal is always possible.
+    renderWithProviders(<AgnesPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    expect(screen.queryByTestId('ag-stalemate-banner')).not.toBeInTheDocument();
+  });
+
+  it('offers an undo-to-escape button in the stalemate banner and fires undo', async () => {
+    const stuck: AgnesResponse = {
+      ...playingState,
+      stockCount: 0,
+      canUndo: true,
+      tableau: [[up('SPADE', 8)], [up('HEART', 3)]],
+      foundation: [[], [], [], []],
+    };
+    mockExec.mockResolvedValue(stuck);
+    renderWithProviders(<AgnesPage />);
+    const escapeBtn = await screen.findByTestId('ag-stalemate-undo');
+    mockExec.mockClear();
+    fireEvent.click(escapeBtn);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('undo'));
+  });
+
+  it('hides the undo-to-escape button when there is nothing to undo', async () => {
+    const stuck: AgnesResponse = {
+      ...playingState,
+      stockCount: 0,
+      canUndo: false,
+      tableau: [[up('SPADE', 8)], [up('HEART', 3)]],
+      foundation: [[], [], [], []],
+    };
+    mockExec.mockResolvedValue(stuck);
+    renderWithProviders(<AgnesPage />);
+    await waitFor(() => expect(screen.getByTestId('ag-stalemate-banner')).toBeInTheDocument());
+    expect(screen.queryByTestId('ag-stalemate-undo')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/AgnesPage.tsx
+++ b/frontend/src/pages/AgnesPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import { type AgnesMoveZone, agnesApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
@@ -30,9 +30,14 @@ import { gameTheme } from '../styles/gameTheme';
 import type { AgnesResponse } from '../types/card';
 import { AgnesPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { agnesHasLegalMove, agnesNextFoundationMove } from '../utils/agnesMoves';
 import { AGNES_HELP, parseAgnesCommand } from '../utils/cli/commands/agnesCommands';
 import { formatAgnesState } from '../utils/cli/formatters/agnesFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { isTableauAllFaceUp } from '../utils/solitaireUtils';
+
+/** Upper bound on auto-complete sweep iterations (one per card) to guard against loops. */
+const AGNES_AUTO_MAX_STEPS = 52;
 
 /** Tutorial steps for the Agnes Sorel solitaire game. */
 const AG_TUTORIAL_STEPS: TutorialStep[] = [
@@ -77,7 +82,7 @@ function AgnesPageContent() {
     confirmGiveUp,
     cancelGiveUp,
   } = useGamePageSetup('agnes');
-  const { state, loading, error, exec: execApi, retry } = useGameApi(agnesApi.exec);
+  const { state, setState, loading, error, exec: execApi, retry } = useGameApi(agnesApi.exec);
   const { cardWidth, cardHeight, isMobile } = useCardDimensions();
   const {
     hint: frontendHint,
@@ -116,6 +121,39 @@ function AgnesPageContent() {
   const handleHint = useCallback(() => execApi('hint'), [execApi]);
   const handleUndo = useCallback(() => execApi('undo'), [execApi]);
 
+  // Auto-complete sweep: drives the existing `move` command to send every
+  // face-up tableau end card to its foundation, re-reading the fresh board after
+  // each move (a move can expose a new foundation-eligible card). Mirrors the
+  // Aces Up / Spiderette sequential-driver pattern (#4193). The ref guard blocks
+  // a second concurrent loop and `isAutoCompleting` gates the page controls.
+  const [isAutoCompleting, setIsAutoCompleting] = useState(false);
+  const autoCompletingRef = useRef(false);
+  const stateRef = useRef(state);
+  stateRef.current = state;
+  const handleAutoComplete = useCallback(async () => {
+    if (autoCompletingRef.current) return;
+    autoCompletingRef.current = true;
+    setIsAutoCompleting(true);
+    let col = -1;
+    try {
+      let cur = stateRef.current;
+      for (let step = 0; step < AGNES_AUTO_MAX_STEPS && cur; step++) {
+        col = agnesNextFoundationMove(cur.tableau, cur.foundation, cur.baseRank);
+        if (col < 0) break;
+        const res = await agnesApi.exec('move', { zone: 'tableau', col }, { zone: 'foundation' });
+        setState(res);
+        cur = res;
+      }
+    } catch {
+      // Re-issue the failing move through the shared exec so the network failure
+      // surfaces via the standard error/retry channel.
+      if (col >= 0) await execApi('move', { zone: 'tableau', col }, { zone: 'foundation' });
+    } finally {
+      autoCompletingRef.current = false;
+      setIsAutoCompleting(false);
+    }
+  }, [execApi, setState]);
+
   const handleMoveTableauToFoundation = useCallback(
     (col: number) => execApi('move', { zone: 'tableau', col }, { zone: 'foundation' }),
     [execApi],
@@ -152,6 +190,17 @@ function AgnesPageContent() {
       ? t('phase.gameOver')
       : t('phase.playing');
 
+  // Auto-complete is offered once the stock is exhausted and every tableau card
+  // is face-up — the endgame sweep, mirroring Spiderette's `autoCompleteReady`.
+  const autoCompleteReady = isPlaying && (state?.stockCount ?? 1) === 0 && isTableauAllFaceUp(state?.tableau ?? []);
+  // Stalemate: no deal, no foundation move, and no tableau move remain. Detected
+  // on the frontend from the deterministic move rules (the backend exposes no
+  // stalemate flag), so the UI can prompt an undo / give-up escape.
+  const hasLegalMove = state
+    ? agnesHasLegalMove(state.tableau, state.foundation, state.baseRank, state.stockCount)
+    : true;
+  const isStalemate = isPlaying && !loading && !isAutoCompleting && !hasLegalMove;
+
   // Keyboard shortcuts for the primary actions, matching other solitaire pages.
   // Give-up (g) is routed through its confirm dialog since it is irreversible.
   const canPlayForKbd = isPlaying && !loading;
@@ -159,10 +208,22 @@ function AgnesPageContent() {
     () => [
       { key: 'd', action: handleDeal, enabled: canPlayForKbd && (state?.stockCount ?? 0) > 0 },
       { key: 'h', action: handleHint, enabled: canPlayForKbd },
+      { key: 'a', action: handleAutoComplete, enabled: canPlayForKbd && autoCompleteReady && !isAutoCompleting },
       { key: 'z', action: handleUndo, enabled: canPlayForKbd && (state?.canUndo ?? false) },
       { key: 'g', action: confirmGiveUpAction, enabled: canPlayForKbd },
     ],
-    [handleDeal, handleHint, handleUndo, confirmGiveUpAction, canPlayForKbd, state?.stockCount, state?.canUndo],
+    [
+      handleDeal,
+      handleHint,
+      handleAutoComplete,
+      handleUndo,
+      confirmGiveUpAction,
+      canPlayForKbd,
+      autoCompleteReady,
+      isAutoCompleting,
+      state?.stockCount,
+      state?.canUndo,
+    ],
   );
   useActionKeyboardNav({ bindings: agnesBindings, enabled: canPlayForKbd });
 
@@ -363,6 +424,27 @@ function AgnesPageContent() {
               })}
             </div>
 
+            {isStalemate && (
+              <div
+                className="mt-1 flex flex-wrap items-center gap-2 text-ds-danger text-sm font-medium"
+                role="status"
+                data-testid="ag-stalemate-banner"
+              >
+                <span>{t('stalemate')}</span>
+                {state.canUndo && (
+                  <button
+                    type="button"
+                    className={`${btnOutline} ${focusRingWhite} text-xs motion-safe:animate-pulse`}
+                    onClick={handleUndo}
+                    disabled={loading}
+                    data-testid="ag-stalemate-undo"
+                  >
+                    {t('stalemateUndo')}
+                  </button>
+                )}
+              </div>
+            )}
+
             <GameMessageBox
               message={state.message}
               messageCode={state.messageCode}
@@ -390,7 +472,7 @@ function AgnesPageContent() {
                     type="button"
                     className={`${btnPrimary} ${focusRingWhite}`}
                     onClick={handleDeal}
-                    disabled={loading || state.stockCount === 0}
+                    disabled={loading || isAutoCompleting || state.stockCount === 0}
                     aria-keyshortcuts="d"
                   >
                     {t('deal')}
@@ -400,7 +482,7 @@ function AgnesPageContent() {
                     type="button"
                     className={`${btnSuccess} ${focusRingWhite}`}
                     onClick={handleHint}
-                    disabled={loading}
+                    disabled={loading || isAutoCompleting}
                     aria-keyshortcuts="h"
                   >
                     {t('hint')}
@@ -408,9 +490,21 @@ function AgnesPageContent() {
                   </button>
                   <button
                     type="button"
+                    className={`${btnSuccess} ${focusRingWhite}${autoCompleteReady && !loading && !isAutoCompleting ? ' motion-safe:animate-pulse ring-2 ring-ds-success' : ''}`}
+                    onClick={handleAutoComplete}
+                    disabled={loading || isAutoCompleting || !autoCompleteReady}
+                    aria-keyshortcuts="a"
+                    data-testid="ag-autocomplete-button"
+                    title={autoCompleteReady ? undefined : t('autoCompleteNotReady')}
+                  >
+                    {t('autoComplete')}
+                    <KbdBadge label={t('kbd.autoComplete')} />
+                  </button>
+                  <button
+                    type="button"
                     className={`${btnOutline} ${focusRingWhite}`}
                     onClick={handleUndo}
-                    disabled={!state.canUndo || loading}
+                    disabled={!state.canUndo || loading || isAutoCompleting}
                     aria-keyshortcuts="z"
                   >
                     {t('undo')}
@@ -420,7 +514,7 @@ function AgnesPageContent() {
                     type="button"
                     className={`${btnDanger} ${focusRingWhite}`}
                     onClick={confirmGiveUpAction}
-                    disabled={loading}
+                    disabled={loading || isAutoCompleting}
                     aria-keyshortcuts="g"
                   >
                     {t('giveup')}

--- a/frontend/src/utils/agnesMoves.test.ts
+++ b/frontend/src/utils/agnesMoves.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import type { AgnesTableauCard, Card, CardDesign } from '../types/card';
+import {
+  agnesCanPlaceOnFoundation,
+  agnesCanPlaceOnTableau,
+  agnesHasLegalMove,
+  agnesNextFoundationMove,
+} from './agnesMoves';
+
+const card = (design: CardDesign, value: number): Card => ({ design, value });
+const up = (design: CardDesign, value: number): AgnesTableauCard => ({ card: card(design, value), faceUp: true });
+const down = (): AgnesTableauCard => ({ card: null, faceUp: false });
+
+// Foundation piles are indexed by suit: [Spade, Clover, Heart, Diamond].
+const emptyFoundation = (): Card[][] => [[], [], [], []];
+
+describe('agnesCanPlaceOnFoundation', () => {
+  it('accepts the base rank on an empty pile', () => {
+    expect(agnesCanPlaceOnFoundation(card('SPADE', 5), emptyFoundation(), 5)).toBe(true);
+  });
+
+  it('rejects a non-base rank on an empty pile', () => {
+    expect(agnesCanPlaceOnFoundation(card('SPADE', 6), emptyFoundation(), 5)).toBe(false);
+  });
+
+  it('builds up in the same suit', () => {
+    const foundation: Card[][] = [[card('SPADE', 5)], [], [], []];
+    expect(agnesCanPlaceOnFoundation(card('SPADE', 6), foundation, 5)).toBe(true);
+    expect(agnesCanPlaceOnFoundation(card('HEART', 6), foundation, 5)).toBe(false);
+  });
+
+  it('wraps King to Ace', () => {
+    const foundation: Card[][] = [[card('SPADE', 13)], [], [], []];
+    expect(agnesCanPlaceOnFoundation(card('SPADE', 1), foundation, 5)).toBe(true);
+  });
+});
+
+describe('agnesCanPlaceOnTableau', () => {
+  const tableau: AgnesTableauCard[][] = [[up('SPADE', 8)], [], [up('HEART', 8)]];
+
+  it('accepts a same-color card one rank lower', () => {
+    // Clover 7 (black) onto Spade 8 (black).
+    expect(agnesCanPlaceOnTableau(card('CLOVER', 7), tableau, 0)).toBe(true);
+  });
+
+  it('rejects a different-color card', () => {
+    expect(agnesCanPlaceOnTableau(card('HEART', 7), tableau, 0)).toBe(false);
+  });
+
+  it('rejects an empty column', () => {
+    expect(agnesCanPlaceOnTableau(card('CLOVER', 7), tableau, 1)).toBe(false);
+  });
+
+  it('rejects a wrong rank', () => {
+    expect(agnesCanPlaceOnTableau(card('CLOVER', 6), tableau, 0)).toBe(false);
+  });
+});
+
+describe('agnesNextFoundationMove', () => {
+  it('returns the first column with a foundation-eligible end card', () => {
+    const foundation: Card[][] = [[card('SPADE', 5)], [], [], []];
+    const tableau: AgnesTableauCard[][] = [[up('HEART', 2)], [up('SPADE', 6)]];
+    expect(agnesNextFoundationMove(tableau, foundation, 5)).toBe(1);
+  });
+
+  it('ignores face-down end cards', () => {
+    const foundation: Card[][] = [[card('SPADE', 5)], [], [], []];
+    const tableau: AgnesTableauCard[][] = [[up('SPADE', 6), down()]];
+    expect(agnesNextFoundationMove(tableau, foundation, 5)).toBe(-1);
+  });
+
+  it('returns -1 when no move exists', () => {
+    const tableau: AgnesTableauCard[][] = [[up('HEART', 9)]];
+    expect(agnesNextFoundationMove(tableau, emptyFoundation(), 5)).toBe(-1);
+  });
+});
+
+describe('agnesHasLegalMove', () => {
+  it('is true while stock remains', () => {
+    expect(agnesHasLegalMove([[]], emptyFoundation(), 5, 23)).toBe(true);
+  });
+
+  it('is true when a foundation move exists', () => {
+    const foundation: Card[][] = [[card('SPADE', 5)], [], [], []];
+    const tableau: AgnesTableauCard[][] = [[up('SPADE', 6)]];
+    expect(agnesHasLegalMove(tableau, foundation, 5, 0)).toBe(true);
+  });
+
+  it('is true when a tableau-to-tableau move exists', () => {
+    const tableau: AgnesTableauCard[][] = [[up('SPADE', 8)], [up('CLOVER', 7)]];
+    expect(agnesHasLegalMove(tableau, emptyFoundation(), 5, 0)).toBe(true);
+  });
+
+  it('is false when stuck (no deal, no foundation, no tableau move)', () => {
+    // Spade 8 and Heart 3: no foundation (base 5), no same-color one-lower stack.
+    const tableau: AgnesTableauCard[][] = [[up('SPADE', 8)], [up('HEART', 3)]];
+    expect(agnesHasLegalMove(tableau, emptyFoundation(), 5, 0)).toBe(false);
+  });
+});

--- a/frontend/src/utils/agnesMoves.ts
+++ b/frontend/src/utils/agnesMoves.ts
@@ -1,0 +1,106 @@
+import type { AgnesTableauCard, Card } from '../types/card';
+
+/**
+ * Maps a card suit to its foundation pile index, mirroring the Go domain's
+ * `fIdx = GetDesign() - 1` (Spade=1, Clover=2, Heart=3, Diamond=4).
+ */
+const DESIGN_TO_FOUNDATION: Record<string, number> = {
+  SPADE: 0,
+  CLOVER: 1,
+  HEART: 2,
+  DIAMOND: 3,
+};
+
+/** Next foundation rank, wrapping King (13) back to Ace (1). Mirrors domain `nextRank`. */
+function nextRank(r: number): number {
+  return (r % 13) + 1;
+}
+
+/** Whether a card is a black suit (Spade or Clover), matching the domain `isBlack`. */
+function isBlack(card: Card): boolean {
+  return card.design === 'SPADE' || card.design === 'CLOVER';
+}
+
+/** Whether two cards share a color, matching the domain `isSameColor`. */
+function sameColor(a: Card, b: Card): boolean {
+  return isBlack(a) === isBlack(b);
+}
+
+/** Face-up end (bottom) card of a tableau column, or null when empty/face-down. */
+function endFaceUpCard(col: readonly AgnesTableauCard[]): Card | null {
+  if (col.length === 0) return null;
+  const tc = col[col.length - 1];
+  return tc.faceUp ? tc.card : null;
+}
+
+/**
+ * Whether a card can move to its suit's foundation pile: an empty pile takes the
+ * base rank, otherwise it builds up in the same suit (with King→Ace wrap).
+ * Mirrors the domain `canPlaceOnFoundation`.
+ */
+export function agnesCanPlaceOnFoundation(card: Card, foundation: readonly Card[][], baseRank: number): boolean {
+  const idx = DESIGN_TO_FOUNDATION[card.design];
+  if (idx === undefined) return false;
+  const pile = foundation[idx] ?? [];
+  if (pile.length === 0) return card.value === baseRank;
+  const top = pile[pile.length - 1];
+  return card.design === top.design && card.value === nextRank(top.value);
+}
+
+/**
+ * Whether a card can stack on a tableau column's end card: same color, one rank
+ * lower, no wrap. Empty columns cannot be filled manually. Mirrors the domain
+ * `canPlaceOnTableau`.
+ */
+export function agnesCanPlaceOnTableau(
+  card: Card,
+  tableau: readonly (readonly AgnesTableauCard[])[],
+  toCol: number,
+): boolean {
+  const col = tableau[toCol];
+  if (!col || col.length === 0) return false;
+  const top = col[col.length - 1]?.card;
+  if (!top) return false;
+  return sameColor(card, top) && card.value === top.value - 1;
+}
+
+/**
+ * Index of the first tableau column whose face-up end card can move to a
+ * foundation, or -1 if none. Drives the auto-complete sweep by re-reading the
+ * board after each move (mirrors the domain's foundation-first hint priority).
+ */
+export function agnesNextFoundationMove(
+  tableau: readonly (readonly AgnesTableauCard[])[],
+  foundation: readonly Card[][],
+  baseRank: number,
+): number {
+  for (let col = 0; col < tableau.length; col++) {
+    const card = endFaceUpCard(tableau[col]);
+    if (card && agnesCanPlaceOnFoundation(card, foundation, baseRank)) return col;
+  }
+  return -1;
+}
+
+/**
+ * Whether any legal move remains: a pending deal, a tableau→foundation move, or a
+ * tableau→tableau move. Used to detect a stalemate so the UI can prompt the
+ * player to undo or give up. Mirrors the union of the domain's `DealStock`
+ * availability and `GetHint` move search.
+ */
+export function agnesHasLegalMove(
+  tableau: readonly (readonly AgnesTableauCard[])[],
+  foundation: readonly Card[][],
+  baseRank: number,
+  stockCount: number,
+): boolean {
+  if (stockCount > 0) return true;
+  for (let col = 0; col < tableau.length; col++) {
+    const card = endFaceUpCard(tableau[col]);
+    if (!card) continue;
+    if (agnesCanPlaceOnFoundation(card, foundation, baseRank)) return true;
+    for (let to = 0; to < tableau.length; to++) {
+      if (to !== col && agnesCanPlaceOnTableau(card, tableau, to)) return true;
+    }
+  }
+  return false;
+}


### PR DESCRIPTION
## Summary

Agnes Sorel (`AgnesPage.tsx`) lacked the assist features that sibling solitaires provide. This PR ships the **frontend-feasible subset** of the three requested in the issue, without touching Go.

## Features shipped / scoped

- [x] **Auto-complete** — a sequential driver (new `handleAutoComplete`) sweeps every face-up tableau end card to its foundation, re-reading the fresh board after each move so newly-exposed cards are swept too. Mirrors the Aces Up / Spiderette pattern (re-entry ref guard + `isAutoCompleting` busy gate). Enabled once the stock is empty and all cards are face up; also bound to the `a` key with a `KbdBadge`.
- [x] **Deadlock (手詰まり) detection** — pure helpers in `src/utils/agnesMoves.ts` replicate the domain move rules (`canPlaceOnFoundation`, `canPlaceOnTableau`) to report when no deal, foundation move, or tableau move remains. A `role="status"` stuck banner then appears.
- [x] **Undo-escape** — the stuck banner offers an "undo to escape" button (reuses the existing `undo` command, shown only when `canUndo`).

**Scoped out:** the backend-driven batch `StalemateEscapeButton` (`undo_n` with an `undoToEscape` count) used by Spiderette/Aces Up. `AgnesResponse` exposes neither an `isStalemate` flag nor an `undoToEscape` count, and deriving a batch count is not possible frontend-side, so this would require Go changes. The single-step undo-escape above is the frontend-feasible slice. (Undo itself already existed in Agnes.)

## Files

- `frontend/src/utils/agnesMoves.ts` (+ `.test.ts`) — pure move-rule helpers mirroring the domain
- `frontend/src/pages/AgnesPage.tsx` (+ `.test.tsx`) — driver, banner, button, `a` keybinding
- `frontend/src/i18n/locales/{ja,en}/agnes.json` — new keys (ja+en parity)

## Testing

- `bun run test -- --run Agnes` — 70 passed (page + util + CLI + formatter)
- `bun run check` — 0 errors
- `bun run build` (tsc) — passes

Closes #3289