### PR TITLE
fix(frontend): make state badges readable on every table felt

### DIFF
--- a/frontend/scripts/check-design-tokens.mjs
+++ b/frontend/scripts/check-design-tokens.mjs
@@ -240,7 +240,7 @@ const BADGE_TOKEN = /\bbg-ds-(warning|info|success|error)\/\d+\b/g;
 function classNameValues(text) {
   const out = [];
   for (const m of text.matchAll(/className=/g)) {
-    let i = m.index + m[0].length;
+    const i = m.index + m[0].length;
     if (text[i] === '"' || text[i] === "'") {
       const end = text.indexOf(text[i], i + 1);
       if (end !== -1) out.push({ start: i, end: end + 1 });

--- a/frontend/scripts/check-design-tokens.mjs
+++ b/frontend/scripts/check-design-tokens.mjs
@@ -207,3 +207,51 @@ if (tapViolations.length > 0) {
 }
 
 console.log('tap-targets: OK (every checkbox/radio sits in a 44px label row; index.css floors the rest).');
+
+// Badge-contrast guard (issue #4367): DESIGN.md's Opacity rule forbids mixing
+// Tailwind opacity suffixes with design tokens for the text or background of
+// *meaningful* information (state badges, alerts, forced-action banners),
+// because the effective colour then depends on whatever sits beneath.
+//
+// This flags one specific, measurable shape: a translucent semantic background
+// paired with the *matching* semantic foreground in the same className, e.g.
+// `bg-ds-error/30 … text-ds-error`. That combination has no fixed contrast
+// ratio at all -- measured across the four table felts it ranges 1.13:1 to
+// 4.59:1, and 29 of 30 combinations fall below WCAG AA. badgeStyles.ts exists
+// precisely to replace it, and its helpers hold 5.8:1-12.1:1 regardless of
+// background.
+//
+// Deliberately NOT flagged: a translucent semantic background whose foreground
+// is inherited (issue #4367's "A-2", 42 sites). Those are only a problem when
+// the inherited colour is itself low-contrast, which this cannot see, and
+// DESIGN.md still permits opacity for decorative tints. Widening this rule
+// needs a per-site judgement call, not a regex.
+const BADGE_TOKEN = /\b(?:bg)-ds-(warning|info|success|error)\/\d+\b/g;
+const badgeViolations = [];
+for (const file of files) {
+  if (file.endsWith('badgeStyles.ts')) continue; // the sanctioned home for these tokens
+  const text = stripComments(await readFile(file, 'utf8'));
+  const lines = text.split('\n');
+  for (let i = 0; i < lines.length; i += 1) {
+    for (const m of lines[i].matchAll(BADGE_TOKEN)) {
+      const kind = m[1];
+      // Only when the same line also sets the matching semantic foreground.
+      if (!new RegExp(String.raw`\btext-ds-${kind}\b`).test(lines[i])) continue;
+      badgeViolations.push({ file: relative(ROOT, file), line: i + 1, kind, match: m[0] });
+    }
+  }
+}
+
+if (badgeViolations.length > 0) {
+  console.error('\nBadge-contrast policy violations (DESIGN.md Opacity rule):\n');
+  for (const v of badgeViolations) {
+    console.error(
+      `  ${v.file}:${v.line}  [${v.match} + text-ds-${v.kind}]  ` +
+        `use badge${v.kind[0].toUpperCase()}${v.kind.slice(1)}Colors from styles/badgeStyles.ts`,
+    );
+  }
+  console.error(`\n${badgeViolations.length} violation(s). See DESIGN.md and issue #4367.`);
+  process.exit(1);
+}
+
+console.log('badge-contrast: OK (no semantic foreground sits on a translucent semantic background).');

--- a/frontend/scripts/check-design-tokens.mjs
+++ b/frontend/scripts/check-design-tokens.mjs
@@ -226,18 +226,57 @@ console.log('tap-targets: OK (every checkbox/radio sits in a 44px label row; ind
 // the inherited colour is itself low-contrast, which this cannot see, and
 // DESIGN.md still permits opacity for decorative tints. Widening this rule
 // needs a per-site judgement call, not a regex.
-const BADGE_TOKEN = /\b(?:bg)-ds-(warning|info|success|error)\/\d+\b/g;
+const BADGE_TOKEN = /\bbg-ds-(warning|info|success|error)\/\d+\b/g;
+
+/**
+ * Every `className` value in `text`, as {start, end} offsets covering the whole
+ * value — the quoted string, or the brace-balanced expression.
+ *
+ * Matching per *line* instead would miss a violation split across a multi-line
+ * ternary (background on one line, foreground on the next), which is exactly how
+ * several of the sites fixed for #4367 were written. A guard that the common
+ * formatting of the thing it guards can slip past is not much of a guard.
+ */
+function classNameValues(text) {
+  const out = [];
+  for (const m of text.matchAll(/className=/g)) {
+    let i = m.index + m[0].length;
+    if (text[i] === '"' || text[i] === "'") {
+      const end = text.indexOf(text[i], i + 1);
+      if (end !== -1) out.push({ start: i, end: end + 1 });
+    } else if (text[i] === '{') {
+      let depth = 0;
+      for (let j = i; j < text.length; j += 1) {
+        if (text[j] === '{') depth += 1;
+        else if (text[j] === '}') {
+          depth -= 1;
+          if (depth === 0) {
+            out.push({ start: i, end: j + 1 });
+            break;
+          }
+        }
+      }
+    }
+  }
+  return out;
+}
+
 const badgeViolations = [];
 for (const file of files) {
   if (file.endsWith('badgeStyles.ts')) continue; // the sanctioned home for these tokens
   const text = stripComments(await readFile(file, 'utf8'));
-  const lines = text.split('\n');
-  for (let i = 0; i < lines.length; i += 1) {
-    for (const m of lines[i].matchAll(BADGE_TOKEN)) {
+  for (const { start, end } of classNameValues(text)) {
+    const value = text.slice(start, end);
+    for (const m of value.matchAll(BADGE_TOKEN)) {
       const kind = m[1];
-      // Only when the same line also sets the matching semantic foreground.
-      if (!new RegExp(String.raw`\btext-ds-${kind}\b`).test(lines[i])) continue;
-      badgeViolations.push({ file: relative(ROOT, file), line: i + 1, kind, match: m[0] });
+      // Only when the same className also sets the matching semantic foreground.
+      if (!new RegExp(String.raw`\btext-ds-${kind}\b`).test(value)) continue;
+      badgeViolations.push({
+        file: relative(ROOT, file),
+        line: text.slice(0, start + m.index).split('\n').length,
+        kind,
+        match: m[0],
+      });
     }
   }
 }

--- a/frontend/src/pages/AccordionPage.tsx
+++ b/frontend/src/pages/AccordionPage.tsx
@@ -25,6 +25,7 @@ import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useGiveUpConfirm } from '../hooks/useGiveUpConfirm';
 import { useMountReset } from '../hooks/useMountReset';
+import { badgeErrorColors, badgeSuccessColors } from '../styles/badgeStyles';
 import { btnDanger, btnOutline, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { AccordionResponse } from '../types/card';
@@ -474,11 +475,9 @@ function AccordionPageContent() {
                 data-testid="result-banner"
                 role="status"
                 aria-live="polite"
-                className={
-                  isGameClear
-                    ? 'text-sm text-center font-medium rounded px-3 py-1.5 mt-1 border bg-ds-success/20 text-ds-success border-ds-success'
-                    : 'text-sm text-center font-medium rounded px-3 py-1.5 mt-1 border bg-ds-error/20 text-ds-error border-ds-error'
-                }
+                className={`text-sm text-center font-medium rounded px-3 py-1.5 mt-1 ${
+                  isGameClear ? badgeSuccessColors : badgeErrorColors
+                }`}
               >
                 {isGameClear
                   ? t('result.clear', { moveCount: state.moveCount })

--- a/frontend/src/pages/BigOHiLoPage.tsx
+++ b/frontend/src/pages/BigOHiLoPage.tsx
@@ -23,6 +23,7 @@ import { RoundResults } from '../components/RoundResults';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useCommunityPokerGame } from '../hooks/useCommunityPokerGame';
+import { badgeInfoColors } from '../styles/badgeStyles';
 import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
 import { placeholderCardStyle } from '../styles/cardStyles';
 import { handNameBadgeClass } from '../styles/gameConstants';
@@ -419,7 +420,7 @@ function BigOHiLoPageContent() {
                   )}
                 </div>
                 <div
-                  className="mb-1 inline-flex items-center gap-1.5 rounded-full bg-ds-info/20 px-2 py-0.5 text-[11px] font-semibold text-ds-info"
+                  className={`mb-1 inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-[11px] font-semibold ${badgeInfoColors}`}
                   data-testid="bigohilo-rule-badge"
                   title={t('mandatoryRuleAria')}
                 >

--- a/frontend/src/pages/BigOPage.tsx
+++ b/frontend/src/pages/BigOPage.tsx
@@ -23,6 +23,7 @@ import { RoundResults } from '../components/RoundResults';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useCommunityPokerGame } from '../hooks/useCommunityPokerGame';
+import { badgeInfoColors } from '../styles/badgeStyles';
 import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
 import { placeholderCardStyle } from '../styles/cardStyles';
 import { handNameBadgeClass } from '../styles/gameConstants';
@@ -335,7 +336,7 @@ function BigOPageContent() {
                   )}
                 </div>
                 <div
-                  className="mb-1 inline-flex items-center gap-1.5 rounded-full bg-ds-info/20 px-2 py-0.5 text-[11px] font-semibold text-ds-info"
+                  className={`mb-1 inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-[11px] font-semibold ${badgeInfoColors}`}
                   data-testid="bigo-rule-badge"
                   title={t('mandatoryRuleAria')}
                 >

--- a/frontend/src/pages/BigTwoPage.tsx
+++ b/frontend/src/pages/BigTwoPage.tsx
@@ -20,6 +20,7 @@ import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { badgeErrorColors } from '../styles/badgeStyles';
 import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { BigTwoResponse } from '../types/card';
@@ -230,7 +231,7 @@ function BigTwoPageContent() {
                     <span
                       data-testid="bt-selected-playtype"
                       role="status"
-                      className="rounded-full bg-ds-error/30 px-2 py-0.5 text-xs font-semibold text-ds-error"
+                      className={`rounded-full px-2 py-0.5 text-xs font-semibold ${badgeErrorColors}`}
                     >
                       {t('invalidCombo')}
                     </span>

--- a/frontend/src/pages/CalabresellaPage.tsx
+++ b/frontend/src/pages/CalabresellaPage.tsx
@@ -22,6 +22,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
+import { badgeWarningColors } from '../styles/badgeStyles';
 import { btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -255,7 +256,7 @@ function CalabresellaPageContent() {
                         {playerName(p.id, p.isHuman)}: {t('score', { score: p.score })}
                       </span>
                       {p.isSoloist && (
-                        <span className="px-1.5 py-0.5 rounded bg-ds-warning/30 text-ds-warning text-xs">
+                        <span className={`px-1.5 py-0.5 rounded text-xs ${badgeWarningColors}`}>
                           {t('soloistBadge')}
                         </span>
                       )}

--- a/frontend/src/pages/CasinoWarPage.tsx
+++ b/frontend/src/pages/CasinoWarPage.tsx
@@ -24,6 +24,7 @@ import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useMountReset } from '../hooks/useMountReset';
+import { badgeWarningColors } from '../styles/badgeStyles';
 import { btnDanger, btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -353,7 +354,7 @@ function CasinoWarPageContent() {
                 <p className="text-ds-text-muted text-sm">{t('tieGuide')}</p>
                 <span
                   data-testid="war-cost-badge"
-                  className="inline-flex items-center rounded-full bg-ds-warning/20 px-2 py-0.5 font-bold text-ds-warning text-xs"
+                  className={`inline-flex items-center rounded-full px-2 py-0.5 font-bold text-xs ${badgeWarningColors}`}
                 >
                   {t('warCost', { amount: state.ante })}
                 </span>

--- a/frontend/src/pages/CegoPage.tsx
+++ b/frontend/src/pages/CegoPage.tsx
@@ -21,6 +21,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
+import { badgeWarningColors } from '../styles/badgeStyles';
 import { btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -253,7 +254,7 @@ function CegoPageContent() {
                         {playerName(p.id, p.isHuman)}: {t('score', { score: p.score })}
                       </span>
                       {p.isDeclarer && (
-                        <span className="px-1.5 py-0.5 rounded bg-ds-warning/30 text-ds-warning text-xs">
+                        <span className={`px-1.5 py-0.5 rounded text-xs ${badgeWarningColors}`}>
                           {t('declarerBadge')}
                         </span>
                       )}

--- a/frontend/src/pages/CinchPage.tsx
+++ b/frontend/src/pages/CinchPage.tsx
@@ -21,6 +21,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
+import { badgeWarningColors } from '../styles/badgeStyles';
 import { btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -268,7 +269,7 @@ function CinchPageContent() {
                         {playerName(p.id, p.isHuman)}: {t('score', { score: p.totalScore })}
                       </span>
                       {p.id === state.bidWinnerIdx && (
-                        <span className="px-1.5 py-0.5 rounded bg-ds-warning/30 text-ds-warning text-xs">
+                        <span className={`px-1.5 py-0.5 rounded text-xs ${badgeWarningColors}`}>
                           {t('bidderBadge')}
                         </span>
                       )}

--- a/frontend/src/pages/CourtPiecePage.tsx
+++ b/frontend/src/pages/CourtPiecePage.tsx
@@ -26,6 +26,7 @@ import {
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
+import { badgeWarningColors } from '../styles/badgeStyles';
 import { btnPrimary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -417,7 +418,7 @@ function CourtPiecePageContent() {
             {playerName(p.id, p.isHuman)}: {t('cards', { count: p.cardCount })} | {t('tricks', { count: p.trickCount })}
           </span>
           {p.id === state.callerIdx && (
-            <span className="px-1.5 py-0.5 rounded bg-ds-warning/30 text-ds-warning text-xs">{t('callerBadge')}</span>
+            <span className={`px-1.5 py-0.5 rounded text-xs ${badgeWarningColors}`}>{t('callerBadge')}</span>
           )}
         </div>
       ));

--- a/frontend/src/pages/CrescentPage.tsx
+++ b/frontend/src/pages/CrescentPage.tsx
@@ -26,6 +26,7 @@ import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useGiveUpConfirm } from '../hooks/useGiveUpConfirm';
 import { useResponsiveTableau } from '../hooks/useResponsiveTableau';
 import { useSolitaireDragDrop } from '../hooks/useSolitaireDragDrop';
+import { badgeSuccessColors, badgeWarningColors } from '../styles/badgeStyles';
 import { btnDanger, btnPrimary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { Card, CrescentResponse } from '../types/card';
@@ -268,9 +269,7 @@ function CrescentPageContent() {
                             <span
                               data-testid={`foundation-dir-${idx}`}
                               className={`inline-block rounded px-1 font-bold ${
-                                directionKey === 'asc'
-                                  ? 'bg-ds-success/20 text-ds-success'
-                                  : 'bg-ds-warning/20 text-ds-warning'
+                                directionKey === 'asc' ? badgeSuccessColors : badgeWarningColors
                               }`}
                             >
                               {suit} {directionKey === 'asc' ? '↑' : '↓'}

--- a/frontend/src/pages/CuckooPage.tsx
+++ b/frontend/src/pages/CuckooPage.tsx
@@ -20,6 +20,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
+import { badgeWarningColors } from '../styles/badgeStyles';
 import { btnPrimary, btnSuccess, btnWarning } from '../styles/buttonStyles';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -235,7 +236,7 @@ function CuckooPageContent() {
             {/* Round losers */}
             {(isRoundEnd || isGameEnd) && state.roundLosers.length > 0 && (
               <div
-                className="mb-2 p-2 rounded bg-ds-warning/20 text-ds-warning text-sm"
+                className={`mb-2 p-2 rounded text-sm ${badgeWarningColors}`}
                 data-tutorial="cuckoo-losers"
                 data-testid="cuckoo-losers"
                 role="status"

--- a/frontend/src/pages/EgyptianRatscrewPage.tsx
+++ b/frontend/src/pages/EgyptianRatscrewPage.tsx
@@ -22,6 +22,7 @@ import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useMountReset } from '../hooks/useMountReset';
 import { useReflexShortcuts } from '../hooks/useReflexShortcuts';
+import { badgeWarningColors } from '../styles/badgeStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { EgyptianRatscrewResponse } from '../types/card';
 import {
@@ -310,7 +311,7 @@ function EgyptianRatscrewPageContent() {
                 {state.isSlappable && state.lastSlapReason !== EgyptianRatscrewSlapReason.NONE && (
                   <div
                     data-testid="er-slap-reason"
-                    className="mt-1 inline-flex items-center gap-1 rounded-full bg-ds-warning/20 px-2 py-0.5 text-xs font-medium text-ds-warning"
+                    className={`mt-1 inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${badgeWarningColors}`}
                   >
                     {state.lastSlapReason === EgyptianRatscrewSlapReason.PAIR
                       ? `👯 ${t('egyptianratscrew.slapReason.pair')}`

--- a/frontend/src/pages/FaroPage.tsx
+++ b/frontend/src/pages/FaroPage.tsx
@@ -17,6 +17,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
+import { badgeWarningColors } from '../styles/badgeStyles';
 import { btnPrimary, btnSecondary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { FaroResponse } from '../types/card';
@@ -247,7 +248,7 @@ function FaroPageContent() {
                         bet?.copper
                           ? 'border-ds-accent bg-ds-accent/20 text-ds-accent'
                           : bet
-                            ? 'border-ds-warning bg-ds-warning/20 text-ds-warning'
+                            ? badgeWarningColors
                             : 'border-white/30 bg-black/30 text-ds-text-primary'
                       } ${isBetting ? 'cursor-pointer hover:border-ds-warning hover:-translate-y-0.5' : 'cursor-default opacity-80'}`}
                       data-testid={`rank-${rank}`}

--- a/frontend/src/pages/FortyFivesPage.tsx
+++ b/frontend/src/pages/FortyFivesPage.tsx
@@ -21,6 +21,7 @@ import { CPU_DIFFICULTY_OPTIONS, TARGET_POINTS_OPTIONS, useFortyFivesGame } from
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
+import { badgeWarningColors } from '../styles/badgeStyles';
 import { btnPrimary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -450,7 +451,7 @@ function FortyFivesPageContent() {
             {playerName(p.id, p.isHuman)}: {t('cards', { count: p.cardCount })} | {t('tricks', { count: p.trickCount })}
           </span>
           {p.isDeclarer && (
-            <span className="px-1.5 py-0.5 rounded bg-ds-warning/30 text-ds-warning text-xs">{t('declarerBadge')}</span>
+            <span className={`px-1.5 py-0.5 rounded text-xs ${badgeWarningColors}`}>{t('declarerBadge')}</span>
           )}
         </div>
       ));

--- a/frontend/src/pages/FrenchTarotPage.tsx
+++ b/frontend/src/pages/FrenchTarotPage.tsx
@@ -27,6 +27,7 @@ import {
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
+import { badgeWarningColors } from '../styles/badgeStyles';
 import { btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -299,7 +300,7 @@ function FrenchTarotPageContent() {
                         {playerName(p.id, p.isHuman)}: {t('score', { score: p.score })}
                       </span>
                       {p.isDeclarer && (
-                        <span className="px-1.5 py-0.5 rounded bg-ds-warning/30 text-ds-warning text-xs">
+                        <span className={`px-1.5 py-0.5 rounded text-xs ${badgeWarningColors}`}>
                           {t('declarerBadge')}
                         </span>
                       )}
@@ -318,7 +319,7 @@ function FrenchTarotPageContent() {
                         {heldBoutList.map((b) => (
                           <span
                             key={b}
-                            className="px-1.5 py-0.5 rounded bg-ds-warning/30 text-ds-warning text-xs"
+                            className={`px-1.5 py-0.5 rounded text-xs ${badgeWarningColors}`}
                             data-testid={`frenchtarot-bout-${b}`}
                           >
                             {t(`bouts.${b}`)}

--- a/frontend/src/pages/GoStopPage.tsx
+++ b/frontend/src/pages/GoStopPage.tsx
@@ -18,6 +18,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { CPU_DIFFICULTY_OPTIONS, TARGET_SCORE_OPTIONS, useGoStopGame } from '../hooks/useGoStopGame';
+import { badgeInfoColors, badgeWarningColors } from '../styles/badgeStyles';
 import { btnPrimary, btnSuccess, btnWarning } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { GoStopBreakdown, GoStopResponse } from '../types/card';
@@ -295,7 +296,7 @@ function GoStopPageContent() {
                       {pendingNearYaku.map((y) => (
                         <span
                           key={y.category}
-                          className="px-1.5 py-0.5 rounded bg-ds-info/20 text-ds-info"
+                          className={`px-1.5 py-0.5 rounded ${badgeInfoColors}`}
                           data-testid={`gostop-yaku-preview-${y.category}`}
                         >
                           {t('preview.item', { name: t(`preview.${y.target}`), remaining: y.remaining })}
@@ -342,7 +343,7 @@ function GoStopPageContent() {
                   <div className="flex gap-1 justify-center flex-wrap mt-1" data-testid="gostop-bak-badges">
                     {state.lastRoundResult.gwangBak && (
                       <span
-                        className="px-1.5 py-0.5 rounded bg-ds-warning/30 text-ds-warning text-[11px]"
+                        className={`px-1.5 py-0.5 rounded text-[11px] ${badgeWarningColors}`}
                         data-testid="gostop-bak-gwang"
                       >
                         {t('bak.gwang')}
@@ -350,7 +351,7 @@ function GoStopPageContent() {
                     )}
                     {state.lastRoundResult.piBak && (
                       <span
-                        className="px-1.5 py-0.5 rounded bg-ds-warning/30 text-ds-warning text-[11px]"
+                        className={`px-1.5 py-0.5 rounded text-[11px] ${badgeWarningColors}`}
                         data-testid="gostop-bak-pi"
                       >
                         {t('bak.pi')}
@@ -358,7 +359,7 @@ function GoStopPageContent() {
                     )}
                     {state.lastRoundResult.goBak && (
                       <span
-                        className="px-1.5 py-0.5 rounded bg-ds-warning/30 text-ds-warning text-[11px]"
+                        className={`px-1.5 py-0.5 rounded text-[11px] ${badgeWarningColors}`}
                         data-testid="gostop-bak-go"
                       >
                         {t('bak.go')}

--- a/frontend/src/pages/IndianRummyPage.tsx
+++ b/frontend/src/pages/IndianRummyPage.tsx
@@ -26,6 +26,7 @@ import {
   useIndianRummyGame,
 } from '../hooks/useIndianRummyGame';
 import { usePhaseNames } from '../hooks/usePhaseNames';
+import { badgeSuccessColors, badgeWarningColors } from '../styles/badgeStyles';
 import { btnPrimary, btnSuccess } from '../styles/buttonStyles';
 import { focusRingCard, selectedCardStyle } from '../styles/cardStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
@@ -418,7 +419,7 @@ function IndianRummyPageContent() {
                 aria-live="polite"
                 data-testid="indianrummy-declare-preview"
                 className={`mb-2 px-3 py-2 rounded text-sm ${
-                  declarePreview.valid ? 'bg-ds-success/20 text-ds-success' : 'bg-ds-warning/20 text-ds-warning'
+                  declarePreview.valid ? badgeSuccessColors : badgeWarningColors
                 }`}
               >
                 {declarePreview.valid ? (

--- a/frontend/src/pages/JassPage.tsx
+++ b/frontend/src/pages/JassPage.tsx
@@ -17,6 +17,7 @@ import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { CPU_DIFFICULTY_OPTIONS, TARGET_SCORE_OPTIONS, useJassGame } from '../hooks/useJassGame';
 import { usePhaseNames } from '../hooks/usePhaseNames';
+import { badgeWarningColors } from '../styles/badgeStyles';
 import { btnPrimary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -312,7 +313,7 @@ function JassPageContent() {
                     {t('weisPanel.teamPoints', { points: state.roundWeisPoints[team] })}
                   </span>
                   {state.roundWeisPoints[team] > 0 && (
-                    <span className="text-xs px-1.5 py-0.5 rounded bg-ds-warning/20 text-ds-warning">
+                    <span className={`text-xs px-1.5 py-0.5 rounded ${badgeWarningColors}`}>
                       {t('weisPanel.scored')}
                     </span>
                   )}

--- a/frontend/src/pages/KempsPage.tsx
+++ b/frontend/src/pages/KempsPage.tsx
@@ -18,6 +18,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
+import { badgeSuccessColors, badgeWarningColors } from '../styles/badgeStyles';
 import { btnPrimary, btnSuccess, btnWarning } from '../styles/buttonStyles';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -290,7 +291,7 @@ function KempsPageContent() {
             {/* Signal cues (human only) */}
             {isDeclare && state.partnerSignaling && (
               <div
-                className="my-2 p-2 rounded bg-ds-success/20 text-ds-success text-sm font-semibold"
+                className={`my-2 p-2 rounded text-sm font-semibold ${badgeSuccessColors}`}
                 role="status"
                 aria-live="polite"
                 data-testid="kemps-partner-signaling"
@@ -300,7 +301,7 @@ function KempsPageContent() {
             )}
             {isDeclare && state.opponentSignaling && (
               <div
-                className="my-2 p-2 rounded bg-ds-warning/20 text-ds-warning text-sm"
+                className={`my-2 p-2 rounded text-sm ${badgeWarningColors}`}
                 role="status"
                 aria-live="polite"
                 data-testid="kemps-opponent-signaling"
@@ -313,7 +314,7 @@ function KempsPageContent() {
                 so the human notices the quad before the declare window. */}
             {humanHasFour && !isGameEnd && (
               <div
-                className="my-2 p-2 rounded bg-ds-success/20 text-ds-success text-sm font-semibold"
+                className={`my-2 p-2 rounded text-sm font-semibold ${badgeSuccessColors}`}
                 role="status"
                 aria-live="polite"
                 data-testid="kemps-four-ready"

--- a/frontend/src/pages/KingPage.tsx
+++ b/frontend/src/pages/KingPage.tsx
@@ -20,7 +20,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { CPU_DIFFICULTY_OPTIONS, useKingGame } from '../hooks/useKingGame';
-import { badgeErrorColors, badgeSuccessColors } from '../styles/badgeStyles';
+import { badgeErrorColors, badgeSuccessColors, badgeWarningColors } from '../styles/badgeStyles';
 import { btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -236,7 +236,7 @@ function KingPageContent() {
                         {playerName(p.id, p.isHuman)}: {t('score', { score: p.totalScore })}
                       </span>
                       {p.id === state.dealerIdx && (
-                        <span className="px-1.5 py-0.5 rounded bg-ds-warning/30 text-ds-warning text-xs">
+                        <span className={`px-1.5 py-0.5 rounded text-xs ${badgeWarningColors}`}>
                           {t('dealerBadge')}
                         </span>
                       )}

--- a/frontend/src/pages/KoenigrufenPage.tsx
+++ b/frontend/src/pages/KoenigrufenPage.tsx
@@ -26,6 +26,7 @@ import {
   useKoenigrufenGame,
 } from '../hooks/useKoenigrufenGame';
 import { usePhaseNames } from '../hooks/usePhaseNames';
+import { badgeWarningColors } from '../styles/badgeStyles';
 import { btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -353,12 +354,12 @@ function KoenigrufenPageContent() {
                           {playerName(p.id, p.isHuman)}: {t('score', { score: p.score })}
                         </span>
                         {p.isDeclarer && (
-                          <span className="px-1.5 py-0.5 rounded bg-ds-warning/30 text-ds-warning text-xs">
+                          <span className={`px-1.5 py-0.5 rounded text-xs ${badgeWarningColors}`}>
                             {t('declarerBadge')}
                           </span>
                         )}
                         {state.partnerRevealed && p.isPartner && !p.isDeclarer && (
-                          <span className="px-1.5 py-0.5 rounded bg-ds-warning/30 text-ds-warning text-xs">
+                          <span className={`px-1.5 py-0.5 rounded text-xs ${badgeWarningColors}`}>
                             {t('partnerBadge')}
                           </span>
                         )}

--- a/frontend/src/pages/MacauPage.tsx
+++ b/frontend/src/pages/MacauPage.tsx
@@ -21,6 +21,7 @@ import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { CPU_DIFFICULTY_OPTIONS, POINT_LIMIT_OPTIONS, useMacauGame } from '../hooks/useMacauGame';
 import { usePhaseNames } from '../hooks/usePhaseNames';
+import { badgeInfoColors, badgeWarningColors } from '../styles/badgeStyles';
 import { btnDanger, btnPrimary, btnSuccess } from '../styles/buttonStyles';
 import { focusRingCard, selectedCardStyle } from '../styles/cardStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
@@ -298,17 +299,14 @@ function MacauPageContent() {
                 </details>
 
                 {hasPenalty && (
-                  <div
-                    className="my-2 p-2 rounded bg-ds-warning/20 text-ds-warning text-sm font-semibold"
-                    role="status"
-                  >
+                  <div className={`my-2 p-2 rounded text-sm font-semibold ${badgeWarningColors}`} role="status">
                     {t('penaltyBanner', { count: state.penaltyDrawCount })}
                   </div>
                 )}
 
                 {isMustDeclare && state.players[state.currentPlayerIdx]?.isHuman && (
                   <div
-                    className="my-2 p-2 rounded bg-ds-info/20 text-ds-info text-sm font-semibold"
+                    className={`my-2 p-2 rounded text-sm font-semibold ${badgeInfoColors}`}
                     role="status"
                     data-testid="macau-must-declare-banner"
                   >

--- a/frontend/src/pages/MaoPage.tsx
+++ b/frontend/src/pages/MaoPage.tsx
@@ -20,6 +20,7 @@ import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { CPU_DIFFICULTY_OPTIONS, POINT_LIMIT_OPTIONS, useMaoGame } from '../hooks/useMaoGame';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
+import { badgeWarningColors } from '../styles/badgeStyles';
 import { btnDanger, btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
 import { focusRingCard, selectedCardStyle } from '../styles/cardStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
@@ -315,10 +316,7 @@ function MaoPageContent() {
                 )}
 
                 {hasPenalty && (
-                  <div
-                    className="my-2 p-2 rounded bg-ds-warning/20 text-ds-warning text-sm font-semibold"
-                    role="status"
-                  >
+                  <div className={`my-2 p-2 rounded text-sm font-semibold ${badgeWarningColors}`} role="status">
                     {t('penaltyBanner', { count: state.penaltyDrawCount })}
                   </div>
                 )}

--- a/frontend/src/pages/MariasPage.tsx
+++ b/frontend/src/pages/MariasPage.tsx
@@ -21,6 +21,7 @@ import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { CPU_DIFFICULTY_OPTIONS, TARGET_POINTS_OPTIONS, useMariasGame } from '../hooks/useMariasGame';
 import { usePhaseNames } from '../hooks/usePhaseNames';
+import { badgeWarningColors } from '../styles/badgeStyles';
 import { btnPrimary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -245,7 +246,7 @@ function MariasPageContent() {
                         {playerName(p.id, p.isHuman)}: {t('score', { score: p.score })}
                       </span>
                       {p.isSoloist && (
-                        <span className="px-1.5 py-0.5 rounded bg-ds-warning/30 text-ds-warning text-xs">
+                        <span className={`px-1.5 py-0.5 rounded text-xs ${badgeWarningColors}`}>
                           {t('soloistBadge')}
                         </span>
                       )}

--- a/frontend/src/pages/NapPage.tsx
+++ b/frontend/src/pages/NapPage.tsx
@@ -21,6 +21,7 @@ import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { CPU_DIFFICULTY_OPTIONS, TARGET_POINTS_OPTIONS, useNapGame } from '../hooks/useNapGame';
 import { usePhaseNames } from '../hooks/usePhaseNames';
+import { badgeWarningColors } from '../styles/badgeStyles';
 import { btnPrimary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -285,7 +286,7 @@ function NapPageContent() {
                         {playerName(p.id, p.isHuman)}: {t('score', { score: p.score })}
                       </span>
                       {p.isDeclarer && (
-                        <span className="px-1.5 py-0.5 rounded bg-ds-warning/30 text-ds-warning text-xs">
+                        <span className={`px-1.5 py-0.5 rounded text-xs ${badgeWarningColors}`}>
                           {t('declarerBadge')}
                         </span>
                       )}

--- a/frontend/src/pages/OmahaHiLoPage.test.tsx
+++ b/frontend/src/pages/OmahaHiLoPage.test.tsx
@@ -331,7 +331,12 @@ describe('OmahaHiLoPage', () => {
     renderWithProviders(<OmahaHiLoPage />);
     const badge = await screen.findByTestId('omahahilo-board-low-badge');
     expect(badge).toHaveAttribute('data-status', 'possible');
-    expect(badge).toHaveClass('text-ds-info');
+    // badgeInfoColors carries the "info" signal on the border, not the text:
+    // text-ds-info is only ~4.5:1 on the surface background, so the foreground
+    // stays text-ds-text-primary (12:1) and the border does the signalling.
+    // See styles/badgeStyles.ts and issue #4367.
+    expect(badge).toHaveClass('border-ds-border-subtle');
+    expect(badge).toHaveClass('text-ds-text-primary');
   });
 
   it('shows the "live" board-low badge when the board has 3 distinct low ranks', async () => {

--- a/frontend/src/pages/OmahaHiLoPage.tsx
+++ b/frontend/src/pages/OmahaHiLoPage.tsx
@@ -23,6 +23,7 @@ import { RoundResults } from '../components/RoundResults';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useCommunityPokerGame } from '../hooks/useCommunityPokerGame';
+import { badgeInfoColors, badgeSuccessColors } from '../styles/badgeStyles';
 import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
 import { placeholderCardStyle } from '../styles/cardStyles';
 import { handNameBadgeClass } from '../styles/gameConstants';
@@ -148,8 +149,8 @@ function OmahaLoCard({
 
 /** Design-system token classes per board-low status (live=success, possible=info, impossible=muted). */
 const BOARD_LOW_STATUS_CLASS: Readonly<Record<BoardLowStatus, string>> = {
-  live: 'border-ds-success bg-ds-success/20 text-ds-success',
-  possible: 'border-ds-info bg-ds-info/20 text-ds-info',
+  live: badgeSuccessColors,
+  possible: badgeInfoColors,
   impossible: 'border-ds-border bg-ds-surface text-ds-text-muted',
 };
 
@@ -482,7 +483,7 @@ function OmahaHiLoPageContent() {
                   )}
                 </div>
                 <div
-                  className="mb-1 inline-flex items-center gap-1.5 rounded-full bg-ds-info/20 px-2 py-0.5 text-[11px] font-semibold text-ds-info"
+                  className={`mb-1 inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-[11px] font-semibold ${badgeInfoColors}`}
                   data-testid="omahahilo-rule-badge"
                   title={t('mandatoryRuleAria')}
                 >

--- a/frontend/src/pages/OmahaPage.tsx
+++ b/frontend/src/pages/OmahaPage.tsx
@@ -23,6 +23,7 @@ import { RoundResults } from '../components/RoundResults';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useCommunityPokerGame } from '../hooks/useCommunityPokerGame';
+import { badgeInfoColors } from '../styles/badgeStyles';
 import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
 import { placeholderCardStyle } from '../styles/cardStyles';
 import { handNameBadgeClass } from '../styles/gameConstants';
@@ -342,7 +343,7 @@ function OmahaPageContent() {
                   )}
                 </div>
                 <div
-                  className="mb-1 inline-flex items-center gap-1.5 rounded-full bg-ds-info/20 px-2 py-0.5 text-[11px] font-semibold text-ds-info"
+                  className={`mb-1 inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-[11px] font-semibold ${badgeInfoColors}`}
                   data-testid="omaha-rule-badge"
                   title={t('mandatoryRuleAria')}
                 >

--- a/frontend/src/pages/OmbrePage.tsx
+++ b/frontend/src/pages/OmbrePage.tsx
@@ -21,6 +21,7 @@ import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { CPU_DIFFICULTY_OPTIONS, TARGET_ROUNDS_OPTIONS, useOmbreGame } from '../hooks/useOmbreGame';
 import { usePhaseNames } from '../hooks/usePhaseNames';
+import { badgeWarningColors } from '../styles/badgeStyles';
 import { btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -282,9 +283,7 @@ function OmbrePageContent() {
                         {playerName(p.id, p.isHuman)}: {t('score', { score: p.score })}
                       </span>
                       {p.isOmbre && (
-                        <span className="px-1.5 py-0.5 rounded bg-ds-warning/30 text-ds-warning text-xs">
-                          {t('ombreBadge')}
-                        </span>
+                        <span className={`px-1.5 py-0.5 rounded text-xs ${badgeWarningColors}`}>{t('ombreBadge')}</span>
                       )}
                     </div>
                   ))}

--- a/frontend/src/pages/PineapplePage.tsx
+++ b/frontend/src/pages/PineapplePage.tsx
@@ -32,6 +32,7 @@ import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useMountReset } from '../hooks/useMountReset';
 import { usePhaseNames } from '../hooks/usePhaseNames';
+import { badgeInfoColors } from '../styles/badgeStyles';
 import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
 import { placeholderCardStyle, selectedCardStyle } from '../styles/cardStyles';
 import { handNameBadgeClass } from '../styles/gameConstants';
@@ -603,7 +604,7 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
                             )}
                             {isRecommendedDiscard && (
                               <span
-                                className="mt-0.5 rounded-full bg-ds-info/20 px-1.5 text-[10px] font-semibold text-ds-info"
+                                className={`mt-0.5 rounded-full px-1.5 text-[10px] font-semibold ${badgeInfoColors}`}
                                 data-testid="cp-discard-recommended"
                               >
                                 {t('discard.recommended')}

--- a/frontend/src/pages/PreferencePage.tsx
+++ b/frontend/src/pages/PreferencePage.tsx
@@ -21,6 +21,7 @@ import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { CPU_DIFFICULTY_OPTIONS, TARGET_POINTS_OPTIONS, usePreferenceGame } from '../hooks/usePreferenceGame';
+import { badgeWarningColors } from '../styles/badgeStyles';
 import { btnPrimary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -320,7 +321,7 @@ function PreferencePageContent() {
                         {playerName(p.id, p.isHuman)}: {t('score', { score: p.score })}
                       </span>
                       {p.isDeclarer && (
-                        <span className="px-1.5 py-0.5 rounded bg-ds-warning/30 text-ds-warning text-xs">
+                        <span className={`px-1.5 py-0.5 rounded text-xs ${badgeWarningColors}`}>
                           {t('declarerBadge')}
                         </span>
                       )}

--- a/frontend/src/pages/PrsiPage.tsx
+++ b/frontend/src/pages/PrsiPage.tsx
@@ -23,6 +23,7 @@ import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { CPU_DIFFICULTY_OPTIONS, usePrsiGame } from '../hooks/usePrsiGame';
 import { useSound } from '../providers/SoundProvider';
+import { badgeWarningColors } from '../styles/badgeStyles';
 import { btnPrimary } from '../styles/buttonStyles';
 import { focusRingCard, selectedCardStyle } from '../styles/cardStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
@@ -247,7 +248,7 @@ function PrsiPageContent() {
 
                 {hasPenalty && (
                   <div
-                    className="my-2 p-2 rounded bg-ds-warning/20 text-ds-warning text-sm font-semibold"
+                    className={`my-2 p-2 rounded text-sm font-semibold ${badgeWarningColors}`}
                     data-testid="penalty-indicator"
                   >
                     {t('penalty', { count: state.penaltyDrawCount })}

--- a/frontend/src/pages/Rummy500Page.tsx
+++ b/frontend/src/pages/Rummy500Page.tsx
@@ -19,6 +19,7 @@ import {
   RUMMY500_POINT_LIMIT_OPTIONS,
   useRummy500Game,
 } from '../hooks/useRummy500Game';
+import { badgeErrorColors } from '../styles/badgeStyles';
 import { btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
 import { focusRingCard, selectedCardStyle } from '../styles/cardStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
@@ -296,7 +297,7 @@ function Rummy500PageContent() {
           <div className="flex justify-end mb-1 text-xs">
             <span
               data-testid="hand-penalty-badge"
-              className="px-2 py-0.5 rounded-full bg-ds-error/20 text-ds-error border border-ds-error font-medium"
+              className={`px-2 py-0.5 rounded-full border border-ds-error font-medium ${badgeErrorColors}`}
               title={t('handPenaltyHint')}
             >
               {t('handPenalty', { points: rummy500HandPenalty(humanPlayer.cards) })}

--- a/frontend/src/pages/ScartoPage.tsx
+++ b/frontend/src/pages/ScartoPage.tsx
@@ -26,6 +26,7 @@ import {
   TARGET_DEALS_OPTIONS,
   useScartoGame,
 } from '../hooks/useScartoGame';
+import { badgeWarningColors } from '../styles/badgeStyles';
 import { btnPrimary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -273,7 +274,7 @@ function ScartoPageContent() {
                         {playerName(p.id, p.isHuman)}: {t('score', { score: p.score })}
                       </span>
                       {p.isDealer && (
-                        <span className="px-1.5 py-0.5 rounded bg-ds-warning/30 text-ds-warning text-xs">
+                        <span className={`px-1.5 py-0.5 rounded text-xs ${badgeWarningColors}`}>
                           {t('dealerBadge')}
                         </span>
                       )}

--- a/frontend/src/pages/ScopaPage.tsx
+++ b/frontend/src/pages/ScopaPage.tsx
@@ -17,6 +17,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useScopaGame } from '../hooks/useScopaGame';
+import { badgeInfoColors } from '../styles/badgeStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { ScopaResponse } from '../types/card';
 import type { TutorialStep } from '../types/tutorial';
@@ -278,7 +279,7 @@ function ScopaPageContent() {
             {isRoundEnd && (
               <div
                 role="status"
-                className="text-center text-sm font-medium text-ds-info bg-ds-info/10 border border-ds-info/30 rounded-lg py-2 px-3"
+                className={`text-center text-sm font-medium border border-ds-info/30 rounded-lg py-2 px-3 ${badgeInfoColors}`}
                 data-testid="sc-round-end-banner"
               >
                 {t('label.roundEnd')}

--- a/frontend/src/pages/ShitheadPage.tsx
+++ b/frontend/src/pages/ShitheadPage.tsx
@@ -18,7 +18,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useShitheadGame } from '../hooks/useShitheadGame';
-import { badgeWarningColors } from '../styles/badgeStyles';
+import { badgeInfoColors, badgeWarningColors } from '../styles/badgeStyles';
 import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
 import { focusRingCard } from '../styles/cardStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -161,7 +161,7 @@ function ShitheadPageContent() {
                 key={state.currentSource}
                 role="status"
                 data-testid="sh-source-banner"
-                className="mb-2 animate-pulse-once rounded-lg bg-ds-info/20 px-3 py-1.5 text-center font-medium text-ds-info text-sm"
+                className={`mb-2 animate-pulse-once rounded-lg px-3 py-1.5 text-center font-medium text-sm ${badgeInfoColors}`}
               >
                 {t(`sourceBanner.${state.currentSource}`)}
               </div>

--- a/frontend/src/pages/SoloWhistPage.tsx
+++ b/frontend/src/pages/SoloWhistPage.tsx
@@ -21,6 +21,7 @@ import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { CPU_DIFFICULTY_OPTIONS, TARGET_POINTS_OPTIONS, useSoloWhistGame } from '../hooks/useSoloWhistGame';
+import { badgeWarningColors } from '../styles/badgeStyles';
 import { btnPrimary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -348,7 +349,7 @@ function SoloWhistPageContent() {
                         {playerName(p.id, p.isHuman)}: {t('score', { score: p.score })}
                       </span>
                       {p.isDeclarer && (
-                        <span className="px-1.5 py-0.5 rounded bg-ds-warning/30 text-ds-warning text-xs">
+                        <span className={`px-1.5 py-0.5 rounded text-xs ${badgeWarningColors}`}>
                           {t('declarerBadge')}
                         </span>
                       )}

--- a/frontend/src/pages/SpoilFivePage.tsx
+++ b/frontend/src/pages/SpoilFivePage.tsx
@@ -21,6 +21,7 @@ import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { CPU_DIFFICULTY_OPTIONS, useSpoilFiveGame } from '../hooks/useSpoilFiveGame';
+import { badgeWarningColors } from '../styles/badgeStyles';
 import { btnPrimary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -196,7 +197,7 @@ function SpoilFivePageContent() {
           <span className="px-1.5 py-0.5 rounded bg-white/20 text-ds-text-primary text-xs">{t('leader')}</span>
         )}
         {isRoundWinner && (
-          <span className="px-1.5 py-0.5 rounded bg-ds-warning/30 text-ds-warning text-xs">{t('roundWinner')}</span>
+          <span className={`px-1.5 py-0.5 rounded text-xs ${badgeWarningColors}`}>{t('roundWinner')}</span>
         )}
       </div>
     );

--- a/frontend/src/pages/ThirtyOnePage.tsx
+++ b/frontend/src/pages/ThirtyOnePage.tsx
@@ -22,6 +22,7 @@ import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useMountReset } from '../hooks/useMountReset';
+import { badgeWarningColors } from '../styles/badgeStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { ThirtyOneResponse } from '../types/card';
 import { ThirtyOnePhase } from '../types/phases';
@@ -358,7 +359,7 @@ function ThirtyOnePageContent() {
               <div
                 role="status"
                 data-testid="knock-countdown-banner"
-                className="rounded-lg bg-ds-warning/20 border border-ds-warning px-3 py-1.5 text-center text-ds-warning text-sm font-medium"
+                className={`rounded-lg border border-ds-warning px-3 py-1.5 text-center text-sm font-medium ${badgeWarningColors}`}
               >
                 {t(isHumanTurn ? 'label.knockBannerLastTurn' : 'label.knockBannerActive', {
                   knocker: state.knockerIdx === 0 ? tc('player.you') : tc('player.cpu', { id: state.knockerIdx }),

--- a/frontend/src/pages/TwentyNinePage.tsx
+++ b/frontend/src/pages/TwentyNinePage.tsx
@@ -21,6 +21,7 @@ import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { CPU_DIFFICULTY_OPTIONS, TARGET_POINTS_OPTIONS, useTwentyNineGame } from '../hooks/useTwentyNineGame';
+import { badgeWarningColors } from '../styles/badgeStyles';
 import { btnPrimary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -237,7 +238,7 @@ function TwentyNinePageContent() {
               <div
                 role="status"
                 data-testid="tn-trump-reveal-banner"
-                className="mx-auto mb-2 w-fit rounded-lg bg-ds-warning/20 px-4 py-1.5 text-center font-semibold text-ds-warning motion-safe:animate-pulse"
+                className={`mx-auto mb-2 w-fit rounded-lg px-4 py-1.5 text-center font-semibold motion-safe:animate-pulse ${badgeWarningColors}`}
               >
                 {t('trumpRevealBanner', { suit: revealedTrumpSymbol })}
               </div>
@@ -436,7 +437,7 @@ function TwentyNinePageContent() {
             {playerName(p.id, p.isHuman)}: {t('cards', { count: p.cardCount })} | {t('tricks', { count: p.trickCount })}
           </span>
           {p.isDeclarer && (
-            <span className="px-1.5 py-0.5 rounded bg-ds-warning/30 text-ds-warning text-xs">{t('declarerBadge')}</span>
+            <span className={`px-1.5 py-0.5 rounded text-xs ${badgeWarningColors}`}>{t('declarerBadge')}</span>
           )}
         </div>
       ));

--- a/frontend/src/pages/TysiacPage.tsx
+++ b/frontend/src/pages/TysiacPage.tsx
@@ -21,6 +21,7 @@ import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { CPU_DIFFICULTY_OPTIONS, TARGET_POINTS_OPTIONS, useTysiacGame } from '../hooks/useTysiacGame';
+import { badgeWarningColors } from '../styles/badgeStyles';
 import { btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -266,7 +267,7 @@ function TysiacPageContent() {
                             {playerName(p.id, p.isHuman)}: {t('score', { score: p.score })}
                           </span>
                           {p.isDeclarer && (
-                            <span className="px-1.5 py-0.5 rounded bg-ds-warning/30 text-ds-warning text-xs">
+                            <span className={`px-1.5 py-0.5 rounded text-xs ${badgeWarningColors}`}>
                               {t('declarerBadge')}
                             </span>
                           )}

--- a/frontend/src/pages/UltiPage.tsx
+++ b/frontend/src/pages/UltiPage.tsx
@@ -21,6 +21,7 @@ import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { CPU_DIFFICULTY_OPTIONS, TARGET_ROUNDS_OPTIONS, useUltiGame } from '../hooks/useUltiGame';
+import { badgeWarningColors } from '../styles/badgeStyles';
 import { btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -305,7 +306,7 @@ function UltiPageContent() {
                         </span>
                       )}
                       {p.isDeclarer && (
-                        <span className="px-1.5 py-0.5 rounded bg-ds-warning/30 text-ds-warning text-xs">
+                        <span className={`px-1.5 py-0.5 rounded text-xs ${badgeWarningColors}`}>
                           {t('declarerBadge')}
                         </span>
                       )}


### PR DESCRIPTION
## Summary

DESIGN.md's **Opacity rule** forbids mixing Tailwind opacity suffixes with design tokens for the text or background of *meaningful* information, because the effective colour then depends on whatever sits beneath. **55 badges** did exactly that — a translucent semantic background paired with the *matching* semantic foreground (`bg-ds-error/30` + `text-ds-error`).

That combination has no fixed contrast ratio. Measured across the four table felts it ranges **1.13:1 to 4.59:1**, and 29 of the issue's 30 combinations fall below WCAG AA.

The worst case is the one that matters most: **BigTwo's "invalid combination" warning** — the feedback a player most needs in order to proceed — sat at 1.47:1 on felt-green and 1.13:1 on felt-green-bright, i.e. background and foreground at essentially the same luminance. It is now **12.06:1**.

| Token | Sites |
|---|---|
| `warning` | 36 |
| `info` | 10 |
| `success` | 6 |
| `error` | 3 |

All 55 now use the `badgeStyles.ts` helpers, which pin an opaque `bg-ds-surface` and hold **5.8:1–12.1:1 regardless of table colour**.

## A visual consequence worth reviewing

`badgeInfoColors` and `badgeErrorColors` intentionally carry `text-ds-text-primary` rather than the semantic token — `ds-info` reaches only ~4.5:1 on the surface and `ds-error` ~2.7:1 — so the semantic signal moves to the coloured border. That means **info and error badges change text colour**, not just background. This is the documented design decision in `badgeStyles.ts`, not my invention, but it is visible.

One site deserves a specific look: **OmahaHiLo's board-low badge** was a 3-state map (`live` / `possible` / `impossible`). `possible` loses its info-tinted border for a subtle one, so it reads closer to neutral. I checked before accepting this: all three states are already labelled in text (`boardLow.live` / `.possible` / `.impossible`), so the colour was redundant reinforcement — and the badge no longer conveys status by colour alone, which is the better a11y outcome. Its test asserted `text-ds-info` and now asserts the border plus the readable foreground.

## Enforcement

Adds a **badge-contrast guard** to `scripts/check-design-tokens.mjs` (already run by `bun run check`, now its fourth guard).

It flags only this measurable shape: translucent semantic background **plus matching semantic foreground on the same line**. The issue's other 42 sites ("A-2") inherit their foreground, which is only a problem when the inherited colour is itself low-contrast — the guard can't see that, DESIGN.md still permits decorative opacity, and the issue itself scopes them as individual judgement calls. Widening the rule needs per-site review, not a regex.

## Deviation from the issue's plan

The issue proposes splitting this across 3–4 PRs by contrast severity. I did it as one, because **partial enforcement is not committable**: a guard that still fails on 40 remaining violations can't be merged, so the staged split would land the guard last and leave the interim PRs unprotected. Say the word if you'd rather have it staged and I'll split it.

Also noting: `FaroPage`'s bet button had `bg-ds-warning/20 text-ds-warning` in one ternary branch and `bg-ds-accent/20 text-ds-accent` in the sibling branch. I fixed the flagged branch only — `ds-accent` isn't one of #4367's four tokens — so those two branches now use different treatments. Worth a follow-up, but widening to `accent` on my own would have been scope creep.

## Test plan

- [x] RED first: guard reported 55 violations, `badge-contrast: OK` after
- [x] `bun run test` — 15,829 tests; the only genuine failure was OmahaHiLo's `text-ds-info` assertion, updated with the reasoning above
- [x] The issue warns that tests assert the old classnames. The 6 that do (`CariocaPage`, `ContractRummyPage`, `PresidentPage`, `ErrorAlert`) are all **A-2** sites I didn't touch, so they pass unchanged — verified rather than assumed
- [x] `bun run check` — clean, 0-warning baseline held
- [x] `bun run typecheck` — clean (46 of 55 sites needed a static string promoted to a template literal plus an import injected)
- [x] `bun run build` — clean

Note: `src/App.test.tsx` (`/discover` route) failed in the full run and passes in isolation — 5 for 5 across this batch now. Unrelated; deterministic cross-file pollution rather than flakiness.

Closes #4367