### PR TITLE
perf(ci): run CodeQL after the merge, not on every PR

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,11 +11,14 @@
 #
 name: "CodeQL"
 
+# Runs after the merge, not on the PR. The Go job takes ~460s and the
+# JavaScript one ~220s, which made CodeQL — not the CI workflow (~230s) — the
+# real wait on every PR. develop is an integration branch, not a release
+# branch (master is), so scanning right after the merge still catches a finding
+# before it can ship, and the weekly run covers query-pack updates against
+# code that has not changed. Findings land in the Security tab either way.
 on:
   push:
-    branches: [ develop ]
-  pull_request:
-    # The branches below must be a subset of the branches above
     branches: [ develop ]
   schedule:
     - cron: '37 4 * * 0'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,7 @@ See [`docs/new-game-checklist.md`](docs/new-game-checklist.md) for the full chec
 
 ## Git Workflow
 
-- **`develop`**: Default branch; target for all PRs. CodeQL analysis and `golangci-lint` run on push/PR.
+- **`develop`**: Default branch; target for all PRs. `golangci-lint` and the CI suite run on push/PR; CodeQL runs on push to `develop` (i.e. after the merge) and weekly — see [ADR-0034](docs/adr/0034-codeql-post-merge.md).
 - **`master`**: Triggers automatic version bump, git tag, and GitHub Release.
 - **PR Summary**: When creating a PR, if there is an associated issue, the PR description must explicitly close the issue (e.g., `Closes #123`).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,8 @@ bun run test    # ユニットテスト
 
 - PR のターゲットブランチは `develop` です
 - 関連する Issue がある場合は `Closes #123` で紐付けてください
-- CI（lint, test, CodeQL）がすべて通ることを確認してください
+- CI（lint, test, E2E）がすべて通ることを確認してください
+- CodeQL は PR では動きません。`develop` へのマージ後に実行され、結果は Security タブに出ます（[ADR-0034](docs/adr/0034-codeql-post-merge.md)）
 
 ## Architecture
 

--- a/docs/adr/0019-ci-cd-pipeline.md
+++ b/docs/adr/0019-ci-cd-pipeline.md
@@ -16,7 +16,7 @@ Accepted
 
 GitHub Actionsで以下のパイプラインを構築:
 
-- **CodeQL**: push/PR時にセキュリティスキャン
+- **CodeQL**: push/PR時にセキュリティスキャン（PR時の実行は [ADR-0034](0034-codeql-post-merge.md) で廃止。現在は `develop` への push と週次のみ）
 - **golangci-lint**: Go コードの静的解析
 - **CI**: バックエンド・フロントエンド双方のテスト自動実行（2026-02-19追加）
 - **Auto-tag**: `master` へのマージ時に自動でgitタグとGitHub Releaseを作成

--- a/docs/adr/0034-codeql-post-merge.md
+++ b/docs/adr/0034-codeql-post-merge.md
@@ -1,0 +1,57 @@
+# ADR-0034: CodeQL を PR ではなくマージ後に実行する
+
+## Status
+
+Accepted
+
+## Date
+
+2026-07-26
+
+## Context
+
+CI の待ち時間を短縮する作業（PR #4343–#4351）で CI ワークフローのクリティカルパスを 1044 秒から 230 秒まで下げたが、PR が起動する**全ワークフロー**を計測したところ、待ち時間を決めていたのは CI ではなく CodeQL だった。
+
+| ワークフロー | PR 上で最も遅いジョブ |
+|---|---|
+| **CodeQL — Analyze (go, autobuild)** | **459 秒** |
+| CI — E2E シャード | 230 秒 |
+| Cloudflare workers build (tinygo ×4) | 225 秒 |
+| CodeQL — Analyze (javascript-typescript) | 218 秒 |
+
+Go ジョブの 459 秒の内訳は、抽出 250 秒 + データベース書き出し 120 秒 + クエリ 51 秒。Go モジュールは既に `actions/setup-go` のキャッシュに乗っており（ログに `go: downloading` が 0 行）、ジョブ内部に削れる無駄はない。抽出時間は 219 ゲーム分のコンパイルそのものである。
+
+### 検討した代替案
+
+1. **`build-mode: none` に切り替える**（JavaScript 側は既にこれを使用）— 最も分かりやすい高速化だが、CodeQL 自身のヘルプテキストが実行ログ内で次のように述べている: *"buildless extraction will generally yield **less accurate analysis results**, and should only be used in cases where it is not possible to build the code"*。本プロジェクトはビルド可能であり、セキュリティスキャンの検出精度を速度と引き換えにするのは筋が悪い。**却下。**
+2. **ジョブ内部の最適化** — キャッシュは既に効いており、抽出はコンパイル時間に等しい。**打つ手なし。**
+3. **実行タイミングを変える**（採用）— スキャン内容は一切変えず、いつ走らせるかだけを変える。
+
+## Decision
+
+CodeQL の `pull_request` トリガーを廃止し、`push: [develop]` と週次 `schedule` のみとする。
+
+`develop` は統合ブランチであり、リリースを駆動するのは `master`（ADR-0019 の auto-tag）である。したがってマージ直後にスキャンしても、検出はリリースよりはるかに早い。週次実行は、コードが変わらないままクエリパックが更新された場合をカバーし続ける。
+
+ADR-0019 の「CodeQL: push/PR時にセキュリティスキャン」のうち、**PR 時の実行のみを本 ADR が置き換える**。ADR-0019 の他の決定（golangci-lint、CI、auto-tag）は有効。
+
+## Consequences
+
+**得るもの:**
+
+- PR の待ち時間が約 459 秒から約 230 秒（E2E シャード）に短縮される。
+- 同時実行ジョブ数が減る。`develop` への push では 25 ジョブに達し、GitHub Free の 20 ジョブ上限でシャードが待たされていた。
+
+**失うもの（明示的なトレードオフ）:**
+
+- **マージ前の検出シグナルが無くなる。** PR が持ち込んだ脆弱性は、マージ前ではなくマージ数分後に報告される。所見は従来どおり Security タブに現れるが、PR のチェック欄には出ない。
+- `develop` はブランチ保護されておらず、CodeQL は必須チェックでもなかったため、実運用上ゲートとして機能していなかった。とはいえこれは実際の後退であり、無償の改善ではない。
+
+**元に戻す方法:** `.github/workflows/codeql-analysis.yml` の `on:` に以下を戻すだけ（3 行）。
+
+```yaml
+  pull_request:
+    branches: [ develop ]
+```
+
+マージ前スキャンを必須にしたい場合は、併せて `develop` のブランチ保護で CodeQL を required check に指定する必要がある（現在は未保護）。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -39,7 +39,7 @@ ADR番号は連番ではない — 欠番はリトマステスト導入時に非
 | [ADR-0013](0013-docker-distroless.md) | Multi-stage Docker build with distroless image | Accepted | 2026-02-20 |
 | [ADR-0015](0015-accessibility-wcag.md) | WCAG accessibility compliance | Accepted | 2026-03-11 |
 | [ADR-0016](0016-production-middleware.md) | Production middleware stack (CORS, security headers) | Accepted | 2026-03-01 |
-| [ADR-0019](0019-ci-cd-pipeline.md) | CI/CD pipeline (CodeQL, golangci-lint, auto-tagging) | Accepted | 2021-04-15 |
+| [ADR-0019](0019-ci-cd-pipeline.md) | CI/CD pipeline (CodeQL, golangci-lint, auto-tagging) | Accepted（CodeQL の PR トリガーのみ [ADR-0034](0034-codeql-post-merge.md) が置換） | 2021-04-15 |
 | [ADR-0021](0021-bun-package-manager.md) | Migrate package manager from npm to bun | Accepted | 2026-03-15 |
 | [ADR-0022](0022-automated-quality-gates.md) | Automated quality gates via Claude Code hooks | Accepted | 2026-03-20 |
 | [ADR-0023](0023-api-documentation.md) | GoDoc/TSDoc + GitHub PagesによるAPIドキュメント自動生成 | Accepted | 2026-03-20 |
@@ -51,3 +51,4 @@ ADR番号は連番ではない — 欠番はリトマステスト導入時に非
 | [ADR-0031](0031-registry-consolidation.md) | 4 レイヤーゲームレジストリの取り扱い方針 | Accepted | 2026-05-02 |
 | [ADR-0032](0032-fourth-worker-capacity.md) | 4 つ目の Cloudflare Worker（容量バケット）の追加 | Accepted | 2026-06-29 |
 | [ADR-0033](0033-procedural-non52-card-rendering.md) | 非52枚デッキ札の手続き的（CSS/SVG）レンダリング | Accepted | 2026-07-06 |
+| [ADR-0034](0034-codeql-post-merge.md) | CodeQL を PR ではなくマージ後に実行する | Accepted | 2026-07-26 |


### PR DESCRIPTION
## I optimized the wrong workflow for most of this session

The CI workflow went 1044s → 230s across #4343-#4351. Meanwhile CodeQL sat next to it, unmeasured, at **459s**. Measured across every workflow a PR triggers:

| Workflow | Slowest job |
|---|---|
| **CodeQL — Analyze (go, autobuild)** | **459s** |
| CI — E2E shard | 230s |
| Cloudflare workers build (tinygo ×4) | 225s |
| CodeQL — Analyze (javascript-typescript) | 218s |

CodeQL was the actual wait the whole time. Credit for the pointer goes to the review comment asking about it — I had been reading `gh pr checks` totals without ever opening those job logs.

## There is nothing to trim inside the Go job

459s = **250s extraction** + **120s writing the database** + **51s queries**. Module downloads are already cached (zero `go: downloading` lines in the log). The extraction cost is compiling 219 games; `autobuild` has to build the project to trace it.

**Not** switching to `build-mode: none`, which is the obvious lever and what the JavaScript job already uses. CodeQL's own help text, quoted from this run's log:

> buildless extraction will generally yield **less accurate analysis results**, and should only be used in cases where it is not possible to build the code

Trading detection accuracy for speed in the security scan is the wrong trade, and it would be an odd one to make silently.

## So change the trigger, not the tool

`develop` is an integration branch; `master` is what triggers releases. Scanning on the merge commit still catches a finding long before it can ship, and the weekly cron still covers query-pack updates against unchanged code. Alerts land in the Security tab exactly as before.

**What is genuinely lost:** the pre-merge signal. A vulnerability introduced by a PR is now reported minutes after the merge instead of before it. On a repo where `develop` is unprotected and merges are already made without waiting for CodeQL (I did exactly that twice today), that signal was not being used as a gate anyway — but it is a real reduction, not a free win, and worth being explicit about.

Reverting is a three-line change if you would rather have the pre-merge scan back.

## Effect

PR wait drops from ~459s to ~230s (the E2E shard), with the Cloudflare tinygo build at 225s right behind it.

## Test plan

- [x] Workflow YAML lints; triggers are now `push: [develop]` + weekly `schedule`
- [ ] Confirm CodeQL runs on the merge commit and its alerts still appear in the Security tab
- [ ] Confirm no CodeQL checks appear on the next PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
