### PR TITLE
fix(hints): carry the passive hint for the last four gated solitaires (#4483)

### DIFF
--- a/frontend/src/utils/cli/formatters/tripeaksFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/tripeaksFormatter.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import type { TriPeaksResponse } from '../../../types/card';
+import { formatTripeaksState } from './tripeaksFormatter';
+
+function makeState(overrides?: Partial<TriPeaksResponse>): TriPeaksResponse {
+  return {
+    layout: [
+      [{ card: { design: 'SPADE', value: 1 }, removed: false, exposed: false }],
+      [
+        { card: { design: 'HEART', value: 6 }, removed: false, exposed: true },
+        { card: { design: 'CLOVER', value: 7 }, removed: true, exposed: true },
+      ],
+    ],
+    stockCount: 18,
+    waste: [{ design: 'DIAMOND', value: 5 }],
+    phase: 0,
+    moveCount: 4,
+    canUndo: true,
+    isStalemate: false,
+    message: '',
+    ...overrides,
+  };
+}
+
+describe('formatTripeaksState', () => {
+  it('formats the basic state', () => {
+    const output = formatTripeaksState(makeState());
+    expect(output).toContain('TriPeaks');
+    expect(output).toContain('stock: 18');
+    expect(output).toContain('moves: 4');
+  });
+
+  it('hides a card that is not exposed', () => {
+    expect(formatTripeaksState(makeState())).toContain('??');
+  });
+
+  it('reports a stalemate', () => {
+    expect(formatTripeaksState(makeState({ isStalemate: true }))).toContain('Stalemate');
+  });
+
+  // **HINT 行は hint を頼んだときだけ。**受動ヒントが Output に載るように
+  // なった (#4483) ので、messageCode で「頼んだ応答か」を見分ける。
+  it('shows the hint only when the hint was requested', () => {
+    const hint = { type: 'remove', row: 1, col: 0 };
+    expect(formatTripeaksState(makeState({ hint, messageCode: 'tripeaks.hintAvailable' }))).toContain('HINT: (1,0)');
+    expect(formatTripeaksState(makeState({ hint, messageCode: 'tripeaks.playing' }))).not.toContain('HINT:');
+  });
+});

--- a/frontend/src/utils/cli/formatters/tripeaksFormatter.ts
+++ b/frontend/src/utils/cli/formatters/tripeaksFormatter.ts
@@ -1,5 +1,5 @@
 import type { TriPeaksResponse } from '../../../types/card';
-import { formatCard, formatHeader, formatSeparator } from '../formatterBase';
+import { formatCard, formatHeader, formatSeparator, isRequestedHint } from '../formatterBase';
 
 /** Format a TriPeaks game state as terminal text. */
 export function formatTripeaksState(state: TriPeaksResponse): string {
@@ -24,7 +24,7 @@ export function formatTripeaksState(state: TriPeaksResponse): string {
   lines.push(`moves: ${state.moveCount}`);
 
   if (state.isStalemate) lines.push('Stalemate - no more moves possible');
-  if (state.hint) lines.push(`HINT: (${state.hint.row},${state.hint.col})`);
+  if (state.hint && isRequestedHint(state)) lines.push(`HINT: (${state.hint.row},${state.hint.col})`);
   if (state.message) lines.push(state.message);
   if (state.phase === 1) lines.push('Congratulations! You win!');
 

--- a/internal/adapter/presenter/RussianSolitaireWebPresenter.go
+++ b/internal/adapter/presenter/RussianSolitaireWebPresenter.go
@@ -45,6 +45,20 @@ func (p *RussianSolitaireWebPresenter) Output(r interfaces.RussianSolitaireGame,
 	}
 
 	// メッセージ
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	if r.GetPhase() == domain.RussianSolitairePhasePlaying && !r.IsStalemate() {
+		if hint := r.GetHint(); hint != nil {
+			resObj.Hint = &controller.RussianSolitaireWebOutputHint{
+				FromCol:   hint.FromCol,
+				CardIndex: hint.CardIndex,
+				ToZone:    hint.ToZone,
+				ToCol:     hint.ToCol,
+			}
+		}
+	}
+
 	if lastErr != nil {
 		resObj.Message = lastErr.Error()
 	} else {

--- a/internal/adapter/presenter/RussianSolitaireWebPresenter_test.go
+++ b/internal/adapter/presenter/RussianSolitaireWebPresenter_test.go
@@ -39,10 +39,18 @@ func parseRussianSolitaireOutput(t *testing.T, jsonStr string) *controller.Russi
 	return &out
 }
 
+// setupRussianSolitaireOutputMock は Output 用の既定。**Output() も受動ヒントを埋める**ように
+// なった (#4483) ので GetHint を呼べるようにする。共有ヘルパーに置くと、先に
+// 登録されたこの期待が HintOutput テストの「ヒントあり」を食う。
+func setupRussianSolitaireOutputMock(g *interfaces.MockRussianSolitaireGame) {
+	setupRussianSolitaireWebMockDefaults(g)
+	g.On("GetHint").Return(nil).Maybe()
+}
+
 func TestRussianSolitaireWebPresenter_Output(t *testing.T) {
 	t.Run("initial state", func(t *testing.T) {
 		rg := new(interfaces.MockRussianSolitaireGame)
-		setupRussianSolitaireWebMockDefaults(rg)
+		setupRussianSolitaireOutputMock(rg)
 		p := new(RussianSolitaireWebPresenter)
 
 		result := parseRussianSolitaireOutput(t, p.Output(rg, nil))
@@ -53,7 +61,7 @@ func TestRussianSolitaireWebPresenter_Output(t *testing.T) {
 
 	t.Run("stalemate with escape available", func(t *testing.T) {
 		rg := new(interfaces.MockRussianSolitaireGame)
-		setupRussianSolitaireWebMockDefaults(rg)
+		setupRussianSolitaireOutputMock(rg)
 		rg.ExpectedCalls = nil
 		rg.On("GetPhase").Return(domain.RussianSolitairePhasePlaying).Maybe()
 		rg.On("GetMoveCount").Return(5).Maybe()
@@ -74,7 +82,7 @@ func TestRussianSolitaireWebPresenter_Output(t *testing.T) {
 
 	t.Run("stalemate without escape available", func(t *testing.T) {
 		rg := new(interfaces.MockRussianSolitaireGame)
-		setupRussianSolitaireWebMockDefaults(rg)
+		setupRussianSolitaireOutputMock(rg)
 		rg.ExpectedCalls = nil
 		rg.On("GetPhase").Return(domain.RussianSolitairePhasePlaying).Maybe()
 		rg.On("GetMoveCount").Return(5).Maybe()
@@ -95,7 +103,7 @@ func TestRussianSolitaireWebPresenter_Output(t *testing.T) {
 
 	t.Run("game clear", func(t *testing.T) {
 		rg := new(interfaces.MockRussianSolitaireGame)
-		setupRussianSolitaireWebMockDefaults(rg)
+		setupRussianSolitaireOutputMock(rg)
 		rg.ExpectedCalls = nil
 		rg.On("GetPhase").Return(domain.RussianSolitairePhaseGameClear).Maybe()
 		rg.On("GetMoveCount").Return(42).Maybe()
@@ -114,7 +122,7 @@ func TestRussianSolitaireWebPresenter_Output(t *testing.T) {
 
 	t.Run("game over", func(t *testing.T) {
 		rg := new(interfaces.MockRussianSolitaireGame)
-		setupRussianSolitaireWebMockDefaults(rg)
+		setupRussianSolitaireOutputMock(rg)
 		rg.ExpectedCalls = nil
 		rg.On("GetPhase").Return(domain.RussianSolitairePhaseGameOver).Maybe()
 		rg.On("GetMoveCount").Return(10).Maybe()
@@ -133,11 +141,36 @@ func TestRussianSolitaireWebPresenter_Output(t *testing.T) {
 
 	t.Run("with error", func(t *testing.T) {
 		rg := new(interfaces.MockRussianSolitaireGame)
-		setupRussianSolitaireWebMockDefaults(rg)
+		setupRussianSolitaireOutputMock(rg)
 		p := new(RussianSolitaireWebPresenter)
 
 		result := parseRussianSolitaireOutput(t, p.Output(rg, errors.New("test error")))
 		assert.Equal(t, "test error", result.Message)
+	})
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+func TestRussianSolitaireWebPresenterOutputCarriesTheHint(t *testing.T) {
+	t.Run("playing", func(t *testing.T) {
+		rsg := new(interfaces.MockRussianSolitaireGame)
+		setupRussianSolitaireWebMockDefaults(rsg)
+		rsg.On("GetHint").Return(&domain.RussianSolitaireHint{FromCol: 2, CardIndex: 0, ToZone: "foundation", ToCol: 1}).Maybe()
+
+		result := new(RussianSolitaireWebPresenter).Output(rsg, nil)
+		assert.Contains(t, result, `"hint"`, "Output must carry the hint -- the frontend reads state.hint")
+	})
+
+	// 手詰まりのヒントは出さない。逃げ道の提示は stalemate 用のメッセージが持つ。
+	t.Run("not while stalemate", func(t *testing.T) {
+		rsg := new(interfaces.MockRussianSolitaireGame)
+		setupRussianSolitaireWebMockDefaults(rsg)
+		rsg.ExpectedCalls = filterCalls(rsg.ExpectedCalls, "IsStalemate")
+		rsg.On("IsStalemate").Return(true)
+		rsg.On("GetHint").Return(&domain.RussianSolitaireHint{FromCol: 2, CardIndex: 0, ToZone: "foundation", ToCol: 1}).Maybe()
+
+		result := new(RussianSolitaireWebPresenter).Output(rsg, nil)
+		assert.NotContains(t, result, `"hint"`)
 	})
 }
 

--- a/internal/adapter/presenter/SirTommyWebPresenter.go
+++ b/internal/adapter/presenter/SirTommyWebPresenter.go
@@ -17,6 +17,19 @@ type SirTommyWebPresenter struct{}
 func (p *SirTommyWebPresenter) Output(g interfaces.SirTommyGame, lastErr error) string {
 	resObj := p.buildBase(g)
 
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	if g.GetPhase() == domain.SirTommyPhasePlaying && !g.IsStalemate() {
+		if hint := g.GetHint(); hint != nil {
+			resObj.Hint = &controller.SirTommyWebOutputHint{
+				FromZone:      hint.FromZone,
+				WasteIdx:      hint.WasteIdx,
+				FoundationIdx: hint.FoundationIdx,
+			}
+		}
+	}
+
 	if lastErr != nil {
 		resObj.Message = lastErr.Error()
 	} else {

--- a/internal/adapter/presenter/SirTommyWebPresenter_test.go
+++ b/internal/adapter/presenter/SirTommyWebPresenter_test.go
@@ -41,10 +41,18 @@ func parseSirTommyOutput(t *testing.T, jsonStr string) *controller.SirTommyWebOu
 	return &out
 }
 
+// setupSirTommyOutputMock は Output 用の既定。**Output() も受動ヒントを埋める**ように
+// なった (#4483) ので GetHint を呼べるようにする。共有ヘルパーに置くと、先に
+// 登録されたこの期待が HintOutput テストの「ヒントあり」を食う。
+func setupSirTommyOutputMock(g *interfaces.MockSirTommyGame) {
+	setupSirTommyWebMockDefaults(g)
+	g.On("GetHint").Return(nil).Maybe()
+}
+
 func TestSirTommyWebPresenter_Output(t *testing.T) {
 	t.Run("initial state", func(t *testing.T) {
 		g := new(interfaces.MockSirTommyGame)
-		setupSirTommyWebMockDefaults(g)
+		setupSirTommyOutputMock(g)
 		result := parseSirTommyOutput(t, new(SirTommyWebPresenter).Output(g, nil))
 		assert.Equal(t, 0, result.Phase)
 		assert.Equal(t, "sirtommy.playing", result.MessageCode)
@@ -109,9 +117,34 @@ func TestSirTommyWebPresenter_Output(t *testing.T) {
 
 	t.Run("with error", func(t *testing.T) {
 		g := new(interfaces.MockSirTommyGame)
-		setupSirTommyWebMockDefaults(g)
+		setupSirTommyOutputMock(g)
 		result := parseSirTommyOutput(t, new(SirTommyWebPresenter).Output(g, errors.New("boom")))
 		assert.Equal(t, "boom", result.Message)
+	})
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+func TestSirTommyWebPresenterOutputCarriesTheHint(t *testing.T) {
+	t.Run("playing", func(t *testing.T) {
+		stg := new(interfaces.MockSirTommyGame)
+		setupSirTommyWebMockDefaults(stg)
+		stg.On("GetHint").Return(&domain.SirTommyHint{FromZone: "waste", WasteIdx: 1, FoundationIdx: 2}).Maybe()
+
+		result := new(SirTommyWebPresenter).Output(stg, nil)
+		assert.Contains(t, result, `"hint"`, "Output must carry the hint -- the frontend reads state.hint")
+	})
+
+	// 手詰まりのヒントは出さない。逃げ道の提示は stalemate 用のメッセージが持つ。
+	t.Run("not while stalemate", func(t *testing.T) {
+		stg := new(interfaces.MockSirTommyGame)
+		setupSirTommyWebMockDefaults(stg)
+		stg.ExpectedCalls = filterCalls(stg.ExpectedCalls, "IsStalemate")
+		stg.On("IsStalemate").Return(true)
+		stg.On("GetHint").Return(&domain.SirTommyHint{FromZone: "waste", WasteIdx: 1, FoundationIdx: 2}).Maybe()
+
+		result := new(SirTommyWebPresenter).Output(stg, nil)
+		assert.NotContains(t, result, `"hint"`)
 	})
 }
 

--- a/internal/adapter/presenter/SpiteAndMaliceWebPresenter.go
+++ b/internal/adapter/presenter/SpiteAndMaliceWebPresenter.go
@@ -14,6 +14,21 @@ type SpiteAndMaliceWebPresenter struct{}
 // Output ゲーム状態を JSON 出力
 func (p *SpiteAndMaliceWebPresenter) Output(g interfaces.SpiteAndMaliceGame, lastErr error) string {
 	resObj := p.buildBase(g)
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	// このゲームは手詰まり判定を持たないので、ゲートは進行中かどうかだけ。
+	if g.GetPhase() == domain.SpiteAndMalicePhasePlaying {
+		if hint := g.GetHint(); hint != nil {
+			resObj.Hint = &controller.SpiteAndMaliceWebHint{
+				Source:        sourceToString(hint.Source),
+				Index:         hint.Index,
+				FoundationIdx: hint.FoundationIdx,
+				Discard:       hint.Discard,
+			}
+		}
+	}
+
 	if lastErr != nil {
 		resObj.Message = lastErr.Error()
 	} else {

--- a/internal/adapter/presenter/SpiteAndMaliceWebPresenter_test.go
+++ b/internal/adapter/presenter/SpiteAndMaliceWebPresenter_test.go
@@ -47,10 +47,18 @@ func decodeSpiteAndMaliceWebOutput(t *testing.T, raw string) *controller.SpiteAn
 	return &out
 }
 
+// setupSpiteAndMaliceOutputMock は Output 用の既定。**Output() も受動ヒントを埋める**ように
+// なった (#4483) ので GetHint を呼べるようにする。共有ヘルパーに置くと、先に
+// 登録されたこの期待が HintOutput テストの「ヒントあり」を食う。
+func setupSpiteAndMaliceOutputMock(g *interfaces.MockSpiteAndMaliceGame) {
+	setupSpiteAndMaliceWebMockDefaults(g)
+	g.On("GetHint").Return(nil).Maybe()
+}
+
 func TestSpiteAndMaliceWebPresenter_Output(t *testing.T) {
 	t.Run("playing", func(t *testing.T) {
 		g := new(interfaces.MockSpiteAndMaliceGame)
-		setupSpiteAndMaliceWebMockDefaults(g)
+		setupSpiteAndMaliceOutputMock(g)
 		raw := new(SpiteAndMaliceWebPresenter).Output(g, nil)
 		out := decodeSpiteAndMaliceWebOutput(t, raw)
 		assert.Equal(t, "spiteandmalice.playing", out.MessageCode)
@@ -60,7 +68,7 @@ func TestSpiteAndMaliceWebPresenter_Output(t *testing.T) {
 
 	t.Run("with error", func(t *testing.T) {
 		g := new(interfaces.MockSpiteAndMaliceGame)
-		setupSpiteAndMaliceWebMockDefaults(g)
+		setupSpiteAndMaliceOutputMock(g)
 		raw := new(SpiteAndMaliceWebPresenter).Output(g, assert.AnError)
 		out := decodeSpiteAndMaliceWebOutput(t, raw)
 		assert.Equal(t, assert.AnError.Error(), out.Message)
@@ -83,6 +91,7 @@ func TestSpiteAndMaliceWebPresenter_Output(t *testing.T) {
 		}
 		g.On("GetPlayer", 0).Return(domain.NewSpiteAndMalicePlayer(false)).Maybe()
 		g.On("GetPlayer", 1).Return(domain.NewSpiteAndMalicePlayer(true)).Maybe()
+		g.On("GetHint").Return(nil).Maybe()
 		raw := new(SpiteAndMaliceWebPresenter).Output(g, nil)
 		out := decodeSpiteAndMaliceWebOutput(t, raw)
 		assert.Equal(t, "spiteandmalice.win", out.MessageCode)
@@ -106,6 +115,7 @@ func TestSpiteAndMaliceWebPresenter_Output(t *testing.T) {
 		}
 		g.On("GetPlayer", 0).Return(domain.NewSpiteAndMalicePlayer(false)).Maybe()
 		g.On("GetPlayer", 1).Return(domain.NewSpiteAndMalicePlayer(true)).Maybe()
+		g.On("GetHint").Return(nil).Maybe()
 		raw := new(SpiteAndMaliceWebPresenter).Output(g, nil)
 		out := decodeSpiteAndMaliceWebOutput(t, raw)
 		assert.Equal(t, "spiteandmalice.lose", out.MessageCode)
@@ -137,6 +147,7 @@ func TestSpiteAndMaliceWebPresenter_Output(t *testing.T) {
 			cpu.AddToHand(domain.NewCard(domain.CardDesignHeart, 9, false))
 			g.On("GetPlayer", 0).Return(human).Maybe()
 			g.On("GetPlayer", 1).Return(cpu).Maybe()
+			g.On("GetHint").Return(nil).Maybe()
 			raw := new(SpiteAndMaliceWebPresenter).Output(g, nil)
 			out := decodeSpiteAndMaliceWebOutput(t, raw)
 			// 人間の手札は常に公開
@@ -168,9 +179,34 @@ func TestSpiteAndMaliceWebPresenter_Output(t *testing.T) {
 		}
 		g.On("GetPlayer", 0).Return((*domain.SpiteAndMalicePlayer)(nil)).Maybe()
 		g.On("GetPlayer", 1).Return((*domain.SpiteAndMalicePlayer)(nil)).Maybe()
+		g.On("GetHint").Return(nil).Maybe()
 		raw := new(SpiteAndMaliceWebPresenter).Output(g, nil)
 		out := decodeSpiteAndMaliceWebOutput(t, raw)
 		assert.Nil(t, out.Players[0].Hand)
+	})
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+func TestSpiteAndMaliceWebPresenterOutputCarriesTheHint(t *testing.T) {
+	t.Run("playing", func(t *testing.T) {
+		smg := new(interfaces.MockSpiteAndMaliceGame)
+		setupSpiteAndMaliceWebMockDefaults(smg)
+		smg.On("GetHint").Return(&domain.SpiteAndMaliceHint{Source: domain.SpiteAndMaliceSourceHand, Index: 0, FoundationIdx: 1, Discard: false}).Maybe()
+
+		result := new(SpiteAndMaliceWebPresenter).Output(smg, nil)
+		assert.Contains(t, result, `"hint"`, "Output must carry the hint -- the frontend reads state.hint")
+	})
+
+	t.Run("not once the game is over", func(t *testing.T) {
+		smg := new(interfaces.MockSpiteAndMaliceGame)
+		setupSpiteAndMaliceWebMockDefaults(smg)
+		smg.ExpectedCalls = filterCalls(smg.ExpectedCalls, "GetPhase")
+		smg.On("GetPhase").Return(domain.SpiteAndMalicePhaseGameOver)
+		smg.On("GetHint").Return(&domain.SpiteAndMaliceHint{Source: domain.SpiteAndMaliceSourceHand, Index: 0, FoundationIdx: 1, Discard: false}).Maybe()
+
+		result := new(SpiteAndMaliceWebPresenter).Output(smg, nil)
+		assert.NotContains(t, result, `"hint"`)
 	})
 }
 

--- a/internal/adapter/presenter/TriPeaksWebPresenter.go
+++ b/internal/adapter/presenter/TriPeaksWebPresenter.go
@@ -52,6 +52,19 @@ func (pr *TriPeaksWebPresenter) Output(t interfaces.TriPeaksGame, lastErr error)
 	}
 
 	// メッセージ
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	if t.GetPhase() == domain.TriPeaksPhasePlaying && !t.IsStalemate() {
+		if hint := t.GetHint(); hint != nil {
+			resObj.Hint = &controller.TriPeaksWebOutputHint{
+				Type: hint.Type,
+				Row:  hint.Row,
+				Col:  hint.Col,
+			}
+		}
+	}
+
 	if lastErr != nil {
 		resObj.Message = lastErr.Error()
 	} else {

--- a/internal/adapter/presenter/TriPeaksWebPresenter_test.go
+++ b/internal/adapter/presenter/TriPeaksWebPresenter_test.go
@@ -55,9 +55,17 @@ func parseTriPeaksOutput(t *testing.T, jsonStr string) *controller.TriPeaksWebOu
 	return &out
 }
 
+// setupTriPeaksOutputMock は Output 用の既定。**Output() も受動ヒントを埋める**ように
+// なった (#4483) ので GetHint を呼べるようにする。共有ヘルパーに置くと、先に
+// 登録されたこの期待が HintOutput テストの「ヒントあり」を食う。
+func setupTriPeaksOutputMock(g *interfaces.MockTriPeaksGame) {
+	setupTriPeaksWebMockDefaults(g)
+	g.On("GetHint").Return(nil).Maybe()
+}
+
 func TestTriPeaksWebPresenterOutput_Playing(t *testing.T) {
 	tg := new(interfaces.MockTriPeaksGame)
-	setupTriPeaksWebMockDefaults(tg)
+	setupTriPeaksOutputMock(tg)
 	p := &TriPeaksWebPresenter{}
 
 	result := p.Output(tg, nil)
@@ -71,7 +79,7 @@ func TestTriPeaksWebPresenterOutput_Playing(t *testing.T) {
 
 func TestTriPeaksWebPresenterOutput_Error(t *testing.T) {
 	tg := new(interfaces.MockTriPeaksGame)
-	setupTriPeaksWebMockDefaults(tg)
+	setupTriPeaksOutputMock(tg)
 	p := &TriPeaksWebPresenter{}
 
 	result := p.Output(tg, errors.New("test error"))
@@ -82,7 +90,7 @@ func TestTriPeaksWebPresenterOutput_Error(t *testing.T) {
 
 func TestTriPeaksWebPresenterOutput_Stalemate(t *testing.T) {
 	tg := new(interfaces.MockTriPeaksGame)
-	setupTriPeaksWebMockDefaults(tg)
+	setupTriPeaksOutputMock(tg)
 	tg.ExpectedCalls = nil
 	tg.On("GetPhase").Return(domain.TriPeaksPhasePlaying).Maybe()
 	tg.On("GetMoveCount").Return(5).Maybe()
@@ -108,7 +116,7 @@ func TestTriPeaksWebPresenterOutput_Stalemate(t *testing.T) {
 
 func TestTriPeaksWebPresenterOutput_GameClear(t *testing.T) {
 	tg := new(interfaces.MockTriPeaksGame)
-	setupTriPeaksWebMockDefaults(tg)
+	setupTriPeaksOutputMock(tg)
 	tg.ExpectedCalls = nil
 	tg.On("GetPhase").Return(domain.TriPeaksPhaseGameClear).Maybe()
 	tg.On("GetMoveCount").Return(10).Maybe()
@@ -135,7 +143,7 @@ func TestTriPeaksWebPresenterOutput_GameClear(t *testing.T) {
 
 func TestTriPeaksWebPresenterOutput_GameOver(t *testing.T) {
 	tg := new(interfaces.MockTriPeaksGame)
-	setupTriPeaksWebMockDefaults(tg)
+	setupTriPeaksOutputMock(tg)
 	tg.ExpectedCalls = nil
 	tg.On("GetPhase").Return(domain.TriPeaksPhaseGameOver).Maybe()
 	tg.On("GetMoveCount").Return(5).Maybe()
@@ -157,6 +165,31 @@ func TestTriPeaksWebPresenterOutput_GameOver(t *testing.T) {
 	out := parseTriPeaksOutput(t, result)
 
 	assert.Equal(t, "tripeaks.gameOver", out.MessageCode)
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+func TestTriPeaksWebPresenterOutputCarriesTheHint(t *testing.T) {
+	t.Run("playing", func(t *testing.T) {
+		tpg := new(interfaces.MockTriPeaksGame)
+		setupTriPeaksWebMockDefaults(tpg)
+		tpg.On("GetHint").Return(&domain.TriPeaksHint{Type: "remove", Row: 2, Col: 3}).Maybe()
+
+		result := new(TriPeaksWebPresenter).Output(tpg, nil)
+		assert.Contains(t, result, `"hint"`, "Output must carry the hint -- the frontend reads state.hint")
+	})
+
+	// 手詰まりのヒントは出さない。逃げ道の提示は stalemate 用のメッセージが持つ。
+	t.Run("not while stalemate", func(t *testing.T) {
+		tpg := new(interfaces.MockTriPeaksGame)
+		setupTriPeaksWebMockDefaults(tpg)
+		tpg.ExpectedCalls = filterCalls(tpg.ExpectedCalls, "IsStalemate")
+		tpg.On("IsStalemate").Return(true)
+		tpg.On("GetHint").Return(&domain.TriPeaksHint{Type: "remove", Row: 2, Col: 3}).Maybe()
+
+		result := new(TriPeaksWebPresenter).Output(tpg, nil)
+		assert.NotContains(t, result, `"hint"`)
+	})
 }
 
 func TestTriPeaksWebPresenterHintOutput(t *testing.T) {


### PR DESCRIPTION
## 概要

18 本目。**Russian Solitaire / Sir Tommy / Spite and Malice / TriPeaks**。

**これで `PhasePlaying` ゲートを持つゲームは全部終わりです。**

Refs #4483

## Poker Squares は「作業」ではなく母数の偽陽性でした

残りリストに入っていましたが、**何も要りません。**

```go
func (pr *PokerSquaresWebPresenter) HintOutput(p interfaces.PokerSquaresGame) string {
	return pr.Output(p, nil)
}
```

`HintOutput` が `Output` を返すだけで、**出力構造体に `Hint` フィールドがなく**、ページもフォーマッタもヒントを読みません。死んだ分岐がそもそも存在しません。

## Spite and Malice は値を変換して出します

```go
resObj.Hint = &controller.SpiteAndMaliceWebHint{
	Source:        sourceToString(hint.Source),   // ← 素の hint.Source ではない
	...
}
```

リテラル抽出が `hint.Field` の形しか受け付けていなかったので、**`hint` に言及する任意の式**を受けるようにしました。`GameClear` フェーズも無く、`GameOver` のみです。

## インライン mock の探し方をまた直しました

Spite and Malice のテストには**自前で mock を組むサブテストが 3 つ**あります。**各 `Output` 呼び出しから、囲っている `t.Run` まで遡る**やり方でようやく全部捕まりました。遡り幅を 40 行に固定していたときは、**隣のサブテストの登録を拾ってしまい 1 件取りこぼしていました。**

## 負のコントロール

| 対象 | 結果 |
|---|---|
| Go プレゼンタのゲート 4 本を `if false` | **8 件 FAIL** |
| TriPeaks フォーマッタのゲートを外す | **1 件 FAIL** |

CLI フォーマッタがあるのは TriPeaks だけで、**テストファイルは無かった**ので新規作成しています。

## この先

`PhasePlaying` を持たない **114 本**（トリックテイキング系など）が残ります。フェーズの概念が違うので、**ゲートの設計から**必要です。

## 確認

- `go test -tags test ./internal/adapter/presenter/ -count=3` green
- `golangci-lint run ./internal/adapter/presenter/` 0 issues
- `bun run check`（11 ガード）/ `typecheck` green

## Test plan

- [ ] CI 全ジョブ green