### PR TITLE
fix(hints): carry the passive hint for Klondike, FreeCell and Spider (#4483)

### DIFF
--- a/frontend/src/utils/cli/formatters/freecellFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/freecellFormatter.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import type { FreeCellResponse } from '../../../types/card';
+import { formatFreecellState } from './freecellFormatter';
+
+function makeState(overrides?: Partial<FreeCellResponse>): FreeCellResponse {
+  return {
+    tableau: [[{ design: 'SPADE', value: 13 }], [], [], [], [], [], [], []],
+    freeCells: [null, null, null, null],
+    foundation: [[], [], [], []],
+    phase: 0,
+    moveCount: 3,
+    canUndo: true,
+    isStalemate: false,
+    message: '',
+    ...overrides,
+  };
+}
+
+describe('formatFreecellState', () => {
+  it('formats the basic state', () => {
+    const output = formatFreecellState(makeState());
+    expect(output).toContain('FreeCell');
+    expect(output).toContain('cells:');
+    expect(output).toContain('foundation:');
+    expect(output).toContain('moves: 3');
+    expect(output).toContain('col0:');
+  });
+
+  it('marks empty columns', () => {
+    expect(formatFreecellState(makeState())).toContain('col1: [empty]');
+  });
+
+  it('reports a stalemate', () => {
+    expect(formatFreecellState(makeState({ isStalemate: true }))).toContain('Stalemate');
+  });
+
+  // **HINT 行は hint を頼んだときだけ。**受動ヒントが Output に載るように
+  // なった (#4483) ので、messageCode で「頼んだ応答か」を見分ける。
+  it('shows the hint only when the hint was requested', () => {
+    const hint = { fromZone: 'tableau', fromCol: 0, cardIndex: 0, toZone: 'foundation', toCol: 1 };
+    expect(formatFreecellState(makeState({ hint, messageCode: 'freecell.hintAvailable' }))).toContain('HINT:');
+    expect(formatFreecellState(makeState({ hint, messageCode: 'freecell.playing' }))).not.toContain('HINT:');
+  });
+});

--- a/frontend/src/utils/cli/formatters/freecellFormatter.ts
+++ b/frontend/src/utils/cli/formatters/freecellFormatter.ts
@@ -1,5 +1,5 @@
 import type { FreeCellResponse } from '../../../types/card';
-import { formatCard, formatHeader, formatSeparator } from '../formatterBase';
+import { formatCard, formatHeader, formatSeparator, isRequestedHint } from '../formatterBase';
 
 /** Format a FreeCell game state as terminal text. */
 export function formatFreecellState(state: FreeCellResponse): string {
@@ -31,7 +31,7 @@ export function formatFreecellState(state: FreeCellResponse): string {
   lines.push(`moves: ${state.moveCount}`);
 
   if (state.isStalemate) lines.push('Stalemate - no more moves possible');
-  if (state.hint) {
+  if (state.hint && isRequestedHint(state)) {
     lines.push(
       `HINT: ${state.hint.fromZone}${state.hint.fromCol >= 0 ? state.hint.fromCol : ''} \u2192 ${state.hint.toZone}${state.hint.toCol >= 0 ? state.hint.toCol : ''}`,
     );

--- a/frontend/src/utils/cli/formatters/klondikeFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/klondikeFormatter.test.ts
@@ -59,4 +59,12 @@ describe('formatKlondikeState', () => {
     const output = formatKlondikeState(makeState({ phase: 2 }));
     expect(output).toContain('Congratulations');
   });
+
+  // **HINT 行は hint を頼んだときだけ。**受動ヒントが Output に載るように
+  // なった (#4483) ので、messageCode で「頼んだ応答か」を見分ける。
+  it('shows the hint only when the hint was requested', () => {
+    const hint = { fromZone: 'tableau', fromCol: 1, cardIndex: 0, toZone: 'foundation', toCol: 2 };
+    expect(formatKlondikeState(makeState({ hint, messageCode: 'klondike.hintAvailable' }))).toContain('HINT:');
+    expect(formatKlondikeState(makeState({ hint, messageCode: 'klondike.playing' }))).not.toContain('HINT:');
+  });
 });

--- a/frontend/src/utils/cli/formatters/klondikeFormatter.ts
+++ b/frontend/src/utils/cli/formatters/klondikeFormatter.ts
@@ -1,5 +1,5 @@
 import type { KlondikeResponse } from '../../../types/card';
-import { formatCard, formatHeader, formatSeparator } from '../formatterBase';
+import { formatCard, formatHeader, formatSeparator, isRequestedHint } from '../formatterBase';
 
 /** Format a Klondike game state as terminal text. */
 export function formatKlondikeState(state: KlondikeResponse): string {
@@ -32,7 +32,7 @@ export function formatKlondikeState(state: KlondikeResponse): string {
   lines.push(`moves: ${state.moveCount} | score: ${state.score}`);
 
   if (state.isStalemate) lines.push('Stalemate - no more moves possible');
-  if (state.hint) {
+  if (state.hint && isRequestedHint(state)) {
     lines.push(
       `HINT: ${state.hint.fromZone}${state.hint.fromCol >= 0 ? state.hint.fromCol : ''} \u2192 ${state.hint.toZone}${state.hint.toCol >= 0 ? state.hint.toCol : ''}`,
     );

--- a/frontend/src/utils/cli/formatters/spiderFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/spiderFormatter.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import type { SpiderResponse } from '../../../types/card';
+import { formatSpiderState } from './spiderFormatter';
+
+function makeState(overrides?: Partial<SpiderResponse>): SpiderResponse {
+  return {
+    tableau: [[{ card: { design: 'SPADE', value: 13 }, faceUp: true }], []],
+    stockCount: 50,
+    completedSuits: 1,
+    phase: 0,
+    moveCount: 7,
+    canUndo: true,
+    isStalemate: false,
+    score: 480,
+    difficulty: 1,
+    message: '',
+    ...overrides,
+  };
+}
+
+describe('formatSpiderState', () => {
+  it('formats the basic state', () => {
+    const output = formatSpiderState(makeState());
+    expect(output).toContain('Spider Solitaire');
+    expect(output).toContain('stock: 50');
+    expect(output).toContain('completed: 1/8');
+    expect(output).toContain('moves: 7');
+  });
+
+  it('names the difficulty', () => {
+    expect(formatSpiderState(makeState())).toContain('1 suit');
+    expect(formatSpiderState(makeState({ difficulty: 4 }))).toContain('4 suits');
+  });
+
+  it('marks empty columns and face-down cards', () => {
+    const output = formatSpiderState(
+      makeState({
+        tableau: [[{ card: { design: 'HEART', value: 2 }, faceUp: false }], []],
+      }),
+    );
+    expect(output).toContain('[?]');
+    expect(output).toContain('col1: [empty]');
+  });
+
+  // **HINT 行は hint を頼んだときだけ。**受動ヒントが Output に載るように
+  // なった (#4483) ので、messageCode で「頼んだ応答か」を見分ける。
+  it('shows the hint only when the hint was requested', () => {
+    const hint = { fromCol: 0, cardIndex: 0, toCol: 1 };
+    expect(formatSpiderState(makeState({ hint, messageCode: 'spider.hintAvailable' }))).toContain('HINT:');
+    expect(formatSpiderState(makeState({ hint, messageCode: 'spider.playing' }))).not.toContain('HINT:');
+  });
+});

--- a/frontend/src/utils/cli/formatters/spiderFormatter.ts
+++ b/frontend/src/utils/cli/formatters/spiderFormatter.ts
@@ -1,5 +1,5 @@
 import type { SpiderResponse } from '../../../types/card';
-import { formatCard, formatHeader, formatSeparator } from '../formatterBase';
+import { formatCard, formatHeader, formatSeparator, isRequestedHint } from '../formatterBase';
 
 const DIFF_NAMES: Record<number, string> = { 1: '1 suit', 2: '2 suits', 4: '4 suits' };
 
@@ -27,7 +27,7 @@ export function formatSpiderState(state: SpiderResponse): string {
   lines.push(`moves: ${state.moveCount} | score: ${state.score}`);
 
   if (state.isStalemate) lines.push('Stalemate - no more moves possible');
-  if (state.hint) {
+  if (state.hint && isRequestedHint(state)) {
     lines.push(`HINT: col${state.hint.fromCol}[${state.hint.cardIndex}] \u2192 col${state.hint.toCol}`);
   }
   if (state.message) lines.push(state.message);

--- a/internal/adapter/presenter/FreeCellWebPresenter.go
+++ b/internal/adapter/presenter/FreeCellWebPresenter.go
@@ -47,6 +47,21 @@ func (p *FreeCellWebPresenter) Output(f interfaces.FreeCellGame, lastErr error) 
 		}
 	}
 
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	if f.GetPhase() == domain.FreeCellPhasePlaying && !f.IsStalemate() {
+		if hint := f.GetHint(); hint != nil {
+			resObj.Hint = &controller.FreeCellWebOutputHint{
+				FromZone:  hint.FromZone,
+				FromCol:   hint.FromCol,
+				CardIndex: hint.CardIndex,
+				ToZone:    hint.ToZone,
+				ToCol:     hint.ToCol,
+			}
+		}
+	}
+
 	// メッセージ
 	if lastErr != nil {
 		resObj.Message = lastErr.Error()

--- a/internal/adapter/presenter/FreeCellWebPresenter_test.go
+++ b/internal/adapter/presenter/FreeCellWebPresenter_test.go
@@ -119,6 +119,36 @@ func TestFreeCellWebPresenterOutputError(t *testing.T) {
 	assert.Contains(t, out.Message, "test error")
 }
 
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+func TestFreeCellWebPresenterOutputCarriesTheHint(t *testing.T) {
+	t.Run("playing", func(t *testing.T) {
+		f := domain.NewFreeCell(domain.NewTrumpCards(0))
+		f.Reset()
+		f.SetPhase(domain.FreeCellPhasePlaying)
+
+		// **配りに依存させない。**SetTableau で場を丸ごと置き換えるので、
+		// エースが 1 枚だけ = 台札へ動かせる = ヒントが必ず出る。
+		var tableau [domain.FreeCellTableauCnt][]*domain.Card
+		tableau[0] = []*domain.Card{domain.NewCard(domain.CardDesignSpade, 1, false)}
+		f.SetTableau(tableau)
+
+		var out controller.FreeCellWebOutput
+		assert.NoError(t, json.Unmarshal([]byte(new(FreeCellWebPresenter).Output(f, nil)), &out))
+		assert.NotNil(t, out.Hint, "Output must carry the hint -- the frontend reads state.hint")
+	})
+
+	t.Run("not while cleared", func(t *testing.T) {
+		f := domain.NewFreeCell(domain.NewTrumpCards(0))
+		f.Reset()
+		f.SetPhase(domain.FreeCellPhaseGameClear)
+
+		var out controller.FreeCellWebOutput
+		assert.NoError(t, json.Unmarshal([]byte(new(FreeCellWebPresenter).Output(f, nil)), &out))
+		assert.Nil(t, out.Hint)
+	})
+}
+
 func TestFreeCellWebPresenterHintOutputWithHint(t *testing.T) {
 	p := new(FreeCellWebPresenter)
 	f := domain.NewFreeCell(domain.NewTrumpCards(0))

--- a/internal/adapter/presenter/KlondikeWebPresenter.go
+++ b/internal/adapter/presenter/KlondikeWebPresenter.go
@@ -59,6 +59,21 @@ func (p *KlondikeWebPresenter) Output(k interfaces.KlondikeGame, lastErr error) 
 		}
 	}
 
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	if k.GetPhase() == domain.KlondikePhasePlaying && !k.IsStalemate() {
+		if hint := k.GetHint(); hint != nil {
+			resObj.Hint = &controller.KlondikeWebOutputHint{
+				FromZone:  hint.FromZone,
+				FromCol:   hint.FromCol,
+				CardIndex: hint.CardIndex,
+				ToZone:    hint.ToZone,
+				ToCol:     hint.ToCol,
+			}
+		}
+	}
+
 	// メッセージ
 	if lastErr != nil {
 		resObj.Message = lastErr.Error()

--- a/internal/adapter/presenter/KlondikeWebPresenter_test.go
+++ b/internal/adapter/presenter/KlondikeWebPresenter_test.go
@@ -49,10 +49,18 @@ func parseKlondikeOutput(t *testing.T, jsonStr string) *controller.KlondikeWebOu
 	return &out
 }
 
+// setupKlondikeOutputMock は Output 用の既定。**Output() も受動ヒントを埋める**ように
+// なった (#4483) ので GetHint を呼べるようにする。共有ヘルパーに置くと、先に
+// 登録されたこの期待が HintOutput テストの「ヒントあり」を食う。
+func setupKlondikeOutputMock(g *interfaces.MockKlondikeGame) {
+	setupKlondikeWebMockDefaults(g)
+	g.On("GetHint").Return(nil).Maybe()
+}
+
 func TestKlondikeWebPresenter_Output(t *testing.T) {
 	t.Run("initial state", func(t *testing.T) {
 		kg := new(interfaces.MockKlondikeGame)
-		setupKlondikeWebMockDefaults(kg)
+		setupKlondikeOutputMock(kg)
 		p := new(KlondikeWebPresenter)
 
 		result := parseKlondikeOutput(t, p.Output(kg, nil))
@@ -67,7 +75,7 @@ func TestKlondikeWebPresenter_Output(t *testing.T) {
 
 	t.Run("waste with cards", func(t *testing.T) {
 		kg := new(interfaces.MockKlondikeGame)
-		setupKlondikeWebMockDefaults(kg)
+		setupKlondikeOutputMock(kg)
 		kg.ExpectedCalls = filterCalls(kg.ExpectedCalls, "GetWaste")
 		kg.On("GetWaste").Return([]*domain.Card{domain.NewCard(domain.CardDesignHeart, 5, false)})
 
@@ -80,7 +88,7 @@ func TestKlondikeWebPresenter_Output(t *testing.T) {
 
 	t.Run("face down card hides data", func(t *testing.T) {
 		kg := new(interfaces.MockKlondikeGame)
-		setupKlondikeWebMockDefaults(kg)
+		setupKlondikeOutputMock(kg)
 		p := new(KlondikeWebPresenter)
 
 		result := parseKlondikeOutput(t, p.Output(kg, nil))
@@ -94,7 +102,7 @@ func TestKlondikeWebPresenter_Output(t *testing.T) {
 
 	t.Run("foundation with cards", func(t *testing.T) {
 		kg := new(interfaces.MockKlondikeGame)
-		setupKlondikeWebMockDefaults(kg)
+		setupKlondikeOutputMock(kg)
 		kg.ExpectedCalls = filterCalls(kg.ExpectedCalls, "GetFoundation")
 		var f [domain.KlondikeFoundationCnt][]*domain.Card
 		f[0] = []*domain.Card{domain.NewCard(domain.CardDesignSpade, 1, false)}
@@ -108,7 +116,7 @@ func TestKlondikeWebPresenter_Output(t *testing.T) {
 
 	t.Run("with error", func(t *testing.T) {
 		kg := new(interfaces.MockKlondikeGame)
-		setupKlondikeWebMockDefaults(kg)
+		setupKlondikeOutputMock(kg)
 		p := new(KlondikeWebPresenter)
 
 		result := parseKlondikeOutput(t, p.Output(kg, assert.AnError))
@@ -117,7 +125,7 @@ func TestKlondikeWebPresenter_Output(t *testing.T) {
 
 	t.Run("game clear", func(t *testing.T) {
 		kg := new(interfaces.MockKlondikeGame)
-		setupKlondikeWebMockDefaults(kg)
+		setupKlondikeOutputMock(kg)
 		kg.ExpectedCalls = filterCalls(kg.ExpectedCalls, "GetPhase")
 		kg.On("GetPhase").Return(domain.KlondikePhaseGameClear)
 
@@ -130,7 +138,7 @@ func TestKlondikeWebPresenter_Output(t *testing.T) {
 
 	t.Run("game over", func(t *testing.T) {
 		kg := new(interfaces.MockKlondikeGame)
-		setupKlondikeWebMockDefaults(kg)
+		setupKlondikeOutputMock(kg)
 		kg.ExpectedCalls = filterCalls(kg.ExpectedCalls, "GetPhase")
 		kg.On("GetPhase").Return(domain.KlondikePhaseGameOver)
 
@@ -144,7 +152,7 @@ func TestKlondikeWebPresenter_Output(t *testing.T) {
 func TestKlondikeWebPresenter_Output_Stalemate(t *testing.T) {
 	t.Run("no escape available", func(t *testing.T) {
 		kg := new(interfaces.MockKlondikeGame)
-		setupKlondikeWebMockDefaults(kg)
+		setupKlondikeOutputMock(kg)
 		kg.ExpectedCalls = filterCalls(kg.ExpectedCalls, "IsStalemate")
 		kg.ExpectedCalls = filterCalls(kg.ExpectedCalls, "UndoToEscape")
 		kg.On("IsStalemate").Return(true)
@@ -159,7 +167,7 @@ func TestKlondikeWebPresenter_Output_Stalemate(t *testing.T) {
 
 	t.Run("escape available with positive count", func(t *testing.T) {
 		kg := new(interfaces.MockKlondikeGame)
-		setupKlondikeWebMockDefaults(kg)
+		setupKlondikeOutputMock(kg)
 		kg.ExpectedCalls = filterCalls(kg.ExpectedCalls, "IsStalemate")
 		kg.ExpectedCalls = filterCalls(kg.ExpectedCalls, "UndoToEscape")
 		kg.On("IsStalemate").Return(true)
@@ -170,6 +178,31 @@ func TestKlondikeWebPresenter_Output_Stalemate(t *testing.T) {
 		assert.True(t, result.IsStalemate)
 		assert.Equal(t, "klondike.stalemateWithEscape", result.MessageCode)
 		assert.Equal(t, "3", result.MessageParams["count"])
+	})
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+func TestKlondikeWebPresenter_OutputCarriesTheHint(t *testing.T) {
+	t.Run("playing", func(t *testing.T) {
+		kg := new(interfaces.MockKlondikeGame)
+		setupKlondikeWebMockDefaults(kg)
+		kg.On("GetHint").Return(&domain.KlondikeHint{FromZone: "tableau", FromCol: 2, CardIndex: 0, ToZone: "foundation", ToCol: 1}).Maybe()
+
+		result := new(KlondikeWebPresenter).Output(kg, nil)
+		assert.Contains(t, result, `"hint"`, "Output must carry the hint -- the frontend reads state.hint")
+	})
+
+	// 手詰まりのヒントは出さない。逃げ道の提示は stalemate 用のメッセージが持つ。
+	t.Run("not while stalemate", func(t *testing.T) {
+		kg := new(interfaces.MockKlondikeGame)
+		setupKlondikeWebMockDefaults(kg)
+		kg.ExpectedCalls = filterCalls(kg.ExpectedCalls, "IsStalemate")
+		kg.On("IsStalemate").Return(true)
+		kg.On("GetHint").Return(&domain.KlondikeHint{FromZone: "tableau", FromCol: 2, CardIndex: 0, ToZone: "foundation", ToCol: 1}).Maybe()
+
+		result := new(KlondikeWebPresenter).Output(kg, nil)
+		assert.NotContains(t, result, `"hint"`)
 	})
 }
 
@@ -225,7 +258,7 @@ func TestKlondikeWebPresenter_HintOutput(t *testing.T) {
 
 func TestKlondikeWebPresenter_Output_DrawCount(t *testing.T) {
 	kg := new(interfaces.MockKlondikeGame)
-	setupKlondikeWebMockDefaults(kg)
+	setupKlondikeOutputMock(kg)
 	kg.ExpectedCalls = filterCalls(kg.ExpectedCalls, "GetDrawCount")
 	kg.On("GetDrawCount").Return(3)
 
@@ -236,7 +269,7 @@ func TestKlondikeWebPresenter_Output_DrawCount(t *testing.T) {
 
 func TestKlondikeWebPresenter_Output_CanUndo(t *testing.T) {
 	kg := new(interfaces.MockKlondikeGame)
-	setupKlondikeWebMockDefaults(kg)
+	setupKlondikeOutputMock(kg)
 	kg.ExpectedCalls = filterCalls(kg.ExpectedCalls, "CanUndo")
 	kg.On("CanUndo").Return(true)
 
@@ -247,7 +280,7 @@ func TestKlondikeWebPresenter_Output_CanUndo(t *testing.T) {
 
 func TestKlondikeWebPresenter_Output_Score(t *testing.T) {
 	kg := new(interfaces.MockKlondikeGame)
-	setupKlondikeWebMockDefaults(kg)
+	setupKlondikeOutputMock(kg)
 	kg.ExpectedCalls = filterCalls(kg.ExpectedCalls, "GetScore")
 	kg.On("GetScore").Return(100)
 
@@ -258,7 +291,7 @@ func TestKlondikeWebPresenter_Output_Score(t *testing.T) {
 
 func TestKlondikeWebPresenter_Output_ScoringMode(t *testing.T) {
 	kg := new(interfaces.MockKlondikeGame)
-	setupKlondikeWebMockDefaults(kg)
+	setupKlondikeOutputMock(kg)
 	kg.ExpectedCalls = filterCalls(kg.ExpectedCalls, "GetScoringMode")
 	kg.On("GetScoringMode").Return(domain.KlondikeScoringVegas)
 

--- a/internal/adapter/presenter/SpiderWebPresenter.go
+++ b/internal/adapter/presenter/SpiderWebPresenter.go
@@ -37,6 +37,19 @@ func (p *SpiderWebPresenter) Output(s interfaces.SpiderGame, lastErr error) stri
 		}
 	}
 
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	if s.GetPhase() == domain.SpiderPhasePlaying && !s.IsStalemate() {
+		if hint := s.GetHint(); hint != nil {
+			resObj.Hint = &controller.SpiderWebOutputHint{
+				FromCol:   hint.FromCol,
+				CardIndex: hint.CardIndex,
+				ToCol:     hint.ToCol,
+			}
+		}
+	}
+
 	// メッセージ
 	if lastErr != nil {
 		resObj.Message = lastErr.Error()

--- a/internal/adapter/presenter/SpiderWebPresenter_test.go
+++ b/internal/adapter/presenter/SpiderWebPresenter_test.go
@@ -45,10 +45,18 @@ func parseSpiderOutput(t *testing.T, jsonStr string) *controller.SpiderWebOutput
 	return &out
 }
 
+// setupSpiderOutputMock は Output 用の既定。**Output() も受動ヒントを埋める**ように
+// なった (#4483) ので GetHint を呼べるようにする。共有ヘルパーに置くと、先に
+// 登録されたこの期待が HintOutput テストの「ヒントあり」を食う。
+func setupSpiderOutputMock(g *interfaces.MockSpiderGame) {
+	setupSpiderWebMockDefaults(g)
+	g.On("GetHint").Return(nil).Maybe()
+}
+
 func TestSpiderWebPresenter_Output(t *testing.T) {
 	t.Run("initial state", func(t *testing.T) {
 		sg := new(interfaces.MockSpiderGame)
-		setupSpiderWebMockDefaults(sg)
+		setupSpiderOutputMock(sg)
 		p := new(SpiderWebPresenter)
 
 		result := parseSpiderOutput(t, p.Output(sg, nil))
@@ -64,7 +72,7 @@ func TestSpiderWebPresenter_Output(t *testing.T) {
 
 	t.Run("face down card hides data", func(t *testing.T) {
 		sg := new(interfaces.MockSpiderGame)
-		setupSpiderWebMockDefaults(sg)
+		setupSpiderOutputMock(sg)
 		p := new(SpiderWebPresenter)
 
 		result := parseSpiderOutput(t, p.Output(sg, nil))
@@ -78,7 +86,7 @@ func TestSpiderWebPresenter_Output(t *testing.T) {
 
 	t.Run("with error", func(t *testing.T) {
 		sg := new(interfaces.MockSpiderGame)
-		setupSpiderWebMockDefaults(sg)
+		setupSpiderOutputMock(sg)
 		p := new(SpiderWebPresenter)
 
 		result := parseSpiderOutput(t, p.Output(sg, assert.AnError))
@@ -87,7 +95,7 @@ func TestSpiderWebPresenter_Output(t *testing.T) {
 
 	t.Run("game clear", func(t *testing.T) {
 		sg := new(interfaces.MockSpiderGame)
-		setupSpiderWebMockDefaults(sg)
+		setupSpiderOutputMock(sg)
 		sg.ExpectedCalls = filterCalls(sg.ExpectedCalls, "GetPhase")
 		sg.On("GetPhase").Return(domain.SpiderPhaseGameClear)
 
@@ -100,7 +108,7 @@ func TestSpiderWebPresenter_Output(t *testing.T) {
 
 	t.Run("game over", func(t *testing.T) {
 		sg := new(interfaces.MockSpiderGame)
-		setupSpiderWebMockDefaults(sg)
+		setupSpiderOutputMock(sg)
 		sg.ExpectedCalls = filterCalls(sg.ExpectedCalls, "GetPhase")
 		sg.On("GetPhase").Return(domain.SpiderPhaseGameOver)
 
@@ -114,7 +122,7 @@ func TestSpiderWebPresenter_Output(t *testing.T) {
 func TestSpiderWebPresenter_Output_Stalemate(t *testing.T) {
 	t.Run("no escape available", func(t *testing.T) {
 		sg := new(interfaces.MockSpiderGame)
-		setupSpiderWebMockDefaults(sg)
+		setupSpiderOutputMock(sg)
 		sg.ExpectedCalls = filterCalls(sg.ExpectedCalls, "IsStalemate")
 		sg.ExpectedCalls = filterCalls(sg.ExpectedCalls, "UndoToEscape")
 		sg.On("IsStalemate").Return(true)
@@ -129,7 +137,7 @@ func TestSpiderWebPresenter_Output_Stalemate(t *testing.T) {
 
 	t.Run("escape available with positive count", func(t *testing.T) {
 		sg := new(interfaces.MockSpiderGame)
-		setupSpiderWebMockDefaults(sg)
+		setupSpiderOutputMock(sg)
 		sg.ExpectedCalls = filterCalls(sg.ExpectedCalls, "IsStalemate")
 		sg.ExpectedCalls = filterCalls(sg.ExpectedCalls, "UndoToEscape")
 		sg.On("IsStalemate").Return(true)
@@ -145,7 +153,7 @@ func TestSpiderWebPresenter_Output_Stalemate(t *testing.T) {
 
 func TestSpiderWebPresenter_Output_CanUndo(t *testing.T) {
 	sg := new(interfaces.MockSpiderGame)
-	setupSpiderWebMockDefaults(sg)
+	setupSpiderOutputMock(sg)
 	sg.ExpectedCalls = filterCalls(sg.ExpectedCalls, "CanUndo")
 	sg.On("CanUndo").Return(true)
 
@@ -156,13 +164,38 @@ func TestSpiderWebPresenter_Output_CanUndo(t *testing.T) {
 
 func TestSpiderWebPresenter_Output_Difficulty(t *testing.T) {
 	sg := new(interfaces.MockSpiderGame)
-	setupSpiderWebMockDefaults(sg)
+	setupSpiderOutputMock(sg)
 	sg.ExpectedCalls = filterCalls(sg.ExpectedCalls, "GetDifficulty")
 	sg.On("GetDifficulty").Return(domain.SpiderDifficulty4Suit)
 
 	p := new(SpiderWebPresenter)
 	result := parseSpiderOutput(t, p.Output(sg, nil))
 	assert.Equal(t, int(domain.SpiderDifficulty4Suit), result.Difficulty)
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+func TestSpiderWebPresenter_OutputCarriesTheHint(t *testing.T) {
+	t.Run("playing", func(t *testing.T) {
+		sg := new(interfaces.MockSpiderGame)
+		setupSpiderWebMockDefaults(sg)
+		sg.On("GetHint").Return(&domain.SpiderHint{FromCol: 3, CardIndex: 0, ToCol: 5}).Maybe()
+
+		result := new(SpiderWebPresenter).Output(sg, nil)
+		assert.Contains(t, result, `"hint"`, "Output must carry the hint -- the frontend reads state.hint")
+	})
+
+	// 手詰まりのヒントは出さない。逃げ道の提示は stalemate 用のメッセージが持つ。
+	t.Run("not while stalemate", func(t *testing.T) {
+		sg := new(interfaces.MockSpiderGame)
+		setupSpiderWebMockDefaults(sg)
+		sg.ExpectedCalls = filterCalls(sg.ExpectedCalls, "IsStalemate")
+		sg.On("IsStalemate").Return(true)
+		sg.On("GetHint").Return(&domain.SpiderHint{FromCol: 3, CardIndex: 0, ToCol: 5}).Maybe()
+
+		result := new(SpiderWebPresenter).Output(sg, nil)
+		assert.NotContains(t, result, `"hint"`)
+	})
 }
 
 func TestSpiderWebPresenter_HintOutput(t *testing.T) {


### PR DESCRIPTION
## 概要

9 本目。**Klondike / FreeCell / Spider** — この作業で一番遊ばれる 3 本です。

Refs #4483

## 進捗の数字を訂正しました

バッチ 8 に書いた **「21 / 91」「残り 70（あり 10 / 無し 60）」は誤り**でした。91 は以前**フロント側**（`state.hint` を読むページ数）を数えた値で、プレゼンタ側の母数ではありません。「10 / 60」は測っておらず、**足しても 70 になりません。**[#4536 に訂正を投稿済み](https://github.com/yuta-yoshinaga/go_trumpcards/pull/4536#issuecomment-5151640507)。

### 実測（develop = e5fa67b。`Output()` の関数本体を切り出して `resObj.Hint =` を探す）

| | |
|---|---|
| `HintOutput` を持つプレゼンタ | **167** |
| うち `Output()` にも載せた | **17** |
| 残り | **150**（ゲートあり **36** / なし **114**） |

以降、進捗は**測り方を併記**します。

## 今回の 3 本

| ゲーム | ヒントの形 | テストの形 |
|---|---|---|
| Klondike | `FromZone`/`FromCol`/`CardIndex`/`ToZone`/`ToCol` | mock |
| FreeCell | 同上 | **実ドメイン**（mock ではない） |
| Spider | **`FromCol`/`CardIndex`/`ToCol` のみ**（zone なし） | mock |

FreeCell のテストだけ共有ヘルパーがなく、`domain.NewFreeCell` を直に組み立てる形でした。既存のヒントテストが使っている **`SetTableau` で場を丸ごと差し替える**やり方に合わせ、エース 1 枚だけを置いて**配りに依存させていません。**

## フォーマッタのテストが無かった 2 本

`freecellFormatter` と `spiderFormatter` には**テストファイルが存在しませんでした。**ヒントのゲートだけでなく、これまで無かった基本描画（空列、伏せ札、難易度名）も含めて新規に作成しています。

## 負のコントロール

| 対象 | 壊しかた | 結果 |
|---|---|---|
| Go プレゼンタのゲート | 3 本とも `if false` | **6 件 FAIL** |
| CLI フォーマッタのゲート | 述語を外す | **3 ファイル FAIL** |

## 確認

- `go test -tags test ./internal/adapter/presenter/ -count=2` green
- `golangci-lint run ./internal/adapter/presenter/` 0 issues
- `bun run check`（11 ガード）/ `typecheck` green

## Test plan

- [ ] CI 全ジョブ green