### PR TITLE
fix(hints): carry the passive hint for Eight Off, Penguin and Seahaven Towers (#4483)

### DIFF
--- a/frontend/src/utils/cli/formatters/eightoffFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/eightoffFormatter.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import type { EightOffResponse } from '../../../types/card';
+import { formatEightoffState } from './eightoffFormatter';
+
+function makeState(overrides?: Partial<EightOffResponse>): EightOffResponse {
+  return {
+    tableau: [[{ design: 'SPADE', value: 13 }], [], [], [], [], [], [], []],
+    freeCells: [null, null, null, null, null, null, null, null],
+    foundation: [[], [], [], []],
+    phase: 0,
+    moveCount: 4,
+    canUndo: true,
+    isStalemate: false,
+    message: '',
+    ...overrides,
+  };
+}
+
+describe('formatEightoffState', () => {
+  it('formats the basic state', () => {
+    const output = formatEightoffState(makeState());
+    expect(output).toContain('Eight Off');
+    expect(output).toContain('cells:');
+    expect(output).toContain('moves: 4');
+    expect(output).toContain('col0:');
+  });
+
+  it('marks empty columns', () => {
+    expect(formatEightoffState(makeState())).toContain('col1: [empty]');
+  });
+
+  it('reports a stalemate', () => {
+    expect(formatEightoffState(makeState({ isStalemate: true }))).toContain('Stalemate');
+  });
+
+  // **HINT 行は hint を頼んだときだけ。**受動ヒントが Output に載るように
+  // なった (#4483) ので、messageCode で「頼んだ応答か」を見分ける。
+  it('shows the hint only when the hint was requested', () => {
+    const hint = { fromZone: 'tableau', fromCol: 0, cardIndex: 0, toZone: 'foundation', toCol: 1 };
+    expect(formatEightoffState(makeState({ hint, messageCode: 'eightoff.hintAvailable' }))).toContain('HINT:');
+    expect(formatEightoffState(makeState({ hint, messageCode: 'eightoff.playing' }))).not.toContain('HINT:');
+  });
+});

--- a/frontend/src/utils/cli/formatters/eightoffFormatter.ts
+++ b/frontend/src/utils/cli/formatters/eightoffFormatter.ts
@@ -1,5 +1,5 @@
 import type { EightOffResponse } from '../../../types/card';
-import { formatCard, formatHeader, formatSeparator } from '../formatterBase';
+import { formatCard, formatHeader, formatSeparator, isRequestedHint } from '../formatterBase';
 
 /** Format an Eight Off game state as terminal text. */
 export function formatEightoffState(state: EightOffResponse): string {
@@ -28,7 +28,7 @@ export function formatEightoffState(state: EightOffResponse): string {
   lines.push(`moves: ${state.moveCount}`);
 
   if (state.isStalemate) lines.push('Stalemate - no more moves possible');
-  if (state.hint) {
+  if (state.hint && isRequestedHint(state)) {
     lines.push(
       `HINT: ${state.hint.fromZone}${state.hint.fromCol >= 0 ? state.hint.fromCol : ''} → ${state.hint.toZone}${state.hint.toCol >= 0 ? state.hint.toCol : ''}`,
     );

--- a/frontend/src/utils/cli/formatters/penguinFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/penguinFormatter.test.ts
@@ -78,6 +78,7 @@ describe('formatPenguinState', () => {
     const result = formatPenguinState(
       makeState({
         hint: { fromZone: 'tableau', fromCol: 0, cardIndex: 0, toZone: 'foundation', toCol: -1 },
+        messageCode: 'penguin.hintAvailable',
       }),
     );
     expect(result).toContain('HINT');
@@ -101,5 +102,13 @@ describe('formatPenguinState', () => {
   it('shows message when present', () => {
     const result = formatPenguinState(makeState({ message: 'test message' }));
     expect(result).toContain('test message');
+  });
+
+  // **HINT 行は hint を頼んだときだけ。**受動ヒントが Output に載るように
+  // なった (#4483) ので、messageCode で「頼んだ応答か」を見分ける。
+  it('shows the hint only when the hint was requested', () => {
+    const hint = { fromZone: 'tableau', fromCol: 0, cardIndex: 0, toZone: 'foundation', toCol: 1 };
+    expect(formatPenguinState(makeState({ hint, messageCode: 'penguin.hintAvailable' }))).toContain('HINT:');
+    expect(formatPenguinState(makeState({ hint, messageCode: 'penguin.playing' }))).not.toContain('HINT:');
   });
 });

--- a/frontend/src/utils/cli/formatters/penguinFormatter.ts
+++ b/frontend/src/utils/cli/formatters/penguinFormatter.ts
@@ -1,5 +1,5 @@
 import type { PenguinResponse } from '../../../types/card';
-import { formatCard, formatHeader, formatSeparator } from '../formatterBase';
+import { formatCard, formatHeader, formatSeparator, isRequestedHint } from '../formatterBase';
 
 /** Convert a card value (1-13) to display label. */
 function rankLabel(rank: number): string {
@@ -46,7 +46,7 @@ export function formatPenguinState(state: PenguinResponse): string {
   lines.push(`moves: ${state.moveCount}`);
 
   if (state.isStalemate) lines.push('Stalemate - no more moves possible');
-  if (state.hint) {
+  if (state.hint && isRequestedHint(state)) {
     lines.push(
       `HINT: ${state.hint.fromZone}${state.hint.fromCol >= 0 ? state.hint.fromCol : ''} → ${state.hint.toZone}${state.hint.toCol >= 0 ? state.hint.toCol : ''}`,
     );

--- a/frontend/src/utils/cli/formatters/seahaventowersFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/seahaventowersFormatter.test.ts
@@ -73,6 +73,7 @@ describe('formatSeahavenTowersState', () => {
     const result = formatSeahavenTowersState(
       makeState({
         hint: { fromZone: 'tableau', fromCol: 0, cardIndex: 1, toZone: 'tableau', toCol: 2 },
+        messageCode: 'seahaventowers.hintAvailable',
       }),
     );
     expect(result).toContain('HINT');
@@ -83,6 +84,7 @@ describe('formatSeahavenTowersState', () => {
     const result = formatSeahavenTowersState(
       makeState({
         hint: { fromZone: 'reserved', fromCol: -1, cardIndex: -1, toZone: 'foundation', toCol: -1 },
+        messageCode: 'seahaventowers.hintAvailable',
       }),
     );
     expect(result).toContain('HINT');
@@ -108,5 +110,17 @@ describe('formatSeahavenTowersState', () => {
   it('omits congrats on playing phase', () => {
     const result = formatSeahavenTowersState(makeState({ phase: 0 }));
     expect(result).not.toContain('Congratulations');
+  });
+
+  // **HINT 行は hint を頼んだときだけ。**受動ヒントが Output に載るように
+  // なった (#4483) ので、messageCode で「頼んだ応答か」を見分ける。
+  it('shows the hint only when the hint was requested', () => {
+    const hint = { fromZone: 'tableau', fromCol: 0, cardIndex: 0, toZone: 'foundation', toCol: 1 };
+    expect(formatSeahavenTowersState(makeState({ hint, messageCode: 'seahaventowers.hintAvailable' }))).toContain(
+      'HINT:',
+    );
+    expect(formatSeahavenTowersState(makeState({ hint, messageCode: 'seahaventowers.playing' }))).not.toContain(
+      'HINT:',
+    );
   });
 });

--- a/frontend/src/utils/cli/formatters/seahaventowersFormatter.ts
+++ b/frontend/src/utils/cli/formatters/seahaventowersFormatter.ts
@@ -1,6 +1,6 @@
 import type { SeahavenTowersResponse } from '../../../types/card';
 import { SeahavenTowersPhase } from '../../../types/phases';
-import { formatCard, formatHeader, formatSeparator } from '../formatterBase';
+import { formatCard, formatHeader, formatSeparator, isRequestedHint } from '../formatterBase';
 
 /** Format a Seahaven Towers game state as terminal text. */
 export function formatSeahavenTowersState(state: SeahavenTowersResponse): string {
@@ -32,7 +32,7 @@ export function formatSeahavenTowersState(state: SeahavenTowersResponse): string
   lines.push(`moves: ${state.moveCount}`);
 
   if (state.isStalemate) lines.push('Stalemate - no more moves possible');
-  if (state.hint) {
+  if (state.hint && isRequestedHint(state)) {
     lines.push(
       `HINT: ${state.hint.fromZone}${state.hint.fromCol >= 0 ? state.hint.fromCol : ''} → ${state.hint.toZone}${state.hint.toCol >= 0 ? state.hint.toCol : ''}`,
     );

--- a/internal/adapter/presenter/EightOffWebPresenter.go
+++ b/internal/adapter/presenter/EightOffWebPresenter.go
@@ -48,6 +48,21 @@ func (p *EightOffWebPresenter) Output(e interfaces.EightOffGame, lastErr error) 
 	}
 
 	// メッセージ
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	if e.GetPhase() == domain.EightOffPhasePlaying && !e.IsStalemate() {
+		if hint := e.GetHint(); hint != nil {
+			resObj.Hint = &controller.EightOffWebOutputHint{
+				FromZone:  hint.FromZone,
+				FromCol:   hint.FromCol,
+				CardIndex: hint.CardIndex,
+				ToZone:    hint.ToZone,
+				ToCol:     hint.ToCol,
+			}
+		}
+	}
+
 	if lastErr != nil {
 		resObj.Message = lastErr.Error()
 	} else {

--- a/internal/adapter/presenter/EightOffWebPresenter_test.go
+++ b/internal/adapter/presenter/EightOffWebPresenter_test.go
@@ -119,6 +119,36 @@ func TestEightOffWebPresenterOutputError(t *testing.T) {
 	assert.Contains(t, out.Message, "test error")
 }
 
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+func TestEightOffWebPresenterOutputCarriesTheHint(t *testing.T) {
+	t.Run("playing", func(t *testing.T) {
+		e := domain.NewEightOff(domain.NewTrumpCards(0))
+		e.Reset()
+		e.SetPhase(domain.EightOffPhasePlaying)
+
+		// **配りに依存させない。**SetTableau で場を丸ごと置き換えるので、
+		// 動かせる札が 1 枚だけ残り、ヒントが必ず出る。
+		var tableau [domain.EightOffTableauCnt][]*domain.Card
+		tableau[0] = []*domain.Card{domain.NewCard(domain.CardDesignSpade, 1, false)}
+		e.SetTableau(tableau)
+
+		var out controller.EightOffWebOutput
+		assert.NoError(t, json.Unmarshal([]byte(new(EightOffWebPresenter).Output(e, nil)), &out))
+		assert.NotNil(t, out.Hint, "Output must carry the hint -- the frontend reads state.hint")
+	})
+
+	t.Run("not while cleared", func(t *testing.T) {
+		e := domain.NewEightOff(domain.NewTrumpCards(0))
+		e.Reset()
+		e.SetPhase(domain.EightOffPhaseGameClear)
+
+		var out controller.EightOffWebOutput
+		assert.NoError(t, json.Unmarshal([]byte(new(EightOffWebPresenter).Output(e, nil)), &out))
+		assert.Nil(t, out.Hint)
+	})
+}
+
 func TestEightOffWebPresenterHintOutputWithHint(t *testing.T) {
 	p := new(EightOffWebPresenter)
 	e := domain.NewEightOff(domain.NewTrumpCards(0))

--- a/internal/adapter/presenter/PenguinWebPresenter.go
+++ b/internal/adapter/presenter/PenguinWebPresenter.go
@@ -51,6 +51,21 @@ func (p *PenguinWebPresenter) Output(pg interfaces.PenguinGame, lastErr error) s
 	resObj.BaseRank = pg.GetBaseRank()
 
 	// メッセージ
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	if pg.GetPhase() == domain.PenguinPhasePlaying && !pg.IsStalemate() {
+		if hint := pg.GetHint(); hint != nil {
+			resObj.Hint = &controller.PenguinWebOutputHint{
+				FromZone:  hint.FromZone,
+				FromCol:   hint.FromCol,
+				CardIndex: hint.CardIndex,
+				ToZone:    hint.ToZone,
+				ToCol:     hint.ToCol,
+			}
+		}
+	}
+
 	if lastErr != nil {
 		resObj.Message = lastErr.Error()
 	} else {

--- a/internal/adapter/presenter/PenguinWebPresenter_test.go
+++ b/internal/adapter/presenter/PenguinWebPresenter_test.go
@@ -122,6 +122,37 @@ func TestPenguinWebPresenterOutputError(t *testing.T) {
 	assert.Contains(t, out.Message, "test error")
 }
 
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+func TestPenguinWebPresenterOutputCarriesTheHint(t *testing.T) {
+	t.Run("playing", func(t *testing.T) {
+		g := domain.NewPenguin(domain.NewTrumpCards(0))
+		g.Reset()
+		g.SetPhase(domain.PenguinPhasePlaying)
+
+		// **配りに依存させない。**SetTableau で場を丸ごと置き換えるので、
+		// 動かせる札が 1 枚だけ残り、ヒントが必ず出る。
+		baseRank := g.GetBaseRank()
+		var tableau [domain.PenguinTableauCnt][]*domain.Card
+		tableau[0] = []*domain.Card{domain.NewCard(domain.CardDesignSpade, baseRank, false)}
+		g.SetTableau(tableau)
+
+		var out controller.PenguinWebOutput
+		assert.NoError(t, json.Unmarshal([]byte(new(PenguinWebPresenter).Output(g, nil)), &out))
+		assert.NotNil(t, out.Hint, "Output must carry the hint -- the frontend reads state.hint")
+	})
+
+	t.Run("not while cleared", func(t *testing.T) {
+		g := domain.NewPenguin(domain.NewTrumpCards(0))
+		g.Reset()
+		g.SetPhase(domain.PenguinPhaseGameClear)
+
+		var out controller.PenguinWebOutput
+		assert.NoError(t, json.Unmarshal([]byte(new(PenguinWebPresenter).Output(g, nil)), &out))
+		assert.Nil(t, out.Hint)
+	})
+}
+
 func TestPenguinWebPresenterHintOutputWithHint(t *testing.T) {
 	p := new(PenguinWebPresenter)
 	g := domain.NewPenguin(domain.NewTrumpCards(0))

--- a/internal/adapter/presenter/SeahavenTowersWebPresenter.go
+++ b/internal/adapter/presenter/SeahavenTowersWebPresenter.go
@@ -48,6 +48,21 @@ func (p *SeahavenTowersWebPresenter) Output(s interfaces.SeahavenTowersGame, las
 	}
 
 	// メッセージ
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	if s.GetPhase() == domain.SeahavenTowersPhasePlaying && !s.IsStalemate() {
+		if hint := s.GetHint(); hint != nil {
+			resObj.Hint = &controller.SeahavenTowersWebOutputHint{
+				FromZone:  hint.FromZone,
+				FromCol:   hint.FromCol,
+				CardIndex: hint.CardIndex,
+				ToZone:    hint.ToZone,
+				ToCol:     hint.ToCol,
+			}
+		}
+	}
+
 	if lastErr != nil {
 		resObj.Message = lastErr.Error()
 	} else {

--- a/internal/adapter/presenter/SeahavenTowersWebPresenter_test.go
+++ b/internal/adapter/presenter/SeahavenTowersWebPresenter_test.go
@@ -119,6 +119,36 @@ func TestSeahavenTowersWebPresenterOutputError(t *testing.T) {
 	assert.Contains(t, out.Message, "test error")
 }
 
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+func TestSeahavenTowersWebPresenterOutputCarriesTheHint(t *testing.T) {
+	t.Run("playing", func(t *testing.T) {
+		s := domain.NewSeahavenTowers(domain.NewTrumpCards(0))
+		s.Reset()
+		s.SetPhase(domain.SeahavenTowersPhasePlaying)
+
+		// **配りに依存させない。**SetTableau で場を丸ごと置き換えるので、
+		// 動かせる札が 1 枚だけ残り、ヒントが必ず出る。
+		var tableau [domain.SeahavenTowersTableauCnt][]*domain.Card
+		tableau[0] = []*domain.Card{domain.NewCard(domain.CardDesignSpade, 1, false)}
+		s.SetTableau(tableau)
+
+		var out controller.SeahavenTowersWebOutput
+		assert.NoError(t, json.Unmarshal([]byte(new(SeahavenTowersWebPresenter).Output(s, nil)), &out))
+		assert.NotNil(t, out.Hint, "Output must carry the hint -- the frontend reads state.hint")
+	})
+
+	t.Run("not while cleared", func(t *testing.T) {
+		s := domain.NewSeahavenTowers(domain.NewTrumpCards(0))
+		s.Reset()
+		s.SetPhase(domain.SeahavenTowersPhaseGameClear)
+
+		var out controller.SeahavenTowersWebOutput
+		assert.NoError(t, json.Unmarshal([]byte(new(SeahavenTowersWebPresenter).Output(s, nil)), &out))
+		assert.Nil(t, out.Hint)
+	})
+}
+
 func TestSeahavenTowersWebPresenterHintOutputWithHint(t *testing.T) {
 	p := new(SeahavenTowersWebPresenter)
 	s := domain.NewSeahavenTowers(domain.NewTrumpCards(0))


### PR DESCRIPTION
## 概要

11 本目。**Eight Off / Penguin / Seahaven Towers**。

Refs #4483

## 3 本とも mock ではなく実ドメインを使うテストでした

共有 mock ヘルパー（`setupXWebMockDefaults`）が存在せず、`domain.NewEightOff(...)` を直に組み立てる形です。**各ゲーム自身の `HintOutput` テストが使っている `SetTableau` のやり方**に合わせ、動かせる札を 1 枚だけ置いて**配りに依存させていません。**

Penguin だけ **`GetBaseRank()` を先に読む必要があります**。台札の開始ランクが可変なので、エース 1 枚では合法手になりません。

## 既存テスト 3 件が落ちました（ゲートが効いている証拠）

| ファイル | テスト |
|---|---|
| `penguinFormatter.test.ts` | `shows hint when present` |
| `seahaventowersFormatter.test.ts` | `shows hint when present` |
| `seahaventowersFormatter.test.ts` | `omits column number from hint when negative` |

いずれも **`messageCode` 無しで HINT 行が出ること**を assert していました。「頼んだ応答」の messageCode を足しています。`eightoffFormatter` には**テストファイルがありませんでした**ので新規作成しています。

## 負のコントロール

| 対象 | 結果 |
|---|---|
| Go プレゼンタのゲート 3 本を `if false` | **6 件 FAIL** |
| CLI フォーマッタのゲート 3 本を外す | **3 ファイル FAIL** |

## 進捗（測り方: `Output()` 本体を切り出して `resObj.Hint =` を探す）

| | |
|---|---|
| `HintOutput` を持つプレゼンタ | 167 |
| `Output()` にも載せた | **23**（#4536 / #4537 マージ済み） |
| この PR + #4538 で | **29** |

## 確認

- `go test -tags test ./internal/adapter/presenter/ -count=3` green
- `golangci-lint run ./internal/adapter/presenter/` 0 issues
- `bun run check`（11 ガード）/ `typecheck` green

## Test plan

- [ ] CI 全ジョブ green