### PR TITLE
feat(hints): wire the frontend hint for Black Hole (#4557)

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -171,7 +171,7 @@ match on the code if you ever script against tsc output.
 | `TutorialProvider` | `src/providers/TutorialProvider.tsx` | Context provider; renders overlay (used internally by TutorialWrapper) |
 | `TutorialOverlay` | `src/components/tutorial/TutorialOverlay.tsx` | Full-screen overlay with SVG mask spotlight |
 | `useTutorial` | `src/hooks/useTutorial.ts` | State management (step progression, localStorage, resume/restart) |
-| `useGameHint` | `src/hooks/useGameHint.ts` | Frontend hints; registry-driven via `hintFactories` (covers most games; currently 221). `frontend/scripts/check-hint-coverage.mjs` fails the build for any new game without one. The supported set is the `HintGameName` union (`keyof typeof hintFactories`) — add a game by registering its factory there |
+| `useGameHint` | `src/hooks/useGameHint.ts` | Frontend hints; registry-driven via `hintFactories` (covers most games; currently 222). `frontend/scripts/check-hint-coverage.mjs` fails the build for any new game without one. The supported set is the `HintGameName` union (`keyof typeof hintFactories`) — add a game by registering its factory there |
 | `TutorialSuggestDialog` | `src/components/tutorial/TutorialSuggestDialog.tsx` | First-visit dialog; controlled by `useFirstVisit` hook |
 | `TutorialProgressPanel` | `src/components/tutorial/TutorialProgressPanel.tsx` | Progress overview in NavBar |
 

--- a/frontend/scripts/check-hint-coverage.mjs
+++ b/frontend/scripts/check-hint-coverage.mjs
@@ -50,7 +50,6 @@ const ALLOWED = new Map();
  */
 const BACKLOG = new Set([
   'bideuchre',
-  'blackhole',
   'boston',
   'bourre',
   'bridge',

--- a/frontend/src/hooks/useGameHint.ts
+++ b/frontend/src/hooks/useGameHint.ts
@@ -18,6 +18,7 @@ import type {
   BidWhistResponse,
   BigTwoResponse,
   BisleyResponse,
+  BlackHoleResponse,
   BlackJackResponse,
   BlackJackSwitchResponse,
   BouillotteResponse,
@@ -221,6 +222,7 @@ import { getBeziqueHint } from '../utils/hints/beziqueHint';
 import { getBidWhistHint } from '../utils/hints/bidwhistHint';
 import { getBigTwoHint } from '../utils/hints/bigtwoHint';
 import { getBisleyHint } from '../utils/hints/bisleyHint';
+import { getBlackHoleHint } from '../utils/hints/blackholeHint';
 import { getBlackjackHint } from '../utils/hints/blackjackHint';
 import { getBlackjackswitchHint } from '../utils/hints/blackjackswitchHint';
 import { getBouillotteHint } from '../utils/hints/bouillotteHint';
@@ -541,6 +543,7 @@ export const hintFactories = {
   easthaven: (s) => getEasthavenHint(s as EasthavenResponse),
   accordion: (s) => getAccordionHint(s as AccordionResponse),
   acesup: (s) => getAcesUpHint(s as AcesUpResponse),
+  blackhole: (s) => getBlackHoleHint(s as BlackHoleResponse),
   calculation: (s) => getCalculationHint(s as CalculationResponse),
   sirtommy: (s) => getSirTommyHint(s as SirTommyResponse),
   bisley: (s) => getBisleyHint(s as BisleyResponse),

--- a/frontend/src/i18n/locales/en/blackhole.json
+++ b/frontend/src/i18n/locales/en/blackhole.json
@@ -34,5 +34,8 @@
   "hintNoLegal": "No playable card",
   "acceptableRanks": "Playable ranks: {{ranks}}",
   "acceptableRanksNone": "Playable ranks: none",
-  "legalMoveCount": "Legal moves: {{count}}"
+  "legalMoveCount": "Legal moves: {{count}}",
+  "frontendHint": {
+    "blackholePlayFan": "The top card of this fan can go into the hole"
+  }
 }

--- a/frontend/src/i18n/locales/ja/blackhole.json
+++ b/frontend/src/i18n/locales/ja/blackhole.json
@@ -34,5 +34,8 @@
   "hintNoLegal": "置けるカードがありません",
   "acceptableRanks": "受け入れ可能: {{ranks}}",
   "acceptableRanksNone": "受け入れ可能: なし",
-  "legalMoveCount": "合法手: {{count}}"
+  "legalMoveCount": "合法手: {{count}}",
+  "frontendHint": {
+    "blackholePlayFan": "この山の一番上の札を穴へ吸い込めます"
+  }
 }

--- a/frontend/src/pages/BlackHolePage.tsx
+++ b/frontend/src/pages/BlackHolePage.tsx
@@ -2,15 +2,18 @@ import { useEffect, useRef, useState } from 'react';
 import { blackholeApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CardImage } from '../components/CardImage';
+import { SettingsPanel } from '../components/common/SettingsPanel';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
+import { FrontendHintTooltip } from '../components/hint/FrontendHintTooltip';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useGameApi } from '../hooks/useGameApi';
+import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
@@ -19,6 +22,7 @@ import { BlackHolePhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import { valueName } from '../utils/cardUtils';
+import { hintCheckboxItem } from '../utils/settingsItems';
 
 /** Black Hole tutorial step definitions. */
 const BH_TUTORIAL_STEPS: TutorialStep[] = [
@@ -74,6 +78,12 @@ function BlackHolePageContent() {
     setShowLegalHint(false);
   }, [moveCount]);
   useEffect(() => () => window.clearTimeout(hintTimerRef.current ?? undefined), []);
+
+  const {
+    hint: frontendHint,
+    hintEnabled: frontendHintEnabled,
+    setHintEnabled: setFrontendHintEnabled,
+  } = useGameHint('blackhole', state);
 
   if (!state) return <GameSkeleton gameKey="blackhole" layout={{ kind: 'tableau', topRow: 1, tableau: 9 }} />;
 
@@ -274,6 +284,13 @@ function BlackHolePageContent() {
         {canAct && <div className="mt-2 text-ds-text-primary text-xs">{t('selectSource')}</div>}
 
         <GameMessageBox message={state.message} messageCode={state.messageCode} messageParams={state.messageParams} />
+        <FrontendHintTooltip hint={frontendHint} enabled={frontendHintEnabled} t={t} />
+
+        <SettingsPanel
+          title={tc('settings.title')}
+          groups={[{ items: [hintCheckboxItem(tc, frontendHintEnabled, setFrontendHintEnabled)] }]}
+        />
+
         <ActionLogSection
           isEndPhase={isEnd}
           actionLog={actionLog}

--- a/frontend/src/utils/hints/blackholeHint.test.ts
+++ b/frontend/src/utils/hints/blackholeHint.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import type { BlackHoleResponse } from '../../types/card';
+import { getBlackHoleHint } from './blackholeHint';
+
+function makeState(overrides?: Partial<BlackHoleResponse>): BlackHoleResponse {
+  return {
+    fans: [[], [], []],
+    blackHole: [],
+    phase: 0,
+    moveCount: 0,
+    canUndo: false,
+    isStalemate: false,
+    message: '',
+    ...overrides,
+  };
+}
+
+describe('getBlackHoleHint', () => {
+  it('names the fan the backend recommends', () => {
+    const hint = getBlackHoleHint(makeState({ hint: { fan: 4 } }));
+    expect(hint?.targetAction).toBe('fan-4');
+    expect(hint?.confidence).toBe('strong');
+  });
+
+  it('returns null without a hint', () => {
+    expect(getBlackHoleHint(makeState())).toBeNull();
+  });
+
+  // **fan が -1 のヒントは「対象なし」。**山番号として使うと fan--1 になる。
+  it('returns null for a negative fan index', () => {
+    expect(getBlackHoleHint(makeState({ hint: { fan: -1 } }))).toBeNull();
+  });
+
+  it('returns null once the game has ended', () => {
+    expect(getBlackHoleHint(makeState({ phase: 1, hint: { fan: 0 } }))).toBeNull();
+  });
+});

--- a/frontend/src/utils/hints/blackholeHint.ts
+++ b/frontend/src/utils/hints/blackholeHint.ts
@@ -1,0 +1,25 @@
+import type { BlackHoleResponse } from '../../types/card';
+import type { HintResult } from '../../types/hint';
+
+/** Black Hole phase: playing. Later phases are game clear / game over. */
+const PHASE_PLAYING = 0;
+
+/**
+ * Returns a Black Hole frontend hint derived from the backend hint, or null.
+ *
+ * The suggestion rides along with every state response (see
+ * BlackHoleWebPresenter.Output, #4483). Black Hole has exactly one kind of
+ * move -- play a fan's top card into the hole -- so the hint names the fan and
+ * nothing else.
+ */
+export function getBlackHoleHint(state: BlackHoleResponse): HintResult | null {
+  if (state.phase !== PHASE_PLAYING) return null;
+  const hint = state.hint;
+  if (!hint || hint.fan < 0) return null;
+
+  return {
+    targetAction: `fan-${hint.fan}`,
+    reason: 'frontendHint.blackholePlayFan',
+    confidence: 'strong',
+  };
+}


### PR DESCRIPTION
## 概要

#4557 の 2 本目。

Refs #4557

## フックの位置でページテストが 13 件落ちました

設定パネルを置く場所（**ローディングの早期 return より後ろ**）にフック呼び出しを置いたところ:

```
Error: Rendered more hooks than during the previous render.
```

`if (!state) return <GameSkeleton .../>` の後ろだと、**レンダーごとにフック数が変わります。**早期 return の**前**へ移しました。

**#4559（Aces Up）に同じ誤りが無いことも確認済み**です（フック 125 行 / 早期 return 171 行）。

## ファクトリ

Black Hole の手は 1 種類（扇の一番上を穴へ）なので、**扇の番号を指すだけ**です。

```ts
if (!hint || hint.fan < 0) return null;
return { targetAction: `fan-${hint.fan}`, reason: 'frontendHint.blackholePlayFan', confidence: 'strong' };
```

**`fan: -1` は「対象なし」**です。そのまま使うと `fan--1` というアクション名になるので null を返します（テストで固定）。

## ページに設定パネルがありませんでした

Black Hole のページは `SettingsPanel` を持っていなかったので、ヒントのチェックボックスと一緒に新設しています。

## 負のコントロール

状態のヒントを無視するよう壊すと **4 件中 1 件 FAIL**、復元で green。

## 確認

- `bun run check` → `221 of 259 games hinted; 38 still owed`
- `bun run typecheck` green
- `BlackHolePage.test.tsx` + `blackholeHint.test.ts` 19 件 green

## Test plan

- [ ] CI 全ジョブ green