### PR TITLE
feat(holdem): add tournament mode settings to web UI

### DIFF
--- a/frontend/src/i18n/locales/en/holdem.json
+++ b/frontend/src/i18n/locales/en/holdem.json
@@ -60,7 +60,11 @@
     "handOdds": "Hand Odds"
   },
   "settings": {
-    "cpuMetaAI": "Meta-AI (CPU learns your play style)"
+    "cpuMetaAI": "Meta-AI (CPU learns your play style)",
+    "tournamentMode": "Tournament mode (rising blinds / rebuy / addon)",
+    "rebuyEnabled": "Enable rebuy",
+    "addonEnabled": "Enable addon",
+    "tournamentNote": "Tournament settings apply from the next reset"
   },
   "tutorial": {
     "communityCards": "Community cards shared by all players. Five cards are revealed progressively.",

--- a/frontend/src/i18n/locales/ja/holdem.json
+++ b/frontend/src/i18n/locales/ja/holdem.json
@@ -60,7 +60,11 @@
     "handOdds": "ハンドオッズ"
   },
   "settings": {
-    "cpuMetaAI": "メタAI（CPUがプレイスタイルを学習）"
+    "cpuMetaAI": "メタAI（CPUがプレイスタイルを学習）",
+    "tournamentMode": "トーナメントモード（ブラインド上昇/リバイ/アドオン）",
+    "rebuyEnabled": "リバイを有効化",
+    "addonEnabled": "アドオンを有効化",
+    "tournamentNote": "トーナメント設定は次のリセットから反映されます"
   },
   "tutorial": {
     "communityCards": "コミュニティカードです。全プレイヤー共有の5枚のカードが順次公開されます。",

--- a/frontend/src/pages/HoldemPage.test.tsx
+++ b/frontend/src/pages/HoldemPage.test.tsx
@@ -1258,6 +1258,50 @@ describe('HoldemPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined, { cpuMetaAI: true }));
   });
 
+  // ---- Tournament settings ----
+  it('sends tournament config when tournament mode is enabled before reset', async () => {
+    renderWithProviders(<HoldemPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+
+    fireEvent.click(screen.getByTestId('tournament-mode-toggle'));
+    // Rebuy/addon toggles only appear once tournament mode is on
+    fireEvent.click(screen.getByTestId('tournament-rebuy-toggle'));
+    fireEvent.click(screen.getByTestId('tournament-addon-toggle'));
+
+    mockExec.mockClear();
+    mockExec.mockResolvedValue(initState);
+    fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
+    await waitFor(() =>
+      expect(mockExec).toHaveBeenCalledWith('reset', undefined, {
+        cpuMetaAI: false,
+        tournamentMode: true,
+        rebuyEnabled: true,
+        addonEnabled: true,
+      }),
+    );
+  });
+
+  it('hides rebuy/addon toggles until tournament mode is enabled', async () => {
+    renderWithProviders(<HoldemPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+
+    expect(screen.queryByTestId('tournament-rebuy-toggle')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('tournament-mode-toggle'));
+    expect(screen.getByTestId('tournament-rebuy-toggle')).toBeInTheDocument();
+  });
+
+  it('omits tournament config from reset when tournament mode is off', async () => {
+    renderWithProviders(<HoldemPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+
+    mockExec.mockClear();
+    mockExec.mockResolvedValue(initState);
+    fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined, { cpuMetaAI: false }));
+  });
+
   // ---- Keyboard navigation ----
   describe('keyboard navigation', () => {
     it('pressing c triggers call when canAct and hasOutstandingBet', async () => {

--- a/frontend/src/pages/HoldemPage.tsx
+++ b/frontend/src/pages/HoldemPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { holdemApi } from '../api/gameApi';
+import { type HoldemConfigInput, holdemApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { BettingControls } from '../components/BettingControls';
 import { CpuAccordion } from '../components/CpuAccordion';
@@ -130,6 +130,9 @@ function HoldemPageContent() {
   const [betAmount, setBetAmount] = useState(20);
   const [learningMode, setLearningMode] = useState(false);
   const [cpuMetaAI, setCpuMetaAI] = useState(false);
+  const [tournamentMode, setTournamentMode] = useState(false);
+  const [rebuyEnabled, setRebuyEnabled] = useState(false);
+  const [addonEnabled, setAddonEnabled] = useState(false);
   const { hint, hintEnabled, setHintEnabled } = useGameHint('holdem', state);
   const turnStartRef = useRef(0);
 
@@ -137,8 +140,14 @@ function HoldemPageContent() {
 
   const handleManualReset = useCallback(() => {
     hideActionLog();
-    void exec('reset', undefined, { cpuMetaAI });
-  }, [exec, hideActionLog, cpuMetaAI]);
+    const config: HoldemConfigInput = { cpuMetaAI };
+    if (tournamentMode) {
+      config.tournamentMode = true;
+      config.rebuyEnabled = rebuyEnabled;
+      config.addonEnabled = addonEnabled;
+    }
+    void exec('reset', undefined, config);
+  }, [exec, hideActionLog, cpuMetaAI, tournamentMode, rebuyEnabled, addonEnabled]);
 
   useEffect(() => {
     if (state?.minRaise && state.minRaise > 0) {
@@ -554,6 +563,40 @@ function HoldemPageContent() {
                     <input type="checkbox" checked={cpuMetaAI} onChange={(e) => setCpuMetaAI(e.target.checked)} />
                     {t('settings.cpuMetaAI')}
                   </label>
+                </div>
+                <div className="flex flex-col gap-2 border-t border-ds-border pt-2" data-testid="tournament-settings">
+                  <label className="text-ds-text-primary text-sm flex items-center gap-1">
+                    <input
+                      type="checkbox"
+                      data-testid="tournament-mode-toggle"
+                      checked={tournamentMode}
+                      onChange={(e) => setTournamentMode(e.target.checked)}
+                    />
+                    {t('settings.tournamentMode')}
+                  </label>
+                  {tournamentMode && (
+                    <div className="flex flex-col gap-2 pl-5">
+                      <label className="text-ds-text-primary text-sm flex items-center gap-1">
+                        <input
+                          type="checkbox"
+                          data-testid="tournament-rebuy-toggle"
+                          checked={rebuyEnabled}
+                          onChange={(e) => setRebuyEnabled(e.target.checked)}
+                        />
+                        {t('settings.rebuyEnabled')}
+                      </label>
+                      <label className="text-ds-text-primary text-sm flex items-center gap-1">
+                        <input
+                          type="checkbox"
+                          data-testid="tournament-addon-toggle"
+                          checked={addonEnabled}
+                          onChange={(e) => setAddonEnabled(e.target.checked)}
+                        />
+                        {t('settings.addonEnabled')}
+                      </label>
+                    </div>
+                  )}
+                  <p className="text-ds-text-secondary text-xs">{t('settings.tournamentNote')}</p>
                 </div>
               </div>
             </details>


### PR DESCRIPTION
## Summary
Adds a tournament-mode configuration UI to the Texas Hold'em web settings panel. Previously the panel only exposed learning mode / hint / meta-AI, and `handleManualReset` only sent `{ cpuMetaAI }`, so there was no way to enable tournament mode from the GUI. The backend `HoldemConfig.ToConfig()` already accepts `tournamentMode`, `rebuyEnabled`, and `addonEnabled` on reset, so this change is frontend-only wiring.

## Changes
- `HoldemPage.tsx`: add Tournament mode toggle plus nested Rebuy / Addon enable toggles (shown only when tournament mode is on) to the settings `<details>`; include the tournament config in the `reset` command when enabled.
- `HoldemPage.test.tsx`: add tests that a tournament setting + reset passes the config to the API, that rebuy/addon toggles are hidden until tournament mode is on, and that the config is omitted when off.
- i18n: add `settings.tournamentMode` / `rebuyEnabled` / `addonEnabled` / `tournamentNote` keys to ja + en (parity verified), with a next-reset note.

## Acceptance criteria
- [x] Tournament mode can be toggled from the settings panel
- [x] Header shows hand count / blind info after reset (existing header logic, now reachable)
- [x] Rebuy/addon phase UI works (existing controls, now enable-able from GUI)
- [x] Unit test for config submission added

## Gates
- [x] `bun run check` (exit 0)
- [x] `bun run test -- --run Holdem` (324 passed)
- [x] `bun run build` (tsc, exit 0)

Frontend-only. No Go changes.

Closes #2999