### PR TITLE
feat(allfours): show high/low/jack/game round breakdown

### DIFF
--- a/frontend/src/i18n/locales/en/allfours.json
+++ b/frontend/src/i18n/locales/en/allfours.json
@@ -46,6 +46,14 @@
     "jack": "Jack (capturing the trump Jack)",
     "game": "Game (most card pips)"
   },
+  "breakdown": {
+    "title": "Point Breakdown",
+    "high": "High",
+    "low": "Low",
+    "jack": "Jack",
+    "game": "Game",
+    "none": "−"
+  },
   "hint": {
     "begBeg": "weak hand, so beg",
     "begStand": "decent hand, so stand",

--- a/frontend/src/i18n/locales/ja/allfours.json
+++ b/frontend/src/i18n/locales/ja/allfours.json
@@ -46,6 +46,14 @@
     "jack": "Jack (Jトランプの捕獲)",
     "game": "Game (ピップ合計最大)"
   },
+  "breakdown": {
+    "title": "得点内訳",
+    "high": "High",
+    "low": "Low",
+    "jack": "Jack",
+    "game": "Game",
+    "none": "−"
+  },
   "hint": {
     "begBeg": "弱い手札なのでベグ",
     "begStand": "十分な手札なのでスタンド",

--- a/frontend/src/pages/AllFoursPage.test.tsx
+++ b/frontend/src/pages/AllFoursPage.test.tsx
@@ -194,4 +194,51 @@ describe('AllFoursPage', () => {
     renderWithProviders(<AllFoursPage />);
     await waitFor(() => expect(screen.getByText('あなたの勝利！')).toBeInTheDocument());
   });
+
+  it('renders the High/Low/Jack/Game breakdown at round end', async () => {
+    const roundEndState: AllFoursResponse = {
+      ...baseState,
+      phase: AllFoursPhase.ROUND_END,
+      roundBreakdown: {
+        high: { winnerIdx: 0, card: { design: 'HEART', value: 1 } },
+        low: { winnerIdx: 1, card: { design: 'HEART', value: 2 } },
+        jack: { winnerIdx: 0 },
+        game: { winnerIdx: 0, points: [5, 0] },
+      },
+    };
+    mockExec.mockResolvedValueOnce(roundEndState);
+    renderWithProviders(<AllFoursPage />);
+    const panel = await screen.findByTestId('af-breakdown');
+    expect(panel).toHaveTextContent('得点内訳');
+    expect(panel).toHaveTextContent('High');
+    expect(panel).toHaveTextContent('Jack');
+    // Per-player Game pip totals are shown.
+    expect(panel).toHaveTextContent('5 / 0');
+  });
+
+  it('shows "−" for the Jack row when no trump Jack was captured', async () => {
+    const roundEndState: AllFoursResponse = {
+      ...baseState,
+      phase: AllFoursPhase.ROUND_END,
+      roundBreakdown: {
+        high: { winnerIdx: 0, card: { design: 'HEART', value: 5 } },
+        low: { winnerIdx: 1, card: { design: 'HEART', value: 3 } },
+        jack: { winnerIdx: -1 },
+        game: { winnerIdx: -1, points: [0, 0] },
+      },
+    };
+    mockExec.mockResolvedValueOnce(roundEndState);
+    renderWithProviders(<AllFoursPage />);
+    const panel = await screen.findByTestId('af-breakdown');
+    // The Jack and Game rows both fall back to the em-dash placeholder.
+    expect(panel.querySelectorAll('td')).not.toHaveLength(0);
+    expect(panel).toHaveTextContent('−');
+  });
+
+  it('omits the breakdown panel outside round/game end', async () => {
+    mockExec.mockResolvedValueOnce(playState);
+    renderWithProviders(<AllFoursPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalled());
+    expect(screen.queryByTestId('af-breakdown')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/AllFoursPage.tsx
+++ b/frontend/src/pages/AllFoursPage.tsx
@@ -280,6 +280,54 @@ function AllFoursPageContent() {
               </table>
             </div>
 
+            {(isRoundEnd || isGameEnd) && state.roundBreakdown && (
+              <div
+                data-testid="af-breakdown"
+                className="border border-ds-border-subtle rounded p-2 mb-3 text-ds-text-primary"
+              >
+                <div className="text-xs uppercase opacity-60 mb-1">{t('breakdown.title')}</div>
+                <div className="overflow-x-auto">
+                  <table className="text-sm w-full border-collapse">
+                    <tbody>
+                      {(['high', 'low'] as const).map((k) => {
+                        const award = state.roundBreakdown?.[k];
+                        return (
+                          <tr key={k} className="border-b border-white/10">
+                            <td className="p-1 opacity-80 whitespace-nowrap">{t(`breakdown.${k}`)}</td>
+                            <td className="p-1">
+                              {!award || award.winnerIdx < 0
+                                ? t('breakdown.none')
+                                : findPlayerName(state.players, award.winnerIdx)}
+                            </td>
+                            <td className="p-1">
+                              {award?.card && <CardImage card={award.card} width={Math.round(cardWidth * 0.6)} />}
+                            </td>
+                          </tr>
+                        );
+                      })}
+                      <tr className="border-b border-white/10">
+                        <td className="p-1 opacity-80 whitespace-nowrap">{t('breakdown.jack')}</td>
+                        <td className="p-1" colSpan={2}>
+                          {state.roundBreakdown.jack.winnerIdx < 0
+                            ? t('breakdown.none')
+                            : findPlayerName(state.players, state.roundBreakdown.jack.winnerIdx)}
+                        </td>
+                      </tr>
+                      <tr>
+                        <td className="p-1 opacity-80 whitespace-nowrap">{t('breakdown.game')}</td>
+                        <td className="p-1" colSpan={2}>
+                          {state.roundBreakdown.game.winnerIdx < 0
+                            ? t('breakdown.none')
+                            : findPlayerName(state.players, state.roundBreakdown.game.winnerIdx)}
+                          <span className="opacity-50 ml-1">({state.roundBreakdown.game.points.join(' / ')})</span>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            )}
+
             <div
               data-tutorial="af-trick-display"
               className="border border-ds-border-subtle rounded p-2 min-h-[80px] mb-3 text-ds-text-primary"

--- a/frontend/src/types/card.ts
+++ b/frontend/src/types/card.ts
@@ -10609,6 +10609,22 @@ export interface AllFoursConfig {
   pointLimit: number;
 }
 
+/** A High/Low point award: the capturing player and the trump card, or -1 if unawarded. */
+export interface AllFoursBreakdownAward {
+  winnerIdx: number;
+  card: Card | null;
+}
+
+/** The round-end point breakdown for All Fours (High/Low/Jack/Game). */
+export interface AllFoursRoundBreakdown {
+  high: AllFoursBreakdownAward;
+  low: AllFoursBreakdownAward;
+  /** Captor of the trump Jack, or -1 if no trump Jack was in play. */
+  jack: { winnerIdx: number };
+  /** Game point (most card pips): winner (-1 on tie/zero) and per-player pip totals. */
+  game: { winnerIdx: number; points: number[] };
+}
+
 /** Full All Fours game state returned from the API. */
 export interface AllFoursResponse extends BaseGameResponse {
   players: AllFoursPlayerData[];
@@ -10629,6 +10645,8 @@ export interface AllFoursResponse extends BaseGameResponse {
   winnerIdx: number;
   leadPlayerIdx: number;
   validPlayIndices: number[];
+  /** Present only at ROUND_END / GAME_END: the High/Low/Jack/Game point breakdown. */
+  roundBreakdown?: AllFoursRoundBreakdown;
   config: AllFoursConfig;
   hint?: AllFoursHint;
 }

--- a/internal/adapter/controller/AllFoursWebController.go
+++ b/internal/adapter/controller/AllFoursWebController.go
@@ -48,24 +48,54 @@ type AllFoursWebOutputHint struct {
 	Reason    string `json:"reason"`
 }
 
+// AllFoursWebOutputBreakdownAward は High / Low 項目の獲得者と該当トランプ札を表す。
+// WinnerIdx が -1 のときは付与なし (トランプ未確定など)。
+type AllFoursWebOutputBreakdownAward struct {
+	WinnerIdx int            `json:"winnerIdx"`
+	Card      *WebOutputCard `json:"card"`
+}
+
+// AllFoursWebOutputBreakdownJack は Jack 項目 (J トランプの捕獲) の獲得者を表す。
+// WinnerIdx が -1 のときは、そのディールで J トランプが場に出なかったことを示す。
+type AllFoursWebOutputBreakdownJack struct {
+	WinnerIdx int `json:"winnerIdx"`
+}
+
+// AllFoursWebOutputBreakdownGame は Game 項目 (カードピップ合計) の内訳を表す。
+// WinnerIdx が -1 のときは付与なし (同点または全員 0 点)。Points はプレイヤーごとのピップ合計。
+type AllFoursWebOutputBreakdownGame struct {
+	WinnerIdx int   `json:"winnerIdx"`
+	Points    []int `json:"points"`
+}
+
+// AllFoursWebOutputRoundBreakdown はラウンド確定時の High / Low / Jack / Game 得点内訳。
+// ROUND_END / GAME_END フェーズでのみ出力される。
+type AllFoursWebOutputRoundBreakdown struct {
+	High AllFoursWebOutputBreakdownAward `json:"high"`
+	Low  AllFoursWebOutputBreakdownAward `json:"low"`
+	Jack AllFoursWebOutputBreakdownJack  `json:"jack"`
+	Game AllFoursWebOutputBreakdownGame  `json:"game"`
+}
+
 // AllFoursWebOutput All Fours Webアウトプット
 type AllFoursWebOutput struct {
-	Players          []*AllFoursWebOutputPlayer    `json:"players"`
-	Phase            int                           `json:"phase"`
-	RoundNumber      int                           `json:"roundNumber"`
-	TrickNumber      int                           `json:"trickNumber"`
-	DealerIdx        int                           `json:"dealerIdx"`
-	NonDealerIdx     int                           `json:"nonDealerIdx"`
-	CurrentPlayerIdx int                           `json:"currentPlayerIdx"`
-	TrumpSuit        int                           `json:"trumpSuit"`
-	TurnUp           *WebOutputCard                `json:"turnUp"`
-	RunCount         int                           `json:"runCount"`
-	CurrentTrick     []*AllFoursWebOutputTrickCard `json:"currentTrick"`
-	GameEndFlag      bool                          `json:"gameEndFlag"`
-	WinnerIdx        int                           `json:"winnerIdx"`
-	LeadPlayerIdx    int                           `json:"leadPlayerIdx"`
-	ValidPlayIndices []int                         `json:"validPlayIndices,omitempty"`
-	Hint             *AllFoursWebOutputHint        `json:"hint,omitempty"`
+	Players          []*AllFoursWebOutputPlayer       `json:"players"`
+	Phase            int                              `json:"phase"`
+	RoundNumber      int                              `json:"roundNumber"`
+	TrickNumber      int                              `json:"trickNumber"`
+	DealerIdx        int                              `json:"dealerIdx"`
+	NonDealerIdx     int                              `json:"nonDealerIdx"`
+	CurrentPlayerIdx int                              `json:"currentPlayerIdx"`
+	TrumpSuit        int                              `json:"trumpSuit"`
+	TurnUp           *WebOutputCard                   `json:"turnUp"`
+	RunCount         int                              `json:"runCount"`
+	CurrentTrick     []*AllFoursWebOutputTrickCard    `json:"currentTrick"`
+	GameEndFlag      bool                             `json:"gameEndFlag"`
+	WinnerIdx        int                              `json:"winnerIdx"`
+	LeadPlayerIdx    int                              `json:"leadPlayerIdx"`
+	ValidPlayIndices []int                            `json:"validPlayIndices,omitempty"`
+	RoundBreakdown   *AllFoursWebOutputRoundBreakdown `json:"roundBreakdown,omitempty"`
+	Hint             *AllFoursWebOutputHint           `json:"hint,omitempty"`
 	WebOutputBase
 	Config AllFoursWebOutputConfig `json:"config"`
 }

--- a/internal/adapter/presenter/AllFoursWebPresenter.go
+++ b/internal/adapter/presenter/AllFoursWebPresenter.go
@@ -1,6 +1,8 @@
 package presenter
 
 import (
+	"math"
+
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
@@ -40,6 +42,7 @@ func (p *AllFoursWebPresenter) buildBase(s interfaces.AllFoursGame) *controller.
 
 	resObj.CurrentTrick = p.buildTrickOutput(s.GetCurrentTrick())
 	resObj.Players = p.buildPlayersOutput(s)
+	resObj.RoundBreakdown = p.buildRoundBreakdown(s)
 
 	for i := 0; i < s.GetPlayerCnt(); i++ {
 		if pl := s.GetPlayer(i); pl != nil && pl.GetIsHuman() {
@@ -76,6 +79,105 @@ func (p *AllFoursWebPresenter) buildPlayersOutput(s interfaces.AllFoursGame) []*
 		})
 	}
 	return out
+}
+
+// allFoursRankValue はカード値 (1=A) を比較用ランクへ変換する (A=14 > K=13 > … > 2=2)。
+// domain.pegAwards と同一ロジックを adapter 層で再現したもの (WASM ワーカーには載せない)。
+func allFoursRankValue(v int) int {
+	if v == 1 {
+		return 14
+	}
+	return v
+}
+
+// allFoursPipValue は Game ポイント計算用のピップ値を返す (A=4 K=3 Q=2 J=1 10=10 他=0)。
+func allFoursPipValue(v int) int {
+	switch v {
+	case 1:
+		return 4
+	case 13:
+		return 3
+	case 12:
+		return 2
+	case 11:
+		return 1
+	case 10:
+		return 10
+	}
+	return 0
+}
+
+// buildRoundBreakdown はラウンド確定時 (ROUND_END / GAME_END) の
+// High / Low / Jack / Game 得点内訳を構築する。domain.pegAwards の判定を
+// adapter 層で再現し、各プレイヤーが捕獲したトランプ札とピップ合計から
+// 各項目の獲得者を求める。その他のフェーズでは nil を返す。
+//
+// High/Low = 捕獲済みトランプの最高/最低ランク札の捕獲者。Jack = J トランプの捕獲者
+// (場に出なければ -1)。Game = ピップ合計が単独最大のプレイヤー (同点・全員 0 なら -1)。
+func (p *AllFoursWebPresenter) buildRoundBreakdown(s interfaces.AllFoursGame) *controller.AllFoursWebOutputRoundBreakdown {
+	phase := s.GetPhase()
+	if phase != domain.AllFoursPhaseRoundEnd && phase != domain.AllFoursPhaseGameEnd {
+		return nil
+	}
+	playerCnt := s.GetPlayerCnt()
+	bd := &controller.AllFoursWebOutputRoundBreakdown{
+		High: controller.AllFoursWebOutputBreakdownAward{WinnerIdx: -1},
+		Low:  controller.AllFoursWebOutputBreakdownAward{WinnerIdx: -1},
+		Jack: controller.AllFoursWebOutputBreakdownJack{WinnerIdx: -1},
+		Game: controller.AllFoursWebOutputBreakdownGame{WinnerIdx: -1, Points: make([]int, playerCnt)},
+	}
+	trump := s.GetTrumpSuit()
+	if trump == domain.AllFoursTrumpUnset {
+		return bd
+	}
+
+	highRank, lowRank := -1, math.MaxInt32
+	var highCard, lowCard *domain.Card
+	for i := 0; i < playerCnt; i++ {
+		pl := s.GetPlayer(i)
+		if pl == nil {
+			continue
+		}
+		for _, trick := range pl.GetTricksTaken() {
+			for _, card := range trick {
+				if card == nil {
+					continue
+				}
+				bd.Game.Points[i] += allFoursPipValue(card.GetValue())
+				if card.GetDesign() != trump {
+					continue
+				}
+				rank := allFoursRankValue(card.GetValue())
+				if rank > highRank {
+					highRank, highCard = rank, card
+					bd.High.WinnerIdx = i
+				}
+				if rank < lowRank {
+					lowRank, lowCard = rank, card
+					bd.Low.WinnerIdx = i
+				}
+				if card.GetValue() == 11 {
+					bd.Jack.WinnerIdx = i
+				}
+			}
+		}
+	}
+	bd.High.Card = cardToOutput(highCard)
+	bd.Low.Card = cardToOutput(lowCard)
+
+	gw, maxTotal, tied := -1, -1, false
+	for i, total := range bd.Game.Points {
+		switch {
+		case total > maxTotal:
+			maxTotal, gw, tied = total, i, false
+		case total == maxTotal:
+			tied = true
+		}
+	}
+	if !tied && gw >= 0 && maxTotal > 0 {
+		bd.Game.WinnerIdx = gw
+	}
+	return bd
 }
 
 // buildMessage ゲーム結果メッセージを構築

--- a/internal/adapter/presenter/AllFoursWebPresenter_test.go
+++ b/internal/adapter/presenter/AllFoursWebPresenter_test.go
@@ -109,6 +109,86 @@ func TestAllFoursWebPresenter_Output(t *testing.T) {
 	})
 }
 
+func TestAllFoursWebPresenter_RoundBreakdown(t *testing.T) {
+	p := new(presenter.AllFoursWebPresenter)
+
+	// setupRoundEnd returns a mock at ROUND_END with the given trump suit and
+	// captured tricks assigned per player. tricks[i] is the list of card sets
+	// captured by player i.
+	setupRoundEnd := func(trump int, tricks [][][]*domain.Card) *interfaces.MockAllFoursGame {
+		m := setupAllFoursWebMock()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetTrumpSuit")
+		m.On("GetPhase").Return(domain.AllFoursPhaseRoundEnd)
+		m.On("GetTrumpSuit").Return(trump)
+		m.On("GetPlayerCnt").Return(2)
+		players := makeAllFoursPlayers()
+		for i, pt := range tricks {
+			for _, trick := range pt {
+				players[i].AddTrick(trick)
+			}
+		}
+		m.On("GetPlayer", 0).Return(players[0])
+		m.On("GetPlayer", 1).Return(players[1])
+		return m
+	}
+
+	decode := func(m *interfaces.MockAllFoursGame) *controller.AllFoursWebOutputRoundBreakdown {
+		var resObj controller.AllFoursWebOutput
+		assert.NoError(t, json.Unmarshal([]byte(p.Output(m, nil)), &resObj))
+		return resObj.RoundBreakdown
+	}
+
+	t.Run("nil breakdown while playing", func(t *testing.T) {
+		m, _ := setupAllFoursWebMockWithPlayers()
+		var resObj controller.AllFoursWebOutput
+		assert.NoError(t, json.Unmarshal([]byte(p.Output(m, nil)), &resObj))
+		assert.Nil(t, resObj.RoundBreakdown)
+	})
+
+	t.Run("high/low/jack/game winners", func(t *testing.T) {
+		// Trump = Spade. Player 0 captures the trump Jack (11) and Ace (1, high).
+		// Player 1 captures the trump 2 (low). Pips: p0 = J(1)+A(4)=5, p1 = 2(0)=0.
+		m := setupRoundEnd(domain.CardDesignSpade, [][][]*domain.Card{
+			{{domain.NewCard(domain.CardDesignSpade, 11, false), domain.NewCard(domain.CardDesignSpade, 1, false)}},
+			{{domain.NewCard(domain.CardDesignSpade, 2, false)}},
+		})
+		bd := decode(m)
+		assert.NotNil(t, bd)
+		assert.Equal(t, 0, bd.High.WinnerIdx)
+		assert.Equal(t, 1, bd.High.Card.Value) // Ace
+		assert.Equal(t, 1, bd.Low.WinnerIdx)
+		assert.Equal(t, 2, bd.Low.Card.Value)
+		assert.Equal(t, 0, bd.Jack.WinnerIdx)
+		assert.Equal(t, 0, bd.Game.WinnerIdx)
+		assert.Equal(t, []int{5, 0}, bd.Game.Points)
+	})
+
+	t.Run("jack absent yields -1", func(t *testing.T) {
+		// Trump = Heart, no Jack captured. Game tie (both 0) yields no game award.
+		m := setupRoundEnd(domain.CardDesignHeart, [][][]*domain.Card{
+			{{domain.NewCard(domain.CardDesignHeart, 5, false)}},
+			{{domain.NewCard(domain.CardDesignHeart, 3, false)}},
+		})
+		bd := decode(m)
+		assert.Equal(t, -1, bd.Jack.WinnerIdx)
+		assert.Equal(t, 0, bd.High.WinnerIdx) // Heart 5 is the highest captured trump
+		assert.Equal(t, 1, bd.Low.WinnerIdx)  // Heart 3 is the lowest
+		assert.Equal(t, -1, bd.Game.WinnerIdx)
+	})
+
+	t.Run("trump unset produces empty award slots", func(t *testing.T) {
+		m := setupRoundEnd(domain.AllFoursTrumpUnset, [][][]*domain.Card{{}, {}})
+		bd := decode(m)
+		assert.NotNil(t, bd)
+		assert.Equal(t, -1, bd.High.WinnerIdx)
+		assert.Nil(t, bd.High.Card)
+		assert.Equal(t, -1, bd.Low.WinnerIdx)
+		assert.Equal(t, -1, bd.Jack.WinnerIdx)
+		assert.Equal(t, -1, bd.Game.WinnerIdx)
+	})
+}
+
 func TestAllFoursWebPresenter_HintOutput(t *testing.T) {
 	p := new(presenter.AllFoursWebPresenter)
 


### PR DESCRIPTION
## 概要

オールフォーズのラウンド終了時に、得点を決める4項目 (High / Low / Jack / Game) の獲得者内訳を表示します。

これまでレスポンスは合算値の `roundScore` しか公開しておらず、フロントエンドだけでは「どの項目で何点入ったか」を分解できませんでした (先行のフロントエンド単独対応はこの理由で断念済み)。本PRは **WASMニュートラル** に、Webプレゼンター (adapter層 / TinyGoワーカーへはビルドタグで載らない) で内訳を算出します。

## 変更内容

- **Webプレゼンター** (`AllFoursWebPresenter.go`): domain の `pegAwards` の High/Low/Jack/Game 判定を adapter 層で再現。`GetTricksTaken()` (捕獲済みカード) と切り札スートを読み、`ROUND_END` / `GAME_END` フェーズで `roundBreakdown` を出力。
  - Game ポイント: A=4, K=3, Q=2, J=1, 10=10。同点・全員0点は付与なし (-1)。
  - High/Low = 捕獲済みトランプの最高/最低ランク札とその捕獲者。Jack = J トランプの捕獲者 (場に出なければ -1)。
- **コントローラ出力** (`AllFoursWebController.go`): `roundBreakdown` フィールドと型を追加。
- **フロントエンド型** (`types/card.ts`): `AllFoursRoundBreakdown` を追加。
- **ページ** (`AllFoursPage.tsx`): スコア表の下に追加の内訳パネル (High/Low/Jack/Game、Jack不在は「−」、Game はプレイヤー別ピップ合計併記)。
- **i18n** (ja/en): `breakdown` セクションを両言語に追加。

ドメイン/ユースケース/CUI には一切触れていません。

## WASMニュートラリティ

`allfours` は `classic` ワーカー所属。ビルド確認済み:

```
GOOS=js GOARCH=wasm go build -tags classic -o /dev/null ./cmd/workers/classic/  → WASM_OK
```

## テスト

- Go: `AllFoursWebPresenter_test.go` に内訳 (High/Low/Jack/Game、Jack不在、トランプ未確定) のテストを追加 → presenter/controller とも green。
- 変更した Go は `goimports` 済み、`golangci-lint ./internal/adapter/...` は 0 issues。
- フロント: `AllFoursPage.test.tsx` にラウンド終了パネル表示 / Jack「−」/ 非表示のテストを追加 → `bun run check` / `bun run test -- --run AllFours` (50 passed) / `bun run build` すべて green。

Closes #3593