### PR TITLE
fix(frontend): hide the keyboard-shortcut panel on mobile

### DIFF
--- a/frontend/src/components/KeyboardShortcutsPanel.test.tsx
+++ b/frontend/src/components/KeyboardShortcutsPanel.test.tsx
@@ -31,6 +31,18 @@ describe('KeyboardShortcutsPanel', () => {
     expect(screen.getByText('キーボードショートカット')).toBeInTheDocument();
   });
 
+  it('is hidden below the sm breakpoint, where there is no keyboard to use', () => {
+    // A 375px phone cannot press these shortcuts, and the panel costs 52px of
+    // the mobile vertical budget on all 111 game pages (44px tap-target summary
+    // + mt-2). Measured: hearts went 683 -> 735 when this shipped, crossing the
+    // 667px viewport that #4373 tracks. Hiding it on mobile returns those pages
+    // to their previous height and loses nothing.
+    render(<KeyboardShortcutsPanel title="キーボードショートカット" shortcuts={shortcuts} data-testid="kbd" />);
+    const panel = screen.getByTestId('kbd');
+    expect(panel).toHaveClass('hidden');
+    expect(panel).toHaveClass('sm:block');
+  });
+
   it('contributes no shortcut text to the page while collapsed', () => {
     // The property that keeps 111 game pages' text unchanged: these rows name
     // the same actions as the buttons they describe, so leaving them mounted

--- a/frontend/src/components/KeyboardShortcutsPanel.tsx
+++ b/frontend/src/components/KeyboardShortcutsPanel.tsx
@@ -34,8 +34,15 @@ export interface KeyboardShortcutsPanelProps extends ComponentPropsWithoutRef<'d
 export function KeyboardShortcutsPanel({ title, shortcuts, className, ...rest }: KeyboardShortcutsPanelProps) {
   const [open, setOpen] = useState(false);
   return (
+    // `hidden sm:block`: a 375px phone has no keyboard, so on mobile this panel
+    // advertises shortcuts that cannot be pressed — while costing 52px of the
+    // vertical budget (44px tap-target summary + mt-2) on all 111 game pages.
+    // That measurably regressed #4373: hearts went from exactly 667px, the
+    // issue's own example of a game that fits, to 735px. Hiding it below the
+    // `sm` breakpoint returns every one of those pages to its previous height
+    // and loses nothing, since the shortcuts are unusable there anyway.
     <details
-      className={`mt-2 w-full max-w-md mx-auto text-ds-text-muted ${className ?? ''}`}
+      className={`mt-2 hidden w-full max-w-md mx-auto text-ds-text-muted sm:block ${className ?? ''}`}
       onToggle={(e) => setOpen(e.currentTarget.open)}
       {...rest}
     >


### PR DESCRIPTION
## Summary

**#4369 regressed #4373, and this returns it.** The collapsed shortcuts panel it added to all 111 game pages costs **52px** of vertical space — a 44px tap-target summary (required by DESIGN.md, which #4368 had *just* enforced) plus `mt-2`. On a phone that space buys nothing: a 375px touch device has no keyboard to press the shortcuts with.

Measured at the 375×667 viewport #4373 tracks:

| game | before the batch | after #4369 | now |
|---|---|---|---|
| `hearts` | **667** | 735 | **683** |
| `freecell` | — | 921 | **869** |
| `blackjack` | — | 773 | **721** |

`hearts` is the example #4373 itself cites as a game that fits *exactly* at 667px. So the batch pushed its own tracked metric the wrong way, on 111 pages at once. Exactly 52px comes back on every page that had the panel.

I found this by spot-checking #4373's measurements before proposing a plan for it — not from a failing test. Nothing would have caught it.

## Why `hidden sm:block` and not the footer restructure

The alternative was moving the panel into each page's existing button row so it shares a line. That means **editing 111 pages a second time**, via the same kind of scripted sweep that needed three reverts earlier in this batch.

Hiding it below `sm` is one line in one file, and it resolves the conflict the two issues created *with each other*: #4368 mandates a 44px tap target on interactive controls, #4369 then added one to 111 pages. **A control that isn't rendered needs no tap target.**

Desktop is untouched, so #4369's 17/111 → 111/111 discoverability holds everywhere a keyboard actually exists.

## What I am deliberately not fixing

`hearts` is still **16px** over 667. That residue is #4365's message box, which now shows phase guidance where Hearts previously displayed **nothing at all**. Trading a real fix for 16px would be optimising the number rather than the product.

Also worth recording for #4373 proper: **`jass` was unchanged at 1169px** because its footer uses `GameFooter`'s `floating` variant (`max-h-[60vh] overflow-y-auto`) — the panel scrolled inside it and never contributed document height. Footer content is free on those pages.

## Test plan

- [x] New test pins `hidden` + `sm:block` with the measurement in the comment, so this can't silently regress
- [x] `bun run test` — 15,841 passed
- [x] `bun run typecheck` — clean
- [x] `bun run check` — clean, 0 warnings, all six guards green
- [x] `bun run e2e` before pushing — 305/307; both failures (`paigow`, `chinesepoker`) are the same "select 2 cards → button enables" timing pattern that failed for `paigow` earlier in this batch on an unrelated branch, and both pass in isolation in 3.5s
- [x] **Confirmed this change is inert in E2E**: Playwright runs at Desktop Chrome width, above the `sm` breakpoint, so those specs see the panel exactly as before
- [x] Re-measured all three games after the fix rather than assuming the 52px

Refs #4373, #4369