### PR TITLE
fix(hints): carry the passive hint for Black Hole, Napoleon's Square and Sultan (#4483)

### DIFF
--- a/frontend/src/utils/cli/formatters/napoleonssquareFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/napoleonssquareFormatter.test.ts
@@ -44,7 +44,10 @@ describe('formatNapoleonsSquareState', () => {
 
   it('shows a tableau hint with the run head', () => {
     const result = formatNapoleonsSquareState(
-      makeState({ hint: { fromZone: 'tableau', fromCol: 3, cardIndex: 1, toZone: 'tableau', toCol: 7 } }),
+      makeState({
+        hint: { fromZone: 'tableau', fromCol: 3, cardIndex: 1, toZone: 'tableau', toCol: 7 },
+        messageCode: 'napoleonssquare.hintAvailable',
+      }),
     );
     expect(result).toContain('HINT');
     expect(result).toContain('t3[1]');
@@ -80,10 +83,25 @@ describe('formatNapoleonsSquareState', () => {
 
   it('renders a waste-to-foundation hint', () => {
     const result = formatNapoleonsSquareState(
-      makeState({ hint: { fromZone: 'waste', fromCol: -1, cardIndex: -1, toZone: 'foundation', toCol: 2 } }),
+      makeState({
+        hint: { fromZone: 'waste', fromCol: -1, cardIndex: -1, toZone: 'foundation', toCol: 2 },
+        messageCode: 'napoleonssquare.hintAvailable',
+      }),
     );
     expect(result).toContain('HINT');
     expect(result).toContain('waste');
     expect(result).toContain('foundation2');
+  });
+
+  // **HINT 行は hint を頼んだときだけ。**受動ヒントが Output に載るように
+  // なった (#4483) ので、messageCode で「頼んだ応答か」を見分ける。
+  it('shows the hint only when the hint was requested', () => {
+    const hint = { fromZone: 'tableau', fromCol: 3, cardIndex: 1, toZone: 'tableau', toCol: 7 };
+    expect(formatNapoleonsSquareState(makeState({ hint, messageCode: 'napoleonssquare.hintAvailable' }))).toContain(
+      'HINT',
+    );
+    expect(formatNapoleonsSquareState(makeState({ hint, messageCode: 'napoleonssquare.playing' }))).not.toContain(
+      'HINT',
+    );
   });
 });

--- a/frontend/src/utils/cli/formatters/napoleonssquareFormatter.ts
+++ b/frontend/src/utils/cli/formatters/napoleonssquareFormatter.ts
@@ -1,5 +1,5 @@
 import type { NapoleonsSquareResponse } from '../../../types/card';
-import { formatCard, formatHeader, formatSeparator } from '../formatterBase';
+import { formatCard, formatHeader, formatSeparator, isRequestedHint } from '../formatterBase';
 
 /** Format a Napoleon's Square game state as terminal text. */
 export function formatNapoleonsSquareState(state: NapoleonsSquareResponse): string {
@@ -27,7 +27,7 @@ export function formatNapoleonsSquareState(state: NapoleonsSquareResponse): stri
 
   lines.push(`moves: ${state.moveCount}  undo:${state.canUndo ? 'yes' : 'no'}`);
 
-  if (state.hint) {
+  if (state.hint && isRequestedHint(state)) {
     const from =
       state.hint.fromZone === 'tableau' ? `t${state.hint.fromCol}[${state.hint.cardIndex}]` : state.hint.fromZone;
     const to = state.hint.toCol >= 0 ? `${state.hint.toZone}${state.hint.toCol}` : state.hint.toZone;

--- a/frontend/src/utils/cli/formatters/sultanFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/sultanFormatter.test.ts
@@ -46,12 +46,16 @@ describe('formatSultanState', () => {
   });
 
   it('renders a divan hint with source index and target', () => {
-    const out = formatSultanState(baseState({ hint: { fromZone: 'divan', fromIdx: 3, toFoundation: 2 } }));
+    const out = formatSultanState(
+      baseState({ hint: { fromZone: 'divan', fromIdx: 3, toFoundation: 2 }, messageCode: 'sultan.hintAvailable' }),
+    );
     expect(out).toContain('HINT: divan[3] → foundation2');
   });
 
   it('renders a waste hint source', () => {
-    const out = formatSultanState(baseState({ hint: { fromZone: 'waste', fromIdx: -1, toFoundation: 4 } }));
+    const out = formatSultanState(
+      baseState({ hint: { fromZone: 'waste', fromIdx: -1, toFoundation: 4 }, messageCode: 'sultan.hintAvailable' }),
+    );
     expect(out).toContain('HINT: waste → foundation4');
   });
 
@@ -60,5 +64,13 @@ describe('formatSultanState', () => {
     expect(out).toContain('Stalemate - no more moves possible');
     expect(out).toContain('stuck');
     expect(out).toContain('Congratulations! You win!');
+  });
+
+  // **HINT 行は hint を頼んだときだけ。**受動ヒントが Output に載るように
+  // なった (#4483) ので、messageCode で「頼んだ応答か」を見分ける。
+  it('shows the hint only when the hint was requested', () => {
+    const hint = { fromZone: 'divan', fromIdx: 3, toFoundation: 2 };
+    expect(formatSultanState(baseState({ hint, messageCode: 'sultan.hintAvailable' }))).toContain('HINT');
+    expect(formatSultanState(baseState({ hint, messageCode: 'sultan.playing' }))).not.toContain('HINT');
   });
 });

--- a/frontend/src/utils/cli/formatters/sultanFormatter.ts
+++ b/frontend/src/utils/cli/formatters/sultanFormatter.ts
@@ -1,6 +1,6 @@
 import type { SultanResponse } from '../../../types/card';
 import { SultanPhase } from '../../../types/phases';
-import { formatCard, formatHeader, formatSeparator } from '../formatterBase';
+import { formatCard, formatHeader, formatSeparator, isRequestedHint } from '../formatterBase';
 
 /** Format a Sultan of Turkey game state as terminal text. */
 export function formatSultanState(state: SultanResponse): string {
@@ -23,7 +23,7 @@ export function formatSultanState(state: SultanResponse): string {
 
   lines.push(`moves: ${state.moveCount}  undo:${state.canUndo ? 'yes' : 'no'}`);
 
-  if (state.hint) {
+  if (state.hint && isRequestedHint(state)) {
     const from = state.hint.fromZone === 'waste' ? 'waste' : `divan[${state.hint.fromIdx}]`;
     lines.push(`HINT: ${from} → foundation${state.hint.toFoundation}`);
   }

--- a/internal/adapter/presenter/BlackHoleWebPresenter.go
+++ b/internal/adapter/presenter/BlackHoleWebPresenter.go
@@ -28,6 +28,15 @@ func (p *BlackHoleWebPresenter) Output(g interfaces.BlackHoleGame, lastErr error
 	resObj.Fans = blackHoleFansOutput(g.GetFans())
 	resObj.BlackHole = cardsToOutputOrEmpty(g.GetBlackHole())
 
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	if g.GetPhase() == domain.BlackHolePhasePlaying && !g.IsStalemate() {
+		if hint := g.GetHint(); hint != nil {
+			resObj.Hint = &controller.BlackHoleWebOutputHint{Fan: hint.Fan}
+		}
+	}
+
 	if lastErr != nil {
 		resObj.Message = lastErr.Error()
 	} else {

--- a/internal/adapter/presenter/BlackHoleWebPresenter_test.go
+++ b/internal/adapter/presenter/BlackHoleWebPresenter_test.go
@@ -35,6 +35,16 @@ func TestBlackHoleWebPresenter_Output(t *testing.T) {
 		assert.Contains(t, p.Output(bhState(t, `{"ph":2}`), nil), "blackhole.gameOver")
 	})
 
+	// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+	// レスポンスで、ページの state にはマージされない (#4483)。
+	t.Run("output carries the hint", func(t *testing.T) {
+		// 穴の一番上が 5、fan0 の一番上が 6（±1）なので fan 0 が勧められる。
+		js := `{"bh":[{"d":1,"v":5,"w":true}],"fn":[[{"d":2,"v":6,"w":true}]],"ph":0}`
+		assert.Contains(t, p.Output(bhState(t, js), nil), `"hint"`,
+			"Output must carry the hint -- the frontend reads state.hint")
+		assert.NotContains(t, p.Output(bhState(t, `{"ph":2}`), nil), `"hint"`)
+	})
+
 	t.Run("hint output carries recommended fan and full board", func(t *testing.T) {
 		// Hole top 5, fan0 top 6 (±1) -> the domain recommends fan 0.
 		js := `{"bh":[{"d":1,"v":5,"w":true}],"fn":[[{"d":2,"v":6,"w":true}]],"ph":0}`

--- a/internal/adapter/presenter/NapoleonsSquareWebPresenter.go
+++ b/internal/adapter/presenter/NapoleonsSquareWebPresenter.go
@@ -53,6 +53,21 @@ func (p *NapoleonsSquareWebPresenter) Output(ns interfaces.NapoleonsSquareGame, 
 	}
 
 	// メッセージ
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	if ns.GetPhase() == domain.NapoleonsSquarePhasePlaying && !ns.IsStalemate() {
+		if hint := ns.GetHint(); hint != nil {
+			resObj.Hint = &controller.NapoleonsSquareWebOutputHint{
+				FromZone:  hint.FromZone,
+				FromCol:   hint.FromCol,
+				CardIndex: hint.CardIndex,
+				ToZone:    hint.ToZone,
+				ToCol:     hint.ToCol,
+			}
+		}
+	}
+
 	if lastErr != nil {
 		resObj.Message = lastErr.Error()
 	} else {

--- a/internal/adapter/presenter/NapoleonsSquareWebPresenter_test.go
+++ b/internal/adapter/presenter/NapoleonsSquareWebPresenter_test.go
@@ -49,10 +49,18 @@ func parseNapoleonsSquareOutput(t *testing.T, jsonStr string) *controller.Napole
 	return &out
 }
 
+// setupNapoleonsSquareOutputMock は Output 用の既定。**Output() も受動ヒントを埋める**ように
+// なった (#4483) ので GetHint を呼べるようにする。共有ヘルパーに置くと、先に
+// 登録されたこの期待が HintOutput テストの「ヒントあり」を食う。
+func setupNapoleonsSquareOutputMock(g *interfaces.MockNapoleonsSquareGame) {
+	setupNapoleonsSquareWebMockDefaults(g)
+	g.On("GetHint").Return(nil).Maybe()
+}
+
 func TestNapoleonsSquareWebPresenter_Output(t *testing.T) {
 	t.Run("initial state", func(t *testing.T) {
 		g := new(interfaces.MockNapoleonsSquareGame)
-		setupNapoleonsSquareWebMockDefaults(g)
+		setupNapoleonsSquareOutputMock(g)
 
 		result := parseNapoleonsSquareOutput(t, new(NapoleonsSquareWebPresenter).Output(g, nil))
 		assert.Equal(t, 0, result.Phase)
@@ -65,7 +73,7 @@ func TestNapoleonsSquareWebPresenter_Output(t *testing.T) {
 
 	t.Run("all face up", func(t *testing.T) {
 		g := new(interfaces.MockNapoleonsSquareGame)
-		setupNapoleonsSquareWebMockDefaults(g)
+		setupNapoleonsSquareOutputMock(g)
 
 		result := parseNapoleonsSquareOutput(t, new(NapoleonsSquareWebPresenter).Output(g, nil))
 		for _, col := range result.Tableau {
@@ -78,7 +86,7 @@ func TestNapoleonsSquareWebPresenter_Output(t *testing.T) {
 
 	t.Run("error message", func(t *testing.T) {
 		g := new(interfaces.MockNapoleonsSquareGame)
-		setupNapoleonsSquareWebMockDefaults(g)
+		setupNapoleonsSquareOutputMock(g)
 
 		result := parseNapoleonsSquareOutput(t, new(NapoleonsSquareWebPresenter).Output(g, errors.New("test error")))
 		assert.Equal(t, "test error", result.Message)
@@ -95,7 +103,7 @@ func TestNapoleonsSquareWebPresenter_Output(t *testing.T) {
 	for _, tc := range phases {
 		t.Run(tc.name, func(t *testing.T) {
 			g := new(interfaces.MockNapoleonsSquareGame)
-			setupNapoleonsSquareWebMockDefaults(g)
+			setupNapoleonsSquareOutputMock(g)
 			g.ExpectedCalls = filterCalls(g.ExpectedCalls, "GetPhase")
 			g.On("GetPhase").Return(tc.val)
 
@@ -106,12 +114,37 @@ func TestNapoleonsSquareWebPresenter_Output(t *testing.T) {
 
 	t.Run("stalemate", func(t *testing.T) {
 		g := new(interfaces.MockNapoleonsSquareGame)
-		setupNapoleonsSquareWebMockDefaults(g)
+		setupNapoleonsSquareOutputMock(g)
 		g.ExpectedCalls = filterCalls(g.ExpectedCalls, "IsStalemate")
 		g.On("IsStalemate").Return(true)
 
 		result := parseNapoleonsSquareOutput(t, new(NapoleonsSquareWebPresenter).Output(g, nil))
 		assert.Equal(t, "napoleonssquare.stalemate", result.MessageCode)
+	})
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+func TestNapoleonsSquareWebPresenter_OutputCarriesTheHint(t *testing.T) {
+	t.Run("playing", func(t *testing.T) {
+		nsg := new(interfaces.MockNapoleonsSquareGame)
+		setupNapoleonsSquareWebMockDefaults(nsg)
+		nsg.On("GetHint").Return(&domain.NapoleonsSquareHint{FromZone: "tableau", FromCol: 1, CardIndex: 0, ToZone: "foundation", ToCol: 2}).Maybe()
+
+		result := new(NapoleonsSquareWebPresenter).Output(nsg, nil)
+		assert.Contains(t, result, `"hint"`, "Output must carry the hint -- the frontend reads state.hint")
+	})
+
+	// 手詰まりのヒントは出さない。逃げ道の提示は stalemate 用のメッセージが持つ。
+	t.Run("not while stalemate", func(t *testing.T) {
+		nsg := new(interfaces.MockNapoleonsSquareGame)
+		setupNapoleonsSquareWebMockDefaults(nsg)
+		nsg.ExpectedCalls = filterCalls(nsg.ExpectedCalls, "IsStalemate")
+		nsg.On("IsStalemate").Return(true)
+		nsg.On("GetHint").Return(&domain.NapoleonsSquareHint{FromZone: "tableau", FromCol: 1, CardIndex: 0, ToZone: "foundation", ToCol: 2}).Maybe()
+
+		result := new(NapoleonsSquareWebPresenter).Output(nsg, nil)
+		assert.NotContains(t, result, `"hint"`)
 	})
 }
 

--- a/internal/adapter/presenter/SultanWebPresenter.go
+++ b/internal/adapter/presenter/SultanWebPresenter.go
@@ -49,6 +49,19 @@ func (p *SultanWebPresenter) Output(su interfaces.SultanGame, lastErr error) str
 	}
 
 	// メッセージ
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	if su.GetPhase() == domain.SultanPhasePlaying && !su.IsStalemate() {
+		if hint := su.GetHint(); hint != nil {
+			resObj.Hint = &controller.SultanWebOutputHint{
+				FromZone:     hint.FromZone,
+				FromIdx:      hint.FromIdx,
+				ToFoundation: hint.ToFoundation,
+			}
+		}
+	}
+
 	if lastErr != nil {
 		resObj.Message = lastErr.Error()
 	} else {

--- a/internal/adapter/presenter/SultanWebPresenter_test.go
+++ b/internal/adapter/presenter/SultanWebPresenter_test.go
@@ -46,10 +46,18 @@ func parseSultanOutput(t *testing.T, jsonStr string) *controller.SultanWebOutput
 	return &out
 }
 
+// setupSultanOutputMock は Output 用の既定。**Output() も受動ヒントを埋める**ように
+// なった (#4483) ので GetHint を呼べるようにする。共有ヘルパーに置くと、先に
+// 登録されたこの期待が HintOutput テストの「ヒントあり」を食う。
+func setupSultanOutputMock(g *interfaces.MockSultanGame) {
+	setupSultanWebMockDefaults(g)
+	g.On("GetHint").Return(nil).Maybe()
+}
+
 func TestSultanWebPresenter_Output(t *testing.T) {
 	t.Run("initial state", func(t *testing.T) {
 		sg := new(interfaces.MockSultanGame)
-		setupSultanWebMockDefaults(sg)
+		setupSultanOutputMock(sg)
 		p := new(SultanWebPresenter)
 
 		result := parseSultanOutput(t, p.Output(sg, nil))
@@ -65,7 +73,7 @@ func TestSultanWebPresenter_Output(t *testing.T) {
 
 	t.Run("waste with cards", func(t *testing.T) {
 		sg := new(interfaces.MockSultanGame)
-		setupSultanWebMockDefaults(sg)
+		setupSultanOutputMock(sg)
 		sg.ExpectedCalls = filterCalls(sg.ExpectedCalls, "GetWaste")
 		sg.On("GetWaste").Return([]*domain.Card{domain.NewCard(domain.CardDesignHeart, 5, false)})
 
@@ -78,7 +86,7 @@ func TestSultanWebPresenter_Output(t *testing.T) {
 
 	t.Run("nil divan slot serialised as null", func(t *testing.T) {
 		sg := new(interfaces.MockSultanGame)
-		setupSultanWebMockDefaults(sg)
+		setupSultanOutputMock(sg)
 		sg.ExpectedCalls = filterCalls(sg.ExpectedCalls, "GetDivan")
 		divan := make([]*domain.Card, domain.SultanDivanCnt) // all nil
 		sg.On("GetDivan").Return(divan)
@@ -91,7 +99,7 @@ func TestSultanWebPresenter_Output(t *testing.T) {
 
 	t.Run("redeal available", func(t *testing.T) {
 		sg := new(interfaces.MockSultanGame)
-		setupSultanWebMockDefaults(sg)
+		setupSultanOutputMock(sg)
 		sg.ExpectedCalls = filterCalls(sg.ExpectedCalls, "CanRedeal")
 		sg.On("CanRedeal").Return(true)
 
@@ -102,7 +110,7 @@ func TestSultanWebPresenter_Output(t *testing.T) {
 
 	t.Run("error message", func(t *testing.T) {
 		sg := new(interfaces.MockSultanGame)
-		setupSultanWebMockDefaults(sg)
+		setupSultanOutputMock(sg)
 		p := new(SultanWebPresenter)
 
 		result := parseSultanOutput(t, p.Output(sg, errors.New("test error")))
@@ -111,7 +119,7 @@ func TestSultanWebPresenter_Output(t *testing.T) {
 
 	t.Run("game clear", func(t *testing.T) {
 		sg := new(interfaces.MockSultanGame)
-		setupSultanWebMockDefaults(sg)
+		setupSultanOutputMock(sg)
 		sg.ExpectedCalls = filterCalls(sg.ExpectedCalls, "GetPhase")
 		sg.On("GetPhase").Return(domain.SultanPhaseGameClear)
 
@@ -122,7 +130,7 @@ func TestSultanWebPresenter_Output(t *testing.T) {
 
 	t.Run("game over", func(t *testing.T) {
 		sg := new(interfaces.MockSultanGame)
-		setupSultanWebMockDefaults(sg)
+		setupSultanOutputMock(sg)
 		sg.ExpectedCalls = filterCalls(sg.ExpectedCalls, "GetPhase")
 		sg.On("GetPhase").Return(domain.SultanPhaseGameOver)
 
@@ -133,13 +141,38 @@ func TestSultanWebPresenter_Output(t *testing.T) {
 
 	t.Run("stalemate", func(t *testing.T) {
 		sg := new(interfaces.MockSultanGame)
-		setupSultanWebMockDefaults(sg)
+		setupSultanOutputMock(sg)
 		sg.ExpectedCalls = filterCalls(sg.ExpectedCalls, "IsStalemate")
 		sg.On("IsStalemate").Return(true)
 
 		p := new(SultanWebPresenter)
 		result := parseSultanOutput(t, p.Output(sg, nil))
 		assert.Equal(t, "sultan.stalemate", result.MessageCode)
+	})
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+func TestSultanWebPresenter_OutputCarriesTheHint(t *testing.T) {
+	t.Run("playing", func(t *testing.T) {
+		sug := new(interfaces.MockSultanGame)
+		setupSultanWebMockDefaults(sug)
+		sug.On("GetHint").Return(&domain.SultanHint{FromZone: "divan", FromIdx: 3, ToFoundation: 1}).Maybe()
+
+		result := new(SultanWebPresenter).Output(sug, nil)
+		assert.Contains(t, result, `"hint"`, "Output must carry the hint -- the frontend reads state.hint")
+	})
+
+	// 手詰まりのヒントは出さない。逃げ道の提示は stalemate 用のメッセージが持つ。
+	t.Run("not while stalemate", func(t *testing.T) {
+		sug := new(interfaces.MockSultanGame)
+		setupSultanWebMockDefaults(sug)
+		sug.ExpectedCalls = filterCalls(sug.ExpectedCalls, "IsStalemate")
+		sug.On("IsStalemate").Return(true)
+		sug.On("GetHint").Return(&domain.SultanHint{FromZone: "divan", FromIdx: 3, ToFoundation: 1}).Maybe()
+
+		result := new(SultanWebPresenter).Output(sug, nil)
+		assert.NotContains(t, result, `"hint"`)
 	})
 }
 


### PR DESCRIPTION
## 概要

14 本目。**Black Hole / Napoleon's Square / Sultan**。

Refs #4483

## 生成スクリプトが 2 つ「想定」をやめました

### 1. リテラルの書き方（1 行 / 複数行）

Black Hole は**1 行**で書いています:

```go
resObj.Hint = &controller.BlackHoleWebOutputHint{Fan: hint.Fan}
```

抽出の正規表現が複数行しか見ていなかったので**アサートで止まりました**。両方の形を拾うようにしています。**黙って間違ったゲートを作らなかったので、レビュー 1 往復ではなく 1 反復で済んでいます。**

### 2. 手詰まり判定の有無

ゲート条件も実物から作るようにしました。`{recv}.IsStalemate()` を**プレゼンタが実際に呼んでいるか**を見て、無ければその節を落とします。

**La Belle Lucie / Osmosis / Simple Simon はインタフェースに `IsStalemate` がありません。**ゲートの形が変わるので、この PR には**入れていません**（別バッチで扱います）。

## ヒントの形

| ゲーム | フィールド |
|---|---|
| **Black Hole** | **`Fan` のみ**（移動元・移動先という概念が無い） |
| Napoleon's Square | `FromZone` / `FromCol` / `CardIndex` / `ToZone` / `ToCol` |
| **Sultan** | `FromZone` / **`FromIdx`** / **`ToFoundation`** |

## 既存テスト 4 件が落ちました（ゲートが効いている証拠）

| ファイル | テスト |
|---|---|
| `napoleonssquareFormatter.test.ts` | `shows a tableau hint with the run head` |
| `napoleonssquareFormatter.test.ts` | `renders a waste-to-foundation hint` |
| `sultanFormatter.test.ts` | `renders a divan hint with source index and target` |
| `sultanFormatter.test.ts` | `renders a waste hint source` |

**Black Hole には CLI フォーマッタがありません。**

## 負のコントロール

| 対象 | 結果 |
|---|---|
| Go プレゼンタのゲート 3 本を `if false` | **6 件 FAIL** |
| CLI フォーマッタのゲート 2 本を外す | **2 ファイル FAIL** |

## 確認

- `go test -tags test ./internal/adapter/presenter/ -count=2` green
- `golangci-lint run ./internal/adapter/presenter/` 0 issues
- `bun run check`（11 ガード）/ `typecheck` green

## Test plan

- [ ] CI 全ジョブ green