### PR TITLE
perf(ci): run tsc once in its own job instead of once per E2E shard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,29 @@ jobs:
         working-directory: frontend
         run: bun run check
 
+  typecheck-frontend:
+    # tsc is the only gate that catches type errors: `bun run check` is Biome
+    # only, and vitest transpiles without checking. It used to run solely as a
+    # side effect of the E2E job's `bun run build` (tsc -b && vite build), so
+    # every E2E shard paid ~48s for the same check. Run it once here instead.
+    name: Frontend Typecheck (tsc)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.10'
+
+      - name: Install dependencies
+        working-directory: frontend
+        run: bun install --frozen-lockfile
+
+      - name: Type-check
+        working-directory: frontend
+        run: bunx tsc -b
+
   test-frontend:
     # Sharded because this is the slowest job in the pipeline (~20 min
     # unsharded): 15,984 tests over 1,133 files. Measured on a 16-core box the
@@ -157,9 +180,11 @@ jobs:
         working-directory: frontend
         run: bun install --frozen-lockfile
 
+      # Bundle only — `bun run build` also runs `tsc -b` (~48s), which the
+      # dedicated typecheck job now covers once instead of once per shard.
       - name: Build frontend
         working-directory: frontend
-        run: bun run build
+        run: bunx vite build
 
       # The browser download is identical across shards and only changes when
       # Playwright itself does, so key the cache on the resolved version from


### PR DESCRIPTION
## Every E2E shard was paying for the same type-check

The E2E job builds with `bun run build`, which is `tsc -b && vite build`. Split and measured cold:

| step | time |
|---|---|
| `tsc -b` | **48s** |
| `vite build` | 18s |

With 5 shards that is ~48s of type-checking performed five times for an identical result — roughly 4 minutes of runner time per run, and ~48s on the critical path of every shard.

## Why this needed a new job, not a deletion

`tsc` is the **only** place CI type-checks. `bun run check` is Biome plus the design-token script; vitest transpiles without checking. Dropping tsc from the E2E build would have quietly removed type coverage from CI — the same "green but not actually verified" shape as the stale-cache idea I rejected in #4344 and the undeclared `jsdom` in #4341.

So: a dedicated `Frontend Typecheck (tsc)` job runs it once, and E2E runs `bunx vite build` for the bundle only.

## Verification

The risk of a bundle-only build is a bundle that is subtly incomplete, which would show up as E2E failures rather than a build error. Ran a full E2E shard against it:

```
62 passed (1.2m)   ×3 consecutive runs
```

(The first attempt showed `chinesepoker` failing — a member of the flaky cluster already tracked in #2443. It passes in isolation in 3.3s and did not recur across three further shard runs.)

## Expected effect

E2E shards were 168-230s with ~107s of setup; ~48s of that setup disappears. The new typecheck job runs ~60s in parallel, well under the shards it no longer blocks. Critical path was 230s (E2E).

## Test plan

- [x] `vite build` alone produces a complete bundle (`public/index.html` + assets)
- [x] Full E2E shard against the bundle-only build: 62/62, three consecutive runs
- [x] tsc still runs in CI, now as its own job
- [x] Workflow YAML lints
- [ ] CI green, E2E shards ~48s faster, typecheck job not the new bottleneck

🤖 Generated with [Claude Code](https://claude.com/claude-code)
