### PR TITLE
refactor(frontend): extract useCommunityPokerGame orchestration hook

### DIFF
--- a/frontend/src/api/gameApi.ts
+++ b/frontend/src/api/gameApi.ts
@@ -782,6 +782,9 @@ function createHoldemLikeApi<T, C = HoldemConfigInput>(game: string) {
   };
 }
 
+/** The exec signature shared by every `createHoldemLikeApi` client (issue #4301). */
+export type HoldemLikeExec<T> = ReturnType<typeof createHoldemLikeApi<T>>['exec'];
+
 /** API client for the Texas Hold'em /holdem/exec endpoint. */
 export const holdemApi = createHoldemLikeApi<HoldemResponse>('holdem');
 

--- a/frontend/src/hooks/useCommunityPokerGame.test.ts
+++ b/frontend/src/hooks/useCommunityPokerGame.test.ts
@@ -1,0 +1,86 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { omahaApi } from '../api/gameApi';
+import { SoundProvider } from '../providers/SoundProvider';
+import type { OmahaResponse } from '../types/card';
+import { OmahaPhase } from '../types/phases';
+import { OMAHA_HELP, parseOmahaCommand } from '../utils/cli/commands/omahaCommands';
+import { formatOmahaState } from '../utils/cli/formatters/omahaFormatter';
+import { useCommunityPokerGame } from './useCommunityPokerGame';
+
+vi.mock('../api/gameApi', () => ({
+  omahaApi: { exec: vi.fn() },
+  actionLogApi: { omaha: vi.fn() },
+}));
+
+const mockExec = vi.mocked(omahaApi.exec);
+
+// Minimal state exercising the hook's derived-value logic (it reads only a
+// handful of fields); cast because building the full OmahaResponse is noise.
+function flopState(currentTurn: number): OmahaResponse {
+  return {
+    players: [
+      { id: 0, isHuman: true, folded: false, allIn: false, currentBet: 0 },
+      { id: 1, isHuman: false, folded: false, allIn: false, currentBet: 0 },
+    ],
+    communityCards: [],
+    phase: OmahaPhase.FLOP,
+    currentTurn,
+    lastBet: 0,
+    minRaise: 20,
+    muckAvailable: false,
+    rebuyPhaseType: 0,
+    rebuyCounts: [],
+  } as unknown as OmahaResponse;
+}
+
+const config = {
+  game: 'omaha',
+  exec: omahaApi.exec,
+  phaseKeys: { [OmahaPhase.FLOP]: 'flop' },
+  cli: { parseCommand: parseOmahaCommand, formatResponse: formatOmahaState, helpText: OMAHA_HELP },
+} as const;
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+  return createElement(QueryClientProvider, { client: queryClient }, createElement(SoundProvider, null, children));
+}
+
+describe('useCommunityPokerGame', () => {
+  beforeEach(() => {
+    mockExec.mockReset();
+    mockExec.mockResolvedValue(flopState(0));
+  });
+
+  it('dispatches a reset on mount and exposes the returned state', async () => {
+    const { result } = renderHook(() => useCommunityPokerGame(config), { wrapper });
+    await waitFor(() => expect(mockExec).toHaveBeenCalled());
+    expect(mockExec.mock.calls[0]?.[0]).toBe('reset');
+    await waitFor(() => expect(result.current.state).not.toBeNull());
+  });
+
+  it('handleManualReset dispatches reset with the meta-AI flag', async () => {
+    const { result } = renderHook(() => useCommunityPokerGame(config), { wrapper });
+    await waitFor(() => expect(result.current.state).not.toBeNull());
+    mockExec.mockClear();
+    result.current.handleManualReset();
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined, { cpuMetaAI: false }));
+  });
+
+  it('derives canAct true on the human turn during an active phase', async () => {
+    const { result } = renderHook(() => useCommunityPokerGame(config), { wrapper });
+    await waitFor(() => expect(result.current.state).not.toBeNull());
+    expect(result.current.isActive).toBe(true);
+    expect(result.current.isShowdown).toBe(false);
+    expect(result.current.canAct).toBe(true);
+  });
+
+  it('derives canAct false when it is not the human turn', async () => {
+    mockExec.mockResolvedValue(flopState(1));
+    const { result } = renderHook(() => useCommunityPokerGame(config), { wrapper });
+    await waitFor(() => expect(result.current.state).not.toBeNull());
+    expect(result.current.canAct).toBe(false);
+  });
+});

--- a/frontend/src/hooks/useCommunityPokerGame.ts
+++ b/frontend/src/hooks/useCommunityPokerGame.ts
@@ -1,0 +1,190 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { HoldemLikeExec } from '../api/gameApi';
+import { useSound } from '../providers/SoundProvider';
+import type { OmahaResponse } from '../types/card';
+import { OmahaPhase, OmahaRebuyPhaseType } from '../types/phases';
+import type { CliGameConfig } from '../utils/cli/types';
+import { useActionKeyboardNav } from './useActionKeyboardNav';
+import { useCardDimensions, useIsLargeDesktop, useIsMobile } from './useCardDimensions';
+import { useCliGame } from './useCliGame';
+import { useCliMode } from './useCliMode';
+import { useGameApi } from './useGameApi';
+import { useGameHint } from './useGameHint';
+import { useGamePageSetup } from './useGamePageSetup';
+import { useMountReset } from './useMountReset';
+import { usePhaseNames } from './usePhaseNames';
+
+/** The exec function shared by every community-poker game API. */
+type CommunityPokerExec = HoldemLikeExec<OmahaResponse>;
+
+/** Community-card poker games sharing the Hold'em response shape + phase enum. */
+export type CommunityPokerName = 'holdem' | 'omaha' | 'omahahilo' | 'bigo' | 'bigohilo' | 'shortdeck';
+
+/** Config for {@link useCommunityPokerGame}. */
+export interface CommunityPokerGameConfig {
+  /** Game key (i18n namespace, hint registry, CLI mode, useGamePageSetup). */
+  game: CommunityPokerName;
+  /** The game's REST exec function (e.g. `omahaApi.exec`). */
+  exec: CommunityPokerExec;
+  /** Phase → i18n key map for `usePhaseNames`. */
+  phaseKeys: Readonly<Record<number, string>>;
+  /** CLI command parser / formatter / help for the terminal fallback. */
+  cli: Pick<
+    CliGameConfig<OmahaResponse, Parameters<CommunityPokerExec>>,
+    'parseCommand' | 'formatResponse' | 'helpText'
+  >;
+}
+
+/**
+ * Shared orchestration for the community-card poker pages (Omaha, Big O, their
+ * Hi-Lo variants, Hold'em, Short Deck) — issue #4301. Centralizes the identical
+ * ~120 lines each page copied: server state, bet-amount / learning / meta-AI
+ * state, the meta-AI elapsed-time tracking, CLI wiring, mount reset, keyboard
+ * shortcuts, and the derived phase/turn booleans the JSX branches on. Each page
+ * still supplies its own layout (tutorial prefixes, hole-card count, Hi-Lo
+ * display, best-five evaluator differ by variant).
+ */
+export function useCommunityPokerGame(config: CommunityPokerGameConfig) {
+  const { game, exec, phaseKeys, cli } = config;
+
+  const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
+    useGamePageSetup(game);
+  const phaseNames = usePhaseNames(game, phaseKeys);
+  const { cardWidth } = useCardDimensions();
+  const { playSound } = useSound();
+  const isMobile = useIsMobile();
+  const isLargeDesktop = useIsLargeDesktop();
+  const { state, loading, error, exec: execApi, retry } = useGameApi(exec);
+  const [betAmount, setBetAmount] = useState(20);
+  const [learningMode, setLearningMode] = useState(false);
+  const [cpuMetaAI, setCpuMetaAI] = useState(false);
+  const { hint, hintEnabled, setHintEnabled } = useGameHint(game, state);
+  const turnStartRef = useRef(0);
+
+  const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode(game);
+  const cliConfig: CliGameConfig<OmahaResponse, Parameters<CommunityPokerExec>> = useMemo<
+    CliGameConfig<OmahaResponse, Parameters<CommunityPokerExec>>
+  >(
+    () => ({
+      gameName: game,
+      parseCommand: cli.parseCommand,
+      formatResponse: cli.formatResponse,
+      helpText: cli.helpText,
+    }),
+    [game, cli.parseCommand, cli.formatResponse, cli.helpText],
+  );
+  const { handleCommand } = useCliGame(execApi, cliConfig, state, { addInput, addOutput, addError, clearLog });
+
+  useMountReset(execApi);
+
+  const handleManualReset = useCallback(() => {
+    hideActionLog();
+    void execApi('reset', undefined, { cpuMetaAI });
+  }, [execApi, hideActionLog, cpuMetaAI]);
+
+  useEffect(() => {
+    if (state?.minRaise && state.minRaise > 0) {
+      setBetAmount(state.minRaise);
+    } else if (state) {
+      setBetAmount(20);
+    }
+  }, [state]);
+
+  useEffect(() => {
+    if (state && state.currentTurn === state.players?.find((p) => p.isHuman)?.id) {
+      turnStartRef.current = Date.now();
+    }
+  }, [state]);
+
+  const getElapsed = useCallback(() => {
+    if (!cpuMetaAI || turnStartRef.current === 0) return 0;
+    const elapsed = Date.now() - turnStartRef.current;
+    turnStartRef.current = 0;
+    return elapsed;
+  }, [cpuMetaAI]);
+
+  const phase = state?.phase ?? OmahaPhase.INIT;
+  const isActive = phase >= OmahaPhase.PRE_FLOP && phase <= OmahaPhase.RIVER;
+  const isShowdown = phase === OmahaPhase.SHOWDOWN || phase === OmahaPhase.END;
+  const humanPlayer = state?.players?.find((p) => p.isHuman);
+  const humanFolded = humanPlayer?.folded ?? false;
+  const humanAllIn = humanPlayer?.allIn ?? false;
+  const canAct = isActive && !humanFolded && !humanAllIn && state?.currentTurn === humanPlayer?.id;
+  const hasOutstandingBet = (state?.lastBet ?? 0) > (humanPlayer?.currentBet ?? 0);
+  const minRaise = state?.minRaise ?? 0;
+  const isMuckPhase = phase === OmahaPhase.SHOWDOWN && state?.muckAvailable === true;
+  const isRebuyPhase = phase === OmahaPhase.REBUY && state?.rebuyPhaseType === OmahaRebuyPhaseType.REBUY;
+  const isAddonPhase = phase === OmahaPhase.REBUY && state?.rebuyPhaseType === OmahaRebuyPhaseType.ADDON;
+  const humanIdx = state?.players?.findIndex((p) => p.isHuman) ?? 0;
+  const humanRebuyCount = state?.rebuyCounts?.[humanIdx] ?? 0;
+  const cpuPlayers = useMemo(() => state?.players?.filter((player) => !player.isHuman) ?? [], [state?.players]);
+
+  const actionBindings = useMemo(
+    () => [
+      { key: 'c', action: () => execApi('call', undefined, undefined, getElapsed()), enabled: hasOutstandingBet },
+      {
+        key: 'r',
+        action: () =>
+          hasOutstandingBet
+            ? execApi('raise', betAmount, undefined, getElapsed())
+            : execApi('bet', betAmount, undefined, getElapsed()),
+      },
+      { key: 'k', action: () => execApi('check', undefined, undefined, getElapsed()), enabled: !hasOutstandingBet },
+      { key: 'f', action: () => execApi('fold', undefined, undefined, getElapsed()) },
+      { key: 'a', action: () => execApi('allin', undefined, undefined, getElapsed()) },
+    ],
+    [execApi, hasOutstandingBet, betAmount, getElapsed],
+  );
+  useActionKeyboardNav({ bindings: actionBindings, enabled: canAct && !loading });
+
+  return {
+    t,
+    tc,
+    actionLog,
+    showActionLog,
+    hideActionLog,
+    confirmOpen,
+    requestConfirm,
+    confirmReset,
+    cancelReset,
+    phaseNames,
+    cardWidth,
+    playSound,
+    isMobile,
+    isLargeDesktop,
+    state,
+    loading,
+    error,
+    execApi,
+    retry,
+    betAmount,
+    setBetAmount,
+    learningMode,
+    setLearningMode,
+    cpuMetaAI,
+    setCpuMetaAI,
+    hint,
+    hintEnabled,
+    setHintEnabled,
+    getElapsed,
+    cliEnabled,
+    toggleCli,
+    logEntries,
+    handleCommand,
+    handleManualReset,
+    phase,
+    isActive,
+    isShowdown,
+    humanPlayer,
+    humanFolded,
+    humanAllIn,
+    canAct,
+    hasOutstandingBet,
+    minRaise,
+    isMuckPhase,
+    isRebuyPhase,
+    isAddonPhase,
+    humanRebuyCount,
+    cpuPlayers,
+  };
+}

--- a/frontend/src/pages/BigOHiLoPage.tsx
+++ b/frontend/src/pages/BigOHiLoPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useMemo } from 'react';
 import { bigOHiLoApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { BettingControls } from '../components/BettingControls';
@@ -22,28 +22,17 @@ import { PokerTableLayout } from '../components/PokerTableLayout';
 import { RoundResults } from '../components/RoundResults';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { withTutorial } from '../components/tutorial/withTutorial';
-import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
-import { useCardDimensions, useIsLargeDesktop, useIsMobile } from '../hooks/useCardDimensions';
-import { useCliGame } from '../hooks/useCliGame';
-import { useCliMode } from '../hooks/useCliMode';
-import { useGameApi } from '../hooks/useGameApi';
-import { useGameHint } from '../hooks/useGameHint';
-import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { useMountReset } from '../hooks/useMountReset';
-import { usePhaseNames } from '../hooks/usePhaseNames';
-import { useSound } from '../providers/SoundProvider';
+import { useCommunityPokerGame } from '../hooks/useCommunityPokerGame';
 import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
 import { placeholderCardStyle } from '../styles/cardStyles';
 import { handNameBadgeClass } from '../styles/gameConstants';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
-import type { OmahaResponse } from '../types/card';
-import { OmahaPhase, OmahaRebuyPhaseType } from '../types/phases';
+import { OmahaPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { valueName } from '../utils/cardUtils';
 import { OMAHA_HELP, parseOmahaCommand } from '../utils/cli/commands/omahaCommands';
 import { formatOmahaState } from '../utils/cli/formatters/omahaFormatter';
-import type { CliGameConfig } from '../utils/cli/types';
 import { omahaBestFive } from '../utils/omahaBestFive';
 import { hiLoRingStyle } from '../utils/omahaHiLoRing';
 import { lowCardIndexSets } from '../utils/omahaLowCards';
@@ -111,63 +100,59 @@ const OMAHA_PHASE_KEYS: Readonly<Record<number, string>> = {
 export const BigOHiLoPage = withTutorial(BigOHiLoPageContent, 'bigohilo', BIGOHL_TUTORIAL_STEPS);
 /** Inner content of the Big O Hi-Lo page, wrapped by TutorialProvider. */
 function BigOHiLoPageContent() {
-  const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
-    useGamePageSetup('bigohilo');
-  const phaseNames = usePhaseNames('bigohilo', OMAHA_PHASE_KEYS);
-  const { cardWidth } = useCardDimensions();
-  const { playSound } = useSound();
-  const isMobile = useIsMobile();
-  const { state, loading, error, exec: execApi, retry } = useGameApi(bigOHiLoApi.exec);
-  const [betAmount, setBetAmount] = useState(20);
-  const [learningMode, setLearningMode] = useState(false);
-  const [cpuMetaAI, setCpuMetaAI] = useState(false);
-  const { hint, hintEnabled, setHintEnabled } = useGameHint('bigohilo', state);
-  const turnStartRef = useRef(0);
-  // CLI mode
-  const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('bigohilo');
-  const cliConfig: CliGameConfig<OmahaResponse, Parameters<typeof bigOHiLoApi.exec>> = useMemo(
-    () => ({
-      gameName: 'bigohilo',
-      parseCommand: parseOmahaCommand,
-      formatResponse: formatOmahaState,
-      helpText: OMAHA_HELP,
-    }),
-    [],
-  );
-  const { handleCommand } = useCliGame(execApi, cliConfig, state, { addInput, addOutput, addError, clearLog });
+  const {
+    t,
+    tc,
+    actionLog,
+    showActionLog,
+    hideActionLog,
+    confirmOpen,
+    requestConfirm,
+    confirmReset,
+    cancelReset,
+    phaseNames,
+    cardWidth,
+    playSound,
+    isMobile,
+    isLargeDesktop,
+    state,
+    loading,
+    error,
+    execApi,
+    retry,
+    betAmount,
+    setBetAmount,
+    learningMode,
+    setLearningMode,
+    cpuMetaAI,
+    setCpuMetaAI,
+    hint,
+    hintEnabled,
+    setHintEnabled,
+    getElapsed,
+    cliEnabled,
+    toggleCli,
+    logEntries,
+    handleCommand,
+    handleManualReset,
+    phase,
+    isShowdown,
+    humanPlayer,
+    canAct,
+    hasOutstandingBet,
+    minRaise,
+    isMuckPhase,
+    isRebuyPhase,
+    isAddonPhase,
+    humanRebuyCount,
+    cpuPlayers,
+  } = useCommunityPokerGame({
+    game: 'bigohilo',
+    exec: bigOHiLoApi.exec,
+    phaseKeys: OMAHA_PHASE_KEYS,
+    cli: { parseCommand: parseOmahaCommand, formatResponse: formatOmahaState, helpText: OMAHA_HELP },
+  });
 
-  useMountReset(execApi);
-
-  const handleManualReset = useCallback(() => {
-    hideActionLog();
-    void execApi('reset', undefined, { cpuMetaAI });
-  }, [execApi, hideActionLog, cpuMetaAI]);
-
-  useEffect(() => {
-    if (state?.minRaise && state.minRaise > 0) {
-      setBetAmount(state.minRaise);
-    } else if (state) {
-      setBetAmount(20);
-    }
-  }, [state]);
-
-  useEffect(() => {
-    if (state && state.currentTurn === state.players?.find((p) => p.isHuman)?.id) {
-      turnStartRef.current = Date.now();
-    }
-  }, [state]);
-
-  const getElapsed = useCallback(() => {
-    if (!cpuMetaAI || turnStartRef.current === 0) return 0;
-    const elapsed = Date.now() - turnStartRef.current;
-    turnStartRef.current = 0;
-    return elapsed;
-  }, [cpuMetaAI]);
-
-  const phase = state?.phase ?? OmahaPhase.INIT;
-  const isActive = phase >= OmahaPhase.PRE_FLOP && phase <= OmahaPhase.RIVER;
-  const isShowdown = phase === OmahaPhase.SHOWDOWN || phase === OmahaPhase.END;
-  const humanPlayer = state?.players?.find((p) => p.isHuman);
   // At showdown, highlight the human's winning 5 cards under the must-use-2 rule.
   const showdownBest5 = useMemo(() => {
     const empty = { holeSet: new Set<number>(), boardSet: new Set<number>() };
@@ -182,40 +167,6 @@ function BigOHiLoPageContent() {
     ? state?.roundResults?.find((r) => r.playerIdx === humanPlayer?.id)?.lowBestHand
     : undefined;
   const lowSets = lowCardIndexSets(humanLowBestHand, humanPlayer?.cards ?? [], state?.communityCards ?? []);
-  const humanFolded = humanPlayer?.folded ?? false;
-  const humanAllIn = humanPlayer?.allIn ?? false;
-  const canAct = isActive && !humanFolded && !humanAllIn && state?.currentTurn === humanPlayer?.id;
-  const hasOutstandingBet = (state?.lastBet ?? 0) > (humanPlayer?.currentBet ?? 0);
-  const minRaise = state?.minRaise ?? 0;
-  const isMuckPhase = phase === OmahaPhase.SHOWDOWN && state?.muckAvailable === true;
-  const isRebuyPhase = phase === OmahaPhase.REBUY && state?.rebuyPhaseType === OmahaRebuyPhaseType.REBUY;
-  const isAddonPhase = phase === OmahaPhase.REBUY && state?.rebuyPhaseType === OmahaRebuyPhaseType.ADDON;
-  const humanIdx = state?.players?.findIndex((p) => p.isHuman) ?? 0;
-  const humanRebuyCount = state?.rebuyCounts?.[humanIdx] ?? 0;
-  const isLargeDesktop = useIsLargeDesktop();
-  const cpuPlayers = useMemo(() => state?.players?.filter((player) => !player.isHuman) ?? [], [state?.players]);
-
-  const actionBindings = useMemo(
-    () => [
-      { key: 'c', action: () => execApi('call', undefined, undefined, getElapsed()), enabled: hasOutstandingBet },
-      {
-        key: 'r',
-        action: () =>
-          hasOutstandingBet
-            ? execApi('raise', betAmount, undefined, getElapsed())
-            : execApi('bet', betAmount, undefined, getElapsed()),
-      },
-      { key: 'k', action: () => execApi('check', undefined, undefined, getElapsed()), enabled: !hasOutstandingBet },
-      { key: 'f', action: () => execApi('fold', undefined, undefined, getElapsed()) },
-      { key: 'a', action: () => execApi('allin', undefined, undefined, getElapsed()) },
-    ],
-    [execApi, hasOutstandingBet, betAmount, getElapsed],
-  );
-
-  useActionKeyboardNav({
-    bindings: actionBindings,
-    enabled: canAct && !loading,
-  });
 
   if (!state)
     return (

--- a/frontend/src/pages/BigOPage.tsx
+++ b/frontend/src/pages/BigOPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useMemo } from 'react';
 import { bigOApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { BettingControls } from '../components/BettingControls';
@@ -22,27 +22,16 @@ import { PokerTableLayout } from '../components/PokerTableLayout';
 import { RoundResults } from '../components/RoundResults';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { withTutorial } from '../components/tutorial/withTutorial';
-import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
-import { useCardDimensions, useIsLargeDesktop, useIsMobile } from '../hooks/useCardDimensions';
-import { useCliGame } from '../hooks/useCliGame';
-import { useCliMode } from '../hooks/useCliMode';
-import { useGameApi } from '../hooks/useGameApi';
-import { useGameHint } from '../hooks/useGameHint';
-import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { useMountReset } from '../hooks/useMountReset';
-import { usePhaseNames } from '../hooks/usePhaseNames';
-import { useSound } from '../providers/SoundProvider';
+import { useCommunityPokerGame } from '../hooks/useCommunityPokerGame';
 import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
 import { placeholderCardStyle } from '../styles/cardStyles';
 import { handNameBadgeClass } from '../styles/gameConstants';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
-import type { OmahaResponse } from '../types/card';
-import { OmahaPhase, OmahaRebuyPhaseType } from '../types/phases';
+import { OmahaPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { OMAHA_HELP, parseOmahaCommand } from '../utils/cli/commands/omahaCommands';
 import { formatOmahaState } from '../utils/cli/formatters/omahaFormatter';
-import type { CliGameConfig } from '../utils/cli/types';
 import { omahaBestFive } from '../utils/omahaBestFive';
 import { findPlayerName } from '../utils/playerUtils';
 
@@ -107,63 +96,59 @@ const OMAHA_PHASE_KEYS: Readonly<Record<number, string>> = {
 export const BigOPage = withTutorial(BigOPageContent, 'bigo', BIGO_TUTORIAL_STEPS);
 /** Inner content of the Big O page, wrapped by TutorialProvider. */
 function BigOPageContent() {
-  const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
-    useGamePageSetup('bigo');
-  const phaseNames = usePhaseNames('bigo', OMAHA_PHASE_KEYS);
-  const { cardWidth } = useCardDimensions();
-  const { playSound } = useSound();
-  const isMobile = useIsMobile();
-  const { state, loading, error, exec: execApi, retry } = useGameApi(bigOApi.exec);
-  const [betAmount, setBetAmount] = useState(20);
-  const [learningMode, setLearningMode] = useState(false);
-  const [cpuMetaAI, setCpuMetaAI] = useState(false);
-  const { hint, hintEnabled, setHintEnabled } = useGameHint('bigo', state);
-  const turnStartRef = useRef(0);
-  // CLI mode
-  const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('bigo');
-  const cliConfig: CliGameConfig<OmahaResponse, Parameters<typeof bigOApi.exec>> = useMemo(
-    () => ({
-      gameName: 'bigo',
-      parseCommand: parseOmahaCommand,
-      formatResponse: formatOmahaState,
-      helpText: OMAHA_HELP,
-    }),
-    [],
-  );
-  const { handleCommand } = useCliGame(execApi, cliConfig, state, { addInput, addOutput, addError, clearLog });
+  const {
+    t,
+    tc,
+    actionLog,
+    showActionLog,
+    hideActionLog,
+    confirmOpen,
+    requestConfirm,
+    confirmReset,
+    cancelReset,
+    phaseNames,
+    cardWidth,
+    playSound,
+    isMobile,
+    isLargeDesktop,
+    state,
+    loading,
+    error,
+    execApi,
+    retry,
+    betAmount,
+    setBetAmount,
+    learningMode,
+    setLearningMode,
+    cpuMetaAI,
+    setCpuMetaAI,
+    hint,
+    hintEnabled,
+    setHintEnabled,
+    getElapsed,
+    cliEnabled,
+    toggleCli,
+    logEntries,
+    handleCommand,
+    handleManualReset,
+    phase,
+    isShowdown,
+    humanPlayer,
+    canAct,
+    hasOutstandingBet,
+    minRaise,
+    isMuckPhase,
+    isRebuyPhase,
+    isAddonPhase,
+    humanRebuyCount,
+    cpuPlayers,
+  } = useCommunityPokerGame({
+    game: 'bigo',
+    exec: bigOApi.exec,
+    phaseKeys: OMAHA_PHASE_KEYS,
+    cli: { parseCommand: parseOmahaCommand, formatResponse: formatOmahaState, helpText: OMAHA_HELP },
+  });
 
-  useMountReset(execApi);
-
-  const handleManualReset = useCallback(() => {
-    hideActionLog();
-    void execApi('reset', undefined, { cpuMetaAI });
-  }, [execApi, hideActionLog, cpuMetaAI]);
-
-  useEffect(() => {
-    if (state?.minRaise && state.minRaise > 0) {
-      setBetAmount(state.minRaise);
-    } else if (state) {
-      setBetAmount(20);
-    }
-  }, [state]);
-
-  useEffect(() => {
-    if (state && state.currentTurn === state.players?.find((p) => p.isHuman)?.id) {
-      turnStartRef.current = Date.now();
-    }
-  }, [state]);
-
-  const getElapsed = useCallback(() => {
-    if (!cpuMetaAI || turnStartRef.current === 0) return 0;
-    const elapsed = Date.now() - turnStartRef.current;
-    turnStartRef.current = 0;
-    return elapsed;
-  }, [cpuMetaAI]);
-
-  const phase = state?.phase ?? OmahaPhase.INIT;
-  const isActive = phase >= OmahaPhase.PRE_FLOP && phase <= OmahaPhase.RIVER;
-  const isShowdown = phase === OmahaPhase.SHOWDOWN || phase === OmahaPhase.END;
-  const humanPlayer = state?.players?.find((p) => p.isHuman);
   // At showdown, highlight the human's winning 5 cards under Big O's
   // must-use-exactly-2-hole (of 5) + 3-board rule.
   const showdownBest5 = useMemo(() => {
@@ -173,40 +158,6 @@ function BigOPageContent() {
     if (!best) return empty;
     return { holeSet: new Set(best.holeIdx), boardSet: new Set(best.boardIdx) };
   }, [isShowdown, humanPlayer, state?.communityCards]);
-  const humanFolded = humanPlayer?.folded ?? false;
-  const humanAllIn = humanPlayer?.allIn ?? false;
-  const canAct = isActive && !humanFolded && !humanAllIn && state?.currentTurn === humanPlayer?.id;
-  const hasOutstandingBet = (state?.lastBet ?? 0) > (humanPlayer?.currentBet ?? 0);
-  const minRaise = state?.minRaise ?? 0;
-  const isMuckPhase = phase === OmahaPhase.SHOWDOWN && state?.muckAvailable === true;
-  const isRebuyPhase = phase === OmahaPhase.REBUY && state?.rebuyPhaseType === OmahaRebuyPhaseType.REBUY;
-  const isAddonPhase = phase === OmahaPhase.REBUY && state?.rebuyPhaseType === OmahaRebuyPhaseType.ADDON;
-  const humanIdx = state?.players?.findIndex((p) => p.isHuman) ?? 0;
-  const humanRebuyCount = state?.rebuyCounts?.[humanIdx] ?? 0;
-  const isLargeDesktop = useIsLargeDesktop();
-  const cpuPlayers = useMemo(() => state?.players?.filter((player) => !player.isHuman) ?? [], [state?.players]);
-
-  const actionBindings = useMemo(
-    () => [
-      { key: 'c', action: () => execApi('call', undefined, undefined, getElapsed()), enabled: hasOutstandingBet },
-      {
-        key: 'r',
-        action: () =>
-          hasOutstandingBet
-            ? execApi('raise', betAmount, undefined, getElapsed())
-            : execApi('bet', betAmount, undefined, getElapsed()),
-      },
-      { key: 'k', action: () => execApi('check', undefined, undefined, getElapsed()), enabled: !hasOutstandingBet },
-      { key: 'f', action: () => execApi('fold', undefined, undefined, getElapsed()) },
-      { key: 'a', action: () => execApi('allin', undefined, undefined, getElapsed()) },
-    ],
-    [execApi, hasOutstandingBet, betAmount, getElapsed],
-  );
-
-  useActionKeyboardNav({
-    bindings: actionBindings,
-    enabled: canAct && !loading,
-  });
 
   if (!state)
     return (

--- a/frontend/src/pages/OmahaHiLoPage.tsx
+++ b/frontend/src/pages/OmahaHiLoPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useMemo } from 'react';
 import { omahaHiLoApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { BettingControls } from '../components/BettingControls';
@@ -22,28 +22,18 @@ import { PokerTableLayout } from '../components/PokerTableLayout';
 import { RoundResults } from '../components/RoundResults';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { withTutorial } from '../components/tutorial/withTutorial';
-import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
-import { useCardDimensions, useIsLargeDesktop, useIsMobile } from '../hooks/useCardDimensions';
-import { useCliGame } from '../hooks/useCliGame';
-import { useCliMode } from '../hooks/useCliMode';
-import { useGameApi } from '../hooks/useGameApi';
-import { useGameHint } from '../hooks/useGameHint';
-import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { useMountReset } from '../hooks/useMountReset';
-import { usePhaseNames } from '../hooks/usePhaseNames';
-import { useSound } from '../providers/SoundProvider';
+import { useCommunityPokerGame } from '../hooks/useCommunityPokerGame';
 import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
 import { placeholderCardStyle } from '../styles/cardStyles';
 import { handNameBadgeClass } from '../styles/gameConstants';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
-import type { Card, OmahaResponse } from '../types/card';
-import { OmahaPhase, OmahaRebuyPhaseType } from '../types/phases';
+import type { Card } from '../types/card';
+import { OmahaPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { valueName } from '../utils/cardUtils';
 import { OMAHA_HELP, parseOmahaCommand } from '../utils/cli/commands/omahaCommands';
 import { formatOmahaState } from '../utils/cli/formatters/omahaFormatter';
-import type { CliGameConfig } from '../utils/cli/types';
 import { omahaBestFive } from '../utils/omahaBestFive';
 import { type BoardLowStatus, boardLowPossibility, lowCardIndexSets } from '../utils/omahaLowCards';
 import { findPlayerName } from '../utils/playerUtils';
@@ -199,67 +189,59 @@ function BoardLowBadge({
 export const OmahaHiLoPage = withTutorial(OmahaHiLoPageContent, 'omahahilo', OHL_TUTORIAL_STEPS);
 /** Inner content of the Omaha Hi-Lo page, wrapped by TutorialProvider. */
 function OmahaHiLoPageContent() {
-  const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
-    useGamePageSetup('omahahilo');
-  const phaseNames = usePhaseNames('omahahilo', OMAHA_PHASE_KEYS);
-  const { cardWidth } = useCardDimensions();
-  const { playSound } = useSound();
-  const isMobile = useIsMobile();
-  const { state, loading, error, exec: execApi, retry } = useGameApi(omahaHiLoApi.exec);
-  const [betAmount, setBetAmount] = useState(20);
-  const [learningMode, setLearningMode] = useState(false);
-  const [cpuMetaAI, setCpuMetaAI] = useState(false);
-  const { hint, hintEnabled, setHintEnabled } = useGameHint('omahahilo', state);
-  const turnStartRef = useRef(0);
-  // CLI mode
-  const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('omahahilo');
-  const cliConfig: CliGameConfig<OmahaResponse, Parameters<typeof omahaHiLoApi.exec>> = useMemo(
-    () => ({
-      gameName: 'omahahilo',
-      parseCommand: parseOmahaCommand,
-      formatResponse: formatOmahaState,
-      helpText: OMAHA_HELP,
-    }),
-    [],
-  );
-  const { handleCommand } = useCliGame(execApi, cliConfig, state, { addInput, addOutput, addError, clearLog });
+  const {
+    t,
+    tc,
+    actionLog,
+    showActionLog,
+    hideActionLog,
+    confirmOpen,
+    requestConfirm,
+    confirmReset,
+    cancelReset,
+    phaseNames,
+    cardWidth,
+    playSound,
+    isMobile,
+    isLargeDesktop,
+    state,
+    loading,
+    error,
+    execApi,
+    retry,
+    betAmount,
+    setBetAmount,
+    learningMode,
+    setLearningMode,
+    cpuMetaAI,
+    setCpuMetaAI,
+    hint,
+    hintEnabled,
+    setHintEnabled,
+    getElapsed,
+    cliEnabled,
+    toggleCli,
+    logEntries,
+    handleCommand,
+    handleManualReset,
+    phase,
+    isShowdown,
+    humanPlayer,
+    canAct,
+    hasOutstandingBet,
+    minRaise,
+    isMuckPhase,
+    isRebuyPhase,
+    isAddonPhase,
+    humanRebuyCount,
+    cpuPlayers,
+  } = useCommunityPokerGame({
+    game: 'omahahilo',
+    exec: omahaHiLoApi.exec,
+    phaseKeys: OMAHA_PHASE_KEYS,
+    cli: { parseCommand: parseOmahaCommand, formatResponse: formatOmahaState, helpText: OMAHA_HELP },
+  });
 
-  useMountReset(execApi);
-
-  const handleManualReset = useCallback(() => {
-    hideActionLog();
-    void execApi('reset', undefined, { cpuMetaAI });
-  }, [execApi, hideActionLog, cpuMetaAI]);
-
-  useEffect(() => {
-    if (state?.minRaise && state.minRaise > 0) {
-      setBetAmount(state.minRaise);
-    } else if (state) {
-      setBetAmount(20);
-    }
-  }, [state]);
-
-  useEffect(() => {
-    if (state && state.currentTurn === state.players?.find((p) => p.isHuman)?.id) {
-      turnStartRef.current = Date.now();
-    }
-  }, [state]);
-
-  const getElapsed = useCallback(() => {
-    if (!cpuMetaAI || turnStartRef.current === 0) return 0;
-    const elapsed = Date.now() - turnStartRef.current;
-    turnStartRef.current = 0;
-    return elapsed;
-  }, [cpuMetaAI]);
-
-  const phase = state?.phase ?? OmahaPhase.INIT;
-  const isActive = phase >= OmahaPhase.PRE_FLOP && phase <= OmahaPhase.RIVER;
-  const isShowdown = phase === OmahaPhase.SHOWDOWN || phase === OmahaPhase.END;
-  const humanPlayer = state?.players?.find((p) => p.isHuman);
-  const humanFolded = humanPlayer?.folded ?? false;
-  const humanAllIn = humanPlayer?.allIn ?? false;
-  const canAct = isActive && !humanFolded && !humanAllIn && state?.currentTurn === humanPlayer?.id;
-  const hasOutstandingBet = (state?.lastBet ?? 0) > (humanPlayer?.currentBet ?? 0);
   // At showdown, highlight the human's winning Hi 5 cards under the must-use-2 rule.
   const showdownBest5 = useMemo(() => {
     const empty = { holeSet: new Set<number>(), boardSet: new Set<number>() };
@@ -273,36 +255,6 @@ function OmahaHiLoPageContent() {
     ? state?.roundResults?.find((r) => r.playerIdx === humanPlayer?.id)?.lowBestHand
     : undefined;
   const lowSets = lowCardIndexSets(humanLowBestHand, humanPlayer?.cards ?? [], state?.communityCards ?? []);
-  const minRaise = state?.minRaise ?? 0;
-  const isMuckPhase = phase === OmahaPhase.SHOWDOWN && state?.muckAvailable === true;
-  const isRebuyPhase = phase === OmahaPhase.REBUY && state?.rebuyPhaseType === OmahaRebuyPhaseType.REBUY;
-  const isAddonPhase = phase === OmahaPhase.REBUY && state?.rebuyPhaseType === OmahaRebuyPhaseType.ADDON;
-  const humanIdx = state?.players?.findIndex((p) => p.isHuman) ?? 0;
-  const humanRebuyCount = state?.rebuyCounts?.[humanIdx] ?? 0;
-  const isLargeDesktop = useIsLargeDesktop();
-  const cpuPlayers = useMemo(() => state?.players?.filter((player) => !player.isHuman) ?? [], [state?.players]);
-
-  const actionBindings = useMemo(
-    () => [
-      { key: 'c', action: () => execApi('call', undefined, undefined, getElapsed()), enabled: hasOutstandingBet },
-      {
-        key: 'r',
-        action: () =>
-          hasOutstandingBet
-            ? execApi('raise', betAmount, undefined, getElapsed())
-            : execApi('bet', betAmount, undefined, getElapsed()),
-      },
-      { key: 'k', action: () => execApi('check', undefined, undefined, getElapsed()), enabled: !hasOutstandingBet },
-      { key: 'f', action: () => execApi('fold', undefined, undefined, getElapsed()) },
-      { key: 'a', action: () => execApi('allin', undefined, undefined, getElapsed()) },
-    ],
-    [execApi, hasOutstandingBet, betAmount, getElapsed],
-  );
-
-  useActionKeyboardNav({
-    bindings: actionBindings,
-    enabled: canAct && !loading,
-  });
 
   if (!state)
     return (

--- a/frontend/src/pages/OmahaPage.tsx
+++ b/frontend/src/pages/OmahaPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useMemo } from 'react';
 import { omahaApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { BettingControls } from '../components/BettingControls';
@@ -22,27 +22,16 @@ import { PokerTableLayout } from '../components/PokerTableLayout';
 import { RoundResults } from '../components/RoundResults';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { withTutorial } from '../components/tutorial/withTutorial';
-import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
-import { useCardDimensions, useIsLargeDesktop, useIsMobile } from '../hooks/useCardDimensions';
-import { useCliGame } from '../hooks/useCliGame';
-import { useCliMode } from '../hooks/useCliMode';
-import { useGameApi } from '../hooks/useGameApi';
-import { useGameHint } from '../hooks/useGameHint';
-import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { useMountReset } from '../hooks/useMountReset';
-import { usePhaseNames } from '../hooks/usePhaseNames';
-import { useSound } from '../providers/SoundProvider';
+import { useCommunityPokerGame } from '../hooks/useCommunityPokerGame';
 import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
 import { placeholderCardStyle } from '../styles/cardStyles';
 import { handNameBadgeClass } from '../styles/gameConstants';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
-import type { OmahaResponse } from '../types/card';
-import { OmahaPhase, OmahaRebuyPhaseType } from '../types/phases';
+import { OmahaPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { OMAHA_HELP, parseOmahaCommand } from '../utils/cli/commands/omahaCommands';
 import { formatOmahaState } from '../utils/cli/formatters/omahaFormatter';
-import type { CliGameConfig } from '../utils/cli/types';
 import { omahaBestFive } from '../utils/omahaBestFive';
 import { findPlayerName } from '../utils/playerUtils';
 import { evaluateFiveCardHand, pokerHandKey } from '../utils/pokerSquaresUtils';
@@ -107,63 +96,60 @@ const OMAHA_PHASE_KEYS: Readonly<Record<number, string>> = {
 export const OmahaPage = withTutorial(OmahaPageContent, 'omaha', OH_TUTORIAL_STEPS);
 /** Inner content of the Omaha Hold'em page, wrapped by TutorialProvider. */
 function OmahaPageContent() {
-  const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
-    useGamePageSetup('omaha');
-  const phaseNames = usePhaseNames('omaha', OMAHA_PHASE_KEYS);
-  const { cardWidth } = useCardDimensions();
-  const { playSound } = useSound();
-  const isMobile = useIsMobile();
-  const { state, loading, error, exec: execApi, retry } = useGameApi(omahaApi.exec);
-  const [betAmount, setBetAmount] = useState(20);
-  const [learningMode, setLearningMode] = useState(false);
-  const [cpuMetaAI, setCpuMetaAI] = useState(false);
-  const { hint, hintEnabled, setHintEnabled } = useGameHint('omaha', state);
-  const turnStartRef = useRef(0);
-  // CLI mode
-  const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('omaha');
-  const cliConfig: CliGameConfig<OmahaResponse, Parameters<typeof omahaApi.exec>> = useMemo(
-    () => ({
-      gameName: 'omaha',
-      parseCommand: parseOmahaCommand,
-      formatResponse: formatOmahaState,
-      helpText: OMAHA_HELP,
-    }),
-    [],
-  );
-  const { handleCommand } = useCliGame(execApi, cliConfig, state, { addInput, addOutput, addError, clearLog });
+  const {
+    t,
+    tc,
+    actionLog,
+    showActionLog,
+    hideActionLog,
+    confirmOpen,
+    requestConfirm,
+    confirmReset,
+    cancelReset,
+    phaseNames,
+    cardWidth,
+    playSound,
+    isMobile,
+    isLargeDesktop,
+    state,
+    loading,
+    error,
+    execApi,
+    retry,
+    betAmount,
+    setBetAmount,
+    learningMode,
+    setLearningMode,
+    cpuMetaAI,
+    setCpuMetaAI,
+    hint,
+    hintEnabled,
+    setHintEnabled,
+    getElapsed,
+    cliEnabled,
+    toggleCli,
+    logEntries,
+    handleCommand,
+    handleManualReset,
+    phase,
+    isActive,
+    isShowdown,
+    humanPlayer,
+    canAct,
+    hasOutstandingBet,
+    minRaise,
+    isMuckPhase,
+    isRebuyPhase,
+    isAddonPhase,
+    humanRebuyCount,
+    cpuPlayers,
+  } = useCommunityPokerGame({
+    game: 'omaha',
+    exec: omahaApi.exec,
+    phaseKeys: OMAHA_PHASE_KEYS,
+    cli: { parseCommand: parseOmahaCommand, formatResponse: formatOmahaState, helpText: OMAHA_HELP },
+  });
 
-  useMountReset(execApi);
-
-  const handleManualReset = useCallback(() => {
-    hideActionLog();
-    void execApi('reset', undefined, { cpuMetaAI });
-  }, [execApi, hideActionLog, cpuMetaAI]);
-
-  useEffect(() => {
-    if (state?.minRaise && state.minRaise > 0) {
-      setBetAmount(state.minRaise);
-    } else if (state) {
-      setBetAmount(20);
-    }
-  }, [state]);
-
-  useEffect(() => {
-    if (state && state.currentTurn === state.players?.find((p) => p.isHuman)?.id) {
-      turnStartRef.current = Date.now();
-    }
-  }, [state]);
-
-  const getElapsed = useCallback(() => {
-    if (!cpuMetaAI || turnStartRef.current === 0) return 0;
-    const elapsed = Date.now() - turnStartRef.current;
-    turnStartRef.current = 0;
-    return elapsed;
-  }, [cpuMetaAI]);
-
-  const phase = state?.phase ?? OmahaPhase.INIT;
-  const isActive = phase >= OmahaPhase.PRE_FLOP && phase <= OmahaPhase.RIVER;
-  const isShowdown = phase === OmahaPhase.SHOWDOWN || phase === OmahaPhase.END;
-  const humanPlayer = state?.players?.find((p) => p.isHuman);
   // At showdown, highlight the human's winning 5 cards under Omaha's
   // must-use-exactly-2-hole + 3-board rule (dim the rest).
   const showdownBest5 = useMemo(() => {
@@ -188,40 +174,6 @@ function OmahaPageContent() {
     const rank = evaluateFiveCardHand(five);
     return rank == null ? null : pokerHandKey(rank);
   }, [isActive, isShowdown, humanPlayer, state?.communityCards]);
-  const humanFolded = humanPlayer?.folded ?? false;
-  const humanAllIn = humanPlayer?.allIn ?? false;
-  const canAct = isActive && !humanFolded && !humanAllIn && state?.currentTurn === humanPlayer?.id;
-  const hasOutstandingBet = (state?.lastBet ?? 0) > (humanPlayer?.currentBet ?? 0);
-  const minRaise = state?.minRaise ?? 0;
-  const isMuckPhase = phase === OmahaPhase.SHOWDOWN && state?.muckAvailable === true;
-  const isRebuyPhase = phase === OmahaPhase.REBUY && state?.rebuyPhaseType === OmahaRebuyPhaseType.REBUY;
-  const isAddonPhase = phase === OmahaPhase.REBUY && state?.rebuyPhaseType === OmahaRebuyPhaseType.ADDON;
-  const humanIdx = state?.players?.findIndex((p) => p.isHuman) ?? 0;
-  const humanRebuyCount = state?.rebuyCounts?.[humanIdx] ?? 0;
-  const isLargeDesktop = useIsLargeDesktop();
-  const cpuPlayers = useMemo(() => state?.players?.filter((player) => !player.isHuman) ?? [], [state?.players]);
-
-  const actionBindings = useMemo(
-    () => [
-      { key: 'c', action: () => execApi('call', undefined, undefined, getElapsed()), enabled: hasOutstandingBet },
-      {
-        key: 'r',
-        action: () =>
-          hasOutstandingBet
-            ? execApi('raise', betAmount, undefined, getElapsed())
-            : execApi('bet', betAmount, undefined, getElapsed()),
-      },
-      { key: 'k', action: () => execApi('check', undefined, undefined, getElapsed()), enabled: !hasOutstandingBet },
-      { key: 'f', action: () => execApi('fold', undefined, undefined, getElapsed()) },
-      { key: 'a', action: () => execApi('allin', undefined, undefined, getElapsed()) },
-    ],
-    [execApi, hasOutstandingBet, betAmount, getElapsed],
-  );
-
-  useActionKeyboardNav({
-    bindings: actionBindings,
-    enabled: canAct && !loading,
-  });
 
   if (!state)
     return (


### PR DESCRIPTION
## Summary

Omaha, Big O, and their Hi-Lo variants each copied the **same ~120 lines** of page orchestration — server state, bet-amount / learning / meta-AI state, meta-AI elapsed-time tracking, CLI wiring, mount reset, keyboard shortcuts, and the derived phase/turn booleans the JSX branches on. A betting-logic or UX fix meant editing 4+ near-identical pages (issue #4301, the stated primary pain).

All four already share the `OmahaResponse` (= `HoldemResponse`) type and `OmahaPhase` enum, so I extracted that orchestration into **`useCommunityPokerGame`** (keyed by `game`/`exec`/`phaseKeys`/CLI config) and reduced each page to `const { … } = useCommunityPokerGame(…)` plus its own game-specific bits (best-five highlight, Hi-Lo low-hand display, tutorial prefix, hole-card count). Added an exported `HoldemLikeExec<T>` type from `gameApi` so the hook can type the shared exec.

Net: ~90 orchestration lines removed from each of 4 pages, and the betting flow now lives in one place.

## Scope note

The per-page **JSX layout** genuinely differs (tutorial prefix `oh-`/`bo-`/`ohl-`/`bohl-`, the Hi-Lo low-hand cards + board-low badge, hole-card count 4 vs 5, per-game `data-testid`s), so it is left per-page. Folding it into a `CommunityPokerPage` template is the issue's explicitly **phased** follow-up ("まず 4ページで確立、その後 Holdem / ShortDeck の取り込みを検討").

## Test plan

- [x] All four pages' existing tests pass unchanged — Omaha 117, Big O 118, Omaha Hi-Lo 120, Big O Hi-Lo 119 (474 total), confirming behavior is preserved
- [x] New `useCommunityPokerGame.test.ts` (mount reset, manual reset with meta-AI flag, canAct/isActive/isShowdown derivation on/off the human turn)
- [x] `bun run check` + `bun run build` clean
- [ ] CI green

Closes #4301