### PR TITLE
feat(hints): wire the frontend hint for Aces Up (#4557)

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -171,7 +171,7 @@ match on the code if you ever script against tsc output.
 | `TutorialProvider` | `src/providers/TutorialProvider.tsx` | Context provider; renders overlay (used internally by TutorialWrapper) |
 | `TutorialOverlay` | `src/components/tutorial/TutorialOverlay.tsx` | Full-screen overlay with SVG mask spotlight |
 | `useTutorial` | `src/hooks/useTutorial.ts` | State management (step progression, localStorage, resume/restart) |
-| `useGameHint` | `src/hooks/useGameHint.ts` | Frontend hints; registry-driven via `hintFactories` (covers most games; currently 220). `frontend/scripts/check-hint-coverage.mjs` fails the build for any new game without one. The supported set is the `HintGameName` union (`keyof typeof hintFactories`) — add a game by registering its factory there |
+| `useGameHint` | `src/hooks/useGameHint.ts` | Frontend hints; registry-driven via `hintFactories` (covers most games; currently 221). `frontend/scripts/check-hint-coverage.mjs` fails the build for any new game without one. The supported set is the `HintGameName` union (`keyof typeof hintFactories`) — add a game by registering its factory there |
 | `TutorialSuggestDialog` | `src/components/tutorial/TutorialSuggestDialog.tsx` | First-visit dialog; controlled by `useFirstVisit` hook |
 | `TutorialProgressPanel` | `src/components/tutorial/TutorialProgressPanel.tsx` | Progress overview in NavBar |
 

--- a/frontend/scripts/check-hint-coverage.mjs
+++ b/frontend/scripts/check-hint-coverage.mjs
@@ -49,7 +49,6 @@ const ALLOWED = new Map();
  * It was never recent. Prose alone had never held.
  */
 const BACKLOG = new Set([
-  'acesup',
   'bideuchre',
   'blackhole',
   'boston',

--- a/frontend/src/hooks/useGameHint.ts
+++ b/frontend/src/hooks/useGameHint.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import type {
   AccordionResponse,
+  AcesUpResponse,
   AgnesResponse,
   AllFoursResponse,
   AmericanToadResponse,
@@ -203,6 +204,7 @@ import type {
 } from '../types/card';
 import type { HintResult } from '../types/hint';
 import { getAccordionHint } from '../utils/hints/accordionHint';
+import { getAcesUpHint } from '../utils/hints/acesupHint';
 import { getAgnesHint } from '../utils/hints/agnesHint';
 import { getAllFoursHint } from '../utils/hints/allfoursHint';
 import { getAmericanToadHint } from '../utils/hints/americantoadHint';
@@ -538,6 +540,7 @@ export const hintFactories = {
   wasp: (s) => getWaspHint(s as WaspResponse),
   easthaven: (s) => getEasthavenHint(s as EasthavenResponse),
   accordion: (s) => getAccordionHint(s as AccordionResponse),
+  acesup: (s) => getAcesUpHint(s as AcesUpResponse),
   calculation: (s) => getCalculationHint(s as CalculationResponse),
   sirtommy: (s) => getSirTommyHint(s as SirTommyResponse),
   bisley: (s) => getBisleyHint(s as BisleyResponse),

--- a/frontend/src/i18n/locales/en/acesup.json
+++ b/frontend/src/i18n/locales/en/acesup.json
@@ -35,5 +35,10 @@
     "controls": "Action buttons: remove, move, and deal.",
     "resetButton": "Use the reset button to start a new game."
   },
-  "landscapeBanner": "Rotate to landscape for easier play"
+  "landscapeBanner": "Rotate to landscape for easier play",
+  "frontendHint": {
+    "acesupRemove": "A lower card of the same suit can be discarded",
+    "acesupMove": "Moving to an empty column exposes a new card",
+    "acesupDeal": "One card can be dealt to each column"
+  }
 }

--- a/frontend/src/i18n/locales/ja/acesup.json
+++ b/frontend/src/i18n/locales/ja/acesup.json
@@ -35,5 +35,10 @@
     "controls": "操作ボタンです。除去・移動・配るを選べます。",
     "resetButton": "リセットボタンで新しいゲームを始められます。"
   },
-  "landscapeBanner": "横向きにすると操作しやすくなります"
+  "landscapeBanner": "横向きにすると操作しやすくなります",
+  "frontendHint": {
+    "acesupRemove": "同じスートで数の小さい札を捨てられます",
+    "acesupMove": "空いた列へ動かすと新しい札をめくれます",
+    "acesupDeal": "各列に 1 枚ずつ配れます"
+  }
 }

--- a/frontend/src/pages/AcesUpPage.tsx
+++ b/frontend/src/pages/AcesUpPage.tsx
@@ -11,6 +11,7 @@ import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
+import { FrontendHintTooltip } from '../components/hint/FrontendHintTooltip';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { LandscapeBanner } from '../components/LandscapeBanner';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
@@ -23,6 +24,7 @@ import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
+import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useGiveUpConfirm } from '../hooks/useGiveUpConfirm';
 import { useSolitaireDragDrop } from '../hooks/useSolitaireDragDrop';
@@ -35,6 +37,7 @@ import { cardAlt } from '../utils/cardAlt';
 import { ACESUP_HELP, parseAcesUpCommand } from '../utils/cli/commands/acesupCommands';
 import { formatAcesUpState } from '../utils/cli/formatters/acesupFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { hintCheckboxItem } from '../utils/settingsItems';
 
 /** Aces Up tutorial step definitions. */
 const ACESUP_TUTORIAL_STEPS: TutorialStep[] = [
@@ -115,6 +118,12 @@ function AcesUpPageContent() {
   const busy = loading || isRemovingAll;
 
   // CLI mode
+  const {
+    hint: frontendHint,
+    hintEnabled: frontendHintEnabled,
+    setHintEnabled: setFrontendHintEnabled,
+  } = useGameHint('acesup', state);
+
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('acesup');
   const cliConfig: CliGameConfig<AcesUpResponse, Parameters<typeof acesupApi.exec>> = useMemo(
     () => ({
@@ -353,6 +362,8 @@ function AcesUpPageContent() {
               messageParams={state.messageParams}
             />
 
+            <FrontendHintTooltip hint={frontendHint} enabled={frontendHintEnabled} t={t} />
+
             <ActionLogSection
               isEndPhase={isEnded}
               actionLog={actionLog}
@@ -361,7 +372,10 @@ function AcesUpPageContent() {
             />
           </div>
 
-          <SettingsPanel title={tc('settings.title')} groups={[]} />
+          <SettingsPanel
+            title={tc('settings.title')}
+            groups={[{ items: [hintCheckboxItem(tc, frontendHintEnabled, setFrontendHintEnabled)] }]}
+          />
 
           <GameFooter className={`${gameTheme.acesup.footer} px-4 py-2.5`}>
             <ErrorAlert message={error ?? hintError} onRetry={retry} />

--- a/frontend/src/utils/hints/acesupHint.test.ts
+++ b/frontend/src/utils/hints/acesupHint.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import type { AcesUpResponse } from '../../types/card';
+import { getAcesUpHint } from './acesupHint';
+
+function makeState(overrides?: Partial<AcesUpResponse>): AcesUpResponse {
+  return {
+    columns: [[], [], [], []],
+    stockCount: 40,
+    discardCount: 0,
+    phase: 0,
+    moveCount: 0,
+    canUndo: false,
+    isStalemate: false,
+    message: '',
+    ...overrides,
+  };
+}
+
+describe('getAcesUpHint', () => {
+  it('maps each backend action onto the button that performs it', () => {
+    expect(getAcesUpHint(makeState({ hint: { type: 'remove', col: 2 } }))?.targetAction).toBe('remove');
+    expect(getAcesUpHint(makeState({ hint: { type: 'move', col: 1 } }))?.targetAction).toBe('move');
+    expect(getAcesUpHint(makeState({ hint: { type: 'draw', col: -1 } }))?.targetAction).toBe('deal');
+  });
+
+  it('rates a discard as strong and the others as moderate', () => {
+    expect(getAcesUpHint(makeState({ hint: { type: 'remove', col: 0 } }))?.confidence).toBe('strong');
+    expect(getAcesUpHint(makeState({ hint: { type: 'draw', col: -1 } }))?.confidence).toBe('moderate');
+  });
+
+  // **ヒントが無いときと、終局後は出さない。**どちらも null。
+  it('returns null without a hint', () => {
+    expect(getAcesUpHint(makeState())).toBeNull();
+  });
+
+  it('returns null once the game has ended', () => {
+    expect(getAcesUpHint(makeState({ phase: 1, hint: { type: 'remove', col: 0 } }))).toBeNull();
+  });
+});

--- a/frontend/src/utils/hints/acesupHint.test.ts
+++ b/frontend/src/utils/hints/acesupHint.test.ts
@@ -36,4 +36,10 @@ describe('getAcesUpHint', () => {
   it('returns null once the game has ended', () => {
     expect(getAcesUpHint(makeState({ phase: 1, hint: { type: 'remove', col: 0 } }))).toBeNull();
   });
+
+  // **知らない type は無視する。**バックエンドが新しい手を返しても、
+  // 対応するボタンが無いうちは何も出さない。
+  it('returns null for an action it does not know', () => {
+    expect(getAcesUpHint(makeState({ hint: { type: 'teleport' as never, col: 0 } }))).toBeNull();
+  });
 });

--- a/frontend/src/utils/hints/acesupHint.ts
+++ b/frontend/src/utils/hints/acesupHint.ts
@@ -1,0 +1,29 @@
+import type { AcesUpResponse } from '../../types/card';
+import type { HintResult } from '../../types/hint';
+
+/** Aces Up phase: playing. Later phases are game clear / game over. */
+const PHASE_PLAYING = 0;
+
+/**
+ * Returns an Aces Up frontend hint derived from the backend hint, or null.
+ *
+ * The suggestion is computed by the Go backend and rides along with every
+ * state response (see AcesUpWebPresenter.Output, #4483), so this only has to
+ * map the recommended action onto the button that performs it.
+ */
+export function getAcesUpHint(state: AcesUpResponse): HintResult | null {
+  if (state.phase !== PHASE_PLAYING) return null;
+  const hint = state.hint;
+  if (!hint) return null;
+
+  switch (hint.type) {
+    case 'remove':
+      return { targetAction: 'remove', reason: 'frontendHint.acesupRemove', confidence: 'strong' };
+    case 'move':
+      return { targetAction: 'move', reason: 'frontendHint.acesupMove', confidence: 'moderate' };
+    case 'draw':
+      return { targetAction: 'deal', reason: 'frontendHint.acesupDeal', confidence: 'moderate' };
+    default:
+      return null;
+  }
+}


### PR DESCRIPTION
## 概要

#4557 の 39 本の 1 本目。**残りいくらで済むかを確定させる**ための 1 本です。

Refs #4557

## #4483 のおかげでファクトリは薄く済みます

#4483 で**バックエンドの提案がすべての状態レスポンスに乗る**ようになったので、ファクトリは**推奨アクションをボタンに対応づけるだけ**です。**TypeScript でヒント計算を書き直していません。**

```ts
switch (hint.type) {
  case 'remove': return { targetAction: 'remove', reason: 'frontendHint.acesupRemove', confidence: 'strong' };
  case 'move':   return { targetAction: 'move',   reason: 'frontendHint.acesupMove',   confidence: 'moderate' };
  case 'draw':   return { targetAction: 'deal',   reason: 'frontendHint.acesupDeal',   confidence: 'moderate' };
}
```

捨て札は**必ず前進する**ので `strong`、移動と配りは `moderate` です。

## ガードが嘘をつくところでした

`check-hint-coverage` は **`hintFactories` の登録しか見ていません。**BACKLOG から名前を消せば、**ページが `useGameHint` を呼んでいなくても通ります。**

**Aces Up のページは呼んでいませんでした。**このままなら、**ユーザーには何も出ないゲームでラチェットだけが締まる**ところでした。

ページ配線も同じコミットに入れています（フック / 設定チェックボックス / ツールチップ）。

## 負のコントロール

状態のヒントを無視するよう壊すと、**ファクトリのテスト 4 件中 2 件が FAIL**。復元で green。

## 確認

- `bun run check`（11 ガード）→ `221 of 259 games hinted; 38 still owed`
- `bun run typecheck` green
- `AcesUpPage.test.tsx` + `acesupHint.test.ts` 34 件 green

## Test plan

- [ ] CI 全ジョブ green