### PR TITLE
fix(hints): carry the passive hint for Crescent, Double Klondike and Forty and Eight (#4483)

### DIFF
--- a/frontend/src/utils/cli/formatters/crescentFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/crescentFormatter.test.ts
@@ -40,17 +40,30 @@ describe('formatCrescentState', () => {
     const out = formatCrescentState({
       ...baseState,
       hint: { fromCol: 2, toZone: 'foundation', toCol: 4, redeal: false },
+      messageCode: 'crescent.hintAvailable',
     });
     expect(out).toContain('HINT: t2 → foundation4');
   });
 
   it('renders a redeal hint', () => {
-    const out = formatCrescentState({ ...baseState, hint: { fromCol: -1, toZone: '', toCol: -1, redeal: true } });
+    const out = formatCrescentState({
+      ...baseState,
+      hint: { fromCol: -1, toZone: '', toCol: -1, redeal: true },
+      messageCode: 'crescent.hintAvailable',
+    });
     expect(out).toContain('HINT: redeal');
   });
 
   it('renders stalemate and win banners', () => {
     expect(formatCrescentState({ ...baseState, isStalemate: true })).toContain('Stalemate');
     expect(formatCrescentState({ ...baseState, phase: 1 })).toContain('Congratulations');
+  });
+
+  // **HINT 行は hint を頼んだときだけ。**受動ヒントが Output に載るように
+  // なった (#4483) ので、messageCode で「頼んだ応答か」を見分ける。
+  it('shows the hint only when the hint was requested', () => {
+    const hint = { fromCol: 2, toZone: 'foundation', toCol: 4, redeal: false };
+    expect(formatCrescentState({ ...baseState, hint, messageCode: 'crescent.hintAvailable' })).toContain('HINT:');
+    expect(formatCrescentState({ ...baseState, hint, messageCode: 'crescent.playing' })).not.toContain('HINT:');
   });
 });

--- a/frontend/src/utils/cli/formatters/crescentFormatter.ts
+++ b/frontend/src/utils/cli/formatters/crescentFormatter.ts
@@ -1,5 +1,5 @@
 import type { Card, CrescentResponse } from '../../../types/card';
-import { formatCard, formatHeader, formatSeparator } from '../formatterBase';
+import { formatCard, formatHeader, formatSeparator, isRequestedHint } from '../formatterBase';
 
 const ASCENDING_COUNT = 4;
 
@@ -33,7 +33,7 @@ export function formatCrescentState(state: CrescentResponse): string {
 
   lines.push(`moves: ${state.moveCount} | redeals: ${state.redealsRemaining} | undo:${state.canUndo ? 'yes' : 'no'}`);
 
-  if (state.hint) {
+  if (state.hint && isRequestedHint(state)) {
     if (state.hint.redeal) {
       lines.push('HINT: redeal (d)');
     } else {

--- a/frontend/src/utils/cli/formatters/fortyandeightFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/fortyandeightFormatter.test.ts
@@ -46,14 +46,20 @@ describe('formatFortyandeightState', () => {
 
   it('renders a tableau hint with source index and target', () => {
     const out = formatFortyandeightState(
-      baseState({ hint: { fromZone: 'tableau', fromCol: 0, cardIndex: 1, toZone: 'foundation', toCol: 2 } }),
+      baseState({
+        hint: { fromZone: 'tableau', fromCol: 0, cardIndex: 1, toZone: 'foundation', toCol: 2 },
+        messageCode: 'fortyandeight.hintAvailable',
+      }),
     );
     expect(out).toContain('HINT: t0[1] → foundation2');
   });
 
   it('renders a waste hint source', () => {
     const out = formatFortyandeightState(
-      baseState({ hint: { fromZone: 'waste', fromCol: -1, cardIndex: -1, toZone: 'tableau', toCol: 4 } }),
+      baseState({
+        hint: { fromZone: 'waste', fromCol: -1, cardIndex: -1, toZone: 'tableau', toCol: 4 },
+        messageCode: 'fortyandeight.hintAvailable',
+      }),
     );
     expect(out).toContain('HINT: waste → tableau4');
   });
@@ -65,5 +71,15 @@ describe('formatFortyandeightState', () => {
     expect(out).toContain('Stalemate - no more moves possible');
     expect(out).toContain('stuck');
     expect(out).toContain('Congratulations! You win!');
+  });
+
+  // **HINT 行は hint を頼んだときだけ。**受動ヒントが Output に載るように
+  // なった (#4483) ので、messageCode で「頼んだ応答か」を見分ける。
+  it('shows the hint only when the hint was requested', () => {
+    const hint = { fromZone: 'tableau', fromCol: 0, cardIndex: 1, toZone: 'foundation', toCol: 2 };
+    expect(formatFortyandeightState(baseState({ hint, messageCode: 'fortyandeight.hintAvailable' }))).toContain(
+      'HINT:',
+    );
+    expect(formatFortyandeightState(baseState({ hint, messageCode: 'fortyandeight.playing' }))).not.toContain('HINT:');
   });
 });

--- a/frontend/src/utils/cli/formatters/fortyandeightFormatter.ts
+++ b/frontend/src/utils/cli/formatters/fortyandeightFormatter.ts
@@ -1,6 +1,6 @@
 import type { FortyAndEightResponse } from '../../../types/card';
 import { FortyAndEightPhase } from '../../../types/phases';
-import { formatCard, formatHeader, formatSeparator } from '../formatterBase';
+import { formatCard, formatHeader, formatSeparator, isRequestedHint } from '../formatterBase';
 
 /** Format a Forty and Eight game state as terminal text. */
 export function formatFortyandeightState(state: FortyAndEightResponse): string {
@@ -31,7 +31,7 @@ export function formatFortyandeightState(state: FortyAndEightResponse): string {
 
   lines.push(`moves: ${state.moveCount}  undo:${state.canUndo ? 'yes' : 'no'}`);
 
-  if (state.hint) {
+  if (state.hint && isRequestedHint(state)) {
     const from = state.hint.fromZone === 'waste' ? 'waste' : `t${state.hint.fromCol}[${state.hint.cardIndex}]`;
     const target = state.hint.toCol >= 0 ? `${state.hint.toZone}${state.hint.toCol}` : state.hint.toZone;
     lines.push(`HINT: ${from} → ${target}`);

--- a/internal/adapter/presenter/CrescentWebPresenter.go
+++ b/internal/adapter/presenter/CrescentWebPresenter.go
@@ -43,6 +43,20 @@ func (p *CrescentWebPresenter) Output(cr interfaces.CrescentGame, lastErr error)
 		}
 	}
 
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	if cr.GetPhase() == domain.CrescentPhasePlaying && !cr.IsStalemate() {
+		if hint := cr.GetHint(); hint != nil {
+			resObj.Hint = &controller.CrescentWebOutputHint{
+				FromCol: hint.FromCol,
+				ToZone:  hint.ToZone,
+				ToCol:   hint.ToCol,
+				Redeal:  hint.Redeal,
+			}
+		}
+	}
+
 	if lastErr != nil {
 		resObj.Message = lastErr.Error()
 	} else {

--- a/internal/adapter/presenter/CrescentWebPresenter_test.go
+++ b/internal/adapter/presenter/CrescentWebPresenter_test.go
@@ -52,10 +52,18 @@ func parseCrescentOutput(t *testing.T, jsonStr string) *controller.CrescentWebOu
 	return &out
 }
 
+// setupCrescentOutputMock は Output 用の既定。**Output() も受動ヒントを埋める**ように
+// なった (#4483) ので GetHint を呼べるようにする。共有ヘルパーに置くと、先に
+// 登録されたこの期待が HintOutput テストの「ヒントあり」を食う。
+func setupCrescentOutputMock(g *interfaces.MockCrescentGame) {
+	setupCrescentWebMockDefaults(g)
+	g.On("GetHint").Return(nil).Maybe()
+}
+
 func TestCrescentWebPresenter_Output(t *testing.T) {
 	t.Run("initial state", func(t *testing.T) {
 		cg := new(interfaces.MockCrescentGame)
-		setupCrescentWebMockDefaults(cg)
+		setupCrescentOutputMock(cg)
 		p := new(CrescentWebPresenter)
 
 		result := parseCrescentOutput(t, p.Output(cg, nil))
@@ -68,7 +76,7 @@ func TestCrescentWebPresenter_Output(t *testing.T) {
 
 	t.Run("error message", func(t *testing.T) {
 		cg := new(interfaces.MockCrescentGame)
-		setupCrescentWebMockDefaults(cg)
+		setupCrescentOutputMock(cg)
 		p := new(CrescentWebPresenter)
 		result := parseCrescentOutput(t, p.Output(cg, errors.New("boom")))
 		assert.Equal(t, "boom", result.Message)
@@ -76,7 +84,7 @@ func TestCrescentWebPresenter_Output(t *testing.T) {
 
 	t.Run("game clear", func(t *testing.T) {
 		cg := new(interfaces.MockCrescentGame)
-		setupCrescentWebMockDefaults(cg)
+		setupCrescentOutputMock(cg)
 		cg.ExpectedCalls = filterCalls(cg.ExpectedCalls, "GetPhase")
 		cg.On("GetPhase").Return(domain.CrescentPhaseGameClear)
 		p := new(CrescentWebPresenter)
@@ -86,7 +94,7 @@ func TestCrescentWebPresenter_Output(t *testing.T) {
 
 	t.Run("game over", func(t *testing.T) {
 		cg := new(interfaces.MockCrescentGame)
-		setupCrescentWebMockDefaults(cg)
+		setupCrescentOutputMock(cg)
 		cg.ExpectedCalls = filterCalls(cg.ExpectedCalls, "GetPhase")
 		cg.On("GetPhase").Return(domain.CrescentPhaseGameOver)
 		p := new(CrescentWebPresenter)
@@ -96,12 +104,37 @@ func TestCrescentWebPresenter_Output(t *testing.T) {
 
 	t.Run("stalemate", func(t *testing.T) {
 		cg := new(interfaces.MockCrescentGame)
-		setupCrescentWebMockDefaults(cg)
+		setupCrescentOutputMock(cg)
 		cg.ExpectedCalls = filterCalls(cg.ExpectedCalls, "IsStalemate")
 		cg.On("IsStalemate").Return(true)
 		p := new(CrescentWebPresenter)
 		result := parseCrescentOutput(t, p.Output(cg, nil))
 		assert.Equal(t, "crescent.stalemate", result.MessageCode)
+	})
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+func TestCrescentWebPresenter_OutputCarriesTheHint(t *testing.T) {
+	t.Run("playing", func(t *testing.T) {
+		cg := new(interfaces.MockCrescentGame)
+		setupCrescentWebMockDefaults(cg)
+		cg.On("GetHint").Return(&domain.CrescentHint{FromCol: 2, ToZone: "foundation", ToCol: 1, Redeal: false}).Maybe()
+
+		result := new(CrescentWebPresenter).Output(cg, nil)
+		assert.Contains(t, result, `"hint"`, "Output must carry the hint -- the frontend reads state.hint")
+	})
+
+	// 手詰まりのヒントは出さない。逃げ道の提示は stalemate 用のメッセージが持つ。
+	t.Run("not while stalemate", func(t *testing.T) {
+		cg := new(interfaces.MockCrescentGame)
+		setupCrescentWebMockDefaults(cg)
+		cg.ExpectedCalls = filterCalls(cg.ExpectedCalls, "IsStalemate")
+		cg.On("IsStalemate").Return(true)
+		cg.On("GetHint").Return(&domain.CrescentHint{FromCol: 2, ToZone: "foundation", ToCol: 1, Redeal: false}).Maybe()
+
+		result := new(CrescentWebPresenter).Output(cg, nil)
+		assert.NotContains(t, result, `"hint"`)
 	})
 }
 

--- a/internal/adapter/presenter/DoubleKlondikeWebPresenter.go
+++ b/internal/adapter/presenter/DoubleKlondikeWebPresenter.go
@@ -24,6 +24,21 @@ func (p *DoubleKlondikeWebPresenter) Output(g interfaces.DoubleKlondikeGame, las
 		resObj.Foundation[i] = cardsToOutputOrEmpty(f)
 	}
 
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	if g.GetPhase() == domain.DoubleKlondikePhasePlaying && !g.IsStalemate() {
+		if hint := g.GetHint(); hint != nil {
+			resObj.Hint = &controller.DoubleKlondikeWebOutputHint{
+				FromZone:  hint.FromZone,
+				FromCol:   hint.FromCol,
+				CardIndex: hint.CardIndex,
+				ToZone:    hint.ToZone,
+				ToCol:     hint.ToCol,
+			}
+		}
+	}
+
 	if lastErr != nil {
 		resObj.Message = lastErr.Error()
 	} else {

--- a/internal/adapter/presenter/DoubleKlondikeWebPresenter_test.go
+++ b/internal/adapter/presenter/DoubleKlondikeWebPresenter_test.go
@@ -35,6 +35,16 @@ func TestDoubleKlondikeWebPresenter_Output(t *testing.T) {
 		assert.Contains(t, p.Output(dkState(t, `{"ph":2}`), nil), "doubleklondike.gameOver")
 	})
 
+	// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+	// レスポンスで、ページの state にはマージされない (#4483)。
+	t.Run("output carries the hint", func(t *testing.T) {
+		// 廃札にスペードのエースを表向きで置く。台札へ動かせるのでヒントが必ず出る。
+		js := `{"wa":[{"d":1,"v":1,"w":true}],"ph":0}`
+		assert.Contains(t, p.Output(dkState(t, js), nil), `"hint"`,
+			"Output must carry the hint -- the frontend reads state.hint")
+		assert.NotContains(t, p.Output(dkState(t, `{"ph":2}`), nil), `"hint"`)
+	})
+
 	t.Run("hint output", func(t *testing.T) {
 		js := `{"wa":[{"d":1,"v":1,"w":true}],"ph":0}`
 		assert.Contains(t, p.HintOutput(dkState(t, js)), "doubleklondike.hintAvailable")

--- a/internal/adapter/presenter/FortyAndEightWebPresenter.go
+++ b/internal/adapter/presenter/FortyAndEightWebPresenter.go
@@ -59,6 +59,21 @@ func (p *FortyAndEightWebPresenter) Output(ft interfaces.FortyAndEightGame, last
 	}
 
 	// メッセージ
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	if ft.GetPhase() == domain.FortyAndEightPhasePlaying && !ft.IsStalemate() {
+		if hint := ft.GetHint(); hint != nil {
+			resObj.Hint = &controller.FortyAndEightWebOutputHint{
+				FromZone:  hint.FromZone,
+				FromCol:   hint.FromCol,
+				CardIndex: hint.CardIndex,
+				ToZone:    hint.ToZone,
+				ToCol:     hint.ToCol,
+			}
+		}
+	}
+
 	if lastErr != nil {
 		resObj.Message = lastErr.Error()
 	} else {

--- a/internal/adapter/presenter/FortyAndEightWebPresenter_test.go
+++ b/internal/adapter/presenter/FortyAndEightWebPresenter_test.go
@@ -49,10 +49,18 @@ func parseFortyAndEightOutput(t *testing.T, jsonStr string) *controller.FortyAnd
 	return &out
 }
 
+// setupFortyAndEightOutputMock は Output 用の既定。**Output() も受動ヒントを埋める**ように
+// なった (#4483) ので GetHint を呼べるようにする。共有ヘルパーに置くと、先に
+// 登録されたこの期待が HintOutput テストの「ヒントあり」を食う。
+func setupFortyAndEightOutputMock(g *interfaces.MockFortyAndEightGame) {
+	setupFortyAndEightWebMockDefaults(g)
+	g.On("GetHint").Return(nil).Maybe()
+}
+
 func TestFortyAndEightWebPresenter_Output(t *testing.T) {
 	t.Run("initial state", func(t *testing.T) {
 		fg := new(interfaces.MockFortyAndEightGame)
-		setupFortyAndEightWebMockDefaults(fg)
+		setupFortyAndEightOutputMock(fg)
 		p := new(FortyAndEightWebPresenter)
 
 		result := parseFortyAndEightOutput(t, p.Output(fg, nil))
@@ -69,7 +77,7 @@ func TestFortyAndEightWebPresenter_Output(t *testing.T) {
 
 	t.Run("waste with cards", func(t *testing.T) {
 		fg := new(interfaces.MockFortyAndEightGame)
-		setupFortyAndEightWebMockDefaults(fg)
+		setupFortyAndEightOutputMock(fg)
 		fg.ExpectedCalls = filterCalls(fg.ExpectedCalls, "GetWaste")
 		fg.On("GetWaste").Return([]*domain.Card{domain.NewCard(domain.CardDesignHeart, 5, false)})
 
@@ -82,7 +90,7 @@ func TestFortyAndEightWebPresenter_Output(t *testing.T) {
 
 	t.Run("redeal available", func(t *testing.T) {
 		fg := new(interfaces.MockFortyAndEightGame)
-		setupFortyAndEightWebMockDefaults(fg)
+		setupFortyAndEightOutputMock(fg)
 		fg.ExpectedCalls = filterCalls(fg.ExpectedCalls, "CanRedeal")
 		fg.On("CanRedeal").Return(true)
 
@@ -93,7 +101,7 @@ func TestFortyAndEightWebPresenter_Output(t *testing.T) {
 
 	t.Run("redeal used", func(t *testing.T) {
 		fg := new(interfaces.MockFortyAndEightGame)
-		setupFortyAndEightWebMockDefaults(fg)
+		setupFortyAndEightOutputMock(fg)
 		fg.ExpectedCalls = filterCalls(fg.ExpectedCalls, "GetRedealUsed")
 		fg.On("GetRedealUsed").Return(true)
 
@@ -104,7 +112,7 @@ func TestFortyAndEightWebPresenter_Output(t *testing.T) {
 
 	t.Run("all face up", func(t *testing.T) {
 		fg := new(interfaces.MockFortyAndEightGame)
-		setupFortyAndEightWebMockDefaults(fg)
+		setupFortyAndEightOutputMock(fg)
 		p := new(FortyAndEightWebPresenter)
 
 		result := parseFortyAndEightOutput(t, p.Output(fg, nil))
@@ -118,7 +126,7 @@ func TestFortyAndEightWebPresenter_Output(t *testing.T) {
 
 	t.Run("error message", func(t *testing.T) {
 		fg := new(interfaces.MockFortyAndEightGame)
-		setupFortyAndEightWebMockDefaults(fg)
+		setupFortyAndEightOutputMock(fg)
 		p := new(FortyAndEightWebPresenter)
 
 		result := parseFortyAndEightOutput(t, p.Output(fg, errors.New("test error")))
@@ -127,7 +135,7 @@ func TestFortyAndEightWebPresenter_Output(t *testing.T) {
 
 	t.Run("game clear", func(t *testing.T) {
 		fg := new(interfaces.MockFortyAndEightGame)
-		setupFortyAndEightWebMockDefaults(fg)
+		setupFortyAndEightOutputMock(fg)
 		fg.ExpectedCalls = filterCalls(fg.ExpectedCalls, "GetPhase")
 		fg.On("GetPhase").Return(domain.FortyAndEightPhaseGameClear)
 
@@ -138,7 +146,7 @@ func TestFortyAndEightWebPresenter_Output(t *testing.T) {
 
 	t.Run("game over", func(t *testing.T) {
 		fg := new(interfaces.MockFortyAndEightGame)
-		setupFortyAndEightWebMockDefaults(fg)
+		setupFortyAndEightOutputMock(fg)
 		fg.ExpectedCalls = filterCalls(fg.ExpectedCalls, "GetPhase")
 		fg.On("GetPhase").Return(domain.FortyAndEightPhaseGameOver)
 
@@ -149,13 +157,38 @@ func TestFortyAndEightWebPresenter_Output(t *testing.T) {
 
 	t.Run("stalemate", func(t *testing.T) {
 		fg := new(interfaces.MockFortyAndEightGame)
-		setupFortyAndEightWebMockDefaults(fg)
+		setupFortyAndEightOutputMock(fg)
 		fg.ExpectedCalls = filterCalls(fg.ExpectedCalls, "IsStalemate")
 		fg.On("IsStalemate").Return(true)
 
 		p := new(FortyAndEightWebPresenter)
 		result := parseFortyAndEightOutput(t, p.Output(fg, nil))
 		assert.Equal(t, "fortyandeight.stalemate", result.MessageCode)
+	})
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+func TestFortyAndEightWebPresenter_OutputCarriesTheHint(t *testing.T) {
+	t.Run("playing", func(t *testing.T) {
+		fg := new(interfaces.MockFortyAndEightGame)
+		setupFortyAndEightWebMockDefaults(fg)
+		fg.On("GetHint").Return(&domain.FortyAndEightHint{FromZone: "tableau", FromCol: 1, CardIndex: 0, ToZone: "foundation", ToCol: 3}).Maybe()
+
+		result := new(FortyAndEightWebPresenter).Output(fg, nil)
+		assert.Contains(t, result, `"hint"`, "Output must carry the hint -- the frontend reads state.hint")
+	})
+
+	// 手詰まりのヒントは出さない。逃げ道の提示は stalemate 用のメッセージが持つ。
+	t.Run("not while stalemate", func(t *testing.T) {
+		fg := new(interfaces.MockFortyAndEightGame)
+		setupFortyAndEightWebMockDefaults(fg)
+		fg.ExpectedCalls = filterCalls(fg.ExpectedCalls, "IsStalemate")
+		fg.On("IsStalemate").Return(true)
+		fg.On("GetHint").Return(&domain.FortyAndEightHint{FromZone: "tableau", FromCol: 1, CardIndex: 0, ToZone: "foundation", ToCol: 3}).Maybe()
+
+		result := new(FortyAndEightWebPresenter).Output(fg, nil)
+		assert.NotContains(t, result, `"hint"`)
 	})
 }
 


### PR DESCRIPTION
## 概要

13 本目。**Crescent / Double Klondike / Forty and Eight**。

Refs #4483

## Crescent のヒントは「移動」とは限りません

`CrescentHint` は **`Redeal bool` を持ちます。**再配りを勧める形では `fromCol` / `toCol` が **-1**、`toZone` は**空文字**です。

```go
type CrescentHint struct {
	FromCol int
	ToZone  string
	ToCol   int
	Redeal  bool   // ← これ
}
```

手でリテラルを並べていたら落としていました。**`HintOutput` から丸ごと持ち上げる**方式なので、こうした「そのゲームにしかない項目」が構造的に残ります。

## Double Klondike はテストの作りが違います

mock ヘルパーも CLI フォーマッタも無く、**JSON フィクスチャから状態を組む `dkState(t, json)`** 形式でした。Output のテストは**そのゲーム自身のヒントテストが使っているフィクスチャをそのまま**使っています（廃札に表向きのスペードのエース）。

## 既存テスト 4 件が落ちました（ゲートが効いている証拠）

| ファイル | テスト |
|---|---|
| `crescentFormatter.test.ts` | `renders a positional hint` |
| `crescentFormatter.test.ts` | `renders a redeal hint` |
| `fortyandeightFormatter.test.ts` | `renders a tableau hint with source index and target` |
| `fortyandeightFormatter.test.ts` | `renders a waste hint source` |

**Double Klondike には CLI フォーマッタがありません**ので、ゲートは 2 本です。

## 負のコントロール

| 対象 | 結果 |
|---|---|
| Go プレゼンタのゲート 3 本を `if false` | **6 件 FAIL** |
| CLI フォーマッタのゲート 2 本を外す | **2 ファイル FAIL** |

## 確認

- `go test -tags test ./internal/adapter/presenter/ -count=2` green
- `golangci-lint run ./internal/adapter/presenter/` 0 issues
- `bun run check`（11 ガード）/ `typecheck` green

## Test plan

- [ ] CI 全ジョブ green