### PR TITLE
feat(omahahilo): add board low-possibility indicator

### DIFF
--- a/frontend/src/i18n/locales/en/omahahilo.json
+++ b/frontend/src/i18n/locales/en/omahahilo.json
@@ -17,6 +17,15 @@
     "rebuy": "Rebuy/Addon"
   },
   "communityCards": "Community Cards",
+  "boardLow": {
+    "label": "Low",
+    "live": "Live",
+    "possible": "Possible",
+    "impossible": "No low",
+    "ariaLive": "The board shows 3 distinct low ranks (8 or lower); a low is live",
+    "ariaPossible": "{{needed}} more distinct low rank(s) of 8 or lower are needed for a low",
+    "ariaImpossible": "Fewer than 3 distinct low ranks on the board; no low is possible"
+  },
   "yourHand": "Your Hand",
   "mandatoryRule": "Rule: 2 hole + 3 board (Hi/Lo separately)",
   "mandatoryRuleAria": "Hi-Lo rule: each of high and low uses exactly 2 hole cards and 3 board cards",

--- a/frontend/src/i18n/locales/ja/omahahilo.json
+++ b/frontend/src/i18n/locales/ja/omahahilo.json
@@ -17,6 +17,15 @@
     "rebuy": "リバイ/アドオン"
   },
   "communityCards": "コミュニティカード",
+  "boardLow": {
+    "label": "ロー",
+    "live": "成立圏",
+    "possible": "成立可能",
+    "impossible": "不成立確定",
+    "ariaLive": "ボードに8以下が3ランクあり、ロー成立圏です",
+    "ariaPossible": "ロー成立まであと{{needed}}ランク（8以下）が必要です",
+    "ariaImpossible": "ボードの8以下が3ランク未満のため、ローは不成立確定です"
+  },
   "yourHand": "あなたの手札",
   "mandatoryRule": "ルール: 手札から2枚 + 場札から3枚 (Hi/Lo別に組合せ可)",
   "mandatoryRuleAria": "Hi-Loルール: ハイとローそれぞれで手札2枚と場札3枚を使います",

--- a/frontend/src/pages/OmahaHiLoPage.test.tsx
+++ b/frontend/src/pages/OmahaHiLoPage.test.tsx
@@ -317,6 +317,57 @@ describe('OmahaHiLoPage', () => {
     expect(screen.getByAltText('♦ 8')).toBeInTheDocument();
   });
 
+  // ---- board low-possibility badge (#3005) ----
+  it('does not show the board-low badge pre-flop', async () => {
+    mockExec.mockResolvedValue(preFlopState);
+    renderWithProviders(<OmahaHiLoPage />);
+    await waitFor(() => expect(screen.getByText('コミュニティカード')).toBeInTheDocument());
+    expect(screen.queryByTestId('omahahilo-board-low-badge')).not.toBeInTheDocument();
+  });
+
+  it('shows the "possible" board-low badge on a flop with 2 distinct low ranks', async () => {
+    // flopState board is 10,5,8 → only 5 and 8 are ≤ 8 (2 distinct low ranks).
+    mockExec.mockResolvedValue(flopState);
+    renderWithProviders(<OmahaHiLoPage />);
+    const badge = await screen.findByTestId('omahahilo-board-low-badge');
+    expect(badge).toHaveAttribute('data-status', 'possible');
+    expect(badge).toHaveClass('text-ds-info');
+  });
+
+  it('shows the "live" board-low badge when the board has 3 distinct low ranks', async () => {
+    mockExec.mockResolvedValue({
+      ...flopState,
+      communityCards: [
+        { design: 'SPADE', value: 2 },
+        { design: 'HEART', value: 4 },
+        { design: 'DIAMOND', value: 7 },
+      ],
+    });
+    renderWithProviders(<OmahaHiLoPage />);
+    const badge = await screen.findByTestId('omahahilo-board-low-badge');
+    expect(badge).toHaveAttribute('data-status', 'live');
+    expect(badge).toHaveClass('text-ds-success');
+  });
+
+  it('shows the "impossible" board-low badge on a full board with fewer than 3 low ranks', async () => {
+    // River with only 5 and 8 low → cannot reach 3 distinct low ranks.
+    mockExec.mockResolvedValue({
+      ...flopState,
+      phase: 4,
+      communityCards: [
+        { design: 'SPADE', value: 5 },
+        { design: 'HEART', value: 8 },
+        { design: 'DIAMOND', value: 10 },
+        { design: 'CLOVER', value: 12 },
+        { design: 'SPADE', value: 13 },
+      ],
+    });
+    renderWithProviders(<OmahaHiLoPage />);
+    const badge = await screen.findByTestId('omahahilo-board-low-badge');
+    expect(badge).toHaveAttribute('data-status', 'impossible');
+    expect(badge).toHaveClass('text-ds-text-muted');
+  });
+
   // ---- CPU players ----
   it('renders CPU player info with playStyleName and chips', async () => {
     mockExec.mockResolvedValue(preFlopState);

--- a/frontend/src/pages/OmahaHiLoPage.tsx
+++ b/frontend/src/pages/OmahaHiLoPage.tsx
@@ -45,7 +45,7 @@ import { OMAHA_HELP, parseOmahaCommand } from '../utils/cli/commands/omahaComman
 import { formatOmahaState } from '../utils/cli/formatters/omahaFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
 import { omahaBestFive } from '../utils/omahaBestFive';
-import { lowCardIndexSets } from '../utils/omahaLowCards';
+import { type BoardLowStatus, boardLowPossibility, lowCardIndexSets } from '../utils/omahaLowCards';
 import { findPlayerName } from '../utils/playerUtils';
 
 /** Omaha Hi-Lo (8 or Better) tutorial step definitions. */
@@ -153,6 +153,44 @@ function OmahaLoCard({
         </>
       )}
     </div>
+  );
+}
+
+/** Design-system token classes per board-low status (live=success, possible=info, impossible=muted). */
+const BOARD_LOW_STATUS_CLASS: Readonly<Record<BoardLowStatus, string>> = {
+  live: 'border-ds-success bg-ds-success/20 text-ds-success',
+  possible: 'border-ds-info bg-ds-info/20 text-ds-info',
+  impossible: 'border-ds-border bg-ds-surface text-ds-text-muted',
+};
+
+/** Additive badge showing whether the community board can still make a qualifying
+ * Omaha Hi-Lo low (8-or-better): 3+ distinct low ranks on board = live, still
+ * reachable = possible, mathematically out = impossible. Inspects the board only. */
+function BoardLowBadge({
+  communityCards,
+  t,
+}: {
+  communityCards: Card[];
+  t: (key: string, opts?: Record<string, unknown>) => string;
+}) {
+  const { status, needed } = boardLowPossibility(communityCards);
+  const aria =
+    status === 'live'
+      ? t('boardLow.ariaLive')
+      : status === 'possible'
+        ? t('boardLow.ariaPossible', { needed })
+        : t('boardLow.ariaImpossible');
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] font-semibold ${BOARD_LOW_STATUS_CLASS[status]}`}
+      data-testid="omahahilo-board-low-badge"
+      data-status={status}
+      title={aria}
+    >
+      <span aria-hidden="true">{t('boardLow.label')}:</span>
+      <span aria-hidden="true">{t(`boardLow.${status}`)}</span>
+      <span className="sr-only">{aria}</span>
+    </span>
   );
 }
 
@@ -318,7 +356,12 @@ function OmahaHiLoPageContent() {
             {(() => {
               const communityCardsContent = (
                 <>
-                  <div className="text-ds-text-primary text-lg mb-1.5">{t('communityCards')}</div>
+                  <div className="mb-1.5 flex flex-wrap items-center gap-2">
+                    <span className="text-ds-text-primary text-lg">{t('communityCards')}</span>
+                    {phase >= OmahaPhase.FLOP && phase <= OmahaPhase.RIVER && (
+                      <BoardLowBadge communityCards={state?.communityCards ?? []} t={t} />
+                    )}
+                  </div>
                   <div className="flex flex-wrap gap-2">
                     {state?.communityCards?.length
                       ? state.communityCards.map((card, idx) => {

--- a/frontend/src/utils/omahaLowCards.test.ts
+++ b/frontend/src/utils/omahaLowCards.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { Card } from '../types/card';
-import { lowCardIndexSets } from './omahaLowCards';
+import { boardLowPossibility, lowCardIndexSets } from './omahaLowCards';
 
 const c = (design: Card['design'], value: number): Card => ({ design, value });
 
@@ -27,5 +27,56 @@ describe('lowCardIndexSets', () => {
     const { loHoleSet, loBoardSet } = lowCardIndexSets(low, hole, board);
     expect(loHoleSet.size).toBe(0);
     expect(loBoardSet.size).toBe(0);
+  });
+});
+
+describe('boardLowPossibility', () => {
+  it('reports possible on an empty (pre-flop) board', () => {
+    const result = boardLowPossibility([]);
+    expect(result.status).toBe('possible');
+    expect(result.lowRankCount).toBe(0);
+    expect(result.needed).toBe(3);
+  });
+
+  it('reports live once the board shows 3 distinct low ranks', () => {
+    // Flop 2,4,7 — all ≤ 8 and distinct.
+    const board = [c('SPADE', 2), c('HEART', 4), c('DIAMOND', 7)];
+    const result = boardLowPossibility(board);
+    expect(result.status).toBe('live');
+    expect(result.lowRankCount).toBe(3);
+    expect(result.needed).toBe(0);
+  });
+
+  it('counts the ace as a low rank', () => {
+    const board = [c('SPADE', 1), c('HEART', 5), c('DIAMOND', 8)];
+    const result = boardLowPossibility(board);
+    expect(result.status).toBe('live');
+    expect(result.lowRankCount).toBe(3);
+  });
+
+  it('treats duplicate low ranks as a single distinct rank', () => {
+    // Two 4s + one 6 → only 2 distinct low ranks, one board card still to come.
+    const board = [c('SPADE', 4), c('HEART', 4), c('DIAMOND', 6), c('CLOVER', 11)];
+    const result = boardLowPossibility(board);
+    expect(result.status).toBe('possible');
+    expect(result.lowRankCount).toBe(2);
+    expect(result.needed).toBe(1);
+  });
+
+  it('reports impossible on a full board with fewer than 3 distinct low ranks', () => {
+    // River: only 5 and 8 are ≤ 8 → 2 distinct low ranks, no cards left.
+    const board = [c('SPADE', 5), c('HEART', 8), c('DIAMOND', 10), c('CLOVER', 12), c('SPADE', 13)];
+    const result = boardLowPossibility(board);
+    expect(result.status).toBe('impossible');
+    expect(result.lowRankCount).toBe(2);
+    expect(result.needed).toBe(1);
+  });
+
+  it('reports impossible on a full board with no low ranks at all', () => {
+    const board = [c('SPADE', 9), c('HEART', 10), c('DIAMOND', 11), c('CLOVER', 12), c('SPADE', 13)];
+    const result = boardLowPossibility(board);
+    expect(result.status).toBe('impossible');
+    expect(result.lowRankCount).toBe(0);
+    expect(result.needed).toBe(3);
   });
 });

--- a/frontend/src/utils/omahaLowCards.ts
+++ b/frontend/src/utils/omahaLowCards.ts
@@ -6,6 +6,64 @@ export interface LowCardIndexSets {
   loBoardSet: Set<number>;
 }
 
+/**
+ * Whether the community board can still yield a qualifying Omaha Hi-Lo (8-or-better) low.
+ *
+ * - `live`: the board already shows 3+ distinct low ranks, so a low is possible given the right hole cards.
+ * - `possible`: fewer than 3 distinct low ranks so far, but enough board cards remain to reach 3.
+ * - `impossible`: the board is complete (or nearly so) and can no longer reach 3 distinct low ranks.
+ */
+export type BoardLowStatus = 'live' | 'possible' | 'impossible';
+
+/** Full board Hi-Lo low possibility, including the distinct low-rank count and how many more are needed. */
+export interface BoardLowPossibility {
+  /** Coarse possibility state derived from the current + remaining board cards. */
+  status: BoardLowStatus;
+  /** Distinct ranks of 8-or-lower (ace counts as low) currently on the board. */
+  lowRankCount: number;
+  /** Additional distinct low ranks the board still needs to make a low possible (0 once `live`). */
+  needed: number;
+}
+
+/** A full Omaha/Hold'em board holds 5 community cards. */
+const FULL_BOARD_SIZE = 5;
+/** A low uses 3 distinct board ranks (plus 2 hole ranks) — the board must supply at least this many. */
+const REQUIRED_BOARD_LOW_RANKS = 3;
+
+/**
+ * Computes whether the current community board can still make an Omaha Hi-Lo
+ * (8-or-better) low possible, matching the domain rule: a low card is any rank
+ * 1–8 with the ace counting low, and all ranks must be distinct. A low draws
+ * exactly 3 cards from the board, so the board must eventually show at least 3
+ * distinct low ranks.
+ *
+ * This inspects the BOARD only — it does not evaluate any player's hole cards.
+ *
+ * @param communityCards - The revealed community board (0–5 cards).
+ * @returns The board low possibility: status, distinct low-rank count, and ranks still needed.
+ */
+export function boardLowPossibility(communityCards: Card[]): BoardLowPossibility {
+  const lowRanks = new Set<number>();
+  for (const card of communityCards) {
+    if (card.value >= 1 && card.value <= 8) {
+      lowRanks.add(card.value);
+    }
+  }
+  const lowRankCount = lowRanks.size;
+  const needed = Math.max(0, REQUIRED_BOARD_LOW_RANKS - lowRankCount);
+  const remaining = Math.max(0, FULL_BOARD_SIZE - communityCards.length);
+
+  let status: BoardLowStatus;
+  if (lowRankCount >= REQUIRED_BOARD_LOW_RANKS) {
+    status = 'live';
+  } else if (needed <= remaining) {
+    status = 'possible';
+  } else {
+    status = 'impossible';
+  }
+  return { status, lowRankCount, needed };
+}
+
 /** Match two cards by design and value (single deck → unique). */
 function sameCard(a: Card, b: Card): boolean {
   return a.design === b.design && a.value === b.value;


### PR DESCRIPTION
## Summary

Adds a board low-possibility status badge to the Omaha Hi-Lo (`omahahilo`) community-card header, so players can see during play whether a qualifying low (8-or-better) is even reachable — previously low info only appeared post-showdown via `lowBestHand`.

## Low rule (matches domain `isQualifyingOmahaLow`)

A low card is any rank 1–8 with the **ace counting as low (=1)**, and a qualifying low uses **5 distinct ranks** = exactly **3 board cards + 2 hole cards**. So the board itself must eventually show **≥3 distinct low ranks**. This is a **board-only** computation (it does not evaluate hole cards):

- **live** — board already shows 3+ distinct low ranks (a low is possible with the right hole cards)
- **possible** — fewer than 3 so far, but enough board cards remain to still reach 3
- **impossible** — board complete (or nearly so) and can no longer reach 3 distinct low ranks

Duplicate low ranks count once; the badge shows from the flop through the river.

## Changes

- `frontend/src/utils/omahaLowCards.ts` — new pure `boardLowPossibility(communityCards)` helper + `BoardLowStatus` / `BoardLowPossibility` types
- `frontend/src/pages/OmahaHiLoPage.tsx` — additive `BoardLowBadge` (design tokens: live=success, possible=info, impossible=muted; `data-testid="omahahilo-board-low-badge"`, `data-status`, sr-only aria text)
- i18n `ja`/`en` `boardLow.*` keys (parity verified)
- Unit + page tests

## Test plan

- [x] `bun run test -- --run OmahaHiLo` (133 passed)
- [x] `bun run check` (exit 0; warnings pre-existing, unrelated files)
- [x] `bun run build` (tsc, exit 0)
- [x] i18n ja/en key parity verified
- [x] Helper tests: empty board→possible, 3 distinct low→live, ace-low counted, duplicate ranks→single, full board <3→impossible
- [x] Page tests: pre-flop hides badge, flop(10,5,8)→possible, 3-low flop→live, full board <3→impossible

Closes #3005