### PR TITLE
fix(test): stop the /discover route tests depending on leftover draft state

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import App, { RouteSuspenseFallback } from './App';
+import { DISCOVER_DRAFT_KEY } from './hooks/useSurveyDraft';
 import { renderWithProviders } from './test/renderWithProviders';
 
 describe('RouteSuspenseFallback', () => {
@@ -56,7 +57,7 @@ describe('App non-game routes', () => {
     // `setup.ts` does not clear localStorage globally, and
     // `useSurveyDraft.test.ts` clears only in beforeEach, so a completed draft
     // can outlive it. Establish the precondition here instead of inheriting it.
-    localStorage.removeItem('trumpcards-discover-draft');
+    localStorage.removeItem(DISCOVER_DRAFT_KEY);
   });
 
   afterEach(() => {

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import App, { RouteSuspenseFallback } from './App';
 import { renderWithProviders } from './test/renderWithProviders';
 
@@ -44,6 +44,21 @@ describe('RouteSuspenseFallback', () => {
 // error (probed directly). The boundary only decides whether the skeleton
 // shows during the chunk download, so removing one is invisible here.
 describe('App non-game routes', () => {
+  beforeEach(() => {
+    // A survey draft with every question answered makes /discover legitimately
+    // NOT show the survey: DiscoverPage's submit effect fires immediately and
+    // redirects to /discover/result with the stored answers. So the two
+    // assertions below are asking for `discover-survey` in a state where its
+    // absence is correct — which is why they failed intermittently, and only in
+    // a full-suite run where an earlier test could leave such a draft behind.
+    // Verified in a browser: seeding this key lands on
+    // #/discover/result?m=0,0&... with the result page rendered.
+    // `setup.ts` does not clear localStorage globally, and
+    // `useSurveyDraft.test.ts` clears only in beforeEach, so a completed draft
+    // can outlive it. Establish the precondition here instead of inheriting it.
+    localStorage.removeItem('trumpcards-discover-draft');
+  });
+
   afterEach(() => {
     window.location.hash = '';
   });


### PR DESCRIPTION
Fixes an intermittent failure I introduced in #4356. It is on `develop` now.

```
FAIL src/App.test.tsx > App non-game routes
     > sends /discover/result back to the survey when the params are absent
TestingLibraryElementError: Unable to find an element by: [data-testid="discover-survey"]
```

Full-suite only — the file passes **8/8 in isolation**.

## Root cause

A survey draft with **every question answered** makes `/discover` legitimately **not** show the survey. `DiscoverPage`'s submit effect fires immediately, redirects to `/discover/result` with the stored answers, and clears the draft. The tests were asking for `discover-survey` in a state where its absence is correct.

Reproduced deterministically by seeding `trumpcards-discover-draft`, and confirmed in a real browser rather than inferred from the unit test:

```
FINAL_URL     = /#/discover/result?m=0,0&s=0,0&so=0,0&t=0,0
RESULT_TESTID = 1      ← the result page rendered
DRAFT_AFTER   = null   ← the draft was cleared, as designed
```

## Timing was the obvious suspicion and it was wrong

Worth recording, because "flaky async test → raise the timeout" would have been a plausible non-fix:

- `setup.ts` already configures `asyncUtilTimeout: 5000`, so the assertion had a 5s window, not the 1s default.
- The failing DOM carried `aria-current="page"` on `#/discover`, so navigation had already resolved.

## The fix

The test removes that key before each case instead of inheriting whatever an earlier test left. `setup.ts` does not clear localStorage globally, and `useSurveyDraft.test.ts` clears only in `beforeEach`, so a completed draft can outlive it.

## Correction to an earlier claim in this PR

An earlier revision of this description said a completed draft leaves `/discover` **blank**, and floated filing that as a user-facing bug. **That was wrong.** It came from reading a `return null` in one render pass of the unit test without checking what happened next — the effect redirects to the results. There is no bug to file; the app behaves correctly. Only the test's expectation was wrong for that state.

## Test plan

- [x] `src/App.test.tsx` — 6/6
- [x] Reproduction confirmed (seeded completed draft), in vitest **and** in a browser
- [x] Fix confirmed against that reproduction
- [x] `bun run typecheck`, `bun run check` — clean