### PR TITLE
fix(piquet): stop GetHint describing a CPU seat's hand (#4554)

### DIFF
--- a/internal/adapter/presenter/PiquetWebPresenter_test.go
+++ b/internal/adapter/presenter/PiquetWebPresenter_test.go
@@ -196,29 +196,52 @@ func TestPiquetWebPresenter_HintOutput_WithHint(t *testing.T) {
 // Piquet の GetHint は現在手番を引数に取るので、呼び出し式ごと HintOutput から
 // 写しています。
 func TestPiquetWebPresenterOutputCarriesTheHint(t *testing.T) {
-	players := []*domain.PiquetPlayer{
-		domain.NewPiquetPlayer(false),
-		domain.NewPiquetPlayer(false),
-	}
-	g := domain.NewPiquet(domain.NewTrumpCardsBelote(), players,
-		domain.PiquetConfig{DealsPerPartie: 1, CpuDifficulty: domain.PiquetCpuDifficultyNormal})
-	g.Reset()
-	for g.GetPhase() == domain.PiquetPhaseExchange {
-		g.CpuPlay()
-	}
-	for g.GetPhase() == domain.PiquetPhaseDeclaration {
-		_, _ = g.ResolveDeclaration()
-	}
-	if g.GetHint(g.GetCurrentPlayerIdx()) == nil {
-		t.Fatal("fixture must actually produce a hint")
+	// **人間席のあるフィクスチャで組む。**前のテストは両席とも CPU で作っていて、
+	// 「CPU の手番でも CPU の手札のヒントが出る」という本題を検出できなかった
+	// (#4554 のレビュー指摘)。
+	//
+	// フェーズは進めない。人間席があると `for phase == Exchange { CpuPlay() }` は
+	// 止まらない（CpuPlay は人間席では何もしない）。配り終えた交換フェーズで
+	// エルダーに捨て札ヒントが出るので、席の是非だけをここで確かめられる。
+	newGame := func(humanSeat int) *domain.Piquet {
+		players := []*domain.PiquetPlayer{
+			domain.NewPiquetPlayer(humanSeat == 0),
+			domain.NewPiquetPlayer(humanSeat == 1),
+		}
+		g := domain.NewPiquet(domain.NewTrumpCardsBelote(), players,
+			domain.PiquetConfig{DealsPerPartie: 1, CpuDifficulty: domain.PiquetCpuDifficultyNormal})
+		g.Reset()
+		return g
 	}
 
-	result := new(PiquetWebPresenter).Output(g, nil)
-	var parsed map[string]any
-	if err := json.Unmarshal([]byte(result), &parsed); err != nil {
-		t.Fatalf("invalid JSON: %v", err)
-	}
-	if parsed["hint"] == nil {
-		t.Error("Output must carry the hint -- the frontend reads state.hint")
-	}
+	t.Run("carries the hint on the human's turn", func(t *testing.T) {
+		g := newGame(newGame(0).GetCurrentPlayerIdx())
+		if g.GetHint(g.GetCurrentPlayerIdx()) == nil {
+			t.Fatal("fixture must actually produce a hint")
+		}
+
+		var parsed map[string]any
+		if err := json.Unmarshal([]byte(new(PiquetWebPresenter).Output(g, nil)), &parsed); err != nil {
+			t.Fatalf("invalid JSON: %v", err)
+		}
+		if parsed["hint"] == nil {
+			t.Error("Output must carry the hint -- the frontend reads state.hint")
+		}
+	})
+
+	// **相手の席のヒントは出さない。**出すと CPU の手札を説明する行が人間に見える。
+	t.Run("stays silent for a CPU seat", func(t *testing.T) {
+		g := newGame(1 - newGame(0).GetCurrentPlayerIdx())
+		if g.GetHint(g.GetCurrentPlayerIdx()) != nil {
+			t.Error("GetHint must not describe a CPU seat's hand")
+		}
+
+		var parsed map[string]any
+		if err := json.Unmarshal([]byte(new(PiquetWebPresenter).Output(g, nil)), &parsed); err != nil {
+			t.Fatalf("invalid JSON: %v", err)
+		}
+		if parsed["hint"] != nil {
+			t.Error("Output must not leak a hint for the CPU's hand")
+		}
+	})
 }

--- a/internal/domain/Piquet.go
+++ b/internal/domain/Piquet.go
@@ -870,6 +870,14 @@ func (p *Piquet) cpuChoosePlay(playerIdx int) int {
 
 // GetHint プレイ/交換時の推奨を返す
 func (p *Piquet) GetHint(playerIdx int) *PiquetHint {
+	// **CPU の席のヒントは返さない。**返すと、呼び手が現在手番をそのまま渡した
+	// ときに CPU の手札を説明するヒントが出る。Output() は毎レスポンスでこれを
+	// 呼ぶので、相手の手番中に相手の札を指すヒントが人間に見えることになる
+	// (#4554 のレビュー指摘)。CourtPiece.GetHint は自分で人間席を解決していて、
+	// この契約が両者で揃っていなかった。
+	if playerIdx < 0 || playerIdx >= len(p.players) || !p.players[playerIdx].GetIsHuman() {
+		return nil
+	}
 	switch p.phase {
 	case PiquetPhaseExchange:
 		if p.exchangeTurn == PiquetExchangeTurnElder && playerIdx == p.elderIdx {

--- a/internal/domain/Piquet_test.go
+++ b/internal/domain/Piquet_test.go
@@ -19,6 +19,17 @@ func newPiquetForTest() *Piquet {
 	return NewPiquet(NewTrumpCardsBelote(), players, DefaultPiquetConfig())
 }
 
+// newPiquetWithHumanForTest は席 humanSeat を人間にした盤面を返す。
+// **GetHint は人間席にしか答えない**（#4554 のレビュー指摘。CPU 席に答えると
+// 相手の手札を説明するヒントが人間に見える）ので、ヒントのテストは人間席が要る。
+func newPiquetWithHumanForTest(humanSeat int) *Piquet {
+	players := []*PiquetPlayer{
+		NewPiquetPlayer(humanSeat == 0),
+		NewPiquetPlayer(humanSeat == 1),
+	}
+	return NewPiquet(NewTrumpCardsBelote(), players, DefaultPiquetConfig())
+}
+
 // addHand replaces a player's hand with the given cards.
 func addHand(pl *PiquetPlayer, cards ...*Card) {
 	pl.Reset()
@@ -869,6 +880,8 @@ func TestPiquetJSONRoundTrip(t *testing.T) {
 func TestGetHintInExchangePhase(t *testing.T) {
 	p := newPiquetForTest()
 	p.Reset()
+	p = newPiquetWithHumanForTest(p.elderIdx)
+	p.Reset()
 	hint := p.GetHint(p.elderIdx)
 	if hint == nil {
 		t.Fatal("expected hint in exchange phase")
@@ -879,7 +892,7 @@ func TestGetHintInExchangePhase(t *testing.T) {
 }
 
 func TestGetHintInPlayPhase(t *testing.T) {
-	p := newPiquetForTest()
+	p := newPiquetWithHumanForTest(0)
 	p.Reset()
 	p.phase = PiquetPhasePlay
 	p.currentTrick = nil
@@ -887,6 +900,27 @@ func TestGetHintInPlayPhase(t *testing.T) {
 	hint := p.GetHint(0)
 	if hint == nil || hint.CardIndex == nil {
 		t.Fatalf("expected card hint, got %+v", hint)
+	}
+}
+
+// **CPU 席のヒントは返さない。**返すと、現在手番をそのまま渡す呼び手
+// （PiquetWebPresenter.Output）経由で CPU の手札を説明する行が人間に見える。
+func TestGetHintRefusesACpuSeat(t *testing.T) {
+	p := newPiquetWithHumanForTest(0)
+	p.Reset()
+	if hint := p.GetHint(1); hint != nil {
+		t.Errorf("expected no hint for a CPU seat, got %+v", hint)
+	}
+}
+
+// 席の範囲外も nil。落ちないことを固定する。
+func TestGetHintRefusesAnOutOfRangeSeat(t *testing.T) {
+	p := newPiquetWithHumanForTest(0)
+	p.Reset()
+	for _, idx := range []int{-1, 2, 99} {
+		if hint := p.GetHint(idx); hint != nil {
+			t.Errorf("expected no hint for seat %d, got %+v", idx, hint)
+		}
 	}
 }
 


### PR DESCRIPTION
## 概要

[#4554 のレビュー指摘](https://github.com/yuta-yoshinaga/go_trumpcards/pull/4554)への対応です。**マージ後に指摘を読みました**（レビューを読み切る前にマージしたのは私の手落ちです）。

## 何が起きていたか

`Piquet.GetHint(playerIdx)` は**その席が人間かを見ていませんでした。**

```go
case PiquetPhasePlay:
	if playerIdx == p.currentPlayerIdx {   // ← Output は GetCurrentPlayerIdx を渡す
```

`PiquetWebPresenter.Output()` が `g.GetCurrentPlayerIdx()` を渡すので、**この条件は毎回自明に真**です。CPU の手番になると、`Output` が **CPU 自身の手札を説明するヒント**を載せ、`PiquetPage` は `state.hint` を無条件に描画します。

**人間プレイヤーに、相手の手札のカード番号が見えていました。**

私が #4554 に「`GetHint` が自分で人間の手番を確かめる」と書いたのは**誤り**でした。そうしているのは CourtPiece で、Piquet は違いました。

## 直し方

**`Output` ではなく `GetHint` にガードを置きます。**呼び手が誰であっても同じ状態に到達できません。これは CourtPiece が既に持っていた契約で、両者が食い違っていたことが誤りの原因です。

```go
if playerIdx < 0 || playerIdx >= len(p.players) || !p.players[playerIdx].GetIsHuman() {
	return nil
}
```

## 私のテストでは捕まえられませんでした

フィクスチャが**両席とも CPU** で、「人間の手番」という場合が存在しませんでした。人間席を作り、**両方向**を assert します。ドメイン側にも契約そのもののテストを 2 本足しました（CPU 席 / 範囲外の席）。

ドメインの既存 `TestGetHintInExchangePhase` / `TestGetHintInPlayPhase` も同じ全 CPU フィクスチャで、**ガードを入れたら落ちました。**それが効いている証拠なので、人間席を与える形に直しています。

### フェーズは進めません

人間席があると `for phase == Exchange { CpuPlay() }` は**止まりません**（`CpuPlay` は人間席では何もしない）。テストは交換フェーズに留まります。エルダーの捨て札ヒントで席の是非は十分区別できます。

## 負のコントロール

| | |
|---|---|
| 席ガードを外す（ビルド可を確認済み） | **2 件 FAIL** |
| 復元 | green |

## 確認

- `go test -tags test ./internal/...` 全体 green
- `golangci-lint run ./internal/domain/ ./internal/adapter/presenter/` 0 issues

## Test plan

- [ ] CI 全ジョブ green