### PR TITLE
test(frontend): assert the keyboard shortcuts run on the 11 casino/poker pages

### DIFF
--- a/frontend/src/pages/AcesUpPage.test.tsx
+++ b/frontend/src/pages/AcesUpPage.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { acesupApi, actionLogApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { AcesUpCard, AcesUpResponse, Card, CardDesign } from '../types/card';
 import { AcesUpPage } from './AcesUpPage';
@@ -219,6 +220,7 @@ describe('AcesUpPage', () => {
     mockExec.mockClear();
     mockExec.mockResolvedValue(gameOverState);
     fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('giveup');
     expect(screen.getByText('投了確認')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: '確認' }));
@@ -347,6 +349,7 @@ describe('AcesUpPage keyboard shortcuts', () => {
     for (const key of ['d', 'h', 'z']) {
       fireEvent.keyDown(document, { key });
     }
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/BeleagueredCastlePage.test.tsx
+++ b/frontend/src/pages/BeleagueredCastlePage.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { beleagueredCastleApi } from '../api/gameApi';
 import { useGameHint } from '../hooks/useGameHint';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { BeleagueredCastleResponse, BeleagueredCastleTableauCard, Card, CardDesign } from '../types/card';
 import { BeleagueredCastlePage } from './BeleagueredCastlePage';
@@ -130,6 +131,7 @@ describe('BeleagueredCastlePage', () => {
     mockExec.mockClear();
     mockExec.mockResolvedValue(gameOverState);
     fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('giveup');
     expect(screen.getByText('投了確認')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: '確認' }));
@@ -239,6 +241,7 @@ describe('BeleagueredCastlePage keyboard shortcuts', () => {
     for (const key of ['h', 'a', 'z']) {
       fireEvent.keyDown(document, { key });
     }
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/CaribbeanStudPage.test.tsx
+++ b/frontend/src/pages/CaribbeanStudPage.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { caribbeanstudApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, CardDesign, CaribbeanStudResponse } from '../types/card';
 import { CaribbeanStudPage } from './CaribbeanStudPage';
@@ -381,5 +382,39 @@ describe('CaribbeanStudPage', () => {
       await waitFor(() => expect(screen.queryByTestId('csp-session-stats')).not.toBeInTheDocument());
       expect(localStorage.getItem('trumpcards-caribbeanstud-history')).toBeNull();
     });
+  });
+});
+
+// --- keyboard shortcut execution (#4429) ---
+// Each key is gated on its own phase, so the case pairs it with the fixture that
+// enables it; the assertion pins the command and its arguments so a swapped
+// binding fails rather than passing on "exec was called at all".
+const kbdCases: [string, unknown[], CaribbeanStudResponse][] = [
+  ['b', ['bet', 100, 0], betPhaseState],
+  ['p', ['play'], actionPhaseState],
+  ['f', ['fold'], actionPhaseState],
+  ['r', ['reset'], endPhasePlayerWins],
+];
+
+describe('CaribbeanStudPage keyboard shortcuts', () => {
+  it.each(kbdCases)('pressing %s dispatches %j', async (key, expected, state) => {
+    mockApi.mockResolvedValue(state);
+    renderWithProviders(<CaribbeanStudPage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
+    mockApi.mockClear();
+    mockApi.mockResolvedValue(state);
+    fireEvent.keyDown(document, { key });
+    await waitFor(() => expect(mockApi).toHaveBeenCalledWith(...expected));
+  });
+
+  it('ignores a key whose phase gate is closed', async () => {
+    // 'b' places the ante and is enabled only in the BET phase.
+    mockApi.mockResolvedValue(actionPhaseState);
+    renderWithProviders(<CaribbeanStudPage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
+    mockApi.mockClear();
+    fireEvent.keyDown(document, { key: 'b' });
+    await flushPendingDispatch();
+    expect(mockApi).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/CasinoHoldemPage.test.tsx
+++ b/frontend/src/pages/CasinoHoldemPage.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { casinoholdemApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, CardDesign, CasinoHoldemResponse } from '../types/card';
 import { CasinoHoldemPage } from './CasinoHoldemPage';
@@ -274,5 +275,40 @@ describe('CasinoHoldemPage', () => {
     mockApi.mockClear();
     fireEvent.click(screen.getByRole('button', { name: '次のゲーム' }));
     await waitFor(() => expect(mockApi).toHaveBeenCalledWith('reset'));
+  });
+});
+
+// --- keyboard shortcut execution (#4429) ---
+// Every key here is gated on a specific phase, so each case pairs the key with
+// the fixture that enables it. Asserting the exact command *and* arguments is
+// the point: a table that only checked "exec was called" would still pass if two
+// keys were swapped, which is the defect class these tests exist to catch.
+const kbdCases: [string, unknown[], CasinoHoldemResponse][] = [
+  ['b', ['bet', 100, 0], betPhaseState],
+  ['c', ['call'], flopState],
+  ['f', ['fold'], flopState],
+  ['r', ['reset'], endPlayerWins],
+];
+
+describe('CasinoHoldemPage keyboard shortcuts', () => {
+  it.each(kbdCases)('pressing %s dispatches %j', async (key, expected, state) => {
+    mockApi.mockResolvedValue(state);
+    renderWithProviders(<CasinoHoldemPage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
+    mockApi.mockClear();
+    mockApi.mockResolvedValue(state);
+    fireEvent.keyDown(document, { key });
+    await waitFor(() => expect(mockApi).toHaveBeenCalledWith(...expected));
+  });
+
+  it('ignores a key whose phase gate is closed', async () => {
+    // 'b' places the ante and is enabled only in the BET phase.
+    mockApi.mockResolvedValue(flopState);
+    renderWithProviders(<CasinoHoldemPage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
+    mockApi.mockClear();
+    fireEvent.keyDown(document, { key: 'b' });
+    await flushPendingDispatch();
+    expect(mockApi).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/CrescentPage.test.tsx
+++ b/frontend/src/pages/CrescentPage.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { actionLogApi, crescentApi } from '../api/gameApi';
 import { useGameHint } from '../hooks/useGameHint';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, CardDesign, CrescentResponse, CrescentTableauCard } from '../types/card';
 import { CrescentPage } from './CrescentPage';
@@ -174,6 +175,7 @@ describe('CrescentPage', () => {
     mockExec.mockResolvedValue(gameOverState);
     // Clicking give-up must NOT dispatch immediately — it opens a confirm dialog (#2099).
     fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('giveup');
     expect(screen.getByText('投了確認')).toBeInTheDocument();
     // Confirming dispatches giveup.
@@ -382,6 +384,7 @@ describe('CrescentPage keyboard shortcuts', () => {
     for (const key of ['d', 'h', 'a', 'z']) {
       fireEvent.keyDown(document, { key });
     }
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/CruelPage.test.tsx
+++ b/frontend/src/pages/CruelPage.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { cruelApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, CardDesign, CruelResponse } from '../types/card';
 import { CruelPage } from './CruelPage';
@@ -156,6 +157,7 @@ describe('CruelPage', () => {
     mockExec.mockClear();
     // Clicking give-up must NOT dispatch immediately — it opens a confirm dialog (#2099).
     fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('giveup');
     expect(screen.getByText('投了確認')).toBeInTheDocument();
     // Confirming dispatches giveup.
@@ -296,6 +298,7 @@ describe('CruelPage keyboard shortcuts', () => {
     for (const key of ['h', 'a', 'z', 's']) {
       fireEvent.keyDown(document, { key });
     }
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/EasthavenPage.test.tsx
+++ b/frontend/src/pages/EasthavenPage.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { easthavenApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, CardDesign, EasthavenResponse } from '../types/card';
 import { EasthavenPage } from './EasthavenPage';
@@ -160,6 +161,7 @@ describe('EasthavenPage', () => {
     mockExec.mockClear();
     // Clicking give-up must NOT dispatch immediately — it opens a confirm dialog (#2099).
     fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('giveup');
     expect(screen.getByText('投了確認')).toBeInTheDocument();
     // Confirming dispatches giveup.
@@ -300,6 +302,7 @@ describe('EasthavenPage', () => {
     mockExec.mockClear();
     // ♥8 has no legal foundation target (the empty ♥ pile needs an Ace first).
     fireEvent.doubleClick(screen.getByRole('button', { name: '♥ 8' }));
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('move', expect.anything(), expect.anything());
   });
 
@@ -387,6 +390,7 @@ describe('EasthavenPage keyboard shortcuts', () => {
     for (const key of ['h', 'a', 'z', 'd']) {
       fireEvent.keyDown(document, { key });
     }
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/FiveCardStudPage.test.tsx
+++ b/frontend/src/pages/FiveCardStudPage.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fiveCardStudApi } from '../api/gameApi';
 import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { FiveCardStudPlayerData, FiveCardStudResponse } from '../types/card';
 import { FiveCardStudPage } from './FiveCardStudPage';
@@ -379,5 +380,56 @@ describe('FiveCardStudPage', () => {
     // Outwait the celebration's 400ms delay so a wrongly-fired overlay would be visible.
     await act(() => new Promise((resolve) => setTimeout(resolve, 600)));
     expect(screen.queryByTestId('win-celebration')).not.toBeInTheDocument();
+  });
+});
+
+// --- keyboard shortcut execution (#4429) ---
+// These bindings are gated on the betting situation rather than on a phase: 'c'
+// (call) needs an outstanding bet and 'k' (check) needs the absence of one, and
+// 'r' is a single key whose command *changes* with that same condition — raise
+// when there is a bet to raise, open bet when there is not. Both branches are
+// covered below, since a regression collapsing them would leave one command
+// unreachable from the keyboard while every button still worked.
+//
+// The trailing argument is the elapsed-thinking-time reading, which is a live
+// measurement rather than a fixed value, so it is matched as a number.
+const kbdCases: [string, unknown[], FiveCardStudResponse][] = [
+  ['c', ['call', undefined, undefined, expect.any(Number)], secondStreetWithBetState],
+  ['r', ['raise', 20, undefined, expect.any(Number)], secondStreetWithBetState],
+  ['k', ['check', undefined, undefined, expect.any(Number)], secondStreetState],
+  ['r', ['bet', 20, undefined, expect.any(Number)], secondStreetState],
+  ['f', ['fold', undefined, undefined, expect.any(Number)], secondStreetState],
+  ['a', ['allin', undefined, undefined, expect.any(Number)], secondStreetState],
+];
+
+describe('FiveCardStudPage keyboard shortcuts', () => {
+  it.each(kbdCases)('pressing %s dispatches %j', async (key, expected, state) => {
+    mockExec.mockResolvedValue(state);
+    renderWithProviders(<FiveCardStudPage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
+    mockExec.mockClear();
+    mockExec.mockResolvedValue(state);
+    fireEvent.keyDown(document, { key });
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith(...expected));
+  });
+
+  it('ignores check while a bet is outstanding', async () => {
+    mockExec.mockResolvedValue(secondStreetWithBetState);
+    renderWithProviders(<FiveCardStudPage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
+    mockExec.mockClear();
+    fireEvent.keyDown(document, { key: 'k' });
+    await flushPendingDispatch();
+    expect(mockExec).not.toHaveBeenCalled();
+  });
+
+  it('ignores call when there is nothing to call', async () => {
+    mockExec.mockResolvedValue(secondStreetState);
+    renderWithProviders(<FiveCardStudPage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
+    mockExec.mockClear();
+    fireEvent.keyDown(document, { key: 'c' });
+    await flushPendingDispatch();
+    expect(mockExec).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/FlowerGardenPage.test.tsx
+++ b/frontend/src/pages/FlowerGardenPage.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { flowerGardenApi } from '../api/gameApi';
 import { useGameHint } from '../hooks/useGameHint';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, CardDesign, FlowerGardenResponse, FlowerGardenTableauCard } from '../types/card';
 import { FlowerGardenPage } from './FlowerGardenPage';
@@ -144,6 +145,7 @@ describe('FlowerGardenPage', () => {
     mockExec.mockClear();
     mockExec.mockResolvedValue(gameOverState);
     fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('giveup');
     expect(screen.getByText('投了確認')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: '確認' }));
@@ -216,6 +218,7 @@ describe('FlowerGardenPage keyboard shortcuts', () => {
     for (const key of ['h', 'a', 'z']) {
       fireEvent.keyDown(document, { key });
     }
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/FortyAndEightPage.test.tsx
+++ b/frontend/src/pages/FortyAndEightPage.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { actionLogApi, fortyAndEightApi } from '../api/gameApi';
 import { useGameHint } from '../hooks/useGameHint';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, CardDesign, FortyAndEightResponse, FortyAndEightTableauCard } from '../types/card';
 import { FortyAndEightPage } from './FortyAndEightPage';
@@ -277,6 +278,7 @@ describe('FortyAndEightPage', () => {
     mockExec.mockClear();
     mockExec.mockResolvedValue(gameOverState);
     fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('giveup');
     expect(screen.getByText('投了確認')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: '確認' }));
@@ -587,6 +589,7 @@ describe('FortyAndEightPage keyboard shortcuts', () => {
     for (const key of ['d', 'h', 'a', 'z']) {
       fireEvent.keyDown(document, { key });
     }
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/FortyThievesPage.test.tsx
+++ b/frontend/src/pages/FortyThievesPage.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { actionLogApi, fortyThievesApi } from '../api/gameApi';
 import { useGameHint } from '../hooks/useGameHint';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, CardDesign, FortyThievesResponse, FortyThievesTableauCard } from '../types/card';
 import { FortyThievesPage } from './FortyThievesPage';
@@ -225,6 +226,7 @@ describe('FortyThievesPage', () => {
     mockExec.mockClear();
     mockExec.mockResolvedValue(gameOverState);
     fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('giveup');
     expect(screen.getByText('投了確認')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: '確認' }));
@@ -450,6 +452,7 @@ describe('FortyThievesPage', () => {
     fireEvent.dblClick(screen.getByTestId('ft-tableau-top-0'));
     fireEvent.dblClick(screen.getByTestId('ft-waste-top'));
 
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('move', expect.anything(), expect.anything());
   });
 
@@ -704,6 +707,7 @@ describe('FortyThievesPage keyboard shortcuts', () => {
     for (const key of ['d', 'h', 'a', 'z']) {
       fireEvent.keyDown(document, { key });
     }
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/GolfPage.test.tsx
+++ b/frontend/src/pages/GolfPage.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { actionLogApi, golfApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, CardDesign, GolfCard, GolfResponse } from '../types/card';
 import { GolfPage } from './GolfPage';
@@ -154,6 +155,7 @@ describe('GolfPage', () => {
     mockExec.mockClear();
     mockExec.mockResolvedValue(gameOverState);
     fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('giveup');
     expect(screen.getByText('投了確認')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: '確認' }));
@@ -411,6 +413,7 @@ describe('GolfPage keyboard shortcuts', () => {
     for (const key of ['d', 'h', 'z']) {
       fireEvent.keyDown(document, { key });
     }
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/IndianPokerPage.test.tsx
+++ b/frontend/src/pages/IndianPokerPage.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { indianpokerApi } from '../api/gameApi';
 import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { IndianPokerResponse } from '../types/card';
 import { IndianPokerPage } from './IndianPokerPage';
@@ -884,5 +885,56 @@ describe('IndianPokerPage', () => {
       await waitFor(() => expect(screen.getByText(/CPU 1/)).toBeInTheDocument());
       expect(screen.queryByText(/バランス型/)).not.toBeInTheDocument();
     });
+  });
+});
+
+// --- keyboard shortcut execution (#4429) ---
+// These bindings are gated on the betting situation rather than on a phase: 'c'
+// (call) needs an outstanding bet and 'k' (check) needs the absence of one, and
+// 'r' is a single key whose command *changes* with that same condition — raise
+// when there is a bet to raise, open bet when there is not. Both branches are
+// covered below, since a regression collapsing them would leave one command
+// unreachable from the keyboard while every button still worked.
+//
+// The trailing argument is the elapsed-thinking-time reading, which is a live
+// measurement rather than a fixed value, so it is matched as a number.
+const kbdCases: [string, unknown[], IndianPokerResponse][] = [
+  ['c', ['call', undefined, undefined, expect.any(Number)], bettingWithBetState],
+  ['r', ['raise', 20, undefined, expect.any(Number)], bettingWithBetState],
+  ['k', ['check', undefined, undefined, expect.any(Number)], bettingState],
+  ['r', ['bet', 20, undefined, expect.any(Number)], bettingState],
+  ['f', ['fold', undefined, undefined, expect.any(Number)], bettingState],
+  ['a', ['allin', undefined, undefined, expect.any(Number)], bettingState],
+];
+
+describe('IndianPokerPage keyboard shortcuts', () => {
+  it.each(kbdCases)('pressing %s dispatches %j', async (key, expected, state) => {
+    mockExec.mockResolvedValue(state);
+    renderWithProviders(<IndianPokerPage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
+    mockExec.mockClear();
+    mockExec.mockResolvedValue(state);
+    fireEvent.keyDown(document, { key });
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith(...expected));
+  });
+
+  it('ignores check while a bet is outstanding', async () => {
+    mockExec.mockResolvedValue(bettingWithBetState);
+    renderWithProviders(<IndianPokerPage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
+    mockExec.mockClear();
+    fireEvent.keyDown(document, { key: 'k' });
+    await flushPendingDispatch();
+    expect(mockExec).not.toHaveBeenCalled();
+  });
+
+  it('ignores call when there is nothing to call', async () => {
+    mockExec.mockResolvedValue(bettingState);
+    renderWithProviders(<IndianPokerPage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
+    mockExec.mockClear();
+    fireEvent.keyDown(document, { key: 'c' });
+    await flushPendingDispatch();
+    expect(mockExec).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/KingAlbertPage.test.tsx
+++ b/frontend/src/pages/KingAlbertPage.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { kingAlbertApi } from '../api/gameApi';
 import { useGameHint } from '../hooks/useGameHint';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, CardDesign, KingAlbertResponse, KingAlbertTableauCard } from '../types/card';
 import { KingAlbertPage } from './KingAlbertPage';
@@ -139,6 +140,7 @@ describe('KingAlbertPage', () => {
     mockExec.mockClear();
     mockExec.mockResolvedValue(gameOverState);
     fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('giveup');
     expect(screen.getByText('投了確認')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: '確認' }));
@@ -211,6 +213,7 @@ describe('KingAlbertPage keyboard shortcuts', () => {
     for (const key of ['h', 'a', 'z']) {
       fireEvent.keyDown(document, { key });
     }
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/MississippiStudPage.test.tsx
+++ b/frontend/src/pages/MississippiStudPage.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { mississippiStudApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, CardDesign, MaskedCard, MississippiStudResponse } from '../types/card';
 import { MississippiStudPhase } from '../types/phases';
@@ -330,5 +331,53 @@ describe('MississippiStudPage', () => {
     await waitFor(() => expect(screen.getByRole('button', { name: 'アンティ' })).toBeInTheDocument());
     // CLI toggle is intentionally hidden until CLI command parsing is implemented
     expect(screen.queryByRole('button', { name: /CLI/i })).not.toBeInTheDocument();
+  });
+});
+
+// --- keyboard shortcut execution (#4429) ---
+// 1/2/3 are the raise multipliers and differ only by their third argument, so
+// asserting that argument is the only thing that distinguishes them: a test that
+// checked the command name alone would pass with all three wired to the same
+// multiplier.
+const kbdCases: [string, unknown[], MississippiStudResponse][] = [
+  ['b', ['bet', 100], antePhaseState],
+  ['1', ['play', undefined, 1], thirdStreetState],
+  ['2', ['play', undefined, 2], thirdStreetState],
+  ['3', ['play', undefined, 3], thirdStreetState],
+  ['f', ['fold'], thirdStreetState],
+  ['r', ['reset'], endPhaseWin],
+];
+
+describe('MississippiStudPage keyboard shortcuts', () => {
+  it.each(kbdCases)('pressing %s dispatches %j', async (key, expected, state) => {
+    mockApi.mockResolvedValue(state);
+    renderWithProviders(<MississippiStudPage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
+    mockApi.mockClear();
+    mockApi.mockResolvedValue(state);
+    fireEvent.keyDown(document, { key });
+    await waitFor(() => expect(mockApi).toHaveBeenCalledWith(...expected));
+  });
+
+  // The street keys stay live across all three streets, not just the third.
+  it('accepts a street raise on fourth street too', async () => {
+    mockApi.mockResolvedValue(fourthStreetState);
+    renderWithProviders(<MississippiStudPage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
+    mockApi.mockClear();
+    mockApi.mockResolvedValue(fourthStreetState);
+    fireEvent.keyDown(document, { key: '3' });
+    await waitFor(() => expect(mockApi).toHaveBeenCalledWith('play', undefined, 3));
+  });
+
+  it('ignores a key whose phase gate is closed', async () => {
+    // Folding is a street decision; there is nothing to fold before the ante.
+    mockApi.mockResolvedValue(antePhaseState);
+    renderWithProviders(<MississippiStudPage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
+    mockApi.mockClear();
+    fireEvent.keyDown(document, { key: 'f' });
+    await flushPendingDispatch();
+    expect(mockApi).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/OasisPokerPage.test.tsx
+++ b/frontend/src/pages/OasisPokerPage.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { oasispokerApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, CardDesign, OasisPokerResponse } from '../types/card';
 import { OasisPokerPage } from './OasisPokerPage';
@@ -270,5 +271,41 @@ describe('OasisPokerPage', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'ベット' }));
     await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+  });
+});
+
+// --- keyboard shortcut execution (#4429) ---
+// 'e' sends the current card selection, which is empty on a fresh mount — that
+// empty array is part of the wire contract, so it is asserted rather than
+// matched loosely.
+const kbdCases: [string, unknown[], OasisPokerResponse][] = [
+  ['b', ['bet', 100, 0], betPhaseState],
+  ['s', ['stand'], exchangePhaseState],
+  ['e', ['exchange', undefined, undefined, []], exchangePhaseState],
+  ['p', ['play'], actionPhaseState],
+  ['f', ['fold'], actionPhaseState],
+  ['r', ['reset'], endPhasePlayerWins],
+];
+
+describe('OasisPokerPage keyboard shortcuts', () => {
+  it.each(kbdCases)('pressing %s dispatches %j', async (key, expected, state) => {
+    mockApi.mockResolvedValue(state);
+    renderWithProviders(<OasisPokerPage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
+    mockApi.mockClear();
+    mockApi.mockResolvedValue(state);
+    fireEvent.keyDown(document, { key });
+    await waitFor(() => expect(mockApi).toHaveBeenCalledWith(...expected));
+  });
+
+  it('ignores a key whose phase gate is closed', async () => {
+    // 'p' (play) belongs to the ACTION phase, not the opening bet.
+    mockApi.mockResolvedValue(betPhaseState);
+    renderWithProviders(<OasisPokerPage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
+    mockApi.mockClear();
+    fireEvent.keyDown(document, { key: 'p' });
+    await flushPendingDispatch();
+    expect(mockApi).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/RedDogPage.test.tsx
+++ b/frontend/src/pages/RedDogPage.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { reddogApi } from '../api/gameApi';
 import { useCliMode } from '../hooks/useCliMode';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, CardDesign, RedDogResponse } from '../types/card';
 import { RedDogPhase } from '../types/phases';
@@ -172,5 +173,36 @@ describe('RedDogPage', () => {
     await waitFor(() => expect(screen.getByTestId('reddog-ghost-7')).toBeInTheDocument());
     const hitChip = screen.getByTestId('reddog-ghost-7');
     expect(hitChip.className).toContain('bg-ds-success');
+  });
+});
+
+// --- keyboard shortcut execution (#4429) ---
+// Red Dog binds only three keys, each gated on a different phase.
+const kbdCases: [string, unknown[], RedDogResponse][] = [
+  ['b', ['bet', 100], betState],
+  ['s', ['stay'], spreadState],
+  ['r', ['reset'], winState],
+];
+
+describe('RedDogPage keyboard shortcuts', () => {
+  it.each(kbdCases)('pressing %s dispatches %j', async (key, expected, state) => {
+    mockApi.mockResolvedValue(state);
+    renderWithProviders(<RedDogPage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
+    mockApi.mockClear();
+    mockApi.mockResolvedValue(state);
+    fireEvent.keyDown(document, { key });
+    await waitFor(() => expect(mockApi).toHaveBeenCalledWith(...expected));
+  });
+
+  it('ignores a key whose phase gate is closed', async () => {
+    // 's' (stay) is only offered once the spread has been revealed.
+    mockApi.mockResolvedValue(betState);
+    renderWithProviders(<RedDogPage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
+    mockApi.mockClear();
+    fireEvent.keyDown(document, { key: 's' });
+    await flushPendingDispatch();
+    expect(mockApi).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/RussianSolitairePage.test.tsx
+++ b/frontend/src/pages/RussianSolitairePage.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { russianSolitaireApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, CardDesign, RussianSolitaireResponse } from '../types/card';
 import { RussianSolitairePage } from './RussianSolitairePage';
@@ -192,6 +193,7 @@ describe('RussianSolitairePage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
     mockExec.mockClear();
     fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('giveup');
     expect(screen.getByText('投了確認')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: '確認' }));
@@ -289,6 +291,7 @@ describe('RussianSolitairePage keyboard shortcuts', () => {
     for (const key of ['h', 'a', 'z']) {
       fireEvent.keyDown(document, { key });
     }
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/SeahavenTowersPage.test.tsx
+++ b/frontend/src/pages/SeahavenTowersPage.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { seahaventowersApi } from '../api/gameApi';
 import { useGameHint } from '../hooks/useGameHint';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, CardDesign, SeahavenTowersResponse } from '../types/card';
 import { SeahavenTowersPage } from './SeahavenTowersPage';
@@ -217,6 +218,7 @@ describe('SeahavenTowersPage', () => {
     mockExec.mockClear();
     mockExec.mockResolvedValue(gameOverState);
     fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('giveup');
     expect(screen.getByText('投了確認')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: '確認' }));
@@ -306,6 +308,7 @@ describe('SeahavenTowersPage keyboard shortcuts', () => {
     for (const key of ['h', 'a', 'z']) {
       fireEvent.keyDown(document, { key });
     }
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/SevenCardStudPage.test.tsx
+++ b/frontend/src/pages/SevenCardStudPage.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { sevenCardStudApi } from '../api/gameApi';
 import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { SevenCardStudResponse } from '../types/card';
 import { SevenCardStudPage } from './SevenCardStudPage';
@@ -772,5 +773,56 @@ describe('SevenCardStudPage', () => {
     expect(container.querySelector('#cpuMetaAI')).toBeInTheDocument();
     expect(screen.getByLabelText('ヒント表示')).toBeInTheDocument();
     expect(screen.getByLabelText('メタAI（CPUがプレイスタイルを学習）')).toBeInTheDocument();
+  });
+});
+
+// --- keyboard shortcut execution (#4429) ---
+// These bindings are gated on the betting situation rather than on a phase: 'c'
+// (call) needs an outstanding bet and 'k' (check) needs the absence of one, and
+// 'r' is a single key whose command *changes* with that same condition — raise
+// when there is a bet to raise, open bet when there is not. Both branches are
+// covered below, since a regression collapsing them would leave one command
+// unreachable from the keyboard while every button still worked.
+//
+// The trailing argument is the elapsed-thinking-time reading, which is a live
+// measurement rather than a fixed value, so it is matched as a number.
+const kbdCases: [string, unknown[], SevenCardStudResponse][] = [
+  ['c', ['call', undefined, undefined, expect.any(Number)], thirdStreetWithBetState],
+  ['r', ['raise', 20, undefined, expect.any(Number)], thirdStreetWithBetState],
+  ['k', ['check', undefined, undefined, expect.any(Number)], thirdStreetState],
+  ['r', ['bet', 20, undefined, expect.any(Number)], thirdStreetState],
+  ['f', ['fold', undefined, undefined, expect.any(Number)], thirdStreetState],
+  ['a', ['allin', undefined, undefined, expect.any(Number)], thirdStreetState],
+];
+
+describe('SevenCardStudPage keyboard shortcuts', () => {
+  it.each(kbdCases)('pressing %s dispatches %j', async (key, expected, state) => {
+    mockExec.mockResolvedValue(state);
+    renderWithProviders(<SevenCardStudPage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
+    mockExec.mockClear();
+    mockExec.mockResolvedValue(state);
+    fireEvent.keyDown(document, { key });
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith(...expected));
+  });
+
+  it('ignores check while a bet is outstanding', async () => {
+    mockExec.mockResolvedValue(thirdStreetWithBetState);
+    renderWithProviders(<SevenCardStudPage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
+    mockExec.mockClear();
+    fireEvent.keyDown(document, { key: 'k' });
+    await flushPendingDispatch();
+    expect(mockExec).not.toHaveBeenCalled();
+  });
+
+  it('ignores call when there is nothing to call', async () => {
+    mockExec.mockResolvedValue(thirdStreetState);
+    renderWithProviders(<SevenCardStudPage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
+    mockExec.mockClear();
+    fireEvent.keyDown(document, { key: 'c' });
+    await flushPendingDispatch();
+    expect(mockExec).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/SpiderettePage.test.tsx
+++ b/frontend/src/pages/SpiderettePage.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { spideretteApi } from '../api/gameApi';
 import { useGameHint } from '../hooks/useGameHint';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, CardDesign, SpideretteResponse, SpideretteTableauCard } from '../types/card';
 import { SpiderettePage } from './SpiderettePage';
@@ -161,6 +162,7 @@ describe('SpiderettePage', () => {
     mockSend.mockClear();
     // Clicking give-up must NOT dispatch immediately — it opens a confirm dialog (#2099).
     fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
+    await flushPendingDispatch();
     expect(mockSend).not.toHaveBeenCalledWith('giveup');
     expect(screen.getByText('投了確認')).toBeInTheDocument();
 
@@ -211,6 +213,7 @@ describe('SpiderettePage keyboard shortcuts', () => {
     await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
     mockSend.mockClear();
     fireEvent.keyDown(document, { key: 'd' });
+    await flushPendingDispatch();
     expect(mockSend).not.toHaveBeenCalledWith('deal');
   });
 
@@ -222,6 +225,7 @@ describe('SpiderettePage keyboard shortcuts', () => {
     for (const key of ['d', 'h', 'a', 'z']) {
       fireEvent.keyDown(document, { key });
     }
+    await flushPendingDispatch();
     expect(mockSend).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/SultanPage.test.tsx
+++ b/frontend/src/pages/SultanPage.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { actionLogApi, sultanApi } from '../api/gameApi';
 import { useGameHint } from '../hooks/useGameHint';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, CardDesign, SultanResponse } from '../types/card';
 import { SultanPage } from './SultanPage';
@@ -293,6 +294,7 @@ describe('SultanPage', () => {
     mockExec.mockClear();
     mockExec.mockResolvedValue(gameOverState);
     fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('giveup');
     expect(screen.getByText('投了確認')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: '確認' }));
@@ -428,6 +430,7 @@ describe('SultanPage keyboard shortcuts', () => {
     for (const key of ['d', 'h', 'a', 'z']) {
       fireEvent.keyDown(document, { key });
     }
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/TexasHoldemBonusPage.test.tsx
+++ b/frontend/src/pages/TexasHoldemBonusPage.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { texasholdembonusApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, CardDesign, TexasHoldemBonusResponse } from '../types/card';
 import { TexasHoldemBonusPage } from './TexasHoldemBonusPage';
@@ -309,5 +310,43 @@ describe('TexasHoldemBonusPage', () => {
     mockApi.mockClear();
     fireEvent.click(screen.getByRole('button', { name: '次のゲーム' }));
     await waitFor(() => expect(mockApi).toHaveBeenCalledWith('reset'));
+  });
+});
+
+// --- keyboard shortcut execution (#4429) ---
+// 'c' and 'a' are gated on isPostFlopPhase, which is FLOP *or* TURN — both are
+// covered below, since a regression narrowing that predicate to one phase would
+// otherwise go unnoticed.
+const kbdCases: [string, unknown[], TexasHoldemBonusResponse][] = [
+  ['b', ['bet', 100, 0], betPhaseState],
+  ['p', ['play'], preFlopState],
+  ['f', ['fold'], preFlopState],
+  ['c', ['check'], flopState],
+  ['a', ['raise'], flopState],
+  ['c', ['check'], turnState],
+  ['a', ['raise'], turnState],
+  ['r', ['reset'], endPlayerWins],
+];
+
+describe('TexasHoldemBonusPage keyboard shortcuts', () => {
+  it.each(kbdCases)('pressing %s dispatches %j', async (key, expected, state) => {
+    mockApi.mockResolvedValue(state);
+    renderWithProviders(<TexasHoldemBonusPage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
+    mockApi.mockClear();
+    mockApi.mockResolvedValue(state);
+    fireEvent.keyDown(document, { key });
+    await waitFor(() => expect(mockApi).toHaveBeenCalledWith(...expected));
+  });
+
+  it('ignores a key whose phase gate is closed', async () => {
+    // 'p' (play) is the pre-flop decision and must not fire during betting.
+    mockApi.mockResolvedValue(betPhaseState);
+    renderWithProviders(<TexasHoldemBonusPage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
+    mockApi.mockClear();
+    fireEvent.keyDown(document, { key: 'p' });
+    await flushPendingDispatch();
+    expect(mockApi).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/TrenteEtQuarantePage.test.tsx
+++ b/frontend/src/pages/TrenteEtQuarantePage.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { trenteetquaranteApi } from '../api/gameApi';
 import { useCliMode } from '../hooks/useCliMode';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import { makeTrenteEtQuaranteState } from '../test/stateFactories';
 import type { Card, CardDesign } from '../types/card';
@@ -224,5 +225,66 @@ describe('TrenteEtQuarantePage', () => {
     mockApi.mockResolvedValue(betState);
     renderWithProviders(<TrenteEtQuarantePage />);
     await waitFor(() => expect(screen.queryByTestId('teq-deal-button')).not.toBeInTheDocument());
+  });
+});
+
+// --- keyboard shortcut execution (#4429) ---
+describe('TrenteEtQuarantePage keyboard shortcuts', () => {
+  it('pressing d places the currently selected bet', async () => {
+    mockApi.mockResolvedValue(betState);
+    renderWithProviders(<TrenteEtQuarantePage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
+    mockApi.mockClear();
+    mockApi.mockResolvedValue(betState);
+    fireEvent.keyDown(document, { key: 'd' });
+    await waitFor(() => expect(mockApi).toHaveBeenCalledWith('bet', TrenteEtQuaranteBetType.NOIR, 100));
+  });
+
+  it('pressing r starts the next round from the result phase', async () => {
+    mockApi.mockResolvedValue(endState);
+    renderWithProviders(<TrenteEtQuarantePage />);
+    await screen.findByTestId('teq-next-round-button');
+    mockApi.mockClear();
+    fireEvent.keyDown(document, { key: 'r' });
+    await waitFor(() => expect(mockApi).toHaveBeenCalledWith('nextround'));
+  });
+
+  it('leaves e inert until a bet has actually been placed this session', async () => {
+    // canRebet is derived from a bet placed in this session, not from server
+    // state, so arriving at a result phase without having staked anything (a
+    // reload, say) leaves the rebet shortcut with nothing to replay.
+    mockApi.mockResolvedValue(endState);
+    renderWithProviders(<TrenteEtQuarantePage />);
+    await screen.findByTestId('teq-next-round-button');
+    mockApi.mockClear();
+    fireEvent.keyDown(document, { key: 'e' });
+    await flushPendingDispatch();
+    expect(mockApi).not.toHaveBeenCalled();
+  });
+
+  it('pressing e after a bet advances the round and re-stakes the same bet', async () => {
+    mockApi.mockResolvedValue(betState);
+    renderWithProviders(<TrenteEtQuarantePage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
+    // Stake a bet and let the server answer with the resolved round, which is
+    // what makes the rebet shortcut live.
+    mockApi.mockResolvedValue(endState);
+    fireEvent.keyDown(document, { key: 'd' });
+    await screen.findByTestId('teq-next-round-button');
+    mockApi.mockClear();
+    fireEvent.keyDown(document, { key: 'e' });
+    // Rebet is two commands in order: advance, then re-stake.
+    await waitFor(() => expect(mockApi).toHaveBeenCalledWith('nextround'));
+    await waitFor(() => expect(mockApi).toHaveBeenCalledWith('bet', TrenteEtQuaranteBetType.NOIR, 100));
+  });
+
+  it('ignores the bet key once the round has been resolved', async () => {
+    mockApi.mockResolvedValue(endState);
+    renderWithProviders(<TrenteEtQuarantePage />);
+    await screen.findByTestId('teq-next-round-button');
+    mockApi.mockClear();
+    fireEvent.keyDown(document, { key: 'd' });
+    await flushPendingDispatch();
+    expect(mockApi).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/TriPeaksPage.test.tsx
+++ b/frontend/src/pages/TriPeaksPage.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { actionLogApi, tripeaksApi } from '../api/gameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { TRIPEAKS_STATS_KEY } from '../hooks/useTriPeaksStats';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, CardDesign, TriPeaksCard, TriPeaksResponse } from '../types/card';
 import { computePeakRemaining, TriPeaksPage } from './TriPeaksPage';
@@ -183,6 +184,7 @@ describe('TriPeaksPage', () => {
     mockExec.mockResolvedValue(gameOverState);
     // Clicking give-up must NOT dispatch immediately — it opens a confirm dialog (#2099).
     fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('giveup');
     expect(screen.getByText('投了確認')).toBeInTheDocument();
 
@@ -480,6 +482,7 @@ describe('TriPeaksPage keyboard shortcuts', () => {
     for (const key of ['d', 'h', 'z']) {
       fireEvent.keyDown(document, { key });
     }
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/UltimateTexasHoldemPage.test.tsx
+++ b/frontend/src/pages/UltimateTexasHoldemPage.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ultimatetexasholdemApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, CardDesign, UltimateTexasHoldemResponse } from '../types/card';
 import { UltimateTexasHoldemPage } from './UltimateTexasHoldemPage';
@@ -432,6 +433,7 @@ describe('UltimateTexasHoldemPage', () => {
 
     // A blocked over-balance bet must not reach the server.
     fireEvent.click(screen.getByRole('button', { name: 'ベット' }));
+    await flushPendingDispatch();
     expect(mockApi).not.toHaveBeenCalledWith('bet', expect.anything(), expect.anything());
   });
 
@@ -449,5 +451,44 @@ describe('UltimateTexasHoldemPage', () => {
     fireEvent.change(screen.getByLabelText('アンテ'), { target: { value: '400' } });
     await waitFor(() => expect(Number(tripsInput.value)).toBe(200));
     expect(screen.queryByTestId('uth-bet-error')).not.toBeInTheDocument();
+  });
+});
+
+// --- keyboard shortcut execution (#4429) ---
+// The digit keys are the play multipliers (4x/3x pre-flop, 2x on the flop, 1x on
+// the river) and differ only by their fourth argument, so that argument is what
+// each case pins.
+const kbdCases: [string, unknown[], UltimateTexasHoldemResponse][] = [
+  ['b', ['bet', 100, 0], betPhaseState],
+  ['4', ['play', undefined, undefined, 4], preFlopState],
+  ['3', ['play', undefined, undefined, 3], preFlopState],
+  ['c', ['check'], preFlopState],
+  ['2', ['play', undefined, undefined, 2], flopState],
+  ['c', ['check'], flopState],
+  ['1', ['play', undefined, undefined, 1], riverState],
+  ['f', ['fold'], riverState],
+  ['r', ['reset'], endPlayerWins],
+];
+
+describe('UltimateTexasHoldemPage keyboard shortcuts', () => {
+  it.each(kbdCases)('pressing %s dispatches %j', async (key, expected, state) => {
+    mockApi.mockResolvedValue(state);
+    renderWithProviders(<UltimateTexasHoldemPage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
+    mockApi.mockClear();
+    mockApi.mockResolvedValue(state);
+    fireEvent.keyDown(document, { key });
+    await waitFor(() => expect(mockApi).toHaveBeenCalledWith(...expected));
+  });
+
+  it('ignores a play multiplier that belongs to another street', async () => {
+    // '2' is the flop bet; pre-flop offers only 4x and 3x.
+    mockApi.mockResolvedValue(preFlopState);
+    renderWithProviders(<UltimateTexasHoldemPage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
+    mockApi.mockClear();
+    fireEvent.keyDown(document, { key: '2' });
+    await flushPendingDispatch();
+    expect(mockApi).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/YukonPage.test.tsx
+++ b/frontend/src/pages/YukonPage.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { yukonApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, CardDesign, YukonResponse } from '../types/card';
 import { YukonPage } from './YukonPage';
@@ -162,6 +163,7 @@ describe('YukonPage', () => {
     mockExec.mockClear();
     // Clicking give-up must NOT dispatch immediately — it opens a confirm dialog (#2099).
     fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('giveup');
     expect(screen.getByText('投了確認')).toBeInTheDocument();
 
@@ -326,6 +328,7 @@ describe('YukonPage keyboard shortcuts', () => {
     for (const key of ['h', 'a', 'z']) {
       fireEvent.keyDown(document, { key });
     }
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/test/flushPendingDispatch.ts
+++ b/frontend/src/test/flushPendingDispatch.ts
@@ -1,0 +1,33 @@
+/**
+ * Waits until a command triggered by `fireEvent` has actually reached the mocked
+ * game API, so that a "nothing was dispatched" assertion means something.
+ *
+ * `exec` from {@link hooks/useGameApi.useGameApi | useGameApi} dispatches through
+ * react-query's `mutateAsync`, which invokes the mutation function on a microtask
+ * rather than synchronously. So this:
+ *
+ * ```ts
+ * fireEvent.keyDown(document, { key: 'b' });
+ * expect(mockApi).not.toHaveBeenCalled(); // passes even when 'b' DID fire
+ * ```
+ *
+ * passes unconditionally — at that instant the call has not happened yet, whether
+ * or not the key was bound. Awaiting this first makes the assertion real:
+ *
+ * ```ts
+ * fireEvent.keyDown(document, { key: 'b' });
+ * await flushPendingDispatch();
+ * expect(mockApi).not.toHaveBeenCalled(); // now fails if 'b' fired
+ * ```
+ *
+ * A single microtask is enough to observe the call, but this yields a macrotask so
+ * that actions chaining more than one `await` (a rebet that advances the round and
+ * then re-stakes it, say) are also fully settled.
+ *
+ * Positive assertions do not need this — `waitFor` already retries.
+ */
+export function flushPendingDispatch(): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
+}


### PR DESCRIPTION
Finishes the keyboard-shortcut execution coverage started in #4438: the 11 casino/poker pages that PR deferred, plus a correctness fix to the tests that PR already merged.

## The 11 remaining pages — 55 bindings

Unlike the 16 uniform solitaire pages, every key here is **phase-gated**, so each case pairs the key with the fixture that enables it. All the fixtures already existed.

| Page | Keys |
|---|---|
| `UltimateTexasHoldem` | `b` `4` `3` `c`(pre-flop + flop) `2` `1` `f` `r` |
| `MississippiStud` | `b` `1` `2` `3` `f` `r` (+ a street key on fourth street) |
| `OasisPoker` | `b` `s` `e` `p` `f` `r` |
| `TexasHoldemBonus` | `b` `p` `f` `c`/`a` (flop **and** turn) `r` |
| `IndianPoker`, `FiveCardStud`, `SevenCardStud` | `c` `k` `f` `a`, and both branches of `r` |
| `CaribbeanStud`, `CasinoHoldem` | `b` `p`/`c` `f` `r` |
| `RedDog` | `b` `s` `r` |
| `TrenteEtQuarante` | `d` `r`, and both halves of `e` |

Cases assert the **command and its arguments**, because on several pages that is the only thing distinguishing two keys: Mississippi Stud's `1`/`2`/`3` and UTH's `4`/`3`/`2`/`1` differ solely in a raise multiplier, so a test checking the command name alone would pass with all of them wired to the same one. Three bindings needed both branches covered rather than one case:

- **`r` on the three stud pages** is one key whose command *changes* with the betting situation — `raise` when there is a bet outstanding, open `bet` when there is not. A regression collapsing that would leave one command unreachable from the keyboard while both buttons still worked.
- **`c`/`a` on Texas Hold'em Bonus** are gated on `isPostFlopPhase`, which is FLOP *or* TURN.
- **`e` on Trente et Quarante** depends on `canRebet`, which is derived from a bet placed in this session rather than from server state — so it is inert on a freshly loaded result phase and only becomes live after the player actually stakes something. Both halves are covered.

## The tests merged in #4438 were partly vacuous — fixed here

While mutation-testing these I removed a page's phase gate expecting the new negative test to fail. **It passed.** The cause is not page-specific:

`exec` from `useGameApi` dispatches through react-query's `mutateAsync`, which invokes the mutation function on a **microtask, not synchronously**. Measured directly:

```
fireEvent.keyDown(document, { key: 'b' })
  sync            -> []
  1 microtask     -> [["bet",100,0]]
```

So `expect(mockApi).not.toHaveBeenCalled()` placed directly after `fireEvent` passes **whether or not the key fired** — there was simply nothing to see yet. That pattern is in the negative tests #4438 merged, so those 16 assertions were not testing what they claimed.

Fixed with `flushPendingDispatch()` (new, in `src/test/`), which documents the cause once instead of scattering the reasoning across 27 files. Applied to all **51** such assertions in the 27 pages in this issue's scope.

Verified by mutation, not by inspection — the same gate removal that used to pass now fails:

| Mutation | Before | After |
|---|---|---|
| CasinoHoldem `b` loses its BET-phase gate | 24 passed ❌ | `× ignores a key whose phase gate is closed` ✅ |
| Yukon shortcuts stay live after game over | (same pattern) | `× ignores shortcuts once the game has ended` ✅ |
| UTH `2` sends multiplier 9 | — | `× pressing 2 …` ✅ |
| FiveCardStud `r` always raises, never opens a bet | — | fails ✅ |

## Not fixed here: 151 more of the same, elsewhere

The same vacuous shape exists in **60 other test files (151 assertions)** that predate this issue — all asserting on a react-query-backed api mock with no await between the event and the assertion. (A further 28 assertions in 16 component test files match the shape but are *fine*: they assert on plain prop callbacks, which are invoked synchronously.)

I left those alone to keep this PR to #4429's scope, and because making them truthful may well turn some of them red — which would be a real finding rather than a test bug. Filed separately as #4439.

## Verification

- Full suite green; test-only change plus one new test helper, no production code touched.
- `bun run typecheck`, `bun run check` (all six guards) clean.
- Every new positive case was written against the real binding array, and the four mutations above confirm the suite bites.

Closes #4429
