### PR TITLE
feat(deuceswild): localize video-poker hand names via stable keys

### DIFF
--- a/frontend/src/components/VideoPokerGameContent.test.tsx
+++ b/frontend/src/components/VideoPokerGameContent.test.tsx
@@ -261,6 +261,21 @@ describe('VideoPokerGameContent', () => {
     expect(screen.getByTestId('vp-payout-row-royalFlush')).not.toHaveAttribute('aria-current');
   });
 
+  it('highlights the winning row by handKey, not the English handName', async () => {
+    // handKey points at wildRoyalFlush while handName is a mismatching English
+    // string; the row highlight must follow the stable key.
+    mockExec.mockResolvedValue({
+      ...resultPhaseWin,
+      variantName: 'deuceswild',
+      handKey: 'wildRoyalFlush',
+      handName: 'SOME UNTRANSLATED STRING',
+    });
+    renderContent('deuceswild');
+    await waitFor(() => expect(screen.getByRole('button', { name: /次のゲーム/ })).toBeInTheDocument());
+    expect(screen.getByTestId('vp-payout-row-wildRoyalFlush')).toHaveAttribute('aria-current', 'true');
+    expect(screen.getByTestId('vp-payout-row-fourDeuces')).not.toHaveAttribute('aria-current');
+  });
+
   it('clicking card in result phase does not toggle hold', async () => {
     mockExec.mockResolvedValue(resultPhaseWin);
     renderContent();

--- a/frontend/src/components/VideoPokerGameContent.tsx
+++ b/frontend/src/components/VideoPokerGameContent.tsx
@@ -20,9 +20,9 @@ import { getVideoPokerBaseHint } from '../utils/hints/videoPokerBaseHint';
 import { evaluateJokerPokerMadeHand } from '../utils/jokerPokerMadeHand';
 import {
   VIDEO_POKER_MAX_BET,
-  videoPokerHandNameToRowKey,
   videoPokerPayoutCell,
   videoPokerPayoutRows,
+  videoPokerRowKey,
 } from '../utils/videoPokerPayout';
 import { videoPokerNet, videoPokerWinRate } from '../utils/videoPokerStats';
 import { ActionLogPanel } from './ActionLogPanel';
@@ -205,7 +205,7 @@ export function VideoPokerGameContent({
     if (!isResultPhase || !state) {
       return;
     }
-    const rowKey = videoPokerHandNameToRowKey(state.handName);
+    const rowKey = videoPokerRowKey(state.handKey, state.handName);
     const msg =
       state.payout > 0
         ? tNs('resultAnnounce.win', {
@@ -473,7 +473,7 @@ export function VideoPokerGameContent({
               t={tNs}
               gameName={gameName}
               betAmount={betAmount}
-              winningRowKey={isResultPhase ? videoPokerHandNameToRowKey(state.handName) : null}
+              winningRowKey={isResultPhase ? videoPokerRowKey(state.handKey, state.handName) : null}
               handCounts={statsEnabled ? stats.handCounts : null}
             />
 

--- a/frontend/src/types/card.ts
+++ b/frontend/src/types/card.ts
@@ -6677,6 +6677,13 @@ export interface VideoPokerResponse extends BaseGameResponse {
   payout: number;
   handRank: number;
   handName: string;
+  /**
+   * Stable, locale-independent hand key (e.g. `"wildRoyalFlush"`) matching the
+   * `payoutTable.name.*` / `videoPokerPayoutRows` row keys. Empty on a losing
+   * hand, and absent on responses that predate this field. Preferred over
+   * reverse-looking up the English `handName`.
+   */
+  handKey?: string;
   heldIndices: boolean[];
   variantName: string;
 }

--- a/frontend/src/utils/videoPokerPayout.test.ts
+++ b/frontend/src/utils/videoPokerPayout.test.ts
@@ -4,6 +4,7 @@ import {
   videoPokerHandNameToRowKey,
   videoPokerPayoutCell,
   videoPokerPayoutRows,
+  videoPokerRowKey,
 } from './videoPokerPayout';
 
 describe('videoPokerPayoutRows', () => {
@@ -66,5 +67,21 @@ describe('videoPokerHandNameToRowKey', () => {
   it('returns null for non-paying / unknown hands', () => {
     expect(videoPokerHandNameToRowKey('High Card')).toBeNull();
     expect(videoPokerHandNameToRowKey('')).toBeNull();
+  });
+});
+
+describe('videoPokerRowKey', () => {
+  it('prefers the stable handKey over the English handName', () => {
+    // handKey wins even when handName would map elsewhere.
+    expect(videoPokerRowKey('wildRoyalFlush', 'Four of a Kind')).toBe('wildRoyalFlush');
+    expect(videoPokerRowKey('fiveOfAKind', '')).toBe('fiveOfAKind');
+  });
+  it('falls back to the handName reverse-lookup when handKey is absent', () => {
+    expect(videoPokerRowKey(undefined, 'Wild Royal Flush')).toBe('wildRoyalFlush');
+    expect(videoPokerRowKey('', 'Four Deuces')).toBe('fourDeuces');
+  });
+  it('returns null when neither a key nor a known name is present', () => {
+    expect(videoPokerRowKey(undefined, '')).toBeNull();
+    expect(videoPokerRowKey('', 'High Card')).toBeNull();
   });
 });

--- a/frontend/src/utils/videoPokerPayout.ts
+++ b/frontend/src/utils/videoPokerPayout.ts
@@ -89,10 +89,23 @@ export function videoPokerPayoutCell(row: VideoPokerPayoutRow, bet: number): num
 /**
  * Maps a server-produced hand name (e.g. "Natural Royal Flush", "Jacks or Better")
  * to its paytable row key, or `null` when the hand pays nothing / is not on the
- * table. Used to highlight the winning row in the result phase.
+ * table. Used as a fallback for states that predate the `handKey` field.
  */
 export function videoPokerHandNameToRowKey(handName: string): string | null {
   return HAND_NAME_TO_ROW_KEY[handName] ?? null;
+}
+
+/**
+ * Resolves the winning paytable row key for a result. Prefers the stable
+ * server-supplied `handKey`; falls back to reverse-looking up the English
+ * `handName` for older responses that omit the key. Returns `null` for a losing
+ * hand (empty key and unmatched name).
+ */
+export function videoPokerRowKey(handKey: string | undefined, handName: string): string | null {
+  if (handKey) {
+    return handKey;
+  }
+  return videoPokerHandNameToRowKey(handName);
 }
 
 const HAND_NAME_TO_ROW_KEY: Record<string, string> = {

--- a/internal/adapter/controller/VideoPokerWebController.go
+++ b/internal/adapter/controller/VideoPokerWebController.go
@@ -25,6 +25,7 @@ type VideoPokerWebOutput struct {
 	Payout      int              `json:"payout"`
 	HandRank    int              `json:"handRank"`
 	HandName    string           `json:"handName"`
+	HandKey     string           `json:"handKey"`
 	HeldIndices [5]bool          `json:"heldIndices"`
 	VariantName string           `json:"variantName"`
 	WebOutputBase

--- a/internal/adapter/presenter/VideoPokerCuiPresenter.go
+++ b/internal/adapter/presenter/VideoPokerCuiPresenter.go
@@ -56,7 +56,7 @@ func (vpp *VideoPokerCuiPresenter) Output(vp interfaces.VideoPokerGame, lastErr 
 	if vp.GetGameEndFlag() {
 		sb.WriteString(i18n.Tf("videopoker.betLine", "bet", strconv.Itoa(vp.GetBetAmount())) + "\n")
 		if vp.GetResult() == domain.GameResultWin {
-			sb.WriteString(color.Green(i18n.Tf("videopoker.winLine", "handName", vp.GetHandName())) + "\n")
+			sb.WriteString(color.Green(i18n.Tf("videopoker.winLine", "handName", vpp.handNameForWin(vp))) + "\n")
 		} else {
 			sb.WriteString(color.Red(i18n.T("videopoker.noWin")) + "\n")
 		}
@@ -100,6 +100,19 @@ func (vpp *VideoPokerCuiPresenter) paytableStr(variantName string) string {
 		sb.WriteString(line + "\n")
 	}
 	return sb.String()
+}
+
+// handNameForWin は勝利行に表示する役名を返す。Deuces Wild は安定キー
+// (GetHandKey) 経由で "deuceswild.hand.<key>" を翻訳し、ja/en それぞれの
+// ロケールで役名を表示する。他バリアント (videopoker / jokerpoker) は従来通り
+// 英語の GetHandName をそのまま返し、後方互換を保つ。
+func (vpp *VideoPokerCuiPresenter) handNameForWin(vp interfaces.VideoPokerGame) string {
+	if vp.GetVariantName() == "deuceswild" {
+		if key := vp.GetHandKey(); key != "" {
+			return i18n.T("deuceswild.hand." + key)
+		}
+	}
+	return vp.GetHandName()
 }
 
 // phaseStr フェーズ文字列

--- a/internal/adapter/presenter/VideoPokerCuiPresenter_test.go
+++ b/internal/adapter/presenter/VideoPokerCuiPresenter_test.go
@@ -22,6 +22,7 @@ func setupVideoPokerCuiMockDefaults(m *interfaces.MockVideoPokerGame) {
 	m.On("GetPayout").Return(0).Maybe()
 	m.On("GetHandRank").Return(0).Maybe()
 	m.On("GetHandName").Return("").Maybe()
+	m.On("GetHandKey").Return("").Maybe()
 	m.On("GetHeldIndices").Return([domain.VideoPokerHandSize]bool{}).Maybe()
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil)).Maybe()
 	m.On("GetVariantName").Return("videopoker").Maybe()
@@ -125,13 +126,61 @@ func TestVideoPokerCuiPresenter_Output_ResultPhase_Win(t *testing.T) {
 	m.On("GetPayout").Return(25).Maybe()
 	m.On("GetHandRank").Return(domain.PokerHandFourOfAKind).Maybe()
 	m.On("GetHandName").Return("Four of a Kind").Maybe()
+	m.On("GetHandKey").Return("fourOfAKind").Maybe()
 	m.On("GetHeldIndices").Return([domain.VideoPokerHandSize]bool{true, true, true, true, false}).Maybe()
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil)).Maybe()
+	m.On("GetVariantName").Return("videopoker").Maybe()
 
 	result := p.Output(m, nil)
 	assert.Contains(t, result, "フェーズ: リザルト")
+	// videopoker keeps the English hand name (backward compatible).
 	assert.Contains(t, result, "Four of a Kind! あなたの勝利です！")
 	assert.Contains(t, result, "払戻し: 25")
+}
+
+func TestVideoPokerCuiPresenter_Output_ResultPhase_Win_DeucesWildTranslated(t *testing.T) {
+	winMock := func(variant, handName, handKey string) *interfaces.MockVideoPokerGame {
+		m := new(interfaces.MockVideoPokerGame)
+		m.On("GetChips").Return(1025).Maybe()
+		m.On("GetPhase").Return(domain.VideoPokerPhaseResult).Maybe()
+		m.On("GetHand").Return([]*domain.Card{
+			domain.NewCard(domain.CardDesignSpade, 2, false),
+			domain.NewCard(domain.CardDesignSpade, 10, false),
+			domain.NewCard(domain.CardDesignSpade, 11, false),
+			domain.NewCard(domain.CardDesignSpade, 12, false),
+			domain.NewCard(domain.CardDesignSpade, 13, false),
+		}).Maybe()
+		m.On("GetGameEndFlag").Return(true).Maybe()
+		m.On("GetBetAmount").Return(1).Maybe()
+		m.On("GetResult").Return(domain.GameResultWin).Maybe()
+		m.On("GetPayout").Return(25).Maybe()
+		m.On("GetHandRank").Return(domain.PokerHandRoyalFlush).Maybe()
+		m.On("GetHandName").Return(handName).Maybe()
+		m.On("GetHandKey").Return(handKey).Maybe()
+		m.On("GetHeldIndices").Return([domain.VideoPokerHandSize]bool{}).Maybe()
+		m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil)).Maybe()
+		m.On("GetVariantName").Return(variant).Maybe()
+		return m
+	}
+	p := new(VideoPokerCuiPresenter)
+
+	t.Run("ja shows the translated hand name", func(t *testing.T) {
+		result := p.Output(winMock("deuceswild", "Wild Royal Flush", "wildRoyalFlush"), nil)
+		assert.Contains(t, result, "ワイルドロイヤルフラッシュ! あなたの勝利です！")
+		assert.NotContains(t, result, "Wild Royal Flush!")
+	})
+
+	t.Run("en shows the translated hand name", func(t *testing.T) {
+		i18n.SetLang("en")
+		t.Cleanup(func() { i18n.SetLang("ja") })
+		result := p.Output(winMock("deuceswild", "Wild Royal Flush", "wildRoyalFlush"), nil)
+		assert.Contains(t, result, "Wild Royal Flush! You win!")
+	})
+
+	t.Run("empty key falls back to the raw hand name", func(t *testing.T) {
+		result := p.Output(winMock("deuceswild", "Wild Royal Flush", ""), nil)
+		assert.Contains(t, result, "Wild Royal Flush! あなたの勝利です！")
+	})
 }
 
 func TestVideoPokerCuiPresenter_Output_ResultPhase_Lose(t *testing.T) {

--- a/internal/adapter/presenter/VideoPokerWebPresenter.go
+++ b/internal/adapter/presenter/VideoPokerWebPresenter.go
@@ -26,6 +26,7 @@ func (vpp *VideoPokerWebPresenter) Output(vp interfaces.VideoPokerGame, lastErr 
 	resObj.Payout = vp.GetPayout()
 	resObj.HandRank = vp.GetHandRank()
 	resObj.HandName = vp.GetHandName()
+	resObj.HandKey = vp.GetHandKey()
 	resObj.HeldIndices = vp.GetHeldIndices()
 	resObj.VariantName = vp.GetVariantName()
 

--- a/internal/adapter/presenter/VideoPokerWebPresenter_test.go
+++ b/internal/adapter/presenter/VideoPokerWebPresenter_test.go
@@ -21,6 +21,7 @@ func setupVideoPokerWebMockDefaults(m *interfaces.MockVideoPokerGame) {
 	m.On("GetPayout").Return(0).Maybe()
 	m.On("GetHandRank").Return(0).Maybe()
 	m.On("GetHandName").Return("").Maybe()
+	m.On("GetHandKey").Return("").Maybe()
 	m.On("GetHeldIndices").Return([domain.VideoPokerHandSize]bool{}).Maybe()
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil)).Maybe()
 	m.On("GetVariantName").Return("jacksorbetter").Maybe()
@@ -64,6 +65,7 @@ func TestVideoPokerWebPresenter_Output_Win(t *testing.T) {
 	m.On("GetPayout").Return(25).Maybe()
 	m.On("GetHandRank").Return(domain.PokerHandFourOfAKind).Maybe()
 	m.On("GetHandName").Return("Four of a Kind").Maybe()
+	m.On("GetHandKey").Return("fourOfAKind").Maybe()
 	m.On("GetHeldIndices").Return([domain.VideoPokerHandSize]bool{true, true, true, true, false}).Maybe()
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil)).Maybe()
 	m.On("GetVariantName").Return("jacksorbetter").Maybe()
@@ -74,6 +76,7 @@ func TestVideoPokerWebPresenter_Output_Win(t *testing.T) {
 	assert.Equal(t, "Four of a Kind", result.MessageParams["handName"])
 	assert.Equal(t, "25", result.MessageParams["payout"])
 	assert.Equal(t, 25, result.Payout)
+	assert.Equal(t, "fourOfAKind", result.HandKey)
 	assert.Len(t, result.Hand, 5)
 }
 
@@ -95,6 +98,7 @@ func TestVideoPokerWebPresenter_Output_Lose(t *testing.T) {
 	m.On("GetPayout").Return(0).Maybe()
 	m.On("GetHandRank").Return(domain.PokerHandHighCard).Maybe()
 	m.On("GetHandName").Return("").Maybe()
+	m.On("GetHandKey").Return("").Maybe()
 	m.On("GetHeldIndices").Return([domain.VideoPokerHandSize]bool{}).Maybe()
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil)).Maybe()
 	m.On("GetVariantName").Return("jacksorbetter").Maybe()

--- a/internal/domain/VideoPoker.go
+++ b/internal/domain/VideoPoker.go
@@ -35,6 +35,7 @@ type VideoPoker struct {
 	payout      int
 	handRank    int
 	handName    string
+	handKey     string
 	actionLog   []*ActionLogEntry
 	config      *VideoPokerVariantConfig
 }
@@ -81,6 +82,7 @@ func (vp *VideoPoker) Reset() {
 	vp.payout = 0
 	vp.handRank = 0
 	vp.handName = ""
+	vp.handKey = ""
 	vp.actionLog = nil
 	if vp.chips.GetChips() < VideoPokerMinBet {
 		vp.chips.SetChips(VideoPokerDefaultChips)
@@ -164,9 +166,11 @@ func (vp *VideoPoker) evaluate() {
 	if vp.payout > 0 {
 		vp.result = GameResultWin
 		vp.handName = handName
+		vp.handKey = videoPokerHandKey(handName)
 	} else {
 		vp.result = GameResultLose
 		vp.handName = ""
+		vp.handKey = ""
 	}
 	displayName := handName
 	if displayName == "" {
@@ -175,6 +179,47 @@ func (vp *VideoPoker) evaluate() {
 		}
 	}
 	vp.appendLog(0, "result", fmt.Sprintf("%s payout=%d", displayName, vp.payout), vp.hand)
+}
+
+// videoPokerHandKey maps a variant hand name (the English string returned by a
+// VideoPokerVariantConfig.GetResult) to a stable, locale-independent key. The
+// key matches the frontend payout-table row keys
+// (frontend/src/utils/videoPokerPayout.ts) and the "<variant>.hand.<key>" CUI
+// translation keys, so both clients can localize the hand without reverse-looking
+// up the English string. It returns "" for an unknown or empty (losing) name.
+func videoPokerHandKey(handName string) string {
+	switch handName {
+	case "Royal Flush":
+		return "royalFlush"
+	case "Natural Royal Flush":
+		return "naturalRoyalFlush"
+	case "Wild Royal Flush":
+		return "wildRoyalFlush"
+	case "Four Deuces":
+		return "fourDeuces"
+	case "Five of a Kind":
+		return "fiveOfAKind"
+	case "Straight Flush":
+		return "straightFlush"
+	case "Four of a Kind":
+		return "fourOfAKind"
+	case "Full House":
+		return "fullHouse"
+	case "Flush":
+		return "flush"
+	case "Straight":
+		return "straight"
+	case "Three of a Kind":
+		return "threeOfAKind"
+	case "Two Pair":
+		return "twoPair"
+	case "Jacks or Better":
+		return "jacksOrBetter"
+	case "Kings or Better":
+		return "kingsOrBetter"
+	default:
+		return ""
+	}
 }
 
 // appendLog 棋譜にエントリを追加する
@@ -217,6 +262,9 @@ func (vp *VideoPoker) GetHandRank() int { return vp.handRank }
 // GetHandName ハンド名
 func (vp *VideoPoker) GetHandName() string { return vp.handName }
 
+// GetHandKey は役の安定キー（ロケール非依存）を返す。役なし時は空文字。
+func (vp *VideoPoker) GetHandKey() string { return vp.handKey }
+
 // GetHeldIndices ホールドインデックス
 func (vp *VideoPoker) GetHeldIndices() [VideoPokerHandSize]bool { return vp.heldIndices }
 
@@ -258,6 +306,9 @@ func (vp *VideoPoker) SetHandRank(rank int) { vp.handRank = rank }
 // SetHandName ハンド名設定（テスト用）
 func (vp *VideoPoker) SetHandName(name string) { vp.handName = name }
 
+// SetHandKey 役キー設定（テスト用）
+func (vp *VideoPoker) SetHandKey(key string) { vp.handKey = key }
+
 // videoPokerJSON is the JSON wire format for VideoPoker.
 type videoPokerJSON struct {
 	TrumpCards  *TrumpCards              `json:"tc"`
@@ -271,6 +322,7 @@ type videoPokerJSON struct {
 	Payout      int                      `json:"po"`
 	HandRank    int                      `json:"hr"`
 	HandName    string                   `json:"hn"`
+	HandKey     string                   `json:"hk"`
 	ActionLog   []*ActionLogEntry        `json:"al"`
 	ConfigName  string                   `json:"cn"`
 	JokerCount  int                      `json:"jc"`
@@ -290,6 +342,7 @@ func (vp *VideoPoker) MarshalJSON() ([]byte, error) {
 		Payout:      vp.payout,
 		HandRank:    vp.handRank,
 		HandName:    vp.handName,
+		HandKey:     vp.handKey,
 		ActionLog:   vp.actionLog,
 	}
 	if vp.config != nil {
@@ -332,6 +385,7 @@ func (vp *VideoPoker) UnmarshalJSON(data []byte) error {
 	vp.payout = j.Payout
 	vp.handRank = j.HandRank
 	vp.handName = j.HandName
+	vp.handKey = j.HandKey
 	vp.actionLog = j.ActionLog
 	if vp.actionLog == nil {
 		vp.actionLog = make([]*ActionLogEntry, 0)

--- a/internal/domain/VideoPoker_test.go
+++ b/internal/domain/VideoPoker_test.go
@@ -192,6 +192,85 @@ func TestVideoPoker_Payout_RoyalFlush_MaxBet(t *testing.T) {
 	assert.Equal(t, 4000, vp.GetPayout()) // 5 * 800
 	assert.Equal(t, 4000, vp.GetChips())
 	assert.Equal(t, "Royal Flush", vp.GetHandName())
+	assert.Equal(t, "royalFlush", vp.GetHandKey())
+}
+
+// --- Stable hand key ---
+
+func TestVideoPokerHandKey(t *testing.T) {
+	tests := []struct {
+		handName string
+		want     string
+	}{
+		{"Royal Flush", "royalFlush"},
+		{"Natural Royal Flush", "naturalRoyalFlush"},
+		{"Wild Royal Flush", "wildRoyalFlush"},
+		{"Four Deuces", "fourDeuces"},
+		{"Five of a Kind", "fiveOfAKind"},
+		{"Straight Flush", "straightFlush"},
+		{"Four of a Kind", "fourOfAKind"},
+		{"Full House", "fullHouse"},
+		{"Flush", "flush"},
+		{"Straight", "straight"},
+		{"Three of a Kind", "threeOfAKind"},
+		{"Two Pair", "twoPair"},
+		{"Jacks or Better", "jacksOrBetter"},
+		{"Kings or Better", "kingsOrBetter"},
+		{"", ""},
+		{"Unknown Hand", ""},
+	}
+	for _, tc := range tests {
+		assert.Equal(t, tc.want, videoPokerHandKey(tc.handName), "handName=%q", tc.handName)
+	}
+}
+
+func TestVideoPoker_HandKey_PopulatedForDeucesWild(t *testing.T) {
+	tests := []struct {
+		name    string
+		hand    [][2]int
+		wantKey string
+	}{
+		{
+			name:    "WildRoyalFlush",
+			hand:    [][2]int{{CardDesignSpade, 2}, {CardDesignSpade, 10}, {CardDesignSpade, 11}, {CardDesignSpade, 12}, {CardDesignSpade, 13}},
+			wantKey: "wildRoyalFlush",
+		},
+		{
+			name:    "FiveOfAKind",
+			hand:    [][2]int{{CardDesignSpade, 7}, {CardDesignHeart, 7}, {CardDesignClover, 7}, {CardDesignDiamond, 7}, {CardDesignSpade, 2}},
+			wantKey: "fiveOfAKind",
+		},
+		{
+			name:    "FourDeuces",
+			hand:    [][2]int{{CardDesignSpade, 2}, {CardDesignHeart, 2}, {CardDesignClover, 2}, {CardDesignDiamond, 2}, {CardDesignSpade, 7}},
+			wantKey: "fourDeuces",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			vp := NewDeucesWildVideoPoker()
+			vp.SetPhase(VideoPokerPhaseDraw)
+			vp.SetBetAmount(1)
+			vp.SetHand(makeHand(tc.hand))
+			assert.NoError(t, vp.Hold([]int{0, 1, 2, 3, 4}))
+			assert.Equal(t, GameResultWin, vp.GetResult())
+			assert.Equal(t, tc.wantKey, vp.GetHandKey())
+		})
+	}
+}
+
+func TestVideoPoker_HandKey_EmptyOnLoss(t *testing.T) {
+	vp := NewDeucesWildVideoPoker()
+	vp.SetPhase(VideoPokerPhaseDraw)
+	vp.SetBetAmount(1)
+	// No deuce, no pair, no flush/straight — a losing high-card hand.
+	vp.SetHand(makeHand([][2]int{
+		{CardDesignSpade, 3}, {CardDesignHeart, 5}, {CardDesignClover, 7},
+		{CardDesignDiamond, 9}, {CardDesignSpade, 11},
+	}))
+	assert.NoError(t, vp.Hold([]int{0, 1, 2, 3, 4}))
+	assert.Equal(t, GameResultLose, vp.GetResult())
+	assert.Equal(t, "", vp.GetHandKey())
 }
 
 func TestVideoPoker_Payout_RoyalFlush_NonMaxBet(t *testing.T) {

--- a/internal/domain/interfaces/videopoker.go
+++ b/internal/domain/interfaces/videopoker.go
@@ -32,6 +32,8 @@ type VideoPokerGame interface {
 	GetHandRank() int
 	// GetHandName ハンド名を取得する
 	GetHandName() string
+	// GetHandKey 役の安定キー（ロケール非依存）を取得する
+	GetHandKey() string
 	// GetHeldIndices ホールドインデックスを取得する
 	GetHeldIndices() [domain.VideoPokerHandSize]bool
 	// GetVariantName バリアント名を取得する

--- a/internal/domain/interfaces/videopoker_mock.go
+++ b/internal/domain/interfaces/videopoker_mock.go
@@ -75,6 +75,11 @@ func (m *MockVideoPokerGame) GetHandName() string {
 	return args.String(0)
 }
 
+func (m *MockVideoPokerGame) GetHandKey() string {
+	args := m.Called()
+	return args.String(0)
+}
+
 func (m *MockVideoPokerGame) GetHeldIndices() [domain.VideoPokerHandSize]bool {
 	args := m.Called()
 	return args.Get(0).([domain.VideoPokerHandSize]bool)

--- a/internal/domain/serialization_test.go
+++ b/internal/domain/serialization_test.go
@@ -267,6 +267,8 @@ func TestIndianPoker_JSONRoundTrip(t *testing.T) {
 
 func TestVideoPoker_JSONRoundTrip(t *testing.T) {
 	vp := NewDefaultVideoPoker()
+	vp.SetHandName("Wild Royal Flush")
+	vp.SetHandKey("wildRoyalFlush")
 
 	data, err := json.Marshal(vp)
 	require.NoError(t, err)
@@ -276,6 +278,8 @@ func TestVideoPoker_JSONRoundTrip(t *testing.T) {
 
 	assert.Equal(t, vp.GetPhase(), got.GetPhase())
 	assert.Equal(t, vp.GetGameEndFlag(), got.GetGameEndFlag())
+	assert.Equal(t, vp.GetHandName(), got.GetHandName())
+	assert.Equal(t, vp.GetHandKey(), got.GetHandKey())
 }
 
 func TestHearts_JSONRoundTrip(t *testing.T) {

--- a/internal/i18n/locales/en/deuceswild.json
+++ b/internal/i18n/locales/en/deuceswild.json
@@ -1,3 +1,13 @@
 {
-  "helpTitle": "Deuces Wild"
+  "helpTitle": "Deuces Wild",
+  "hand.naturalRoyalFlush": "Natural Royal Flush",
+  "hand.fourDeuces": "Four Deuces",
+  "hand.wildRoyalFlush": "Wild Royal Flush",
+  "hand.fiveOfAKind": "Five of a Kind",
+  "hand.straightFlush": "Straight Flush",
+  "hand.fourOfAKind": "Four of a Kind",
+  "hand.fullHouse": "Full House",
+  "hand.flush": "Flush",
+  "hand.straight": "Straight",
+  "hand.threeOfAKind": "Three of a Kind"
 }

--- a/internal/i18n/locales/ja/deuceswild.json
+++ b/internal/i18n/locales/ja/deuceswild.json
@@ -1,3 +1,13 @@
 {
-  "helpTitle": "Deuces Wild (デューシーズワイルド)"
+  "helpTitle": "Deuces Wild (デューシーズワイルド)",
+  "hand.naturalRoyalFlush": "ナチュラルロイヤルフラッシュ",
+  "hand.fourDeuces": "フォーデューシーズ",
+  "hand.wildRoyalFlush": "ワイルドロイヤルフラッシュ",
+  "hand.fiveOfAKind": "ファイブカード",
+  "hand.straightFlush": "ストレートフラッシュ",
+  "hand.fourOfAKind": "フォーカード",
+  "hand.fullHouse": "フルハウス",
+  "hand.flush": "フラッシュ",
+  "hand.straight": "ストレート",
+  "hand.threeOfAKind": "スリーカード"
 }


### PR DESCRIPTION
Closes #3073

## Summary
Deuces Wild video-poker hand names ("Wild Royal Flush", "Five of a Kind", …) displayed as raw English in the CUI and were reverse-looked-up from the English string on the web. This adds a **stable, locale-independent hand key** to the response so both clients localize the hand name properly.

## Backward compatibility (videopoker / jokerpoker unaffected)
- The existing `handName` string is **retained unchanged**; a new parallel `handKey` field is **added** (derived from `handName` via `videoPokerHandKey()` in the domain).
- **CUI:** only `deuceswild` switches to `i18n.T("deuceswild.hand.<key>")` in the win line (gated by `GetVariantName() == "deuceswild"`). `videopoker` and `jokerpoker` still render the English `handName` — their presenter tests are unchanged in behavior. Empty key falls back to the raw name.
- **Web:** `videoPokerRowKey()` prefers the server `handKey` and **falls back** to the old English reverse-lookup, so any response lacking the key (older/cached state) still highlights correctly. `handKey` is typed optional (`handKey?: string`).

## Changes
- **domain** (`VideoPoker.go`, interface + mock, serialization): `handKey` field, `videoPokerHandKey()` English→key map (matches the frontend row keys), getter/setter, JSON `hk`.
- **adapter**: `VideoPokerWebOutput.handKey` (wire), web presenter sets it; CUI presenter `handNameForWin()` translates the Deuces Wild win line.
- **i18n (Go)**: `deuceswild.hand.*` entries added to `internal/i18n/locales/{ja,en}/deuceswild.json` (ja/en parity). These locales are **not** embedded in the WASM workers (i18n stub), so zero casino-size impact.
- **frontend**: `videoPokerRowKey()` helper; `VideoPokerGameContent.tsx` uses it for the winning-row highlight + result announcement; `VideoPokerResponse.handKey?`.

## Tests
- domain: `videoPokerHandKey` mapping table; `handKey` populated for wild royal flush / five of a kind / four deuces and empty on loss; JSON round-trip carries `handKey`.
- presenter: Deuces Wild win line asserts the **translated** ja and en names + empty-key fallback; web output asserts `handKey`.
- frontend: `videoPokerRowKey` prefers key over name / falls back / returns null; component highlights the winning row by `handKey` even when `handName` is a mismatching string.

## Gates
- `go test -tags test ./...` — all pass
- `golangci-lint run ./internal/...` — 0 issues
- `bun run build` (tsc -b + vite), `bun run check` (biome, no new flags), targeted Vitest (56 pass)
- `GOOS=js GOARCH=wasm go build -tags casino` — **WASM_CASINO_OK**

## Casino size note
The casino worker has only ~14 KB gzip headroom. This change adds to the WASM only a small `switch` (14 short cases), one struct field, a getter, and a ~10-line presenter helper (the Go locale strings are stub-excluded from the worker) — on the order of <1 KB. TinyGo was not available locally to measure exactly; CI's casino size-check is the gate. If it trips, shrinking the key set/strings is the mitigation.