### PR TITLE
docs(frontend): make cross-module {@link} targets resolvable in TypeDoc

### DIFF
--- a/frontend/src/api/gameApi.ts
+++ b/frontend/src/api/gameApi.ts
@@ -1075,7 +1075,7 @@ export interface TwoTenJackConfigInput {
 /** API client for the Two Ten Jack /twotenjack/exec endpoint.
  *
  * Argument order mirrors {@link spadesApi}: command, trumpSuit, cardIndex, config.
- * This keeps compatibility with {@link useTrickGameBase} which invokes play as
+ * This keeps compatibility with {@link hooks/useTrickGameBase.useTrickGameBase | useTrickGameBase} which invokes play as
  * `(command, undefined, cardIndex)`.
  */
 export const twoTenJackApi = {

--- a/frontend/src/components/GameGiveUpDialog.tsx
+++ b/frontend/src/components/GameGiveUpDialog.tsx
@@ -10,7 +10,7 @@ export interface GameGiveUpDialogProps {
 
 /**
  * Renders a give-up confirmation dialog using common translation keys.
- * Mirrors {@link GameResetDialog} but with give-up-specific copy, since
+ * Mirrors {@link components/GameResetDialog.GameResetDialog | GameResetDialog} but with give-up-specific copy, since
  * give-up is an irreversible destructive action that deserves the same
  * "are you sure?" guard as reset (issue #2099).
  */

--- a/frontend/src/components/KeyboardShortcutsPanel.tsx
+++ b/frontend/src/components/KeyboardShortcutsPanel.tsx
@@ -19,7 +19,7 @@ export interface KeyboardShortcutsPanelProps extends ComponentPropsWithoutRef<'d
 /**
  * Collapsible, keyboard-discoverable list of the shortcuts available on a game
  * page. Rendered as a native `<details>`/`<summary>` so it is closed by
- * default, focusable, and operable without JavaScript. Unlike {@link KbdBadge}
+ * default, focusable, and operable without JavaScript. Unlike {@link components/KbdBadge.KbdBadge | KbdBadge}
  * (a silent affordance on a button whose name already conveys the action), the
  * key chips here are read by assistive tech because advertising the keys *is*
  * the panel's purpose.

--- a/frontend/src/components/common/ReplaySpeedSettingsPanel.tsx
+++ b/frontend/src/components/common/ReplaySpeedSettingsPanel.tsx
@@ -7,7 +7,7 @@ const SPEED_OPTIONS: ReadonlyArray<ReplaySpeed> = ['normal', 'fast', 'instant'];
 /**
  * Renders a small settings panel that lets the player tune the CPU replay
  * animation speed (Normal / Fast / Instant). The choice is persisted globally
- * so it carries across every game that uses {@link runReplay}.
+ * so it carries across every game that uses {@link hooks/gameReplay.runReplay | runReplay}.
  *
  * Designed to sit alongside an existing per-game `<SettingsPanel>` on pages
  * that animate CPU turns (Daifugo, Old Maid, Sevens, President — see #1649).

--- a/frontend/src/hooks/useFocusTrap.ts
+++ b/frontend/src/hooks/useFocusTrap.ts
@@ -9,7 +9,7 @@ import { getFocusableElements } from '../utils/dom';
  * calls `onClose`; unmount/close returns focus to whatever had it when the
  * dialog opened.
  *
- * Body scroll-locking is handled separately (by {@link useBodyScrollLock},
+ * Body scroll-locking is handled separately (by {@link hooks/useBodyScrollLock.useBodyScrollLock | useBodyScrollLock},
  * wired in the shared `Modal` component) so this hook stays focus-only and
  * reusable by dialogs that manage their own overlay.
  */

--- a/frontend/src/hooks/useGiveUpConfirm.ts
+++ b/frontend/src/hooks/useGiveUpConfirm.ts
@@ -8,7 +8,7 @@ import { useCallback } from 'react';
  *
  * `giveUp` is the page's give-up action (however it sources it — an inline
  * `apiCall('giveup')` callback or one returned from a per-game hook);
- * `requestGiveUpConfirm` comes from {@link useGamePageSetup}. Give-up abandons an
+ * `requestGiveUpConfirm` comes from {@link hooks/useGamePageSetup.useGamePageSetup | useGamePageSetup}. Give-up abandons an
  * in-progress game and is irreversible, so it is always confirmed before firing
  * (issue #2099).
  */

--- a/frontend/src/utils/hints/anacondaHint.ts
+++ b/frontend/src/utils/hints/anacondaHint.ts
@@ -10,7 +10,7 @@ import type { HintResult } from '../../types/hint';
  * `raise` / `call` / `fold`) mapped to the `targetAction` string, and a
  * `reason` suffix (`pass_weakest` / `keep_best` / `strong_hand` /
  * `medium_hand` / `weak_hand`) re-mapped into the frontend HintResult shape so
- * the shared {@link useGameHint} tooltip can render it. A `strong_hand`
+ * the shared {@link hooks/useGameHint.useGameHint | useGameHint} tooltip can render it. A `strong_hand`
  * suggestion reports strong confidence; everything else is moderate.
  */
 export function getAnacondaHint(state: AnacondaResponse): HintResult | null {

--- a/frontend/src/utils/hints/basraHint.ts
+++ b/frontend/src/utils/hints/basraHint.ts
@@ -8,7 +8,7 @@ import type { HintResult } from '../../types/hint';
  * Basra's hint is computed entirely by the Go backend and surfaced on the
  * response's `hint` field (with a `reason` i18n suffix such as `basra_sweep`,
  * `jack_sweep`, `capture`, or `trail_low`). This adapter re-maps that server hint
- * into the frontend HintResult shape so the shared {@link useGameHint} tooltip can
+ * into the frontend HintResult shape so the shared {@link hooks/useGameHint.useGameHint | useGameHint} tooltip can
  * render it. The `targetAction` is fixed to `play` because every hint points the
  * player at which card to play.
  */

--- a/frontend/src/utils/hints/beziqueHint.ts
+++ b/frontend/src/utils/hints/beziqueHint.ts
@@ -8,7 +8,7 @@ import type { HintResult } from '../../types/hint';
  * Like Court Piece, Bezique's hint is computed entirely by the Go backend and
  * surfaced on the response's `hint` field (with a `reason` i18n suffix). This
  * adapter re-maps that server hint into the frontend HintResult shape so the
- * shared {@link useGameHint} tooltip can render it. The hint carries a
+ * shared {@link hooks/useGameHint.useGameHint | useGameHint} tooltip can render it. The hint carries a
  * `meldIndex` during the Meld phase (the special value -1 means "skip the
  * meld"), and a `cardIndex` during the Play phase. The `targetAction` is `meld`
  * while a meld declaration / skip is suggested and `play` otherwise.

--- a/frontend/src/utils/hints/bidwhistHint.ts
+++ b/frontend/src/utils/hints/bidwhistHint.ts
@@ -7,7 +7,7 @@ import type { HintResult } from '../../types/hint';
  * partnership signalling that the client does not model. The authoritative hint
  * is computed server-side (see internal/domain/BidWhist.go GetHint, surfaced via
  * the `hint` command). This explicit stub keeps the game registered in
- * {@link useGameHint} so the hint-toggle UI stays consistent across the suite.
+ * {@link hooks/useGameHint.useGameHint | useGameHint} so the hint-toggle UI stays consistent across the suite.
  */
 export function getBidWhistHint(_state: BidWhistResponse): HintResult | null {
   return null;

--- a/frontend/src/utils/hints/bigtwoHint.ts
+++ b/frontend/src/utils/hints/bigtwoHint.ts
@@ -4,7 +4,7 @@ import type { HintResult } from '../../types/hint';
 /**
  * Returns null — Big Two's optimal play depends on complex hand evaluation
  * and opponent modeling that the client does not perform.
- * Keeping an explicit stub so the game is registered in {@link useGameHint}
+ * Keeping an explicit stub so the game is registered in {@link hooks/useGameHint.useGameHint | useGameHint}
  * and the hint toggle UI stays consistent across the suite.
  */
 export function getBigTwoHint(_state: BigTwoResponse): HintResult | null {

--- a/frontend/src/utils/hints/bouillotteHint.ts
+++ b/frontend/src/utils/hints/bouillotteHint.ts
@@ -10,7 +10,7 @@ import type { HintResult } from '../../types/hint';
  * `action` (`"call"` / `"raise"` / `"fold"`) mapped to the `targetAction`
  * string, and a `reason` i18n suffix (`strong_hand` / `medium_hand` /
  * `weak_hand`) re-mapped into the frontend HintResult shape so the shared
- * {@link useGameHint} tooltip can render it.
+ * {@link hooks/useGameHint.useGameHint | useGameHint} tooltip can render it.
  */
 export function getBouillotteHint(state: BouillotteResponse): HintResult | null {
   const hint = state.hint;

--- a/frontend/src/utils/hints/calabresellaHint.ts
+++ b/frontend/src/utils/hints/calabresellaHint.ts
@@ -9,7 +9,7 @@ import type { HintResult } from '../../types/hint';
  * surfaced on the response's `hint` field (with a `reason` i18n suffix such as
  * `lead_low`, `follow_win`, `follow_duck`, `give_partner`, `discard_low`,
  * `bid_chiamo`, `bid_solo`, or `bid_pass`). This adapter re-maps that server
- * hint into the frontend HintResult shape so the shared {@link useGameHint}
+ * hint into the frontend HintResult shape so the shared {@link hooks/useGameHint.useGameHint | useGameHint}
  * tooltip can render it. The `targetAction` is fixed to `play` because every
  * hint ultimately points the player at a card.
  */

--- a/frontend/src/utils/hints/cegoHint.ts
+++ b/frontend/src/utils/hints/cegoHint.ts
@@ -10,7 +10,7 @@ import type { HintResult } from '../../types/hint';
  * `bid_take`, `bid_pass`, `contract_cego`, `contract_handspiel`, `keep_best`,
  * `lead_high`, `lead_low`, `follow_win`, or `follow_duck`). This adapter re-maps
  * that server hint into the frontend HintResult shape so the shared
- * {@link useGameHint} tooltip can render it. The `targetAction` is fixed to
+ * {@link hooks/useGameHint.useGameHint | useGameHint} tooltip can render it. The `targetAction` is fixed to
  * `play` because every hint ultimately points the player at a decision.
  */
 export function getCegoHint(state: CegoResponse): HintResult | null {

--- a/frontend/src/utils/hints/cinchHint.ts
+++ b/frontend/src/utils/hints/cinchHint.ts
@@ -9,7 +9,7 @@ import type { HintResult } from '../../types/hint';
  * Go backend and surfaced on the response's `hint` field (with a `reason` i18n
  * suffix such as `bid_pass`, `bid_strong`, `name_trump`, `lead_strong`,
  * `trump_cut`, `follow_suit`, or `discard_low`). This adapter re-maps that server
- * hint into the frontend HintResult shape so the shared {@link useGameHint}
+ * hint into the frontend HintResult shape so the shared {@link hooks/useGameHint.useGameHint | useGameHint}
  * tooltip can render it. The `targetAction` is fixed to `play` because every
  * hint ultimately points the player at a decision.
  */

--- a/frontend/src/utils/hints/courtPieceHint.ts
+++ b/frontend/src/utils/hints/courtPieceHint.ts
@@ -8,7 +8,7 @@ import type { HintResult } from '../../types/hint';
  * Like Twenty-Nine, Court Piece's hint is computed entirely by the Go backend
  * and surfaced on the response's `hint` field (with a `reason` i18n suffix).
  * This adapter re-maps that server hint into the frontend HintResult shape so
- * the shared {@link useGameHint} tooltip can render it. The `targetAction` is
+ * the shared {@link hooks/useGameHint.useGameHint | useGameHint} tooltip can render it. The `targetAction` is
  * `trump` while a trump-suit declaration is suggested (the hint carries a
  * `trumpSuit`), and `play` otherwise (trick-play phase).
  */

--- a/frontend/src/utils/hints/doppelkopfHint.ts
+++ b/frontend/src/utils/hints/doppelkopfHint.ts
@@ -8,7 +8,7 @@ import type { HintResult } from '../../types/hint';
  * Like Sheepshead, Doppelkopf's hint is computed entirely by the Go backend
  * and surfaced on the response's `hint` field (with a `reason` i18n suffix).
  * This adapter re-maps that server hint into the frontend HintResult shape so
- * the shared {@link useGameHint} tooltip can render it. The `targetAction` is
+ * the shared {@link hooks/useGameHint.useGameHint | useGameHint} tooltip can render it. The `targetAction` is
  * fixed to `play` because the in-page tooltip only annotates the play step.
  */
 export function getDoppelkopfHint(state: DoppelkopfResponse): HintResult | null {

--- a/frontend/src/utils/hints/ecarteHint.ts
+++ b/frontend/src/utils/hints/ecarteHint.ts
@@ -8,7 +8,7 @@ import type { HintResult } from '../../types/hint';
  * Like Bezique, Écarté's hint is computed entirely by the Go backend and
  * surfaced on the response's `hint` field (with a `reason` i18n suffix). This
  * adapter re-maps that server hint into the frontend HintResult shape so the
- * shared {@link useGameHint} tooltip can render it. The hint carries a
+ * shared {@link hooks/useGameHint.useGameHint | useGameHint} tooltip can render it. The hint carries a
  * `cardIndex` during the Play phase, and an `action` string (e.g. `propose`,
  * `stand`, `accept`, `refuse`, `discard`) during the Exchange phase. The
  * `targetAction` is the exchange action while one is suggested, and `play`

--- a/frontend/src/utils/hints/fivehundredHint.ts
+++ b/frontend/src/utils/hints/fivehundredHint.ts
@@ -6,7 +6,7 @@ import type { HintResult } from '../../types/hint';
  * bower/joker trump tracking, kitty inference, and partnership signalling that
  * the client does not model. The authoritative hint is computed server-side
  * (see internal/domain/FiveHundred.go GetHint, surfaced via the `hint` command).
- * This explicit stub keeps the game registered in {@link useGameHint} so the
+ * This explicit stub keeps the game registered in {@link hooks/useGameHint.useGameHint | useGameHint} so the
  * hint-toggle UI stays consistent across the suite.
  */
 export function getFiveHundredHint(_state: FiveHundredResponse): HintResult | null {

--- a/frontend/src/utils/hints/fortyFivesHint.ts
+++ b/frontend/src/utils/hints/fortyFivesHint.ts
@@ -8,7 +8,7 @@ import type { HintResult } from '../../types/hint';
  * Like Solo Whist, Auction Forty-Fives' hint is computed entirely by the Go
  * backend and surfaced on the response's `hint` field (with a `reason` i18n
  * suffix). This adapter re-maps that server hint into the frontend HintResult
- * shape so the shared {@link useGameHint} tooltip can render it. The
+ * shape so the shared {@link hooks/useGameHint.useGameHint | useGameHint} tooltip can render it. The
  * `targetAction` is fixed to `play` because the hint only applies during the
  * trick-play phase.
  */

--- a/frontend/src/utils/hints/frenchtarotHint.ts
+++ b/frontend/src/utils/hints/frenchtarotHint.ts
@@ -9,7 +9,7 @@ import type { HintResult } from '../../types/hint';
  * response's `hint` field (with a `reason` i18n suffix such as `bid_take`,
  * `bid_pass`, `discard_weak`, `lead_high`, `lead_low`, `follow_win`,
  * `follow_duck`, or `play_excuse`). This adapter re-maps that server hint into
- * the frontend HintResult shape so the shared {@link useGameHint} tooltip can
+ * the frontend HintResult shape so the shared {@link hooks/useGameHint.useGameHint | useGameHint} tooltip can
  * render it. The `targetAction` is fixed to `play` because every hint ultimately
  * points the player at a decision.
  */

--- a/frontend/src/utils/hints/gostopHint.ts
+++ b/frontend/src/utils/hints/gostopHint.ts
@@ -9,7 +9,7 @@ import type { HintResult } from '../../types/hint';
  * response's `hint` field (with a `reason` i18n suffix such as `capture`,
  * `discard_low`, `go_lowscore`, or `stop_secure`). This adapter re-maps that
  * server hint into the frontend HintResult shape so the shared
- * {@link useGameHint} tooltip can render it. During the GoDecision phase the
+ * {@link hooks/useGameHint.useGameHint | useGameHint} tooltip can render it. During the GoDecision phase the
  * hint points at the go/stop choice; during Play it points at which card to
  * play.
  */

--- a/frontend/src/utils/hints/gutsHint.ts
+++ b/frontend/src/utils/hints/gutsHint.ts
@@ -9,7 +9,7 @@ import type { HintResult } from '../../types/hint';
  * surfaced on the response's `hint` field. The hint carries a `declaration`
  * (0=out/fold, 1=in/stay) mapped to the `targetAction` string, and a `reason`
  * i18n suffix (`strong_hand` / `weak_hand`) re-mapped into the frontend
- * HintResult shape so the shared {@link useGameHint} tooltip can render it.
+ * HintResult shape so the shared {@link hooks/useGameHint.useGameHint | useGameHint} tooltip can render it.
  */
 export function getGutsHint(state: GutsResponse): HintResult | null {
   const hint = state.hint;

--- a/frontend/src/utils/hints/hachihachiHint.ts
+++ b/frontend/src/utils/hints/hachihachiHint.ts
@@ -8,7 +8,7 @@ import type { HintResult } from '../../types/hint';
  * Hachi-Hachi's hint is computed entirely by the Go backend and surfaced on the
  * response's `hint` field (with a `reason` i18n suffix such as `capture` or
  * `discard_low`). This adapter re-maps that server hint into the frontend
- * HintResult shape so the shared {@link useGameHint} tooltip can render it.
+ * HintResult shape so the shared {@link hooks/useGameHint.useGameHint | useGameHint} tooltip can render it.
  */
 export function getHachiHachiHint(state: HachiHachiResponse): HintResult | null {
   const hint = state.hint;

--- a/frontend/src/utils/hints/kingHint.ts
+++ b/frontend/src/utils/hints/kingHint.ts
@@ -8,7 +8,7 @@ import type { HintResult } from '../../types/hint';
  * King's hint is computed entirely by the Go backend and surfaced on the
  * response's `hint` field (with a `reason` i18n suffix such as `avoid_low` or
  * `win_high`). This adapter re-maps that server hint into the frontend
- * HintResult shape so the shared {@link useGameHint} tooltip can render it. The
+ * HintResult shape so the shared {@link hooks/useGameHint.useGameHint | useGameHint} tooltip can render it. The
  * `targetAction` is fixed to `play` because every hint ultimately points the
  * player at a card.
  */

--- a/frontend/src/utils/hints/klaverjasHint.ts
+++ b/frontend/src/utils/hints/klaverjasHint.ts
@@ -8,7 +8,7 @@ import type { HintResult } from '../../types/hint';
  * Like Sueca and Tute, Klaverjas's hint is computed entirely by the Go backend
  * and surfaced on the response's `hint` field (with a `reason` i18n suffix).
  * This adapter re-maps that server hint into the frontend HintResult shape so
- * the shared {@link useGameHint} tooltip can render it. The `targetAction` is
+ * the shared {@link hooks/useGameHint.useGameHint | useGameHint} tooltip can render it. The `targetAction` is
  * fixed to `play` because the only action is playing a card.
  */
 export function getKlaverjasHint(state: KlaverjasResponse): HintResult | null {

--- a/frontend/src/utils/hints/knockoutWhistHint.ts
+++ b/frontend/src/utils/hints/knockoutWhistHint.ts
@@ -9,7 +9,7 @@ import type { HintResult } from '../../types/hint';
  * backend and surfaced on the response's `hint` field (with a `reason` i18n
  * suffix such as `lead_high`, `follow_win`, `follow_duck`, or `discard_low`).
  * This adapter re-maps that server hint into the frontend HintResult shape so
- * the shared {@link useGameHint} tooltip can render it. The `targetAction` is
+ * the shared {@link hooks/useGameHint.useGameHint | useGameHint} tooltip can render it. The `targetAction` is
  * fixed to `play` because the only action is playing a card.
  */
 export function getKnockoutWhistHint(state: KnockoutWhistResponse): HintResult | null {

--- a/frontend/src/utils/hints/koenigrufenHint.ts
+++ b/frontend/src/utils/hints/koenigrufenHint.ts
@@ -9,7 +9,7 @@ import type { HintResult } from '../../types/hint';
  * surfaced on the response's `hint` field (with a `reason` i18n suffix such as
  * `bid_take`, `bid_pass`, `call_king`, `discard_weak`, `lead_high`, `lead_low`,
  * `follow_win`, or `follow_duck`). This adapter re-maps that server hint into the
- * frontend HintResult shape so the shared {@link useGameHint} tooltip can render
+ * frontend HintResult shape so the shared {@link hooks/useGameHint.useGameHint | useGameHint} tooltip can render
  * it. The `targetAction` is fixed to `play` because every hint ultimately points
  * the player at a decision.
  */

--- a/frontend/src/utils/hints/koikoiHint.ts
+++ b/frontend/src/utils/hints/koikoiHint.ts
@@ -9,7 +9,7 @@ import type { HintResult } from '../../types/hint';
  * response's `hint` field (with a `reason` i18n suffix such as `capture`,
  * `discard_low`, `koikoi_lowyaku`, or `stop_secure`). This adapter re-maps that
  * server hint into the frontend HintResult shape so the shared
- * {@link useGameHint} tooltip can render it. During the KoiKoiDecision phase the
+ * {@link hooks/useGameHint.useGameHint | useGameHint} tooltip can render it. During the KoiKoiDecision phase the
  * hint points at the koi-koi/shobu choice; during Play it points at which card
  * to play.
  */

--- a/frontend/src/utils/hints/looHint.ts
+++ b/frontend/src/utils/hints/looHint.ts
@@ -9,7 +9,7 @@ import type { HintResult } from '../../types/hint';
  * and surfaced on the response's `hint` field (with a `reason` i18n suffix such
  * as `decide_play`, `decide_pass`, `lead_high`, `follow_win`, or `discard_low`).
  * This adapter re-maps that server hint into the frontend HintResult shape so the
- * shared {@link useGameHint} tooltip can render it. The `targetAction` is fixed to
+ * shared {@link hooks/useGameHint.useGameHint | useGameHint} tooltip can render it. The `targetAction` is fixed to
  * `play` because every hint ultimately points the player at a decision.
  */
 export function getLooHint(state: LooResponse): HintResult | null {

--- a/frontend/src/utils/hints/manilleHint.ts
+++ b/frontend/src/utils/hints/manilleHint.ts
@@ -8,7 +8,7 @@ import type { HintResult } from '../../types/hint';
  * Like Klaverjas and Sueca, Manille's hint is computed entirely by the Go
  * backend and surfaced on the response's `hint` field (with a `reason` i18n
  * suffix). This adapter re-maps that server hint into the frontend HintResult
- * shape so the shared {@link useGameHint} tooltip can render it. The
+ * shape so the shared {@link hooks/useGameHint.useGameHint | useGameHint} tooltip can render it. The
  * `targetAction` is fixed to `play` because the only action is playing a card.
  */
 export function getManilleHint(state: ManilleResponse): HintResult | null {

--- a/frontend/src/utils/hints/mariasHint.ts
+++ b/frontend/src/utils/hints/mariasHint.ts
@@ -8,7 +8,7 @@ import type { HintResult } from '../../types/hint';
  * Like Manille and Sueca, Mariáš's hint is computed entirely by the Go backend
  * and surfaced on the response's `hint` field (with a `reason` i18n suffix).
  * This adapter re-maps that server hint into the frontend HintResult shape so
- * the shared {@link useGameHint} tooltip can render it. The `targetAction` is
+ * the shared {@link hooks/useGameHint.useGameHint | useGameHint} tooltip can render it. The `targetAction` is
  * fixed to `play` because the only action is playing a card.
  */
 export function getMariasHint(state: MariasResponse): HintResult | null {

--- a/frontend/src/utils/hints/michiganHint.ts
+++ b/frontend/src/utils/hints/michiganHint.ts
@@ -8,7 +8,7 @@ import type { HintResult } from '../../types/hint';
  * Michigan's hint is computed entirely by the Go backend and surfaced on the
  * response's `hint` field (with a `reason` i18n suffix such as `forced`,
  * `claim_boodle`, or `lead_low`). This adapter re-maps that server hint into the
- * frontend HintResult shape so the shared {@link useGameHint} tooltip can render
+ * frontend HintResult shape so the shared {@link hooks/useGameHint.useGameHint | useGameHint} tooltip can render
  * it. The `targetAction` is fixed to `play` because every hint points the player
  * at which card to play.
  */

--- a/frontend/src/utils/hints/musHint.ts
+++ b/frontend/src/utils/hints/musHint.ts
@@ -8,7 +8,7 @@ import type { HintResult } from '../../types/hint';
  * Like Sheepshead, Mus computes its hint entirely on the Go backend and surfaces
  * it on the response's `hint` field with a `reason` i18n suffix. This adapter
  * re-maps that server hint into the frontend HintResult shape so the shared
- * {@link useGameHint} tooltip can render it. The `targetAction` is derived from
+ * {@link hooks/useGameHint.useGameHint | useGameHint} tooltip can render it. The `targetAction` is derived from
  * the reason family (mus / discard / bet) so the in-page tooltip can annotate
  * the matching control group.
  */

--- a/frontend/src/utils/hints/napHint.ts
+++ b/frontend/src/utils/hints/napHint.ts
@@ -8,7 +8,7 @@ import type { HintResult } from '../../types/hint';
  * Like Solo Whist, Nap's hint is computed entirely by the Go backend and
  * surfaced on the response's `hint` field (with a `reason` i18n suffix). This
  * adapter re-maps that server hint into the frontend HintResult shape so the
- * shared {@link useGameHint} tooltip can render it. The `targetAction` is fixed
+ * shared {@link hooks/useGameHint.useGameHint | useGameHint} tooltip can render it. The `targetAction` is fixed
  * to `play` because the hint only applies during the trick-play phase.
  */
 export function getNapHint(state: NapResponse): HintResult | null {

--- a/frontend/src/utils/hints/ombreHint.ts
+++ b/frontend/src/utils/hints/ombreHint.ts
@@ -10,7 +10,7 @@ import type { HintResult } from '../../types/hint';
  * `lead_high`, `lead_low`, `follow_win`, `follow_duck`, `give_partner`,
  * `discard_low`, `bid_entrar`, `bid_solo`, or `bid_pass`). This adapter re-maps
  * that server hint into the frontend HintResult shape so the shared
- * {@link useGameHint} tooltip can render it. The `targetAction` is fixed to
+ * {@link hooks/useGameHint.useGameHint | useGameHint} tooltip can render it. The `targetAction` is fixed to
  * `play` because every hint ultimately points the player at a card.
  */
 export function getOmbreHint(state: OmbreResponse): HintResult | null {

--- a/frontend/src/utils/hints/preferenceHint.ts
+++ b/frontend/src/utils/hints/preferenceHint.ts
@@ -8,7 +8,7 @@ import type { HintResult } from '../../types/hint';
  * Like Solo Whist, Préférence's hint is computed entirely by the Go backend and
  * surfaced on the response's `hint` field (with a `reason` i18n suffix). This
  * adapter re-maps that server hint into the frontend HintResult shape so the
- * shared {@link useGameHint} tooltip can render it. The `targetAction` is fixed
+ * shared {@link hooks/useGameHint.useGameHint | useGameHint} tooltip can render it. The `targetAction` is fixed
  * to `play` because the hint only applies during the trick-play phase.
  */
 export function getPreferenceHint(state: PreferenceResponse): HintResult | null {

--- a/frontend/src/utils/hints/presidentHint.ts
+++ b/frontend/src/utils/hints/presidentHint.ts
@@ -4,7 +4,7 @@ import type { HintResult } from '../../types/hint';
 /**
  * Returns null — President's optimal play depends on information-set reasoning
  * (opponent hands, partnership dynamics) that the client does not model.
- * Keeping an explicit stub so the game is registered in {@link useGameHint}
+ * Keeping an explicit stub so the game is registered in {@link hooks/useGameHint.useGameHint | useGameHint}
  * and the hint toggle UI stays consistent across the suite.
  */
 export function getPresidentHint(_state: PresidentResponse): HintResult | null {

--- a/frontend/src/utils/hints/primeroHint.ts
+++ b/frontend/src/utils/hints/primeroHint.ts
@@ -10,7 +10,7 @@ import type { HintResult } from '../../types/hint';
  * `action` (`"call"` / `"raise"` / `"fold"`) mapped to the `targetAction`
  * string, and a `reason` i18n suffix (`strong_hand` / `medium_hand` /
  * `weak_hand`) re-mapped into the frontend HintResult shape so the shared
- * {@link useGameHint} tooltip can render it.
+ * {@link hooks/useGameHint.useGameHint | useGameHint} tooltip can render it.
  */
 export function getPrimeroHint(state: PrimeroResponse): HintResult | null {
   const hint = state.hint;

--- a/frontend/src/utils/hints/rookHint.ts
+++ b/frontend/src/utils/hints/rookHint.ts
@@ -6,7 +6,7 @@ import type { HintResult } from '../../types/hint';
  * inference, trump-color choice, and partnership signalling that the client
  * does not model. The authoritative hint is computed server-side (see
  * internal/domain/Rook.go GetHint, surfaced via the `hint` command). This
- * explicit stub keeps the game registered in {@link useGameHint} so the
+ * explicit stub keeps the game registered in {@link hooks/useGameHint.useGameHint | useGameHint} so the
  * hint-toggle UI stays consistent across the suite.
  */
 export function getRookHint(_state: RookResponse): HintResult | null {

--- a/frontend/src/utils/hints/scartoHint.ts
+++ b/frontend/src/utils/hints/scartoHint.ts
@@ -9,7 +9,7 @@ import type { HintResult } from '../../types/hint';
  * surfaced on the response's `hint` field (with a `reason` i18n suffix such as
  * `scarto_weak`, `lead_low`, `follow_win`, `follow_duck`, or `play_excuse`).
  * This adapter re-maps that server hint into the frontend HintResult shape so
- * the shared {@link useGameHint} tooltip can render it. The `targetAction` is
+ * the shared {@link hooks/useGameHint.useGameHint | useGameHint} tooltip can render it. The `targetAction` is
  * fixed to `play` because every hint ultimately points the player at a decision.
  */
 export function getScartoHint(state: ScartoResponse): HintResult | null {

--- a/frontend/src/utils/hints/schnapsenHint.ts
+++ b/frontend/src/utils/hints/schnapsenHint.ts
@@ -6,7 +6,7 @@ import type { HintResult } from '../../types/hint';
  * conservation, stock-depletion tracking, and the must-follow second phase that
  * the client does not model. The authoritative hint is computed server-side
  * (see internal/domain/Schnapsen.go GetHint, surfaced via the `hint` command).
- * This explicit stub keeps the game registered in {@link useGameHint} so the
+ * This explicit stub keeps the game registered in {@link hooks/useGameHint.useGameHint | useGameHint} so the
  * hint-toggle UI stays consistent across the suite.
  */
 export function getSchnapsenHint(_state: SchnapsenResponse): HintResult | null {

--- a/frontend/src/utils/hints/sedmaHint.ts
+++ b/frontend/src/utils/hints/sedmaHint.ts
@@ -8,7 +8,7 @@ import type { HintResult } from '../../types/hint';
  * Like Manille and Sueca, Sedma's hint is computed entirely by the Go backend
  * and surfaced on the response's `hint` field (with a `reason` i18n suffix).
  * This adapter re-maps that server hint into the frontend HintResult shape so
- * the shared {@link useGameHint} tooltip can render it. The `targetAction` is
+ * the shared {@link hooks/useGameHint.useGameHint | useGameHint} tooltip can render it. The `targetAction` is
  * fixed to `play` because the only action is playing a card.
  */
 export function getSedmaHint(state: SedmaResponse): HintResult | null {

--- a/frontend/src/utils/hints/sheepsheadHint.ts
+++ b/frontend/src/utils/hints/sheepsheadHint.ts
@@ -8,7 +8,7 @@ import type { HintResult } from '../../types/hint';
  * Unlike most games, Sheepshead's hint is computed entirely by the Go backend
  * and surfaced on the response's `hint` field (with a `reason` i18n suffix).
  * This adapter simply re-maps that server hint into the frontend HintResult
- * shape so the shared {@link useGameHint} tooltip can render it. The
+ * shape so the shared {@link hooks/useGameHint.useGameHint | useGameHint} tooltip can render it. The
  * `targetAction` is fixed to `play` because the in-page tooltip only annotates
  * the play step; the richer per-phase hint (pick/call) is shown via the
  * dedicated server-hint banner on the page.

--- a/frontend/src/utils/hints/soloWhistHint.ts
+++ b/frontend/src/utils/hints/soloWhistHint.ts
@@ -8,7 +8,7 @@ import type { HintResult } from '../../types/hint';
  * Like Mariáš, Solo Whist's hint is computed entirely by the Go backend and
  * surfaced on the response's `hint` field (with a `reason` i18n suffix). This
  * adapter re-maps that server hint into the frontend HintResult shape so the
- * shared {@link useGameHint} tooltip can render it. The `targetAction` is fixed
+ * shared {@link hooks/useGameHint.useGameHint | useGameHint} tooltip can render it. The `targetAction` is fixed
  * to `play` because the hint only applies during the trick-play phase.
  */
 export function getSoloWhistHint(state: SoloWhistResponse): HintResult | null {

--- a/frontend/src/utils/hints/spoilFiveHint.ts
+++ b/frontend/src/utils/hints/spoilFiveHint.ts
@@ -9,7 +9,7 @@ import type { HintResult } from '../../types/hint';
  * and surfaced on the response's `hint` field (with a `reason` i18n suffix such
  * as `lead_high`, `take_trick`, or `discard_low`). This adapter re-maps that
  * server hint into the frontend HintResult shape so the shared
- * {@link useGameHint} tooltip can render it. The `targetAction` is fixed to
+ * {@link hooks/useGameHint.useGameHint | useGameHint} tooltip can render it. The `targetAction` is fixed to
  * `play` because the only action is playing a card.
  */
 export function getSpoilFiveHint(state: SpoilFiveResponse): HintResult | null {

--- a/frontend/src/utils/hints/suecaHint.ts
+++ b/frontend/src/utils/hints/suecaHint.ts
@@ -8,7 +8,7 @@ import type { HintResult } from '../../types/hint';
  * Like Tute and Tressette, Sueca's hint is computed entirely by the Go backend
  * and surfaced on the response's `hint` field (with a `reason` i18n suffix).
  * This adapter re-maps that server hint into the frontend HintResult shape so
- * the shared {@link useGameHint} tooltip can render it. The `targetAction` is
+ * the shared {@link hooks/useGameHint.useGameHint | useGameHint} tooltip can render it. The `targetAction` is
  * fixed to `play` because the only action is playing a card.
  */
 export function getSuecaHint(state: SuecaResponse): HintResult | null {

--- a/frontend/src/utils/hints/tablanetHint.ts
+++ b/frontend/src/utils/hints/tablanetHint.ts
@@ -8,7 +8,7 @@ import type { HintResult } from '../../types/hint';
  * Tablanet's hint is computed entirely by the Go backend and surfaced on the
  * response's `hint` field (with a `reason` i18n suffix such as `tabla_sweep`,
  * `jack_sweep`, `capture`, or `trail_low`). This adapter re-maps that server hint
- * into the frontend HintResult shape so the shared {@link useGameHint} tooltip can
+ * into the frontend HintResult shape so the shared {@link hooks/useGameHint.useGameHint | useGameHint} tooltip can
  * render it. The `targetAction` is fixed to `play` because every hint points the
  * player at which card to play.
  */

--- a/frontend/src/utils/hints/teenPattiHint.ts
+++ b/frontend/src/utils/hints/teenPattiHint.ts
@@ -8,7 +8,7 @@ import type { HintResult } from '../../types/hint';
  * Like Three Card Brag, Teen Patti's hint is computed entirely by the Go
  * backend and surfaced on the response's `hint` field (with a `reason` i18n
  * suffix). This adapter re-maps that server hint into the frontend HintResult
- * shape so the shared {@link useGameHint} tooltip can render it. The hint
+ * shape so the shared {@link hooks/useGameHint.useGameHint | useGameHint} tooltip can render it. The hint
  * carries an `action` string (`see`, `bet`, `raise`, `fold`, `show`, or
  * `sideshow`) used as the `targetAction`.
  */

--- a/frontend/src/utils/hints/threeCardBragHint.ts
+++ b/frontend/src/utils/hints/threeCardBragHint.ts
@@ -8,7 +8,7 @@ import type { HintResult } from '../../types/hint';
  * Like Mus and Écarté, Three Card Brag's hint is computed entirely by the Go
  * backend and surfaced on the response's `hint` field (with a `reason` i18n
  * suffix). This adapter re-maps that server hint into the frontend HintResult
- * shape so the shared {@link useGameHint} tooltip can render it. The hint
+ * shape so the shared {@link hooks/useGameHint.useGameHint | useGameHint} tooltip can render it. The hint
  * carries an `action` string (`see`, `bet`, `raise`, `fold`, or `show`) used as
  * the `targetAction`.
  */

--- a/frontend/src/utils/hints/tienlenHint.ts
+++ b/frontend/src/utils/hints/tienlenHint.ts
@@ -4,7 +4,7 @@ import type { HintResult } from '../../types/hint';
 /**
  * Returns null — Tien Len's optimal play depends on combination evaluation,
  * chop timing, and opponent modeling that the client does not perform.
- * Keeping an explicit stub so the game is registered in {@link useGameHint}
+ * Keeping an explicit stub so the game is registered in {@link hooks/useGameHint.useGameHint | useGameHint}
  * and the hint toggle UI stays consistent across the suite.
  */
 export function getTienLenHint(_state: TienLenResponse): HintResult | null {

--- a/frontend/src/utils/hints/trashHint.ts
+++ b/frontend/src/utils/hints/trashHint.ts
@@ -4,7 +4,7 @@ import type { HintResult } from '../../types/hint';
 /**
  * Returns null — Trash has no decisional hint beyond wild placement, which is
  * driven directly by the UI affordance (clicking a face-down slot). Keeping an
- * explicit stub so the game is registered in {@link useGameHint} and the hint
+ * explicit stub so the game is registered in {@link hooks/useGameHint.useGameHint | useGameHint} and the hint
  * toggle UI remains consistent across the suite.
  */
 export function getTrashHint(_state: TrashResponse): HintResult | null {

--- a/frontend/src/utils/hints/tuteHint.ts
+++ b/frontend/src/utils/hints/tuteHint.ts
@@ -8,7 +8,7 @@ import type { HintResult } from '../../types/hint';
  * Like Doppelkopf and Sheepshead, Tute's hint is computed entirely by the Go
  * backend and surfaced on the response's `hint` field (with a `reason` i18n
  * suffix). This adapter re-maps that server hint into the frontend HintResult
- * shape so the shared {@link useGameHint} tooltip can render it. The
+ * shape so the shared {@link hooks/useGameHint.useGameHint | useGameHint} tooltip can render it. The
  * `targetAction` is fixed to `play` because the in-page tooltip only annotates
  * the play step.
  */

--- a/frontend/src/utils/hints/twentyNineHint.ts
+++ b/frontend/src/utils/hints/twentyNineHint.ts
@@ -8,7 +8,7 @@ import type { HintResult } from '../../types/hint';
  * Like Auction Forty-Fives, Twenty-Nine's hint is computed entirely by the Go
  * backend and surfaced on the response's `hint` field (with a `reason` i18n
  * suffix). This adapter re-maps that server hint into the frontend HintResult
- * shape so the shared {@link useGameHint} tooltip can render it. The
+ * shape so the shared {@link hooks/useGameHint.useGameHint | useGameHint} tooltip can render it. The
  * `targetAction` is fixed to `play` because the hint only applies during the
  * trick-play phase.
  */

--- a/frontend/src/utils/hints/tysiacHint.ts
+++ b/frontend/src/utils/hints/tysiacHint.ts
@@ -10,7 +10,7 @@ import type { HintResult } from '../../types/hint';
  * `lead_low`, `lead_marriage`, `follow_win`, `follow_duck`, `discard_low`,
  * `bid_raise`, `bid_pass`, or `talon_discard`). This adapter re-maps that
  * server hint into the frontend HintResult shape so the shared
- * {@link useGameHint} tooltip can render it. The `targetAction` is fixed to
+ * {@link hooks/useGameHint.useGameHint | useGameHint} tooltip can render it. The `targetAction` is fixed to
  * `play` because every hint ultimately points the player at a card.
  */
 export function getTysiacHint(state: TysiacResponse): HintResult | null {

--- a/frontend/src/utils/hints/ultiHint.ts
+++ b/frontend/src/utils/hints/ultiHint.ts
@@ -9,7 +9,7 @@ import type { HintResult } from '../../types/hint';
  * the response's `hint` field (with a `reason` i18n suffix such as `lead_high`,
  * `lead_low`, `follow_win`, `follow_duck`, `discard_low`, `discard_weak`,
  * `bid_party`, `bid_betli`, or `bid_durchmarsch`). This adapter re-maps that
- * server hint into the frontend HintResult shape so the shared {@link useGameHint}
+ * server hint into the frontend HintResult shape so the shared {@link hooks/useGameHint.useGameHint | useGameHint}
  * tooltip can render it. The `targetAction` is fixed to `play` because every hint
  * ultimately points the player at a card.
  */

--- a/frontend/src/utils/hints/wattenHint.ts
+++ b/frontend/src/utils/hints/wattenHint.ts
@@ -10,7 +10,7 @@ import type { HintResult } from '../../types/hint';
  * `hold`, or `fold` and whose `reason` is an i18n suffix such as
  * `declare_strong`, `raise_strong`, `lead_trump`, `lead_plain`, `follow_win`,
  * `follow_dump`, `hold_ok`, or `fold_weak`. This adapter re-maps the server hint
- * into the frontend HintResult shape so the shared {@link useGameHint} tooltip
+ * into the frontend HintResult shape so the shared {@link hooks/useGameHint.useGameHint | useGameHint} tooltip
  * can render it; `targetAction` mirrors the server's action.
  */
 export function getWattenHint(state: WattenResponse): HintResult | null {

--- a/frontend/src/utils/settingsItems.ts
+++ b/frontend/src/utils/settingsItems.ts
@@ -2,7 +2,7 @@ import type { SettingsItem } from '../components/common/SettingsPanel';
 
 /**
  * Builds the standard "frontend hint" checkbox item for a game's
- * {@link SettingsPanel}.
+ * {@link components/common/SettingsPanel.SettingsPanel | SettingsPanel}.
  *
  * Consolidates the identical `{ type: 'checkbox', id: 'frontendHint', … }`
  * object literal that was duplicated across ~147 game pages (issue #4302).


### PR DESCRIPTION
First of two PRs clearing TypeDoc's warnings. **142 → 84**; all 58 "Failed to resolve link" warnings are gone. The remaining 84 are a different problem (types used in public signatures but not exported) and follow separately.

## Why they failed

TypeDoc resolves a bare `{@link X}` through TypeScript, so `X` has to be in the **declaring module's scope**. 51 of the 58 are `{@link useGameHint}` in the per-game hint utils, which mention the hook in prose and never import it — so every one of them silently rendered as plain text where a link was intended. The other 7 are the same thing for `useTrickGameBase`, `useGamePageSetup`, `useBodyScrollLock`, `runReplay`, `SettingsPanel`, `KbdBadge`, `GameResetDialog`.

## Why not just import them

Adding an import to satisfy a doc comment creates a **real module dependency** — a hint util would start depending on a React hook, with a plausible cycle — for documentation's sake. The module-qualified form needs no import:

```diff
- * ...the shared {@link useGameHint} tooltip
+ * ...the shared {@link hooks/useGameHint.useGameHint | useGameHint} tooltip
```

## The syntax was chosen by experiment, not by guessing

Three candidate forms went into three different files in a single docs run:

| form | result |
|---|---|
| `{@link hooks/useGameHint.useGameHint}` | ✅ resolved |
| `{@link !useGameHint}` | ❌ still failed |
| `{@link ../../hooks/useGameHint!useGameHint}` | ❌ still failed |

Guessing here would have meant rewriting 58 files and finding out afterwards.

The explicit display text after `|` is not cosmetic housekeeping — without it the rendered link text becomes the entire path, so the sentence would read *"the shared hooks/useGameHint.useGameHint tooltip"*.

## Verified positively, not by warning count alone

A link TypeDoc quietly declines to emit produces zero warnings too, so the generated HTML was checked directly. Where these pages previously had bare text they now carry real anchors:

```html
<a href="hooks_useGameHint.useGameHint.html" class="tsd-kind-function">useGameHint</a>
<a href="hooks_gameReplay.runReplay.html" class="tsd-kind-function">runReplay</a>
<a href="components_common_SettingsPanel.SettingsPanel.html" class="tsd-kind-function">SettingsPanel</a>
```

## Test plan

- [x] `bun run docs:generate` — 0 errors, **0 "Failed to resolve link"** (was 58)
- [x] Anchors verified in the generated HTML (above)
- [x] `bun run typecheck` — clean
- [x] `bun run check` — clean

Comment-only changes; no runtime code touched.