### PR TITLE
feat(irishpoker): forewarn upcoming 2-card discard during flop bet

### DIFF
--- a/frontend/src/i18n/locales/en/irishpoker.json
+++ b/frontend/src/i18n/locales/en/irishpoker.json
@@ -12,6 +12,7 @@
   },
   "communityCards": "Community Cards",
   "yourHand": "Your Hand",
+  "discardUpcoming": "You will discard two cards after the flop betting round",
   "handNumber": "Hand #{{count}} (Level up: every {{level}} hands)",
   "discard": {
     "prompt": "Discard a card.",

--- a/frontend/src/i18n/locales/ja/irishpoker.json
+++ b/frontend/src/i18n/locales/ja/irishpoker.json
@@ -12,6 +12,7 @@
   },
   "communityCards": "コミュニティカード",
   "yourHand": "あなたの手札",
+  "discardUpcoming": "フロップベット終了後にカードを2枚捨てます",
   "handNumber": "ハンド#{{count}} (レベルアップ:{{level}}ハンド毎)",
   "discard": {
     "prompt": "カードを捨ててください。",

--- a/frontend/src/pages/PineapplePage.test.tsx
+++ b/frontend/src/pages/PineapplePage.test.tsx
@@ -594,6 +594,32 @@ describe('PineapplePage', () => {
     expect(screen.queryByTestId('irishpoker-discard-preview')).not.toBeInTheDocument();
   });
 
+  it('shows the Irish Poker discard-upcoming banner during the flop bet phase', async () => {
+    // phase 2 = FLOP betting round; Irish Poker discards two cards afterwards.
+    mockIrishExec.mockResolvedValue({ ...preFlopState, phase: 2, initialDealCount: 4 });
+    renderWithProviders(<PineapplePage variant="irishpoker" />);
+    await waitFor(() => expect(screen.getByTestId('cp-discard-upcoming-banner')).toBeInTheDocument());
+    expect(screen.getByTestId('cp-discard-upcoming-banner')).toHaveTextContent(
+      'フロップベット終了後にカードを2枚捨てます',
+    );
+  });
+
+  it('does not show the Irish Poker discard-upcoming banner outside the flop bet phase', async () => {
+    // preFlopState is phase 1 (PRE_FLOP), before the flop betting round.
+    mockIrishExec.mockResolvedValue({ ...preFlopState, initialDealCount: 4 });
+    renderWithProviders(<PineapplePage variant="irishpoker" />);
+    await waitFor(() => expect(screen.getByText('あなたの手札')).toBeInTheDocument());
+    expect(screen.queryByTestId('cp-discard-upcoming-banner')).not.toBeInTheDocument();
+  });
+
+  it('does not show the discard-upcoming banner for the plain Pineapple variant during the flop', async () => {
+    // Plain Pineapple discards before the flop, so no forewarning banner applies.
+    mockExec.mockResolvedValue({ ...preFlopState, phase: 2 });
+    renderWithProviders(<PineapplePage />);
+    await waitFor(() => expect(screen.getByText('あなたの手札')).toBeInTheDocument());
+    expect(screen.queryByTestId('cp-discard-upcoming-banner')).not.toBeInTheDocument();
+  });
+
   it('annotates each Crazy Pineapple hole card with the keep-hand if discarded', async () => {
     const crazyDiscardState: PineappleResponse = {
       ...discardState,

--- a/frontend/src/pages/PineapplePage.tsx
+++ b/frontend/src/pages/PineapplePage.tsx
@@ -522,9 +522,10 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
 
           {/* Sticky footer: player hand + buttons */}
           <GameFooter className={`${gameTheme[variant].footer} px-5 py-3`}>
-            {/* Crazy Pineapple discards after the flop betting round (unlike plain
-                Pineapple's immediate discard) — forewarn the player during the flop bet. */}
-            {variant === 'crazypineapple' && phase === PineapplePhase.FLOP && (
+            {/* Crazy Pineapple and Irish Poker discard after the flop betting round
+                (unlike plain Pineapple's immediate discard) — forewarn the player during
+                the flop bet so they can factor the upcoming discard into their decision. */}
+            {(variant === 'crazypineapple' || variant === 'irishpoker') && phase === PineapplePhase.FLOP && (
               <div
                 data-testid="cp-discard-upcoming-banner"
                 className="mb-2 rounded border border-ds-info bg-ds-surface px-3 py-1.5 text-center text-ds-info text-sm"


### PR DESCRIPTION
## Summary

During the Irish Poker flop betting round, players start with 4 hole cards and must discard 2 after the round. Previously only Crazy Pineapple showed the "you will discard next" advance banner (`cp-discard-upcoming-banner`), leaving first-time Irish Poker players unaware of the upcoming discard when making their flop bet.

This extends the existing banner to also fire for the `irishpoker` variant during the flop bet phase (`PineapplePhase.FLOP`), and adds an `irishpoker`-specific `discardUpcoming` string (2 cards, vs. Crazy Pineapple's 1). Purely additive and informational (`role`-less info banner, design-token styled) — derived from the confirmed domain rule (`internal/domain/Pineapple.go` / `IrishPoker_test.go`: Irish Poker deals 4 hole cards and discards 2 after flop betting). No Go changes.

## Changes
- `frontend/src/pages/PineapplePage.tsx` — extend banner condition to `crazypineapple || irishpoker`
- `frontend/src/i18n/locales/{ja,en}/irishpoker.json` — add `discardUpcoming` key (ja + en parity)
- `frontend/src/pages/PineapplePage.test.tsx` — 3 tests: banner shown during flop, hidden pre-flop for irishpoker, hidden for plain pineapple

## Acceptance criteria
- [x] Banner shows during the irishpoker flop bet phase
- [x] Not shown in other phases (pineapple pre-flop discard unaffected)
- [x] ja/en translation keys added
- [x] Display-condition unit tests added

## Gates
- [x] `bun run check`
- [x] `bun run test -- --run IrishPoker` + new banner tests
- [x] `bun run build`

Closes #3023