### PR TITLE
fix(hints): carry the passive hint for Spiderette, Yukon and Scorpion (#4483)

### DIFF
--- a/frontend/src/utils/cli/formatters/spideretteFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/spideretteFormatter.test.ts
@@ -41,12 +41,24 @@ describe('formatSpideretteState', () => {
   });
 
   it('renders a hint line when present', () => {
-    const out = formatSpideretteState({ ...baseState, hint: { fromCol: 0, cardIndex: 0, toCol: 2 } });
+    const out = formatSpideretteState({
+      ...baseState,
+      hint: { fromCol: 0, cardIndex: 0, toCol: 2 },
+      messageCode: 'spiderette.hintAvailable',
+    });
     expect(out).toContain('HINT: col0[0] → col2');
   });
 
   it('renders a stalemate notice and a win banner', () => {
     expect(formatSpideretteState({ ...baseState, isStalemate: true })).toContain('Stalemate');
     expect(formatSpideretteState({ ...baseState, phase: 1 })).toContain('Congratulations');
+  });
+
+  // **HINT 行は hint を頼んだときだけ。**受動ヒントが Output に載るように
+  // なった (#4483) ので、messageCode で「頼んだ応答か」を見分ける。
+  it('shows the hint only when the hint was requested', () => {
+    const hint = { fromCol: 1, cardIndex: 0, toCol: 3 };
+    expect(formatSpideretteState({ ...baseState, hint, messageCode: 'spiderette.hintAvailable' })).toContain('HINT:');
+    expect(formatSpideretteState({ ...baseState, hint, messageCode: 'spiderette.playing' })).not.toContain('HINT:');
   });
 });

--- a/frontend/src/utils/cli/formatters/spideretteFormatter.ts
+++ b/frontend/src/utils/cli/formatters/spideretteFormatter.ts
@@ -1,5 +1,5 @@
 import type { SpideretteResponse } from '../../../types/card';
-import { formatCard, formatHeader, formatSeparator } from '../formatterBase';
+import { formatCard, formatHeader, formatSeparator, isRequestedHint } from '../formatterBase';
 
 /** Format a Spiderette game state as terminal text. */
 export function formatSpideretteState(state: SpideretteResponse): string {
@@ -23,7 +23,7 @@ export function formatSpideretteState(state: SpideretteResponse): string {
   lines.push(`moves: ${state.moveCount} | score: ${state.score}`);
 
   if (state.isStalemate) lines.push('Stalemate - no more moves possible');
-  if (state.hint) {
+  if (state.hint && isRequestedHint(state)) {
     lines.push(`HINT: col${state.hint.fromCol}[${state.hint.cardIndex}] → col${state.hint.toCol}`);
   }
   if (state.message) lines.push(state.message);

--- a/internal/adapter/presenter/ScorpionWebPresenter.go
+++ b/internal/adapter/presenter/ScorpionWebPresenter.go
@@ -17,6 +17,19 @@ type ScorpionWebPresenter struct{}
 func (p *ScorpionWebPresenter) Output(s interfaces.ScorpionGame, lastErr error) string {
 	resObj := p.buildBase(s)
 
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	if s.GetPhase() == domain.ScorpionPhasePlaying && !s.IsStalemate() {
+		if hint := s.GetHint(); hint != nil {
+			resObj.Hint = &controller.ScorpionWebOutputHint{
+				FromCol:   hint.FromCol,
+				CardIndex: hint.CardIndex,
+				ToCol:     hint.ToCol,
+			}
+		}
+	}
+
 	if lastErr != nil {
 		resObj.Message = lastErr.Error()
 	} else {

--- a/internal/adapter/presenter/ScorpionWebPresenter_test.go
+++ b/internal/adapter/presenter/ScorpionWebPresenter_test.go
@@ -38,10 +38,18 @@ func parseScorpionOutput(t *testing.T, jsonStr string) *controller.ScorpionWebOu
 	return &out
 }
 
+// setupScorpionOutputMock は Output 用の既定。**Output() も受動ヒントを埋める**ように
+// なった (#4483) ので GetHint を呼べるようにする。共有ヘルパーに置くと、先に
+// 登録されたこの期待が HintOutput テストの「ヒントあり」を食う。
+func setupScorpionOutputMock(g *interfaces.MockScorpionGame) {
+	setupScorpionWebMockDefaults(g)
+	g.On("GetHint").Return(nil).Maybe()
+}
+
 func TestScorpionWebPresenter_Output(t *testing.T) {
 	t.Run("initial state", func(t *testing.T) {
 		sg := new(interfaces.MockScorpionGame)
-		setupScorpionWebMockDefaults(sg)
+		setupScorpionOutputMock(sg)
 		p := new(ScorpionWebPresenter)
 
 		result := parseScorpionOutput(t, p.Output(sg, nil))
@@ -104,7 +112,7 @@ func TestScorpionWebPresenter_Output(t *testing.T) {
 
 	t.Run("with error", func(t *testing.T) {
 		sg := new(interfaces.MockScorpionGame)
-		setupScorpionWebMockDefaults(sg)
+		setupScorpionOutputMock(sg)
 		p := new(ScorpionWebPresenter)
 
 		result := parseScorpionOutput(t, p.Output(sg, errors.New("test error")))
@@ -114,13 +122,38 @@ func TestScorpionWebPresenter_Output(t *testing.T) {
 
 func TestScorpionWebPresenter_LegalMovesOutput(t *testing.T) {
 	sg := new(interfaces.MockScorpionGame)
-	setupScorpionWebMockDefaults(sg)
+	setupScorpionOutputMock(sg)
 	p := new(ScorpionWebPresenter)
 
 	// Web delegates legal-move previews to the normal state JSON (targets are
 	// computed client-side), so the output mirrors Output.
 	result := parseScorpionOutput(t, p.LegalMovesOutput(sg, 0))
 	assert.Equal(t, "scorpion.playing", result.MessageCode)
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+func TestScorpionWebPresenter_OutputCarriesTheHint(t *testing.T) {
+	t.Run("playing", func(t *testing.T) {
+		sg := new(interfaces.MockScorpionGame)
+		setupScorpionWebMockDefaults(sg)
+		sg.On("GetHint").Return(&domain.ScorpionHint{FromCol: 0, CardIndex: 1, ToCol: 5}).Maybe()
+
+		result := new(ScorpionWebPresenter).Output(sg, nil)
+		assert.Contains(t, result, `"hint"`, "Output must carry the hint -- the frontend reads state.hint")
+	})
+
+	// 手詰まりのヒントは出さない。逃げ道の提示は stalemate 用のメッセージが持つ。
+	t.Run("not while stalemate", func(t *testing.T) {
+		sg := new(interfaces.MockScorpionGame)
+		setupScorpionWebMockDefaults(sg)
+		sg.ExpectedCalls = filterCalls(sg.ExpectedCalls, "IsStalemate")
+		sg.On("IsStalemate").Return(true)
+		sg.On("GetHint").Return(&domain.ScorpionHint{FromCol: 0, CardIndex: 1, ToCol: 5}).Maybe()
+
+		result := new(ScorpionWebPresenter).Output(sg, nil)
+		assert.NotContains(t, result, `"hint"`)
+	})
 }
 
 func TestScorpionWebPresenter_HintOutput(t *testing.T) {

--- a/internal/adapter/presenter/SpideretteWebPresenter.go
+++ b/internal/adapter/presenter/SpideretteWebPresenter.go
@@ -35,6 +35,19 @@ func (p *SpideretteWebPresenter) Output(s interfaces.SpideretteGame, lastErr err
 		}
 	}
 
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	if s.GetPhase() == domain.SpiderettePhasePlaying && !s.IsStalemate() {
+		if hint := s.GetHint(); hint != nil {
+			resObj.Hint = &controller.SpideretteWebOutputHint{
+				FromCol:   hint.FromCol,
+				CardIndex: hint.CardIndex,
+				ToCol:     hint.ToCol,
+			}
+		}
+	}
+
 	if lastErr != nil {
 		resObj.Message = lastErr.Error()
 	} else {

--- a/internal/adapter/presenter/SpideretteWebPresenter_test.go
+++ b/internal/adapter/presenter/SpideretteWebPresenter_test.go
@@ -44,10 +44,18 @@ func parseSpideretteOutput(t *testing.T, jsonStr string) *controller.SpideretteW
 	return &out
 }
 
+// setupSpideretteOutputMock は Output 用の既定。**Output() も受動ヒントを埋める**ように
+// なった (#4483) ので GetHint を呼べるようにする。共有ヘルパーに置くと、先に
+// 登録されたこの期待が HintOutput テストの「ヒントあり」を食う。
+func setupSpideretteOutputMock(g *interfaces.MockSpideretteGame) {
+	setupSpideretteWebMockDefaults(g)
+	g.On("GetHint").Return(nil).Maybe()
+}
+
 func TestSpideretteWebPresenter_Output(t *testing.T) {
 	t.Run("initial state", func(t *testing.T) {
 		sg := new(interfaces.MockSpideretteGame)
-		setupSpideretteWebMockDefaults(sg)
+		setupSpideretteOutputMock(sg)
 		p := new(SpideretteWebPresenter)
 
 		result := parseSpideretteOutput(t, p.Output(sg, nil))
@@ -62,7 +70,7 @@ func TestSpideretteWebPresenter_Output(t *testing.T) {
 
 	t.Run("face down card hides data", func(t *testing.T) {
 		sg := new(interfaces.MockSpideretteGame)
-		setupSpideretteWebMockDefaults(sg)
+		setupSpideretteOutputMock(sg)
 		p := new(SpideretteWebPresenter)
 
 		result := parseSpideretteOutput(t, p.Output(sg, nil))
@@ -75,7 +83,7 @@ func TestSpideretteWebPresenter_Output(t *testing.T) {
 
 	t.Run("with error", func(t *testing.T) {
 		sg := new(interfaces.MockSpideretteGame)
-		setupSpideretteWebMockDefaults(sg)
+		setupSpideretteOutputMock(sg)
 		p := new(SpideretteWebPresenter)
 
 		result := parseSpideretteOutput(t, p.Output(sg, assert.AnError))
@@ -84,7 +92,7 @@ func TestSpideretteWebPresenter_Output(t *testing.T) {
 
 	t.Run("game clear", func(t *testing.T) {
 		sg := new(interfaces.MockSpideretteGame)
-		setupSpideretteWebMockDefaults(sg)
+		setupSpideretteOutputMock(sg)
 		sg.ExpectedCalls = filterCalls(sg.ExpectedCalls, "GetPhase")
 		sg.On("GetPhase").Return(domain.SpiderettePhaseGameClear)
 
@@ -97,7 +105,7 @@ func TestSpideretteWebPresenter_Output(t *testing.T) {
 
 	t.Run("game over", func(t *testing.T) {
 		sg := new(interfaces.MockSpideretteGame)
-		setupSpideretteWebMockDefaults(sg)
+		setupSpideretteOutputMock(sg)
 		sg.ExpectedCalls = filterCalls(sg.ExpectedCalls, "GetPhase")
 		sg.On("GetPhase").Return(domain.SpiderettePhaseGameOver)
 
@@ -111,7 +119,7 @@ func TestSpideretteWebPresenter_Output(t *testing.T) {
 func TestSpideretteWebPresenter_Output_Stalemate(t *testing.T) {
 	t.Run("no escape available", func(t *testing.T) {
 		sg := new(interfaces.MockSpideretteGame)
-		setupSpideretteWebMockDefaults(sg)
+		setupSpideretteOutputMock(sg)
 		sg.ExpectedCalls = filterCalls(sg.ExpectedCalls, "IsStalemate")
 		sg.ExpectedCalls = filterCalls(sg.ExpectedCalls, "UndoToEscape")
 		sg.On("IsStalemate").Return(true)
@@ -126,7 +134,7 @@ func TestSpideretteWebPresenter_Output_Stalemate(t *testing.T) {
 
 	t.Run("escape available with positive count", func(t *testing.T) {
 		sg := new(interfaces.MockSpideretteGame)
-		setupSpideretteWebMockDefaults(sg)
+		setupSpideretteOutputMock(sg)
 		sg.ExpectedCalls = filterCalls(sg.ExpectedCalls, "IsStalemate")
 		sg.ExpectedCalls = filterCalls(sg.ExpectedCalls, "UndoToEscape")
 		sg.On("IsStalemate").Return(true)
@@ -142,13 +150,38 @@ func TestSpideretteWebPresenter_Output_Stalemate(t *testing.T) {
 
 func TestSpideretteWebPresenter_Output_CanUndo(t *testing.T) {
 	sg := new(interfaces.MockSpideretteGame)
-	setupSpideretteWebMockDefaults(sg)
+	setupSpideretteOutputMock(sg)
 	sg.ExpectedCalls = filterCalls(sg.ExpectedCalls, "CanUndo")
 	sg.On("CanUndo").Return(true)
 
 	p := new(SpideretteWebPresenter)
 	result := parseSpideretteOutput(t, p.Output(sg, nil))
 	assert.True(t, result.CanUndo)
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+func TestSpideretteWebPresenter_OutputCarriesTheHint(t *testing.T) {
+	t.Run("playing", func(t *testing.T) {
+		sg := new(interfaces.MockSpideretteGame)
+		setupSpideretteWebMockDefaults(sg)
+		sg.On("GetHint").Return(&domain.SpideretteHint{FromCol: 2, CardIndex: 0, ToCol: 4}).Maybe()
+
+		result := new(SpideretteWebPresenter).Output(sg, nil)
+		assert.Contains(t, result, `"hint"`, "Output must carry the hint -- the frontend reads state.hint")
+	})
+
+	// 手詰まりのヒントは出さない。逃げ道の提示は stalemate 用のメッセージが持つ。
+	t.Run("not while stalemate", func(t *testing.T) {
+		sg := new(interfaces.MockSpideretteGame)
+		setupSpideretteWebMockDefaults(sg)
+		sg.ExpectedCalls = filterCalls(sg.ExpectedCalls, "IsStalemate")
+		sg.On("IsStalemate").Return(true)
+		sg.On("GetHint").Return(&domain.SpideretteHint{FromCol: 2, CardIndex: 0, ToCol: 4}).Maybe()
+
+		result := new(SpideretteWebPresenter).Output(sg, nil)
+		assert.NotContains(t, result, `"hint"`)
+	})
 }
 
 func TestSpideretteWebPresenter_HintOutput(t *testing.T) {

--- a/internal/adapter/presenter/YukonWebPresenter.go
+++ b/internal/adapter/presenter/YukonWebPresenter.go
@@ -45,6 +45,20 @@ func (p *YukonWebPresenter) Output(y interfaces.YukonGame, lastErr error) string
 	}
 
 	// メッセージ
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	if y.GetPhase() == domain.YukonPhasePlaying && !y.IsStalemate() {
+		if hint := y.GetHint(); hint != nil {
+			resObj.Hint = &controller.YukonWebOutputHint{
+				FromCol:   hint.FromCol,
+				CardIndex: hint.CardIndex,
+				ToZone:    hint.ToZone,
+				ToCol:     hint.ToCol,
+			}
+		}
+	}
+
 	if lastErr != nil {
 		resObj.Message = lastErr.Error()
 	} else {

--- a/internal/adapter/presenter/YukonWebPresenter_test.go
+++ b/internal/adapter/presenter/YukonWebPresenter_test.go
@@ -39,10 +39,18 @@ func parseYukonOutput(t *testing.T, jsonStr string) *controller.YukonWebOutput {
 	return &out
 }
 
+// setupYukonOutputMock は Output 用の既定。**Output() も受動ヒントを埋める**ように
+// なった (#4483) ので GetHint を呼べるようにする。共有ヘルパーに置くと、先に
+// 登録されたこの期待が HintOutput テストの「ヒントあり」を食う。
+func setupYukonOutputMock(g *interfaces.MockYukonGame) {
+	setupYukonWebMockDefaults(g)
+	g.On("GetHint").Return(nil).Maybe()
+}
+
 func TestYukonWebPresenter_Output(t *testing.T) {
 	t.Run("initial state", func(t *testing.T) {
 		yg := new(interfaces.MockYukonGame)
-		setupYukonWebMockDefaults(yg)
+		setupYukonOutputMock(yg)
 		p := new(YukonWebPresenter)
 
 		result := parseYukonOutput(t, p.Output(yg, nil))
@@ -53,7 +61,7 @@ func TestYukonWebPresenter_Output(t *testing.T) {
 
 	t.Run("stalemate with escape available", func(t *testing.T) {
 		yg := new(interfaces.MockYukonGame)
-		setupYukonWebMockDefaults(yg)
+		setupYukonOutputMock(yg)
 		yg.ExpectedCalls = nil
 		yg.On("GetPhase").Return(domain.YukonPhasePlaying).Maybe()
 		yg.On("GetMoveCount").Return(5).Maybe()
@@ -74,7 +82,7 @@ func TestYukonWebPresenter_Output(t *testing.T) {
 
 	t.Run("stalemate without escape available", func(t *testing.T) {
 		yg := new(interfaces.MockYukonGame)
-		setupYukonWebMockDefaults(yg)
+		setupYukonOutputMock(yg)
 		yg.ExpectedCalls = nil
 		yg.On("GetPhase").Return(domain.YukonPhasePlaying).Maybe()
 		yg.On("GetMoveCount").Return(5).Maybe()
@@ -95,7 +103,7 @@ func TestYukonWebPresenter_Output(t *testing.T) {
 
 	t.Run("game clear", func(t *testing.T) {
 		yg := new(interfaces.MockYukonGame)
-		setupYukonWebMockDefaults(yg)
+		setupYukonOutputMock(yg)
 		yg.ExpectedCalls = nil
 		yg.On("GetPhase").Return(domain.YukonPhaseGameClear).Maybe()
 		yg.On("GetMoveCount").Return(42).Maybe()
@@ -114,7 +122,7 @@ func TestYukonWebPresenter_Output(t *testing.T) {
 
 	t.Run("game over", func(t *testing.T) {
 		yg := new(interfaces.MockYukonGame)
-		setupYukonWebMockDefaults(yg)
+		setupYukonOutputMock(yg)
 		yg.ExpectedCalls = nil
 		yg.On("GetPhase").Return(domain.YukonPhaseGameOver).Maybe()
 		yg.On("GetMoveCount").Return(10).Maybe()
@@ -133,11 +141,36 @@ func TestYukonWebPresenter_Output(t *testing.T) {
 
 	t.Run("with error", func(t *testing.T) {
 		yg := new(interfaces.MockYukonGame)
-		setupYukonWebMockDefaults(yg)
+		setupYukonOutputMock(yg)
 		p := new(YukonWebPresenter)
 
 		result := parseYukonOutput(t, p.Output(yg, errors.New("test error")))
 		assert.Equal(t, "test error", result.Message)
+	})
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+func TestYukonWebPresenter_OutputCarriesTheHint(t *testing.T) {
+	t.Run("playing", func(t *testing.T) {
+		yg := new(interfaces.MockYukonGame)
+		setupYukonWebMockDefaults(yg)
+		yg.On("GetHint").Return(&domain.YukonHint{FromCol: 1, CardIndex: 0, ToZone: "foundation", ToCol: 3}).Maybe()
+
+		result := new(YukonWebPresenter).Output(yg, nil)
+		assert.Contains(t, result, `"hint"`, "Output must carry the hint -- the frontend reads state.hint")
+	})
+
+	// 手詰まりのヒントは出さない。逃げ道の提示は stalemate 用のメッセージが持つ。
+	t.Run("not while stalemate", func(t *testing.T) {
+		yg := new(interfaces.MockYukonGame)
+		setupYukonWebMockDefaults(yg)
+		yg.ExpectedCalls = filterCalls(yg.ExpectedCalls, "IsStalemate")
+		yg.On("IsStalemate").Return(true)
+		yg.On("GetHint").Return(&domain.YukonHint{FromCol: 1, CardIndex: 0, ToZone: "foundation", ToCol: 3}).Maybe()
+
+		result := new(YukonWebPresenter).Output(yg, nil)
+		assert.NotContains(t, result, `"hint"`)
 	})
 }
 


### PR DESCRIPTION
## 概要

10 本目。**Spiderette / Yukon / Scorpion**。

Refs #4483

## Output 側のリテラルを手で書くのをやめました

Duchess と American Toad で **`CardIndex` を落とした**（同じヒントなのに経路によって欠ける項目が出た）ので、生成スクリプトが**そのプレゼンタの `HintOutput` から複合リテラルを丸ごと持ち上げて**字下げし直す方式にしました。**手で並べ直さないので、項目が欠けようがありません。**

今回それが効きました:

| ゲーム | フィールド |
|---|---|
| Spiderette | `FromCol` / `CardIndex` / `ToCol` |
| **Yukon** | `FromCol` / `CardIndex` / **`ToZone`** / `ToCol` — **`FromZone` は無い** |
| Scorpion | `FromCol` / `CardIndex` / `ToCol` |

Yukon だけ `ToZone` を持ち、しかも `FromZone` は持ちません。**周りのコードのどこにもそう書いていません。**

## CLI フォーマッタは 1 本だけ

**Yukon と Scorpion には CLI フォーマッタが存在しません**（372 本を確認）。ゲートが要るのは Spiderette だけです。

その Spiderette の既存テスト `renders a hint line when present` が**旧挙動（無条件に HINT 行）を assert していて落ちました。**ゲートが効いている証拠なので、`messageCode` を「頼んだ応答」に直しています。

## 負のコントロール

| 対象 | 結果 |
|---|---|
| Go プレゼンタのゲート 3 本を `if false` | **6 件 FAIL** |
| Spiderette フォーマッタのゲートを外す | **1 件 FAIL** |

## 進捗（測り方: `Output()` 本体を切り出して `resObj.Hint =` を探す）

| | |
|---|---|
| `HintOutput` を持つプレゼンタ | 167 |
| `Output()` にも載せた | **23**（#4536 / #4537 マージ後の見込み） |
| 残り | 144（ゲートあり 30 / なし 114） |

## 確認

- `go test -tags test ./internal/adapter/presenter/ -count=2` green
- `golangci-lint run ./internal/adapter/presenter/` 0 issues
- `bun run check`（11 ガード）/ `typecheck` green

## Test plan

- [ ] CI 全ジョブ green