### PR TITLE
test(michigan): stop TestMichiganWebPresenter_PlayPhase depending on the deal (closes #4506)

### DIFF
--- a/internal/adapter/presenter/MichiganWebPresenter_test.go
+++ b/internal/adapter/presenter/MichiganWebPresenter_test.go
@@ -117,15 +117,30 @@ func TestMichiganWebPresenter_ResultHumanWin(t *testing.T) {
 	assert.Equal(t, float64(0), b0["chips"])
 }
 
+// **配り方に依存させない。**PlaceHumanBet は配ってから CPU を回すので、人間が
+// 一度も出せない配りを引くと、プレゼンターに渡る前にラウンドが終わってしまい
+// michigan.roundEndHumanLose になる (#4506)。プレイフェーズに入った局だけを
+// 対象にし、それが一度も起きなければ落とす。
 func TestMichiganWebPresenter_PlayPhase(t *testing.T) {
-	g := domain.NewDefaultMichigan()
-	require.NoError(t, g.PlaceHumanBet(michiganWebEvenBet(g.GetBetBudget())))
+	const attempts = 50
 	p := new(presenter.MichiganWebPresenter)
-	out := p.Output(g, nil)
-	var decoded map[string]any
-	require.NoError(t, json.Unmarshal([]byte(out), &decoded))
-	assert.Equal(t, float64(domain.MichiganPhasePlay), decoded["phase"])
-	assert.Equal(t, "michigan.playPhase", decoded["messageCode"])
+
+	for i := 0; i < attempts; i++ {
+		g := domain.NewDefaultMichigan()
+		require.NoError(t, g.PlaceHumanBet(michiganWebEvenBet(g.GetBetBudget())))
+		if g.GetPhase() != domain.MichiganPhasePlay {
+			// この配りは人間の手番を迎えずにラウンドが終わった。配り直す。
+			continue
+		}
+
+		out := p.Output(g, nil)
+		var decoded map[string]any
+		require.NoError(t, json.Unmarshal([]byte(out), &decoded))
+		assert.Equal(t, float64(domain.MichiganPhasePlay), decoded["phase"])
+		assert.Equal(t, "michigan.playPhase", decoded["messageCode"])
+		return
+	}
+	t.Fatalf("no deal out of %d reached the play phase — the CPU drive may never be yielding", attempts)
 }
 
 // michiganWebEvenBet は budget を 4 分割した賭けスライスを返す。


### PR DESCRIPTION
## 概要

`TestMichiganWebPresenter_PlayPhase` の配り方依存を外します。

Closes #4506

## 機構

`PlaceHumanBet` は**配ってから CPU を回します**。

```go
func (g *Michigan) finishBetting() {
	g.deal()
	g.state.phase = MichiganPhasePlay
	...
	g.driveCPU()
}
```

人間が一度も出せない配りを引くと、`driveCPU` の中でラウンドが終わりきってしまい、プレゼンターに渡る頃には `michigan.roundEndHumanLose` になります。issue の症状そのものです。

## 直しかた

Michigan の shuffle は**グローバルの `rand` を使っていて seed の差し込み口がありません。**Tonk (#4523) では `SetRand` があったのでそれを使いましたが、こちらは seam を新設する方が issue の範囲を超えます。

代わりに、**プレイフェーズに入った局だけを対象**にしました。50 回試して一度も入らなければ落とします（`driveCPU` が人間に手番を渡さなくなったら、それはそれで捕まえたい事象なので）。`TestTonk_Reset_NormalDeal` と同じ形です。

## **ローカルで再現できませんでした**

正直に書きます。**640 回走らせて 1 度も落ちませんでした。**

- `-count=200` × 3（同一プロセス）
- `-count=1` を別プロセスで 40 回

issue には「3 回中 2 回 FAIL」とあるので、環境かシャッフルの巡り合わせだと思います。**観測ではなく機構を読んで直しています。**

その代わり負のコントロールを取りました。プレゼンター側のフェーズコードを壊すと、ちゃんと落ちます:

```
--- FAIL: TestMichiganWebPresenter_PlayPhase
    expected: "michigan.playPhase"
    actual  : "michigan.WRONG"
```

戻すと `-count=50` で green です。**「配りに依存しなくなった」ことと「まだ壊れたら捕まえる」ことの両方**は確認できています。

## 確認

- `go test -tags test ./internal/adapter/presenter -run TestMichiganWebPresenter -count=200` green
- `golangci-lint run ./internal/adapter/presenter/` 0 issues

## Test plan

- [ ] CI 全ジョブ green