### PR TITLE
test(sirtommy): stop TestSirTommy_Hint depending on the shuffle

### DIFF
--- a/internal/domain/SirTommy_test.go
+++ b/internal/domain/SirTommy_test.go
@@ -177,7 +177,13 @@ func TestSirTommy_StalemateOnlyWhenStockEmptyAndNothingPlayable(t *testing.T) {
 
 func TestSirTommy_Hint(t *testing.T) {
 	s := newTestSirTommy()
-	assert.Nil(t, s.GetHint(), "no hint before anything is playable")
+
+	// Deal a stock whose top is not an Ace, with every foundation empty, so
+	// nothing is playable. Asserting this on a freshly shuffled deck would be a
+	// 4-in-52 flake: a real Reset leaves whatever the shuffle put on top, and an
+	// Ace there is a legitimate hint.
+	stackDeck(s, []*Card{NewCard(0, 9, true)})
+	assert.Nil(t, s.GetHint(), "no hint while nothing is playable")
 
 	// stock top is an Ace -> hint points at the stock
 	stackDeck(s, []*Card{NewCard(0, 1, true)})


### PR DESCRIPTION
develop が #4466 マージ直後に赤くなった件の修正。

## 原因

`TestSirTommy_Hint` が **実際にシャッフルした 52 枚**に対して「ヒントは無い」と断定していました。山札の一番上が A だと `GetHint()` は正しくヒントを返すので落ちます（**4/52 ≈ 7.7%**）。ローカルでも PR の CI でもたまたま通っていただけです。

`internal/CLAUDE.md` に明記されている規約（「シャッフル順に依存するな、状態は手で組め」）に、私自身が違反していました。

## 修正

A 以外の 1 枚だけを積み、ファウンデーションを空にした決定的な状態にしました。元々このアサーションが表現したかったのは「何も置けない状態ではヒントが出ない」ことなので、意図はそのままです。

## 検証

- 当該テスト `-count=200`
- Sir Tommy 全テスト（domain / usecase / adapter 2 パッケージ）`-count=100`
- `go test -tags test ./...` 全体

他の Sir Tommy テストにも同じ罠が無いか機械的に洗い、`Reset_InitialState` の `IsStalemate()` 断定が引っかかりましたが、`Reset()` が明示的に false を代入するためシャッフル非依存で問題なしと確認しました。