### PR TITLE
feat(pokersquares): add best-placement hint command to the CUI

### DIFF
--- a/internal/adapter/controller/PokerSquaresCuiController.go
+++ b/internal/adapter/controller/PokerSquaresCuiController.go
@@ -24,7 +24,7 @@ func (c *PokerSquaresCuiController) Exec(command string) string {
 	return execCuiCommand(
 		command,
 		func(_ []string) string { return c.pi.Reset() },
-		[]string{"p", "place", "u", "undo", "g", "giveup", "log", "l"},
+		[]string{"p", "place", "u", "undo", "g", "giveup", "h", "hint", "log", "l"},
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "p", "place":
@@ -33,6 +33,8 @@ func (c *PokerSquaresCuiController) Exec(command string) string {
 				return c.pi.Undo(), true
 			case "g", "giveup":
 				return c.pi.GiveUp(), true
+			case "h", "hint":
+				return c.pi.Hint(), true
 			default:
 				return handleCuiLog(cmd, c.pi.ActionLog)
 			}

--- a/internal/adapter/controller/PokerSquaresCuiController_test.go
+++ b/internal/adapter/controller/PokerSquaresCuiController_test.go
@@ -61,6 +61,14 @@ func TestPokerSquaresCuiController_GiveUp(t *testing.T) {
 	assert.Equal(t, "giveup_output", c.Exec("giveup"))
 }
 
+func TestPokerSquaresCuiController_Hint(t *testing.T) {
+	pi := newMockPokerSquaresInteractor()
+	c := NewPokerSquaresCuiController(pi)
+	pi.On("Hint").Return("hint_output")
+	assert.Equal(t, "hint_output", c.Exec("h"))
+	assert.Equal(t, "hint_output", c.Exec("hint"))
+}
+
 func TestPokerSquaresCuiController_ActionLog(t *testing.T) {
 	pi := newMockPokerSquaresInteractor()
 	c := NewPokerSquaresCuiController(pi)

--- a/internal/adapter/controller/usecase/PokerSquaresInteractor_mock.go
+++ b/internal/adapter/controller/usecase/PokerSquaresInteractor_mock.go
@@ -33,6 +33,12 @@ func (_m *MockPokerSquaresInteractor) GiveUp() string {
 	return ret.Get(0).(string)
 }
 
+// Hint モック
+func (_m *MockPokerSquaresInteractor) Hint() string {
+	ret := _m.Called()
+	return ret.Get(0).(string)
+}
+
 // ActionLog モック
 func (_m *MockPokerSquaresInteractor) ActionLog() string {
 	ret := _m.Called()

--- a/internal/adapter/presenter/PokerSquaresCuiPresenter.go
+++ b/internal/adapter/presenter/PokerSquaresCuiPresenter.go
@@ -70,6 +70,29 @@ func (pr *PokerSquaresCuiPresenter) Output(p interfaces.PokerSquaresGame, lastEr
 	})
 }
 
+// HintOutput emits the best-placement hint for the current card. It suggests
+// the empty cell whose row/column offer the strongest poker-hand synergy, or an
+// explanatory line when no hint is available (game over or no current card).
+func (pr *PokerSquaresCuiPresenter) HintOutput(p interfaces.PokerSquaresGame) string {
+	hint := p.GetHint()
+	if hint == nil {
+		return i18n.T("cuiHintNone") + "\n"
+	}
+	reason := i18n.T("pokersquares.hintAny")
+	if hint.Synergy {
+		reason = i18n.T("pokersquares.hintSynergy")
+	}
+	card := i18n.T("pokersquares.currentCardNone")
+	if cc := p.GetCurrentCard(); cc != nil {
+		card = cuiCardStr(cc)
+	}
+	return i18n.Tf("pokersquares.hintLine",
+		"card", card,
+		"r", strconv.Itoa(hint.Row),
+		"c", strconv.Itoa(hint.Col),
+		"reason", reason) + "\n"
+}
+
 // ActionLogOutput emits the action-log transcript as plain text.
 func (pr *PokerSquaresCuiPresenter) ActionLogOutput(p interfaces.PokerSquaresGame) string {
 	if p.GetPhase() == domain.PokerSquaresPhasePlaying {

--- a/internal/adapter/presenter/PokerSquaresCuiPresenter_test.go
+++ b/internal/adapter/presenter/PokerSquaresCuiPresenter_test.go
@@ -61,6 +61,44 @@ func TestPokerSquaresCuiPresenter_Output_Complete(t *testing.T) {
 	assert.NotContains(t, out, "カードを置く: p")
 }
 
+func TestPokerSquaresCuiPresenter_Hint_Synergy(t *testing.T) {
+	pg := new(interfaces.MockPokerSquaresGame)
+	pg.On("GetHint").Return(&domain.PokerSquaresHint{Row: 1, Col: 2, Score: 6, Synergy: true})
+	pg.On("GetCurrentCard").Return(domain.NewCard(domain.CardDesignSpade, 5, false))
+	p := &PokerSquaresCuiPresenter{}
+	out := p.HintOutput(pg)
+	assert.Contains(t, out, "ヒント")
+	assert.Contains(t, out, "(1,2)")
+	assert.Contains(t, out, "ペア")
+}
+
+func TestPokerSquaresCuiPresenter_Hint_NoSynergy(t *testing.T) {
+	pg := new(interfaces.MockPokerSquaresGame)
+	pg.On("GetHint").Return(&domain.PokerSquaresHint{Row: 0, Col: 0, Score: 0, Synergy: false})
+	pg.On("GetCurrentCard").Return(domain.NewCard(domain.CardDesignHeart, 9, false))
+	p := &PokerSquaresCuiPresenter{}
+	out := p.HintOutput(pg)
+	assert.Contains(t, out, "(0,0)")
+	assert.Contains(t, out, "相乗効果はありません")
+}
+
+func TestPokerSquaresCuiPresenter_Hint_None(t *testing.T) {
+	pg := new(interfaces.MockPokerSquaresGame)
+	pg.On("GetHint").Return((*domain.PokerSquaresHint)(nil))
+	p := &PokerSquaresCuiPresenter{}
+	out := p.HintOutput(pg)
+	assert.Contains(t, out, "ヒントはありません")
+}
+
+func TestPokerSquaresCuiPresenter_Hint_NoCurrentCard(t *testing.T) {
+	pg := new(interfaces.MockPokerSquaresGame)
+	pg.On("GetHint").Return(&domain.PokerSquaresHint{Row: 3, Col: 4, Score: 2, Synergy: true})
+	pg.On("GetCurrentCard").Return((*domain.Card)(nil))
+	p := &PokerSquaresCuiPresenter{}
+	out := p.HintOutput(pg)
+	assert.Contains(t, out, "(3,4)")
+}
+
 func TestPokerSquaresCuiPresenter_ActionLog_Playing(t *testing.T) {
 	pg := new(interfaces.MockPokerSquaresGame)
 	pg.On("GetPhase").Return(domain.PokerSquaresPhasePlaying)

--- a/internal/adapter/presenter/PokerSquaresWebPresenter.go
+++ b/internal/adapter/presenter/PokerSquaresWebPresenter.go
@@ -58,6 +58,13 @@ func (pr *PokerSquaresWebPresenter) Output(p interfaces.PokerSquaresGame, lastEr
 	return marshalOrError(resObj)
 }
 
+// HintOutput はヒントを JSON で出力する。Web GUI はクライアント側の
+// ヒューリスティックヒントを使うため、ここでは JSON 化した状態を返して
+// PokerSquaresPresenter インタフェースを満たす (CUI のみが利用する)。
+func (pr *PokerSquaresWebPresenter) HintOutput(p interfaces.PokerSquaresGame) string {
+	return pr.Output(p, nil)
+}
+
 // ActionLogOutput は棋譜を JSON で出力する。
 func (pr *PokerSquaresWebPresenter) ActionLogOutput(p interfaces.PokerSquaresGame) string {
 	return actionLogOutputJSON(p)

--- a/internal/domain/PokerSquares.go
+++ b/internal/domain/PokerSquares.go
@@ -245,6 +245,76 @@ func (p *PokerSquares) TotalScore() int {
 	return total
 }
 
+// PokerSquaresHint は現在のカードを置く最善のセルを表す配置ヒント。
+type PokerSquaresHint struct {
+	// Row は推奨する行 (0-4)。
+	Row int
+	// Col は推奨する列 (0-4)。
+	Col int
+	// Score はその配置が生む行・列の相乗効果スコア。
+	Score int
+	// Synergy はスコアが正 (既存カードと相乗効果あり) かどうか。
+	Synergy bool
+}
+
+// GetHint は現在のカードを置く最善のセルを返す。
+//
+// 各空きセルについて、そのセルが属する行と列に既にあるカードとの
+// ポーカーハンド相乗効果 (同ランクのペア/スリー、同スートのフラッシュ、
+// 隣接ランクのストレート) を評価し、最も高い合計スコアのセルを推奨する。
+// プレイ中でない、または現在のカードが無い場合は nil を返す。
+func (p *PokerSquares) GetHint() *PokerSquaresHint {
+	if p.phase != PokerSquaresPhasePlaying || p.currentCard == nil {
+		return nil
+	}
+	var best *PokerSquaresHint
+	for r := range PokerSquaresGridSize {
+		for c := range PokerSquaresGridSize {
+			if p.board[r][c] != nil {
+				continue
+			}
+			score := p.scorePlacement(p.currentCard, r, c)
+			if best == nil || score > best.Score {
+				best = &PokerSquaresHint{Row: r, Col: c, Score: score, Synergy: score > 0}
+			}
+		}
+	}
+	return best
+}
+
+// scorePlacement は card を (row, col) に置いたときの行・列の合計相乗効果スコア。
+func (p *PokerSquares) scorePlacement(card *Card, row, col int) int {
+	score := 0
+	for c := range PokerSquaresGridSize {
+		if cell := p.board[row][c]; cell != nil {
+			score += pokerSquaresLineSynergy(card, cell)
+		}
+	}
+	for r := range PokerSquaresGridSize {
+		if cell := p.board[r][col]; cell != nil {
+			score += pokerSquaresLineSynergy(card, cell)
+		}
+	}
+	return score
+}
+
+// pokerSquaresLineSynergy は card と既存カード existing の相乗効果を評価する。
+// ペア/スリー候補が最も強い信号 (x4)、フラッシュ候補が次点 (x2)、
+// ストレート候補が最も弱い (x1)。
+func pokerSquaresLineSynergy(card, existing *Card) int {
+	score := 0
+	if existing.GetValue() == card.GetValue() {
+		score += 4
+	}
+	if existing.GetDesign() == card.GetDesign() {
+		score += 2
+	}
+	if diff := existing.GetValue() - card.GetValue(); diff == 1 || diff == -1 {
+		score++
+	}
+	return score
+}
+
 // pokerSquaresRankToScore はハンドランクを得点に変換する。
 func pokerSquaresRankToScore(rank int) int {
 	if s, ok := pokerSquaresScoreTable[rank]; ok {

--- a/internal/domain/PokerSquares_test.go
+++ b/internal/domain/PokerSquares_test.go
@@ -71,6 +71,61 @@ func TestPokerSquares_PlaceErrors(t *testing.T) {
 	assert.Error(t, g2.Place(0, 0))
 }
 
+func TestPokerSquares_GetHint_NotPlaying(t *testing.T) {
+	g := newPokerSquaresForTest()
+	g.SetCurrentCard(NewCard(CardDesignSpade, 5, false))
+	g.SetPhase(PokerSquaresPhaseComplete)
+	assert.Nil(t, g.GetHint())
+}
+
+func TestPokerSquares_GetHint_NoCurrentCard(t *testing.T) {
+	g := newPokerSquaresForTest()
+	g.SetCurrentCard(nil)
+	assert.Nil(t, g.GetHint())
+}
+
+func TestPokerSquares_GetHint_EmptyBoard(t *testing.T) {
+	g := newPokerSquaresForTest()
+	g.SetCurrentCard(NewCard(CardDesignSpade, 5, false))
+	hint := g.GetHint()
+	assert.NotNil(t, hint)
+	// No existing cards → no synergy; the first empty cell (0,0) is suggested.
+	assert.Equal(t, 0, hint.Row)
+	assert.Equal(t, 0, hint.Col)
+	assert.Equal(t, 0, hint.Score)
+	assert.False(t, hint.Synergy)
+}
+
+func TestPokerSquares_GetHint_ValuePairSynergy(t *testing.T) {
+	g := newPokerSquaresForTest()
+	g.SetCurrentCard(NewCard(CardDesignSpade, 5, false))
+	var b [PokerSquaresGridSize][PokerSquaresGridSize]*Card
+	// A same-value card in row 0 gives every empty row-0 cell a pair bonus (+4).
+	b[0][1] = NewCard(CardDesignHeart, 5, false)
+	g.SetBoard(b)
+
+	hint := g.GetHint()
+	assert.NotNil(t, hint)
+	assert.True(t, hint.Synergy)
+	assert.Equal(t, 4, hint.Score)
+	assert.Equal(t, 0, hint.Row)
+	assert.Equal(t, 0, hint.Col)
+}
+
+func TestPokerSquares_GetHint_SuitAndStraightSynergy(t *testing.T) {
+	g := newPokerSquaresForTest()
+	g.SetCurrentCard(NewCard(CardDesignSpade, 5, false))
+	var b [PokerSquaresGridSize][PokerSquaresGridSize]*Card
+	// Same suit (+2) and adjacent value (+1) in row 0 → +3 for empty row-0 cells.
+	b[0][1] = NewCard(CardDesignSpade, 6, false)
+	g.SetBoard(b)
+
+	hint := g.GetHint()
+	assert.NotNil(t, hint)
+	assert.True(t, hint.Synergy)
+	assert.Equal(t, 3, hint.Score)
+}
+
 func TestPokerSquares_IsCompleteAndPhase(t *testing.T) {
 	g := newPokerSquaresForTest()
 	g.Reset()

--- a/internal/domain/interfaces/poker_squares.go
+++ b/internal/domain/interfaces/poker_squares.go
@@ -39,4 +39,6 @@ type PokerSquaresGame interface {
 	ColScore(c int) int
 	// TotalScore 合計得点を返す
 	TotalScore() int
+	// GetHint 現在のカードを置く最善のセルを返す (無い場合 nil)
+	GetHint() *domain.PokerSquaresHint
 }

--- a/internal/domain/interfaces/poker_squares_mock.go
+++ b/internal/domain/interfaces/poker_squares_mock.go
@@ -116,3 +116,13 @@ func (_m *MockPokerSquaresGame) GetGameEndFlag() bool {
 	ret := _m.Called()
 	return ret.Bool(0)
 }
+
+// GetHint モック
+func (_m *MockPokerSquaresGame) GetHint() *domain.PokerSquaresHint {
+	ret := _m.Called()
+	v := ret.Get(0)
+	if v == nil {
+		return nil
+	}
+	return v.(*domain.PokerSquaresHint)
+}

--- a/internal/i18n/locales/en/pokersquares.json
+++ b/internal/i18n/locales/en/pokersquares.json
@@ -8,5 +8,8 @@
   "currentCardNone": "Current card: (none)",
   "placedLine": "Placed: {{placed}}/{{total}}  Total score: {{score}}",
   "cuiPlaceHint": "Place a card: p <row> <col> or place <row> <col> (0-based, e.g. p 2 3)",
+  "hintLine": "Hint: place {{card}} at ({{r}},{{c}}) - {{reason}}",
+  "hintSynergy": "it pairs, flushes, or extends a straight with cards already in that row/column",
+  "hintAny": "no synergy yet; any empty cell keeps your options open",
   "gameComplete": "Game complete! Total score: {{score}}"
 }

--- a/internal/i18n/locales/ja/pokersquares.json
+++ b/internal/i18n/locales/ja/pokersquares.json
@@ -8,5 +8,8 @@
   "currentCardNone": "手持ちカード: (なし)",
   "placedLine": "配置済み: {{placed}}/{{total}}  合計得点: {{score}}",
   "cuiPlaceHint": "カードを置く: p <行> <列> または place <行> <列> (0始まり, 例 p 2 3)",
+  "hintLine": "ヒント: {{card}} を ({{r}},{{c}}) に置く - {{reason}}",
+  "hintSynergy": "同じ行・列の既存カードとペア/フラッシュ/ストレートを狙えます",
+  "hintAny": "まだ相乗効果はありません。空きセルならどこでも大丈夫です",
   "gameComplete": "ゲーム終了 合計得点: {{score}}"
 }

--- a/internal/infrastructure/ui/GameManager.go
+++ b/internal/infrastructure/ui/GameManager.go
@@ -1023,6 +1023,7 @@ var gameRegistry = []GameRegistryEntry{
 				"  p <row> <col>            カードを配置 (0-4)",
 				"  u                        アンドゥ",
 				"  g                        ギブアップ",
+				"  h                        ヒント (現在のカードの最善配置)",
 				"  l                        action log",
 				"",
 				i18n.T("session"),

--- a/internal/usecase/PokerSquaresInteractor.go
+++ b/internal/usecase/PokerSquaresInteractor.go
@@ -20,6 +20,8 @@ type PokerSquaresInteractorIF interface {
 	Undo() string
 	// GiveUp ギブアップ
 	GiveUp() string
+	// Hint 現在のカードを置く最善のセルのヒントを出力する
+	Hint() string
 	// ActionLog 棋譜を出力する
 	ActionLog() string
 }
@@ -54,6 +56,11 @@ func (pi *PokerSquaresInteractor) Undo() string {
 // GiveUp ギブアップ
 func (pi *PokerSquaresInteractor) GiveUp() string {
 	return runAndPresent(pi.Game, pi.pp, pi.Game.GiveUp)
+}
+
+// Hint 現在のカードを置く最善のセルのヒントを出力する
+func (pi *PokerSquaresInteractor) Hint() string {
+	return pi.pp.HintOutput(pi.Game)
 }
 
 // ActionLog 棋譜を出力する

--- a/internal/usecase/PokerSquaresInteractor_snapshot_test.go
+++ b/internal/usecase/PokerSquaresInteractor_snapshot_test.go
@@ -22,6 +22,10 @@ func (s *stubPokerSquaresPresenter) ActionLogOutput(_ interfaces.PokerSquaresGam
 	return `{"log":[]}`
 }
 
+func (s *stubPokerSquaresPresenter) HintOutput(_ interfaces.PokerSquaresGame) string {
+	return `{"hint":true}`
+}
+
 func TestPokerSquaresInteractor_SnapshotRestore(t *testing.T) {
 	g := domain.NewPokerSquares(domain.NewTrumpCards(0))
 	pi := NewPokerSquaresInteractor(g, new(stubPokerSquaresPresenter))

--- a/internal/usecase/PokerSquaresInteractor_test.go
+++ b/internal/usecase/PokerSquaresInteractor_test.go
@@ -91,6 +91,17 @@ func TestPokerSquaresInteractor_GiveUp(t *testing.T) {
 	assert.Equal(t, "giveup_output", pi.GiveUp())
 }
 
+func TestPokerSquaresInteractor_Hint(t *testing.T) {
+	pg := newMockPokerSquaresGame()
+	pp := newMockPokerSquaresPresenter()
+	pi := NewPokerSquaresInteractor(pg, pp)
+
+	pp.On("HintOutput", pg).Return("hint_output")
+
+	assert.Equal(t, "hint_output", pi.Hint())
+	pp.AssertCalled(t, "HintOutput", pg)
+}
+
 func TestPokerSquaresInteractor_ActionLog(t *testing.T) {
 	pg := newMockPokerSquaresGame()
 	pp := newMockPokerSquaresPresenter()

--- a/internal/usecase/presenter/PokerSquaresPresenter.go
+++ b/internal/usecase/presenter/PokerSquaresPresenter.go
@@ -7,4 +7,6 @@ import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 // PokerSquaresPresenter はポーカー・スクエアズのプレゼンターインタフェース。
 type PokerSquaresPresenter interface {
 	GamePresenter[interfaces.PokerSquaresGame]
+	// HintOutput 現在のカードを置く最善のセルのヒントを出力する
+	HintOutput(p interfaces.PokerSquaresGame) string
 }

--- a/internal/usecase/presenter/PokerSquaresPresenter_mock.go
+++ b/internal/usecase/presenter/PokerSquaresPresenter_mock.go
@@ -8,3 +8,9 @@ import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 type MockPokerSquaresPresenter struct {
 	MockGamePresenter[interfaces.PokerSquaresGame]
 }
+
+// HintOutput はヒント出力のモック。
+func (_m *MockPokerSquaresPresenter) HintOutput(p interfaces.PokerSquaresGame) string {
+	ret := _m.Called(p)
+	return ret.String(0)
+}


### PR DESCRIPTION
## Summary
The Poker Squares CUI/CLI had no hint feature, unlike the Web GUI (which uses a client-side `useGameHint('pokersquares', ...)` heuristic) and unlike the sibling solitaire CUIs (`wasp`, `scorpion`, etc.) that already expose a `hint` command. This PR adds a server-side best-placement hint and wires it through to the CUI.

## What changed
- **Domain** (`PokerSquares.GetHint`): scores every empty cell by the poker-hand synergy the current card gains in its row and column — same-value pair/triple (+4), same-suit flush (+2), adjacent-value straight (+1) — and returns the highest-scoring cell as a new `PokerSquaresHint`. Mirrors the existing frontend heuristic; no new scoring invented.
- **CUI**: new `h`/`hint` command (controller + interactor `Hint()` + `PokerSquaresCuiPresenter.HintOutput`) prints the recommended `(row,col)`, the current card, and a reason. English/Japanese i18n added.
- **Web presenter**: implements the same `HintOutput` interface method (required so the TinyGo `solo` worker compiles).
- Interface, presenter/interactor mocks, and snapshot stub updated. Help text updated in `GameManager`.
- Tests added at domain, presenter, interactor, and controller layers.

The Web frontend keeps its independent client-side heuristic; matching the `wasp`/`scorpion` precedent, the in-browser CLI overlay (`pokersquaresCommands.ts`) is left unchanged.

## Verification
- `go test -tags test ./internal/domain ./internal/usecase ./internal/adapter/...` — pass
- `golangci-lint run` on affected packages — 0 issues
- `GOOS=js GOARCH=wasm go build -tags solo ./cmd/workers/solo/` — **WASM_SOLO_OK**

Closes #3166