### PR TITLE
perf(ci): parallelize and shard the two slowest jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,8 +67,18 @@ jobs:
         run: bun run check
 
   test-frontend:
-    name: Frontend Tests
+    # Sharded because this is the slowest job in the pipeline (~20 min
+    # unsharded): 15,984 tests over 1,133 files. Measured on a 16-core box the
+    # run still takes ~11 min WITHOUT coverage, so the cost is the test volume
+    # itself, not the coverage instrumentation — splitting the work is the only
+    # lever that moves it. Each shard uploads its own coverage; Codecov merges
+    # them server-side.
+    name: Frontend Tests (${{ matrix.shard }}/4)
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@v6
 
@@ -89,18 +99,28 @@ jobs:
         # forked test workers via NODE_OPTIONS.
         env:
           NODE_OPTIONS: --max-old-space-size=8192
-        run: bun run test:coverage
+        run: bun run test:coverage -- --shard=${{ matrix.shard }}/4
 
       - name: Upload frontend coverage to Codecov
         uses: codecov/codecov-action@v6
         with:
           files: frontend/coverage/lcov.info
           flags: frontend
+          # Each shard reports partial coverage; Codecov merges the uploads for
+          # the commit, so the job must not fail when one shard misses a file.
+          fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
 
   test-e2e:
-    name: E2E Tests (Playwright)
+    # Sharded on top of the in-job parallelism (playwright.config.ts runs 4
+    # workers in CI). Each shard boots its own server binary, so shards cannot
+    # interfere with each other.
+    name: E2E Tests (${{ matrix.shard }}/3)
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
     steps:
       - uses: actions/checkout@v6
 
@@ -133,12 +153,12 @@ jobs:
         working-directory: frontend
         env:
           E2E_SERVER_BIN: /tmp/trumpcards-server
-        run: bunx playwright test
+        run: bunx playwright test --shard=${{ matrix.shard }}/3
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}
         with:
-          name: playwright-report
+          name: playwright-report-${{ matrix.shard }}
           path: frontend/playwright-report/
           retention-days: 14

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -12,7 +12,13 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  // The server keys game state by sessionId (the frontend mints one per page
+  // load via crypto.randomUUID), so specs cannot collide on shared state and
+  // can run in parallel. Measured on a 20-spec sample: 1m24s at 1 worker vs
+  // 38s at 4. Pinned to 4 rather than left undefined so a runner with more
+  // cores does not oversubscribe one Chromium per core against a single
+  // backend.
+  workers: process.env.CI ? 4 : undefined,
   reporter: 'html',
   timeout: 90_000,
   use: {


### PR DESCRIPTION
## Measured first

Every PR waits on two ~20 minute jobs. Per-step timings from a recent `develop` run:

| Step | Time |
|---|---|
| Frontend Tests → run with coverage | **1205s (20m)** |
| E2E → the test run | **~20m** |
| Backend Tests → run with coverage | 267s |
| E2E → build frontend | 78s |
| E2E → build server binary | 39s |
| E2E → install Playwright browsers | 27s |

## E2E was running single-threaded for no reason

`playwright.config.ts` had `workers: process.env.CI ? 1 : undefined` with no explanation. Nothing requires it: the server keys game state by `sessionId` (`base_controller.go` → `SessionProvider.Acquire`) and the frontend mints a fresh one per page load (`gameApi.ts:244`, `crypto.randomUUID()`), so two specs cannot land on the same game state.

Raising it to 4 on a 20-spec sample: **1m24s → 38s**, 32/32 passing. Pinned to 4 rather than `undefined` so a larger runner does not aim one Chromium per core at a single backend.

## Both jobs sharded

Frontend 4 ways, E2E 3 ways (on top of the 4 workers). Each E2E shard boots its own server binary, so shards are independent.

**Why sharding and not "just drop coverage":** on a 16-core box the frontend suite still takes **10m43s without coverage** (85 min of CPU time). The cost is the 15,984 tests, not the v8 instrumentation — dropping coverage would surrender the 80% branch-coverage gate and buy almost nothing.

## Verified the splits are lossless before trusting them

A shard config that silently drops tests is worse than a slow one, so I checked the arithmetic rather than assuming:

- vitest: 3658 + 3746 + 4458 + 4122 = **15,984** — exactly the unsharded total
- Playwright: 102 + 102 + 102 = **306** — exactly the unsharded total
- One E2E shard end-to-end locally: **3m0s**, 102/102 passing

Expected wall clock: frontend ~5-6 min, E2E ~3-4 min, so the critical path drops from ~20 min to roughly the Backend Tests' 4.5 min.

## Test plan

- [x] Shard arithmetic verified lossless on both runners (above)
- [x] E2E shard 1/3 at 4 workers: 102 passed in 3m0s
- [x] 20-spec parallel sample: 32 passed, 2.2× faster
- [x] Workflow YAML lints
- [ ] CI green, and the wall-clock improvement confirmed on the real runners
- [ ] Codecov still reports merged frontend coverage across the 4 shard uploads

🤖 Generated with [Claude Code](https://claude.com/claude-code)