### PR TITLE
feat(hints): wire the frontend hint for Simple Simon (#4557)

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -171,7 +171,7 @@ match on the code if you ever script against tsc output.
 | `TutorialProvider` | `src/providers/TutorialProvider.tsx` | Context provider; renders overlay (used internally by TutorialWrapper) |
 | `TutorialOverlay` | `src/components/tutorial/TutorialOverlay.tsx` | Full-screen overlay with SVG mask spotlight |
 | `useTutorial` | `src/hooks/useTutorial.ts` | State management (step progression, localStorage, resume/restart) |
-| `useGameHint` | `src/hooks/useGameHint.ts` | Frontend hints; registry-driven via `hintFactories` (covers most games; currently 222). `frontend/scripts/check-hint-coverage.mjs` fails the build for any new game without one. The supported set is the `HintGameName` union (`keyof typeof hintFactories`) — add a game by registering its factory there |
+| `useGameHint` | `src/hooks/useGameHint.ts` | Frontend hints; registry-driven via `hintFactories` (covers most games; currently 223). `frontend/scripts/check-hint-coverage.mjs` fails the build for any new game without one. The supported set is the `HintGameName` union (`keyof typeof hintFactories`) — add a game by registering its factory there |
 | `TutorialSuggestDialog` | `src/components/tutorial/TutorialSuggestDialog.tsx` | First-visit dialog; controlled by `useFirstVisit` hook |
 | `TutorialProgressPanel` | `src/components/tutorial/TutorialProgressPanel.tsx` | Progress overview in NavBar |
 

--- a/frontend/scripts/check-hint-coverage.mjs
+++ b/frontend/scripts/check-hint-coverage.mjs
@@ -81,7 +81,6 @@ const BACKLOG = new Set([
   'russianbank',
   'scopone',
   'settemezzo',
-  'simplesimon',
   'sixbidsolo',
   'spoons',
   'threethirteen',

--- a/frontend/src/hooks/useGameHint.ts
+++ b/frontend/src/hooks/useGameHint.ts
@@ -153,6 +153,7 @@ import type {
   ShengJiResponse,
   ShitheadResponse,
   ShortDeckResponse,
+  SimpleSimonResponse,
   SirTommyResponse,
   SixCardGolfResponse,
   SjavsResponse,
@@ -362,6 +363,7 @@ import { getSheepsheadHint } from '../utils/hints/sheepsheadHint';
 import { getShengJiHint } from '../utils/hints/shengjiHint';
 import { getShitheadHint } from '../utils/hints/shitheadHint';
 import { getShortDeckHint } from '../utils/hints/shortdeckHint';
+import { getSimpleSimonHint } from '../utils/hints/simplesimonHint';
 import { getSirTommyHint } from '../utils/hints/sirtommyHint';
 import { getSixcardgolfHint } from '../utils/hints/sixcardgolfHint';
 import { getSjavsHint } from '../utils/hints/sjavsHint';
@@ -544,6 +546,7 @@ export const hintFactories = {
   accordion: (s) => getAccordionHint(s as AccordionResponse),
   acesup: (s) => getAcesUpHint(s as AcesUpResponse),
   blackhole: (s) => getBlackHoleHint(s as BlackHoleResponse),
+  simplesimon: (s) => getSimpleSimonHint(s as SimpleSimonResponse),
   calculation: (s) => getCalculationHint(s as CalculationResponse),
   sirtommy: (s) => getSirTommyHint(s as SirTommyResponse),
   bisley: (s) => getBisleyHint(s as BisleyResponse),

--- a/frontend/src/i18n/locales/en/simplesimon.json
+++ b/frontend/src/i18n/locales/en/simplesimon.json
@@ -26,5 +26,8 @@
     "resetButton": "Start a new game."
   },
   "cardPosAria": "{{card}} (column {{col}}, position {{pos}})",
-  "emptyColAria": "column {{col}} (empty)"
+  "emptyColAria": "column {{col}} (empty)",
+  "frontendHint": {
+    "simplesimonMove": "Cards in this column can move to another"
+  }
 }

--- a/frontend/src/i18n/locales/ja/simplesimon.json
+++ b/frontend/src/i18n/locales/ja/simplesimon.json
@@ -26,5 +26,8 @@
     "resetButton": "新しいゲームを始めるボタンです。"
   },
   "cardPosAria": "{{card}}（列{{col}}・上から{{pos}}枚目）",
-  "emptyColAria": "列{{col}}（空）"
+  "emptyColAria": "列{{col}}（空）",
+  "frontendHint": {
+    "simplesimonMove": "この列の札を別の列へ移せます"
+  }
 }

--- a/frontend/src/pages/SimpleSimonPage.tsx
+++ b/frontend/src/pages/SimpleSimonPage.tsx
@@ -2,15 +2,18 @@ import { useEffect, useState } from 'react';
 import { simplesimonApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CardImage } from '../components/CardImage';
+import { SettingsPanel } from '../components/common/SettingsPanel';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
+import { FrontendHintTooltip } from '../components/hint/FrontendHintTooltip';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useGameApi } from '../hooks/useGameApi';
+import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
@@ -19,6 +22,7 @@ import type { Card } from '../types/card';
 import { SimpleSimonPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
+import { hintCheckboxItem } from '../utils/settingsItems';
 import { simpleSimonAutoMoveTarget } from '../utils/simpleSimonAutoMoveTarget';
 import { isGrabbable, movableFromIndex } from '../utils/simpleSimonRun';
 
@@ -80,6 +84,12 @@ function SimpleSimonPageContent() {
   const phaseNames = usePhaseNames('simplesimon', SS_PHASE_KEYS);
   const { cardWidth } = useCardDimensions();
   const w = Math.round(cardWidth * 0.58);
+
+  const {
+    hint: frontendHint,
+    hintEnabled: frontendHintEnabled,
+    setHintEnabled: setFrontendHintEnabled,
+  } = useGameHint('simplesimon', state);
 
   if (!state) return <GameSkeleton gameKey="simplesimon" layout={{ kind: 'tableau', topRow: 0, tableau: 10 }} />;
 
@@ -230,6 +240,13 @@ function SimpleSimonPageContent() {
         )}
 
         <GameMessageBox message={state.message} messageCode={state.messageCode} messageParams={state.messageParams} />
+        <FrontendHintTooltip hint={frontendHint} enabled={frontendHintEnabled} t={t} />
+
+        <SettingsPanel
+          title={tc('settings.title')}
+          groups={[{ items: [hintCheckboxItem(tc, frontendHintEnabled, setFrontendHintEnabled)] }]}
+        />
+
         <ActionLogSection
           isEndPhase={isEnd}
           actionLog={actionLog}

--- a/frontend/src/utils/hints/simplesimonHint.test.ts
+++ b/frontend/src/utils/hints/simplesimonHint.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import type { SimpleSimonResponse } from '../../types/card';
+import { getSimpleSimonHint } from './simplesimonHint';
+
+function makeState(overrides?: Partial<SimpleSimonResponse>): SimpleSimonResponse {
+  return {
+    columns: [[], [], []],
+    completedSuits: 0,
+    phase: 0,
+    moveCount: 0,
+    canUndo: false,
+    message: '',
+    ...overrides,
+  };
+}
+
+describe('getSimpleSimonHint', () => {
+  it('names the source column the backend recommends', () => {
+    const hint = getSimpleSimonHint(makeState({ hint: { fromCol: 3, cardIndex: 0, toCol: 5 } }));
+    expect(hint?.targetAction).toBe('col-3');
+    expect(hint?.confidence).toBe('moderate');
+  });
+
+  it('returns null without a hint', () => {
+    expect(getSimpleSimonHint(makeState())).toBeNull();
+  });
+
+  // **負の列番号は「対象なし」。**そのまま使うと col--1 になる。
+  it('returns null for a negative column', () => {
+    expect(getSimpleSimonHint(makeState({ hint: { fromCol: -1, cardIndex: 0, toCol: 2 } }))).toBeNull();
+    expect(getSimpleSimonHint(makeState({ hint: { fromCol: 2, cardIndex: 0, toCol: -1 } }))).toBeNull();
+  });
+
+  it('returns null once the game has ended', () => {
+    expect(getSimpleSimonHint(makeState({ phase: 1, hint: { fromCol: 0, cardIndex: 0, toCol: 1 } }))).toBeNull();
+  });
+});

--- a/frontend/src/utils/hints/simplesimonHint.ts
+++ b/frontend/src/utils/hints/simplesimonHint.ts
@@ -1,0 +1,24 @@
+import type { SimpleSimonResponse } from '../../types/card';
+import type { HintResult } from '../../types/hint';
+
+/** Simple Simon phase: playing. Later phases are game clear / game over. */
+const PHASE_PLAYING = 0;
+
+/**
+ * Returns a Simple Simon frontend hint derived from the backend hint, or null.
+ *
+ * The suggestion rides along with every state response (see
+ * SimpleSimonWebPresenter.Output, #4483). Every move is column-to-column, so
+ * the hint only has to name the two columns.
+ */
+export function getSimpleSimonHint(state: SimpleSimonResponse): HintResult | null {
+  if (state.phase !== PHASE_PLAYING) return null;
+  const hint = state.hint;
+  if (!hint || hint.fromCol < 0 || hint.toCol < 0) return null;
+
+  return {
+    targetAction: `col-${hint.fromCol}`,
+    reason: 'frontendHint.simplesimonMove',
+    confidence: 'moderate',
+  };
+}


### PR DESCRIPTION
## 概要

#4557 の 3 本目。

Refs #4557

## ファクトリ

Simple Simon の手はすべて列 → 列なので、**移動元の列を指すだけ**です。

```ts
if (!hint || hint.fromCol < 0 || hint.toCol < 0) return null;
return { targetAction: `col-${hint.fromCol}`, reason: 'frontendHint.simplesimonMove', confidence: 'moderate' };
```

**列番号 -1 は「対象なし」**です。そのまま使うと `col--1` というアクション名になります（Black Hole の `fan: -1` と同じ形。#4561）。**移動元・移動先の両方**をテストで固定しています。

## フックの位置

**早期 return の前**に置いています。#4561 でこれを間違えてページテストが 13 件落ちました。

## 負のコントロール

状態のヒントを無視するよう壊すと **4 件中 1 件 FAIL**。

**1 件だけなのには理由があります。**残り 3 件は「null が返ること」を assert しており、**ヒントを読まないファクトリはどの入力でも null を返す**ので区別できません。両者を分けられるのは**ヒントが出る場合のテストだけ**です。

## 確認

- `bun run check` → `221 of 259 games hinted; 38 still owed`
- `bun run typecheck` green
- `SimpleSimonPage.test.tsx` + `simplesimonHint.test.ts` 15 件 green

## Test plan

- [ ] CI 全ジョブ green