### PR TITLE
fix(hints): carry the passive hint for Monte Carlo, Nertz and Pyramid (#4483)

### DIFF
--- a/frontend/src/utils/cli/formatters/nertzFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/nertzFormatter.test.ts
@@ -78,6 +78,7 @@ describe('formatNertzState', () => {
     const result = formatNertzState(
       makeState({
         hint: { fromZone: 'tableau', fromCol: 0, cardIndex: 1, toZone: 'foundation', toCol: 2 },
+        messageCode: 'nertz.hintAvailable',
       }),
     );
     expect(result).toContain('HINT');
@@ -179,5 +180,13 @@ describe('formatNertzState', () => {
   it('renders message when present', () => {
     const result = formatNertzState(makeState({ message: 'You drew a card' }));
     expect(result).toContain('You drew a card');
+  });
+
+  // **HINT 行は hint を頼んだときだけ。**受動ヒントが Output に載るように
+  // なった (#4483) ので、messageCode で「頼んだ応答か」を見分ける。
+  it('shows the hint only when the hint was requested', () => {
+    const hint = { fromZone: 'tableau', fromCol: 0, cardIndex: 1, toZone: 'foundation', toCol: 2 };
+    expect(formatNertzState(makeState({ hint, messageCode: 'nertz.hintAvailable' }))).toContain('HINT');
+    expect(formatNertzState(makeState({ hint, messageCode: 'nertz.playing' }))).not.toContain('HINT');
   });
 });

--- a/frontend/src/utils/cli/formatters/nertzFormatter.ts
+++ b/frontend/src/utils/cli/formatters/nertzFormatter.ts
@@ -1,5 +1,5 @@
 import type { NertzResponse } from '../../../types/card';
-import { formatCard, formatHeader, formatSeparator } from '../formatterBase';
+import { formatCard, formatHeader, formatSeparator, isRequestedHint } from '../formatterBase';
 
 const PHASE_NAMES: Record<number, string> = {
   0: 'INIT',
@@ -45,7 +45,7 @@ export function formatNertzState(state: NertzResponse): string {
 
   lines.push(`moves: ${state.moveCount}  undo:${state.canUndo ? 'yes' : 'no'}`);
 
-  if (state.hint) {
+  if (state.hint && isRequestedHint(state)) {
     const fromCol = state.hint.fromCol >= 0 ? state.hint.fromCol : '';
     const toCol = state.hint.toCol >= 0 ? state.hint.toCol : '';
     lines.push(`HINT: ${state.hint.fromZone}${fromCol}[${state.hint.cardIndex}] → ${state.hint.toZone}${toCol}`);

--- a/frontend/src/utils/cli/formatters/pyramidFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/pyramidFormatter.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import type { PyramidResponse } from '../../../types/card';
+import { formatPyramidState } from './pyramidFormatter';
+
+function makeState(overrides?: Partial<PyramidResponse>): PyramidResponse {
+  return {
+    pyramid: [
+      [{ card: { design: 'SPADE', value: 1 }, removed: false, exposed: false }],
+      [
+        { card: { design: 'HEART', value: 6 }, removed: false, exposed: true },
+        { card: { design: 'CLOVER', value: 7 }, removed: true, exposed: true },
+      ],
+    ],
+    stockCount: 20,
+    waste: [{ design: 'DIAMOND', value: 4 }],
+    phase: 0,
+    moveCount: 8,
+    canUndo: true,
+    isStalemate: false,
+    message: '',
+    ...overrides,
+  };
+}
+
+describe('formatPyramidState', () => {
+  it('formats the basic state', () => {
+    const output = formatPyramidState(makeState());
+    expect(output).toContain('Pyramid');
+    expect(output).toContain('stock: 20');
+    expect(output).toContain('moves: 8');
+  });
+
+  it('hides a card that is not exposed', () => {
+    expect(formatPyramidState(makeState())).toContain('??');
+  });
+
+  it('reports a stalemate', () => {
+    expect(formatPyramidState(makeState({ isStalemate: true }))).toContain('Stalemate');
+  });
+
+  // **HINT 行は hint を頼んだときだけ。**受動ヒントが Output に載るように
+  // なった (#4483) ので、messageCode で「頼んだ応答か」を見分ける。
+  it('shows the hint only when the hint was requested', () => {
+    const hint = { type: 'pair', row1: 1, col1: 0, row2: 1, col2: 1 };
+    expect(formatPyramidState(makeState({ hint, messageCode: 'pyramid.hintAvailable' }))).toContain('HINT: (1,0)');
+    expect(formatPyramidState(makeState({ hint, messageCode: 'pyramid.playing' }))).not.toContain('HINT:');
+  });
+});

--- a/frontend/src/utils/cli/formatters/pyramidFormatter.ts
+++ b/frontend/src/utils/cli/formatters/pyramidFormatter.ts
@@ -1,5 +1,5 @@
 import type { PyramidResponse } from '../../../types/card';
-import { formatCard, formatHeader, formatSeparator } from '../formatterBase';
+import { formatCard, formatHeader, formatSeparator, isRequestedHint } from '../formatterBase';
 
 /** Format a Pyramid Solitaire game state as terminal text. */
 export function formatPyramidState(state: PyramidResponse): string {
@@ -26,7 +26,8 @@ export function formatPyramidState(state: PyramidResponse): string {
   lines.push(`moves: ${state.moveCount}`);
 
   if (state.isStalemate) lines.push('Stalemate - no more moves possible');
-  if (state.hint) lines.push(`HINT: (${state.hint.row1},${state.hint.col1}) + (${state.hint.row2},${state.hint.col2})`);
+  if (state.hint && isRequestedHint(state))
+    lines.push(`HINT: (${state.hint.row1},${state.hint.col1}) + (${state.hint.row2},${state.hint.col2})`);
   if (state.message) lines.push(state.message);
   if (state.phase === 1) lines.push('Congratulations! You win!');
 

--- a/internal/adapter/presenter/MonteCarloWebPresenter.go
+++ b/internal/adapter/presenter/MonteCarloWebPresenter.go
@@ -17,6 +17,21 @@ type MonteCarloWebPresenter struct{}
 func (pr *MonteCarloWebPresenter) Output(g interfaces.MonteCarloGame, lastErr error) string {
 	resObj := pr.buildBase(g)
 
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	if g.GetPhase() == domain.MonteCarloPhasePlaying && !g.IsStalemate() {
+		if hint := g.Hint(); hint != nil {
+			resObj.Hint = &controller.MonteCarloWebOutputHint{
+				Action: hint.Action,
+				FromR:  hint.FromR,
+				FromC:  hint.FromC,
+				ToR:    hint.ToR,
+				ToC:    hint.ToC,
+			}
+		}
+	}
+
 	if lastErr != nil {
 		resObj.Message = lastErr.Error()
 	} else {

--- a/internal/adapter/presenter/MonteCarloWebPresenter_test.go
+++ b/internal/adapter/presenter/MonteCarloWebPresenter_test.go
@@ -33,9 +33,17 @@ func parseMonteCarloOutput(t *testing.T, s string) *controller.MonteCarloWebOutp
 	return &out
 }
 
+// setupMonteCarloOutputMock は Output 用の既定。**Output() も受動ヒントを埋める**ように
+// なった (#4483) ので Hint を呼べるようにする。共有ヘルパーに置くと、先に
+// 登録されたこの期待が HintOutput テストの「ヒントあり」を食う。
+func setupMonteCarloOutputMock(g *interfaces.MockMonteCarloGame) {
+	setupMonteCarloWebMockDefaults(g)
+	g.On("Hint").Return(nil).Maybe()
+}
+
 func TestMonteCarloWebPresenter_Output_Playing(t *testing.T) {
 	g := new(interfaces.MockMonteCarloGame)
-	setupMonteCarloWebMockDefaults(g)
+	setupMonteCarloOutputMock(g)
 	p := &MonteCarloWebPresenter{}
 	out := parseMonteCarloOutput(t, p.Output(g, nil))
 
@@ -55,6 +63,7 @@ func TestMonteCarloWebPresenter_Output_PlayingStalemate(t *testing.T) {
 	g.On("IsStalemate").Return(true).Maybe()
 	var board [domain.MonteCarloGridSize][domain.MonteCarloGridSize]*domain.Card
 	g.On("GetBoard").Return(board).Maybe()
+	g.On("Hint").Return(nil).Maybe()
 
 	p := &MonteCarloWebPresenter{}
 	out := parseMonteCarloOutput(t, p.Output(g, nil))
@@ -72,6 +81,7 @@ func TestMonteCarloWebPresenter_Output_GameClear(t *testing.T) {
 	g.On("IsStalemate").Return(false).Maybe()
 	var board [domain.MonteCarloGridSize][domain.MonteCarloGridSize]*domain.Card
 	g.On("GetBoard").Return(board).Maybe()
+	g.On("Hint").Return(nil).Maybe()
 
 	p := &MonteCarloWebPresenter{}
 	out := parseMonteCarloOutput(t, p.Output(g, nil))
@@ -90,6 +100,7 @@ func TestMonteCarloWebPresenter_Output_GameOver(t *testing.T) {
 	g.On("IsStalemate").Return(false).Maybe()
 	var board [domain.MonteCarloGridSize][domain.MonteCarloGridSize]*domain.Card
 	g.On("GetBoard").Return(board).Maybe()
+	g.On("Hint").Return(nil).Maybe()
 
 	p := &MonteCarloWebPresenter{}
 	out := parseMonteCarloOutput(t, p.Output(g, nil))
@@ -98,7 +109,7 @@ func TestMonteCarloWebPresenter_Output_GameOver(t *testing.T) {
 
 func TestMonteCarloWebPresenter_Output_Error(t *testing.T) {
 	g := new(interfaces.MockMonteCarloGame)
-	setupMonteCarloWebMockDefaults(g)
+	setupMonteCarloOutputMock(g)
 	p := &MonteCarloWebPresenter{}
 	out := parseMonteCarloOutput(t, p.Output(g, errors.New("boom")))
 	assert.Equal(t, "boom", out.Message)
@@ -115,11 +126,36 @@ func TestMonteCarloWebPresenter_Output_BoardWithCard(t *testing.T) {
 	var board [domain.MonteCarloGridSize][domain.MonteCarloGridSize]*domain.Card
 	board[0][0] = domain.NewCard(domain.CardDesignSpade, 7, false)
 	g.On("GetBoard").Return(board).Maybe()
+	g.On("Hint").Return(nil).Maybe()
 
 	p := &MonteCarloWebPresenter{}
 	out := parseMonteCarloOutput(t, p.Output(g, nil))
 	assert.NotNil(t, out.Board[0][0].Card)
 	assert.Nil(t, out.Board[0][1].Card)
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+func TestMonteCarloWebPresenterOutputCarriesTheHint(t *testing.T) {
+	t.Run("playing", func(t *testing.T) {
+		mcg := new(interfaces.MockMonteCarloGame)
+		setupMonteCarloWebMockDefaults(mcg)
+		mcg.On("Hint").Return(&domain.MonteCarloHint{Action: "remove", FromR: 0, FromC: 1, ToR: 1, ToC: 2}).Maybe()
+
+		result := new(MonteCarloWebPresenter).Output(mcg, nil)
+		assert.Contains(t, result, `"hint"`, "Output must carry the hint -- the frontend reads state.hint")
+	})
+
+	t.Run("not while stalemate", func(t *testing.T) {
+		mcg := new(interfaces.MockMonteCarloGame)
+		setupMonteCarloWebMockDefaults(mcg)
+		mcg.ExpectedCalls = filterCalls(mcg.ExpectedCalls, "IsStalemate")
+		mcg.On("IsStalemate").Return(true)
+		mcg.On("Hint").Return(&domain.MonteCarloHint{Action: "remove", FromR: 0, FromC: 1, ToR: 1, ToC: 2}).Maybe()
+
+		result := new(MonteCarloWebPresenter).Output(mcg, nil)
+		assert.NotContains(t, result, `"hint"`)
+	})
 }
 
 func TestMonteCarloWebPresenter_HintOutput_Remove(t *testing.T) {

--- a/internal/adapter/presenter/NertzWebPresenter.go
+++ b/internal/adapter/presenter/NertzWebPresenter.go
@@ -14,6 +14,22 @@ type NertzWebPresenter struct{}
 // Output ゲーム状態を JSON 出力
 func (p *NertzWebPresenter) Output(g interfaces.NertzGame, lastErr error) string {
 	resObj := p.buildBase(g)
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	// このゲームは手詰まり判定を持たないので、ゲートは進行中かどうかだけ。
+	if g.GetPhase() == domain.NertzPhasePlaying {
+		if hint := g.GetHint(); hint != nil {
+			resObj.Hint = &controller.NertzWebHint{
+				FromZone:  hint.FromZone,
+				FromCol:   hint.FromCol,
+				CardIndex: hint.CardIndex,
+				ToZone:    hint.ToZone,
+				ToCol:     hint.ToCol,
+			}
+		}
+	}
+
 	if lastErr != nil {
 		resObj.Message = lastErr.Error()
 	} else {

--- a/internal/adapter/presenter/NertzWebPresenter_test.go
+++ b/internal/adapter/presenter/NertzWebPresenter_test.go
@@ -54,10 +54,18 @@ func decodeNertzWebOutput(t *testing.T, raw string) *controller.NertzWebOutput {
 	return &out
 }
 
+// setupNertzOutputMock は Output 用の既定。**Output() も受動ヒントを埋める**ように
+// なった (#4483) ので GetHint を呼べるようにする。共有ヘルパーに置くと、先に
+// 登録されたこの期待が HintOutput テストの「ヒントあり」を食う。
+func setupNertzOutputMock(g *interfaces.MockNertzGame) {
+	setupNertzWebMockDefaults(g)
+	g.On("GetHint").Return(nil).Maybe()
+}
+
 func TestNertzWebPresenter_Output(t *testing.T) {
 	t.Run("playing", func(t *testing.T) {
 		g := new(interfaces.MockNertzGame)
-		setupNertzWebMockDefaults(g)
+		setupNertzOutputMock(g)
 		raw := new(NertzWebPresenter).Output(g, nil)
 		out := decodeNertzWebOutput(t, raw)
 		assert.Equal(t, "nertz.playing", out.MessageCode)
@@ -80,7 +88,7 @@ func TestNertzWebPresenter_Output(t *testing.T) {
 	// in the public API contract. See issue #1532.
 	t.Run("JSON shape uses isHuman / roundNumber", func(t *testing.T) {
 		g := new(interfaces.MockNertzGame)
-		setupNertzWebMockDefaults(g)
+		setupNertzOutputMock(g)
 		raw := new(NertzWebPresenter).Output(g, nil)
 		// New canonical names must appear.
 		assert.Contains(t, raw, `"roundNumber":`, "JSON output must use roundNumber")
@@ -92,7 +100,7 @@ func TestNertzWebPresenter_Output(t *testing.T) {
 
 	t.Run("with error", func(t *testing.T) {
 		g := new(interfaces.MockNertzGame)
-		setupNertzWebMockDefaults(g)
+		setupNertzOutputMock(g)
 		raw := new(NertzWebPresenter).Output(g, assert.AnError)
 		out := decodeNertzWebOutput(t, raw)
 		assert.Equal(t, assert.AnError.Error(), out.Message)
@@ -158,11 +166,36 @@ func TestNertzWebPresenter_Output(t *testing.T) {
 		g.On("GetConfig").Return(domain.DefaultNertzConfig()).Maybe()
 		g.On("GetPlayers").Return([]*domain.NertzPlayer{nil}).Maybe()
 		g.On("GetFoundations").Return([]*domain.NertzFoundation{nil}).Maybe()
+		g.On("GetHint").Return(nil).Maybe()
 		raw := new(NertzWebPresenter).Output(g, nil)
 		out := decodeNertzWebOutput(t, raw)
 		assert.Empty(t, out.Players)
 		require.Len(t, out.Foundations, 1)
 		assert.Equal(t, -1, out.Foundations[0].Suit)
+	})
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+func TestNertzWebPresenterOutputCarriesTheHint(t *testing.T) {
+	t.Run("playing", func(t *testing.T) {
+		ntg := new(interfaces.MockNertzGame)
+		setupNertzWebMockDefaults(ntg)
+		ntg.On("GetHint").Return(&domain.NertzHint{FromZone: "waste", FromCol: -1, CardIndex: -1, ToZone: "foundation", ToCol: 2}).Maybe()
+
+		result := new(NertzWebPresenter).Output(ntg, nil)
+		assert.Contains(t, result, `"hint"`, "Output must carry the hint -- the frontend reads state.hint")
+	})
+
+	t.Run("not once the game has ended", func(t *testing.T) {
+		ntg := new(interfaces.MockNertzGame)
+		setupNertzWebMockDefaults(ntg)
+		ntg.ExpectedCalls = filterCalls(ntg.ExpectedCalls, "GetPhase")
+		ntg.On("GetPhase").Return(domain.NertzPhaseGameEnd)
+		ntg.On("GetHint").Return(&domain.NertzHint{FromZone: "waste", FromCol: -1, CardIndex: -1, ToZone: "foundation", ToCol: 2}).Maybe()
+
+		result := new(NertzWebPresenter).Output(ntg, nil)
+		assert.NotContains(t, result, `"hint"`)
 	})
 }
 

--- a/internal/adapter/presenter/PyramidWebPresenter.go
+++ b/internal/adapter/presenter/PyramidWebPresenter.go
@@ -49,6 +49,21 @@ func (pr *PyramidWebPresenter) Output(p interfaces.PyramidGame, lastErr error) s
 	}
 
 	// メッセージ
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	if p.GetPhase() == domain.PyramidPhasePlaying && !p.IsStalemate() {
+		if hint := p.GetHint(); hint != nil {
+			resObj.Hint = &controller.PyramidWebOutputHint{
+				Type: hint.Type,
+				Row1: hint.Row1,
+				Col1: hint.Col1,
+				Row2: hint.Row2,
+				Col2: hint.Col2,
+			}
+		}
+	}
+
 	if lastErr != nil {
 		resObj.Message = lastErr.Error()
 	} else {

--- a/internal/adapter/presenter/PyramidWebPresenter_test.go
+++ b/internal/adapter/presenter/PyramidWebPresenter_test.go
@@ -55,9 +55,17 @@ func parsePyramidOutput(t *testing.T, jsonStr string) *controller.PyramidWebOutp
 	return &out
 }
 
+// setupPyramidOutputMock は Output 用の既定。**Output() も受動ヒントを埋める**ように
+// なった (#4483) ので GetHint を呼べるようにする。共有ヘルパーに置くと、先に
+// 登録されたこの期待が HintOutput テストの「ヒントあり」を食う。
+func setupPyramidOutputMock(g *interfaces.MockPyramidGame) {
+	setupPyramidWebMockDefaults(g)
+	g.On("GetHint").Return(nil).Maybe()
+}
+
 func TestPyramidWebPresenterOutput_Playing(t *testing.T) {
 	pg := new(interfaces.MockPyramidGame)
-	setupPyramidWebMockDefaults(pg)
+	setupPyramidOutputMock(pg)
 	p := &PyramidWebPresenter{}
 
 	result := p.Output(pg, nil)
@@ -71,7 +79,7 @@ func TestPyramidWebPresenterOutput_Playing(t *testing.T) {
 
 func TestPyramidWebPresenterOutput_Error(t *testing.T) {
 	pg := new(interfaces.MockPyramidGame)
-	setupPyramidWebMockDefaults(pg)
+	setupPyramidOutputMock(pg)
 	p := &PyramidWebPresenter{}
 
 	result := p.Output(pg, errors.New("test error"))
@@ -82,7 +90,7 @@ func TestPyramidWebPresenterOutput_Error(t *testing.T) {
 
 func TestPyramidWebPresenterOutput_GameClear(t *testing.T) {
 	pg := new(interfaces.MockPyramidGame)
-	setupPyramidWebMockDefaults(pg)
+	setupPyramidOutputMock(pg)
 	pg.ExpectedCalls = nil
 	pg.On("GetPhase").Return(domain.PyramidPhaseGameClear).Maybe()
 	pg.On("GetMoveCount").Return(10).Maybe()
@@ -91,6 +99,7 @@ func TestPyramidWebPresenterOutput_GameClear(t *testing.T) {
 	pg.On("CanUndo").Return(false).Maybe()
 	pg.On("IsStalemate").Return(false).Maybe()
 	pg.On("UndoToEscape").Return(0).Maybe()
+	pg.On("GetHint").Return(nil).Maybe()
 
 	var pyramid [domain.PyramidRowCnt][]*domain.PyramidCard
 	for row := range domain.PyramidRowCnt {
@@ -120,7 +129,7 @@ func TestPyramidWebPresenterOutput_GameClear(t *testing.T) {
 
 func TestPyramidWebPresenterOutput_GameOver(t *testing.T) {
 	pg := new(interfaces.MockPyramidGame)
-	setupPyramidWebMockDefaults(pg)
+	setupPyramidOutputMock(pg)
 	pg.ExpectedCalls = nil
 	pg.On("GetPhase").Return(domain.PyramidPhaseGameOver).Maybe()
 	pg.On("GetMoveCount").Return(5).Maybe()
@@ -154,7 +163,7 @@ func TestPyramidWebPresenterOutput_GameOver(t *testing.T) {
 
 func TestPyramidWebPresenterOutput_Stalemate(t *testing.T) {
 	pg := new(interfaces.MockPyramidGame)
-	setupPyramidWebMockDefaults(pg)
+	setupPyramidOutputMock(pg)
 	pg.ExpectedCalls = nil
 	pg.On("GetPhase").Return(domain.PyramidPhasePlaying).Maybe()
 	pg.On("GetMoveCount").Return(5).Maybe()
@@ -183,6 +192,30 @@ func TestPyramidWebPresenterOutput_Stalemate(t *testing.T) {
 	out := parsePyramidOutput(t, result)
 
 	assert.Equal(t, "pyramid.stalemate", out.MessageCode)
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+func TestPyramidWebPresenterOutputCarriesTheHint(t *testing.T) {
+	t.Run("playing", func(t *testing.T) {
+		pyg := new(interfaces.MockPyramidGame)
+		setupPyramidWebMockDefaults(pyg)
+		pyg.On("GetHint").Return(&domain.PyramidHint{Type: "pair", Row1: 3, Col1: 0, Row2: 3, Col2: 1}).Maybe()
+
+		result := new(PyramidWebPresenter).Output(pyg, nil)
+		assert.Contains(t, result, `"hint"`, "Output must carry the hint -- the frontend reads state.hint")
+	})
+
+	t.Run("not while stalemate", func(t *testing.T) {
+		pyg := new(interfaces.MockPyramidGame)
+		setupPyramidWebMockDefaults(pyg)
+		pyg.ExpectedCalls = filterCalls(pyg.ExpectedCalls, "IsStalemate")
+		pyg.On("IsStalemate").Return(true)
+		pyg.On("GetHint").Return(&domain.PyramidHint{Type: "pair", Row1: 3, Col1: 0, Row2: 3, Col2: 1}).Maybe()
+
+		result := new(PyramidWebPresenter).Output(pyg, nil)
+		assert.NotContains(t, result, `"hint"`)
+	})
 }
 
 func TestPyramidWebPresenterHintOutput_WithHint(t *testing.T) {


### PR DESCRIPTION
## 概要

17 本目。**Monte Carlo / Nertz / Pyramid**。

Refs #4483

## 負のコントロールが自分自身を捕まえました

Pyramid のヒント行は**波括弧なしの 1 行**でしたが、**biome が 2 行に折り返していました。**負のコントロールが置換しようとした文字列はもう存在せず、**黙って何もせずに「pass」を報告していました。**

```
 Test Files  1 failed | 1 passed (2)   ← 2 本壊したのに 1 本しか鳴らない
```

**ガードを壊したのに鳴らないのを、鳴ったと勘違いしかけました。**負のコントロールも、**生成スクリプトと同じく「ファイルが実際に変わったこと」を assert** するようにしています。

```python
out = s.replace(old, "state.hint", 1)
assert out != s, g   # ← これ
```

直したあと、**2 ファイルとも鳴りました。**

## ゲームごとの違い（どれも実物から読んでいます）

| | |
|---|---|
| **Monte Carlo** | アクセサが **`Hint()`**（`GetHint()` ではない）。全プレゼンタ中ここだけ |
| **Nertz** | **`GameClear` フェーズが存在しない**。ラウンド制で `RoundEnd` / `GameEnd`。手詰まり判定も無し |
| Pyramid | ヒントは `Type` / `Row1` / `Col1` / `Row2` / `Col2` |

Nertz はゲートも「進行中かどうかだけ」、負のサブテストも `GameEnd` を使います。

## 共有ヘルパーを通らない Output テスト

Monte Carlo と Nertz に、mock を直に組む Output テストがありました。**片方はサブテストの中**で、関数単位の走査では見つかりません（外側の関数本体には共有ヘルパーの呼び出しがあるため）。

## 負のコントロール

| 対象 | 結果 |
|---|---|
| Go プレゼンタのゲート 3 本を `if false` | **6 件 FAIL** |
| CLI フォーマッタのゲート 2 本を外す | **2 ファイル FAIL** |

`montecarloFormatter` は存在しません。`pyramidFormatter` には**テストが無かった**ので新規作成しています。

## 確認

- `go test -tags test ./internal/adapter/presenter/ -count=3` green
- `golangci-lint run ./internal/adapter/presenter/` 0 issues
- `bun run check`（11 ガード）/ `typecheck` green

## Test plan

- [ ] CI 全ジョブ green