### PR TITLE
fix(frontend): enforce reduced-motion with a universal CSS block

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -185,6 +185,7 @@ Visual size of a checkbox or radio dot may stay at ~16-20px so the element still
   | long | 400-700ms | Shake, complex multi-card animations |
 - **Existing animations to keep:** flipIn (card reveal), shake (error feedback), pulse-once (attention), sweat-drop (CPU thinking), memory-card flip
 - **New animations to add:** Subtle fade-in for panels on mount, micro scale(1.02) on button hover
+- **Reduced motion (SSoT):** `prefers-reduced-motion: reduce` is enforced by a single universal block in [`frontend/src/index.css`](frontend/src/index.css) that near-zeroes (`0.01ms`) every animation and transition — it covers arbitrary `animate-[…]` utilities and any future animation automatically. Components must **not** add `motion-safe:` / `useReducedMotion` merely to disable a CSS animation (redundant); keep `useReducedMotion` only for JS that branches on motion (e.g. skipping an animation-completion wait). `0.01ms` (not `animation: none`) is used so `animationend`/`transitionend` handlers still fire.
 
 ## Design Risks (deliberate departures)
 1. **Fraunces serif for headings** — No card game site uses a serif. Immediately signals "crafted, different."

--- a/frontend/scripts/check-design-tokens.mjs
+++ b/frontend/scripts/check-design-tokens.mjs
@@ -69,4 +69,20 @@ if (violations.length > 0) {
   process.exit(1);
 }
 
+// Reduced-motion SSoT guard (issue #4315): prefers-reduced-motion must be
+// enforced by a single universal block, not a class-name allowlist that
+// silently misses arbitrary animate-[…] utilities and future animations.
+const indexCss = await readFile(join(SRC_DIR, 'index.css'), 'utf8');
+const rmIdx = indexCss.indexOf('@media (prefers-reduced-motion: reduce)');
+const rmBlock = rmIdx === -1 ? '' : indexCss.slice(rmIdx, rmIdx + 400);
+if (!rmBlock.includes('*,') || !rmBlock.includes('animation-duration: 0.01ms')) {
+  console.error(
+    '\nreduced-motion: index.css must enforce prefers-reduced-motion with a universal\n' +
+      '(`*, *::before, *::after`) block that near-zeroes animation/transition durations,\n' +
+      'not a per-class allowlist. See DESIGN.md Motion section and issue #4315.',
+  );
+  process.exit(1);
+}
+
 console.log(`design-tokens: OK (${files.length} source files scanned, test files skipped).`);
+console.log('reduced-motion: OK (index.css uses the universal prefers-reduced-motion block).');

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -557,18 +557,21 @@ input:not([type]):focus-visible {
   animation: card-deal-in 0.15s ease-out both;
 }
 
-/* Respect reduced motion preferences */
+/* Respect reduced motion preferences.
+ * Universal enforcement (issue #4315): rather than an allowlist of animation
+ * class names — which silently missed arbitrary `animate-[…]` utilities and
+ * every future animation — near-zero every animation/transition here. This is
+ * the single source of truth for motion suppression; components no longer need
+ * `motion-safe:` / useReducedMotion just to disable CSS animation. Using
+ * 0.01ms (not `animation: none`) keeps `animationend`/`transitionend` handlers
+ * firing, so completion logic (card-flip, deal-in) still resolves. */
 @media (prefers-reduced-motion: reduce) {
-  .animate-pulse,
-  .animate-pulse-once,
-  .animate-shake,
-  .animate-flipIn,
-  .animate-sweat-drop,
-  .animate-eye-dart,
-  .animate-card-deal-in {
-    animation: none;
-  }
-  .memory-card-inner {
-    transition: none;
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
   }
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -571,7 +571,9 @@ input:not([type]):focus-visible {
   *::after {
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
+    animation-delay: 0s !important;
     transition-duration: 0.01ms !important;
+    transition-delay: 0s !important;
     scroll-behavior: auto !important;
   }
 }


### PR DESCRIPTION
## Summary

`prefers-reduced-motion: reduce` was enforced three ways, with a gap: the `index.css` block used a **class-name allowlist** (`animate-pulse`, `animate-shake`, …). Arbitrary `animate-[…]` utilities and every future animation slipped through — `MetaAiToast`'s `animate-[slideDown…]` was the one animation that still played for users who set reduced-motion (grep-verified as the only unguarded `animate-[…]`). The real problem is structural: every new `animate-[…]` reintroduces the same silent failure.

## Change

Replace the allowlist with a **universal block**:

```css
@media (prefers-reduced-motion: reduce) {
  *, *::before, *::after {
    animation-duration: 0.01ms !important;
    animation-iteration-count: 1 !important;
    transition-duration: 0.01ms !important;
    scroll-behavior: auto !important;
  }
}
```

- Covers arbitrary `animate-[…]` and any future animation automatically — the single source of truth for motion suppression.
- Uses `0.01ms` (not `animation: none`) so `animationend`/`transitionend` handlers still fire (card-flip / deal-in completion logic keeps resolving).
- Components no longer need `motion-safe:` / `useReducedMotion` merely to disable a CSS animation; `useReducedMotion` stays only for JS that branches on motion. (Per-component cleanup of now-redundant `motion-safe:` is left as a gradual follow-up per the issue.)

## Guard & docs

- Added a **reduced-motion check to `check-design-tokens.mjs`** (part of `bun run check`, CI-gated) so the block can't regress to an allowlist. A jsdom/happy-dom vitest can't cover this — the tailwind-vite plugin stubs `.css` imports to empty — so a node-based check in the existing DESIGN.md-enforcement script is the right net.
- Documented the SSoT in the DESIGN.md Motion section.

## Pendulum check

Zero impact on users **without** reduced-motion set (change is inside the media query). Users with it set get a fully static experience instead of "one animation still moves".

## Test plan

- [x] `bun run check` — biome + design-tokens + new `reduced-motion: OK` guard pass
- [x] `bun run build` — tsc + vite build clean
- [ ] CI green

Closes #4315