### PR TITLE
chore(workers): wire real KV namespaces for extra2/extra3 and enable their deploy

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -34,14 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # extra2/extra3 are deliberately absent until their KV namespaces exist
-        # (ADR-0036 Phase 1 ships them with REPLACE_ME placeholder IDs). Adding
-        # them here would run `wrangler deploy` against those placeholders on every
-        # push to develop; with fail-fast defaulting to true that failure cancels
-        # the other four legs, and deploy-pages `needs: deploy-workers`, so the
-        # frontend deploy dies too. Add them in the same change that fills in the
-        # real IDs.
-        worker: [casino, classic, solo, extra]
+        worker: [casino, classic, solo, extra, extra2, extra3]
     environment:
       name: ${{ github.ref == 'refs/heads/master' && 'production' || 'staging' }}
     steps:

--- a/Makefile
+++ b/Makefile
@@ -52,14 +52,15 @@ build-worker-extra3:
 clean-workers:
 	rm -rf workers/casino/build workers/classic/build workers/solo/build workers/extra/build workers/extra2/build workers/extra3/build
 
-# extra2/extra3 are intentionally missing here, exactly as in the CI deploy matrix:
-# their wrangler.toml still holds REPLACE_ME KV namespace IDs (ADR-0036 Phase 1), so
-# `wrangler deploy` would fail. Add them in the change that fills in the real IDs.
+# Deploys to production. CI passes `--env staging` for develop; this target does not,
+# so running it by hand publishes to the live workers.
 deploy-workers: build-workers
 	cd workers/casino && bunx wrangler deploy
 	cd workers/classic && bunx wrangler deploy
 	cd workers/solo && bunx wrangler deploy
 	cd workers/extra && bunx wrangler deploy
+	cd workers/extra2 && bunx wrangler deploy
+	cd workers/extra3 && bunx wrangler deploy
 
 coverage: ## Run tests with coverage, writing profile and HTML report to build/coverage/.
 	@mkdir -p $(COVERAGE_DIR)

--- a/docs/adr/0036-fifth-sixth-worker-capacity.md
+++ b/docs/adr/0036-fifth-sixth-worker-capacity.md
@@ -86,13 +86,24 @@ ADR-0032 は「ゲームを移す手順」しか残していなかったため�
 
 **Cloudflare アカウント側（コードでは完結しない）**
 
-- KV namespace を production / preview / staging 分作成し、その ID を `wrangler.toml` に入れる
+- KV namespace を production / preview / staging の **3 つ**作成し、その ID を `wrangler.toml` に入れる。3 つは別物であること（Phase 1 のプレースホルダは production と staging に同じトークンを使っていたため、素朴に置換すると staging が production のストアを指す）
 - GitHub の deploy variables に `WORKER_<NAME>_URL` と `WORKER_<NAME>_STAGING_URL` を設定
-- フロントエンドビルド用に `VITE_WORKER_<NAME>_URL` を設定
 
-**この 3 つが揃うまで新 Worker は実際にはデプロイできない。** Phase 1 の PR は KV ID をプレースホルダで置き、ビルドとサイズチェックまでを通す。
+`VITE_WORKER_<NAME>_URL` は**手で設定しない**。`deploy-cloudflare.yml` が上記 2 つから
+ref に応じて導出する（master→production, それ以外→staging）ので、設定するのは worker
+あたり 2 変数だけ。
 
-**プレースホルダのまま deploy matrix に足してはいけない。** `deploy-cloudflare.yml` は
+**この 2 つが揃うまで新 Worker は実際にはデプロイできない。** Phase 1 の PR は KV ID をプレースホルダで置き、ビルドとサイズチェックまでを通す。
+
+なお KV namespace は **worker ごとに分ける必要はない**。KV キーは `<game>:<sessionId>`
+（`worker_helper.go` が `name+":"` を prefix に渡す）で、ゲームは必ず 1 バケットにしか
+属さないため、複数 worker が 1 つの namespace を共有しても衝突しない。実際
+casino / classic / solo は ADR-0027 以来 1 つを共有している。それでも `extra` 以降は
+worker ごとに分けている — 片方のセッションだけを列挙・削除できる方が運用が楽なため。
+
+**プレースホルダのまま deploy matrix に足してはいけない**（extra2/extra3 の
+namespace と変数は 2026-07-28 に用意済みで、matrix にも追加した。以下は
+なぜ Phase 1 で足さなかったかの記録）**。** `deploy-cloudflare.yml` は
 `cmd/workers/**` と `workers/**` の変更で develop への push 時に走るため、Phase 1 の変更
 そのものがトリガーになる。プレースホルダ ID で `wrangler deploy` が失敗し、`fail-fast` は
 既定 true なので**他の 4 Worker のデプロイまで巻き添えでキャンセル**され、さらに

--- a/workers/extra2/wrangler.toml
+++ b/workers/extra2/wrangler.toml
@@ -1,20 +1,25 @@
-# ADR-0036 Phase 1: the extra2 bucket exists so the build and size checks run.
-# The KV namespace IDs below are PLACEHOLDERS. Create real namespaces in
-# Cloudflare (production, preview and staging) and paste their IDs here before
-# deploying — copying another worker's IDs would make two workers share one
-# session store and collide on keys.
 name = "go-trumpcards-extra2"
 main = "./build/worker.mjs"
 compatibility_date = "2024-09-23"
 
+# Dedicated namespaces, matching `extra` (ADR-0032). Sharing one namespace across
+# workers would in fact be safe -- KV keys are "<game>:<sessionId>" (worker_helper.go
+# passes name+":" as the prefix) and a game lives in exactly one bucket, which is why
+# casino/classic/solo have shared a single namespace since ADR-0027. Separate stores
+# are still preferred: they let one worker's sessions be listed or purged without
+# touching another's.
+#
+# Production, preview and staging are three DIFFERENT namespaces. Phase 1's
+# placeholders used one token for both production and staging, so a find-replace
+# would have quietly pointed staging at the production store.
 [[kv_namespaces]]
 binding = "GAME_SESSIONS"
-id = "REPLACE_ME_EXTRA2_KV_ID"
-preview_id = "REPLACE_ME_EXTRA2_KV_PREVIEW_ID"
+id = "2b905bc12dfd4b69bfc4124838c8442d"
+preview_id = "3f47dc95789d47b1b017c81a2f1f6c35"
 
 [env.staging]
 name = "go-trumpcards-extra2-staging"
 
 [[env.staging.kv_namespaces]]
 binding = "GAME_SESSIONS"
-id = "REPLACE_ME_EXTRA2_KV_ID"
+id = "70c217c24a7f4d5d8947df3329f47b97"

--- a/workers/extra3/wrangler.toml
+++ b/workers/extra3/wrangler.toml
@@ -1,20 +1,18 @@
-# ADR-0036 Phase 1: the extra3 bucket exists so the build and size checks run.
-# The KV namespace IDs below are PLACEHOLDERS. Create real namespaces in
-# Cloudflare (production, preview and staging) and paste their IDs here before
-# deploying — copying another worker's IDs would make two workers share one
-# session store and collide on keys.
 name = "go-trumpcards-extra3"
 main = "./build/worker.mjs"
 compatibility_date = "2024-09-23"
 
+# Dedicated namespaces, matching `extra` (ADR-0032). See workers/extra2/wrangler.toml
+# for why sharing would also have been safe, and why separate stores are preferred
+# anyway. Production, preview and staging are three DIFFERENT namespaces.
 [[kv_namespaces]]
 binding = "GAME_SESSIONS"
-id = "REPLACE_ME_EXTRA3_KV_ID"
-preview_id = "REPLACE_ME_EXTRA3_KV_PREVIEW_ID"
+id = "14080bf47090424aa495ec3cd677c270"
+preview_id = "aef6b2be3e444f8191808ac4123e4e22"
 
 [env.staging]
 name = "go-trumpcards-extra3-staging"
 
 [[env.staging.kv_namespaces]]
 binding = "GAME_SESSIONS"
-id = "REPLACE_ME_EXTRA3_KV_ID"
+id = "fe1f52261f06430f80eea6a376eac693"


### PR DESCRIPTION
#4458 のブロッカーを解消する。wrangler で実際にアカウントを調査し、KV namespace を作成、deploy variables を設定した。

## 作成した KV namespace

`extra` の命名規則に合わせて 6 つ作成（production / preview / staging × 2 worker）:

| title | id |
|---|---|
| `go-trumpcards-extra2-GAME_SESSIONS` | `2b905bc12dfd4b69bfc4124838c8442d` |
| `go-trumpcards-extra2-GAME_SESSIONS_preview` | `3f47dc95789d47b1b017c81a2f1f6c35` |
| `go-trumpcards-extra2-staging-GAME_SESSIONS` | `70c217c24a7f4d5d8947df3329f47b97` |
| `go-trumpcards-extra3-GAME_SESSIONS` | `14080bf47090424aa495ec3cd677c270` |
| `go-trumpcards-extra3-GAME_SESSIONS_preview` | `aef6b2be3e444f8191808ac4123e4e22` |
| `go-trumpcards-extra3-staging-GAME_SESSIONS` | `fe1f52261f06430f80eea6a376eac693` |

## 設定した deploy variables

`WORKER_EXTRA2_URL` / `WORKER_EXTRA2_STAGING_URL` / `WORKER_EXTRA3_URL` / `WORKER_EXTRA3_STAGING_URL`（既存 8 変数と同じ `https://go-trumpcards-<worker>[-staging].yuta-yoshinaga.workers.dev` パターン）。

**`VITE_WORKER_*` は設定不要でした。** ADR には「フロントエンドビルド用に設定する」と書いていましたが誤りで、`deploy-cloudflare.yml:132-133` が `WORKER_*` から ref に応じて導出します。ADR を訂正しました。worker あたり必要なのは 2 変数だけです。

## 検証

- 18 個すべての id（6 worker 分）を `wrangler kv namespace list` に突き合わせて実在確認
- `wrangler deploy --dry-run` を extra2/extra3 × production/staging の 4 通りで実行し、**それぞれが別々の namespace に解決される**ことを確認（下記の Phase 1 の穴が本当に直っているか）

```
extra2 production → 2b905bc1... (extra2-GAME_SESSIONS)
extra2 staging    → 70c217c2... (extra2-staging-GAME_SESSIONS)
extra3 production → 14080bf4... (extra3-GAME_SESSIONS)
extra3 staging    → fe1f5226... (extra3-staging-GAME_SESSIONS)
```

## Phase 1 に 2 つの誤りがあった（どちらも私が書いたもの）

**1. placeholder が production と staging で同じトークンだった。** `REPLACE_ME_EXTRA2_KV_ID` が両方に使われていたので、素朴に置換すると **staging が production のセッションストアを指す**。3 つは別物であることをコメントに明記した。

**2. 「namespace を共有すると key が衝突する」は誤り。** KV キーは `<game>:<sessionId>`（`worker_helper.go` が `name+":"` を prefix に渡す）で、ゲームは必ず 1 バケットにしか属さないため衝突しない。実際 **casino / classic / solo は ADR-0027 以来 1 つの namespace を共有している**。worker ごとに分けるのは運用の都合（片方だけ列挙・削除できる）であって、正しさの要件ではない。`extra` の前例に合わせて分けたが、理由は正しく書き直した。

## deploy matrix と Makefile

実 ID が入ったので、ADR-0032/0036 が「実 ID を入れる変更と同時に」と指定していたとおり、matrix と `deploy-workers` を 6 worker に拡張した。

## 単独でマージして安全

このマージで deploy が走るが、**extra2/extra3 は #4458 がマージされるまで中身が 0 ゲーム**なので空の worker としてデプロイされるだけで、219 ゲームは全て従来の 4 worker にルーティングされ続ける。#4458 を後からマージした時点で 41 ゲームが移動し、フロントのルーティングも切り替わる。この順序が ADR の指定どおり。

Refs ADR-0036, #4458
