### PR TITLE
feat(ginrummy): show round-end score breakdown for knock/gin/undercut

### DIFF
--- a/frontend/src/i18n/locales/en/ginrummy.json
+++ b/frontend/src/i18n/locales/en/ginrummy.json
@@ -41,6 +41,20 @@
   "knockerMelds": "Knocker's Melds",
   "knockerDeadwood": "Knocker's Deadwood",
   "gin": "Gin!",
+  "breakdown": {
+    "title": "Score breakdown",
+    "outcome": {
+      "gin": "Gin",
+      "knock": "Knock",
+      "undercut": "Undercut"
+    },
+    "winner": "{{name}} scores {{total}}",
+    "deadwood": "Deadwood — knocker {{knocker}} / opponent {{opponent}}",
+    "opponentDeadwoodPart": "opponent deadwood {{value}}",
+    "differencePart": "deadwood difference {{value}}",
+    "ginBonusPart": "gin bonus {{value}}",
+    "undercutBonusPart": "undercut bonus {{value}}"
+  },
   "result": {
     "humanWin": "You win!",
     "cpuWin": "CPU {{cpuId}} wins!"

--- a/frontend/src/i18n/locales/ja/ginrummy.json
+++ b/frontend/src/i18n/locales/ja/ginrummy.json
@@ -41,6 +41,20 @@
   "knockerMelds": "ノッカーのメルド",
   "knockerDeadwood": "ノッカーのデッドウッド",
   "gin": "ジン！",
+  "breakdown": {
+    "title": "得点内訳",
+    "outcome": {
+      "gin": "ジン",
+      "knock": "ノック",
+      "undercut": "アンダーカット"
+    },
+    "winner": "{{name}} が {{total}} 点獲得",
+    "deadwood": "デッドウッド — ノッカー {{knocker}} / 相手 {{opponent}}",
+    "opponentDeadwoodPart": "相手デッドウッド {{value}}",
+    "differencePart": "デッドウッド差 {{value}}",
+    "ginBonusPart": "ジンボーナス {{value}}",
+    "undercutBonusPart": "アンダーカットボーナス {{value}}"
+  },
   "result": {
     "humanWin": "あなたの勝利！",
     "cpuWin": "CPU {{cpuId}} の勝利！"

--- a/frontend/src/pages/GinRummyPage.test.tsx
+++ b/frontend/src/pages/GinRummyPage.test.tsx
@@ -135,6 +135,63 @@ const roundEndCpuCardsState: GinRummyResponse = {
   ],
 };
 
+// Round-end fixtures for the score breakdown. The opponent's (CPU, id 1) hand
+// is scored via the same meld search the domain uses.
+const knockRoundEndState: GinRummyResponse = {
+  ...drawPhaseState,
+  phase: 3,
+  knockerIdx: 0,
+  isGin: false,
+  knockerDeadwood: [{ design: 'CLOVER', value: 9 }], // knocker deadwood 9
+  players: [
+    drawPhaseState.players[0],
+    {
+      id: 1,
+      isHuman: false,
+      cardCount: 3,
+      // No meld: 5 + 6 + 8 = 19 deadwood > 9 → plain knock, knocker scores 10.
+      cards: [
+        { design: 'DIAMOND', value: 5 },
+        { design: 'CLOVER', value: 6 },
+        { design: 'HEART', value: 8 },
+      ],
+      roundScore: 0,
+      cumulativeScore: 0,
+    },
+  ],
+};
+
+const ginRoundEndState: GinRummyResponse = {
+  ...knockRoundEndState,
+  isGin: true,
+  knockerDeadwood: [], // gin → knocker deadwood 0, scores opponent 19 + 25 bonus = 44
+};
+
+const undercutRoundEndState: GinRummyResponse = {
+  ...drawPhaseState,
+  phase: 3,
+  knockerIdx: 0,
+  isGin: false,
+  knockerDeadwood: [{ design: 'CLOVER', value: 9 }], // knocker deadwood 9
+  players: [
+    drawPhaseState.players[0],
+    {
+      id: 1,
+      isHuman: false,
+      cardCount: 4,
+      // ♦5-6-7 run (melded) + ♥2 → deadwood 2 ≤ 9 → undercut, opponent scores 7 + 25 = 32.
+      cards: [
+        { design: 'DIAMOND', value: 5 },
+        { design: 'DIAMOND', value: 6 },
+        { design: 'DIAMOND', value: 7 },
+        { design: 'HEART', value: 2 },
+      ],
+      roundScore: 0,
+      cumulativeScore: 0,
+    },
+  ],
+};
+
 beforeEach(() => {
   mockExec.mockResolvedValue(drawPhaseState);
 });
@@ -432,6 +489,57 @@ describe('GinRummyPage', () => {
     fireEvent.click(screen.getByRole('button', { name: '次のラウンド' }));
 
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('nextround'));
+  });
+
+  // -- Round-end score breakdown --
+
+  it('shows a plain-knock score breakdown at round end', async () => {
+    mockExec.mockResolvedValue(knockRoundEndState);
+    renderWithProviders(<GinRummyPage />);
+    await waitFor(() => expect(screen.getByTestId('ginrummy-score-breakdown')).toBeInTheDocument());
+    expect(screen.getByTestId('ginrummy-breakdown-outcome')).toHaveTextContent('ノック');
+    // opponent deadwood 19 − knocker 9 = 10, no bonus.
+    expect(screen.getByTestId('ginrummy-breakdown-formula')).toHaveTextContent('デッドウッド差 10 = 10');
+    expect(screen.getByText('あなた が 10 点獲得')).toBeInTheDocument();
+  });
+
+  it('shows a gin score breakdown at round end', async () => {
+    mockExec.mockResolvedValue(ginRoundEndState);
+    renderWithProviders(<GinRummyPage />);
+    await waitFor(() => expect(screen.getByTestId('ginrummy-score-breakdown')).toBeInTheDocument());
+    expect(screen.getByTestId('ginrummy-breakdown-outcome')).toHaveTextContent('ジン');
+    // opponent deadwood 19 + gin bonus 25 = 44.
+    expect(screen.getByTestId('ginrummy-breakdown-formula')).toHaveTextContent(
+      '相手デッドウッド 19 + ジンボーナス 25 = 44',
+    );
+    expect(screen.getByText('あなた が 44 点獲得')).toBeInTheDocument();
+  });
+
+  it('shows an undercut score breakdown crediting the defender at round end', async () => {
+    mockExec.mockResolvedValue(undercutRoundEndState);
+    renderWithProviders(<GinRummyPage />);
+    await waitFor(() => expect(screen.getByTestId('ginrummy-score-breakdown')).toBeInTheDocument());
+    expect(screen.getByTestId('ginrummy-breakdown-outcome')).toHaveTextContent('アンダーカット');
+    // knocker 9 − opponent 2 = 7 difference + undercut bonus 25 = 32, credited to CPU.
+    expect(screen.getByTestId('ginrummy-breakdown-formula')).toHaveTextContent(
+      'デッドウッド差 7 + アンダーカットボーナス 25 = 32',
+    );
+    expect(screen.getByText('CPU 1 が 32 点獲得')).toBeInTheDocument();
+  });
+
+  it('hides the score breakdown before round end', async () => {
+    mockExec.mockResolvedValue(discardPhaseState);
+    renderWithProviders(<GinRummyPage />);
+    await waitFor(() => expect(screen.getByText('スコア')).toBeInTheDocument());
+    expect(screen.queryByTestId('ginrummy-score-breakdown')).not.toBeInTheDocument();
+  });
+
+  it('hides the score breakdown on a drawn round (no knocker)', async () => {
+    // roundEndState keeps knockerIdx -1 (stock exhausted) → no scoring to show.
+    mockExec.mockResolvedValue(roundEndState);
+    renderWithProviders(<GinRummyPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: '次のラウンド' })).toBeInTheDocument());
+    expect(screen.queryByTestId('ginrummy-score-breakdown')).not.toBeInTheDocument();
   });
 
   it('shows game end with action log button', async () => {

--- a/frontend/src/pages/GinRummyPage.tsx
+++ b/frontend/src/pages/GinRummyPage.tsx
@@ -38,6 +38,7 @@ import {
   bestMeldSplit,
   GIN_RUMMY_KNOCK_THRESHOLD,
   ginRummyMeldLabel,
+  ginRummyScoreBreakdown,
 } from '../utils/ginRummyDeadwood';
 import { playerName } from '../utils/playerUtils';
 
@@ -194,6 +195,17 @@ function GinRummyPageContent() {
     const human = state.players.find((p) => p.isHuman);
     if (!human || human.cards.length === 0) return new Set();
     return bestMeldSplit(human.cards).meldedIndices;
+  }, [state]);
+
+  // At round/game end, derive the additive score breakdown (outcome, each
+  // player's deadwood, and the deadwood-difference + bonus components) from the
+  // exposed round result, mirroring the domain's scoreRound. `null` for a drawn
+  // round (stock exhausted) so the panel stays hidden.
+  const scoreBreakdown = useMemo(() => {
+    if (!state) return null;
+    const atRoundEnd = state.phase === GinRummyPhase.ROUND_END || state.phase === GinRummyPhase.GAME_END;
+    if (!atRoundEnd && !state.gameEndFlag) return null;
+    return ginRummyScoreBreakdown(state.players, state.knockerIdx, state.knockerDeadwood, state.isGin);
   }, [state]);
 
   if (!state)
@@ -373,6 +385,48 @@ function GinRummyPageContent() {
               messageCode={state.messageCode}
               messageParams={state.messageParams}
             />
+
+            {scoreBreakdown &&
+              (() => {
+                const winner = state.players.find((p) => p.id === scoreBreakdown.winnerId);
+                const winnerLabel = winner ? playerName(winner.id, winner.isHuman) : '';
+                const basePart =
+                  scoreBreakdown.outcome === 'gin'
+                    ? t('breakdown.opponentDeadwoodPart', { value: scoreBreakdown.base })
+                    : t('breakdown.differencePart', { value: scoreBreakdown.base });
+                const bonusPart =
+                  scoreBreakdown.bonus > 0
+                    ? scoreBreakdown.outcome === 'gin'
+                      ? t('breakdown.ginBonusPart', { value: scoreBreakdown.bonus })
+                      : t('breakdown.undercutBonusPart', { value: scoreBreakdown.bonus })
+                    : null;
+                const formula = `${basePart}${bonusPart ? ` + ${bonusPart}` : ''} = ${scoreBreakdown.total}`;
+                return (
+                  <div className="my-3 p-3 rounded bg-black/30" data-testid="ginrummy-score-breakdown">
+                    <div className="text-ds-text-muted text-sm mb-1">{t('breakdown.title')}</div>
+                    <div className="flex items-center gap-2 mb-1 flex-wrap">
+                      <span
+                        data-testid="ginrummy-breakdown-outcome"
+                        className="inline-block rounded border border-ds-secondary px-1.5 py-0.5 text-ds-text-primary text-xs"
+                      >
+                        {t(`breakdown.outcome.${scoreBreakdown.outcome}`)}
+                      </span>
+                      <span className="text-ds-accent text-sm font-bold">
+                        {t('breakdown.winner', { name: winnerLabel, total: scoreBreakdown.total })}
+                      </span>
+                    </div>
+                    <div className="text-ds-text-muted text-xs mb-1">
+                      {t('breakdown.deadwood', {
+                        knocker: scoreBreakdown.knockerDeadwood,
+                        opponent: scoreBreakdown.opponentDeadwood,
+                      })}
+                    </div>
+                    <div className="text-ds-text-primary text-sm" data-testid="ginrummy-breakdown-formula">
+                      {formula}
+                    </div>
+                  </div>
+                );
+              })()}
 
             <ActionLogSection
               isEndPhase={isGameEnd}

--- a/frontend/src/utils/ginRummyDeadwood.test.ts
+++ b/frontend/src/utils/ginRummyDeadwood.test.ts
@@ -6,6 +6,7 @@ import {
   calcDeadwoodValue,
   ginRummyCardValue,
   ginRummyMeldLabel,
+  ginRummyScoreBreakdown,
 } from './ginRummyDeadwood';
 
 const c = (design: Card['design'], value: number): Card => ({ design, value });
@@ -137,5 +138,66 @@ describe('ginRummyMeldLabel', () => {
 
   it('returns an empty string for an empty meld', () => {
     expect(ginRummyMeldLabel([])).toBe('');
+  });
+});
+
+describe('ginRummyScoreBreakdown', () => {
+  const knocker = { id: 0, cards: [] as Card[] };
+  const opp = (cards: Card[]) => ({ id: 1, cards });
+
+  it('scores a plain knock as the deadwood difference to the knocker', () => {
+    // knocker deadwood 9, opponent 5+6+8=19 (no meld) → 19-9=10, no bonus.
+    const b = ginRummyScoreBreakdown(
+      [knocker, opp([c('DIAMOND', 5), c('CLOVER', 6), c('HEART', 8)])],
+      0,
+      [c('CLOVER', 9)],
+      false,
+    );
+    expect(b).toEqual({
+      outcome: 'knock',
+      winnerId: 0,
+      knockerDeadwood: 9,
+      opponentDeadwood: 19,
+      base: 10,
+      bonus: 0,
+      total: 10,
+    });
+  });
+
+  it('scores a gin as opponent deadwood + 25 bonus to the knocker', () => {
+    const b = ginRummyScoreBreakdown([knocker, opp([c('DIAMOND', 5), c('CLOVER', 6), c('HEART', 8)])], 0, [], true);
+    expect(b).toMatchObject({ outcome: 'gin', winnerId: 0, opponentDeadwood: 19, base: 19, bonus: 25, total: 44 });
+  });
+
+  it('scores an undercut as the difference + 25 bonus to the defender', () => {
+    // knocker deadwood 9, opponent ♦5-6-7 run + ♥2 = 2 ≤ 9 → 7 diff + 25 = 32 to opponent.
+    const b = ginRummyScoreBreakdown(
+      [knocker, opp([c('DIAMOND', 5), c('DIAMOND', 6), c('DIAMOND', 7), c('HEART', 2)])],
+      0,
+      [c('CLOVER', 9)],
+      false,
+    );
+    expect(b).toEqual({
+      outcome: 'undercut',
+      winnerId: 1,
+      knockerDeadwood: 9,
+      opponentDeadwood: 2,
+      base: 7,
+      bonus: 25,
+      total: 32,
+    });
+  });
+
+  it('treats equal deadwood as an undercut for the defender', () => {
+    const b = ginRummyScoreBreakdown([knocker, opp([c('CLOVER', 9)])], 0, [c('SPADE', 9)], false);
+    expect(b).toMatchObject({ outcome: 'undercut', winnerId: 1, base: 0, bonus: 25, total: 25 });
+  });
+
+  it('returns null for a drawn round (no knocker)', () => {
+    expect(ginRummyScoreBreakdown([knocker, opp([c('CLOVER', 9)])], -1, [], false)).toBeNull();
+  });
+
+  it('returns null when the players cannot be resolved', () => {
+    expect(ginRummyScoreBreakdown([knocker], 0, [], false)).toBeNull();
   });
 });

--- a/frontend/src/utils/ginRummyDeadwood.ts
+++ b/frontend/src/utils/ginRummyDeadwood.ts
@@ -20,6 +20,105 @@ export function ginRummyMeldLabel(cards: readonly Card[]): string {
   return `${suitSymbol(first.design)} ${valueName(sorted[0])}-${valueName(sorted[sorted.length - 1])}`;
 }
 
+/** Gin bonus points. Mirrors `GinRummyGinBonus` in internal/domain/GinRummy.go. */
+export const GIN_RUMMY_GIN_BONUS = 25;
+/** Undercut bonus points. Mirrors `GinRummyUndercutBonus` in internal/domain/GinRummy.go. */
+export const GIN_RUMMY_UNDERCUT_BONUS = 25;
+
+/** Which side scored the round: a gin, a plain knock, or an undercut. */
+export type GinRummyOutcome = 'gin' | 'knock' | 'undercut';
+
+/**
+ * Additive score breakdown for a completed Gin Rummy round. Mirrors the scoring
+ * in `scoreRound` of internal/domain/GinRummy.go:
+ * - gin: the knocker scores the opponent's deadwood + a 25-pt bonus;
+ * - undercut (opponent deadwood ≤ knocker deadwood): the defender scores the
+ *   deadwood difference + a 25-pt bonus;
+ * - plain knock: the knocker scores the deadwood difference (no bonus).
+ *
+ * `base + bonus === total` always holds.
+ */
+export interface GinRummyScoreBreakdown {
+  /** The scoring outcome. */
+  outcome: GinRummyOutcome;
+  /** Player id awarded the round's points. */
+  winnerId: number;
+  /** The knocker's deadwood value. */
+  knockerDeadwood: number;
+  /** The opponent's (defender's) deadwood value. */
+  opponentDeadwood: number;
+  /** Deadwood-based component: the opponent's deadwood for a gin, otherwise the
+   * absolute deadwood difference between the two hands. */
+  base: number;
+  /** Bonus component (25 for gin/undercut, 0 for a plain knock). */
+  bonus: number;
+  /** Total points awarded this round (`base + bonus`). */
+  total: number;
+}
+
+/** Minimal player shape needed to derive the round-end score breakdown. */
+interface GinRummyBreakdownPlayer {
+  id: number;
+  cards: readonly Card[];
+}
+
+/**
+ * Derive the additive round-end score breakdown from the exposed round result,
+ * faithfully mirroring `scoreRound` in internal/domain/GinRummy.go. The knocker's
+ * deadwood comes from the exposed `knockerDeadwood` cards; the opponent's is
+ * recomputed from their (post-layoff) hand via {@link bestDeadwoodValue}, so the
+ * derived total matches the backend's `roundScore`. Returns `null` for a drawn
+ * round (`knockerIdx < 0`, stock exhausted) or when the players can't be resolved.
+ */
+export function ginRummyScoreBreakdown(
+  players: readonly GinRummyBreakdownPlayer[],
+  knockerIdx: number,
+  knockerDeadwoodCards: readonly Card[],
+  isGin: boolean,
+): GinRummyScoreBreakdown | null {
+  if (knockerIdx < 0) return null; // drawn round (stock empty) — no scoring
+  const knocker = players.find((p) => p.id === knockerIdx);
+  const opponent = players.find((p) => p.id !== knockerIdx);
+  if (!knocker || !opponent) return null;
+
+  const knockerDeadwood = calcDeadwoodValue(knockerDeadwoodCards);
+  const opponentDeadwood = bestDeadwoodValue(opponent.cards);
+
+  if (isGin) {
+    return {
+      outcome: 'gin',
+      winnerId: knockerIdx,
+      knockerDeadwood,
+      opponentDeadwood,
+      base: opponentDeadwood,
+      bonus: GIN_RUMMY_GIN_BONUS,
+      total: opponentDeadwood + GIN_RUMMY_GIN_BONUS,
+    };
+  }
+  if (opponentDeadwood <= knockerDeadwood) {
+    const diff = knockerDeadwood - opponentDeadwood;
+    return {
+      outcome: 'undercut',
+      winnerId: opponent.id,
+      knockerDeadwood,
+      opponentDeadwood,
+      base: diff,
+      bonus: GIN_RUMMY_UNDERCUT_BONUS,
+      total: diff + GIN_RUMMY_UNDERCUT_BONUS,
+    };
+  }
+  const diff = opponentDeadwood - knockerDeadwood;
+  return {
+    outcome: 'knock',
+    winnerId: knockerIdx,
+    knockerDeadwood,
+    opponentDeadwood,
+    base: diff,
+    bonus: 0,
+    total: diff,
+  };
+}
+
 /** Gin Rummy card value (A=1, 2-9=face, 10/J/Q/K=10). */
 export function ginRummyCardValue(card: Card): number {
   if (card.value === 1) return 1;


### PR DESCRIPTION
## 概要 / Summary

Gin Rummy のラウンド終了時に、得点の内訳（ノック / ジン / アンダーカット）を表示する内訳パネルを追加しました。従来はスコアテーブルの数値だけが更新され、「なぜその点数になったか」が分かりませんでした。

**フロントエンドのみ**の変更です。Go には一切触れていません。ラウンド結果はすでに API レスポンスで公開済み（`knockerIdx` / `isGin` / `knockerDeadwood` / 両者の手札）なので、ドメインの `scoreRound`（`internal/domain/GinRummy.go`）と同じ計算を純粋関数として忠実に再現し、内訳を導出しています。

## 得点内訳（ドメイン定数に一致）

- **ジン**: ノッカーが「相手デッドウッド + ジンボーナス 25」を獲得
- **アンダーカット**（相手デッドウッド ≤ ノッカーデッドウッド）: 防御側が「デッドウッド差 + アンダーカットボーナス 25」を獲得
- **通常ノック**: ノッカーが「デッドウッド差」を獲得（ボーナスなし）

`base + bonus === total` が常に成立します。

## 変更点

- `frontend/src/utils/ginRummyDeadwood.ts` — 純粋ヘルパー `ginRummyScoreBreakdown` と定数 `GIN_RUMMY_GIN_BONUS` / `GIN_RUMMY_UNDERCUT_BONUS` を追加
- `frontend/src/pages/GinRummyPage.tsx` — ラウンド/ゲーム終了時に内訳パネルを表示（種別バッジ・勝者名・両者デッドウッド・加算式）。ローカライズしたプレイヤー名を使用
- `frontend/src/i18n/locales/{ja,en}/ginrummy.json` — `breakdown.*` を ja/en パリティで追加
- テスト追加（ヘルパー + ページ）

## テスト計画 / Test plan

- [x] `bun run check`（biome）— exit 0
- [x] `bun run build`（tsc）— exit 0
- [x] `bun run test -- --run GinRummy` — 149 passed
- [x] ジン / ノック / アンダーカットの各内訳が正しく表示される
- [x] ラウンド終了前は非表示、引き分けラウンド（ノッカーなし）でも非表示

Closes #3053