### PR TITLE
fix(solitaire): persist the undo stack in the last six games (closes #4478)

### DIFF
--- a/internal/domain/BlackHoleState.go
+++ b/internal/domain/BlackHoleState.go
@@ -10,7 +10,7 @@ import (
 var errBlackHole = errors.New("blackhole: invalid state")
 
 // blackHoleJSON は BlackHole の JSON ワイヤ形式。配り切ると trumpCards は空になるため
-// 保存しない。history も永続化対象外。
+// 保存しない。
 type blackHoleJSON struct {
 	Fans      [][]*Card         `json:"fn"`
 	BlackHole []*Card           `json:"bh"`

--- a/internal/domain/BlackHoleState.go
+++ b/internal/domain/BlackHoleState.go
@@ -17,6 +17,10 @@ type blackHoleJSON struct {
 	Phase     BlackHolePhase    `json:"ph"`
 	MoveCount int               `json:"mc"`
 	ActionLog []*ActionLogEntry `json:"al"`
+	// History must round-trip: the Cloudflare Worker is stateless per request
+	// and rebuilds the game from KV every call, so an unpersisted undo stack
+	// means Undo/UndoN/UndoToEscape silently never work in production (#4478).
+	History []*blackHoleSnapshot `json:"hi,omitempty"`
 }
 
 // MarshalJSON implements json.Marshaler.
@@ -27,6 +31,7 @@ func (g *BlackHole) MarshalJSON() ([]byte, error) {
 		Phase:     g.phase,
 		MoveCount: g.moveCount,
 		ActionLog: g.actionLog,
+		History:   g.history,
 	})
 }
 
@@ -51,7 +56,52 @@ func (g *BlackHole) UnmarshalJSON(data []byte) error {
 	g.blackHole = j.BlackHole
 	g.phase = j.Phase
 	g.moveCount = j.MoveCount
+	if len(j.History) > blackHoleMaxSliceLen {
+		return errors.New("blackhole: history exceeds maximum allowed size")
+	}
 	g.actionLog = j.ActionLog
-	g.history = nil
+	g.history = j.History
+	return nil
+}
+
+// blackHoleSnapshotJSON is the wire format for a single undo snapshot.
+// blackHoleSnapshot uses unexported fields, so marshalling it directly would
+// emit `[{},{}]` -- the undo depth would survive but every snapshot would be
+// blank, and Undo would wipe the board instead of rewinding it (#4478).
+type blackHoleSnapshotJSON struct {
+	Fans      [][]*Card      `json:"fn"`
+	BlackHole []*Card        `json:"bh"`
+	Phase     BlackHolePhase `json:"ph"`
+	MoveCount int            `json:"mc"`
+}
+
+// MarshalJSON implements json.Marshaler for blackHoleSnapshot.
+func (s *blackHoleSnapshot) MarshalJSON() ([]byte, error) {
+	return json.Marshal(blackHoleSnapshotJSON{
+		Fans:      s.fans,
+		BlackHole: s.blackHole,
+		Phase:     s.phase,
+		MoveCount: s.moveCount,
+	})
+}
+
+// UnmarshalJSON implements json.Unmarshaler for blackHoleSnapshot.
+func (s *blackHoleSnapshot) UnmarshalJSON(data []byte) error {
+	var j blackHoleSnapshotJSON
+	if err := json.Unmarshal(data, &j); err != nil {
+		return err
+	}
+	if len(j.Fans) > blackHoleMaxSliceLen || len(j.BlackHole) > blackHoleMaxSliceLen {
+		return errors.New("blackhole: snapshot array exceeds maximum allowed size")
+	}
+	for _, fan := range j.Fans {
+		if len(fan) > blackHoleMaxSliceLen {
+			return errors.New("blackhole: snapshot fan exceeds maximum allowed size")
+		}
+	}
+	s.fans = j.Fans
+	s.blackHole = j.BlackHole
+	s.phase = j.Phase
+	s.moveCount = j.MoveCount
 	return nil
 }

--- a/internal/domain/DoubleKlondikeState.go
+++ b/internal/domain/DoubleKlondikeState.go
@@ -19,6 +19,10 @@ type doubleKlondikeJSON struct {
 	Phase      DoubleKlondikePhase                                    `json:"ph"`
 	MoveCount  int                                                    `json:"mc"`
 	ActionLog  []*ActionLogEntry                                      `json:"al"`
+	// History must round-trip: the Cloudflare Worker is stateless per request
+	// and rebuilds the game from KV every call, so an unpersisted undo stack
+	// means Undo/UndoN/UndoToEscape silently never work in production (#4478).
+	History []*doubleKlondikeSnapshot `json:"hi,omitempty"`
 }
 
 // MarshalJSON implements json.Marshaler.
@@ -31,6 +35,7 @@ func (g *DoubleKlondike) MarshalJSON() ([]byte, error) {
 		Phase:      g.phase,
 		MoveCount:  g.moveCount,
 		ActionLog:  g.actionLog,
+		History:    g.history,
 	})
 }
 
@@ -62,7 +67,63 @@ func (g *DoubleKlondike) UnmarshalJSON(data []byte) error {
 	g.foundation = j.Foundation
 	g.phase = j.Phase
 	g.moveCount = j.MoveCount
+	if len(j.History) > doubleKlondikeMaxSliceLen {
+		return errors.New("doubleklondike: history exceeds maximum allowed size")
+	}
 	g.actionLog = j.ActionLog
-	g.history = nil
+	g.history = j.History
+	return nil
+}
+
+// doubleKlondikeSnapshotJSON is the wire format for a single undo snapshot.
+// doubleKlondikeSnapshot uses unexported fields, so marshalling it directly
+// would emit `[{},{}]` -- the undo depth would survive but every snapshot would
+// be blank, and Undo would wipe the board instead of rewinding it (#4478).
+type doubleKlondikeSnapshotJSON struct {
+	Tableau    [DoubleKlondikeTableauCnt][]*DoubleKlondikeTableauCard `json:"tb"`
+	Stock      []*Card                                                `json:"st"`
+	Waste      []*Card                                                `json:"ws"`
+	Foundation [DoubleKlondikeFoundationCnt][]*Card                   `json:"fd"`
+	Phase      DoubleKlondikePhase                                    `json:"ph"`
+	MoveCount  int                                                    `json:"mc"`
+}
+
+// MarshalJSON implements json.Marshaler for doubleKlondikeSnapshot.
+func (s *doubleKlondikeSnapshot) MarshalJSON() ([]byte, error) {
+	return json.Marshal(doubleKlondikeSnapshotJSON{
+		Tableau:    s.tableau,
+		Stock:      s.stock,
+		Waste:      s.waste,
+		Foundation: s.foundation,
+		Phase:      s.phase,
+		MoveCount:  s.moveCount,
+	})
+}
+
+// UnmarshalJSON implements json.Unmarshaler for doubleKlondikeSnapshot.
+func (s *doubleKlondikeSnapshot) UnmarshalJSON(data []byte) error {
+	var j doubleKlondikeSnapshotJSON
+	if err := json.Unmarshal(data, &j); err != nil {
+		return err
+	}
+	if len(j.Stock) > doubleKlondikeMaxSliceLen || len(j.Waste) > doubleKlondikeMaxSliceLen {
+		return errors.New("doubleklondike: snapshot array exceeds maximum allowed size")
+	}
+	for _, col := range j.Tableau {
+		if len(col) > doubleKlondikeMaxSliceLen {
+			return errors.New("doubleklondike: snapshot column exceeds maximum allowed size")
+		}
+	}
+	for _, pile := range j.Foundation {
+		if len(pile) > doubleKlondikeMaxSliceLen {
+			return errors.New("doubleklondike: snapshot pile exceeds maximum allowed size")
+		}
+	}
+	s.tableau = j.Tableau
+	s.stock = j.Stock
+	s.waste = j.Waste
+	s.foundation = j.Foundation
+	s.phase = j.Phase
+	s.moveCount = j.MoveCount
 	return nil
 }

--- a/internal/domain/DoubleKlondikeState.go
+++ b/internal/domain/DoubleKlondikeState.go
@@ -10,7 +10,7 @@ import (
 var errDoubleKlondike = errors.New("doubleklondike: invalid state")
 
 // doubleKlondikeJSON は DoubleKlondike の JSON ワイヤ形式。配り切ると trumpCards は
-// 空になるため保存しない。history も永続化対象外。
+// 空になるため保存しない。
 type doubleKlondikeJSON struct {
 	Tableau    [DoubleKlondikeTableauCnt][]*DoubleKlondikeTableauCard `json:"tb"`
 	Stock      []*Card                                                `json:"st"`

--- a/internal/domain/LaBelleLucieState.go
+++ b/internal/domain/LaBelleLucieState.go
@@ -18,6 +18,10 @@ type laBelleLucieJSON struct {
 	Phase       LaBelleLuciePhase                  `json:"ph"`
 	MoveCount   int                                `json:"mc"`
 	ActionLog   []*ActionLogEntry                  `json:"al"`
+	// History must round-trip: the Cloudflare Worker is stateless per request
+	// and rebuilds the game from KV every call, so an unpersisted undo stack
+	// means Undo/UndoN/UndoToEscape silently never work in production (#4478).
+	History []*laBelleLucieSnapshot `json:"hi,omitempty"`
 }
 
 // MarshalJSON implements json.Marshaler.
@@ -29,6 +33,7 @@ func (g *LaBelleLucie) MarshalJSON() ([]byte, error) {
 		Phase:       g.phase,
 		MoveCount:   g.moveCount,
 		ActionLog:   g.actionLog,
+		History:     g.history,
 	})
 }
 
@@ -49,7 +54,60 @@ func (g *LaBelleLucie) UnmarshalJSON(data []byte) error {
 	g.redealsLeft = j.RedealsLeft
 	g.phase = j.Phase
 	g.moveCount = j.MoveCount
+	if len(j.History) > laBelleLucieMaxSliceLen {
+		return errors.New("labellelucie: history exceeds maximum allowed size")
+	}
 	g.actionLog = j.ActionLog
-	g.history = nil
+	g.history = j.History
+	return nil
+}
+
+// laBelleLucieSnapshotJSON is the wire format for a single undo snapshot.
+// laBelleLucieSnapshot uses unexported fields, so marshalling it directly would
+// emit `[{},{}]` -- the undo depth would survive but every snapshot would be
+// blank, and Undo would wipe the board instead of rewinding it (#4478).
+type laBelleLucieSnapshotJSON struct {
+	Fans        [][]*Card                          `json:"fn"`
+	Foundation  [LaBelleLucieFoundationCnt][]*Card `json:"fd"`
+	RedealsLeft int                                `json:"rd"`
+	Phase       LaBelleLuciePhase                  `json:"ph"`
+	MoveCount   int                                `json:"mc"`
+}
+
+// MarshalJSON implements json.Marshaler for laBelleLucieSnapshot.
+func (s *laBelleLucieSnapshot) MarshalJSON() ([]byte, error) {
+	return json.Marshal(laBelleLucieSnapshotJSON{
+		Fans:        s.fans,
+		Foundation:  s.foundation,
+		RedealsLeft: s.redealsLeft,
+		Phase:       s.phase,
+		MoveCount:   s.moveCount,
+	})
+}
+
+// UnmarshalJSON implements json.Unmarshaler for laBelleLucieSnapshot.
+func (s *laBelleLucieSnapshot) UnmarshalJSON(data []byte) error {
+	var j laBelleLucieSnapshotJSON
+	if err := json.Unmarshal(data, &j); err != nil {
+		return err
+	}
+	if len(j.Fans) > laBelleLucieMaxSliceLen {
+		return errors.New("labellelucie: snapshot fan count exceeds maximum allowed size")
+	}
+	for _, fan := range j.Fans {
+		if len(fan) > laBelleLucieMaxSliceLen {
+			return errors.New("labellelucie: snapshot fan exceeds maximum allowed size")
+		}
+	}
+	for _, pile := range j.Foundation {
+		if len(pile) > laBelleLucieMaxSliceLen {
+			return errors.New("labellelucie: snapshot pile exceeds maximum allowed size")
+		}
+	}
+	s.fans = j.Fans
+	s.foundation = j.Foundation
+	s.redealsLeft = j.RedealsLeft
+	s.phase = j.Phase
+	s.moveCount = j.MoveCount
 	return nil
 }

--- a/internal/domain/LaBelleLucieState.go
+++ b/internal/domain/LaBelleLucieState.go
@@ -10,7 +10,7 @@ import (
 var errLaBelleLucie = errors.New("labellelucie: invalid state")
 
 // laBelleLucieJSON は LaBelleLucie の JSON ワイヤ形式。配り切ると trumpCards は空に
-// なるため保存しない。history も永続化対象外。
+// なるため保存しない。
 type laBelleLucieJSON struct {
 	Fans        [][]*Card                          `json:"fn"`
 	Foundation  [LaBelleLucieFoundationCnt][]*Card `json:"fd"`

--- a/internal/domain/Nertz.go
+++ b/internal/domain/Nertz.go
@@ -1164,6 +1164,10 @@ type nertzJSON struct {
 	MatchWinner int                `json:"mw"`
 	MoveCount   int                `json:"mc"`
 	ActionLog   []*ActionLogEntry  `json:"al"`
+	// History must round-trip: the Cloudflare Worker is stateless per request
+	// and rebuilds the game from KV every call, so an unpersisted undo stack
+	// means Undo/UndoN/UndoToEscape silently never work in production (#4478).
+	History []*nertzSnapshot `json:"hi,omitempty"`
 }
 
 // MarshalJSON implements json.Marshaler.
@@ -1179,6 +1183,7 @@ func (g *Nertz) MarshalJSON() ([]byte, error) {
 		MatchWinner: g.matchWinner,
 		MoveCount:   g.moveCount,
 		ActionLog:   g.actionLog,
+		History:     g.history,
 	})
 }
 
@@ -1201,7 +1206,59 @@ func (g *Nertz) UnmarshalJSON(data []byte) error {
 	g.winnerIdx = j.WinnerIdx
 	g.matchWinner = j.MatchWinner
 	g.moveCount = j.MoveCount
+	if len(j.History) > nertzMaxSliceLen {
+		return errors.New("nertz: history exceeds maximum allowed size")
+	}
 	g.actionLog = j.ActionLog
-	g.history = nil
+	g.history = j.History
+	return nil
+}
+
+// nertzSnapshotMaxBytes bounds one embedded snapshot document. A full table is
+// a few KB, so 1 MiB is far above any legitimate value and exists only to stop
+// a hostile KV entry from being expanded.
+const nertzSnapshotMaxBytes = 1 << 20
+
+// nertzSnapshotJSON is the wire format for a single undo snapshot.
+// nertzSnapshot uses unexported fields, so marshalling it directly would emit
+// `[{},{}]` -- the undo depth would survive but every snapshot would be blank,
+// and Undo would wipe the board instead of rewinding it (#4478).
+//
+// The two document fields ride as json.RawMessage rather than []byte: a []byte
+// would be re-encoded as base64 on every save, which costs a third more bytes
+// per snapshot in KV for no benefit.
+type nertzSnapshotJSON struct {
+	Players     json.RawMessage `json:"pl"`
+	Foundations json.RawMessage `json:"fd"`
+	Phase       NertzPhase      `json:"ph"`
+	MoveCount   int             `json:"mc"`
+	WinnerIdx   int             `json:"wi"`
+}
+
+// MarshalJSON implements json.Marshaler for nertzSnapshot.
+func (s *nertzSnapshot) MarshalJSON() ([]byte, error) {
+	return json.Marshal(nertzSnapshotJSON{
+		Players:     s.playersJSON,
+		Foundations: s.foundationsJSON,
+		Phase:       s.phase,
+		MoveCount:   s.moveCount,
+		WinnerIdx:   s.winnerIdx,
+	})
+}
+
+// UnmarshalJSON implements json.Unmarshaler for nertzSnapshot.
+func (s *nertzSnapshot) UnmarshalJSON(data []byte) error {
+	var j nertzSnapshotJSON
+	if err := json.Unmarshal(data, &j); err != nil {
+		return err
+	}
+	if len(j.Players) > nertzSnapshotMaxBytes || len(j.Foundations) > nertzSnapshotMaxBytes {
+		return errors.New("nertz: snapshot document exceeds maximum allowed size")
+	}
+	s.playersJSON = j.Players
+	s.foundationsJSON = j.Foundations
+	s.phase = j.Phase
+	s.moveCount = j.MoveCount
+	s.winnerIdx = j.WinnerIdx
 	return nil
 }

--- a/internal/domain/RussianBankState.go
+++ b/internal/domain/RussianBankState.go
@@ -18,7 +18,12 @@ func (g *RussianBank) takeSnapshot() {
 	if g.current != 0 || g.phase != RussianBankPhasePlaying {
 		return
 	}
-	b, err := json.Marshal(g)
+	// boardJSON, NOT MarshalJSON. MarshalJSON now carries the undo history, so
+	// snapshotting through it would embed every earlier snapshot inside the new
+	// one and double the payload on every move: measured 5.6 KB after move 1,
+	// 1.45 MB after move 9. Past ~1 MiB the snapshot codec rejects it and the
+	// whole session stops restoring from KV.
+	b, err := json.Marshal(g.boardJSON())
 	if err != nil {
 		return
 	}
@@ -137,9 +142,10 @@ type russianBankJSON struct {
 	History []*russianBankSnapshot `json:"hi,omitempty"`
 }
 
-// MarshalJSON implements json.Marshaler.
-func (g *RussianBank) MarshalJSON() ([]byte, error) {
-	return json.Marshal(russianBankJSON{
+// boardJSON projects the board into the wire struct WITHOUT the undo history.
+// takeSnapshot marshals this; MarshalJSON adds the history on top.
+func (g *RussianBank) boardJSON() russianBankJSON {
+	return russianBankJSON{
 		Players:     g.players,
 		Tableau:     g.tableau,
 		Foundations: g.foundations,
@@ -151,8 +157,14 @@ func (g *RussianBank) MarshalJSON() ([]byte, error) {
 		PassStreak:  g.passStreak,
 		StopPoints:  g.stopPoints,
 		ActionLog:   g.actionLog,
-		History:     g.history,
-	})
+	}
+}
+
+// MarshalJSON implements json.Marshaler.
+func (g *RussianBank) MarshalJSON() ([]byte, error) {
+	j := g.boardJSON()
+	j.History = g.history
+	return json.Marshal(j)
 }
 
 // UnmarshalJSON implements json.Unmarshaler.

--- a/internal/domain/RussianBankState.go
+++ b/internal/domain/RussianBankState.go
@@ -131,9 +131,13 @@ type russianBankJSON struct {
 	PassStreak  int                               `json:"ks"`
 	StopPoints  [RussianBankPlayerCnt]int         `json:"sp"`
 	ActionLog   []*ActionLogEntry                 `json:"al"`
+	// History must round-trip: the Cloudflare Worker is stateless per request
+	// and rebuilds the game from KV every call, so an unpersisted undo stack
+	// means Undo/UndoN/UndoToEscape silently never work in production (#4478).
+	History []*russianBankSnapshot `json:"hi,omitempty"`
 }
 
-// MarshalJSON implements json.Marshaler. history は永続化対象外。
+// MarshalJSON implements json.Marshaler.
 func (g *RussianBank) MarshalJSON() ([]byte, error) {
 	return json.Marshal(russianBankJSON{
 		Players:     g.players,
@@ -147,6 +151,7 @@ func (g *RussianBank) MarshalJSON() ([]byte, error) {
 		PassStreak:  g.passStreak,
 		StopPoints:  g.stopPoints,
 		ActionLog:   g.actionLog,
+		History:     g.history,
 	})
 }
 
@@ -183,7 +188,45 @@ func (g *RussianBank) UnmarshalJSON(data []byte) error {
 	g.moveCount = j.MoveCount
 	g.passStreak = j.PassStreak
 	g.stopPoints = j.StopPoints
+	if len(j.History) > russianBankMaxSliceLen {
+		return errors.New("russianbank: history exceeds maximum allowed size")
+	}
 	g.actionLog = j.ActionLog
-	g.history = nil
+	g.history = j.History
+	return nil
+}
+
+// russianBankSnapshotMaxBytes bounds one embedded snapshot document. A full
+// two-player board is a few KB, so 1 MiB is far above any legitimate value and
+// exists only to stop a hostile KV entry from being expanded.
+const russianBankSnapshotMaxBytes = 1 << 20
+
+// russianBankSnapshotJSON is the wire format for a single undo snapshot.
+// russianBankSnapshot holds one unexported field, so marshalling it directly
+// would emit `[{},{}]` -- the undo depth would survive but every snapshot would
+// be blank, and Undo would wipe the board instead of rewinding it (#4478).
+//
+// The field is already a JSON document, so it rides as json.RawMessage rather
+// than a []byte: a []byte would be re-encoded as base64 on every save, which
+// costs a third more bytes per snapshot in KV for no benefit.
+type russianBankSnapshotJSON struct {
+	State json.RawMessage `json:"st"`
+}
+
+// MarshalJSON implements json.Marshaler for russianBankSnapshot.
+func (s *russianBankSnapshot) MarshalJSON() ([]byte, error) {
+	return json.Marshal(russianBankSnapshotJSON{State: s.stateJSON})
+}
+
+// UnmarshalJSON implements json.Unmarshaler for russianBankSnapshot.
+func (s *russianBankSnapshot) UnmarshalJSON(data []byte) error {
+	var j russianBankSnapshotJSON
+	if err := json.Unmarshal(data, &j); err != nil {
+		return err
+	}
+	if len(j.State) > russianBankSnapshotMaxBytes {
+		return errors.New("russianbank: snapshot state exceeds maximum allowed size")
+	}
+	s.stateJSON = j.State
 	return nil
 }

--- a/internal/domain/SimpleSimonState.go
+++ b/internal/domain/SimpleSimonState.go
@@ -17,6 +17,10 @@ type simpleSimonJSON struct {
 	Phase          SimpleSimonPhase           `json:"ph"`
 	MoveCount      int                        `json:"mc"`
 	ActionLog      []*ActionLogEntry          `json:"al"`
+	// History must round-trip: the Cloudflare Worker is stateless per request
+	// and rebuilds the game from KV every call, so an unpersisted undo stack
+	// means Undo/UndoN/UndoToEscape silently never work in production (#4478).
+	History []*simpleSimonSnapshot `json:"hi,omitempty"`
 }
 
 // MarshalJSON implements json.Marshaler.
@@ -27,6 +31,7 @@ func (g *SimpleSimon) MarshalJSON() ([]byte, error) {
 		Phase:          g.phase,
 		MoveCount:      g.moveCount,
 		ActionLog:      g.actionLog,
+		History:        g.history,
 	})
 }
 
@@ -49,7 +54,49 @@ func (g *SimpleSimon) UnmarshalJSON(data []byte) error {
 	g.completedSuits = j.CompletedSuits
 	g.phase = j.Phase
 	g.moveCount = j.MoveCount
+	if len(j.History) > simpleSimonMaxSliceLen {
+		return errors.New("simplesimon: history exceeds maximum allowed size")
+	}
 	g.actionLog = j.ActionLog
-	g.history = nil
+	g.history = j.History
+	return nil
+}
+
+// simpleSimonSnapshotJSON is the wire format for a single undo snapshot.
+// simpleSimonSnapshot uses unexported fields, so marshalling it directly would
+// emit `[{},{}]` -- the undo depth would survive but every snapshot would be
+// blank, and Undo would wipe the board instead of rewinding it (#4478).
+type simpleSimonSnapshotJSON struct {
+	Columns        [SimpleSimonColCnt][]*Card `json:"co"`
+	CompletedSuits int                        `json:"cs"`
+	Phase          SimpleSimonPhase           `json:"ph"`
+	MoveCount      int                        `json:"mc"`
+}
+
+// MarshalJSON implements json.Marshaler for simpleSimonSnapshot.
+func (s *simpleSimonSnapshot) MarshalJSON() ([]byte, error) {
+	return json.Marshal(simpleSimonSnapshotJSON{
+		Columns:        s.columns,
+		CompletedSuits: s.completedSuits,
+		Phase:          s.phase,
+		MoveCount:      s.moveCount,
+	})
+}
+
+// UnmarshalJSON implements json.Unmarshaler for simpleSimonSnapshot.
+func (s *simpleSimonSnapshot) UnmarshalJSON(data []byte) error {
+	var j simpleSimonSnapshotJSON
+	if err := json.Unmarshal(data, &j); err != nil {
+		return err
+	}
+	for _, col := range j.Columns {
+		if len(col) > simpleSimonMaxSliceLen {
+			return errors.New("simplesimon: snapshot column exceeds maximum allowed size")
+		}
+	}
+	s.columns = j.Columns
+	s.completedSuits = j.CompletedSuits
+	s.phase = j.Phase
+	s.moveCount = j.MoveCount
 	return nil
 }

--- a/internal/domain/SimpleSimonState.go
+++ b/internal/domain/SimpleSimonState.go
@@ -10,7 +10,7 @@ import (
 var errSimpleSimon = errors.New("simplesimon: invalid state")
 
 // simpleSimonJSON は SimpleSimon の JSON ワイヤ形式。配り切ると trumpCards は空に
-// なるため保存しない。history も永続化対象外。
+// なるため保存しない。
 type simpleSimonJSON struct {
 	Columns        [SimpleSimonColCnt][]*Card `json:"co"`
 	CompletedSuits int                        `json:"cs"`

--- a/internal/domain/undo_persistence_test.go
+++ b/internal/domain/undo_persistence_test.go
@@ -372,6 +372,14 @@ func TestEveryUndoStackIsPersisted(t *testing.T) {
 			"with a json tag to the wire struct -- see AmericanToad or Canfield, and #4478")
 }
 
+// bigDocument returns a JSON array literal longer than n bytes, for the two
+// games whose snapshot holds a document and is bounded by size rather than by
+// element count.
+func bigDocument(n int) json.RawMessage {
+	body := strings.Repeat("0,", n/2+2)
+	return json.RawMessage("[" + body + "0]")
+}
+
 // bigCards returns a slice long enough to trip a MaxSliceLen guard.
 func bigCards(n int) []*Card {
 	out := make([]*Card, n)
@@ -396,6 +404,8 @@ func bigLog(n int) []*ActionLogEntry {
 // them (#4478).
 func TestUndoPersistenceRespectsMaxSliceLen(t *testing.T) {
 	const over = 1001
+	// bigOver clears the 10000-element caps the older games use.
+	const bigOver = 10001
 
 	cases := []struct {
 		name string
@@ -511,6 +521,95 @@ func TestUndoPersistenceRespectsMaxSliceLen(t *testing.T) {
 			},
 			restore:         func(b []byte) error { return NewDefaultWindmill().UnmarshalJSON(b) },
 			restoreSnapshot: func(b []byte) error { return new(windmillSnapshot).UnmarshalJSON(b) },
+		},
+		// The six below cap at 10000 rather than 1000, so they need their own
+		// oversize figure. Nertz and RussianBank bound their snapshots by BYTES,
+		// not by element count, because the snapshot holds a JSON document.
+		{
+			name: "BlackHole",
+			tooManySnapshots: func() ([]byte, error) {
+				return json.Marshal(&blackHoleJSON{History: make([]*blackHoleSnapshot, bigOver)})
+			},
+			tooLongLog: func() ([]byte, error) {
+				return json.Marshal(&blackHoleJSON{ActionLog: bigLog(bigOver)})
+			},
+			bloatedSnapshot: func() ([]byte, error) {
+				return json.Marshal(&blackHoleSnapshotJSON{BlackHole: bigCards(bigOver)})
+			},
+			restore:         func(b []byte) error { return NewDefaultBlackHole().UnmarshalJSON(b) },
+			restoreSnapshot: func(b []byte) error { return new(blackHoleSnapshot).UnmarshalJSON(b) },
+		},
+		{
+			name: "SimpleSimon",
+			tooManySnapshots: func() ([]byte, error) {
+				return json.Marshal(&simpleSimonJSON{History: make([]*simpleSimonSnapshot, bigOver)})
+			},
+			tooLongLog: func() ([]byte, error) {
+				return json.Marshal(&simpleSimonJSON{ActionLog: bigLog(bigOver)})
+			},
+			bloatedSnapshot: func() ([]byte, error) {
+				return json.Marshal(&simpleSimonSnapshotJSON{
+					Columns: [SimpleSimonColCnt][]*Card{bigCards(bigOver)},
+				})
+			},
+			restore:         func(b []byte) error { return NewDefaultSimpleSimon().UnmarshalJSON(b) },
+			restoreSnapshot: func(b []byte) error { return new(simpleSimonSnapshot).UnmarshalJSON(b) },
+		},
+		{
+			name: "LaBelleLucie",
+			tooManySnapshots: func() ([]byte, error) {
+				return json.Marshal(&laBelleLucieJSON{History: make([]*laBelleLucieSnapshot, bigOver)})
+			},
+			tooLongLog: func() ([]byte, error) {
+				return json.Marshal(&laBelleLucieJSON{ActionLog: bigLog(bigOver)})
+			},
+			bloatedSnapshot: func() ([]byte, error) {
+				return json.Marshal(&laBelleLucieSnapshotJSON{Fans: [][]*Card{bigCards(bigOver)}})
+			},
+			restore:         func(b []byte) error { return NewDefaultLaBelleLucie().UnmarshalJSON(b) },
+			restoreSnapshot: func(b []byte) error { return new(laBelleLucieSnapshot).UnmarshalJSON(b) },
+		},
+		{
+			name: "DoubleKlondike",
+			tooManySnapshots: func() ([]byte, error) {
+				return json.Marshal(&doubleKlondikeJSON{History: make([]*doubleKlondikeSnapshot, bigOver)})
+			},
+			tooLongLog: func() ([]byte, error) {
+				return json.Marshal(&doubleKlondikeJSON{ActionLog: bigLog(bigOver)})
+			},
+			bloatedSnapshot: func() ([]byte, error) {
+				return json.Marshal(&doubleKlondikeSnapshotJSON{Stock: bigCards(bigOver)})
+			},
+			restore:         func(b []byte) error { return NewDefaultDoubleKlondike().UnmarshalJSON(b) },
+			restoreSnapshot: func(b []byte) error { return new(doubleKlondikeSnapshot).UnmarshalJSON(b) },
+		},
+		{
+			name: "Nertz",
+			tooManySnapshots: func() ([]byte, error) {
+				return json.Marshal(&nertzJSON{History: make([]*nertzSnapshot, bigOver)})
+			},
+			tooLongLog: func() ([]byte, error) {
+				return json.Marshal(&nertzJSON{ActionLog: bigLog(bigOver)})
+			},
+			bloatedSnapshot: func() ([]byte, error) {
+				return json.Marshal(&nertzSnapshotJSON{Players: bigDocument(nertzSnapshotMaxBytes)})
+			},
+			restore:         func(b []byte) error { return NewDefaultNertz().UnmarshalJSON(b) },
+			restoreSnapshot: func(b []byte) error { return new(nertzSnapshot).UnmarshalJSON(b) },
+		},
+		{
+			name: "RussianBank",
+			tooManySnapshots: func() ([]byte, error) {
+				return json.Marshal(&russianBankJSON{History: make([]*russianBankSnapshot, bigOver)})
+			},
+			tooLongLog: func() ([]byte, error) {
+				return json.Marshal(&russianBankJSON{ActionLog: bigLog(bigOver)})
+			},
+			bloatedSnapshot: func() ([]byte, error) {
+				return json.Marshal(&russianBankSnapshotJSON{State: bigDocument(russianBankSnapshotMaxBytes)})
+			},
+			restore:         func(b []byte) error { return NewDefaultRussianBank().UnmarshalJSON(b) },
+			restoreSnapshot: func(b []byte) error { return new(russianBankSnapshot).UnmarshalJSON(b) },
 		},
 	}
 

--- a/internal/domain/undo_persistence_test.go
+++ b/internal/domain/undo_persistence_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"testing"
 
@@ -115,25 +116,140 @@ func TestUndoSurvivesAKVRoundTrip(t *testing.T) {
 			require.NoError(t, g.Draw())
 			return g, g.CanUndo, g.Undo
 		}},
+		// The six below predate #4478 and were fixed last. None of them has a
+		// move that is legal on every deal, so each one deals until its own hint
+		// appears and then plays exactly what the hint says.
+		{"BlackHole", func(t *testing.T) (any, func() bool, func() error) {
+			g := NewDefaultBlackHole()
+			var h *BlackHoleHint
+			for range dealAttempts {
+				g.Reset()
+				if h = g.GetHint(); h != nil {
+					break
+				}
+			}
+			require.NotNil(t, h, "no deal in %d had a legal move", dealAttempts)
+			require.NoError(t, g.MoveFanToBlackHole(h.Fan))
+			return g, g.CanUndo, g.Undo
+		}},
+		{"SimpleSimon", func(t *testing.T) (any, func() bool, func() error) {
+			g := NewDefaultSimpleSimon()
+			var h *SimpleSimonHint
+			for range dealAttempts {
+				g.Reset()
+				if h = g.GetHint(); h != nil {
+					break
+				}
+			}
+			require.NotNil(t, h, "no deal in %d had a legal move", dealAttempts)
+			require.NoError(t, g.MoveSequence(h.FromCol, h.CardIndex, h.ToCol))
+			return g, g.CanUndo, g.Undo
+		}},
+		{"LaBelleLucie", func(t *testing.T) (any, func() bool, func() error) {
+			g := NewDefaultLaBelleLucie()
+			var h *LaBelleLucieHint
+			for range dealAttempts {
+				g.Reset()
+				if h = g.GetHint(); h != nil {
+					break
+				}
+			}
+			require.NotNil(t, h, "no deal in %d had a legal move", dealAttempts)
+			if h.ToFoundation {
+				require.NoError(t, g.MoveFanToFoundation(h.FromFan))
+			} else {
+				require.NoError(t, g.MoveFanToFan(h.FromFan, h.ToFan))
+			}
+			return g, g.CanUndo, g.Undo
+		}},
+		{"DoubleKlondike", func(t *testing.T) (any, func() bool, func() error) {
+			g := NewDefaultDoubleKlondike()
+			g.Reset()
+			require.NoError(t, g.Draw())
+			return g, g.CanUndo, g.Undo
+		}},
+		{"Nertz", func(t *testing.T) (any, func() bool, func() error) {
+			g := NewDefaultNertz()
+			g.Reset()
+			require.NoError(t, g.DrawStock(0))
+			return g, g.CanUndo, g.Undo
+		}},
+		{"RussianBank", func(t *testing.T) (any, func() bool, func() error) {
+			g := NewDefaultRussianBank()
+			var h *RussianBankHint
+			for range dealAttempts {
+				g.Reset()
+				if h = g.GetHint(); h != nil {
+					break
+				}
+			}
+			require.NotNil(t, h, "no deal in %d had a legal move", dealAttempts)
+			src := RussianBankSource{Zone: h.Zone, FromOpponent: h.FromOpponent, Col: h.Col}
+			if h.ToFoundation {
+				require.NoError(t, g.MoveToFoundation(src))
+			} else {
+				require.NoError(t, g.MoveToTableau(src, h.ToCol))
+			}
+			return g, g.CanUndo, g.Undo
+		}},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			game, canUndo, _ := tc.play(t)
+			game, canUndo, undo := tc.play(t)
 			require.True(t, canUndo(), "the test needs an undoable move to be meaningful")
 
 			data, err := json.Marshal(game)
 			require.NoError(t, err)
+
+			// The reference board is the in-process game undone directly: its
+			// history never went near JSON, so it is what a correct KV round trip
+			// has to reproduce.
+			require.NoError(t, undo())
+			want := boardFingerprint(t, game)
 
 			// Round-trip into a fresh instance the way the Worker does.
 			restored := newEmptyLike(t, tc.name)
 			require.NoError(t, json.Unmarshal(data, restored))
 
 			ru, rundo := undoFuncsFor(t, tc.name, restored)
-			assert.True(t, ru(), "the undo stack must survive KV")
-			assert.NoError(t, rundo(), "and undoing must actually work")
+			require.True(t, ru(), "the undo stack must survive KV")
+			require.NoError(t, rundo(), "and undoing must actually work")
+
+			// Depth alone is not enough. A snapshot type with no codec of its own
+			// serialises as `{}`, which keeps CanUndo true and lets Undo return
+			// nil while restoring a BLANK board -- the undo wipes the game instead
+			// of rewinding it. Only comparing the board catches that.
+			assert.Equal(t, want, boardFingerprint(t, restored),
+				"undo after a KV round trip must restore the pre-move board, not blank it")
 		})
 	}
+}
+
+// boardFingerprint is a game's serialised state with the two fields that are
+// expected to differ stripped: the action log (Undo rewinds the board, not the
+// transcript) and the history itself.
+func boardFingerprint(t *testing.T, game any) string {
+	t.Helper()
+	data, err := json.Marshal(game)
+	require.NoError(t, err)
+	var m map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(data, &m))
+	delete(m, "al")
+	delete(m, "hi")
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	for _, k := range keys {
+		b.WriteString(k)
+		b.WriteByte(':')
+		b.Write(m[k])
+		b.WriteByte('\n')
+	}
+	return b.String()
 }
 
 // newEmptyLike builds a fresh game of the named type, standing in for the
@@ -157,6 +273,18 @@ func newEmptyLike(t *testing.T, name string) any {
 		return NewDefaultWindmill()
 	case "AmericanToad":
 		return NewDefaultAmericanToad()
+	case "BlackHole":
+		return NewDefaultBlackHole()
+	case "SimpleSimon":
+		return NewDefaultSimpleSimon()
+	case "LaBelleLucie":
+		return NewDefaultLaBelleLucie()
+	case "DoubleKlondike":
+		return NewDefaultDoubleKlondike()
+	case "Nertz":
+		return NewDefaultNertz()
+	case "RussianBank":
+		return NewDefaultRussianBank()
 	}
 	t.Fatalf("unknown game %q", name)
 	return nil
@@ -183,18 +311,13 @@ func persistedHistoryRe(snapshot string) *regexp.Regexp {
 	return regexp.MustCompile(`\[\]\*` + regexp.QuoteMeta(snapshot) + `\s+` + "`" + `json:`)
 }
 
-// knownUnpersistedHistories are games that predate #4478 and still lose their
-// undo stack across a KV round trip. The list is deliberately explicit and
-// finite: it exists so the guard below fails for anything NEW, and it must only
-// ever shrink. Do not add to it -- fix the game instead.
-var knownUnpersistedHistories = map[string]string{
-	"BlackHole":      "#4478",
-	"DoubleKlondike": "#4478",
-	"LaBelleLucie":   "#4478",
-	"Nertz":          "#4478",
-	"RussianBank":    "#4478",
-	"SimpleSimon":    "#4478",
-}
+// knownUnpersistedHistories is the exemption list the guard consults. It is
+// EMPTY, and #4478 is closed -- every domain that keeps an undo stack now sends
+// it to KV. Adding an entry here re-opens that bug for one game, so don't:
+// give the snapshot type a MarshalJSON/UnmarshalJSON pair instead. The map is
+// kept rather than deleted so the guard keeps reporting a *named* regression
+// ("X now persists...") if someone does add one.
+var knownUnpersistedHistories = map[string]string{}
 
 // A new game that keeps an undo stack must persist it, or its undo button is
 // dead in production. Nothing else catches that, because the CLI and the local

--- a/internal/domain/undo_persistence_test.go
+++ b/internal/domain/undo_persistence_test.go
@@ -638,3 +638,66 @@ func TestUndoPersistenceRespectsMaxSliceLen(t *testing.T) {
 		})
 	}
 }
+
+// TestUndoHistoryGrowsLinearly guards the shape of the undo stack, not just its
+// presence.
+//
+// RussianBank is the only game that snapshots by marshalling a whole wire
+// struct rather than copying named fields. When History joined that wire struct
+// (#4478), each snapshot started embedding every earlier snapshot, so the
+// payload DOUBLED per move: 5.6 KB after move 1, 1.45 MB after move 9. Nothing
+// else would have caught it -- the round-trip test plays one move, and the size
+// caps only fire once a session is already unrestorable.
+//
+// A per-move delta is the right assertion because the absolute size depends on
+// the deal: exponential growth blows the bound within a handful of moves, while
+// linear growth keeps every delta near one board.
+func TestUndoHistoryGrowsLinearly(t *testing.T) {
+	const maxDeltaBytes = 8 * 1024
+
+	// Deals differ in how long the hint keeps finding a move -- some run dry at
+	// move 6 -- so keep dealing until one lasts long enough to be evidence.
+	const wantMoves = 5
+	g := NewDefaultRussianBank()
+	var moves int
+	for range dealAttempts {
+		g.Reset()
+		moves = 0
+		prev := len(mustMarshal(t, g))
+		for moves < 12 {
+			h := g.GetHint()
+			if h == nil {
+				break
+			}
+			src := RussianBankSource{Zone: h.Zone, FromOpponent: h.FromOpponent, Col: h.Col}
+			var err error
+			if h.ToFoundation {
+				err = g.MoveToFoundation(src)
+			} else {
+				err = g.MoveToTableau(src, h.ToCol)
+			}
+			if err != nil {
+				break
+			}
+			moves++
+			size := len(mustMarshal(t, g))
+			require.LessOrEqual(t, size-prev, maxDeltaBytes,
+				"move %d grew the payload by %d bytes; a snapshot is embedding the history",
+				moves, size-prev)
+			prev = size
+		}
+		if moves >= wantMoves {
+			return
+		}
+	}
+	t.Fatalf("no deal in %d lasted %d moves; the probe never got to measure",
+		dealAttempts, wantMoves)
+}
+
+// mustMarshal marshals or fails the test.
+func mustMarshal(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return b
+}


### PR DESCRIPTION
Closes #4478

## 概要

**BlackHole / SimpleSimon / LaBelleLucie / DoubleKlondike / Nertz / RussianBank** の 6 ゲームで、アンドゥ履歴が KV に載っていませんでした。Cloudflare Worker はリクエストごとに KV からゲームを組み直すため、**2 リクエスト目以降 `CanUndo()` が常に false** になり、「元に戻す」ボタンも**手詰まり脱出ボタンも本番でだけ死んでいました**。CLI とローカルサーバーはプロセス内で状態を持つので再現しません。

これで #4478 の 13 件（+ PR #4477 の AmericanToad、#4479 の 7 件）がすべて片付きます。

## 修正

各スナップショット型に専用の `MarshalJSON` / `UnmarshalJSON` を実装し、wire 構造体に `History []*<game>Snapshot` を追加しました。

**Nertz と RussianBank はスナップショットがフィールドではなく JSON ドキュメントを持つ**ため、`[]byte` ではなく `json.RawMessage` で載せています。`[]byte` のままだと保存のたびに base64 化され、**スナップショット 1 件あたり KV 容量が約 1/3 増える**だけで何の得もありません。

## issue に書いていなかった、作業中に出てきた 2 点

### 1. 既存の `g.history = nil` が新しい復元行の**後**にあった

6 ファイルすべてが `UnmarshalJSON` の末尾で履歴を明示的にクリアしていたため、`g.history = j.History` を足しても**何も変わりませんでした**。生成された diff を読んで気づきました。

（`Nertz.go` にはもう 1 箇所同じ行がありますが、そちらは `startRound()` 内なので正当です。残しています。）

### 2. `TestUndoSurvivesAKVRoundTrip` は、それが対象にしていたバグを検出できなかった

`CanUndo()` が true で `Undo()` が nil を返すことしか見ておらず、**自前の codec を持たないスナップショット型は `{}` にシリアライズされるので、その両方を満たしたまま盤面を空にして復元します**。実際に**スナップショット codec を丸ごと削ってもテストは緑のまま**でした。

修正後は次のようにしています:

1. 手を打った後の状態を marshal
2. **プロセス内のゲームをその場で Undo** して、真の「手を打つ前の盤面」を得る（この履歴は JSON を経由していないので、正しい round-trip が再現すべき基準になる）
3. KV から復元したコピーを Undo し、同じ指紋になることを要求（アクションログと履歴は除外 — Undo は盤面を巻き戻すのであって棋譜ではない）

**4 つの codec を 1 つずつ削って、対応するケースが落ちることを確認済み**です。

免除マップは空のまま残しました。削除せず置いておくことで、将来誰かが戻したときにガードが**ゲーム名つきで**報告し続けます。

## 検証

**「issue の数字を issue と同じ手法で再現しても検証にならない」**ため、2 通りの独立した方法で確認しました:

| 指標 | 結果 |
|---|---|
| ガード（wire 構造体にタグ付きフィールドがあるか） | offender **0 件** |
| 別スキャン（スナップショット型自身が `MarshalJSON` を持つか） | 欠落 **0 件** |

**アンドゥ履歴を持つドメイン 53 型すべてが両方を満たします**（issue 起票時は 50 型中 14 件が欠落。その後 Congress / Terrace / Braid が増えて 53 型になりました）。

- [x] `go test -tags test ./internal/domain/`
- [x] `golangci-lint run ./...` — 0 issues
- [x] 6 ワーカーすべてのビルドタグ検証
- [x] codec を削るネガティブコントロール（4 ゲーム）
- [x] `-count=100` ストレス（アンドゥ系ガード、12.9 秒で全通過）