### PR TITLE
fix(hints): drop the unreachable stalemate clause from Black Hole's gate (#4483)

### DIFF
--- a/internal/adapter/presenter/BlackHoleWebPresenter.go
+++ b/internal/adapter/presenter/BlackHoleWebPresenter.go
@@ -31,7 +31,11 @@ func (p *BlackHoleWebPresenter) Output(g interfaces.BlackHoleGame, lastErr error
 	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
 	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
 	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
-	if g.GetPhase() == domain.BlackHolePhasePlaying && !g.IsStalemate() {
+	// **手詰まり判定は足さない。**Black Hole の `IsStalemate()` と `GetHint()` は
+	// どちらも `canPlay(i)` を同じ順に回すだけで、手詰まりなら必ずヒントも nil に
+	// なる。`!IsStalemate()` を書くと、決して偽にならない条件のために毎回もう一度
+	// 全扇を走査することになる。他ゲームと形が違うのはこの理由 (#4542 のレビュー指摘)。
+	if g.GetPhase() == domain.BlackHolePhasePlaying {
 		if hint := g.GetHint(); hint != nil {
 			resObj.Hint = &controller.BlackHoleWebOutputHint{Fan: hint.Fan}
 		}

--- a/internal/adapter/presenter/BlackHoleWebPresenter_test.go
+++ b/internal/adapter/presenter/BlackHoleWebPresenter_test.go
@@ -37,6 +37,18 @@ func TestBlackHoleWebPresenter_Output(t *testing.T) {
 
 	// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
 	// レスポンスで、ページの state にはマージされない (#4483)。
+	// **「手詰まりならヒントは nil」をドメインの性質として固定する。**
+	// Output のゲートから `!IsStalemate()` を外した根拠がこれで、崩れたら
+	// ゲートを戻す必要がある (#4542 のレビュー指摘)。
+	t.Run("a stalemate never has a hint", func(t *testing.T) {
+		// 穴の一番上が 5、どの扇の一番上も ±1 でない → 合法手なし。
+		js := `{"bh":[{"d":1,"v":5,"w":true}],"fn":[[{"d":2,"v":10,"w":true}]],"ph":0}`
+		g := bhState(t, js)
+		assert.True(t, g.IsStalemate(), "fixture must actually be a stalemate")
+		assert.Nil(t, g.GetHint(), "a stalemate must not produce a hint")
+		assert.NotContains(t, p.Output(g, nil), `"hint"`)
+	})
+
 	t.Run("output carries the hint", func(t *testing.T) {
 		// 穴の一番上が 5、fan0 の一番上が 6（±1）なので fan 0 が勧められる。
 		js := `{"bh":[{"d":1,"v":5,"w":true}],"fn":[[{"d":2,"v":6,"w":true}]],"ph":0}`


### PR DESCRIPTION
## 概要

[#4542 のレビュー指摘](https://github.com/yuta-yoshinaga/go_trumpcards/pull/4542)への対応です。

> `BlackHoleWebPresenter_test.go` の新テストは `GetPhase() != Playing` の分岐しか通しておらず、`IsStalemate() == true` かつフェーズが `Playing` の場合を駆動していないので、`&&` の片側が独立に検証されていない。

**指摘は正しく、そしてそのケースは書けません。**

## なぜ書けないか

`IsStalemate()` と `GetHint()` は、**同じ `canPlay(i)` を同じ順に回すだけ**です。

```go
func (g *BlackHole) GetHint() *BlackHoleHint {
	for i := range g.fans {
		if g.canPlay(i) { return &BlackHoleHint{Fan: i} }
	}
	return nil
}

func (g *BlackHole) hasAnyLegalMove() bool {
	for i := range g.fans {
		if g.canPlay(i) { return true }
	}
	return false
}

func (g *BlackHole) IsStalemate() bool {
	return g.phase == BlackHolePhasePlaying && !g.hasAnyLegalMove()
}
```

**手詰まりなら必ず `GetHint()` は nil** で、内側の nil 判定がすでに拾っています。`!IsStalemate()` は、**意味を持つ場面では決して偽にならない条件のために、全扇をもう一度走査していた**だけです。

（`MockBlackHoleGame` は存在しないので、他ゲームのように mock で分岐させることもできません。）

## 対応

非対称を注記して残すのではなく、**節を削って理由をコードに書きました。**40 本以上ある兄弟プレゼンタと形が違う理由が、その場で読めます。

## 根拠を散文ではなくテストで固定しました

```go
t.Run("a stalemate never has a hint", func(t *testing.T) {
	// 穴の一番上が 5、どの扇の一番上も ±1 でない → 合法手なし。
	js := `{"bh":[{"d":1,"v":5,"w":true}],"fn":[[{"d":2,"v":10,"w":true}]],"ph":0}`
	g := bhState(t, js)
	assert.True(t, g.IsStalemate(), "fixture must actually be a stalemate")
	assert.Nil(t, g.GetHint(), "a stalemate must not produce a hint")
	assert.NotContains(t, p.Output(g, nil), `"hint"`)
})
```

**フィクスチャが本当に手詰まりであること自体も assert しています**（そうでなければ、何も確かめずに通るテストになります）。ドメインが将来この 2 つの述語を分けたら**このテストが落ち、節を戻す必要があると分かります。**

## 確認

- `go test -tags test ./internal/adapter/presenter/ -count=3` green
- `golangci-lint run ./internal/adapter/presenter/` 0 issues

## Test plan

- [ ] CI 全ジョブ green