### PR TITLE
fix(windmill): block the corner as a source only while transferBlocked (closes #4476)

### DIFF
--- a/frontend/src/pages/WindmillPage.test.tsx
+++ b/frontend/src/pages/WindmillPage.test.tsx
@@ -180,6 +180,42 @@ describe('WindmillPage', () => {
     await waitFor(() => expect(screen.getByText(/次に中央へ置く札は/)).toBeInTheDocument());
   });
 
+  // **移動先としては塞がない。**四隅は置き場と引き戻し元を兼ねていて、
+  // transferBlocked が禁じるのは引き戻しだけ。ボタンごと無効にすると、
+  // 影響を受けないはずの「四隅へ置く」手まで潰れる。
+  describe('the corner while the transfer is blocked', () => {
+    const cornerName = /四隅基礎札0/;
+
+    it('cannot be picked as a source', async () => {
+      mockExec.mockResolvedValue({ ...playingState, transferBlocked: true });
+      renderWithProviders(<WindmillPage />);
+      await waitFor(() => expect(screen.getByRole('button', { name: cornerName })).toBeInTheDocument());
+
+      const corner = screen.getByRole('button', { name: cornerName });
+      expect(corner).toBeDisabled();
+      expect(corner).toHaveAttribute('title', expect.stringContaining('引き戻した直後'));
+    });
+
+    it('is still usable as a target once something is selected', async () => {
+      mockExec.mockResolvedValue({ ...playingState, transferBlocked: true });
+      renderWithProviders(<WindmillPage />);
+      await waitFor(() => expect(screen.getByRole('button', { name: cornerName })).toBeInTheDocument());
+
+      // 帆の札を選ぶと、四隅は「置き先」になるので再び押せる。
+      // 帆のボタンは札そのものの名前で引ける (aria-label = cardAlt)。
+      fireEvent.click(screen.getByRole('button', { name: '♠ 9' }));
+
+      await waitFor(() => expect(screen.getByRole('button', { name: cornerName })).toBeEnabled());
+    });
+
+    it('stays selectable as a source when nothing is blocked', async () => {
+      mockExec.mockResolvedValue(playingState);
+      renderWithProviders(<WindmillPage />);
+      await waitFor(() => expect(screen.getByRole('button', { name: cornerName })).toBeEnabled());
+      expect(screen.getByRole('button', { name: cornerName })).not.toHaveAttribute('title');
+    });
+  });
+
   it('renders giveup button when playing and hides it once cleared', async () => {
     mockExec.mockResolvedValue(playingState);
     const { unmount } = renderWithProviders(<WindmillPage />);

--- a/frontend/src/pages/WindmillPage.tsx
+++ b/frontend/src/pages/WindmillPage.tsx
@@ -199,6 +199,10 @@ function WindmillPageContent() {
     const pile = state.corners[idx] ?? [];
     const cornerZone: WindmillMoveZone = { zone: 'corner', col: idx };
     const top = pile.length > 0 ? pile[pile.length - 1] : null;
+    // **移動先としては塞がない。**四隅は「降順に積む置き場」と「中央への引き戻し
+    // 元」を兼ねていて、transferBlocked が禁じるのは後者だけ。ボタンごと無効に
+    // すると、影響を受けないはずの「四隅へ置く」手まで潰れる。
+    const blockedAsSource = selectedSource === null && state.transferBlocked;
     return (
       <div key={`corner-${idx.toString()}`} className="text-center">
         <div className="text-game-text-muted text-xs mb-1" aria-hidden="true">
@@ -216,10 +220,11 @@ function WindmillPageContent() {
               onClick={() =>
                 selectedSource ? game.handleSelectTarget(cornerZone) : game.handleSelectSource(cornerZone)
               }
-              disabled={!isPlaying || loading || isAutoCompleting}
+              disabled={!isPlaying || loading || isAutoCompleting || blockedAsSource}
+              title={blockedAsSource ? t('transferBlocked') : undefined}
               aria-label={t('cornerAriaLabel', { idx, count: pile.length })}
               aria-pressed={isSourceSelected('corner', idx)}
-              draggable={isPlaying && !loading}
+              draggable={isPlaying && !loading && !blockedAsSource}
               onDragStart={dnd.handleDragStart(cornerZone)}
               onDragEnd={dnd.handleDragEnd}
               className={`p-0 border-0 bg-transparent cursor-pointer rounded ${focusRingWhite} ${isSourceSelected('corner', idx) ? 'ring-2 ring-ds-warning' : ''}`}


### PR DESCRIPTION
## 概要

`transferBlocked` のとき、四隅を**移動元としてだけ**無効化します。移動先としての利用は残します。

Closes #4476

## なぜ単純な `disabled` ではだめか

issue の指摘どおりです。四隅は**置き場**と**引き戻し元**を兼ねていて、`transferBlocked` が禁じるのは後者だけです。ボタンごと無効にすると、**影響を受けないはずの「四隅へ降順に置く」手まで潰れます**（機能後退）。

条件は「次のクリックが移動元になるとき」＝ `selectedSource === null` です。

```tsx
const blockedAsSource = selectedSource === null && state.transferBlocked;
```

`draggable` にも同じ条件をかけ、`title` に既存の `transferBlocked` の文言を出しています。

## 負のコントロール — **両方向**

「捕まえる」だけでなく「正しいコードで鳴らない」ことも、さらに**やりすぎても鳴る**ことを見ています。

| 壊しかた | 落ちるテスト |
|---|---|
| ガードを外す（`false` 固定） | 「移動元として選べない」 |
| **`selectedSource` を無視する**（issue が警告している素朴な 1 行版） | 「移動先としては使える」 |

つまり、**issue が「これをやると機能後退する」と書いた実装をそのまま入れると、このテストが落ちます。**

## チェックリスト

- [x] `renderCorner` で `selectedSource === null && state.transferBlocked` のときだけ移動元を無効化
- [x] `draggable` / `onDragStart` にも同じ条件
- [x] `title` で理由を表示
- [x] ページテストに 3 ケース追加（移動元不可 / 移動先は可 / 非ブロック時は従来どおり）
- [ ] **他のソリティアページとの方針統一** — これは判断が要るので分けます

### 最後の項目について

issue の「他のソリティアページも、サーバーが拒否する手をクライアントで先回りして無効化しているか確認し、方針を揃えるか判断する」は、**このゲーム 1 本の修正とは別の判断**だと思っています。現状はサーバー検証 + `ErrorAlert` が多数派で、そちらに寄せるのか先回り無効化に寄せるのかは方針の話です。**この PR では Windmill 固有の機能後退（引き戻し直後に必ず往復して失敗する）だけを直します。**

## 確認

- `bun run test -- --run src/pages/WindmillPage.test.tsx` 32 件 green
- `bun run check` / `bun run typecheck` green

## Test plan

- [ ] CI 全ジョブ green