### PR TITLE
feat(teenpatti): show hand comparison result after a side show

### DIFF
--- a/frontend/src/i18n/locales/en/teenpatti.json
+++ b/frontend/src/i18n/locales/en/teenpatti.json
@@ -53,6 +53,10 @@
   "betNotice": "Your turn — choose See, Bet, Raise or Fold.",
   "sideShowTitle": "Side Show Request",
   "sideShowPending": "{{requester}} requested a Side Show with {{target}}. Accept or decline.",
+  "sideShowResult": {
+    "title": "Side Show Result",
+    "outcome": "{{winner}} ({{winnerHand}}) beat {{loser}} ({{loserHand}}); {{loser}} folded."
+  },
   "roundResult": {
     "title": "Deal Result",
     "winner": "{{name}} wins the pot of {{pot}}."

--- a/frontend/src/i18n/locales/ja/teenpatti.json
+++ b/frontend/src/i18n/locales/ja/teenpatti.json
@@ -53,6 +53,10 @@
   "betNotice": "あなたの番です — シー／ベット／レイズ／フォールドを選んでください。",
   "sideShowTitle": "サイドショー要求",
   "sideShowPending": "{{requester}} が {{target}} にサイドショーを要求しました。承諾か拒否を選んでください。",
+  "sideShowResult": {
+    "title": "サイドショー結果",
+    "outcome": "{{winner}}（{{winnerHand}}）が {{loser}}（{{loserHand}}）に勝ち、{{loser}} がフォールドしました。"
+  },
   "roundResult": {
     "title": "ディール結果",
     "winner": "{{name}} がポット {{pot}} を獲得しました。"

--- a/frontend/src/pages/TeenPattiPage.test.tsx
+++ b/frontend/src/pages/TeenPattiPage.test.tsx
@@ -123,6 +123,54 @@ describe('TeenPattiPage', () => {
     expect(within(panel).queryByRole('button', { name: '拒否' })).not.toBeInTheDocument();
   });
 
+  it('shows the resolved Side Show comparison panel with both hands and the outcome', async () => {
+    mockExec.mockResolvedValue(
+      makeTeenPattiState({
+        phase: 0,
+        currentPlayerIdx: 0,
+        isHumanTurn: true,
+        lastSideShow: {
+          requesterIdx: 0,
+          targetIdx: 2,
+          winnerIdx: 0,
+          loserIdx: 2,
+          requester: {
+            playerIdx: 0,
+            handName: 'trail',
+            cards: [
+              { design: 'SPADE', value: 5 },
+              { design: 'HEART', value: 5 },
+              { design: 'CLOVER', value: 5 },
+            ],
+          },
+          target: {
+            playerIdx: 2,
+            handName: 'highcard',
+            cards: [
+              { design: 'DIAMOND', value: 2 },
+              { design: 'CLOVER', value: 7 },
+              { design: 'SPADE', value: 9 },
+            ],
+          },
+        },
+      }),
+    );
+    renderWithProviders(<TeenPattiPage />);
+    const panel = await screen.findByTestId('teenpatti-sideshow-result');
+    // The result title and outcome sentence naming winner/loser and their hand ranks.
+    expect(within(panel).getByText('サイドショー結果')).toBeInTheDocument();
+    expect(within(panel).getAllByText(/あなた/).length).toBeGreaterThanOrEqual(1);
+    expect(within(panel).getAllByText(/トレイル/).length).toBeGreaterThanOrEqual(1);
+    // Both participants' cards are rendered (3 + 3).
+    expect(within(panel).getAllByRole('img').length).toBeGreaterThanOrEqual(6);
+  });
+
+  it('hides the resolved Side Show panel when there is no last side show', async () => {
+    renderWithProviders(<TeenPattiPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalled());
+    expect(screen.queryByTestId('teenpatti-sideshow-result')).not.toBeInTheDocument();
+  });
+
   it('hides the Side Show panel outside the Side Show phase', async () => {
     renderWithProviders(<TeenPattiPage />);
     await waitFor(() => expect(mockExec).toHaveBeenCalled());

--- a/frontend/src/pages/TeenPattiPage.tsx
+++ b/frontend/src/pages/TeenPattiPage.tsx
@@ -301,6 +301,49 @@ function TeenPattiPageContent() {
               </div>
             )}
 
+            {/* Resolved Side Show comparison — both hands + who won (human-involved only) */}
+            {state.lastSideShow && (
+              <div
+                className="mb-2 p-3 rounded bg-black/30 ring-1 ring-ds-warning/60"
+                data-testid="teenpatti-sideshow-result"
+              >
+                <div className="text-ds-warning text-sm font-semibold mb-1">{t('sideShowResult.title')}</div>
+                <div className="text-ds-text-primary text-sm mb-2">
+                  {t('sideShowResult.outcome', {
+                    winner: playerLabel(state.lastSideShow.winnerIdx, state.lastSideShow.winnerIdx === humanIdx),
+                    loser: playerLabel(state.lastSideShow.loserIdx, state.lastSideShow.loserIdx === humanIdx),
+                    winnerHand: handName(
+                      (state.lastSideShow.winnerIdx === state.lastSideShow.requester.playerIdx
+                        ? state.lastSideShow.requester
+                        : state.lastSideShow.target
+                      ).handName,
+                    ),
+                    loserHand: handName(
+                      (state.lastSideShow.loserIdx === state.lastSideShow.requester.playerIdx
+                        ? state.lastSideShow.requester
+                        : state.lastSideShow.target
+                      ).handName,
+                    ),
+                  })}
+                </div>
+                <div className="flex flex-wrap gap-4">
+                  {[state.lastSideShow.requester, state.lastSideShow.target].map((h) => (
+                    <div key={h.playerIdx}>
+                      <div className="text-ds-text-muted text-xs mb-0.5">
+                        {playerLabel(h.playerIdx, h.playerIdx === humanIdx)}
+                        {h.handName ? ` — ${handName(h.handName)}` : ''}
+                      </div>
+                      <div className="flex gap-1">
+                        {h.cards.map((c, i) => (
+                          <CardImage key={`ss-${h.playerIdx}-${i}`} card={c} width={cardWidth} />
+                        ))}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
             {/* Revealed hands at showdown */}
             {state.isShowdown && (
               <div className="mb-2 p-2 rounded bg-black/30">

--- a/frontend/src/types/card.ts
+++ b/frontend/src/types/card.ts
@@ -4101,6 +4101,35 @@ export interface TeenPattiHint {
   reason: string;
 }
 
+/** One participant's revealed hand in a resolved Side Show. */
+export interface TeenPattiSideShowHand {
+  /** Seat index of this participant. */
+  playerIdx: number;
+  /** Hand ranking name key (see `hand.*` i18n). */
+  handName: string;
+  /** The participant's three cards, revealed for the comparison. */
+  cards: Card[];
+}
+
+/**
+ * The comparison result of the most recent accepted Side Show, present only
+ * when the human was a participant (CPU-vs-CPU comparisons stay hidden).
+ */
+export interface TeenPattiSideShowResult {
+  /** Seat index that requested the Side Show. */
+  requesterIdx: number;
+  /** Seat index that accepted the Side Show. */
+  targetIdx: number;
+  /** Seat index that won the comparison. */
+  winnerIdx: number;
+  /** Seat index that lost and folded. */
+  loserIdx: number;
+  /** The requester's revealed hand. */
+  requester: TeenPattiSideShowHand;
+  /** The target's revealed hand. */
+  target: TeenPattiSideShowHand;
+}
+
 /**
  * Full Teen Patti game state returned from the API.
  *
@@ -4144,6 +4173,8 @@ export interface TeenPattiResponse extends BaseGameResponse {
   /** Whether it is currently the human's turn to act. */
   isHumanTurn: boolean;
   hint?: TeenPattiHint | null;
+  /** Result of the last human-involved Side Show comparison, if any. */
+  lastSideShow?: TeenPattiSideShowResult | null;
   config: TeenPattiConfig;
 }
 

--- a/internal/adapter/controller/TeenPattiWebController.go
+++ b/internal/adapter/controller/TeenPattiWebController.go
@@ -49,6 +49,32 @@ type TeenPattiWebOutputHint struct {
 	Reason string `json:"reason"`
 }
 
+// TeenPattiWebOutputSideShowHand サイドショー参加者 1 人分の公開手札
+type TeenPattiWebOutputSideShowHand struct {
+	// PlayerIdx 参加者の席インデックス
+	PlayerIdx int `json:"playerIdx"`
+	// HandName 役名 i18n キー
+	HandName string `json:"handName"`
+	// Cards 公開された 3 枚のカード
+	Cards []*WebOutputCard `json:"cards"`
+}
+
+// TeenPattiWebOutputSideShow 直近で成立したサイドショーの比較結果 (人間が当事者のときのみ設定)
+type TeenPattiWebOutputSideShow struct {
+	// RequesterIdx サイドショー申請者の席インデックス
+	RequesterIdx int `json:"requesterIdx"`
+	// TargetIdx サイドショー対象者の席インデックス
+	TargetIdx int `json:"targetIdx"`
+	// WinnerIdx 手比べの勝者インデックス
+	WinnerIdx int `json:"winnerIdx"`
+	// LoserIdx 手比べの敗者 (フォールドした) インデックス
+	LoserIdx int `json:"loserIdx"`
+	// Requester 申請者の公開手札
+	Requester *TeenPattiWebOutputSideShowHand `json:"requester"`
+	// Target 対象者の公開手札
+	Target *TeenPattiWebOutputSideShowHand `json:"target"`
+}
+
 // TeenPattiWebOutputConfig ティーン・パティの設定アウトプット
 type TeenPattiWebOutputConfig struct {
 	CpuDifficulty int `json:"cpuDifficulty"`
@@ -75,6 +101,7 @@ type TeenPattiWebOutput struct {
 	GameEndFlag        bool                        `json:"gameEndFlag"`
 	IsHumanTurn        bool                        `json:"isHumanTurn"`
 	Hint               *TeenPattiWebOutputHint     `json:"hint,omitempty"`
+	LastSideShow       *TeenPattiWebOutputSideShow `json:"lastSideShow,omitempty"`
 	Config             TeenPattiWebOutputConfig    `json:"config"`
 	WebOutputBase
 }

--- a/internal/adapter/presenter/TeenPattiWebPresenter.go
+++ b/internal/adapter/presenter/TeenPattiWebPresenter.go
@@ -81,7 +81,47 @@ func (p *TeenPattiWebPresenter) buildBase(g interfaces.TeenPattiGame) *controlle
 	}
 
 	resObj.Players = p.buildPlayersOutput(g)
+	resObj.LastSideShow = p.buildSideShowOutput(g)
 	return resObj
+}
+
+// buildSideShowOutput 直近で成立したサイドショーの比較結果を構築する。
+// 人間が申請者または対象のときのみ両者の手札と役名を公開する (CPU 同士は秘匿)。
+func (p *TeenPattiWebPresenter) buildSideShowOutput(g interfaces.TeenPattiGame) *controller.TeenPattiWebOutputSideShow {
+	req, tgt, loser, ok := g.GetLastSideShow()
+	if !ok {
+		return nil
+	}
+	reqP := g.GetPlayer(req)
+	tgtP := g.GetPlayer(tgt)
+	if reqP == nil || tgtP == nil {
+		return nil
+	}
+	// 秘匿: 人間が当事者でないサイドショー (CPU 同士) はカードを漏らさない。
+	if !reqP.GetIsHuman() && !tgtP.GetIsHuman() {
+		return nil
+	}
+	winner := req
+	if loser == req {
+		winner = tgt
+	}
+	return &controller.TeenPattiWebOutputSideShow{
+		RequesterIdx: req,
+		TargetIdx:    tgt,
+		WinnerIdx:    winner,
+		LoserIdx:     loser,
+		Requester:    teenPattiSideShowHand(req, reqP),
+		Target:       teenPattiSideShowHand(tgt, tgtP),
+	}
+}
+
+// teenPattiSideShowHand はサイドショー参加者 1 人分の公開手札を構築する。
+func teenPattiSideShowHand(idx int, player *domain.TeenPattiPlayer) *controller.TeenPattiWebOutputSideShowHand {
+	return &controller.TeenPattiWebOutputSideShowHand{
+		PlayerIdx: idx,
+		HandName:  teenPattiHandName(player),
+		Cards:     playerCardsToOutput(player, true),
+	}
 }
 
 // buildPlayersOutput プレイヤー情報を構築

--- a/internal/adapter/presenter/TeenPattiWebPresenter_test.go
+++ b/internal/adapter/presenter/TeenPattiWebPresenter_test.go
@@ -31,6 +31,7 @@ func tpSetupWebMock() *interfaces.MockTeenPattiGame {
 	m.On("CanRequestSideShow").Return(false)
 	m.On("GetSideShowRequester").Return(-1)
 	m.On("GetSideShowTarget").Return(-1)
+	m.On("GetLastSideShow").Return(-1, -1, -1, false)
 	m.On("IsHumanTurn").Return(true)
 	m.On("GetConfig").Return(domain.DefaultTeenPattiConfig())
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
@@ -142,6 +143,45 @@ func TestTeenPattiWebPresenter_Output(t *testing.T) {
 		assert.NoError(t, json.Unmarshal([]byte(result), &resObj))
 		assert.Equal(t, "teenpatti.roundEndCpuWin", resObj.MessageCode)
 		assert.Equal(t, map[string]string{"player": "1"}, resObj.MessageParams)
+	})
+
+	t.Run("human-involved side show reveals both hands", func(t *testing.T) {
+		m, players := tpSetupWebMockWithPlayers()
+		// 人間 (0) が申請者、CPU (2) が対象。人間の勝ち (トレイル) → 対象が敗者。
+		players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 5, false))
+		players[0].AddCard(domain.NewCard(domain.CardDesignHeart, 5, false))
+		players[0].AddCard(domain.NewCard(domain.CardDesignClover, 5, false))
+		players[2].AddCard(domain.NewCard(domain.CardDesignDiamond, 2, false))
+		players[2].AddCard(domain.NewCard(domain.CardDesignClover, 7, false))
+		players[2].AddCard(domain.NewCard(domain.CardDesignSpade, 9, false))
+		players[2].SetFolded(true)
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetLastSideShow")
+		m.On("GetLastSideShow").Return(0, 2, 2, true)
+		result := p.Output(m, nil)
+		var resObj controller.TeenPattiWebOutput
+		assert.NoError(t, json.Unmarshal([]byte(result), &resObj))
+		assert.NotNil(t, resObj.LastSideShow)
+		assert.Equal(t, 0, resObj.LastSideShow.RequesterIdx)
+		assert.Equal(t, 2, resObj.LastSideShow.TargetIdx)
+		assert.Equal(t, 0, resObj.LastSideShow.WinnerIdx)
+		assert.Equal(t, 2, resObj.LastSideShow.LoserIdx)
+		assert.Len(t, resObj.LastSideShow.Requester.Cards, 3)
+		assert.Equal(t, "trail", resObj.LastSideShow.Requester.HandName)
+		assert.Len(t, resObj.LastSideShow.Target.Cards, 3)
+		assert.Equal(t, "highcard", resObj.LastSideShow.Target.HandName)
+	})
+
+	t.Run("cpu-vs-cpu side show stays hidden", func(t *testing.T) {
+		m, players := tpSetupWebMockWithPlayers()
+		// CPU (1) 申請者・CPU (2) 対象 → 人間非関与のため非公開。
+		players[1].AddCard(domain.NewCard(domain.CardDesignSpade, 5, false))
+		players[2].AddCard(domain.NewCard(domain.CardDesignDiamond, 2, false))
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetLastSideShow")
+		m.On("GetLastSideShow").Return(1, 2, 2, true)
+		result := p.Output(m, nil)
+		var resObj controller.TeenPattiWebOutput
+		assert.NoError(t, json.Unmarshal([]byte(result), &resObj))
+		assert.Nil(t, resObj.LastSideShow)
 	})
 
 	t.Run("error message takes priority", func(t *testing.T) {

--- a/internal/domain/TeenPatti.go
+++ b/internal/domain/TeenPatti.go
@@ -49,6 +49,15 @@ type TeenPattiHint struct {
 	Reason string // ヒント理由キー
 }
 
+// teenPattiSideShow は直近で成立した (承諾された) サイドショーの結果を保持する (表示用)。
+// カード自体は保持せず参加者インデックスと敗者のみを持つ (WASM バイナリを軽く保つため)。
+// プレゼンター側が保持中のカードを敗者・勝者インデックスから引いて役名と手札を組み立てる。
+type teenPattiSideShow struct {
+	Requester int `json:"rq"` // 申請者インデックス
+	Target    int `json:"tg"` // 対象インデックス
+	Loser     int `json:"ls"` // 敗者インデックス (Requester または Target)
+}
+
 // TeenPatti ティーンパッティ ゲームクラス
 type TeenPatti struct {
 	trumpCards        *TrumpCards
@@ -67,7 +76,8 @@ type TeenPatti struct {
 	sideShowRequester int // サイドショー申請者 (-1: なし)
 	sideShowTarget    int // サイドショー対象 (-1: なし)
 	gameEndFlag       bool
-	matchWinnerIdx    int // 試合の勝者 (-1: 未確定)
+	matchWinnerIdx    int                // 試合の勝者 (-1: 未確定)
+	lastSideShow      *teenPattiSideShow // 直近で成立したサイドショー結果 (nil: なし)
 	actionLog         []*ActionLogEntry
 }
 
@@ -126,6 +136,7 @@ func (g *TeenPatti) startDeal() {
 	g.actionCount = 0
 	g.sideShowRequester = -1
 	g.sideShowTarget = -1
+	g.lastSideShow = nil
 	g.stake = g.config.Ante
 
 	for _, p := range g.players {
@@ -289,6 +300,8 @@ func (g *TeenPatti) applyRespondSideShow(accept bool) {
 		if cmp > 0 {
 			loser = tgt
 		}
+		// 表示用に成立したサイドショーの結果を保持する (参加者のカードは deal 更新まで保持される)。
+		g.lastSideShow = &teenPattiSideShow{Requester: req, Target: tgt, Loser: loser}
 		g.appendLog(tgt, "sideshow_accept",
 			fmt.Sprintf("%s accepts; %s loses the side show", g.playerName(tgt), g.playerName(loser)), nil)
 		g.players[loser].SetFolded(true)
@@ -755,6 +768,15 @@ func (g *TeenPatti) GetSideShowRequester() int { return g.sideShowRequester }
 // GetSideShowTarget サイドショー対象インデックス取得 (-1: なし)
 func (g *TeenPatti) GetSideShowTarget() int { return g.sideShowTarget }
 
+// GetLastSideShow は直近で成立 (承諾) したサイドショーの申請者・対象・敗者を返す。
+// 成立したサイドショーがまだ無い (またはディール更新で消去済み) のとき ok=false。
+func (g *TeenPatti) GetLastSideShow() (requester, target, loser int, ok bool) {
+	if g.lastSideShow == nil {
+		return -1, -1, -1, false
+	}
+	return g.lastSideShow.Requester, g.lastSideShow.Target, g.lastSideShow.Loser, true
+}
+
 // GetHint 人間プレイヤーへのヒントを取得する
 func (g *TeenPatti) GetHint() *TeenPattiHint {
 	if g.phase != TeenPattiPhaseBetting || g.currentPlayerIdx != 0 {
@@ -798,6 +820,7 @@ type teenPattiJSON struct {
 	SideShowTarget    int                `json:"st"`
 	GameEndFlag       bool               `json:"ge"`
 	MatchWinnerIdx    int                `json:"mw"`
+	LastSideShow      *teenPattiSideShow `json:"ls,omitempty"`
 	ActionLog         []*ActionLogEntry  `json:"al"`
 }
 
@@ -821,6 +844,7 @@ func (g *TeenPatti) MarshalJSON() ([]byte, error) {
 		SideShowTarget:    g.sideShowTarget,
 		GameEndFlag:       g.gameEndFlag,
 		MatchWinnerIdx:    g.matchWinnerIdx,
+		LastSideShow:      g.lastSideShow,
 		ActionLog:         g.actionLog,
 	})
 }
@@ -848,6 +872,13 @@ func (g *TeenPatti) UnmarshalJSON(data []byte) error {
 		j.SideShowTarget < -1 || j.SideShowTarget >= TeenPattiPlayerCnt ||
 		j.Phase < TeenPattiPhaseBetting || j.Phase > TeenPattiPhaseGameEnd {
 		return errTeenPattiSnapshot
+	}
+	if j.LastSideShow != nil {
+		ss := j.LastSideShow
+		if !teenPattiIdxInRange(ss.Requester) || !teenPattiIdxInRange(ss.Target) ||
+			!teenPattiIdxInRange(ss.Loser) || (ss.Loser != ss.Requester && ss.Loser != ss.Target) {
+			return errTeenPattiSnapshot
+		}
 	}
 	for _, p := range j.Players {
 		if p == nil {
@@ -879,6 +910,7 @@ func (g *TeenPatti) UnmarshalJSON(data []byte) error {
 	g.sideShowTarget = j.SideShowTarget
 	g.gameEndFlag = j.GameEndFlag
 	g.matchWinnerIdx = j.MatchWinnerIdx
+	g.lastSideShow = j.LastSideShow
 	g.actionLog = j.ActionLog
 	if g.actionLog == nil {
 		g.actionLog = make([]*ActionLogEntry, 0)

--- a/internal/domain/TeenPatti_test.go
+++ b/internal/domain/TeenPatti_test.go
@@ -130,6 +130,43 @@ func TestTeenPatti_SideShowAcceptLoserFolds(t *testing.T) {
 	require.NoError(t, g.PlayerRespondSideShow(true))
 	assert.True(t, g.GetPlayer(3).GetFolded()) // seat 3 lost and folded
 	assert.Equal(t, domain.TeenPattiPhaseBetting, g.GetPhase())
+	// The accepted side show result is retained for display.
+	req, tgt, loser, ok := g.GetLastSideShow()
+	require.True(t, ok)
+	assert.Equal(t, 0, req)
+	assert.Equal(t, 3, tgt)
+	assert.Equal(t, 3, loser)
+}
+
+func TestTeenPatti_LastSideShowLifecycle(t *testing.T) {
+	g := newAllHumanTeenPatti()
+	g.Reset()
+	// No side show has happened yet.
+	_, _, _, ok := g.GetLastSideShow()
+	assert.False(t, ok)
+
+	for i := 0; i < domain.TeenPattiPlayerCnt; i++ {
+		g.GetPlayer(i).SetSeen(true)
+	}
+	g.SetStake(1)
+	g.SetCurrentPlayerIdx(0)
+
+	// Declining does not record a comparison result.
+	require.NoError(t, g.PlayerRequestSideShow())
+	require.NoError(t, g.PlayerRespondSideShow(false))
+	_, _, _, ok = g.GetLastSideShow()
+	assert.False(t, ok)
+
+	// Accepting records a result; a new deal clears it.
+	g.SetCurrentPlayerIdx(0)
+	require.NoError(t, g.PlayerRequestSideShow())
+	require.NoError(t, g.PlayerRespondSideShow(true))
+	_, _, _, ok = g.GetLastSideShow()
+	require.True(t, ok)
+	g.SetPhase(domain.TeenPattiPhaseRoundEnd)
+	g.NextRound()
+	_, _, _, ok = g.GetLastSideShow()
+	assert.False(t, ok)
 }
 
 func TestTeenPatti_SideShowDeclineContinues(t *testing.T) {
@@ -253,4 +290,34 @@ func TestTeenPatti_UnmarshalRejectsInvalid(t *testing.T) {
 	assert.Error(t, bad2.UnmarshalJSON([]byte(`{"ps":[null]}`)))
 	var bad3 domain.TeenPatti
 	assert.Error(t, bad3.UnmarshalJSON([]byte(`not json`)))
+}
+
+func TestTeenPatti_JSONRoundTripSideShow(t *testing.T) {
+	g := newAllHumanTeenPatti()
+	g.Reset()
+	for i := 0; i < domain.TeenPattiPlayerCnt; i++ {
+		g.GetPlayer(i).SetSeen(true)
+	}
+	g.SetStake(1)
+	g.SetCurrentPlayerIdx(0)
+	tpSetHand(g.GetPlayer(0), tpCard(domain.CardDesignSpade, 13), tpCard(domain.CardDesignClover, 13), tpCard(domain.CardDesignHeart, 13))
+	tpSetHand(g.GetPlayer(3), tpCard(domain.CardDesignSpade, 2), tpCard(domain.CardDesignClover, 7), tpCard(domain.CardDesignHeart, 9))
+	require.NoError(t, g.PlayerRequestSideShow())
+	require.NoError(t, g.PlayerRespondSideShow(true))
+
+	data, err := json.Marshal(g)
+	require.NoError(t, err)
+	var g2 domain.TeenPatti
+	require.NoError(t, json.Unmarshal(data, &g2))
+	req, tgt, loser, ok := g2.GetLastSideShow()
+	require.True(t, ok)
+	assert.Equal(t, 0, req)
+	assert.Equal(t, 3, tgt)
+	assert.Equal(t, 3, loser)
+
+	// A side show whose loser is neither participant is rejected.
+	tampered := strings.Replace(string(data), `"ls":{"rq":0,"tg":3,"ls":3}`, `"ls":{"rq":0,"tg":3,"ls":1}`, 1)
+	require.NotEqual(t, string(data), tampered)
+	var bad domain.TeenPatti
+	assert.Error(t, bad.UnmarshalJSON([]byte(tampered)))
 }

--- a/internal/domain/interfaces/teenpatti.go
+++ b/internal/domain/interfaces/teenpatti.go
@@ -55,6 +55,8 @@ type TeenPattiGame interface {
 	GetSideShowRequester() int
 	// GetSideShowTarget サイドショー対象者インデックスを取得する (-1=なし)
 	GetSideShowTarget() int
+	// GetLastSideShow 直近で成立したサイドショーの申請者・対象・敗者を返す (ok=false=結果なし)
+	GetLastSideShow() (requester, target, loser int, ok bool)
 	// GetGameEndFlag ゲーム終了フラグを取得する
 	GetGameEndFlag() bool
 	// GetMatchWinnerIdx 試合の勝者を取得する (-1=未確定)

--- a/internal/domain/interfaces/teenpatti_mock.go
+++ b/internal/domain/interfaces/teenpatti_mock.go
@@ -147,6 +147,12 @@ func (_m *MockTeenPattiGame) GetSideShowTarget() int {
 	return ret.Get(0).(int)
 }
 
+// GetLastSideShow モック
+func (_m *MockTeenPattiGame) GetLastSideShow() (int, int, int, bool) {
+	ret := _m.Called()
+	return ret.Int(0), ret.Int(1), ret.Int(2), ret.Bool(3)
+}
+
 // GetGameEndFlag モック
 func (_m *MockTeenPattiGame) GetGameEndFlag() bool {
 	ret := _m.Called()


### PR DESCRIPTION
## Summary

On a **Side Show** in Teen Patti, the two hands are compared and the loser folds, but until now the human — even when a participant — only saw a one-line message and never learned *which hands* were compared or who lost. This adds a comparison-result panel showing both participants' cards, their hand ranks, and the winner/loser.

## What changed

- **Domain** (`internal/domain/TeenPatti.go`): retain a minimal `lastSideShow` struct (`requester`, `target`, `loser` seat indices only — **no cards**) set when an accepted Side Show is resolved, cleared at the start of each deal. Exposed via `GetLastSideShow() (requester, target, loser int, ok bool)`. Serialized in the game snapshot with validation (loser must be one of the two participants).
- **Presenter** (`TeenPattiWebPresenter.go`): builds a `lastSideShow` output field, rebuilding both hands (cards + hand-rank name) from the participants' still-held cards. Exposed **only when the human is a participant** — CPU-vs-CPU comparisons stay hidden (privacy).
- **Frontend** (`TeenPattiPage.tsx`, `types/card.ts`, i18n): additive result panel with both hands and an outcome sentence.

## Size / WASM (casino worker)

The casino worker is tight. To stay safe I retained **only 3 ints** in the domain (no card data); the presenter reconstructs the hands from live state.

- Casino gzip on latest develop: **1,033,372 B** (headroom vs 1,048,576 = **~14.8 KB**).
- Domain addition: one 3-int struct + pointer field + getter + one JSON field — negligible.
- `GOOS=js GOARCH=wasm go build -tags casino ./cmd/workers/casino/` → **WASM_OK**. CI's size-check remains the final guard.

## Tests

- Domain: side-show result retained on accept, not on decline, cleared on new deal; JSON round-trip + invalid-loser rejection.
- Presenter: human-involved reveals both hands + ranks; CPU-vs-CPU stays hidden.
- Page: result panel renders both hands + outcome; hidden when no side show.
- `go test -tags test ./...` green; `bun run build && bun run check && bun run test -- --run TeenPatti` green; WASM_OK.

Closes #3461

🤖 Generated with [Claude Code](https://claude.com/claude-code)