### PR TITLE
fix(hints): carry the passive hint for Grandfather's Clock, King Albert and Miss Milligan (#4483)

### DIFF
--- a/frontend/src/utils/cli/formatters/grandfathersclockFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/grandfathersclockFormatter.test.ts
@@ -51,13 +51,28 @@ describe('formatGrandfathersClockState', () => {
   });
 
   it('shows a clock-face hint', () => {
-    const result = formatGrandfathersClockState(makeState({ hint: { fromCol: 3, toZone: 'foundation', toIdx: 7 } }));
+    const result = formatGrandfathersClockState(
+      makeState({
+        hint: { fromCol: 3, toZone: 'foundation', toIdx: 7 },
+        messageCode: 'grandfathersclock.hintAvailable',
+      }),
+    );
     expect(result).toContain('HINT');
     expect(result).toContain('f7');
   });
 
+  // **頼んでいないヒントは CLI に出さない。**#4483 以降 Output() もヒントを載せる。
+  it('does not print a passive hint carried on an ordinary response', () => {
+    const result = formatGrandfathersClockState(
+      makeState({ hint: { fromCol: 3, toZone: 'foundation', toIdx: 7 }, messageCode: 'grandfathersclock.playing' }),
+    );
+    expect(result).not.toContain('HINT');
+  });
+
   it('shows a tableau hint', () => {
-    const result = formatGrandfathersClockState(makeState({ hint: { fromCol: 3, toZone: 'tableau', toIdx: 5 } }));
+    const result = formatGrandfathersClockState(
+      makeState({ hint: { fromCol: 3, toZone: 'tableau', toIdx: 5 }, messageCode: 'grandfathersclock.hintAvailable' }),
+    );
     expect(result).toContain('t5');
   });
 

--- a/frontend/src/utils/cli/formatters/grandfathersclockFormatter.ts
+++ b/frontend/src/utils/cli/formatters/grandfathersclockFormatter.ts
@@ -1,5 +1,5 @@
 import type { GrandfathersClockResponse } from '../../../types/card';
-import { formatCard, formatHeader, formatSeparator } from '../formatterBase';
+import { formatCard, formatHeader, formatSeparator, isRequestedHint } from '../formatterBase';
 
 /** Format a Grandfather's Clock game state as terminal text. */
 export function formatGrandfathersClockState(state: GrandfathersClockResponse): string {
@@ -28,7 +28,7 @@ export function formatGrandfathersClockState(state: GrandfathersClockResponse): 
 
   lines.push(`moves: ${state.moveCount}  undo:${state.canUndo ? 'yes' : 'no'}`);
 
-  if (state.hint) {
+  if (state.hint && isRequestedHint(state)) {
     const to = state.hint.toZone === 'foundation' ? `f${state.hint.toIdx}` : `t${state.hint.toIdx}`;
     lines.push(`HINT: t${state.hint.fromCol} → ${to}`);
   }

--- a/frontend/src/utils/cli/formatters/kingalbertFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/kingalbertFormatter.test.ts
@@ -56,6 +56,7 @@ describe('formatKingAlbertState', () => {
     const result = formatKingAlbertState(
       makeState({
         hint: { fromZone: 'tableau', fromCol: 0, cardIndex: 1, toZone: 'tableau', toCol: 2 },
+        messageCode: 'kingalbert.hintAvailable',
       }),
     );
     expect(result).toContain('HINT');
@@ -63,10 +64,22 @@ describe('formatKingAlbertState', () => {
     expect(result).toContain('tableau2');
   });
 
+  // **頼んでいないヒントは CLI に出さない。**#4483 以降 Output() もヒントを載せる。
+  it('does not print a passive hint carried on an ordinary response', () => {
+    const result = formatKingAlbertState(
+      makeState({
+        hint: { fromZone: 'tableau', fromCol: 0, cardIndex: 1, toZone: 'tableau', toCol: 2 },
+        messageCode: 'kingalbert.playing',
+      }),
+    );
+    expect(result).not.toContain('HINT');
+  });
+
   it('shows hint from reserve when present', () => {
     const result = formatKingAlbertState(
       makeState({
         hint: { fromZone: 'reserve', fromCol: 3, cardIndex: 0, toZone: 'foundation', toCol: 1 },
+        messageCode: 'kingalbert.hintAvailable',
       }),
     );
     expect(result).toContain('HINT');

--- a/frontend/src/utils/cli/formatters/kingalbertFormatter.ts
+++ b/frontend/src/utils/cli/formatters/kingalbertFormatter.ts
@@ -1,5 +1,5 @@
 import type { KingAlbertResponse } from '../../../types/card';
-import { formatCard, formatHeader, formatSeparator } from '../formatterBase';
+import { formatCard, formatHeader, formatSeparator, isRequestedHint } from '../formatterBase';
 
 /** Format a King Albert game state as terminal text. */
 export function formatKingAlbertState(state: KingAlbertResponse): string {
@@ -30,7 +30,7 @@ export function formatKingAlbertState(state: KingAlbertResponse): string {
 
   lines.push(`moves: ${state.moveCount}  undo:${state.canUndo ? 'yes' : 'no'}`);
 
-  if (state.hint) {
+  if (state.hint && isRequestedHint(state)) {
     const src =
       state.hint.fromZone === 'reserve' ? `r${state.hint.fromCol}` : `t${state.hint.fromCol}[${state.hint.cardIndex}]`;
     const target = state.hint.toCol >= 0 ? `${state.hint.toZone}${state.hint.toCol}` : state.hint.toZone;

--- a/frontend/src/utils/cli/formatters/missmilliganFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/missmilliganFormatter.test.ts
@@ -59,16 +59,33 @@ describe('formatMissMilliganState', () => {
 
   it('shows a tableau hint with the run head', () => {
     const result = formatMissMilliganState(
-      makeState({ hint: { fromZone: 'tableau', fromCol: 3, cardIndex: 1, toZone: 'tableau', toIdx: 7 } }),
+      makeState({
+        hint: { fromZone: 'tableau', fromCol: 3, cardIndex: 1, toZone: 'tableau', toIdx: 7 },
+        messageCode: 'missmilligan.hintAvailable',
+      }),
     );
     expect(result).toContain('HINT');
     expect(result).toContain('t3[1]');
   });
 
+  // **頼んでいないヒントは CLI に出さない。**#4483 以降 Output() もヒントを載せる。
+  it('does not print a passive hint carried on an ordinary response', () => {
+    const result = formatMissMilliganState(
+      makeState({
+        hint: { fromZone: 'tableau', fromCol: 3, cardIndex: 1, toZone: 'tableau', toIdx: 7 },
+        messageCode: 'missmilligan.playing',
+      }),
+    );
+    expect(result).not.toContain('HINT');
+  });
+
   // A deal targets every column, so it has no single destination index.
   it('renders a deal hint without a destination index', () => {
     const result = formatMissMilliganState(
-      makeState({ hint: { fromZone: 'stock', fromCol: -1, cardIndex: -1, toZone: 'tableau', toIdx: -1 } }),
+      makeState({
+        hint: { fromZone: 'stock', fromCol: -1, cardIndex: -1, toZone: 'tableau', toIdx: -1 },
+        messageCode: 'missmilligan.hintAvailable',
+      }),
     );
     expect(result).toContain('stock');
     expect(result).toContain('deal');

--- a/frontend/src/utils/cli/formatters/missmilliganFormatter.ts
+++ b/frontend/src/utils/cli/formatters/missmilliganFormatter.ts
@@ -1,5 +1,5 @@
 import type { MissMilliganResponse } from '../../../types/card';
-import { formatCard, formatHeader, formatSeparator } from '../formatterBase';
+import { formatCard, formatHeader, formatSeparator, isRequestedHint } from '../formatterBase';
 
 /** Format a Miss Milligan game state as terminal text. */
 export function formatMissMilliganState(state: MissMilliganResponse): string {
@@ -34,7 +34,7 @@ export function formatMissMilliganState(state: MissMilliganResponse): string {
 
   lines.push(`moves: ${state.moveCount}  undo:${state.canUndo ? 'yes' : 'no'}`);
 
-  if (state.hint) {
+  if (state.hint && isRequestedHint(state)) {
     const from =
       state.hint.fromZone === 'tableau' ? `t${state.hint.fromCol}[${state.hint.cardIndex}]` : state.hint.fromZone;
     const to = state.hint.toIdx >= 0 ? `${state.hint.toZone}${state.hint.toIdx}` : 'deal';

--- a/internal/adapter/presenter/GrandfathersClockWebPresenter.go
+++ b/internal/adapter/presenter/GrandfathersClockWebPresenter.go
@@ -51,6 +51,19 @@ func (p *GrandfathersClockWebPresenter) Output(gc interfaces.GrandfathersClockGa
 	}
 
 	// メッセージ
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	if gc.GetPhase() == domain.GrandfathersClockPhasePlaying && !gc.IsStalemate() {
+		if hint := gc.GetHint(); hint != nil {
+			resObj.Hint = &controller.GrandfathersClockWebOutputHint{
+				FromCol: hint.FromCol,
+				ToZone:  hint.ToZone,
+				ToIdx:   hint.ToIdx,
+			}
+		}
+	}
+
 	if lastErr != nil {
 		resObj.Message = lastErr.Error()
 	} else {

--- a/internal/adapter/presenter/GrandfathersClockWebPresenter_test.go
+++ b/internal/adapter/presenter/GrandfathersClockWebPresenter_test.go
@@ -49,10 +49,17 @@ func parseGrandfathersClockOutput(t *testing.T, jsonStr string) *controller.Gran
 	return &out
 }
 
+// setupGrandfathersClockOutputMock は Output 用の既定。**Output() も受動ヒントを埋める**
+// ようになった (#4483) ので GetHint を呼べるようにする。
+func setupGrandfathersClockOutputMock(g *interfaces.MockGrandfathersClockGame) {
+	setupGrandfathersClockWebMockDefaults(g)
+	g.On("GetHint").Return(nil).Maybe()
+}
+
 func TestGrandfathersClockWebPresenter_Output(t *testing.T) {
 	t.Run("initial state", func(t *testing.T) {
 		g := new(interfaces.MockGrandfathersClockGame)
-		setupGrandfathersClockWebMockDefaults(g)
+		setupGrandfathersClockOutputMock(g)
 
 		result := parseGrandfathersClockOutput(t, new(GrandfathersClockWebPresenter).Output(g, nil))
 		assert.Equal(t, 0, result.Phase)
@@ -65,7 +72,7 @@ func TestGrandfathersClockWebPresenter_Output(t *testing.T) {
 	// clock ordering and drift from the domain.
 	t.Run("each face carries its target rank", func(t *testing.T) {
 		g := new(interfaces.MockGrandfathersClockGame)
-		setupGrandfathersClockWebMockDefaults(g)
+		setupGrandfathersClockOutputMock(g)
 
 		result := parseGrandfathersClockOutput(t, new(GrandfathersClockWebPresenter).Output(g, nil))
 		for i, f := range result.Foundation {
@@ -78,7 +85,7 @@ func TestGrandfathersClockWebPresenter_Output(t *testing.T) {
 
 	t.Run("completed faces are flagged", func(t *testing.T) {
 		g := new(interfaces.MockGrandfathersClockGame)
-		setupGrandfathersClockWebMockDefaults(g)
+		setupGrandfathersClockOutputMock(g)
 		g.ExpectedCalls = filterCalls(g.ExpectedCalls, "IsFoundationComplete")
 		g.On("IsFoundationComplete", mock.AnythingOfType("int")).Return(true)
 
@@ -90,7 +97,7 @@ func TestGrandfathersClockWebPresenter_Output(t *testing.T) {
 
 	t.Run("all face up", func(t *testing.T) {
 		g := new(interfaces.MockGrandfathersClockGame)
-		setupGrandfathersClockWebMockDefaults(g)
+		setupGrandfathersClockOutputMock(g)
 
 		result := parseGrandfathersClockOutput(t, new(GrandfathersClockWebPresenter).Output(g, nil))
 		for _, col := range result.Tableau {
@@ -103,7 +110,7 @@ func TestGrandfathersClockWebPresenter_Output(t *testing.T) {
 
 	t.Run("error message", func(t *testing.T) {
 		g := new(interfaces.MockGrandfathersClockGame)
-		setupGrandfathersClockWebMockDefaults(g)
+		setupGrandfathersClockOutputMock(g)
 
 		result := parseGrandfathersClockOutput(t, new(GrandfathersClockWebPresenter).Output(g, errors.New("test error")))
 		assert.Equal(t, "test error", result.Message)
@@ -119,7 +126,7 @@ func TestGrandfathersClockWebPresenter_Output(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			g := new(interfaces.MockGrandfathersClockGame)
-			setupGrandfathersClockWebMockDefaults(g)
+			setupGrandfathersClockOutputMock(g)
 			g.ExpectedCalls = filterCalls(g.ExpectedCalls, "GetPhase")
 			g.On("GetPhase").Return(tc.val)
 
@@ -130,13 +137,29 @@ func TestGrandfathersClockWebPresenter_Output(t *testing.T) {
 
 	t.Run("stalemate", func(t *testing.T) {
 		g := new(interfaces.MockGrandfathersClockGame)
-		setupGrandfathersClockWebMockDefaults(g)
+		setupGrandfathersClockOutputMock(g)
 		g.ExpectedCalls = filterCalls(g.ExpectedCalls, "IsStalemate")
 		g.On("IsStalemate").Return(true)
 
 		result := parseGrandfathersClockOutput(t, new(GrandfathersClockWebPresenter).Output(g, nil))
 		assert.Equal(t, "grandfathersclock.stalemate", result.MessageCode)
 	})
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+func TestGrandfathersClockWebPresenter_OutputCarriesTheHint(t *testing.T) {
+	hint := &domain.GrandfathersClockHint{FromCol: 2, ToZone: "foundation", ToIdx: 0}
+
+	g := new(interfaces.MockGrandfathersClockGame)
+	setupGrandfathersClockWebMockDefaults(g)
+	g.On("GetHint").Return(hint).Maybe()
+
+	result := parseGrandfathersClockOutput(t, new(GrandfathersClockWebPresenter).Output(g, nil))
+	if result.Hint == nil {
+		t.Fatal("Output must carry the hint -- the frontend reads state.hint")
+	}
+	assert.Equal(t, 2, result.Hint.FromCol)
 }
 
 func TestGrandfathersClockWebPresenter_HintOutput(t *testing.T) {

--- a/internal/adapter/presenter/KingAlbertWebPresenter.go
+++ b/internal/adapter/presenter/KingAlbertWebPresenter.go
@@ -53,6 +53,21 @@ func (p *KingAlbertWebPresenter) Output(bc interfaces.KingAlbertGame, lastErr er
 	}
 
 	// メッセージ
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	if bc.GetPhase() == domain.KingAlbertPhasePlaying && !bc.IsStalemate() {
+		if hint := bc.GetHint(); hint != nil {
+			resObj.Hint = &controller.KingAlbertWebOutputHint{
+				FromZone:  hint.FromZone,
+				FromCol:   hint.FromCol,
+				CardIndex: hint.CardIndex,
+				ToZone:    hint.ToZone,
+				ToCol:     hint.ToCol,
+			}
+		}
+	}
+
 	if lastErr != nil {
 		resObj.Message = lastErr.Error()
 	} else {

--- a/internal/adapter/presenter/KingAlbertWebPresenter_test.go
+++ b/internal/adapter/presenter/KingAlbertWebPresenter_test.go
@@ -54,10 +54,17 @@ func parseKingAlbertOutput(t *testing.T, jsonStr string) *controller.KingAlbertW
 	return &out
 }
 
+// setupKingAlbertOutputMock は Output 用の既定。**Output() も受動ヒントを埋める**
+// ようになった (#4483) ので GetHint を呼べるようにする。
+func setupKingAlbertOutputMock(g *interfaces.MockKingAlbertGame) {
+	setupKingAlbertWebMockDefaults(g)
+	g.On("GetHint").Return(nil).Maybe()
+}
+
 func TestKingAlbertWebPresenter_Output(t *testing.T) {
 	t.Run("initial state", func(t *testing.T) {
 		bg := new(interfaces.MockKingAlbertGame)
-		setupKingAlbertWebMockDefaults(bg)
+		setupKingAlbertOutputMock(bg)
 		p := new(KingAlbertWebPresenter)
 
 		result := parseKingAlbertOutput(t, p.Output(bg, nil))
@@ -71,7 +78,7 @@ func TestKingAlbertWebPresenter_Output(t *testing.T) {
 
 	t.Run("all face up", func(t *testing.T) {
 		bg := new(interfaces.MockKingAlbertGame)
-		setupKingAlbertWebMockDefaults(bg)
+		setupKingAlbertOutputMock(bg)
 		p := new(KingAlbertWebPresenter)
 
 		result := parseKingAlbertOutput(t, p.Output(bg, nil))
@@ -85,7 +92,7 @@ func TestKingAlbertWebPresenter_Output(t *testing.T) {
 
 	t.Run("error message", func(t *testing.T) {
 		bg := new(interfaces.MockKingAlbertGame)
-		setupKingAlbertWebMockDefaults(bg)
+		setupKingAlbertOutputMock(bg)
 		p := new(KingAlbertWebPresenter)
 
 		result := parseKingAlbertOutput(t, p.Output(bg, errors.New("test error")))
@@ -94,7 +101,7 @@ func TestKingAlbertWebPresenter_Output(t *testing.T) {
 
 	t.Run("game clear", func(t *testing.T) {
 		bg := new(interfaces.MockKingAlbertGame)
-		setupKingAlbertWebMockDefaults(bg)
+		setupKingAlbertOutputMock(bg)
 		bg.ExpectedCalls = filterCalls(bg.ExpectedCalls, "GetPhase")
 		bg.On("GetPhase").Return(domain.KingAlbertPhaseGameClear)
 
@@ -105,7 +112,7 @@ func TestKingAlbertWebPresenter_Output(t *testing.T) {
 
 	t.Run("game over", func(t *testing.T) {
 		bg := new(interfaces.MockKingAlbertGame)
-		setupKingAlbertWebMockDefaults(bg)
+		setupKingAlbertOutputMock(bg)
 		bg.ExpectedCalls = filterCalls(bg.ExpectedCalls, "GetPhase")
 		bg.On("GetPhase").Return(domain.KingAlbertPhaseGameOver)
 
@@ -116,7 +123,7 @@ func TestKingAlbertWebPresenter_Output(t *testing.T) {
 
 	t.Run("stalemate", func(t *testing.T) {
 		bg := new(interfaces.MockKingAlbertGame)
-		setupKingAlbertWebMockDefaults(bg)
+		setupKingAlbertOutputMock(bg)
 		bg.ExpectedCalls = filterCalls(bg.ExpectedCalls, "IsStalemate")
 		bg.On("IsStalemate").Return(true)
 
@@ -127,7 +134,7 @@ func TestKingAlbertWebPresenter_Output(t *testing.T) {
 
 	t.Run("depleted reserve cell serialises null", func(t *testing.T) {
 		bg := new(interfaces.MockKingAlbertGame)
-		setupKingAlbertWebMockDefaults(bg)
+		setupKingAlbertOutputMock(bg)
 		bg.ExpectedCalls = filterCalls(bg.ExpectedCalls, "GetReserve")
 		bg.On("GetReserve").Return([]*domain.Card{nil, domain.NewCard(domain.CardDesignSpade, 5, false)})
 
@@ -137,6 +144,22 @@ func TestKingAlbertWebPresenter_Output(t *testing.T) {
 		assert.Nil(t, result.Reserve[0])
 		assert.NotNil(t, result.Reserve[1])
 	})
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+func TestKingAlbertWebPresenter_OutputCarriesTheHint(t *testing.T) {
+	hint := &domain.KingAlbertHint{FromZone: "tableau", FromCol: 2, CardIndex: 1, ToZone: "foundation", ToCol: 0}
+
+	bg := new(interfaces.MockKingAlbertGame)
+	setupKingAlbertWebMockDefaults(bg)
+	bg.On("GetHint").Return(hint).Maybe()
+
+	result := parseKingAlbertOutput(t, new(KingAlbertWebPresenter).Output(bg, nil))
+	if result.Hint == nil {
+		t.Fatal("Output must carry the hint -- the frontend reads state.hint")
+	}
+	assert.Equal(t, 2, result.Hint.FromCol)
 }
 
 func TestKingAlbertWebPresenter_HintOutput(t *testing.T) {

--- a/internal/adapter/presenter/MissMilliganWebPresenter.go
+++ b/internal/adapter/presenter/MissMilliganWebPresenter.go
@@ -55,6 +55,21 @@ func (p *MissMilliganWebPresenter) Output(mm interfaces.MissMilliganGame, lastEr
 	resObj.CanWaive = mm.CanWaive()
 
 	// メッセージ
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	if mm.GetPhase() == domain.MissMilliganPhasePlaying && !mm.IsStalemate() {
+		if hint := mm.GetHint(); hint != nil {
+			resObj.Hint = &controller.MissMilliganWebOutputHint{
+				FromZone:  hint.FromZone,
+				FromCol:   hint.FromCol,
+				CardIndex: hint.CardIndex,
+				ToZone:    hint.ToZone,
+				ToIdx:     hint.ToIdx,
+			}
+		}
+	}
+
 	if lastErr != nil {
 		resObj.Message = lastErr.Error()
 	} else {

--- a/internal/adapter/presenter/MissMilliganWebPresenter_test.go
+++ b/internal/adapter/presenter/MissMilliganWebPresenter_test.go
@@ -43,10 +43,17 @@ func parseMissMilliganOutput(t *testing.T, jsonStr string) *controller.MissMilli
 	return &out
 }
 
+// setupMissMilliganOutputMock は Output 用の既定。**Output() も受動ヒントを埋める**
+// ようになった (#4483) ので GetHint を呼べるようにする。
+func setupMissMilliganOutputMock(g *interfaces.MockMissMilliganGame) {
+	setupMissMilliganWebMockDefaults(g)
+	g.On("GetHint").Return(nil).Maybe()
+}
+
 func TestMissMilliganWebPresenter_Output(t *testing.T) {
 	t.Run("initial state", func(t *testing.T) {
 		g := new(interfaces.MockMissMilliganGame)
-		setupMissMilliganWebMockDefaults(g)
+		setupMissMilliganOutputMock(g)
 
 		result := parseMissMilliganOutput(t, new(MissMilliganWebPresenter).Output(g, nil))
 		assert.Equal(t, 0, result.Phase)
@@ -62,7 +69,7 @@ func TestMissMilliganWebPresenter_Output(t *testing.T) {
 	// client must not have to recompute it.
 	t.Run("canWaive is surfaced", func(t *testing.T) {
 		g := new(interfaces.MockMissMilliganGame)
-		setupMissMilliganWebMockDefaults(g)
+		setupMissMilliganOutputMock(g)
 		g.ExpectedCalls = filterCalls(g.ExpectedCalls, "CanWaive")
 		g.On("CanWaive").Return(true)
 
@@ -74,7 +81,7 @@ func TestMissMilliganWebPresenter_Output(t *testing.T) {
 	// gets its own message rather than looking like ordinary play.
 	t.Run("waiving has its own message", func(t *testing.T) {
 		g := new(interfaces.MockMissMilliganGame)
-		setupMissMilliganWebMockDefaults(g)
+		setupMissMilliganOutputMock(g)
 		g.ExpectedCalls = filterCalls(g.ExpectedCalls, "GetWaived")
 		g.On("GetWaived").Return([]*domain.Card{domain.NewCard(domain.CardDesignHeart, 8, true)})
 
@@ -85,7 +92,7 @@ func TestMissMilliganWebPresenter_Output(t *testing.T) {
 
 	t.Run("stalemate outranks waiving", func(t *testing.T) {
 		g := new(interfaces.MockMissMilliganGame)
-		setupMissMilliganWebMockDefaults(g)
+		setupMissMilliganOutputMock(g)
 		g.ExpectedCalls = filterCalls(g.ExpectedCalls, "GetWaived")
 		g.ExpectedCalls = filterCalls(g.ExpectedCalls, "IsStalemate")
 		g.On("GetWaived").Return([]*domain.Card{domain.NewCard(domain.CardDesignHeart, 8, true)})
@@ -97,7 +104,7 @@ func TestMissMilliganWebPresenter_Output(t *testing.T) {
 
 	t.Run("error message", func(t *testing.T) {
 		g := new(interfaces.MockMissMilliganGame)
-		setupMissMilliganWebMockDefaults(g)
+		setupMissMilliganOutputMock(g)
 
 		result := parseMissMilliganOutput(t, new(MissMilliganWebPresenter).Output(g, errors.New("test error")))
 		assert.Equal(t, "test error", result.Message)
@@ -113,7 +120,7 @@ func TestMissMilliganWebPresenter_Output(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			g := new(interfaces.MockMissMilliganGame)
-			setupMissMilliganWebMockDefaults(g)
+			setupMissMilliganOutputMock(g)
 			g.ExpectedCalls = filterCalls(g.ExpectedCalls, "GetPhase")
 			g.On("GetPhase").Return(tc.val)
 
@@ -121,6 +128,22 @@ func TestMissMilliganWebPresenter_Output(t *testing.T) {
 			assert.Equal(t, tc.code, result.MessageCode)
 		})
 	}
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+func TestMissMilliganWebPresenter_OutputCarriesTheHint(t *testing.T) {
+	hint := &domain.MissMilliganHint{FromZone: "tableau", FromCol: 2, CardIndex: 1, ToZone: "foundation", ToIdx: 0}
+
+	g := new(interfaces.MockMissMilliganGame)
+	setupMissMilliganWebMockDefaults(g)
+	g.On("GetHint").Return(hint).Maybe()
+
+	result := parseMissMilliganOutput(t, new(MissMilliganWebPresenter).Output(g, nil))
+	if result.Hint == nil {
+		t.Fatal("Output must carry the hint -- the frontend reads state.hint")
+	}
+	assert.Equal(t, 2, result.Hint.FromCol)
 }
 
 func TestMissMilliganWebPresenter_HintOutput(t *testing.T) {


### PR DESCRIPTION
## 概要

8 本目。**Grandfather's Clock / King Albert / Miss Milligan**。**21 / 91**。

Refs #4483

## 前バッチの反省を仕組みに落としました

#4535 で、生成スクリプトが**アンカー不在のまま「追加した」と報告して黙って何もしていなかった**（Gaps）件を受けて、2 点直しています。

1. **すべての生成編集で「ファイルが実際に変わったこと」を assert** します。no-op なら例外で止まります
2. **アンカーは実在するテスト名を正規表現で拾います**。`Test<Game>WebPresenter_HintOutput` 固定だと、Gaps のように `_None` / `_WithHint` に分かれている場合に外れます

## 負のコントロールを毎回 2 種類とも取ります

| 対象 | 壊しかた | 結果 |
|---|---|---|
| Go プレゼンタのゲート | 3 本とも `if false` | **3 件 FAIL** |
| CLI フォーマッタのゲート | 3 本とも述語を外す | **3 ファイル FAIL** |

## ヒント構造体（今回もばらばら）

| ゲーム | フィールド |
|---|---|
| Grandfather's Clock | `FromCol` / `ToZone` / **`ToIdx`** |
| King Albert | `FromZone` / `FromCol` / `CardIndex` / `ToZone` / **`ToCol`** |
| Miss Milligan | `FromZone` / `FromCol` / `CardIndex` / `ToZone` / **`ToIdx`** |

King Albert と Miss Milligan は 1 フィールドだけ違います（`ToCol` / `ToIdx`）。コピーで済ませていたら気づけません。

## 確認

- `go test -tags test ./internal/adapter/presenter/ -count=2` green
- `golangci-lint run ./internal/adapter/presenter/` 0 issues
- CLI フォーマッタ 3 本 28 件 green
- `bun run check` / `typecheck` green

## 進捗

| | |
|---|---|
| 受動ヒント済み | **21 / 91** |
| 残り | 70（Playing フェーズあり 10 / 無し 60） |

## Test plan

- [ ] CI 全ジョブ green