### PR TITLE
perf(e2e): skip the CPU replay animation and race the Sevens loop

### DIFF
--- a/frontend/e2e/helpers.ts
+++ b/frontend/e2e/helpers.ts
@@ -35,6 +35,10 @@ export async function navigateTo(page: Page, path: string) {
   // Suppress the first-visit tutorial suggestion dialog to avoid blocking game interaction
   await page.addInitScript(() => {
     localStorage.setItem('tutorial_no_suggest', 'true');
+    // Skip the CPU replay animation. Specs assert on state, not on the
+    // pacing of the animation, and at the default 'normal' speed every
+    // CPU action costs 800ms — Sevens alone spent ~2.9s per turn waiting.
+    localStorage.setItem('cpuReplaySpeed', 'instant');
   });
   await page.goto(`/#${path}`);
   await waitForLoaded(page);

--- a/frontend/e2e/sevens.spec.ts
+++ b/frontend/e2e/sevens.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { isVisibleWithin, navigateTo, TIMEOUT_ACTION, TIMEOUT_QUICK, waitForLoaded } from './helpers';
+import { navigateTo, TIMEOUT_GAME_LOOP, waitForLoaded } from './helpers';
 
 test.describe('Sevens E2E', () => {
   test('plays a full game: reset → play or pass each turn → end → reset', async ({ page }) => {
@@ -16,26 +16,22 @@ test.describe('Sevens E2E', () => {
     let gameEnded = false;
     for (let turn = 0; turn < 300; turn++) {
       const passButton = page.getByRole('button', { name: 'パス' });
-
-      // Check if game ended: all players finished
       const gameEnd = page.locator('text=ゲーム終了');
-      if (await isVisibleWithin(gameEnd, TIMEOUT_QUICK)) {
+      const playableCards = page.locator('[data-testid="playable-card"]');
+
+      // Wait for whichever of the three appears first. Probing the end state
+      // with its own timeout cost a full second every turn even mid-game.
+      await expect(gameEnd.or(playableCards).or(passButton).first()).toBeVisible({ timeout: TIMEOUT_GAME_LOOP });
+
+      if (await gameEnd.isVisible()) {
         gameEnded = true;
         break;
       }
 
-      // Try to find a playable card via data-testid and click it
-      const playableCards = page.locator('[data-testid="playable-card"]');
-      const playableCount = await playableCards.count();
-
-      if (playableCount > 0) {
+      if ((await playableCards.count()) > 0) {
         await playableCards.first().click();
-        await waitForLoaded(page);
-      } else if (await isVisibleWithin(passButton, TIMEOUT_ACTION)) {
-        if (await passButton.isEnabled()) {
-          await passButton.click();
-          await waitForLoaded(page);
-        }
+      } else if (await passButton.isEnabled()) {
+        await passButton.click();
       }
 
       await waitForLoaded(page);


### PR DESCRIPTION
## The remaining E2E cost was the app's animation, not the tests

I went after `sevens.spec.ts` expecting the #4342 shape — a 300-iteration loop probing controls one at a time. Fixing that gave **53.4s → 45.9s**, far less than expected, so I instrumented the loop instead of accepting it:

```
turn 1  2878ms
turn 2  2862ms
turn 3  2869ms
turn 4  2866ms
...
```

A flat ~2.87s per turn regardless of what the turn did. That is three CPU actions at `REPLAY_DELAY_MS = 800ms` — the replay animation, which no amount of test-side restructuring can remove.

## The lever was already in the app

`useReplaySpeed` is a user setting (`normal` / `fast` / `instant`) stored in localStorage, read fresh on every replay step, and `instant` means multiplier **0**. `navigateTo` already seeds localStorage to suppress the tutorial dialog, so one more line covers every spec that drives CPU turns:

```ts
localStorage.setItem('cpuReplaySpeed', 'instant');
```

| | Before | After |
|---|---|---|
| `sevens.spec.ts` | 53.4s | **4.1s** |
| Full suite (4 workers, local) | 10.1m | **6.0m** |

306/306 still passing, which is the check that matters here: nothing in the suite was asserting on the animation being visible. Specs assert on the state a replay lands in, not on its pacing.

## Also included: the Sevens loop fix

Kept because it is correct on its own merits — the loop probed the end-state with a 1s timeout every turn even mid-game, the same budget problem as #4342. It just was not the dominant cost, and finding that out is what led to the replay setting.

## Effect on CI

E2E shards are ~105s setup + test time; this attacks the test-time half. With 5 shards from #4348 they ran 171-227s, so this should pull them toward the setup floor.

## Test plan

- [x] `sevens.spec.ts`: 53.4s → 4.1s
- [x] Full E2E suite: **306/306 passing**, 10.1m → 6.0m locally at 4 workers
- [x] Biome clean
- [ ] CI green, E2E shards closer to their ~105s setup floor

🤖 Generated with [Claude Code](https://claude.com/claude-code)
