### PR TITLE
feat(indianrummy): preview declare validity before declaring

### DIFF
--- a/frontend/src/i18n/locales/en/indianrummy.json
+++ b/frontend/src/i18n/locales/en/indianrummy.json
@@ -32,6 +32,14 @@
   "drawDiscardButton": "Draw Discard",
   "discardButton": "Discard",
   "declareButton": "Declare",
+  "declarePreview": {
+    "valid": "Ready to declare — valid arrangement",
+    "title": "Declaring now would be invalid",
+    "noPureSequence": "No pure sequence yet",
+    "unmelded": "{{count}} card(s) unmelded ({{points}} pts)",
+    "incomplete": "At least two sequences are required",
+    "penalty": "Declaring now costs +{{penalty}} pts"
+  },
   "nextRound": "Next Round",
   "drawPhase": "Draw a card from the stock or discard pile",
   "discardPhase": "Discard a card, or declare if your 13 cards are valid",

--- a/frontend/src/i18n/locales/ja/indianrummy.json
+++ b/frontend/src/i18n/locales/ja/indianrummy.json
@@ -32,6 +32,14 @@
   "drawDiscardButton": "捨て札から引く",
   "discardButton": "捨てる",
   "declareButton": "宣言",
+  "declarePreview": {
+    "valid": "宣言OK: 有効な宣言です",
+    "title": "このまま宣言すると無効になります",
+    "noPureSequence": "純シーケンス未成立",
+    "unmelded": "未メルド {{count}} 枚（{{points}} 点）",
+    "incomplete": "シーケンスが 2 組以上必要です",
+    "penalty": "このまま宣言すると +{{penalty}} 点"
+  },
   "nextRound": "次のラウンド",
   "drawPhase": "山札または捨て札から1枚引いてください",
   "discardPhase": "1枚捨てるか、13枚が有効なら宣言してください",

--- a/frontend/src/pages/IndianRummyPage.test.tsx
+++ b/frontend/src/pages/IndianRummyPage.test.tsx
@@ -55,6 +55,84 @@ const drawPhaseState: IndianRummyResponse = {
 };
 
 const discardPhaseState: IndianRummyResponse = { ...drawPhaseState, phase: 1 };
+
+// 13-card arrangement that IS a valid declaration (two pure runs + two sets),
+// verified against the Go domain. The 14th card (♣2) is the finish/discard card.
+const declareValidHand: IndianRummyPlayer['cards'] = [
+  { design: 'SPADE', value: 3 },
+  { design: 'SPADE', value: 4 },
+  { design: 'SPADE', value: 5 },
+  { design: 'HEART', value: 7 },
+  { design: 'HEART', value: 8 },
+  { design: 'HEART', value: 9 },
+  { design: 'DIAMOND', value: 10 },
+  { design: 'CLOVER', value: 10 },
+  { design: 'SPADE', value: 10 },
+  { design: 'DIAMOND', value: 13 },
+  { design: 'CLOVER', value: 13 },
+  { design: 'HEART', value: 13 },
+  { design: 'SPADE', value: 13 },
+  { design: 'CLOVER', value: 2 }, // finish card (index 13)
+];
+
+const declareValidState: IndianRummyResponse = {
+  ...discardPhaseState,
+  wildJoker: null,
+  wildRank: 0,
+  players: [player({ cards: declareValidHand }), player({ id: 1, isHuman: false })],
+};
+
+// 13-card arrangement that is INVALID: only sets, no sequence at all (no pure
+// sequence). The 14th card (♥8) is the finish card.
+const declareNoPureHand: IndianRummyPlayer['cards'] = [
+  { design: 'DIAMOND', value: 2 },
+  { design: 'CLOVER', value: 2 },
+  { design: 'SPADE', value: 2 },
+  { design: 'DIAMOND', value: 6 },
+  { design: 'CLOVER', value: 6 },
+  { design: 'SPADE', value: 6 },
+  { design: 'DIAMOND', value: 10 },
+  { design: 'CLOVER', value: 10 },
+  { design: 'SPADE', value: 10 },
+  { design: 'DIAMOND', value: 13 },
+  { design: 'CLOVER', value: 13 },
+  { design: 'HEART', value: 13 },
+  { design: 'SPADE', value: 13 },
+  { design: 'HEART', value: 8 }, // finish card (index 13)
+];
+
+const declareNoPureState: IndianRummyResponse = {
+  ...discardPhaseState,
+  wildJoker: null,
+  wildRank: 0,
+  players: [player({ cards: declareNoPureHand }), player({ id: 1, isHuman: false })],
+};
+
+// 13-card arrangement that is INVALID: one pure run but 10 cards cannot all be
+// melded (76 deadwood points). The 14th card (♣9) is the finish card.
+const declareUncoveredHand: IndianRummyPlayer['cards'] = [
+  { design: 'SPADE', value: 3 },
+  { design: 'SPADE', value: 4 },
+  { design: 'SPADE', value: 5 },
+  { design: 'HEART', value: 7 },
+  { design: 'DIAMOND', value: 9 },
+  { design: 'CLOVER', value: 11 },
+  { design: 'DIAMOND', value: 2 },
+  { design: 'CLOVER', value: 13 },
+  { design: 'SPADE', value: 8 },
+  { design: 'HEART', value: 6 },
+  { design: 'DIAMOND', value: 4 },
+  { design: 'HEART', value: 12 },
+  { design: 'SPADE', value: 1 },
+  { design: 'CLOVER', value: 9 }, // finish card (index 13)
+];
+
+const declareUncoveredState: IndianRummyResponse = {
+  ...discardPhaseState,
+  wildJoker: null,
+  wildRank: 0,
+  players: [player({ cards: declareUncoveredHand }), player({ id: 1, isHuman: false })],
+};
 const roundEndState: IndianRummyResponse = { ...drawPhaseState, phase: 2 };
 const gameEndState: IndianRummyResponse = {
   ...drawPhaseState,
@@ -231,6 +309,49 @@ describe('IndianRummyPage', () => {
     mockExec.mockResolvedValue(roundEndState);
     fireEvent.click(screen.getByRole('button', { name: '宣言' }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('declare', 0));
+  });
+
+  // -- Declaration preview (client-side) --
+  it('does not show the declare preview until a finish card is selected', async () => {
+    mockExec.mockResolvedValue(declareValidState);
+    renderWithProviders(<IndianRummyPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: '宣言' })).toBeInTheDocument());
+    expect(screen.queryByTestId('indianrummy-declare-preview')).not.toBeInTheDocument();
+  });
+
+  it('shows a valid declare preview when the remaining 13 cards form a valid declaration', async () => {
+    mockExec.mockResolvedValue(declareValidState);
+    renderWithProviders(<IndianRummyPage />);
+    await waitFor(() => expect(screen.getByAltText('♣ 2')).toBeInTheDocument());
+    fireEvent.click(screen.getByAltText('♣ 2').closest('button') as HTMLButtonElement);
+    const preview = await screen.findByTestId('indianrummy-declare-preview');
+    expect(preview).toBeInTheDocument();
+    expect(screen.getByTestId('indianrummy-declare-preview-valid')).toBeInTheDocument();
+    expect(screen.queryByTestId('indianrummy-declare-preview-invalid')).not.toBeInTheDocument();
+    // Declare button is never blocked by the preview.
+    expect(screen.getByRole('button', { name: '宣言' })).not.toBeDisabled();
+  });
+
+  it('warns about a missing pure sequence and the penalty for an invalid declaration', async () => {
+    mockExec.mockResolvedValue(declareNoPureState);
+    renderWithProviders(<IndianRummyPage />);
+    await waitFor(() => expect(screen.getByAltText('♥ 8')).toBeInTheDocument());
+    fireEvent.click(screen.getByAltText('♥ 8').closest('button') as HTMLButtonElement);
+    await screen.findByTestId('indianrummy-declare-preview-invalid');
+    expect(screen.getByText('純シーケンス未成立')).toBeInTheDocument();
+    expect(screen.getByText('このまま宣言すると +80 点')).toBeInTheDocument();
+    // Player can still force the declaration through.
+    expect(screen.getByRole('button', { name: '宣言' })).not.toBeDisabled();
+  });
+
+  it('warns about unmelded cards when a pure sequence exists but cards are uncovered', async () => {
+    mockExec.mockResolvedValue(declareUncoveredState);
+    renderWithProviders(<IndianRummyPage />);
+    await waitFor(() => expect(screen.getByAltText('♣ 9')).toBeInTheDocument());
+    fireEvent.click(screen.getByAltText('♣ 9').closest('button') as HTMLButtonElement);
+    await screen.findByTestId('indianrummy-declare-preview-invalid');
+    expect(screen.queryByText('純シーケンス未成立')).not.toBeInTheDocument();
+    expect(screen.getByText(/未メルド .*枚（76 点）/)).toBeInTheDocument();
   });
 
   it('does not show draw buttons when not human turn', async () => {

--- a/frontend/src/pages/IndianRummyPage.tsx
+++ b/frontend/src/pages/IndianRummyPage.tsx
@@ -38,6 +38,7 @@ import { cardAlt } from '../utils/cardAlt';
 import { INDIANRUMMY_HELP, parseIndianrummyCommand } from '../utils/cli/commands/indianrummyCommands';
 import { formatIndianrummyState } from '../utils/cli/formatters/indianrummyFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { evaluateIndianRummyDeclare, INDIAN_RUMMY_HAND_SIZE } from '../utils/indianRummyDeclare';
 import { playerName } from '../utils/playerUtils';
 
 const INDIANRUMMY_PHASE_KEYS: Readonly<Record<number, string>> = {
@@ -148,6 +149,21 @@ function IndianRummyPageContent() {
   });
 
   const phaseNames = usePhaseNames('indianrummy', INDIANRUMMY_PHASE_KEYS);
+
+  // Client-side declaration preview: when a finish card is selected during the
+  // discard phase, evaluate whether the remaining 13 cards form a valid declare.
+  // The backend still re-validates on submit; this only powers a non-blocking hint.
+  const declarePreview = useMemo(() => {
+    if (!state || state.phase !== IndianRummyPhase.DISCARD) return null;
+    if (state.players[state.currentPlayerIdx]?.isHuman !== true) return null;
+    if (selectedCardIndices.length !== 1) return null;
+    const human = state.players.find((p) => p.isHuman);
+    if (!human) return null;
+    const finishIdx = selectedCardIndices[0];
+    const remaining = human.cards.filter((_, i) => i !== finishIdx);
+    if (remaining.length !== INDIAN_RUMMY_HAND_SIZE) return null;
+    return evaluateIndianRummyDeclare(remaining, state.wildRank);
+  }, [state, selectedCardIndices]);
 
   const handleManualReset = useCallback(() => {
     hideActionLog();
@@ -404,6 +420,40 @@ function IndianRummyPageContent() {
 
             {frontendHintEnabled && frontendHint && (
               <HintTooltip reason={t(frontendHint.reason)} confidence={frontendHint.confidence} />
+            )}
+
+            {isDiscardPhase && isHumanTurn && declarePreview && (
+              <div
+                role="status"
+                aria-live="polite"
+                data-testid="indianrummy-declare-preview"
+                className={`mb-2 px-3 py-2 rounded text-sm ${
+                  declarePreview.valid ? 'bg-ds-success/20 text-ds-success' : 'bg-ds-warning/20 text-ds-warning'
+                }`}
+              >
+                {declarePreview.valid ? (
+                  <span data-testid="indianrummy-declare-preview-valid">{t('declarePreview.valid')}</span>
+                ) : (
+                  <div data-testid="indianrummy-declare-preview-invalid">
+                    <div className="font-semibold">{t('declarePreview.title')}</div>
+                    <ul className="list-disc list-inside">
+                      {!declarePreview.hasPureSequence && <li>{t('declarePreview.noPureSequence')}</li>}
+                      {declarePreview.unmeldedCount > 0 && (
+                        <li>
+                          {t('declarePreview.unmelded', {
+                            count: declarePreview.unmeldedCount,
+                            points: declarePreview.unmeldedPoints,
+                          })}
+                        </li>
+                      )}
+                      {declarePreview.hasPureSequence && declarePreview.unmeldedCount === 0 && (
+                        <li>{t('declarePreview.incomplete')}</li>
+                      )}
+                    </ul>
+                    <div>{t('declarePreview.penalty', { penalty: declarePreview.penalty })}</div>
+                  </div>
+                )}
+              </div>
             )}
 
             <div className="flex gap-2 items-center flex-wrap">

--- a/frontend/src/utils/indianRummyDeclare.test.ts
+++ b/frontend/src/utils/indianRummyDeclare.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it } from 'vitest';
+import type { Card } from '../types/card';
+import {
+  evaluateIndianRummyDeclare,
+  INDIAN_RUMMY_DEADWOOD_CAP,
+  indianRummyCardPoints,
+  indianRummyDeadwoodScore,
+  indianRummyHasPureSequence,
+  indianRummyIsWild,
+  indianRummyValidateDeclaration,
+} from './indianRummyDeclare';
+
+/** Terse card constructor. */
+const c = (design: Card['design'], value: number): Card => ({ design, value }) as Card;
+
+// The expected verdicts below were cross-checked against the Go domain functions
+// (IndianRummyValidateDeclaration / IndianRummyHasPureSequence / IndianRummyDeadwoodScore).
+
+/** Valid: two pure runs (♠3-5, ♥7-9) + set of 10s + set of Ks. */
+const validHand: Card[] = [
+  c('SPADE', 3),
+  c('SPADE', 4),
+  c('SPADE', 5),
+  c('HEART', 7),
+  c('HEART', 8),
+  c('HEART', 9),
+  c('DIAMOND', 10),
+  c('CLOVER', 10),
+  c('SPADE', 10),
+  c('DIAMOND', 13),
+  c('CLOVER', 13),
+  c('HEART', 13),
+  c('SPADE', 13),
+];
+
+/** Invalid: only sets, no sequence at all -> no pure sequence. */
+const noSequenceHand: Card[] = [
+  c('DIAMOND', 2),
+  c('CLOVER', 2),
+  c('SPADE', 2),
+  c('DIAMOND', 6),
+  c('CLOVER', 6),
+  c('SPADE', 6),
+  c('DIAMOND', 10),
+  c('CLOVER', 10),
+  c('SPADE', 10),
+  c('DIAMOND', 13),
+  c('CLOVER', 13),
+  c('HEART', 13),
+  c('SPADE', 13),
+];
+
+/** Invalid: one pure run but the remaining 10 cards cannot all be melded. */
+const uncoveredHand: Card[] = [
+  c('SPADE', 3),
+  c('SPADE', 4),
+  c('SPADE', 5),
+  c('HEART', 7),
+  c('DIAMOND', 9),
+  c('CLOVER', 11),
+  c('DIAMOND', 2),
+  c('CLOVER', 13),
+  c('SPADE', 8),
+  c('HEART', 6),
+  c('DIAMOND', 4),
+  c('HEART', 12),
+  c('SPADE', 1),
+];
+
+/** Valid with wildRank=5: two pure runs + set of Ks (with a wild 5) + set of 2s. */
+const wildHand: Card[] = [
+  c('SPADE', 6),
+  c('SPADE', 7),
+  c('SPADE', 8),
+  c('HEART', 9),
+  c('HEART', 10),
+  c('HEART', 11),
+  c('DIAMOND', 13),
+  c('CLOVER', 13),
+  c('DIAMOND', 5), // wild (rank 5)
+  c('DIAMOND', 2),
+  c('CLOVER', 2),
+  c('SPADE', 2),
+  c('HEART', 2),
+];
+
+/** Valid using an Ace-high run (Q-K-A of spades). */
+const aceHighHand: Card[] = [
+  c('SPADE', 12),
+  c('SPADE', 13),
+  c('SPADE', 1),
+  c('HEART', 7),
+  c('HEART', 8),
+  c('HEART', 9),
+  c('DIAMOND', 10),
+  c('CLOVER', 10),
+  c('SPADE', 10),
+  c('DIAMOND', 4),
+  c('CLOVER', 4),
+  c('HEART', 4),
+  c('SPADE', 4),
+];
+
+/** Valid using a printed joker as the wild card in the set of 10s. */
+const jokerHand: Card[] = [
+  c('SPADE', 3),
+  c('SPADE', 4),
+  c('SPADE', 5),
+  c('HEART', 7),
+  c('HEART', 8),
+  c('HEART', 9),
+  c('DIAMOND', 10),
+  c('CLOVER', 10),
+  c('JOKER', 0),
+  c('DIAMOND', 13),
+  c('CLOVER', 13),
+  c('HEART', 13),
+  c('SPADE', 13),
+];
+
+describe('indianRummyIsWild', () => {
+  it('treats printed jokers as wild', () => {
+    expect(indianRummyIsWild(c('JOKER', 0), 0)).toBe(true);
+  });
+  it('treats the round wild rank as wild', () => {
+    expect(indianRummyIsWild(c('SPADE', 5), 5)).toBe(true);
+    expect(indianRummyIsWild(c('SPADE', 6), 5)).toBe(false);
+  });
+  it('does not treat any rank as wild when wildRank is 0', () => {
+    expect(indianRummyIsWild(c('SPADE', 5), 0)).toBe(false);
+  });
+});
+
+describe('indianRummyCardPoints', () => {
+  it('scores wilds as 0, Ace and high cards as 10, pips as face value', () => {
+    expect(indianRummyCardPoints(c('JOKER', 0), 0)).toBe(0);
+    expect(indianRummyCardPoints(c('SPADE', 5), 5)).toBe(0); // wild rank
+    expect(indianRummyCardPoints(c('SPADE', 1), 0)).toBe(10); // Ace
+    expect(indianRummyCardPoints(c('SPADE', 7), 0)).toBe(7);
+    expect(indianRummyCardPoints(c('SPADE', 10), 0)).toBe(10);
+    expect(indianRummyCardPoints(c('SPADE', 13), 0)).toBe(10);
+  });
+});
+
+describe('indianRummyValidateDeclaration - valid hands pass', () => {
+  it('accepts two pure runs plus two sets', () => {
+    expect(indianRummyValidateDeclaration(validHand, 0)).toBe(true);
+  });
+  it('accepts a set completed with the round wild rank', () => {
+    expect(indianRummyValidateDeclaration(wildHand, 5)).toBe(true);
+  });
+  it('accepts an Ace-high sequence', () => {
+    expect(indianRummyValidateDeclaration(aceHighHand, 0)).toBe(true);
+  });
+  it('accepts a set completed with a printed joker', () => {
+    expect(indianRummyValidateDeclaration(jokerHand, 0)).toBe(true);
+  });
+});
+
+describe('indianRummyValidateDeclaration - invalid hands fail', () => {
+  it('rejects a hand with no pure sequence (only sets)', () => {
+    expect(indianRummyValidateDeclaration(noSequenceHand, 0)).toBe(false);
+  });
+  it('rejects a hand with uncovered (unmelded) cards', () => {
+    expect(indianRummyValidateDeclaration(uncoveredHand, 0)).toBe(false);
+  });
+  it('rejects a hand that is not exactly 13 cards', () => {
+    expect(indianRummyValidateDeclaration(validHand.slice(0, 12), 0)).toBe(false);
+    expect(indianRummyValidateDeclaration([...validHand, c('CLOVER', 9)], 0)).toBe(false);
+  });
+});
+
+describe('indianRummyHasPureSequence', () => {
+  it('detects a pure sequence', () => {
+    expect(indianRummyHasPureSequence(validHand, 0)).toBe(true);
+  });
+  it('returns false when there is no pure sequence', () => {
+    expect(indianRummyHasPureSequence(noSequenceHand, 0)).toBe(false);
+  });
+});
+
+describe('indianRummyDeadwoodScore', () => {
+  it('returns 0 for a fully melded valid hand', () => {
+    expect(indianRummyDeadwoodScore(validHand, 0)).toBe(0);
+  });
+  it('returns the full cap when there is no pure sequence', () => {
+    expect(indianRummyDeadwoodScore(noSequenceHand, 0)).toBe(INDIAN_RUMMY_DEADWOOD_CAP);
+  });
+  it('returns the minimum deadwood when a pure sequence exists', () => {
+    // Cross-checked against the Go domain: 76 points remain unmelded.
+    expect(indianRummyDeadwoodScore(uncoveredHand, 0)).toBe(76);
+  });
+});
+
+describe('evaluateIndianRummyDeclare', () => {
+  it('reports a valid hand with no penalty', () => {
+    const p = evaluateIndianRummyDeclare(validHand, 0);
+    expect(p.valid).toBe(true);
+    expect(p.hasPureSequence).toBe(true);
+    expect(p.unmeldedCount).toBe(0);
+    expect(p.penalty).toBe(0);
+  });
+
+  it('flags a missing pure sequence with the full penalty', () => {
+    const p = evaluateIndianRummyDeclare(noSequenceHand, 0);
+    expect(p.valid).toBe(false);
+    expect(p.hasPureSequence).toBe(false);
+    expect(p.penalty).toBe(INDIAN_RUMMY_DEADWOOD_CAP);
+  });
+
+  it('flags unmelded cards with a positive count and points', () => {
+    const p = evaluateIndianRummyDeclare(uncoveredHand, 0);
+    expect(p.valid).toBe(false);
+    expect(p.hasPureSequence).toBe(true);
+    expect(p.unmeldedCount).toBeGreaterThan(0);
+    expect(p.unmeldedPoints).toBe(76);
+    expect(p.penalty).toBe(INDIAN_RUMMY_DEADWOOD_CAP);
+  });
+});

--- a/frontend/src/utils/indianRummyDeclare.ts
+++ b/frontend/src/utils/indianRummyDeclare.ts
@@ -1,0 +1,352 @@
+import type { Card } from '../types/card';
+
+/**
+ * Client-side port of Indian Rummy declaration validation, mirroring
+ * `IndianRummyValidateDeclaration`, `IndianRummyHasPureSequence`, and
+ * `IndianRummyDeadwoodScore` in `internal/domain/IndianRummy.go`. Used to preview,
+ * before the player declares, whether their arranged 13-card hand forms a valid
+ * declaration (>=2 sequences of which >=1 is pure, every card melded). The backend
+ * remains the source of truth; this only powers a non-blocking warning.
+ */
+
+/** Indian Rummy hand size validated on declaration (13, after the finish card). */
+export const INDIAN_RUMMY_HAND_SIZE = 13;
+/** Minimum length of a sequence (run). Mirrors `IndianRummySeqMin`. */
+const SEQ_MIN = 3;
+/** Full deadwood penalty; an invalid declaration scores this flat. Mirrors `IndianRummyDeadwoodCap`. */
+export const INDIAN_RUMMY_DEADWOOD_CAP = 80;
+/** DFS iteration ceiling. Mirrors `indianRummySearchCap`. */
+const SEARCH_CAP = 2_000_000;
+/** Cartesian product ceiling. Mirrors the domain's `maxCartesian`. */
+const CARTESIAN_CAP = 256;
+
+/** A candidate meld: original hand indices plus its sequence / pure flags. */
+interface Meld {
+  idx: number[];
+  seq: boolean;
+  pure: boolean;
+}
+
+/** Whether a card is wild: a printed joker, or matching the round's wild rank. */
+export function indianRummyIsWild(card: Card, wildRank: number): boolean {
+  if (card.design === 'JOKER') return true;
+  return wildRank !== 0 && card.value === wildRank;
+}
+
+/** Deadwood points for a card (wild=0, A=10, 2-9=pip, 10/J/Q/K=10). */
+export function indianRummyCardPoints(card: Card, wildRank: number): number {
+  if (indianRummyIsWild(card, wildRank)) return 0;
+  const v = card.value;
+  if (v === 1) return 10; // Ace
+  if (v >= 10) return 10; // 10, J, Q, K
+  return v;
+}
+
+/** Enumerate index combinations of size `k` from `idxs` with all-distinct suits. */
+function distinctSuitCombos(idxs: number[], cards: readonly Card[], k: number): number[][] {
+  const bySuit = new Map<string, number[]>();
+  const order: string[] = [];
+  for (const i of idxs) {
+    const s = cards[i].design;
+    if (!bySuit.has(s)) order.push(s);
+    const list = bySuit.get(s) ?? [];
+    list.push(i);
+    bySuit.set(s, list);
+  }
+  const res: number[][] = [];
+  const rec = (pos: number, cur: number[]): void => {
+    if (cur.length === k) {
+      res.push([...cur]);
+      return;
+    }
+    if (pos >= order.length || order.length - pos < k - cur.length) return;
+    // Skip this suit.
+    rec(pos + 1, cur);
+    // Use one card of this suit.
+    for (const i of bySuit.get(order[pos]) ?? []) {
+      cur.push(i);
+      rec(pos + 1, cur);
+      cur.pop();
+    }
+  };
+  rec(0, []);
+  return res;
+}
+
+/** Enumerate set candidates (same rank, distinct suits, 3-4 cards, <=1 wild). */
+function generateSets(cards: readonly Card[], wildRank: number, wildIdxs: number[]): Meld[] {
+  const byRank = new Map<number, number[]>();
+  for (let i = 0; i < cards.length; i++) {
+    if (indianRummyIsWild(cards[i], wildRank)) continue;
+    const list = byRank.get(cards[i].value) ?? [];
+    list.push(i);
+    byRank.set(cards[i].value, list);
+  }
+  const melds: Meld[] = [];
+  for (const idxs of byRank.values()) {
+    // Pure sets (no wild), 3 and 4 cards.
+    for (const k of [3, 4]) {
+      for (const combo of distinctSuitCombos(idxs, cards, k)) {
+        melds.push({ idx: combo, seq: false, pure: false });
+      }
+    }
+    // Sets including one wild (3 and 4 total).
+    for (const total of [3, 4]) {
+      const naturals = total - 1;
+      for (const combo of distinctSuitCombos(idxs, cards, naturals)) {
+        for (const w of wildIdxs) {
+          melds.push({ idx: [...combo, w], seq: false, pure: false });
+        }
+      }
+    }
+  }
+  return melds;
+}
+
+/** Build run candidates for one suit over the window `[start, start+length-1]`. */
+function buildRunWindow(
+  byVal: Map<number, number[]>,
+  start: number,
+  length: number,
+  wildIdxs: number[],
+): Meld[] | null {
+  const present: number[][] = [];
+  let missing = 0;
+  const seen = new Set<number>();
+  for (let v = start; v < start + length; v++) {
+    let lv = v;
+    if (lv === 14) lv = 1; // Ace-high
+    if (seen.has(lv)) return null; // window referencing a rank twice (wrap-around) is invalid
+    seen.add(lv);
+    const opts = byVal.get(lv) ?? [];
+    if (opts.length === 0) {
+      missing++;
+      present.push([]);
+    } else {
+      present.push(opts);
+    }
+  }
+  if (missing === 0) {
+    return cartesian(present).map((combo) => ({ idx: combo, seq: true, pure: true }));
+  }
+  if (missing === 1 && wildIdxs.length > 0) {
+    const base = present.filter((opts) => opts.length > 0);
+    const combos = cartesian(base);
+    const out: Meld[] = [];
+    for (const combo of combos) {
+      for (const w of wildIdxs) {
+        out.push({ idx: [...combo, w], seq: true, pure: false });
+      }
+    }
+    return out;
+  }
+  return null;
+}
+
+/** Enumerate run candidates (same suit, consecutive 3+, <=1 wild; Ace low & high). */
+function generateRuns(cards: readonly Card[], wildRank: number, wildIdxs: number[]): Meld[] {
+  const bySuit = new Map<string, Map<number, number[]>>();
+  for (let i = 0; i < cards.length; i++) {
+    if (indianRummyIsWild(cards[i], wildRank)) continue;
+    const s = cards[i].design;
+    let byVal = bySuit.get(s);
+    if (!byVal) {
+      byVal = new Map();
+      bySuit.set(s, byVal);
+    }
+    const list = byVal.get(cards[i].value) ?? [];
+    list.push(i);
+    byVal.set(cards[i].value, list);
+  }
+  const melds: Meld[] = [];
+  for (const byVal of bySuit.values()) {
+    for (let start = 1; start <= 13; start++) {
+      for (let length = SEQ_MIN; start + length - 1 <= 14; length++) {
+        const window = buildRunWindow(byVal, start, length, wildIdxs);
+        if (window) melds.push(...window);
+      }
+    }
+  }
+  return melds;
+}
+
+/** Cartesian product picking one index per list, capped to avoid blow-up. */
+function cartesian(lists: number[][]): number[][] {
+  let res: number[][] = [[]];
+  for (const opts of lists) {
+    if (opts.length === 0) continue;
+    const next: number[][] = [];
+    for (const prefix of res) {
+      for (const o of opts) next.push([...prefix, o]);
+    }
+    res = next.length > CARTESIAN_CAP ? next.slice(0, CARTESIAN_CAP) : next;
+  }
+  return res;
+}
+
+/** Enumerate every valid set / sequence candidate from `cards`. */
+function generateMelds(cards: readonly Card[], wildRank: number): Meld[] {
+  const wildIdxs: number[] = [];
+  for (let i = 0; i < cards.length; i++) {
+    if (indianRummyIsWild(cards[i], wildRank)) wildIdxs.push(i);
+  }
+  return [...generateSets(cards, wildRank, wildIdxs), ...generateRuns(cards, wildRank, wildIdxs)];
+}
+
+/** For each card index, the list of meld indices that cover it. */
+function covering(n: number, melds: Meld[]): number[][] {
+  const cov: number[][] = Array.from({ length: n }, () => []);
+  for (let mi = 0; mi < melds.length; mi++) {
+    for (const ci of melds[mi].idx) cov[ci].push(mi);
+  }
+  return cov;
+}
+
+/**
+ * Whether `cards` (13 cards) form a valid declaration: every card melded, with
+ * at least two sequences of which at least one is pure. Mirrors
+ * `IndianRummyValidateDeclaration`.
+ */
+export function indianRummyValidateDeclaration(cards: readonly Card[], wildRank: number): boolean {
+  const n = cards.length;
+  if (n !== INDIAN_RUMMY_HAND_SIZE) return false;
+  const melds = generateMelds(cards, wildRank);
+  const cov = covering(n, melds);
+  const decided = new Array<boolean>(n).fill(false);
+  let iter = 0;
+
+  const firstUndecided = (): number => {
+    for (let i = 0; i < n; i++) if (!decided[i]) return i;
+    return -1;
+  };
+  const allUndecided = (idx: number[]): boolean => idx.every((ci) => !decided[ci]);
+  const setDecided = (idx: number[], v: boolean): void => {
+    for (const ci of idx) decided[ci] = v;
+  };
+
+  const dfs = (seq: number, pure: number): boolean => {
+    iter++;
+    if (iter > SEARCH_CAP) return false;
+    const i = firstUndecided();
+    if (i === -1) return seq >= 2 && pure >= 1;
+    for (const mi of cov[i]) {
+      const m = melds[mi];
+      if (!allUndecided(m.idx)) continue;
+      setDecided(m.idx, true);
+      let si = 0;
+      let pi = 0;
+      if (m.seq) {
+        si = 1;
+        if (m.pure) pi = 1;
+      }
+      if (dfs(seq + si, pure + pi)) return true;
+      setDecided(m.idx, false);
+    }
+    return false;
+  };
+  return dfs(0, 0);
+}
+
+/** Whether `cards` contain a pure sequence (no wild, same-suit run of 3+). */
+export function indianRummyHasPureSequence(cards: readonly Card[], wildRank: number): boolean {
+  return generateMelds(cards, wildRank).some((m) => m.seq && m.pure);
+}
+
+/** A minimum-deadwood split: total deadwood points plus the melded indices. */
+interface DeadwoodSplit {
+  points: number;
+  melded: Set<number>;
+}
+
+/** Minimum-deadwood partition of `cards` into disjoint melds. Mirrors `indianRummyMinDeadwood`. */
+function minDeadwoodSplit(cards: readonly Card[], wildRank: number): DeadwoodSplit {
+  const n = cards.length;
+  if (n === 0) return { points: 0, melded: new Set() };
+  const melds = generateMelds(cards, wildRank);
+  const cov = covering(n, melds);
+  const points = cards.map((c) => indianRummyCardPoints(c, wildRank));
+  const decided = new Array<boolean>(n).fill(false);
+  let iter = 0;
+
+  const firstUndecided = (): number => {
+    for (let i = 0; i < n; i++) if (!decided[i]) return i;
+    return -1;
+  };
+  const allUndecided = (idx: number[]): boolean => idx.every((ci) => !decided[ci]);
+  const setDecided = (idx: number[], v: boolean): void => {
+    for (const ci of idx) decided[ci] = v;
+  };
+
+  const dfs = (): DeadwoodSplit => {
+    iter++;
+    if (iter > SEARCH_CAP) {
+      let s = 0;
+      for (let k = 0; k < n; k++) if (!decided[k]) s += points[k];
+      return { points: s, melded: new Set() };
+    }
+    const i = firstUndecided();
+    if (i === -1) return { points: 0, melded: new Set() };
+    // Option A: card i is deadwood.
+    decided[i] = true;
+    const subA = dfs();
+    decided[i] = false;
+    let best: DeadwoodSplit = { points: points[i] + subA.points, melded: subA.melded };
+    // Option B: cover i with a meld.
+    for (const mi of cov[i]) {
+      const m = melds[mi];
+      if (!allUndecided(m.idx)) continue;
+      setDecided(m.idx, true);
+      const sub = dfs();
+      setDecided(m.idx, false);
+      if (sub.points < best.points) {
+        const melded = new Set<number>(sub.melded);
+        for (const ci of m.idx) melded.add(ci);
+        best = { points: sub.points, melded };
+      }
+    }
+    return best;
+  };
+  return dfs();
+}
+
+/**
+ * Deadwood score for `cards`: 80 (full cap) if there is no pure sequence;
+ * otherwise the minimum deadwood capped at 80. Mirrors `IndianRummyDeadwoodScore`.
+ */
+export function indianRummyDeadwoodScore(cards: readonly Card[], wildRank: number): number {
+  if (!indianRummyHasPureSequence(cards, wildRank)) return INDIAN_RUMMY_DEADWOOD_CAP;
+  const dw = minDeadwoodSplit(cards, wildRank).points;
+  return dw > INDIAN_RUMMY_DEADWOOD_CAP ? INDIAN_RUMMY_DEADWOOD_CAP : dw;
+}
+
+/** Preview of an Indian Rummy declaration for a 13-card arranged hand. */
+export interface IndianRummyDeclarePreview {
+  /** Whether the hand is a valid declaration (backend still re-validates). */
+  valid: boolean;
+  /** Whether the hand contains at least one pure sequence. */
+  hasPureSequence: boolean;
+  /** Number of cards left unmelded in the best (minimum-deadwood) split. */
+  unmeldedCount: number;
+  /** Deadwood points of the unmelded cards in that best split. */
+  unmeldedPoints: number;
+  /** Penalty the player would take on this declaration (0 if valid, else 80). */
+  penalty: number;
+}
+
+/**
+ * Evaluate whether the given arranged 13-card hand forms a valid Indian Rummy
+ * declaration, returning both the validity verdict and human-friendly context
+ * (missing pure sequence, unmelded card count / points, projected penalty).
+ */
+export function evaluateIndianRummyDeclare(cards: readonly Card[], wildRank: number): IndianRummyDeclarePreview {
+  const valid = indianRummyValidateDeclaration(cards, wildRank);
+  const hasPureSequence = indianRummyHasPureSequence(cards, wildRank);
+  const split = minDeadwoodSplit(cards, wildRank);
+  return {
+    valid,
+    hasPureSequence,
+    unmeldedCount: cards.length - split.melded.size,
+    unmeldedPoints: split.points,
+    penalty: valid ? 0 : INDIAN_RUMMY_DEADWOOD_CAP,
+  };
+}


### PR DESCRIPTION
## Summary

Adds a client-side **declaration validity preview** for Indian Rummy so players can see, before they declare, whether their arranged 13-card hand is a valid declaration — Indian Rummy requires every card melded into valid sequences/sets with at least two sequences of which at least one is pure. Invalid declarations cost the full 80-point penalty on the server, so beginners previously lost big without warning.

When a finish card is selected during the discard phase, a non-blocking status box appears near the declare button:

- **Valid** → green "ready to declare" message.
- **Invalid** → amber warning listing the reason(s): missing pure sequence, unmelded card count/points, and the projected `+80` penalty.

The declare button is **never blocked** — the player can still force the declaration, and the backend remains the source of truth.

## How the validation was ported

`frontend/src/utils/indianRummyDeclare.ts` faithfully mirrors `internal/domain/IndianRummy.go`:

- `indianRummyGenerateMelds` → set enumeration (same rank, distinct suits, 3-4 cards, ≤1 wild) + run enumeration (same suit, consecutive 3+, ≤1 wild, Ace low **and** high).
- `IndianRummyValidateDeclaration` → partition DFS requiring all cards covered, `seq ≥ 2`, `pure ≥ 1`.
- `IndianRummyHasPureSequence` and `IndianRummyDeadwoodScore` (min-deadwood DFS, 80-cap, no-pure-sequence rule).

Test fixtures' expected verdicts were **cross-checked against the real Go functions** (temporary throwaway test, not committed) to guarantee the preview can never show a false "valid": valid two-pure-runs hand, wild-rank set completion, Ace-high run, printed-joker set (all pass); no-pure-sequence and uncovered-cards hands (both fail, deadwood 80 / 76 respectively).

## Checklist

- [x] Warning + projected loss shown when requirements unmet
- [x] Player can still force the declaration (button never disabled by the preview)
- [x] Wild-aware validation unit tests, both valid-pass and invalid-fail (missing pure sequence, uncovered cards); branch coverage 89%
- [x] ja/en warning strings added (key parity verified)
- [x] `bun run check`, `bun run build`, `bun run test -- --run IndianRummy` (119 tests) all green

Closes #3056
