### PR TITLE
test(frontend): add the missing tests for the last four untested game hooks

### DIFF
--- a/frontend/src/hooks/useEuchreGame.test.ts
+++ b/frontend/src/hooks/useEuchreGame.test.ts
@@ -1,0 +1,141 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { createElement } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { euchreApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
+import type { EuchreResponse } from '../types/card';
+import { DEFAULT_EUCHRE_CONFIG, useEuchreGame } from './useEuchreGame';
+
+vi.mock('../api/gameApi', () => ({
+  euchreApi: { exec: vi.fn() },
+}));
+
+const mockExec = vi.mocked(euchreApi.exec);
+
+function createWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+  return ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+/** Minimal response — only the fields these tests read. */
+const baseState = { players: [], phase: 0, message: '' } as unknown as EuchreResponse;
+
+async function mounted() {
+  const rendered = renderHook(() => useEuchreGame(), { wrapper: createWrapper() });
+  await waitFor(() => expect(mockExec).toHaveBeenCalled());
+  mockExec.mockClear();
+  mockExec.mockResolvedValue(baseState);
+  return rendered;
+}
+
+describe('useEuchreGame', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExec.mockResolvedValue(baseState);
+  });
+
+  it('resets with the default config on mount', async () => {
+    renderHook(() => useEuchreGame(), { wrapper: createWrapper() });
+    await waitFor(() =>
+      expect(mockExec).toHaveBeenCalledWith('reset', undefined, undefined, undefined, DEFAULT_EUCHRE_CONFIG),
+    );
+  });
+
+  it('orders up, optionally going alone', async () => {
+    const { result } = await mounted();
+    act(() => result.current.handleOrderUp(true));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('orderup', undefined, undefined, true));
+  });
+
+  it('passes on the bid', async () => {
+    const { result } = await mounted();
+    act(() => result.current.handlePass());
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('pass'));
+  });
+
+  it('calls trump with the chosen suit', async () => {
+    const { result } = await mounted();
+    act(() => result.current.handleCallTrump(2, false));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('calltrump', undefined, 2, false));
+  });
+
+  // The dealer discards exactly one card, so the handler must refuse anything else
+  // rather than send a malformed command.
+  it('discards only when exactly one card is selected', async () => {
+    const { result } = await mounted();
+    act(() => result.current.handleDiscard());
+    await flushPendingDispatch();
+    expect(mockExec).not.toHaveBeenCalled();
+
+    act(() => result.current.toggleCard(3));
+    act(() => result.current.handleDiscard());
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('discard', 3));
+  });
+
+  it('plays only when exactly one card is selected', async () => {
+    const { result } = await mounted();
+    act(() => result.current.handlePlay());
+    await flushPendingDispatch();
+    expect(mockExec).not.toHaveBeenCalled();
+
+    act(() => result.current.toggleCard(1));
+    act(() => result.current.handlePlay());
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', 1));
+  });
+
+  it('advances the trick and the round', async () => {
+    const { result } = await mounted();
+    act(() => result.current.handleNextTrick());
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('next'));
+    act(() => result.current.handleNextRound());
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('nextround'));
+  });
+
+  it('stores the hint the server returns and clears any error', async () => {
+    const hint = { cardIndices: [1], reason: 'follow suit' };
+    const { result } = await mounted();
+    mockExec.mockResolvedValue({ ...baseState, hint } as unknown as EuchreResponse);
+    await act(async () => {
+      await result.current.handleHint();
+    });
+    expect(mockExec).toHaveBeenCalledWith('hint');
+    expect(result.current.hint).toEqual(hint);
+    expect(result.current.hintError).toBeNull();
+    expect(result.current.hintLoading).toBe(false);
+  });
+
+  it('normalises a response with no hint to null', async () => {
+    const { result } = await mounted();
+    await act(async () => {
+      await result.current.handleHint();
+    });
+    expect(result.current.hint).toBeNull();
+  });
+
+  it('reports a failed hint request without stranding hintLoading', async () => {
+    const { result } = await mounted();
+    mockExec.mockRejectedValue(new Error('network'));
+    await act(async () => {
+      await result.current.handleHint();
+    });
+    expect(result.current.hintError).toEqual(expect.any(String));
+    expect(result.current.hintLoading).toBe(false);
+  });
+
+  it('clears a stale hint once a command succeeds', async () => {
+    const { result } = await mounted();
+    mockExec.mockResolvedValue({ ...baseState, hint: { cardIndices: [0], reason: 'x' } } as unknown as EuchreResponse);
+    await act(async () => {
+      await result.current.handleHint();
+    });
+    expect(result.current.hint).not.toBeNull();
+    mockExec.mockResolvedValue(baseState);
+    await act(async () => {
+      await result.current.apiExec('next');
+    });
+    expect(result.current.hint).toBeNull();
+  });
+});

--- a/frontend/src/hooks/useMightyGame.test.ts
+++ b/frontend/src/hooks/useMightyGame.test.ts
@@ -1,0 +1,171 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { createElement } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { mightyApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
+import type { MightyResponse } from '../types/card';
+import { DEFAULT_MIGHTY_CONFIG, useMightyGame } from './useMightyGame';
+
+vi.mock('../api/gameApi', () => ({
+  mightyApi: { exec: vi.fn() },
+}));
+
+const mockExec = vi.mocked(mightyApi.exec);
+
+function createWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+  return ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+/** Minimal response — only the fields these tests read. */
+const baseState = { players: [], phase: 0, message: '' } as unknown as MightyResponse;
+
+async function mounted() {
+  const rendered = renderHook(() => useMightyGame(), { wrapper: createWrapper() });
+  await waitFor(() => expect(mockExec).toHaveBeenCalled());
+  mockExec.mockClear();
+  mockExec.mockResolvedValue(baseState);
+  return rendered;
+}
+
+describe('useMightyGame', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExec.mockResolvedValue(baseState);
+  });
+
+  // Mighty's command signature is wide, so the config rides in the 10th slot. Pinning
+  // the position matters: a signature change that silently shifted it would leave the
+  // game resetting with server defaults instead of the configured ones.
+  it('resets with the default config on mount', async () => {
+    renderHook(() => useMightyGame(), { wrapper: createWrapper() });
+    await waitFor(() => expect(mockExec).toHaveBeenCalled());
+    const resetCall = mockExec.mock.calls.find((call) => call[0] === 'reset');
+    expect(resetCall).toBeDefined();
+    expect(resetCall?.[9]).toEqual(DEFAULT_MIGHTY_CONFIG);
+  });
+
+  it('submits a bid, carrying the no-trump flag', async () => {
+    const { result } = await mounted();
+    act(() => result.current.handleBid(15, true));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('bid', 15, true));
+  });
+
+  it('passes by bidding zero', async () => {
+    const { result } = await mounted();
+    act(() => result.current.handlePass());
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('bid', 0, false));
+  });
+
+  it('declares trump together with the friend card', async () => {
+    const { result } = await mounted();
+    act(() => result.current.handleTrumpAndFriend(1, 3, 14));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('trump', undefined, undefined, undefined, 1, 3, 14));
+  });
+
+  // Mighty's declarer discards exactly three cards; anything else must not be sent.
+  it('exchanges only when exactly three discards are given', async () => {
+    const { result } = await mounted();
+    act(() => result.current.handleExchange([1, 2]));
+    await flushPendingDispatch();
+    expect(mockExec).not.toHaveBeenCalled();
+
+    act(() => result.current.handleExchange([1, 2, 3]));
+    await waitFor(() =>
+      expect(mockExec).toHaveBeenCalledWith(
+        'exchange',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        [1, 2, 3],
+      ),
+    );
+  });
+
+  it('plays only when exactly one card is selected', async () => {
+    const { result } = await mounted();
+    act(() => result.current.handlePlay());
+    await flushPendingDispatch();
+    expect(mockExec).not.toHaveBeenCalled();
+
+    act(() => result.current.toggleCard(0));
+    act(() => result.current.handlePlay());
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', undefined, undefined, 0));
+  });
+
+  // Leading the joker names the suit everyone must follow, so the suit has to reach
+  // the server alongside the card.
+  it('leads the joker with the nominated suit, and only with a card selected', async () => {
+    const { result } = await mounted();
+    act(() => result.current.handleJokerLead(2));
+    await flushPendingDispatch();
+    expect(mockExec).not.toHaveBeenCalled();
+
+    act(() => result.current.toggleCard(6));
+    act(() => result.current.handleJokerLead(2));
+    await waitFor(() =>
+      expect(mockExec).toHaveBeenCalledWith(
+        'jokerlead',
+        undefined,
+        undefined,
+        6,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        2,
+      ),
+    );
+  });
+
+  it('stores the hint the server returns and clears any error', async () => {
+    const hint = { cardIndices: [1], reason: 'follow suit' };
+    const { result } = await mounted();
+    mockExec.mockResolvedValue({ ...baseState, hint } as unknown as MightyResponse);
+    await act(async () => {
+      await result.current.handleHint();
+    });
+    expect(mockExec).toHaveBeenCalledWith('hint');
+    expect(result.current.hint).toEqual(hint);
+    expect(result.current.hintError).toBeNull();
+    expect(result.current.hintLoading).toBe(false);
+  });
+
+  it('normalises a response with no hint to null', async () => {
+    const { result } = await mounted();
+    await act(async () => {
+      await result.current.handleHint();
+    });
+    expect(result.current.hint).toBeNull();
+  });
+
+  it('reports a failed hint request without stranding hintLoading', async () => {
+    const { result } = await mounted();
+    mockExec.mockRejectedValue(new Error('network'));
+    await act(async () => {
+      await result.current.handleHint();
+    });
+    expect(result.current.hintError).toEqual(expect.any(String));
+    expect(result.current.hintLoading).toBe(false);
+  });
+
+  it('clears a stale hint once a command succeeds', async () => {
+    const { result } = await mounted();
+    mockExec.mockResolvedValue({ ...baseState, hint: { cardIndices: [0], reason: 'x' } } as unknown as MightyResponse);
+    await act(async () => {
+      await result.current.handleHint();
+    });
+    expect(result.current.hint).not.toBeNull();
+    mockExec.mockResolvedValue(baseState);
+    await act(async () => {
+      await result.current.apiCall('next');
+    });
+    expect(result.current.hint).toBeNull();
+  });
+});

--- a/frontend/src/hooks/useNapoleonGame.test.ts
+++ b/frontend/src/hooks/useNapoleonGame.test.ts
@@ -1,0 +1,144 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { createElement } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { napoleonApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
+import type { NapoleonResponse } from '../types/card';
+import { DEFAULT_NAPOLEON_CONFIG, useNapoleonGame } from './useNapoleonGame';
+
+vi.mock('../api/gameApi', () => ({
+  napoleonApi: { exec: vi.fn() },
+}));
+
+const mockExec = vi.mocked(napoleonApi.exec);
+
+function createWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+  return ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+/** Minimal response — only the fields these tests read. */
+const baseState = { players: [], phase: 0, message: '' } as unknown as NapoleonResponse;
+
+async function mounted() {
+  const rendered = renderHook(() => useNapoleonGame(), { wrapper: createWrapper() });
+  await waitFor(() => expect(mockExec).toHaveBeenCalled());
+  mockExec.mockClear();
+  mockExec.mockResolvedValue(baseState);
+  return rendered;
+}
+
+describe('useNapoleonGame', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExec.mockResolvedValue(baseState);
+  });
+
+  it('resets with the default config on mount', async () => {
+    renderHook(() => useNapoleonGame(), { wrapper: createWrapper() });
+    await waitFor(() =>
+      expect(mockExec).toHaveBeenCalledWith(
+        'reset',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        DEFAULT_NAPOLEON_CONFIG,
+      ),
+    );
+  });
+
+  it('submits a bid', async () => {
+    const { result } = await mounted();
+    act(() => result.current.handleBid(14));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('bid', 14));
+  });
+
+  // Passing is the same command with a zero bid, which is worth pinning: a future
+  // refactor introducing a separate 'pass' command would break the server contract.
+  it('passes by bidding zero', async () => {
+    const { result } = await mounted();
+    act(() => result.current.handlePass());
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('bid', 0));
+  });
+
+  it('declares trump together with the adjutant card', async () => {
+    const { result } = await mounted();
+    act(() => result.current.handleTrumpDeclaration(1, 2, 13));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('trump', undefined, 1, 2, 13));
+  });
+
+  it('exchanges a chosen discard', async () => {
+    const { result } = await mounted();
+    act(() => result.current.handleExchange(4));
+    await waitFor(() =>
+      expect(mockExec).toHaveBeenCalledWith('exchange', undefined, undefined, undefined, undefined, 4),
+    );
+  });
+
+  it('plays only when exactly one card is selected', async () => {
+    const { result } = await mounted();
+    act(() => result.current.handlePlay());
+    await flushPendingDispatch();
+    expect(mockExec).not.toHaveBeenCalled();
+
+    act(() => result.current.toggleCard(5));
+    act(() => result.current.handlePlay());
+    await waitFor(() =>
+      expect(mockExec).toHaveBeenCalledWith('play', undefined, undefined, undefined, undefined, undefined, 5),
+    );
+  });
+
+  it('stores the hint the server returns and clears any error', async () => {
+    const hint = { cardIndices: [1], reason: 'follow suit' };
+    const { result } = await mounted();
+    mockExec.mockResolvedValue({ ...baseState, hint } as unknown as NapoleonResponse);
+    await act(async () => {
+      await result.current.handleHint();
+    });
+    expect(mockExec).toHaveBeenCalledWith('hint');
+    expect(result.current.hint).toEqual(hint);
+    expect(result.current.hintError).toBeNull();
+    expect(result.current.hintLoading).toBe(false);
+  });
+
+  it('normalises a response with no hint to null', async () => {
+    const { result } = await mounted();
+    await act(async () => {
+      await result.current.handleHint();
+    });
+    expect(result.current.hint).toBeNull();
+  });
+
+  it('reports a failed hint request without stranding hintLoading', async () => {
+    const { result } = await mounted();
+    mockExec.mockRejectedValue(new Error('network'));
+    await act(async () => {
+      await result.current.handleHint();
+    });
+    expect(result.current.hintError).toEqual(expect.any(String));
+    expect(result.current.hintLoading).toBe(false);
+  });
+
+  it('clears a stale hint once a command succeeds', async () => {
+    const { result } = await mounted();
+    mockExec.mockResolvedValue({
+      ...baseState,
+      hint: { cardIndices: [0], reason: 'x' },
+    } as unknown as NapoleonResponse);
+    await act(async () => {
+      await result.current.handleHint();
+    });
+    expect(result.current.hint).not.toBeNull();
+    mockExec.mockResolvedValue(baseState);
+    await act(async () => {
+      await result.current.apiExec('next');
+    });
+    expect(result.current.hint).toBeNull();
+  });
+});

--- a/frontend/src/hooks/useOhHellGame.test.ts
+++ b/frontend/src/hooks/useOhHellGame.test.ts
@@ -1,0 +1,120 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { createElement } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ohHellApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
+import type { OhHellResponse } from '../types/card';
+import { DEFAULT_OH_HELL_CONFIG, useOhHellGame } from './useOhHellGame';
+
+vi.mock('../api/gameApi', () => ({
+  ohHellApi: { exec: vi.fn() },
+}));
+
+const mockExec = vi.mocked(ohHellApi.exec);
+
+function createWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+  return ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+/** Minimal response — only the fields these tests read. */
+const baseState = { players: [], phase: 0, message: '' } as unknown as OhHellResponse;
+
+async function mounted() {
+  const rendered = renderHook(() => useOhHellGame(), { wrapper: createWrapper() });
+  await waitFor(() => expect(mockExec).toHaveBeenCalled());
+  mockExec.mockClear();
+  mockExec.mockResolvedValue(baseState);
+  return rendered;
+}
+
+describe('useOhHellGame', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExec.mockResolvedValue(baseState);
+  });
+
+  it('resets with the default config on mount', async () => {
+    renderHook(() => useOhHellGame(), { wrapper: createWrapper() });
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined, undefined, DEFAULT_OH_HELL_CONFIG));
+  });
+
+  it('submits a bid', async () => {
+    const { result } = await mounted();
+    act(() => result.current.handleBid(3));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('bid', 3));
+  });
+
+  it('submits a zero bid, which is a legal call rather than a no-op', async () => {
+    const { result } = await mounted();
+    act(() => result.current.handleBid(0));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('bid', 0));
+  });
+
+  it('plays only when exactly one card is selected', async () => {
+    const { result } = await mounted();
+    act(() => result.current.handlePlay());
+    await flushPendingDispatch();
+    expect(mockExec).not.toHaveBeenCalled();
+
+    act(() => result.current.toggleCard(2));
+    act(() => result.current.handlePlay());
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', undefined, 2));
+  });
+
+  it('advances the trick and the round', async () => {
+    const { result } = await mounted();
+    act(() => result.current.handleNextTrick());
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('next'));
+    act(() => result.current.handleNextRound());
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('nextround'));
+  });
+
+  it('stores the hint the server returns and clears any error', async () => {
+    const hint = { cardIndices: [1], reason: 'follow suit' };
+    const { result } = await mounted();
+    mockExec.mockResolvedValue({ ...baseState, hint } as unknown as OhHellResponse);
+    await act(async () => {
+      await result.current.handleHint();
+    });
+    expect(mockExec).toHaveBeenCalledWith('hint');
+    expect(result.current.hint).toEqual(hint);
+    expect(result.current.hintError).toBeNull();
+    expect(result.current.hintLoading).toBe(false);
+  });
+
+  it('normalises a response with no hint to null', async () => {
+    const { result } = await mounted();
+    await act(async () => {
+      await result.current.handleHint();
+    });
+    expect(result.current.hint).toBeNull();
+  });
+
+  it('reports a failed hint request without stranding hintLoading', async () => {
+    const { result } = await mounted();
+    mockExec.mockRejectedValue(new Error('network'));
+    await act(async () => {
+      await result.current.handleHint();
+    });
+    expect(result.current.hintError).toEqual(expect.any(String));
+    expect(result.current.hintLoading).toBe(false);
+  });
+
+  it('clears a stale hint once a command succeeds', async () => {
+    const { result } = await mounted();
+    mockExec.mockResolvedValue({ ...baseState, hint: { cardIndices: [0], reason: 'x' } } as unknown as OhHellResponse);
+    await act(async () => {
+      await result.current.handleHint();
+    });
+    expect(result.current.hint).not.toBeNull();
+    mockExec.mockResolvedValue(baseState);
+    await act(async () => {
+      await result.current.exec('next');
+    });
+    expect(result.current.hint).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #4449. `useEuchreGame`, `useOhHellGame`, `useNapoleonGame` and `useMightyGame` had **no test file at all**; `useWizardGame` got its own in #4448.

41 tests. The plumbing half asserts each handler dispatches the right command and arguments; the valuable half is real conditional logic and two contracts a refactor could plausibly break:

| what | why it matters |
|---|---|
| Euchre discards / plays only with **exactly one** card selected | otherwise a malformed command reaches the server |
| Mighty exchanges only with **exactly three** discards; leads the joker only with a card selected | same, and the joker's nominated suit must travel with the card |
| passing is `bid 0`, not a separate command (Mighty, Napoleon) | a refactor introducing a `pass` command would break the server contract silently |
| Mighty's config rides in the **10th** argument slot | shifting it would reset games with server defaults instead of the configured ones |

## I wrote these tests wrong first, and mutation testing caught it

The guard tests originally used a synchronous `expect(mockExec).not.toHaveBeenCalled()`. Mutation testing showed **all of them passing against deliberately broken guards**:

| mutation | before | after |
|---|---|---|
| Euchre discards regardless of selection size | 11 passed ❌ | `× discards only when exactly one card is selected` ✅ |
| Mighty exchanges with two discards | 11 passed ❌ | `× exchanges only when exactly three discards are given` ✅ |

I had reintroduced the exact vacuous pattern #4443 existed to remove — `apiExec` dispatches through react-query's microtask, so the assertion runs before the call can appear. They now await `flushPendingDispatch()` first.

## Which exposed a gap in #4443's sweep

#4443's detector keyed on `fireEvent`/`userEvent` preceding the assertion. Hook tests use `act(...)` instead, so that whole family was invisible to it — my "0 remaining" claim there was scoped to a pattern I had not realised was partial.

Re-scanning with `act(` included finds **75 vacuous assertions across ~60 hook test files**. Filed separately (same fix, same triage caveat: some may turn red, and a red one is a finding rather than a test bug) rather than folded into a PR about adding missing tests.

## Verification

- `bun run test` — **16,081 passed**
- `bun run typecheck`, `bun run check` (all 8 guards) clean
- Both guard mutations above confirmed failing after the fix
- Test-only change; no production files touched
