### PR TITLE
feat(baccarat): auto-scroll big road to latest and improve container

### DIFF
--- a/frontend/src/pages/BaccaratPage.test.tsx
+++ b/frontend/src/pages/BaccaratPage.test.tsx
@@ -341,6 +341,29 @@ describe('BaccaratPage', () => {
     await waitFor(() => expect(screen.getByTestId('big-road')).toBeInTheDocument());
   });
 
+  it('wraps the Big Road in a bounded, horizontally scrollable container', async () => {
+    mockExec.mockResolvedValue(endPhaseWithHistory);
+    renderWithProviders(<BaccaratPage />);
+    const scroller = await screen.findByTestId('big-road-scroll');
+    expect(scroller).toHaveClass('overflow-x-auto');
+  });
+
+  it('auto-scrolls the Big Road to the latest (right-most) results', async () => {
+    // jsdom does no layout, so fake a wide scroll width and assert the effect
+    // pins scrollLeft to the right edge.
+    Object.defineProperty(HTMLElement.prototype, 'scrollWidth', {
+      configurable: true,
+      get() {
+        return 500;
+      },
+    });
+    mockExec.mockResolvedValue(endPhaseWithHistory);
+    renderWithProviders(<BaccaratPage />);
+    const scroller = await screen.findByTestId('big-road-scroll');
+    await waitFor(() => expect(scroller.scrollLeft).toBe(500));
+    delete (HTMLElement.prototype as unknown as { scrollWidth?: number }).scrollWidth;
+  });
+
   it('does not render Big Road when history is only ties', async () => {
     mockExec.mockResolvedValue(endPhaseWithOnlyTies);
     renderWithProviders(<BaccaratPage />);

--- a/frontend/src/pages/BaccaratPage.tsx
+++ b/frontend/src/pages/BaccaratPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { baccaratApi } from '../api/gameApi';
 import { ActionLogPanel } from '../components/ActionLogPanel';
 import { CliTerminal } from '../components/cli/CliTerminal';
@@ -86,12 +86,23 @@ function baccaratHandValue(cards: readonly Card[]): number {
 }
 
 function BigRoadGrid({ history }: { history: number[] }) {
+  // Auto-scroll the road to the latest (right-most) column whenever the
+  // history grows, so the most recent results are always in view without
+  // manual scrolling. Hooks must run unconditionally, before any early return.
+  const scrollRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (el && history.length > 0) el.scrollLeft = el.scrollWidth;
+  }, [history.length]);
+
   if (history.length === 0) return null;
 
   // Build columns: new column on side change, ties mark previous cell
   const columns: { result: number; tie: boolean }[][] = [];
   let currentCol: { result: number; tie: boolean }[] = [];
   let lastSide: number | null = null;
+  // Track the most recently placed non-tie cell so it can be highlighted.
+  let latestCell: { result: number; tie: boolean } | null = null;
 
   for (const result of history) {
     if (result !== ROAD_PLAYER && result !== ROAD_BANKER) {
@@ -108,7 +119,9 @@ function BigRoadGrid({ history }: { history: number[] }) {
       columns.push(currentCol);
       currentCol = [];
     }
-    currentCol.push({ result, tie: false });
+    const cell = { result, tie: false };
+    currentCol.push(cell);
+    latestCell = cell;
     lastSide = result;
   }
   if (currentCol.length > 0) {
@@ -139,32 +152,39 @@ function BigRoadGrid({ history }: { history: number[] }) {
   }
 
   return (
-    <div className="mb-4" data-testid="big-road">
+    <div className="mb-4 w-full max-w-md" data-testid="big-road">
       <div
-        className="inline-grid gap-px bg-ds-surface-elevated border border-ds-border-subtle rounded overflow-x-auto"
-        style={{ gridTemplateColumns: `repeat(${maxCols}, 28px)` }}
+        ref={scrollRef}
+        data-testid="big-road-scroll"
+        className="overflow-x-auto rounded border border-ds-border-subtle bg-ds-surface-elevated"
       >
-        {grid.flatMap((row, ri) =>
-          row.map((cell, ci) => {
-            const cellKey = `r${String(ri)}c${String(ci)}`;
-            return (
-              <div key={cellKey} className="w-7 h-7 flex items-center justify-center bg-ds-surface-elevated relative">
-                {cell && (
-                  <>
-                    <span
-                      className={`w-5 h-5 rounded-full inline-block ${cell.result === ROAD_PLAYER ? 'bg-ds-info' : 'bg-ds-error'}`}
-                    />
-                    {cell.tie && (
-                      <span className="absolute inset-0 flex items-center justify-center text-ds-success font-bold text-xs">
-                        /
-                      </span>
-                    )}
-                  </>
-                )}
-              </div>
-            );
-          }),
-        )}
+        <div
+          className="inline-grid gap-px bg-ds-surface-elevated"
+          style={{ gridTemplateColumns: `repeat(${maxCols}, 28px)` }}
+        >
+          {grid.flatMap((row, ri) =>
+            row.map((cell, ci) => {
+              const cellKey = `r${String(ri)}c${String(ci)}`;
+              const isLatest = cell !== null && cell === latestCell;
+              return (
+                <div key={cellKey} className="w-7 h-7 flex items-center justify-center bg-ds-surface-elevated relative">
+                  {cell && (
+                    <>
+                      <span
+                        className={`w-5 h-5 rounded-full inline-block ${cell.result === ROAD_PLAYER ? 'bg-ds-info' : 'bg-ds-error'} ${isLatest ? 'ring-2 ring-ds-accent ring-offset-1 ring-offset-ds-surface-elevated' : ''}`}
+                      />
+                      {cell.tie && (
+                        <span className="absolute inset-0 flex items-center justify-center text-ds-success font-bold text-xs">
+                          /
+                        </span>
+                      )}
+                    </>
+                  )}
+                </div>
+              );
+            }),
+          )}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
Improves the baccarat big road (罫線) so the latest results are always visible and the grid no longer overflows the page on mobile.

- Wrap the `inline-grid` in a bounded (`w-full max-w-md`), `overflow-x-auto` scroll container (`data-testid="big-road-scroll"`) instead of putting `overflow-x-auto` directly on the growing grid.
- Auto-scroll to the right-most (latest) column on every `history` change via a `useRef` + `useEffect` that sets `scrollLeft = scrollWidth`.
- Highlight the most recent result cell with an accent ring (`ring-ds-accent`) for at-a-glance orientation.

## Acceptance criteria
- [x] Big road auto-scrolls to the right edge when history is appended
- [x] The latest result cell is visually emphasized
- [x] No page-level horizontal scroll on mobile widths (bounded `max-w-md` container)
- [x] `BaccaratPage.test.tsx` covers the scroll wiring

## Tests
Added to `BaccaratPage.test.tsx`:
- `wraps the Big Road in a bounded, horizontally scrollable container`
- `auto-scrolls the Big Road to the latest (right-most) results`

## Gates
- `bun run check` ✅
- `bun run test -- --run Baccarat` ✅ (76 passed)
- `bun run build` ✅

Frontend-only; no Go or results-data changes.

Closes #3043