### PR TITLE
fix(hints): write the Oh Hell formatter test, then carry its passive hint (#4483)

### DIFF
--- a/frontend/src/i18n/locales/en/ohhell.json
+++ b/frontend/src/i18n/locales/en/ohhell.json
@@ -92,5 +92,7 @@
     "trumpWithCard": "Trump with a card",
     "discardLowest": "Discard your lowest card"
   },
-  "restrictedBidAria": "Bid {{n}} (unavailable due to the dealer restriction)"
+  "restrictedBidAria": "Bid {{n}} (unavailable due to the dealer restriction)",
+  "hintRequested": "Hint available",
+  "noHint": "No hint available"
 }

--- a/frontend/src/i18n/locales/ja/ohhell.json
+++ b/frontend/src/i18n/locales/ja/ohhell.json
@@ -92,5 +92,7 @@
     "trumpWithCard": "切り札を使うチャンス",
     "discardLowest": "最も低いカードを捨てることを推奨"
   },
-  "restrictedBidAria": "{{n}} をビッド（ディーラー制約により選択できません）"
+  "restrictedBidAria": "{{n}} をビッド（ディーラー制約により選択できません）",
+  "hintRequested": "ヒントがあります",
+  "noHint": "ヒントはありません"
 }

--- a/frontend/src/utils/cli/formatters/ohhellFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/ohhellFormatter.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import type { OhHellPlayerData, OhHellResponse } from '../../../types/card';
+import { formatOhhellState } from './ohhellFormatter';
+
+function makePlayer(overrides?: Partial<OhHellPlayerData>): OhHellPlayerData {
+  return {
+    id: 0,
+    isHuman: true,
+    cardCount: 1,
+    cards: [{ design: 'SPADE', value: 1 }],
+    bid: 1,
+    roundScore: 0,
+    cumulativeScore: 10,
+    trickCount: 0,
+    ...overrides,
+  };
+}
+
+function makeState(overrides?: Partial<OhHellResponse>): OhHellResponse {
+  return {
+    players: [makePlayer(), makePlayer({ id: 1, isHuman: false, cards: [] })],
+    phase: 0,
+    roundNumber: 2,
+    totalRounds: 7,
+    handSize: 3,
+    trickNumber: 1,
+    currentPlayerIdx: 0,
+    bidPlayerIdx: 0,
+    dealerIdx: 1,
+    currentTrick: [],
+    trumpCard: { design: 'HEART', value: 12 },
+    trumpSuit: 3,
+    restrictedBid: -1,
+    gameEndFlag: false,
+    winnerIdx: -1,
+    leadPlayerIdx: 0,
+    config: { cpuDifficulty: 1, maxHandSize: 7, scoringVariant: 0, roundDirection: 0 },
+    message: '',
+    ...overrides,
+  };
+}
+
+describe('formatOhhellState', () => {
+  it('renders the header, round out of total, trick and hand size', () => {
+    const out = formatOhhellState(makeState());
+    expect(out).toContain('Oh Hell');
+    expect(out).toContain('round: 2/7');
+    expect(out).toContain('trick: 1');
+    expect(out).toContain('hand size: 3');
+  });
+
+  it('names the trump card only when there is one', () => {
+    expect(formatOhhellState(makeState())).toContain('trump:');
+    expect(formatOhhellState(makeState({ trumpCard: null }))).not.toContain('trump:');
+  });
+
+  it("renders each player's score, bid and tricks", () => {
+    const out = formatOhhellState(makeState());
+    expect(out).toContain('total=10');
+    expect(out).toContain('bid=1');
+    expect(out).toContain('tricks=0');
+  });
+
+  // **入札とプレイでヒント行が変わる。**
+  it('renders a bid hint and a play hint differently', () => {
+    const bid = formatOhhellState(
+      makeState({ hint: { bid: 2, reason: 'strategic_bid' }, messageCode: 'ohhell.hintRequested' }),
+    );
+    expect(bid).toContain('HINT: bid 2');
+
+    const play = formatOhhellState(
+      makeState({ hint: { cardIndex: 1, reason: 'follow_suit' }, messageCode: 'ohhell.hintRequested' }),
+    );
+    expect(play).toContain('HINT: play [1]');
+  });
+
+  it('renders the message when present', () => {
+    expect(formatOhhellState(makeState({ message: 'done' }))).toContain('done');
+  });
+
+  // **HINT 行は hint を頼んだときだけ。**受動ヒントが Output に載るように
+  // なった (#4483) ので、messageCode で「頼んだ応答か」を見分ける。
+  it('shows the hint only when the hint was requested', () => {
+    const hint = { cardIndex: 1, reason: 'follow_suit' };
+    expect(formatOhhellState(makeState({ hint, messageCode: 'ohhell.hintRequested' }))).toContain('HINT');
+    expect(formatOhhellState(makeState({ hint, messageCode: 'ohhell.playing' }))).not.toContain('HINT');
+  });
+});

--- a/frontend/src/utils/cli/formatters/ohhellFormatter.ts
+++ b/frontend/src/utils/cli/formatters/ohhellFormatter.ts
@@ -1,5 +1,12 @@
 import type { OhHellResponse } from '../../../types/card';
-import { formatCard, formatHeader, formatIndexedCards, formatPlayerName, formatSeparator } from '../formatterBase';
+import {
+  formatCard,
+  formatHeader,
+  formatIndexedCards,
+  formatPlayerName,
+  formatSeparator,
+  isRequestedHint,
+} from '../formatterBase';
 
 /** Format an Oh Hell game state as terminal text. */
 export function formatOhhellState(state: OhHellResponse): string {
@@ -34,7 +41,7 @@ export function formatOhhellState(state: OhHellResponse): string {
     if (state.restrictedBid >= 0) lines.push(`(cannot bid ${state.restrictedBid})`);
   }
 
-  if (state.hint) {
+  if (state.hint && isRequestedHint(state)) {
     if (state.hint.bid !== undefined) lines.push(`HINT: bid ${state.hint.bid} (${state.hint.reason})`);
     if (state.hint.cardIndex !== undefined) lines.push(`HINT: play [${state.hint.cardIndex}] (${state.hint.reason})`);
   }

--- a/internal/adapter/presenter/OhHellWebPresenter.go
+++ b/internal/adapter/presenter/OhHellWebPresenter.go
@@ -13,6 +13,20 @@ type OhHellWebPresenter struct{}
 func (p *OhHellWebPresenter) Output(o interfaces.OhHellGame, lastErr error) string {
 	resObj := p.buildBase(o)
 	resObj.Message, resObj.MessageCode, resObj.MessageParams = p.buildMessage(o, lastErr)
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	//
+	// **フェーズと手番はここでは見ない。**OhHell.GetHint() が自分で
+	// 「人間の手番で、かつ行動を選べる状態か」を確かめて nil を返す。
+	if hint := o.GetHint(); hint != nil {
+		resObj.Hint = &controller.OhHellWebOutputHint{
+			CardIndex: hint.CardIndex,
+			Bid:       hint.Bid,
+			Reason:    hint.Reason,
+		}
+	}
+
 	return marshalOrError(resObj)
 }
 
@@ -27,6 +41,13 @@ func (p *OhHellWebPresenter) HintOutput(o interfaces.OhHellGame) string {
 			Bid:       hint.Bid,
 			Reason:    hint.Reason,
 		}
+	}
+	// **「頼んだヒントか」を CLI が見分けられるようにする。**このゲーム群の
+	// `hintAvailable` は画面のラベルとして既に使われているので、別キーを出す (#4483)。
+	if hint != nil {
+		resObj.MessageCode = "ohhell.hintRequested"
+	} else {
+		resObj.MessageCode = "ohhell.noHint"
 	}
 	return marshalOrError(resObj)
 }

--- a/internal/adapter/presenter/OhHellWebPresenter_test.go
+++ b/internal/adapter/presenter/OhHellWebPresenter_test.go
@@ -43,6 +43,10 @@ func setupOhHellWebMock() *interfaces.MockOhHellGame {
 	m.On("GetLeadPlayerIdx").Return(0)
 	m.On("GetConfig").Return(domain.DefaultOhHellConfig())
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
+	// **Output() も受動ヒントを埋める**ようになった (#4483)。既定は「ヒント無し」。
+	// **base だけに置く。**removeMockCall は最初の 1 件しか外さない。
+	m.On("GetHint").Return(nil).Maybe()
+
 	return m
 }
 
@@ -168,6 +172,7 @@ func TestOhHellWebPresenter_HintOutput(t *testing.T) {
 	t.Run("with hint", func(t *testing.T) {
 		m, _ := setupOhHellWebMockWithPlayers()
 		bid := 3
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHint")
 		m.On("GetHint").Return(&domain.OhHellHint{Bid: &bid, Reason: "strategic_bid"})
 
 		result := p.HintOutput(m)
@@ -180,6 +185,7 @@ func TestOhHellWebPresenter_HintOutput(t *testing.T) {
 
 	t.Run("nil hint", func(t *testing.T) {
 		m, _ := setupOhHellWebMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHint")
 		m.On("GetHint").Return((*domain.OhHellHint)(nil))
 
 		result := p.HintOutput(m)
@@ -198,4 +204,31 @@ func TestOhHellWebPresenter_ActionLogOutput(t *testing.T) {
 
 	result := p.ActionLogOutput(m)
 	assert.NotEmpty(t, result)
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+func TestOhHellWebPresenterOutputCarriesTheHint(t *testing.T) {
+	idx := 0
+	ohg, _ := setupOhHellWebMockWithPlayers()
+	ohg.ExpectedCalls = removeMockCall(ohg.ExpectedCalls, "GetHint")
+	ohg.On("GetHint").Return(&domain.OhHellHint{CardIndex: &idx, Reason: "follow_suit"})
+
+	result := new(presenter.OhHellWebPresenter).Output(ohg, nil)
+	assert.Contains(t, result, `"hint"`, "Output must carry the hint -- the frontend reads state.hint")
+	assert.NotContains(t, result, "ohhell.hintRequested")
+}
+
+// **HintOutput は「頼んだヒント」だと分かる印を付ける。**
+func TestOhHellWebPresenterHintOutputMarksTheRequest(t *testing.T) {
+	idx := 0
+	ohg, _ := setupOhHellWebMockWithPlayers()
+	ohg.ExpectedCalls = removeMockCall(ohg.ExpectedCalls, "GetHint")
+	ohg.On("GetHint").Return(&domain.OhHellHint{CardIndex: &idx, Reason: "follow_suit"})
+	assert.Contains(t, new(presenter.OhHellWebPresenter).HintOutput(ohg), "ohhell.hintRequested")
+
+	none, _ := setupOhHellWebMockWithPlayers()
+	none.ExpectedCalls = removeMockCall(none.ExpectedCalls, "GetHint")
+	none.On("GetHint").Return((*domain.OhHellHint)(nil))
+	assert.Contains(t, new(presenter.OhHellWebPresenter).HintOutput(none), "ohhell.noHint")
 }


### PR DESCRIPTION
## 概要

**CLI フォーマッタのテストが無い 9 本**の 2 本目。Oh Hell。

Refs #4483

## 共有 state ファクトリもありません

`makeOhHellState` は存在しないので、**レスポンス型からフィクスチャを組み立て**ています（players / currentTrick / trumpCard / config）。

残り 7 本のうち **Doppelkopf 以外はすべて同じ状況**です（Bridge / Euchre / Napoleon / NinetyNine / Whist / Wizard）。

## ゲートに必要な 1 行だけでなく

- 切り札行が**切り札があるときだけ**出ること
- プレイヤーごとの `total=` / `bid=` / `tricks=`
- **入札ヒントとプレイヒントで行が変わる**こと

## 関数名は `formatOhhellState`

`formatOhHellState` ではありません。テストが即座に捕まえました。**残り 7 本でも同じ落とし穴があり得ます。**

## 負のコントロール

| 壊しかた | 結果 |
|---|---|
| `Output` のヒントを落とす | **1 件 FAIL** |
| CLI のゲートを外す | **1 ファイル FAIL** |

## 確認

- `go test -tags test ./internal/adapter/presenter/ -count=2` green（パッケージ全体）
- `golangci-lint run ./internal/adapter/presenter/` 0 issues
- `bun run test` / `bun run check` / `typecheck` green

## Test plan

- [ ] CI 全ジョブ green