### PR TITLE
fix(hints): write the Wizard formatter test, then carry its passive hint (#4483)

### DIFF
--- a/frontend/src/i18n/locales/en/wizard.json
+++ b/frontend/src/i18n/locales/en/wizard.json
@@ -93,5 +93,7 @@
     "trumpWithCard": "Trump with a card",
     "dumpJester": "Good chance to dump a Jester",
     "discardLowest": "Discard your lowest card"
-  }
+  },
+  "hintRequested": "Hint available",
+  "noHint": "No hint available"
 }

--- a/frontend/src/i18n/locales/ja/wizard.json
+++ b/frontend/src/i18n/locales/ja/wizard.json
@@ -93,5 +93,7 @@
     "trumpWithCard": "切り札を使うチャンス",
     "dumpJester": "ジェスターを捨てる好機",
     "discardLowest": "最も低いカードを捨てることを推奨"
-  }
+  },
+  "hintRequested": "ヒントがあります",
+  "noHint": "ヒントはありません"
 }

--- a/frontend/src/utils/cli/formatters/wizardFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/wizardFormatter.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import type { WizardPlayerData, WizardResponse } from '../../../types/card';
+import { formatWizardState } from './wizardFormatter';
+
+function makePlayer(overrides?: Partial<WizardPlayerData>): WizardPlayerData {
+  return {
+    id: 0,
+    isHuman: true,
+    cardCount: 1,
+    cards: [{ design: 'SPADE', value: 1 }],
+    bid: 2,
+    roundScore: 20,
+    cumulativeScore: 60,
+    trickCount: 2,
+    ...overrides,
+  };
+}
+
+function makeState(overrides?: Partial<WizardResponse>): WizardResponse {
+  return {
+    players: [makePlayer(), makePlayer({ id: 1, isHuman: false, cards: [] })],
+    phase: 0,
+    roundNumber: 3,
+    totalRounds: 20,
+    handSize: 3,
+    trickNumber: 2,
+    currentPlayerIdx: 0,
+    bidPlayerIdx: 0,
+    dealerIdx: 1,
+    currentTrick: [],
+    trumpCard: { design: 'HEART', value: 11 },
+    trumpSuit: 3,
+    restrictedBid: -1,
+    gameEndFlag: false,
+    winnerIdx: -1,
+    leadPlayerIdx: 0,
+    config: { cpuDifficulty: 1 },
+    message: '',
+    ...overrides,
+  };
+}
+
+describe('formatWizardState', () => {
+  it('renders the header, round out of total, trick and hand size', () => {
+    const out = formatWizardState(makeState());
+    expect(out).toContain('Wizard');
+    expect(out).toContain('round: 3/20');
+    expect(out).toContain('trick: 2');
+    expect(out).toContain('hand size: 3');
+  });
+
+  // **切り札なしのラウンドがある。**最終ラウンドは山が尽きて trumpCard が null。
+  it('names the trump card only when there is one', () => {
+    expect(formatWizardState(makeState())).toContain('trump:');
+    expect(formatWizardState(makeState({ trumpCard: null }))).not.toContain('trump:');
+  });
+
+  it("renders each player's score, bid and tricks", () => {
+    const out = formatWizardState(makeState());
+    expect(out).toContain('total=60');
+    expect(out).toContain('bid=2');
+    expect(out).toContain('tricks=2');
+  });
+
+  it('renders the current trick when one is under way', () => {
+    const out = formatWizardState(
+      makeState({ currentTrick: [{ playerIdx: 1, card: { design: 'CLOVER', value: 5 } }] }),
+    );
+    expect(out).toContain('trick:');
+  });
+
+  // **入札とプレイでヒント行が変わる。**
+  it('renders a bid hint and a play hint differently', () => {
+    expect(
+      formatWizardState(makeState({ hint: { bid: 1, reason: 'strategic_bid' }, messageCode: 'wizard.hintRequested' })),
+    ).toContain('HINT: bid 1');
+    expect(
+      formatWizardState(
+        makeState({ hint: { cardIndex: 0, reason: 'follow_suit' }, messageCode: 'wizard.hintRequested' }),
+      ),
+    ).toContain('HINT: play [0]');
+  });
+
+  it('renders the message when present', () => {
+    expect(formatWizardState(makeState({ message: 'done' }))).toContain('done');
+  });
+
+  // **HINT 行は hint を頼んだときだけ。**受動ヒントが Output に載るように
+  // なった (#4483) ので、messageCode で「頼んだ応答か」を見分ける。
+  it('shows the hint only when the hint was requested', () => {
+    const hint = { cardIndex: 0, reason: 'follow_suit' };
+    expect(formatWizardState(makeState({ hint, messageCode: 'wizard.hintRequested' }))).toContain('HINT');
+    expect(formatWizardState(makeState({ hint, messageCode: 'wizard.playing' }))).not.toContain('HINT');
+  });
+});

--- a/frontend/src/utils/cli/formatters/wizardFormatter.ts
+++ b/frontend/src/utils/cli/formatters/wizardFormatter.ts
@@ -1,5 +1,12 @@
 import type { WizardResponse } from '../../../types/card';
-import { formatCard, formatHeader, formatIndexedCards, formatPlayerName, formatSeparator } from '../formatterBase';
+import {
+  formatCard,
+  formatHeader,
+  formatIndexedCards,
+  formatPlayerName,
+  formatSeparator,
+  isRequestedHint,
+} from '../formatterBase';
 
 /** Format a Wizard game state as terminal text. */
 export function formatWizardState(state: WizardResponse): string {
@@ -33,7 +40,7 @@ export function formatWizardState(state: WizardResponse): string {
     lines.push('Bidding phase');
   }
 
-  if (state.hint) {
+  if (state.hint && isRequestedHint(state)) {
     if (state.hint.bid !== undefined) lines.push(`HINT: bid ${state.hint.bid} (${state.hint.reason})`);
     if (state.hint.cardIndex !== undefined) lines.push(`HINT: play [${state.hint.cardIndex}] (${state.hint.reason})`);
   }

--- a/internal/adapter/presenter/WizardWebPresenter.go
+++ b/internal/adapter/presenter/WizardWebPresenter.go
@@ -29,6 +29,20 @@ type WizardWebPresenter struct{}
 func (p *WizardWebPresenter) Output(o interfaces.WizardGame, lastErr error) string {
 	resObj := p.buildBase(o)
 	resObj.Message, resObj.MessageCode, resObj.MessageParams = p.buildMessage(o, lastErr)
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	//
+	// **フェーズと手番はここでは見ない。**Wizard.GetHint() が自分で
+	// 「人間の手番で、かつ行動を選べる状態か」を確かめて nil を返す。
+	if hint := o.GetHint(); hint != nil {
+		resObj.Hint = &controller.WizardWebOutputHint{
+			CardIndex: hint.CardIndex,
+			Bid:       hint.Bid,
+			Reason:    hint.Reason,
+		}
+	}
+
 	return marshalOrError(resObj)
 }
 
@@ -43,6 +57,13 @@ func (p *WizardWebPresenter) HintOutput(o interfaces.WizardGame) string {
 			Bid:       hint.Bid,
 			Reason:    hint.Reason,
 		}
+	}
+	// **「頼んだヒントか」を CLI が見分けられるようにする。**このゲーム群の
+	// `hintAvailable` は画面のラベルとして既に使われているので、別キーを出す (#4483)。
+	if hint != nil {
+		resObj.MessageCode = "wizard.hintRequested"
+	} else {
+		resObj.MessageCode = "wizard.noHint"
 	}
 	return marshalOrError(resObj)
 }

--- a/internal/adapter/presenter/WizardWebPresenter_test.go
+++ b/internal/adapter/presenter/WizardWebPresenter_test.go
@@ -44,6 +44,10 @@ func setupWizardWebMock() *interfaces.MockWizardGame {
 	m.On("GetLeadPlayerIdx").Return(0)
 	m.On("GetConfig").Return(domain.DefaultWizardConfig())
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
+	// **Output() も受動ヒントを埋める**ようになった (#4483)。既定は「ヒント無し」。
+	// **base だけに置く。**removeMockCall は最初の 1 件しか外さない。
+	m.On("GetHint").Return(nil).Maybe()
+
 	return m
 }
 
@@ -224,6 +228,7 @@ func TestWizardWebPresenter_HintOutput(t *testing.T) {
 	t.Run("with hint", func(t *testing.T) {
 		m, _ := setupWizardWebMockWithPlayers()
 		bid := 3
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHint")
 		m.On("GetHint").Return(&domain.WizardHint{Bid: &bid, Reason: "strategic_bid"})
 
 		result := p.HintOutput(m)
@@ -236,6 +241,7 @@ func TestWizardWebPresenter_HintOutput(t *testing.T) {
 
 	t.Run("nil hint", func(t *testing.T) {
 		m, _ := setupWizardWebMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHint")
 		m.On("GetHint").Return((*domain.WizardHint)(nil))
 
 		result := p.HintOutput(m)
@@ -254,4 +260,31 @@ func TestWizardWebPresenter_ActionLogOutput(t *testing.T) {
 
 	result := p.ActionLogOutput(m)
 	assert.NotEmpty(t, result)
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+func TestWizardWebPresenterOutputCarriesTheHint(t *testing.T) {
+	idx := 0
+	wzg, _ := setupWizardWebMockWithPlayers()
+	wzg.ExpectedCalls = removeMockCall(wzg.ExpectedCalls, "GetHint")
+	wzg.On("GetHint").Return(&domain.WizardHint{CardIndex: &idx, Reason: "follow_suit"})
+
+	result := new(presenter.WizardWebPresenter).Output(wzg, nil)
+	assert.Contains(t, result, `"hint"`, "Output must carry the hint -- the frontend reads state.hint")
+	assert.NotContains(t, result, "wizard.hintRequested")
+}
+
+// **HintOutput は「頼んだヒント」だと分かる印を付ける。**
+func TestWizardWebPresenterHintOutputMarksTheRequest(t *testing.T) {
+	idx := 0
+	wzg, _ := setupWizardWebMockWithPlayers()
+	wzg.ExpectedCalls = removeMockCall(wzg.ExpectedCalls, "GetHint")
+	wzg.On("GetHint").Return(&domain.WizardHint{CardIndex: &idx, Reason: "follow_suit"})
+	assert.Contains(t, new(presenter.WizardWebPresenter).HintOutput(wzg), "wizard.hintRequested")
+
+	none, _ := setupWizardWebMockWithPlayers()
+	none.ExpectedCalls = removeMockCall(none.ExpectedCalls, "GetHint")
+	none.On("GetHint").Return((*domain.WizardHint)(nil))
+	assert.Contains(t, new(presenter.WizardWebPresenter).HintOutput(none), "wizard.noHint")
 }


### PR DESCRIPTION
## 概要

**CLI フォーマッタのテストが無い 9 本**の 5 本目。Wizard。

Refs #4483

## 切り札なしのラウンドを固定しました

Wizard の**最終ラウンドは山札を配り切る**ので、切り札としてめくるカードが残りません。`trumpCard` が null になり、フォーマッタは**行ごと出しません**。

[#4580 の Whist](https://github.com/yuta-yoshinaga/go_trumpcards/pull/4580)（切り札なし契約）と同じ形です。常に切り札を入れるフィクスチャでは**この分岐を一度も通りません**。

## そのほか

- ヘッダ / ラウンド（`3/20`）/ トリック / 手札枚数
- プレイヤーごとの `total=` / `bid=` / `tricks=`
- 進行中のトリック
- **入札ヒントとプレイヒントで行が変わる**こと

## 負のコントロール

| 壊しかた | 結果 |
|---|---|
| `Output` のヒントを落とす | **1 件 FAIL** |
| CLI のゲートを外す | **1 ファイル FAIL** |

## 残り

CLI テストが無い残り 4 本: Bridge / Doppelkopf / Euchre / Napoleon

## 確認

- `go test -tags test ./internal/adapter/presenter/ -count=2` green（パッケージ全体）
- `golangci-lint run ./internal/adapter/presenter/` 0 issues
- `bun run test` / `bun run check` / `typecheck` green

## Test plan

- [ ] CI 全ジョブ green