### PR TITLE
fix(hints): carry the passive hint for Briscola, and establish the trick-taking shape (#4483)

### DIFF
--- a/internal/adapter/presenter/BriscolaWebPresenter.go
+++ b/internal/adapter/presenter/BriscolaWebPresenter.go
@@ -15,6 +15,20 @@ type BriscolaWebPresenter struct{}
 func (p *BriscolaWebPresenter) Output(b interfaces.BriscolaGame, lastErr error) string {
 	resObj := p.buildBase(b)
 	resObj.Message, resObj.MessageCode, resObj.MessageParams = p.buildMessage(b, lastErr)
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	//
+	// **フェーズと手番はここでは見ない。**Briscola.GetHint() が自分で
+	// 「プレイ中かつ人間の手番」を確かめて nil を返す。ソリティア側のゲートを
+	// 持ち込むと、ドメインが既に持つ判定を二重に書くことになる。
+	if hint := b.GetHint(); hint != nil {
+		resObj.Hint = &controller.BriscolaWebOutputHint{
+			CardIndex: hint.CardIndex,
+			Reason:    hint.Reason,
+		}
+	}
+
 	return marshalOrError(resObj)
 }
 

--- a/internal/adapter/presenter/BriscolaWebPresenter_test.go
+++ b/internal/adapter/presenter/BriscolaWebPresenter_test.go
@@ -30,6 +30,9 @@ func setupBriscolaWebMock(trumpCard *domain.Card) *interfaces.MockBriscolaGame {
 	m.On("GetWinnerIdx").Return(-1)
 	m.On("GetConfig").Return(domain.DefaultBriscolaConfig())
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
+	// **Output() も受動ヒントを埋める**ようになった (#4483)。既定は「ヒント無し」。
+	m.On("GetHint").Return(nil).Maybe()
+
 	return m
 }
 
@@ -151,6 +154,7 @@ func TestBriscolaWebPresenter_HintOutput(t *testing.T) {
 	m, players := setupBriscolaWebMockWithPlayers(trump)
 	players[0].AddCard(domain.NewCard(domain.CardDesignClover, 1, false))
 	idx := 0
+	m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHint")
 	m.On("GetHint").Return(&domain.BriscolaHint{CardIndex: &idx, Reason: "lead_low"})
 
 	got := p.HintOutput(m)
@@ -164,6 +168,7 @@ func TestBriscolaWebPresenter_HintOutput(t *testing.T) {
 func TestBriscolaWebPresenter_HintOutput_None(t *testing.T) {
 	p := new(presenter.BriscolaWebPresenter)
 	m, _ := setupBriscolaWebMockWithPlayers(nil)
+	m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHint")
 	m.On("GetHint").Return((*domain.BriscolaHint)(nil))
 	got := p.HintOutput(m)
 	var out controller.BriscolaWebOutput
@@ -176,4 +181,22 @@ func TestBriscolaWebPresenter_ActionLogOutput(t *testing.T) {
 	m, _ := setupBriscolaWebMockWithPlayers(nil)
 	got := p.ActionLogOutput(m)
 	assert.NotEmpty(t, got)
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+//
+// トリックテイキング系はソリティア系と違い、**Output 側のゲートが要りません。**
+// Briscola.GetHint() が「プレイ中かつ人間の手番」を自分で確かめて nil を返すので、
+// フェーズ判定を持ち込むとドメインの判定を二重に書くことになります。
+func TestBriscolaWebPresenterOutputCarriesTheHint(t *testing.T) {
+	trump := domain.NewCard(domain.CardDesignSpade, 13, false)
+	brg, players := setupBriscolaWebMockWithPlayers(trump)
+	players[0].AddCard(domain.NewCard(domain.CardDesignClover, 1, false))
+	idx := 0
+	brg.ExpectedCalls = removeMockCall(brg.ExpectedCalls, "GetHint")
+	brg.On("GetHint").Return(&domain.BriscolaHint{CardIndex: &idx, Reason: "lead_low"})
+
+	result := new(presenter.BriscolaWebPresenter).Output(brg, nil)
+	assert.Contains(t, result, `"hint"`, "Output must carry the hint -- the frontend reads state.hint")
 }


### PR DESCRIPTION
## 概要

トリックテイキング系の 1 本目。**Briscola のみ**です。

用意した 3 本のうち **Sedma と Sueca は出せませんでした**（理由は下記）。Refs #4483

## トリックテイキング系にゲートは要りません

```go
func (b *Briscola) GetHint() *BriscolaHint {
	if b.phase != BriscolaPhasePlay || b.currentPlayerIdx != 0 {
		return nil
	}
	...
```

**`GetHint()` が自分で「プレイ中かつ人間の手番」を確かめています。**ソリティア側のフェーズ判定を持ち込むと、**ドメインが既に持つ判定を二重に書く**ことになります（[#4546](https://github.com/yuta-yoshinaga/go_trumpcards/pull/4546) で Black Hole から外したのと同じ重複）。

50 本中 25 本で同じ自前ガードを確認しました。

## Sedma と Sueca を外した理由

**CLI のゲートが成立しません。**

ソリティア側は `isRequestedHint(state)`（`messageCode` が `.hintAvailable` で終わるか）で「頼んだヒントか」を見分けています。ところが**トリックテイキング系の `HintOutput` は messageCode を一切設定しません。**

```go
func (p *SedmaWebPresenter) HintOutput(g interfaces.SedmaGame) string {
	hint := g.GetHint()
	resObj := p.buildBase(g)
	if hint != nil { resObj.Hint = ... }
	return marshalOrError(resObj)   // ← messageCode 無し
}
```

`buildBase` も設定しません（0 件）。つまり **`isRequestedHint` は永遠に false** で、ゲートを掛ければ CLI のヒントが完全に死に、掛けなければ**毎回 HINT 行が出ます。**どちらも回帰です。

**Briscola には CLI フォーマッタがない**ので、この問題の影響を受けません。先に型だけ確立します。

Sedma / Sueca を含む残りは、**`HintOutput` に messageCode を持たせる**か、**別の見分け方**が要ります。設計を決めてから進めます。

## 負のコントロールも直しました

`if false` に置き換えると **`hint` が未使用でビルドが落ち**、`--- FAIL` を grep した件数が **0 になり「成功」と読めてしまいます。**

```
0        ← 3 本壊したのに 0 件
```

`hint != nil && false` に変え、**壊した版がビルドできることを先に確かめて**から件数を数えます。直した結果 **3 件 FAIL**、復元で green。

## 確認

- `go test -tags test ./internal/adapter/presenter/ -count=3` green
- `golangci-lint run ./internal/adapter/presenter/` 0 issues

## Test plan

- [ ] CI 全ジョブ green