### PR TITLE
fix(frontend): clip the shell column so a descendant cannot grow the document

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -174,7 +174,9 @@ area, never by growing the document. This has regressed repeatedly (#1861, #1367
 | Play area | `flex-1 overflow-y-auto` **and `min-h-0`** — this is the only region allowed to absorb overflow |
 | `GameFooter` (actions) | `shrink-0`, capped at `max-h-[45vh]` with internal scroll below `sm` |
 
-Two classes are load-bearing and must not be "cleaned up":
+Three classes are load-bearing and must not be "cleaned up". All three are enforced
+by the `shell-height` guard in `scripts/check-design-tokens.mjs`, because each one
+looks like redundant cruft to a reader:
 
 - **`min-h-0` on the flex column in `App.tsx`.** A flex item's automatic minimum
   size is its content height, so without this the column refuses to shrink to the
@@ -185,10 +187,17 @@ Two classes are load-bearing and must not be "cleaned up":
   takes whatever its controls want and the play area is what gives way. Measured,
   the tallest footer was 558px (84% of the viewport) and 26 pages were left under
   80px of play area. The cap is lifted at `sm` and up.
+- **`overflow-hidden` on `GamePageShell`'s column.** Its children each scroll
+  themselves, so nothing should overflow it — but stray scrollable overflow from a
+  descendant still propagated to the viewport and grew the document. That kept six
+  pages scrolling even though their children measurably fitted (606px of children
+  in a 605px box), so clipping here is correct rather than a workaround.
 
 When adding a game page, verify at 375×667 that `document.documentElement.scrollHeight`
 equals the viewport height. Note that page height depends on the deal — measure
-several, not one.
+several, not one. `e2e/mobile-viewport.spec.ts` asserts this in a real browser for a
+spread of pages, which is the only way to catch a page adding tall `shrink-0`
+content outside its play area.
 - **Border radius:**
   | Token | Value | Usage |
   |-------|-------|-------|

--- a/frontend/e2e/mobile-viewport.spec.ts
+++ b/frontend/e2e/mobile-viewport.spec.ts
@@ -44,6 +44,17 @@ const PATHS = [
   '/piquet',
   '/kalooki',
   '/carioca',
+  // These six were the last holdouts (#4373 phase 4). Their children measurably
+  // fitted — 606px in a 605px box — yet the document still grew, because stray
+  // scrollable overflow from a descendant propagated past the shell column. They
+  // are guarded because that is invisible to any static check and was only found
+  // by bisecting the DOM in a real browser.
+  '/memory',
+  '/openfacechinese',
+  '/jass',
+  '/clocksolitaire',
+  '/gaigel',
+  '/spiteandmalice',
 ];
 
 for (const path of PATHS) {

--- a/frontend/e2e/mobile-viewport.spec.ts
+++ b/frontend/e2e/mobile-viewport.spec.ts
@@ -57,6 +57,39 @@ const PATHS = [
   '/spiteandmalice',
 ];
 
+// The shell column clips its overflow (#4373 phase 4), which is safe for the win
+// celebration only because that overlay is `position: fixed` and the column does not
+// establish a containing block for fixed descendants. Adding `transform`, `filter`,
+// `perspective`, `contain` or `will-change` to the column would silently start
+// clipping the celebration to the play area — a regression no unit test can see, so
+// it is asserted here on the real rendered page.
+test('the clipped shell column does not become a containing block for fixed overlays', async ({ page }) => {
+  await navigateTo(page, '/hearts');
+  const result = await page.evaluate(() => {
+    const shell = document.querySelector('main > div');
+    if (!shell) return null;
+    const cs = getComputedStyle(shell);
+    const probe = document.createElement('div');
+    probe.style.cssText = 'position:fixed;inset:0;pointer-events:none';
+    shell.appendChild(probe);
+    const probeH = Math.round(probe.getBoundingClientRect().height);
+    probe.remove();
+    return {
+      overflowY: cs.overflowY,
+      containing: [cs.transform, cs.filter, cs.perspective, cs.contain, cs.willChange].filter(
+        (v) => v && v !== 'none' && v !== 'auto' && v !== 'normal',
+      ),
+      probeH,
+      viewportH: window.innerHeight,
+    };
+  });
+  expect(result).not.toBeNull();
+  expect(result?.overflowY).toBe('hidden');
+  expect(result?.containing, 'the shell column must not establish a containing block for fixed children').toEqual([]);
+  // A fixed child therefore still spans the viewport rather than being clipped to the column.
+  expect(result?.probeH).toBe(result?.viewportH);
+});
+
 for (const path of PATHS) {
   test(`${path} does not scroll the document at 375x667`, async ({ page }) => {
     await navigateTo(page, path);

--- a/frontend/scripts/check-design-tokens.mjs
+++ b/frontend/scripts/check-design-tokens.mjs
@@ -392,6 +392,24 @@ if (appColumn === undefined) {
   );
 }
 
+// The shell column must clip: its children each scroll themselves, so any overflow
+// reaching it would otherwise propagate to the viewport and grow the document.
+const shellText = await readFile(join(SRC_DIR, 'components/GamePageShell.tsx'), 'utf8');
+const shellColumn = [...shellText.matchAll(/className=\{`([^`]*)`\}/g)]
+  .map((m) => m[1])
+  .find((cls) => /\bflex-1\b/.test(cls) && /\bflex-col\b/.test(cls) && /\brelative\b/.test(cls));
+if (shellColumn === undefined) {
+  shellViolations.push('src/components/GamePageShell.tsx: could not find the shell column — did its markup change?');
+} else {
+  for (const need of ['min-h-0', 'overflow-hidden']) {
+    if (!new RegExp(`\\b${need.replace('-', '-')}\\b`).test(shellColumn)) {
+      shellViolations.push(
+        `src/components/GamePageShell.tsx: the shell column lost ${need} (found "${shellColumn}") — a descendant's overflow will grow the document on mobile`,
+      );
+    }
+  }
+}
+
 const footerText = await readFile(join(SRC_DIR, 'components/GameFooter.tsx'), 'utf8');
 for (const need of ['max-h-[45vh]', 'overflow-y-auto', 'sm:max-h-none', 'sm:overflow-y-visible']) {
   if (!footerText.includes(need)) {
@@ -408,4 +426,6 @@ if (shellViolations.length > 0) {
   process.exit(1);
 }
 
-console.log('shell-height: OK (App.tsx column keeps min-h-0; GameFooter keeps its 45vh mobile cap).');
+console.log(
+  'shell-height: OK (App.tsx + GamePageShell columns keep min-h-0, the shell clips, GameFooter keeps its 45vh mobile cap).',
+);

--- a/frontend/scripts/check-design-tokens.mjs
+++ b/frontend/scripts/check-design-tokens.mjs
@@ -402,7 +402,7 @@ if (shellColumn === undefined) {
   shellViolations.push('src/components/GamePageShell.tsx: could not find the shell column — did its markup change?');
 } else {
   for (const need of ['min-h-0', 'overflow-hidden']) {
-    if (!new RegExp(`\\b${need.replace('-', '-')}\\b`).test(shellColumn)) {
+    if (!shellColumn.split(/\s+/).includes(need)) {
       shellViolations.push(
         `src/components/GamePageShell.tsx: the shell column lost ${need} (found "${shellColumn}") — a descendant's overflow will grow the document on mobile`,
       );

--- a/frontend/src/components/GamePageShell.test.tsx
+++ b/frontend/src/components/GamePageShell.test.tsx
@@ -316,6 +316,24 @@ describe('GamePageShell', () => {
     expect(outer.className).toContain('relative');
   });
 
+  // This column's children each scroll themselves (the play area and the footer
+  // both carry `overflow-y-auto`), so nothing should overflow it — but stray
+  // scrollable overflow from a descendant still propagated to the viewport and grew
+  // the document, which is what kept 6 game pages scrolling at 375x667 while their
+  // children measurably fit. Clipping here is what stops that. See issue #4373.
+  it('clips its own overflow so a descendant cannot grow the document', () => {
+    const { container } = render(
+      <GamePageShell {...baseProps}>
+        <div data-testid="anchor" />
+      </GamePageShell>,
+    );
+    const outer = container.firstElementChild as HTMLElement;
+    expect(outer.className).toContain('overflow-hidden');
+    // min-h-0 is the other half of the contract: without it this column refuses to
+    // shrink to the viewport in the first place.
+    expect(outer.className).toContain('min-h-0');
+  });
+
   describe('central sound taps', () => {
     beforeEach(() => {
       playCalls.length = 0;

--- a/frontend/src/components/GamePageShell.tsx
+++ b/frontend/src/components/GamePageShell.tsx
@@ -168,7 +168,20 @@ export function GamePageShell({
   }, [isHumanTurn]);
 
   return (
-    <div key={outerKey} className={`relative flex-1 flex flex-col min-h-0 ${gameThemeBg}`} aria-busy={loading}>
+    // `overflow-hidden` is load-bearing. This is a full-height flex column whose
+    // children each manage their own scrolling (the play area and the footer both
+    // carry `overflow-y-auto`), so nothing should ever overflow this box — but
+    // stray scrollable overflow from a descendant still propagated to the
+    // viewport and grew the document. That is what kept 6 pages scrolling at
+    // 375x667 (`memory` +257, `openfacechinese` +216, `jass` +209) even though
+    // their children measurably fit: 606px of children in a 605px box. Clipping
+    // here is correct rather than a workaround, and it does not affect the
+    // celebration or dialogs, which are `fixed`. See issue #4373.
+    <div
+      key={outerKey}
+      className={`relative flex-1 flex flex-col min-h-0 overflow-hidden ${gameThemeBg}`}
+      aria-busy={loading}
+    >
       <GamePageHeading title={title} />
       <PhaseIndicator phaseName={phaseName} isHumanTurn={isHumanTurn}>
         {headerExtra}


### PR DESCRIPTION
Phase 4 of #4373, after #4441 (phases 1–2) and #4442 (phase 3). **All 219 game pages now fit a 375×667 phone**, up from 40 when this started.

| | pages that do not scroll the document |
|---|---|
| before any fix | 40 / 219 |
| after #4441 (shell `min-h-0` + 45vh footer cap) | 210 |
| after #4442 (five pages had no play area) | 213 |
| **after this** | **219 / 219** |

Zero footers clipped. Zero pages harmed.

## What the last six had wrong — one shared cause, not six

`memory` +257, `openfacechinese` +216, `jass` +209, `clocksolitaire` +149, `gaigel` +39, `spiteandmalice` +12.

I could not diagnose these when I filed the phase-4 note, so this time I bisected in the browser instead of reasoning about CSS: hide each child of the shell column in turn and see whose removal drops the document overflow to zero. That pointed at the play area on all six — but `min-height: 0` and `flex-basis: 0` on it changed nothing, while **`overflow: hidden` on the shell column fixed all six**.

The reason the earlier analysis went in circles: **the children measurably fit.** On `gaigel` they sum to 606px in a 605px box, and every one of them is accounted for. What grew the document was *scrollable overflow* from a descendant propagating up past the shell column to the viewport — which is invisible if you only measure element boxes, and is why the element-rect sweep in my phase-4 note found "nothing escaping a clipping ancestor".

So the fix is one class on `GamePageShell`'s column:

```diff
-<div className={`relative flex-1 flex flex-col min-h-0 ${gameThemeBg}`}>
+<div className={`relative flex-1 flex flex-col min-h-0 overflow-hidden ${gameThemeBg}`}>
```

This is correct rather than a workaround: that column's children each scroll themselves (the play area and the footer both carry `overflow-y-auto`), so nothing is *supposed* to overflow it, and clipping is what stops a stray descendant from growing the page.

## The overlays are unaffected — checked, not assumed

`overflow: hidden` clips absolutely-positioned descendants, so the celebration and dialogs were the risk. All are `position: fixed` with no transformed ancestor, so they are not clipped. Verified in the browser at 375×667 rather than by reading the CSS:

- reset confirm dialog — `fixed`, spans 0→667, both buttons on screen (screenshotted)
- tutorial overlay — `fixed`, covers the full viewport
- 127 existing E2E specs exercise dialog/reset flows and pass

## Guards extended

- The `shell-height` guard now also requires `min-h-0` **and** `overflow-hidden` on the shell column. Negative-controlled: stripping `overflow-hidden` gives `exit 1` with the message naming that class.
- `GamePageShell.test.tsx` pins both classes.
- `e2e/mobile-viewport.spec.ts` grows to **19 paths** (38 assertions), now including all six of these — the only check that can catch this class of regression, since it is invisible to static analysis.
- DESIGN.md's "Mobile vertical budget" section now documents all three load-bearing classes and why each looks like removable cruft.

## Verification

- All 219 pages re-verified at 375×667: `docOver` 0 everywhere, no footer clipped, play areas usable (min 72px, median ~250px)
- `bun run test` — 16,012 passed
- `bunx playwright test e2e/mobile-viewport.spec.ts` — 38 passed
- `bun run typecheck`, `bun run check` (all 7 guards) clean
- Production diff is one class

`paigow` and `chinesepoker` still report a 72px play area, which is not a defect: their content is exactly 72px, nothing overflows, and they deliberately do not fill the viewport (`!isBetPhase && 'flex-1'`).

Separately filed #4444 for an intermittent unhandled rejection in `useGameApi` (`setLoading` after unmount). It is **not** from this change — it appeared in one run of three and not on the `develop` baseline — but it fails the suite while reporting every test as passed, so it wants its own fix.

Closes #4373
