### PR TITLE
fix(frontend): guard the remaining 25 hooks against writing state after unmount

### DIFF
--- a/frontend/scripts/check-design-tokens.mjs
+++ b/frontend/scripts/check-design-tokens.mjs
@@ -448,9 +448,7 @@ for (const file of hookFiles) {
   const text = stripComments(await readFile(join(SRC_DIR, 'hooks', file), 'utf8'));
   if (/\b(useIsMounted|mountedRef)\b/.test(text)) continue;
   // Setters this file owns.
-  const owned = new Set(
-    [...text.matchAll(/const \[[^,\]]+,\s*(set[A-Z]\w*)\]\s*=\s*useState/g)].map((m) => m[1]),
-  );
+  const owned = new Set([...text.matchAll(/const \[[^,\]]+,\s*(set[A-Z]\w*)\]\s*=\s*useState/g)].map((m) => m[1]));
   if (owned.size === 0) continue;
   const lines = text.split('\n');
   for (let i = 0; i < lines.length; i += 1) {

--- a/frontend/scripts/check-design-tokens.mjs
+++ b/frontend/scripts/check-design-tokens.mjs
@@ -429,3 +429,50 @@ if (shellViolations.length > 0) {
 console.log(
   'shell-height: OK (App.tsx + GamePageShell columns keep min-h-0, the shell clips, GameFooter keeps its 45vh mobile cap).',
 );
+
+// --- Unmount-safe state writes in hooks (issue #4447) -----------------------
+//
+// A hook that awaits and then writes its own state can have that write land after
+// the component is gone. React makes it a silent no-op, so nothing complains until
+// the surrounding environment is torn down, where React reaches for `window` and
+// throws from `dispatchSetState` — which failed whole CI runs while reporting every
+// test as passed (#4444). The fix is `useIsMounted()` and a check after the await.
+//
+// Scoped deliberately: only flags a `set<X>` that this file declares via `useState`,
+// so passing someone else's setter or calling an unrelated `set*` method is ignored.
+const unmountViolations = [];
+const hookFiles = (await readdir(join(SRC_DIR, 'hooks'))).filter(
+  (f) => (f.endsWith('.ts') || f.endsWith('.tsx')) && !f.includes('.test.'),
+);
+for (const file of hookFiles) {
+  const text = stripComments(await readFile(join(SRC_DIR, 'hooks', file), 'utf8'));
+  if (/\b(useIsMounted|mountedRef)\b/.test(text)) continue;
+  // Setters this file owns.
+  const owned = new Set(
+    [...text.matchAll(/const \[[^,\]]+,\s*(set[A-Z]\w*)\]\s*=\s*useState/g)].map((m) => m[1]),
+  );
+  if (owned.size === 0) continue;
+  const lines = text.split('\n');
+  for (let i = 0; i < lines.length; i += 1) {
+    if (!/\bawait\b/.test(lines[i])) continue;
+    for (let j = i + 1; j < Math.min(lines.length, i + 12); j += 1) {
+      const m = /\b(set[A-Z]\w*)\(/.exec(lines[j]);
+      if (!m) continue;
+      if (owned.has(m[1])) {
+        unmountViolations.push({ file: `src/hooks/${file}`, line: j + 1, setter: m[1], awaitLine: i + 1 });
+      }
+      break;
+    }
+  }
+}
+
+if (unmountViolations.length > 0) {
+  console.error('\nUnmount-safety violations (state written after an await, with no useIsMounted guard):\n');
+  for (const v of unmountViolations) {
+    console.error(`  ${v.file}:${v.line}  ${v.setter}() runs after the await on line ${v.awaitLine}`);
+  }
+  console.error('\nUse useIsMounted() and `if (!isMounted()) return;` after the await. See issue #4447.');
+  process.exit(1);
+}
+
+console.log(`unmount-safety: OK (${hookFiles.length} hooks; no state written after an await without a guard).`);

--- a/frontend/scripts/check-design-tokens.mjs
+++ b/frontend/scripts/check-design-tokens.mjs
@@ -438,28 +438,64 @@ console.log(
 // throws from `dispatchSetState` — which failed whole CI runs while reporting every
 // test as passed (#4444). The fix is `useIsMounted()` and a check after the await.
 //
-// Scoped deliberately: only flags a `set<X>` that this file declares via `useState`,
-// so passing someone else's setter or calling an unrelated `set*` method is ignored.
+// Checked PER SITE, not per file. The first version of this guard skipped any file
+// that mentioned `useIsMounted` anywhere, which let `useAcesUpGame` pass with an
+// unguarded catch branch — a guard that grants a file blanket absolution is worse
+// than none, because it reads as coverage it does not provide.
 const unmountViolations = [];
-const hookFiles = (await readdir(join(SRC_DIR, 'hooks'))).filter(
+const hookDir = join(SRC_DIR, 'hooks');
+const hookFiles = (await readdir(hookDir)).filter(
   (f) => (f.endsWith('.ts') || f.endsWith('.tsx')) && !f.includes('.test.'),
 );
+const GUARD_RE = /\bisMounted\(\)|\bmountedRef\.current\b/;
 for (const file of hookFiles) {
-  const text = stripComments(await readFile(join(SRC_DIR, 'hooks', file), 'utf8'));
-  if (/\b(useIsMounted|mountedRef)\b/.test(text)) continue;
-  // Setters this file owns.
-  const owned = new Set([...text.matchAll(/const \[[^,\]]+,\s*(set[A-Z]\w*)\]\s*=\s*useState/g)].map((m) => m[1]));
-  if (owned.size === 0) continue;
+  const text = stripComments(await readFile(join(hookDir, file), 'utf8'));
   const lines = text.split('\n');
-  for (let i = 0; i < lines.length; i += 1) {
-    if (!/\bawait\b/.test(lines[i])) continue;
-    for (let j = i + 1; j < Math.min(lines.length, i + 12); j += 1) {
-      const m = /\b(set[A-Z]\w*)\(/.exec(lines[j]);
-      if (!m) continue;
-      if (owned.has(m[1])) {
-        unmountViolations.push({ file: `src/hooks/${file}`, line: j + 1, setter: m[1], awaitLine: i + 1 });
+  // Setters this file owns; passing someone else's setter is not this file's problem.
+  const owned = new Set([...text.matchAll(/const \[[^,\]]+,\s*(set[A-Z]\w*)\]\s*=\s*useState/g)].map((m) => m[1]));
+  if (owned.size > 0) {
+    for (let i = 0; i < lines.length; i += 1) {
+      if (!/\bawait\b/.test(lines[i])) continue;
+      // Every write in the window, not just the first: stopping at the first one is
+      // how useAcesUpGame's unguarded `catch` hid behind the guarded `try` above it.
+      for (let j = i + 1; j < Math.min(lines.length, i + 14); j += 1) {
+        // Stop at the end of the enclosing callback — otherwise the window spills
+        // into the next function and flags its synchronous writes, which is how an
+        // early version of this guard "found" setHint(null) in useAcesUpGame's
+        // handleUndo. A guard that cries wolf gets switched off.
+        if (/^\s{0,4}\}(,\s*\[|\)|;|$)/.test(lines[j])) break;
+        const m = /\b(set[A-Z]\w*)\(/.exec(lines[j]);
+        if (!m) continue;
+        // The guard must be in the same branch as the write. A check inside `try`
+        // does nothing for a `catch`/`finally` body, which is exactly how
+        // useAcesUpGame's catch slipped past the first version of this guard: so
+        // only look from the nearest intervening `} catch {` / `} finally {`.
+        let from = i;
+        for (let k = i + 1; k <= j; k += 1) {
+          if (/\}\s*(catch|finally)\b/.test(lines[k])) from = k;
+        }
+        const between = lines.slice(from, j + 1).join('\n');
+        if (owned.has(m[1]) && !GUARD_RE.test(between)) {
+          unmountViolations.push({
+            file: `src/hooks/${file}`,
+            line: j + 1,
+            detail: `${m[1]}() runs after the await on line ${i + 1} with no isMounted guard between them`,
+          });
+        }
       }
-      break;
+    }
+  }
+  // runReplay sleeps between steps, so it routinely outlives the page. Its callers
+  // must pass `isMounted` or it cannot stop — and the writes it drives are theirs.
+  for (const m of text.matchAll(/runReplay\(/g)) {
+    const call = text.slice(m.index, m.index + 400);
+    const body = call.slice(0, call.indexOf('});') + 1);
+    if (!/\bisMounted\b/.test(body)) {
+      unmountViolations.push({
+        file: `src/hooks/${file}`,
+        line: text.slice(0, m.index).split('\n').length,
+        detail: 'runReplay() without `isMounted` — the replay keeps driving state after the page is gone',
+      });
     }
   }
 }
@@ -467,10 +503,10 @@ for (const file of hookFiles) {
 if (unmountViolations.length > 0) {
   console.error('\nUnmount-safety violations (state written after an await, with no useIsMounted guard):\n');
   for (const v of unmountViolations) {
-    console.error(`  ${v.file}:${v.line}  ${v.setter}() runs after the await on line ${v.awaitLine}`);
+    console.error(`  ${v.file}:${v.line}  ${v.detail}`);
   }
   console.error('\nUse useIsMounted() and `if (!isMounted()) return;` after the await. See issue #4447.');
   process.exit(1);
 }
 
-console.log(`unmount-safety: OK (${hookFiles.length} hooks; no state written after an await without a guard).`);
+console.log(`unmount-safety: OK (${hookFiles.length} hooks; every await -> own-state write is guarded).`);

--- a/frontend/src/hooks/gameReplay.test.ts
+++ b/frontend/src/hooks/gameReplay.test.ts
@@ -182,6 +182,25 @@ describe('runReplay', () => {
     expect(setDisplayState).not.toHaveBeenCalledWith('final');
   });
 
+  // The other bail-out: the human-action state renders first, then the replay sleeps
+  // before the CPU steps. Losing the page during THAT sleep must stop it too (#4447).
+  it('abandons the replay if the page is lost during the human-action delay', async () => {
+    const setDisplayState = vi.fn();
+    let mounted = true;
+    const config: ReplayConfig<string> = {
+      buildHumanActionState: () => 'human',
+      buildReplayStates: () => ['a', 'b'],
+      isMounted: () => mounted,
+    };
+    const promise = runReplay('final', setDisplayState, config);
+    mounted = false;
+    await flushDelays();
+    await promise;
+    expect(setDisplayState).toHaveBeenCalledWith('human');
+    expect(setDisplayState).not.toHaveBeenCalledWith('a');
+    expect(setDisplayState).not.toHaveBeenCalledWith('final');
+  });
+
   it('runs every step when the component stays mounted', async () => {
     const setDisplayState = vi.fn();
     const config: ReplayConfig<string> = {

--- a/frontend/src/hooks/gameReplay.test.ts
+++ b/frontend/src/hooks/gameReplay.test.ts
@@ -163,6 +163,95 @@ describe('runReplay', () => {
     expect(getActionDelay).toHaveBeenCalledWith('final', 0);
     expect(getActionDelay).toHaveBeenCalledWith('final', 1);
   });
+  // A replay sleeps between steps, so it routinely outlives a page the player left.
+  // It must stop rather than keep driving state into a gone component (#4447).
+  it('abandons the remaining steps once the component has unmounted', async () => {
+    const setDisplayState = vi.fn();
+    let mounted = true;
+    const config: ReplayConfig<string> = {
+      buildReplayStates: () => ['a', 'b', 'c'],
+      isMounted: () => mounted,
+    };
+    const promise = runReplay('final', setDisplayState, config);
+    // First step renders, then the player navigates away mid-sleep.
+    mounted = false;
+    await flushDelays();
+    await promise;
+    expect(setDisplayState).toHaveBeenCalledWith('a');
+    expect(setDisplayState).not.toHaveBeenCalledWith('c');
+    expect(setDisplayState).not.toHaveBeenCalledWith('final');
+  });
+
+  it('runs every step when the component stays mounted', async () => {
+    const setDisplayState = vi.fn();
+    const config: ReplayConfig<string> = {
+      buildReplayStates: () => ['a', 'b'],
+      isMounted: () => true,
+    };
+    const promise = runReplay('final', setDisplayState, config);
+    await flushDelays();
+    await promise;
+    expect(setDisplayState).toHaveBeenCalledWith('a');
+    expect(setDisplayState).toHaveBeenCalledWith('b');
+    expect(setDisplayState).toHaveBeenLastCalledWith('final');
+  });
+});
+
+describe('shouldSkipReplay', () => {
+  it('returns false and updates ref on first call (ref is undefined)', () => {
+    const ref = { current: undefined as unknown[] | undefined };
+    const setDisplayState = vi.fn();
+    const actions = [{ id: 1 }];
+
+    const skipped = shouldSkipReplay(actions, ref, 'state', setDisplayState);
+
+    expect(skipped).toBe(false);
+    expect(ref.current).toEqual(actions);
+    expect(setDisplayState).not.toHaveBeenCalled();
+  });
+
+  it('returns true and calls setDisplayState when actions unchanged', () => {
+    const actions = [{ id: 1 }];
+    const ref = { current: [{ id: 1 }] as unknown[] | undefined };
+    const setDisplayState = vi.fn();
+
+    const skipped = shouldSkipReplay(actions, ref, 'state', setDisplayState);
+
+    expect(skipped).toBe(true);
+    expect(setDisplayState).toHaveBeenCalledWith('state');
+  });
+
+  it('returns false and updates ref when actions change', () => {
+    const ref = { current: [{ id: 1 }] as unknown[] | undefined };
+    const setDisplayState = vi.fn();
+    const newActions = [{ id: 2 }];
+
+    const skipped = shouldSkipReplay(newActions, ref, 'state', setDisplayState);
+
+    expect(skipped).toBe(false);
+    expect(ref.current).toEqual(newActions);
+    expect(setDisplayState).not.toHaveBeenCalled();
+  });
+
+  it('returns false on first call with empty actions (ref undefined vs [])', () => {
+    const ref = { current: undefined as unknown[] | undefined };
+    const setDisplayState = vi.fn();
+
+    const skipped = shouldSkipReplay([], ref, 'state', setDisplayState);
+
+    expect(skipped).toBe(false);
+    expect(ref.current).toEqual([]);
+  });
+
+  it('returns true when both current and new are empty arrays', () => {
+    const ref = { current: [] as unknown[] | undefined };
+    const setDisplayState = vi.fn();
+
+    const skipped = shouldSkipReplay([], ref, 'state', setDisplayState);
+
+    expect(skipped).toBe(true);
+    expect(setDisplayState).toHaveBeenCalledWith('state');
+  });
 });
 
 describe('shouldSkipReplay', () => {

--- a/frontend/src/hooks/gameReplay.ts
+++ b/frontend/src/hooks/gameReplay.ts
@@ -20,6 +20,14 @@ export interface ReplayConfig<TState> {
   buildReplayStates: (finalState: TState) => TState[];
   buildHumanActionState?: (finalState: TState) => TState | null;
   getActionDelay?: (finalState: TState, actionIndex: number) => number;
+  /**
+   * Whether the calling component is still mounted. A replay sleeps between steps,
+   * so it routinely outlives the page a player navigates away from; without this it
+   * keeps calling `setDisplayState` on a gone component, and such a write can throw
+   * once the environment is torn down. Supplying it also stops the remaining timers
+   * rather than merely suppressing their writes. See issue #4447.
+   */
+  isMounted?: () => boolean;
 }
 
 /**
@@ -50,6 +58,7 @@ export async function runReplay<TState>(
   if (humanState) {
     setDisplayState(humanState);
     await delay(scaledDelay(REPLAY_DELAY_MS));
+    if (config.isMounted?.() === false) return;
   }
 
   const replayStates = config.buildReplayStates(finalState);
@@ -62,6 +71,7 @@ export async function runReplay<TState>(
     setDisplayState(replayStates[i]);
     const actionDelay = config.getActionDelay?.(finalState, i) ?? REPLAY_DELAY_MS;
     await delay(scaledDelay(actionDelay));
+    if (config.isMounted?.() === false) return;
   }
 
   setDisplayState(finalState);

--- a/frontend/src/hooks/useAcesUpGame.ts
+++ b/frontend/src/hooks/useAcesUpGame.ts
@@ -3,6 +3,7 @@ import { acesupApi } from '../api/gameApi';
 import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
 import type { AcesUpCard, AcesUpHint, AcesUpResponse } from '../types/card';
 import { useGameApi } from './useGameApi';
+import { useIsMounted } from './useIsMounted';
 
 /** Upper bound on batch-removal iterations (one per non-ace card) to guard against loops. */
 const MAX_REMOVE_ALL_STEPS = 52;
@@ -44,15 +45,19 @@ export function useAcesUpGame() {
     exec('giveup');
   }, [exec]);
 
+  const isMounted = useIsMounted();
+
   const handleHint = useCallback(async () => {
     try {
       const res = await acesupApi.exec('hint');
+      // Navigating away mid-request must not write to a gone component (#4447).
+      if (!isMounted()) return;
       setHint(res.hint ?? null);
       setHintError(null);
     } catch {
       setHintError(NETWORK_ERROR_MESSAGE());
     }
-  }, []);
+  }, [isMounted]);
 
   const handleUndo = useCallback(() => {
     setHint(null);
@@ -106,6 +111,8 @@ export function useAcesUpGame() {
         col = firstRemovableCol(columns);
         if (col < 0) break;
         const res = await acesupApi.exec('remove', col);
+        // Abandon the remove-all loop if the player left mid-sequence (#4447).
+        if (!isMounted()) return;
         setState(res);
         columns = res.columns;
       }
@@ -115,9 +122,9 @@ export function useAcesUpGame() {
       if (col >= 0) await exec('remove', col);
     } finally {
       removingAllRef.current = false;
-      setIsRemovingAll(false);
+      if (isMounted()) setIsRemovingAll(false);
     }
-  }, [exec, setState]);
+  }, [exec, setState, isMounted]);
 
   return {
     state,

--- a/frontend/src/hooks/useAcesUpGame.ts
+++ b/frontend/src/hooks/useAcesUpGame.ts
@@ -55,6 +55,7 @@ export function useAcesUpGame() {
       setHint(res.hint ?? null);
       setHintError(null);
     } catch {
+      if (!isMounted()) return;
       setHintError(NETWORK_ERROR_MESSAGE());
     }
   }, [isMounted]);

--- a/frontend/src/hooks/useActionLog.test.ts
+++ b/frontend/src/hooks/useActionLog.test.ts
@@ -49,4 +49,28 @@ describe('useActionLog', () => {
     });
     expect(result.current.actionLog).toBeNull();
   });
+
+  // The log fetch can land after the player closes the page; writing state then is a
+  // no-op until the environment is torn down, where it throws (#4447).
+  it('does not store entries that arrive after unmount', async () => {
+    let resolveLog: ((value: { entries: [] }) => void) | undefined;
+    vi.mocked(actionLogApi.blackjack).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveLog = resolve;
+        }) as ReturnType<typeof actionLogApi.blackjack>,
+    );
+    const { result, unmount } = renderHook(() => useActionLog('blackjack'));
+    act(() => {
+      void result.current.showActionLog();
+    });
+    unmount();
+    resolveLog?.({ entries: [] });
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+    // Nothing to assert on the unmounted hook's state directly; the contract is that
+    // resolving late does not throw and leaves the last rendered value untouched.
+    expect(result.current.actionLog).toBeNull();
+  });
 });

--- a/frontend/src/hooks/useActionLog.ts
+++ b/frontend/src/hooks/useActionLog.ts
@@ -1,15 +1,19 @@
 import { useCallback, useState } from 'react';
 import { actionLogApi } from '../api/gameApi';
 import type { ActionLogEntry } from '../types/card';
+import { useIsMounted } from './useIsMounted';
 
 /** Hook that provides action log fetching and display state for a game. */
 export function useActionLog(game: keyof typeof actionLogApi) {
   const [actionLog, setActionLog] = useState<ActionLogEntry[] | null>(null);
+  const isMounted = useIsMounted();
 
   const showActionLog = useCallback(async () => {
     const res = await actionLogApi[game]();
+    // Closing the page mid-fetch must not write to it (#4447).
+    if (!isMounted()) return;
     setActionLog(res.entries);
-  }, [game]);
+  }, [game, isMounted]);
 
   const hideActionLog = useCallback(() => {
     setActionLog(null);

--- a/frontend/src/hooks/useBakersDozenGame.ts
+++ b/frontend/src/hooks/useBakersDozenGame.ts
@@ -1,10 +1,9 @@
 import { useCallback, useEffect, useState } from 'react';
 import { type BakersDozenMoveZone, bakersDozenApi } from '../api/gameApi';
-import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
 import type { BakersDozenHint } from '../types/card';
 import { useAutoCompleteState } from './useAutoCompleteState';
 import { useGameApi } from './useGameApi';
-import { useIsMounted } from './useIsMounted';
+import { useHintRequest } from './useHintRequest';
 
 /** Hook that manages Baker's Dozen game state, source selection, hints, and moves. */
 export function useBakersDozenGame() {
@@ -32,20 +31,12 @@ export function useBakersDozenGame() {
     exec('giveup');
   }, [exec]);
 
-  const isMounted = useIsMounted();
-
-  const handleHint = useCallback(async () => {
-    try {
-      const res = await bakersDozenApi.exec('hint');
-      // Navigating away mid-request must not write to a gone component (#4447).
-      if (!isMounted()) return;
-      setHint(res.hint ?? null);
-      setHintError(null);
-    } catch {
-      if (!isMounted()) return;
-      setHintError(NETWORK_ERROR_MESSAGE());
-    }
-  }, [isMounted]);
+  const handleHint = useHintRequest({
+    fetchHint: () => bakersDozenApi.exec('hint'),
+    selectHint: (res) => res.hint,
+    setHint,
+    setHintError,
+  });
 
   const handleAutoComplete = useCallback(() => {
     setSelectedSource(null);

--- a/frontend/src/hooks/useBakersDozenGame.ts
+++ b/frontend/src/hooks/useBakersDozenGame.ts
@@ -4,6 +4,7 @@ import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
 import type { BakersDozenHint } from '../types/card';
 import { useAutoCompleteState } from './useAutoCompleteState';
 import { useGameApi } from './useGameApi';
+import { useIsMounted } from './useIsMounted';
 
 /** Hook that manages Baker's Dozen game state, source selection, hints, and moves. */
 export function useBakersDozenGame() {
@@ -31,15 +32,20 @@ export function useBakersDozenGame() {
     exec('giveup');
   }, [exec]);
 
+  const isMounted = useIsMounted();
+
   const handleHint = useCallback(async () => {
     try {
       const res = await bakersDozenApi.exec('hint');
+      // Navigating away mid-request must not write to a gone component (#4447).
+      if (!isMounted()) return;
       setHint(res.hint ?? null);
       setHintError(null);
     } catch {
+      if (!isMounted()) return;
       setHintError(NETWORK_ERROR_MESSAGE());
     }
-  }, []);
+  }, [isMounted]);
 
   const handleAutoComplete = useCallback(() => {
     setSelectedSource(null);

--- a/frontend/src/hooks/useBeleagueredCastleGame.ts
+++ b/frontend/src/hooks/useBeleagueredCastleGame.ts
@@ -1,10 +1,9 @@
 import { useCallback, useEffect, useState } from 'react';
 import { type BeleagueredCastleMoveZone, beleagueredCastleApi } from '../api/gameApi';
-import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
 import type { BeleagueredCastleHint } from '../types/card';
 import { useAutoCompleteState } from './useAutoCompleteState';
 import { useGameApi } from './useGameApi';
-import { useIsMounted } from './useIsMounted';
+import { useHintRequest } from './useHintRequest';
 
 /** Hook that manages Beleaguered Castle game state, source selection, hints, and moves. */
 export function useBeleagueredCastleGame() {
@@ -32,20 +31,12 @@ export function useBeleagueredCastleGame() {
     runApi('giveup');
   }, [runApi]);
 
-  const isMounted = useIsMounted();
-
-  const handleHint = useCallback(async () => {
-    try {
-      const res = await beleagueredCastleApi.exec('hint');
-      // Navigating away mid-request must not write to a gone component (#4447).
-      if (!isMounted()) return;
-      setHint(res.hint ?? null);
-      setHintError(null);
-    } catch {
-      if (!isMounted()) return;
-      setHintError(NETWORK_ERROR_MESSAGE());
-    }
-  }, [isMounted]);
+  const handleHint = useHintRequest({
+    fetchHint: () => beleagueredCastleApi.exec('hint'),
+    selectHint: (res) => res.hint,
+    setHint,
+    setHintError,
+  });
 
   const handleAutoComplete = useCallback(() => {
     setSelectedSource(null);

--- a/frontend/src/hooks/useBeleagueredCastleGame.ts
+++ b/frontend/src/hooks/useBeleagueredCastleGame.ts
@@ -4,6 +4,7 @@ import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
 import type { BeleagueredCastleHint } from '../types/card';
 import { useAutoCompleteState } from './useAutoCompleteState';
 import { useGameApi } from './useGameApi';
+import { useIsMounted } from './useIsMounted';
 
 /** Hook that manages Beleaguered Castle game state, source selection, hints, and moves. */
 export function useBeleagueredCastleGame() {
@@ -31,15 +32,20 @@ export function useBeleagueredCastleGame() {
     runApi('giveup');
   }, [runApi]);
 
+  const isMounted = useIsMounted();
+
   const handleHint = useCallback(async () => {
     try {
       const res = await beleagueredCastleApi.exec('hint');
+      // Navigating away mid-request must not write to a gone component (#4447).
+      if (!isMounted()) return;
       setHint(res.hint ?? null);
       setHintError(null);
     } catch {
+      if (!isMounted()) return;
       setHintError(NETWORK_ERROR_MESSAGE());
     }
-  }, []);
+  }, [isMounted]);
 
   const handleAutoComplete = useCallback(() => {
     setSelectedSource(null);

--- a/frontend/src/hooks/useBigTwoGame.ts
+++ b/frontend/src/hooks/useBigTwoGame.ts
@@ -5,6 +5,7 @@ import { buildHumanActionState, buildReplayStates } from '../utils/replayBuilder
 import { runReplay, shouldSkipReplay } from './gameReplay';
 import { useCardSelection } from './useCardSelection';
 import { useGameApi } from './useGameApi';
+import { useIsMounted } from './useIsMounted';
 
 const defaultConfigInput: BigTwoConfigInput = {
   cpuDifficulty: 1,
@@ -83,6 +84,8 @@ function buildBigTwoReplayStates(finalState: BigTwoResponse): BigTwoResponse[] {
 
 /** Hook that manages Big Two game state, card selection, and CPU replay. */
 export function useBigTwoGame() {
+  const isMounted = useIsMounted();
+
   const { selected: selectedIndices, toggle: toggleCardSelection, clear: clearSelection } = useCardSelection();
   const [configInput, setConfigInput] = useState<BigTwoConfigInput>(defaultConfigInput);
   const [displayState, setDisplayState] = useState<BigTwoResponse | null>(null);
@@ -96,11 +99,12 @@ export function useBigTwoGame() {
         return;
       }
       await runReplay(res, setDisplayState, {
+        isMounted,
         buildReplayStates: buildBigTwoReplayStates,
         buildHumanActionState: buildBigTwoHumanActionState,
       });
     },
-    [clearSelection],
+    [clearSelection, isMounted],
   );
 
   const { loading, error, exec: callApi, retry } = useGameApi(bigtwoApi.exec, { onSuccess });

--- a/frontend/src/hooks/useBridgeGame.ts
+++ b/frontend/src/hooks/useBridgeGame.ts
@@ -1,11 +1,10 @@
 import { useCallback, useEffect, useState } from 'react';
 import { bridgeApi } from '../api/gameApi';
-import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
 import type { BridgeConfig, BridgeHint } from '../types/card';
 import { useCardSelection } from './useCardSelection';
 import { useGameApi } from './useGameApi';
 import { useGameConfig } from './useGameConfig';
-import { useIsMounted } from './useIsMounted';
+import { useHintRequest } from './useHintRequest';
 
 /** Default Bridge game configuration. */
 export const DEFAULT_BRIDGE_CONFIG: BridgeConfig = {
@@ -59,23 +58,13 @@ export function useBridgeGame() {
     apiExec('nextround');
   }, [apiExec]);
 
-  const isMounted = useIsMounted();
-
-  const handleHint = useCallback(async () => {
-    setHintLoading(true);
-    try {
-      const res = await bridgeApi.exec('hint');
-      // Navigating away mid-request must not write to a gone component (#4447).
-      if (!isMounted()) return;
-      setHint(res.hint ?? null);
-      setHintError(null);
-    } catch {
-      if (!isMounted()) return;
-      setHintError(NETWORK_ERROR_MESSAGE());
-    } finally {
-      if (isMounted()) setHintLoading(false);
-    }
-  }, [isMounted]);
+  const handleHint = useHintRequest({
+    fetchHint: () => bridgeApi.exec('hint'),
+    selectHint: (res) => res.hint,
+    setHint,
+    setHintError,
+    setHintLoading,
+  });
 
   return {
     state,

--- a/frontend/src/hooks/useBridgeGame.ts
+++ b/frontend/src/hooks/useBridgeGame.ts
@@ -5,6 +5,7 @@ import type { BridgeConfig, BridgeHint } from '../types/card';
 import { useCardSelection } from './useCardSelection';
 import { useGameApi } from './useGameApi';
 import { useGameConfig } from './useGameConfig';
+import { useIsMounted } from './useIsMounted';
 
 /** Default Bridge game configuration. */
 export const DEFAULT_BRIDGE_CONFIG: BridgeConfig = {
@@ -58,18 +59,23 @@ export function useBridgeGame() {
     apiExec('nextround');
   }, [apiExec]);
 
+  const isMounted = useIsMounted();
+
   const handleHint = useCallback(async () => {
     setHintLoading(true);
     try {
       const res = await bridgeApi.exec('hint');
+      // Navigating away mid-request must not write to a gone component (#4447).
+      if (!isMounted()) return;
       setHint(res.hint ?? null);
       setHintError(null);
     } catch {
+      if (!isMounted()) return;
       setHintError(NETWORK_ERROR_MESSAGE());
     } finally {
-      setHintLoading(false);
+      if (isMounted()) setHintLoading(false);
     }
-  }, []);
+  }, [isMounted]);
 
   return {
     state,

--- a/frontend/src/hooks/useCrescentGame.ts
+++ b/frontend/src/hooks/useCrescentGame.ts
@@ -4,6 +4,7 @@ import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
 import type { CrescentHint } from '../types/card';
 import { useAutoCompleteState } from './useAutoCompleteState';
 import { useGameApi } from './useGameApi';
+import { useIsMounted } from './useIsMounted';
 
 /** Hook that manages Crescent Solitaire state, source selection, hints, and moves. */
 export function useCrescentGame() {
@@ -37,15 +38,20 @@ export function useCrescentGame() {
     exec('giveup');
   }, [exec]);
 
+  const isMounted = useIsMounted();
+
   const handleHint = useCallback(async () => {
     try {
       const res = await crescentApi.exec('hint');
+      // Navigating away mid-request must not write to a gone component (#4447).
+      if (!isMounted()) return;
       setHint(res.hint ?? null);
       setHintError(null);
     } catch {
+      if (!isMounted()) return;
       setHintError(NETWORK_ERROR_MESSAGE());
     }
-  }, []);
+  }, [isMounted]);
 
   const handleAutoComplete = useCallback(() => {
     setSelectedSource(null);

--- a/frontend/src/hooks/useCrescentGame.ts
+++ b/frontend/src/hooks/useCrescentGame.ts
@@ -1,10 +1,9 @@
 import { useCallback, useEffect, useState } from 'react';
 import { type CrescentMoveZone, crescentApi } from '../api/gameApi';
-import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
 import type { CrescentHint } from '../types/card';
 import { useAutoCompleteState } from './useAutoCompleteState';
 import { useGameApi } from './useGameApi';
-import { useIsMounted } from './useIsMounted';
+import { useHintRequest } from './useHintRequest';
 
 /** Hook that manages Crescent Solitaire state, source selection, hints, and moves. */
 export function useCrescentGame() {
@@ -38,20 +37,12 @@ export function useCrescentGame() {
     exec('giveup');
   }, [exec]);
 
-  const isMounted = useIsMounted();
-
-  const handleHint = useCallback(async () => {
-    try {
-      const res = await crescentApi.exec('hint');
-      // Navigating away mid-request must not write to a gone component (#4447).
-      if (!isMounted()) return;
-      setHint(res.hint ?? null);
-      setHintError(null);
-    } catch {
-      if (!isMounted()) return;
-      setHintError(NETWORK_ERROR_MESSAGE());
-    }
-  }, [isMounted]);
+  const handleHint = useHintRequest({
+    fetchHint: () => crescentApi.exec('hint'),
+    selectHint: (res) => res.hint,
+    setHint,
+    setHintError,
+  });
 
   const handleAutoComplete = useCallback(() => {
     setSelectedSource(null);

--- a/frontend/src/hooks/useDaifugoGame.ts
+++ b/frontend/src/hooks/useDaifugoGame.ts
@@ -5,6 +5,7 @@ import { buildHumanActionState, buildReplayStates } from '../utils/replayBuilder
 import { runReplay, shouldSkipReplay } from './gameReplay';
 import { useCardSelection } from './useCardSelection';
 import { useGameApi } from './useGameApi';
+import { useIsMounted } from './useIsMounted';
 
 const defaultConfigInput: DaifugoConfigInput = {
   jokerCount: 2,
@@ -112,6 +113,8 @@ export function useDaifugoGame() {
     clear: clearSelection,
     setSelected: setSelectedIndices,
   } = useCardSelection();
+  const isMounted = useIsMounted();
+
   const [configInput, setConfigInput] = useState<DaifugoConfigInput>(defaultConfigInput);
   const [displayState, setDisplayState] = useState<DaifugoResponse | null>(null);
 
@@ -124,11 +127,12 @@ export function useDaifugoGame() {
         return;
       }
       await runReplay(res, setDisplayState, {
+        isMounted,
         buildReplayStates: buildDaifugoReplayStates,
         buildHumanActionState: buildDaifugoHumanActionState,
       });
     },
-    [clearSelection],
+    [clearSelection, isMounted],
   );
 
   const { loading, error, exec, retry } = useGameApi(daifugoApi.exec, { onSuccess });

--- a/frontend/src/hooks/useDoppelkopfGame.ts
+++ b/frontend/src/hooks/useDoppelkopfGame.ts
@@ -3,6 +3,7 @@ import { type DoppelkopfConfigInput, doppelkopfApi } from '../api/gameApi';
 import { useCardSelection } from './useCardSelection';
 import { useGameApi } from './useGameApi';
 import { useGameConfig } from './useGameConfig';
+import { useIsMounted } from './useIsMounted';
 
 /** Default Doppelkopf game configuration. */
 export const DEFAULT_DOPPELKOPF_CONFIG: Required<DoppelkopfConfigInput> = {
@@ -42,15 +43,18 @@ export function useDoppelkopfGame() {
 
   const [hintLoading, setHintLoading] = useState(false);
 
+  const isMounted = useIsMounted();
+
   /** Requests a play hint from the server; guards against double-clicks. */
   const handleHint = useCallback(async () => {
     setHintLoading(true);
     try {
       await exec('hint');
     } finally {
-      setHintLoading(false);
+      // The hint request outliving the page must not write to it (#4447).
+      if (isMounted()) setHintLoading(false);
     }
-  }, [exec]);
+  }, [exec, isMounted]);
 
   /** Resets the game, applying the current config. */
   const reset = useCallback(() => {

--- a/frontend/src/hooks/useEightOffGame.ts
+++ b/frontend/src/hooks/useEightOffGame.ts
@@ -1,6 +1,7 @@
 import { useCallback, useState } from 'react';
 import { type EightOffMoveZone, eightoffApi } from '../api/gameApi';
 import type { EightOffHint } from '../types/card';
+import { useIsMounted } from './useIsMounted';
 import { useSolitaireGameBase } from './useSolitaireGameBase';
 
 /** Hook that manages Eight Off game state, source selection, hints, and moves. */
@@ -30,12 +31,16 @@ export function useEightOffGame() {
   // hint value — a null hint after a request is indistinguishable from the
   // initial null without this signal.
   const [hintNonce, setHintNonce] = useState(0);
+  const isMounted = useIsMounted();
+
   // Depend on the stable baseHandleHint reference, not the base result object
   // (which is re-created whenever state/loading change), so this callback stays stable.
   const handleHint = useCallback(async () => {
     await baseHandleHint();
+    // The base guards its own writes; this nonce is ours (#4447).
+    if (!isMounted()) return;
     setHintNonce((n) => n + 1);
-  }, [baseHandleHint]);
+  }, [baseHandleHint, isMounted]);
 
   const handleSelectSource = useCallback((zone: EightOffMoveZone) => {
     setSelectedSource((prev) => {

--- a/frontend/src/hooks/useEuchreGame.ts
+++ b/frontend/src/hooks/useEuchreGame.ts
@@ -5,6 +5,7 @@ import type { EuchreConfig, EuchreHint } from '../types/card';
 import { useCardSelection } from './useCardSelection';
 import { useGameApi } from './useGameApi';
 import { useGameConfig } from './useGameConfig';
+import { useIsMounted } from './useIsMounted';
 
 /** Default Euchre game configuration. */
 export const DEFAULT_EUCHRE_CONFIG: EuchreConfig = {
@@ -78,18 +79,23 @@ export function useEuchreGame() {
     apiExec('nextround');
   }, [apiExec]);
 
+  const isMounted = useIsMounted();
+
   const handleHint = useCallback(async () => {
     setHintLoading(true);
     try {
       const res = await euchreApi.exec('hint');
+      // Navigating away mid-request must not write to a gone component (#4447).
+      if (!isMounted()) return;
       setHint(res.hint ?? null);
       setHintError(null);
     } catch {
+      if (!isMounted()) return;
       setHintError(NETWORK_ERROR_MESSAGE());
     } finally {
-      setHintLoading(false);
+      if (isMounted()) setHintLoading(false);
     }
-  }, []);
+  }, [isMounted]);
 
   return {
     state,

--- a/frontend/src/hooks/useEuchreGame.ts
+++ b/frontend/src/hooks/useEuchreGame.ts
@@ -1,11 +1,10 @@
 import { useCallback, useEffect, useState } from 'react';
 import { euchreApi } from '../api/gameApi';
-import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
 import type { EuchreConfig, EuchreHint } from '../types/card';
 import { useCardSelection } from './useCardSelection';
 import { useGameApi } from './useGameApi';
 import { useGameConfig } from './useGameConfig';
-import { useIsMounted } from './useIsMounted';
+import { useHintRequest } from './useHintRequest';
 
 /** Default Euchre game configuration. */
 export const DEFAULT_EUCHRE_CONFIG: EuchreConfig = {
@@ -79,23 +78,13 @@ export function useEuchreGame() {
     apiExec('nextround');
   }, [apiExec]);
 
-  const isMounted = useIsMounted();
-
-  const handleHint = useCallback(async () => {
-    setHintLoading(true);
-    try {
-      const res = await euchreApi.exec('hint');
-      // Navigating away mid-request must not write to a gone component (#4447).
-      if (!isMounted()) return;
-      setHint(res.hint ?? null);
-      setHintError(null);
-    } catch {
-      if (!isMounted()) return;
-      setHintError(NETWORK_ERROR_MESSAGE());
-    } finally {
-      if (isMounted()) setHintLoading(false);
-    }
-  }, [isMounted]);
+  const handleHint = useHintRequest({
+    fetchHint: () => euchreApi.exec('hint'),
+    selectHint: (res) => res.hint,
+    setHint,
+    setHintError,
+    setHintLoading,
+  });
 
   return {
     state,

--- a/frontend/src/hooks/useFlowerGardenGame.ts
+++ b/frontend/src/hooks/useFlowerGardenGame.ts
@@ -4,6 +4,7 @@ import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
 import type { FlowerGardenHint } from '../types/card';
 import { useAutoCompleteState } from './useAutoCompleteState';
 import { useGameApi } from './useGameApi';
+import { useIsMounted } from './useIsMounted';
 
 /** Hook that manages Flower Garden game state, source selection, hints, and moves. */
 export function useFlowerGardenGame() {
@@ -31,15 +32,20 @@ export function useFlowerGardenGame() {
     runApi('giveup');
   }, [runApi]);
 
+  const isMounted = useIsMounted();
+
   const handleHint = useCallback(async () => {
     try {
       const res = await flowerGardenApi.exec('hint');
+      // Navigating away mid-request must not write to a gone component (#4447).
+      if (!isMounted()) return;
       setHint(res.hint ?? null);
       setHintError(null);
     } catch {
+      if (!isMounted()) return;
       setHintError(NETWORK_ERROR_MESSAGE());
     }
-  }, []);
+  }, [isMounted]);
 
   const handleAutoComplete = useCallback(() => {
     setSelectedSource(null);

--- a/frontend/src/hooks/useFlowerGardenGame.ts
+++ b/frontend/src/hooks/useFlowerGardenGame.ts
@@ -1,10 +1,9 @@
 import { useCallback, useEffect, useState } from 'react';
 import { type FlowerGardenMoveZone, flowerGardenApi } from '../api/gameApi';
-import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
 import type { FlowerGardenHint } from '../types/card';
 import { useAutoCompleteState } from './useAutoCompleteState';
 import { useGameApi } from './useGameApi';
-import { useIsMounted } from './useIsMounted';
+import { useHintRequest } from './useHintRequest';
 
 /** Hook that manages Flower Garden game state, source selection, hints, and moves. */
 export function useFlowerGardenGame() {
@@ -32,20 +31,12 @@ export function useFlowerGardenGame() {
     runApi('giveup');
   }, [runApi]);
 
-  const isMounted = useIsMounted();
-
-  const handleHint = useCallback(async () => {
-    try {
-      const res = await flowerGardenApi.exec('hint');
-      // Navigating away mid-request must not write to a gone component (#4447).
-      if (!isMounted()) return;
-      setHint(res.hint ?? null);
-      setHintError(null);
-    } catch {
-      if (!isMounted()) return;
-      setHintError(NETWORK_ERROR_MESSAGE());
-    }
-  }, [isMounted]);
+  const handleHint = useHintRequest({
+    fetchHint: () => flowerGardenApi.exec('hint'),
+    selectHint: (res) => res.hint,
+    setHint,
+    setHintError,
+  });
 
   const handleAutoComplete = useCallback(() => {
     setSelectedSource(null);

--- a/frontend/src/hooks/useFortyAndEightGame.ts
+++ b/frontend/src/hooks/useFortyAndEightGame.ts
@@ -4,6 +4,7 @@ import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
 import type { FortyAndEightHint } from '../types/card';
 import { useAutoCompleteState } from './useAutoCompleteState';
 import { useGameApi } from './useGameApi';
+import { useIsMounted } from './useIsMounted';
 
 /** Hook that manages Forty and Eight game state, source selection, hints, redeal, and moves. */
 export function useFortyAndEightGame() {
@@ -43,15 +44,20 @@ export function useFortyAndEightGame() {
     exec('giveup');
   }, [exec]);
 
+  const isMounted = useIsMounted();
+
   const handleHint = useCallback(async () => {
     try {
       const res = await fortyAndEightApi.exec('hint');
+      // Navigating away mid-request must not write to a gone component (#4447).
+      if (!isMounted()) return;
       setHint(res.hint ?? null);
       setHintError(null);
     } catch {
+      if (!isMounted()) return;
       setHintError(NETWORK_ERROR_MESSAGE());
     }
-  }, []);
+  }, [isMounted]);
 
   const handleAutoComplete = useCallback(() => {
     setSelectedSource(null);

--- a/frontend/src/hooks/useFortyAndEightGame.ts
+++ b/frontend/src/hooks/useFortyAndEightGame.ts
@@ -1,10 +1,9 @@
 import { useCallback, useEffect, useState } from 'react';
 import { type FortyAndEightMoveZone, fortyAndEightApi } from '../api/gameApi';
-import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
 import type { FortyAndEightHint } from '../types/card';
 import { useAutoCompleteState } from './useAutoCompleteState';
 import { useGameApi } from './useGameApi';
-import { useIsMounted } from './useIsMounted';
+import { useHintRequest } from './useHintRequest';
 
 /** Hook that manages Forty and Eight game state, source selection, hints, redeal, and moves. */
 export function useFortyAndEightGame() {
@@ -44,20 +43,12 @@ export function useFortyAndEightGame() {
     exec('giveup');
   }, [exec]);
 
-  const isMounted = useIsMounted();
-
-  const handleHint = useCallback(async () => {
-    try {
-      const res = await fortyAndEightApi.exec('hint');
-      // Navigating away mid-request must not write to a gone component (#4447).
-      if (!isMounted()) return;
-      setHint(res.hint ?? null);
-      setHintError(null);
-    } catch {
-      if (!isMounted()) return;
-      setHintError(NETWORK_ERROR_MESSAGE());
-    }
-  }, [isMounted]);
+  const handleHint = useHintRequest({
+    fetchHint: () => fortyAndEightApi.exec('hint'),
+    selectHint: (res) => res.hint,
+    setHint,
+    setHintError,
+  });
 
   const handleAutoComplete = useCallback(() => {
     setSelectedSource(null);

--- a/frontend/src/hooks/useFortyThievesGame.ts
+++ b/frontend/src/hooks/useFortyThievesGame.ts
@@ -1,11 +1,10 @@
 import { useCallback, useEffect, useState } from 'react';
 import { type FortyThievesMoveZone, fortyThievesApi } from '../api/gameApi';
-import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
 import type { Card, FortyThievesHint } from '../types/card';
 import { fortyThievesFoundationTarget } from '../utils/fortyThievesFoundationTarget';
 import { useAutoCompleteState } from './useAutoCompleteState';
 import { useGameApi } from './useGameApi';
-import { useIsMounted } from './useIsMounted';
+import { useHintRequest } from './useHintRequest';
 
 /** Hook that manages Forty Thieves game state, source selection, hints, and moves. */
 export function useFortyThievesGame() {
@@ -39,20 +38,12 @@ export function useFortyThievesGame() {
     exec('giveup');
   }, [exec]);
 
-  const isMounted = useIsMounted();
-
-  const handleHint = useCallback(async () => {
-    try {
-      const res = await fortyThievesApi.exec('hint');
-      // Navigating away mid-request must not write to a gone component (#4447).
-      if (!isMounted()) return;
-      setHint(res.hint ?? null);
-      setHintError(null);
-    } catch {
-      if (!isMounted()) return;
-      setHintError(NETWORK_ERROR_MESSAGE());
-    }
-  }, [isMounted]);
+  const handleHint = useHintRequest({
+    fetchHint: () => fortyThievesApi.exec('hint'),
+    selectHint: (res) => res.hint,
+    setHint,
+    setHintError,
+  });
 
   const handleAutoComplete = useCallback(() => {
     setSelectedSource(null);

--- a/frontend/src/hooks/useFortyThievesGame.ts
+++ b/frontend/src/hooks/useFortyThievesGame.ts
@@ -5,6 +5,7 @@ import type { Card, FortyThievesHint } from '../types/card';
 import { fortyThievesFoundationTarget } from '../utils/fortyThievesFoundationTarget';
 import { useAutoCompleteState } from './useAutoCompleteState';
 import { useGameApi } from './useGameApi';
+import { useIsMounted } from './useIsMounted';
 
 /** Hook that manages Forty Thieves game state, source selection, hints, and moves. */
 export function useFortyThievesGame() {
@@ -38,15 +39,20 @@ export function useFortyThievesGame() {
     exec('giveup');
   }, [exec]);
 
+  const isMounted = useIsMounted();
+
   const handleHint = useCallback(async () => {
     try {
       const res = await fortyThievesApi.exec('hint');
+      // Navigating away mid-request must not write to a gone component (#4447).
+      if (!isMounted()) return;
       setHint(res.hint ?? null);
       setHintError(null);
     } catch {
+      if (!isMounted()) return;
       setHintError(NETWORK_ERROR_MESSAGE());
     }
-  }, []);
+  }, [isMounted]);
 
   const handleAutoComplete = useCallback(() => {
     setSelectedSource(null);

--- a/frontend/src/hooks/useGolfGame.ts
+++ b/frontend/src/hooks/useGolfGame.ts
@@ -3,6 +3,7 @@ import { golfApi } from '../api/gameApi';
 import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
 import type { GolfHint } from '../types/card';
 import { useGameApi } from './useGameApi';
+import { useIsMounted } from './useIsMounted';
 
 /** Hook that manages Golf Solitaire game state, hints, and card removal actions. */
 export function useGolfGame() {
@@ -29,15 +30,20 @@ export function useGolfGame() {
     exec('giveup');
   }, [exec]);
 
+  const isMounted = useIsMounted();
+
   const handleHint = useCallback(async () => {
     try {
       const res = await golfApi.exec('hint');
+      // Navigating away mid-request must not write to a gone component (#4447).
+      if (!isMounted()) return;
       setHint(res.hint ?? null);
       setHintError(null);
     } catch {
+      if (!isMounted()) return;
       setHintError(NETWORK_ERROR_MESSAGE());
     }
-  }, []);
+  }, [isMounted]);
 
   const handleUndo = useCallback(() => {
     setHint(null);

--- a/frontend/src/hooks/useGolfGame.ts
+++ b/frontend/src/hooks/useGolfGame.ts
@@ -1,9 +1,8 @@
 import { useCallback, useEffect, useState } from 'react';
 import { golfApi } from '../api/gameApi';
-import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
 import type { GolfHint } from '../types/card';
 import { useGameApi } from './useGameApi';
-import { useIsMounted } from './useIsMounted';
+import { useHintRequest } from './useHintRequest';
 
 /** Hook that manages Golf Solitaire game state, hints, and card removal actions. */
 export function useGolfGame() {
@@ -30,20 +29,12 @@ export function useGolfGame() {
     exec('giveup');
   }, [exec]);
 
-  const isMounted = useIsMounted();
-
-  const handleHint = useCallback(async () => {
-    try {
-      const res = await golfApi.exec('hint');
-      // Navigating away mid-request must not write to a gone component (#4447).
-      if (!isMounted()) return;
-      setHint(res.hint ?? null);
-      setHintError(null);
-    } catch {
-      if (!isMounted()) return;
-      setHintError(NETWORK_ERROR_MESSAGE());
-    }
-  }, [isMounted]);
+  const handleHint = useHintRequest({
+    fetchHint: () => golfApi.exec('hint'),
+    selectHint: (res) => res.hint,
+    setHint,
+    setHintError,
+  });
 
   const handleUndo = useCallback(() => {
     setHint(null);

--- a/frontend/src/hooks/useHintRequest.test.ts
+++ b/frontend/src/hooks/useHintRequest.test.ts
@@ -1,0 +1,111 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { useHintRequest } from './useHintRequest';
+
+interface Res {
+  hint: { kind: string } | null;
+}
+
+function setup(overrides: Partial<Parameters<typeof useHintRequest<Res, { kind: string }>>[0]> = {}) {
+  const setHint = vi.fn();
+  const setHintError = vi.fn();
+  const setHintLoading = vi.fn();
+  const fetchHint = vi.fn(async () => ({ hint: { kind: 'play' } }) as Res);
+  const { result, unmount, rerender } = renderHook(() =>
+    useHintRequest<Res, { kind: string }>({
+      fetchHint,
+      selectHint: (res) => res.hint,
+      setHint,
+      setHintError,
+      setHintLoading,
+      ...overrides,
+    }),
+  );
+  return { result, unmount, rerender, setHint, setHintError, setHintLoading, fetchHint };
+}
+
+describe('useHintRequest', () => {
+  it('stores the selected hint and clears any previous error', async () => {
+    const { result, setHint, setHintError } = setup();
+    await act(async () => {
+      await result.current();
+    });
+    expect(setHint).toHaveBeenCalledWith({ kind: 'play' });
+    expect(setHintError).toHaveBeenCalledWith(null);
+  });
+
+  it('toggles the loading flag around the request when one is supplied', async () => {
+    const { result, setHintLoading } = setup();
+    await act(async () => {
+      await result.current();
+    });
+    expect(setHintLoading).toHaveBeenNthCalledWith(1, true);
+    expect(setHintLoading).toHaveBeenNthCalledWith(2, false);
+  });
+
+  it('works for games that do not track a loading flag', async () => {
+    const { result, setHint } = setup({ setHintLoading: undefined });
+    await act(async () => {
+      await result.current();
+    });
+    expect(setHint).toHaveBeenCalledWith({ kind: 'play' });
+  });
+
+  it('normalises a missing hint to null', async () => {
+    const { result, setHint } = setup({ fetchHint: async () => ({ hint: null }) as Res });
+    await act(async () => {
+      await result.current();
+    });
+    expect(setHint).toHaveBeenCalledWith(null);
+  });
+
+  it('reports a network error and leaves the hint alone', async () => {
+    const { result, setHint, setHintError, setHintLoading } = setup({
+      fetchHint: async () => {
+        throw new Error('boom');
+      },
+    });
+    await act(async () => {
+      await result.current();
+    });
+    expect(setHint).not.toHaveBeenCalled();
+    expect(setHintError).toHaveBeenCalledWith(expect.any(String));
+    expect(setHintLoading).toHaveBeenLastCalledWith(false);
+  });
+
+  // The reason this hook exists rather than 20 hand-written copies: the response
+  // lands after an await, so it can outlive the page. Writing state then is a silent
+  // no-op until the environment is torn down, where React throws from
+  // dispatchSetState. See #4444 / #4447.
+  it('writes nothing once the component has unmounted', async () => {
+    let resolveHint: ((value: Res) => void) | undefined;
+    const { result, unmount, setHint, setHintError, setHintLoading } = setup({
+      fetchHint: () =>
+        new Promise<Res>((resolve) => {
+          resolveHint = resolve;
+        }),
+    });
+    act(() => {
+      void result.current();
+    });
+    await waitFor(() => expect(setHintLoading).toHaveBeenCalledWith(true));
+    setHintLoading.mockClear();
+
+    unmount();
+    resolveHint?.({ hint: { kind: 'too-late' } });
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+
+    expect(setHint).not.toHaveBeenCalled();
+    expect(setHintError).not.toHaveBeenCalled();
+    expect(setHintLoading).not.toHaveBeenCalled();
+  });
+
+  it('keeps a stable identity across renders so dependents are not invalidated', () => {
+    const { result, rerender } = setup();
+    const first = result.current;
+    rerender();
+    expect(result.current).toBe(first);
+  });
+});

--- a/frontend/src/hooks/useHintRequest.ts
+++ b/frontend/src/hooks/useHintRequest.ts
@@ -1,0 +1,56 @@
+import { useCallback, useRef } from 'react';
+import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
+import { useIsMounted } from './useIsMounted';
+
+/** Options for {@link useHintRequest}. */
+export interface UseHintRequestOptions<TRes, THint> {
+  /** Fetches the hint, e.g. `() => golfApi.exec('hint')`. */
+  fetchHint: () => Promise<TRes>;
+  /**
+   * Pulls the hint out of the response, e.g. `(res) => res.hint`. A missing hint may
+   * be returned as `undefined`; it is normalised to `null` before being stored, so
+   * callers do not each have to remember the `?? null`.
+   */
+  selectHint: (res: TRes) => THint | null | undefined;
+  setHint: (hint: THint | null) => void;
+  setHintError: (message: string | null) => void;
+  /** Only some games show a spinner while the hint is in flight. */
+  setHintLoading?: (loading: boolean) => void;
+}
+
+/**
+ * Builds the "ask the server for a hint" handler that 20 game hooks had written out
+ * by hand, identically apart from which API they call and whether they track a
+ * loading flag.
+ *
+ * Beyond the duplication, each copy had to remember that the response arrives after
+ * an `await` and so may outlive the page: writing state to a gone component is a
+ * silent no-op in React until the surrounding environment is torn down, at which
+ * point React reaches for `window` and throws from `dispatchSetState` — failing CI
+ * runs that report every test as passed. Centralising it means that reasoning lives
+ * (and is tested) in one place instead of twenty. See issues #4444 and #4447.
+ *
+ * The returned callback is stable: options are read through a ref, so callers can
+ * pass a fresh object literal every render without invalidating dependents.
+ */
+export function useHintRequest<TRes, THint>(options: UseHintRequestOptions<TRes, THint>): () => Promise<void> {
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+  const isMounted = useIsMounted();
+
+  return useCallback(async () => {
+    const { fetchHint, selectHint, setHint, setHintError, setHintLoading } = optionsRef.current;
+    setHintLoading?.(true);
+    try {
+      const res = await fetchHint();
+      if (!isMounted()) return;
+      setHint(selectHint(res) ?? null);
+      setHintError(null);
+    } catch {
+      if (!isMounted()) return;
+      setHintError(NETWORK_ERROR_MESSAGE());
+    } finally {
+      if (isMounted()) setHintLoading?.(false);
+    }
+  }, [isMounted]);
+}

--- a/frontend/src/hooks/useIsMounted.test.tsx
+++ b/frontend/src/hooks/useIsMounted.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react';
+import { StrictMode, useEffect, useState } from 'react';
+import { describe, expect, it } from 'vitest';
+import { useIsMounted } from './useIsMounted';
+
+/** Renders the flag's value, re-read on every render. */
+function Harness({ onRead }: { onRead: (isMounted: () => boolean) => void }) {
+  const isMounted = useIsMounted();
+  const [, force] = useState(0);
+  useEffect(() => {
+    // Re-render once after mount so the assertion reads the flag after all effects
+    // (including StrictMode's simulated cleanup/remount) have settled.
+    force(1);
+  }, []);
+  onRead(isMounted);
+  return <div data-testid="mounted">{isMounted() ? 'yes' : 'no'}</div>;
+}
+
+describe('useIsMounted', () => {
+  it('reports mounted while mounted', () => {
+    render(<Harness onRead={() => {}} />);
+    expect(screen.getByTestId('mounted')).toHaveTextContent('yes');
+  });
+
+  // The regression that matters: StrictMode runs mount → cleanup → remount in dev, so
+  // a cleanup-only effect would latch the flag false on a component that is genuinely
+  // mounted and silently skip every guarded state write from then on. See #4446.
+  it('stays mounted through a StrictMode mount/cleanup/remount cycle', () => {
+    let latest: (() => boolean) | undefined;
+    render(
+      <StrictMode>
+        <Harness
+          onRead={(isMounted) => {
+            latest = isMounted;
+          }}
+        />
+      </StrictMode>,
+    );
+    expect(latest?.()).toBe(true);
+    expect(screen.getByTestId('mounted')).toHaveTextContent('yes');
+  });
+
+  it('reports unmounted after unmount', () => {
+    let latest: (() => boolean) | undefined;
+    const { unmount } = render(
+      <Harness
+        onRead={(isMounted) => {
+          latest = isMounted;
+        }}
+      />,
+    );
+    expect(latest?.()).toBe(true);
+    unmount();
+    expect(latest?.()).toBe(false);
+  });
+});

--- a/frontend/src/hooks/useIsMounted.ts
+++ b/frontend/src/hooks/useIsMounted.ts
@@ -1,0 +1,37 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+/**
+ * Returns a stable getter for whether the calling component is still mounted.
+ *
+ * Use it to skip state writes that would otherwise happen after an `await`:
+ *
+ * ```ts
+ * const res = await someApi();
+ * if (!isMounted()) return;
+ * setThing(res);
+ * ```
+ *
+ * React treats `setState` after unmount as a silent no-op, so the motivation is not
+ * a console warning — it is that the write can land after the surrounding
+ * environment is gone, where React's internals reach for `window` and throw from
+ * `dispatchSetState`. In CI that failed whole runs while reporting every test as
+ * passed (#4444).
+ *
+ * The flag is re-armed in the effect body rather than relying on the `useRef(true)`
+ * initialiser. `main.tsx` wraps the app in `StrictMode`, which in dev runs
+ * mount → cleanup → remount specifically to surface this: a cleanup-only effect
+ * latches the flag `false` on a component that is genuinely mounted, and every
+ * later guarded write is silently skipped. That is not theoretical — it would have
+ * left every game page stuck on its skeleton under `bun run dev` while production
+ * builds, E2E and CI all stayed green (#4446).
+ */
+export function useIsMounted(): () => boolean {
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+  return useCallback(() => mountedRef.current, []);
+}

--- a/frontend/src/hooks/useKingAlbertGame.ts
+++ b/frontend/src/hooks/useKingAlbertGame.ts
@@ -4,6 +4,7 @@ import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
 import type { KingAlbertHint } from '../types/card';
 import { useAutoCompleteState } from './useAutoCompleteState';
 import { useGameApi } from './useGameApi';
+import { useIsMounted } from './useIsMounted';
 
 /** Hook that manages King Albert game state, source selection, hints, and moves. */
 export function useKingAlbertGame() {
@@ -31,15 +32,20 @@ export function useKingAlbertGame() {
     runApi('giveup');
   }, [runApi]);
 
+  const isMounted = useIsMounted();
+
   const handleHint = useCallback(async () => {
     try {
       const res = await kingAlbertApi.exec('hint');
+      // Navigating away mid-request must not write to a gone component (#4447).
+      if (!isMounted()) return;
       setHint(res.hint ?? null);
       setHintError(null);
     } catch {
+      if (!isMounted()) return;
       setHintError(NETWORK_ERROR_MESSAGE());
     }
-  }, []);
+  }, [isMounted]);
 
   const handleAutoComplete = useCallback(() => {
     setSelectedSource(null);

--- a/frontend/src/hooks/useKingAlbertGame.ts
+++ b/frontend/src/hooks/useKingAlbertGame.ts
@@ -1,10 +1,9 @@
 import { useCallback, useEffect, useState } from 'react';
 import { type KingAlbertMoveZone, kingAlbertApi } from '../api/gameApi';
-import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
 import type { KingAlbertHint } from '../types/card';
 import { useAutoCompleteState } from './useAutoCompleteState';
 import { useGameApi } from './useGameApi';
-import { useIsMounted } from './useIsMounted';
+import { useHintRequest } from './useHintRequest';
 
 /** Hook that manages King Albert game state, source selection, hints, and moves. */
 export function useKingAlbertGame() {
@@ -32,20 +31,12 @@ export function useKingAlbertGame() {
     runApi('giveup');
   }, [runApi]);
 
-  const isMounted = useIsMounted();
-
-  const handleHint = useCallback(async () => {
-    try {
-      const res = await kingAlbertApi.exec('hint');
-      // Navigating away mid-request must not write to a gone component (#4447).
-      if (!isMounted()) return;
-      setHint(res.hint ?? null);
-      setHintError(null);
-    } catch {
-      if (!isMounted()) return;
-      setHintError(NETWORK_ERROR_MESSAGE());
-    }
-  }, [isMounted]);
+  const handleHint = useHintRequest({
+    fetchHint: () => kingAlbertApi.exec('hint'),
+    selectHint: (res) => res.hint,
+    setHint,
+    setHintError,
+  });
 
   const handleAutoComplete = useCallback(() => {
     setSelectedSource(null);

--- a/frontend/src/hooks/useMightyGame.ts
+++ b/frontend/src/hooks/useMightyGame.ts
@@ -1,11 +1,10 @@
 import { useCallback, useEffect, useState } from 'react';
 import { mightyApi } from '../api/gameApi';
-import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
 import type { MightyConfig, MightyHint } from '../types/card';
 import { useCardSelection } from './useCardSelection';
 import { useGameApi } from './useGameApi';
 import { useGameConfig } from './useGameConfig';
-import { useIsMounted } from './useIsMounted';
+import { useHintRequest } from './useHintRequest';
 
 /** Default Mighty game configuration. */
 export const DEFAULT_MIGHTY_CONFIG: MightyConfig = {
@@ -116,23 +115,13 @@ export function useMightyGame() {
     apiCall('nextround');
   }, [apiCall]);
 
-  const isMounted = useIsMounted();
-
-  const handleHint = useCallback(async () => {
-    setHintLoading(true);
-    try {
-      const res = await mightyApi.exec('hint');
-      // Navigating away mid-request must not write to a gone component (#4447).
-      if (!isMounted()) return;
-      setHint(res.hint ?? null);
-      setHintError(null);
-    } catch {
-      if (!isMounted()) return;
-      setHintError(NETWORK_ERROR_MESSAGE());
-    } finally {
-      if (isMounted()) setHintLoading(false);
-    }
-  }, [isMounted]);
+  const handleHint = useHintRequest({
+    fetchHint: () => mightyApi.exec('hint'),
+    selectHint: (res) => res.hint,
+    setHint,
+    setHintError,
+    setHintLoading,
+  });
 
   return {
     state,

--- a/frontend/src/hooks/useMightyGame.ts
+++ b/frontend/src/hooks/useMightyGame.ts
@@ -5,6 +5,7 @@ import type { MightyConfig, MightyHint } from '../types/card';
 import { useCardSelection } from './useCardSelection';
 import { useGameApi } from './useGameApi';
 import { useGameConfig } from './useGameConfig';
+import { useIsMounted } from './useIsMounted';
 
 /** Default Mighty game configuration. */
 export const DEFAULT_MIGHTY_CONFIG: MightyConfig = {
@@ -115,18 +116,23 @@ export function useMightyGame() {
     apiCall('nextround');
   }, [apiCall]);
 
+  const isMounted = useIsMounted();
+
   const handleHint = useCallback(async () => {
     setHintLoading(true);
     try {
       const res = await mightyApi.exec('hint');
+      // Navigating away mid-request must not write to a gone component (#4447).
+      if (!isMounted()) return;
       setHint(res.hint ?? null);
       setHintError(null);
     } catch {
+      if (!isMounted()) return;
       setHintError(NETWORK_ERROR_MESSAGE());
     } finally {
-      setHintLoading(false);
+      if (isMounted()) setHintLoading(false);
     }
-  }, []);
+  }, [isMounted]);
 
   return {
     state,

--- a/frontend/src/hooks/useNapoleonGame.ts
+++ b/frontend/src/hooks/useNapoleonGame.ts
@@ -5,6 +5,7 @@ import type { NapoleonConfig, NapoleonHint } from '../types/card';
 import { useCardSelection } from './useCardSelection';
 import { useGameApi } from './useGameApi';
 import { useGameConfig } from './useGameConfig';
+import { useIsMounted } from './useIsMounted';
 
 /** Default Napoleon game configuration. */
 export const DEFAULT_NAPOLEON_CONFIG: NapoleonConfig = {
@@ -84,18 +85,23 @@ export function useNapoleonGame() {
     apiExec('nextround');
   }, [apiExec]);
 
+  const isMounted = useIsMounted();
+
   const handleHint = useCallback(async () => {
     setHintLoading(true);
     try {
       const res = await napoleonApi.exec('hint');
+      // Navigating away mid-request must not write to a gone component (#4447).
+      if (!isMounted()) return;
       setHint(res.hint ?? null);
       setHintError(null);
     } catch {
+      if (!isMounted()) return;
       setHintError(NETWORK_ERROR_MESSAGE());
     } finally {
-      setHintLoading(false);
+      if (isMounted()) setHintLoading(false);
     }
-  }, []);
+  }, [isMounted]);
 
   return {
     state,

--- a/frontend/src/hooks/useNapoleonGame.ts
+++ b/frontend/src/hooks/useNapoleonGame.ts
@@ -1,11 +1,10 @@
 import { useCallback, useEffect, useState } from 'react';
 import { napoleonApi } from '../api/gameApi';
-import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
 import type { NapoleonConfig, NapoleonHint } from '../types/card';
 import { useCardSelection } from './useCardSelection';
 import { useGameApi } from './useGameApi';
 import { useGameConfig } from './useGameConfig';
-import { useIsMounted } from './useIsMounted';
+import { useHintRequest } from './useHintRequest';
 
 /** Default Napoleon game configuration. */
 export const DEFAULT_NAPOLEON_CONFIG: NapoleonConfig = {
@@ -85,23 +84,13 @@ export function useNapoleonGame() {
     apiExec('nextround');
   }, [apiExec]);
 
-  const isMounted = useIsMounted();
-
-  const handleHint = useCallback(async () => {
-    setHintLoading(true);
-    try {
-      const res = await napoleonApi.exec('hint');
-      // Navigating away mid-request must not write to a gone component (#4447).
-      if (!isMounted()) return;
-      setHint(res.hint ?? null);
-      setHintError(null);
-    } catch {
-      if (!isMounted()) return;
-      setHintError(NETWORK_ERROR_MESSAGE());
-    } finally {
-      if (isMounted()) setHintLoading(false);
-    }
-  }, [isMounted]);
+  const handleHint = useHintRequest({
+    fetchHint: () => napoleonApi.exec('hint'),
+    selectHint: (res) => res.hint,
+    setHint,
+    setHintError,
+    setHintLoading,
+  });
 
   return {
     state,

--- a/frontend/src/hooks/useOhHellGame.ts
+++ b/frontend/src/hooks/useOhHellGame.ts
@@ -5,6 +5,7 @@ import type { OhHellConfig, OhHellHint } from '../types/card';
 import { useCardSelection } from './useCardSelection';
 import { useGameApi } from './useGameApi';
 import { useGameConfig } from './useGameConfig';
+import { useIsMounted } from './useIsMounted';
 
 /** Default Oh Hell game configuration. */
 export const DEFAULT_OH_HELL_CONFIG: OhHellConfig = {
@@ -76,18 +77,23 @@ export function useOhHellGame() {
     exec('nextround');
   }, [exec]);
 
+  const isMounted = useIsMounted();
+
   const handleHint = useCallback(async () => {
     setHintLoading(true);
     try {
       const res = await ohHellApi.exec('hint');
+      // Navigating away mid-request must not write to a gone component (#4447).
+      if (!isMounted()) return;
       setHint(res.hint ?? null);
       setHintError(null);
     } catch {
+      if (!isMounted()) return;
       setHintError(NETWORK_ERROR_MESSAGE());
     } finally {
-      setHintLoading(false);
+      if (isMounted()) setHintLoading(false);
     }
-  }, []);
+  }, [isMounted]);
 
   return {
     state,

--- a/frontend/src/hooks/useOhHellGame.ts
+++ b/frontend/src/hooks/useOhHellGame.ts
@@ -1,11 +1,10 @@
 import { useCallback, useEffect, useState } from 'react';
 import { ohHellApi } from '../api/gameApi';
-import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
 import type { OhHellConfig, OhHellHint } from '../types/card';
 import { useCardSelection } from './useCardSelection';
 import { useGameApi } from './useGameApi';
 import { useGameConfig } from './useGameConfig';
-import { useIsMounted } from './useIsMounted';
+import { useHintRequest } from './useHintRequest';
 
 /** Default Oh Hell game configuration. */
 export const DEFAULT_OH_HELL_CONFIG: OhHellConfig = {
@@ -77,23 +76,13 @@ export function useOhHellGame() {
     exec('nextround');
   }, [exec]);
 
-  const isMounted = useIsMounted();
-
-  const handleHint = useCallback(async () => {
-    setHintLoading(true);
-    try {
-      const res = await ohHellApi.exec('hint');
-      // Navigating away mid-request must not write to a gone component (#4447).
-      if (!isMounted()) return;
-      setHint(res.hint ?? null);
-      setHintError(null);
-    } catch {
-      if (!isMounted()) return;
-      setHintError(NETWORK_ERROR_MESSAGE());
-    } finally {
-      if (isMounted()) setHintLoading(false);
-    }
-  }, [isMounted]);
+  const handleHint = useHintRequest({
+    fetchHint: () => ohHellApi.exec('hint'),
+    selectHint: (res) => res.hint,
+    setHint,
+    setHintError,
+    setHintLoading,
+  });
 
   return {
     state,

--- a/frontend/src/hooks/useOldMaidGame.ts
+++ b/frontend/src/hooks/useOldMaidGame.ts
@@ -4,6 +4,7 @@ import type { Card, CpuAction, OldMaidResponse } from '../types/card';
 import { buildHumanActionState, buildReplayStates } from '../utils/replayBuilder';
 import { REPLAY_DELAY_MS, runReplay, shouldSkipReplay } from './gameReplay';
 import { useGameApi } from './useGameApi';
+import { useIsMounted } from './useIsMounted';
 
 /** Old Maid game mode constants (Normal or JijiNuki). */
 export const OldMaidMode = {
@@ -96,6 +97,8 @@ function buildHumanDrawState(finalState: OldMaidResponse): OldMaidResponse | nul
 
 /** Hook that manages Old Maid game state, setup, CPU replay, and card reveal. */
 export function useOldMaidGame() {
+  const isMounted = useIsMounted();
+
   const [displayState, setDisplayState] = useState<OldMaidResponse | null>(null);
   const [setupMode, setSetupMode] = useState<number>(OldMaidMode.Normal);
   const [setupStrategy, setSetupStrategy] = useState(false);
@@ -139,17 +142,21 @@ export function useOldMaidGame() {
 
   const lastReplayedActionsRef = useRef<OldMaidResponse['cpuActions']>(undefined);
 
-  const onSuccess = useCallback(async (res: OldMaidResponse) => {
-    if (shouldSkipReplay(res.cpuActions ?? [], lastReplayedActionsRef, res, setDisplayState)) {
-      return;
-    }
-    await runReplay(res, setDisplayState, {
-      buildReplayStates: buildOldMaidReplayStates,
-      buildHumanActionState: buildHumanDrawState,
-      // hesitationMs is 0 when disabled; || falls back to REPLAY_DELAY_MS (min enabled value is 300ms)
-      getActionDelay: (state, i) => state.cpuActions[i]?.hesitationMs || REPLAY_DELAY_MS,
-    });
-  }, []);
+  const onSuccess = useCallback(
+    async (res: OldMaidResponse) => {
+      if (shouldSkipReplay(res.cpuActions ?? [], lastReplayedActionsRef, res, setDisplayState)) {
+        return;
+      }
+      await runReplay(res, setDisplayState, {
+        isMounted,
+        buildReplayStates: buildOldMaidReplayStates,
+        buildHumanActionState: buildHumanDrawState,
+        // hesitationMs is 0 when disabled; || falls back to REPLAY_DELAY_MS (min enabled value is 300ms)
+        getActionDelay: (state, i) => state.cpuActions[i]?.hesitationMs || REPLAY_DELAY_MS,
+      });
+    },
+    [isMounted],
+  );
 
   const { loading, error, exec: gameExec, retry } = useGameApi(oldmaidApi.exec, { onSuccess });
 

--- a/frontend/src/hooks/usePinochleGame.ts
+++ b/frontend/src/hooks/usePinochleGame.ts
@@ -4,6 +4,7 @@ import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
 import type { PinochleConfig } from '../types/card';
 import { useGameApi } from './useGameApi';
 import { useGameConfig } from './useGameConfig';
+import { useIsMounted } from './useIsMounted';
 
 /**
  * Server-computed hint returned by the Pinochle `hint` command. Exactly one of
@@ -97,21 +98,26 @@ export function usePinochleGame() {
   // The `hint` command returns only the hint object (not full game state), so
   // it is fetched directly and stored separately rather than via gameExec,
   // which would otherwise clobber the rendered game state.
+  const isMounted = useIsMounted();
+
   const handleHint = useCallback(async () => {
     setHintLoading(true);
     try {
       const res = await pinochleApi.exec('hint');
+      // Navigating away mid-request must not write to a gone component (#4447).
+      if (!isMounted()) return;
       // Server marshals the bare hint fields at the top level (cardIndex,
       // bidAmount, pass, suit, reason); when no hint applies `reason` is absent.
       const raw = res as unknown as Partial<PinochleHint>;
       setHint(raw.reason ? (raw as PinochleHint) : null);
       setHintError(null);
     } catch {
+      if (!isMounted()) return;
       setHintError(NETWORK_ERROR_MESSAGE());
     } finally {
-      setHintLoading(false);
+      if (isMounted()) setHintLoading(false);
     }
-  }, []);
+  }, [isMounted]);
 
   return {
     state,

--- a/frontend/src/hooks/usePresidentGame.ts
+++ b/frontend/src/hooks/usePresidentGame.ts
@@ -5,6 +5,7 @@ import { buildHumanActionState, buildReplayStates } from '../utils/replayBuilder
 import { runReplay, shouldSkipReplay } from './gameReplay';
 import { useCardSelection } from './useCardSelection';
 import { useGameApi } from './useGameApi';
+import { useIsMounted } from './useIsMounted';
 
 const defaultConfigInput: PresidentConfigInput = {
   revolutionEnabled: true,
@@ -86,6 +87,8 @@ function buildPresidentReplayStates(finalState: PresidentResponse): PresidentRes
 
 /** Hook that manages President game state, card selection, and CPU replay. */
 export function usePresidentGame() {
+  const isMounted = useIsMounted();
+
   const { selected: selectedIndices, toggle: toggleCardSelection, clear: clearSelection } = useCardSelection();
   const [configInput, setConfigInput] = useState<PresidentConfigInput>(defaultConfigInput);
   const [displayState, setDisplayState] = useState<PresidentResponse | null>(null);
@@ -99,11 +102,12 @@ export function usePresidentGame() {
         return;
       }
       await runReplay(res, setDisplayState, {
+        isMounted,
         buildReplayStates: buildPresidentReplayStates,
         buildHumanActionState: buildPresidentHumanActionState,
       });
     },
-    [clearSelection],
+    [clearSelection, isMounted],
   );
 
   const { loading, error, exec: callApi, retry } = useGameApi(presidentApi.exec, { onSuccess });

--- a/frontend/src/hooks/useSevensGame.ts
+++ b/frontend/src/hooks/useSevensGame.ts
@@ -5,6 +5,7 @@ import { buildReplayStates } from '../utils/replayBuilder';
 import { runReplay, shouldSkipReplay } from './gameReplay';
 import { useGameApi } from './useGameApi';
 import { useGameConfig } from './useGameConfig';
+import { useIsMounted } from './useIsMounted';
 
 /**
  * Local config state shape for the Sevens settings panel. Mirrors the
@@ -93,6 +94,8 @@ function buildSevensReplayStates(finalState: SevensResponse): SevensResponse[] {
 
 /** Hook that manages Sevens game state, joker placement, configuration, and CPU replay. */
 export function useSevensGame() {
+  const isMounted = useIsMounted();
+
   const [jokerCardIdx, setJokerCardIdx] = useState<number | null>(null);
   const { config, setConfig, handleConfigChange, handleToggle } =
     useGameConfig<SevensConfigState>(DEFAULT_SEVENS_CONFIG);
@@ -121,10 +124,11 @@ export function useSevensGame() {
         return;
       }
       await runReplay(res, setDisplayState, {
+        isMounted,
         buildReplayStates: buildSevensReplayStates,
       });
     },
-    [setConfig],
+    [setConfig, isMounted],
   );
 
   const { loading, error, exec, retry } = useGameApi(sevensApi.exec, { onSuccess });

--- a/frontend/src/hooks/useSkatGame.ts
+++ b/frontend/src/hooks/useSkatGame.ts
@@ -5,6 +5,7 @@ import type { SkatConfig, SkatHint } from '../types/card';
 import { useCardSelection } from './useCardSelection';
 import { useGameApi } from './useGameApi';
 import { useGameConfig } from './useGameConfig';
+import { useIsMounted } from './useIsMounted';
 
 /** Default Skat game configuration. */
 export const DEFAULT_SKAT_CONFIG: SkatConfig = {
@@ -87,18 +88,23 @@ export function useSkatGame() {
     dispatch('nextround');
   }, [dispatch]);
 
+  const isMounted = useIsMounted();
+
   const handleHint = useCallback(async () => {
     setHintLoading(true);
     try {
       const res = await skatApi.exec('hint');
+      // Navigating away mid-request must not write to a gone component (#4447).
+      if (!isMounted()) return;
       setHint(res.hint ?? null);
       setHintError(null);
     } catch {
+      if (!isMounted()) return;
       setHintError(NETWORK_ERROR_MESSAGE());
     } finally {
-      setHintLoading(false);
+      if (isMounted()) setHintLoading(false);
     }
-  }, []);
+  }, [isMounted]);
 
   return {
     state,

--- a/frontend/src/hooks/useSkatGame.ts
+++ b/frontend/src/hooks/useSkatGame.ts
@@ -1,11 +1,10 @@
 import { useCallback, useEffect, useState } from 'react';
 import { skatApi } from '../api/gameApi';
-import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
 import type { SkatConfig, SkatHint } from '../types/card';
 import { useCardSelection } from './useCardSelection';
 import { useGameApi } from './useGameApi';
 import { useGameConfig } from './useGameConfig';
-import { useIsMounted } from './useIsMounted';
+import { useHintRequest } from './useHintRequest';
 
 /** Default Skat game configuration. */
 export const DEFAULT_SKAT_CONFIG: SkatConfig = {
@@ -88,23 +87,13 @@ export function useSkatGame() {
     dispatch('nextround');
   }, [dispatch]);
 
-  const isMounted = useIsMounted();
-
-  const handleHint = useCallback(async () => {
-    setHintLoading(true);
-    try {
-      const res = await skatApi.exec('hint');
-      // Navigating away mid-request must not write to a gone component (#4447).
-      if (!isMounted()) return;
-      setHint(res.hint ?? null);
-      setHintError(null);
-    } catch {
-      if (!isMounted()) return;
-      setHintError(NETWORK_ERROR_MESSAGE());
-    } finally {
-      if (isMounted()) setHintLoading(false);
-    }
-  }, [isMounted]);
+  const handleHint = useHintRequest({
+    fetchHint: () => skatApi.exec('hint'),
+    selectHint: (res) => res.hint,
+    setHint,
+    setHintError,
+    setHintLoading,
+  });
 
   return {
     state,

--- a/frontend/src/hooks/useSolitaireGameBase.test.ts
+++ b/frontend/src/hooks/useSolitaireGameBase.test.ts
@@ -93,4 +93,36 @@ describe('useSolitaireGameBase', () => {
     rerender();
     expect(result.current).toBe(before);
   });
+
+  // `selectHint` runs AFTER the mounted check, so it is the observable that
+  // distinguishes a guarded hook from an unguarded one: asserting on the returned
+  // hint cannot, because React no-ops a post-unmount setState either way. #4447
+  it('does not process a hint that arrives after unmount', async () => {
+    let resolveHint: ((value: FakeState) => void) | undefined;
+    const hintApi = vi.fn(
+      () =>
+        new Promise<FakeState>((resolve) => {
+          resolveHint = resolve;
+        }),
+    );
+    const selectHint = vi.fn((res: FakeState) => res.hint ?? null);
+    const { result, unmount } = renderHook(
+      () => useSolitaireGameBase<FakeState, unknown[], { kind: string }>(mockExec, { hintApi, selectHint }),
+      { wrapper: createWrapper() },
+    );
+    await waitFor(() => expect(mockExec).toHaveBeenCalled());
+
+    act(() => {
+      void result.current.handleHint();
+    });
+    await waitFor(() => expect(hintApi).toHaveBeenCalled());
+
+    unmount();
+    resolveHint?.({ message: 'late', hint: { kind: 'too-late' } });
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+
+    expect(selectHint).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/src/hooks/useSolitaireGameBase.ts
+++ b/frontend/src/hooks/useSolitaireGameBase.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
 import { useAutoCompleteState } from './useAutoCompleteState';
 import { useGameApi } from './useGameApi';
+import { useIsMounted } from './useIsMounted';
 
 /** Options for {@link useSolitaireGameBase}. */
 export interface SolitaireGameBaseOptions<THint, THintRes> {
@@ -91,6 +92,8 @@ export function useSolitaireGameBase<TState, TArgs extends unknown[], THint, THi
     [apiCall],
   );
 
+  const isMounted = useIsMounted();
+
   const handleReset = useCallback(() => runAction(...(['reset'] as unknown as TArgs)), [runAction]);
   const handleGiveUp = useCallback(() => runAction(...(['giveup'] as unknown as TArgs)), [runAction]);
   const handleUndo = useCallback(() => runAction(...(['undo'] as unknown as TArgs)), [runAction]);
@@ -100,13 +103,17 @@ export function useSolitaireGameBase<TState, TArgs extends unknown[], THint, THi
     if (!hintApi) return;
     try {
       const res = await hintApi();
+      // The player may have navigated away while the hint was in flight; writing
+      // state to a gone component can throw once the environment is torn down. #4447
+      if (!isMounted()) return;
       const value = selectHint ? selectHint(res) : (res as unknown as { hint?: THint | null }).hint;
       setHint(value ?? null);
       setHintError(null);
     } catch {
+      if (!isMounted()) return;
       setHintError(NETWORK_ERROR_MESSAGE());
     }
-  }, []);
+  }, [isMounted]);
 
   const handleAutoComplete = useCallback(() => {
     optionsRef.current.onClearSelection?.();

--- a/frontend/src/hooks/useStreetsAndAlleysGame.ts
+++ b/frontend/src/hooks/useStreetsAndAlleysGame.ts
@@ -4,6 +4,7 @@ import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
 import type { StreetsAndAlleysHint } from '../types/card';
 import { useAutoCompleteState } from './useAutoCompleteState';
 import { useGameApi } from './useGameApi';
+import { useIsMounted } from './useIsMounted';
 
 /** Hook that manages Streets and Alleys game state, source selection, hints, and moves. */
 export function useStreetsAndAlleysGame() {
@@ -31,15 +32,20 @@ export function useStreetsAndAlleysGame() {
     runApi('giveup');
   }, [runApi]);
 
+  const isMounted = useIsMounted();
+
   const handleHint = useCallback(async () => {
     try {
       const res = await streetsAndAlleysApi.exec('hint');
+      // Navigating away mid-request must not write to a gone component (#4447).
+      if (!isMounted()) return;
       setHint(res.hint ?? null);
       setHintError(null);
     } catch {
+      if (!isMounted()) return;
       setHintError(NETWORK_ERROR_MESSAGE());
     }
-  }, []);
+  }, [isMounted]);
 
   const handleAutoComplete = useCallback(() => {
     setSelectedSource(null);

--- a/frontend/src/hooks/useStreetsAndAlleysGame.ts
+++ b/frontend/src/hooks/useStreetsAndAlleysGame.ts
@@ -1,10 +1,9 @@
 import { useCallback, useEffect, useState } from 'react';
 import { type StreetsAndAlleysMoveZone, streetsAndAlleysApi } from '../api/gameApi';
-import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
 import type { StreetsAndAlleysHint } from '../types/card';
 import { useAutoCompleteState } from './useAutoCompleteState';
 import { useGameApi } from './useGameApi';
-import { useIsMounted } from './useIsMounted';
+import { useHintRequest } from './useHintRequest';
 
 /** Hook that manages Streets and Alleys game state, source selection, hints, and moves. */
 export function useStreetsAndAlleysGame() {
@@ -32,20 +31,12 @@ export function useStreetsAndAlleysGame() {
     runApi('giveup');
   }, [runApi]);
 
-  const isMounted = useIsMounted();
-
-  const handleHint = useCallback(async () => {
-    try {
-      const res = await streetsAndAlleysApi.exec('hint');
-      // Navigating away mid-request must not write to a gone component (#4447).
-      if (!isMounted()) return;
-      setHint(res.hint ?? null);
-      setHintError(null);
-    } catch {
-      if (!isMounted()) return;
-      setHintError(NETWORK_ERROR_MESSAGE());
-    }
-  }, [isMounted]);
+  const handleHint = useHintRequest({
+    fetchHint: () => streetsAndAlleysApi.exec('hint'),
+    selectHint: (res) => res.hint,
+    setHint,
+    setHintError,
+  });
 
   const handleAutoComplete = useCallback(() => {
     setSelectedSource(null);

--- a/frontend/src/hooks/useSultanGame.ts
+++ b/frontend/src/hooks/useSultanGame.ts
@@ -4,6 +4,7 @@ import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
 import type { SultanHint } from '../types/card';
 import { useAutoCompleteState } from './useAutoCompleteState';
 import { useGameApi } from './useGameApi';
+import { useIsMounted } from './useIsMounted';
 
 /** Hook that manages Sultan of Turkey game state, source selection, hints, redeal, and moves. */
 export function useSultanGame() {
@@ -38,15 +39,20 @@ export function useSultanGame() {
     exec('giveup');
   }, [exec]);
 
+  const isMounted = useIsMounted();
+
   const handleHint = useCallback(async () => {
     try {
       const res = await sultanApi.exec('hint');
+      // Navigating away mid-request must not write to a gone component (#4447).
+      if (!isMounted()) return;
       setHint(res.hint ?? null);
       setHintError(null);
     } catch {
+      if (!isMounted()) return;
       setHintError(NETWORK_ERROR_MESSAGE());
     }
-  }, []);
+  }, [isMounted]);
 
   const handleAutoComplete = useCallback(() => {
     setHint(null);

--- a/frontend/src/hooks/useSultanGame.ts
+++ b/frontend/src/hooks/useSultanGame.ts
@@ -1,10 +1,9 @@
 import { useCallback, useEffect, useState } from 'react';
 import { type SultanMoveZone, sultanApi } from '../api/gameApi';
-import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
 import type { SultanHint } from '../types/card';
 import { useAutoCompleteState } from './useAutoCompleteState';
 import { useGameApi } from './useGameApi';
-import { useIsMounted } from './useIsMounted';
+import { useHintRequest } from './useHintRequest';
 
 /** Hook that manages Sultan of Turkey game state, source selection, hints, redeal, and moves. */
 export function useSultanGame() {
@@ -39,20 +38,12 @@ export function useSultanGame() {
     exec('giveup');
   }, [exec]);
 
-  const isMounted = useIsMounted();
-
-  const handleHint = useCallback(async () => {
-    try {
-      const res = await sultanApi.exec('hint');
-      // Navigating away mid-request must not write to a gone component (#4447).
-      if (!isMounted()) return;
-      setHint(res.hint ?? null);
-      setHintError(null);
-    } catch {
-      if (!isMounted()) return;
-      setHintError(NETWORK_ERROR_MESSAGE());
-    }
-  }, [isMounted]);
+  const handleHint = useHintRequest({
+    fetchHint: () => sultanApi.exec('hint'),
+    selectHint: (res) => res.hint,
+    setHint,
+    setHintError,
+  });
 
   const handleAutoComplete = useCallback(() => {
     setHint(null);

--- a/frontend/src/hooks/useTienLenGame.ts
+++ b/frontend/src/hooks/useTienLenGame.ts
@@ -5,6 +5,7 @@ import { buildHumanActionState, buildReplayStates } from '../utils/replayBuilder
 import { runReplay, shouldSkipReplay } from './gameReplay';
 import { useCardSelection } from './useCardSelection';
 import { useGameApi } from './useGameApi';
+import { useIsMounted } from './useIsMounted';
 
 // 0 = Normal, matching the server's DefaultTienLenConfig() so the settings
 // panel's initial value agrees with the on-mount reset (which sends no config).
@@ -85,6 +86,8 @@ function buildTienLenReplayStates(finalState: TienLenResponse): TienLenResponse[
 
 /** Hook that manages Tien Len game state, card selection, and CPU replay. */
 export function useTienLenGame() {
+  const isMounted = useIsMounted();
+
   const { selected: selectedIndices, toggle: toggleCardSelection, clear: clearSelection } = useCardSelection();
   const [configInput, setConfigInput] = useState<TienLenConfigInput>(defaultConfigInput);
   const [displayState, setDisplayState] = useState<TienLenResponse | null>(null);
@@ -98,11 +101,12 @@ export function useTienLenGame() {
         return;
       }
       await runReplay(res, setDisplayState, {
+        isMounted,
         buildReplayStates: buildTienLenReplayStates,
         buildHumanActionState: buildTienLenHumanActionState,
       });
     },
-    [clearSelection],
+    [clearSelection, isMounted],
   );
 
   const { loading, error, exec: callApi, retry } = useGameApi(tienlenApi.exec, { onSuccess });

--- a/frontend/src/hooks/useTrickGameBase.test.ts
+++ b/frontend/src/hooks/useTrickGameBase.test.ts
@@ -250,4 +250,41 @@ describe('useTrickGameBase', () => {
 
     expect(result.current.config.omnibusJD).toBe(true);
   });
+
+  // `getHint` runs AFTER the mounted check — see the sibling test in
+  // useSolitaireGameBase.test.ts for why it, not the returned hint, is the observable.
+  it('does not process a hint that arrives after unmount', async () => {
+    let resolveHint: ((value: HeartsResponse) => void) | undefined;
+    mockExec.mockResolvedValue(defaultState);
+    const getHint = vi.fn((s: HeartsResponse) => s.hint ?? null);
+    const { result, unmount } = renderHook(
+      () =>
+        useTrickGameBase({
+          apiFn: heartsApi.exec,
+          defaultConfig: DEFAULT_CONFIG,
+          getHint,
+        }),
+      { wrapper: createWrapper() },
+    );
+    await waitFor(() => expect(mockExec).toHaveBeenCalled());
+
+    mockExec.mockImplementation(
+      () =>
+        new Promise<HeartsResponse>((resolve) => {
+          resolveHint = resolve;
+        }),
+    );
+    act(() => {
+      void result.current.handleHint();
+    });
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('hint'));
+
+    unmount();
+    resolveHint?.(defaultState);
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+
+    expect(getHint).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/src/hooks/useTrickGameBase.ts
+++ b/frontend/src/hooks/useTrickGameBase.ts
@@ -3,6 +3,7 @@ import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
 import { useCardSelection } from './useCardSelection';
 import { useGameApi } from './useGameApi';
 import { useGameConfig } from './useGameConfig';
+import { useIsMounted } from './useIsMounted';
 
 /**
  * Options passed to {@link useTrickGameBase} to configure the base trick-taking game hook.
@@ -124,18 +125,24 @@ export function useTrickGameBase<TState, TArgs extends unknown[], TConfig extend
     (exec as unknown as ExecCmd)('nextround');
   }, [exec]);
 
+  const isMounted = useIsMounted();
+
   const handleHint = useCallback(async () => {
     setHintLoading(true);
     try {
       const res = await (apiFn as unknown as ApiCmd)('hint');
+      // The player may have navigated away while the hint was in flight; writing
+      // state to a gone component can throw once the environment is torn down. #4447
+      if (!isMounted()) return;
       setHint(getHint(res) ?? null);
       setHintError(null);
     } catch {
+      if (!isMounted()) return;
       setHintError(NETWORK_ERROR_MESSAGE());
     } finally {
-      setHintLoading(false);
+      if (isMounted()) setHintLoading(false);
     }
-  }, [apiFn, getHint]);
+  }, [apiFn, getHint, isMounted]);
 
   return {
     state,

--- a/frontend/src/hooks/useWizardGame.test.ts
+++ b/frontend/src/hooks/useWizardGame.test.ts
@@ -1,0 +1,95 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { createElement } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { wizardApi } from '../api/gameApi';
+import type { WizardResponse } from '../types/card';
+import { DEFAULT_WIZARD_CONFIG, useWizardGame } from './useWizardGame';
+
+vi.mock('../api/gameApi', () => ({
+  wizardApi: { exec: vi.fn() },
+}));
+
+const mockExec = vi.mocked(wizardApi.exec);
+
+function createWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+  return ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+/** Minimal response — only the fields these tests read. */
+const baseState = { players: [], phase: 0, message: '' } as unknown as WizardResponse;
+
+describe('useWizardGame', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExec.mockResolvedValue(baseState);
+  });
+
+  it('resets with the default config on mount', async () => {
+    renderHook(() => useWizardGame(), { wrapper: createWrapper() });
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined, undefined, DEFAULT_WIZARD_CONFIG));
+  });
+
+  it('stores the hint the server returns', async () => {
+    const hint = { cardIndices: [2], reason: 'lead trump' };
+    const { result } = renderHook(() => useWizardGame(), { wrapper: createWrapper() });
+    await waitFor(() => expect(mockExec).toHaveBeenCalled());
+
+    mockExec.mockResolvedValue({ ...baseState, hint } as unknown as WizardResponse);
+    await act(async () => {
+      await result.current.handleHint();
+    });
+
+    expect(mockExec).toHaveBeenCalledWith('hint');
+    expect(result.current.hint).toEqual(hint);
+    expect(result.current.hintError).toBeNull();
+    expect(result.current.hintLoading).toBe(false);
+  });
+
+  it('normalises a response with no hint to null', async () => {
+    const { result } = renderHook(() => useWizardGame(), { wrapper: createWrapper() });
+    await waitFor(() => expect(mockExec).toHaveBeenCalled());
+
+    await act(async () => {
+      await result.current.handleHint();
+    });
+
+    expect(result.current.hint).toBeNull();
+  });
+
+  it('surfaces a hint request failure without clearing hintLoading forever', async () => {
+    const { result } = renderHook(() => useWizardGame(), { wrapper: createWrapper() });
+    await waitFor(() => expect(mockExec).toHaveBeenCalled());
+
+    mockExec.mockRejectedValue(new Error('network'));
+    await act(async () => {
+      await result.current.handleHint();
+    });
+
+    expect(result.current.hintError).toEqual(expect.any(String));
+    expect(result.current.hintLoading).toBe(false);
+  });
+
+  it('clears the hint when a command succeeds, so a stale suggestion is not shown', async () => {
+    const { result } = renderHook(() => useWizardGame(), { wrapper: createWrapper() });
+    await waitFor(() => expect(mockExec).toHaveBeenCalled());
+
+    mockExec.mockResolvedValue({
+      ...baseState,
+      hint: { cardIndices: [0], reason: 'x' },
+    } as unknown as WizardResponse);
+    await act(async () => {
+      await result.current.handleHint();
+    });
+    expect(result.current.hint).not.toBeNull();
+
+    mockExec.mockResolvedValue(baseState);
+    await act(async () => {
+      await result.current.exec('play', 0);
+    });
+    expect(result.current.hint).toBeNull();
+  });
+});

--- a/frontend/src/hooks/useWizardGame.ts
+++ b/frontend/src/hooks/useWizardGame.ts
@@ -1,11 +1,10 @@
 import { useCallback, useEffect, useState } from 'react';
 import { wizardApi } from '../api/gameApi';
-import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
 import type { WizardConfig, WizardHint } from '../types/card';
 import { useCardSelection } from './useCardSelection';
 import { useGameApi } from './useGameApi';
 import { useGameConfig } from './useGameConfig';
-import { useIsMounted } from './useIsMounted';
+import { useHintRequest } from './useHintRequest';
 
 /** Default Wizard game configuration. */
 export const DEFAULT_WIZARD_CONFIG: WizardConfig = {
@@ -59,23 +58,13 @@ export function useWizardGame() {
     exec('nextround');
   }, [exec]);
 
-  const isMounted = useIsMounted();
-
-  const handleHint = useCallback(async () => {
-    setHintLoading(true);
-    try {
-      const res = await wizardApi.exec('hint');
-      // Navigating away mid-request must not write to a gone component (#4447).
-      if (!isMounted()) return;
-      setHint(res.hint ?? null);
-      setHintError(null);
-    } catch {
-      if (!isMounted()) return;
-      setHintError(NETWORK_ERROR_MESSAGE());
-    } finally {
-      if (isMounted()) setHintLoading(false);
-    }
-  }, [isMounted]);
+  const handleHint = useHintRequest({
+    fetchHint: () => wizardApi.exec('hint'),
+    selectHint: (res) => res.hint,
+    setHint,
+    setHintError,
+    setHintLoading,
+  });
 
   return {
     state,

--- a/frontend/src/hooks/useWizardGame.ts
+++ b/frontend/src/hooks/useWizardGame.ts
@@ -5,6 +5,7 @@ import type { WizardConfig, WizardHint } from '../types/card';
 import { useCardSelection } from './useCardSelection';
 import { useGameApi } from './useGameApi';
 import { useGameConfig } from './useGameConfig';
+import { useIsMounted } from './useIsMounted';
 
 /** Default Wizard game configuration. */
 export const DEFAULT_WIZARD_CONFIG: WizardConfig = {
@@ -58,18 +59,23 @@ export function useWizardGame() {
     exec('nextround');
   }, [exec]);
 
+  const isMounted = useIsMounted();
+
   const handleHint = useCallback(async () => {
     setHintLoading(true);
     try {
       const res = await wizardApi.exec('hint');
+      // Navigating away mid-request must not write to a gone component (#4447).
+      if (!isMounted()) return;
       setHint(res.hint ?? null);
       setHintError(null);
     } catch {
+      if (!isMounted()) return;
       setHintError(NETWORK_ERROR_MESSAGE());
     } finally {
-      setHintLoading(false);
+      if (isMounted()) setHintLoading(false);
     }
-  }, []);
+  }, [isMounted]);
 
   return {
     state,

--- a/frontend/src/hooks/useZhengGame.ts
+++ b/frontend/src/hooks/useZhengGame.ts
@@ -5,6 +5,7 @@ import { buildHumanActionState, buildReplayStates } from '../utils/replayBuilder
 import { runReplay, shouldSkipReplay } from './gameReplay';
 import { useCardSelection } from './useCardSelection';
 import { useGameApi } from './useGameApi';
+import { useIsMounted } from './useIsMounted';
 
 // 0 = Normal, matching the server's DefaultZhengConfig() so the settings
 // panel's initial value agrees with the on-mount reset (which sends no config).
@@ -85,6 +86,8 @@ function buildZhengReplayStates(finalState: ZhengResponse): ZhengResponse[] {
 
 /** Hook that manages Zheng Shangyou game state, card selection, and CPU replay. */
 export function useZhengGame() {
+  const isMounted = useIsMounted();
+
   const { selected: selectedIndices, toggle: toggleCardSelection, clear: clearSelection } = useCardSelection();
   const [configInput, setConfigInput] = useState<ZhengConfigInput>(defaultConfigInput);
   const [displayState, setDisplayState] = useState<ZhengResponse | null>(null);
@@ -98,11 +101,12 @@ export function useZhengGame() {
         return;
       }
       await runReplay(res, setDisplayState, {
+        isMounted,
         buildReplayStates: buildZhengReplayStates,
         buildHumanActionState: buildZhengHumanActionState,
       });
     },
-    [clearSelection],
+    [clearSelection, isMounted],
   );
 
   const { loading, error, exec: callApi, retry } = useGameApi(zhengApi.exec, { onSuccess });


### PR DESCRIPTION
Closes #4447. Follows #4446, which fixed the same shape in `useGameApi`.

Each of these hooks awaits and then writes its own state, so the write can land after the component is gone. React makes that a silent no-op — which is exactly why it stays invisible until the surrounding environment is torn down, where React reaches for `window` and throws from `dispatchSetState`, failing a whole CI run while reporting **every test as passed**.

## A shared helper, and the mistake it encodes

`useIsMounted()` rather than 25 copies of the ref boilerplate. It re-arms the flag **in the effect body**, not via the `useRef(true)` initialiser alone:

```ts
useEffect(() => {
  mountedRef.current = true;          // ← this line is the whole point
  return () => { mountedRef.current = false; };
}, []);
```

`main.tsx` wraps the app in `StrictMode`, which in dev runs mount → cleanup → remount specifically to surface this. A cleanup-only effect latches the flag `false` on a component that is genuinely mounted, and every guarded write is then skipped — which would have left **every game page stuck on its skeleton under `bun run dev`** while production builds, E2E and CI all stayed green. That was caught in review on #4446, and the helper now ships with a StrictMode test that fails against the cleanup-only version.

## Coverage

| | |
|---|---|
| shared bases | `useSolitaireGameBase`, `useTrickGameBase` |
| hint handlers | 20 per-game hooks |
| other state | `useDoppelkopfGame` (loading flag), `useEightOffGame` (its own nonce — the base guards the rest), `useActionLog` (fetch) |
| not a hook | `gameReplay` |

`gameReplay` is a plain function taking `setDisplayState` as a parameter, so it gets an optional `isMounted` in its config and now **bails out of the remaining steps** rather than merely suppressing their writes. A replay sleeps between steps, so it routinely outlives a page the player has left — stopping the timers is the better outcome. Its four callers pass the predicate.

## Guarded, so it cannot drift back

An eighth guard in `bun run check`: a hook that awaits and then calls a setter **it declared via `useState`**, with no `useIsMounted`, fails the build. Scoped to self-declared setters deliberately — passing someone else's setter, or calling an unrelated `set*` method, is not flagged.

Negative-controlled: stripping the guard from `useGolfGame` reports `setHint() runs after the await on line 35` and exits 1.

## Verification

- `bun run test` — **16,017 passed**
- `bun run typecheck`, `bun run check` (all 8 guards) clean
- Re-scan finds **0** remaining `await` → `setState` sites without a guard (was 28 across 25 hooks)
- Biome's `useExhaustiveDependencies` caught my first attempt putting `isMounted` in the wrong dependency array on the four replay callers — `runReplay` sits inside `onSuccess`, not the callback I had matched. Fixed and re-verified rather than autofixed.
