### PR TITLE
docs: sync docs with 219-game registry (add zheng, fix stale counts)

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ Go + Clean Architecture で実装した219種類のトランプゲーム。CLI �
 | ケーニッヒルーフェン (Königrufen) | `koenigrufen` | [CUI](docs/manual/cui/koenigrufen.md) / [Web](docs/manual/web/koenigrufen.md) |
 | スカルト (Scarto) | `scarto` | [CUI](docs/manual/cui/scarto.md) / [Web](docs/manual/web/scarto.md) |
 | チェゴ (Cego) | `cego` | [CUI](docs/manual/cui/cego.md) / [Web](docs/manual/web/cego.md) |
+| 争上游 (Zheng Shangyou) | `zheng` | [CUI](docs/manual/cui/zheng.md) / [Web](docs/manual/web/zheng.md) |
 
 ## Demo
 

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -449,6 +449,8 @@ tags:
     description: Watten (ヴァッテン) game
   - name: wizard
     description: Wizard (ウィザード) game
+  - name: zheng
+    description: Zheng Shangyou (争上游) game
 
 paths:
   /blackjack/exec:
@@ -19068,6 +19070,65 @@ paths:
         the session. Consult the in-app manual for the full command set and
         phase progression specific to this game.
       operationId: wizardExec
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - command
+                - sessionId
+              properties:
+                command:
+                  type: string
+                  description: The game command to execute (e.g. reset, or a game-specific action).
+                amount:
+                  type: integer
+                  description: Optional numeric argument for commands that require one (e.g. a bet, index, or selection).
+                sessionId:
+                  type: string
+                  description: Client-supplied session identifier.
+            examples:
+              reset:
+                summary: Start a new game
+                value:
+                  command: reset
+                  sessionId: my-session-001
+      responses:
+        '200':
+          description: Command processed successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                description: Game state after the command was processed.
+                properties:
+                  message:
+                    type: string
+        '400':
+          description: Bad request (unsupported command, invalid parameters, or session error)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+  /zheng/exec:
+    post:
+      tags:
+        - zheng
+      summary: Execute a Zheng Shangyou (争上游) game command
+      description: |
+        Send a command to advance the Zheng Shangyou (争上游) game session identified by
+        `sessionId`. Zheng Shangyou, a Chinese 4-player climbing/shedding game on a 54-card deck (52 cards plus two jokers), an ancestor of Big Two and Daifugo in which suits are irrelevant and bombs beat any normal play.
+
+        Use `reset` (`r`) to start or restart a game and `quit` (`q`) to end
+        the session. Consult the in-app manual for the full command set and
+        phase progression specific to this game.
+      operationId: zhengExec
       requestBody:
         required: true
         content:

--- a/docs/design/backend.md
+++ b/docs/design/backend.md
@@ -6,7 +6,7 @@
 
 - [1. クラス図](#1-クラス図)
   - [1.1 コアドメイン (カード・プレイヤー)](#11-コアドメイン-カードプレイヤー)
-  - [1.2 ゲームドメイン (全218ゲーム)](#12-ゲームドメイン-全218ゲーム)
+  - [1.2 ゲームドメイン (全219ゲーム)](#12-ゲームドメイン-全219ゲーム)
   - [1.3 ユースケース層 (Interactor・Presenter)](#13-ユースケース層-interactorpresenter)
   - [1.4 アダプタ層 (Controller・Presenter実装)](#14-アダプタ層-controllerpresenter実装)
   - [1.5 インフラストラクチャ層](#15-インフラストラクチャ層)
@@ -154,7 +154,7 @@ classDiagram
     GamePlayer *-- ChipHolder : mixin
 ```
 
-### 1.2 ゲームドメイン (全218ゲーム)
+### 1.2 ゲームドメイン (全219ゲーム)
 
 #### ベッティング系ゲーム
 
@@ -1354,7 +1354,7 @@ classDiagram
 
     class ClockSolitaire {
         -trumpCards *TrumpCards
-        -piles [13][]*ClockCard
+        -piles [13][]*ClockSolitaireCard
         -currentPileIdx int
         -stepCount int
         -phase ClockSolitairePhase
@@ -1420,7 +1420,7 @@ classDiagram
         +bool Matched
     }
 
-    class ClockCard {
+    class ClockSolitaireCard {
         +*Card Card
         +bool FaceUp
     }
@@ -1434,7 +1434,7 @@ classDiagram
     Memory --> "*" MemoryBoardCard
     Memory --> "*" MemoryPlayer
     MemoryPlayer --|> GamePlayer
-    ClockSolitaire --> "*" ClockCard
+    ClockSolitaire --> "*" ClockSolitaireCard
     Durak --> "*" DurakPlayer
     Durak --> "1" DurakConfig
     DurakPlayer --|> GamePlayer
@@ -1715,7 +1715,7 @@ classDiagram
     note for GamePresenter "各ゲームの Presenter は\nGamePresenter[G] の型エイリアス\nまたは拡張インターフェース"
 ```
 
-**Interactor パターン (全218ゲーム共通)**
+**Interactor パターン (全219ゲーム共通)**
 
 ```mermaid
 classDiagram
@@ -1787,8 +1787,8 @@ classDiagram
     GameCuiPresenter ..|> GamePresenter : implements
     GameWebPresenter ..|> GamePresenter : implements
 
-    note for GameCuiController "218ゲーム × CUI/Web = 436 Controller\nGameCuiController / GameWebController は\n各ゲーム毎に具体的な実装が存在"
-    note for GameCuiPresenter "218ゲーム × CUI/Web = 436 Presenter 実装"
+    note for GameCuiController "219ゲーム × CUI/Web = 438 Controller\nGameCuiController / GameWebController は\n各ゲーム毎に具体的な実装が存在"
+    note for GameCuiPresenter "219ゲーム × CUI/Web = 438 Presenter 実装"
 ```
 
 ### 1.5 インフラストラクチャ層
@@ -1828,8 +1828,8 @@ classDiagram
     }
 
     TrumpCardsWeb --> "*" gameEntry : registerAll() over games.All()
-    gameEntry --> GameWebController : holds 218 controllers
-    GameManager --> "*" CuiExecer : holds 218 games
+    gameEntry --> GameWebController : holds 219 controllers
+    GameManager --> "*" CuiExecer : holds 219 games
     GameCui ..|> CuiExecer : implements
     GameCui --> GameCuiController : delegates
 ```

--- a/docs/design/frontend.md
+++ b/docs/design/frontend.md
@@ -437,7 +437,7 @@ classDiagram
         +object messageParams
     }
 
-    note for BlackJackResponse "各ゲームが固有のResponse型を持つ\n(全218ゲーム分存在)\n共通フィールド: message, messageCode, messageParams"
+    note for BlackJackResponse "各ゲームが固有のResponse型を持つ\n(全219ゲーム分存在)\n共通フィールド: message, messageCode, messageParams"
 ```
 
 **フェーズ定数 (全ゲーム)**
@@ -868,7 +868,7 @@ classDiagram
     class actionLogApi {
         +blackjack() Promise~ActionLogResponse~
         +poker() Promise~ActionLogResponse~
-        ...全218ゲーム()
+        ...全219ゲーム()
     }
 
     BlackJackApi --> gameApi : uses postJson/gameExec
@@ -930,7 +930,7 @@ classDiagram
 
     RedDogApi --> gameApi : uses postJson/gameExec
 
-    note for BlackJackApi "全218ゲーム分のAPI Objectが存在\n(blackjack, poker, oldmaid, daifugo, bigtwo, sevens, doubt, holdem,\nomaha, omahahilo, bigo, bigohilo, shortdeck, pineapple, crazypineapple, irishpoker,\nhearts, memory, klondike, freecell, seahaventowers, cruel, baccarat, spades,\ncrazyeights, ginrummy, canasta, spider, napoleon, indianpoker, videopoker, deuceswild,\njokerpoker, euchre, pyramid, tripeaks, cribbage, threecard, ohhell, bridge,\nspeed, gofish, pinochle, golf, pigtail, sevencardstud, clocksolitaire, durak,\nfortythieves, paigow, twotenjack, caribbeanstud, texasholdembonus, war, canfield, fiftyone,\nyukon, russiansolitaire, whist, letitride, pokersquares, pageone, reddog, badugi,\ndeucetoseven, razz, scorpion, wasp, accordion, trash, sevenbridge, president,\ncassino, spanish21, calculation, spiteandmalice, skat, shithead, nertz, slapjack,\negyptianratscrew, bakersdozen, tonk, casinowar, pitch, dragontiger, blackjackswitch, montecarlo,\ncontractrummy, ultimatetexasholdem, crescent, mississippistud, belote, spiderette, mighty, oasispoker,\nbeleagueredcastle, piquet, casinoholdem, callbreak, tarneeb, highcardflush, briscola, gaps,\nfourcardpoker, rummy500, eightoff, russianpoker, penguin, chinesepoker, sixcardgolf, doudizhu,\ntruco, scopa, acesup, barbu, macau, thirtyone, tienlen, osmosis,\nfivehundred, schnapsen, burraco, yaniv, gongzhu, bristol, bidwhist, tressette,\neasthaven, tichu, bakersgame, bourre, sheepshead, doppelkopf, mus, tute,\nsueca, fortyfives, twentynine, klaverjas, manille, marias, sedma, solowhist,\nknockoutwhist, nap, preference, spoilfive, courtpiece, bezique, ecarte, threecardbrag,\nteenpatti, scopone, escoba, handandfoot, conquian, chinchon, kalooki, threethirteen,\nmao, spoons, kemps, cuckoo, pishti, cuarenta, fivecardstud, faro,\nopenfacechinese, russianbank, labellelucie, simplesimon, doubleklondike, blackhole)"
+    note for BlackJackApi "全219ゲーム分のAPI Objectが存在\n(ゲーム一覧の SSoT は internal/infrastructure/games/registry.go。\nfrontend/src/api/gameApi.ts の games 配列と1:1対応)"
 ```
 
 ### 1.3 Hook 層 (共通Hook)
@@ -1309,7 +1309,7 @@ classDiagram
 
     useCanastaGame --> useGameApi : uses
 
-    note for useBlackJackGame "主要ゲームに固有Hookが存在 (現在130ファイル)\n各HookはuseGameApiで統一的にAPI呼出し\n必要に応じてuseCardSelectionを合成"
+    note for useBlackJackGame "主要ゲームに固有Hookが存在 (現在131ファイル)\n各HookはuseGameApiで統一的にAPI呼出し\n必要に応じてuseCardSelectionを合成"
 ```
 
 ### 1.5 コンポーネント層
@@ -1908,7 +1908,7 @@ classDiagram
     GamePage --> PokerTableLayout : renders (Hold'em/Omaha/BigO/ShortDeck/Pineapple/SevenCardStud/Razz)
     PokerTableLayout --> CpuPlayerCard : wraps
 
-    note for GamePage "全218ゲームページが同一パターンで構成\nuseGamePageSetup → ゲーム固有Hook → 描画"
+    note for GamePage "全219ゲームページが同一パターンで構成\nuseGamePageSetup → ゲーム固有Hook → 描画"
 ```
 
 ### 1.7 i18n・プロバイダー・ルーティング
@@ -1931,7 +1931,7 @@ classDiagram
         +HashRouter
         +ErrorBoundary
         +NavBar
-        +Routes (218ゲーム)
+        +Routes (219ゲーム)
     }
 
     class gameCategories {
@@ -1942,7 +1942,7 @@ classDiagram
         +solitaire
         +rummy
     }
-    note for gameCategories "6カテゴリの各メンバー構成 (全218ゲーム) は\nfrontend/src/constants/gameRoutes.ts が SSoT。\n個別の所属はそこで定義される"
+    note for gameCategories "6カテゴリの各メンバー構成 (全219ゲーム) は\nfrontend/src/constants/gameRoutes.ts が SSoT。\n個別の所属はそこで定義される"
 
     class TutorialProvider {
         +TutorialConfig config
@@ -1959,7 +1959,7 @@ classDiagram
     GamePage --> TutorialProvider : wraps (per-game)
     TutorialProvider --> TutorialOverlay : renders when active
 
-    note for i18n "221名前空間: common + 218ゲーム固有 + tutorial + discover\n翻訳ファイル: locales/{ja,en}/game.json"
+    note for i18n "222名前空間: common + 219ゲーム固有 + tutorial + discover\n翻訳ファイル: locales/{ja,en}/game.json"
 ```
 
 ### 1.8 AI Game Concierge (/discover)


### PR DESCRIPTION
## Summary

`/doc-drift-check` で検出したドキュメントドリフトの修正。原因はゲーム #219 `zheng`(争上游)追加時の更新漏れがほとんど。正解値は SSoT (`internal/infrastructure/games/registry.go`) の**全219ゲーム**。

- **api/openapi.yaml**: 欠落していた `POST /zheng/exec` パスと `zheng` タグを追加(218→219、レジストリと1:1に)
- **README.md**: ゲーム表に欠落していた 争上游 (Zheng Shangyou) の行を追加(「219種類」の記載と一致)
- **docs/design/backend.md**: ゲーム数 218→219(Controller/Presenter 436→438、holds 218→219 含む)、ClockSolitaire クラス図の存在しない型 `ClockCard` を実際の `ClockSolitaireCard` に修正
- **docs/design/frontend.md**: ゲーム数 218→219、i18n 名前空間 221→222、ゲームHook数 130→131 に更新。BlackJackApi 注記の古い約180ゲーム列挙(45件以上欠落)を SSoT 参照に置換して再ドリフトを防止

検査で不一致なしと確認済み: CLAUDE.md、docs/games.md、CUI/Web マニュアル(各219ファイル)、docs/architecture.md(219エンドポイント)、frontend/CLAUDE.md、ja/en ロケール(各222ファイル)、ADR 索引、gameRoutes.ts(blackjack の `/` 配置は意図的)。

設計書2ファイルは `docs_consistency_test.go` の対象外のためドリフトしていた点は issue に記録済み。

Closes #4295

## Test plan

- [x] `python3` で `api/openapi.yaml` のパースを確認(exec パス 219 / タグ 219)
- [x] `go test -tags test ./internal/infrastructure/games/`(docs_consistency_test 含む)合格
- [ ] CI (golangci-lint / CodeQL) グリーン確認
