### PR TITLE
fix(frontend): make 148 vacuous test assertions real, and fix the bug they hid

### DIFF
--- a/frontend/src/pages/AccordionPage.test.tsx
+++ b/frontend/src/pages/AccordionPage.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { accordionApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { AccordionResponse, Card, CardDesign } from '../types/card';
 import { AccordionPage } from './AccordionPage';
@@ -127,6 +128,7 @@ describe('AccordionPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
     mockExec.mockClear();
     fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('giveup');
     expect(screen.getByText('投了確認')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: '確認' }));
@@ -274,6 +276,7 @@ describe('AccordionPage', () => {
     fireEvent.click(pile0);
     await waitFor(() => expect(pile0.className).toMatch(/ring-/));
     fireEvent.click(pile0);
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 
@@ -319,6 +322,7 @@ describe('AccordionPage', () => {
     const pile0 = screen.getByRole('button', { name: /^0:/ });
     fireEvent.click(pile0);
     // offset=2 is invalid; pile0 becomes the new selection instead
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
     await waitFor(() => expect(pile0.className).toMatch(/ring-/));
   });

--- a/frontend/src/pages/AgnesPage.test.tsx
+++ b/frontend/src/pages/AgnesPage.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { agnesApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { AgnesResponse, Card, CardDesign } from '../types/card';
 import { AgnesPage } from './AgnesPage';
@@ -138,6 +139,7 @@ describe('AgnesPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
     mockExec.mockClear();
     fireEvent.keyDown(document.body, { key: 'z' });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('undo');
   });
 
@@ -146,6 +148,7 @@ describe('AgnesPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
     mockExec.mockClear();
     fireEvent.keyDown(document.body, { key: 'g' });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('giveup');
     expect(screen.getByText('投了確認')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: '確認' }));
@@ -166,6 +169,7 @@ describe('AgnesPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
     mockExec.mockClear();
     fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('giveup');
     expect(screen.getByText('投了確認')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: '確認' }));

--- a/frontend/src/pages/BaccaratPage.test.tsx
+++ b/frontend/src/pages/BaccaratPage.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, screen, waitFor, within } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { actionLogApi, baccaratApi } from '../api/gameApi';
 import { useGameHint } from '../hooks/useGameHint';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { BaccaratResponse, Card, CardDesign } from '../types/card';
 import { BaccaratPage } from './BaccaratPage';
@@ -455,6 +456,7 @@ describe('BaccaratPage', () => {
     await waitFor(() => expect(screen.getByText(/プレイヤーの勝ち/)).toBeInTheDocument());
     mockExec.mockClear();
     fireEvent.keyDown(document, { key: 'b' });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 
@@ -464,6 +466,7 @@ describe('BaccaratPage', () => {
     await waitFor(() => expect(screen.getByText('チップ: 1000')).toBeInTheDocument());
     mockExec.mockClear();
     fireEvent.keyDown(document, { key: 'r' });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/pages/BakersDozenPage.test.tsx
+++ b/frontend/src/pages/BakersDozenPage.test.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { bakersDozenApi } from '../api/gameApi';
 import { useGameHint } from '../hooks/useGameHint';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { BakersDozenResponse, BakersDozenTableauCard, Card, CardDesign } from '../types/card';
 import { BakersDozenPage } from './BakersDozenPage';
@@ -187,6 +188,7 @@ describe('BakersDozenPage', () => {
     mockExec.mockClear();
     mockExec.mockResolvedValue(gameOverState);
     fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('giveup');
     expect(screen.getByText('投了確認')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: '確認' }));

--- a/frontend/src/pages/BakersGamePage.test.tsx
+++ b/frontend/src/pages/BakersGamePage.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { actionLogApi, bakersgameApi } from '../api/gameApi';
 import { useGameHint } from '../hooks/useGameHint';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, CardDesign, FreeCellResponse } from '../types/card';
 import { BakersGamePage } from './BakersGamePage';
@@ -216,6 +217,7 @@ describe('BakersGamePage', () => {
     mockExec.mockClear();
     mockExec.mockResolvedValue(gameOverState);
     fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('giveup');
     expect(screen.getByText('投了確認')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: '確認' }));
@@ -394,6 +396,7 @@ describe('BakersGamePage', () => {
     mockExec.mockClear();
     mockExec.mockResolvedValue(gameOverState);
     fireEvent.keyDown(document, { key: 'g' });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('giveup');
     expect(screen.getByText('投了確認')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: '確認' }));
@@ -420,6 +423,7 @@ describe('BakersGamePage', () => {
     fireEvent.keyDown(document, { key: 'a' });
     fireEvent.keyDown(document, { key: 'g' });
     fireEvent.keyDown(document, { key: 'z' });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/pages/BigOHiLoPage.test.tsx
+++ b/frontend/src/pages/BigOHiLoPage.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, screen, waitFor, within } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { actionLogApi, bigOHiLoApi } from '../api/gameApi';
 import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { OmahaResponse } from '../types/card';
 import { BigOHiLoPage } from './BigOHiLoPage';
@@ -1496,6 +1497,7 @@ describe('BigOHiLoPage', () => {
         fireEvent.keyDown(document, { key: 'f' });
         fireEvent.keyDown(document, { key: 'a' });
       });
+      await flushPendingDispatch();
       expect(mockExec).not.toHaveBeenCalled();
     });
 
@@ -1509,6 +1511,7 @@ describe('BigOHiLoPage', () => {
       await act(async () => {
         fireEvent.keyDown(document, { key: 'c' });
       });
+      await flushPendingDispatch();
       expect(mockExec).not.toHaveBeenCalled();
     });
 
@@ -1522,6 +1525,7 @@ describe('BigOHiLoPage', () => {
       await act(async () => {
         fireEvent.keyDown(document, { key: 'k' });
       });
+      await flushPendingDispatch();
       expect(mockExec).not.toHaveBeenCalled();
     });
   });

--- a/frontend/src/pages/BigOPage.test.tsx
+++ b/frontend/src/pages/BigOPage.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, screen, waitFor, within } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { actionLogApi, bigOApi } from '../api/gameApi';
 import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { OmahaResponse } from '../types/card';
 import { BigOPage } from './BigOPage';
@@ -1406,6 +1407,7 @@ describe('BigOPage', () => {
         fireEvent.keyDown(document, { key: 'f' });
         fireEvent.keyDown(document, { key: 'a' });
       });
+      await flushPendingDispatch();
       expect(mockExec).not.toHaveBeenCalled();
     });
 
@@ -1419,6 +1421,7 @@ describe('BigOPage', () => {
       await act(async () => {
         fireEvent.keyDown(document, { key: 'c' });
       });
+      await flushPendingDispatch();
       expect(mockExec).not.toHaveBeenCalled();
     });
 
@@ -1432,6 +1435,7 @@ describe('BigOPage', () => {
       await act(async () => {
         fireEvent.keyDown(document, { key: 'k' });
       });
+      await flushPendingDispatch();
       expect(mockExec).not.toHaveBeenCalled();
     });
   });

--- a/frontend/src/pages/BlackHolePage.test.tsx
+++ b/frontend/src/pages/BlackHolePage.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { blackholeApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { BlackHoleResponse, Card } from '../types/card';
 import { BlackHolePage } from './BlackHolePage';
@@ -66,6 +67,7 @@ describe('BlackHolePage', () => {
     const buried = await screen.findByTestId('card-0-0');
     mockExec.mockClear();
     fireEvent.click(buried);
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/pages/BlackJackPage.test.tsx
+++ b/frontend/src/pages/BlackJackPage.test.tsx
@@ -3,6 +3,7 @@ import i18n from 'i18next';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { actionLogApi, blackjackApi } from '../api/gameApi';
 import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { BlackJackCpuSeat, BlackJackHand, BlackJackResponse } from '../types/card';
 import { BlackJackPage } from './BlackJackPage';
@@ -1477,6 +1478,7 @@ describe('BlackJackPage', () => {
     fireEvent.click(screen.getByRole('button', { name: '次のゲーム' }));
     // Confirmation dialog appears and no reset fires until it is confirmed.
     expect(screen.getByText('本当にゲームをリセットしますか？')).toBeInTheDocument();
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 
@@ -1554,6 +1556,7 @@ describe('BlackJackPage', () => {
     await waitFor(() => expect(screen.getByRole('button', { name: 'ヒット' })).toBeInTheDocument());
     mockExec.mockClear();
     fireEvent.keyDown(document, { key: 'd' });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('doubledown');
   });
 
@@ -1564,6 +1567,7 @@ describe('BlackJackPage', () => {
     mockExec.mockClear();
     fireEvent.keyDown(document, { key: 'h' });
     fireEvent.keyDown(document, { key: 's' });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 
@@ -1593,6 +1597,7 @@ describe('BlackJackPage', () => {
     await waitFor(() => expect(screen.getByRole('button', { name: 'ヒット' })).toBeInTheDocument());
     mockExec.mockClear();
     fireEvent.keyDown(document, { key: 'i' });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('insurance');
   });
 
@@ -1624,6 +1629,7 @@ describe('BlackJackPage', () => {
     await waitFor(() => expect(screen.getByRole('button', { name: 'ベット' })).toBeInTheDocument());
     mockExec.mockClear();
     fireEvent.keyDown(document, { key: 'u' });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('earlysurrender');
   });
 

--- a/frontend/src/pages/BriscolaPage.test.tsx
+++ b/frontend/src/pages/BriscolaPage.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { briscolaApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { BriscolaResponse, Card } from '../types/card';
 import { BriscolaPage } from './BriscolaPage';
@@ -116,6 +117,7 @@ describe('BriscolaPage', () => {
     fireEvent.keyDown(document.body, { key: 'Escape' });
     await waitFor(() => expect(firstCard).toHaveAttribute('aria-pressed', 'false'));
     fireEvent.keyDown(document.body, { key: 'Enter' });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('play', expect.anything());
   });
 
@@ -127,6 +129,7 @@ describe('BriscolaPage', () => {
     fireEvent.keyDown(document.body, { key: '1' });
     fireEvent.keyDown(document.body, { key: 'Enter' });
     expect(firstCard).toHaveAttribute('aria-pressed', 'false');
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('play', expect.anything());
   });
 

--- a/frontend/src/pages/BristolPage.test.tsx
+++ b/frontend/src/pages/BristolPage.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { bristolApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { BristolResponse, Card, CardDesign } from '../types/card';
 import { BristolPage } from './BristolPage';
@@ -179,6 +180,7 @@ describe('BristolPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
     mockExec.mockClear();
     fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('giveup');
     expect(screen.getByText('投了確認')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: '確認' }));
@@ -239,6 +241,7 @@ describe('BristolPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
     mockExec.mockClear();
     fireEvent.keyDown(document.body, { key: 'd' });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('draw');
   });
 
@@ -256,6 +259,7 @@ describe('BristolPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
     mockExec.mockClear();
     fireEvent.keyDown(document.body, { key: 'z' });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('undo');
   });
 
@@ -264,6 +268,7 @@ describe('BristolPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
     mockExec.mockClear();
     fireEvent.keyDown(document.body, { key: 'g' });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('giveup');
     expect(screen.getByText('投了確認')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: '確認' }));
@@ -346,6 +351,7 @@ describe('BristolPage', () => {
       fireEvent.drop(dropZone, { dataTransfer });
 
       // No source was dragged, so getData returns '' and no move is dispatched.
+      await flushPendingDispatch();
       expect(mockExec).not.toHaveBeenCalledWith('move', expect.anything(), expect.anything());
     });
   });

--- a/frontend/src/pages/CalculationPage.test.tsx
+++ b/frontend/src/pages/CalculationPage.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { calculationApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { CalculationResponse, Card, CardDesign } from '../types/card';
 import { CalculationPage, calculationNextRank } from './CalculationPage';
@@ -107,6 +108,7 @@ describe('CalculationPage', () => {
     mockExec.mockClear();
     // Clicking give-up must NOT dispatch immediately — it opens a confirm dialog (#2099).
     fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('giveup');
     expect(screen.getByText('投了確認')).toBeInTheDocument();
     // Confirming dispatches giveup.
@@ -183,6 +185,7 @@ describe('CalculationPage', () => {
     mockExec.mockClear();
     const f0 = screen.getByLabelText(/ファンデーション 0 \+1/);
     fireEvent.click(f0);
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/pages/CanfieldPage.test.tsx
+++ b/frontend/src/pages/CanfieldPage.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { canfieldApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { CanfieldResponse, Card, CardDesign } from '../types/card';
 import { CanfieldPage } from './CanfieldPage';
@@ -191,6 +192,7 @@ describe('CanfieldPage', () => {
     mockExec.mockClear();
     // Clicking give-up must NOT dispatch immediately — it opens a confirm dialog (#2099).
     fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('giveup');
     expect(screen.getByText('投了確認')).toBeInTheDocument();
     // Confirming dispatches giveup.

--- a/frontend/src/pages/ChinesePokerPage.test.tsx
+++ b/frontend/src/pages/ChinesePokerPage.test.tsx
@@ -12,6 +12,7 @@ vi.mock('../hooks/useGameHint', () => ({
 }));
 
 import { chinesepokerApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { ChinesePokerPage } from './ChinesePokerPage';
 
 const mockExec = vi.mocked(chinesepokerApi.exec);
@@ -187,6 +188,7 @@ describe('ChinesePokerPage', () => {
     expect(screen.getByRole('alert')).toBeInTheDocument();
     mockExec.mockClear();
     fireEvent.keyDown(document, { key: 'b' });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/pages/ConquianPage.test.tsx
+++ b/frontend/src/pages/ConquianPage.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { actionLogApi, conquianApi } from '../api/gameApi';
 import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { ConquianResponse } from '../types/card';
 import { ConquianPage } from './ConquianPage';
@@ -233,6 +234,7 @@ describe('ConquianPage', () => {
     await screen.findByRole('button', { name: '捨て札から引く' });
     mockExec.mockClear();
     fireEvent.keyDown(document.body, { key: 'd' });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('drawdiscard');
   });
 
@@ -243,7 +245,9 @@ describe('ConquianPage', () => {
     mockExec.mockClear();
     fireEvent.keyDown(document.body, { key: 's' });
     fireEvent.keyDown(document.body, { key: 'd' });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('drawstock');
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('drawdiscard');
   });
 

--- a/frontend/src/pages/CuarentaPage.test.tsx
+++ b/frontend/src/pages/CuarentaPage.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { cuarentaApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, CuarentaPlayer, CuarentaResponse } from '../types/card';
 import { CuarentaPage } from './CuarentaPage';
@@ -228,6 +229,7 @@ describe('CuarentaPage', () => {
     const cardBtn = await screen.findByTestId('hand-card-0');
     mockExec.mockClear();
     fireEvent.click(cardBtn);
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/pages/DaifugoPage.test.tsx
+++ b/frontend/src/pages/DaifugoPage.test.tsx
@@ -2,6 +2,7 @@ import { act, createEvent, fireEvent, screen, waitFor } from '@testing-library/r
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { actionLogApi, daifugoApi } from '../api/gameApi';
 import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { DaifugoResponse } from '../types/card';
 import { DaifugoPage } from './DaifugoPage';
@@ -996,6 +997,7 @@ describe('DaifugoPage', () => {
     mockExec.mockClear();
     fireEvent(dropZone, dropEvent);
     // exec should NOT be called when draggedIdx is NaN
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 
@@ -1247,6 +1249,7 @@ describe('DaifugoPage', () => {
     mockExec.mockClear();
     fireEvent.keyDown(document, { key: 'Enter' });
     // exec should not have been called with 'play' since no cards selected
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('play', expect.anything());
   });
 
@@ -1258,6 +1261,7 @@ describe('DaifugoPage', () => {
     mockExec.mockClear();
     fireEvent.keyDown(document, { key: '1' });
     fireEvent.keyDown(document, { key: 'Enter' });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('play', expect.anything());
   });
 
@@ -1299,6 +1303,7 @@ describe('DaifugoPage', () => {
     mockExec.mockClear();
     fireEvent.keyDown(document, { key: 'Enter' });
     // no cards selected so Enter should not call play
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('play', expect.anything());
   });
 

--- a/frontend/src/pages/DoubtPage.test.tsx
+++ b/frontend/src/pages/DoubtPage.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, screen, waitFor, within } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { actionLogApi, doubtApi } from '../api/gameApi';
 import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { DoubtConfig, DoubtResponse } from '../types/card';
 import { DoubtPage } from './DoubtPage';
@@ -438,6 +439,7 @@ describe('DoubtPage', () => {
     mockExec.mockClear();
     fireEvent.keyDown(selectEl, { key: ' ' });
     fireEvent.keyDown(selectEl, { key: 'Escape' });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/pages/EightOffPage.test.tsx
+++ b/frontend/src/pages/EightOffPage.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { actionLogApi, eightoffApi } from '../api/gameApi';
 import { useGameHint } from '../hooks/useGameHint';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, CardDesign, EightOffResponse } from '../types/card';
 import { EightOffPage } from './EightOffPage';
@@ -315,6 +316,7 @@ describe('EightOffPage', () => {
     mockExec.mockResolvedValue(gameOverState);
     // Clicking give-up must NOT dispatch immediately — it opens a confirm dialog (#2099).
     fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('giveup');
     expect(screen.getByText('投了確認')).toBeInTheDocument();
     // Confirming dispatches giveup.
@@ -545,6 +547,7 @@ describe('EightOffPage', () => {
     mockExec.mockClear();
     mockExec.mockResolvedValue(gameOverState);
     fireEvent.keyDown(document, { key: 'g' });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('giveup');
     expect(screen.getByText('投了確認')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: '確認' }));
@@ -571,6 +574,7 @@ describe('EightOffPage', () => {
     fireEvent.keyDown(document, { key: 'a' });
     fireEvent.keyDown(document, { key: 'g' });
     fireEvent.keyDown(document, { key: 'z' });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 
@@ -924,6 +928,7 @@ describe('EightOffPage', () => {
       const cardButton = screen.getByAltText('♠ K').closest('button') as HTMLButtonElement;
       fireEvent.doubleClick(cardButton);
 
+      await flushPendingDispatch();
       expect(mockExec).not.toHaveBeenCalledWith('move', expect.anything(), expect.anything());
     });
 

--- a/frontend/src/pages/FreeCellPage.test.tsx
+++ b/frontend/src/pages/FreeCellPage.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { actionLogApi, freecellApi } from '../api/gameApi';
 import { useGameHint } from '../hooks/useGameHint';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, CardDesign, FreeCellResponse } from '../types/card';
 import { FreeCellPage } from './FreeCellPage';
@@ -233,6 +234,7 @@ describe('FreeCellPage', () => {
     mockExec.mockResolvedValue(gameOverState);
     // Clicking give-up must NOT dispatch immediately — it opens a confirm dialog (#2180).
     fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('giveup');
     expect(screen.getByText('投了確認')).toBeInTheDocument();
 
@@ -247,6 +249,7 @@ describe('FreeCellPage', () => {
     mockExec.mockClear();
     fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
     fireEvent.click(screen.getByRole('button', { name: 'キャンセル' }));
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('giveup');
   });
 
@@ -495,6 +498,7 @@ describe('FreeCellPage', () => {
     mockExec.mockClear();
     mockExec.mockResolvedValue(gameOverState);
     fireEvent.keyDown(document, { key: 'g' });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('giveup');
     expect(screen.getByText('投了確認')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: '確認' }));
@@ -521,6 +525,7 @@ describe('FreeCellPage', () => {
     fireEvent.keyDown(document, { key: 'a' });
     fireEvent.keyDown(document, { key: 'g' });
     fireEvent.keyDown(document, { key: 'z' });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/pages/GapsPage.test.tsx
+++ b/frontend/src/pages/GapsPage.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { gapsApi } from '../api/gameApi';
 import { useGameHint } from '../hooks/useGameHint';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, CardDesign, GapsResponse } from '../types/card';
 import { GapsPage } from './GapsPage';
@@ -144,6 +145,7 @@ describe('GapsPage', () => {
     renderWithProviders(<GapsPage />);
     const btn = await screen.findByRole('button', { name: 'ギブアップ' });
     fireEvent.click(btn);
+    await flushPendingDispatch();
     expect(mockedRun).not.toHaveBeenCalledWith('giveup');
     expect(screen.getByText('投了確認')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: '確認' }));
@@ -209,6 +211,7 @@ describe('GapsPage', () => {
     await screen.findByRole('button', { name: '元に戻す' });
     mockedRun.mockClear();
     fireEvent.keyDown(document.body, { key: 'z' });
+    await flushPendingDispatch();
     expect(mockedRun).not.toHaveBeenCalledWith('undo');
   });
 
@@ -226,6 +229,7 @@ describe('GapsPage', () => {
     await screen.findByTestId('gaps-redeal-button');
     mockedRun.mockClear();
     fireEvent.keyDown(document.body, { key: 'd' });
+    await flushPendingDispatch();
     expect(mockedRun).not.toHaveBeenCalledWith('redeal');
   });
 
@@ -242,6 +246,7 @@ describe('GapsPage', () => {
     await screen.findByRole('button', { name: 'ギブアップ' });
     mockedRun.mockClear();
     fireEvent.keyDown(document.body, { key: 'g' });
+    await flushPendingDispatch();
     expect(mockedRun).not.toHaveBeenCalledWith('giveup');
     expect(screen.getByText('投了確認')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: '確認' }));
@@ -254,6 +259,7 @@ describe('GapsPage', () => {
     await waitFor(() => expect(screen.queryByRole('button', { name: 'ヒント' })).not.toBeInTheDocument());
     mockedRun.mockClear();
     fireEvent.keyDown(document.body, { key: 'h' });
+    await flushPendingDispatch();
     expect(mockedRun).not.toHaveBeenCalledWith('hint');
   });
 

--- a/frontend/src/pages/GoFishPage.test.tsx
+++ b/frontend/src/pages/GoFishPage.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { goFishApi } from '../api/gameApi';
 import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, GoFishResponse } from '../types/card';
 import { GoFishPhase } from '../types/phases';
@@ -179,6 +180,7 @@ describe('GoFishPage', () => {
     fireEvent.keyDown(document.body, { key: '1' });
     fireEvent.keyDown(document.body, { key: 'ArrowRight' });
     fireEvent.keyDown(document.body, { key: 'a' });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('ask', expect.anything(), expect.anything());
     expect(screen.getByTestId('gf-kbd-announce').textContent).toBe('');
   });

--- a/frontend/src/pages/GoStopPage.test.tsx
+++ b/frontend/src/pages/GoStopPage.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { gostopApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import { makeGoStopState } from '../test/stateFactories';
 import { GoStopPage } from './GoStopPage';
@@ -219,6 +220,7 @@ describe('GoStopPage', () => {
     expect(card).toBeDisabled();
     mockExec.mockClear();
     fireEvent.click(card);
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/pages/HachiHachiPage.test.tsx
+++ b/frontend/src/pages/HachiHachiPage.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { hachihachiApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import { makeHachiHachiState } from '../test/stateFactories';
 import { HachiHachiPage } from './HachiHachiPage';
@@ -141,6 +142,7 @@ describe('HachiHachiPage', () => {
     expect(card).toBeDisabled();
     mockExec.mockClear();
     fireEvent.click(card);
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/pages/HoldemPage.test.tsx
+++ b/frontend/src/pages/HoldemPage.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, screen, waitFor, within } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { actionLogApi, holdemApi } from '../api/gameApi';
 import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { HoldemResponse } from '../types/card';
 import { HoldemPage } from './HoldemPage';
@@ -1401,6 +1402,7 @@ describe('HoldemPage', () => {
         fireEvent.keyDown(document, { key: 'f' });
         fireEvent.keyDown(document, { key: 'a' });
       });
+      await flushPendingDispatch();
       expect(mockExec).not.toHaveBeenCalled();
     });
 
@@ -1414,6 +1416,7 @@ describe('HoldemPage', () => {
       await act(async () => {
         fireEvent.keyDown(document, { key: 'c' });
       });
+      await flushPendingDispatch();
       expect(mockExec).not.toHaveBeenCalled();
     });
 
@@ -1427,6 +1430,7 @@ describe('HoldemPage', () => {
       await act(async () => {
         fireEvent.keyDown(document, { key: 'k' });
       });
+      await flushPendingDispatch();
       expect(mockExec).not.toHaveBeenCalled();
     });
   });

--- a/frontend/src/pages/KlondikePage.test.tsx
+++ b/frontend/src/pages/KlondikePage.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { actionLogApi, klondikeApi } from '../api/gameApi';
 import { useGameHint } from '../hooks/useGameHint';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, CardDesign, KlondikeResponse, KlondikeTableauCard } from '../types/card';
 import { KlondikePage } from './KlondikePage';
@@ -293,6 +294,7 @@ describe('KlondikePage', () => {
     mockExec.mockResolvedValue(gameOverState);
     // Clicking give-up must NOT dispatch immediately — it opens a confirm dialog (#2099).
     fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('giveup');
     expect(screen.getByText('投了確認')).toBeInTheDocument();
 
@@ -308,6 +310,7 @@ describe('KlondikePage', () => {
     mockExec.mockClear();
     fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
     fireEvent.click(screen.getByRole('button', { name: 'キャンセル' }));
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('giveup');
   });
 
@@ -730,6 +733,7 @@ describe('KlondikePage', () => {
     mockExec.mockClear();
     fireEvent.keyDown(document, { key: 'd' });
     fireEvent.keyDown(document, { key: 'h' });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 
@@ -754,6 +758,7 @@ describe('KlondikePage', () => {
     mockExec.mockResolvedValue({ ...playingState, drawCount: 3 });
     fireEvent.change(screen.getByLabelText('ドローモード'), { target: { value: '3' } });
     // Mid-game: no reset until the dialog is confirmed (#2179).
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
     fireEvent.click(screen.getByRole('button', { name: '確認' }));
 
@@ -769,6 +774,7 @@ describe('KlondikePage', () => {
     mockExec.mockClear();
     fireEvent.change(screen.getByLabelText('ドローモード'), { target: { value: '3' } });
     fireEvent.click(screen.getByRole('button', { name: 'キャンセル' }));
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
     // The select must revert to the still-active setting.
     expect(screen.getByLabelText('ドローモード')).toHaveValue('1');
@@ -781,6 +787,7 @@ describe('KlondikePage', () => {
     mockExec.mockClear();
     mockExec.mockResolvedValue({ ...playingState, scoringMode: 1 });
     fireEvent.change(screen.getByLabelText('スコアモード'), { target: { value: '1' } });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
     fireEvent.click(screen.getByRole('button', { name: '確認' }));
 
@@ -809,6 +816,7 @@ describe('KlondikePage', () => {
     mockExec.mockClear();
     fireEvent.change(screen.getByLabelText('スコアモード'), { target: { value: '1' } });
     fireEvent.click(screen.getByRole('button', { name: 'キャンセル' }));
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
     expect(screen.getByLabelText('スコアモード')).toHaveValue('0');
   });

--- a/frontend/src/pages/KoiKoiPage.test.tsx
+++ b/frontend/src/pages/KoiKoiPage.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { koikoiApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import { makeKoiKoiState } from '../test/stateFactories';
 import { KoiKoiPage } from './KoiKoiPage';
@@ -137,6 +138,7 @@ describe('KoiKoiPage', () => {
     mockExec.mockClear();
     fireEvent.click(card);
     // Clicking a disabled/non-human-turn card issues no API call.
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/pages/LetItRidePage.test.tsx
+++ b/frontend/src/pages/LetItRidePage.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { letitrideApi } from '../api/gameApi';
 import { useCliMode } from '../hooks/useCliMode';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, CardDesign, LetItRideResponse, MaskedCard } from '../types/card';
 import { LetItRidePhase } from '../types/phases';
@@ -312,6 +313,7 @@ describe('LetItRidePage', () => {
     expect(screen.getByText('ベットを引き下げますか？')).toBeInTheDocument();
     // firstDecisionState: betAmount 100, all 3 active → risk 300, newRisk 200.
     expect(screen.getByText(/100 が戻り、総リスクは 300 → 200/)).toBeInTheDocument();
+    await flushPendingDispatch();
     expect(mockApi).not.toHaveBeenCalledWith('pull');
 
     mockApi.mockResolvedValue(secondDecisionState);
@@ -325,6 +327,7 @@ describe('LetItRidePage', () => {
     await waitFor(() => expect(screen.getByRole('button', { name: 'プル' })).toBeInTheDocument());
     fireEvent.click(screen.getByRole('button', { name: 'プル' }));
     fireEvent.click(screen.getByRole('button', { name: 'キャンセル' }));
+    await flushPendingDispatch();
     expect(mockApi).not.toHaveBeenCalledWith('pull');
   });
 
@@ -334,6 +337,7 @@ describe('LetItRidePage', () => {
     await waitFor(() => expect(screen.getByRole('button', { name: 'プル' })).toBeInTheDocument());
     fireEvent.keyDown(document, { key: 'p' });
     expect(screen.getByText('ベットを引き下げますか？')).toBeInTheDocument();
+    await flushPendingDispatch();
     expect(mockApi).not.toHaveBeenCalledWith('pull');
   });
 
@@ -344,6 +348,7 @@ describe('LetItRidePage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'プル' }));
     // With the dialog open, the 'l' shortcut must not bypass it.
     fireEvent.keyDown(document, { key: 'l' });
+    await flushPendingDispatch();
     expect(mockApi).not.toHaveBeenCalledWith('letitride');
   });
 

--- a/frontend/src/pages/MemoryPage.test.tsx
+++ b/frontend/src/pages/MemoryPage.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { actionLogApi, memoryApi } from '../api/gameApi';
 import { useGameHint } from '../hooks/useGameHint';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, MemoryBoardCard, MemoryResponse } from '../types/card';
 import { MemoryPage } from './MemoryPage';
@@ -455,6 +456,7 @@ describe('MemoryPage', () => {
     await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
     mockExec.mockClear();
     fireEvent.keyDown(document, { key: 'n' });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/pages/MonteCarloPage.test.tsx
+++ b/frontend/src/pages/MonteCarloPage.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { montecarloApi } from '../api/gameApi';
 import { useGameHint } from '../hooks/useGameHint';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, CardDesign, MonteCarloBoardCell, MonteCarloResponse } from '../types/card';
 import { MonteCarloPage } from './MonteCarloPage';
@@ -105,6 +106,7 @@ describe('MonteCarloPage', () => {
     expect(prompt.textContent).toMatch(/隣接/);
     fireEvent.click(cell00);
     expect(cell00).toHaveAttribute('aria-pressed', 'false');
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 
@@ -130,6 +132,7 @@ describe('MonteCarloPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
     mockExec.mockClear();
     fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('giveup');
     expect(screen.getByText('投了確認')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: '確認' }));

--- a/frontend/src/pages/OhHellPage.test.tsx
+++ b/frontend/src/pages/OhHellPage.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { actionLogApi, ohHellApi } from '../api/gameApi';
 import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { OhHellResponse } from '../types/card';
 import { OhHellPage } from './OhHellPage';
@@ -295,6 +296,7 @@ describe('OhHellPage', () => {
     // Clicking the restricted bid dispatches nothing.
     mockExec.mockClear();
     fireEvent.click(restricted);
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
 
     // Other choices remain enabled and normal.

--- a/frontend/src/pages/OldMaidPage.test.tsx
+++ b/frontend/src/pages/OldMaidPage.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { actionLogApi, oldmaidApi } from '../api/gameApi';
 import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { OldMaidResponse } from '../types/card';
 import { OldMaidPage } from './OldMaidPage';
@@ -218,6 +219,7 @@ describe('OldMaidPage', () => {
     mockExec.mockClear();
     fireEvent.click(screen.getByRole('button', { name: 'キャンセル' }));
     expect(screen.queryByText('Old Maid 設定')).not.toBeInTheDocument();
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
     // Reopen dialog: mode should be reverted to 0 (original)
     fireEvent.click(screen.getByRole('button', { name: '設定' }));
@@ -969,6 +971,7 @@ describe('OldMaidPage', () => {
     });
 
     // Should NOT call API since from === to
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 
@@ -981,6 +984,7 @@ describe('OldMaidPage', () => {
       dataTransfer: { getData: () => '' },
     });
 
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 
@@ -1291,6 +1295,7 @@ describe('OldMaidPage', () => {
     mockExec.mockClear();
     fireEvent.keyDown(document, { key: 'd' });
     fireEvent.keyDown(document, { key: 's' });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 
@@ -1300,6 +1305,7 @@ describe('OldMaidPage', () => {
     mockExec.mockClear();
     fireEvent.keyDown(document, { key: 'd' });
     fireEvent.keyDown(document, { key: 's' });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/pages/OmahaHiLoPage.test.tsx
+++ b/frontend/src/pages/OmahaHiLoPage.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, screen, waitFor, within } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { actionLogApi, omahaHiLoApi } from '../api/gameApi';
 import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { OmahaResponse } from '../types/card';
 import { OmahaHiLoPage } from './OmahaHiLoPage';
@@ -1469,6 +1470,7 @@ describe('OmahaHiLoPage', () => {
         fireEvent.keyDown(document, { key: 'f' });
         fireEvent.keyDown(document, { key: 'a' });
       });
+      await flushPendingDispatch();
       expect(mockExec).not.toHaveBeenCalled();
     });
 
@@ -1482,6 +1484,7 @@ describe('OmahaHiLoPage', () => {
       await act(async () => {
         fireEvent.keyDown(document, { key: 'c' });
       });
+      await flushPendingDispatch();
       expect(mockExec).not.toHaveBeenCalled();
     });
 
@@ -1495,6 +1498,7 @@ describe('OmahaHiLoPage', () => {
       await act(async () => {
         fireEvent.keyDown(document, { key: 'k' });
       });
+      await flushPendingDispatch();
       expect(mockExec).not.toHaveBeenCalled();
     });
   });

--- a/frontend/src/pages/OmahaPage.test.tsx
+++ b/frontend/src/pages/OmahaPage.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, screen, waitFor, within } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { actionLogApi, omahaApi } from '../api/gameApi';
 import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { OmahaResponse } from '../types/card';
 import { OmahaPage } from './OmahaPage';
@@ -1391,6 +1392,7 @@ describe('OmahaPage', () => {
         fireEvent.keyDown(document, { key: 'f' });
         fireEvent.keyDown(document, { key: 'a' });
       });
+      await flushPendingDispatch();
       expect(mockExec).not.toHaveBeenCalled();
     });
 
@@ -1404,6 +1406,7 @@ describe('OmahaPage', () => {
       await act(async () => {
         fireEvent.keyDown(document, { key: 'c' });
       });
+      await flushPendingDispatch();
       expect(mockExec).not.toHaveBeenCalled();
     });
 
@@ -1417,6 +1420,7 @@ describe('OmahaPage', () => {
       await act(async () => {
         fireEvent.keyDown(document, { key: 'k' });
       });
+      await flushPendingDispatch();
       expect(mockExec).not.toHaveBeenCalled();
     });
   });

--- a/frontend/src/pages/OpenFaceChinesePage.test.tsx
+++ b/frontend/src/pages/OpenFaceChinesePage.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { openfacechineseApi } from '../api/gameApi';
 import { useCliMode } from '../hooks/useCliMode';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, OpenFaceChinesePlayer, OpenFaceChineseResponse } from '../types/card';
 import { isOfcRowFull, OpenFaceChinesePage } from './OpenFaceChinesePage';
@@ -247,6 +248,7 @@ describe('OpenFaceChinesePage', () => {
     expect(row).toBeDisabled();
     mockExec.mockClear();
     fireEvent.click(row);
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('place', expect.anything());
   });
 

--- a/frontend/src/pages/OsmosisPage.test.tsx
+++ b/frontend/src/pages/OsmosisPage.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { osmosisApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, CardDesign, OsmosisResponse } from '../types/card';
 import { OsmosisPage } from './OsmosisPage';
@@ -142,6 +143,7 @@ describe('OsmosisPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
     mockExec.mockClear();
     fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('giveup');
     expect(screen.getByText('投了確認')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: '確認' }));
@@ -213,6 +215,7 @@ describe('OsmosisPage', () => {
     mockExec.mockClear();
     fireEvent.keyDown(document.body, { key: 'g' });
     // The key must not dispatch giveup directly — it opens the confirm dialog first.
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('giveup');
     expect(screen.getByText('投了確認')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: '確認' }));
@@ -226,7 +229,9 @@ describe('OsmosisPage', () => {
     mockExec.mockClear();
     fireEvent.keyDown(document.body, { key: 'd' });
     fireEvent.keyDown(document.body, { key: 'h' });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('draw');
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('hint');
   });
 
@@ -316,6 +321,7 @@ describe('OsmosisPage', () => {
       mockExec.mockClear();
       // No dragStart ran, so the dataTransfer carries no source payload.
       fireEvent.drop(dropZone, { dataTransfer: buildDataTransfer() });
+      await flushPendingDispatch();
       expect(mockExec).not.toHaveBeenCalled();
     });
 

--- a/frontend/src/pages/PaiGowPage.test.tsx
+++ b/frontend/src/pages/PaiGowPage.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { actionLogApi, paigowApi } from '../api/gameApi';
 import { useGameHint } from '../hooks/useGameHint';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, CardDesign, PaiGowResponse } from '../types/card';
 import { cardAlt } from '../utils/cardAlt';
@@ -365,6 +366,7 @@ describe('PaiGowPage', () => {
 
     mockExec.mockClear();
     fireEvent.click(screen.getByRole('button', { name: 'ベット' }));
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('bet', 15);
   });
 
@@ -457,6 +459,7 @@ describe('PaiGowPage', () => {
     await waitFor(() => expect(screen.getByText(/勝利/)).toBeInTheDocument());
     mockExec.mockClear();
     fireEvent.keyDown(document, { key: 'b' });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 
@@ -466,6 +469,7 @@ describe('PaiGowPage', () => {
     await waitFor(() => expect(screen.getByText('チップ: 1000')).toBeInTheDocument());
     mockExec.mockClear();
     fireEvent.keyDown(document, { key: 'r' });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/pages/PenguinPage.test.tsx
+++ b/frontend/src/pages/PenguinPage.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { actionLogApi, penguinApi } from '../api/gameApi';
 import { useGameHint } from '../hooks/useGameHint';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, CardDesign, PenguinResponse } from '../types/card';
 import { PenguinPage } from './PenguinPage';
@@ -247,6 +248,7 @@ describe('PenguinPage', () => {
     mockExec.mockClear();
     mockExec.mockResolvedValue(gameOverState);
     fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('giveup');
     expect(screen.getByText('投了確認')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: '確認' }));
@@ -434,6 +436,7 @@ describe('PenguinPage', () => {
     mockExec.mockClear();
     mockExec.mockResolvedValue(gameOverState);
     fireEvent.keyDown(document, { key: 'g' });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('giveup');
     expect(screen.getByText('投了確認')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: '確認' }));
@@ -449,6 +452,7 @@ describe('PenguinPage', () => {
     fireEvent.keyDown(document, { key: 'a' });
     fireEvent.keyDown(document, { key: 'g' });
     fireEvent.keyDown(document, { key: 'z' });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/pages/PineapplePage.test.tsx
+++ b/frontend/src/pages/PineapplePage.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { crazyPineappleApi, irishPokerApi, pineappleApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { PineappleResponse } from '../types/card';
 import { PineapplePage } from './PineapplePage';
@@ -241,6 +242,7 @@ describe('PineapplePage', () => {
 
     // Pressing discard now opens an inline confirm step rather than committing immediately.
     fireEvent.click(discardBtn);
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('discard', undefined, { cardIdxs: [0] });
     expect(screen.getByTestId('discard-confirm')).toBeInTheDocument();
 
@@ -312,6 +314,7 @@ describe('PineapplePage', () => {
     // First Enter opens the confirm step without committing.
     fireEvent.keyDown(document.body, { key: 'Enter' });
     expect(screen.getByTestId('discard-confirm')).toBeInTheDocument();
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('discard', undefined, { cardIdxs: [0] });
     // Second Enter commits the discard.
     fireEvent.keyDown(document.body, { key: 'Enter' });
@@ -347,6 +350,7 @@ describe('PineapplePage', () => {
     // With nothing selected, Enter neither opens the confirm step nor commits.
     fireEvent.keyDown(document.body, { key: 'Enter' });
     expect(screen.queryByTestId('discard-confirm')).not.toBeInTheDocument();
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('discard', undefined, expect.anything());
   });
 
@@ -851,6 +855,7 @@ describe('PineapplePage', () => {
     // Back to selection; nothing discarded.
     expect(screen.queryByTestId('discard-confirm')).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: '1枚捨ててください。' })).toBeInTheDocument();
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('discard', undefined, { cardIdxs: [0] });
   });
 

--- a/frontend/src/pages/PinochlePage.test.tsx
+++ b/frontend/src/pages/PinochlePage.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { pinochleApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { PinochleResponse } from '../types/card';
 import { PinochlePage } from './PinochlePage';
@@ -169,6 +170,7 @@ describe('PinochlePage', () => {
 
     mockExec.mockClear();
     fireEvent.click(bidBtn);
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('bid', undefined, undefined, expect.anything());
   });
 

--- a/frontend/src/pages/PishtiPage.test.tsx
+++ b/frontend/src/pages/PishtiPage.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { pishtiApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, PishtiPlayer, PishtiResponse } from '../types/card';
 import { PishtiPage } from './PishtiPage';
@@ -195,6 +196,7 @@ describe('PishtiPage', () => {
     const cardBtn = await screen.findByTestId('hand-card-0');
     mockExec.mockClear();
     fireEvent.click(cardBtn);
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/pages/PokerPage.test.tsx
+++ b/frontend/src/pages/PokerPage.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, screen, waitFor, within } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { actionLogApi, pokerApi } from '../api/gameApi';
 import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { PokerResponse } from '../types/card';
 import { PokerPage } from './PokerPage';
@@ -1194,6 +1195,7 @@ describe('PokerPage', () => {
     fireEvent.click(screen.getByAltText('♥ 5'));
 
     // Before debounce fires, no odds call
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('odds', expect.anything());
 
     // After 300ms, one odds call with both indices
@@ -1399,6 +1401,7 @@ describe('PokerPage', () => {
         fireEvent.keyDown(document, { key: 'Enter' });
       });
 
+      await flushPendingDispatch();
       expect(mockExec).not.toHaveBeenCalled();
     });
 

--- a/frontend/src/pages/PokerSquaresPage.test.tsx
+++ b/frontend/src/pages/PokerSquaresPage.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { pokersquaresApi } from '../api/gameApi';
 import { useCliMode } from '../hooks/useCliMode';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, CardDesign, PokerSquaresResponse } from '../types/card';
 import { PokerSquaresPhase } from '../types/phases';
@@ -231,6 +232,7 @@ describe('PokerSquaresPage', () => {
     await waitFor(() => expect(screen.getByRole('button', { name: 'ギブアップ' })).toBeInTheDocument());
     mockApi.mockClear();
     fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
+    await flushPendingDispatch();
     expect(mockApi).not.toHaveBeenCalledWith('giveup');
     expect(screen.getByText('投了確認')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: '確認' }));

--- a/frontend/src/pages/PyramidPage.test.tsx
+++ b/frontend/src/pages/PyramidPage.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { actionLogApi, pyramidApi } from '../api/gameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { PYRAMID_STATS_KEY } from '../hooks/usePyramidStats';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, CardDesign, PyramidCard, PyramidResponse } from '../types/card';
 import { PyramidPage } from './PyramidPage';
@@ -210,6 +211,7 @@ describe('PyramidPage', () => {
     mockExec.mockClear();
     mockExec.mockResolvedValue(gameOverState);
     fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('giveup');
     expect(screen.getByText('投了確認')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: '確認' }));
@@ -552,6 +554,7 @@ describe('PyramidPage', () => {
     mockExec.mockClear();
     fireEvent.keyDown(document, { key: 'd' });
     fireEvent.keyDown(document, { key: 'h' });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/pages/RussianPokerPage.test.tsx
+++ b/frontend/src/pages/RussianPokerPage.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { russianpokerApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, RussianPokerResponse } from '../types/card';
 import { RussianPokerPhase } from '../types/phases';
@@ -124,6 +125,7 @@ describe('RussianPokerPage', () => {
     await screen.findByTestId('russian-exchange-fee-line');
     mockExec.mockClear();
     fireEvent.keyDown(document.body, { key: 'Enter' });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('exchange', undefined, expect.anything());
   });
 

--- a/frontend/src/pages/RussianSolitairePage.test.tsx
+++ b/frontend/src/pages/RussianSolitairePage.test.tsx
@@ -295,3 +295,24 @@ describe('RussianSolitairePage keyboard shortcuts', () => {
     expect(mockExec).not.toHaveBeenCalled();
   });
 });
+
+describe('RussianSolitairePage deselect routing (#4439)', () => {
+  // Clicking a selected card that is ALSO the last card in its column must
+  // deselect it. It used to be routed to handleSelectTarget instead, dispatching a
+  // move onto its own column, which the server rejects — so a player trying to
+  // deselect got a rejection message. Scorpion had this same bug and had a test
+  // for it, but the assertion ran before react-query's microtask could deliver the
+  // call, so it passed regardless. These two pages had no such test at all.
+  it('clicking the same selected card deselects it instead of moving onto itself', async () => {
+    mockExec.mockResolvedValue(playingState);
+    renderWithProviders(<RussianSolitairePage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    mockExec.mockClear();
+    const heart8 = screen.getByRole('button', { name: /♥ 8/ });
+    fireEvent.click(heart8);
+    await waitFor(() => expect(heart8.className).toMatch(/ring-/));
+    fireEvent.click(heart8);
+    await flushPendingDispatch();
+    expect(mockExec).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/pages/RussianSolitairePage.test.tsx
+++ b/frontend/src/pages/RussianSolitairePage.test.tsx
@@ -303,6 +303,26 @@ describe('RussianSolitairePage deselect routing (#4439)', () => {
   // deselect got a rejection message. Scorpion had this same bug and had a test
   // for it, but the assertion ran before react-query's microtask could deliver the
   // call, so it passed regardless. These two pages had no such test at all.
+  // The other branch of the same condition: a DIFFERENT column's last card, while
+  // something is selected, is a move target. Neither of these two pages had any
+  // test covering a move dispatch at all before this, so the fix above changed a
+  // line that nothing exercised.
+  it("clicking another column's last card while a card is selected dispatches the move", async () => {
+    mockExec.mockResolvedValue(playingState);
+    renderWithProviders(<RussianSolitairePage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    mockExec.mockClear();
+    fireEvent.click(screen.getByRole('button', { name: /\u2665 8/ }));
+    fireEvent.click(screen.getByRole('button', { name: /\u2663 5/ }));
+    await waitFor(() =>
+      expect(mockExec).toHaveBeenCalledWith(
+        'move',
+        { zone: 'tableau', col: 1, cardIndex: 1 },
+        { zone: 'tableau', col: 2 },
+      ),
+    );
+  });
+
   it('clicking the same selected card deselects it instead of moving onto itself', async () => {
     mockExec.mockResolvedValue(playingState);
     renderWithProviders(<RussianSolitairePage />);

--- a/frontend/src/pages/RussianSolitairePage.tsx
+++ b/frontend/src/pages/RussianSolitairePage.tsx
@@ -467,12 +467,14 @@ function RussianSolitairePageContent() {
                                         inHoverBlock && !isSelected ? 'ring-2 ring-ds-accent/70' : ''
                                       }`}
                                       onClick={() => {
-                                        if (selectedSource) {
-                                          if (isLast) {
-                                            handleSelectTarget('tableau', colIdx);
-                                          } else {
-                                            handleSelectSource('tableau', colIdx, cardIdx);
-                                          }
+                                        // Clicking the selected card again deselects it, which
+                                        // `handleSelectSource` implements by toggling. That has to be checked
+                                        // BEFORE the isLast branch: a selected card that is also last in its
+                                        // column would otherwise be treated as a move target and dispatch a move
+                                        // onto its own column, which the server rejects — so the player got a
+                                        // rejection message instead of a deselect. Found by #4439.
+                                        if (selectedSource && !isSelected && isLast) {
+                                          handleSelectTarget('tableau', colIdx);
                                         } else {
                                           handleSelectSource('tableau', colIdx, cardIdx);
                                         }

--- a/frontend/src/pages/ScorpionPage.test.tsx
+++ b/frontend/src/pages/ScorpionPage.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { scorpionApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, CardDesign, ScorpionResponse } from '../types/card';
 import { ScorpionPage } from './ScorpionPage';
@@ -225,6 +226,7 @@ describe('ScorpionPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
     mockExec.mockClear();
     fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('giveup');
     expect(screen.getByText('投了確認')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: '確認' }));
@@ -360,6 +362,7 @@ describe('ScorpionPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
     mockExec.mockClear();
     fireEvent.keyDown(document, { key: 'g' });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('giveup');
     expect(screen.getByText('投了確認')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: '確認' }));
@@ -403,6 +406,7 @@ describe('ScorpionPage', () => {
     fireEvent.keyDown(document, { key: 'g' });
     fireEvent.keyDown(document, { key: 'd' });
     // No additional API calls
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 
@@ -446,6 +450,7 @@ describe('ScorpionPage', () => {
     await waitFor(() => expect(heart8.className).toMatch(/ring-/));
     // Clicking again deselects (no API call)
     fireEvent.click(heart8);
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/pages/ScorpionPage.tsx
+++ b/frontend/src/pages/ScorpionPage.tsx
@@ -440,12 +440,15 @@ function ScorpionPageContent() {
                                     isLast && legalTargets.has(colIdx) ? 'ring-2 ring-ds-success' : ''
                                   }`}
                                   onClick={() => {
-                                    if (selectedSource) {
-                                      if (isLast) {
-                                        handleSelectTarget('tableau', colIdx);
-                                      } else {
-                                        handleSelectSource('tableau', colIdx, cardIdx);
-                                      }
+                                    // Clicking the selected card again deselects it, which
+                                    // `handleSelectSource` implements by toggling. That has to be
+                                    // checked BEFORE the isLast branch: a selected card that is
+                                    // also last in its column would otherwise be treated as a move
+                                    // target and dispatch a move onto its own column, which the
+                                    // server rejects — so the player got a rejection message
+                                    // instead of a deselect. Found by #4439.
+                                    if (selectedSource && !isSelected && isLast) {
+                                      handleSelectTarget('tableau', colIdx);
                                     } else {
                                       handleSelectSource('tableau', colIdx, cardIdx);
                                     }

--- a/frontend/src/pages/SevensPage.test.tsx
+++ b/frontend/src/pages/SevensPage.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { actionLogApi, sevensApi } from '../api/gameApi';
 import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { SevensResponse } from '../types/card';
 import { SevensPage } from './SevensPage';
@@ -267,6 +268,7 @@ describe('SevensPage', () => {
     await waitFor(() => expect(screen.getByAltText('♥ 5')).toBeInTheDocument());
     mockExec.mockClear();
     fireEvent.click(screen.getByAltText('♥ 5'));
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 
@@ -1640,6 +1642,7 @@ describe('SevensPage', () => {
       await act(async () => {
         fireEvent.keyDown(document, { key: '1' });
       });
+      await flushPendingDispatch();
       expect(mockExec).not.toHaveBeenCalled();
     });
 
@@ -1652,6 +1655,7 @@ describe('SevensPage', () => {
       await act(async () => {
         fireEvent.keyDown(document, { key: '1' });
       });
+      await flushPendingDispatch();
       expect(mockExec).not.toHaveBeenCalled();
     });
 
@@ -1664,6 +1668,7 @@ describe('SevensPage', () => {
       await act(async () => {
         fireEvent.keyDown(document, { key: '5' });
       });
+      await flushPendingDispatch();
       expect(mockExec).not.toHaveBeenCalled();
     });
   });

--- a/frontend/src/pages/SheepsheadPage.test.tsx
+++ b/frontend/src/pages/SheepsheadPage.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { sheepsheadApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import { makeSheepsheadState } from '../test/stateFactories';
 import { SheepsheadPage } from './SheepsheadPage';
@@ -107,6 +108,7 @@ describe('SheepsheadPage', () => {
     mockExec.mockClear();
     fireEvent.keyDown(document.body, { key: '1' });
     fireEvent.keyDown(document.body, { key: 'Enter' });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('play', expect.anything());
   });
 

--- a/frontend/src/pages/ShortDeckPage.test.tsx
+++ b/frontend/src/pages/ShortDeckPage.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, screen, waitFor, within } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { actionLogApi, shortdeckApi } from '../api/gameApi';
 import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { ShortDeckResponse } from '../types/card';
 import { ShortDeckPage } from './ShortDeckPage';
@@ -990,6 +991,7 @@ describe('ShortDeckPage', () => {
         fireEvent.keyDown(document, { key: 'f' });
         fireEvent.keyDown(document, { key: 'a' });
       });
+      await flushPendingDispatch();
       expect(mockExec).not.toHaveBeenCalled();
     });
   });

--- a/frontend/src/pages/Spanish21Page.test.tsx
+++ b/frontend/src/pages/Spanish21Page.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { spanish21Api } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { BlackJackResponse } from '../types/card';
 import { Spanish21Page } from './Spanish21Page';
@@ -93,6 +94,7 @@ describe('Spanish21Page', () => {
     mockExec.mockClear();
     fireEvent.click(screen.getByRole('button', { name: '次のゲーム' }));
     expect(screen.getByText('本当にゲームをリセットしますか？')).toBeInTheDocument();
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/pages/SpeedPage.test.tsx
+++ b/frontend/src/pages/SpeedPage.test.tsx
@@ -1,6 +1,7 @@
 import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { speedApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { SpeedResponse } from '../types/card';
 import { SpeedPage } from './SpeedPage';
@@ -301,6 +302,7 @@ describe('SpeedPage', () => {
     await waitFor(() => expect(screen.getByText('手札')).toBeInTheDocument());
     mockExec.mockClear();
     fireEvent.keyDown(window, { key: ' ' });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 
@@ -335,6 +337,7 @@ describe('SpeedPage', () => {
     mockExec.mockClear();
     fireEvent.keyDown(window, { key: 'ArrowLeft' });
     fireEvent.keyDown(window, { key: 'ArrowRight' });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 
@@ -343,6 +346,7 @@ describe('SpeedPage', () => {
     await waitFor(() => expect(screen.getByText('手札')).toBeInTheDocument());
     mockExec.mockClear();
     fireEvent.keyDown(window, { key: '5' });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 
@@ -353,6 +357,7 @@ describe('SpeedPage', () => {
     fireEvent.keyDown(window, { key: '1', ctrlKey: true });
     fireEvent.keyDown(window, { key: 'ArrowLeft', altKey: true });
     fireEvent.keyDown(window, { key: '2', metaKey: true });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/pages/SpiderPage.test.tsx
+++ b/frontend/src/pages/SpiderPage.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { actionLogApi, spiderApi } from '../api/gameApi';
 import { useGameHint } from '../hooks/useGameHint';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, CardDesign, SpiderResponse, SpiderTableauCard } from '../types/card';
 import { SpiderPage } from './SpiderPage';
@@ -261,6 +262,7 @@ describe('SpiderPage', () => {
     mockExec.mockResolvedValue(gameOverState);
     // Clicking give-up must NOT dispatch immediately — it opens a confirm dialog (#2099).
     fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('giveup');
     expect(screen.getByText('投了確認')).toBeInTheDocument();
 
@@ -342,6 +344,7 @@ describe('SpiderPage', () => {
     mockExec.mockResolvedValue({ ...playingState, difficulty: 2 });
     fireEvent.change(screen.getByLabelText('難易度'), { target: { value: '2' } });
     // Mid-game: no reset until the dialog is confirmed (#2188).
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
     fireEvent.click(screen.getByRole('button', { name: '確認' }));
 
@@ -355,6 +358,7 @@ describe('SpiderPage', () => {
     mockExec.mockClear();
     fireEvent.change(screen.getByLabelText('難易度'), { target: { value: '4' } });
     fireEvent.click(screen.getByRole('button', { name: 'キャンセル' }));
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 
@@ -492,6 +496,7 @@ describe('SpiderPage', () => {
     mockExec.mockClear();
     fireEvent.keyDown(document, { key: 'd' });
     fireEvent.keyDown(document, { key: 'h' });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/pages/StreetsAndAlleysPage.test.tsx
+++ b/frontend/src/pages/StreetsAndAlleysPage.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { streetsAndAlleysApi } from '../api/gameApi';
 import { useGameHint } from '../hooks/useGameHint';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, CardDesign, StreetsAndAlleysResponse, StreetsAndAlleysTableauCard } from '../types/card';
 import { StreetsAndAlleysPage } from './StreetsAndAlleysPage';
@@ -185,6 +186,7 @@ describe('StreetsAndAlleysPage', () => {
     mockExec.mockClear();
     mockExec.mockResolvedValue(gameOverState);
     fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('giveup');
     expect(screen.getByText('投了確認')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: '確認' }));

--- a/frontend/src/pages/ThirtyOnePage.test.tsx
+++ b/frontend/src/pages/ThirtyOnePage.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { thirtyoneApi } from '../api/gameApi';
 import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, ThirtyOneResponse } from '../types/card';
 import { ThirtyOnePhase } from '../types/phases';
@@ -281,6 +282,7 @@ describe('ThirtyOnePage', () => {
     renderWithProviders(<ThirtyOnePage />);
     // The key is inert until a card is selected (mirrors the disabled button).
     fireEvent.keyDown(document.body, { key: 'x' });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('discard', expect.anything());
     fireEvent.click(await screen.findByTestId('hand-card-0'));
     fireEvent.keyDown(document.body, { key: 'x' });

--- a/frontend/src/pages/ThreeCardPage.test.tsx
+++ b/frontend/src/pages/ThreeCardPage.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { actionLogApi, threecardApi } from '../api/gameApi';
 import { useGameHint } from '../hooks/useGameHint';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, CardDesign, ThreeCardResponse } from '../types/card';
 import { ThreeCardPage } from './ThreeCardPage';
@@ -392,6 +393,7 @@ describe('ThreeCardPage', () => {
     await waitFor(() => expect(screen.getByText(/勝利/)).toBeInTheDocument());
     mockExec.mockClear();
     fireEvent.keyDown(document, { key: 'b' });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 
@@ -401,6 +403,7 @@ describe('ThreeCardPage', () => {
     await waitFor(() => expect(screen.getByText('チップ: 1000')).toBeInTheDocument());
     mockExec.mockClear();
     fireEvent.keyDown(document, { key: 'r' });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 
@@ -566,6 +569,7 @@ describe('ThreeCardPage', () => {
     await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument());
     mockExec.mockClear();
     fireEvent.keyDown(document, { key: 'n' });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/TonkPage.test.tsx
+++ b/frontend/src/pages/TonkPage.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { tonkApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, TonkResponse } from '../types/card';
 import { TonkPhase } from '../types/phases';
@@ -191,6 +192,7 @@ describe('TonkPage', () => {
     expect(pile.className).not.toContain('ring-ds-info');
     mockExec.mockClear();
     fireEvent.click(pile);
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('drawdiscard');
   });
 

--- a/frontend/src/pages/TrashPage.test.tsx
+++ b/frontend/src/pages/TrashPage.test.tsx
@@ -1,6 +1,7 @@
 import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { trashApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, CardDesign, TrashResponse, TrashSlot } from '../types/card';
 import { TrashPage } from './TrashPage';
@@ -164,6 +165,7 @@ describe('TrashPage', () => {
     fireEvent.click(slot);
     // Only the mount-time reset call is expected.
     expect(mockExec).toHaveBeenCalledTimes(1);
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('place', expect.anything());
   });
 

--- a/frontend/src/pages/TrucoPage.test.tsx
+++ b/frontend/src/pages/TrucoPage.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { trucoApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, TrucoResponse } from '../types/card';
 import { TrucoPage } from './TrucoPage';
@@ -92,8 +93,11 @@ describe('TrucoPage', () => {
     fireEvent.keyDown(document, { key: '1' });
     fireEvent.keyDown(document, { key: 'a' });
     fireEvent.keyDown(document, { key: 't' });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('play', 0);
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('accept');
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('truco');
   });
 

--- a/frontend/src/pages/WaspPage.test.tsx
+++ b/frontend/src/pages/WaspPage.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { waspApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, CardDesign, WaspResponse } from '../types/card';
 import { cardAlt } from '../utils/cardAlt';
@@ -247,6 +248,7 @@ describe('WaspPage', () => {
     mockExec.mockClear();
     // Clicking give-up must NOT dispatch immediately — it opens a confirm dialog (#2099).
     fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('giveup');
     expect(screen.getByText('投了確認')).toBeInTheDocument();
 
@@ -306,6 +308,7 @@ describe('WaspPage', () => {
     mockExec.mockClear();
     fireEvent.click(lastCardBtn); // select
     fireEvent.click(lastCardBtn); // re-click → deselect, no API call
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 
@@ -398,6 +401,7 @@ describe('WaspPage', () => {
 
     mockExec.mockClear();
     fireEvent.keyDown(document, { key: 'g' });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('giveup');
     expect(screen.getByText('投了確認')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: '確認' }));
@@ -441,6 +445,7 @@ describe('WaspPage', () => {
     fireEvent.keyDown(document, { key: 'g' });
     fireEvent.keyDown(document, { key: 'd' });
     // No additional API calls
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 
@@ -484,6 +489,7 @@ describe('WaspPage', () => {
     await waitFor(() => expect(heart8.className).toMatch(/ring-/));
     // Clicking again deselects (no API call)
     fireEvent.click(heart8);
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/pages/YukonPage.test.tsx
+++ b/frontend/src/pages/YukonPage.test.tsx
@@ -340,6 +340,26 @@ describe('YukonPage deselect routing (#4439)', () => {
   // deselect got a rejection message. Scorpion had this same bug and had a test
   // for it, but the assertion ran before react-query's microtask could deliver the
   // call, so it passed regardless. These two pages had no such test at all.
+  // The other branch of the same condition: a DIFFERENT column's last card, while
+  // something is selected, is a move target. Neither of these two pages had any
+  // test covering a move dispatch at all before this, so the fix above changed a
+  // line that nothing exercised.
+  it("clicking another column's last card while a card is selected dispatches the move", async () => {
+    mockExec.mockResolvedValue(playingState);
+    renderWithProviders(<YukonPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    mockExec.mockClear();
+    fireEvent.click(screen.getByRole('button', { name: /\u2665 8/ }));
+    fireEvent.click(screen.getByRole('button', { name: /\u2663 5/ }));
+    await waitFor(() =>
+      expect(mockExec).toHaveBeenCalledWith(
+        'move',
+        { zone: 'tableau', col: 1, cardIndex: 1 },
+        { zone: 'tableau', col: 2 },
+      ),
+    );
+  });
+
   it('clicking the same selected card deselects it instead of moving onto itself', async () => {
     mockExec.mockResolvedValue(playingState);
     renderWithProviders(<YukonPage />);

--- a/frontend/src/pages/YukonPage.test.tsx
+++ b/frontend/src/pages/YukonPage.test.tsx
@@ -332,3 +332,24 @@ describe('YukonPage keyboard shortcuts', () => {
     expect(mockExec).not.toHaveBeenCalled();
   });
 });
+
+describe('YukonPage deselect routing (#4439)', () => {
+  // Clicking a selected card that is ALSO the last card in its column must
+  // deselect it. It used to be routed to handleSelectTarget instead, dispatching a
+  // move onto its own column, which the server rejects — so a player trying to
+  // deselect got a rejection message. Scorpion had this same bug and had a test
+  // for it, but the assertion ran before react-query's microtask could deliver the
+  // call, so it passed regardless. These two pages had no such test at all.
+  it('clicking the same selected card deselects it instead of moving onto itself', async () => {
+    mockExec.mockResolvedValue(playingState);
+    renderWithProviders(<YukonPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    mockExec.mockClear();
+    const heart8 = screen.getByRole('button', { name: /♥ 8/ });
+    fireEvent.click(heart8);
+    await waitFor(() => expect(heart8.className).toMatch(/ring-/));
+    fireEvent.click(heart8);
+    await flushPendingDispatch();
+    expect(mockExec).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/pages/YukonPage.tsx
+++ b/frontend/src/pages/YukonPage.tsx
@@ -454,12 +454,14 @@ function YukonPageContent() {
                                         inHoverBlock && !isSelected ? 'ring-2 ring-ds-accent/70' : ''
                                       } ${inSelectedBlock && !isSelected ? 'ring-2 ring-ds-info' : ''}`}
                                       onClick={() => {
-                                        if (selectedSource) {
-                                          if (isLast) {
-                                            handleSelectTarget('tableau', colIdx);
-                                          } else {
-                                            handleSelectSource('tableau', colIdx, cardIdx);
-                                          }
+                                        // Clicking the selected card again deselects it, which
+                                        // `handleSelectSource` implements by toggling. That has to be checked
+                                        // BEFORE the isLast branch: a selected card that is also last in its
+                                        // column would otherwise be treated as a move target and dispatch a move
+                                        // onto its own column, which the server rejects — so the player got a
+                                        // rejection message instead of a deselect. Found by #4439.
+                                        if (selectedSource && !isSelected && isLast) {
+                                          handleSelectTarget('tableau', colIdx);
                                         } else {
                                           handleSelectSource('tableau', colIdx, cardIdx);
                                         }

--- a/frontend/src/test/flushPendingDispatch.ts
+++ b/frontend/src/test/flushPendingDispatch.ts
@@ -1,3 +1,5 @@
+import { vi } from 'vitest';
+
 /**
  * Waits until a command triggered by `fireEvent` has actually reached the mocked
  * game API, so that a "nothing was dispatched" assertion means something.
@@ -24,10 +26,19 @@
  * that actions chaining more than one `await` (a rebet that advances the round and
  * then re-stakes it, say) are also fully settled.
  *
+ * Under fake timers a plain `setTimeout` would never fire, so awaiting one would
+ * hang until the test timed out rather than flush anything — that is not
+ * hypothetical, it stalled all 24 of `PokerPage.test.tsx`'s fake-timer tests for
+ * 10s each. So the timer is advanced explicitly when they are installed.
+ *
  * Positive assertions do not need this — `waitFor` already retries.
  */
-export function flushPendingDispatch(): Promise<void> {
-  return new Promise((resolve) => {
+export async function flushPendingDispatch(): Promise<void> {
+  if (vi.isFakeTimers()) {
+    await vi.advanceTimersByTimeAsync(0);
+    return;
+  }
+  await new Promise((resolve) => {
     setTimeout(resolve, 0);
   });
 }


### PR DESCRIPTION
Closes #4439.

`expect(<apiMock>).not.toHaveBeenCalled()` placed directly after `fireEvent` passes **whether or not the action fired** — `exec` from `useGameApi` dispatches through react-query's `mutateAsync`, which invokes the mutation function on a microtask, so at that instant there is nothing to see. 148 such assertions across 59 files were asserting nothing. Each now awaits `flushPendingDispatch()` first.

## The bug they were hiding

**Clicking a selected card that is also the last card in its column dispatched a `move` onto its own column instead of deselecting it.**

```jsx
if (selectedSource) {
  if (isLast) {
    handleSelectTarget('tableau', colIdx);   // ← source === target
  } else {
    handleSelectSource('tableau', colIdx, cardIdx);
  }
}
```

`handleSelectSource` implements deselection by toggling, but the `isLast` branch was checked first, so for a selected last card the click became a move with source and target being the same column. The server rejects that, so a player trying to deselect got a rejection message instead.

Affects **Scorpion, Yukon and Russian Solitaire** — the three Yukon-family pages that route per-card on `isLast`. I checked the other 29 pages using `handleSelectTarget`: they attach the target to the column element rather than per-card and never had this shape. Whether they have an analogous problem in a *different* shape is a separate behavioural question I did not try to answer here.

Fixed by checking `isSelected` first:

```jsx
if (selectedSource && !isSelected && isLast) {
  handleSelectTarget('tableau', colIdx);
} else {
  handleSelectSource('tableau', colIdx, cardIdx);
}
```

### Scorpion already had a test for this

`clicking the same selected card deselects it (same-cell click path)` — it existed, described the correct behaviour, and passed anyway, because its assertion ran before the microtask could deliver the call. That is the whole thesis of #4439 demonstrated on a real case.

Yukon and Russian Solitaire had no such test. Both now have one, written **RED-first** — each failed with `expected "vi.fn()" to not be called at all, but actually been called 1 times` before the fix and passes after.

## A bug in my own helper, too

`flushPendingDispatch()` awaited a `setTimeout`, which **never fires under `vi.useFakeTimers()`**. So every fake-timer test using it hung until its 10s timeout: the first full run came back with 24 failures in `PokerPage.test.tsx` (which fakes timers to test odds debouncing), all of them timeouts rather than assertion failures. It now advances the timer explicitly when fake timers are installed. `PokerPage.test.tsx`: 118/118.

Worth noting the failure mode was loud rather than silent — but only because the flush was on the *await* path. A helper that silently no-op'd would have quietly restored the original vacuity.

## Not touched

The 28 assertions of the same textual shape in 16 component test files are deliberately left alone: they assert on plain prop callbacks (`onClick` mocks), which are invoked synchronously and need no flush. A blanket sweep on the text pattern would have churned those for nothing.

## Verification

- `bun run test` — **16,009 passed** (up 2 from the new tests)
- `bun run typecheck`, `bun run check` (all 7 guards) clean
- Production changes limited to the 3 page files plus the test helper; the other 62 files are test-only
- The two new tests were confirmed to fail before the fix, and Scorpion's pre-existing test now fails against the old routing
