### PR TITLE
fix(cli): unify unknown-game exit code to 2 and add recovery hint

### DIFF
--- a/cmd/trumpcards/main.go
+++ b/cmd/trumpcards/main.go
@@ -612,6 +612,10 @@ func resolveStartGame(flagValue string, stderr io.Writer) (string, int, bool) {
 	if suggestion := cuiutil.SuggestCommand(v, helpSuggestionCandidates(), 2); suggestion != "" {
 		_, _ = fmt.Fprintf(stderr, "  %s\n", i18n.Tf("didYouMean", "name", suggestion))
 	}
+	// Same one-line recovery hint as the top-level positional-arg path, so a
+	// far-off `--start` typo with no Did-you-mean suggestion still has a way
+	// forward. Keeps the two unknown-game entry points consistent.
+	_, _ = fmt.Fprintln(stderr, i18n.T("cliUnknownGameHint"))
 	return "", 2, false
 }
 

--- a/cmd/trumpcards/main.go
+++ b/cmd/trumpcards/main.go
@@ -558,9 +558,13 @@ func run() int {
 		if suggestion := cuiutil.SuggestCommand(arg, suggestionCandidates(commands), 2); suggestion != "" {
 			fmt.Fprintf(os.Stderr, "  %s\n", i18n.Tf("didYouMean", "name", suggestion))
 		}
-		fmt.Fprintln(os.Stderr)
-		flag.Usage()
-		return 1
+		// A one-line recovery hint instead of re-dumping the full help (which
+		// buries the error). Note flag.Usage is a no-op here (SetOutput was
+		// pointed at io.Discard above), so the old flag.Usage() call rendered
+		// nothing but a stray blank line. Exit 2 (usage error) to match the
+		// `--start <unknown>` path (resolveStartGame) and the EXIT CODES table.
+		fmt.Fprintln(os.Stderr, i18n.T("cliUnknownGameHint"))
+		return 2
 	}
 
 	// No argument: start interactive multi-game mode (defaults to blackjack).
@@ -1262,7 +1266,7 @@ ENVIRONMENT VARIABLES:
 EXIT CODES:
    0  Success (normal exit, EOF, or 'exit' command)
    1  General error (e.g., web server failed to start, interactive input read error)
-   2  Usage error (invalid flags, unknown category, missing required argument)
+   2  Usage error (invalid flags, unknown game/command, unknown category, missing required argument)
   10  'update --check': a newer version is available (non-error signal for scripts)
   75  'update': user declined the confirmation prompt
  130  Terminated by SIGINT (Ctrl+C; POSIX 128 + 2)

--- a/cmd/trumpcards/main_test.go
+++ b/cmd/trumpcards/main_test.go
@@ -438,6 +438,57 @@ func TestRunUnsupportedLangFlagFallsBackAndWarns(t *testing.T) {
 	}
 }
 
+// TestRunUnknownGameExitsUsageError verifies issue #4305: an unknown top-level
+// game name exits 2 (usage error) — matching the `--start <unknown>` path — and
+// prints a Did-you-mean suggestion plus a one-line recovery hint on stderr,
+// instead of the old exit-1-with-dead-flag.Usage()-blank-line behavior.
+func TestRunUnknownGameExitsUsageError(t *testing.T) {
+	origArgs := os.Args
+	origCmdLine := flag.CommandLine
+	origStdout := os.Stdout
+	origStderr := os.Stderr
+	defer func() {
+		os.Args = origArgs
+		flag.CommandLine = origCmdLine
+		os.Stdout = origStdout
+		os.Stderr = origStderr
+		i18n.SetLang("ja")
+	}()
+
+	flag.CommandLine = flag.NewFlagSet("trumpcards", flag.ExitOnError)
+	os.Args = []string{"trumpcards", "blackjak"} // typo for blackjack
+
+	rOut, wOut, _ := os.Pipe()
+	rErr, wErr, _ := os.Pipe()
+	os.Stdout = wOut
+	os.Stderr = wErr
+
+	exitCh := make(chan int, 1)
+	go func() { exitCh <- run() }()
+	exit := <-exitCh
+
+	_ = wOut.Close()
+	_ = wErr.Close()
+	var outBuf, errBuf bytes.Buffer
+	_, _ = outBuf.ReadFrom(rOut)
+	_, _ = errBuf.ReadFrom(rErr)
+
+	if exit != 2 {
+		t.Errorf("exit = %d, want 2 (usage error); stderr=%q", exit, errBuf.String())
+	}
+	if !strings.Contains(errBuf.String(), "blackjack") {
+		t.Errorf("expected Did-you-mean to mention blackjack; stderr=%q", errBuf.String())
+	}
+	// The recovery hint must point at `games` and `--help`.
+	if !strings.Contains(errBuf.String(), "games") || !strings.Contains(errBuf.String(), "--help") {
+		t.Errorf("expected recovery hint mentioning 'games' and '--help'; stderr=%q", errBuf.String())
+	}
+	// Unknown game is an error path: nothing goes to stdout.
+	if outBuf.Len() != 0 {
+		t.Errorf("expected no stdout on unknown game; got %q", outBuf.String())
+	}
+}
+
 // TestRunGlobalQuietFlagSuppressesWarnings verifies issue #1553: the global
 // --quiet/-q flag is OR-combined with TRUMPCARDS_QUIET, so users can suppress
 // the locale-fallback warning without exporting an env var first. Both the

--- a/cmd/trumpcards/main_test.go
+++ b/cmd/trumpcards/main_test.go
@@ -1921,6 +1921,10 @@ func TestResolveStartGame_UnknownEmitsDidYouMean(t *testing.T) {
 	if !strings.Contains(stderr.String(), "blackjack") {
 		t.Errorf("expected Did-you-mean to mention blackjack; stderr=%q", stderr.String())
 	}
+	// The --start path prints the same recovery hint as the positional path.
+	if !strings.Contains(stderr.String(), "games") || !strings.Contains(stderr.String(), "--help") {
+		t.Errorf("expected recovery hint mentioning 'games' and '--help'; stderr=%q", stderr.String())
+	}
 }
 
 // TestBuildHelpTextDocumentsStartFlag verifies the --start flag is advertised

--- a/internal/i18n/locales/en/common.json
+++ b/internal/i18n/locales/en/common.json
@@ -35,6 +35,7 @@
   "inputReadError": "Error reading input: {{error}}",
   "cliUnknownGame": "Error: unknown game \"{{name}}\"",
   "didYouMean": "Did you mean \"{{name}}\"?",
+  "cliUnknownGameHint": "Run 'trumpcards games' for the full list, or 'trumpcards --help' for help.",
   "cliUnsupportedLang": "Warning: unsupported language \"{{lang}}\", defaulting to ja (pass --quiet/-q or set TRUMPCARDS_QUIET=1 to silence)",
   "emptyInputHint": "Type 'help' for available commands.",
   "cliStartupBanner": "trumpcards {{version}} - Interactive Mode",

--- a/internal/i18n/locales/ja/common.json
+++ b/internal/i18n/locales/ja/common.json
@@ -35,6 +35,7 @@
   "inputReadError": "入力の読み取り中にエラーが発生しました: {{error}}",
   "cliUnknownGame": "エラー: 不明なゲーム「{{name}}」",
   "didYouMean": "もしかして「{{name}}」ですか？",
+  "cliUnknownGameHint": "ゲーム一覧は 'trumpcards games'、ヘルプは 'trumpcards --help' で確認できます。",
   "cliUnsupportedLang": "警告: サポートされていない言語「{{lang}}」です。ja をデフォルトとして使用します (--quiet/-q または TRUMPCARDS_QUIET=1 で抑止可能)",
   "emptyInputHint": "'help' でコマンド一覧を表示します。",
   "cliStartupBanner": "trumpcards {{version}} - インタラクティブモード",


### PR DESCRIPTION
## Summary

Two issues in the unknown-game (unknown top-level command) error path in `cmd/trumpcards/main.go`:

1. **Inconsistent exit code** — `trumpcards blackjak` exited **1**, but the identical "unknown game" error from `trumpcards --start blackjak` exited **2** (usage error). The help EXIT CODES table defines 2 as "Usage error", so a mistyped command belongs there. Scripts branching on exit code couldn't rely on the documented table.
2. **Dead `flag.Usage()`** — after printing the error, the handler called `flag.Usage()`, but `run()` sets `flag.CommandLine.SetOutput(io.Discard)`, so the package-level usage rendered nothing and left only a stray blank line — the intended guidance never appeared.

## Change

- Return **2** from the unknown-game handler to match `--start <unknown>` (`resolveStartGame`) and the EXIT CODES table.
- Drop the dead `flag.Usage()` + blank line.
- Print a one-line recovery hint (new i18n key `cliUnknownGameHint`, ja + en) pointing at `trumpcards games` and `trumpcards --help`, so far-off typos with no Did-you-mean suggestion still have a way forward.
- Update the top-level EXIT CODES wording to list "unknown game/command" under 2.

Verified with a built binary in both locales:
```
$ trumpcards blackjak; echo $?
Error: unknown game "blackjak"
  Did you mean "blackjack"?
Run 'trumpcards games' for the full list, or 'trumpcards --help' for help.
2
```

## Compatibility

The 1→2 change is a behavior change for scripts that branched specifically on exit 1 for this path; both are non-zero and the EXIT CODES table already declared 2 as the usage-error code, so real-world impact is minimal. Noted here rather than requiring a CHANGELOG entry.

## Test plan

- [x] `go test -tags test ./cmd/trumpcards/` — added `TestRunUnknownGameExitsUsageError` (exit 2, suggestion + hint on stderr, no stdout); existing `TestRunHelpCommandUnknownGame` (the `help` subcommand, documented exit 1) unchanged
- [x] `golangci-lint run ./cmd/trumpcards/` — 0 issues
- [x] JSON locale files valid
- [ ] CI green

Closes #4305