### PR TITLE
feat(burraco): add CUI hint command

### DIFF
--- a/internal/adapter/controller/BurracoCuiController.go
+++ b/internal/adapter/controller/BurracoCuiController.go
@@ -16,6 +16,7 @@ var burracoNoArgCommands = cuiutil.NewCommandMap[usecase.BurracoInteractorIF]().
 	Add(usecase.BurracoInteractorIF.SkipMeld, "sm", "skipmeld").
 	Add(usecase.BurracoInteractorIF.GoOut, "go", "goout").
 	Add(usecase.BurracoInteractorIF.NextRound, "nr", "nextround").
+	Add(usecase.BurracoInteractorIF.Hint, "h", "hint").
 	Add(usecase.BurracoInteractorIF.ActionLog, "log", "l")
 
 // burracoArgfulCommands lists alias names for argful commands handled in the

--- a/internal/adapter/controller/BurracoCuiController_test.go
+++ b/internal/adapter/controller/BurracoCuiController_test.go
@@ -27,6 +27,7 @@ func TestBurracoCuiController_Exec(t *testing.T) {
 		m.On("Discard", mock.Anything).Return(mockOutput)
 		m.On("GoOut").Return(mockOutput)
 		m.On("NextRound").Return(mockOutput)
+		m.On("Hint").Return(mockOutput)
 		m.On("ActionLog").Return(mockOutput)
 		return m
 	}
@@ -301,6 +302,22 @@ func TestBurracoCuiController_Exec(t *testing.T) {
 		result := c.Exec("l")
 		assert.Equal(t, mockOutput, result)
 		m.AssertCalled(t, "ActionLog")
+	})
+
+	t.Run("hint command h", func(t *testing.T) {
+		m := newMock()
+		c := controller.NewBurracoCuiController(m)
+		result := c.Exec("h")
+		assert.Equal(t, mockOutput, result)
+		m.AssertCalled(t, "Hint")
+	})
+
+	t.Run("hint command hint", func(t *testing.T) {
+		m := newMock()
+		c := controller.NewBurracoCuiController(m)
+		result := c.Exec("hint")
+		assert.Equal(t, mockOutput, result)
+		m.AssertCalled(t, "Hint")
 	})
 
 	// unknown

--- a/internal/adapter/controller/usecase/BurracoInteractor_mock.go
+++ b/internal/adapter/controller/usecase/BurracoInteractor_mock.go
@@ -53,6 +53,10 @@ func (_m *MockBurracoInteractor) GetConfig() domain.BurracoConfig {
 	return _m.Called().Get(0).(domain.BurracoConfig)
 }
 
+func (_m *MockBurracoInteractor) Hint() string {
+	return _m.Called().String(0)
+}
+
 func (_m *MockBurracoInteractor) ActionLog() string {
 	return _m.Called().String(0)
 }

--- a/internal/adapter/presenter/BurracoCuiPresenter.go
+++ b/internal/adapter/presenter/BurracoCuiPresenter.go
@@ -127,6 +127,57 @@ func (p *BurracoCuiPresenter) Output(g interfaces.BurracoGame, lastErr error) st
 	})
 }
 
+// burracoHintReasonKeys maps Burraco-specific hint reasons to i18n keys.
+var burracoHintReasonKeys = map[string]string{
+	"draw_discard_pair": "burraco.hintReasonDrawDiscard",
+	"draw_stock_safe":   "burraco.hintReasonDrawStock",
+	"meld_available":    "burraco.hintReasonMeld",
+	"no_meld":           "burraco.hintReasonNoMeld",
+	"discard_safe":      "burraco.hintReasonDiscard",
+}
+
+// HintOutput emits the current recommended action for the human player.
+func (p *BurracoCuiPresenter) HintOutput(g interfaces.BurracoGame) string {
+	hint := g.GetHint()
+	if hint == nil {
+		return i18n.T("burraco.hintNone") + "\n"
+	}
+	reason := hintReasonStr(hint.Reason, burracoHintReasonKeys)
+	switch hint.Action {
+	case "draw_stock":
+		return color.Yellow(i18n.Tf("burraco.hintDrawStock", "reason", reason)) + "\n"
+	case "draw_discard":
+		return color.Yellow(i18n.Tf("burraco.hintDrawDiscard",
+			"indices", burracoJoinInts(hint.Indices), "reason", reason)) + "\n"
+	case "meld":
+		return color.Yellow(i18n.Tf("burraco.hintMeld",
+			"indices", burracoJoinInts(hint.Indices), "reason", reason)) + "\n"
+	case "skip_meld":
+		return color.Yellow(i18n.Tf("burraco.hintSkipMeld", "reason", reason)) + "\n"
+	case "discard":
+		idx := 0
+		if len(hint.Indices) > 0 {
+			idx = hint.Indices[0]
+		}
+		card := ""
+		if c := g.GetPlayer(g.GetCurrentPlayerIdx()).GetCard(idx); c != nil {
+			card = cuiCardStr(c)
+		}
+		return color.Yellow(i18n.Tf("burraco.hintDiscard",
+			"idx", strconv.Itoa(idx), "card", card, "reason", reason)) + "\n"
+	}
+	return i18n.T("burraco.hintNone") + "\n"
+}
+
+// burracoJoinInts formats a slice of indices as a comma-separated string.
+func burracoJoinInts(xs []int) string {
+	parts := make([]string, len(xs))
+	for i, x := range xs {
+		parts[i] = strconv.Itoa(x)
+	}
+	return strings.Join(parts, ",")
+}
+
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *BurracoCuiPresenter) ActionLogOutput(g interfaces.BurracoGame) string {
 	return actionLogOutputText(g)

--- a/internal/adapter/presenter/BurracoCuiPresenter_test.go
+++ b/internal/adapter/presenter/BurracoCuiPresenter_test.go
@@ -242,3 +242,70 @@ func TestBurracoCuiPresenter_ActionLogOutput(t *testing.T) {
 		m.AssertExpectations(t)
 	})
 }
+
+// newBurracoHintGame builds a real 2-player Burraco game for hint tests.
+func newBurracoHintGame() *domain.Burraco {
+	players := []*domain.BurracoPlayer{
+		domain.NewCanastaPlayer(true),
+		domain.NewCanastaPlayer(false),
+	}
+	return domain.NewCanasta(domain.NewTrumpCardsWithDecks(2, 4), players, domain.DefaultCanastaConfig())
+}
+
+func TestBurracoCuiPresenter_HintOutput(t *testing.T) {
+	p := &presenter.BurracoCuiPresenter{}
+
+	t.Run("no hint on CPU turn", func(t *testing.T) {
+		g := newBurracoHintGame()
+		g.SetPhase(domain.BurracoPhaseDraw)
+		g.SetCurrentPlayerIdx(1) // CPU
+		out := p.HintOutput(g)
+		assert.NotEmpty(t, out)
+	})
+
+	t.Run("draw stock", func(t *testing.T) {
+		g := newBurracoHintGame()
+		g.SetPhase(domain.BurracoPhaseDraw)
+		g.SetCurrentPlayerIdx(0)
+		g.GetPlayer(0).AddCard(domain.NewCard(domain.CardDesignHeart, 4, false))
+		g.SetDiscardPile([]*domain.Card{domain.NewCard(domain.CardDesignSpade, 9, false)})
+		assert.NotEmpty(t, p.HintOutput(g))
+	})
+
+	t.Run("draw discard", func(t *testing.T) {
+		g := newBurracoHintGame()
+		g.SetPhase(domain.BurracoPhaseDraw)
+		g.SetCurrentPlayerIdx(0)
+		g.GetPlayer(0).AddCard(domain.NewCard(domain.CardDesignHeart, 7, false))
+		g.GetPlayer(0).AddCard(domain.NewCard(domain.CardDesignDiamond, 7, false))
+		g.SetDiscardPile([]*domain.Card{domain.NewCard(domain.CardDesignSpade, 7, false)})
+		assert.NotEmpty(t, p.HintOutput(g))
+	})
+
+	t.Run("meld", func(t *testing.T) {
+		g := newBurracoHintGame()
+		g.SetPhase(domain.BurracoPhaseMeld)
+		g.SetCurrentPlayerIdx(0)
+		g.GetPlayer(0).AddCard(domain.NewCard(domain.CardDesignHeart, 8, false))
+		g.GetPlayer(0).AddCard(domain.NewCard(domain.CardDesignDiamond, 8, false))
+		g.GetPlayer(0).AddCard(domain.NewCard(domain.CardDesignSpade, 8, false))
+		assert.NotEmpty(t, p.HintOutput(g))
+	})
+
+	t.Run("skip meld", func(t *testing.T) {
+		g := newBurracoHintGame()
+		g.SetPhase(domain.BurracoPhaseMeld)
+		g.SetCurrentPlayerIdx(0)
+		g.GetPlayer(0).AddCard(domain.NewCard(domain.CardDesignHeart, 4, false))
+		assert.NotEmpty(t, p.HintOutput(g))
+	})
+
+	t.Run("discard", func(t *testing.T) {
+		g := newBurracoHintGame()
+		g.SetPhase(domain.BurracoPhaseDiscard)
+		g.SetCurrentPlayerIdx(0)
+		g.GetPlayer(0).AddCard(domain.NewCard(domain.CardDesignHeart, 9, false))
+		out := p.HintOutput(g)
+		assert.NotEmpty(t, out)
+	})
+}

--- a/internal/adapter/presenter/BurracoWebPresenter.go
+++ b/internal/adapter/presenter/BurracoWebPresenter.go
@@ -123,6 +123,13 @@ func (p *BurracoWebPresenter) buildMessage(g interfaces.BurracoGame, lastErr err
 	return "", "", nil
 }
 
+// HintOutput ヒント情報をJSON出力する。Web GUI はフロントエンドのヒント推定を
+// 使うためバックエンドヒントは持たず、標準の状態出力をそのまま返す
+// (BurracoPresenter インタフェースを満たすための実装)。
+func (p *BurracoWebPresenter) HintOutput(g interfaces.BurracoGame) string {
+	return p.Output(g, nil)
+}
+
 // ActionLogOutput 棋譜をJSON出力
 func (p *BurracoWebPresenter) ActionLogOutput(g interfaces.BurracoGame) string {
 	return actionLogOutputJSON(g)

--- a/internal/domain/Burraco.go
+++ b/internal/domain/Burraco.go
@@ -32,6 +32,9 @@ type BurracoPhase = CanastaPhase
 // BurracoCpuDifficulty はブラーコの CPU 難易度型。
 type BurracoCpuDifficulty = CanastaCpuDifficulty
 
+// BurracoHint はブラーコのヒント情報。
+type BurracoHint = CanastaHint
+
 // ブラーコのフェーズ定数（Canasta と同一値）。
 const (
 	BurracoPhaseDraw     = CanastaPhaseDraw

--- a/internal/domain/Canasta.go
+++ b/internal/domain/Canasta.go
@@ -1450,6 +1450,65 @@ func (g *Canasta) GetActionLog() []*ActionLogEntry { return g.actionLog }
 // GetDrewFromDiscard 捨て札から引いたか取得
 func (g *Canasta) GetDrewFromDiscard() bool { return g.drewFromDiscard }
 
+// --- Hint ---
+
+// CanastaHint はカナスタ / ブラーコの現在手番に対する推奨アクション。
+type CanastaHint struct {
+	// Action は推奨アクション種別。
+	// "draw_stock" / "draw_discard" / "meld" / "skip_meld" / "discard" のいずれか。
+	Action string
+	// Indices は推奨アクションの対象カードの手札インデックス。
+	// draw_discard: 捨て札トップと同ランクのナチュラルペア、meld: メルド候補、
+	// discard: 捨てる1枚。draw_stock / skip_meld では空。
+	Indices []int
+	// Reason はヒント理由の i18n キー(接頭辞なし)。
+	Reason string
+}
+
+// GetHint は現在の人間の手番フェーズに応じた推奨アクションを返す。CPU の手番や
+// ヒント不要なフェーズでは nil を返す。判定には既存の CPU AI ヘルパーを再利用する。
+func (g *Canasta) GetHint() *CanastaHint {
+	if !g.IsHumanTurn() {
+		return nil
+	}
+	player := g.players[g.currentPlayerIdx]
+	switch g.phase {
+	case CanastaPhaseDraw:
+		if top := g.GetDiscardTop(); top != nil {
+			if pair := g.cpuFindNaturalPair(player, top); pair != nil {
+				return &CanastaHint{Action: "draw_discard", Indices: pair, Reason: "draw_discard_pair"}
+			}
+		}
+		return &CanastaHint{Action: "draw_stock", Reason: "draw_stock_safe"}
+	case CanastaPhaseMeld:
+		if melds := g.cpuFindMelds(player); len(melds) > 0 {
+			return &CanastaHint{Action: "meld", Indices: g.handIndicesOf(player, melds[0]), Reason: "meld_available"}
+		}
+		return &CanastaHint{Action: "skip_meld", Reason: "no_meld"}
+	case CanastaPhaseDiscard:
+		if player.GetCardsSize() == 0 {
+			return nil
+		}
+		return &CanastaHint{Action: "discard", Indices: []int{g.cpuBestDiscard(player)}, Reason: "discard_safe"}
+	default:
+		return nil
+	}
+}
+
+// handIndicesOf は指定カード群の手札インデックスを返す(見つからないカードは除外)。
+func (g *Canasta) handIndicesOf(player *CanastaPlayer, cards []*Card) []int {
+	idxs := make([]int, 0, len(cards))
+	for _, c := range cards {
+		for i := 0; i < player.GetCardsSize(); i++ {
+			if player.GetCard(i) == c {
+				idxs = append(idxs, i)
+				break
+			}
+		}
+	}
+	return idxs
+}
+
 // --- Private helpers ---
 
 // sortAllHands 全プレイヤーの手札をソートする

--- a/internal/domain/Canasta_test.go
+++ b/internal/domain/Canasta_test.go
@@ -836,3 +836,83 @@ func TestCanastaConfig_Validate(t *testing.T) {
 		})
 	}
 }
+
+// --- Hint ---
+
+func TestCanasta_GetHint(t *testing.T) {
+	t.Run("nil when CPU turn", func(t *testing.T) {
+		g := newTestCanasta()
+		setupCanastaDrawPhase(g, 1) // player 1 is CPU
+		assert.Nil(t, g.GetHint())
+	})
+
+	t.Run("draw phase takes discard when natural pair matches top", func(t *testing.T) {
+		g := newTestCanasta()
+		setupCanastaDrawPhase(g, 0)
+		p := g.GetPlayer(0)
+		p.AddCard(domain.NewCard(domain.CardDesignHeart, 7, false))
+		p.AddCard(domain.NewCard(domain.CardDesignDiamond, 7, false))
+		g.SetDiscardPile([]*domain.Card{domain.NewCard(domain.CardDesignSpade, 7, false)})
+		h := g.GetHint()
+		require.NotNil(t, h)
+		assert.Equal(t, "draw_discard", h.Action)
+		assert.Len(t, h.Indices, 2)
+		assert.Equal(t, "draw_discard_pair", h.Reason)
+	})
+
+	t.Run("draw phase recommends stock when no pair", func(t *testing.T) {
+		g := newTestCanasta()
+		setupCanastaDrawPhase(g, 0)
+		g.GetPlayer(0).AddCard(domain.NewCard(domain.CardDesignHeart, 4, false))
+		g.SetDiscardPile([]*domain.Card{domain.NewCard(domain.CardDesignSpade, 9, false)})
+		h := g.GetHint()
+		require.NotNil(t, h)
+		assert.Equal(t, "draw_stock", h.Action)
+		assert.Empty(t, h.Indices)
+	})
+
+	t.Run("meld phase recommends a meld when available", func(t *testing.T) {
+		g := newTestCanasta()
+		setupCanastaMeldPhase(g, 0)
+		p := g.GetPlayer(0)
+		p.AddCard(domain.NewCard(domain.CardDesignHeart, 8, false))
+		p.AddCard(domain.NewCard(domain.CardDesignDiamond, 8, false))
+		p.AddCard(domain.NewCard(domain.CardDesignSpade, 8, false))
+		h := g.GetHint()
+		require.NotNil(t, h)
+		assert.Equal(t, "meld", h.Action)
+		assert.NotEmpty(t, h.Indices)
+	})
+
+	t.Run("meld phase skips when no meld", func(t *testing.T) {
+		g := newTestCanasta()
+		setupCanastaMeldPhase(g, 0)
+		g.GetPlayer(0).AddCard(domain.NewCard(domain.CardDesignHeart, 4, false))
+		h := g.GetHint()
+		require.NotNil(t, h)
+		assert.Equal(t, "skip_meld", h.Action)
+	})
+
+	t.Run("discard phase recommends a discard", func(t *testing.T) {
+		g := newTestCanasta()
+		setupCanastaDiscardPhase(g, 0)
+		g.GetPlayer(0).AddCard(domain.NewCard(domain.CardDesignHeart, 9, false))
+		h := g.GetHint()
+		require.NotNil(t, h)
+		assert.Equal(t, "discard", h.Action)
+		assert.Len(t, h.Indices, 1)
+	})
+
+	t.Run("discard phase nil with empty hand", func(t *testing.T) {
+		g := newTestCanasta()
+		setupCanastaDiscardPhase(g, 0)
+		assert.Nil(t, g.GetHint())
+	})
+
+	t.Run("nil for round-end phase", func(t *testing.T) {
+		g := newTestCanasta()
+		g.SetPhase(domain.CanastaPhaseRoundEnd)
+		g.SetCurrentPlayerIdx(0)
+		assert.Nil(t, g.GetHint())
+	})
+}

--- a/internal/domain/interfaces/canasta.go
+++ b/internal/domain/interfaces/canasta.go
@@ -61,4 +61,6 @@ type CanastaGame interface {
 	GetPlayer(i int) *domain.CanastaPlayer
 	// GetDrewFromDiscard 捨て札から引いたかを返す
 	GetDrewFromDiscard() bool
+	// GetHint 現在手番に対する推奨アクションを返す
+	GetHint() *domain.CanastaHint
 }

--- a/internal/domain/interfaces/canasta_mock.go
+++ b/internal/domain/interfaces/canasta_mock.go
@@ -60,3 +60,10 @@ func (m *MockCanastaGame) GetActionLog() []*domain.ActionLogEntry {
 	return m.Called().Get(0).([]*domain.ActionLogEntry)
 }
 func (m *MockCanastaGame) GetDrewFromDiscard() bool { return m.Called().Bool(0) }
+func (m *MockCanastaGame) GetHint() *domain.CanastaHint {
+	ret := m.Called().Get(0)
+	if ret == nil {
+		return nil
+	}
+	return ret.(*domain.CanastaHint)
+}

--- a/internal/i18n/locales/en/burraco.json
+++ b/internal/i18n/locales/en/burraco.json
@@ -33,5 +33,16 @@
   "promptDiscardHelp": "d <idx>: discard a card",
   "promptGoOutHelp": "go: go out (requires the pozzetto + a burraco)",
   "promptRoundEnd": "Round complete",
-  "promptRoundEndHelp": "nr / nextround: advance to next round"
+  "promptRoundEndHelp": "nr / nextround: advance to next round",
+  "hintNone": "No hint available",
+  "hintDrawStock": "Recommended: draw from stock ({{reason}})",
+  "hintDrawDiscard": "Recommended: take the discard pile [{{indices}}] ({{reason}})",
+  "hintMeld": "Recommended meld: [{{indices}}] ({{reason}})",
+  "hintSkipMeld": "Recommended: skip melding ({{reason}})",
+  "hintDiscard": "Recommended discard: [{{idx}}] {{card}} ({{reason}})",
+  "hintReasonDrawStock": "no useful pair for the discard top, so draw from stock",
+  "hintReasonDrawDiscard": "a natural pair matches the discard top, so take the pile",
+  "hintReasonMeld": "a meldable combination is available",
+  "hintReasonNoMeld": "no valid meld, so skip",
+  "hintReasonDiscard": "discard the least useful card"
 }

--- a/internal/i18n/locales/ja/burraco.json
+++ b/internal/i18n/locales/ja/burraco.json
@@ -33,5 +33,16 @@
   "promptDiscardHelp": "d <idx>・・・カードを捨てる",
   "promptGoOutHelp": "go・・・上がる (ポゼット獲得＋ブラーコが必要)",
   "promptRoundEnd": "ラウンド終了",
-  "promptRoundEndHelp": "nr / nextround・・・次のラウンドへ"
+  "promptRoundEndHelp": "nr / nextround・・・次のラウンドへ",
+  "hintNone": "ヒントはありません",
+  "hintDrawStock": "推奨: 山札から引く ({{reason}})",
+  "hintDrawDiscard": "推奨: 捨て札の山を取る [{{indices}}] ({{reason}})",
+  "hintMeld": "推奨メルド: [{{indices}}] ({{reason}})",
+  "hintSkipMeld": "推奨: メルドをスキップ ({{reason}})",
+  "hintDiscard": "推奨ディスカード: [{{idx}}] {{card}} ({{reason}})",
+  "hintReasonDrawStock": "捨て札に有効なペアがないため山札から引く",
+  "hintReasonDrawDiscard": "捨て札トップとナチュラルペアが揃うため山を取る",
+  "hintReasonMeld": "メルド可能な組み合わせがある",
+  "hintReasonNoMeld": "有効なメルドがないためスキップ",
+  "hintReasonDiscard": "最も不要なカードを捨てる"
 }

--- a/internal/infrastructure/ui/GameManager.go
+++ b/internal/infrastructure/ui/GameManager.go
@@ -2088,6 +2088,7 @@ var gameRegistry = []GameRegistryEntry{
 				"  d <idx>              discard a card",
 				"  go                   go out (requires the pozzetto + a burraco)",
 				"  nr                   next round",
+				"  h                    hint (recommended action)",
 				"  l                    action log",
 				"",
 				"Settings:",

--- a/internal/usecase/BurracoInteractor.go
+++ b/internal/usecase/BurracoInteractor.go
@@ -32,6 +32,8 @@ type BurracoInteractorIF interface {
 	NextRound() string
 	// GetConfig 現在の設定を取得
 	GetConfig() domain.BurracoConfig
+	// Hint 現在手番に対する推奨アクションを出力する
+	Hint() string
 	// ActionLog 棋譜を出力する
 	ActionLog() string
 }
@@ -151,6 +153,11 @@ func (ci *BurracoInteractor) NextRound() string {
 // GetConfig 現在の設定を取得
 func (ci *BurracoInteractor) GetConfig() domain.BurracoConfig {
 	return ci.Game.GetConfig()
+}
+
+// Hint 現在手番に対する推奨アクションを出力する
+func (ci *BurracoInteractor) Hint() string {
+	return ci.gp.HintOutput(ci.Game)
 }
 
 // ActionLog 棋譜を出力する

--- a/internal/usecase/BurracoInteractor_test.go
+++ b/internal/usecase/BurracoInteractor_test.go
@@ -453,6 +453,17 @@ func TestBurracoInteractor_ActionLog(t *testing.T) {
 	pMock.AssertExpectations(t)
 }
 
+func TestBurracoInteractor_Hint(t *testing.T) {
+	pMock := new(presenter.MockBurracoPresenter)
+	gameMock := new(interfaces.MockBurracoGame)
+	pMock.On("HintOutput", gameMock).Return("recommended: draw from stock")
+
+	ci := usecase.NewBurracoInteractor(gameMock, pMock)
+	result := ci.Hint()
+	assert.Equal(t, "recommended: draw from stock", result)
+	pMock.AssertExpectations(t)
+}
+
 func TestBurracoInteractor_RunCpuTurns(t *testing.T) {
 	mockOutput := `{"phase":0}`
 

--- a/internal/usecase/presenter/BurracoPresenter.go
+++ b/internal/usecase/presenter/BurracoPresenter.go
@@ -5,4 +5,8 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // BurracoPresenter ブラーコプレゼンタインタフェース
-type BurracoPresenter = GamePresenter[interfaces.BurracoGame]
+type BurracoPresenter interface {
+	GamePresenter[interfaces.BurracoGame]
+	// HintOutput ヒント情報を出力する
+	HintOutput(g interfaces.BurracoGame) string
+}

--- a/internal/usecase/presenter/BurracoPresenter_mock.go
+++ b/internal/usecase/presenter/BurracoPresenter_mock.go
@@ -5,4 +5,12 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // MockBurracoPresenter ブラーコプレゼンターモック
-type MockBurracoPresenter = MockGamePresenter[interfaces.BurracoGame]
+type MockBurracoPresenter struct {
+	MockGamePresenter[interfaces.BurracoGame]
+}
+
+// HintOutput モック
+func (_m *MockBurracoPresenter) HintOutput(g interfaces.BurracoGame) string {
+	ret := _m.Called(g)
+	return ret.Get(0).(string)
+}


### PR DESCRIPTION
Closes #3372

## What
Adds a phase-aware CUI **hint** command (`h` / `hint`) to Burraco that emits a recommended action via a new `HintOutput` presenter method, mirroring the existing FiveHundred / BidWhist pattern.

## How (kept small to fit the `extra` worker budget)
The hint logic reuses Burraco/Canasta's **existing CPU AI helpers** rather than adding new heuristics — so the addition is minimal:
- `domain.Canasta.GetHint()` returns a `CanastaHint` by reusing `cpuFindNaturalPair` (DRAW: take the discard pile when a natural pair matches the top, else draw stock), `cpuFindMelds` (MELD: recommend a meldable group, else skip), and `cpuBestDiscard` (DISCARD: least-useful card). `BurracoHint` is an alias of `CanastaHint`.
- Interface: `CanastaGame.GetHint()` (+ mock).
- Presenters: `BurracoCuiPresenter.HintOutput` formats the hint with i18n reason keys; `BurracoWebPresenter.HintOutput` satisfies the extended `BurracoPresenter` interface and returns the standard state JSON (the web GUI keeps its existing frontend `useGameHint` heuristic — no backend web hint added).
- Usecase: `BurracoInteractor.Hint()`; Controller: `h` / `hint` command; Help line added.
- i18n: ja/en hint format + reason keys (key parity verified, 46/46).

Burraco had **no prior domain hint** (only a frontend heuristic), so this is new domain logic — but it is thin because it delegates entirely to the existing CPU decision functions.

## Backend / CUI only
No frontend changes.

## Gates
- `go test -tags test ./...` — all pass (added domain `GetHint`, presenter `HintOutput`, interactor `Hint`, controller `h`/`hint` tests)
- `golangci-lint run ./internal/...` — 0 issues
- `goimports -w` on all modified Go files
- `GOOS=js GOARCH=wasm go build -tags extra ./cmd/workers/extra/` — **WASM_EXTRA_OK**

## Size note (`extra` worker)
The `extra` TinyGo worker had ~18 KB gzip headroom (1,030,145 / 1,048,576 B). This change is deliberately minimal — it reuses existing CPU helpers and adds no new web output types (the web `HintOutput` just delegates to `Output`), so the net code addition is a small `GetHint` switch, one CUI formatter, and i18n strings. Gzip cannot be measured locally without TinyGo; **relying on CI's "Check size limit" step on the `extra` build as the gate.** If it trips the 1 MB limit, the hint formatting can be trimmed further.