### PR TITLE
fix(hints): carry the passive hint for Calculation, Canfield and Cruel (#4483)

### DIFF
--- a/frontend/src/utils/cli/formatters/canfieldFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/canfieldFormatter.test.ts
@@ -37,6 +37,7 @@ describe('formatCanfieldState', () => {
     const result = formatCanfieldState(
       makeState({
         hint: { fromZone: 'tableau', fromCol: 0, cardIndex: 1, toZone: 'foundation', toCol: 2 },
+        messageCode: 'canfield.hintAvailable',
       }),
     );
     expect(result).toContain('HINT');
@@ -84,6 +85,7 @@ describe('formatCanfieldState', () => {
     const result = formatCanfieldState(
       makeState({
         hint: { fromZone: 'waste', fromCol: -1, cardIndex: 0, toZone: 'foundation', toCol: -1 },
+        messageCode: 'canfield.hintAvailable',
       }),
     );
     expect(result).toContain('HINT');

--- a/frontend/src/utils/cli/formatters/canfieldFormatter.ts
+++ b/frontend/src/utils/cli/formatters/canfieldFormatter.ts
@@ -1,5 +1,5 @@
 import type { CanfieldResponse } from '../../../types/card';
-import { formatCard, formatHeader, formatSeparator } from '../formatterBase';
+import { formatCard, formatHeader, formatSeparator, isRequestedHint } from '../formatterBase';
 
 /** Format a Canfield game state as terminal text. */
 export function formatCanfieldState(state: CanfieldResponse): string {
@@ -34,7 +34,7 @@ export function formatCanfieldState(state: CanfieldResponse): string {
 
   lines.push(`moves: ${state.moveCount}  undo:${state.canUndo ? 'yes' : 'no'}`);
 
-  if (state.hint) {
+  if (state.hint && isRequestedHint(state)) {
     const fromCol = state.hint.fromCol >= 0 ? state.hint.fromCol : '';
     const toCol = state.hint.toCol >= 0 ? state.hint.toCol : '';
     lines.push(`HINT: ${state.hint.fromZone}${fromCol}[${state.hint.cardIndex}] → ${state.hint.toZone}${toCol}`);

--- a/internal/adapter/presenter/CalculationWebPresenter.go
+++ b/internal/adapter/presenter/CalculationWebPresenter.go
@@ -17,6 +17,19 @@ type CalculationWebPresenter struct{}
 func (p *CalculationWebPresenter) Output(g interfaces.CalculationGame, lastErr error) string {
 	resObj := p.buildBase(g)
 
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	if g.GetPhase() == domain.CalculationPhasePlaying && !g.IsStalemate() {
+		if hint := g.GetHint(); hint != nil {
+			resObj.Hint = &controller.CalculationWebOutputHint{
+				FromZone:      hint.FromZone,
+				WasteIdx:      hint.WasteIdx,
+				FoundationIdx: hint.FoundationIdx,
+			}
+		}
+	}
+
 	if lastErr != nil {
 		resObj.Message = lastErr.Error()
 	} else {

--- a/internal/adapter/presenter/CalculationWebPresenter_test.go
+++ b/internal/adapter/presenter/CalculationWebPresenter_test.go
@@ -41,10 +41,17 @@ func parseCalculationOutput(t *testing.T, jsonStr string) *controller.Calculatio
 	return &out
 }
 
+// setupCalculationOutputMock は Output 用の既定。**Output() も受動ヒントを埋める**
+// ようになった (#4483) ので GetHint を呼べるようにする。
+func setupCalculationOutputMock(g *interfaces.MockCalculationGame) {
+	setupCalculationWebMockDefaults(g)
+	g.On("GetHint").Return(nil).Maybe()
+}
+
 func TestCalculationWebPresenter_Output(t *testing.T) {
 	t.Run("initial state", func(t *testing.T) {
 		g := new(interfaces.MockCalculationGame)
-		setupCalculationWebMockDefaults(g)
+		setupCalculationOutputMock(g)
 		result := parseCalculationOutput(t, new(CalculationWebPresenter).Output(g, nil))
 		assert.Equal(t, 0, result.Phase)
 		assert.Equal(t, "calculation.playing", result.MessageCode)
@@ -109,10 +116,26 @@ func TestCalculationWebPresenter_Output(t *testing.T) {
 
 	t.Run("with error", func(t *testing.T) {
 		g := new(interfaces.MockCalculationGame)
-		setupCalculationWebMockDefaults(g)
+		setupCalculationOutputMock(g)
 		result := parseCalculationOutput(t, new(CalculationWebPresenter).Output(g, errors.New("boom")))
 		assert.Equal(t, "boom", result.Message)
 	})
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+func TestCalculationWebPresenter_OutputCarriesTheHint(t *testing.T) {
+	hint := &domain.CalculationHint{FromZone: "waste", WasteIdx: 2, FoundationIdx: 1}
+
+	g := new(interfaces.MockCalculationGame)
+	setupCalculationWebMockDefaults(g)
+	g.On("GetHint").Return(hint).Maybe()
+
+	result := parseCalculationOutput(t, new(CalculationWebPresenter).Output(g, nil))
+	if result.Hint == nil {
+		t.Fatal("Output must carry the hint -- the frontend reads state.hint")
+	}
+	assert.Equal(t, 2, result.Hint.WasteIdx)
 }
 
 func TestCalculationWebPresenter_HintOutput(t *testing.T) {

--- a/internal/adapter/presenter/CanfieldWebPresenter.go
+++ b/internal/adapter/presenter/CanfieldWebPresenter.go
@@ -58,6 +58,21 @@ func (p *CanfieldWebPresenter) Output(c interfaces.CanfieldGame, lastErr error) 
 	}
 
 	// メッセージ
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	if c.GetPhase() == domain.CanfieldPhasePlaying {
+		if hint := c.GetHint(); hint != nil {
+			resObj.Hint = &controller.CanfieldWebOutputHint{
+				FromZone:  hint.FromZone,
+				FromCol:   hint.FromCol,
+				CardIndex: hint.CardIndex,
+				ToZone:    hint.ToZone,
+				ToCol:     hint.ToCol,
+			}
+		}
+	}
+
 	if lastErr != nil {
 		resObj.Message = lastErr.Error()
 	} else {

--- a/internal/adapter/presenter/CanfieldWebPresenter_test.go
+++ b/internal/adapter/presenter/CanfieldWebPresenter_test.go
@@ -30,10 +30,17 @@ func setupCanfieldWebMockDefaults(cg *interfaces.MockCanfieldGame) {
 	cg.On("GetFoundation").Return(foundation).Maybe()
 }
 
+// setupCanfieldOutputMock は Output 用の既定。**Output() も受動ヒントを埋める**
+// ようになった (#4483) ので GetHint を呼べるようにする。
+func setupCanfieldOutputMock(g *interfaces.MockCanfieldGame) {
+	setupCanfieldWebMockDefaults(g)
+	g.On("GetHint").Return(nil).Maybe()
+}
+
 func TestCanfieldWebPresenter_Output(t *testing.T) {
 	t.Run("initial state", func(t *testing.T) {
 		cg := new(interfaces.MockCanfieldGame)
-		setupCanfieldWebMockDefaults(cg)
+		setupCanfieldOutputMock(cg)
 		p := new(CanfieldWebPresenter)
 		result := p.Output(cg, nil)
 		assert.Contains(t, result, `"baseRank":7`)
@@ -43,7 +50,7 @@ func TestCanfieldWebPresenter_Output(t *testing.T) {
 
 	t.Run("with error", func(t *testing.T) {
 		cg := new(interfaces.MockCanfieldGame)
-		setupCanfieldWebMockDefaults(cg)
+		setupCanfieldOutputMock(cg)
 		p := new(CanfieldWebPresenter)
 		result := p.Output(cg, assert.AnError)
 		assert.Contains(t, result, assert.AnError.Error())
@@ -51,7 +58,7 @@ func TestCanfieldWebPresenter_Output(t *testing.T) {
 
 	t.Run("game clear", func(t *testing.T) {
 		cg := new(interfaces.MockCanfieldGame)
-		setupCanfieldWebMockDefaults(cg)
+		setupCanfieldOutputMock(cg)
 		cg.ExpectedCalls = filterCalls(cg.ExpectedCalls, "GetPhase")
 		cg.On("GetPhase").Return(domain.CanfieldPhaseGameClear)
 		p := new(CanfieldWebPresenter)
@@ -61,7 +68,7 @@ func TestCanfieldWebPresenter_Output(t *testing.T) {
 
 	t.Run("game over", func(t *testing.T) {
 		cg := new(interfaces.MockCanfieldGame)
-		setupCanfieldWebMockDefaults(cg)
+		setupCanfieldOutputMock(cg)
 		cg.ExpectedCalls = filterCalls(cg.ExpectedCalls, "GetPhase")
 		cg.On("GetPhase").Return(domain.CanfieldPhaseGameOver)
 		p := new(CanfieldWebPresenter)
@@ -71,7 +78,7 @@ func TestCanfieldWebPresenter_Output(t *testing.T) {
 
 	t.Run("with waste", func(t *testing.T) {
 		cg := new(interfaces.MockCanfieldGame)
-		setupCanfieldWebMockDefaults(cg)
+		setupCanfieldOutputMock(cg)
 		cg.ExpectedCalls = filterCalls(cg.ExpectedCalls, "GetWaste")
 		cg.On("GetWaste").Return([]*domain.Card{domain.NewCard(domain.CardDesignHeart, 5, false)})
 		p := new(CanfieldWebPresenter)
@@ -81,7 +88,7 @@ func TestCanfieldWebPresenter_Output(t *testing.T) {
 
 	t.Run("foundation with cards", func(t *testing.T) {
 		cg := new(interfaces.MockCanfieldGame)
-		setupCanfieldWebMockDefaults(cg)
+		setupCanfieldOutputMock(cg)
 		cg.ExpectedCalls = filterCalls(cg.ExpectedCalls, "GetFoundation")
 		var f [domain.CanfieldFoundationCnt][]*domain.Card
 		f[0] = []*domain.Card{domain.NewCard(domain.CardDesignSpade, 7, false)}
@@ -90,6 +97,19 @@ func TestCanfieldWebPresenter_Output(t *testing.T) {
 		result := p.Output(cg, nil)
 		assert.Contains(t, result, `"foundation"`)
 	})
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+func TestCanfieldWebPresenter_OutputCarriesTheHint(t *testing.T) {
+	hint := &domain.CanfieldHint{FromZone: "tableau", FromCol: 2, CardIndex: 1, ToZone: "foundation", ToCol: 0}
+
+	cg := new(interfaces.MockCanfieldGame)
+	setupCanfieldWebMockDefaults(cg)
+	cg.On("GetHint").Return(hint).Maybe()
+
+	result := new(CanfieldWebPresenter).Output(cg, nil)
+	assert.Contains(t, result, `"hint"`, "Output must carry the hint -- the frontend reads state.hint")
 }
 
 func TestCanfieldWebPresenter_HintOutput(t *testing.T) {

--- a/internal/adapter/presenter/CruelWebPresenter.go
+++ b/internal/adapter/presenter/CruelWebPresenter.go
@@ -45,6 +45,20 @@ func (p *CruelWebPresenter) Output(c interfaces.CruelGame, lastErr error) string
 	}
 
 	// メッセージ
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	if c.GetPhase() == domain.CruelPhasePlaying && !c.IsStalemate() {
+		if hint := c.GetHint(); hint != nil {
+			resObj.Hint = &controller.CruelWebOutputHint{
+				FromCol:   hint.FromCol,
+				CardIndex: hint.CardIndex,
+				ToZone:    hint.ToZone,
+				ToCol:     hint.ToCol,
+			}
+		}
+	}
+
 	if lastErr != nil {
 		resObj.Message = lastErr.Error()
 	} else {

--- a/internal/adapter/presenter/CruelWebPresenter_test.go
+++ b/internal/adapter/presenter/CruelWebPresenter_test.go
@@ -39,10 +39,17 @@ func parseCruelOutput(t *testing.T, jsonStr string) *controller.CruelWebOutput {
 	return &out
 }
 
+// setupCruelOutputMock は Output 用の既定。**Output() も受動ヒントを埋める**
+// ようになった (#4483) ので GetHint を呼べるようにする。
+func setupCruelOutputMock(g *interfaces.MockCruelGame) {
+	setupCruelWebMockDefaults(g)
+	g.On("GetHint").Return(nil).Maybe()
+}
+
 func TestCruelWebPresenter_Output(t *testing.T) {
 	t.Run("initial state", func(t *testing.T) {
 		cg := new(interfaces.MockCruelGame)
-		setupCruelWebMockDefaults(cg)
+		setupCruelOutputMock(cg)
 		p := new(CruelWebPresenter)
 
 		result := parseCruelOutput(t, p.Output(cg, nil))
@@ -126,12 +133,28 @@ func TestCruelWebPresenter_Output(t *testing.T) {
 
 	t.Run("with error", func(t *testing.T) {
 		cg := new(interfaces.MockCruelGame)
-		setupCruelWebMockDefaults(cg)
+		setupCruelOutputMock(cg)
 		p := new(CruelWebPresenter)
 
 		result := parseCruelOutput(t, p.Output(cg, errors.New("test error")))
 		assert.Equal(t, "test error", result.Message)
 	})
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+func TestCruelWebPresenter_OutputCarriesTheHint(t *testing.T) {
+	hint := &domain.CruelHint{FromCol: 2, CardIndex: 1, ToZone: "foundation", ToCol: 0}
+
+	cg := new(interfaces.MockCruelGame)
+	setupCruelWebMockDefaults(cg)
+	cg.On("GetHint").Return(hint).Maybe()
+
+	result := parseCruelOutput(t, new(CruelWebPresenter).Output(cg, nil))
+	if result.Hint == nil {
+		t.Fatal("Output must carry the hint -- the frontend reads state.hint")
+	}
+	assert.Equal(t, 2, result.Hint.FromCol)
 }
 
 func TestCruelWebPresenter_HintOutput(t *testing.T) {


### PR DESCRIPTION
## 概要

6 本目。**Calculation / Canfield / Cruel**。**15 / 91**。

Refs #4483

## CLI ゲートは 1 本だけ必要でした

3 本すべてに `isRequestedHint` を当てるつもりでしたが、**調べたら 2 本は不要**でした。

| ゲーム | CLI フォーマッタ | ゲート |
|---|---|---|
| Calculation | **存在しない** | 不要 |
| Cruel | あるが**ヒントを参照していない** | 不要 |
| Canfield | ヒントを印字する | **適用** |

「全部に当てる」と決め打ちしていたら、2 本に無意味な import と条件が入っていました。

## ヒント構造体はゲームごとに違います

| ゲーム | フィールド |
|---|---|
| Calculation | `FromZone` / `WasteIdx` / `FoundationIdx` |
| Canfield | `FromZone` / `FromCol` / `CardIndex` / `ToZone` / `ToCol` |
| Cruel | `FromCol` / `CardIndex` / `ToZone` / `ToCol` |

`FromIdx` / `ToIdx` で統一されている前提は、ここでも成り立ちません。各ゲームの定義を読んでから書いています。

テストのスタイルも Canfield だけ生 JSON への `Contains` で、パース済み構造体を返す helper がありません。

## 負のコントロール

3 本ともゲートを落とすと対応するテストが落ちます（3 件 FAIL）。

## 確認

- `go test -tags test ./internal/adapter/presenter/ -count=2` green
- `golangci-lint run ./internal/adapter/presenter/` 0 issues
- `bun run check` / `typecheck` green

## 進捗

| | |
|---|---|
| 受動ヒント済み | **15 / 91** |
| 残り | 76（Playing フェーズあり 16 / 無し 60） |

## Test plan

- [ ] CI 全ジョブ green