### PR TITLE
fix(hints): carry the passive hint for Gaigel, Jass and Pitch (#4483)

### DIFF
--- a/internal/adapter/presenter/GaigelWebPresenter.go
+++ b/internal/adapter/presenter/GaigelWebPresenter.go
@@ -17,6 +17,20 @@ type GaigelWebPresenter struct{}
 func (p *GaigelWebPresenter) Output(g interfaces.GaigelGame, lastErr error) string {
 	resObj := p.buildBase(g)
 	resObj.Message, resObj.MessageCode, resObj.MessageParams = p.buildMessage(g, g.GetCurrentTrick(), lastErr)
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	//
+	// **フェーズと手番はここでは見ない。**Gaigel.GetHint() が自分で
+	// 「人間の手番で、かつ行動を選べる状態か」を確かめて nil を返す。
+	if hint := g.GetHint(); hint != nil {
+		resObj.Hint = &controller.GaigelWebOutputHint{
+			CardIndex:  hint.CardIndex,
+			Reason:     hint.Reason,
+			IsMarriage: hint.IsMarriage,
+		}
+	}
+
 	return marshalOrError(resObj)
 }
 

--- a/internal/adapter/presenter/GaigelWebPresenter_test.go
+++ b/internal/adapter/presenter/GaigelWebPresenter_test.go
@@ -36,6 +36,9 @@ func setupGaigelWebMock() *interfaces.MockGaigelGame {
 	m.On("GetMarriageIndices", 0).Return([]int(nil))
 	m.On("GetConfig").Return(domain.DefaultGaigelConfig())
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
+	// **Output() も受動ヒントを埋める**ようになった (#4483)。既定は「ヒント無し」。
+	m.On("GetHint").Return(nil).Maybe()
+
 	return m
 }
 
@@ -123,6 +126,7 @@ func TestGaigelWebPresenter_HintOutput(t *testing.T) {
 	m, players := setupGaigelWebMockWithPlayers()
 	players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 11, false))
 	idx := 0
+	m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHint")
 	m.On("GetHint").Return(&domain.GaigelHint{CardIndex: &idx, Reason: "follow_win"})
 	result := p.HintOutput(m)
 	var resObj controller.GaigelWebOutput
@@ -134,6 +138,7 @@ func TestGaigelWebPresenter_HintOutput(t *testing.T) {
 func TestGaigelWebPresenter_HintOutput_Nil(t *testing.T) {
 	p := new(presenter.GaigelWebPresenter)
 	m, _ := setupGaigelWebMockWithPlayers()
+	m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHint")
 	m.On("GetHint").Return((*domain.GaigelHint)(nil))
 	result := p.HintOutput(m)
 	var resObj controller.GaigelWebOutput
@@ -145,4 +150,19 @@ func TestGaigelWebPresenter_ActionLogOutput(t *testing.T) {
 	p := new(presenter.GaigelWebPresenter)
 	m := setupGaigelWebMock()
 	assert.NotNil(t, p.ActionLogOutput(m))
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+//
+// トリックテイキング系は Output 側にゲートを置きません。Gaigel.GetHint() が
+// 「人間の手番で、かつ行動を選べる状態か」を自分で確かめて nil を返します。
+func TestGaigelWebPresenterOutputCarriesTheHint(t *testing.T) {
+	idx := 0
+	ggg, _ := setupGaigelWebMockWithPlayers()
+	ggg.ExpectedCalls = removeMockCall(ggg.ExpectedCalls, "GetHint")
+	ggg.On("GetHint").Return(&domain.GaigelHint{CardIndex: &idx, Reason: "lead_low"})
+
+	result := new(presenter.GaigelWebPresenter).Output(ggg, nil)
+	assert.Contains(t, result, `"hint"`, "Output must carry the hint -- the frontend reads state.hint")
 }

--- a/internal/adapter/presenter/JassWebPresenter.go
+++ b/internal/adapter/presenter/JassWebPresenter.go
@@ -17,6 +17,21 @@ type JassWebPresenter struct{}
 func (p *JassWebPresenter) Output(g interfaces.JassGame, lastErr error) string {
 	resObj := p.buildBase(g)
 	resObj.Message, resObj.MessageCode, resObj.MessageParams = p.buildMessage(g, g.GetCurrentTrick(), lastErr)
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	//
+	// **フェーズと手番はここでは見ない。**Jass.GetHint() が自分で
+	// 「人間の手番で、かつ行動を選べる状態か」を確かめて nil を返す。
+	if hint := g.GetHint(); hint != nil {
+		resObj.Hint = &controller.JassWebOutputHint{
+			CardIndex: hint.CardIndex,
+			Schieben:  hint.Schieben,
+			Suit:      hint.Suit,
+			Reason:    hint.Reason,
+		}
+	}
+
 	return marshalOrError(resObj)
 }
 

--- a/internal/adapter/presenter/JassWebPresenter_test.go
+++ b/internal/adapter/presenter/JassWebPresenter_test.go
@@ -40,6 +40,9 @@ func setupJassWebMock() *interfaces.MockJassGame {
 	m.On("GetLeadPlayerIdx").Return(0)
 	m.On("GetConfig").Return(domain.DefaultJassConfig())
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
+	// **Output() も受動ヒントを埋める**ようになった (#4483)。既定は「ヒント無し」。
+	m.On("GetHint").Return(nil).Maybe()
+
 	return m
 }
 
@@ -180,6 +183,7 @@ func TestJassWebPresenter_HintOutput(t *testing.T) {
 	p := new(presenter.JassWebPresenter)
 	m, _ := setupJassWebMockWithPlayers()
 	suit := 2
+	m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHint")
 	m.On("GetHint").Return(&domain.JassHint{Suit: &suit, Reason: "strategic_trump"})
 	result := p.HintOutput(m)
 	var resObj controller.JassWebOutput
@@ -191,6 +195,7 @@ func TestJassWebPresenter_HintOutput(t *testing.T) {
 func TestJassWebPresenter_HintOutput_Nil(t *testing.T) {
 	p := new(presenter.JassWebPresenter)
 	m, _ := setupJassWebMockWithPlayers()
+	m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHint")
 	m.On("GetHint").Return((*domain.JassHint)(nil))
 	result := p.HintOutput(m)
 	var resObj controller.JassWebOutput
@@ -202,4 +207,19 @@ func TestJassWebPresenter_ActionLogOutput(t *testing.T) {
 	p := new(presenter.JassWebPresenter)
 	m := setupJassWebMock()
 	assert.NotNil(t, p.ActionLogOutput(m))
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+//
+// トリックテイキング系は Output 側にゲートを置きません。Jass.GetHint() が
+// 「人間の手番で、かつ行動を選べる状態か」を自分で確かめて nil を返します。
+func TestJassWebPresenterOutputCarriesTheHint(t *testing.T) {
+	idx := 0
+	jsg, _ := setupJassWebMockWithPlayers()
+	jsg.ExpectedCalls = removeMockCall(jsg.ExpectedCalls, "GetHint")
+	jsg.On("GetHint").Return(&domain.JassHint{CardIndex: &idx, Reason: "follow_suit"})
+
+	result := new(presenter.JassWebPresenter).Output(jsg, nil)
+	assert.Contains(t, result, `"hint"`, "Output must carry the hint -- the frontend reads state.hint")
 }

--- a/internal/adapter/presenter/PitchWebPresenter.go
+++ b/internal/adapter/presenter/PitchWebPresenter.go
@@ -13,6 +13,20 @@ type PitchWebPresenter struct{}
 func (p *PitchWebPresenter) Output(s interfaces.PitchGame, lastErr error) string {
 	resObj := p.buildBase(s)
 	resObj.Message, resObj.MessageCode, resObj.MessageParams = p.buildMessage(s, s.GetCurrentTrick(), lastErr)
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	//
+	// **フェーズと手番はここでは見ない。**Pitch.GetHint() が自分で
+	// 「人間の手番で、かつ行動を選べる状態か」を確かめて nil を返す。
+	if hint := s.GetHint(); hint != nil {
+		resObj.Hint = &controller.PitchWebOutputHint{
+			CardIndex: hint.CardIndex,
+			Bid:       hint.Bid,
+			Reason:    hint.Reason,
+		}
+	}
+
 	return marshalOrError(resObj)
 }
 

--- a/internal/adapter/presenter/PitchWebPresenter_test.go
+++ b/internal/adapter/presenter/PitchWebPresenter_test.go
@@ -31,6 +31,9 @@ func setupPitchWebMock() *interfaces.MockPitchGame {
 	m.On("GetConfig").Return(domain.DefaultPitchConfig())
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
 	m.On("GetValidPlayIndices", 0).Return([]int{0, 1})
+	// **Output() も受動ヒントを埋める**ようになった (#4483)。既定は「ヒント無し」。
+	m.On("GetHint").Return(nil).Maybe()
+
 	return m
 }
 
@@ -109,6 +112,7 @@ func TestPitchWebPresenter_HintOutput(t *testing.T) {
 
 	t.Run("nil hint", func(t *testing.T) {
 		m, _ := setupPitchWebMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHint")
 		m.On("GetHint").Return((*domain.PitchHint)(nil))
 		result := p.HintOutput(m)
 		var resObj controller.PitchWebOutput
@@ -119,6 +123,7 @@ func TestPitchWebPresenter_HintOutput(t *testing.T) {
 	t.Run("with hint", func(t *testing.T) {
 		m, _ := setupPitchWebMockWithPlayers()
 		bid := 3
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHint")
 		m.On("GetHint").Return(&domain.PitchHint{Bid: &bid, Reason: "bid_strong"})
 		result := p.HintOutput(m)
 		var resObj controller.PitchWebOutput
@@ -155,6 +160,9 @@ func setupPitchWebMockCustom(phase domain.PitchPhase, trickNumber int, log []*do
 	for i := 0; i < 4; i++ {
 		m.On("GetPlayer", i).Return(players[i])
 	}
+	// **Output() も受動ヒントを埋める**ようになった (#4483)。既定は「ヒント無し」。
+	m.On("GetHint").Return(nil).Maybe()
+
 	return m
 }
 
@@ -212,4 +220,19 @@ func TestPitchWebPresenter_ActionLogOutput(t *testing.T) {
 	})
 	out := p.ActionLogOutput(m)
 	assert.Contains(t, out, "You bid 3")
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+//
+// トリックテイキング系は Output 側にゲートを置きません。Pitch.GetHint() が
+// 「人間の手番で、かつ行動を選べる状態か」を自分で確かめて nil を返します。
+func TestPitchWebPresenterOutputCarriesTheHint(t *testing.T) {
+	idx := 0
+	ptg, _ := setupPitchWebMockWithPlayers()
+	ptg.ExpectedCalls = removeMockCall(ptg.ExpectedCalls, "GetHint")
+	ptg.On("GetHint").Return(&domain.PitchHint{CardIndex: &idx, Reason: "lead_trump"})
+
+	result := new(presenter.PitchWebPresenter).Output(ptg, nil)
+	assert.Contains(t, result, `"hint"`, "Output must carry the hint -- the frontend reads state.hint")
 }


### PR DESCRIPTION
## 概要

CLI フォーマッタが `state.hint` を読まない 43 本から、さらに 3 本。

Refs #4483

## Pitch には mock ヘルパーが 3 つありました

他のゲームは `setupXWebMock` と `setupXWebMockWithPlayers` の 2 つですが、**Pitch には `setupPitchWebMockCustom` があります。**分かりやすい 2 つだけに既定を足したところ、`TestPitchWebPresenter_LastTrick` が **`GetHint()` の未登録で panic** しました。

**「2 つある」と決めつけず、名前で grep して数えた**ので見つかりました。

## ゲートは置きません

```go
// **フェーズと手番はここでは見ない。**Jass.GetHint() が自分で
// 「人間の手番で、かつ行動を選べる状態か」を確かめて nil を返す。
if hint := g.GetHint(); hint != nil {
```

## 負のコントロール

`hint != nil && false` に置き換え（`if false` だと未使用変数でビルドが落ち、FAIL 0 件を成功と読み違えます）、**壊した版がビルドできることを確認**してから計測:

| | |
|---|---|
| ゲート 3 本を neuter | **3 件 FAIL** |
| 復元 | green |

## 確認

- `go test -tags test ./internal/adapter/presenter/ -count=2` green
- `golangci-lint run ./internal/adapter/presenter/` 0 issues

## Test plan

- [ ] CI 全ジョブ green