### PR TITLE
fix(hints): carry the passive hint for Call Break and Doppelkopf (#4483)

### DIFF
--- a/frontend/src/i18n/locales/en/callbreak.json
+++ b/frontend/src/i18n/locales/en/callbreak.json
@@ -79,5 +79,7 @@
     "mustTrumpWithSpade": "Void: must trump with a spade",
     "discardLowest": "Discard your lowest card"
   },
-  "bidSelected": "Selected bid: {{n}}"
+  "bidSelected": "Selected bid: {{n}}",
+  "hintRequested": "Hint available",
+  "noHint": "No hint available"
 }

--- a/frontend/src/i18n/locales/en/doppelkopf.json
+++ b/frontend/src/i18n/locales/en/doppelkopf.json
@@ -63,5 +63,7 @@
     "title": "Trump ranking",
     "caption": "strong → weak",
     "badgeTitle": "Trump"
-  }
+  },
+  "hintRequested": "Hint available",
+  "noHint": "No hint available"
 }

--- a/frontend/src/i18n/locales/ja/callbreak.json
+++ b/frontend/src/i18n/locales/ja/callbreak.json
@@ -79,5 +79,7 @@
     "mustTrumpWithSpade": "ボイドなのでスペードで切らなければなりません",
     "discardLowest": "最も低いカードを捨てることを推奨"
   },
-  "bidSelected": "選択中のビッド: {{n}}"
+  "bidSelected": "選択中のビッド: {{n}}",
+  "hintRequested": "ヒントがあります",
+  "noHint": "ヒントはありません"
 }

--- a/frontend/src/i18n/locales/ja/doppelkopf.json
+++ b/frontend/src/i18n/locales/ja/doppelkopf.json
@@ -63,5 +63,7 @@
     "title": "切り札序列",
     "caption": "強い → 弱い",
     "badgeTitle": "切り札"
-  }
+  },
+  "hintRequested": "ヒントがあります",
+  "noHint": "ヒントはありません"
 }

--- a/frontend/src/utils/cli/formatters/callbreakFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/callbreakFormatter.test.ts
@@ -63,6 +63,7 @@ describe('formatCallBreakState', () => {
   it('renders bid hint when hint.bid is present', () => {
     const out = formatCallBreakState(
       makeCallBreakState({
+        messageCode: 'callbreak.hintRequested',
         hint: { bid: 4, reason: 'strategic_bid' },
       }),
     );
@@ -72,6 +73,7 @@ describe('formatCallBreakState', () => {
   it('renders play hint when hint.cardIndex is present', () => {
     const out = formatCallBreakState(
       makeCallBreakState({
+        messageCode: 'callbreak.hintRequested',
         hint: { cardIndex: 2, reason: 'follow_suit' },
       }),
     );
@@ -95,5 +97,15 @@ describe('formatCallBreakState', () => {
       currentTrick: [{ playerIdx: 99, card: { design: 'HEART', value: 5 } }],
     });
     expect(() => formatCallBreakState(state)).not.toThrow();
+  });
+
+  // **HINT 行は hint を頼んだときだけ。**受動ヒントが Output に載るように
+  // なった (#4483) ので、messageCode で「頼んだ応答か」を見分ける。
+  it('shows the hint only when the hint was requested', () => {
+    const hint = { bid: 4, reason: 'strategic_bid' };
+    expect(formatCallBreakState(makeCallBreakState({ hint, messageCode: 'callbreak.hintRequested' }))).toContain(
+      'HINT',
+    );
+    expect(formatCallBreakState(makeCallBreakState({ hint, messageCode: 'callbreak.playing' }))).not.toContain('HINT');
   });
 });

--- a/frontend/src/utils/cli/formatters/callbreakFormatter.ts
+++ b/frontend/src/utils/cli/formatters/callbreakFormatter.ts
@@ -1,5 +1,12 @@
 import type { CallBreakResponse } from '../../../types/card';
-import { formatCard, formatHeader, formatIndexedCards, formatPlayerName, formatSeparator } from '../formatterBase';
+import {
+  formatCard,
+  formatHeader,
+  formatIndexedCards,
+  formatPlayerName,
+  formatSeparator,
+  isRequestedHint,
+} from '../formatterBase';
 
 /** Render a Call Break int×10 score as "X.Y" / "-X.Y" for terminal display. */
 function fmtScore(internal: number): string {
@@ -39,7 +46,7 @@ export function formatCallBreakState(state: CallBreakResponse): string {
 
   if (state.phase === 0) lines.push('Bidding phase (1-13, no Nil)');
 
-  if (state.hint) {
+  if (state.hint && isRequestedHint(state)) {
     if (state.hint.bid !== undefined) lines.push(`HINT: bid ${state.hint.bid} (${state.hint.reason})`);
     if (state.hint.cardIndex !== undefined) lines.push(`HINT: play [${state.hint.cardIndex}] (${state.hint.reason})`);
   }

--- a/frontend/src/utils/cli/formatters/doppelkopfFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/doppelkopfFormatter.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { makeDoppelkopfState } from '../../../test/stateFactories';
+import { formatDoppelkopfState } from './doppelkopfFormatter';
+
+describe('formatDoppelkopfState', () => {
+  it('renders the header', () => {
+    expect(formatDoppelkopfState(makeDoppelkopfState())).toContain('Doppelkopf');
+  });
+
+  // **HINT 行は hint を頼んだときだけ。**受動ヒントが Output に載るように
+  // なった (#4483) ので、messageCode で「頼んだ応答か」を見分ける。
+  it('shows the hint only when the hint was requested', () => {
+    const hint = { cardIndices: [1], reason: 'follow_suit' };
+    expect(formatDoppelkopfState(makeDoppelkopfState({ hint, messageCode: 'doppelkopf.hintRequested' }))).toContain(
+      'HINT',
+    );
+    expect(formatDoppelkopfState(makeDoppelkopfState({ hint, messageCode: 'doppelkopf.playing' }))).not.toContain(
+      'HINT',
+    );
+  });
+});

--- a/frontend/src/utils/cli/formatters/doppelkopfFormatter.ts
+++ b/frontend/src/utils/cli/formatters/doppelkopfFormatter.ts
@@ -1,5 +1,12 @@
 import type { DoppelkopfResponse } from '../../../types/card';
-import { formatCard, formatHeader, formatIndexedCards, formatPlayerName, formatSeparator } from '../formatterBase';
+import {
+  formatCard,
+  formatHeader,
+  formatIndexedCards,
+  formatPlayerName,
+  formatSeparator,
+  isRequestedHint,
+} from '../formatterBase';
 
 const PHASE_NAMES = ['Play', 'TrickEnd', 'RoundEnd', 'GameEnd'];
 
@@ -46,7 +53,7 @@ export function formatDoppelkopfState(state: DoppelkopfResponse): string {
     );
   }
 
-  if (state.hint) {
+  if (state.hint && isRequestedHint(state)) {
     const indices = state.hint.cardIndices ?? [];
     lines.push(`HINT: card indices [${indices.join(', ')}] (${state.hint.reason})`);
   }

--- a/internal/adapter/presenter/CallBreakWebPresenter.go
+++ b/internal/adapter/presenter/CallBreakWebPresenter.go
@@ -13,6 +13,20 @@ type CallBreakWebPresenter struct{}
 func (p *CallBreakWebPresenter) Output(cb interfaces.CallBreakGame, lastErr error) string {
 	resObj := p.buildBase(cb)
 	resObj.Message, resObj.MessageCode, resObj.MessageParams = p.buildMessage(cb, cb.GetCurrentTrick(), lastErr)
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	//
+	// **フェーズと手番はここでは見ない。**CallBreak.GetHint() が自分で
+	// 「人間の手番で、かつ行動を選べる状態か」を確かめて nil を返す。
+	if hint := cb.GetHint(); hint != nil {
+		resObj.Hint = &controller.CallBreakWebOutputHint{
+			CardIndex: hint.CardIndex,
+			Bid:       hint.Bid,
+			Reason:    hint.Reason,
+		}
+	}
+
 	return marshalOrError(resObj)
 }
 
@@ -109,6 +123,13 @@ func (p *CallBreakWebPresenter) HintOutput(cb interfaces.CallBreakGame) string {
 			Bid:       hint.Bid,
 			Reason:    hint.Reason,
 		}
+	}
+	// **「頼んだヒントか」を CLI が見分けられるようにする。**このゲーム群の
+	// `hintAvailable` は画面のラベルとして既に使われているので、別キーを出す (#4483)。
+	if hint != nil {
+		resObj.MessageCode = "callbreak.hintRequested"
+	} else {
+		resObj.MessageCode = "callbreak.noHint"
 	}
 	return marshalOrError(resObj)
 }

--- a/internal/adapter/presenter/CallBreakWebPresenter_test.go
+++ b/internal/adapter/presenter/CallBreakWebPresenter_test.go
@@ -27,6 +27,10 @@ func setupCallBreakWebMock() *interfaces.MockCallBreakGame {
 	m.On("GetLeadPlayerIdx").Return(0)
 	m.On("GetConfig").Return(domain.DefaultCallBreakConfig())
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
+	// **Output() も受動ヒントを埋める**ようになった (#4483)。既定は「ヒント無し」。
+	// **base だけに置く。**removeMockCall は最初の 1 件しか外さない。
+	m.On("GetHint").Return(nil).Maybe()
+
 	return m
 }
 
@@ -155,6 +159,7 @@ func TestCallBreakWebPresenter_HintOutput(t *testing.T) {
 
 	t.Run("nil hint", func(t *testing.T) {
 		m, _ := setupCallBreakWebMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHint")
 		m.On("GetHint").Return((*domain.CallBreakHint)(nil))
 		var resObj controller.CallBreakWebOutput
 		assert.NoError(t, json.Unmarshal([]byte(p.HintOutput(m)), &resObj))
@@ -164,6 +169,7 @@ func TestCallBreakWebPresenter_HintOutput(t *testing.T) {
 	t.Run("bid hint", func(t *testing.T) {
 		m, _ := setupCallBreakWebMockWithPlayers()
 		bid := 4
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHint")
 		m.On("GetHint").Return(&domain.CallBreakHint{Bid: &bid, Reason: "strategic_bid"})
 		var resObj controller.CallBreakWebOutput
 		assert.NoError(t, json.Unmarshal([]byte(p.HintOutput(m)), &resObj))
@@ -183,4 +189,32 @@ func TestCallBreakWebPresenter_ActionLogOutput(t *testing.T) {
 	})
 	out := p.ActionLogOutput(m)
 	assert.Contains(t, out, "\"actionType\":\"play\"")
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+func TestCallBreakWebPresenterOutputCarriesTheHint(t *testing.T) {
+	idx := 0
+	cbg, _ := setupCallBreakWebMockWithPlayers()
+	cbg.ExpectedCalls = removeMockCall(cbg.ExpectedCalls, "GetHint")
+	cbg.On("GetHint").Return(&domain.CallBreakHint{CardIndex: &idx, Reason: "follow_suit"})
+
+	result := new(presenter.CallBreakWebPresenter).Output(cbg, nil)
+	assert.Contains(t, result, `"hint"`, "Output must carry the hint -- the frontend reads state.hint")
+	// **Output は「頼んだヒント」の印を付けない。**付けると CLI が毎回 HINT 行を出す。
+	assert.NotContains(t, result, "callbreak.hintRequested")
+}
+
+// **HintOutput は「頼んだヒント」だと分かる印を付ける。**
+func TestCallBreakWebPresenterHintOutputMarksTheRequest(t *testing.T) {
+	idx := 0
+	cbg, _ := setupCallBreakWebMockWithPlayers()
+	cbg.ExpectedCalls = removeMockCall(cbg.ExpectedCalls, "GetHint")
+	cbg.On("GetHint").Return(&domain.CallBreakHint{CardIndex: &idx, Reason: "follow_suit"})
+	assert.Contains(t, new(presenter.CallBreakWebPresenter).HintOutput(cbg), "callbreak.hintRequested")
+
+	none, _ := setupCallBreakWebMockWithPlayers()
+	none.ExpectedCalls = removeMockCall(none.ExpectedCalls, "GetHint")
+	none.On("GetHint").Return((*domain.CallBreakHint)(nil))
+	assert.Contains(t, new(presenter.CallBreakWebPresenter).HintOutput(none), "callbreak.noHint")
 }

--- a/internal/adapter/presenter/DoppelkopfWebPresenter.go
+++ b/internal/adapter/presenter/DoppelkopfWebPresenter.go
@@ -17,6 +17,19 @@ type DoppelkopfWebPresenter struct{}
 func (p *DoppelkopfWebPresenter) Output(g interfaces.DoppelkopfGame, lastErr error) string {
 	resObj := p.buildBase(g)
 	resObj.Message, resObj.MessageCode, resObj.MessageParams = p.buildMessage(g, lastErr)
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	//
+	// **フェーズと手番はここでは見ない。**Doppelkopf.GetHint() が自分で
+	// 「人間の手番で、かつ行動を選べる状態か」を確かめて nil を返す。
+	if hint := g.GetHint(); hint != nil {
+		resObj.Hint = &controller.WebOutputCardHint{
+			CardIndices: hint.CardIndices,
+			Reason:      hint.Reason,
+		}
+	}
+
 	return marshalOrError(resObj)
 }
 
@@ -166,6 +179,13 @@ func (p *DoppelkopfWebPresenter) HintOutput(g interfaces.DoppelkopfGame) string 
 			CardIndices: hint.CardIndices,
 			Reason:      hint.Reason,
 		}
+	}
+	// **「頼んだヒントか」を CLI が見分けられるようにする。**このゲーム群の
+	// `hintAvailable` は画面のラベルとして既に使われているので、別キーを出す (#4483)。
+	if hint != nil {
+		resObj.MessageCode = "doppelkopf.hintRequested"
+	} else {
+		resObj.MessageCode = "doppelkopf.noHint"
 	}
 	return marshalOrError(resObj)
 }

--- a/internal/adapter/presenter/DoppelkopfWebPresenter_test.go
+++ b/internal/adapter/presenter/DoppelkopfWebPresenter_test.go
@@ -42,6 +42,10 @@ func setupDoppelkopfWebMock() *interfaces.MockDoppelkopfGame {
 	m.On("IsHumanTurn").Return(true)
 	m.On("GetConfig").Return(domain.DefaultDoppelkopfConfig())
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
+	// **Output() も受動ヒントを埋める**ようになった (#4483)。既定は「ヒント無し」。
+	// **base だけに置く。**removeMockCall は最初の 1 件しか外さない。
+	m.On("GetHint").Return(nil).Maybe()
+
 	return m
 }
 
@@ -199,6 +203,7 @@ func TestDoppelkopfWebPresenter_HintOutput(t *testing.T) {
 
 	t.Run("hint with card indices", func(t *testing.T) {
 		m, _ := setupDoppelkopfWebMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHint")
 		m.On("GetHint").Return(&domain.DoppelkopfHint{CardIndices: []int{2}, Reason: "follow_win"})
 		result := p.HintOutput(m)
 		var resObj controller.DoppelkopfWebOutput
@@ -210,6 +215,7 @@ func TestDoppelkopfWebPresenter_HintOutput(t *testing.T) {
 
 	t.Run("no hint", func(t *testing.T) {
 		m, _ := setupDoppelkopfWebMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHint")
 		m.On("GetHint").Return((*domain.DoppelkopfHint)(nil))
 		result := p.HintOutput(m)
 		var resObj controller.DoppelkopfWebOutput
@@ -227,4 +233,30 @@ func TestDoppelkopfWebPresenter_ActionLogOutput(t *testing.T) {
 	})
 	result := p.ActionLogOutput(m)
 	assert.Contains(t, result, `"actionType":"play"`)
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+func TestDoppelkopfWebPresenterOutputCarriesTheHint(t *testing.T) {
+	dkg, _ := setupDoppelkopfWebMockWithPlayers()
+	dkg.ExpectedCalls = removeMockCall(dkg.ExpectedCalls, "GetHint")
+	dkg.On("GetHint").Return(&domain.DoppelkopfHint{CardIndices: []int{0}, Reason: "follow_suit"})
+
+	result := new(presenter.DoppelkopfWebPresenter).Output(dkg, nil)
+	assert.Contains(t, result, `"hint"`, "Output must carry the hint -- the frontend reads state.hint")
+	// **Output は「頼んだヒント」の印を付けない。**付けると CLI が毎回 HINT 行を出す。
+	assert.NotContains(t, result, "doppelkopf.hintRequested")
+}
+
+// **HintOutput は「頼んだヒント」だと分かる印を付ける。**
+func TestDoppelkopfWebPresenterHintOutputMarksTheRequest(t *testing.T) {
+	dkg, _ := setupDoppelkopfWebMockWithPlayers()
+	dkg.ExpectedCalls = removeMockCall(dkg.ExpectedCalls, "GetHint")
+	dkg.On("GetHint").Return(&domain.DoppelkopfHint{CardIndices: []int{0}, Reason: "follow_suit"})
+	assert.Contains(t, new(presenter.DoppelkopfWebPresenter).HintOutput(dkg), "doppelkopf.hintRequested")
+
+	none, _ := setupDoppelkopfWebMockWithPlayers()
+	none.ExpectedCalls = removeMockCall(none.ExpectedCalls, "GetHint")
+	none.On("GetHint").Return((*domain.DoppelkopfHint)(nil))
+	assert.Contains(t, new(presenter.DoppelkopfWebPresenter).HintOutput(none), "doppelkopf.noHint")
 }


### PR DESCRIPTION
## 概要

`hintRequested` 方式の 6 バッチ目。**Call Break / Doppelkopf**。

Refs #4483

## Euchre を外しました

3 本目に用意しましたが、**共有の state ファクトリが無く**、ヒント行も**波括弧なしの 1 行**（`if (state.hint) lines.push(...)`）でバッチ用スクリプトが扱えません。フィクスチャを一から作る必要があるので、**プレゼンタテストが要る 12 本と一緒に**後のバッチに回します。

## `doppelkopfFormatter` にテストがありませんでした

ゲートを足しても何も検証されない状態だったので、共有ファクトリ `makeDoppelkopfState` を使って新規作成しています。

（この「フォーマッタにテストが無い」は #4569 の Sheepshead に続いて 2 例目です。）

## 負のコントロール

| 壊しかた | 結果 |
|---|---|
| `Output` のヒントを落とす | **2 件 FAIL** |
| `hintRequested` を出さなくする | **2 件 FAIL** |
| CLI のゲートを外す | **2 ファイル FAIL** |

## 確認

- `go test -tags test ./internal/adapter/presenter/ -count=2` green（パッケージ全体）
- `golangci-lint run ./internal/adapter/presenter/` 0 issues
- `bun run test` / `bun run check` / `typecheck` green

## Test plan

- [ ] CI 全ジョブ green