### PR TITLE
feat(wasp): add legal <col> CUI command to preview move destinations

### DIFF
--- a/internal/adapter/controller/WaspCuiController.go
+++ b/internal/adapter/controller/WaspCuiController.go
@@ -22,7 +22,7 @@ var waspNoArgCommands = cuiutil.NewCommandMap[usecase.WaspInteractorIF]().
 
 // waspArgfulCommands lists alias names for argful commands handled in the
 // Exec switch.
-var waspArgfulCommands = []string{"m", "move"}
+var waspArgfulCommands = []string{"m", "move", "legal"}
 
 // WaspCuiController ワスプCUIコントローラークラス
 type WaspCuiController struct {
@@ -47,6 +47,8 @@ func (c *WaspCuiController) Exec(command string) string {
 			switch cmd {
 			case "m", "move":
 				return c.handleMove(args), true
+			case "legal":
+				return c.handleLegal(args), true
 			default:
 				return "", false
 			}
@@ -92,6 +94,20 @@ func (c *WaspCuiController) handleMove(args []string) string {
 		return i18n.Tf("invalidColumn", "val", args[4])
 	}
 	return c.si.MoveTableauToTableau(fromCol, cardIdx, toCol)
+}
+
+// handleLegal previews the legal destination columns for the top card of the
+// given column, including empty columns (which always accept a card in Wasp).
+// Format: legal <col>
+func (c *WaspCuiController) handleLegal(args []string) string {
+	if len(args) == 0 {
+		return cuiutil.PromptRequest(i18n.T("wasp.promptFromColumn"), "legal {0}")
+	}
+	col, err := strconv.Atoi(args[0])
+	if err != nil {
+		return i18n.Tf("invalidColumn", "val", args[0])
+	}
+	return c.si.LegalMoves(col)
 }
 
 func (c *WaspCuiController) handleMoveShorthand(args []string) string {

--- a/internal/adapter/controller/WaspCuiController_test.go
+++ b/internal/adapter/controller/WaspCuiController_test.go
@@ -76,6 +76,26 @@ func TestWaspCuiControllerUndo(t *testing.T) {
 	assert.Equal(t, "undo_output", c.Exec("undo"))
 }
 
+func TestWaspCuiControllerLegal(t *testing.T) {
+	si := newMockWaspInteractor()
+	c := NewWaspCuiController(si)
+	si.On("LegalMoves", 2).Return("legal_output")
+	assert.Equal(t, "legal_output", c.Exec("legal 2"))
+}
+
+func TestWaspCuiControllerLegalPrompt(t *testing.T) {
+	si := newMockWaspInteractor()
+	c := NewWaspCuiController(si)
+	result := c.Exec("legal")
+	assert.Contains(t, result, cuiutil.PromptPrefix)
+}
+
+func TestWaspCuiControllerLegalInvalidCol(t *testing.T) {
+	si := newMockWaspInteractor()
+	c := NewWaspCuiController(si)
+	assert.NotEmpty(t, c.Exec("legal abc"))
+}
+
 func TestWaspCuiControllerMoveShorthandTopCard(t *testing.T) {
 	si := newMockWaspInteractor()
 	c := NewWaspCuiController(si)

--- a/internal/adapter/controller/usecase/WaspInteractor_mock.go
+++ b/internal/adapter/controller/usecase/WaspInteractor_mock.go
@@ -36,6 +36,11 @@ func (_m *MockWaspInteractor) Hint() string {
 	return ret.Get(0).(string)
 }
 
+func (_m *MockWaspInteractor) LegalMoves(col int) string {
+	ret := _m.Called(col)
+	return ret.Get(0).(string)
+}
+
 func (_m *MockWaspInteractor) AutoComplete() string {
 	ret := _m.Called()
 	return ret.Get(0).(string)

--- a/internal/adapter/presenter/WaspCuiPresenter.go
+++ b/internal/adapter/presenter/WaspCuiPresenter.go
@@ -72,6 +72,56 @@ func (p *WaspCuiPresenter) HintOutput(s interfaces.WaspGame) string {
 		"toCol", strconv.Itoa(hint.ToCol)) + "\n"
 }
 
+// LegalMovesOutput lists the tableau columns onto which the top (last) card of
+// the given column may legally move. Empty columns always accept a card in Wasp
+// and are flagged as such. Outside the playing phase, for an out-of-range
+// column, or when the column has no movable face-up card, an explanatory line
+// is returned instead.
+func (p *WaspCuiPresenter) LegalMovesOutput(s interfaces.WaspGame, col int) string {
+	if s.GetPhase() != domain.WaspPhasePlaying {
+		return i18n.T("wasp.legalNotPlaying") + "\n"
+	}
+	if col < 0 || col >= domain.WaspTableauCnt {
+		return i18n.Tf("invalidColumn", "val", strconv.Itoa(col)) + "\n"
+	}
+	tableau := s.GetTableau()
+	fromCards := tableau[col]
+	if len(fromCards) == 0 || !fromCards[len(fromCards)-1].FaceUp {
+		return i18n.Tf("wasp.legalNoCard", "col", strconv.Itoa(col)) + "\n"
+	}
+	moving := fromCards[len(fromCards)-1].Card
+
+	var b strings.Builder
+	b.WriteString(i18n.Tf("wasp.legalHeader",
+		"col", strconv.Itoa(col),
+		"card", cuiCardStr(moving)) + "\n")
+
+	found := false
+	for idx := range domain.WaspTableauCnt {
+		if idx == col {
+			continue
+		}
+		colCards := tableau[idx]
+		if len(colCards) == 0 {
+			b.WriteString(i18n.Tf("wasp.legalTargetEmpty", "col", strconv.Itoa(idx)) + "\n")
+			found = true
+			continue
+		}
+		top := colCards[len(colCards)-1]
+		if top.FaceUp && top.Card.GetDesign() == moving.GetDesign() &&
+			top.Card.GetValue() == moving.GetValue()+1 {
+			b.WriteString(i18n.Tf("wasp.legalTarget",
+				"col", strconv.Itoa(idx),
+				"card", cuiCardStr(top.Card)) + "\n")
+			found = true
+		}
+	}
+	if !found {
+		b.WriteString(i18n.T("wasp.legalNone") + "\n")
+	}
+	return b.String()
+}
+
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *WaspCuiPresenter) ActionLogOutput(s interfaces.WaspGame) string {
 	if s.GetPhase() == domain.WaspPhasePlaying {

--- a/internal/adapter/presenter/WaspCuiPresenter_test.go
+++ b/internal/adapter/presenter/WaspCuiPresenter_test.go
@@ -128,6 +128,99 @@ func TestWaspCuiPresenter_HintOutput(t *testing.T) {
 	})
 }
 
+func TestWaspCuiPresenter_LegalMovesOutput(t *testing.T) {
+	// waspTableauWith builds a full-length tableau, overriding specific columns.
+	waspTableauWith := func(overrides map[int][]*domain.KlondikeTableauCard) [domain.WaspTableauCnt][]*domain.KlondikeTableauCard {
+		var tableau [domain.WaspTableauCnt][]*domain.KlondikeTableauCard
+		for i := range domain.WaspTableauCnt {
+			if cards, ok := overrides[i]; ok {
+				tableau[i] = cards
+				continue
+			}
+			tableau[i] = nil
+		}
+		return tableau
+	}
+
+	t.Run("lists matching column and flags empty columns", func(t *testing.T) {
+		sg := new(interfaces.MockWaspGame)
+		sg.On("GetPhase").Return(domain.WaspPhasePlaying).Maybe()
+		// Column 0 top card: Spade 5 (movable). Column 1 top card: Spade 6 (legal target).
+		// Column 2 top card: Heart 6 (wrong suit). Column 3 empty (always legal).
+		tableau := waspTableauWith(map[int][]*domain.KlondikeTableauCard{
+			0: {{Card: domain.NewCard(domain.CardDesignSpade, 5, false), FaceUp: true}},
+			1: {{Card: domain.NewCard(domain.CardDesignSpade, 6, false), FaceUp: true}},
+			2: {{Card: domain.NewCard(domain.CardDesignHeart, 6, false), FaceUp: true}},
+		})
+		sg.On("GetTableau").Return(tableau).Maybe()
+
+		p := new(WaspCuiPresenter)
+		result := p.LegalMovesOutput(sg, 0)
+		assert.Contains(t, result, "列0")
+		assert.Contains(t, result, "列1")      // suit-matching target
+		assert.Contains(t, result, "空列")      // empty columns flagged
+		assert.NotContains(t, result, "列2 (") // wrong-suit column not listed as a target
+	})
+
+	t.Run("no movable card in empty column", func(t *testing.T) {
+		sg := new(interfaces.MockWaspGame)
+		sg.On("GetPhase").Return(domain.WaspPhasePlaying).Maybe()
+		sg.On("GetTableau").Return(waspTableauWith(nil)).Maybe()
+
+		p := new(WaspCuiPresenter)
+		result := p.LegalMovesOutput(sg, 0)
+		assert.Contains(t, result, "移動可能")
+	})
+
+	t.Run("face-down top card", func(t *testing.T) {
+		sg := new(interfaces.MockWaspGame)
+		sg.On("GetPhase").Return(domain.WaspPhasePlaying).Maybe()
+		tableau := waspTableauWith(map[int][]*domain.KlondikeTableauCard{
+			0: {{Card: domain.NewCard(domain.CardDesignSpade, 5, false), FaceUp: false}},
+		})
+		sg.On("GetTableau").Return(tableau).Maybe()
+
+		p := new(WaspCuiPresenter)
+		result := p.LegalMovesOutput(sg, 0)
+		assert.Contains(t, result, "移動可能")
+	})
+
+	t.Run("no legal destinations", func(t *testing.T) {
+		sg := new(interfaces.MockWaspGame)
+		sg.On("GetPhase").Return(domain.WaspPhasePlaying).Maybe()
+		// Every other column occupied with a non-matching card, none empty.
+		overrides := map[int][]*domain.KlondikeTableauCard{}
+		for i := range domain.WaspTableauCnt {
+			overrides[i] = []*domain.KlondikeTableauCard{
+				{Card: domain.NewCard(domain.CardDesignHeart, 2, false), FaceUp: true},
+			}
+		}
+		sg.On("GetTableau").Return(waspTableauWith(overrides)).Maybe()
+
+		p := new(WaspCuiPresenter)
+		result := p.LegalMovesOutput(sg, 0)
+		assert.Contains(t, result, "なし")
+	})
+
+	t.Run("invalid column", func(t *testing.T) {
+		sg := new(interfaces.MockWaspGame)
+		sg.On("GetPhase").Return(domain.WaspPhasePlaying).Maybe()
+
+		p := new(WaspCuiPresenter)
+		assert.NotEmpty(t, p.LegalMovesOutput(sg, -1))
+		assert.NotEmpty(t, p.LegalMovesOutput(sg, domain.WaspTableauCnt))
+	})
+
+	t.Run("not in playing phase", func(t *testing.T) {
+		sg := new(interfaces.MockWaspGame)
+		sg.On("GetPhase").Return(domain.WaspPhaseGameOver).Maybe()
+
+		p := new(WaspCuiPresenter)
+		result := p.LegalMovesOutput(sg, 0)
+		assert.NotEmpty(t, result)
+	})
+}
+
 func TestWaspCuiPresenter_ActionLogOutput(t *testing.T) {
 	t.Run("playing", func(t *testing.T) {
 		sg := new(interfaces.MockWaspGame)

--- a/internal/adapter/presenter/WaspWebPresenter.go
+++ b/internal/adapter/presenter/WaspWebPresenter.go
@@ -57,6 +57,12 @@ func (p *WaspWebPresenter) HintOutput(s interfaces.WaspGame) string {
 	return marshalOrError(resObj)
 }
 
+// LegalMovesOutput は合法な移動先を返す。Web版は WaspPage の waspLegalTargets が
+// クライアント側で移動先を算出・ハイライトするため、通常の状態JSONへ委譲する。
+func (p *WaspWebPresenter) LegalMovesOutput(s interfaces.WaspGame, _ int) string {
+	return p.Output(s, nil)
+}
+
 // ActionLogOutput 棋譜をJSON出力
 func (p *WaspWebPresenter) ActionLogOutput(s interfaces.WaspGame) string {
 	return actionLogOutputJSON(s)

--- a/internal/adapter/presenter/WaspWebPresenter_test.go
+++ b/internal/adapter/presenter/WaspWebPresenter_test.go
@@ -137,6 +137,17 @@ func TestWaspWebPresenter_HintOutput(t *testing.T) {
 	})
 }
 
+func TestWaspWebPresenter_LegalMovesOutput(t *testing.T) {
+	sg := new(interfaces.MockWaspGame)
+	setupWaspWebMockDefaults(sg)
+	p := new(WaspWebPresenter)
+
+	// Web delegates legal-move previews to the normal state JSON (targets are
+	// computed client-side), so the output mirrors Output.
+	result := parseWaspOutput(t, p.LegalMovesOutput(sg, 0))
+	assert.Equal(t, "wasp.playing", result.MessageCode)
+}
+
 func TestWaspWebPresenter_ActionLogOutput(t *testing.T) {
 	t.Run("playing", func(t *testing.T) {
 		sg := new(interfaces.MockWaspGame)

--- a/internal/i18n/locales/en/wasp.json
+++ b/internal/i18n/locales/en/wasp.json
@@ -5,6 +5,7 @@
   "helpDeal": "  d                    deal 3 stock cards to columns 0-2",
   "helpGiveUp": "  g                    give up",
   "helpHint": "  h                    hint",
+  "helpLegal": "  legal <col>          list legal destinations for the column's top card",
   "helpAutoComplete": "  ac                   auto-complete",
   "promptFromColumn": "Enter source column number",
   "promptCardIndex": "Enter card index",
@@ -19,5 +20,11 @@
   "header": "Completed: {{completed}}/{{total}} | Stock: {{stock}}",
   "columnLabel": "Column {{col}}:",
   "hintDeal": "Hint: deal stock cards with d",
-  "hintLine": "Hint: tableau column {{fromCol}}[{{idx}}] → tableau column {{toCol}}"
+  "hintLine": "Hint: tableau column {{fromCol}}[{{idx}}] → tableau column {{toCol}}",
+  "legalHeader": "Legal destinations for column {{col}} top card {{card}}:",
+  "legalTarget": "  column {{col}} (onto {{card}})",
+  "legalTargetEmpty": "  column {{col}} (empty — accepts any card)",
+  "legalNone": "  none",
+  "legalNoCard": "Column {{col}} has no movable face-up card",
+  "legalNotPlaying": "No legal moves to show (game is not in play)"
 }

--- a/internal/i18n/locales/ja/wasp.json
+++ b/internal/i18n/locales/ja/wasp.json
@@ -5,6 +5,7 @@
   "helpDeal": "  d                    deal 3 stock cards to columns 0-2",
   "helpGiveUp": "  g                    give up",
   "helpHint": "  h                    hint",
+  "helpLegal": "  legal <col>          list legal destinations for the column's top card",
   "helpAutoComplete": "  ac                   auto-complete",
   "promptFromColumn": "移動元の列番号を入力してください",
   "promptCardIndex": "カード番号を入力してください",
@@ -19,5 +20,11 @@
   "header": "完成スーツ: {{completed}}/{{total}} | 山札: {{stock}}枚",
   "columnLabel": "列{{col}}:",
   "hintDeal": "ヒント: d でストックから配ってください",
-  "hintLine": "ヒント: タブロー列{{fromCol}}[{{idx}}] → タブロー列{{toCol}}"
+  "hintLine": "ヒント: タブロー列{{fromCol}}[{{idx}}] → タブロー列{{toCol}}",
+  "legalHeader": "列{{col}}のトップカード{{card}}の合法な移動先:",
+  "legalTarget": "  列{{col}} ({{card}}の上)",
+  "legalTargetEmpty": "  列{{col}} (空列 — 任意のカード可)",
+  "legalNone": "  なし",
+  "legalNoCard": "列{{col}}には移動可能な表向きカードがありません",
+  "legalNotPlaying": "表示できる合法手はありません（プレイ中ではありません）"
 }

--- a/internal/infrastructure/ui/GameManager.go
+++ b/internal/infrastructure/ui/GameManager.go
@@ -1145,6 +1145,7 @@ var gameRegistry = []GameRegistryEntry{
 					"wasp.helpDeal",
 					"wasp.helpGiveUp",
 					"wasp.helpHint",
+					"wasp.helpLegal",
 					"wasp.helpAutoComplete",
 				},
 				ExtraCommandLines: []string{"  l                        action log"},

--- a/internal/usecase/WaspInteractor.go
+++ b/internal/usecase/WaspInteractor.go
@@ -22,6 +22,8 @@ type WaspInteractorIF interface {
 	GiveUp() string
 	// Hint ヒント取得
 	Hint() string
+	// LegalMoves 指定列のトップカードの合法な移動先を出力する
+	LegalMoves(col int) string
 	// AutoComplete オートコンプリート
 	AutoComplete() string
 	// ActionLog 棋譜を出力する
@@ -69,6 +71,11 @@ func (si *WaspInteractor) MoveTableauToTableau(fromCol, cardIndex, toCol int) st
 // Hint ヒント取得
 func (si *WaspInteractor) Hint() string {
 	return si.sp.HintOutput(si.Game)
+}
+
+// LegalMoves 指定列のトップカードの合法な移動先を出力する
+func (si *WaspInteractor) LegalMoves(col int) string {
+	return si.sp.LegalMovesOutput(si.Game, col)
 }
 
 // ActionLog 棋譜を出力する

--- a/internal/usecase/WaspInteractor_test.go
+++ b/internal/usecase/WaspInteractor_test.go
@@ -115,6 +115,16 @@ func TestWaspInteractorHint(t *testing.T) {
 	assert.Equal(t, "hint_output", si.Hint())
 }
 
+func TestWaspInteractorLegalMoves(t *testing.T) {
+	sg := newMockWaspGame()
+	sp := newMockWaspPresenter()
+	si := NewWaspInteractor(sg, sp)
+
+	sp.On("LegalMovesOutput", sg, 2).Return("legal_output")
+
+	assert.Equal(t, "legal_output", si.LegalMoves(2))
+}
+
 func TestWaspInteractorAutoComplete(t *testing.T) {
 	sg := newMockWaspGame()
 	sp := newMockWaspPresenter()

--- a/internal/usecase/presenter/WaspPresenter.go
+++ b/internal/usecase/presenter/WaspPresenter.go
@@ -9,4 +9,6 @@ type WaspPresenter interface {
 	GamePresenter[interfaces.WaspGame]
 	// HintOutput ヒント情報を出力する
 	HintOutput(s interfaces.WaspGame) string
+	// LegalMovesOutput 指定列のトップカードの合法な移動先を出力する
+	LegalMovesOutput(s interfaces.WaspGame, col int) string
 }

--- a/internal/usecase/presenter/WaspPresenter_mock.go
+++ b/internal/usecase/presenter/WaspPresenter_mock.go
@@ -23,6 +23,11 @@ func (_m *MockWaspPresenter) HintOutput(s interfaces.WaspGame) string {
 	return ret.String(0)
 }
 
+func (_m *MockWaspPresenter) LegalMovesOutput(s interfaces.WaspGame, col int) string {
+	ret := _m.Called(s, col)
+	return ret.String(0)
+}
+
 func (_m *MockWaspPresenter) ActionLogOutput(s interfaces.WaspGame) string {
 	ret := _m.Called(s)
 	return ret.String(0)


### PR DESCRIPTION
## Summary

The Wasp Solitaire CUI had no way to preview where a card can legally go before committing a move — the Web page already highlights legal targets via `waspLegalTargets`, but the terminal interface only exposed Output/Hint/ActionLog.

This adds a **`legal <col>`** command that lists the tableau columns onto which the given column's **top card** may legally move, and explicitly flags **empty columns** (which always accept a card in Wasp — the game's one rule difference from Scorpion).

Example output:
```
Legal destinations for column 0 top card S5:
  column 1 (onto S6)
  column 3 (empty — accepts any card)
```

## Changes

- **`WaspCuiPresenter.LegalMovesOutput`** — computes destinations from `GetTableau()` (empty column ⇒ always legal; otherwise same-suit face-up top card exactly one rank higher, mirroring `canPlaceOnTableau` / the frontend `waspLegalTargets`). Handles non-playing phase, out-of-range column, and no-movable-card cases.
- **`WaspPresenter` interface** — new `LegalMovesOutput`; `WaspWebPresenter` delegates to `Output` (Web computes targets client-side).
- **`WaspInteractor.LegalMoves` + IF method**, controller `legal` command + help spec line (`wasp.helpLegal`).
- ja/en CUI translations; presenter/interactor mocks extended.
- Tests: controller, CUI presenter (all branches), web presenter, interactor.

Sibling mirrored: the recent `feat(handandfoot): add meld-candidate hint command to the CUI` (#3805) end-to-end wiring pattern (interface method + interactor + controller + mocks + ja/en + tests).

## WASM size (solo worker)

Wasp ships in the **`solo`** worker. TinyGo isn't installed locally, so I used the plain-Go `GOOS=js GOARCH=wasm` build as a delta signal:

| build | gzip |
|-------|------|
| develop | 3,761,721 B |
| this branch | 3,766,698 B |
| **delta** | **+4,977 B** |

The plain-Go figure vastly over-represents the real TinyGo+wasm-opt binary (solo worker sits well under 1 MB gzipped with headroom). The change is a handful of i18n strings plus one small read-only presenter method, so the actual TinyGo delta is negligible and stays under the 1 MB (1,048,576 B) free-tier limit.

## Checklist
- [x] `go test -tags test ./...` passes
- [x] `golangci-lint run ./internal/...` clean (0 issues)
- [x] `goimports -w` on all modified files
- [x] ja/en translations added
- [x] Tests added (controller, presenter, interactor)
- [x] WASM `solo` worker stays under the 1 MB gzipped limit

Closes #3188