### PR TITLE
test(tonk): stop TestTonk_GameEnd depending on the deal

### DIFF
--- a/internal/domain/Tonk_test.go
+++ b/internal/domain/Tonk_test.go
@@ -640,8 +640,14 @@ func TestTonk_ScoreRound_NoOp(t *testing.T) {
 
 func TestTonk_GameEnd(t *testing.T) {
 	g := newTestTonk()
-	g.SetConfig(domain.TonkConfig{CpuDifficulty: domain.TonkCpuDifficultyNormal, PointLimit: 1})
+	// **配牌を固定してから点数上限を下げる。**上限 1 のまま素の Reset を通すと、
+	// 配牌 Tonk (50 ボーナス + 50 点 = 100) を引いた局でその場で試合が終わり、
+	// ノック前にゲーム終了になったり、勝者が配牌 Tonk を引いた側になったりする。
+	// seed 1 が配牌 Tonk にならないことは TestTonk_ResetTwice が使っている。
+	g.SetRand(rand.New(rand.NewSource(1)))
 	g.Reset()
+	require.Equal(t, domain.TonkPhaseDraw, g.GetPhase(), "seed 1 should deal without a Tonk")
+	g.SetConfig(domain.TonkConfig{CpuDifficulty: domain.TonkCpuDifficultyNormal, PointLimit: 1})
 	giveHand(g.GetPlayer(0), []*domain.Card{
 		domain.NewCard(domain.CardDesignSpade, 1, false),
 		domain.NewCard(domain.CardDesignHeart, 1, false),

--- a/internal/domain/Tonk_test.go
+++ b/internal/domain/Tonk_test.go
@@ -640,10 +640,13 @@ func TestTonk_ScoreRound_NoOp(t *testing.T) {
 
 func TestTonk_GameEnd(t *testing.T) {
 	g := newTestTonk()
-	// **配牌を固定してから点数上限を下げる。**上限 1 のまま素の Reset を通すと、
-	// 配牌 Tonk (50 ボーナス + 50 点 = 100) を引いた局でその場で試合が終わり、
-	// ノック前にゲーム終了になったり、勝者が配牌 Tonk を引いた側になったりする。
-	// seed 1 が配牌 Tonk にならないことは TestTonk_ResetTwice が使っている。
+	// Pin the deal BEFORE lowering the point limit. Running Reset() with the
+	// limit already at 1 lets a Tonk-on-deal (50 bonus + 50 hand = 100) end the
+	// match on the spot, so the knock below reports "game has ended"; ordering
+	// it the other way still banks those 100 points for whoever drew the Tonk,
+	// which flips the winner assertion. Seed 1 is known to deal without a Tonk
+	// (TestTonk_ResetTwice relies on the same seed), and the assertion below
+	// checks that rather than assuming it.
 	g.SetRand(rand.New(rand.NewSource(1)))
 	g.Reset()
 	require.Equal(t, domain.TonkPhaseDraw, g.GetPhase(), "seed 1 should deal without a Tonk")


### PR DESCRIPTION
## 概要

`TestTonk_GameEnd` が配牌に依存していて、**develop を赤くします**。PR #4521 の CI で踏んだので切り出しました。

## 何が起きていたか

テストは `Reset()` の**前**に `PointLimit` を 1 に下げていました。ところが `newTestTonk` が上限を高く取っているのは、まさにこれを避けるためです:

```go
// High point limit so a Tonk-on-deal (50-bonus + 50-hand = 100) does not end the match
cfg.PointLimit = 10000
```

上限 1 のまま `Reset()` を通すと、**配牌 Tonk を引いた局でその場で試合が終わります**（100 点 ≥ 1 点）。

```
--- FAIL: TestTonk_GameEnd
    Received unexpected error: game has ended
```

順序だけ直すと、今度は**勝者が入れ替わります**。配牌 Tonk を引いた側が既に 100 点持っているためです:

```
--- FAIL: TestTonk_GameEnd
    expected: 0
    actual  : 1
```

## 直しかた

**配牌を seed で固定**しました。同じファイルの `TestTonk_ResetTwice` が既に採っている手です。

seed 1 が配牌 Tonk にならないことを**暗黙の前提にせず、その場で assert** しています。seed の性質が変わったときに、遠くの assert が謎に落ちるのではなく、ここで落ちてほしいからです。

```go
g.SetRand(rand.New(rand.NewSource(1)))
g.Reset()
require.Equal(t, domain.TonkPhaseDraw, g.GetPhase(), "seed 1 should deal without a Tonk")
g.SetConfig(domain.TonkConfig{CpuDifficulty: domain.TonkCpuDifficultyNormal, PointLimit: 1})
```

## 確認

- 修正前: `-count=300` で再現
- 修正後: `TestTonk_GameEnd` を `-count=500` で green
- Tonk スイート全体を `-count=200` で green
- `golangci-lint run ./internal/domain/` 0 issues

## Test plan

- [ ] CI 全ジョブ green