### PR TITLE
perf(test): make the NavBar active-link assertion O(n) instead of O(n²)

### DIFF
--- a/frontend/src/components/NavBar.test.tsx
+++ b/frontend/src/components/NavBar.test.tsx
@@ -54,10 +54,8 @@ describe('NavBar', () => {
 
     it(`marks ${labelKey} link as active when on ${path}`, () => {
       renderNavBar(path);
-      // Collect the links carrying aria-current in one pass and assert there is
-      // exactly one. Equivalent to checking every other route individually, but
-      // O(n) instead of O(n^2) — the per-route version ran 219 getByText queries
-      // per test across 219 tests (~48k DOM scans) and dominated the suite.
+      // Exactly one link may carry aria-current, which also proves no other
+      // route's link has it.
       const current = screen.getAllByRole('link').filter((link) => link.hasAttribute('aria-current'));
       expect(current).toHaveLength(1);
       expect(current[0]).toHaveAttribute('aria-current', 'page');

--- a/frontend/src/components/NavBar.test.tsx
+++ b/frontend/src/components/NavBar.test.tsx
@@ -54,12 +54,14 @@ describe('NavBar', () => {
 
     it(`marks ${labelKey} link as active when on ${path}`, () => {
       renderNavBar(path);
-      expect(screen.getByText(labelFor(labelKey))).toHaveAttribute('aria-current', 'page');
-      for (const other of gameRoutes) {
-        if (other.path !== path) {
-          expect(screen.getByText(labelFor(other.labelKey))).not.toHaveAttribute('aria-current');
-        }
-      }
+      // Collect the links carrying aria-current in one pass and assert there is
+      // exactly one. Equivalent to checking every other route individually, but
+      // O(n) instead of O(n^2) — the per-route version ran 219 getByText queries
+      // per test across 219 tests (~48k DOM scans) and dominated the suite.
+      const current = screen.getAllByRole('link').filter((link) => link.hasAttribute('aria-current'));
+      expect(current).toHaveLength(1);
+      expect(current[0]).toHaveAttribute('aria-current', 'page');
+      expect(current[0]).toHaveTextContent(labelFor(labelKey));
     });
   }
 


### PR DESCRIPTION
## The frontend job's floor was one file, and one loop inside it

After #4344 the six frontend shards land at 192, 196, 207, 207, 211 … and **405s**. That outlier is not scheduler imbalance — it is the shard holding `NavBar.test.tsx`, which takes **149s on its own with zero contention** (489 tests, 19× the next slowest file at 30s). No shard count can go below a single file's runtime, so more shards could never move it.

The cost turned out to be algorithmic:

```ts
for (const { path, labelKey } of gameRoutes) {        // 219 routes
  it(`marks ${labelKey} link as active when on ${path}`, () => {
    renderNavBar(path);
    expect(screen.getByText(labelFor(labelKey))).toHaveAttribute('aria-current', 'page');
    for (const other of gameRoutes) {                 // × 218 more lookups
      if (other.path !== path) {
        expect(screen.getByText(labelFor(other.labelKey))).not.toHaveAttribute('aria-current');
      }
    }
  });
}
```

219 × 218 ≈ **48,000 `getByText` scans**. Collecting the `aria-current` links in one pass gives the same guarantee in O(n):

```ts
const current = screen.getAllByRole('link').filter((link) => link.hasAttribute('aria-current'));
expect(current).toHaveLength(1);
expect(current[0]).toHaveAttribute('aria-current', 'page');
expect(current[0]).toHaveTextContent(labelFor(labelKey));
```

**149s → 78s, all 489 tests still passing.**

## Equivalence verified by mutation, not by reading

A faster test that catches less is a downgrade, so I broke the component on purpose and compared old vs new:

| Mutation in `NavBar.tsx` | Old test | New test |
|---|---|---|
| every game link gets `aria-current="page"` | 219 failed | **219 failed** |
| the wrong link gets `aria-current` (`===` → `!==`) | 219 failed | **219 failed** |

Identical detection, both times.

(A first attempt at this mutated lines 176/199 and *nothing* failed — those sit in the mobile favourites/recents branches, which the default render never reaches. The old test passed too, which is what flagged the experiment as invalid rather than the rewrite as weak. The real link list is at 227/263.)

## Expected effect

That shard should drop from ~405s toward the ~200s band the other five already occupy, taking the pipeline's critical path with it. Same file also OOM'd the vitest worker earlier today (#4340) — halving its DOM churn should ease that pressure too.

## Test plan

- [x] 489/489 passing, 149s → 78s locally
- [x] Mutation-tested for equivalence against the previous assertion (table above)
- [x] Biome clean
- [ ] CI green, and the slow shard measurably closer to the others

🤖 Generated with [Claude Code](https://claude.com/claude-code)