### PR TITLE
fix(kaiser): make the allowNoTrump setting bite (closes #4515)

### DIFF
--- a/frontend/src/pages/KaiserPage.test.tsx
+++ b/frontend/src/pages/KaiserPage.test.tsx
@@ -61,6 +61,7 @@ function makeState(overrides?: Partial<KaiserResponse>): KaiserResponse {
     maxBid: 12,
     gameEndFlag: false,
     winnerTeam: -1,
+    config: { cpuDifficulty: 0, allowNoTrump: true },
     message: '',
     ...overrides,
   };
@@ -72,6 +73,36 @@ function handButtons() {
 }
 
 describe('KaiserPage', () => {
+  // **サーバーが弾く選択肢は出さない。**設定でノートランプを切っていると
+  // Bid が error を返すので、選べてしまうと押した瞬間に必ず失敗する。
+  describe('the no-trump setting', () => {
+    const biddingState = (allowNoTrump: boolean) =>
+      makeState({
+        phase: KaiserPhase.BID,
+        highBid: null,
+        declarerIdx: -1,
+        trumpSuit: 0,
+        config: { cpuDifficulty: 0, allowNoTrump },
+      });
+
+    it('offers all three contracts while it is on', async () => {
+      mockExec.mockResolvedValue(biddingState(true));
+      renderWithProviders(<KaiserPage />);
+      await waitFor(() => expect(screen.getByLabelText(/契約/)).toBeInTheDocument());
+      const select = screen.getByLabelText(/契約/) as HTMLSelectElement;
+      expect(select.options).toHaveLength(3);
+    });
+
+    it('offers only the trump contract while it is off', async () => {
+      mockExec.mockResolvedValue(biddingState(false));
+      renderWithProviders(<KaiserPage />);
+      await waitFor(() => expect(screen.getByLabelText(/契約/)).toBeInTheDocument());
+      const select = screen.getByLabelText(/契約/) as HTMLSelectElement;
+      expect(select.options).toHaveLength(1);
+      expect(select.options[0]?.textContent).toBe('切札あり');
+    });
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
     mockExec.mockResolvedValue(makeState());

--- a/frontend/src/pages/KaiserPage.tsx
+++ b/frontend/src/pages/KaiserPage.tsx
@@ -132,6 +132,11 @@ function KaiserPageContent() {
   const isHumanDeclarer = isDiscard && state.declarerIdx === 0 && !isGameEnd;
   // **切札を先に決めてからでないと捨てられない。**捨てる札の判断が切札に依る。
   const needsTrump = isHumanDeclarer && state.contract === 0 && state.trumpSuit === 0;
+  // **サーバーが弾く選択肢は出さない。**設定でノートランプを切っていると
+  // Bid が error を返すので、選べてしまうと押した瞬間に必ず失敗する。
+  const availableContracts = state.config.allowNoTrump ? CONTRACTS : CONTRACTS.filter((c) => c.value === 0);
+  // 選択中の契約が落ちたら、残っている先頭へ寄せる。
+  const selectedContract = availableContracts.some((c) => c.value === contract) ? contract : 0;
   const isHumanPlay = isPlay && state.currentPlayerIdx === 0 && !isGameEnd;
 
   const playerLabel = (id: number, isHuman: boolean): string => (isHuman ? t('you') : t('cpu', { id }));
@@ -349,10 +354,10 @@ function KaiserPageContent() {
                     <select
                       id="kaiser-contract-select"
                       className="bg-black/30 text-ds-text-primary rounded px-1 min-h-[44px]"
-                      value={contract}
+                      value={selectedContract}
                       onChange={(e) => setContract(Number(e.target.value))}
                     >
-                      {CONTRACTS.map((c) => (
+                      {availableContracts.map((c) => (
                         <option key={c.value} value={c.value}>
                           {t(c.labelKey)}
                         </option>
@@ -364,7 +369,7 @@ function KaiserPageContent() {
                       key={`bid-${v}`}
                       type="button"
                       className={btnPrimary}
-                      onClick={() => exec('bid', { bid: v, contract })}
+                      onClick={() => exec('bid', { bid: v, contract: selectedContract })}
                       disabled={loading}
                     >
                       {t('bidButton', { n: v })}

--- a/frontend/src/types/games/kaiser.ts
+++ b/frontend/src/types/games/kaiser.ts
@@ -80,4 +80,15 @@ export interface KaiserResponse extends BaseGameResponse {
   gameEndFlag: boolean;
   /** Winning team; -1 while the game is live. */
   winnerTeam: number;
+  config: KaiserConfigOutput;
+}
+
+/** Settings echoed back with the game state. */
+export interface KaiserConfigOutput {
+  cpuDifficulty: number;
+  /**
+   * Whether no-trump and low-no-trump bids are allowed. **The server rejects
+   * them when this is false**, so the contract select must not offer them.
+   */
+  allowNoTrump: boolean;
 }

--- a/frontend/src/utils/cli/formatters/kaiserFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/kaiserFormatter.test.ts
@@ -46,6 +46,7 @@ function makeState(overrides?: Partial<KaiserResponse>): KaiserResponse {
     maxBid: 12,
     gameEndFlag: false,
     winnerTeam: -1,
+    config: { cpuDifficulty: 0, allowNoTrump: true },
     message: '',
     ...overrides,
   };

--- a/internal/domain/Kaiser.go
+++ b/internal/domain/Kaiser.go
@@ -329,6 +329,11 @@ func KaiserBidRank(value int, contract KaiserContract) int {
 	return value*3 + int(contract)
 }
 
+// KaiserIsNoTrump は契約がノートランプ系かを返す。
+func KaiserIsNoTrump(contract KaiserContract) bool {
+	return contract == KaiserContractNoTrump || contract == KaiserContractLowNoTrump
+}
+
 // Bid は点数を宣言する。
 func (k *Kaiser) Bid(player, value int, contract KaiserContract) error {
 	if err := k.checkBidTurn(player); err != nil {
@@ -339,6 +344,12 @@ func (k *Kaiser) Bid(player, value int, contract KaiserContract) error {
 	}
 	if contract < KaiserContractTrump || contract > KaiserContractLowNoTrump {
 		return fmt.Errorf("bad contract: %d", contract)
+	}
+	// **設定でノートランプを切れる。**契約はここで決まるので、読まないと
+	// config が黙って効かなくなる。SetTrump は切札契約のスート名指しだけを
+	// 扱うので、そちらでは弾けない。
+	if !k.config.AllowNoTrump && KaiserIsNoTrump(contract) {
+		return fmt.Errorf("no-trump bids are switched off")
 	}
 	if k.highBid != nil && KaiserBidRank(value, contract) <= KaiserBidRank(k.highBid.Value, k.highBid.Contract) {
 		return fmt.Errorf("a bid must beat the standing %d", k.highBid.Value)

--- a/internal/domain/Kaiser_test.go
+++ b/internal/domain/Kaiser_test.go
@@ -112,6 +112,49 @@ func TestKaiserMinimumBidIsSeven(t *testing.T) {
 	}
 }
 
+// **設定でノートランプを切れる。**読まないと config が黙って効かなくなる。
+func TestKaiserRespectsAllowNoTrump(t *testing.T) {
+	t.Run("switched off, no-trump bids are refused", func(t *testing.T) {
+		k := NewDefaultKaiser()
+		cfg := k.GetConfig()
+		cfg.AllowNoTrump = false
+		k.SetConfig(cfg)
+		k.Reset()
+
+		if err := k.Bid(1, KaiserMinBid, KaiserContractNoTrump); err == nil {
+			t.Error("a no-trump bid must be refused when the setting is off")
+		}
+		if err := k.Bid(1, KaiserMinBid, KaiserContractLowNoTrump); err == nil {
+			t.Error("a low-no-trump bid must be refused when the setting is off")
+		}
+	})
+
+	// **設定は無トランプだけを切る。**通常の切札宣言はそのまま通ること。
+	t.Run("switched off, a plain trump bid still goes through", func(t *testing.T) {
+		k := NewDefaultKaiser()
+		cfg := k.GetConfig()
+		cfg.AllowNoTrump = false
+		k.SetConfig(cfg)
+		k.Reset()
+
+		if err := k.Bid(1, KaiserMinBid, KaiserContractTrump); err != nil {
+			t.Errorf("a trump bid must still be accepted: %v", err)
+		}
+	})
+
+	t.Run("switched on, no-trump bids are accepted", func(t *testing.T) {
+		k := NewDefaultKaiser()
+		cfg := k.GetConfig()
+		cfg.AllowNoTrump = true
+		k.SetConfig(cfg)
+		k.Reset()
+
+		if err := k.Bid(1, KaiserMinBid, KaiserContractNoTrump); err != nil {
+			t.Errorf("a no-trump bid must be accepted when the setting is on: %v", err)
+		}
+	})
+}
+
 // TestKaiserBidOrdering は同じ数字でもノートランプが上位に来ることを確かめる。
 func TestKaiserBidOrdering(t *testing.T) {
 	if KaiserBidRank(7, KaiserContractNoTrump) <= KaiserBidRank(7, KaiserContractTrump) {


### PR DESCRIPTION
## 概要

Kaiser の `allowNoTrump` 設定が**まったく効いていませんでした**。Web コントローラーとプレゼンターが設定をドメインまで運んでいるのに、その先で誰も読んでいません。

Closes #4515

## issue の指摘箇所は少しずれていました

issue は `SetTrump` を挙げていますが、**`SetTrump` はノートランプを作れません。**

```go
func (k *Kaiser) SetTrump(player, suit int) error {
	...
	if k.contract != KaiserContractTrump {
		return fmt.Errorf("a no-trump contract has no trump suit")
	}
```

この関数は「**すでに切札契約になっている**ものにスートを名指す」だけで、ノートランプ契約のときはそもそも弾かれます。

**契約が決まるのは `Bid` の `contract` 引数**です。検査もそこに置きました。

## 直したもの

### ドメイン

```go
// **設定でノートランプを切れる。**契約はここで決まるので、読まないと
// config が黙って効かなくなる。SetTrump は切札契約のスート名指しだけを
// 扱うので、そちらでは弾けない。
if !k.config.AllowNoTrump && KaiserIsNoTrump(contract) {
	return fmt.Errorf("no-trump bids are switched off")
}
```

### フロントエンド

**フラグがクライアントに届いていませんでした。**Go 側のプレゼンターは `config.allowNoTrump` を送っていたのに、**TS の型が宣言していなかった**のでページから見えませんでした。

型を足し、契約セレクトが**サーバーが受け付けるものだけ**を並べるようにしました。選択中の契約が消えた場合は切札契約に寄せます（`value` に無い選択肢が残ると、押した瞬間に必ず失敗するため）。

## 負のコントロール

「捕まえる」だけでなく「正しいコードで鳴らない」ことも見ています。

| 壊した箇所 | 結果 |
|---|---|
| ドメインのガードを殺す | `TestKaiserRespectsAllowNoTrump` が落ちる |
| セレクトのフィルタを `true` 固定にする | `KaiserPage.test.tsx` の「off のとき 1 件だけ」が落ちる |

戻すと両方 green です。

## 確認

- `go test -tags test ./internal/domain -run TestKaiser -count=20` green
- `golangci-lint run ./internal/domain/` 0 issues
- `bun run test -- --run src/pages/KaiserPage.test.tsx src/utils/cli/formatters/kaiserFormatter.test.ts` 25 件 green
- `bun run check` / `bun run typecheck` green

## Test plan

- [ ] CI 全ジョブ green
- [ ] 設定でノートランプを切った状態で、CUI / Web ともに選べないこと