### PR TITLE
feat(bourre): add settings panel to change cpu difficulty from the gui

### DIFF
--- a/frontend/src/i18n/locales/en/bourre.json
+++ b/frontend/src/i18n/locales/en/bourre.json
@@ -1,5 +1,9 @@
 {
   "title": "Bourré",
+  "settings": {
+    "cpuDifficulty": "CPU difficulty",
+    "cpuDifficultyNote": "Difficulty changes take effect from the next game."
+  },
   "decideSummary": "Pot: {{pot}} chips | Play and win no tricks: {{penalty}}-chip penalty (folding avoids it)",
   "decideSummaryHelp": "If you play and take zero tricks you are 'bourréd' and pay {{penalty}} chips. Folding incurs no penalty.",
   "label": {

--- a/frontend/src/i18n/locales/ja/bourre.json
+++ b/frontend/src/i18n/locales/ja/bourre.json
@@ -1,5 +1,9 @@
 {
   "title": "ブーレ",
+  "settings": {
+    "cpuDifficulty": "CPU難易度",
+    "cpuDifficultyNote": "難易度の変更は次のゲームから反映されます。"
+  },
   "decideSummary": "ポット: {{pot}}チップ | 参加して0トリックだと罰金 {{penalty}}チップ（降りれば罰金なし）",
   "decideSummaryHelp": "「参加」して1トリックも取れないと「ブーレ」となり {{penalty}}チップを支払います。「降りる」を選べば罰金はありません。",
   "label": {

--- a/frontend/src/pages/BourrePage.test.tsx
+++ b/frontend/src/pages/BourrePage.test.tsx
@@ -361,6 +361,42 @@ describe('BourrePage', () => {
     });
   });
 
+  it('settings: changing CPU difficulty resets the game with the config', async () => {
+    renderWithProviders(<BourrePage />);
+    const select = (await screen.findByTestId('bourre-difficulty')) as HTMLSelectElement;
+    expect(select.value).toBe('0');
+    fireEvent.change(select, { target: { value: '2' } });
+    await waitFor(() => {
+      expect(mockExec).toHaveBeenCalledWith(
+        expect.objectContaining({ command: 'reset', config: { cpuDifficulty: 2 } }),
+      );
+    });
+    expect(select.value).toBe('2');
+  });
+
+  it('settings: the next-game button reuses the selected CPU difficulty', async () => {
+    // At game end the footer button fires reset directly (no confirm dialog).
+    mockExec.mockResolvedValue(
+      makeState({
+        phase: 'gameEnd',
+        gameEndFlag: true,
+        winnerIdx: 0,
+        results: [{ playerIdx: 0, tricks: 5, wonAmount: 50, bourreed: false, folded: false }],
+      }),
+    );
+    renderWithProviders(<BourrePage />);
+    const select = (await screen.findByTestId('bourre-difficulty')) as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: '1' } });
+    await waitFor(() => expect(select.value).toBe('1'));
+    mockExec.mockClear();
+    fireEvent.click(screen.getByRole('button', { name: '次のゲーム' }));
+    await waitFor(() => {
+      expect(mockExec).toHaveBeenCalledWith(
+        expect.objectContaining({ command: 'reset', config: { cpuDifficulty: 1 } }),
+      );
+    });
+  });
+
   it('toggles CLI mode', async () => {
     renderWithProviders(<BourrePage />);
     await waitFor(() => expect(screen.getByText(/CPU 1/)).toBeInTheDocument());

--- a/frontend/src/pages/BourrePage.tsx
+++ b/frontend/src/pages/BourrePage.tsx
@@ -3,6 +3,7 @@ import { bourreApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
 import { CliToggle } from '../components/cli/CliToggle';
+import { SettingsPanel } from '../components/common/SettingsPanel';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
@@ -35,6 +36,13 @@ type ApiArgs = {
 };
 
 const BOURRE_PENALTY_WARN_THRESHOLD = 10;
+
+// Values match the Go domain constants (BourreConfig.go): 0=Normal, 1=Easy, 2=Hard.
+const DIFFICULTY_OPTIONS = [
+  { value: '0', label: 'Normal' },
+  { value: '1', label: 'Easy' },
+  { value: '2', label: 'Hard' },
+];
 
 /** Plain-text trump-suit glyph for the CLI formatter: a suit symbol, or '-' when unset. */
 function trumpSuitText(design: string): string {
@@ -134,10 +142,11 @@ function BourrePageContent() {
   const { playSound } = useSound();
 
   const [selectedCards, setSelectedCards] = useState<Set<number>>(new Set());
+  const [cpuDifficulty, setCpuDifficulty] = useState(0);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: mount-only reset
   useEffect(() => {
-    void apiCall({ command: 'reset' });
+    void apiCall({ command: 'reset', config: { cpuDifficulty } });
   }, []);
 
   const phase = state?.phase ?? '';
@@ -181,8 +190,16 @@ function BourrePageContent() {
     void apiCall({ command: 'next' });
   }, [apiCall]);
   const handleReset = useCallback(() => {
-    void apiCall({ command: 'reset' });
-  }, [apiCall]);
+    void apiCall({ command: 'reset', config: { cpuDifficulty } });
+  }, [apiCall, cpuDifficulty]);
+
+  const handleDifficultyChange = useCallback(
+    (value: number) => {
+      setCpuDifficulty(value);
+      void apiCall({ command: 'reset', config: { cpuDifficulty: value } });
+    },
+    [apiCall],
+  );
 
   const toggleCard = useCallback((idx: number) => {
     setSelectedCards((prev) => {
@@ -405,6 +422,25 @@ function BourrePageContent() {
           />
         </div>
       )}
+      <SettingsPanel
+        title={tc('settings.title')}
+        groups={[
+          {
+            items: [
+              {
+                type: 'select' as const,
+                id: 'cpuDifficulty',
+                label: t('settings.cpuDifficulty'),
+                tooltip: t('settings.cpuDifficultyNote'),
+                value: String(cpuDifficulty),
+                options: DIFFICULTY_OPTIONS,
+                onSelect: (v: string) => handleDifficultyChange(Number.parseInt(v, 10)),
+                testId: 'bourre-difficulty',
+              },
+            ],
+          },
+        ]}
+      />
       <GameFooter className={gameTheme.bourre.footer}>
         <GameResetButton
           isGameEnd={isGameEnd}


### PR DESCRIPTION
## 概要

`BourrePage` に `SettingsPanel` を追加し、GUI から CPU 難易度（Easy / Normal / Hard）を変更できるようにしました。従来 CPU 難易度は CLI モードの `sd [0-2]` コマンドでしか変更できず、GUI のリセットは常に config なしで発行されていました。バックエンド (`BourreWebController` → `BourreConfig`) はすでに `cpuDifficulty` を受け付けているため、フロントエンドのみの変更です（`TichuPage` と同じパターン）。

## 変更内容

- `cpuDifficulty` state + `handleDifficultyChange` を追加
- `SettingsPanel`（select: Normal/Easy/Hard、`data-testid="bourre-difficulty"`）を追加
- 難易度変更時に `apiCall({ command: 'reset', config: { cpuDifficulty } })` を発行
- `handleReset` とマウント時リセットも現在の難易度を引き継ぐように変更
- i18n（ja/en）に `settings.cpuDifficulty` と次ゲーム反映の注記 `settings.cpuDifficultyNote` を追加
- `BourrePage.test.tsx` に難易度変更テストとリセット引き継ぎテストを追加

## 受け入れ条件

- [x] GUI の設定パネルから CPU 難易度を変更できる
- [x] 難易度変更でゲームがリセットされ config が反映される
- [x] リセット（次のゲーム）ボタンでも選択中の難易度が維持される
- [x] `BourrePage.test.tsx` に設定変更テスト追加

## テスト

- `bun run test -- --run Bourre`: 29 passed
- `bun run check`: exit 0
- `bun run build`: exit 0

Closes #3398

🤖 Generated with [Claude Code](https://claude.com/claude-code)