### PR TITLE
fix(cli): print HINT only when the player asked (#4483)

### DIFF
--- a/frontend/src/utils/cli/formatterBase.test.ts
+++ b/frontend/src/utils/cli/formatterBase.test.ts
@@ -7,6 +7,7 @@ import {
   formatIndexedCards,
   formatPlayerName,
   formatSeparator,
+  isRequestedHint,
 } from './formatterBase';
 
 const S = '\u2660'; // spade
@@ -103,5 +104,28 @@ describe('formatPlayerName', () => {
 
   it('returns CPU label with given index', () => {
     expect(formatPlayerName(3, false)).toBe('CPU 3');
+  });
+});
+
+describe('isRequestedHint', () => {
+  // **頼んでいないヒントは CLI に出さない。**#4483 以降 Output() もヒントを載せる
+  // ので、state.hint だけを見ると毎手 HINT が印字される。要求への応答だけが
+  // hintAvailable を持つので、そこで区別する。
+  it('is true only for a hint command response', () => {
+    expect(isRequestedHint({ messageCode: 'braid.hintAvailable' })).toBe(true);
+    expect(isRequestedHint({ messageCode: 'braid.playing' })).toBe(false);
+    expect(isRequestedHint({ messageCode: 'braid.noHint' })).toBe(false);
+  });
+
+  // messageCode が無いレスポンスもある。undefined で落ちないこと。
+  it('is false when the response carries no message code', () => {
+    expect(isRequestedHint({})).toBe(false);
+    expect(isRequestedHint({ messageCode: undefined })).toBe(false);
+  });
+
+  // 別ゲームの接尾辞でも同じ規則で効くこと。
+  it('works for any game prefix', () => {
+    expect(isRequestedHint({ messageCode: 'terrace.hintAvailable' })).toBe(true);
+    expect(isRequestedHint({ messageCode: 'americantoad.hintAvailable' })).toBe(true);
   });
 });

--- a/frontend/src/utils/cli/formatterBase.ts
+++ b/frontend/src/utils/cli/formatterBase.ts
@@ -49,3 +49,21 @@ export function formatHeader(title: string): string {
 export function formatPlayerName(id: number, isHuman: boolean): string {
   return isHuman ? i18n.t('player.you') : i18n.t('player.cpu', { id });
 }
+
+/**
+ * True when this response is an answer to an explicit `hint` command.
+ *
+ * Since #4483, `Output()` also carries the hint so the board tooltip can read
+ * `state.hint` (it was permanently undefined before). But `Output()` runs on
+ * every command, so a CLI formatter that keys off `state.hint` alone would
+ * print `HINT:` after every single move, unasked.
+ *
+ * Only the `hint` command's own response sets a `hintAvailable` message code,
+ * so that is what separates "the player asked" from "the tooltip needs data".
+ * Gating on it costs nothing: no extra request, and no extra KV write, which
+ * matters because every request writes the session back and the free tier
+ * allows 1,000 writes a day (ADR-0028).
+ */
+export function isRequestedHint(state: { messageCode?: string }): boolean {
+  return state.messageCode?.endsWith('.hintAvailable') ?? false;
+}

--- a/frontend/src/utils/cli/formatters/braidFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/braidFormatter.test.ts
@@ -71,16 +71,35 @@ describe('formatBraidState', () => {
 
   it('renders a hint with slot indices', () => {
     const result = formatBraidState(
-      makeState({ hint: { fromZone: 'field', fromIdx: 2, toZone: 'foundation', toIdx: 1 } }),
+      makeState({
+        hint: { fromZone: 'field', fromIdx: 2, toZone: 'foundation', toIdx: 1 },
+        messageCode: 'braid.hintAvailable',
+      }),
     );
     expect(result).toContain('HINT: field2 → foundation1');
   });
 
   it('renders a hint without indices', () => {
     const result = formatBraidState(
-      makeState({ hint: { fromZone: 'stock', fromIdx: -1, toZone: 'waste', toIdx: -1 } }),
+      makeState({
+        hint: { fromZone: 'stock', fromIdx: -1, toZone: 'waste', toIdx: -1 },
+        messageCode: 'braid.hintAvailable',
+      }),
     );
     expect(result).toContain('HINT: stock → waste');
+  });
+
+  // **頼んでいないヒントは CLI に出さない。**#4483 以降 Output() もヒントを載せる
+  // ので、state.hint だけを見ると毎手 HINT が印字される。要求への応答だけが
+  // hintAvailable を持つので、そこで区別する。
+  it('does not print a passive hint carried on an ordinary response', () => {
+    const result = formatBraidState(
+      makeState({
+        hint: { fromZone: 'field', fromIdx: 2, toZone: 'foundation', toIdx: 1 },
+        messageCode: 'braid.playing',
+      }),
+    );
+    expect(result).not.toContain('HINT:');
   });
 
   it('renders stalemate, message and the win line', () => {

--- a/frontend/src/utils/cli/formatters/braidFormatter.ts
+++ b/frontend/src/utils/cli/formatters/braidFormatter.ts
@@ -1,5 +1,5 @@
 import type { BraidResponse } from '../../../types/card';
-import { formatCard, formatHeader, formatSeparator } from '../formatterBase';
+import { formatCard, formatHeader, formatSeparator, isRequestedHint } from '../formatterBase';
 
 /** Render one row of single-card slots, keeping empty slots in place. */
 function formatSlots(label: string, slots: (Card | null)[]): string {
@@ -39,7 +39,7 @@ export function formatBraidState(state: BraidResponse): string {
 
   lines.push(`moves: ${state.moveCount}  undo:${state.canUndo ? 'yes' : 'no'}`);
 
-  if (state.hint) {
+  if (state.hint && isRequestedHint(state)) {
     const from = state.hint.fromIdx >= 0 ? `${state.hint.fromZone}${state.hint.fromIdx}` : state.hint.fromZone;
     const to = state.hint.toIdx >= 0 ? `${state.hint.toZone}${state.hint.toIdx}` : state.hint.toZone;
     lines.push(`HINT: ${from} → ${to}`);


### PR DESCRIPTION
## 概要

CLI に**頼んでいないヒントが毎手出る**問題を直します。PR #4529 のレビュー指摘への対応です。

Refs #4483

## 経緯: 私の当初案は KV の制約に反していました

レビューで CLI の挙動変更を指摘され、いったん「フロントで完結させる案（トグル on の間、毎手ヒントを取りに行く）」を推しました。**これは誤りでした。**

`base_controller.go:115` が `defer release()` で、**`hint` を含む全リクエストがセッションを KV に書き戻します。**そして ADR-0028:

> **KV 無料枠制約**: 書き込み 1,000回/日のためデモ用途に限定（**1アクション=1書き込み**）

毎手リクエストを 1 本増やす案は、**KV 書き込みを 2 倍にして枠を半分にします。**ADR が明示的に置いた設計に真正面から反するので撤回しました。

**`Output()` に相乗りする現行方針は、リクエストも KV 書き込みも 1 つも増やしません。**この制約下ではこれが正解で、CLI 側だけをフロントで直すのが筋でした。

## 直しかた

要求への応答だけが `messageCode` に `hintAvailable` を持ちます（通常の `Output()` は `playing` / `stalemate` など）。そこで区別します。

```ts
export function isRequestedHint(state: { messageCode?: string }): boolean {
  return state.messageCode?.endsWith('.hintAvailable') ?? false;
}
```

`formatterBase` に置いたので、**残りのゲームは 87 個の手書き条件ではなく同じ述語を使えます。**

## 範囲

**受動ヒントを実際に入れたゲームだけ**に適用します。今回は Braid（マージ済み）。#4529 / #4530 / #4531 の 8 本には、それぞれの PR で同じ述語を適用してからマージします。**87 本の一括変換はしません**（前のバッチでスクリプト化が壊れた反省です）。

## Speed について

調べたところ、**`speed` は以前から `Output()` にヒントを載せていて**、CLI も毎手 `HINT:` を出しています。今回の変更が持ち込んだ挙動ではなく、1 ゲームぶんの既存挙動なので**触っていません**。必要なら別issueで。

## 負のコントロール

ゲートを外すと「通常応答では HINT を出さない」テストが落ちます。戻すと 9 件 green。

## 確認

- `bun run test -- --run src/utils/cli/formatters/braidFormatter.test.ts` 9 件 green
- `bun run check` / `bun run typecheck` green

## Test plan

- [ ] CI 全ジョブ green
- [ ] CLI モードで Braid を数手進めて HINT が出ないこと、`hint` コマンドでは出ること