### PR TITLE
perf(ci): use covermode=set for the backend suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,13 @@ jobs:
       - name: Download dependencies
         run: go mod download
 
+      # covermode=set, not atomic. atomic updates every counter with an atomic
+      # add, which costs ~2x wall clock here (measured at CI's -p 4: 124s ->
+      # 62s) for identical numbers (82.3% either way). Go itself only defaults
+      # to atomic under -race, which this job does not use; if -race is ever
+      # added, this must go back to atomic.
       - name: Run backend tests with coverage
-        run: go test -tags test -coverprofile=coverage.out -covermode=atomic ./...
+        run: go test -tags test -coverprofile=coverage.out -covermode=set ./...
 
       - name: Upload backend coverage to Codecov
         uses: codecov/codecov-action@v6

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ go run ./cmd/server                # Start REST API + web GUI server (direct)
 
 # Test
 go test -tags test ./...                                              # Run all Go tests
-go test -tags test -coverprofile=coverage.out -covermode=atomic ./... # Coverage report
+go test -tags test -coverprofile=coverage.out -covermode=set ./...    # Coverage report
 
 # Format
 goimports -w ./...           # Format and organize imports (use goimports, not gofmt)


### PR DESCRIPTION
## Half of Backend Tests was coverage bookkeeping

After #4345 the pipeline is balanced: frontend shards 293s, **Backend Tests 280s**, E2E 272s. Backend had never been touched, so I measured it before assuming anything.

Per-package, cold cache: `internal/domain` **112s**, next-slowest `internal/usecase` **12.9s**. So the backend job is essentially one package. Splitting `internal/domain` into itself is what `-covermode` turned out to be doing to it:

| | `internal/domain` alone | full suite at CI's `-p 4` |
|---|---|---|
| `-covermode=atomic` (current) | 140-146s | **124s** |
| `-covermode=set` | 46-49s | **62s** |
| reported coverage | 89.6% either way | **82.3% either way** |

`atomic` updates every coverage counter with an atomic add. Go only defaults to it under `-race`; otherwise `set` is the toolchain's own default. This job does not use `-race`.

## Why the first measurement said "no difference"

My first full-suite comparison came back 112s vs 114s — no effect. That run used this box's 16-way package parallelism, where `internal/domain`'s cost overlaps with 15 other packages and disappears into the noise. Re-running at CI's actual `-p 4` exposed the 2× gap. Worth stating because the wrong number was the more convenient one to believe, and it nearly ended this investigation.

## Risk

The repo has 248 `t.Parallel()` calls, which is the usual reason to reach for atomic. In `set` mode a counter is a plain `true` assignment, so concurrent writes converge on the same value; the only genuine hazard is the race detector flagging it, and that requires `-race`. Noted in the workflow comment: **if `-race` is ever added to this job, this must go back to atomic.**

`CLAUDE.md` documented the same command, so it moves with the workflow rather than drifting out of sync.

## Test plan

- [x] Coverage identical at both `internal/domain` (89.6%) and repo level (82.3%)
- [x] Measured twice per mode, alternating, to rule out load noise (atomic 145.5/140.2s vs set 45.6/48.8s)
- [x] Workflow YAML lints
- [ ] CI green, and Codecov reports the same backend coverage as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
