### PR TITLE
refactor(frontend): consolidate transient toasts onto a shared primitive

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -185,6 +185,7 @@ Visual size of a checkbox or radio dot may stay at ~16-20px so the element still
   | long | 400-700ms | Shake, complex multi-card animations |
 - **Existing animations to keep:** flipIn (card reveal), shake (error feedback), pulse-once (attention), sweat-drop (CPU thinking), memory-card flip
 - **New animations to add:** Subtle fade-in for panels on mount, micro scale(1.02) on button hover
+- **Toast / transient-notice durations (SSoT):** auto-dismiss timings for "notice me, then disappear" notifications come from `TOAST_DURATION` in [`frontend/src/styles/toastDurations.ts`](frontend/src/styles/toastDurations.ts) — `short` 2500ms, `medium` 4000ms, `long` 6000ms — not ad-hoc per-component values. Banner toasts share the [`Toast`](frontend/src/components/Toast.tsx) primitive (opaque surface, 44×44 close button) + the `useTransientToast` lifecycle hook.
 - **Reduced motion (SSoT):** `prefers-reduced-motion: reduce` is enforced by a single universal block in [`frontend/src/index.css`](frontend/src/index.css) that near-zeroes (`0.01ms`) every animation and transition — it covers arbitrary `animate-[…]` utilities and any future animation automatically. Components must **not** add `motion-safe:` / `useReducedMotion` merely to disable a CSS animation (redundant); keep `useReducedMotion` only for JS that branches on motion (e.g. skipping an animation-completion wait). `0.01ms` (not `animation: none`) is used so `animationend`/`transitionend` handlers still fire.
 
 ## Design Risks (deliberate departures)

--- a/frontend/src/components/CpuActionBubble.tsx
+++ b/frontend/src/components/CpuActionBubble.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { useReducedMotion } from '../hooks/useReducedMotion';
+import { TOAST_DURATION } from '../styles/toastDurations';
 
 interface CpuActionBubbleProps {
   /** Text shown in the bubble. Pass an empty string or undefined to hide. */
@@ -10,7 +11,7 @@ interface CpuActionBubbleProps {
    * identical — e.g. CPU A asks for 5, CPU B asks for 5.
    */
   triggerKey: string | number | undefined;
-  /** Milliseconds before auto-dismissing. Defaults to 2500. */
+  /** Milliseconds before auto-dismissing. Defaults to the short toast duration. */
   durationMs?: number;
   /** Extra Tailwind classes for positioning. */
   className?: string;
@@ -24,7 +25,12 @@ interface CpuActionBubbleProps {
  *
  * Honors `prefers-reduced-motion`: animation is suppressed when set.
  */
-export function CpuActionBubble({ message, triggerKey, durationMs = 2500, className = '' }: CpuActionBubbleProps) {
+export function CpuActionBubble({
+  message,
+  triggerKey,
+  durationMs = TOAST_DURATION.short,
+  className = '',
+}: CpuActionBubbleProps) {
   const [visible, setVisible] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const reduced = useReducedMotion();
@@ -62,7 +68,7 @@ export function CpuActionBubble({ message, triggerKey, durationMs = 2500, classN
       aria-live="polite"
       aria-atomic="true"
       data-testid="cpu-action-bubble"
-      className={`pointer-events-none ${animation}inline-block rounded-full bg-ds-accent/90 px-3 py-1 text-white text-xs font-bold shadow-lg ${className}`}
+      className={`pointer-events-none ${animation}inline-block rounded-full bg-ds-accent px-3 py-1 text-ds-surface text-xs font-bold shadow-lg ${className}`}
     >
       {message}
     </div>

--- a/frontend/src/components/CpuActionToast.test.tsx
+++ b/frontend/src/components/CpuActionToast.test.tsx
@@ -8,16 +8,10 @@ vi.mock('react-i18next', async () => ({
   useTranslation: () => ({ t: mockT }),
 }));
 
-const mockReduced = vi.fn(() => false);
-vi.mock('../hooks/useReducedMotion', () => ({
-  useReducedMotion: () => mockReduced(),
-}));
-
 describe('CpuActionToast', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     mockT.mockClear();
-    mockReduced.mockReturnValue(false);
   });
 
   afterEach(() => {
@@ -41,13 +35,13 @@ describe('CpuActionToast', () => {
     expect(mockT).toHaveBeenCalledWith('player.player', { idx: 1 });
   });
 
-  it('auto-dismisses after 5 seconds', () => {
+  it('auto-dismisses after the long duration (6s)', () => {
     const actions = [{ playerIdx: 1, action: 2, amount: 0 }];
     render(<CpuActionToast actions={actions} />);
     expect(screen.getByRole('status')).toBeInTheDocument();
 
     act(() => {
-      vi.advanceTimersByTime(4999);
+      vi.advanceTimersByTime(5999);
     });
     expect(screen.getByRole('status')).toBeInTheDocument();
 
@@ -72,13 +66,13 @@ describe('CpuActionToast', () => {
     ];
     rerender(<CpuActionToast actions={actions2} />);
 
-    // 4 more seconds (7s total) — still visible because timer reset
+    // 5s more (8s total) — still visible because the 6s timer reset on the update
     act(() => {
-      vi.advanceTimersByTime(4000);
+      vi.advanceTimersByTime(5000);
     });
     expect(screen.getByRole('status')).toBeInTheDocument();
 
-    // Past the 5s window since last update
+    // Past the 6s window since the last update
     act(() => {
       vi.advanceTimersByTime(1001);
     });
@@ -104,6 +98,14 @@ describe('CpuActionToast', () => {
     expect(screen.queryByRole('status')).toBeNull();
   });
 
+  it('has a 44x44px close button (WCAG 2.5.5)', () => {
+    const actions = [{ playerIdx: 1, action: 2, amount: 0 }];
+    render(<CpuActionToast actions={actions} />);
+    const btn = screen.getByRole('button', { name: 'button.dismiss' });
+    expect(btn.className).toContain('min-h-[44px]');
+    expect(btn.className).toContain('min-w-[44px]');
+  });
+
   it('dismisses when Escape is pressed', () => {
     const actions = [{ playerIdx: 1, action: 2, amount: 0 }];
     render(<CpuActionToast actions={actions} />);
@@ -113,11 +115,12 @@ describe('CpuActionToast', () => {
     expect(screen.queryByRole('status')).toBeNull();
   });
 
-  it('omits the slide-down animation when prefers-reduced-motion is set', () => {
-    mockReduced.mockReturnValue(true);
+  it('uses an opaque surface background (DESIGN.md Opacity rule)', () => {
     const actions = [{ playerIdx: 1, action: 2, amount: 0 }];
     render(<CpuActionToast actions={actions} />);
-    expect(screen.getByRole('status').className).not.toContain('slideDown');
+    const cls = screen.getByRole('status').className;
+    expect(cls).toContain('bg-ds-surface-elevated');
+    expect(cls).not.toContain('bg-black/');
   });
 
   it('does not dismiss on Escape while an aria-modal dialog is open', () => {
@@ -212,8 +215,7 @@ describe('CpuActionToast', () => {
     document.body.removeChild(trigger);
   });
 
-  it('applies the slide-down animation when reduced motion is off', () => {
-    mockReduced.mockReturnValue(false);
+  it('always applies the slide-down animation (reduced motion is handled by CSS)', () => {
     const actions = [{ playerIdx: 1, action: 2, amount: 0 }];
     render(<CpuActionToast actions={actions} />);
     expect(screen.getByRole('status').className).toContain('slideDown');

--- a/frontend/src/components/CpuActionToast.tsx
+++ b/frontend/src/components/CpuActionToast.tsx
@@ -1,87 +1,37 @@
-import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useReducedMotion } from '../hooks/useReducedMotion';
+import { useTransientToast } from '../hooks/useTransientToast';
 import { bettingActionName } from '../styles/gameConstants';
+import { TOAST_DURATION } from '../styles/toastDurations';
+import { Toast } from './Toast';
 
 interface CpuActionToastProps {
   actions: { playerIdx: number; action: number; amount: number }[] | undefined;
 }
 
-const DISMISS_MS = 5000;
-
 /**
- * Toast notification for CPU betting actions. Auto-dismisses after 5 seconds,
- * but can be dismissed early via the close button or the Escape key. Respects
- * the user's `prefers-reduced-motion` setting.
+ * Toast notification for CPU betting actions. Shows when new actions arrive,
+ * auto-dismisses after the long duration, and can be dismissed early via the
+ * close button or Escape. A thin wrapper over the shared {@link Toast} banner +
+ * {@link useTransientToast} lifecycle (issue #4313).
  */
 export function CpuActionToast({ actions }: CpuActionToastProps) {
   const { t } = useTranslation('common');
-  const reduced = useReducedMotion();
-  const [visible, setVisible] = useState(false);
-  const prevLenRef = useRef(0);
-  const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
-  const triggerRef = useRef<Element | null>(null);
-
   const len = actions?.length ?? 0;
-
-  useEffect(() => {
-    if (len > 0 && len !== prevLenRef.current) {
-      setVisible((prev) => {
-        if (!prev) triggerRef.current = document.activeElement;
-        return true;
-      });
-      clearTimeout(timerRef.current);
-      timerRef.current = setTimeout(() => setVisible(false), DISMISS_MS);
-    }
-    prevLenRef.current = len;
-    return () => clearTimeout(timerRef.current);
-  }, [len]);
-
-  useEffect(() => {
-    if (!visible) {
-      if (
-        document.activeElement === document.body &&
-        triggerRef.current instanceof HTMLElement &&
-        document.contains(triggerRef.current)
-      ) {
-        triggerRef.current.focus();
-      }
-      triggerRef.current = null;
-      return;
-    }
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key !== 'Escape') return;
-      if (document.querySelector('[role="dialog"][aria-modal="true"]')) return;
-      setVisible(false);
-    };
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
-  }, [visible]);
+  const { visible, dismiss } = useTransientToast(len, TOAST_DURATION.long, {
+    active: len > 0,
+    skipInitial: false,
+  });
 
   if (!visible || !actions || actions.length === 0) return null;
 
-  const animation = reduced ? '' : 'animate-[slideDown_0.3s_ease-out] ';
-
   return (
-    <div
-      role="status"
-      aria-live="polite"
-      className={`absolute top-0 left-0 right-0 z-20 mx-4 mt-1 ${animation}rounded bg-black/70 px-3 py-1.5 pr-8 text-white text-xs shadow-lg`}
-    >
+    <Toast onDismiss={dismiss}>
       {actions.map((a, i) => (
         <div key={`${i}-${a.playerIdx}-${a.action}`}>
           {t('player.player', { idx: a.playerIdx })}: {bettingActionName(a.action)}
           {a.amount > 0 && ` (${a.amount})`}
         </div>
       ))}
-      <button
-        type="button"
-        onClick={() => setVisible(false)}
-        aria-label={t('button.dismiss')}
-        className="absolute top-0 right-1 px-2 py-0.5 text-ds-text-muted hover:text-ds-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-ds-accent"
-      >
-        ×
-      </button>
-    </div>
+    </Toast>
   );
 }

--- a/frontend/src/components/MetaAiToast.test.tsx
+++ b/frontend/src/components/MetaAiToast.test.tsx
@@ -28,13 +28,13 @@ describe('MetaAiToast', () => {
     expect(screen.queryByTestId('meta-ai-toast')).not.toBeInTheDocument();
   });
 
-  it('auto-dismisses after 3000ms', () => {
+  it('auto-dismisses after the medium duration (4000ms)', () => {
     const { rerender } = render(<MetaAiToast strategyStyle="balanced" />);
     rerender(<MetaAiToast strategyStyle="defensive" />);
     expect(screen.getByTestId('meta-ai-toast')).toBeInTheDocument();
 
     act(() => {
-      vi.advanceTimersByTime(3000);
+      vi.advanceTimersByTime(4000);
     });
 
     expect(screen.queryByTestId('meta-ai-toast')).not.toBeInTheDocument();
@@ -52,15 +52,25 @@ describe('MetaAiToast', () => {
     rerender(<MetaAiToast strategyStyle="aggressive" />);
     expect(screen.getByTestId('meta-ai-toast')).toHaveTextContent('CPU戦略変更: 攻撃的');
 
-    // Should still be visible after original 3000ms since timer was reset
+    // Should still be visible after the original 4000ms since the timer reset
     act(() => {
-      vi.advanceTimersByTime(2000);
+      vi.advanceTimersByTime(3000);
     });
     expect(screen.getByTestId('meta-ai-toast')).toBeInTheDocument();
 
-    // Should dismiss after the full 3000ms from the second change
+    // Should dismiss after the full 4000ms from the second change
     act(() => {
       vi.advanceTimersByTime(1000);
+    });
+    expect(screen.queryByTestId('meta-ai-toast')).not.toBeInTheDocument();
+  });
+
+  it('can be dismissed early via the close button', () => {
+    const { rerender } = render(<MetaAiToast strategyStyle="balanced" />);
+    rerender(<MetaAiToast strategyStyle="aggressive" />);
+    expect(screen.getByTestId('meta-ai-toast')).toBeInTheDocument();
+    act(() => {
+      screen.getByRole('button').click();
     });
     expect(screen.queryByTestId('meta-ai-toast')).not.toBeInTheDocument();
   });

--- a/frontend/src/components/MetaAiToast.tsx
+++ b/frontend/src/components/MetaAiToast.tsx
@@ -1,6 +1,8 @@
-import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useTransientToast } from '../hooks/useTransientToast';
+import { TOAST_DURATION } from '../styles/toastDurations';
 import type { StrategyStyle } from '../utils/metaAiAdaptation';
+import { Toast } from './Toast';
 
 /** Props for the MetaAiToast component. */
 export interface MetaAiToastProps {
@@ -8,44 +10,24 @@ export interface MetaAiToastProps {
   strategyStyle: StrategyStyle | undefined;
 }
 
-const DISMISS_MS = 3000;
-
-/** Toast notification for CPU meta-AI strategy changes. Auto-dismisses after 3 seconds. */
+/**
+ * Toast notification for CPU meta-AI strategy changes. Shows when the strategy
+ * changes, auto-dismisses after the medium duration, and can be dismissed early
+ * via the close button or Escape. A thin wrapper over the shared {@link Toast}
+ * banner + {@link useTransientToast} lifecycle (issue #4313).
+ */
 export function MetaAiToast({ strategyStyle }: MetaAiToastProps) {
   const { t } = useTranslation('common');
-  const [visible, setVisible] = useState(false);
-  const prevRef = useRef<StrategyStyle | null>(null);
-  const timerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
-  const isFirstRender = useRef(true);
+  const { visible, dismiss } = useTransientToast(strategyStyle, TOAST_DURATION.medium, {
+    active: strategyStyle !== undefined,
+  });
 
-  useEffect(() => {
-    if (!strategyStyle) return;
-    if (isFirstRender.current) {
-      isFirstRender.current = false;
-      prevRef.current = strategyStyle;
-      return;
-    }
-    if (strategyStyle !== prevRef.current) {
-      prevRef.current = strategyStyle;
-      setVisible(true);
-      clearTimeout(timerRef.current);
-      timerRef.current = setTimeout(() => setVisible(false), DISMISS_MS);
-    }
-    return () => clearTimeout(timerRef.current);
-  }, [strategyStyle]);
-
-  if (!visible) return null;
+  if (!visible || !strategyStyle) return null;
 
   const strategyLabel = t(`metaAi.strategy.${strategyStyle}`);
-
   return (
-    <div
-      role="status"
-      aria-live="polite"
-      data-testid="meta-ai-toast"
-      className="absolute top-0 left-0 right-0 z-20 mx-4 mt-1 animate-[slideDown_0.3s_ease-out] rounded bg-black/70 px-3 py-1.5 text-white text-xs shadow-lg"
-    >
+    <Toast onDismiss={dismiss} testId="meta-ai-toast">
       {t('metaAi.strategyShift', { strategy: strategyLabel })}
-    </div>
+    </Toast>
   );
 }

--- a/frontend/src/components/Toast.test.tsx
+++ b/frontend/src/components/Toast.test.tsx
@@ -1,0 +1,48 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { Toast } from './Toast';
+
+describe('Toast', () => {
+  it('renders children in a polite status region by default', () => {
+    render(<Toast testId="t">hello</Toast>);
+    const region = screen.getByTestId('t');
+    expect(region).toHaveAttribute('role', 'status');
+    expect(region).toHaveAttribute('aria-live', 'polite');
+    expect(region).toHaveTextContent('hello');
+  });
+
+  it('supports an assertive live region', () => {
+    render(
+      <Toast testId="t" live="assertive">
+        urgent
+      </Toast>,
+    );
+    expect(screen.getByTestId('t')).toHaveAttribute('aria-live', 'assertive');
+  });
+
+  it('uses an opaque surface background, not an alpha-suffixed color', () => {
+    render(<Toast testId="t">x</Toast>);
+    const cls = screen.getByTestId('t').className;
+    expect(cls).toContain('bg-ds-surface-elevated');
+    expect(cls).not.toContain('bg-black/');
+  });
+
+  it('omits the close button when onDismiss is not provided', () => {
+    render(<Toast testId="t">x</Toast>);
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('renders a 44x44px close button that calls onDismiss', () => {
+    const onDismiss = vi.fn();
+    render(
+      <Toast testId="t" onDismiss={onDismiss}>
+        x
+      </Toast>,
+    );
+    const btn = screen.getByRole('button');
+    expect(btn.className).toContain('min-h-[44px]');
+    expect(btn.className).toContain('min-w-[44px]');
+    fireEvent.click(btn);
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/Toast.test.tsx
+++ b/frontend/src/components/Toast.test.tsx
@@ -45,4 +45,13 @@ describe('Toast', () => {
     fireEvent.click(btn);
     expect(onDismiss).toHaveBeenCalledTimes(1);
   });
+
+  it('keeps the banner at least 44px tall so the close button never overflows', () => {
+    render(
+      <Toast testId="t" onDismiss={() => {}}>
+        x
+      </Toast>,
+    );
+    expect(screen.getByTestId('t').className).toContain('min-h-[44px]');
+  });
 });

--- a/frontend/src/components/Toast.tsx
+++ b/frontend/src/components/Toast.tsx
@@ -33,7 +33,7 @@ export function Toast({ children, onDismiss, live = 'polite', testId }: ToastPro
       role="status"
       aria-live={live}
       data-testid={testId}
-      className={`absolute top-0 left-0 right-0 z-20 mx-4 mt-1 animate-[slideDown_0.3s_ease-out] rounded bg-ds-surface-elevated px-3 py-1.5 text-ds-text-primary text-xs shadow-lg${
+      className={`absolute top-0 left-0 right-0 z-20 mx-4 mt-1 flex min-h-[44px] flex-col justify-center animate-[slideDown_0.3s_ease-out] rounded bg-ds-surface-elevated px-3 py-1.5 text-ds-text-primary text-xs shadow-lg${
         onDismiss ? ' pr-11' : ''
       }`}
     >

--- a/frontend/src/components/Toast.tsx
+++ b/frontend/src/components/Toast.tsx
@@ -1,0 +1,53 @@
+import type { ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
+
+/** Props for the shared {@link Toast} banner primitive. */
+export interface ToastProps {
+  /** Toast body. */
+  children: ReactNode;
+  /**
+   * When provided, renders a 44×44px close button that calls this handler.
+   * Omit for toasts that are display-only (auto-dismiss with no manual close).
+   */
+  onDismiss?: () => void;
+  /** aria-live politeness for the announcement region. Defaults to 'polite'. */
+  live?: 'polite' | 'assertive';
+  /** Forwarded to the root element for tests. */
+  testId?: string;
+}
+
+/**
+ * Shared top-of-board notification banner (issue #4313). Standardizes the
+ * position, an **opaque** surface background (DESIGN.md Opacity rule — no
+ * alpha-suffixed color whose contrast would collapse over the game felt), the
+ * `role="status"` live region, and a WCAG-2.5.5 44×44px close button. Entrance
+ * animation is handled globally: `animate-[slideDown…]` is near-zeroed by the
+ * universal `prefers-reduced-motion` block in index.css, so no per-toast guard
+ * is needed. Lifecycle (auto-dismiss, Escape, focus restore) lives in
+ * `useTransientToast`; this component is presentational.
+ */
+export function Toast({ children, onDismiss, live = 'polite', testId }: ToastProps) {
+  const { t } = useTranslation('common');
+  return (
+    <div
+      role="status"
+      aria-live={live}
+      data-testid={testId}
+      className={`absolute top-0 left-0 right-0 z-20 mx-4 mt-1 animate-[slideDown_0.3s_ease-out] rounded bg-ds-surface-elevated px-3 py-1.5 text-ds-text-primary text-xs shadow-lg${
+        onDismiss ? ' pr-11' : ''
+      }`}
+    >
+      {children}
+      {onDismiss && (
+        <button
+          type="button"
+          onClick={onDismiss}
+          aria-label={t('button.dismiss')}
+          className="absolute top-0 right-0 inline-flex min-h-[44px] min-w-[44px] items-center justify-center text-ds-text-muted hover:text-ds-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-ds-accent"
+        >
+          ×
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/hooks/useTransientToast.test.ts
+++ b/frontend/src/hooks/useTransientToast.test.ts
@@ -1,0 +1,70 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useTransientToast } from './useTransientToast';
+
+describe('useTransientToast', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('does not show on the initial render when skipInitial (default)', () => {
+    const { result } = renderHook(({ trigger }) => useTransientToast(trigger, 1000), {
+      initialProps: { trigger: 'a' },
+    });
+    expect(result.current.visible).toBe(false);
+  });
+
+  it('shows on a subsequent trigger change and auto-dismisses', () => {
+    const { result, rerender } = renderHook(({ trigger }) => useTransientToast(trigger, 1000), {
+      initialProps: { trigger: 'a' },
+    });
+    act(() => rerender({ trigger: 'b' }));
+    expect(result.current.visible).toBe(true);
+    act(() => vi.advanceTimersByTime(1000));
+    expect(result.current.visible).toBe(false);
+  });
+
+  it('shows on the initial render when skipInitial is false', () => {
+    const { result } = renderHook(() => useTransientToast(2, 1000, { skipInitial: false, active: true }));
+    expect(result.current.visible).toBe(true);
+  });
+
+  it('does not show when active is false, even on a trigger change', () => {
+    const { result, rerender } = renderHook(({ trigger, active }) => useTransientToast(trigger, 1000, { active }), {
+      initialProps: { trigger: 0, active: false },
+    });
+    act(() => rerender({ trigger: 2, active: false }));
+    expect(result.current.visible).toBe(false);
+  });
+
+  it('dismiss() hides an already-visible toast', () => {
+    const { result, rerender } = renderHook(({ trigger }) => useTransientToast(trigger, 1000), {
+      initialProps: { trigger: 'a' },
+    });
+    act(() => rerender({ trigger: 'b' }));
+    expect(result.current.visible).toBe(true);
+    act(() => result.current.dismiss());
+    expect(result.current.visible).toBe(false);
+  });
+
+  it('closes on Escape unless a modal dialog is open', () => {
+    const { result, rerender } = renderHook(({ trigger }) => useTransientToast(trigger, 1000), {
+      initialProps: { trigger: 'a' },
+    });
+    // Modal open: Escape is ignored.
+    const dialog = document.createElement('div');
+    dialog.setAttribute('role', 'dialog');
+    dialog.setAttribute('aria-modal', 'true');
+    document.body.appendChild(dialog);
+    act(() => rerender({ trigger: 'b' }));
+    act(() => window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' })));
+    expect(result.current.visible).toBe(true);
+    document.body.removeChild(dialog);
+    // No modal: Escape closes it.
+    act(() => window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' })));
+    expect(result.current.visible).toBe(false);
+  });
+});

--- a/frontend/src/hooks/useTransientToast.ts
+++ b/frontend/src/hooks/useTransientToast.ts
@@ -1,0 +1,93 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/** Options for {@link useTransientToast}. */
+export interface UseTransientToastOptions {
+  /**
+   * When false, a `trigger` change does not show the toast (but still updates
+   * the tracked previous value). Lets callers gate on state like "there is at
+   * least one action to show". Defaults to true.
+   */
+  active?: boolean;
+  /**
+   * When true (default), the initial render never shows the toast — only later
+   * `trigger` changes do. Set false to also treat the very first render as a
+   * showable event (e.g. a component mounted with content already present).
+   */
+  skipInitial?: boolean;
+}
+
+/** Return value of {@link useTransientToast}. */
+export interface TransientToast {
+  /** Whether the toast should currently render. */
+  visible: boolean;
+  /** Dismiss the toast immediately (close button / programmatic). */
+  dismiss: () => void;
+}
+
+/**
+ * Drives the shared lifecycle of a transient banner toast: show whenever
+ * `trigger` changes to a new value (skipping the initial render), auto-dismiss
+ * after `durationMs`, allow early dismissal via Escape (unless a modal dialog
+ * is open) or the returned `dismiss`, and restore focus to the element that had
+ * it when the toast appeared. Extracted from the previously divergent
+ * CpuActionToast / MetaAiToast implementations (issue #4313).
+ */
+export function useTransientToast(
+  trigger: unknown,
+  durationMs: number,
+  { active = true, skipInitial = true }: UseTransientToastOptions = {},
+): TransientToast {
+  const [visible, setVisible] = useState(false);
+  const prevRef = useRef(trigger);
+  const isFirst = useRef(true);
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const triggerElRef = useRef<Element | null>(null);
+
+  useEffect(() => {
+    const firstRun = isFirst.current;
+    isFirst.current = false;
+    if (firstRun && skipInitial) {
+      prevRef.current = trigger;
+      return;
+    }
+    if (trigger !== prevRef.current || (firstRun && !skipInitial)) {
+      prevRef.current = trigger;
+      if (active) {
+        setVisible((prev) => {
+          if (!prev) triggerElRef.current = document.activeElement;
+          return true;
+        });
+        clearTimeout(timerRef.current);
+        timerRef.current = setTimeout(() => setVisible(false), durationMs);
+      }
+    }
+    return () => clearTimeout(timerRef.current);
+  }, [trigger, durationMs, active, skipInitial]);
+
+  useEffect(() => {
+    if (!visible) {
+      // Restore focus to the trigger element only if focus fell back to <body>
+      // (i.e. nothing else claimed it) and the element is still in the DOM.
+      if (
+        document.activeElement === document.body &&
+        triggerElRef.current instanceof HTMLElement &&
+        document.contains(triggerElRef.current)
+      ) {
+        triggerElRef.current.focus();
+      }
+      triggerElRef.current = null;
+      return;
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return;
+      // Defer to an open modal dialog's own Escape handling.
+      if (document.querySelector('[role="dialog"][aria-modal="true"]')) return;
+      setVisible(false);
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [visible]);
+
+  const dismiss = useCallback(() => setVisible(false), []);
+  return { visible, dismiss };
+}

--- a/frontend/src/styles/toastDurations.ts
+++ b/frontend/src/styles/toastDurations.ts
@@ -14,6 +14,3 @@ export const TOAST_DURATION = {
   medium: 4000,
   long: 6000,
 } as const;
-
-/** Valid duration token names. */
-export type ToastDuration = keyof typeof TOAST_DURATION;

--- a/frontend/src/styles/toastDurations.ts
+++ b/frontend/src/styles/toastDurations.ts
@@ -1,0 +1,19 @@
+/**
+ * Auto-dismiss durations (ms) for transient toast / bubble notifications.
+ *
+ * Single source of truth so every "notice me, then disappear" notification
+ * uses one of three consistent timings instead of ad-hoc per-component values
+ * (issue #4313). Mirrored in the DESIGN.md Motion section.
+ *
+ * - `short`  — a glanceable one-liner (CPU action bubble).
+ * - `medium` — a short status change worth a beat longer (meta-AI strategy).
+ * - `long`   — multi-line content that takes longer to read (betting actions).
+ */
+export const TOAST_DURATION = {
+  short: 2500,
+  medium: 4000,
+  long: 6000,
+} as const;
+
+/** Valid duration token names. */
+export type ToastDuration = keyof typeof TOAST_DURATION;


### PR DESCRIPTION
## Summary

Five transient-notice components had diverged (issue #4313):

- **CpuActionToast** (5000ms; dismiss + Escape + focus restore) and **MetaAiToast** (3000ms; **no** dismiss, unconditional animation) were near-identical banners with inconsistent behavior.
- **CpuActionBubble** (2500ms) painted CPU actions on `bg-ds-accent/90 text-white` — a **DESIGN.md Opacity-rule violation** (effective contrast collapses over the game felt).
- **CpuActionToast**'s close button was `px-2 py-0.5` (~24px), under the **44px tap-target** rule.

## Change

- **`TOAST_DURATION`** (`short` 2500 / `medium` 4000 / `long` 6000) — single source of truth for auto-dismiss timings.
- **`useTransientToast`** hook — the shared lifecycle (show-on-trigger, auto-dismiss, Escape-to-close deferring to open modals, focus restore), with a `skipInitial` option for the two components' differing mount semantics.
- **`<Toast>`** presentational banner — opaque `bg-ds-surface-elevated` (Opacity rule), `role=status` live region, and a 44×44 close button.
- **CpuActionToast** + **MetaAiToast** are now thin wrappers; **MetaAiToast gains a close button + Escape** and a consistent timing.
- **CpuActionBubble**: opacity violation fixed (`bg-ds-accent text-ds-surface`, opaque, ~7.8:1) and duration sourced from the token.
- DESIGN.md documents the toast-duration SSoT.

Reduced-motion no longer needs per-toast JS guards — #4315 made `index.css` enforce it universally, so the `animate-[slideDown…]` class can live in the shared `<Toast>` unconditionally.

## Scope note

`PartnerRevealFlash` (full-screen role-reveal overlay) and `RoundScoreAnnouncement` (**pure sr-only** live region, no timer, no visual) are genuinely different shapes — folding them into the banner primitive would make it a god-component, so they stay separate. The duration SSoT is available to them if a future change wants it.

## Test plan

- [x] `bun run test` on the affected files — CpuActionToast (durations 6s, opaque bg, 44px button, focus/Escape all retained), MetaAiToast (4s + new dismiss), CpuActionBubble, new Toast.test.tsx, useTransientToast all green
- [x] Removed the now-obsolete "omits animation under reduced-motion" JS tests (CSS handles it since #4315); assert the animation class is always present instead
- [x] `bun run check` (biome + design-tokens + reduced-motion) and `bun run build` (tsc + vite) clean
- [ ] CI green

Closes #4313