### PR TITLE
feat(bristol): add drag-and-drop card moves

### DIFF
--- a/frontend/src/pages/BristolPage.test.tsx
+++ b/frontend/src/pages/BristolPage.test.tsx
@@ -280,4 +280,73 @@ describe('BristolPage', () => {
     expect(screen.getByRole('button', { name: '元に戻す' })).toHaveAttribute('aria-keyshortcuts', 'z');
     expect(screen.getByRole('button', { name: 'ギブアップ' })).toHaveAttribute('aria-keyshortcuts', 'g');
   });
+
+  describe('drag and drop', () => {
+    function buildDataTransfer() {
+      const store: Record<string, string> = {};
+      return {
+        setData: (type: string, val: string) => {
+          store[type] = val;
+        },
+        getData: (type: string) => store[type] ?? '',
+        effectAllowed: '',
+        dropEffect: '',
+      };
+    }
+
+    it('tableau column top card is draggable while playing', async () => {
+      renderWithProviders(<BristolPage />);
+      await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+      expect(screen.getByRole('button', { name: /降順ビルド列 1/ })).toHaveAttribute('draggable', 'true');
+    });
+
+    it('dragging a tableau column onto a foundation dispatches move', async () => {
+      renderWithProviders(<BristolPage />);
+      await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+
+      const source = screen.getByRole('button', { name: /降順ビルド列 1/ });
+      const dataTransfer = buildDataTransfer();
+      fireEvent.dragStart(source, { dataTransfer });
+
+      const dropZone = screen.getByRole('button', { name: /^組札 0/ }).closest('div') as HTMLElement;
+      mockExec.mockClear();
+      fireEvent.dragOver(dropZone, { dataTransfer });
+      fireEvent.drop(dropZone, { dataTransfer });
+
+      await waitFor(() =>
+        expect(mockExec).toHaveBeenCalledWith('move', { zone: 'tableau', col: 0 }, { zone: 'foundation', col: 0 }),
+      );
+    });
+
+    it('dragging a fan top onto a tableau column dispatches move', async () => {
+      renderWithProviders(<BristolPage />);
+      await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+
+      const source = screen.getByRole('button', { name: /^ファン 0/ });
+      const dataTransfer = buildDataTransfer();
+      fireEvent.dragStart(source, { dataTransfer });
+
+      const dropZone = screen.getByRole('button', { name: /降順ビルド列 2/ }).closest('div') as HTMLElement;
+      mockExec.mockClear();
+      fireEvent.dragOver(dropZone, { dataTransfer });
+      fireEvent.drop(dropZone, { dataTransfer });
+
+      await waitFor(() =>
+        expect(mockExec).toHaveBeenCalledWith('move', { zone: 'fan', col: 0 }, { zone: 'tableau', col: 1 }),
+      );
+    });
+
+    it('a drop with no active drag issues no move', async () => {
+      renderWithProviders(<BristolPage />);
+      await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+
+      const dropZone = screen.getByRole('button', { name: /^組札 0/ }).closest('div') as HTMLElement;
+      mockExec.mockClear();
+      const dataTransfer = buildDataTransfer();
+      fireEvent.drop(dropZone, { dataTransfer });
+
+      // No source was dragged, so getData returns '' and no move is dispatched.
+      expect(mockExec).not.toHaveBeenCalledWith('move', expect.anything(), expect.anything());
+    });
+  });
 });

--- a/frontend/src/pages/BristolPage.tsx
+++ b/frontend/src/pages/BristolPage.tsx
@@ -4,6 +4,7 @@ import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
 import { CliToggle } from '../components/cli/CliToggle';
 import { SettingsPanel } from '../components/common/SettingsPanel';
+import { DropZone } from '../components/DropZone';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
@@ -23,6 +24,7 @@ import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useMountReset } from '../hooks/useMountReset';
+import { useSolitaireDragDrop } from '../hooks/useSolitaireDragDrop';
 import { btnDanger, btnOutline, btnPrimary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { BristolMoveZone, BristolResponse } from '../types/card';
@@ -155,6 +157,23 @@ function BristolPageContent() {
     [execApi, selected],
   );
 
+  // Drag-and-drop: a dropped card fires the same `move` command as a click, so
+  // click/tap selection and DnD share one code path. Clearing the click
+  // selection keeps the two interaction modes from stepping on each other.
+  const dispatchMove = useCallback(
+    (source: BristolMoveZone, target: BristolMoveZone) => {
+      execApi('move', source, target);
+      setSelected(null);
+    },
+    [execApi],
+  );
+  const isPlayingForDnd = state?.phase === BristolPhase.PLAYING;
+  const dnd = useSolitaireDragDrop<BristolMoveZone>({
+    onMove: dispatchMove,
+    isPlaying: isPlayingForDnd,
+    disabled: loading,
+  });
+
   const theme = useMemo(() => gameTheme.bristol, []);
 
   const phase = state?.phase ?? BristolPhase.PLAYING;
@@ -251,33 +270,43 @@ function BristolPageContent() {
             <div className="mb-3 flex items-start gap-2" data-tutorial="br-foundation">
               <span className="w-14 shrink-0 pt-2 text-xs text-ds-text-muted">{t('foundation')}</span>
               <div className="flex gap-2">
-                {state.foundation.map((pile, i) => (
-                  <button
-                    key={`f-${i}`}
-                    type="button"
-                    onClick={() => handleFoundationClick(i)}
-                    disabled={!isPlaying || !selected || loading}
-                    aria-label={
-                      pile.length > 0
-                        ? t('foundationAria', { num: i, card: cardAlt(pile[pile.length - 1]), count: pile.length })
-                        : t('foundationAriaEmpty', { num: i })
-                    }
-                    className={
-                      selected
-                        ? `rounded border p-0.5 ${focusRingWhite} border-ds-info`
-                        : `rounded border p-0.5 ${focusRingWhite} border-white/30`
-                    }
-                    style={{ width: cardWidth + 4, height: cardHeight + 4 }}
-                  >
-                    {pile.length > 0 ? (
-                      <AnimatedCard card={pile[pile.length - 1]} width={cardWidth} />
-                    ) : (
-                      <span className="flex h-full w-full items-center justify-center text-xs text-ds-text-muted/80">
-                        A
-                      </span>
-                    )}
-                  </button>
-                ))}
+                {state.foundation.map((pile, i) => {
+                  const zone: BristolMoveZone = { zone: 'foundation', col: i };
+                  return (
+                    <DropZone
+                      key={`f-${i}`}
+                      onDrop={dnd.handleDrop(zone)}
+                      onDragOver={dnd.handleDragOver(zone)}
+                      onDragLeave={dnd.handleDragLeave}
+                      isDropTarget={dnd.isDropTarget(zone)}
+                    >
+                      <button
+                        type="button"
+                        onClick={() => handleFoundationClick(i)}
+                        disabled={!isPlaying || !selected || loading}
+                        aria-label={
+                          pile.length > 0
+                            ? t('foundationAria', { num: i, card: cardAlt(pile[pile.length - 1]), count: pile.length })
+                            : t('foundationAriaEmpty', { num: i })
+                        }
+                        className={
+                          selected
+                            ? `rounded border p-0.5 ${focusRingWhite} border-ds-info`
+                            : `rounded border p-0.5 ${focusRingWhite} border-white/30`
+                        }
+                        style={{ width: cardWidth + 4, height: cardHeight + 4 }}
+                      >
+                        {pile.length > 0 ? (
+                          <AnimatedCard card={pile[pile.length - 1]} width={cardWidth} />
+                        ) : (
+                          <span className="flex h-full w-full items-center justify-center text-xs text-ds-text-muted/80">
+                            A
+                          </span>
+                        )}
+                      </button>
+                    </DropZone>
+                  );
+                })}
               </div>
             </div>
 
@@ -292,38 +321,49 @@ function BristolPageContent() {
                 return (
                   <div key={`col-${colIdx}`} className="flex flex-1 flex-col items-center gap-1 min-w-0">
                     <span className="text-xs text-ds-text-muted">#{colIdx + 1}</span>
-                    <button
-                      type="button"
-                      onClick={() => handleTableauClick(colIdx)}
-                      disabled={!isPlaying || loading || (col.length === 0 && !selected)}
-                      aria-label={t('tableauColAria', { num: colIdx + 1, count: col.length })}
-                      aria-pressed={isSelected(zone)}
-                      className={
-                        isSelected(zone)
-                          ? `relative w-full rounded border-2 bg-transparent p-0 ${focusRingWhite} border-ds-info`
-                          : `relative w-full rounded border-2 bg-transparent p-0 ${focusRingWhite} border-transparent`
-                      }
-                      style={{ height: colHeight }}
+                    <DropZone
+                      onDrop={dnd.handleDrop(zone)}
+                      onDragOver={dnd.handleDragOver(zone)}
+                      onDragLeave={dnd.handleDragLeave}
+                      isDropTarget={dnd.isDropTarget(zone)}
+                      className="w-full"
                     >
-                      {col.length === 0 ? (
-                        <span
-                          className="flex w-full items-center justify-center rounded border-2 border-dashed border-white/20 text-xs text-ds-text-muted"
-                          style={{ height: cardHeight }}
-                        >
-                          {t('empty')}
-                        </span>
-                      ) : (
-                        col.map((card, cardIdx) => (
-                          <div
-                            key={`c-${colIdx}-${cardIdx}`}
-                            className="absolute left-0 right-0"
-                            style={{ top: cardIdx * colOffset }}
+                      <button
+                        type="button"
+                        draggable={isPlaying && !loading && col.length > 0}
+                        onDragStart={dnd.handleDragStart(zone)}
+                        onDragEnd={dnd.handleDragEnd}
+                        onClick={() => handleTableauClick(colIdx)}
+                        disabled={!isPlaying || loading || (col.length === 0 && !selected)}
+                        aria-label={t('tableauColAria', { num: colIdx + 1, count: col.length })}
+                        aria-pressed={isSelected(zone)}
+                        className={
+                          isSelected(zone)
+                            ? `relative w-full rounded border-2 bg-transparent p-0 ${focusRingWhite} border-ds-info`
+                            : `relative w-full rounded border-2 bg-transparent p-0 ${focusRingWhite} border-transparent`
+                        }
+                        style={{ height: colHeight }}
+                      >
+                        {col.length === 0 ? (
+                          <span
+                            className="flex w-full items-center justify-center rounded border-2 border-dashed border-white/20 text-xs text-ds-text-muted"
+                            style={{ height: cardHeight }}
                           >
-                            <AnimatedCard card={card} width={cardWidth} draggable={false} style={{ width: '100%' }} />
-                          </div>
-                        ))
-                      )}
-                    </button>
+                            {t('empty')}
+                          </span>
+                        ) : (
+                          col.map((card, cardIdx) => (
+                            <div
+                              key={`c-${colIdx}-${cardIdx}`}
+                              className="absolute left-0 right-0"
+                              style={{ top: cardIdx * colOffset }}
+                            >
+                              <AnimatedCard card={card} width={cardWidth} draggable={false} style={{ width: '100%' }} />
+                            </div>
+                          ))
+                        )}
+                      </button>
+                    </DropZone>
                   </div>
                 );
               })}
@@ -343,6 +383,9 @@ function BristolPageContent() {
                       {top ? (
                         <button
                           type="button"
+                          draggable={isPlaying && !loading}
+                          onDragStart={dnd.handleDragStart(zone)}
+                          onDragEnd={dnd.handleDragEnd}
                           onClick={() => handleFanClick(i)}
                           disabled={!isPlaying || loading}
                           aria-label={t('fanAria', { num: i, card: cardAlt(top), count: pile.length })}


### PR DESCRIPTION
## 概要

ブリストル（Bristol solitaire）にドラッグ&ドロップによるカード移動を追加しました。既存のクリック/タップ選択方式はそのまま併存します。共有 DnD サブシステム（`useSolitaireDragDrop` フック + `DropZone` コンポーネント、`EasthavenPage` で実証済み）をミラーしています。

## 実装

- `useSolitaireDragDrop<BristolMoveZone>` を導入し、ドロップ時に **クリック時と同じ `move` API** を呼び出す（`dispatchMove`）。両モードが単一パスを共有。
- **ドラッグ元**: タブロー列トップ + ファン 3 山のトップを `draggable` 化。
- **ドロップ先**: タブロー各列 + ファウンデーション 4 山を `DropZone` 化。
- ドラッグ中は `DropZone` の `isDropTarget` ハイライト（`ring-2 ring-ds-info`）を表示。
- 既存のクリック選択（`aria-pressed`）・#4239 のキーボードショートカットは無改変。
- デザインシステムトークンのみ使用。Go には一切触れていません（フロントエンドのみ）。

## テスト

`BristolPage.test.tsx` に `drag and drop` describe ブロックを追加:
- `tableau column top card is draggable while playing`
- `dragging a tableau column onto a foundation dispatches move`
- `dragging a fan top onto a tableau column dispatches move`
- `a drop with no active drag issues no move`

## ゲート（すべて green）

- [x] `bun run check`（Biome）— Bristol 関連の指摘なし
- [x] `bun run test -- --run Bristol` — 64 tests passed
- [x] `bun run build`（tsc）— exit 0

## 受け入れ条件

- [x] タブロー/ファン → タブロー/ファウンデーションのドラッグ移動で `move` API が呼ばれる
- [x] ドラッグ中のドロップ先ハイライトが表示される
- [x] クリック選択（`aria-pressed` 含む）の既存動作が回帰しない
- [x] `BristolPage.test.tsx` に DnD テスト追加

Closes #3379

🤖 Generated with [Claude Code](https://claude.com/claude-code)