### PR TITLE
fix(pontoon): do not open a brand-new session with the human banking (closes #4487)

### DIFF
--- a/frontend/e2e/pontoon.spec.ts
+++ b/frontend/e2e/pontoon.spec.ts
@@ -8,8 +8,9 @@ test.describe('Pontoon E2E', () => {
     await expect(page.getByText(/チップ/)).toBeVisible();
     await expect(page.getByText(/親/).first()).toBeVisible();
 
-    // The stake buttons are only offered when a CPU banks; if the human banks
-    // the first round, deal instead.
+    // A CPU banks the opening round, so the stake buttons are what appears --
+    // but the bank moves to whoever makes a pontoon, and a resumed session can
+    // land on either, so handle both.
     const betButton = page.getByRole('button', { name: '100', exact: true });
     const dealButton = page.getByRole('button', { name: '配る', exact: true });
     if (await betButton.isVisible()) {

--- a/internal/domain/Pontoon.go
+++ b/internal/domain/Pontoon.go
@@ -148,9 +148,25 @@ type Pontoon struct {
 	actionLog  []*ActionLogEntry
 }
 
+// pontoonOpeningBanker 最初の局の親。
+//
+// 人間 (seat 0) にしないのは、そこから始めると新規セッションがいきなり
+// 「あなたが配ってください」で開き、このゲームの主要な流れ — 賭けて Stick /
+// Twist / Buy を選ぶ — に入れないため。最初に誰が親を持つかは規則が定めて
+// いないので (以後はポンツーンを出した者が取る)、遊びやすい方を選ぶ。
+const pontoonOpeningBanker = 1
+
 // NewPontoon コンストラクタ
 func NewPontoon(trumpCards *TrumpCards) *Pontoon {
-	p := &Pontoon{trumpCards: trumpCards, phase: PontoonPhaseBet}
+	p := &Pontoon{
+		trumpCards: trumpCards,
+		phase:      PontoonPhaseBet,
+		banker:     pontoonOpeningBanker,
+		// nextBanker must start at -1, not at its zero value. Reset applies it
+		// with `>= 0`, so a zero would hand seat 0 -- the human -- the bank on
+		// the very first deal and undo the line above.
+		nextBanker: -1,
+	}
 	p.chips.SetChips(PontoonDefaultChips)
 	return p
 }

--- a/internal/domain/Pontoon_test.go
+++ b/internal/domain/Pontoon_test.go
@@ -53,6 +53,28 @@ func TestPontoon_Reset(t *testing.T) {
 	}
 }
 
+// A brand-new session must open on the ordinary flow -- place a bet -- rather
+// than on "you deal". Two zero values conspire here: `banker`'s is seat 0, and
+// `nextBanker`'s is 0 too, which Reset applies with `>= 0`. Fixing only the
+// first would be undone by the second.
+func TestPontoon_AFreshGameDoesNotOpenWithTheHumanBanking(t *testing.T) {
+	p := NewDefaultPontoon()
+	if p.IsHumanBanker() {
+		t.Error("a brand-new game should not start with the human banking")
+	}
+	if p.GetNextBanker() != -1 {
+		t.Errorf("nextBanker = %d, want -1 -- a zero would hand seat 0 the bank at Reset",
+			p.GetNextBanker())
+	}
+	p.Reset()
+	if p.IsHumanBanker() {
+		t.Error("the first Reset should not hand the human the bank either")
+	}
+	if err := p.PlaceBet(100); err != nil {
+		t.Errorf("PlaceBet on a fresh game: %v", err)
+	}
+}
+
 func TestPontoon_Total(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
Closes #4487

## 現象

ポンツーンを初めて開くと、**いきなり「あなたが親です。deal で配ってください」**から始まり、賭けて Stick / Twist / Buy を選ぶという主要な流れに一度も入れません。

## 原因: ゼロ値が 2 つ重なっていました

| フィールド | ゼロ値 | 効果 |
|---|---|---|
| `banker` | `0` | = 人間の席 |
| `nextBanker` | `0` | `Reset()` が `>= 0` で適用 → **人間に上書き** |

**片方だけ直しても、もう片方が初回の `Reset()` で黙って戻します。** そのためコンストラクタで両方を明示し、テストも両方を検査しています。

規則上、**最初に誰が親を持つかは決まっていません**（以後はポンツーンを出した者が取る）ので、遊びやすい方を選んでよい部分です。

## 検証

修正前後をプローブで実測:

```
修正前: banker=0 nextBanker=0  → after Reset: banker=0 (isHumanBanker=true)
修正後: banker=1 nextBanker=-1 → after Reset: banker=1 (isHumanBanker=false)
```

`TestPontoon_AFreshGameDoesNotOpenWithTheHumanBanking` は**どちらのゼロ値を戻しても落ちます**。

## 横断確認

`nextBanker` 相当のフィールドを持つゲームをドメイン全体で走査したところ、**Pontoon と Sette e Mezzo の 2 件のみ**で、どちらも明示済みになりました。

## E2E コメントも直しました

「The stake buttons are only offered when a CPU banks」は、初回が運任せであるかのように読めました。初回の親は固定なので、分岐が要るのは再開したセッションだけです。

## テスト計画

- [x] `go test -tags test ./internal/domain/`
- [x] `golangci-lint run ./internal/domain/...` — 0 issues
- [x] `-count=50` 安定
- [x] ネガティブコントロール（どちらのゼロ値を戻しても失敗）