### PR TITLE
perf(ci): 8 frontend shards and 5 E2E shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,17 +79,17 @@ jobs:
     # lever that moves it. Each shard uploads its own coverage; Codecov merges
     # them server-side.
     #
-    # Six rather than four: --shard splits by file COUNT, but file runtimes
+    # Eight rather than four: --shard splits by file COUNT, but file runtimes
     # vary widely, so at 4 the slowest shard ran 435s against a 280s mean (the
     # whole pipeline waits on that one). Per-shard fixed overhead is only ~16s,
     # so extra shards are nearly free and each one dilutes the effect of a
-    # single heavy file.
-    name: Frontend Tests (${{ matrix.shard }}/6)
+    # single heavy file. At 6 the spread was 199-287s over 1320s of work.
+    name: Frontend Tests (${{ matrix.shard }}/8)
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4, 5, 6]
+        shard: [1, 2, 3, 4, 5, 6, 7, 8]
     steps:
       - uses: actions/checkout@v6
 
@@ -110,7 +110,7 @@ jobs:
         # forked test workers via NODE_OPTIONS.
         env:
           NODE_OPTIONS: --max-old-space-size=8192
-        run: bun run test:coverage -- --shard=${{ matrix.shard }}/6
+        run: bun run test:coverage -- --shard=${{ matrix.shard }}/8
 
       - name: Upload frontend coverage to Codecov
         uses: codecov/codecov-action@v6
@@ -126,12 +126,17 @@ jobs:
     # Sharded on top of the in-job parallelism (playwright.config.ts runs 4
     # workers in CI). Each shard boots its own server binary, so shards cannot
     # interfere with each other.
-    name: E2E Tests (${{ matrix.shard }}/3)
+    #
+    # Five shards, not more: ~105s of every shard is setup (frontend build,
+    # browsers, server binary) and does not shrink with the split, so the job
+    # asymptotes there. 3 -> 5 moves the slowest shard ~261s -> ~190s; 8 would
+    # buy another ~20s for three more runners.
+    name: E2E Tests (${{ matrix.shard }}/5)
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3]
+        shard: [1, 2, 3, 4, 5]
     steps:
       - uses: actions/checkout@v6
 
@@ -190,7 +195,7 @@ jobs:
         working-directory: frontend
         env:
           E2E_SERVER_BIN: /tmp/trumpcards-server
-        run: bunx playwright test --shard=${{ matrix.shard }}/3
+        run: bunx playwright test --shard=${{ matrix.shard }}/5
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Where the time is now

| Job | Current | This PR targets |
|---|---|---|
| Frontend Tests (6 shards) | 199-**287s** | ~181s at 8 |
| E2E Tests (3 shards) | 225-**261s** | ~190s at 5 |
| Backend Tests | 170s | untouched |

## Frontend 6 → 8

1320s of work spread 199-287s across six shards. At eight the ideal is 165s + ~16s fixed overhead. Headroom remains because the real floor is the slowest single **file** — NavBar, now ~76s after #4345 and #4347 took it from 149s.

Split verified lossless: 1999+1659+1801+1951+1734+2740+2166+1934 = **15,984**, the unsharded total.

## E2E 3 → 5

~105s of every E2E shard is setup — frontend build 76s, browsers, server binary — and **does not shrink when you split**. Only the ~409s of test time divides:

| shards | estimate |
|---|---|
| 3 (today) | 105 + 136 = 241s |
| **5** | 105 + 82 = **187s** |
| 8 | 105 + 51 = 156s |

Playwright's 5-way split lists 62+61+61+61+61 = **306**, the unsharded total.

## Why stop at 8 and 5

Not runner cost — this repo is public, so GitHub-hosted runners are free. Two measured limits instead:

1. **Concurrency.** GitHub Free allows 20 concurrent jobs. The last run used 12 in the CI workflow plus CodeQL and review jobs, all starting within 2s of each other (no queuing). 8+5 brings the account to ~19 — going further risks queuing, which would cost more wall clock than the extra shards save.
2. **The pipeline converges.** At these counts all three jobs land near 180s. Pushing frontend or E2E lower just promotes backend's 170s to critical path.

## Measured and deliberately NOT done

**Splitting the backend job.** `internal/domain` is ~75% of its runtime (measured 3:1 against everything else), so a domain/rest split caps at ~128s — already below the other two jobs, so it would not move the critical path at all.

**Sharing the E2E frontend build via a prep job.** Recomputed at 5 shards: 95s prep + 112s per shard = 207s, worse than 187s, because it serializes a build that currently runs in parallel. Same conclusion as at 3 shards.

## Test plan

- [x] vitest 8-way split lossless (15,984 = unsharded total)
- [x] Playwright 5-way split lossless (306 = unsharded total)
- [x] Workflow YAML lints
- [ ] CI green, all jobs start without queuing, and the critical path lands near 180s

🤖 Generated with [Claude Code](https://claude.com/claude-code)
