### PR TITLE
feat(clocksolitaire): add undo for the last placed card

### DIFF
--- a/frontend/src/api/gameApi.ts
+++ b/frontend/src/api/gameApi.ts
@@ -4539,7 +4539,7 @@ export const pigtailApi = {
 
 /** API client for the Clock Solitaire /clocksolitaire/exec endpoint. */
 export const clocksolitaireApi = {
-  exec: (command: 'reset' | 'step' | 'autoplay' | 'log') =>
+  exec: (command: 'reset' | 'step' | 'autoplay' | 'undo' | 'log') =>
     gameExec<ClockSolitaireResponse>('clocksolitaire', { command }),
 };
 

--- a/frontend/src/i18n/locales/en/clocksolitaire.json
+++ b/frontend/src/i18n/locales/en/clocksolitaire.json
@@ -9,6 +9,7 @@
   "step": "Step",
   "autoplay": "Auto Play",
   "stopAutoplay": "Stop",
+  "undo": "Undo",
   "currentCard": "Current Card",
   "settings": {
     "speed": "Animation Speed",

--- a/frontend/src/i18n/locales/ja/clocksolitaire.json
+++ b/frontend/src/i18n/locales/ja/clocksolitaire.json
@@ -9,6 +9,7 @@
   "step": "ステップ",
   "autoplay": "オートプレイ",
   "stopAutoplay": "停止",
+  "undo": "元に戻す",
   "currentCard": "手持ちカード",
   "settings": {
     "speed": "演出速度",

--- a/frontend/src/pages/ClockSolitairePage.test.tsx
+++ b/frontend/src/pages/ClockSolitairePage.test.tsx
@@ -344,4 +344,32 @@ describe('ClockSolitairePage', () => {
       vi.useRealTimers();
     }
   });
+
+  it('disables the undo button when canUndo is false', async () => {
+    restoreCliModeDefault();
+    mockExec.mockResolvedValue({ ...playingState, canUndo: false });
+    renderWithProviders(<ClockSolitairePage />);
+    const undoBtn = await screen.findByTestId('cs-undo-button');
+    expect(undoBtn).toBeDisabled();
+  });
+
+  it('enables the undo button and dispatches undo on click', async () => {
+    restoreCliModeDefault();
+    mockExec.mockResolvedValue({ ...playingState, canUndo: true });
+    renderWithProviders(<ClockSolitairePage />);
+    const undoBtn = await screen.findByTestId('cs-undo-button');
+    await waitFor(() => expect(undoBtn).not.toBeDisabled());
+    fireEvent.click(undoBtn);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('undo'));
+  });
+
+  it('shows an enabled undo button after game over so the last move can be reverted', async () => {
+    restoreCliModeDefault();
+    mockExec.mockResolvedValue({ ...gameOverState, canUndo: true });
+    renderWithProviders(<ClockSolitairePage />);
+    const undoBtn = await screen.findByTestId('cs-undo-button');
+    await waitFor(() => expect(undoBtn).not.toBeDisabled());
+    // The step/autoplay controls are hidden once the game has ended.
+    expect(screen.queryByTestId('cs-step-button')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/ClockSolitairePage.tsx
+++ b/frontend/src/pages/ClockSolitairePage.tsx
@@ -22,7 +22,7 @@ import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useMountReset } from '../hooks/useMountReset';
-import { btnPrimary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
+import { btnOutline, btnPrimary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { ClockSolitaireResponse } from '../types/card';
 import { ClockSolitairePhase } from '../types/phases';
@@ -103,6 +103,12 @@ function ClockSolitairePageContent() {
   const [autoPlaying, setAutoPlaying] = useState(false);
 
   const handleStep = useCallback(() => execApi('step'), [execApi]);
+  // Undo the last placed card. Stop autoplay first so the timed loop doesn't
+  // race the rewind.
+  const handleUndo = useCallback(() => {
+    setAutoPlaying(false);
+    return execApi('undo');
+  }, [execApi]);
   // Autoplay is driven client-side as a timed sequence of `step` calls (see the
   // effect below) so each card's landing highlight plays out; the button toggles it.
   const handleAutoPlay = useCallback(() => setAutoPlaying((prev) => !prev), []);
@@ -166,6 +172,7 @@ function ClockSolitairePageContent() {
         if (cmd === 'reset' || cmd === 'r') return { args: ['reset'] };
         if (cmd === 'step' || cmd === 's') return { args: ['step'] };
         if (cmd === 'autoplay' || cmd === 'auto' || cmd === 'a') return { args: ['autoplay'] };
+        if (cmd === 'undo' || cmd === 'u') return { args: ['undo'] };
         if (cmd === 'log' || cmd === 'l') return { args: ['log'] };
         return { error: `Unknown command: ${cmd}` };
       },
@@ -189,6 +196,7 @@ function ClockSolitairePageContent() {
       helpText: [
         's/step     - Place one card',
         'a/autoplay - Auto-play to end',
+        'u/undo     - Undo the last step',
         'l/log      - Show action log',
         'r/reset    - Reset game',
       ],
@@ -449,6 +457,15 @@ function ClockSolitairePageContent() {
                   </button>
                 </div>
               )}
+              <button
+                type="button"
+                className={`${btnOutline} ${focusRingWhite}`}
+                onClick={handleUndo}
+                disabled={!state.canUndo || loading || autoPlaying}
+                data-testid="cs-undo-button"
+              >
+                {t('undo')}
+              </button>
               <GameResetButton
                 isGameEnd={isEnded}
                 onReset={handleReset}

--- a/frontend/src/types/card.ts
+++ b/frontend/src/types/card.ts
@@ -7862,6 +7862,7 @@ export interface ClockSolitaireResponse extends BaseGameResponse {
   phase: number;
   stepCount: number;
   currentCard?: Card;
+  canUndo?: boolean;
 }
 
 /** Durak player data. */

--- a/internal/adapter/controller/ClockSolitaireCuiController.go
+++ b/internal/adapter/controller/ClockSolitaireCuiController.go
@@ -23,13 +23,15 @@ func (c *ClockSolitaireCuiController) Exec(command string) string {
 		func(_ []string) string {
 			return c.ci.Reset()
 		},
-		[]string{"s", "step", "a", "autoplay", "log", "l"},
+		[]string{"s", "step", "a", "autoplay", "u", "undo", "log", "l"},
 		func(cmd string, _ []string) (string, bool) {
 			switch cmd {
 			case "s", "step":
 				return c.ci.Step(), true
 			case "a", "autoplay":
 				return c.ci.AutoPlay(), true
+			case "u", "undo":
+				return c.ci.Undo(), true
 			default:
 				return handleCuiLog(cmd, c.ci.ActionLog)
 			}

--- a/internal/adapter/controller/ClockSolitaireCuiController_test.go
+++ b/internal/adapter/controller/ClockSolitaireCuiController_test.go
@@ -43,6 +43,14 @@ func TestClockSolitaireCuiControllerAutoPlay(t *testing.T) {
 	assert.Equal(t, "autoplay_output", c.Exec("autoplay"))
 }
 
+func TestClockSolitaireCuiControllerUndo(t *testing.T) {
+	ci := newMockClockSolitaireInteractor()
+	c := NewClockSolitaireCuiController(ci)
+	ci.On("Undo").Return("undo_output")
+	assert.Equal(t, "undo_output", c.Exec("u"))
+	assert.Equal(t, "undo_output", c.Exec("undo"))
+}
+
 func TestClockSolitaireCuiControllerActionLog(t *testing.T) {
 	ci := newMockClockSolitaireInteractor()
 	c := NewClockSolitaireCuiController(ci)

--- a/internal/adapter/controller/ClockSolitaireWebController.go
+++ b/internal/adapter/controller/ClockSolitaireWebController.go
@@ -26,6 +26,7 @@ type ClockSolitaireWebOutput struct {
 	Phase       int                              `json:"phase"`
 	StepCount   int                              `json:"stepCount"`
 	CurrentCard *WebOutputCard                   `json:"currentCard,omitempty"`
+	CanUndo     bool                             `json:"canUndo"`
 	WebOutputBase
 }
 
@@ -47,8 +48,12 @@ func newClockSolitaireDefaultOutput(msg string) *ClockSolitaireWebOutput {
 }
 
 func clockSolitaireDispatch(bc *baseController, w http.ResponseWriter, ci usecase.ClockSolitaireInteractorIF, param ClockSolitaireWebInput, _ func(string) *ClockSolitaireWebOutput) bool {
-	if param.Command == "a" || param.Command == "autoplay" {
+	switch param.Command {
+	case "a", "autoplay":
 		bc.writePresenterResponse(w, ci.AutoPlay())
+		return true
+	case "u", "undo":
+		bc.writePresenterResponse(w, ci.Undo())
 		return true
 	}
 	return dispatchResetStepLog(param.Command, bc, w, ci)

--- a/internal/adapter/controller/ClockSolitaireWebController_test.go
+++ b/internal/adapter/controller/ClockSolitaireWebController_test.go
@@ -33,6 +33,7 @@ func TestClockSolitaireWebController_Commands(t *testing.T) {
 	ciMock.On("Reset").Return(mockOutput)
 	ciMock.On("Step").Return(mockOutput)
 	ciMock.On("AutoPlay").Return(mockOutput)
+	ciMock.On("Undo").Return(mockOutput)
 	ciMock.On("ActionLog").Return(mockOutput)
 
 	tests := []struct {
@@ -42,10 +43,12 @@ func TestClockSolitaireWebController_Commands(t *testing.T) {
 		{"reset", "reset"},
 		{"step", "step"},
 		{"autoplay", "autoplay"},
+		{"undo", "undo"},
 		{"log", "log"},
 		{"short-r", "r"},
 		{"short-s", "s"},
 		{"short-a", "a"},
+		{"short-u", "u"},
 		{"short-l", "l"},
 	}
 

--- a/internal/adapter/controller/usecase/ClockSolitaireInteractor_mock.go
+++ b/internal/adapter/controller/usecase/ClockSolitaireInteractor_mock.go
@@ -24,6 +24,12 @@ func (_m *MockClockSolitaireInteractor) AutoPlay() string {
 	return ret.Get(0).(string)
 }
 
+// Undo モック
+func (_m *MockClockSolitaireInteractor) Undo() string {
+	ret := _m.Called()
+	return ret.Get(0).(string)
+}
+
 func (_m *MockClockSolitaireInteractor) ActionLog() string {
 	ret := _m.Called()
 	return ret.Get(0).(string)

--- a/internal/adapter/presenter/ClockSolitaireWebPresenter.go
+++ b/internal/adapter/presenter/ClockSolitaireWebPresenter.go
@@ -18,6 +18,7 @@ func (pr *ClockSolitaireWebPresenter) Output(g interfaces.ClockSolitaireGame, la
 	resObj := new(controller.ClockSolitaireWebOutput)
 	resObj.Phase = int(g.GetPhase())
 	resObj.StepCount = g.GetStepCount()
+	resObj.CanUndo = g.CanUndo()
 
 	// パイル
 	piles := g.GetPiles()

--- a/internal/adapter/presenter/ClockSolitaireWebPresenter_test.go
+++ b/internal/adapter/presenter/ClockSolitaireWebPresenter_test.go
@@ -34,6 +34,7 @@ func setupClockSolitaireWebMockDefaults(gg *interfaces.MockClockSolitaireGame) {
 	gg.On("GetPiles").Return(piles).Maybe()
 	gg.On("GetFaceUpCount").Return(fuc).Maybe()
 	gg.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil)).Maybe()
+	gg.On("CanUndo").Return(false).Maybe()
 }
 
 func parseClockSolitaireOutput(t *testing.T, jsonStr string) *controller.ClockSolitaireWebOutput {
@@ -86,6 +87,7 @@ func TestClockSolitaireWebPresenterOutput_GameClear(t *testing.T) {
 	}
 	gg.On("GetPiles").Return(piles)
 	gg.On("GetFaceUpCount").Return(fuc)
+	gg.On("CanUndo").Return(false)
 
 	p := &ClockSolitaireWebPresenter{}
 
@@ -113,6 +115,7 @@ func TestClockSolitaireWebPresenterOutput_GameOver(t *testing.T) {
 	}
 	gg.On("GetPiles").Return(piles)
 	gg.On("GetFaceUpCount").Return(fuc)
+	gg.On("CanUndo").Return(false)
 
 	p := &ClockSolitaireWebPresenter{}
 
@@ -145,12 +148,14 @@ func TestClockSolitaireWebPresenterOutput_FaceUpCards(t *testing.T) {
 	gg.On("GetCurrentCard").Return(domain.NewCard(domain.CardDesignSpade, 3, false))
 	gg.On("GetPiles").Return(piles)
 	gg.On("GetFaceUpCount").Return(fuc)
+	gg.On("CanUndo").Return(true)
 
 	p := &ClockSolitaireWebPresenter{}
 
 	result := p.Output(gg, nil)
 	out := parseClockSolitaireOutput(t, result)
 
+	assert.True(t, out.CanUndo)
 	// 表向きカードにはcard情報がある
 	assert.NotNil(t, out.Piles[0][0].Card)
 	assert.True(t, out.Piles[0][0].FaceUp)

--- a/internal/domain/ClockSolitaire.go
+++ b/internal/domain/ClockSolitaire.go
@@ -36,6 +36,11 @@ type ClockSolitaireCard struct {
 	FaceUp bool  `json:"f"`
 }
 
+// ClockSolitaireMaxUndoDepth caps the undo history so the serialised state
+// stays bounded. A full game places at most 52 cards, so this ceiling is never
+// hit in practice; it exists purely as a safety bound on the KV payload.
+const ClockSolitaireMaxUndoDepth = 50
+
 // ClockSolitaire クロックソリティアゲームクラス
 type ClockSolitaire struct {
 	trumpCards  *TrumpCards
@@ -45,6 +50,16 @@ type ClockSolitaire struct {
 	phase       ClockSolitairePhase
 	stepCount   int
 	actionLog   []*ActionLogEntry
+	history     []*clockSolitaireSnapshot
+}
+
+// clockSolitaireSnapshot アンドゥ用スナップショット
+type clockSolitaireSnapshot struct {
+	piles       [ClockSolitairePileCount][]*ClockSolitaireCard
+	faceUpCount [ClockSolitairePileCount]int
+	currentCard *Card
+	phase       ClockSolitairePhase
+	stepCount   int
 }
 
 // NewClockSolitaire コンストラクタ
@@ -67,6 +82,7 @@ func (cs *ClockSolitaire) Reset() {
 	cs.stepCount = 0
 	cs.actionLog = nil
 	cs.currentCard = nil
+	cs.history = nil
 
 	// 13パイルに4枚ずつ裏向きで配る
 	for i := range ClockSolitairePileCount {
@@ -93,6 +109,9 @@ func (cs *ClockSolitaire) Step() error {
 	if cs.currentCard == nil {
 		return errors.New("no current card")
 	}
+
+	// Snapshot the pre-move state so this step can be undone (#3121).
+	cs.takeSnapshot()
 
 	// カードの値から配置先パイルを決定（A=1→pile0, ..., Q=12→pile11, K=13→pile12）
 	destIdx := cs.currentCard.GetValue() - 1
@@ -143,6 +162,55 @@ func (cs *ClockSolitaire) AutoPlay() error {
 		}
 	}
 	return nil
+}
+
+// Undo 直前のステップを取り消す。ゲーム終了後でも巻き戻せる（スナップショットが
+// プレイ中フェーズを復元するため）。
+func (cs *ClockSolitaire) Undo() error {
+	if len(cs.history) == 0 {
+		return errors.New("cannot undo: no history")
+	}
+	snap := cs.history[len(cs.history)-1]
+	cs.history = cs.history[:len(cs.history)-1]
+	cs.restoreSnapshot(snap)
+	cs.appendLog("undo", "1手戻す", nil)
+	return nil
+}
+
+// CanUndo アンドゥ可能か
+func (cs *ClockSolitaire) CanUndo() bool {
+	return len(cs.history) > 0
+}
+
+// takeSnapshot 現在の可変状態をアンドゥ履歴に積む。履歴は
+// ClockSolitaireMaxUndoDepth 件で頭打ちにする。
+func (cs *ClockSolitaire) takeSnapshot() {
+	snap := &clockSolitaireSnapshot{
+		faceUpCount: cs.faceUpCount,
+		currentCard: cs.currentCard,
+		phase:       cs.phase,
+		stepCount:   cs.stepCount,
+	}
+	for i := range ClockSolitairePileCount {
+		snap.piles[i] = make([]*ClockSolitaireCard, len(cs.piles[i]))
+		for j, pc := range cs.piles[i] {
+			snap.piles[i][j] = &ClockSolitaireCard{Card: pc.Card, FaceUp: pc.FaceUp}
+		}
+	}
+	cs.history = append(cs.history, snap)
+	if len(cs.history) > ClockSolitaireMaxUndoDepth {
+		cs.history = cs.history[len(cs.history)-ClockSolitaireMaxUndoDepth:]
+	}
+}
+
+// restoreSnapshot スナップショットの状態を復元する。actionLog と history は
+// 復元対象外（アンドゥ操作自体を棋譜に残すため）。
+func (cs *ClockSolitaire) restoreSnapshot(snap *clockSolitaireSnapshot) {
+	cs.piles = snap.piles
+	cs.faceUpCount = snap.faceUpCount
+	cs.currentCard = snap.currentCard
+	cs.phase = snap.phase
+	cs.stepCount = snap.stepCount
 }
 
 // checkGameClear 全12時計位置がクリアかチェック
@@ -220,6 +288,53 @@ type clockSolitaireJSON struct {
 	Phase       ClockSolitairePhase                            `json:"ps"`
 	StepCount   int                                            `json:"sc"`
 	ActionLog   []*ActionLogEntry                              `json:"al"`
+	History     []*clockSolitaireSnapshot                      `json:"hi,omitempty"`
+}
+
+// clockSolitaireSnapshotJSON is the wire format for a single undo snapshot.
+// clockSolitaireSnapshot uses unexported fields, so we project to/from this
+// shape with explicit Marshal/Unmarshal methods.
+type clockSolitaireSnapshotJSON struct {
+	Piles       [ClockSolitairePileCount][]*ClockSolitaireCard `json:"pi"`
+	FaceUpCount [ClockSolitairePileCount]int                   `json:"fu"`
+	CurrentCard *Card                                          `json:"cc"`
+	Phase       ClockSolitairePhase                            `json:"ps"`
+	StepCount   int                                            `json:"sc"`
+}
+
+// MarshalJSON implements json.Marshaler for clockSolitaireSnapshot.
+func (s *clockSolitaireSnapshot) MarshalJSON() ([]byte, error) {
+	return json.Marshal(clockSolitaireSnapshotJSON{
+		Piles:       s.piles,
+		FaceUpCount: s.faceUpCount,
+		CurrentCard: s.currentCard,
+		Phase:       s.phase,
+		StepCount:   s.stepCount,
+	})
+}
+
+// UnmarshalJSON implements json.Unmarshaler for clockSolitaireSnapshot.
+func (s *clockSolitaireSnapshot) UnmarshalJSON(data []byte) error {
+	var j clockSolitaireSnapshotJSON
+	if err := json.Unmarshal(data, &j); err != nil {
+		return err
+	}
+	for i := range ClockSolitairePileCount {
+		if len(j.Piles[i]) > clockSolitaireMaxSliceLen {
+			return fmt.Errorf("clocksolitaire: snapshot pile %d exceeds maximum allowed size", i)
+		}
+	}
+	s.piles = j.Piles
+	for i := range ClockSolitairePileCount {
+		if s.piles[i] == nil {
+			s.piles[i] = make([]*ClockSolitaireCard, 0)
+		}
+	}
+	s.faceUpCount = j.FaceUpCount
+	s.currentCard = j.CurrentCard
+	s.phase = j.Phase
+	s.stepCount = j.StepCount
+	return nil
 }
 
 // MarshalJSON implements json.Marshaler.
@@ -232,6 +347,7 @@ func (cs *ClockSolitaire) MarshalJSON() ([]byte, error) {
 		Phase:       cs.phase,
 		StepCount:   cs.stepCount,
 		ActionLog:   cs.actionLog,
+		History:     cs.history,
 	})
 }
 
@@ -244,7 +360,7 @@ func (cs *ClockSolitaire) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &j); err != nil {
 		return err
 	}
-	if len(j.ActionLog) > clockSolitaireMaxSliceLen {
+	if len(j.ActionLog) > clockSolitaireMaxSliceLen || len(j.History) > clockSolitaireMaxSliceLen {
 		return fmt.Errorf("clocksolitaire: input array exceeds maximum allowed size")
 	}
 	for i := range ClockSolitairePileCount {
@@ -270,6 +386,10 @@ func (cs *ClockSolitaire) UnmarshalJSON(data []byte) error {
 	cs.actionLog = j.ActionLog
 	if cs.actionLog == nil {
 		cs.actionLog = make([]*ActionLogEntry, 0)
+	}
+	cs.history = j.History
+	if cs.history == nil {
+		cs.history = make([]*clockSolitaireSnapshot, 0)
 	}
 	return nil
 }

--- a/internal/domain/ClockSolitaire_test.go
+++ b/internal/domain/ClockSolitaire_test.go
@@ -484,3 +484,113 @@ func TestClockSolitaire_MarshalJSON_InvalidJSON(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, strings.HasPrefix(string(data), "{"))
 }
+
+func TestClockSolitaire_CanUndo_InitiallyFalse(t *testing.T) {
+	cs := newTestClockSolitaire()
+	assert.False(t, cs.CanUndo())
+}
+
+func TestClockSolitaire_Undo_ErrorWhenNoHistory(t *testing.T) {
+	cs := newTestClockSolitaire()
+	err := cs.Undo()
+	assert.Error(t, err)
+}
+
+func TestClockSolitaire_Undo_RestoresPreviousState(t *testing.T) {
+	cs := newTestClockSolitaire()
+
+	// Force a deterministic first move: place an Ace on pile 0.
+	ace := NewCard(CardDesignSpade, 1, false)
+	cs.SetCurrentCard(ace)
+
+	prevPiles := cs.GetPiles()
+	prevFuc := cs.GetFaceUpCount()
+	prevStep := cs.GetStepCount()
+
+	require.NoError(t, cs.Step())
+	assert.True(t, cs.CanUndo())
+	assert.Equal(t, prevStep+1, cs.GetStepCount())
+
+	require.NoError(t, cs.Undo())
+
+	// State reverts to the pre-step snapshot.
+	assert.Equal(t, prevStep, cs.GetStepCount())
+	assert.Equal(t, prevFuc, cs.GetFaceUpCount())
+	assert.Equal(t, prevPiles, cs.GetPiles())
+	assert.Equal(t, ace, cs.GetCurrentCard())
+	assert.Equal(t, ClockSolitairePhasePlaying, cs.GetPhase())
+	// No more history to undo.
+	assert.False(t, cs.CanUndo())
+}
+
+func TestClockSolitaire_Undo_RecordsActionLog(t *testing.T) {
+	cs := newTestClockSolitaire()
+	cs.SetCurrentCard(NewCard(CardDesignSpade, 1, false))
+	require.NoError(t, cs.Step())
+
+	logLenAfterStep := len(cs.GetActionLog())
+	require.NoError(t, cs.Undo())
+
+	// Undo appends its own action-log entry (not removed).
+	log := cs.GetActionLog()
+	assert.Equal(t, logLenAfterStep+1, len(log))
+	assert.Equal(t, "undo", log[len(log)-1].ActionType)
+}
+
+func TestClockSolitaire_Undo_RevertsGameOver(t *testing.T) {
+	cs := newTestClockSolitaire()
+	// Arrange the center pile so the next King placement is the fourth face-up King.
+	cs.SetFaceUpCount(func() [ClockSolitairePileCount]int {
+		var fuc [ClockSolitairePileCount]int
+		fuc[ClockSolitaireKingPileIdx] = 3
+		return fuc
+	}())
+	cs.SetCurrentCard(NewCard(CardDesignSpade, 13, false))
+
+	require.NoError(t, cs.Step())
+	assert.Equal(t, ClockSolitairePhaseGameOver, cs.GetPhase())
+	assert.True(t, cs.CanUndo())
+
+	require.NoError(t, cs.Undo())
+	assert.Equal(t, ClockSolitairePhasePlaying, cs.GetPhase())
+	assert.Equal(t, 3, cs.GetFaceUpCount()[ClockSolitaireKingPileIdx])
+}
+
+func TestClockSolitaire_Reset_ClearsUndoHistory(t *testing.T) {
+	cs := newTestClockSolitaire()
+	cs.SetCurrentCard(NewCard(CardDesignSpade, 1, false))
+	require.NoError(t, cs.Step())
+	assert.True(t, cs.CanUndo())
+
+	cs.Reset()
+	assert.False(t, cs.CanUndo())
+}
+
+func TestClockSolitaire_Undo_StackCappedAtMaxDepth(t *testing.T) {
+	cs := newTestClockSolitaire()
+	// Push more snapshots than the cap by repeatedly stepping with a fresh Ace.
+	for i := 0; i < ClockSolitaireMaxUndoDepth+10; i++ {
+		cs.SetPhase(ClockSolitairePhasePlaying)
+		cs.SetCurrentCard(NewCard(CardDesignSpade, 1, false))
+		require.NoError(t, cs.Step())
+	}
+	assert.LessOrEqual(t, len(cs.history), ClockSolitaireMaxUndoDepth)
+}
+
+func TestClockSolitaire_JSON_RoundTrip_PreservesUndoHistory(t *testing.T) {
+	cs := newTestClockSolitaire()
+	cs.SetCurrentCard(NewCard(CardDesignSpade, 1, false))
+	require.NoError(t, cs.Step())
+	require.True(t, cs.CanUndo())
+
+	data, err := json.Marshal(cs)
+	require.NoError(t, err)
+
+	cs2 := &ClockSolitaire{}
+	require.NoError(t, json.Unmarshal(data, cs2))
+	assert.True(t, cs2.CanUndo())
+
+	// Undo works after a JSON round-trip (survives page reload / KV persistence).
+	require.NoError(t, cs2.Undo())
+	assert.False(t, cs2.CanUndo())
+}

--- a/internal/domain/interfaces/clocksolitaire.go
+++ b/internal/domain/interfaces/clocksolitaire.go
@@ -15,6 +15,10 @@ type ClockSolitaireGame interface {
 	Step() error
 	// AutoPlay 自動プレイ（全ステップ実行）
 	AutoPlay() error
+	// Undo 直前のステップを取り消す
+	Undo() error
+	// CanUndo アンドゥ可能か
+	CanUndo() bool
 	// GetPhase 現在のフェーズを取得する
 	GetPhase() domain.ClockSolitairePhase
 	// GetPiles パイルを取得する

--- a/internal/domain/interfaces/clocksolitaire_mock.go
+++ b/internal/domain/interfaces/clocksolitaire_mock.go
@@ -27,6 +27,16 @@ func (_m *MockClockSolitaireGame) AutoPlay() error {
 	return ret.Error(0)
 }
 
+func (_m *MockClockSolitaireGame) Undo() error {
+	ret := _m.Called()
+	return ret.Error(0)
+}
+
+func (_m *MockClockSolitaireGame) CanUndo() bool {
+	ret := _m.Called()
+	return ret.Bool(0)
+}
+
 func (_m *MockClockSolitaireGame) GetPhase() domain.ClockSolitairePhase {
 	ret := _m.Called()
 	return ret.Get(0).(domain.ClockSolitairePhase)

--- a/internal/i18n/locales/en/clocksolitaire.json
+++ b/internal/i18n/locales/en/clocksolitaire.json
@@ -2,6 +2,7 @@
   "helpTitle": "Clock Solitaire",
   "helpStep": "  s                        step (flip next card)",
   "helpAutoPlay": "  a                        auto play (run all steps)",
+  "helpUndo": "  u                        undo (take back the last step)",
   "hourLabel": "[{{label}}:00]",
   "centerLabel": "[Center K]",
   "pileFootnote": " ({{up}}/{{total}})",

--- a/internal/i18n/locales/ja/clocksolitaire.json
+++ b/internal/i18n/locales/ja/clocksolitaire.json
@@ -2,6 +2,7 @@
   "helpTitle": "Clock Solitaire (クロックソリティア)",
   "helpStep": "  s                        ステップ（次のカードをめくる）",
   "helpAutoPlay": "  a                        オートプレイ（全ステップ実行）",
+  "helpUndo": "  u                        アンドゥ（直前の1手を取り消す）",
   "hourLabel": "[{{label}}時]",
   "centerLabel": "[中央K]",
   "pileFootnote": " ({{up}}/{{total}})",

--- a/internal/infrastructure/ui/GameManager.go
+++ b/internal/infrastructure/ui/GameManager.go
@@ -811,7 +811,7 @@ var gameRegistry = []GameRegistryEntry{
 				domain.NewDefaultClockSolitaire(), new(presenter.ClockSolitaireCuiPresenter))),
 			CuiHelpSpec{
 				TitleKey:          "clocksolitaire.helpTitle",
-				CommandKeys:       []string{"clocksolitaire.helpStep", "clocksolitaire.helpAutoPlay"},
+				CommandKeys:       []string{"clocksolitaire.helpStep", "clocksolitaire.helpAutoPlay", "clocksolitaire.helpUndo"},
 				ExtraCommandLines: []string{"  l                        action log"},
 			})
 	}},

--- a/internal/usecase/ClockSolitaireInteractor.go
+++ b/internal/usecase/ClockSolitaireInteractor.go
@@ -18,6 +18,8 @@ type ClockSolitaireInteractorIF interface {
 	Step() string
 	// AutoPlay 自動プレイ
 	AutoPlay() string
+	// Undo 直前のステップを取り消す
+	Undo() string
 	// ActionLog 棋譜を出力する
 	ActionLog() string
 }
@@ -47,6 +49,11 @@ func (ci *ClockSolitaireInteractor) Step() string {
 // AutoPlay 自動プレイ
 func (ci *ClockSolitaireInteractor) AutoPlay() string {
 	return execAndPresent(ci.Game, ci.p, ci.Game.AutoPlay)
+}
+
+// Undo 直前のステップを取り消す
+func (ci *ClockSolitaireInteractor) Undo() string {
+	return execAndPresent(ci.Game, ci.p, ci.Game.Undo)
 }
 
 // ActionLog 棋譜を出力する

--- a/internal/usecase/ClockSolitaireInteractor_test.go
+++ b/internal/usecase/ClockSolitaireInteractor_test.go
@@ -100,6 +100,33 @@ func TestClockSolitaireInteractorAutoPlay(t *testing.T) {
 	})
 }
 
+func TestClockSolitaireInteractorUndo(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		g := newMockClockSolitaireGame()
+		p := newMockClockSolitairePresenter()
+		ci := NewClockSolitaireInteractor(g, p)
+
+		g.On("Undo").Return(nil)
+		p.On("Output", g, nil).Return("undo_output")
+
+		result := ci.Undo()
+		assert.Equal(t, "undo_output", result)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		g := newMockClockSolitaireGame()
+		p := newMockClockSolitairePresenter()
+		ci := NewClockSolitaireInteractor(g, p)
+
+		err := errors.New("no history")
+		g.On("Undo").Return(err)
+		p.On("Output", g, err).Return("error_output")
+
+		result := ci.Undo()
+		assert.Equal(t, "error_output", result)
+	})
+}
+
 func TestClockSolitaireInteractorActionLog(t *testing.T) {
 	g := newMockClockSolitaireGame()
 	p := newMockClockSolitairePresenter()


### PR DESCRIPTION
Closes #3121

## Summary

Clock Solitaire had no way to take back a step (`ClockSolitairePageContent` exposed only reset/step/autoplay). This adds a bounded snapshot-based **Undo** across the full stack, matching the pattern used by sibling solitaires (Canfield).

## How undo works / persists

- **Domain (`ClockSolitaire.go`):** `Step()` snapshots the pre-move mutable state (piles, faceUpCount, currentCard, phase, stepCount) into an undo history **before** mutating. `Undo()` pops and restores the last snapshot; `CanUndo()` reports availability.
  - Snapshot approach (a): each snapshot deep-copies the 13 pile slices. `actionLog`/`history` are intentionally **not** restored, so undo appends its own `"undo"` action-log entry (satisfies the "undo recorded in ActionLog" acceptance criterion) rather than erasing history.
  - **Stack cap:** `ClockSolitaireMaxUndoDepth = 50`. A full game places ≤52 cards, so the cap is essentially never hit; it exists purely as a bound on the serialised payload.
  - **Persistence:** the history is added to the game JSON (`hi` key, with an explicit snapshot Marshal/Unmarshal since the snapshot uses unexported fields). This game is KV-backed and round-trips its full JSON each request, so serialising the stack is what lets undo survive a page reload. A round-trip test proves undo still works after unmarshal.
  - Undo is allowed even after game clear/over — the restored snapshot brings the phase back to `Playing`, letting the player revert the losing/final move.
- **Adapter/usecase:** `u`/`undo` command added to the web dispatcher and CUI controller; `Undo()` interactor method; `canUndo` added to the web output and populated by the web presenter.
- **Frontend (`ClockSolitairePage.tsx`):** an Undo button gated on `state.canUndo` (available after game over too, since the play controls hide once the game ends), CLI `u`/`undo` command + help line, and ja/en `undo` strings.
- **CUI help** (`GameManager.go` + backend i18n) lists the new undo command.

## Tests

- Domain: undo restores previous state, records the action log, reverts a game-over, clears on reset, respects the depth cap, and survives a JSON round-trip.
- Interactor / web controller / CUI controller: undo command wiring.
- Web presenter: `canUndo` surfaced in output.
- Frontend page: undo button disabled/enabled by `canUndo`, dispatches `undo`, and stays available after game over.

## Verification

- `go test -tags test ./...` — all pass
- `golangci-lint run ./internal/...` — 0 issues
- `cd frontend && bun run check && bun run test -- --run ClockSolitaire && bun run build` — all pass
- `GOOS=js GOARCH=wasm go build -tags solo -o /dev/null ./cmd/workers/solo/` — **WASM_SOLO_OK** (undo adds only a few small methods; binary impact is negligible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)