### PR TITLE
fix(hints): carry the passive hint for Aces Up, Baker's Game and Golf (#4483)

### DIFF
--- a/frontend/src/utils/cli/formatters/acesupFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/acesupFormatter.test.ts
@@ -33,13 +33,18 @@ describe('formatAcesUpState', () => {
   });
 
   it('renders stalemate and hint lines', () => {
-    const out = formatAcesUpState({ ...base, isStalemate: true, hint: { type: 'move', col: 2 } });
+    const out = formatAcesUpState({
+      ...base,
+      isStalemate: true,
+      hint: { type: 'move', col: 2 },
+      messageCode: 'acesup.hintAvailable',
+    });
     expect(out).toContain('Stalemate');
     expect(out).toContain('HINT: move col 2');
   });
 
   it('renders draw hint without a column', () => {
-    const out = formatAcesUpState({ ...base, hint: { type: 'draw', col: -1 } });
+    const out = formatAcesUpState({ ...base, hint: { type: 'draw', col: -1 }, messageCode: 'acesup.hintAvailable' });
     expect(out).toContain('HINT: deal');
   });
 
@@ -47,5 +52,13 @@ describe('formatAcesUpState', () => {
     const out = formatAcesUpState({ ...base, phase: 1, message: 'done' });
     expect(out).toContain('Congratulations');
     expect(out).toContain('done');
+  });
+
+  // **HINT 行は hint を頼んだときだけ。**受動ヒントが Output に載るように
+  // なった (#4483) ので、messageCode で「頼んだ応答か」を見分ける。
+  it('shows the hint only when the hint was requested', () => {
+    const state = { ...base, hint: { type: 'move', col: 2 } } satisfies AcesUpResponse;
+    expect(formatAcesUpState({ ...state, messageCode: 'acesup.hintAvailable' })).toContain('HINT:');
+    expect(formatAcesUpState({ ...state, messageCode: 'acesup.playing' })).not.toContain('HINT:');
   });
 });

--- a/frontend/src/utils/cli/formatters/acesupFormatter.ts
+++ b/frontend/src/utils/cli/formatters/acesupFormatter.ts
@@ -1,5 +1,5 @@
 import type { AcesUpResponse } from '../../../types/card';
-import { formatCard, formatHeader, formatSeparator } from '../formatterBase';
+import { formatCard, formatHeader, formatSeparator, isRequestedHint } from '../formatterBase';
 
 /** Format an Aces Up game state as terminal text. */
 export function formatAcesUpState(state: AcesUpResponse): string {
@@ -25,7 +25,7 @@ export function formatAcesUpState(state: AcesUpResponse): string {
   lines.push(`moves: ${state.moveCount}`);
 
   if (state.isStalemate) lines.push('Stalemate - no more moves possible');
-  if (state.hint) {
+  if (state.hint && isRequestedHint(state)) {
     lines.push(state.hint.type === 'draw' ? 'HINT: deal' : `HINT: ${state.hint.type} col ${state.hint.col}`);
   }
   if (state.message) lines.push(state.message);

--- a/frontend/src/utils/cli/formatters/golfFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/golfFormatter.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import type { GolfResponse } from '../../../types/card';
+import { formatGolfState } from './golfFormatter';
+
+function makeState(overrides?: Partial<GolfResponse>): GolfResponse {
+  return {
+    layout: [
+      [{ card: { design: 'SPADE', value: 13 }, removed: false, exposed: true }],
+      [{ card: { design: 'HEART', value: 7 }, removed: false, exposed: false }],
+    ],
+    stockCount: 12,
+    waste: [{ design: 'CLOVER', value: 5 }],
+    phase: 0,
+    moveCount: 6,
+    canUndo: true,
+    isStalemate: false,
+    message: '',
+    ...overrides,
+  };
+}
+
+describe('formatGolfState', () => {
+  it('formats the basic state', () => {
+    const output = formatGolfState(makeState());
+    expect(output).toContain('Golf');
+    expect(output).toContain('stock: 12');
+    expect(output).toContain('moves: 6');
+    expect(output).toContain('[0]');
+  });
+
+  it('hides a card that is not exposed', () => {
+    expect(formatGolfState(makeState())).toContain('??');
+  });
+
+  it('reports a stalemate', () => {
+    expect(formatGolfState(makeState({ isStalemate: true }))).toContain('Stalemate');
+  });
+
+  // **HINT 行は hint を頼んだときだけ。**受動ヒントが Output に載るように
+  // なった (#4483) ので、messageCode で「頼んだ応答か」を見分ける。
+  it('shows the hint only when the hint was requested', () => {
+    const hint = { type: 'remove', col: 1 };
+    expect(formatGolfState(makeState({ hint, messageCode: 'golf.hintAvailable' }))).toContain('HINT: col 1');
+    expect(formatGolfState(makeState({ hint, messageCode: 'golf.playing' }))).not.toContain('HINT:');
+  });
+});

--- a/frontend/src/utils/cli/formatters/golfFormatter.ts
+++ b/frontend/src/utils/cli/formatters/golfFormatter.ts
@@ -1,5 +1,5 @@
 import type { GolfResponse } from '../../../types/card';
-import { formatCard, formatHeader, formatSeparator } from '../formatterBase';
+import { formatCard, formatHeader, formatSeparator, isRequestedHint } from '../formatterBase';
 
 /** Format a Golf Solitaire game state as terminal text. */
 export function formatGolfState(state: GolfResponse): string {
@@ -30,7 +30,7 @@ export function formatGolfState(state: GolfResponse): string {
   lines.push(`moves: ${state.moveCount}`);
 
   if (state.isStalemate) lines.push('Stalemate - no more moves possible');
-  if (state.hint) lines.push(`HINT: col ${state.hint.col}`);
+  if (state.hint && isRequestedHint(state)) lines.push(`HINT: col ${state.hint.col}`);
   if (state.message) lines.push(state.message);
   if (state.phase === 1) lines.push('Congratulations! You win!');
 

--- a/internal/adapter/presenter/AcesUpWebPresenter.go
+++ b/internal/adapter/presenter/AcesUpWebPresenter.go
@@ -22,6 +22,18 @@ func (pr *AcesUpWebPresenter) Output(g interfaces.AcesUpGame, lastErr error) str
 	resObj.DiscardTop = cardToOutput(g.GetDiscardTop())
 	resObj.Columns = acesUpColumns(g)
 
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	if g.GetPhase() == domain.AcesUpPhasePlaying && !g.IsStalemate() {
+		if hint := g.GetHint(); hint != nil {
+			resObj.Hint = &controller.AcesUpWebOutputHint{
+				Type: hint.Type,
+				Col:  hint.Col,
+			}
+		}
+	}
+
 	if lastErr != nil {
 		resObj.Message = lastErr.Error()
 	} else {

--- a/internal/adapter/presenter/AcesUpWebPresenter_test.go
+++ b/internal/adapter/presenter/AcesUpWebPresenter_test.go
@@ -49,9 +49,17 @@ func parseAcesUpOutput(t *testing.T, jsonStr string) *controller.AcesUpWebOutput
 	return &out
 }
 
+// setupAcesUpOutputMock は Output 用の既定。**Output() も受動ヒントを埋める**ように
+// なった (#4483) ので GetHint を呼べるようにする。共有ヘルパーに置くと、先に
+// 登録されたこの期待が HintOutput テストの「ヒントあり」を食う。
+func setupAcesUpOutputMock(g *interfaces.MockAcesUpGame) {
+	setupAcesUpWebMockDefaults(g)
+	g.On("GetHint").Return(nil).Maybe()
+}
+
 func TestAcesUpWebPresenterOutput_Playing(t *testing.T) {
 	g := new(interfaces.MockAcesUpGame)
-	setupAcesUpWebMockDefaults(g)
+	setupAcesUpOutputMock(g)
 	p := &AcesUpWebPresenter{}
 
 	out := parseAcesUpOutput(t, p.Output(g, nil))
@@ -76,7 +84,7 @@ func TestAcesUpWebPresenterOutput_Playing(t *testing.T) {
 
 func TestAcesUpWebPresenterOutput_EmptyDiscard(t *testing.T) {
 	g := new(interfaces.MockAcesUpGame)
-	setupAcesUpWebMockDefaults(g)
+	setupAcesUpOutputMock(g)
 	// Override the discard top to nil (no cards removed yet).
 	g.ExpectedCalls = nil
 	g.On("GetPhase").Return(domain.AcesUpPhasePlaying).Maybe()
@@ -92,6 +100,7 @@ func TestAcesUpWebPresenterOutput_EmptyDiscard(t *testing.T) {
 		g.On("CanRemove", c).Return(false).Maybe()
 		g.On("CanMove", c).Return(false).Maybe()
 	}
+	g.On("GetHint").Return(nil).Maybe()
 	p := &AcesUpWebPresenter{}
 
 	out := parseAcesUpOutput(t, p.Output(g, nil))
@@ -102,7 +111,7 @@ func TestAcesUpWebPresenterOutput_EmptyDiscard(t *testing.T) {
 
 func TestAcesUpWebPresenterOutput_Error(t *testing.T) {
 	g := new(interfaces.MockAcesUpGame)
-	setupAcesUpWebMockDefaults(g)
+	setupAcesUpOutputMock(g)
 	p := &AcesUpWebPresenter{}
 
 	out := parseAcesUpOutput(t, p.Output(g, errors.New("test error")))
@@ -162,6 +171,31 @@ func TestAcesUpWebPresenterOutput_GameOver(t *testing.T) {
 
 	out := parseAcesUpOutput(t, p.Output(g, nil))
 	assert.Equal(t, "acesup.gameOver", out.MessageCode)
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+func TestAcesUpWebPresenterOutputCarriesTheHint(t *testing.T) {
+	t.Run("playing", func(t *testing.T) {
+		aug := new(interfaces.MockAcesUpGame)
+		setupAcesUpWebMockDefaults(aug)
+		aug.On("GetHint").Return(&domain.AcesUpHint{Type: "remove", Col: 1}).Maybe()
+
+		result := new(AcesUpWebPresenter).Output(aug, nil)
+		assert.Contains(t, result, `"hint"`, "Output must carry the hint -- the frontend reads state.hint")
+	})
+
+	// 手詰まりのヒントは出さない。逃げ道の提示は stalemate 用のメッセージが持つ。
+	t.Run("not while stalemate", func(t *testing.T) {
+		aug := new(interfaces.MockAcesUpGame)
+		setupAcesUpWebMockDefaults(aug)
+		aug.ExpectedCalls = filterCalls(aug.ExpectedCalls, "IsStalemate")
+		aug.On("IsStalemate").Return(true)
+		aug.On("GetHint").Return(&domain.AcesUpHint{Type: "remove", Col: 1}).Maybe()
+
+		result := new(AcesUpWebPresenter).Output(aug, nil)
+		assert.NotContains(t, result, `"hint"`)
+	})
 }
 
 func TestAcesUpWebPresenterHintOutput(t *testing.T) {

--- a/internal/adapter/presenter/BakersGameWebPresenter.go
+++ b/internal/adapter/presenter/BakersGameWebPresenter.go
@@ -51,6 +51,21 @@ func (p *BakersGameWebPresenter) Output(f interfaces.FreeCellGame, lastErr error
 	}
 
 	// メッセージ
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	if f.GetPhase() == domain.FreeCellPhasePlaying && !f.IsStalemate() {
+		if hint := f.GetHint(); hint != nil {
+			resObj.Hint = &controller.FreeCellWebOutputHint{
+				FromZone:  hint.FromZone,
+				FromCol:   hint.FromCol,
+				CardIndex: hint.CardIndex,
+				ToZone:    hint.ToZone,
+				ToCol:     hint.ToCol,
+			}
+		}
+	}
+
 	if lastErr != nil {
 		resObj.Message = lastErr.Error()
 	} else {

--- a/internal/adapter/presenter/BakersGameWebPresenter_test.go
+++ b/internal/adapter/presenter/BakersGameWebPresenter_test.go
@@ -109,6 +109,37 @@ func TestBakersGameWebPresenterOutputError(t *testing.T) {
 	assert.Contains(t, out.Message, "test error")
 }
 
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+// **フェーズ定数は FreeCell のもの。**Baker's Game は FreeCell の派生で、
+// 自分の名前のフェーズ定数を持たない。
+func TestBakersGameWebPresenterOutputCarriesTheHint(t *testing.T) {
+	t.Run("playing", func(t *testing.T) {
+		f := domain.NewDefaultBakersGame()
+		f.Reset()
+		f.SetPhase(domain.FreeCellPhasePlaying)
+
+		// **配りに依存させない。**SetTableau で場を丸ごと置き換える。
+		var tableau [domain.FreeCellTableauCnt][]*domain.Card
+		tableau[0] = []*domain.Card{domain.NewCard(domain.CardDesignSpade, 1, false)}
+		f.SetTableau(tableau)
+
+		var out controller.FreeCellWebOutput
+		assert.NoError(t, json.Unmarshal([]byte(new(BakersGameWebPresenter).Output(f, nil)), &out))
+		assert.NotNil(t, out.Hint, "Output must carry the hint -- the frontend reads state.hint")
+	})
+
+	t.Run("not while cleared", func(t *testing.T) {
+		f := domain.NewDefaultBakersGame()
+		f.Reset()
+		f.SetPhase(domain.FreeCellPhaseGameClear)
+
+		var out controller.FreeCellWebOutput
+		assert.NoError(t, json.Unmarshal([]byte(new(BakersGameWebPresenter).Output(f, nil)), &out))
+		assert.Nil(t, out.Hint)
+	})
+}
+
 func TestBakersGameWebPresenterHintOutputWithHint(t *testing.T) {
 	p := new(BakersGameWebPresenter)
 	f := domain.NewDefaultBakersGame()

--- a/internal/adapter/presenter/GolfWebPresenter.go
+++ b/internal/adapter/presenter/GolfWebPresenter.go
@@ -52,6 +52,18 @@ func (pr *GolfWebPresenter) Output(g interfaces.GolfGame, lastErr error) string 
 	}
 
 	// メッセージ
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	if g.GetPhase() == domain.GolfPhasePlaying && !g.IsStalemate() {
+		if hint := g.GetHint(); hint != nil {
+			resObj.Hint = &controller.GolfWebOutputHint{
+				Type: hint.Type,
+				Col:  hint.Col,
+			}
+		}
+	}
+
 	if lastErr != nil {
 		resObj.Message = lastErr.Error()
 	} else {

--- a/internal/adapter/presenter/GolfWebPresenter_test.go
+++ b/internal/adapter/presenter/GolfWebPresenter_test.go
@@ -53,9 +53,17 @@ func parseGolfOutput(t *testing.T, jsonStr string) *controller.GolfWebOutput {
 	return &out
 }
 
+// setupGolfOutputMock は Output 用の既定。**Output() も受動ヒントを埋める**ように
+// なった (#4483) ので GetHint を呼べるようにする。共有ヘルパーに置くと、先に
+// 登録されたこの期待が HintOutput テストの「ヒントあり」を食う。
+func setupGolfOutputMock(g *interfaces.MockGolfGame) {
+	setupGolfWebMockDefaults(g)
+	g.On("GetHint").Return(nil).Maybe()
+}
+
 func TestGolfWebPresenterOutput_Playing(t *testing.T) {
 	gg := new(interfaces.MockGolfGame)
-	setupGolfWebMockDefaults(gg)
+	setupGolfOutputMock(gg)
 	p := &GolfWebPresenter{}
 
 	result := p.Output(gg, nil)
@@ -69,7 +77,7 @@ func TestGolfWebPresenterOutput_Playing(t *testing.T) {
 
 func TestGolfWebPresenterOutput_Error(t *testing.T) {
 	gg := new(interfaces.MockGolfGame)
-	setupGolfWebMockDefaults(gg)
+	setupGolfOutputMock(gg)
 	p := &GolfWebPresenter{}
 
 	result := p.Output(gg, errors.New("test error"))
@@ -80,7 +88,7 @@ func TestGolfWebPresenterOutput_Error(t *testing.T) {
 
 func TestGolfWebPresenterOutput_Stalemate(t *testing.T) {
 	gg := new(interfaces.MockGolfGame)
-	setupGolfWebMockDefaults(gg)
+	setupGolfOutputMock(gg)
 	gg.ExpectedCalls = nil
 	gg.On("GetPhase").Return(domain.GolfPhasePlaying).Maybe()
 	gg.On("GetMoveCount").Return(5).Maybe()
@@ -106,7 +114,7 @@ func TestGolfWebPresenterOutput_Stalemate(t *testing.T) {
 
 func TestGolfWebPresenterOutput_GameClear(t *testing.T) {
 	gg := new(interfaces.MockGolfGame)
-	setupGolfWebMockDefaults(gg)
+	setupGolfOutputMock(gg)
 	gg.ExpectedCalls = nil
 	gg.On("GetPhase").Return(domain.GolfPhaseGameClear).Maybe()
 	gg.On("GetMoveCount").Return(10).Maybe()
@@ -133,7 +141,7 @@ func TestGolfWebPresenterOutput_GameClear(t *testing.T) {
 
 func TestGolfWebPresenterOutput_GameOver(t *testing.T) {
 	gg := new(interfaces.MockGolfGame)
-	setupGolfWebMockDefaults(gg)
+	setupGolfOutputMock(gg)
 	gg.ExpectedCalls = nil
 	gg.On("GetPhase").Return(domain.GolfPhaseGameOver).Maybe()
 	gg.On("GetMoveCount").Return(5).Maybe()
@@ -155,6 +163,31 @@ func TestGolfWebPresenterOutput_GameOver(t *testing.T) {
 	out := parseGolfOutput(t, result)
 
 	assert.Equal(t, "golf.gameOver", out.MessageCode)
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+func TestGolfWebPresenterOutputCarriesTheHint(t *testing.T) {
+	t.Run("playing", func(t *testing.T) {
+		glg := new(interfaces.MockGolfGame)
+		setupGolfWebMockDefaults(glg)
+		glg.On("GetHint").Return(&domain.GolfHint{Type: "remove", Col: 2}).Maybe()
+
+		result := new(GolfWebPresenter).Output(glg, nil)
+		assert.Contains(t, result, `"hint"`, "Output must carry the hint -- the frontend reads state.hint")
+	})
+
+	// 手詰まりのヒントは出さない。逃げ道の提示は stalemate 用のメッセージが持つ。
+	t.Run("not while stalemate", func(t *testing.T) {
+		glg := new(interfaces.MockGolfGame)
+		setupGolfWebMockDefaults(glg)
+		glg.ExpectedCalls = filterCalls(glg.ExpectedCalls, "IsStalemate")
+		glg.On("IsStalemate").Return(true)
+		glg.On("GetHint").Return(&domain.GolfHint{Type: "remove", Col: 2}).Maybe()
+
+		result := new(GolfWebPresenter).Output(glg, nil)
+		assert.NotContains(t, result, `"hint"`)
+	})
 }
 
 func TestGolfWebPresenterHintOutput(t *testing.T) {


### PR DESCRIPTION
## 概要

16 本目。**Aces Up / Baker's Game / Golf**。生成スクリプトから**決め打ちを 3 つ**外しました。

Refs #4483

## 1. 受信者名 — これが進捗の数字を狂わせていた原因です

`func (p *XWebPresenter)` と決め打ちしていましたが、**Aces Up / Golf / Gaps は `pr`** です。

生成側はマッチしなければ**例外で止まる**ので実害はありませんでした。壊れていたのは**数える側**で、実装済みの Gaps を「未実装」と数えていました。[#4483 に訂正を投稿済み](https://github.com/yuta-yoshinaga/go_trumpcards/issues/4483#issuecomment-5151773370)。

## 2. フェーズ定数 — ゲーム名から作れません

**Baker's Game には `BakersGamePhasePlaying` が存在しません。**FreeCell の派生で、`domain.FreeCellPhasePlaying` を使います。

```go
if f.GetPhase() == domain.FreeCellPhasePlaying && !f.IsStalemate() {
```

これは**ビルドが落ちて**気づきました。ただし「2 つある有効な定数のうち間違ったほう」を選んでいたら**ビルドは通ります。**定数はプレゼンタ自身の `switch` から拾うようにしました。

## 3. 共有ヘルパーを通らない Output テストがある

`TestAcesUpWebPresenterOutput_EmptyDiscard` は mock を**直に組んでいて**、`setupAcesUpWebMockDefaults` を通りません。個別に `GetHint` の期待が要りました。

## typecheck で 1 件

`AcesUpHint.type` は **`'remove' | 'move' | 'draw'` のリテラル型**です。フィクスチャを `const` に切り出すと `string` に広がって TS2322。その場に置いています。

## CLI フォーマッタ

| ゲーム | 状況 |
|---|---|
| Aces Up | 既存テスト 2 件が旧挙動を assert していて FAIL → 修正 |
| **Golf** | **波括弧なしの 1 行形式**。**テストファイルが無かった**ので新規作成 |
| Baker's Game | フォーマッタ自体が無い |

## 負のコントロール

| 対象 | 結果 |
|---|---|
| Go プレゼンタのゲート 3 本を `if false` | **6 件 FAIL** |
| CLI フォーマッタのゲート 2 本を外す | **2 ファイル FAIL** |

## 確認

- `go test -tags test ./internal/adapter/presenter/ -count=2` green
- `golangci-lint run ./internal/adapter/presenter/` 0 issues
- `bun run check`（11 ガード）/ `typecheck` green

## Test plan

- [ ] CI 全ジョブ green