### PR TITLE
refactor(frontend): extract localStorage stats factory (4 best-record hooks)

### DIFF
--- a/frontend/src/hooks/createLocalStorageStats.test.ts
+++ b/frontend/src/hooks/createLocalStorageStats.test.ts
@@ -1,0 +1,77 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createFlatStatsReader, createLocalStorageStats } from './createLocalStorageStats';
+
+interface Stat {
+  plays: number;
+  best: number | null;
+}
+const KEY = 'test-stats';
+const empty = (): Stat => ({ plays: 0, best: null });
+const isStat = (v: unknown): v is Stat => typeof v === 'object' && v !== null && typeof (v as Stat).plays === 'number';
+
+describe('createFlatStatsReader', () => {
+  beforeEach(() => localStorage.clear());
+  afterEach(() => localStorage.clear());
+
+  const read = createFlatStatsReader(KEY, empty, isStat);
+
+  it('returns empty when the key is absent', () => {
+    expect(read()).toEqual({ plays: 0, best: null });
+  });
+
+  it('returns the parsed value when valid', () => {
+    localStorage.setItem(KEY, JSON.stringify({ plays: 3, best: 90 }));
+    expect(read()).toEqual({ plays: 3, best: 90 });
+  });
+
+  it('falls back to empty on malformed JSON', () => {
+    localStorage.setItem(KEY, '{not json');
+    expect(read()).toEqual({ plays: 0, best: null });
+  });
+
+  it('falls back to empty when validation fails', () => {
+    localStorage.setItem(KEY, JSON.stringify({ nope: true }));
+    expect(read()).toEqual({ plays: 0, best: null });
+  });
+});
+
+describe('createLocalStorageStats', () => {
+  beforeEach(() => localStorage.clear());
+  afterEach(() => localStorage.clear());
+
+  const read = createFlatStatsReader(KEY, empty, isStat);
+  const store = createLocalStorageStats<Stat, { score: number }, boolean>({
+    key: KEY,
+    read,
+    reduce: (prev, result) => {
+      const newBest = prev.best === null || result.score > prev.best;
+      return { stats: { plays: prev.plays + 1, best: newBest ? result.score : prev.best }, update: newBest };
+    },
+  });
+
+  it('apply is the provided reduce', () => {
+    expect(store.apply({ plays: 0, best: null }, { score: 5 })).toEqual({
+      stats: { plays: 1, best: 5 },
+      update: true,
+    });
+  });
+
+  it('useStats records, persists, and returns the update', () => {
+    const { result } = renderHook(() => store.useStats());
+    let update = false;
+    act(() => {
+      update = result.current.recordResult({ score: 42 });
+    });
+    expect(update).toBe(true);
+    expect(result.current.stats).toEqual({ plays: 1, best: 42 });
+    expect(JSON.parse(localStorage.getItem(KEY) ?? '{}')).toEqual({ plays: 1, best: 42 });
+
+    // A lower score does not beat the best.
+    act(() => {
+      update = result.current.recordResult({ score: 10 });
+    });
+    expect(update).toBe(false);
+    expect(result.current.stats).toEqual({ plays: 2, best: 42 });
+  });
+});

--- a/frontend/src/hooks/createLocalStorageStats.ts
+++ b/frontend/src/hooks/createLocalStorageStats.ts
@@ -1,0 +1,70 @@
+import { useCallback, useState } from 'react';
+
+/**
+ * Builds a `read()` for a single flat stats record: parse + validate the value
+ * persisted under `key`, falling back to `empty()` on a missing key, malformed
+ * JSON, failed validation, or unavailable storage. Per-key-map stats (e.g.
+ * Klondike variants, Spider difficulties) supply their own entry-sanitizing
+ * reader instead. Issue #4303.
+ */
+export function createFlatStatsReader<Stat>(
+  key: string,
+  empty: () => Stat,
+  validate: (value: unknown) => value is Stat,
+): () => Stat {
+  return () => {
+    try {
+      const raw = localStorage.getItem(key);
+      if (!raw) return empty();
+      const parsed: unknown = JSON.parse(raw);
+      return validate(parsed) ? parsed : empty();
+    } catch {
+      return empty();
+    }
+  };
+}
+
+/** Configuration for {@link createLocalStorageStats}. */
+export interface LocalStorageStatsConfig<Stat, Result, Update> {
+  /** localStorage key the stats are persisted under. */
+  key: string;
+  /** Reads the current persisted stats (e.g. from {@link createFlatStatsReader}). */
+  read: () => Stat;
+  /**
+   * Pure reducer folding a finished-game result into the previous stats,
+   * returning the next stats and a game-specific "which personal bests were
+   * beaten" update (a boolean for single-best games, an object for multi-best).
+   */
+  reduce: (prev: Stat, result: Result) => { stats: Stat; update: Update };
+}
+
+/**
+ * Factory for a localStorage-backed best-record stats hook (issue #4303).
+ * Centralizes the persist + useState plumbing copy-pasted across the solitaire /
+ * best-record stats hooks; each game supplies its key, reader, and reduce.
+ *
+ * Returns `apply` (the provided `reduce`, re-exported so callers keep a pure
+ * `applyXResult`) and `useStats()` — React state seeded from `read()`, plus
+ * `recordResult`, which folds a result into the freshly-read stats, persists it
+ * (swallowing quota / availability errors), and returns the reduce's `update`.
+ */
+export function createLocalStorageStats<Stat, Result, Update>(config: LocalStorageStatsConfig<Stat, Result, Update>) {
+  const { key, read, reduce } = config;
+
+  function useStats() {
+    const [stats, setStats] = useState<Stat>(read);
+    const recordResult = useCallback((result: Result): Update => {
+      const { stats: next, update } = reduce(read(), result);
+      setStats(next);
+      try {
+        localStorage.setItem(key, JSON.stringify(next));
+      } catch {
+        /* storage unavailable / quota exceeded */
+      }
+      return update;
+    }, []);
+    return { stats, recordResult };
+  }
+
+  return { apply: reduce, useStats };
+}

--- a/frontend/src/hooks/useKlondikeStats.ts
+++ b/frontend/src/hooks/useKlondikeStats.ts
@@ -1,4 +1,5 @@
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
+import { createLocalStorageStats } from './createLocalStorageStats';
 
 /** localStorage key for per-variant Klondike play statistics. */
 export const KLONDIKE_STATS_KEY = 'klondike_stats';
@@ -113,19 +114,14 @@ export function klondikeWinRate(stat: KlondikeVariantStat): number {
  * finished games. `recordResult` returns which personal bests were beaten so the
  * page can surface a badge.
  */
-export function useKlondikeStats() {
-  const [stats, setStats] = useState<KlondikeStats>(readKlondikeStats);
+const store = createLocalStorageStats<KlondikeStats, KlondikeResult, KlondikeBestUpdate>({
+  key: KLONDIKE_STATS_KEY,
+  read: readKlondikeStats,
+  reduce: applyKlondikeResult,
+});
 
-  const recordResult = useCallback((result: KlondikeResult): KlondikeBestUpdate => {
-    const { stats: next, update } = applyKlondikeResult(readKlondikeStats(), result);
-    setStats(next);
-    try {
-      localStorage.setItem(KLONDIKE_STATS_KEY, JSON.stringify(next));
-    } catch {
-      /* storage unavailable / quota exceeded */
-    }
-    return update;
-  }, []);
+export function useKlondikeStats() {
+  const { stats, recordResult } = store.useStats();
 
   const getStat = useCallback(
     (drawCount: number, scoringMode: number): KlondikeVariantStat =>

--- a/frontend/src/hooks/usePyramidStats.ts
+++ b/frontend/src/hooks/usePyramidStats.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { createFlatStatsReader, createLocalStorageStats } from './createLocalStorageStats';
 
 /** localStorage key for Pyramid Solitaire best-record statistics. */
 export const PYRAMID_STATS_KEY = 'trumpcards-pyramid-stats';
@@ -34,19 +34,6 @@ function isValidStats(value: unknown): value is PyramidStats {
   );
 }
 
-/** Reads and validates the stats from localStorage; returns a zeroed record on any error. */
-export function readPyramidStats(): PyramidStats {
-  try {
-    const raw = localStorage.getItem(PYRAMID_STATS_KEY);
-    if (!raw) return emptyPyramidStats();
-    const parsed: unknown = JSON.parse(raw);
-    if (!isValidStats(parsed)) return emptyPyramidStats();
-    return parsed;
-  } catch {
-    return emptyPyramidStats();
-  }
-}
-
 /**
  * Pure reducer: folds a finished-game result into the stats and reports whether it
  * set a new fewest-moves record. Fewest moves only advances on a positive-move clear.
@@ -68,24 +55,21 @@ export function applyPyramidResult(
   return { stats: next, newBest };
 }
 
+/** Reads and validates the stats from localStorage; returns a zeroed record on any error. */
+export const readPyramidStats = createFlatStatsReader(PYRAMID_STATS_KEY, emptyPyramidStats, isValidStats);
+
+const store = createLocalStorageStats<PyramidStats, PyramidResult, boolean>({
+  key: PYRAMID_STATS_KEY,
+  read: readPyramidStats,
+  reduce: (prev, result) => {
+    const { stats, newBest } = applyPyramidResult(prev, result);
+    return { stats, update: newBest };
+  },
+});
+
 /**
  * Hook that persists Pyramid best-record statistics in localStorage and records
  * finished games. `recordResult` returns whether the game set a new fewest-moves
- * record so the page can surface a badge. Modeled on `useTriPeaksStats`.
+ * record so the page can surface a badge.
  */
-export function usePyramidStats() {
-  const [stats, setStats] = useState<PyramidStats>(readPyramidStats);
-
-  const recordResult = useCallback((result: PyramidResult): boolean => {
-    const { stats: next, newBest } = applyPyramidResult(readPyramidStats(), result);
-    setStats(next);
-    try {
-      localStorage.setItem(PYRAMID_STATS_KEY, JSON.stringify(next));
-    } catch {
-      /* storage unavailable / quota exceeded */
-    }
-    return newBest;
-  }, []);
-
-  return { stats, recordResult };
-}
+export const usePyramidStats = store.useStats;

--- a/frontend/src/hooks/useSpiderStats.ts
+++ b/frontend/src/hooks/useSpiderStats.ts
@@ -1,4 +1,5 @@
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
+import { createLocalStorageStats } from './createLocalStorageStats';
 
 /** localStorage key for per-difficulty Spider Solitaire play statistics. */
 export const SPIDER_STATS_KEY = 'trumpcards-spider-stats';
@@ -104,19 +105,14 @@ export function spiderWinRate(stat: SpiderDifficultyStat): number {
  * finished games. `recordResult` returns which personal bests were beaten so the
  * page can surface a badge.
  */
-export function useSpiderStats() {
-  const [stats, setStats] = useState<SpiderStats>(readSpiderStats);
+const store = createLocalStorageStats<SpiderStats, SpiderResult, SpiderBestUpdate>({
+  key: SPIDER_STATS_KEY,
+  read: readSpiderStats,
+  reduce: applySpiderResult,
+});
 
-  const recordResult = useCallback((result: SpiderResult): SpiderBestUpdate => {
-    const { stats: next, update } = applySpiderResult(readSpiderStats(), result);
-    setStats(next);
-    try {
-      localStorage.setItem(SPIDER_STATS_KEY, JSON.stringify(next));
-    } catch {
-      /* storage unavailable / quota exceeded */
-    }
-    return update;
-  }, []);
+export function useSpiderStats() {
+  const { stats, recordResult } = store.useStats();
 
   const getStat = useCallback(
     (difficulty: number): SpiderDifficultyStat => stats[String(difficulty)] ?? emptySpiderStat(),

--- a/frontend/src/hooks/useTriPeaksStats.ts
+++ b/frontend/src/hooks/useTriPeaksStats.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { createFlatStatsReader, createLocalStorageStats } from './createLocalStorageStats';
 
 /** localStorage key for TriPeaks Solitaire best-record statistics. */
 export const TRIPEAKS_STATS_KEY = 'trumpcards-tripeaks-stats';
@@ -34,19 +34,6 @@ function isValidStats(value: unknown): value is TriPeaksStats {
   );
 }
 
-/** Reads and validates the stats from localStorage; returns a zeroed record on any error. */
-export function readTriPeaksStats(): TriPeaksStats {
-  try {
-    const raw = localStorage.getItem(TRIPEAKS_STATS_KEY);
-    if (!raw) return emptyTriPeaksStats();
-    const parsed: unknown = JSON.parse(raw);
-    if (!isValidStats(parsed)) return emptyTriPeaksStats();
-    return parsed;
-  } catch {
-    return emptyTriPeaksStats();
-  }
-}
-
 /**
  * Pure reducer: folds a finished-game result into the stats and reports whether it
  * set a new best score. Best score only advances on a positive score.
@@ -68,24 +55,21 @@ export function applyTriPeaksResult(
   return { stats: next, newBest };
 }
 
+/** Reads and validates the stats from localStorage; returns a zeroed record on any error. */
+export const readTriPeaksStats = createFlatStatsReader(TRIPEAKS_STATS_KEY, emptyTriPeaksStats, isValidStats);
+
+const store = createLocalStorageStats<TriPeaksStats, TriPeaksResult, boolean>({
+  key: TRIPEAKS_STATS_KEY,
+  read: readTriPeaksStats,
+  reduce: (prev, result) => {
+    const { stats, newBest } = applyTriPeaksResult(prev, result);
+    return { stats, update: newBest };
+  },
+});
+
 /**
  * Hook that persists TriPeaks best-record statistics in localStorage and records
  * finished games. `recordResult` returns whether the game set a new best score so
- * the page can surface a badge. Modeled on `useSpiderStats`.
+ * the page can surface a badge.
  */
-export function useTriPeaksStats() {
-  const [stats, setStats] = useState<TriPeaksStats>(readTriPeaksStats);
-
-  const recordResult = useCallback((result: TriPeaksResult): boolean => {
-    const { stats: next, newBest } = applyTriPeaksResult(readTriPeaksStats(), result);
-    setStats(next);
-    try {
-      localStorage.setItem(TRIPEAKS_STATS_KEY, JSON.stringify(next));
-    } catch {
-      /* storage unavailable / quota exceeded */
-    }
-    return newBest;
-  }, []);
-
-  return { stats, recordResult };
-}
+export const useTriPeaksStats = store.useStats;


### PR DESCRIPTION
Extract createLocalStorageStats({key,read,reduce}) + createFlatStatsReader(key,empty,validate); route 4 best-record hooks through shared persist plumbing. Pyramid/TriPeaks flat via createFlatStatsReader; Klondike/Spider per-key maps keep entry-sanitizing readers + getStat. All public signatures unchanged so consuming pages/tests untouched. CaribbeanStud/CasinoWar (bounded history logs) left out — different pattern. New factory test; 4 hooks' tests unchanged; page tests (259) pass; check+build clean. Closes #4303