### PR TITLE
fix(hints): carry the passive hint for seven more trick-taking games (#4483)

### DIFF
--- a/internal/adapter/presenter/FortyFivesWebPresenter.go
+++ b/internal/adapter/presenter/FortyFivesWebPresenter.go
@@ -17,6 +17,19 @@ type FortyFivesWebPresenter struct{}
 func (p *FortyFivesWebPresenter) Output(g interfaces.FortyFivesGame, lastErr error) string {
 	resObj := p.buildBase(g)
 	resObj.Message, resObj.MessageCode, resObj.MessageParams = p.buildMessage(g, lastErr)
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	//
+	// **フェーズと手番はここでは見ない。**FortyFives.GetHint() が自分で
+	// 「人間の手番で、かつ行動を選べる状態か」を確かめて nil を返す。
+	if hint := g.GetHint(); hint != nil {
+		resObj.Hint = &controller.WebOutputCardHint{
+			CardIndices: hint.CardIndices,
+			Reason:      hint.Reason,
+		}
+	}
+
 	return marshalOrError(resObj)
 }
 

--- a/internal/adapter/presenter/FortyFivesWebPresenter_test.go
+++ b/internal/adapter/presenter/FortyFivesWebPresenter_test.go
@@ -37,6 +37,10 @@ func setupFortyFivesWebMock() *interfaces.MockFortyFivesGame {
 	m.On("IsHumanBidTurn").Return(false)
 	m.On("GetConfig").Return(domain.DefaultFortyFivesConfig())
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
+	// **Output() も受動ヒントを埋める**ようになった (#4483)。既定は「ヒント無し」。
+	// **base だけに置く。**removeMockCall は最初の 1 件しか外さない。
+	m.On("GetHint").Return(nil).Maybe()
+
 	return m
 }
 
@@ -185,6 +189,7 @@ func TestFortyFivesWebPresenter_HintOutput(t *testing.T) {
 
 	t.Run("hint with card indices", func(t *testing.T) {
 		m, _ := setupFortyFivesWebMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHint")
 		m.On("GetHint").Return(&domain.FortyFivesHint{CardIndices: []int{2}, Reason: "take_trick"})
 		result := p.HintOutput(m)
 		var resObj controller.FortyFivesWebOutput
@@ -196,6 +201,7 @@ func TestFortyFivesWebPresenter_HintOutput(t *testing.T) {
 
 	t.Run("no hint", func(t *testing.T) {
 		m, _ := setupFortyFivesWebMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHint")
 		m.On("GetHint").Return((*domain.FortyFivesHint)(nil))
 		result := p.HintOutput(m)
 		var resObj controller.FortyFivesWebOutput
@@ -213,4 +219,18 @@ func TestFortyFivesWebPresenter_ActionLogOutput(t *testing.T) {
 	})
 	result := p.ActionLogOutput(m)
 	assert.Contains(t, result, `"actionType":"play"`)
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+//
+// Output 側にゲートは置きません。FortyFives.GetHint() が「人間の手番で、かつ
+// 行動を選べる状態か」を自分で確かめて nil を返します。
+func TestFortyFivesWebPresenterOutputCarriesTheHint(t *testing.T) {
+	ffg, _ := setupFortyFivesWebMockWithPlayers()
+	ffg.ExpectedCalls = removeMockCall(ffg.ExpectedCalls, "GetHint")
+	ffg.On("GetHint").Return(&domain.FortyFivesHint{CardIndices: []int{0}, Reason: "follow_suit"})
+
+	result := new(presenter.FortyFivesWebPresenter).Output(ffg, nil)
+	assert.Contains(t, result, `"hint"`, "Output must carry the hint -- the frontend reads state.hint")
 }

--- a/internal/adapter/presenter/KnockoutWhistWebPresenter.go
+++ b/internal/adapter/presenter/KnockoutWhistWebPresenter.go
@@ -17,6 +17,19 @@ type KnockoutWhistWebPresenter struct{}
 func (p *KnockoutWhistWebPresenter) Output(g interfaces.KnockoutWhistGame, lastErr error) string {
 	resObj := p.buildBase(g)
 	resObj.Message, resObj.MessageCode, resObj.MessageParams = p.buildMessage(g, lastErr)
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	//
+	// **フェーズと手番はここでは見ない。**KnockoutWhist.GetHint() が自分で
+	// 「人間の手番で、かつ行動を選べる状態か」を確かめて nil を返す。
+	if hint := g.GetHint(); hint != nil {
+		resObj.Hint = &controller.WebOutputCardHint{
+			CardIndices: hint.CardIndices,
+			Reason:      hint.Reason,
+		}
+	}
+
 	return marshalOrError(resObj)
 }
 

--- a/internal/adapter/presenter/KnockoutWhistWebPresenter_test.go
+++ b/internal/adapter/presenter/KnockoutWhistWebPresenter_test.go
@@ -34,6 +34,10 @@ func setupKnockoutWhistWebMock() *interfaces.MockKnockoutWhistGame {
 	m.On("IsHumanTurn").Return(true)
 	m.On("GetConfig").Return(domain.DefaultKnockoutWhistConfig())
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
+	// **Output() も受動ヒントを埋める**ようになった (#4483)。既定は「ヒント無し」。
+	// **base だけに置く。**removeMockCall は最初の 1 件しか外さない。
+	m.On("GetHint").Return(nil).Maybe()
+
 	return m
 }
 
@@ -174,6 +178,7 @@ func TestKnockoutWhistWebPresenter_HintOutput(t *testing.T) {
 
 	t.Run("hint with card indices", func(t *testing.T) {
 		m, _ := setupKnockoutWhistWebMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHint")
 		m.On("GetHint").Return(&domain.KnockoutWhistHint{CardIndices: []int{2}, Reason: "follow_win"})
 		result := p.HintOutput(m)
 		var resObj controller.KnockoutWhistWebOutput
@@ -185,6 +190,7 @@ func TestKnockoutWhistWebPresenter_HintOutput(t *testing.T) {
 
 	t.Run("no hint", func(t *testing.T) {
 		m, _ := setupKnockoutWhistWebMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHint")
 		m.On("GetHint").Return((*domain.KnockoutWhistHint)(nil))
 		result := p.HintOutput(m)
 		var resObj controller.KnockoutWhistWebOutput
@@ -202,4 +208,18 @@ func TestKnockoutWhistWebPresenter_ActionLogOutput(t *testing.T) {
 	})
 	result := p.ActionLogOutput(m)
 	assert.Contains(t, result, `"actionType":"play"`)
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+//
+// Output 側にゲートは置きません。KnockoutWhist.GetHint() が「人間の手番で、かつ
+// 行動を選べる状態か」を自分で確かめて nil を返します。
+func TestKnockoutWhistWebPresenterOutputCarriesTheHint(t *testing.T) {
+	kwg, _ := setupKnockoutWhistWebMockWithPlayers()
+	kwg.ExpectedCalls = removeMockCall(kwg.ExpectedCalls, "GetHint")
+	kwg.On("GetHint").Return(&domain.KnockoutWhistHint{CardIndices: []int{0}, Reason: "follow_suit"})
+
+	result := new(presenter.KnockoutWhistWebPresenter).Output(kwg, nil)
+	assert.Contains(t, result, `"hint"`, "Output must carry the hint -- the frontend reads state.hint")
 }

--- a/internal/adapter/presenter/OpenFaceChineseWebPresenter.go
+++ b/internal/adapter/presenter/OpenFaceChineseWebPresenter.go
@@ -17,6 +17,19 @@ type OpenFaceChineseWebPresenter struct{}
 func (p *OpenFaceChineseWebPresenter) Output(g interfaces.OpenFaceChineseGame, lastErr error) string {
 	resObj := p.buildBase(g)
 	resObj.Message, resObj.MessageCode, resObj.MessageParams = p.buildMessage(g, lastErr)
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	//
+	// **フェーズと手番はここでは見ない。**OpenFaceChinese.GetHint() が自分で
+	// 「人間の手番で、かつ行動を選べる状態か」を確かめて nil を返す。
+	if hint := g.GetHint(); hint != nil {
+		resObj.Hint = &controller.OpenFaceChineseWebOutputHint{
+			Row:    hint.Row,
+			Reason: hint.Reason,
+		}
+	}
+
 	return marshalOrError(resObj)
 }
 

--- a/internal/adapter/presenter/OpenFaceChineseWebPresenter_test.go
+++ b/internal/adapter/presenter/OpenFaceChineseWebPresenter_test.go
@@ -34,6 +34,10 @@ func setupOpenFaceChineseWebMock() (*interfaces.MockOpenFaceChineseGame, []*doma
 	m.On("GetPlayerCnt").Return(2)
 	m.On("GetPlayer", 0).Return(human)
 	m.On("GetPlayer", 1).Return(cpu)
+	// **Output() も受動ヒントを埋める**ようになった (#4483)。既定は「ヒント無し」。
+	// **base だけに置く。**removeMockCall は最初の 1 件しか外さない。
+	m.On("GetHint").Return(nil).Maybe()
+
 	return m, players
 }
 
@@ -111,6 +115,7 @@ func TestOpenFaceChineseWebPresenter_HintOutput(t *testing.T) {
 
 	t.Run("with hint", func(t *testing.T) {
 		m, _ := setupOpenFaceChineseWebMock()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHint")
 		m.On("GetHint").Return(&domain.OpenFaceChineseHint{Row: domain.OpenFaceChineseRowBack, Reason: "strong_back"})
 		result := p.HintOutput(m)
 		var out controller.OpenFaceChineseWebOutput
@@ -121,6 +126,7 @@ func TestOpenFaceChineseWebPresenter_HintOutput(t *testing.T) {
 
 	t.Run("no hint", func(t *testing.T) {
 		m, _ := setupOpenFaceChineseWebMock()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHint")
 		m.On("GetHint").Return((*domain.OpenFaceChineseHint)(nil))
 		result := p.HintOutput(m)
 		var out controller.OpenFaceChineseWebOutput
@@ -134,4 +140,18 @@ func TestOpenFaceChineseWebPresenter_ActionLogOutput(t *testing.T) {
 	m, _ := setupOpenFaceChineseWebMock()
 	result := p.ActionLogOutput(m)
 	assert.NotEmpty(t, result)
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+//
+// Output 側にゲートは置きません。OpenFaceChinese.GetHint() が「人間の手番で、かつ
+// 行動を選べる状態か」を自分で確かめて nil を返します。
+func TestOpenFaceChineseWebPresenterOutputCarriesTheHint(t *testing.T) {
+	ofc, _ := setupOpenFaceChineseWebMock()
+	ofc.ExpectedCalls = removeMockCall(ofc.ExpectedCalls, "GetHint")
+	ofc.On("GetHint").Return(&domain.OpenFaceChineseHint{Row: 1, Reason: "balance"})
+
+	result := new(presenter.OpenFaceChineseWebPresenter).Output(ofc, nil)
+	assert.Contains(t, result, `"hint"`, "Output must carry the hint -- the frontend reads state.hint")
 }

--- a/internal/adapter/presenter/SoloWhistWebPresenter.go
+++ b/internal/adapter/presenter/SoloWhistWebPresenter.go
@@ -17,6 +17,19 @@ type SoloWhistWebPresenter struct{}
 func (p *SoloWhistWebPresenter) Output(g interfaces.SoloWhistGame, lastErr error) string {
 	resObj := p.buildBase(g)
 	resObj.Message, resObj.MessageCode, resObj.MessageParams = p.buildMessage(g, lastErr)
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	//
+	// **フェーズと手番はここでは見ない。**SoloWhist.GetHint() が自分で
+	// 「人間の手番で、かつ行動を選べる状態か」を確かめて nil を返す。
+	if hint := g.GetHint(); hint != nil {
+		resObj.Hint = &controller.WebOutputCardHint{
+			CardIndices: hint.CardIndices,
+			Reason:      hint.Reason,
+		}
+	}
+
 	return marshalOrError(resObj)
 }
 

--- a/internal/adapter/presenter/SoloWhistWebPresenter_test.go
+++ b/internal/adapter/presenter/SoloWhistWebPresenter_test.go
@@ -37,6 +37,10 @@ func setupSoloWhistWebMock() *interfaces.MockSoloWhistGame {
 	m.On("IsHumanBidTurn").Return(false)
 	m.On("GetConfig").Return(domain.DefaultSoloWhistConfig())
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
+	// **Output() も受動ヒントを埋める**ようになった (#4483)。既定は「ヒント無し」。
+	// **base だけに置く。**removeMockCall は最初の 1 件しか外さない。
+	m.On("GetHint").Return(nil).Maybe()
+
 	return m
 }
 
@@ -183,6 +187,7 @@ func TestSoloWhistWebPresenter_HintOutput(t *testing.T) {
 
 	t.Run("hint with card indices", func(t *testing.T) {
 		m, _ := setupSoloWhistWebMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHint")
 		m.On("GetHint").Return(&domain.SoloWhistHint{CardIndices: []int{2}, Reason: "follow_win"})
 		result := p.HintOutput(m)
 		var resObj controller.SoloWhistWebOutput
@@ -194,6 +199,7 @@ func TestSoloWhistWebPresenter_HintOutput(t *testing.T) {
 
 	t.Run("no hint", func(t *testing.T) {
 		m, _ := setupSoloWhistWebMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHint")
 		m.On("GetHint").Return((*domain.SoloWhistHint)(nil))
 		result := p.HintOutput(m)
 		var resObj controller.SoloWhistWebOutput
@@ -211,4 +217,18 @@ func TestSoloWhistWebPresenter_ActionLogOutput(t *testing.T) {
 	})
 	result := p.ActionLogOutput(m)
 	assert.Contains(t, result, `"actionType":"play"`)
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+//
+// Output 側にゲートは置きません。SoloWhist.GetHint() が「人間の手番で、かつ
+// 行動を選べる状態か」を自分で確かめて nil を返します。
+func TestSoloWhistWebPresenterOutputCarriesTheHint(t *testing.T) {
+	swg, _ := setupSoloWhistWebMockWithPlayers()
+	swg.ExpectedCalls = removeMockCall(swg.ExpectedCalls, "GetHint")
+	swg.On("GetHint").Return(&domain.SoloWhistHint{CardIndices: []int{0}, Reason: "follow_suit"})
+
+	result := new(presenter.SoloWhistWebPresenter).Output(swg, nil)
+	assert.Contains(t, result, `"hint"`, "Output must carry the hint -- the frontend reads state.hint")
 }

--- a/internal/adapter/presenter/SpoilFiveWebPresenter.go
+++ b/internal/adapter/presenter/SpoilFiveWebPresenter.go
@@ -17,6 +17,19 @@ type SpoilFiveWebPresenter struct{}
 func (p *SpoilFiveWebPresenter) Output(g interfaces.SpoilFiveGame, lastErr error) string {
 	resObj := p.buildBase(g)
 	resObj.Message, resObj.MessageCode, resObj.MessageParams = p.buildMessage(g, lastErr)
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	//
+	// **フェーズと手番はここでは見ない。**SpoilFive.GetHint() が自分で
+	// 「人間の手番で、かつ行動を選べる状態か」を確かめて nil を返す。
+	if hint := g.GetHint(); hint != nil {
+		resObj.Hint = &controller.WebOutputCardHint{
+			CardIndices: hint.CardIndices,
+			Reason:      hint.Reason,
+		}
+	}
+
 	return marshalOrError(resObj)
 }
 

--- a/internal/adapter/presenter/SpoilFiveWebPresenter_test.go
+++ b/internal/adapter/presenter/SpoilFiveWebPresenter_test.go
@@ -33,6 +33,10 @@ func setupSpoilFiveWebMock() *interfaces.MockSpoilFiveGame {
 	m.On("IsHumanTurn").Return(true)
 	m.On("GetConfig").Return(domain.DefaultSpoilFiveConfig())
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
+	// **Output() も受動ヒントを埋める**ようになった (#4483)。既定は「ヒント無し」。
+	// **base だけに置く。**removeMockCall は最初の 1 件しか外さない。
+	m.On("GetHint").Return(nil).Maybe()
+
 	return m
 }
 
@@ -179,6 +183,7 @@ func TestSpoilFiveWebPresenter_HintOutput(t *testing.T) {
 
 	t.Run("hint with card indices", func(t *testing.T) {
 		m, _ := setupSpoilFiveWebMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHint")
 		m.On("GetHint").Return(&domain.SpoilFiveHint{CardIndices: []int{2}, Reason: "take_trick"})
 		result := p.HintOutput(m)
 		var resObj controller.SpoilFiveWebOutput
@@ -190,6 +195,7 @@ func TestSpoilFiveWebPresenter_HintOutput(t *testing.T) {
 
 	t.Run("no hint", func(t *testing.T) {
 		m, _ := setupSpoilFiveWebMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHint")
 		m.On("GetHint").Return((*domain.SpoilFiveHint)(nil))
 		result := p.HintOutput(m)
 		var resObj controller.SpoilFiveWebOutput
@@ -207,4 +213,18 @@ func TestSpoilFiveWebPresenter_ActionLogOutput(t *testing.T) {
 	})
 	result := p.ActionLogOutput(m)
 	assert.Contains(t, result, `"actionType":"play"`)
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+//
+// Output 側にゲートは置きません。SpoilFive.GetHint() が「人間の手番で、かつ
+// 行動を選べる状態か」を自分で確かめて nil を返します。
+func TestSpoilFiveWebPresenterOutputCarriesTheHint(t *testing.T) {
+	sfg, _ := setupSpoilFiveWebMockWithPlayers()
+	sfg.ExpectedCalls = removeMockCall(sfg.ExpectedCalls, "GetHint")
+	sfg.On("GetHint").Return(&domain.SpoilFiveHint{CardIndices: []int{0}, Reason: "follow_suit"})
+
+	result := new(presenter.SpoilFiveWebPresenter).Output(sfg, nil)
+	assert.Contains(t, result, `"hint"`, "Output must carry the hint -- the frontend reads state.hint")
 }

--- a/internal/adapter/presenter/TwentyNineWebPresenter.go
+++ b/internal/adapter/presenter/TwentyNineWebPresenter.go
@@ -17,6 +17,19 @@ type TwentyNineWebPresenter struct{}
 func (p *TwentyNineWebPresenter) Output(g interfaces.TwentyNineGame, lastErr error) string {
 	resObj := p.buildBase(g)
 	resObj.Message, resObj.MessageCode, resObj.MessageParams = p.buildMessage(g, lastErr)
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	//
+	// **フェーズと手番はここでは見ない。**TwentyNine.GetHint() が自分で
+	// 「人間の手番で、かつ行動を選べる状態か」を確かめて nil を返す。
+	if hint := g.GetHint(); hint != nil {
+		resObj.Hint = &controller.WebOutputCardHint{
+			CardIndices: hint.CardIndices,
+			Reason:      hint.Reason,
+		}
+	}
+
 	return marshalOrError(resObj)
 }
 

--- a/internal/adapter/presenter/TwentyNineWebPresenter_test.go
+++ b/internal/adapter/presenter/TwentyNineWebPresenter_test.go
@@ -38,6 +38,10 @@ func setupTwentyNineWebMock() *interfaces.MockTwentyNineGame {
 	m.On("IsHumanBidTurn").Return(false)
 	m.On("GetConfig").Return(domain.DefaultTwentyNineConfig())
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
+	// **Output() も受動ヒントを埋める**ようになった (#4483)。既定は「ヒント無し」。
+	// **base だけに置く。**removeMockCall は最初の 1 件しか外さない。
+	m.On("GetHint").Return(nil).Maybe()
+
 	return m
 }
 
@@ -197,6 +201,7 @@ func TestTwentyNineWebPresenter_HintOutput(t *testing.T) {
 
 	t.Run("hint with card indices", func(t *testing.T) {
 		m, _ := setupTwentyNineWebMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHint")
 		m.On("GetHint").Return(&domain.TwentyNineHint{CardIndices: []int{2}, Reason: "follow_win"})
 		result := p.HintOutput(m)
 		var resObj controller.TwentyNineWebOutput
@@ -208,6 +213,7 @@ func TestTwentyNineWebPresenter_HintOutput(t *testing.T) {
 
 	t.Run("no hint", func(t *testing.T) {
 		m, _ := setupTwentyNineWebMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHint")
 		m.On("GetHint").Return((*domain.TwentyNineHint)(nil))
 		result := p.HintOutput(m)
 		var resObj controller.TwentyNineWebOutput
@@ -225,4 +231,18 @@ func TestTwentyNineWebPresenter_ActionLogOutput(t *testing.T) {
 	})
 	result := p.ActionLogOutput(m)
 	assert.Contains(t, result, `"actionType":"play"`)
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+//
+// Output 側にゲートは置きません。TwentyNine.GetHint() が「人間の手番で、かつ
+// 行動を選べる状態か」を自分で確かめて nil を返します。
+func TestTwentyNineWebPresenterOutputCarriesTheHint(t *testing.T) {
+	tng, _ := setupTwentyNineWebMockWithPlayers()
+	tng.ExpectedCalls = removeMockCall(tng.ExpectedCalls, "GetHint")
+	tng.On("GetHint").Return(&domain.TwentyNineHint{CardIndices: []int{0}, Reason: "follow_suit"})
+
+	result := new(presenter.TwentyNineWebPresenter).Output(tng, nil)
+	assert.Contains(t, result, `"hint"`, "Output must carry the hint -- the frontend reads state.hint")
 }

--- a/internal/adapter/presenter/TwoTenJackWebPresenter.go
+++ b/internal/adapter/presenter/TwoTenJackWebPresenter.go
@@ -13,6 +13,20 @@ type TwoTenJackWebPresenter struct{}
 func (p *TwoTenJackWebPresenter) Output(s interfaces.TwoTenJackGame, lastErr error) string {
 	resObj := p.buildBase(s)
 	resObj.Message, resObj.MessageCode, resObj.MessageParams = p.buildMessage(s, lastErr)
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	//
+	// **フェーズと手番はここでは見ない。**TwoTenJack.GetHint() が自分で
+	// 「人間の手番で、かつ行動を選べる状態か」を確かめて nil を返す。
+	if hint := s.GetHint(); hint != nil {
+		resObj.Hint = &controller.TwoTenJackWebOutputHint{
+			CardIndex: hint.CardIndex,
+			TrumpSuit: hint.TrumpSuit,
+			Reason:    hint.Reason,
+		}
+	}
+
 	return marshalOrError(resObj)
 }
 

--- a/internal/adapter/presenter/TwoTenJackWebPresenter_test.go
+++ b/internal/adapter/presenter/TwoTenJackWebPresenter_test.go
@@ -30,6 +30,10 @@ func setupTTJWebMock() (*interfaces.MockTwoTenJackGame, []*domain.TwoTenJackPlay
 	m.On("GetPlayer", 1).Return(players[1])
 	m.On("GetPlayer", 2).Return(players[2])
 	m.On("GetPlayer", 3).Return(players[3])
+	// **Output() も受動ヒントを埋める**ようになった (#4483)。既定は「ヒント無し」。
+	// **base だけに置く。**removeMockCall は最初の 1 件しか外さない。
+	m.On("GetHint").Return(nil).Maybe()
+
 	return m, players
 }
 
@@ -101,6 +105,7 @@ func TestTwoTenJackWebPresenter_HintOutput(t *testing.T) {
 	t.Run("with hint", func(t *testing.T) {
 		m, _ := setupTTJWebMock()
 		idx := 0
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHint")
 		m.On("GetHint").Return(&domain.TwoTenJackHint{CardIndex: &idx, Reason: "lead"})
 		result := p.HintOutput(m)
 		assert.Contains(t, result, `"hint"`)
@@ -108,6 +113,7 @@ func TestTwoTenJackWebPresenter_HintOutput(t *testing.T) {
 
 	t.Run("no hint", func(t *testing.T) {
 		m, _ := setupTTJWebMock()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHint")
 		m.On("GetHint").Return((*domain.TwoTenJackHint)(nil))
 		result := p.HintOutput(m)
 		assert.NotContains(t, result, `"hint":{`)
@@ -120,4 +126,19 @@ func TestTwoTenJackWebPresenter_ActionLogOutput(t *testing.T) {
 	m.On("GetGameEndFlag").Return(false)
 	result := p.ActionLogOutput(m)
 	assert.NotEmpty(t, result)
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+//
+// Output 側にゲートは置きません。TwoTenJack.GetHint() が「人間の手番で、かつ
+// 行動を選べる状態か」を自分で確かめて nil を返します。
+func TestTwoTenJackWebPresenterOutputCarriesTheHint(t *testing.T) {
+	idx := 0
+	ttj, _ := setupTTJWebMock()
+	ttj.ExpectedCalls = removeMockCall(ttj.ExpectedCalls, "GetHint")
+	ttj.On("GetHint").Return(&domain.TwoTenJackHint{CardIndex: &idx, Reason: "lead_trump"})
+
+	result := new(presenter.TwoTenJackWebPresenter).Output(ttj, nil)
+	assert.Contains(t, result, `"hint"`, "Output must carry the hint -- the frontend reads state.hint")
 }


### PR DESCRIPTION
## 概要

**Forty-Fives / Knockout Whist / Solo Whist / Spoil Five / Twenty-Nine / Two-Ten-Jack / Open Face Chinese** —— CLI フォーマッタが `state.hint` を読まない群のうち、mock 生成ヘルパーが 1 つのものを**まとめて 7 本**。

Refs #4483

## 3 本ずつをやめました

型が固まったので 7 本同時に流しています。

| 決め打ちを外した点 | 効果 |
|---|---|
| ヘルパーは**名前ではなく形**で探す | **Two-Ten-Jack は `setupTTJWebMock`** — 名前では見つかりません |
| base ヘルパーが**ちょうど 1 つ**であることを assert | wrapper にも既定が入る事故（#4551）を構造的に防止 |
| ドメインの `GetHint()` ガードをそのまま使う | アダプタで二重に書かない |

2 本は mock を**2 値の 1 つ目**で返しており、ビルドが捕まえました。

## ヒントの形もばらばらです

| ゲーム | フィールド |
|---|---|
| Forty-Fives / Knockout Whist / Solo Whist / Spoil Five / Twenty-Nine | `CardIndices []int` / `Reason` |
| Two-Ten-Jack | `CardIndex *int` / `TrumpSuit *int` / `Reason` |
| **Open Face Chinese** | **`Row int`** / `Reason` |

## 負のコントロール

| | |
|---|---|
| ゲート 7 本を neuter（ビルド可を確認済み） | **7 件 FAIL** |
| 復元 | green |

## 確認

- `go test -tags test ./internal/adapter/presenter/ -count=2` green
- `golangci-lint run ./internal/adapter/presenter/` 0 issues

## Test plan

- [ ] CI 全ジョブ green