### PR TITLE
perf(frontend): type-check with TypeScript 7 via an npm alias

### DIFF
--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -13,6 +13,7 @@ globs: ["frontend/**/*.ts", "frontend/**/*.tsx"]
 ```sh
 cd frontend && bun run build   # React build
 cd frontend && bun run check   # Biome lint + format check
+cd frontend && bun run typecheck # TypeScript 7 type check (never bare `tsc`)
 cd frontend && bun run test    # Vitest unit tests
 ```
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -27,7 +27,7 @@
           },
           {
             "type": "command",
-            "command": "jq -r '.tool_input.command' | { read -r cmd; case \"$cmd\" in git\\ commit*) if git diff --cached --name-only | grep -qE '\\.(ts|tsx)$'; then cd frontend && output=$(bunx tsc -b 2>&1); if [ $? -ne 0 ]; then jq -nc --arg msg \"$(printf '%s' \"$output\" | head -30)\" '{continue: false, stopReason: (\"tsc type-check failed (CI runs tsc -b in the build; vitest/biome do not catch this):\\n\" + $msg)}'; else echo '{}'; fi; else echo '{}'; fi ;; *) echo '{}' ;; esac; }",
+            "command": "jq -r '.tool_input.command' | { read -r cmd; case \"$cmd\" in git\\ commit*) if git diff --cached --name-only | grep -qE '\\.(ts|tsx)$'; then cd frontend && output=$(bun run typecheck 2>&1); if [ $? -ne 0 ]; then jq -nc --arg msg \"$(printf '%s' \"$output\" | head -30)\" '{continue: false, stopReason: (\"tsc type-check failed (TypeScript 7 via bun run typecheck; vitest/biome do not catch this):\\n\" + $msg)}'; else echo '{}'; fi; else echo '{}'; fi ;; *) echo '{}' ;; esac; }",
             "timeout": 180,
             "statusMessage": "Running tsc type-check..."
           },

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,8 +185,9 @@ jobs:
         working-directory: frontend
         run: bun install --frozen-lockfile
 
-      # Bundle only — `bun run build` also runs `tsc -b` (~48s), which the
-      # dedicated typecheck job now covers once instead of once per shard.
+      # Bundle only — `bun run build` also runs `bun run typecheck` (~5s since
+      # the TypeScript 7 switch, ~48s before it), which the dedicated typecheck
+      # job now covers once instead of once per shard.
       - name: Build frontend
         working-directory: frontend
         run: bunx vite build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,11 @@ jobs:
     # only, and vitest transpiles without checking. It used to run solely as a
     # side effect of the E2E job's `bun run build` (tsc -b && vite build), so
     # every E2E shard paid ~48s for the same check. Run it once here instead.
+    #
+    # `bun run typecheck` uses the `typescript7` alias, not the `typescript`
+    # dependency — see frontend/CLAUDE.md "Type checking" for why both are
+    # installed. Never substitute a bare `tsc`/`bunx tsc`: that resolves to
+    # TypeScript 5.9 and takes ~46s instead of ~5s.
     name: Frontend Typecheck (tsc)
     runs-on: ubuntu-latest
     steps:
@@ -92,7 +97,7 @@ jobs:
 
       - name: Type-check
         working-directory: frontend
-        run: bunx tsc -b
+        run: bun run typecheck
 
   test-frontend:
     # Sharded because this is the slowest job in the pipeline (~20 min

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,7 @@ golangci-lint run ./...      # Run Go linter (must pass before commit)
 cd frontend && bun install   # Install dependencies
 cd frontend && bun run build # Build React app
 cd frontend && bun run check # Biome lint + format check
+cd frontend && bun run typecheck # TypeScript 7 type check (never bare `tsc` -- that is 5.9; see frontend/CLAUDE.md)
 cd frontend && bun run test  # Run Vitest unit tests
 cd frontend && bun run e2e   # Run Playwright E2E tests
 cd frontend && bun run docs:generate  # Generate TypeDoc documentation

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -149,9 +149,16 @@ aliased binary explicitly. Both versions tolerate each other's
 `.tsbuildinfo` (they rebuild on a version mismatch rather than failing), so
 running one after the other is safe.
 
-Verified equivalent, not assumed: with five deliberate type errors injected
-(assignment, return type, `satisfies`, readonly violation, possibly-undefined)
-both versions reported the same five diagnostics with the same TS codes.
+Verified equivalent, not assumed: with deliberate errors injected, both versions
+reported the same diagnostics — five core `strict` cases (assignment, return
+type, `satisfies`, readonly violation, possibly-undefined) plus this project's
+less common flags, `verbatimModuleSyntax` (TS1484) and `erasableSyntaxOnly`
+(TS1294).
+
+The one behavioural difference found: an unresolvable **side-effect** import
+(`noUncheckedSideEffectImports`) is `TS2307` on 5.9 but `TS2882` on 7 — the code
+dedicated to that flag. Both error, so nothing is silently skipped, but do not
+match on the code if you ever script against tsc output.
 
 ## Tutorial System
 

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -119,6 +119,40 @@ All exported symbols (types, interfaces, functions, components, constants, hooks
 bun run build && bun run check && bun run test
 ```
 
+## Type checking
+
+**Always type-check with `bun run typecheck`. Never with a bare `tsc` / `bunx tsc`.**
+
+`tsc` is the only gate that catches type errors — `bun run check` is Biome only,
+and vitest transpiles without checking. Two TypeScript versions are installed on
+purpose:
+
+| Dependency | Version | Used by |
+|---|---|---|
+| `typescript` | 5.9 | `bun run docs:generate` (typedoc), editors, vitest's type surface |
+| `typescript7` (npm alias) | 7.0 | `bun run typecheck` — the gate, and `bun run build`'s first half |
+
+TypeScript 7 is the native (Go) compiler and type-checks this project in ~5s
+versus ~46s for 5.9, which matters because the commit hook in
+`.claude/settings.json` runs the gate on every commit that stages a `.ts`/`.tsx`
+file. TypeScript 5.9 has to stay because **typedoc cannot run on 7** — it depends
+on compiler internals the rewrite does not expose
+([TypeStrong/typedoc#3098](https://github.com/TypeStrong/typedoc/issues/3098),
+no timeline), and the generated docs are published to GitHub Pages by
+`deploy-pages.yml`. Alternatives such as api-extractor depend on the same
+internals, so switching tools would not help.
+
+The catch that makes the "never a bare `tsc`" rule load-bearing:
+`node_modules/.bin/tsc` points at **5.9**, so `bunx tsc -b` silently runs the
+slow compiler rather than the one the gate uses. `bun run typecheck` names the
+aliased binary explicitly. Both versions tolerate each other's
+`.tsbuildinfo` (they rebuild on a version mismatch rather than failing), so
+running one after the other is safe.
+
+Verified equivalent, not assumed: with five deliberate type errors injected
+(assignment, return type, `satisfies`, readonly violation, possibly-undefined)
+both versions reported the same five diagnostics with the same TS codes.
+
 ## Tutorial System
 
 ### Key components

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -35,6 +35,7 @@
         "tailwindcss": "^4.3.3",
         "typedoc": "^0.28.20",
         "typescript": "~5.9.3",
+        "typescript7": "npm:typescript@~7.0.2",
         "vite": "^7.3.6",
         "vitest": "^4.1.10",
       },
@@ -416,6 +417,46 @@
     "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
+    "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
+
+    "@typescript/typescript-darwin-arm64": ["@typescript/typescript-darwin-arm64@7.0.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA=="],
+
+    "@typescript/typescript-darwin-x64": ["@typescript/typescript-darwin-x64@7.0.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA=="],
+
+    "@typescript/typescript-freebsd-arm64": ["@typescript/typescript-freebsd-arm64@7.0.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ=="],
+
+    "@typescript/typescript-freebsd-x64": ["@typescript/typescript-freebsd-x64@7.0.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw=="],
+
+    "@typescript/typescript-linux-arm": ["@typescript/typescript-linux-arm@7.0.2", "", { "os": "linux", "cpu": "arm" }, "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ=="],
+
+    "@typescript/typescript-linux-arm64": ["@typescript/typescript-linux-arm64@7.0.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ=="],
+
+    "@typescript/typescript-linux-loong64": ["@typescript/typescript-linux-loong64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ=="],
+
+    "@typescript/typescript-linux-mips64el": ["@typescript/typescript-linux-mips64el@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA=="],
+
+    "@typescript/typescript-linux-ppc64": ["@typescript/typescript-linux-ppc64@7.0.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA=="],
+
+    "@typescript/typescript-linux-riscv64": ["@typescript/typescript-linux-riscv64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ=="],
+
+    "@typescript/typescript-linux-s390x": ["@typescript/typescript-linux-s390x@7.0.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw=="],
+
+    "@typescript/typescript-linux-x64": ["@typescript/typescript-linux-x64@7.0.2", "", { "os": "linux", "cpu": "x64" }, "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A=="],
+
+    "@typescript/typescript-netbsd-arm64": ["@typescript/typescript-netbsd-arm64@7.0.2", "", { "os": "none", "cpu": "arm64" }, "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA=="],
+
+    "@typescript/typescript-netbsd-x64": ["@typescript/typescript-netbsd-x64@7.0.2", "", { "os": "none", "cpu": "x64" }, "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA=="],
+
+    "@typescript/typescript-openbsd-arm64": ["@typescript/typescript-openbsd-arm64@7.0.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ=="],
+
+    "@typescript/typescript-openbsd-x64": ["@typescript/typescript-openbsd-x64@7.0.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg=="],
+
+    "@typescript/typescript-sunos-x64": ["@typescript/typescript-sunos-x64@7.0.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g=="],
+
+    "@typescript/typescript-win32-arm64": ["@typescript/typescript-win32-arm64@7.0.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ=="],
+
+    "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 
@@ -994,6 +1035,8 @@
     "typedoc": ["typedoc@0.28.20", "", { "dependencies": { "@gerrit0/mini-shiki": "^3.23.0", "lunr": "^2.3.9", "markdown-it": "^14.3.0", "minimatch": "^10.2.5", "yaml": "^2.9.0" }, "peerDependencies": { "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x || 6.0.x" }, "bin": { "typedoc": "bin/typedoc" } }, "sha512-uSKqkh8Cr48vllnEy+jdaAgOeR6Y+QCBW7usgUsKj7gJEfR7stw9U/fE49LBnj2tPRKPY0c0EBJSWe9Appmplg=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "typescript7": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 
     "uc.micro": ["uc.micro@2.1.0", "", {}, "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "bun run typecheck && vite build",
     "lint": "biome lint .",
     "lint:tokens": "bun scripts/check-design-tokens.mjs",
     "format": "biome format --write .",
@@ -22,7 +22,8 @@
     "e2e": "playwright test",
     "e2e:ui": "playwright test --ui",
     "e2e:headed": "playwright test --headed",
-    "docs:generate": "typedoc"
+    "docs:generate": "typedoc",
+    "typecheck": "bun ./node_modules/typescript7/bin/tsc -b"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.101.4",
@@ -55,6 +56,7 @@
     "tailwindcss": "^4.3.3",
     "typedoc": "^0.28.20",
     "typescript": "~5.9.3",
+    "typescript7": "npm:typescript@~7.0.2",
     "vite": "^7.3.6",
     "vitest": "^4.1.10"
   }


### PR DESCRIPTION
## What

Type checking now runs on **TypeScript 7** (the native Go compiler) through a `typescript7` npm alias, while TypeScript 5.9 stays installed for typedoc.

| | Before | After |
|---|---|---|
| `tsc -b` (cold) | 46.5s | **4.5s** |
| `bun run build` | 64s | **23s** |

This runs on **every commit** that stages a `.ts`/`.tsx` file (the gate in `.claude/settings.json`), not just in CI.

## Why both versions

typedoc cannot run on TypeScript 7 — it depends on compiler internals the rewrite does not expose ([TypeStrong/typedoc#3098](https://github.com/TypeStrong/typedoc/issues/3098), **no timeline**; maintained a few hours a week). Its output is published to GitHub Pages by `deploy-pages.yml`, so it is not droppable. Alternatives such as api-extractor depend on the same `ts.createProgram()` surface and would break identically.

So: **5.9 for typedoc / editors / vitest's type surface, 7 for the gate.**

## One place names the binary

All three call sites (commit gate, CI job, `bun run build`) now go through `bun run typecheck`. This is load-bearing rather than cosmetic: `node_modules/.bin/tsc` resolves to **5.9**, so a bare `bunx tsc -b` would silently run the slow compiler instead of the one the gate uses. Confirmed on a fresh `--frozen-lockfile` install, not just an incremental one.

## Verified, not assumed

- **Equivalence** — five injected type errors (assignment, return type, `satisfies`, readonly violation, possibly-undefined) produce the same five diagnostics with identical TS codes on both versions. TS18048 being among them proves `strict` is genuinely active under 7, not silently dropped.
- **The gate still blocks** — staging a deliberate type error returns `continue:false` carrying the TS7 diagnostic; staging valid code passes.
- **typedoc unaffected** — `bun run docs:generate` gives 0 errors and the same 142 pre-existing warnings.
- **Shared `.tsbuildinfo` is safe** — each version rebuilds on a version mismatch rather than failing, in both orders.
- **Clean install** — `bun install --frozen-lockfile` in an empty dir resolves both versions and the linux-x64 native binary.

## Test plan

- [x] `bun run typecheck` — clean, 4.5s
- [x] `bun run build` — clean, 23s
- [x] `bun run check` — passes
- [x] `bun run docs:generate` — 0 errors
- [x] Commit gate blocks a type error and passes valid code