### PR TITLE
docs(frontend): export the types that appear in public signatures

### DIFF
--- a/frontend/src/api/gameApi.ts
+++ b/frontend/src/api/gameApi.ts
@@ -759,7 +759,7 @@ export interface HoldemConfigInput {
 }
 
 /** Command set shared by Hold'em-family games. */
-type HoldemLikeCommand =
+export type HoldemLikeCommand =
   | 'reset'
   | 'fold'
   | 'check'
@@ -775,7 +775,7 @@ type HoldemLikeCommand =
   | 'show';
 
 /** Factory for Hold'em-family APIs that share the same exec pattern. */
-function createHoldemLikeApi<T, C = HoldemConfigInput>(game: string) {
+export function createHoldemLikeApi<T, C = HoldemConfigInput>(game: string) {
   return {
     exec: (command: HoldemLikeCommand, amount?: number, config?: C, humanPlayMs?: number, profile?: unknown) =>
       gameExec<T>(game, { command, amount, humanPlayMs, profile, ...(config as Record<string, unknown>) }),
@@ -5174,7 +5174,8 @@ export const kalookiApi = {
   ) => gameExec<KalookiResponse>('kalooki', { command, ...(params ?? {}) }),
 };
 
-const games = [
+/** Every registered game name — the SSoT the {@link Game} union is derived from. */
+export const games = [
   'blackjack',
   'poker',
   'oldmaid',
@@ -5395,7 +5396,8 @@ const games = [
   'koenigrufen',
   'zheng',
 ] as const;
-type Game = (typeof games)[number];
+/** Union of every registered game name — the keys of the `games` list. */
+export type Game = (typeof games)[number];
 
 /** API clients for fetching action logs from each game's /log endpoint. */
 export const actionLogApi: { [K in Game]: () => Promise<ActionLogResponse> } = games.reduce(

--- a/frontend/src/components/ActionLogPanel.tsx
+++ b/frontend/src/components/ActionLogPanel.tsx
@@ -4,7 +4,8 @@ import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
 import type { ActionLogEntry } from '../types/card';
 import { cardLabel } from '../utils/cardUtils';
 
-interface ActionLogPanelProps {
+/** Props for {@link ActionLogPanel}. */
+export interface ActionLogPanelProps {
   entries: ActionLogEntry[];
   onClose: () => void;
 }

--- a/frontend/src/components/ActionLogSection.tsx
+++ b/frontend/src/components/ActionLogSection.tsx
@@ -3,7 +3,8 @@ import { btnSecondary } from '../styles/buttonStyles';
 import type { ActionLogEntry } from '../types/card';
 import { ActionLogPanel } from './ActionLogPanel';
 
-interface ActionLogSectionProps {
+/** Props for {@link ActionLogSection}. */
+export interface ActionLogSectionProps {
   isEndPhase: boolean;
   actionLog: ActionLogEntry[] | null;
   showActionLog: () => void;

--- a/frontend/src/components/BettingControls.tsx
+++ b/frontend/src/components/BettingControls.tsx
@@ -5,7 +5,8 @@ import { btnPokerAccent, btnPokerAllIn, btnPokerMuted, btnPokerPrimary } from '.
 import { ChipBetInput } from './common/ChipBetInput';
 import { KbdBadge } from './KbdBadge';
 
-interface BettingControlsProps {
+/** Props for {@link BettingControls}. */
+export interface BettingControlsProps {
   inputId: string;
   betAmount: number;
   onBetAmountChange: (v: number) => void;

--- a/frontend/src/components/CardFace.tsx
+++ b/frontend/src/components/CardFace.tsx
@@ -19,7 +19,8 @@ function inkColor(color?: string): string {
   return (color && INK_COLORS[color]) || INK_COLORS.black;
 }
 
-interface CardFaceProps {
+/** Props for {@link CardFace}. */
+export interface CardFaceProps {
   card: Card;
   width?: number;
   style?: React.CSSProperties;

--- a/frontend/src/components/CardImage.tsx
+++ b/frontend/src/components/CardImage.tsx
@@ -22,7 +22,8 @@ function getImagePath(card: Card): string {
   return `/images/${prefix}${zeroPad(card.value)}.png`;
 }
 
-interface CardImageProps {
+/** Props for {@link CardImage}. */
+export interface CardImageProps {
   card: Card;
   width?: number;
   style?: React.CSSProperties;
@@ -94,7 +95,8 @@ export function CardImage({
   );
 }
 
-interface CardBackProps {
+/** Props for {@link CardBack}. */
+export interface CardBackProps {
   width?: number;
   style?: React.CSSProperties;
   className?: string;

--- a/frontend/src/components/CpuAccordion.tsx
+++ b/frontend/src/components/CpuAccordion.tsx
@@ -1,7 +1,8 @@
 import { useTranslation } from 'react-i18next';
 import { useIsMobile } from '../hooks/useCardDimensions';
 
-interface CpuAccordionProps {
+/** Props for {@link CpuAccordion}. */
+export interface CpuAccordionProps {
   children: React.ReactNode;
   playerCount: number;
   dataTutorial?: string;

--- a/frontend/src/components/CpuActionBubble.tsx
+++ b/frontend/src/components/CpuActionBubble.tsx
@@ -2,7 +2,8 @@ import { useEffect, useRef, useState } from 'react';
 import { useReducedMotion } from '../hooks/useReducedMotion';
 import { TOAST_DURATION } from '../styles/toastDurations';
 
-interface CpuActionBubbleProps {
+/** Props for {@link CpuActionBubble}. */
+export interface CpuActionBubbleProps {
   /** Text shown in the bubble. Pass an empty string or undefined to hide. */
   message: string | undefined;
   /**

--- a/frontend/src/components/CpuActionLog.tsx
+++ b/frontend/src/components/CpuActionLog.tsx
@@ -1,7 +1,8 @@
 import { useTranslation } from 'react-i18next';
 import { bettingActionName } from '../styles/gameConstants';
 
-interface CpuActionLogProps {
+/** Props for {@link CpuActionLog}. */
+export interface CpuActionLogProps {
   actions: { playerIdx: number; action: number; amount: number }[] | undefined;
 }
 

--- a/frontend/src/components/CpuActionToast.tsx
+++ b/frontend/src/components/CpuActionToast.tsx
@@ -4,7 +4,8 @@ import { bettingActionName } from '../styles/gameConstants';
 import { TOAST_DURATION } from '../styles/toastDurations';
 import { Toast } from './Toast';
 
-interface CpuActionToastProps {
+/** Props for {@link CpuActionToast}. */
+export interface CpuActionToastProps {
   actions: { playerIdx: number; action: number; amount: number }[] | undefined;
 }
 

--- a/frontend/src/components/CpuPlayerCard.tsx
+++ b/frontend/src/components/CpuPlayerCard.tsx
@@ -21,7 +21,8 @@ export interface CpuMetaAiProp {
   edgePickRate?: number;
 }
 
-interface CpuPlayerCardProps {
+/** Props for {@link CpuPlayerCard}. */
+export interface CpuPlayerCardProps {
   player: {
     id: number;
     playStyleName: string;

--- a/frontend/src/components/CpuTurnArea.tsx
+++ b/frontend/src/components/CpuTurnArea.tsx
@@ -3,7 +3,8 @@ import { activeTurnClass, finishedPlayerClass } from '../styles/gameConstants';
 import { playerName } from '../utils/playerUtils';
 import { StatusBadge } from './StatusBadge';
 
-interface CpuTurnAreaProps {
+/** Props for {@link CpuTurnArea}. */
+export interface CpuTurnAreaProps {
   id?: string;
   playerId: number;
   isHuman: boolean;

--- a/frontend/src/components/DropZone.tsx
+++ b/frontend/src/components/DropZone.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
 
 /** Props for the DropZone wrapper component. */
-interface DropZoneProps {
+export interface DropZoneProps {
   /** Whether this zone is the currently active drop target (for highlighting). */
   isDropTarget: boolean;
   /** Handler invoked on dragOver (should call preventDefault to allow drop). */

--- a/frontend/src/components/EquityDisplay.tsx
+++ b/frontend/src/components/EquityDisplay.tsx
@@ -2,7 +2,8 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { HoldemEquity } from '../types/card';
 
-interface EquityDisplayProps {
+/** Props for {@link EquityDisplay}. */
+export interface EquityDisplayProps {
   equity: HoldemEquity;
   potOdds: number;
 }

--- a/frontend/src/components/ErrorAlert.tsx
+++ b/frontend/src/components/ErrorAlert.tsx
@@ -2,7 +2,8 @@ import { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useOptionalSound } from '../providers/SoundProvider';
 
-interface ErrorAlertProps {
+/** Props for {@link ErrorAlert}. */
+export interface ErrorAlertProps {
   message: string | null;
   onRetry?: () => void;
 }

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -4,7 +4,8 @@ import type { WithTranslation } from 'react-i18next';
 import { withTranslation } from 'react-i18next';
 import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
 
-interface ErrorBoundaryProps extends WithTranslation {
+/** Props for {@link ErrorBoundary}, injected via `withTranslation()`. */
+export interface ErrorBoundaryProps extends WithTranslation {
   children: ReactNode;
 }
 

--- a/frontend/src/components/GameFooter.tsx
+++ b/frontend/src/components/GameFooter.tsx
@@ -1,4 +1,5 @@
-interface GameFooterProps {
+/** Props for {@link GameFooter}. */
+export interface GameFooterProps {
   className?: string;
   children: React.ReactNode;
   /** When true, applies glassmorphism + rounded top corners + scroll on mobile. */

--- a/frontend/src/components/GameMessageBox.tsx
+++ b/frontend/src/components/GameMessageBox.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next';
 
-interface GameMessageBoxProps {
+/** Props for {@link GameMessageBox}. */
+export interface GameMessageBoxProps {
   message: string | undefined;
   messageCode?: string;
   messageParams?: Record<string, string>;

--- a/frontend/src/components/GamePageShell.tsx
+++ b/frontend/src/components/GamePageShell.tsx
@@ -11,7 +11,7 @@ import { PhaseIndicator } from './PhaseIndicator';
 import { TutorialButton } from './tutorial/TutorialButton';
 
 /** Base props for the GamePageShell component (everything except the give-up trio). */
-interface GamePageShellBaseProps {
+export interface GamePageShellBaseProps {
   /** Page title rendered as a visually-hidden h1 heading. */
   title: string;
   /** Tailwind background class for the outer container (e.g., gameTheme.hearts.bg). */
@@ -82,7 +82,7 @@ interface GamePageShellBaseProps {
  * wiring a compile error rather than a silently no-op dialog (issue #2099,
  * PR #2108 review).
  */
-type GiveUpConfirmProps =
+export type GiveUpConfirmProps =
   | { giveUpConfirmOpen?: undefined; confirmGiveUp?: undefined; cancelGiveUp?: undefined }
   | {
       /** Whether the give-up confirmation dialog is open. */

--- a/frontend/src/components/HudStats.tsx
+++ b/frontend/src/components/HudStats.tsx
@@ -11,7 +11,7 @@ import { useTranslation } from 'react-i18next';
  * color-coded triage so casual players can enjoy the CPU style variation
  * (TAG / LAG / GTO etc.) without studying definitions first. See issue #1564.
  */
-type Tendency = 'tight' | 'normal' | 'loose' | 'passive' | 'balanced' | 'aggressive';
+export type Tendency = 'tight' | 'normal' | 'loose' | 'passive' | 'balanced' | 'aggressive';
 
 /**
  * StatTooltip renders a label that reveals a tooltip on hover/focus.
@@ -156,7 +156,7 @@ function tendencyClass(t: Tendency): string {
  * that lets variant pages (e.g. crazypineapple sharing logic with
  * pineapple) reuse this component without duplicating tooltip copy.
  */
-type HudStatsProps = {
+export type HudStatsProps = {
   vpip: number;
   pfr: number;
   threeBet: number;

--- a/frontend/src/components/LandscapeBanner.tsx
+++ b/frontend/src/components/LandscapeBanner.tsx
@@ -1,5 +1,5 @@
 /** Props for the LandscapeBanner component. */
-interface LandscapeBannerProps {
+export interface LandscapeBannerProps {
   /** The message to display in the banner. */
   message: string;
 }

--- a/frontend/src/components/MobileHandGrid.tsx
+++ b/frontend/src/components/MobileHandGrid.tsx
@@ -28,7 +28,7 @@ const MIN_CARD_EXPOSURE_PX = 44;
 const DEAL_IN_STAGGER_S = 0.12;
 
 /** Props for the MobileHandGrid component. */
-interface MobileHandGridProps {
+export interface MobileHandGridProps {
   /** Cards to display. */
   cards: Card[];
   /** Indices of currently selected cards. */

--- a/frontend/src/components/PhaseIndicator.tsx
+++ b/frontend/src/components/PhaseIndicator.tsx
@@ -1,7 +1,8 @@
 import type { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 
-interface PhaseIndicatorProps {
+/** Props for {@link PhaseIndicator}. */
+export interface PhaseIndicatorProps {
   phaseName: string;
   isHumanTurn?: boolean;
   children?: ReactNode;

--- a/frontend/src/components/PokerTableLayout.tsx
+++ b/frontend/src/components/PokerTableLayout.tsx
@@ -1,7 +1,8 @@
 import type { ReactNode } from 'react';
 import { useIsLargeDesktop } from '../hooks/useCardDimensions';
 
-interface PokerTableLayoutProps {
+/** Props for {@link PokerTableLayout}. */
+export interface PokerTableLayoutProps {
   communityCards: ReactNode;
   cpuPlayers: ReactNode;
   cpuAreaTutorial?: string;

--- a/frontend/src/components/RoundResults.tsx
+++ b/frontend/src/components/RoundResults.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next';
 
-interface RoundResultEntry {
+/** One player's line in a round-result table. */
+export interface RoundResultEntry {
   playerIdx: number;
   handName: string;
   kickers?: string;
@@ -8,7 +9,8 @@ interface RoundResultEntry {
   mucked?: boolean;
 }
 
-interface RoundResultsProps {
+/** Props for {@link RoundResults}. */
+export interface RoundResultsProps {
   results: RoundResultEntry[] | undefined;
   players: { isHuman: boolean }[];
 }

--- a/frontend/src/components/RoundScoreAnnouncement.tsx
+++ b/frontend/src/components/RoundScoreAnnouncement.tsx
@@ -7,7 +7,8 @@ export interface RoundScoreEntry {
   cumulativeScore: number;
 }
 
-interface RoundScoreAnnouncementProps {
+/** Props for {@link RoundScoreAnnouncement}. */
+export interface RoundScoreAnnouncementProps {
   active: boolean;
   entries: RoundScoreEntry[];
 }

--- a/frontend/src/components/SkipNavLink.tsx
+++ b/frontend/src/components/SkipNavLink.tsx
@@ -1,5 +1,5 @@
 /** Props for the SkipNavLink component. */
-interface SkipNavLinkProps {
+export interface SkipNavLinkProps {
   /** The id of the target element to skip to. */
   targetId: string;
   /** The visible label text for the skip link. */

--- a/frontend/src/components/TonkOnDealCelebration.tsx
+++ b/frontend/src/components/TonkOnDealCelebration.tsx
@@ -4,7 +4,8 @@ import { useTranslation } from 'react-i18next';
 import { useReducedMotion } from '../hooks/useReducedMotion';
 import type { Card } from '../types/card';
 
-interface TonkOnDealCelebrationProps {
+/** Props for {@link TonkOnDealCelebration}. */
+export interface TonkOnDealCelebrationProps {
   /** Whether the player or CPU achieved Tonk on the deal. */
   show: boolean;
   /** Cards that produced the Tonk total — used to compute the 49 / 50 sum displayed. */

--- a/frontend/src/components/cli/CliTerminal.tsx
+++ b/frontend/src/components/cli/CliTerminal.tsx
@@ -5,7 +5,7 @@ import type { CliLogEntry } from '../../utils/cli/types';
 const MAX_HISTORY = 50;
 
 /** Props for the CliTerminal component. */
-interface CliTerminalProps {
+export interface CliTerminalProps {
   /** Log entries to display. */
   logEntries: CliLogEntry[];
   /** Callback when the user submits a command. */

--- a/frontend/src/components/cli/CliToggle.tsx
+++ b/frontend/src/components/cli/CliToggle.tsx
@@ -45,7 +45,7 @@ function GuiIcon() {
 }
 
 /** Props for the CliToggle component. */
-interface CliToggleProps {
+export interface CliToggleProps {
   /** Whether CLI mode is currently enabled. */
   cliEnabled: boolean;
   /** Callback to toggle CLI mode. */

--- a/frontend/src/components/common/SettingsPanel.tsx
+++ b/frontend/src/components/common/SettingsPanel.tsx
@@ -26,7 +26,8 @@ export interface SettingsGroup {
   items: SettingsItem[];
 }
 
-interface SettingsPanelProps {
+/** Props for {@link SettingsPanel}. */
+export interface SettingsPanelProps {
   title: string;
   groups: SettingsGroup[];
 }

--- a/frontend/src/components/daifugo/DaifugoHumanArea.tsx
+++ b/frontend/src/components/daifugo/DaifugoHumanArea.tsx
@@ -7,7 +7,8 @@ import { CardImage } from '../CardImage';
 import { StatusBadge } from '../StatusBadge';
 import { playerAreaClass } from './DaifugoCpuArea';
 
-interface HumanPlayerAreaProps {
+/** Props for {@link DaifugoHumanArea}. */
+export interface HumanPlayerAreaProps {
   player: DaifugoPlayerData;
   selectedIndices: number[];
   onToggle: (idx: number) => void;

--- a/frontend/src/components/daifugo/DaifugoSettingsPanel.tsx
+++ b/frontend/src/components/daifugo/DaifugoSettingsPanel.tsx
@@ -3,7 +3,8 @@ import type { DaifugoConfigInput } from '../../types/card';
 import type { SettingsGroup } from '../common/SettingsPanel';
 import { SettingsPanel } from '../common/SettingsPanel';
 
-interface DaifugoSettingsPanelProps {
+/** Props for {@link DaifugoSettingsPanel}. */
+export interface DaifugoSettingsPanelProps {
   config: DaifugoConfigInput;
   onChange: (key: keyof DaifugoConfigInput, value: boolean | number) => void;
 }

--- a/frontend/src/components/doubt/CountdownBar.tsx
+++ b/frontend/src/components/doubt/CountdownBar.tsx
@@ -1,7 +1,7 @@
 import { useReducedMotion } from '../../hooks/useReducedMotion';
 
 /** Props for the CountdownBar component. */
-interface CountdownBarProps {
+export interface CountdownBarProps {
   /** Seconds remaining in the countdown. */
   remaining: number;
   /** Total countdown duration in seconds. */

--- a/frontend/src/components/doubt/DoubtHandCard.tsx
+++ b/frontend/src/components/doubt/DoubtHandCard.tsx
@@ -3,7 +3,8 @@ import { focusRingCard, selectedCardStyle } from '../../styles/cardStyles';
 import type { Card } from '../../types/card';
 import { CardImage } from '../CardImage';
 
-interface HandCardProps {
+/** Props for {@link DoubtHandCard}. */
+export interface HandCardProps {
   card: Card;
   index: number;
   selected: boolean;

--- a/frontend/src/components/gofish/GoFishBooksDisplay.tsx
+++ b/frontend/src/components/gofish/GoFishBooksDisplay.tsx
@@ -2,7 +2,8 @@ import { useTranslation } from 'react-i18next';
 import type { GoFishBook } from '../../types/card';
 import { valueName } from '../../utils/cardUtils';
 
-interface GoFishBooksDisplayProps {
+/** Props for {@link GoFishBooksDisplay}. */
+export interface GoFishBooksDisplayProps {
   books: GoFishBook[];
 }
 

--- a/frontend/src/components/gofish/GoFishPlayerArea.tsx
+++ b/frontend/src/components/gofish/GoFishPlayerArea.tsx
@@ -14,7 +14,8 @@ export interface GoFishAskAnnotation {
   triggerKey: string | number;
 }
 
-interface GoFishPlayerAreaProps {
+/** Props for {@link GoFishPlayerArea}. */
+export interface GoFishPlayerAreaProps {
   player: GoFishPlayerData;
   isSelected: boolean;
   onSelect: (idx: number) => void;

--- a/frontend/src/components/motion/AnimatedCard.tsx
+++ b/frontend/src/components/motion/AnimatedCard.tsx
@@ -5,7 +5,8 @@ import { useOptionalSound } from '../../providers/SoundProvider';
 import { dealSpring, hoverLift, selectLift } from '../../styles/motionPresets';
 import { CardImage } from '../CardImage';
 
-interface AnimatedCardProps extends React.ComponentProps<typeof CardImage> {
+/** Props for {@link AnimatedCard}. */
+export interface AnimatedCardProps extends React.ComponentProps<typeof CardImage> {
   /** Stagger delay in seconds for deal animation. */
   dealDelay?: number;
   /** Whether this card is selected (lift + glow). */

--- a/frontend/src/components/motion/AnimatedCardBack.tsx
+++ b/frontend/src/components/motion/AnimatedCardBack.tsx
@@ -5,7 +5,8 @@ import { useOptionalSound } from '../../providers/SoundProvider';
 import { flipSpring } from '../../styles/motionPresets';
 import { CardBack } from '../CardImage';
 
-interface AnimatedCardBackProps extends React.ComponentProps<typeof CardBack> {
+/** Props for {@link AnimatedCardBack}. */
+export interface AnimatedCardBackProps extends React.ComponentProps<typeof CardBack> {
   /** Stagger delay in seconds for deal animation. */
   dealDelay?: number;
   /** Shared layout animation ID. */

--- a/frontend/src/components/motion/AnimatedPile.tsx
+++ b/frontend/src/components/motion/AnimatedPile.tsx
@@ -12,7 +12,8 @@ const CASCADE_BATCH_DELAY = 0.4;
 /** Stagger between cards within a batch in seconds. */
 const CASCADE_CARD_STAGGER = 0.08;
 
-interface AnimatedPileProps {
+/** Props for {@link AnimatedPile}. */
+export interface AnimatedPileProps {
   /** Cards in this pile (bottom to top). */
   cards: Card[];
   /** Layout mode: stacked (overlapping) or fanned (spread). */

--- a/frontend/src/components/motion/LossFeedback.tsx
+++ b/frontend/src/components/motion/LossFeedback.tsx
@@ -2,7 +2,8 @@ import { motion } from 'framer-motion';
 import { useTranslation } from 'react-i18next';
 import { useReducedMotion } from '../../hooks/useReducedMotion';
 
-interface LossFeedbackProps {
+/** Props for {@link LossFeedback}. */
+export interface LossFeedbackProps {
   /** Whether to show the loss feedback. */
   show: boolean;
 }

--- a/frontend/src/components/motion/WinCelebration.tsx
+++ b/frontend/src/components/motion/WinCelebration.tsx
@@ -3,7 +3,8 @@ import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useReducedMotion } from '../../hooks/useReducedMotion';
 
-interface WinCelebrationProps {
+/** Props for {@link WinCelebration}. */
+export interface WinCelebrationProps {
   /** Whether to show the celebration animation. */
   show: boolean;
   /** Delay in ms before particles appear. Default: 400 (the "tension beat"). */

--- a/frontend/src/components/nav/FavoriteToggleButton.tsx
+++ b/frontend/src/components/nav/FavoriteToggleButton.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next';
 
-interface FavoriteToggleButtonProps {
+/** Props for {@link FavoriteToggleButton}. */
+export interface FavoriteToggleButtonProps {
   /** Game route path (e.g. "/blackjack") used as the favorite key passed to onToggle. */
   path: string;
   /** Whether the path is currently a favorite. Drives the ★/☆ glyph and aria-pressed. */

--- a/frontend/src/components/nav/NavLangToggle.tsx
+++ b/frontend/src/components/nav/NavLangToggle.tsx
@@ -3,7 +3,8 @@ import { useTranslation } from 'react-i18next';
 /** Size variant — `'md'` matches the NavBar (44 px touch target), `'sm'` matches the desktop sidebar. */
 export type NavLangToggleSize = 'sm' | 'md';
 
-interface NavLangToggleProps {
+/** Props for {@link NavLangToggle}. */
+export interface NavLangToggleProps {
   /** Visual size; defaults to `'md'` to preserve mobile/tablet touch target. */
   size?: NavLangToggleSize;
 }

--- a/frontend/src/components/oldmaid/OldMaidPlayerArea.tsx
+++ b/frontend/src/components/oldmaid/OldMaidPlayerArea.tsx
@@ -18,7 +18,8 @@ export interface PlayerAreaBubble {
 /** CSS class for Old Maid player area layout. */
 export const playerAreaClass = `${playerAreaBase} p-2 flex-[1_1_140px] min-w-[120px]`;
 
-interface PlayerAreaProps {
+/** Props for {@link OldMaidPlayerArea}. */
+export interface PlayerAreaProps {
   player: OldMaidPlayerData;
   isTarget: boolean;
   isHumanTurn: boolean;

--- a/frontend/src/components/oldmaid/OldMaidSettingsDialog.tsx
+++ b/frontend/src/components/oldmaid/OldMaidSettingsDialog.tsx
@@ -4,7 +4,7 @@ import { btnPrimary, btnSecondary } from '../../styles/buttonStyles';
 import { Modal } from '../common/Modal';
 
 /** Props for the OldMaidSettingsDialog component. */
-interface OldMaidSettingsDialogProps {
+export interface OldMaidSettingsDialogProps {
   open: boolean;
   mode: number;
   cpuPlacementStrategy: boolean;

--- a/frontend/src/components/sevens/SevensBoard.tsx
+++ b/frontend/src/components/sevens/SevensBoard.tsx
@@ -4,7 +4,8 @@ import { suitName, valueName } from '../../utils/cardUtils';
 import { isPositionPlaced, isPositionPlayable, SUITS } from '../../utils/sevensUtils';
 import { ScrollFadeHint } from '../ScrollFadeHint';
 
-interface BoardProps {
+/** Props for {@link SevensBoard}. */
+export interface BoardProps {
   tablePlaced: number[];
   tunnelEnabled: boolean;
   tunnelSkipWidth: number;

--- a/frontend/src/components/sevens/SevensHumanArea.tsx
+++ b/frontend/src/components/sevens/SevensHumanArea.tsx
@@ -9,7 +9,8 @@ import { isCardPlayable, playerAreaClass } from '../../utils/sevensUtils';
 import { CardImage } from '../CardImage';
 import { StatusBadge } from '../StatusBadge';
 
-interface HumanAreaProps {
+/** Props for {@link SevensHumanArea}. */
+export interface HumanAreaProps {
   player: SevensPlayerData;
   isCurrentTurn: boolean;
   tablePlaced: number[];

--- a/frontend/src/components/skeleton/GameSkeleton.tsx
+++ b/frontend/src/components/skeleton/GameSkeleton.tsx
@@ -6,7 +6,7 @@ import { SkeletonHand } from './SkeletonHand';
 import { SkeletonShell } from './SkeletonShell';
 
 /** Centered hand sections (BlackJack/Baccarat-style table games). */
-interface CasinoTableLayout {
+export interface CasinoTableLayout {
   kind: 'casino-table';
   /** Number of cards per centered hand section (one section per entry). */
   sections: number[];
@@ -21,7 +21,7 @@ interface CasinoTableLayout {
 }
 
 /** Optional community cards + opponent boxes + footer hand (Hold'em-style poker). */
-interface CommunityPokerLayout {
+export interface CommunityPokerLayout {
   kind: 'community-poker';
   /** Cards in the community-card row. Omit to hide the row. */
   community?: number;
@@ -34,7 +34,7 @@ interface CommunityPokerLayout {
 }
 
 /** Title bar + opponent rows + optional trick area + footer hand (most trick-taking & matching games). */
-interface TrickTakingLayout {
+export interface TrickTakingLayout {
   kind: 'trick-taking';
   /** Number of opponent rows (default 3). */
   opponents?: number;
@@ -55,7 +55,7 @@ interface TrickTakingLayout {
 }
 
 /** Foundation-style top row + tableau columns (Klondike-style solitaire). */
-interface TableauLayout {
+export interface TableauLayout {
   kind: 'tableau';
   /** Cards in the top (foundation/stock/freecells) row. */
   topRow: number;
@@ -64,7 +64,7 @@ interface TableauLayout {
 }
 
 /** Triangle/columns of cards + optional stock-waste row (Pyramid/TriPeaks/Golf). */
-interface TieredRowsLayout {
+export interface TieredRowsLayout {
   kind: 'tiered-rows';
   /** Card counts per row. */
   rows: number[];
@@ -75,7 +75,7 @@ interface TieredRowsLayout {
 }
 
 /** Full grid of cards (Memory, Sevens). */
-interface CardGridLayout {
+export interface CardGridLayout {
   kind: 'card-grid';
   count: number;
   cols: string;
@@ -88,7 +88,7 @@ interface CardGridLayout {
 }
 
 /** Centered placeholder for War/PigsTail/FiftyOne. */
-interface CenteredLayout {
+export interface CenteredLayout {
   kind: 'centered';
   /** Card counts per row (centered). */
   rows: number[];

--- a/frontend/src/components/skeleton/SkeletonBar.tsx
+++ b/frontend/src/components/skeleton/SkeletonBar.tsx
@@ -1,4 +1,5 @@
-interface SkeletonBarProps {
+/** Props for {@link SkeletonBar}. */
+export interface SkeletonBarProps {
   height?: string;
   className?: string;
 }

--- a/frontend/src/components/skeleton/SkeletonCard.tsx
+++ b/frontend/src/components/skeleton/SkeletonCard.tsx
@@ -1,4 +1,5 @@
-interface SkeletonCardProps {
+/** Props for {@link SkeletonCard}. */
+export interface SkeletonCardProps {
   width: number;
   height: number;
   className?: string;

--- a/frontend/src/components/skeleton/SkeletonGrid.tsx
+++ b/frontend/src/components/skeleton/SkeletonGrid.tsx
@@ -1,4 +1,5 @@
-interface SkeletonGridProps {
+/** Props for {@link SkeletonGrid}. */
+export interface SkeletonGridProps {
   count: number;
   cols: string;
   aspectRatio?: string;

--- a/frontend/src/components/skeleton/SkeletonHand.tsx
+++ b/frontend/src/components/skeleton/SkeletonHand.tsx
@@ -1,6 +1,7 @@
 import { SkeletonCard } from './SkeletonCard';
 
-interface SkeletonHandProps {
+/** Props for {@link SkeletonHand}. */
+export interface SkeletonHandProps {
   cardWidth: number;
   cardHeight: number;
   count?: number;

--- a/frontend/src/components/skeleton/SkeletonShell.tsx
+++ b/frontend/src/components/skeleton/SkeletonShell.tsx
@@ -4,7 +4,7 @@ import { GameFooter } from '../GameFooter';
 import { SkeletonBar } from './SkeletonBar';
 
 /** Props for the shared game skeleton shell. */
-interface SkeletonShellProps {
+export interface SkeletonShellProps {
   /** Background color class for the outer wrapper (e.g. "bg-game-bg-green-bright"). */
   bgClass: string;
   /** Classes for the scrollable body area. Defaults to "pt-3 px-4". */

--- a/frontend/src/hooks/useActionKeyboardNav.ts
+++ b/frontend/src/hooks/useActionKeyboardNav.ts
@@ -1,13 +1,15 @@
 import { useEffect } from 'react';
 import { IGNORED_TAGS } from './keyboardNavUtils';
 
-interface ActionBinding {
+/** One keyboard shortcut bound to a game action. */
+export interface ActionBinding {
   key: string;
   action: () => void;
   enabled?: boolean;
 }
 
-interface UseActionKeyboardNavOptions {
+/** Options for {@link useActionKeyboardNav}. */
+export interface UseActionKeyboardNavOptions {
   bindings: ActionBinding[];
   enabled: boolean;
 }

--- a/frontend/src/hooks/useCardKeyboardNav.ts
+++ b/frontend/src/hooks/useCardKeyboardNav.ts
@@ -1,7 +1,8 @@
 import { useEffect } from 'react';
 import { IGNORED_TAGS } from './keyboardNavUtils';
 
-interface UseCardKeyboardNavOptions {
+/** Options for {@link useCardKeyboardNav}. */
+export interface UseCardKeyboardNavOptions {
   cardCount: number;
   onToggle: (index: number) => void;
   onConfirm: () => void;

--- a/frontend/src/hooks/useCliGame.ts
+++ b/frontend/src/hooks/useCliGame.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef } from 'react';
 import type { CliGameConfig } from '../utils/cli/types';
 
 /** Log callbacks provided by useCliMode. */
-interface CliLogCallbacks {
+export interface CliLogCallbacks {
   addInput: (text: string) => void;
   addOutput: (text: string) => void;
   addError: (text: string) => void;

--- a/frontend/src/hooks/useCommunityPokerGame.ts
+++ b/frontend/src/hooks/useCommunityPokerGame.ts
@@ -14,7 +14,7 @@ import { useMountReset } from './useMountReset';
 import { usePhaseNames } from './usePhaseNames';
 
 /** The exec function shared by every community-poker game API. */
-type CommunityPokerExec = HoldemLikeExec<OmahaResponse>;
+export type CommunityPokerExec = HoldemLikeExec<OmahaResponse>;
 
 /** Community-card poker games sharing the Hold'em response shape + phase enum. */
 export type CommunityPokerName = 'holdem' | 'omaha' | 'omahahilo' | 'bigo' | 'bigohilo' | 'shortdeck';

--- a/frontend/src/hooks/useGameConfig.ts
+++ b/frontend/src/hooks/useGameConfig.ts
@@ -1,10 +1,10 @@
 import { useCallback, useState } from 'react';
 
 /** Extracts keys of T whose values extend number. */
-type NumberKeys<T> = { [K in keyof T]: T[K] extends number ? K : never }[keyof T];
+export type NumberKeys<T> = { [K in keyof T]: T[K] extends number ? K : never }[keyof T];
 
 /** Extracts keys of T whose values extend boolean. */
-type BooleanKeys<T> = { [K in keyof T]: T[K] extends boolean ? K : never }[keyof T];
+export type BooleanKeys<T> = { [K in keyof T]: T[K] extends boolean ? K : never }[keyof T];
 
 /** Generic hook for managing game configuration state with number parsing and boolean toggling. */
 export function useGameConfig<T extends object>(defaultConfig: T) {

--- a/frontend/src/hooks/useGameHint.ts
+++ b/frontend/src/hooks/useGameHint.ts
@@ -361,7 +361,7 @@ import { useLocalStorageToggle } from './useLocalStorageToggle';
 type HintFn = (state: unknown) => HintResult | null;
 
 /** Registry mapping game names to their hint functions. */
-const hintFactories = {
+export const hintFactories = {
   baccarat: (s) => getBaccaratHint(s as BaccaratResponse),
   blackjack: (s) => getBlackjackHint(s as BlackJackResponse),
   spanish21: (s) => getBlackjackHint(s as BlackJackResponse),

--- a/frontend/src/hooks/useSolitaireDragDrop.ts
+++ b/frontend/src/hooks/useSolitaireDragDrop.ts
@@ -1,7 +1,7 @@
 import { useCallback, useState } from 'react';
 
 /** Options for the solitaire drag-and-drop hook. */
-interface UseSolitaireDragDropOptions<T> {
+export interface UseSolitaireDragDropOptions<T> {
   /** Callback invoked when a card is dropped on a valid target. */
   onMove: (source: T, target: T) => void;
   /** Whether the game is in a playing state. */
@@ -11,7 +11,7 @@ interface UseSolitaireDragDropOptions<T> {
 }
 
 /** Return type for the solitaire drag-and-drop hook. */
-interface UseSolitaireDragDropReturn<T> {
+export interface UseSolitaireDragDropReturn<T> {
   /** The zone currently being dragged, or null. */
   dragSource: T | null;
   /** Whether a drag operation is in progress. */

--- a/frontend/src/hooks/useTrenteEtQuaranteGame.ts
+++ b/frontend/src/hooks/useTrenteEtQuaranteGame.ts
@@ -4,7 +4,7 @@ import { TrenteEtQuaranteBetType, TrenteEtQuarantePhase } from '../types/phases'
 import { useGameApi } from './useGameApi';
 
 /** A previously placed bet, remembered so it can be replayed in the next round. */
-interface LastBet {
+export interface LastBet {
   bet: number;
   stake: number;
 }

--- a/frontend/src/pages/BlackJackPage.tsx
+++ b/frontend/src/pages/BlackJackPage.tsx
@@ -160,7 +160,8 @@ const SPANISH21_TUTORIAL_STEPS: TutorialStep[] = [
 /** Variant identifier shared by BlackJack and Spanish 21 (which reuses this page). */
 export type BlackJackVariant = 'blackjack' | 'spanish21';
 
-interface BlackJackPageProps {
+/** Props for {@link BlackJackPage}. */
+export interface BlackJackPageProps {
   /** Variant of BlackJack to render. Defaults to 'blackjack'. */
   variant?: BlackJackVariant;
 }

--- a/frontend/src/providers/SoundProvider.tsx
+++ b/frontend/src/providers/SoundProvider.tsx
@@ -26,7 +26,7 @@ export interface PlayOptions {
 }
 
 /** Context value provided by SoundProvider. */
-interface SoundContextValue {
+export interface SoundContextValue {
   /** Fire-and-forget sound playback. Silently no-ops if muted or sound fails. */
   playSound: (name: SoundName, options?: PlayOptions) => void;
   /** Whether sound is currently muted. */
@@ -36,8 +36,9 @@ interface SoundContextValue {
   /**
    * Marks the next exec resolution's generic sound as already covered by a
    * more specific action sound (e.g., chipClick on a bet). The claim is
-   * consumed by the next `consumeExecClaim` call or expires after
-   * {@link CLAIM_EXPIRY_MS}, whichever comes first.
+   * consumed by the next `consumeExecClaim` call or expires after 3s
+   * (`CLAIM_EXPIRY_MS` — deliberately not exported; it is a tuning value, not
+   * part of the contract), whichever comes first.
    */
   claimExecSound: () => void;
   /**

--- a/frontend/src/utils/accordionUtils.ts
+++ b/frontend/src/utils/accordionUtils.ts
@@ -1,7 +1,7 @@
 import type { AccordionPile } from '../types/card';
 
 /** The two legal merge offsets in Accordion: pile-1 (adjacent) and pile-3 (three-back). */
-const ACCORDION_OFFSETS: readonly number[] = [1, 3] as const;
+export const ACCORDION_OFFSETS: readonly number[] = [1, 3] as const;
 
 /**
  * Returns the indices of piles to the left of `fromIdx` (at offsets 1 and 3)

--- a/frontend/src/utils/cli/formatters/genericFormatter.ts
+++ b/frontend/src/utils/cli/formatters/genericFormatter.ts
@@ -9,7 +9,7 @@ import {
 } from '../formatterBase';
 
 /** Generic player-like structure. */
-interface GenericPlayer {
+export interface GenericPlayer {
   id: number;
   isHuman: boolean;
   cards?: Card[];
@@ -27,7 +27,7 @@ interface GenericPlayer {
 }
 
 /** Generic trick card. */
-interface GenericTrickCard {
+export interface GenericTrickCard {
   playerIdx: number;
   card: Card;
 }

--- a/frontend/src/utils/ginRummyDeadwood.ts
+++ b/frontend/src/utils/ginRummyDeadwood.ts
@@ -57,7 +57,7 @@ export interface GinRummyScoreBreakdown {
 }
 
 /** Minimal player shape needed to derive the round-end score breakdown. */
-interface GinRummyBreakdownPlayer {
+export interface GinRummyBreakdownPlayer {
   id: number;
   cards: readonly Card[];
 }

--- a/frontend/src/utils/resolvePageComponent.ts
+++ b/frontend/src/utils/resolvePageComponent.ts
@@ -1,7 +1,7 @@
 import { type ComponentType, lazy } from 'react';
 
 /** Async loader for one ESM module, returned by `import.meta.glob`. */
-type ModuleLoader = () => Promise<Record<string, ComponentType<unknown>>>;
+export type ModuleLoader = () => Promise<Record<string, ComponentType<unknown>>>;
 
 /**
  * Pulls the named export `<page>Page` out of an already-imported module

--- a/frontend/src/utils/solitaireUtils.ts
+++ b/frontend/src/utils/solitaireUtils.ts
@@ -3,7 +3,7 @@
  */
 
 /** Minimal tableau card shape — any solitaire card with a face-up flag. */
-interface TableauCardLike {
+export interface TableauCardLike {
   faceUp: boolean;
 }
 
@@ -23,13 +23,13 @@ export function isTableauAllFaceUp(tableau: readonly (readonly TableauCardLike[]
 }
 
 /** Minimal card shape for movable-run detection: suit (`design`) + rank (`value`). */
-interface SuitRankCard {
+export interface SuitRankCard {
   design: string;
   value: number;
 }
 
 /** Tableau card with a nullable face and a face-up flag (Spider column shape). */
-interface RunTableauCard {
+export interface RunTableauCard {
   card: SuitRankCard | null;
   faceUp: boolean;
 }


### PR DESCRIPTION
Second and last of the TypeDoc cleanup. **84 → 0**; with #4358 already merged, `bun run docs:generate` is now completely clean (was 142).

## What these were

Every one is a type used in the signature of an **already-exported** function, component or hook, while not being exported itself. A reader of the published docs hit a dead end at, say, `useSound(): SoundContextValue` with no way to see what that is. 73 are React prop interfaces; the rest are option/return shapes and two values.

- **37** already carried TSDoc and only needed `export`.
- **46** got a comment in the existing one-line house style.

## Prop docs are matched to the real component, not to the name

Prop interfaces are documented against the component that actually consumes them — found by matching the type in the component's signature. Stripping `"Props"` off the name would have been wrong three times:

| interface | naive guess | actual public component |
|---|---|---|
| `BoardProps` | `Board` | **`SevensBoard`** (`export { Board as SevensBoard }`) |
| `HumanAreaProps` | `HumanArea` | **`SevensHumanArea`** |
| `ErrorBoundaryProps` | `ErrorBoundary` | consumed by the private `ErrorBoundaryInner`; public face is `ErrorBoundary` |

## Exporting 84 types surfaced 5 more

TypeDoc only reports symbols reachable from documented ones, so publishing a type publishes whatever it references. Four — `games`, `RoundResultEntry`, `ActionBinding`, `SuitRankCard` — are part of the shape of a now-public type and are exported too.

**The fifth deliberately is not.** `CLAIM_EXPIRY_MS` is a 3s tuning constant inside `SoundProvider`; exporting an implementation detail to satisfy a doc link would be backwards. The comment now names it in a code span and states the value:

```diff
-   * consumed by the next `consumeExecClaim` call or expires after
-   * {@link CLAIM_EXPIRY_MS}, whichever comes first.
+   * consumed by the next `consumeExecClaim` call or expires after 3s
+   * (`CLAIM_EXPIRY_MS` — deliberately not exported; it is a tuning value, not
+   * part of the contract), whichever comes first.
```

## Test plan

- [x] `bun run docs:generate` — **0 warnings, 0 errors** (was 84 on this branch's base)
- [x] `bun run test` — 1,133 files / 15,768 tests pass
- [x] `bun run typecheck` — clean
- [x] `bun run check` — clean

Adding `export` cannot change behaviour, but the suite was run rather than reasoned about.