### PR TITLE
feat(scorpion): add legal <col> CUI command to preview move destinations

### DIFF
--- a/internal/adapter/controller/ScorpionCuiController.go
+++ b/internal/adapter/controller/ScorpionCuiController.go
@@ -22,7 +22,7 @@ var scorpionNoArgCommands = cuiutil.NewCommandMap[usecase.ScorpionInteractorIF](
 
 // scorpionArgfulCommands lists alias names for argful commands handled in the
 // Exec switch.
-var scorpionArgfulCommands = []string{"m", "move"}
+var scorpionArgfulCommands = []string{"m", "move", "legal"}
 
 // ScorpionCuiController スコーピオンCUIコントローラークラス
 type ScorpionCuiController struct {
@@ -47,6 +47,8 @@ func (c *ScorpionCuiController) Exec(command string) string {
 			switch cmd {
 			case "m", "move":
 				return c.handleMove(args), true
+			case "legal":
+				return c.handleLegal(args), true
 			default:
 				return "", false
 			}
@@ -92,6 +94,20 @@ func (c *ScorpionCuiController) handleMove(args []string) string {
 		return i18n.Tf("invalidColumn", "val", args[4])
 	}
 	return c.si.MoveTableauToTableau(fromCol, cardIdx, toCol)
+}
+
+// handleLegal previews the legal destination columns for the top card of the
+// given column. In Scorpion an empty column only accepts a King.
+// Format: legal <col>
+func (c *ScorpionCuiController) handleLegal(args []string) string {
+	if len(args) == 0 {
+		return cuiutil.PromptRequest(i18n.T("scorpion.promptFromColumn"), "legal {0}")
+	}
+	col, err := strconv.Atoi(args[0])
+	if err != nil {
+		return i18n.Tf("invalidColumn", "val", args[0])
+	}
+	return c.si.LegalMoves(col)
 }
 
 func (c *ScorpionCuiController) handleMoveShorthand(args []string) string {

--- a/internal/adapter/controller/ScorpionCuiController_test.go
+++ b/internal/adapter/controller/ScorpionCuiController_test.go
@@ -36,6 +36,26 @@ func TestScorpionCuiControllerDeal(t *testing.T) {
 	assert.Equal(t, "deal_output", c.Exec("deal"))
 }
 
+func TestScorpionCuiControllerLegal(t *testing.T) {
+	si := newMockScorpionInteractor()
+	c := NewScorpionCuiController(si)
+	si.On("LegalMoves", 2).Return("legal_output")
+	assert.Equal(t, "legal_output", c.Exec("legal 2"))
+}
+
+func TestScorpionCuiControllerLegalPrompt(t *testing.T) {
+	si := newMockScorpionInteractor()
+	c := NewScorpionCuiController(si)
+	result := c.Exec("legal")
+	assert.Contains(t, result, cuiutil.PromptPrefix)
+}
+
+func TestScorpionCuiControllerLegalInvalidCol(t *testing.T) {
+	si := newMockScorpionInteractor()
+	c := NewScorpionCuiController(si)
+	assert.NotEmpty(t, c.Exec("legal abc"))
+}
+
 func TestScorpionCuiControllerGiveUp(t *testing.T) {
 	si := newMockScorpionInteractor()
 	c := NewScorpionCuiController(si)

--- a/internal/adapter/controller/usecase/ScorpionInteractor_mock.go
+++ b/internal/adapter/controller/usecase/ScorpionInteractor_mock.go
@@ -36,6 +36,11 @@ func (_m *MockScorpionInteractor) Hint() string {
 	return ret.Get(0).(string)
 }
 
+func (_m *MockScorpionInteractor) LegalMoves(col int) string {
+	ret := _m.Called(col)
+	return ret.Get(0).(string)
+}
+
 func (_m *MockScorpionInteractor) AutoComplete() string {
 	ret := _m.Called()
 	return ret.Get(0).(string)

--- a/internal/adapter/presenter/ScorpionCuiPresenter.go
+++ b/internal/adapter/presenter/ScorpionCuiPresenter.go
@@ -72,6 +72,59 @@ func (p *ScorpionCuiPresenter) HintOutput(s interfaces.ScorpionGame) string {
 		"toCol", strconv.Itoa(hint.ToCol)) + "\n"
 }
 
+// LegalMovesOutput lists the tableau columns onto which the top (last) card of
+// the given column may legally move. In Scorpion an empty column only accepts a
+// King, so empty columns are listed only when the moving card is a King.
+// Outside the playing phase, for an out-of-range column, or when the column has
+// no movable face-up card, an explanatory line is returned instead.
+func (p *ScorpionCuiPresenter) LegalMovesOutput(s interfaces.ScorpionGame, col int) string {
+	if s.GetPhase() != domain.ScorpionPhasePlaying {
+		return i18n.T("scorpion.legalNotPlaying") + "\n"
+	}
+	if col < 0 || col >= domain.ScorpionTableauCnt {
+		return i18n.Tf("invalidColumn", "val", strconv.Itoa(col)) + "\n"
+	}
+	tableau := s.GetTableau()
+	fromCards := tableau[col]
+	if len(fromCards) == 0 || !fromCards[len(fromCards)-1].FaceUp {
+		return i18n.Tf("scorpion.legalNoCard", "col", strconv.Itoa(col)) + "\n"
+	}
+	moving := fromCards[len(fromCards)-1].Card
+	isKing := moving.GetValue() == domain.CardValueMax
+
+	var b strings.Builder
+	b.WriteString(i18n.Tf("scorpion.legalHeader",
+		"col", strconv.Itoa(col),
+		"card", cuiCardStr(moving)) + "\n")
+
+	found := false
+	for idx := range domain.ScorpionTableauCnt {
+		if idx == col {
+			continue
+		}
+		colCards := tableau[idx]
+		if len(colCards) == 0 {
+			if isKing {
+				b.WriteString(i18n.Tf("scorpion.legalTargetEmpty", "col", strconv.Itoa(idx)) + "\n")
+				found = true
+			}
+			continue
+		}
+		top := colCards[len(colCards)-1]
+		if top.FaceUp && top.Card.GetDesign() == moving.GetDesign() &&
+			top.Card.GetValue() == moving.GetValue()+1 {
+			b.WriteString(i18n.Tf("scorpion.legalTarget",
+				"col", strconv.Itoa(idx),
+				"card", cuiCardStr(top.Card)) + "\n")
+			found = true
+		}
+	}
+	if !found {
+		b.WriteString(i18n.T("scorpion.legalNone") + "\n")
+	}
+	return b.String()
+}
+
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *ScorpionCuiPresenter) ActionLogOutput(s interfaces.ScorpionGame) string {
 	if s.GetPhase() == domain.ScorpionPhasePlaying {

--- a/internal/adapter/presenter/ScorpionCuiPresenter_test.go
+++ b/internal/adapter/presenter/ScorpionCuiPresenter_test.go
@@ -128,6 +128,113 @@ func TestScorpionCuiPresenter_HintOutput(t *testing.T) {
 	})
 }
 
+func TestScorpionCuiPresenter_LegalMovesOutput(t *testing.T) {
+	// scorpionTableauWith builds a full-length tableau, overriding specific columns.
+	scorpionTableauWith := func(overrides map[int][]*domain.KlondikeTableauCard) [domain.ScorpionTableauCnt][]*domain.KlondikeTableauCard {
+		var tableau [domain.ScorpionTableauCnt][]*domain.KlondikeTableauCard
+		for i := range domain.ScorpionTableauCnt {
+			if cards, ok := overrides[i]; ok {
+				tableau[i] = cards
+			}
+		}
+		return tableau
+	}
+
+	t.Run("lists suit-matching column, empty not flagged for non-King", func(t *testing.T) {
+		sg := new(interfaces.MockScorpionGame)
+		sg.On("GetPhase").Return(domain.ScorpionPhasePlaying).Maybe()
+		// Column 0 top card: Spade 5 (movable, non-King). Column 1 top: Spade 6 (legal target).
+		// Column 2 top: Heart 6 (wrong suit). Column 3 empty (NOT legal for a non-King in Scorpion).
+		tableau := scorpionTableauWith(map[int][]*domain.KlondikeTableauCard{
+			0: {{Card: domain.NewCard(domain.CardDesignSpade, 5, false), FaceUp: true}},
+			1: {{Card: domain.NewCard(domain.CardDesignSpade, 6, false), FaceUp: true}},
+			2: {{Card: domain.NewCard(domain.CardDesignHeart, 6, false), FaceUp: true}},
+		})
+		sg.On("GetTableau").Return(tableau).Maybe()
+
+		p := new(ScorpionCuiPresenter)
+		result := p.LegalMovesOutput(sg, 0)
+		assert.Contains(t, result, "列0")
+		assert.Contains(t, result, "列1")    // suit-matching target
+		assert.NotContains(t, result, "空列") // empty columns NOT accepted for non-King
+	})
+
+	t.Run("flags empty columns for a King", func(t *testing.T) {
+		sg := new(interfaces.MockScorpionGame)
+		sg.On("GetPhase").Return(domain.ScorpionPhasePlaying).Maybe()
+		// Column 0 top card: Spade King (movable). Column 3 empty (legal for a King).
+		tableau := scorpionTableauWith(map[int][]*domain.KlondikeTableauCard{
+			0: {{Card: domain.NewCard(domain.CardDesignSpade, domain.CardValueMax, false), FaceUp: true}},
+		})
+		sg.On("GetTableau").Return(tableau).Maybe()
+
+		p := new(ScorpionCuiPresenter)
+		result := p.LegalMovesOutput(sg, 0)
+		assert.Contains(t, result, "空列")
+	})
+
+	t.Run("no movable card in empty column", func(t *testing.T) {
+		sg := new(interfaces.MockScorpionGame)
+		sg.On("GetPhase").Return(domain.ScorpionPhasePlaying).Maybe()
+		sg.On("GetTableau").Return(scorpionTableauWith(nil)).Maybe()
+
+		p := new(ScorpionCuiPresenter)
+		result := p.LegalMovesOutput(sg, 0)
+		assert.Contains(t, result, "移動可能")
+	})
+
+	t.Run("face-down top card", func(t *testing.T) {
+		sg := new(interfaces.MockScorpionGame)
+		sg.On("GetPhase").Return(domain.ScorpionPhasePlaying).Maybe()
+		tableau := scorpionTableauWith(map[int][]*domain.KlondikeTableauCard{
+			0: {{Card: domain.NewCard(domain.CardDesignSpade, 5, false), FaceUp: false}},
+		})
+		sg.On("GetTableau").Return(tableau).Maybe()
+
+		p := new(ScorpionCuiPresenter)
+		result := p.LegalMovesOutput(sg, 0)
+		assert.Contains(t, result, "移動可能")
+	})
+
+	t.Run("no legal destinations", func(t *testing.T) {
+		sg := new(interfaces.MockScorpionGame)
+		sg.On("GetPhase").Return(domain.ScorpionPhasePlaying).Maybe()
+		// Every other column occupied with a non-matching card, none empty; moving card non-King.
+		overrides := map[int][]*domain.KlondikeTableauCard{}
+		for i := range domain.ScorpionTableauCnt {
+			overrides[i] = []*domain.KlondikeTableauCard{
+				{Card: domain.NewCard(domain.CardDesignHeart, 2, false), FaceUp: true},
+			}
+		}
+		overrides[0] = []*domain.KlondikeTableauCard{
+			{Card: domain.NewCard(domain.CardDesignSpade, 5, false), FaceUp: true},
+		}
+		sg.On("GetTableau").Return(scorpionTableauWith(overrides)).Maybe()
+
+		p := new(ScorpionCuiPresenter)
+		result := p.LegalMovesOutput(sg, 0)
+		assert.Contains(t, result, "なし")
+	})
+
+	t.Run("invalid column", func(t *testing.T) {
+		sg := new(interfaces.MockScorpionGame)
+		sg.On("GetPhase").Return(domain.ScorpionPhasePlaying).Maybe()
+
+		p := new(ScorpionCuiPresenter)
+		assert.NotEmpty(t, p.LegalMovesOutput(sg, -1))
+		assert.NotEmpty(t, p.LegalMovesOutput(sg, domain.ScorpionTableauCnt))
+	})
+
+	t.Run("not in playing phase", func(t *testing.T) {
+		sg := new(interfaces.MockScorpionGame)
+		sg.On("GetPhase").Return(domain.ScorpionPhaseGameOver).Maybe()
+
+		p := new(ScorpionCuiPresenter)
+		result := p.LegalMovesOutput(sg, 0)
+		assert.NotEmpty(t, result)
+	})
+}
+
 func TestScorpionCuiPresenter_ActionLogOutput(t *testing.T) {
 	t.Run("playing", func(t *testing.T) {
 		sg := new(interfaces.MockScorpionGame)

--- a/internal/adapter/presenter/ScorpionWebPresenter.go
+++ b/internal/adapter/presenter/ScorpionWebPresenter.go
@@ -57,6 +57,13 @@ func (p *ScorpionWebPresenter) HintOutput(s interfaces.ScorpionGame) string {
 	return marshalOrError(resObj)
 }
 
+// LegalMovesOutput は合法な移動先を返す。Web版は ScorpionPage が
+// scorpionLegalTargets でクライアント側に移動先を算出・ハイライトするため、
+// 通常の状態JSONへ委譲する。
+func (p *ScorpionWebPresenter) LegalMovesOutput(s interfaces.ScorpionGame, _ int) string {
+	return p.Output(s, nil)
+}
+
 // ActionLogOutput 棋譜をJSON出力
 func (p *ScorpionWebPresenter) ActionLogOutput(s interfaces.ScorpionGame) string {
 	return actionLogOutputJSON(s)

--- a/internal/adapter/presenter/ScorpionWebPresenter_test.go
+++ b/internal/adapter/presenter/ScorpionWebPresenter_test.go
@@ -112,6 +112,17 @@ func TestScorpionWebPresenter_Output(t *testing.T) {
 	})
 }
 
+func TestScorpionWebPresenter_LegalMovesOutput(t *testing.T) {
+	sg := new(interfaces.MockScorpionGame)
+	setupScorpionWebMockDefaults(sg)
+	p := new(ScorpionWebPresenter)
+
+	// Web delegates legal-move previews to the normal state JSON (targets are
+	// computed client-side), so the output mirrors Output.
+	result := parseScorpionOutput(t, p.LegalMovesOutput(sg, 0))
+	assert.Equal(t, "scorpion.playing", result.MessageCode)
+}
+
 func TestScorpionWebPresenter_HintOutput(t *testing.T) {
 	t.Run("with hint", func(t *testing.T) {
 		sg := new(interfaces.MockScorpionGame)

--- a/internal/i18n/locales/en/scorpion.json
+++ b/internal/i18n/locales/en/scorpion.json
@@ -5,6 +5,7 @@
   "helpDeal": "  d                    deal 3 stock cards to columns 0-2",
   "helpGiveUp": "  g                    give up",
   "helpHint": "  h                    hint",
+  "helpLegal": "  legal <col>          list legal destinations for the column's top card",
   "helpAutoComplete": "  ac                   auto-complete",
   "promptFromColumn": "Enter source column number",
   "promptCardIndex": "Enter card index",
@@ -19,5 +20,11 @@
   "header": "Completed: {{completed}}/{{total}} | Stock: {{stock}}",
   "columnLabel": "Column {{col}}:",
   "hintDeal": "Hint: deal stock cards with d",
-  "hintLine": "Hint: tableau column {{fromCol}}[{{idx}}] → tableau column {{toCol}}"
+  "hintLine": "Hint: tableau column {{fromCol}}[{{idx}}] → tableau column {{toCol}}",
+  "legalHeader": "Legal destinations for column {{col}} top card {{card}}:",
+  "legalTarget": "  column {{col}} (onto {{card}})",
+  "legalTargetEmpty": "  column {{col}} (empty — accepts a King)",
+  "legalNone": "  none",
+  "legalNoCard": "Column {{col}} has no movable face-up card",
+  "legalNotPlaying": "No legal moves to show (game is not in play)"
 }

--- a/internal/i18n/locales/ja/scorpion.json
+++ b/internal/i18n/locales/ja/scorpion.json
@@ -5,6 +5,7 @@
   "helpDeal": "  d                    deal 3 stock cards to columns 0-2",
   "helpGiveUp": "  g                    give up",
   "helpHint": "  h                    hint",
+  "helpLegal": "  legal <col>          list legal destinations for the column's top card",
   "helpAutoComplete": "  ac                   auto-complete",
   "promptFromColumn": "移動元の列番号を入力してください",
   "promptCardIndex": "カード番号を入力してください",
@@ -19,5 +20,11 @@
   "header": "完成スーツ: {{completed}}/{{total}} | 山札: {{stock}}枚",
   "columnLabel": "列{{col}}:",
   "hintDeal": "ヒント: d でストックから配ってください",
-  "hintLine": "ヒント: タブロー列{{fromCol}}[{{idx}}] → タブロー列{{toCol}}"
+  "hintLine": "ヒント: タブロー列{{fromCol}}[{{idx}}] → タブロー列{{toCol}}",
+  "legalHeader": "列{{col}}のトップカード{{card}}の合法な移動先:",
+  "legalTarget": "  列{{col}} ({{card}}の上)",
+  "legalTargetEmpty": "  列{{col}} (空列 — Kのみ可)",
+  "legalNone": "  なし",
+  "legalNoCard": "列{{col}}には移動可能な表向きカードがありません",
+  "legalNotPlaying": "表示できる合法手はありません（プレイ中ではありません）"
 }

--- a/internal/infrastructure/ui/GameManager.go
+++ b/internal/infrastructure/ui/GameManager.go
@@ -1128,6 +1128,7 @@ var gameRegistry = []GameRegistryEntry{
 					"scorpion.helpDeal",
 					"scorpion.helpGiveUp",
 					"scorpion.helpHint",
+					"scorpion.helpLegal",
 					"scorpion.helpAutoComplete",
 				},
 				ExtraCommandLines: []string{"  l                        action log"},

--- a/internal/usecase/ScorpionInteractor.go
+++ b/internal/usecase/ScorpionInteractor.go
@@ -22,6 +22,8 @@ type ScorpionInteractorIF interface {
 	GiveUp() string
 	// Hint ヒント取得
 	Hint() string
+	// LegalMoves 指定列のトップカードの合法な移動先を出力する
+	LegalMoves(col int) string
 	// AutoComplete オートコンプリート
 	AutoComplete() string
 	// ActionLog 棋譜を出力する
@@ -69,6 +71,11 @@ func (si *ScorpionInteractor) MoveTableauToTableau(fromCol, cardIndex, toCol int
 // Hint ヒント取得
 func (si *ScorpionInteractor) Hint() string {
 	return si.sp.HintOutput(si.Game)
+}
+
+// LegalMoves 指定列のトップカードの合法な移動先を出力する
+func (si *ScorpionInteractor) LegalMoves(col int) string {
+	return si.sp.LegalMovesOutput(si.Game, col)
 }
 
 // ActionLog 棋譜を出力する

--- a/internal/usecase/ScorpionInteractor_test.go
+++ b/internal/usecase/ScorpionInteractor_test.go
@@ -115,6 +115,16 @@ func TestScorpionInteractorHint(t *testing.T) {
 	assert.Equal(t, "hint_output", si.Hint())
 }
 
+func TestScorpionInteractorLegalMoves(t *testing.T) {
+	sg := newMockScorpionGame()
+	sp := newMockScorpionPresenter()
+	si := NewScorpionInteractor(sg, sp)
+
+	sp.On("LegalMovesOutput", sg, 2).Return("legal_output")
+
+	assert.Equal(t, "legal_output", si.LegalMoves(2))
+}
+
 func TestScorpionInteractorAutoComplete(t *testing.T) {
 	sg := newMockScorpionGame()
 	sp := newMockScorpionPresenter()

--- a/internal/usecase/presenter/ScorpionPresenter.go
+++ b/internal/usecase/presenter/ScorpionPresenter.go
@@ -9,4 +9,6 @@ type ScorpionPresenter interface {
 	GamePresenter[interfaces.ScorpionGame]
 	// HintOutput ヒント情報を出力する
 	HintOutput(s interfaces.ScorpionGame) string
+	// LegalMovesOutput 指定列のトップカードの合法な移動先を出力する
+	LegalMovesOutput(s interfaces.ScorpionGame, col int) string
 }

--- a/internal/usecase/presenter/ScorpionPresenter_mock.go
+++ b/internal/usecase/presenter/ScorpionPresenter_mock.go
@@ -23,6 +23,11 @@ func (_m *MockScorpionPresenter) HintOutput(s interfaces.ScorpionGame) string {
 	return ret.String(0)
 }
 
+func (_m *MockScorpionPresenter) LegalMovesOutput(s interfaces.ScorpionGame, col int) string {
+	ret := _m.Called(s, col)
+	return ret.String(0)
+}
+
 func (_m *MockScorpionPresenter) ActionLogOutput(s interfaces.ScorpionGame) string {
 	ret := _m.Called(s)
 	return ret.String(0)


### PR DESCRIPTION
## Summary
Adds a `legal <col>` command to the Scorpion Solitaire CUI that lists the tableau columns onto which the given column's top card may legally move — so players can preview legality instead of trying a move and hitting an error.

This mirrors the just-merged Wasp twin (#4275 / issue #3188), adapted to Scorpion's real move rules.

### Scorpion's empty-column rule (KEY DIFFERENCE from Wasp)
In Scorpion, an empty column **only accepts a King** (`canPlaceOnTableau` in `internal/domain/Scorpion.go` returns `card.GetValue() == CardValueMax` for empty columns). So empty columns are flagged as legal targets **only when the moving card is a King** — unlike Wasp where empty columns accept any card.

Non-empty targets: same suit, exactly one rank higher than the moving card (descending same-suit build).

## Changes
- `ScorpionCuiPresenter.LegalMovesOutput` — computes destinations from `GetTableau()` (King-to-empty rule applied)
- `ScorpionWebPresenter.LegalMovesOutput` — delegates to `Output` (targets computed client-side by `scorpionLegalTargets`); **required so the WASM `solo` worker compiles**
- `ScorpionPresenter` interface + mock, `ScorpionInteractor.LegalMoves` + IF + interactor mock
- `ScorpionCuiController` — `legal` command + `handleLegal`
- `GameManager` CUI help (`scorpion.helpLegal`) + en/ja translations
- Controller, CUI presenter (all-branches), web presenter, and interactor tests

## Test plan
- [x] `go test -tags test ./...` — all green
- [x] `golangci-lint run ./internal/...` — 0 issues
- [x] `goimports -w` on all modified Go files
- [x] `GOOS=js GOARCH=wasm go build -tags solo -o /dev/null ./cmd/workers/solo/` — **WASM_SOLO_OK** (worker compiles with the new interface method)
- [x] Mirrors Wasp #4275, adapted to Scorpion's King-only empty-column rule

Closes #3185