### PR TITLE
fix(hints): carry the passive hint for All Fours and Belote (#4483)

### DIFF
--- a/internal/adapter/presenter/AllFoursWebPresenter.go
+++ b/internal/adapter/presenter/AllFoursWebPresenter.go
@@ -15,6 +15,21 @@ type AllFoursWebPresenter struct{}
 func (p *AllFoursWebPresenter) Output(s interfaces.AllFoursGame, lastErr error) string {
 	resObj := p.buildBase(s)
 	resObj.Message, resObj.MessageCode, resObj.MessageParams = p.buildMessage(s, s.GetCurrentTrick(), lastErr)
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	//
+	// **フェーズと手番はここでは見ない。**AllFours.GetHint() が自分で
+	// 「人間の手番で、かつ行動を選べる状態か」を確かめて nil を返す。
+	if hint := s.GetHint(); hint != nil {
+		resObj.Hint = &controller.AllFoursWebOutputHint{
+			CardIndex: hint.CardIndex,
+			Beg:       hint.Beg,
+			Run:       hint.Run,
+			Reason:    hint.Reason,
+		}
+	}
+
 	return marshalOrError(resObj)
 }
 

--- a/internal/adapter/presenter/AllFoursWebPresenter_test.go
+++ b/internal/adapter/presenter/AllFoursWebPresenter_test.go
@@ -40,6 +40,9 @@ func setupAllFoursWebMock() *interfaces.MockAllFoursGame {
 	m.On("GetConfig").Return(domain.DefaultAllFoursConfig())
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
 	m.On("GetValidPlayIndices", 0).Return([]int{0, 1})
+	// **Output() も受動ヒントを埋める**ようになった (#4483)。既定は「ヒント無し」。
+	m.On("GetHint").Return(nil).Maybe()
+
 	return m
 }
 
@@ -194,6 +197,7 @@ func TestAllFoursWebPresenter_HintOutput(t *testing.T) {
 
 	t.Run("nil hint", func(t *testing.T) {
 		m, _ := setupAllFoursWebMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHint")
 		m.On("GetHint").Return((*domain.AllFoursHint)(nil))
 		result := p.HintOutput(m)
 		var resObj controller.AllFoursWebOutput
@@ -204,6 +208,7 @@ func TestAllFoursWebPresenter_HintOutput(t *testing.T) {
 	t.Run("with beg hint", func(t *testing.T) {
 		m, _ := setupAllFoursWebMockWithPlayers()
 		beg := true
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHint")
 		m.On("GetHint").Return(&domain.AllFoursHint{Beg: &beg, Reason: "beg_beg"})
 		result := p.HintOutput(m)
 		var resObj controller.AllFoursWebOutput
@@ -223,4 +228,19 @@ func TestAllFoursWebPresenter_ActionLogOutput(t *testing.T) {
 	})
 	out := p.ActionLogOutput(m)
 	assert.Contains(t, out, "You stand")
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+//
+// トリックテイキング系は Output 側にゲートを置きません。AllFours.GetHint() が
+// 「人間の手番で、かつ行動を選べる状態か」を自分で確かめて nil を返します。
+func TestAllFoursWebPresenterOutputCarriesTheHint(t *testing.T) {
+	idx := 1
+	afg, _ := setupAllFoursWebMockWithPlayers()
+	afg.ExpectedCalls = removeMockCall(afg.ExpectedCalls, "GetHint")
+	afg.On("GetHint").Return(&domain.AllFoursHint{CardIndex: &idx, Reason: "lead_low"})
+
+	result := new(presenter.AllFoursWebPresenter).Output(afg, nil)
+	assert.Contains(t, result, `"hint"`, "Output must carry the hint -- the frontend reads state.hint")
 }

--- a/internal/adapter/presenter/BeloteWebPresenter.go
+++ b/internal/adapter/presenter/BeloteWebPresenter.go
@@ -17,6 +17,21 @@ type BeloteWebPresenter struct{}
 func (p *BeloteWebPresenter) Output(b interfaces.BeloteGame, lastErr error) string {
 	resObj := p.buildBase(b)
 	resObj.Message, resObj.MessageCode, resObj.MessageParams = p.buildMessage(b, b.GetCurrentTrick(), lastErr)
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	//
+	// **フェーズと手番はここでは見ない。**Belote.GetHint() が自分で
+	// 「人間の手番で、かつ行動を選べる状態か」を確かめて nil を返す。
+	if hint := b.GetHint(); hint != nil {
+		resObj.Hint = &controller.BeloteWebOutputHint{
+			CardIndex: hint.CardIndex,
+			OrderUp:   hint.OrderUp,
+			Suit:      hint.Suit,
+			Reason:    hint.Reason,
+		}
+	}
+
 	return marshalOrError(resObj)
 }
 

--- a/internal/adapter/presenter/BeloteWebPresenter_test.go
+++ b/internal/adapter/presenter/BeloteWebPresenter_test.go
@@ -37,6 +37,9 @@ func setupBeloteWebMock() *interfaces.MockBeloteGame {
 	m.On("GetLeadPlayerIdx").Return(0)
 	m.On("GetConfig").Return(domain.DefaultBeloteConfig())
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
+	// **Output() も受動ヒントを埋める**ようになった (#4483)。既定は「ヒント無し」。
+	m.On("GetHint").Return(nil).Maybe()
+
 	return m
 }
 
@@ -132,6 +135,7 @@ func TestBeloteWebPresenter_HintOutput(t *testing.T) {
 
 	t.Run("nil hint", func(t *testing.T) {
 		m, _ := setupBeloteWebMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHint")
 		m.On("GetHint").Return((*domain.BeloteHint)(nil))
 		result := p.HintOutput(m)
 		var resObj controller.BeloteWebOutput
@@ -142,6 +146,7 @@ func TestBeloteWebPresenter_HintOutput(t *testing.T) {
 	t.Run("with hint", func(t *testing.T) {
 		m, _ := setupBeloteWebMockWithPlayers()
 		ok := true
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHint")
 		m.On("GetHint").Return(&domain.BeloteHint{OrderUp: &ok, Reason: "strategic_pickup"})
 
 		result := p.HintOutput(m)
@@ -158,4 +163,19 @@ func TestBeloteWebPresenter_ActionLogOutput(t *testing.T) {
 	p := new(presenter.BeloteWebPresenter)
 	result := p.ActionLogOutput(m)
 	assert.NotEmpty(t, result)
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+//
+// トリックテイキング系は Output 側にゲートを置きません。Belote.GetHint() が
+// 「人間の手番で、かつ行動を選べる状態か」を自分で確かめて nil を返します。
+func TestBeloteWebPresenterOutputCarriesTheHint(t *testing.T) {
+	idx := 0
+	blg, _ := setupBeloteWebMockWithPlayers()
+	blg.ExpectedCalls = removeMockCall(blg.ExpectedCalls, "GetHint")
+	blg.On("GetHint").Return(&domain.BeloteHint{CardIndex: &idx, Reason: "follow_suit"})
+
+	result := new(presenter.BeloteWebPresenter).Output(blg, nil)
+	assert.Contains(t, result, `"hint"`, "Output must carry the hint -- the frontend reads state.hint")
 }


### PR DESCRIPTION
## 概要

**CLI フォーマッタが `state.hint` を読まない 43 本**からの 2 本です。#4548 で Sedma / Sueca を止めた messageCode の問題が当たりません。

Refs #4483

## Bid Whist は用意して落としました

テストが mock ではなく実ドメインを回す作りで、**Reset 直後の `GetHint()` が 200 回中 200 回 nil** でした。

```
nil hints: 200/200
```

素直に書くと**何も確かめないテスト**になります。入札可能な状態まで進めるのはフィクスチャ 1 行では済まない実装作業なので、**「戻したときに落ちるテスト」が付けられないまま本体だけ出すことはしません。**

## ゲートは置きません

```go
// **フェーズと手番はここでは見ない。**AllFours.GetHint() が自分で
// 「人間の手番で、かつ行動を選べる状態か」を確かめて nil を返す。
if hint := s.GetHint(); hint != nil {
```

## mock ヘルパーの形が違います

この 2 本のヘルパーは **mock を受け取るのではなく生成して返す**ので、既定の `GetHint → nil` はヘルパーの中に入ります。その結果、**既存の `HintOutput` テストが先勝ちで負ける**ため、`removeMockCall` で外してから登録し直しています（同ファイルが `GetPhase` で既に使っている手です）。

## 負のコントロール

`if false` に置き換えると **`hint` が未使用でビルドが落ち**、FAIL 件数が 0 になって「成功」に見えます。**`hint != nil && false` に変え、壊した版がビルドできることを先に確認**してから数えます。

| | |
|---|---|
| ゲート 2 本を neuter | **2 件 FAIL** |
| 復元 | green |

## 確認

- `go test -tags test ./internal/adapter/presenter/ -count=2` green
- `golangci-lint run ./internal/adapter/presenter/` 0 issues

## Test plan

- [ ] CI 全ジョブ green