### PR TITLE
feat(hints): wire the frontend hint for La Belle Lucie (#4557)

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -171,7 +171,7 @@ match on the code if you ever script against tsc output.
 | `TutorialProvider` | `src/providers/TutorialProvider.tsx` | Context provider; renders overlay (used internally by TutorialWrapper) |
 | `TutorialOverlay` | `src/components/tutorial/TutorialOverlay.tsx` | Full-screen overlay with SVG mask spotlight |
 | `useTutorial` | `src/hooks/useTutorial.ts` | State management (step progression, localStorage, resume/restart) |
-| `useGameHint` | `src/hooks/useGameHint.ts` | Frontend hints; registry-driven via `hintFactories` (covers most games; currently 223). `frontend/scripts/check-hint-coverage.mjs` fails the build for any new game without one. The supported set is the `HintGameName` union (`keyof typeof hintFactories`) — add a game by registering its factory there |
+| `useGameHint` | `src/hooks/useGameHint.ts` | Frontend hints; registry-driven via `hintFactories` (covers most games; currently 224). `frontend/scripts/check-hint-coverage.mjs` fails the build for any new game without one. The supported set is the `HintGameName` union (`keyof typeof hintFactories`) — add a game by registering its factory there |
 | `TutorialSuggestDialog` | `src/components/tutorial/TutorialSuggestDialog.tsx` | First-visit dialog; controlled by `useFirstVisit` hook |
 | `TutorialProgressPanel` | `src/components/tutorial/TutorialProgressPanel.tsx` | Progress overview in NavBar |
 

--- a/frontend/scripts/check-hint-coverage.mjs
+++ b/frontend/scripts/check-hint-coverage.mjs
@@ -70,7 +70,6 @@ const BACKLOG = new Set([
   'kemps',
   'kille',
   'klaberjass',
-  'labellelucie',
   'literature',
   'mao',
   'niuniu',

--- a/frontend/src/hooks/useGameHint.ts
+++ b/frontend/src/hooks/useGameHint.ts
@@ -89,6 +89,7 @@ import type {
   KnockoutWhistResponse,
   KoenigrufenResponse,
   KoiKoiResponse,
+  LaBelleLucieResponse,
   LaughAndLieDownResponse,
   LetItRideResponse,
   LobaResponse,
@@ -298,6 +299,7 @@ import { getKlondikeHint } from '../utils/hints/klondikeHint';
 import { getKnockoutWhistHint } from '../utils/hints/knockoutWhistHint';
 import { getKoenigrufenHint } from '../utils/hints/koenigrufenHint';
 import { getKoiKoiHint } from '../utils/hints/koikoiHint';
+import { getLaBelleLucieHint } from '../utils/hints/labellelucieHint';
 import { getLaughAndLieDownHint } from '../utils/hints/laughandliedownHint';
 import { getLetitrideHint } from '../utils/hints/letitrideHint';
 import { getLobaHint } from '../utils/hints/lobaHint';
@@ -547,6 +549,7 @@ export const hintFactories = {
   acesup: (s) => getAcesUpHint(s as AcesUpResponse),
   blackhole: (s) => getBlackHoleHint(s as BlackHoleResponse),
   simplesimon: (s) => getSimpleSimonHint(s as SimpleSimonResponse),
+  labellelucie: (s) => getLaBelleLucieHint(s as LaBelleLucieResponse),
   calculation: (s) => getCalculationHint(s as CalculationResponse),
   sirtommy: (s) => getSirTommyHint(s as SirTommyResponse),
   bisley: (s) => getBisleyHint(s as BisleyResponse),

--- a/frontend/src/i18n/locales/en/labellelucie.json
+++ b/frontend/src/i18n/locales/en/labellelucie.json
@@ -31,5 +31,9 @@
     "redeal": "When stuck, gather the remaining cards, shuffle and redeal — up to 3 times.",
     "actionButtons": "Hint, auto-complete and undo controls.",
     "resetButton": "Start a new game."
+  },
+  "frontendHint": {
+    "labellelucieToFoundation": "This fan's card can go to a foundation",
+    "labellelucieToFan": "This fan's card can move to another fan"
   }
 }

--- a/frontend/src/i18n/locales/ja/labellelucie.json
+++ b/frontend/src/i18n/locales/ja/labellelucie.json
@@ -31,5 +31,9 @@
     "redeal": "詰まったら残り札を集めてシャッフルし配り直せます（最大3回）。",
     "actionButtons": "ヒント・自動完成・元に戻すなどの操作ボタンです。",
     "resetButton": "新しいゲームを始めるボタンです。"
+  },
+  "frontendHint": {
+    "labellelucieToFoundation": "この扇の札を台札へ上げられます",
+    "labellelucieToFan": "この扇の札を別の扇へ移せます"
   }
 }

--- a/frontend/src/pages/LaBelleLuciePage.tsx
+++ b/frontend/src/pages/LaBelleLuciePage.tsx
@@ -2,15 +2,18 @@ import { useEffect, useRef, useState } from 'react';
 import { labellelucieApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CardImage } from '../components/CardImage';
+import { SettingsPanel } from '../components/common/SettingsPanel';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
+import { FrontendHintTooltip } from '../components/hint/FrontendHintTooltip';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useGameApi } from '../hooks/useGameApi';
+import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { btnPrimary, btnSecondary, btnSuccess, btnWarning } from '../styles/buttonStyles';
@@ -19,6 +22,7 @@ import type { Card } from '../types/card';
 import { LaBelleLuciePhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { labelleLucieHasLegalMove } from '../utils/labelleLucieLegalMove';
+import { hintCheckboxItem } from '../utils/settingsItems';
 
 /** La Belle Lucie tutorial step definitions. */
 const LL_TUTORIAL_STEPS: TutorialStep[] = [
@@ -81,6 +85,12 @@ function LaBelleLuciePageContent() {
   const phaseNames = usePhaseNames('labellelucie', LL_PHASE_KEYS);
   const { cardWidth } = useCardDimensions();
   const w = Math.round(cardWidth * 0.6);
+
+  const {
+    hint: frontendHint,
+    hintEnabled: frontendHintEnabled,
+    setHintEnabled: setFrontendHintEnabled,
+  } = useGameHint('labellelucie', state);
 
   if (!state) return <GameSkeleton gameKey="labellelucie" layout={{ kind: 'tableau', topRow: 4, tableau: 9 }} />;
 
@@ -262,6 +272,13 @@ function LaBelleLuciePageContent() {
         )}
 
         <GameMessageBox message={state.message} messageCode={state.messageCode} messageParams={state.messageParams} />
+        <FrontendHintTooltip hint={frontendHint} enabled={frontendHintEnabled} t={t} />
+
+        <SettingsPanel
+          title={tc('settings.title')}
+          groups={[{ items: [hintCheckboxItem(tc, frontendHintEnabled, setFrontendHintEnabled)] }]}
+        />
+
         <ActionLogSection
           isEndPhase={isEnd}
           actionLog={actionLog}

--- a/frontend/src/utils/hints/labellelucieHint.test.ts
+++ b/frontend/src/utils/hints/labellelucieHint.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import type { LaBelleLucieResponse } from '../../types/card';
+import { getLaBelleLucieHint } from './labellelucieHint';
+
+function makeState(overrides?: Partial<LaBelleLucieResponse>): LaBelleLucieResponse {
+  return {
+    fans: [[], [], []],
+    foundation: [[], [], [], []],
+    redealsLeft: 2,
+    phase: 0,
+    moveCount: 0,
+    canUndo: false,
+    message: '',
+    ...overrides,
+  };
+}
+
+describe('getLaBelleLucieHint', () => {
+  it('rates a foundation move as strong', () => {
+    const hint = getLaBelleLucieHint(makeState({ hint: { fromFan: 2, toFan: -1, toFoundation: true } }));
+    expect(hint?.targetAction).toBe('fan-2');
+    expect(hint?.reason).toBe('frontendHint.labellelucieToFoundation');
+    expect(hint?.confidence).toBe('strong');
+  });
+
+  it('rates a fan-to-fan move as moderate', () => {
+    const hint = getLaBelleLucieHint(makeState({ hint: { fromFan: 1, toFan: 4, toFoundation: false } }));
+    expect(hint?.reason).toBe('frontendHint.labellelucieToFan');
+    expect(hint?.confidence).toBe('moderate');
+  });
+
+  // **台札行きは toFan が -1 でも成立する。**移動先が扇ではないため。
+  it('does not require a target fan for a foundation move', () => {
+    expect(getLaBelleLucieHint(makeState({ hint: { fromFan: 0, toFan: -1, toFoundation: true } }))).not.toBeNull();
+  });
+
+  it('returns null when a fan-to-fan move has no target', () => {
+    expect(getLaBelleLucieHint(makeState({ hint: { fromFan: 0, toFan: -1, toFoundation: false } }))).toBeNull();
+  });
+
+  it('returns null without a hint', () => {
+    expect(getLaBelleLucieHint(makeState())).toBeNull();
+  });
+
+  it('returns null once the game has ended', () => {
+    expect(
+      getLaBelleLucieHint(makeState({ phase: 1, hint: { fromFan: 0, toFan: 1, toFoundation: false } })),
+    ).toBeNull();
+  });
+});

--- a/frontend/src/utils/hints/labellelucieHint.ts
+++ b/frontend/src/utils/hints/labellelucieHint.ts
@@ -1,0 +1,33 @@
+import type { LaBelleLucieResponse } from '../../types/card';
+import type { HintResult } from '../../types/hint';
+
+/** La Belle Lucie phase: playing. Later phases are game clear / game over. */
+const PHASE_PLAYING = 0;
+
+/**
+ * Returns a La Belle Lucie frontend hint derived from the backend hint, or null.
+ *
+ * The suggestion rides along with every state response (see
+ * LaBelleLucieWebPresenter.Output, #4483). A move either starts or extends a
+ * foundation, which is always progress, or shuffles a card between fans, which
+ * only sometimes is -- hence the two confidences.
+ */
+export function getLaBelleLucieHint(state: LaBelleLucieResponse): HintResult | null {
+  if (state.phase !== PHASE_PLAYING) return null;
+  const hint = state.hint;
+  if (!hint || hint.fromFan < 0) return null;
+
+  if (hint.toFoundation) {
+    return {
+      targetAction: `fan-${hint.fromFan}`,
+      reason: 'frontendHint.labellelucieToFoundation',
+      confidence: 'strong',
+    };
+  }
+  if (hint.toFan < 0) return null;
+  return {
+    targetAction: `fan-${hint.fromFan}`,
+    reason: 'frontendHint.labellelucieToFan',
+    confidence: 'moderate',
+  };
+}


### PR DESCRIPTION
## 概要

#4557 の 4 本目。**手が 2 種類ある最初のゲーム**です。

Refs #4557

## 台札行きと扇間移動を区別します

| 手 | 確度 | 理由 |
|---|---|---|
| 台札へ | **strong** | **必ず前進する** |
| 扇 → 扇 | moderate | 前進とは限らない |

## `toFan: -1` の扱いに気をつけました

**台札行きでは `toFan` は -1 です**（移動先が扇ではないため）。

前の 2 本（Black Hole / Simple Simon）が使っている「**負の番号は対象なし → null**」をそのまま当てると、**台札行きのヒントを全部捨てる**ことになります。負判定は**扇 → 扇の枝にだけ**掛けています。

```ts
if (hint.toFoundation) {
  return { ..., confidence: 'strong' };   // toFan は見ない
}
if (hint.toFan < 0) return null;          // ここだけ
```

両方をテストで固定しています（`does not require a target fan for a foundation move` / `returns null when a fan-to-fan move has no target`）。

## 負のコントロール

状態のヒントを無視するよう壊すと **6 件中 3 件 FAIL** —— **ヒントが返ることを assert している全件**です。残り 3 件は null を assert しているので、読まないファクトリでも通ります。

## 確認

- `bun run check` → `221 of 259 games hinted; 38 still owed`
- `bun run typecheck` green
- `LaBelleLuciePage.test.tsx` + `labellelucieHint.test.ts` 22 件 green

## Test plan

- [ ] CI 全ジョブ green