### PR TITLE
feat(blackjack): keyboard shortcuts for insurance & early-surrender phases

### DIFF
--- a/frontend/src/components/blackjack/BjEarlySurrenderPhaseControls.tsx
+++ b/frontend/src/components/blackjack/BjEarlySurrenderPhaseControls.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { btnDanger, btnPrimary } from '../../styles/buttonStyles';
+import { KbdBadge } from '../KbdBadge';
 import { BJ_SUGGEST_STAND, BJ_SUGGEST_SURRENDER, highlightClass } from './bjConstants';
 
 /** Props for BlackJack early surrender phase controls. */
@@ -23,16 +24,20 @@ export function BjEarlySurrenderPhaseControls(props: BjEarlySurrenderPhaseContro
         className={highlightClass(btnDanger, surHighlight)}
         disabled={props.loading}
         onClick={props.onSurrender}
+        aria-keyshortcuts="u"
       >
         {t('button.earlySurrender')}
+        <KbdBadge label={t('kbd.earlySurrender')} />
       </button>
       <button
         type="button"
         className={highlightClass(btnPrimary, contHighlight)}
         disabled={props.loading}
         onClick={props.onContinue}
+        aria-keyshortcuts="n"
       >
         {t('button.continue')}
+        <KbdBadge label={t('kbd.continue')} />
       </button>
     </div>
   );

--- a/frontend/src/components/blackjack/BjInsurancePhaseControls.tsx
+++ b/frontend/src/components/blackjack/BjInsurancePhaseControls.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { btnDanger, btnWarning } from '../../styles/buttonStyles';
+import { KbdBadge } from '../KbdBadge';
 import { BJ_SUGGEST_DECLINE_INSURANCE, highlightClass } from './bjConstants';
 
 /** Props for BlackJack insurance phase controls. */
@@ -16,8 +17,15 @@ export function BjInsurancePhaseControls(props: BjInsurancePhaseControlsProps) {
   const { t } = useTranslation('blackjack');
   return (
     <>
-      <button type="button" className={btnWarning} disabled={props.loading} onClick={props.onInsurance}>
+      <button
+        type="button"
+        className={btnWarning}
+        disabled={props.loading}
+        onClick={props.onInsurance}
+        aria-keyshortcuts="i"
+      >
         {t('button.insurance')}
+        <KbdBadge label={t('kbd.insurance')} />
       </button>
       <button
         type="button"
@@ -27,8 +35,10 @@ export function BjInsurancePhaseControls(props: BjInsurancePhaseControlsProps) {
         )}
         disabled={props.loading}
         onClick={props.onDecline}
+        aria-keyshortcuts="n"
       >
         {t('button.decline')}
+        <KbdBadge label={t('kbd.decline')} />
       </button>
     </>
   );

--- a/frontend/src/i18n/locales/en/blackjack.json
+++ b/frontend/src/i18n/locales/en/blackjack.json
@@ -124,5 +124,11 @@
     "push": "Push (Tie: bet returned)",
     "surrender": "Surrender (half bet returned)",
     "bust": "Bust (over 21: lose)"
+  },
+  "kbd": {
+    "insurance": "I",
+    "decline": "N",
+    "earlySurrender": "U",
+    "continue": "N"
   }
 }

--- a/frontend/src/i18n/locales/ja/blackjack.json
+++ b/frontend/src/i18n/locales/ja/blackjack.json
@@ -123,5 +123,11 @@
     "push": "プッシュ (引き分け: 返金)",
     "surrender": "サレンダー (ベットの半額返金)",
     "bust": "バスト (21超過: 負け)"
+  },
+  "kbd": {
+    "insurance": "I",
+    "decline": "N",
+    "earlySurrender": "U",
+    "continue": "N"
   }
 }

--- a/frontend/src/pages/BlackJackPage.test.tsx
+++ b/frontend/src/pages/BlackJackPage.test.tsx
@@ -1562,6 +1562,66 @@ describe('BlackJackPage', () => {
     expect(mockExec).not.toHaveBeenCalled();
   });
 
+  it('pressing i triggers insurance in INSURANCE phase', async () => {
+    mockExec.mockResolvedValue(insurancePhaseState);
+    renderWithProviders(<BlackJackPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'インシュランス' })).toBeInTheDocument());
+    mockExec.mockClear();
+    mockExec.mockResolvedValue(insurancePhaseState);
+    fireEvent.keyDown(document, { key: 'i' });
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('insurance'));
+  });
+
+  it('pressing n triggers declineinsurance in INSURANCE phase', async () => {
+    mockExec.mockResolvedValue(insurancePhaseState);
+    renderWithProviders(<BlackJackPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: '辞退' })).toBeInTheDocument());
+    mockExec.mockClear();
+    mockExec.mockResolvedValue(insurancePhaseState);
+    fireEvent.keyDown(document, { key: 'n' });
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('declineinsurance'));
+  });
+
+  it('insurance keyboard shortcuts are disabled outside INSURANCE phase', async () => {
+    mockExec.mockResolvedValue(actionPhaseState);
+    renderWithProviders(<BlackJackPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'ヒット' })).toBeInTheDocument());
+    mockExec.mockClear();
+    fireEvent.keyDown(document, { key: 'i' });
+    expect(mockExec).not.toHaveBeenCalledWith('insurance');
+  });
+
+  it('pressing u triggers earlysurrender in EARLY_SURRENDER phase', async () => {
+    const earlySurrenderState: BlackJackResponse = { ...actionPhaseState, phase: 6 };
+    mockExec.mockResolvedValue(earlySurrenderState);
+    renderWithProviders(<BlackJackPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'アーリーサレンダー' })).toBeInTheDocument());
+    mockExec.mockClear();
+    mockExec.mockResolvedValue(earlySurrenderState);
+    fireEvent.keyDown(document, { key: 'u' });
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('earlysurrender'));
+  });
+
+  it('pressing n triggers declineearlysurrender in EARLY_SURRENDER phase', async () => {
+    const earlySurrenderState: BlackJackResponse = { ...actionPhaseState, phase: 6 };
+    mockExec.mockResolvedValue(earlySurrenderState);
+    renderWithProviders(<BlackJackPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: '続行' })).toBeInTheDocument());
+    mockExec.mockClear();
+    mockExec.mockResolvedValue(earlySurrenderState);
+    fireEvent.keyDown(document, { key: 'n' });
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('declineearlysurrender'));
+  });
+
+  it('early surrender keyboard shortcuts are disabled outside EARLY_SURRENDER phase', async () => {
+    mockExec.mockResolvedValue(betPhaseState);
+    renderWithProviders(<BlackJackPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'ベット' })).toBeInTheDocument());
+    mockExec.mockClear();
+    fireEvent.keyDown(document, { key: 'u' });
+    expect(mockExec).not.toHaveBeenCalledWith('earlysurrender');
+  });
+
   // --- PhaseIndicator coverage ---
 
   it('phase indicator shows your turn during action phase', async () => {

--- a/frontend/src/pages/BlackJackPage.tsx
+++ b/frontend/src/pages/BlackJackPage.tsx
@@ -272,6 +272,32 @@ function BlackJackPageContent({ variant = 'blackjack' }: BlackJackPageProps) {
     enabled: phase === BjPhase.ACTION && !loading,
   });
 
+  const insuranceBindings = useMemo(
+    () => [
+      { key: 'i', action: () => exec('insurance') },
+      { key: 'n', action: () => exec('declineinsurance') },
+    ],
+    [exec],
+  );
+
+  useActionKeyboardNav({
+    bindings: insuranceBindings,
+    enabled: phase === BjPhase.INSURANCE && !loading,
+  });
+
+  const earlySurrenderBindings = useMemo(
+    () => [
+      { key: 'u', action: () => exec('earlysurrender') },
+      { key: 'n', action: () => exec('declineearlysurrender') },
+    ],
+    [exec],
+  );
+
+  useActionKeyboardNav({
+    bindings: earlySurrenderBindings,
+    enabled: phase === BjPhase.EARLY_SURRENDER && !loading,
+  });
+
   const handleReset = useCallback(() => {
     hideActionLog();
     const config: BlackJackConfigInput = {


### PR DESCRIPTION
## Summary

Extends BlackJack keyboard controls beyond the ACTION phase so keyboard players keep an uninterrupted flow across phase boundaries (issue #2978).

- **INSURANCE phase**: `i` = take insurance, `n` = decline
- **EARLY_SURRENDER phase**: `u` = surrender, `n` = continue
- Each binding is gated to its own phase and disabled while `loading`, so there are no cross-phase key conflicts (reuses the existing `useActionKeyboardNav` hook).
- Buttons now advertise their key via `KbdBadge` + `aria-keyshortcuts`, matching the `BlackJackSwitchPage` convention. Badge text is `aria-hidden`, so accessible button names are unchanged (E2E `getByRole` matchers unaffected).
- Added `kbd.*` labels to `ja`/`en` blackjack i18n (parity).

## Acceptance criteria
- [x] `i` / `n` work in INSURANCE phase
- [x] `u` / `n` work in EARLY_SURRENDER phase
- [x] Keys inert while `loading`
- [x] Each button shows its key
- [x] Unit tests added (fire + gating)

## Test plan
- [x] `bun run check`
- [x] `bun run test -- --run BlackJack` (346 passed)
- [x] `bun run build`

Closes #2978