### PR TITLE
fix(hints): carry the passive hint for Forty Thieves, Streets and Alleys and Wasp (#4483)

### DIFF
--- a/frontend/src/utils/cli/formatters/fortythievesFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/fortythievesFormatter.test.ts
@@ -39,14 +39,20 @@ describe('formatFortythievesState', () => {
 
   it('renders a tableau hint with source index and target', () => {
     const out = formatFortythievesState(
-      baseState({ hint: { fromZone: 'tableau', fromCol: 0, cardIndex: 1, toZone: 'foundation', toCol: 2 } }),
+      baseState({
+        hint: { fromZone: 'tableau', fromCol: 0, cardIndex: 1, toZone: 'foundation', toCol: 2 },
+        messageCode: 'fortythieves.hintAvailable',
+      }),
     );
     expect(out).toContain('HINT: t0[1] → foundation2');
   });
 
   it('renders a waste hint source', () => {
     const out = formatFortythievesState(
-      baseState({ hint: { fromZone: 'waste', fromCol: -1, cardIndex: -1, toZone: 'tableau', toCol: 4 } }),
+      baseState({
+        hint: { fromZone: 'waste', fromCol: -1, cardIndex: -1, toZone: 'tableau', toCol: 4 },
+        messageCode: 'fortythieves.hintAvailable',
+      }),
     );
     expect(out).toContain('HINT: waste → tableau4');
   });
@@ -58,5 +64,13 @@ describe('formatFortythievesState', () => {
     expect(out).toContain('Stalemate - no more moves possible');
     expect(out).toContain('stuck');
     expect(out).toContain('Congratulations! You win!');
+  });
+
+  // **HINT 行は hint を頼んだときだけ。**受動ヒントが Output に載るように
+  // なった (#4483) ので、messageCode で「頼んだ応答か」を見分ける。
+  it('shows the hint only when the hint was requested', () => {
+    const hint = { fromZone: 'tableau', fromCol: 0, cardIndex: 1, toZone: 'foundation', toCol: 2 };
+    expect(formatFortythievesState(baseState({ hint, messageCode: 'fortythieves.hintAvailable' }))).toContain('HINT:');
+    expect(formatFortythievesState(baseState({ hint, messageCode: 'fortythieves.playing' }))).not.toContain('HINT:');
   });
 });

--- a/frontend/src/utils/cli/formatters/fortythievesFormatter.ts
+++ b/frontend/src/utils/cli/formatters/fortythievesFormatter.ts
@@ -1,6 +1,6 @@
 import type { FortyThievesResponse } from '../../../types/card';
 import { FortyThievesPhase } from '../../../types/phases';
-import { formatCard, formatHeader, formatSeparator } from '../formatterBase';
+import { formatCard, formatHeader, formatSeparator, isRequestedHint } from '../formatterBase';
 
 /** Format a Forty Thieves game state as terminal text. */
 export function formatFortythievesState(state: FortyThievesResponse): string {
@@ -31,7 +31,7 @@ export function formatFortythievesState(state: FortyThievesResponse): string {
 
   lines.push(`moves: ${state.moveCount}  undo:${state.canUndo ? 'yes' : 'no'}`);
 
-  if (state.hint) {
+  if (state.hint && isRequestedHint(state)) {
     const from = state.hint.fromZone === 'waste' ? 'waste' : `t${state.hint.fromCol}[${state.hint.cardIndex}]`;
     const target = state.hint.toCol >= 0 ? `${state.hint.toZone}${state.hint.toCol}` : state.hint.toZone;
     lines.push(`HINT: ${from} → ${target}`);

--- a/frontend/src/utils/cli/formatters/streetsandalleysFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/streetsandalleysFormatter.test.ts
@@ -45,6 +45,7 @@ describe('formatStreetsAndAlleysState', () => {
     const result = formatStreetsAndAlleysState(
       makeState({
         hint: { fromCol: 0, cardIndex: 1, toZone: 'tableau', toCol: 2 },
+        messageCode: 'streetsandalleys.hintAvailable',
       }),
     );
     expect(result).toContain('HINT');
@@ -59,5 +60,17 @@ describe('formatStreetsAndAlleysState', () => {
   it('shows congrats on win phase', () => {
     const result = formatStreetsAndAlleysState(makeState({ phase: 1 }));
     expect(result).toContain('Congratulations');
+  });
+
+  // **HINT 行は hint を頼んだときだけ。**受動ヒントが Output に載るように
+  // なった (#4483) ので、messageCode で「頼んだ応答か」を見分ける。
+  it('shows the hint only when the hint was requested', () => {
+    const hint = { fromCol: 0, cardIndex: 1, toZone: 'tableau', toCol: 2 };
+    expect(formatStreetsAndAlleysState(makeState({ hint, messageCode: 'streetsandalleys.hintAvailable' }))).toContain(
+      'HINT:',
+    );
+    expect(formatStreetsAndAlleysState(makeState({ hint, messageCode: 'streetsandalleys.playing' }))).not.toContain(
+      'HINT:',
+    );
   });
 });

--- a/frontend/src/utils/cli/formatters/streetsandalleysFormatter.ts
+++ b/frontend/src/utils/cli/formatters/streetsandalleysFormatter.ts
@@ -1,5 +1,5 @@
 import type { StreetsAndAlleysResponse } from '../../../types/card';
-import { formatCard, formatHeader, formatSeparator } from '../formatterBase';
+import { formatCard, formatHeader, formatSeparator, isRequestedHint } from '../formatterBase';
 
 /** Format a Streets and Alleys game state as terminal text. */
 export function formatStreetsAndAlleysState(state: StreetsAndAlleysResponse): string {
@@ -26,7 +26,7 @@ export function formatStreetsAndAlleysState(state: StreetsAndAlleysResponse): st
 
   lines.push(`moves: ${state.moveCount}  undo:${state.canUndo ? 'yes' : 'no'}`);
 
-  if (state.hint) {
+  if (state.hint && isRequestedHint(state)) {
     const target = state.hint.toCol >= 0 ? `${state.hint.toZone}${state.hint.toCol}` : state.hint.toZone;
     lines.push(`HINT: t${state.hint.fromCol}[${state.hint.cardIndex}] → ${target}`);
   }

--- a/internal/adapter/presenter/FortyThievesWebPresenter.go
+++ b/internal/adapter/presenter/FortyThievesWebPresenter.go
@@ -57,6 +57,21 @@ func (p *FortyThievesWebPresenter) Output(ft interfaces.FortyThievesGame, lastEr
 	}
 
 	// メッセージ
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	if ft.GetPhase() == domain.FortyThievesPhasePlaying && !ft.IsStalemate() {
+		if hint := ft.GetHint(); hint != nil {
+			resObj.Hint = &controller.FortyThievesWebOutputHint{
+				FromZone:  hint.FromZone,
+				FromCol:   hint.FromCol,
+				CardIndex: hint.CardIndex,
+				ToZone:    hint.ToZone,
+				ToCol:     hint.ToCol,
+			}
+		}
+	}
+
 	if lastErr != nil {
 		resObj.Message = lastErr.Error()
 	} else {

--- a/internal/adapter/presenter/FortyThievesWebPresenter_test.go
+++ b/internal/adapter/presenter/FortyThievesWebPresenter_test.go
@@ -47,10 +47,18 @@ func parseFortyThievesOutput(t *testing.T, jsonStr string) *controller.FortyThie
 	return &out
 }
 
+// setupFortyThievesOutputMock は Output 用の既定。**Output() も受動ヒントを埋める**ように
+// なった (#4483) ので GetHint を呼べるようにする。共有ヘルパーに置くと、先に
+// 登録されたこの期待が HintOutput テストの「ヒントあり」を食う。
+func setupFortyThievesOutputMock(g *interfaces.MockFortyThievesGame) {
+	setupFortyThievesWebMockDefaults(g)
+	g.On("GetHint").Return(nil).Maybe()
+}
+
 func TestFortyThievesWebPresenter_Output(t *testing.T) {
 	t.Run("initial state", func(t *testing.T) {
 		fg := new(interfaces.MockFortyThievesGame)
-		setupFortyThievesWebMockDefaults(fg)
+		setupFortyThievesOutputMock(fg)
 		p := new(FortyThievesWebPresenter)
 
 		result := parseFortyThievesOutput(t, p.Output(fg, nil))
@@ -65,7 +73,7 @@ func TestFortyThievesWebPresenter_Output(t *testing.T) {
 
 	t.Run("waste with cards", func(t *testing.T) {
 		fg := new(interfaces.MockFortyThievesGame)
-		setupFortyThievesWebMockDefaults(fg)
+		setupFortyThievesOutputMock(fg)
 		fg.ExpectedCalls = filterCalls(fg.ExpectedCalls, "GetWaste")
 		fg.On("GetWaste").Return([]*domain.Card{domain.NewCard(domain.CardDesignHeart, 5, false)})
 
@@ -78,7 +86,7 @@ func TestFortyThievesWebPresenter_Output(t *testing.T) {
 
 	t.Run("all face up", func(t *testing.T) {
 		fg := new(interfaces.MockFortyThievesGame)
-		setupFortyThievesWebMockDefaults(fg)
+		setupFortyThievesOutputMock(fg)
 		p := new(FortyThievesWebPresenter)
 
 		result := parseFortyThievesOutput(t, p.Output(fg, nil))
@@ -93,7 +101,7 @@ func TestFortyThievesWebPresenter_Output(t *testing.T) {
 
 	t.Run("error message", func(t *testing.T) {
 		fg := new(interfaces.MockFortyThievesGame)
-		setupFortyThievesWebMockDefaults(fg)
+		setupFortyThievesOutputMock(fg)
 		p := new(FortyThievesWebPresenter)
 
 		result := parseFortyThievesOutput(t, p.Output(fg, errors.New("test error")))
@@ -102,7 +110,7 @@ func TestFortyThievesWebPresenter_Output(t *testing.T) {
 
 	t.Run("game clear", func(t *testing.T) {
 		fg := new(interfaces.MockFortyThievesGame)
-		setupFortyThievesWebMockDefaults(fg)
+		setupFortyThievesOutputMock(fg)
 		fg.ExpectedCalls = filterCalls(fg.ExpectedCalls, "GetPhase")
 		fg.On("GetPhase").Return(domain.FortyThievesPhaseGameClear)
 
@@ -113,7 +121,7 @@ func TestFortyThievesWebPresenter_Output(t *testing.T) {
 
 	t.Run("game over", func(t *testing.T) {
 		fg := new(interfaces.MockFortyThievesGame)
-		setupFortyThievesWebMockDefaults(fg)
+		setupFortyThievesOutputMock(fg)
 		fg.ExpectedCalls = filterCalls(fg.ExpectedCalls, "GetPhase")
 		fg.On("GetPhase").Return(domain.FortyThievesPhaseGameOver)
 
@@ -124,13 +132,38 @@ func TestFortyThievesWebPresenter_Output(t *testing.T) {
 
 	t.Run("stalemate", func(t *testing.T) {
 		fg := new(interfaces.MockFortyThievesGame)
-		setupFortyThievesWebMockDefaults(fg)
+		setupFortyThievesOutputMock(fg)
 		fg.ExpectedCalls = filterCalls(fg.ExpectedCalls, "IsStalemate")
 		fg.On("IsStalemate").Return(true)
 
 		p := new(FortyThievesWebPresenter)
 		result := parseFortyThievesOutput(t, p.Output(fg, nil))
 		assert.Equal(t, "fortythieves.stalemate", result.MessageCode)
+	})
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+func TestFortyThievesWebPresenter_OutputCarriesTheHint(t *testing.T) {
+	t.Run("playing", func(t *testing.T) {
+		ftg := new(interfaces.MockFortyThievesGame)
+		setupFortyThievesWebMockDefaults(ftg)
+		ftg.On("GetHint").Return(&domain.FortyThievesHint{FromZone: "tableau", FromCol: 2, CardIndex: 0, ToZone: "foundation", ToCol: 1}).Maybe()
+
+		result := new(FortyThievesWebPresenter).Output(ftg, nil)
+		assert.Contains(t, result, `"hint"`, "Output must carry the hint -- the frontend reads state.hint")
+	})
+
+	// 手詰まりのヒントは出さない。逃げ道の提示は stalemate 用のメッセージが持つ。
+	t.Run("not while stalemate", func(t *testing.T) {
+		ftg := new(interfaces.MockFortyThievesGame)
+		setupFortyThievesWebMockDefaults(ftg)
+		ftg.ExpectedCalls = filterCalls(ftg.ExpectedCalls, "IsStalemate")
+		ftg.On("IsStalemate").Return(true)
+		ftg.On("GetHint").Return(&domain.FortyThievesHint{FromZone: "tableau", FromCol: 2, CardIndex: 0, ToZone: "foundation", ToCol: 1}).Maybe()
+
+		result := new(FortyThievesWebPresenter).Output(ftg, nil)
+		assert.NotContains(t, result, `"hint"`)
 	})
 }
 

--- a/internal/adapter/presenter/StreetsAndAlleysWebPresenter.go
+++ b/internal/adapter/presenter/StreetsAndAlleysWebPresenter.go
@@ -46,6 +46,20 @@ func (p *StreetsAndAlleysWebPresenter) Output(bc interfaces.StreetsAndAlleysGame
 	}
 
 	// メッセージ
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	if bc.GetPhase() == domain.StreetsAndAlleysPhasePlaying && !bc.IsStalemate() {
+		if hint := bc.GetHint(); hint != nil {
+			resObj.Hint = &controller.StreetsAndAlleysWebOutputHint{
+				FromCol:   hint.FromCol,
+				CardIndex: hint.CardIndex,
+				ToZone:    hint.ToZone,
+				ToCol:     hint.ToCol,
+			}
+		}
+	}
+
 	if lastErr != nil {
 		resObj.Message = lastErr.Error()
 	} else {

--- a/internal/adapter/presenter/StreetsAndAlleysWebPresenter_test.go
+++ b/internal/adapter/presenter/StreetsAndAlleysWebPresenter_test.go
@@ -48,10 +48,18 @@ func parseStreetsAndAlleysOutput(t *testing.T, jsonStr string) *controller.Stree
 	return &out
 }
 
+// setupStreetsAndAlleysOutputMock は Output 用の既定。**Output() も受動ヒントを埋める**ように
+// なった (#4483) ので GetHint を呼べるようにする。共有ヘルパーに置くと、先に
+// 登録されたこの期待が HintOutput テストの「ヒントあり」を食う。
+func setupStreetsAndAlleysOutputMock(g *interfaces.MockStreetsAndAlleysGame) {
+	setupStreetsAndAlleysWebMockDefaults(g)
+	g.On("GetHint").Return(nil).Maybe()
+}
+
 func TestStreetsAndAlleysWebPresenter_Output(t *testing.T) {
 	t.Run("initial state", func(t *testing.T) {
 		bg := new(interfaces.MockStreetsAndAlleysGame)
-		setupStreetsAndAlleysWebMockDefaults(bg)
+		setupStreetsAndAlleysOutputMock(bg)
 		p := new(StreetsAndAlleysWebPresenter)
 
 		result := parseStreetsAndAlleysOutput(t, p.Output(bg, nil))
@@ -64,7 +72,7 @@ func TestStreetsAndAlleysWebPresenter_Output(t *testing.T) {
 
 	t.Run("all face up", func(t *testing.T) {
 		bg := new(interfaces.MockStreetsAndAlleysGame)
-		setupStreetsAndAlleysWebMockDefaults(bg)
+		setupStreetsAndAlleysOutputMock(bg)
 		p := new(StreetsAndAlleysWebPresenter)
 
 		result := parseStreetsAndAlleysOutput(t, p.Output(bg, nil))
@@ -78,7 +86,7 @@ func TestStreetsAndAlleysWebPresenter_Output(t *testing.T) {
 
 	t.Run("error message", func(t *testing.T) {
 		bg := new(interfaces.MockStreetsAndAlleysGame)
-		setupStreetsAndAlleysWebMockDefaults(bg)
+		setupStreetsAndAlleysOutputMock(bg)
 		p := new(StreetsAndAlleysWebPresenter)
 
 		result := parseStreetsAndAlleysOutput(t, p.Output(bg, errors.New("test error")))
@@ -87,7 +95,7 @@ func TestStreetsAndAlleysWebPresenter_Output(t *testing.T) {
 
 	t.Run("game clear", func(t *testing.T) {
 		bg := new(interfaces.MockStreetsAndAlleysGame)
-		setupStreetsAndAlleysWebMockDefaults(bg)
+		setupStreetsAndAlleysOutputMock(bg)
 		bg.ExpectedCalls = filterCalls(bg.ExpectedCalls, "GetPhase")
 		bg.On("GetPhase").Return(domain.StreetsAndAlleysPhaseGameClear)
 
@@ -98,7 +106,7 @@ func TestStreetsAndAlleysWebPresenter_Output(t *testing.T) {
 
 	t.Run("game over", func(t *testing.T) {
 		bg := new(interfaces.MockStreetsAndAlleysGame)
-		setupStreetsAndAlleysWebMockDefaults(bg)
+		setupStreetsAndAlleysOutputMock(bg)
 		bg.ExpectedCalls = filterCalls(bg.ExpectedCalls, "GetPhase")
 		bg.On("GetPhase").Return(domain.StreetsAndAlleysPhaseGameOver)
 
@@ -109,13 +117,38 @@ func TestStreetsAndAlleysWebPresenter_Output(t *testing.T) {
 
 	t.Run("stalemate", func(t *testing.T) {
 		bg := new(interfaces.MockStreetsAndAlleysGame)
-		setupStreetsAndAlleysWebMockDefaults(bg)
+		setupStreetsAndAlleysOutputMock(bg)
 		bg.ExpectedCalls = filterCalls(bg.ExpectedCalls, "IsStalemate")
 		bg.On("IsStalemate").Return(true)
 
 		p := new(StreetsAndAlleysWebPresenter)
 		result := parseStreetsAndAlleysOutput(t, p.Output(bg, nil))
 		assert.Equal(t, "streetsandalleys.stalemate", result.MessageCode)
+	})
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+func TestStreetsAndAlleysWebPresenter_OutputCarriesTheHint(t *testing.T) {
+	t.Run("playing", func(t *testing.T) {
+		sg := new(interfaces.MockStreetsAndAlleysGame)
+		setupStreetsAndAlleysWebMockDefaults(sg)
+		sg.On("GetHint").Return(&domain.StreetsAndAlleysHint{FromCol: 3, CardIndex: 0, ToZone: "foundation", ToCol: 2}).Maybe()
+
+		result := new(StreetsAndAlleysWebPresenter).Output(sg, nil)
+		assert.Contains(t, result, `"hint"`, "Output must carry the hint -- the frontend reads state.hint")
+	})
+
+	// 手詰まりのヒントは出さない。逃げ道の提示は stalemate 用のメッセージが持つ。
+	t.Run("not while stalemate", func(t *testing.T) {
+		sg := new(interfaces.MockStreetsAndAlleysGame)
+		setupStreetsAndAlleysWebMockDefaults(sg)
+		sg.ExpectedCalls = filterCalls(sg.ExpectedCalls, "IsStalemate")
+		sg.On("IsStalemate").Return(true)
+		sg.On("GetHint").Return(&domain.StreetsAndAlleysHint{FromCol: 3, CardIndex: 0, ToZone: "foundation", ToCol: 2}).Maybe()
+
+		result := new(StreetsAndAlleysWebPresenter).Output(sg, nil)
+		assert.NotContains(t, result, `"hint"`)
 	})
 }
 

--- a/internal/adapter/presenter/WaspWebPresenter.go
+++ b/internal/adapter/presenter/WaspWebPresenter.go
@@ -17,6 +17,19 @@ type WaspWebPresenter struct{}
 func (p *WaspWebPresenter) Output(s interfaces.WaspGame, lastErr error) string {
 	resObj := p.buildBase(s)
 
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	if s.GetPhase() == domain.WaspPhasePlaying && !s.IsStalemate() {
+		if hint := s.GetHint(); hint != nil {
+			resObj.Hint = &controller.WaspWebOutputHint{
+				FromCol:   hint.FromCol,
+				CardIndex: hint.CardIndex,
+				ToCol:     hint.ToCol,
+			}
+		}
+	}
+
 	if lastErr != nil {
 		resObj.Message = lastErr.Error()
 	} else {

--- a/internal/adapter/presenter/WaspWebPresenter_test.go
+++ b/internal/adapter/presenter/WaspWebPresenter_test.go
@@ -38,10 +38,18 @@ func parseWaspOutput(t *testing.T, jsonStr string) *controller.WaspWebOutput {
 	return &out
 }
 
+// setupWaspOutputMock は Output 用の既定。**Output() も受動ヒントを埋める**ように
+// なった (#4483) ので GetHint を呼べるようにする。共有ヘルパーに置くと、先に
+// 登録されたこの期待が HintOutput テストの「ヒントあり」を食う。
+func setupWaspOutputMock(g *interfaces.MockWaspGame) {
+	setupWaspWebMockDefaults(g)
+	g.On("GetHint").Return(nil).Maybe()
+}
+
 func TestWaspWebPresenter_Output(t *testing.T) {
 	t.Run("initial state", func(t *testing.T) {
 		sg := new(interfaces.MockWaspGame)
-		setupWaspWebMockDefaults(sg)
+		setupWaspOutputMock(sg)
 		p := new(WaspWebPresenter)
 
 		result := parseWaspOutput(t, p.Output(sg, nil))
@@ -104,11 +112,36 @@ func TestWaspWebPresenter_Output(t *testing.T) {
 
 	t.Run("with error", func(t *testing.T) {
 		sg := new(interfaces.MockWaspGame)
-		setupWaspWebMockDefaults(sg)
+		setupWaspOutputMock(sg)
 		p := new(WaspWebPresenter)
 
 		result := parseWaspOutput(t, p.Output(sg, errors.New("test error")))
 		assert.Equal(t, "test error", result.Message)
+	})
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+func TestWaspWebPresenter_OutputCarriesTheHint(t *testing.T) {
+	t.Run("playing", func(t *testing.T) {
+		wg := new(interfaces.MockWaspGame)
+		setupWaspWebMockDefaults(wg)
+		wg.On("GetHint").Return(&domain.WaspHint{FromCol: 1, CardIndex: 0, ToCol: 4}).Maybe()
+
+		result := new(WaspWebPresenter).Output(wg, nil)
+		assert.Contains(t, result, `"hint"`, "Output must carry the hint -- the frontend reads state.hint")
+	})
+
+	// 手詰まりのヒントは出さない。逃げ道の提示は stalemate 用のメッセージが持つ。
+	t.Run("not while stalemate", func(t *testing.T) {
+		wg := new(interfaces.MockWaspGame)
+		setupWaspWebMockDefaults(wg)
+		wg.ExpectedCalls = filterCalls(wg.ExpectedCalls, "IsStalemate")
+		wg.On("IsStalemate").Return(true)
+		wg.On("GetHint").Return(&domain.WaspHint{FromCol: 1, CardIndex: 0, ToCol: 4}).Maybe()
+
+		result := new(WaspWebPresenter).Output(wg, nil)
+		assert.NotContains(t, result, `"hint"`)
 	})
 }
 
@@ -139,7 +172,7 @@ func TestWaspWebPresenter_HintOutput(t *testing.T) {
 
 func TestWaspWebPresenter_LegalMovesOutput(t *testing.T) {
 	sg := new(interfaces.MockWaspGame)
-	setupWaspWebMockDefaults(sg)
+	setupWaspOutputMock(sg)
 	p := new(WaspWebPresenter)
 
 	// Web delegates legal-move previews to the normal state JSON (targets are


### PR DESCRIPTION
## 概要

12 本目。**Forty Thieves / Streets and Alleys / Wasp**。

Refs #4483

## 受信者名もフィールドも、想定せず実物から読みます

**Streets and Alleys の Output の受信者は `bc`** です（ゲーム名の頭文字ではありません）。ヒントも **`ToZone` を持つのに `FromZone` は持ちません。**生成スクリプトは受信者を `func (p *XWebPresenter) Output(` から正規表現で拾い、リテラルは `HintOutput` から丸ごと持ち上げるので、**どちらも想定しません。**

| ゲーム | フィールド |
|---|---|
| Forty Thieves | `FromZone` / `FromCol` / `CardIndex` / `ToZone` / `ToCol` |
| **Streets and Alleys** | `FromCol` / `CardIndex` / **`ToZone`** / `ToCol` — `FromZone` 無し |
| Wasp | `FromCol` / `CardIndex` / `ToCol` |

## CLI フォーマッタは 2 本

**Wasp には CLI フォーマッタがありません。**残る 2 本で、既存テスト 3 件が旧挙動（`messageCode` 無しで HINT 行）を assert していて落ちました。ゲートが効いている証拠なので、「頼んだ応答」の messageCode を足しています。

| ファイル | テスト |
|---|---|
| `fortythievesFormatter.test.ts` | `renders a tableau hint with source index and target` |
| `fortythievesFormatter.test.ts` | `renders a waste hint source` |
| `streetsandalleysFormatter.test.ts` | `shows hint when present` |

## 負のコントロール

| 対象 | 結果 |
|---|---|
| Go プレゼンタのゲート 3 本を `if false` | **6 件 FAIL** |
| CLI フォーマッタのゲート 2 本を外す | **2 ファイル FAIL** |

## 確認

- `go test -tags test ./internal/adapter/presenter/ -count=2` green
- `golangci-lint run ./internal/adapter/presenter/` 0 issues
- `bun run check`（11 ガード）/ `typecheck` green

## Test plan

- [ ] CI 全ジョブ green