### PR TITLE
fix(hints): write the Ninety-Nine formatter test, then carry its passive hint (#4483)

### DIFF
--- a/frontend/src/i18n/locales/en/ninetynine.json
+++ b/frontend/src/i18n/locales/en/ninetynine.json
@@ -87,5 +87,7 @@
     "followSuit": "Follow the led suit",
     "trumpWithCard": "Trump with a card",
     "discardLowest": "Discard your lowest card"
-  }
+  },
+  "hintRequested": "Hint available",
+  "noHint": "No hint available"
 }

--- a/frontend/src/i18n/locales/ja/ninetynine.json
+++ b/frontend/src/i18n/locales/ja/ninetynine.json
@@ -87,5 +87,7 @@
     "followSuit": "リードスートに従いましょう",
     "trumpWithCard": "切り札で取りましょう",
     "discardLowest": "一番低いカードを捨てましょう"
-  }
+  },
+  "hintRequested": "ヒントがあります",
+  "noHint": "ヒントはありません"
 }

--- a/frontend/src/utils/cli/formatters/ninetynineFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/ninetynineFormatter.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import type { NinetyNinePlayerData, NinetyNineResponse } from '../../../types/card';
+import { formatNinetynineState } from './ninetynineFormatter';
+
+function makePlayer(overrides?: Partial<NinetyNinePlayerData>): NinetyNinePlayerData {
+  return {
+    id: 0,
+    isHuman: true,
+    cardCount: 1,
+    cards: [{ design: 'SPADE', value: 1 }],
+    bid: 2,
+    roundScore: 0,
+    cumulativeScore: 15,
+    trickCount: 1,
+    buriedCount: 3,
+    ...overrides,
+  };
+}
+
+function makeState(overrides?: Partial<NinetyNineResponse>): NinetyNineResponse {
+  return {
+    players: [makePlayer(), makePlayer({ id: 1, isHuman: false, cards: [] })],
+    phase: 0,
+    dealNumber: 2,
+    targetScore: 100,
+    handSize: 12,
+    trickNumber: 3,
+    currentPlayerIdx: 0,
+    bidPlayerIdx: 0,
+    dealerIdx: 1,
+    trumpSuit: 1,
+    currentTrick: [],
+    gameEndFlag: false,
+    winnerIdx: -1,
+    leadPlayerIdx: 0,
+    config: { cpuDifficulty: 1, targetScore: 100 },
+    message: '',
+    ...overrides,
+  };
+}
+
+describe('formatNinetynineState', () => {
+  it('renders the header, deal, trick and hand size', () => {
+    const out = formatNinetynineState(makeState());
+    expect(out).toContain('Ninety-Nine');
+    expect(out).toContain('deal: 2');
+    expect(out).toContain('trick: 3');
+    expect(out).toContain('hand size: 12');
+  });
+
+  it('renders the trump and the target score', () => {
+    const out = formatNinetynineState(makeState());
+    expect(out).toContain('trump:');
+    expect(out).toContain('target: 100');
+  });
+
+  it('renders the current trick when one is under way', () => {
+    const out = formatNinetynineState(
+      makeState({ currentTrick: [{ playerIdx: 1, card: { design: 'HEART', value: 9 } }] }),
+    );
+    expect(out).toContain('trick:');
+  });
+
+  // **伏せ札とプレイでヒント行が変わる。**
+  it('renders a bury hint and a play hint differently', () => {
+    const bury = formatNinetynineState(
+      makeState({ hint: { buryIndices: [0, 2], reason: 'bury_low' }, messageCode: 'ninetynine.hintRequested' }),
+    );
+    expect(bury).toContain('HINT: bury [0, 2]');
+
+    const play = formatNinetynineState(
+      makeState({ hint: { cardIndex: 1, reason: 'follow_suit' }, messageCode: 'ninetynine.hintRequested' }),
+    );
+    expect(play).toContain('HINT: play [1]');
+  });
+
+  it('renders the message when present', () => {
+    expect(formatNinetynineState(makeState({ message: 'done' }))).toContain('done');
+  });
+
+  // **HINT 行は hint を頼んだときだけ。**受動ヒントが Output に載るように
+  // なった (#4483) ので、messageCode で「頼んだ応答か」を見分ける。
+  it('shows the hint only when the hint was requested', () => {
+    const hint = { cardIndex: 1, reason: 'follow_suit' };
+    expect(formatNinetynineState(makeState({ hint, messageCode: 'ninetynine.hintRequested' }))).toContain('HINT');
+    expect(formatNinetynineState(makeState({ hint, messageCode: 'ninetynine.playing' }))).not.toContain('HINT');
+  });
+});

--- a/frontend/src/utils/cli/formatters/ninetynineFormatter.ts
+++ b/frontend/src/utils/cli/formatters/ninetynineFormatter.ts
@@ -1,5 +1,12 @@
 import type { NinetyNineResponse } from '../../../types/card';
-import { formatCard, formatHeader, formatIndexedCards, formatPlayerName, formatSeparator } from '../formatterBase';
+import {
+  formatCard,
+  formatHeader,
+  formatIndexedCards,
+  formatPlayerName,
+  formatSeparator,
+  isRequestedHint,
+} from '../formatterBase';
 
 /** Maps numeric trump suit to a display label. */
 const SUIT_LABEL: Readonly<Record<number, string>> = {
@@ -41,7 +48,7 @@ export function formatNinetynineState(state: NinetyNineResponse): string {
     lines.push('Bury phase: bury 3 cards (suit-sum = bid)');
   }
 
-  if (state.hint) {
+  if (state.hint && isRequestedHint(state)) {
     if (state.hint.buryIndices !== undefined) {
       lines.push(`HINT: bury [${state.hint.buryIndices.join(', ')}] (${state.hint.reason})`);
     }

--- a/internal/adapter/presenter/NinetyNineWebPresenter.go
+++ b/internal/adapter/presenter/NinetyNineWebPresenter.go
@@ -13,6 +13,20 @@ type NinetyNineWebPresenter struct{}
 func (p *NinetyNineWebPresenter) Output(o interfaces.NinetyNineGame, lastErr error) string {
 	resObj := p.buildBase(o)
 	resObj.Message, resObj.MessageCode, resObj.MessageParams = p.buildMessage(o, lastErr)
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	//
+	// **フェーズと手番はここでは見ない。**NinetyNine.GetHint() が自分で
+	// 「人間の手番で、かつ行動を選べる状態か」を確かめて nil を返す。
+	if hint := o.GetHint(); hint != nil {
+		resObj.Hint = &controller.NinetyNineWebOutputHint{
+			CardIndex:   hint.CardIndex,
+			BuryIndices: hint.BuryIndices,
+			Reason:      hint.Reason,
+		}
+	}
+
 	return marshalOrError(resObj)
 }
 
@@ -27,6 +41,13 @@ func (p *NinetyNineWebPresenter) HintOutput(o interfaces.NinetyNineGame) string 
 			BuryIndices: hint.BuryIndices,
 			Reason:      hint.Reason,
 		}
+	}
+	// **「頼んだヒントか」を CLI が見分けられるようにする。**このゲーム群の
+	// `hintAvailable` は画面のラベルとして既に使われているので、別キーを出す (#4483)。
+	if hint != nil {
+		resObj.MessageCode = "ninetynine.hintRequested"
+	} else {
+		resObj.MessageCode = "ninetynine.noHint"
 	}
 	return marshalOrError(resObj)
 }

--- a/internal/adapter/presenter/NinetyNineWebPresenter_test.go
+++ b/internal/adapter/presenter/NinetyNineWebPresenter_test.go
@@ -40,6 +40,10 @@ func setupNinetyNineWebMock() *interfaces.MockNinetyNineGame {
 	m.On("GetLeadPlayerIdx").Return(0)
 	m.On("GetConfig").Return(domain.DefaultNinetyNineConfig())
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
+	// **Output() も受動ヒントを埋める**ようになった (#4483)。既定は「ヒント無し」。
+	// **base だけに置く。**removeMockCall は最初の 1 件しか外さない。
+	m.On("GetHint").Return(nil).Maybe()
+
 	return m
 }
 
@@ -150,6 +154,7 @@ func TestNinetyNineWebPresenter_HintOutput(t *testing.T) {
 
 	t.Run("with bury hint", func(t *testing.T) {
 		m, _ := setupNinetyNineWebMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHint")
 		m.On("GetHint").Return(&domain.NinetyNineHint{BuryIndices: []int{0, 1, 2}, Reason: "strategic_bury"})
 		result := p.HintOutput(m)
 		var resObj controller.NinetyNineWebOutput
@@ -160,6 +165,7 @@ func TestNinetyNineWebPresenter_HintOutput(t *testing.T) {
 
 	t.Run("nil hint", func(t *testing.T) {
 		m, _ := setupNinetyNineWebMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHint")
 		m.On("GetHint").Return((*domain.NinetyNineHint)(nil))
 		result := p.HintOutput(m)
 		var resObj controller.NinetyNineWebOutput
@@ -175,4 +181,31 @@ func TestNinetyNineWebPresenter_ActionLogOutput(t *testing.T) {
 		{TurnNumber: 1, PlayerIdx: 0, ActionType: "bid", Detail: "test"},
 	})
 	assert.NotEmpty(t, p.ActionLogOutput(m))
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+func TestNinetyNineWebPresenterOutputCarriesTheHint(t *testing.T) {
+	idx := 0
+	nng, _ := setupNinetyNineWebMockWithPlayers()
+	nng.ExpectedCalls = removeMockCall(nng.ExpectedCalls, "GetHint")
+	nng.On("GetHint").Return(&domain.NinetyNineHint{CardIndex: &idx, Reason: "follow_suit"})
+
+	result := new(presenter.NinetyNineWebPresenter).Output(nng, nil)
+	assert.Contains(t, result, `"hint"`, "Output must carry the hint -- the frontend reads state.hint")
+	assert.NotContains(t, result, "ninetynine.hintRequested")
+}
+
+// **HintOutput は「頼んだヒント」だと分かる印を付ける。**
+func TestNinetyNineWebPresenterHintOutputMarksTheRequest(t *testing.T) {
+	idx := 0
+	nng, _ := setupNinetyNineWebMockWithPlayers()
+	nng.ExpectedCalls = removeMockCall(nng.ExpectedCalls, "GetHint")
+	nng.On("GetHint").Return(&domain.NinetyNineHint{CardIndex: &idx, Reason: "follow_suit"})
+	assert.Contains(t, new(presenter.NinetyNineWebPresenter).HintOutput(nng), "ninetynine.hintRequested")
+
+	none, _ := setupNinetyNineWebMockWithPlayers()
+	none.ExpectedCalls = removeMockCall(none.ExpectedCalls, "GetHint")
+	none.On("GetHint").Return((*domain.NinetyNineHint)(nil))
+	assert.Contains(t, new(presenter.NinetyNineWebPresenter).HintOutput(none), "ninetynine.noHint")
 }


### PR DESCRIPTION
## 概要

**CLI フォーマッタのテストが無い 9 本**の 3 本目。Ninety-Nine。

Refs #4483

## テストを先に

共有 state ファクトリが無いので、レスポンス型からフィクスチャを組み立てています。**ゲートに必要な 1 行だけでなく**:

- ヘッダ / ディール / トリック / 手札枚数
- 切り札と目標点
- 進行中のトリック
- **伏せ札ヒントとプレイヒントで行が変わる**こと（`HINT: bury [0, 2]` と `HINT: play [1]`）

## 負のコントロール

| 壊しかた | 結果 |
|---|---|
| `Output` のヒントを落とす | **1 件 FAIL** |
| CLI のゲートを外す | **1 ファイル FAIL** |

## 残り

CLI テストが無い残り 6 本: Bridge / Doppelkopf / Euchre / Napoleon / Whist / Wizard

## 確認

- `go test -tags test ./internal/adapter/presenter/ -count=2` green（パッケージ全体）
- `golangci-lint run ./internal/adapter/presenter/` 0 issues
- `bun run test` / `bun run check` / `typecheck` green

## Test plan

- [ ] CI 全ジョブ green