### PR TITLE
refactor(domain): extract shared TrickCard + ResolveTrickWinner helper

### DIFF
--- a/docs/design/backend.md
+++ b/docs/design/backend.md
@@ -447,7 +447,7 @@ classDiagram
         -players []*HeartsPlayer
         -config HeartsConfig
         -phase HeartsPhase
-        -trickCards []*HeartsTrickCard
+        -currentTrick []*TrickCard
         +Reset()
         +PassCards(indices []int) error
         +PlayCard(index int) error
@@ -462,7 +462,7 @@ classDiagram
         -players []*SpadesPlayer
         -config SpadesConfig
         -phase SpadesPhase
-        -trickCards []*SpadesTrickCard
+        -currentTrick []*TrickCard
         +Reset()
         +Bid(amount int) error
         +PlayCard(index int) error
@@ -472,12 +472,10 @@ classDiagram
         +Phase() SpadesPhase
     }
 
-    class HeartsTrickCard {
-        +int PlayerIdx
-        +*Card Card
-    }
-
-    class SpadesTrickCard {
+    %% Shared trick-card type (internal/domain/trick_helpers.go, issue #4297) —
+    %% reused by the migrated trick-taking games (Hearts, Spades, OhHell,
+    %% TwoTenJack, Whist, …) in place of a per-game struct.
+    class TrickCard {
         +int PlayerIdx
         +*Card Card
     }
@@ -593,7 +591,7 @@ classDiagram
         -players []*OhHellPlayer
         -config OhHellConfig
         -phase OhHellPhase
-        -trickCards []*OhHellTrickCard
+        -currentTrick []*TrickCard
         -trumpCard *Card
         -trumpSuit int
         -handSize int
@@ -605,11 +603,6 @@ classDiagram
         +ScoreRound()
         +GetHint() *OhHellHint
         +GetPhase() OhHellPhase
-    }
-
-    class OhHellTrickCard {
-        +int PlayerIdx
-        +*Card Card
     }
 
     class Bridge {
@@ -643,7 +636,7 @@ classDiagram
         -players []*TwoTenJackPlayer
         -config TwoTenJackConfig
         -phase TwoTenJackPhase
-        -currentTrick []*TwoTenJackTrickCard
+        -currentTrick []*TrickCard
         -declarerIdx int
         -trumpSuit int
         +Reset()
@@ -657,15 +650,10 @@ classDiagram
         +GetPhase() TwoTenJackPhase
     }
 
-    class TwoTenJackTrickCard {
-        +int PlayerIdx
-        +*Card Card
-    }
-
     Hearts --> "4" HeartsPlayer
-    Hearts --> "*" HeartsTrickCard
+    Hearts --> "*" TrickCard
     Spades --> "4" SpadesPlayer
-    Spades --> "*" SpadesTrickCard
+    Spades --> "*" TrickCard
     Napoleon --> "4" NapoleonPlayer
     Napoleon --> "*" NapoleonTrickCard
     Mighty *-- "5" MightyPlayer
@@ -675,11 +663,11 @@ classDiagram
     Euchre --> "4" EuchrePlayer
     Euchre --> "*" EuchreTrickCard
     OhHell --> "4" OhHellPlayer
-    OhHell --> "*" OhHellTrickCard
+    OhHell --> "*" TrickCard
     Bridge --> "4" BridgePlayer
     Bridge --> "*" BridgeTrickCard
     TwoTenJack --> "4" TwoTenJackPlayer
-    TwoTenJack --> "*" TwoTenJackTrickCard
+    TwoTenJack --> "*" TrickCard
     HeartsPlayer --|> GamePlayer
     SpadesPlayer --|> GamePlayer
     NapoleonPlayer --|> GamePlayer
@@ -1592,7 +1580,7 @@ classDiagram
         -roundNumber int
         -trickNumber int
         -currentPlayerIdx int
-        -currentTrick []*WhistTrickCard
+        -currentTrick []*TrickCard
         -trumpSuit int
         -leadPlayerIdx int
         -dealerIdx int

--- a/docs/new-game-checklist.md
+++ b/docs/new-game-checklist.md
@@ -5,7 +5,7 @@ When adding a new game, follow this checklist to avoid post-feat fix commits. Co
 ## Backend (Go)
 
 1. **Domain**: Create `internal/domain/<Game>.go`, `<Game>Player.go`, `<Game>Config.go` (if configurable)
-2. **Reuse shared helpers**: `deal_helper.go` (dealAllCards), `hand_eval.go` (hand evaluation), `betting.go` (chip/betting), `play_style_helper.go` (CPU styles), `player_helpers.go` (resetPlayers), `hesitation.go` (CPU delay), `memory_manager.go`/`memory_decay.go` (CPU memory AI), `GamePlayer.go` (base player struct), `ChipHolder.go` (chip system), `kicker.go` (kicker comparison)
+2. **Reuse shared helpers**: `deal_helper.go` (dealAllCards), `hand_eval.go` (hand evaluation), `betting.go` (chip/betting), `play_style_helper.go` (CPU styles), `player_helpers.go` (resetPlayers), `trick_helpers.go` (`TrickCard` type + `ResolveTrickWinner` for trick-taking games), `hesitation.go` (CPU delay), `memory_manager.go`/`memory_decay.go` (CPU memory AI), `GamePlayer.go` (base player struct), `ChipHolder.go` (chip system), `kicker.go` (kicker comparison)
 3. **Interactor**: `internal/usecase/<Game>Interactor.go` with presenter interface in `internal/usecase/presenter/`
 4. **Controller**: CUI controller in `internal/adapter/controller/`, Web controller in `internal/adapter/controller/`, reuse `cuiutil` package for input parsing and `ClampIntPtr` for config validation
 5. **Presenter**: CUI and Web presenters in `internal/adapter/presenter/`, reuse `buildCuiOutput`, `cuiCardListStr`, `ActionLogOutput` helpers, `WebOutputBase` for common web output fields

--- a/internal/adapter/presenter/CallBreakCuiPresenter.go
+++ b/internal/adapter/presenter/CallBreakCuiPresenter.go
@@ -58,8 +58,8 @@ func (p *CallBreakCuiPresenter) Output(cb interfaces.CallBreakGame, lastErr erro
 		// Current trick
 		trick := cb.GetCurrentTrick()
 		cuiTrickBlock(b, trick,
-			func(tc *domain.CallBreakTrickCard) int { return tc.PlayerIdx },
-			func(tc *domain.CallBreakTrickCard) string { return cuiCardStr(tc.Card) },
+			func(tc *domain.TrickCard) int { return tc.PlayerIdx },
+			func(tc *domain.TrickCard) string { return cuiCardStr(tc.Card) },
 			func(idx int) string { return cuiPlayerName(cb.GetPlayer(idx), idx) },
 		)
 

--- a/internal/adapter/presenter/CallBreakCuiPresenter_test.go
+++ b/internal/adapter/presenter/CallBreakCuiPresenter_test.go
@@ -17,7 +17,7 @@ func setupCallBreakCuiMock() *interfaces.MockCallBreakGame {
 	m.On("GetRoundNumber").Return(1)
 	m.On("GetTrickNumber").Return(1)
 	m.On("GetSpadesBroken").Return(false)
-	m.On("GetCurrentTrick").Return([]*domain.CallBreakTrickCard(nil))
+	m.On("GetCurrentTrick").Return([]*domain.TrickCard(nil))
 	m.On("GetGameEndFlag").Return(false)
 	m.On("GetPhase").Return(domain.CallBreakPhasePlay)
 	m.On("GetCurrentPlayerIdx").Return(0)

--- a/internal/adapter/presenter/CallBreakWebPresenter.go
+++ b/internal/adapter/presenter/CallBreakWebPresenter.go
@@ -53,8 +53,8 @@ func (p *CallBreakWebPresenter) buildBase(cb interfaces.CallBreakGame) *controll
 }
 
 // buildTrickOutput 現在のトリック情報を構築
-func (p *CallBreakWebPresenter) buildTrickOutput(trick []*domain.CallBreakTrickCard) []*controller.CallBreakWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.CallBreakTrickCard) *controller.CallBreakWebOutputTrickCard {
+func (p *CallBreakWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.CallBreakWebOutputTrickCard {
+	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.CallBreakWebOutputTrickCard {
 		return &controller.CallBreakWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
 	})
 }
@@ -80,7 +80,7 @@ func (p *CallBreakWebPresenter) buildPlayersOutput(cb interfaces.CallBreakGame) 
 }
 
 // buildMessage ゲーム結果メッセージを構築
-func (p *CallBreakWebPresenter) buildMessage(cb interfaces.CallBreakGame, trick []*domain.CallBreakTrickCard, lastErr error) (string, string, map[string]string) {
+func (p *CallBreakWebPresenter) buildMessage(cb interfaces.CallBreakGame, trick []*domain.TrickCard, lastErr error) (string, string, map[string]string) {
 	if lastErr != nil {
 		return lastErr.Error(), "", nil
 	}

--- a/internal/adapter/presenter/CallBreakWebPresenter_test.go
+++ b/internal/adapter/presenter/CallBreakWebPresenter_test.go
@@ -18,7 +18,7 @@ func setupCallBreakWebMock() *interfaces.MockCallBreakGame {
 	m.On("GetRoundNumber").Return(1)
 	m.On("GetTrickNumber").Return(1)
 	m.On("GetSpadesBroken").Return(false)
-	m.On("GetCurrentTrick").Return([]*domain.CallBreakTrickCard(nil))
+	m.On("GetCurrentTrick").Return([]*domain.TrickCard(nil))
 	m.On("GetGameEndFlag").Return(false)
 	m.On("GetPhase").Return(domain.CallBreakPhasePlay)
 	m.On("GetCurrentPlayerIdx").Return(0)
@@ -83,7 +83,7 @@ func TestCallBreakWebPresenter_Output(t *testing.T) {
 	t.Run("follow phase shows follow code", func(t *testing.T) {
 		m, _ := setupCallBreakWebMockWithPlayers()
 		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetCurrentTrick")
-		m.On("GetCurrentTrick").Return([]*domain.CallBreakTrickCard{
+		m.On("GetCurrentTrick").Return([]*domain.TrickCard{
 			{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignHeart, 9, false)},
 		})
 		var resObj controller.CallBreakWebOutput

--- a/internal/adapter/presenter/CourtPieceCuiPresenter.go
+++ b/internal/adapter/presenter/CourtPieceCuiPresenter.go
@@ -85,8 +85,8 @@ func (p *CourtPieceCuiPresenter) Output(t interfaces.CourtPieceGame, lastErr err
 
 		trick := t.GetCurrentTrick()
 		cuiTrickBlock(b, trick,
-			func(tc *domain.CourtPieceTrickCard) int { return tc.PlayerIdx },
-			func(tc *domain.CourtPieceTrickCard) string { return cuiCardStr(tc.Card) },
+			func(tc *domain.TrickCard) int { return tc.PlayerIdx },
+			func(tc *domain.TrickCard) string { return cuiCardStr(tc.Card) },
 			func(idx int) string { return cuiPlayerName(t.GetPlayer(idx), idx) },
 		)
 

--- a/internal/adapter/presenter/CourtPieceWebPresenter.go
+++ b/internal/adapter/presenter/CourtPieceWebPresenter.go
@@ -49,8 +49,8 @@ func (p *CourtPieceWebPresenter) buildBase(t interfaces.CourtPieceGame) *control
 }
 
 // buildTrickOutput 現在のトリック情報を構築
-func (p *CourtPieceWebPresenter) buildTrickOutput(trick []*domain.CourtPieceTrickCard) []*controller.CourtPieceWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.CourtPieceTrickCard) *controller.CourtPieceWebOutputTrickCard {
+func (p *CourtPieceWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.CourtPieceWebOutputTrickCard {
+	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.CourtPieceWebOutputTrickCard {
 		return &controller.CourtPieceWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
 	})
 }

--- a/internal/adapter/presenter/CourtPieceWebPresenter_test.go
+++ b/internal/adapter/presenter/CourtPieceWebPresenter_test.go
@@ -57,7 +57,7 @@ func TestCourtPieceWebPresenter_Output(t *testing.T) {
 	t.Run("play phase follow when trick has cards", func(t *testing.T) {
 		cp := newCourtPieceForWebTest()
 		cp.SetPhase(domain.CourtPiecePhasePlay)
-		cp.SetCurrentTrick([]*domain.CourtPieceTrickCard{
+		cp.SetCurrentTrick([]*domain.TrickCard{
 			{PlayerIdx: 3, Card: domain.NewCard(domain.CardDesignSpade, 7, false)},
 		})
 		var got cpWebOutPartial

--- a/internal/adapter/presenter/HeartsCuiPresenter.go
+++ b/internal/adapter/presenter/HeartsCuiPresenter.go
@@ -72,8 +72,8 @@ func (p *HeartsCuiPresenter) Output(h interfaces.HeartsGame, lastErr error) stri
 		// Current trick
 		trick := h.GetCurrentTrick()
 		cuiTrickBlock(b, trick,
-			func(tc *domain.HeartsTrickCard) int { return tc.PlayerIdx },
-			func(tc *domain.HeartsTrickCard) string { return cuiCardStr(tc.Card) },
+			func(tc *domain.TrickCard) int { return tc.PlayerIdx },
+			func(tc *domain.TrickCard) string { return cuiCardStr(tc.Card) },
 			func(idx int) string { return cuiPlayerName(h.GetPlayer(idx), idx) },
 		)
 

--- a/internal/adapter/presenter/HeartsCuiPresenter_test.go
+++ b/internal/adapter/presenter/HeartsCuiPresenter_test.go
@@ -33,7 +33,7 @@ func setupHeartsCuiMock() *interfaces.MockHeartsGame {
 	m.On("GetRoundNumber").Return(1)
 	m.On("GetTrickNumber").Return(1)
 	m.On("GetHeartsBroken").Return(false)
-	m.On("GetCurrentTrick").Return([]*domain.HeartsTrickCard(nil))
+	m.On("GetCurrentTrick").Return([]*domain.TrickCard(nil))
 	m.On("GetGameEndFlag").Return(false)
 	m.On("GetPhase").Return(domain.HeartsPhasePlay)
 	m.On("GetCurrentPlayerIdx").Return(0)
@@ -152,7 +152,7 @@ func TestHeartsCuiPresenter_Output(t *testing.T) {
 	t.Run("current trick shown", func(t *testing.T) {
 		m, _ := setupHeartsCuiMockWithPlayers()
 		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetCurrentTrick")
-		trick := []*domain.HeartsTrickCard{
+		trick := []*domain.TrickCard{
 			{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignClover, 3, false)},
 			{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignClover, 7, false)},
 		}

--- a/internal/adapter/presenter/HeartsWebPresenter.go
+++ b/internal/adapter/presenter/HeartsWebPresenter.go
@@ -45,8 +45,8 @@ func (p *HeartsWebPresenter) buildBase(h interfaces.HeartsGame) *controller.Hear
 }
 
 // buildTrickOutput 現在のトリック情報を構築
-func (p *HeartsWebPresenter) buildTrickOutput(trick []*domain.HeartsTrickCard) []*controller.HeartsWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.HeartsTrickCard) *controller.HeartsWebOutputTrickCard {
+func (p *HeartsWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.HeartsWebOutputTrickCard {
+	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.HeartsWebOutputTrickCard {
 		return &controller.HeartsWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
 	})
 }
@@ -109,7 +109,7 @@ func isHeartsPenaltyCard(card *domain.Card) bool {
 }
 
 // buildMessage ゲーム結果メッセージを構築
-func (p *HeartsWebPresenter) buildMessage(h interfaces.HeartsGame, trick []*domain.HeartsTrickCard, lastErr error) (string, string, map[string]string) {
+func (p *HeartsWebPresenter) buildMessage(h interfaces.HeartsGame, trick []*domain.TrickCard, lastErr error) (string, string, map[string]string) {
 	if lastErr != nil {
 		return lastErr.Error(), "", nil
 	}

--- a/internal/adapter/presenter/HeartsWebPresenter_test.go
+++ b/internal/adapter/presenter/HeartsWebPresenter_test.go
@@ -20,7 +20,7 @@ func setupHeartsWebMock() *interfaces.MockHeartsGame {
 	m.On("GetRoundNumber").Return(1)
 	m.On("GetTrickNumber").Return(1)
 	m.On("GetHeartsBroken").Return(false)
-	m.On("GetCurrentTrick").Return([]*domain.HeartsTrickCard(nil))
+	m.On("GetCurrentTrick").Return([]*domain.TrickCard(nil))
 	m.On("GetGameEndFlag").Return(false)
 	m.On("GetPhase").Return(domain.HeartsPhasePlay)
 	m.On("GetCurrentPlayerIdx").Return(0)
@@ -150,7 +150,7 @@ func TestHeartsWebPresenter_Output(t *testing.T) {
 	t.Run("current trick populated", func(t *testing.T) {
 		m, _ := setupHeartsWebMockWithPlayers()
 		m.ExpectedCalls = removeWebMockCall(m.ExpectedCalls, "GetCurrentTrick")
-		trick := []*domain.HeartsTrickCard{
+		trick := []*domain.TrickCard{
 			{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignClover, 3, false)},
 			{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignClover, 7, false)},
 		}
@@ -296,7 +296,7 @@ func TestHeartsWebPresenter_Output(t *testing.T) {
 	t.Run("play phase follow messageCode when trick has cards", func(t *testing.T) {
 		m, _ := setupHeartsWebMockWithPlayers()
 		m.ExpectedCalls = removeWebMockCall(m.ExpectedCalls, "GetCurrentTrick")
-		trick := []*domain.HeartsTrickCard{
+		trick := []*domain.TrickCard{
 			{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignClover, 3, false)},
 		}
 		m.On("GetCurrentTrick").Return(trick)

--- a/internal/adapter/presenter/NinetyNineCuiPresenter.go
+++ b/internal/adapter/presenter/NinetyNineCuiPresenter.go
@@ -58,8 +58,8 @@ func (p *NinetyNineCuiPresenter) Output(o interfaces.NinetyNineGame, lastErr err
 
 		trick := o.GetCurrentTrick()
 		cuiTrickBlock(b, trick,
-			func(tc *domain.NinetyNineTrickCard) int { return tc.PlayerIdx },
-			func(tc *domain.NinetyNineTrickCard) string { return cuiCardStr(tc.Card) },
+			func(tc *domain.TrickCard) int { return tc.PlayerIdx },
+			func(tc *domain.TrickCard) string { return cuiCardStr(tc.Card) },
 			func(idx int) string { return cuiPlayerName(o.GetPlayer(idx), idx) },
 		)
 

--- a/internal/adapter/presenter/NinetyNineCuiPresenter_test.go
+++ b/internal/adapter/presenter/NinetyNineCuiPresenter_test.go
@@ -19,7 +19,7 @@ func setupNinetyNineCuiMock() *interfaces.MockNinetyNineGame {
 	m.On("GetTargetScore").Return(100)
 	m.On("GetHandSize").Return(9)
 	m.On("GetTrickNumber").Return(1)
-	m.On("GetCurrentTrick").Return([]*domain.NinetyNineTrickCard(nil))
+	m.On("GetCurrentTrick").Return([]*domain.TrickCard(nil))
 	m.On("GetGameEndFlag").Return(false)
 	m.On("GetPhase").Return(domain.NinetyNinePhasePlay)
 	m.On("GetCurrentPlayerIdx").Return(0)

--- a/internal/adapter/presenter/NinetyNineWebPresenter.go
+++ b/internal/adapter/presenter/NinetyNineWebPresenter.go
@@ -64,8 +64,8 @@ func (p *NinetyNineWebPresenter) buildBase(o interfaces.NinetyNineGame) *control
 }
 
 // buildTrickOutput 現在のトリック情報を構築
-func (p *NinetyNineWebPresenter) buildTrickOutput(trick []*domain.NinetyNineTrickCard) []*controller.NinetyNineWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.NinetyNineTrickCard) *controller.NinetyNineWebOutputTrickCard {
+func (p *NinetyNineWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.NinetyNineWebOutputTrickCard {
+	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.NinetyNineWebOutputTrickCard {
 		return &controller.NinetyNineWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
 	})
 }

--- a/internal/adapter/presenter/NinetyNineWebPresenter_test.go
+++ b/internal/adapter/presenter/NinetyNineWebPresenter_test.go
@@ -29,7 +29,7 @@ func setupNinetyNineWebMock() *interfaces.MockNinetyNineGame {
 	m.On("GetTargetScore").Return(100)
 	m.On("GetHandSize").Return(9)
 	m.On("GetTrickNumber").Return(1)
-	m.On("GetCurrentTrick").Return([]*domain.NinetyNineTrickCard(nil))
+	m.On("GetCurrentTrick").Return([]*domain.TrickCard(nil))
 	m.On("GetGameEndFlag").Return(false)
 	m.On("GetPhase").Return(domain.NinetyNinePhasePlay)
 	m.On("GetCurrentPlayerIdx").Return(0)
@@ -102,7 +102,7 @@ func TestNinetyNineWebPresenter_Output(t *testing.T) {
 	t.Run("play phase follow message", func(t *testing.T) {
 		m, _ := setupNinetyNineWebMockWithPlayers()
 		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetCurrentTrick")
-		m.On("GetCurrentTrick").Return([]*domain.NinetyNineTrickCard{
+		m.On("GetCurrentTrick").Return([]*domain.TrickCard{
 			{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignHeart, 7, false)},
 		})
 		result := p.Output(m, nil)

--- a/internal/adapter/presenter/OhHellCuiPresenter.go
+++ b/internal/adapter/presenter/OhHellCuiPresenter.go
@@ -63,8 +63,8 @@ func (p *OhHellCuiPresenter) Output(o interfaces.OhHellGame, lastErr error) stri
 		// Current trick
 		trick := o.GetCurrentTrick()
 		cuiTrickBlock(b, trick,
-			func(tc *domain.OhHellTrickCard) int { return tc.PlayerIdx },
-			func(tc *domain.OhHellTrickCard) string { return cuiCardStr(tc.Card) },
+			func(tc *domain.TrickCard) int { return tc.PlayerIdx },
+			func(tc *domain.TrickCard) string { return cuiCardStr(tc.Card) },
 			func(idx int) string { return cuiPlayerName(o.GetPlayer(idx), idx) },
 		)
 

--- a/internal/adapter/presenter/OhHellCuiPresenter_test.go
+++ b/internal/adapter/presenter/OhHellCuiPresenter_test.go
@@ -19,7 +19,7 @@ func setupOhHellCuiMock() *interfaces.MockOhHellGame {
 	m.On("GetTotalRounds").Return(19)
 	m.On("GetHandSize").Return(10)
 	m.On("GetTrickNumber").Return(1)
-	m.On("GetCurrentTrick").Return([]*domain.OhHellTrickCard(nil))
+	m.On("GetCurrentTrick").Return([]*domain.TrickCard(nil))
 	m.On("GetGameEndFlag").Return(false)
 	m.On("GetPhase").Return(domain.OhHellPhasePlay)
 	m.On("GetCurrentPlayerIdx").Return(0)

--- a/internal/adapter/presenter/OhHellWebPresenter.go
+++ b/internal/adapter/presenter/OhHellWebPresenter.go
@@ -68,8 +68,8 @@ func (p *OhHellWebPresenter) buildBase(o interfaces.OhHellGame) *controller.OhHe
 }
 
 // buildTrickOutput 現在のトリック情報を構築
-func (p *OhHellWebPresenter) buildTrickOutput(trick []*domain.OhHellTrickCard) []*controller.OhHellWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.OhHellTrickCard) *controller.OhHellWebOutputTrickCard {
+func (p *OhHellWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.OhHellWebOutputTrickCard {
+	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.OhHellWebOutputTrickCard {
 		return &controller.OhHellWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
 	})
 }

--- a/internal/adapter/presenter/OhHellWebPresenter_test.go
+++ b/internal/adapter/presenter/OhHellWebPresenter_test.go
@@ -30,7 +30,7 @@ func setupOhHellWebMock() *interfaces.MockOhHellGame {
 	m.On("GetTotalRounds").Return(19)
 	m.On("GetHandSize").Return(10)
 	m.On("GetTrickNumber").Return(1)
-	m.On("GetCurrentTrick").Return([]*domain.OhHellTrickCard(nil))
+	m.On("GetCurrentTrick").Return([]*domain.TrickCard(nil))
 	m.On("GetGameEndFlag").Return(false)
 	m.On("GetPhase").Return(domain.OhHellPhasePlay)
 	m.On("GetCurrentPlayerIdx").Return(0)
@@ -114,7 +114,7 @@ func TestOhHellWebPresenter_Output(t *testing.T) {
 	t.Run("play phase follow message", func(t *testing.T) {
 		m, _ := setupOhHellWebMockWithPlayers()
 		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetCurrentTrick")
-		m.On("GetCurrentTrick").Return([]*domain.OhHellTrickCard{
+		m.On("GetCurrentTrick").Return([]*domain.TrickCard{
 			{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignHeart, 3, false)},
 		})
 

--- a/internal/adapter/presenter/SpadesCuiPresenter.go
+++ b/internal/adapter/presenter/SpadesCuiPresenter.go
@@ -83,8 +83,8 @@ func (p *SpadesCuiPresenter) Output(s interfaces.SpadesGame, lastErr error) stri
 		// Current trick
 		trick := s.GetCurrentTrick()
 		cuiTrickBlock(b, trick,
-			func(tc *domain.SpadesTrickCard) int { return tc.PlayerIdx },
-			func(tc *domain.SpadesTrickCard) string { return cuiCardStr(tc.Card) },
+			func(tc *domain.TrickCard) int { return tc.PlayerIdx },
+			func(tc *domain.TrickCard) string { return cuiCardStr(tc.Card) },
 			func(idx int) string { return cuiPlayerName(s.GetPlayer(idx), idx) },
 		)
 

--- a/internal/adapter/presenter/SpadesCuiPresenter_test.go
+++ b/internal/adapter/presenter/SpadesCuiPresenter_test.go
@@ -18,7 +18,7 @@ func setupSpadesCuiMock() *interfaces.MockSpadesGame {
 	m.On("GetRoundNumber").Return(1)
 	m.On("GetTrickNumber").Return(1)
 	m.On("GetSpadesBroken").Return(false)
-	m.On("GetCurrentTrick").Return([]*domain.SpadesTrickCard(nil))
+	m.On("GetCurrentTrick").Return([]*domain.TrickCard(nil))
 	m.On("GetGameEndFlag").Return(false)
 	m.On("GetPhase").Return(domain.SpadesPhasePlay)
 	m.On("GetCurrentPlayerIdx").Return(0)
@@ -134,7 +134,7 @@ func TestSpadesCuiPresenter_Output(t *testing.T) {
 	t.Run("current trick shown", func(t *testing.T) {
 		m, _ := setupSpadesCuiMockWithPlayers()
 		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetCurrentTrick")
-		trick := []*domain.SpadesTrickCard{
+		trick := []*domain.TrickCard{
 			{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignClover, 3, false)},
 			{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignClover, 7, false)},
 		}

--- a/internal/adapter/presenter/SpadesWebPresenter.go
+++ b/internal/adapter/presenter/SpadesWebPresenter.go
@@ -44,8 +44,8 @@ func (p *SpadesWebPresenter) buildBase(s interfaces.SpadesGame) *controller.Spad
 }
 
 // buildTrickOutput 現在のトリック情報を構築
-func (p *SpadesWebPresenter) buildTrickOutput(trick []*domain.SpadesTrickCard) []*controller.SpadesWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.SpadesTrickCard) *controller.SpadesWebOutputTrickCard {
+func (p *SpadesWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.SpadesWebOutputTrickCard {
+	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.SpadesWebOutputTrickCard {
 		return &controller.SpadesWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
 	})
 }
@@ -72,7 +72,7 @@ func (p *SpadesWebPresenter) buildPlayersOutput(s interfaces.SpadesGame) []*cont
 }
 
 // buildMessage ゲーム結果メッセージを構築
-func (p *SpadesWebPresenter) buildMessage(s interfaces.SpadesGame, trick []*domain.SpadesTrickCard, lastErr error) (string, string, map[string]string) {
+func (p *SpadesWebPresenter) buildMessage(s interfaces.SpadesGame, trick []*domain.TrickCard, lastErr error) (string, string, map[string]string) {
 	if lastErr != nil {
 		return lastErr.Error(), "", nil
 	}

--- a/internal/adapter/presenter/SpadesWebPresenter_test.go
+++ b/internal/adapter/presenter/SpadesWebPresenter_test.go
@@ -20,7 +20,7 @@ func setupSpadesWebMock() *interfaces.MockSpadesGame {
 	m.On("GetRoundNumber").Return(1)
 	m.On("GetTrickNumber").Return(1)
 	m.On("GetSpadesBroken").Return(false)
-	m.On("GetCurrentTrick").Return([]*domain.SpadesTrickCard(nil))
+	m.On("GetCurrentTrick").Return([]*domain.TrickCard(nil))
 	m.On("GetGameEndFlag").Return(false)
 	m.On("GetPhase").Return(domain.SpadesPhasePlay)
 	m.On("GetCurrentPlayerIdx").Return(0)
@@ -118,7 +118,7 @@ func TestSpadesWebPresenter_Output(t *testing.T) {
 	t.Run("current trick populated", func(t *testing.T) {
 		m, _ := setupSpadesWebMockWithPlayers()
 		m.ExpectedCalls = removeSpadesWebMockCall(m.ExpectedCalls, "GetCurrentTrick")
-		trick := []*domain.SpadesTrickCard{
+		trick := []*domain.TrickCard{
 			{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignClover, 3, false)},
 			{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignClover, 7, false)},
 		}
@@ -268,7 +268,7 @@ func TestSpadesWebPresenter_Output(t *testing.T) {
 	t.Run("play phase follow messageCode when trick has cards", func(t *testing.T) {
 		m, _ := setupSpadesWebMockWithPlayers()
 		m.ExpectedCalls = removeSpadesWebMockCall(m.ExpectedCalls, "GetCurrentTrick")
-		trick := []*domain.SpadesTrickCard{
+		trick := []*domain.TrickCard{
 			{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignClover, 3, false)},
 		}
 		m.On("GetCurrentTrick").Return(trick)

--- a/internal/adapter/presenter/TarneebCuiPresenter.go
+++ b/internal/adapter/presenter/TarneebCuiPresenter.go
@@ -84,8 +84,8 @@ func (p *TarneebCuiPresenter) Output(t interfaces.TarneebGame, lastErr error) st
 
 		trick := t.GetCurrentTrick()
 		cuiTrickBlock(b, trick,
-			func(tc *domain.TarneebTrickCard) int { return tc.PlayerIdx },
-			func(tc *domain.TarneebTrickCard) string { return cuiCardStr(tc.Card) },
+			func(tc *domain.TrickCard) int { return tc.PlayerIdx },
+			func(tc *domain.TrickCard) string { return cuiCardStr(tc.Card) },
 			func(idx int) string { return cuiPlayerName(t.GetPlayer(idx), idx) },
 		)
 

--- a/internal/adapter/presenter/TarneebWebPresenter.go
+++ b/internal/adapter/presenter/TarneebWebPresenter.go
@@ -51,8 +51,8 @@ func (p *TarneebWebPresenter) buildBase(t interfaces.TarneebGame) *controller.Ta
 }
 
 // buildTrickOutput 現在のトリック情報を構築
-func (p *TarneebWebPresenter) buildTrickOutput(trick []*domain.TarneebTrickCard) []*controller.TarneebWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.TarneebTrickCard) *controller.TarneebWebOutputTrickCard {
+func (p *TarneebWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.TarneebWebOutputTrickCard {
+	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.TarneebWebOutputTrickCard {
 		return &controller.TarneebWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
 	})
 }

--- a/internal/adapter/presenter/TarneebWebPresenter_test.go
+++ b/internal/adapter/presenter/TarneebWebPresenter_test.go
@@ -64,7 +64,7 @@ func TestTarneebWebPresenter_Output(t *testing.T) {
 	t.Run("play phase follow when trick has cards", func(t *testing.T) {
 		tn := newTarneebForWebTest()
 		tn.SetPhase(domain.TarneebPhasePlay)
-		tn.SetCurrentTrick([]*domain.TarneebTrickCard{
+		tn.SetCurrentTrick([]*domain.TrickCard{
 			{PlayerIdx: 3, Card: domain.NewCard(domain.CardDesignSpade, 7, false)},
 		})
 		var got webOutPartial

--- a/internal/adapter/presenter/TwoTenJackCuiPresenter.go
+++ b/internal/adapter/presenter/TwoTenJackCuiPresenter.go
@@ -66,8 +66,8 @@ func (p *TwoTenJackCuiPresenter) Output(s interfaces.TwoTenJackGame, lastErr err
 
 		trick := s.GetCurrentTrick()
 		cuiTrickBlock(b, trick,
-			func(tc *domain.TwoTenJackTrickCard) int { return tc.PlayerIdx },
-			func(tc *domain.TwoTenJackTrickCard) string { return cuiCardStr(tc.Card) },
+			func(tc *domain.TrickCard) int { return tc.PlayerIdx },
+			func(tc *domain.TrickCard) string { return cuiCardStr(tc.Card) },
 			func(idx int) string { return cuiPlayerName(s.GetPlayer(idx), idx) },
 		)
 

--- a/internal/adapter/presenter/TwoTenJackCuiPresenter_test.go
+++ b/internal/adapter/presenter/TwoTenJackCuiPresenter_test.go
@@ -28,7 +28,7 @@ func setupTTJCuiMock() (*interfaces.MockTwoTenJackGame, []*domain.TwoTenJackPlay
 	m.On("GetTrickNumber").Return(1)
 	m.On("GetTrumpSuit").Return(domain.CardDesignSpade)
 	m.On("GetDeclarerIdx").Return(0)
-	m.On("GetCurrentTrick").Return([]*domain.TwoTenJackTrickCard(nil))
+	m.On("GetCurrentTrick").Return([]*domain.TrickCard(nil))
 	m.On("GetGameEndFlag").Return(false)
 	m.On("GetPhase").Return(domain.TwoTenJackPhasePlay)
 	m.On("GetCurrentPlayerIdx").Return(0)
@@ -113,7 +113,7 @@ func TestTwoTenJackCuiPresenter_Output(t *testing.T) {
 	t.Run("trick shown", func(t *testing.T) {
 		m, _ := setupTTJCuiMock()
 		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetCurrentTrick")
-		trick := []*domain.TwoTenJackTrickCard{
+		trick := []*domain.TrickCard{
 			{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignClover, 3, false)},
 		}
 		m.On("GetCurrentTrick").Return(trick)

--- a/internal/adapter/presenter/TwoTenJackWebPresenter.go
+++ b/internal/adapter/presenter/TwoTenJackWebPresenter.go
@@ -41,8 +41,8 @@ func (p *TwoTenJackWebPresenter) buildBase(s interfaces.TwoTenJackGame) *control
 }
 
 // buildTrickOutput 現在のトリック情報を構築
-func (p *TwoTenJackWebPresenter) buildTrickOutput(trick []*domain.TwoTenJackTrickCard) []*controller.TwoTenJackWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.TwoTenJackTrickCard) *controller.TwoTenJackWebOutputTrickCard {
+func (p *TwoTenJackWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.TwoTenJackWebOutputTrickCard {
+	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.TwoTenJackWebOutputTrickCard {
 		return &controller.TwoTenJackWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
 	})
 }

--- a/internal/adapter/presenter/TwoTenJackWebPresenter_test.go
+++ b/internal/adapter/presenter/TwoTenJackWebPresenter_test.go
@@ -18,7 +18,7 @@ func setupTTJWebMock() (*interfaces.MockTwoTenJackGame, []*domain.TwoTenJackPlay
 	m.On("GetTrickNumber").Return(1)
 	m.On("GetTrumpSuit").Return(domain.CardDesignSpade)
 	m.On("GetDeclarerIdx").Return(0)
-	m.On("GetCurrentTrick").Return([]*domain.TwoTenJackTrickCard(nil))
+	m.On("GetCurrentTrick").Return([]*domain.TrickCard(nil))
 	m.On("GetGameEndFlag").Return(false)
 	m.On("GetPhase").Return(domain.TwoTenJackPhasePlay)
 	m.On("GetCurrentPlayerIdx").Return(0)
@@ -76,7 +76,7 @@ func TestTwoTenJackWebPresenter_Output(t *testing.T) {
 	t.Run("play follow msg", func(t *testing.T) {
 		m, _ := setupTTJWebMock()
 		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetCurrentTrick")
-		trick := []*domain.TwoTenJackTrickCard{
+		trick := []*domain.TrickCard{
 			{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignHeart, 5, false)},
 		}
 		m.On("GetCurrentTrick").Return(trick)

--- a/internal/adapter/presenter/WhistCuiPresenter.go
+++ b/internal/adapter/presenter/WhistCuiPresenter.go
@@ -52,8 +52,8 @@ func (p *WhistCuiPresenter) Output(w interfaces.WhistGame, lastErr error) string
 		// Current trick
 		trick := w.GetCurrentTrick()
 		cuiTrickBlock(b, trick,
-			func(tc *domain.WhistTrickCard) int { return tc.PlayerIdx },
-			func(tc *domain.WhistTrickCard) string { return cuiCardStr(tc.Card) },
+			func(tc *domain.TrickCard) int { return tc.PlayerIdx },
+			func(tc *domain.TrickCard) string { return cuiCardStr(tc.Card) },
 			func(idx int) string { return cuiPlayerName(w.GetPlayer(idx), idx) },
 		)
 

--- a/internal/adapter/presenter/WhistWebPresenter.go
+++ b/internal/adapter/presenter/WhistWebPresenter.go
@@ -45,8 +45,8 @@ func (p *WhistWebPresenter) buildBase(w interfaces.WhistGame) *controller.WhistW
 }
 
 // buildTrickOutput 現在のトリック情報を構築
-func (p *WhistWebPresenter) buildTrickOutput(trick []*domain.WhistTrickCard) []*controller.WhistWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.WhistTrickCard) *controller.WhistWebOutputTrickCard {
+func (p *WhistWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.WhistWebOutputTrickCard {
+	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.WhistWebOutputTrickCard {
 		return &controller.WhistWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
 	})
 }
@@ -72,7 +72,7 @@ func (p *WhistWebPresenter) buildPlayersOutput(w interfaces.WhistGame) []*contro
 }
 
 // buildMessage ゲーム結果メッセージを構築
-func (p *WhistWebPresenter) buildMessage(w interfaces.WhistGame, trick []*domain.WhistTrickCard, lastErr error) (string, string, map[string]string) {
+func (p *WhistWebPresenter) buildMessage(w interfaces.WhistGame, trick []*domain.TrickCard, lastErr error) (string, string, map[string]string) {
 	if lastErr != nil {
 		return lastErr.Error(), "", nil
 	}

--- a/internal/adapter/presenter/WhistWebPresenter_test.go
+++ b/internal/adapter/presenter/WhistWebPresenter_test.go
@@ -17,7 +17,7 @@ func setupWhistWebMock() *interfaces.MockWhistGame {
 	m := new(interfaces.MockWhistGame)
 	m.On("GetRoundNumber").Return(1)
 	m.On("GetTrickNumber").Return(1)
-	m.On("GetCurrentTrick").Return([]*domain.WhistTrickCard(nil))
+	m.On("GetCurrentTrick").Return([]*domain.TrickCard(nil))
 	m.On("GetGameEndFlag").Return(false)
 	m.On("GetPhase").Return(domain.WhistPhasePlay)
 	m.On("GetCurrentPlayerIdx").Return(0)
@@ -166,7 +166,7 @@ func TestWhistWebPresenter_Output(t *testing.T) {
 	t.Run("play phase follow message", func(t *testing.T) {
 		m, _ := setupWhistWebMockWithPlayers()
 		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetCurrentTrick")
-		trick := []*domain.WhistTrickCard{
+		trick := []*domain.TrickCard{
 			{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignHeart, 5, false)},
 		}
 		m.On("GetCurrentTrick").Return(trick)

--- a/internal/domain/CallBreak.go
+++ b/internal/domain/CallBreak.go
@@ -36,12 +36,6 @@ type CallBreakHint struct {
 	Reason    string // ヒント理由キー
 }
 
-// CallBreakTrickCard トリック中の 1 枚
-type CallBreakTrickCard struct {
-	PlayerIdx int   `json:"pi"`
-	Card      *Card `json:"c"`
-}
-
 // CallBreak Call Break ゲームクラス
 //
 // ルール上の差分メモ (Spades との比較):
@@ -59,7 +53,7 @@ type CallBreak struct {
 	roundNumber      int
 	trickNumber      int
 	currentPlayerIdx int
-	currentTrick     []*CallBreakTrickCard
+	currentTrick     []*TrickCard
 	spadesBroken     bool
 	leadPlayerIdx    int
 	bidPlayerIdx     int
@@ -353,10 +347,10 @@ func (cb *CallBreak) GetCurrentPlayerIdx() int { return cb.currentPlayerIdx }
 func (cb *CallBreak) SetCurrentPlayerIdx(idx int) { cb.currentPlayerIdx = idx }
 
 // GetCurrentTrick 現在のトリック取得
-func (cb *CallBreak) GetCurrentTrick() []*CallBreakTrickCard { return cb.currentTrick }
+func (cb *CallBreak) GetCurrentTrick() []*TrickCard { return cb.currentTrick }
 
 // SetCurrentTrick トリック設定 (テスト用)
-func (cb *CallBreak) SetCurrentTrick(trick []*CallBreakTrickCard) { cb.currentTrick = trick }
+func (cb *CallBreak) SetCurrentTrick(trick []*TrickCard) { cb.currentTrick = trick }
 
 // GetSpadesBroken スペードブレイク状態取得
 func (cb *CallBreak) GetSpadesBroken() bool { return cb.spadesBroken }
@@ -448,7 +442,7 @@ func (cb *CallBreak) startPlayPhase() {
 
 // playCard カードをプレイする共通処理
 func (cb *CallBreak) playCard(playerIdx int, card *Card) {
-	cb.currentTrick = append(cb.currentTrick, &CallBreakTrickCard{
+	cb.currentTrick = append(cb.currentTrick, &TrickCard{
 		PlayerIdx: playerIdx,
 		Card:      card,
 	})
@@ -521,34 +515,7 @@ func (cb *CallBreak) playerHasNonSpade(playerIdx int) bool {
 
 // trickWinner トリックの勝者を決定する (スペードがトランプ)
 func (cb *CallBreak) trickWinner() int {
-	if len(cb.currentTrick) == 0 {
-		return 0
-	}
-	leadSuit := cb.currentTrick[0].Card.GetDesign()
-	winnerIdx := cb.currentTrick[0].PlayerIdx
-	winnerValue := cb.currentTrick[0].Card.GetValue()
-	winnerIsSpade := cb.currentTrick[0].Card.GetDesign() == CardDesignSpade
-
-	for _, tc := range cb.currentTrick[1:] {
-		isSpade := tc.Card.GetDesign() == CardDesignSpade
-
-		switch {
-		case isSpade && !winnerIsSpade:
-			// スペード (トランプ) がリードスートに勝つ
-			winnerIdx = tc.PlayerIdx
-			winnerValue = tc.Card.GetValue()
-			winnerIsSpade = true
-		case isSpade && winnerIsSpade:
-			if tc.Card.GetValue() > winnerValue {
-				winnerIdx = tc.PlayerIdx
-				winnerValue = tc.Card.GetValue()
-			}
-		case !isSpade && !winnerIsSpade && tc.Card.GetDesign() == leadSuit && tc.Card.GetValue() > winnerValue:
-			winnerIdx = tc.PlayerIdx
-			winnerValue = tc.Card.GetValue()
-		}
-	}
-	return winnerIdx
+	return ResolveTrickWinner(cb.currentTrick, CardDesignSpade, nil)
 }
 
 // checkGameEnd ゲーム終了判定: MaxRounds 到達でゲーム終了、最高スコアが勝者
@@ -963,20 +930,20 @@ func (cb *CallBreak) GetValidPlayIndices(playerIdx int) []int {
 
 // callBreakJSON is the JSON wire format for CallBreak.
 type callBreakJSON struct {
-	TrumpCards       *TrumpCards           `json:"tc"`
-	Players          []*CallBreakPlayer    `json:"ps"`
-	Config           CallBreakConfig       `json:"cf"`
-	Phase            CallBreakPhase        `json:"ph"`
-	RoundNumber      int                   `json:"rn"`
-	TrickNumber      int                   `json:"tn"`
-	CurrentPlayerIdx int                   `json:"ci"`
-	CurrentTrick     []*CallBreakTrickCard `json:"ct"`
-	SpadesBroken     bool                  `json:"sb"`
-	LeadPlayerIdx    int                   `json:"li"`
-	BidPlayerIdx     int                   `json:"bi"`
-	GameEndFlag      bool                  `json:"ge"`
-	WinnerIdx        int                   `json:"wi"`
-	ActionLog        []*ActionLogEntry     `json:"al"`
+	TrumpCards       *TrumpCards        `json:"tc"`
+	Players          []*CallBreakPlayer `json:"ps"`
+	Config           CallBreakConfig    `json:"cf"`
+	Phase            CallBreakPhase     `json:"ph"`
+	RoundNumber      int                `json:"rn"`
+	TrickNumber      int                `json:"tn"`
+	CurrentPlayerIdx int                `json:"ci"`
+	CurrentTrick     []*TrickCard       `json:"ct"`
+	SpadesBroken     bool               `json:"sb"`
+	LeadPlayerIdx    int                `json:"li"`
+	BidPlayerIdx     int                `json:"bi"`
+	GameEndFlag      bool               `json:"ge"`
+	WinnerIdx        int                `json:"wi"`
+	ActionLog        []*ActionLogEntry  `json:"al"`
 }
 
 // MarshalJSON implements json.Marshaler.
@@ -1033,7 +1000,7 @@ func (cb *CallBreak) UnmarshalJSON(data []byte) error {
 	cb.currentPlayerIdx = j.CurrentPlayerIdx
 	cb.currentTrick = j.CurrentTrick
 	if cb.currentTrick == nil {
-		cb.currentTrick = make([]*CallBreakTrickCard, 0)
+		cb.currentTrick = make([]*TrickCard, 0)
 	}
 	cb.spadesBroken = j.SpadesBroken
 	cb.leadPlayerIdx = j.LeadPlayerIdx

--- a/internal/domain/CallBreak_internal_test.go
+++ b/internal/domain/CallBreak_internal_test.go
@@ -58,7 +58,7 @@ func TestCallBreak_trickWinner_EmptyTrick(t *testing.T) {
 
 func TestCallBreak_trickWinner_LeadSuitWins(t *testing.T) {
 	cb := newInternalCallBreak()
-	cb.currentTrick = []*CallBreakTrickCard{
+	cb.currentTrick = []*TrickCard{
 		{PlayerIdx: 0, Card: NewCard(CardDesignHeart, 5, false)},
 		{PlayerIdx: 1, Card: NewCard(CardDesignHeart, 11, false)},
 		{PlayerIdx: 2, Card: NewCard(CardDesignHeart, 4, false)},
@@ -69,7 +69,7 @@ func TestCallBreak_trickWinner_LeadSuitWins(t *testing.T) {
 
 func TestCallBreak_trickWinner_SpadeBeatsLeadSuit(t *testing.T) {
 	cb := newInternalCallBreak()
-	cb.currentTrick = []*CallBreakTrickCard{
+	cb.currentTrick = []*TrickCard{
 		{PlayerIdx: 0, Card: NewCard(CardDesignHeart, 13, false)},
 		{PlayerIdx: 1, Card: NewCard(CardDesignSpade, 2, false)},
 		{PlayerIdx: 2, Card: NewCard(CardDesignHeart, 12, false)},
@@ -80,7 +80,7 @@ func TestCallBreak_trickWinner_SpadeBeatsLeadSuit(t *testing.T) {
 
 func TestCallBreak_trickWinner_HigherSpadeWins(t *testing.T) {
 	cb := newInternalCallBreak()
-	cb.currentTrick = []*CallBreakTrickCard{
+	cb.currentTrick = []*TrickCard{
 		{PlayerIdx: 0, Card: NewCard(CardDesignHeart, 13, false)},
 		{PlayerIdx: 1, Card: NewCard(CardDesignSpade, 2, false)},
 		{PlayerIdx: 2, Card: NewCard(CardDesignSpade, 7, false)},
@@ -91,7 +91,7 @@ func TestCallBreak_trickWinner_HigherSpadeWins(t *testing.T) {
 
 func TestCallBreak_trickWinner_AllSpades(t *testing.T) {
 	cb := newInternalCallBreak()
-	cb.currentTrick = []*CallBreakTrickCard{
+	cb.currentTrick = []*TrickCard{
 		{PlayerIdx: 0, Card: NewCard(CardDesignSpade, 3, false)},
 		{PlayerIdx: 1, Card: NewCard(CardDesignSpade, 11, false)},
 		{PlayerIdx: 2, Card: NewCard(CardDesignSpade, 7, false)},
@@ -138,7 +138,7 @@ func TestCallBreak_validatePlay_MustFollowSuit(t *testing.T) {
 	cb.players[0].Reset()
 	cb.players[0].AddCard(NewCard(CardDesignHeart, 5, false))
 	cb.players[0].AddCard(NewCard(CardDesignClover, 3, false))
-	cb.currentTrick = []*CallBreakTrickCard{
+	cb.currentTrick = []*TrickCard{
 		{PlayerIdx: 1, Card: NewCard(CardDesignHeart, 9, false)},
 	}
 
@@ -155,7 +155,7 @@ func TestCallBreak_validatePlay_MustTrumpWhenVoid(t *testing.T) {
 	// Heart リードに対してプレイヤー 0 はハート無し、スペードあり、クラブあり
 	cb.players[0].AddCard(NewCard(CardDesignSpade, 5, false))
 	cb.players[0].AddCard(NewCard(CardDesignClover, 3, false))
-	cb.currentTrick = []*CallBreakTrickCard{
+	cb.currentTrick = []*TrickCard{
 		{PlayerIdx: 1, Card: NewCard(CardDesignHeart, 9, false)},
 	}
 
@@ -174,7 +174,7 @@ func TestCallBreak_validatePlay_DiscardWhenVoidAndNoTrump(t *testing.T) {
 	// Heart リードに対してハート無し・スペード無し
 	cb.players[0].AddCard(NewCard(CardDesignClover, 3, false))
 	cb.players[0].AddCard(NewCard(CardDesignDiamond, 7, false))
-	cb.currentTrick = []*CallBreakTrickCard{
+	cb.currentTrick = []*TrickCard{
 		{PlayerIdx: 1, Card: NewCard(CardDesignHeart, 9, false)},
 	}
 
@@ -189,7 +189,7 @@ func TestCallBreak_validatePlay_SpadeLeadFollowSuit(t *testing.T) {
 	cb.players[0].Reset()
 	cb.players[0].AddCard(NewCard(CardDesignSpade, 5, false))
 	cb.players[0].AddCard(NewCard(CardDesignHeart, 3, false))
-	cb.currentTrick = []*CallBreakTrickCard{
+	cb.currentTrick = []*TrickCard{
 		{PlayerIdx: 1, Card: NewCard(CardDesignSpade, 9, false)},
 	}
 	// スペードリードに対して非スペードを出せない (スペードを持っている)
@@ -210,7 +210,7 @@ func TestCallBreak_playCard_AdvancesToTrickEnd(t *testing.T) {
 	cb := newInternalCallBreak()
 	cb.SetPhase(CallBreakPhasePlay)
 	cb.SetCurrentPlayerIdx(3)
-	cb.currentTrick = []*CallBreakTrickCard{
+	cb.currentTrick = []*TrickCard{
 		{PlayerIdx: 0, Card: NewCard(CardDesignHeart, 2, false)},
 		{PlayerIdx: 1, Card: NewCard(CardDesignHeart, 3, false)},
 		{PlayerIdx: 2, Card: NewCard(CardDesignHeart, 4, false)},
@@ -323,7 +323,7 @@ func TestCallBreak_cpuPlayHard_PicksWinningOver(t *testing.T) {
 	cb.players[1].AddCard(NewCard(CardDesignHeart, 4, false))
 	cb.players[1].AddCard(NewCard(CardDesignHeart, 12, false))
 	cb.players[1].SetBid(3)
-	cb.currentTrick = []*CallBreakTrickCard{
+	cb.currentTrick = []*TrickCard{
 		{PlayerIdx: 0, Card: NewCard(CardDesignHeart, 10, false)},
 	}
 	idx := cb.cpuPlayHard(1, []int{0, 1})
@@ -336,7 +336,7 @@ func TestCallBreak_cpuPlayHard_DiscardHighWhenNoTrump(t *testing.T) {
 	cb.players[1].AddCard(NewCard(CardDesignClover, 4, false))
 	cb.players[1].AddCard(NewCard(CardDesignClover, 13, false))
 	cb.players[1].SetBid(0) // bid 達成済みのつもり (ahead)
-	cb.currentTrick = []*CallBreakTrickCard{
+	cb.currentTrick = []*TrickCard{
 		{PlayerIdx: 0, Card: NewCard(CardDesignHeart, 10, false)},
 	}
 	idx := cb.cpuPlayHard(1, []int{0, 1})
@@ -390,21 +390,21 @@ func TestCallBreak_playHintReason_Variants(t *testing.T) {
 
 	cb.players[0].Reset()
 	cb.players[0].AddCard(NewCard(CardDesignHeart, 5, false))
-	cb.currentTrick = []*CallBreakTrickCard{
+	cb.currentTrick = []*TrickCard{
 		{PlayerIdx: 1, Card: NewCard(CardDesignHeart, 11, false)},
 	}
 	assert.Equal(t, "follow_suit", cb.playHintReason(0))
 
 	cb.players[0].Reset()
 	cb.players[0].AddCard(NewCard(CardDesignSpade, 5, false))
-	cb.currentTrick = []*CallBreakTrickCard{
+	cb.currentTrick = []*TrickCard{
 		{PlayerIdx: 1, Card: NewCard(CardDesignHeart, 11, false)},
 	}
 	assert.Equal(t, "trump_cut", cb.playHintReason(0))
 
 	cb.players[0].Reset()
 	cb.players[0].AddCard(NewCard(CardDesignClover, 5, false))
-	cb.currentTrick = []*CallBreakTrickCard{
+	cb.currentTrick = []*TrickCard{
 		{PlayerIdx: 1, Card: NewCard(CardDesignHeart, 11, false)},
 	}
 	assert.Equal(t, "discard_high", cb.playHintReason(0))
@@ -469,7 +469,7 @@ func TestCallBreak_filterAbove(t *testing.T) {
 
 func TestCallBreak_summariseTrick(t *testing.T) {
 	cb := newInternalCallBreak()
-	cb.currentTrick = []*CallBreakTrickCard{
+	cb.currentTrick = []*TrickCard{
 		{PlayerIdx: 0, Card: NewCard(CardDesignHeart, 10, false)},
 		{PlayerIdx: 1, Card: NewCard(CardDesignSpade, 5, false)},
 		{PlayerIdx: 2, Card: NewCard(CardDesignSpade, 11, false)},

--- a/internal/domain/CallBreak_test.go
+++ b/internal/domain/CallBreak_test.go
@@ -340,7 +340,7 @@ func TestCallBreak_ResolveTrick(t *testing.T) {
 	cb := newTestCallBreak()
 	cb.SetPhase(domain.CallBreakPhaseTrickEnd)
 	cb.SetTrickNumber(1)
-	trick := []*domain.CallBreakTrickCard{
+	trick := []*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignHeart, 5, false)},
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignHeart, 11, false)},
 		{PlayerIdx: 2, Card: domain.NewCard(domain.CardDesignHeart, 4, false)},
@@ -356,7 +356,7 @@ func TestCallBreak_ResolveTrick_TrumpWins(t *testing.T) {
 	cb := newTestCallBreak()
 	cb.SetPhase(domain.CallBreakPhaseTrickEnd)
 	cb.SetTrickNumber(1)
-	trick := []*domain.CallBreakTrickCard{
+	trick := []*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignHeart, 13, false)},
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignSpade, 2, false)},
 		{PlayerIdx: 2, Card: domain.NewCard(domain.CardDesignHeart, 4, false)},
@@ -371,7 +371,7 @@ func TestCallBreak_ResolveTrick_AdvancesToRoundEnd(t *testing.T) {
 	cb := newTestCallBreak()
 	cb.SetPhase(domain.CallBreakPhaseTrickEnd)
 	cb.SetTrickNumber(domain.CallBreakHandSize)
-	cb.SetCurrentTrick([]*domain.CallBreakTrickCard{
+	cb.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignHeart, 5, false)},
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignHeart, 11, false)},
 		{PlayerIdx: 2, Card: domain.NewCard(domain.CardDesignHeart, 4, false)},

--- a/internal/domain/CourtPiece.go
+++ b/internal/domain/CourtPiece.go
@@ -57,12 +57,6 @@ type CourtPieceHint struct {
 	Reason    string // ヒント理由キー
 }
 
-// CourtPieceTrickCard トリック中の1枚
-type CourtPieceTrickCard struct {
-	PlayerIdx int   `json:"pi"`
-	Card      *Card `json:"c"`
-}
-
 // CourtPiece Court Piece ゲームクラス
 type CourtPiece struct {
 	trumpCards       *TrumpCards
@@ -72,7 +66,7 @@ type CourtPiece struct {
 	roundNumber      int
 	trickNumber      int
 	currentPlayerIdx int
-	currentTrick     []*CourtPieceTrickCard
+	currentTrick     []*TrickCard
 	trumpSuit        int // 0 = 未宣言、それ以外は CardDesign 値
 	callerIdx        int // 呼び手 (Hakim) のインデックス
 	leadPlayerIdx    int
@@ -422,10 +416,10 @@ func (c *CourtPiece) GetCurrentPlayerIdx() int { return c.currentPlayerIdx }
 func (c *CourtPiece) SetCurrentPlayerIdx(idx int) { c.currentPlayerIdx = idx }
 
 // GetCurrentTrick 現在のトリック取得
-func (c *CourtPiece) GetCurrentTrick() []*CourtPieceTrickCard { return c.currentTrick }
+func (c *CourtPiece) GetCurrentTrick() []*TrickCard { return c.currentTrick }
 
 // SetCurrentTrick トリック設定 (テスト用)
-func (c *CourtPiece) SetCurrentTrick(trick []*CourtPieceTrickCard) { c.currentTrick = trick }
+func (c *CourtPiece) SetCurrentTrick(trick []*TrickCard) { c.currentTrick = trick }
 
 // GetTrumpSuit トランプスート取得 (0 = 未宣言)
 func (c *CourtPiece) GetTrumpSuit() int { return c.trumpSuit }
@@ -557,7 +551,7 @@ func (c *CourtPiece) findHumanIdx() int {
 
 // playCard カードをプレイする共通処理
 func (c *CourtPiece) playCard(playerIdx int, card *Card) {
-	c.currentTrick = append(c.currentTrick, &CourtPieceTrickCard{
+	c.currentTrick = append(c.currentTrick, &TrickCard{
 		PlayerIdx: playerIdx,
 		Card:      card,
 	})
@@ -607,33 +601,7 @@ func courtPieceRank(v int) int {
 //   - 任意のトランプが出ていれば最高トランプの勝ち。
 //   - そうでなければリードスート最高の勝ち。
 func (c *CourtPiece) trickWinner() int {
-	if len(c.currentTrick) == 0 {
-		return 0
-	}
-	leadSuit := c.currentTrick[0].Card.GetDesign()
-	winnerIdx := c.currentTrick[0].PlayerIdx
-	winnerRank := courtPieceRank(c.currentTrick[0].Card.GetValue())
-	winnerIsTrump := c.currentTrick[0].Card.GetDesign() == c.trumpSuit
-
-	for _, tc := range c.currentTrick[1:] {
-		isTrump := tc.Card.GetDesign() == c.trumpSuit
-		r := courtPieceRank(tc.Card.GetValue())
-		switch {
-		case isTrump && !winnerIsTrump:
-			winnerIdx = tc.PlayerIdx
-			winnerRank = r
-			winnerIsTrump = true
-		case isTrump && winnerIsTrump:
-			if r > winnerRank {
-				winnerIdx = tc.PlayerIdx
-				winnerRank = r
-			}
-		case !isTrump && !winnerIsTrump && tc.Card.GetDesign() == leadSuit && r > winnerRank:
-			winnerIdx = tc.PlayerIdx
-			winnerRank = r
-		}
-	}
-	return winnerIdx
+	return ResolveTrickWinner(c.currentTrick, c.trumpSuit, func(cd *Card) int { return courtPieceRank(cd.GetValue()) })
 }
 
 // sortAllHands 全プレイヤーの手札をソートする
@@ -994,7 +962,7 @@ type courtPieceJSON struct {
 	RoundNumber      int                    `json:"rn"`
 	TrickNumber      int                    `json:"tn"`
 	CurrentPlayerIdx int                    `json:"ci"`
-	CurrentTrick     []*CourtPieceTrickCard `json:"ct"`
+	CurrentTrick     []*TrickCard           `json:"ct"`
 	TrumpSuit        int                    `json:"ts"`
 	CallerIdx        int                    `json:"ka"`
 	LeadPlayerIdx    int                    `json:"li"`
@@ -1097,7 +1065,7 @@ func (c *CourtPiece) UnmarshalJSON(data []byte) error {
 	c.currentPlayerIdx = j.CurrentPlayerIdx
 	c.currentTrick = j.CurrentTrick
 	if c.currentTrick == nil {
-		c.currentTrick = make([]*CourtPieceTrickCard, 0)
+		c.currentTrick = make([]*TrickCard, 0)
 	}
 	c.trumpSuit = j.TrumpSuit
 	c.callerIdx = j.CallerIdx

--- a/internal/domain/CourtPiece_test.go
+++ b/internal/domain/CourtPiece_test.go
@@ -113,7 +113,7 @@ func TestCourtPiece_MustFollowSuit(t *testing.T) {
 	c.SetCurrentPlayerIdx(0)
 	c.SetTrickNumber(1)
 	// Lead a heart; seat 0 holds a heart and a club -> must follow heart.
-	c.SetCurrentTrick([]*domain.CourtPieceTrickCard{
+	c.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 1, Card: cpCard(domain.CardDesignHeart, 7)},
 	})
 	p := c.GetPlayer(0)
@@ -130,7 +130,7 @@ func TestCourtPiece_TrickWinnerTrumpBeatsFailLead(t *testing.T) {
 	c.SetPhase(domain.CourtPiecePhaseTrickEnd)
 	c.SetTrickNumber(1)
 	// Lead a high heart, but a low trump spade should win.
-	c.SetCurrentTrick([]*domain.CourtPieceTrickCard{
+	c.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 0, Card: cpCard(domain.CardDesignHeart, 1)},   // A♥ lead
 		{PlayerIdx: 1, Card: cpCard(domain.CardDesignHeart, 13)},  // K♥
 		{PlayerIdx: 2, Card: cpCard(domain.CardDesignSpade, 2)},   // 2♠ trump
@@ -145,7 +145,7 @@ func TestCourtPiece_TrickWinnerAceHigh(t *testing.T) {
 	c.SetTrumpSuit(domain.CardDesignSpade) // no trump in trick
 	c.SetPhase(domain.CourtPiecePhaseTrickEnd)
 	c.SetTrickNumber(1)
-	c.SetCurrentTrick([]*domain.CourtPieceTrickCard{
+	c.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 0, Card: cpCard(domain.CardDesignHeart, 13)}, // K♥
 		{PlayerIdx: 1, Card: cpCard(domain.CardDesignHeart, 1)},  // A♥ wins (ace-high)
 		{PlayerIdx: 2, Card: cpCard(domain.CardDesignHeart, 10)},

--- a/internal/domain/Hearts.go
+++ b/internal/domain/Hearts.go
@@ -57,12 +57,6 @@ type HeartsHint struct {
 	Reason      string // ヒント理由キー
 }
 
-// HeartsTrickCard トリック中の1枚
-type HeartsTrickCard struct {
-	PlayerIdx int   `json:"pi"`
-	Card      *Card `json:"c"`
-}
-
 // Hearts ハーツゲームクラス
 type Hearts struct {
 	trumpCards       *TrumpCards
@@ -72,7 +66,7 @@ type Hearts struct {
 	roundNumber      int
 	trickNumber      int
 	currentPlayerIdx int
-	currentTrick     []*HeartsTrickCard
+	currentTrick     []*TrickCard
 	heartsBroken     bool
 	passedCards      [HeartsPlayerCnt][]*Card
 	passReady        [HeartsPlayerCnt]bool
@@ -431,10 +425,10 @@ func (h *Hearts) GetCurrentPlayerIdx() int { return h.currentPlayerIdx }
 func (h *Hearts) SetCurrentPlayerIdx(idx int) { h.currentPlayerIdx = idx }
 
 // GetCurrentTrick 現在のトリック取得
-func (h *Hearts) GetCurrentTrick() []*HeartsTrickCard { return h.currentTrick }
+func (h *Hearts) GetCurrentTrick() []*TrickCard { return h.currentTrick }
 
 // SetCurrentTrick トリック設定 (テスト用)
-func (h *Hearts) SetCurrentTrick(trick []*HeartsTrickCard) { h.currentTrick = trick }
+func (h *Hearts) SetCurrentTrick(trick []*TrickCard) { h.currentTrick = trick }
 
 // GetHeartsBroken ハーツブレイク状態取得
 func (h *Hearts) GetHeartsBroken() bool { return h.heartsBroken }
@@ -545,7 +539,7 @@ func (h *Hearts) findTwoOfClubs() int {
 
 // playCard カードをプレイする共通処理
 func (h *Hearts) playCard(playerIdx int, card *Card) {
-	h.currentTrick = append(h.currentTrick, &HeartsTrickCard{
+	h.currentTrick = append(h.currentTrick, &TrickCard{
 		PlayerIdx: playerIdx,
 		Card:      card,
 	})
@@ -696,20 +690,7 @@ func isPenaltyCard(card *Card) bool {
 
 // trickWinner トリックの勝者を決定する
 func (h *Hearts) trickWinner() int {
-	if len(h.currentTrick) == 0 {
-		return 0
-	}
-	leadSuit := h.currentTrick[0].Card.GetDesign()
-	winnerIdx := h.currentTrick[0].PlayerIdx
-	winnerValue := h.currentTrick[0].Card.GetValue()
-
-	for _, tc := range h.currentTrick[1:] {
-		if tc.Card.GetDesign() == leadSuit && tc.Card.GetValue() > winnerValue {
-			winnerIdx = tc.PlayerIdx
-			winnerValue = tc.Card.GetValue()
-		}
-	}
-	return winnerIdx
+	return ResolveTrickWinner(h.currentTrick, -1, nil)
 }
 
 // passTarget パス先のプレイヤーインデックスを計算する
@@ -1195,7 +1176,7 @@ type heartsJSON struct {
 	RoundNumber      int                      `json:"rn"`
 	TrickNumber      int                      `json:"tn"`
 	CurrentPlayerIdx int                      `json:"ci"`
-	CurrentTrick     []*HeartsTrickCard       `json:"ct"`
+	CurrentTrick     []*TrickCard             `json:"ct"`
 	HeartsBroken     bool                     `json:"hb"`
 	PassedCards      [HeartsPlayerCnt][]*Card `json:"pc"`
 	PassReady        [HeartsPlayerCnt]bool    `json:"pr"`
@@ -1260,7 +1241,7 @@ func (h *Hearts) UnmarshalJSON(data []byte) error {
 	h.currentPlayerIdx = j.CurrentPlayerIdx
 	h.currentTrick = j.CurrentTrick
 	if h.currentTrick == nil {
-		h.currentTrick = make([]*HeartsTrickCard, 0)
+		h.currentTrick = make([]*TrickCard, 0)
 	}
 	h.heartsBroken = j.HeartsBroken
 	h.passedCards = j.PassedCards

--- a/internal/domain/Hearts_internal_test.go
+++ b/internal/domain/Hearts_internal_test.go
@@ -125,7 +125,7 @@ func TestHearts_cpuPlayHard_FollowWithNonLeadSuitCards(t *testing.T) {
 	h.config.CpuDifficulty = HeartsCpuDifficultyHard
 
 	// Set up trick with clover lead
-	h.currentTrick = []*HeartsTrickCard{
+	h.currentTrick = []*TrickCard{
 		{PlayerIdx: 0, Card: NewCard(CardDesignClover, 10, false)},
 	}
 

--- a/internal/domain/Hearts_test.go
+++ b/internal/domain/Hearts_test.go
@@ -460,7 +460,7 @@ func TestHearts_PlayerPlay_MustFollowSuit(t *testing.T) {
 	h.SetHeartsBroken(true)
 
 	// Set lead card as clover
-	h.SetCurrentTrick([]*domain.HeartsTrickCard{
+	h.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignClover, 5, false)},
 	})
 
@@ -484,7 +484,7 @@ func TestHearts_PlayerPlay_CanPlayOffSuitWhenVoid(t *testing.T) {
 	setupPlayPhase(h, 0, 1, 2)
 	h.SetHeartsBroken(true)
 
-	h.SetCurrentTrick([]*domain.HeartsTrickCard{
+	h.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignClover, 5, false)},
 	})
 
@@ -551,7 +551,7 @@ func TestHearts_PlayerPlay_FirstTrickNoPointCards(t *testing.T) {
 	h := newTestHearts()
 	setupPlayPhase(h, 0, 1, 1) // first trick, following
 
-	h.SetCurrentTrick([]*domain.HeartsTrickCard{
+	h.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignClover, 2, false)},
 	})
 
@@ -575,7 +575,7 @@ func TestHearts_PlayerPlay_FirstTrickNoPointCards_QueenOfSpades(t *testing.T) {
 	h := newTestHearts()
 	setupPlayPhase(h, 0, 1, 1)
 
-	h.SetCurrentTrick([]*domain.HeartsTrickCard{
+	h.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignClover, 2, false)},
 	})
 
@@ -594,7 +594,7 @@ func TestHearts_PlayerPlay_FirstTrickOnlyPointCards(t *testing.T) {
 	h := newTestHearts()
 	setupPlayPhase(h, 0, 1, 1)
 
-	h.SetCurrentTrick([]*domain.HeartsTrickCard{
+	h.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignClover, 2, false)},
 	})
 
@@ -614,7 +614,7 @@ func TestHearts_PlayerPlay_BreaksHearts(t *testing.T) {
 	h.SetHeartsBroken(false)
 
 	// Lead is diamond, player has no diamond
-	h.SetCurrentTrick([]*domain.HeartsTrickCard{
+	h.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignDiamond, 5, false)},
 	})
 
@@ -633,7 +633,7 @@ func TestHearts_PlayerPlay_TrickComplete(t *testing.T) {
 	h.SetHeartsBroken(true)
 
 	// 3 cards already in trick
-	h.SetCurrentTrick([]*domain.HeartsTrickCard{
+	h.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignClover, 5, false)},
 		{PlayerIdx: 2, Card: domain.NewCard(domain.CardDesignClover, 7, false)},
 		{PlayerIdx: 3, Card: domain.NewCard(domain.CardDesignClover, 9, false)},
@@ -715,7 +715,7 @@ func TestHearts_ResolveTrick_Winner(t *testing.T) {
 	h.SetPhase(domain.HeartsPhaseTrickEnd)
 	h.SetTrickNumber(2)
 
-	h.SetCurrentTrick([]*domain.HeartsTrickCard{
+	h.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignClover, 5, false)},
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignClover, 10, false)}, // highest clover = winner
 		{PlayerIdx: 2, Card: domain.NewCard(domain.CardDesignClover, 3, false)},
@@ -735,7 +735,7 @@ func TestHearts_ResolveTrick_QueenOfSpades(t *testing.T) {
 	h.SetPhase(domain.HeartsPhaseTrickEnd)
 	h.SetTrickNumber(2)
 
-	h.SetCurrentTrick([]*domain.HeartsTrickCard{
+	h.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignSpade, 5, false)},
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignSpade, 12, false)}, // Q♠ = 13 pts, also highest
 		{PlayerIdx: 2, Card: domain.NewCard(domain.CardDesignSpade, 3, false)},
@@ -757,7 +757,7 @@ func TestHearts_ResolveTrick_WrongPhase(t *testing.T) {
 func TestHearts_ResolveTrick_IncompleteTrick(t *testing.T) {
 	h := newTestHearts()
 	h.SetPhase(domain.HeartsPhaseTrickEnd)
-	h.SetCurrentTrick([]*domain.HeartsTrickCard{
+	h.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignClover, 5, false)},
 	})
 	h.ResolveTrick() // should do nothing (not 4 cards)
@@ -768,7 +768,7 @@ func TestHearts_ResolveTrick_LastTrick(t *testing.T) {
 	h.SetPhase(domain.HeartsPhaseTrickEnd)
 	h.SetTrickNumber(13) // last trick
 
-	h.SetCurrentTrick([]*domain.HeartsTrickCard{
+	h.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignClover, 5, false)},
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignClover, 10, false)},
 		{PlayerIdx: 2, Card: domain.NewCard(domain.CardDesignClover, 3, false)},
@@ -784,7 +784,7 @@ func TestHearts_ResolveTrick_NotLastTrick(t *testing.T) {
 	h.SetPhase(domain.HeartsPhaseTrickEnd)
 	h.SetTrickNumber(5)
 
-	h.SetCurrentTrick([]*domain.HeartsTrickCard{
+	h.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignClover, 5, false)},
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignClover, 10, false)},
 		{PlayerIdx: 2, Card: domain.NewCard(domain.CardDesignClover, 3, false)},
@@ -802,7 +802,7 @@ func TestHearts_ResolveTrick_HeartsBroken(t *testing.T) {
 	h.SetHeartsBroken(false)
 
 	// Hearts card in trick -> should already be broken from playCard, but points still count
-	h.SetCurrentTrick([]*domain.HeartsTrickCard{
+	h.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignClover, 5, false)},
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignClover, 10, false)},
 		{PlayerIdx: 2, Card: domain.NewCard(domain.CardDesignHeart, 3, false)},
@@ -818,7 +818,7 @@ func TestHearts_ResolveTrick_ZeroPoints(t *testing.T) {
 	h.SetPhase(domain.HeartsPhaseTrickEnd)
 	h.SetTrickNumber(3)
 
-	h.SetCurrentTrick([]*domain.HeartsTrickCard{
+	h.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignClover, 5, false)},
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignClover, 10, false)},
 		{PlayerIdx: 2, Card: domain.NewCard(domain.CardDesignDiamond, 3, false)},
@@ -855,7 +855,7 @@ func TestHearts_NextTrick_IncrementsThroughMultipleTricks(t *testing.T) {
 	for trick := 1; trick <= 3; trick++ {
 		// Set up a complete trick
 		h.SetPhase(domain.HeartsPhaseTrickEnd)
-		h.SetCurrentTrick([]*domain.HeartsTrickCard{
+		h.SetCurrentTrick([]*domain.TrickCard{
 			{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignClover, 5, false)},
 			{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignClover, 10, false)},
 			{PlayerIdx: 2, Card: domain.NewCard(domain.CardDesignClover, 3, false)},
@@ -1225,7 +1225,7 @@ func TestHearts_CpuPlay_Normal_Follow_AvoidWinning(t *testing.T) {
 	h.SetHeartsBroken(true)
 
 	// Lead is clover 5
-	h.SetCurrentTrick([]*domain.HeartsTrickCard{
+	h.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignClover, 5, false)},
 	})
 
@@ -1249,7 +1249,7 @@ func TestHearts_CpuPlay_Normal_Follow_CannotAvoid(t *testing.T) {
 	setupPlayPhase(h, 1, 0, 2)
 	h.SetHeartsBroken(true)
 
-	h.SetCurrentTrick([]*domain.HeartsTrickCard{
+	h.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignClover, 5, false)},
 	})
 
@@ -1272,7 +1272,7 @@ func TestHearts_CpuPlay_Normal_Void_DumpsPointCard(t *testing.T) {
 	setupPlayPhase(h, 1, 0, 2)
 	h.SetHeartsBroken(true)
 
-	h.SetCurrentTrick([]*domain.HeartsTrickCard{
+	h.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignClover, 5, false)},
 	})
 
@@ -1298,7 +1298,7 @@ func TestHearts_CpuPlay_Normal_Void_HighCard(t *testing.T) {
 	setupPlayPhase(h, 1, 0, 2)
 	h.SetHeartsBroken(true)
 
-	h.SetCurrentTrick([]*domain.HeartsTrickCard{
+	h.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignClover, 5, false)},
 	})
 
@@ -1368,7 +1368,7 @@ func TestHearts_CpuPlay_Hard_Follow_UnderTrick(t *testing.T) {
 	setupPlayPhase(h, 1, 0, 2)
 	h.SetHeartsBroken(true)
 
-	h.SetCurrentTrick([]*domain.HeartsTrickCard{
+	h.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignClover, 10, false)},
 	})
 
@@ -1395,7 +1395,7 @@ func TestHearts_CpuPlay_Hard_Follow_AllAboveTrick(t *testing.T) {
 	setupPlayPhase(h, 1, 0, 2)
 	h.SetHeartsBroken(true)
 
-	h.SetCurrentTrick([]*domain.HeartsTrickCard{
+	h.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignClover, 3, false)},
 	})
 
@@ -1420,7 +1420,7 @@ func TestHearts_CpuPlay_Hard_Discard_QueenOfSpades(t *testing.T) {
 	setupPlayPhase(h, 1, 0, 2)
 	h.SetHeartsBroken(true)
 
-	h.SetCurrentTrick([]*domain.HeartsTrickCard{
+	h.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignClover, 5, false)},
 	})
 
@@ -1447,7 +1447,7 @@ func TestHearts_CpuPlay_Hard_Discard_Heart(t *testing.T) {
 	setupPlayPhase(h, 1, 0, 2)
 	h.SetHeartsBroken(true)
 
-	h.SetCurrentTrick([]*domain.HeartsTrickCard{
+	h.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignClover, 5, false)},
 	})
 
@@ -1473,7 +1473,7 @@ func TestHearts_CpuPlay_Hard_Discard_HighNonPointCard(t *testing.T) {
 	setupPlayPhase(h, 1, 0, 2)
 	h.SetHeartsBroken(true)
 
-	h.SetCurrentTrick([]*domain.HeartsTrickCard{
+	h.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignClover, 5, false)},
 	})
 
@@ -1555,7 +1555,7 @@ func TestHearts_CpuPlay_Normal_Follow_BestUnderTrick(t *testing.T) {
 	setupPlayPhase(h, 1, 0, 2)
 	h.SetHeartsBroken(true)
 
-	h.SetCurrentTrick([]*domain.HeartsTrickCard{
+	h.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignClover, 10, false)},
 	})
 
@@ -1581,7 +1581,7 @@ func TestHearts_CpuPlay_Normal_Follow_FallbackToLowest(t *testing.T) {
 	setupPlayPhase(h, 1, 0, 2)
 	h.SetHeartsBroken(true)
 
-	h.SetCurrentTrick([]*domain.HeartsTrickCard{
+	h.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignClover, 3, false)},
 	})
 
@@ -1784,7 +1784,7 @@ func TestHearts_PointCards_InTrick(t *testing.T) {
 	h.SetTrickNumber(3)
 
 	// Heart = 1 point, Q♠ = 13 points, others = 0
-	h.SetCurrentTrick([]*domain.HeartsTrickCard{
+	h.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignSpade, 5, false)},  // lead
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignSpade, 12, false)}, // Q♠ = 13 pts
 		{PlayerIdx: 2, Card: domain.NewCard(domain.CardDesignHeart, 3, false)},  // 1 pt
@@ -1860,7 +1860,7 @@ func TestHearts_TrickWinner_FirstPlayer(t *testing.T) {
 	h.SetTrickNumber(3)
 
 	// Lead player has the highest card
-	h.SetCurrentTrick([]*domain.HeartsTrickCard{
+	h.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignClover, 13, false)}, // highest
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignClover, 5, false)},
 		{PlayerIdx: 2, Card: domain.NewCard(domain.CardDesignClover, 3, false)},
@@ -1877,7 +1877,7 @@ func TestHearts_PlayerPlay_NotFirstTrick_CanPlayPointOffSuit(t *testing.T) {
 	h := newTestHearts()
 	setupPlayPhase(h, 0, 1, 3) // trick 3, not first trick
 
-	h.SetCurrentTrick([]*domain.HeartsTrickCard{
+	h.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignClover, 5, false)},
 	})
 
@@ -1902,7 +1902,7 @@ func TestHearts_CpuPlay_Hard_Follow_MixedSuits(t *testing.T) {
 	setupPlayPhase(h, 1, 0, 2)
 	h.SetHeartsBroken(true)
 
-	h.SetCurrentTrick([]*domain.HeartsTrickCard{
+	h.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignClover, 7, false)},
 	})
 
@@ -1948,7 +1948,7 @@ func TestHearts_CpuPlay_Normal_Follow_FirstCardOffSuit(t *testing.T) {
 	setupPlayPhase(h, 1, 0, 2)
 	h.SetHeartsBroken(true)
 
-	h.SetCurrentTrick([]*domain.HeartsTrickCard{
+	h.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignClover, 5, false)},
 	})
 
@@ -1977,7 +1977,7 @@ func TestHearts_CpuPlay_Hard_Follow_BestIdxStartsAboveTrick(t *testing.T) {
 	setupPlayPhase(h, 1, 0, 2)
 	h.SetHeartsBroken(true)
 
-	h.SetCurrentTrick([]*domain.HeartsTrickCard{
+	h.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignClover, 7, false)},
 	})
 
@@ -2005,7 +2005,7 @@ func TestHearts_CpuPlay_Hard_Follow_AllAbove_PicksLowest(t *testing.T) {
 	setupPlayPhase(h, 1, 0, 2)
 	h.SetHeartsBroken(true)
 
-	h.SetCurrentTrick([]*domain.HeartsTrickCard{
+	h.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignClover, 2, false)},
 	})
 
@@ -2034,7 +2034,7 @@ func TestHearts_CpuPlay_Hard_Follow_WithTrickPoints(t *testing.T) {
 	h.SetHeartsBroken(true)
 
 	// Trick has points in it
-	h.SetCurrentTrick([]*domain.HeartsTrickCard{
+	h.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignHeart, 5, false)}, // 1 point
 		{PlayerIdx: 3, Card: domain.NewCard(domain.CardDesignHeart, 8, false)}, // 1 point
 	})
@@ -2097,7 +2097,7 @@ func TestHearts_PlayerPlay_FollowSuit_Success(t *testing.T) {
 	h := newTestHearts()
 	setupPlayPhase(h, 0, 1, 3)
 
-	h.SetCurrentTrick([]*domain.HeartsTrickCard{
+	h.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignSpade, 5, false)},
 	})
 
@@ -2137,7 +2137,7 @@ func TestHearts_ResolveTrick_ActionLog(t *testing.T) {
 	h.SetPhase(domain.HeartsPhaseTrickEnd)
 	h.SetTrickNumber(2)
 
-	h.SetCurrentTrick([]*domain.HeartsTrickCard{
+	h.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignClover, 5, false)},
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignClover, 10, false)},
 		{PlayerIdx: 2, Card: domain.NewCard(domain.CardDesignClover, 3, false)},
@@ -2166,7 +2166,7 @@ func TestHearts_PlayerPlay_FirstTrick_FollowSuit(t *testing.T) {
 	h := newTestHearts()
 	setupPlayPhase(h, 0, 1, 1) // first trick
 
-	h.SetCurrentTrick([]*domain.HeartsTrickCard{
+	h.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignClover, 2, false)},
 	})
 
@@ -2220,7 +2220,7 @@ func TestHearts_CpuPlay_Normal_Void_BothNonPoint_HigherWins(t *testing.T) {
 	setupPlayPhase(h, 1, 0, 2)
 	h.SetHeartsBroken(true)
 
-	h.SetCurrentTrick([]*domain.HeartsTrickCard{
+	h.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignClover, 5, false)},
 	})
 
@@ -2244,7 +2244,7 @@ func TestHearts_PlayCard_WrapsAround(t *testing.T) {
 	setupPlayPhase(h, 3, 0, 2) // player 3's turn
 	h.SetHeartsBroken(true)
 
-	h.SetCurrentTrick([]*domain.HeartsTrickCard{
+	h.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignClover, 5, false)},
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignClover, 7, false)},
 	})
@@ -2460,7 +2460,7 @@ func TestHearts_CpuPlayHard_Follow_SkipNonLeadSuit(t *testing.T) {
 	setupPlayPhase(h, 1, 0, 2)
 	h.SetHeartsBroken(true)
 
-	h.SetCurrentTrick([]*domain.HeartsTrickCard{
+	h.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignClover, 7, false)},
 	})
 
@@ -2487,7 +2487,7 @@ func TestHearts_CpuPlay_Normal_Follow_BothAbove_PicksLower(t *testing.T) {
 	setupPlayPhase(h, 1, 0, 2)
 	h.SetHeartsBroken(true)
 
-	h.SetCurrentTrick([]*domain.HeartsTrickCard{
+	h.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignClover, 3, false)},
 	})
 
@@ -2528,7 +2528,7 @@ func TestHearts_Omnibus_ResolveTrick_JDiamondGivesNegativePoints(t *testing.T) {
 	h.SetHeartsBroken(true)
 
 	// Build a trick where player 0 wins and J♦ is in the trick
-	h.SetCurrentTrick([]*domain.HeartsTrickCard{
+	h.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignDiamond, 13, false)}, // K♦ leads
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignDiamond, 11, false)}, // J♦ (-10 pts)
 		{PlayerIdx: 2, Card: domain.NewCard(domain.CardDesignDiamond, 5, false)},
@@ -2550,7 +2550,7 @@ func TestHearts_Omnibus_ResolveTrick_JDiamondPlusHearts(t *testing.T) {
 	h.SetHeartsBroken(true)
 
 	// Trick with J♦ and a heart: -10 + 1 = -9
-	h.SetCurrentTrick([]*domain.HeartsTrickCard{
+	h.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignDiamond, 13, false)},
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignDiamond, 11, false)}, // J♦
 		{PlayerIdx: 2, Card: domain.NewCard(domain.CardDesignHeart, 5, false)},    // ♥5
@@ -2645,7 +2645,7 @@ func TestHearts_Omnibus_ValidatePlay_FirstTrick_JDiamondBlocked(t *testing.T) {
 
 	// First trick, player follows with void in lead suit
 	setupPlayPhase(h, 0, 0, 1)
-	h.SetCurrentTrick([]*domain.HeartsTrickCard{
+	h.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 3, Card: domain.NewCard(domain.CardDesignClover, 2, false)}, // lead: ♣2
 	})
 
@@ -2666,7 +2666,7 @@ func TestHearts_Omnibus_ValidatePlay_FirstTrick_JDiamondAllowed_OnlyPointCards(t
 
 	// First trick, player is void in lead suit and has only point cards
 	setupPlayPhase(h, 0, 0, 1)
-	h.SetCurrentTrick([]*domain.HeartsTrickCard{
+	h.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 3, Card: domain.NewCard(domain.CardDesignClover, 2, false)},
 	})
 
@@ -2743,7 +2743,7 @@ func TestHearts_Omnibus_CpuPlayHard_DiscardKeepsJDiamond(t *testing.T) {
 	h.SetHeartsBroken(true)
 
 	// Lead is clover, CPU1 has no clover (void)
-	h.SetCurrentTrick([]*domain.HeartsTrickCard{
+	h.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignClover, 10, false)},
 	})
 
@@ -2773,7 +2773,7 @@ func TestHearts_Omnibus_CpuPlayNormal_DiscardKeepsJDiamond(t *testing.T) {
 	h.SetHeartsBroken(true)
 
 	// Lead is clover, CPU1 is void in clover
-	h.SetCurrentTrick([]*domain.HeartsTrickCard{
+	h.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignClover, 10, false)},
 	})
 
@@ -2806,7 +2806,7 @@ func TestHearts_Omnibus_CpuPlayNormal_DiscardKeepsJDiamond_NoQSpade(t *testing.T
 	h.SetHeartsBroken(true)
 
 	// Lead is clover, CPU1 is void in clover
-	h.SetCurrentTrick([]*domain.HeartsTrickCard{
+	h.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignClover, 10, false)},
 	})
 
@@ -2861,7 +2861,7 @@ func TestHearts_GetHint_PlayPhase_FollowSuit(t *testing.T) {
 	h := newTestHearts()
 	h.Reset()
 	setupPlayPhase(h, 0, 1, 1)
-	h.SetCurrentTrick([]*domain.HeartsTrickCard{
+	h.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignClover, 7, false)},
 	})
 	p := h.GetPlayer(0)
@@ -2880,7 +2880,7 @@ func TestHearts_GetHint_PlayPhase_DiscardQueenSpades(t *testing.T) {
 	h.Reset()
 	setupPlayPhase(h, 0, 1, 2)
 	h.SetHeartsBroken(true)
-	h.SetCurrentTrick([]*domain.HeartsTrickCard{
+	h.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignDiamond, 7, false)},
 	})
 	p := h.GetPlayer(0)
@@ -2898,7 +2898,7 @@ func TestHearts_GetHint_PlayPhase_DiscardHearts(t *testing.T) {
 	h.Reset()
 	setupPlayPhase(h, 0, 1, 2)
 	h.SetHeartsBroken(true)
-	h.SetCurrentTrick([]*domain.HeartsTrickCard{
+	h.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignDiamond, 7, false)},
 	})
 	p := h.GetPlayer(0)
@@ -2916,7 +2916,7 @@ func TestHearts_GetHint_PlayPhase_DiscardHigh(t *testing.T) {
 	h.Reset()
 	setupPlayPhase(h, 0, 1, 2)
 	h.SetHeartsBroken(true)
-	h.SetCurrentTrick([]*domain.HeartsTrickCard{
+	h.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignDiamond, 7, false)},
 	})
 	p := h.GetPlayer(0)

--- a/internal/domain/NinetyNine.go
+++ b/internal/domain/NinetyNine.go
@@ -43,12 +43,6 @@ type NinetyNineHint struct {
 	Reason      string // ヒント理由キー
 }
 
-// NinetyNineTrickCard トリック中の1枚
-type NinetyNineTrickCard struct {
-	PlayerIdx int   `json:"pi"`
-	Card      *Card `json:"c"`
-}
-
 // ninetyNineTrumpRotation はディール番号で巡回する切り札スート。
 // 各ディールで切り札を固定し、ディールごとに ♠→♥→♣→♦ と巡回させる
 // (David Parlett のバリエーションのうち「ディールごとに切り札が決まる」方式を採用)。
@@ -85,7 +79,7 @@ type NinetyNine struct {
 	dealNumber       int
 	trickNumber      int
 	currentPlayerIdx int
-	currentTrick     []*NinetyNineTrickCard
+	currentTrick     []*TrickCard
 	leadPlayerIdx    int
 	bidPlayerIdx     int
 	dealerIdx        int
@@ -392,10 +386,10 @@ func (o *NinetyNine) GetCurrentPlayerIdx() int { return o.currentPlayerIdx }
 func (o *NinetyNine) SetCurrentPlayerIdx(idx int) { o.currentPlayerIdx = idx }
 
 // GetCurrentTrick 現在のトリック取得
-func (o *NinetyNine) GetCurrentTrick() []*NinetyNineTrickCard { return o.currentTrick }
+func (o *NinetyNine) GetCurrentTrick() []*TrickCard { return o.currentTrick }
 
 // SetCurrentTrick トリック設定 (テスト用)
-func (o *NinetyNine) SetCurrentTrick(trick []*NinetyNineTrickCard) { o.currentTrick = trick }
+func (o *NinetyNine) SetCurrentTrick(trick []*TrickCard) { o.currentTrick = trick }
 
 // GetTrumpSuit 切り札スート取得
 func (o *NinetyNine) GetTrumpSuit() int { return o.trumpSuit }
@@ -570,7 +564,7 @@ func (o *NinetyNine) startPlayPhase() {
 
 // playCard カードをプレイする共通処理
 func (o *NinetyNine) playCard(playerIdx int, card *Card) {
-	o.currentTrick = append(o.currentTrick, &NinetyNineTrickCard{
+	o.currentTrick = append(o.currentTrick, &TrickCard{
 		PlayerIdx: playerIdx,
 		Card:      card,
 	})
@@ -609,32 +603,7 @@ func (o *NinetyNine) playerHasSuit(playerIdx int, design int) bool {
 
 // trickWinner トリックの勝者を決定する
 func (o *NinetyNine) trickWinner() int {
-	if len(o.currentTrick) == 0 {
-		return 0
-	}
-	leadSuit := o.currentTrick[0].Card.GetDesign()
-	winnerIdx := o.currentTrick[0].PlayerIdx
-	winnerValue := ninetyNineRankValue(o.currentTrick[0].Card)
-	winnerIsTrump := o.currentTrick[0].Card.GetDesign() == o.trumpSuit
-
-	for _, tc := range o.currentTrick[1:] {
-		isTrump := tc.Card.GetDesign() == o.trumpSuit
-		val := ninetyNineRankValue(tc.Card)
-		if isTrump && !winnerIsTrump {
-			winnerIdx = tc.PlayerIdx
-			winnerValue = val
-			winnerIsTrump = true
-		} else if isTrump && winnerIsTrump {
-			if val > winnerValue {
-				winnerIdx = tc.PlayerIdx
-				winnerValue = val
-			}
-		} else if !isTrump && !winnerIsTrump && tc.Card.GetDesign() == leadSuit && val > winnerValue {
-			winnerIdx = tc.PlayerIdx
-			winnerValue = val
-		}
-	}
-	return winnerIdx
+	return ResolveTrickWinner(o.currentTrick, o.trumpSuit, ninetyNineRankValue)
 }
 
 // ninetyNineRankValue はトリックの強さ比較に使う値を返す。
@@ -1046,21 +1015,21 @@ func (o *NinetyNine) tryLoseTrick(player *NinetyNinePlayer, validIndices []int, 
 
 // ninetyNineJSON is the JSON wire format for NinetyNine.
 type ninetyNineJSON struct {
-	TrumpCards       *TrumpCards            `json:"tc"`
-	Players          []*NinetyNinePlayer    `json:"ps"`
-	Config           NinetyNineConfig       `json:"cf"`
-	Phase            NinetyNinePhase        `json:"ph"`
-	DealNumber       int                    `json:"dn"`
-	TrickNumber      int                    `json:"tn"`
-	CurrentPlayerIdx int                    `json:"ci"`
-	CurrentTrick     []*NinetyNineTrickCard `json:"ct"`
-	LeadPlayerIdx    int                    `json:"li"`
-	BidPlayerIdx     int                    `json:"bi"`
-	DealerIdx        int                    `json:"di"`
-	TrumpSuit        int                    `json:"ts"`
-	GameEndFlag      bool                   `json:"ge"`
-	WinnerIdx        int                    `json:"wi"`
-	ActionLog        []*ActionLogEntry      `json:"al"`
+	TrumpCards       *TrumpCards         `json:"tc"`
+	Players          []*NinetyNinePlayer `json:"ps"`
+	Config           NinetyNineConfig    `json:"cf"`
+	Phase            NinetyNinePhase     `json:"ph"`
+	DealNumber       int                 `json:"dn"`
+	TrickNumber      int                 `json:"tn"`
+	CurrentPlayerIdx int                 `json:"ci"`
+	CurrentTrick     []*TrickCard        `json:"ct"`
+	LeadPlayerIdx    int                 `json:"li"`
+	BidPlayerIdx     int                 `json:"bi"`
+	DealerIdx        int                 `json:"di"`
+	TrumpSuit        int                 `json:"ts"`
+	GameEndFlag      bool                `json:"ge"`
+	WinnerIdx        int                 `json:"wi"`
+	ActionLog        []*ActionLogEntry   `json:"al"`
 }
 
 // MarshalJSON implements json.Marshaler.
@@ -1164,7 +1133,7 @@ func (o *NinetyNine) UnmarshalJSON(data []byte) error {
 	o.currentPlayerIdx = j.CurrentPlayerIdx
 	o.currentTrick = j.CurrentTrick
 	if o.currentTrick == nil {
-		o.currentTrick = make([]*NinetyNineTrickCard, 0)
+		o.currentTrick = make([]*TrickCard, 0)
 	}
 	o.leadPlayerIdx = j.LeadPlayerIdx
 	o.bidPlayerIdx = j.BidPlayerIdx

--- a/internal/domain/NinetyNine_test.go
+++ b/internal/domain/NinetyNine_test.go
@@ -263,7 +263,7 @@ func TestNinetyNine_PlayerPlay_MustFollow(t *testing.T) {
 	// human has hearts and a club; lead heart trick already in progress
 	o.GetPlayer(0).AddCard(domain.NewCard(domain.CardDesignHeart, 7, false))
 	o.GetPlayer(0).AddCard(domain.NewCard(domain.CardDesignClover, 8, false))
-	o.SetCurrentTrick([]*domain.NinetyNineTrickCard{
+	o.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 2, Card: domain.NewCard(domain.CardDesignHeart, 10, false)},
 	})
 	// playing club (idx1) while holding heart must fail
@@ -308,7 +308,7 @@ func TestNinetyNine_ResolveTrick_HighestLeadWins(t *testing.T) {
 	setupPlay(o)
 	o.SetTrumpSuit(domain.CardDesignClover) // no trump in trick
 	o.SetTrickNumber(1)
-	o.SetCurrentTrick([]*domain.NinetyNineTrickCard{
+	o.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignHeart, 7, false)},
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignHeart, 13, false)},
 		{PlayerIdx: 2, Card: domain.NewCard(domain.CardDesignHeart, 9, false)},
@@ -324,7 +324,7 @@ func TestNinetyNine_ResolveTrick_AceHighWins(t *testing.T) {
 	setupPlay(o)
 	o.SetTrumpSuit(domain.CardDesignClover)
 	o.SetTrickNumber(1)
-	o.SetCurrentTrick([]*domain.NinetyNineTrickCard{
+	o.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignHeart, 13, false)},
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignHeart, 1, false)}, // Ace
 		{PlayerIdx: 2, Card: domain.NewCard(domain.CardDesignHeart, 12, false)},
@@ -339,7 +339,7 @@ func TestNinetyNine_ResolveTrick_TrumpWins(t *testing.T) {
 	setupPlay(o)
 	o.SetTrumpSuit(domain.CardDesignSpade)
 	o.SetTrickNumber(1)
-	o.SetCurrentTrick([]*domain.NinetyNineTrickCard{
+	o.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignHeart, 1, false)}, // Ace heart lead
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignSpade, 6, false)}, // low trump
 		{PlayerIdx: 2, Card: domain.NewCard(domain.CardDesignHeart, 13, false)},
@@ -353,7 +353,7 @@ func TestNinetyNine_ResolveTrick_LastTrickSetsRoundEnd(t *testing.T) {
 	o := newTestNinetyNine()
 	setupPlay(o)
 	o.SetTrickNumber(domain.NinetyNineTricksPerDeal)
-	o.SetCurrentTrick([]*domain.NinetyNineTrickCard{
+	o.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignHeart, 7, false)},
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignHeart, 8, false)},
 		{PlayerIdx: 2, Card: domain.NewCard(domain.CardDesignHeart, 9, false)},
@@ -543,7 +543,7 @@ func TestNinetyNine_Accessors(t *testing.T) {
 	o.SetBidPlayerIdx(1)
 	o.CpuBid() // generate at least one action-log entry
 	assert.NotEmpty(t, o.GetActionLog())
-	o.SetCurrentTrick([]*domain.NinetyNineTrickCard{})
+	o.SetCurrentTrick([]*domain.TrickCard{})
 	assert.NotNil(t, o.GetCurrentTrick())
 
 	// IsHumanTurn both branches
@@ -566,7 +566,7 @@ func TestNinetyNine_Accessors(t *testing.T) {
 func TestNinetyNine_GetValidPlayIndices(t *testing.T) {
 	o := newTestNinetyNine()
 	setupPlay(o)
-	o.SetCurrentTrick([]*domain.NinetyNineTrickCard{
+	o.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignHeart, 10, false)},
 	})
 	o.GetPlayer(0).AddCard(domain.NewCard(domain.CardDesignHeart, 7, false))

--- a/internal/domain/OhHell.go
+++ b/internal/domain/OhHell.go
@@ -33,12 +33,6 @@ type OhHellHint struct {
 	Reason    string // ヒント理由キー
 }
 
-// OhHellTrickCard トリック中の1枚
-type OhHellTrickCard struct {
-	PlayerIdx int   `json:"pi"`
-	Card      *Card `json:"c"`
-}
-
 // OhHell オー・ヘルゲームクラス
 type OhHell struct {
 	trumpCards       *TrumpCards
@@ -50,7 +44,7 @@ type OhHell struct {
 	handSize         int // 現在のラウンドの手札枚数
 	trickNumber      int
 	currentPlayerIdx int
-	currentTrick     []*OhHellTrickCard
+	currentTrick     []*TrickCard
 	leadPlayerIdx    int
 	bidPlayerIdx     int
 	dealerIdx        int
@@ -356,10 +350,10 @@ func (o *OhHell) GetCurrentPlayerIdx() int { return o.currentPlayerIdx }
 func (o *OhHell) SetCurrentPlayerIdx(idx int) { o.currentPlayerIdx = idx }
 
 // GetCurrentTrick 現在のトリック取得
-func (o *OhHell) GetCurrentTrick() []*OhHellTrickCard { return o.currentTrick }
+func (o *OhHell) GetCurrentTrick() []*TrickCard { return o.currentTrick }
 
 // SetCurrentTrick トリック設定 (テスト用)
-func (o *OhHell) SetCurrentTrick(trick []*OhHellTrickCard) { o.currentTrick = trick }
+func (o *OhHell) SetCurrentTrick(trick []*TrickCard) { o.currentTrick = trick }
 
 // GetTrumpCard 切り札カード取得
 func (o *OhHell) GetTrumpCard() *Card { return o.trumpCard }
@@ -571,7 +565,7 @@ func (o *OhHell) startPlayPhase() {
 
 // playCard カードをプレイする共通処理
 func (o *OhHell) playCard(playerIdx int, card *Card) {
-	o.currentTrick = append(o.currentTrick, &OhHellTrickCard{
+	o.currentTrick = append(o.currentTrick, &TrickCard{
 		PlayerIdx: playerIdx,
 		Card:      card,
 	})
@@ -616,35 +610,7 @@ func (o *OhHell) playerHasSuit(playerIdx int, design int) bool {
 
 // trickWinner トリックの勝者を決定する
 func (o *OhHell) trickWinner() int {
-	if len(o.currentTrick) == 0 {
-		return 0
-	}
-	leadSuit := o.currentTrick[0].Card.GetDesign()
-	winnerIdx := o.currentTrick[0].PlayerIdx
-	winnerValue := o.currentTrick[0].Card.GetValue()
-	winnerIsTrump := o.trumpSuit >= 0 && o.currentTrick[0].Card.GetDesign() == o.trumpSuit
-
-	for _, tc := range o.currentTrick[1:] {
-		isTrump := o.trumpSuit >= 0 && tc.Card.GetDesign() == o.trumpSuit
-
-		if isTrump && !winnerIsTrump {
-			// トランプがリードスートに勝つ
-			winnerIdx = tc.PlayerIdx
-			winnerValue = tc.Card.GetValue()
-			winnerIsTrump = true
-		} else if isTrump && winnerIsTrump {
-			// トランプ同士: 高い方が勝つ
-			if tc.Card.GetValue() > winnerValue {
-				winnerIdx = tc.PlayerIdx
-				winnerValue = tc.Card.GetValue()
-			}
-		} else if !isTrump && !winnerIsTrump && tc.Card.GetDesign() == leadSuit && tc.Card.GetValue() > winnerValue {
-			// 非トランプ同士: リードスートの高い方が勝つ
-			winnerIdx = tc.PlayerIdx
-			winnerValue = tc.Card.GetValue()
-		}
-	}
-	return winnerIdx
+	return ResolveTrickWinner(o.currentTrick, o.trumpSuit, nil)
 }
 
 // determineWinner 最終的な勝者を決定する
@@ -1106,24 +1072,24 @@ func (o *OhHell) tryLoseTrick(player *OhHellPlayer, validIndices []int, leadSuit
 
 // ohHellJSON is the JSON wire format for OhHell.
 type ohHellJSON struct {
-	TrumpCards       *TrumpCards        `json:"tc"`
-	Players          []*OhHellPlayer    `json:"ps"`
-	Config           OhHellConfig       `json:"cf"`
-	Phase            OhHellPhase        `json:"ph"`
-	RoundNumber      int                `json:"rn"`
-	TotalRounds      int                `json:"tr"`
-	HandSize         int                `json:"hs"`
-	TrickNumber      int                `json:"tn"`
-	CurrentPlayerIdx int                `json:"ci"`
-	CurrentTrick     []*OhHellTrickCard `json:"ct"`
-	LeadPlayerIdx    int                `json:"li"`
-	BidPlayerIdx     int                `json:"bi"`
-	DealerIdx        int                `json:"di"`
-	TrumpCard        *Card              `json:"tp"`
-	TrumpSuit        int                `json:"ts"`
-	GameEndFlag      bool               `json:"ge"`
-	WinnerIdx        int                `json:"wi"`
-	ActionLog        []*ActionLogEntry  `json:"al"`
+	TrumpCards       *TrumpCards       `json:"tc"`
+	Players          []*OhHellPlayer   `json:"ps"`
+	Config           OhHellConfig      `json:"cf"`
+	Phase            OhHellPhase       `json:"ph"`
+	RoundNumber      int               `json:"rn"`
+	TotalRounds      int               `json:"tr"`
+	HandSize         int               `json:"hs"`
+	TrickNumber      int               `json:"tn"`
+	CurrentPlayerIdx int               `json:"ci"`
+	CurrentTrick     []*TrickCard      `json:"ct"`
+	LeadPlayerIdx    int               `json:"li"`
+	BidPlayerIdx     int               `json:"bi"`
+	DealerIdx        int               `json:"di"`
+	TrumpCard        *Card             `json:"tp"`
+	TrumpSuit        int               `json:"ts"`
+	GameEndFlag      bool              `json:"ge"`
+	WinnerIdx        int               `json:"wi"`
+	ActionLog        []*ActionLogEntry `json:"al"`
 }
 
 // MarshalJSON implements json.Marshaler.
@@ -1200,7 +1166,7 @@ func (o *OhHell) UnmarshalJSON(data []byte) error {
 	o.currentPlayerIdx = j.CurrentPlayerIdx
 	o.currentTrick = j.CurrentTrick
 	if o.currentTrick == nil {
-		o.currentTrick = make([]*OhHellTrickCard, 0)
+		o.currentTrick = make([]*TrickCard, 0)
 	}
 	o.leadPlayerIdx = j.LeadPlayerIdx
 	o.bidPlayerIdx = j.BidPlayerIdx

--- a/internal/domain/OhHell_test.go
+++ b/internal/domain/OhHell_test.go
@@ -407,7 +407,7 @@ func TestOhHell_PlayerPlay_FollowSuit(t *testing.T) {
 
 	setupOhHellPlayPhase(o, 0, 1, 1)
 	// Lead card is a heart
-	o.SetCurrentTrick([]*domain.OhHellTrickCard{
+	o.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignHeart, 8, false)},
 	})
 
@@ -429,7 +429,7 @@ func TestOhHell_PlayerPlay_NoFollowSuitWhenVoid(t *testing.T) {
 	p.AddCard(domain.NewCard(domain.CardDesignSpade, 10, false))
 
 	setupOhHellPlayPhase(o, 0, 1, 1)
-	o.SetCurrentTrick([]*domain.OhHellTrickCard{
+	o.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignHeart, 8, false)},
 	})
 
@@ -490,7 +490,7 @@ func TestOhHell_ResolveTrick_HighestLeadWins(t *testing.T) {
 	o.SetTrickNumber(1)
 	o.SetHandSize(3)
 	// All hearts — trump irrelevant, highest lead suit wins
-	o.SetCurrentTrick([]*domain.OhHellTrickCard{
+	o.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignHeart, 5, false)},
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignHeart, 10, false)},
 		{PlayerIdx: 2, Card: domain.NewCard(domain.CardDesignHeart, 13, false)},
@@ -514,7 +514,7 @@ func TestOhHell_ResolveTrick_TrumpWins(t *testing.T) {
 	o.SetPhase(domain.OhHellPhaseTrickEnd)
 	o.SetTrickNumber(1)
 	o.SetHandSize(3)
-	o.SetCurrentTrick([]*domain.OhHellTrickCard{
+	o.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignHeart, 13, false)},
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignHeart, 10, false)},
 		{PlayerIdx: 2, Card: domain.NewCard(domain.CardDesignSpade, 2, false)},
@@ -544,7 +544,7 @@ func TestOhHell_ResolveTrick_NoTrump(t *testing.T) {
 	o.SetPhase(domain.OhHellPhaseTrickEnd)
 	o.SetTrickNumber(1)
 	o.SetHandSize(13)
-	o.SetCurrentTrick([]*domain.OhHellTrickCard{
+	o.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignHeart, 5, false)},
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignSpade, 13, false)},
 		{PlayerIdx: 2, Card: domain.NewCard(domain.CardDesignHeart, 10, false)},
@@ -562,7 +562,7 @@ func TestOhHell_ResolveTrick_SetsRoundEnd(t *testing.T) {
 	o.SetPhase(domain.OhHellPhaseTrickEnd)
 	o.SetTrickNumber(10) // last trick (handSize=10)
 	o.SetHandSize(10)
-	o.SetCurrentTrick([]*domain.OhHellTrickCard{
+	o.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignHeart, 5, false)},
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignHeart, 10, false)},
 		{PlayerIdx: 2, Card: domain.NewCard(domain.CardDesignHeart, 3, false)},
@@ -940,7 +940,7 @@ func TestOhHell_GetValidPlayIndices(t *testing.T) {
 	p.AddCard(domain.NewCard(domain.CardDesignHeart, 8, false))
 
 	setupOhHellPlayPhase(o, 0, 1, 1)
-	o.SetCurrentTrick([]*domain.OhHellTrickCard{
+	o.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignHeart, 3, false)},
 	})
 
@@ -980,7 +980,7 @@ func TestOhHell_ResolveTrick_IncompleteTrick(t *testing.T) {
 	o := newTestOhHell()
 	o.Reset()
 	o.SetPhase(domain.OhHellPhaseTrickEnd)
-	o.SetCurrentTrick([]*domain.OhHellTrickCard{
+	o.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignHeart, 5, false)},
 	})
 
@@ -1000,7 +1000,7 @@ func TestOhHell_CpuPlay_FollowSuit(t *testing.T) {
 	p.SetBid(1)
 
 	setupOhHellPlayPhase(o, 1, 0, 1)
-	o.SetCurrentTrick([]*domain.OhHellTrickCard{
+	o.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignHeart, 8, false)},
 	})
 

--- a/internal/domain/Spades.go
+++ b/internal/domain/Spades.go
@@ -36,12 +36,6 @@ type SpadesHint struct {
 	Reason    string // ヒント理由キー
 }
 
-// SpadesTrickCard トリック中の1枚
-type SpadesTrickCard struct {
-	PlayerIdx int   `json:"pi"`
-	Card      *Card `json:"c"`
-}
-
 // SpadesLoseThreshold 負け閾値 (-200点以下で負け)
 const SpadesLoseThreshold = -200
 
@@ -54,7 +48,7 @@ type Spades struct {
 	roundNumber      int
 	trickNumber      int
 	currentPlayerIdx int
-	currentTrick     []*SpadesTrickCard
+	currentTrick     []*TrickCard
 	spadesBroken     bool
 	leadPlayerIdx    int
 	bidPlayerIdx     int
@@ -361,10 +355,10 @@ func (s *Spades) GetCurrentPlayerIdx() int { return s.currentPlayerIdx }
 func (s *Spades) SetCurrentPlayerIdx(idx int) { s.currentPlayerIdx = idx }
 
 // GetCurrentTrick 現在のトリック取得
-func (s *Spades) GetCurrentTrick() []*SpadesTrickCard { return s.currentTrick }
+func (s *Spades) GetCurrentTrick() []*TrickCard { return s.currentTrick }
 
 // SetCurrentTrick トリック設定 (テスト用)
-func (s *Spades) SetCurrentTrick(trick []*SpadesTrickCard) { s.currentTrick = trick }
+func (s *Spades) SetCurrentTrick(trick []*TrickCard) { s.currentTrick = trick }
 
 // GetSpadesBroken スペードブレイク状態取得
 func (s *Spades) GetSpadesBroken() bool { return s.spadesBroken }
@@ -479,7 +473,7 @@ func (s *Spades) findTwoOfClubs() int {
 
 // playCard カードをプレイする共通処理
 func (s *Spades) playCard(playerIdx int, card *Card) {
-	s.currentTrick = append(s.currentTrick, &SpadesTrickCard{
+	s.currentTrick = append(s.currentTrick, &TrickCard{
 		PlayerIdx: playerIdx,
 		Card:      card,
 	})
@@ -566,35 +560,7 @@ func (s *Spades) playerHasNonSpade(playerIdx int) bool {
 
 // trickWinner トリックの勝者を決定する (スペードがトランプ)
 func (s *Spades) trickWinner() int {
-	if len(s.currentTrick) == 0 {
-		return 0
-	}
-	leadSuit := s.currentTrick[0].Card.GetDesign()
-	winnerIdx := s.currentTrick[0].PlayerIdx
-	winnerValue := s.currentTrick[0].Card.GetValue()
-	winnerIsSpade := s.currentTrick[0].Card.GetDesign() == CardDesignSpade
-
-	for _, tc := range s.currentTrick[1:] {
-		isSpade := tc.Card.GetDesign() == CardDesignSpade
-
-		if isSpade && !winnerIsSpade {
-			// スペード（トランプ）がリードスートに勝つ
-			winnerIdx = tc.PlayerIdx
-			winnerValue = tc.Card.GetValue()
-			winnerIsSpade = true
-		} else if isSpade && winnerIsSpade {
-			// スペード同士: 高い方が勝つ
-			if tc.Card.GetValue() > winnerValue {
-				winnerIdx = tc.PlayerIdx
-				winnerValue = tc.Card.GetValue()
-			}
-		} else if !isSpade && !winnerIsSpade && tc.Card.GetDesign() == leadSuit && tc.Card.GetValue() > winnerValue {
-			// 非スペード同士: リードスートの高い方が勝つ
-			winnerIdx = tc.PlayerIdx
-			winnerValue = tc.Card.GetValue()
-		}
-	}
-	return winnerIdx
+	return ResolveTrickWinner(s.currentTrick, CardDesignSpade, nil)
 }
 
 // checkGameEnd ゲーム終了判定
@@ -1132,20 +1098,20 @@ func (s *Spades) GetValidPlayIndices(playerIdx int) []int {
 
 // spadesJSON is the JSON wire format for Spades.
 type spadesJSON struct {
-	TrumpCards       *TrumpCards        `json:"tc"`
-	Players          []*SpadesPlayer    `json:"ps"`
-	Config           SpadesConfig       `json:"cf"`
-	Phase            SpadesPhase        `json:"ph"`
-	RoundNumber      int                `json:"rn"`
-	TrickNumber      int                `json:"tn"`
-	CurrentPlayerIdx int                `json:"ci"`
-	CurrentTrick     []*SpadesTrickCard `json:"ct"`
-	SpadesBroken     bool               `json:"sb"`
-	LeadPlayerIdx    int                `json:"li"`
-	BidPlayerIdx     int                `json:"bi"`
-	GameEndFlag      bool               `json:"ge"`
-	WinnerIdx        int                `json:"wi"`
-	ActionLog        []*ActionLogEntry  `json:"al"`
+	TrumpCards       *TrumpCards       `json:"tc"`
+	Players          []*SpadesPlayer   `json:"ps"`
+	Config           SpadesConfig      `json:"cf"`
+	Phase            SpadesPhase       `json:"ph"`
+	RoundNumber      int               `json:"rn"`
+	TrickNumber      int               `json:"tn"`
+	CurrentPlayerIdx int               `json:"ci"`
+	CurrentTrick     []*TrickCard      `json:"ct"`
+	SpadesBroken     bool              `json:"sb"`
+	LeadPlayerIdx    int               `json:"li"`
+	BidPlayerIdx     int               `json:"bi"`
+	GameEndFlag      bool              `json:"ge"`
+	WinnerIdx        int               `json:"wi"`
+	ActionLog        []*ActionLogEntry `json:"al"`
 }
 
 // MarshalJSON implements json.Marshaler.
@@ -1197,7 +1163,7 @@ func (s *Spades) UnmarshalJSON(data []byte) error {
 	s.currentPlayerIdx = j.CurrentPlayerIdx
 	s.currentTrick = j.CurrentTrick
 	if s.currentTrick == nil {
-		s.currentTrick = make([]*SpadesTrickCard, 0)
+		s.currentTrick = make([]*TrickCard, 0)
 	}
 	s.spadesBroken = j.SpadesBroken
 	s.leadPlayerIdx = j.LeadPlayerIdx

--- a/internal/domain/Spades_internal_test.go
+++ b/internal/domain/Spades_internal_test.go
@@ -99,7 +99,7 @@ func TestSpades_trickWinner_EmptyTrick(t *testing.T) {
 
 func TestSpades_trickWinner_LeadSuitWins(t *testing.T) {
 	s := newInternalTestSpades()
-	s.currentTrick = []*SpadesTrickCard{
+	s.currentTrick = []*TrickCard{
 		{PlayerIdx: 0, Card: NewCard(CardDesignHeart, 5, false)},
 		{PlayerIdx: 1, Card: NewCard(CardDesignHeart, 10, false)},
 		{PlayerIdx: 2, Card: NewCard(CardDesignHeart, 3, false)},
@@ -110,7 +110,7 @@ func TestSpades_trickWinner_LeadSuitWins(t *testing.T) {
 
 func TestSpades_trickWinner_SpadeBeatsLead(t *testing.T) {
 	s := newInternalTestSpades()
-	s.currentTrick = []*SpadesTrickCard{
+	s.currentTrick = []*TrickCard{
 		{PlayerIdx: 0, Card: NewCard(CardDesignHeart, 13, false)},
 		{PlayerIdx: 1, Card: NewCard(CardDesignSpade, 2, false)},
 		{PlayerIdx: 2, Card: NewCard(CardDesignHeart, 10, false)},
@@ -121,7 +121,7 @@ func TestSpades_trickWinner_SpadeBeatsLead(t *testing.T) {
 
 func TestSpades_trickWinner_HighestSpadeWins(t *testing.T) {
 	s := newInternalTestSpades()
-	s.currentTrick = []*SpadesTrickCard{
+	s.currentTrick = []*TrickCard{
 		{PlayerIdx: 0, Card: NewCard(CardDesignHeart, 13, false)},
 		{PlayerIdx: 1, Card: NewCard(CardDesignSpade, 5, false)},
 		{PlayerIdx: 2, Card: NewCard(CardDesignSpade, 10, false)},
@@ -132,7 +132,7 @@ func TestSpades_trickWinner_HighestSpadeWins(t *testing.T) {
 
 func TestSpades_trickWinner_OffSuitDoesNotWin(t *testing.T) {
 	s := newInternalTestSpades()
-	s.currentTrick = []*SpadesTrickCard{
+	s.currentTrick = []*TrickCard{
 		{PlayerIdx: 0, Card: NewCard(CardDesignClover, 5, false)},
 		{PlayerIdx: 1, Card: NewCard(CardDesignHeart, 13, false)}, // off-suit K
 		{PlayerIdx: 2, Card: NewCard(CardDesignClover, 3, false)},
@@ -150,7 +150,7 @@ func TestSpades_validatePlay_FollowSuit(t *testing.T) {
 	s.players[0].AddCard(NewCard(CardDesignHeart, 5, false))
 	s.players[0].AddCard(NewCard(CardDesignClover, 3, false))
 
-	s.currentTrick = []*SpadesTrickCard{
+	s.currentTrick = []*TrickCard{
 		{PlayerIdx: 1, Card: NewCard(CardDesignClover, 7, false)},
 	}
 
@@ -170,7 +170,7 @@ func TestSpades_validatePlay_NoSuitAllowed(t *testing.T) {
 	s.players[0].Reset()
 	s.players[0].AddCard(NewCard(CardDesignHeart, 5, false))
 
-	s.currentTrick = []*SpadesTrickCard{
+	s.currentTrick = []*TrickCard{
 		{PlayerIdx: 1, Card: NewCard(CardDesignClover, 7, false)},
 	}
 
@@ -261,7 +261,7 @@ func TestSpades_getValidPlayIndices_FollowSuit(t *testing.T) {
 	s := newInternalTestSpades()
 	s.trickNumber = 2
 	s.spadesBroken = true
-	s.currentTrick = []*SpadesTrickCard{
+	s.currentTrick = []*TrickCard{
 		{PlayerIdx: 1, Card: NewCard(CardDesignHeart, 7, false)},
 	}
 
@@ -349,7 +349,7 @@ func TestSpades_cpuPlayNormal_Lead(t *testing.T) {
 
 func TestSpades_cpuPlayNormal_Follow_TryToWin(t *testing.T) {
 	s := newInternalTestSpades()
-	s.currentTrick = []*SpadesTrickCard{
+	s.currentTrick = []*TrickCard{
 		{PlayerIdx: 2, Card: NewCard(CardDesignHeart, 7, false)},
 	}
 
@@ -365,7 +365,7 @@ func TestSpades_cpuPlayNormal_Follow_TryToWin(t *testing.T) {
 
 func TestSpades_cpuPlayNormal_Follow_UnderOnly(t *testing.T) {
 	s := newInternalTestSpades()
-	s.currentTrick = []*SpadesTrickCard{
+	s.currentTrick = []*TrickCard{
 		{PlayerIdx: 2, Card: NewCard(CardDesignHeart, 13, false)}, // K♥
 	}
 
@@ -381,7 +381,7 @@ func TestSpades_cpuPlayNormal_Follow_UnderOnly(t *testing.T) {
 
 func TestSpades_cpuPlayNormal_Follow_NoLeadSuit(t *testing.T) {
 	s := newInternalTestSpades()
-	s.currentTrick = []*SpadesTrickCard{
+	s.currentTrick = []*TrickCard{
 		{PlayerIdx: 2, Card: NewCard(CardDesignClover, 7, false)},
 	}
 
@@ -397,7 +397,7 @@ func TestSpades_cpuPlayNormal_Follow_NoLeadSuit(t *testing.T) {
 
 func TestSpades_cpuPlayNormal_Follow_NoLeadSuit_EnoughTricks(t *testing.T) {
 	s := newInternalTestSpades()
-	s.currentTrick = []*SpadesTrickCard{
+	s.currentTrick = []*TrickCard{
 		{PlayerIdx: 2, Card: NewCard(CardDesignClover, 7, false)},
 	}
 
@@ -416,7 +416,7 @@ func TestSpades_cpuPlayNormal_Follow_NoLeadSuit_EnoughTricks(t *testing.T) {
 
 func TestSpades_cpuPlayNormal_Follow_MustFollowSuit_LowestLeadSuit(t *testing.T) {
 	s := newInternalTestSpades()
-	s.currentTrick = []*SpadesTrickCard{
+	s.currentTrick = []*TrickCard{
 		{PlayerIdx: 2, Card: NewCard(CardDesignHeart, 13, false)},
 	}
 
@@ -462,7 +462,7 @@ func TestSpades_cpuPlayHard_Lead_EnoughTricks(t *testing.T) {
 
 func TestSpades_cpuPlayHard_Follow_TryToWin(t *testing.T) {
 	s := newInternalTestSpades()
-	s.currentTrick = []*SpadesTrickCard{
+	s.currentTrick = []*TrickCard{
 		{PlayerIdx: 2, Card: NewCard(CardDesignHeart, 7, false)},
 	}
 
@@ -478,7 +478,7 @@ func TestSpades_cpuPlayHard_Follow_TryToWin(t *testing.T) {
 
 func TestSpades_cpuPlayHard_Follow_UnderCards(t *testing.T) {
 	s := newInternalTestSpades()
-	s.currentTrick = []*SpadesTrickCard{
+	s.currentTrick = []*TrickCard{
 		{PlayerIdx: 2, Card: NewCard(CardDesignHeart, 13, false)},
 	}
 
@@ -494,7 +494,7 @@ func TestSpades_cpuPlayHard_Follow_UnderCards(t *testing.T) {
 
 func TestSpades_cpuPlayHard_Follow_OverCardsOnly(t *testing.T) {
 	s := newInternalTestSpades()
-	s.currentTrick = []*SpadesTrickCard{
+	s.currentTrick = []*TrickCard{
 		{PlayerIdx: 2, Card: NewCard(CardDesignHeart, 2, false)},
 	}
 
@@ -510,7 +510,7 @@ func TestSpades_cpuPlayHard_Follow_OverCardsOnly(t *testing.T) {
 
 func TestSpades_cpuPlayHard_Void_SpadesCut(t *testing.T) {
 	s := newInternalTestSpades()
-	s.currentTrick = []*SpadesTrickCard{
+	s.currentTrick = []*TrickCard{
 		{PlayerIdx: 2, Card: NewCard(CardDesignClover, 7, false)},
 	}
 
@@ -526,7 +526,7 @@ func TestSpades_cpuPlayHard_Void_SpadesCut(t *testing.T) {
 
 func TestSpades_cpuPlayHard_Void_SpadesCut_WithExistingSpade(t *testing.T) {
 	s := newInternalTestSpades()
-	s.currentTrick = []*SpadesTrickCard{
+	s.currentTrick = []*TrickCard{
 		{PlayerIdx: 2, Card: NewCard(CardDesignClover, 7, false)},
 		{PlayerIdx: 3, Card: NewCard(CardDesignSpade, 5, false)},
 	}
@@ -544,7 +544,7 @@ func TestSpades_cpuPlayHard_Void_SpadesCut_WithExistingSpade(t *testing.T) {
 
 func TestSpades_cpuPlayHard_Void_NoSpade(t *testing.T) {
 	s := newInternalTestSpades()
-	s.currentTrick = []*SpadesTrickCard{
+	s.currentTrick = []*TrickCard{
 		{PlayerIdx: 2, Card: NewCard(CardDesignClover, 7, false)},
 	}
 
@@ -561,7 +561,7 @@ func TestSpades_cpuPlayHard_Void_NoSpade(t *testing.T) {
 
 func TestSpades_cpuPlayHard_Follow_SpadeInTrick(t *testing.T) {
 	s := newInternalTestSpades()
-	s.currentTrick = []*SpadesTrickCard{
+	s.currentTrick = []*TrickCard{
 		{PlayerIdx: 2, Card: NewCard(CardDesignHeart, 7, false)},
 		{PlayerIdx: 3, Card: NewCard(CardDesignSpade, 10, false)},
 	}
@@ -579,7 +579,7 @@ func TestSpades_cpuPlayHard_Follow_SpadeInTrick(t *testing.T) {
 
 func TestSpades_cpuPlayHard_Follow_SpadeLeadSuit(t *testing.T) {
 	s := newInternalTestSpades()
-	s.currentTrick = []*SpadesTrickCard{
+	s.currentTrick = []*TrickCard{
 		{PlayerIdx: 2, Card: NewCard(CardDesignSpade, 7, false)},
 	}
 

--- a/internal/domain/Spades_test.go
+++ b/internal/domain/Spades_test.go
@@ -394,7 +394,7 @@ func TestSpades_ValidatePlay_FollowSuit(t *testing.T) {
 
 	setupSpadesPlayPhase(s, 0, 1, 2)
 	s.SetSpadesBroken(true)
-	s.SetCurrentTrick([]*domain.SpadesTrickCard{
+	s.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignClover, 7, false)},
 	})
 
@@ -417,7 +417,7 @@ func TestSpades_ValidatePlay_NoSuitToFollow(t *testing.T) {
 
 	setupSpadesPlayPhase(s, 0, 1, 2)
 	s.SetSpadesBroken(true)
-	s.SetCurrentTrick([]*domain.SpadesTrickCard{
+	s.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignClover, 7, false)},
 	})
 
@@ -467,7 +467,7 @@ func TestSpades_TrickWinner_NoTrump(t *testing.T) {
 
 	s.SetPhase(domain.SpadesPhaseTrickEnd)
 	s.SetTrickNumber(2)
-	s.SetCurrentTrick([]*domain.SpadesTrickCard{
+	s.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignHeart, 5, false)},
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignHeart, 10, false)},
 		{PlayerIdx: 2, Card: domain.NewCard(domain.CardDesignHeart, 3, false)},
@@ -485,7 +485,7 @@ func TestSpades_TrickWinner_WithTrump(t *testing.T) {
 	s.SetSpadesBroken(true)
 
 	s.SetPhase(domain.SpadesPhaseTrickEnd)
-	s.SetCurrentTrick([]*domain.SpadesTrickCard{
+	s.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignHeart, 13, false)},   // K♥
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignHeart, 10, false)},   // 10♥
 		{PlayerIdx: 2, Card: domain.NewCard(domain.CardDesignSpade, 2, false)},    // 2♠ (trump)
@@ -502,7 +502,7 @@ func TestSpades_TrickWinner_MultipleTrumps(t *testing.T) {
 
 	s.SetPhase(domain.SpadesPhaseTrickEnd)
 	s.SetTrickNumber(2)
-	s.SetCurrentTrick([]*domain.SpadesTrickCard{
+	s.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignHeart, 13, false)},
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignSpade, 5, false)},
 		{PlayerIdx: 2, Card: domain.NewCard(domain.CardDesignSpade, 10, false)},
@@ -524,7 +524,7 @@ func TestSpades_ResolveTrick_IncompleteCards(t *testing.T) {
 	s := newTestSpades()
 	s.Reset()
 	s.SetPhase(domain.SpadesPhaseTrickEnd)
-	s.SetCurrentTrick([]*domain.SpadesTrickCard{
+	s.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignHeart, 5, false)},
 	})
 	s.ResolveTrick() // should be no-op (not 4 cards)
@@ -817,7 +817,7 @@ func TestSpades_SpadesBrokenOnPlay(t *testing.T) {
 	s.SetSpadesBroken(false)
 
 	// Leading with only spades should break spades
-	s.SetCurrentTrick([]*domain.SpadesTrickCard{
+	s.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignHeart, 7, false)},
 	})
 
@@ -837,7 +837,7 @@ func TestSpades_TrickEndToRoundEnd(t *testing.T) {
 		s.GetPlayer(i).SetBid(3)
 	}
 
-	s.SetCurrentTrick([]*domain.SpadesTrickCard{
+	s.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignHeart, 5, false)},
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignHeart, 10, false)},
 		{PlayerIdx: 2, Card: domain.NewCard(domain.CardDesignHeart, 3, false)},
@@ -1019,7 +1019,7 @@ func TestSpades_GetHint_PlayPhase_FollowSuit(t *testing.T) {
 	s := newTestSpades()
 	s.Reset()
 	setupSpadesPlayPhase(s, 0, 1, 1)
-	s.SetCurrentTrick([]*domain.SpadesTrickCard{
+	s.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignClover, 7, false)},
 	})
 	p := s.GetPlayer(0)
@@ -1038,7 +1038,7 @@ func TestSpades_GetHint_PlayPhase_TrumpCut(t *testing.T) {
 	s.Reset()
 	setupSpadesPlayPhase(s, 0, 1, 2)
 	s.SetSpadesBroken(true)
-	s.SetCurrentTrick([]*domain.SpadesTrickCard{
+	s.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignDiamond, 7, false)},
 	})
 	p := s.GetPlayer(0)
@@ -1058,7 +1058,7 @@ func TestSpades_GetHint_PlayPhase_DiscardHigh(t *testing.T) {
 	s.Reset()
 	setupSpadesPlayPhase(s, 0, 1, 2)
 	s.SetSpadesBroken(true)
-	s.SetCurrentTrick([]*domain.SpadesTrickCard{
+	s.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignDiamond, 7, false)},
 	})
 	p := s.GetPlayer(0)

--- a/internal/domain/Tarneeb.go
+++ b/internal/domain/Tarneeb.go
@@ -44,12 +44,6 @@ type TarneebHint struct {
 	Reason    string // ヒント理由キー
 }
 
-// TarneebTrickCard トリック中の1枚
-type TarneebTrickCard struct {
-	PlayerIdx int   `json:"pi"`
-	Card      *Card `json:"c"`
-}
-
 // Tarneeb Tarneebゲームクラス
 //
 // ルール概要:
@@ -68,7 +62,7 @@ type Tarneeb struct {
 	roundNumber      int
 	trickNumber      int
 	currentPlayerIdx int
-	currentTrick     []*TarneebTrickCard
+	currentTrick     []*TrickCard
 	trumpSuit        int // 0 = 未宣言、それ以外は CardDesign 値
 	bidPlayerIdx     int // 次にビッドするプレイヤー (ビッドフェーズ中)
 	bidWinnerIdx     int // 最高ビッド者 (-1 = 未確定)
@@ -462,10 +456,10 @@ func (t *Tarneeb) GetCurrentPlayerIdx() int { return t.currentPlayerIdx }
 func (t *Tarneeb) SetCurrentPlayerIdx(idx int) { t.currentPlayerIdx = idx }
 
 // GetCurrentTrick 現在のトリック取得
-func (t *Tarneeb) GetCurrentTrick() []*TarneebTrickCard { return t.currentTrick }
+func (t *Tarneeb) GetCurrentTrick() []*TrickCard { return t.currentTrick }
 
 // SetCurrentTrick トリック設定 (テスト用)
-func (t *Tarneeb) SetCurrentTrick(trick []*TarneebTrickCard) { t.currentTrick = trick }
+func (t *Tarneeb) SetCurrentTrick(trick []*TrickCard) { t.currentTrick = trick }
 
 // GetTrumpSuit トランプスート取得 (0 = 未宣言)
 func (t *Tarneeb) GetTrumpSuit() int { return t.trumpSuit }
@@ -630,7 +624,7 @@ func (t *Tarneeb) findHumanIdx() int {
 
 // playCard カードをプレイする共通処理
 func (t *Tarneeb) playCard(playerIdx int, card *Card) {
-	t.currentTrick = append(t.currentTrick, &TarneebTrickCard{
+	t.currentTrick = append(t.currentTrick, &TrickCard{
 		PlayerIdx: playerIdx,
 		Card:      card,
 	})
@@ -684,33 +678,7 @@ func tarneebRank(v int) int {
 //
 // Aces compare as the strongest rank (see tarneebRank).
 func (t *Tarneeb) trickWinner() int {
-	if len(t.currentTrick) == 0 {
-		return 0
-	}
-	leadSuit := t.currentTrick[0].Card.GetDesign()
-	winnerIdx := t.currentTrick[0].PlayerIdx
-	winnerRank := tarneebRank(t.currentTrick[0].Card.GetValue())
-	winnerIsTrump := t.currentTrick[0].Card.GetDesign() == t.trumpSuit
-
-	for _, tc := range t.currentTrick[1:] {
-		isTrump := tc.Card.GetDesign() == t.trumpSuit
-		r := tarneebRank(tc.Card.GetValue())
-		switch {
-		case isTrump && !winnerIsTrump:
-			winnerIdx = tc.PlayerIdx
-			winnerRank = r
-			winnerIsTrump = true
-		case isTrump && winnerIsTrump:
-			if r > winnerRank {
-				winnerIdx = tc.PlayerIdx
-				winnerRank = r
-			}
-		case !isTrump && !winnerIsTrump && tc.Card.GetDesign() == leadSuit && r > winnerRank:
-			winnerIdx = tc.PlayerIdx
-			winnerRank = r
-		}
-	}
-	return winnerIdx
+	return ResolveTrickWinner(t.currentTrick, t.trumpSuit, func(cd *Card) int { return tarneebRank(cd.GetValue()) })
 }
 
 // sortAllHands 全プレイヤーの手札をソートする
@@ -1184,7 +1152,7 @@ type tarneebJSON struct {
 	RoundNumber      int                 `json:"rn"`
 	TrickNumber      int                 `json:"tn"`
 	CurrentPlayerIdx int                 `json:"ci"`
-	CurrentTrick     []*TarneebTrickCard `json:"ct"`
+	CurrentTrick     []*TrickCard        `json:"ct"`
 	TrumpSuit        int                 `json:"ts"`
 	BidPlayerIdx     int                 `json:"bi"`
 	BidWinnerIdx     int                 `json:"bw"`
@@ -1255,7 +1223,7 @@ func (t *Tarneeb) UnmarshalJSON(data []byte) error {
 	t.currentPlayerIdx = j.CurrentPlayerIdx
 	t.currentTrick = j.CurrentTrick
 	if t.currentTrick == nil {
-		t.currentTrick = make([]*TarneebTrickCard, 0)
+		t.currentTrick = make([]*TrickCard, 0)
 	}
 	t.trumpSuit = j.TrumpSuit
 	t.bidPlayerIdx = j.BidPlayerIdx

--- a/internal/domain/Tarneeb_coverage_test.go
+++ b/internal/domain/Tarneeb_coverage_test.go
@@ -35,7 +35,7 @@ func TestTarneeb_Setters(t *testing.T) {
 	tn.SetRoundNumber(7)
 	tn.SetTrickNumber(3)
 	tn.SetCurrentPlayerIdx(2)
-	tn.SetCurrentTrick([]*TarneebTrickCard{{PlayerIdx: 1, Card: NewCard(CardDesignSpade, 4, false)}})
+	tn.SetCurrentTrick([]*TrickCard{{PlayerIdx: 1, Card: NewCard(CardDesignSpade, 4, false)}})
 	tn.SetTrumpSuit(CardDesignDiamond)
 	tn.SetBidPlayerIdx(3)
 	tn.SetBidWinnerIdx(2)
@@ -213,7 +213,7 @@ func TestTarneeb_PlayerPlay_BadValidate(t *testing.T) {
 	tn.SetTrumpSuit(CardDesignSpade)
 	tn.SetCurrentPlayerIdx(0)
 	leadCard := NewCard(CardDesignHeart, 6, false)
-	tn.SetCurrentTrick([]*TarneebTrickCard{{PlayerIdx: 3, Card: leadCard}})
+	tn.SetCurrentTrick([]*TrickCard{{PlayerIdx: 3, Card: leadCard}})
 	fillHand(tn.GetPlayer(0), []*Card{
 		NewCard(CardDesignHeart, 4, false),
 		NewCard(CardDesignClover, 2, false),
@@ -234,7 +234,7 @@ func TestTarneeb_JSON_RoundTrip_WithTrick(t *testing.T) {
 	tn.SetTeamScore(0, 4)
 	tn.SetTeamScore(1, -1)
 	tn.SetLeadPlayerIdx(2)
-	tn.SetCurrentTrick([]*TarneebTrickCard{
+	tn.SetCurrentTrick([]*TrickCard{
 		{PlayerIdx: 2, Card: NewCard(CardDesignSpade, 13, false)},
 		{PlayerIdx: 3, Card: NewCard(CardDesignSpade, 1, false)},
 	})
@@ -278,7 +278,7 @@ func TestTarneeb_TrickWinner_AllTrumps(t *testing.T) {
 	tn := newCov(TarneebCpuDifficultyNormal)
 	tn.Reset()
 	tn.SetTrumpSuit(CardDesignSpade)
-	tn.SetCurrentTrick([]*TarneebTrickCard{
+	tn.SetCurrentTrick([]*TrickCard{
 		{PlayerIdx: 0, Card: NewCard(CardDesignSpade, 7, false)},
 		{PlayerIdx: 1, Card: NewCard(CardDesignSpade, 13, false)},
 		{PlayerIdx: 2, Card: NewCard(CardDesignSpade, 2, false)},
@@ -297,7 +297,7 @@ func TestTarneeb_TrickWinner_NoCards(t *testing.T) {
 func TestTarneeb_SummariseTrick_NoTrump(t *testing.T) {
 	tn := newCov(TarneebCpuDifficultyNormal)
 	tn.SetTrumpSuit(CardDesignSpade)
-	tn.SetCurrentTrick([]*TarneebTrickCard{
+	tn.SetCurrentTrick([]*TrickCard{
 		{PlayerIdx: 0, Card: NewCard(CardDesignHeart, 5, false)},
 		{PlayerIdx: 1, Card: NewCard(CardDesignHeart, 9, false)},
 	})
@@ -318,19 +318,19 @@ func TestTarneeb_IsPartnerCurrentlyWinning(t *testing.T) {
 	assert.False(t, tn.isPartnerCurrentlyWinning(0))
 
 	// Idx 2 is partner of 0; idx 2 leads the trick → from idx 0's POV partner is winning.
-	tn.SetCurrentTrick([]*TarneebTrickCard{
+	tn.SetCurrentTrick([]*TrickCard{
 		{PlayerIdx: 2, Card: NewCard(CardDesignHeart, 12, false)},
 	})
 	assert.True(t, tn.isPartnerCurrentlyWinning(0))
 
 	// Idx 1 winning is not partner of idx 0.
-	tn.SetCurrentTrick([]*TarneebTrickCard{
+	tn.SetCurrentTrick([]*TrickCard{
 		{PlayerIdx: 1, Card: NewCard(CardDesignSpade, 5, false)},
 	})
 	assert.False(t, tn.isPartnerCurrentlyWinning(0))
 
 	// Self-winning is not "partner winning".
-	tn.SetCurrentTrick([]*TarneebTrickCard{
+	tn.SetCurrentTrick([]*TrickCard{
 		{PlayerIdx: 0, Card: NewCard(CardDesignSpade, 5, false)},
 	})
 	assert.False(t, tn.isPartnerCurrentlyWinning(0))
@@ -375,7 +375,7 @@ func TestTarneeb_CpuPlayNormal_Lead_Overcards(t *testing.T) {
 	tn.SetPhase(TarneebPhasePlay)
 	tn.SetTrumpSuit(CardDesignSpade)
 	// Existing trick led with H-9. Player 1 has H-10 and H-K — should play the lowest over (10).
-	tn.SetCurrentTrick([]*TarneebTrickCard{
+	tn.SetCurrentTrick([]*TrickCard{
 		{PlayerIdx: 3, Card: NewCard(CardDesignHeart, 9, false)},
 	})
 	fillHand(tn.GetPlayer(1), []*Card{
@@ -391,7 +391,7 @@ func TestTarneeb_CpuPlayNormal_Void_TrumpAvailable(t *testing.T) {
 	tn.Reset()
 	tn.SetPhase(TarneebPhasePlay)
 	tn.SetTrumpSuit(CardDesignSpade)
-	tn.SetCurrentTrick([]*TarneebTrickCard{
+	tn.SetCurrentTrick([]*TrickCard{
 		{PlayerIdx: 3, Card: NewCard(CardDesignHeart, 9, false)},
 	})
 	fillHand(tn.GetPlayer(1), []*Card{
@@ -408,7 +408,7 @@ func TestTarneeb_CpuPlayNormal_Void_TrumpInTrick(t *testing.T) {
 	tn.Reset()
 	tn.SetPhase(TarneebPhasePlay)
 	tn.SetTrumpSuit(CardDesignSpade)
-	tn.SetCurrentTrick([]*TarneebTrickCard{
+	tn.SetCurrentTrick([]*TrickCard{
 		{PlayerIdx: 3, Card: NewCard(CardDesignHeart, 9, false)},
 		{PlayerIdx: 2, Card: NewCard(CardDesignSpade, 5, false)},
 	})
@@ -442,7 +442,7 @@ func TestTarneeb_CpuPlayHard_Void_NoTrump(t *testing.T) {
 	tn.Reset()
 	tn.SetPhase(TarneebPhasePlay)
 	tn.SetTrumpSuit(CardDesignSpade)
-	tn.SetCurrentTrick([]*TarneebTrickCard{
+	tn.SetCurrentTrick([]*TrickCard{
 		{PlayerIdx: 0, Card: NewCard(CardDesignHeart, 13, false)},
 	})
 	fillHand(tn.GetPlayer(1), []*Card{
@@ -460,7 +460,7 @@ func TestTarneeb_CpuPlayHard_PartnerWinning_Void(t *testing.T) {
 	tn.SetPhase(TarneebPhasePlay)
 	tn.SetTrumpSuit(CardDesignSpade)
 	// Idx 1's partner is idx 3; idx 3 leads with H-A → partner winning. Idx 1 is void.
-	tn.SetCurrentTrick([]*TarneebTrickCard{
+	tn.SetCurrentTrick([]*TrickCard{
 		{PlayerIdx: 3, Card: NewCard(CardDesignHeart, 1, false)},
 	})
 	fillHand(tn.GetPlayer(1), []*Card{
@@ -478,7 +478,7 @@ func TestTarneeb_CpuPlayHard_LeadSuit_PartnerWinning(t *testing.T) {
 	tn.SetPhase(TarneebPhasePlay)
 	tn.SetTrumpSuit(CardDesignSpade)
 	// Partner (idx 3) of idx 1 winning with H-A. Idx 1 has H-5 and H-K → must play low.
-	tn.SetCurrentTrick([]*TarneebTrickCard{
+	tn.SetCurrentTrick([]*TrickCard{
 		{PlayerIdx: 3, Card: NewCard(CardDesignHeart, 1, false)},
 	})
 	fillHand(tn.GetPlayer(1), []*Card{
@@ -494,7 +494,7 @@ func TestTarneeb_CpuSelectPlayCard_Single(t *testing.T) {
 	tn.Reset()
 	tn.SetPhase(TarneebPhasePlay)
 	tn.SetTrumpSuit(CardDesignSpade)
-	tn.SetCurrentTrick([]*TarneebTrickCard{
+	tn.SetCurrentTrick([]*TrickCard{
 		{PlayerIdx: 0, Card: NewCard(CardDesignHeart, 5, false)},
 	})
 	fillHand(tn.GetPlayer(1), []*Card{NewCard(CardDesignHeart, 3, false)})
@@ -507,7 +507,7 @@ func TestTarneeb_CpuSelectPlayCard_Empty(t *testing.T) {
 	tn.Reset()
 	tn.SetPhase(TarneebPhasePlay)
 	tn.SetTrumpSuit(CardDesignSpade)
-	tn.SetCurrentTrick([]*TarneebTrickCard{
+	tn.SetCurrentTrick([]*TrickCard{
 		{PlayerIdx: 0, Card: NewCard(CardDesignHeart, 5, false)},
 	})
 	// Empty hand → fallback 0.
@@ -601,7 +601,7 @@ func TestTarneeb_GetValidPlayIndices_Public(t *testing.T) {
 	tn.SetPhase(TarneebPhasePlay)
 	tn.SetCurrentPlayerIdx(0)
 	leadCard := NewCard(CardDesignHeart, 5, false)
-	tn.SetCurrentTrick([]*TarneebTrickCard{{PlayerIdx: 3, Card: leadCard}})
+	tn.SetCurrentTrick([]*TrickCard{{PlayerIdx: 3, Card: leadCard}})
 	fillHand(tn.GetPlayer(0), []*Card{
 		NewCard(CardDesignHeart, 9, false),
 		NewCard(CardDesignSpade, 4, false),

--- a/internal/domain/Tarneeb_internal_test.go
+++ b/internal/domain/Tarneeb_internal_test.go
@@ -143,7 +143,7 @@ func TestCpuPlayHard_PartnerWinning_PlaysLow(t *testing.T) {
 	// idx 2 (team 0) leads with A♥; idx 1 (team 1) is current player; idx 3 (team 1) is partner of idx 1.
 	// idx 3 hasn't played yet, but trick winner consult is for idx 1's choice with idx 0 (team 0) being current trick.
 	// パートナーが勝っている状況を模擬: idx 3 がパートナーで A♥ をリード。
-	tn.SetCurrentTrick([]*TarneebTrickCard{
+	tn.SetCurrentTrick([]*TrickCard{
 		{PlayerIdx: 3, Card: NewCard(CardDesignHeart, 1, false)}, // partner of idx1
 	})
 	fillHand(tn.GetPlayer(1), []*Card{
@@ -174,7 +174,7 @@ func TestIsValidSuit(t *testing.T) {
 func TestSummariseTrick(t *testing.T) {
 	tn := newInternalTarneeb(TarneebCpuDifficultyNormal)
 	tn.SetTrumpSuit(CardDesignSpade)
-	tn.SetCurrentTrick([]*TarneebTrickCard{
+	tn.SetCurrentTrick([]*TrickCard{
 		{PlayerIdx: 0, Card: NewCard(CardDesignHeart, 5, false)},
 		{PlayerIdx: 1, Card: NewCard(CardDesignSpade, 2, false)},
 		{PlayerIdx: 2, Card: NewCard(CardDesignHeart, 13, false)},
@@ -202,7 +202,7 @@ func TestPlayHintReason(t *testing.T) {
 	tn.SetCurrentTrick(nil)
 	assert.Equal(t, "lead_strong", tn.playHintReason(0, 0))
 
-	tn.SetCurrentTrick([]*TarneebTrickCard{
+	tn.SetCurrentTrick([]*TrickCard{
 		{PlayerIdx: 3, Card: NewCard(CardDesignHeart, 8, false)},
 	})
 	assert.Equal(t, "follow_suit", tn.playHintReason(0, 0))

--- a/internal/domain/Tarneeb_test.go
+++ b/internal/domain/Tarneeb_test.go
@@ -270,7 +270,7 @@ func TestTarneeb_FollowSuit_Violation(t *testing.T) {
 	tn.SetCurrentPlayerIdx(0)
 	// リードカードがハートになるよう、currentTrick をセット
 	leadCard := domain.NewCard(domain.CardDesignHeart, 6, false)
-	tn.SetCurrentTrick([]*domain.TarneebTrickCard{{PlayerIdx: 3, Card: leadCard}})
+	tn.SetCurrentTrick([]*domain.TrickCard{{PlayerIdx: 3, Card: leadCard}})
 	clearAndDeal(tn.GetPlayer(0), []*domain.Card{
 		domain.NewCard(domain.CardDesignHeart, 4, false),
 		domain.NewCard(domain.CardDesignDiamond, 2, false),
@@ -289,7 +289,7 @@ func TestTarneeb_Void_AllowsAnyCard(t *testing.T) {
 	tn.SetTrumpSuit(domain.CardDesignSpade)
 	tn.SetCurrentPlayerIdx(0)
 	leadCard := domain.NewCard(domain.CardDesignHeart, 6, false)
-	tn.SetCurrentTrick([]*domain.TarneebTrickCard{{PlayerIdx: 3, Card: leadCard}})
+	tn.SetCurrentTrick([]*domain.TrickCard{{PlayerIdx: 3, Card: leadCard}})
 	clearAndDeal(tn.GetPlayer(0), []*domain.Card{
 		domain.NewCard(domain.CardDesignDiamond, 2, false),
 		domain.NewCard(domain.CardDesignSpade, 5, false),
@@ -304,7 +304,7 @@ func TestTarneeb_TrickWinner_TrumpBeatsLead(t *testing.T) {
 	tn.SetPhase(domain.TarneebPhasePlay)
 	tn.SetTrumpSuit(domain.CardDesignSpade)
 	tn.SetTrickNumber(1)
-	tn.SetCurrentTrick([]*domain.TarneebTrickCard{
+	tn.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignHeart, 13, false)},
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignHeart, 1, false)},
 		{PlayerIdx: 2, Card: domain.NewCard(domain.CardDesignSpade, 2, false)},
@@ -323,7 +323,7 @@ func TestTarneeb_TrickWinner_NoTrump_HighLeadWins(t *testing.T) {
 	tn.SetPhase(domain.TarneebPhaseTrickEnd)
 	tn.SetTrumpSuit(domain.CardDesignSpade)
 	tn.SetTrickNumber(1)
-	tn.SetCurrentTrick([]*domain.TarneebTrickCard{
+	tn.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignHeart, 13, false)},
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignHeart, 1, false)},
 		{PlayerIdx: 2, Card: domain.NewCard(domain.CardDesignDiamond, 2, false)},
@@ -460,7 +460,7 @@ func TestTarneeb_GetValidPlayIndices(t *testing.T) {
 	tn.SetTrumpSuit(domain.CardDesignSpade)
 	tn.SetCurrentPlayerIdx(0)
 	leadCard := domain.NewCard(domain.CardDesignHeart, 3, false)
-	tn.SetCurrentTrick([]*domain.TarneebTrickCard{{PlayerIdx: 3, Card: leadCard}})
+	tn.SetCurrentTrick([]*domain.TrickCard{{PlayerIdx: 3, Card: leadCard}})
 	clearAndDeal(tn.GetPlayer(0), []*domain.Card{
 		domain.NewCard(domain.CardDesignHeart, 4, false),
 		domain.NewCard(domain.CardDesignDiamond, 2, false),

--- a/internal/domain/TwoTenJack.go
+++ b/internal/domain/TwoTenJack.go
@@ -42,12 +42,6 @@ type TwoTenJackHint struct {
 	Reason    string // ヒント理由キー
 }
 
-// TwoTenJackTrickCard トリック中の1枚
-type TwoTenJackTrickCard struct {
-	PlayerIdx int   `json:"pi"`
-	Card      *Card `json:"c"`
-}
-
 // TwoTenJack ツーテンジャックゲームクラス
 type TwoTenJack struct {
 	trumpCards       *TrumpCards
@@ -57,7 +51,7 @@ type TwoTenJack struct {
 	roundNumber      int
 	trickNumber      int
 	currentPlayerIdx int
-	currentTrick     []*TwoTenJackTrickCard
+	currentTrick     []*TrickCard
 	leadPlayerIdx    int
 	declarerIdx      int
 	trumpSuit        int // -1 = 未宣言
@@ -359,10 +353,10 @@ func (t *TwoTenJack) GetCurrentPlayerIdx() int { return t.currentPlayerIdx }
 func (t *TwoTenJack) SetCurrentPlayerIdx(idx int) { t.currentPlayerIdx = idx }
 
 // GetCurrentTrick 現在のトリック取得
-func (t *TwoTenJack) GetCurrentTrick() []*TwoTenJackTrickCard { return t.currentTrick }
+func (t *TwoTenJack) GetCurrentTrick() []*TrickCard { return t.currentTrick }
 
 // SetCurrentTrick トリック設定 (テスト用)
-func (t *TwoTenJack) SetCurrentTrick(trick []*TwoTenJackTrickCard) { t.currentTrick = trick }
+func (t *TwoTenJack) SetCurrentTrick(trick []*TrickCard) { t.currentTrick = trick }
 
 // GetLeadPlayerIdx リードプレイヤーインデックス取得
 func (t *TwoTenJack) GetLeadPlayerIdx() int { return t.leadPlayerIdx }
@@ -437,7 +431,7 @@ func (t *TwoTenJack) startPlayPhase() {
 
 // playCard カードをプレイする共通処理
 func (t *TwoTenJack) playCard(playerIdx int, card *Card) {
-	t.currentTrick = append(t.currentTrick, &TwoTenJackTrickCard{
+	t.currentTrick = append(t.currentTrick, &TrickCard{
 		PlayerIdx: playerIdx,
 		Card:      card,
 	})
@@ -475,32 +469,7 @@ func (t *TwoTenJack) playerHasSuit(playerIdx int, design int) bool {
 
 // trickWinner トリックの勝者を決定する
 func (t *TwoTenJack) trickWinner() int {
-	if len(t.currentTrick) == 0 {
-		return 0
-	}
-	leadSuit := t.currentTrick[0].Card.GetDesign()
-	winnerIdx := t.currentTrick[0].PlayerIdx
-	winnerValue := ttjEffectiveValue(t.currentTrick[0].Card)
-	winnerIsTrump := t.currentTrick[0].Card.GetDesign() == t.trumpSuit
-
-	for _, tc := range t.currentTrick[1:] {
-		isTrump := tc.Card.GetDesign() == t.trumpSuit
-		v := ttjEffectiveValue(tc.Card)
-		if isTrump && !winnerIsTrump {
-			winnerIdx = tc.PlayerIdx
-			winnerValue = v
-			winnerIsTrump = true
-		} else if isTrump && winnerIsTrump {
-			if v > winnerValue {
-				winnerIdx = tc.PlayerIdx
-				winnerValue = v
-			}
-		} else if !isTrump && !winnerIsTrump && tc.Card.GetDesign() == leadSuit && v > winnerValue {
-			winnerIdx = tc.PlayerIdx
-			winnerValue = v
-		}
-	}
-	return winnerIdx
+	return ResolveTrickWinner(t.currentTrick, t.trumpSuit, ttjEffectiveValue)
 }
 
 // ttjEffectiveValue トリック比較用の値。A=14, K=13, Q=12, J=11, 10=10, ..., 2=2
@@ -912,20 +881,20 @@ func (t *TwoTenJack) GetValidPlayIndices(playerIdx int) []int {
 
 // twoTenJackJSON is the JSON wire format for TwoTenJack.
 type twoTenJackJSON struct {
-	TrumpCards       *TrumpCards            `json:"tc"`
-	Players          []*TwoTenJackPlayer    `json:"ps"`
-	Config           TwoTenJackConfig       `json:"cf"`
-	Phase            TwoTenJackPhase        `json:"ph"`
-	RoundNumber      int                    `json:"rn"`
-	TrickNumber      int                    `json:"tn"`
-	CurrentPlayerIdx int                    `json:"ci"`
-	CurrentTrick     []*TwoTenJackTrickCard `json:"ct"`
-	LeadPlayerIdx    int                    `json:"li"`
-	DeclarerIdx      int                    `json:"di"`
-	TrumpSuit        int                    `json:"ts"`
-	GameEndFlag      bool                   `json:"ge"`
-	WinnerTeam       int                    `json:"wt"`
-	ActionLog        []*ActionLogEntry      `json:"al"`
+	TrumpCards       *TrumpCards         `json:"tc"`
+	Players          []*TwoTenJackPlayer `json:"ps"`
+	Config           TwoTenJackConfig    `json:"cf"`
+	Phase            TwoTenJackPhase     `json:"ph"`
+	RoundNumber      int                 `json:"rn"`
+	TrickNumber      int                 `json:"tn"`
+	CurrentPlayerIdx int                 `json:"ci"`
+	CurrentTrick     []*TrickCard        `json:"ct"`
+	LeadPlayerIdx    int                 `json:"li"`
+	DeclarerIdx      int                 `json:"di"`
+	TrumpSuit        int                 `json:"ts"`
+	GameEndFlag      bool                `json:"ge"`
+	WinnerTeam       int                 `json:"wt"`
+	ActionLog        []*ActionLogEntry   `json:"al"`
 }
 
 // MarshalJSON implements json.Marshaler.
@@ -976,7 +945,7 @@ func (t *TwoTenJack) UnmarshalJSON(data []byte) error {
 	t.currentPlayerIdx = j.CurrentPlayerIdx
 	t.currentTrick = j.CurrentTrick
 	if t.currentTrick == nil {
-		t.currentTrick = make([]*TwoTenJackTrickCard, 0)
+		t.currentTrick = make([]*TrickCard, 0)
 	}
 	t.leadPlayerIdx = j.LeadPlayerIdx
 	t.declarerIdx = j.DeclarerIdx

--- a/internal/domain/TwoTenJack_internal_test.go
+++ b/internal/domain/TwoTenJack_internal_test.go
@@ -125,7 +125,7 @@ func TestTTJInternal_CpuSelectPlayCard_SingleOption(t *testing.T) {
 	ttj.phase = TwoTenJackPhasePlay
 	ttj.trickNumber = 1
 	// lead clover, so only clover card is valid
-	ttj.currentTrick = []*TwoTenJackTrickCard{
+	ttj.currentTrick = []*TrickCard{
 		{PlayerIdx: 0, Card: NewCard(CardDesignClover, 10, false)},
 	}
 	idx := ttj.cpuSelectPlayCard(1)
@@ -152,7 +152,7 @@ func TestTTJInternal_PickLowestWinning_NoWinners(t *testing.T) {
 	p.Reset()
 	p.AddCard(NewCard(CardDesignClover, 2, false))
 	ttj.trumpSuit = CardDesignSpade
-	ttj.currentTrick = []*TwoTenJackTrickCard{
+	ttj.currentTrick = []*TrickCard{
 		{PlayerIdx: 0, Card: NewCard(CardDesignClover, 13, false)},
 	}
 	_, ok := pickLowestWinning(ttj, p, []int{0})
@@ -165,7 +165,7 @@ func TestTTJInternal_PickLowestWinning_TrumpWins(t *testing.T) {
 	p.Reset()
 	p.AddCard(NewCard(CardDesignSpade, 2, false))
 	ttj.trumpSuit = CardDesignSpade
-	ttj.currentTrick = []*TwoTenJackTrickCard{
+	ttj.currentTrick = []*TrickCard{
 		{PlayerIdx: 0, Card: NewCard(CardDesignClover, 13, false)},
 	}
 	idx, ok := pickLowestWinning(ttj, p, []int{0})

--- a/internal/domain/TwoTenJack_test.go
+++ b/internal/domain/TwoTenJack_test.go
@@ -173,7 +173,7 @@ func TestTwoTenJack_ValidatePlay_FollowSuit(t *testing.T) {
 	p.AddCard(domain.NewCard(domain.CardDesignClover, 3, false))
 
 	setupTTJPlayPhase(ttj, 0, 1, 2, domain.CardDesignSpade)
-	ttj.SetCurrentTrick([]*domain.TwoTenJackTrickCard{
+	ttj.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignClover, 7, false)},
 	})
 
@@ -193,7 +193,7 @@ func TestTwoTenJack_ValidatePlay_NoLeadSuit(t *testing.T) {
 	p.AddCard(domain.NewCard(domain.CardDesignSpade, 3, false))
 
 	setupTTJPlayPhase(ttj, 0, 1, 2, domain.CardDesignSpade)
-	ttj.SetCurrentTrick([]*domain.TwoTenJackTrickCard{
+	ttj.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignClover, 7, false)},
 	})
 
@@ -235,7 +235,7 @@ func TestTwoTenJack_TrickWinner(t *testing.T) {
 		ttj.Reset()
 		setupTTJPlayPhase(ttj, 0, 0, 2, domain.CardDesignSpade)
 		ttj.SetPhase(domain.TwoTenJackPhaseTrickEnd)
-		ttj.SetCurrentTrick([]*domain.TwoTenJackTrickCard{
+		ttj.SetCurrentTrick([]*domain.TrickCard{
 			{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignHeart, 5, false)},
 			{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignHeart, 13, false)},
 			{PlayerIdx: 2, Card: domain.NewCard(domain.CardDesignHeart, 1, false)}, // A=14
@@ -250,7 +250,7 @@ func TestTwoTenJack_TrickWinner(t *testing.T) {
 		ttj.Reset()
 		setupTTJPlayPhase(ttj, 0, 0, 2, domain.CardDesignSpade)
 		ttj.SetPhase(domain.TwoTenJackPhaseTrickEnd)
-		ttj.SetCurrentTrick([]*domain.TwoTenJackTrickCard{
+		ttj.SetCurrentTrick([]*domain.TrickCard{
 			{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignHeart, 13, false)},
 			{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignHeart, 1, false)},
 			{PlayerIdx: 2, Card: domain.NewCard(domain.CardDesignSpade, 2, false)}, // trump
@@ -265,7 +265,7 @@ func TestTwoTenJack_TrickWinner(t *testing.T) {
 		ttj.Reset()
 		setupTTJPlayPhase(ttj, 0, 0, 2, domain.CardDesignSpade)
 		ttj.SetPhase(domain.TwoTenJackPhaseTrickEnd)
-		ttj.SetCurrentTrick([]*domain.TwoTenJackTrickCard{
+		ttj.SetCurrentTrick([]*domain.TrickCard{
 			{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignHeart, 13, false)},
 			{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignSpade, 5, false)},
 			{PlayerIdx: 2, Card: domain.NewCard(domain.CardDesignSpade, 1, false)}, // A=14
@@ -283,7 +283,7 @@ func TestTwoTenJack_ResolveTrick_WrongPhaseOrIncomplete(t *testing.T) {
 	ttj.ResolveTrick() // no-op
 
 	ttj.SetPhase(domain.TwoTenJackPhaseTrickEnd)
-	ttj.SetCurrentTrick([]*domain.TwoTenJackTrickCard{
+	ttj.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignHeart, 5, false)},
 	})
 	ttj.ResolveTrick() // no-op
@@ -488,7 +488,7 @@ func TestTwoTenJack_GetValidPlayIndices(t *testing.T) {
 	p.AddCard(domain.NewCard(domain.CardDesignHeart, 5, false))
 	p.AddCard(domain.NewCard(domain.CardDesignClover, 3, false))
 	setupTTJPlayPhase(ttj, 0, 1, 2, domain.CardDesignSpade)
-	ttj.SetCurrentTrick([]*domain.TwoTenJackTrickCard{
+	ttj.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignClover, 7, false)},
 	})
 	valid := ttj.GetValidPlayIndices(0)

--- a/internal/domain/Whist.go
+++ b/internal/domain/Whist.go
@@ -33,12 +33,6 @@ type WhistHint struct {
 	Reason    string // ヒント理由キー
 }
 
-// WhistTrickCard トリック中の1枚
-type WhistTrickCard struct {
-	PlayerIdx int   `json:"pi"`
-	Card      *Card `json:"c"`
-}
-
 // Whist ホイストゲームクラス
 type Whist struct {
 	trumpCards       *TrumpCards
@@ -48,7 +42,7 @@ type Whist struct {
 	roundNumber      int
 	trickNumber      int
 	currentPlayerIdx int
-	currentTrick     []*WhistTrickCard
+	currentTrick     []*TrickCard
 	trumpSuit        int // トランプ（切り札）スート
 	leadPlayerIdx    int
 	dealerIdx        int
@@ -266,10 +260,10 @@ func (w *Whist) GetCurrentPlayerIdx() int { return w.currentPlayerIdx }
 func (w *Whist) SetCurrentPlayerIdx(idx int) { w.currentPlayerIdx = idx }
 
 // GetCurrentTrick 現在のトリック取得
-func (w *Whist) GetCurrentTrick() []*WhistTrickCard { return w.currentTrick }
+func (w *Whist) GetCurrentTrick() []*TrickCard { return w.currentTrick }
 
 // SetCurrentTrick トリック設定 (テスト用)
-func (w *Whist) SetCurrentTrick(trick []*WhistTrickCard) { w.currentTrick = trick }
+func (w *Whist) SetCurrentTrick(trick []*TrickCard) { w.currentTrick = trick }
 
 // GetTrumpSuit トランプスート取得
 func (w *Whist) GetTrumpSuit() int { return w.trumpSuit }
@@ -398,7 +392,7 @@ func (w *Whist) startPlayPhase() {
 
 // playCard カードをプレイする共通処理
 func (w *Whist) playCard(playerIdx int, card *Card) {
-	w.currentTrick = append(w.currentTrick, &WhistTrickCard{
+	w.currentTrick = append(w.currentTrick, &TrickCard{
 		PlayerIdx: playerIdx,
 		Card:      card,
 	})
@@ -443,35 +437,7 @@ func (w *Whist) playerHasSuit(playerIdx int, design int) bool {
 
 // trickWinner トリックの勝者を決定する
 func (w *Whist) trickWinner() int {
-	if len(w.currentTrick) == 0 {
-		return 0
-	}
-	leadSuit := w.currentTrick[0].Card.GetDesign()
-	winnerIdx := w.currentTrick[0].PlayerIdx
-	winnerValue := w.currentTrick[0].Card.GetValue()
-	winnerIsTrump := w.currentTrick[0].Card.GetDesign() == w.trumpSuit
-
-	for _, tc := range w.currentTrick[1:] {
-		isTrump := tc.Card.GetDesign() == w.trumpSuit
-
-		if isTrump && !winnerIsTrump {
-			// トランプがリードスートに勝つ
-			winnerIdx = tc.PlayerIdx
-			winnerValue = tc.Card.GetValue()
-			winnerIsTrump = true
-		} else if isTrump && winnerIsTrump {
-			// トランプ同士: 高い方が勝つ
-			if tc.Card.GetValue() > winnerValue {
-				winnerIdx = tc.PlayerIdx
-				winnerValue = tc.Card.GetValue()
-			}
-		} else if !isTrump && !winnerIsTrump && tc.Card.GetDesign() == leadSuit && tc.Card.GetValue() > winnerValue {
-			// 非トランプ同士: リードスートの高い方が勝つ
-			winnerIdx = tc.PlayerIdx
-			winnerValue = tc.Card.GetValue()
-		}
-	}
-	return winnerIdx
+	return ResolveTrickWinner(w.currentTrick, w.trumpSuit, nil)
 }
 
 // checkGameEnd ゲーム終了判定
@@ -879,7 +845,7 @@ type whistJSON struct {
 	RoundNumber      int               `json:"rn"`
 	TrickNumber      int               `json:"tn"`
 	CurrentPlayerIdx int               `json:"ci"`
-	CurrentTrick     []*WhistTrickCard `json:"ct"`
+	CurrentTrick     []*TrickCard      `json:"ct"`
 	TrumpSuit        int               `json:"ts"`
 	LeadPlayerIdx    int               `json:"li"`
 	DealerIdx        int               `json:"di"`
@@ -939,7 +905,7 @@ func (w *Whist) UnmarshalJSON(data []byte) error {
 	w.currentPlayerIdx = j.CurrentPlayerIdx
 	w.currentTrick = j.CurrentTrick
 	if w.currentTrick == nil {
-		w.currentTrick = make([]*WhistTrickCard, 0)
+		w.currentTrick = make([]*TrickCard, 0)
 	}
 	w.trumpSuit = j.TrumpSuit
 	w.leadPlayerIdx = j.LeadPlayerIdx

--- a/internal/domain/Whist_internal_test.go
+++ b/internal/domain/Whist_internal_test.go
@@ -22,7 +22,7 @@ func TestWhist_trickWinner_LeadSuitWins(t *testing.T) {
 	w := newInternalTestWhist()
 	w.trumpSuit = CardDesignSpade
 
-	w.currentTrick = []*WhistTrickCard{
+	w.currentTrick = []*TrickCard{
 		{PlayerIdx: 0, Card: NewCard(CardDesignHeart, 5, false)},
 		{PlayerIdx: 1, Card: NewCard(CardDesignHeart, 10, false)},
 		{PlayerIdx: 2, Card: NewCard(CardDesignHeart, 3, false)},
@@ -36,7 +36,7 @@ func TestWhist_trickWinner_TrumpBeatsLead(t *testing.T) {
 	w := newInternalTestWhist()
 	w.trumpSuit = CardDesignSpade
 
-	w.currentTrick = []*WhistTrickCard{
+	w.currentTrick = []*TrickCard{
 		{PlayerIdx: 0, Card: NewCard(CardDesignHeart, 13, false)},
 		{PlayerIdx: 1, Card: NewCard(CardDesignSpade, 2, false)}, // lowest trump beats K of hearts
 		{PlayerIdx: 2, Card: NewCard(CardDesignHeart, 10, false)},
@@ -50,7 +50,7 @@ func TestWhist_trickWinner_HighestTrumpWins(t *testing.T) {
 	w := newInternalTestWhist()
 	w.trumpSuit = CardDesignSpade
 
-	w.currentTrick = []*WhistTrickCard{
+	w.currentTrick = []*TrickCard{
 		{PlayerIdx: 0, Card: NewCard(CardDesignHeart, 13, false)},
 		{PlayerIdx: 1, Card: NewCard(CardDesignSpade, 2, false)},
 		{PlayerIdx: 2, Card: NewCard(CardDesignSpade, 10, false)}, // higher trump
@@ -62,7 +62,7 @@ func TestWhist_trickWinner_HighestTrumpWins(t *testing.T) {
 
 func TestWhist_trickWinner_EmptyTrick(t *testing.T) {
 	w := newInternalTestWhist()
-	w.currentTrick = []*WhistTrickCard{}
+	w.currentTrick = []*TrickCard{}
 
 	assert.Equal(t, 0, w.trickWinner())
 }
@@ -78,7 +78,7 @@ func TestWhist_validatePlay_LeadAnyCard(t *testing.T) {
 
 func TestWhist_validatePlay_MustFollowSuit(t *testing.T) {
 	w := newInternalTestWhist()
-	w.currentTrick = []*WhistTrickCard{
+	w.currentTrick = []*TrickCard{
 		{PlayerIdx: 1, Card: NewCard(CardDesignHeart, 5, false)},
 	}
 
@@ -98,7 +98,7 @@ func TestWhist_validatePlay_MustFollowSuit(t *testing.T) {
 
 func TestWhist_validatePlay_CanPlayAnythingWhenVoid(t *testing.T) {
 	w := newInternalTestWhist()
-	w.currentTrick = []*WhistTrickCard{
+	w.currentTrick = []*TrickCard{
 		{PlayerIdx: 1, Card: NewCard(CardDesignHeart, 5, false)},
 	}
 
@@ -159,7 +159,7 @@ func TestWhist_isPartnerWinning(t *testing.T) {
 	w.trumpSuit = CardDesignSpade
 
 	// Player 0 (team 0), partner is player 2 (team 0)
-	w.currentTrick = []*WhistTrickCard{
+	w.currentTrick = []*TrickCard{
 		{PlayerIdx: 1, Card: NewCard(CardDesignHeart, 5, false)},  // team 1
 		{PlayerIdx: 2, Card: NewCard(CardDesignHeart, 13, false)}, // team 0 - winning
 	}

--- a/internal/domain/Whist_test.go
+++ b/internal/domain/Whist_test.go
@@ -128,7 +128,7 @@ func TestWhist_PlayerPlay(t *testing.T) {
 
 		// リードカードを設定
 		leadCard := domain.NewCard(domain.CardDesignHeart, 10, false)
-		w.SetCurrentTrick([]*domain.WhistTrickCard{
+		w.SetCurrentTrick([]*domain.TrickCard{
 			{PlayerIdx: 1, Card: leadCard},
 		})
 
@@ -177,7 +177,7 @@ func TestWhist_ResolveTrick(t *testing.T) {
 	w.SetTrickNumber(1)
 	w.SetPhase(domain.WhistPhaseTrickEnd)
 
-	trick := []*domain.WhistTrickCard{
+	trick := []*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignHeart, 10, false)},
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignHeart, 5, false)},
 		{PlayerIdx: 2, Card: domain.NewCard(domain.CardDesignHeart, 13, false)},
@@ -199,7 +199,7 @@ func TestWhist_ResolveTrick_TrumpWins(t *testing.T) {
 	w.SetTrickNumber(1)
 	w.SetPhase(domain.WhistPhaseTrickEnd)
 
-	trick := []*domain.WhistTrickCard{
+	trick := []*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignHeart, 13, false)},
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignSpade, 2, false)}, // trump
 		{PlayerIdx: 2, Card: domain.NewCard(domain.CardDesignHeart, 10, false)},
@@ -221,7 +221,7 @@ func TestWhist_ResolveTrick_LastTrick(t *testing.T) {
 	w.SetTrickNumber(13) // last trick
 	w.SetPhase(domain.WhistPhaseTrickEnd)
 
-	trick := []*domain.WhistTrickCard{
+	trick := []*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignHeart, 10, false)},
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignHeart, 5, false)},
 		{PlayerIdx: 2, Card: domain.NewCard(domain.CardDesignHeart, 13, false)},
@@ -599,7 +599,7 @@ func TestWhist_CpuPlayHard_FollowWithPartnerWinning(t *testing.T) {
 
 	// Player 1 leads heart 5, player 2 (team 0, partner of 0) has hearts
 	// Player 2's partner (player 0) is not in the trick yet
-	w.SetCurrentTrick([]*domain.WhistTrickCard{
+	w.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignHeart, 5, false)},
 	})
 
@@ -624,7 +624,7 @@ func TestWhist_CpuPlayHard_VoidTrumpCut(t *testing.T) {
 	setupWhistPlayPhase(w, 1, 0, 2)
 
 	// Player 0 leads heart, player 1 has no hearts but has trump
-	w.SetCurrentTrick([]*domain.WhistTrickCard{
+	w.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignHeart, 10, false)},
 	})
 
@@ -648,7 +648,7 @@ func TestWhist_CpuPlayHard_PartnerWinningDiscard(t *testing.T) {
 
 	// Player 1 (team 1) leads heart 5, player 2 (team 0) plays heart K (winning)
 	// Player 3 (team 1) should see partner is NOT winning (team 0 is winning)
-	w.SetCurrentTrick([]*domain.WhistTrickCard{
+	w.SetCurrentTrick([]*domain.TrickCard{
 		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignHeart, 5, false)},
 		{PlayerIdx: 2, Card: domain.NewCard(domain.CardDesignHeart, 13, false)},
 	})

--- a/internal/domain/interfaces/callbreak.go
+++ b/internal/domain/interfaces/callbreak.go
@@ -44,7 +44,7 @@ type CallBreakGame interface {
 	// GetCurrentPlayerIdx 現在のプレイヤーインデックスを取得する
 	GetCurrentPlayerIdx() int
 	// GetCurrentTrick 現在のトリックを取得する
-	GetCurrentTrick() []*domain.CallBreakTrickCard
+	GetCurrentTrick() []*domain.TrickCard
 	// GetSpadesBroken スペードブレイク済みかを返す
 	GetSpadesBroken() bool
 	// GetLeadPlayerIdx リードプレイヤーインデックスを取得する

--- a/internal/domain/interfaces/callbreak_mock.go
+++ b/internal/domain/interfaces/callbreak_mock.go
@@ -79,9 +79,9 @@ func (m *MockCallBreakGame) GetCurrentPlayerIdx() int {
 	return args.Int(0)
 }
 
-func (m *MockCallBreakGame) GetCurrentTrick() []*domain.CallBreakTrickCard {
+func (m *MockCallBreakGame) GetCurrentTrick() []*domain.TrickCard {
 	args := m.Called()
-	return args.Get(0).([]*domain.CallBreakTrickCard)
+	return args.Get(0).([]*domain.TrickCard)
 }
 
 func (m *MockCallBreakGame) GetSpadesBroken() bool {

--- a/internal/domain/interfaces/courtpiece.go
+++ b/internal/domain/interfaces/courtpiece.go
@@ -46,7 +46,7 @@ type CourtPieceGame interface {
 	// GetCurrentPlayerIdx 現在のプレイヤーインデックスを取得する
 	GetCurrentPlayerIdx() int
 	// GetCurrentTrick 現在のトリックを取得する
-	GetCurrentTrick() []*domain.CourtPieceTrickCard
+	GetCurrentTrick() []*domain.TrickCard
 	// GetTrumpSuit トランプスートを取得する (0 = 未宣言)
 	GetTrumpSuit() int
 	// GetCallerIdx 呼び手 (Hakim) インデックスを取得する

--- a/internal/domain/interfaces/courtpiece_mock.go
+++ b/internal/domain/interfaces/courtpiece_mock.go
@@ -79,9 +79,9 @@ func (m *MockCourtPieceGame) GetCurrentPlayerIdx() int {
 	return args.Int(0)
 }
 
-func (m *MockCourtPieceGame) GetCurrentTrick() []*domain.CourtPieceTrickCard {
+func (m *MockCourtPieceGame) GetCurrentTrick() []*domain.TrickCard {
 	args := m.Called()
-	return args.Get(0).([]*domain.CourtPieceTrickCard)
+	return args.Get(0).([]*domain.TrickCard)
 }
 
 func (m *MockCourtPieceGame) GetTrumpSuit() int {

--- a/internal/domain/interfaces/hearts.go
+++ b/internal/domain/interfaces/hearts.go
@@ -44,7 +44,7 @@ type HeartsGame interface {
 	// GetCurrentPlayerIdx 現在のプレイヤーインデックスを取得する
 	GetCurrentPlayerIdx() int
 	// GetCurrentTrick 現在のトリックを取得する
-	GetCurrentTrick() []*domain.HeartsTrickCard
+	GetCurrentTrick() []*domain.TrickCard
 	// GetHeartsBroken ハーツブレイク済みかを返す
 	GetHeartsBroken() bool
 	// GetPassDirection パス方向を取得する

--- a/internal/domain/interfaces/hearts_mock.go
+++ b/internal/domain/interfaces/hearts_mock.go
@@ -113,9 +113,9 @@ func (_m *MockHeartsGame) GetCurrentPlayerIdx() int {
 }
 
 // GetCurrentTrick モック
-func (_m *MockHeartsGame) GetCurrentTrick() []*domain.HeartsTrickCard {
+func (_m *MockHeartsGame) GetCurrentTrick() []*domain.TrickCard {
 	ret := _m.Called()
-	if val, ok := ret.Get(0).([]*domain.HeartsTrickCard); ok {
+	if val, ok := ret.Get(0).([]*domain.TrickCard); ok {
 		return val
 	}
 	return nil

--- a/internal/domain/interfaces/ninetyNine.go
+++ b/internal/domain/interfaces/ninetyNine.go
@@ -46,7 +46,7 @@ type NinetyNineGame interface {
 	// GetCurrentPlayerIdx 現在のプレイヤーインデックスを取得する
 	GetCurrentPlayerIdx() int
 	// GetCurrentTrick 現在のトリックを取得する
-	GetCurrentTrick() []*domain.NinetyNineTrickCard
+	GetCurrentTrick() []*domain.TrickCard
 	// GetTrumpSuit 切り札スートを取得する
 	GetTrumpSuit() int
 	// GetDealerIdx ディーラーインデックスを取得する

--- a/internal/domain/interfaces/ninetyNine_mock.go
+++ b/internal/domain/interfaces/ninetyNine_mock.go
@@ -100,9 +100,9 @@ func (m *MockNinetyNineGame) GetCurrentPlayerIdx() int {
 	return args.Int(0)
 }
 
-func (m *MockNinetyNineGame) GetCurrentTrick() []*domain.NinetyNineTrickCard {
+func (m *MockNinetyNineGame) GetCurrentTrick() []*domain.TrickCard {
 	args := m.Called()
-	return args.Get(0).([]*domain.NinetyNineTrickCard)
+	return args.Get(0).([]*domain.TrickCard)
 }
 
 func (m *MockNinetyNineGame) GetTrumpSuit() int {

--- a/internal/domain/interfaces/ohHell.go
+++ b/internal/domain/interfaces/ohHell.go
@@ -48,7 +48,7 @@ type OhHellGame interface {
 	// GetCurrentPlayerIdx 現在のプレイヤーインデックスを取得する
 	GetCurrentPlayerIdx() int
 	// GetCurrentTrick 現在のトリックを取得する
-	GetCurrentTrick() []*domain.OhHellTrickCard
+	GetCurrentTrick() []*domain.TrickCard
 	// GetTrumpCard 切り札カードを取得する
 	GetTrumpCard() *domain.Card
 	// GetTrumpSuit 切り札スートを取得する (-1 = 切り札なし)

--- a/internal/domain/interfaces/ohHell_mock.go
+++ b/internal/domain/interfaces/ohHell_mock.go
@@ -105,9 +105,9 @@ func (m *MockOhHellGame) GetCurrentPlayerIdx() int {
 	return args.Int(0)
 }
 
-func (m *MockOhHellGame) GetCurrentTrick() []*domain.OhHellTrickCard {
+func (m *MockOhHellGame) GetCurrentTrick() []*domain.TrickCard {
 	args := m.Called()
-	return args.Get(0).([]*domain.OhHellTrickCard)
+	return args.Get(0).([]*domain.TrickCard)
 }
 
 func (m *MockOhHellGame) GetTrumpCard() *domain.Card {

--- a/internal/domain/interfaces/spades.go
+++ b/internal/domain/interfaces/spades.go
@@ -44,7 +44,7 @@ type SpadesGame interface {
 	// GetCurrentPlayerIdx 現在のプレイヤーインデックスを取得する
 	GetCurrentPlayerIdx() int
 	// GetCurrentTrick 現在のトリックを取得する
-	GetCurrentTrick() []*domain.SpadesTrickCard
+	GetCurrentTrick() []*domain.TrickCard
 	// GetSpadesBroken スペードブレイク済みかを返す
 	GetSpadesBroken() bool
 	// GetLeadPlayerIdx リードプレイヤーインデックスを取得する

--- a/internal/domain/interfaces/spades_mock.go
+++ b/internal/domain/interfaces/spades_mock.go
@@ -95,9 +95,9 @@ func (m *MockSpadesGame) GetCurrentPlayerIdx() int {
 	return args.Int(0)
 }
 
-func (m *MockSpadesGame) GetCurrentTrick() []*domain.SpadesTrickCard {
+func (m *MockSpadesGame) GetCurrentTrick() []*domain.TrickCard {
 	args := m.Called()
-	return args.Get(0).([]*domain.SpadesTrickCard)
+	return args.Get(0).([]*domain.TrickCard)
 }
 
 func (m *MockSpadesGame) GetSpadesBroken() bool {

--- a/internal/domain/interfaces/tarneeb.go
+++ b/internal/domain/interfaces/tarneeb.go
@@ -52,7 +52,7 @@ type TarneebGame interface {
 	// GetCurrentPlayerIdx 現在のプレイヤーインデックスを取得する
 	GetCurrentPlayerIdx() int
 	// GetCurrentTrick 現在のトリックを取得する
-	GetCurrentTrick() []*domain.TarneebTrickCard
+	GetCurrentTrick() []*domain.TrickCard
 	// GetTrumpSuit トランプスートを取得する (0 = 未宣言)
 	GetTrumpSuit() int
 	// GetLeadPlayerIdx リードプレイヤーインデックスを取得する

--- a/internal/domain/interfaces/tarneeb_mock.go
+++ b/internal/domain/interfaces/tarneeb_mock.go
@@ -91,9 +91,9 @@ func (m *MockTarneebGame) GetCurrentPlayerIdx() int {
 	return args.Int(0)
 }
 
-func (m *MockTarneebGame) GetCurrentTrick() []*domain.TarneebTrickCard {
+func (m *MockTarneebGame) GetCurrentTrick() []*domain.TrickCard {
 	args := m.Called()
-	return args.Get(0).([]*domain.TarneebTrickCard)
+	return args.Get(0).([]*domain.TrickCard)
 }
 
 func (m *MockTarneebGame) GetTrumpSuit() int {

--- a/internal/domain/interfaces/twotenjack.go
+++ b/internal/domain/interfaces/twotenjack.go
@@ -44,7 +44,7 @@ type TwoTenJackGame interface {
 	// GetCurrentPlayerIdx 現在のプレイヤーインデックスを取得する
 	GetCurrentPlayerIdx() int
 	// GetCurrentTrick 現在のトリックを取得する
-	GetCurrentTrick() []*domain.TwoTenJackTrickCard
+	GetCurrentTrick() []*domain.TrickCard
 	// GetLeadPlayerIdx リードプレイヤーインデックスを取得する
 	GetLeadPlayerIdx() int
 	// GetDeclarerIdx 宣言者インデックスを取得する

--- a/internal/domain/interfaces/twotenjack_mock.go
+++ b/internal/domain/interfaces/twotenjack_mock.go
@@ -75,9 +75,9 @@ func (m *MockTwoTenJackGame) GetCurrentPlayerIdx() int {
 	return args.Int(0)
 }
 
-func (m *MockTwoTenJackGame) GetCurrentTrick() []*domain.TwoTenJackTrickCard {
+func (m *MockTwoTenJackGame) GetCurrentTrick() []*domain.TrickCard {
 	args := m.Called()
-	return args.Get(0).([]*domain.TwoTenJackTrickCard)
+	return args.Get(0).([]*domain.TrickCard)
 }
 
 func (m *MockTwoTenJackGame) GetLeadPlayerIdx() int {

--- a/internal/domain/interfaces/whist.go
+++ b/internal/domain/interfaces/whist.go
@@ -38,7 +38,7 @@ type WhistGame interface {
 	// GetCurrentPlayerIdx 現在のプレイヤーインデックスを取得する
 	GetCurrentPlayerIdx() int
 	// GetCurrentTrick 現在のトリックを取得する
-	GetCurrentTrick() []*domain.WhistTrickCard
+	GetCurrentTrick() []*domain.TrickCard
 	// GetTrumpSuit トランプスートを取得する
 	GetTrumpSuit() int
 	// GetLeadPlayerIdx リードプレイヤーインデックスを取得する

--- a/internal/domain/interfaces/whist_mock.go
+++ b/internal/domain/interfaces/whist_mock.go
@@ -81,10 +81,10 @@ func (m *MockWhistGame) GetCurrentPlayerIdx() int {
 	return args.Int(0)
 }
 
-func (m *MockWhistGame) GetCurrentTrick() []*domain.WhistTrickCard {
+func (m *MockWhistGame) GetCurrentTrick() []*domain.TrickCard {
 	args := m.Called()
 	if v := args.Get(0); v != nil {
-		return v.([]*domain.WhistTrickCard)
+		return v.([]*domain.TrickCard)
 	}
 	return nil
 }

--- a/internal/domain/trick_helpers.go
+++ b/internal/domain/trick_helpers.go
@@ -1,0 +1,67 @@
+// Package domain トリックテイキング系ゲーム共通のトリック勝者判定ヘルパー。
+//
+// No build tag: this file is compiled into every build, including all
+// Cloudflare Worker WASM binaries. The helper is game-agnostic (each game
+// supplies its own trump suit and card-ranking function), so it must be
+// available regardless of which category worker a game lands in. Mirrors the
+// rationale in slice_helpers.go / player_helpers.go.
+package domain
+
+// TrickCard is a single card played into a trick, tagged with the seat that
+// played it. The vast majority of trick-taking games share this exact shape
+// (issue #4297), so they reuse this type rather than redeclaring an identical
+// per-game struct. Games needing extra per-play state (e.g. Mighty's joker-lead
+// flag) keep their own bespoke type.
+//
+// The JSON tags match every game's historical per-game struct (`pi`/`c`) so the
+// serialized KV snapshot shape is unchanged.
+type TrickCard struct {
+	PlayerIdx int   `json:"pi"`
+	Card      *Card `json:"c"`
+}
+
+// ResolveTrickWinner returns the PlayerIdx of the card that wins trick.
+//
+// The first card sets the lead suit. A card of trumpSuit beats any non-trump;
+// among trumps (and, when no trump is present, among lead-suit cards) the higher
+// rank wins. Ties resolve to the earlier-played card (the comparison is strict).
+// Pass trumpSuit < 0 (or any value no card's design can equal) for a no-trump
+// deal. rank maps a card to its comparable strength; nil uses (*Card).GetValue
+// (natural 2..14 order). An empty trick returns 0.
+//
+// This consolidates the "trump beats non-trump, else lead-suit highest by rank"
+// winner logic that was hand-written identically across the standard
+// trick-taking games; games with a bespoke ranking (e.g. suit-independent tarot
+// orderings, joker/bower reordering, or delegated `beats` helpers) keep their
+// own implementation.
+func ResolveTrickWinner(trick []*TrickCard, trumpSuit int, rank func(*Card) int) int {
+	if len(trick) == 0 {
+		return 0
+	}
+	if rank == nil {
+		rank = (*Card).GetValue
+	}
+	leadSuit := trick[0].Card.GetDesign()
+	winnerIdx := trick[0].PlayerIdx
+	winnerRank := rank(trick[0].Card)
+	winnerIsTrump := trick[0].Card.GetDesign() == trumpSuit
+
+	for _, tc := range trick[1:] {
+		isTrump := tc.Card.GetDesign() == trumpSuit
+		r := rank(tc.Card)
+		switch {
+		case isTrump && !winnerIsTrump:
+			// Trump beats a non-trump leader.
+			winnerIdx, winnerRank, winnerIsTrump = tc.PlayerIdx, r, true
+		case isTrump && winnerIsTrump:
+			// Trump vs trump: higher rank wins.
+			if r > winnerRank {
+				winnerIdx, winnerRank = tc.PlayerIdx, r
+			}
+		case !isTrump && !winnerIsTrump && tc.Card.GetDesign() == leadSuit && r > winnerRank:
+			// Non-trump vs non-trump: higher lead-suit card wins.
+			winnerIdx, winnerRank = tc.PlayerIdx, r
+		}
+	}
+	return winnerIdx
+}

--- a/internal/domain/trick_helpers_test.go
+++ b/internal/domain/trick_helpers_test.go
@@ -1,0 +1,74 @@
+//go:build test
+
+package domain
+
+import "testing"
+
+func tc(playerIdx, design, value int) *TrickCard {
+	return &TrickCard{PlayerIdx: playerIdx, Card: NewCard(design, value, false)}
+}
+
+func TestResolveTrickWinner_Empty(t *testing.T) {
+	if got := ResolveTrickWinner(nil, -1, nil); got != 0 {
+		t.Fatalf("empty trick: want 0, got %d", got)
+	}
+}
+
+func TestResolveTrickWinner_NoTrump(t *testing.T) {
+	// Lead suit = Heart. Highest Heart wins; the higher off-suit Diamond loses.
+	trick := []*TrickCard{
+		tc(0, CardDesignHeart, 9),
+		tc(1, CardDesignDiamond, 14),
+		tc(2, CardDesignHeart, 11),
+		tc(3, CardDesignClover, 13),
+	}
+	if got := ResolveTrickWinner(trick, -1, nil); got != 2 {
+		t.Fatalf("no-trump: want seat 2, got %d", got)
+	}
+}
+
+func TestResolveTrickWinner_TrumpBeatsNonTrump(t *testing.T) {
+	// Lead Heart, trump = Spade. A low Spade beats the high Heart.
+	trick := []*TrickCard{
+		tc(0, CardDesignHeart, 14),
+		tc(1, CardDesignSpade, 2),
+		tc(2, CardDesignHeart, 13),
+	}
+	if got := ResolveTrickWinner(trick, CardDesignSpade, nil); got != 1 {
+		t.Fatalf("trump beats non-trump: want seat 1, got %d", got)
+	}
+}
+
+func TestResolveTrickWinner_HighestTrumpWins(t *testing.T) {
+	trick := []*TrickCard{
+		tc(0, CardDesignHeart, 14),
+		tc(1, CardDesignSpade, 5),
+		tc(2, CardDesignSpade, 10),
+	}
+	if got := ResolveTrickWinner(trick, CardDesignSpade, nil); got != 2 {
+		t.Fatalf("highest trump: want seat 2, got %d", got)
+	}
+}
+
+func TestResolveTrickWinner_TieKeepsEarlierCard(t *testing.T) {
+	// Two equal-rank lead-suit cards: the earlier-played seat keeps the trick.
+	trick := []*TrickCard{
+		tc(0, CardDesignHeart, 10),
+		tc(1, CardDesignHeart, 10),
+	}
+	if got := ResolveTrickWinner(trick, CardDesignSpade, nil); got != 0 {
+		t.Fatalf("tie: want earlier seat 0, got %d", got)
+	}
+}
+
+func TestResolveTrickWinner_CustomRank(t *testing.T) {
+	// Inverted rank: lower raw value is stronger. Lead-suit 3 beats lead-suit 14.
+	invert := func(c *Card) int { return -c.GetValue() }
+	trick := []*TrickCard{
+		tc(0, CardDesignClover, 14),
+		tc(1, CardDesignClover, 3),
+	}
+	if got := ResolveTrickWinner(trick, -1, invert); got != 1 {
+		t.Fatalf("custom rank: want seat 1, got %d", got)
+	}
+}


### PR DESCRIPTION
Closes #4297

## Problem

The standard trick-taking games each hand-wrote the same trick-winner
loop ("trump beats non-trump, else lead-suit highest by rank, earlier
card wins ties") and redeclared a byte-identical `XxxTrickCard`
`{PlayerIdx, Card}` struct across **five layers** (domain, interface,
testify mock, web presenter, cui presenter).

## Change

New untagged `internal/domain/trick_helpers.go` — compiled into every
Cloudflare Worker WASM binary, like `slice_helpers.go` / `player_helpers.go`:

- **`TrickCard{PlayerIdx json:"pi"; Card json:"c"}`** — the shared
  per-play type. JSON tags match every game's historical struct, so the
  serialized KV snapshot shape is **unchanged**.
- **`ResolveTrickWinner(trick, trumpSuit, rank)`** — the consolidated
  winner logic. `trumpSuit < 0` ⇒ no-trump deal; `rank == nil` ⇒
  `(*Card).GetValue`.

9 games migrated (winner logic verified character-identical to the
skeleton), each `trickWinner()` collapsing to a one-liner and its
per-game struct removed:

| rank | games |
|------|-------|
| `GetValue` (nil) | Whist, Spades, CallBreak, Hearts, OhHell |
| bespoke rank fn | NinetyNine, Tarneeb, CourtPiece, TwoTenJack |

## Scope note (honest)

The issue estimated "~60 nearly identical" `trickWinner`s and "~182
`TrickCard` redefinitions". I clustered all 60 `trickWinner` bodies by
normalized shape: there is **no further character-identical group** — the
rest are genuinely bespoke (delegated `beats` helpers, suit-independent
tarot orderings, joker/bower reordering, `currentLeader` short-circuits,
or candidate-filter-then-rank whose equivalence depends on subtle rank
encoding). Blanket-merging those onto `ResolveTrickWinner` would risk
altering winner determination — the most bug-prone rule in each game — so
they deliberately keep their own implementations and their own structs.
This PR establishes the shared helper + type and migrates the provably
safe set; further games can adopt it individually as their semantics are
verified.

## Verification

- `go test -tags test ./...` — full backend suite green (behaviour unchanged)
- `golangci-lint run` — 0 issues
- `goimports` clean; `go build ./...` (all tags) green
- New `trick_helpers_test.go` covers empty / no-trump / trump-beats-nontrump
  / highest-trump / tie-keeps-earlier / custom-rank paths

Net **−280 LOC** across 76 files.