### PR TITLE
test(frontend): let the Discover route tests wait for their lazy chunk

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -74,18 +74,28 @@ describe('App non-game routes', () => {
     expect(await screen.findByRole('heading', { level: 1 })).toBeInTheDocument();
   });
 
+  // Both assertions wait on a lazily-loaded route chunk, so they need more than
+  // the 5s global asyncUtilTimeout from setup.ts. In a full-suite run every core
+  // is busy compiling other files, and the wait is for a dynamic import to
+  // resolve rather than for a state update — the second test below measured
+  // 5810ms against the 5000ms budget and failed, while passing in ~1s when run
+  // alone. Raising just these two keeps the global default tight.
+  const CHUNK_TIMEOUT = { timeout: 20000 };
+
   it('renders the Discover survey at /discover', async () => {
     window.location.hash = '#/discover';
     renderWithProviders(<App />);
-    expect(await screen.findByTestId('discover-survey')).toBeInTheDocument();
+    expect(await screen.findByTestId('discover-survey', {}, CHUNK_TIMEOUT)).toBeInTheDocument();
   });
 
   it('sends /discover/result back to the survey when the params are absent', async () => {
     // DiscoverResultPage redirects to /discover when it cannot parse the
     // search params. Reaching that redirect at all proves its own chunk
-    // resolved under Suspense first, so this covers both pages.
+    // resolved under Suspense first, so this covers both pages — which is also
+    // why it is the slowest of the three: two dynamic imports resolve in
+    // sequence, not one.
     window.location.hash = '#/discover/result';
     renderWithProviders(<App />);
-    expect(await screen.findByTestId('discover-survey')).toBeInTheDocument();
+    expect(await screen.findByTestId('discover-survey', {}, CHUNK_TIMEOUT)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

`src/App.test.tsx > sends /discover/result back to the survey when the params are absent` failed in **5 consecutive full-suite runs** and passed every time it ran alone.

That pattern reads like leftover state, and #4361 had already chased a stale survey draft through this exact test. **It is not state.** The failure detail settles it:

```
× sends /discover/result back to the survey when the params are absent  5810ms
TestingLibraryElementError: Unable to find an element by: [data-testid="discover-survey"]
<body> … <aside aria-label="Game navigation"> … メインコンテンツへスキップ …
```

- **5810ms** against the **5000ms** `asyncUtilTimeout` that `setup.ts` sets globally — it timed out, it did not assert against wrong content.
- The dump shows the **app shell fully rendered** (skip link, sidebar, nav). Only the lazily-loaded route chunk was outstanding.

The wait is on a **dynamic import**, not a state update, so it scales with machine load — and a full run has every core busy compiling other files. This test is the slowest of the three because **two chunks resolve in sequence**: `DiscoverResultPage`, then the `DiscoverPage` it redirects to. That is precisely why it was the one that failed while its `/discover` sibling passed.

## Change

Both Discover assertions get a 20s budget; the global default stays tight at 5s so ordinary state-update waits keep failing fast.

## Why not the alternatives

- **Raising the global `asyncUtilTimeout`** would slow every genuine failure in 15,829 tests from 5s to 20s.
- **Asserting the hash changed instead of the survey rendering** would dodge the second chunk, but the test deliberately covers both pages through the redirect — that coverage is the point of it, per its own comment.

## Test plan

- [x] `bun run test` — **1135 files / 15,829 tests, zero failures.** First fully green full run; this test had failed 5 runs in a row before
- [x] `bun run typecheck` — clean
- [x] `bun run check` — clean, 0-warning baseline held

## Note

I reported this to the user four times as "deterministic cross-file state pollution" before reading the failure detail. The observation (fails in full runs, passes isolated) was accurate; my explanation was wrong, and CI's sharding hid it rather than the sharding being evidence for pollution. Worth stating plainly since the wrong diagnosis would have sent the next person hunting for a `localStorage` leak.