### PR TITLE
fix(cli): stop warning that completion's shell argument was ignored

### DIFF
--- a/cmd/trumpcards/completion_test.go
+++ b/cmd/trumpcards/completion_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"bytes"
 	"flag"
+	"io"
+	"os"
 	"strings"
 	"testing"
 
@@ -11,6 +13,44 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/infrastructure/ui"
 )
+
+// runCLI drives the real run() entry point with the given argv (the program
+// name is prepended) and returns what reached stdout, stderr, and the exit
+// code. Both pipes are drained concurrently: the completion scripts are several
+// KB, which would deadlock a read-after-close approach once the output exceeds
+// the pipe buffer.
+func runCLI(t *testing.T, args ...string) (stdout, stderr string, exit int) {
+	t.Helper()
+	origArgs, origCmdLine := os.Args, flag.CommandLine
+	origStdout, origStderr := os.Stdout, os.Stderr
+	t.Cleanup(func() {
+		os.Args, flag.CommandLine = origArgs, origCmdLine
+		os.Stdout, os.Stderr = origStdout, origStderr
+	})
+
+	flag.CommandLine = flag.NewFlagSet("trumpcards", flag.ExitOnError)
+	os.Args = append([]string{"trumpcards"}, args...)
+
+	rOut, wOut, err := os.Pipe()
+	require.NoError(t, err)
+	rErr, wErr, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout, os.Stderr = wOut, wErr
+
+	outCh, errCh := make(chan string, 1), make(chan string, 1)
+	drain := func(r *os.File, ch chan<- string) {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		ch <- buf.String()
+	}
+	go drain(rOut, outCh)
+	go drain(rErr, errCh)
+
+	exit = run()
+	require.NoError(t, wOut.Close())
+	require.NoError(t, wErr.Close())
+	return <-outCh, <-errCh, exit
+}
 
 func TestWriteBashCompletion(t *testing.T) {
 	var buf bytes.Buffer
@@ -154,6 +194,22 @@ func TestRunCompletion_ExtraArgs(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	code := runCompletionTo([]string{"bash", "extra"}, &stdout, &stderr, false, false)
 	assert.Equal(t, 2, code)
+}
+
+// TestCompletionShellArgNotReportedAsIgnored guards the documented, canonical
+// invocation `trumpcards completion <shell>`: the shell name is a required
+// argument that runCompletionTo consumes, so the generic leftover-args warning
+// must not claim it was ignored. Users source this from .bashrc, which made the
+// bogus warning appear on every shell startup. See issue #4370.
+func TestCompletionShellArgNotReportedAsIgnored(t *testing.T) {
+	for _, shell := range []string{"bash", "zsh", "fish"} {
+		t.Run(shell, func(t *testing.T) {
+			stdout, stderr, exit := runCLI(t, "completion", shell)
+			assert.Equal(t, 0, exit)
+			assert.NotEmpty(t, stdout, "the completion script must still reach stdout")
+			assert.Empty(t, stderr, "a valid invocation must not warn on stderr")
+		})
+	}
 }
 
 func TestRunCompletion_UnsupportedShell(t *testing.T) {
@@ -304,7 +360,7 @@ func TestParseSubFlagsTo_HelpFlag_WritesHelpToStdoutAndExitsZero(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	_, code, ok := parseSubFlagsTo("web", []string{"--help"}, func(fs *flag.FlagSet) {
 		fs.String("port", "", "port")
-	}, &stdout, &stderr)
+	}, &stdout, &stderr, false)
 	assert.False(t, ok)
 	assert.Equal(t, 0, code)
 	// The USAGE line names the command regardless of the active locale.
@@ -316,7 +372,7 @@ func TestParseSubFlagsTo_UnknownFlag_WritesI18nErrorAndExit2(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	_, code, ok := parseSubFlagsTo("web", []string{"--nope"}, func(fs *flag.FlagSet) {
 		fs.String("port", "", "port")
-	}, &stdout, &stderr)
+	}, &stdout, &stderr, false)
 	assert.False(t, ok)
 	assert.Equal(t, 2, code)
 	// Must not leak Go's raw "flag provided but not defined" line to either stream
@@ -324,6 +380,36 @@ func TestParseSubFlagsTo_UnknownFlag_WritesI18nErrorAndExit2(t *testing.T) {
 	assert.NotContains(t, stdout.String(), "flag provided but not defined")
 	assert.Contains(t, stderr.String(), "web")
 	assert.Contains(t, stderr.String(), "help web")
+}
+
+// The leftover-args warning is right for the five subcommands that take no
+// positional arguments and wrong for the one that does, so it is gated on
+// takesPositional rather than on fs.NArg() alone. See issue #4370.
+func TestParseSubFlagsTo_LeftoverArgs_WarnsOnlyWhenNotExpected(t *testing.T) {
+	for _, tc := range []struct {
+		name            string
+		takesPositional bool
+		wantWarning     bool
+	}{
+		{"warns when the subcommand takes no positional args", false, true},
+		{"stays quiet when the subcommand consumes them", true, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			fs, code, ok := parseSubFlagsTo("completion", []string{"bash"}, func(fs *flag.FlagSet) {
+				fs.Bool("no-hint", false, "no-hint")
+			}, &stdout, &stderr, tc.takesPositional)
+			require.True(t, ok)
+			assert.Equal(t, 0, code)
+			// Either way the argument is handed to the caller, never swallowed.
+			assert.Equal(t, []string{"bash"}, fs.Args())
+			if tc.wantWarning {
+				assert.NotEmpty(t, stderr.String())
+			} else {
+				assert.Empty(t, stderr.String())
+			}
+		})
+	}
 }
 
 func TestBuiltinSubcommandHelp_CoversAllNonGameSubcommands(t *testing.T) {

--- a/cmd/trumpcards/main.go
+++ b/cmd/trumpcards/main.go
@@ -408,7 +408,7 @@ func run() int {
 	}
 	commands["completion"] = func() int {
 		var noHint bool
-		fs, code, ok := parseSubFlags("completion", subArgs, func(f *flag.FlagSet) {
+		fs, code, ok := parseSubFlagsWithArgs("completion", subArgs, func(f *flag.FlagSet) {
 			f.BoolVar(&noHint, "no-hint", false, "Suppress installation hint comments (also implied when stdout is not a TTY)")
 		})
 		if !ok {
@@ -806,14 +806,27 @@ func suggestionCandidates(commands map[string]func() int) []string {
 // args (already stripped of trailing global flags by the dispatch loop), and
 // warns about extra positional arguments. Returns (fs, exitCode, ok). If ok is
 // false, the caller should return exitCode immediately.
+//
+// Use parseSubFlagsWithArgs instead for subcommands that take positional
+// arguments of their own.
 func parseSubFlags(name string, args []string, setup func(*flag.FlagSet)) (*flag.FlagSet, int, bool) {
-	return parseSubFlagsTo(name, args, setup, os.Stdout, os.Stderr)
+	return parseSubFlagsTo(name, args, setup, os.Stdout, os.Stderr, false)
+}
+
+// parseSubFlagsWithArgs is parseSubFlags for subcommands that consume their own
+// positional arguments, and so must not be told they were ignored. `completion
+// <shell>` is the only such subcommand today: the shell name is required, and
+// runCompletion validates the argument count itself (exit 2 on anything but one).
+// See issue #4370.
+func parseSubFlagsWithArgs(name string, args []string, setup func(*flag.FlagSet)) (*flag.FlagSet, int, bool) {
+	return parseSubFlagsTo(name, args, setup, os.Stdout, os.Stderr, true)
 }
 
 // parseSubFlagsTo is the testable core of parseSubFlags: it parses args with a
 // subcommand FlagSet, wires the shared builtin help text as the usage, and
-// writes help/diagnostics to the given streams.
-func parseSubFlagsTo(name string, args []string, setup func(*flag.FlagSet), stdout, stderr io.Writer) (*flag.FlagSet, int, bool) {
+// writes help/diagnostics to the given streams. takesPositional suppresses the
+// leftover-args warning for subcommands whose handler consumes fs.Args().
+func parseSubFlagsTo(name string, args []string, setup func(*flag.FlagSet), stdout, stderr io.Writer, takesPositional bool) (*flag.FlagSet, int, bool) {
 	fs := flag.NewFlagSet(name, flag.ContinueOnError)
 	fs.SetOutput(io.Discard) // suppress Go's raw English error/usage text
 	setup(fs)
@@ -839,7 +852,7 @@ func parseSubFlagsTo(name string, args []string, setup func(*flag.FlagSet), stdo
 		_, _ = fmt.Fprintln(stderr, i18n.Tf("cliTryHelp", "cmd", name))
 		return nil, 2, false
 	}
-	if fs.NArg() > 0 {
+	if fs.NArg() > 0 && !takesPositional {
 		_, _ = fmt.Fprintln(stderr, i18n.Tf("cliExtraArgsWarning", "args", strings.Join(fs.Args(), " ")))
 	}
 	return fs, 0, true

--- a/cmd/trumpcards/main_test.go
+++ b/cmd/trumpcards/main_test.go
@@ -553,7 +553,7 @@ func TestParseSubFlagsToNoHelpDumpOnFlagError(t *testing.T) {
 	fs, code, ok := parseSubFlagsTo("version", []string{"--bogus"}, func(fs *flag.FlagSet) {
 		var short bool
 		fs.BoolVar(&short, "short", false, "")
-	}, &stdout, &stderr)
+	}, &stdout, &stderr, false)
 
 	if ok || fs != nil {
 		t.Fatalf("expected (nil, code, false) on flag error; got ok=%v fs=%v", ok, fs)
@@ -577,7 +577,7 @@ func TestParseSubFlagsToPrintsHelpOnceOnHelpFlag(t *testing.T) {
 	fs, code, ok := parseSubFlagsTo("version", []string{"-h"}, func(fs *flag.FlagSet) {
 		var short bool
 		fs.BoolVar(&short, "short", false, "")
-	}, &stdout, &stderr)
+	}, &stdout, &stderr, false)
 
 	if ok || fs != nil {
 		t.Fatalf("expected (nil, 0, false) on -h; got ok=%v fs=%v", ok, fs)


### PR DESCRIPTION
## Summary

`trumpcards completion <shell>` — the invocation the help EXAMPLES tell users to source from `.bashrc` — printed a factually wrong warning to stderr on every run, so it fired on **every shell startup**:

```console
$ trumpcards completion bash 2>&1 >/dev/null
警告: 余分な引数は無視されました: bash
$ echo $?
0
```

Nothing was ignored. `bash` is required, `runCompletion` consumes it, and the script was correctly written to stdout with exit 0.

The same warning made a genuine error doubly misleading — the args weren't ignored, they *were* the cause of the exit 2:

```console
$ trumpcards completion bash extra1
警告: 余分な引数は無視されました: bash extra1   # ← not ignored
使い方: trumpcards completion <bash|zsh|fish>
```

## Cause

`parseSubFlagsTo` warned whenever positional args remained after flag parsing. Correct for `games` / `version` / `web` / `update` (which take none), wrong for `completion` — the only one of the six that takes a positional argument. (`help` takes one too but doesn't route through this helper.)

## Change

Gate the warning on a new `takesPositional` parameter, and give `completion` a `parseSubFlagsWithArgs` wrapper.

I considered the cheaper alternative of keying the exemption off the subcommand name (`map[string]bool{"completion": true}`) and rejected it: renaming the subcommand would silently stop matching and the bogus warning would come back. Arity validation is untouched — `runCompletionTo` still rejects anything but exactly one shell with exit 2.

## Verified behavior

| Invocation | stderr | exit |
|---|---|---|
| `completion bash` / `zsh` / `fish` | *(empty)* | 0 |
| `completion bash extra1` | usage only, no bogus warning | 2 |
| `completion bogus` | unsupported-shell + did-you-mean | 2 |
| `version stray` | still warns (unchanged) | 0 |

## Test plan

- [x] RED first: new `TestCompletionShellArgNotReportedAsIgnored` failed for all three shells
- [x] Added `TestParseSubFlagsTo_LeftoverArgs_WarnsOnlyWhenNotExpected` covering both sides of the new flag, asserting the arg reaches `fs.Args()` either way
- [x] `go test -tags test ./...` — full suite green
- [x] `golangci-lint run ./...` — 0 issues
- [x] `gofmt -l` clean

### Note on the new test helper

`runCLI` drives the real `run()` entry point and captures both streams. It drains the pipes **concurrently** rather than the read-after-close pattern used by the existing ~8 inline copies in `main_test.go` — the completion scripts are several KB and would deadlock once output exceeds the pipe buffer. I did not retrofit the existing call sites; that's unrelated churn.

Closes #4370