### PR TITLE
fix(hints): write the Euchre formatter test, then carry its passive hint (#4483)

### DIFF
--- a/frontend/src/i18n/locales/en/euchre.json
+++ b/frontend/src/i18n/locales/en/euchre.json
@@ -87,5 +87,7 @@
     "trumpCut": "Opportunity to cut with trump",
     "discardWeakest": "Recommend discarding the weakest card",
     "leadOffSuit": "Lead with a non-trump card"
-  }
+  },
+  "hintRequested": "Hint available",
+  "noHint": "No hint available"
 }

--- a/frontend/src/i18n/locales/ja/euchre.json
+++ b/frontend/src/i18n/locales/ja/euchre.json
@@ -87,5 +87,7 @@
     "trumpCut": "切り札でカットするチャンス",
     "discardWeakest": "最も弱いカードを捨てることを推奨",
     "leadOffSuit": "切り札以外のカードでリード推奨"
-  }
+  },
+  "hintRequested": "ヒントがあります",
+  "noHint": "ヒントはありません"
 }

--- a/frontend/src/utils/cli/formatters/euchreFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/euchreFormatter.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import type { EuchrePlayerData, EuchreResponse } from '../../../types/card';
+import { formatEuchreState } from './euchreFormatter';
+
+function makePlayer(overrides?: Partial<EuchrePlayerData>): EuchrePlayerData {
+  return {
+    id: 0,
+    isHuman: true,
+    cardCount: 1,
+    cards: [{ design: 'SPADE', value: 1 }],
+    team: 0,
+    trickCount: 2,
+    ...overrides,
+  };
+}
+
+function makeState(overrides?: Partial<EuchreResponse>): EuchreResponse {
+  return {
+    players: [makePlayer(), makePlayer({ id: 1, isHuman: false, cards: [], team: 1 })],
+    phase: 0,
+    roundNumber: 1,
+    trickNumber: 3,
+    currentPlayerIdx: 0,
+    bidPlayerIdx: 0,
+    dealerIdx: 1,
+    trumpSuit: 1,
+    faceUpCard: { design: 'HEART', value: 11 },
+    makerTeam: 0,
+    goingAlone: false,
+    goingAlonePlayerIdx: -1,
+    currentTrick: [],
+    teamScores: [2, 1],
+    gameEndFlag: false,
+    winnerTeam: -1,
+    leadPlayerIdx: 0,
+    config: { cpuDifficulty: 1, pointLimit: 10 },
+    message: '',
+    ...overrides,
+  };
+}
+
+describe('formatEuchreState', () => {
+  it('renders the header, round, trick and team scores', () => {
+    const out = formatEuchreState(makeState());
+    expect(out).toContain('Euchre');
+    expect(out).toContain('round: 1');
+    expect(out).toContain('trick: 3');
+    expect(out).toContain('Team0=2');
+    expect(out).toContain('Team1=1');
+  });
+
+  // **切り札は入札が決まるまで無い。**suit 0 のあいだ行ごと出ない。
+  it('names the trump only once it is decided', () => {
+    expect(formatEuchreState(makeState())).toContain('trump:');
+    expect(formatEuchreState(makeState({ trumpSuit: 0 }))).not.toContain('trump:');
+  });
+
+  // **一人打ちは宣言されたときだけ告知する。**
+  it('announces going alone only when someone did', () => {
+    expect(formatEuchreState(makeState())).not.toContain('Going alone');
+    expect(formatEuchreState(makeState({ goingAlone: true }))).toContain('Going alone!');
+  });
+
+  it("renders each player's team and trick count", () => {
+    const out = formatEuchreState(makeState());
+    expect(out).toContain('team=0');
+    expect(out).toContain('tricks=2');
+  });
+
+  it('renders a hint line', () => {
+    expect(
+      formatEuchreState(
+        makeState({ hint: { cardIndex: 0, reason: 'follow_suit' }, messageCode: 'euchre.hintRequested' }),
+      ),
+    ).toContain('HINT');
+  });
+
+  it('renders the message when present', () => {
+    expect(formatEuchreState(makeState({ message: 'done' }))).toContain('done');
+  });
+
+  // **HINT 行は hint を頼んだときだけ。**受動ヒントが Output に載るように
+  // なった (#4483) ので、messageCode で「頼んだ応答か」を見分ける。
+  it('shows the hint only when the hint was requested', () => {
+    const hint = { cardIndex: 0, reason: 'follow_suit' };
+    expect(formatEuchreState(makeState({ hint, messageCode: 'euchre.hintRequested' }))).toContain('HINT');
+    expect(formatEuchreState(makeState({ hint, messageCode: 'euchre.playing' }))).not.toContain('HINT');
+  });
+});

--- a/frontend/src/utils/cli/formatters/euchreFormatter.ts
+++ b/frontend/src/utils/cli/formatters/euchreFormatter.ts
@@ -1,5 +1,12 @@
 import type { EuchreResponse } from '../../../types/card';
-import { formatCard, formatHeader, formatIndexedCards, formatPlayerName, formatSeparator } from '../formatterBase';
+import {
+  formatCard,
+  formatHeader,
+  formatIndexedCards,
+  formatPlayerName,
+  formatSeparator,
+  isRequestedHint,
+} from '../formatterBase';
 
 const SUIT_NAMES: Record<number, string> = { 1: 'Spade', 2: 'Clover', 3: 'Heart', 4: 'Diamond' };
 
@@ -33,7 +40,7 @@ export function formatEuchreState(state: EuchreResponse): string {
     lines.push(`trick: ${parts.join(', ')}`);
   }
 
-  if (state.hint) lines.push(`HINT: ${state.hint.reason}`);
+  if (state.hint && isRequestedHint(state)) lines.push(`HINT: ${state.hint.reason}`);
 
   if (state.message) lines.push(state.message);
   if (state.gameEndFlag) lines.push(`Game Over! Winner: Team ${state.winnerTeam}`);

--- a/internal/adapter/presenter/EuchreWebPresenter.go
+++ b/internal/adapter/presenter/EuchreWebPresenter.go
@@ -17,6 +17,22 @@ type EuchreWebPresenter struct{}
 func (p *EuchreWebPresenter) Output(e interfaces.EuchreGame, lastErr error) string {
 	resObj := p.buildBase(e)
 	resObj.Message, resObj.MessageCode, resObj.MessageParams = p.buildMessage(e, e.GetCurrentTrick(), lastErr)
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	//
+	// **フェーズと手番はここでは見ない。**Euchre.GetHint() が自分で
+	// 「人間の手番で、かつ行動を選べる状態か」を確かめて nil を返す。
+	if hint := e.GetHint(); hint != nil {
+		resObj.Hint = &controller.EuchreWebOutputHint{
+			CardIndex: hint.CardIndex,
+			OrderUp:   hint.OrderUp,
+			Suit:      hint.Suit,
+			GoAlone:   hint.GoAlone,
+			Reason:    hint.Reason,
+		}
+	}
+
 	return marshalOrError(resObj)
 }
 
@@ -113,6 +129,13 @@ func (p *EuchreWebPresenter) HintOutput(e interfaces.EuchreGame) string {
 			GoAlone:   hint.GoAlone,
 			Reason:    hint.Reason,
 		}
+	}
+	// **「頼んだヒントか」を CLI が見分けられるようにする。**このゲーム群の
+	// `hintAvailable` は画面のラベルとして既に使われているので、別キーを出す (#4483)。
+	if hint != nil {
+		resObj.MessageCode = "euchre.hintRequested"
+	} else {
+		resObj.MessageCode = "euchre.noHint"
 	}
 	return marshalOrError(resObj)
 }

--- a/internal/adapter/presenter/EuchreWebPresenter_test.go
+++ b/internal/adapter/presenter/EuchreWebPresenter_test.go
@@ -35,6 +35,10 @@ func setupEuchreWebMock() *interfaces.MockEuchreGame {
 	m.On("GetLeadPlayerIdx").Return(0)
 	m.On("GetConfig").Return(domain.DefaultEuchreConfig())
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
+	// **Output() も受動ヒントを埋める**ようになった (#4483)。既定は「ヒント無し」。
+	// **base だけに置く。**removeMockCall は最初の 1 件しか外さない。
+	m.On("GetHint").Return(nil).Maybe()
+
 	return m
 }
 
@@ -424,6 +428,7 @@ func TestEuchreWebPresenter_HintOutput(t *testing.T) {
 	t.Run("hint available with card", func(t *testing.T) {
 		idx := 2
 		m, _ := setupEuchreWebMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHint")
 		m.On("GetHint").Return(&domain.EuchreHint{
 			CardIndex: &idx,
 			Reason:    "follow_suit",
@@ -436,12 +441,13 @@ func TestEuchreWebPresenter_HintOutput(t *testing.T) {
 		assert.NotNil(t, resObj.Hint)
 		assert.Equal(t, &idx, resObj.Hint.CardIndex)
 		assert.Equal(t, "follow_suit", resObj.Hint.Reason)
-		assert.Empty(t, resObj.MessageCode)
+		assert.Equal(t, "euchre.hintRequested", resObj.MessageCode)
 	})
 
 	t.Run("hint available with orderUp", func(t *testing.T) {
 		orderUp := true
 		m, _ := setupEuchreWebMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHint")
 		m.On("GetHint").Return(&domain.EuchreHint{
 			OrderUp: &orderUp,
 			Reason:  "strong_hand",
@@ -460,6 +466,7 @@ func TestEuchreWebPresenter_HintOutput(t *testing.T) {
 		suit := 3
 		goAlone := true
 		m, _ := setupEuchreWebMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHint")
 		m.On("GetHint").Return(&domain.EuchreHint{
 			Suit:    &suit,
 			GoAlone: &goAlone,
@@ -477,6 +484,7 @@ func TestEuchreWebPresenter_HintOutput(t *testing.T) {
 
 	t.Run("no hint", func(t *testing.T) {
 		m, _ := setupEuchreWebMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHint")
 		m.On("GetHint").Return((*domain.EuchreHint)(nil))
 
 		result := p.HintOutput(m)
@@ -484,6 +492,33 @@ func TestEuchreWebPresenter_HintOutput(t *testing.T) {
 		err := json.Unmarshal([]byte(result), &resObj)
 		assert.NoError(t, err)
 		assert.Nil(t, resObj.Hint)
-		assert.Empty(t, resObj.MessageCode)
+		assert.Equal(t, "euchre.noHint", resObj.MessageCode)
 	})
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+func TestEuchreWebPresenterOutputCarriesTheHint(t *testing.T) {
+	idx := 0
+	ecg, _ := setupEuchreWebMockWithPlayers()
+	ecg.ExpectedCalls = removeMockCall(ecg.ExpectedCalls, "GetHint")
+	ecg.On("GetHint").Return(&domain.EuchreHint{CardIndex: &idx, Reason: "follow_suit"})
+
+	result := new(presenter.EuchreWebPresenter).Output(ecg, nil)
+	assert.Contains(t, result, `"hint"`, "Output must carry the hint -- the frontend reads state.hint")
+	assert.NotContains(t, result, "euchre.hintRequested")
+}
+
+// **HintOutput は「頼んだヒント」だと分かる印を付ける。**
+func TestEuchreWebPresenterHintOutputMarksTheRequest(t *testing.T) {
+	idx := 0
+	ecg, _ := setupEuchreWebMockWithPlayers()
+	ecg.ExpectedCalls = removeMockCall(ecg.ExpectedCalls, "GetHint")
+	ecg.On("GetHint").Return(&domain.EuchreHint{CardIndex: &idx, Reason: "follow_suit"})
+	assert.Contains(t, new(presenter.EuchreWebPresenter).HintOutput(ecg), "euchre.hintRequested")
+
+	none, _ := setupEuchreWebMockWithPlayers()
+	none.ExpectedCalls = removeMockCall(none.ExpectedCalls, "GetHint")
+	none.On("GetHint").Return((*domain.EuchreHint)(nil))
+	assert.Contains(t, new(presenter.EuchreWebPresenter).HintOutput(none), "euchre.noHint")
 }


### PR DESCRIPTION
## 概要

**CLI フォーマッタのテストが無い 9 本**の 7 本目。Euchre。

[#4572 で外した](https://github.com/yuta-yoshinaga/go_trumpcards/pull/4572)理由（波括弧なしのヒント行）は [#4575](https://github.com/yuta-yoshinaga/go_trumpcards/pull/4575) でスクリプトが対応済みです。

Refs #4483

## 特定の状態でしか出ない行を固定しました

```ts
if (state.trumpSuit > 0) lines.push(`trump: ...`);   // 入札が決まるまで無い
if (state.goingAlone) lines.push('Going alone!');    // 宣言されたときだけ
```

**出ないこと**も assert しています。

## Doppelkopf は既に済んでいました

[#4572](https://github.com/yuta-yoshinaga/go_trumpcards/pull/4572) でゲート済みです。**9 本のうち残りは Bridge 1 本**になりました。

## 負のコントロール

| 壊しかた | 結果 |
|---|---|
| `Output` のヒントを落とす | **1 件 FAIL** |
| CLI のゲートを外す | **1 ファイル FAIL** |

## 確認

- `go test -tags test ./internal/adapter/presenter/ -count=2` green（パッケージ全体）
- `golangci-lint run ./internal/adapter/presenter/` 0 issues
- `bun run test` / `bun run check` / `typecheck` green

## Test plan

- [ ] CI 全ジョブ green