### PR TITLE
feat(hints): wire the frontend hint for Double Klondike (#4557)

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -171,7 +171,7 @@ match on the code if you ever script against tsc output.
 | `TutorialProvider` | `src/providers/TutorialProvider.tsx` | Context provider; renders overlay (used internally by TutorialWrapper) |
 | `TutorialOverlay` | `src/components/tutorial/TutorialOverlay.tsx` | Full-screen overlay with SVG mask spotlight |
 | `useTutorial` | `src/hooks/useTutorial.ts` | State management (step progression, localStorage, resume/restart) |
-| `useGameHint` | `src/hooks/useGameHint.ts` | Frontend hints; registry-driven via `hintFactories` (covers most games; currently 224). `frontend/scripts/check-hint-coverage.mjs` fails the build for any new game without one. The supported set is the `HintGameName` union (`keyof typeof hintFactories`) — add a game by registering its factory there |
+| `useGameHint` | `src/hooks/useGameHint.ts` | Frontend hints; registry-driven via `hintFactories` (covers most games; currently 225). `frontend/scripts/check-hint-coverage.mjs` fails the build for any new game without one. The supported set is the `HintGameName` union (`keyof typeof hintFactories`) — add a game by registering its factory there |
 | `TutorialSuggestDialog` | `src/components/tutorial/TutorialSuggestDialog.tsx` | First-visit dialog; controlled by `useFirstVisit` hook |
 | `TutorialProgressPanel` | `src/components/tutorial/TutorialProgressPanel.tsx` | Progress overview in NavBar |
 

--- a/frontend/scripts/check-hint-coverage.mjs
+++ b/frontend/scripts/check-hint-coverage.mjs
@@ -58,7 +58,6 @@ const BACKLOG = new Set([
   'conquian',
   'cuarenta',
   'cuckoo',
-  'doubleklondike',
   'escoba',
   'faro',
   'fivecardstud',

--- a/frontend/src/hooks/useGameHint.ts
+++ b/frontend/src/hooks/useGameHint.ts
@@ -49,6 +49,7 @@ import type {
   DesmocheResponse,
   DeuceToSevenResponse,
   DoppelkopfResponse,
+  DoubleKlondikeResponse,
   DoubtResponse,
   DoudizhuResponse,
   DragonTigerResponse,
@@ -257,6 +258,7 @@ import { getDesmocheHint } from '../utils/hints/desmocheHint';
 import { getDeucesWildHint } from '../utils/hints/deuceswildHint';
 import { getDeuceToSevenHint } from '../utils/hints/deuceToSevenHint';
 import { getDoppelkopfHint } from '../utils/hints/doppelkopfHint';
+import { getDoubleKlondikeHint } from '../utils/hints/doubleklondikeHint';
 import { getDoubtHint } from '../utils/hints/doubtHint';
 import { getDoudizhuHint } from '../utils/hints/doudizhuHint';
 import { getDragontigerHint } from '../utils/hints/dragontigerHint';
@@ -550,6 +552,7 @@ export const hintFactories = {
   blackhole: (s) => getBlackHoleHint(s as BlackHoleResponse),
   simplesimon: (s) => getSimpleSimonHint(s as SimpleSimonResponse),
   labellelucie: (s) => getLaBelleLucieHint(s as LaBelleLucieResponse),
+  doubleklondike: (s) => getDoubleKlondikeHint(s as DoubleKlondikeResponse),
   calculation: (s) => getCalculationHint(s as CalculationResponse),
   sirtommy: (s) => getSirTommyHint(s as SirTommyResponse),
   bisley: (s) => getBisleyHint(s as BisleyResponse),

--- a/frontend/src/i18n/locales/en/doubleklondike.json
+++ b/frontend/src/i18n/locales/en/doubleklondike.json
@@ -1,5 +1,9 @@
 {
-  "phase": { "playing": "Playing", "gameClear": "Game Clear", "gameOver": "Game Over" },
+  "phase": {
+    "playing": "Playing",
+    "gameClear": "Game Clear",
+    "gameOver": "Game Over"
+  },
   "title": "Double Klondike",
   "stock": "Stock",
   "waste": "Waste",
@@ -27,5 +31,9 @@
     "rules": "Build the tableau down in alternating colours and the foundations up by suit from Ace to King. Move all 104 cards to the foundations to win.",
     "actionButtons": "Buttons for draw, hint, undo, give up and more.",
     "resetButton": "Start a new game."
+  },
+  "frontendHint": {
+    "dklondikeToFoundation": "This card can go to a foundation",
+    "dklondikeToTableau": "This card can move to another column"
   }
 }

--- a/frontend/src/i18n/locales/ja/doubleklondike.json
+++ b/frontend/src/i18n/locales/ja/doubleklondike.json
@@ -1,5 +1,9 @@
 {
-  "phase": { "playing": "プレイ中", "gameClear": "ゲームクリア", "gameOver": "ゲームオーバー" },
+  "phase": {
+    "playing": "プレイ中",
+    "gameClear": "ゲームクリア",
+    "gameOver": "ゲームオーバー"
+  },
   "title": "ダブル・クロンダイク",
   "stock": "ストック",
   "waste": "山札（めくり）",
@@ -27,5 +31,9 @@
     "rules": "場札は色違いの降順に重ね、組札はスートごとにA→Kで積み上げます。104枚すべてを組札に上げるとクリアです。",
     "actionButtons": "めくる・ヒント・元に戻す・ギブアップなどの操作ボタンです。",
     "resetButton": "新しいゲームを始めるボタンです。"
+  },
+  "frontendHint": {
+    "dklondikeToFoundation": "この札を台札へ上げられます",
+    "dklondikeToTableau": "この札を別の列へ移せます"
   }
 }

--- a/frontend/src/pages/DoubleKlondikePage.tsx
+++ b/frontend/src/pages/DoubleKlondikePage.tsx
@@ -2,21 +2,25 @@ import { useEffect, useState } from 'react';
 import { doubleklondikeApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CardBack, CardImage } from '../components/CardImage';
+import { SettingsPanel } from '../components/common/SettingsPanel';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
+import { FrontendHintTooltip } from '../components/hint/FrontendHintTooltip';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useGameApi } from '../hooks/useGameApi';
+import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
 import { DoubleKlondikePhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { hintCheckboxItem } from '../utils/settingsItems';
 
 /** Double Klondike tutorial step definitions. */
 const DK_TUTORIAL_STEPS: TutorialStep[] = [
@@ -73,6 +77,12 @@ function DoubleKlondikePageContent() {
   // targets meet the DESIGN.md 44px minimum; the 9-column tableau and 8
   // foundations then scroll horizontally. Desktop keeps the compact half-width.
   const w = isMobile ? 44 : Math.round(cardWidth * 0.5);
+
+  const {
+    hint: frontendHint,
+    hintEnabled: frontendHintEnabled,
+    setHintEnabled: setFrontendHintEnabled,
+  } = useGameHint('doubleklondike', state);
 
   if (!state) return <GameSkeleton gameKey="doubleklondike" layout={{ kind: 'tableau', topRow: 4, tableau: 9 }} />;
 
@@ -294,6 +304,13 @@ function DoubleKlondikePageContent() {
         )}
 
         <GameMessageBox message={state.message} messageCode={state.messageCode} messageParams={state.messageParams} />
+        <FrontendHintTooltip hint={frontendHint} enabled={frontendHintEnabled} t={t} />
+
+        <SettingsPanel
+          title={tc('settings.title')}
+          groups={[{ items: [hintCheckboxItem(tc, frontendHintEnabled, setFrontendHintEnabled)] }]}
+        />
+
         <ActionLogSection
           isEndPhase={isEnd}
           actionLog={actionLog}

--- a/frontend/src/utils/hints/doubleklondikeHint.test.ts
+++ b/frontend/src/utils/hints/doubleklondikeHint.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import type { DoubleKlondikeResponse } from '../../types/card';
+import { getDoubleKlondikeHint } from './doubleklondikeHint';
+
+function makeState(overrides?: Partial<DoubleKlondikeResponse>): DoubleKlondikeResponse {
+  return {
+    tableau: [],
+    foundation: [],
+    stockCount: 40,
+    waste: [],
+    phase: 0,
+    moveCount: 0,
+    canUndo: false,
+    isStalemate: false,
+    message: '',
+    ...overrides,
+  };
+}
+
+describe('getDoubleKlondikeHint', () => {
+  it('rates a foundation move as strong', () => {
+    const hint = getDoubleKlondikeHint(
+      makeState({ hint: { fromZone: 'tableau', fromCol: 3, cardIndex: 0, toZone: 'foundation', toCol: 1 } }),
+    );
+    expect(hint?.targetAction).toBe('tableau-3');
+    expect(hint?.confidence).toBe('strong');
+  });
+
+  it('rates a tableau move as moderate', () => {
+    const hint = getDoubleKlondikeHint(
+      makeState({ hint: { fromZone: 'tableau', fromCol: 0, cardIndex: 2, toZone: 'tableau', toCol: 5 } }),
+    );
+    expect(hint?.reason).toBe('frontendHint.dklondikeToTableau');
+    expect(hint?.confidence).toBe('moderate');
+  });
+
+  // **廃札には列が無い。**-1 を付けて waste--1 にしない。
+  it('names the waste without a column', () => {
+    const hint = getDoubleKlondikeHint(
+      makeState({ hint: { fromZone: 'waste', fromCol: -1, cardIndex: -1, toZone: 'foundation', toCol: 0 } }),
+    );
+    expect(hint?.targetAction).toBe('waste');
+  });
+
+  it('returns null without a hint', () => {
+    expect(getDoubleKlondikeHint(makeState())).toBeNull();
+  });
+
+  it('returns null when a zone is missing', () => {
+    expect(
+      getDoubleKlondikeHint(
+        makeState({ hint: { fromZone: '', fromCol: 0, cardIndex: 0, toZone: 'tableau', toCol: 1 } }),
+      ),
+    ).toBeNull();
+  });
+
+  it('returns null once the game has ended', () => {
+    expect(
+      getDoubleKlondikeHint(
+        makeState({
+          phase: 1,
+          hint: { fromZone: 'tableau', fromCol: 0, cardIndex: 0, toZone: 'foundation', toCol: 0 },
+        }),
+      ),
+    ).toBeNull();
+  });
+});

--- a/frontend/src/utils/hints/doubleklondikeHint.ts
+++ b/frontend/src/utils/hints/doubleklondikeHint.ts
@@ -1,0 +1,27 @@
+import type { DoubleKlondikeResponse } from '../../types/card';
+import type { HintResult } from '../../types/hint';
+
+/** Double Klondike phase: playing. Later phases are game clear / game over. */
+const PHASE_PLAYING = 0;
+
+/**
+ * Returns a Double Klondike frontend hint derived from the backend hint, or null.
+ *
+ * The suggestion rides along with every state response (see
+ * DoubleKlondikeWebPresenter.Output, #4483). A card reaching a foundation is
+ * always progress; everything else is a rearrangement that may or may not be.
+ */
+export function getDoubleKlondikeHint(state: DoubleKlondikeResponse): HintResult | null {
+  if (state.phase !== PHASE_PLAYING) return null;
+  const hint = state.hint;
+  if (!hint || !hint.fromZone || !hint.toZone) return null;
+
+  // The waste has no column, so the action names the zone alone.
+  const from = hint.fromCol >= 0 ? `${hint.fromZone}-${hint.fromCol}` : hint.fromZone;
+  const toFoundation = hint.toZone === 'foundation';
+  return {
+    targetAction: from,
+    reason: toFoundation ? 'frontendHint.dklondikeToFoundation' : 'frontendHint.dklondikeToTableau',
+    confidence: toFoundation ? 'strong' : 'moderate',
+  };
+}


### PR DESCRIPTION
## 概要

#4557 の 5 本目。**`Output` が既にヒントを載せているゲームはこれで最後**です。残りは #4483 の進行待ちになります。

Refs #4557

## 廃札には列がありません

移動元が廃札のとき `fromCol` は -1 です。そのまま繋ぐと **`waste--1`** というアクション名になります。

```ts
const from = hint.fromCol >= 0 ? `${hint.fromZone}-${hint.fromCol}` : hint.fromZone;
```

テストで固定しています（`names the waste without a column`）。

**負の番号の扱いはゲームごとに違います** —— Black Hole / Simple Simon は「対象なし → null」、La Belle Lucie は台札行きのみ許容、Double Klondike は**ゾーン名だけにする**。3 通り出ました。

## 確度

| 移動先 | 確度 |
|---|---|
| 台札 | **strong** |
| それ以外 | moderate |

## 負のコントロール

状態のヒントを無視するよう壊すと **6 件中 3 件 FAIL**（ヒントが返ることを assert している全件）。

## 確認

- `bun run check` → `221 of 259 games hinted; 38 still owed`
- `bun run typecheck` green
- `DoubleKlondikePage.test.tsx` + `doubleklondikeHint.test.ts` 23 件 green

## Test plan

- [ ] CI 全ジョブ green