### PR TITLE
feat(machiavelli): add table rearrange preview and submit flow

### DIFF
--- a/frontend/src/hooks/useMachiavelliGame.ts
+++ b/frontend/src/hooks/useMachiavelliGame.ts
@@ -59,6 +59,14 @@ export function useMachiavelliGame() {
     [exec, selectedCardIndices],
   );
 
+  const handleRearrange = useCallback(
+    (tableMelds: { design: number; value: number }[][], handIndices: number[]) => {
+      if (handIndices.length < 1 || tableMelds.length < 1) return;
+      exec('play', { tableMelds, handIndices });
+    },
+    [exec],
+  );
+
   const handleNextRound = useCallback(() => {
     exec('nextround');
   }, [exec]);
@@ -76,6 +84,7 @@ export function useMachiavelliGame() {
     handleDraw,
     handleNewMeld,
     handleLayoff,
+    handleRearrange,
     handleNextRound,
     retry,
   };

--- a/frontend/src/i18n/locales/en/machiavelli.json
+++ b/frontend/src/i18n/locales/en/machiavelli.json
@@ -53,5 +53,28 @@
   "a11y": {
     "meldLabel": "{{kind}}, {{count}} cards, {{rank}}",
     "layoffTo": "Lay off onto {{meld}}"
+  },
+  "rearrange": {
+    "toggle": "Rearrange",
+    "title": "Rearrange table",
+    "help": "Break up table melds and recombine them with your hand. Assign each card to a target group. You can submit only when every group is a valid meld.",
+    "selectPrompt": "Select one or more hand cards to start rearranging",
+    "poolTitle": "Assign cards to groups",
+    "previewTitle": "Rearrange preview",
+    "sourceTable": "Table",
+    "sourceHand": "Hand",
+    "unassigned": "Unassigned",
+    "group": "Group {{n}}",
+    "newGroup": "New group",
+    "assignLabel": "Target group for {{card}}",
+    "valid": "Valid",
+    "invalid": "Invalid",
+    "previewEmpty": "No groups yet",
+    "statusOk": "Valid rearrangement. Ready to submit",
+    "statusMelds": "Make every group a valid meld (a set or run of 3+ cards)",
+    "statusConserve": "Assign every card to a group (some are still unassigned)",
+    "statusPlay": "You must play at least one card from your hand",
+    "submit": "Submit rearrangement",
+    "cancel": "Cancel"
   }
 }

--- a/frontend/src/i18n/locales/ja/machiavelli.json
+++ b/frontend/src/i18n/locales/ja/machiavelli.json
@@ -53,5 +53,28 @@
   "a11y": {
     "meldLabel": "{{kind}} {{count}}枚 {{rank}}",
     "layoffTo": "{{meld}} にレイオフ"
+  },
+  "rearrange": {
+    "toggle": "再構成",
+    "title": "テーブル再構成",
+    "help": "場のメルドを崩して手札と組み替えます。各カードを行き先のグループへ割り当ててください。すべてが有効なメルドになったときだけ送信できます。",
+    "selectPrompt": "手札を1枚以上選んでから再構成を始められます",
+    "poolTitle": "カードをグループへ割り当て",
+    "previewTitle": "再構成プレビュー",
+    "sourceTable": "場",
+    "sourceHand": "手札",
+    "unassigned": "未割り当て",
+    "group": "グループ {{n}}",
+    "newGroup": "新しいグループ",
+    "assignLabel": "{{card}} の割り当て先",
+    "valid": "有効",
+    "invalid": "無効",
+    "previewEmpty": "まだグループがありません",
+    "statusOk": "有効な再構成です。送信できます",
+    "statusMelds": "各グループを有効なメルド（3枚以上のセットまたはシーケンス）にしてください",
+    "statusConserve": "すべてのカードをグループに割り当ててください（未割り当てが残っています）",
+    "statusPlay": "手札から少なくとも1枚を出す必要があります",
+    "submit": "再構成を送信",
+    "cancel": "やめる"
   }
 }

--- a/frontend/src/pages/MachiavelliPage.test.tsx
+++ b/frontend/src/pages/MachiavelliPage.test.tsx
@@ -442,4 +442,107 @@ describe('MachiavelliPage', () => {
     renderWithProviders(<MachiavelliPage />);
     await waitFor(() => expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument());
   });
+
+  describe('rearrange preview', () => {
+    // Table run ♠3-4-5; human holds ♠6 so assigning it into the run yields a
+    // valid rearrangement (♠3-4-5-6) that conserves all cards.
+    const rearrangeState: MachiavelliResponse = {
+      ...turnState,
+      players: [
+        player({
+          cards: [
+            { design: 'SPADE', value: 6 },
+            { design: 'HEART', value: 11 },
+          ],
+        }),
+        turnState.players[1],
+      ],
+    };
+
+    it('rearrange toggle is disabled until a hand card is selected', async () => {
+      mockExec.mockResolvedValue(rearrangeState);
+      renderWithProviders(<MachiavelliPage />);
+      await waitFor(() => expect(screen.getByTestId('machiavelli-rearrange-toggle')).toBeDisabled());
+      fireEvent.click(screen.getByAltText('♠ 6').closest('button') as HTMLButtonElement);
+      expect(screen.getByTestId('machiavelli-rearrange-toggle')).not.toBeDisabled();
+    });
+
+    it('opens the rearrange panel with pool assign controls', async () => {
+      mockExec.mockResolvedValue(rearrangeState);
+      renderWithProviders(<MachiavelliPage />);
+      await waitFor(() => expect(screen.getByAltText('♠ 6')).toBeInTheDocument());
+      fireEvent.click(screen.getByAltText('♠ 6').closest('button') as HTMLButtonElement);
+      fireEvent.click(screen.getByTestId('machiavelli-rearrange-toggle'));
+      expect(screen.getByTestId('machiavelli-rearrange-panel')).toBeInTheDocument();
+      // Three table cards + one selected hand card in the pool.
+      expect(screen.getByTestId('machiavelli-assign-t-0-0')).toBeInTheDocument();
+      expect(screen.getByTestId('machiavelli-assign-t-0-1')).toBeInTheDocument();
+      expect(screen.getByTestId('machiavelli-assign-t-0-2')).toBeInTheDocument();
+      expect(screen.getByTestId('machiavelli-assign-h-0')).toBeInTheDocument();
+    });
+
+    it('blocks submit until every card is assigned into a valid meld, then submits play', async () => {
+      mockExec.mockResolvedValue(rearrangeState);
+      renderWithProviders(<MachiavelliPage />);
+      await waitFor(() => expect(screen.getByAltText('♠ 6')).toBeInTheDocument());
+      fireEvent.click(screen.getByAltText('♠ 6').closest('button') as HTMLButtonElement);
+      fireEvent.click(screen.getByTestId('machiavelli-rearrange-toggle'));
+
+      // The played hand card starts unassigned → submit blocked, conservation status.
+      const submit = screen.getByTestId('machiavelli-rearrange-submit');
+      expect(submit).toBeDisabled();
+      expect(screen.getByTestId('machiavelli-rearrange-status')).toHaveTextContent(
+        'すべてのカードをグループに割り当ててください（未割り当てが残っています）',
+      );
+
+      // Assign the ♠6 into the existing run group (group 1 in the UI = index 0).
+      fireEvent.change(screen.getByTestId('machiavelli-assign-h-0'), { target: { value: '0' } });
+      expect(submit).not.toBeDisabled();
+      expect(screen.getByTestId('machiavelli-rearrange-status')).toHaveTextContent('有効な再構成です。送信できます');
+
+      mockExec.mockClear();
+      mockExec.mockResolvedValue(rearrangeState);
+      fireEvent.click(submit);
+      await waitFor(() =>
+        expect(mockExec).toHaveBeenCalledWith('play', {
+          tableMelds: [
+            [
+              { design: 1, value: 3 },
+              { design: 1, value: 4 },
+              { design: 1, value: 5 },
+              { design: 1, value: 6 },
+            ],
+          ],
+          handIndices: [0],
+        }),
+      );
+    });
+
+    it('shows an invalid badge for a group that is not a valid meld', async () => {
+      mockExec.mockResolvedValue(rearrangeState);
+      renderWithProviders(<MachiavelliPage />);
+      await waitFor(() => expect(screen.getByAltText('♠ 6')).toBeInTheDocument());
+      fireEvent.click(screen.getByAltText('♠ 6').closest('button') as HTMLButtonElement);
+      fireEvent.click(screen.getByTestId('machiavelli-rearrange-toggle'));
+      // Assign ♠6 to its own new group: cards are conserved, but the singleton
+      // group is not a valid meld, so submit stays blocked with a melds status.
+      fireEvent.change(screen.getByTestId('machiavelli-assign-h-0'), { target: { value: '1' } });
+      expect(screen.getByTestId('machiavelli-rearrange-group-1')).toHaveTextContent('無効');
+      expect(screen.getByTestId('machiavelli-rearrange-status')).toHaveTextContent(
+        '各グループを有効なメルド（3枚以上のセットまたはシーケンス）にしてください',
+      );
+      expect(screen.getByTestId('machiavelli-rearrange-submit')).toBeDisabled();
+    });
+
+    it('cancel closes the rearrange panel', async () => {
+      mockExec.mockResolvedValue(rearrangeState);
+      renderWithProviders(<MachiavelliPage />);
+      await waitFor(() => expect(screen.getByAltText('♠ 6')).toBeInTheDocument());
+      fireEvent.click(screen.getByAltText('♠ 6').closest('button') as HTMLButtonElement);
+      fireEvent.click(screen.getByTestId('machiavelli-rearrange-toggle'));
+      expect(screen.getByTestId('machiavelli-rearrange-panel')).toBeInTheDocument();
+      fireEvent.click(screen.getByRole('button', { name: 'やめる' }));
+      expect(screen.queryByTestId('machiavelli-rearrange-panel')).not.toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/src/pages/MachiavelliPage.tsx
+++ b/frontend/src/pages/MachiavelliPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import type { machiavelliApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
@@ -27,11 +27,11 @@ import {
 } from '../hooks/useMachiavelliGame';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
-import { btnPrimary, btnSuccess } from '../styles/buttonStyles';
+import { btnOutline, btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
 import { focusRingCard, selectedCardStyle } from '../styles/cardStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
-import type { MachiavelliResponse } from '../types/card';
+import type { Card, MachiavelliResponse } from '../types/card';
 import { MachiavelliPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
@@ -39,6 +39,7 @@ import { valueName } from '../utils/cardUtils';
 import { MACHIAVELLI_HELP, parseMachiavelliCommand } from '../utils/cli/commands/machiavelliCommands';
 import { formatMachiavelliState } from '../utils/cli/formatters/machiavelliFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { designToNum, evaluateRearrange, isMachiavelliValidMeld } from '../utils/machiavelliRearrange';
 import { playerName } from '../utils/playerUtils';
 
 const MACHIAVELLI_PHASE_KEYS: Readonly<Record<number, string>> = {
@@ -102,8 +103,21 @@ function MachiavelliPageContent() {
     handleDraw,
     handleNewMeld,
     handleLayoff,
+    handleRearrange,
     handleNextRound,
   } = useMachiavelliGame();
+  // Rearrange composer: staged assignment of pool cards (flattened table cards +
+  // selected hand cards) into proposed melds, previewed against the domain rules.
+  const [rearrangeOpen, setRearrangeOpen] = useState(false);
+  const [assignments, setAssignments] = useState<Record<string, number>>({});
+  const openRearrange = useCallback(() => {
+    setAssignments({});
+    setRearrangeOpen(true);
+  }, []);
+  const closeRearrange = useCallback(() => {
+    setRearrangeOpen(false);
+    setAssignments({});
+  }, []);
   const {
     hint: frontendHint,
     hintEnabled: frontendHintEnabled,
@@ -174,6 +188,52 @@ function MachiavelliPageContent() {
   // When exactly one hand card is selected it can be laid off onto any table
   // meld, so highlight the melds as drop targets and describe the layoff.
   const canLayoff = isHumanTurn && selectedCardIndices.length === 1;
+
+  // --- Rearrange composer derivations ---
+  // A pool card is either a card already on the table (defaulting to its current
+  // meld group) or a selected hand card (initially unassigned, group -1).
+  type PoolItem = { id: string; card: Card; source: 'table' | 'hand'; defaultGroup: number };
+  const tableItems: PoolItem[] = state.table.flatMap((meld, m) =>
+    meld.cards.map((card, ci) => ({ id: `t-${m}-${ci}`, card, source: 'table' as const, defaultGroup: m })),
+  );
+  const handItems: PoolItem[] = humanPlayer
+    ? selectedCardIndices
+        .map((hi) => ({ hi, card: humanPlayer.cards[hi] }))
+        .filter((x): x is { hi: number; card: Card } => !!x.card)
+        .map((x) => ({ id: `h-${x.hi}`, card: x.card, source: 'hand' as const, defaultGroup: -1 }))
+    : [];
+  const poolItems = [...tableItems, ...handItems];
+  const groupOf = (item: PoolItem): number => assignments[item.id] ?? item.defaultGroup;
+  let maxGroupId = state.table.length - 1;
+  for (const item of poolItems) maxGroupId = Math.max(maxGroupId, groupOf(item));
+  const groupCards: Card[][] = [];
+  for (let g = 0; g <= maxGroupId; g++) {
+    groupCards[g] = poolItems.filter((it) => groupOf(it) === g).map((it) => it.card);
+  }
+  const previewGroups = groupCards.map((cards, g) => ({ g, cards })).filter((x) => x.cards.length > 0);
+  const playedCards = handItems.map((it) => it.card);
+  const rearrangeEval = evaluateRearrange(
+    groupCards,
+    state.table.map((m) => m.cards),
+    playedCards,
+  );
+  const rearrangeStatusKey = !rearrangeEval.playsFromHand
+    ? 'rearrange.statusPlay'
+    : !rearrangeEval.conserves
+      ? 'rearrange.statusConserve'
+      : !rearrangeEval.allMeldsValid
+        ? 'rearrange.statusMelds'
+        : 'rearrange.statusOk';
+  const submitRearrange = () => {
+    if (!rearrangeEval.canSubmit) return;
+    const tableMelds = previewGroups.map((x) =>
+      x.cards.map((card) => ({ design: designToNum(card.design), value: card.value })),
+    );
+    handleRearrange(tableMelds, [...selectedCardIndices]);
+    setRearrangeOpen(false);
+    setAssignments({});
+  };
+  const showRearrangePanel = isHumanTurn && rearrangeOpen && selectedCardIndices.length >= 1;
 
   /** Describes a table meld for assistive tech: kind, size, and rank(s). */
   const meldAria = (meld: { kind: number; cards: { design: string; value: number }[] }): string => {
@@ -355,6 +415,98 @@ function MachiavelliPageContent() {
               </div>
             </div>
 
+            {showRearrangePanel && (
+              <div className="my-3 p-3 rounded bg-black/40" data-testid="machiavelli-rearrange-panel">
+                <div className="flex items-center justify-between mb-2">
+                  <span className="text-ds-text-primary font-medium">{t('rearrange.title')}</span>
+                  <button type="button" className={btnOutline} onClick={closeRearrange}>
+                    {t('rearrange.cancel')}
+                  </button>
+                </div>
+                <p className="text-ds-text-muted text-sm mb-3">{t('rearrange.help')}</p>
+
+                <div className="text-ds-text-muted text-xs mb-1">{t('rearrange.poolTitle')}</div>
+                <div className="flex flex-wrap gap-2 mb-3">
+                  {poolItems.map((item) => (
+                    <div key={item.id} className="flex flex-col items-center gap-1">
+                      <AnimatedCard card={item.card} width={cardWidth * 0.7} />
+                      <span className="text-ds-text-muted text-[10px]">
+                        {item.source === 'table' ? t('rearrange.sourceTable') : t('rearrange.sourceHand')}
+                      </span>
+                      <select
+                        className="text-xs rounded bg-ds-surface-elevated text-ds-text-primary px-1 py-0.5"
+                        data-testid={`machiavelli-assign-${item.id}`}
+                        aria-label={t('rearrange.assignLabel', { card: cardAlt(item.card) })}
+                        value={groupOf(item)}
+                        onChange={(e) => {
+                          const g = Number(e.target.value);
+                          setAssignments((prev) => ({ ...prev, [item.id]: g }));
+                        }}
+                      >
+                        <option value={-1}>{t('rearrange.unassigned')}</option>
+                        {Array.from({ length: maxGroupId + 1 }, (_, g) => (
+                          <option key={g} value={g}>
+                            {t('rearrange.group', { n: g + 1 })}
+                          </option>
+                        ))}
+                        <option value={maxGroupId + 1}>{t('rearrange.newGroup')}</option>
+                      </select>
+                    </div>
+                  ))}
+                </div>
+
+                <div className="text-ds-text-muted text-xs mb-1">{t('rearrange.previewTitle')}</div>
+                {previewGroups.length === 0 ? (
+                  <div className="text-ds-text-muted text-sm">{t('rearrange.previewEmpty')}</div>
+                ) : (
+                  <div className="flex flex-col gap-2">
+                    {previewGroups.map((x) => {
+                      const ok = isMachiavelliValidMeld(x.cards);
+                      return (
+                        <div
+                          key={x.g}
+                          className="flex items-center gap-2 flex-wrap"
+                          data-testid={`machiavelli-rearrange-group-${x.g}`}
+                        >
+                          <span
+                            className={`text-xs px-2 py-0.5 rounded ${
+                              ok ? 'bg-ds-success/30 text-ds-text-primary' : 'bg-ds-error/30 text-ds-text-primary'
+                            }`}
+                          >
+                            {ok ? t('rearrange.valid') : t('rearrange.invalid')}
+                          </span>
+                          <div className="flex flex-wrap gap-1">
+                            {x.cards.map((card, ci) => (
+                              <AnimatedCard
+                                key={`rg-${x.g}-${card.design}-${card.value}-${ci}`}
+                                card={card}
+                                width={cardWidth * 0.6}
+                              />
+                            ))}
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+
+                <div className="mt-3 flex items-center gap-3 flex-wrap">
+                  <button
+                    type="button"
+                    className={btnSuccess}
+                    onClick={submitRearrange}
+                    disabled={loading || !rearrangeEval.canSubmit}
+                    data-testid="machiavelli-rearrange-submit"
+                  >
+                    {t('rearrange.submit')}
+                  </button>
+                  <span className="text-ds-text-muted text-sm" role="status" data-testid="machiavelli-rearrange-status">
+                    {t(rearrangeStatusKey)}
+                  </span>
+                </div>
+              </div>
+            )}
+
             <GameMessageBox
               message={state.message}
               messageCode={state.messageCode}
@@ -421,6 +573,17 @@ function MachiavelliPageContent() {
                     data-testid="machiavelli-newmeld-button"
                   >
                     {t('newMeldButton')}
+                  </button>
+                  <button
+                    type="button"
+                    className={btnSecondary}
+                    onClick={rearrangeOpen ? closeRearrange : openRearrange}
+                    disabled={loading || selectedCardIndices.length < 1}
+                    aria-pressed={rearrangeOpen}
+                    title={selectedCardIndices.length < 1 ? t('rearrange.selectPrompt') : undefined}
+                    data-testid="machiavelli-rearrange-toggle"
+                  >
+                    {t('rearrange.toggle')}
                   </button>
                 </>
               )}

--- a/frontend/src/utils/machiavelliRearrange.test.ts
+++ b/frontend/src/utils/machiavelliRearrange.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest';
+import type { Card } from '../types/card';
+import {
+  designToNum,
+  evaluateRearrange,
+  isMachiavelliRun,
+  isMachiavelliSet,
+  isMachiavelliValidMeld,
+  machiavelliConserves,
+} from './machiavelliRearrange';
+
+const c = (design: Card['design'], value: number): Card => ({ design, value });
+
+describe('machiavelliRearrange helpers', () => {
+  describe('designToNum', () => {
+    it('maps suits to the Go numeric constants', () => {
+      expect(designToNum('SPADE')).toBe(1);
+      expect(designToNum('CLOVER')).toBe(2);
+      expect(designToNum('HEART')).toBe(3);
+      expect(designToNum('DIAMOND')).toBe(4);
+      expect(designToNum('JOKER')).toBe(0);
+    });
+  });
+
+  describe('isMachiavelliSet', () => {
+    it('accepts 3 same-rank distinct-suit cards', () => {
+      expect(isMachiavelliSet([c('SPADE', 9), c('HEART', 9), c('CLOVER', 9)])).toBe(true);
+    });
+    it('rejects fewer than 3 cards', () => {
+      expect(isMachiavelliSet([c('SPADE', 9), c('HEART', 9)])).toBe(false);
+    });
+    it('rejects mismatched ranks', () => {
+      expect(isMachiavelliSet([c('SPADE', 9), c('HEART', 8), c('CLOVER', 9)])).toBe(false);
+    });
+    it('rejects duplicate suits', () => {
+      expect(isMachiavelliSet([c('SPADE', 9), c('SPADE', 9), c('CLOVER', 9)])).toBe(false);
+    });
+    it('rejects jokers', () => {
+      expect(isMachiavelliSet([c('JOKER', 0), c('HEART', 9), c('CLOVER', 9)])).toBe(false);
+    });
+  });
+
+  describe('isMachiavelliRun', () => {
+    it('accepts a same-suit consecutive run', () => {
+      expect(isMachiavelliRun([c('SPADE', 3), c('SPADE', 4), c('SPADE', 5)])).toBe(true);
+    });
+    it('accepts an ace-low run (A-2-3)', () => {
+      expect(isMachiavelliRun([c('SPADE', 1), c('SPADE', 2), c('SPADE', 3)])).toBe(true);
+    });
+    it('accepts an ace-high run (Q-K-A)', () => {
+      expect(isMachiavelliRun([c('SPADE', 12), c('SPADE', 13), c('SPADE', 1)])).toBe(true);
+    });
+    it('rejects a wrap-around run (K-A-2)', () => {
+      expect(isMachiavelliRun([c('SPADE', 13), c('SPADE', 1), c('SPADE', 2)])).toBe(false);
+    });
+    it('rejects mixed suits', () => {
+      expect(isMachiavelliRun([c('SPADE', 3), c('HEART', 4), c('SPADE', 5)])).toBe(false);
+    });
+    it('rejects duplicate values', () => {
+      expect(isMachiavelliRun([c('SPADE', 3), c('SPADE', 3), c('SPADE', 4)])).toBe(false);
+    });
+    it('rejects a non-consecutive run', () => {
+      expect(isMachiavelliRun([c('SPADE', 3), c('SPADE', 5), c('SPADE', 6)])).toBe(false);
+    });
+  });
+
+  describe('isMachiavelliValidMeld', () => {
+    it('accepts either a set or a run', () => {
+      expect(isMachiavelliValidMeld([c('SPADE', 9), c('HEART', 9), c('CLOVER', 9)])).toBe(true);
+      expect(isMachiavelliValidMeld([c('SPADE', 3), c('SPADE', 4), c('SPADE', 5)])).toBe(true);
+    });
+    it('rejects an invalid group', () => {
+      expect(isMachiavelliValidMeld([c('SPADE', 3), c('HEART', 8), c('CLOVER', 9)])).toBe(false);
+    });
+  });
+
+  describe('machiavelliConserves', () => {
+    const oldTable = [[c('SPADE', 3), c('SPADE', 4), c('SPADE', 5)]];
+    it('holds when the proposed table is old + played', () => {
+      const proposed = [[c('SPADE', 3), c('SPADE', 4), c('SPADE', 5), c('SPADE', 6)]];
+      expect(machiavelliConserves(oldTable, [c('SPADE', 6)], proposed)).toBe(true);
+    });
+    it('fails when a card is missing', () => {
+      const proposed = [[c('SPADE', 4), c('SPADE', 5), c('SPADE', 6)]];
+      expect(machiavelliConserves(oldTable, [c('SPADE', 6)], proposed)).toBe(false);
+    });
+    it('fails when card counts differ', () => {
+      const proposed = [[c('SPADE', 3), c('SPADE', 4), c('SPADE', 5)]];
+      expect(machiavelliConserves(oldTable, [c('SPADE', 6)], proposed)).toBe(false);
+    });
+  });
+
+  describe('evaluateRearrange', () => {
+    const oldTable = [[c('SPADE', 3), c('SPADE', 4), c('SPADE', 5)]];
+
+    it('allows submitting a valid layoff-style rearrangement', () => {
+      const played = [c('SPADE', 6)];
+      const groups = [[c('SPADE', 3), c('SPADE', 4), c('SPADE', 5), c('SPADE', 6)]];
+      const evalResult = evaluateRearrange(groups, oldTable, played);
+      expect(evalResult.groupValidity).toEqual([true]);
+      expect(evalResult.allMeldsValid).toBe(true);
+      expect(evalResult.conserves).toBe(true);
+      expect(evalResult.playsFromHand).toBe(true);
+      expect(evalResult.canSubmit).toBe(true);
+    });
+
+    it('allows splitting a run into two valid melds using a played card', () => {
+      // Table run 3-4-5-6-7 borrowed + played S8/S9 → 3-4-5 and 6-7-8-9.
+      const table = [[c('SPADE', 3), c('SPADE', 4), c('SPADE', 5), c('SPADE', 6), c('SPADE', 7)]];
+      const played = [c('SPADE', 8), c('SPADE', 9)];
+      const groups = [
+        [c('SPADE', 3), c('SPADE', 4), c('SPADE', 5)],
+        [c('SPADE', 6), c('SPADE', 7), c('SPADE', 8), c('SPADE', 9)],
+      ];
+      expect(evaluateRearrange(groups, table, played).canSubmit).toBe(true);
+    });
+
+    it('blocks submission when a group is not a valid meld', () => {
+      const played = [c('HEART', 9)];
+      const groups = [[c('SPADE', 3), c('SPADE', 4), c('SPADE', 5), c('HEART', 9)]];
+      const evalResult = evaluateRearrange(groups, oldTable, played);
+      expect(evalResult.allMeldsValid).toBe(false);
+      expect(evalResult.canSubmit).toBe(false);
+    });
+
+    it('blocks submission when cards are not conserved (unassigned remain)', () => {
+      const played = [c('SPADE', 6)];
+      // Only the table meld is grouped; the played 6 is left out → not conserved.
+      const groups = [[c('SPADE', 3), c('SPADE', 4), c('SPADE', 5)]];
+      const evalResult = evaluateRearrange(groups, oldTable, played);
+      expect(evalResult.conserves).toBe(false);
+      expect(evalResult.canSubmit).toBe(false);
+    });
+
+    it('blocks submission when no hand card is played', () => {
+      const groups = [[c('SPADE', 3), c('SPADE', 4), c('SPADE', 5)]];
+      const evalResult = evaluateRearrange(groups, oldTable, []);
+      expect(evalResult.playsFromHand).toBe(false);
+      expect(evalResult.canSubmit).toBe(false);
+    });
+
+    it('ignores empty groups when evaluating', () => {
+      const played = [c('SPADE', 6)];
+      const groups = [[c('SPADE', 3), c('SPADE', 4), c('SPADE', 5), c('SPADE', 6)], []];
+      expect(evaluateRearrange(groups, oldTable, played).canSubmit).toBe(true);
+    });
+  });
+});

--- a/frontend/src/utils/machiavelliRearrange.ts
+++ b/frontend/src/utils/machiavelliRearrange.ts
@@ -1,0 +1,146 @@
+import type { Card } from '../types/card';
+
+/**
+ * Pure client-side mirrors of the Machiavelli meld-validity and table
+ * conservation rules from `internal/domain/Machiavelli.go`. Used by the
+ * rearrange preview UI to decide, before submitting the `play` power move,
+ * whether a proposed table is a legal rearrangement. The backend re-validates
+ * on submit; these helpers only gate the preview so the button is enabled
+ * exactly when the domain would accept the play.
+ */
+
+/** Minimum cards in a Machiavelli meld (set or run). */
+export const MACHIAVELLI_MELD_MIN = 3;
+
+/** Suit-name → numeric design index, matching the Go `CardDesign*` constants. */
+const SUIT_TO_NUM: Record<string, number> = { SPADE: 1, CLOVER: 2, HEART: 3, DIAMOND: 4 };
+
+/** Numeric design index for a card ('SPADE'→1 … 'DIAMOND'→4, 'JOKER'→0). */
+export function designToNum(design: string): number {
+  return SUIT_TO_NUM[design] ?? 0;
+}
+
+/** Multiset key for a card: `design*100 + value`, matching Go `machiavelliCardKey`. */
+function cardKey(card: Card): number {
+  return designToNum(card.design) * 100 + card.value;
+}
+
+/**
+ * True if `cards` form a valid set: 3+ cards of the same rank with distinct
+ * suits and no joker. Mirrors Go `machiavelliIsSet`.
+ */
+export function isMachiavelliSet(cards: Card[]): boolean {
+  if (cards.length < MACHIAVELLI_MELD_MIN) return false;
+  let rank = -1;
+  const seenSuit = new Set<string>();
+  for (const c of cards) {
+    if (c.design === 'JOKER') return false;
+    if (rank === -1) rank = c.value;
+    else if (c.value !== rank) return false;
+    if (seenSuit.has(c.design)) return false;
+    seenSuit.add(c.design);
+  }
+  return true;
+}
+
+/** Ace-low and (when an ace is present) ace-high sorted variants. Mirrors Go `aceVariants`. */
+function aceVariants(values: number[]): number[][] {
+  const low = [...values].sort((a, b) => a - b);
+  const out = [low];
+  if (low.length > 0 && low[0] === 1) {
+    const high = [...low.slice(1), 14].sort((a, b) => a - b);
+    out.push(high);
+  }
+  return out;
+}
+
+/** True if a sorted list increases by exactly 1 each step. Mirrors Go `isConsecutive`. */
+function isConsecutive(values: number[]): boolean {
+  for (let i = 1; i < values.length; i++) {
+    if (values[i] !== values[i - 1] + 1) return false;
+  }
+  return true;
+}
+
+/**
+ * True if `cards` form a valid run: 3+ same-suit cards with distinct,
+ * consecutive values (ace low or high, no wrap) and no joker. Mirrors Go
+ * `machiavelliIsRun`.
+ */
+export function isMachiavelliRun(cards: Card[]): boolean {
+  if (cards.length < MACHIAVELLI_MELD_MIN) return false;
+  let suit = '';
+  const seen = new Set<number>();
+  const values: number[] = [];
+  for (const c of cards) {
+    if (c.design === 'JOKER') return false;
+    if (suit === '') suit = c.design;
+    else if (c.design !== suit) return false;
+    if (seen.has(c.value)) return false;
+    seen.add(c.value);
+    values.push(c.value);
+  }
+  return aceVariants(values).some(isConsecutive);
+}
+
+/** True if `cards` form a valid meld (set or run of 3+). Mirrors Go `machiavelliIsValidMeld`. */
+export function isMachiavelliValidMeld(cards: Card[]): boolean {
+  return isMachiavelliSet(cards) || isMachiavelliRun(cards);
+}
+
+/** Multiset equality of two card lists by (design, value). */
+function sameMultiset(a: Card[], b: Card[]): boolean {
+  if (a.length !== b.length) return false;
+  const counts = new Map<number, number>();
+  for (const c of a) counts.set(cardKey(c), (counts.get(cardKey(c)) ?? 0) + 1);
+  for (const c of b) {
+    const k = cardKey(c);
+    const n = counts.get(k);
+    if (!n) return false;
+    counts.set(k, n - 1);
+  }
+  return true;
+}
+
+/**
+ * True if `proposed` conserves the cards: its multiset equals the old table's
+ * cards plus the `played` hand cards. Mirrors Go `machiavelliConserves`.
+ */
+export function machiavelliConserves(oldTable: Card[][], played: Card[], proposed: Card[][]): boolean {
+  return sameMultiset([...oldTable.flat(), ...played], proposed.flat());
+}
+
+/** Result of evaluating a staged rearrangement against the domain rules. */
+export interface RearrangeEvaluation {
+  /** Per-group validity flags, in group order (empty groups are dropped). */
+  groupValidity: boolean[];
+  /** Whether every non-empty group is a valid meld. */
+  allMeldsValid: boolean;
+  /** Whether the proposed table conserves exactly the old table + played cards. */
+  conserves: boolean;
+  /** Whether at least one hand card is played (Machiavelli requires ≥1). */
+  playsFromHand: boolean;
+  /** Whether the rearrangement is legal and can be submitted. */
+  canSubmit: boolean;
+}
+
+/**
+ * Evaluate a staged rearrangement: `groups` are the proposed table melds (empty
+ * groups ignored), `oldTable` the current table melds, and `played` the hand
+ * cards being contributed. Returns per-group validity and an overall submit
+ * gate mirroring the three domain checks (valid melds, conservation, ≥1 played).
+ */
+export function evaluateRearrange(groups: Card[][], oldTable: Card[][], played: Card[]): RearrangeEvaluation {
+  const nonEmpty = groups.filter((g) => g.length > 0);
+  const groupValidity = nonEmpty.map(isMachiavelliValidMeld);
+  const allMeldsValid = nonEmpty.length > 0 && groupValidity.every(Boolean);
+  const conserves = machiavelliConserves(oldTable, played, nonEmpty);
+  const playsFromHand = played.length >= 1;
+  return {
+    groupValidity,
+    allMeldsValid,
+    conserves,
+    playsFromHand,
+    canSubmit: allMeldsValid && conserves && playsFromHand,
+  };
+}


### PR DESCRIPTION
## What

Adds a bounded **rearrange (再構成) preview** to the Machiavelli page. Machiavelli's core mechanic — breaking up existing shared-table melds and recombining them with your own cards — was not directly available in the UI (only new-meld and layoff). This PR adds a staging composer that lets the player weave selected hand cards into the table and submit the result via the **existing backend `play` power move**, with a live validity preview so submit is only enabled when the rearrangement is legal.

## How

- **New pure helper** `frontend/src/utils/machiavelliRearrange.ts` mirrors `internal/domain/Machiavelli.go` exactly:
  - set validity (same rank, distinct suits, 3+), run validity (same suit, consecutive, ace low/high, no wrap, no dup), and multiset **conservation** (proposed table == old table + played hand cards, with ≥1 hand card played).
  - `evaluateRearrange()` returns per-group validity + an overall submit gate.
- **`MachiavelliPage.tsx`**: a "再構成" toggle (enabled once ≥1 hand card is selected) opens a panel. Each pool card (flattened table cards + selected hand cards) gets a labelled group `<select>`; the preview shows per-group Valid/Invalid badges and a status line. Submit calls `play` with `{ tableMelds, handIndices }`.
- **`useMachiavelliGame.ts`**: adds `handleRearrange` dispatching the `play` command (already wired through the API/controller/domain).
- The backend re-validates on submit — the helper only drives the preview.

## Scope / safety

- Additive only: existing **draw / new-meld / layoff** flows are untouched.
- No Go changes; no new backend actions (reuses `play`).
- ja/en locale keys added at parity.

## Acceptance criteria

- [x] Preview a rearrangement that involves table cards
- [x] Submit only enabled when the result is a set of valid melds (and cards are conserved)
- [x] Existing newMeld/layoff paths not broken
- [x] Rearrange preview tests added to `MachiavelliPage.test.tsx`

## Tests / gates

- `bun run test -- --run Machiavelli` — 113 passing (incl. new helper + page rearrange tests)
- `bun run check` — pass
- `bun run build` (tsc) — pass
- Full `bun run test` — pass (exit 0)

Closes #3501

🤖 Generated with [Claude Code](https://claude.com/claude-code)