### PR TITLE
fix(solitaire): persist the undo stack in the 7 games from the new-game batch (#4478)

### DIFF
--- a/internal/domain/Bisley.go
+++ b/internal/domain/Bisley.go
@@ -493,6 +493,64 @@ func (b *Bisley) appendLog(actionType, detail string, cards []*Card) {
 	})
 }
 
+// bisleyMaxSliceLen caps slice sizes during deserialisation.
+const bisleyMaxSliceLen = 1000
+
+// bisleySnapshotJSON is the wire format for a single undo snapshot.
+// bisleySnapshot uses unexported fields, so marshalling it directly would emit
+// `[{},{}]` -- the undo depth would survive but every snapshot would be blank,
+// and Undo would wipe the board instead of rewinding it (#4478).
+type bisleySnapshotJSON struct {
+	AceFoundations  [BisleyFoundationCnt][]*Card           `json:"af"`
+	KingFoundations [BisleyFoundationCnt][]*Card           `json:"kf"`
+	Tableau         [BisleyTableauCnt][]*BisleyTableauCard `json:"tb"`
+	Phase           BisleyPhase                            `json:"ps"`
+	MoveCount       int                                    `json:"mc"`
+	IsStalemate     bool                                   `json:"sl"`
+}
+
+// MarshalJSON implements json.Marshaler for bisleySnapshot.
+func (s *bisleySnapshot) MarshalJSON() ([]byte, error) {
+	return json.Marshal(bisleySnapshotJSON{
+		AceFoundations:  s.aceFoundations,
+		KingFoundations: s.kingFoundations,
+		Tableau:         s.tableau,
+		Phase:           s.phase,
+		MoveCount:       s.moveCount,
+		IsStalemate:     s.isStalemate,
+	})
+}
+
+// UnmarshalJSON implements json.Unmarshaler for bisleySnapshot.
+func (s *bisleySnapshot) UnmarshalJSON(data []byte) error {
+	var j bisleySnapshotJSON
+	if err := json.Unmarshal(data, &j); err != nil {
+		return err
+	}
+	for _, pile := range j.AceFoundations {
+		if len(pile) > bisleyMaxSliceLen {
+			return errors.New("bisley: snapshot pile exceeds maximum allowed size")
+		}
+	}
+	for _, pile := range j.KingFoundations {
+		if len(pile) > bisleyMaxSliceLen {
+			return errors.New("bisley: snapshot pile exceeds maximum allowed size")
+		}
+	}
+	for _, pile := range j.Tableau {
+		if len(pile) > bisleyMaxSliceLen {
+			return errors.New("bisley: snapshot pile exceeds maximum allowed size")
+		}
+	}
+	s.aceFoundations = j.AceFoundations
+	s.kingFoundations = j.KingFoundations
+	s.tableau = j.Tableau
+	s.phase = j.Phase
+	s.moveCount = j.MoveCount
+	s.isStalemate = j.IsStalemate
+	return nil
+}
+
 // bisleyJSON is the JSON wire format for Bisley.
 type bisleyJSON struct {
 	TrumpCards      *TrumpCards                            `json:"tc"`
@@ -503,6 +561,10 @@ type bisleyJSON struct {
 	MoveCount       int                                    `json:"mc"`
 	ActionLog       []*ActionLogEntry                      `json:"al"`
 	IsStalemate     bool                                   `json:"sl"`
+	// History must round-trip: the Cloudflare Worker is stateless per request
+	// and rebuilds the game from KV every call, so an unpersisted undo stack
+	// means Undo/UndoN/UndoToEscape silently never work in production (#4478).
+	History []*bisleySnapshot `json:"hi,omitempty"`
 }
 
 // MarshalJSON KV スナップショット用のシリアライズ
@@ -516,6 +578,7 @@ func (b *Bisley) MarshalJSON() ([]byte, error) {
 		MoveCount:       b.moveCount,
 		ActionLog:       b.actionLog,
 		IsStalemate:     b.isStalemate,
+		History:         b.history,
 	})
 }
 
@@ -525,6 +588,9 @@ func (b *Bisley) UnmarshalJSON(data []byte) error {
 	var j bisleyJSON
 	if err := json.Unmarshal(data, &j); err != nil {
 		return err
+	}
+	if len(j.ActionLog) > bisleyMaxSliceLen || len(j.History) > bisleyMaxSliceLen {
+		return errors.New("bisley: input array exceeds maximum allowed size")
 	}
 	if j.Phase < BisleyPhasePlaying || j.Phase > BisleyPhaseGameOver {
 		return fmt.Errorf("invalid phase: %d", j.Phase)
@@ -547,5 +613,6 @@ func (b *Bisley) UnmarshalJSON(data []byte) error {
 	b.moveCount = j.MoveCount
 	b.actionLog = j.ActionLog
 	b.isStalemate = j.IsStalemate
+	b.history = j.History
 	return nil
 }

--- a/internal/domain/Duchess.go
+++ b/internal/domain/Duchess.go
@@ -832,6 +832,77 @@ func (d *Duchess) appendLog(actionType, detail string, cards []*Card) {
 	})
 }
 
+// duchessMaxSliceLen caps slice sizes during deserialisation.
+const duchessMaxSliceLen = 1000
+
+// duchessSnapshotJSON is the wire format for a single undo snapshot.
+// duchessSnapshot uses unexported fields, so marshalling it directly would emit
+// `[{},{}]` -- the undo depth would survive but every snapshot would be blank,
+// and Undo would wipe the board instead of rewinding it (#4478).
+type duchessSnapshotJSON struct {
+	Reserve     [DuchessReserveCnt][]*Card               `json:"rs"`
+	Tableau     [DuchessTableauCnt][]*DuchessTableauCard `json:"tb"`
+	Foundation  [DuchessFoundationCnt][]*Card            `json:"fd"`
+	Stock       []*Card                                  `json:"st"`
+	Waste       []*Card                                  `json:"wa"`
+	BaseRank    int                                      `json:"br"`
+	Phase       DuchessPhase                             `json:"ps"`
+	MoveCount   int                                      `json:"mc"`
+	IsStalemate bool                                     `json:"sl"`
+}
+
+// MarshalJSON implements json.Marshaler for duchessSnapshot.
+func (s *duchessSnapshot) MarshalJSON() ([]byte, error) {
+	return json.Marshal(duchessSnapshotJSON{
+		Reserve:     s.reserve,
+		Tableau:     s.tableau,
+		Foundation:  s.foundation,
+		Stock:       s.stock,
+		Waste:       s.waste,
+		BaseRank:    s.baseRank,
+		Phase:       s.phase,
+		MoveCount:   s.moveCount,
+		IsStalemate: s.isStalemate,
+	})
+}
+
+// UnmarshalJSON implements json.Unmarshaler for duchessSnapshot.
+func (s *duchessSnapshot) UnmarshalJSON(data []byte) error {
+	var j duchessSnapshotJSON
+	if err := json.Unmarshal(data, &j); err != nil {
+		return err
+	}
+	if len(j.Stock) > duchessMaxSliceLen ||
+		len(j.Waste) > duchessMaxSliceLen {
+		return errors.New("duchess: snapshot array exceeds maximum allowed size")
+	}
+	for _, pile := range j.Reserve {
+		if len(pile) > duchessMaxSliceLen {
+			return errors.New("duchess: snapshot pile exceeds maximum allowed size")
+		}
+	}
+	for _, pile := range j.Tableau {
+		if len(pile) > duchessMaxSliceLen {
+			return errors.New("duchess: snapshot pile exceeds maximum allowed size")
+		}
+	}
+	for _, pile := range j.Foundation {
+		if len(pile) > duchessMaxSliceLen {
+			return errors.New("duchess: snapshot pile exceeds maximum allowed size")
+		}
+	}
+	s.reserve = j.Reserve
+	s.tableau = j.Tableau
+	s.foundation = j.Foundation
+	s.stock = j.Stock
+	s.waste = j.Waste
+	s.baseRank = j.BaseRank
+	s.phase = j.Phase
+	s.moveCount = j.MoveCount
+	s.isStalemate = j.IsStalemate
+	return nil
+}
+
 // duchessJSON is the JSON wire format for Duchess.
 type duchessJSON struct {
 	TrumpCards  *TrumpCards                              `json:"tc"`
@@ -845,6 +916,10 @@ type duchessJSON struct {
 	MoveCount   int                                      `json:"mc"`
 	ActionLog   []*ActionLogEntry                        `json:"al"`
 	IsStalemate bool                                     `json:"sl"`
+	// History must round-trip: the Cloudflare Worker is stateless per request
+	// and rebuilds the game from KV every call, so an unpersisted undo stack
+	// means Undo/UndoN/UndoToEscape silently never work in production (#4478).
+	History []*duchessSnapshot `json:"hi,omitempty"`
 }
 
 // MarshalJSON KV スナップショット用のシリアライズ
@@ -861,6 +936,7 @@ func (d *Duchess) MarshalJSON() ([]byte, error) {
 		MoveCount:   d.moveCount,
 		ActionLog:   d.actionLog,
 		IsStalemate: d.isStalemate,
+		History:     d.history,
 	})
 }
 
@@ -870,6 +946,9 @@ func (d *Duchess) UnmarshalJSON(data []byte) error {
 	var j duchessJSON
 	if err := json.Unmarshal(data, &j); err != nil {
 		return err
+	}
+	if len(j.ActionLog) > duchessMaxSliceLen || len(j.History) > duchessMaxSliceLen {
+		return errors.New("duchess: input array exceeds maximum allowed size")
 	}
 	if j.Phase < DuchessPhasePlaying || j.Phase > DuchessPhaseGameOver {
 		return fmt.Errorf("invalid phase: %d", j.Phase)
@@ -912,5 +991,6 @@ func (d *Duchess) UnmarshalJSON(data []byte) error {
 	d.moveCount = j.MoveCount
 	d.actionLog = j.ActionLog
 	d.isStalemate = j.IsStalemate
+	d.history = j.History
 	return nil
 }

--- a/internal/domain/GrandfathersClock.go
+++ b/internal/domain/GrandfathersClock.go
@@ -537,6 +537,56 @@ func (gc *GrandfathersClock) appendLog(actionType, detail string, cards []*Card)
 	})
 }
 
+// grandfathersClockMaxSliceLen caps slice sizes during deserialisation.
+const grandfathersClockMaxSliceLen = 1000
+
+// grandfathersClockSnapshotJSON is the wire format for a single undo snapshot.
+// grandfathersClockSnapshot uses unexported fields, so marshalling it directly would emit
+// `[{},{}]` -- the undo depth would survive but every snapshot would be blank,
+// and Undo would wipe the board instead of rewinding it (#4478).
+type grandfathersClockSnapshotJSON struct {
+	Foundation  [GrandfathersClockFoundationCnt][]*Card                      `json:"fd"`
+	Tableau     [GrandfathersClockTableauCnt][]*GrandfathersClockTableauCard `json:"tb"`
+	Phase       GrandfathersClockPhase                                       `json:"ps"`
+	MoveCount   int                                                          `json:"mc"`
+	IsStalemate bool                                                         `json:"sl"`
+}
+
+// MarshalJSON implements json.Marshaler for grandfathersClockSnapshot.
+func (s *grandfathersClockSnapshot) MarshalJSON() ([]byte, error) {
+	return json.Marshal(grandfathersClockSnapshotJSON{
+		Foundation:  s.foundation,
+		Tableau:     s.tableau,
+		Phase:       s.phase,
+		MoveCount:   s.moveCount,
+		IsStalemate: s.isStalemate,
+	})
+}
+
+// UnmarshalJSON implements json.Unmarshaler for grandfathersClockSnapshot.
+func (s *grandfathersClockSnapshot) UnmarshalJSON(data []byte) error {
+	var j grandfathersClockSnapshotJSON
+	if err := json.Unmarshal(data, &j); err != nil {
+		return err
+	}
+	for _, pile := range j.Foundation {
+		if len(pile) > grandfathersClockMaxSliceLen {
+			return errors.New("grandfathersclock: snapshot pile exceeds maximum allowed size")
+		}
+	}
+	for _, pile := range j.Tableau {
+		if len(pile) > grandfathersClockMaxSliceLen {
+			return errors.New("grandfathersclock: snapshot pile exceeds maximum allowed size")
+		}
+	}
+	s.foundation = j.Foundation
+	s.tableau = j.Tableau
+	s.phase = j.Phase
+	s.moveCount = j.MoveCount
+	s.isStalemate = j.IsStalemate
+	return nil
+}
+
 // grandfathersClockJSON is the JSON wire format for GrandfathersClock.
 type grandfathersClockJSON struct {
 	TrumpCards  *TrumpCards                                                  `json:"tc"`
@@ -546,6 +596,10 @@ type grandfathersClockJSON struct {
 	MoveCount   int                                                          `json:"mc"`
 	ActionLog   []*ActionLogEntry                                            `json:"al"`
 	IsStalemate bool                                                         `json:"sl"`
+	// History must round-trip: the Cloudflare Worker is stateless per request
+	// and rebuilds the game from KV every call, so an unpersisted undo stack
+	// means Undo/UndoN/UndoToEscape silently never work in production (#4478).
+	History []*grandfathersClockSnapshot `json:"hi,omitempty"`
 }
 
 // MarshalJSON KV スナップショット用のシリアライズ
@@ -558,6 +612,7 @@ func (gc *GrandfathersClock) MarshalJSON() ([]byte, error) {
 		MoveCount:   gc.moveCount,
 		ActionLog:   gc.actionLog,
 		IsStalemate: gc.isStalemate,
+		History:     gc.history,
 	})
 }
 
@@ -567,6 +622,9 @@ func (gc *GrandfathersClock) UnmarshalJSON(data []byte) error {
 	var j grandfathersClockJSON
 	if err := json.Unmarshal(data, &j); err != nil {
 		return err
+	}
+	if len(j.ActionLog) > grandfathersClockMaxSliceLen || len(j.History) > grandfathersClockMaxSliceLen {
+		return errors.New("grandfathersclock: input array exceeds maximum allowed size")
 	}
 	if j.Phase < GrandfathersClockPhasePlaying || j.Phase > GrandfathersClockPhaseGameOver {
 		return fmt.Errorf("invalid phase: %d", j.Phase)
@@ -593,5 +651,6 @@ func (gc *GrandfathersClock) UnmarshalJSON(data []byte) error {
 	gc.moveCount = j.MoveCount
 	gc.actionLog = j.ActionLog
 	gc.isStalemate = j.IsStalemate
+	gc.history = j.History
 	return nil
 }

--- a/internal/domain/MissMilligan.go
+++ b/internal/domain/MissMilligan.go
@@ -697,6 +697,66 @@ func (mm *MissMilligan) appendLog(actionType, detail string, cards []*Card) {
 	})
 }
 
+// missMilliganMaxSliceLen caps slice sizes during deserialisation.
+const missMilliganMaxSliceLen = 1000
+
+// missMilliganSnapshotJSON is the wire format for a single undo snapshot.
+// missMilliganSnapshot uses unexported fields, so marshalling it directly would emit
+// `[{},{}]` -- the undo depth would survive but every snapshot would be blank,
+// and Undo would wipe the board instead of rewinding it (#4478).
+type missMilliganSnapshotJSON struct {
+	Tableau     [MissMilliganTableauCnt][]*MissMilliganTableauCard `json:"tb"`
+	Stock       []*Card                                            `json:"st"`
+	Foundation  [MissMilliganFoundationCnt][]*Card                 `json:"fd"`
+	Waived      []*Card                                            `json:"wv"`
+	Phase       MissMilliganPhase                                  `json:"ps"`
+	MoveCount   int                                                `json:"mc"`
+	IsStalemate bool                                               `json:"sl"`
+}
+
+// MarshalJSON implements json.Marshaler for missMilliganSnapshot.
+func (s *missMilliganSnapshot) MarshalJSON() ([]byte, error) {
+	return json.Marshal(missMilliganSnapshotJSON{
+		Tableau:     s.tableau,
+		Stock:       s.stock,
+		Foundation:  s.foundation,
+		Waived:      s.waived,
+		Phase:       s.phase,
+		MoveCount:   s.moveCount,
+		IsStalemate: s.isStalemate,
+	})
+}
+
+// UnmarshalJSON implements json.Unmarshaler for missMilliganSnapshot.
+func (s *missMilliganSnapshot) UnmarshalJSON(data []byte) error {
+	var j missMilliganSnapshotJSON
+	if err := json.Unmarshal(data, &j); err != nil {
+		return err
+	}
+	if len(j.Stock) > missMilliganMaxSliceLen ||
+		len(j.Waived) > missMilliganMaxSliceLen {
+		return errors.New("missmilligan: snapshot array exceeds maximum allowed size")
+	}
+	for _, pile := range j.Tableau {
+		if len(pile) > missMilliganMaxSliceLen {
+			return errors.New("missmilligan: snapshot pile exceeds maximum allowed size")
+		}
+	}
+	for _, pile := range j.Foundation {
+		if len(pile) > missMilliganMaxSliceLen {
+			return errors.New("missmilligan: snapshot pile exceeds maximum allowed size")
+		}
+	}
+	s.tableau = j.Tableau
+	s.stock = j.Stock
+	s.foundation = j.Foundation
+	s.waived = j.Waived
+	s.phase = j.Phase
+	s.moveCount = j.MoveCount
+	s.isStalemate = j.IsStalemate
+	return nil
+}
+
 // missMilliganJSON is the JSON wire format for MissMilligan.
 type missMilliganJSON struct {
 	TrumpCards  *TrumpCards                                        `json:"tc"`
@@ -708,6 +768,10 @@ type missMilliganJSON struct {
 	MoveCount   int                                                `json:"mc"`
 	ActionLog   []*ActionLogEntry                                  `json:"al"`
 	IsStalemate bool                                               `json:"sl"`
+	// History must round-trip: the Cloudflare Worker is stateless per request
+	// and rebuilds the game from KV every call, so an unpersisted undo stack
+	// means Undo/UndoN/UndoToEscape silently never work in production (#4478).
+	History []*missMilliganSnapshot `json:"hi,omitempty"`
 }
 
 // MarshalJSON KV スナップショット用のシリアライズ
@@ -722,6 +786,7 @@ func (mm *MissMilligan) MarshalJSON() ([]byte, error) {
 		MoveCount:   mm.moveCount,
 		ActionLog:   mm.actionLog,
 		IsStalemate: mm.isStalemate,
+		History:     mm.history,
 	})
 }
 
@@ -734,6 +799,9 @@ func (mm *MissMilligan) UnmarshalJSON(data []byte) error {
 	var j missMilliganJSON
 	if err := json.Unmarshal(data, &j); err != nil {
 		return err
+	}
+	if len(j.ActionLog) > missMilliganMaxSliceLen || len(j.History) > missMilliganMaxSliceLen {
+		return errors.New("missmilligan: input array exceeds maximum allowed size")
 	}
 	if j.Phase < MissMilliganPhasePlaying || j.Phase > MissMilliganPhaseGameOver {
 		return fmt.Errorf("invalid phase: %d", j.Phase)
@@ -768,5 +836,6 @@ func (mm *MissMilligan) UnmarshalJSON(data []byte) error {
 	mm.moveCount = j.MoveCount
 	mm.actionLog = j.ActionLog
 	mm.isStalemate = j.IsStalemate
+	mm.history = j.History
 	return nil
 }

--- a/internal/domain/NapoleonsSquare.go
+++ b/internal/domain/NapoleonsSquare.go
@@ -618,6 +618,66 @@ func (ns *NapoleonsSquare) appendLog(actionType, detail string, cards []*Card) {
 	})
 }
 
+// napoleonsSquareMaxSliceLen caps slice sizes during deserialisation.
+const napoleonsSquareMaxSliceLen = 1000
+
+// napoleonsSquareSnapshotJSON is the wire format for a single undo snapshot.
+// napoleonsSquareSnapshot uses unexported fields, so marshalling it directly would emit
+// `[{},{}]` -- the undo depth would survive but every snapshot would be blank,
+// and Undo would wipe the board instead of rewinding it (#4478).
+type napoleonsSquareSnapshotJSON struct {
+	Tableau     [NapoleonsSquareTableauCnt][]*NapoleonsSquareTableauCard `json:"tb"`
+	Stock       []*Card                                                  `json:"st"`
+	Waste       []*Card                                                  `json:"wa"`
+	Foundation  [NapoleonsSquareFoundationCnt][]*Card                    `json:"fd"`
+	Phase       NapoleonsSquarePhase                                     `json:"ps"`
+	MoveCount   int                                                      `json:"mc"`
+	IsStalemate bool                                                     `json:"sl"`
+}
+
+// MarshalJSON implements json.Marshaler for napoleonsSquareSnapshot.
+func (s *napoleonsSquareSnapshot) MarshalJSON() ([]byte, error) {
+	return json.Marshal(napoleonsSquareSnapshotJSON{
+		Tableau:     s.tableau,
+		Stock:       s.stock,
+		Waste:       s.waste,
+		Foundation:  s.foundation,
+		Phase:       s.phase,
+		MoveCount:   s.moveCount,
+		IsStalemate: s.isStalemate,
+	})
+}
+
+// UnmarshalJSON implements json.Unmarshaler for napoleonsSquareSnapshot.
+func (s *napoleonsSquareSnapshot) UnmarshalJSON(data []byte) error {
+	var j napoleonsSquareSnapshotJSON
+	if err := json.Unmarshal(data, &j); err != nil {
+		return err
+	}
+	if len(j.Stock) > napoleonsSquareMaxSliceLen ||
+		len(j.Waste) > napoleonsSquareMaxSliceLen {
+		return errors.New("napoleonssquare: snapshot array exceeds maximum allowed size")
+	}
+	for _, pile := range j.Tableau {
+		if len(pile) > napoleonsSquareMaxSliceLen {
+			return errors.New("napoleonssquare: snapshot pile exceeds maximum allowed size")
+		}
+	}
+	for _, pile := range j.Foundation {
+		if len(pile) > napoleonsSquareMaxSliceLen {
+			return errors.New("napoleonssquare: snapshot pile exceeds maximum allowed size")
+		}
+	}
+	s.tableau = j.Tableau
+	s.stock = j.Stock
+	s.waste = j.Waste
+	s.foundation = j.Foundation
+	s.phase = j.Phase
+	s.moveCount = j.MoveCount
+	s.isStalemate = j.IsStalemate
+	return nil
+}
+
 // napoleonsSquareJSON is the JSON wire format for NapoleonsSquare.
 type napoleonsSquareJSON struct {
 	TrumpCards  *TrumpCards                                              `json:"tc"`
@@ -629,6 +689,10 @@ type napoleonsSquareJSON struct {
 	MoveCount   int                                                      `json:"mc"`
 	ActionLog   []*ActionLogEntry                                        `json:"al"`
 	IsStalemate bool                                                     `json:"sl"`
+	// History must round-trip: the Cloudflare Worker is stateless per request
+	// and rebuilds the game from KV every call, so an unpersisted undo stack
+	// means Undo/UndoN/UndoToEscape silently never work in production (#4478).
+	History []*napoleonsSquareSnapshot `json:"hi,omitempty"`
 }
 
 // MarshalJSON KV スナップショット用のシリアライズ
@@ -643,6 +707,7 @@ func (ns *NapoleonsSquare) MarshalJSON() ([]byte, error) {
 		MoveCount:   ns.moveCount,
 		ActionLog:   ns.actionLog,
 		IsStalemate: ns.isStalemate,
+		History:     ns.history,
 	})
 }
 
@@ -655,6 +720,9 @@ func (ns *NapoleonsSquare) UnmarshalJSON(data []byte) error {
 	var j napoleonsSquareJSON
 	if err := json.Unmarshal(data, &j); err != nil {
 		return err
+	}
+	if len(j.ActionLog) > napoleonsSquareMaxSliceLen || len(j.History) > napoleonsSquareMaxSliceLen {
+		return errors.New("napoleonssquare: input array exceeds maximum allowed size")
 	}
 	if j.Phase < NapoleonsSquarePhasePlaying || j.Phase > NapoleonsSquarePhaseGameOver {
 		return fmt.Errorf("invalid phase: %d", j.Phase)
@@ -686,5 +754,6 @@ func (ns *NapoleonsSquare) UnmarshalJSON(data []byte) error {
 	ns.moveCount = j.MoveCount
 	ns.actionLog = j.ActionLog
 	ns.isStalemate = j.IsStalemate
+	ns.history = j.History
 	return nil
 }

--- a/internal/domain/SirTommy.go
+++ b/internal/domain/SirTommy.go
@@ -411,6 +411,62 @@ func (s *SirTommy) appendLog(actionType, detail string, cards []*Card) {
 	})
 }
 
+// sirTommyMaxSliceLen caps slice sizes during deserialisation.
+const sirTommyMaxSliceLen = 1000
+
+// sirTommySnapshotJSON is the wire format for a single undo snapshot.
+// sirTommySnapshot uses unexported fields, so marshalling it directly would emit
+// `[{},{}]` -- the undo depth would survive but every snapshot would be blank,
+// and Undo would wipe the board instead of rewinding it (#4478).
+type sirTommySnapshotJSON struct {
+	Foundations [SirTommyFoundationCnt][]*Card `json:"fs"`
+	Wastes      [SirTommyWasteCnt][]*Card      `json:"ws"`
+	Stock       []*Card                        `json:"st"`
+	Phase       SirTommyPhase                  `json:"ps"`
+	MoveCount   int                            `json:"mc"`
+	IsStalemate bool                           `json:"sl"`
+}
+
+// MarshalJSON implements json.Marshaler for sirTommySnapshot.
+func (s *sirTommySnapshot) MarshalJSON() ([]byte, error) {
+	return json.Marshal(sirTommySnapshotJSON{
+		Foundations: s.foundations,
+		Wastes:      s.wastes,
+		Stock:       s.stock,
+		Phase:       s.phase,
+		MoveCount:   s.moveCount,
+		IsStalemate: s.isStalemate,
+	})
+}
+
+// UnmarshalJSON implements json.Unmarshaler for sirTommySnapshot.
+func (s *sirTommySnapshot) UnmarshalJSON(data []byte) error {
+	var j sirTommySnapshotJSON
+	if err := json.Unmarshal(data, &j); err != nil {
+		return err
+	}
+	if len(j.Stock) > sirTommyMaxSliceLen {
+		return errors.New("sirtommy: snapshot array exceeds maximum allowed size")
+	}
+	for _, pile := range j.Foundations {
+		if len(pile) > sirTommyMaxSliceLen {
+			return errors.New("sirtommy: snapshot pile exceeds maximum allowed size")
+		}
+	}
+	for _, pile := range j.Wastes {
+		if len(pile) > sirTommyMaxSliceLen {
+			return errors.New("sirtommy: snapshot pile exceeds maximum allowed size")
+		}
+	}
+	s.foundations = j.Foundations
+	s.wastes = j.Wastes
+	s.stock = j.Stock
+	s.phase = j.Phase
+	s.moveCount = j.MoveCount
+	s.isStalemate = j.IsStalemate
+	return nil
+}
+
 // sirTommyJSON is the JSON wire format for SirTommy.
 type sirTommyJSON struct {
 	TrumpCards  *TrumpCards                    `json:"tc"`
@@ -421,6 +477,10 @@ type sirTommyJSON struct {
 	MoveCount   int                            `json:"mc"`
 	ActionLog   []*ActionLogEntry              `json:"al"`
 	IsStalemate bool                           `json:"sl"`
+	// History must round-trip: the Cloudflare Worker is stateless per request
+	// and rebuilds the game from KV every call, so an unpersisted undo stack
+	// means Undo/UndoN/UndoToEscape silently never work in production (#4478).
+	History []*sirTommySnapshot `json:"hi,omitempty"`
 }
 
 // MarshalJSON KV スナップショット用のシリアライズ
@@ -434,6 +494,7 @@ func (s *SirTommy) MarshalJSON() ([]byte, error) {
 		MoveCount:   s.moveCount,
 		ActionLog:   s.actionLog,
 		IsStalemate: s.isStalemate,
+		History:     s.history,
 	})
 }
 
@@ -444,6 +505,9 @@ func (s *SirTommy) UnmarshalJSON(data []byte) error {
 	var j sirTommyJSON
 	if err := json.Unmarshal(data, &j); err != nil {
 		return err
+	}
+	if len(j.ActionLog) > sirTommyMaxSliceLen || len(j.History) > sirTommyMaxSliceLen {
+		return errors.New("sirtommy: input array exceeds maximum allowed size")
 	}
 	if j.Phase < SirTommyPhasePlaying || j.Phase > SirTommyPhaseGameOver {
 		return fmt.Errorf("invalid phase: %d", j.Phase)
@@ -466,5 +530,6 @@ func (s *SirTommy) UnmarshalJSON(data []byte) error {
 	s.moveCount = j.MoveCount
 	s.actionLog = j.ActionLog
 	s.isStalemate = j.IsStalemate
+	s.history = j.History
 	return nil
 }

--- a/internal/domain/Windmill.go
+++ b/internal/domain/Windmill.go
@@ -652,6 +652,68 @@ func (w *Windmill) appendLog(actionType, detail string, cards []*Card) {
 	})
 }
 
+// windmillMaxSliceLen caps slice sizes during deserialisation.
+const windmillMaxSliceLen = 1000
+
+// windmillSnapshotJSON is the wire format for a single undo snapshot.
+// windmillSnapshot uses unexported fields, so marshalling it directly would emit
+// `[{},{}]` -- the undo depth would survive but every snapshot would be blank,
+// and Undo would wipe the board instead of rewinding it (#4478).
+type windmillSnapshotJSON struct {
+	Center          []*Card                    `json:"ce"`
+	Corners         [WindmillCornerCnt][]*Card `json:"co"`
+	Sails           [WindmillSailCnt]*Card     `json:"sa"`
+	Stock           []*Card                    `json:"st"`
+	Waste           []*Card                    `json:"wa"`
+	TransferBlocked bool                       `json:"tf"`
+	Phase           WindmillPhase              `json:"ps"`
+	MoveCount       int                        `json:"mc"`
+	IsStalemate     bool                       `json:"sl"`
+}
+
+// MarshalJSON implements json.Marshaler for windmillSnapshot.
+func (s *windmillSnapshot) MarshalJSON() ([]byte, error) {
+	return json.Marshal(windmillSnapshotJSON{
+		Center:          s.center,
+		Corners:         s.corners,
+		Sails:           s.sails,
+		Stock:           s.stock,
+		Waste:           s.waste,
+		TransferBlocked: s.transferBlocked,
+		Phase:           s.phase,
+		MoveCount:       s.moveCount,
+		IsStalemate:     s.isStalemate,
+	})
+}
+
+// UnmarshalJSON implements json.Unmarshaler for windmillSnapshot.
+func (s *windmillSnapshot) UnmarshalJSON(data []byte) error {
+	var j windmillSnapshotJSON
+	if err := json.Unmarshal(data, &j); err != nil {
+		return err
+	}
+	if len(j.Center) > windmillMaxSliceLen ||
+		len(j.Stock) > windmillMaxSliceLen ||
+		len(j.Waste) > windmillMaxSliceLen {
+		return errors.New("windmill: snapshot array exceeds maximum allowed size")
+	}
+	for _, pile := range j.Corners {
+		if len(pile) > windmillMaxSliceLen {
+			return errors.New("windmill: snapshot pile exceeds maximum allowed size")
+		}
+	}
+	s.center = j.Center
+	s.corners = j.Corners
+	s.sails = j.Sails
+	s.stock = j.Stock
+	s.waste = j.Waste
+	s.transferBlocked = j.TransferBlocked
+	s.phase = j.Phase
+	s.moveCount = j.MoveCount
+	s.isStalemate = j.IsStalemate
+	return nil
+}
+
 // windmillJSON is the JSON wire format for Windmill.
 type windmillJSON struct {
 	TrumpCards      *TrumpCards                `json:"tc"`
@@ -665,6 +727,10 @@ type windmillJSON struct {
 	MoveCount       int                        `json:"mc"`
 	ActionLog       []*ActionLogEntry          `json:"al"`
 	IsStalemate     bool                       `json:"sl"`
+	// History must round-trip: the Cloudflare Worker is stateless per request
+	// and rebuilds the game from KV every call, so an unpersisted undo stack
+	// means Undo/UndoN/UndoToEscape silently never work in production (#4478).
+	History []*windmillSnapshot `json:"hi,omitempty"`
 }
 
 // MarshalJSON KV スナップショット用のシリアライズ
@@ -681,6 +747,7 @@ func (w *Windmill) MarshalJSON() ([]byte, error) {
 		MoveCount:       w.moveCount,
 		ActionLog:       w.actionLog,
 		IsStalemate:     w.isStalemate,
+		History:         w.history,
 	})
 }
 
@@ -690,6 +757,9 @@ func (w *Windmill) UnmarshalJSON(data []byte) error {
 	var j windmillJSON
 	if err := json.Unmarshal(data, &j); err != nil {
 		return err
+	}
+	if len(j.ActionLog) > windmillMaxSliceLen || len(j.History) > windmillMaxSliceLen {
+		return errors.New("windmill: input array exceeds maximum allowed size")
 	}
 	if j.Phase < WindmillPhasePlaying || j.Phase > WindmillPhaseGameOver {
 		return fmt.Errorf("invalid phase: %d", j.Phase)
@@ -721,5 +791,6 @@ func (w *Windmill) UnmarshalJSON(data []byte) error {
 	w.moveCount = j.MoveCount
 	w.actionLog = j.ActionLog
 	w.isStalemate = j.IsStalemate
+	w.history = j.History
 	return nil
 }

--- a/internal/domain/undo_persistence_test.go
+++ b/internal/domain/undo_persistence_test.go
@@ -1,0 +1,222 @@
+//go:build test
+
+package domain
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The Cloudflare Workers are stateless per request: every call rebuilds the game
+// from KV through UnmarshalJSON. A game whose undo stack does not round-trip
+// therefore reports CanUndo() == false from the second request onwards, so the
+// undo button and the stalemate-escape button silently do nothing in production
+// while working perfectly in the CLI and the local server. See #4478.
+//
+// Asserting on the restored field counts is NOT enough: a snapshot struct with
+// unexported fields marshals to `{}`, which preserves the undo *depth* while
+// losing every position, so Undo would wipe the board instead of rewinding it.
+// Each case below therefore performs a real move, round-trips, and then undoes.
+
+type undoRoundTripCase struct {
+	name string
+	// setup returns a game that has made at least one undoable move, plus the
+	// funcs needed to round-trip and check it.
+	play func(t *testing.T) (game any, canUndo func() bool, undo func() error)
+}
+
+func TestUndoSurvivesAKVRoundTrip(t *testing.T) {
+	cases := []undoRoundTripCase{
+		{"SirTommy", func(t *testing.T) (any, func() bool, func() error) {
+			g := NewDefaultSirTommy()
+			g.Reset()
+			require.NoError(t, g.PlayStockToWaste(0))
+			return g, g.CanUndo, g.Undo
+		}},
+		{"Bisley", func(t *testing.T) (any, func() bool, func() error) {
+			g := NewDefaultBisley()
+			g.Reset()
+			// Bisley opens with the four Aces already up, so a foundation move
+			// always exists on a fresh deal.
+			require.NoError(t, g.AutoComplete())
+			return g, g.CanUndo, g.Undo
+		}},
+		{"NapoleonsSquare", func(t *testing.T) (any, func() bool, func() error) {
+			g := NewDefaultNapoleonsSquare()
+			g.Reset()
+			require.NoError(t, g.Draw())
+			return g, g.CanUndo, g.Undo
+		}},
+		{"GrandfathersClock", func(t *testing.T) (any, func() bool, func() error) {
+			g := NewDefaultGrandfathersClock()
+			g.Reset()
+			h := g.GetHint()
+			require.NotNil(t, h, "a fresh clock always has a move")
+			require.Equal(t, "foundation", h.ToZone, "the first hint sends a card up")
+			require.NoError(t, g.MoveTableauToFoundation(h.FromCol, h.ToIdx))
+			return g, g.CanUndo, g.Undo
+		}},
+		{"MissMilligan", func(t *testing.T) (any, func() bool, func() error) {
+			g := NewDefaultMissMilligan()
+			g.Reset()
+			require.NoError(t, g.Deal())
+			return g, g.CanUndo, g.Undo
+		}},
+		{"Duchess", func(t *testing.T) (any, func() bool, func() error) {
+			g := NewDefaultDuchess()
+			g.Reset()
+			require.NoError(t, g.ChooseBaseRank(0))
+			return g, g.CanUndo, g.Undo
+		}},
+		{"Windmill", func(t *testing.T) (any, func() bool, func() error) {
+			g := NewDefaultWindmill()
+			g.Reset()
+			require.NoError(t, g.Draw())
+			return g, g.CanUndo, g.Undo
+		}},
+		{"AmericanToad", func(t *testing.T) (any, func() bool, func() error) {
+			g := NewDefaultAmericanToad()
+			g.Reset()
+			require.NoError(t, g.Draw())
+			return g, g.CanUndo, g.Undo
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			game, canUndo, _ := tc.play(t)
+			require.True(t, canUndo(), "the test needs an undoable move to be meaningful")
+
+			data, err := json.Marshal(game)
+			require.NoError(t, err)
+
+			// Round-trip into a fresh instance the way the Worker does.
+			restored := newEmptyLike(t, tc.name)
+			require.NoError(t, json.Unmarshal(data, restored))
+
+			ru, rundo := undoFuncsFor(t, tc.name, restored)
+			assert.True(t, ru(), "the undo stack must survive KV")
+			assert.NoError(t, rundo(), "and undoing must actually work")
+		})
+	}
+}
+
+// newEmptyLike builds a fresh game of the named type, standing in for the
+// Worker's RestoreXInteractor path.
+func newEmptyLike(t *testing.T, name string) any {
+	t.Helper()
+	switch name {
+	case "SirTommy":
+		return NewDefaultSirTommy()
+	case "Bisley":
+		return NewDefaultBisley()
+	case "NapoleonsSquare":
+		return NewDefaultNapoleonsSquare()
+	case "GrandfathersClock":
+		return NewDefaultGrandfathersClock()
+	case "MissMilligan":
+		return NewDefaultMissMilligan()
+	case "Duchess":
+		return NewDefaultDuchess()
+	case "Windmill":
+		return NewDefaultWindmill()
+	case "AmericanToad":
+		return NewDefaultAmericanToad()
+	}
+	t.Fatalf("unknown game %q", name)
+	return nil
+}
+
+func undoFuncsFor(t *testing.T, name string, g any) (func() bool, func() error) {
+	t.Helper()
+	type undoable interface {
+		CanUndo() bool
+		Undo() error
+	}
+	u, ok := g.(undoable)
+	require.True(t, ok, "%s must expose CanUndo/Undo", name)
+	return u.CanUndo, u.Undo
+}
+
+// historyFieldRe finds a domain type that keeps an undo stack.
+var historyFieldRe = regexp.MustCompile(`(?m)^\s+history\s+\[\]\*(\w+)`)
+
+// persistedHistoryRe reports whether a snapshot type reaches the wire. Struct
+// fields are gofmt-aligned, so the gap before the tag is arbitrary whitespace --
+// matching on a single space silently marks 35 correct games as broken.
+func persistedHistoryRe(snapshot string) *regexp.Regexp {
+	return regexp.MustCompile(`\[\]\*` + regexp.QuoteMeta(snapshot) + `\s+` + "`" + `json:`)
+}
+
+// knownUnpersistedHistories are games that predate #4478 and still lose their
+// undo stack across a KV round trip. The list is deliberately explicit and
+// finite: it exists so the guard below fails for anything NEW, and it must only
+// ever shrink. Do not add to it -- fix the game instead.
+var knownUnpersistedHistories = map[string]string{
+	"BlackHole":      "#4478",
+	"DoubleKlondike": "#4478",
+	"LaBelleLucie":   "#4478",
+	"Nertz":          "#4478",
+	"RussianBank":    "#4478",
+	"SimpleSimon":    "#4478",
+}
+
+// A new game that keeps an undo stack must persist it, or its undo button is
+// dead in production. Nothing else catches that, because the CLI and the local
+// server keep state in-process (#4478).
+func TestEveryUndoStackIsPersisted(t *testing.T) {
+	files, err := filepath.Glob("*.go")
+	require.NoError(t, err)
+
+	sources := map[string]string{}
+	for _, f := range files {
+		if strings.HasSuffix(f, "_test.go") {
+			continue
+		}
+		b, err := os.ReadFile(f)
+		require.NoError(t, err)
+		sources[f] = string(b)
+	}
+
+	var offenders []string
+	for f, src := range sources {
+		m := historyFieldRe.FindStringSubmatch(src)
+		if m == nil {
+			continue
+		}
+		game := strings.TrimSuffix(filepath.Base(f), ".go")
+		snapshot := m[1]
+
+		// The snapshot type must appear in some wire struct with a json tag.
+		persisted := false
+		want := persistedHistoryRe(snapshot)
+		for _, other := range sources {
+			if want.MatchString(other) {
+				persisted = true
+				break
+			}
+		}
+		if persisted {
+			assert.NotContains(t, knownUnpersistedHistories, game,
+				"%s now persists its history -- remove it from knownUnpersistedHistories", game)
+			continue
+		}
+		if _, known := knownUnpersistedHistories[game]; known {
+			continue
+		}
+		offenders = append(offenders, game)
+	}
+
+	assert.Empty(t, offenders,
+		"these games keep an undo stack that never reaches KV, so Undo/UndoN and the "+
+			"stalemate-escape button do nothing on the Cloudflare Workers. Give the "+
+			"snapshot type its own MarshalJSON/UnmarshalJSON and add a History field "+
+			"with a json tag to the wire struct -- see AmericanToad or Canfield, and #4478")
+}

--- a/internal/domain/undo_persistence_test.go
+++ b/internal/domain/undo_persistence_test.go
@@ -220,3 +220,171 @@ func TestEveryUndoStackIsPersisted(t *testing.T) {
 			"snapshot type its own MarshalJSON/UnmarshalJSON and add a History field "+
 			"with a json tag to the wire struct -- see AmericanToad or Canfield, and #4478")
 }
+
+// bigCards returns a slice long enough to trip a MaxSliceLen guard.
+func bigCards(n int) []*Card {
+	out := make([]*Card, n)
+	for i := range out {
+		out[i] = NewCard(CardDesignSpade, 1, true)
+	}
+	return out
+}
+
+// bigLog returns an action log long enough to trip a MaxSliceLen guard.
+func bigLog(n int) []*ActionLogEntry {
+	out := make([]*ActionLogEntry, n)
+	for i := range out {
+		out[i] = &ActionLogEntry{}
+	}
+	return out
+}
+
+// KV holds whatever an earlier version -- or a tampering client -- wrote, and a
+// snapshot is just as reachable as the top-level state. Both layers need bounds,
+// and the guards added with the History field are only real if something trips
+// them (#4478).
+func TestUndoPersistenceRespectsMaxSliceLen(t *testing.T) {
+	const over = 1001
+
+	cases := []struct {
+		name string
+		// tooManySnapshots marshals a wire payload whose History is oversized.
+		tooManySnapshots func() ([]byte, error)
+		// tooLongLog marshals a wire payload whose ActionLog is oversized.
+		tooLongLog func() ([]byte, error)
+		// bloatedSnapshot marshals a single snapshot with an oversized pile.
+		bloatedSnapshot func() ([]byte, error)
+		// restore feeds bytes to the game's UnmarshalJSON.
+		restore func([]byte) error
+		// restoreSnapshot feeds bytes to the snapshot's UnmarshalJSON.
+		restoreSnapshot func([]byte) error
+	}{
+		{
+			name: "SirTommy",
+			tooManySnapshots: func() ([]byte, error) {
+				return json.Marshal(&sirTommyJSON{History: make([]*sirTommySnapshot, over)})
+			},
+			tooLongLog: func() ([]byte, error) {
+				return json.Marshal(&sirTommyJSON{ActionLog: bigLog(over)})
+			},
+			bloatedSnapshot: func() ([]byte, error) {
+				return json.Marshal(&sirTommySnapshotJSON{Stock: bigCards(over)})
+			},
+			restore:         func(b []byte) error { return NewDefaultSirTommy().UnmarshalJSON(b) },
+			restoreSnapshot: func(b []byte) error { return new(sirTommySnapshot).UnmarshalJSON(b) },
+		},
+		{
+			name: "Bisley",
+			tooManySnapshots: func() ([]byte, error) {
+				return json.Marshal(&bisleyJSON{History: make([]*bisleySnapshot, over)})
+			},
+			tooLongLog: func() ([]byte, error) {
+				return json.Marshal(&bisleyJSON{ActionLog: bigLog(over)})
+			},
+			bloatedSnapshot: func() ([]byte, error) {
+				return json.Marshal(&bisleySnapshotJSON{
+					AceFoundations: [BisleyFoundationCnt][]*Card{bigCards(over)},
+				})
+			},
+			restore:         func(b []byte) error { return NewDefaultBisley().UnmarshalJSON(b) },
+			restoreSnapshot: func(b []byte) error { return new(bisleySnapshot).UnmarshalJSON(b) },
+		},
+		{
+			name: "NapoleonsSquare",
+			tooManySnapshots: func() ([]byte, error) {
+				return json.Marshal(&napoleonsSquareJSON{History: make([]*napoleonsSquareSnapshot, over)})
+			},
+			tooLongLog: func() ([]byte, error) {
+				return json.Marshal(&napoleonsSquareJSON{ActionLog: bigLog(over)})
+			},
+			bloatedSnapshot: func() ([]byte, error) {
+				return json.Marshal(&napoleonsSquareSnapshotJSON{Stock: bigCards(over)})
+			},
+			restore:         func(b []byte) error { return NewDefaultNapoleonsSquare().UnmarshalJSON(b) },
+			restoreSnapshot: func(b []byte) error { return new(napoleonsSquareSnapshot).UnmarshalJSON(b) },
+		},
+		{
+			name: "GrandfathersClock",
+			tooManySnapshots: func() ([]byte, error) {
+				return json.Marshal(&grandfathersClockJSON{History: make([]*grandfathersClockSnapshot, over)})
+			},
+			tooLongLog: func() ([]byte, error) {
+				return json.Marshal(&grandfathersClockJSON{ActionLog: bigLog(over)})
+			},
+			bloatedSnapshot: func() ([]byte, error) {
+				return json.Marshal(&grandfathersClockSnapshotJSON{
+					Foundation: [GrandfathersClockFoundationCnt][]*Card{bigCards(over)},
+				})
+			},
+			restore:         func(b []byte) error { return NewDefaultGrandfathersClock().UnmarshalJSON(b) },
+			restoreSnapshot: func(b []byte) error { return new(grandfathersClockSnapshot).UnmarshalJSON(b) },
+		},
+		{
+			name: "MissMilligan",
+			tooManySnapshots: func() ([]byte, error) {
+				return json.Marshal(&missMilliganJSON{History: make([]*missMilliganSnapshot, over)})
+			},
+			tooLongLog: func() ([]byte, error) {
+				return json.Marshal(&missMilliganJSON{ActionLog: bigLog(over)})
+			},
+			bloatedSnapshot: func() ([]byte, error) {
+				return json.Marshal(&missMilliganSnapshotJSON{Stock: bigCards(over)})
+			},
+			restore:         func(b []byte) error { return NewDefaultMissMilligan().UnmarshalJSON(b) },
+			restoreSnapshot: func(b []byte) error { return new(missMilliganSnapshot).UnmarshalJSON(b) },
+		},
+		{
+			name: "Duchess",
+			tooManySnapshots: func() ([]byte, error) {
+				return json.Marshal(&duchessJSON{History: make([]*duchessSnapshot, over)})
+			},
+			tooLongLog: func() ([]byte, error) {
+				return json.Marshal(&duchessJSON{ActionLog: bigLog(over)})
+			},
+			bloatedSnapshot: func() ([]byte, error) {
+				return json.Marshal(&duchessSnapshotJSON{Stock: bigCards(over)})
+			},
+			restore:         func(b []byte) error { return NewDefaultDuchess().UnmarshalJSON(b) },
+			restoreSnapshot: func(b []byte) error { return new(duchessSnapshot).UnmarshalJSON(b) },
+		},
+		{
+			name: "Windmill",
+			tooManySnapshots: func() ([]byte, error) {
+				return json.Marshal(&windmillJSON{History: make([]*windmillSnapshot, over)})
+			},
+			tooLongLog: func() ([]byte, error) {
+				return json.Marshal(&windmillJSON{ActionLog: bigLog(over)})
+			},
+			bloatedSnapshot: func() ([]byte, error) {
+				return json.Marshal(&windmillSnapshotJSON{Stock: bigCards(over)})
+			},
+			restore:         func(b []byte) error { return NewDefaultWindmill().UnmarshalJSON(b) },
+			restoreSnapshot: func(b []byte) error { return new(windmillSnapshot).UnmarshalJSON(b) },
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			for name, build := range map[string]func() ([]byte, error){
+				"too many snapshots":     tc.tooManySnapshots,
+				"too long an action log": tc.tooLongLog,
+			} {
+				t.Run(name, func(t *testing.T) {
+					data, err := build()
+					require.NoError(t, err)
+					assert.Error(t, tc.restore(data))
+				})
+			}
+
+			t.Run("an oversized pile inside a snapshot", func(t *testing.T) {
+				data, err := tc.bloatedSnapshot()
+				require.NoError(t, err)
+				assert.Error(t, tc.restoreSnapshot(data))
+			})
+
+			t.Run("malformed snapshot json", func(t *testing.T) {
+				assert.Error(t, tc.restoreSnapshot([]byte("not json")))
+			})
+		})
+	}
+}


### PR DESCRIPTION
Part of #4478.

## 何が壊れていたか

Cloudflare Worker はリクエストごとにステートレスで、毎回 KV から `UnmarshalJSON` でゲームを組み直します。#4375–#4419 バッチで追加した 7 ゲームは**アンドゥ履歴を wire に載せていなかった**ため、本番では:

- 2 リクエスト目以降 `CanUndo()` が常に false
- 「元に戻す」ボタンが効かない
- **マニュアルに書いてある手詰まり脱出ボタン（`undo_n`）も効かない**

CLI とローカル web サーバーはプロセス内に状態を持つので完全に動きます。**だからテストも E2E も自分の手動確認も全部通っていました。**

対象 7 件: `SirTommy` / `Bisley` / `NapoleonsSquare` / `GrandfathersClock` / `MissMilligan` / `Duchess` / `Windmill`
（`AmericanToad` は #4477 のレビュー指摘で修正済み。この PR はその横展開です）

## 実装

各スナップショット型に**専用の wire 構造体 + `MarshalJSON`/`UnmarshalJSON`** を実装しました。スナップショットのスライスをそのまま marshal するだけでは不十分です — フィールドが非公開なので `[{},{}]` が保存され、**アンドゥの深さだけ残って中身が空**になります。つまり Undo が盤面を巻き戻すのではなく**消し飛ばす**という、より悪い壊れ方をします。

あわせて `x MaxSliceLen`（1000）ガードを、トップレベルの `History` / `ActionLog` と**スナップショット内の各スライス**の両方にかけています。

## テスト（いずれもネガティブコントロール済み）

**`TestUndoSurvivesAKVRoundTrip`** — 8 ゲームすべてで「実際に 1 手指す → Marshal → Unmarshal → 本当に Undo する」まで通します。復元後のフィールド数を見るだけでは上記の空スナップショット退行を捕まえられません。

**`TestEveryUndoStackIsPersisted`** — 再発防止ガード。`history []*xSnapshot` を持つドメインは、その型が wire 構造体に到達していなければ FAIL します。3 通りで検証しました:

| 検証 | 結果 |
|---|---|
| 履歴を永続化しない**新規ゲーム**を追加 | ✅ FAIL する（`[ZzFakeGame]`） |
| 既知リストのゲームを直したのにリストに残す | ✅ FAIL する（リストは縮む方向にしか動かせない） |
| **既に正しい 35 ゲーム** | ✅ 鳴らない |

3 つ目が特に重要でした。**最初の実装は構造体タグ前のスペースを 1 個と決め打ちしていたため、正しい 35 ゲームすべてを「壊れている」と報告していました**（gofmt はタグを可変幅で揃えるため）。ガードは「捕まえること」だけでなく「正しいコードで鳴らないこと」も確かめないと使い物になりません。

既存の 6 件（`BlackHole` / `DoubleKlondike` / `LaBelleLucie` / `Nertz` / `RussianBank` / `SimpleSimon`）はリストに残し、#4478 で追跡します。

## 根本原因

**兄弟ゲームから派生させると、兄弟の「抜け」も一緒にコピーされます。** アンドゥ履歴を持つ 50 ドメインのうち 36 は正しく永続化していて、私が参照したものがたまたま残り 14 の側でした。今回入れたガードは、次の新規ゲームで同じことが起きるのを止めます。

## テスト計画

- [x] `go test -tags test ./...` — パス（後述の既知フレーク 1 件を除く）
- [x] `golangci-lint run ./...` — 0 issues
- [x] ガードを 3 通りでネガティブコントロール
- [x] 8 ゲームすべてで KV ラウンドトリップ後の Undo が実際に成功することを確認

> **注記**: `TestTonk_GameEnd` が `-count=40` で落ちますが、**このブランチを stash して clean な `develop` で走らせても同じように落ちます**。本 PR は Tonk に一切触れていません。既知のフレークで、2026-05-22 に無関係なフロントエンド専用 PR (#1972) でも観測されています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)