### PR TITLE
fix(cli): stop subcommand flag errors dumping full help to stdout

### DIFF
--- a/cmd/trumpcards/main.go
+++ b/cmd/trumpcards/main.go
@@ -890,7 +890,12 @@ func parseSubFlagsTo(name string, args []string, setup func(*flag.FlagSet), stdo
 			}
 		}
 	}
-	fs.Usage = printHelp
+	// Suppress the FlagSet's internal Usage callback: flag.Parse invokes it on
+	// *any* parse error, which would dump the full help to stdout before our
+	// localized error reaches stderr (and would double-print it on -h/--help,
+	// where the ErrHelp branch below already calls printHelp). Mirrors the
+	// top-level flag.CommandLine.Usage = func(){} in run(). See issue #4307.
+	fs.Usage = func() {}
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			printHelp()

--- a/cmd/trumpcards/main_test.go
+++ b/cmd/trumpcards/main_test.go
@@ -489,6 +489,56 @@ func TestRunUnknownGameExitsUsageError(t *testing.T) {
 	}
 }
 
+// TestParseSubFlagsToNoHelpDumpOnFlagError verifies issue #4307: an unknown
+// subcommand flag must not dump the full help text to stdout before the
+// localized error goes to stderr. The FlagSet's Usage callback fires inside
+// fs.Parse on a parse error, so it must be a no-op (help is printed explicitly
+// only on the flag.ErrHelp path).
+func TestParseSubFlagsToNoHelpDumpOnFlagError(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	fs, code, ok := parseSubFlagsTo("version", []string{"--bogus"}, func(fs *flag.FlagSet) {
+		var short bool
+		fs.BoolVar(&short, "short", false, "")
+	}, &stdout, &stderr)
+
+	if ok || fs != nil {
+		t.Fatalf("expected (nil, code, false) on flag error; got ok=%v fs=%v", ok, fs)
+	}
+	if code != 2 {
+		t.Errorf("exit = %d, want 2 (usage error)", code)
+	}
+	if stdout.Len() != 0 {
+		t.Errorf("expected NO help dump on stdout for a flag error; got %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "help version") {
+		t.Errorf("stderr should carry the cliTryHelp hint; got %q", stderr.String())
+	}
+}
+
+// TestParseSubFlagsToPrintsHelpOnceOnHelpFlag verifies that `-h` prints the
+// subcommand help to stdout exactly once (not twice, as it did when Usage
+// duplicated the explicit ErrHelp-branch print). See issue #4307.
+func TestParseSubFlagsToPrintsHelpOnceOnHelpFlag(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	fs, code, ok := parseSubFlagsTo("version", []string{"-h"}, func(fs *flag.FlagSet) {
+		var short bool
+		fs.BoolVar(&short, "short", false, "")
+	}, &stdout, &stderr)
+
+	if ok || fs != nil {
+		t.Fatalf("expected (nil, 0, false) on -h; got ok=%v fs=%v", ok, fs)
+	}
+	if code != 0 {
+		t.Errorf("exit = %d, want 0 for -h", code)
+	}
+	if n := strings.Count(stdout.String(), "USAGE:"); n != 1 {
+		t.Errorf("expected help printed exactly once on stdout; USAGE: appeared %d times in %q", n, stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("expected no stderr on -h; got %q", stderr.String())
+	}
+}
+
 // TestRunGlobalQuietFlagSuppressesWarnings verifies issue #1553: the global
 // --quiet/-q flag is OR-combined with TRUMPCARDS_QUIET, so users can suppress
 // the locale-fallback warning without exporting an env var first. Both the


### PR DESCRIPTION
## Summary

`parseSubFlagsTo` set `fs.Usage = printHelp`. Go's `flag.Parse` invokes the FlagSet's `Usage` callback on **any** parse error, so:

- An unknown subcommand flag (e.g. `trumpcards version --bogus`) dumped the **entire help text to stdout** before the localized error reached stderr — burying the actual error and polluting stdout for scripts.
- `-h`/`--help` printed the help **twice** (once via `Usage`, once via the explicit `flag.ErrHelp` branch).

## Change

Set `fs.Usage = func(){}` (mirroring the top-level `flag.CommandLine.Usage = func(){}` in `run()`). The `flag.ErrHelp` branch still calls `printHelp()`, so `-h` prints help exactly once; flag errors now emit only the localized error + `help <cmd>` hint on stderr, nothing on stdout.

Verified with a built binary:
```
$ trumpcards version --bogus 1>/dev/null     # stdout empty
Error: trumpcards version: flag provided but not defined: -bogus
Run 'trumpcards help version' for usage.
$ trumpcards version -h | grep -c USAGE:     # 1
```

## Test plan

- [x] `go test -tags test ./cmd/trumpcards/` — added `TestParseSubFlagsToNoHelpDumpOnFlagError` (stdout empty, exit 2, hint on stderr) and `TestParseSubFlagsToPrintsHelpOnceOnHelpFlag` (`USAGE:` appears exactly once). Both fail before the fix.
- [x] `golangci-lint run ./cmd/trumpcards/` — 0 issues
- [ ] CI green

Closes #4307