### PR TITLE
test(guandan): drop the deal-dependent tail assertion

### DIFF
--- a/internal/domain/Guandan_test.go
+++ b/internal/domain/Guandan_test.go
@@ -1024,11 +1024,32 @@ func TestGuandanDealsASortedHand(t *testing.T) {
 		}
 	}
 
-	// **レベル札は末尾に固まる。**A より強いという序列が並びに出ていること。
-	p := g.GetPlayer(0)
-	last := p.GetCard(p.GetCardsSize() - 1)
-	if !GuandanIsLevelCard(last, g.GetLevel()) && !GuandanIsJoker(last) {
-		t.Errorf("the hand ends with %v, want a level card or a joker", last)
+	// **レベル札が A より上に並ぶことを、配りに依存せずに確かめる。**
+	//
+	// 「手札の末尾はレベル札かジョーカー」と書いていたが、これは配りに依存する。
+	// 108 枚から 27 枚では、レベル札もジョーカーも 1 枚も来ない席が実際に出て、
+	// そのとき末尾は A になる。develop を赤くしたのはこの断定だった。
+	//
+	// 不変なのは「レベル札を持っているなら、それは平札より後ろにある」ほう。
+	for seat := range GuandanPlayerCnt {
+		p := g.GetPlayer(seat)
+		lastPlain, firstLevel := -1, -1
+		for i := range p.GetCardsSize() {
+			c := p.GetCard(i)
+			switch {
+			case GuandanIsJoker(c):
+				// ジョーカーはさらに上。ここでは対象外。
+			case GuandanIsLevelCard(c, g.GetLevel()):
+				if firstLevel < 0 {
+					firstLevel = i
+				}
+			default:
+				lastPlain = i
+			}
+		}
+		if firstLevel >= 0 && lastPlain > firstLevel {
+			t.Errorf("seat %d has a plain card at %d after a level card at %d", seat, lastPlain, firstLevel)
+		}
 	}
 }
 


### PR DESCRIPTION
## 概要

**私が今日入れたテストが develop を赤くしています。**その修正です。

## 何を間違えたか

`TestGuandanDealsASortedHand` に、こう書いていました。

```go
// **レベル札は末尾に固まる。**A より強いという序列が並びに出ていること。
last := p.GetCard(p.GetCardsSize() - 1)
if !GuandanIsLevelCard(last, g.GetLevel()) && !GuandanIsJoker(last) {
	t.Errorf("the hand ends with %v, want a level card or a joker", last)
}
```

**これは配りに依存します。**108 枚から 27 枚では、レベル札もジョーカーも 1 枚も来ない席が普通に出ます。そのとき末尾は A になり、落ちます。

```
--- FAIL: TestGuandanDealsASortedHand
    Guandan_test.go:1031: the hand ends with &{3 1 true}, want a level card or a joker
```

`&{3 1 true}` は ♥A です。

**再現率は 200 回あたり 4〜9 回。**マージ数時間後に PR #4527 の CI で踏みました。

## 同じ間違いを今日 3 回目にやりました

今日は `TestTonk_GameEnd` (#4523) と `TestMichiganWebPresenter_PlayPhase` (#4525) を、まさに**「シャッフルがたまたま出したものに対して断定している」**という理由で直したところです。その 2 本を直しながら、自分は同じ穴に落ちたテストを混ぜていました。

## 直しかた

このテストが本当に確かめたかったのは「**レベル札が平札より後ろに並ぶ**」ことです。これは**手札にレベル札があるときに常に成り立つ**ので、配りに依存しません。

末尾を見る代わりに、席ごとに「平札がレベル札より後ろに来ていないか」を見ます。座席 0 だけでなく**全席**に広げました。

## 負のコントロール

ソート自体を殺すと、ちゃんと落ちます。

```
--- FAIL: TestGuandanDealsASortedHand
    Guandan_test.go:1018: seat 0 is out of order at 1: rank 13 then 5
```

## 確認

- 修正前: `-count=200` を 5 回で 4/5/7/9/9 件 FAIL
- 修正後: `-count=300` を 3 回で green
- `go test -tags test ./internal/domain -run TestGuandan -count=30` green
- `golangci-lint run ./internal/domain/` 0 issues

## Test plan

- [ ] CI 全ジョブ green