### PR TITLE
perf(ci): rebalance the frontend shards and cache the E2E build inputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,12 +73,18 @@ jobs:
     # itself, not the coverage instrumentation — splitting the work is the only
     # lever that moves it. Each shard uploads its own coverage; Codecov merges
     # them server-side.
-    name: Frontend Tests (${{ matrix.shard }}/4)
+    #
+    # Six rather than four: --shard splits by file COUNT, but file runtimes
+    # vary widely, so at 4 the slowest shard ran 435s against a 280s mean (the
+    # whole pipeline waits on that one). Per-shard fixed overhead is only ~16s,
+    # so extra shards are nearly free and each one dilutes the effect of a
+    # single heavy file.
+    name: Frontend Tests (${{ matrix.shard }}/6)
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4]
+        shard: [1, 2, 3, 4, 5, 6]
     steps:
       - uses: actions/checkout@v6
 
@@ -99,7 +105,7 @@ jobs:
         # forked test workers via NODE_OPTIONS.
         env:
           NODE_OPTIONS: --max-old-space-size=8192
-        run: bun run test:coverage -- --shard=${{ matrix.shard }}/4
+        run: bun run test:coverage -- --shard=${{ matrix.shard }}/6
 
       - name: Upload frontend coverage to Codecov
         uses: codecov/codecov-action@v6
@@ -128,6 +134,9 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: '1.26'
+          # Reuse the module + build cache across shards so `go build` of the
+          # server binary is not paid three times from cold (~37s each).
+          cache-dependency-path: go.sum
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
@@ -142,9 +151,32 @@ jobs:
         working-directory: frontend
         run: bun run build
 
+      # The browser download is identical across shards and only changes when
+      # Playwright itself does, so key the cache on the resolved version from
+      # the lockfile. Cold: ~21s per shard; warm: a few seconds.
+      - name: Resolve Playwright version
+        id: pw
+        working-directory: frontend
+        run: echo "version=$(node -p "require('./node_modules/@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        id: pw-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}
+
       - name: Install Playwright browsers
         working-directory: frontend
         run: bunx playwright install --with-deps chromium
+        if: steps.pw-cache.outputs.cache-hit != 'true'
+
+      # --with-deps installs OS packages outside the cached directory, so a
+      # cache hit still needs them.
+      - name: Install Playwright OS dependencies
+        working-directory: frontend
+        run: bunx playwright install-deps chromium
+        if: steps.pw-cache.outputs.cache-hit == 'true'
 
       - name: Build server binary
         run: go build -o /tmp/trumpcards-server ./cmd/server


### PR DESCRIPTION
Follow-up to #4343, driven by its per-step timings rather than guesswork.

## The critical path was imbalance, not volume

#4343 got the pipeline to 7.6 min, gated by one job:

| Frontend shard | fixed overhead | test run | total |
|---|---|---|---|
| 3/4 | 16s | **435s** | 454s |
| 1/4 | 16s | 267s | 288s |
| 4/4 | 20s | 209s | 233s |
| 2/4 | 14s | 209s | 226s |

Same work, wildly different runtimes: `--shard` splits by file **count**, and file runtimes are not uniform. The slowest shard ran 55% over the mean and everything waited on it.

Per-shard fixed overhead is only ~16s, so shards are nearly free. **4 → 6** puts the ideal at ~187s + 16s, and each extra shard dilutes the effect of any single heavy file.

Verified lossless before trusting it: 2587 + 2215 + 2602 + 2964 + 3015 + 2601 = **15,984**, exactly the unsharded total.

## E2E: stop paying for the same build three times

E2E shard 2/3 spent **137s of its 370s on setup**: frontend build 79s, server binary 37s, Playwright browsers 21s — repeated in every shard.

- Playwright browsers are now cached, keyed on the resolved Playwright version (identical across shards, changes only when the package does).
- `setup-go` gets an explicit `cache-dependency-path` so the server binary is not built cold three times.

This is honestly a **cost** win more than a wait win today — E2E at 370s is not the critical path while the frontend job sits at 454s. It starts paying in wall clock as soon as the frontend job drops below it, which is the point of this PR.

## What I deliberately did not do

**Cache the frontend build output (79s/shard).** Its cache key would have to cover every build input — `src/**`, `index.html`, configs, and the `docs/manual/**` tree pulled in via `?raw`. Miss one and E2E runs against a stale bundle: tests passing against code that is not under test. This session already produced two green-but-broken states (a Vite bump that broke 222 test files while the build stayed green, and a stale `node_modules` hiding an undeclared `jsdom`); a false-green cache is the same failure mode with a longer fuse.

The safe alternative — build once in a prep job, share via artifacts — serializes what currently runs in parallel, so it trades ~137s of parallel setup for ~100s of serial setup. Not worth the complexity.

## Test plan

- [x] 6-way split verified lossless (15,984 = unsharded total)
- [x] Workflow YAML lints
- [ ] CI green
- [ ] Confirm on the real runners: slowest frontend shard well under 435s, and the Playwright cache hits on the second run

🤖 Generated with [Claude Code](https://claude.com/claude-code)