### PR TITLE
feat(blackjack): add additive quick-chip bet buttons to the bet phase

### DIFF
--- a/frontend/src/components/blackjack/BjBetPhaseControls.test.tsx
+++ b/frontend/src/components/blackjack/BjBetPhaseControls.test.tsx
@@ -65,6 +65,45 @@ describe('BjBetPhaseControls', () => {
     expect(onBetAmountChange).toHaveBeenLastCalledWith(1000);
   });
 
+  it('renders additive quick-chip buttons and a clear button', () => {
+    render(<BjBetPhaseControls {...defaultProps()} />);
+    const row = screen.getByTestId('bj-chip-add');
+    expect(row).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '+10' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '+25' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '+100' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'クリア' })).toBeInTheDocument();
+  });
+
+  it('adds the chip value to the current bet (clamped to chips) when a chip button is clicked', () => {
+    const onBetAmountChange = vi.fn();
+    render(<BjBetPhaseControls {...defaultProps({ onBetAmountChange, betAmount: 10, playerChips: 1000 })} />);
+    fireEvent.click(screen.getByRole('button', { name: '+25' }));
+    expect(onBetAmountChange).toHaveBeenLastCalledWith(35);
+    fireEvent.click(screen.getByRole('button', { name: '+100' }));
+    expect(onBetAmountChange).toHaveBeenLastCalledWith(110);
+  });
+
+  it('disables a chip button when adding it would exceed the chip balance', () => {
+    render(<BjBetPhaseControls {...defaultProps({ betAmount: 90, playerChips: 100 })} />);
+    expect(screen.getByRole('button', { name: '+10' })).not.toBeDisabled();
+    expect(screen.getByRole('button', { name: '+25' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: '+100' })).toBeDisabled();
+  });
+
+  it('resets the bet to the table minimum when the clear button is clicked', () => {
+    const onBetAmountChange = vi.fn();
+    render(<BjBetPhaseControls {...defaultProps({ onBetAmountChange, betAmount: 500 })} />);
+    fireEvent.click(screen.getByRole('button', { name: 'クリア' }));
+    expect(onBetAmountChange).toHaveBeenLastCalledWith(10);
+  });
+
+  it('disables the additive chip and clear buttons when loading', () => {
+    render(<BjBetPhaseControls {...defaultProps({ loading: true })} />);
+    expect(screen.getByRole('button', { name: '+10' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'クリア' })).toBeDisabled();
+  });
+
   it('renders deck count selector with provided value', () => {
     render(<BjBetPhaseControls {...defaultProps({ deckCount: 6 })} />);
     expect(screen.getByLabelText('デッキ数:')).toHaveValue('6');

--- a/frontend/src/components/blackjack/BjBetPhaseControls.tsx
+++ b/frontend/src/components/blackjack/BjBetPhaseControls.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { btnPrimary, btnSuccess, btnWarning } from '../../styles/buttonStyles';
-import { type BjQuickBetKind, bjQuickBetAmount } from '../../utils/blackjackBet';
+import { BJ_CHIP_VALUES, BJ_MIN_BET, type BjQuickBetKind, bjAddChip, bjQuickBetAmount } from '../../utils/blackjackBet';
 import { ChipBetInput } from '../common/ChipBetInput';
 import {
   BJ_COUNTING_HILO,
@@ -70,6 +70,30 @@ export function BjBetPhaseControls(props: BjBetPhaseControlsProps) {
             {t(`betChip.${kind}`)}
           </button>
         ))}
+      </div>
+      {/* Additive quick-chip buttons: add to the current bet (clamped to chips), plus a clear/reset */}
+      <div className="flex items-center justify-center gap-2 mb-2 flex-wrap" data-testid="bj-chip-add">
+        {BJ_CHIP_VALUES.map((value) => (
+          <button
+            key={value}
+            type="button"
+            data-testid={`bj-chip-add-${value}`}
+            className={`${btnPrimary} min-w-[44px] min-h-[44px] px-3 text-sm`}
+            disabled={props.loading || props.betAmount + value > props.playerChips}
+            onClick={() => props.onBetAmountChange(bjAddChip(props.betAmount, value, props.playerChips))}
+          >
+            {t('betChip.add', { amount: value })}
+          </button>
+        ))}
+        <button
+          type="button"
+          data-testid="bj-chip-clear"
+          className={`${btnWarning} min-w-[44px] min-h-[44px] px-3 text-sm`}
+          disabled={props.loading}
+          onClick={() => props.onBetAmountChange(BJ_MIN_BET)}
+        >
+          {t('betChip.clear')}
+        </button>
       </div>
       {/* Basic settings: bet amount, hand count */}
       <div className="flex items-center justify-center gap-2 mb-2">

--- a/frontend/src/i18n/locales/en/blackjack.json
+++ b/frontend/src/i18n/locales/en/blackjack.json
@@ -41,6 +41,8 @@
   "betChip.min": "Min",
   "betChip.half": "Half",
   "betChip.max": "Max",
+  "betChip.add": "+{{amount}}",
+  "betChip.clear": "Clear",
   "deckCount": "Decks:",
   "cpuCount": "CPU Players:",
   "cpuUnit": "",

--- a/frontend/src/i18n/locales/ja/blackjack.json
+++ b/frontend/src/i18n/locales/ja/blackjack.json
@@ -40,6 +40,8 @@
   "betChip.min": "最小",
   "betChip.half": "半額",
   "betChip.max": "全額",
+  "betChip.add": "+{{amount}}",
+  "betChip.clear": "クリア",
   "deckCount": "デッキ数:",
   "cpuCount": "CPU人数:",
   "cpuUnit": "人",

--- a/frontend/src/utils/blackjackBet.test.ts
+++ b/frontend/src/utils/blackjackBet.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { BJ_MIN_BET, bjQuickBetAmount } from './blackjackBet';
+import { BJ_CHIP_VALUES, BJ_MIN_BET, bjAddChip, bjQuickBetAmount } from './blackjackBet';
 
 describe('bjQuickBetAmount', () => {
   it('returns the table minimum for "min"', () => {
@@ -22,5 +22,21 @@ describe('bjQuickBetAmount', () => {
       expect(bjQuickBetAmount(kind, 5)).toBeLessThanOrEqual(5);
       expect(bjQuickBetAmount(kind, 15)).toBeLessThanOrEqual(15);
     }
+  });
+});
+
+describe('bjAddChip', () => {
+  it('adds the chip value to the current bet', () => {
+    expect(bjAddChip(10, 25, 1000)).toBe(35);
+    expect(bjAddChip(100, 100, 1000)).toBe(200);
+  });
+
+  it('clamps the result to the available chips', () => {
+    expect(bjAddChip(90, 25, 100)).toBe(100);
+    expect(bjAddChip(500, 100, 500)).toBe(500);
+  });
+
+  it('offers the +10 / +25 / +100 denominations', () => {
+    expect(BJ_CHIP_VALUES).toEqual([10, 25, 100]);
   });
 });

--- a/frontend/src/utils/blackjackBet.ts
+++ b/frontend/src/utils/blackjackBet.ts
@@ -4,6 +4,26 @@ export const BJ_MIN_BET = 10;
 /** Quick-bet shortcut kinds offered in the bet phase. */
 export type BjQuickBetKind = 'min' | 'half' | 'max';
 
+/**
+ * Additive quick-chip denominations offered in the bet phase. Each button adds
+ * its value to the current bet (clamped to the player's chip balance) so the
+ * player can build a bet quickly instead of typing or stepping the input.
+ */
+export const BJ_CHIP_VALUES = [10, 25, 100] as const;
+
+/**
+ * Adds a chip value to the current bet, clamped to the player's chip balance.
+ * Never returns more than `playerChips`.
+ *
+ * @param current - The current bet amount.
+ * @param delta - The chip value to add.
+ * @param playerChips - The player's current chip balance (the upper bound).
+ * @returns The new bet amount, clamped to `playerChips`.
+ */
+export function bjAddChip(current: number, delta: number, playerChips: number): number {
+  return Math.min(playerChips, current + delta);
+}
+
 /** Round a chip amount down to the nearest valid (10-multiple) bet. */
 function floorToStep(amount: number): number {
   return Math.floor(Math.max(0, amount) / BJ_MIN_BET) * BJ_MIN_BET;


### PR DESCRIPTION
## Summary

Adds additive quick-chip bet buttons to the BlackJack bet phase so players can build a bet quickly instead of typing or stepping the input.

- New **+10 / +25 / +100** chip buttons add their value to the current bet, clamped to the player's chip balance.
- Each chip button is **disabled when adding it would exceed the balance** (per the acceptance criteria).
- New **Clear** button resets the bet to the table minimum (10).
- Sits alongside the existing min/half/max set-to shortcuts; the existing bet input and submit flow are untouched.
- FRONTEND-ONLY. No Go changes.

## Implementation

- `blackjackBet.ts`: new `BJ_CHIP_VALUES` denominations + pure `bjAddChip(current, delta, playerChips)` add-and-clamp helper.
- `BjBetPhaseControls.tsx`: additive chip row (`data-testid="bj-chip-add"`) + clear button, design-system button tokens, 44x44 tap targets.
- i18n: `betChip.add` / `betChip.clear` keys added to ja + en (parity).

## Test plan

- [x] `bun run check` (biome + design-tokens) — passes
- [x] `bun run test -- --run BlackJack` — 340 passed
- [x] `bun run test -- --run blackjackBet` — 7 passed
- [x] `bun run build` (tsc) — passes
- [x] Unit tests: +25 adds 25 (clamped to balance), disabled-on-overflow, clear resets to minimum, loading disables buttons

Closes #2977