### PR TITLE
fix(hints): carry the passive hint for Easthaven, Flower Garden and Gaps (#4483)

### DIFF
--- a/frontend/src/utils/cli/formatters/flowergardenFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/flowergardenFormatter.test.ts
@@ -56,6 +56,7 @@ describe('formatFlowerGardenState', () => {
     const result = formatFlowerGardenState(
       makeState({
         hint: { fromZone: 'tableau', fromCol: 0, cardIndex: 1, toZone: 'tableau', toCol: 2 },
+        messageCode: 'flowergarden.hintAvailable',
       }),
     );
     expect(result).toContain('HINT');
@@ -63,10 +64,22 @@ describe('formatFlowerGardenState', () => {
     expect(result).toContain('tableau2');
   });
 
+  // **頼んでいないヒントは CLI に出さない。**#4483 以降 Output() もヒントを載せる。
+  it('does not print a passive hint carried on an ordinary response', () => {
+    const result = formatFlowerGardenState(
+      makeState({
+        hint: { fromZone: 'tableau', fromCol: 0, cardIndex: 1, toZone: 'tableau', toCol: 2 },
+        messageCode: 'flowergarden.playing',
+      }),
+    );
+    expect(result).not.toContain('HINT');
+  });
+
   it('shows hint from reserve when present', () => {
     const result = formatFlowerGardenState(
       makeState({
         hint: { fromZone: 'reserve', fromCol: 3, cardIndex: 0, toZone: 'foundation', toCol: 1 },
+        messageCode: 'flowergarden.hintAvailable',
       }),
     );
     expect(result).toContain('HINT');

--- a/frontend/src/utils/cli/formatters/flowergardenFormatter.ts
+++ b/frontend/src/utils/cli/formatters/flowergardenFormatter.ts
@@ -1,5 +1,5 @@
 import type { FlowerGardenResponse } from '../../../types/card';
-import { formatCard, formatHeader, formatSeparator } from '../formatterBase';
+import { formatCard, formatHeader, formatSeparator, isRequestedHint } from '../formatterBase';
 
 /** Format a Flower Garden game state as terminal text. */
 export function formatFlowerGardenState(state: FlowerGardenResponse): string {
@@ -30,7 +30,7 @@ export function formatFlowerGardenState(state: FlowerGardenResponse): string {
 
   lines.push(`moves: ${state.moveCount}  undo:${state.canUndo ? 'yes' : 'no'}`);
 
-  if (state.hint) {
+  if (state.hint && isRequestedHint(state)) {
     const src =
       state.hint.fromZone === 'reserve' ? `r${state.hint.fromCol}` : `t${state.hint.fromCol}[${state.hint.cardIndex}]`;
     const target = state.hint.toCol >= 0 ? `${state.hint.toZone}${state.hint.toCol}` : state.hint.toZone;

--- a/internal/adapter/presenter/EasthavenWebPresenter.go
+++ b/internal/adapter/presenter/EasthavenWebPresenter.go
@@ -46,6 +46,20 @@ func (p *EasthavenWebPresenter) Output(e interfaces.EasthavenGame, lastErr error
 	}
 
 	// メッセージ
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	if e.GetPhase() == domain.EasthavenPhasePlaying && !e.IsStalemate() {
+		if hint := e.GetHint(); hint != nil {
+			resObj.Hint = &controller.EasthavenWebOutputHint{
+				FromCol:   hint.FromCol,
+				CardIndex: hint.CardIndex,
+				ToZone:    hint.ToZone,
+				ToCol:     hint.ToCol,
+			}
+		}
+	}
+
 	if lastErr != nil {
 		resObj.Message = lastErr.Error()
 	} else {

--- a/internal/adapter/presenter/EasthavenWebPresenter_test.go
+++ b/internal/adapter/presenter/EasthavenWebPresenter_test.go
@@ -39,10 +39,17 @@ func parseEasthavenOutput(t *testing.T, jsonStr string) *controller.EasthavenWeb
 	return &out
 }
 
+// setupEasthavenOutputMock は Output 用の既定。**Output() も受動ヒントを埋める**
+// ようになった (#4483) ので GetHint を呼べるようにする。
+func setupEasthavenOutputMock(g *interfaces.MockEasthavenGame) {
+	setupEasthavenWebMockDefaults(g)
+	g.On("GetHint").Return(nil).Maybe()
+}
+
 func TestEasthavenWebPresenter_Output(t *testing.T) {
 	t.Run("initial state", func(t *testing.T) {
 		eg := new(interfaces.MockEasthavenGame)
-		setupEasthavenWebMockDefaults(eg)
+		setupEasthavenOutputMock(eg)
 		p := new(EasthavenWebPresenter)
 
 		result := parseEasthavenOutput(t, p.Output(eg, nil))
@@ -53,7 +60,7 @@ func TestEasthavenWebPresenter_Output(t *testing.T) {
 
 	t.Run("stalemate with escape", func(t *testing.T) {
 		eg := new(interfaces.MockEasthavenGame)
-		setupEasthavenWebMockDefaults(eg)
+		setupEasthavenOutputMock(eg)
 		eg.ExpectedCalls = nil
 		eg.On("GetPhase").Return(domain.EasthavenPhasePlaying).Maybe()
 		eg.On("GetMoveCount").Return(5).Maybe()
@@ -74,7 +81,7 @@ func TestEasthavenWebPresenter_Output(t *testing.T) {
 
 	t.Run("stalemate without escape", func(t *testing.T) {
 		eg := new(interfaces.MockEasthavenGame)
-		setupEasthavenWebMockDefaults(eg)
+		setupEasthavenOutputMock(eg)
 		eg.ExpectedCalls = nil
 		eg.On("GetPhase").Return(domain.EasthavenPhasePlaying).Maybe()
 		eg.On("GetMoveCount").Return(5).Maybe()
@@ -94,7 +101,7 @@ func TestEasthavenWebPresenter_Output(t *testing.T) {
 
 	t.Run("game clear", func(t *testing.T) {
 		eg := new(interfaces.MockEasthavenGame)
-		setupEasthavenWebMockDefaults(eg)
+		setupEasthavenOutputMock(eg)
 		eg.ExpectedCalls = nil
 		eg.On("GetPhase").Return(domain.EasthavenPhaseGameClear).Maybe()
 		eg.On("GetMoveCount").Return(42).Maybe()
@@ -114,7 +121,7 @@ func TestEasthavenWebPresenter_Output(t *testing.T) {
 
 	t.Run("game over", func(t *testing.T) {
 		eg := new(interfaces.MockEasthavenGame)
-		setupEasthavenWebMockDefaults(eg)
+		setupEasthavenOutputMock(eg)
 		eg.ExpectedCalls = nil
 		eg.On("GetPhase").Return(domain.EasthavenPhaseGameOver).Maybe()
 		eg.On("GetMoveCount").Return(10).Maybe()
@@ -134,12 +141,28 @@ func TestEasthavenWebPresenter_Output(t *testing.T) {
 
 	t.Run("with error", func(t *testing.T) {
 		eg := new(interfaces.MockEasthavenGame)
-		setupEasthavenWebMockDefaults(eg)
+		setupEasthavenOutputMock(eg)
 		p := new(EasthavenWebPresenter)
 
 		result := parseEasthavenOutput(t, p.Output(eg, errors.New("test error")))
 		assert.Equal(t, "test error", result.Message)
 	})
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+func TestEasthavenWebPresenter_OutputCarriesTheHint(t *testing.T) {
+	hint := &domain.EasthavenHint{FromCol: 2, CardIndex: 1, ToZone: "foundation", ToCol: 0}
+
+	eg := new(interfaces.MockEasthavenGame)
+	setupEasthavenWebMockDefaults(eg)
+	eg.On("GetHint").Return(hint).Maybe()
+
+	result := parseEasthavenOutput(t, new(EasthavenWebPresenter).Output(eg, nil))
+	if result.Hint == nil {
+		t.Fatal("Output must carry the hint -- the frontend reads state.hint")
+	}
+	assert.Equal(t, 2, result.Hint.FromCol)
 }
 
 func TestEasthavenWebPresenter_HintOutput(t *testing.T) {

--- a/internal/adapter/presenter/FlowerGardenWebPresenter.go
+++ b/internal/adapter/presenter/FlowerGardenWebPresenter.go
@@ -53,6 +53,21 @@ func (p *FlowerGardenWebPresenter) Output(bc interfaces.FlowerGardenGame, lastEr
 	}
 
 	// メッセージ
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	if bc.GetPhase() == domain.FlowerGardenPhasePlaying && !bc.IsStalemate() {
+		if hint := bc.GetHint(); hint != nil {
+			resObj.Hint = &controller.FlowerGardenWebOutputHint{
+				FromZone:  hint.FromZone,
+				FromCol:   hint.FromCol,
+				CardIndex: hint.CardIndex,
+				ToZone:    hint.ToZone,
+				ToCol:     hint.ToCol,
+			}
+		}
+	}
+
 	if lastErr != nil {
 		resObj.Message = lastErr.Error()
 	} else {

--- a/internal/adapter/presenter/FlowerGardenWebPresenter_test.go
+++ b/internal/adapter/presenter/FlowerGardenWebPresenter_test.go
@@ -54,10 +54,17 @@ func parseFlowerGardenOutput(t *testing.T, jsonStr string) *controller.FlowerGar
 	return &out
 }
 
+// setupFlowerGardenOutputMock は Output 用の既定。**Output() も受動ヒントを埋める**
+// ようになった (#4483) ので GetHint を呼べるようにする。
+func setupFlowerGardenOutputMock(g *interfaces.MockFlowerGardenGame) {
+	setupFlowerGardenWebMockDefaults(g)
+	g.On("GetHint").Return(nil).Maybe()
+}
+
 func TestFlowerGardenWebPresenter_Output(t *testing.T) {
 	t.Run("initial state", func(t *testing.T) {
 		bg := new(interfaces.MockFlowerGardenGame)
-		setupFlowerGardenWebMockDefaults(bg)
+		setupFlowerGardenOutputMock(bg)
 		p := new(FlowerGardenWebPresenter)
 
 		result := parseFlowerGardenOutput(t, p.Output(bg, nil))
@@ -71,7 +78,7 @@ func TestFlowerGardenWebPresenter_Output(t *testing.T) {
 
 	t.Run("all face up", func(t *testing.T) {
 		bg := new(interfaces.MockFlowerGardenGame)
-		setupFlowerGardenWebMockDefaults(bg)
+		setupFlowerGardenOutputMock(bg)
 		p := new(FlowerGardenWebPresenter)
 
 		result := parseFlowerGardenOutput(t, p.Output(bg, nil))
@@ -85,7 +92,7 @@ func TestFlowerGardenWebPresenter_Output(t *testing.T) {
 
 	t.Run("error message", func(t *testing.T) {
 		bg := new(interfaces.MockFlowerGardenGame)
-		setupFlowerGardenWebMockDefaults(bg)
+		setupFlowerGardenOutputMock(bg)
 		p := new(FlowerGardenWebPresenter)
 
 		result := parseFlowerGardenOutput(t, p.Output(bg, errors.New("test error")))
@@ -94,7 +101,7 @@ func TestFlowerGardenWebPresenter_Output(t *testing.T) {
 
 	t.Run("game clear", func(t *testing.T) {
 		bg := new(interfaces.MockFlowerGardenGame)
-		setupFlowerGardenWebMockDefaults(bg)
+		setupFlowerGardenOutputMock(bg)
 		bg.ExpectedCalls = filterCalls(bg.ExpectedCalls, "GetPhase")
 		bg.On("GetPhase").Return(domain.FlowerGardenPhaseGameClear)
 
@@ -105,7 +112,7 @@ func TestFlowerGardenWebPresenter_Output(t *testing.T) {
 
 	t.Run("game over", func(t *testing.T) {
 		bg := new(interfaces.MockFlowerGardenGame)
-		setupFlowerGardenWebMockDefaults(bg)
+		setupFlowerGardenOutputMock(bg)
 		bg.ExpectedCalls = filterCalls(bg.ExpectedCalls, "GetPhase")
 		bg.On("GetPhase").Return(domain.FlowerGardenPhaseGameOver)
 
@@ -116,7 +123,7 @@ func TestFlowerGardenWebPresenter_Output(t *testing.T) {
 
 	t.Run("stalemate", func(t *testing.T) {
 		bg := new(interfaces.MockFlowerGardenGame)
-		setupFlowerGardenWebMockDefaults(bg)
+		setupFlowerGardenOutputMock(bg)
 		bg.ExpectedCalls = filterCalls(bg.ExpectedCalls, "IsStalemate")
 		bg.On("IsStalemate").Return(true)
 
@@ -127,7 +134,7 @@ func TestFlowerGardenWebPresenter_Output(t *testing.T) {
 
 	t.Run("depleted reserve cell serialises null", func(t *testing.T) {
 		bg := new(interfaces.MockFlowerGardenGame)
-		setupFlowerGardenWebMockDefaults(bg)
+		setupFlowerGardenOutputMock(bg)
 		bg.ExpectedCalls = filterCalls(bg.ExpectedCalls, "GetReserve")
 		bg.On("GetReserve").Return([]*domain.Card{nil, domain.NewCard(domain.CardDesignSpade, 5, false)})
 
@@ -137,6 +144,22 @@ func TestFlowerGardenWebPresenter_Output(t *testing.T) {
 		assert.Nil(t, result.Reserve[0])
 		assert.NotNil(t, result.Reserve[1])
 	})
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+func TestFlowerGardenWebPresenter_OutputCarriesTheHint(t *testing.T) {
+	hint := &domain.FlowerGardenHint{FromZone: "tableau", FromCol: 2, CardIndex: 1, ToZone: "foundation", ToCol: 0}
+
+	bg := new(interfaces.MockFlowerGardenGame)
+	setupFlowerGardenWebMockDefaults(bg)
+	bg.On("GetHint").Return(hint).Maybe()
+
+	result := parseFlowerGardenOutput(t, new(FlowerGardenWebPresenter).Output(bg, nil))
+	if result.Hint == nil {
+		t.Fatal("Output must carry the hint -- the frontend reads state.hint")
+	}
+	assert.Equal(t, 2, result.Hint.FromCol)
 }
 
 func TestFlowerGardenWebPresenter_HintOutput(t *testing.T) {

--- a/internal/adapter/presenter/GapsWebPresenter.go
+++ b/internal/adapter/presenter/GapsWebPresenter.go
@@ -18,6 +18,20 @@ func (pr *GapsWebPresenter) Output(g interfaces.GapsGame, lastErr error) string 
 	resObj := new(controller.GapsWebOutput)
 	pr.populate(resObj, g)
 
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	if g.GetPhase() == domain.GapsPhasePlaying && !g.IsStalemate() {
+		if hint := g.GetHint(); hint != nil {
+			resObj.Hint = &controller.GapsWebOutputHint{
+				FromRow: hint.FromRow,
+				FromCol: hint.FromCol,
+				ToRow:   hint.ToRow,
+				ToCol:   hint.ToCol,
+			}
+		}
+	}
+
 	if lastErr != nil {
 		resObj.Message = lastErr.Error()
 	} else {

--- a/internal/adapter/presenter/GapsWebPresenter_test.go
+++ b/internal/adapter/presenter/GapsWebPresenter_test.go
@@ -39,9 +39,16 @@ func parseGapsOutput(t *testing.T, s string) *controller.GapsWebOutput {
 	return &out
 }
 
+// setupGapsOutputMock は Output 用の既定。**Output() も受動ヒントを埋める**
+// ようになった (#4483) ので GetHint を呼べるようにする。
+func setupGapsOutputMock(g *interfaces.MockGapsGame) {
+	setupGapsWebMockDefaults(g)
+	g.On("GetHint").Return(nil).Maybe()
+}
+
 func TestGapsWebPresenter_Output_Playing(t *testing.T) {
 	g := new(interfaces.MockGapsGame)
-	setupGapsWebMockDefaults(g)
+	setupGapsOutputMock(g)
 	p := &GapsWebPresenter{}
 	out := parseGapsOutput(t, p.Output(g, nil))
 	assert.Equal(t, "gaps.playing", out.MessageCode)
@@ -51,7 +58,7 @@ func TestGapsWebPresenter_Output_Playing(t *testing.T) {
 
 func TestGapsWebPresenter_Output_Stalemate(t *testing.T) {
 	g := new(interfaces.MockGapsGame)
-	setupGapsWebMockDefaults(g)
+	setupGapsOutputMock(g)
 	g.ExpectedCalls = nil
 	g.On("GetPhase").Return(domain.GapsPhasePlaying).Maybe()
 	g.On("GetMoveCount").Return(0).Maybe()
@@ -69,7 +76,7 @@ func TestGapsWebPresenter_Output_Stalemate(t *testing.T) {
 
 func TestGapsWebPresenter_Output_GameClear(t *testing.T) {
 	g := new(interfaces.MockGapsGame)
-	setupGapsWebMockDefaults(g)
+	setupGapsOutputMock(g)
 	g.ExpectedCalls = nil
 	g.On("GetPhase").Return(domain.GapsPhaseGameClear).Maybe()
 	g.On("GetMoveCount").Return(42).Maybe()
@@ -88,7 +95,7 @@ func TestGapsWebPresenter_Output_GameClear(t *testing.T) {
 
 func TestGapsWebPresenter_Output_GameOver(t *testing.T) {
 	g := new(interfaces.MockGapsGame)
-	setupGapsWebMockDefaults(g)
+	setupGapsOutputMock(g)
 	g.ExpectedCalls = nil
 	g.On("GetPhase").Return(domain.GapsPhaseGameOver).Maybe()
 	g.On("GetMoveCount").Return(0).Maybe()
@@ -106,10 +113,23 @@ func TestGapsWebPresenter_Output_GameOver(t *testing.T) {
 
 func TestGapsWebPresenter_Output_Error(t *testing.T) {
 	g := new(interfaces.MockGapsGame)
-	setupGapsWebMockDefaults(g)
+	setupGapsOutputMock(g)
 	p := &GapsWebPresenter{}
 	out := parseGapsOutput(t, p.Output(g, errors.New("oops")))
 	assert.Equal(t, "oops", out.Message)
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+func TestGapsWebPresenter_OutputCarriesTheHint(t *testing.T) {
+	hint := &domain.GapsHint{FromRow: 1, FromCol: 2, ToRow: 0, ToCol: 3}
+
+	g := new(interfaces.MockGapsGame)
+	setupGapsWebMockDefaults(g)
+	g.On("GetHint").Return(hint).Maybe()
+
+	result := new(GapsWebPresenter).Output(g, nil)
+	assert.Contains(t, result, `"hint"`, "Output must carry the hint -- the frontend reads state.hint")
 }
 
 func TestGapsWebPresenter_HintOutput_None(t *testing.T) {


### PR DESCRIPTION
## 概要

7 本目。**Easthaven / Flower Garden / Gaps**。**18 / 91**。

Refs #4483

## 負のコントロールが、私の生成スクリプトの嘘を捕まえました

3 本のゲートを落として全部落ちるはずが、**2 本しか落ちませんでした。**

調べると、**Gaps のテストがそもそも入っていませんでした。**スクリプトは `Test<Game>WebPresenter_HintOutput` をアンカーにしていましたが、Gaps は `HintOutput_None` / `HintOutput_WithHint` と分かれていてアンカーが存在せず、`str.replace` が**黙って no-op**になり、それでも「added: Gaps」と表示していました。

**負のコントロールを取っていなければ、「テストがある」と思ったまま通していました。**スクリプトには挿入後に文字列が変わったことを assert する検証を入れています。

```
# 修正後（3 本とも網になっている）
$ (ゲートを 3 本とも false に) && go test -run OutputCarriesTheHint
--- FAIL: TestEasthavenWebPresenter_OutputCarriesTheHint
--- FAIL: TestFlowerGardenWebPresenter_OutputCarriesTheHint
--- FAIL: TestGapsWebPresenter_OutputCarriesTheHint
```

## CLI ゲートは 1 本だけ

| ゲーム | CLI フォーマッタ | ゲート |
|---|---|---|
| Easthaven | あるが**ヒントを参照していない** | 不要 |
| Gaps | **存在しない** | 不要 |
| Flower Garden | 印字する | **適用** |

**負のコントロールもフィクスチャ変更と同じコミットに入れています。**直近 3 回のレビューで「フィクスチャだけ直してテストを足していない」と指摘された箇所です。

## ヒント構造体

| ゲーム | フィールド |
|---|---|
| Easthaven | `FromCol` / `CardIndex` / `ToZone` / `ToCol` |
| Flower Garden | `FromZone` / `FromCol` / `CardIndex` / `ToZone` / `ToCol` |
| Gaps | **`FromRow` / `FromCol` / `ToRow` / `ToCol`**（行列型はこのゲームだけ） |

## 確認

- `go test -tags test ./internal/adapter/presenter/ -count=2` green
- `golangci-lint run ./internal/adapter/presenter/` 0 issues
- `bun run check` / `typecheck` green

## 進捗

| | |
|---|---|
| 受動ヒント済み | **18 / 91** |
| 残り | 73（Playing フェーズあり 13 / 無し 60） |

## Test plan

- [ ] CI 全ジョブ green