### PR TITLE
fix(hints): carry the passive hint for Schnapsen, Skat and Rook (#4483)

### DIFF
--- a/internal/adapter/presenter/RookWebPresenter.go
+++ b/internal/adapter/presenter/RookWebPresenter.go
@@ -34,6 +34,23 @@ type RookWebPresenter struct{}
 func (p *RookWebPresenter) Output(g interfaces.RookGame, lastErr error) string {
 	resObj := p.buildBase(g)
 	resObj.Message, resObj.MessageCode, resObj.MessageParams = p.buildMessage(g, lastErr)
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	//
+	// **フェーズと手番はここでは見ない。**Rook.GetHint() が自分で
+	// 「人間の手番で、かつ行動を選べる状態か」を確かめて nil を返す。
+	if hint := g.GetHint(); hint != nil {
+		resObj.Hint = &controller.RookWebOutputHint{
+			Bid:            hint.Bid,
+			Pass:           hint.Pass,
+			DiscardIndices: hint.DiscardIndices,
+			TrumpColor:     hint.TrumpColor,
+			CardIndex:      hint.CardIndex,
+			Reason:         hint.Reason,
+		}
+	}
+
 	return marshalOrError(resObj)
 }
 

--- a/internal/adapter/presenter/RookWebPresenter_test.go
+++ b/internal/adapter/presenter/RookWebPresenter_test.go
@@ -182,3 +182,22 @@ func TestRookWebPresenter_PhaseMessages(t *testing.T) {
 		t.Errorf("game-end message missing: %s", out)
 	}
 }
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+//
+// Rook のテストは mock ではなく実ドメインを組み立てます。既存の Hint テストと
+// 同じ状態を作るので、配りには依存しません。
+func TestRookWebPresenterOutputCarriesTheHint(t *testing.T) {
+	g := newRookGame()
+	g.SetTrumpColor(1)
+	g.SetDeclarerIdx(0)
+	g.GetPlayer(0).AddCard(domain.NewCard(1, 1, false))
+	g.SetPhase(domain.RookPhasePlay)
+	g.SetCurrentPlayerIdx(0)
+
+	result := new(presenter.RookWebPresenter).Output(g, nil)
+	if !strings.Contains(result, `"hint"`) {
+		t.Error("Output must carry the hint -- the frontend reads state.hint")
+	}
+}

--- a/internal/adapter/presenter/SchnapsenWebPresenter.go
+++ b/internal/adapter/presenter/SchnapsenWebPresenter.go
@@ -17,6 +17,20 @@ type SchnapsenWebPresenter struct{}
 func (p *SchnapsenWebPresenter) Output(s interfaces.SchnapsenGame, lastErr error) string {
 	resObj := p.buildBase(s)
 	resObj.Message, resObj.MessageCode, resObj.MessageParams = p.buildMessage(s, lastErr)
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	//
+	// **フェーズと手番はここでは見ない。**Schnapsen.GetHint() が自分で
+	// 「人間の手番で、かつ行動を選べる状態か」を確かめて nil を返す。
+	if hint := s.GetHint(); hint != nil {
+		resObj.Hint = &controller.SchnapsenWebOutputHint{
+			CardIndex:  hint.CardIndex,
+			Reason:     hint.Reason,
+			IsMarriage: hint.IsMarriage,
+		}
+	}
+
 	return marshalOrError(resObj)
 }
 

--- a/internal/adapter/presenter/SchnapsenWebPresenter_test.go
+++ b/internal/adapter/presenter/SchnapsenWebPresenter_test.go
@@ -33,6 +33,9 @@ func setupSchnapsenWebMock(trumpCard *domain.Card) *interfaces.MockSchnapsenGame
 	m.On("GetWinnerIdx").Return(-1)
 	m.On("GetConfig").Return(domain.DefaultSchnapsenConfig())
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
+	// **Output() も受動ヒントを埋める**ようになった (#4483)。既定は「ヒント無し」。
+	m.On("GetHint").Return(nil).Maybe()
+
 	return m
 }
 
@@ -127,6 +130,7 @@ func TestSchnapsenWebPresenter_HintOutput(t *testing.T) {
 	m, players := setupSchnapsenWebMockWithPlayers(trump)
 	players[0].AddCard(domain.NewCard(domain.CardDesignClover, 1, false))
 	idx := 0
+	m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHint")
 	m.On("GetHint").Return(&domain.SchnapsenHint{CardIndex: &idx, Reason: "lead_low"})
 
 	got := p.HintOutput(m)
@@ -140,6 +144,7 @@ func TestSchnapsenWebPresenter_HintOutput(t *testing.T) {
 func TestSchnapsenWebPresenter_HintOutput_None(t *testing.T) {
 	p := new(presenter.SchnapsenWebPresenter)
 	m, _ := setupSchnapsenWebMockWithPlayers(nil)
+	m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHint")
 	m.On("GetHint").Return((*domain.SchnapsenHint)(nil))
 	got := p.HintOutput(m)
 	var out controller.SchnapsenWebOutput
@@ -152,4 +157,21 @@ func TestSchnapsenWebPresenter_ActionLogOutput(t *testing.T) {
 	m, _ := setupSchnapsenWebMockWithPlayers(nil)
 	got := p.ActionLogOutput(m)
 	assert.NotEmpty(t, got)
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+//
+// トリックテイキング系は Output 側にゲートを置きません。Schnapsen.GetHint() が
+// 「人間の手番で、かつ行動を選べる状態か」を自分で確かめて nil を返します。
+func TestSchnapsenWebPresenterOutputCarriesTheHint(t *testing.T) {
+	trump := domain.NewCard(domain.CardDesignSpade, 13, false)
+	idx := 0
+	sng, players := setupSchnapsenWebMockWithPlayers(trump)
+	players[0].AddCard(domain.NewCard(domain.CardDesignClover, 1, false))
+	sng.ExpectedCalls = removeMockCall(sng.ExpectedCalls, "GetHint")
+	sng.On("GetHint").Return(&domain.SchnapsenHint{CardIndex: &idx, Reason: "lead_low"})
+
+	result := new(presenter.SchnapsenWebPresenter).Output(sng, nil)
+	assert.Contains(t, result, `"hint"`, "Output must carry the hint -- the frontend reads state.hint")
 }

--- a/internal/adapter/presenter/SkatWebPresenter.go
+++ b/internal/adapter/presenter/SkatWebPresenter.go
@@ -15,6 +15,24 @@ type SkatWebPresenter struct{}
 func (p *SkatWebPresenter) Output(s interfaces.SkatGame, lastErr error) string {
 	resObj := p.buildBaseOutput(s)
 	resObj.Message, resObj.MessageCode, resObj.MessageParams = p.buildMessage(s, lastErr)
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	//
+	// **フェーズと手番はここでは見ない。**Skat.GetHint() が自分で
+	// 「人間の手番で、かつ行動を選べる状態か」を確かめて nil を返す。
+	if hint := s.GetHint(); hint != nil {
+		resObj.Hint = &controller.SkatWebOutputHint{
+			CardIndex:    hint.CardIndex,
+			Bid:          hint.Bid,
+			GameType:     hint.GameType,
+			TrumpSuit:    hint.TrumpSuit,
+			PickSkat:     hint.PickSkat,
+			DiscardIndex: hint.DiscardIndex,
+			Reason:       hint.Reason,
+		}
+	}
+
 	return marshalOrError(resObj)
 }
 

--- a/internal/adapter/presenter/SkatWebPresenter_test.go
+++ b/internal/adapter/presenter/SkatWebPresenter_test.go
@@ -46,6 +46,9 @@ func setupSkatWebMock() *interfaces.MockSkatGame {
 		m.On("GetPlayer", i).Return(domain.NewSkatPlayer(i == 0))
 	}
 	m.On("GetPhase").Return(domain.SkatPhaseBid)
+	// **Output() も受動ヒントを埋める**ようになった (#4483)。既定は「ヒント無し」。
+	m.On("GetHint").Return(nil).Maybe()
+
 	return m
 }
 
@@ -110,6 +113,7 @@ func TestSkatWebPresenter_OutputRoundEndExposesSkat(t *testing.T) {
 	}
 	m.On("GetPhase").Return(domain.SkatPhaseRoundEnd)
 
+	m.On("GetHint").Return(nil).Maybe()
 	body := p.Output(m, nil)
 	var resObj controller.SkatWebOutput
 	_ = json.Unmarshal([]byte(body), &resObj)
@@ -123,6 +127,7 @@ func TestSkatWebPresenter_HintAndActionLog(t *testing.T) {
 	m := setupSkatWebMock()
 	val := 1
 	hint := &domain.SkatHint{Bid: &val, Reason: "strategic_bid"}
+	m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHint")
 	m.On("GetHint").Return(hint)
 	body := p.HintOutput(m)
 	var resObj controller.SkatWebOutput
@@ -132,4 +137,19 @@ func TestSkatWebPresenter_HintAndActionLog(t *testing.T) {
 	assert.NotPanics(t, func() {
 		_ = p.ActionLogOutput(m)
 	})
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+//
+// トリックテイキング系は Output 側にゲートを置きません。Skat.GetHint() が
+// 「人間の手番で、かつ行動を選べる状態か」を自分で確かめて nil を返します。
+func TestSkatWebPresenterOutputCarriesTheHint(t *testing.T) {
+	val := 1
+	skg := setupSkatWebMock()
+	skg.ExpectedCalls = removeMockCall(skg.ExpectedCalls, "GetHint")
+	skg.On("GetHint").Return(&domain.SkatHint{Bid: &val, Reason: "strategic_bid"})
+
+	result := new(presenter.SkatWebPresenter).Output(skg, nil)
+	assert.Contains(t, result, `"hint"`, "Output must carry the hint -- the frontend reads state.hint")
 }


### PR DESCRIPTION
## 概要

CLI フォーマッタが `state.hint` を読まない群から、さらに 3 本。

Refs #4483

## `removeMockCall` は最初の 1 件しか外しません

```go
func removeMockCall(calls []*mock.Call, method string) []*mock.Call {
	found := false
	for _, c := range calls {
		if !found && c.Method == method {   // ← 最初の 1 件だけ
			found = true
			continue
		}
```

Schnapsen は `setupSchnapsenWebMockWithPlayers` が `setupSchnapsenWebMock` を**呼びます。**両方に既定の `GetHint → nil` を入れたので、既存の `HintOutput` テストが `removeMockCall` で 1 件外しても**もう 1 件が生き残って実物を食っていました。**

**既定は base のヘルパー 1 つだけ**に置きます。

## Rook は testify を import していません

実ドメインを組み立てるテストで、周りは `strings.Contains` で書かれています。**1 行のために import を増やさず**、既存の書き方に合わせました。

状態は既存の Hint テストと同じ組み立て（trump color / declarer / 手札 1 枚 / Play フェーズ / 手番 0）なので、**配りに依存しません。**

## Skat のインライン mock

`TestSkatWebPresenter_OutputRoundEndExposesSkat` は mock を直に組むので、個別に期待が要りました。`Output` 呼び出しから **`t.Run` 境界まで遡って**探しています。

## 負のコントロール

| | |
|---|---|
| ゲート 3 本を neuter（ビルド可を確認済み） | **3 件 FAIL** |
| 復元 | green |

## 確認

- `go test -tags test ./internal/adapter/presenter/ -count=2` green
- `golangci-lint run ./internal/adapter/presenter/` 0 issues

## Test plan

- [ ] CI 全ジョブ green