### PR TITLE
feat(frontend): contain page crashes with a route-scoped ErrorBoundary

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import { HashRouter, Navigate, Route, Routes } from 'react-router-dom';
 import { DesktopSidebar } from './components/DesktopSidebar';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { NavBar } from './components/NavBar';
+import { RouteErrorBoundary } from './components/RouteErrorBoundary';
 import { SkipNavLink } from './components/SkipNavLink';
 import { SkeletonBar } from './components/skeleton/SkeletonBar';
 import { gameRoutes } from './constants/gameRoutes';
@@ -54,31 +55,36 @@ export default function App() {
           <div className="flex flex-col flex-1 min-w-0">
             <NavBar />
             <main id="main-content" tabIndex={-1} className="flex-1 flex flex-col min-h-0">
-              <Routes>
-                {gameRoutes.map(({ path }) => {
-                  const LazyPage = lazyPages.get(path);
-                  if (!LazyPage) return null;
-                  return (
-                    <Route
-                      key={path}
-                      path={path}
-                      element={
-                        <Suspense fallback={<RouteSuspenseFallback />}>
-                          <LazyPage />
-                        </Suspense>
-                      }
-                    />
-                  );
-                })}
-                {/* AI Game Concierge — survey + recommendation result. */}
-                <Route path="/discover" element={<DiscoverPage />} />
-                <Route path="/discover/result" element={<DiscoverResultPage />} />
-                {/* BlackJack lives at "/", but external links may use "/blackjack". */}
-                <Route path="/blackjack" element={<Navigate to="/" replace />} />
-                {/* Unknown hash routes (e.g., "#/notagame") render the 404
+              {/* Route-scoped boundary: a crash in one page is contained here so
+                  the nav/sidebar stay usable; it resets on navigation. The outer
+                  ErrorBoundary remains the last resort for chrome crashes (#4314). */}
+              <RouteErrorBoundary>
+                <Routes>
+                  {gameRoutes.map(({ path }) => {
+                    const LazyPage = lazyPages.get(path);
+                    if (!LazyPage) return null;
+                    return (
+                      <Route
+                        key={path}
+                        path={path}
+                        element={
+                          <Suspense fallback={<RouteSuspenseFallback />}>
+                            <LazyPage />
+                          </Suspense>
+                        }
+                      />
+                    );
+                  })}
+                  {/* AI Game Concierge — survey + recommendation result. */}
+                  <Route path="/discover" element={<DiscoverPage />} />
+                  <Route path="/discover/result" element={<DiscoverResultPage />} />
+                  {/* BlackJack lives at "/", but external links may use "/blackjack". */}
+                  <Route path="/blackjack" element={<Navigate to="/" replace />} />
+                  {/* Unknown hash routes (e.g., "#/notagame") render the 404
                     surface instead of silently redirecting home — #1902. */}
-                <Route path="*" element={<NotFoundPage />} />
-              </Routes>
+                  <Route path="*" element={<NotFoundPage />} />
+                </Routes>
+              </RouteErrorBoundary>
             </main>
           </div>
         </div>

--- a/frontend/src/components/RouteErrorBoundary.test.tsx
+++ b/frontend/src/components/RouteErrorBoundary.test.tsx
@@ -1,0 +1,60 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { Link, MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { RouteErrorBoundary } from './RouteErrorBoundary';
+
+function Boom(): never {
+  throw new Error('page boom');
+}
+function OkPage() {
+  return <div>ok page</div>;
+}
+
+describe('RouteErrorBoundary', () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    // React logs caught render errors; silence for a clean test output.
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
+
+  it('contains a routed page crash in the boundary fallback', () => {
+    render(
+      <MemoryRouter initialEntries={['/boom']}>
+        <RouteErrorBoundary>
+          <Routes>
+            <Route path="/boom" element={<Boom />} />
+            <Route path="/ok" element={<OkPage />} />
+          </Routes>
+        </RouteErrorBoundary>
+      </MemoryRouter>,
+    );
+    // The ErrorBoundary fallback (role="alert") is shown instead of crashing up.
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+
+  it('resets when navigating to a different route (pathname key remounts it)', () => {
+    render(
+      <MemoryRouter initialEntries={['/boom']}>
+        {/* Nav lives outside the boundary so it survives the crashed page. */}
+        <Link to="/ok">go ok</Link>
+        <RouteErrorBoundary>
+          <Routes>
+            <Route path="/boom" element={<Boom />} />
+            <Route path="/ok" element={<OkPage />} />
+          </Routes>
+        </RouteErrorBoundary>
+      </MemoryRouter>,
+    );
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('go ok'));
+
+    // Navigation changed the pathname key → boundary remounts fresh → the new
+    // (non-crashing) page renders and the fallback is gone.
+    expect(screen.getByText('ok page')).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/RouteErrorBoundary.tsx
+++ b/frontend/src/components/RouteErrorBoundary.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from 'react';
+import { useLocation } from 'react-router-dom';
+import { ErrorBoundary } from './ErrorBoundary';
+
+/**
+ * Route-scoped error boundary. Wraps the routed page in an {@link ErrorBoundary}
+ * keyed on the current pathname, so a render crash in one game page is contained
+ * to the `<main>` content area — the surrounding navigation and sidebar stay
+ * usable — and the boundary automatically resets when the user navigates to a
+ * different route (the changed `key` remounts it). The app-level
+ * `ErrorBoundary` in App.tsx remains as the last-resort boundary for crashes in
+ * the chrome itself. See issue #4314.
+ */
+export function RouteErrorBoundary({ children }: { children: ReactNode }) {
+  const { pathname } = useLocation();
+  return <ErrorBoundary key={pathname}>{children}</ErrorBoundary>;
+}


### PR DESCRIPTION
## Summary

The app had a **single** `ErrorBoundary` (App.tsx) wrapping the `SkipNavLink` + `DesktopSidebar` + `NavBar` + `<main>` together. So a render crash in any **one** of the 219 game pages (e.g. an unguarded `undefined` in a rare game state) replaced the **entire screen** — nav included — with the fallback. The user's only recovery was a full reload; the natural "this game's acting up, let me play another" move was impossible (issue #4314).

## Change

Add **`RouteErrorBoundary`** — a thin `ErrorBoundary` wrapper keyed on `useLocation().pathname` — inside `<main>`, around `<Routes>`:

```tsx
<ErrorBoundary>            {/* last resort: chrome crashes */}
  … SkipNavLink / DesktopSidebar / NavBar …
  <main>
    <RouteErrorBoundary>   {/* new: contains page crashes, resets on nav */}
      <Routes>…</Routes>
    </RouteErrorBoundary>
  </main>
</ErrorBoundary>
```

A page crash is now contained to the content area — the nav/sidebar stay usable — and the boundary **resets automatically on navigation** (the changed `pathname` key remounts it). The outer app-level boundary remains the last resort for crashes in the chrome itself.

## Test plan

- [x] `RouteErrorBoundary.test.tsx` — a routed page that throws renders the fallback (contained, `role="alert"`), and navigating to a different route clears the fallback and renders the new page (key-reset)
- [x] `App.test.tsx` still green; `bun run check` + `bun run build` clean

Closes #4314