### PR TITLE
fix(hints): carry the passive hint for Beleaguered Castle, Bisley and Bristol (#4483)

### DIFF
--- a/frontend/src/utils/cli/formatters/beleagueredcastleFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/beleagueredcastleFormatter.test.ts
@@ -45,6 +45,7 @@ describe('formatBeleagueredCastleState', () => {
     const result = formatBeleagueredCastleState(
       makeState({
         hint: { fromCol: 0, cardIndex: 1, toZone: 'tableau', toCol: 2 },
+        messageCode: 'beleagueredcastle.hintAvailable',
       }),
     );
     expect(result).toContain('HINT');

--- a/frontend/src/utils/cli/formatters/beleagueredcastleFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/beleagueredcastleFormatter.test.ts
@@ -52,6 +52,18 @@ describe('formatBeleagueredCastleState', () => {
     expect(result).toContain('tableau2');
   });
 
+  // **頼んでいないヒントは CLI に出さない。**#4483 以降 Output() もヒントを載せる
+  // ので、state.hint だけを見ると毎手 HINT が印字される。
+  it('does not print a passive hint carried on an ordinary response', () => {
+    const result = formatBeleagueredCastleState(
+      makeState({
+        hint: { fromCol: 0, cardIndex: 1, toZone: 'tableau', toCol: 2 },
+        messageCode: 'beleagueredcastle.playing',
+      }),
+    );
+    expect(result).not.toContain('HINT');
+  });
+
   it('shows stalemate message', () => {
     const result = formatBeleagueredCastleState(makeState({ isStalemate: true }));
     expect(result).toContain('Stalemate');

--- a/frontend/src/utils/cli/formatters/beleagueredcastleFormatter.ts
+++ b/frontend/src/utils/cli/formatters/beleagueredcastleFormatter.ts
@@ -1,5 +1,5 @@
 import type { BeleagueredCastleResponse } from '../../../types/card';
-import { formatCard, formatHeader, formatSeparator } from '../formatterBase';
+import { formatCard, formatHeader, formatSeparator, isRequestedHint } from '../formatterBase';
 
 /** Format a Beleaguered Castle game state as terminal text. */
 export function formatBeleagueredCastleState(state: BeleagueredCastleResponse): string {
@@ -26,7 +26,7 @@ export function formatBeleagueredCastleState(state: BeleagueredCastleResponse): 
 
   lines.push(`moves: ${state.moveCount}  undo:${state.canUndo ? 'yes' : 'no'}`);
 
-  if (state.hint) {
+  if (state.hint && isRequestedHint(state)) {
     const target = state.hint.toCol >= 0 ? `${state.hint.toZone}${state.hint.toCol}` : state.hint.toZone;
     lines.push(`HINT: t${state.hint.fromCol}[${state.hint.cardIndex}] → ${target}`);
   }

--- a/frontend/src/utils/cli/formatters/bisleyFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/bisleyFormatter.test.ts
@@ -47,13 +47,17 @@ describe('formatBisleyState', () => {
   });
 
   it('shows a tableau hint', () => {
-    const result = formatBisleyState(makeState({ hint: { fromCol: 0, toZone: 'tableau', toIdx: 2 } }));
+    const result = formatBisleyState(
+      makeState({ hint: { fromCol: 0, toZone: 'tableau', toIdx: 2 }, messageCode: 'bisley.hintAvailable' }),
+    );
     expect(result).toContain('HINT');
     expect(result).toContain('t2');
   });
 
   it('shows a foundation hint', () => {
-    const result = formatBisleyState(makeState({ hint: { fromCol: 3, toZone: 'king', toIdx: 1 } }));
+    const result = formatBisleyState(
+      makeState({ hint: { fromCol: 3, toZone: 'king', toIdx: 1 }, messageCode: 'bisley.hintAvailable' }),
+    );
     expect(result).toContain('HINT');
     expect(result).toContain('king1');
   });

--- a/frontend/src/utils/cli/formatters/bisleyFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/bisleyFormatter.test.ts
@@ -54,6 +54,15 @@ describe('formatBisleyState', () => {
     expect(result).toContain('t2');
   });
 
+  // **頼んでいないヒントは CLI に出さない。**#4483 以降 Output() もヒントを載せる
+  // ので、state.hint だけを見ると毎手 HINT が印字される。
+  it('does not print a passive hint carried on an ordinary response', () => {
+    const result = formatBisleyState(
+      makeState({ hint: { fromCol: 0, toZone: 'tableau', toIdx: 2 }, messageCode: 'bisley.playing' }),
+    );
+    expect(result).not.toContain('HINT');
+  });
+
   it('shows a foundation hint', () => {
     const result = formatBisleyState(
       makeState({ hint: { fromCol: 3, toZone: 'king', toIdx: 1 }, messageCode: 'bisley.hintAvailable' }),

--- a/frontend/src/utils/cli/formatters/bisleyFormatter.ts
+++ b/frontend/src/utils/cli/formatters/bisleyFormatter.ts
@@ -1,5 +1,5 @@
 import type { BisleyResponse } from '../../../types/card';
-import { formatCard, formatHeader, formatSeparator } from '../formatterBase';
+import { formatCard, formatHeader, formatSeparator, isRequestedHint } from '../formatterBase';
 
 /** Format a Bisley game state as terminal text. */
 export function formatBisleyState(state: BisleyResponse): string {
@@ -27,7 +27,7 @@ export function formatBisleyState(state: BisleyResponse): string {
 
   lines.push(`moves: ${state.moveCount}  undo:${state.canUndo ? 'yes' : 'no'}`);
 
-  if (state.hint) {
+  if (state.hint && isRequestedHint(state)) {
     const target = state.hint.toZone === 'tableau' ? `t${state.hint.toIdx}` : `${state.hint.toZone}${state.hint.toIdx}`;
     lines.push(`HINT: t${state.hint.fromCol} → ${target}`);
   }

--- a/frontend/src/utils/cli/formatters/bristolFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/bristolFormatter.test.ts
@@ -89,6 +89,18 @@ describe('formatBristolState', () => {
     expect(output).toContain('HINT: tableau2 → foundation0');
   });
 
+  // **頼んでいないヒントは CLI に出さない。**#4483 以降 Output() もヒントを載せる
+  // ので、state.hint だけを見ると毎手 HINT が印字される。
+  it('does not print a passive hint carried on an ordinary response', () => {
+    const result = formatBristolState(
+      makeState({
+        hint: { fromZone: 'tableau', fromCol: 2, toZone: 'foundation', toCol: 0 },
+        messageCode: 'bristol.playing',
+      }),
+    );
+    expect(result).not.toContain('HINT');
+  });
+
   it('shows fan-to-tableau hint', () => {
     const output = formatBristolState(
       makeState({

--- a/frontend/src/utils/cli/formatters/bristolFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/bristolFormatter.test.ts
@@ -81,14 +81,20 @@ describe('formatBristolState', () => {
 
   it('shows tableau-to-foundation hint', () => {
     const output = formatBristolState(
-      makeState({ hint: { fromZone: 'tableau', fromCol: 2, toZone: 'foundation', toCol: 0 } }),
+      makeState({
+        hint: { fromZone: 'tableau', fromCol: 2, toZone: 'foundation', toCol: 0 },
+        messageCode: 'bristol.hintAvailable',
+      }),
     );
     expect(output).toContain('HINT: tableau2 → foundation0');
   });
 
   it('shows fan-to-tableau hint', () => {
     const output = formatBristolState(
-      makeState({ hint: { fromZone: 'fan', fromCol: 1, toZone: 'tableau', toCol: 3 } }),
+      makeState({
+        hint: { fromZone: 'fan', fromCol: 1, toZone: 'tableau', toCol: 3 },
+        messageCode: 'bristol.hintAvailable',
+      }),
     );
     expect(output).toContain('HINT: fan1 → tableau3');
   });

--- a/frontend/src/utils/cli/formatters/bristolFormatter.ts
+++ b/frontend/src/utils/cli/formatters/bristolFormatter.ts
@@ -1,5 +1,5 @@
 import type { BristolResponse } from '../../../types/card';
-import { formatCard, formatHeader, formatSeparator } from '../formatterBase';
+import { formatCard, formatHeader, formatSeparator, isRequestedHint } from '../formatterBase';
 
 /** Format a Bristol game state as terminal text. */
 export function formatBristolState(state: BristolResponse): string {
@@ -34,7 +34,7 @@ export function formatBristolState(state: BristolResponse): string {
   lines.push(`stock: ${state.stockCount}`);
   lines.push(`moves: ${state.moveCount}  undo:${state.canUndo ? 'yes' : 'no'}`);
 
-  if (state.hint) {
+  if (state.hint && isRequestedHint(state)) {
     const from = state.hint.fromZone === 'fan' ? `fan${state.hint.fromCol}` : `tableau${state.hint.fromCol}`;
     const to = state.hint.toZone === 'foundation' ? `foundation${state.hint.toCol}` : `tableau${state.hint.toCol}`;
     lines.push(`HINT: ${from} → ${to}`);

--- a/internal/adapter/presenter/BeleagueredCastleWebPresenter.go
+++ b/internal/adapter/presenter/BeleagueredCastleWebPresenter.go
@@ -46,6 +46,20 @@ func (p *BeleagueredCastleWebPresenter) Output(bc interfaces.BeleagueredCastleGa
 	}
 
 	// メッセージ
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	if bc.GetPhase() == domain.BeleagueredCastlePhasePlaying && !bc.IsStalemate() {
+		if hint := bc.GetHint(); hint != nil {
+			resObj.Hint = &controller.BeleagueredCastleWebOutputHint{
+				FromCol:   hint.FromCol,
+				CardIndex: hint.CardIndex,
+				ToZone:    hint.ToZone,
+				ToCol:     hint.ToCol,
+			}
+		}
+	}
+
 	if lastErr != nil {
 		resObj.Message = lastErr.Error()
 	} else {

--- a/internal/adapter/presenter/BeleagueredCastleWebPresenter_test.go
+++ b/internal/adapter/presenter/BeleagueredCastleWebPresenter_test.go
@@ -48,10 +48,18 @@ func parseBeleagueredCastleOutput(t *testing.T, jsonStr string) *controller.Bele
 	return &out
 }
 
+// setupBeleagueredCastleOutputMock は Output 用の既定。**Output() も受動ヒントを埋める**
+// ようになった (#4483) ので GetHint を呼べるようにする。共有ヘルパーに置くと
+// 先に登録されたこの期待が HintOutput テストの「ヒントあり」を食う。
+func setupBeleagueredCastleOutputMock(g *interfaces.MockBeleagueredCastleGame) {
+	setupBeleagueredCastleWebMockDefaults(g)
+	g.On("GetHint").Return(nil).Maybe()
+}
+
 func TestBeleagueredCastleWebPresenter_Output(t *testing.T) {
 	t.Run("initial state", func(t *testing.T) {
 		bg := new(interfaces.MockBeleagueredCastleGame)
-		setupBeleagueredCastleWebMockDefaults(bg)
+		setupBeleagueredCastleOutputMock(bg)
 		p := new(BeleagueredCastleWebPresenter)
 
 		result := parseBeleagueredCastleOutput(t, p.Output(bg, nil))
@@ -64,7 +72,7 @@ func TestBeleagueredCastleWebPresenter_Output(t *testing.T) {
 
 	t.Run("all face up", func(t *testing.T) {
 		bg := new(interfaces.MockBeleagueredCastleGame)
-		setupBeleagueredCastleWebMockDefaults(bg)
+		setupBeleagueredCastleOutputMock(bg)
 		p := new(BeleagueredCastleWebPresenter)
 
 		result := parseBeleagueredCastleOutput(t, p.Output(bg, nil))
@@ -78,7 +86,7 @@ func TestBeleagueredCastleWebPresenter_Output(t *testing.T) {
 
 	t.Run("error message", func(t *testing.T) {
 		bg := new(interfaces.MockBeleagueredCastleGame)
-		setupBeleagueredCastleWebMockDefaults(bg)
+		setupBeleagueredCastleOutputMock(bg)
 		p := new(BeleagueredCastleWebPresenter)
 
 		result := parseBeleagueredCastleOutput(t, p.Output(bg, errors.New("test error")))
@@ -87,7 +95,7 @@ func TestBeleagueredCastleWebPresenter_Output(t *testing.T) {
 
 	t.Run("game clear", func(t *testing.T) {
 		bg := new(interfaces.MockBeleagueredCastleGame)
-		setupBeleagueredCastleWebMockDefaults(bg)
+		setupBeleagueredCastleOutputMock(bg)
 		bg.ExpectedCalls = filterCalls(bg.ExpectedCalls, "GetPhase")
 		bg.On("GetPhase").Return(domain.BeleagueredCastlePhaseGameClear)
 
@@ -98,7 +106,7 @@ func TestBeleagueredCastleWebPresenter_Output(t *testing.T) {
 
 	t.Run("game over", func(t *testing.T) {
 		bg := new(interfaces.MockBeleagueredCastleGame)
-		setupBeleagueredCastleWebMockDefaults(bg)
+		setupBeleagueredCastleOutputMock(bg)
 		bg.ExpectedCalls = filterCalls(bg.ExpectedCalls, "GetPhase")
 		bg.On("GetPhase").Return(domain.BeleagueredCastlePhaseGameOver)
 
@@ -109,7 +117,7 @@ func TestBeleagueredCastleWebPresenter_Output(t *testing.T) {
 
 	t.Run("stalemate", func(t *testing.T) {
 		bg := new(interfaces.MockBeleagueredCastleGame)
-		setupBeleagueredCastleWebMockDefaults(bg)
+		setupBeleagueredCastleOutputMock(bg)
 		bg.ExpectedCalls = filterCalls(bg.ExpectedCalls, "IsStalemate")
 		bg.On("IsStalemate").Return(true)
 
@@ -117,6 +125,22 @@ func TestBeleagueredCastleWebPresenter_Output(t *testing.T) {
 		result := parseBeleagueredCastleOutput(t, p.Output(bg, nil))
 		assert.Equal(t, "beleagueredcastle.stalemate", result.MessageCode)
 	})
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+func TestBeleagueredCastleWebPresenter_OutputCarriesTheHint(t *testing.T) {
+	hint := &domain.BeleagueredCastleHint{FromCol: 2, CardIndex: 2, ToZone: "tableau", ToCol: 2}
+
+	bg := new(interfaces.MockBeleagueredCastleGame)
+	setupBeleagueredCastleWebMockDefaults(bg)
+	bg.On("GetHint").Return(hint).Maybe()
+
+	result := parseBeleagueredCastleOutput(t, new(BeleagueredCastleWebPresenter).Output(bg, nil))
+	if result.Hint == nil {
+		t.Fatal("Output must carry the hint -- the frontend reads state.hint")
+	}
+	assert.Equal(t, 2, result.Hint.FromCol)
 }
 
 func TestBeleagueredCastleWebPresenter_HintOutput(t *testing.T) {

--- a/internal/adapter/presenter/BisleyWebPresenter.go
+++ b/internal/adapter/presenter/BisleyWebPresenter.go
@@ -50,6 +50,19 @@ func (p *BisleyWebPresenter) Output(b interfaces.BisleyGame, lastErr error) stri
 	resObj.KingFoundations = bisleyFoundationsToOutput(b.GetKingFoundations())
 
 	// メッセージ
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	if b.GetPhase() == domain.BisleyPhasePlaying && !b.IsStalemate() {
+		if hint := b.GetHint(); hint != nil {
+			resObj.Hint = &controller.BisleyWebOutputHint{
+				FromCol: hint.FromCol,
+				ToZone:  hint.ToZone,
+				ToIdx:   hint.ToIdx,
+			}
+		}
+	}
+
 	if lastErr != nil {
 		resObj.Message = lastErr.Error()
 	} else {

--- a/internal/adapter/presenter/BisleyWebPresenter_test.go
+++ b/internal/adapter/presenter/BisleyWebPresenter_test.go
@@ -51,10 +51,18 @@ func parseBisleyOutput(t *testing.T, jsonStr string) *controller.BisleyWebOutput
 	return &out
 }
 
+// setupBisleyOutputMock は Output 用の既定。**Output() も受動ヒントを埋める**
+// ようになった (#4483) ので GetHint を呼べるようにする。共有ヘルパーに置くと
+// 先に登録されたこの期待が HintOutput テストの「ヒントあり」を食う。
+func setupBisleyOutputMock(g *interfaces.MockBisleyGame) {
+	setupBisleyWebMockDefaults(g)
+	g.On("GetHint").Return(nil).Maybe()
+}
+
 func TestBisleyWebPresenter_Output(t *testing.T) {
 	t.Run("initial state", func(t *testing.T) {
 		bg := new(interfaces.MockBisleyGame)
-		setupBisleyWebMockDefaults(bg)
+		setupBisleyOutputMock(bg)
 		p := new(BisleyWebPresenter)
 
 		result := parseBisleyOutput(t, p.Output(bg, nil))
@@ -68,7 +76,7 @@ func TestBisleyWebPresenter_Output(t *testing.T) {
 
 	t.Run("all face up", func(t *testing.T) {
 		bg := new(interfaces.MockBisleyGame)
-		setupBisleyWebMockDefaults(bg)
+		setupBisleyOutputMock(bg)
 		p := new(BisleyWebPresenter)
 
 		result := parseBisleyOutput(t, p.Output(bg, nil))
@@ -82,7 +90,7 @@ func TestBisleyWebPresenter_Output(t *testing.T) {
 
 	t.Run("error message", func(t *testing.T) {
 		bg := new(interfaces.MockBisleyGame)
-		setupBisleyWebMockDefaults(bg)
+		setupBisleyOutputMock(bg)
 		p := new(BisleyWebPresenter)
 
 		result := parseBisleyOutput(t, p.Output(bg, errors.New("test error")))
@@ -91,7 +99,7 @@ func TestBisleyWebPresenter_Output(t *testing.T) {
 
 	t.Run("game clear", func(t *testing.T) {
 		bg := new(interfaces.MockBisleyGame)
-		setupBisleyWebMockDefaults(bg)
+		setupBisleyOutputMock(bg)
 		bg.ExpectedCalls = filterCalls(bg.ExpectedCalls, "GetPhase")
 		bg.On("GetPhase").Return(domain.BisleyPhaseGameClear)
 
@@ -103,7 +111,7 @@ func TestBisleyWebPresenter_Output(t *testing.T) {
 
 	t.Run("game over", func(t *testing.T) {
 		bg := new(interfaces.MockBisleyGame)
-		setupBisleyWebMockDefaults(bg)
+		setupBisleyOutputMock(bg)
 		bg.ExpectedCalls = filterCalls(bg.ExpectedCalls, "GetPhase")
 		bg.On("GetPhase").Return(domain.BisleyPhaseGameOver)
 
@@ -114,7 +122,7 @@ func TestBisleyWebPresenter_Output(t *testing.T) {
 
 	t.Run("stalemate", func(t *testing.T) {
 		bg := new(interfaces.MockBisleyGame)
-		setupBisleyWebMockDefaults(bg)
+		setupBisleyOutputMock(bg)
 		bg.ExpectedCalls = filterCalls(bg.ExpectedCalls, "IsStalemate")
 		bg.On("IsStalemate").Return(true)
 
@@ -122,6 +130,22 @@ func TestBisleyWebPresenter_Output(t *testing.T) {
 		result := parseBisleyOutput(t, p.Output(bg, nil))
 		assert.Equal(t, "bisley.stalemate", result.MessageCode)
 	})
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+func TestBisleyWebPresenter_OutputCarriesTheHint(t *testing.T) {
+	hint := &domain.BisleyHint{FromCol: 2, ToZone: "tableau", ToIdx: 2}
+
+	bg := new(interfaces.MockBisleyGame)
+	setupBisleyWebMockDefaults(bg)
+	bg.On("GetHint").Return(hint).Maybe()
+
+	result := parseBisleyOutput(t, new(BisleyWebPresenter).Output(bg, nil))
+	if result.Hint == nil {
+		t.Fatal("Output must carry the hint -- the frontend reads state.hint")
+	}
+	assert.Equal(t, 2, result.Hint.FromCol)
 }
 
 func TestBisleyWebPresenter_HintOutput(t *testing.T) {

--- a/internal/adapter/presenter/BristolWebPresenter.go
+++ b/internal/adapter/presenter/BristolWebPresenter.go
@@ -51,6 +51,20 @@ func (p *BristolWebPresenter) Output(b interfaces.BristolGame, lastErr error) st
 	}
 
 	// メッセージ
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	if b.GetPhase() == domain.BristolPhasePlaying {
+		if hint := b.GetHint(); hint != nil {
+			resObj.Hint = &controller.BristolWebOutputHint{
+				FromZone: hint.FromZone,
+				FromCol:  hint.FromCol,
+				ToZone:   hint.ToZone,
+				ToCol:    hint.ToCol,
+			}
+		}
+	}
+
 	if lastErr != nil {
 		resObj.Message = lastErr.Error()
 	} else {

--- a/internal/adapter/presenter/BristolWebPresenter_test.go
+++ b/internal/adapter/presenter/BristolWebPresenter_test.go
@@ -84,8 +84,6 @@ func TestBristolWebPresenter_Output(t *testing.T) {
 
 // **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
 // レスポンスで、ページの state にはマージされない (#4483)。
-// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
-// レスポンスで、ページの state にはマージされない (#4483)。
 func TestBristolWebPresenter_OutputCarriesTheHint(t *testing.T) {
 	hint := &domain.BristolHint{FromZone: "tableau", FromCol: 2, ToZone: "foundation", ToCol: 0}
 

--- a/internal/adapter/presenter/BristolWebPresenter_test.go
+++ b/internal/adapter/presenter/BristolWebPresenter_test.go
@@ -32,10 +32,18 @@ func setupBristolWebMockDefaults(bg *interfaces.MockBristolGame) {
 	bg.On("GetFoundation").Return(foundation).Maybe()
 }
 
+// setupBristolOutputMock は Output 用の既定。**Output() も受動ヒントを埋める**
+// ようになった (#4483) ので GetHint を呼べるようにする。共有ヘルパーに置くと
+// 先に登録されたこの期待が HintOutput テストの「ヒントあり」を食う。
+func setupBristolOutputMock(g *interfaces.MockBristolGame) {
+	setupBristolWebMockDefaults(g)
+	g.On("GetHint").Return(nil).Maybe()
+}
+
 func TestBristolWebPresenter_Output(t *testing.T) {
 	t.Run("initial state", func(t *testing.T) {
 		bg := new(interfaces.MockBristolGame)
-		setupBristolWebMockDefaults(bg)
+		setupBristolOutputMock(bg)
 		p := new(BristolWebPresenter)
 		result := p.Output(bg, nil)
 		assert.Contains(t, result, `"stockCount":28`)
@@ -47,7 +55,7 @@ func TestBristolWebPresenter_Output(t *testing.T) {
 
 	t.Run("with error", func(t *testing.T) {
 		bg := new(interfaces.MockBristolGame)
-		setupBristolWebMockDefaults(bg)
+		setupBristolOutputMock(bg)
 		p := new(BristolWebPresenter)
 		result := p.Output(bg, assert.AnError)
 		assert.Contains(t, result, assert.AnError.Error())
@@ -55,7 +63,7 @@ func TestBristolWebPresenter_Output(t *testing.T) {
 
 	t.Run("game clear", func(t *testing.T) {
 		bg := new(interfaces.MockBristolGame)
-		setupBristolWebMockDefaults(bg)
+		setupBristolOutputMock(bg)
 		bg.ExpectedCalls = filterCalls(bg.ExpectedCalls, "GetPhase")
 		bg.On("GetPhase").Return(domain.BristolPhaseGameClear)
 		p := new(BristolWebPresenter)
@@ -65,13 +73,28 @@ func TestBristolWebPresenter_Output(t *testing.T) {
 
 	t.Run("game over", func(t *testing.T) {
 		bg := new(interfaces.MockBristolGame)
-		setupBristolWebMockDefaults(bg)
+		setupBristolOutputMock(bg)
 		bg.ExpectedCalls = filterCalls(bg.ExpectedCalls, "GetPhase")
 		bg.On("GetPhase").Return(domain.BristolPhaseGameOver)
 		p := new(BristolWebPresenter)
 		result := p.Output(bg, nil)
 		assert.Contains(t, result, "bristol.gameOver")
 	})
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+func TestBristolWebPresenter_OutputCarriesTheHint(t *testing.T) {
+	hint := &domain.BristolHint{FromZone: "tableau", FromCol: 2, ToZone: "foundation", ToCol: 0}
+
+	bg := new(interfaces.MockBristolGame)
+	setupBristolWebMockDefaults(bg)
+	bg.On("GetHint").Return(hint).Maybe()
+
+	result := new(BristolWebPresenter).Output(bg, nil)
+	assert.Contains(t, result, `"hint"`, "Output must carry the hint -- the frontend reads state.hint")
 }
 
 func TestBristolWebPresenter_HintOutput(t *testing.T) {


### PR DESCRIPTION
## 概要

5 本目。**Beleaguered Castle / Bisley / Bristol**。**12 / 91**。

Refs #4483

## 今回から CLI ゲートを同じコミットに入れています

前の 3 本（#4529 / #4530 / #4531）は、受動ヒントを入れたあとに CLI ゲートを別途足す形になり、**その間はレビューで指摘されるまで CLI に毎手 HINT が出る状態**でした。今回から `isRequestedHint` の適用を同じ変更に含めます。

## 前バッチのレビュー指摘を反映しています

| 指摘 | 今回の対応 |
|---|---|
| 負のコントロールを**コミットしていない**（手元で走らせただけ） | ゲートを落とすと 3 件落ちることを確認し、**テストとして入れています** |
| 実ドメインオブジェクトを使うゲームは**テスト変更不要 = 検証済みではない** | 各ゲームで `Output()` がヒントを載せることを assert |

## 機械適用が効かなかった点

**Bristol だけ形が違いました。**

- テストが**パース済み構造体ではなく生の JSON 文字列**に `Contains` する形（`parseBristolOutput` が存在しない）
- ヒントのフィールドが `FromIdx` / `ToIdx` ではなく **`FromCol` / `ToCol`**

どちらもコンパイルエラーで気づきました。**形が揃っている前提で書くと通らない**ことが、これで 3 バッチ連続です。

## 確認

- `go test -tags test ./internal/adapter/presenter/ -count=2` green
- `golangci-lint run ./internal/adapter/presenter/` 0 issues
- CLI フォーマッタ 3 本 29 件 green
- `bun run check` / `typecheck` green

## 進捗

| | |
|---|---|
| 受動ヒント済み | **12 / 91** |
| 残り | 79（うち Playing フェーズあり 19、フェーズ無しで個別判断が要るもの 60） |

## Test plan

- [ ] CI 全ジョブ green