### PR TITLE
test(frontend): make the remaining 76 "not called" assertions real, and guard the pattern

### DIFF
--- a/frontend/scripts/check-design-tokens.mjs
+++ b/frontend/scripts/check-design-tokens.mjs
@@ -510,3 +510,62 @@ if (unmountViolations.length > 0) {
 }
 
 console.log(`unmount-safety: OK (${hookFiles.length} hooks; every await -> own-state write is guarded).`);
+
+// --- Vacuous "not called" assertions in tests (issues #4439, #4451) ---------
+//
+// `expect(<apiMock>).not.toHaveBeenCalled()` placed straight after an interaction
+// passes whether or not the action fired: `exec` dispatches through react-query's
+// `mutateAsync`, which invokes the mutation function on a microtask. The assertion
+// runs first and sees nothing, so it asserts nothing. #4443 fixed 148 of these and
+// found a real 3-page bug doing so; #4451 fixed 76 more that its detector could not
+// see, because that one keyed on `fireEvent` and missed the `act(...)` form used in
+// hook tests. The fix is `await flushPendingDispatch()` before the assertion.
+//
+// Checked per site, and the interaction list is deliberately broad — three widenings
+// (fireEvent -> act -> raw .click()) each turned up sites the previous pass called
+// clean, so a narrow matcher here reads as coverage it does not provide.
+const vacuousViolations = [];
+const INTERACTION = /fireEvent|userEvent|\bact\(|\.click\(\)|\.type\(/;
+async function collectTests(dir) {
+  const out = [];
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...(await collectTests(full)));
+    else if (/\.test\.tsx?$/.test(entry.name)) out.push(full);
+  }
+  return out;
+}
+for (const file of await collectTests(SRC_DIR)) {
+  const text = await readFile(file, 'utf8');
+  // Only mocks of a game API — a plain `vi.fn()` prop callback IS synchronous and
+  // needs no flush, so flagging those would be noise that gets the guard switched off.
+  const apiMocks = new Set([...text.matchAll(/const (\w+) = vi\.mocked\((\w+Api)\.\w+\)/g)].map((m) => m[1]));
+  if (apiMocks.size === 0) continue;
+  const lines = text.split('\n');
+  for (let i = 0; i < lines.length; i += 1) {
+    const m = /^\s*expect\((\w+)\)\.not\.toHaveBeenCalled/.exec(lines[i]);
+    if (!m || !apiMocks.has(m[1])) continue;
+    for (let j = i - 1; j >= Math.max(0, i - 8); j -= 1) {
+      // Already flushed. Advancing fake timers counts: usePokerGame's debounce test
+      // drives the pending timer with `vi.advanceTimersByTime(300)` rather than an
+      // await, and its assertion is meaningful precisely because of that — flagging
+      // it would be the guard crying wolf.
+      if (/\bawait\b|advanceTimersByTime|runAllTimers|runOnlyPendingTimers/.test(lines[j])) break;
+      if (INTERACTION.test(lines[j])) {
+        vacuousViolations.push({ file: relative(ROOT, file), line: i + 1, mock: m[1] });
+        break;
+      }
+    }
+  }
+}
+
+if (vacuousViolations.length > 0) {
+  console.error('\nVacuous "not called" assertions (no await between the interaction and the assertion):\n');
+  for (const v of vacuousViolations) {
+    console.error(`  ${v.file}:${v.line}  expect(${v.mock}).not.toHaveBeenCalled() cannot fail here`);
+  }
+  console.error('\nAwait flushPendingDispatch() first. See issues #4439 and #4451.');
+  process.exit(1);
+}
+
+console.log('vacuous-assertions: OK (every "not called" assertion on an api mock is awaited first).');

--- a/frontend/scripts/check-design-tokens.mjs
+++ b/frontend/scripts/check-design-tokens.mjs
@@ -551,6 +551,12 @@ for (const file of await collectTests(SRC_DIR)) {
       // await, and its assertion is meaningful precisely because of that — flagging
       // it would be the guard crying wolf.
       if (/\bawait\b|advanceTimersByTime|runAllTimers|runOnlyPendingTimers/.test(lines[j])) break;
+      // Stop at the enclosing test's opening line. Without this the window walks into
+      // the PREVIOUS test block and can attribute its interaction to an assertion
+      // that legitimately has none of its own ("exec is not called on mount"), failing
+      // the build for correct code. The unmount-safety guard above needed the same
+      // boundary for the same reason; I did not carry the lesson across the first time.
+      if (/^\s*(it|test|describe)[.(]/.test(lines[j])) break;
       if (INTERACTION.test(lines[j])) {
         vacuousViolations.push({ file: relative(ROOT, file), line: i + 1, mock: m[1] });
         break;

--- a/frontend/src/hooks/useBakersDozenGame.test.ts
+++ b/frontend/src/hooks/useBakersDozenGame.test.ts
@@ -3,6 +3,7 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { bakersDozenApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import type { BakersDozenResponse } from '../types/card';
 import { useBakersDozenGame } from './useBakersDozenGame';
 
@@ -120,6 +121,7 @@ describe('useBakersDozenGame', () => {
 
     act(() => result.current.handleSelectTarget({ zone: 'tableau', col: 1 }));
     // No move call should have been issued.
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('move', expect.anything(), expect.anything());
   });
 

--- a/frontend/src/hooks/useBeleagueredCastleGame.test.ts
+++ b/frontend/src/hooks/useBeleagueredCastleGame.test.ts
@@ -3,6 +3,7 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { beleagueredCastleApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import type { BeleagueredCastleResponse } from '../types/card';
 import { useBeleagueredCastleGame } from './useBeleagueredCastleGame';
 
@@ -119,6 +120,7 @@ describe('useBeleagueredCastleGame', () => {
     mockExec.mockClear();
 
     act(() => result.current.handleSelectTarget({ zone: 'tableau', col: 1 }));
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('move', expect.anything(), expect.anything());
   });
 

--- a/frontend/src/hooks/useBeziqueGame.test.ts
+++ b/frontend/src/hooks/useBeziqueGame.test.ts
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { beziqueApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { makeBeziqueState } from '../test/stateFactories';
 import { DEFAULT_BEZIQUE_CONFIG, useBeziqueGame } from './useBeziqueGame';
 
@@ -32,9 +33,10 @@ describe('useBeziqueGame', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', { config: DEFAULT_BEZIQUE_CONFIG }));
   });
 
-  it('handlePlay does nothing without exactly one selected card', () => {
+  it('handlePlay does nothing without exactly one selected card', async () => {
     const { result } = renderHook(() => useBeziqueGame(), { wrapper: createWrapper() });
     act(() => result.current.handlePlay());
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/hooks/useBridgeGame.test.ts
+++ b/frontend/src/hooks/useBridgeGame.test.ts
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { bridgeApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import type { BridgeResponse } from '../types/card';
 import { DEFAULT_BRIDGE_CONFIG, useBridgeGame } from './useBridgeGame';
 
@@ -91,6 +92,7 @@ describe('useBridgeGame', () => {
 
     mockExec.mockClear();
     act(() => result.current.handlePlay());
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/hooks/useCalabresellaGame.test.ts
+++ b/frontend/src/hooks/useCalabresellaGame.test.ts
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { calabresellaApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { makeCalabresellaState } from '../test/stateFactories';
 import { DEFAULT_CALABRESELLA_CONFIG, useCalabresellaGame } from './useCalabresellaGame';
 
@@ -40,9 +41,10 @@ describe('useCalabresellaGame', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('bid', { bid: 0 }));
   });
 
-  it('handleDiscard does nothing without exactly one selected card', () => {
+  it('handleDiscard does nothing without exactly one selected card', async () => {
     const { result } = renderHook(() => useCalabresellaGame(), { wrapper: createWrapper() });
     act(() => result.current.handleDiscard());
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 
@@ -53,9 +55,10 @@ describe('useCalabresellaGame', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('discard', { cardIndex: 1 }));
   });
 
-  it('handlePlay does nothing without exactly one selected card', () => {
+  it('handlePlay does nothing without exactly one selected card', async () => {
     const { result } = renderHook(() => useCalabresellaGame(), { wrapper: createWrapper() });
     act(() => result.current.handlePlay());
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/hooks/useCassinoGame.test.tsx
+++ b/frontend/src/hooks/useCassinoGame.test.tsx
@@ -48,6 +48,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 // renderHook needs a wrapper element, so we forward the providers manually.
 import type { ReactNode } from 'react';
 import { MemoryRouter } from 'react-router';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 
 function Hookwrapper({ children }: { children: ReactNode }) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -118,6 +119,7 @@ describe('useCassinoGame', () => {
     act(() => {
       result.current.playTake();
     });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 
@@ -128,6 +130,7 @@ describe('useCassinoGame', () => {
     act(() => {
       result.current.playBuild();
     });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 
@@ -138,6 +141,7 @@ describe('useCassinoGame', () => {
     act(() => {
       result.current.playTrail();
     });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/hooks/useCourtPieceGame.test.ts
+++ b/frontend/src/hooks/useCourtPieceGame.test.ts
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { courtPieceApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { makeCourtPieceState } from '../test/stateFactories';
 import { DEFAULT_COURT_PIECE_CONFIG, useCourtPieceGame } from './useCourtPieceGame';
 
@@ -38,9 +39,10 @@ describe('useCourtPieceGame', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('trump', { trumpSuit: 3 }));
   });
 
-  it('handlePlay does nothing without exactly one selected card', () => {
+  it('handlePlay does nothing without exactly one selected card', async () => {
     const { result } = renderHook(() => useCourtPieceGame(), { wrapper: createWrapper() });
     act(() => result.current.handlePlay());
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/hooks/useCrazyEightsGame.test.ts
+++ b/frontend/src/hooks/useCrazyEightsGame.test.ts
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { crazyeightsApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import type { CrazyEightsResponse } from '../types/card';
 import { useCrazyEightsGame } from './useCrazyEightsGame';
 
@@ -84,6 +85,7 @@ describe('useCrazyEightsGame', () => {
       result.current.handlePlay();
     });
 
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 
@@ -101,6 +103,7 @@ describe('useCrazyEightsGame', () => {
       result.current.handlePlay();
     });
 
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/hooks/useEcarteGame.test.ts
+++ b/frontend/src/hooks/useEcarteGame.test.ts
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ecarteApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { makeEcarteState } from '../test/stateFactories';
 import { DEFAULT_ECARTE_CONFIG, useEcarteGame } from './useEcarteGame';
 
@@ -32,9 +33,10 @@ describe('useEcarteGame', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', { config: DEFAULT_ECARTE_CONFIG }));
   });
 
-  it('handlePlay does nothing without exactly one selected card', () => {
+  it('handlePlay does nothing without exactly one selected card', async () => {
     const { result } = renderHook(() => useEcarteGame(), { wrapper: createWrapper() });
     act(() => result.current.handlePlay());
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/hooks/useEscobaGame.test.ts
+++ b/frontend/src/hooks/useEscobaGame.test.ts
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { escobaApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { makeEscobaState } from '../test/stateFactories';
 import { useEscobaGame } from './useEscobaGame';
 
@@ -64,6 +65,7 @@ describe('useEscobaGame', () => {
 
     mockExec.mockClear();
     act(() => result.current.play());
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/hooks/useFlowerGardenGame.test.ts
+++ b/frontend/src/hooks/useFlowerGardenGame.test.ts
@@ -3,6 +3,7 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { flowerGardenApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import type { FlowerGardenResponse } from '../types/card';
 import { useFlowerGardenGame } from './useFlowerGardenGame';
 
@@ -126,6 +127,7 @@ describe('useFlowerGardenGame', () => {
     mockExec.mockClear();
 
     act(() => result.current.handleSelectTarget({ zone: 'tableau', col: 1 }));
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('move', expect.anything(), expect.anything());
   });
 

--- a/frontend/src/hooks/useFortyFivesGame.test.ts
+++ b/frontend/src/hooks/useFortyFivesGame.test.ts
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fortyFivesApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { makeFortyFivesState } from '../test/stateFactories';
 import { DEFAULT_FORTY_FIVES_CONFIG, useFortyFivesGame } from './useFortyFivesGame';
 
@@ -38,9 +39,10 @@ describe('useFortyFivesGame', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('bid', { bid: 15 }));
   });
 
-  it('handlePlay does nothing without exactly one selected card', () => {
+  it('handlePlay does nothing without exactly one selected card', async () => {
     const { result } = renderHook(() => useFortyFivesGame(), { wrapper: createWrapper() });
     act(() => result.current.handlePlay());
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/hooks/useFreeCellGame.test.ts
+++ b/frontend/src/hooks/useFreeCellGame.test.ts
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { freecellApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import type { FreeCellResponse } from '../types/card';
 import { useFreeCellGame } from './useFreeCellGame';
 
@@ -336,6 +337,7 @@ describe('useFreeCellGame', () => {
       result.current.handleSelectTarget({ zone: 'foundation', col: 0 });
     });
 
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/hooks/useGaigelGame.test.ts
+++ b/frontend/src/hooks/useGaigelGame.test.ts
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { gaigelApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import type { GaigelResponse } from '../types/card';
 import { GaigelPhase } from '../types/phases';
 import { DEFAULT_GAIGEL_CONFIG, useGaigelGame } from './useGaigelGame';
@@ -74,6 +75,7 @@ describe('useGaigelGame', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalled());
     mockExec.mockClear();
     act(() => result.current.handlePlay());
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/hooks/useGinRummyGame.test.ts
+++ b/frontend/src/hooks/useGinRummyGame.test.ts
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ginrummyApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import type { GinRummyResponse } from '../types/card';
 import { useGinRummyGame } from './useGinRummyGame';
 
@@ -111,6 +112,7 @@ describe('useGinRummyGame', () => {
       result.current.handleDiscard();
     });
 
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 
@@ -128,6 +130,7 @@ describe('useGinRummyGame', () => {
       result.current.handleDiscard();
     });
 
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 
@@ -157,6 +160,7 @@ describe('useGinRummyGame', () => {
       result.current.handleKnock();
     });
 
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 
@@ -174,6 +178,7 @@ describe('useGinRummyGame', () => {
       result.current.handleKnock();
     });
 
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/hooks/useGoFishGame.test.ts
+++ b/frontend/src/hooks/useGoFishGame.test.ts
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { goFishApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import type { GoFishResponse } from '../types/card';
 import { GoFishPhase } from '../types/phases';
 import { useGoFishGame } from './useGoFishGame';
@@ -119,6 +120,7 @@ describe('useGoFishGame', () => {
       result.current.handleAsk();
     });
 
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 
@@ -134,6 +136,7 @@ describe('useGoFishGame', () => {
       result.current.handleAsk();
     });
 
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/hooks/useHeartsGame.test.ts
+++ b/frontend/src/hooks/useHeartsGame.test.ts
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { heartsApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import type { HeartsResponse } from '../types/card';
 import { useHeartsGame } from './useHeartsGame';
 
@@ -142,6 +143,7 @@ describe('useHeartsGame', () => {
       result.current.handlePlay();
     });
 
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 
@@ -159,6 +161,7 @@ describe('useHeartsGame', () => {
       result.current.handlePlay();
     });
 
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/hooks/useIndianRummyGame.test.ts
+++ b/frontend/src/hooks/useIndianRummyGame.test.ts
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { indianRummyApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import type { IndianRummyResponse } from '../types/card';
 import { useIndianRummyGame } from './useIndianRummyGame';
 
@@ -127,6 +128,7 @@ describe('useIndianRummyGame', () => {
     act(() => {
       result.current.handleDiscard();
     });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 
@@ -142,6 +144,7 @@ describe('useIndianRummyGame', () => {
     act(() => {
       result.current.handleDiscard();
     });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 
@@ -168,6 +171,7 @@ describe('useIndianRummyGame', () => {
     act(() => {
       result.current.handleDeclare();
     });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/hooks/useJassGame.test.ts
+++ b/frontend/src/hooks/useJassGame.test.ts
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { jassApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import type { JassResponse } from '../types/card';
 import { JassPhase } from '../types/phases';
 import { DEFAULT_JASS_CONFIG, useJassGame } from './useJassGame';
@@ -88,6 +89,7 @@ describe('useJassGame', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalled());
     mockExec.mockClear();
     act(() => result.current.handlePlay());
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/hooks/useKingAlbertGame.test.ts
+++ b/frontend/src/hooks/useKingAlbertGame.test.ts
@@ -3,6 +3,7 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { kingAlbertApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import type { KingAlbertResponse } from '../types/card';
 import { useKingAlbertGame } from './useKingAlbertGame';
 
@@ -126,6 +127,7 @@ describe('useKingAlbertGame', () => {
     mockExec.mockClear();
 
     act(() => result.current.handleSelectTarget({ zone: 'tableau', col: 1 }));
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('move', expect.anything(), expect.anything());
   });
 

--- a/frontend/src/hooks/useKingGame.test.ts
+++ b/frontend/src/hooks/useKingGame.test.ts
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { kingApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { makeKingState } from '../test/stateFactories';
 import { DEFAULT_KING_CONFIG, useKingGame } from './useKingGame';
 
@@ -44,9 +45,10 @@ describe('useKingGame', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('contract', { contract: 6, trumpSuit: 3 }));
   });
 
-  it('handlePlay does nothing without exactly one selected card', () => {
+  it('handlePlay does nothing without exactly one selected card', async () => {
     const { result } = renderHook(() => useKingGame(), { wrapper: createWrapper() });
     act(() => result.current.handlePlay());
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/hooks/useKlaverjasGame.test.ts
+++ b/frontend/src/hooks/useKlaverjasGame.test.ts
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { klaverjasApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { makeKlaverjasState } from '../test/stateFactories';
 import { DEFAULT_KLAVERJAS_CONFIG, useKlaverjasGame } from './useKlaverjasGame';
 
@@ -32,9 +33,10 @@ describe('useKlaverjasGame', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', { config: DEFAULT_KLAVERJAS_CONFIG }));
   });
 
-  it('handlePlay does nothing without exactly one selected card', () => {
+  it('handlePlay does nothing without exactly one selected card', async () => {
     const { result } = renderHook(() => useKlaverjasGame(), { wrapper: createWrapper() });
     act(() => result.current.handlePlay());
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/hooks/useKlondikeGame.test.ts
+++ b/frontend/src/hooks/useKlondikeGame.test.ts
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { klondikeApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import type { KlondikeResponse } from '../types/card';
 import { useKlondikeGame } from './useKlondikeGame';
 
@@ -219,6 +220,7 @@ describe('useKlondikeGame', () => {
       result.current.handleSelectTarget({ zone: 'tableau', col: 3 });
     });
 
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/hooks/useKnockoutWhistGame.test.ts
+++ b/frontend/src/hooks/useKnockoutWhistGame.test.ts
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { knockoutWhistApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { makeKnockoutWhistState } from '../test/stateFactories';
 import { DEFAULT_KNOCKOUT_WHIST_CONFIG, useKnockoutWhistGame } from './useKnockoutWhistGame';
 
@@ -32,9 +33,10 @@ describe('useKnockoutWhistGame', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', { config: DEFAULT_KNOCKOUT_WHIST_CONFIG }));
   });
 
-  it('handlePlay does nothing without exactly one selected card', () => {
+  it('handlePlay does nothing without exactly one selected card', async () => {
     const { result } = renderHook(() => useKnockoutWhistGame(), { wrapper: createWrapper() });
     act(() => result.current.handlePlay());
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/hooks/useMacauGame.test.ts
+++ b/frontend/src/hooks/useMacauGame.test.ts
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { macauApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import type { MacauResponse } from '../types/card';
 import { useMacauGame } from './useMacauGame';
 
@@ -75,6 +76,7 @@ describe('useMacauGame', () => {
     await waitFor(() => expect(result.current.state).not.toBeNull());
     mockExec.mockClear();
     act(() => result.current.handlePlay());
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/hooks/useMachiavelliGame.test.ts
+++ b/frontend/src/hooks/useMachiavelliGame.test.ts
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { machiavelliApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import type { MachiavelliResponse } from '../types/card';
 import { useMachiavelliGame } from './useMachiavelliGame';
 
@@ -116,6 +117,7 @@ describe('useMachiavelliGame', () => {
     act(() => {
       result.current.handleNewMeld();
     });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 
@@ -142,6 +144,7 @@ describe('useMachiavelliGame', () => {
     act(() => {
       result.current.handleLayoff(0);
     });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/hooks/useManilleGame.test.ts
+++ b/frontend/src/hooks/useManilleGame.test.ts
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { manilleApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { makeManilleState } from '../test/stateFactories';
 import { DEFAULT_MANILLE_CONFIG, useManilleGame } from './useManilleGame';
 
@@ -32,9 +33,10 @@ describe('useManilleGame', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', { config: DEFAULT_MANILLE_CONFIG }));
   });
 
-  it('handlePlay does nothing without exactly one selected card', () => {
+  it('handlePlay does nothing without exactly one selected card', async () => {
     const { result } = renderHook(() => useManilleGame(), { wrapper: createWrapper() });
     act(() => result.current.handlePlay());
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/hooks/useMariasGame.test.ts
+++ b/frontend/src/hooks/useMariasGame.test.ts
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { mariasApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { makeMariasState } from '../test/stateFactories';
 import { DEFAULT_MARIAS_CONFIG, useMariasGame } from './useMariasGame';
 
@@ -32,9 +33,10 @@ describe('useMariasGame', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', { config: DEFAULT_MARIAS_CONFIG }));
   });
 
-  it('handlePlay does nothing without exactly one selected card', () => {
+  it('handlePlay does nothing without exactly one selected card', async () => {
     const { result } = renderHook(() => useMariasGame(), { wrapper: createWrapper() });
     act(() => result.current.handlePlay());
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/hooks/useNapGame.test.ts
+++ b/frontend/src/hooks/useNapGame.test.ts
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { napApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { makeNapState } from '../test/stateFactories';
 import { DEFAULT_NAP_CONFIG, useNapGame } from './useNapGame';
 
@@ -38,9 +39,10 @@ describe('useNapGame', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('bid', { bid: 5 }));
   });
 
-  it('handlePlay does nothing without exactly one selected card', () => {
+  it('handlePlay does nothing without exactly one selected card', async () => {
     const { result } = renderHook(() => useNapGame(), { wrapper: createWrapper() });
     act(() => result.current.handlePlay());
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/hooks/useOmbreGame.test.ts
+++ b/frontend/src/hooks/useOmbreGame.test.ts
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ombreApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { makeOmbreState } from '../test/stateFactories';
 import { DEFAULT_OMBRE_CONFIG, useOmbreGame } from './useOmbreGame';
 
@@ -44,9 +45,10 @@ describe('useOmbreGame', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('bid', { bid: 1, trumpSuit: 3 }));
   });
 
-  it('handlePlay does nothing without exactly one selected card', () => {
+  it('handlePlay does nothing without exactly one selected card', async () => {
     const { result } = renderHook(() => useOmbreGame(), { wrapper: createWrapper() });
     act(() => result.current.handlePlay());
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/hooks/usePageOneGame.test.ts
+++ b/frontend/src/hooks/usePageOneGame.test.ts
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { pageoneApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import type { PageOneResponse } from '../types/card';
 import { usePageOneGame } from './usePageOneGame';
 
@@ -79,6 +80,7 @@ describe('usePageOneGame', () => {
     act(() => {
       result.current.handlePlay();
     });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/hooks/usePanGame.test.ts
+++ b/frontend/src/hooks/usePanGame.test.ts
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { panApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import type { PanResponse } from '../types/card';
 import { usePanGame } from './usePanGame';
 
@@ -129,6 +130,7 @@ describe('usePanGame', () => {
     act(() => {
       result.current.handleMeld();
     });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 
@@ -152,6 +154,7 @@ describe('usePanGame', () => {
     act(() => {
       result.current.handleLayoff(1, 0);
     });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 
@@ -175,6 +178,7 @@ describe('usePanGame', () => {
     act(() => {
       result.current.handleDiscard();
     });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/hooks/usePokerGame.test.ts
+++ b/frontend/src/hooks/usePokerGame.test.ts
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { pokerApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import type { PokerResponse } from '../types/card';
 import { PokerPhase } from '../types/phases';
 import { usePokerGame } from './usePokerGame';
@@ -135,6 +136,7 @@ describe('usePokerGame', () => {
     mockExec.mockResolvedValue({ ...exchangeState, odds: [] });
 
     act(() => result.current.toggleCard(0));
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
 
     await act(async () => {

--- a/frontend/src/hooks/usePreferenceGame.test.ts
+++ b/frontend/src/hooks/usePreferenceGame.test.ts
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { preferenceApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { makePreferenceState } from '../test/stateFactories';
 import { DEFAULT_PREFERENCE_CONFIG, usePreferenceGame } from './usePreferenceGame';
 
@@ -38,9 +39,10 @@ describe('usePreferenceGame', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('bid', { bid: 3 }));
   });
 
-  it('handlePlay does nothing without exactly one selected card', () => {
+  it('handlePlay does nothing without exactly one selected card', async () => {
     const { result } = renderHook(() => usePreferenceGame(), { wrapper: createWrapper() });
     act(() => result.current.handlePlay());
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/hooks/usePrsiGame.test.ts
+++ b/frontend/src/hooks/usePrsiGame.test.ts
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { prsiApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import type { PrsiResponse } from '../types/card';
 import { usePrsiGame } from './usePrsiGame';
 
@@ -79,6 +80,7 @@ describe('usePrsiGame', () => {
       result.current.handlePlay();
     });
 
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 
@@ -96,6 +98,7 @@ describe('usePrsiGame', () => {
       result.current.handlePlay();
     });
 
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/hooks/useSambaGame.test.ts
+++ b/frontend/src/hooks/useSambaGame.test.ts
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { sambaApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { makeSambaState } from '../test/stateFactories';
 import { useSambaGame } from './useSambaGame';
 
@@ -74,6 +75,7 @@ describe('useSambaGame', () => {
     act(() => {
       result.current.handleDrawDiscard();
     });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 
@@ -104,6 +106,7 @@ describe('useSambaGame', () => {
     act(() => {
       result.current.handleMeldSelected();
     });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 
@@ -139,6 +142,7 @@ describe('useSambaGame', () => {
     act(() => {
       result.current.handleDiscard();
     });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/hooks/useScoponeGame.test.ts
+++ b/frontend/src/hooks/useScoponeGame.test.ts
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { scoponeApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { makeScoponeState } from '../test/stateFactories';
 import { useScoponeGame } from './useScoponeGame';
 
@@ -64,6 +65,7 @@ describe('useScoponeGame', () => {
 
     mockExec.mockClear();
     act(() => result.current.play());
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/hooks/useSeahavenTowersGame.test.ts
+++ b/frontend/src/hooks/useSeahavenTowersGame.test.ts
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { seahaventowersApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import type { SeahavenTowersResponse } from '../types/card';
 import { useSeahavenTowersGame } from './useSeahavenTowersGame';
 
@@ -232,6 +233,7 @@ describe('useSeahavenTowersGame', () => {
     act(() => {
       result.current.handleSelectTarget({ zone: 'foundation', col: 0 });
     });
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/hooks/useSedmaGame.test.ts
+++ b/frontend/src/hooks/useSedmaGame.test.ts
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { sedmaApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { makeSedmaState } from '../test/stateFactories';
 import { DEFAULT_SEDMA_CONFIG, useSedmaGame } from './useSedmaGame';
 
@@ -32,9 +33,10 @@ describe('useSedmaGame', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', { config: DEFAULT_SEDMA_CONFIG }));
   });
 
-  it('handlePlay does nothing without exactly one selected card', () => {
+  it('handlePlay does nothing without exactly one selected card', async () => {
     const { result } = renderHook(() => useSedmaGame(), { wrapper: createWrapper() });
     act(() => result.current.handlePlay());
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/hooks/useSkatGame.test.ts
+++ b/frontend/src/hooks/useSkatGame.test.ts
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { skatApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import type { SkatResponse } from '../types/card';
 import { SkatGameType } from '../types/phases';
 import { DEFAULT_SKAT_CONFIG, useSkatGame } from './useSkatGame';
@@ -126,11 +127,13 @@ describe('useSkatGame', () => {
 
     mockExec.mockClear();
     act(() => result.current.handleDiscard()); // 0 selected
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
 
     act(() => result.current.toggleCard(0));
     mockExec.mockClear();
     act(() => result.current.handleDiscard()); // 1 selected
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 
@@ -178,6 +181,7 @@ describe('useSkatGame', () => {
 
     mockExec.mockClear();
     act(() => result.current.handlePlay());
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/hooks/useSoloWhistGame.test.ts
+++ b/frontend/src/hooks/useSoloWhistGame.test.ts
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { soloWhistApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { makeSoloWhistState } from '../test/stateFactories';
 import { DEFAULT_SOLO_WHIST_CONFIG, useSoloWhistGame } from './useSoloWhistGame';
 
@@ -38,9 +39,10 @@ describe('useSoloWhistGame', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('bid', { bid: 1 }));
   });
 
-  it('handlePlay does nothing without exactly one selected card', () => {
+  it('handlePlay does nothing without exactly one selected card', async () => {
     const { result } = renderHook(() => useSoloWhistGame(), { wrapper: createWrapper() });
     act(() => result.current.handlePlay());
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/hooks/useSpiderGame.test.ts
+++ b/frontend/src/hooks/useSpiderGame.test.ts
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { spiderApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import type { SpiderResponse } from '../types/card';
 import { useSpiderGame } from './useSpiderGame';
 
@@ -261,6 +262,7 @@ describe('useSpiderGame', () => {
       result.current.handleSelectTarget({ zone: 'tableau', col: 3 });
     });
 
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/hooks/useSpoilFiveGame.test.ts
+++ b/frontend/src/hooks/useSpoilFiveGame.test.ts
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { spoilFiveApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { makeSpoilFiveState } from '../test/stateFactories';
 import { DEFAULT_SPOIL_FIVE_CONFIG, useSpoilFiveGame } from './useSpoilFiveGame';
 
@@ -32,9 +33,10 @@ describe('useSpoilFiveGame', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', { config: DEFAULT_SPOIL_FIVE_CONFIG }));
   });
 
-  it('handlePlay does nothing without exactly one selected card', () => {
+  it('handlePlay does nothing without exactly one selected card', async () => {
     const { result } = renderHook(() => useSpoilFiveGame(), { wrapper: createWrapper() });
     act(() => result.current.handlePlay());
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/hooks/useStreetsAndAlleysGame.test.ts
+++ b/frontend/src/hooks/useStreetsAndAlleysGame.test.ts
@@ -3,6 +3,7 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { streetsAndAlleysApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import type { StreetsAndAlleysResponse } from '../types/card';
 import { useStreetsAndAlleysGame } from './useStreetsAndAlleysGame';
 
@@ -119,6 +120,7 @@ describe('useStreetsAndAlleysGame', () => {
     mockExec.mockClear();
 
     act(() => result.current.handleSelectTarget({ zone: 'tableau', col: 1 }));
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('move', expect.anything(), expect.anything());
   });
 

--- a/frontend/src/hooks/useSuecaGame.test.ts
+++ b/frontend/src/hooks/useSuecaGame.test.ts
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { suecaApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { makeSuecaState } from '../test/stateFactories';
 import { DEFAULT_SUECA_CONFIG, useSuecaGame } from './useSuecaGame';
 
@@ -32,9 +33,10 @@ describe('useSuecaGame', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', { config: DEFAULT_SUECA_CONFIG }));
   });
 
-  it('handlePlay does nothing without exactly one selected card', () => {
+  it('handlePlay does nothing without exactly one selected card', async () => {
     const { result } = renderHook(() => useSuecaGame(), { wrapper: createWrapper() });
     act(() => result.current.handlePlay());
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/hooks/useTonkGame.test.ts
+++ b/frontend/src/hooks/useTonkGame.test.ts
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { tonkApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import type { TonkResponse } from '../types/card';
 import { useTonkGame } from './useTonkGame';
 
@@ -114,6 +115,7 @@ describe('useTonkGame', () => {
       result.current.handleDiscard();
     });
 
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 
@@ -143,6 +145,7 @@ describe('useTonkGame', () => {
       result.current.handleKnock();
     });
 
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/hooks/useTrickGameBase.test.ts
+++ b/frontend/src/hooks/useTrickGameBase.test.ts
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { heartsApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import type { HeartsResponse } from '../types/card';
 import { useTrickGameBase } from './useTrickGameBase';
 
@@ -131,6 +132,7 @@ describe('useTrickGameBase', () => {
       result.current.handlePlay();
     });
 
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 
@@ -148,6 +150,7 @@ describe('useTrickGameBase', () => {
       result.current.handlePlay();
     });
 
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/hooks/useTuteGame.test.ts
+++ b/frontend/src/hooks/useTuteGame.test.ts
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { tuteApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { makeTuteState } from '../test/stateFactories';
 import { DEFAULT_TUTE_CONFIG, useTuteGame } from './useTuteGame';
 
@@ -32,9 +33,10 @@ describe('useTuteGame', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', { config: DEFAULT_TUTE_CONFIG }));
   });
 
-  it('handlePlay does nothing without exactly one selected card', () => {
+  it('handlePlay does nothing without exactly one selected card', async () => {
     const { result } = renderHook(() => useTuteGame(), { wrapper: createWrapper() });
     act(() => result.current.handlePlay());
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/hooks/useTwentyNineGame.test.ts
+++ b/frontend/src/hooks/useTwentyNineGame.test.ts
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { twentyNineApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { makeTwentyNineState } from '../test/stateFactories';
 import { DEFAULT_TWENTY_NINE_CONFIG, useTwentyNineGame } from './useTwentyNineGame';
 
@@ -38,9 +39,10 @@ describe('useTwentyNineGame', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('bid', { bid: 20 }));
   });
 
-  it('handlePlay does nothing without exactly one selected card', () => {
+  it('handlePlay does nothing without exactly one selected card', async () => {
     const { result } = renderHook(() => useTwentyNineGame(), { wrapper: createWrapper() });
     act(() => result.current.handlePlay());
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/hooks/useTysiacGame.test.ts
+++ b/frontend/src/hooks/useTysiacGame.test.ts
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { tysiacApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { makeTysiacState } from '../test/stateFactories';
 import { DEFAULT_TYSIAC_CONFIG, useTysiacGame } from './useTysiacGame';
 
@@ -40,9 +41,10 @@ describe('useTysiacGame', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('bid', { raise: false }));
   });
 
-  it('handleDiscard does nothing without exactly one selected card', () => {
+  it('handleDiscard does nothing without exactly one selected card', async () => {
     const { result } = renderHook(() => useTysiacGame(), { wrapper: createWrapper() });
     act(() => result.current.handleDiscard());
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 
@@ -53,9 +55,10 @@ describe('useTysiacGame', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('discard', { cardIndex: 1 }));
   });
 
-  it('handlePlay does nothing without exactly one selected card', () => {
+  it('handlePlay does nothing without exactly one selected card', async () => {
     const { result } = renderHook(() => useTysiacGame(), { wrapper: createWrapper() });
     act(() => result.current.handlePlay());
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/hooks/useUltiGame.test.ts
+++ b/frontend/src/hooks/useUltiGame.test.ts
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ultiApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { makeUltiState } from '../test/stateFactories';
 import { DEFAULT_ULTI_CONFIG, useUltiGame } from './useUltiGame';
 
@@ -44,10 +45,11 @@ describe('useUltiGame', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('bid', { contract: 'party', trumpSuit: 3 }));
   });
 
-  it('handleDiscard does nothing without exactly two selected cards', () => {
+  it('handleDiscard does nothing without exactly two selected cards', async () => {
     const { result } = renderHook(() => useUltiGame(), { wrapper: createWrapper() });
     act(() => result.current.toggleCard(0));
     act(() => result.current.handleDiscard());
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 
@@ -59,9 +61,10 @@ describe('useUltiGame', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('discard', { cardIndices: [0, 3] }));
   });
 
-  it('handlePlay does nothing without exactly one selected card', () => {
+  it('handlePlay does nothing without exactly one selected card', async () => {
     const { result } = renderHook(() => useUltiGame(), { wrapper: createWrapper() });
     act(() => result.current.handlePlay());
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/hooks/useWattenGame.test.ts
+++ b/frontend/src/hooks/useWattenGame.test.ts
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { wattenApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { makeWattenState } from '../test/stateFactories';
 import { DEFAULT_WATTEN_CONFIG, useWattenGame } from './useWattenGame';
 
@@ -40,9 +41,10 @@ describe('useWattenGame', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('declare', 13, 3));
   });
 
-  it('handlePlay does nothing without exactly one selected card', () => {
+  it('handlePlay does nothing without exactly one selected card', async () => {
     const { result } = renderHook(() => useWattenGame(), { wrapper: createWrapper() });
     act(() => result.current.handlePlay());
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/pages/EasthavenPage.test.tsx
+++ b/frontend/src/pages/EasthavenPage.test.tsx
@@ -339,6 +339,7 @@ describe('EasthavenPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
     mockExec.mockClear();
     screen.getByRole('button', { name: '配る' }).click();
+    await flushPendingDispatch();
     expect(mockExec).not.toHaveBeenCalledWith('deal');
   });
 


### PR DESCRIPTION
Closes #4451.

`expect(<apiMock>).not.toHaveBeenCalled()` placed straight after an interaction passes **whether or not the action fired** — `exec` dispatches through react-query's `mutateAsync`, so the assertion runs before the call can appear. #4443 fixed 148 of these. These 76 survived it.

## Why #4443 missed them

Its detector keyed on `fireEvent`/`userEvent` preceding the assertion — the *page-test* idiom. Hook tests drive the hook through `act(...)`:

```ts
act(() => result.current.handleDiscard());
expect(mockExec).not.toHaveBeenCalled();   // vacuous
```

So that whole family was invisible, and #4443's "0 remaining" was true only of the pattern it searched for. Widening again — to raw `.click()` — then turned up one more the `act`-aware pass had called clean (`EasthavenPage`'s deal guard).

**Three widenings, three times more sites.** The generalisable point: a clean scan means "clean under this pattern", not "clean".

## No production bugs this time — and that is a result, not a disappointment

#4443's sweep uncovered a real 3-page bug, so each failure here was worth checking. All 76 guards genuinely hold. What matters is that the assertions now *bite* rather than merely pass:

| guard disabled | before | after |
|---|---|---|
| Ulti's two-card discard | 9 passed ❌ | `× handleDiscard does nothing without exactly two selected cards` ✅ |
| Watten's one-card play | 9 passed ❌ | `× handlePlay does nothing without exactly one selected card` ✅ |
| Easthaven's deal guard | 34 passed ❌ | `× deal is guarded while an empty column exists` ✅ |

## Ninth guard, so it cannot come back

It already came back once: I reintroduced this exact pattern in tests I wrote hours earlier (#4450), and only mutation testing caught it. So `bun run check` now fails the build on it.

Two design decisions taken from the unmount guard's three rewrites in #4448:

- **Only mocks of a game API.** A plain `vi.fn()` prop callback *is* invoked synchronously and needs no flush — flagging those would be noise, and a noisy guard gets switched off.
- **Advancing fake timers counts as a flush.** `usePokerGame`'s debounce test drives its pending timer with `vi.advanceTimersByTime(300)`, and its assertion is meaningful precisely because of that. The guard flagged it until taught otherwise — exactly the false positive that gets a guard deleted rather than fixed.

Negative-controlled on both forms: removing a flush from a hook test (`act`) and from a page test (raw `.click()`) each exit 1 naming the exact line.

## Verification

- `bun run test` — **16,081 passed**
- `bun run typecheck`, `bun run check` (all 9 guards) clean
- Three mutations above confirmed failing after the change and passing before it
- Test-only, plus the guard script; no production files touched
