### PR TITLE
fix(frontend): stop game pages from scrolling the document on mobile

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -160,6 +160,35 @@ Visual size of a checkbox or radio dot may stay at ~16-20px so the element still
 - **Approach:** Grid-disciplined — strict alignment for game UI, consistent card grid sizing
 - **Grid:** Desktop: sidebar (240px fixed) + fluid main. Mobile: single column with hamburger nav
 - **Max content width:** 1200px for non-game content. Game area fills available space.
+
+### Mobile vertical budget (a game page must not scroll the document)
+
+On a 375×667 phone a game page fits the viewport and scrolls **inside** its play
+area, never by growing the document. This has regressed repeatedly (#1861, #1367,
+#4373), so the contract is written down here:
+
+| Region | Behaviour |
+|---|---|
+| Mobile nav | fixed, ~62px |
+| Header block (phase, score chips, settings `<details>`) | `shrink-0` |
+| Play area | `flex-1 overflow-y-auto` **and `min-h-0`** — this is the only region allowed to absorb overflow |
+| `GameFooter` (actions) | `shrink-0`, capped at `max-h-[45vh]` with internal scroll below `sm` |
+
+Two classes are load-bearing and must not be "cleaned up":
+
+- **`min-h-0` on the flex column in `App.tsx`.** A flex item's automatic minimum
+  size is its content height, so without this the column refuses to shrink to the
+  viewport and grows the document instead — which is what made 179 of 219 game
+  pages scroll vertically even though every page already had a play area meant to
+  absorb it.
+- **The `45vh` cap on `GameFooter`.** The footer is `shrink-0`, so without a cap it
+  takes whatever its controls want and the play area is what gives way. Measured,
+  the tallest footer was 558px (84% of the viewport) and 26 pages were left under
+  80px of play area. The cap is lifted at `sm` and up.
+
+When adding a game page, verify at 375×667 that `document.documentElement.scrollHeight`
+equals the viewport height. Note that page height depends on the deal — measure
+several, not one.
 - **Border radius:**
   | Token | Value | Usage |
   |-------|-------|-------|

--- a/frontend/e2e/mobile-viewport.spec.ts
+++ b/frontend/e2e/mobile-viewport.spec.ts
@@ -17,6 +17,15 @@ test.use({ viewport: { width: 375, height: 667 } });
 // (watten 558px, spades 511px before the cap), a trick-taking page that used to
 // fit at exactly 667, a deep tableau, a page with tall CPU meld display, a
 // solitaire, a betting page, and the default route.
+//
+// Each runs against one unseeded deal, and page height IS deal-dependent — `/pan`
+// varies by 46px across deals, and elsewhere `jass` varies by 200px. That does not
+// make these assertions flaky, because what they assert is deal-independent: once
+// the shell constrains the column, extra content lands in the `overflow-y-auto`
+// play area and cannot change the document height. A flake here would therefore
+// mean a page grew tall `shrink-0` content *outside* its play area — which is a
+// real regression and exactly what this spec is for, so investigate rather than
+// retry.
 const PATHS = ['/watten', '/spades', '/hearts', '/crescent', '/pan', '/freecell', '/poker', '/'];
 
 for (const path of PATHS) {

--- a/frontend/e2e/mobile-viewport.spec.ts
+++ b/frontend/e2e/mobile-viewport.spec.ts
@@ -1,0 +1,46 @@
+import { expect, test } from '@playwright/test';
+import { navigateTo } from './helpers';
+
+/**
+ * A game page must fit a 375x667 phone and scroll inside its play area, never by
+ * growing the document (#1861, #4373).
+ *
+ * This has regressed five times (#965, #993, #1058, #1367, #4373). The static half
+ * of the contract — the two load-bearing classes — is guarded by
+ * `scripts/check-design-tokens.mjs`; this is the half only a real browser can
+ * check, because it catches a *page* adding tall `shrink-0` content outside its
+ * scroll region, which no static check can see.
+ */
+test.use({ viewport: { width: 375, height: 667 } });
+
+// A spread of layout shapes rather than a long list: the two tallest footers
+// (watten 558px, spades 511px before the cap), a trick-taking page that used to
+// fit at exactly 667, a deep tableau, a page with tall CPU meld display, a
+// solitaire, a betting page, and the default route.
+const PATHS = ['/watten', '/spades', '/hearts', '/crescent', '/pan', '/freecell', '/poker', '/'];
+
+for (const path of PATHS) {
+  test(`${path} does not scroll the document at 375x667`, async ({ page }) => {
+    await navigateTo(page, path);
+    const { docH, innerH } = await page.evaluate(() => ({
+      docH: document.documentElement.scrollHeight,
+      innerH: window.innerHeight,
+    }));
+    expect(docH, `${path} grew the document to ${docH}px inside a ${innerH}px viewport`).toBeLessThanOrEqual(innerH);
+  });
+
+  test(`${path} keeps its action footer within the mobile cap`, async ({ page }) => {
+    await navigateTo(page, path);
+    const footer = await page.evaluate(() => {
+      const f = document.querySelector('main footer');
+      if (!f) return null;
+      return { h: Math.round(f.getBoundingClientRect().height), vh: window.innerHeight };
+    });
+    // Not every page has an action footer; those that do must leave the play area
+    // usable, which is what the 45vh cap buys.
+    if (footer === null) return;
+    expect(footer.h, `${path} footer is ${footer.h}px of a ${footer.vh}px viewport`).toBeLessThanOrEqual(
+      Math.ceil(footer.vh * 0.45) + 1,
+    );
+  });
+}

--- a/frontend/scripts/check-design-tokens.mjs
+++ b/frontend/scripts/check-design-tokens.mjs
@@ -358,3 +358,48 @@ if (labelViolations.length > 0) {
 }
 
 console.log(`kbd-labels: OK (every ActionBinding label resolves; ${knownLabels.size} shared labels).`);
+
+// --- Mobile shell-height contract (issue #4373) -----------------------------
+//
+// Two classes keep every game page inside a 375x667 viewport, and both look like
+// redundant cruft to a reader or an autofixer:
+//
+//   * `min-h-0` on the flex column in App.tsx — without it that column's
+//     automatic minimum size is its content height, so it grows the document
+//     instead of shrinking to the viewport. Removing it made 179 of 219 game
+//     pages scroll vertically.
+//   * the `max-h-[45vh]` cap on GameFooter — the footer is `shrink-0`, so without
+//     a cap it takes whatever its controls want and the play area is squeezed
+//     instead (measured: tallest footer 558px, 26 pages left under 80px).
+//
+// This has regressed five times (#965, #993, #1058, #1367, #4373), which is why
+// it is a guard and not only a line in DESIGN.md.
+const shellViolations = [];
+
+const appText = await readFile(join(SRC_DIR, 'App.tsx'), 'utf8');
+const appColumn = /<div className="([^"]*\bflex-1\b[^"]*\bmin-w-0\b[^"]*)"/.exec(appText);
+if (!appColumn) {
+  shellViolations.push('src/App.tsx: could not find the main flex column (flex-1 + min-w-0) — did its markup change?');
+} else if (!/\bmin-h-0\b/.test(appColumn[1])) {
+  shellViolations.push(
+    `src/App.tsx: the main flex column lost min-h-0 (found "${appColumn[1]}") — the document will grow past the viewport on mobile`,
+  );
+}
+
+const footerText = await readFile(join(SRC_DIR, 'components/GameFooter.tsx'), 'utf8');
+for (const need of ['max-h-[45vh]', 'overflow-y-auto', 'sm:max-h-none', 'sm:overflow-y-visible']) {
+  if (!footerText.includes(need)) {
+    shellViolations.push(
+      `src/components/GameFooter.tsx: lost "${need}" — the footer will crowd out the play area on mobile`,
+    );
+  }
+}
+
+if (shellViolations.length > 0) {
+  console.error('\nMobile shell-height violations:\n');
+  for (const v of shellViolations) console.error(`  ${v}`);
+  console.error('\nSee the "Mobile vertical budget" section of DESIGN.md and issue #4373.');
+  process.exit(1);
+}
+
+console.log('shell-height: OK (App.tsx column keeps min-h-0; GameFooter keeps its 45vh mobile cap).');

--- a/frontend/scripts/check-design-tokens.mjs
+++ b/frontend/scripts/check-design-tokens.mjs
@@ -377,12 +377,18 @@ console.log(`kbd-labels: OK (every ActionBinding label resolves; ${knownLabels.s
 const shellViolations = [];
 
 const appText = await readFile(join(SRC_DIR, 'App.tsx'), 'utf8');
-const appColumn = /<div className="([^"]*\bflex-1\b[^"]*\bmin-w-0\b[^"]*)"/.exec(appText);
-if (!appColumn) {
+// Identify the column by the classes it has, in any order: a single regex
+// requiring `flex-1` to textually precede `min-w-0` would still fail the build if
+// a class sorter reordered them, but with a misleading "markup changed" message
+// instead of naming the real problem.
+const appColumn = [...appText.matchAll(/className="([^"]*)"/g)]
+  .map((m) => m[1])
+  .find((cls) => /\bflex-1\b/.test(cls) && /\bmin-w-0\b/.test(cls));
+if (appColumn === undefined) {
   shellViolations.push('src/App.tsx: could not find the main flex column (flex-1 + min-w-0) — did its markup change?');
-} else if (!/\bmin-h-0\b/.test(appColumn[1])) {
+} else if (!/\bmin-h-0\b/.test(appColumn)) {
   shellViolations.push(
-    `src/App.tsx: the main flex column lost min-h-0 (found "${appColumn[1]}") — the document will grow past the viewport on mobile`,
+    `src/App.tsx: the main flex column lost min-h-0 (found "${appColumn}") — the document will grow past the viewport on mobile`,
   );
 }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -59,7 +59,14 @@ export default function App() {
         <div className="flex flex-col h-full lg:flex-row">
           <SkipNavLink targetId="main-content" label={t('nav.skipToContent')} />
           <DesktopSidebar />
-          <div className="flex flex-col flex-1 min-w-0">
+          {/* `min-h-0` is load-bearing, not defensive: this is a flex item in a
+              `h-full` column, and without it its automatic minimum size is its
+              content height, so it refuses to shrink to the viewport and instead
+              grows the document. That is what made 179 of 219 game pages scroll
+              vertically on a 375x667 phone even though every page already has an
+              internal `flex-1 overflow-y-auto` region meant to absorb the
+              overflow. See issue #4373. */}
+          <div className="flex flex-col flex-1 min-w-0 min-h-0">
             <NavBar />
             <main id="main-content" tabIndex={-1} className="flex-1 flex flex-col min-h-0">
               {/* Route-scoped boundary: a crash in one page is contained here so

--- a/frontend/src/components/GameFooter.test.tsx
+++ b/frontend/src/components/GameFooter.test.tsx
@@ -56,27 +56,33 @@ describe('GameFooter', () => {
     expect(footer.className).toContain('py-3');
   });
 
-  it('applies floating classes when floating is true', () => {
+  // The footer is `shrink-0`, so whatever height its content wants, it takes —
+  // and the sibling scroll region is what gives way. Measured at 375x667 across
+  // all 219 game pages, 26 pages were left with under 80px for their content and
+  // the tallest footer was 558px (`watten`), 84% of the viewport. Capping it at
+  // 45vh guarantees at least 102px of content on every page that has both a
+  // footer and a scroll region. See issue #4373.
+  it('caps its height and scrolls internally on mobile', () => {
     render(
-      <GameFooter floating>
+      <GameFooter>
         <span>content</span>
       </GameFooter>,
     );
     const footer = screen.getByRole('contentinfo');
-    expect(footer.className).toContain('glass-panel');
-    expect(footer.className).toContain('rounded-t-xl');
-    expect(footer.className).toContain('max-h-[60vh]');
+    expect(footer.className).toContain('max-h-[45vh]');
     expect(footer.className).toContain('overflow-y-auto');
   });
 
-  it('does not apply floating classes when floating is false', () => {
+  // The cap exists to protect a 667px-tall phone; on a laptop it would only add a
+  // pointless inner scrollbar, so it must be lifted from `sm` up.
+  it('lifts the cap from the sm breakpoint up', () => {
     render(
-      <GameFooter floating={false}>
+      <GameFooter>
         <span>content</span>
       </GameFooter>,
     );
     const footer = screen.getByRole('contentinfo');
-    expect(footer.className).not.toContain('glass-panel');
-    expect(footer.className).not.toContain('rounded-t-xl');
+    expect(footer.className).toContain('sm:max-h-none');
+    expect(footer.className).toContain('sm:overflow-y-visible');
   });
 });

--- a/frontend/src/components/GameFooter.tsx
+++ b/frontend/src/components/GameFooter.tsx
@@ -2,18 +2,30 @@
 export interface GameFooterProps {
   className?: string;
   children: React.ReactNode;
-  /** When true, applies glassmorphism + rounded top corners + scroll on mobile. */
-  floating?: boolean;
 }
 
-/** Renders a sticky footer area for game action buttons with safe-area padding. */
-export function GameFooter({ className, children, floating = false }: GameFooterProps) {
-  const floatingClass = floating
-    ? 'glass-panel rounded-t-xl max-h-[60vh] overflow-y-auto sm:max-h-none sm:overflow-y-visible'
-    : '';
+/**
+ * Renders a sticky footer area for game action buttons with safe-area padding.
+ *
+ * The height cap is load-bearing on mobile. This footer is `shrink-0`, so it takes
+ * whatever height its content wants and the sibling `flex-1 overflow-y-auto` play
+ * area is what gives way. Measured at 375x667 across all 219 game pages, the
+ * tallest footer was 558px — 84% of the viewport — and 26 pages were left with
+ * under 80px for their actual content. Capping at 45vh leaves at least 102px of
+ * play area on every page that has both a footer and a scroll region, at the cost
+ * of an inner scroll on the 47 pages whose controls exceed the cap. That trade is
+ * deliberate: a footer that scrolls keeps the cards visible while the player
+ * reaches a button, whereas a document that scrolls does not. See issue #4373.
+ *
+ * The cap is lifted from `sm` up, where the viewport is tall enough that it would
+ * only add a pointless inner scrollbar.
+ */
+export function GameFooter({ className, children }: GameFooterProps) {
   return (
     <footer
-      className={['shrink-0', 'border-t', floatingClass, className].filter(Boolean).join(' ')}
+      className={['shrink-0', 'border-t', 'max-h-[45vh] overflow-y-auto sm:max-h-none sm:overflow-y-visible', className]
+        .filter(Boolean)
+        .join(' ')}
       style={{ paddingBottom: 'calc(env(safe-area-inset-bottom) + 12px)' }}
     >
       {children}


### PR DESCRIPTION
Phase 1+2 of #4373. They ship together because **neither is safe alone** — that is the main finding here.

## What was actually wrong

Not per-game content. Every game page already has a `flex-1 overflow-y-auto` play area meant to absorb overflow, and `html`/`body`/`#root` are all `height: 100%`, so a correct layout would pin the document at 667 and scroll *inside*. Two things defeated that:

1. **`App.tsx`'s main flex column had `min-w-0` but no `min-h-0`.** A flex item's automatic minimum size is its content height, so the column refused to shrink to the viewport and grew the document instead.
2. **`GameFooter` is `shrink-0` with no cap.** Footers run up to 558px (`watten` — 84% of a 667px viewport), so once (1) is fixed, the play area is what gives way.

## Why `min-h-0` alone was rejected

Adding it is dramatic on paper — `crescent` +720 → **0**, `pan` +626 → **0**, `freecell` +202 → 0. But "the document stopped growing" is not "the content is reachable". Verified page by page with only that change:

| | pages |
|---|---|
| cleanly fixed | 181 |
| play area crushed below 80px | 27 |
| footer pushed off screen | 20 |
| document still overflowed | 29 |
| **harmed or unfixed** | **38** |

`spades` ended up with a **12px** play area holding 226px of content, with its action buttons 64px off screen. That is worse than scrolling. So the footer had to be bounded first.

## The cap value is measured, not guessed

| cap | footers capped | worst play area |
|---|---|---|
| none | – | **−409px** |
| 60vh (400px) ← the unused `floating` variant's value | 24 | **2px** |
| 50vh (333px) | 40 | 69px |
| **45vh (300px)** | **47** | **102px** (median 248) |

45vh is the largest cap that leaves every page a usable play area. The cost is 47 footers scrolling internally — a deliberate trade: a footer that scrolls keeps the cards visible while you reach a button; a document that scrolls does not. The cap is lifted at `sm` and up, where it would only add a pointless inner scrollbar (verified: `watten` at 1280×800 renders its footer at its natural 406px with no inner scroll).

## Result

Verified page by page at 375×667, worst of 3 deals:

| | before | after |
|---|---|---|
| document does not scroll | 40 | **210** |
| fully clean (document pinned, play area usable, footer on screen) | 40 | **206** |
| harmed | — | **0** |

The 9 remaining put tall `shrink-0` content outside their play area; **5 have no play area at all** (`speed`, `contractrummy`, `piquet`, `kalooki`, `carioca`). Those need per-page work — [detailed on the issue](https://github.com/yuta-yoshinaga/go_trumpcards/issues/4373) as phases 3–4. `paigow`/`chinesepoker` show a 72px play area but are *not* harmed: their content is exactly 72px and nothing overflows — they simply do not fill the viewport, by design (`!isBetPhase && 'flex-1'`).

## Guarded, because this is the sixth attempt

This area regressed five times (#965, #993, #1058, #1367, #4373), and the fix now rests on two classes that look exactly like cleanup candidates. So both halves are enforced, not just written down:

- **Static** — a new `shell-height` guard in `check-design-tokens.mjs` (7th guard) fails the build if `App.tsx` loses `min-h-0` or `GameFooter` loses its cap. Negative-controlled: **exit 1** on either.
- **Browser** — `e2e/mobile-viewport.spec.ts` asserts 8 representative pages do not grow the document and keep the footer within the cap. This is the only way to catch a *page* adding tall `shrink-0` content, which no static check sees. Negative-controlled: removing `min-h-0` fails **6 of 8** assertions.

Also documents the contract in DESIGN.md (it had no footer/viewport rules at all — the "no scrolling" principle only existed in #1861).

## Dead code removed

`GameFooter`'s `floating` prop: **none of the 215 call sites passed it**. Its `max-h`/`overflow` half is now the default; the `glass-panel rounded-t-xl` half went unused. Worth noting because I had recorded that `jass` was unaffected by an earlier change *because* of this variant — that explanation was wrong, since nothing ever used it.

## Measurement note

Page height depends on the deal — `jass` measured +502 and +302 on two consecutive loads of the same build, `euchre` spreads ±227, and 5 pages fit on some deals but not others (`speed` ranges 0 → +201). All numbers here are the **worst of 3 deals**; a single sample would have misclassified those 5 as fitting. The issue's original table is a single sample, which is why its 47-fits baseline reads higher than the real 40.

## Verification

- `bun run test` — 16,007 passed
- `bun run typecheck`, `bun run check` (all 7 guards) clean
- `bunx playwright test e2e/mobile-viewport.spec.ts` — 16 passed
- Visual check at 375×667 on the two worst footers plus desktop at 1280×800

Refs #4373
