### PR TITLE
chore(frontend): raise the vitest worker heap so no test is silently skipped

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -14,6 +14,14 @@ export default defineConfig({
     setupFiles: './src/test/setup.ts',
     testTimeout: 10000,
     exclude: ['e2e/**', 'node_modules/**'],
+    // Forked test workers inherit Node's default ~4 GB heap cap, which the
+    // largest single file (NavBar.test.tsx, 489 tests) exceeds — the worker
+    // dies with "Reached heap limit" and Vitest then SKIPS the ~200 tests
+    // queued behind it while still reporting the run as green, which has
+    // already let real failures reach CI. Machine RAM is not the constraint
+    // (the cap is per process); this only raises the ceiling, it allocates
+    // nothing up front. CI sets the same value via NODE_OPTIONS.
+    execArgv: ['--max-old-space-size=8192'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'lcov'],

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -20,7 +20,9 @@ export default defineConfig({
     // queued behind it while still reporting the run as green, which has
     // already let real failures reach CI. Machine RAM is not the constraint
     // (the cap is per process); this only raises the ceiling, it allocates
-    // nothing up front. CI sets the same value via NODE_OPTIONS.
+    // nothing up front. Keep CI's NODE_OPTIONS too: execArgv reaches only the
+    // forked workers, while the coverage run also needs headroom in the PARENT
+    // process that aggregates it.
     execArgv: ['--max-old-space-size=8192'],
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
## Summary

`NavBar.test.tsx` (489 tests in one file) exhausts its forked worker's default V8 heap and dies with `FATAL ERROR: Reached heap limit`. The damage is not the crash — it's that **Vitest then skips the ~200 tests queued behind that worker while still printing a passing summary**. A local run reported `15771 passed (15987)` and the 216-test gap hid 5 genuine failures that only CI caught during PR #4339.

**Machine RAM was never the constraint.** Measured on a box with ~12 GB free:

| | |
|---|---|
| Node's default `heap_size_limit` here | 4288 MB |
| Heap at the crash | 4048 MB |
| After this change (measured in a worker) | 8384 MB |

`--max-old-space-size` raises a ceiling; it allocates nothing up front. CI already sets the same value via `NODE_OPTIONS` for the coverage run (with a comment describing this same ~4 GB wall), so this just brings local runs in line.

Set as Vitest 4's **top-level `execArgv`** — my first attempt used `poolOptions.forks.execArgv`, which v4 removed and silently ignores behind a `DEPRECATED` notice, so it looked configured but the worker still capped at 4288 MB.

## Test plan

- [x] `NavBar.test.tsx` alone: 489/489 pass (previously died at ~277)
- [x] Full local suite, no exclusions: **1133 files / 15984 tests, all passing**, no DEPRECATED warning
- [x] Verified the worker's actual cap with a throwaway probe test before trusting the config
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)