### PR TITLE
feat(jokerpoker): show payout table in CUI bet phase

### DIFF
--- a/internal/adapter/presenter/VideoPokerCuiPresenter.go
+++ b/internal/adapter/presenter/VideoPokerCuiPresenter.go
@@ -41,6 +41,11 @@ func (vpp *VideoPokerCuiPresenter) Output(vp interfaces.VideoPokerGame, lastErr 
 		sb.WriteString("\n")
 	}
 
+	// ベットフェーズではベット額決定の判断材料として配当表を表示する。
+	if vp.GetPhase() == domain.VideoPokerPhaseBet {
+		sb.WriteString(vpp.paytableStr(vp.GetVariantName()))
+	}
+
 	sb.WriteString("----------\n")
 
 	if lastErr != nil {
@@ -79,6 +84,21 @@ func (vpp *VideoPokerCuiPresenter) cardStr(vp interfaces.VideoPokerGame, card *d
 		return color.Yellow(cuiSuitName(card.GetDesign()) + " 2")
 	}
 	return cuiCardStr(card)
+}
+
+// paytableStr はバリアント固有の配当表（役名と 1 コインあたりの倍率）を組み立てる。
+// 配当値は domain.VideoPokerPaytable を単一情報源として参照する。
+func (vpp *VideoPokerCuiPresenter) paytableStr(variantName string) string {
+	var sb strings.Builder
+	sb.WriteString(i18n.T("videopoker.payoutTitle") + "\n")
+	for _, row := range domain.VideoPokerPaytable(variantName) {
+		line := i18n.T("videopoker."+row.HandKey) + " x" + strconv.Itoa(row.Multiplier)
+		if row.RoyalJackpot {
+			line += " " + i18n.T("videopoker.payoutMaxBetNote")
+		}
+		sb.WriteString(line + "\n")
+	}
+	return sb.String()
 }
 
 // phaseStr フェーズ文字列

--- a/internal/adapter/presenter/VideoPokerCuiPresenter_test.go
+++ b/internal/adapter/presenter/VideoPokerCuiPresenter_test.go
@@ -35,6 +35,49 @@ func TestVideoPokerCuiPresenter_Output_BetPhase(t *testing.T) {
 	result := p.Output(m, nil)
 	assert.Contains(t, result, "チップ: 1000")
 	assert.Contains(t, result, "フェーズ: ベット")
+	// ベットフェーズでは配当表を表示する（デフォルト videopoker バリアント）。
+	assert.Contains(t, result, i18n.T("videopoker.payoutTitle"))
+	assert.Contains(t, result, "ロイヤルフラッシュ x250")
+	assert.Contains(t, result, i18n.T("videopoker.payoutMaxBetNote"))
+	assert.Contains(t, result, "ジャックス・オア・ベター x1")
+}
+
+func TestVideoPokerCuiPresenter_Output_BetPhase_JokerPokerPaytable(t *testing.T) {
+	p := new(VideoPokerCuiPresenter)
+	m := new(interfaces.MockVideoPokerGame)
+	setupVideoPokerCuiMockDefaults(m)
+	// バリアント固有の役（Kings or Better / Five of a Kind / Wild Royal Flush）が出ること。
+	m.ExpectedCalls = nil
+	m.On("GetChips").Return(1000).Maybe()
+	m.On("GetPhase").Return(domain.VideoPokerPhaseBet).Maybe()
+	m.On("GetHand").Return(([]*domain.Card)(nil)).Maybe()
+	m.On("GetGameEndFlag").Return(false).Maybe()
+	m.On("GetVariantName").Return("jokerpoker").Maybe()
+
+	result := p.Output(m, nil)
+	assert.Contains(t, result, "キングス・オア・ベター x1")
+	assert.Contains(t, result, "ファイブカード x200")
+	assert.Contains(t, result, "ワイルドロイヤルフラッシュ x100")
+	// jacksorbetter 固有行は出ないこと。
+	assert.NotContains(t, result, "ジャックス・オア・ベター")
+}
+
+func TestVideoPokerCuiPresenter_Output_BetPhase_Paytable_EnLocale(t *testing.T) {
+	i18n.SetLang("en")
+	t.Cleanup(func() { i18n.SetLang("ja") })
+	p := new(VideoPokerCuiPresenter)
+	m := new(interfaces.MockVideoPokerGame)
+	setupVideoPokerCuiMockDefaults(m)
+	m.ExpectedCalls = nil
+	m.On("GetChips").Return(1000).Maybe()
+	m.On("GetPhase").Return(domain.VideoPokerPhaseBet).Maybe()
+	m.On("GetHand").Return(([]*domain.Card)(nil)).Maybe()
+	m.On("GetGameEndFlag").Return(false).Maybe()
+	m.On("GetVariantName").Return("jokerpoker").Maybe()
+
+	result := p.Output(m, nil)
+	assert.Contains(t, result, "Kings or Better x1")
+	assert.Contains(t, result, "Natural Royal Flush x250")
 }
 
 func TestVideoPokerCuiPresenter_Output_DrawPhase_WithHand(t *testing.T) {

--- a/internal/domain/VideoPokerVariant.go
+++ b/internal/domain/VideoPokerVariant.go
@@ -14,6 +14,66 @@ type VideoPokerVariantConfig struct {
 	GetResult func(hand []*Card, betAmount int) (rank int, multiplier int, handName string)
 }
 
+// --- 配当表（表示用の単一情報源） ---
+
+// VideoPokerPayoutRow は配当表の 1 行（表示用）を表す。
+// Multiplier は 1 コインあたりの配当倍率で、各バリアントの GetResult が返す値と一致する。
+type VideoPokerPayoutRow struct {
+	// HandKey は i18n ハンド名キー（"videopoker." 名前空間の接尾辞）
+	HandKey string
+	// Multiplier は 1 コインあたりの配当倍率
+	Multiplier int
+	// RoyalJackpot が true の行は最大ベット時に 1 コインあたり 800（合計 4000）を支払う
+	RoyalJackpot bool
+}
+
+// VideoPokerPaytable は指定バリアントの配当表を高い役から順に返す。倍率は本ファイル内の
+// 各 GetResult 実装と同じ単一情報源であり、Web 版 frontend/src/utils/videoPokerPayout.ts と一致する。
+// 未知のバリアントは Jacks or Better（videopoker）の表を返す。
+func VideoPokerPaytable(variant string) []VideoPokerPayoutRow {
+	switch variant {
+	case "jokerpoker":
+		return []VideoPokerPayoutRow{
+			{HandKey: "ptNaturalRoyalFlush", Multiplier: 250, RoyalJackpot: true},
+			{HandKey: "ptFiveOfAKind", Multiplier: 200},
+			{HandKey: "ptWildRoyalFlush", Multiplier: 100},
+			{HandKey: "ptStraightFlush", Multiplier: 50},
+			{HandKey: "ptFourOfAKind", Multiplier: 20},
+			{HandKey: "ptFullHouse", Multiplier: 7},
+			{HandKey: "ptFlush", Multiplier: 5},
+			{HandKey: "ptStraight", Multiplier: 3},
+			{HandKey: "ptThreeOfAKind", Multiplier: 2},
+			{HandKey: "ptTwoPair", Multiplier: 1},
+			{HandKey: "ptKingsOrBetter", Multiplier: 1},
+		}
+	case "deuceswild":
+		return []VideoPokerPayoutRow{
+			{HandKey: "ptNaturalRoyalFlush", Multiplier: 250, RoyalJackpot: true},
+			{HandKey: "ptFourDeuces", Multiplier: 200},
+			{HandKey: "ptWildRoyalFlush", Multiplier: 25},
+			{HandKey: "ptFiveOfAKind", Multiplier: 15},
+			{HandKey: "ptStraightFlush", Multiplier: 9},
+			{HandKey: "ptFourOfAKind", Multiplier: 5},
+			{HandKey: "ptFullHouse", Multiplier: 3},
+			{HandKey: "ptFlush", Multiplier: 2},
+			{HandKey: "ptStraight", Multiplier: 2},
+			{HandKey: "ptThreeOfAKind", Multiplier: 1},
+		}
+	default:
+		return []VideoPokerPayoutRow{
+			{HandKey: "ptRoyalFlush", Multiplier: 250, RoyalJackpot: true},
+			{HandKey: "ptStraightFlush", Multiplier: 50},
+			{HandKey: "ptFourOfAKind", Multiplier: 25},
+			{HandKey: "ptFullHouse", Multiplier: 9},
+			{HandKey: "ptFlush", Multiplier: 6},
+			{HandKey: "ptStraight", Multiplier: 4},
+			{HandKey: "ptThreeOfAKind", Multiplier: 3},
+			{HandKey: "ptTwoPair", Multiplier: 2},
+			{HandKey: "ptJacksOrBetter", Multiplier: 1},
+		}
+	}
+}
+
 // --- Jacks or Better ---
 
 // jacksOrBetterPayouts Jacks or Betterのペイアウト倍率テーブル

--- a/internal/domain/VideoPokerVariant_test.go
+++ b/internal/domain/VideoPokerVariant_test.go
@@ -410,3 +410,50 @@ func TestVariantConfigFactories(t *testing.T) {
 		assert.NotNil(t, cfg.GetResult)
 	})
 }
+
+// --- VideoPokerPaytable tests ---
+
+func TestVideoPokerPaytable(t *testing.T) {
+	t.Run("jokerpoker rows and order", func(t *testing.T) {
+		rows := VideoPokerPaytable("jokerpoker")
+		assert.Len(t, rows, 11)
+		assert.Equal(t, "ptNaturalRoyalFlush", rows[0].HandKey)
+		assert.Equal(t, 250, rows[0].Multiplier)
+		assert.True(t, rows[0].RoyalJackpot)
+		assert.Equal(t, "ptKingsOrBetter", rows[len(rows)-1].HandKey)
+	})
+
+	t.Run("deuceswild rows", func(t *testing.T) {
+		rows := VideoPokerPaytable("deuceswild")
+		assert.Len(t, rows, 10)
+		assert.Equal(t, "ptFourDeuces", rows[1].HandKey)
+		assert.Equal(t, 200, rows[1].Multiplier)
+	})
+
+	t.Run("unknown variant falls back to jacks or better", func(t *testing.T) {
+		rows := VideoPokerPaytable("does-not-exist")
+		assert.Len(t, rows, 9)
+		assert.Equal(t, "ptRoyalFlush", rows[0].HandKey)
+		assert.Equal(t, "ptJacksOrBetter", rows[len(rows)-1].HandKey)
+	})
+
+	t.Run("multipliers match GetResult (SSoT consistency)", func(t *testing.T) {
+		// Joker + four Kings evaluates to Five of a Kind, which the paytable lists at 200x.
+		cfg := JokerPokerConfig()
+		hand := []*Card{
+			NewCard(CardDesignJoker, 1, false),
+			NewCard(CardDesignSpade, 13, false),
+			NewCard(CardDesignHeart, 13, false),
+			NewCard(CardDesignClover, 13, false),
+			NewCard(CardDesignDiamond, 13, false),
+		}
+		_, multiplier, _ := cfg.GetResult(hand, 1)
+		var fiveOfAKind int
+		for _, row := range VideoPokerPaytable("jokerpoker") {
+			if row.HandKey == "ptFiveOfAKind" {
+				fiveOfAKind = row.Multiplier
+			}
+		}
+		assert.Equal(t, fiveOfAKind, multiplier)
+	})
+}

--- a/internal/i18n/locales/en/videopoker.json
+++ b/internal/i18n/locales/en/videopoker.json
@@ -16,5 +16,21 @@
   "payoutLine": "payout: {{payout}}",
   "hintNone": "No hint available.",
   "hintHold": "Hold recommendation: {{cards}} (h <idx...> to hold)",
-  "hintHoldNone": "Nothing to hold; consider redrawing all five."
+  "hintHoldNone": "Nothing to hold; consider redrawing all five.",
+  "payoutTitle": "--- PAYOUT TABLE (per coin) ---",
+  "payoutMaxBetNote": "(x800 at max bet)",
+  "ptRoyalFlush": "Royal Flush",
+  "ptNaturalRoyalFlush": "Natural Royal Flush",
+  "ptWildRoyalFlush": "Wild Royal Flush",
+  "ptFourDeuces": "Four Deuces",
+  "ptFiveOfAKind": "Five of a Kind",
+  "ptStraightFlush": "Straight Flush",
+  "ptFourOfAKind": "Four of a Kind",
+  "ptFullHouse": "Full House",
+  "ptFlush": "Flush",
+  "ptStraight": "Straight",
+  "ptThreeOfAKind": "Three of a Kind",
+  "ptTwoPair": "Two Pair",
+  "ptJacksOrBetter": "Jacks or Better",
+  "ptKingsOrBetter": "Kings or Better"
 }

--- a/internal/i18n/locales/ja/videopoker.json
+++ b/internal/i18n/locales/ja/videopoker.json
@@ -16,5 +16,21 @@
   "payoutLine": "払戻し: {{payout}}",
   "hintNone": "現在ヒントはありません。",
   "hintHold": "ホールド推奨: {{cards}}（h <idx...> でホールド）",
-  "hintHoldNone": "ホールド推奨なし。5枚すべて引き直しを検討してください。"
+  "hintHoldNone": "ホールド推奨なし。5枚すべて引き直しを検討してください。",
+  "payoutTitle": "--- 配当表（1コインあたり） ---",
+  "payoutMaxBetNote": "(最大ベット時 x800)",
+  "ptRoyalFlush": "ロイヤルフラッシュ",
+  "ptNaturalRoyalFlush": "ナチュラルロイヤルフラッシュ",
+  "ptWildRoyalFlush": "ワイルドロイヤルフラッシュ",
+  "ptFourDeuces": "フォーデューシーズ",
+  "ptFiveOfAKind": "ファイブカード",
+  "ptStraightFlush": "ストレートフラッシュ",
+  "ptFourOfAKind": "フォーカード",
+  "ptFullHouse": "フルハウス",
+  "ptFlush": "フラッシュ",
+  "ptStraight": "ストレート",
+  "ptThreeOfAKind": "スリーカード",
+  "ptTwoPair": "ツーペア",
+  "ptJacksOrBetter": "ジャックス・オア・ベター",
+  "ptKingsOrBetter": "キングス・オア・ベター"
 }


### PR DESCRIPTION
## Summary
The Video Poker CUI (`VideoPokerCuiPresenter.Output`) previously showed only chips, phase, and hand — CUI players had no way to see the variant-specific payouts before choosing a bet. This adds a **payout table** to the **bet phase** output, matching the web `PayoutTable` component.

Covers all three variants sharing the presenter: **jokerpoker**, **deuceswild**, **videopoker** (Jacks or Better).

## Changes
- `internal/domain/VideoPokerVariant.go` — new `VideoPokerPayoutRow` type + `VideoPokerPaytable(variant)` returning the ordered per-coin multipliers. This is the single source of truth for the display values, mirroring each variant's `GetResult` and the web `frontend/src/utils/videoPokerPayout.ts`.
- `internal/adapter/presenter/VideoPokerCuiPresenter.go` — render the paytable during `VideoPokerPhaseBet`.
- `internal/i18n/locales/{ja,en}/videopoker.json` — payout title, max-bet Royal note, and hand-name keys (added to the shared `videopoker.*` namespace the presenter reads, not `jokerpoker.json`).
- Tests: presenter bet-phase paytable (ja + en, jokerpoker variant), domain `VideoPokerPaytable` rows/order/fallback + SSoT cross-check against `GetResult`.

## Paytable source
Values read 1:1 from the domain `jokerPokerGetResult` / `deucesWildGetResult` / `jacksOrBetterGetResult` (e.g. Joker Poker: Natural Royal 250 / Five of a Kind 200 / Wild Royal 100 / Straight Flush 50 / 4oaK 20 / Full House 7 / Flush 5 / Straight 3 / 3oaK 2 / Two Pair 1 / Kings or Better 1). Royal rows flagged with the max-bet 800x jackpot note.

## Verification
- `go test -tags test ./...` — pass
- `golangci-lint run ./internal/...` — 0 issues
- `GOOS=js GOARCH=wasm go build -tags casino` — **WASM_OK**

## Worker size
Casino worker headroom before this change: **1,033,372 B gzip vs 1,048,576 B limit (~14.8 KB free)**. This adds a small static paytable (data rows + ~14 short i18n strings), well within headroom.

Closes #3077