### PR TITLE
perf(frontend): split Discover, DiscoverResult and NotFound out of the entry chunk

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
-import { RouteSuspenseFallback } from './App';
+import { afterEach, describe, expect, it } from 'vitest';
+import App, { RouteSuspenseFallback } from './App';
+import { renderWithProviders } from './test/renderWithProviders';
 
 describe('RouteSuspenseFallback', () => {
   it('preserves the role="status" + aria-busy contract for assistive tech', () => {
@@ -23,5 +24,48 @@ describe('RouteSuspenseFallback', () => {
     // Accept either locale's translation of skeleton.loading; the test
     // setup defaults to ja but a contributor's env may differ.
     expect(screen.getByText(/^(Loading…|読み込み中…)$/)).toBeInTheDocument();
+  });
+});
+
+// The three non-game routes are the only ones whose page component is not
+// reached through `gameRoutes`, so nothing else asserted they render at all —
+// there is no E2E spec for /discover, /discover/result or a 404 either.
+//
+// What these guard specifically: those pages are now pulled out of the
+// `./pages/*Page.tsx` glob by module NAME (#4355), so a typo in the name
+// passed to `resolvePageComponent` — or a page renamed without updating
+// App.tsx — throws only when the route is actually mounted. Neither tsc nor
+// the build can see it, since the name is a plain string looked up in a glob
+// record. Verified by mutation: 'NotFound' → 'NotFund' fails the file with
+// `no module at ./pages/NotFundPage.tsx`.
+//
+// They do NOT prove the Suspense boundaries are present: React 19 renders a
+// lazy component with no boundary at all, silently and without a console
+// error (probed directly). The boundary only decides whether the skeleton
+// shows during the chunk download, so removing one is invisible here.
+describe('App non-game routes', () => {
+  afterEach(() => {
+    window.location.hash = '';
+  });
+
+  it('renders the 404 page for an unknown hash route', async () => {
+    window.location.hash = '#/notagame';
+    renderWithProviders(<App />);
+    expect(await screen.findByText('お探しのページは見つかりません')).toBeInTheDocument();
+  });
+
+  it('renders the Discover survey at /discover', async () => {
+    window.location.hash = '#/discover';
+    renderWithProviders(<App />);
+    expect(await screen.findByTestId('discover-survey')).toBeInTheDocument();
+  });
+
+  it('sends /discover/result back to the survey when the params are absent', async () => {
+    // DiscoverResultPage redirects to /discover when it cannot parse the
+    // search params. Reaching that redirect at all proves its own chunk
+    // resolved under Suspense first, so this covers both pages.
+    window.location.hash = '#/discover/result';
+    renderWithProviders(<App />);
+    expect(await screen.findByTestId('discover-survey')).toBeInTheDocument();
   });
 });

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -51,7 +51,11 @@ describe('App non-game routes', () => {
   it('renders the 404 page for an unknown hash route', async () => {
     window.location.hash = '#/notagame';
     renderWithProviders(<App />);
-    expect(await screen.findByText('お探しのページは見つかりません')).toBeInTheDocument();
+    // Matched by role rather than by the title string: this asserts "the 404
+    // page mounted", and NotFoundPage's h1 is the only level-1 heading on the
+    // route. Keying on the copy would tie the test to one locale, which is
+    // what the sibling tests above avoid with a two-locale regex.
+    expect(await screen.findByRole('heading', { level: 1 })).toBeInTheDocument();
   });
 
   it('renders the Discover survey at /discover', async () => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,9 +8,6 @@ import { RouteErrorBoundary } from './components/RouteErrorBoundary';
 import { SkipNavLink } from './components/SkipNavLink';
 import { SkeletonBar } from './components/skeleton/SkeletonBar';
 import { gameRoutes } from './constants/gameRoutes';
-import { DiscoverPage } from './pages/DiscoverPage';
-import { DiscoverResultPage } from './pages/DiscoverResultPage';
-import { NotFoundPage } from './pages/NotFoundPage';
 import { resolvePageComponent } from './utils/resolvePageComponent';
 
 // Vite resolves this glob at build time; each match becomes its own chunk
@@ -24,6 +21,16 @@ const pageModules = import.meta.glob<Record<string, ComponentType<any>>>('./page
 const lazyPages = new Map<string, ComponentType>(
   gameRoutes.map(({ path, page }) => [path, resolvePageComponent(pageModules, path, page)]),
 );
+
+// The three non-game pages match the glob above too, so importing them
+// statically made them *both* dynamic and static imports — which a static
+// import always wins. They were therefore inlined into the entry chunk that
+// every visitor downloads, including visitors who never open Discover or hit
+// a 404. Resolving them the same way as game pages is what actually splits
+// them out (#4355). Each usage below needs its own Suspense boundary.
+const DiscoverPage = resolvePageComponent(pageModules, '/discover', 'Discover');
+const DiscoverResultPage = resolvePageComponent(pageModules, '/discover/result', 'DiscoverResult');
+const NotFoundPage = resolvePageComponent(pageModules, '*', 'NotFound');
 
 /**
  * Placeholder rendered while a lazy game-page chunk downloads. Shows a
@@ -76,13 +83,34 @@ export default function App() {
                     );
                   })}
                   {/* AI Game Concierge — survey + recommendation result. */}
-                  <Route path="/discover" element={<DiscoverPage />} />
-                  <Route path="/discover/result" element={<DiscoverResultPage />} />
+                  <Route
+                    path="/discover"
+                    element={
+                      <Suspense fallback={<RouteSuspenseFallback />}>
+                        <DiscoverPage />
+                      </Suspense>
+                    }
+                  />
+                  <Route
+                    path="/discover/result"
+                    element={
+                      <Suspense fallback={<RouteSuspenseFallback />}>
+                        <DiscoverResultPage />
+                      </Suspense>
+                    }
+                  />
                   {/* BlackJack lives at "/", but external links may use "/blackjack". */}
                   <Route path="/blackjack" element={<Navigate to="/" replace />} />
                   {/* Unknown hash routes (e.g., "#/notagame") render the 404
                     surface instead of silently redirecting home — #1902. */}
-                  <Route path="*" element={<NotFoundPage />} />
+                  <Route
+                    path="*"
+                    element={
+                      <Suspense fallback={<RouteSuspenseFallback />}>
+                        <NotFoundPage />
+                      </Suspense>
+                    }
+                  />
                 </Routes>
               </RouteErrorBoundary>
             </main>


### PR DESCRIPTION
Closes #4355.

## What

`App.tsx` glob-imports every `./pages/*Page.tsx`, but these three pages were **also** imported statically. A static import wins, so they were inlined into the entry chunk every visitor downloads — including visitors who never open Discover or hit a 404.

**The issue named two pages. There are three** — `DiscoverPage` was cut off the bottom of the build output when I first read it.

## Measured

Initial-load closure (entry + everything `index.html` modulepreloads). Both built into a clean `--outDir`, since the real `outDir` is `../public` with `emptyOutDir: false` and accumulates across builds:

| | files | raw | gzip |
|---|---|---|---|
| before | 10 | 1,842,491 B | 517,915 B |
| after | **8** | 1,698,860 B | **471,868 B** |

**−8.9% gzip, two fewer requests.**

⚠️ The entry chunk *alone* **grows** 8.3% (91,010 → 98,544 B gzip). Two whole preloaded chunks drop out of the initial load — that is where the win is. Measuring only the entry chunk, as the issue suggested, reads as a regression.

`INEFFECTIVE_DYNAMIC_IMPORT` warnings: 3 → **0**. Three new chunks appear (`DiscoverPage-*.js`, `DiscoverResultPage-*.js`, `NotFoundPage-*.js`).

## Tests

These three routes had **no unit or E2E coverage at all** — this adds the first.

What they actually guard: the pages are now located by a **string key** in a glob record, so a typo, or a page renamed without updating `App.tsx`, throws only when the route mounts. Neither tsc nor the build can see it. Verified by mutation — `'NotFound'` → `'NotFund'` fails the file with `no module at ./pages/NotFundPage.tsx`.

They deliberately do **not** claim to guard the Suspense boundaries. The issue text (mine) said a missing boundary would surface as a thrown promise; that is wrong for React 19, which renders a lazy component with no boundary at all, silently and with no console error — I probed this directly. Removing a boundary is undetectable in a test; boundaries only decide whether the skeleton shows during the download. The comment in the test file states this so nobody later mistakes these for boundary coverage.

## Test plan

- [x] `bun run test` — 1,133 files / 15,768 tests pass
- [x] `bun run typecheck` — clean
- [x] `bun run check` — passes
- [x] `bun run build` — 0 `INEFFECTIVE_DYNAMIC_IMPORT`
- [x] Mutation: module-name typo fails the new tests
- [ ] ⚠️ One earlier full run reported `1 failed | 15767 passed` but I did not capture which test, and it did **not** reproduce across two subsequent full runs; the three new tests also passed 5/5 in isolation. Flagging rather than asserting it was unrelated.