### PR TITLE
refactor(domain): extract collectValidIndices helper (48 games)

### DIFF
--- a/internal/domain/Belote.go
+++ b/internal/domain/Belote.go
@@ -1035,14 +1035,9 @@ func (b *Belote) GetValidPlayIndices(playerIdx int) []int {
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す
 func (b *Belote) getValidPlayIndices(playerIdx int) []int {
 	player := b.players[playerIdx]
-	var valid []int
-	for i := range player.GetCardsSize() {
-		card := player.GetCard(i)
-		if b.validatePlay(playerIdx, card) == nil {
-			valid = append(valid, i)
-		}
-	}
-	return valid
+	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
+		return b.validatePlay(playerIdx, player.GetCard(i)) == nil
+	})
 }
 
 // --- Game end + bookkeeping ---

--- a/internal/domain/BidWhist.go
+++ b/internal/domain/BidWhist.go
@@ -766,14 +766,10 @@ func (g *BidWhist) GetValidPlayIndices(playerIdx int) []int {
 
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す
 func (g *BidWhist) getValidPlayIndices(playerIdx int) []int {
-	p := g.players[playerIdx]
-	var valid []int
-	for i := 0; i < p.GetCardsSize(); i++ {
-		if g.validatePlay(playerIdx, p.GetCard(i)) == nil {
-			valid = append(valid, i)
-		}
-	}
-	return valid
+	player := g.players[playerIdx]
+	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
+		return g.validatePlay(playerIdx, player.GetCard(i)) == nil
+	})
 }
 
 // --- CPU AI ---

--- a/internal/domain/Bridge.go
+++ b/internal/domain/Bridge.go
@@ -1100,14 +1100,9 @@ func (b *Bridge) playerHasSuit(playerIdx int, suit int) bool {
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す
 func (b *Bridge) getValidPlayIndices(playerIdx int) []int {
 	player := b.players[playerIdx]
-	var valid []int
-	for i := 0; i < player.GetCardsSize(); i++ {
-		card := player.GetCard(i)
-		if b.validatePlay(playerIdx, card) == nil {
-			valid = append(valid, i)
-		}
-	}
-	return valid
+	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
+		return b.validatePlay(playerIdx, player.GetCard(i)) == nil
+	})
 }
 
 // trickWinner トリックの勝者を決定する

--- a/internal/domain/Calabresella.go
+++ b/internal/domain/Calabresella.go
@@ -663,13 +663,9 @@ func (g *Calabresella) trickWinner() int {
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す。
 func (g *Calabresella) getValidPlayIndices(playerIdx int) []int {
 	player := g.players[playerIdx]
-	var valid []int
-	for i := 0; i < player.GetCardsSize(); i++ {
-		if g.validatePlay(playerIdx, player.GetCard(i)) == nil {
-			valid = append(valid, i)
-		}
-	}
-	return valid
+	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
+		return g.validatePlay(playerIdx, player.GetCard(i)) == nil
+	})
 }
 
 // isCoalition playerIdx が連合 (非ソリスト) 側か。

--- a/internal/domain/CallBreak.go
+++ b/internal/domain/CallBreak.go
@@ -960,14 +960,9 @@ func filterAbove(player *CallBreakPlayer, validIndices []int, threshold int) []i
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す
 func (cb *CallBreak) getValidPlayIndices(playerIdx int) []int {
 	player := cb.players[playerIdx]
-	var valid []int
-	for i := 0; i < player.GetCardsSize(); i++ {
-		card := player.GetCard(i)
-		if cb.validatePlay(playerIdx, card) == nil {
-			valid = append(valid, i)
-		}
-	}
-	return valid
+	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
+		return cb.validatePlay(playerIdx, player.GetCard(i)) == nil
+	})
 }
 
 // GetValidPlayIndices プレイ可能なカードのインデックスリストを返す (Web 用)

--- a/internal/domain/CatchTen.go
+++ b/internal/domain/CatchTen.go
@@ -819,14 +819,9 @@ func (g *CatchTen) isPartnerWinning(playerIdx int) bool {
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す
 func (g *CatchTen) getValidPlayIndices(playerIdx int) []int {
 	player := g.players[playerIdx]
-	var valid []int
-	for i := 0; i < player.GetCardsSize(); i++ {
-		card := player.GetCard(i)
-		if g.validatePlay(playerIdx, card) == nil {
-			valid = append(valid, i)
-		}
-	}
-	return valid
+	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
+		return g.validatePlay(playerIdx, player.GetCard(i)) == nil
+	})
 }
 
 // catchTenJSON is the JSON wire format for CatchTen.

--- a/internal/domain/Cinch.go
+++ b/internal/domain/Cinch.go
@@ -835,14 +835,10 @@ func (g *Cinch) appendLog(playerIdx int, actionType, detail string, cards []*Car
 }
 
 func (g *Cinch) getValidPlayIndices(playerIdx int) []int {
-	p := g.players[playerIdx]
-	var valid []int
-	for i := 0; i < p.GetCardsSize(); i++ {
-		if g.validatePlay(playerIdx, p.GetCard(i)) == nil {
-			valid = append(valid, i)
-		}
-	}
-	return valid
+	player := g.players[playerIdx]
+	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
+		return g.validatePlay(playerIdx, player.GetCard(i)) == nil
+	})
 }
 
 // --- 状態アクセサ ---

--- a/internal/domain/CourtPiece.go
+++ b/internal/domain/CourtPiece.go
@@ -704,14 +704,9 @@ func (c *CourtPiece) playHintReason(playerIdx, chosenIdx int) string {
 // getValidPlayIndices プレイ可能なカードのインデックスリスト
 func (c *CourtPiece) getValidPlayIndices(playerIdx int) []int {
 	player := c.players[playerIdx]
-	var valid []int
-	for i := 0; i < player.GetCardsSize(); i++ {
-		card := player.GetCard(i)
-		if c.validatePlay(playerIdx, card) == nil {
-			valid = append(valid, i)
-		}
-	}
-	return valid
+	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
+		return c.validatePlay(playerIdx, player.GetCard(i)) == nil
+	})
 }
 
 // --- CPU AI ---

--- a/internal/domain/CrazyEights.go
+++ b/internal/domain/CrazyEights.go
@@ -714,13 +714,9 @@ func (g *CrazyEights) countSuits(playerIdx int) map[int]int {
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す
 func (g *CrazyEights) getValidPlayIndices(playerIdx int) []int {
 	player := g.players[playerIdx]
-	var valid []int
-	for i := 0; i < player.GetCardsSize(); i++ {
-		if g.isValidPlay(player.GetCard(i)) {
-			valid = append(valid, i)
-		}
-	}
-	return valid
+	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
+		return g.isValidPlay(player.GetCard(i))
+	})
 }
 
 // GetValidPlayIndices プレイ可能なカードのインデックスリストを返す (Web用)

--- a/internal/domain/Doppelkopf.go
+++ b/internal/domain/Doppelkopf.go
@@ -470,13 +470,9 @@ func (g *Doppelkopf) trickWinner() int {
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す。
 func (g *Doppelkopf) getValidPlayIndices(playerIdx int) []int {
 	player := g.players[playerIdx]
-	var valid []int
-	for i := 0; i < player.GetCardsSize(); i++ {
-		if g.validatePlay(playerIdx, player.GetCard(i)) == nil {
-			valid = append(valid, i)
-		}
-	}
-	return valid
+	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
+		return g.validatePlay(playerIdx, player.GetCard(i)) == nil
+	})
 }
 
 // --- Misc helpers ---

--- a/internal/domain/Euchre.go
+++ b/internal/domain/Euchre.go
@@ -1023,14 +1023,9 @@ func (e *Euchre) GetValidPlayIndices(playerIdx int) []int {
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す
 func (e *Euchre) getValidPlayIndices(playerIdx int) []int {
 	player := e.players[playerIdx]
-	var valid []int
-	for i := 0; i < player.GetCardsSize(); i++ {
-		card := player.GetCard(i)
-		if e.validatePlay(playerIdx, card) == nil {
-			valid = append(valid, i)
-		}
-	}
-	return valid
+	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
+		return e.validatePlay(playerIdx, player.GetCard(i)) == nil
+	})
 }
 
 // --- CPU AI ---

--- a/internal/domain/FiveHundred.go
+++ b/internal/domain/FiveHundred.go
@@ -1013,14 +1013,10 @@ func (g *FiveHundred) GetValidPlayIndices(playerIdx int) []int {
 
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す
 func (g *FiveHundred) getValidPlayIndices(playerIdx int) []int {
-	p := g.players[playerIdx]
-	var valid []int
-	for i := 0; i < p.GetCardsSize(); i++ {
-		if g.validatePlay(playerIdx, p.GetCard(i)) == nil {
-			valid = append(valid, i)
-		}
-	}
-	return valid
+	player := g.players[playerIdx]
+	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
+		return g.validatePlay(playerIdx, player.GetCard(i)) == nil
+	})
 }
 
 // --- Hint ---

--- a/internal/domain/FortyFives.go
+++ b/internal/domain/FortyFives.go
@@ -583,13 +583,9 @@ func fortyFivesPip(v int) int {
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す。
 func (g *FortyFives) getValidPlayIndices(playerIdx int) []int {
 	player := g.players[playerIdx]
-	var valid []int
-	for i := 0; i < player.GetCardsSize(); i++ {
-		if g.validatePlay(playerIdx, player.GetCard(i)) == nil {
-			valid = append(valid, i)
-		}
-	}
-	return valid
+	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
+		return g.validatePlay(playerIdx, player.GetCard(i)) == nil
+	})
 }
 
 // --- Misc helpers ---

--- a/internal/domain/GongZhu.go
+++ b/internal/domain/GongZhu.go
@@ -943,13 +943,9 @@ func (g *GongZhu) cpuDiscard(player *GongZhuPlayer, validIndices []int) int {
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す
 func (g *GongZhu) getValidPlayIndices(playerIdx int) []int {
 	player := g.players[playerIdx]
-	var valid []int
-	for i := 0; i < player.GetCardsSize(); i++ {
-		if g.validatePlay(playerIdx, player.GetCard(i)) == nil {
-			valid = append(valid, i)
-		}
-	}
-	return valid
+	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
+		return g.validatePlay(playerIdx, player.GetCard(i)) == nil
+	})
 }
 
 // gzLeadDanger リード時のカード危険度（低いほど安全）

--- a/internal/domain/Hearts.go
+++ b/internal/domain/Hearts.go
@@ -1167,14 +1167,9 @@ func (h *Hearts) cpuPlayHard(playerIdx int, validIndices []int) int {
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す
 func (h *Hearts) getValidPlayIndices(playerIdx int) []int {
 	player := h.players[playerIdx]
-	var valid []int
-	for i := 0; i < player.GetCardsSize(); i++ {
-		card := player.GetCard(i)
-		if h.validatePlay(playerIdx, card) == nil {
-			valid = append(valid, i)
-		}
-	}
-	return valid
+	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
+		return h.validatePlay(playerIdx, player.GetCard(i)) == nil
+	})
 }
 
 // playerName プレイヤー名を返す

--- a/internal/domain/Jass.go
+++ b/internal/domain/Jass.go
@@ -1043,14 +1043,9 @@ func (g *Jass) GetValidPlayIndices(playerIdx int) []int {
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す
 func (g *Jass) getValidPlayIndices(playerIdx int) []int {
 	player := g.players[playerIdx]
-	var valid []int
-	for i := range player.GetCardsSize() {
-		card := player.GetCard(i)
-		if g.validatePlay(playerIdx, card) == nil {
-			valid = append(valid, i)
-		}
-	}
-	return valid
+	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
+		return g.validatePlay(playerIdx, player.GetCard(i)) == nil
+	})
 }
 
 // --- Game end + bookkeeping ---

--- a/internal/domain/Klaverjas.go
+++ b/internal/domain/Klaverjas.go
@@ -475,13 +475,9 @@ func (g *Klaverjas) cardPoints(card *Card) int {
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す。
 func (g *Klaverjas) getValidPlayIndices(playerIdx int) []int {
 	player := g.players[playerIdx]
-	var valid []int
-	for i := 0; i < player.GetCardsSize(); i++ {
-		if g.validatePlay(playerIdx, player.GetCard(i)) == nil {
-			valid = append(valid, i)
-		}
-	}
-	return valid
+	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
+		return g.validatePlay(playerIdx, player.GetCard(i)) == nil
+	})
 }
 
 // --- Roem detection ---

--- a/internal/domain/KnockoutWhist.go
+++ b/internal/domain/KnockoutWhist.go
@@ -452,13 +452,9 @@ func knockoutCardStrength(value int) int {
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す。
 func (g *KnockoutWhist) getValidPlayIndices(playerIdx int) []int {
 	player := g.players[playerIdx]
-	var valid []int
-	for i := 0; i < player.GetCardsSize(); i++ {
-		if g.validatePlay(playerIdx, player.GetCard(i)) == nil {
-			valid = append(valid, i)
-		}
-	}
-	return valid
+	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
+		return g.validatePlay(playerIdx, player.GetCard(i)) == nil
+	})
 }
 
 // --- Misc helpers ---

--- a/internal/domain/Loo.go
+++ b/internal/domain/Loo.go
@@ -604,14 +604,10 @@ func (g *Loo) playerHasSuit(playerIdx, suit int) bool {
 
 // getValidPlayIndices はプレイ可能なカードのインデックスリストを返す。
 func (g *Loo) getValidPlayIndices(playerIdx int) []int {
-	p := g.players[playerIdx]
-	var valid []int
-	for i := 0; i < p.GetCardsSize(); i++ {
-		if g.validatePlay(playerIdx, p.GetCard(i)) == nil {
-			valid = append(valid, i)
-		}
-	}
-	return valid
+	player := g.players[playerIdx]
+	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
+		return g.validatePlay(playerIdx, player.GetCard(i)) == nil
+	})
 }
 
 // --- ヘルパー ---

--- a/internal/domain/Macau.go
+++ b/internal/domain/Macau.go
@@ -881,13 +881,9 @@ func (g *Macau) countSuits(playerIdx int) map[int]int {
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す
 func (g *Macau) getValidPlayIndices(playerIdx int) []int {
 	player := g.players[playerIdx]
-	var valid []int
-	for i := 0; i < player.GetCardsSize(); i++ {
-		if g.isValidPlay(player.GetCard(i)) {
-			valid = append(valid, i)
-		}
-	}
-	return valid
+	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
+		return g.isValidPlay(player.GetCard(i))
+	})
 }
 
 // GetValidPlayIndices プレイ可能なカードのインデックスリストを返す (Web用)

--- a/internal/domain/Manille.go
+++ b/internal/domain/Manille.go
@@ -395,13 +395,9 @@ func manilleCardPoints(card *Card) int {
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す。
 func (g *Manille) getValidPlayIndices(playerIdx int) []int {
 	player := g.players[playerIdx]
-	var valid []int
-	for i := 0; i < player.GetCardsSize(); i++ {
-		if g.validatePlay(playerIdx, player.GetCard(i)) == nil {
-			valid = append(valid, i)
-		}
-	}
-	return valid
+	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
+		return g.validatePlay(playerIdx, player.GetCard(i)) == nil
+	})
 }
 
 // --- Misc helpers ---

--- a/internal/domain/Mao.go
+++ b/internal/domain/Mao.go
@@ -1073,13 +1073,9 @@ func (g *Mao) countSuits(playerIdx int) map[int]int {
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す
 func (g *Mao) getValidPlayIndices(playerIdx int) []int {
 	player := g.players[playerIdx]
-	var valid []int
-	for i := 0; i < player.GetCardsSize(); i++ {
-		if g.isValidPlay(player.GetCard(i)) {
-			valid = append(valid, i)
-		}
-	}
-	return valid
+	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
+		return g.isValidPlay(player.GetCard(i))
+	})
 }
 
 // GetValidPlayIndices プレイ可能なカードのインデックスリストを返す (Web用)

--- a/internal/domain/Marias.go
+++ b/internal/domain/Marias.go
@@ -458,13 +458,9 @@ func mariasCardPoints(card *Card) int {
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す。
 func (g *Marias) getValidPlayIndices(playerIdx int) []int {
 	player := g.players[playerIdx]
-	var valid []int
-	for i := 0; i < player.GetCardsSize(); i++ {
-		if g.validatePlay(playerIdx, player.GetCard(i)) == nil {
-			valid = append(valid, i)
-		}
-	}
-	return valid
+	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
+		return g.validatePlay(playerIdx, player.GetCard(i)) == nil
+	})
 }
 
 // --- Misc helpers ---

--- a/internal/domain/Mighty.go
+++ b/internal/domain/Mighty.go
@@ -1465,18 +1465,14 @@ func (m *Mighty) playHintReason(chosenIdx int) string {
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す
 func (m *Mighty) getValidPlayIndices(playerIdx int) []int {
 	player := m.players[playerIdx]
-	var valid []int
-	for i := 0; i < player.GetCardsSize(); i++ {
+	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
 		card := player.GetCard(i)
 		// リード時にジョーカー単独は禁止 (PlayerPlayJokerLead 経由が必要)
 		if len(m.round.currentTrick) == 0 && card.GetDesign() == CardDesignJoker {
-			continue
+			return false
 		}
-		if m.validatePlay(playerIdx, card) == nil {
-			valid = append(valid, i)
-		}
-	}
-	return valid
+		return m.validatePlay(playerIdx, card) == nil
+	})
 }
 
 // --- CPU AI ---

--- a/internal/domain/Nap.go
+++ b/internal/domain/Nap.go
@@ -523,13 +523,9 @@ func napCardStrength(value int) int {
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す。
 func (g *Nap) getValidPlayIndices(playerIdx int) []int {
 	player := g.players[playerIdx]
-	var valid []int
-	for i := 0; i < player.GetCardsSize(); i++ {
-		if g.validatePlay(playerIdx, player.GetCard(i)) == nil {
-			valid = append(valid, i)
-		}
-	}
-	return valid
+	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
+		return g.validatePlay(playerIdx, player.GetCard(i)) == nil
+	})
 }
 
 // --- Misc helpers ---

--- a/internal/domain/Napoleon.go
+++ b/internal/domain/Napoleon.go
@@ -1106,14 +1106,9 @@ func (n *Napoleon) playHintReason(chosenIdx int) string {
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す
 func (n *Napoleon) getValidPlayIndices(playerIdx int) []int {
 	player := n.players[playerIdx]
-	var valid []int
-	for i := 0; i < player.GetCardsSize(); i++ {
-		card := player.GetCard(i)
-		if n.validatePlay(playerIdx, card) == nil {
-			valid = append(valid, i)
-		}
-	}
-	return valid
+	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
+		return n.validatePlay(playerIdx, player.GetCard(i)) == nil
+	})
 }
 
 // --- CPU AI ---

--- a/internal/domain/NinetyNine.go
+++ b/internal/domain/NinetyNine.go
@@ -723,14 +723,9 @@ func (o *NinetyNine) appendLog(playerIdx int, actionType, detail string, cards [
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す
 func (o *NinetyNine) getValidPlayIndices(playerIdx int) []int {
 	player := o.players[playerIdx]
-	var valid []int
-	for i := 0; i < player.GetCardsSize(); i++ {
-		card := player.GetCard(i)
-		if o.validatePlay(playerIdx, card) == nil {
-			valid = append(valid, i)
-		}
-	}
-	return valid
+	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
+		return o.validatePlay(playerIdx, player.GetCard(i)) == nil
+	})
 }
 
 // GetHint ヒントを取得する

--- a/internal/domain/OhHell.go
+++ b/internal/domain/OhHell.go
@@ -711,14 +711,9 @@ func (o *OhHell) appendLog(playerIdx int, actionType, detail string, cards []*Ca
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す
 func (o *OhHell) getValidPlayIndices(playerIdx int) []int {
 	player := o.players[playerIdx]
-	var valid []int
-	for i := 0; i < player.GetCardsSize(); i++ {
-		card := player.GetCard(i)
-		if o.validatePlay(playerIdx, card) == nil {
-			valid = append(valid, i)
-		}
-	}
-	return valid
+	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
+		return o.validatePlay(playerIdx, player.GetCard(i)) == nil
+	})
 }
 
 // GetHint ヒントを取得する

--- a/internal/domain/Ombre.go
+++ b/internal/domain/Ombre.go
@@ -719,13 +719,9 @@ func (g *Ombre) trickWinner() int {
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す。
 func (g *Ombre) getValidPlayIndices(playerIdx int) []int {
 	player := g.players[playerIdx]
-	var valid []int
-	for i := 0; i < player.GetCardsSize(); i++ {
-		if g.validatePlay(playerIdx, player.GetCard(i)) == nil {
-			valid = append(valid, i)
-		}
-	}
-	return valid
+	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
+		return g.validatePlay(playerIdx, player.GetCard(i)) == nil
+	})
 }
 
 // isCoalition playerIdx が連合 (非オンブル) 側か。

--- a/internal/domain/PageOne.go
+++ b/internal/domain/PageOne.go
@@ -650,13 +650,9 @@ func (g *PageOne) countSuits(playerIdx int) map[int]int {
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す
 func (g *PageOne) getValidPlayIndices(playerIdx int) []int {
 	player := g.players[playerIdx]
-	var valid []int
-	for i := 0; i < player.GetCardsSize(); i++ {
-		if g.isValidPlay(player.GetCard(i)) {
-			valid = append(valid, i)
-		}
-	}
-	return valid
+	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
+		return g.isValidPlay(player.GetCard(i))
+	})
 }
 
 // pageOneCardScore カードのスコアを計算する

--- a/internal/domain/Pitch.go
+++ b/internal/domain/Pitch.go
@@ -801,15 +801,10 @@ func (p *Pitch) appendLog(playerIdx int, actionType, detail string, cards []*Car
 }
 
 func (p *Pitch) getValidPlayIndices(playerIdx int) []int {
-	pl := p.players[playerIdx]
-	var valid []int
-	for i := 0; i < pl.GetCardsSize(); i++ {
-		card := pl.GetCard(i)
-		if p.validatePlay(playerIdx, card) == nil {
-			valid = append(valid, i)
-		}
-	}
-	return valid
+	player := p.players[playerIdx]
+	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
+		return p.validatePlay(playerIdx, player.GetCard(i)) == nil
+	})
 }
 
 // --- CPU AI ---

--- a/internal/domain/Preference.go
+++ b/internal/domain/Preference.go
@@ -546,13 +546,9 @@ func preferenceCardStrength(value int) int {
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す。
 func (g *Preference) getValidPlayIndices(playerIdx int) []int {
 	player := g.players[playerIdx]
-	var valid []int
-	for i := 0; i < player.GetCardsSize(); i++ {
-		if g.validatePlay(playerIdx, player.GetCard(i)) == nil {
-			valid = append(valid, i)
-		}
-	}
-	return valid
+	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
+		return g.validatePlay(playerIdx, player.GetCard(i)) == nil
+	})
 }
 
 // --- Misc helpers ---

--- a/internal/domain/Prsi.go
+++ b/internal/domain/Prsi.go
@@ -576,13 +576,9 @@ func (g *Prsi) countSuits(playerIdx int) map[int]int {
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す
 func (g *Prsi) getValidPlayIndices(playerIdx int) []int {
 	player := g.players[playerIdx]
-	var valid []int
-	for i := 0; i < player.GetCardsSize(); i++ {
-		if g.isValidPlay(player.GetCard(i)) {
-			valid = append(valid, i)
-		}
-	}
-	return valid
+	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
+		return g.isValidPlay(player.GetCard(i))
+	})
 }
 
 // GetValidPlayIndices プレイ可能なカードのインデックスリストを返す (Web用)

--- a/internal/domain/Rook.go
+++ b/internal/domain/Rook.go
@@ -919,14 +919,10 @@ func (g *Rook) GetValidPlayIndices(playerIdx int) []int {
 
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す
 func (g *Rook) getValidPlayIndices(playerIdx int) []int {
-	p := g.players[playerIdx]
-	var valid []int
-	for i := 0; i < p.GetCardsSize(); i++ {
-		if g.validatePlay(playerIdx, p.GetCard(i)) == nil {
-			valid = append(valid, i)
-		}
-	}
-	return valid
+	player := g.players[playerIdx]
+	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
+		return g.validatePlay(playerIdx, player.GetCard(i)) == nil
+	})
 }
 
 // --- Hint ---

--- a/internal/domain/Sheepshead.go
+++ b/internal/domain/Sheepshead.go
@@ -597,13 +597,9 @@ func (g *Sheepshead) trickWinner() int {
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す。
 func (g *Sheepshead) getValidPlayIndices(playerIdx int) []int {
 	player := g.players[playerIdx]
-	var valid []int
-	for i := 0; i < player.GetCardsSize(); i++ {
-		if g.validatePlay(playerIdx, player.GetCard(i)) == nil {
-			valid = append(valid, i)
-		}
-	}
-	return valid
+	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
+		return g.validatePlay(playerIdx, player.GetCard(i)) == nil
+	})
 }
 
 // --- Call helpers ---

--- a/internal/domain/SoloWhist.go
+++ b/internal/domain/SoloWhist.go
@@ -542,13 +542,9 @@ func soloWhistCardStrength(value int) int {
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す。
 func (g *SoloWhist) getValidPlayIndices(playerIdx int) []int {
 	player := g.players[playerIdx]
-	var valid []int
-	for i := 0; i < player.GetCardsSize(); i++ {
-		if g.validatePlay(playerIdx, player.GetCard(i)) == nil {
-			valid = append(valid, i)
-		}
-	}
-	return valid
+	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
+		return g.validatePlay(playerIdx, player.GetCard(i)) == nil
+	})
 }
 
 // --- Misc helpers ---

--- a/internal/domain/Spades.go
+++ b/internal/domain/Spades.go
@@ -1129,14 +1129,9 @@ func (s *Spades) cpuPlayHard(playerIdx int, validIndices []int) int {
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す
 func (s *Spades) getValidPlayIndices(playerIdx int) []int {
 	player := s.players[playerIdx]
-	var valid []int
-	for i := 0; i < player.GetCardsSize(); i++ {
-		card := player.GetCard(i)
-		if s.validatePlay(playerIdx, card) == nil {
-			valid = append(valid, i)
-		}
-	}
-	return valid
+	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
+		return s.validatePlay(playerIdx, player.GetCard(i)) == nil
+	})
 }
 
 // GetValidPlayIndices プレイ可能なカードのインデックスリストを返す (Web用)

--- a/internal/domain/SpoilFive.go
+++ b/internal/domain/SpoilFive.go
@@ -410,13 +410,9 @@ func spoilPlainStrength(v int) int {
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す。
 func (g *SpoilFive) getValidPlayIndices(playerIdx int) []int {
 	player := g.players[playerIdx]
-	var valid []int
-	for i := 0; i < player.GetCardsSize(); i++ {
-		if g.validatePlay(playerIdx, player.GetCard(i)) == nil {
-			valid = append(valid, i)
-		}
-	}
-	return valid
+	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
+		return g.validatePlay(playerIdx, player.GetCard(i)) == nil
+	})
 }
 
 // --- Misc helpers ---

--- a/internal/domain/Sueca.go
+++ b/internal/domain/Sueca.go
@@ -361,13 +361,9 @@ func (g *Sueca) suecaRank(card *Card) int {
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す。
 func (g *Sueca) getValidPlayIndices(playerIdx int) []int {
 	player := g.players[playerIdx]
-	var valid []int
-	for i := 0; i < player.GetCardsSize(); i++ {
-		if g.validatePlay(playerIdx, player.GetCard(i)) == nil {
-			valid = append(valid, i)
-		}
-	}
-	return valid
+	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
+		return g.validatePlay(playerIdx, player.GetCard(i)) == nil
+	})
 }
 
 // --- Card helpers ---

--- a/internal/domain/Tarneeb.go
+++ b/internal/domain/Tarneeb.go
@@ -788,14 +788,9 @@ func (t *Tarneeb) playHintReason(playerIdx, chosenIdx int) string {
 // getValidPlayIndices プレイ可能なカードのインデックスリスト
 func (t *Tarneeb) getValidPlayIndices(playerIdx int) []int {
 	player := t.players[playerIdx]
-	var valid []int
-	for i := 0; i < player.GetCardsSize(); i++ {
-		card := player.GetCard(i)
-		if t.validatePlay(playerIdx, card) == nil {
-			valid = append(valid, i)
-		}
-	}
-	return valid
+	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
+		return t.validatePlay(playerIdx, player.GetCard(i)) == nil
+	})
 }
 
 // --- CPU AI ---

--- a/internal/domain/Tressette.go
+++ b/internal/domain/Tressette.go
@@ -421,13 +421,9 @@ func (g *Tressette) trickWinner() int {
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す
 func (g *Tressette) getValidPlayIndices(playerIdx int) []int {
 	player := g.players[playerIdx]
-	var valid []int
-	for i := 0; i < player.GetCardsSize(); i++ {
-		if g.validatePlay(playerIdx, player.GetCard(i)) == nil {
-			valid = append(valid, i)
-		}
-	}
-	return valid
+	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
+		return g.validatePlay(playerIdx, player.GetCard(i)) == nil
+	})
 }
 
 // sortAllHands 全プレイヤーの手札をソートする

--- a/internal/domain/Tute.go
+++ b/internal/domain/Tute.go
@@ -427,13 +427,9 @@ func (g *Tute) tuteRank(card *Card) int {
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す。
 func (g *Tute) getValidPlayIndices(playerIdx int) []int {
 	player := g.players[playerIdx]
-	var valid []int
-	for i := 0; i < player.GetCardsSize(); i++ {
-		if g.validatePlay(playerIdx, player.GetCard(i)) == nil {
-			valid = append(valid, i)
-		}
-	}
-	return valid
+	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
+		return g.validatePlay(playerIdx, player.GetCard(i)) == nil
+	})
 }
 
 // --- Card helpers ---

--- a/internal/domain/TwentyNine.go
+++ b/internal/domain/TwentyNine.go
@@ -560,13 +560,9 @@ func twentyNineCardPoints(card *Card) int {
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す。
 func (g *TwentyNine) getValidPlayIndices(playerIdx int) []int {
 	player := g.players[playerIdx]
-	var valid []int
-	for i := 0; i < player.GetCardsSize(); i++ {
-		if g.validatePlay(playerIdx, player.GetCard(i)) == nil {
-			valid = append(valid, i)
-		}
-	}
-	return valid
+	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
+		return g.validatePlay(playerIdx, player.GetCard(i)) == nil
+	})
 }
 
 // --- Misc helpers ---

--- a/internal/domain/TwoTenJack.go
+++ b/internal/domain/TwoTenJack.go
@@ -909,14 +909,9 @@ func (t *TwoTenJack) teamOf(playerIdx int) int {
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す
 func (t *TwoTenJack) getValidPlayIndices(playerIdx int) []int {
 	player := t.players[playerIdx]
-	var valid []int
-	for i := 0; i < player.GetCardsSize(); i++ {
-		card := player.GetCard(i)
-		if t.validatePlay(playerIdx, card) == nil {
-			valid = append(valid, i)
-		}
-	}
-	return valid
+	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
+		return t.validatePlay(playerIdx, player.GetCard(i)) == nil
+	})
 }
 
 // GetValidPlayIndices プレイ可能なカードのインデックスリストを返す (Web用)

--- a/internal/domain/Tysiac.go
+++ b/internal/domain/Tysiac.go
@@ -801,13 +801,9 @@ func tysiacSuitName(suit int) string {
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す。
 func (g *Tysiac) getValidPlayIndices(playerIdx int) []int {
 	player := g.players[playerIdx]
-	var valid []int
-	for i := 0; i < player.GetCardsSize(); i++ {
-		if g.validatePlay(playerIdx, player.GetCard(i)) == nil {
-			valid = append(valid, i)
-		}
-	}
-	return valid
+	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
+		return g.validatePlay(playerIdx, player.GetCard(i)) == nil
+	})
 }
 
 // --- Misc helpers ---

--- a/internal/domain/Watten.go
+++ b/internal/domain/Watten.go
@@ -760,13 +760,9 @@ func (g *Watten) getValidPlayIndices(playerIdx int) []int {
 		return nil
 	}
 	player := g.players[playerIdx]
-	var valid []int
-	for i := range player.GetCardsSize() {
-		if g.validatePlay(playerIdx, player.GetCard(i)) == nil {
-			valid = append(valid, i)
-		}
-	}
-	return valid
+	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
+		return g.validatePlay(playerIdx, player.GetCard(i)) == nil
+	})
 }
 
 // --- Sorting / bookkeeping ---

--- a/internal/domain/Whist.go
+++ b/internal/domain/Whist.go
@@ -874,14 +874,9 @@ func (w *Whist) isPartnerWinning(playerIdx int) bool {
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す
 func (w *Whist) getValidPlayIndices(playerIdx int) []int {
 	player := w.players[playerIdx]
-	var valid []int
-	for i := 0; i < player.GetCardsSize(); i++ {
-		card := player.GetCard(i)
-		if w.validatePlay(playerIdx, card) == nil {
-			valid = append(valid, i)
-		}
-	}
-	return valid
+	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
+		return w.validatePlay(playerIdx, player.GetCard(i)) == nil
+	})
 }
 
 // whistJSON is the JSON wire format for Whist.

--- a/internal/domain/Wizard.go
+++ b/internal/domain/Wizard.go
@@ -804,14 +804,9 @@ func (o *Wizard) appendLog(playerIdx int, actionType, detail string, cards []*Ca
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す
 func (o *Wizard) getValidPlayIndices(playerIdx int) []int {
 	player := o.players[playerIdx]
-	var valid []int
-	for i := 0; i < player.GetCardsSize(); i++ {
-		card := player.GetCard(i)
-		if o.validatePlay(playerIdx, card) == nil {
-			valid = append(valid, i)
-		}
-	}
-	return valid
+	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
+		return o.validatePlay(playerIdx, player.GetCard(i)) == nil
+	})
 }
 
 // GetHint ヒントを取得する

--- a/internal/domain/slice_helpers.go
+++ b/internal/domain/slice_helpers.go
@@ -7,6 +7,22 @@
 // rebucketing any game that used it to another worker).
 package domain
 
+// collectValidIndices returns the indices in [0, size) for which ok reports
+// true. It factors out the "scan a hand and keep the playable card indices"
+// loop duplicated across dozens of trick-taking / shedding games (issue #4299):
+// each game passes a closure wrapping its own validation (e.g. validatePlay ==
+// nil, or isValidPlay). The result is pre-sized to size and is non-nil even
+// when empty.
+func collectValidIndices(size int, ok func(i int) bool) []int {
+	valid := make([]int, 0, size)
+	for i := range size {
+		if ok(i) {
+			valid = append(valid, i)
+		}
+	}
+	return valid
+}
+
 // sliceOrEmpty replaces nil with an empty slice for JSON round-trip stability.
 func sliceOrEmpty[T any](s []T) []T {
 	if s == nil {

--- a/internal/domain/slice_helpers_internal_test.go
+++ b/internal/domain/slice_helpers_internal_test.go
@@ -1,0 +1,33 @@
+//go:build test
+
+package domain
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestCollectValidIndices(t *testing.T) {
+	tests := []struct {
+		name string
+		size int
+		ok   func(i int) bool
+		want []int
+	}{
+		{"all valid", 3, func(int) bool { return true }, []int{0, 1, 2}},
+		{"none valid", 3, func(int) bool { return false }, []int{}},
+		{"even only", 5, func(i int) bool { return i%2 == 0 }, []int{0, 2, 4}},
+		{"empty hand", 0, func(int) bool { return true }, []int{}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := collectValidIndices(tc.size, tc.ok)
+			if got == nil {
+				t.Fatalf("result must be non-nil even when empty")
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("collectValidIndices(%d) = %v, want %v", tc.size, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

48 trick-taking / shedding games in `internal/domain` had a byte-identical (modulo receiver/var names) `getValidPlayIndices` loop — scan the hand, keep the indices whose card passes the game's validation (issue #4299).

## Change

Add `collectValidIndices(size int, ok func(i int) bool) []int` to the **untagged** `slice_helpers.go` (so every Cloudflare Worker WASM binary includes it — cross-game helpers must not be build-tagged), and have each game pass a closure wrapping its own validator:

- 43 games: `return g.validatePlay(playerIdx, player.GetCard(i)) == nil`
- 5 games (CrazyEights, Macau, Mao, PageOne, Prsi): `return g.isValidPlay(player.GetCard(i))`

Each method drops from ~10 lines to ~4.

## Left as-is (genuinely different)

The premise "55 identical" was slightly optimistic. Untouched: the complex trick-following games (**Cego, Koenigrufen, FrenchTarot, Pinochle, Ulti, Scarto**), **Sedma** (returns all indices, no filter), and **Watten**'s bounds guard (transformed but keeps the guard). **Mighty** keeps its lead-joker exclusion *inside* the closure — the mechanical pass initially dropped it, which `TestMighty_CpuJokerLeadPath` caught; verified no other transformed game had hidden extra logic (grepped every diff for a second `if`/`continue`).

## Test plan

- [x] `go test -tags test ./internal/domain/` — full suite green (incl. `TestMighty_CpuJokerLeadPath`); added `TestCollectValidIndices` (all/none/even/empty, non-nil result)
- [x] `golangci-lint run ./internal/domain/` — 0 issues
- [ ] CI green

Closes #4299