### PR TITLE
perf(test): index NavBar links once in the href assertion

### DIFF
--- a/frontend/src/components/NavBar.test.tsx
+++ b/frontend/src/components/NavBar.test.tsx
@@ -65,8 +65,19 @@ describe('NavBar', () => {
 
   it('links point to correct hrefs', () => {
     renderNavBar();
+    // Index the links once. Querying by accessible name recomputes it for every
+    // element in the tree, so doing that per route is quadratic.
+    // A path can be rendered by more than one link (category list, sidebar),
+    // so collect every label per href rather than keeping the last one.
+    const labelsByHref = new Map<string, string[]>();
+    for (const link of screen.getAllByRole('link')) {
+      const href = link.getAttribute('href') ?? '';
+      const labels = labelsByHref.get(href) ?? [];
+      labels.push(link.textContent ?? '');
+      labelsByHref.set(href, labels);
+    }
     for (const { path, labelKey } of gameRoutes) {
-      expect(screen.getByRole('link', { name: labelFor(labelKey) })).toHaveAttribute('href', path);
+      expect(labelsByHref.get(path)?.some((label) => label.includes(labelFor(labelKey)))).toBe(true);
     }
   });
 


### PR DESCRIPTION
## A test that passes on rerun is still broken

`Frontend Tests (4/6)` failed on #4346 — a PR that only changes a Go flag — with:

```
FAIL src/components/NavBar.test.tsx > NavBar > links point to correct hrefs
Error: Test timed out in 10000ms.
```

It passed on rerun, so it would be easy to file as flake and move on. But the cause is not randomness, it is a budget that barely fits:

```ts
for (const { path, labelKey } of gameRoutes) {          // 219 routes
  expect(screen.getByRole('link', { name: labelFor(labelKey) })).toHaveAttribute('href', path);
}
```

Querying **by accessible name** recomputes that name for every element in the tree, once per route. That is 1232ms on an idle 16-core box — fine in isolation, and roughly 8× worse on a 4-core runner with six shards competing, which lands right on the 10s ceiling. Same shape as the `poker.spec.ts` timeout fixed in #4342 and the O(n²) assertion in #4345: the failure mode is a clock, not a bug.

## Fix

Index the links by href in a single pass:

**1232ms → 570ms**, with room under the timeout instead of resting on it.

One wrinkle worth noting: a path is rendered by more than one link (category list and sidebar), so labels are collected **per href** rather than last-write-wins. My first attempt kept only the last link and failed against an icon-only entry — a good reminder that the DOM here is not one link per route.

## Equivalence verified by mutation

| Mutation in `NavBar.tsx` | Old test | New test |
|---|---|---|
| every category link points at `/blackjack` | failed | **failed** |
| every category link's label replaced | failed | **failed** |

(The first run of this experiment showed both passing — `git stash` had quietly reverted the component mutation along with the test file. Redone with plain file copies. Worth stating because a mutation test that silently tests nothing is exactly as misleading as the flake it is meant to rule out.)

## Test plan

- [x] 489/489 NavBar tests pass; file 78s → 76s
- [x] Target test 1232ms → 570ms
- [x] Mutation-tested for equivalence (table above)
- [x] `bun run build` (incl. tsc) and Biome clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
