### PR TITLE
fix(cli): list every registry category in the --category error

### DIFF
--- a/.claude/agents/game-registration-checker.md
+++ b/.claude/agents/game-registration-checker.md
@@ -7,7 +7,7 @@ model: sonnet
 
 You are a registration-consistency checker for the go_trumpcards repo. You are **read-only**:
 never edit files, never commit. Your job is to verify a game `<name>` (bucket `<category>` ∈
-{casino, classic, solo}) is fully and consistently wired, then report PASS/FAIL with exact
+{casino, classic, solo, extra}) is fully and consistently wired, then report PASS/FAIL with exact
 file:line evidence for every gap.
 
 The caller gives you the game `<name>` and its `<category>`. If `<category>` is not given,

--- a/cmd/trumpcards/main.go
+++ b/cmd/trumpcards/main.go
@@ -212,6 +212,11 @@ var categoryFilterPipe = strings.Join(categoryDisplayNames(), "|")
 // "or" (e.g. "casino, classic, solo, or extra"), for prose descriptions.
 var categoryFilterProse = joinOr(categoryDisplayNames())
 
+// categoryFilterList is the same list comma-separated without a conjunction
+// (e.g. "casino, classic, solo, extra"), for interpolation into localized
+// messages where the surrounding grammar is supplied by the locale file.
+var categoryFilterList = strings.Join(categoryDisplayNames(), ", ")
+
 // joinOr renders items as an English list with an Oxford "or": one item as-is,
 // two joined by " or ", three+ comma-separated with a trailing ", or ".
 func joinOr(items []string) string {
@@ -380,7 +385,7 @@ func run() int {
 			return code
 		}
 		if category != "" && !validCategory(category) {
-			fmt.Fprintln(os.Stderr, i18n.Tf("cliInvalidCategory", "category", category))
+			fmt.Fprintln(os.Stderr, i18n.Tf("cliInvalidCategory", "category", category, "categories", categoryFilterList))
 			return 2
 		}
 		if asJSON {

--- a/cmd/trumpcards/main_test.go
+++ b/cmd/trumpcards/main_test.go
@@ -1407,6 +1407,15 @@ func TestRunGamesInvalidCategoryExits2(t *testing.T) {
 	if !strings.Contains(errBuf.String(), "bogus") {
 		t.Errorf("stderr must name the offending category 'bogus'; got: %q", errBuf.String())
 	}
+	// The list of accepted values must come from the registry, not a literal
+	// baked into the locale file: `extra` was added by ADR-0032 and the help
+	// text picked it up in #4308, but this error message kept advertising only
+	// three categories while `--category extra` worked fine. See issue #4371.
+	for _, want := range categoryDisplayNames() {
+		if !strings.Contains(errBuf.String(), want) {
+			t.Errorf("stderr must list the accepted category %q; got: %q", want, errBuf.String())
+		}
+	}
 }
 
 func TestCliAliasesWithoutShortKeyRemoved(t *testing.T) {

--- a/internal/i18n/locales/en/common.json
+++ b/internal/i18n/locales/en/common.json
@@ -54,7 +54,7 @@
   "cliHelpUnknownGame": "Unknown game: \"{{name}}\". Run 'trumpcards games' to see available games.",
   "updateNonInteractive": "Non-interactive stdin: re-run with --yes to auto-confirm.",
   "cliLangEnvFallback": "Note: LANG=\"{{lang}}\" is not a supported language, defaulting to ja (pass --quiet/-q or set TRUMPCARDS_QUIET=1 to silence)",
-  "cliInvalidCategory": "Error: invalid category \"{{category}}\" (supported: casino, classic, solo)",
+  "cliInvalidCategory": "Error: invalid category \"{{category}}\" (supported: {{categories}})",
   "cliGamesJSONError": "Error: failed to encode games as JSON: {{err}}",
   "cliGamesJSONIgnoredFlags": "Warning: --short / --aliases are ignored in --json mode (the JSON schema is fixed)",
   "cliSubcommandFlagError": "Error: trumpcards {{cmd}}: {{err}}",

--- a/internal/i18n/locales/ja/common.json
+++ b/internal/i18n/locales/ja/common.json
@@ -54,7 +54,7 @@
   "cliHelpUnknownGame": "不明なゲームです: \"{{name}}\"。'trumpcards games' でゲーム一覧を確認できます。",
   "updateNonInteractive": "標準入力が非対話モードです: --yes を付けて再実行してください。",
   "cliLangEnvFallback": "注意: LANG=\"{{lang}}\" はサポートされていない言語です。ja をデフォルトとして使用します (--quiet/-q または TRUMPCARDS_QUIET=1 で抑止可能)",
-  "cliInvalidCategory": "エラー: 無効なカテゴリ「{{category}}」です (対応: casino, classic, solo)",
+  "cliInvalidCategory": "エラー: 無効なカテゴリ「{{category}}」です (対応: {{categories}})",
   "cliGamesJSONError": "エラー: ゲーム一覧の JSON 生成に失敗しました: {{err}}",
   "cliGamesJSONIgnoredFlags": "警告: --json モードでは --short / --aliases は無視されます (JSON スキーマは固定)",
   "cliSubcommandFlagError": "エラー: trumpcards {{cmd}}: {{err}}",

--- a/internal/infrastructure/games/registry_worker_consistency_test.go
+++ b/internal/infrastructure/games/registry_worker_consistency_test.go
@@ -14,7 +14,7 @@ import (
 
 // TestWorkerRegistrationsCoverAllGames asserts that every game in
 // games.ByCategory(c) has a matching games.RegisterKVGame call in the
-// corresponding worker sub-package (casino, classic, solo) — and conversely,
+// corresponding worker sub-package (casino, classic, solo, extra) — and conversely,
 // that no sub-package registers a name absent from the registry.
 //
 // The worker init functions live under `//go:build js && wasm`, so a normal


### PR DESCRIPTION
## Summary

`games --category bogus` advertised only three categories while `extra` has been valid since [ADR-0032](docs/adr/0032-fourth-worker-capacity.md):

```console
$ trumpcards games --category bogus
エラー: 無効なカテゴリ「bogus」です (対応: casino, classic, solo)   # ← 3

$ trumpcards games --category extra --short | wc -l
46                                                                  # ← but extra works

$ trumpcards help games | grep -i category
      --category CAT       ... casino, classic, solo, or extra。      # ← help says 4
```

#4308 moved the **help text** onto `games.AllCategories()`, but the error message kept a literal baked into both locale files — so the CLI contradicted its own help output.

## Change

`cliInvalidCategory` now takes a `{{categories}}` placeholder, filled from a new `categoryFilterList` built off the same `categoryDisplayNames()` helper that `categoryFilterPipe` / `categoryFilterProse` already use. The locale files keep their own surrounding grammar; only the list is interpolated.

```console
$ trumpcards games --category bogus
エラー: 無効なカテゴリ「bogus」です (対応: casino, classic, solo, extra)
$ trumpcards --lang en games --category bogus
Error: invalid category "bogus" (supported: casino, classic, solo, extra)
$ echo $?
2
```

The test now iterates `categoryDisplayNames()` and asserts every registry category appears in the message, so a fifth worker cannot silently desync it again.

## Beyond the reported symptom

While grepping for other copies of the stale list I found two more #4308 leftovers still describing the buckets as a set of three, and fixed them in the same commit:

- `internal/infrastructure/games/registry_worker_consistency_test.go:17` — doc comment on the test that enforces the very invariant it mis-describes.
- `.claude/agents/game-registration-checker.md:10` — the checker agent's brief. This one was live: told that valid categories are `{casino, classic, solo}`, it would flag a legitimately `extra`-bucketed game as mis-registered.

## Test plan

- [x] RED first: new assertion failed with `stderr must list the accepted category "extra"`
- [x] `go test -tags test ./cmd/... ./internal/i18n/... ./internal/infrastructure/games/...` — pass
- [x] `golangci-lint run ./cmd/...` — 0 issues
- [x] `gofmt -l` clean on all touched Go files
- [x] Manually verified both locales and that exit code stays 2

Closes #4371