### PR TITLE
fix(hints): carry the passive hint for Russian Bank, Trente et Quarante, Truco and Five Hundred (#4483)

### DIFF
--- a/internal/adapter/presenter/FiveHundredWebPresenter.go
+++ b/internal/adapter/presenter/FiveHundredWebPresenter.go
@@ -17,6 +17,25 @@ type FiveHundredWebPresenter struct{}
 func (p *FiveHundredWebPresenter) Output(g interfaces.FiveHundredGame, lastErr error) string {
 	resObj := p.buildBase(g)
 	resObj.Message, resObj.MessageCode, resObj.MessageParams = p.buildMessage(g, lastErr)
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	//
+	// **フェーズと手番はここでは見ない。**FiveHundred.GetHint() が自分で
+	// 「人間の手番で、かつ行動を選べる状態か」を確かめて nil を返す。
+	if hint := g.GetHint(); hint != nil {
+		resObj.Hint = &controller.FiveHundredWebOutputHint{
+			BidKind:        hint.BidKind,
+			BidTricks:      hint.BidTricks,
+			BidSuit:        hint.BidSuit,
+			Pass:           hint.Pass,
+			DiscardIndices: hint.DiscardIndices,
+			CardIndex:      hint.CardIndex,
+			JokerSuit:      hint.JokerSuit,
+			Reason:         hint.Reason,
+		}
+	}
+
 	return marshalOrError(resObj)
 }
 

--- a/internal/adapter/presenter/FiveHundredWebPresenter_test.go
+++ b/internal/adapter/presenter/FiveHundredWebPresenter_test.go
@@ -136,3 +136,24 @@ func TestFiveHundredWebPresenter_PhaseMessages(t *testing.T) {
 		t.Errorf("game-end message missing: %s", out)
 	}
 }
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+//
+// Output 側にゲートは置きません。FiveHundred.GetHint() が「人間の手番で、かつ
+// 行動を選べる状態か」を自分で確かめて nil を返します。
+func TestFiveHundredWebPresenterOutputCarriesTheHint(t *testing.T) {
+	g := newFiveHundredGame()
+	g.SetContract(domain.FiveHundredContractSuit, 7, domain.CardDesignSpade)
+	g.GetPlayer(0).AddCard(domain.NewCard(domain.CardDesignSpade, 1, false))
+	g.SetPhase(domain.FiveHundredPhasePlay)
+	g.SetCurrentPlayerIdx(0)
+	if g.GetHint() == nil {
+		t.Fatal("fixture must actually produce a hint")
+	}
+
+	result := new(presenter.FiveHundredWebPresenter).Output(g, nil)
+	if !strings.Contains(result, `"hint"`) {
+		t.Error("Output must carry the hint -- the frontend reads state.hint")
+	}
+}

--- a/internal/adapter/presenter/RussianBankWebPresenter.go
+++ b/internal/adapter/presenter/RussianBankWebPresenter.go
@@ -16,6 +16,22 @@ type RussianBankWebPresenter struct{}
 func (p *RussianBankWebPresenter) Output(g interfaces.RussianBankGame, lastErr error) string {
 	resObj := p.buildBase(g)
 	resObj.Message, resObj.MessageCode, resObj.MessageParams = p.buildMessage(g, lastErr)
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	//
+	// **フェーズと手番はここでは見ない。**RussianBank.GetHint() が自分で
+	// 「人間の手番で、かつ行動を選べる状態か」を確かめて nil を返す。
+	if hint := g.GetHint(); hint != nil {
+		resObj.Hint = &controller.RussianBankWebOutputHint{
+			Zone:         int(hint.Zone),
+			FromOpponent: hint.FromOpponent,
+			Col:          hint.Col,
+			ToFoundation: hint.ToFoundation,
+			ToCol:        hint.ToCol,
+		}
+	}
+
 	return marshalOrError(resObj)
 }
 

--- a/internal/adapter/presenter/RussianBankWebPresenter_test.go
+++ b/internal/adapter/presenter/RussianBankWebPresenter_test.go
@@ -61,3 +61,19 @@ func TestRussianBankWebPresenter_Output(t *testing.T) {
 		assert.True(t, json.Valid([]byte(out)))
 	})
 }
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+//
+// Output 側にゲートは置きません。RussianBank.GetHint() が「人間の手番で、かつ
+// 行動を選べる状態か」を自分で確かめて nil を返します。
+func TestRussianBankWebPresenterOutputCarriesTheHint(t *testing.T) {
+	g := domain.NewDefaultRussianBank()
+	g.Reset()
+	if g.GetHint() == nil {
+		t.Fatal("fixture must actually produce a hint")
+	}
+
+	result := new(presenter.RussianBankWebPresenter).Output(g, nil)
+	assert.Contains(t, result, `"hint"`, "Output must carry the hint -- the frontend reads state.hint")
+}

--- a/internal/adapter/presenter/TrenteEtQuaranteWebPresenter.go
+++ b/internal/adapter/presenter/TrenteEtQuaranteWebPresenter.go
@@ -20,6 +20,19 @@ func (p *TrenteEtQuaranteWebPresenter) Output(g interfaces.TrenteEtQuaranteGame,
 	} else if g.GetPhase() == domain.TrenteEtQuarantePhaseResult {
 		resObj.Message, resObj.MessageCode = trenteEtQuaranteEndMessage(g)
 	}
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	//
+	// **フェーズと手番はここでは見ない。**TrenteEtQuarante.GetHint() が自分で
+	// 「人間の手番で、かつ行動を選べる状態か」を確かめて nil を返す。
+	if hint := g.GetHint(); hint != nil {
+		resObj.Hint = &controller.TrenteEtQuaranteWebOutputHint{
+			Bet:    int(hint.Bet),
+			Reason: hint.Reason,
+		}
+	}
+
 	return marshalOrError(resObj)
 }
 

--- a/internal/adapter/presenter/TrenteEtQuaranteWebPresenter_test.go
+++ b/internal/adapter/presenter/TrenteEtQuaranteWebPresenter_test.go
@@ -72,3 +72,19 @@ func TestTrenteEtQuaranteWebPresenter_ActionLog(t *testing.T) {
 	p := new(presenter.TrenteEtQuaranteWebPresenter)
 	assert.NotEmpty(t, p.ActionLogOutput(g))
 }
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+//
+// Output 側にゲートは置きません。TrenteEtQuarante.GetHint() が「人間の手番で、かつ
+// 行動を選べる状態か」を自分で確かめて nil を返します。
+func TestTrenteEtQuaranteWebPresenterOutputCarriesTheHint(t *testing.T) {
+	g := domain.NewDefaultTrenteEtQuarante()
+	g.Reset()
+	if g.GetHint() == nil {
+		t.Fatal("fixture must actually produce a hint")
+	}
+
+	result := new(presenter.TrenteEtQuaranteWebPresenter).Output(g, nil)
+	assert.Contains(t, result, `"hint"`, "Output must carry the hint -- the frontend reads state.hint")
+}

--- a/internal/adapter/presenter/TrucoWebPresenter.go
+++ b/internal/adapter/presenter/TrucoWebPresenter.go
@@ -15,6 +15,20 @@ type TrucoWebPresenter struct{}
 func (p *TrucoWebPresenter) Output(g interfaces.TrucoGame, lastErr error) string {
 	resObj := p.buildBase(g)
 	resObj.Message, resObj.MessageCode, resObj.MessageParams = p.buildMessage(g, lastErr)
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	//
+	// **フェーズと手番はここでは見ない。**Truco.GetHint() が自分で
+	// 「人間の手番で、かつ行動を選べる状態か」を確かめて nil を返す。
+	if hint := g.GetHint(); hint != nil {
+		resObj.Hint = &controller.TrucoWebOutputHint{
+			Action:    hint.Action,
+			CardIndex: hint.CardIndex,
+			Reason:    hint.Reason,
+		}
+	}
+
 	return marshalOrError(resObj)
 }
 

--- a/internal/adapter/presenter/TrucoWebPresenter_test.go
+++ b/internal/adapter/presenter/TrucoWebPresenter_test.go
@@ -123,3 +123,21 @@ func TestTrucoWebPresenter_ActionLogOutput(t *testing.T) {
 	g := newTrucoGame()
 	assert.NotEmpty(t, p.ActionLogOutput(g))
 }
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+//
+// Output 側にゲートは置きません。Truco.GetHint() が「人間の手番で、かつ
+// 行動を選べる状態か」を自分で確かめて nil を返します。
+func TestTrucoWebPresenterOutputCarriesTheHint(t *testing.T) {
+	g := newTrucoGame()
+	g.SetPhase(domain.TrucoPhasePlay)
+	g.SetCurrentPlayerIdx(0)
+	g.SetCurrentTrick(nil)
+	if g.GetHint() == nil {
+		t.Fatal("fixture must actually produce a hint")
+	}
+
+	result := new(presenter.TrucoWebPresenter).Output(g, nil)
+	assert.Contains(t, result, `"hint"`, "Output must carry the hint -- the frontend reads state.hint")
+}


### PR DESCRIPTION
## 概要

CLI フォーマッタが `state.hint` を読まない群から 4 本。

Refs #4483

## フィクスチャが本当にヒントを出すことを、毎回先に assert します

```go
if g.GetHint() == nil {
	t.Fatal("fixture must actually produce a hint")
}
```

流用元の既存テストのうち **3 本はこれを確かめていませんでした。**

| ゲーム | 既存テストの assert | 問題 |
|---|---|---|
| Russian Bank | `Contains(out, "hint") \|\| Contains(out, "zone")` | **どちらでも通る** |
| Five Hundred | `strings.Contains(out, "hint")` | **`noHint` にも "hint" が含まれる** |
| Trente et Quarante | `assert.Contains(decoded, "hint")` | キーの存在のみ |

同じフィクスチャを使う以上、**そのフィクスチャが実際にヒントを出すことを自分で確かめない限り、新しいテストも空振りします。**

## 負のコントロール

| | |
|---|---|
| ゲート 4 本を neuter（ビルド可を確認済み） | **4 件 FAIL** |
| 復元 | green |

## 確認

- `go test -tags test ./internal/adapter/presenter/ -count=2` green
- `golangci-lint run ./internal/adapter/presenter/` 0 issues

## Test plan

- [ ] CI 全ジョブ green