### PR TITLE
fix(hints): carry the passive hint for Court Piece and Piquet (#4483)

### DIFF
--- a/internal/adapter/presenter/CourtPieceWebPresenter.go
+++ b/internal/adapter/presenter/CourtPieceWebPresenter.go
@@ -17,6 +17,20 @@ type CourtPieceWebPresenter struct{}
 func (p *CourtPieceWebPresenter) Output(t interfaces.CourtPieceGame, lastErr error) string {
 	resObj := p.buildBase(t)
 	resObj.Message, resObj.MessageCode, resObj.MessageParams = p.buildMessage(t, lastErr)
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	//
+	// **フェーズと手番はここでは見ない。**CourtPiece.GetHint() が自分で
+	// 「人間の手番で、かつ行動を選べる状態か」を確かめて nil を返す。
+	if hint := t.GetHint(); hint != nil {
+		resObj.Hint = &controller.CourtPieceWebOutputHint{
+			CardIndex: hint.CardIndex,
+			TrumpSuit: hint.TrumpSuit,
+			Reason:    hint.Reason,
+		}
+	}
+
 	return marshalOrError(resObj)
 }
 

--- a/internal/adapter/presenter/CourtPieceWebPresenter_test.go
+++ b/internal/adapter/presenter/CourtPieceWebPresenter_test.go
@@ -158,3 +158,17 @@ func TestCourtPieceWebPresenter_ActionLogOutput(t *testing.T) {
 	out := p.ActionLogOutput(cp)
 	assert.NotEmpty(t, out)
 }
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+//
+// Output 側にゲートは置きません。CourtPiece.GetHint() が「人間の手番で、かつ
+// 行動を選べる状態か」を自分で確かめて nil を返します。
+func TestCourtPieceWebPresenterOutputCarriesTheHint(t *testing.T) {
+	cp := newCourtPieceForWebTest()
+	cp.SetPhase(domain.CourtPiecePhaseTrumpDeclaration)
+	cp.SetCallerIdx(0)
+
+	result := new(presenter.CourtPieceWebPresenter).Output(cp, nil)
+	assert.Contains(t, result, `"hint"`, "Output must carry the hint -- the frontend reads state.hint")
+}

--- a/internal/adapter/presenter/PiquetWebPresenter.go
+++ b/internal/adapter/presenter/PiquetWebPresenter.go
@@ -26,6 +26,20 @@ func (p *PiquetWebPresenter) Output(g interfaces.PiquetGame, lastErr error) stri
 		resObj.LegalPlayIndices = g.GetLegalPlayIndices(g.GetCurrentPlayerIdx())
 	}
 
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	//
+	// **フェーズと手番はここでは見ない。**Piquet.GetHint() が自分で
+	// 「人間の手番で、かつ行動を選べる状態か」を確かめて nil を返す。
+	if hint := g.GetHint(g.GetCurrentPlayerIdx()); hint != nil {
+		resObj.Hint = &controller.PiquetWebOutputHint{
+			CardIndex:      hint.CardIndex,
+			DiscardIndices: hint.DiscardIndices,
+			Reason:         hint.Reason,
+		}
+	}
+
 	return marshalOrError(resObj)
 }
 

--- a/internal/adapter/presenter/PiquetWebPresenter_test.go
+++ b/internal/adapter/presenter/PiquetWebPresenter_test.go
@@ -188,3 +188,37 @@ func TestPiquetWebPresenter_HintOutput_WithHint(t *testing.T) {
 		t.Errorf("messageCode unexpected: %v", parsed["messageCode"])
 	}
 }
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+//
+// 交換と申告を CPU に進めさせた時点でヒントが必ず出ます（100 回中 100 回で確認）。
+// Piquet の GetHint は現在手番を引数に取るので、呼び出し式ごと HintOutput から
+// 写しています。
+func TestPiquetWebPresenterOutputCarriesTheHint(t *testing.T) {
+	players := []*domain.PiquetPlayer{
+		domain.NewPiquetPlayer(false),
+		domain.NewPiquetPlayer(false),
+	}
+	g := domain.NewPiquet(domain.NewTrumpCardsBelote(), players,
+		domain.PiquetConfig{DealsPerPartie: 1, CpuDifficulty: domain.PiquetCpuDifficultyNormal})
+	g.Reset()
+	for g.GetPhase() == domain.PiquetPhaseExchange {
+		g.CpuPlay()
+	}
+	for g.GetPhase() == domain.PiquetPhaseDeclaration {
+		_, _ = g.ResolveDeclaration()
+	}
+	if g.GetHint(g.GetCurrentPlayerIdx()) == nil {
+		t.Fatal("fixture must actually produce a hint")
+	}
+
+	result := new(PiquetWebPresenter).Output(g, nil)
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(result), &parsed); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if parsed["hint"] == nil {
+		t.Error("Output must carry the hint -- the frontend reads state.hint")
+	}
+}


### PR DESCRIPTION
## 概要

CLI フォーマッタが `state.hint` を読まない群から 2 本。

Refs #4483

## Piquet の `GetHint` は引数を取ります

```go
hint := g.GetHint(g.GetCurrentPlayerIdx())
```

`GetHint()` 決め打ちだったのでビルドが落ちました。**呼び出し式ごと `HintOutput` から写して、受信者名だけ書き換える**ようにしています。

## Piquet の既存テストは何も確かめていませんでした

```go
if parsed["messageCode"] != "piquet.hintAvailable" && parsed["messageCode"] != "piquet.noHint" {
	t.Errorf(...)
}
```

**ヒントが返ろうと返るまいと通ります。**（テスト名は `_WithHint` です。）

新しいテストは同じ状態を作り、**フィクスチャが本当にヒントを出すことを先に assert** します。

```go
if g.GetHint(g.GetCurrentPlayerIdx()) == nil {
	t.Fatal("fixture must actually produce a hint")
}
```

その状態が確実であることは**先に 100 回試して nil 0 件**を確認しました。

## 負のコントロール

| | |
|---|---|
| ゲート 2 本を neuter（ビルド可を確認済み） | **2 件 FAIL** |
| 復元 | green |

## 確認

- `go test -tags test ./internal/adapter/presenter/ -count=3` green
- `golangci-lint run ./internal/adapter/presenter/` 0 issues

## Test plan

- [ ] CI 全ジョブ green