### PR TITLE
fix(frontend): stop showing raw i18n keys in 8 games

### DIFF
--- a/frontend/src/components/HudStats.test.tsx
+++ b/frontend/src/components/HudStats.test.tsx
@@ -109,6 +109,21 @@ describe('HudStats component', () => {
     expect(badge).toHaveAttribute('data-style', expectedStyle);
     expect(badge.textContent).toContain(expectedLabel);
   });
+
+  // Every namespace that a page actually passes must own the `style.*` keys,
+  // otherwise i18next falls back to printing the key itself and the badge
+  // reads "style.tp" on screen. omahahilo / bigohilo shipped without them.
+  // See issue #4374.
+  it.each(['holdem', 'omaha', 'shortdeck', 'pineapple', 'bigo', 'omahahilo', 'bigohilo'])(
+    'resolves the style badge label in the %s namespace',
+    (namespace) => {
+      render(<HudStats vpip={15} pfr={5} threeBet={6} af="2.0" namespace={namespace} />);
+      const badge = screen.getByTestId('hud-overall-style');
+      expect(badge).toHaveAttribute('data-style', 'tp');
+      expect(badge.textContent).toContain('TP');
+      expect(badge.textContent).not.toContain('style.');
+    },
+  );
 });
 
 describe('overallStyle', () => {

--- a/frontend/src/i18n/locales/en/bigohilo.json
+++ b/frontend/src/i18n/locales/en/bigohilo.json
@@ -80,5 +80,17 @@
     "weakHandRank": "Weak hand — fold recommended",
     "scoopChance": "Scoop range (hi + lo) — raise recommended",
     "lowDraw": "Low likely to qualify — call to chase the half"
+  },
+  "style": {
+    "tag": "TAG",
+    "tagTooltip": "Tight Aggressive: plays few hands but bets strongly when in",
+    "lag": "LAG",
+    "lagTooltip": "Loose Aggressive: plays many hands and bets strongly",
+    "tp": "TP",
+    "tpTooltip": "Tight Passive: plays few hands, mostly calls",
+    "lp": "LP",
+    "lpTooltip": "Loose Passive: plays many hands but rarely raises",
+    "balanced": "BAL",
+    "balancedTooltip": "Balanced style"
   }
 }

--- a/frontend/src/i18n/locales/en/omahahilo.json
+++ b/frontend/src/i18n/locales/en/omahahilo.json
@@ -87,5 +87,17 @@
     "lowDraw": "Low likely to qualify — call to chase the half"
   },
   "loCardAria": "Low hand card",
-  "loBadge": "LO"
+  "loBadge": "LO",
+  "style": {
+    "tag": "TAG",
+    "tagTooltip": "Tight Aggressive: plays few hands but bets strongly when in",
+    "lag": "LAG",
+    "lagTooltip": "Loose Aggressive: plays many hands and bets strongly",
+    "tp": "TP",
+    "tpTooltip": "Tight Passive: plays few hands, mostly calls",
+    "lp": "LP",
+    "lpTooltip": "Loose Passive: plays many hands but rarely raises",
+    "balanced": "BAL",
+    "balancedTooltip": "Balanced style"
+  }
 }

--- a/frontend/src/i18n/locales/en/skat.json
+++ b/frontend/src/i18n/locales/en/skat.json
@@ -52,7 +52,11 @@
     "bid": "Bidding",
     "skatPickup": "Skat pickup",
     "discard": "Discard",
-    "gameDeclaration": "Game declaration"
+    "gameDeclaration": "Game declaration",
+    "play": "Play",
+    "trickEnd": "Trick end",
+    "roundEnd": "Round end",
+    "gameEnd": "Game over"
   },
   "tutorial": {
     "trickDisplay": "The trick area shows the cards each of the three players plays.",

--- a/frontend/src/i18n/locales/ja/bigohilo.json
+++ b/frontend/src/i18n/locales/ja/bigohilo.json
@@ -80,5 +80,17 @@
     "weakHandRank": "弱いハンド — フォールド推奨",
     "scoopChance": "ハイ＋ローのスクープ圏内 — レイズ推奨",
     "lowDraw": "ロー成立濃厚 — 半分狙いでコール推奨"
+  },
+  "style": {
+    "tag": "TAG",
+    "tagTooltip": "Tight Aggressive：参加少なめだが入ったら強気",
+    "lag": "LAG",
+    "lagTooltip": "Loose Aggressive：参加多くかつ攻め志向",
+    "tp": "TP",
+    "tpTooltip": "Tight Passive：参加少なめでコール中心",
+    "lp": "LP",
+    "lpTooltip": "Loose Passive：参加多めだがコール中心",
+    "balanced": "BAL",
+    "balancedTooltip": "バランス型のスタイル"
   }
 }

--- a/frontend/src/i18n/locales/ja/omahahilo.json
+++ b/frontend/src/i18n/locales/ja/omahahilo.json
@@ -87,5 +87,17 @@
     "lowDraw": "ロー成立濃厚 — 半分狙いでコール推奨"
   },
   "loCardAria": "ロー構成カード",
-  "loBadge": "LO"
+  "loBadge": "LO",
+  "style": {
+    "tag": "TAG",
+    "tagTooltip": "Tight Aggressive：参加少なめだが入ったら強気",
+    "lag": "LAG",
+    "lagTooltip": "Loose Aggressive：参加多くかつ攻め志向",
+    "tp": "TP",
+    "tpTooltip": "Tight Passive：参加少なめでコール中心",
+    "lp": "LP",
+    "lpTooltip": "Loose Passive：参加多めだがコール中心",
+    "balanced": "BAL",
+    "balancedTooltip": "バランス型のスタイル"
+  }
 }

--- a/frontend/src/i18n/locales/ja/skat.json
+++ b/frontend/src/i18n/locales/ja/skat.json
@@ -52,7 +52,11 @@
     "bid": "ビッドフェーズ",
     "skatPickup": "スカート拾い",
     "discard": "捨て札",
-    "gameDeclaration": "ゲーム宣言"
+    "gameDeclaration": "ゲーム宣言",
+    "play": "プレイ",
+    "trickEnd": "トリック終了",
+    "roundEnd": "ラウンド終了",
+    "gameEnd": "ゲーム終了"
   },
   "tutorial": {
     "trickDisplay": "トリックエリア。3人の出した札がここに並びます。",

--- a/frontend/src/pages/BelotePage.test.tsx
+++ b/frontend/src/pages/BelotePage.test.tsx
@@ -100,6 +100,15 @@ describe('BelotePage', () => {
     );
   });
 
+  // The phase key map must hold bare keys; usePhaseNames adds the `phase.`
+  // prefix itself, so a prefixed key resolved to the literal
+  // "phase.phase.bidPickUp" on screen. See issue #4374.
+  it('renders the translated phase name, not the raw i18n key', async () => {
+    renderWithProviders(<BelotePage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toHaveTextContent('ターンアップを取る'));
+    expect(screen.getByTestId('phase-indicator')).not.toHaveTextContent('phase.');
+  });
+
   it('shows the orderup and pass buttons in pick-up phase when human is bid turn', async () => {
     renderWithProviders(<BelotePage />);
     await waitFor(() => expect(screen.getByRole('button', { name: '取る' })).toBeInTheDocument());

--- a/frontend/src/pages/BelotePage.tsx
+++ b/frontend/src/pages/BelotePage.tsx
@@ -69,12 +69,12 @@ const BELOTE_TUTORIAL_STEPS: TutorialStep[] = [
 ];
 
 const BELOTE_PHASE_KEYS: Readonly<Record<number, string>> = {
-  [BelotePhase.BID_PICK_UP]: 'phase.bidPickUp',
-  [BelotePhase.BID_CALL_TRUMP]: 'phase.bidCallTrump',
-  [BelotePhase.PLAY]: 'phase.play',
-  [BelotePhase.TRICK_END]: 'phase.trickEnd',
-  [BelotePhase.ROUND_END]: 'phase.roundEnd',
-  [BelotePhase.GAME_END]: 'phase.gameEnd',
+  [BelotePhase.BID_PICK_UP]: 'bidPickUp',
+  [BelotePhase.BID_CALL_TRUMP]: 'bidCallTrump',
+  [BelotePhase.PLAY]: 'play',
+  [BelotePhase.TRICK_END]: 'trickEnd',
+  [BelotePhase.ROUND_END]: 'roundEnd',
+  [BelotePhase.GAME_END]: 'gameEnd',
 };
 
 const SUIT_LABEL_KEYS: Readonly<Record<number, string>> = {

--- a/frontend/src/pages/CatchTenPage.test.tsx
+++ b/frontend/src/pages/CatchTenPage.test.tsx
@@ -64,6 +64,15 @@ describe('CatchTenPage', () => {
     );
   });
 
+  // The phase key map must hold bare keys; usePhaseNames adds the `phase.`
+  // prefix itself, so a prefixed key resolved to the literal
+  // "phase.phase.play" on screen. See issue #4374.
+  it('renders the translated phase name, not the raw i18n key', async () => {
+    renderWithProviders(<CatchTenPage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toHaveTextContent('プレイ'));
+    expect(screen.getByTestId('phase-indicator')).not.toHaveTextContent('phase.');
+  });
+
   it('renders CPU stats as a structured definition list with labeled fields', async () => {
     renderWithProviders(<CatchTenPage />);
     // Each CPU stat block is a <dl>; every field is a term/definition pair so

--- a/frontend/src/pages/CatchTenPage.tsx
+++ b/frontend/src/pages/CatchTenPage.tsx
@@ -80,10 +80,10 @@ const CT_TUTORIAL_STEPS: TutorialStep[] = [
 
 /** Phase translation key map for Catch the Ten. */
 const CATCHTEN_PHASE_KEYS: Readonly<Record<number, string>> = {
-  [CatchTenPhase.PLAY]: 'phase.play',
-  [CatchTenPhase.TRICK_END]: 'phase.trickEnd',
-  [CatchTenPhase.ROUND_END]: 'phase.roundEnd',
-  [CatchTenPhase.GAME_END]: 'phase.gameEnd',
+  [CatchTenPhase.PLAY]: 'play',
+  [CatchTenPhase.TRICK_END]: 'trickEnd',
+  [CatchTenPhase.ROUND_END]: 'roundEnd',
+  [CatchTenPhase.GAME_END]: 'gameEnd',
 };
 
 /**

--- a/frontend/src/pages/GaigelPage.test.tsx
+++ b/frontend/src/pages/GaigelPage.test.tsx
@@ -84,6 +84,15 @@ describe('GaigelPage', () => {
     );
   });
 
+  // The phase key map must hold bare keys; usePhaseNames adds the `phase.`
+  // prefix itself, so a prefixed key resolved to the literal
+  // "phase.phase.play" on screen. See issue #4374.
+  it('renders the translated phase name, not the raw i18n key', async () => {
+    renderWithProviders(<GaigelPage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toHaveTextContent('プレイ'));
+    expect(screen.getByTestId('phase-indicator')).not.toHaveTextContent('phase.');
+  });
+
   it('renders the team score table and stock readout during play', async () => {
     renderWithProviders(<GaigelPage />);
     await waitFor(() => expect(screen.getByText('チームスコア')).toBeInTheDocument());

--- a/frontend/src/pages/GaigelPage.tsx
+++ b/frontend/src/pages/GaigelPage.tsx
@@ -61,10 +61,10 @@ const GAIGEL_TUTORIAL_STEPS: TutorialStep[] = [
 ];
 
 const GAIGEL_PHASE_KEYS: Readonly<Record<number, string>> = {
-  [GaigelPhase.PLAY]: 'phase.play',
-  [GaigelPhase.TRICK_END]: 'phase.trickEnd',
-  [GaigelPhase.ROUND_END]: 'phase.roundEnd',
-  [GaigelPhase.GAME_END]: 'phase.gameEnd',
+  [GaigelPhase.PLAY]: 'play',
+  [GaigelPhase.TRICK_END]: 'trickEnd',
+  [GaigelPhase.ROUND_END]: 'roundEnd',
+  [GaigelPhase.GAME_END]: 'gameEnd',
 };
 
 const SUIT_LABEL_KEYS: Readonly<Record<number, string>> = {

--- a/frontend/src/pages/JassPage.test.tsx
+++ b/frontend/src/pages/JassPage.test.tsx
@@ -97,6 +97,15 @@ describe('JassPage', () => {
     );
   });
 
+  // The phase key map must hold bare keys; usePhaseNames adds the `phase.`
+  // prefix itself, so a prefixed key resolved to the literal
+  // "phase.phase.bidTrump" on screen. See issue #4374.
+  it('renders the translated phase name, not the raw i18n key', async () => {
+    renderWithProviders(<JassPage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toHaveTextContent('切り札を選ぶ'));
+    expect(screen.getByTestId('phase-indicator')).not.toHaveTextContent('phase.');
+  });
+
   it('shows the four trump suit buttons and Schieben in the trump-bid phase', async () => {
     renderWithProviders(<JassPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: '♠ スペード' })).toBeInTheDocument());

--- a/frontend/src/pages/JassPage.tsx
+++ b/frontend/src/pages/JassPage.tsx
@@ -66,12 +66,12 @@ const JASS_TUTORIAL_STEPS: TutorialStep[] = [
 ];
 
 const JASS_PHASE_KEYS: Readonly<Record<number, string>> = {
-  [JassPhase.BID_TRUMP]: 'phase.bidTrump',
-  [JassPhase.BID_PARTNER]: 'phase.bidPartner',
-  [JassPhase.PLAY]: 'phase.play',
-  [JassPhase.TRICK_END]: 'phase.trickEnd',
-  [JassPhase.ROUND_END]: 'phase.roundEnd',
-  [JassPhase.GAME_END]: 'phase.gameEnd',
+  [JassPhase.BID_TRUMP]: 'bidTrump',
+  [JassPhase.BID_PARTNER]: 'bidPartner',
+  [JassPhase.PLAY]: 'play',
+  [JassPhase.TRICK_END]: 'trickEnd',
+  [JassPhase.ROUND_END]: 'roundEnd',
+  [JassPhase.GAME_END]: 'gameEnd',
 };
 
 const SUIT_LABEL_KEYS: Readonly<Record<number, string>> = {

--- a/frontend/src/pages/SkatPage.test.tsx
+++ b/frontend/src/pages/SkatPage.test.tsx
@@ -193,6 +193,29 @@ describe('SkatPage', () => {
     );
   });
 
+  // The phase key map must hold bare keys; usePhaseNames adds the `phase.`
+  // prefix itself, so Skat's namespace-qualified keys resolved to literals
+  // like "phase.skat.phase.skatPickup" on screen. The trick phases also had
+  // no locale entry at all. See issue #4374.
+  it.each([
+    [bidPhaseHumanTurn, 'ビッドフェーズ'],
+    [skatPickupPhase, 'スカート拾い'],
+    [discardPhase, '捨て札'],
+    [gameDeclarationPhase, 'ゲーム宣言'],
+    [playPhaseHumanTurn, 'プレイ'],
+    [trickEndPhase, 'トリック終了'],
+    [roundEndPhase, 'ラウンド終了'],
+  ])('renders the translated phase name, not the raw i18n key (%#)', async (state, expected) => {
+    mockExec.mockResolvedValue(state);
+    renderWithProviders(
+      <MemoryRouter initialEntries={['/skat']}>
+        <SkatPage />
+      </MemoryRouter>,
+    );
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toHaveTextContent(expected));
+    expect(screen.getByTestId('phase-indicator')).not.toHaveTextContent('phase.');
+  });
+
   it('renders the CPU difficulty selector in the settings panel', async () => {
     renderWithProviders(
       <MemoryRouter initialEntries={['/skat']}>

--- a/frontend/src/pages/SkatPage.tsx
+++ b/frontend/src/pages/SkatPage.tsx
@@ -62,14 +62,14 @@ const SKAT_TUTORIAL_STEPS: TutorialStep[] = [
 
 /** Phase translation key map for Skat. */
 const SKAT_PHASE_KEYS: Readonly<Record<number, string>> = {
-  [SkatPhase.BID]: 'skat.phase.bid',
-  [SkatPhase.SKAT_PICKUP]: 'skat.phase.skatPickup',
-  [SkatPhase.DISCARD]: 'skat.phase.discard',
-  [SkatPhase.GAME_DECLARATION]: 'skat.phase.gameDeclaration',
-  [SkatPhase.PLAY]: 'phase.play',
-  [SkatPhase.TRICK_END]: 'phase.trickEnd',
-  [SkatPhase.ROUND_END]: 'phase.roundEnd',
-  [SkatPhase.GAME_END]: 'phase.gameEnd',
+  [SkatPhase.BID]: 'bid',
+  [SkatPhase.SKAT_PICKUP]: 'skatPickup',
+  [SkatPhase.DISCARD]: 'discard',
+  [SkatPhase.GAME_DECLARATION]: 'gameDeclaration',
+  [SkatPhase.PLAY]: 'play',
+  [SkatPhase.TRICK_END]: 'trickEnd',
+  [SkatPhase.ROUND_END]: 'roundEnd',
+  [SkatPhase.GAME_END]: 'gameEnd',
 };
 
 /** Renders the Skat (German trick-taking) game page. */

--- a/frontend/src/pages/WhistPage.test.tsx
+++ b/frontend/src/pages/WhistPage.test.tsx
@@ -64,6 +64,15 @@ describe('WhistPage', () => {
     );
   });
 
+  // The phase key map must hold bare keys; usePhaseNames adds the `phase.`
+  // prefix itself, so a prefixed key resolved to the literal
+  // "phase.phase.play" on screen. See issue #4374.
+  it('renders the translated phase name, not the raw i18n key', async () => {
+    renderWithProviders(<WhistPage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toHaveTextContent('プレイ'));
+    expect(screen.getByTestId('phase-indicator')).not.toHaveTextContent('phase.');
+  });
+
   it('lists the keyboard shortcuts in a collapsible panel', async () => {
     renderWithProviders(<WhistPage />);
     const panel = await screen.findByTestId('wh-kbd-shortcuts');

--- a/frontend/src/pages/WhistPage.tsx
+++ b/frontend/src/pages/WhistPage.tsx
@@ -81,10 +81,10 @@ const WH_TUTORIAL_STEPS: TutorialStep[] = [
 
 /** Phase translation key map for Whist. */
 const WHIST_PHASE_KEYS: Readonly<Record<number, string>> = {
-  [WhistPhase.PLAY]: 'phase.play',
-  [WhistPhase.TRICK_END]: 'phase.trickEnd',
-  [WhistPhase.ROUND_END]: 'phase.roundEnd',
-  [WhistPhase.GAME_END]: 'phase.gameEnd',
+  [WhistPhase.PLAY]: 'play',
+  [WhistPhase.TRICK_END]: 'trickEnd',
+  [WhistPhase.ROUND_END]: 'roundEnd',
+  [WhistPhase.GAME_END]: 'gameEnd',
 };
 
 /** Renders the Whist game page with trump suit, trick play, and team scoring. */


### PR DESCRIPTION
## Summary

Two independent gaps let untranslated i18next keys render on screen in 8 games (found during the 375×667 mobile sweep).

### Cause 1 — double `phase.` prefix (6 games)

`usePhaseNames` adds the `phase.` prefix itself, but these six phase key maps already carried it, so the lookup became `phase.phase.play` and i18next echoed the key back:

| Game | Was displayed | Now |
|---|---|---|
| `belote` | `phase.phase.bidPickUp` | ターンアップを取る |
| `catchten` | `phase.phase.play` | プレイ |
| `gaigel` | `phase.phase.play` | プレイ |
| `jass` | `phase.phase.play` | プレイ |
| `whist` | `phase.phase.play` | プレイ |
| `skat` | `phase.skat.phase.skatPickup` | スカット交換 |

`skat` also qualified its keys with the namespace, and its four trick phases (`play` / `trickEnd` / `roundEnd` / `gameEnd`) had **no locale entry at all** — added to ja + en.

The other 98 `usePhaseNames` callers already pass bare keys, so this is a per-page oversight, not a design change.

### Cause 2 — missing `style.*` block (2 games)

`HudStats` renders the CPU style badge via `t('style.<style>')` against a caller-supplied namespace. `omahahilo` / `bigohilo` shipped without a `style` block, so they showed `style.tp` / `style.tpTooltip`. Copied from their base variants (`omaha` / `bigo`); the other five HudStats namespaces already had it.

## Test plan

- [x] RED first: 14 new assertions failed before the fix (12 phase-indicator + 2 HudStats namespaces)
- [x] `bun run test` — 15,794 passed
- [x] `bun run typecheck` — clean
- [x] `bun run check` — clean (Biome + design tokens + reduced-motion)
- [x] `bun run build` — clean
- [x] ja/en locale parity verified for every touched file
- [x] Confirmed no other page mixes the prefix (`MississippiStud` / `Pishti` call `t()` directly, so their `phase.` prefix is correct) and no other HudStats namespace lacks `style.*`

Note: `src/App.test.tsx` (`/discover` route) flaked once in the full run and passes in isolation — same cross-file draft-state class as #4361, unrelated to these files.

Closes #4374