### PR TITLE
refactor(domain): extract sortPlayerHand generic helper (41 games)

### DIFF
--- a/internal/domain/AllFours.go
+++ b/internal/domain/AllFours.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
-	"sort"
 )
 
 // AllFoursPlayerCnt All Fours プレイヤー数 (1 human vs 1 CPU)
@@ -724,20 +723,12 @@ func (a *AllFours) sortAllHands() {
 }
 
 func allFoursSortHand(pl *AllFoursPlayer) {
-	cards := make([]*Card, pl.GetCardsSize())
-	for i := 0; i < pl.GetCardsSize(); i++ {
-		cards[i] = pl.GetCard(i)
-	}
-	sort.Slice(cards, func(i, j int) bool {
-		if cards[i].GetDesign() != cards[j].GetDesign() {
-			return cards[i].GetDesign() < cards[j].GetDesign()
+	sortPlayerHand(pl, func(ci, cj *Card) bool {
+		if ci.GetDesign() != cj.GetDesign() {
+			return ci.GetDesign() < cj.GetDesign()
 		}
-		return allFoursRankValue(cards[i].GetValue()) < allFoursRankValue(cards[j].GetValue())
+		return allFoursRankValue(ci.GetValue()) < allFoursRankValue(cj.GetValue())
 	})
-	pl.Reset()
-	for _, c := range cards {
-		pl.AddCard(c)
-	}
 }
 
 func (a *AllFours) playerName(idx int) string {

--- a/internal/domain/Belote.go
+++ b/internal/domain/Belote.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
-	"sort"
 )
 
 // BelotePlayerCnt ベロートプレイヤー数
@@ -1067,25 +1066,17 @@ func (b *Belote) sortAllHands() {
 }
 
 func beloteSortHand(p *BelotePlayer, b *Belote) {
-	cards := make([]*Card, p.GetCardsSize())
-	for i := range p.GetCardsSize() {
-		cards[i] = p.GetCard(i)
-	}
-	sort.Slice(cards, func(i, j int) bool {
-		si := cards[i].GetDesign()
-		sj := cards[j].GetDesign()
+	sortPlayerHand(p, func(ci, cj *Card) bool {
+		si := ci.GetDesign()
+		sj := cj.GetDesign()
 		if si != sj {
 			return si < sj
 		}
 		// Strongest card first within each suit — matches the manual's display
 		// example and lets the CPU's "play valid[0]" easy-lead actually pick a
 		// strong card instead of the weakest.
-		return b.cardRank(cards[i]) > b.cardRank(cards[j])
+		return b.cardRank(ci) > b.cardRank(cj)
 	})
-	p.Reset()
-	for _, c := range cards {
-		p.AddCard(c)
-	}
 }
 
 func (b *Belote) findHumanIdx() int {

--- a/internal/domain/Bezique.go
+++ b/internal/domain/Bezique.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"sort"
 )
 
 // BeziqueHandSize 各プレイヤーの手札最大枚数 (山札がある間は補充される)
@@ -916,26 +915,18 @@ func (b *Bezique) sortAllHands() {
 
 // sortHand プレイヤーの手札をスート (トランプ最後) → ランク でソートする
 func (b *Bezique) sortHand(p *BeziquePlayer) {
-	cards := make([]*Card, p.GetCardsSize())
-	for i := 0; i < p.GetCardsSize(); i++ {
-		cards[i] = p.GetCard(i)
-	}
 	trumpSuit := b.trumpSuit
-	sort.Slice(cards, func(i, j int) bool {
-		iTrump := cards[i].GetDesign() == trumpSuit
-		jTrump := cards[j].GetDesign() == trumpSuit
+	sortPlayerHand(p, func(ci, cj *Card) bool {
+		iTrump := ci.GetDesign() == trumpSuit
+		jTrump := cj.GetDesign() == trumpSuit
 		if iTrump != jTrump {
 			return !iTrump
 		}
-		if cards[i].GetDesign() != cards[j].GetDesign() {
-			return cards[i].GetDesign() < cards[j].GetDesign()
+		if ci.GetDesign() != cj.GetDesign() {
+			return ci.GetDesign() < cj.GetDesign()
 		}
-		return BeziqueRankOrder(cards[i]) < BeziqueRankOrder(cards[j])
+		return BeziqueRankOrder(ci) < BeziqueRankOrder(cj)
 	})
-	p.Reset()
-	for _, c := range cards {
-		p.AddCard(c)
-	}
 }
 
 // playerName プレイヤー名を返す (ログ用)

--- a/internal/domain/Bridge.go
+++ b/internal/domain/Bridge.go
@@ -1162,18 +1162,14 @@ func (b *Bridge) sortAllHands() {
 
 // bridgeSortHand プレイヤーの手札をスート→ランクの順にソートする
 func bridgeSortHand(p *BridgePlayer) {
-	cards := make([]*Card, p.GetCardsSize())
-	for i := 0; i < p.GetCardsSize(); i++ {
-		cards[i] = p.GetCard(i)
-	}
-	sort.Slice(cards, func(i, j int) bool {
-		si := cards[i].GetDesign()
-		sj := cards[j].GetDesign()
+	sortPlayerHand(p, func(ci, cj *Card) bool {
+		si := ci.GetDesign()
+		sj := cj.GetDesign()
 		if si != sj {
 			return si < sj
 		}
-		vi := cards[i].GetValue()
-		vj := cards[j].GetValue()
+		vi := ci.GetValue()
+		vj := cj.GetValue()
 		// Aceを最強にするため14に変換
 		if vi == 1 {
 			vi = 14
@@ -1183,10 +1179,6 @@ func bridgeSortHand(p *BridgePlayer) {
 		}
 		return vi < vj
 	})
-	p.Reset()
-	for _, c := range cards {
-		p.AddCard(c)
-	}
 }
 
 // bidSuitToCardDesign ビッドスートをカードデザインに変換する

--- a/internal/domain/Briscola.go
+++ b/internal/domain/Briscola.go
@@ -13,7 +13,6 @@ package domain
 import (
 	"encoding/json"
 	"fmt"
-	"sort"
 )
 
 // BriscolaPlayerCnt ブリスコラのプレイヤー数 (v1は2人固定)
@@ -549,26 +548,18 @@ func (b *Briscola) sortAllHands() {
 
 // sortHand プレイヤーの手札をスート (トランプ最後) → ブリスコラ順位 でソートする
 func (b *Briscola) sortHand(p *BriscolaPlayer) {
-	cards := make([]*Card, p.GetCardsSize())
-	for i := 0; i < p.GetCardsSize(); i++ {
-		cards[i] = p.GetCard(i)
-	}
 	trumpSuit := b.trumpSuit
-	sort.Slice(cards, func(i, j int) bool {
-		iTrump := cards[i].GetDesign() == trumpSuit
-		jTrump := cards[j].GetDesign() == trumpSuit
+	sortPlayerHand(p, func(ci, cj *Card) bool {
+		iTrump := ci.GetDesign() == trumpSuit
+		jTrump := cj.GetDesign() == trumpSuit
 		if iTrump != jTrump {
 			return !iTrump // 非トランプを先に
 		}
-		if cards[i].GetDesign() != cards[j].GetDesign() {
-			return cards[i].GetDesign() < cards[j].GetDesign()
+		if ci.GetDesign() != cj.GetDesign() {
+			return ci.GetDesign() < cj.GetDesign()
 		}
-		return BriscolaRankOrder(cards[i]) < BriscolaRankOrder(cards[j])
+		return BriscolaRankOrder(ci) < BriscolaRankOrder(cj)
 	})
-	p.Reset()
-	for _, c := range cards {
-		p.AddCard(c)
-	}
 }
 
 // playerName プレイヤー名を返す (ログ用)

--- a/internal/domain/CallBreak.go
+++ b/internal/domain/CallBreak.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
-	"sort"
 )
 
 // CallBreakPlayerCnt Call Break のプレイヤー数
@@ -581,20 +580,12 @@ func (cb *CallBreak) sortAllHands() {
 
 // callBreakSortHand プレイヤーの手札をスート → 値の順にソートする
 func callBreakSortHand(p *CallBreakPlayer) {
-	cards := make([]*Card, p.GetCardsSize())
-	for i := 0; i < p.GetCardsSize(); i++ {
-		cards[i] = p.GetCard(i)
-	}
-	sort.Slice(cards, func(i, j int) bool {
-		if cards[i].GetDesign() != cards[j].GetDesign() {
-			return cards[i].GetDesign() < cards[j].GetDesign()
+	sortPlayerHand(p, func(ci, cj *Card) bool {
+		if ci.GetDesign() != cj.GetDesign() {
+			return ci.GetDesign() < cj.GetDesign()
 		}
-		return cards[i].GetValue() < cards[j].GetValue()
+		return ci.GetValue() < cj.GetValue()
 	})
-	p.Reset()
-	for _, c := range cards {
-		p.AddCard(c)
-	}
 }
 
 // playerName プレイヤー名を返す

--- a/internal/domain/Canasta.go
+++ b/internal/domain/Canasta.go
@@ -1521,20 +1521,12 @@ func (g *Canasta) sortAllHands() {
 // sortHand プレイヤーの手札をスート→値の順にソートする
 func (g *Canasta) sortHand(playerIdx int) {
 	p := g.players[playerIdx]
-	cards := make([]*Card, p.GetCardsSize())
-	for i := 0; i < p.GetCardsSize(); i++ {
-		cards[i] = p.GetCard(i)
-	}
-	sort.Slice(cards, func(i, j int) bool {
-		if cards[i].GetDesign() != cards[j].GetDesign() {
-			return cards[i].GetDesign() < cards[j].GetDesign()
+	sortPlayerHand(p, func(ci, cj *Card) bool {
+		if ci.GetDesign() != cj.GetDesign() {
+			return ci.GetDesign() < cj.GetDesign()
 		}
-		return cards[i].GetValue() < cards[j].GetValue()
+		return ci.GetValue() < cj.GetValue()
 	})
-	p.Reset()
-	for _, c := range cards {
-		p.AddCard(c)
-	}
 }
 
 // playerName プレイヤー名を返す

--- a/internal/domain/CatchTen.go
+++ b/internal/domain/CatchTen.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
-	"sort"
 )
 
 // CatchTenHandSize 各プレイヤーの手札枚数 (36枚 / 4人)
@@ -559,20 +558,12 @@ func (g *CatchTen) sortAllHands() {
 
 // catchTenSortHand プレイヤーの手札をスート→値の順にソートする
 func catchTenSortHand(p *CatchTenPlayer) {
-	cards := make([]*Card, p.GetCardsSize())
-	for i := 0; i < p.GetCardsSize(); i++ {
-		cards[i] = p.GetCard(i)
-	}
-	sort.Slice(cards, func(i, j int) bool {
-		if cards[i].GetDesign() != cards[j].GetDesign() {
-			return cards[i].GetDesign() < cards[j].GetDesign()
+	sortPlayerHand(p, func(ci, cj *Card) bool {
+		if ci.GetDesign() != cj.GetDesign() {
+			return ci.GetDesign() < cj.GetDesign()
 		}
-		return cards[i].GetValue() < cards[j].GetValue()
+		return ci.GetValue() < cj.GetValue()
 	})
-	p.Reset()
-	for _, c := range cards {
-		p.AddCard(c)
-	}
 }
 
 // playerName プレイヤー名を返す

--- a/internal/domain/CourtPiece.go
+++ b/internal/domain/CourtPiece.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
-	"sort"
 )
 
 // CourtPieceHandSize 各プレイヤーの手札枚数
@@ -646,20 +645,12 @@ func (c *CourtPiece) sortAllHands() {
 
 // courtPieceSortHand プレイヤーの手札をスート→値の順にソートする
 func courtPieceSortHand(p *CourtPiecePlayer) {
-	cards := make([]*Card, p.GetCardsSize())
-	for i := 0; i < p.GetCardsSize(); i++ {
-		cards[i] = p.GetCard(i)
-	}
-	sort.Slice(cards, func(i, j int) bool {
-		if cards[i].GetDesign() != cards[j].GetDesign() {
-			return cards[i].GetDesign() < cards[j].GetDesign()
+	sortPlayerHand(p, func(ci, cj *Card) bool {
+		if ci.GetDesign() != cj.GetDesign() {
+			return ci.GetDesign() < cj.GetDesign()
 		}
-		return courtPieceRank(cards[i].GetValue()) < courtPieceRank(cards[j].GetValue())
+		return courtPieceRank(ci.GetValue()) < courtPieceRank(cj.GetValue())
 	})
-	p.Reset()
-	for _, c := range cards {
-		p.AddCard(c)
-	}
 }
 
 // playerName プレイヤー名を返す

--- a/internal/domain/CrazyEights.go
+++ b/internal/domain/CrazyEights.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
-	"sort"
 )
 
 // CrazyEightsPlayerCnt クレイジーエイトプレイヤー数
@@ -529,20 +528,12 @@ func (g *CrazyEights) sortAllHands() {
 // sortHand プレイヤーの手札をスート→値の順にソートする
 func (g *CrazyEights) sortHand(playerIdx int) {
 	p := g.players[playerIdx]
-	cards := make([]*Card, p.GetCardsSize())
-	for i := 0; i < p.GetCardsSize(); i++ {
-		cards[i] = p.GetCard(i)
-	}
-	sort.Slice(cards, func(i, j int) bool {
-		if cards[i].GetDesign() != cards[j].GetDesign() {
-			return cards[i].GetDesign() < cards[j].GetDesign()
+	sortPlayerHand(p, func(ci, cj *Card) bool {
+		if ci.GetDesign() != cj.GetDesign() {
+			return ci.GetDesign() < cj.GetDesign()
 		}
-		return cards[i].GetValue() < cards[j].GetValue()
+		return ci.GetValue() < cj.GetValue()
 	})
-	p.Reset()
-	for _, c := range cards {
-		p.AddCard(c)
-	}
 }
 
 // playerName プレイヤー名を返す

--- a/internal/domain/Ecarte.go
+++ b/internal/domain/Ecarte.go
@@ -804,26 +804,18 @@ func (e *Ecarte) sortAllHands() {
 }
 
 func (e *Ecarte) sortHand(p *EcartePlayer) {
-	cards := make([]*Card, p.GetCardsSize())
-	for i := 0; i < p.GetCardsSize(); i++ {
-		cards[i] = p.GetCard(i)
-	}
 	trumpSuit := e.trumpSuit
-	sort.Slice(cards, func(i, j int) bool {
-		iTrump := cards[i].GetDesign() == trumpSuit
-		jTrump := cards[j].GetDesign() == trumpSuit
+	sortPlayerHand(p, func(ci, cj *Card) bool {
+		iTrump := ci.GetDesign() == trumpSuit
+		jTrump := cj.GetDesign() == trumpSuit
 		if iTrump != jTrump {
 			return !iTrump
 		}
-		if cards[i].GetDesign() != cards[j].GetDesign() {
-			return cards[i].GetDesign() < cards[j].GetDesign()
+		if ci.GetDesign() != cj.GetDesign() {
+			return ci.GetDesign() < cj.GetDesign()
 		}
-		return EcarteRankOrder(cards[i]) < EcarteRankOrder(cards[j])
+		return EcarteRankOrder(ci) < EcarteRankOrder(cj)
 	})
-	p.Reset()
-	for _, c := range cards {
-		p.AddCard(c)
-	}
 }
 
 func (e *Ecarte) playerName(idx int) string {

--- a/internal/domain/Euchre.go
+++ b/internal/domain/Euchre.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
-	"sort"
 )
 
 // EuchrePlayerCnt ユーカープレイヤー数
@@ -904,22 +903,14 @@ func (e *Euchre) sortAllHands() {
 
 // euchreSortHand プレイヤーの手札を実効スート→ランクの順にソートする
 func euchreSortHand(p *EuchrePlayer, e *Euchre) {
-	cards := make([]*Card, p.GetCardsSize())
-	for i := 0; i < p.GetCardsSize(); i++ {
-		cards[i] = p.GetCard(i)
-	}
-	sort.Slice(cards, func(i, j int) bool {
-		si := e.effectiveSuit(cards[i])
-		sj := e.effectiveSuit(cards[j])
+	sortPlayerHand(p, func(ci, cj *Card) bool {
+		si := e.effectiveSuit(ci)
+		sj := e.effectiveSuit(cj)
 		if si != sj {
 			return si < sj
 		}
-		return e.cardRank(cards[i]) < e.cardRank(cards[j])
+		return e.cardRank(ci) < e.cardRank(cj)
 	})
-	p.Reset()
-	for _, c := range cards {
-		p.AddCard(c)
-	}
 }
 
 // playerName プレイヤー名を返す

--- a/internal/domain/Gaigel.go
+++ b/internal/domain/Gaigel.go
@@ -26,7 +26,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
-	"sort"
 )
 
 // GaigelPlayerCnt ガイゲルのプレイヤー数 (4人固定)
@@ -1023,26 +1022,18 @@ func (g *Gaigel) sortAllHands() {
 
 // sortHand プレイヤーの手札をスート (トランプ最後) → ランク でソートする
 func (g *Gaigel) sortHand(p *GaigelPlayer) {
-	cards := make([]*Card, p.GetCardsSize())
-	for i := 0; i < p.GetCardsSize(); i++ {
-		cards[i] = p.GetCard(i)
-	}
 	trumpSuit := g.trumpSuit
-	sort.Slice(cards, func(i, j int) bool {
-		iTrump := cards[i].GetDesign() == trumpSuit
-		jTrump := cards[j].GetDesign() == trumpSuit
+	sortPlayerHand(p, func(ci, cj *Card) bool {
+		iTrump := ci.GetDesign() == trumpSuit
+		jTrump := cj.GetDesign() == trumpSuit
 		if iTrump != jTrump {
 			return !iTrump
 		}
-		if cards[i].GetDesign() != cards[j].GetDesign() {
-			return cards[i].GetDesign() < cards[j].GetDesign()
+		if ci.GetDesign() != cj.GetDesign() {
+			return ci.GetDesign() < cj.GetDesign()
 		}
-		return GaigelRankOrder(cards[i]) < GaigelRankOrder(cards[j])
+		return GaigelRankOrder(ci) < GaigelRankOrder(cj)
 	})
-	p.Reset()
-	for _, c := range cards {
-		p.AddCard(c)
-	}
 }
 
 func (g *Gaigel) playerName(idx int) string {

--- a/internal/domain/GinRummy.go
+++ b/internal/domain/GinRummy.go
@@ -832,20 +832,12 @@ func (g *GinRummy) sortAllHands() {
 // sortHand プレイヤーの手札をスート→値の順にソートする
 func (g *GinRummy) sortHand(playerIdx int) {
 	p := g.players[playerIdx]
-	cards := make([]*Card, p.GetCardsSize())
-	for i := 0; i < p.GetCardsSize(); i++ {
-		cards[i] = p.GetCard(i)
-	}
-	sort.Slice(cards, func(i, j int) bool {
-		if cards[i].GetDesign() != cards[j].GetDesign() {
-			return cards[i].GetDesign() < cards[j].GetDesign()
+	sortPlayerHand(p, func(ci, cj *Card) bool {
+		if ci.GetDesign() != cj.GetDesign() {
+			return ci.GetDesign() < cj.GetDesign()
 		}
-		return cards[i].GetValue() < cards[j].GetValue()
+		return ci.GetValue() < cj.GetValue()
 	})
-	p.Reset()
-	for _, c := range cards {
-		p.AddCard(c)
-	}
 }
 
 // playerName プレイヤー名を返す

--- a/internal/domain/GongZhu.go
+++ b/internal/domain/GongZhu.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
-	"sort"
 )
 
 // GongZhuPlayerCnt 拱猪（Gong Zhu）プレイヤー数
@@ -691,20 +690,12 @@ func (g *GongZhu) sortAllHands() {
 
 // gzSortHand プレイヤーの手札をスート→値の順にソートする
 func gzSortHand(p *GongZhuPlayer) {
-	cards := make([]*Card, p.GetCardsSize())
-	for i := 0; i < p.GetCardsSize(); i++ {
-		cards[i] = p.GetCard(i)
-	}
-	sort.Slice(cards, func(i, j int) bool {
-		if cards[i].GetDesign() != cards[j].GetDesign() {
-			return cards[i].GetDesign() < cards[j].GetDesign()
+	sortPlayerHand(p, func(ci, cj *Card) bool {
+		if ci.GetDesign() != cj.GetDesign() {
+			return ci.GetDesign() < cj.GetDesign()
 		}
-		return cards[i].GetValue() < cards[j].GetValue()
+		return ci.GetValue() < cj.GetValue()
 	})
-	p.Reset()
-	for _, c := range cards {
-		p.AddCard(c)
-	}
 }
 
 // playerName プレイヤー名を返す

--- a/internal/domain/HandAndFoot.go
+++ b/internal/domain/HandAndFoot.go
@@ -1312,20 +1312,12 @@ func (g *HandAndFoot) sortAllHands() {
 // sortHand プレイヤーの手札をスート→値の順にソートする
 func (g *HandAndFoot) sortHand(playerIdx int) {
 	p := g.players[playerIdx]
-	cards := make([]*Card, p.GetCardsSize())
-	for i := 0; i < p.GetCardsSize(); i++ {
-		cards[i] = p.GetCard(i)
-	}
-	sort.Slice(cards, func(i, j int) bool {
-		if cards[i].GetDesign() != cards[j].GetDesign() {
-			return cards[i].GetDesign() < cards[j].GetDesign()
+	sortPlayerHand(p, func(ci, cj *Card) bool {
+		if ci.GetDesign() != cj.GetDesign() {
+			return ci.GetDesign() < cj.GetDesign()
 		}
-		return cards[i].GetValue() < cards[j].GetValue()
+		return ci.GetValue() < cj.GetValue()
 	})
-	p.Reset()
-	for _, c := range cards {
-		p.AddCard(c)
-	}
 }
 
 // playerName プレイヤー名を返す

--- a/internal/domain/Hearts.go
+++ b/internal/domain/Hearts.go
@@ -749,20 +749,12 @@ func (h *Hearts) sortAllHands() {
 
 // sortHand プレイヤーの手札をスート→値の順にソートする
 func sortHand(p *HeartsPlayer) {
-	cards := make([]*Card, p.GetCardsSize())
-	for i := 0; i < p.GetCardsSize(); i++ {
-		cards[i] = p.GetCard(i)
-	}
-	sort.Slice(cards, func(i, j int) bool {
-		if cards[i].GetDesign() != cards[j].GetDesign() {
-			return cards[i].GetDesign() < cards[j].GetDesign()
+	sortPlayerHand(p, func(ci, cj *Card) bool {
+		if ci.GetDesign() != cj.GetDesign() {
+			return ci.GetDesign() < cj.GetDesign()
 		}
-		return cards[i].GetValue() < cards[j].GetValue()
+		return ci.GetValue() < cj.GetValue()
 	})
-	p.Reset()
-	for _, c := range cards {
-		p.AddCard(c)
-	}
 }
 
 // cardStr カードの文字列表現

--- a/internal/domain/Jass.go
+++ b/internal/domain/Jass.go
@@ -1075,22 +1075,14 @@ func (g *Jass) sortAllHands() {
 }
 
 func jassSortHand(p *JassPlayer, g *Jass) {
-	cards := make([]*Card, p.GetCardsSize())
-	for i := range p.GetCardsSize() {
-		cards[i] = p.GetCard(i)
-	}
-	sort.Slice(cards, func(i, j int) bool {
-		si := cards[i].GetDesign()
-		sj := cards[j].GetDesign()
+	sortPlayerHand(p, func(ci, cj *Card) bool {
+		si := ci.GetDesign()
+		sj := cj.GetDesign()
 		if si != sj {
 			return si < sj
 		}
-		return g.cardRank(cards[i]) > g.cardRank(cards[j])
+		return g.cardRank(ci) > g.cardRank(cj)
 	})
-	p.Reset()
-	for _, c := range cards {
-		p.AddCard(c)
-	}
 }
 
 func (g *Jass) findHumanIdx() int {

--- a/internal/domain/Macau.go
+++ b/internal/domain/Macau.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
-	"sort"
 )
 
 // MacauPlayerCnt マカオプレイヤー数
@@ -700,20 +699,12 @@ func (g *Macau) sortAllHands() {
 // sortHand プレイヤーの手札をスート→値の順にソートする
 func (g *Macau) sortHand(playerIdx int) {
 	p := g.players[playerIdx]
-	cards := make([]*Card, p.GetCardsSize())
-	for i := 0; i < p.GetCardsSize(); i++ {
-		cards[i] = p.GetCard(i)
-	}
-	sort.Slice(cards, func(i, j int) bool {
-		if cards[i].GetDesign() != cards[j].GetDesign() {
-			return cards[i].GetDesign() < cards[j].GetDesign()
+	sortPlayerHand(p, func(ci, cj *Card) bool {
+		if ci.GetDesign() != cj.GetDesign() {
+			return ci.GetDesign() < cj.GetDesign()
 		}
-		return cards[i].GetValue() < cards[j].GetValue()
+		return ci.GetValue() < cj.GetValue()
 	})
-	p.Reset()
-	for _, c := range cards {
-		p.AddCard(c)
-	}
 }
 
 // playerName プレイヤー名を返す

--- a/internal/domain/Mao.go
+++ b/internal/domain/Mao.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
-	"sort"
 	"strings"
 )
 
@@ -892,20 +891,12 @@ func (g *Mao) sortAllHands() {
 // sortHand プレイヤーの手札をスート→値の順にソートする
 func (g *Mao) sortHand(playerIdx int) {
 	p := g.players[playerIdx]
-	cards := make([]*Card, p.GetCardsSize())
-	for i := 0; i < p.GetCardsSize(); i++ {
-		cards[i] = p.GetCard(i)
-	}
-	sort.Slice(cards, func(i, j int) bool {
-		if cards[i].GetDesign() != cards[j].GetDesign() {
-			return cards[i].GetDesign() < cards[j].GetDesign()
+	sortPlayerHand(p, func(ci, cj *Card) bool {
+		if ci.GetDesign() != cj.GetDesign() {
+			return ci.GetDesign() < cj.GetDesign()
 		}
-		return cards[i].GetValue() < cards[j].GetValue()
+		return ci.GetValue() < cj.GetValue()
 	})
-	p.Reset()
-	for _, c := range cards {
-		p.AddCard(c)
-	}
 }
 
 // playerName プレイヤー名を返す

--- a/internal/domain/Mighty.go
+++ b/internal/domain/Mighty.go
@@ -1373,21 +1373,13 @@ func (m *Mighty) sortAllHands() {
 
 // sortHand プレイヤーの手札をスート→値の順にソートする
 func (m *Mighty) sortHand(p *MightyPlayer) {
-	cards := make([]*Card, p.GetCardsSize())
-	for i := 0; i < p.GetCardsSize(); i++ {
-		cards[i] = p.GetCard(i)
-	}
-	sort.Slice(cards, func(i, j int) bool {
-		di, dj := cards[i].GetDesign(), cards[j].GetDesign()
+	sortPlayerHand(p, func(ci, cj *Card) bool {
+		di, dj := ci.GetDesign(), cj.GetDesign()
 		if di != dj {
 			return di < dj
 		}
-		return cards[i].GetValue() < cards[j].GetValue()
+		return ci.GetValue() < cj.GetValue()
 	})
-	p.Reset()
-	for _, c := range cards {
-		p.AddCard(c)
-	}
 }
 
 // playerName プレイヤー名を返す

--- a/internal/domain/Napoleon.go
+++ b/internal/domain/Napoleon.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
-	"sort"
 )
 
 // NapoleonPlayerCnt ナポレオンプレイヤー数
@@ -1031,21 +1030,13 @@ func (n *Napoleon) sortAllHands() {
 
 // sortHand プレイヤーの手札をスート→値の順にソートする
 func (n *Napoleon) sortHand(p *NapoleonPlayer) {
-	cards := make([]*Card, p.GetCardsSize())
-	for i := 0; i < p.GetCardsSize(); i++ {
-		cards[i] = p.GetCard(i)
-	}
-	sort.Slice(cards, func(i, j int) bool {
-		di, dj := cards[i].GetDesign(), cards[j].GetDesign()
+	sortPlayerHand(p, func(ci, cj *Card) bool {
+		di, dj := ci.GetDesign(), cj.GetDesign()
 		if di != dj {
 			return di < dj
 		}
-		return cards[i].GetValue() < cards[j].GetValue()
+		return ci.GetValue() < cj.GetValue()
 	})
-	p.Reset()
-	for _, c := range cards {
-		p.AddCard(c)
-	}
 }
 
 // playerName プレイヤー名を返す

--- a/internal/domain/NinetyNine.go
+++ b/internal/domain/NinetyNine.go
@@ -682,20 +682,12 @@ func (o *NinetyNine) sortAllHands() {
 
 // ninetyNineSortHand プレイヤーの手札をスート→値の順にソートする
 func ninetyNineSortHand(p *NinetyNinePlayer) {
-	cards := make([]*Card, p.GetCardsSize())
-	for i := 0; i < p.GetCardsSize(); i++ {
-		cards[i] = p.GetCard(i)
-	}
-	sort.Slice(cards, func(i, j int) bool {
-		if cards[i].GetDesign() != cards[j].GetDesign() {
-			return cards[i].GetDesign() < cards[j].GetDesign()
+	sortPlayerHand(p, func(ci, cj *Card) bool {
+		if ci.GetDesign() != cj.GetDesign() {
+			return ci.GetDesign() < cj.GetDesign()
 		}
-		return ninetyNineRankValue(cards[i]) < ninetyNineRankValue(cards[j])
+		return ninetyNineRankValue(ci) < ninetyNineRankValue(cj)
 	})
-	p.Reset()
-	for _, c := range cards {
-		p.AddCard(c)
-	}
 }
 
 // playerName プレイヤー名を返す

--- a/internal/domain/OhHell.go
+++ b/internal/domain/OhHell.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
-	"sort"
 )
 
 // OhHellPlayerCnt オー・ヘルプレイヤー数
@@ -670,20 +669,12 @@ func (o *OhHell) sortAllHands() {
 
 // ohHellSortHand プレイヤーの手札をスート→値の順にソートする
 func ohHellSortHand(p *OhHellPlayer) {
-	cards := make([]*Card, p.GetCardsSize())
-	for i := 0; i < p.GetCardsSize(); i++ {
-		cards[i] = p.GetCard(i)
-	}
-	sort.Slice(cards, func(i, j int) bool {
-		if cards[i].GetDesign() != cards[j].GetDesign() {
-			return cards[i].GetDesign() < cards[j].GetDesign()
+	sortPlayerHand(p, func(ci, cj *Card) bool {
+		if ci.GetDesign() != cj.GetDesign() {
+			return ci.GetDesign() < cj.GetDesign()
 		}
-		return cards[i].GetValue() < cards[j].GetValue()
+		return ci.GetValue() < cj.GetValue()
 	})
-	p.Reset()
-	for _, c := range cards {
-		p.AddCard(c)
-	}
 }
 
 // playerName ���レイヤー名を返す

--- a/internal/domain/PageOne.go
+++ b/internal/domain/PageOne.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
-	"sort"
 )
 
 // PageOnePlayerCnt ページワンプレイヤー数
@@ -538,20 +537,12 @@ func (g *PageOne) sortAllHands() {
 // sortHand プレイヤーの手札をスート→値の順にソートする
 func (g *PageOne) sortHand(playerIdx int) {
 	p := g.players[playerIdx]
-	cards := make([]*Card, p.GetCardsSize())
-	for i := 0; i < p.GetCardsSize(); i++ {
-		cards[i] = p.GetCard(i)
-	}
-	sort.Slice(cards, func(i, j int) bool {
-		if cards[i].GetDesign() != cards[j].GetDesign() {
-			return cards[i].GetDesign() < cards[j].GetDesign()
+	sortPlayerHand(p, func(ci, cj *Card) bool {
+		if ci.GetDesign() != cj.GetDesign() {
+			return ci.GetDesign() < cj.GetDesign()
 		}
-		return cards[i].GetValue() < cards[j].GetValue()
+		return ci.GetValue() < cj.GetValue()
 	})
-	p.Reset()
-	for _, c := range cards {
-		p.AddCard(c)
-	}
 }
 
 // playerName プレイヤー名を返す

--- a/internal/domain/Pan.go
+++ b/internal/domain/Pan.go
@@ -739,20 +739,12 @@ func (g *Pan) sortAllHands() {
 
 func (g *Pan) sortHand(playerIdx int) {
 	p := g.players[playerIdx]
-	cards := make([]*Card, p.GetCardsSize())
-	for i := 0; i < p.GetCardsSize(); i++ {
-		cards[i] = p.GetCard(i)
-	}
-	sort.Slice(cards, func(i, j int) bool {
-		if cards[i].GetDesign() != cards[j].GetDesign() {
-			return cards[i].GetDesign() < cards[j].GetDesign()
+	sortPlayerHand(p, func(ci, cj *Card) bool {
+		if ci.GetDesign() != cj.GetDesign() {
+			return ci.GetDesign() < cj.GetDesign()
 		}
-		return cards[i].GetValue() < cards[j].GetValue()
+		return ci.GetValue() < cj.GetValue()
 	})
-	p.Reset()
-	for _, c := range cards {
-		p.AddCard(c)
-	}
 }
 
 func (g *Pan) playerName(idx int) string {

--- a/internal/domain/Pitch.go
+++ b/internal/domain/Pitch.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
-	"sort"
 )
 
 // PitchPlayerCnt ピッチプレイヤー数 (4人, シングルハンド/カットスロート)
@@ -764,20 +763,12 @@ func (p *Pitch) sortAllHands() {
 }
 
 func pitchSortHand(pl *PitchPlayer) {
-	cards := make([]*Card, pl.GetCardsSize())
-	for i := 0; i < pl.GetCardsSize(); i++ {
-		cards[i] = pl.GetCard(i)
-	}
-	sort.Slice(cards, func(i, j int) bool {
-		if cards[i].GetDesign() != cards[j].GetDesign() {
-			return cards[i].GetDesign() < cards[j].GetDesign()
+	sortPlayerHand(pl, func(ci, cj *Card) bool {
+		if ci.GetDesign() != cj.GetDesign() {
+			return ci.GetDesign() < cj.GetDesign()
 		}
-		return pitchRankValue(cards[i].GetValue()) < pitchRankValue(cards[j].GetValue())
+		return pitchRankValue(ci.GetValue()) < pitchRankValue(cj.GetValue())
 	})
-	pl.Reset()
-	for _, c := range cards {
-		pl.AddCard(c)
-	}
 }
 
 func (p *Pitch) playerName(idx int) string {

--- a/internal/domain/Prsi.go
+++ b/internal/domain/Prsi.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
-	"sort"
 )
 
 // PrsiPlayerCnt プルシープレイヤー数 (1 human + 3 CPU)
@@ -438,20 +437,12 @@ func (g *Prsi) sortAllHands() {
 // sortHand プレイヤーの手札をスート→値の順にソートする
 func (g *Prsi) sortHand(playerIdx int) {
 	p := g.players[playerIdx]
-	cards := make([]*Card, p.GetCardsSize())
-	for i := 0; i < p.GetCardsSize(); i++ {
-		cards[i] = p.GetCard(i)
-	}
-	sort.Slice(cards, func(i, j int) bool {
-		if cards[i].GetDesign() != cards[j].GetDesign() {
-			return cards[i].GetDesign() < cards[j].GetDesign()
+	sortPlayerHand(p, func(ci, cj *Card) bool {
+		if ci.GetDesign() != cj.GetDesign() {
+			return ci.GetDesign() < cj.GetDesign()
 		}
-		return cards[i].GetValue() < cards[j].GetValue()
+		return ci.GetValue() < cj.GetValue()
 	})
-	p.Reset()
-	for _, c := range cards {
-		p.AddCard(c)
-	}
 }
 
 // playerName プレイヤー名を返す

--- a/internal/domain/Rummy500.go
+++ b/internal/domain/Rummy500.go
@@ -678,20 +678,12 @@ func (g *Rummy500) sortAllHands() {
 
 func (g *Rummy500) sortHand(playerIdx int) {
 	p := g.players[playerIdx]
-	cards := make([]*Card, p.GetCardsSize())
-	for i := 0; i < p.GetCardsSize(); i++ {
-		cards[i] = p.GetCard(i)
-	}
-	sort.Slice(cards, func(i, j int) bool {
-		if cards[i].GetDesign() != cards[j].GetDesign() {
-			return cards[i].GetDesign() < cards[j].GetDesign()
+	sortPlayerHand(p, func(ci, cj *Card) bool {
+		if ci.GetDesign() != cj.GetDesign() {
+			return ci.GetDesign() < cj.GetDesign()
 		}
-		return cards[i].GetValue() < cards[j].GetValue()
+		return ci.GetValue() < cj.GetValue()
 	})
-	p.Reset()
-	for _, c := range cards {
-		p.AddCard(c)
-	}
 }
 
 func (g *Rummy500) playerName(idx int) string {

--- a/internal/domain/Samba.go
+++ b/internal/domain/Samba.go
@@ -1635,20 +1635,12 @@ func (g *Samba) sortAllHands() {
 // sortHand プレイヤーの手札をスート→値の順にソートする
 func (g *Samba) sortHand(playerIdx int) {
 	p := g.players[playerIdx]
-	cards := make([]*Card, p.GetCardsSize())
-	for i := 0; i < p.GetCardsSize(); i++ {
-		cards[i] = p.GetCard(i)
-	}
-	sort.Slice(cards, func(i, j int) bool {
-		if cards[i].GetDesign() != cards[j].GetDesign() {
-			return cards[i].GetDesign() < cards[j].GetDesign()
+	sortPlayerHand(p, func(ci, cj *Card) bool {
+		if ci.GetDesign() != cj.GetDesign() {
+			return ci.GetDesign() < cj.GetDesign()
 		}
-		return cards[i].GetValue() < cards[j].GetValue()
+		return ci.GetValue() < cj.GetValue()
 	})
-	p.Reset()
-	for _, c := range cards {
-		p.AddCard(c)
-	}
 }
 
 // playerName プレイヤー名を返す

--- a/internal/domain/Schnapsen.go
+++ b/internal/domain/Schnapsen.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"sort"
 )
 
 // SchnapsenPlayerCnt シュナプセンのプレイヤー数 (2人固定)
@@ -766,26 +765,18 @@ func (s *Schnapsen) sortAllHands() {
 
 // sortHand プレイヤーの手札をスート (トランプ最後) → ランク でソートする
 func (s *Schnapsen) sortHand(p *SchnapsenPlayer) {
-	cards := make([]*Card, p.GetCardsSize())
-	for i := 0; i < p.GetCardsSize(); i++ {
-		cards[i] = p.GetCard(i)
-	}
 	trumpSuit := s.trumpSuit
-	sort.Slice(cards, func(i, j int) bool {
-		iTrump := cards[i].GetDesign() == trumpSuit
-		jTrump := cards[j].GetDesign() == trumpSuit
+	sortPlayerHand(p, func(ci, cj *Card) bool {
+		iTrump := ci.GetDesign() == trumpSuit
+		jTrump := cj.GetDesign() == trumpSuit
 		if iTrump != jTrump {
 			return !iTrump
 		}
-		if cards[i].GetDesign() != cards[j].GetDesign() {
-			return cards[i].GetDesign() < cards[j].GetDesign()
+		if ci.GetDesign() != cj.GetDesign() {
+			return ci.GetDesign() < cj.GetDesign()
 		}
-		return SchnapsenRankOrder(cards[i]) < SchnapsenRankOrder(cards[j])
+		return SchnapsenRankOrder(ci) < SchnapsenRankOrder(cj)
 	})
-	p.Reset()
-	for _, c := range cards {
-		p.AddCard(c)
-	}
 }
 
 // playerName プレイヤー名を返す (ログ用)

--- a/internal/domain/SevenBridge.go
+++ b/internal/domain/SevenBridge.go
@@ -935,20 +935,12 @@ func (g *SevenBridge) sortAllHands() {
 
 func (g *SevenBridge) sortHand(playerIdx int) {
 	p := g.players[playerIdx]
-	cards := make([]*Card, p.GetCardsSize())
-	for i := 0; i < p.GetCardsSize(); i++ {
-		cards[i] = p.GetCard(i)
-	}
-	sort.Slice(cards, func(i, j int) bool {
-		if cards[i].GetDesign() != cards[j].GetDesign() {
-			return cards[i].GetDesign() < cards[j].GetDesign()
+	sortPlayerHand(p, func(ci, cj *Card) bool {
+		if ci.GetDesign() != cj.GetDesign() {
+			return ci.GetDesign() < cj.GetDesign()
 		}
-		return cards[i].GetValue() < cards[j].GetValue()
+		return ci.GetValue() < cj.GetValue()
 	})
-	p.Reset()
-	for _, c := range cards {
-		p.AddCard(c)
-	}
 }
 
 func (g *SevenBridge) playerName(idx int) string {

--- a/internal/domain/Sheepshead.go
+++ b/internal/domain/Sheepshead.go
@@ -668,21 +668,13 @@ func (g *Sheepshead) sortAllHands() {
 
 // sheepsheadSortHand 手札を切り札を先頭に、スートごと強い順にソートする。
 func sheepsheadSortHand(p *SheepsheadPlayer) {
-	cards := make([]*Card, p.GetCardsSize())
-	for i := 0; i < p.GetCardsSize(); i++ {
-		cards[i] = p.GetCard(i)
-	}
-	sort.Slice(cards, func(i, j int) bool {
-		si, sj := sheepsheadSuitID(cards[i]), sheepsheadSuitID(cards[j])
+	sortPlayerHand(p, func(ci, cj *Card) bool {
+		si, sj := sheepsheadSuitID(ci), sheepsheadSuitID(cj)
 		if si != sj {
 			return si < sj
 		}
-		return sheepsheadStrength(cards[i]) > sheepsheadStrength(cards[j])
+		return sheepsheadStrength(ci) > sheepsheadStrength(cj)
 	})
-	p.Reset()
-	for _, c := range cards {
-		p.AddCard(c)
-	}
 }
 
 // playerName プレイヤー名を返す。

--- a/internal/domain/Skat.go
+++ b/internal/domain/Skat.go
@@ -1301,21 +1301,13 @@ func (s *Skat) sortAllHands() {
 
 // sortHand sorts the player's hand by suit then value.
 func (s *Skat) sortHand(p *SkatPlayer) {
-	cards := make([]*Card, p.GetCardsSize())
-	for i := 0; i < p.GetCardsSize(); i++ {
-		cards[i] = p.GetCard(i)
-	}
-	sort.Slice(cards, func(i, j int) bool {
-		di, dj := cards[i].GetDesign(), cards[j].GetDesign()
+	sortPlayerHand(p, func(ci, cj *Card) bool {
+		di, dj := ci.GetDesign(), cj.GetDesign()
 		if di != dj {
 			return di < dj
 		}
-		return cards[i].GetValue() < cards[j].GetValue()
+		return ci.GetValue() < cj.GetValue()
 	})
-	p.Reset()
-	for _, c := range cards {
-		p.AddCard(c)
-	}
 }
 
 // --- Getters / setters ---

--- a/internal/domain/Spades.go
+++ b/internal/domain/Spades.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
-	"sort"
 )
 
 // SpadesPlayerCnt スペードプレイヤー数
@@ -646,20 +645,12 @@ func (s *Spades) sortAllHands() {
 
 // spadeSortHand プレイヤーの手札をスート→値の順にソートする
 func spadeSortHand(p *SpadesPlayer) {
-	cards := make([]*Card, p.GetCardsSize())
-	for i := 0; i < p.GetCardsSize(); i++ {
-		cards[i] = p.GetCard(i)
-	}
-	sort.Slice(cards, func(i, j int) bool {
-		if cards[i].GetDesign() != cards[j].GetDesign() {
-			return cards[i].GetDesign() < cards[j].GetDesign()
+	sortPlayerHand(p, func(ci, cj *Card) bool {
+		if ci.GetDesign() != cj.GetDesign() {
+			return ci.GetDesign() < cj.GetDesign()
 		}
-		return cards[i].GetValue() < cards[j].GetValue()
+		return ci.GetValue() < cj.GetValue()
 	})
-	p.Reset()
-	for _, c := range cards {
-		p.AddCard(c)
-	}
 }
 
 // playerName プレイヤー名を返す

--- a/internal/domain/Tarneeb.go
+++ b/internal/domain/Tarneeb.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
-	"sort"
 )
 
 // TarneebHandSize 各プレイヤーの手札枚数
@@ -723,22 +722,14 @@ func (t *Tarneeb) sortAllHands() {
 
 // tarneebSortHand プレイヤーの手札をスート→値の順にソートする
 func tarneebSortHand(p *TarneebPlayer) {
-	cards := make([]*Card, p.GetCardsSize())
-	for i := 0; i < p.GetCardsSize(); i++ {
-		cards[i] = p.GetCard(i)
-	}
-	sort.Slice(cards, func(i, j int) bool {
-		if cards[i].GetDesign() != cards[j].GetDesign() {
-			return cards[i].GetDesign() < cards[j].GetDesign()
+	sortPlayerHand(p, func(ci, cj *Card) bool {
+		if ci.GetDesign() != cj.GetDesign() {
+			return ci.GetDesign() < cj.GetDesign()
 		}
 		// Aces sort to the right (largest) so the hand display matches Tarneeb's
 		// A > K > … ranking.
-		return tarneebRank(cards[i].GetValue()) < tarneebRank(cards[j].GetValue())
+		return tarneebRank(ci.GetValue()) < tarneebRank(cj.GetValue())
 	})
-	p.Reset()
-	for _, c := range cards {
-		p.AddCard(c)
-	}
 }
 
 // playerName プレイヤー名を返す

--- a/internal/domain/Tonk.go
+++ b/internal/domain/Tonk.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
-	"sort"
 	"time"
 )
 
@@ -719,20 +718,12 @@ func (g *Tonk) sortAllHands() {
 // sortHand プレイヤーの手札をスート→値の順にソートする
 func (g *Tonk) sortHand(playerIdx int) {
 	p := g.players[playerIdx]
-	cards := make([]*Card, p.GetCardsSize())
-	for i := 0; i < p.GetCardsSize(); i++ {
-		cards[i] = p.GetCard(i)
-	}
-	sort.Slice(cards, func(i, j int) bool {
-		if cards[i].GetDesign() != cards[j].GetDesign() {
-			return cards[i].GetDesign() < cards[j].GetDesign()
+	sortPlayerHand(p, func(ci, cj *Card) bool {
+		if ci.GetDesign() != cj.GetDesign() {
+			return ci.GetDesign() < cj.GetDesign()
 		}
-		return cards[i].GetValue() < cards[j].GetValue()
+		return ci.GetValue() < cj.GetValue()
 	})
-	p.Reset()
-	for _, c := range cards {
-		p.AddCard(c)
-	}
 }
 
 // playerName プレイヤー名を返す

--- a/internal/domain/Tressette.go
+++ b/internal/domain/Tressette.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
-	"sort"
 )
 
 // TressettePlayerCnt トレセッテのプレイヤー数
@@ -435,20 +434,12 @@ func (g *Tressette) sortAllHands() {
 
 // tressetteSortHand プレイヤーの手札をスート→強さの順にソートする
 func tressetteSortHand(p *TressettePlayer) {
-	cards := make([]*Card, p.GetCardsSize())
-	for i := 0; i < p.GetCardsSize(); i++ {
-		cards[i] = p.GetCard(i)
-	}
-	sort.Slice(cards, func(i, j int) bool {
-		if cards[i].GetDesign() != cards[j].GetDesign() {
-			return cards[i].GetDesign() < cards[j].GetDesign()
+	sortPlayerHand(p, func(ci, cj *Card) bool {
+		if ci.GetDesign() != cj.GetDesign() {
+			return ci.GetDesign() < cj.GetDesign()
 		}
-		return tressetteStrength(cards[i].GetValue()) < tressetteStrength(cards[j].GetValue())
+		return tressetteStrength(ci.GetValue()) < tressetteStrength(cj.GetValue())
 	})
-	p.Reset()
-	for _, c := range cards {
-		p.AddCard(c)
-	}
 }
 
 // playerName プレイヤー名を返す

--- a/internal/domain/TwoTenJack.go
+++ b/internal/domain/TwoTenJack.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
-	"sort"
 )
 
 // TwoTenJackPlayerCnt ツーテンジャックプレイヤー数
@@ -540,20 +539,12 @@ func (t *TwoTenJack) sortAllHands() {
 
 // twoTenJackSortHand プレイヤーの手札をスート→値の順にソートする
 func twoTenJackSortHand(p *TwoTenJackPlayer) {
-	cards := make([]*Card, p.GetCardsSize())
-	for i := 0; i < p.GetCardsSize(); i++ {
-		cards[i] = p.GetCard(i)
-	}
-	sort.Slice(cards, func(i, j int) bool {
-		if cards[i].GetDesign() != cards[j].GetDesign() {
-			return cards[i].GetDesign() < cards[j].GetDesign()
+	sortPlayerHand(p, func(ci, cj *Card) bool {
+		if ci.GetDesign() != cj.GetDesign() {
+			return ci.GetDesign() < cj.GetDesign()
 		}
-		return cards[i].GetValue() < cards[j].GetValue()
+		return ci.GetValue() < cj.GetValue()
 	})
-	p.Reset()
-	for _, c := range cards {
-		p.AddCard(c)
-	}
 }
 
 // playerName プレイヤー名を返す

--- a/internal/domain/Whist.go
+++ b/internal/domain/Whist.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
-	"sort"
 )
 
 // WhistHandSize 各プレイヤーの手札枚数
@@ -510,20 +509,12 @@ func (w *Whist) sortAllHands() {
 
 // whistSortHand プレイヤーの手札をスート→値の順にソートする
 func whistSortHand(p *WhistPlayer) {
-	cards := make([]*Card, p.GetCardsSize())
-	for i := 0; i < p.GetCardsSize(); i++ {
-		cards[i] = p.GetCard(i)
-	}
-	sort.Slice(cards, func(i, j int) bool {
-		if cards[i].GetDesign() != cards[j].GetDesign() {
-			return cards[i].GetDesign() < cards[j].GetDesign()
+	sortPlayerHand(p, func(ci, cj *Card) bool {
+		if ci.GetDesign() != cj.GetDesign() {
+			return ci.GetDesign() < cj.GetDesign()
 		}
-		return cards[i].GetValue() < cards[j].GetValue()
+		return ci.GetValue() < cj.GetValue()
 	})
-	p.Reset()
-	for _, c := range cards {
-		p.AddCard(c)
-	}
 }
 
 // playerName プレイヤー名を返す

--- a/internal/domain/Wizard.go
+++ b/internal/domain/Wizard.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
-	"sort"
 )
 
 // WizardPlayerCnt ウィザードプレイヤー数
@@ -749,20 +748,12 @@ func (o *Wizard) sortAllHands() {
 
 // wizardSortHand プレイヤーの手札をスート→値の順にソートする
 func wizardSortHand(p *WizardPlayer) {
-	cards := make([]*Card, p.GetCardsSize())
-	for i := 0; i < p.GetCardsSize(); i++ {
-		cards[i] = p.GetCard(i)
-	}
-	sort.Slice(cards, func(i, j int) bool {
-		if cards[i].GetDesign() != cards[j].GetDesign() {
-			return cards[i].GetDesign() < cards[j].GetDesign()
+	sortPlayerHand(p, func(ci, cj *Card) bool {
+		if ci.GetDesign() != cj.GetDesign() {
+			return ci.GetDesign() < cj.GetDesign()
 		}
-		return cards[i].GetValue() < cards[j].GetValue()
+		return ci.GetValue() < cj.GetValue()
 	})
-	p.Reset()
-	for _, c := range cards {
-		p.AddCard(c)
-	}
 }
 
 // wizardCardStr 棋譜表示用のカード文字列 (ウィザード/ジェスターを含む)。

--- a/internal/domain/player_helpers.go
+++ b/internal/domain/player_helpers.go
@@ -1,5 +1,32 @@
 package domain
 
+import "sort"
+
+// handHolder is the minimal interface for a player whose hand can be sorted in
+// place: enumerate the cards, clear the hand, and re-add them.
+type handHolder interface {
+	GetCardsSize() int
+	GetCard(int) *Card
+	Reset()
+	AddCard(*Card)
+}
+
+// sortPlayerHand sorts p's hand by the given comparator, folding the
+// "extract cards → sort.Slice → Reset → re-add" boilerplate that was duplicated
+// across ~80 games (issue #4298) into one place. less reports whether card ci
+// should sort before card cj.
+func sortPlayerHand[T handHolder](p T, less func(ci, cj *Card) bool) {
+	cards := make([]*Card, p.GetCardsSize())
+	for i := 0; i < p.GetCardsSize(); i++ {
+		cards[i] = p.GetCard(i)
+	}
+	sort.Slice(cards, func(i, j int) bool { return less(cards[i], cards[j]) })
+	p.Reset()
+	for _, c := range cards {
+		p.AddCard(c)
+	}
+}
+
 // finishable is the minimal interface satisfied by OldMaidPlayer,
 // SevensPlayer, DaifugoPlayer, etc.
 type finishable interface {

--- a/internal/domain/player_helpers_internal_test.go
+++ b/internal/domain/player_helpers_internal_test.go
@@ -142,3 +142,35 @@ func TestCountPlayers_SomeMatch(t *testing.T) {
 	got := countPlayers(players, func(p *OldMaidPlayer) bool { return !p.GetIsFinished() })
 	assert.Equal(t, 2, got)
 }
+
+// --- sortPlayerHand tests ---
+
+// sortTestHand is a minimal handHolder for exercising sortPlayerHand
+// independently of any concrete game player type.
+type sortTestHand struct{ cards []*Card }
+
+func (h *sortTestHand) GetCardsSize() int   { return len(h.cards) }
+func (h *sortTestHand) GetCard(i int) *Card { return h.cards[i] }
+func (h *sortTestHand) Reset()              { h.cards = nil }
+func (h *sortTestHand) AddCard(c *Card)     { h.cards = append(h.cards, c) }
+
+func TestSortPlayerHand(t *testing.T) {
+	h := &sortTestHand{cards: []*Card{
+		NewCard(1, 5, false),
+		NewCard(1, 2, false),
+		NewCard(1, 9, false),
+	}}
+	sortPlayerHand(h, func(ci, cj *Card) bool { return ci.GetValue() < cj.GetValue() })
+
+	// No cards lost in the Reset/re-add round-trip.
+	assert.Equal(t, 3, h.GetCardsSize())
+	assert.Equal(t, 2, h.GetCard(0).GetValue())
+	assert.Equal(t, 5, h.GetCard(1).GetValue())
+	assert.Equal(t, 9, h.GetCard(2).GetValue())
+}
+
+func TestSortPlayerHand_Empty(t *testing.T) {
+	h := &sortTestHand{}
+	sortPlayerHand(h, func(ci, cj *Card) bool { return ci.GetValue() < cj.GetValue() })
+	assert.Equal(t, 0, h.GetCardsSize())
+}


### PR DESCRIPTION
## Summary

41 games duplicated the same hand-sort skeleton — extract the cards to a slice, `sort.Slice` by a comparator, `Reset()` the hand, and re-`AddCard` — differing only in the comparator (issue #4298). It's a risky pattern: getting the `Reset`/re-add order wrong silently drops the whole hand.

Add `sortPlayerHand[T handHolder](p T, less func(ci, cj *Card) bool)` to the **untagged** `player_helpers.go` (so every WASM worker includes it), and have each game pass just its comparator closure. Each `sortHand` drops from ~15 lines to ~4.

## Transform notes

- Comparator params are named **`ci`/`cj`** (not `a`/`b`) to avoid colliding with single-letter game receivers — e.g. Belote's receiver is `b`, so `func(a, b *Card)` would shadow it and break `b.cardRank(...)`.
- Games with an extra local before the sort (e.g. `trumpSuit := b.trumpSuit`) keep that statement before the `sortPlayerHand` call.

## Left as-is (genuinely different)

- Games already using the shared `sortCards()` helper (ContractRummy et al.) — already DRY.
- **Pinochle** — sorts *indices* and calls `player.ReorderCards`, not extract/re-add.
- Local **hand-evaluation** sorts in the badugi / daifugo / poker solvers — they sort a working slice, not a player's display hand.

## Test plan

- [x] `go test -tags test ./internal/domain/` — full suite green; added `TestSortPlayerHand` (values sorted, no cards lost in the Reset/re-add round-trip) + empty-hand case
- [x] `golangci-lint run ./internal/domain/` — 0 issues
- [ ] CI green (incl. all tinygo worker builds)

Closes #4298