### PR TITLE
fix(hints): carry the passive hint for Bid Whist (#4483)

### DIFF
--- a/internal/adapter/presenter/BidWhistWebPresenter.go
+++ b/internal/adapter/presenter/BidWhistWebPresenter.go
@@ -17,6 +17,24 @@ type BidWhistWebPresenter struct{}
 func (p *BidWhistWebPresenter) Output(g interfaces.BidWhistGame, lastErr error) string {
 	resObj := p.buildBase(g)
 	resObj.Message, resObj.MessageCode, resObj.MessageParams = p.buildMessage(g, lastErr)
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	//
+	// **フェーズと手番はここでは見ない。**BidWhist.GetHint() が自分で
+	// 「人間の手番で、かつ行動を選べる状態か」を確かめて nil を返す。
+	if hint := g.GetHint(); hint != nil {
+		resObj.Hint = &controller.BidWhistWebOutputHint{
+			BidTricks:      hint.BidTricks,
+			BidDirection:   hint.BidDirection,
+			Pass:           hint.Pass,
+			TrumpSuit:      hint.TrumpSuit,
+			DiscardIndices: hint.DiscardIndices,
+			CardIndex:      hint.CardIndex,
+			Reason:         hint.Reason,
+		}
+	}
+
 	return marshalOrError(resObj)
 }
 

--- a/internal/adapter/presenter/BidWhistWebPresenter_test.go
+++ b/internal/adapter/presenter/BidWhistWebPresenter_test.go
@@ -193,3 +193,27 @@ func TestBidWhistWebPresenter_PhaseMessages(t *testing.T) {
 		t.Errorf("game-end message missing: %s", out)
 	}
 }
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+//
+// Reset 直後は入札フェーズに入っておらず、GetHint は 200 回中 200 回 nil を
+// 返す。フェーズと入札手番を明示して初めてヒントが出る（この状態でも 200/200 で
+// 確認済み）。
+func TestBidWhistWebPresenterOutputCarriesTheHint(t *testing.T) {
+	g := newBidWhistGame()
+	g.Reset()
+	g.SetPhase(domain.BidWhistPhaseBid)
+	g.SetBidPlayerIdx(0)
+	if g.GetHint() == nil {
+		t.Fatal("fixture must actually produce a hint")
+	}
+
+	var parsed controller.BidWhistWebOutput
+	if err := json.Unmarshal([]byte(new(presenter.BidWhistWebPresenter).Output(g, nil)), &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if parsed.Hint == nil {
+		t.Error("Output must carry the hint -- the frontend reads state.hint")
+	}
+}


### PR DESCRIPTION
## 概要

[#4549 で落とした Bid Whist](https://github.com/yuta-yoshinaga/go_trumpcards/pull/4549) を、テストを書けるようにして入れます。**CLI が `state.hint` を読まない群はこれで終わりです。**

Refs #4483

## なぜ落としていたか / どう解いたか

`Reset()` 直後は**入札フェーズに入っていません。**

| 状態 | `GetHint()` が nil |
|---|---|
| `Reset()` のみ | **200 / 200** |
| `SetPhase(BidWhistPhaseBid)` + `SetBidPlayerIdx(0)` | **0 / 200** |

フェーズと入札手番を明示して初めてヒントが出ます。テストは**そのフィクスチャが本当にヒントを出すことを先に assert** してから Output を見ます。

```go
g.SetPhase(domain.BidWhistPhaseBid)
g.SetBidPlayerIdx(0)
if g.GetHint() == nil {
	t.Fatal("fixture must actually produce a hint")
}
```

## 負のコントロール

| | |
|---|---|
| ゲートを neuter（ビルド可を確認済み） | **1 件 FAIL** |
| 復元 | green |

## 確認

- `go test -tags test ./internal/adapter/presenter/ -count=3` green
- `golangci-lint run ./internal/adapter/presenter/` 0 issues

## Test plan

- [ ] CI 全ジョブ green