### PR TITLE
chore(hints): point the hint-coverage guard at its live tracking issue (#4557)

### DIFF
--- a/frontend/scripts/check-hint-coverage.mjs
+++ b/frontend/scripts/check-hint-coverage.mjs
@@ -4,7 +4,7 @@
 // docs/new-game-checklist.md item 14 asks each new game for a hint factory
 // registered in `hintFactories`. Nothing enforced it, and two games in a row
 // shipped without one (Literature #257, Guandan #258) before a reviewer
-// noticed — see issue #4520. Neither game's absence was visible anywhere:
+// noticed — see issue #4557. Neither game's absence was visible anywhere:
 //
 //   - `useGameHint` looks the name up with `hintFactories[gameName]?.(state)`,
 //     so a missing factory yields `null` rather than throwing. The page renders
@@ -40,7 +40,7 @@ const ALLOWED = new Map();
  *
  * This is a RATCHET, not an exemption list: the guard fails if a game outside
  * both maps is missing a hint, so the set can shrink but never grow. Delete a
- * name from here when you write its factory. Filed as issue #4520.
+ * name from here when you write its factory. Filed as issue #4557.
  *
  * The count was 39 when the guard went in, which is the point. The reviewer on
  * PR #4519 saw two consecutive games skip checklist item 14 and read it as a
@@ -158,5 +158,5 @@ if (missing.length > 0 || stale.length > 0 || redundant.length > 0) {
 
 console.log(
   `hint-coverage: OK (${hinted.size} of ${games.size} games hinted; ` +
-    `${ALLOWED.size} need none; ${BACKLOG.size} still owed, see #4520).`,
+    `${ALLOWED.size} need none; ${BACKLOG.size} still owed, see #4557).`,
 );


### PR DESCRIPTION
## 概要

`check-hint-coverage` ガードが**閉じた issue #4520 を指したまま**でした。`bun run check` を回した人全員がこのメッセージを見ます。

```
hint-coverage: OK (220 of 259 games hinted; 0 need none; 39 still owed, see #4520).
                                                                          ^^^^^ CLOSED
```

参照 3 箇所（ファイル冒頭のコメント 2 つと、**実際に印字されるメッセージ**）を **#4557** に更新しました。

Closes #4557 ではありません（#4557 は 39 ゲームの配線そのものを追跡します）。

## #4557 に記録した実態

抜き取りで確認しました。**バックエンドは既に揃っています。**

| ゲーム | ドメインの `GetHint` | `HintOutput` | ページの `useGameHint` |
|---|---|---|---|
| Aces Up | ✅ | ✅ | **❌** |
| Briscola | ✅ | ✅ | **❌** |
| La Belle Lucie | ✅ | ✅ | **❌** |

**API はヒントを返せるのに、ページが要求しません。**

## #4483 と紛らわしいので、issue に区別を明記しました

| | 症状 |
|---|---|
| **#4483** | `Output()` がヒントを載せず、ページの `state.hint` が常に undefined |
| **#4557** | ページが `useGameHint` を呼ばず、**要求する導線が無い** |

両方に該当するゲームもあります（Briscola / La Belle Lucie / Russian Bank / Open Face Chinese / Piquet）。

## 確認

- `bun scripts/check-hint-coverage.mjs` → `... 39 still owed, see #4557).`

## Test plan

- [ ] CI 全ジョブ green