### PR TITLE
refactor(adapter): unify the trick DTOs in controller and presenter

### DIFF
--- a/internal/adapter/controller/AllFoursWebController.go
+++ b/internal/adapter/controller/AllFoursWebController.go
@@ -34,12 +34,6 @@ type AllFoursWebOutputPlayer struct {
 	TrickCount      int              `json:"trickCount"`
 }
 
-// AllFoursWebOutputTrickCard トリック中の1枚
-type AllFoursWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
 // AllFoursWebOutputHint ヒント出力
 type AllFoursWebOutputHint struct {
 	CardIndex *int   `json:"cardIndex,omitempty"`
@@ -89,7 +83,7 @@ type AllFoursWebOutput struct {
 	TrumpSuit        int                              `json:"trumpSuit"`
 	TurnUp           *WebOutputCard                   `json:"turnUp"`
 	RunCount         int                              `json:"runCount"`
-	CurrentTrick     []*AllFoursWebOutputTrickCard    `json:"currentTrick"`
+	CurrentTrick     []*WebOutputTrickCard            `json:"currentTrick"`
 	GameEndFlag      bool                             `json:"gameEndFlag"`
 	WinnerIdx        int                              `json:"winnerIdx"`
 	LeadPlayerIdx    int                              `json:"leadPlayerIdx"`
@@ -131,7 +125,7 @@ var NewAllFoursWebController, NewAllFoursWebControllerWithProvider = webControll
 func newAllFoursDefaultOutput(msg string) *AllFoursWebOutput {
 	return &AllFoursWebOutput{
 		Players:       make([]*AllFoursWebOutputPlayer, 0),
-		CurrentTrick:  make([]*AllFoursWebOutputTrickCard, 0),
+		CurrentTrick:  make([]*WebOutputTrickCard, 0),
 		WinnerIdx:     -1,
 		WebOutputBase: WebOutputBase{Message: msg},
 	}

--- a/internal/adapter/controller/AllFoursWebController_test.go
+++ b/internal/adapter/controller/AllFoursWebController_test.go
@@ -17,7 +17,7 @@ import (
 func mustAllFoursOutputJSON(msg string) string {
 	out := &controller.AllFoursWebOutput{
 		Players:       []*controller.AllFoursWebOutputPlayer{},
-		CurrentTrick:  []*controller.AllFoursWebOutputTrickCard{},
+		CurrentTrick:  []*controller.WebOutputTrickCard{},
 		WinnerIdx:     -1,
 		WebOutputBase: controller.WebOutputBase{Message: msg},
 	}

--- a/internal/adapter/controller/BarbuWebController.go
+++ b/internal/adapter/controller/BarbuWebController.go
@@ -42,12 +42,6 @@ type BarbuWebOutputPlayer struct {
 	TotalScore int              `json:"totalScore"`
 }
 
-// BarbuWebOutputTrickCard トリック中の 1 枚
-type BarbuWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
 // BarbuWebOutputDealDetail 1 ディールの得点内訳
 type BarbuWebOutputDealDetail struct {
 	Contract  int         `json:"contract"`
@@ -67,8 +61,8 @@ type BarbuWebOutput struct {
 	CurrentContract int                         `json:"currentContract"`
 	TrumpSuit       int                         `json:"trumpSuit"`
 	TrickNumber     int                         `json:"trickNumber"`
-	CurrentTrick    []*BarbuWebOutputTrickCard  `json:"currentTrick"`
-	LastTrick       []*BarbuWebOutputTrickCard  `json:"lastTrick"`
+	CurrentTrick    []*WebOutputTrickCard       `json:"currentTrick"`
+	LastTrick       []*WebOutputTrickCard       `json:"lastTrick"`
 	LastTrickWinner int                         `json:"lastTrickWinner"`
 	TablePlaced     []int                       `json:"tablePlaced"`
 	DominoPlayable  []int                       `json:"dominoPlayable"`
@@ -93,8 +87,8 @@ var NewBarbuWebController, NewBarbuWebControllerWithProvider = webControllerPair
 func newBarbuDefaultOutput(msg string) *BarbuWebOutput {
 	return &BarbuWebOutput{
 		Players:        make([]*BarbuWebOutputPlayer, 0),
-		CurrentTrick:   make([]*BarbuWebOutputTrickCard, 0),
-		LastTrick:      make([]*BarbuWebOutputTrickCard, 0),
+		CurrentTrick:   make([]*WebOutputTrickCard, 0),
+		LastTrick:      make([]*WebOutputTrickCard, 0),
 		TablePlaced:    make([]int, 0),
 		DominoPlayable: make([]int, 0),
 		UsedContracts:  make([]bool, 0),

--- a/internal/adapter/controller/BeloteWebController.go
+++ b/internal/adapter/controller/BeloteWebController.go
@@ -37,12 +37,6 @@ type BeloteWebOutputPlayer struct {
 	TrickCount int              `json:"trickCount"`
 }
 
-// BeloteWebOutputTrickCard トリック中の1枚
-type BeloteWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
 // BeloteWebOutputHint ヒント出力
 type BeloteWebOutputHint struct {
 	CardIndex *int   `json:"cardIndex,omitempty"`
@@ -53,25 +47,25 @@ type BeloteWebOutputHint struct {
 
 // BeloteWebOutput ベロートWebアウトプット
 type BeloteWebOutput struct {
-	Players          []*BeloteWebOutputPlayer    `json:"players"`
-	Phase            int                         `json:"phase"`
-	RoundNumber      int                         `json:"roundNumber"`
-	TrickNumber      int                         `json:"trickNumber"`
-	CurrentPlayerIdx int                         `json:"currentPlayerIdx"`
-	BidPlayerIdx     int                         `json:"bidPlayerIdx"`
-	DealerIdx        int                         `json:"dealerIdx"`
-	TrumpSuit        int                         `json:"trumpSuit"`
-	FaceUpCard       *WebOutputCard              `json:"faceUpCard"`
-	MakerTeam        int                         `json:"makerTeam"`
-	MakerPlayerIdx   int                         `json:"makerPlayerIdx"`
-	CurrentTrick     []*BeloteWebOutputTrickCard `json:"currentTrick"`
-	TeamScores       [2]int                      `json:"teamScores"`
-	RoundPoints      [2]int                      `json:"roundPoints"`
-	RoundBeloteBonus [2]int                      `json:"roundBeloteBonus"`
-	GameEndFlag      bool                        `json:"gameEndFlag"`
-	WinnerTeam       int                         `json:"winnerTeam"`
-	LeadPlayerIdx    int                         `json:"leadPlayerIdx"`
-	Hint             *BeloteWebOutputHint        `json:"hint,omitempty"`
+	Players          []*BeloteWebOutputPlayer `json:"players"`
+	Phase            int                      `json:"phase"`
+	RoundNumber      int                      `json:"roundNumber"`
+	TrickNumber      int                      `json:"trickNumber"`
+	CurrentPlayerIdx int                      `json:"currentPlayerIdx"`
+	BidPlayerIdx     int                      `json:"bidPlayerIdx"`
+	DealerIdx        int                      `json:"dealerIdx"`
+	TrumpSuit        int                      `json:"trumpSuit"`
+	FaceUpCard       *WebOutputCard           `json:"faceUpCard"`
+	MakerTeam        int                      `json:"makerTeam"`
+	MakerPlayerIdx   int                      `json:"makerPlayerIdx"`
+	CurrentTrick     []*WebOutputTrickCard    `json:"currentTrick"`
+	TeamScores       [2]int                   `json:"teamScores"`
+	RoundPoints      [2]int                   `json:"roundPoints"`
+	RoundBeloteBonus [2]int                   `json:"roundBeloteBonus"`
+	GameEndFlag      bool                     `json:"gameEndFlag"`
+	WinnerTeam       int                      `json:"winnerTeam"`
+	LeadPlayerIdx    int                      `json:"leadPlayerIdx"`
+	Hint             *BeloteWebOutputHint     `json:"hint,omitempty"`
 	WebOutputBase
 	Config BeloteWebOutputConfig `json:"config"`
 }
@@ -113,7 +107,7 @@ var NewBeloteWebController, NewBeloteWebControllerWithProvider = webControllerPa
 func newBeloteDefaultOutput(msg string) *BeloteWebOutput {
 	return &BeloteWebOutput{
 		Players:       make([]*BeloteWebOutputPlayer, 0),
-		CurrentTrick:  make([]*BeloteWebOutputTrickCard, 0),
+		CurrentTrick:  make([]*WebOutputTrickCard, 0),
 		WinnerTeam:    -1,
 		WebOutputBase: WebOutputBase{Message: msg},
 	}

--- a/internal/adapter/controller/BeloteWebController_test.go
+++ b/internal/adapter/controller/BeloteWebController_test.go
@@ -17,7 +17,7 @@ import (
 func mustBeloteOutputJSON(msg string) string {
 	out := &controller.BeloteWebOutput{
 		Players:       []*controller.BeloteWebOutputPlayer{},
-		CurrentTrick:  []*controller.BeloteWebOutputTrickCard{},
+		CurrentTrick:  []*controller.WebOutputTrickCard{},
 		WinnerTeam:    -1,
 		WebOutputBase: controller.WebOutputBase{Message: msg},
 	}

--- a/internal/adapter/controller/BeziqueWebController.go
+++ b/internal/adapter/controller/BeziqueWebController.go
@@ -35,12 +35,6 @@ type BeziqueWebOutputPlayer struct {
 	TrickCount      int              `json:"trickCount"`
 }
 
-// BeziqueWebOutputTrickCard トリック中の1枚
-type BeziqueWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
 // BeziqueWebOutputMeld 宣言可能な役
 type BeziqueWebOutputMeld struct {
 	Type   int `json:"type"`
@@ -57,25 +51,25 @@ type BeziqueWebOutputHint struct {
 
 // BeziqueWebOutput ベジークWebアウトプット
 type BeziqueWebOutput struct {
-	Players          []*BeziqueWebOutputPlayer    `json:"players"`
-	DealPoints       []int                        `json:"dealPoints"`
-	DealMeldPoints   []int                        `json:"dealMeldPoints"`
-	MatchScore       []int                        `json:"matchScore"`
-	Phase            int                          `json:"phase"`
-	RoundNumber      int                          `json:"roundNumber"`
-	TrickNumber      int                          `json:"trickNumber"`
-	CurrentPlayerIdx int                          `json:"currentPlayerIdx"`
-	LeadPlayerIdx    int                          `json:"leadPlayerIdx"`
-	DealerIdx        int                          `json:"dealerIdx"`
-	TrumpSuit        int                          `json:"trumpSuit"`
-	TrumpCard        *WebOutputCard               `json:"trumpCard,omitempty"`
-	CurrentTrick     []*BeziqueWebOutputTrickCard `json:"currentTrick"`
-	StockRemaining   int                          `json:"stockRemaining"`
-	IsEndgame        bool                         `json:"isEndgame"`
-	AvailableMelds   []*BeziqueWebOutputMeld      `json:"availableMelds"`
-	GameEndFlag      bool                         `json:"gameEndFlag"`
-	WinnerIdx        int                          `json:"winnerIdx"`
-	Hint             *BeziqueWebOutputHint        `json:"hint,omitempty"`
+	Players          []*BeziqueWebOutputPlayer `json:"players"`
+	DealPoints       []int                     `json:"dealPoints"`
+	DealMeldPoints   []int                     `json:"dealMeldPoints"`
+	MatchScore       []int                     `json:"matchScore"`
+	Phase            int                       `json:"phase"`
+	RoundNumber      int                       `json:"roundNumber"`
+	TrickNumber      int                       `json:"trickNumber"`
+	CurrentPlayerIdx int                       `json:"currentPlayerIdx"`
+	LeadPlayerIdx    int                       `json:"leadPlayerIdx"`
+	DealerIdx        int                       `json:"dealerIdx"`
+	TrumpSuit        int                       `json:"trumpSuit"`
+	TrumpCard        *WebOutputCard            `json:"trumpCard,omitempty"`
+	CurrentTrick     []*WebOutputTrickCard     `json:"currentTrick"`
+	StockRemaining   int                       `json:"stockRemaining"`
+	IsEndgame        bool                      `json:"isEndgame"`
+	AvailableMelds   []*BeziqueWebOutputMeld   `json:"availableMelds"`
+	GameEndFlag      bool                      `json:"gameEndFlag"`
+	WinnerIdx        int                       `json:"winnerIdx"`
+	Hint             *BeziqueWebOutputHint     `json:"hint,omitempty"`
 	WebOutputBase
 	Config BeziqueWebOutputConfig `json:"config"`
 }
@@ -116,7 +110,7 @@ func newBeziqueDefaultOutput(msg string) *BeziqueWebOutput {
 		DealPoints:     make([]int, 0),
 		DealMeldPoints: make([]int, 0),
 		MatchScore:     make([]int, 0),
-		CurrentTrick:   make([]*BeziqueWebOutputTrickCard, 0),
+		CurrentTrick:   make([]*WebOutputTrickCard, 0),
 		AvailableMelds: make([]*BeziqueWebOutputMeld, 0),
 		WinnerIdx:      -1,
 		WebOutputBase:  WebOutputBase{Message: msg},

--- a/internal/adapter/controller/BeziqueWebController_test.go
+++ b/internal/adapter/controller/BeziqueWebController_test.go
@@ -23,7 +23,7 @@ func mustBeziqueOutputJSON(msg string) string {
 		DealPoints:     []int{},
 		DealMeldPoints: []int{},
 		MatchScore:     []int{},
-		CurrentTrick:   []*controller.BeziqueWebOutputTrickCard{},
+		CurrentTrick:   []*controller.WebOutputTrickCard{},
 		AvailableMelds: []*controller.BeziqueWebOutputMeld{},
 		WinnerIdx:      -1,
 		WebOutputBase:  controller.WebOutputBase{Message: msg},

--- a/internal/adapter/controller/BidWhistWebController.go
+++ b/internal/adapter/controller/BidWhistWebController.go
@@ -46,12 +46,6 @@ type BidWhistWebOutputPlayer struct {
 	IsDeclarer bool                  `json:"isDeclarer"`
 }
 
-// BidWhistWebOutputTrickCard トリック中の1枚
-type BidWhistWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
 // BidWhistWebOutputHint ヒント出力
 type BidWhistWebOutputHint struct {
 	BidTricks      *int   `json:"bidTricks,omitempty"`
@@ -65,27 +59,27 @@ type BidWhistWebOutputHint struct {
 
 // BidWhistWebOutput Bid Whist Webアウトプット
 type BidWhistWebOutput struct {
-	Players           []*BidWhistWebOutputPlayer    `json:"players"`
-	Phase             int                           `json:"phase"`
-	RoundNumber       int                           `json:"roundNumber"`
-	TrickNumber       int                           `json:"trickNumber"`
-	CurrentPlayerIdx  int                           `json:"currentPlayerIdx"`
-	BidPlayerIdx      int                           `json:"bidPlayerIdx"`
-	DealerIdx         int                           `json:"dealerIdx"`
-	LeadPlayerIdx     int                           `json:"leadPlayerIdx"`
-	TrumpSuit         int                           `json:"trumpSuit"`
-	ContractTricks    int                           `json:"contractTricks"`
-	ContractDirection int                           `json:"contractDirection"`
-	DeclarerIdx       int                           `json:"declarerIdx"`
-	HighestBid        *BidWhistWebOutputBid         `json:"highestBid,omitempty"`
-	HighestBidder     int                           `json:"highestBidder"`
-	KittyCount        int                           `json:"kittyCount"`
-	KittyIndices      []int                         `json:"kittyIndices"`
-	CurrentTrick      []*BidWhistWebOutputTrickCard `json:"currentTrick"`
-	TeamScores        [2]int                        `json:"teamScores"`
-	GameEndFlag       bool                          `json:"gameEndFlag"`
-	WinnerTeam        int                           `json:"winnerTeam"`
-	Hint              *BidWhistWebOutputHint        `json:"hint,omitempty"`
+	Players           []*BidWhistWebOutputPlayer `json:"players"`
+	Phase             int                        `json:"phase"`
+	RoundNumber       int                        `json:"roundNumber"`
+	TrickNumber       int                        `json:"trickNumber"`
+	CurrentPlayerIdx  int                        `json:"currentPlayerIdx"`
+	BidPlayerIdx      int                        `json:"bidPlayerIdx"`
+	DealerIdx         int                        `json:"dealerIdx"`
+	LeadPlayerIdx     int                        `json:"leadPlayerIdx"`
+	TrumpSuit         int                        `json:"trumpSuit"`
+	ContractTricks    int                        `json:"contractTricks"`
+	ContractDirection int                        `json:"contractDirection"`
+	DeclarerIdx       int                        `json:"declarerIdx"`
+	HighestBid        *BidWhistWebOutputBid      `json:"highestBid,omitempty"`
+	HighestBidder     int                        `json:"highestBidder"`
+	KittyCount        int                        `json:"kittyCount"`
+	KittyIndices      []int                      `json:"kittyIndices"`
+	CurrentTrick      []*WebOutputTrickCard      `json:"currentTrick"`
+	TeamScores        [2]int                     `json:"teamScores"`
+	GameEndFlag       bool                       `json:"gameEndFlag"`
+	WinnerTeam        int                        `json:"winnerTeam"`
+	Hint              *BidWhistWebOutputHint     `json:"hint,omitempty"`
 	WebOutputBase
 	Config BidWhistWebOutputConfig `json:"config"`
 }
@@ -125,7 +119,7 @@ var NewBidWhistWebController, NewBidWhistWebControllerWithProvider = webControll
 func newBidWhistDefaultOutput(msg string) *BidWhistWebOutput {
 	return &BidWhistWebOutput{
 		Players:       make([]*BidWhistWebOutputPlayer, 0),
-		CurrentTrick:  make([]*BidWhistWebOutputTrickCard, 0),
+		CurrentTrick:  make([]*WebOutputTrickCard, 0),
 		KittyIndices:  make([]int, 0),
 		WinnerTeam:    -1,
 		DeclarerIdx:   -1,

--- a/internal/adapter/controller/BridgeWebController.go
+++ b/internal/adapter/controller/BridgeWebController.go
@@ -35,12 +35,6 @@ type BridgeWebOutputPlayer struct {
 	TrickCount int              `json:"trickCount"`
 }
 
-// BridgeWebOutputTrickCard トリック中の1枚
-type BridgeWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
 // BridgeWebOutputBidEntry ビッド履歴エントリ
 type BridgeWebOutputBidEntry struct {
 	PlayerIdx int `json:"playerIdx"`
@@ -60,31 +54,31 @@ type BridgeWebOutputHint struct {
 
 // BridgeWebOutput ブリッジWebアウトプット
 type BridgeWebOutput struct {
-	Players          []*BridgeWebOutputPlayer    `json:"players"`
-	Phase            int                         `json:"phase"`
-	RoundNumber      int                         `json:"roundNumber"`
-	TrickNumber      int                         `json:"trickNumber"`
-	CurrentPlayerIdx int                         `json:"currentPlayerIdx"`
-	BidPlayerIdx     int                         `json:"bidPlayerIdx"`
-	DealerIdx        int                         `json:"dealerIdx"`
-	TrumpSuit        int                         `json:"trumpSuit"`
-	ContractLevel    int                         `json:"contractLevel"`
-	ContractSuit     int                         `json:"contractSuit"`
-	Doubled          int                         `json:"doubled"`
-	DeclarerIdx      int                         `json:"declarerIdx"`
-	DummyIdx         int                         `json:"dummyIdx"`
-	BidHistory       []*BridgeWebOutputBidEntry  `json:"bidHistory"`
-	Vulnerability    [2]bool                     `json:"vulnerability"`
-	CurrentTrick     []*BridgeWebOutputTrickCard `json:"currentTrick"`
-	TeamScores       [2]int                      `json:"teamScores"`
-	GamesWon         [2]int                      `json:"gamesWon"`
-	BelowLine        [2]int                      `json:"belowLine"`
-	GameEndFlag      bool                        `json:"gameEndFlag"`
-	WinnerTeam       int                         `json:"winnerTeam"`
-	LeadPlayerIdx    int                         `json:"leadPlayerIdx"`
-	OpeningLeadDone  bool                        `json:"openingLeadDone"`
-	DummyHand        []*WebOutputCard            `json:"dummyHand"`
-	Hint             *BridgeWebOutputHint        `json:"hint,omitempty"`
+	Players          []*BridgeWebOutputPlayer   `json:"players"`
+	Phase            int                        `json:"phase"`
+	RoundNumber      int                        `json:"roundNumber"`
+	TrickNumber      int                        `json:"trickNumber"`
+	CurrentPlayerIdx int                        `json:"currentPlayerIdx"`
+	BidPlayerIdx     int                        `json:"bidPlayerIdx"`
+	DealerIdx        int                        `json:"dealerIdx"`
+	TrumpSuit        int                        `json:"trumpSuit"`
+	ContractLevel    int                        `json:"contractLevel"`
+	ContractSuit     int                        `json:"contractSuit"`
+	Doubled          int                        `json:"doubled"`
+	DeclarerIdx      int                        `json:"declarerIdx"`
+	DummyIdx         int                        `json:"dummyIdx"`
+	BidHistory       []*BridgeWebOutputBidEntry `json:"bidHistory"`
+	Vulnerability    [2]bool                    `json:"vulnerability"`
+	CurrentTrick     []*WebOutputTrickCard      `json:"currentTrick"`
+	TeamScores       [2]int                     `json:"teamScores"`
+	GamesWon         [2]int                     `json:"gamesWon"`
+	BelowLine        [2]int                     `json:"belowLine"`
+	GameEndFlag      bool                       `json:"gameEndFlag"`
+	WinnerTeam       int                        `json:"winnerTeam"`
+	LeadPlayerIdx    int                        `json:"leadPlayerIdx"`
+	OpeningLeadDone  bool                       `json:"openingLeadDone"`
+	DummyHand        []*WebOutputCard           `json:"dummyHand"`
+	Hint             *BridgeWebOutputHint       `json:"hint,omitempty"`
 	WebOutputBase
 	Config BridgeWebOutputConfig `json:"config"`
 }
@@ -119,7 +113,7 @@ func newBridgeDefaultOutput(msg string) *BridgeWebOutput {
 	return &BridgeWebOutput{
 		Players:       make([]*BridgeWebOutputPlayer, 0),
 		BidHistory:    make([]*BridgeWebOutputBidEntry, 0),
-		CurrentTrick:  make([]*BridgeWebOutputTrickCard, 0),
+		CurrentTrick:  make([]*WebOutputTrickCard, 0),
 		DummyHand:     make([]*WebOutputCard, 0),
 		WinnerTeam:    -1,
 		DeclarerIdx:   -1,

--- a/internal/adapter/controller/BridgeWebController_test.go
+++ b/internal/adapter/controller/BridgeWebController_test.go
@@ -19,7 +19,7 @@ func mustBridgeOutputJSON(msg string) string {
 	out := &controller.BridgeWebOutput{
 		Players:       []*controller.BridgeWebOutputPlayer{},
 		BidHistory:    []*controller.BridgeWebOutputBidEntry{},
-		CurrentTrick:  []*controller.BridgeWebOutputTrickCard{},
+		CurrentTrick:  []*controller.WebOutputTrickCard{},
 		DummyHand:     []*controller.WebOutputCard{},
 		WinnerTeam:    -1,
 		DeclarerIdx:   -1,

--- a/internal/adapter/controller/BriscolaWebController.go
+++ b/internal/adapter/controller/BriscolaWebController.go
@@ -30,12 +30,6 @@ type BriscolaWebOutputPlayer struct {
 	TrickCount int              `json:"trickCount"`
 }
 
-// BriscolaWebOutputTrickCard トリック中の1枚
-type BriscolaWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
 // BriscolaWebOutputHint ヒント出力
 type BriscolaWebOutputHint struct {
 	CardIndex *int   `json:"cardIndex,omitempty"`
@@ -44,19 +38,19 @@ type BriscolaWebOutputHint struct {
 
 // BriscolaWebOutput ブリスコラWebアウトプット
 type BriscolaWebOutput struct {
-	Players          []*BriscolaWebOutputPlayer    `json:"players"`
-	Phase            int                           `json:"phase"`
-	TrickNumber      int                           `json:"trickNumber"`
-	CurrentPlayerIdx int                           `json:"currentPlayerIdx"`
-	CurrentTrick     []*BriscolaWebOutputTrickCard `json:"currentTrick"`
-	TrumpSuit        int                           `json:"trumpSuit"`
-	TrumpCard        *WebOutputCard                `json:"trumpCard,omitempty"`
-	DealerIdx        int                           `json:"dealerIdx"`
-	LeadPlayerIdx    int                           `json:"leadPlayerIdx"`
-	StockRemaining   int                           `json:"stockRemaining"`
-	GameEndFlag      bool                          `json:"gameEndFlag"`
-	WinnerIdx        int                           `json:"winnerIdx"`
-	Hint             *BriscolaWebOutputHint        `json:"hint,omitempty"`
+	Players          []*BriscolaWebOutputPlayer `json:"players"`
+	Phase            int                        `json:"phase"`
+	TrickNumber      int                        `json:"trickNumber"`
+	CurrentPlayerIdx int                        `json:"currentPlayerIdx"`
+	CurrentTrick     []*WebOutputTrickCard      `json:"currentTrick"`
+	TrumpSuit        int                        `json:"trumpSuit"`
+	TrumpCard        *WebOutputCard             `json:"trumpCard,omitempty"`
+	DealerIdx        int                        `json:"dealerIdx"`
+	LeadPlayerIdx    int                        `json:"leadPlayerIdx"`
+	StockRemaining   int                        `json:"stockRemaining"`
+	GameEndFlag      bool                       `json:"gameEndFlag"`
+	WinnerIdx        int                        `json:"winnerIdx"`
+	Hint             *BriscolaWebOutputHint     `json:"hint,omitempty"`
 	WebOutputBase
 	Config BriscolaWebOutputConfig `json:"config"`
 }
@@ -92,7 +86,7 @@ var NewBriscolaWebController, NewBriscolaWebControllerWithProvider = webControll
 func newBriscolaDefaultOutput(msg string) *BriscolaWebOutput {
 	return &BriscolaWebOutput{
 		Players:       make([]*BriscolaWebOutputPlayer, 0),
-		CurrentTrick:  make([]*BriscolaWebOutputTrickCard, 0),
+		CurrentTrick:  make([]*WebOutputTrickCard, 0),
 		WinnerIdx:     -1,
 		WebOutputBase: WebOutputBase{Message: msg},
 	}

--- a/internal/adapter/controller/BriscolaWebController_test.go
+++ b/internal/adapter/controller/BriscolaWebController_test.go
@@ -20,7 +20,7 @@ import (
 func mustBriscolaOutputJSON(msg string) string {
 	out := &controller.BriscolaWebOutput{
 		Players:       []*controller.BriscolaWebOutputPlayer{},
-		CurrentTrick:  []*controller.BriscolaWebOutputTrickCard{},
+		CurrentTrick:  []*controller.WebOutputTrickCard{},
 		WinnerIdx:     -1,
 		WebOutputBase: controller.WebOutputBase{Message: msg},
 	}

--- a/internal/adapter/controller/CalabresellaWebController.go
+++ b/internal/adapter/controller/CalabresellaWebController.go
@@ -39,18 +39,6 @@ type CalabresellaWebOutputPlayer struct {
 	RoundThirds int              `json:"roundThirds"`
 }
 
-// CalabresellaWebOutputTrickCard トリック中の1枚
-type CalabresellaWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
-// CalabresellaWebOutputHint ヒント出力
-type CalabresellaWebOutputHint struct {
-	CardIndices []int  `json:"cardIndices"`
-	Reason      string `json:"reason"`
-}
-
 // CalabresellaWebOutput カラブレセッラのWebアウトプット
 type CalabresellaWebOutput struct {
 	Players          []*CalabresellaWebOutputPlayer    `json:"players"`
@@ -64,7 +52,7 @@ type CalabresellaWebOutput struct {
 	ForehandIdx      int                               `json:"forehandIdx"`
 	SoloistIdx       int                               `json:"soloistIdx"`
 	WinningBid       int                               `json:"winningBid"`
-	CurrentTrick     []*CalabresellaWebOutputTrickCard `json:"currentTrick"`
+	CurrentTrick     []*WebOutputTrickCard             `json:"currentTrick"`
 	Monte            []*WebOutputCard                  `json:"monte,omitempty"`
 	PlayerScores     [domain.CalabresellaPlayerCnt]int `json:"playerScores"`
 	RoundThirds      [domain.CalabresellaPlayerCnt]int `json:"roundThirds"`
@@ -73,7 +61,7 @@ type CalabresellaWebOutput struct {
 	GameEndFlag      bool                              `json:"gameEndFlag"`
 	WinnerPlayer     int                               `json:"winnerPlayer"`
 	IsHumanTurn      bool                              `json:"isHumanTurn"`
-	Hint             *CalabresellaWebOutputHint        `json:"hint,omitempty"`
+	Hint             *WebOutputCardHint                `json:"hint,omitempty"`
 	WebOutputBase
 	Config CalabresellaWebOutputConfig `json:"config"`
 }
@@ -109,7 +97,7 @@ var NewCalabresellaWebController, NewCalabresellaWebControllerWithProvider = web
 func newCalabresellaDefaultOutput(msg string) *CalabresellaWebOutput {
 	return &CalabresellaWebOutput{
 		Players:         make([]*CalabresellaWebOutputPlayer, 0),
-		CurrentTrick:    make([]*CalabresellaWebOutputTrickCard, 0),
+		CurrentTrick:    make([]*WebOutputTrickCard, 0),
 		PlayableIndices: make([]int, 0),
 		SoloistIdx:      -1,
 		LastTrickWinner: -1,

--- a/internal/adapter/controller/CalabresellaWebController_test.go
+++ b/internal/adapter/controller/CalabresellaWebController_test.go
@@ -17,7 +17,7 @@ import (
 func mustCalabresellaOutputJSON(msg string) string {
 	out := &controller.CalabresellaWebOutput{
 		Players:         []*controller.CalabresellaWebOutputPlayer{},
-		CurrentTrick:    []*controller.CalabresellaWebOutputTrickCard{},
+		CurrentTrick:    []*controller.WebOutputTrickCard{},
 		PlayableIndices: []int{},
 		SoloistIdx:      -1,
 		LastTrickWinner: -1,

--- a/internal/adapter/controller/CallBreakWebController.go
+++ b/internal/adapter/controller/CallBreakWebController.go
@@ -37,12 +37,6 @@ type CallBreakWebOutputPlayer struct {
 	TrickCount      int              `json:"trickCount"`
 }
 
-// CallBreakWebOutputTrickCard トリック中の 1 枚
-type CallBreakWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
 // CallBreakWebOutputHint ヒント出力
 type CallBreakWebOutputHint struct {
 	CardIndex *int   `json:"cardIndex,omitempty"`
@@ -52,19 +46,19 @@ type CallBreakWebOutputHint struct {
 
 // CallBreakWebOutput Call Break Web アウトプット
 type CallBreakWebOutput struct {
-	Players          []*CallBreakWebOutputPlayer    `json:"players"`
-	Phase            int                            `json:"phase"`
-	RoundNumber      int                            `json:"roundNumber"`
-	TrickNumber      int                            `json:"trickNumber"`
-	CurrentPlayerIdx int                            `json:"currentPlayerIdx"`
-	BidPlayerIdx     int                            `json:"bidPlayerIdx"`
-	CurrentTrick     []*CallBreakWebOutputTrickCard `json:"currentTrick"`
-	SpadesBroken     bool                           `json:"spadesBroken"`
-	GameEndFlag      bool                           `json:"gameEndFlag"`
-	WinnerIdx        int                            `json:"winnerIdx"`
-	LeadPlayerIdx    int                            `json:"leadPlayerIdx"`
-	Hint             *CallBreakWebOutputHint        `json:"hint,omitempty"`
-	ValidPlayIndices []int                          `json:"validPlayIndices"`
+	Players          []*CallBreakWebOutputPlayer `json:"players"`
+	Phase            int                         `json:"phase"`
+	RoundNumber      int                         `json:"roundNumber"`
+	TrickNumber      int                         `json:"trickNumber"`
+	CurrentPlayerIdx int                         `json:"currentPlayerIdx"`
+	BidPlayerIdx     int                         `json:"bidPlayerIdx"`
+	CurrentTrick     []*WebOutputTrickCard       `json:"currentTrick"`
+	SpadesBroken     bool                        `json:"spadesBroken"`
+	GameEndFlag      bool                        `json:"gameEndFlag"`
+	WinnerIdx        int                         `json:"winnerIdx"`
+	LeadPlayerIdx    int                         `json:"leadPlayerIdx"`
+	Hint             *CallBreakWebOutputHint     `json:"hint,omitempty"`
+	ValidPlayIndices []int                       `json:"validPlayIndices"`
 	WebOutputBase
 	Config CallBreakWebOutputConfig `json:"config"`
 }
@@ -100,7 +94,7 @@ var NewCallBreakWebController, NewCallBreakWebControllerWithProvider = webContro
 func newCallBreakDefaultOutput(msg string) *CallBreakWebOutput {
 	return &CallBreakWebOutput{
 		Players:          make([]*CallBreakWebOutputPlayer, 0),
-		CurrentTrick:     make([]*CallBreakWebOutputTrickCard, 0),
+		CurrentTrick:     make([]*WebOutputTrickCard, 0),
 		ValidPlayIndices: make([]int, 0),
 		WinnerIdx:        -1,
 		WebOutputBase:    WebOutputBase{Message: msg},

--- a/internal/adapter/controller/CallBreakWebController_test.go
+++ b/internal/adapter/controller/CallBreakWebController_test.go
@@ -18,7 +18,7 @@ import (
 func mustCallBreakOutputJSON(msg string) string {
 	out := &controller.CallBreakWebOutput{
 		Players:          []*controller.CallBreakWebOutputPlayer{},
-		CurrentTrick:     []*controller.CallBreakWebOutputTrickCard{},
+		CurrentTrick:     []*controller.WebOutputTrickCard{},
 		ValidPlayIndices: []int{},
 		WinnerIdx:        -1,
 		WebOutputBase:    controller.WebOutputBase{Message: msg},

--- a/internal/adapter/controller/CatchTenWebController.go
+++ b/internal/adapter/controller/CatchTenWebController.go
@@ -33,12 +33,6 @@ type CatchTenWebOutputPlayer struct {
 	Team            int              `json:"team"`
 }
 
-// CatchTenWebOutputTrickCard トリック中の1枚
-type CatchTenWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
 // CatchTenWebOutputHint ヒント出力
 type CatchTenWebOutputHint struct {
 	CardIndex *int   `json:"cardIndex,omitempty"`
@@ -47,19 +41,19 @@ type CatchTenWebOutputHint struct {
 
 // CatchTenWebOutput Catch the Ten Webアウトプット
 type CatchTenWebOutput struct {
-	Players          []*CatchTenWebOutputPlayer    `json:"players"`
-	Phase            int                           `json:"phase"`
-	RoundNumber      int                           `json:"roundNumber"`
-	TrickNumber      int                           `json:"trickNumber"`
-	CurrentPlayerIdx int                           `json:"currentPlayerIdx"`
-	CurrentTrick     []*CatchTenWebOutputTrickCard `json:"currentTrick"`
-	TrumpSuit        int                           `json:"trumpSuit"`
-	DealerIdx        int                           `json:"dealerIdx"`
-	TeamScores       [2]int                        `json:"teamScores"`
-	GameEndFlag      bool                          `json:"gameEndFlag"`
-	WinnerTeam       int                           `json:"winnerTeam"`
-	LeadPlayerIdx    int                           `json:"leadPlayerIdx"`
-	Hint             *CatchTenWebOutputHint        `json:"hint,omitempty"`
+	Players          []*CatchTenWebOutputPlayer `json:"players"`
+	Phase            int                        `json:"phase"`
+	RoundNumber      int                        `json:"roundNumber"`
+	TrickNumber      int                        `json:"trickNumber"`
+	CurrentPlayerIdx int                        `json:"currentPlayerIdx"`
+	CurrentTrick     []*WebOutputTrickCard      `json:"currentTrick"`
+	TrumpSuit        int                        `json:"trumpSuit"`
+	DealerIdx        int                        `json:"dealerIdx"`
+	TeamScores       [2]int                     `json:"teamScores"`
+	GameEndFlag      bool                       `json:"gameEndFlag"`
+	WinnerTeam       int                        `json:"winnerTeam"`
+	LeadPlayerIdx    int                        `json:"leadPlayerIdx"`
+	Hint             *CatchTenWebOutputHint     `json:"hint,omitempty"`
 	WebOutputBase
 	Config CatchTenWebOutputConfig `json:"config"`
 }
@@ -95,7 +89,7 @@ var NewCatchTenWebController, NewCatchTenWebControllerWithProvider = webControll
 func newCatchTenDefaultOutput(msg string) *CatchTenWebOutput {
 	return &CatchTenWebOutput{
 		Players:       make([]*CatchTenWebOutputPlayer, 0),
-		CurrentTrick:  make([]*CatchTenWebOutputTrickCard, 0),
+		CurrentTrick:  make([]*WebOutputTrickCard, 0),
 		WinnerTeam:    -1,
 		WebOutputBase: WebOutputBase{Message: msg},
 	}

--- a/internal/adapter/controller/CatchTenWebController_test.go
+++ b/internal/adapter/controller/CatchTenWebController_test.go
@@ -20,7 +20,7 @@ import (
 func mustCatchTenOutputJSON(msg string) string {
 	out := &controller.CatchTenWebOutput{
 		Players:       []*controller.CatchTenWebOutputPlayer{},
-		CurrentTrick:  []*controller.CatchTenWebOutputTrickCard{},
+		CurrentTrick:  []*controller.WebOutputTrickCard{},
 		WinnerTeam:    -1,
 		WebOutputBase: controller.WebOutputBase{Message: msg},
 	}

--- a/internal/adapter/controller/CegoWebController.go
+++ b/internal/adapter/controller/CegoWebController.go
@@ -43,12 +43,6 @@ type CegoWebOutputPlayer struct {
 	IsDeclarer bool             `json:"isDeclarer"`
 }
 
-// CegoWebOutputTrickCard トリック中の1枚
-type CegoWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
 // CegoWebOutputHint ヒント出力
 type CegoWebOutputHint struct {
 	Bid         *int   `json:"bid,omitempty"`
@@ -76,7 +70,7 @@ type CegoWebOutput struct {
 	BlindCount       int                       `json:"blindCount"`
 	Blind            []*WebOutputCard          `json:"blind"`
 	StashOwner       int                       `json:"stashOwner"`
-	CurrentTrick     []*CegoWebOutputTrickCard `json:"currentTrick"`
+	CurrentTrick     []*WebOutputTrickCard     `json:"currentTrick"`
 	PlayerScores     [domain.CegoPlayerCnt]int `json:"playerScores"`
 	LastTrickWinner  int                       `json:"lastTrickWinner"`
 	Outcome          int                       `json:"outcome"`
@@ -146,7 +140,7 @@ var NewCegoWebController, NewCegoWebControllerWithProvider = webControllerPair[u
 func newCegoDefaultOutput(msg string) *CegoWebOutput {
 	return &CegoWebOutput{
 		Players:         make([]*CegoWebOutputPlayer, 0),
-		CurrentTrick:    make([]*CegoWebOutputTrickCard, 0),
+		CurrentTrick:    make([]*WebOutputTrickCard, 0),
 		Blind:           make([]*WebOutputCard, 0),
 		PlayableIndices: make([]int, 0),
 		DeclarerIdx:     -1,

--- a/internal/adapter/controller/CegoWebController_test.go
+++ b/internal/adapter/controller/CegoWebController_test.go
@@ -17,7 +17,7 @@ import (
 func mustCegoOutputJSON(msg string) string {
 	out := &controller.CegoWebOutput{
 		Players:         []*controller.CegoWebOutputPlayer{},
-		CurrentTrick:    []*controller.CegoWebOutputTrickCard{},
+		CurrentTrick:    []*controller.WebOutputTrickCard{},
 		Blind:           []*controller.WebOutputCard{},
 		PlayableIndices: []int{},
 		DeclarerIdx:     -1,

--- a/internal/adapter/controller/CinchWebController.go
+++ b/internal/adapter/controller/CinchWebController.go
@@ -50,12 +50,6 @@ type CinchWebOutputPlayer struct {
 	TotalScore int              `json:"totalScore"`
 }
 
-// CinchWebOutputTrickCard はトリック中の 1 枚。
-type CinchWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
 // CinchWebOutputDealDetail は 1 ディールの得点内訳。
 type CinchWebOutputDealDetail struct {
 	TrumpSuit int         `json:"trumpSuit"`
@@ -76,27 +70,27 @@ type CinchWebOutputHint struct {
 
 // CinchWebOutput はチンチ Web アウトプット。
 type CinchWebOutput struct {
-	Players         []*CinchWebOutputPlayer    `json:"players"`
-	Phase           int                        `json:"phase"`
-	RoundNumber     int                        `json:"roundNumber"`
-	TrickNumber     int                        `json:"trickNumber"`
-	TotalTricks     int                        `json:"totalTricks"`
-	DealerIdx       int                        `json:"dealerIdx"`
-	CurrentTurn     int                        `json:"currentTurn"`
-	BidPlayerIdx    int                        `json:"bidPlayerIdx"`
-	CurrentBid      int                        `json:"currentBid"`
-	BidWinnerIdx    int                        `json:"bidWinnerIdx"`
-	TrumpSuit       int                        `json:"trumpSuit"`
-	CurrentTrick    []*CinchWebOutputTrickCard `json:"currentTrick"`
-	LastTrick       []*CinchWebOutputTrickCard `json:"lastTrick"`
-	LastTrickWinner int                        `json:"lastTrickWinner"`
-	PlayableIndices []int                      `json:"playableIndices"`
-	GameEndFlag     bool                       `json:"gameEndFlag"`
-	WinnerIdx       int                        `json:"winnerIdx"`
-	RoundWinners    []int                      `json:"roundWinners"`
-	LastDealDetail  *CinchWebOutputDealDetail  `json:"lastDealDetail"`
-	IsHumanTurn     bool                       `json:"isHumanTurn"`
-	Hint            *CinchWebOutputHint        `json:"hint,omitempty"`
+	Players         []*CinchWebOutputPlayer   `json:"players"`
+	Phase           int                       `json:"phase"`
+	RoundNumber     int                       `json:"roundNumber"`
+	TrickNumber     int                       `json:"trickNumber"`
+	TotalTricks     int                       `json:"totalTricks"`
+	DealerIdx       int                       `json:"dealerIdx"`
+	CurrentTurn     int                       `json:"currentTurn"`
+	BidPlayerIdx    int                       `json:"bidPlayerIdx"`
+	CurrentBid      int                       `json:"currentBid"`
+	BidWinnerIdx    int                       `json:"bidWinnerIdx"`
+	TrumpSuit       int                       `json:"trumpSuit"`
+	CurrentTrick    []*WebOutputTrickCard     `json:"currentTrick"`
+	LastTrick       []*WebOutputTrickCard     `json:"lastTrick"`
+	LastTrickWinner int                       `json:"lastTrickWinner"`
+	PlayableIndices []int                     `json:"playableIndices"`
+	GameEndFlag     bool                      `json:"gameEndFlag"`
+	WinnerIdx       int                       `json:"winnerIdx"`
+	RoundWinners    []int                     `json:"roundWinners"`
+	LastDealDetail  *CinchWebOutputDealDetail `json:"lastDealDetail"`
+	IsHumanTurn     bool                      `json:"isHumanTurn"`
+	Hint            *CinchWebOutputHint       `json:"hint,omitempty"`
 	WebOutputBase
 	Config CinchWebConfigOutput `json:"config"`
 }
@@ -119,8 +113,8 @@ var NewCinchWebController, NewCinchWebControllerWithProvider = webControllerPair
 func newCinchDefaultOutput(msg string) *CinchWebOutput {
 	return &CinchWebOutput{
 		Players:         make([]*CinchWebOutputPlayer, 0),
-		CurrentTrick:    make([]*CinchWebOutputTrickCard, 0),
-		LastTrick:       make([]*CinchWebOutputTrickCard, 0),
+		CurrentTrick:    make([]*WebOutputTrickCard, 0),
+		LastTrick:       make([]*WebOutputTrickCard, 0),
 		PlayableIndices: make([]int, 0),
 		RoundWinners:    make([]int, 0),
 		TotalTricks:     domain.CinchTotalTricks,

--- a/internal/adapter/controller/CinchWebController_test.go
+++ b/internal/adapter/controller/CinchWebController_test.go
@@ -17,8 +17,8 @@ import (
 func mustCinchOutputJSON(msg string) string {
 	out := &controller.CinchWebOutput{
 		Players:         []*controller.CinchWebOutputPlayer{},
-		CurrentTrick:    []*controller.CinchWebOutputTrickCard{},
-		LastTrick:       []*controller.CinchWebOutputTrickCard{},
+		CurrentTrick:    []*controller.WebOutputTrickCard{},
+		LastTrick:       []*controller.WebOutputTrickCard{},
 		PlayableIndices: []int{},
 		RoundWinners:    []int{},
 		TotalTricks:     domain.CinchTotalTricks,

--- a/internal/adapter/controller/CourtPieceWebController.go
+++ b/internal/adapter/controller/CourtPieceWebController.go
@@ -36,12 +36,6 @@ type CourtPieceWebOutputPlayer struct {
 	TrickCount      int              `json:"trickCount"`
 }
 
-// CourtPieceWebOutputTrickCard トリック中の 1 枚
-type CourtPieceWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
 // CourtPieceWebOutputHint ヒント出力
 type CourtPieceWebOutputHint struct {
 	CardIndex *int   `json:"cardIndex,omitempty"`
@@ -57,22 +51,22 @@ type CourtPieceWebOutputConfig struct {
 
 // CourtPieceWebOutput Court Piece Web アウトプット
 type CourtPieceWebOutput struct {
-	Players          []*CourtPieceWebOutputPlayer    `json:"players"`
-	TeamScores       []int                           `json:"teamScores"`
-	Phase            int                             `json:"phase"`
-	RoundNumber      int                             `json:"roundNumber"`
-	TrickNumber      int                             `json:"trickNumber"`
-	CurrentPlayerIdx int                             `json:"currentPlayerIdx"`
-	CallerIdx        int                             `json:"callerIdx"`
-	TrumpSuit        int                             `json:"trumpSuit"`
-	CurrentTrick     []*CourtPieceWebOutputTrickCard `json:"currentTrick"`
-	ConsecutiveWins  int                             `json:"consecutiveWins"`
-	LastWinnerTeam   int                             `json:"lastWinnerTeam"`
-	LastRoundCourt   bool                            `json:"lastRoundCourt"`
-	GameEndFlag      bool                            `json:"gameEndFlag"`
-	WinnerTeam       int                             `json:"winnerTeam"`
-	LeadPlayerIdx    int                             `json:"leadPlayerIdx"`
-	Hint             *CourtPieceWebOutputHint        `json:"hint,omitempty"`
+	Players          []*CourtPieceWebOutputPlayer `json:"players"`
+	TeamScores       []int                        `json:"teamScores"`
+	Phase            int                          `json:"phase"`
+	RoundNumber      int                          `json:"roundNumber"`
+	TrickNumber      int                          `json:"trickNumber"`
+	CurrentPlayerIdx int                          `json:"currentPlayerIdx"`
+	CallerIdx        int                          `json:"callerIdx"`
+	TrumpSuit        int                          `json:"trumpSuit"`
+	CurrentTrick     []*WebOutputTrickCard        `json:"currentTrick"`
+	ConsecutiveWins  int                          `json:"consecutiveWins"`
+	LastWinnerTeam   int                          `json:"lastWinnerTeam"`
+	LastRoundCourt   bool                         `json:"lastRoundCourt"`
+	GameEndFlag      bool                         `json:"gameEndFlag"`
+	WinnerTeam       int                          `json:"winnerTeam"`
+	LeadPlayerIdx    int                          `json:"leadPlayerIdx"`
+	Hint             *CourtPieceWebOutputHint     `json:"hint,omitempty"`
 	WebOutputBase
 	Config CourtPieceWebOutputConfig `json:"config"`
 }
@@ -103,7 +97,7 @@ func newCourtPieceDefaultOutput(msg string) *CourtPieceWebOutput {
 	return &CourtPieceWebOutput{
 		Players:       make([]*CourtPieceWebOutputPlayer, 0),
 		TeamScores:    make([]int, 0),
-		CurrentTrick:  make([]*CourtPieceWebOutputTrickCard, 0),
+		CurrentTrick:  make([]*WebOutputTrickCard, 0),
 		WinnerTeam:    -1,
 		WebOutputBase: WebOutputBase{Message: msg},
 	}

--- a/internal/adapter/controller/CourtPieceWebController_test.go
+++ b/internal/adapter/controller/CourtPieceWebController_test.go
@@ -19,7 +19,7 @@ func mustCourtPieceOutputJSON(msg string) string {
 	out := &controller.CourtPieceWebOutput{
 		Players:       []*controller.CourtPieceWebOutputPlayer{},
 		TeamScores:    []int{},
-		CurrentTrick:  []*controller.CourtPieceWebOutputTrickCard{},
+		CurrentTrick:  []*controller.WebOutputTrickCard{},
 		WinnerTeam:    -1,
 		WebOutputBase: controller.WebOutputBase{Message: msg},
 	}

--- a/internal/adapter/controller/DoppelkopfWebController.go
+++ b/internal/adapter/controller/DoppelkopfWebController.go
@@ -39,43 +39,31 @@ type DoppelkopfWebOutputPlayer struct {
 	IsRe bool `json:"isRe"`
 }
 
-// DoppelkopfWebOutputTrickCard トリック中の1枚
-type DoppelkopfWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
-// DoppelkopfWebOutputHint ヒント出力
-type DoppelkopfWebOutputHint struct {
-	CardIndices []int  `json:"cardIndices"`
-	Reason      string `json:"reason"`
-}
-
 // DoppelkopfWebOutput ドッペルコップのWebアウトプット
 type DoppelkopfWebOutput struct {
-	Players          []*DoppelkopfWebOutputPlayer    `json:"players"`
-	Phase            int                             `json:"phase"`
-	RoundNumber      int                             `json:"roundNumber"`
-	TrickNumber      int                             `json:"trickNumber"`
-	CurrentPlayerIdx int                             `json:"currentPlayerIdx"`
-	LeadPlayerIdx    int                             `json:"leadPlayerIdx"`
-	DealerIdx        int                             `json:"dealerIdx"`
-	CurrentTrick     []*DoppelkopfWebOutputTrickCard `json:"currentTrick"`
+	Players          []*DoppelkopfWebOutputPlayer `json:"players"`
+	Phase            int                          `json:"phase"`
+	RoundNumber      int                          `json:"roundNumber"`
+	TrickNumber      int                          `json:"trickNumber"`
+	CurrentPlayerIdx int                          `json:"currentPlayerIdx"`
+	LeadPlayerIdx    int                          `json:"leadPlayerIdx"`
+	DealerIdx        int                          `json:"dealerIdx"`
+	CurrentTrick     []*WebOutputTrickCard        `json:"currentTrick"`
 	// ReTeam 各プレイヤーの Re チーム所属 (チーム公開後のみ true になりうる; 4要素)
-	ReTeam          []bool                   `json:"reTeam"`
-	SoloRe          bool                     `json:"soloRe"`
-	TeamsRevealed   bool                     `json:"teamsRevealed"`
-	ReAnnounced     bool                     `json:"reAnnounced"`
-	KontraAnnounced bool                     `json:"kontraAnnounced"`
-	CanAnnounce     bool                     `json:"canAnnounce"`
-	YouAreRe        bool                     `json:"youAreRe"`
-	PlayableIndices []int                    `json:"playableIndices"`
-	RoundRePoints   int                      `json:"roundRePoints"`
-	RoundReWon      bool                     `json:"roundReWon"`
-	RoundGamePoints int                      `json:"roundGamePoints"`
-	GameEndFlag     bool                     `json:"gameEndFlag"`
-	WinnerIdx       int                      `json:"winnerIdx"`
-	Hint            *DoppelkopfWebOutputHint `json:"hint,omitempty"`
+	ReTeam          []bool             `json:"reTeam"`
+	SoloRe          bool               `json:"soloRe"`
+	TeamsRevealed   bool               `json:"teamsRevealed"`
+	ReAnnounced     bool               `json:"reAnnounced"`
+	KontraAnnounced bool               `json:"kontraAnnounced"`
+	CanAnnounce     bool               `json:"canAnnounce"`
+	YouAreRe        bool               `json:"youAreRe"`
+	PlayableIndices []int              `json:"playableIndices"`
+	RoundRePoints   int                `json:"roundRePoints"`
+	RoundReWon      bool               `json:"roundReWon"`
+	RoundGamePoints int                `json:"roundGamePoints"`
+	GameEndFlag     bool               `json:"gameEndFlag"`
+	WinnerIdx       int                `json:"winnerIdx"`
+	Hint            *WebOutputCardHint `json:"hint,omitempty"`
 	WebOutputBase
 	Config DoppelkopfWebOutputConfig `json:"config"`
 }
@@ -115,7 +103,7 @@ var NewDoppelkopfWebController, NewDoppelkopfWebControllerWithProvider = webCont
 func newDoppelkopfDefaultOutput(msg string) *DoppelkopfWebOutput {
 	return &DoppelkopfWebOutput{
 		Players:         make([]*DoppelkopfWebOutputPlayer, 0),
-		CurrentTrick:    make([]*DoppelkopfWebOutputTrickCard, 0),
+		CurrentTrick:    make([]*WebOutputTrickCard, 0),
 		ReTeam:          make([]bool, domain.DoppelkopfPlayerCnt),
 		PlayableIndices: make([]int, 0),
 		WinnerIdx:       -1,

--- a/internal/adapter/controller/DoppelkopfWebController_test.go
+++ b/internal/adapter/controller/DoppelkopfWebController_test.go
@@ -17,7 +17,7 @@ import (
 func mustDoppelkopfOutputJSON(msg string) string {
 	out := &controller.DoppelkopfWebOutput{
 		Players:         []*controller.DoppelkopfWebOutputPlayer{},
-		CurrentTrick:    []*controller.DoppelkopfWebOutputTrickCard{},
+		CurrentTrick:    []*controller.WebOutputTrickCard{},
 		ReTeam:          make([]bool, domain.DoppelkopfPlayerCnt),
 		PlayableIndices: []int{},
 		WinnerIdx:       -1,

--- a/internal/adapter/controller/EcarteWebController.go
+++ b/internal/adapter/controller/EcarteWebController.go
@@ -36,12 +36,6 @@ type EcarteWebOutputPlayer struct {
 	TrickCount      int              `json:"trickCount"`
 }
 
-// EcarteWebOutputTrickCard トリック中の1枚
-type EcarteWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
 // EcarteWebOutputHint ヒント出力
 type EcarteWebOutputHint struct {
 	CardIndex *int   `json:"cardIndex,omitempty"`
@@ -51,26 +45,26 @@ type EcarteWebOutputHint struct {
 
 // EcarteWebOutput エカルテWebアウトプット
 type EcarteWebOutput struct {
-	Players          []*EcarteWebOutputPlayer    `json:"players"`
-	DealPoints       []int                       `json:"dealPoints"`
-	MatchScore       []int                       `json:"matchScore"`
-	Phase            int                         `json:"phase"`
-	NegStep          int                         `json:"negStep"`
-	RoundNumber      int                         `json:"roundNumber"`
-	TrickNumber      int                         `json:"trickNumber"`
-	CurrentPlayerIdx int                         `json:"currentPlayerIdx"`
-	DealerIdx        int                         `json:"dealerIdx"`
-	ElderIdx         int                         `json:"elderIdx"`
-	LeadPlayerIdx    int                         `json:"leadPlayerIdx"`
-	TrumpSuit        int                         `json:"trumpSuit"`
-	TrumpCard        *WebOutputCard              `json:"trumpCard,omitempty"`
-	CurrentTrick     []*EcarteWebOutputTrickCard `json:"currentTrick"`
-	StockRemaining   int                         `json:"stockRemaining"`
-	RefusalByDealer  bool                        `json:"refusalByDealer"`
-	ValidPlays       []int                       `json:"validPlays"`
-	GameEndFlag      bool                        `json:"gameEndFlag"`
-	WinnerIdx        int                         `json:"winnerIdx"`
-	Hint             *EcarteWebOutputHint        `json:"hint,omitempty"`
+	Players          []*EcarteWebOutputPlayer `json:"players"`
+	DealPoints       []int                    `json:"dealPoints"`
+	MatchScore       []int                    `json:"matchScore"`
+	Phase            int                      `json:"phase"`
+	NegStep          int                      `json:"negStep"`
+	RoundNumber      int                      `json:"roundNumber"`
+	TrickNumber      int                      `json:"trickNumber"`
+	CurrentPlayerIdx int                      `json:"currentPlayerIdx"`
+	DealerIdx        int                      `json:"dealerIdx"`
+	ElderIdx         int                      `json:"elderIdx"`
+	LeadPlayerIdx    int                      `json:"leadPlayerIdx"`
+	TrumpSuit        int                      `json:"trumpSuit"`
+	TrumpCard        *WebOutputCard           `json:"trumpCard,omitempty"`
+	CurrentTrick     []*WebOutputTrickCard    `json:"currentTrick"`
+	StockRemaining   int                      `json:"stockRemaining"`
+	RefusalByDealer  bool                     `json:"refusalByDealer"`
+	ValidPlays       []int                    `json:"validPlays"`
+	GameEndFlag      bool                     `json:"gameEndFlag"`
+	WinnerIdx        int                      `json:"winnerIdx"`
+	Hint             *EcarteWebOutputHint     `json:"hint,omitempty"`
 	WebOutputBase
 	Config EcarteWebOutputConfig `json:"config"`
 }
@@ -110,7 +104,7 @@ func newEcarteDefaultOutput(msg string) *EcarteWebOutput {
 		Players:       make([]*EcarteWebOutputPlayer, 0),
 		DealPoints:    make([]int, 0),
 		MatchScore:    make([]int, 0),
-		CurrentTrick:  make([]*EcarteWebOutputTrickCard, 0),
+		CurrentTrick:  make([]*WebOutputTrickCard, 0),
 		ValidPlays:    make([]int, 0),
 		WinnerIdx:     -1,
 		WebOutputBase: WebOutputBase{Message: msg},

--- a/internal/adapter/controller/EcarteWebController_test.go
+++ b/internal/adapter/controller/EcarteWebController_test.go
@@ -22,7 +22,7 @@ func mustEcarteOutputJSON(msg string) string {
 		Players:       []*controller.EcarteWebOutputPlayer{},
 		DealPoints:    []int{},
 		MatchScore:    []int{},
-		CurrentTrick:  []*controller.EcarteWebOutputTrickCard{},
+		CurrentTrick:  []*controller.WebOutputTrickCard{},
 		ValidPlays:    []int{},
 		WinnerIdx:     -1,
 		WebOutputBase: controller.WebOutputBase{Message: msg},

--- a/internal/adapter/controller/EuchreWebController.go
+++ b/internal/adapter/controller/EuchreWebController.go
@@ -36,12 +36,6 @@ type EuchreWebOutputPlayer struct {
 	TrickCount int              `json:"trickCount"`
 }
 
-// EuchreWebOutputTrickCard トリック中の1枚
-type EuchreWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
 // EuchreWebOutputHint ヒント出力
 type EuchreWebOutputHint struct {
 	CardIndex *int   `json:"cardIndex,omitempty"`
@@ -53,24 +47,24 @@ type EuchreWebOutputHint struct {
 
 // EuchreWebOutput ユーカーWebアウトプット
 type EuchreWebOutput struct {
-	Players             []*EuchreWebOutputPlayer    `json:"players"`
-	Phase               int                         `json:"phase"`
-	RoundNumber         int                         `json:"roundNumber"`
-	TrickNumber         int                         `json:"trickNumber"`
-	CurrentPlayerIdx    int                         `json:"currentPlayerIdx"`
-	BidPlayerIdx        int                         `json:"bidPlayerIdx"`
-	DealerIdx           int                         `json:"dealerIdx"`
-	TrumpSuit           int                         `json:"trumpSuit"`
-	FaceUpCard          *WebOutputCard              `json:"faceUpCard"`
-	MakerTeam           int                         `json:"makerTeam"`
-	GoingAlone          bool                        `json:"goingAlone"`
-	GoingAlonePlayerIdx int                         `json:"goingAlonePlayerIdx"`
-	CurrentTrick        []*EuchreWebOutputTrickCard `json:"currentTrick"`
-	TeamScores          [2]int                      `json:"teamScores"`
-	GameEndFlag         bool                        `json:"gameEndFlag"`
-	WinnerTeam          int                         `json:"winnerTeam"`
-	LeadPlayerIdx       int                         `json:"leadPlayerIdx"`
-	Hint                *EuchreWebOutputHint        `json:"hint,omitempty"`
+	Players             []*EuchreWebOutputPlayer `json:"players"`
+	Phase               int                      `json:"phase"`
+	RoundNumber         int                      `json:"roundNumber"`
+	TrickNumber         int                      `json:"trickNumber"`
+	CurrentPlayerIdx    int                      `json:"currentPlayerIdx"`
+	BidPlayerIdx        int                      `json:"bidPlayerIdx"`
+	DealerIdx           int                      `json:"dealerIdx"`
+	TrumpSuit           int                      `json:"trumpSuit"`
+	FaceUpCard          *WebOutputCard           `json:"faceUpCard"`
+	MakerTeam           int                      `json:"makerTeam"`
+	GoingAlone          bool                     `json:"goingAlone"`
+	GoingAlonePlayerIdx int                      `json:"goingAlonePlayerIdx"`
+	CurrentTrick        []*WebOutputTrickCard    `json:"currentTrick"`
+	TeamScores          [2]int                   `json:"teamScores"`
+	GameEndFlag         bool                     `json:"gameEndFlag"`
+	WinnerTeam          int                      `json:"winnerTeam"`
+	LeadPlayerIdx       int                      `json:"leadPlayerIdx"`
+	Hint                *EuchreWebOutputHint     `json:"hint,omitempty"`
 	WebOutputBase
 	Config EuchreWebOutputConfig `json:"config"`
 }
@@ -106,7 +100,7 @@ var NewEuchreWebController, NewEuchreWebControllerWithProvider = webControllerPa
 func newEuchreDefaultOutput(msg string) *EuchreWebOutput {
 	return &EuchreWebOutput{
 		Players:       make([]*EuchreWebOutputPlayer, 0),
-		CurrentTrick:  make([]*EuchreWebOutputTrickCard, 0),
+		CurrentTrick:  make([]*WebOutputTrickCard, 0),
 		WinnerTeam:    -1,
 		WebOutputBase: WebOutputBase{Message: msg},
 	}

--- a/internal/adapter/controller/EuchreWebController_test.go
+++ b/internal/adapter/controller/EuchreWebController_test.go
@@ -18,7 +18,7 @@ import (
 func mustEuchreOutputJSON(msg string) string {
 	out := &controller.EuchreWebOutput{
 		Players:       []*controller.EuchreWebOutputPlayer{},
-		CurrentTrick:  []*controller.EuchreWebOutputTrickCard{},
+		CurrentTrick:  []*controller.WebOutputTrickCard{},
 		WinnerTeam:    -1,
 		WebOutputBase: controller.WebOutputBase{Message: msg},
 	}

--- a/internal/adapter/controller/FiveHundredWebController.go
+++ b/internal/adapter/controller/FiveHundredWebController.go
@@ -49,12 +49,6 @@ type FiveHundredWebOutputPlayer struct {
 	IsDeclarer bool                     `json:"isDeclarer"`
 }
 
-// FiveHundredWebOutputTrickCard トリック中の1枚
-type FiveHundredWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
 // FiveHundredWebOutputHint ヒント出力
 type FiveHundredWebOutputHint struct {
 	BidKind        *int   `json:"bidKind,omitempty"`
@@ -69,28 +63,28 @@ type FiveHundredWebOutputHint struct {
 
 // FiveHundredWebOutput 500 Webアウトプット
 type FiveHundredWebOutput struct {
-	Players          []*FiveHundredWebOutputPlayer    `json:"players"`
-	Phase            int                              `json:"phase"`
-	RoundNumber      int                              `json:"roundNumber"`
-	TrickNumber      int                              `json:"trickNumber"`
-	CurrentPlayerIdx int                              `json:"currentPlayerIdx"`
-	BidPlayerIdx     int                              `json:"bidPlayerIdx"`
-	DealerIdx        int                              `json:"dealerIdx"`
-	LeadPlayerIdx    int                              `json:"leadPlayerIdx"`
-	TrumpSuit        int                              `json:"trumpSuit"`
-	ContractKind     int                              `json:"contractKind"`
-	ContractTricks   int                              `json:"contractTricks"`
-	ContractValue    int                              `json:"contractValue"`
-	DeclarerIdx      int                              `json:"declarerIdx"`
-	HighestBid       *FiveHundredWebOutputBid         `json:"highestBid,omitempty"`
-	HighestBidder    int                              `json:"highestBidder"`
-	JokerLeadSuit    int                              `json:"jokerLeadSuit"`
-	KittyCount       int                              `json:"kittyCount"`
-	CurrentTrick     []*FiveHundredWebOutputTrickCard `json:"currentTrick"`
-	TeamScores       [2]int                           `json:"teamScores"`
-	GameEndFlag      bool                             `json:"gameEndFlag"`
-	WinnerTeam       int                              `json:"winnerTeam"`
-	Hint             *FiveHundredWebOutputHint        `json:"hint,omitempty"`
+	Players          []*FiveHundredWebOutputPlayer `json:"players"`
+	Phase            int                           `json:"phase"`
+	RoundNumber      int                           `json:"roundNumber"`
+	TrickNumber      int                           `json:"trickNumber"`
+	CurrentPlayerIdx int                           `json:"currentPlayerIdx"`
+	BidPlayerIdx     int                           `json:"bidPlayerIdx"`
+	DealerIdx        int                           `json:"dealerIdx"`
+	LeadPlayerIdx    int                           `json:"leadPlayerIdx"`
+	TrumpSuit        int                           `json:"trumpSuit"`
+	ContractKind     int                           `json:"contractKind"`
+	ContractTricks   int                           `json:"contractTricks"`
+	ContractValue    int                           `json:"contractValue"`
+	DeclarerIdx      int                           `json:"declarerIdx"`
+	HighestBid       *FiveHundredWebOutputBid      `json:"highestBid,omitempty"`
+	HighestBidder    int                           `json:"highestBidder"`
+	JokerLeadSuit    int                           `json:"jokerLeadSuit"`
+	KittyCount       int                           `json:"kittyCount"`
+	CurrentTrick     []*WebOutputTrickCard         `json:"currentTrick"`
+	TeamScores       [2]int                        `json:"teamScores"`
+	GameEndFlag      bool                          `json:"gameEndFlag"`
+	WinnerTeam       int                           `json:"winnerTeam"`
+	Hint             *FiveHundredWebOutputHint     `json:"hint,omitempty"`
 	WebOutputBase
 	Config FiveHundredWebOutputConfig `json:"config"`
 }
@@ -130,7 +124,7 @@ var NewFiveHundredWebController, NewFiveHundredWebControllerWithProvider = webCo
 func newFiveHundredDefaultOutput(msg string) *FiveHundredWebOutput {
 	return &FiveHundredWebOutput{
 		Players:       make([]*FiveHundredWebOutputPlayer, 0),
-		CurrentTrick:  make([]*FiveHundredWebOutputTrickCard, 0),
+		CurrentTrick:  make([]*WebOutputTrickCard, 0),
 		WinnerTeam:    -1,
 		DeclarerIdx:   -1,
 		HighestBidder: -1,

--- a/internal/adapter/controller/FortyFivesWebController.go
+++ b/internal/adapter/controller/FortyFivesWebController.go
@@ -38,18 +38,6 @@ type FortyFivesWebOutputPlayer struct {
 	IsDeclarer bool             `json:"isDeclarer"`
 }
 
-// FortyFivesWebOutputTrickCard トリック中の1枚
-type FortyFivesWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
-// FortyFivesWebOutputHint ヒント出力
-type FortyFivesWebOutputHint struct {
-	CardIndices []int  `json:"cardIndices"`
-	Reason      string `json:"reason"`
-}
-
 // FortyFivesWebOutput オークション・フォーティファイブズのWebアウトプット
 type FortyFivesWebOutput struct {
 	Players          []*FortyFivesWebOutputPlayer    `json:"players"`
@@ -63,7 +51,7 @@ type FortyFivesWebOutput struct {
 	Contract         int                             `json:"contract"`
 	TrumpSuit        int                             `json:"trumpSuit"`
 	Bids             [domain.FortyFivesPlayerCnt]int `json:"bids"`
-	CurrentTrick     []*FortyFivesWebOutputTrickCard `json:"currentTrick"`
+	CurrentTrick     []*WebOutputTrickCard           `json:"currentTrick"`
 	TeamScores       [domain.FortyFivesTeamCnt]int   `json:"teamScores"`
 	RoundTeamPoints  [domain.FortyFivesTeamCnt]int   `json:"roundTeamPoints"`
 	PlayableIndices  []int                           `json:"playableIndices"`
@@ -71,7 +59,7 @@ type FortyFivesWebOutput struct {
 	WinnerTeam       int                             `json:"winnerTeam"`
 	IsHumanTurn      bool                            `json:"isHumanTurn"`
 	IsHumanBidTurn   bool                            `json:"isHumanBidTurn"`
-	Hint             *FortyFivesWebOutputHint        `json:"hint,omitempty"`
+	Hint             *WebOutputCardHint              `json:"hint,omitempty"`
 	WebOutputBase
 	Config FortyFivesWebOutputConfig `json:"config"`
 }
@@ -107,7 +95,7 @@ var NewFortyFivesWebController, NewFortyFivesWebControllerWithProvider = webCont
 func newFortyFivesDefaultOutput(msg string) *FortyFivesWebOutput {
 	return &FortyFivesWebOutput{
 		Players:         make([]*FortyFivesWebOutputPlayer, 0),
-		CurrentTrick:    make([]*FortyFivesWebOutputTrickCard, 0),
+		CurrentTrick:    make([]*WebOutputTrickCard, 0),
 		PlayableIndices: make([]int, 0),
 		DeclarerIdx:     -1,
 		WinnerTeam:      -1,

--- a/internal/adapter/controller/FortyFivesWebController_test.go
+++ b/internal/adapter/controller/FortyFivesWebController_test.go
@@ -17,7 +17,7 @@ import (
 func mustFortyFivesOutputJSON(msg string) string {
 	out := &controller.FortyFivesWebOutput{
 		Players:         []*controller.FortyFivesWebOutputPlayer{},
-		CurrentTrick:    []*controller.FortyFivesWebOutputTrickCard{},
+		CurrentTrick:    []*controller.WebOutputTrickCard{},
 		PlayableIndices: []int{},
 		DeclarerIdx:     -1,
 		WinnerTeam:      -1,

--- a/internal/adapter/controller/FrenchTarotWebController.go
+++ b/internal/adapter/controller/FrenchTarotWebController.go
@@ -41,12 +41,6 @@ type FrenchTarotWebOutputPlayer struct {
 	IsDeclarer bool             `json:"isDeclarer"`
 }
 
-// FrenchTarotWebOutputTrickCard トリック中の1枚
-type FrenchTarotWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
 // FrenchTarotWebOutputHint ヒント出力
 type FrenchTarotWebOutputHint struct {
 	Bid         *int   `json:"bid,omitempty"`
@@ -72,7 +66,7 @@ type FrenchTarotWebOutput struct {
 	Chien            []*WebOutputCard                 `json:"chien"`
 	ChienRevealed    bool                             `json:"chienRevealed"`
 	StashOwner       int                              `json:"stashOwner"`
-	CurrentTrick     []*FrenchTarotWebOutputTrickCard `json:"currentTrick"`
+	CurrentTrick     []*WebOutputTrickCard            `json:"currentTrick"`
 	PlayerScores     [domain.FrenchTarotPlayerCnt]int `json:"playerScores"`
 	LastTrickWinner  int                              `json:"lastTrickWinner"`
 	Outcome          int                              `json:"outcome"`
@@ -135,7 +129,7 @@ var NewFrenchTarotWebController, NewFrenchTarotWebControllerWithProvider = webCo
 func newFrenchTarotDefaultOutput(msg string) *FrenchTarotWebOutput {
 	return &FrenchTarotWebOutput{
 		Players:         make([]*FrenchTarotWebOutputPlayer, 0),
-		CurrentTrick:    make([]*FrenchTarotWebOutputTrickCard, 0),
+		CurrentTrick:    make([]*WebOutputTrickCard, 0),
 		Chien:           make([]*WebOutputCard, 0),
 		PlayableIndices: make([]int, 0),
 		DeclarerIdx:     -1,

--- a/internal/adapter/controller/FrenchTarotWebController_test.go
+++ b/internal/adapter/controller/FrenchTarotWebController_test.go
@@ -17,7 +17,7 @@ import (
 func mustFrenchTarotOutputJSON(msg string) string {
 	out := &controller.FrenchTarotWebOutput{
 		Players:         []*controller.FrenchTarotWebOutputPlayer{},
-		CurrentTrick:    []*controller.FrenchTarotWebOutputTrickCard{},
+		CurrentTrick:    []*controller.WebOutputTrickCard{},
 		Chien:           []*controller.WebOutputCard{},
 		PlayableIndices: []int{},
 		DeclarerIdx:     -1,

--- a/internal/adapter/controller/GaigelWebController.go
+++ b/internal/adapter/controller/GaigelWebController.go
@@ -33,12 +33,6 @@ type GaigelWebOutputPlayer struct {
 	TrickCount int              `json:"trickCount"`
 }
 
-// GaigelWebOutputTrickCard トリック中の1枚
-type GaigelWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
 // GaigelWebOutputHint ヒント出力
 type GaigelWebOutputHint struct {
 	CardIndex  *int   `json:"cardIndex,omitempty"`
@@ -48,24 +42,24 @@ type GaigelWebOutputHint struct {
 
 // GaigelWebOutput ガイゲルWebアウトプット
 type GaigelWebOutput struct {
-	Players          []*GaigelWebOutputPlayer    `json:"players"`
-	Phase            int                         `json:"phase"`
-	RoundNumber      int                         `json:"roundNumber"`
-	TrickNumber      int                         `json:"trickNumber"`
-	CurrentPlayerIdx int                         `json:"currentPlayerIdx"`
-	DealerIdx        int                         `json:"dealerIdx"`
-	TrumpSuit        int                         `json:"trumpSuit"`
-	TrumpCard        *WebOutputCard              `json:"trumpCard,omitempty"`
-	StockRemaining   int                         `json:"stockRemaining"`
-	CurrentTrick     []*GaigelWebOutputTrickCard `json:"currentTrick"`
-	TeamScores       [2]int                      `json:"teamScores"`
-	RoundPoints      [2]int                      `json:"roundPoints"`
-	RoundMarriage    [2]int                      `json:"roundMarriage"`
-	MarriageIndices  []int                       `json:"marriageIndices"`
-	GameEndFlag      bool                        `json:"gameEndFlag"`
-	WinnerTeam       int                         `json:"winnerTeam"`
-	LeadPlayerIdx    int                         `json:"leadPlayerIdx"`
-	Hint             *GaigelWebOutputHint        `json:"hint,omitempty"`
+	Players          []*GaigelWebOutputPlayer `json:"players"`
+	Phase            int                      `json:"phase"`
+	RoundNumber      int                      `json:"roundNumber"`
+	TrickNumber      int                      `json:"trickNumber"`
+	CurrentPlayerIdx int                      `json:"currentPlayerIdx"`
+	DealerIdx        int                      `json:"dealerIdx"`
+	TrumpSuit        int                      `json:"trumpSuit"`
+	TrumpCard        *WebOutputCard           `json:"trumpCard,omitempty"`
+	StockRemaining   int                      `json:"stockRemaining"`
+	CurrentTrick     []*WebOutputTrickCard    `json:"currentTrick"`
+	TeamScores       [2]int                   `json:"teamScores"`
+	RoundPoints      [2]int                   `json:"roundPoints"`
+	RoundMarriage    [2]int                   `json:"roundMarriage"`
+	MarriageIndices  []int                    `json:"marriageIndices"`
+	GameEndFlag      bool                     `json:"gameEndFlag"`
+	WinnerTeam       int                      `json:"winnerTeam"`
+	LeadPlayerIdx    int                      `json:"leadPlayerIdx"`
+	Hint             *GaigelWebOutputHint     `json:"hint,omitempty"`
 	WebOutputBase
 	Config GaigelWebOutputConfig `json:"config"`
 }
@@ -101,7 +95,7 @@ var NewGaigelWebController, NewGaigelWebControllerWithProvider = webControllerPa
 func newGaigelDefaultOutput(msg string) *GaigelWebOutput {
 	return &GaigelWebOutput{
 		Players:         make([]*GaigelWebOutputPlayer, 0),
-		CurrentTrick:    make([]*GaigelWebOutputTrickCard, 0),
+		CurrentTrick:    make([]*WebOutputTrickCard, 0),
 		MarriageIndices: make([]int, 0),
 		WinnerTeam:      -1,
 		WebOutputBase:   WebOutputBase{Message: msg},

--- a/internal/adapter/controller/GaigelWebController_test.go
+++ b/internal/adapter/controller/GaigelWebController_test.go
@@ -17,7 +17,7 @@ import (
 func mustGaigelOutputJSON(msg string) string {
 	out := &controller.GaigelWebOutput{
 		Players:         []*controller.GaigelWebOutputPlayer{},
-		CurrentTrick:    []*controller.GaigelWebOutputTrickCard{},
+		CurrentTrick:    []*controller.WebOutputTrickCard{},
 		MarriageIndices: []int{},
 		WinnerTeam:      -1,
 		WebOutputBase:   controller.WebOutputBase{Message: msg},

--- a/internal/adapter/controller/GongZhuWebController.go
+++ b/internal/adapter/controller/GongZhuWebController.go
@@ -37,12 +37,6 @@ type GongZhuWebOutputPlayer struct {
 	TrickCount         int              `json:"trickCount"`
 }
 
-// GongZhuWebOutputTrickCard トリック中の1枚
-type GongZhuWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
 // GongZhuWebOutputExposure 公開されたポイントカード
 type GongZhuWebOutputExposure struct {
 	Pig     bool `json:"pig"`
@@ -51,27 +45,21 @@ type GongZhuWebOutputExposure struct {
 	Doubler bool `json:"doubler"`
 }
 
-// GongZhuWebOutputHint ヒント出力
-type GongZhuWebOutputHint struct {
-	CardIndices []int  `json:"cardIndices"`
-	Reason      string `json:"reason"`
-}
-
 // GongZhuWebOutput 拱猪Webアウトプット
 type GongZhuWebOutput struct {
-	Players          []*GongZhuWebOutputPlayer    `json:"players"`
-	Phase            int                          `json:"phase"`
-	RoundNumber      int                          `json:"roundNumber"`
-	TrickNumber      int                          `json:"trickNumber"`
-	CurrentPlayerIdx int                          `json:"currentPlayerIdx"`
-	CurrentTrick     []*GongZhuWebOutputTrickCard `json:"currentTrick"`
-	HeartsBroken     bool                         `json:"heartsBroken"`
-	Exposed          GongZhuWebOutputExposure     `json:"exposed"`
-	ExposableIndices []int                        `json:"exposableIndices"`
-	GameEndFlag      bool                         `json:"gameEndFlag"`
-	WinnerIdx        int                          `json:"winnerIdx"`
-	LeadPlayerIdx    int                          `json:"leadPlayerIdx"`
-	Hint             *GongZhuWebOutputHint        `json:"hint,omitempty"`
+	Players          []*GongZhuWebOutputPlayer `json:"players"`
+	Phase            int                       `json:"phase"`
+	RoundNumber      int                       `json:"roundNumber"`
+	TrickNumber      int                       `json:"trickNumber"`
+	CurrentPlayerIdx int                       `json:"currentPlayerIdx"`
+	CurrentTrick     []*WebOutputTrickCard     `json:"currentTrick"`
+	HeartsBroken     bool                      `json:"heartsBroken"`
+	Exposed          GongZhuWebOutputExposure  `json:"exposed"`
+	ExposableIndices []int                     `json:"exposableIndices"`
+	GameEndFlag      bool                      `json:"gameEndFlag"`
+	WinnerIdx        int                       `json:"winnerIdx"`
+	LeadPlayerIdx    int                       `json:"leadPlayerIdx"`
+	Hint             *WebOutputCardHint        `json:"hint,omitempty"`
 	WebOutputBase
 	Config GongZhuWebOutputConfig `json:"config"`
 }
@@ -107,7 +95,7 @@ var NewGongZhuWebController, NewGongZhuWebControllerWithProvider = webController
 func newGongZhuDefaultOutput(msg string) *GongZhuWebOutput {
 	return &GongZhuWebOutput{
 		Players:          make([]*GongZhuWebOutputPlayer, 0),
-		CurrentTrick:     make([]*GongZhuWebOutputTrickCard, 0),
+		CurrentTrick:     make([]*WebOutputTrickCard, 0),
 		ExposableIndices: make([]int, 0),
 		WinnerIdx:        -1,
 		WebOutputBase:    WebOutputBase{Message: msg},

--- a/internal/adapter/controller/GongZhuWebController_test.go
+++ b/internal/adapter/controller/GongZhuWebController_test.go
@@ -17,7 +17,7 @@ import (
 func mustGongZhuOutputJSON(msg string) string {
 	out := &controller.GongZhuWebOutput{
 		Players:          []*controller.GongZhuWebOutputPlayer{},
-		CurrentTrick:     []*controller.GongZhuWebOutputTrickCard{},
+		CurrentTrick:     []*controller.WebOutputTrickCard{},
 		ExposableIndices: []int{},
 		WinnerIdx:        -1,
 		WebOutputBase:    controller.WebOutputBase{Message: msg},

--- a/internal/adapter/controller/HeartsWebController.go
+++ b/internal/adapter/controller/HeartsWebController.go
@@ -38,32 +38,20 @@ type HeartsWebOutputPlayer struct {
 	PenaltyCards []*WebOutputCard `json:"penaltyCards"`
 }
 
-// HeartsWebOutputTrickCard トリック中の1枚
-type HeartsWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
-// HeartsWebOutputHint ヒント出力
-type HeartsWebOutputHint struct {
-	CardIndices []int  `json:"cardIndices"`
-	Reason      string `json:"reason"`
-}
-
 // HeartsWebOutput ハーツWebアウトプット
 type HeartsWebOutput struct {
-	Players          []*HeartsWebOutputPlayer    `json:"players"`
-	Phase            int                         `json:"phase"`
-	RoundNumber      int                         `json:"roundNumber"`
-	TrickNumber      int                         `json:"trickNumber"`
-	CurrentPlayerIdx int                         `json:"currentPlayerIdx"`
-	CurrentTrick     []*HeartsWebOutputTrickCard `json:"currentTrick"`
-	HeartsBroken     bool                        `json:"heartsBroken"`
-	PassDirection    int                         `json:"passDirection"`
-	GameEndFlag      bool                        `json:"gameEndFlag"`
-	WinnerIdx        int                         `json:"winnerIdx"`
-	LeadPlayerIdx    int                         `json:"leadPlayerIdx"`
-	Hint             *HeartsWebOutputHint        `json:"hint,omitempty"`
+	Players          []*HeartsWebOutputPlayer `json:"players"`
+	Phase            int                      `json:"phase"`
+	RoundNumber      int                      `json:"roundNumber"`
+	TrickNumber      int                      `json:"trickNumber"`
+	CurrentPlayerIdx int                      `json:"currentPlayerIdx"`
+	CurrentTrick     []*WebOutputTrickCard    `json:"currentTrick"`
+	HeartsBroken     bool                     `json:"heartsBroken"`
+	PassDirection    int                      `json:"passDirection"`
+	GameEndFlag      bool                     `json:"gameEndFlag"`
+	WinnerIdx        int                      `json:"winnerIdx"`
+	LeadPlayerIdx    int                      `json:"leadPlayerIdx"`
+	Hint             *WebOutputCardHint       `json:"hint,omitempty"`
 	WebOutputBase
 	Config HeartsWebOutputConfig `json:"config"`
 }
@@ -101,7 +89,7 @@ var NewHeartsWebController, NewHeartsWebControllerWithProvider = webControllerPa
 func newHeartsDefaultOutput(msg string) *HeartsWebOutput {
 	return &HeartsWebOutput{
 		Players:       make([]*HeartsWebOutputPlayer, 0),
-		CurrentTrick:  make([]*HeartsWebOutputTrickCard, 0),
+		CurrentTrick:  make([]*WebOutputTrickCard, 0),
 		WinnerIdx:     -1,
 		WebOutputBase: WebOutputBase{Message: msg},
 	}

--- a/internal/adapter/controller/HeartsWebController_test.go
+++ b/internal/adapter/controller/HeartsWebController_test.go
@@ -18,7 +18,7 @@ import (
 func mustHeartsOutputJSON(msg string) string {
 	out := &controller.HeartsWebOutput{
 		Players:       []*controller.HeartsWebOutputPlayer{},
-		CurrentTrick:  []*controller.HeartsWebOutputTrickCard{},
+		CurrentTrick:  []*controller.WebOutputTrickCard{},
 		WinnerIdx:     -1,
 		WebOutputBase: controller.WebOutputBase{Message: msg},
 	}

--- a/internal/adapter/controller/JassWebController.go
+++ b/internal/adapter/controller/JassWebController.go
@@ -36,12 +36,6 @@ type JassWebOutputPlayer struct {
 	TrickCount int              `json:"trickCount"`
 }
 
-// JassWebOutputTrickCard トリック中の1枚
-type JassWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
 // JassWebOutputHint ヒント出力
 type JassWebOutputHint struct {
 	CardIndex *int   `json:"cardIndex,omitempty"`
@@ -52,29 +46,29 @@ type JassWebOutputHint struct {
 
 // JassWebOutput ヤスWebアウトプット
 type JassWebOutput struct {
-	Players          []*JassWebOutputPlayer    `json:"players"`
-	Phase            int                       `json:"phase"`
-	RoundNumber      int                       `json:"roundNumber"`
-	TrickNumber      int                       `json:"trickNumber"`
-	CurrentPlayerIdx int                       `json:"currentPlayerIdx"`
-	BidPlayerIdx     int                       `json:"bidPlayerIdx"`
-	DealerIdx        int                       `json:"dealerIdx"`
-	ForehandIdx      int                       `json:"forehandIdx"`
-	TrumpSuit        int                       `json:"trumpSuit"`
-	Schieben         bool                      `json:"schieben"`
-	MakerTeam        int                       `json:"makerTeam"`
-	MakerPlayerIdx   int                       `json:"makerPlayerIdx"`
-	CurrentTrick     []*JassWebOutputTrickCard `json:"currentTrick"`
-	LastTrick        []*JassWebOutputTrickCard `json:"lastTrick"`
-	LastTrickWinner  int                       `json:"lastTrickWinner"`
-	TeamScores       [2]int                    `json:"teamScores"`
-	RoundPoints      [2]int                    `json:"roundPoints"`
-	RoundWeisPoints  [2]int                    `json:"roundWeisPoints"`
-	RoundStockPoints [2]int                    `json:"roundStockPoints"`
-	GameEndFlag      bool                      `json:"gameEndFlag"`
-	WinnerTeam       int                       `json:"winnerTeam"`
-	LeadPlayerIdx    int                       `json:"leadPlayerIdx"`
-	Hint             *JassWebOutputHint        `json:"hint,omitempty"`
+	Players          []*JassWebOutputPlayer `json:"players"`
+	Phase            int                    `json:"phase"`
+	RoundNumber      int                    `json:"roundNumber"`
+	TrickNumber      int                    `json:"trickNumber"`
+	CurrentPlayerIdx int                    `json:"currentPlayerIdx"`
+	BidPlayerIdx     int                    `json:"bidPlayerIdx"`
+	DealerIdx        int                    `json:"dealerIdx"`
+	ForehandIdx      int                    `json:"forehandIdx"`
+	TrumpSuit        int                    `json:"trumpSuit"`
+	Schieben         bool                   `json:"schieben"`
+	MakerTeam        int                    `json:"makerTeam"`
+	MakerPlayerIdx   int                    `json:"makerPlayerIdx"`
+	CurrentTrick     []*WebOutputTrickCard  `json:"currentTrick"`
+	LastTrick        []*WebOutputTrickCard  `json:"lastTrick"`
+	LastTrickWinner  int                    `json:"lastTrickWinner"`
+	TeamScores       [2]int                 `json:"teamScores"`
+	RoundPoints      [2]int                 `json:"roundPoints"`
+	RoundWeisPoints  [2]int                 `json:"roundWeisPoints"`
+	RoundStockPoints [2]int                 `json:"roundStockPoints"`
+	GameEndFlag      bool                   `json:"gameEndFlag"`
+	WinnerTeam       int                    `json:"winnerTeam"`
+	LeadPlayerIdx    int                    `json:"leadPlayerIdx"`
+	Hint             *JassWebOutputHint     `json:"hint,omitempty"`
 	WebOutputBase
 	Config JassWebOutputConfig `json:"config"`
 }
@@ -116,8 +110,8 @@ var NewJassWebController, NewJassWebControllerWithProvider = webControllerPair[u
 func newJassDefaultOutput(msg string) *JassWebOutput {
 	return &JassWebOutput{
 		Players:         make([]*JassWebOutputPlayer, 0),
-		CurrentTrick:    make([]*JassWebOutputTrickCard, 0),
-		LastTrick:       make([]*JassWebOutputTrickCard, 0),
+		CurrentTrick:    make([]*WebOutputTrickCard, 0),
+		LastTrick:       make([]*WebOutputTrickCard, 0),
 		LastTrickWinner: -1,
 		WinnerTeam:      -1,
 		WebOutputBase:   WebOutputBase{Message: msg},

--- a/internal/adapter/controller/JassWebController_test.go
+++ b/internal/adapter/controller/JassWebController_test.go
@@ -17,8 +17,8 @@ import (
 func mustJassOutputJSON(msg string) string {
 	out := &controller.JassWebOutput{
 		Players:         []*controller.JassWebOutputPlayer{},
-		CurrentTrick:    []*controller.JassWebOutputTrickCard{},
-		LastTrick:       []*controller.JassWebOutputTrickCard{},
+		CurrentTrick:    []*controller.WebOutputTrickCard{},
+		LastTrick:       []*controller.WebOutputTrickCard{},
 		LastTrickWinner: -1,
 		WinnerTeam:      -1,
 		WebOutputBase:   controller.WebOutputBase{Message: msg},

--- a/internal/adapter/controller/KingWebController.go
+++ b/internal/adapter/controller/KingWebController.go
@@ -40,12 +40,6 @@ type KingWebOutputPlayer struct {
 	TotalScore int              `json:"totalScore"`
 }
 
-// KingWebOutputTrickCard はトリック中の 1 枚。
-type KingWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
 // KingWebOutputDealDetail は 1 ディールの得点内訳。
 type KingWebOutputDealDetail struct {
 	Contract  int         `json:"contract"`
@@ -54,34 +48,28 @@ type KingWebOutputDealDetail struct {
 	Gained    map[int]int `json:"gained"`
 }
 
-// KingWebOutputHint はヒント出力。
-type KingWebOutputHint struct {
-	CardIndices []int  `json:"cardIndices"`
-	Reason      string `json:"reason"`
-}
-
 // KingWebOutput はキング Web アウトプット。
 type KingWebOutput struct {
-	Players         []*KingWebOutputPlayer    `json:"players"`
-	Phase           string                    `json:"phase"`
-	DealNumber      int                       `json:"dealNumber"`
-	TotalDeals      int                       `json:"totalDeals"`
-	DealerIdx       int                       `json:"dealerIdx"`
-	CurrentTurn     int                       `json:"currentTurn"`
-	CurrentContract int                       `json:"currentContract"`
-	TrumpSuit       int                       `json:"trumpSuit"`
-	TrickNumber     int                       `json:"trickNumber"`
-	CurrentTrick    []*KingWebOutputTrickCard `json:"currentTrick"`
-	LastTrick       []*KingWebOutputTrickCard `json:"lastTrick"`
-	LastTrickWinner int                       `json:"lastTrickWinner"`
-	UsedContracts   []bool                    `json:"usedContracts"`
-	PlayableIndices []int                     `json:"playableIndices"`
-	GameEndFlag     bool                      `json:"gameEndFlag"`
-	Config          KingWebConfig             `json:"config"`
-	RoundWinners    []int                     `json:"roundWinners"`
-	LastDealDetail  *KingWebOutputDealDetail  `json:"lastDealDetail"`
-	IsHumanTurn     bool                      `json:"isHumanTurn"`
-	Hint            *KingWebOutputHint        `json:"hint,omitempty"`
+	Players         []*KingWebOutputPlayer   `json:"players"`
+	Phase           string                   `json:"phase"`
+	DealNumber      int                      `json:"dealNumber"`
+	TotalDeals      int                      `json:"totalDeals"`
+	DealerIdx       int                      `json:"dealerIdx"`
+	CurrentTurn     int                      `json:"currentTurn"`
+	CurrentContract int                      `json:"currentContract"`
+	TrumpSuit       int                      `json:"trumpSuit"`
+	TrickNumber     int                      `json:"trickNumber"`
+	CurrentTrick    []*WebOutputTrickCard    `json:"currentTrick"`
+	LastTrick       []*WebOutputTrickCard    `json:"lastTrick"`
+	LastTrickWinner int                      `json:"lastTrickWinner"`
+	UsedContracts   []bool                   `json:"usedContracts"`
+	PlayableIndices []int                    `json:"playableIndices"`
+	GameEndFlag     bool                     `json:"gameEndFlag"`
+	Config          KingWebConfig            `json:"config"`
+	RoundWinners    []int                    `json:"roundWinners"`
+	LastDealDetail  *KingWebOutputDealDetail `json:"lastDealDetail"`
+	IsHumanTurn     bool                     `json:"isHumanTurn"`
+	Hint            *WebOutputCardHint       `json:"hint,omitempty"`
 	WebOutputBase
 }
 
@@ -97,8 +85,8 @@ var NewKingWebController, NewKingWebControllerWithProvider = webControllerPair[u
 func newKingDefaultOutput(msg string) *KingWebOutput {
 	return &KingWebOutput{
 		Players:         make([]*KingWebOutputPlayer, 0),
-		CurrentTrick:    make([]*KingWebOutputTrickCard, 0),
-		LastTrick:       make([]*KingWebOutputTrickCard, 0),
+		CurrentTrick:    make([]*WebOutputTrickCard, 0),
+		LastTrick:       make([]*WebOutputTrickCard, 0),
 		UsedContracts:   make([]bool, 0),
 		PlayableIndices: make([]int, 0),
 		RoundWinners:    make([]int, 0),

--- a/internal/adapter/controller/KlaverjasWebController.go
+++ b/internal/adapter/controller/KlaverjasWebController.go
@@ -35,37 +35,25 @@ type KlaverjasWebOutputPlayer struct {
 	TeamScore  int              `json:"teamScore"`
 }
 
-// KlaverjasWebOutputTrickCard トリック中の1枚
-type KlaverjasWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
-// KlaverjasWebOutputHint ヒント出力
-type KlaverjasWebOutputHint struct {
-	CardIndices []int  `json:"cardIndices"`
-	Reason      string `json:"reason"`
-}
-
 // KlaverjasWebOutput クラヴァヤスのWebアウトプット
 type KlaverjasWebOutput struct {
-	Players          []*KlaverjasWebOutputPlayer    `json:"players"`
-	Phase            int                            `json:"phase"`
-	RoundNumber      int                            `json:"roundNumber"`
-	TrickNumber      int                            `json:"trickNumber"`
-	CurrentPlayerIdx int                            `json:"currentPlayerIdx"`
-	LeadPlayerIdx    int                            `json:"leadPlayerIdx"`
-	DealerIdx        int                            `json:"dealerIdx"`
-	TrumpSuit        int                            `json:"trumpSuit"`
-	CurrentTrick     []*KlaverjasWebOutputTrickCard `json:"currentTrick"`
-	TeamScores       [domain.KlaverjasTeamCnt]int   `json:"teamScores"`
-	RoundCardPoints  [domain.KlaverjasTeamCnt]int   `json:"roundCardPoints"`
-	RoundRoem        [domain.KlaverjasTeamCnt]int   `json:"roundRoem"`
-	PlayableIndices  []int                          `json:"playableIndices"`
-	GameEndFlag      bool                           `json:"gameEndFlag"`
-	WinnerTeam       int                            `json:"winnerTeam"`
-	IsHumanTurn      bool                           `json:"isHumanTurn"`
-	Hint             *KlaverjasWebOutputHint        `json:"hint,omitempty"`
+	Players          []*KlaverjasWebOutputPlayer  `json:"players"`
+	Phase            int                          `json:"phase"`
+	RoundNumber      int                          `json:"roundNumber"`
+	TrickNumber      int                          `json:"trickNumber"`
+	CurrentPlayerIdx int                          `json:"currentPlayerIdx"`
+	LeadPlayerIdx    int                          `json:"leadPlayerIdx"`
+	DealerIdx        int                          `json:"dealerIdx"`
+	TrumpSuit        int                          `json:"trumpSuit"`
+	CurrentTrick     []*WebOutputTrickCard        `json:"currentTrick"`
+	TeamScores       [domain.KlaverjasTeamCnt]int `json:"teamScores"`
+	RoundCardPoints  [domain.KlaverjasTeamCnt]int `json:"roundCardPoints"`
+	RoundRoem        [domain.KlaverjasTeamCnt]int `json:"roundRoem"`
+	PlayableIndices  []int                        `json:"playableIndices"`
+	GameEndFlag      bool                         `json:"gameEndFlag"`
+	WinnerTeam       int                          `json:"winnerTeam"`
+	IsHumanTurn      bool                         `json:"isHumanTurn"`
+	Hint             *WebOutputCardHint           `json:"hint,omitempty"`
 	WebOutputBase
 	Config KlaverjasWebOutputConfig `json:"config"`
 }
@@ -101,7 +89,7 @@ var NewKlaverjasWebController, NewKlaverjasWebControllerWithProvider = webContro
 func newKlaverjasDefaultOutput(msg string) *KlaverjasWebOutput {
 	return &KlaverjasWebOutput{
 		Players:         make([]*KlaverjasWebOutputPlayer, 0),
-		CurrentTrick:    make([]*KlaverjasWebOutputTrickCard, 0),
+		CurrentTrick:    make([]*WebOutputTrickCard, 0),
 		PlayableIndices: make([]int, 0),
 		WinnerTeam:      -1,
 		WebOutputBase:   WebOutputBase{Message: msg},

--- a/internal/adapter/controller/KlaverjasWebController_test.go
+++ b/internal/adapter/controller/KlaverjasWebController_test.go
@@ -17,7 +17,7 @@ import (
 func mustKlaverjasOutputJSON(msg string) string {
 	out := &controller.KlaverjasWebOutput{
 		Players:         []*controller.KlaverjasWebOutputPlayer{},
-		CurrentTrick:    []*controller.KlaverjasWebOutputTrickCard{},
+		CurrentTrick:    []*controller.WebOutputTrickCard{},
 		PlayableIndices: []int{},
 		WinnerTeam:      -1,
 		WebOutputBase:   controller.WebOutputBase{Message: msg},

--- a/internal/adapter/controller/KnockoutWhistWebController.go
+++ b/internal/adapter/controller/KnockoutWhistWebController.go
@@ -38,37 +38,25 @@ type KnockoutWhistWebOutputPlayer struct {
 	RoundTricks int              `json:"roundTricks"`
 }
 
-// KnockoutWhistWebOutputTrickCard トリック中の1枚
-type KnockoutWhistWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
-// KnockoutWhistWebOutputHint ヒント出力
-type KnockoutWhistWebOutputHint struct {
-	CardIndices []int  `json:"cardIndices"`
-	Reason      string `json:"reason"`
-}
-
 // KnockoutWhistWebOutput ノックアウト・ホイストのWebアウトプット
 type KnockoutWhistWebOutput struct {
-	Players          []*KnockoutWhistWebOutputPlayer    `json:"players"`
-	Phase            int                                `json:"phase"`
-	RoundNumber      int                                `json:"roundNumber"`
-	HandSize         int                                `json:"handSize"`
-	TrickNumber      int                                `json:"trickNumber"`
-	CurrentPlayerIdx int                                `json:"currentPlayerIdx"`
-	LeadPlayerIdx    int                                `json:"leadPlayerIdx"`
-	DealerIdx        int                                `json:"dealerIdx"`
-	TrumpSuit        int                                `json:"trumpSuit"`
-	RoundWinnerIdx   int                                `json:"roundWinnerIdx"`
-	CurrentTrick     []*KnockoutWhistWebOutputTrickCard `json:"currentTrick"`
-	ActiveCount      int                                `json:"activeCount"`
-	PlayableIndices  []int                              `json:"playableIndices"`
-	GameEndFlag      bool                               `json:"gameEndFlag"`
-	WinnerPlayer     int                                `json:"winnerPlayer"`
-	IsHumanTurn      bool                               `json:"isHumanTurn"`
-	Hint             *KnockoutWhistWebOutputHint        `json:"hint,omitempty"`
+	Players          []*KnockoutWhistWebOutputPlayer `json:"players"`
+	Phase            int                             `json:"phase"`
+	RoundNumber      int                             `json:"roundNumber"`
+	HandSize         int                             `json:"handSize"`
+	TrickNumber      int                             `json:"trickNumber"`
+	CurrentPlayerIdx int                             `json:"currentPlayerIdx"`
+	LeadPlayerIdx    int                             `json:"leadPlayerIdx"`
+	DealerIdx        int                             `json:"dealerIdx"`
+	TrumpSuit        int                             `json:"trumpSuit"`
+	RoundWinnerIdx   int                             `json:"roundWinnerIdx"`
+	CurrentTrick     []*WebOutputTrickCard           `json:"currentTrick"`
+	ActiveCount      int                             `json:"activeCount"`
+	PlayableIndices  []int                           `json:"playableIndices"`
+	GameEndFlag      bool                            `json:"gameEndFlag"`
+	WinnerPlayer     int                             `json:"winnerPlayer"`
+	IsHumanTurn      bool                            `json:"isHumanTurn"`
+	Hint             *WebOutputCardHint              `json:"hint,omitempty"`
 	WebOutputBase
 	Config KnockoutWhistWebOutputConfig `json:"config"`
 }
@@ -102,7 +90,7 @@ var NewKnockoutWhistWebController, NewKnockoutWhistWebControllerWithProvider = w
 func newKnockoutWhistDefaultOutput(msg string) *KnockoutWhistWebOutput {
 	return &KnockoutWhistWebOutput{
 		Players:         make([]*KnockoutWhistWebOutputPlayer, 0),
-		CurrentTrick:    make([]*KnockoutWhistWebOutputTrickCard, 0),
+		CurrentTrick:    make([]*WebOutputTrickCard, 0),
 		PlayableIndices: make([]int, 0),
 		RoundWinnerIdx:  -1,
 		WinnerPlayer:    -1,

--- a/internal/adapter/controller/KnockoutWhistWebController_test.go
+++ b/internal/adapter/controller/KnockoutWhistWebController_test.go
@@ -17,7 +17,7 @@ import (
 func mustKnockoutWhistOutputJSON(msg string) string {
 	out := &controller.KnockoutWhistWebOutput{
 		Players:         []*controller.KnockoutWhistWebOutputPlayer{},
-		CurrentTrick:    []*controller.KnockoutWhistWebOutputTrickCard{},
+		CurrentTrick:    []*controller.WebOutputTrickCard{},
 		PlayableIndices: []int{},
 		RoundWinnerIdx:  -1,
 		WinnerPlayer:    -1,

--- a/internal/adapter/controller/KoenigrufenWebController.go
+++ b/internal/adapter/controller/KoenigrufenWebController.go
@@ -45,12 +45,6 @@ type KoenigrufenWebOutputPlayer struct {
 	IsPartner  bool             `json:"isPartner"`
 }
 
-// KoenigrufenWebOutputTrickCard トリック中の1枚
-type KoenigrufenWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
 // KoenigrufenWebOutputHint ヒント出力
 type KoenigrufenWebOutputHint struct {
 	Bid         *int   `json:"bid,omitempty"`
@@ -80,7 +74,7 @@ type KoenigrufenWebOutput struct {
 	TalonCount       int                              `json:"talonCount"`
 	Talon            []*WebOutputCard                 `json:"talon"`
 	StashOwner       int                              `json:"stashOwner"`
-	CurrentTrick     []*KoenigrufenWebOutputTrickCard `json:"currentTrick"`
+	CurrentTrick     []*WebOutputTrickCard            `json:"currentTrick"`
 	PlayerScores     [domain.KoenigrufenPlayerCnt]int `json:"playerScores"`
 	LastTrickWinner  int                              `json:"lastTrickWinner"`
 	Outcome          int                              `json:"outcome"`
@@ -138,7 +132,7 @@ var NewKoenigrufenWebController, NewKoenigrufenWebControllerWithProvider = webCo
 func newKoenigrufenDefaultOutput(msg string) *KoenigrufenWebOutput {
 	return &KoenigrufenWebOutput{
 		Players:         make([]*KoenigrufenWebOutputPlayer, 0),
-		CurrentTrick:    make([]*KoenigrufenWebOutputTrickCard, 0),
+		CurrentTrick:    make([]*WebOutputTrickCard, 0),
 		Talon:           make([]*WebOutputCard, 0),
 		PlayableIndices: make([]int, 0),
 		DeclarerIdx:     -1,

--- a/internal/adapter/controller/KoenigrufenWebController_test.go
+++ b/internal/adapter/controller/KoenigrufenWebController_test.go
@@ -17,7 +17,7 @@ import (
 func mustKoenigrufenOutputJSON(msg string) string {
 	out := &controller.KoenigrufenWebOutput{
 		Players:         []*controller.KoenigrufenWebOutputPlayer{},
-		CurrentTrick:    []*controller.KoenigrufenWebOutputTrickCard{},
+		CurrentTrick:    []*controller.WebOutputTrickCard{},
 		Talon:           []*controller.WebOutputCard{},
 		PlayableIndices: []int{},
 		DeclarerIdx:     -1,

--- a/internal/adapter/controller/LooWebController.go
+++ b/internal/adapter/controller/LooWebController.go
@@ -49,12 +49,6 @@ type LooWebOutputPlayer struct {
 	Chips      int              `json:"chips"`
 }
 
-// LooWebOutputTrickCard はトリック中の 1 枚。
-type LooWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
 // LooWebOutputDealDetail は 1 ディールの精算内訳。
 type LooWebOutputDealDetail struct {
 	PotStart  int         `json:"potStart"`
@@ -75,26 +69,26 @@ type LooWebOutputHint struct {
 
 // LooWebOutput はルー Web アウトプット。
 type LooWebOutput struct {
-	Players         []*LooWebOutputPlayer    `json:"players"`
-	Phase           int                      `json:"phase"`
-	RoundNumber     int                      `json:"roundNumber"`
-	TrickNumber     int                      `json:"trickNumber"`
-	TotalTricks     int                      `json:"totalTricks"`
-	DealerIdx       int                      `json:"dealerIdx"`
-	CurrentTurn     int                      `json:"currentTurn"`
-	DecidePlayerIdx int                      `json:"decidePlayerIdx"`
-	TrumpSuit       int                      `json:"trumpSuit"`
-	TurnUp          *WebOutputCard           `json:"turnUp,omitempty"`
-	Pot             int                      `json:"pot"`
-	PotStart        int                      `json:"potStart"`
-	CurrentTrick    []*LooWebOutputTrickCard `json:"currentTrick"`
-	LastTrick       []*LooWebOutputTrickCard `json:"lastTrick"`
-	LastTrickWinner int                      `json:"lastTrickWinner"`
-	PlayableIndices []int                    `json:"playableIndices"`
-	GameEndFlag     bool                     `json:"gameEndFlag"`
-	LastDealDetail  *LooWebOutputDealDetail  `json:"lastDealDetail"`
-	IsHumanTurn     bool                     `json:"isHumanTurn"`
-	Hint            *LooWebOutputHint        `json:"hint,omitempty"`
+	Players         []*LooWebOutputPlayer   `json:"players"`
+	Phase           int                     `json:"phase"`
+	RoundNumber     int                     `json:"roundNumber"`
+	TrickNumber     int                     `json:"trickNumber"`
+	TotalTricks     int                     `json:"totalTricks"`
+	DealerIdx       int                     `json:"dealerIdx"`
+	CurrentTurn     int                     `json:"currentTurn"`
+	DecidePlayerIdx int                     `json:"decidePlayerIdx"`
+	TrumpSuit       int                     `json:"trumpSuit"`
+	TurnUp          *WebOutputCard          `json:"turnUp,omitempty"`
+	Pot             int                     `json:"pot"`
+	PotStart        int                     `json:"potStart"`
+	CurrentTrick    []*WebOutputTrickCard   `json:"currentTrick"`
+	LastTrick       []*WebOutputTrickCard   `json:"lastTrick"`
+	LastTrickWinner int                     `json:"lastTrickWinner"`
+	PlayableIndices []int                   `json:"playableIndices"`
+	GameEndFlag     bool                    `json:"gameEndFlag"`
+	LastDealDetail  *LooWebOutputDealDetail `json:"lastDealDetail"`
+	IsHumanTurn     bool                    `json:"isHumanTurn"`
+	Hint            *LooWebOutputHint       `json:"hint,omitempty"`
 	WebOutputBase
 	Config LooWebConfigOutput `json:"config"`
 }
@@ -117,8 +111,8 @@ var NewLooWebController, NewLooWebControllerWithProvider = webControllerPair[use
 func newLooDefaultOutput(msg string) *LooWebOutput {
 	return &LooWebOutput{
 		Players:         make([]*LooWebOutputPlayer, 0),
-		CurrentTrick:    make([]*LooWebOutputTrickCard, 0),
-		LastTrick:       make([]*LooWebOutputTrickCard, 0),
+		CurrentTrick:    make([]*WebOutputTrickCard, 0),
+		LastTrick:       make([]*WebOutputTrickCard, 0),
 		PlayableIndices: make([]int, 0),
 		TotalTricks:     domain.LooTrickCount,
 		LastTrickWinner: -1,

--- a/internal/adapter/controller/LooWebController_test.go
+++ b/internal/adapter/controller/LooWebController_test.go
@@ -17,8 +17,8 @@ import (
 func mustLooOutputJSON(msg string) string {
 	out := &controller.LooWebOutput{
 		Players:         []*controller.LooWebOutputPlayer{},
-		CurrentTrick:    []*controller.LooWebOutputTrickCard{},
-		LastTrick:       []*controller.LooWebOutputTrickCard{},
+		CurrentTrick:    []*controller.WebOutputTrickCard{},
+		LastTrick:       []*controller.WebOutputTrickCard{},
 		PlayableIndices: []int{},
 		TotalTricks:     domain.LooTrickCount,
 		LastTrickWinner: -1,

--- a/internal/adapter/controller/ManilleWebController.go
+++ b/internal/adapter/controller/ManilleWebController.go
@@ -35,36 +35,24 @@ type ManilleWebOutputPlayer struct {
 	TeamScore  int              `json:"teamScore"`
 }
 
-// ManilleWebOutputTrickCard トリック中の1枚
-type ManilleWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
-// ManilleWebOutputHint ヒント出力
-type ManilleWebOutputHint struct {
-	CardIndices []int  `json:"cardIndices"`
-	Reason      string `json:"reason"`
-}
-
 // ManilleWebOutput マニーユのWebアウトプット
 type ManilleWebOutput struct {
-	Players          []*ManilleWebOutputPlayer    `json:"players"`
-	Phase            int                          `json:"phase"`
-	RoundNumber      int                          `json:"roundNumber"`
-	TrickNumber      int                          `json:"trickNumber"`
-	CurrentPlayerIdx int                          `json:"currentPlayerIdx"`
-	LeadPlayerIdx    int                          `json:"leadPlayerIdx"`
-	DealerIdx        int                          `json:"dealerIdx"`
-	TrumpSuit        int                          `json:"trumpSuit"`
-	CurrentTrick     []*ManilleWebOutputTrickCard `json:"currentTrick"`
-	TeamScores       [domain.ManilleTeamCnt]int   `json:"teamScores"`
-	RoundCardPoints  [domain.ManilleTeamCnt]int   `json:"roundCardPoints"`
-	PlayableIndices  []int                        `json:"playableIndices"`
-	GameEndFlag      bool                         `json:"gameEndFlag"`
-	WinnerTeam       int                          `json:"winnerTeam"`
-	IsHumanTurn      bool                         `json:"isHumanTurn"`
-	Hint             *ManilleWebOutputHint        `json:"hint,omitempty"`
+	Players          []*ManilleWebOutputPlayer  `json:"players"`
+	Phase            int                        `json:"phase"`
+	RoundNumber      int                        `json:"roundNumber"`
+	TrickNumber      int                        `json:"trickNumber"`
+	CurrentPlayerIdx int                        `json:"currentPlayerIdx"`
+	LeadPlayerIdx    int                        `json:"leadPlayerIdx"`
+	DealerIdx        int                        `json:"dealerIdx"`
+	TrumpSuit        int                        `json:"trumpSuit"`
+	CurrentTrick     []*WebOutputTrickCard      `json:"currentTrick"`
+	TeamScores       [domain.ManilleTeamCnt]int `json:"teamScores"`
+	RoundCardPoints  [domain.ManilleTeamCnt]int `json:"roundCardPoints"`
+	PlayableIndices  []int                      `json:"playableIndices"`
+	GameEndFlag      bool                       `json:"gameEndFlag"`
+	WinnerTeam       int                        `json:"winnerTeam"`
+	IsHumanTurn      bool                       `json:"isHumanTurn"`
+	Hint             *WebOutputCardHint         `json:"hint,omitempty"`
 	WebOutputBase
 	Config ManilleWebOutputConfig `json:"config"`
 }
@@ -100,7 +88,7 @@ var NewManilleWebController, NewManilleWebControllerWithProvider = webController
 func newManilleDefaultOutput(msg string) *ManilleWebOutput {
 	return &ManilleWebOutput{
 		Players:         make([]*ManilleWebOutputPlayer, 0),
-		CurrentTrick:    make([]*ManilleWebOutputTrickCard, 0),
+		CurrentTrick:    make([]*WebOutputTrickCard, 0),
 		PlayableIndices: make([]int, 0),
 		WinnerTeam:      -1,
 		WebOutputBase:   WebOutputBase{Message: msg},

--- a/internal/adapter/controller/ManilleWebController_test.go
+++ b/internal/adapter/controller/ManilleWebController_test.go
@@ -17,7 +17,7 @@ import (
 func mustManilleOutputJSON(msg string) string {
 	out := &controller.ManilleWebOutput{
 		Players:         []*controller.ManilleWebOutputPlayer{},
-		CurrentTrick:    []*controller.ManilleWebOutputTrickCard{},
+		CurrentTrick:    []*controller.WebOutputTrickCard{},
 		PlayableIndices: []int{},
 		WinnerTeam:      -1,
 		WebOutputBase:   controller.WebOutputBase{Message: msg},

--- a/internal/adapter/controller/MariasWebController.go
+++ b/internal/adapter/controller/MariasWebController.go
@@ -36,18 +36,6 @@ type MariasWebOutputPlayer struct {
 	IsSoloist  bool             `json:"isSoloist"`
 }
 
-// MariasWebOutputTrickCard トリック中の1枚
-type MariasWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
-// MariasWebOutputHint ヒント出力
-type MariasWebOutputHint struct {
-	CardIndices []int  `json:"cardIndices"`
-	Reason      string `json:"reason"`
-}
-
 // MariasWebOutput マリアーシュのWebアウトプット
 type MariasWebOutput struct {
 	Players          []*MariasWebOutputPlayer    `json:"players"`
@@ -59,7 +47,7 @@ type MariasWebOutput struct {
 	DealerIdx        int                         `json:"dealerIdx"`
 	SoloistIdx       int                         `json:"soloistIdx"`
 	TrumpSuit        int                         `json:"trumpSuit"`
-	CurrentTrick     []*MariasWebOutputTrickCard `json:"currentTrick"`
+	CurrentTrick     []*WebOutputTrickCard       `json:"currentTrick"`
 	PlayerScores     [domain.MariasPlayerCnt]int `json:"playerScores"`
 	RoundCardPoints  [domain.MariasPlayerCnt]int `json:"roundCardPoints"`
 	RoundMarriage    [domain.MariasPlayerCnt]int `json:"roundMarriage"`
@@ -68,7 +56,7 @@ type MariasWebOutput struct {
 	GameEndFlag      bool                        `json:"gameEndFlag"`
 	WinnerPlayer     int                         `json:"winnerPlayer"`
 	IsHumanTurn      bool                        `json:"isHumanTurn"`
-	Hint             *MariasWebOutputHint        `json:"hint,omitempty"`
+	Hint             *WebOutputCardHint          `json:"hint,omitempty"`
 	WebOutputBase
 	Config MariasWebOutputConfig `json:"config"`
 }
@@ -104,7 +92,7 @@ var NewMariasWebController, NewMariasWebControllerWithProvider = webControllerPa
 func newMariasDefaultOutput(msg string) *MariasWebOutput {
 	return &MariasWebOutput{
 		Players:         make([]*MariasWebOutputPlayer, 0),
-		CurrentTrick:    make([]*MariasWebOutputTrickCard, 0),
+		CurrentTrick:    make([]*WebOutputTrickCard, 0),
 		PlayableIndices: make([]int, 0),
 		LastTrickWinner: -1,
 		WinnerPlayer:    -1,

--- a/internal/adapter/controller/MariasWebController_test.go
+++ b/internal/adapter/controller/MariasWebController_test.go
@@ -17,7 +17,7 @@ import (
 func mustMariasOutputJSON(msg string) string {
 	out := &controller.MariasWebOutput{
 		Players:         []*controller.MariasWebOutputPlayer{},
-		CurrentTrick:    []*controller.MariasWebOutputTrickCard{},
+		CurrentTrick:    []*controller.WebOutputTrickCard{},
 		PlayableIndices: []int{},
 		LastTrickWinner: -1,
 		WinnerPlayer:    -1,

--- a/internal/adapter/controller/NapWebController.go
+++ b/internal/adapter/controller/NapWebController.go
@@ -38,18 +38,6 @@ type NapWebOutputPlayer struct {
 	IsDeclarer bool             `json:"isDeclarer"`
 }
 
-// NapWebOutputTrickCard トリック中の1枚
-type NapWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
-// NapWebOutputHint ヒント出力
-type NapWebOutputHint struct {
-	CardIndices []int  `json:"cardIndices"`
-	Reason      string `json:"reason"`
-}
-
 // NapWebOutput ナップのWebアウトプット
 type NapWebOutput struct {
 	Players          []*NapWebOutputPlayer    `json:"players"`
@@ -63,7 +51,7 @@ type NapWebOutput struct {
 	Contract         int                      `json:"contract"`
 	TrumpSuit        int                      `json:"trumpSuit"`
 	Bids             [domain.NapPlayerCnt]int `json:"bids"`
-	CurrentTrick     []*NapWebOutputTrickCard `json:"currentTrick"`
+	CurrentTrick     []*WebOutputTrickCard    `json:"currentTrick"`
 	PlayerScores     [domain.NapPlayerCnt]int `json:"playerScores"`
 	RoundTricks      [domain.NapPlayerCnt]int `json:"roundTricks"`
 	PlayableIndices  []int                    `json:"playableIndices"`
@@ -71,7 +59,7 @@ type NapWebOutput struct {
 	WinnerPlayer     int                      `json:"winnerPlayer"`
 	IsHumanTurn      bool                     `json:"isHumanTurn"`
 	IsHumanBidTurn   bool                     `json:"isHumanBidTurn"`
-	Hint             *NapWebOutputHint        `json:"hint,omitempty"`
+	Hint             *WebOutputCardHint       `json:"hint,omitempty"`
 	WebOutputBase
 	Config NapWebOutputConfig `json:"config"`
 }
@@ -107,7 +95,7 @@ var NewNapWebController, NewNapWebControllerWithProvider = webControllerPair[use
 func newNapDefaultOutput(msg string) *NapWebOutput {
 	return &NapWebOutput{
 		Players:         make([]*NapWebOutputPlayer, 0),
-		CurrentTrick:    make([]*NapWebOutputTrickCard, 0),
+		CurrentTrick:    make([]*WebOutputTrickCard, 0),
 		PlayableIndices: make([]int, 0),
 		DeclarerIdx:     -1,
 		WinnerPlayer:    -1,

--- a/internal/adapter/controller/NapWebController_test.go
+++ b/internal/adapter/controller/NapWebController_test.go
@@ -17,7 +17,7 @@ import (
 func mustNapOutputJSON(msg string) string {
 	out := &controller.NapWebOutput{
 		Players:         []*controller.NapWebOutputPlayer{},
-		CurrentTrick:    []*controller.NapWebOutputTrickCard{},
+		CurrentTrick:    []*controller.WebOutputTrickCard{},
 		PlayableIndices: []int{},
 		DeclarerIdx:     -1,
 		WinnerPlayer:    -1,

--- a/internal/adapter/controller/NapoleonWebController.go
+++ b/internal/adapter/controller/NapoleonWebController.go
@@ -45,12 +45,6 @@ type NapoleonWebOutputPlayer struct {
 	TrickCount       int              `json:"trickCount"`
 }
 
-// NapoleonWebOutputTrickCard トリック中の1枚
-type NapoleonWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
 // NapoleonWebOutputHint ヒント出力
 type NapoleonWebOutputHint struct {
 	CardIndex     *int   `json:"cardIndex,omitempty"`
@@ -64,25 +58,25 @@ type NapoleonWebOutputHint struct {
 
 // NapoleonWebOutput ナポレオンWebアウトプット
 type NapoleonWebOutput struct {
-	Players          []*NapoleonWebOutputPlayer    `json:"players"`
-	Phase            int                           `json:"phase"`
-	RoundNumber      int                           `json:"roundNumber"`
-	TrickNumber      int                           `json:"trickNumber"`
-	CurrentPlayerIdx int                           `json:"currentPlayerIdx"`
-	BidPlayerIdx     int                           `json:"bidPlayerIdx"`
-	CurrentTrick     []*NapoleonWebOutputTrickCard `json:"currentTrick"`
-	TrumpSuit        int                           `json:"trumpSuit"`
-	AdjutantCard     *WebOutputCard                `json:"adjutantCard,omitempty"`
-	NapoleonIdx      int                           `json:"napoleonIdx"`
-	AdjutantIdx      int                           `json:"adjutantIdx"`
-	AdjutantRevealed bool                          `json:"adjutantRevealed"`
-	HighestBid       int                           `json:"highestBid"`
-	HighestBidder    int                           `json:"highestBidder"`
-	Kitty            []*WebOutputCard              `json:"kitty,omitempty"`
-	GameEndFlag      bool                          `json:"gameEndFlag"`
-	WinnerTeam       int                           `json:"winnerTeam"`
-	LeadPlayerIdx    int                           `json:"leadPlayerIdx"`
-	Hint             *NapoleonWebOutputHint        `json:"hint,omitempty"`
+	Players          []*NapoleonWebOutputPlayer `json:"players"`
+	Phase            int                        `json:"phase"`
+	RoundNumber      int                        `json:"roundNumber"`
+	TrickNumber      int                        `json:"trickNumber"`
+	CurrentPlayerIdx int                        `json:"currentPlayerIdx"`
+	BidPlayerIdx     int                        `json:"bidPlayerIdx"`
+	CurrentTrick     []*WebOutputTrickCard      `json:"currentTrick"`
+	TrumpSuit        int                        `json:"trumpSuit"`
+	AdjutantCard     *WebOutputCard             `json:"adjutantCard,omitempty"`
+	NapoleonIdx      int                        `json:"napoleonIdx"`
+	AdjutantIdx      int                        `json:"adjutantIdx"`
+	AdjutantRevealed bool                       `json:"adjutantRevealed"`
+	HighestBid       int                        `json:"highestBid"`
+	HighestBidder    int                        `json:"highestBidder"`
+	Kitty            []*WebOutputCard           `json:"kitty,omitempty"`
+	GameEndFlag      bool                       `json:"gameEndFlag"`
+	WinnerTeam       int                        `json:"winnerTeam"`
+	LeadPlayerIdx    int                        `json:"leadPlayerIdx"`
+	Hint             *NapoleonWebOutputHint     `json:"hint,omitempty"`
 	WebOutputBase
 	Config NapoleonWebOutputConfig `json:"config"`
 }
@@ -120,7 +114,7 @@ var NewNapoleonWebController, NewNapoleonWebControllerWithProvider = webControll
 func newNapoleonDefaultOutput(msg string) *NapoleonWebOutput {
 	return &NapoleonWebOutput{
 		Players:       make([]*NapoleonWebOutputPlayer, 0),
-		CurrentTrick:  make([]*NapoleonWebOutputTrickCard, 0),
+		CurrentTrick:  make([]*WebOutputTrickCard, 0),
 		WinnerTeam:    domain.NapoleonWinnerUndecided,
 		NapoleonIdx:   -1,
 		AdjutantIdx:   -1,

--- a/internal/adapter/controller/NapoleonWebController_test.go
+++ b/internal/adapter/controller/NapoleonWebController_test.go
@@ -18,7 +18,7 @@ import (
 func mustNapoleonOutputJSON(msg string) string {
 	out := &controller.NapoleonWebOutput{
 		Players:       []*controller.NapoleonWebOutputPlayer{},
-		CurrentTrick:  []*controller.NapoleonWebOutputTrickCard{},
+		CurrentTrick:  []*controller.WebOutputTrickCard{},
 		WinnerTeam:    domain.NapoleonWinnerUndecided,
 		NapoleonIdx:   -1,
 		AdjutantIdx:   -1,

--- a/internal/adapter/controller/NinetyNineWebController.go
+++ b/internal/adapter/controller/NinetyNineWebController.go
@@ -35,12 +35,6 @@ type NinetyNineWebOutputPlayer struct {
 	BuriedCount     int              `json:"buriedCount"`
 }
 
-// NinetyNineWebOutputTrickCard トリック中の1枚
-type NinetyNineWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
 // NinetyNineWebOutputHint ヒント出力
 type NinetyNineWebOutputHint struct {
 	CardIndex   *int   `json:"cardIndex,omitempty"`
@@ -50,21 +44,21 @@ type NinetyNineWebOutputHint struct {
 
 // NinetyNineWebOutput ナインティナインWebアウトプット
 type NinetyNineWebOutput struct {
-	Players          []*NinetyNineWebOutputPlayer    `json:"players"`
-	Phase            int                             `json:"phase"`
-	DealNumber       int                             `json:"dealNumber"`
-	TargetScore      int                             `json:"targetScore"`
-	HandSize         int                             `json:"handSize"`
-	TrickNumber      int                             `json:"trickNumber"`
-	CurrentPlayerIdx int                             `json:"currentPlayerIdx"`
-	BidPlayerIdx     int                             `json:"bidPlayerIdx"`
-	DealerIdx        int                             `json:"dealerIdx"`
-	TrumpSuit        int                             `json:"trumpSuit"`
-	CurrentTrick     []*NinetyNineWebOutputTrickCard `json:"currentTrick"`
-	GameEndFlag      bool                            `json:"gameEndFlag"`
-	WinnerIdx        int                             `json:"winnerIdx"`
-	LeadPlayerIdx    int                             `json:"leadPlayerIdx"`
-	Hint             *NinetyNineWebOutputHint        `json:"hint,omitempty"`
+	Players          []*NinetyNineWebOutputPlayer `json:"players"`
+	Phase            int                          `json:"phase"`
+	DealNumber       int                          `json:"dealNumber"`
+	TargetScore      int                          `json:"targetScore"`
+	HandSize         int                          `json:"handSize"`
+	TrickNumber      int                          `json:"trickNumber"`
+	CurrentPlayerIdx int                          `json:"currentPlayerIdx"`
+	BidPlayerIdx     int                          `json:"bidPlayerIdx"`
+	DealerIdx        int                          `json:"dealerIdx"`
+	TrumpSuit        int                          `json:"trumpSuit"`
+	CurrentTrick     []*WebOutputTrickCard        `json:"currentTrick"`
+	GameEndFlag      bool                         `json:"gameEndFlag"`
+	WinnerIdx        int                          `json:"winnerIdx"`
+	LeadPlayerIdx    int                          `json:"leadPlayerIdx"`
+	Hint             *NinetyNineWebOutputHint     `json:"hint,omitempty"`
 	WebOutputBase
 	Config NinetyNineWebOutputConfig `json:"config"`
 }
@@ -100,7 +94,7 @@ var NewNinetyNineWebController, NewNinetyNineWebControllerWithProvider = webCont
 func newNinetyNineDefaultOutput(msg string) *NinetyNineWebOutput {
 	return &NinetyNineWebOutput{
 		Players:       make([]*NinetyNineWebOutputPlayer, 0),
-		CurrentTrick:  make([]*NinetyNineWebOutputTrickCard, 0),
+		CurrentTrick:  make([]*WebOutputTrickCard, 0),
 		WinnerIdx:     -1,
 		WebOutputBase: WebOutputBase{Message: msg},
 	}

--- a/internal/adapter/controller/NinetyNineWebController_test.go
+++ b/internal/adapter/controller/NinetyNineWebController_test.go
@@ -17,7 +17,7 @@ import (
 func mustNinetyNineOutputJSON(msg string) string {
 	out := &controller.NinetyNineWebOutput{
 		Players:       []*controller.NinetyNineWebOutputPlayer{},
-		CurrentTrick:  []*controller.NinetyNineWebOutputTrickCard{},
+		CurrentTrick:  []*controller.WebOutputTrickCard{},
 		WinnerIdx:     -1,
 		WebOutputBase: controller.WebOutputBase{Message: msg},
 	}

--- a/internal/adapter/controller/OhHellWebController.go
+++ b/internal/adapter/controller/OhHellWebController.go
@@ -36,12 +36,6 @@ type OhHellWebOutputPlayer struct {
 	TrickCount      int              `json:"trickCount"`
 }
 
-// OhHellWebOutputTrickCard トリック中の1枚
-type OhHellWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
 // OhHellWebOutputHint ヒント出力
 type OhHellWebOutputHint struct {
 	CardIndex *int   `json:"cardIndex,omitempty"`
@@ -51,23 +45,23 @@ type OhHellWebOutputHint struct {
 
 // OhHellWebOutput オー・ヘルWebアウトプット
 type OhHellWebOutput struct {
-	Players          []*OhHellWebOutputPlayer    `json:"players"`
-	Phase            int                         `json:"phase"`
-	RoundNumber      int                         `json:"roundNumber"`
-	TotalRounds      int                         `json:"totalRounds"`
-	HandSize         int                         `json:"handSize"`
-	TrickNumber      int                         `json:"trickNumber"`
-	CurrentPlayerIdx int                         `json:"currentPlayerIdx"`
-	BidPlayerIdx     int                         `json:"bidPlayerIdx"`
-	DealerIdx        int                         `json:"dealerIdx"`
-	TrumpCard        *WebOutputCard              `json:"trumpCard"`
-	TrumpSuit        int                         `json:"trumpSuit"`
-	RestrictedBid    int                         `json:"restrictedBid"`
-	CurrentTrick     []*OhHellWebOutputTrickCard `json:"currentTrick"`
-	GameEndFlag      bool                        `json:"gameEndFlag"`
-	WinnerIdx        int                         `json:"winnerIdx"`
-	LeadPlayerIdx    int                         `json:"leadPlayerIdx"`
-	Hint             *OhHellWebOutputHint        `json:"hint,omitempty"`
+	Players          []*OhHellWebOutputPlayer `json:"players"`
+	Phase            int                      `json:"phase"`
+	RoundNumber      int                      `json:"roundNumber"`
+	TotalRounds      int                      `json:"totalRounds"`
+	HandSize         int                      `json:"handSize"`
+	TrickNumber      int                      `json:"trickNumber"`
+	CurrentPlayerIdx int                      `json:"currentPlayerIdx"`
+	BidPlayerIdx     int                      `json:"bidPlayerIdx"`
+	DealerIdx        int                      `json:"dealerIdx"`
+	TrumpCard        *WebOutputCard           `json:"trumpCard"`
+	TrumpSuit        int                      `json:"trumpSuit"`
+	RestrictedBid    int                      `json:"restrictedBid"`
+	CurrentTrick     []*WebOutputTrickCard    `json:"currentTrick"`
+	GameEndFlag      bool                     `json:"gameEndFlag"`
+	WinnerIdx        int                      `json:"winnerIdx"`
+	LeadPlayerIdx    int                      `json:"leadPlayerIdx"`
+	Hint             *OhHellWebOutputHint     `json:"hint,omitempty"`
 	WebOutputBase
 	Config OhHellWebOutputConfig `json:"config"`
 }
@@ -107,7 +101,7 @@ var NewOhHellWebController, NewOhHellWebControllerWithProvider = webControllerPa
 func newOhHellDefaultOutput(msg string) *OhHellWebOutput {
 	return &OhHellWebOutput{
 		Players:       make([]*OhHellWebOutputPlayer, 0),
-		CurrentTrick:  make([]*OhHellWebOutputTrickCard, 0),
+		CurrentTrick:  make([]*WebOutputTrickCard, 0),
 		WinnerIdx:     -1,
 		TrumpSuit:     -1,
 		RestrictedBid: -1,

--- a/internal/adapter/controller/OhHellWebController_test.go
+++ b/internal/adapter/controller/OhHellWebController_test.go
@@ -17,7 +17,7 @@ import (
 func mustOhHellOutputJSON(msg string) string {
 	out := &controller.OhHellWebOutput{
 		Players:       []*controller.OhHellWebOutputPlayer{},
-		CurrentTrick:  []*controller.OhHellWebOutputTrickCard{},
+		CurrentTrick:  []*controller.WebOutputTrickCard{},
 		WinnerIdx:     -1,
 		TrumpSuit:     -1,
 		RestrictedBid: -1,

--- a/internal/adapter/controller/OmbreWebController.go
+++ b/internal/adapter/controller/OmbreWebController.go
@@ -40,18 +40,6 @@ type OmbreWebOutputPlayer struct {
 	IsOmbre    bool             `json:"isOmbre"`
 }
 
-// OmbreWebOutputTrickCard トリック中の1枚
-type OmbreWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
-// OmbreWebOutputHint ヒント出力
-type OmbreWebOutputHint struct {
-	CardIndices []int  `json:"cardIndices"`
-	Reason      string `json:"reason"`
-}
-
 // OmbreWebOutput オンブルのWebアウトプット
 type OmbreWebOutput struct {
 	Players          []*OmbreWebOutputPlayer    `json:"players"`
@@ -66,7 +54,7 @@ type OmbreWebOutput struct {
 	OmbreIdx         int                        `json:"ombreIdx"`
 	WinningBid       int                        `json:"winningBid"`
 	TrumpSuit        int                        `json:"trumpSuit"`
-	CurrentTrick     []*OmbreWebOutputTrickCard `json:"currentTrick"`
+	CurrentTrick     []*WebOutputTrickCard      `json:"currentTrick"`
 	PlayerScores     [domain.OmbrePlayerCnt]int `json:"playerScores"`
 	LastTrickWinner  int                        `json:"lastTrickWinner"`
 	Outcome          int                        `json:"outcome"`
@@ -76,7 +64,7 @@ type OmbreWebOutput struct {
 	WinnerPlayer     int                        `json:"winnerPlayer"`
 	IsHumanTurn      bool                       `json:"isHumanTurn"`
 	IsHumanBidTurn   bool                       `json:"isHumanBidTurn"`
-	Hint             *OmbreWebOutputHint        `json:"hint,omitempty"`
+	Hint             *WebOutputCardHint         `json:"hint,omitempty"`
 	WebOutputBase
 	Config OmbreWebOutputConfig `json:"config"`
 }
@@ -112,7 +100,7 @@ var NewOmbreWebController, NewOmbreWebControllerWithProvider = webControllerPair
 func newOmbreDefaultOutput(msg string) *OmbreWebOutput {
 	return &OmbreWebOutput{
 		Players:         make([]*OmbreWebOutputPlayer, 0),
-		CurrentTrick:    make([]*OmbreWebOutputTrickCard, 0),
+		CurrentTrick:    make([]*WebOutputTrickCard, 0),
 		PlayableIndices: make([]int, 0),
 		OmbreIdx:        -1,
 		TrumpSuit:       -1,

--- a/internal/adapter/controller/OmbreWebController_test.go
+++ b/internal/adapter/controller/OmbreWebController_test.go
@@ -17,7 +17,7 @@ import (
 func mustOmbreOutputJSON(msg string) string {
 	out := &controller.OmbreWebOutput{
 		Players:         []*controller.OmbreWebOutputPlayer{},
-		CurrentTrick:    []*controller.OmbreWebOutputTrickCard{},
+		CurrentTrick:    []*controller.WebOutputTrickCard{},
 		PlayableIndices: []int{},
 		OmbreIdx:        -1,
 		TrumpSuit:       -1,

--- a/internal/adapter/controller/PinochleWebController.go
+++ b/internal/adapter/controller/PinochleWebController.go
@@ -37,12 +37,6 @@ type PinochleWebOutputPlayer struct {
 	TrickPoints int              `json:"trickPoints"`
 }
 
-// PinochleWebOutputTrickCard トリック中の1枚
-type PinochleWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
 // PinochleWebOutputMeld メルド情報
 type PinochleWebOutputMeld struct {
 	Type   int              `json:"type"`
@@ -61,24 +55,24 @@ type PinochleWebOutputHint struct {
 
 // PinochleWebOutput ピノクルWebアウトプット
 type PinochleWebOutput struct {
-	Players          []*PinochleWebOutputPlayer    `json:"players"`
-	Phase            int                           `json:"phase"`
-	RoundNumber      int                           `json:"roundNumber"`
-	TrickNumber      int                           `json:"trickNumber"`
-	CurrentPlayerIdx int                           `json:"currentPlayerIdx"`
-	BidPlayerIdx     int                           `json:"bidPlayerIdx"`
-	DealerIdx        int                           `json:"dealerIdx"`
-	TrumpSuit        int                           `json:"trumpSuit"`
-	HighestBid       int                           `json:"highestBid"`
-	HighestBidder    int                           `json:"highestBidder"`
-	CurrentTrick     []*PinochleWebOutputTrickCard `json:"currentTrick"`
-	TeamScores       [2]int                        `json:"teamScores"`
-	GameEndFlag      bool                          `json:"gameEndFlag"`
-	WinnerTeam       int                           `json:"winnerTeam"`
-	LeadPlayerIdx    int                           `json:"leadPlayerIdx"`
-	PlayerMelds      [4][]*PinochleWebOutputMeld   `json:"playerMelds"`
-	ValidPlayIndices []int                         `json:"validPlayIndices,omitempty"`
-	Hint             *PinochleWebOutputHint        `json:"hint,omitempty"`
+	Players          []*PinochleWebOutputPlayer  `json:"players"`
+	Phase            int                         `json:"phase"`
+	RoundNumber      int                         `json:"roundNumber"`
+	TrickNumber      int                         `json:"trickNumber"`
+	CurrentPlayerIdx int                         `json:"currentPlayerIdx"`
+	BidPlayerIdx     int                         `json:"bidPlayerIdx"`
+	DealerIdx        int                         `json:"dealerIdx"`
+	TrumpSuit        int                         `json:"trumpSuit"`
+	HighestBid       int                         `json:"highestBid"`
+	HighestBidder    int                         `json:"highestBidder"`
+	CurrentTrick     []*WebOutputTrickCard       `json:"currentTrick"`
+	TeamScores       [2]int                      `json:"teamScores"`
+	GameEndFlag      bool                        `json:"gameEndFlag"`
+	WinnerTeam       int                         `json:"winnerTeam"`
+	LeadPlayerIdx    int                         `json:"leadPlayerIdx"`
+	PlayerMelds      [4][]*PinochleWebOutputMeld `json:"playerMelds"`
+	ValidPlayIndices []int                       `json:"validPlayIndices,omitempty"`
+	Hint             *PinochleWebOutputHint      `json:"hint,omitempty"`
 	WebOutputBase
 	Config PinochleWebOutputConfig `json:"config"`
 }
@@ -114,7 +108,7 @@ var NewPinochleWebController, NewPinochleWebControllerWithProvider = webControll
 func newPinochleDefaultOutput(msg string) *PinochleWebOutput {
 	return &PinochleWebOutput{
 		Players:       make([]*PinochleWebOutputPlayer, 0),
-		CurrentTrick:  make([]*PinochleWebOutputTrickCard, 0),
+		CurrentTrick:  make([]*WebOutputTrickCard, 0),
 		WinnerTeam:    -1,
 		WebOutputBase: WebOutputBase{Message: msg},
 	}

--- a/internal/adapter/controller/PiquetWebController.go
+++ b/internal/adapter/controller/PiquetWebController.go
@@ -56,12 +56,6 @@ type PiquetWebOutputPlayer struct {
 	MatchScore int              `json:"matchScore"`
 }
 
-// PiquetWebOutputTrickCard トリック中の1枚
-type PiquetWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
 // PiquetWebOutputClaim 宣言の中身
 type PiquetWebOutputClaim struct {
 	Length   int              `json:"length"`
@@ -117,7 +111,7 @@ type PiquetWebOutput struct {
 	CarteBlanche         [2]bool                       `json:"carteBlanche"`
 	DeclStage            int                           `json:"declStage"`
 	DeclResults          []*PiquetWebOutputDeclaration `json:"declResults"`
-	CurrentTrick         []*PiquetWebOutputTrickCard   `json:"currentTrick"`
+	CurrentTrick         []*WebOutputTrickCard         `json:"currentTrick"`
 	LegalPlayIndices     []int                         `json:"legalPlayIndices,omitempty"`
 	GameEndFlag          bool                          `json:"gameEndFlag"`
 	WinnerIdx            int                           `json:"winnerIdx"`
@@ -137,7 +131,7 @@ var NewPiquetWebController, NewPiquetWebControllerWithProvider = webControllerPa
 func newPiquetDefaultOutput(msg string) *PiquetWebOutput {
 	return &PiquetWebOutput{
 		Players:       make([]*PiquetWebOutputPlayer, 0),
-		CurrentTrick:  make([]*PiquetWebOutputTrickCard, 0),
+		CurrentTrick:  make([]*WebOutputTrickCard, 0),
 		DeclResults:   make([]*PiquetWebOutputDeclaration, 0),
 		WinnerIdx:     -1,
 		WebOutputBase: WebOutputBase{Message: msg},

--- a/internal/adapter/controller/PitchWebController.go
+++ b/internal/adapter/controller/PitchWebController.go
@@ -34,12 +34,6 @@ type PitchWebOutputPlayer struct {
 	TrickCount      int              `json:"trickCount"`
 }
 
-// PitchWebOutputTrickCard トリック中の1枚
-type PitchWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
 // PitchWebOutputHint ヒント出力
 type PitchWebOutputHint struct {
 	CardIndex *int   `json:"cardIndex,omitempty"`
@@ -49,24 +43,24 @@ type PitchWebOutputHint struct {
 
 // PitchWebOutput ピッチWebアウトプット
 type PitchWebOutput struct {
-	Players          []*PitchWebOutputPlayer    `json:"players"`
-	Phase            int                        `json:"phase"`
-	RoundNumber      int                        `json:"roundNumber"`
-	TrickNumber      int                        `json:"trickNumber"`
-	DealerIdx        int                        `json:"dealerIdx"`
-	CurrentPlayerIdx int                        `json:"currentPlayerIdx"`
-	BidPlayerIdx     int                        `json:"bidPlayerIdx"`
-	CurrentBid       int                        `json:"currentBid"`
-	BidWinnerIdx     int                        `json:"bidWinnerIdx"`
-	TrumpSuit        int                        `json:"trumpSuit"`
-	CurrentTrick     []*PitchWebOutputTrickCard `json:"currentTrick"`
-	LastTrick        []*PitchWebOutputTrickCard `json:"lastTrick"`
-	LastTrickWinner  int                        `json:"lastTrickWinner"`
-	GameEndFlag      bool                       `json:"gameEndFlag"`
-	WinnerIdx        int                        `json:"winnerIdx"`
-	LeadPlayerIdx    int                        `json:"leadPlayerIdx"`
-	ValidPlayIndices []int                      `json:"validPlayIndices,omitempty"`
-	Hint             *PitchWebOutputHint        `json:"hint,omitempty"`
+	Players          []*PitchWebOutputPlayer `json:"players"`
+	Phase            int                     `json:"phase"`
+	RoundNumber      int                     `json:"roundNumber"`
+	TrickNumber      int                     `json:"trickNumber"`
+	DealerIdx        int                     `json:"dealerIdx"`
+	CurrentPlayerIdx int                     `json:"currentPlayerIdx"`
+	BidPlayerIdx     int                     `json:"bidPlayerIdx"`
+	CurrentBid       int                     `json:"currentBid"`
+	BidWinnerIdx     int                     `json:"bidWinnerIdx"`
+	TrumpSuit        int                     `json:"trumpSuit"`
+	CurrentTrick     []*WebOutputTrickCard   `json:"currentTrick"`
+	LastTrick        []*WebOutputTrickCard   `json:"lastTrick"`
+	LastTrickWinner  int                     `json:"lastTrickWinner"`
+	GameEndFlag      bool                    `json:"gameEndFlag"`
+	WinnerIdx        int                     `json:"winnerIdx"`
+	LeadPlayerIdx    int                     `json:"leadPlayerIdx"`
+	ValidPlayIndices []int                   `json:"validPlayIndices,omitempty"`
+	Hint             *PitchWebOutputHint     `json:"hint,omitempty"`
 	WebOutputBase
 	Config PitchWebOutputConfig `json:"config"`
 }
@@ -102,8 +96,8 @@ var NewPitchWebController, NewPitchWebControllerWithProvider = webControllerPair
 func newPitchDefaultOutput(msg string) *PitchWebOutput {
 	return &PitchWebOutput{
 		Players:         make([]*PitchWebOutputPlayer, 0),
-		CurrentTrick:    make([]*PitchWebOutputTrickCard, 0),
-		LastTrick:       make([]*PitchWebOutputTrickCard, 0),
+		CurrentTrick:    make([]*WebOutputTrickCard, 0),
+		LastTrick:       make([]*WebOutputTrickCard, 0),
 		LastTrickWinner: -1,
 		WinnerIdx:       -1,
 		BidWinnerIdx:    -1,

--- a/internal/adapter/controller/PitchWebController_test.go
+++ b/internal/adapter/controller/PitchWebController_test.go
@@ -17,8 +17,8 @@ import (
 func mustPitchOutputJSON(msg string) string {
 	out := &controller.PitchWebOutput{
 		Players:         []*controller.PitchWebOutputPlayer{},
-		CurrentTrick:    []*controller.PitchWebOutputTrickCard{},
-		LastTrick:       []*controller.PitchWebOutputTrickCard{},
+		CurrentTrick:    []*controller.WebOutputTrickCard{},
+		LastTrick:       []*controller.WebOutputTrickCard{},
 		LastTrickWinner: -1,
 		WinnerIdx:       -1,
 		BidWinnerIdx:    -1,

--- a/internal/adapter/controller/PreferenceWebController.go
+++ b/internal/adapter/controller/PreferenceWebController.go
@@ -38,18 +38,6 @@ type PreferenceWebOutputPlayer struct {
 	IsDeclarer bool             `json:"isDeclarer"`
 }
 
-// PreferenceWebOutputTrickCard トリック中の1枚
-type PreferenceWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
-// PreferenceWebOutputHint ヒント出力
-type PreferenceWebOutputHint struct {
-	CardIndices []int  `json:"cardIndices"`
-	Reason      string `json:"reason"`
-}
-
 // PreferenceWebOutput プレフェランスのWebアウトプット
 type PreferenceWebOutput struct {
 	Players          []*PreferenceWebOutputPlayer    `json:"players"`
@@ -63,7 +51,7 @@ type PreferenceWebOutput struct {
 	Contract         int                             `json:"contract"`
 	TrumpSuit        int                             `json:"trumpSuit"`
 	Bids             [domain.PreferencePlayerCnt]int `json:"bids"`
-	CurrentTrick     []*PreferenceWebOutputTrickCard `json:"currentTrick"`
+	CurrentTrick     []*WebOutputTrickCard           `json:"currentTrick"`
 	PlayerScores     [domain.PreferencePlayerCnt]int `json:"playerScores"`
 	RoundTricks      [domain.PreferencePlayerCnt]int `json:"roundTricks"`
 	PlayableIndices  []int                           `json:"playableIndices"`
@@ -71,7 +59,7 @@ type PreferenceWebOutput struct {
 	WinnerPlayer     int                             `json:"winnerPlayer"`
 	IsHumanTurn      bool                            `json:"isHumanTurn"`
 	IsHumanBidTurn   bool                            `json:"isHumanBidTurn"`
-	Hint             *PreferenceWebOutputHint        `json:"hint,omitempty"`
+	Hint             *WebOutputCardHint              `json:"hint,omitempty"`
 	WebOutputBase
 	Config PreferenceWebOutputConfig `json:"config"`
 }
@@ -107,7 +95,7 @@ var NewPreferenceWebController, NewPreferenceWebControllerWithProvider = webCont
 func newPreferenceDefaultOutput(msg string) *PreferenceWebOutput {
 	return &PreferenceWebOutput{
 		Players:         make([]*PreferenceWebOutputPlayer, 0),
-		CurrentTrick:    make([]*PreferenceWebOutputTrickCard, 0),
+		CurrentTrick:    make([]*WebOutputTrickCard, 0),
 		PlayableIndices: make([]int, 0),
 		DeclarerIdx:     -1,
 		WinnerPlayer:    -1,

--- a/internal/adapter/controller/PreferenceWebController_test.go
+++ b/internal/adapter/controller/PreferenceWebController_test.go
@@ -17,7 +17,7 @@ import (
 func mustPreferenceOutputJSON(msg string) string {
 	out := &controller.PreferenceWebOutput{
 		Players:         []*controller.PreferenceWebOutputPlayer{},
-		CurrentTrick:    []*controller.PreferenceWebOutputTrickCard{},
+		CurrentTrick:    []*controller.WebOutputTrickCard{},
 		PlayableIndices: []int{},
 		DeclarerIdx:     -1,
 		WinnerPlayer:    -1,

--- a/internal/adapter/controller/RookWebController.go
+++ b/internal/adapter/controller/RookWebController.go
@@ -40,12 +40,6 @@ type RookWebOutputPlayer struct {
 	IsDeclarer bool             `json:"isDeclarer"`
 }
 
-// RookWebOutputTrickCard トリック中の1枚
-type RookWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
 // RookWebOutputHint ヒント出力
 type RookWebOutputHint struct {
 	Bid            *int   `json:"bid,omitempty"`
@@ -58,27 +52,27 @@ type RookWebOutputHint struct {
 
 // RookWebOutput ルーク(Rook) Webアウトプット
 type RookWebOutput struct {
-	Players          []*RookWebOutputPlayer    `json:"players"`
-	Phase            int                       `json:"phase"`
-	RoundNumber      int                       `json:"roundNumber"`
-	TrickNumber      int                       `json:"trickNumber"`
-	CurrentPlayerIdx int                       `json:"currentPlayerIdx"`
-	BidPlayerIdx     int                       `json:"bidPlayerIdx"`
-	DealerIdx        int                       `json:"dealerIdx"`
-	LeadPlayerIdx    int                       `json:"leadPlayerIdx"`
-	TrumpColor       int                       `json:"trumpColor"`
-	ContractBid      int                       `json:"contractBid"`
-	DeclarerIdx      int                       `json:"declarerIdx"`
-	HighestBid       int                       `json:"highestBid"`
-	HighestBidder    int                       `json:"highestBidder"`
-	NestCount        int                       `json:"nestCount"`
-	Nest             []*WebOutputCard          `json:"nest"`
-	CurrentTrick     []*RookWebOutputTrickCard `json:"currentTrick"`
-	TeamScores       [2]int                    `json:"teamScores"`
-	TeamPoints       [2]int                    `json:"teamPoints"`
-	GameEndFlag      bool                      `json:"gameEndFlag"`
-	WinnerTeam       int                       `json:"winnerTeam"`
-	Hint             *RookWebOutputHint        `json:"hint,omitempty"`
+	Players          []*RookWebOutputPlayer `json:"players"`
+	Phase            int                    `json:"phase"`
+	RoundNumber      int                    `json:"roundNumber"`
+	TrickNumber      int                    `json:"trickNumber"`
+	CurrentPlayerIdx int                    `json:"currentPlayerIdx"`
+	BidPlayerIdx     int                    `json:"bidPlayerIdx"`
+	DealerIdx        int                    `json:"dealerIdx"`
+	LeadPlayerIdx    int                    `json:"leadPlayerIdx"`
+	TrumpColor       int                    `json:"trumpColor"`
+	ContractBid      int                    `json:"contractBid"`
+	DeclarerIdx      int                    `json:"declarerIdx"`
+	HighestBid       int                    `json:"highestBid"`
+	HighestBidder    int                    `json:"highestBidder"`
+	NestCount        int                    `json:"nestCount"`
+	Nest             []*WebOutputCard       `json:"nest"`
+	CurrentTrick     []*WebOutputTrickCard  `json:"currentTrick"`
+	TeamScores       [2]int                 `json:"teamScores"`
+	TeamPoints       [2]int                 `json:"teamPoints"`
+	GameEndFlag      bool                   `json:"gameEndFlag"`
+	WinnerTeam       int                    `json:"winnerTeam"`
+	Hint             *RookWebOutputHint     `json:"hint,omitempty"`
 	WebOutputBase
 	Config RookWebOutputConfig `json:"config"`
 }
@@ -118,7 +112,7 @@ var NewRookWebController, NewRookWebControllerWithProvider = webControllerPair[u
 func newRookDefaultOutput(msg string) *RookWebOutput {
 	return &RookWebOutput{
 		Players:       make([]*RookWebOutputPlayer, 0),
-		CurrentTrick:  make([]*RookWebOutputTrickCard, 0),
+		CurrentTrick:  make([]*WebOutputTrickCard, 0),
 		Nest:          make([]*WebOutputCard, 0),
 		WinnerTeam:    -1,
 		DeclarerIdx:   -1,

--- a/internal/adapter/controller/ScartoWebController.go
+++ b/internal/adapter/controller/ScartoWebController.go
@@ -39,18 +39,6 @@ type ScartoWebOutputPlayer struct {
 	IsDealer   bool             `json:"isDealer"`
 }
 
-// ScartoWebOutputTrickCard トリック中の1枚
-type ScartoWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
-// ScartoWebOutputHint ヒント出力
-type ScartoWebOutputHint struct {
-	CardIndices []int  `json:"cardIndices"`
-	Reason      string `json:"reason"`
-}
-
 // ScartoWebOutput スカルトのWebアウトプット
 type ScartoWebOutput struct {
 	Players          []*ScartoWebOutputPlayer    `json:"players"`
@@ -61,7 +49,7 @@ type ScartoWebOutput struct {
 	LeadPlayerIdx    int                         `json:"leadPlayerIdx"`
 	DealerIdx        int                         `json:"dealerIdx"`
 	ScartoCount      int                         `json:"scartoCount"`
-	CurrentTrick     []*ScartoWebOutputTrickCard `json:"currentTrick"`
+	CurrentTrick     []*WebOutputTrickCard       `json:"currentTrick"`
 	PlayerScores     [domain.ScartoPlayerCnt]int `json:"playerScores"`
 	DealScores       [domain.ScartoPlayerCnt]int `json:"dealScores"`
 	LastTrickWinner  int                         `json:"lastTrickWinner"`
@@ -72,7 +60,7 @@ type ScartoWebOutput struct {
 	WinnerPlayer     int                         `json:"winnerPlayer"`
 	IsHumanTurn      bool                        `json:"isHumanTurn"`
 	IsHumanScarto    bool                        `json:"isHumanScarto"`
-	Hint             *ScartoWebOutputHint        `json:"hint,omitempty"`
+	Hint             *WebOutputCardHint          `json:"hint,omitempty"`
 	WebOutputBase
 	Config ScartoWebOutputConfig `json:"config"`
 }
@@ -108,7 +96,7 @@ var NewScartoWebController, NewScartoWebControllerWithProvider = webControllerPa
 func newScartoDefaultOutput(msg string) *ScartoWebOutput {
 	return &ScartoWebOutput{
 		Players:         make([]*ScartoWebOutputPlayer, 0),
-		CurrentTrick:    make([]*ScartoWebOutputTrickCard, 0),
+		CurrentTrick:    make([]*WebOutputTrickCard, 0),
 		PlayableIndices: make([]int, 0),
 		LastTrickWinner: -1,
 		WinnerPlayer:    -1,

--- a/internal/adapter/controller/ScartoWebController_test.go
+++ b/internal/adapter/controller/ScartoWebController_test.go
@@ -17,7 +17,7 @@ import (
 func mustScartoOutputJSON(msg string) string {
 	out := &controller.ScartoWebOutput{
 		Players:         []*controller.ScartoWebOutputPlayer{},
-		CurrentTrick:    []*controller.ScartoWebOutputTrickCard{},
+		CurrentTrick:    []*controller.WebOutputTrickCard{},
 		PlayableIndices: []int{},
 		LastTrickWinner: -1,
 		WinnerPlayer:    -1,

--- a/internal/adapter/controller/SchnapsenWebController.go
+++ b/internal/adapter/controller/SchnapsenWebController.go
@@ -32,12 +32,6 @@ type SchnapsenWebOutputPlayer struct {
 	TrickCount int              `json:"trickCount"`
 }
 
-// SchnapsenWebOutputTrickCard トリック中の1枚
-type SchnapsenWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
 // SchnapsenWebOutputHint ヒント出力
 type SchnapsenWebOutputHint struct {
 	CardIndex  *int   `json:"cardIndex,omitempty"`
@@ -47,22 +41,22 @@ type SchnapsenWebOutputHint struct {
 
 // SchnapsenWebOutput シュナプセンWebアウトプット
 type SchnapsenWebOutput struct {
-	Players          []*SchnapsenWebOutputPlayer    `json:"players"`
-	Phase            int                            `json:"phase"`
-	TrickNumber      int                            `json:"trickNumber"`
-	CurrentPlayerIdx int                            `json:"currentPlayerIdx"`
-	CurrentTrick     []*SchnapsenWebOutputTrickCard `json:"currentTrick"`
-	TrumpSuit        int                            `json:"trumpSuit"`
-	TrumpCard        *WebOutputCard                 `json:"trumpCard,omitempty"`
-	DealerIdx        int                            `json:"dealerIdx"`
-	LeadPlayerIdx    int                            `json:"leadPlayerIdx"`
-	StockRemaining   int                            `json:"stockRemaining"`
-	IsEndgame        bool                           `json:"isEndgame"`
-	ValidPlays       []int                          `json:"validPlays"`
-	MarriagePlays    []int                          `json:"marriagePlays"`
-	GameEndFlag      bool                           `json:"gameEndFlag"`
-	WinnerIdx        int                            `json:"winnerIdx"`
-	Hint             *SchnapsenWebOutputHint        `json:"hint,omitempty"`
+	Players          []*SchnapsenWebOutputPlayer `json:"players"`
+	Phase            int                         `json:"phase"`
+	TrickNumber      int                         `json:"trickNumber"`
+	CurrentPlayerIdx int                         `json:"currentPlayerIdx"`
+	CurrentTrick     []*WebOutputTrickCard       `json:"currentTrick"`
+	TrumpSuit        int                         `json:"trumpSuit"`
+	TrumpCard        *WebOutputCard              `json:"trumpCard,omitempty"`
+	DealerIdx        int                         `json:"dealerIdx"`
+	LeadPlayerIdx    int                         `json:"leadPlayerIdx"`
+	StockRemaining   int                         `json:"stockRemaining"`
+	IsEndgame        bool                        `json:"isEndgame"`
+	ValidPlays       []int                       `json:"validPlays"`
+	MarriagePlays    []int                       `json:"marriagePlays"`
+	GameEndFlag      bool                        `json:"gameEndFlag"`
+	WinnerIdx        int                         `json:"winnerIdx"`
+	Hint             *SchnapsenWebOutputHint     `json:"hint,omitempty"`
 	WebOutputBase
 	Config SchnapsenWebOutputConfig `json:"config"`
 }
@@ -98,7 +92,7 @@ var NewSchnapsenWebController, NewSchnapsenWebControllerWithProvider = webContro
 func newSchnapsenDefaultOutput(msg string) *SchnapsenWebOutput {
 	return &SchnapsenWebOutput{
 		Players:       make([]*SchnapsenWebOutputPlayer, 0),
-		CurrentTrick:  make([]*SchnapsenWebOutputTrickCard, 0),
+		CurrentTrick:  make([]*WebOutputTrickCard, 0),
 		ValidPlays:    make([]int, 0),
 		MarriagePlays: make([]int, 0),
 		WinnerIdx:     -1,

--- a/internal/adapter/controller/SchnapsenWebController_test.go
+++ b/internal/adapter/controller/SchnapsenWebController_test.go
@@ -20,7 +20,7 @@ import (
 func mustSchnapsenOutputJSON(msg string) string {
 	out := &controller.SchnapsenWebOutput{
 		Players:       []*controller.SchnapsenWebOutputPlayer{},
-		CurrentTrick:  []*controller.SchnapsenWebOutputTrickCard{},
+		CurrentTrick:  []*controller.WebOutputTrickCard{},
 		ValidPlays:    []int{},
 		MarriagePlays: []int{},
 		WinnerIdx:     -1,

--- a/internal/adapter/controller/SedmaWebController.go
+++ b/internal/adapter/controller/SedmaWebController.go
@@ -35,35 +35,23 @@ type SedmaWebOutputPlayer struct {
 	TeamScore  int              `json:"teamScore"`
 }
 
-// SedmaWebOutputTrickCard トリック中の1枚
-type SedmaWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
-// SedmaWebOutputHint ヒント出力
-type SedmaWebOutputHint struct {
-	CardIndices []int  `json:"cardIndices"`
-	Reason      string `json:"reason"`
-}
-
 // SedmaWebOutput セドマのWebアウトプット
 type SedmaWebOutput struct {
-	Players          []*SedmaWebOutputPlayer    `json:"players"`
-	Phase            int                        `json:"phase"`
-	RoundNumber      int                        `json:"roundNumber"`
-	TrickNumber      int                        `json:"trickNumber"`
-	CurrentPlayerIdx int                        `json:"currentPlayerIdx"`
-	LeadPlayerIdx    int                        `json:"leadPlayerIdx"`
-	DealerIdx        int                        `json:"dealerIdx"`
-	CurrentTrick     []*SedmaWebOutputTrickCard `json:"currentTrick"`
-	TeamScores       [domain.SedmaTeamCnt]int   `json:"teamScores"`
-	RoundCardPoints  [domain.SedmaTeamCnt]int   `json:"roundCardPoints"`
-	PlayableIndices  []int                      `json:"playableIndices"`
-	GameEndFlag      bool                       `json:"gameEndFlag"`
-	WinnerTeam       int                        `json:"winnerTeam"`
-	IsHumanTurn      bool                       `json:"isHumanTurn"`
-	Hint             *SedmaWebOutputHint        `json:"hint,omitempty"`
+	Players          []*SedmaWebOutputPlayer  `json:"players"`
+	Phase            int                      `json:"phase"`
+	RoundNumber      int                      `json:"roundNumber"`
+	TrickNumber      int                      `json:"trickNumber"`
+	CurrentPlayerIdx int                      `json:"currentPlayerIdx"`
+	LeadPlayerIdx    int                      `json:"leadPlayerIdx"`
+	DealerIdx        int                      `json:"dealerIdx"`
+	CurrentTrick     []*WebOutputTrickCard    `json:"currentTrick"`
+	TeamScores       [domain.SedmaTeamCnt]int `json:"teamScores"`
+	RoundCardPoints  [domain.SedmaTeamCnt]int `json:"roundCardPoints"`
+	PlayableIndices  []int                    `json:"playableIndices"`
+	GameEndFlag      bool                     `json:"gameEndFlag"`
+	WinnerTeam       int                      `json:"winnerTeam"`
+	IsHumanTurn      bool                     `json:"isHumanTurn"`
+	Hint             *WebOutputCardHint       `json:"hint,omitempty"`
 	WebOutputBase
 	Config SedmaWebOutputConfig `json:"config"`
 }
@@ -99,7 +87,7 @@ var NewSedmaWebController, NewSedmaWebControllerWithProvider = webControllerPair
 func newSedmaDefaultOutput(msg string) *SedmaWebOutput {
 	return &SedmaWebOutput{
 		Players:         make([]*SedmaWebOutputPlayer, 0),
-		CurrentTrick:    make([]*SedmaWebOutputTrickCard, 0),
+		CurrentTrick:    make([]*WebOutputTrickCard, 0),
 		PlayableIndices: make([]int, 0),
 		WinnerTeam:      -1,
 		WebOutputBase:   WebOutputBase{Message: msg},

--- a/internal/adapter/controller/SedmaWebController_test.go
+++ b/internal/adapter/controller/SedmaWebController_test.go
@@ -17,7 +17,7 @@ import (
 func mustSedmaOutputJSON(msg string) string {
 	out := &controller.SedmaWebOutput{
 		Players:         []*controller.SedmaWebOutputPlayer{},
-		CurrentTrick:    []*controller.SedmaWebOutputTrickCard{},
+		CurrentTrick:    []*controller.WebOutputTrickCard{},
 		PlayableIndices: []int{},
 		WinnerTeam:      -1,
 		WebOutputBase:   controller.WebOutputBase{Message: msg},

--- a/internal/adapter/controller/SheepsheadWebController.go
+++ b/internal/adapter/controller/SheepsheadWebController.go
@@ -43,12 +43,6 @@ type SheepsheadWebOutputPlayer struct {
 	Chips      int              `json:"chips"`
 }
 
-// SheepsheadWebOutputTrickCard トリック中の1枚
-type SheepsheadWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
 // SheepsheadWebOutputHint ヒント出力
 type SheepsheadWebOutputHint struct {
 	CardIndices []int  `json:"cardIndices"`
@@ -59,14 +53,14 @@ type SheepsheadWebOutputHint struct {
 
 // SheepsheadWebOutput シープスヘッドのWebアウトプット
 type SheepsheadWebOutput struct {
-	Players          []*SheepsheadWebOutputPlayer    `json:"players"`
-	Phase            int                             `json:"phase"`
-	RoundNumber      int                             `json:"roundNumber"`
-	TrickNumber      int                             `json:"trickNumber"`
-	CurrentPlayerIdx int                             `json:"currentPlayerIdx"`
-	LeadPlayerIdx    int                             `json:"leadPlayerIdx"`
-	DealerIdx        int                             `json:"dealerIdx"`
-	CurrentTrick     []*SheepsheadWebOutputTrickCard `json:"currentTrick"`
+	Players          []*SheepsheadWebOutputPlayer `json:"players"`
+	Phase            int                          `json:"phase"`
+	RoundNumber      int                          `json:"roundNumber"`
+	TrickNumber      int                          `json:"trickNumber"`
+	CurrentPlayerIdx int                          `json:"currentPlayerIdx"`
+	LeadPlayerIdx    int                          `json:"leadPlayerIdx"`
+	DealerIdx        int                          `json:"dealerIdx"`
+	CurrentTrick     []*WebOutputTrickCard        `json:"currentTrick"`
 	// BlindCount ブラインドの枚数 (ピックフェーズ中は枚数のみ公開)
 	BlindCount        int                      `json:"blindCount"`
 	Buried            []*WebOutputCard         `json:"buried"`
@@ -122,7 +116,7 @@ var NewSheepsheadWebController, NewSheepsheadWebControllerWithProvider = webCont
 func newSheepsheadDefaultOutput(msg string) *SheepsheadWebOutput {
 	return &SheepsheadWebOutput{
 		Players:         make([]*SheepsheadWebOutputPlayer, 0),
-		CurrentTrick:    make([]*SheepsheadWebOutputTrickCard, 0),
+		CurrentTrick:    make([]*WebOutputTrickCard, 0),
 		Buried:          make([]*WebOutputCard, 0),
 		CallableSuits:   make([]int, 0),
 		PlayableIndices: make([]int, 0),

--- a/internal/adapter/controller/SheepsheadWebController_test.go
+++ b/internal/adapter/controller/SheepsheadWebController_test.go
@@ -17,7 +17,7 @@ import (
 func mustSheepsheadOutputJSON(msg string) string {
 	out := &controller.SheepsheadWebOutput{
 		Players:         []*controller.SheepsheadWebOutputPlayer{},
-		CurrentTrick:    []*controller.SheepsheadWebOutputTrickCard{},
+		CurrentTrick:    []*controller.WebOutputTrickCard{},
 		Buried:          []*controller.WebOutputCard{},
 		CallableSuits:   []int{},
 		PlayableIndices: []int{},

--- a/internal/adapter/controller/SkatWebController.go
+++ b/internal/adapter/controller/SkatWebController.go
@@ -45,12 +45,6 @@ type SkatWebOutputPlayer struct {
 	TrickCount      int              `json:"trickCount"`
 }
 
-// SkatWebOutputTrickCard one card played in a trick.
-type SkatWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
 // SkatWebOutputHint hint output.
 type SkatWebOutputHint struct {
 	CardIndex    *int   `json:"cardIndex,omitempty"`
@@ -64,31 +58,31 @@ type SkatWebOutputHint struct {
 
 // SkatWebOutput Skat web response payload.
 type SkatWebOutput struct {
-	Players             []*SkatWebOutputPlayer    `json:"players"`
-	Phase               int                       `json:"phase"`
-	RoundNumber         int                       `json:"roundNumber"`
-	TrickNumber         int                       `json:"trickNumber"`
-	CurrentPlayerIdx    int                       `json:"currentPlayerIdx"`
-	CurrentTrick        []*SkatWebOutputTrickCard `json:"currentTrick"`
-	ForehandIdx         int                       `json:"forehandIdx"`
-	MiddlehandIdx       int                       `json:"middlehandIdx"`
-	RearhandIdx         int                       `json:"rearhandIdx"`
-	DealerIdx           int                       `json:"dealerIdx"`
-	DeclarerIdx         int                       `json:"declarerIdx"`
-	CurrentBid          int                       `json:"currentBid"`
-	ActiveBidActorIdx   int                       `json:"activeBidActorIdx"`
-	GameType            int                       `json:"gameType"`
-	TrumpSuit           int                       `json:"trumpSuit"`
-	Skat                []*WebOutputCard          `json:"skat,omitempty"`
-	OriginalSkat        []*WebOutputCard          `json:"originalSkat,omitempty"`
-	PickedSkat          bool                      `json:"pickedSkat"`
-	DeclarerCardPoints  int                       `json:"declarerCardPoints"`
-	DefendersCardPoints int                       `json:"defendersCardPoints"`
-	WinnerSide          int                       `json:"winnerSide"`
-	GameValue           int                       `json:"gameValue"`
-	GameEndFlag         bool                      `json:"gameEndFlag"`
-	LeadPlayerIdx       int                       `json:"leadPlayerIdx"`
-	Hint                *SkatWebOutputHint        `json:"hint,omitempty"`
+	Players             []*SkatWebOutputPlayer `json:"players"`
+	Phase               int                    `json:"phase"`
+	RoundNumber         int                    `json:"roundNumber"`
+	TrickNumber         int                    `json:"trickNumber"`
+	CurrentPlayerIdx    int                    `json:"currentPlayerIdx"`
+	CurrentTrick        []*WebOutputTrickCard  `json:"currentTrick"`
+	ForehandIdx         int                    `json:"forehandIdx"`
+	MiddlehandIdx       int                    `json:"middlehandIdx"`
+	RearhandIdx         int                    `json:"rearhandIdx"`
+	DealerIdx           int                    `json:"dealerIdx"`
+	DeclarerIdx         int                    `json:"declarerIdx"`
+	CurrentBid          int                    `json:"currentBid"`
+	ActiveBidActorIdx   int                    `json:"activeBidActorIdx"`
+	GameType            int                    `json:"gameType"`
+	TrumpSuit           int                    `json:"trumpSuit"`
+	Skat                []*WebOutputCard       `json:"skat,omitempty"`
+	OriginalSkat        []*WebOutputCard       `json:"originalSkat,omitempty"`
+	PickedSkat          bool                   `json:"pickedSkat"`
+	DeclarerCardPoints  int                    `json:"declarerCardPoints"`
+	DefendersCardPoints int                    `json:"defendersCardPoints"`
+	WinnerSide          int                    `json:"winnerSide"`
+	GameValue           int                    `json:"gameValue"`
+	GameEndFlag         bool                   `json:"gameEndFlag"`
+	LeadPlayerIdx       int                    `json:"leadPlayerIdx"`
+	Hint                *SkatWebOutputHint     `json:"hint,omitempty"`
 	WebOutputBase
 	Config SkatWebOutputConfig `json:"config"`
 }
@@ -128,7 +122,7 @@ var NewSkatWebController, NewSkatWebControllerWithProvider = webControllerPair[u
 func newSkatDefaultOutput(msg string) *SkatWebOutput {
 	return &SkatWebOutput{
 		Players:           make([]*SkatWebOutputPlayer, 0),
-		CurrentTrick:      make([]*SkatWebOutputTrickCard, 0),
+		CurrentTrick:      make([]*WebOutputTrickCard, 0),
 		WinnerSide:        domain.SkatWinnerUndecided,
 		DeclarerIdx:       -1,
 		ActiveBidActorIdx: -1,

--- a/internal/adapter/controller/SkatWebController_test.go
+++ b/internal/adapter/controller/SkatWebController_test.go
@@ -17,7 +17,7 @@ import (
 func mustSkatOutputJSON(msg string) string {
 	out := &controller.SkatWebOutput{
 		Players:           []*controller.SkatWebOutputPlayer{},
-		CurrentTrick:      []*controller.SkatWebOutputTrickCard{},
+		CurrentTrick:      []*controller.WebOutputTrickCard{},
 		WinnerSide:        domain.SkatWinnerUndecided,
 		DeclarerIdx:       -1,
 		ActiveBidActorIdx: -1,

--- a/internal/adapter/controller/SoloWhistWebController.go
+++ b/internal/adapter/controller/SoloWhistWebController.go
@@ -38,18 +38,6 @@ type SoloWhistWebOutputPlayer struct {
 	IsDeclarer bool             `json:"isDeclarer"`
 }
 
-// SoloWhistWebOutputTrickCard トリック中の1枚
-type SoloWhistWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
-// SoloWhistWebOutputHint ヒント出力
-type SoloWhistWebOutputHint struct {
-	CardIndices []int  `json:"cardIndices"`
-	Reason      string `json:"reason"`
-}
-
 // SoloWhistWebOutput ソロ・ホイストのWebアウトプット
 type SoloWhistWebOutput struct {
 	Players          []*SoloWhistWebOutputPlayer    `json:"players"`
@@ -63,7 +51,7 @@ type SoloWhistWebOutput struct {
 	Contract         int                            `json:"contract"`
 	TrumpSuit        int                            `json:"trumpSuit"`
 	Bids             [domain.SoloWhistPlayerCnt]int `json:"bids"`
-	CurrentTrick     []*SoloWhistWebOutputTrickCard `json:"currentTrick"`
+	CurrentTrick     []*WebOutputTrickCard          `json:"currentTrick"`
 	PlayerScores     [domain.SoloWhistPlayerCnt]int `json:"playerScores"`
 	RoundTricks      [domain.SoloWhistPlayerCnt]int `json:"roundTricks"`
 	PlayableIndices  []int                          `json:"playableIndices"`
@@ -71,7 +59,7 @@ type SoloWhistWebOutput struct {
 	WinnerPlayer     int                            `json:"winnerPlayer"`
 	IsHumanTurn      bool                           `json:"isHumanTurn"`
 	IsHumanBidTurn   bool                           `json:"isHumanBidTurn"`
-	Hint             *SoloWhistWebOutputHint        `json:"hint,omitempty"`
+	Hint             *WebOutputCardHint             `json:"hint,omitempty"`
 	WebOutputBase
 	Config SoloWhistWebOutputConfig `json:"config"`
 }
@@ -107,7 +95,7 @@ var NewSoloWhistWebController, NewSoloWhistWebControllerWithProvider = webContro
 func newSoloWhistDefaultOutput(msg string) *SoloWhistWebOutput {
 	return &SoloWhistWebOutput{
 		Players:         make([]*SoloWhistWebOutputPlayer, 0),
-		CurrentTrick:    make([]*SoloWhistWebOutputTrickCard, 0),
+		CurrentTrick:    make([]*WebOutputTrickCard, 0),
 		PlayableIndices: make([]int, 0),
 		DeclarerIdx:     -1,
 		WinnerPlayer:    -1,

--- a/internal/adapter/controller/SoloWhistWebController_test.go
+++ b/internal/adapter/controller/SoloWhistWebController_test.go
@@ -17,7 +17,7 @@ import (
 func mustSoloWhistOutputJSON(msg string) string {
 	out := &controller.SoloWhistWebOutput{
 		Players:         []*controller.SoloWhistWebOutputPlayer{},
-		CurrentTrick:    []*controller.SoloWhistWebOutputTrickCard{},
+		CurrentTrick:    []*controller.WebOutputTrickCard{},
 		PlayableIndices: []int{},
 		DeclarerIdx:     -1,
 		WinnerPlayer:    -1,

--- a/internal/adapter/controller/SpadesWebController.go
+++ b/internal/adapter/controller/SpadesWebController.go
@@ -37,12 +37,6 @@ type SpadesWebOutputPlayer struct {
 	Bags            int              `json:"bags"`
 }
 
-// SpadesWebOutputTrickCard トリック中の1枚
-type SpadesWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
 // SpadesWebOutputHint ヒント出力
 type SpadesWebOutputHint struct {
 	CardIndex *int   `json:"cardIndex,omitempty"`
@@ -52,18 +46,18 @@ type SpadesWebOutputHint struct {
 
 // SpadesWebOutput スペードWebアウトプット
 type SpadesWebOutput struct {
-	Players          []*SpadesWebOutputPlayer    `json:"players"`
-	Phase            int                         `json:"phase"`
-	RoundNumber      int                         `json:"roundNumber"`
-	TrickNumber      int                         `json:"trickNumber"`
-	CurrentPlayerIdx int                         `json:"currentPlayerIdx"`
-	BidPlayerIdx     int                         `json:"bidPlayerIdx"`
-	CurrentTrick     []*SpadesWebOutputTrickCard `json:"currentTrick"`
-	SpadesBroken     bool                        `json:"spadesBroken"`
-	GameEndFlag      bool                        `json:"gameEndFlag"`
-	WinnerIdx        int                         `json:"winnerIdx"`
-	LeadPlayerIdx    int                         `json:"leadPlayerIdx"`
-	Hint             *SpadesWebOutputHint        `json:"hint,omitempty"`
+	Players          []*SpadesWebOutputPlayer `json:"players"`
+	Phase            int                      `json:"phase"`
+	RoundNumber      int                      `json:"roundNumber"`
+	TrickNumber      int                      `json:"trickNumber"`
+	CurrentPlayerIdx int                      `json:"currentPlayerIdx"`
+	BidPlayerIdx     int                      `json:"bidPlayerIdx"`
+	CurrentTrick     []*WebOutputTrickCard    `json:"currentTrick"`
+	SpadesBroken     bool                     `json:"spadesBroken"`
+	GameEndFlag      bool                     `json:"gameEndFlag"`
+	WinnerIdx        int                      `json:"winnerIdx"`
+	LeadPlayerIdx    int                      `json:"leadPlayerIdx"`
+	Hint             *SpadesWebOutputHint     `json:"hint,omitempty"`
 	WebOutputBase
 	Config SpadesWebOutputConfig `json:"config"`
 }
@@ -103,7 +97,7 @@ var NewSpadesWebController, NewSpadesWebControllerWithProvider = webControllerPa
 func newSpadesDefaultOutput(msg string) *SpadesWebOutput {
 	return &SpadesWebOutput{
 		Players:       make([]*SpadesWebOutputPlayer, 0),
-		CurrentTrick:  make([]*SpadesWebOutputTrickCard, 0),
+		CurrentTrick:  make([]*WebOutputTrickCard, 0),
 		WinnerIdx:     -1,
 		WebOutputBase: WebOutputBase{Message: msg},
 	}

--- a/internal/adapter/controller/SpadesWebController_test.go
+++ b/internal/adapter/controller/SpadesWebController_test.go
@@ -18,7 +18,7 @@ import (
 func mustSpadesOutputJSON(msg string) string {
 	out := &controller.SpadesWebOutput{
 		Players:       []*controller.SpadesWebOutputPlayer{},
-		CurrentTrick:  []*controller.SpadesWebOutputTrickCard{},
+		CurrentTrick:  []*controller.WebOutputTrickCard{},
 		WinnerIdx:     -1,
 		WebOutputBase: controller.WebOutputBase{Message: msg},
 	}

--- a/internal/adapter/controller/SpoilFiveWebController.go
+++ b/internal/adapter/controller/SpoilFiveWebController.go
@@ -35,36 +35,24 @@ type SpoilFiveWebOutputPlayer struct {
 	RoundTricks int              `json:"roundTricks"`
 }
 
-// SpoilFiveWebOutputTrickCard トリック中の1枚
-type SpoilFiveWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
-// SpoilFiveWebOutputHint ヒント出力
-type SpoilFiveWebOutputHint struct {
-	CardIndices []int  `json:"cardIndices"`
-	Reason      string `json:"reason"`
-}
-
 // SpoilFiveWebOutput スポイル・ファイブのWebアウトプット
 type SpoilFiveWebOutput struct {
-	Players          []*SpoilFiveWebOutputPlayer    `json:"players"`
-	Phase            int                            `json:"phase"`
-	RoundNumber      int                            `json:"roundNumber"`
-	TrickNumber      int                            `json:"trickNumber"`
-	CurrentPlayerIdx int                            `json:"currentPlayerIdx"`
-	LeadPlayerIdx    int                            `json:"leadPlayerIdx"`
-	DealerIdx        int                            `json:"dealerIdx"`
-	TrumpSuit        int                            `json:"trumpSuit"`
-	Pot              int                            `json:"pot"`
-	RoundWinnerIdx   int                            `json:"roundWinnerIdx"`
-	CurrentTrick     []*SpoilFiveWebOutputTrickCard `json:"currentTrick"`
-	PlayableIndices  []int                          `json:"playableIndices"`
-	GameEndFlag      bool                           `json:"gameEndFlag"`
-	WinnerPlayer     int                            `json:"winnerPlayer"`
-	IsHumanTurn      bool                           `json:"isHumanTurn"`
-	Hint             *SpoilFiveWebOutputHint        `json:"hint,omitempty"`
+	Players          []*SpoilFiveWebOutputPlayer `json:"players"`
+	Phase            int                         `json:"phase"`
+	RoundNumber      int                         `json:"roundNumber"`
+	TrickNumber      int                         `json:"trickNumber"`
+	CurrentPlayerIdx int                         `json:"currentPlayerIdx"`
+	LeadPlayerIdx    int                         `json:"leadPlayerIdx"`
+	DealerIdx        int                         `json:"dealerIdx"`
+	TrumpSuit        int                         `json:"trumpSuit"`
+	Pot              int                         `json:"pot"`
+	RoundWinnerIdx   int                         `json:"roundWinnerIdx"`
+	CurrentTrick     []*WebOutputTrickCard       `json:"currentTrick"`
+	PlayableIndices  []int                       `json:"playableIndices"`
+	GameEndFlag      bool                        `json:"gameEndFlag"`
+	WinnerPlayer     int                         `json:"winnerPlayer"`
+	IsHumanTurn      bool                        `json:"isHumanTurn"`
+	Hint             *WebOutputCardHint          `json:"hint,omitempty"`
 	WebOutputBase
 	Config SpoilFiveWebOutputConfig `json:"config"`
 }
@@ -99,7 +87,7 @@ var NewSpoilFiveWebController, NewSpoilFiveWebControllerWithProvider = webContro
 func newSpoilFiveDefaultOutput(msg string) *SpoilFiveWebOutput {
 	return &SpoilFiveWebOutput{
 		Players:         make([]*SpoilFiveWebOutputPlayer, 0),
-		CurrentTrick:    make([]*SpoilFiveWebOutputTrickCard, 0),
+		CurrentTrick:    make([]*WebOutputTrickCard, 0),
 		PlayableIndices: make([]int, 0),
 		RoundWinnerIdx:  -1,
 		WinnerPlayer:    -1,

--- a/internal/adapter/controller/SpoilFiveWebController_test.go
+++ b/internal/adapter/controller/SpoilFiveWebController_test.go
@@ -17,7 +17,7 @@ import (
 func mustSpoilFiveOutputJSON(msg string) string {
 	out := &controller.SpoilFiveWebOutput{
 		Players:         []*controller.SpoilFiveWebOutputPlayer{},
-		CurrentTrick:    []*controller.SpoilFiveWebOutputTrickCard{},
+		CurrentTrick:    []*controller.WebOutputTrickCard{},
 		PlayableIndices: []int{},
 		RoundWinnerIdx:  -1,
 		WinnerPlayer:    -1,

--- a/internal/adapter/controller/SuecaWebController.go
+++ b/internal/adapter/controller/SuecaWebController.go
@@ -35,38 +35,26 @@ type SuecaWebOutputPlayer struct {
 	TeamGamePoints int              `json:"teamGamePoints"`
 }
 
-// SuecaWebOutputTrickCard トリック中の1枚
-type SuecaWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
-// SuecaWebOutputHint ヒント出力
-type SuecaWebOutputHint struct {
-	CardIndices []int  `json:"cardIndices"`
-	Reason      string `json:"reason"`
-}
-
 // SuecaWebOutput スエカのWebアウトプット
 type SuecaWebOutput struct {
-	Players          []*SuecaWebOutputPlayer    `json:"players"`
-	Phase            int                        `json:"phase"`
-	RoundNumber      int                        `json:"roundNumber"`
-	TrickNumber      int                        `json:"trickNumber"`
-	CurrentPlayerIdx int                        `json:"currentPlayerIdx"`
-	LeadPlayerIdx    int                        `json:"leadPlayerIdx"`
-	DealerIdx        int                        `json:"dealerIdx"`
-	TrumpSuit        int                        `json:"trumpSuit"`
-	CurrentTrick     []*SuecaWebOutputTrickCard `json:"currentTrick"`
-	TeamGamePoints   [domain.SuecaTeamCnt]int   `json:"teamGamePoints"`
-	RoundCardPoints  [domain.SuecaTeamCnt]int   `json:"roundCardPoints"`
-	RoundWinnerTeam  int                        `json:"roundWinnerTeam"`
-	RoundGamePoints  int                        `json:"roundGamePoints"`
-	PlayableIndices  []int                      `json:"playableIndices"`
-	GameEndFlag      bool                       `json:"gameEndFlag"`
-	WinnerTeam       int                        `json:"winnerTeam"`
-	IsHumanTurn      bool                       `json:"isHumanTurn"`
-	Hint             *SuecaWebOutputHint        `json:"hint,omitempty"`
+	Players          []*SuecaWebOutputPlayer  `json:"players"`
+	Phase            int                      `json:"phase"`
+	RoundNumber      int                      `json:"roundNumber"`
+	TrickNumber      int                      `json:"trickNumber"`
+	CurrentPlayerIdx int                      `json:"currentPlayerIdx"`
+	LeadPlayerIdx    int                      `json:"leadPlayerIdx"`
+	DealerIdx        int                      `json:"dealerIdx"`
+	TrumpSuit        int                      `json:"trumpSuit"`
+	CurrentTrick     []*WebOutputTrickCard    `json:"currentTrick"`
+	TeamGamePoints   [domain.SuecaTeamCnt]int `json:"teamGamePoints"`
+	RoundCardPoints  [domain.SuecaTeamCnt]int `json:"roundCardPoints"`
+	RoundWinnerTeam  int                      `json:"roundWinnerTeam"`
+	RoundGamePoints  int                      `json:"roundGamePoints"`
+	PlayableIndices  []int                    `json:"playableIndices"`
+	GameEndFlag      bool                     `json:"gameEndFlag"`
+	WinnerTeam       int                      `json:"winnerTeam"`
+	IsHumanTurn      bool                     `json:"isHumanTurn"`
+	Hint             *WebOutputCardHint       `json:"hint,omitempty"`
 	WebOutputBase
 	Config SuecaWebOutputConfig `json:"config"`
 }
@@ -102,7 +90,7 @@ var NewSuecaWebController, NewSuecaWebControllerWithProvider = webControllerPair
 func newSuecaDefaultOutput(msg string) *SuecaWebOutput {
 	return &SuecaWebOutput{
 		Players:         make([]*SuecaWebOutputPlayer, 0),
-		CurrentTrick:    make([]*SuecaWebOutputTrickCard, 0),
+		CurrentTrick:    make([]*WebOutputTrickCard, 0),
 		PlayableIndices: make([]int, 0),
 		WinnerTeam:      -1,
 		RoundWinnerTeam: -1,

--- a/internal/adapter/controller/SuecaWebController_test.go
+++ b/internal/adapter/controller/SuecaWebController_test.go
@@ -17,7 +17,7 @@ import (
 func mustSuecaOutputJSON(msg string) string {
 	out := &controller.SuecaWebOutput{
 		Players:         []*controller.SuecaWebOutputPlayer{},
-		CurrentTrick:    []*controller.SuecaWebOutputTrickCard{},
+		CurrentTrick:    []*controller.WebOutputTrickCard{},
 		PlayableIndices: []int{},
 		WinnerTeam:      -1,
 		RoundWinnerTeam: -1,

--- a/internal/adapter/controller/TarneebWebController.go
+++ b/internal/adapter/controller/TarneebWebController.go
@@ -39,12 +39,6 @@ type TarneebWebOutputPlayer struct {
 	TrickCount      int              `json:"trickCount"`
 }
 
-// TarneebWebOutputTrickCard トリック中の 1 枚
-type TarneebWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
 // TarneebWebOutputHint ヒント出力
 type TarneebWebOutputHint struct {
 	CardIndex *int   `json:"cardIndex,omitempty"`
@@ -62,23 +56,23 @@ type TarneebWebOutputConfig struct {
 
 // TarneebWebOutput Tarneeb Web アウトプット
 type TarneebWebOutput struct {
-	Players          []*TarneebWebOutputPlayer    `json:"players"`
-	TeamScores       []int                        `json:"teamScores"`
-	Phase            int                          `json:"phase"`
-	RoundNumber      int                          `json:"roundNumber"`
-	TrickNumber      int                          `json:"trickNumber"`
-	CurrentPlayerIdx int                          `json:"currentPlayerIdx"`
-	BidPlayerIdx     int                          `json:"bidPlayerIdx"`
-	BidWinnerIdx     int                          `json:"bidWinnerIdx"`
-	HighestBid       int                          `json:"highestBid"`
-	TrumpSuit        int                          `json:"trumpSuit"`
-	RedealCount      int                          `json:"redealCount"`
-	DealerIdx        int                          `json:"dealerIdx"`
-	CurrentTrick     []*TarneebWebOutputTrickCard `json:"currentTrick"`
-	GameEndFlag      bool                         `json:"gameEndFlag"`
-	WinnerTeam       int                          `json:"winnerTeam"`
-	LeadPlayerIdx    int                          `json:"leadPlayerIdx"`
-	Hint             *TarneebWebOutputHint        `json:"hint,omitempty"`
+	Players          []*TarneebWebOutputPlayer `json:"players"`
+	TeamScores       []int                     `json:"teamScores"`
+	Phase            int                       `json:"phase"`
+	RoundNumber      int                       `json:"roundNumber"`
+	TrickNumber      int                       `json:"trickNumber"`
+	CurrentPlayerIdx int                       `json:"currentPlayerIdx"`
+	BidPlayerIdx     int                       `json:"bidPlayerIdx"`
+	BidWinnerIdx     int                       `json:"bidWinnerIdx"`
+	HighestBid       int                       `json:"highestBid"`
+	TrumpSuit        int                       `json:"trumpSuit"`
+	RedealCount      int                       `json:"redealCount"`
+	DealerIdx        int                       `json:"dealerIdx"`
+	CurrentTrick     []*WebOutputTrickCard     `json:"currentTrick"`
+	GameEndFlag      bool                      `json:"gameEndFlag"`
+	WinnerTeam       int                       `json:"winnerTeam"`
+	LeadPlayerIdx    int                       `json:"leadPlayerIdx"`
+	Hint             *TarneebWebOutputHint     `json:"hint,omitempty"`
 	WebOutputBase
 	Config TarneebWebOutputConfig `json:"config"`
 }
@@ -110,7 +104,7 @@ func newTarneebDefaultOutput(msg string) *TarneebWebOutput {
 	return &TarneebWebOutput{
 		Players:       make([]*TarneebWebOutputPlayer, 0),
 		TeamScores:    make([]int, 0),
-		CurrentTrick:  make([]*TarneebWebOutputTrickCard, 0),
+		CurrentTrick:  make([]*WebOutputTrickCard, 0),
 		WinnerTeam:    -1,
 		BidWinnerIdx:  -1,
 		WebOutputBase: WebOutputBase{Message: msg},

--- a/internal/adapter/controller/TarneebWebController_test.go
+++ b/internal/adapter/controller/TarneebWebController_test.go
@@ -19,7 +19,7 @@ func mustTarneebOutputJSON(msg string) string {
 	out := &controller.TarneebWebOutput{
 		Players:       []*controller.TarneebWebOutputPlayer{},
 		TeamScores:    []int{},
-		CurrentTrick:  []*controller.TarneebWebOutputTrickCard{},
+		CurrentTrick:  []*controller.WebOutputTrickCard{},
 		WinnerTeam:    -1,
 		BidWinnerIdx:  -1,
 		WebOutputBase: controller.WebOutputBase{Message: msg},

--- a/internal/adapter/controller/TressetteWebController.go
+++ b/internal/adapter/controller/TressetteWebController.go
@@ -33,35 +33,23 @@ type TressetteWebOutputPlayer struct {
 	TeamID     int              `json:"teamId"`
 }
 
-// TressetteWebOutputTrickCard トリック中の1枚
-type TressetteWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
-// TressetteWebOutputHint ヒント出力
-type TressetteWebOutputHint struct {
-	CardIndices []int  `json:"cardIndices"`
-	Reason      string `json:"reason"`
-}
-
 // TressetteWebOutput トレセッテのWebアウトプット
 type TressetteWebOutput struct {
-	Players          []*TressetteWebOutputPlayer    `json:"players"`
-	Phase            int                            `json:"phase"`
-	RoundNumber      int                            `json:"roundNumber"`
-	TrickNumber      int                            `json:"trickNumber"`
-	CurrentPlayerIdx int                            `json:"currentPlayerIdx"`
-	CurrentTrick     []*TressetteWebOutputTrickCard `json:"currentTrick"`
-	LastTrick        []*TressetteWebOutputTrickCard `json:"lastTrick"`
-	LastTrickWinner  int                            `json:"lastTrickWinner"`
-	LeadPlayerIdx    int                            `json:"leadPlayerIdx"`
-	TeamScores       []int                          `json:"teamScores"`
-	TeamRoundThirds  []int                          `json:"teamRoundThirds"`
-	PlayableIndices  []int                          `json:"playableIndices"`
-	GameEndFlag      bool                           `json:"gameEndFlag"`
-	WinnerTeam       int                            `json:"winnerTeam"`
-	Hint             *TressetteWebOutputHint        `json:"hint,omitempty"`
+	Players          []*TressetteWebOutputPlayer `json:"players"`
+	Phase            int                         `json:"phase"`
+	RoundNumber      int                         `json:"roundNumber"`
+	TrickNumber      int                         `json:"trickNumber"`
+	CurrentPlayerIdx int                         `json:"currentPlayerIdx"`
+	CurrentTrick     []*WebOutputTrickCard       `json:"currentTrick"`
+	LastTrick        []*WebOutputTrickCard       `json:"lastTrick"`
+	LastTrickWinner  int                         `json:"lastTrickWinner"`
+	LeadPlayerIdx    int                         `json:"leadPlayerIdx"`
+	TeamScores       []int                       `json:"teamScores"`
+	TeamRoundThirds  []int                       `json:"teamRoundThirds"`
+	PlayableIndices  []int                       `json:"playableIndices"`
+	GameEndFlag      bool                        `json:"gameEndFlag"`
+	WinnerTeam       int                         `json:"winnerTeam"`
+	Hint             *WebOutputCardHint          `json:"hint,omitempty"`
 	WebOutputBase
 	Config TressetteWebOutputConfig `json:"config"`
 }
@@ -97,8 +85,8 @@ var NewTressetteWebController, NewTressetteWebControllerWithProvider = webContro
 func newTressetteDefaultOutput(msg string) *TressetteWebOutput {
 	return &TressetteWebOutput{
 		Players:         make([]*TressetteWebOutputPlayer, 0),
-		CurrentTrick:    make([]*TressetteWebOutputTrickCard, 0),
-		LastTrick:       make([]*TressetteWebOutputTrickCard, 0),
+		CurrentTrick:    make([]*WebOutputTrickCard, 0),
+		LastTrick:       make([]*WebOutputTrickCard, 0),
 		LastTrickWinner: -1,
 		TeamScores:      make([]int, 0),
 		TeamRoundThirds: make([]int, 0),

--- a/internal/adapter/controller/TressetteWebController_test.go
+++ b/internal/adapter/controller/TressetteWebController_test.go
@@ -17,8 +17,8 @@ import (
 func mustTressetteOutputJSON(msg string) string {
 	out := &controller.TressetteWebOutput{
 		Players:         []*controller.TressetteWebOutputPlayer{},
-		CurrentTrick:    []*controller.TressetteWebOutputTrickCard{},
-		LastTrick:       []*controller.TressetteWebOutputTrickCard{},
+		CurrentTrick:    []*controller.WebOutputTrickCard{},
+		LastTrick:       []*controller.WebOutputTrickCard{},
 		LastTrickWinner: -1,
 		TeamScores:      []int{},
 		TeamRoundThirds: []int{},

--- a/internal/adapter/controller/TrucoWebController.go
+++ b/internal/adapter/controller/TrucoWebController.go
@@ -30,12 +30,6 @@ type TrucoWebOutputPlayer struct {
 	TrickCount int              `json:"trickCount"`
 }
 
-// TrucoWebOutputTrickCard バサ中の1枚
-type TrucoWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
 // TrucoWebOutputHint ヒント出力
 type TrucoWebOutputHint struct {
 	Action    string `json:"action"`
@@ -45,28 +39,28 @@ type TrucoWebOutputHint struct {
 
 // TrucoWebOutput トゥルコWebアウトプット
 type TrucoWebOutput struct {
-	Players          []*TrucoWebOutputPlayer    `json:"players"`
-	Phase            int                        `json:"phase"`
-	HandNumber       int                        `json:"handNumber"`
-	TrickNumber      int                        `json:"trickNumber"`
-	CurrentPlayerIdx int                        `json:"currentPlayerIdx"`
-	ResponderIdx     int                        `json:"responderIdx"`
-	CurrentTrick     []*TrucoWebOutputTrickCard `json:"currentTrick"`
-	TrickResults     []int                      `json:"trickResults"`
-	LeadPlayerIdx    int                        `json:"leadPlayerIdx"`
-	ManoIdx          int                        `json:"manoIdx"`
-	DealerIdx        int                        `json:"dealerIdx"`
-	HandStake        int                        `json:"handStake"`
-	AcceptedLevel    int                        `json:"acceptedLevel"`
-	PendingLevel     int                        `json:"pendingLevel"`
-	TrucoCallerIdx   int                        `json:"trucoCallerIdx"`
-	CanDeclareTruco  bool                       `json:"canDeclareTruco"`
-	MatchTarget      int                        `json:"matchTarget"`
-	MatchPoints      []int                      `json:"matchPoints"`
-	HandWinnerIdx    int                        `json:"handWinnerIdx"`
-	GameEndFlag      bool                       `json:"gameEndFlag"`
-	WinnerIdx        int                        `json:"winnerIdx"`
-	Hint             *TrucoWebOutputHint        `json:"hint,omitempty"`
+	Players          []*TrucoWebOutputPlayer `json:"players"`
+	Phase            int                     `json:"phase"`
+	HandNumber       int                     `json:"handNumber"`
+	TrickNumber      int                     `json:"trickNumber"`
+	CurrentPlayerIdx int                     `json:"currentPlayerIdx"`
+	ResponderIdx     int                     `json:"responderIdx"`
+	CurrentTrick     []*WebOutputTrickCard   `json:"currentTrick"`
+	TrickResults     []int                   `json:"trickResults"`
+	LeadPlayerIdx    int                     `json:"leadPlayerIdx"`
+	ManoIdx          int                     `json:"manoIdx"`
+	DealerIdx        int                     `json:"dealerIdx"`
+	HandStake        int                     `json:"handStake"`
+	AcceptedLevel    int                     `json:"acceptedLevel"`
+	PendingLevel     int                     `json:"pendingLevel"`
+	TrucoCallerIdx   int                     `json:"trucoCallerIdx"`
+	CanDeclareTruco  bool                    `json:"canDeclareTruco"`
+	MatchTarget      int                     `json:"matchTarget"`
+	MatchPoints      []int                   `json:"matchPoints"`
+	HandWinnerIdx    int                     `json:"handWinnerIdx"`
+	GameEndFlag      bool                    `json:"gameEndFlag"`
+	WinnerIdx        int                     `json:"winnerIdx"`
+	Hint             *TrucoWebOutputHint     `json:"hint,omitempty"`
 	WebOutputBase
 	Config TrucoWebOutputConfig `json:"config"`
 }
@@ -105,7 +99,7 @@ var NewTrucoWebController, NewTrucoWebControllerWithProvider = webControllerPair
 func newTrucoDefaultOutput(msg string) *TrucoWebOutput {
 	return &TrucoWebOutput{
 		Players:       make([]*TrucoWebOutputPlayer, 0),
-		CurrentTrick:  make([]*TrucoWebOutputTrickCard, 0),
+		CurrentTrick:  make([]*WebOutputTrickCard, 0),
 		MatchPoints:   make([]int, 0),
 		WinnerIdx:     -1,
 		HandWinnerIdx: -1,

--- a/internal/adapter/controller/TrucoWebController_test.go
+++ b/internal/adapter/controller/TrucoWebController_test.go
@@ -20,7 +20,7 @@ import (
 func mustTrucoOutputJSON(msg string) string {
 	out := &controller.TrucoWebOutput{
 		Players:       []*controller.TrucoWebOutputPlayer{},
-		CurrentTrick:  []*controller.TrucoWebOutputTrickCard{},
+		CurrentTrick:  []*controller.WebOutputTrickCard{},
 		MatchPoints:   []int{},
 		WinnerIdx:     -1,
 		HandWinnerIdx: -1,

--- a/internal/adapter/controller/TuteWebController.go
+++ b/internal/adapter/controller/TuteWebController.go
@@ -37,12 +37,6 @@ type TuteWebOutputPlayer struct {
 	TeamScore  int              `json:"teamScore"`
 }
 
-// TuteWebOutputTrickCard トリック中の1枚
-type TuteWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
 // TuteWebOutputHint ヒント出力
 type TuteWebOutputHint struct {
 	CardIndices []int  `json:"cardIndices"`
@@ -52,15 +46,15 @@ type TuteWebOutputHint struct {
 
 // TuteWebOutput トゥーテのWebアウトプット
 type TuteWebOutput struct {
-	Players          []*TuteWebOutputPlayer    `json:"players"`
-	Phase            int                       `json:"phase"`
-	RoundNumber      int                       `json:"roundNumber"`
-	TrickNumber      int                       `json:"trickNumber"`
-	CurrentPlayerIdx int                       `json:"currentPlayerIdx"`
-	LeadPlayerIdx    int                       `json:"leadPlayerIdx"`
-	DealerIdx        int                       `json:"dealerIdx"`
-	TrumpSuit        int                       `json:"trumpSuit"`
-	CurrentTrick     []*TuteWebOutputTrickCard `json:"currentTrick"`
+	Players          []*TuteWebOutputPlayer `json:"players"`
+	Phase            int                    `json:"phase"`
+	RoundNumber      int                    `json:"roundNumber"`
+	TrickNumber      int                    `json:"trickNumber"`
+	CurrentPlayerIdx int                    `json:"currentPlayerIdx"`
+	LeadPlayerIdx    int                    `json:"leadPlayerIdx"`
+	DealerIdx        int                    `json:"dealerIdx"`
+	TrumpSuit        int                    `json:"trumpSuit"`
+	CurrentTrick     []*WebOutputTrickCard  `json:"currentTrick"`
 	// DeclaredSuits 結婚宣言済みスート (インデックス1-4が有効; 0は未使用)
 	DeclaredSuits      []bool                  `json:"declaredSuits"`
 	TeamScores         [domain.TuteTeamCnt]int `json:"teamScores"`
@@ -107,7 +101,7 @@ var NewTuteWebController, NewTuteWebControllerWithProvider = webControllerPair[u
 func newTuteDefaultOutput(msg string) *TuteWebOutput {
 	return &TuteWebOutput{
 		Players:         make([]*TuteWebOutputPlayer, 0),
-		CurrentTrick:    make([]*TuteWebOutputTrickCard, 0),
+		CurrentTrick:    make([]*WebOutputTrickCard, 0),
 		DeclaredSuits:   make([]bool, domain.CardDesignMax+1),
 		PlayableIndices: make([]int, 0),
 		WinnerTeam:      -1,

--- a/internal/adapter/controller/TuteWebController_test.go
+++ b/internal/adapter/controller/TuteWebController_test.go
@@ -17,7 +17,7 @@ import (
 func mustTuteOutputJSON(msg string) string {
 	out := &controller.TuteWebOutput{
 		Players:         []*controller.TuteWebOutputPlayer{},
-		CurrentTrick:    []*controller.TuteWebOutputTrickCard{},
+		CurrentTrick:    []*controller.WebOutputTrickCard{},
 		DeclaredSuits:   make([]bool, domain.CardDesignMax+1),
 		PlayableIndices: []int{},
 		WinnerTeam:      -1,

--- a/internal/adapter/controller/TwentyNineWebController.go
+++ b/internal/adapter/controller/TwentyNineWebController.go
@@ -38,18 +38,6 @@ type TwentyNineWebOutputPlayer struct {
 	IsDeclarer bool             `json:"isDeclarer"`
 }
 
-// TwentyNineWebOutputTrickCard トリック中の1枚
-type TwentyNineWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
-// TwentyNineWebOutputHint ヒント出力
-type TwentyNineWebOutputHint struct {
-	CardIndices []int  `json:"cardIndices"`
-	Reason      string `json:"reason"`
-}
-
 // TwentyNineWebOutput トゥエンティナイン (29) のWebアウトプット
 type TwentyNineWebOutput struct {
 	Players          []*TwentyNineWebOutputPlayer    `json:"players"`
@@ -64,7 +52,7 @@ type TwentyNineWebOutput struct {
 	TrumpSuit        int                             `json:"trumpSuit"`
 	TrumpRevealed    bool                            `json:"trumpRevealed"`
 	Bids             [domain.TwentyNinePlayerCnt]int `json:"bids"`
-	CurrentTrick     []*TwentyNineWebOutputTrickCard `json:"currentTrick"`
+	CurrentTrick     []*WebOutputTrickCard           `json:"currentTrick"`
 	TeamScores       [domain.TwentyNineTeamCnt]int   `json:"teamScores"`
 	RoundTeamPoints  [domain.TwentyNineTeamCnt]int   `json:"roundTeamPoints"`
 	PlayableIndices  []int                           `json:"playableIndices"`
@@ -72,7 +60,7 @@ type TwentyNineWebOutput struct {
 	WinnerTeam       int                             `json:"winnerTeam"`
 	IsHumanTurn      bool                            `json:"isHumanTurn"`
 	IsHumanBidTurn   bool                            `json:"isHumanBidTurn"`
-	Hint             *TwentyNineWebOutputHint        `json:"hint,omitempty"`
+	Hint             *WebOutputCardHint              `json:"hint,omitempty"`
 	WebOutputBase
 	Config TwentyNineWebOutputConfig `json:"config"`
 }
@@ -108,7 +96,7 @@ var NewTwentyNineWebController, NewTwentyNineWebControllerWithProvider = webCont
 func newTwentyNineDefaultOutput(msg string) *TwentyNineWebOutput {
 	return &TwentyNineWebOutput{
 		Players:         make([]*TwentyNineWebOutputPlayer, 0),
-		CurrentTrick:    make([]*TwentyNineWebOutputTrickCard, 0),
+		CurrentTrick:    make([]*WebOutputTrickCard, 0),
 		PlayableIndices: make([]int, 0),
 		DeclarerIdx:     -1,
 		WinnerTeam:      -1,

--- a/internal/adapter/controller/TwentyNineWebController_test.go
+++ b/internal/adapter/controller/TwentyNineWebController_test.go
@@ -17,7 +17,7 @@ import (
 func mustTwentyNineOutputJSON(msg string) string {
 	out := &controller.TwentyNineWebOutput{
 		Players:         []*controller.TwentyNineWebOutputPlayer{},
-		CurrentTrick:    []*controller.TwentyNineWebOutputTrickCard{},
+		CurrentTrick:    []*controller.WebOutputTrickCard{},
 		PlayableIndices: []int{},
 		DeclarerIdx:     -1,
 		WinnerTeam:      -1,

--- a/internal/adapter/controller/TwoTenJackWebController.go
+++ b/internal/adapter/controller/TwoTenJackWebController.go
@@ -34,12 +34,6 @@ type TwoTenJackWebOutputPlayer struct {
 	CapturedPoints  int              `json:"capturedPoints"`
 }
 
-// TwoTenJackWebOutputTrickCard トリック中の1枚
-type TwoTenJackWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
 // TwoTenJackWebOutputHint ヒント出力
 type TwoTenJackWebOutputHint struct {
 	CardIndex *int   `json:"cardIndex,omitempty"`
@@ -49,18 +43,18 @@ type TwoTenJackWebOutputHint struct {
 
 // TwoTenJackWebOutput ツーテンジャックWebアウトプット
 type TwoTenJackWebOutput struct {
-	Players          []*TwoTenJackWebOutputPlayer    `json:"players"`
-	Phase            int                             `json:"phase"`
-	RoundNumber      int                             `json:"roundNumber"`
-	TrickNumber      int                             `json:"trickNumber"`
-	CurrentPlayerIdx int                             `json:"currentPlayerIdx"`
-	DeclarerIdx      int                             `json:"declarerIdx"`
-	TrumpSuit        int                             `json:"trumpSuit"`
-	CurrentTrick     []*TwoTenJackWebOutputTrickCard `json:"currentTrick"`
-	GameEndFlag      bool                            `json:"gameEndFlag"`
-	WinnerTeam       int                             `json:"winnerTeam"`
-	LeadPlayerIdx    int                             `json:"leadPlayerIdx"`
-	Hint             *TwoTenJackWebOutputHint        `json:"hint,omitempty"`
+	Players          []*TwoTenJackWebOutputPlayer `json:"players"`
+	Phase            int                          `json:"phase"`
+	RoundNumber      int                          `json:"roundNumber"`
+	TrickNumber      int                          `json:"trickNumber"`
+	CurrentPlayerIdx int                          `json:"currentPlayerIdx"`
+	DeclarerIdx      int                          `json:"declarerIdx"`
+	TrumpSuit        int                          `json:"trumpSuit"`
+	CurrentTrick     []*WebOutputTrickCard        `json:"currentTrick"`
+	GameEndFlag      bool                         `json:"gameEndFlag"`
+	WinnerTeam       int                          `json:"winnerTeam"`
+	LeadPlayerIdx    int                          `json:"leadPlayerIdx"`
+	Hint             *TwoTenJackWebOutputHint     `json:"hint,omitempty"`
 	WebOutputBase
 	Config TwoTenJackWebOutputConfig `json:"config"`
 }
@@ -95,7 +89,7 @@ var NewTwoTenJackWebController, NewTwoTenJackWebControllerWithProvider = webCont
 func newTwoTenJackDefaultOutput(msg string) *TwoTenJackWebOutput {
 	return &TwoTenJackWebOutput{
 		Players:       make([]*TwoTenJackWebOutputPlayer, 0),
-		CurrentTrick:  make([]*TwoTenJackWebOutputTrickCard, 0),
+		CurrentTrick:  make([]*WebOutputTrickCard, 0),
 		WinnerTeam:    -1,
 		TrumpSuit:     -1,
 		WebOutputBase: WebOutputBase{Message: msg},

--- a/internal/adapter/controller/TwoTenJackWebController_test.go
+++ b/internal/adapter/controller/TwoTenJackWebController_test.go
@@ -17,7 +17,7 @@ import (
 func mustTwoTenJackOutputJSON(msg string) string {
 	out := &controller.TwoTenJackWebOutput{
 		Players:       []*controller.TwoTenJackWebOutputPlayer{},
-		CurrentTrick:  []*controller.TwoTenJackWebOutputTrickCard{},
+		CurrentTrick:  []*controller.WebOutputTrickCard{},
 		WinnerTeam:    -1,
 		TrumpSuit:     -1,
 		WebOutputBase: controller.WebOutputBase{Message: msg},

--- a/internal/adapter/controller/TysiacWebController.go
+++ b/internal/adapter/controller/TysiacWebController.go
@@ -38,18 +38,6 @@ type TysiacWebOutputPlayer struct {
 	IsDeclarer bool             `json:"isDeclarer"`
 }
 
-// TysiacWebOutputTrickCard トリック中の1枚
-type TysiacWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
-// TysiacWebOutputHint ヒント出力
-type TysiacWebOutputHint struct {
-	CardIndices []int  `json:"cardIndices"`
-	Reason      string `json:"reason"`
-}
-
 // TysiacWebOutput サウザンドのWebアウトプット
 type TysiacWebOutput struct {
 	Players          []*TysiacWebOutputPlayer    `json:"players"`
@@ -64,7 +52,7 @@ type TysiacWebOutput struct {
 	Contract         int                         `json:"contract"`
 	CurrentBid       int                         `json:"currentBid"`
 	TrumpSuit        int                         `json:"trumpSuit"`
-	CurrentTrick     []*TysiacWebOutputTrickCard `json:"currentTrick"`
+	CurrentTrick     []*WebOutputTrickCard       `json:"currentTrick"`
 	PlayerScores     [domain.TysiacPlayerCnt]int `json:"playerScores"`
 	RoundCardPoints  [domain.TysiacPlayerCnt]int `json:"roundCardPoints"`
 	RoundMarriage    [domain.TysiacPlayerCnt]int `json:"roundMarriage"`
@@ -73,7 +61,7 @@ type TysiacWebOutput struct {
 	GameEndFlag      bool                        `json:"gameEndFlag"`
 	WinnerPlayer     int                         `json:"winnerPlayer"`
 	IsHumanTurn      bool                        `json:"isHumanTurn"`
-	Hint             *TysiacWebOutputHint        `json:"hint,omitempty"`
+	Hint             *WebOutputCardHint          `json:"hint,omitempty"`
 	WebOutputBase
 	Config TysiacWebOutputConfig `json:"config"`
 }
@@ -109,7 +97,7 @@ var NewTysiacWebController, NewTysiacWebControllerWithProvider = webControllerPa
 func newTysiacDefaultOutput(msg string) *TysiacWebOutput {
 	return &TysiacWebOutput{
 		Players:         make([]*TysiacWebOutputPlayer, 0),
-		CurrentTrick:    make([]*TysiacWebOutputTrickCard, 0),
+		CurrentTrick:    make([]*WebOutputTrickCard, 0),
 		PlayableIndices: make([]int, 0),
 		DeclarerIdx:     -1,
 		LastTrickWinner: -1,

--- a/internal/adapter/controller/TysiacWebController_test.go
+++ b/internal/adapter/controller/TysiacWebController_test.go
@@ -17,7 +17,7 @@ import (
 func mustTysiacOutputJSON(msg string) string {
 	out := &controller.TysiacWebOutput{
 		Players:         []*controller.TysiacWebOutputPlayer{},
-		CurrentTrick:    []*controller.TysiacWebOutputTrickCard{},
+		CurrentTrick:    []*controller.WebOutputTrickCard{},
 		PlayableIndices: []int{},
 		DeclarerIdx:     -1,
 		LastTrickWinner: -1,

--- a/internal/adapter/controller/UltiWebController.go
+++ b/internal/adapter/controller/UltiWebController.go
@@ -43,18 +43,6 @@ type UltiWebOutputPlayer struct {
 	IsDeclarer bool             `json:"isDeclarer"`
 }
 
-// UltiWebOutputTrickCard トリック中の1枚
-type UltiWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
-// UltiWebOutputHint ヒント出力
-type UltiWebOutputHint struct {
-	CardIndices []int  `json:"cardIndices"`
-	Reason      string `json:"reason"`
-}
-
 // UltiWebOutput ウルティのWebアウトプット
 type UltiWebOutput struct {
 	Players          []*UltiWebOutputPlayer    `json:"players"`
@@ -70,7 +58,7 @@ type UltiWebOutput struct {
 	TalonCount       int                       `json:"talonCount"`
 	TalonTaken       bool                      `json:"talonTaken"`
 	DiscardCount     int                       `json:"discardCount"`
-	CurrentTrick     []*UltiWebOutputTrickCard `json:"currentTrick"`
+	CurrentTrick     []*WebOutputTrickCard     `json:"currentTrick"`
 	PlayerCoins      [domain.UltiPlayerCnt]int `json:"playerCoins"`
 	LastTrickWinner  int                       `json:"lastTrickWinner"`
 	Outcome          int                       `json:"outcome"`
@@ -80,7 +68,7 @@ type UltiWebOutput struct {
 	WinnerPlayer     int                       `json:"winnerPlayer"`
 	IsHumanTurn      bool                      `json:"isHumanTurn"`
 	IsHumanBidTurn   bool                      `json:"isHumanBidTurn"`
-	Hint             *UltiWebOutputHint        `json:"hint,omitempty"`
+	Hint             *WebOutputCardHint        `json:"hint,omitempty"`
 	WebOutputBase
 	Config UltiWebOutputConfig `json:"config"`
 }
@@ -132,7 +120,7 @@ var NewUltiWebController, NewUltiWebControllerWithProvider = webControllerPair[u
 func newUltiDefaultOutput(msg string) *UltiWebOutput {
 	return &UltiWebOutput{
 		Players:         make([]*UltiWebOutputPlayer, 0),
-		CurrentTrick:    make([]*UltiWebOutputTrickCard, 0),
+		CurrentTrick:    make([]*WebOutputTrickCard, 0),
 		PlayableIndices: make([]int, 0),
 		DeclarerIdx:     0,
 		TrumpSuit:       -1,

--- a/internal/adapter/controller/UltiWebController_test.go
+++ b/internal/adapter/controller/UltiWebController_test.go
@@ -17,7 +17,7 @@ import (
 func mustUltiOutputJSON(msg string) string {
 	out := &controller.UltiWebOutput{
 		Players:         []*controller.UltiWebOutputPlayer{},
-		CurrentTrick:    []*controller.UltiWebOutputTrickCard{},
+		CurrentTrick:    []*controller.WebOutputTrickCard{},
 		PlayableIndices: []int{},
 		TrumpSuit:       -1,
 		LastTrickWinner: -1,

--- a/internal/adapter/controller/WattenWebController.go
+++ b/internal/adapter/controller/WattenWebController.go
@@ -37,12 +37,6 @@ type WattenWebOutputPlayer struct {
 	TrickCount int              `json:"trickCount"`
 }
 
-// WattenWebOutputTrickCard トリック中の1枚
-type WattenWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
 // WattenWebOutputHint ヒント出力
 type WattenWebOutputHint struct {
 	Action    string `json:"action"`
@@ -54,29 +48,29 @@ type WattenWebOutputHint struct {
 
 // WattenWebOutput ヴァッテンWebアウトプット
 type WattenWebOutput struct {
-	Players          []*WattenWebOutputPlayer    `json:"players"`
-	Phase            int                         `json:"phase"`
-	RoundNumber      int                         `json:"roundNumber"`
-	TrickNumber      int                         `json:"trickNumber"`
-	CurrentPlayerIdx int                         `json:"currentPlayerIdx"`
-	DealerIdx        int                         `json:"dealerIdx"`
-	LeadPlayerIdx    int                         `json:"leadPlayerIdx"`
-	SchlagRank       int                         `json:"schlagRank"`
-	CriticalSuit     int                         `json:"criticalSuit"`
-	Stake            int                         `json:"stake"`
-	PendingStake     int                         `json:"pendingStake"`
-	RaiseCount       int                         `json:"raiseCount"`
-	RaiserTeam       int                         `json:"raiserTeam"`
-	ResponderIdx     int                         `json:"responderIdx"`
-	CanRaise         bool                        `json:"canRaise"`
-	CurrentTrick     []*WattenWebOutputTrickCard `json:"currentTrick"`
-	TeamScores       [2]int                      `json:"teamScores"`
-	TeamTricks       [2]int                      `json:"teamTricks"`
-	DealWinnerTeam   int                         `json:"dealWinnerTeam"`
-	GameEndFlag      bool                        `json:"gameEndFlag"`
-	WinnerTeam       int                         `json:"winnerTeam"`
-	Result           int                         `json:"result"`
-	Hint             *WattenWebOutputHint        `json:"hint,omitempty"`
+	Players          []*WattenWebOutputPlayer `json:"players"`
+	Phase            int                      `json:"phase"`
+	RoundNumber      int                      `json:"roundNumber"`
+	TrickNumber      int                      `json:"trickNumber"`
+	CurrentPlayerIdx int                      `json:"currentPlayerIdx"`
+	DealerIdx        int                      `json:"dealerIdx"`
+	LeadPlayerIdx    int                      `json:"leadPlayerIdx"`
+	SchlagRank       int                      `json:"schlagRank"`
+	CriticalSuit     int                      `json:"criticalSuit"`
+	Stake            int                      `json:"stake"`
+	PendingStake     int                      `json:"pendingStake"`
+	RaiseCount       int                      `json:"raiseCount"`
+	RaiserTeam       int                      `json:"raiserTeam"`
+	ResponderIdx     int                      `json:"responderIdx"`
+	CanRaise         bool                     `json:"canRaise"`
+	CurrentTrick     []*WebOutputTrickCard    `json:"currentTrick"`
+	TeamScores       [2]int                   `json:"teamScores"`
+	TeamTricks       [2]int                   `json:"teamTricks"`
+	DealWinnerTeam   int                      `json:"dealWinnerTeam"`
+	GameEndFlag      bool                     `json:"gameEndFlag"`
+	WinnerTeam       int                      `json:"winnerTeam"`
+	Result           int                      `json:"result"`
+	Hint             *WattenWebOutputHint     `json:"hint,omitempty"`
 	WebOutputBase
 	Config WattenWebOutputConfig `json:"config"`
 }
@@ -114,7 +108,7 @@ var NewWattenWebController, NewWattenWebControllerWithProvider = webControllerPa
 func newWattenDefaultOutput(msg string) *WattenWebOutput {
 	return &WattenWebOutput{
 		Players:        make([]*WattenWebOutputPlayer, 0),
-		CurrentTrick:   make([]*WattenWebOutputTrickCard, 0),
+		CurrentTrick:   make([]*WebOutputTrickCard, 0),
 		WinnerTeam:     -1,
 		RaiserTeam:     -1,
 		ResponderIdx:   -1,

--- a/internal/adapter/controller/WattenWebController_test.go
+++ b/internal/adapter/controller/WattenWebController_test.go
@@ -17,7 +17,7 @@ import (
 func mustWattenOutputJSON(msg string) string {
 	out := &controller.WattenWebOutput{
 		Players:        []*controller.WattenWebOutputPlayer{},
-		CurrentTrick:   []*controller.WattenWebOutputTrickCard{},
+		CurrentTrick:   []*controller.WebOutputTrickCard{},
 		WinnerTeam:     -1,
 		RaiserTeam:     -1,
 		ResponderIdx:   -1,

--- a/internal/adapter/controller/WhistWebController.go
+++ b/internal/adapter/controller/WhistWebController.go
@@ -33,12 +33,6 @@ type WhistWebOutputPlayer struct {
 	Team            int              `json:"team"`
 }
 
-// WhistWebOutputTrickCard トリック中の1枚
-type WhistWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
 // WhistWebOutputHint ヒント出力
 type WhistWebOutputHint struct {
 	CardIndex *int   `json:"cardIndex,omitempty"`
@@ -47,19 +41,19 @@ type WhistWebOutputHint struct {
 
 // WhistWebOutput ホイストWebアウトプット
 type WhistWebOutput struct {
-	Players          []*WhistWebOutputPlayer    `json:"players"`
-	Phase            int                        `json:"phase"`
-	RoundNumber      int                        `json:"roundNumber"`
-	TrickNumber      int                        `json:"trickNumber"`
-	CurrentPlayerIdx int                        `json:"currentPlayerIdx"`
-	CurrentTrick     []*WhistWebOutputTrickCard `json:"currentTrick"`
-	TrumpSuit        int                        `json:"trumpSuit"`
-	DealerIdx        int                        `json:"dealerIdx"`
-	TeamScores       [2]int                     `json:"teamScores"`
-	GameEndFlag      bool                       `json:"gameEndFlag"`
-	WinnerTeam       int                        `json:"winnerTeam"`
-	LeadPlayerIdx    int                        `json:"leadPlayerIdx"`
-	Hint             *WhistWebOutputHint        `json:"hint,omitempty"`
+	Players          []*WhistWebOutputPlayer `json:"players"`
+	Phase            int                     `json:"phase"`
+	RoundNumber      int                     `json:"roundNumber"`
+	TrickNumber      int                     `json:"trickNumber"`
+	CurrentPlayerIdx int                     `json:"currentPlayerIdx"`
+	CurrentTrick     []*WebOutputTrickCard   `json:"currentTrick"`
+	TrumpSuit        int                     `json:"trumpSuit"`
+	DealerIdx        int                     `json:"dealerIdx"`
+	TeamScores       [2]int                  `json:"teamScores"`
+	GameEndFlag      bool                    `json:"gameEndFlag"`
+	WinnerTeam       int                     `json:"winnerTeam"`
+	LeadPlayerIdx    int                     `json:"leadPlayerIdx"`
+	Hint             *WhistWebOutputHint     `json:"hint,omitempty"`
 	WebOutputBase
 	Config WhistWebOutputConfig `json:"config"`
 }
@@ -95,7 +89,7 @@ var NewWhistWebController, NewWhistWebControllerWithProvider = webControllerPair
 func newWhistDefaultOutput(msg string) *WhistWebOutput {
 	return &WhistWebOutput{
 		Players:       make([]*WhistWebOutputPlayer, 0),
-		CurrentTrick:  make([]*WhistWebOutputTrickCard, 0),
+		CurrentTrick:  make([]*WebOutputTrickCard, 0),
 		WinnerTeam:    -1,
 		WebOutputBase: WebOutputBase{Message: msg},
 	}

--- a/internal/adapter/controller/WhistWebController_test.go
+++ b/internal/adapter/controller/WhistWebController_test.go
@@ -20,7 +20,7 @@ import (
 func mustWhistOutputJSON(msg string) string {
 	out := &controller.WhistWebOutput{
 		Players:       []*controller.WhistWebOutputPlayer{},
-		CurrentTrick:  []*controller.WhistWebOutputTrickCard{},
+		CurrentTrick:  []*controller.WebOutputTrickCard{},
 		WinnerTeam:    -1,
 		WebOutputBase: controller.WebOutputBase{Message: msg},
 	}

--- a/internal/adapter/controller/WizardWebController.go
+++ b/internal/adapter/controller/WizardWebController.go
@@ -33,12 +33,6 @@ type WizardWebOutputPlayer struct {
 	TrickCount      int              `json:"trickCount"`
 }
 
-// WizardWebOutputTrickCard トリック中の1枚
-type WizardWebOutputTrickCard struct {
-	PlayerIdx int            `json:"playerIdx"`
-	Card      *WebOutputCard `json:"card"`
-}
-
 // WizardWebOutputHint ヒント出力
 type WizardWebOutputHint struct {
 	CardIndex *int   `json:"cardIndex,omitempty"`
@@ -48,23 +42,23 @@ type WizardWebOutputHint struct {
 
 // WizardWebOutput ウィザードWebアウトプット
 type WizardWebOutput struct {
-	Players          []*WizardWebOutputPlayer    `json:"players"`
-	Phase            int                         `json:"phase"`
-	RoundNumber      int                         `json:"roundNumber"`
-	TotalRounds      int                         `json:"totalRounds"`
-	HandSize         int                         `json:"handSize"`
-	TrickNumber      int                         `json:"trickNumber"`
-	CurrentPlayerIdx int                         `json:"currentPlayerIdx"`
-	BidPlayerIdx     int                         `json:"bidPlayerIdx"`
-	DealerIdx        int                         `json:"dealerIdx"`
-	TrumpCard        *WebOutputCard              `json:"trumpCard"`
-	TrumpSuit        int                         `json:"trumpSuit"`
-	RestrictedBid    int                         `json:"restrictedBid"`
-	CurrentTrick     []*WizardWebOutputTrickCard `json:"currentTrick"`
-	GameEndFlag      bool                        `json:"gameEndFlag"`
-	WinnerIdx        int                         `json:"winnerIdx"`
-	LeadPlayerIdx    int                         `json:"leadPlayerIdx"`
-	Hint             *WizardWebOutputHint        `json:"hint,omitempty"`
+	Players          []*WizardWebOutputPlayer `json:"players"`
+	Phase            int                      `json:"phase"`
+	RoundNumber      int                      `json:"roundNumber"`
+	TotalRounds      int                      `json:"totalRounds"`
+	HandSize         int                      `json:"handSize"`
+	TrickNumber      int                      `json:"trickNumber"`
+	CurrentPlayerIdx int                      `json:"currentPlayerIdx"`
+	BidPlayerIdx     int                      `json:"bidPlayerIdx"`
+	DealerIdx        int                      `json:"dealerIdx"`
+	TrumpCard        *WebOutputCard           `json:"trumpCard"`
+	TrumpSuit        int                      `json:"trumpSuit"`
+	RestrictedBid    int                      `json:"restrictedBid"`
+	CurrentTrick     []*WebOutputTrickCard    `json:"currentTrick"`
+	GameEndFlag      bool                     `json:"gameEndFlag"`
+	WinnerIdx        int                      `json:"winnerIdx"`
+	LeadPlayerIdx    int                      `json:"leadPlayerIdx"`
+	Hint             *WizardWebOutputHint     `json:"hint,omitempty"`
 	WebOutputBase
 	Config WizardWebOutputConfig `json:"config"`
 }
@@ -98,7 +92,7 @@ var NewWizardWebController, NewWizardWebControllerWithProvider = webControllerPa
 func newWizardDefaultOutput(msg string) *WizardWebOutput {
 	return &WizardWebOutput{
 		Players:       make([]*WizardWebOutputPlayer, 0),
-		CurrentTrick:  make([]*WizardWebOutputTrickCard, 0),
+		CurrentTrick:  make([]*WebOutputTrickCard, 0),
 		WinnerIdx:     -1,
 		TrumpSuit:     -1,
 		RestrictedBid: -1,

--- a/internal/adapter/controller/WizardWebController_test.go
+++ b/internal/adapter/controller/WizardWebController_test.go
@@ -17,7 +17,7 @@ import (
 func mustWizardOutputJSON(msg string) string {
 	out := &controller.WizardWebOutput{
 		Players:       []*controller.WizardWebOutputPlayer{},
-		CurrentTrick:  []*controller.WizardWebOutputTrickCard{},
+		CurrentTrick:  []*controller.WebOutputTrickCard{},
 		WinnerIdx:     -1,
 		TrumpSuit:     -1,
 		RestrictedBid: -1,

--- a/internal/adapter/controller/trick_web_output.go
+++ b/internal/adapter/controller/trick_web_output.go
@@ -1,0 +1,29 @@
+package controller
+
+// WebOutputTrickCard トリック中の1枚の共通Web出力。
+//
+// 60ゲームが完全に同一の構造体を各 *WebController.go で再宣言していたものを
+// 統合した（issue #4432、#4363 の adapter 層分）。json タグは移行前の各ゲームの
+// 型と同一（playerIdx / card）なので、**RESTレスポンスの形状は不変**であり、
+// フロントエンドの型定義・テスト・E2E は無変更で通る。
+//
+// Mighty は LeadDemandSuit / IsJokerLead を追加で持つ正当な別形状なので、
+// domain.TrickCard と同じ理由で MightyWebOutputTrickCard を維持する。
+type WebOutputTrickCard struct {
+	PlayerIdx int            `json:"playerIdx"`
+	Card      *WebOutputCard `json:"card"`
+}
+
+// WebOutputCardHint 手札のカードを指すヒントの共通Web出力。
+//
+// 22ゲームが同一形状で再宣言していたものを統合した。
+//
+// 注意: *WebOutputHint という名前の型は全部で115個あり、そのうちこの形状
+// （CardIndices + Reason）を共有するのは22個だけである。残り93個はソリティア
+// 系の移動ヒント（fromZone/fromCol/toZone/toCol）やビッドヒントなど本当に
+// 別物なので、統合してはならない。#4363 は「Hint 22型が同一形状」と読める
+// 書き方をしているが、実際には「115型のうち22型」である。
+type WebOutputCardHint struct {
+	CardIndices []int  `json:"cardIndices"`
+	Reason      string `json:"reason"`
+}

--- a/internal/adapter/controller/trick_web_output_test.go
+++ b/internal/adapter/controller/trick_web_output_test.go
@@ -1,0 +1,48 @@
+//go:build test
+
+package controller
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWebOutputTrickCard_WireShape pins the REST field names.
+//
+// 60 games' trick display now serializes through this one type (issue #4432),
+// each of which previously declared its own struct with these exact tags.
+// Renaming either would change the REST response for all 60 at once, and the
+// frontend reads `playerIdx` / `card` directly — so the failure would surface as
+// blank trick cards in the browser, not as a Go test failure.
+func TestWebOutputTrickCard_WireShape(t *testing.T) {
+	data, err := json.Marshal(&WebOutputTrickCard{
+		PlayerIdx: 2,
+		Card:      &WebOutputCard{Design: "SPADE", Value: 11},
+	})
+	require.NoError(t, err)
+
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(data, &raw))
+	assert.Len(t, raw, 2, "must serialize exactly playerIdx + card; got %s", data)
+	assert.Contains(t, raw, "playerIdx")
+	assert.Contains(t, raw, "card")
+}
+
+// TestWebOutputCardHint_WireShape pins the same contract for the shared hint.
+//
+// Only 22 of the 115 *WebOutputHint types share this shape; the rest are
+// genuinely different (solitaire zone/column moves, bid hints) and keep their
+// own declarations. See the type's doc comment.
+func TestWebOutputCardHint_WireShape(t *testing.T) {
+	data, err := json.Marshal(&WebOutputCardHint{CardIndices: []int{0, 3}, Reason: "lead"})
+	require.NoError(t, err)
+
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(data, &raw))
+	assert.Len(t, raw, 2, "must serialize exactly cardIndices + reason; got %s", data)
+	assert.Contains(t, raw, "cardIndices")
+	assert.Contains(t, raw, "reason")
+}

--- a/internal/adapter/presenter/AllFoursWebPresenter.go
+++ b/internal/adapter/presenter/AllFoursWebPresenter.go
@@ -40,7 +40,7 @@ func (p *AllFoursWebPresenter) buildBase(s interfaces.AllFoursGame) *controller.
 		PointLimit:    cfg.PointLimit,
 	}
 
-	resObj.CurrentTrick = p.buildTrickOutput(s.GetCurrentTrick())
+	resObj.CurrentTrick = trickCardsToOutput(s.GetCurrentTrick())
 	resObj.Players = p.buildPlayersOutput(s)
 	resObj.RoundBreakdown = p.buildRoundBreakdown(s)
 
@@ -54,13 +54,6 @@ func (p *AllFoursWebPresenter) buildBase(s interfaces.AllFoursGame) *controller.
 		resObj.ValidPlayIndices = make([]int, 0)
 	}
 	return resObj
-}
-
-// buildTrickOutput 現在のトリック情報を構築
-func (p *AllFoursWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.AllFoursWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.AllFoursWebOutputTrickCard {
-		return &controller.AllFoursWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
-	})
 }
 
 // buildPlayersOutput プレイヤー情報を構築

--- a/internal/adapter/presenter/BarbuWebPresenter.go
+++ b/internal/adapter/presenter/BarbuWebPresenter.go
@@ -69,8 +69,8 @@ func (bwp *BarbuWebPresenter) Output(bg interfaces.BarbuGame, lastErr error) str
 func newBarbuOutput(bg interfaces.BarbuGame) *controller.BarbuWebOutput {
 	resObj := new(controller.BarbuWebOutput)
 	resObj.Players = make([]*controller.BarbuWebOutputPlayer, 0)
-	resObj.CurrentTrick = make([]*controller.BarbuWebOutputTrickCard, 0)
-	resObj.LastTrick = make([]*controller.BarbuWebOutputTrickCard, 0)
+	resObj.CurrentTrick = make([]*controller.WebOutputTrickCard, 0)
+	resObj.LastTrick = make([]*controller.WebOutputTrickCard, 0)
 	resObj.TablePlaced = make([]int, 0)
 	resObj.DominoPlayable = make([]int, 0)
 	resObj.UsedContracts = make([]bool, 0)
@@ -95,13 +95,13 @@ func newBarbuOutput(bg interfaces.BarbuGame) *controller.BarbuWebOutput {
 }
 
 // barbuTrickToOutput はトリックを WebOutput 表現に変換する。
-func barbuTrickToOutput(trick []*domain.TrickCard) []*controller.BarbuWebOutputTrickCard {
-	out := make([]*controller.BarbuWebOutputTrickCard, 0, len(trick))
+func barbuTrickToOutput(trick []*domain.TrickCard) []*controller.WebOutputTrickCard {
+	out := make([]*controller.WebOutputTrickCard, 0, len(trick))
 	for _, tc := range trick {
 		if tc == nil {
 			continue
 		}
-		out = append(out, &controller.BarbuWebOutputTrickCard{
+		out = append(out, &controller.WebOutputTrickCard{
 			PlayerIdx: tc.PlayerIdx,
 			Card:      cardToOutput(tc.Card),
 		})

--- a/internal/adapter/presenter/BeloteWebPresenter.go
+++ b/internal/adapter/presenter/BeloteWebPresenter.go
@@ -47,15 +47,9 @@ func (p *BeloteWebPresenter) buildBase(b interfaces.BeloteGame) *controller.Belo
 		EnableBeloteRebelote: cfg.EnableBeloteRebelote,
 	}
 
-	resObj.CurrentTrick = p.buildTrickOutput(b.GetCurrentTrick())
+	resObj.CurrentTrick = trickCardsToOutput(b.GetCurrentTrick())
 	resObj.Players = p.buildPlayersOutput(b)
 	return resObj
-}
-
-func (p *BeloteWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.BeloteWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.BeloteWebOutputTrickCard {
-		return &controller.BeloteWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
-	})
 }
 
 func (p *BeloteWebPresenter) buildPlayersOutput(b interfaces.BeloteGame) []*controller.BeloteWebOutputPlayer {

--- a/internal/adapter/presenter/BeziqueWebPresenter.go
+++ b/internal/adapter/presenter/BeziqueWebPresenter.go
@@ -54,17 +54,10 @@ func (p *BeziqueWebPresenter) buildBase(b interfaces.BeziqueGame) *controller.Be
 		resObj.MatchScore[i] = b.GetMatchScore(i)
 	}
 
-	resObj.CurrentTrick = p.buildTrickOutput(b.GetCurrentTrick())
+	resObj.CurrentTrick = trickCardsToOutput(b.GetCurrentTrick())
 	resObj.Players = p.buildPlayersOutput(b)
 	resObj.AvailableMelds = p.buildMeldsOutput(b)
 	return resObj
-}
-
-// buildTrickOutput 現在のトリック情報を構築
-func (p *BeziqueWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.BeziqueWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.BeziqueWebOutputTrickCard {
-		return &controller.BeziqueWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
-	})
 }
 
 // buildPlayersOutput プレイヤー情報を構築

--- a/internal/adapter/presenter/BidWhistWebPresenter.go
+++ b/internal/adapter/presenter/BidWhistWebPresenter.go
@@ -48,7 +48,7 @@ func (p *BidWhistWebPresenter) buildBase(g interfaces.BidWhistGame) *controller.
 		TargetScore:   cfg.TargetScore,
 	}
 
-	resObj.CurrentTrick = p.buildTrickOutput(g.GetCurrentTrick())
+	resObj.CurrentTrick = trickCardsToOutput(g.GetCurrentTrick())
 	resObj.Players = p.buildPlayersOutput(g)
 	return resObj
 }
@@ -73,13 +73,6 @@ func bidWhistBidToOutput(b *domain.BidWhistBid) *controller.BidWhistWebOutputBid
 		Tricks:    b.Tricks,
 		Direction: b.Direction,
 	}
-}
-
-// buildTrickOutput 現在のトリック情報を構築
-func (p *BidWhistWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.BidWhistWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.BidWhistWebOutputTrickCard {
-		return &controller.BidWhistWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
-	})
 }
 
 // buildPlayersOutput プレイヤー情報を構築 (人間の手札のみ公開)

--- a/internal/adapter/presenter/BridgeWebPresenter.go
+++ b/internal/adapter/presenter/BridgeWebPresenter.go
@@ -54,7 +54,7 @@ func (p *BridgeWebPresenter) buildBase(b interfaces.BridgeGame) *controller.Brid
 	}
 
 	resObj.BidHistory = p.buildBidHistoryOutput(b.GetBidHistory())
-	resObj.CurrentTrick = p.buildTrickOutput(b.GetCurrentTrick())
+	resObj.CurrentTrick = trickCardsToOutput(b.GetCurrentTrick())
 	resObj.Players = p.buildPlayersOutput(b)
 	return resObj
 }
@@ -71,13 +71,6 @@ func (p *BridgeWebPresenter) buildBidHistoryOutput(history []*domain.BridgeBidEn
 		})
 	}
 	return out
-}
-
-// buildTrickOutput 現在のトリック情報を構築
-func (p *BridgeWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.BridgeWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.BridgeWebOutputTrickCard {
-		return &controller.BridgeWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
-	})
 }
 
 // buildPlayersOutput プレイヤー情報を構築

--- a/internal/adapter/presenter/BriscolaWebPresenter.go
+++ b/internal/adapter/presenter/BriscolaWebPresenter.go
@@ -39,16 +39,9 @@ func (p *BriscolaWebPresenter) buildBase(b interfaces.BriscolaGame) *controller.
 		CpuDifficulty: int(cfg.CpuDifficulty),
 	}
 
-	resObj.CurrentTrick = p.buildTrickOutput(b.GetCurrentTrick())
+	resObj.CurrentTrick = trickCardsToOutput(b.GetCurrentTrick())
 	resObj.Players = p.buildPlayersOutput(b)
 	return resObj
-}
-
-// buildTrickOutput 現在のトリック情報を構築
-func (p *BriscolaWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.BriscolaWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.BriscolaWebOutputTrickCard {
-		return &controller.BriscolaWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
-	})
 }
 
 // buildPlayersOutput プレイヤー情報を構築

--- a/internal/adapter/presenter/CalabresellaWebPresenter.go
+++ b/internal/adapter/presenter/CalabresellaWebPresenter.go
@@ -48,7 +48,7 @@ func (p *CalabresellaWebPresenter) buildBase(g interfaces.CalabresellaGame) *con
 		TargetPoints:  cfg.TargetPoints,
 	}
 
-	resObj.CurrentTrick = p.buildTrickOutput(g.GetCurrentTrick())
+	resObj.CurrentTrick = trickCardsToOutput(g.GetCurrentTrick())
 	resObj.Players = p.buildPlayersOutput(g)
 	resObj.Monte = p.buildMonteOutput(g)
 	return resObj
@@ -87,13 +87,6 @@ func (p *CalabresellaWebPresenter) playableIndices(g interfaces.CalabresellaGame
 		return make([]int, 0)
 	}
 	return idx
-}
-
-// buildTrickOutput 現在のトリック情報を構築
-func (p *CalabresellaWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.CalabresellaWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.CalabresellaWebOutputTrickCard {
-		return &controller.CalabresellaWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
-	})
 }
 
 // buildPlayersOutput プレイヤー情報を構築
@@ -169,7 +162,7 @@ func (p *CalabresellaWebPresenter) HintOutput(g interfaces.CalabresellaGame) str
 	hint := g.GetHint()
 	resObj := p.buildBase(g)
 	if hint != nil {
-		resObj.Hint = &controller.CalabresellaWebOutputHint{
+		resObj.Hint = &controller.WebOutputCardHint{
 			CardIndices: hint.CardIndices,
 			Reason:      hint.Reason,
 		}

--- a/internal/adapter/presenter/CallBreakWebPresenter.go
+++ b/internal/adapter/presenter/CallBreakWebPresenter.go
@@ -35,7 +35,7 @@ func (p *CallBreakWebPresenter) buildBase(cb interfaces.CallBreakGame) *controll
 		MaxRounds:     cfg.MaxRounds,
 	}
 
-	resObj.CurrentTrick = p.buildTrickOutput(cb.GetCurrentTrick())
+	resObj.CurrentTrick = trickCardsToOutput(cb.GetCurrentTrick())
 	resObj.Players = p.buildPlayersOutput(cb)
 
 	// Provide the human player's valid play indices so the frontend can grey out
@@ -50,13 +50,6 @@ func (p *CallBreakWebPresenter) buildBase(cb interfaces.CallBreakGame) *controll
 		resObj.ValidPlayIndices = make([]int, 0)
 	}
 	return resObj
-}
-
-// buildTrickOutput 現在のトリック情報を構築
-func (p *CallBreakWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.CallBreakWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.CallBreakWebOutputTrickCard {
-		return &controller.CallBreakWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
-	})
 }
 
 // buildPlayersOutput プレイヤー情報を構築

--- a/internal/adapter/presenter/CatchTenWebPresenter.go
+++ b/internal/adapter/presenter/CatchTenWebPresenter.go
@@ -36,16 +36,9 @@ func (p *CatchTenWebPresenter) buildBase(g interfaces.CatchTenGame) *controller.
 		PointLimit:    cfg.PointLimit,
 	}
 
-	resObj.CurrentTrick = p.buildTrickOutput(g.GetCurrentTrick())
+	resObj.CurrentTrick = trickCardsToOutput(g.GetCurrentTrick())
 	resObj.Players = p.buildPlayersOutput(g)
 	return resObj
-}
-
-// buildTrickOutput 現在のトリック情報を構築
-func (p *CatchTenWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.CatchTenWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.CatchTenWebOutputTrickCard {
-		return &controller.CatchTenWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
-	})
 }
 
 // buildPlayersOutput プレイヤー情報を構築

--- a/internal/adapter/presenter/CegoWebPresenter.go
+++ b/internal/adapter/presenter/CegoWebPresenter.go
@@ -112,7 +112,7 @@ func (p *CegoWebPresenter) buildBase(g interfaces.CegoGame) *controller.CegoWebO
 
 	// 場札 (Cego / blind) の中身は決して公開しない (伏せ札)。BlindCount のみを出力する。
 	resObj.Blind = make([]*controller.WebOutputCard, 0)
-	resObj.CurrentTrick = p.buildTrickOutput(g.GetCurrentTrick())
+	resObj.CurrentTrick = trickCardsToOutputWithFace(g.GetCurrentTrick(), cegoFace)
 	resObj.Players = p.buildPlayersOutput(g)
 	return resObj
 }
@@ -127,13 +127,6 @@ func (p *CegoWebPresenter) playableIndices(g interfaces.CegoGame) []int {
 		return make([]int, 0)
 	}
 	return idx
-}
-
-// buildTrickOutput 現在のトリック情報を構築
-func (p *CegoWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.CegoWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.CegoWebOutputTrickCard {
-		return &controller.CegoWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutputWithFace(tc.Card, cegoFace)}
-	})
 }
 
 // buildPlayersOutput プレイヤー情報を構築 (人間のみ手札を公開)。

--- a/internal/adapter/presenter/CinchWebPresenter.go
+++ b/internal/adapter/presenter/CinchWebPresenter.go
@@ -31,8 +31,8 @@ func (p *CinchWebPresenter) Output(g interfaces.CinchGame, lastErr error) string
 func (p *CinchWebPresenter) buildBase(g interfaces.CinchGame) *controller.CinchWebOutput {
 	resObj := new(controller.CinchWebOutput)
 	resObj.Players = make([]*controller.CinchWebOutputPlayer, 0)
-	resObj.CurrentTrick = make([]*controller.CinchWebOutputTrickCard, 0)
-	resObj.LastTrick = make([]*controller.CinchWebOutputTrickCard, 0)
+	resObj.CurrentTrick = make([]*controller.WebOutputTrickCard, 0)
+	resObj.LastTrick = make([]*controller.WebOutputTrickCard, 0)
 	resObj.PlayableIndices = make([]int, 0)
 	resObj.RoundWinners = make([]int, 0)
 
@@ -104,12 +104,12 @@ func (p *CinchWebPresenter) playableIndices(g interfaces.CinchGame) []int {
 }
 
 // cinchTrickToOutput はトリックを WebOutput 表現に変換する。
-func cinchTrickToOutput(trick []*domain.TrickCard) []*controller.CinchWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.CinchWebOutputTrickCard {
+func cinchTrickToOutput(trick []*domain.TrickCard) []*controller.WebOutputTrickCard {
+	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.WebOutputTrickCard {
 		if tc == nil {
 			return nil
 		}
-		return &controller.CinchWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
+		return &controller.WebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
 	})
 }
 

--- a/internal/adapter/presenter/CourtPieceWebPresenter.go
+++ b/internal/adapter/presenter/CourtPieceWebPresenter.go
@@ -43,16 +43,9 @@ func (p *CourtPieceWebPresenter) buildBase(t interfaces.CourtPieceGame) *control
 	}
 
 	resObj.TeamScores = []int{t.GetTeamScore(0), t.GetTeamScore(1)}
-	resObj.CurrentTrick = p.buildTrickOutput(t.GetCurrentTrick())
+	resObj.CurrentTrick = trickCardsToOutput(t.GetCurrentTrick())
 	resObj.Players = p.buildPlayersOutput(t)
 	return resObj
-}
-
-// buildTrickOutput 現在のトリック情報を構築
-func (p *CourtPieceWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.CourtPieceWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.CourtPieceWebOutputTrickCard {
-		return &controller.CourtPieceWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
-	})
 }
 
 // buildPlayersOutput プレイヤー情報を構築

--- a/internal/adapter/presenter/DoppelkopfWebPresenter.go
+++ b/internal/adapter/presenter/DoppelkopfWebPresenter.go
@@ -64,7 +64,7 @@ func (p *DoppelkopfWebPresenter) buildBase(g interfaces.DoppelkopfGame) *control
 		TargetChips:   cfg.TargetChips,
 	}
 
-	resObj.CurrentTrick = p.buildTrickOutput(g.GetCurrentTrick())
+	resObj.CurrentTrick = trickCardsToOutput(g.GetCurrentTrick())
 	resObj.Players = p.buildPlayersOutput(g)
 	return resObj
 }
@@ -90,13 +90,6 @@ func (p *DoppelkopfWebPresenter) playableIndices(g interfaces.DoppelkopfGame) []
 		return make([]int, 0)
 	}
 	return idx
-}
-
-// buildTrickOutput 現在のトリック情報を構築
-func (p *DoppelkopfWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.DoppelkopfWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.DoppelkopfWebOutputTrickCard {
-		return &controller.DoppelkopfWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
-	})
 }
 
 // buildPlayersOutput プレイヤー情報を構築
@@ -169,7 +162,7 @@ func (p *DoppelkopfWebPresenter) HintOutput(g interfaces.DoppelkopfGame) string 
 	hint := g.GetHint()
 	resObj := p.buildBase(g)
 	if hint != nil {
-		resObj.Hint = &controller.DoppelkopfWebOutputHint{
+		resObj.Hint = &controller.WebOutputCardHint{
 			CardIndices: hint.CardIndices,
 			Reason:      hint.Reason,
 		}

--- a/internal/adapter/presenter/EcarteWebPresenter.go
+++ b/internal/adapter/presenter/EcarteWebPresenter.go
@@ -54,17 +54,10 @@ func (p *EcarteWebPresenter) buildBase(b interfaces.EcarteGame) *controller.Ecar
 		resObj.MatchScore[i] = b.GetMatchScore(i)
 	}
 
-	resObj.CurrentTrick = p.buildTrickOutput(b.GetCurrentTrick())
+	resObj.CurrentTrick = trickCardsToOutput(b.GetCurrentTrick())
 	resObj.Players = p.buildPlayersOutput(b)
 	resObj.ValidPlays = p.buildValidPlays(b)
 	return resObj
-}
-
-// buildTrickOutput 現在のトリック情報を構築
-func (p *EcarteWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.EcarteWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.EcarteWebOutputTrickCard {
-		return &controller.EcarteWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
-	})
 }
 
 // buildPlayersOutput プレイヤー情報を構築

--- a/internal/adapter/presenter/EuchreWebPresenter.go
+++ b/internal/adapter/presenter/EuchreWebPresenter.go
@@ -46,16 +46,9 @@ func (p *EuchreWebPresenter) buildBase(e interfaces.EuchreGame) *controller.Euch
 		PointLimit:    cfg.PointLimit,
 	}
 
-	resObj.CurrentTrick = p.buildTrickOutput(e.GetCurrentTrick())
+	resObj.CurrentTrick = trickCardsToOutput(e.GetCurrentTrick())
 	resObj.Players = p.buildPlayersOutput(e)
 	return resObj
-}
-
-// buildTrickOutput 現在のトリック情報を構築
-func (p *EuchreWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.EuchreWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.EuchreWebOutputTrickCard {
-		return &controller.EuchreWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
-	})
 }
 
 // buildPlayersOutput プレイヤー情報を構築

--- a/internal/adapter/presenter/FiveHundredWebPresenter.go
+++ b/internal/adapter/presenter/FiveHundredWebPresenter.go
@@ -49,7 +49,7 @@ func (p *FiveHundredWebPresenter) buildBase(g interfaces.FiveHundredGame) *contr
 		TargetScore:   cfg.TargetScore,
 	}
 
-	resObj.CurrentTrick = p.buildTrickOutput(g.GetCurrentTrick())
+	resObj.CurrentTrick = trickCardsToOutput(g.GetCurrentTrick())
 	resObj.Players = p.buildPlayersOutput(g)
 	return resObj
 }
@@ -65,13 +65,6 @@ func bidToOutput(b *domain.FiveHundredBid) *controller.FiveHundredWebOutputBid {
 		Suit:   b.Suit,
 		Value:  b.Value(),
 	}
-}
-
-// buildTrickOutput 現在のトリック情報を構築
-func (p *FiveHundredWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.FiveHundredWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.FiveHundredWebOutputTrickCard {
-		return &controller.FiveHundredWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
-	})
 }
 
 // buildPlayersOutput プレイヤー情報を構築。オープンミゼールの落札者は手札を公開する。

--- a/internal/adapter/presenter/FortyFivesWebPresenter.go
+++ b/internal/adapter/presenter/FortyFivesWebPresenter.go
@@ -48,7 +48,7 @@ func (p *FortyFivesWebPresenter) buildBase(g interfaces.FortyFivesGame) *control
 		TargetPoints:  cfg.TargetPoints,
 	}
 
-	resObj.CurrentTrick = p.buildTrickOutput(g.GetCurrentTrick())
+	resObj.CurrentTrick = trickCardsToOutput(g.GetCurrentTrick())
 	resObj.Players = p.buildPlayersOutput(g)
 	return resObj
 }
@@ -73,13 +73,6 @@ func (p *FortyFivesWebPresenter) playableIndices(g interfaces.FortyFivesGame) []
 		return make([]int, 0)
 	}
 	return idx
-}
-
-// buildTrickOutput 現在のトリック情報を構築
-func (p *FortyFivesWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.FortyFivesWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.FortyFivesWebOutputTrickCard {
-		return &controller.FortyFivesWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
-	})
 }
 
 // buildPlayersOutput プレイヤー情報を構築
@@ -152,7 +145,7 @@ func (p *FortyFivesWebPresenter) HintOutput(g interfaces.FortyFivesGame) string 
 	hint := g.GetHint()
 	resObj := p.buildBase(g)
 	if hint != nil {
-		resObj.Hint = &controller.FortyFivesWebOutputHint{
+		resObj.Hint = &controller.WebOutputCardHint{
 			CardIndices: hint.CardIndices,
 			Reason:      hint.Reason,
 		}

--- a/internal/adapter/presenter/FrenchTarotWebPresenter.go
+++ b/internal/adapter/presenter/FrenchTarotWebPresenter.go
@@ -110,7 +110,7 @@ func (p *FrenchTarotWebPresenter) buildBase(g interfaces.FrenchTarotGame) *contr
 	}
 
 	resObj.Chien = p.buildChienOutput(g)
-	resObj.CurrentTrick = p.buildTrickOutput(g.GetCurrentTrick())
+	resObj.CurrentTrick = trickCardsToOutputWithFace(g.GetCurrentTrick(), frenchTarotFace)
 	resObj.Players = p.buildPlayersOutput(g)
 	return resObj
 }
@@ -138,13 +138,6 @@ func (p *FrenchTarotWebPresenter) buildChienOutput(g interfaces.FrenchTarotGame)
 		out = append(out, cardToOutputWithFace(c, frenchTarotFace))
 	}
 	return out
-}
-
-// buildTrickOutput 現在のトリック情報を構築
-func (p *FrenchTarotWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.FrenchTarotWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.FrenchTarotWebOutputTrickCard {
-		return &controller.FrenchTarotWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutputWithFace(tc.Card, frenchTarotFace)}
-	})
 }
 
 // buildPlayersOutput プレイヤー情報を構築 (人間のみ手札を公開)

--- a/internal/adapter/presenter/GaigelWebPresenter.go
+++ b/internal/adapter/presenter/GaigelWebPresenter.go
@@ -48,15 +48,9 @@ func (p *GaigelWebPresenter) buildBase(g interfaces.GaigelGame) *controller.Gaig
 		TargetScore:   cfg.TargetScore,
 	}
 
-	resObj.CurrentTrick = p.buildTrickOutput(g.GetCurrentTrick())
+	resObj.CurrentTrick = trickCardsToOutput(g.GetCurrentTrick())
 	resObj.Players = p.buildPlayersOutput(g)
 	return resObj
-}
-
-func (p *GaigelWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.GaigelWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.GaigelWebOutputTrickCard {
-		return &controller.GaigelWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
-	})
 }
 
 func (p *GaigelWebPresenter) buildPlayersOutput(g interfaces.GaigelGame) []*controller.GaigelWebOutputPlayer {

--- a/internal/adapter/presenter/GongZhuWebPresenter.go
+++ b/internal/adapter/presenter/GongZhuWebPresenter.go
@@ -43,7 +43,7 @@ func (p *GongZhuWebPresenter) buildBase(g interfaces.GongZhuGame) *controller.Go
 		PointLimit:    cfg.PointLimit,
 	}
 
-	resObj.CurrentTrick = p.buildTrickOutput(g.GetCurrentTrick())
+	resObj.CurrentTrick = trickCardsToOutput(g.GetCurrentTrick())
 	resObj.Players = p.buildPlayersOutput(g)
 	return resObj
 }
@@ -60,13 +60,6 @@ func (p *GongZhuWebPresenter) exposableIndices(g interfaces.GongZhuGame) []int {
 		}
 	}
 	return make([]int, 0)
-}
-
-// buildTrickOutput 現在のトリック情報を構築
-func (p *GongZhuWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.GongZhuWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.GongZhuWebOutputTrickCard {
-		return &controller.GongZhuWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
-	})
 }
 
 // buildPlayersOutput プレイヤー情報を構築
@@ -129,7 +122,7 @@ func (p *GongZhuWebPresenter) HintOutput(g interfaces.GongZhuGame) string {
 	hint := g.GetHint()
 	resObj := p.buildBase(g)
 	if hint != nil {
-		resObj.Hint = &controller.GongZhuWebOutputHint{
+		resObj.Hint = &controller.WebOutputCardHint{
 			CardIndices: hint.CardIndices,
 			Reason:      hint.Reason,
 		}

--- a/internal/adapter/presenter/HeartsWebPresenter.go
+++ b/internal/adapter/presenter/HeartsWebPresenter.go
@@ -39,16 +39,9 @@ func (p *HeartsWebPresenter) buildBase(h interfaces.HeartsGame) *controller.Hear
 		OmnibusJD:     cfg.OmnibusJD,
 	}
 
-	resObj.CurrentTrick = p.buildTrickOutput(h.GetCurrentTrick())
+	resObj.CurrentTrick = trickCardsToOutput(h.GetCurrentTrick())
 	resObj.Players = p.buildPlayersOutput(h)
 	return resObj
-}
-
-// buildTrickOutput 現在のトリック情報を構築
-func (p *HeartsWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.HeartsWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.HeartsWebOutputTrickCard {
-		return &controller.HeartsWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
-	})
 }
 
 // buildPlayersOutput プレイヤー情報を構築
@@ -140,7 +133,7 @@ func (p *HeartsWebPresenter) HintOutput(h interfaces.HeartsGame) string {
 	hint := h.GetHint()
 	resObj := p.buildBase(h)
 	if hint != nil {
-		resObj.Hint = &controller.HeartsWebOutputHint{
+		resObj.Hint = &controller.WebOutputCardHint{
 			CardIndices: hint.CardIndices,
 			Reason:      hint.Reason,
 		}

--- a/internal/adapter/presenter/JassWebPresenter.go
+++ b/internal/adapter/presenter/JassWebPresenter.go
@@ -49,7 +49,7 @@ func (p *JassWebPresenter) buildBase(g interfaces.JassGame) *controller.JassWebO
 		EnableWeis:     cfg.EnableWeis,
 	}
 
-	resObj.CurrentTrick = p.buildTrickOutput(g.GetCurrentTrick())
+	resObj.CurrentTrick = trickCardsToOutput(g.GetCurrentTrick())
 	resObj.LastTrick, resObj.LastTrickWinner = p.buildLastTrickOutput(g)
 	resObj.Players = p.buildPlayersOutput(g)
 	return resObj
@@ -62,8 +62,8 @@ func (p *JassWebPresenter) buildBase(g interfaces.JassGame) *controller.JassWebO
 // プレイ中（この局にまだ確定済みトリックが無い）は空スライスと -1 を返す。
 // アクションログはゲーム全体で累積されるため、フェーズガードにより前ラウンドの
 // トリックを誤って表示しないようにする。
-func (p *JassWebPresenter) buildLastTrickOutput(g interfaces.JassGame) ([]*controller.JassWebOutputTrickCard, int) {
-	empty := make([]*controller.JassWebOutputTrickCard, 0)
+func (p *JassWebPresenter) buildLastTrickOutput(g interfaces.JassGame) ([]*controller.WebOutputTrickCard, int) {
+	empty := make([]*controller.WebOutputTrickCard, 0)
 	switch g.GetPhase() {
 	case domain.JassPhaseBidTrump, domain.JassPhaseBidPartner:
 		// 新ラウンドのビッド中は当ラウンドの確定済みトリックが無いため空を返す。
@@ -99,20 +99,14 @@ func (p *JassWebPresenter) buildLastTrickOutput(g interfaces.JassGame) ([]*contr
 	}
 	plays = plays[len(plays)-domain.JassPlayerCnt:]
 
-	out := make([]*controller.JassWebOutputTrickCard, 0, len(plays))
+	out := make([]*controller.WebOutputTrickCard, 0, len(plays))
 	for _, e := range plays {
-		out = append(out, &controller.JassWebOutputTrickCard{
+		out = append(out, &controller.WebOutputTrickCard{
 			PlayerIdx: e.PlayerIdx,
 			Card:      cardToOutput(e.Cards[0]),
 		})
 	}
 	return out, log[winIdx].PlayerIdx
-}
-
-func (p *JassWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.JassWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.JassWebOutputTrickCard {
-		return &controller.JassWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
-	})
 }
 
 func (p *JassWebPresenter) buildPlayersOutput(g interfaces.JassGame) []*controller.JassWebOutputPlayer {

--- a/internal/adapter/presenter/KingWebPresenter.go
+++ b/internal/adapter/presenter/KingWebPresenter.go
@@ -35,8 +35,8 @@ func (kwp *KingWebPresenter) Output(kg interfaces.KingGame, lastErr error) strin
 func (kwp *KingWebPresenter) buildBase(kg interfaces.KingGame) *controller.KingWebOutput {
 	resObj := new(controller.KingWebOutput)
 	resObj.Players = make([]*controller.KingWebOutputPlayer, 0)
-	resObj.CurrentTrick = make([]*controller.KingWebOutputTrickCard, 0)
-	resObj.LastTrick = make([]*controller.KingWebOutputTrickCard, 0)
+	resObj.CurrentTrick = make([]*controller.WebOutputTrickCard, 0)
+	resObj.LastTrick = make([]*controller.WebOutputTrickCard, 0)
 	resObj.UsedContracts = make([]bool, 0)
 	resObj.PlayableIndices = make([]int, 0)
 	resObj.RoundWinners = make([]int, 0)
@@ -101,12 +101,12 @@ func (kwp *KingWebPresenter) playableIndices(kg interfaces.KingGame) []int {
 }
 
 // kingTrickToOutput はトリックを WebOutput 表現に変換する。
-func kingTrickToOutput(trick []*domain.TrickCard) []*controller.KingWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.KingWebOutputTrickCard {
+func kingTrickToOutput(trick []*domain.TrickCard) []*controller.WebOutputTrickCard {
+	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.WebOutputTrickCard {
 		if tc == nil {
 			return nil
 		}
-		return &controller.KingWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
+		return &controller.WebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
 	})
 }
 
@@ -151,7 +151,7 @@ func (kwp *KingWebPresenter) buildResultMessage(kg interfaces.KingGame) string {
 func (kwp *KingWebPresenter) HintOutput(kg interfaces.KingGame) string {
 	resObj := kwp.buildBase(kg)
 	if hint := kg.GetHint(); hint != nil {
-		resObj.Hint = &controller.KingWebOutputHint{
+		resObj.Hint = &controller.WebOutputCardHint{
 			CardIndices: hint.CardIndices,
 			Reason:      hint.Reason,
 		}

--- a/internal/adapter/presenter/KlaverjasWebPresenter.go
+++ b/internal/adapter/presenter/KlaverjasWebPresenter.go
@@ -45,7 +45,7 @@ func (p *KlaverjasWebPresenter) buildBase(g interfaces.KlaverjasGame) *controlle
 		TargetPoints:  cfg.TargetPoints,
 	}
 
-	resObj.CurrentTrick = p.buildTrickOutput(g.GetCurrentTrick())
+	resObj.CurrentTrick = trickCardsToOutput(g.GetCurrentTrick())
 	resObj.Players = p.buildPlayersOutput(g)
 	return resObj
 }
@@ -60,13 +60,6 @@ func (p *KlaverjasWebPresenter) playableIndices(g interfaces.KlaverjasGame) []in
 		return make([]int, 0)
 	}
 	return idx
-}
-
-// buildTrickOutput 現在のトリック情報を構築
-func (p *KlaverjasWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.KlaverjasWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.KlaverjasWebOutputTrickCard {
-		return &controller.KlaverjasWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
-	})
 }
 
 // buildPlayersOutput プレイヤー情報を構築
@@ -135,7 +128,7 @@ func (p *KlaverjasWebPresenter) HintOutput(g interfaces.KlaverjasGame) string {
 	hint := g.GetHint()
 	resObj := p.buildBase(g)
 	if hint != nil {
-		resObj.Hint = &controller.KlaverjasWebOutputHint{
+		resObj.Hint = &controller.WebOutputCardHint{
 			CardIndices: hint.CardIndices,
 			Reason:      hint.Reason,
 		}

--- a/internal/adapter/presenter/KnockoutWhistWebPresenter.go
+++ b/internal/adapter/presenter/KnockoutWhistWebPresenter.go
@@ -44,7 +44,7 @@ func (p *KnockoutWhistWebPresenter) buildBase(g interfaces.KnockoutWhistGame) *c
 		CpuDifficulty: int(cfg.CpuDifficulty),
 	}
 
-	resObj.CurrentTrick = p.buildTrickOutput(g.GetCurrentTrick())
+	resObj.CurrentTrick = trickCardsToOutput(g.GetCurrentTrick())
 	resObj.Players = p.buildPlayersOutput(g)
 	return resObj
 }
@@ -59,13 +59,6 @@ func (p *KnockoutWhistWebPresenter) playableIndices(g interfaces.KnockoutWhistGa
 		return make([]int, 0)
 	}
 	return idx
-}
-
-// buildTrickOutput 現在のトリック情報を構築
-func (p *KnockoutWhistWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.KnockoutWhistWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.KnockoutWhistWebOutputTrickCard {
-		return &controller.KnockoutWhistWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
-	})
 }
 
 // buildPlayersOutput プレイヤー情報を構築
@@ -134,7 +127,7 @@ func (p *KnockoutWhistWebPresenter) HintOutput(g interfaces.KnockoutWhistGame) s
 	hint := g.GetHint()
 	resObj := p.buildBase(g)
 	if hint != nil {
-		resObj.Hint = &controller.KnockoutWhistWebOutputHint{
+		resObj.Hint = &controller.WebOutputCardHint{
 			CardIndices: hint.CardIndices,
 			Reason:      hint.Reason,
 		}

--- a/internal/adapter/presenter/KoenigrufenWebPresenter.go
+++ b/internal/adapter/presenter/KoenigrufenWebPresenter.go
@@ -114,7 +114,7 @@ func (p *KoenigrufenWebPresenter) buildBase(g interfaces.KoenigrufenGame) *contr
 	}
 
 	resObj.Talon = p.buildTalonOutput(g)
-	resObj.CurrentTrick = p.buildTrickOutput(g.GetCurrentTrick())
+	resObj.CurrentTrick = trickCardsToOutputWithFace(g.GetCurrentTrick(), koenigrufenFace)
 	resObj.Players = p.buildPlayersOutput(g)
 	return resObj
 }
@@ -151,13 +151,6 @@ func (p *KoenigrufenWebPresenter) buildTalonOutput(g interfaces.KoenigrufenGame)
 		out = append(out, cardToOutputWithFace(c, koenigrufenFace))
 	}
 	return out
-}
-
-// buildTrickOutput 現在のトリック情報を構築
-func (p *KoenigrufenWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.KoenigrufenWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.KoenigrufenWebOutputTrickCard {
-		return &controller.KoenigrufenWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutputWithFace(tc.Card, koenigrufenFace)}
-	})
 }
 
 // buildPlayersOutput プレイヤー情報を構築 (人間のみ手札を公開)。IsPartner は partnerRevealed=true

--- a/internal/adapter/presenter/LooWebPresenter.go
+++ b/internal/adapter/presenter/LooWebPresenter.go
@@ -31,8 +31,8 @@ func (p *LooWebPresenter) Output(g interfaces.LooGame, lastErr error) string {
 func (p *LooWebPresenter) buildBase(g interfaces.LooGame) *controller.LooWebOutput {
 	resObj := new(controller.LooWebOutput)
 	resObj.Players = make([]*controller.LooWebOutputPlayer, 0)
-	resObj.CurrentTrick = make([]*controller.LooWebOutputTrickCard, 0)
-	resObj.LastTrick = make([]*controller.LooWebOutputTrickCard, 0)
+	resObj.CurrentTrick = make([]*controller.WebOutputTrickCard, 0)
+	resObj.LastTrick = make([]*controller.WebOutputTrickCard, 0)
 	resObj.PlayableIndices = make([]int, 0)
 
 	resObj.Phase = int(g.GetPhase())
@@ -106,12 +106,12 @@ func (p *LooWebPresenter) playableIndices(g interfaces.LooGame) []int {
 }
 
 // looTrickToOutput はトリックを WebOutput 表現に変換する。
-func looTrickToOutput(trick []*domain.TrickCard) []*controller.LooWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.LooWebOutputTrickCard {
+func looTrickToOutput(trick []*domain.TrickCard) []*controller.WebOutputTrickCard {
+	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.WebOutputTrickCard {
 		if tc == nil {
 			return nil
 		}
-		return &controller.LooWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
+		return &controller.WebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
 	})
 }
 

--- a/internal/adapter/presenter/ManilleWebPresenter.go
+++ b/internal/adapter/presenter/ManilleWebPresenter.go
@@ -44,7 +44,7 @@ func (p *ManilleWebPresenter) buildBase(g interfaces.ManilleGame) *controller.Ma
 		TargetPoints:  cfg.TargetPoints,
 	}
 
-	resObj.CurrentTrick = p.buildTrickOutput(g.GetCurrentTrick())
+	resObj.CurrentTrick = trickCardsToOutput(g.GetCurrentTrick())
 	resObj.Players = p.buildPlayersOutput(g)
 	return resObj
 }
@@ -59,13 +59,6 @@ func (p *ManilleWebPresenter) playableIndices(g interfaces.ManilleGame) []int {
 		return make([]int, 0)
 	}
 	return idx
-}
-
-// buildTrickOutput 現在のトリック情報を構築
-func (p *ManilleWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.ManilleWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.ManilleWebOutputTrickCard {
-		return &controller.ManilleWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
-	})
 }
 
 // buildPlayersOutput プレイヤー情報を構築
@@ -134,7 +127,7 @@ func (p *ManilleWebPresenter) HintOutput(g interfaces.ManilleGame) string {
 	hint := g.GetHint()
 	resObj := p.buildBase(g)
 	if hint != nil {
-		resObj.Hint = &controller.ManilleWebOutputHint{
+		resObj.Hint = &controller.WebOutputCardHint{
 			CardIndices: hint.CardIndices,
 			Reason:      hint.Reason,
 		}

--- a/internal/adapter/presenter/MariasWebPresenter.go
+++ b/internal/adapter/presenter/MariasWebPresenter.go
@@ -47,7 +47,7 @@ func (p *MariasWebPresenter) buildBase(g interfaces.MariasGame) *controller.Mari
 		TargetPoints:  cfg.TargetPoints,
 	}
 
-	resObj.CurrentTrick = p.buildTrickOutput(g.GetCurrentTrick())
+	resObj.CurrentTrick = trickCardsToOutput(g.GetCurrentTrick())
 	resObj.Players = p.buildPlayersOutput(g)
 	return resObj
 }
@@ -62,13 +62,6 @@ func (p *MariasWebPresenter) playableIndices(g interfaces.MariasGame) []int {
 		return make([]int, 0)
 	}
 	return idx
-}
-
-// buildTrickOutput 現在のトリック情報を構築
-func (p *MariasWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.MariasWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.MariasWebOutputTrickCard {
-		return &controller.MariasWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
-	})
 }
 
 // buildPlayersOutput プレイヤー情報を構築
@@ -138,7 +131,7 @@ func (p *MariasWebPresenter) HintOutput(g interfaces.MariasGame) string {
 	hint := g.GetHint()
 	resObj := p.buildBase(g)
 	if hint != nil {
-		resObj.Hint = &controller.MariasWebOutputHint{
+		resObj.Hint = &controller.WebOutputCardHint{
 			CardIndices: hint.CardIndices,
 			Reason:      hint.Reason,
 		}

--- a/internal/adapter/presenter/MightyWebPresenter.go
+++ b/internal/adapter/presenter/MightyWebPresenter.go
@@ -66,7 +66,10 @@ func (p *MightyWebPresenter) buildBaseOutput(m interfaces.MightyGame) *controlle
 	return resObj
 }
 
-// buildTrickOutput 現在のトリック情報を構築
+// buildTrickOutput 現在のトリック情報を構築。
+//
+// 共有の trickCardsToOutput に寄せられない: Mighty は domain / controller とも
+// IsJokerLead と LeadDemandSuit を追加で持つ正当な別形状（#4363）。
 func (p *MightyWebPresenter) buildTrickOutput(trick []*domain.MightyTrickCard) []*controller.MightyWebOutputTrickCard {
 	return buildTrickCards(trick, func(tc *domain.MightyTrickCard) *controller.MightyWebOutputTrickCard {
 		out := &controller.MightyWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}

--- a/internal/adapter/presenter/NapWebPresenter.go
+++ b/internal/adapter/presenter/NapWebPresenter.go
@@ -48,7 +48,7 @@ func (p *NapWebPresenter) buildBase(g interfaces.NapGame) *controller.NapWebOutp
 		TargetPoints:  cfg.TargetPoints,
 	}
 
-	resObj.CurrentTrick = p.buildTrickOutput(g.GetCurrentTrick())
+	resObj.CurrentTrick = trickCardsToOutput(g.GetCurrentTrick())
 	resObj.Players = p.buildPlayersOutput(g)
 	return resObj
 }
@@ -73,13 +73,6 @@ func (p *NapWebPresenter) playableIndices(g interfaces.NapGame) []int {
 		return make([]int, 0)
 	}
 	return idx
-}
-
-// buildTrickOutput 現在のトリック情報を構築
-func (p *NapWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.NapWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.NapWebOutputTrickCard {
-		return &controller.NapWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
-	})
 }
 
 // buildPlayersOutput プレイヤー情報を構築
@@ -151,7 +144,7 @@ func (p *NapWebPresenter) HintOutput(g interfaces.NapGame) string {
 	hint := g.GetHint()
 	resObj := p.buildBase(g)
 	if hint != nil {
-		resObj.Hint = &controller.NapWebOutputHint{
+		resObj.Hint = &controller.WebOutputCardHint{
 			CardIndices: hint.CardIndices,
 			Reason:      hint.Reason,
 		}

--- a/internal/adapter/presenter/NapoleonWebPresenter.go
+++ b/internal/adapter/presenter/NapoleonWebPresenter.go
@@ -68,10 +68,15 @@ func (p *NapoleonWebPresenter) buildBaseOutput(n interfaces.NapoleonGame) *contr
 	return resObj
 }
 
-// buildTrickOutput 現在のトリック情報を構築
-func (p *NapoleonWebPresenter) buildTrickOutput(trick []*domain.NapoleonTrickCard) []*controller.NapoleonWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.NapoleonTrickCard) *controller.NapoleonWebOutputTrickCard {
-		return &controller.NapoleonWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
+// buildTrickOutput 現在のトリック情報を構築。
+//
+// 共有の trickCardsToOutput に寄せられない: Napoleon は KV スナップショットの
+// タグ差異（pi/cd）のため domain 側が独自型のままで（#4363 / PR #4431）、この
+// ラッパーがその型と共有の WebOutputTrickCard を橋渡ししている。出力型は共有型
+// なので REST 形状は他の60ゲームと同一。
+func (p *NapoleonWebPresenter) buildTrickOutput(trick []*domain.NapoleonTrickCard) []*controller.WebOutputTrickCard {
+	return buildTrickCards(trick, func(tc *domain.NapoleonTrickCard) *controller.WebOutputTrickCard {
+		return &controller.WebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
 	})
 }
 

--- a/internal/adapter/presenter/NinetyNineWebPresenter.go
+++ b/internal/adapter/presenter/NinetyNineWebPresenter.go
@@ -58,16 +58,9 @@ func (p *NinetyNineWebPresenter) buildBase(o interfaces.NinetyNineGame) *control
 		TargetScore:   cfg.TargetScore,
 	}
 
-	resObj.CurrentTrick = p.buildTrickOutput(o.GetCurrentTrick())
+	resObj.CurrentTrick = trickCardsToOutput(o.GetCurrentTrick())
 	resObj.Players = p.buildPlayersOutput(o)
 	return resObj
-}
-
-// buildTrickOutput 現在のトリック情報を構築
-func (p *NinetyNineWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.NinetyNineWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.NinetyNineWebOutputTrickCard {
-		return &controller.NinetyNineWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
-	})
 }
 
 // buildPlayersOutput プレイヤー情報を構築

--- a/internal/adapter/presenter/OhHellWebPresenter.go
+++ b/internal/adapter/presenter/OhHellWebPresenter.go
@@ -62,16 +62,9 @@ func (p *OhHellWebPresenter) buildBase(o interfaces.OhHellGame) *controller.OhHe
 		RoundDirection: int(cfg.RoundDirection),
 	}
 
-	resObj.CurrentTrick = p.buildTrickOutput(o.GetCurrentTrick())
+	resObj.CurrentTrick = trickCardsToOutput(o.GetCurrentTrick())
 	resObj.Players = p.buildPlayersOutput(o)
 	return resObj
-}
-
-// buildTrickOutput 現在のトリック情報を構築
-func (p *OhHellWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.OhHellWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.OhHellWebOutputTrickCard {
-		return &controller.OhHellWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
-	})
 }
 
 // buildPlayersOutput プレイヤー情報を構築

--- a/internal/adapter/presenter/OmbreWebPresenter.go
+++ b/internal/adapter/presenter/OmbreWebPresenter.go
@@ -51,7 +51,7 @@ func (p *OmbreWebPresenter) buildBase(g interfaces.OmbreGame) *controller.OmbreW
 		TargetRounds:  cfg.TargetRounds,
 	}
 
-	resObj.CurrentTrick = p.buildTrickOutput(g.GetCurrentTrick())
+	resObj.CurrentTrick = trickCardsToOutput(g.GetCurrentTrick())
 	resObj.Players = p.buildPlayersOutput(g)
 	return resObj
 }
@@ -66,13 +66,6 @@ func (p *OmbreWebPresenter) playableIndices(g interfaces.OmbreGame) []int {
 		return make([]int, 0)
 	}
 	return idx
-}
-
-// buildTrickOutput 現在のトリック情報を構築
-func (p *OmbreWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.OmbreWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.OmbreWebOutputTrickCard {
-		return &controller.OmbreWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
-	})
 }
 
 // buildPlayersOutput プレイヤー情報を構築
@@ -158,7 +151,7 @@ func (p *OmbreWebPresenter) HintOutput(g interfaces.OmbreGame) string {
 	hint := g.GetHint()
 	resObj := p.buildBase(g)
 	if hint != nil {
-		resObj.Hint = &controller.OmbreWebOutputHint{
+		resObj.Hint = &controller.WebOutputCardHint{
 			CardIndices: hint.CardIndices,
 			Reason:      hint.Reason,
 		}

--- a/internal/adapter/presenter/PinochleWebPresenter.go
+++ b/internal/adapter/presenter/PinochleWebPresenter.go
@@ -36,7 +36,7 @@ func (p *PinochleWebPresenter) Output(g interfaces.PinochleGame, lastErr error) 
 	}
 
 	trick := g.GetCurrentTrick()
-	resObj.CurrentTrick = p.buildTrickOutput(trick)
+	resObj.CurrentTrick = trickCardsToOutput(trick)
 	resObj.Players = p.buildPlayersOutput(g)
 	resObj.PlayerMelds = p.buildMeldsOutput(g)
 
@@ -71,13 +71,6 @@ func (p *PinochleWebPresenter) HintOutput(g interfaces.PinochleGame) string {
 // ActionLogOutput 棋譜を出力
 func (p *PinochleWebPresenter) ActionLogOutput(g interfaces.PinochleGame) string {
 	return actionLogToJSON(g.GetActionLog())
-}
-
-// buildTrickOutput 現在のトリック情報を構築
-func (p *PinochleWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.PinochleWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.PinochleWebOutputTrickCard {
-		return &controller.PinochleWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
-	})
 }
 
 // buildPlayersOutput プレイヤー情報を構築

--- a/internal/adapter/presenter/PiquetWebPresenter.go
+++ b/internal/adapter/presenter/PiquetWebPresenter.go
@@ -114,10 +114,10 @@ func piquetBuildPlayers(g interfaces.PiquetGame) []*controller.PiquetWebOutputPl
 	return out
 }
 
-func piquetBuildCurrentTrick(trick []*domain.TrickCard) []*controller.PiquetWebOutputTrickCard {
-	out := make([]*controller.PiquetWebOutputTrickCard, len(trick))
+func piquetBuildCurrentTrick(trick []*domain.TrickCard) []*controller.WebOutputTrickCard {
+	out := make([]*controller.WebOutputTrickCard, len(trick))
 	for i, tc := range trick {
-		out[i] = &controller.PiquetWebOutputTrickCard{
+		out[i] = &controller.WebOutputTrickCard{
 			PlayerIdx: tc.PlayerIdx,
 			Card:      cardToOutput(tc.Card),
 		}

--- a/internal/adapter/presenter/PitchWebPresenter.go
+++ b/internal/adapter/presenter/PitchWebPresenter.go
@@ -38,7 +38,7 @@ func (p *PitchWebPresenter) buildBase(s interfaces.PitchGame) *controller.PitchW
 		PointLimit:    cfg.PointLimit,
 	}
 
-	resObj.CurrentTrick = p.buildTrickOutput(s.GetCurrentTrick())
+	resObj.CurrentTrick = trickCardsToOutput(s.GetCurrentTrick())
 	resObj.LastTrick, resObj.LastTrickWinner = p.buildLastTrickOutput(s)
 	resObj.Players = p.buildPlayersOutput(s)
 
@@ -55,20 +55,13 @@ func (p *PitchWebPresenter) buildBase(s interfaces.PitchGame) *controller.PitchW
 	return resObj
 }
 
-// buildTrickOutput 現在のトリック情報を構築
-func (p *PitchWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.PitchWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.PitchWebOutputTrickCard {
-		return &controller.PitchWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
-	})
-}
-
 // buildLastTrickOutput は直前に解決されたトリック（誰が何を出し誰が取ったか）を
 // アクションログから再構築する。ドメインは専用の lastTrick フィールドを持たないが、
 // 各トリックの "play" ログ（プレイヤーと札）と "trick_win" ログ（勝者）から
 // 現ラウンドの直近トリックを復元できる。ラウンド開始直後（プレイフェーズのトリック 1
 // で、この局のトリックがまだ確定していない）は空スライスと -1 を返す。
-func (p *PitchWebPresenter) buildLastTrickOutput(s interfaces.PitchGame) ([]*controller.PitchWebOutputTrickCard, int) {
-	empty := make([]*controller.PitchWebOutputTrickCard, 0)
+func (p *PitchWebPresenter) buildLastTrickOutput(s interfaces.PitchGame) ([]*controller.WebOutputTrickCard, int) {
+	empty := make([]*controller.WebOutputTrickCard, 0)
 	// ラウンド最初のトリックがプレイ中は、この局に確定済みトリックが無いため空を返す。
 	if s.GetPhase() == domain.PitchPhasePlay && s.GetTrickNumber() <= 1 {
 		return empty, -1
@@ -98,9 +91,9 @@ func (p *PitchWebPresenter) buildLastTrickOutput(s interfaces.PitchGame) ([]*con
 	}
 	plays = plays[len(plays)-domain.PitchPlayerCnt:]
 
-	out := make([]*controller.PitchWebOutputTrickCard, 0, len(plays))
+	out := make([]*controller.WebOutputTrickCard, 0, len(plays))
 	for _, e := range plays {
-		out = append(out, &controller.PitchWebOutputTrickCard{
+		out = append(out, &controller.WebOutputTrickCard{
 			PlayerIdx: e.PlayerIdx,
 			Card:      cardToOutput(e.Cards[0]),
 		})

--- a/internal/adapter/presenter/PreferenceWebPresenter.go
+++ b/internal/adapter/presenter/PreferenceWebPresenter.go
@@ -48,7 +48,7 @@ func (p *PreferenceWebPresenter) buildBase(g interfaces.PreferenceGame) *control
 		TargetPoints:  cfg.TargetPoints,
 	}
 
-	resObj.CurrentTrick = p.buildTrickOutput(g.GetCurrentTrick())
+	resObj.CurrentTrick = trickCardsToOutput(g.GetCurrentTrick())
 	resObj.Players = p.buildPlayersOutput(g)
 	return resObj
 }
@@ -73,13 +73,6 @@ func (p *PreferenceWebPresenter) playableIndices(g interfaces.PreferenceGame) []
 		return make([]int, 0)
 	}
 	return idx
-}
-
-// buildTrickOutput 現在のトリック情報を構築
-func (p *PreferenceWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.PreferenceWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.PreferenceWebOutputTrickCard {
-		return &controller.PreferenceWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
-	})
 }
 
 // buildPlayersOutput プレイヤー情報を構築
@@ -151,7 +144,7 @@ func (p *PreferenceWebPresenter) HintOutput(g interfaces.PreferenceGame) string 
 	hint := g.GetHint()
 	resObj := p.buildBase(g)
 	if hint != nil {
-		resObj.Hint = &controller.PreferenceWebOutputHint{
+		resObj.Hint = &controller.WebOutputCardHint{
 			CardIndices: hint.CardIndices,
 			Reason:      hint.Reason,
 		}

--- a/internal/adapter/presenter/RookWebPresenter.go
+++ b/internal/adapter/presenter/RookWebPresenter.go
@@ -65,7 +65,7 @@ func (p *RookWebPresenter) buildBase(g interfaces.RookGame) *controller.RookWebO
 	}
 
 	resObj.Nest = p.buildNestOutput(g)
-	resObj.CurrentTrick = p.buildTrickOutput(g.GetCurrentTrick())
+	resObj.CurrentTrick = trickCardsToOutputWithFace(g.GetCurrentTrick(), rookFace)
 	resObj.Players = p.buildPlayersOutput(g)
 	return resObj
 }
@@ -83,13 +83,6 @@ func (p *RookWebPresenter) buildNestOutput(g interfaces.RookGame) []*controller.
 		out = append(out, cardToOutputWithFace(c, rookFace))
 	}
 	return out
-}
-
-// buildTrickOutput 現在のトリック情報を構築
-func (p *RookWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.RookWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.RookWebOutputTrickCard {
-		return &controller.RookWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutputWithFace(tc.Card, rookFace)}
-	})
 }
 
 // buildPlayersOutput プレイヤー情報を構築 (人間のみ手札を公開)

--- a/internal/adapter/presenter/ScartoWebPresenter.go
+++ b/internal/adapter/presenter/ScartoWebPresenter.go
@@ -102,7 +102,7 @@ func (p *ScartoWebPresenter) buildBase(g interfaces.ScartoGame) *controller.Scar
 		TargetDeals:   cfg.TargetDeals,
 	}
 
-	resObj.CurrentTrick = p.buildTrickOutput(g.GetCurrentTrick())
+	resObj.CurrentTrick = trickCardsToOutputWithFace(g.GetCurrentTrick(), scartoFace)
 	resObj.Players = p.buildPlayersOutput(g)
 	return resObj
 }
@@ -117,13 +117,6 @@ func (p *ScartoWebPresenter) playableIndices(g interfaces.ScartoGame) []int {
 		return make([]int, 0)
 	}
 	return idx
-}
-
-// buildTrickOutput 現在のトリック情報を構築
-func (p *ScartoWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.ScartoWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.ScartoWebOutputTrickCard {
-		return &controller.ScartoWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutputWithFace(tc.Card, scartoFace)}
-	})
 }
 
 // buildPlayersOutput プレイヤー情報を構築 (人間のみ手札を公開、伏せたスカルトは非公開)
@@ -211,7 +204,7 @@ func (p *ScartoWebPresenter) HintOutput(g interfaces.ScartoGame) string {
 	hint := g.GetHint()
 	resObj := p.buildBase(g)
 	if hint != nil {
-		resObj.Hint = &controller.ScartoWebOutputHint{
+		resObj.Hint = &controller.WebOutputCardHint{
 			CardIndices: hint.CardIndices,
 			Reason:      hint.Reason,
 		}

--- a/internal/adapter/presenter/SchnapsenWebPresenter.go
+++ b/internal/adapter/presenter/SchnapsenWebPresenter.go
@@ -44,7 +44,7 @@ func (p *SchnapsenWebPresenter) buildBase(s interfaces.SchnapsenGame) *controlle
 		CpuDifficulty: int(cfg.CpuDifficulty),
 	}
 
-	resObj.CurrentTrick = p.buildTrickOutput(s.GetCurrentTrick())
+	resObj.CurrentTrick = trickCardsToOutput(s.GetCurrentTrick())
 	resObj.Players = p.buildPlayersOutput(s)
 	return resObj
 }
@@ -55,13 +55,6 @@ func intSliceOrEmpty(in []int) []int {
 		return make([]int, 0)
 	}
 	return in
-}
-
-// buildTrickOutput 現在のトリック情報を構築
-func (p *SchnapsenWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.SchnapsenWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.SchnapsenWebOutputTrickCard {
-		return &controller.SchnapsenWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
-	})
 }
 
 // buildPlayersOutput プレイヤー情報を構築

--- a/internal/adapter/presenter/SedmaWebPresenter.go
+++ b/internal/adapter/presenter/SedmaWebPresenter.go
@@ -43,7 +43,7 @@ func (p *SedmaWebPresenter) buildBase(g interfaces.SedmaGame) *controller.SedmaW
 		TargetPoints:  cfg.TargetPoints,
 	}
 
-	resObj.CurrentTrick = p.buildTrickOutput(g.GetCurrentTrick())
+	resObj.CurrentTrick = trickCardsToOutput(g.GetCurrentTrick())
 	resObj.Players = p.buildPlayersOutput(g)
 	return resObj
 }
@@ -58,13 +58,6 @@ func (p *SedmaWebPresenter) playableIndices(g interfaces.SedmaGame) []int {
 		return make([]int, 0)
 	}
 	return idx
-}
-
-// buildTrickOutput 現在のトリック情報を構築
-func (p *SedmaWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.SedmaWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.SedmaWebOutputTrickCard {
-		return &controller.SedmaWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
-	})
 }
 
 // buildPlayersOutput プレイヤー情報を構築
@@ -134,7 +127,7 @@ func (p *SedmaWebPresenter) HintOutput(g interfaces.SedmaGame) string {
 	hint := g.GetHint()
 	resObj := p.buildBase(g)
 	if hint != nil {
-		resObj.Hint = &controller.SedmaWebOutputHint{
+		resObj.Hint = &controller.WebOutputCardHint{
 			CardIndices: hint.CardIndices,
 			Reason:      hint.Reason,
 		}

--- a/internal/adapter/presenter/SheepsheadWebPresenter.go
+++ b/internal/adapter/presenter/SheepsheadWebPresenter.go
@@ -69,7 +69,7 @@ func (p *SheepsheadWebPresenter) buildBase(g interfaces.SheepsheadGame) *control
 		TargetChips:   cfg.TargetChips,
 	}
 
-	resObj.CurrentTrick = p.buildTrickOutput(g.GetCurrentTrick())
+	resObj.CurrentTrick = trickCardsToOutput(g.GetCurrentTrick())
 	resObj.Players = p.buildPlayersOutput(g)
 	return resObj
 }
@@ -96,13 +96,6 @@ func (p *SheepsheadWebPresenter) playableIndices(g interfaces.SheepsheadGame) []
 		return make([]int, 0)
 	}
 	return idx
-}
-
-// buildTrickOutput 現在のトリック情報を構築
-func (p *SheepsheadWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.SheepsheadWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.SheepsheadWebOutputTrickCard {
-		return &controller.SheepsheadWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
-	})
 }
 
 // buildPlayersOutput プレイヤー情報を構築

--- a/internal/adapter/presenter/SkatWebPresenter.go
+++ b/internal/adapter/presenter/SkatWebPresenter.go
@@ -67,16 +67,9 @@ func (p *SkatWebPresenter) buildBaseOutput(s interfaces.SkatGame) *controller.Sk
 		TargetScore:   cfg.TargetScore,
 	}
 
-	resObj.CurrentTrick = p.buildTrickOutput(s.GetCurrentTrick())
+	resObj.CurrentTrick = trickCardsToOutput(s.GetCurrentTrick())
 	resObj.Players = p.buildPlayersOutput(s)
 	return resObj
-}
-
-// buildTrickOutput maps the current trick to the response shape.
-func (p *SkatWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.SkatWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.SkatWebOutputTrickCard {
-		return &controller.SkatWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
-	})
 }
 
 // buildPlayersOutput builds the per-player output.

--- a/internal/adapter/presenter/SoloWhistWebPresenter.go
+++ b/internal/adapter/presenter/SoloWhistWebPresenter.go
@@ -48,7 +48,7 @@ func (p *SoloWhistWebPresenter) buildBase(g interfaces.SoloWhistGame) *controlle
 		TargetPoints:  cfg.TargetPoints,
 	}
 
-	resObj.CurrentTrick = p.buildTrickOutput(g.GetCurrentTrick())
+	resObj.CurrentTrick = trickCardsToOutput(g.GetCurrentTrick())
 	resObj.Players = p.buildPlayersOutput(g)
 	return resObj
 }
@@ -73,13 +73,6 @@ func (p *SoloWhistWebPresenter) playableIndices(g interfaces.SoloWhistGame) []in
 		return make([]int, 0)
 	}
 	return idx
-}
-
-// buildTrickOutput 現在のトリック情報を構築
-func (p *SoloWhistWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.SoloWhistWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.SoloWhistWebOutputTrickCard {
-		return &controller.SoloWhistWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
-	})
 }
 
 // buildPlayersOutput プレイヤー情報を構築
@@ -151,7 +144,7 @@ func (p *SoloWhistWebPresenter) HintOutput(g interfaces.SoloWhistGame) string {
 	hint := g.GetHint()
 	resObj := p.buildBase(g)
 	if hint != nil {
-		resObj.Hint = &controller.SoloWhistWebOutputHint{
+		resObj.Hint = &controller.WebOutputCardHint{
 			CardIndices: hint.CardIndices,
 			Reason:      hint.Reason,
 		}

--- a/internal/adapter/presenter/SpadesWebPresenter.go
+++ b/internal/adapter/presenter/SpadesWebPresenter.go
@@ -38,16 +38,9 @@ func (p *SpadesWebPresenter) buildBase(s interfaces.SpadesGame) *controller.Spad
 		BagPenaltyThreshold: cfg.BagPenaltyThreshold,
 	}
 
-	resObj.CurrentTrick = p.buildTrickOutput(s.GetCurrentTrick())
+	resObj.CurrentTrick = trickCardsToOutput(s.GetCurrentTrick())
 	resObj.Players = p.buildPlayersOutput(s)
 	return resObj
-}
-
-// buildTrickOutput 現在のトリック情報を構築
-func (p *SpadesWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.SpadesWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.SpadesWebOutputTrickCard {
-		return &controller.SpadesWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
-	})
 }
 
 // buildPlayersOutput プレイヤー情報を構築

--- a/internal/adapter/presenter/SpoilFiveWebPresenter.go
+++ b/internal/adapter/presenter/SpoilFiveWebPresenter.go
@@ -44,7 +44,7 @@ func (p *SpoilFiveWebPresenter) buildBase(g interfaces.SpoilFiveGame) *controlle
 		TargetPoints:  cfg.TargetPoints,
 	}
 
-	resObj.CurrentTrick = p.buildTrickOutput(g.GetCurrentTrick())
+	resObj.CurrentTrick = trickCardsToOutput(g.GetCurrentTrick())
 	resObj.Players = p.buildPlayersOutput(g)
 	return resObj
 }
@@ -59,13 +59,6 @@ func (p *SpoilFiveWebPresenter) playableIndices(g interfaces.SpoilFiveGame) []in
 		return make([]int, 0)
 	}
 	return idx
-}
-
-// buildTrickOutput 現在のトリック情報を構築
-func (p *SpoilFiveWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.SpoilFiveWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.SpoilFiveWebOutputTrickCard {
-		return &controller.SpoilFiveWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
-	})
 }
 
 // buildPlayersOutput プレイヤー情報を構築
@@ -136,7 +129,7 @@ func (p *SpoilFiveWebPresenter) HintOutput(g interfaces.SpoilFiveGame) string {
 	hint := g.GetHint()
 	resObj := p.buildBase(g)
 	if hint != nil {
-		resObj.Hint = &controller.SpoilFiveWebOutputHint{
+		resObj.Hint = &controller.WebOutputCardHint{
 			CardIndices: hint.CardIndices,
 			Reason:      hint.Reason,
 		}

--- a/internal/adapter/presenter/SuecaWebPresenter.go
+++ b/internal/adapter/presenter/SuecaWebPresenter.go
@@ -46,7 +46,7 @@ func (p *SuecaWebPresenter) buildBase(g interfaces.SuecaGame) *controller.SuecaW
 		TargetGamePoints: cfg.TargetGamePoints,
 	}
 
-	resObj.CurrentTrick = p.buildTrickOutput(g.GetCurrentTrick())
+	resObj.CurrentTrick = trickCardsToOutput(g.GetCurrentTrick())
 	resObj.Players = p.buildPlayersOutput(g)
 	return resObj
 }
@@ -61,13 +61,6 @@ func (p *SuecaWebPresenter) playableIndices(g interfaces.SuecaGame) []int {
 		return make([]int, 0)
 	}
 	return idx
-}
-
-// buildTrickOutput 現在のトリック情報を構築
-func (p *SuecaWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.SuecaWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.SuecaWebOutputTrickCard {
-		return &controller.SuecaWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
-	})
 }
 
 // buildPlayersOutput プレイヤー情報を構築
@@ -136,7 +129,7 @@ func (p *SuecaWebPresenter) HintOutput(g interfaces.SuecaGame) string {
 	hint := g.GetHint()
 	resObj := p.buildBase(g)
 	if hint != nil {
-		resObj.Hint = &controller.SuecaWebOutputHint{
+		resObj.Hint = &controller.WebOutputCardHint{
 			CardIndices: hint.CardIndices,
 			Reason:      hint.Reason,
 		}

--- a/internal/adapter/presenter/TarneebWebPresenter.go
+++ b/internal/adapter/presenter/TarneebWebPresenter.go
@@ -45,16 +45,9 @@ func (p *TarneebWebPresenter) buildBase(t interfaces.TarneebGame) *controller.Ta
 	}
 
 	resObj.TeamScores = []int{t.GetTeamScore(0), t.GetTeamScore(1)}
-	resObj.CurrentTrick = p.buildTrickOutput(t.GetCurrentTrick())
+	resObj.CurrentTrick = trickCardsToOutput(t.GetCurrentTrick())
 	resObj.Players = p.buildPlayersOutput(t)
 	return resObj
-}
-
-// buildTrickOutput 現在のトリック情報を構築
-func (p *TarneebWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.TarneebWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.TarneebWebOutputTrickCard {
-		return &controller.TarneebWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
-	})
 }
 
 // buildPlayersOutput プレイヤー情報を構築

--- a/internal/adapter/presenter/TressetteWebPresenter.go
+++ b/internal/adapter/presenter/TressetteWebPresenter.go
@@ -43,7 +43,7 @@ func (p *TressetteWebPresenter) buildBase(g interfaces.TressetteGame) *controlle
 		TargetPoints:  cfg.TargetPoints,
 	}
 
-	resObj.CurrentTrick = p.buildTrickOutput(g.GetCurrentTrick())
+	resObj.CurrentTrick = trickCardsToOutput(g.GetCurrentTrick())
 	resObj.LastTrick, resObj.LastTrickWinner = p.buildLastTrickOutput(g)
 	resObj.Players = p.buildPlayersOutput(g)
 	return resObj
@@ -54,8 +54,8 @@ func (p *TressetteWebPresenter) buildBase(g interfaces.TressetteGame) *controlle
 // 各トリックの "play" ログ（プレイヤーと札）と "trick_win" ログ（勝者）から
 // 現ラウンドの直近トリックを復元できる。ラウンド開始直後（プレイフェーズのトリック 1
 // で、この局のトリックがまだ確定していない）は空スライスと -1 を返す。
-func (p *TressetteWebPresenter) buildLastTrickOutput(g interfaces.TressetteGame) ([]*controller.TressetteWebOutputTrickCard, int) {
-	empty := make([]*controller.TressetteWebOutputTrickCard, 0)
+func (p *TressetteWebPresenter) buildLastTrickOutput(g interfaces.TressetteGame) ([]*controller.WebOutputTrickCard, int) {
+	empty := make([]*controller.WebOutputTrickCard, 0)
 	// ラウンド最初のトリックがプレイ中は、この局に確定済みトリックが無いため空を返す。
 	if g.GetPhase() == domain.TressettePhasePlay && g.GetTrickNumber() <= 1 {
 		return empty, -1
@@ -85,9 +85,9 @@ func (p *TressetteWebPresenter) buildLastTrickOutput(g interfaces.TressetteGame)
 	}
 	plays = plays[len(plays)-domain.TressettePlayerCnt:]
 
-	out := make([]*controller.TressetteWebOutputTrickCard, 0, len(plays))
+	out := make([]*controller.WebOutputTrickCard, 0, len(plays))
 	for _, e := range plays {
-		out = append(out, &controller.TressetteWebOutputTrickCard{
+		out = append(out, &controller.WebOutputTrickCard{
 			PlayerIdx: e.PlayerIdx,
 			Card:      cardToOutput(e.Cards[0]),
 		})
@@ -105,13 +105,6 @@ func (p *TressetteWebPresenter) playableIndices(g interfaces.TressetteGame) []in
 		return make([]int, 0)
 	}
 	return idx
-}
-
-// buildTrickOutput 現在のトリック情報を構築
-func (p *TressetteWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.TressetteWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.TressetteWebOutputTrickCard {
-		return &controller.TressetteWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
-	})
 }
 
 // buildPlayersOutput プレイヤー情報を構築
@@ -182,7 +175,7 @@ func (p *TressetteWebPresenter) HintOutput(g interfaces.TressetteGame) string {
 	hint := g.GetHint()
 	resObj := p.buildBase(g)
 	if hint != nil {
-		resObj.Hint = &controller.TressetteWebOutputHint{
+		resObj.Hint = &controller.WebOutputCardHint{
 			CardIndices: hint.CardIndices,
 			Reason:      hint.Reason,
 		}

--- a/internal/adapter/presenter/TrucoWebPresenter.go
+++ b/internal/adapter/presenter/TrucoWebPresenter.go
@@ -53,16 +53,9 @@ func (p *TrucoWebPresenter) buildBase(g interfaces.TrucoGame) *controller.TrucoW
 		MatchTarget:   g.GetMatchTarget(),
 	}
 
-	resObj.CurrentTrick = p.buildTrickOutput(g.GetCurrentTrick())
+	resObj.CurrentTrick = trickCardsToOutput(g.GetCurrentTrick())
 	resObj.Players = p.buildPlayersOutput(g)
 	return resObj
-}
-
-// buildTrickOutput 現在のバサ情報を構築
-func (p *TrucoWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.TrucoWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.TrucoWebOutputTrickCard {
-		return &controller.TrucoWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
-	})
 }
 
 // buildPlayersOutput プレイヤー情報を構築

--- a/internal/adapter/presenter/TuteWebPresenter.go
+++ b/internal/adapter/presenter/TuteWebPresenter.go
@@ -47,7 +47,7 @@ func (p *TuteWebPresenter) buildBase(g interfaces.TuteGame) *controller.TuteWebO
 		TargetPoints:  cfg.TargetPoints,
 	}
 
-	resObj.CurrentTrick = p.buildTrickOutput(g.GetCurrentTrick())
+	resObj.CurrentTrick = trickCardsToOutput(g.GetCurrentTrick())
 	resObj.Players = p.buildPlayersOutput(g)
 	return resObj
 }
@@ -71,13 +71,6 @@ func (p *TuteWebPresenter) playableIndices(g interfaces.TuteGame) []int {
 		return make([]int, 0)
 	}
 	return idx
-}
-
-// buildTrickOutput 現在のトリック情報を構築
-func (p *TuteWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.TuteWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.TuteWebOutputTrickCard {
-		return &controller.TuteWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
-	})
 }
 
 // buildPlayersOutput プレイヤー情報を構築

--- a/internal/adapter/presenter/TwentyNineWebPresenter.go
+++ b/internal/adapter/presenter/TwentyNineWebPresenter.go
@@ -49,7 +49,7 @@ func (p *TwentyNineWebPresenter) buildBase(g interfaces.TwentyNineGame) *control
 		TargetPoints:  cfg.TargetPoints,
 	}
 
-	resObj.CurrentTrick = p.buildTrickOutput(g.GetCurrentTrick())
+	resObj.CurrentTrick = trickCardsToOutput(g.GetCurrentTrick())
 	resObj.Players = p.buildPlayersOutput(g)
 	return resObj
 }
@@ -74,13 +74,6 @@ func (p *TwentyNineWebPresenter) playableIndices(g interfaces.TwentyNineGame) []
 		return make([]int, 0)
 	}
 	return idx
-}
-
-// buildTrickOutput 現在のトリック情報を構築
-func (p *TwentyNineWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.TwentyNineWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.TwentyNineWebOutputTrickCard {
-		return &controller.TwentyNineWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
-	})
 }
 
 // buildPlayersOutput プレイヤー情報を構築
@@ -153,7 +146,7 @@ func (p *TwentyNineWebPresenter) HintOutput(g interfaces.TwentyNineGame) string 
 	hint := g.GetHint()
 	resObj := p.buildBase(g)
 	if hint != nil {
-		resObj.Hint = &controller.TwentyNineWebOutputHint{
+		resObj.Hint = &controller.WebOutputCardHint{
 			CardIndices: hint.CardIndices,
 			Reason:      hint.Reason,
 		}

--- a/internal/adapter/presenter/TwoTenJackWebPresenter.go
+++ b/internal/adapter/presenter/TwoTenJackWebPresenter.go
@@ -35,16 +35,9 @@ func (p *TwoTenJackWebPresenter) buildBase(s interfaces.TwoTenJackGame) *control
 		PointLimit:    cfg.PointLimit,
 	}
 
-	resObj.CurrentTrick = p.buildTrickOutput(s.GetCurrentTrick())
+	resObj.CurrentTrick = trickCardsToOutput(s.GetCurrentTrick())
 	resObj.Players = p.buildPlayersOutput(s)
 	return resObj
-}
-
-// buildTrickOutput 現在のトリック情報を構築
-func (p *TwoTenJackWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.TwoTenJackWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.TwoTenJackWebOutputTrickCard {
-		return &controller.TwoTenJackWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
-	})
 }
 
 // buildPlayersOutput プレイヤー情報を構築

--- a/internal/adapter/presenter/TysiacWebPresenter.go
+++ b/internal/adapter/presenter/TysiacWebPresenter.go
@@ -50,7 +50,7 @@ func (p *TysiacWebPresenter) buildBase(g interfaces.TysiacGame) *controller.Tysi
 		TargetPoints:  cfg.TargetPoints,
 	}
 
-	resObj.CurrentTrick = p.buildTrickOutput(g.GetCurrentTrick())
+	resObj.CurrentTrick = trickCardsToOutput(g.GetCurrentTrick())
 	resObj.Players = p.buildPlayersOutput(g)
 	return resObj
 }
@@ -65,13 +65,6 @@ func (p *TysiacWebPresenter) playableIndices(g interfaces.TysiacGame) []int {
 		return make([]int, 0)
 	}
 	return idx
-}
-
-// buildTrickOutput 現在のトリック情報を構築
-func (p *TysiacWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.TysiacWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.TysiacWebOutputTrickCard {
-		return &controller.TysiacWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
-	})
 }
 
 // buildPlayersOutput プレイヤー情報を構築
@@ -145,7 +138,7 @@ func (p *TysiacWebPresenter) HintOutput(g interfaces.TysiacGame) string {
 	hint := g.GetHint()
 	resObj := p.buildBase(g)
 	if hint != nil {
-		resObj.Hint = &controller.TysiacWebOutputHint{
+		resObj.Hint = &controller.WebOutputCardHint{
 			CardIndices: hint.CardIndices,
 			Reason:      hint.Reason,
 		}

--- a/internal/adapter/presenter/UltiWebPresenter.go
+++ b/internal/adapter/presenter/UltiWebPresenter.go
@@ -52,7 +52,7 @@ func (p *UltiWebPresenter) buildBase(g interfaces.UltiGame) *controller.UltiWebO
 		TargetRounds:  cfg.TargetRounds,
 	}
 
-	resObj.CurrentTrick = p.buildTrickOutput(g.GetCurrentTrick())
+	resObj.CurrentTrick = trickCardsToOutput(g.GetCurrentTrick())
 	resObj.Players = p.buildPlayersOutput(g)
 	return resObj
 }
@@ -67,13 +67,6 @@ func (p *UltiWebPresenter) playableIndices(g interfaces.UltiGame) []int {
 		return make([]int, 0)
 	}
 	return idx
-}
-
-// buildTrickOutput 現在のトリック情報を構築
-func (p *UltiWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.UltiWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.UltiWebOutputTrickCard {
-		return &controller.UltiWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
-	})
 }
 
 // buildPlayersOutput プレイヤー情報を構築
@@ -160,7 +153,7 @@ func (p *UltiWebPresenter) HintOutput(g interfaces.UltiGame) string {
 	hint := g.GetHint()
 	resObj := p.buildBase(g)
 	if hint != nil {
-		resObj.Hint = &controller.UltiWebOutputHint{
+		resObj.Hint = &controller.WebOutputCardHint{
 			CardIndices: hint.CardIndices,
 			Reason:      hint.Reason,
 		}

--- a/internal/adapter/presenter/WattenWebPresenter.go
+++ b/internal/adapter/presenter/WattenWebPresenter.go
@@ -50,15 +50,9 @@ func (p *WattenWebPresenter) buildBase(g interfaces.WattenGame) *controller.Watt
 		MaxRaises:     cfg.MaxRaises,
 	}
 
-	resObj.CurrentTrick = p.buildTrickOutput(g.GetCurrentTrick())
+	resObj.CurrentTrick = trickCardsToOutput(g.GetCurrentTrick())
 	resObj.Players = p.buildPlayersOutput(g)
 	return resObj
-}
-
-func (p *WattenWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.WattenWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.WattenWebOutputTrickCard {
-		return &controller.WattenWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
-	})
 }
 
 func (p *WattenWebPresenter) buildPlayersOutput(g interfaces.WattenGame) []*controller.WattenWebOutputPlayer {

--- a/internal/adapter/presenter/WhistWebPresenter.go
+++ b/internal/adapter/presenter/WhistWebPresenter.go
@@ -39,16 +39,9 @@ func (p *WhistWebPresenter) buildBase(w interfaces.WhistGame) *controller.WhistW
 		PointLimit:    cfg.PointLimit,
 	}
 
-	resObj.CurrentTrick = p.buildTrickOutput(w.GetCurrentTrick())
+	resObj.CurrentTrick = trickCardsToOutput(w.GetCurrentTrick())
 	resObj.Players = p.buildPlayersOutput(w)
 	return resObj
-}
-
-// buildTrickOutput 現在のトリック情報を構築
-func (p *WhistWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.WhistWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.WhistWebOutputTrickCard {
-		return &controller.WhistWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
-	})
 }
 
 // buildPlayersOutput プレイヤー情報を構築

--- a/internal/adapter/presenter/WizardWebPresenter.go
+++ b/internal/adapter/presenter/WizardWebPresenter.go
@@ -75,16 +75,9 @@ func (p *WizardWebPresenter) buildBase(o interfaces.WizardGame) *controller.Wiza
 		CpuDifficulty: int(cfg.CpuDifficulty),
 	}
 
-	resObj.CurrentTrick = p.buildTrickOutput(o.GetCurrentTrick())
+	resObj.CurrentTrick = trickCardsToOutputWithFace(o.GetCurrentTrick(), wizardFace)
 	resObj.Players = p.buildPlayersOutput(o)
 	return resObj
-}
-
-// buildTrickOutput 現在のトリック情報を構築
-func (p *WizardWebPresenter) buildTrickOutput(trick []*domain.TrickCard) []*controller.WizardWebOutputTrickCard {
-	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.WizardWebOutputTrickCard {
-		return &controller.WizardWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutputWithFace(tc.Card, wizardFace)}
-	})
 }
 
 // buildPlayersOutput プレイヤー情報を構築

--- a/internal/adapter/presenter/card_output_helper.go
+++ b/internal/adapter/presenter/card_output_helper.go
@@ -109,3 +109,30 @@ func cardsToOutputOrEmpty(cards []*domain.Card) []*controller.WebOutputCard {
 	}
 	return cardsToOutput(cards)
 }
+
+// trickCardsToOutput はトリックを共通の WebOutputTrickCard スライスに変換する。
+//
+// 50ゲームが同一のラッパー（buildTrickOutput）を各 *WebPresenter.go に持って
+// いたものを統合した（issue #4432）。
+//
+// Mighty / Napoleon は domain 側が共有の TrickCard ではない独自型のままなので
+// （#4363 / PR #4431 の除外理由を参照）、この関数の対象外で、各自のラッパーを
+// 維持する。
+func trickCardsToOutput(trick []*domain.TrickCard) []*controller.WebOutputTrickCard {
+	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.WebOutputTrickCard {
+		return &controller.WebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
+	})
+}
+
+// trickCardsToOutputWithFace は trickCardsToOutput の手続き描画版。
+//
+// 非52枚デッキの6ゲーム（Cego / FrenchTarot / Koenigrufen / Rook / Scarto /
+// Wizard）は、トリック中の札にも Glyph/Label/Color/Deck を載せる必要がある
+// (ADR-0033)。face 引数のない trickCardsToOutput にこれらを寄せると、トリック
+// 表示だけ手続き描画のメタデータが落ちて標準札として描かれる — 型にもテストにも
+// 現れない、静かな表示バグになる。
+func trickCardsToOutputWithFace(trick []*domain.TrickCard, fp faceProvider) []*controller.WebOutputTrickCard {
+	return buildTrickCards(trick, func(tc *domain.TrickCard) *controller.WebOutputTrickCard {
+		return &controller.WebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutputWithFace(tc.Card, fp)}
+	})
+}


### PR DESCRIPTION
## Summary

#4363's remaining two layers, after PR #4431 did domain. **Net −839 lines.**

| layer | before | after |
|---|---|---|
| controller | 60 `<Game>WebOutputTrickCard` | `WebOutputTrickCard` |
| controller | 22 `<Game>WebOutputHint` | `WebOutputCardHint` |
| presenter | 54 `buildTrickOutput` wrappers | 2 shared helpers |

The json tags are identical to the per-game types they replace, so the **REST response shape is unchanged** — which is why the whole Go suite passes with **no test edits** and E2E is **307/307**.

## Two presenter helpers, not one — and that's the point

The 56 wrappers were **not** all the same. After removing them I checked the bodies and found 7 distinct variants. Six games — `Cego`, `FrenchTarot`, `Koenigrufen`, `Rook`, `Scarto`, `Wizard` — call `cardToOutputWithFace(tc.Card, <game>Face)` rather than `cardToOutput`. Those are the non-52-card decks whose cards carry `Glyph`/`Label`/`Color`/`Deck` for the procedural render path ([ADR-0033](docs/adr/0033-procedural-card-face.md)).

Folding them into a face-less helper would have dropped that metadata **from the trick display alone**: no type error, no failing test, just tarot cards drawn as ordinary playing cards in the browser. `trickCardsToOutputWithFace` keeps them correct.

## Mighty and Napoleon keep their wrappers, for different reasons

Both now carry a comment saying which, since a future sweep would otherwise target them:

- **`Mighty`** — genuinely different shape (`IsJokerLead` / `LeadDemandSuit`) in *both* domain and controller.
- **`Napoleon`** — its domain type stays per-game because the KV snapshot tags are `pi`/`cd` (#4363, PR #4431). The wrapper bridges that to the shared output type, so its REST shape matches the other 60.

A first pass at the presenter sweep deleted both by mistake: the pattern matched any wrapper returning a `*WebOutputTrickCard`, and both take a *per-game domain* type. I reverted the directory and re-ran with the parameter type as a guard rather than patching the fallout.

## New tests

Wire-shape tests for both DTOs. 60 games' trick display and 22 games' hints now serialize through these, and the frontend reads `playerIdx` / `card` directly — so a renamed tag surfaces as blank cards in the browser, not as a Go failure. Both negative-controlled (renaming `playerIdx` fails; restoring passes).

## Correction to #4363, carried forward from the issue I filed

**Only 22 of the 115 `*WebOutputHint` types share a shape.** The other 93 are genuinely different — solitaire zone/column moves, bid hints — and must stay. #4363 reads as though all Hint types were identical; the shared type's doc comment records the real split.

## Test plan

- [x] `go build ./...`, `go vet ./internal/...` clean
- [x] `go test -tags test ./...` — full suite green, **zero test changes** (the wire-shape evidence)
- [x] `golangci-lint run ./...` — 0 issues
- [x] `gofmt` / `goimports` clean across all 177 touched files
- [x] **`bun run e2e` before pushing — 307/307, no failures**
- [x] Verified none of the 60 unified types had a custom `MarshalJSON` (the trap that made Napoleon's domain type unsafe in #4431) and that all 60 struct bodies were byte-identical
- [x] Both new wire-shape tests negative-controlled

Closes #4432