### PR TITLE
refactor(frontend): forward base hook results by spread, not by hand

### DIFF
--- a/frontend/src/hooks/gameHookBaseSurface.test.ts
+++ b/frontend/src/hooks/gameHookBaseSurface.test.ts
@@ -1,0 +1,179 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { createElement } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+// Every wrapper hook under test pulls its api object off this module, so the
+// mock has to cover all of them at once. The hooks only ever call `exec`, and
+// this suite never asserts on API traffic -- it inspects the shape of the
+// object each hook returns.
+vi.mock('../api/gameApi', () => {
+  // Exact export names, not derived from the game name -- a few are camelCased
+  // (callBreakApi, twoTenJackApi) while the rest are all-lowercase.
+  const names = [
+    'beloteApi',
+    'callBreakApi',
+    'catchtenApi',
+    'gaigelApi',
+    'gongzhuApi',
+    'heartsApi',
+    'jassApi',
+    'spadesApi',
+    'tarneebApi',
+    'tressetteApi',
+    'twoTenJackApi',
+    'whistApi',
+    'bakersgameApi',
+    'eightoffApi',
+    'freecellApi',
+    'klondikeApi',
+    'penguinApi',
+    'pyramidApi',
+    'seahaventowersApi',
+    'spiderApi',
+    'spideretteApi',
+    'tripeaksApi',
+    'hintApi',
+  ];
+  const mod: Record<string, unknown> = {
+    actionLogApi: new Proxy({}, { get: () => vi.fn() }),
+  };
+  for (const n of names) {
+    mod[n] = { exec: vi.fn().mockResolvedValue(null), hint: vi.fn().mockResolvedValue(null) };
+  }
+  return mod;
+});
+
+import { useBakersGameGame } from './useBakersGameGame';
+import { useBeloteGame } from './useBeloteGame';
+import { useCallBreakGame } from './useCallBreakGame';
+import { useCatchTenGame } from './useCatchTenGame';
+import { useEightOffGame } from './useEightOffGame';
+import { useFreeCellGame } from './useFreeCellGame';
+import { useGaigelGame } from './useGaigelGame';
+import { useGongZhuGame } from './useGongZhuGame';
+import { useHeartsGame } from './useHeartsGame';
+import { useJassGame } from './useJassGame';
+import { useKlondikeGame } from './useKlondikeGame';
+import { usePenguinGame } from './usePenguinGame';
+import { usePyramidGame } from './usePyramidGame';
+import { useSeahavenTowersGame } from './useSeahavenTowersGame';
+import { useSpadesGame } from './useSpadesGame';
+import { useSpideretteGame } from './useSpideretteGame';
+import { useSpiderGame } from './useSpiderGame';
+import { useTarneebGame } from './useTarneebGame';
+import { useTressetteGame } from './useTressetteGame';
+import { useTriPeaksGame } from './useTriPeaksGame';
+import { useTwoTenJackGame } from './useTwoTenJackGame';
+import { useWhistGame } from './useWhistGame';
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return createElement(QueryClientProvider, { client }, children);
+}
+
+function keysOf(hook: () => object): string[] {
+  const { result } = renderHook(hook, { wrapper });
+  return Object.keys(result.current as object).sort();
+}
+
+/**
+ * The wrappers around useTrickGameBase / useSolitaireGameBase re-exported the
+ * base result field by field, which meant a field added to a base hook was
+ * invisible to a game page until it was transcribed into that game's wrapper by
+ * hand. The transcription had already drifted: useWhistGame exposed
+ * clearSelection but not handleToggle, useBeloteGame the reverse -- both use the
+ * same base and neither difference reflects a game rule.
+ *
+ * These tests pin the contract that a wrapper forwards its base's entire
+ * surface, renaming only what it means to rename. See issue #4364.
+ */
+describe('trick-game hooks expose the full useTrickGameBase surface', () => {
+  // Fields every useTrickGameBase consumer must be able to reach. `config` is
+  // deliberately absent: each wrapper republishes it under a game-specific name.
+  const BASE_FIELDS = [
+    'clearSelection',
+    'error',
+    'exec',
+    'handleConfigChange',
+    'handleHint',
+    'handleNextRound',
+    'handleNextTrick',
+    'handlePlay',
+    'handleToggle',
+    'hint',
+    'hintError',
+    'hintLoading',
+    'loading',
+    'retry',
+    'selectedCardIndices',
+    'state',
+    'toggleCard',
+  ] as const;
+
+  it.each([
+    ['useBeloteGame', useBeloteGame, 'beloteConfig'],
+    ['useCallBreakGame', useCallBreakGame, 'callBreakConfig'],
+    ['useCatchTenGame', useCatchTenGame, 'catchtenConfig'],
+    ['useGaigelGame', useGaigelGame, 'gaigelConfig'],
+    ['useGongZhuGame', useGongZhuGame, 'gongzhuConfig'],
+    ['useHeartsGame', useHeartsGame, 'heartsConfig'],
+    ['useJassGame', useJassGame, 'jassConfig'],
+    ['useSpadesGame', useSpadesGame, 'spadesConfig'],
+    ['useTarneebGame', useTarneebGame, 'tarneebConfig'],
+    ['useTressetteGame', useTressetteGame, 'tressetteConfig'],
+    ['useTwoTenJackGame', useTwoTenJackGame, 'twoTenJackConfig'],
+    ['useWhistGame', useWhistGame, 'whistConfig'],
+  ])('%s forwards every base field and renames config', (_name, hook, configKey) => {
+    const keys = keysOf(hook as () => object);
+    for (const field of BASE_FIELDS) {
+      expect(keys).toContain(field);
+    }
+    expect(keys).toContain(configKey);
+    // The rename must be a rename, not an addition.
+    expect(keys).not.toContain('config');
+  });
+});
+
+describe('solitaire hooks expose the full useSolitaireGameBase surface', () => {
+  // `apiCall` is absent by design: the wrappers republish it as `exec` to match
+  // the naming every other game hook uses.
+  const BASE_FIELDS = [
+    'error',
+    'exec',
+    'handleAutoComplete',
+    'handleGiveUp',
+    'handleHint',
+    'handleReset',
+    'handleUndo',
+    'hint',
+    'hintError',
+    'isAutoCompleting',
+    'loading',
+    'retry',
+    'runAction',
+    'setHint',
+    'startAutoComplete',
+    'state',
+  ] as const;
+
+  it.each([
+    ['useBakersGameGame', useBakersGameGame],
+    ['useEightOffGame', useEightOffGame],
+    ['useFreeCellGame', useFreeCellGame],
+    ['useKlondikeGame', useKlondikeGame],
+    ['usePenguinGame', usePenguinGame],
+    ['usePyramidGame', usePyramidGame],
+    ['useSeahavenTowersGame', useSeahavenTowersGame],
+    ['useSpiderGame', useSpiderGame],
+    ['useSpideretteGame', useSpideretteGame],
+    ['useTriPeaksGame', useTriPeaksGame],
+  ])('%s forwards every base field', (_name, hook) => {
+    const keys = keysOf(hook as () => object);
+    for (const field of BASE_FIELDS) {
+      expect(keys).toContain(field);
+    }
+    expect(keys).not.toContain('apiCall');
+  });
+});

--- a/frontend/src/hooks/useBakersGameGame.ts
+++ b/frontend/src/hooks/useBakersGameGame.ts
@@ -12,7 +12,7 @@ export function useBakersGameGame() {
   const [selectedSource, setSelectedSource] = useState<FreeCellMoveZone | null>(null);
   const onClearSelection = useCallback(() => setSelectedSource(null), []);
 
-  const base = useSolitaireGameBase<
+  const { apiCall, runAction, setHint, ...rest } = useSolitaireGameBase<
     Awaited<ReturnType<typeof bakersgameApi.exec>>,
     Parameters<typeof bakersgameApi.exec>,
     FreeCellHint
@@ -21,10 +21,7 @@ export function useBakersGameGame() {
     hintApi: () => bakersgameApi.exec('hint'),
   });
 
-  const handleUndoEscape = useCallback(
-    (n: number) => base.runAction('undo_n', undefined, undefined, n),
-    [base.runAction],
-  );
+  const handleUndoEscape = useCallback((n: number) => runAction('undo_n', undefined, undefined, n), [runAction]);
 
   const handleSelectSource = useCallback((zone: FreeCellMoveZone) => {
     setSelectedSource((prev) => {
@@ -44,11 +41,11 @@ export function useBakersGameGame() {
   const handleSelectTarget = useCallback(
     (zone: FreeCellMoveZone) => {
       if (!selectedSource) return;
-      base.setHint(null);
-      void base.apiCall('move', selectedSource, zone);
+      setHint(null);
+      void apiCall('move', selectedSource, zone);
       setSelectedSource(null);
     },
-    [selectedSource, base],
+    [selectedSource, apiCall, setHint],
   );
 
   // Double-click / double-tap shortcut: dispatch a pre-computed auto-move (a
@@ -57,31 +54,22 @@ export function useBakersGameGame() {
   // stays in lockstep.
   const handleAutoMove = useCallback(
     (source: FreeCellMoveZone, target: FreeCellMoveZone) => {
-      base.setHint(null);
-      void base.apiCall('move', source, target);
+      setHint(null);
+      void apiCall('move', source, target);
       setSelectedSource(null);
     },
-    [base],
+    [apiCall, setHint],
   );
 
   return {
-    state: base.state,
-    loading: base.loading,
-    error: base.error,
-    hintError: base.hintError,
-    exec: base.apiCall,
+    ...rest,
+    runAction,
+    setHint,
+    exec: apiCall,
     selectedSource,
-    hint: base.hint,
-    handleReset: base.handleReset,
-    handleGiveUp: base.handleGiveUp,
-    handleHint: base.handleHint,
-    handleAutoComplete: base.handleAutoComplete,
-    handleUndo: base.handleUndo,
     handleUndoEscape,
     handleSelectSource,
     handleSelectTarget,
     handleAutoMove,
-    isAutoCompleting: base.isAutoCompleting,
-    retry: base.retry,
   };
 }

--- a/frontend/src/hooks/useBeloteGame.ts
+++ b/frontend/src/hooks/useBeloteGame.ts
@@ -23,51 +23,30 @@ export const TARGET_SCORE_OPTIONS = [500, 750, 1000, 1500] as const;
 
 /** Hook that manages Belote game state and player actions. */
 export function useBeloteGame() {
-  const base = useTrickGameBase({
+  const { exec, config, ...rest } = useTrickGameBase({
     apiFn: beloteApi.exec,
     defaultConfig: DEFAULT_BELOTE_CONFIG,
     getHint: (state) => state.hint ?? null,
   });
 
   const handleOrderUp = useCallback(() => {
-    void (base.exec as unknown as (command: string) => Promise<void>)('orderup');
-  }, [base.exec]);
+    void (exec as unknown as (command: string) => Promise<void>)('orderup');
+  }, [exec]);
 
   const handlePass = useCallback(() => {
-    void (base.exec as unknown as (command: string) => Promise<void>)('pass');
-  }, [base.exec]);
+    void (exec as unknown as (command: string) => Promise<void>)('pass');
+  }, [exec]);
 
   const handleCallTrump = useCallback(
     (suit: number) => {
-      void (base.exec as unknown as (command: string, cardIndex?: number, s?: number) => Promise<void>)(
+      void (exec as unknown as (command: string, cardIndex?: number, s?: number) => Promise<void>)(
         'calltrump',
         undefined,
         suit,
       );
     },
-    [base.exec],
+    [exec],
   );
 
-  return {
-    state: base.state,
-    loading: base.loading,
-    error: base.error,
-    hint: base.hint,
-    hintError: base.hintError,
-    hintLoading: base.hintLoading,
-    exec: base.exec,
-    beloteConfig: base.config,
-    selectedCardIndices: base.selectedCardIndices,
-    toggleCard: base.toggleCard,
-    handleConfigChange: base.handleConfigChange,
-    handleToggle: base.handleToggle,
-    handlePlay: base.handlePlay,
-    handleNextTrick: base.handleNextTrick,
-    handleNextRound: base.handleNextRound,
-    handleHint: base.handleHint,
-    handleOrderUp,
-    handlePass,
-    handleCallTrump,
-    retry: base.retry,
-  };
+  return { ...rest, exec, beloteConfig: config, handleOrderUp, handlePass, handleCallTrump };
 }

--- a/frontend/src/hooks/useCallBreakGame.ts
+++ b/frontend/src/hooks/useCallBreakGame.ts
@@ -21,13 +21,11 @@ export const CALLBREAK_MAX_ROUNDS_OPTIONS = [3, 5, 7, 10] as const;
 
 /** Hook that manages Call Break game state, bidding, and player actions. */
 export function useCallBreakGame() {
-  const base = useTrickGameBase({
+  const { exec, config, ...rest } = useTrickGameBase({
     apiFn: callBreakApi.exec,
     defaultConfig: DEFAULT_CALLBREAK_CONFIG,
     getHint: (state) => state.hint ?? null,
   });
-
-  const { exec } = base;
 
   const handleBid = useCallback(
     (bid: number) => {
@@ -36,24 +34,5 @@ export function useCallBreakGame() {
     [exec],
   );
 
-  return {
-    state: base.state,
-    loading: base.loading,
-    error: base.error,
-    hint: base.hint,
-    hintError: base.hintError,
-    hintLoading: base.hintLoading,
-    exec: base.exec,
-    callBreakConfig: base.config,
-    selectedCardIndices: base.selectedCardIndices,
-    toggleCard: base.toggleCard,
-    clearSelection: base.clearSelection,
-    handleConfigChange: base.handleConfigChange,
-    handleBid,
-    handlePlay: base.handlePlay,
-    handleNextTrick: base.handleNextTrick,
-    handleNextRound: base.handleNextRound,
-    handleHint: base.handleHint,
-    retry: base.retry,
-  };
+  return { ...rest, exec, callBreakConfig: config, handleBid };
 }

--- a/frontend/src/hooks/useCatchTenGame.ts
+++ b/frontend/src/hooks/useCatchTenGame.ts
@@ -20,29 +20,11 @@ export const POINT_LIMIT_OPTIONS = [21, 31, 41, 51] as const;
 
 /** Hook that manages Catch the Ten game state and player actions. */
 export function useCatchTenGame() {
-  const base = useTrickGameBase({
+  const { config, ...rest } = useTrickGameBase({
     apiFn: catchtenApi.exec,
     defaultConfig: DEFAULT_CATCHTEN_CONFIG,
     getHint: (state) => state.hint ?? null,
   });
 
-  return {
-    state: base.state,
-    loading: base.loading,
-    error: base.error,
-    hint: base.hint,
-    hintError: base.hintError,
-    hintLoading: base.hintLoading,
-    exec: base.exec,
-    catchtenConfig: base.config,
-    selectedCardIndices: base.selectedCardIndices,
-    toggleCard: base.toggleCard,
-    clearSelection: base.clearSelection,
-    handleConfigChange: base.handleConfigChange,
-    handlePlay: base.handlePlay,
-    handleNextTrick: base.handleNextTrick,
-    handleNextRound: base.handleNextRound,
-    handleHint: base.handleHint,
-    retry: base.retry,
-  };
+  return { ...rest, catchtenConfig: config };
 }

--- a/frontend/src/hooks/useEightOffGame.ts
+++ b/frontend/src/hooks/useEightOffGame.ts
@@ -8,7 +8,13 @@ export function useEightOffGame() {
   const [selectedSource, setSelectedSource] = useState<EightOffMoveZone | null>(null);
   const onClearSelection = useCallback(() => setSelectedSource(null), []);
 
-  const base = useSolitaireGameBase<
+  const {
+    handleHint: baseHandleHint,
+    apiCall,
+    runAction,
+    setHint,
+    ...rest
+  } = useSolitaireGameBase<
     Awaited<ReturnType<typeof eightoffApi.exec>>,
     Parameters<typeof eightoffApi.exec>,
     EightOffHint
@@ -17,19 +23,15 @@ export function useEightOffGame() {
     hintApi: () => eightoffApi.exec('hint'),
   });
 
-  const handleUndoEscape = useCallback(
-    (n: number) => base.runAction('undo_n', undefined, undefined, n),
-    [base.runAction],
-  );
+  const handleUndoEscape = useCallback((n: number) => runAction('undo_n', undefined, undefined, n), [runAction]);
 
   // Bumped every time a hint is requested so the page can announce the result
   // (a move, or "no moves available") even when two requests yield the same
   // hint value — a null hint after a request is indistinguishable from the
   // initial null without this signal.
   const [hintNonce, setHintNonce] = useState(0);
-  // Depend on the stable base.handleHint reference, not the whole `base` object
+  // Depend on the stable baseHandleHint reference, not the base result object
   // (which is re-created whenever state/loading change), so this callback stays stable.
-  const baseHandleHint = base.handleHint;
   const handleHint = useCallback(async () => {
     await baseHandleHint();
     setHintNonce((n) => n + 1);
@@ -53,31 +55,23 @@ export function useEightOffGame() {
   const handleSelectTarget = useCallback(
     (zone: EightOffMoveZone) => {
       if (!selectedSource) return;
-      base.setHint(null);
-      void base.apiCall('move', selectedSource, zone);
+      setHint(null);
+      void apiCall('move', selectedSource, zone);
       setSelectedSource(null);
     },
-    [selectedSource, base],
+    [selectedSource, apiCall, setHint],
   );
 
   return {
-    state: base.state,
-    loading: base.loading,
-    error: base.error,
-    hintError: base.hintError,
-    exec: base.apiCall,
+    ...rest,
+    runAction,
+    setHint,
+    exec: apiCall,
     selectedSource,
-    hint: base.hint,
     hintNonce,
-    handleReset: base.handleReset,
-    handleGiveUp: base.handleGiveUp,
     handleHint,
-    handleAutoComplete: base.handleAutoComplete,
-    handleUndo: base.handleUndo,
     handleUndoEscape,
     handleSelectSource,
     handleSelectTarget,
-    isAutoCompleting: base.isAutoCompleting,
-    retry: base.retry,
   };
 }

--- a/frontend/src/hooks/useFreeCellGame.ts
+++ b/frontend/src/hooks/useFreeCellGame.ts
@@ -8,7 +8,7 @@ export function useFreeCellGame() {
   const [selectedSource, setSelectedSource] = useState<FreeCellMoveZone | null>(null);
   const onClearSelection = useCallback(() => setSelectedSource(null), []);
 
-  const base = useSolitaireGameBase<
+  const { apiCall, runAction, setHint, ...rest } = useSolitaireGameBase<
     Awaited<ReturnType<typeof freecellApi.exec>>,
     Parameters<typeof freecellApi.exec>,
     FreeCellHint
@@ -17,10 +17,7 @@ export function useFreeCellGame() {
     hintApi: () => freecellApi.exec('hint'),
   });
 
-  const handleUndoEscape = useCallback(
-    (n: number) => base.runAction('undo_n', undefined, undefined, n),
-    [base.runAction],
-  );
+  const handleUndoEscape = useCallback((n: number) => runAction('undo_n', undefined, undefined, n), [runAction]);
 
   const handleSelectSource = useCallback((zone: FreeCellMoveZone) => {
     setSelectedSource((prev) => {
@@ -40,11 +37,11 @@ export function useFreeCellGame() {
   const handleSelectTarget = useCallback(
     (zone: FreeCellMoveZone) => {
       if (!selectedSource) return;
-      base.setHint(null);
-      void base.apiCall('move', selectedSource, zone);
+      setHint(null);
+      void apiCall('move', selectedSource, zone);
       setSelectedSource(null);
     },
-    [selectedSource, base],
+    [selectedSource, apiCall, setHint],
   );
 
   // Double-click / double-tap shortcut: dispatch a pre-computed foundation
@@ -52,31 +49,22 @@ export function useFreeCellGame() {
   // clear any pending selection so it stays in lockstep.
   const handleAutoFoundation = useCallback(
     (source: FreeCellMoveZone, target: FreeCellMoveZone) => {
-      base.setHint(null);
-      void base.apiCall('move', source, target);
+      setHint(null);
+      void apiCall('move', source, target);
       setSelectedSource(null);
     },
-    [base],
+    [apiCall, setHint],
   );
 
   return {
-    state: base.state,
-    loading: base.loading,
-    error: base.error,
-    hintError: base.hintError,
-    exec: base.apiCall,
+    ...rest,
+    runAction,
+    setHint,
+    exec: apiCall,
     selectedSource,
-    hint: base.hint,
-    handleReset: base.handleReset,
-    handleGiveUp: base.handleGiveUp,
-    handleHint: base.handleHint,
-    handleAutoComplete: base.handleAutoComplete,
-    handleUndo: base.handleUndo,
     handleUndoEscape,
     handleSelectSource,
     handleSelectTarget,
     handleAutoFoundation,
-    isAutoCompleting: base.isAutoCompleting,
-    retry: base.retry,
   };
 }

--- a/frontend/src/hooks/useGaigelGame.ts
+++ b/frontend/src/hooks/useGaigelGame.ts
@@ -21,7 +21,7 @@ export const TARGET_SCORE_OPTIONS = [101, 201, 301] as const;
 
 /** Hook that manages Gaigel game state and player actions. */
 export function useGaigelGame() {
-  const base = useTrickGameBase({
+  const { exec, config, ...rest } = useTrickGameBase({
     apiFn: gaigelApi.exec,
     defaultConfig: DEFAULT_GAIGEL_CONFIG,
     getHint: (state) => state.hint ?? null,
@@ -29,32 +29,14 @@ export function useGaigelGame() {
 
   const handleMarriage = useCallback(
     (cardIndex: number) => {
-      void (base.exec as unknown as (command: string, a1?: number, ci?: number) => Promise<void>)(
+      void (exec as unknown as (command: string, a1?: number, ci?: number) => Promise<void>)(
         'marriage',
         undefined,
         cardIndex,
       );
     },
-    [base.exec],
+    [exec],
   );
 
-  return {
-    state: base.state,
-    loading: base.loading,
-    error: base.error,
-    hint: base.hint,
-    hintError: base.hintError,
-    hintLoading: base.hintLoading,
-    exec: base.exec,
-    gaigelConfig: base.config,
-    selectedCardIndices: base.selectedCardIndices,
-    toggleCard: base.toggleCard,
-    handleConfigChange: base.handleConfigChange,
-    handlePlay: base.handlePlay,
-    handleMarriage,
-    handleNextTrick: base.handleNextTrick,
-    handleNextRound: base.handleNextRound,
-    handleHint: base.handleHint,
-    retry: base.retry,
-  };
+  return { ...rest, exec, gaigelConfig: config, handleMarriage };
 }

--- a/frontend/src/hooks/useGongZhuGame.ts
+++ b/frontend/src/hooks/useGongZhuGame.ts
@@ -21,37 +21,15 @@ export const POINT_LIMIT_OPTIONS = [500, 1000, 1500, 2000] as const;
 
 /** Hook that manages Gong Zhu game state and player actions. */
 export function useGongZhuGame() {
-  const base = useTrickGameBase({
+  const { exec, selectedCardIndices, config, ...rest } = useTrickGameBase({
     apiFn: gongzhuApi.exec,
     defaultConfig: DEFAULT_GONGZHU_CONFIG,
     getHint: (state) => state.hint ?? null,
   });
 
-  const { exec, selectedCardIndices } = base;
-
   const handleExpose = useCallback(() => {
     exec('expose', selectedCardIndices);
   }, [exec, selectedCardIndices]);
 
-  return {
-    state: base.state,
-    loading: base.loading,
-    error: base.error,
-    hint: base.hint,
-    hintError: base.hintError,
-    hintLoading: base.hintLoading,
-    exec: base.exec,
-    gongzhuConfig: base.config,
-    selectedCardIndices: base.selectedCardIndices,
-    toggleCard: base.toggleCard,
-    clearSelection: base.clearSelection,
-    handleConfigChange: base.handleConfigChange,
-    handleToggle: base.handleToggle,
-    handleExpose,
-    handlePlay: base.handlePlay,
-    handleNextTrick: base.handleNextTrick,
-    handleNextRound: base.handleNextRound,
-    handleHint: base.handleHint,
-    retry: base.retry,
-  };
+  return { ...rest, exec, gongzhuConfig: config, selectedCardIndices, handleExpose };
 }

--- a/frontend/src/hooks/useHeartsGame.ts
+++ b/frontend/src/hooks/useHeartsGame.ts
@@ -22,37 +22,15 @@ export const POINT_LIMIT_OPTIONS = [50, 100, 150, 200] as const;
 
 /** Hook that manages Hearts game state and player actions. */
 export function useHeartsGame() {
-  const base = useTrickGameBase({
+  const { exec, selectedCardIndices, config, ...rest } = useTrickGameBase({
     apiFn: heartsApi.exec,
     defaultConfig: DEFAULT_HEARTS_CONFIG,
     getHint: (state) => state.hint ?? null,
   });
 
-  const { exec, selectedCardIndices } = base;
-
   const handlePass = useCallback(() => {
     exec('pass', selectedCardIndices);
   }, [exec, selectedCardIndices]);
 
-  return {
-    state: base.state,
-    loading: base.loading,
-    error: base.error,
-    hint: base.hint,
-    hintError: base.hintError,
-    hintLoading: base.hintLoading,
-    exec: base.exec,
-    heartsConfig: base.config,
-    selectedCardIndices: base.selectedCardIndices,
-    toggleCard: base.toggleCard,
-    clearSelection: base.clearSelection,
-    handleConfigChange: base.handleConfigChange,
-    handleToggle: base.handleToggle,
-    handlePass,
-    handlePlay: base.handlePlay,
-    handleNextTrick: base.handleNextTrick,
-    handleNextRound: base.handleNextRound,
-    handleHint: base.handleHint,
-    retry: base.retry,
-  };
+  return { ...rest, exec, heartsConfig: config, selectedCardIndices, handlePass };
 }

--- a/frontend/src/hooks/useJassGame.ts
+++ b/frontend/src/hooks/useJassGame.ts
@@ -23,7 +23,7 @@ export const TARGET_SCORE_OPTIONS = [500, 1000, 1500, 2500] as const;
 
 /** Hook that manages Jass (Schieber) game state and player actions. */
 export function useJassGame() {
-  const base = useTrickGameBase({
+  const { exec, config, ...rest } = useTrickGameBase({
     apiFn: jassApi.exec,
     defaultConfig: DEFAULT_JASS_CONFIG,
     getHint: (state) => state.hint ?? null,
@@ -31,34 +31,14 @@ export function useJassGame() {
 
   const handleCallTrump = useCallback(
     (suit: number) => {
-      void (base.exec as unknown as (command: string, s?: number) => Promise<void>)('calltrump', suit);
+      void (exec as unknown as (command: string, s?: number) => Promise<void>)('calltrump', suit);
     },
-    [base.exec],
+    [exec],
   );
 
   const handleSchieben = useCallback(() => {
-    void (base.exec as unknown as (command: string) => Promise<void>)('schieben');
-  }, [base.exec]);
+    void (exec as unknown as (command: string) => Promise<void>)('schieben');
+  }, [exec]);
 
-  return {
-    state: base.state,
-    loading: base.loading,
-    error: base.error,
-    hint: base.hint,
-    hintError: base.hintError,
-    hintLoading: base.hintLoading,
-    exec: base.exec,
-    jassConfig: base.config,
-    selectedCardIndices: base.selectedCardIndices,
-    toggleCard: base.toggleCard,
-    handleConfigChange: base.handleConfigChange,
-    handleToggle: base.handleToggle,
-    handlePlay: base.handlePlay,
-    handleNextTrick: base.handleNextTrick,
-    handleNextRound: base.handleNextRound,
-    handleHint: base.handleHint,
-    handleCallTrump,
-    handleSchieben,
-    retry: base.retry,
-  };
+  return { ...rest, exec, jassConfig: config, handleCallTrump, handleSchieben };
 }

--- a/frontend/src/hooks/useKlondikeGame.ts
+++ b/frontend/src/hooks/useKlondikeGame.ts
@@ -8,7 +8,7 @@ export function useKlondikeGame() {
   const [selectedSource, setSelectedSource] = useState<KlondikeMoveZone | null>(null);
   const onClearSelection = useCallback(() => setSelectedSource(null), []);
 
-  const base = useSolitaireGameBase<
+  const { apiCall, runAction, setHint, ...rest } = useSolitaireGameBase<
     Awaited<ReturnType<typeof klondikeApi.exec>>,
     Parameters<typeof klondikeApi.exec>,
     KlondikeHint
@@ -17,14 +17,14 @@ export function useKlondikeGame() {
     hintApi: () => klondikeApi.exec('hint'),
   });
 
-  const handleDraw = useCallback(() => base.runAction('draw'), [base.runAction]);
+  const handleDraw = useCallback(() => runAction('draw'), [runAction]);
   const handleResetWithConfig = useCallback(
-    (config: KlondikeConfigInput) => base.runAction('reset', undefined, undefined, config),
-    [base.runAction],
+    (config: KlondikeConfigInput) => runAction('reset', undefined, undefined, config),
+    [runAction],
   );
   const handleUndoEscape = useCallback(
-    (n: number) => base.runAction('undo_n', undefined, undefined, undefined, n),
-    [base.runAction],
+    (n: number) => runAction('undo_n', undefined, undefined, undefined, n),
+    [runAction],
   );
 
   const handleSelectSource = useCallback((zone: KlondikeMoveZone) => {
@@ -39,32 +39,23 @@ export function useKlondikeGame() {
   const handleSelectTarget = useCallback(
     (zone: KlondikeMoveZone) => {
       if (!selectedSource) return;
-      base.setHint(null);
-      void base.apiCall('move', selectedSource, zone);
+      setHint(null);
+      void apiCall('move', selectedSource, zone);
       setSelectedSource(null);
     },
-    [selectedSource, base],
+    [selectedSource, apiCall, setHint],
   );
 
   return {
-    state: base.state,
-    loading: base.loading,
-    error: base.error,
-    hintError: base.hintError,
-    exec: base.apiCall,
+    ...rest,
+    runAction,
+    setHint,
+    exec: apiCall,
     selectedSource,
-    hint: base.hint,
     handleDraw,
-    handleReset: base.handleReset,
     handleResetWithConfig,
-    handleGiveUp: base.handleGiveUp,
-    handleHint: base.handleHint,
-    handleAutoComplete: base.handleAutoComplete,
-    handleUndo: base.handleUndo,
     handleUndoEscape,
     handleSelectSource,
     handleSelectTarget,
-    isAutoCompleting: base.isAutoCompleting,
-    retry: base.retry,
   };
 }

--- a/frontend/src/hooks/usePenguinGame.ts
+++ b/frontend/src/hooks/usePenguinGame.ts
@@ -8,7 +8,7 @@ export function usePenguinGame() {
   const [selectedSource, setSelectedSource] = useState<PenguinMoveZone | null>(null);
   const onClearSelection = useCallback(() => setSelectedSource(null), []);
 
-  const base = useSolitaireGameBase<
+  const { apiCall, runAction, setHint, ...rest } = useSolitaireGameBase<
     Awaited<ReturnType<typeof penguinApi.exec>>,
     Parameters<typeof penguinApi.exec>,
     PenguinHint
@@ -17,10 +17,7 @@ export function usePenguinGame() {
     hintApi: () => penguinApi.exec('hint'),
   });
 
-  const handleUndoEscape = useCallback(
-    (n: number) => base.runAction('undo_n', undefined, undefined, n),
-    [base.runAction],
-  );
+  const handleUndoEscape = useCallback((n: number) => runAction('undo_n', undefined, undefined, n), [runAction]);
 
   const handleSelectSource = useCallback((zone: PenguinMoveZone) => {
     setSelectedSource((prev) => {
@@ -40,30 +37,21 @@ export function usePenguinGame() {
   const handleSelectTarget = useCallback(
     (zone: PenguinMoveZone) => {
       if (!selectedSource) return;
-      base.setHint(null);
-      void base.apiCall('move', selectedSource, zone);
+      setHint(null);
+      void apiCall('move', selectedSource, zone);
       setSelectedSource(null);
     },
-    [selectedSource, base],
+    [selectedSource, apiCall, setHint],
   );
 
   return {
-    state: base.state,
-    loading: base.loading,
-    error: base.error,
-    hintError: base.hintError,
-    exec: base.apiCall,
+    ...rest,
+    runAction,
+    setHint,
+    exec: apiCall,
     selectedSource,
-    hint: base.hint,
-    handleReset: base.handleReset,
-    handleGiveUp: base.handleGiveUp,
-    handleHint: base.handleHint,
-    handleAutoComplete: base.handleAutoComplete,
-    handleUndo: base.handleUndo,
     handleUndoEscape,
     handleSelectSource,
     handleSelectTarget,
-    isAutoCompleting: base.isAutoCompleting,
-    retry: base.retry,
   };
 }

--- a/frontend/src/hooks/usePyramidGame.ts
+++ b/frontend/src/hooks/usePyramidGame.ts
@@ -15,7 +15,7 @@ export function usePyramidGame() {
   const [selectedCard, setSelectedCard] = useState<PyramidSelection | null>(null);
   const onClearSelection = useCallback(() => setSelectedCard(null), []);
 
-  const base = useSolitaireGameBase<
+  const { apiCall, runAction, setHint, ...rest } = useSolitaireGameBase<
     Awaited<ReturnType<typeof pyramidApi.exec>>,
     Parameters<typeof pyramidApi.exec>,
     PyramidHint
@@ -24,11 +24,8 @@ export function usePyramidGame() {
     hintApi: () => pyramidApi.exec('hint'),
   });
 
-  const handleDraw = useCallback(() => base.runAction('draw'), [base.runAction]);
-  const handleUndoEscape = useCallback(
-    (n: number) => base.runAction('undo_n', undefined, undefined, n),
-    [base.runAction],
-  );
+  const handleDraw = useCallback(() => runAction('draw'), [runAction]);
+  const handleUndoEscape = useCallback((n: number) => runAction('undo_n', undefined, undefined, n), [runAction]);
 
   const selectionToRemoveCard = useCallback((sel: PyramidSelection): PyramidRemoveCard => {
     return { zone: sel.zone, row: sel.row, col: sel.col };
@@ -37,10 +34,10 @@ export function usePyramidGame() {
   const handleSelectCard = useCallback(
     (sel: PyramidSelection, cardValue?: number) => {
       // Any card interaction consumes the current hint.
-      base.setHint(null);
+      setHint(null);
       // King (value 13) - remove solo immediately
       if (cardValue === 13) {
-        void base.apiCall('remove', selectionToRemoveCard(sel));
+        void apiCall('remove', selectionToRemoveCard(sel));
         setSelectedCard(null);
         return;
       }
@@ -58,27 +55,11 @@ export function usePyramidGame() {
       }
 
       // Second card selected - attempt to remove pair
-      void base.apiCall('remove', selectionToRemoveCard(selectedCard), selectionToRemoveCard(sel));
+      void apiCall('remove', selectionToRemoveCard(selectedCard), selectionToRemoveCard(sel));
       setSelectedCard(null);
     },
-    [selectedCard, base, selectionToRemoveCard],
+    [selectedCard, apiCall, setHint, selectionToRemoveCard],
   );
 
-  return {
-    state: base.state,
-    loading: base.loading,
-    error: base.error,
-    exec: base.apiCall,
-    hintError: base.hintError,
-    selectedCard,
-    hint: base.hint,
-    handleDraw,
-    handleReset: base.handleReset,
-    handleGiveUp: base.handleGiveUp,
-    handleHint: base.handleHint,
-    handleUndo: base.handleUndo,
-    handleUndoEscape,
-    handleSelectCard,
-    retry: base.retry,
-  };
+  return { ...rest, runAction, setHint, exec: apiCall, selectedCard, handleDraw, handleUndoEscape, handleSelectCard };
 }

--- a/frontend/src/hooks/useSeahavenTowersGame.ts
+++ b/frontend/src/hooks/useSeahavenTowersGame.ts
@@ -8,7 +8,7 @@ export function useSeahavenTowersGame() {
   const [selectedSource, setSelectedSource] = useState<SeahavenTowersMoveZone | null>(null);
   const onClearSelection = useCallback(() => setSelectedSource(null), []);
 
-  const base = useSolitaireGameBase<
+  const { apiCall, runAction, setHint, ...rest } = useSolitaireGameBase<
     Awaited<ReturnType<typeof seahaventowersApi.exec>>,
     Parameters<typeof seahaventowersApi.exec>,
     SeahavenTowersHint
@@ -17,10 +17,7 @@ export function useSeahavenTowersGame() {
     hintApi: () => seahaventowersApi.exec('hint'),
   });
 
-  const handleUndoEscape = useCallback(
-    (n: number) => base.runAction('undo_n', undefined, undefined, n),
-    [base.runAction],
-  );
+  const handleUndoEscape = useCallback((n: number) => runAction('undo_n', undefined, undefined, n), [runAction]);
 
   const handleSelectSource = useCallback((zone: SeahavenTowersMoveZone) => {
     setSelectedSource((prev) => {
@@ -40,30 +37,21 @@ export function useSeahavenTowersGame() {
   const handleSelectTarget = useCallback(
     (zone: SeahavenTowersMoveZone) => {
       if (!selectedSource) return;
-      base.setHint(null);
-      void base.apiCall('move', selectedSource, zone);
+      setHint(null);
+      void apiCall('move', selectedSource, zone);
       setSelectedSource(null);
     },
-    [selectedSource, base],
+    [selectedSource, apiCall, setHint],
   );
 
   return {
-    state: base.state,
-    loading: base.loading,
-    error: base.error,
-    hintError: base.hintError,
-    exec: base.apiCall,
+    ...rest,
+    runAction,
+    setHint,
+    exec: apiCall,
     selectedSource,
-    hint: base.hint,
-    handleReset: base.handleReset,
-    handleGiveUp: base.handleGiveUp,
-    handleHint: base.handleHint,
-    handleAutoComplete: base.handleAutoComplete,
-    handleUndo: base.handleUndo,
     handleUndoEscape,
     handleSelectSource,
     handleSelectTarget,
-    isAutoCompleting: base.isAutoCompleting,
-    retry: base.retry,
   };
 }

--- a/frontend/src/hooks/useSpadesGame.ts
+++ b/frontend/src/hooks/useSpadesGame.ts
@@ -29,13 +29,11 @@ export const BAG_PENALTY_THRESHOLD_OPTIONS = [5, 10, 15] as const;
 
 /** Hook that manages Spades game state, bidding, and player actions. */
 export function useSpadesGame() {
-  const base = useTrickGameBase({
+  const { exec, config, ...rest } = useTrickGameBase({
     apiFn: spadesApi.exec,
     defaultConfig: DEFAULT_SPADES_CONFIG,
     getHint: (state) => state.hint ?? null,
   });
-
-  const { exec } = base;
 
   const handleBid = useCallback(
     (bid: number) => {
@@ -44,24 +42,5 @@ export function useSpadesGame() {
     [exec],
   );
 
-  return {
-    state: base.state,
-    loading: base.loading,
-    error: base.error,
-    hint: base.hint,
-    hintError: base.hintError,
-    hintLoading: base.hintLoading,
-    exec: base.exec,
-    spadesConfig: base.config,
-    selectedCardIndices: base.selectedCardIndices,
-    toggleCard: base.toggleCard,
-    clearSelection: base.clearSelection,
-    handleConfigChange: base.handleConfigChange,
-    handleBid,
-    handlePlay: base.handlePlay,
-    handleNextTrick: base.handleNextTrick,
-    handleNextRound: base.handleNextRound,
-    handleHint: base.handleHint,
-    retry: base.retry,
-  };
+  return { ...rest, exec, spadesConfig: config, handleBid };
 }

--- a/frontend/src/hooks/useSpiderGame.ts
+++ b/frontend/src/hooks/useSpiderGame.ts
@@ -8,7 +8,7 @@ export function useSpiderGame() {
   const [selectedSource, setSelectedSource] = useState<SpiderMoveZone | null>(null);
   const onClearSelection = useCallback(() => setSelectedSource(null), []);
 
-  const base = useSolitaireGameBase<
+  const { apiCall, runAction, setHint, ...rest } = useSolitaireGameBase<
     Awaited<ReturnType<typeof spiderApi.exec>>,
     Parameters<typeof spiderApi.exec>,
     SpiderHint
@@ -17,14 +17,14 @@ export function useSpiderGame() {
     hintApi: () => spiderApi.exec('hint'),
   });
 
-  const handleDeal = useCallback(() => base.runAction('deal'), [base.runAction]);
+  const handleDeal = useCallback(() => runAction('deal'), [runAction]);
   const handleResetWithConfig = useCallback(
-    (config: SpiderConfigInput) => base.runAction('reset', undefined, undefined, config),
-    [base.runAction],
+    (config: SpiderConfigInput) => runAction('reset', undefined, undefined, config),
+    [runAction],
   );
   const handleUndoEscape = useCallback(
-    (n: number) => base.runAction('undo_n', undefined, undefined, undefined, n),
-    [base.runAction],
+    (n: number) => runAction('undo_n', undefined, undefined, undefined, n),
+    [runAction],
   );
 
   const handleSelectSource = useCallback((zone: SpiderMoveZone) => {
@@ -39,32 +39,23 @@ export function useSpiderGame() {
   const handleSelectTarget = useCallback(
     (zone: SpiderMoveZone) => {
       if (!selectedSource) return;
-      base.setHint(null);
-      void base.apiCall('move', selectedSource, zone);
+      setHint(null);
+      void apiCall('move', selectedSource, zone);
       setSelectedSource(null);
     },
-    [selectedSource, base],
+    [selectedSource, apiCall, setHint],
   );
 
   return {
-    state: base.state,
-    loading: base.loading,
-    error: base.error,
-    exec: base.apiCall,
-    hintError: base.hintError,
+    ...rest,
+    runAction,
+    setHint,
+    exec: apiCall,
     selectedSource,
-    hint: base.hint,
     handleDeal,
-    handleReset: base.handleReset,
     handleResetWithConfig,
-    handleGiveUp: base.handleGiveUp,
-    handleHint: base.handleHint,
-    handleAutoComplete: base.handleAutoComplete,
-    handleUndo: base.handleUndo,
     handleUndoEscape,
     handleSelectSource,
     handleSelectTarget,
-    isAutoCompleting: base.isAutoCompleting,
-    retry: base.retry,
   };
 }

--- a/frontend/src/hooks/useSpideretteGame.ts
+++ b/frontend/src/hooks/useSpideretteGame.ts
@@ -10,7 +10,7 @@ export function useSpideretteGame() {
   const [selectedSource, setSelectedSource] = useState<SpideretteMoveZone | null>(null);
   const onClearSelection = useCallback(() => setSelectedSource(null), []);
 
-  const base = useSolitaireGameBase<
+  const { apiCall, runAction, setHint, ...rest } = useSolitaireGameBase<
     Awaited<ReturnType<typeof runCommand>>,
     Parameters<typeof runCommand>,
     SpideretteHint
@@ -19,11 +19,8 @@ export function useSpideretteGame() {
     hintApi: () => runCommand('hint'),
   });
 
-  const handleDeal = useCallback(() => base.runAction('deal'), [base.runAction]);
-  const handleUndoEscape = useCallback(
-    (n: number) => base.runAction('undo_n', undefined, undefined, n),
-    [base.runAction],
-  );
+  const handleDeal = useCallback(() => runAction('deal'), [runAction]);
+  const handleUndoEscape = useCallback((n: number) => runAction('undo_n', undefined, undefined, n), [runAction]);
 
   const handleSelectSource = useCallback((zone: SpideretteMoveZone) => {
     setSelectedSource((prev) => {
@@ -37,31 +34,22 @@ export function useSpideretteGame() {
   const handleSelectTarget = useCallback(
     (zone: SpideretteMoveZone) => {
       if (!selectedSource) return;
-      base.setHint(null);
-      void base.apiCall('move', selectedSource, zone);
+      setHint(null);
+      void apiCall('move', selectedSource, zone);
       setSelectedSource(null);
     },
-    [selectedSource, base],
+    [selectedSource, apiCall, setHint],
   );
 
   return {
-    state: base.state,
-    loading: base.loading,
-    error: base.error,
-    exec: base.apiCall,
-    hintError: base.hintError,
+    ...rest,
+    runAction,
+    setHint,
+    exec: apiCall,
     selectedSource,
-    hint: base.hint,
     handleDeal,
-    handleReset: base.handleReset,
-    handleGiveUp: base.handleGiveUp,
-    handleHint: base.handleHint,
-    handleAutoComplete: base.handleAutoComplete,
-    handleUndo: base.handleUndo,
     handleUndoEscape,
     handleSelectSource,
     handleSelectTarget,
-    isAutoCompleting: base.isAutoCompleting,
-    retry: base.retry,
   };
 }

--- a/frontend/src/hooks/useTarneebGame.ts
+++ b/frontend/src/hooks/useTarneebGame.ts
@@ -25,13 +25,15 @@ export const TARNEEB_MIN_BID_OPTIONS = [5, 6, 7, 8] as const;
 
 /** Hook that manages Tarneeb game state, bidding, trump declaration, and play. */
 export function useTarneebGame() {
-  const base = useTrickGameBase({
+  const {
+    exec: runAction,
+    config,
+    ...rest
+  } = useTrickGameBase({
     apiFn: tarneebApi.exec,
     defaultConfig: DEFAULT_TARNEEB_CONFIG,
     getHint: (state) => state.hint ?? null,
   });
-
-  const runAction = base.exec;
 
   const handleBid = useCallback(
     (bid: number) => {
@@ -47,25 +49,5 @@ export function useTarneebGame() {
     [runAction],
   );
 
-  return {
-    state: base.state,
-    loading: base.loading,
-    error: base.error,
-    hint: base.hint,
-    hintError: base.hintError,
-    hintLoading: base.hintLoading,
-    exec: base.exec,
-    tarneebConfig: base.config,
-    selectedCardIndices: base.selectedCardIndices,
-    toggleCard: base.toggleCard,
-    clearSelection: base.clearSelection,
-    handleConfigChange: base.handleConfigChange,
-    handleBid,
-    handleDeclareTrump,
-    handlePlay: base.handlePlay,
-    handleNextTrick: base.handleNextTrick,
-    handleNextRound: base.handleNextRound,
-    handleHint: base.handleHint,
-    retry: base.retry,
-  };
+  return { ...rest, exec: runAction, tarneebConfig: config, handleBid, handleDeclareTrump };
 }

--- a/frontend/src/hooks/useTressetteGame.ts
+++ b/frontend/src/hooks/useTressetteGame.ts
@@ -20,30 +20,11 @@ export const TARGET_POINTS_OPTIONS = [11, 21, 31, 41] as const;
 
 /** Hook that manages Tressette game state and player actions. */
 export function useTressetteGame() {
-  const base = useTrickGameBase({
+  const { config, ...rest } = useTrickGameBase({
     apiFn: tressetteApi.exec,
     defaultConfig: DEFAULT_TRESSETTE_CONFIG,
     getHint: (state) => state.hint ?? null,
   });
 
-  return {
-    state: base.state,
-    loading: base.loading,
-    error: base.error,
-    hint: base.hint,
-    hintError: base.hintError,
-    hintLoading: base.hintLoading,
-    exec: base.exec,
-    tressetteConfig: base.config,
-    selectedCardIndices: base.selectedCardIndices,
-    toggleCard: base.toggleCard,
-    clearSelection: base.clearSelection,
-    handleConfigChange: base.handleConfigChange,
-    handleToggle: base.handleToggle,
-    handlePlay: base.handlePlay,
-    handleNextTrick: base.handleNextTrick,
-    handleNextRound: base.handleNextRound,
-    handleHint: base.handleHint,
-    retry: base.retry,
-  };
+  return { ...rest, tressetteConfig: config };
 }

--- a/frontend/src/hooks/useTriPeaksGame.ts
+++ b/frontend/src/hooks/useTriPeaksGame.ts
@@ -5,7 +5,7 @@ import { useSolitaireGameBase } from './useSolitaireGameBase';
 
 /** Hook that manages TriPeaks game state, hints, and card removal actions. */
 export function useTriPeaksGame() {
-  const base = useSolitaireGameBase<
+  const { apiCall, runAction, setHint, ...rest } = useSolitaireGameBase<
     Awaited<ReturnType<typeof tripeaksApi.exec>>,
     Parameters<typeof tripeaksApi.exec>,
     TriPeaksHint
@@ -13,34 +13,16 @@ export function useTriPeaksGame() {
     hintApi: () => tripeaksApi.exec('hint'),
   });
 
-  const handleDraw = useCallback(() => base.runAction('draw'), [base.runAction]);
-  const handleUndoEscape = useCallback(
-    (n: number) => base.runAction('undo_n', undefined, undefined, n),
-    [base.runAction],
-  );
+  const handleDraw = useCallback(() => runAction('draw'), [runAction]);
+  const handleUndoEscape = useCallback((n: number) => runAction('undo_n', undefined, undefined, n), [runAction]);
 
   const handleSelectCard = useCallback(
     (row: number, col: number) => {
-      base.setHint(null);
-      void base.apiCall('remove', row, col);
+      setHint(null);
+      void apiCall('remove', row, col);
     },
-    [base],
+    [apiCall, setHint],
   );
 
-  return {
-    state: base.state,
-    loading: base.loading,
-    error: base.error,
-    exec: base.apiCall,
-    hintError: base.hintError,
-    hint: base.hint,
-    handleDraw,
-    handleReset: base.handleReset,
-    handleGiveUp: base.handleGiveUp,
-    handleHint: base.handleHint,
-    handleUndo: base.handleUndo,
-    handleUndoEscape,
-    handleSelectCard,
-    retry: base.retry,
-  };
+  return { ...rest, runAction, setHint, exec: apiCall, handleDraw, handleUndoEscape, handleSelectCard };
 }

--- a/frontend/src/hooks/useTwoTenJackGame.ts
+++ b/frontend/src/hooks/useTwoTenJackGame.ts
@@ -24,13 +24,15 @@ export const POINT_LIMIT_OPTIONS = [30, 50, 75, 100] as const;
  * Wraps {@link useTrickGameBase} and exposes a trump suit declaration handler.
  */
 export function useTwoTenJackGame() {
-  const base = useTrickGameBase({
+  const {
+    exec: dispatch,
+    config,
+    ...rest
+  } = useTrickGameBase({
     apiFn: twoTenJackApi.exec,
     defaultConfig: DEFAULT_TWOTENJACK_CONFIG,
     getHint: (state) => state.hint ?? null,
   });
-
-  const dispatch = base.exec;
 
   const handleDeclare = useCallback(
     (trumpSuit: number) => {
@@ -39,24 +41,5 @@ export function useTwoTenJackGame() {
     [dispatch],
   );
 
-  return {
-    state: base.state,
-    loading: base.loading,
-    error: base.error,
-    hint: base.hint,
-    hintError: base.hintError,
-    hintLoading: base.hintLoading,
-    exec: base.exec,
-    twoTenJackConfig: base.config,
-    selectedCardIndices: base.selectedCardIndices,
-    toggleCard: base.toggleCard,
-    clearSelection: base.clearSelection,
-    handleConfigChange: base.handleConfigChange,
-    handleDeclare,
-    handlePlay: base.handlePlay,
-    handleNextTrick: base.handleNextTrick,
-    handleNextRound: base.handleNextRound,
-    handleHint: base.handleHint,
-    retry: base.retry,
-  };
+  return { ...rest, exec: dispatch, twoTenJackConfig: config, handleDeclare };
 }

--- a/frontend/src/hooks/useWhistGame.ts
+++ b/frontend/src/hooks/useWhistGame.ts
@@ -20,29 +20,11 @@ export const POINT_LIMIT_OPTIONS = [3, 5, 7, 10] as const;
 
 /** Hook that manages Whist game state and player actions. */
 export function useWhistGame() {
-  const base = useTrickGameBase({
+  const { config, ...rest } = useTrickGameBase({
     apiFn: whistApi.exec,
     defaultConfig: DEFAULT_WHIST_CONFIG,
     getHint: (state) => state.hint ?? null,
   });
 
-  return {
-    state: base.state,
-    loading: base.loading,
-    error: base.error,
-    hint: base.hint,
-    hintError: base.hintError,
-    hintLoading: base.hintLoading,
-    exec: base.exec,
-    whistConfig: base.config,
-    selectedCardIndices: base.selectedCardIndices,
-    toggleCard: base.toggleCard,
-    clearSelection: base.clearSelection,
-    handleConfigChange: base.handleConfigChange,
-    handlePlay: base.handlePlay,
-    handleNextTrick: base.handleNextTrick,
-    handleNextRound: base.handleNextRound,
-    handleHint: base.handleHint,
-    retry: base.retry,
-  };
+  return { ...rest, whistConfig: config };
 }


### PR DESCRIPTION
## Summary

The 22 hooks wrapping `useTrickGameBase` / `useSolitaireGameBase` re-exported the base result one field at a time. The only real transformations were two renames — `config` → `<game>Config` and `apiCall` → `exec` — so the rest was 1:1 passthrough kept in sync by hand.

**Net −356 lines** across the 22 hooks (509 deletions / 153 insertions).

```ts
// before — useWhistGame, 19 of 48 lines
return {
  state: base.state, loading: base.loading, error: base.error,
  /* …14 more… */  whistConfig: base.config,  retry: base.retry,
};

// after
const { config, ...rest } = useTrickGameBase({ /* … */ });
return { ...rest, whistConfig: config };
```

## The drift was worse than reported

The issue cited `clearSelection` / `handleToggle` diverging between `useWhistGame` and `useBeloteGame`. Writing the guard test first showed **19 of the 22 hooks** were missing at least one base field, and that **all ten solitaire wrappers** dropped `runAction` *and* `setHint`. None of those differences track a game rule — they track which sibling each file was copied from.

For fields a wrapper binds for internal use (`runAction` / `setHint`), I re-export them explicitly rather than leaving them absent, so nothing silently drops out of a page's reach again. This widens the return type of those 10 hooks, which the issue anticipated and endorsed; `bun run typecheck` is clean.

## Two incidental improvements

1. **Tighter dependency arrays.** Ten callbacks listed the whole `base` object as a dependency. `base` is a `useMemo`'d object keyed on `state`/`loading`, so those callbacks were re-created on *every state change*; they now depend on the specific stable functions they call. Referential identity of e.g. `handleSelectTarget` changes less often than before — a behavior change in the safe direction, and all page tests pass.
2. **Folded redundant destructuring.** Six hooks had a second `const { exec } = base;` line after the base call purely to reach a field; that is now the same statement.

## Test plan

- [x] **New `gameHookBaseSurface.test.ts`** renders all 22 wrappers and asserts each exposes its base's full surface plus its renames. **19 of 22 failed before this change**, all 22 pass after — this is the guard that makes the passthrough unnecessary rather than merely shorter.
- [x] `bun run typecheck` — clean (the real gate here; it catches any page reaching for a field the spread dropped)
- [x] `bun run check` — clean, including `useExhaustiveDependencies` on every rewritten dep array
- [x] `bun run test` — 15,815 passed
- [x] `bun run build` — clean
- [x] Existing `use*Game.test.ts` suites pass untouched, acting as the behavior-preservation net

Note: `src/App.test.tsx` (`/discover` route) failed once in the full run and passes in isolation — the same cross-file draft-state flake seen on #4420, unrelated to these files.

Closes #4364