### PR TITLE
feat(courtpiece): show caller team and unify CUI team labels to A/B

### DIFF
--- a/internal/adapter/presenter/CourtPieceCuiPresenter.go
+++ b/internal/adapter/presenter/CourtPieceCuiPresenter.go
@@ -12,12 +12,23 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
+// courtPieceTeamLabels maps a team index (0/1) to its display name.
+var courtPieceTeamLabels = [domain.CourtPieceTeamCnt]string{"A", "B"}
+
+// courtPieceTeamLabel returns the team label (A/B) for a team index, or "?" when out of range.
+func courtPieceTeamLabel(team int) string {
+	if team < 0 || team >= len(courtPieceTeamLabels) {
+		return "?"
+	}
+	return courtPieceTeamLabels[team]
+}
+
 // courtPiecePlayerStr returns the display string for a single Court Piece player.
 func courtPiecePlayerStr(player *domain.CourtPiecePlayer, i int) string {
 	var b strings.Builder
 	b.WriteString(i18n.Tf("courtpiece.playerLine",
 		"name", cuiPlayerName(player, i),
-		"team", strconv.Itoa(player.GetTeam()),
+		"team", courtPieceTeamLabel(player.GetTeam()),
 		"tricks", strconv.Itoa(player.GetTrickCount()),
 		"cards", strconv.Itoa(player.GetCardsSize()),
 	))
@@ -62,7 +73,8 @@ func (p *CourtPieceCuiPresenter) Output(t interfaces.CourtPieceGame, lastErr err
 		if callerIdx >= 0 {
 			caller := t.GetPlayer(callerIdx)
 			b.WriteString(i18n.Tf("courtpiece.callerLine",
-				"name", cuiPlayerName(caller, callerIdx)) + "\n")
+				"name", cuiPlayerName(caller, callerIdx),
+				"team", courtPieceTeamLabel(caller.GetTeam())) + "\n")
 		}
 
 		for i := 0; i < t.GetPlayerCnt(); i++ {
@@ -81,7 +93,7 @@ func (p *CourtPieceCuiPresenter) Output(t interfaces.CourtPieceGame, lastErr err
 		cuiErrorBlock(b, lastErr)
 
 		if t.GetGameEndFlag() {
-			banner := i18n.Tf("courtpiece.gameEnd", "team", strconv.Itoa(t.GetWinnerTeam()))
+			banner := i18n.Tf("courtpiece.gameEnd", "team", courtPieceTeamLabel(t.GetWinnerTeam()))
 			b.WriteString(color.Green(banner) + "\n")
 			return
 		}

--- a/internal/adapter/presenter/CourtPieceCuiPresenter_test.go
+++ b/internal/adapter/presenter/CourtPieceCuiPresenter_test.go
@@ -71,6 +71,19 @@ func TestCourtPieceCuiPresenter_Output_PhaseLabels(t *testing.T) {
 		out := p.Output(cp, nil)
 		assert.NotEmpty(t, out)
 	})
+
+	t.Run("caller and player lines render with team labels", func(t *testing.T) {
+		cp := newCourtPieceForCuiTest()
+		cp.SetPhase(domain.CourtPiecePhasePlay)
+		cp.SetTrumpSuit(domain.CardDesignSpade)
+		cp.SetCallerIdx(0)
+		out := p.Output(cp, nil)
+		// The caller line (which now carries the caller's team) and one player
+		// line per seat are rendered. Assertions key on the section markers
+		// because i18n templates resolve to their literal keys in tests.
+		assert.Contains(t, out, "courtpiece.callerLine")
+		assert.Contains(t, out, "courtpiece.playerLine")
+	})
 }
 
 func TestCourtPieceCuiPresenter_HintOutput(t *testing.T) {


### PR DESCRIPTION
## Summary
Adds team display to the Court Piece CUI caller line and unifies all team labels to `A`/`B`, matching the Web presenter (`CourtPiecePage.tsx`) and the existing `FortyFivesCuiPresenter` convention.

- Introduce `courtPieceTeamLabel` helper (backed by `courtPieceTeamLabels = {"A","B"}`), mirroring `fortyFivesTeamLabel`.
- `callerLine` now passes the caller's team (`team` param) in addition to the name.
- `playerLine` and the `gameEnd` banner render the team as `A`/`B` instead of the raw `strconv.Itoa(0/1)` index.

## Notes
- Bounded CUI display change; no interface changes, so both CUI and Web presenters are unaffected at the interface level.
- Court Piece belongs to the **casino** worker. Verified the WASM worker still compiles: `GOOS=js GOARCH=wasm go build -tags casino ./cmd/workers/casino/` → **WASM_OK**.
- Court Piece has no Go-side `i18n/locales/{ja,en}/courtpiece.json` (a pre-existing, systemic gap shared only with `tarneeb`), so the CUI resolves `courtpiece.*` keys to their literal key strings today. This change threads the A/B team label through the presenter so it renders correctly once that locale file is added; wiring up the full locale file is out of scope for this focused issue and would break the existing literal-key test assertions.

## Test plan
- [x] `go test -tags test ./...`
- [x] `golangci-lint run ./internal/...` (0 issues)
- [x] `goimports -w` on modified files
- [x] `GOOS=js GOARCH=wasm go build -tags casino ./cmd/workers/casino/` (WASM_OK)

Closes #3450