### PR TITLE
fix(cli): derive games --category help from registry (add missing extra)

### DIFF
--- a/cmd/trumpcards/completion.go
+++ b/cmd/trumpcards/completion.go
@@ -138,6 +138,7 @@ func writeInstallHint(w io.Writer, shell string) {
 func writeBashCompletion(w io.Writer) error {
 	cmds := strings.Join(completionSubcommands(), " ")
 	games := strings.Join(completionGameTargets(), " ")
+	cats := strings.Join(categoryDisplayNames(), " ")
 	// `commands` (every game + alias + subcommand) and `games` (game targets
 	// only, used by --start and `help <target>`) are declared once at the
 	// top of the function so each case reuses them, avoiding the previous
@@ -178,7 +179,7 @@ func writeBashCompletion(w io.Writer) error {
             return
             ;;
         --category)
-            COMPREPLY=( $(compgen -W "casino classic solo" -- "$cur") )
+            COMPREPLY=( $(compgen -W "%[3]s" -- "$cur") )
             return
             ;;
         games|--short|--aliases|--json)
@@ -203,7 +204,7 @@ func writeBashCompletion(w io.Writer) error {
     COMPREPLY=( $(compgen -W "$commands" -- "$cur") )
 }
 complete -F _trumpcards trumpcards
-`, cmds, games)
+`, cmds, games, cats)
 	_, err := fmt.Fprint(w, script)
 	return err
 }
@@ -217,6 +218,7 @@ func writeZshCompletion(w io.Writer) error {
 		fmt.Fprintf(&sb, "        '%s:%s'\n", e.name, desc)
 	}
 	games := strings.Join(completionGameTargets(), " ")
+	cats := strings.Join(categoryDisplayNames(), " ")
 	script := fmt.Sprintf(`#compdef trumpcards
 
 _trumpcards() {
@@ -258,7 +260,7 @@ _trumpcards() {
                         '--short[Print game names only]' \
                         '--aliases[Include aliases in output]' \
                         '--json[Emit machine-readable JSON]' \
-                        '--category[Filter by category]:category:(casino classic solo)'
+                        '--category[Filter by category]:category:(%[3]s)'
                     ;;
                 web)
                     _arguments \
@@ -280,7 +282,7 @@ _trumpcards() {
 }
 
 _trumpcards "$@"
-`, sb.String(), games)
+`, sb.String(), games, cats)
 	_, err := fmt.Fprint(w, script)
 	return err
 }
@@ -294,6 +296,7 @@ func writeFishCompletion(w io.Writer) error {
 		fmt.Fprintf(&sb, "complete -c trumpcards -n __fish_use_subcommand -a %s -d '%s'\n", e.name, desc)
 	}
 	games := strings.Join(completionGameTargets(), " ")
+	cats := strings.Join(categoryDisplayNames(), " ")
 	script := fmt.Sprintf(`# Fish completion for trumpcards
 complete -c trumpcards -f
 
@@ -321,7 +324,7 @@ complete -c trumpcards -n '__fish_seen_subcommand_from update' -l dry-run -d 'Al
 complete -c trumpcards -n '__fish_seen_subcommand_from games' -l short -d 'Print game names only'
 complete -c trumpcards -n '__fish_seen_subcommand_from games' -l aliases -d 'Include aliases in output'
 complete -c trumpcards -n '__fish_seen_subcommand_from games' -l json -d 'Emit machine-readable JSON'
-complete -c trumpcards -n '__fish_seen_subcommand_from games' -l category -x -a 'casino classic solo' -d 'Filter by category'
+complete -c trumpcards -n '__fish_seen_subcommand_from games' -l category -x -a '%[3]s' -d 'Filter by category'
 
 # web subcommand
 complete -c trumpcards -n '__fish_seen_subcommand_from web' -l port -s p -d 'Port number' -x
@@ -334,7 +337,7 @@ complete -c trumpcards -n '__fish_seen_subcommand_from version' -l short -d 'Pri
 
 # help subcommand (game or subcommand argument)
 complete -c trumpcards -n '__fish_seen_subcommand_from help' -a '%[2]s completion games help update version web'
-`, sb.String(), games)
+`, sb.String(), games, cats)
 	_, err := fmt.Fprint(w, script)
 	return err
 }

--- a/cmd/trumpcards/completion_test.go
+++ b/cmd/trumpcards/completion_test.go
@@ -33,6 +33,10 @@ func TestWriteBashCompletion(t *testing.T) {
 	assert.Contains(t, script, "--open", "bash completion missing web --open flag")
 	assert.Contains(t, script, "--check", "bash completion missing update --check flag")
 	assert.Contains(t, script, "--dry-run", "bash completion missing update --dry-run flag")
+	// Issue #4308: --category value completion must list every registered
+	// category (including the `extra` bucket the old hardcoded list omitted).
+	assert.Contains(t, script, `compgen -W "`+strings.Join(categoryDisplayNames(), " ")+`"`,
+		"bash --category completion must list all registry categories")
 }
 
 func TestWriteZshCompletion(t *testing.T) {
@@ -53,6 +57,9 @@ func TestWriteZshCompletion(t *testing.T) {
 	assert.Contains(t, script, "--open", "zsh completion missing web --open flag")
 	assert.Contains(t, script, "--check", "zsh completion missing update --check flag")
 	assert.Contains(t, script, "--dry-run", "zsh completion missing update --dry-run flag")
+	// Issue #4308: --category value completion must list every registered category.
+	assert.Contains(t, script, `:category:(`+strings.Join(categoryDisplayNames(), " ")+`)`,
+		"zsh --category completion must list all registry categories")
 }
 
 func TestWriteFishCompletion(t *testing.T) {
@@ -74,6 +81,9 @@ func TestWriteFishCompletion(t *testing.T) {
 	assert.Contains(t, script, "-l open", "fish completion missing web --open flag")
 	assert.Contains(t, script, "-l check", "fish completion missing update --check flag")
 	assert.Contains(t, script, "-l dry-run", "fish completion missing update --dry-run flag")
+	// Issue #4308: --category value completion must list every registered category.
+	assert.Contains(t, script, `-l category -x -a '`+strings.Join(categoryDisplayNames(), " ")+`'`,
+		"fish --category completion must list all registry categories")
 }
 
 // TestCompletionGameTargets_ExcludesSubcommands guards the contract that

--- a/cmd/trumpcards/main.go
+++ b/cmd/trumpcards/main.go
@@ -182,6 +182,42 @@ func validCategory(s string) bool {
 	return validCategoryNames[s]
 }
 
+// categoryDisplayNames returns the canonical category names in display order
+// (casino, classic, solo, extra), sourced from games.AllCategories() so the
+// help/usage text listing the `--category` values cannot drift from the
+// registry when a category is added. See issue #4308.
+func categoryDisplayNames() []string {
+	cats := games.AllCategories()
+	names := make([]string, len(cats))
+	for i, c := range cats {
+		names[i] = c.String()
+	}
+	return names
+}
+
+// categoryFilterPipe is the accepted `--category` values joined by "|"
+// (e.g. "casino|classic|solo|extra"), for compact usage strings.
+var categoryFilterPipe = strings.Join(categoryDisplayNames(), "|")
+
+// categoryFilterProse is the same list as an English clause with an Oxford
+// "or" (e.g. "casino, classic, solo, or extra"), for prose descriptions.
+var categoryFilterProse = joinOr(categoryDisplayNames())
+
+// joinOr renders items as an English list with an Oxford "or": one item as-is,
+// two joined by " or ", three+ comma-separated with a trailing ", or ".
+func joinOr(items []string) string {
+	switch len(items) {
+	case 0:
+		return ""
+	case 1:
+		return items[0]
+	case 2:
+		return items[0] + " or " + items[1]
+	default:
+		return strings.Join(items[:len(items)-1], ", ") + ", or " + items[len(items)-1]
+	}
+}
+
 // flagSetVisited reports whether any of the named flags was explicitly set
 // on fs. This lets the caller distinguish "user did not pass --port" from
 // "user passed --port 0" without needing a sentinel value in the integer
@@ -327,7 +363,7 @@ func run() int {
 			f.BoolVar(&short, "short", false, "Print game names only")
 			f.BoolVar(&aliases, "aliases", false, "With --short, also print each alias on its own line (long output always includes aliases inline)")
 			f.BoolVar(&asJSON, "json", false, "Emit machine-readable JSON (array of {name, category, description, aliases})")
-			f.StringVar(&category, "category", "", "Filter by category: casino|classic|solo")
+			f.StringVar(&category, "category", "", "Filter by category: "+categoryFilterPipe)
 			f.BoolVar(&quietSink, "quiet", quiet, "Accepted for consistency with the global flag; the global -q already applied")
 			f.BoolVar(&quietSink, "q", quiet, "Accepted for consistency with the global flag; the global -q already applied (shorthand)")
 		})
@@ -713,7 +749,7 @@ var builtinSubcommandHelp = map[string][]string{
 	},
 	"games": {
 		"USAGE:",
-		"  trumpcards games [--short] [--aliases] [--json] [--category casino|classic|solo]",
+		"  trumpcards games [--short] [--aliases] [--json] [--category " + categoryFilterPipe + "]",
 		"",
 		"FLAGS:",
 		"      --short              Print game names only (for scripting)",
@@ -726,7 +762,7 @@ var builtinSubcommandHelp = map[string][]string{
 		"                           effect in JSON mode (the schema is fixed) and emit a",
 		"                           one-line warning to stderr if used together.",
 		"      --category CAT       Restrict output to one Cloudflare Worker category:",
-		"                           casino, classic, or solo. Combinable with --short / --json.",
+		"                           " + categoryFilterProse + ". Combinable with --short / --json.",
 		"                           Invalid value exits 2.",
 		"",
 		"EXIT CODES:",
@@ -1199,7 +1235,7 @@ GAMES:
 		}
 		fmt.Fprintf(&sb, "  %-8s (%2d)  %s%s\n", cat.String(), len(entries), strings.Join(preview, ", "), more)
 	}
-	sb.WriteString(`
+	fmt.Fprintf(&sb, `
 COMMANDS:
   games        List all available games (--short for names only; with --short, --aliases adds alias lines)
   help [game]  Show this help, or a specific game's help text
@@ -1248,7 +1284,7 @@ EXAMPLES:
   trumpcards games --short       List game names only (for scripting)
   trumpcards games --short --aliases  List game names including aliases
   trumpcards games --json        Machine-readable list (name, category, description, aliases)
-  trumpcards games --category solo  Filter by Cloudflare Worker category (casino|classic|solo)
+  trumpcards games --category solo  Filter by Cloudflare Worker category (%s)
   trumpcards update              Self-update to the latest version
   trumpcards update --yes        Update without confirmation prompt
   trumpcards update --check      Report whether an update is available (exit 10 if yes)
@@ -1282,7 +1318,7 @@ EXIT CODES:
  143  Terminated by SIGTERM (POSIX 128 + 15)
 
   See 'trumpcards help update' for update-specific exit codes (3, 4, 5, 6).
-`)
+`, categoryFilterPipe)
 	return sb.String()
 }
 

--- a/cmd/trumpcards/main_test.go
+++ b/cmd/trumpcards/main_test.go
@@ -1057,6 +1057,54 @@ func TestPrintGamesLongDynamicWidthAlignsDescriptions(t *testing.T) {
 	}
 }
 
+// TestJoinOr covers the English list renderer used for the --category prose.
+func TestJoinOr(t *testing.T) {
+	cases := []struct {
+		in   []string
+		want string
+	}{
+		{nil, ""},
+		{[]string{"a"}, "a"},
+		{[]string{"a", "b"}, "a or b"},
+		{[]string{"a", "b", "c"}, "a, b, or c"},
+		{[]string{"casino", "classic", "solo", "extra"}, "casino, classic, solo, or extra"},
+	}
+	for _, tc := range cases {
+		if got := joinOr(tc.in); got != tc.want {
+			t.Errorf("joinOr(%v) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestGamesHelpListsAllCategories verifies issue #4308: the --category values
+// advertised in the games subcommand help and the top-level help are derived
+// from games.AllCategories() (the SSoT), so every registered category —
+// including the `extra` bucket the old hardcoded strings omitted — is listed.
+func TestGamesHelpListsAllCategories(t *testing.T) {
+	for _, c := range games.AllCategories() {
+		if !strings.Contains(categoryFilterPipe, c.String()) {
+			t.Errorf("categoryFilterPipe %q missing category %q", categoryFilterPipe, c.String())
+		}
+		if !strings.Contains(categoryFilterProse, c.String()) {
+			t.Errorf("categoryFilterProse %q missing category %q", categoryFilterProse, c.String())
+		}
+	}
+	if !strings.Contains(categoryFilterPipe, "extra") {
+		t.Errorf("expected 'extra' in categoryFilterPipe; got %q", categoryFilterPipe)
+	}
+
+	gamesHelp := strings.Join(builtinSubcommandHelp["games"], "\n")
+	if !strings.Contains(gamesHelp, categoryFilterPipe) {
+		t.Errorf("games help USAGE should list %q; got:\n%s", categoryFilterPipe, gamesHelp)
+	}
+	if !strings.Contains(gamesHelp, categoryFilterProse) {
+		t.Errorf("games help --category desc should list %q; got:\n%s", categoryFilterProse, gamesHelp)
+	}
+	if help := buildHelpText(); !strings.Contains(help, categoryFilterPipe) {
+		t.Errorf("top-level help should list the dynamic category list %q", categoryFilterPipe)
+	}
+}
+
 // TestValidCategory pins down the predicate used to gate `--category`. The
 // canonical strings must match games.Category.String() (casino / classic /
 // solo) — drift between the CLI list and the games-pkg enum would silently

--- a/internal/infrastructure/games/registry.go
+++ b/internal/infrastructure/games/registry.go
@@ -770,7 +770,7 @@ func ByCategory(cat Category) []Game {
 }
 
 // AllCategories returns every Category value in canonical display order
-// (casino, classic, solo). The returned slice is fresh per call so callers
+// (casino, classic, solo, extra). The returned slice is fresh per call so callers
 // cannot mutate package state. Adding a new Category value to the iota above
 // requires extending this slice — that intentional coupling is the SSoT
 // guarantee that consumers (e.g. the CLI --help summary) cannot drift out


### PR DESCRIPTION
## Summary

The `--category` filter accepts four Cloudflare Worker buckets (`casino`, `classic`, `solo`, `extra` — validated dynamically against the registry via `validCategoryNames`), but four pieces of help text hardcoded only `casino|classic|solo`, silently omitting `extra`:

- the `games` subcommand help USAGE line,
- its `--category` description prose,
- the `--category` flag's own usage string,
- the top-level `--help` example.

## Change

Add `categoryDisplayNames()` (sourced from `games.AllCategories()`, the same SSoT `buildHelpText`'s GAMES section already uses) and derive two package strings — `categoryFilterPipe` (`casino|classic|solo|extra`) and `categoryFilterProse` (`casino, classic, solo, or extra`, via a small `joinOr` helper) — then reference them in all four spots. The advertised categories can no longer drift from the registry.

Verified with a built binary:
```
$ trumpcards help games | grep category
  trumpcards games [--short] [--aliases] [--json] [--category casino|classic|solo|extra]
      --category CAT ... casino, classic, solo, or extra. ...
$ trumpcards --help | grep 'Filter by Cloudflare'
  trumpcards games --category solo  Filter by Cloudflare Worker category (casino|classic|solo|extra)
```

## Test plan

- [x] `go test -tags test ./cmd/trumpcards/` — added `TestGamesHelpListsAllCategories` (every `games.AllCategories()` value, incl. `extra`, appears in the games help + top-level help) and `TestJoinOr` (full branch coverage of the list renderer)
- [x] `golangci-lint run ./cmd/trumpcards/` — 0 issues
- [ ] CI green

Closes #4308