### PR TITLE
fix(hints): carry the passive hint for Three Card Brag and Teen Patti (#4483)

### DIFF
--- a/internal/adapter/presenter/TeenPattiWebPresenter.go
+++ b/internal/adapter/presenter/TeenPattiWebPresenter.go
@@ -51,6 +51,19 @@ type TeenPattiWebPresenter struct{}
 func (p *TeenPattiWebPresenter) Output(g interfaces.TeenPattiGame, lastErr error) string {
 	resObj := p.buildBase(g)
 	resObj.Message, resObj.MessageCode, resObj.MessageParams = p.buildMessage(g, lastErr)
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	//
+	// **フェーズと手番はここでは見ない。**TeenPatti.GetHint() が自分で
+	// 「人間の手番で、かつ行動を選べる状態か」を確かめて nil を返す。
+	if hint := g.GetHint(); hint != nil {
+		resObj.Hint = &controller.TeenPattiWebOutputHint{
+			Action: hint.Action,
+			Reason: hint.Reason,
+		}
+	}
+
 	return marshalOrError(resObj)
 }
 

--- a/internal/adapter/presenter/TeenPattiWebPresenter_test.go
+++ b/internal/adapter/presenter/TeenPattiWebPresenter_test.go
@@ -35,6 +35,11 @@ func tpSetupWebMock() *interfaces.MockTeenPattiGame {
 	m.On("IsHumanTurn").Return(true)
 	m.On("GetConfig").Return(domain.DefaultTeenPattiConfig())
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
+	// **Output() も受動ヒントを埋める**ようになった (#4483)。既定は「ヒント無し」。
+	// **base だけに置く。**removeMockCall は最初の 1 件しか外さないので、
+	// wrapper にも入れると HintOutput テストの実物が食われる。
+	m.On("GetHint").Return(nil).Maybe()
+
 	return m
 }
 
@@ -225,6 +230,7 @@ func TestTeenPattiWebPresenter_HintOutput(t *testing.T) {
 
 	t.Run("hint present", func(t *testing.T) {
 		m, _ := tpSetupWebMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHint")
 		m.On("GetHint").Return(&domain.TeenPattiHint{Action: "raise", Reason: "strong_hand"})
 		result := p.HintOutput(m)
 		var resObj controller.TeenPattiWebOutput
@@ -236,6 +242,7 @@ func TestTeenPattiWebPresenter_HintOutput(t *testing.T) {
 
 	t.Run("no hint", func(t *testing.T) {
 		m, _ := tpSetupWebMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHint")
 		m.On("GetHint").Return((*domain.TeenPattiHint)(nil))
 		result := p.HintOutput(m)
 		var resObj controller.TeenPattiWebOutput
@@ -253,4 +260,18 @@ func TestTeenPattiWebPresenter_ActionLogOutput(t *testing.T) {
 	})
 	result := p.ActionLogOutput(m)
 	assert.Contains(t, result, `"actionType":"bet"`)
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+//
+// ベッティング系も Output 側にゲートを置きません。TeenPatti.GetHint() が
+// 「人間の手番で、かつ行動を選べる状態か」を自分で確かめて nil を返します。
+func TestTeenPattiWebPresenterOutputCarriesTheHint(t *testing.T) {
+	tpg, _ := tpSetupWebMockWithPlayers()
+	tpg.ExpectedCalls = removeMockCall(tpg.ExpectedCalls, "GetHint")
+	tpg.On("GetHint").Return(&domain.TeenPattiHint{Action: "call", Reason: "strong_hand"})
+
+	result := new(presenter.TeenPattiWebPresenter).Output(tpg, nil)
+	assert.Contains(t, result, `"hint"`, "Output must carry the hint -- the frontend reads state.hint")
 }

--- a/internal/adapter/presenter/ThreeCardBragWebPresenter.go
+++ b/internal/adapter/presenter/ThreeCardBragWebPresenter.go
@@ -51,6 +51,19 @@ type ThreeCardBragWebPresenter struct{}
 func (p *ThreeCardBragWebPresenter) Output(g interfaces.ThreeCardBragGame, lastErr error) string {
 	resObj := p.buildBase(g)
 	resObj.Message, resObj.MessageCode, resObj.MessageParams = p.buildMessage(g, lastErr)
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	//
+	// **フェーズと手番はここでは見ない。**ThreeCardBrag.GetHint() が自分で
+	// 「人間の手番で、かつ行動を選べる状態か」を確かめて nil を返す。
+	if hint := g.GetHint(); hint != nil {
+		resObj.Hint = &controller.ThreeCardBragWebOutputHint{
+			Action: hint.Action,
+			Reason: hint.Reason,
+		}
+	}
+
 	return marshalOrError(resObj)
 }
 

--- a/internal/adapter/presenter/ThreeCardBragWebPresenter_test.go
+++ b/internal/adapter/presenter/ThreeCardBragWebPresenter_test.go
@@ -31,6 +31,11 @@ func tcbSetupWebMock() *interfaces.MockThreeCardBragGame {
 	m.On("IsHumanTurn").Return(true)
 	m.On("GetConfig").Return(domain.DefaultThreeCardBragConfig())
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
+	// **Output() も受動ヒントを埋める**ようになった (#4483)。既定は「ヒント無し」。
+	// **base だけに置く。**removeMockCall は最初の 1 件しか外さないので、
+	// wrapper にも入れると HintOutput テストの実物が食われる。
+	m.On("GetHint").Return(nil).Maybe()
+
 	return m
 }
 
@@ -163,6 +168,7 @@ func TestThreeCardBragWebPresenter_HintOutput(t *testing.T) {
 
 	t.Run("hint present", func(t *testing.T) {
 		m, _ := tcbSetupWebMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHint")
 		m.On("GetHint").Return(&domain.ThreeCardBragHint{Action: "raise", Reason: "strong_hand"})
 		result := p.HintOutput(m)
 		var resObj controller.ThreeCardBragWebOutput
@@ -174,6 +180,7 @@ func TestThreeCardBragWebPresenter_HintOutput(t *testing.T) {
 
 	t.Run("no hint", func(t *testing.T) {
 		m, _ := tcbSetupWebMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHint")
 		m.On("GetHint").Return((*domain.ThreeCardBragHint)(nil))
 		result := p.HintOutput(m)
 		var resObj controller.ThreeCardBragWebOutput
@@ -191,4 +198,18 @@ func TestThreeCardBragWebPresenter_ActionLogOutput(t *testing.T) {
 	})
 	result := p.ActionLogOutput(m)
 	assert.Contains(t, result, `"actionType":"bet"`)
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+//
+// ベッティング系も Output 側にゲートを置きません。ThreeCardBrag.GetHint() が
+// 「人間の手番で、かつ行動を選べる状態か」を自分で確かめて nil を返します。
+func TestThreeCardBragWebPresenterOutputCarriesTheHint(t *testing.T) {
+	tcbg, _ := tcbSetupWebMockWithPlayers()
+	tcbg.ExpectedCalls = removeMockCall(tcbg.ExpectedCalls, "GetHint")
+	tcbg.On("GetHint").Return(&domain.ThreeCardBragHint{Action: "call", Reason: "strong_hand"})
+
+	result := new(presenter.ThreeCardBragWebPresenter).Output(tcbg, nil)
+	assert.Contains(t, result, `"hint"`, "Output must carry the hint -- the frontend reads state.hint")
 }


### PR DESCRIPTION
## 概要

CLI フォーマッタが `state.hint` を読まない群から、ベッティング系 2 本。

Refs #4483

## ヘルパー名の規則が違いました

これまでのバッチは `setup<Game>WebMock` を前提にしていましたが、この 2 本は **`tcbSetupWebMock` / `tpSetupWebMock`** です。名前で探すと**何も見つかりません。**

**形で探すようにしました** — 「本体が mock の生成で始まり、`return m` で終わる関数」。

```python
ms = [m for m in re.finditer(
    r"(func (\w+)\([^)]*\)[^{]*\{\n\tm := new\(interfaces\.%s\).*?\n)(\treturn m[,)\n])" % mock, src, re.S)]
assert len(ms) == 1, f"{g}: base helpers {len(ms)}"
```

**「ちょうど 1 つ」を assert** しているので、これは #4551 で踏んだ罠（wrapper にも既定を入れると `removeMockCall` が 1 件しか外さず実物が食われる）も同時に防ぎます。wrapper は `m := new(...)` で始まらないので拾われません。

## 負のコントロール

| | |
|---|---|
| ゲート 2 本を neuter（ビルド可を確認済み） | **2 件 FAIL** |
| 復元 | green |

## 確認

- `go test -tags test ./internal/adapter/presenter/ -count=2` green
- `golangci-lint run ./internal/adapter/presenter/` 0 issues

## Test plan

- [ ] CI 全ジョブ green