### PR TITLE
fix(hints): write the Spades formatter test, then carry its passive hint (#4483)

### DIFF
--- a/frontend/src/i18n/locales/en/spades.json
+++ b/frontend/src/i18n/locales/en/spades.json
@@ -82,5 +82,7 @@
     "followSuit": "Follow the led suit",
     "trumpWithSpade": "Trump with a spade",
     "discardLowest": "Discard your lowest card"
-  }
+  },
+  "hintRequested": "Hint available",
+  "noHint": "No hint available"
 }

--- a/frontend/src/i18n/locales/ja/spades.json
+++ b/frontend/src/i18n/locales/ja/spades.json
@@ -82,5 +82,7 @@
     "followSuit": "リードされたスートに従ってプレイ推奨",
     "trumpWithSpade": "スペードで切り札を使うチャンス",
     "discardLowest": "最も低いカードを捨てることを推奨"
-  }
+  },
+  "hintRequested": "ヒントがあります",
+  "noHint": "ヒントはありません"
 }

--- a/frontend/src/utils/cli/formatters/spadesFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/spadesFormatter.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { makeSpadesState } from '../../../test/stateFactories';
+import { formatSpadesState } from './spadesFormatter';
+
+describe('formatSpadesState', () => {
+  it('renders the header, round, trick and whether spades are broken', () => {
+    const out = formatSpadesState(makeSpadesState());
+    expect(out).toContain('Spades');
+    expect(out).toContain('round:');
+    expect(out).toContain('trick:');
+    expect(out).toContain('spades broken:');
+  });
+
+  it('reports broken spades', () => {
+    expect(formatSpadesState(makeSpadesState({ spadesBroken: true }))).toContain('spades broken: yes');
+    expect(formatSpadesState(makeSpadesState({ spadesBroken: false }))).toContain('spades broken: no');
+  });
+
+  it('renders a bid hint and a play hint differently', () => {
+    const bid = formatSpadesState(
+      makeSpadesState({ hint: { bid: 3, reason: 'strategic_bid' }, messageCode: 'spades.hintRequested' }),
+    );
+    expect(bid).toContain('HINT: bid 3');
+
+    const play = formatSpadesState(
+      makeSpadesState({ hint: { cardIndex: 2, reason: 'follow_suit' }, messageCode: 'spades.hintRequested' }),
+    );
+    expect(play).toContain('HINT: play [2]');
+  });
+
+  it('renders the message when present', () => {
+    expect(formatSpadesState(makeSpadesState({ message: 'done' }))).toContain('done');
+  });
+
+  // **HINT 行は hint を頼んだときだけ。**受動ヒントが Output に載るように
+  // なった (#4483) ので、messageCode で「頼んだ応答か」を見分ける。
+  it('shows the hint only when the hint was requested', () => {
+    const hint = { cardIndex: 2, reason: 'follow_suit' };
+    expect(formatSpadesState(makeSpadesState({ hint, messageCode: 'spades.hintRequested' }))).toContain('HINT');
+    expect(formatSpadesState(makeSpadesState({ hint, messageCode: 'spades.playing' }))).not.toContain('HINT');
+  });
+});

--- a/frontend/src/utils/cli/formatters/spadesFormatter.ts
+++ b/frontend/src/utils/cli/formatters/spadesFormatter.ts
@@ -1,5 +1,12 @@
 import type { SpadesResponse } from '../../../types/card';
-import { formatCard, formatHeader, formatIndexedCards, formatPlayerName, formatSeparator } from '../formatterBase';
+import {
+  formatCard,
+  formatHeader,
+  formatIndexedCards,
+  formatPlayerName,
+  formatSeparator,
+  isRequestedHint,
+} from '../formatterBase';
 
 /** Format a Spades game state as terminal text. */
 export function formatSpadesState(state: SpadesResponse): string {
@@ -32,7 +39,7 @@ export function formatSpadesState(state: SpadesResponse): string {
 
   if (state.phase === 0) lines.push('Bidding phase');
 
-  if (state.hint) {
+  if (state.hint && isRequestedHint(state)) {
     if (state.hint.bid !== undefined) lines.push(`HINT: bid ${state.hint.bid} (${state.hint.reason})`);
     if (state.hint.cardIndex !== undefined) lines.push(`HINT: play [${state.hint.cardIndex}] (${state.hint.reason})`);
   }

--- a/internal/adapter/presenter/SpadesWebPresenter.go
+++ b/internal/adapter/presenter/SpadesWebPresenter.go
@@ -13,6 +13,20 @@ type SpadesWebPresenter struct{}
 func (p *SpadesWebPresenter) Output(s interfaces.SpadesGame, lastErr error) string {
 	resObj := p.buildBase(s)
 	resObj.Message, resObj.MessageCode, resObj.MessageParams = p.buildMessage(s, s.GetCurrentTrick(), lastErr)
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	//
+	// **フェーズと手番はここでは見ない。**Spades.GetHint() が自分で
+	// 「人間の手番で、かつ行動を選べる状態か」を確かめて nil を返す。
+	if hint := s.GetHint(); hint != nil {
+		resObj.Hint = &controller.SpadesWebOutputHint{
+			CardIndex: hint.CardIndex,
+			Bid:       hint.Bid,
+			Reason:    hint.Reason,
+		}
+	}
+
 	return marshalOrError(resObj)
 }
 
@@ -101,6 +115,13 @@ func (p *SpadesWebPresenter) HintOutput(s interfaces.SpadesGame) string {
 			Bid:       hint.Bid,
 			Reason:    hint.Reason,
 		}
+	}
+	// **「頼んだヒントか」を CLI が見分けられるようにする。**このゲーム群の
+	// `hintAvailable` は画面のラベルとして既に使われているので、別キーを出す (#4483)。
+	if hint != nil {
+		resObj.MessageCode = "spades.hintRequested"
+	} else {
+		resObj.MessageCode = "spades.noHint"
 	}
 	return marshalOrError(resObj)
 }

--- a/internal/adapter/presenter/SpadesWebPresenter_test.go
+++ b/internal/adapter/presenter/SpadesWebPresenter_test.go
@@ -29,6 +29,10 @@ func setupSpadesWebMock() *interfaces.MockSpadesGame {
 	m.On("GetLeadPlayerIdx").Return(0)
 	m.On("GetConfig").Return(domain.DefaultSpadesConfig())
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
+	// **Output() も受動ヒントを埋める**ようになった (#4483)。既定は「ヒント無し」。
+	// **base だけに置く。**removeMockCall は最初の 1 件しか外さない。
+	m.On("GetHint").Return(nil).Maybe()
+
 	return m
 }
 
@@ -404,6 +408,7 @@ func TestSpadesWebPresenter_HintOutput(t *testing.T) {
 	t.Run("hint available with card", func(t *testing.T) {
 		idx := 2
 		m, _ := setupSpadesWebMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHint")
 		m.On("GetHint").Return(&domain.SpadesHint{
 			CardIndex: &idx,
 			Reason:    "follow_suit",
@@ -416,12 +421,13 @@ func TestSpadesWebPresenter_HintOutput(t *testing.T) {
 		assert.NotNil(t, resObj.Hint)
 		assert.Equal(t, &idx, resObj.Hint.CardIndex)
 		assert.Equal(t, "follow_suit", resObj.Hint.Reason)
-		assert.Empty(t, resObj.MessageCode)
+		assert.Equal(t, "spades.hintRequested", resObj.MessageCode)
 	})
 
 	t.Run("hint available with bid", func(t *testing.T) {
 		bid := 3
 		m, _ := setupSpadesWebMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHint")
 		m.On("GetHint").Return(&domain.SpadesHint{
 			Bid:    &bid,
 			Reason: "strategic_bid",
@@ -434,11 +440,12 @@ func TestSpadesWebPresenter_HintOutput(t *testing.T) {
 		assert.NotNil(t, resObj.Hint)
 		assert.Equal(t, &bid, resObj.Hint.Bid)
 		assert.Equal(t, "strategic_bid", resObj.Hint.Reason)
-		assert.Empty(t, resObj.MessageCode)
+		assert.Equal(t, "spades.hintRequested", resObj.MessageCode)
 	})
 
 	t.Run("no hint", func(t *testing.T) {
 		m, _ := setupSpadesWebMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHint")
 		m.On("GetHint").Return((*domain.SpadesHint)(nil))
 
 		result := p.HintOutput(m)
@@ -446,6 +453,33 @@ func TestSpadesWebPresenter_HintOutput(t *testing.T) {
 		err := json.Unmarshal([]byte(result), &resObj)
 		assert.NoError(t, err)
 		assert.Nil(t, resObj.Hint)
-		assert.Empty(t, resObj.MessageCode)
+		assert.Equal(t, "spades.noHint", resObj.MessageCode)
 	})
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+func TestSpadesWebPresenterOutputCarriesTheHint(t *testing.T) {
+	idx := 0
+	spg, _ := setupSpadesWebMockWithPlayers()
+	spg.ExpectedCalls = removeMockCall(spg.ExpectedCalls, "GetHint")
+	spg.On("GetHint").Return(&domain.SpadesHint{CardIndex: &idx, Reason: "follow_suit"})
+
+	result := new(presenter.SpadesWebPresenter).Output(spg, nil)
+	assert.Contains(t, result, `"hint"`, "Output must carry the hint -- the frontend reads state.hint")
+	assert.NotContains(t, result, "spades.hintRequested")
+}
+
+// **HintOutput は「頼んだヒント」だと分かる印を付ける。**
+func TestSpadesWebPresenterHintOutputMarksTheRequest(t *testing.T) {
+	idx := 0
+	spg, _ := setupSpadesWebMockWithPlayers()
+	spg.ExpectedCalls = removeMockCall(spg.ExpectedCalls, "GetHint")
+	spg.On("GetHint").Return(&domain.SpadesHint{CardIndex: &idx, Reason: "follow_suit"})
+	assert.Contains(t, new(presenter.SpadesWebPresenter).HintOutput(spg), "spades.hintRequested")
+
+	none, _ := setupSpadesWebMockWithPlayers()
+	none.ExpectedCalls = removeMockCall(none.ExpectedCalls, "GetHint")
+	none.On("GetHint").Return((*domain.SpadesHint)(nil))
+	assert.Contains(t, new(presenter.SpadesWebPresenter).HintOutput(none), "spades.noHint")
 }


### PR DESCRIPTION
## 概要

**CLI フォーマッタのテストが無い 9 本**の 1 本目。Spades。

Refs #4483

## テストを先に書きました

ゲートを足しても**何も検証されない**ので、まずテストです。**ゲートに必要な 1 行だけでなく、そのフォーマッタが実際に出すもの**を覆っています。

- ヘッダ / ラウンド / トリック / スペード解禁フラグ
- **入札ヒントとプレイヒントで行が変わる**こと（`HINT: bid 3` と `HINT: play [2]`）
- メッセージ

## 既存テストが旧仕様を固定していました

`assert.Empty(t, resObj.MessageCode)` が**3 箇所**（ヒントあり・入札ヒント・ヒント無し）。[#4574 の Hearts](https://github.com/yuta-yoshinaga/go_trumpcards/pull/4574) と同じ形です。

## 負のコントロール

| 壊しかた | 結果 |
|---|---|
| `Output` のヒントを落とす | **1 件 FAIL** |
| CLI のゲートを外す | **1 ファイル FAIL** |

## 残り

CLI テストが無い残り 8 本: Bridge / Doppelkopf / Euchre / Napoleon / NinetyNine / OhHell / Whist / Wizard

**Whist と Wizard には共有 state ファクトリもありません**ので、フィクスチャから作ることになります。

## 確認

- `go test -tags test ./internal/adapter/presenter/ -count=2` green（パッケージ全体）
- `golangci-lint run ./internal/adapter/presenter/` 0 issues
- `bun run test` / `bun run check` / `typecheck` green

## Test plan

- [ ] CI 全ジョブ green