### PR TITLE
feat(frontend): shared Modal primitive + useFocusTrap for dialog a11y

### DIFF
--- a/frontend/src/components/ConfirmDialog.tsx
+++ b/frontend/src/components/ConfirmDialog.tsx
@@ -1,7 +1,6 @@
-import { useEffect, useId, useRef } from 'react';
-import { useBodyScrollLock } from '../hooks/useBodyScrollLock';
+import { useId } from 'react';
 import { btnDanger, btnSecondary } from '../styles/buttonStyles';
-import { getFocusableElements } from '../utils/dom';
+import { Modal } from './common/Modal';
 
 // Re-export for backward compatibility with existing imports
 export { getFocusableElements } from '../utils/dom';
@@ -19,92 +18,36 @@ export interface ConfirmDialogProps {
 
 /** Renders a modal confirmation dialog with confirm and cancel buttons. */
 export function ConfirmDialog(props: ConfirmDialogProps) {
-  const dialogRef = useRef<HTMLDivElement>(null);
-  const triggerRef = useRef<Element | null>(null);
   const id = useId();
   const titleId = `${id}-title`;
   const descId = `${id}-desc`;
   const hasDescription = props.message.length > 0;
 
-  useBodyScrollLock(props.open);
-
-  useEffect(() => {
-    if (!props.open) return;
-    triggerRef.current = document.activeElement;
-
-    // Safe assertion: useEffect runs after render, so ref is always attached when open=true
-    const dialog = dialogRef.current as HTMLElement;
-    const focusable = getFocusableElements(dialog);
-    if (focusable.length === 0) return;
-
-    const first = focusable[0];
-    const last = focusable[focusable.length - 1];
-    first.focus();
-
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        props.onCancel();
-        return;
-      }
-      if (e.key !== 'Tab') return;
-      if (e.shiftKey) {
-        if (document.activeElement === first) {
-          e.preventDefault();
-          last.focus();
-        }
-      } else {
-        if (document.activeElement === last) {
-          e.preventDefault();
-          first.focus();
-        }
-      }
-    };
-
-    document.addEventListener('keydown', handleKeyDown);
-    return () => {
-      document.removeEventListener('keydown', handleKeyDown);
-      if (triggerRef.current instanceof HTMLElement) {
-        triggerRef.current.focus();
-      }
-    };
-  }, [props.open, props.onCancel]);
-
-  if (!props.open) return null;
-
   return (
-    // biome-ignore lint/a11y/noStaticElementInteractions: overlay backdrop dismisses dialog on click
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-      onClick={props.onCancel}
-      role="presentation"
+    <Modal
+      open={props.open}
+      onClose={props.onCancel}
+      role="alertdialog"
+      ariaLabelledBy={titleId}
+      ariaDescribedBy={hasDescription ? descId : undefined}
+      panelClassName="glass-panel rounded-lg shadow-xl p-6 max-w-sm mx-4"
     >
-      {/* biome-ignore lint/a11y/useKeyWithClickEvents: keyboard events handled at document level via useEffect */}
-      <div
-        ref={dialogRef}
-        role="alertdialog"
-        aria-modal="true"
-        aria-labelledby={titleId}
-        aria-describedby={hasDescription ? descId : undefined}
-        className="glass-panel rounded-lg shadow-xl p-6 max-w-sm mx-4"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <h2 id={titleId} className="text-lg font-bold text-ds-text-primary mb-2">
-          {props.title}
-        </h2>
-        {hasDescription && (
-          <p id={descId} className="text-ds-text-primary mb-4">
-            {props.message}
-          </p>
-        )}
-        <div className="flex justify-end gap-2">
-          <button type="button" className={btnSecondary} onClick={props.onCancel}>
-            {props.cancelLabel}
-          </button>
-          <button type="button" className={btnDanger} onClick={props.onConfirm}>
-            {props.confirmLabel}
-          </button>
-        </div>
+      <h2 id={titleId} className="text-lg font-bold text-ds-text-primary mb-2">
+        {props.title}
+      </h2>
+      {hasDescription && (
+        <p id={descId} className="text-ds-text-primary mb-4">
+          {props.message}
+        </p>
+      )}
+      <div className="flex justify-end gap-2">
+        <button type="button" className={btnSecondary} onClick={props.onCancel}>
+          {props.cancelLabel}
+        </button>
+        <button type="button" className={btnDanger} onClick={props.onConfirm}>
+          {props.confirmLabel}
+        </button>
       </div>
-    </div>
+    </Modal>
   );
 }

--- a/frontend/src/components/ManualModal.tsx
+++ b/frontend/src/components/ManualModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import type { Components } from 'react-markdown';
@@ -7,8 +7,8 @@ import remarkGfm from 'remark-gfm';
 import { cuiManualTexts, isCliModeEnabled } from '../constants/cuiManualTexts';
 import { manualTexts } from '../constants/manualTexts';
 import { useBodyScrollLock } from '../hooks/useBodyScrollLock';
+import { useFocusTrap } from '../hooks/useFocusTrap';
 import { btnSecondary } from '../styles/buttonStyles';
-import { getFocusableElements } from '../utils/dom';
 import { MermaidBlock } from './MermaidBlock';
 
 /** Props for the ManualModal component. */
@@ -43,53 +43,9 @@ const markdownComponents: Components = {
 export function ManualModal({ open, onClose, gamePath }: ManualModalProps) {
   const { t } = useTranslation('common');
   const dialogRef = useRef<HTMLDivElement>(null);
-  const triggerRef = useRef<Element | null>(null);
 
   useBodyScrollLock(open);
-
-  useEffect(() => {
-    if (!open) return;
-    triggerRef.current = document.activeElement;
-
-    const dialog = dialogRef.current;
-    if (!dialog) return;
-
-    const focusable = getFocusableElements(dialog);
-    if (focusable.length > 0) {
-      focusable[0].focus();
-    }
-
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        onClose();
-        return;
-      }
-      if (e.key !== 'Tab') return;
-      const elems = getFocusableElements(dialog);
-      if (elems.length === 0) return;
-      const first = elems[0];
-      const last = elems[elems.length - 1];
-      if (e.shiftKey) {
-        if (document.activeElement === first) {
-          e.preventDefault();
-          last.focus();
-        }
-      } else {
-        if (document.activeElement === last) {
-          e.preventDefault();
-          first.focus();
-        }
-      }
-    };
-
-    document.addEventListener('keydown', handleKeyDown);
-    return () => {
-      document.removeEventListener('keydown', handleKeyDown);
-      if (triggerRef.current instanceof HTMLElement) {
-        triggerRef.current.focus();
-      }
-    };
-  }, [open, onClose]);
+  useFocusTrap(dialogRef, open, onClose);
 
   if (!open) return null;
 

--- a/frontend/src/components/common/Modal.test.tsx
+++ b/frontend/src/components/common/Modal.test.tsx
@@ -1,0 +1,93 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { Modal } from './Modal';
+
+describe('Modal', () => {
+  it('renders nothing when closed', () => {
+    render(
+      <Modal open={false} onClose={() => {}}>
+        <button type="button">inside</button>
+      </Modal>,
+    );
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('portals an aria-modal dialog and moves focus inside on open', () => {
+    render(
+      <Modal open onClose={() => {}} ariaLabel="picker">
+        <button type="button">first</button>
+        <button type="button">second</button>
+      </Modal>,
+    );
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    // Portaled to body, not nested in the render container.
+    expect(dialog.closest('[data-testid="rtl-container"]')).toBeNull();
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: 'first' }));
+  });
+
+  it('closes on Escape', () => {
+    const onClose = vi.fn();
+    render(
+      <Modal open onClose={onClose}>
+        <button type="button">x</button>
+      </Modal>,
+    );
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes on backdrop click by default but not when dismissOnBackdrop is false', () => {
+    const onClose = vi.fn();
+    const { rerender } = render(
+      <Modal open onClose={onClose}>
+        <button type="button">x</button>
+      </Modal>,
+    );
+    fireEvent.click(screen.getByRole('presentation'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    onClose.mockClear();
+    rerender(
+      <Modal open onClose={onClose} dismissOnBackdrop={false}>
+        <button type="button">x</button>
+      </Modal>,
+    );
+    fireEvent.click(screen.getByRole('presentation'));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('does not close when the panel itself is clicked', () => {
+    const onClose = vi.fn();
+    render(
+      <Modal open onClose={onClose}>
+        <button type="button">x</button>
+      </Modal>,
+    );
+    fireEvent.click(screen.getByRole('dialog'));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('restores focus to the trigger element on close', () => {
+    const trigger = document.createElement('button');
+    document.body.appendChild(trigger);
+    trigger.focus();
+    expect(document.activeElement).toBe(trigger);
+
+    const { rerender } = render(
+      <Modal open onClose={() => {}}>
+        <button type="button">x</button>
+      </Modal>,
+    );
+    // focus moved into the dialog
+    expect(document.activeElement).not.toBe(trigger);
+
+    rerender(
+      <Modal open={false} onClose={() => {}}>
+        <button type="button">x</button>
+      </Modal>,
+    );
+    expect(document.activeElement).toBe(trigger);
+    document.body.removeChild(trigger);
+  });
+});

--- a/frontend/src/components/common/Modal.tsx
+++ b/frontend/src/components/common/Modal.tsx
@@ -63,6 +63,7 @@ export function Modal({
       {/* biome-ignore lint/a11y/useAriaPropsSupportedByRole: role is constrained to dialog|alertdialog, both of which support aria-modal (biome can't narrow the dynamic prop) */}
       <div
         ref={dialogRef}
+        tabIndex={-1}
         role={role}
         aria-modal="true"
         aria-label={ariaLabel}

--- a/frontend/src/components/common/Modal.tsx
+++ b/frontend/src/components/common/Modal.tsx
@@ -1,0 +1,79 @@
+import { type ReactNode, useRef } from 'react';
+import { createPortal } from 'react-dom';
+import { useBodyScrollLock } from '../../hooks/useBodyScrollLock';
+import { useFocusTrap } from '../../hooks/useFocusTrap';
+
+/** Props for the shared {@link Modal} primitive. */
+export interface ModalProps {
+  /** Whether the modal is shown. */
+  open: boolean;
+  /** Called on Escape, backdrop click (unless disabled), or programmatic close. */
+  onClose: () => void;
+  /** Dialog content. */
+  children: ReactNode;
+  /** ARIA role — use 'alertdialog' for confirmations, 'dialog' otherwise. */
+  role?: 'dialog' | 'alertdialog';
+  /** Accessible name when there is no visible titled element to reference. */
+  ariaLabel?: string;
+  /** id of the element labelling the dialog (preferred over ariaLabel). */
+  ariaLabelledBy?: string;
+  /** id of the element describing the dialog. */
+  ariaDescribedBy?: string;
+  /** Classes for the inner dialog panel. */
+  panelClassName?: string;
+  /** Whether a backdrop click closes the modal (default true). */
+  dismissOnBackdrop?: boolean;
+}
+
+/**
+ * Shared modal-dialog primitive (issue #4312): a single implementation of the
+ * a11y behavior that had diverged across eight hand-rolled dialogs. It portals
+ * to `document.body` (so it escapes `overflow-hidden` game panels), renders a
+ * dismiss-on-click backdrop scrim, locks body scroll via {@link useBodyScrollLock},
+ * and traps focus / closes on Escape / restores focus via {@link useFocusTrap}.
+ * Centered-dialog layout; bespoke overlays (manual, tutorial spotlight) reuse
+ * the `useFocusTrap` hook directly instead.
+ */
+export function Modal({
+  open,
+  onClose,
+  children,
+  role = 'dialog',
+  ariaLabel,
+  ariaLabelledBy,
+  ariaDescribedBy,
+  panelClassName = '',
+  dismissOnBackdrop = true,
+}: ModalProps) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  useBodyScrollLock(open);
+  useFocusTrap(dialogRef, open, onClose);
+
+  if (!open) return null;
+
+  return createPortal(
+    // biome-ignore lint/a11y/noStaticElementInteractions: overlay backdrop dismisses the dialog on click
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      role="presentation"
+      onClick={dismissOnBackdrop ? onClose : undefined}
+    >
+      {/* biome-ignore lint/a11y/useKeyWithClickEvents: keyboard handling lives in useFocusTrap (document-level) */}
+      {/* biome-ignore lint/a11y/noStaticElementInteractions: this is the dialog panel (role dialog/alertdialog); onClick only stops backdrop propagation */}
+      {/* biome-ignore lint/a11y/useAriaPropsSupportedByRole: role is constrained to dialog|alertdialog, both of which support aria-modal (biome can't narrow the dynamic prop) */}
+      <div
+        ref={dialogRef}
+        role={role}
+        aria-modal="true"
+        aria-label={ariaLabel}
+        aria-labelledby={ariaLabelledBy}
+        aria-describedby={ariaDescribedBy}
+        className={panelClassName}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {children}
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/frontend/src/components/oldmaid/OldMaidSettingsDialog.test.tsx
+++ b/frontend/src/components/oldmaid/OldMaidSettingsDialog.test.tsx
@@ -164,8 +164,9 @@ describe('OldMaidSettingsDialog', () => {
   it('every radio/checkbox label meets the 44px minimum touch target (WCAG 2.5.5)', () => {
     // Issue #1510: setup dialog stacks 6 small toggles; below 44px tap area
     // mobile users mis-toggle adjacent options.
-    const { container } = render(<OldMaidSettingsDialog {...defaultProps} />);
-    const labels = container.querySelectorAll('label.flex.items-center');
+    render(<OldMaidSettingsDialog {...defaultProps} />);
+    // The dialog portals to document.body via the shared Modal, so query the document.
+    const labels = document.querySelectorAll('label.flex.items-center');
     expect(labels.length).toBeGreaterThanOrEqual(6);
     for (const label of labels) {
       expect(label.className).toContain('min-h-[44px]');

--- a/frontend/src/components/oldmaid/OldMaidSettingsDialog.tsx
+++ b/frontend/src/components/oldmaid/OldMaidSettingsDialog.tsx
@@ -1,8 +1,7 @@
-import { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { OldMaidMode } from '../../hooks/useOldMaidGame';
 import { btnPrimary, btnSecondary } from '../../styles/buttonStyles';
-import { getFocusableElements } from '../../utils/dom';
+import { Modal } from '../common/Modal';
 
 /** Props for the OldMaidSettingsDialog component. */
 interface OldMaidSettingsDialogProps {
@@ -38,131 +37,79 @@ export function OldMaidSettingsDialog({
   onClose,
 }: OldMaidSettingsDialogProps) {
   const { t } = useTranslation('oldmaid');
-  const dialogRef = useRef<HTMLDivElement>(null);
-  const triggerRef = useRef<Element | null>(null);
-
-  useEffect(() => {
-    if (!open) return;
-    triggerRef.current = document.activeElement;
-
-    const dialog = dialogRef.current;
-    if (!dialog) return;
-    const focusable = getFocusableElements(dialog);
-    if (focusable.length === 0) return;
-
-    const first = focusable[0];
-    const last = focusable[focusable.length - 1];
-    first.focus();
-
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key !== 'Tab') return;
-      if (e.shiftKey) {
-        if (document.activeElement === first) {
-          e.preventDefault();
-          last.focus();
-        }
-      } else {
-        if (document.activeElement === last) {
-          e.preventDefault();
-          first.focus();
-        }
-      }
-    };
-
-    dialog.addEventListener('keydown', handleKeyDown);
-    return () => {
-      dialog.removeEventListener('keydown', handleKeyDown);
-      if (triggerRef.current instanceof HTMLElement) {
-        triggerRef.current.focus();
-      }
-    };
-  }, [open]);
-
-  if (!open) return null;
 
   return (
-    // biome-ignore lint/a11y/noStaticElementInteractions: overlay backdrop dismisses dialog on click
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-      onClick={onClose}
-      role="presentation"
+    <Modal
+      open={open}
+      onClose={onClose}
+      role="dialog"
+      ariaLabelledBy="oldmaid-settings-title"
+      panelClassName="glass-panel rounded-lg shadow-xl p-6 max-w-sm mx-4"
     >
-      <div
-        ref={dialogRef}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="oldmaid-settings-title"
-        className="glass-panel rounded-lg shadow-xl p-6 max-w-sm mx-4"
-        onClick={(e) => e.stopPropagation()}
-        onKeyDown={(e) => {
-          if (e.key === 'Escape') onClose();
-        }}
-      >
-        <h2 id="oldmaid-settings-title" className="text-lg font-bold text-ds-text-primary mb-4">
-          {t('setup.title')}
-        </h2>
-        <div className="flex flex-col gap-3">
-          <fieldset className="flex flex-col gap-3 border-0 p-0 m-0">
-            <legend className="text-ds-text-primary font-bold mb-1">{t('setup.modeSelect')}</legend>
-            <label className="flex items-center gap-2 text-ds-text-primary cursor-pointer min-h-[44px]">
-              <input
-                type="radio"
-                name="oldmaid-mode"
-                value={OldMaidMode.Normal}
-                checked={mode === OldMaidMode.Normal}
-                onChange={() => onModeChange(OldMaidMode.Normal)}
-              />
-              {t('setup.normal')}
-            </label>
-            <label className="flex items-center gap-2 text-ds-text-primary cursor-pointer min-h-[44px]">
-              <input
-                type="radio"
-                name="oldmaid-mode"
-                value={OldMaidMode.JijiNuki}
-                checked={mode === OldMaidMode.JijiNuki}
-                onChange={() => onModeChange(OldMaidMode.JijiNuki)}
-              />
-              {t('setup.jijiNuki')}
-            </label>
-          </fieldset>
-          <div className="border-t border-white/20 my-1" />
-          <fieldset className="flex flex-col gap-3 border-0 p-0 m-0">
-            <legend className="text-ds-text-primary font-bold mb-1">{t('setup.cpuSettings')}</legend>
-            <label className="flex items-center gap-2 text-ds-text-primary cursor-pointer min-h-[44px]">
-              <input
-                type="checkbox"
-                checked={cpuPlacementStrategy}
-                onChange={(e) => onStrategyChange(e.target.checked)}
-              />
-              {t('setup.cpuStrategy')}
-            </label>
-            <label className="flex items-center gap-2 text-ds-text-primary cursor-pointer min-h-[44px]">
-              <input type="checkbox" checked={cpuMemoryAI} onChange={(e) => onMemoryAIChange(e.target.checked)} />
-              {t('setup.cpuMemoryAI')}
-            </label>
-            <label className="flex items-center gap-2 text-ds-text-primary cursor-pointer min-h-[44px]">
-              <input
-                type="checkbox"
-                checked={cpuHesitationEnabled}
-                onChange={(e) => onHesitationChange(e.target.checked)}
-              />
-              {t('setup.cpuHesitation')}
-            </label>
-            <label className="flex items-center gap-2 text-ds-text-primary cursor-pointer min-h-[44px]">
-              <input type="checkbox" checked={cpuMetaAI} onChange={(e) => onMetaAIChange(e.target.checked)} />
-              {t('setup.cpuMetaAI')}
-            </label>
-          </fieldset>
-        </div>
-        <div className="flex justify-end gap-2 mt-4">
-          <button type="button" className={btnSecondary} onClick={onClose}>
-            {t('setup.cancel')}
-          </button>
-          <button type="button" className={btnPrimary} onClick={onApply}>
-            {t('setup.apply')}
-          </button>
-        </div>
+      <h2 id="oldmaid-settings-title" className="text-lg font-bold text-ds-text-primary mb-4">
+        {t('setup.title')}
+      </h2>
+      <div className="flex flex-col gap-3">
+        <fieldset className="flex flex-col gap-3 border-0 p-0 m-0">
+          <legend className="text-ds-text-primary font-bold mb-1">{t('setup.modeSelect')}</legend>
+          <label className="flex items-center gap-2 text-ds-text-primary cursor-pointer min-h-[44px]">
+            <input
+              type="radio"
+              name="oldmaid-mode"
+              value={OldMaidMode.Normal}
+              checked={mode === OldMaidMode.Normal}
+              onChange={() => onModeChange(OldMaidMode.Normal)}
+            />
+            {t('setup.normal')}
+          </label>
+          <label className="flex items-center gap-2 text-ds-text-primary cursor-pointer min-h-[44px]">
+            <input
+              type="radio"
+              name="oldmaid-mode"
+              value={OldMaidMode.JijiNuki}
+              checked={mode === OldMaidMode.JijiNuki}
+              onChange={() => onModeChange(OldMaidMode.JijiNuki)}
+            />
+            {t('setup.jijiNuki')}
+          </label>
+        </fieldset>
+        <div className="border-t border-white/20 my-1" />
+        <fieldset className="flex flex-col gap-3 border-0 p-0 m-0">
+          <legend className="text-ds-text-primary font-bold mb-1">{t('setup.cpuSettings')}</legend>
+          <label className="flex items-center gap-2 text-ds-text-primary cursor-pointer min-h-[44px]">
+            <input
+              type="checkbox"
+              checked={cpuPlacementStrategy}
+              onChange={(e) => onStrategyChange(e.target.checked)}
+            />
+            {t('setup.cpuStrategy')}
+          </label>
+          <label className="flex items-center gap-2 text-ds-text-primary cursor-pointer min-h-[44px]">
+            <input type="checkbox" checked={cpuMemoryAI} onChange={(e) => onMemoryAIChange(e.target.checked)} />
+            {t('setup.cpuMemoryAI')}
+          </label>
+          <label className="flex items-center gap-2 text-ds-text-primary cursor-pointer min-h-[44px]">
+            <input
+              type="checkbox"
+              checked={cpuHesitationEnabled}
+              onChange={(e) => onHesitationChange(e.target.checked)}
+            />
+            {t('setup.cpuHesitation')}
+          </label>
+          <label className="flex items-center gap-2 text-ds-text-primary cursor-pointer min-h-[44px]">
+            <input type="checkbox" checked={cpuMetaAI} onChange={(e) => onMetaAIChange(e.target.checked)} />
+            {t('setup.cpuMetaAI')}
+          </label>
+        </fieldset>
       </div>
-    </div>
+      <div className="flex justify-end gap-2 mt-4">
+        <button type="button" className={btnSecondary} onClick={onClose}>
+          {t('setup.cancel')}
+        </button>
+        <button type="button" className={btnPrimary} onClick={onApply}>
+          {t('setup.apply')}
+        </button>
+      </div>
+    </Modal>
   );
 }

--- a/frontend/src/hooks/useFocusTrap.test.ts
+++ b/frontend/src/hooks/useFocusTrap.test.ts
@@ -1,0 +1,101 @@
+import { act, renderHook } from '@testing-library/react';
+import type { RefObject } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useFocusTrap } from './useFocusTrap';
+
+/** Builds a container with `n` buttons, mounts it, and returns a ref to it. */
+function mountContainer(n: number, tabIndex?: number): { ref: RefObject<HTMLDivElement>; cleanup: () => void } {
+  const container = document.createElement('div');
+  if (tabIndex !== undefined) container.tabIndex = tabIndex;
+  for (let i = 0; i < n; i++) {
+    const b = document.createElement('button');
+    b.textContent = `b${i}`;
+    container.appendChild(b);
+  }
+  document.body.appendChild(container);
+  return { ref: { current: container }, cleanup: () => container.remove() };
+}
+
+describe('useFocusTrap', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('focuses the first focusable child on open', () => {
+    const { ref, cleanup } = mountContainer(2);
+    renderHook(() => useFocusTrap(ref, true, () => {}));
+    expect(document.activeElement).toBe(ref.current.querySelector('button'));
+    cleanup();
+  });
+
+  it('falls back to the container when it has no focusable children', () => {
+    const { ref, cleanup } = mountContainer(0, -1);
+    renderHook(() => useFocusTrap(ref, true, () => {}));
+    expect(document.activeElement).toBe(ref.current);
+    cleanup();
+  });
+
+  it('calls onClose on Escape', () => {
+    const { ref, cleanup } = mountContainer(1);
+    const onClose = vi.fn();
+    renderHook(() => useFocusTrap(ref, true, onClose));
+    act(() => document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' })));
+    expect(onClose).toHaveBeenCalledTimes(1);
+    cleanup();
+  });
+
+  it('wraps Tab from last to first and Shift+Tab from first to last', () => {
+    const { ref, cleanup } = mountContainer(3);
+    renderHook(() => useFocusTrap(ref, true, () => {}));
+    const buttons = ref.current.querySelectorAll('button');
+    const last = buttons[2] as HTMLElement;
+    const first = buttons[0] as HTMLElement;
+
+    last.focus();
+    act(() => document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' })));
+    expect(document.activeElement).toBe(first);
+
+    first.focus();
+    act(() => document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true })));
+    expect(document.activeElement).toBe(last);
+    cleanup();
+  });
+
+  it('pulls focus back inside when it has escaped the container', () => {
+    const outside = document.createElement('button');
+    document.body.appendChild(outside);
+    const { ref, cleanup } = mountContainer(2);
+    renderHook(() => useFocusTrap(ref, true, () => {}));
+
+    // Focus escaped to an element outside the trap (e.g. via a mouse click).
+    outside.focus();
+    act(() => document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' })));
+    expect(document.activeElement).toBe(ref.current.querySelector('button'));
+    outside.remove();
+    cleanup();
+  });
+
+  it('restores focus to the previously-focused element on close', () => {
+    const trigger = document.createElement('button');
+    document.body.appendChild(trigger);
+    trigger.focus();
+    const { ref, cleanup } = mountContainer(1);
+    const { rerender } = renderHook(({ open }) => useFocusTrap(ref, open, () => {}), {
+      initialProps: { open: true },
+    });
+    expect(document.activeElement).not.toBe(trigger);
+    rerender({ open: false });
+    expect(document.activeElement).toBe(trigger);
+    trigger.remove();
+    cleanup();
+  });
+
+  it('does not trap while closed', () => {
+    const { ref, cleanup } = mountContainer(1);
+    const onClose = vi.fn();
+    renderHook(() => useFocusTrap(ref, false, onClose));
+    act(() => document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' })));
+    expect(onClose).not.toHaveBeenCalled();
+    cleanup();
+  });
+});

--- a/frontend/src/hooks/useFocusTrap.ts
+++ b/frontend/src/hooks/useFocusTrap.ts
@@ -25,8 +25,11 @@ export function useFocusTrap(containerRef: RefObject<HTMLElement | null>, open: 
     triggerRef.current = document.activeElement;
     const container = containerRef.current;
 
+    // Focus the first focusable child, or the container itself (if it is
+    // programmatically focusable, e.g. has tabIndex={-1}) when it has none — so
+    // a content-less modal still traps focus rather than leaving it in the page.
     const focusable = getFocusableElements(container);
-    focusable[0]?.focus();
+    (focusable[0] ?? container).focus();
 
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {

--- a/frontend/src/hooks/useFocusTrap.ts
+++ b/frontend/src/hooks/useFocusTrap.ts
@@ -1,0 +1,62 @@
+import { type RefObject, useEffect, useRef } from 'react';
+import { getFocusableElements } from '../utils/dom';
+
+/**
+ * Traps focus inside `containerRef` while `open`, closes on Escape, and restores
+ * focus to the previously-focused element on close. The single source of truth
+ * for modal-dialog keyboard behavior (issue #4312): on open it focuses the first
+ * focusable descendant and cycles Tab / Shift+Tab within the container; Escape
+ * calls `onClose`; unmount/close returns focus to whatever had it when the
+ * dialog opened.
+ *
+ * Body scroll-locking is handled separately (by {@link useBodyScrollLock},
+ * wired in the shared `Modal` component) so this hook stays focus-only and
+ * reusable by dialogs that manage their own overlay.
+ */
+export function useFocusTrap(containerRef: RefObject<HTMLElement | null>, open: boolean, onClose: () => void): void {
+  const triggerRef = useRef<Element | null>(null);
+  // Keep the latest onClose without re-running the trap effect when a parent
+  // passes a new inline callback each render.
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
+  useEffect(() => {
+    if (!open || !containerRef.current) return;
+    triggerRef.current = document.activeElement;
+    const container = containerRef.current;
+
+    const focusable = getFocusableElements(container);
+    focusable[0]?.focus();
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onCloseRef.current();
+        return;
+      }
+      if (e.key !== 'Tab') return;
+      const items = getFocusableElements(container);
+      if (items.length === 0) return;
+      const first = items[0];
+      const last = items[items.length - 1];
+      if (e.shiftKey) {
+        if (document.activeElement === first || !container.contains(document.activeElement)) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (document.activeElement === last || !container.contains(document.activeElement)) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      if (triggerRef.current instanceof HTMLElement) {
+        triggerRef.current.focus();
+      }
+    };
+  }, [open, containerRef]);
+}

--- a/frontend/src/pages/MightyPage.test.tsx
+++ b/frontend/src/pages/MightyPage.test.tsx
@@ -571,7 +571,9 @@ describe('MightyPage', () => {
 
     fireEvent.click(screen.getByAltText('ジョーカー').closest('button') as HTMLButtonElement);
     fireEvent.click(screen.getByLabelText('joker-lead-button'));
-    expect(screen.getByRole('dialog', { name: 'joker-suit-picker' })).toBeInTheDocument();
+    // The picker is now the shared Modal (portaled, labelled by the translated
+    // demand-suit string); a single dialog is present.
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
 
     mockCall.mockClear();
     mockCall.mockResolvedValue(playPhaseState);

--- a/frontend/src/pages/MightyPage.tsx
+++ b/frontend/src/pages/MightyPage.tsx
@@ -4,6 +4,7 @@ import { ActionLogSection } from '../components/ActionLogSection';
 import { CardRoleBadge } from '../components/CardRoleBadge';
 import { CliTerminal } from '../components/cli/CliTerminal';
 import { CliToggle } from '../components/cli/CliToggle';
+import { Modal } from '../components/common/Modal';
 import { SettingsPanel } from '../components/common/SettingsPanel';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
@@ -627,30 +628,28 @@ function MightyPageContent() {
             )}
 
             {/* Joker suit picker dialog */}
-            {jokerSuitPickerOpen && (
-              <div
-                role="dialog"
-                aria-modal="true"
-                aria-label="joker-suit-picker"
-                className="my-2 p-2 rounded bg-black/60 flex gap-2 items-center flex-wrap"
-              >
-                <span className="text-ds-text-primary text-sm mr-2">{t('demandSuit')}:</span>
-                {[1, 2, 3, 4].map((s) => (
-                  <button
-                    key={s}
-                    type="button"
-                    className={btnPrimary}
-                    onClick={() => {
-                      handleJokerLead(s);
-                      setJokerSuitPickerOpen(false);
-                    }}
-                    disabled={loading}
-                  >
-                    {t(`suitName.${SUIT_KEYS[s]}`)}
-                  </button>
-                ))}
-              </div>
-            )}
+            <Modal
+              open={jokerSuitPickerOpen}
+              onClose={() => setJokerSuitPickerOpen(false)}
+              ariaLabel={t('demandSuit')}
+              panelClassName="glass-panel rounded-lg shadow-xl p-4 flex gap-2 items-center flex-wrap max-w-sm mx-4"
+            >
+              <span className="text-ds-text-primary text-sm mr-2">{t('demandSuit')}:</span>
+              {[1, 2, 3, 4].map((s) => (
+                <button
+                  key={s}
+                  type="button"
+                  className={btnPrimary}
+                  onClick={() => {
+                    handleJokerLead(s);
+                    setJokerSuitPickerOpen(false);
+                  }}
+                  disabled={loading}
+                >
+                  {t(`suitName.${SUIT_KEYS[s]}`)}
+                </button>
+              ))}
+            </Modal>
 
             <div className="flex gap-2 items-center flex-wrap">
               {(isHumanBidTurn || isHumanTurn || isHumanDeclarer || isHumanExchange) && (


### PR DESCRIPTION
## Summary

Eight dialogs hand-rolled their modal a11y, and it had drifted (issue #4312): scroll-lock, Escape-to-close, focus-trap, focus-restore, and portal were each present-or-absent in a different combination. Add a single source of truth:

- **`useFocusTrap(ref, open, onClose)`** — focus-trap (Tab cycle) + Escape-to-close + focus-restore.
- **`<Modal>`** — portals to `document.body` (escaping `overflow-hidden` game panels), renders a dismissable backdrop scrim, locks body scroll (`useBodyScrollLock`), and wires `useFocusTrap`.

## Migrations

| Dialog | Was broken | Now |
|--------|-----------|-----|
| **MightyPage joker picker** | declared `role=dialog aria-modal=true` with **no** trap/Escape/scroll-lock/restore — the worst case for screen-reader users | real `<Modal>`; accessible name is the translated demand-suit label, not a raw `"joker-suit-picker"` dev string |
| **ConfirmDialog** (reset/give-up base) | no portal (clip risk inside felt panels) | `<Modal>` (portaled) |
| **OldMaidSettingsDialog** | no body scroll-lock | `<Modal>` |
| **ManualModal** | duplicated trap effect | reuses `useFocusTrap` (keeps its markdown/portal layout) |

Bespoke overlays — `TutorialOverlay`'s SVG spotlight and the mobile-only `useNavFocusTrap` — keep their own trap (different semantics). `TutorialSuggestDialog` / `DaifugoRulesBadges` already behave correctly and can adopt the shared hook incrementally.

## Test plan

- [x] New `Modal.test.tsx` (portal, focus-in-on-open, Escape close, backdrop dismiss + `dismissOnBackdrop={false}`, panel-click no-op, focus restore)
- [x] Migrated dialogs' existing tests pass (129 across Modal/ConfirmDialog/ManualModal/OldMaidSettings/Mighty); updated two assertions that queried the now-portaled DOM via `container` → `document`/role
- [x] `bun run check` (biome + design-tokens + reduced-motion) + `bun run build` clean
- [ ] CI green

Closes #4312