### PR TITLE
fix(braid): carry the passive hint on Output as well (#4483)

### DIFF
--- a/internal/adapter/presenter/BraidWebPresenter.go
+++ b/internal/adapter/presenter/BraidWebPresenter.go
@@ -62,6 +62,23 @@ func (p *BraidWebPresenter) Output(b interfaces.BraidGame, lastErr error) string
 	resObj.RedealsLeft = domain.BraidMaxPasses - 1 - b.GetPassesUsed()
 	resObj.CanRedeal = b.CanRedeal()
 
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	//
+	// 手が進められる局面だけで計算する。終局・向き待ち・手詰まりでは助言する手が
+	// 無いので、探索を走らせるだけ無駄になる。
+	if b.GetPhase() == domain.BraidPhasePlaying && !b.IsAwaitingDirection() && !b.IsStalemate() {
+		if hint := b.GetHint(); hint != nil {
+			resObj.Hint = &controller.BraidWebOutputHint{
+				FromZone: hint.FromZone,
+				FromIdx:  hint.FromIdx,
+				ToZone:   hint.ToZone,
+				ToIdx:    hint.ToIdx,
+			}
+		}
+	}
+
 	if lastErr != nil {
 		resObj.Message = lastErr.Error()
 	} else {

--- a/internal/adapter/presenter/BraidWebPresenter_test.go
+++ b/internal/adapter/presenter/BraidWebPresenter_test.go
@@ -56,10 +56,20 @@ func parseBraidOutput(t *testing.T, jsonStr string) *controller.BraidWebOutput {
 	return &out
 }
 
+// setupBraidOutputMock は Output 用の既定を組む。
+//
+// **Output() も受動ヒントを埋めるようになった** (#4483) ので、GetHint を
+// 呼べるようにしておく必要がある。共有ヘルパー側に置くと、先に登録された
+// この期待が HintOutput テストの「ヒントあり」を食ってしまう。
+func setupBraidOutputMock(g *interfaces.MockBraidGame) {
+	setupBraidWebMockDefaults(g)
+	g.On("GetHint").Return(nil).Maybe()
+}
+
 func TestBraidWebPresenter_Output(t *testing.T) {
 	t.Run("initial state", func(t *testing.T) {
 		g := new(interfaces.MockBraidGame)
-		setupBraidWebMockDefaults(g)
+		setupBraidOutputMock(g)
 
 		result := parseBraidOutput(t, new(BraidWebPresenter).Output(g, nil))
 		assert.Equal(t, 0, result.Phase)
@@ -78,7 +88,7 @@ func TestBraidWebPresenter_Output(t *testing.T) {
 	// 空き枠を詰めるとインデックスがずれ、ヒントの枠番号が画面と食い違う。
 	t.Run("an empty slot stays null instead of being squeezed out", func(t *testing.T) {
 		g := new(interfaces.MockBraidGame)
-		setupBraidWebMockDefaults(g)
+		setupBraidOutputMock(g)
 
 		result := parseBraidOutput(t, new(BraidWebPresenter).Output(g, nil))
 		assert.Len(t, result.Fields, domain.BraidFieldCnt)
@@ -90,7 +100,7 @@ func TestBraidWebPresenter_Output(t *testing.T) {
 	// The client must not have to infer "direction 0 means unchosen".
 	t.Run("awaiting the direction has its own message", func(t *testing.T) {
 		g := new(interfaces.MockBraidGame)
-		setupBraidWebMockDefaults(g)
+		setupBraidOutputMock(g)
 		g.ExpectedCalls = filterCalls(g.ExpectedCalls, "IsAwaitingDirection")
 		g.ExpectedCalls = filterCalls(g.ExpectedCalls, "GetDirection")
 		g.On("IsAwaitingDirection").Return(true)
@@ -104,7 +114,7 @@ func TestBraidWebPresenter_Output(t *testing.T) {
 
 	t.Run("awaiting the direction outranks stalemate", func(t *testing.T) {
 		g := new(interfaces.MockBraidGame)
-		setupBraidWebMockDefaults(g)
+		setupBraidOutputMock(g)
 		g.ExpectedCalls = filterCalls(g.ExpectedCalls, "IsAwaitingDirection")
 		g.ExpectedCalls = filterCalls(g.ExpectedCalls, "IsStalemate")
 		g.On("IsAwaitingDirection").Return(true)
@@ -116,7 +126,7 @@ func TestBraidWebPresenter_Output(t *testing.T) {
 
 	t.Run("stalemate", func(t *testing.T) {
 		g := new(interfaces.MockBraidGame)
-		setupBraidWebMockDefaults(g)
+		setupBraidOutputMock(g)
 		g.ExpectedCalls = filterCalls(g.ExpectedCalls, "IsStalemate")
 		g.On("IsStalemate").Return(true)
 
@@ -126,7 +136,7 @@ func TestBraidWebPresenter_Output(t *testing.T) {
 
 	t.Run("redeals left counts down with the passes used", func(t *testing.T) {
 		g := new(interfaces.MockBraidGame)
-		setupBraidWebMockDefaults(g)
+		setupBraidOutputMock(g)
 		g.ExpectedCalls = filterCalls(g.ExpectedCalls, "GetPassesUsed")
 		g.ExpectedCalls = filterCalls(g.ExpectedCalls, "CanRedeal")
 		g.On("GetPassesUsed").Return(1)
@@ -139,7 +149,7 @@ func TestBraidWebPresenter_Output(t *testing.T) {
 
 	t.Run("error message", func(t *testing.T) {
 		g := new(interfaces.MockBraidGame)
-		setupBraidWebMockDefaults(g)
+		setupBraidOutputMock(g)
 
 		result := parseBraidOutput(t, new(BraidWebPresenter).Output(g, errors.New("test error")))
 		assert.Equal(t, "test error", result.Message)
@@ -155,7 +165,7 @@ func TestBraidWebPresenter_Output(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			g := new(interfaces.MockBraidGame)
-			setupBraidWebMockDefaults(g)
+			setupBraidOutputMock(g)
 			g.ExpectedCalls = filterCalls(g.ExpectedCalls, "GetPhase")
 			g.On("GetPhase").Return(tc.val)
 
@@ -163,6 +173,41 @@ func TestBraidWebPresenter_Output(t *testing.T) {
 			assert.Equal(t, tc.code, result.MessageCode)
 		})
 	}
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない。ここが埋まっていないと
+// フロントの `state.hint` は常に undefined で、それを読む分岐が全部死ぬ (#4483)。
+func TestBraidWebPresenter_OutputCarriesTheHint(t *testing.T) {
+	hint := &domain.BraidHint{FromZone: "field", FromIdx: 2, ToZone: "foundation", ToIdx: 1}
+
+	t.Run("while the game is playable", func(t *testing.T) {
+		g := new(interfaces.MockBraidGame)
+		setupBraidWebMockDefaults(g)
+		g.On("GetHint").Return(hint).Maybe()
+
+		result := parseBraidOutput(t, new(BraidWebPresenter).Output(g, nil))
+		if result.Hint == nil {
+			t.Fatal("Output must carry the hint -- the frontend reads state.hint")
+		}
+		assert.Equal(t, "field", result.Hint.FromZone)
+		assert.Equal(t, 2, result.Hint.FromIdx)
+		assert.Equal(t, "foundation", result.Hint.ToZone)
+		assert.Equal(t, 1, result.Hint.ToIdx)
+	})
+
+	// **助言する手が無い局面では探索を走らせない。**
+	t.Run("not while awaiting the direction", func(t *testing.T) {
+		g := new(interfaces.MockBraidGame)
+		// 期待は先に登録したものが勝つので、ヘルパーより前に置く。
+		g.On("IsAwaitingDirection").Return(true).Maybe()
+		setupBraidWebMockDefaults(g)
+		g.On("GetHint").Return(hint).Maybe()
+
+		result := parseBraidOutput(t, new(BraidWebPresenter).Output(g, nil))
+		assert.Nil(t, result.Hint)
+		g.AssertNotCalled(t, "GetHint")
+	})
 }
 
 func TestBraidWebPresenter_HintOutput(t *testing.T) {


### PR DESCRIPTION
## 概要

`Output()` でも受動ヒントを埋めます。**まず Braid 1 本だけ**です。

Refs #4483（issue はまだ閉じません。下記「範囲」参照）

## 何が死んでいたか

`state.hint` はフロントで**常に undefined** でした。ヒントには経路が 2 つあり、`Hint` をセットするのは `HintOutput()` だけ、しかしそれは `command: "hint"` 専用のレスポンスで**ページの state にはマージされません**。

結果、`braidHint.ts` の `state` だけを読む分岐（向き待ち・手詰まり）は生きているのに、**盤面上の具体的な手を出す分岐は 1 つも到達しません**でした。

## 範囲を 1 本に絞った理由

[issue に実測を投稿しました](https://github.com/yuta-yoshinaga/go_trumpcards/issues/4483#issuecomment-5150252806)。**該当は 91 ゲーム**で、`Output()` で受動ヒントを埋めているプレゼンターは **0** です。issue の見積もり（ソリティア数件）とは桁が違います。

`Output()` は全ゲーム共通の経路なので、91 本を一度に変えると**全リクエストにヒント探索が乗ります**。まず 1 本入れて、コストと使い勝手を見てから広げたいです。**この PR では issue を閉じません。**

実装してみて分かった副作用も 1 つあります。`Output()` が `GetHint()` を呼ぶようになるので、**既存のプレゼンターテストのモックに `GetHint` の期待を足す必要があります**（91 ゲームぶん）。機構としては小さい変更ですが、テスト側の波及はそれなりにあります。

## ゲート

手が進められる局面だけで計算します。

```go
if b.GetPhase() == domain.BraidPhasePlaying && !b.IsAwaitingDirection() && !b.IsStalemate() {
```

向き待ちと手詰まりでは助言する手が無いので、探索を走らせるだけ無駄です。

## 負のコントロール — 両方向

| 壊しかた | 落ちるテスト |
|---|---|
| ヒントを埋めない（`if false`） | 「Output がヒントを運ぶ」 |
| ゲートを外す（`if true`） | 「向き待ちでは走らせない」（`AssertNotCalled(GetHint)`） |

## テストの並び順に 1 つ罠がありました

共有ヘルパーに `GetHint` の既定（nil）を置くと、**先に登録された期待が勝つ**ため `TestBraidWebPresenter_HintOutput` の「ヒントあり」を食ってしまいました。Output 用のヘルパーに分けています。

## 確認

- `go test -tags test ./internal/adapter/presenter/ -count=3` green
- `golangci-lint run ./internal/adapter/presenter/` 0 issues
- `bun run test -- --run src/pages/BraidPage.test.tsx src/utils/hints/braidHint.test.ts` 42 件 green

## Test plan

- [ ] CI 全ジョブ green
- [ ] Braid でヒントトグルを入れて、盤面の手が実際に出ること