### PR TITLE
feat(calabresella): reveal talon (monte) cards in the web GUI

### DIFF
--- a/frontend/src/i18n/locales/en/calabresella.json
+++ b/frontend/src/i18n/locales/en/calabresella.json
@@ -30,6 +30,7 @@
   "cards": "{{count}} cards",
   "tricks": "{{count}} tricks",
   "currentTrick": "Current Trick",
+  "monteLabel": "Monte (widow)",
   "players": "Players",
   "you": "You",
   "cpu": "CPU {{id}}",

--- a/frontend/src/i18n/locales/ja/calabresella.json
+++ b/frontend/src/i18n/locales/ja/calabresella.json
@@ -30,6 +30,7 @@
   "cards": "{{count}}枚",
   "tricks": "{{count}}トリック",
   "currentTrick": "現在のトリック",
+  "monteLabel": "モンテ（伏せ札）",
   "players": "プレイヤー",
   "you": "あなた",
   "cpu": "CPU {{id}}",

--- a/frontend/src/pages/CalabresellaPage.test.tsx
+++ b/frontend/src/pages/CalabresellaPage.test.tsx
@@ -132,6 +132,31 @@ describe('CalabresellaPage', () => {
     expect(screen.getByRole('button', { name: /カードを捨てる/ })).toBeInTheDocument();
   });
 
+  it('reveals the monte (widow) cards once the Soloist has taken them', async () => {
+    mockExec.mockResolvedValue({
+      ...discardPhaseState,
+      monte: [
+        { design: 'DIAMOND', value: 3 },
+        { design: 'SPADE', value: 11 },
+        { design: 'CLOVER', value: 7 },
+        { design: 'HEART', value: 2 },
+      ],
+    });
+    renderWithProviders(<CalabresellaPage />);
+    const monte = await screen.findByTestId('calabresella-monte');
+    expect(monte).toBeInTheDocument();
+    expect(monte).toHaveTextContent('モンテ');
+    // All four widow cards are rendered as face-up images inside the monte row.
+    expect(monte.querySelectorAll('img')).toHaveLength(4);
+  });
+
+  it('does not render the monte row during the bid phase (widow not yet taken)', async () => {
+    mockExec.mockResolvedValue(bidPhaseState);
+    renderWithProviders(<CalabresellaPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'キアーモ' })).toBeInTheDocument());
+    expect(screen.queryByTestId('calabresella-monte')).not.toBeInTheDocument();
+  });
+
   it('shows the remaining discard count in the prompt and on the button', async () => {
     // 16-card soloist hand → 4 discards remain before reaching the regulation 12.
     mockExec.mockResolvedValue(discardPhaseState);

--- a/frontend/src/pages/CalabresellaPage.tsx
+++ b/frontend/src/pages/CalabresellaPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo } from 'react';
 import type { calabresellaApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
+import { CardImage } from '../components/CardImage';
 import { CliTerminal } from '../components/cli/CliTerminal';
 import { CliToggle } from '../components/cli/CliToggle';
 import { SettingsPanel } from '../components/common/SettingsPanel';
@@ -220,6 +221,26 @@ function CalabresellaPageContent() {
             <div className={lgTwoColGrid}>
               {/* Left: play area */}
               <div>
+                {/* Monte (widow): the 4 cards the Soloist took, revealed to all players. */}
+                {state.monte && state.monte.length > 0 && (
+                  <div
+                    className="mb-3 p-2 rounded bg-black/30"
+                    data-testid="calabresella-monte"
+                    data-tutorial="calabresella-monte"
+                  >
+                    <div className="text-ds-text-muted text-sm mb-1">{t('monteLabel')}</div>
+                    <div className="flex flex-wrap gap-1">
+                      {state.monte.map((c, i) => (
+                        <CardImage
+                          key={`monte-${c.design}-${c.value}-${i}`}
+                          card={c}
+                          width={Math.round(cardWidth * 0.75)}
+                        />
+                      ))}
+                    </div>
+                  </div>
+                )}
+
                 <TrickDisplay
                   currentTrick={state.currentTrick}
                   players={state.players}

--- a/frontend/src/types/card.ts
+++ b/frontend/src/types/card.ts
@@ -2180,6 +2180,11 @@ export interface CalabresellaResponse extends BaseGameResponse {
   /** The winning bid (0=none, 1=chiamo, 2=solo). */
   winningBid: number;
   currentTrick: CalabresellaTrickCard[];
+  /**
+   * The four monte (widow) cards, revealed to every player once the Soloist has
+   * taken them (present from the Discard phase onward; omitted during Bidding).
+   */
+  monte?: Card[];
   /** Cumulative match scores per player — [p0, p1, p2]. */
   playerScores: number[];
   /** Thirds of a point captured per player this round — [p0, p1, p2]. */

--- a/internal/adapter/controller/CalabresellaWebController.go
+++ b/internal/adapter/controller/CalabresellaWebController.go
@@ -65,6 +65,7 @@ type CalabresellaWebOutput struct {
 	SoloistIdx       int                               `json:"soloistIdx"`
 	WinningBid       int                               `json:"winningBid"`
 	CurrentTrick     []*CalabresellaWebOutputTrickCard `json:"currentTrick"`
+	Monte            []*WebOutputCard                  `json:"monte,omitempty"`
 	PlayerScores     [domain.CalabresellaPlayerCnt]int `json:"playerScores"`
 	RoundThirds      [domain.CalabresellaPlayerCnt]int `json:"roundThirds"`
 	LastTrickWinner  int                               `json:"lastTrickWinner"`

--- a/internal/adapter/presenter/CalabresellaWebPresenter.go
+++ b/internal/adapter/presenter/CalabresellaWebPresenter.go
@@ -50,7 +50,31 @@ func (p *CalabresellaWebPresenter) buildBase(g interfaces.CalabresellaGame) *con
 
 	resObj.CurrentTrick = p.buildTrickOutput(g.GetCurrentTrick())
 	resObj.Players = p.buildPlayersOutput(g)
+	resObj.Monte = p.buildMonteOutput(g)
 	return resObj
+}
+
+// buildMonteOutput 公開済みモンテ (widow) 4 枚を構築する。
+// モンテはソリスト確定後の discard フェーズで取得された時点で全員へ公開されるため、
+// bid フェーズ (取得前・次ラウンド開始直後) では表示しない。取得記録は棋譜の
+// "monte_take" エントリに残っているので、その最新エントリのカードを返す。
+func (p *CalabresellaWebPresenter) buildMonteOutput(g interfaces.CalabresellaGame) []*controller.WebOutputCard {
+	if g.GetPhase() == domain.CalabresellaPhaseBid {
+		return nil
+	}
+	log := g.GetActionLog()
+	for i := len(log) - 1; i >= 0; i-- {
+		entry := log[i]
+		if entry == nil || entry.ActionType != "monte_take" {
+			continue
+		}
+		out := make([]*controller.WebOutputCard, 0, len(entry.Cards))
+		for _, c := range entry.Cards {
+			out = append(out, cardToOutput(c))
+		}
+		return out
+	}
+	return nil
 }
 
 // playableIndices 人間プレイヤーがプレイできるカードのインデックスを返す

--- a/internal/adapter/presenter/CalabresellaWebPresenter_test.go
+++ b/internal/adapter/presenter/CalabresellaWebPresenter_test.go
@@ -140,6 +140,49 @@ func TestCalabresellaWebPresenter_Output(t *testing.T) {
 		assert.Equal(t, "calabresella.roundEnd", resObj.MessageCode)
 	})
 
+	t.Run("monte revealed from action log after discard", func(t *testing.T) {
+		m, _ := setupCalabresellaWebMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetActionLog")
+		m.On("GetActionLog").Return([]*domain.ActionLogEntry{
+			{PlayerIdx: 0, ActionType: "monte_take", Cards: []*domain.Card{
+				domain.NewCard(domain.CardDesignDiamond, 3, false),
+				domain.NewCard(domain.CardDesignSpade, 11, false),
+				domain.NewCard(domain.CardDesignClover, 7, false),
+				domain.NewCard(domain.CardDesignHeart, 2, false),
+			}},
+		})
+		result := p.Output(m, nil)
+		var resObj controller.CalabresellaWebOutput
+		assert.NoError(t, json.Unmarshal([]byte(result), &resObj))
+		assert.Len(t, resObj.Monte, 4)
+		assert.Equal(t, 3, resObj.Monte[0].Value)
+		assert.Equal(t, 2, resObj.Monte[3].Value)
+	})
+
+	t.Run("monte hidden during bid phase even if log has entry", func(t *testing.T) {
+		m, _ := setupCalabresellaWebMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetActionLog")
+		m.On("GetPhase").Return(domain.CalabresellaPhaseBid)
+		m.On("GetActionLog").Return([]*domain.ActionLogEntry{
+			{PlayerIdx: 0, ActionType: "monte_take", Cards: []*domain.Card{
+				domain.NewCard(domain.CardDesignDiamond, 3, false),
+			}},
+		})
+		result := p.Output(m, nil)
+		var resObj controller.CalabresellaWebOutput
+		assert.NoError(t, json.Unmarshal([]byte(result), &resObj))
+		assert.Empty(t, resObj.Monte)
+	})
+
+	t.Run("monte empty when no take logged", func(t *testing.T) {
+		m, _ := setupCalabresellaWebMockWithPlayers()
+		result := p.Output(m, nil)
+		var resObj controller.CalabresellaWebOutput
+		assert.NoError(t, json.Unmarshal([]byte(result), &resObj))
+		assert.Empty(t, resObj.Monte)
+	})
+
 	t.Run("error message takes priority", func(t *testing.T) {
 		m, _ := setupCalabresellaWebMockWithPlayers()
 		result := p.Output(m, errors.New("boom"))

--- a/internal/domain/Calabresella.go
+++ b/internal/domain/Calabresella.go
@@ -384,13 +384,16 @@ func (g *Calabresella) handBidStrength(playerIdx int) int {
 func (g *Calabresella) startDiscard() {
 	g.phase = CalabresellaPhaseDiscard
 	g.monteTaken = true
+	// monte の内容は取得時点で全員へ公開される情報なので、棋譜に残して
+	// Web/CUI プレゼンターが伏せ札の中身を明示できるようにする。
+	revealed := append([]*Card(nil), g.monte...)
 	for _, c := range g.monte {
 		g.players[g.soloistIdx].AddCard(c)
 	}
 	g.monte = nil
 	calabresellaSortHand(g.players[g.soloistIdx])
 	g.appendLog(g.soloistIdx, "monte_take",
-		fmt.Sprintf("%s takes the monte", g.playerName(g.soloistIdx)), nil)
+		fmt.Sprintf("%s takes the monte", g.playerName(g.soloistIdx)), revealed)
 	g.discardCount = 0
 	g.currentPlayerIdx = g.soloistIdx
 

--- a/internal/domain/Calabresella_test.go
+++ b/internal/domain/Calabresella_test.go
@@ -130,6 +130,38 @@ func TestCalabresella_Bidding_EveryonePasses_ForehandTakesChiamo(t *testing.T) {
 		g.GetPhase())
 }
 
+func TestCalabresella_MonteTakeLogRevealsCards(t *testing.T) {
+	g := newTestCalabresella()
+	cfg := g.GetConfig()
+	cfg.CpuDifficulty = domain.CalabresellaCpuDifficultyEasy // CPUs always pass
+	g.SetConfig(cfg)
+	g.SetPhase(domain.CalabresellaPhaseBid)
+
+	guard := 0
+	for g.GetPhase() == domain.CalabresellaPhaseBid && guard < 50 {
+		guard++
+		if g.GetPlayer(g.GetCurrentBidderIdx()).GetIsHuman() {
+			require.NoError(t, g.PlayerBid(domain.CalabresellaBidNone)) // human passes
+		} else {
+			g.CpuBid()
+		}
+	}
+
+	// A soloist took the monte; the action log must expose the 4 monte cards
+	// so presenters can reveal the widow to every player.
+	var monteEntry *domain.ActionLogEntry
+	for _, e := range g.GetActionLog() {
+		if e.ActionType == "monte_take" {
+			monteEntry = e
+		}
+	}
+	require.NotNil(t, monteEntry, "monte_take entry must be logged")
+	assert.Len(t, monteEntry.Cards, domain.CalabresellaMonteSize)
+	for _, c := range monteEntry.Cards {
+		assert.NotNil(t, c)
+	}
+}
+
 func TestCalabresella_Bidding_SoloBeatsChiamo(t *testing.T) {
 	g := newTestCalabresella()
 	g.SetPhase(domain.CalabresellaPhaseBid)


### PR DESCRIPTION
## Summary

Reveals the **monte (talon/widow)** cards in the Calabresella web GUI. In Terziglio, the 4-card monte the Soloist takes is public information, but the page had no way to show it — defenders could not see what was in the widow. This adds a labeled "Monte (widow)" row above the trick display, revealed from the Discard phase onward.

Closes #3608

## Approach — WASM-neutral, no worker growth

`calabresella` ships on the **`extra`** TinyGo worker, which is near the 1 MB gzip free-tier limit, so the change avoids growing the worker:

- **No new domain state.** The domain already logs a `monte_take` action-log entry when the Soloist takes the widow; it previously passed `nil` for the cards. That single call now includes a copy of the 4 monte cards (already in memory) — **no new struct field, getter, or interface method.** The existing `ActionLog` machinery (already compiled into the worker) carries them.
- **Web presenter** (`CalabresellaWebPresenter`) extracts the monte from the latest `monte_take` log entry into a new `monte` output field, gated to omit it during the Bid phase (so a prior round's entry never leaks).
- **Frontend** renders the `monte` cards as small face-up `CardImage`s with ja/en `monteLabel` i18n (kept in parity).

CUI was intentionally left untouched to keep the change WASM-neutral (per size constraint); the monte cards now also appear in the shared action log as a side benefit.

## Tests
- Domain: `monte_take` log carries the 4 monte cards after a driven auction.
- Web presenter: monte populated at reveal phase, hidden during Bid, empty when no take logged.
- Page: monte row renders 4 card images when present; absent during Bid.

## Verification
- `go test -tags test ./...` — pass
- `golangci-lint run ./internal/...` — 0 issues
- `bun run check` / `bun run test -- --run Calabresella` (55 pass) / `bun run build` — pass
- `GOOS=js GOARCH=wasm go build -tags extra ./cmd/workers/extra/` — **WASM_EXTRA_OK** (compiles). Change is WASM-neutral (web presenter + frontend + one reused log arg); CI's TinyGo gzip size-check on `extra` is the final guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)