### PR TITLE
fix(frontend): give the five pages with no play area an internal scroll region

### DIFF
--- a/frontend/e2e/mobile-viewport.spec.ts
+++ b/frontend/e2e/mobile-viewport.spec.ts
@@ -26,7 +26,25 @@ test.use({ viewport: { width: 375, height: 667 } });
 // mean a page grew tall `shrink-0` content *outside* its play area — which is a
 // real regression and exactly what this spec is for, so investigate rather than
 // retry.
-const PATHS = ['/watten', '/spades', '/hearts', '/crescent', '/pan', '/freecell', '/poker', '/'];
+const PATHS = [
+  '/watten',
+  '/spades',
+  '/hearts',
+  '/crescent',
+  '/pan',
+  '/freecell',
+  '/poker',
+  '/',
+  // These five had no play area at all until #4373 phase 3 — their content went
+  // straight into the document height. `/speed` is the reason they are guarded
+  // rather than trusted: it fitted on some deals and overflowed by 201px on
+  // others, so it looked fine whenever it was spot-checked.
+  '/speed',
+  '/contractrummy',
+  '/piquet',
+  '/kalooki',
+  '/carioca',
+];
 
 for (const path of PATHS) {
   test(`${path} does not scroll the document at 375x667`, async ({ page }) => {

--- a/frontend/src/pages/CariocaPage.tsx
+++ b/frontend/src/pages/CariocaPage.tsx
@@ -227,154 +227,161 @@ function CariocaPageContent() {
     >
       {error && <ErrorAlert message={error} onRetry={retry} />}
 
-      <section className="px-4 py-2 flex flex-wrap gap-3 items-center text-white" data-tutorial="ca-contract">
-        <span className="font-semibold">{t('roundLabel', { round: state.roundNumber, total: state.totalRounds })}</span>
-        <span>
-          {t('contractLabel')}: {state.contractSlots.map((s) => formatSlot(s, t)).join(' + ')}
-        </span>
-        <span>
-          {t('stockLabel')}: {state.drawPileCount}
-        </span>
-        {state.discardTop && (
-          <span className="flex items-center gap-2">
-            {t('discardLabel')}:
-            <AnimatedCard card={state.discardTop} width={cardWidth} />
+      {/* Scrollable state display. Carioca had no play area at all, so its
+          content grew the document by 333px at 375x667; the pinned action row,
+          message box and footer below stay reachable. See issue #4373. */}
+      <div className="flex-1 overflow-y-auto min-h-0">
+        <section className="px-4 py-2 flex flex-wrap gap-3 items-center text-white" data-tutorial="ca-contract">
+          <span className="font-semibold">
+            {t('roundLabel', { round: state.roundNumber, total: state.totalRounds })}
           </span>
-        )}
-      </section>
-
-      {isPlayPhase && humanPlayer && !humanPlayer.contractMet && state.contractSlots.length > 0 && (
-        <section className="px-4 py-2 flex flex-wrap gap-2 text-sm" data-testid="ca-slot-progress">
-          {state.contractSlots.map((slot, slotIdx) => {
-            const detail = slotEvaluations[slotIdx];
-            const ev = detail?.ev ?? { placed: 0, required: slot.size, satisfied: false, invalid: false };
-            const shortfall = detail?.shortfall ?? null;
-            const color = ev.satisfied
-              ? badgeSuccessColors
-              : ev.invalid
-                ? badgeErrorColors
-                : ev.placed === 0
-                  ? 'bg-black/20 border border-white/30 text-ds-text-muted'
-                  : badgeWarningColors;
-            return (
-              <span key={`slot-${slotIdx}`} className="flex flex-col items-start gap-0.5">
-                <span
-                  className={`px-2 py-1 rounded ${color}`}
-                  data-testid={`ca-slot-progress-${slotIdx}`}
-                  data-state={
-                    ev.satisfied ? 'satisfied' : ev.invalid ? 'invalid' : ev.placed === 0 ? 'empty' : 'partial'
-                  }
-                >
-                  {formatSlot(slot, t)} ({ev.placed}/{ev.required}){ev.satisfied ? ' ✓' : ''}
-                </span>
-                {shortfall && (
-                  <span className="text-xs text-ds-text-muted" data-testid={`ca-slot-shortfall-${slotIdx}`}>
-                    {t(`shortfall.${shortfall.code}`, shortfall.count != null ? { n: shortfall.count } : undefined)}
-                  </span>
-                )}
-              </span>
-            );
-          })}
+          <span>
+            {t('contractLabel')}: {state.contractSlots.map((s) => formatSlot(s, t)).join(' + ')}
+          </span>
+          <span>
+            {t('stockLabel')}: {state.drawPileCount}
+          </span>
+          {state.discardTop && (
+            <span className="flex items-center gap-2">
+              {t('discardLabel')}:
+              <AnimatedCard card={state.discardTop} width={cardWidth} />
+            </span>
+          )}
         </section>
-      )}
 
-      <section className="px-4 py-2 grid gap-2 md:grid-cols-3">
-        {state.players.map((p) => (
-          <div
-            key={p.id}
-            className={`p-3 rounded border ${
-              state.currentPlayerIdx === p.id ? 'border-ds-warning' : 'border-white/30'
-            } text-white text-sm bg-black/20`}
-          >
-            <div className="flex justify-between font-semibold">
-              <span>
-                {p.isHuman ? tc('player.you') : tc('player.cpu', { id: p.id })}
-                {p.contractMet ? ` ✓` : ''}
-              </span>
-              <span>
-                {t('cards')}: {p.cardCount}
-              </span>
-            </div>
-            <div className="text-xs opacity-75">
-              {t('scoreLabel')}: {p.cumulativeScore} (+{p.roundScore})
-            </div>
-            {p.melds.length > 0 && (
-              <div className="mt-2">
-                {p.melds.map((m, mi) => {
-                  const isLayoffTarget = layoffTarget?.playerIdx === p.id && layoffTarget?.meldIdx === mi;
-                  const playerLabel = p.isHuman ? tc('player.you') : tc('player.cpu', { id: p.id });
-                  // The meld is only a selectable layoff target once both contracts are met.
-                  const canLayoff = humanPlayer?.contractMet === true && p.contractMet;
-                  // Preview: does the staged card fit this meld? `null` when no preview applies.
-                  const accepts = canLayoff && layoffCard ? canLayoffCariocaMeld(m.cards, layoffCard) : null;
-                  // The selection highlight (warning) wins; otherwise the acceptance preview
-                  // marks the meld green (accepts) or dims + reds it (rejects).
-                  const previewRing = isLayoffTarget
-                    ? 'ring-2 ring-ds-warning bg-ds-warning/20'
-                    : accepts === true
-                      ? 'ring-2 ring-ds-success'
-                      : accepts === false
-                        ? 'ring-2 ring-ds-error opacity-50'
-                        : '';
-                  return (
-                    <button
-                      type="button"
-                      key={`${p.id}-${mi}`}
-                      onClick={() => {
-                        if (canLayoff) {
-                          setLayoffTarget({ playerIdx: p.id, meldIdx: mi });
-                        }
-                      }}
-                      aria-label={t('meldAria', { player: playerLabel, meld: mi + 1 })}
-                      // Only expose the toggle semantics when the meld is actually actionable.
-                      aria-pressed={canLayoff ? isLayoffTarget : undefined}
-                      data-testid={`ca-meld-${p.id}-${mi}`}
-                      data-layoff-accepts={accepts === null ? undefined : String(accepts)}
-                      className={`flex flex-wrap gap-1 mb-1 px-1 rounded ${focusRingWhite} ${previewRing}`}
-                    >
-                      {m.cards.map((c, ci) => (
-                        <AnimatedCard key={`${p.id}-${mi}-${ci}`} card={c} width={cardWidth * 0.6} />
-                      ))}
-                    </button>
-                  );
-                })}
-              </div>
-            )}
-          </div>
-        ))}
-      </section>
-
-      {humanPlayer && (
-        <section className="px-4 py-2" data-tutorial="ca-hand">
-          <div className="text-white text-sm mb-1">
-            {t('yourHand')} ({humanPlayer.cardCount})
-            {contractSlots.length > 0 && (
-              <span className="ml-2 opacity-75">
-                {t('slotsBuilt')}: {contractSlots.length}
-              </span>
-            )}
-          </div>
-          <div className="flex flex-wrap gap-1">
-            {humanPlayer.cards.map((c: Card, idx: number) => {
-              const isSelected = selectedCards.includes(idx);
-              const isInSlot = contractSlots.some((slot) => slot.includes(idx));
+        {isPlayPhase && humanPlayer && !humanPlayer.contractMet && state.contractSlots.length > 0 && (
+          <section className="px-4 py-2 flex flex-wrap gap-2 text-sm" data-testid="ca-slot-progress">
+            {state.contractSlots.map((slot, slotIdx) => {
+              const detail = slotEvaluations[slotIdx];
+              const ev = detail?.ev ?? { placed: 0, required: slot.size, satisfied: false, invalid: false };
+              const shortfall = detail?.shortfall ?? null;
+              const color = ev.satisfied
+                ? badgeSuccessColors
+                : ev.invalid
+                  ? badgeErrorColors
+                  : ev.placed === 0
+                    ? 'bg-black/20 border border-white/30 text-ds-text-muted'
+                    : badgeWarningColors;
               return (
-                <button
-                  type="button"
-                  key={`${idx}-${c.design}-${c.value}`}
-                  onClick={() => toggleCard(idx)}
-                  disabled={isInSlot}
-                  className={`${focusRingWhite} ${isSelected ? 'ring-2 ring-ds-warning' : ''} ${
-                    isInSlot ? 'opacity-40' : ''
-                  }`}
-                >
-                  <AnimatedCard card={c} width={cardWidth} />
-                </button>
+                <span key={`slot-${slotIdx}`} className="flex flex-col items-start gap-0.5">
+                  <span
+                    className={`px-2 py-1 rounded ${color}`}
+                    data-testid={`ca-slot-progress-${slotIdx}`}
+                    data-state={
+                      ev.satisfied ? 'satisfied' : ev.invalid ? 'invalid' : ev.placed === 0 ? 'empty' : 'partial'
+                    }
+                  >
+                    {formatSlot(slot, t)} ({ev.placed}/{ev.required}){ev.satisfied ? ' ✓' : ''}
+                  </span>
+                  {shortfall && (
+                    <span className="text-xs text-ds-text-muted" data-testid={`ca-slot-shortfall-${slotIdx}`}>
+                      {t(`shortfall.${shortfall.code}`, shortfall.count != null ? { n: shortfall.count } : undefined)}
+                    </span>
+                  )}
+                </span>
               );
             })}
-          </div>
+          </section>
+        )}
+
+        <section className="px-4 py-2 grid gap-2 md:grid-cols-3">
+          {state.players.map((p) => (
+            <div
+              key={p.id}
+              className={`p-3 rounded border ${
+                state.currentPlayerIdx === p.id ? 'border-ds-warning' : 'border-white/30'
+              } text-white text-sm bg-black/20`}
+            >
+              <div className="flex justify-between font-semibold">
+                <span>
+                  {p.isHuman ? tc('player.you') : tc('player.cpu', { id: p.id })}
+                  {p.contractMet ? ` ✓` : ''}
+                </span>
+                <span>
+                  {t('cards')}: {p.cardCount}
+                </span>
+              </div>
+              <div className="text-xs opacity-75">
+                {t('scoreLabel')}: {p.cumulativeScore} (+{p.roundScore})
+              </div>
+              {p.melds.length > 0 && (
+                <div className="mt-2">
+                  {p.melds.map((m, mi) => {
+                    const isLayoffTarget = layoffTarget?.playerIdx === p.id && layoffTarget?.meldIdx === mi;
+                    const playerLabel = p.isHuman ? tc('player.you') : tc('player.cpu', { id: p.id });
+                    // The meld is only a selectable layoff target once both contracts are met.
+                    const canLayoff = humanPlayer?.contractMet === true && p.contractMet;
+                    // Preview: does the staged card fit this meld? `null` when no preview applies.
+                    const accepts = canLayoff && layoffCard ? canLayoffCariocaMeld(m.cards, layoffCard) : null;
+                    // The selection highlight (warning) wins; otherwise the acceptance preview
+                    // marks the meld green (accepts) or dims + reds it (rejects).
+                    const previewRing = isLayoffTarget
+                      ? 'ring-2 ring-ds-warning bg-ds-warning/20'
+                      : accepts === true
+                        ? 'ring-2 ring-ds-success'
+                        : accepts === false
+                          ? 'ring-2 ring-ds-error opacity-50'
+                          : '';
+                    return (
+                      <button
+                        type="button"
+                        key={`${p.id}-${mi}`}
+                        onClick={() => {
+                          if (canLayoff) {
+                            setLayoffTarget({ playerIdx: p.id, meldIdx: mi });
+                          }
+                        }}
+                        aria-label={t('meldAria', { player: playerLabel, meld: mi + 1 })}
+                        // Only expose the toggle semantics when the meld is actually actionable.
+                        aria-pressed={canLayoff ? isLayoffTarget : undefined}
+                        data-testid={`ca-meld-${p.id}-${mi}`}
+                        data-layoff-accepts={accepts === null ? undefined : String(accepts)}
+                        className={`flex flex-wrap gap-1 mb-1 px-1 rounded ${focusRingWhite} ${previewRing}`}
+                      >
+                        {m.cards.map((c, ci) => (
+                          <AnimatedCard key={`${p.id}-${mi}-${ci}`} card={c} width={cardWidth * 0.6} />
+                        ))}
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          ))}
         </section>
-      )}
+
+        {humanPlayer && (
+          <section className="px-4 py-2" data-tutorial="ca-hand">
+            <div className="text-white text-sm mb-1">
+              {t('yourHand')} ({humanPlayer.cardCount})
+              {contractSlots.length > 0 && (
+                <span className="ml-2 opacity-75">
+                  {t('slotsBuilt')}: {contractSlots.length}
+                </span>
+              )}
+            </div>
+            <div className="flex flex-wrap gap-1">
+              {humanPlayer.cards.map((c: Card, idx: number) => {
+                const isSelected = selectedCards.includes(idx);
+                const isInSlot = contractSlots.some((slot) => slot.includes(idx));
+                return (
+                  <button
+                    type="button"
+                    key={`${idx}-${c.design}-${c.value}`}
+                    onClick={() => toggleCard(idx)}
+                    disabled={isInSlot}
+                    className={`${focusRingWhite} ${isSelected ? 'ring-2 ring-ds-warning' : ''} ${
+                      isInSlot ? 'opacity-40' : ''
+                    }`}
+                  >
+                    <AnimatedCard card={c} width={cardWidth} />
+                  </button>
+                );
+              })}
+            </div>
+          </section>
+        )}
+      </div>
 
       <section className="px-4 py-2 flex flex-wrap gap-2" data-tutorial="ca-actions">
         {isDrawPhase && (

--- a/frontend/src/pages/ContractRummyPage.tsx
+++ b/frontend/src/pages/ContractRummyPage.tsx
@@ -251,157 +251,162 @@ function ContractRummyPageContent() {
         <>
           {error && <ErrorAlert message={error} onRetry={retry} />}
 
-          <section className="px-4 py-2 flex flex-wrap gap-3 items-center text-white" data-tutorial="cr-contract">
-            <span className="font-semibold">
-              {t('roundLabel', { round: state.roundNumber, total: state.totalRounds })}
-            </span>
-            <span>
-              {t('contractLabel')}: {state.contractSlots.map((s) => formatSlot(s, t)).join(' + ')}
-            </span>
-            <span>
-              {t('stockLabel')}: {state.drawPileCount}
-            </span>
-            {state.discardTop && (
-              <span className="flex items-center gap-2">
-                {t('discardLabel')}:
-                <AnimatedCard card={state.discardTop} width={cardWidth} />
+          {/* Scrollable state display: this page had no play area, so its
+              content grew the document at 375x667 while the action row below
+              stayed pinned and reachable. See issue #4373. */}
+          <div className="flex-1 overflow-y-auto min-h-0">
+            <section className="px-4 py-2 flex flex-wrap gap-3 items-center text-white" data-tutorial="cr-contract">
+              <span className="font-semibold">
+                {t('roundLabel', { round: state.roundNumber, total: state.totalRounds })}
               </span>
-            )}
-          </section>
-
-          {isPlayPhase && humanPlayer && !humanPlayer.contractMet && state.contractSlots.length > 0 && (
-            <section className="px-4 py-2 flex flex-wrap gap-2 text-sm" data-testid="cr-slot-progress">
-              {state.contractSlots.map((slot, slotIdx) => {
-                const ev = slotEvaluations[slotIdx] ?? {
-                  placed: 0,
-                  required: slot.size,
-                  satisfied: false,
-                  invalid: false,
-                };
-                const color = ev.satisfied
-                  ? badgeSuccessColors
-                  : ev.invalid
-                    ? badgeErrorColors
-                    : ev.placed === 0
-                      ? 'bg-black/20 border border-white/30 text-ds-text-muted'
-                      : badgeWarningColors;
-                return (
-                  <span
-                    key={`slot-${slotIdx}`}
-                    className={`px-2 py-1 rounded ${color}`}
-                    data-testid={`cr-slot-progress-${slotIdx}`}
-                    data-state={
-                      ev.satisfied ? 'satisfied' : ev.invalid ? 'invalid' : ev.placed === 0 ? 'empty' : 'partial'
-                    }
-                  >
-                    {formatSlot(slot, t)} ({ev.placed}/{ev.required}){ev.satisfied ? ' ✓' : ''}
-                  </span>
-                );
-              })}
+              <span>
+                {t('contractLabel')}: {state.contractSlots.map((s) => formatSlot(s, t)).join(' + ')}
+              </span>
+              <span>
+                {t('stockLabel')}: {state.drawPileCount}
+              </span>
+              {state.discardTop && (
+                <span className="flex items-center gap-2">
+                  {t('discardLabel')}:
+                  <AnimatedCard card={state.discardTop} width={cardWidth} />
+                </span>
+              )}
             </section>
-          )}
 
-          <section className="px-4 py-2 grid gap-2 md:grid-cols-3">
-            {state.players.map((p) => (
-              <div
-                key={p.id}
-                className={`p-3 rounded border ${
-                  state.currentPlayerIdx === p.id ? 'border-ds-warning' : 'border-white/30'
-                } text-white text-sm bg-black/20`}
-              >
-                <div className="flex justify-between font-semibold">
-                  <span>
-                    {p.isHuman ? tc('player.you') : tc('player.cpu', { id: p.id })}
-                    {p.contractMet ? ` ✓` : ''}
-                  </span>
-                  <span>
-                    {t('cards')}: {p.cardCount}
-                  </span>
-                </div>
-                <div className="text-xs opacity-75">
-                  {t('scoreLabel')}: {p.cumulativeScore} (+{p.roundScore})
-                </div>
-                {p.melds.length > 0 && (
-                  <div className="mt-2">
-                    {p.melds.map((m, mi) => {
-                      const isLayoffTarget = layoffTarget?.playerIdx === p.id && layoffTarget?.meldIdx === mi;
-                      const playerLabel = p.isHuman ? tc('player.you') : tc('player.cpu', { id: p.id });
-                      // The meld is only a selectable layoff target once both contracts are met.
-                      const canLayoff = humanPlayer?.contractMet === true && p.contractMet;
-                      return (
-                        <button
-                          type="button"
-                          key={`${p.id}-${mi}`}
-                          onClick={() => {
-                            if (canLayoff) {
-                              setLayoffTarget({ playerIdx: p.id, meldIdx: mi });
-                            }
-                          }}
-                          aria-label={t('meldAria', { player: playerLabel, meld: mi + 1 })}
-                          // Only expose the toggle semantics when the meld is actually actionable.
-                          aria-pressed={canLayoff ? isLayoffTarget : undefined}
-                          className={`flex flex-wrap gap-1 mb-1 px-1 rounded ${focusRingWhite} ${
-                            isLayoffTarget ? 'ring-2 ring-ds-warning bg-ds-warning/20' : ''
-                          }`}
-                        >
-                          {m.cards.map((c, ci) => (
-                            <AnimatedCard key={`${p.id}-${mi}-${ci}`} card={c} width={cardWidth * 0.6} />
-                          ))}
-                        </button>
-                      );
-                    })}
-                  </div>
-                )}
-              </div>
-            ))}
-          </section>
-
-          {humanPlayer && (
-            <section className="px-4 py-2" data-tutorial="cr-hand">
-              <div className="text-white text-sm mb-1">
-                {t('yourHand')} ({humanPlayer.cardCount})
-                {contractSlots.length > 0 && (
-                  <span className="ml-2 opacity-75">
-                    {t('slotsBuilt')}: {contractSlots.length}
-                  </span>
-                )}
-              </div>
-              <div className="flex flex-wrap gap-1">
-                {humanPlayer.cards.map((c: Card, idx: number) => {
-                  const isSelected = selectedCards.includes(idx);
-                  const slotOfCard = contractSlots.findIndex((slot) => slot.includes(idx));
-                  const isInSlot = slotOfCard !== -1;
+            {isPlayPhase && humanPlayer && !humanPlayer.contractMet && state.contractSlots.length > 0 && (
+              <section className="px-4 py-2 flex flex-wrap gap-2 text-sm" data-testid="cr-slot-progress">
+                {state.contractSlots.map((slot, slotIdx) => {
+                  const ev = slotEvaluations[slotIdx] ?? {
+                    placed: 0,
+                    required: slot.size,
+                    satisfied: false,
+                    invalid: false,
+                  };
+                  const color = ev.satisfied
+                    ? badgeSuccessColors
+                    : ev.invalid
+                      ? badgeErrorColors
+                      : ev.placed === 0
+                        ? 'bg-black/20 border border-white/30 text-ds-text-muted'
+                        : badgeWarningColors;
                   return (
-                    <button
-                      type="button"
-                      key={`${idx}-${c.design}-${c.value}`}
-                      // A staged card removes itself from its slot; an unstaged card toggles selection.
-                      onClick={() => (isInSlot ? handleRemoveCardFromSlot(idx) : toggleCard(idx))}
-                      aria-pressed={isInSlot ? undefined : isSelected}
-                      aria-label={
-                        isInSlot ? t('cardInSlotRemoveAria', { card: cardAlt(c), n: slotOfCard + 1 }) : cardAlt(c)
+                    <span
+                      key={`slot-${slotIdx}`}
+                      className={`px-2 py-1 rounded ${color}`}
+                      data-testid={`cr-slot-progress-${slotIdx}`}
+                      data-state={
+                        ev.satisfied ? 'satisfied' : ev.invalid ? 'invalid' : ev.placed === 0 ? 'empty' : 'partial'
                       }
-                      data-testid={isInSlot ? `cr-slot-card-${idx}` : undefined}
-                      data-slot={isInSlot ? slotOfCard + 1 : undefined}
-                      className={`relative ${focusRingWhite} ${isSelected ? 'ring-2 ring-ds-warning' : ''} ${
-                        isInSlot ? 'opacity-40' : ''
-                      }`}
                     >
-                      {isInSlot && (
-                        <span
-                          className={`absolute top-0 left-0 z-10 px-1 rounded-br text-[10px] font-bold ${badgeWarningColors}`}
-                          aria-hidden="true"
-                        >
-                          {slotOfCard + 1}
-                        </span>
-                      )}
-                      <AnimatedCard card={c} width={cardWidth} />
-                    </button>
+                      {formatSlot(slot, t)} ({ev.placed}/{ev.required}){ev.satisfied ? ' ✓' : ''}
+                    </span>
                   );
                 })}
-              </div>
+              </section>
+            )}
+
+            <section className="px-4 py-2 grid gap-2 md:grid-cols-3">
+              {state.players.map((p) => (
+                <div
+                  key={p.id}
+                  className={`p-3 rounded border ${
+                    state.currentPlayerIdx === p.id ? 'border-ds-warning' : 'border-white/30'
+                  } text-white text-sm bg-black/20`}
+                >
+                  <div className="flex justify-between font-semibold">
+                    <span>
+                      {p.isHuman ? tc('player.you') : tc('player.cpu', { id: p.id })}
+                      {p.contractMet ? ` ✓` : ''}
+                    </span>
+                    <span>
+                      {t('cards')}: {p.cardCount}
+                    </span>
+                  </div>
+                  <div className="text-xs opacity-75">
+                    {t('scoreLabel')}: {p.cumulativeScore} (+{p.roundScore})
+                  </div>
+                  {p.melds.length > 0 && (
+                    <div className="mt-2">
+                      {p.melds.map((m, mi) => {
+                        const isLayoffTarget = layoffTarget?.playerIdx === p.id && layoffTarget?.meldIdx === mi;
+                        const playerLabel = p.isHuman ? tc('player.you') : tc('player.cpu', { id: p.id });
+                        // The meld is only a selectable layoff target once both contracts are met.
+                        const canLayoff = humanPlayer?.contractMet === true && p.contractMet;
+                        return (
+                          <button
+                            type="button"
+                            key={`${p.id}-${mi}`}
+                            onClick={() => {
+                              if (canLayoff) {
+                                setLayoffTarget({ playerIdx: p.id, meldIdx: mi });
+                              }
+                            }}
+                            aria-label={t('meldAria', { player: playerLabel, meld: mi + 1 })}
+                            // Only expose the toggle semantics when the meld is actually actionable.
+                            aria-pressed={canLayoff ? isLayoffTarget : undefined}
+                            className={`flex flex-wrap gap-1 mb-1 px-1 rounded ${focusRingWhite} ${
+                              isLayoffTarget ? 'ring-2 ring-ds-warning bg-ds-warning/20' : ''
+                            }`}
+                          >
+                            {m.cards.map((c, ci) => (
+                              <AnimatedCard key={`${p.id}-${mi}-${ci}`} card={c} width={cardWidth * 0.6} />
+                            ))}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  )}
+                </div>
+              ))}
             </section>
-          )}
+
+            {humanPlayer && (
+              <section className="px-4 py-2" data-tutorial="cr-hand">
+                <div className="text-white text-sm mb-1">
+                  {t('yourHand')} ({humanPlayer.cardCount})
+                  {contractSlots.length > 0 && (
+                    <span className="ml-2 opacity-75">
+                      {t('slotsBuilt')}: {contractSlots.length}
+                    </span>
+                  )}
+                </div>
+                <div className="flex flex-wrap gap-1">
+                  {humanPlayer.cards.map((c: Card, idx: number) => {
+                    const isSelected = selectedCards.includes(idx);
+                    const slotOfCard = contractSlots.findIndex((slot) => slot.includes(idx));
+                    const isInSlot = slotOfCard !== -1;
+                    return (
+                      <button
+                        type="button"
+                        key={`${idx}-${c.design}-${c.value}`}
+                        // A staged card removes itself from its slot; an unstaged card toggles selection.
+                        onClick={() => (isInSlot ? handleRemoveCardFromSlot(idx) : toggleCard(idx))}
+                        aria-pressed={isInSlot ? undefined : isSelected}
+                        aria-label={
+                          isInSlot ? t('cardInSlotRemoveAria', { card: cardAlt(c), n: slotOfCard + 1 }) : cardAlt(c)
+                        }
+                        data-testid={isInSlot ? `cr-slot-card-${idx}` : undefined}
+                        data-slot={isInSlot ? slotOfCard + 1 : undefined}
+                        className={`relative ${focusRingWhite} ${isSelected ? 'ring-2 ring-ds-warning' : ''} ${
+                          isInSlot ? 'opacity-40' : ''
+                        }`}
+                      >
+                        {isInSlot && (
+                          <span
+                            className={`absolute top-0 left-0 z-10 px-1 rounded-br text-[10px] font-bold ${badgeWarningColors}`}
+                            aria-hidden="true"
+                          >
+                            {slotOfCard + 1}
+                          </span>
+                        )}
+                        <AnimatedCard card={c} width={cardWidth} />
+                      </button>
+                    );
+                  })}
+                </div>
+              </section>
+            )}
+          </div>
 
           <section className="px-4 py-2 flex flex-wrap gap-2" data-tutorial="cr-actions">
             {isDrawPhase && (

--- a/frontend/src/pages/KalookiPage.tsx
+++ b/frontend/src/pages/KalookiPage.tsx
@@ -280,173 +280,178 @@ function KalookiPageContent() {
             ]}
           />
 
-          <section className="px-4 py-2 flex flex-wrap gap-3 items-center text-white" data-tutorial="kalooki-table">
-            <span className="font-semibold">
-              {t('openingLabel')}: {state.openingThreshold}
-            </span>
-            <span>
-              {t('stockLabel')}: {state.drawPileCount}
-            </span>
-            {state.discardTop && (
-              <span className="flex items-center gap-2">
-                {t('discardLabel')}:
-                <AnimatedCard card={state.discardTop} width={cardWidth} />
+          {/* Scrollable state display: this page had no play area, so its
+              content grew the document at 375x667 while the action row below
+              stayed pinned and reachable. See issue #4373. */}
+          <div className="flex-1 overflow-y-auto min-h-0">
+            <section className="px-4 py-2 flex flex-wrap gap-3 items-center text-white" data-tutorial="kalooki-table">
+              <span className="font-semibold">
+                {t('openingLabel')}: {state.openingThreshold}
               </span>
+              <span>
+                {t('stockLabel')}: {state.drawPileCount}
+              </span>
+              {state.discardTop && (
+                <span className="flex items-center gap-2">
+                  {t('discardLabel')}:
+                  <AnimatedCard card={state.discardTop} width={cardWidth} />
+                </span>
+              )}
+            </section>
+
+            {isMeldPhase && humanPlayer && !humanPlayer.hasOpened && (
+              <section className="px-4 py-1 text-sm text-ds-warning" data-testid="kalooki-opening-hint">
+                {t('openingHint', { n: state.openingThreshold })}
+              </section>
             )}
-          </section>
 
-          {isMeldPhase && humanPlayer && !humanPlayer.hasOpened && (
-            <section className="px-4 py-1 text-sm text-ds-warning" data-testid="kalooki-opening-hint">
-              {t('openingHint', { n: state.openingThreshold })}
-            </section>
-          )}
-
-          <section className="px-4 py-2 grid gap-2 md:grid-cols-3">
-            {state.players.map((p) => (
-              <div
-                key={p.id}
-                className={`p-3 rounded border ${
-                  state.currentPlayerIdx === p.id ? 'border-ds-warning' : 'border-white/30'
-                } text-white text-sm bg-black/20`}
-              >
-                <div className="flex justify-between font-semibold">
-                  <span className="flex items-center gap-1">
-                    {p.isHuman ? tc('player.you') : tc('player.cpu', { id: p.id })}
-                    {p.hasOpened && (
-                      <span
-                        className={`px-1.5 rounded text-xs ${badgeSuccessColors}`}
-                        data-testid={`kalooki-opened-${p.id}`}
-                      >
-                        {t('openedBadge')}
-                      </span>
-                    )}
-                  </span>
-                  <span>
-                    {t('cards')}: {p.cardCount}
-                  </span>
-                </div>
-                <div className="text-xs opacity-75">
-                  {t('scoreLabel')}: {p.cumulativeScore} (+{p.roundScore})
-                </div>
-                {p.melds.length > 0 && (
-                  <div className="mt-2">
-                    {p.melds.map((m, mi) => {
-                      const isLayoffTarget = layoffTarget?.playerIdx === p.id && layoffTarget?.meldIdx === mi;
-                      const playerLabel = p.isHuman ? tc('player.you') : tc('player.cpu', { id: p.id });
-                      // A meld is only a selectable layoff target once the human has opened.
-                      const canLayoff = humanPlayer?.hasOpened === true;
-                      return (
-                        <button
-                          type="button"
-                          key={`${p.id}-${mi}`}
-                          onClick={() => {
-                            if (canLayoff) setLayoffTarget({ playerIdx: p.id, meldIdx: mi });
-                          }}
-                          aria-label={t('meldAria', { player: playerLabel, meld: mi + 1 })}
-                          aria-pressed={canLayoff ? isLayoffTarget : undefined}
-                          className={`flex flex-wrap gap-1 mb-1 px-1 rounded ${focusRingWhite} ${
-                            isLayoffTarget ? 'ring-2 ring-ds-warning bg-ds-warning/20' : ''
-                          }`}
+            <section className="px-4 py-2 grid gap-2 md:grid-cols-3">
+              {state.players.map((p) => (
+                <div
+                  key={p.id}
+                  className={`p-3 rounded border ${
+                    state.currentPlayerIdx === p.id ? 'border-ds-warning' : 'border-white/30'
+                  } text-white text-sm bg-black/20`}
+                >
+                  <div className="flex justify-between font-semibold">
+                    <span className="flex items-center gap-1">
+                      {p.isHuman ? tc('player.you') : tc('player.cpu', { id: p.id })}
+                      {p.hasOpened && (
+                        <span
+                          className={`px-1.5 rounded text-xs ${badgeSuccessColors}`}
+                          data-testid={`kalooki-opened-${p.id}`}
                         >
-                          {m.cards.map((c, ci) => (
-                            <AnimatedCard key={`${p.id}-${mi}-${ci}`} card={c} width={cardWidth * 0.6} />
-                          ))}
-                        </button>
-                      );
-                    })}
+                          {t('openedBadge')}
+                        </span>
+                      )}
+                    </span>
+                    <span>
+                      {t('cards')}: {p.cardCount}
+                    </span>
                   </div>
-                )}
-                {/* Reveal CPU hands at round end / game end so the human can verify penalty scores. */}
-                {!p.isHuman && (isRoundEnd || isGameEnd) && p.cards.length > 0 && (
-                  <div className="mt-2">
-                    <div className="text-xs opacity-75 mb-1">{t('revealedHand')}</div>
-                    <div className="flex flex-wrap gap-1" data-testid={`kalooki-reveal-${p.id}`}>
-                      {p.cards.map((c, ci) => (
-                        <AnimatedCard
-                          key={`reveal-${p.id}-${c.design}-${c.value}-${ci}`}
-                          card={c}
-                          width={cardWidth * 0.6}
-                        />
-                      ))}
-                    </div>
+                  <div className="text-xs opacity-75">
+                    {t('scoreLabel')}: {p.cumulativeScore} (+{p.roundScore})
                   </div>
-                )}
-              </div>
-            ))}
-          </section>
-
-          {humanPlayer && (
-            <section className="px-4 py-2" data-tutorial="kalooki-hand">
-              <div className="text-white text-sm mb-1">
-                {t('yourHand')} ({humanPlayer.cardCount})
-                {meldGroups.length > 0 && (
-                  <span className="ml-2 opacity-75">
-                    {t('groupsBuilt')}: {meldGroups.length}
-                  </span>
-                )}
-              </div>
-              <div className="flex flex-wrap gap-1">
-                {humanPlayer.cards.map((c: Card, idx: number) => {
-                  const isSelected = selectedCards.includes(idx);
-                  const groupIdx = meldGroups.findIndex((g) => g.includes(idx));
-                  const isInGroup = groupIdx >= 0;
-                  const ariaLabel = isInGroup
-                    ? t('cardInGroup', { card: cardAlt(c), group: groupIdx + 1 })
-                    : cardAlt(c);
-                  return (
-                    <button
-                      type="button"
-                      key={`${idx}-${c.design}-${c.value}`}
-                      onClick={() => toggleCard(idx)}
-                      disabled={isInGroup}
-                      aria-label={ariaLabel}
-                      aria-pressed={isSelected}
-                      data-testid={`kalooki-hand-${idx}`}
-                      className={`${focusRingWhite} ${isSelected ? 'ring-2 ring-ds-warning' : ''} ${
-                        isInGroup ? 'opacity-40' : ''
-                      }`}
-                    >
-                      <AnimatedCard card={c} width={cardWidth} />
-                    </button>
-                  );
-                })}
-              </div>
-            </section>
-          )}
-
-          {isMeldPhase && humanPlayer && meldGroups.length > 0 && (
-            <section className="px-4 py-2" data-testid="kalooki-staged-groups">
-              <div className="text-white text-sm mb-1">{t('stagedGroupsTitle')}</div>
-              <div className="flex flex-col gap-2">
-                {meldGroups.map((group, gi) => (
-                  <div
-                    // Group order is stable within a staging session; index keys are safe here.
-                    key={`staged-group-${gi}`}
-                    data-testid={`kalooki-staged-group-${gi}`}
-                    className="flex items-center gap-2 flex-wrap p-2 rounded border border-white/30 bg-black/20"
-                  >
-                    <span className="text-white text-xs font-semibold">{t('groupLabel', { n: gi + 1 })}</span>
-                    <div className="flex flex-wrap gap-1">
-                      {group.map((cardIdx) => {
-                        const c = humanPlayer.cards[cardIdx];
-                        if (!c) return null;
-                        return <AnimatedCard key={`staged-${gi}-${cardIdx}`} card={c} width={cardWidth * 0.6} />;
+                  {p.melds.length > 0 && (
+                    <div className="mt-2">
+                      {p.melds.map((m, mi) => {
+                        const isLayoffTarget = layoffTarget?.playerIdx === p.id && layoffTarget?.meldIdx === mi;
+                        const playerLabel = p.isHuman ? tc('player.you') : tc('player.cpu', { id: p.id });
+                        // A meld is only a selectable layoff target once the human has opened.
+                        const canLayoff = humanPlayer?.hasOpened === true;
+                        return (
+                          <button
+                            type="button"
+                            key={`${p.id}-${mi}`}
+                            onClick={() => {
+                              if (canLayoff) setLayoffTarget({ playerIdx: p.id, meldIdx: mi });
+                            }}
+                            aria-label={t('meldAria', { player: playerLabel, meld: mi + 1 })}
+                            aria-pressed={canLayoff ? isLayoffTarget : undefined}
+                            className={`flex flex-wrap gap-1 mb-1 px-1 rounded ${focusRingWhite} ${
+                              isLayoffTarget ? 'ring-2 ring-ds-warning bg-ds-warning/20' : ''
+                            }`}
+                          >
+                            {m.cards.map((c, ci) => (
+                              <AnimatedCard key={`${p.id}-${mi}-${ci}`} card={c} width={cardWidth * 0.6} />
+                            ))}
+                          </button>
+                        );
                       })}
                     </div>
-                    <button
-                      type="button"
-                      onClick={() => handleRemoveGroup(gi)}
-                      aria-label={t('removeGroupAria', { n: gi + 1 })}
-                      data-testid={`kalooki-remove-group-${gi}`}
-                      className={`${btnDanger} ml-auto`}
-                    >
-                      ✕
-                    </button>
-                  </div>
-                ))}
-              </div>
+                  )}
+                  {/* Reveal CPU hands at round end / game end so the human can verify penalty scores. */}
+                  {!p.isHuman && (isRoundEnd || isGameEnd) && p.cards.length > 0 && (
+                    <div className="mt-2">
+                      <div className="text-xs opacity-75 mb-1">{t('revealedHand')}</div>
+                      <div className="flex flex-wrap gap-1" data-testid={`kalooki-reveal-${p.id}`}>
+                        {p.cards.map((c, ci) => (
+                          <AnimatedCard
+                            key={`reveal-${p.id}-${c.design}-${c.value}-${ci}`}
+                            card={c}
+                            width={cardWidth * 0.6}
+                          />
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              ))}
             </section>
-          )}
+
+            {humanPlayer && (
+              <section className="px-4 py-2" data-tutorial="kalooki-hand">
+                <div className="text-white text-sm mb-1">
+                  {t('yourHand')} ({humanPlayer.cardCount})
+                  {meldGroups.length > 0 && (
+                    <span className="ml-2 opacity-75">
+                      {t('groupsBuilt')}: {meldGroups.length}
+                    </span>
+                  )}
+                </div>
+                <div className="flex flex-wrap gap-1">
+                  {humanPlayer.cards.map((c: Card, idx: number) => {
+                    const isSelected = selectedCards.includes(idx);
+                    const groupIdx = meldGroups.findIndex((g) => g.includes(idx));
+                    const isInGroup = groupIdx >= 0;
+                    const ariaLabel = isInGroup
+                      ? t('cardInGroup', { card: cardAlt(c), group: groupIdx + 1 })
+                      : cardAlt(c);
+                    return (
+                      <button
+                        type="button"
+                        key={`${idx}-${c.design}-${c.value}`}
+                        onClick={() => toggleCard(idx)}
+                        disabled={isInGroup}
+                        aria-label={ariaLabel}
+                        aria-pressed={isSelected}
+                        data-testid={`kalooki-hand-${idx}`}
+                        className={`${focusRingWhite} ${isSelected ? 'ring-2 ring-ds-warning' : ''} ${
+                          isInGroup ? 'opacity-40' : ''
+                        }`}
+                      >
+                        <AnimatedCard card={c} width={cardWidth} />
+                      </button>
+                    );
+                  })}
+                </div>
+              </section>
+            )}
+
+            {isMeldPhase && humanPlayer && meldGroups.length > 0 && (
+              <section className="px-4 py-2" data-testid="kalooki-staged-groups">
+                <div className="text-white text-sm mb-1">{t('stagedGroupsTitle')}</div>
+                <div className="flex flex-col gap-2">
+                  {meldGroups.map((group, gi) => (
+                    <div
+                      // Group order is stable within a staging session; index keys are safe here.
+                      key={`staged-group-${gi}`}
+                      data-testid={`kalooki-staged-group-${gi}`}
+                      className="flex items-center gap-2 flex-wrap p-2 rounded border border-white/30 bg-black/20"
+                    >
+                      <span className="text-white text-xs font-semibold">{t('groupLabel', { n: gi + 1 })}</span>
+                      <div className="flex flex-wrap gap-1">
+                        {group.map((cardIdx) => {
+                          const c = humanPlayer.cards[cardIdx];
+                          if (!c) return null;
+                          return <AnimatedCard key={`staged-${gi}-${cardIdx}`} card={c} width={cardWidth * 0.6} />;
+                        })}
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() => handleRemoveGroup(gi)}
+                        aria-label={t('removeGroupAria', { n: gi + 1 })}
+                        data-testid={`kalooki-remove-group-${gi}`}
+                        className={`${btnDanger} ml-auto`}
+                      >
+                        ✕
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              </section>
+            )}
+          </div>
 
           <section className="px-4 py-2 flex flex-wrap gap-2" data-tutorial="kalooki-actions">
             {isDrawPhase && (

--- a/frontend/src/pages/PiquetPage.tsx
+++ b/frontend/src/pages/PiquetPage.tsx
@@ -133,63 +133,72 @@ function PiquetPageContent() {
       <ErrorAlert message={error} onRetry={retry} />
       <GameMessageBox message={state.message} messageCode={state.messageCode} messageParams={state.messageParams} />
 
-      <div className="text-sm opacity-80 px-2">
-        {t('dealHeader', { deal: state.dealNumber, total: state.dealsPerPartie })}
-      </div>
-
-      <PlayerCard label={t('roleElder')} player={state.players[elderIdx]} carteBlanche={state.carteBlanche[elderIdx]} />
-      <PlayerCard
-        label={t('roleYounger')}
-        player={state.players[state.youngerIdx]}
-        carteBlanche={state.carteBlanche[state.youngerIdx]}
-      />
-
-      {human ? (
-        <div data-tutorial="piquet-hand" className="rounded border border-white/20 p-2 mx-2">
-          <div className="mb-1 flex items-center justify-between text-xs">
-            <span className="opacity-70">{t('yourHand')}</span>
-            {activeHighlight ? (
-              <span
-                data-testid="piquet-meld-badge"
-                className={`rounded px-2 py-0.5 text-xs font-bold ${
-                  activeHighlight.won ? badgeSuccessColors : badgeErrorColors
-                }`}
-              >
-                {t(activeHighlight.won ? 'meldWonBadge' : 'meldLostBadge', {
-                  label: t(activeHighlight.labelKey, { count: activeHighlight.count }),
-                })}
-              </span>
-            ) : null}
-          </div>
-          <div className="flex flex-wrap gap-1">
-            {human.cards.map((c, i) => {
-              const selected = selectedDiscards.includes(i);
-              const highlighted = activeHighlight?.cardIndices.includes(i) ?? false;
-              // Highlight ring lives on the AnimatedCard wrapper so it tracks the lift; the
-              // selection lift/glow is driven by AnimatedCard's isSelected (Framer Motion).
-              const ringClass = highlighted
-                ? activeHighlight?.won
-                  ? 'ring-2 ring-ds-success'
-                  : 'ring-2 ring-ds-error'
-                : '';
-              const handlePlay = () => game.handlePlay(i);
-              const handleClick = humanCanExchange ? () => toggleDiscard(i) : humanCanPlay ? handlePlay : undefined;
-              return (
-                <button
-                  key={`hand-${i}-${c.design}-${c.value}`}
-                  type="button"
-                  aria-pressed={humanCanExchange ? selected : undefined}
-                  className="rounded"
-                  onClick={handleClick}
-                  disabled={handleClick == null}
-                >
-                  <AnimatedCard card={c} width={cardWidth} isSelected={selected} wrapperClassName={ringClass} />
-                </button>
-              );
-            })}
-          </div>
+      {/* Scrollable state display. Piquet fits a 375x667 viewport today with
+          room to spare, but it had no play area at all, so any growth would have
+          gone straight into the document height. See issue #4373. */}
+      <div className="flex-1 overflow-y-auto min-h-0">
+        <div className="text-sm opacity-80 px-2">
+          {t('dealHeader', { deal: state.dealNumber, total: state.dealsPerPartie })}
         </div>
-      ) : null}
+
+        <PlayerCard
+          label={t('roleElder')}
+          player={state.players[elderIdx]}
+          carteBlanche={state.carteBlanche[elderIdx]}
+        />
+        <PlayerCard
+          label={t('roleYounger')}
+          player={state.players[state.youngerIdx]}
+          carteBlanche={state.carteBlanche[state.youngerIdx]}
+        />
+
+        {human ? (
+          <div data-tutorial="piquet-hand" className="rounded border border-white/20 p-2 mx-2">
+            <div className="mb-1 flex items-center justify-between text-xs">
+              <span className="opacity-70">{t('yourHand')}</span>
+              {activeHighlight ? (
+                <span
+                  data-testid="piquet-meld-badge"
+                  className={`rounded px-2 py-0.5 text-xs font-bold ${
+                    activeHighlight.won ? badgeSuccessColors : badgeErrorColors
+                  }`}
+                >
+                  {t(activeHighlight.won ? 'meldWonBadge' : 'meldLostBadge', {
+                    label: t(activeHighlight.labelKey, { count: activeHighlight.count }),
+                  })}
+                </span>
+              ) : null}
+            </div>
+            <div className="flex flex-wrap gap-1">
+              {human.cards.map((c, i) => {
+                const selected = selectedDiscards.includes(i);
+                const highlighted = activeHighlight?.cardIndices.includes(i) ?? false;
+                // Highlight ring lives on the AnimatedCard wrapper so it tracks the lift; the
+                // selection lift/glow is driven by AnimatedCard's isSelected (Framer Motion).
+                const ringClass = highlighted
+                  ? activeHighlight?.won
+                    ? 'ring-2 ring-ds-success'
+                    : 'ring-2 ring-ds-error'
+                  : '';
+                const handlePlay = () => game.handlePlay(i);
+                const handleClick = humanCanExchange ? () => toggleDiscard(i) : humanCanPlay ? handlePlay : undefined;
+                return (
+                  <button
+                    key={`hand-${i}-${c.design}-${c.value}`}
+                    type="button"
+                    aria-pressed={humanCanExchange ? selected : undefined}
+                    className="rounded"
+                    onClick={handleClick}
+                    disabled={handleClick == null}
+                  >
+                    <AnimatedCard card={c} width={cardWidth} isSelected={selected} wrapperClassName={ringClass} />
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        ) : null}
+      </div>
 
       <div data-tutorial="piquet-controls" className="flex flex-wrap gap-2 px-2">
         {humanCanExchange && state.exchangeTurn === PiquetExchangeTurn.ELDER ? (

--- a/frontend/src/pages/SpeedPage.tsx
+++ b/frontend/src/pages/SpeedPage.tsx
@@ -216,7 +216,7 @@ function SpeedPageContent() {
                 : t('clearTime', { time: formatTime(elapsedMs) })}
             </p>
           )}
-          <div className="flex-1 flex flex-col gap-3 min-h-0">
+          <div className="flex-1 flex flex-col gap-3 min-h-0 overflow-y-auto">
             {/* CPU area */}
             <div className="flex items-center justify-center gap-2">
               <span className="text-sm text-ds-text-muted">


### PR DESCRIPTION
Phase 3 of #4373, following #4441 (phases 1–2).

#4441 pinned the document for 206 of 219 game pages by fixing the shell and bounding the footer. It could not help pages that have **no play area at all** — with nothing carrying `overflow-y-auto`, there is nothing to absorb the overflow, so their content goes straight into the document height. There were five:

| page | before | after | what it needed |
|---|---|---|---|
| `carioca` | +333 | **0** | wrap the state display; region 286px for 614px of content |
| `kalooki` | +264 | **0** | wrap the state display; region 278px for 542px |
| `contractrummy` | +230 | **0** | wrap the state display; region 322px for 544px |
| `speed` | 0 … **+201** | **0** | its `flex-1` area was missing `overflow-y-auto` |
| `piquet` | 0 | **0** | had no play area; fits today, now resilient |

## The split was measured, not guessed

Wrapping *everything* above the footer would have pushed the primary action buttons into a scroll region — on these pages the actions live in a `<section>` above the footer, not inside it, and the footer holds only reset. So I measured each page's parts first. Carioca:

```
header 110 + contract 148 + players 288 + hand 178 + actions 60 + message 74 + footer 67 = 925
available: 605
```

Pinning header + actions + message + footer (311px) leaves 294px of play area for the 614px of state display. Predicted 294, measured 286. The action row stays visible and the state scrolls — which is the structure every other game page already uses.

## `speed` is why these are guarded rather than trusted

`speed` fitted on the deal I first sampled and overflowed by **201px** on others (it is one of the five pages whose height depends on the deal). Spot-checking would have called it fine. It now has `overflow-y-auto` on the `flex-1` area it already had, and it — along with the other four — is added to `e2e/mobile-viewport.spec.ts`, which now covers 13 paths.

`piquet` was not broken (it fits with ~147px to spare and shows no deal variance), but it had no play area either, so any future growth would have gone into the document height. Wrapping its state display costs nothing visually — `overflow-y-auto` only scrolls when it must.

## Result

**213 of 219 pages no longer scroll the document**, up from 210 after #4441 and 40 before it. (206 vs 211 on the stricter "fully clean" check, which also requires a play area over 80px — `paigow` and `chinesepoker` trip that threshold but are not overflowing at all; their content is exactly 72px and they simply do not fill the viewport, by design.)

## Still open — phase 4, and an honest note on it

Six pages still overflow: `memory` +257, `openfacechinese` +216, `jass` +209, `clocksolitaire` +149, `gaigel` +39, `spiteandmalice` +12.

I looked into these and **did not reach a confident diagnosis**, so I am not guessing at a fix. What is established: each one *has* a constrained, scrollable play area (e.g. `memory` 356px client / 734px content, scrollable), its footer is on screen, and no element escapes a clipping ancestor — every element extending past the viewport reports the play area as its nearest clipping ancestor. Their region classes are also near-identical to `hearts`, which fits. So the cause is something subtler than a missing region, and it wants its own investigation rather than a plausible-looking patch.

## Verification

- 219 pages re-verified at 375×667: no page regressed
- `bun run test` (5 edited pages: 137 tests) and full suite green
- `bun run typecheck`, `bun run check` (7 guards) clean
- `bunx playwright test e2e/mobile-viewport.spec.ts` — 26 tests across 13 paths

Refs #4373
