### PR TITLE
fix(e2e): race the betting controls instead of probing them in turn

### DIFF
--- a/frontend/e2e/holdem.spec.ts
+++ b/frontend/e2e/holdem.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { isVisibleWithin, navigateTo, TIMEOUT_ACTION, waitForLoaded } from './helpers';
+import { navigateTo, TIMEOUT_GAME_LOOP, waitForLoaded } from './helpers';
 
 test.describe("Texas Hold'em E2E", () => {
   test('plays a full round: reset → check/call through rounds → showdown → reset', async ({ page }) => {
@@ -19,6 +19,16 @@ test.describe("Texas Hold'em E2E", () => {
       const checkButton = page.getByRole('button', { name: 'チェック', exact: true });
       const callButton = page.getByRole('button', { name: 'コール', exact: true });
 
+      // Wait for whichever control appears FIRST rather than probing each one
+      // in turn: two sequential 3s probes cost 6s per lap even once the hand
+      // has ended, so a re-raising CPU could push 20 laps past the 90s test
+      // timeout — Playwright then tears the context down and the in-flight
+      // waitForSelector reports "Target page, context or browser has been
+      // closed", which reads like a browser crash but is really this timeout
+      // (#2443). Racing them returns as soon as any control is actionable.
+      const anyControl = endResetButton.or(checkButton).or(callButton).first();
+      await expect(anyControl).toBeVisible({ timeout: TIMEOUT_GAME_LOOP });
+
       // End state reached — break immediately.
       if (await endResetButton.isVisible()) {
         roundEnded = true;
@@ -26,7 +36,7 @@ test.describe("Texas Hold'em E2E", () => {
       }
 
       // Try check first, then call
-      if (await isVisibleWithin(checkButton, TIMEOUT_ACTION)) {
+      if (await checkButton.isVisible()) {
         if (await checkButton.isEnabled()) {
           await checkButton.click();
           await waitForLoaded(page);
@@ -34,7 +44,7 @@ test.describe("Texas Hold'em E2E", () => {
         }
       }
 
-      if (await isVisibleWithin(callButton, TIMEOUT_ACTION)) {
+      if (await callButton.isVisible()) {
         if (await callButton.isEnabled()) {
           await callButton.click();
           await waitForLoaded(page);

--- a/frontend/e2e/indianpoker.spec.ts
+++ b/frontend/e2e/indianpoker.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { isVisibleWithin, navigateTo, TIMEOUT_ACTION, waitForLoaded } from './helpers';
+import { navigateTo, TIMEOUT_GAME_LOOP, waitForLoaded } from './helpers';
 
 test.describe('Indian Poker E2E', () => {
   test('plays a full round: reset → bet/check through betting → showdown → reset', async ({ page }) => {
@@ -19,6 +19,16 @@ test.describe('Indian Poker E2E', () => {
       const checkButton = page.getByRole('button', { name: 'チェック', exact: true });
       const callButton = page.getByRole('button', { name: 'コール', exact: true });
 
+      // Wait for whichever control appears FIRST rather than probing each one
+      // in turn: two sequential 3s probes cost 6s per lap even once the hand
+      // has ended, so a re-raising CPU could push 20 laps past the 90s test
+      // timeout — Playwright then tears the context down and the in-flight
+      // waitForSelector reports "Target page, context or browser has been
+      // closed", which reads like a browser crash but is really this timeout
+      // (#2443). Racing them returns as soon as any control is actionable.
+      const anyControl = endResetButton.or(checkButton).or(callButton).first();
+      await expect(anyControl).toBeVisible({ timeout: TIMEOUT_GAME_LOOP });
+
       // End state reached — break immediately.
       if (await endResetButton.isVisible()) {
         roundEnded = true;
@@ -26,7 +36,7 @@ test.describe('Indian Poker E2E', () => {
       }
 
       // Try check first, then call
-      if (await isVisibleWithin(checkButton, TIMEOUT_ACTION)) {
+      if (await checkButton.isVisible()) {
         if (await checkButton.isEnabled()) {
           await checkButton.click();
           await waitForLoaded(page);
@@ -34,7 +44,7 @@ test.describe('Indian Poker E2E', () => {
         }
       }
 
-      if (await isVisibleWithin(callButton, TIMEOUT_ACTION)) {
+      if (await callButton.isVisible()) {
         if (await callButton.isEnabled()) {
           await callButton.click();
           await waitForLoaded(page);

--- a/frontend/e2e/omaha.spec.ts
+++ b/frontend/e2e/omaha.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { isVisibleWithin, navigateTo, TIMEOUT_ACTION, waitForLoaded } from './helpers';
+import { navigateTo, TIMEOUT_GAME_LOOP, waitForLoaded } from './helpers';
 
 test.describe('Omaha E2E', () => {
   test('plays a full round: reset → check/call through rounds → showdown → reset', async ({ page }) => {
@@ -19,6 +19,16 @@ test.describe('Omaha E2E', () => {
       const checkButton = page.getByRole('button', { name: 'チェック', exact: true });
       const callButton = page.getByRole('button', { name: 'コール', exact: true });
 
+      // Wait for whichever control appears FIRST rather than probing each one
+      // in turn: two sequential 3s probes cost 6s per lap even once the hand
+      // has ended, so a re-raising CPU could push 20 laps past the 90s test
+      // timeout — Playwright then tears the context down and the in-flight
+      // waitForSelector reports "Target page, context or browser has been
+      // closed", which reads like a browser crash but is really this timeout
+      // (#2443). Racing them returns as soon as any control is actionable.
+      const anyControl = endResetButton.or(checkButton).or(callButton).first();
+      await expect(anyControl).toBeVisible({ timeout: TIMEOUT_GAME_LOOP });
+
       // End state reached — break immediately.
       if (await endResetButton.isVisible()) {
         roundEnded = true;
@@ -26,13 +36,13 @@ test.describe('Omaha E2E', () => {
       }
 
       // Try check first, then call
-      if ((await isVisibleWithin(checkButton, TIMEOUT_ACTION)) && (await checkButton.isEnabled())) {
+      if ((await checkButton.isVisible()) && (await checkButton.isEnabled())) {
         await checkButton.click();
         await waitForLoaded(page);
         continue;
       }
 
-      if ((await isVisibleWithin(callButton, TIMEOUT_ACTION)) && (await callButton.isEnabled())) {
+      if ((await callButton.isVisible()) && (await callButton.isEnabled())) {
         await callButton.click();
         await waitForLoaded(page);
         continue;

--- a/frontend/e2e/omahahilo.spec.ts
+++ b/frontend/e2e/omahahilo.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { isVisibleWithin, navigateTo, TIMEOUT_ACTION, waitForLoaded } from './helpers';
+import { navigateTo, TIMEOUT_GAME_LOOP, waitForLoaded } from './helpers';
 
 test.describe('Omaha Hi-Lo E2E', () => {
   test('plays a full round: reset → check/call through rounds → showdown → reset', async ({ page }) => {
@@ -19,6 +19,16 @@ test.describe('Omaha Hi-Lo E2E', () => {
       const checkButton = page.getByRole('button', { name: 'チェック', exact: true });
       const callButton = page.getByRole('button', { name: 'コール', exact: true });
 
+      // Wait for whichever control appears FIRST rather than probing each one
+      // in turn: two sequential 3s probes cost 6s per lap even once the hand
+      // has ended, so a re-raising CPU could push 20 laps past the 90s test
+      // timeout — Playwright then tears the context down and the in-flight
+      // waitForSelector reports "Target page, context or browser has been
+      // closed", which reads like a browser crash but is really this timeout
+      // (#2443). Racing them returns as soon as any control is actionable.
+      const anyControl = endResetButton.or(checkButton).or(callButton).first();
+      await expect(anyControl).toBeVisible({ timeout: TIMEOUT_GAME_LOOP });
+
       // End state reached — break immediately.
       if (await endResetButton.isVisible()) {
         roundEnded = true;
@@ -26,13 +36,13 @@ test.describe('Omaha Hi-Lo E2E', () => {
       }
 
       // Try check first, then call
-      if ((await isVisibleWithin(checkButton, TIMEOUT_ACTION)) && (await checkButton.isEnabled())) {
+      if ((await checkButton.isVisible()) && (await checkButton.isEnabled())) {
         await checkButton.click();
         await waitForLoaded(page);
         continue;
       }
 
-      if ((await isVisibleWithin(callButton, TIMEOUT_ACTION)) && (await callButton.isEnabled())) {
+      if ((await callButton.isVisible()) && (await callButton.isEnabled())) {
         await callButton.click();
         await waitForLoaded(page);
         continue;

--- a/frontend/e2e/poker.spec.ts
+++ b/frontend/e2e/poker.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { isVisibleWithin, navigateTo, TIMEOUT_ACTION, waitForLoaded } from './helpers';
+import { isVisibleWithin, navigateTo, TIMEOUT_ACTION, TIMEOUT_GAME_LOOP, waitForLoaded } from './helpers';
 
 test.describe('Poker E2E', () => {
   test('plays a full round: reset → bet → stand (no exchange) → bet → result → reset', async ({ page }) => {
@@ -31,18 +31,24 @@ test.describe('Poker E2E', () => {
 
     // SECOND_BET phase: check/call repeatedly until end-state 次のゲーム appears.
     // A single check/call may not conclude the hand if a CPU re-raises.
+    //
+    // Wait for whichever control appears FIRST rather than probing each one in
+    // turn: two sequential 3s probes cost 6s per lap even when the hand has
+    // already ended, so a re-raising CPU could push 20 laps past the 90s test
+    // timeout. Playwright then tears the context down, and the in-flight
+    // waitForSelector reports "Target page, context or browser has been closed"
+    // — which reads like a browser crash but is really this timeout (#2443).
+    // Racing them returns as soon as any control is actionable, and a genuine
+    // stall now fails fast with a clear message instead of burning the budget.
     const endResetButton = page.getByRole('button', { name: '次のゲーム' });
     for (let i = 0; i < 20; i++) {
+      const anyControl = endResetButton.or(checkButton).or(callButton).first();
+      await expect(anyControl).toBeVisible({ timeout: TIMEOUT_GAME_LOOP });
       if (await endResetButton.isVisible()) break;
-      if (await isVisibleWithin(checkButton, TIMEOUT_ACTION)) {
+      if (await checkButton.isVisible()) {
         await checkButton.click();
-        await waitForLoaded(page);
-        continue;
-      }
-      if (await isVisibleWithin(callButton, TIMEOUT_ACTION)) {
+      } else {
         await callButton.click();
-        await waitForLoaded(page);
-        continue;
       }
       await waitForLoaded(page);
     }

--- a/frontend/e2e/razz.spec.ts
+++ b/frontend/e2e/razz.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { isVisibleWithin, navigateTo, TIMEOUT_ACTION, waitForLoaded } from './helpers';
+import { navigateTo, TIMEOUT_GAME_LOOP, waitForLoaded } from './helpers';
 
 test.describe('Razz E2E', () => {
   test('plays a full round: reset → check/call through streets → showdown → reset', async ({ page }) => {
@@ -19,6 +19,16 @@ test.describe('Razz E2E', () => {
       const checkButton = page.getByRole('button', { name: 'チェック', exact: true });
       const callButton = page.getByRole('button', { name: 'コール', exact: true });
 
+      // Wait for whichever control appears FIRST rather than probing each one
+      // in turn: two sequential 3s probes cost 6s per lap even once the hand
+      // has ended, so a re-raising CPU could push 20 laps past the 90s test
+      // timeout — Playwright then tears the context down and the in-flight
+      // waitForSelector reports "Target page, context or browser has been
+      // closed", which reads like a browser crash but is really this timeout
+      // (#2443). Racing them returns as soon as any control is actionable.
+      const anyControl = endResetButton.or(checkButton).or(callButton).first();
+      await expect(anyControl).toBeVisible({ timeout: TIMEOUT_GAME_LOOP });
+
       // End state reached — break immediately.
       if (await endResetButton.isVisible()) {
         roundEnded = true;
@@ -26,7 +36,7 @@ test.describe('Razz E2E', () => {
       }
 
       // Try check first, then call
-      if (await isVisibleWithin(checkButton, TIMEOUT_ACTION)) {
+      if (await checkButton.isVisible()) {
         if (await checkButton.isEnabled()) {
           await checkButton.click();
           await waitForLoaded(page);
@@ -34,7 +44,7 @@ test.describe('Razz E2E', () => {
         }
       }
 
-      if (await isVisibleWithin(callButton, TIMEOUT_ACTION)) {
+      if (await callButton.isVisible()) {
         if (await callButton.isEnabled()) {
           await callButton.click();
           await waitForLoaded(page);

--- a/frontend/e2e/sevencardstud.spec.ts
+++ b/frontend/e2e/sevencardstud.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { isVisibleWithin, navigateTo, TIMEOUT_ACTION, waitForLoaded } from './helpers';
+import { navigateTo, TIMEOUT_GAME_LOOP, waitForLoaded } from './helpers';
 
 test.describe('Seven Card Stud E2E', () => {
   test('plays a full round: reset → check/call through streets → showdown → reset', async ({ page }) => {
@@ -19,6 +19,16 @@ test.describe('Seven Card Stud E2E', () => {
       const checkButton = page.getByRole('button', { name: 'チェック', exact: true });
       const callButton = page.getByRole('button', { name: 'コール', exact: true });
 
+      // Wait for whichever control appears FIRST rather than probing each one
+      // in turn: two sequential 3s probes cost 6s per lap even once the hand
+      // has ended, so a re-raising CPU could push 20 laps past the 90s test
+      // timeout — Playwright then tears the context down and the in-flight
+      // waitForSelector reports "Target page, context or browser has been
+      // closed", which reads like a browser crash but is really this timeout
+      // (#2443). Racing them returns as soon as any control is actionable.
+      const anyControl = endResetButton.or(checkButton).or(callButton).first();
+      await expect(anyControl).toBeVisible({ timeout: TIMEOUT_GAME_LOOP });
+
       // End state reached — break immediately.
       if (await endResetButton.isVisible()) {
         roundEnded = true;
@@ -26,7 +36,7 @@ test.describe('Seven Card Stud E2E', () => {
       }
 
       // Try check first, then call
-      if (await isVisibleWithin(checkButton, TIMEOUT_ACTION)) {
+      if (await checkButton.isVisible()) {
         if (await checkButton.isEnabled()) {
           await checkButton.click();
           await waitForLoaded(page);
@@ -34,7 +44,7 @@ test.describe('Seven Card Stud E2E', () => {
         }
       }
 
-      if (await isVisibleWithin(callButton, TIMEOUT_ACTION)) {
+      if (await callButton.isVisible()) {
         if (await callButton.isEnabled()) {
           await callButton.click();
           await waitForLoaded(page);

--- a/frontend/e2e/shortdeck.spec.ts
+++ b/frontend/e2e/shortdeck.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { isVisibleWithin, navigateTo, TIMEOUT_ACTION, waitForLoaded } from './helpers';
+import { navigateTo, TIMEOUT_GAME_LOOP, waitForLoaded } from './helpers';
 
 test.describe("Short Deck Hold'em E2E", () => {
   test('plays a full round: reset → check/call through rounds → showdown → reset', async ({ page }) => {
@@ -19,6 +19,16 @@ test.describe("Short Deck Hold'em E2E", () => {
       const checkButton = page.getByRole('button', { name: 'チェック', exact: true });
       const callButton = page.getByRole('button', { name: 'コール', exact: true });
 
+      // Wait for whichever control appears FIRST rather than probing each one
+      // in turn: two sequential 3s probes cost 6s per lap even once the hand
+      // has ended, so a re-raising CPU could push 20 laps past the 90s test
+      // timeout — Playwright then tears the context down and the in-flight
+      // waitForSelector reports "Target page, context or browser has been
+      // closed", which reads like a browser crash but is really this timeout
+      // (#2443). Racing them returns as soon as any control is actionable.
+      const anyControl = endResetButton.or(checkButton).or(callButton).first();
+      await expect(anyControl).toBeVisible({ timeout: TIMEOUT_GAME_LOOP });
+
       // End state reached — break immediately.
       if (await endResetButton.isVisible()) {
         roundEnded = true;
@@ -26,7 +36,7 @@ test.describe("Short Deck Hold'em E2E", () => {
       }
 
       // Try check first, then call
-      if (await isVisibleWithin(checkButton, TIMEOUT_ACTION)) {
+      if (await checkButton.isVisible()) {
         if (await checkButton.isEnabled()) {
           await checkButton.click();
           await waitForLoaded(page);
@@ -34,7 +44,7 @@ test.describe("Short Deck Hold'em E2E", () => {
         }
       }
 
-      if (await isVisibleWithin(callButton, TIMEOUT_ACTION)) {
+      if (await callButton.isVisible()) {
         if (await callButton.isEnabled()) {
           await callButton.click();
           await waitForLoaded(page);


### PR DESCRIPTION
## The flake was a timeout wearing a browser-crash costume

`Poker E2E › plays a full round` has been failing intermittently for months and was written off as "the browser dies hard." The log actually reports two things:

```
Test timeout of 90000ms exceeded.
Error: page.waitForSelector: Target page, context or browser has been closed
```

The second is a consequence of the first — Playwright tears the context down on test timeout, so whatever `waitForSelector` was in flight reports a closed page. That explains why the two previous mitigations never worked: `retries: 2` re-ran a test that would time out again, and `--disable-dev-shm-usage` (#2369) fixed a real but different crash.

## The budget never fit

Each lap probed the controls **in sequence**:

```ts
if (await isVisibleWithin(checkButton, TIMEOUT_ACTION)) { ... }   // 3s if absent
if (await isVisibleWithin(callButton, TIMEOUT_ACTION)) { ... }    // 3s if absent
```

A lap where neither is up costs **6s** — and the end-state check at the top of the lap is a non-waiting `isVisible()`, so a hand that ends mid-lap still burns the full 6s before anyone notices. 20 laps × 6s = **120s against a 90s test timeout**, reachable whenever the CPU re-raises enough times. Nothing about it required a crash.

## Fix

Wait for whichever control appears first, which is the pattern the rest of the suite already uses (`marias`, `tute`, `burraco`):

```ts
const anyControl = endResetButton.or(checkButton).or(callButton).first();
await expect(anyControl).toBeVisible({ timeout: TIMEOUT_GAME_LOOP });
```

A lap returns as soon as anything is actionable, and a genuine stall now fails fast with a clear message instead of consuming the budget and dying by timeout.

## Same defect in 8 specs, not just poker

An initial grep for `for (let i = 0; i < 20` matched only poker; the loops elsewhere use different counter names. A structural scan found the identical two-sequential-probe shape in **poker, holdem, indianpoker, omaha, omahahilo, razz, sevencardstud, shortdeck** — all fixed here.

Left alone: `sevens.spec.ts` has a 300-iteration loop but a different shape (1s probes plus a `count()` branch); it deserves its own analysis rather than a mechanical edit.

## Test plan

- [x] All 8 specs run locally: **8 passed in 8.9s** (poker alone: 6.8s, against a 90s timeout)
- [x] Biome clean; unused `isVisibleWithin`/`TIMEOUT_ACTION` imports removed
- [ ] CI green

Refs #2443.

🤖 Generated with [Claude Code](https://claude.com/claude-code)