### PR TITLE
feat(indianpoker): make ante amount configurable from settings panel

### DIFF
--- a/frontend/src/i18n/locales/en/indianpoker.json
+++ b/frontend/src/i18n/locales/en/indianpoker.json
@@ -12,6 +12,7 @@
   "ante": "Ante",
   "settings": {
     "ante": "Ante",
+    "anteAmount": "Ante (applies next game)",
     "bettingLimit": "Betting Limit",
     "metaAI": "Meta AI"
   },

--- a/frontend/src/i18n/locales/ja/indianpoker.json
+++ b/frontend/src/i18n/locales/ja/indianpoker.json
@@ -12,6 +12,7 @@
   "ante": "アンティ",
   "settings": {
     "ante": "アンティ",
+    "anteAmount": "アンティ額（次のゲームから反映）",
     "bettingLimit": "ベッティングリミット",
     "metaAI": "メタAI"
   },

--- a/frontend/src/pages/IndianPokerPage.test.tsx
+++ b/frontend/src/pages/IndianPokerPage.test.tsx
@@ -760,6 +760,23 @@ describe('IndianPokerPage', () => {
     );
   });
 
+  // ---- ante select ----
+  it('sends updated ante when the ante select changes before reset', async () => {
+    renderWithProviders(<IndianPokerPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+
+    const anteSelect = screen.getByRole('combobox', { name: 'アンティ額（次のゲームから反映）' });
+    fireEvent.change(anteSelect, { target: { value: '50' } });
+
+    mockExec.mockClear();
+    mockExec.mockResolvedValue(initState);
+    fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
+    await waitFor(() =>
+      expect(mockExec).toHaveBeenCalledWith('reset', undefined, { ante: 50, bettingLimit: 2, cpuMetaAI: true }),
+    );
+  });
+
   it('renders tutorial button', async () => {
     renderWithProviders(<IndianPokerPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: 'チュートリアル' })).toBeInTheDocument());

--- a/frontend/src/pages/IndianPokerPage.tsx
+++ b/frontend/src/pages/IndianPokerPage.tsx
@@ -91,7 +91,7 @@ function IndianPokerPageContent() {
   const isMobile = useIsMobile();
   const { state, loading, error, exec: execApi, retry } = useGameApi(indianpokerApi.exec);
   const [betAmount, setBetAmount] = useState(20);
-  const [ante] = useState(10);
+  const [ante, setAnte] = useState(10);
   const [bettingLimit, setBettingLimit] = useState(2);
   const [cpuMetaAI, setCpuMetaAI] = useState(true);
   const { hint, hintEnabled, setHintEnabled } = useGameHint('indianpoker', state);
@@ -404,6 +404,19 @@ function IndianPokerPageContent() {
               groups={[
                 {
                   items: [
+                    {
+                      type: 'select' as const,
+                      id: 'indianpoker-ante',
+                      label: t('settings.anteAmount'),
+                      value: ante,
+                      options: [
+                        { value: 5, label: '5' },
+                        { value: 10, label: '10' },
+                        { value: 20, label: '20' },
+                        { value: 50, label: '50' },
+                      ],
+                      onSelect: (v: string) => setAnte(Number(v)),
+                    },
                     {
                       type: 'select' as const,
                       id: 'indianpoker-betting-limit',


### PR DESCRIPTION
## 概要

インディアンポーカーの設定パネルからアンティ額を選択できるようにしました。従来 `const [ante] = useState(10)` とセッターを捨てた固定値だったため、UI からアンティを変更する手段がありませんでした。バックエンドの `reset` は既に `ante` 設定パラメータ（`IndianPokerConfig.Ante`、`p.Ante >= 1` で反映）を受け付けているため、フロントエンドのみで対応しています。

## 変更内容

- `IndianPokerPage.tsx`: `setAnte` を復活させ、SettingsPanel にアンティ額 select（5 / 10 / 20 / 50）を追加。次回リセット時に選択値が `{ ante, ... }` として送信される。
- パネルのタイトル（`t('settings.ante')`）に対応する項目が存在しなかったねじれを、アンティ項目の追加で解消。
- i18n（ja / en）に `settings.anteAmount` を追加。ラベルに「次のゲームから反映」と明記。
- `IndianPokerPage.test.tsx`: アンティ選択→リセットで選択値が API に渡ることを検証するテストを追加。

## 受け入れ条件

- [x] 設定パネルからアンティ額を選択できる
- [x] リセット後に選択したアンティが state.ante に反映される（reset に `ante` を送信）
- [x] SettingsPanel のタイトルと項目の対応が整理される
- [x] `IndianPokerPage.test.tsx` に設定反映テストを追加

## テスト

- `bun run check`: OK（exit 0、indianpoker 関連の警告なし）
- `bun run test -- --run IndianPoker`: 98 passed
- `bun run build`: OK

Closes #3067