### PR TITLE
fix(hints): carry the passive hint for La Belle Lucie, Osmosis and Simple Simon (#4483)

### DIFF
--- a/frontend/src/utils/cli/formatters/osmosisFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/osmosisFormatter.test.ts
@@ -45,14 +45,18 @@ describe('formatOsmosisState', () => {
   });
 
   it('shows reserve hint when present', () => {
-    const result = formatOsmosisState(makeState({ hint: { fromZone: 'reserve', fromCol: 2, toCol: 1 } }));
+    const result = formatOsmosisState(
+      makeState({ hint: { fromZone: 'reserve', fromCol: 2, toCol: 1 }, messageCode: 'osmosis.hintAvailable' }),
+    );
     expect(result).toContain('HINT');
     expect(result).toContain('reserve2');
     expect(result).toContain('foundation1');
   });
 
   it('shows waste hint when present', () => {
-    const result = formatOsmosisState(makeState({ hint: { fromZone: 'waste', fromCol: -1, toCol: 0 } }));
+    const result = formatOsmosisState(
+      makeState({ hint: { fromZone: 'waste', fromCol: -1, toCol: 0 }, messageCode: 'osmosis.hintAvailable' }),
+    );
     expect(result).toContain('HINT');
     expect(result).toContain('waste');
   });
@@ -63,5 +67,13 @@ describe('formatOsmosisState', () => {
 
   it('renders message when present', () => {
     expect(formatOsmosisState(makeState({ message: 'No moves available' }))).toContain('No moves available');
+  });
+
+  // **HINT 行は hint を頼んだときだけ。**受動ヒントが Output に載るように
+  // なった (#4483) ので、messageCode で「頼んだ応答か」を見分ける。
+  it('shows the hint only when the hint was requested', () => {
+    const hint = { fromZone: 'reserve', fromCol: 2, toCol: 1 };
+    expect(formatOsmosisState(makeState({ hint, messageCode: 'osmosis.hintAvailable' }))).toContain('HINT');
+    expect(formatOsmosisState(makeState({ hint, messageCode: 'osmosis.playing' }))).not.toContain('HINT');
   });
 });

--- a/frontend/src/utils/cli/formatters/osmosisFormatter.ts
+++ b/frontend/src/utils/cli/formatters/osmosisFormatter.ts
@@ -1,5 +1,5 @@
 import type { OsmosisResponse } from '../../../types/card';
-import { formatCard, formatHeader, formatSeparator } from '../formatterBase';
+import { formatCard, formatHeader, formatSeparator, isRequestedHint } from '../formatterBase';
 
 /** Format an Osmosis game state as terminal text. */
 export function formatOsmosisState(state: OsmosisResponse): string {
@@ -30,7 +30,7 @@ export function formatOsmosisState(state: OsmosisResponse): string {
 
   lines.push(`moves: ${state.moveCount}  undo:${state.canUndo ? 'yes' : 'no'}`);
 
-  if (state.hint) {
+  if (state.hint && isRequestedHint(state)) {
     const from = state.hint.fromZone === 'reserve' ? `reserve${state.hint.fromCol}` : 'waste';
     lines.push(`HINT: ${from} → foundation${state.hint.toCol}`);
   }

--- a/internal/adapter/presenter/LaBelleLucieWebPresenter.go
+++ b/internal/adapter/presenter/LaBelleLucieWebPresenter.go
@@ -20,6 +20,20 @@ func (p *LaBelleLucieWebPresenter) Output(g interfaces.LaBelleLucieGame, lastErr
 	foundation := g.GetFoundation()
 	resObj.Foundation = pilesToOutput(foundation[:])
 
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	// このゲームは手詰まり判定を持たないので、ゲートは進行中かどうかだけ。
+	if g.GetPhase() == domain.LaBelleLuciePhasePlaying {
+		if hint := g.GetHint(); hint != nil {
+			resObj.Hint = &controller.LaBelleLucieWebOutputHint{
+				FromFan:      hint.FromFan,
+				ToFan:        hint.ToFan,
+				ToFoundation: hint.ToFoundation,
+			}
+		}
+	}
+
 	if lastErr != nil {
 		resObj.Message = lastErr.Error()
 	} else {

--- a/internal/adapter/presenter/LaBelleLucieWebPresenter_test.go
+++ b/internal/adapter/presenter/LaBelleLucieWebPresenter_test.go
@@ -35,6 +35,16 @@ func TestLaBelleLucieWebPresenter_Output(t *testing.T) {
 		assert.Contains(t, p.Output(llState(t, `{"ph":2}`), nil), "labellelucie.gameOver")
 	})
 
+	// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+	// レスポンスで、ページの state にはマージされない (#4483)。
+	t.Run("output carries the hint", func(t *testing.T) {
+		// 扇の一番上がスペードのエース。台札を開始できるのでヒントが必ず出る。
+		js := `{"fn":[[{"d":1,"v":1,"w":true}]],"ph":0}`
+		assert.Contains(t, p.Output(llState(t, js), nil), `"hint"`,
+			"Output must carry the hint -- the frontend reads state.hint")
+		assert.NotContains(t, p.Output(llState(t, `{"ph":2}`), nil), `"hint"`)
+	})
+
 	t.Run("hint output", func(t *testing.T) {
 		g := domain.NewDefaultLaBelleLucie()
 		g.Reset()

--- a/internal/adapter/presenter/OsmosisWebPresenter.go
+++ b/internal/adapter/presenter/OsmosisWebPresenter.go
@@ -47,6 +47,20 @@ func (p *OsmosisWebPresenter) Output(o interfaces.OsmosisGame, lastErr error) st
 	}
 
 	// メッセージ
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	// このゲームは手詰まり判定を持たないので、ゲートは進行中かどうかだけ。
+	if o.GetPhase() == domain.OsmosisPhasePlaying {
+		if hint := o.GetHint(); hint != nil {
+			resObj.Hint = &controller.OsmosisWebOutputHint{
+				FromZone: hint.FromZone,
+				FromCol:  hint.FromCol,
+				ToCol:    hint.ToCol,
+			}
+		}
+	}
+
 	if lastErr != nil {
 		resObj.Message = lastErr.Error()
 	} else {

--- a/internal/adapter/presenter/OsmosisWebPresenter_test.go
+++ b/internal/adapter/presenter/OsmosisWebPresenter_test.go
@@ -30,10 +30,18 @@ func setupOsmosisWebMockDefaults(og *interfaces.MockOsmosisGame) {
 	og.On("GetFoundation").Return(foundation).Maybe()
 }
 
+// setupOsmosisOutputMock は Output 用の既定。**Output() も受動ヒントを埋める**ように
+// なった (#4483) ので GetHint を呼べるようにする。共有ヘルパーに置くと、先に
+// 登録されたこの期待が HintOutput テストの「ヒントあり」を食う。
+func setupOsmosisOutputMock(g *interfaces.MockOsmosisGame) {
+	setupOsmosisWebMockDefaults(g)
+	g.On("GetHint").Return(nil).Maybe()
+}
+
 func TestOsmosisWebPresenter_Output(t *testing.T) {
 	t.Run("initial state", func(t *testing.T) {
 		og := new(interfaces.MockOsmosisGame)
-		setupOsmosisWebMockDefaults(og)
+		setupOsmosisOutputMock(og)
 		p := new(OsmosisWebPresenter)
 		result := p.Output(og, nil)
 		assert.Contains(t, result, `"baseRank":7`)
@@ -45,7 +53,7 @@ func TestOsmosisWebPresenter_Output(t *testing.T) {
 
 	t.Run("with error", func(t *testing.T) {
 		og := new(interfaces.MockOsmosisGame)
-		setupOsmosisWebMockDefaults(og)
+		setupOsmosisOutputMock(og)
 		p := new(OsmosisWebPresenter)
 		result := p.Output(og, assert.AnError)
 		assert.Contains(t, result, assert.AnError.Error())
@@ -53,7 +61,7 @@ func TestOsmosisWebPresenter_Output(t *testing.T) {
 
 	t.Run("game clear", func(t *testing.T) {
 		og := new(interfaces.MockOsmosisGame)
-		setupOsmosisWebMockDefaults(og)
+		setupOsmosisOutputMock(og)
 		og.ExpectedCalls = filterCalls(og.ExpectedCalls, "GetPhase")
 		og.On("GetPhase").Return(domain.OsmosisPhaseGameClear)
 		p := new(OsmosisWebPresenter)
@@ -63,7 +71,7 @@ func TestOsmosisWebPresenter_Output(t *testing.T) {
 
 	t.Run("game over", func(t *testing.T) {
 		og := new(interfaces.MockOsmosisGame)
-		setupOsmosisWebMockDefaults(og)
+		setupOsmosisOutputMock(og)
 		og.ExpectedCalls = filterCalls(og.ExpectedCalls, "GetPhase")
 		og.On("GetPhase").Return(domain.OsmosisPhaseGameOver)
 		p := new(OsmosisWebPresenter)
@@ -73,12 +81,37 @@ func TestOsmosisWebPresenter_Output(t *testing.T) {
 
 	t.Run("with waste", func(t *testing.T) {
 		og := new(interfaces.MockOsmosisGame)
-		setupOsmosisWebMockDefaults(og)
+		setupOsmosisOutputMock(og)
 		og.ExpectedCalls = filterCalls(og.ExpectedCalls, "GetWaste")
 		og.On("GetWaste").Return([]*domain.Card{domain.NewCard(domain.CardDesignHeart, 5, false)})
 		p := new(OsmosisWebPresenter)
 		result := p.Output(og, nil)
 		assert.Contains(t, result, `"waste"`)
+	})
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+// このゲームは手詰まり判定を持たないので、ゲートは進行中かどうかだけ。
+func TestOsmosisWebPresenter_OutputCarriesTheHint(t *testing.T) {
+	t.Run("playing", func(t *testing.T) {
+		og := new(interfaces.MockOsmosisGame)
+		setupOsmosisWebMockDefaults(og)
+		og.On("GetHint").Return(&domain.OsmosisHint{FromZone: "reserve", FromCol: 1, ToCol: 2}).Maybe()
+
+		result := new(OsmosisWebPresenter).Output(og, nil)
+		assert.Contains(t, result, `"hint"`, "Output must carry the hint -- the frontend reads state.hint")
+	})
+
+	t.Run("not once cleared", func(t *testing.T) {
+		og := new(interfaces.MockOsmosisGame)
+		setupOsmosisWebMockDefaults(og)
+		og.ExpectedCalls = filterCalls(og.ExpectedCalls, "GetPhase")
+		og.On("GetPhase").Return(domain.OsmosisPhaseGameClear)
+		og.On("GetHint").Return(&domain.OsmosisHint{FromZone: "reserve", FromCol: 1, ToCol: 2}).Maybe()
+
+		result := new(OsmosisWebPresenter).Output(og, nil)
+		assert.NotContains(t, result, `"hint"`)
 	})
 }
 

--- a/internal/adapter/presenter/SimpleSimonWebPresenter.go
+++ b/internal/adapter/presenter/SimpleSimonWebPresenter.go
@@ -19,6 +19,20 @@ func (p *SimpleSimonWebPresenter) Output(g interfaces.SimpleSimonGame, lastErr e
 	cols := g.GetColumns()
 	resObj.Columns = pilesToOutput(cols[:])
 
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	// このゲームは手詰まり判定を持たないので、ゲートは進行中かどうかだけ。
+	if g.GetPhase() == domain.SimpleSimonPhasePlaying {
+		if hint := g.GetHint(); hint != nil {
+			resObj.Hint = &controller.SimpleSimonWebOutputHint{
+				FromCol:   hint.FromCol,
+				CardIndex: hint.CardIndex,
+				ToCol:     hint.ToCol,
+			}
+		}
+	}
+
 	if lastErr != nil {
 		resObj.Message = lastErr.Error()
 	} else {

--- a/internal/adapter/presenter/SimpleSimonWebPresenter_test.go
+++ b/internal/adapter/presenter/SimpleSimonWebPresenter_test.go
@@ -35,6 +35,16 @@ func TestSimpleSimonWebPresenter_Output(t *testing.T) {
 		assert.Contains(t, p.Output(ssState(t, `{"ph":2}`), nil), "simplesimon.gameOver")
 	})
 
+	// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+	// レスポンスで、ページの state にはマージされない (#4483)。
+	t.Run("output carries the hint", func(t *testing.T) {
+		// 9 の上に 8 を重ねられる並び。同スートなので合法手になる。
+		js := `{"co":[[{"d":1,"v":9,"w":true}],[{"d":1,"v":8,"w":true}]],"ph":0}`
+		assert.Contains(t, p.Output(ssState(t, js), nil), `"hint"`,
+			"Output must carry the hint -- the frontend reads state.hint")
+		assert.NotContains(t, p.Output(ssState(t, `{"ph":2}`), nil), `"hint"`)
+	})
+
 	t.Run("hint output", func(t *testing.T) {
 		js := `{"co":[[{"d":1,"v":9,"w":true}],[{"d":1,"v":8,"w":true}]],"ph":0}`
 		assert.Contains(t, p.HintOutput(ssState(t, js)), "simplesimon.hintAvailable")


### PR DESCRIPTION
## 概要

15 本目。**手詰まり判定を一切持たない 3 本** — La Belle Lucie / Osmosis / Simple Simon。

Refs #4483

## ゲートの形が違います

この 3 本は**インタフェースに `IsStalemate` がありません。**ゲートは進行中かどうかだけで、コメントにその理由を書いています。

```go
// このゲームは手詰まり判定を持たないので、ゲートは進行中かどうかだけ。
if g.GetPhase() == domain.SimpleSimonPhasePlaying {
```

生成スクリプトが**プレゼンタが実際に `IsStalemate()` を呼んでいるか**を見るようにしたので、**コードを書く前にこの 3 本を前バッチから切り離せました**（[#4542](https://github.com/yuta-yoshinaga/go_trumpcards/pull/4542) に理由を記載）。「ソリティアなら必ず手詰まり判定がある」は成り立ちません。

## La Belle Lucie の既存ヒントテストは何も確かめていませんでした

```go
g := domain.NewDefaultLaBelleLucie()
g.Reset()
assert.Contains(t, p.HintOutput(g), "labellelucie.")
```

**`labellelucie.` は `hintAvailable` にも `noHint` にも含まれます。**ヒントが返ろうと返るまいと通ります。新しいテストは**扇にスペードのエースを 1 枚だけ**置いた状態を固定しています。

## CLI フォーマッタは 1 本

**La Belle Lucie と Simple Simon には CLI フォーマッタがありません。**Osmosis の既存テスト 2 件が旧挙動を assert していて落ちました。

## 負のコントロール

| 対象 | 結果 |
|---|---|
| Go プレゼンタのゲート 3 本を `if false` | **6 件 FAIL** |
| Osmosis フォーマッタのゲートを外す | **1 件 FAIL** |

## 確認

- `go test -tags test ./internal/adapter/presenter/ -count=2` green
- `golangci-lint run ./internal/adapter/presenter/` 0 issues
- `bun run check`（11 ガード）/ `typecheck` green

## Test plan

- [ ] CI 全ジョブ green