### PR TITLE
fix(cli): accept trailing global flags after any subcommand

### DIFF
--- a/cmd/trumpcards/main.go
+++ b/cmd/trumpcards/main.go
@@ -452,13 +452,16 @@ func run() int {
 		var port int
 		var host string
 		var openBrowser bool
-		webQuiet := quiet // inherit TRUMPCARDS_QUIET env var (and trailing -q) as default
+		// webQuiet inherits TRUMPCARDS_QUIET and any trailing -q/--quiet: the
+		// dispatch loop already folded a trailing -q into `quiet` (and stripped
+		// it from subArgs) via applyTrailingGlobalFlags, so web needs no -q flag
+		// of its own — it just reads the resolved value. The web help text still
+		// documents -q (builtinSubcommandHelp["web"]).
+		webQuiet := quiet
 		fs, code, ok := parseSubFlags("web", subArgs, func(f *flag.FlagSet) {
 			f.IntVar(&port, "port", 0, "Port number for the web server (default: 8080; 0 for OS-assigned ephemeral)")
 			f.IntVar(&port, "p", 0, "Port number for the web server (shorthand)")
 			f.StringVar(&host, "host", "", "Bind address for the web server (default: 127.0.0.1; use 0.0.0.0 to expose)")
-			f.BoolVar(&webQuiet, "quiet", webQuiet, "Suppress human-friendly startup/shutdown messages (structured slog still emitted)")
-			f.BoolVar(&webQuiet, "q", webQuiet, "Suppress human-friendly startup/shutdown messages (shorthand)")
 			f.BoolVar(&openBrowser, "open", false, "Open the resolved URL in the default browser after the server is ready (silently skipped when stderr is not a TTY)")
 			f.BoolVar(&openBrowser, "o", false, "Open the resolved URL in the default browser (shorthand)")
 		})

--- a/cmd/trumpcards/main.go
+++ b/cmd/trumpcards/main.go
@@ -347,25 +347,22 @@ func run() int {
 		fmt.Fprintln(os.Stderr, i18n.Tf("cliUnsupportedLang", "lang", langFlagWarn))
 		fmt.Fprintln(os.Stderr, i18n.T("cliSupportedLangs"))
 	}
+	// subArgs holds the subcommand's own arguments after the dispatch loop has
+	// stripped any trailing global flags (--lang/--color/--no-color/-q) via
+	// applyTrailingGlobalFlags. The subcommand handler closures below capture it
+	// by reference; it is assigned just before the handler runs (issue #4306).
+	var subArgs []string
+
 	// Build game commands from the registry (single source of truth).
 	commands := buildGameCommands()
 	commands["games"] = func() int {
 		var short, aliases, asJSON bool
 		var category string
-		// quietSink absorbs `-q`/`--quiet` when placed after the subcommand
-		// name so Go's FlagSet does not reject it as an unknown flag. The
-		// outer `quiet` was already resolved before subcommand dispatch
-		// and is the source of truth for behavior; this binding only
-		// exists so subcommand parsing does not exit 2 on a recognized
-		// global flag (PR #1582 review).
-		var quietSink bool
-		fs, code, ok := parseSubFlags("games", func(f *flag.FlagSet) {
+		fs, code, ok := parseSubFlags("games", subArgs, func(f *flag.FlagSet) {
 			f.BoolVar(&short, "short", false, "Print game names only")
 			f.BoolVar(&aliases, "aliases", false, "With --short, also print each alias on its own line (long output always includes aliases inline)")
 			f.BoolVar(&asJSON, "json", false, "Emit machine-readable JSON (array of {name, category, description, aliases})")
 			f.StringVar(&category, "category", "", "Filter by category: "+categoryFilterPipe)
-			f.BoolVar(&quietSink, "quiet", quiet, "Accepted for consistency with the global flag; the global -q already applied")
-			f.BoolVar(&quietSink, "q", quiet, "Accepted for consistency with the global flag; the global -q already applied (shorthand)")
 		})
 		if !ok {
 			return code
@@ -394,11 +391,8 @@ func run() int {
 	}
 	commands["completion"] = func() int {
 		var noHint bool
-		var quietSink bool // see comment on the games subcommand
-		fs, code, ok := parseSubFlags("completion", func(f *flag.FlagSet) {
+		fs, code, ok := parseSubFlags("completion", subArgs, func(f *flag.FlagSet) {
 			f.BoolVar(&noHint, "no-hint", false, "Suppress installation hint comments (also implied when stdout is not a TTY)")
-			f.BoolVar(&quietSink, "quiet", quiet, "Accepted for consistency with the global flag; the global -q already applied")
-			f.BoolVar(&quietSink, "q", quiet, "Accepted for consistency with the global flag; the global -q already applied (shorthand)")
 		})
 		if !ok {
 			return code
@@ -407,11 +401,11 @@ func run() int {
 		return runCompletion(fs.Args(), stdoutIsTTY, noHint)
 	}
 	commands["help"] = func() int {
-		return runHelpCommand(flag.Args()[1:], helpText, os.Stdout, os.Stderr)
+		return runHelpCommand(subArgs, helpText, os.Stdout, os.Stderr)
 	}
 	commands["version"] = func() int {
 		var short bool
-		_, code, ok := parseSubFlags("version", func(f *flag.FlagSet) {
+		_, code, ok := parseSubFlags("version", subArgs, func(f *flag.FlagSet) {
 			f.BoolVar(&short, "short", false, "Print version number only (machine-readable)")
 		})
 		if !ok {
@@ -426,14 +420,11 @@ func run() int {
 	}
 	commands["update"] = func() int {
 		var yes, check bool
-		var quietSink bool // see comment on the games subcommand
-		_, code, ok := parseSubFlags("update", func(f *flag.FlagSet) {
+		_, code, ok := parseSubFlags("update", subArgs, func(f *flag.FlagSet) {
 			f.BoolVar(&yes, "yes", false, "Skip confirmation prompt")
 			f.BoolVar(&yes, "y", false, "Skip confirmation prompt (shorthand)")
 			f.BoolVar(&check, "check", false, "Check for an update without installing (prints latest tag, status, current to stdout)")
 			f.BoolVar(&check, "dry-run", false, "Alias for --check")
-			f.BoolVar(&quietSink, "quiet", quiet, "Accepted for consistency with the global flag; the global -q already applied")
-			f.BoolVar(&quietSink, "q", quiet, "Accepted for consistency with the global flag; the global -q already applied (shorthand)")
 		})
 		if !ok {
 			return code
@@ -461,8 +452,8 @@ func run() int {
 		var port int
 		var host string
 		var openBrowser bool
-		webQuiet := quiet // inherit TRUMPCARDS_QUIET env var as default
-		fs, code, ok := parseSubFlags("web", func(f *flag.FlagSet) {
+		webQuiet := quiet // inherit TRUMPCARDS_QUIET env var (and trailing -q) as default
+		fs, code, ok := parseSubFlags("web", subArgs, func(f *flag.FlagSet) {
 			f.IntVar(&port, "port", 0, "Port number for the web server (default: 8080; 0 for OS-assigned ephemeral)")
 			f.IntVar(&port, "p", 0, "Port number for the web server (shorthand)")
 			f.StringVar(&host, "host", "", "Bind address for the web server (default: 127.0.0.1; use 0.0.0.0 to expose)")
@@ -565,26 +556,28 @@ func run() int {
 		arg = canonical
 	}
 	if handler, ok := commands[arg]; ok {
+		// Apply --lang / --color / --no-color / -q when they land after the
+		// command name so `trumpcards <game|subcmd> --lang en` matches the
+		// prepositional form. quiet is passed by pointer because a trailing -q
+		// must update the caller's value. See issues #1509, #4306.
+		trailing := applyTrailingGlobalFlags(flag.Args()[1:], &quiet, os.Stderr)
 		if !subFlagCommands[arg] {
-			// Apply --lang / --no-color / -q when they land after the game name
-			// so `trumpcards <game> --lang en` and `trumpcards <game> -q`
-			// match the prepositional form. Done before the help short-circuit
-			// so `<game> --lang en --help` renders help in the requested locale.
-			// quiet is passed by pointer because a trailing -q must update the
-			// caller's value (otherwise the extras warning below would still
-			// fire after the user asked for silence).
-			extras := applyTrailingGlobalFlags(flag.Args()[1:], &quiet, os.Stderr)
 			// `<game> --help` / `<game> -h`: Go's flag package stops parsing at
 			// the first non-flag argument, so these trailing flags land in Args().
 			// Intercept them and print that game's help instead of launching the
 			// game. Subcommands in subFlagCommands are handled by parseSubFlags
 			// (which catches flag.ErrHelp).
-			if hasHelpFlag(extras) {
+			if hasHelpFlag(trailing) {
 				return runHelpCommand([]string{arg}, helpText, os.Stdout, os.Stderr)
 			}
-			if len(extras) > 0 && !quiet {
-				fmt.Fprintln(os.Stderr, i18n.Tf("cliExtraArgsWarning", "args", strings.Join(extras, " ")))
+			if len(trailing) > 0 && !quiet {
+				fmt.Fprintln(os.Stderr, i18n.Tf("cliExtraArgsWarning", "args", strings.Join(trailing, " ")))
 			}
+		} else {
+			// Subcommands parse their own flags from the stripped remainder, so
+			// --lang/--color/-q now work uniformly after any subcommand (#4306),
+			// not just the -q that used to be absorbed by per-command sinks.
+			subArgs = trailing
 		}
 		return handler()
 	}
@@ -905,11 +898,12 @@ func suggestionCandidates(commands map[string]func() int) []string {
 	return out
 }
 
-// parseSubFlags creates a FlagSet, applies setup, parses subcommand args, and
+// parseSubFlags creates a FlagSet, applies setup, parses the given subcommand
+// args (already stripped of trailing global flags by the dispatch loop), and
 // warns about extra positional arguments. Returns (fs, exitCode, ok). If ok is
 // false, the caller should return exitCode immediately.
-func parseSubFlags(name string, setup func(*flag.FlagSet)) (*flag.FlagSet, int, bool) {
-	return parseSubFlagsTo(name, flag.Args()[1:], setup, os.Stdout, os.Stderr)
+func parseSubFlags(name string, args []string, setup func(*flag.FlagSet)) (*flag.FlagSet, int, bool) {
+	return parseSubFlagsTo(name, args, setup, os.Stdout, os.Stderr)
 }
 
 // parseSubFlagsTo is the testable core of parseSubFlags: it parses args with a

--- a/cmd/trumpcards/main_test.go
+++ b/cmd/trumpcards/main_test.go
@@ -683,6 +683,68 @@ func TestRunGlobalQuietFlagAcceptedAfterSubcommand(t *testing.T) {
 	}
 }
 
+// TestRunGlobalFlagsAcceptedAfterSubcommand verifies issue #4306: global flags
+// (--lang / --color / --no-color) placed after a subcommand name are applied and
+// stripped before the subcommand FlagSet parses, instead of being rejected with
+// "flag provided but not defined" (exit 2). This makes trailing global flags
+// uniform across all subcommands, matching the -q handling and the mental model
+// the top-level --help advertises (`trumpcards poker --lang en`).
+func TestRunGlobalFlagsAcceptedAfterSubcommand(t *testing.T) {
+	origArgs := os.Args
+	origCmdLine := flag.CommandLine
+	origStdout := os.Stdout
+	origStderr := os.Stderr
+	defer func() {
+		os.Args = origArgs
+		flag.CommandLine = origCmdLine
+		os.Stdout = origStdout
+		os.Stderr = origStderr
+		i18n.SetLang("ja")
+	}()
+
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"games --lang en --short", []string{"trumpcards", "games", "--lang", "en", "--short"}},
+		{"games --short --lang en (trailing)", []string{"trumpcards", "games", "--short", "--lang", "en"}},
+		{"games --lang=en --short (inline)", []string{"trumpcards", "games", "--lang=en", "--short"}},
+		{"games --color never --short", []string{"trumpcards", "games", "--color", "never", "--short"}},
+		{"games --no-color --short", []string{"trumpcards", "games", "--no-color", "--short"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			flag.CommandLine = flag.NewFlagSet("trumpcards", flag.ExitOnError)
+			os.Args = tc.args
+
+			rOut, wOut, _ := os.Pipe()
+			rErr, wErr, _ := os.Pipe()
+			os.Stdout = wOut
+			os.Stderr = wErr
+
+			exitCh := make(chan int, 1)
+			go func() { exitCh <- run() }()
+			exit := <-exitCh
+
+			_ = wOut.Close()
+			_ = wErr.Close()
+			var outBuf, errBuf bytes.Buffer
+			_, _ = outBuf.ReadFrom(rOut)
+			_, _ = errBuf.ReadFrom(rErr)
+
+			if exit != 0 {
+				t.Errorf("exit = %d, want 0 (stderr=%q)", exit, errBuf.String())
+			}
+			if strings.Contains(errBuf.String(), "flag provided but not defined") {
+				t.Errorf("subcommand must accept trailing global flags; got stderr=%q", errBuf.String())
+			}
+			if outBuf.Len() == 0 {
+				t.Error("expected `games --short` stdout output")
+			}
+		})
+	}
+}
+
 // TestRunPosixLocalePlaceholderEnvSuppressesWarn verifies issue #1534: LANG
 // values that are POSIX locale placeholders ("C", "POSIX", "C.UTF-8") do NOT
 // trigger the cliLangEnvFallback warning, because they are the default in

--- a/cmd/trumpcards/main_test.go
+++ b/cmd/trumpcards/main_test.go
@@ -246,6 +246,59 @@ func TestRunWebRejectsInvalidHost(t *testing.T) {
 	}
 }
 
+// TestRunWebAcceptsTrailingQuiet verifies that `web -q` is accepted after the
+// web subcommand (issue #4306): applyTrailingGlobalFlags strips -q before the
+// web FlagSet parses, so web no longer needs its own -q sink. Uses an invalid
+// host so the run fails fast (exit 2) without binding a server — the point is
+// that the failure is the host error, NOT "flag provided but not defined: -q".
+func TestRunWebAcceptsTrailingQuiet(t *testing.T) {
+	origArgs := os.Args
+	origCmdLine := flag.CommandLine
+	origStdout := os.Stdout
+	origStderr := os.Stderr
+	origHostEnv, hostEnvWasSet := os.LookupEnv("HOST")
+	defer func() {
+		os.Args = origArgs
+		flag.CommandLine = origCmdLine
+		os.Stdout = origStdout
+		os.Stderr = origStderr
+		if hostEnvWasSet {
+			_ = os.Setenv("HOST", origHostEnv)
+		} else {
+			_ = os.Unsetenv("HOST")
+		}
+	}()
+	_ = os.Unsetenv("HOST")
+
+	flag.CommandLine = flag.NewFlagSet("trumpcards", flag.ExitOnError)
+	os.Args = []string{"trumpcards", "web", "-q", "--host", "bad host"}
+
+	rOut, wOut, _ := os.Pipe()
+	rErr, wErr, _ := os.Pipe()
+	os.Stdout = wOut
+	os.Stderr = wErr
+
+	exitCh := make(chan int, 1)
+	go func() { exitCh <- run() }()
+	exit := <-exitCh
+
+	_ = wOut.Close()
+	_ = wErr.Close()
+	var errBuf bytes.Buffer
+	_, _ = errBuf.ReadFrom(rErr)
+	_, _ = io.Copy(io.Discard, rOut)
+
+	if exit != 2 {
+		t.Errorf("exit = %d, want 2 (invalid host; stderr=%q)", exit, errBuf.String())
+	}
+	if strings.Contains(errBuf.String(), "flag provided but not defined") {
+		t.Errorf("web must accept trailing -q; got stderr=%q", errBuf.String())
+	}
+	if !strings.Contains(errBuf.String(), "bad host") {
+		t.Errorf("expected the invalid-host error (proves -q was consumed, not rejected); got %q", errBuf.String())
+	}
+}
+
 func TestFlagSetVisitedDistinguishesExplicitFromDefault(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
## Summary

Global-flag "trailing" support was uneven across command kinds:

| Invocation | Before |
|-----------|--------|
| `trumpcards blackjack --lang en` | ✅ works (`applyTrailingGlobalFlags`) |
| `trumpcards games --lang en` | ❌ `flag provided but not defined: -lang` (exit 2) |
| `trumpcards games -q` | ✅ works (per-command `quietSink` added in PR #1582) |

Only `-q` had been hand-wired into each subcommand's FlagSet; `--lang`/`--color`/`--no-color` had no equivalent, so users who learned "global flags work after the command name" (the top-level `--help` even advertises `trumpcards poker --lang en`) hit a usage error on `games --lang en`.

## Change

Instead of extending the per-command sink approach (flag × subcommand combinatorial growth), route **every** subcommand's args through the existing `applyTrailingGlobalFlags` in the dispatch loop, then hand the stripped remainder to the subcommand FlagSet:

- `parseSubFlags` now takes the pre-cleaned `args` explicitly instead of reading `flag.Args()[1:]`.
- The dispatch loop calls `applyTrailingGlobalFlags` for both game and subcommand paths, assigning the remainder to a captured `subArgs` for subcommand handlers.
- The redundant `-q`/`--quiet` sink bindings in `games`/`completion`/`update` are deleted (`applyTrailingGlobalFlags` already applies `-q` through `&quiet`). `web`'s `-q`/`--quiet` stay as documented web flags; `webQuiet` still resolves correctly from its default.

`applyTrailingGlobalFlags` already handles every syntax (`=value`, separated value, `--` terminator) and is well-tested, so no new parsing logic was needed.

## Compatibility

Purely additive: inputs that previously errored now work; all existing successful invocations are unchanged. `trumpcards games -q` and the game-name trailing-flag paths keep their behavior (existing tests still pass).

## Test plan

- [x] `go test -tags test ./cmd/trumpcards/` — added `TestRunGlobalFlagsAcceptedAfterSubcommand` (--lang/--color/--no-color, inline + separated + trailing; all exit 0, no "not defined"); existing `TestRunGlobalQuietFlagAcceptedAfterSubcommand` still green
- [x] `golangci-lint run ./cmd/trumpcards/` — 0 issues
- [x] Manual: `games --lang en` lists games; `web --quiet` suppresses the human banner
- [ ] CI green

Closes #4306