### PR TITLE
chore(frontend): clear all 70 Biome warnings

### DIFF
--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.8/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
@@ -17,7 +17,7 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true,
+      "preset": "recommended",
       "a11y": {}
     }
   },

--- a/frontend/scripts/check-design-tokens.mjs
+++ b/frontend/scripts/check-design-tokens.mjs
@@ -74,7 +74,13 @@ if (violations.length > 0) {
 // silently misses arbitrary animate-[…] utilities and future animations.
 const indexCss = await readFile(join(SRC_DIR, 'index.css'), 'utf8');
 const rmIdx = indexCss.indexOf('@media (prefers-reduced-motion: reduce)');
-const rmBlock = rmIdx === -1 ? '' : indexCss.slice(rmIdx, rmIdx + 400);
+// Read to the at-rule's own closing brace — the only `}` in column 0 after it,
+// since the nested `*` rule closes indented. This used to slice a fixed 400
+// characters, which silently failed the moment a comment was added inside the
+// block: the declarations it looks for slid past the window and the guard
+// reported the SSoT block missing when it was right there.
+const rmEnd = rmIdx === -1 ? -1 : indexCss.indexOf('\n}', rmIdx);
+const rmBlock = rmIdx === -1 || rmEnd === -1 ? '' : indexCss.slice(rmIdx, rmEnd + 2);
 if (!rmBlock.includes('*,') || !rmBlock.includes('animation-duration: 0.01ms')) {
   console.error(
     '\nreduced-motion: index.css must enforce prefers-reduced-motion with a universal\n' +

--- a/frontend/src/constants/discoverAxes.test.ts
+++ b/frontend/src/constants/discoverAxes.test.ts
@@ -70,10 +70,10 @@ describe('discoverAxes constants', () => {
 
   it('every axis label and question key omits the `discover.` namespace prefix', () => {
     for (const key of AXIS_KEYS) {
-      expect(AXES[key].labelI18nKey).toMatch(new RegExp('^axis\\.' + key + '\\.label$'));
+      expect(AXES[key].labelI18nKey).toMatch(new RegExp(`^axis\\.${key}\\.label$`));
       expect(AXES[key].labelI18nKey).not.toMatch(/^discover\./);
       for (const q of AXES[key].questions) {
-        expect(q.questionI18nKey).toMatch(new RegExp('^axis\\.' + key + '\\.q[12]$'));
+        expect(q.questionI18nKey).toMatch(new RegExp(`^axis\\.${key}\\.q[12]$`));
       }
     }
   });

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -464,13 +464,16 @@ input:not([type]):focus-visible {
   animation: suit-watermark 0.4s ease-out;
 }
 
+/* Base first, then the higher-specificity open state — the two set different
+   properties so the cascade result is identical either way, but declaring the
+   specific rule first trips Biome's noDescendingSpecificity. */
+.sidebar-category-chevron {
+  transition: transform 150ms ease;
+}
+
 /* Rotate chevron when sidebar category is open */
 .sidebar-category[open] .sidebar-category-chevron {
   transform: rotate(90deg);
-}
-
-.sidebar-category-chevron {
-  transition: transform 150ms ease;
 }
 
 /* Force nav category details open on tablet/small desktop (sm to lg) */
@@ -569,11 +572,18 @@ input:not([type]):focus-visible {
   *,
   *::before,
   *::after {
+    /* biome-ignore-start lint/complexity/noImportantStyles: this is the
+       accessibility reset — it exists precisely to beat every component's own
+       animation/transition declaration, so `!important` is the mechanism, not
+       an accident. Dropping it would silently un-suppress motion for users who
+       asked for less of it, and `scripts/check-design-tokens.mjs` asserts this
+       block is present. */
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
     animation-delay: 0s !important;
     transition-duration: 0.01ms !important;
     transition-delay: 0s !important;
     scroll-behavior: auto !important;
+    /* biome-ignore-end lint/complexity/noImportantStyles: see above */
   }
 }

--- a/frontend/src/pages/CrescentPage.tsx
+++ b/frontend/src/pages/CrescentPage.tsx
@@ -159,7 +159,7 @@ function CrescentPageContent() {
   // persistent valid-destination highlight so mouse, touch, and keyboard users
   // all see where the selected card can legally go (#3257).
   const selectedCard: Card | null = useMemo(() => {
-    if (!selectedSource || selectedSource.zone !== 'tableau' || selectedSource.col === undefined) return null;
+    if (selectedSource?.zone !== 'tableau' || selectedSource.col === undefined) return null;
     const col = state?.tableau[selectedSource.col];
     if (!col || col.length === 0) return null;
     return col[col.length - 1]?.card ?? null;

--- a/frontend/src/utils/bakersGameAutoMoveTarget.ts
+++ b/frontend/src/utils/bakersGameAutoMoveTarget.ts
@@ -25,6 +25,6 @@ export function bakersGameAutoMoveTarget(
   const foundationTarget = freeCellFoundationTarget(card, foundation);
   if (foundationTarget) return foundationTarget;
 
-  const emptyCell = freeCells.findIndex((c) => c === null);
+  const emptyCell = freeCells.indexOf(null);
   return emptyCell === -1 ? null : { zone: 'freecell', cell: emptyCell };
 }

--- a/frontend/src/utils/cli/commands/anacondaCommands.ts
+++ b/frontend/src/utils/cli/commands/anacondaCommands.ts
@@ -77,7 +77,7 @@ export function parseAnacondaCommand(input: string): CliParseResult<AnacondaCliA
     case 'k':
     case 'keep': {
       const indices = parseIndices(args);
-      if (!indices || indices.length !== 5) {
+      if (indices?.length !== 5) {
         return { error: 'Usage: k <i...> (keep exactly 5 card indices)' };
       }
       return { args: ['keep', indices] };

--- a/frontend/src/utils/cli/commands/contractrummyCommands.ts
+++ b/frontend/src/utils/cli/commands/contractrummyCommands.ts
@@ -55,7 +55,7 @@ export function parseContractRummyCommand(input: string): CliParseResult<Contrac
     case 'x':
     case 'discard': {
       const list = parseIdxList(args.join(' '));
-      if (!list || list.length !== 1) return { error: 'Usage: discard <cardIdx>' };
+      if (list?.length !== 1) return { error: 'Usage: discard <cardIdx>' };
       return { args: ['discard', { cardIndex: list[0] }] as ContractRummyArgs };
     }
     case 'meld': {
@@ -82,7 +82,7 @@ export function parseContractRummyCommand(input: string): CliParseResult<Contrac
     case 'lo':
     case 'layoff': {
       const list = parseIdxList(args.join(' '));
-      if (!list || list.length !== 3) return { error: 'Usage: layoff <cardIdx> <playerIdx> <meldIdx>' };
+      if (list?.length !== 3) return { error: 'Usage: layoff <cardIdx> <playerIdx> <meldIdx>' };
       return {
         args: ['layoff', { cardIndex: list[0], targetPlayerIdx: list[1], meldIdx: list[2] }] as ContractRummyArgs,
       };

--- a/frontend/src/utils/hints/anacondaHint.ts
+++ b/frontend/src/utils/hints/anacondaHint.ts
@@ -15,7 +15,7 @@ import type { HintResult } from '../../types/hint';
  */
 export function getAnacondaHint(state: AnacondaResponse): HintResult | null {
   const hint = state.hint;
-  if (!hint || !hint.reason) return null;
+  if (!hint?.reason) return null;
   return {
     targetAction: hint.action,
     reason: `hint.${hint.reason}`,

--- a/frontend/src/utils/hints/basraHint.ts
+++ b/frontend/src/utils/hints/basraHint.ts
@@ -14,7 +14,7 @@ import type { HintResult } from '../../types/hint';
  */
 export function getBasraHint(state: BasraResponse): HintResult | null {
   const hint = state.hint;
-  if (!hint || !hint.reason) return null;
+  if (!hint?.reason) return null;
   return {
     targetAction: 'play',
     reason: `hint.${hint.reason}`,

--- a/frontend/src/utils/hints/beziqueHint.ts
+++ b/frontend/src/utils/hints/beziqueHint.ts
@@ -15,7 +15,7 @@ import type { HintResult } from '../../types/hint';
  */
 export function getBeziqueHint(state: BeziqueResponse): HintResult | null {
   const hint = state.hint;
-  if (!hint || !hint.reason) return null;
+  if (!hint?.reason) return null;
   return {
     targetAction: hint.meldIndex != null ? 'meld' : 'play',
     reason: `hint.${hint.reason}`,

--- a/frontend/src/utils/hints/bouillotteHint.ts
+++ b/frontend/src/utils/hints/bouillotteHint.ts
@@ -14,7 +14,7 @@ import type { HintResult } from '../../types/hint';
  */
 export function getBouillotteHint(state: BouillotteResponse): HintResult | null {
   const hint = state.hint;
-  if (!hint || !hint.reason) return null;
+  if (!hint?.reason) return null;
   return {
     targetAction: hint.action,
     reason: `hint.${hint.reason}`,

--- a/frontend/src/utils/hints/calabresellaHint.ts
+++ b/frontend/src/utils/hints/calabresellaHint.ts
@@ -15,7 +15,7 @@ import type { HintResult } from '../../types/hint';
  */
 export function getCalabresellaHint(state: CalabresellaResponse): HintResult | null {
   const hint = state.hint;
-  if (!hint || !hint.reason) return null;
+  if (!hint?.reason) return null;
   return {
     targetAction: 'play',
     reason: `hint.${hint.reason}`,

--- a/frontend/src/utils/hints/cegoHint.ts
+++ b/frontend/src/utils/hints/cegoHint.ts
@@ -15,7 +15,7 @@ import type { HintResult } from '../../types/hint';
  */
 export function getCegoHint(state: CegoResponse): HintResult | null {
   const hint = state.hint;
-  if (!hint || !hint.reason) return null;
+  if (!hint?.reason) return null;
   return {
     targetAction: 'play',
     reason: `hint.${hint.reason}`,

--- a/frontend/src/utils/hints/cinchHint.ts
+++ b/frontend/src/utils/hints/cinchHint.ts
@@ -15,7 +15,7 @@ import type { HintResult } from '../../types/hint';
  */
 export function getCinchHint(state: CinchResponse): HintResult | null {
   const hint = state.hint;
-  if (!hint || !hint.reason) return null;
+  if (!hint?.reason) return null;
   return {
     targetAction: 'play',
     reason: `hint.${hint.reason}`,

--- a/frontend/src/utils/hints/courtPieceHint.ts
+++ b/frontend/src/utils/hints/courtPieceHint.ts
@@ -14,7 +14,7 @@ import type { HintResult } from '../../types/hint';
  */
 export function getCourtPieceHint(state: CourtPieceResponse): HintResult | null {
   const hint = state.hint;
-  if (!hint || !hint.reason) return null;
+  if (!hint?.reason) return null;
   return {
     targetAction: hint.trumpSuit != null ? 'trump' : 'play',
     reason: `hint.${hint.reason}`,

--- a/frontend/src/utils/hints/doppelkopfHint.ts
+++ b/frontend/src/utils/hints/doppelkopfHint.ts
@@ -13,7 +13,7 @@ import type { HintResult } from '../../types/hint';
  */
 export function getDoppelkopfHint(state: DoppelkopfResponse): HintResult | null {
   const hint = state.hint;
-  if (!hint || !hint.reason) return null;
+  if (!hint?.reason) return null;
   return {
     targetAction: 'play',
     reason: `hint.${hint.reason}`,

--- a/frontend/src/utils/hints/ecarteHint.ts
+++ b/frontend/src/utils/hints/ecarteHint.ts
@@ -16,7 +16,7 @@ import type { HintResult } from '../../types/hint';
  */
 export function getEcarteHint(state: EcarteResponse): HintResult | null {
   const hint = state.hint;
-  if (!hint || !hint.reason) return null;
+  if (!hint?.reason) return null;
   return {
     targetAction: hint.action ?? 'play',
     reason: `hint.${hint.reason}`,

--- a/frontend/src/utils/hints/fortyFivesHint.ts
+++ b/frontend/src/utils/hints/fortyFivesHint.ts
@@ -14,7 +14,7 @@ import type { HintResult } from '../../types/hint';
  */
 export function getFortyFivesHint(state: FortyFivesResponse): HintResult | null {
   const hint = state.hint;
-  if (!hint || !hint.reason) return null;
+  if (!hint?.reason) return null;
   return {
     targetAction: 'play',
     reason: `hint.${hint.reason}`,

--- a/frontend/src/utils/hints/frenchtarotHint.ts
+++ b/frontend/src/utils/hints/frenchtarotHint.ts
@@ -15,7 +15,7 @@ import type { HintResult } from '../../types/hint';
  */
 export function getFrenchTarotHint(state: FrenchTarotResponse): HintResult | null {
   const hint = state.hint;
-  if (!hint || !hint.reason) return null;
+  if (!hint?.reason) return null;
   return {
     targetAction: 'play',
     reason: `hint.${hint.reason}`,

--- a/frontend/src/utils/hints/gostopHint.ts
+++ b/frontend/src/utils/hints/gostopHint.ts
@@ -15,7 +15,7 @@ import type { HintResult } from '../../types/hint';
  */
 export function getGoStopHint(state: GoStopResponse): HintResult | null {
   const hint = state.hint;
-  if (!hint || !hint.reason) return null;
+  if (!hint?.reason) return null;
   return {
     targetAction: state.phase === 1 ? 'decide' : 'play',
     reason: `hint.${hint.reason}`,

--- a/frontend/src/utils/hints/gutsHint.ts
+++ b/frontend/src/utils/hints/gutsHint.ts
@@ -13,7 +13,7 @@ import type { HintResult } from '../../types/hint';
  */
 export function getGutsHint(state: GutsResponse): HintResult | null {
   const hint = state.hint;
-  if (!hint || !hint.reason) return null;
+  if (!hint?.reason) return null;
   return {
     targetAction: hint.declaration === 1 ? 'in' : 'out',
     reason: `hint.${hint.reason}`,

--- a/frontend/src/utils/hints/hachihachiHint.ts
+++ b/frontend/src/utils/hints/hachihachiHint.ts
@@ -12,7 +12,7 @@ import type { HintResult } from '../../types/hint';
  */
 export function getHachiHachiHint(state: HachiHachiResponse): HintResult | null {
   const hint = state.hint;
-  if (!hint || !hint.reason) return null;
+  if (!hint?.reason) return null;
   return {
     targetAction: 'play',
     reason: `hint.${hint.reason}`,

--- a/frontend/src/utils/hints/kingHint.ts
+++ b/frontend/src/utils/hints/kingHint.ts
@@ -14,7 +14,7 @@ import type { HintResult } from '../../types/hint';
  */
 export function getKingHint(state: KingResponse): HintResult | null {
   const hint = state.hint;
-  if (!hint || !hint.reason) return null;
+  if (!hint?.reason) return null;
   return {
     targetAction: 'play',
     reason: `hint.${hint.reason}`,

--- a/frontend/src/utils/hints/klaverjasHint.ts
+++ b/frontend/src/utils/hints/klaverjasHint.ts
@@ -13,7 +13,7 @@ import type { HintResult } from '../../types/hint';
  */
 export function getKlaverjasHint(state: KlaverjasResponse): HintResult | null {
   const hint = state.hint;
-  if (!hint || !hint.reason) return null;
+  if (!hint?.reason) return null;
   return {
     targetAction: 'play',
     reason: `hint.${hint.reason}`,

--- a/frontend/src/utils/hints/knockoutWhistHint.ts
+++ b/frontend/src/utils/hints/knockoutWhistHint.ts
@@ -14,7 +14,7 @@ import type { HintResult } from '../../types/hint';
  */
 export function getKnockoutWhistHint(state: KnockoutWhistResponse): HintResult | null {
   const hint = state.hint;
-  if (!hint || !hint.reason) return null;
+  if (!hint?.reason) return null;
   return {
     targetAction: 'play',
     reason: `hint.${hint.reason}`,

--- a/frontend/src/utils/hints/koenigrufenHint.ts
+++ b/frontend/src/utils/hints/koenigrufenHint.ts
@@ -15,7 +15,7 @@ import type { HintResult } from '../../types/hint';
  */
 export function getKoenigrufenHint(state: KoenigrufenResponse): HintResult | null {
   const hint = state.hint;
-  if (!hint || !hint.reason) return null;
+  if (!hint?.reason) return null;
   return {
     targetAction: 'play',
     reason: `hint.${hint.reason}`,

--- a/frontend/src/utils/hints/koikoiHint.ts
+++ b/frontend/src/utils/hints/koikoiHint.ts
@@ -15,7 +15,7 @@ import type { HintResult } from '../../types/hint';
  */
 export function getKoiKoiHint(state: KoiKoiResponse): HintResult | null {
   const hint = state.hint;
-  if (!hint || !hint.reason) return null;
+  if (!hint?.reason) return null;
   return {
     targetAction: state.phase === 1 ? 'decide' : 'play',
     reason: `hint.${hint.reason}`,

--- a/frontend/src/utils/hints/looHint.ts
+++ b/frontend/src/utils/hints/looHint.ts
@@ -14,7 +14,7 @@ import type { HintResult } from '../../types/hint';
  */
 export function getLooHint(state: LooResponse): HintResult | null {
   const hint = state.hint;
-  if (!hint || !hint.reason) return null;
+  if (!hint?.reason) return null;
   return {
     targetAction: 'play',
     reason: `hint.${hint.reason}`,

--- a/frontend/src/utils/hints/manilleHint.ts
+++ b/frontend/src/utils/hints/manilleHint.ts
@@ -13,7 +13,7 @@ import type { HintResult } from '../../types/hint';
  */
 export function getManilleHint(state: ManilleResponse): HintResult | null {
   const hint = state.hint;
-  if (!hint || !hint.reason) return null;
+  if (!hint?.reason) return null;
   return {
     targetAction: 'play',
     reason: `hint.${hint.reason}`,

--- a/frontend/src/utils/hints/mariasHint.ts
+++ b/frontend/src/utils/hints/mariasHint.ts
@@ -13,7 +13,7 @@ import type { HintResult } from '../../types/hint';
  */
 export function getMariasHint(state: MariasResponse): HintResult | null {
   const hint = state.hint;
-  if (!hint || !hint.reason) return null;
+  if (!hint?.reason) return null;
   return {
     targetAction: 'play',
     reason: `hint.${hint.reason}`,

--- a/frontend/src/utils/hints/michiganHint.ts
+++ b/frontend/src/utils/hints/michiganHint.ts
@@ -14,7 +14,7 @@ import type { HintResult } from '../../types/hint';
  */
 export function getMichiganHint(state: MichiganResponse): HintResult | null {
   const hint = state.hint;
-  if (!hint || !hint.reason) return null;
+  if (!hint?.reason) return null;
   return {
     targetAction: 'play',
     reason: `hint.${hint.reason}`,

--- a/frontend/src/utils/hints/musHint.ts
+++ b/frontend/src/utils/hints/musHint.ts
@@ -14,7 +14,7 @@ import type { HintResult } from '../../types/hint';
  */
 export function getMusHint(state: MusResponse): HintResult | null {
   const hint = state.hint;
-  if (!hint || !hint.reason) return null;
+  if (!hint?.reason) return null;
 
   let targetAction = 'bet';
   if (hint.reason.startsWith('mus_')) targetAction = 'mus';

--- a/frontend/src/utils/hints/napHint.ts
+++ b/frontend/src/utils/hints/napHint.ts
@@ -13,7 +13,7 @@ import type { HintResult } from '../../types/hint';
  */
 export function getNapHint(state: NapResponse): HintResult | null {
   const hint = state.hint;
-  if (!hint || !hint.reason) return null;
+  if (!hint?.reason) return null;
   return {
     targetAction: 'play',
     reason: `hint.${hint.reason}`,

--- a/frontend/src/utils/hints/ombreHint.ts
+++ b/frontend/src/utils/hints/ombreHint.ts
@@ -15,7 +15,7 @@ import type { HintResult } from '../../types/hint';
  */
 export function getOmbreHint(state: OmbreResponse): HintResult | null {
   const hint = state.hint;
-  if (!hint || !hint.reason) return null;
+  if (!hint?.reason) return null;
   return {
     targetAction: 'play',
     reason: `hint.${hint.reason}`,

--- a/frontend/src/utils/hints/pinochleHint.ts
+++ b/frontend/src/utils/hints/pinochleHint.ts
@@ -21,7 +21,7 @@ const REASON_MAP: Record<string, string> = {
 export function getPinochleHint(state: PinochleResponse): HintResult | null {
   if (state.gameEndFlag) return null;
   const hint = state.hint;
-  if (!hint || !hint.reason) return null;
+  if (!hint?.reason) return null;
   return {
     targetAction: hint.cardIndex !== undefined ? 'play' : hint.pass ? 'pass' : 'bid',
     reason: REASON_MAP[hint.reason] ?? hint.reason,

--- a/frontend/src/utils/hints/preferenceHint.ts
+++ b/frontend/src/utils/hints/preferenceHint.ts
@@ -13,7 +13,7 @@ import type { HintResult } from '../../types/hint';
  */
 export function getPreferenceHint(state: PreferenceResponse): HintResult | null {
   const hint = state.hint;
-  if (!hint || !hint.reason) return null;
+  if (!hint?.reason) return null;
   return {
     targetAction: 'play',
     reason: `hint.${hint.reason}`,

--- a/frontend/src/utils/hints/primeroHint.ts
+++ b/frontend/src/utils/hints/primeroHint.ts
@@ -14,7 +14,7 @@ import type { HintResult } from '../../types/hint';
  */
 export function getPrimeroHint(state: PrimeroResponse): HintResult | null {
   const hint = state.hint;
-  if (!hint || !hint.reason) return null;
+  if (!hint?.reason) return null;
   return {
     targetAction: hint.action,
     reason: `hint.${hint.reason}`,

--- a/frontend/src/utils/hints/russianpokerHint.test.ts
+++ b/frontend/src/utils/hints/russianpokerHint.test.ts
@@ -55,8 +55,8 @@ describe('getRussianPokerHint', () => {
     });
     const hint = getRussianPokerHint(state);
     expect(hint).not.toBeNull();
-    expect(hint!.targetAction).toBe('play');
-    expect(hint!.confidence).toBe('strong');
+    expect(hint?.targetAction).toBe('play');
+    expect(hint?.confidence).toBe('strong');
   });
 
   it('recommends play with Ace-King high', () => {
@@ -73,8 +73,8 @@ describe('getRussianPokerHint', () => {
     });
     const hint = getRussianPokerHint(state);
     expect(hint).not.toBeNull();
-    expect(hint!.targetAction).toBe('play');
-    expect(hint!.confidence).toBe('moderate');
+    expect(hint?.targetAction).toBe('play');
+    expect(hint?.confidence).toBe('moderate');
   });
 
   it('recommends fold with weak hand', () => {
@@ -91,7 +91,7 @@ describe('getRussianPokerHint', () => {
     });
     const hint = getRussianPokerHint(state);
     expect(hint).not.toBeNull();
-    expect(hint!.targetAction).toBe('fold');
+    expect(hint?.targetAction).toBe('fold');
   });
 
   it('works in PostAction phase', () => {
@@ -108,6 +108,6 @@ describe('getRussianPokerHint', () => {
     });
     const hint = getRussianPokerHint(state);
     expect(hint).not.toBeNull();
-    expect(hint!.targetAction).toBe('play');
+    expect(hint?.targetAction).toBe('play');
   });
 });

--- a/frontend/src/utils/hints/scartoHint.ts
+++ b/frontend/src/utils/hints/scartoHint.ts
@@ -14,7 +14,7 @@ import type { HintResult } from '../../types/hint';
  */
 export function getScartoHint(state: ScartoResponse): HintResult | null {
   const hint = state.hint;
-  if (!hint || !hint.reason) return null;
+  if (!hint?.reason) return null;
   return {
     targetAction: 'play',
     reason: `hint.${hint.reason}`,

--- a/frontend/src/utils/hints/sedmaHint.ts
+++ b/frontend/src/utils/hints/sedmaHint.ts
@@ -13,7 +13,7 @@ import type { HintResult } from '../../types/hint';
  */
 export function getSedmaHint(state: SedmaResponse): HintResult | null {
   const hint = state.hint;
-  if (!hint || !hint.reason) return null;
+  if (!hint?.reason) return null;
   return {
     targetAction: 'play',
     reason: `hint.${hint.reason}`,

--- a/frontend/src/utils/hints/sheepsheadHint.ts
+++ b/frontend/src/utils/hints/sheepsheadHint.ts
@@ -15,7 +15,7 @@ import type { HintResult } from '../../types/hint';
  */
 export function getSheepsheadHint(state: SheepsheadResponse): HintResult | null {
   const hint = state.hint;
-  if (!hint || !hint.reason) return null;
+  if (!hint?.reason) return null;
   return {
     targetAction: 'play',
     reason: `hint.${hint.reason}`,

--- a/frontend/src/utils/hints/soloWhistHint.ts
+++ b/frontend/src/utils/hints/soloWhistHint.ts
@@ -13,7 +13,7 @@ import type { HintResult } from '../../types/hint';
  */
 export function getSoloWhistHint(state: SoloWhistResponse): HintResult | null {
   const hint = state.hint;
-  if (!hint || !hint.reason) return null;
+  if (!hint?.reason) return null;
   return {
     targetAction: 'play',
     reason: `hint.${hint.reason}`,

--- a/frontend/src/utils/hints/spoilFiveHint.ts
+++ b/frontend/src/utils/hints/spoilFiveHint.ts
@@ -14,7 +14,7 @@ import type { HintResult } from '../../types/hint';
  */
 export function getSpoilFiveHint(state: SpoilFiveResponse): HintResult | null {
   const hint = state.hint;
-  if (!hint || !hint.reason) return null;
+  if (!hint?.reason) return null;
   return {
     targetAction: 'play',
     reason: `hint.${hint.reason}`,

--- a/frontend/src/utils/hints/suecaHint.ts
+++ b/frontend/src/utils/hints/suecaHint.ts
@@ -13,7 +13,7 @@ import type { HintResult } from '../../types/hint';
  */
 export function getSuecaHint(state: SuecaResponse): HintResult | null {
   const hint = state.hint;
-  if (!hint || !hint.reason) return null;
+  if (!hint?.reason) return null;
   return {
     targetAction: 'play',
     reason: `hint.${hint.reason}`,

--- a/frontend/src/utils/hints/tablanetHint.ts
+++ b/frontend/src/utils/hints/tablanetHint.ts
@@ -14,7 +14,7 @@ import type { HintResult } from '../../types/hint';
  */
 export function getTablanetHint(state: TablanetResponse): HintResult | null {
   const hint = state.hint;
-  if (!hint || !hint.reason) return null;
+  if (!hint?.reason) return null;
   return {
     targetAction: 'play',
     reason: `hint.${hint.reason}`,

--- a/frontend/src/utils/hints/teenPattiHint.ts
+++ b/frontend/src/utils/hints/teenPattiHint.ts
@@ -14,7 +14,7 @@ import type { HintResult } from '../../types/hint';
  */
 export function getTeenPattiHint(state: TeenPattiResponse): HintResult | null {
   const hint = state.hint;
-  if (!hint || !hint.reason) return null;
+  if (!hint?.reason) return null;
   return {
     targetAction: hint.action || 'bet',
     reason: `hint.${hint.reason}`,

--- a/frontend/src/utils/hints/threeCardBragHint.ts
+++ b/frontend/src/utils/hints/threeCardBragHint.ts
@@ -14,7 +14,7 @@ import type { HintResult } from '../../types/hint';
  */
 export function getThreeCardBragHint(state: ThreeCardBragResponse): HintResult | null {
   const hint = state.hint;
-  if (!hint || !hint.reason) return null;
+  if (!hint?.reason) return null;
   return {
     targetAction: hint.action || 'bet',
     reason: `hint.${hint.reason}`,

--- a/frontend/src/utils/hints/tuteHint.ts
+++ b/frontend/src/utils/hints/tuteHint.ts
@@ -14,7 +14,7 @@ import type { HintResult } from '../../types/hint';
  */
 export function getTuteHint(state: TuteResponse): HintResult | null {
   const hint = state.hint;
-  if (!hint || !hint.reason) return null;
+  if (!hint?.reason) return null;
   return {
     targetAction: 'play',
     reason: `hint.${hint.reason}`,

--- a/frontend/src/utils/hints/twentyNineHint.ts
+++ b/frontend/src/utils/hints/twentyNineHint.ts
@@ -14,7 +14,7 @@ import type { HintResult } from '../../types/hint';
  */
 export function getTwentyNineHint(state: TwentyNineResponse): HintResult | null {
   const hint = state.hint;
-  if (!hint || !hint.reason) return null;
+  if (!hint?.reason) return null;
   return {
     targetAction: 'play',
     reason: `hint.${hint.reason}`,

--- a/frontend/src/utils/hints/twotenjackHint.ts
+++ b/frontend/src/utils/hints/twotenjackHint.ts
@@ -19,7 +19,7 @@ const REASON_MAP: Record<string, string> = {
 export function getTwoTenJackHint(state: TwoTenJackResponse): HintResult | null {
   if (state.gameEndFlag) return null;
   const hint = state.hint;
-  if (!hint || !hint.reason) return null;
+  if (!hint?.reason) return null;
   return {
     targetAction: hint.cardIndex !== undefined ? 'play' : 'declare',
     reason: REASON_MAP[hint.reason] ?? hint.reason,

--- a/frontend/src/utils/hints/tysiacHint.ts
+++ b/frontend/src/utils/hints/tysiacHint.ts
@@ -15,7 +15,7 @@ import type { HintResult } from '../../types/hint';
  */
 export function getTysiacHint(state: TysiacResponse): HintResult | null {
   const hint = state.hint;
-  if (!hint || !hint.reason) return null;
+  if (!hint?.reason) return null;
   return {
     targetAction: 'play',
     reason: `hint.${hint.reason}`,

--- a/frontend/src/utils/hints/ultiHint.ts
+++ b/frontend/src/utils/hints/ultiHint.ts
@@ -15,7 +15,7 @@ import type { HintResult } from '../../types/hint';
  */
 export function getUltiHint(state: UltiResponse): HintResult | null {
   const hint = state.hint;
-  if (!hint || !hint.reason) return null;
+  if (!hint?.reason) return null;
   return {
     targetAction: 'play',
     reason: `hint.${hint.reason}`,

--- a/frontend/src/utils/hints/wattenHint.ts
+++ b/frontend/src/utils/hints/wattenHint.ts
@@ -15,7 +15,7 @@ import type { HintResult } from '../../types/hint';
  */
 export function getWattenHint(state: WattenResponse): HintResult | null {
   const hint = state.hint;
-  if (!hint || !hint.reason) return null;
+  if (!hint?.reason) return null;
   return {
     targetAction: hint.action || 'play',
     reason: `hint.${hint.reason}`,

--- a/frontend/src/utils/holdemBestFive.test.ts
+++ b/frontend/src/utils/holdemBestFive.test.ts
@@ -4,6 +4,22 @@ import { holdemBestFive } from './holdemBestFive';
 
 const c = (design: Card['design'], value: number): Card => ({ design, value });
 
+/**
+ * Calls {@link holdemBestFive} and narrows away the `null` return.
+ *
+ * Every case below except the explicit "fewer than 5 cards" one expects a
+ * hand, so the alternative is a `!` on each call — which Biome flags, and
+ * whose auto-fix (`?.`) would only push the `undefined` into the assertions
+ * and fail tsc. Throwing here keeps the call sites clean and turns a
+ * regression that starts returning null into a named failure rather than a
+ * "cannot read property of undefined".
+ */
+const bestFive = (cards: Card[]): number[] => {
+  const picked = holdemBestFive(cards);
+  if (picked === null) throw new Error('holdemBestFive unexpectedly returned null');
+  return picked;
+};
+
 describe('holdemBestFive', () => {
   it('returns null for fewer than 5 cards', () => {
     expect(holdemBestFive([c('SPADE', 2), c('CLOVER', 3)])).toBeNull();
@@ -19,7 +35,7 @@ describe('holdemBestFive', () => {
       c('SPADE', 7),
       c('SPADE', 3),
     ];
-    const picked = holdemBestFive(cards)!;
+    const picked = bestFive(cards);
     const values = picked.map((i) => cards[i].value).sort((a, b) => a - b);
     // Quad 9s + highest available kicker (7).
     expect(values).toEqual([7, 9, 9, 9, 9]);
@@ -35,7 +51,7 @@ describe('holdemBestFive', () => {
       c('HEART', 4),
       c('HEART', 6),
     ];
-    const picked = holdemBestFive(cards)!.map((i) => cards[i]);
+    const picked = bestFive(cards).map((i) => cards[i]);
     expect(picked.every((card) => card.design === 'SPADE')).toBe(true);
   });
 
@@ -49,7 +65,7 @@ describe('holdemBestFive', () => {
       c('HEART', 9),
       c('CLOVER', 10),
     ];
-    const picked = holdemBestFive(cards)!
+    const picked = bestFive(cards)
       .map((i) => cards[i].value)
       .sort((a, b) => a - b);
     expect(picked).toEqual([1, 2, 3, 4, 5]);
@@ -65,7 +81,7 @@ describe('holdemBestFive', () => {
       c('CLOVER', 7),
       c('HEART', 2),
     ];
-    const picked = holdemBestFive(cards)!
+    const picked = bestFive(cards)
       .map((i) => cards[i].value)
       .sort((a, b) => a - b);
     // Pair of 10s plus K, 9, 7 kickers.
@@ -83,7 +99,7 @@ describe('holdemBestFive', () => {
       c('HEART', 13),
       c('HEART', 1), // Ace high
     ];
-    const picked = holdemBestFive(cards)!.map((i) => cards[i]);
+    const picked = bestFive(cards).map((i) => cards[i]);
     expect(picked.every((card) => card.design === 'HEART')).toBe(true);
   });
 });


### PR DESCRIPTION
Takes `bun run check` from **70 Biome diagnostics to 0**. Three commits, readable in order.

## 1. Migrate `biome.json` to the 2.5.5 schema (2 diagnostics)

The `$schema` URL still pointed at 2.4.8 while the pinned CLI is 2.5.5 — left behind by an earlier bump, so editors were validating against the wrong schema. `linter.rules.recommended` is also deprecated in favour of `preset`.

Produced by `biome migrate --write`. **Verified the rule set did not change** rather than assumed: per-rule diagnostic counts are byte-identical before and after (49/11/6/2/1/1), so `preset: "recommended"` enables exactly what `recommended: true` did. Without that check there is no way to tell a fixed warning from a disabled rule.

## 2. `useOptionalChain` (49 sites)

45 are one shape — `if (!hint || !hint.reason)` → `if (!hint?.reason)`. The rest are `!list || list.length !== N` → `list?.length !== N`, plus one compound guard in `CrescentPage`.

Applied with `--unsafe`, then **every one of the 49 lines was read**. Biome calls this unsafe for a real reason: `!x || x.y` and `x?.y` diverge when `x` is falsy but not nullish (`0`, `''`, `false`). Every subject here is an object or array type, and `![]` is `false`, so no site can hit that. The `CrescentPage` one leaves `selectedSource.col` un-chained after the rewrite — safe because `||` short-circuits first, and tsc confirms the narrowing.

## 3. The remaining 21

- **`noNonNullAssertion` (11, all in tests)** — ⚠️ **Biome's autofix produces broken code here.** It rewrites `holdemBestFive(cards)!` to `?.`, which does not remove the `undefined`, it pushes it into the assertions: tsc then fails with `TS18048: 'picked' is possibly 'undefined'` at two sites. Replaced with a narrowing `bestFive()` helper so all five lose the `!` legitimately. The `russianpokerHint` sites are fine as `?.` — each is preceded by an explicit `expect(hint).not.toBeNull()`.
- **`useTemplate` (2), `useIndexOf` (1)** — autofix, reviewed.
- **`noDescendingSpecificity` (1)** — reordered two chevron rules. They set different properties (`transition` vs `transform`), so the cascade result is unchanged; this is readability only.
- **`noImportantStyles` (6)** — **not fixed, deliberately suppressed.** This is the `prefers-reduced-motion` universal reset. `!important` is the mechanism that lets it beat each component's own animation declarations; removing it would silently restore motion for users who asked for less of it. Suppressed with a comment saying so.

## The suppression broke a project check — and that is fixed at the root

Adding that `biome-ignore` comment made `bun run check` fail: `check-design-tokens.mjs` asserted the reduced-motion block by slicing a **fixed 400 characters** after the `@media` line, and the comment pushed `animation-duration: 0.01ms` past the window. The guard reported the SSoT block missing while it was sitting right there.

Shortening the comment would have passed and left the landmine armed, so the guard now reads to the at-rule's closing brace.

Because loosening a guard looks exactly like fixing it, I re-mutated it:

| mutation | result |
|---|---|
| universal selector `*,` → `.some-class` | exit 1 ✅ |
| `animation-duration: 0.01ms` → `animation: none` | exit 1 ✅ |

Comment-tolerance increased; detection unchanged.

## Test plan

- [x] `bun run check` — **0 diagnostics**, design-tokens and reduced-motion OK
- [x] `bun run typecheck` — clean
- [x] `bun run test` — 1,133 files / 15,765 tests pass
- [x] Guard mutation-tested (table above)