### PR TITLE
feat(bigo): keep 5 hole cards on one scrollable row on mobile

### DIFF
--- a/frontend/src/pages/BigOPage.test.tsx
+++ b/frontend/src/pages/BigOPage.test.tsx
@@ -601,6 +601,32 @@ describe('BigOPage', () => {
     expect(screen.getByAltText('♣ 5')).toBeInTheDocument();
   });
 
+  // ---- mobile hole-card layout (#3007) ----
+  it('keeps the 5 hole cards on a single scrollable row on mobile (no wrap)', async () => {
+    const original = window.innerWidth;
+    Object.defineProperty(window, 'innerWidth', { configurable: true, writable: true, value: 375 });
+    try {
+      mockExec.mockResolvedValue(preFlopState);
+      renderWithProviders(<BigOPage />);
+      await waitFor(() => expect(screen.getByAltText('♠ A')).toBeInTheDocument());
+      const hole = screen.getByTestId('bigo-hole-cards');
+      expect(hole.className).toContain('flex-nowrap');
+      expect(hole.className).toContain('overflow-x-auto');
+      expect(hole.className).not.toContain('flex-wrap');
+    } finally {
+      Object.defineProperty(window, 'innerWidth', { configurable: true, writable: true, value: original });
+    }
+  });
+
+  it('wraps the hole cards on desktop (no horizontal scroll)', async () => {
+    mockExec.mockResolvedValue(preFlopState);
+    renderWithProviders(<BigOPage />);
+    await waitFor(() => expect(screen.getByAltText('♠ A')).toBeInTheDocument());
+    const hole = screen.getByTestId('bigo-hole-cards');
+    expect(hole.className).toContain('flex-wrap');
+    expect(hole.className).not.toContain('overflow-x-auto');
+  });
+
   it('shows CardBack for human when cards is empty and not folded', async () => {
     mockExec.mockResolvedValue({
       ...preFlopState,

--- a/frontend/src/pages/BigOPage.tsx
+++ b/frontend/src/pages/BigOPage.tsx
@@ -393,14 +393,21 @@ function BigOPageContent() {
                   <span aria-hidden="true">🎯</span>
                   {t('mandatoryRule')}
                 </div>
-                <div className="flex flex-wrap gap-1.5 mb-2" data-tutorial="bo-combination-rule">
+                {/* Big O deals 5 hole cards; on mobile keep them on a single
+                    scrollable row (never wrap) so all 5 stay visible with
+                    full-size tap targets. Desktop keeps the wrapping layout. */}
+                <div
+                  className={`gap-1.5 mb-2 ${isMobile ? 'flex flex-nowrap overflow-x-auto pb-1' : 'flex flex-wrap'}`}
+                  data-testid="bigo-hole-cards"
+                  data-tutorial="bo-combination-rule"
+                >
                   {humanPlayer.cards?.length
                     ? humanPlayer.cards.map((card, idx) => {
                         const inBest = showdownBest5.holeSet.has(idx);
                         const showUsage = showdownBest5.holeSet.size > 0;
                         const dim = showUsage && !inBest;
                         return (
-                          <div key={`${card.design}-${card.value}`} className="flex flex-col items-center">
+                          <div key={`${card.design}-${card.value}`} className="flex shrink-0 flex-col items-center">
                             <div
                               className={`transition-all ${
                                 inBest ? '-translate-y-1 ring-2 ring-ds-success motion-safe:animate-pulse' : ''
@@ -421,7 +428,11 @@ function BigOPageContent() {
                         );
                       })
                     : !humanPlayer.folded &&
-                      Array.from({ length: 5 }).map((_, i) => <AnimatedCardBack key={i} width={cardWidth} />)}
+                      Array.from({ length: 5 }).map((_, i) => (
+                        <div key={i} className="shrink-0">
+                          <AnimatedCardBack width={cardWidth} />
+                        </div>
+                      ))}
                 </div>
               </div>
             )}


### PR DESCRIPTION
## 概要
Big O（5カードオマハ）はホールカードが5枚あり、モバイルの狭幅端末では `flex flex-wrap` により手札が2段に折り返し、ボード5枚+手札5枚でアクションボタンがファーストビューから押し出されていた。

モバイルでは手札コンテナを `flex flex-nowrap overflow-x-auto` に切り替え、各カードに `shrink-0` を付与することで、5枚を1行（必要時のみ横スクロール）に収めつつフルサイズのタップ領域を維持する。デスクトップは従来の折り返しレイアウトのまま。

先行事例の `doubleklondike` (#4164, `overflow-x-auto`) と同じ確立済みのレスポンシブ手法を踏襲。純粋に表示上の変更で、ゲームロジック・API・DOM の既存 testid は不変。

## 変更点
- `frontend/src/pages/BigOPage.tsx`: モバイル時のみホールカード行を `flex-nowrap overflow-x-auto pb-1` に、カード列に `shrink-0` を追加。プレースホルダの裏面カードも `shrink-0` ラッパーで包む。新規 `data-testid="bigo-hole-cards"` を付与（既存 testid は保持）。
- `frontend/src/pages/BigOPage.test.tsx`: モバイル1行スクロール / デスクトップ折り返しを検証するテストを2件追加。

## テスト計画
- [x] `bun run test -- --run BigOPage`（118件パス、うち新規2件）
- [x] `bun run check`（exit 0、警告は既存の別ファイルのみ）
- [x] `bun run build`（tsc / vite ビルド成功）
- [x] モバイル幅で手札5枚が1行に収まる
- [x] ショーダウンの used/unused ラベルが崩れない（`flex-col` 列構造を保持）
- [x] デスクトップ表示は現状維持（`flex-wrap`）

Closes #3007