### PR TITLE
feat(cli): group 'games' long output by category with dynamic column width

### DIFF
--- a/cmd/trumpcards/main.go
+++ b/cmd/trumpcards/main.go
@@ -1349,16 +1349,21 @@ func detectBootstrapLang(args []string, langEnv string) string {
 // games.Category matches; the caller is expected to have validated category
 // via validCategory before invoking. See issue #1535.
 func printGames(short, aliases bool, category string, w io.Writer) {
+	if short {
+		printGamesShort(aliases, category, w)
+		return
+	}
+	printGamesLong(category, w)
+}
+
+// printGamesShort prints one game name per line (and, with aliases=true, each
+// alias on its own line), flat and unadorned so scripts can consume it. Honors
+// the --category filter.
+func printGamesShort(aliases bool, category string, w io.Writer) {
 	var reverseAliases map[string][]string
-	if !short || aliases {
+	if aliases {
 		reverseAliases = buildReverseAliases()
 	}
-
-	var descs map[string]string
-	if !short {
-		descs = ui.GameDescriptions()
-	}
-
 	// Only build the category index when a filter is active — otherwise the
 	// allocation is wasted because the gating predicate below is a no-op.
 	var categoryByName map[string]string
@@ -1369,15 +1374,50 @@ func printGames(short, aliases bool, category string, w io.Writer) {
 		if category != "" && categoryByName[name] != category {
 			continue
 		}
-		if short {
-			_, _ = fmt.Fprintln(w, name)
-			if aliases {
-				for _, alias := range reverseAliases[name] {
-					_, _ = fmt.Fprintln(w, alias)
-				}
+		_, _ = fmt.Fprintln(w, name)
+		if aliases {
+			for _, alias := range reverseAliases[name] {
+				_, _ = fmt.Fprintln(w, alias)
 			}
-		} else {
-			line := fmt.Sprintf("  %-16s %s", name, descs[name])
+		}
+	}
+}
+
+// printGamesLong prints the human-facing game list grouped by Cloudflare Worker
+// category, with an uppercase "CATEGORY (N):" heading before each group. The
+// name column is sized to the longest displayed name so long names (e.g.
+// ultimatetexasholdem, 19 chars) no longer push the description column out of
+// alignment on their row. Honors the --category filter (then only the matching
+// group prints). See issue #4311.
+func printGamesLong(category string, w io.Writer) {
+	reverseAliases := buildReverseAliases()
+	descs := ui.GameDescriptions()
+	categoryByName := gameCategoryByName()
+
+	// Bucket names by category, preserving GameNames() order within each group,
+	// and track the widest displayed name for a single shared column width
+	// (keeps the description column aligned across every group).
+	namesByCategory := make(map[string][]string)
+	width := 0
+	for _, name := range ui.GameNames() {
+		cat := categoryByName[name]
+		if category != "" && cat != category {
+			continue
+		}
+		namesByCategory[cat] = append(namesByCategory[cat], name)
+		if len(name) > width {
+			width = len(name)
+		}
+	}
+
+	for _, cat := range games.AllCategories() {
+		names := namesByCategory[cat.String()]
+		if len(names) == 0 {
+			continue
+		}
+		_, _ = fmt.Fprintf(w, "%s (%d):\n", strings.ToUpper(cat.String()), len(names))
+		for _, name := range names {
+			line := fmt.Sprintf("  %-*s %s", width, name, descs[name])
 			if aliasList := reverseAliases[name]; len(aliasList) > 0 {
 				line += fmt.Sprintf("  [aliases: %s]", strings.Join(aliasList, ", "))
 			}

--- a/cmd/trumpcards/main_test.go
+++ b/cmd/trumpcards/main_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/infrastructure/games"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/infrastructure/ui"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/infrastructure/update"
 )
@@ -964,6 +965,62 @@ func TestPrintGamesShortModeRespectsAliasesFlag(t *testing.T) {
 	// With --aliases, alias lines must appear.
 	if !strings.Contains(with.String(), aliasSample) {
 		t.Errorf("short mode with --aliases should list alias %q; got:\n%s", aliasSample, with.String())
+	}
+}
+
+// TestPrintGamesLongGroupsByCategory verifies issue #4311: the long-form list
+// prints an uppercase "CATEGORY (N):" heading (derived from games.AllCategories,
+// the SSoT) before each group.
+func TestPrintGamesLongGroupsByCategory(t *testing.T) {
+	var buf bytes.Buffer
+	printGames(false, false, "", &buf)
+	out := buf.String()
+	for _, cat := range games.AllCategories() {
+		heading := strings.ToUpper(cat.String()) + " ("
+		if !strings.Contains(out, heading) {
+			t.Errorf("expected category heading starting %q in long output; got:\n%s", heading, out)
+		}
+	}
+}
+
+// TestPrintGamesLongDynamicWidthAlignsDescriptions verifies issue #4311: the
+// name column is sized to the longest displayed name so every description
+// starts at the same byte offset — including the row for the longest name
+// (ultimatetexasholdem), which the old fixed %-16s clipped out of alignment.
+func TestPrintGamesLongDynamicWidthAlignsDescriptions(t *testing.T) {
+	var buf bytes.Buffer
+	printGames(false, false, "", &buf)
+	descs := ui.GameDescriptions()
+
+	width := 0
+	for _, n := range ui.GameNames() {
+		if len(n) > width {
+			width = len(n)
+		}
+	}
+	descStart := 2 + width + 1 // "  " + padded name + single separating space
+
+	checked := 0
+	for _, line := range strings.Split(buf.String(), "\n") {
+		if !strings.HasPrefix(line, "  ") { // skip headings (no indent) and blanks
+			continue
+		}
+		if len(line) < descStart {
+			t.Errorf("line shorter than aligned description column %d: %q", descStart, line)
+			continue
+		}
+		name := strings.TrimSpace(line[2 : descStart-1])
+		desc := descs[name]
+		if desc == "" {
+			continue
+		}
+		if !strings.HasPrefix(line[descStart:], desc) {
+			t.Errorf("description column misaligned for %q: expected desc at offset %d; line=%q", name, descStart, line)
+		}
+		checked++
+	}
+	if checked < 10 {
+		t.Fatalf("expected to verify many game lines; only checked %d", checked)
 	}
 }
 

--- a/cmd/trumpcards/main_test.go
+++ b/cmd/trumpcards/main_test.go
@@ -968,6 +968,39 @@ func TestPrintGamesShortModeRespectsAliasesFlag(t *testing.T) {
 	}
 }
 
+// TestGameNamesAllHaveCategory guards the invariant that the category-grouped
+// printGamesLong depends on: every ui.GameNames() entry must map to a non-empty
+// games-registry category. printGamesLong iterates games.AllCategories() and
+// prints each category's bucket, so a name whose category is "" (two-registry
+// drift between ui.gameRegistry and games.registry) would land in the never-
+// printed "" bucket and silently vanish from even the unfiltered `games`
+// listing. This test makes such drift fail loudly instead. See PR #4320 review.
+func TestGameNamesAllHaveCategory(t *testing.T) {
+	byName := gameCategoryByName()
+	for _, name := range ui.GameNames() {
+		if byName[name] == "" {
+			t.Errorf("game %q has no games-registry category — it would be dropped from `games` output (registry drift)", name)
+		}
+	}
+}
+
+// TestPrintGamesLongListsEveryGame is the direct backstop for the same drift:
+// the unfiltered long listing must emit exactly one row per registered game, so
+// a silently-dropped game shrinks the count and fails here.
+func TestPrintGamesLongListsEveryGame(t *testing.T) {
+	var buf bytes.Buffer
+	printGames(false, false, "", &buf)
+	rows := 0
+	for _, line := range strings.Split(buf.String(), "\n") {
+		if strings.HasPrefix(line, "  ") { // game rows are indented; headings are not
+			rows++
+		}
+	}
+	if want := len(ui.GameNames()); rows != want {
+		t.Errorf("long listing emitted %d game rows, want %d", rows, want)
+	}
+}
+
 // TestPrintGamesLongGroupsByCategory verifies issue #4311: the long-form list
 // prints an uppercase "CATEGORY (N):" heading (derived from games.AllCategories,
 // the SSoT) before each group.


### PR DESCRIPTION
## Summary

Two problems in the long-form `trumpcards games` output:

1. **Column drift** — `printGames` used a fixed `%-16s` name column, but 3 game names exceed 16 chars (`ultimatetexasholdem` 19, `beleagueredcastle`/`beggarmyneighbour` 17), so those rows pushed their description column out of alignment.
2. **Flat 219-line dump** — no category headings or structure, making the list hard to scan (the top-level `--help` already introduced a category-grouped preview in #1694; this was inconsistent with it).

## Change

- Size the name column to the **longest displayed name** (`%-*s`) so every description aligns — including the previously-clipped `ultimatetexasholdem` row.
- Group the long output under uppercase **`CATEGORY (N):`** headings derived from `games.AllCategories()` (the SSoT). With `--category`, only the matching group prints.
- `--short` and `--json` are **unchanged** (machine-readable forms); refactored into `printGamesShort`/`printGamesLong` for clarity.

Verified with a built binary — `blackjack` and `ultimatetexasholdem` descriptions now start at the same column under a `CASINO (64):` heading.

## Compatibility

Long form has always been human-facing (descriptions + alias formatting); `--short` (one name per line) and `--json` remain the documented machine-readable outputs. Headings are un-indented and game rows keep their 2-space indent, so naive `awk 'NR...'` parsing can still skip headings.

## Test plan

- [x] `go test -tags test ./cmd/trumpcards/` — added `TestPrintGamesLongGroupsByCategory` (heading per SSoT category) and `TestPrintGamesLongDynamicWidthAlignsDescriptions` (every description at the same aligned offset, longest name included); existing filter/short/JSON tests still pass
- [x] `golangci-lint run ./cmd/trumpcards/` — 0 issues
- [ ] CI green

Closes #4311