### PR TITLE
feat(spades): expose nil-bonus and bag-penalty threshold in settings panel

### DIFF
--- a/frontend/src/hooks/useSpadesGame.ts
+++ b/frontend/src/hooks/useSpadesGame.ts
@@ -21,6 +21,12 @@ export const CPU_DIFFICULTY_OPTIONS = [
 /** Available point limit options for Spades. */
 export const POINT_LIMIT_OPTIONS = [200, 300, 500, 750, 1000] as const;
 
+/** Available nil-bonus options for Spades (backend accepts 0-500). */
+export const NIL_BONUS_OPTIONS = [50, 100, 150, 200] as const;
+
+/** Available bag-penalty threshold options for Spades (backend accepts 1-100). */
+export const BAG_PENALTY_THRESHOLD_OPTIONS = [5, 10, 15] as const;
+
 /** Hook that manages Spades game state, bidding, and player actions. */
 export function useSpadesGame() {
   const base = useTrickGameBase({

--- a/frontend/src/i18n/locales/en/spades.json
+++ b/frontend/src/i18n/locales/en/spades.json
@@ -10,6 +10,9 @@
     "title": "Settings",
     "cpuDifficulty": "CPU Difficulty",
     "pointLimit": "Point Limit",
+    "nilBonus": "Nil Bonus",
+    "bagPenaltyThreshold": "Bag Penalty Threshold",
+    "nextGameNote": "Setting changes take effect from the next game.",
     "easy": "Easy",
     "normal": "Normal",
     "hard": "Hard"

--- a/frontend/src/i18n/locales/ja/spades.json
+++ b/frontend/src/i18n/locales/ja/spades.json
@@ -10,6 +10,9 @@
     "title": "設定",
     "cpuDifficulty": "CPU難易度",
     "pointLimit": "目標スコア",
+    "nilBonus": "ニルボーナス",
+    "bagPenaltyThreshold": "バッグペナルティ閾値",
+    "nextGameNote": "設定変更は次のゲームから有効になります。",
     "easy": "Easy",
     "normal": "Normal",
     "hard": "Hard"

--- a/frontend/src/pages/SpadesPage.test.tsx
+++ b/frontend/src/pages/SpadesPage.test.tsx
@@ -343,6 +343,50 @@ describe('SpadesPage', () => {
     );
   });
 
+  it('settings panel changes nilBonus and passes it on reset', async () => {
+    renderWithProviders(<SpadesPage />);
+    await waitFor(() => expect(screen.getByText('スコア')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText('設定'));
+    fireEvent.change(screen.getByTestId('sp-setting-nil-bonus'), { target: { value: '200' } });
+
+    mockExec.mockClear();
+    mockExec.mockResolvedValue(playPhaseState);
+    fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
+
+    await waitFor(() =>
+      expect(mockExec).toHaveBeenCalledWith('reset', undefined, undefined, {
+        cpuDifficulty: 1,
+        pointLimit: 500,
+        nilBonus: 200,
+        bagPenaltyThreshold: 10,
+      }),
+    );
+  });
+
+  it('settings panel changes bagPenaltyThreshold and passes it on reset', async () => {
+    renderWithProviders(<SpadesPage />);
+    await waitFor(() => expect(screen.getByText('スコア')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText('設定'));
+    fireEvent.change(screen.getByTestId('sp-setting-bag-threshold'), { target: { value: '5' } });
+
+    mockExec.mockClear();
+    mockExec.mockResolvedValue(playPhaseState);
+    fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
+
+    await waitFor(() =>
+      expect(mockExec).toHaveBeenCalledWith('reset', undefined, undefined, {
+        cpuDifficulty: 1,
+        pointLimit: 500,
+        nilBonus: 100,
+        bagPenaltyThreshold: 5,
+      }),
+    );
+  });
+
   it('card selection toggle via aria-pressed', async () => {
     renderWithProviders(<SpadesPage />);
     await waitFor(() => expect(screen.getByAltText('\u2660 A')).toBeInTheDocument());

--- a/frontend/src/pages/SpadesPage.tsx
+++ b/frontend/src/pages/SpadesPage.tsx
@@ -23,7 +23,13 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
-import { CPU_DIFFICULTY_OPTIONS, POINT_LIMIT_OPTIONS, useSpadesGame } from '../hooks/useSpadesGame';
+import {
+  BAG_PENALTY_THRESHOLD_OPTIONS,
+  CPU_DIFFICULTY_OPTIONS,
+  NIL_BONUS_OPTIONS,
+  POINT_LIMIT_OPTIONS,
+  useSpadesGame,
+} from '../hooks/useSpadesGame';
 import { badgeError, badgeInfo, badgeSuccess, badgeWarning } from '../styles/badgeStyles';
 import { btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
@@ -241,6 +247,26 @@ function SpadesPageContent() {
                     value: spadesConfig.pointLimit,
                     options: POINT_LIMIT_OPTIONS.map((v) => ({ value: v, label: String(v) })),
                     onSelect: (v) => handleConfigChange('pointLimit', v),
+                  },
+                  {
+                    type: 'select',
+                    id: 'nilBonus',
+                    label: t('settings.nilBonus'),
+                    value: spadesConfig.nilBonus,
+                    options: NIL_BONUS_OPTIONS.map((v) => ({ value: v, label: String(v) })),
+                    onSelect: (v) => handleConfigChange('nilBonus', v),
+                    tooltip: t('settings.nextGameNote'),
+                    testId: 'sp-setting-nil-bonus',
+                  },
+                  {
+                    type: 'select',
+                    id: 'bagPenaltyThreshold',
+                    label: t('settings.bagPenaltyThreshold'),
+                    value: spadesConfig.bagPenaltyThreshold,
+                    options: BAG_PENALTY_THRESHOLD_OPTIONS.map((v) => ({ value: v, label: String(v) })),
+                    onSelect: (v) => handleConfigChange('bagPenaltyThreshold', v),
+                    tooltip: t('settings.nextGameNote'),
+                    testId: 'sp-setting-bag-threshold',
                   },
                   {
                     type: 'checkbox',


### PR DESCRIPTION
## Summary
`SpadesPage.tsx` already sent `nilBonus` and `bagPenaltyThreshold` in the reset payload, but the SettingsPanel had no controls for them, so they were always locked to the defaults (dead settings). The backend `reset` command fully accepts both params (`SpadesWebConfig.NilBonus` / `BagPenaltyThreshold`, clamped to 0-500 and 1-100), so this is frontend-only wiring.

This adds two `select` controls to the Spades SettingsPanel exposing the accepted thresholds:
- **Nil Bonus** (50 / 100 / 150 / 200)
- **Bag Penalty Threshold** (5 / 10 / 15)

Both apply on the next reset and carry a "takes effect from the next game" help tooltip.

## Changes
- `useSpadesGame.ts`: add `NIL_BONUS_OPTIONS` and `BAG_PENALTY_THRESHOLD_OPTIONS` constants.
- `SpadesPage.tsx`: add two `select` items (with `data-testid` + next-game tooltip) to the SettingsPanel.
- `i18n ja/en`: add `settings.nilBonus`, `settings.bagPenaltyThreshold`, `settings.nextGameNote` (parity kept).
- `SpadesPage.test.tsx`: add tests that changing each threshold and resetting passes the new value to the API.

## Test plan
- [x] `bun run check` (exit 0; warnings are pre-existing in unrelated files)
- [x] `bun run test -- --run Spades` (108 passed)
- [x] `bun run build` (tsc, exit 0)
- [x] New tests: `settings panel changes nilBonus and passes it on reset`, `settings panel changes bagPenaltyThreshold and passes it on reset`

Closes #3046

🤖 Generated with [Claude Code](https://claude.com/claude-code)