### PR TITLE
feat(bigohilo): dual-highlight cards used by both hi and lo at showdown

### DIFF
--- a/frontend/src/pages/BigOHiLoPage.test.tsx
+++ b/frontend/src/pages/BigOHiLoPage.test.tsx
@@ -415,6 +415,64 @@ describe('BigOHiLoPage', () => {
     expect(screen.getByTestId('bigohilo-lo-badge')).toHaveTextContent('A 5 8 2 5');
   });
 
+  it('dual-highlights cards used by both Hi and Lo, distinct from hi-only and lo-only', async () => {
+    // Hole A♠ 2♠ + board 5♠ 6♠ 7♠ = A-high spade flush (Hi). Lo = A 3 5 6 7.
+    // → A♠ (hole) is used by BOTH; 2♠ is Hi-only; 3♦ is Lo-only.
+    const dualState: OmahaResponse = {
+      ...showdownState,
+      players: [
+        humanPlayer({
+          handName: 'フラッシュ',
+          cards: [
+            { design: 'SPADE', value: 1 },
+            { design: 'SPADE', value: 2 },
+            { design: 'DIAMOND', value: 3 },
+            { design: 'HEART', value: 4 },
+            { design: 'CLOVER', value: 13 },
+          ],
+        }),
+        cpuPlayer(1, { folded: true }),
+      ],
+      communityCards: [
+        { design: 'SPADE', value: 5 },
+        { design: 'SPADE', value: 6 },
+        { design: 'SPADE', value: 7 },
+        { design: 'DIAMOND', value: 12 },
+        { design: 'CLOVER', value: 11 },
+      ],
+      roundResults: [
+        {
+          ...showdownState.roundResults[0],
+          hiWonAmount: 100,
+          lowWonAmount: 100,
+          lowBestHand: [
+            { design: 'SPADE', value: 1 },
+            { design: 'DIAMOND', value: 3 },
+            { design: 'SPADE', value: 5 },
+            { design: 'SPADE', value: 6 },
+            { design: 'SPADE', value: 7 },
+          ],
+        },
+      ],
+    };
+    mockExec.mockResolvedValue(dualState);
+    const { container } = renderWithProviders(<BigOHiLoPage />);
+    await waitFor(() => expect(screen.getByTestId('bigohilo-split')).toBeInTheDocument());
+    // A♠ (hole) + 5♠/6♠/7♠ (board) belong to both the flush and the low.
+    const both = container.querySelectorAll('[data-hilo="both"]');
+    expect(both.length).toBeGreaterThan(0);
+    // The dual ring carries both green (Hi) and blue-offset (Lo) attributes.
+    expect(both[0].className).toContain('ring-ds-success');
+    expect(both[0].className).toContain('ring-offset-ds-info');
+    // 2♠ is Hi-only (green, no blue); 3♦ is Lo-only (blue, no green).
+    const hiOnly = container.querySelectorAll('[data-hilo="hi"]');
+    const loOnly = container.querySelectorAll('[data-hilo="lo"]');
+    expect(hiOnly.length).toBeGreaterThan(0);
+    expect(loOnly.length).toBeGreaterThan(0);
+    expect(hiOnly[0].className).not.toContain('ring-offset-ds-info');
+    expect(loOnly[0].className).not.toContain('ring-ds-success');
+  });
+
   it('states Hi scoops the pot when no low qualifies', async () => {
     const hiOnlyState: OmahaResponse = {
       ...showdownState,

--- a/frontend/src/pages/BigOHiLoPage.tsx
+++ b/frontend/src/pages/BigOHiLoPage.tsx
@@ -45,6 +45,7 @@ import { OMAHA_HELP, parseOmahaCommand } from '../utils/cli/commands/omahaComman
 import { formatOmahaState } from '../utils/cli/formatters/omahaFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
 import { omahaBestFive } from '../utils/omahaBestFive';
+import { hiLoRingStyle } from '../utils/omahaHiLoRing';
 import { lowCardIndexSets } from '../utils/omahaLowCards';
 import { findPlayerName } from '../utils/playerUtils';
 
@@ -275,16 +276,13 @@ function BigOHiLoPageContent() {
                           const inBest = showdownBest5.boardSet.has(idx);
                           const inLo = lowSets.loBoardSet.has(idx);
                           const dim = showdownBest5.boardSet.size > 0 && !inBest && !inLo;
-                          const ring = inLo
-                            ? 'ring-2 ring-ds-info motion-safe:animate-pulse'
-                            : inBest
-                              ? '-translate-y-1 ring-2 ring-ds-success motion-safe:animate-pulse'
-                              : '';
+                          const { category, ring } = hiLoRingStyle(inBest, inLo);
                           return (
                             <div
                               key={`${card.design}-${card.value}`}
                               className={`transition-all ${ring} ${dim ? 'opacity-50' : ''}`}
                               data-best5-board={inBest || undefined}
+                              data-hilo={category === 'none' ? undefined : category}
                               data-testid={inLo ? 'bigohilo-lo-card' : undefined}
                             >
                               <AnimatedCard card={card} width={cardWidth} style={placeholderCardStyle} />
@@ -485,16 +483,13 @@ function BigOHiLoPageContent() {
                         const inBest = showdownBest5.holeSet.has(idx);
                         const inLo = lowSets.loHoleSet.has(idx);
                         const dim = showdownBest5.holeSet.size > 0 && !inBest && !inLo;
-                        const ring = inLo
-                          ? 'ring-2 ring-ds-info motion-safe:animate-pulse'
-                          : inBest
-                            ? '-translate-y-1 ring-2 ring-ds-success motion-safe:animate-pulse'
-                            : '';
+                        const { category, ring } = hiLoRingStyle(inBest, inLo);
                         return (
                           <div
                             key={`${card.design}-${card.value}`}
                             className={`transition-all ${ring} ${dim ? 'opacity-50' : ''}`}
                             data-best5-hole={inBest || undefined}
+                            data-hilo={category === 'none' ? undefined : category}
                             data-testid={inLo ? 'bigohilo-lo-card' : undefined}
                           >
                             <AnimatedCard card={card} width={cardWidth} style={placeholderCardStyle} />

--- a/frontend/src/utils/omahaHiLoRing.test.ts
+++ b/frontend/src/utils/omahaHiLoRing.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { hiLoRingStyle } from './omahaHiLoRing';
+
+describe('hiLoRingStyle', () => {
+  it('returns a distinct dual ring for a card used by both Hi and Lo', () => {
+    const { category, ring } = hiLoRingStyle(true, true);
+    expect(category).toBe('both');
+    // Dual ring conveys both attributes: outer green ring + inner blue offset.
+    expect(ring).toContain('ring-ds-success');
+    expect(ring).toContain('ring-offset-ds-info');
+  });
+
+  it('returns the green Hi ring for a Hi-only card (no blue)', () => {
+    const { category, ring } = hiLoRingStyle(true, false);
+    expect(category).toBe('hi');
+    expect(ring).toContain('ring-ds-success');
+    expect(ring).not.toContain('ring-ds-info');
+    expect(ring).not.toContain('ring-offset-ds-info');
+  });
+
+  it('returns the blue Lo ring for a Lo-only card (no green)', () => {
+    const { category, ring } = hiLoRingStyle(false, true);
+    expect(category).toBe('lo');
+    expect(ring).toContain('ring-ds-info');
+    expect(ring).not.toContain('ring-ds-success');
+  });
+
+  it('returns no ring for a card used by neither half', () => {
+    const { category, ring } = hiLoRingStyle(false, false);
+    expect(category).toBe('none');
+    expect(ring).toBe('');
+  });
+});

--- a/frontend/src/utils/omahaHiLoRing.ts
+++ b/frontend/src/utils/omahaHiLoRing.ts
@@ -1,0 +1,35 @@
+/** Which showdown highlight a card qualifies for under the Hi-Lo split. */
+export type HiLoHighlight = 'both' | 'hi' | 'lo' | 'none';
+
+/** A card's Hi-Lo highlight category plus the Tailwind ring classes to render it. */
+export interface HiLoRingStyle {
+  /** Whether the card is used by the Hi hand, the Lo hand, both, or neither. */
+  category: HiLoHighlight;
+  /** Tailwind ring/utility classes conveying the highlight (empty for `none`). */
+  ring: string;
+}
+
+/** Hi-only ring: raised green outline. */
+const HI_RING = '-translate-y-1 ring-2 ring-ds-success motion-safe:animate-pulse';
+/** Lo-only ring: blue outline. */
+const LO_RING = 'ring-2 ring-ds-info motion-safe:animate-pulse';
+/** Dual ring: raised outer green + inner blue offset, so a card used by BOTH
+ * the Hi and the Lo hand shows both attributes at once instead of Lo winning. */
+const BOTH_RING = '-translate-y-1 ring-2 ring-ds-success ring-offset-2 ring-offset-ds-info motion-safe:animate-pulse';
+
+/**
+ * Resolve the showdown highlight for a single card given whether it belongs to
+ * the player's best Hi five and/or their qualifying Lo five. A card used by both
+ * halves gets a distinct dual ring (outer green + inner blue) rather than
+ * collapsing to the Lo (blue) style, so scoop-level hands are verifiable.
+ *
+ * @param inHi - The card is part of the best Hi five-card hand.
+ * @param inLo - The card is part of the qualifying Lo five-card hand.
+ * @returns The highlight category and the ring classes to apply.
+ */
+export function hiLoRingStyle(inHi: boolean, inLo: boolean): HiLoRingStyle {
+  if (inHi && inLo) return { category: 'both', ring: BOTH_RING };
+  if (inHi) return { category: 'hi', ring: HI_RING };
+  if (inLo) return { category: 'lo', ring: LO_RING };
+  return { category: 'none', ring: '' };
+}


### PR DESCRIPTION
## Summary
In 5 Card Omaha Hi-Lo (Big O), the showdown ring logic prioritized Lo over Hi (`inLo ? blue : inBest ? green : ''`), so a card used by **both** the best Hi five and the qualifying Lo five lost its green Hi marker. Scoop-level hands (where overlap is most common) were the hardest to verify.

Now a dual-used card gets a distinct **dual ring** (outer green + inner blue offset), while Hi-only (green) and Lo-only (blue) keep their existing styles. Applies to both the community board and the player's hand.

The Hi and Lo used-card sets were already computed on the page (`omahaBestFive` with `.holeIdx`/`.boardIdx` for Hi; `lowCardIndexSets(lowBestHand, …)` for Lo). This PR only fixes the precedence via a small pure helper — no new evaluation was invented, and no Go was touched.

## Changes
- `frontend/src/utils/omahaHiLoRing.ts` — new pure `hiLoRingStyle(inHi, inLo)` helper returning `{ category, ring }` (`both`/`hi`/`lo`/`none`)
- `frontend/src/utils/omahaHiLoRing.test.ts` — unit tests for all four cases
- `frontend/src/pages/BigOHiLoPage.tsx` — use the helper for both board + hand; add `data-hilo` attribute
- `frontend/src/pages/BigOHiLoPage.test.tsx` — test that a both-card gets the dual style, distinct from hi-only/lo-only

## Acceptance criteria
- [x] Hi/Lo dual-use cards show both attributes simultaneously (dual ring)
- [x] Hi-only / Lo-only cards unchanged
- [x] Applied to both board and hand
- [x] Unit tests added

## Gates
- [x] `bun run check`
- [x] `bun run test` (123 passing incl. new tests)
- [x] `bun run build` (tsc)

Closes #3010

🤖 Generated with [Claude Code](https://claude.com/claude-code)