### PR TITLE
feat(pigtail): make participant count configurable

### DIFF
--- a/frontend/src/api/gameApi.ts
+++ b/frontend/src/api/gameApi.ts
@@ -4533,8 +4533,8 @@ export const acesupApi = {
 
 /** Pig's Tail game API client. */
 export const pigtailApi = {
-  exec: (command: 'reset' | 'draw', cpuHesitationEnabled?: boolean) =>
-    gameExec<PigsTailResponse>('pigtail', { command, cpuHesitationEnabled }),
+  exec: (command: 'reset' | 'draw', cpuHesitationEnabled?: boolean, playerCount?: number) =>
+    gameExec<PigsTailResponse>('pigtail', { command, cpuHesitationEnabled, playerCount }),
 };
 
 /** API client for the Clock Solitaire /clocksolitaire/exec endpoint. */

--- a/frontend/src/api/pigtailApi.test.ts
+++ b/frontend/src/api/pigtailApi.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { pigtailApi, sessionId } from './gameApi';
+
+describe('pigtailApi', () => {
+  const mockFetch = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', mockFetch);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  const ok = (data: unknown) => Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(data) });
+  const err = () => Promise.resolve({ ok: false, status: 500, json: () => Promise.resolve(null) });
+
+  const payload = { players: [], circleCount: 52, gameEndFlag: false, message: '' };
+
+  it('reset omits the player count when not supplied', async () => {
+    mockFetch.mockReturnValue(ok(payload));
+    const result = await pigtailApi.exec('reset');
+    expect(mockFetch).toHaveBeenCalledWith('/pigtail/exec', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ command: 'reset', sessionId }),
+    });
+    expect(result).toEqual(payload);
+  });
+
+  it('reset forwards the selected player count', async () => {
+    mockFetch.mockReturnValue(ok(payload));
+    await pigtailApi.exec('reset', undefined, 6);
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/pigtail/exec',
+      expect.objectContaining({ body: JSON.stringify({ command: 'reset', playerCount: 6, sessionId }) }),
+    );
+  });
+
+  it('draw sends command=draw', async () => {
+    mockFetch.mockReturnValue(ok(payload));
+    await pigtailApi.exec('draw');
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/pigtail/exec',
+      expect.objectContaining({ body: JSON.stringify({ command: 'draw', sessionId }) }),
+    );
+  });
+
+  it('throws on HTTP error', async () => {
+    mockFetch.mockReturnValue(err());
+    await expect(pigtailApi.exec('reset')).rejects.toThrow('HTTP error: 500');
+  });
+});

--- a/frontend/src/i18n/locales/en/pigtail.json
+++ b/frontend/src/i18n/locales/en/pigtail.json
@@ -1,7 +1,9 @@
 {
   "setup": {
     "title": "Pig's Tail Settings",
-    "start": "Start Game"
+    "start": "Start Game",
+    "playerCount": "Players",
+    "playerCountUnit": "{{count}} players"
   },
   "button": {
     "draw": "Draw from Circle",

--- a/frontend/src/i18n/locales/ja/pigtail.json
+++ b/frontend/src/i18n/locales/ja/pigtail.json
@@ -1,7 +1,9 @@
 {
   "setup": {
     "title": "ぶたのしっぽ 設定",
-    "start": "ゲーム開始"
+    "start": "ゲーム開始",
+    "playerCount": "参加人数",
+    "playerCountUnit": "{{count}}人"
   },
   "button": {
     "draw": "山札から引く",

--- a/frontend/src/pages/PigsTailPage.test.tsx
+++ b/frontend/src/pages/PigsTailPage.test.tsx
@@ -304,6 +304,25 @@ describe('PigsTailPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('draw'));
   });
 
+  it('resets with the default player count on mount', async () => {
+    mockExec.mockClear();
+    renderWithProviders(<PigsTailPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    // Mount reset carries no explicit player count (server uses the default).
+    expect(mockExec.mock.calls[0]).toEqual(['reset']);
+  });
+
+  it('applies the selected player count on the next reset', async () => {
+    mockExec.mockResolvedValue(gameEndState);
+    renderWithProviders(<PigsTailPage />);
+    const select = await screen.findByTestId('pigtail-player-count');
+    fireEvent.change(select, { target: { value: '6' } });
+
+    mockExec.mockClear();
+    fireEvent.click(screen.getByRole('button', { name: '次のゲーム' }));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined, 6));
+  });
+
   it('places the action log section inside the scrollable area before the footer', async () => {
     mockExec.mockResolvedValue(gameEndState);
     renderWithProviders(<PigsTailPage />);

--- a/frontend/src/pages/PigsTailPage.tsx
+++ b/frontend/src/pages/PigsTailPage.tsx
@@ -4,6 +4,7 @@ import { ActionLogSection } from '../components/ActionLogSection';
 import { CircularDeck } from '../components/CircularDeck';
 import { CliTerminal } from '../components/cli/CliTerminal';
 import { CliToggle } from '../components/cli/CliToggle';
+import { SettingsPanel } from '../components/common/SettingsPanel';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
@@ -43,6 +44,12 @@ function centerCardLabel(card: Card): string {
 
 /** Max number of recent center-pile tops kept in the client-side tail strip. */
 const CENTER_HISTORY_MAX = 6;
+
+/** Default participant count (1 human + 3 CPU). Mirrors the domain default. */
+const PIGTAIL_DEFAULT_PLAYER_COUNT = 4;
+
+/** Selectable participant counts (1 human + CPUs). Mirrors the domain 2..6 range. */
+const PIGTAIL_PLAYER_COUNT_OPTIONS = [2, 3, 4, 5, 6] as const;
 
 const PT_TUTORIAL_STEPS: TutorialStep[] = [
   {
@@ -86,8 +93,9 @@ function PigsTailPageContent() {
   const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
     useGamePageSetup('pigtail');
   const { state, loading, exec: execApi } = useGameApi(pigtailApi.exec);
+  const [playerCount, setPlayerCount] = useState<number>(PIGTAIL_DEFAULT_PLAYER_COUNT);
   const handleDraw = useCallback(() => execApi('draw'), [execApi]);
-  const handleReset = useCallback(() => execApi('reset'), [execApi]);
+  const handleReset = useCallback(() => execApi('reset', undefined, playerCount), [execApi, playerCount]);
   const { hint, hintEnabled, setHintEnabled } = useGameHint('pigtail', state);
 
   useMountReset(execApi);
@@ -172,6 +180,27 @@ function PigsTailPageContent() {
         <CliTerminal logEntries={logEntries} onCommand={handleCommand} disabled={loading} />
       ) : (
         <>
+          <SettingsPanel
+            title={t('setup.title')}
+            groups={[
+              {
+                items: [
+                  {
+                    type: 'select' as const,
+                    id: 'playerCount',
+                    label: t('setup.playerCount'),
+                    value: playerCount,
+                    options: PIGTAIL_PLAYER_COUNT_OPTIONS.map((n) => ({
+                      value: n,
+                      label: t('setup.playerCountUnit', { count: n }),
+                    })),
+                    onSelect: (v) => setPlayerCount(Number(v)),
+                    testId: 'pigtail-player-count',
+                  },
+                ],
+              },
+            ]}
+          />
           {penaltyFlash > 0 && (
             <div
               aria-hidden="true"

--- a/internal/adapter/controller/PigsTailWebController.go
+++ b/internal/adapter/controller/PigsTailWebController.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"net/http"
 
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/webutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
@@ -11,6 +12,7 @@ import (
 type PigsTailWebInput struct {
 	BaseWebInput
 	CpuHesitationEnabled bool `json:"cpuHesitationEnabled"`
+	PlayerCount          *int `json:"playerCount,omitempty"`
 }
 
 // PigsTailWebOutputPlayer ぶたのしっぽWebアウトプットプレイヤー
@@ -67,9 +69,9 @@ func newPigsTailDefaultOutput(msg string) *PigsTailWebOutput {
 func pigsTailDispatch(bc *baseController, w http.ResponseWriter, pti usecase.PigsTailInteractorIF, param PigsTailWebInput, _ func(string) *PigsTailWebOutput) bool {
 	switch param.Command {
 	case "r", "reset":
-		cfg := domain.PigsTailConfig{
-			CpuHesitationEnabled: param.CpuHesitationEnabled,
-		}
+		cfg := domain.DefaultPigsTailConfig()
+		cfg.CpuHesitationEnabled = param.CpuHesitationEnabled
+		webutil.ApplyBoundedInt(&cfg.PlayerCount, param.PlayerCount, domain.PigsTailMinPlayers, domain.PigsTailMaxPlayers)
 		bc.writePresenterResponse(w, pti.Reset(cfg))
 	case "d", "draw":
 		bc.writePresenterResponse(w, pti.Action(0))

--- a/internal/adapter/controller/PigsTailWebController_test.go
+++ b/internal/adapter/controller/PigsTailWebController_test.go
@@ -7,8 +7,10 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/usecase"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	uc "github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -69,4 +71,39 @@ func TestPigsTailWebController_Method(t *testing.T) {
 		recorded.ContentTypeIsJson()
 		recorded.BodyIs(`[]`)
 	})
+}
+
+func TestPigsTailWebController_ResetAppliesPlayerCount(t *testing.T) {
+	mockOutput := `{}`
+	tests := []struct {
+		name      string
+		body      string
+		wantCount int
+	}{
+		{"explicit valid count", `{"command":"reset","playerCount":3,"sessionId":"s"}`, 3},
+		{"max valid count", `{"command":"reset","playerCount":6,"sessionId":"s"}`, domain.PigsTailMaxPlayers},
+		{"omitted uses default", `{"command":"reset","sessionId":"s"}`, domain.PigsTailPlayerCnt},
+		{"above max falls back to default", `{"command":"reset","playerCount":99,"sessionId":"s"}`, domain.PigsTailPlayerCnt},
+		{"below min falls back to default", `{"command":"reset","playerCount":1,"sessionId":"s"}`, domain.PigsTailPlayerCnt},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ptiMock := new(usecase.MockPigsTailInteractor)
+			var gotCfg domain.PigsTailConfig
+			ptiMock.On("Reset", mock.MatchedBy(func(c domain.PigsTailConfig) bool {
+				gotCfg = c
+				return true
+			})).Return(mockOutput)
+
+			factory := func() uc.PigsTailInteractorIF { return ptiMock }
+			towc := controller.NewPigsTailWebController(factory)
+			defer towc.Stop()
+
+			var in controller.PigsTailWebInput
+			_ = json.Unmarshal([]byte(tt.body), &in)
+			recorded := execRequest(t, towc.Exec, &in)
+			recorded.CodeIs(http.StatusOK)
+			assert.Equal(t, tt.wantCount, gotCfg.PlayerCount)
+		})
+	}
 }

--- a/internal/domain/PigsTail.go
+++ b/internal/domain/PigsTail.go
@@ -89,16 +89,27 @@ func NewPigsTail(trumpCards *TrumpCards, players []*PigsTailPlayer) *PigsTail {
 	}
 }
 
+// buildPigsTailPlayers builds a roster of the given size: 1 human followed by
+// (count-1) CPUs. The count is clamped to the supported range so callers can
+// pass an unvalidated config value safely.
+func buildPigsTailPlayers(count int) []*PigsTailPlayer {
+	if count < PigsTailMinPlayers {
+		count = PigsTailMinPlayers
+	} else if count > PigsTailMaxPlayers {
+		count = PigsTailMaxPlayers
+	}
+	players := make([]*PigsTailPlayer, count)
+	players[0] = NewPigsTailPlayer(true)
+	for i := 1; i < count; i++ {
+		players[i] = NewPigsTailPlayer(false)
+	}
+	return players
+}
+
 // NewDefaultPigsTail returns PigsTail with the standard 4-player setup (1 human, 3 CPU).
 // Used as the single source of truth for CUI, Web, and Worker construction sites.
 func NewDefaultPigsTail() *PigsTail {
-	players := []*PigsTailPlayer{
-		NewPigsTailPlayer(true),
-		NewPigsTailPlayer(false),
-		NewPigsTailPlayer(false),
-		NewPigsTailPlayer(false),
-	}
-	return NewPigsTail(NewTrumpCards(0), players)
+	return NewPigsTail(NewTrumpCards(0), buildPigsTailPlayers(PigsTailPlayerCnt))
 }
 
 // SetConfig ゲーム設定をセット
@@ -119,8 +130,8 @@ func (pt *PigsTail) Reset() {
 	pt.center = make([]*Card, 0)
 	pt.actionLog = nil
 
-	// 全プレイヤーのカードリセット
-	resetPlayers(pt.players, func(_ *PigsTailPlayer) {})
+	// 設定の参加人数に合わせてロスター (人間1 + CPU) を再構築する。
+	pt.players = buildPigsTailPlayers(pt.config.PlayerCount)
 
 	// プレイ順をランダムにする
 	rand.Shuffle(len(pt.players), func(i, j int) {

--- a/internal/domain/PigsTailConfig.go
+++ b/internal/domain/PigsTailConfig.go
@@ -2,24 +2,32 @@ package domain
 
 import "encoding/json"
 
+// PigsTailMinPlayers ぶたのしっぽ最小プレイヤー数 (人間1 + CPU1)
+const PigsTailMinPlayers = 2
+
+// PigsTailMaxPlayers ぶたのしっぽ最大プレイヤー数
+const PigsTailMaxPlayers = 6
+
 // PigsTailConfig ぶたのしっぽ設定
 type PigsTailConfig struct {
 	CpuHesitationEnabled bool // CPU迷い時間ディレイ
+	PlayerCount          int  // 参加人数 (人間1 + CPU) — PigsTailMinPlayers..PigsTailMaxPlayers
 }
 
-// DefaultPigsTailConfig デフォルト設定を返す
+// DefaultPigsTailConfig デフォルト設定を返す (4人: 人間1 + CPU3)
 func DefaultPigsTailConfig() PigsTailConfig {
-	return PigsTailConfig{}
+	return PigsTailConfig{PlayerCount: PigsTailPlayerCnt}
 }
 
 // Validate 設定値のドメインバリデーション
 func (c PigsTailConfig) Validate() error {
-	return nil
+	return ValidateRange("player count", c.PlayerCount, PigsTailMinPlayers, PigsTailMaxPlayers)
 }
 
 // pigsTailConfigJSON is the JSON wire format for PigsTailConfig.
 type pigsTailConfigJSON struct {
 	CpuHesitationEnabled bool `json:"ch"`
+	PlayerCount          int  `json:"pc"`
 }
 
 // MarshalJSON implements json.Marshaler.
@@ -34,5 +42,10 @@ func (c *PigsTailConfig) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	c.CpuHesitationEnabled = j.CpuHesitationEnabled
+	// 旧スナップショット (pc 未設定) との後方互換: 0 は既定値へ丸める。
+	if j.PlayerCount == 0 {
+		j.PlayerCount = PigsTailPlayerCnt
+	}
+	c.PlayerCount = j.PlayerCount
 	return nil
 }

--- a/internal/domain/PigsTailConfig_test.go
+++ b/internal/domain/PigsTailConfig_test.go
@@ -13,15 +13,35 @@ import (
 func TestDefaultPigsTailConfig(t *testing.T) {
 	cfg := DefaultPigsTailConfig()
 	assert.False(t, cfg.CpuHesitationEnabled)
+	assert.Equal(t, PigsTailPlayerCnt, cfg.PlayerCount)
 }
 
 func TestPigsTailConfig_Validate(t *testing.T) {
-	cfg := PigsTailConfig{CpuHesitationEnabled: true}
-	assert.NoError(t, cfg.Validate())
+	tests := []struct {
+		name    string
+		count   int
+		wantErr bool
+	}{
+		{"min valid", PigsTailMinPlayers, false},
+		{"default valid", PigsTailPlayerCnt, false},
+		{"max valid", PigsTailMaxPlayers, false},
+		{"below min", PigsTailMinPlayers - 1, true},
+		{"above max", PigsTailMaxPlayers + 1, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := PigsTailConfig{CpuHesitationEnabled: true, PlayerCount: tt.count}
+			if tt.wantErr {
+				assert.Error(t, cfg.Validate())
+			} else {
+				assert.NoError(t, cfg.Validate())
+			}
+		})
+	}
 }
 
 func TestPigsTailConfig_JSONRoundTrip(t *testing.T) {
-	cfg := PigsTailConfig{CpuHesitationEnabled: true}
+	cfg := PigsTailConfig{CpuHesitationEnabled: true, PlayerCount: 3}
 	data, err := json.Marshal(cfg)
 	require.NoError(t, err)
 
@@ -29,6 +49,14 @@ func TestPigsTailConfig_JSONRoundTrip(t *testing.T) {
 	err = json.Unmarshal(data, &restored)
 	require.NoError(t, err)
 	assert.Equal(t, cfg, restored)
+}
+
+func TestPigsTailConfig_UnmarshalJSON_LegacyDefaultsPlayerCount(t *testing.T) {
+	// 旧スナップショット (pc フィールドなし) は既定人数へ丸める。
+	var cfg PigsTailConfig
+	err := json.Unmarshal([]byte(`{"ch":true}`), &cfg)
+	require.NoError(t, err)
+	assert.Equal(t, PigsTailPlayerCnt, cfg.PlayerCount)
 }
 
 func TestPigsTailConfig_UnmarshalJSON_InvalidJSON(t *testing.T) {

--- a/internal/domain/PigsTail_test.go
+++ b/internal/domain/PigsTail_test.go
@@ -216,9 +216,33 @@ func TestPigsTail_SetConfig(t *testing.T) {
 	assert.Equal(t, cfg, pt.GetConfig())
 }
 
+func TestPigsTail_Reset_RebuildsRosterFromConfig(t *testing.T) {
+	pt, _ := newTestPigsTail()
+	for _, count := range []int{PigsTailMinPlayers, 3, PigsTailMaxPlayers} {
+		pt.SetConfig(PigsTailConfig{PlayerCount: count})
+		pt.Reset()
+		assert.Equal(t, count, pt.GetPlayerCnt())
+		// 常に人間がちょうど1人。
+		humans := 0
+		for i := 0; i < pt.GetPlayerCnt(); i++ {
+			if pt.GetPlayer(i).GetIsHuman() {
+				humans++
+			}
+		}
+		assert.Equal(t, 1, humans)
+	}
+}
+
+func TestPigsTail_Reset_ClampsOutOfRangePlayerCount(t *testing.T) {
+	pt, _ := newTestPigsTail()
+	pt.SetConfig(PigsTailConfig{PlayerCount: 99})
+	pt.Reset()
+	assert.Equal(t, PigsTailMaxPlayers, pt.GetPlayerCnt())
+}
+
 func TestPigsTail_CpuHesitation(t *testing.T) {
 	pt, _ := newTestPigsTail()
-	pt.SetConfig(PigsTailConfig{CpuHesitationEnabled: true})
+	pt.SetConfig(PigsTailConfig{CpuHesitationEnabled: true, PlayerCount: PigsTailPlayerCnt})
 	pt.Reset()
 
 	// Find a CPU player's turn


### PR DESCRIPTION
## Summary

Makes the Pig's Tail (ぶたのしっぽ) participant count configurable end-to-end. Previously the roster was hardcoded to 4 players (1 human + 3 CPU); the config only carried `CpuHesitationEnabled`. This PR adds the full config plumbing so the count can be chosen from the settings panel.

Closes #3116

## Changes

**Domain**
- `PigsTailConfig` gains a `PlayerCount int` field. `Validate()` enforces the supported range **2..6** (1 human + 1..5 CPU). Default is 4.
- `Reset()` now rebuilds the roster from `config.PlayerCount` via a new `buildPigsTailPlayers` helper (1 human + N-1 CPU), clamped to the supported range. `NewDefaultPigsTail()` uses the same helper. Deal/rotation/win-check were already parameterized on `len(players)`, so no fixed-4 assumptions remained.
- JSON: `pc` wire field; legacy snapshots without `pc` default to 4 on unmarshal.

**Controller**
- `PigsTailWebInput` gains `PlayerCount *int`. On reset it is applied with `webutil.ApplyBoundedInt` (2..6); out-of-range or omitted values fall back to the default (4), per the issue's acceptance criteria.

**Frontend**
- `pigtailApi.exec` accepts an optional `playerCount` argument.
- `PigsTailPage` adds a player-count `SettingsPanel` select (2–6); the choice is applied on the next reset. Mount reset uses the server default. Player list and CPU actions already follow the roster returned by the server.
- i18n: `setup.playerCount` / `setup.playerCountUnit` for ja + en.

## Supported player-count range
**2..6** (default 4).

## Tests
- Domain: config validation table (min/default/max/out-of-range), legacy-JSON default, roster-rebuild-from-config, out-of-range clamp.
- Controller: reset applies/clamps/defaults player count.
- Frontend: api body (with/without playerCount), page mount-reset default + settings-select applied on reset.

## Gates
- `go test -tags test ./...` — all pass
- `golangci-lint run ./internal/...` — 0 issues
- `goimports -w` on modified Go files
- `bun run check` (biome) + `bun run build` (tsc + vite) — pass
- Pig's Tail lives in the **classic** worker: `GOOS=js GOARCH=wasm go build -tags classic` — OK (also verified solo build OK). CI runs the real gzip size-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)