### PR TITLE
fix(hints): make Pinochle's HintOutput return a state response (#4483)

### DIFF
--- a/frontend/src/hooks/usePinochleGame.test.ts
+++ b/frontend/src/hooks/usePinochleGame.test.ts
@@ -180,7 +180,7 @@ describe('usePinochleGame', () => {
 
     mockExec.mockClear();
     // The hint command returns only the bare hint object (top-level fields).
-    mockExec.mockResolvedValue({ bidAmount: 25, reason: 'hint_bid' } as unknown as PinochleResponse);
+    mockExec.mockResolvedValue({ hint: { bidAmount: 25, reason: 'hint_bid' } } as unknown as PinochleResponse);
     await act(async () => {
       await result.current.handleHint();
     });
@@ -224,7 +224,7 @@ describe('usePinochleGame', () => {
     const { result } = renderHook(() => usePinochleGame(), { wrapper: createWrapper() });
     await waitFor(() => expect(result.current.state).not.toBeNull());
 
-    mockExec.mockResolvedValue({ suit: 1, reason: 'hint_trump' } as unknown as PinochleResponse);
+    mockExec.mockResolvedValue({ hint: { suit: 1, reason: 'hint_trump' } } as unknown as PinochleResponse);
     await act(async () => {
       await result.current.handleHint();
     });

--- a/frontend/src/hooks/usePinochleGame.ts
+++ b/frontend/src/hooks/usePinochleGame.ts
@@ -106,10 +106,10 @@ export function usePinochleGame() {
       const res = await pinochleApi.exec('hint');
       // Navigating away mid-request must not write to a gone component (#4447).
       if (!isMounted()) return;
-      // Server marshals the bare hint fields at the top level (cardIndex,
-      // bidAmount, pass, suit, reason); when no hint applies `reason` is absent.
-      const raw = res as unknown as Partial<PinochleHint>;
-      setHint(raw.reason ? (raw as PinochleHint) : null);
+      // **ヒントは state レスポンスの `hint` に入る。**以前は裸のヒント構造体が
+      // 返っていたので最上位から読んでいたが、他ゲームと同じ形に揃えた (#4483)。
+      const hint = res.hint as PinochleHint | undefined;
+      setHint(hint?.reason ? hint : null);
       setHintError(null);
     } catch {
       if (!isMounted()) return;

--- a/frontend/src/i18n/locales/en/pinochle.json
+++ b/frontend/src/i18n/locales/en/pinochle.json
@@ -76,5 +76,7 @@
     "resetButton": "Press the reset button to start a new game."
   },
   "bidAmountLabel": "Bid amount (min {{min}})",
-  "bidTooLow": "Bid must be at least {{min}}."
+  "bidTooLow": "Bid must be at least {{min}}.",
+  "hintRequested": "Hint available",
+  "noHint": "No hint available"
 }

--- a/frontend/src/i18n/locales/ja/pinochle.json
+++ b/frontend/src/i18n/locales/ja/pinochle.json
@@ -76,5 +76,7 @@
     "resetButton": "リセットボタンで新しいゲームを始められます。"
   },
   "bidAmountLabel": "ビッド額（最低 {{min}}）",
-  "bidTooLow": "ビッド額は {{min}} 以上にしてください"
+  "bidTooLow": "ビッド額は {{min}} 以上にしてください",
+  "hintRequested": "ヒントがあります",
+  "noHint": "ヒントはありません"
 }

--- a/frontend/src/pages/PinochlePage.test.tsx
+++ b/frontend/src/pages/PinochlePage.test.tsx
@@ -495,7 +495,7 @@ describe('PinochlePage', () => {
     await waitFor(() => expect(screen.getByTestId('pn-hint-button')).toBeInTheDocument());
 
     mockExec.mockClear();
-    mockExec.mockResolvedValue({ bidAmount: 30, reason: 'hint_bid' } as unknown as PinochleResponse);
+    mockExec.mockResolvedValue({ hint: { bidAmount: 30, reason: 'hint_bid' } } as unknown as PinochleResponse);
     fireEvent.click(screen.getByTestId('pn-hint-button'));
 
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('hint'));
@@ -512,7 +512,7 @@ describe('PinochlePage', () => {
     await waitFor(() => expect(screen.getByTestId('pn-hint-button')).toBeInTheDocument());
 
     mockExec.mockClear();
-    mockExec.mockResolvedValue({ pass: true, reason: 'hint_pass' } as unknown as PinochleResponse);
+    mockExec.mockResolvedValue({ hint: { pass: true, reason: 'hint_pass' } } as unknown as PinochleResponse);
     fireEvent.click(screen.getByTestId('pn-hint-button'));
 
     const hintBox = await screen.findByTestId('pn-server-hint');
@@ -527,7 +527,7 @@ describe('PinochlePage', () => {
     await waitFor(() => expect(screen.getByTestId('pn-hint-button')).toBeInTheDocument());
 
     mockExec.mockClear();
-    mockExec.mockResolvedValue({ cardIndex: 1, reason: 'hint_play' } as unknown as PinochleResponse);
+    mockExec.mockResolvedValue({ hint: { cardIndex: 1, reason: 'hint_play' } } as unknown as PinochleResponse);
     fireEvent.click(screen.getByTestId('pn-hint-button'));
 
     const hintBox = await screen.findByTestId('pn-server-hint');

--- a/frontend/src/utils/cli/formatters/pinochleFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/pinochleFormatter.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import type { PinochlePlayerData, PinochleResponse } from '../../../types/card';
+import { formatPinochleState } from './pinochleFormatter';
+
+function makePlayer(overrides?: Partial<PinochlePlayerData>): PinochlePlayerData {
+  return {
+    id: 0,
+    isHuman: true,
+    cardCount: 1,
+    cards: [{ design: 'SPADE', value: 1 }],
+    team: 0,
+    trickCount: 2,
+    bid: 0,
+    hasPassed: false,
+    meldScore: 40,
+    trickPoints: 12,
+    ...overrides,
+  };
+}
+
+function makeState(overrides?: Partial<PinochleResponse>): PinochleResponse {
+  return {
+    players: [makePlayer(), makePlayer({ id: 1, isHuman: false, cards: [], team: 1 })],
+    phase: 0,
+    roundNumber: 2,
+    trickNumber: 5,
+    currentPlayerIdx: 0,
+    bidPlayerIdx: 0,
+    dealerIdx: 1,
+    trumpSuit: 1,
+    highestBid: 250,
+    highestBidder: 0,
+    currentTrick: [],
+    teamScores: [120, 80],
+    gameEndFlag: false,
+    winnerTeam: -1,
+    leadPlayerIdx: 0,
+    playerMelds: [[], []],
+    config: { cpuDifficulty: 1, pointLimit: 1500 },
+    message: '',
+    ...overrides,
+  };
+}
+
+describe('formatPinochleState', () => {
+  it('renders the header, round, trick and team scores', () => {
+    const out = formatPinochleState(makeState());
+    expect(out).toContain('Pinochle');
+    expect(out).toContain('round: 2');
+    expect(out).toContain('trick: 5');
+    expect(out).toContain('Team0=120');
+    expect(out).toContain('Team1=80');
+  });
+
+  // **切り札も宣言額も競りが終わるまで無い。**どちらも行ごと出ない。
+  it('omits the trump and the bid until the auction settles them', () => {
+    const out = formatPinochleState(makeState({ trumpSuit: 0, highestBid: 0 }));
+    expect(out).not.toContain('trump:');
+    expect(out).not.toContain('bid:');
+    expect(formatPinochleState(makeState())).toContain('bid: 250');
+  });
+
+  it("renders each player's meld and trick points", () => {
+    const out = formatPinochleState(makeState());
+    expect(out).toContain('meld=40');
+    expect(out).toContain('tricks=12');
+  });
+
+  // **パスした席にだけ印が付く。**
+  it('marks a seat that has passed', () => {
+    expect(formatPinochleState(makeState())).not.toContain('[Passed]');
+    expect(formatPinochleState(makeState({ players: [makePlayer({ hasPassed: true })] }))).toContain('[Passed]');
+  });
+
+  it('announces the winner once the game ends', () => {
+    const out = formatPinochleState(makeState({ gameEndFlag: true, winnerTeam: 1 }));
+    expect(out).toContain('Game Over!');
+  });
+
+  // **HINT 行は hint を頼んだときだけ。**受動ヒントが Output に載るように
+  // なった (#4483) ので、messageCode で「頼んだ応答か」を見分ける。
+  it('shows the hint only when the hint was requested', () => {
+    const hint = { cardIndex: 0, reason: 'follow_suit' };
+    expect(formatPinochleState(makeState({ hint, messageCode: 'pinochle.hintRequested' }))).toContain('HINT');
+    expect(formatPinochleState(makeState({ hint, messageCode: 'pinochle.playing' }))).not.toContain('HINT');
+  });
+});

--- a/frontend/src/utils/cli/formatters/pinochleFormatter.ts
+++ b/frontend/src/utils/cli/formatters/pinochleFormatter.ts
@@ -6,6 +6,7 @@ import {
   formatIndexedCards,
   formatPlayerName,
   formatSeparator,
+  isRequestedHint,
 } from '../formatterBase';
 
 const SUIT_NAMES: Record<number, string> = { 1: 'Spade', 2: 'Clover', 3: 'Heart', 4: 'Diamond' };
@@ -52,7 +53,7 @@ export function formatPinochleState(state: PinochleResponse): string {
     lines.push(`trick: ${parts.join(', ')}`);
   }
 
-  if (state.hint) lines.push(`HINT: ${state.hint.reason}`);
+  if (state.hint && isRequestedHint(state)) lines.push(`HINT: ${state.hint.reason}`);
 
   if (state.message) lines.push(state.message);
   if (state.gameEndFlag) lines.push(`Game Over! Winner: Team ${state.winnerTeam}`);

--- a/internal/adapter/presenter/PinochleWebPresenter.go
+++ b/internal/adapter/presenter/PinochleWebPresenter.go
@@ -19,8 +19,9 @@ func (p *PinochleWebPresenter) Output(g interfaces.PinochleGame, lastErr error) 
 	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
 	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
 	//
-	// **フェーズと手番はここでは見ない。**Pinochle.GetHint() が自分で
-	// 「人間の手番で、かつ行動を選べる状態か」を確かめて nil を返す。
+	// **フェーズと手番はここでは見ない。**Pinochle.Hint() が自分で人間の手番かを
+	// 確かめて nil を返す —— ただし**このシリーズでその保証を足したのは #4585 で、
+	// それまでは見ていなかった。**「他ゲームがそうだから」で書かず、1 本ずつ読む。
 	if hint := g.GetHint(); hint != nil {
 		resObj.Hint = &controller.PinochleWebOutputHint{
 			CardIndex: hint.CardIndex,

--- a/internal/adapter/presenter/PinochleWebPresenter.go
+++ b/internal/adapter/presenter/PinochleWebPresenter.go
@@ -13,6 +13,31 @@ type PinochleWebPresenter struct{}
 
 // Output ゲーム状態をJSON出力
 func (p *PinochleWebPresenter) Output(g interfaces.PinochleGame, lastErr error) string {
+	resObj := p.buildBase(g, lastErr)
+
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	//
+	// **フェーズと手番はここでは見ない。**Pinochle.GetHint() が自分で
+	// 「人間の手番で、かつ行動を選べる状態か」を確かめて nil を返す。
+	if hint := g.GetHint(); hint != nil {
+		resObj.Hint = &controller.PinochleWebOutputHint{
+			CardIndex: hint.CardIndex,
+			BidAmount: hint.BidAmount,
+			Pass:      hint.Pass,
+			Suit:      hint.Suit,
+			Reason:    hint.Reason,
+		}
+	}
+
+	return marshalOrError(resObj)
+}
+
+// buildBase は状態レスポンスを組み立てる。Output と HintOutput で共有する。
+// **HintOutput もこれを使う。**以前はヒント構造体を裸で返していて `hint` キーが
+// 無く、フロントの `state.hint` からは読めなかった (#4483)。
+func (p *PinochleWebPresenter) buildBase(g interfaces.PinochleGame, lastErr error) *controller.PinochleWebOutput {
 	resObj := new(controller.PinochleWebOutput)
 	resObj.Phase = int(g.GetPhase())
 	resObj.RoundNumber = g.GetRoundNumber()
@@ -47,25 +72,29 @@ func (p *PinochleWebPresenter) Output(g interfaces.PinochleGame, lastErr error) 
 
 	resObj.Message, resObj.MessageCode, resObj.MessageParams = p.buildMessage(g, lastErr)
 
-	return marshalOrError(resObj)
+	return resObj
 }
 
 // HintOutput ヒント情報を出力
 func (p *PinochleWebPresenter) HintOutput(g interfaces.PinochleGame) string {
-	hint := g.GetHint()
-	if hint == nil {
-		return marshalOrError(controller.PinochleWebOutput{
-			WebOutputBase: controller.WebOutputBase{Message: "ヒントなし"},
-		})
+	// **状態レスポンスを返す。**以前はヒント構造体を裸で返していたので `hint`
+	// キーが無く、フロントの `state.hint` からは読めなかった (#4483)。
+	resObj := p.buildBase(g, nil)
+	if hint := g.GetHint(); hint != nil {
+		resObj.Hint = &controller.PinochleWebOutputHint{
+			CardIndex: hint.CardIndex,
+			BidAmount: hint.BidAmount,
+			Pass:      hint.Pass,
+			Suit:      hint.Suit,
+			Reason:    hint.Reason,
+		}
+		// **「頼んだヒントか」を CLI が見分けられるようにする。**このゲーム群の
+		// `hintAvailable` は画面のラベルとして既に使われているので、別キーを出す。
+		resObj.MessageCode = "pinochle.hintRequested"
+	} else {
+		resObj.MessageCode = "pinochle.noHint"
 	}
-	out := &controller.PinochleWebOutputHint{
-		CardIndex: hint.CardIndex,
-		BidAmount: hint.BidAmount,
-		Pass:      hint.Pass,
-		Suit:      hint.Suit,
-		Reason:    hint.Reason,
-	}
-	return marshalOrError(out)
+	return marshalOrError(resObj)
 }
 
 // ActionLogOutput 棋譜を出力

--- a/internal/adapter/presenter/PinochleWebPresenter_test.go
+++ b/internal/adapter/presenter/PinochleWebPresenter_test.go
@@ -37,6 +37,10 @@ func setupPinochleWebMock() *interfaces.MockPinochleGame {
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
 	m.On("IsHumanTurn").Return(true)
 	m.On("GetValidPlayIndices", 0).Return([]int{0, 1})
+	// **Output() も受動ヒントを埋める**ようになった (#4483)。既定は「ヒント無し」。
+	// **base だけに置く。**removeMockCall は最初の 1 件しか外さない。
+	m.On("GetHint").Return(nil).Maybe()
+
 	return m
 }
 
@@ -123,6 +127,7 @@ func TestPinochleWebPresenter_Output(t *testing.T) {
 		m.On("GetPlayer", 1).Return(domain.NewPinochlePlayer(false, 1))
 		m.On("GetPlayer", 2).Return(domain.NewPinochlePlayer(false, 0))
 		m.On("GetPlayer", 3).Return(domain.NewPinochlePlayer(false, 1))
+		m.On("GetHint").Return(nil).Maybe()
 
 		result := p.Output(m, nil)
 		var resObj controller.PinochleWebOutput
@@ -146,8 +151,9 @@ func TestPinochleWebPresenter_HintOutput(t *testing.T) {
 	p := new(presenter.PinochleWebPresenter)
 
 	t.Run("returns hint", func(t *testing.T) {
-		m := setupPinochleWebMock()
+		m, _ := setupPinochleWebMockWithPlayers()
 		bid := 25
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHint")
 		m.On("GetHint").Return(&domain.PinochleHint{BidAmount: &bid, Reason: "hint_bid"})
 
 		result := p.HintOutput(m)
@@ -155,11 +161,12 @@ func TestPinochleWebPresenter_HintOutput(t *testing.T) {
 	})
 
 	t.Run("returns nil hint", func(t *testing.T) {
-		m := setupPinochleWebMock()
+		m, _ := setupPinochleWebMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHint")
 		m.On("GetHint").Return((*domain.PinochleHint)(nil))
 
 		result := p.HintOutput(m)
-		assert.Contains(t, result, "ヒントなし")
+		assert.Contains(t, result, "pinochle.noHint")
 	})
 }
 
@@ -169,4 +176,35 @@ func TestPinochleWebPresenter_ActionLogOutput(t *testing.T) {
 
 	result := p.ActionLogOutput(m)
 	assert.NotEmpty(t, result)
+}
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+func TestPinochleWebPresenterOutputCarriesTheHint(t *testing.T) {
+	idx := 0
+	png, _ := setupPinochleWebMockWithPlayers()
+	png.ExpectedCalls = removeMockCall(png.ExpectedCalls, "GetHint")
+	png.On("GetHint").Return(&domain.PinochleHint{CardIndex: &idx, Reason: "follow_suit"})
+
+	result := new(presenter.PinochleWebPresenter).Output(png, nil)
+	assert.Contains(t, result, `"hint"`, "Output must carry the hint -- the frontend reads state.hint")
+	assert.NotContains(t, result, "pinochle.hintRequested")
+}
+
+// **HintOutput は状態レスポンスを返し、「頼んだヒント」の印を付ける。**
+// 以前はヒント構造体を裸で返していて `hint` キーが無かった (#4483)。
+func TestPinochleWebPresenterHintOutputMarksTheRequest(t *testing.T) {
+	idx := 0
+	png, _ := setupPinochleWebMockWithPlayers()
+	png.ExpectedCalls = removeMockCall(png.ExpectedCalls, "GetHint")
+	png.On("GetHint").Return(&domain.PinochleHint{CardIndex: &idx, Reason: "follow_suit"})
+	got := new(presenter.PinochleWebPresenter).HintOutput(png)
+	assert.Contains(t, got, "pinochle.hintRequested")
+	assert.Contains(t, got, `"hint"`)
+	assert.Contains(t, got, `"players"`, "HintOutput must return a state response, not a bare hint")
+
+	none, _ := setupPinochleWebMockWithPlayers()
+	none.ExpectedCalls = removeMockCall(none.ExpectedCalls, "GetHint")
+	none.On("GetHint").Return((*domain.PinochleHint)(nil))
+	assert.Contains(t, new(presenter.PinochleWebPresenter).HintOutput(none), "pinochle.noHint")
 }

--- a/internal/domain/Pinochle.go
+++ b/internal/domain/Pinochle.go
@@ -1235,12 +1235,23 @@ func (p *Pinochle) scoreRound() {
 
 // Hint ヒントを返す
 func (p *Pinochle) Hint() *PinochleHint {
+	// **人間の手番でなければ答えない。**hintBid / hintTrump / hintPlay は
+	// bidPlayerIdx / currentPlayerIdx をそのまま使うので、席が誰かを見ない。
+	// Output() が毎レスポンスでこれを呼ぶようになった以上、ガードが無いと
+	// **CPU の手番に CPU 自身の手を「推奨手」として人間に見せる** (#4585 のレビュー指摘)。
 	switch p.phase {
 	case PinochlePhaseBid:
+		if !p.IsHumanBidTurn() {
+			return nil
+		}
 		return p.hintBid()
-	case PinochlePhaseTrump:
-		return p.hintTrump()
-	case PinochlePhasePlay:
+	case PinochlePhaseTrump, PinochlePhasePlay:
+		if !p.IsHumanTurn() {
+			return nil
+		}
+		if p.phase == PinochlePhaseTrump {
+			return p.hintTrump()
+		}
 		return p.hintPlay()
 	default:
 		return nil

--- a/internal/domain/Pinochle_test.go
+++ b/internal/domain/Pinochle_test.go
@@ -1067,6 +1067,9 @@ func TestPinochle_NextRound_WrongPhase(t *testing.T) {
 func TestPinochle_Hint_Bid(t *testing.T) {
 	g := newTestPinochle()
 	g.Reset()
+	// **Hint は人間の席にしか答えない (#4585)。**Reset 後の入札手番が人間とは
+	// 限らないので、明示する。
+	g.bidPlayerIdx = g.findHumanIdxForTest()
 	hint := g.Hint()
 	if hint == nil {
 		t.Fatal("expected hint, got nil")
@@ -1264,4 +1267,34 @@ func TestPinochle_NextTrick(t *testing.T) {
 	if g.GetTrickNumber() != 2 {
 		t.Errorf("expected trick number 2, got %d", g.GetTrickNumber())
 	}
+}
+
+// **CPU の席のヒントは返さない。**返すと、Output() が毎レスポンスで呼ぶ以上、
+// CPU の手番に CPU 自身の手が「推奨手」として人間に見える (#4585 のレビュー指摘)。
+func TestPinochleHintRefusesTheCpuTurn(t *testing.T) {
+	p := newTestPinochle()
+	p.Reset()
+
+	// 人間の手番では出る。
+	p.phase = PinochlePhasePlay
+	p.currentPlayerIdx = p.findHumanIdxForTest()
+	if p.Hint() == nil {
+		t.Error("the human's own turn must still get a hint")
+	}
+
+	// CPU の手番では出ない。
+	p.currentPlayerIdx = (p.findHumanIdxForTest() + 1) % PinochlePlayerCnt
+	if got := p.Hint(); got != nil {
+		t.Errorf("Hint must not describe a CPU seat's move, got %+v", got)
+	}
+}
+
+// findHumanIdxForTest は人間の席を返す。
+func (p *Pinochle) findHumanIdxForTest() int {
+	for i, pl := range p.players {
+		if pl.GetIsHuman() {
+			return i
+		}
+	}
+	return -1
 }


### PR DESCRIPTION
## 概要

Pinochle は**受動ヒントが無いだけではありませんでした。**

Refs #4483

## `HintOutput` がヒント構造体を裸で返していました

```go
out := &controller.PinochleWebOutputHint{...}
return marshalOrError(out)   // ← players も phase も無い。`hint` キーすら無い
```

**フロントはどちらの経路からも読めません。**ヒント無しの場合は **`"ヒントなし"` という生の日本語**を返していました（messageCode ではなく）。

## `Output` が状態を直に組んでいた

共有できるものが無かったので、その本体を `buildBase` に切り出し、`Output` と `HintOutput` の両方から呼ぶようにしました。そのうえで `Output` に受動ヒントを載せています。

## #4575 の「Pinochle は対象外」は誤りでした

[#4575](https://github.com/yuta-yoshinaga/go_trumpcards/pull/4575) で「そもそも対象外」と書きましたが、**別の問いに答えていた分類スクリプトの出力を信じていました。**実際にはこのシリーズで**最も手が要るゲーム**でした。

## フォーマッタのテストもありませんでした

競りが決まるまで出ない **trump / bid** の 2 行と、**席ごとの `[Passed]` 印**を固定しています。埋めきったフィクスチャでは通りません。

## 負のコントロール

| 壊しかた | 結果 |
|---|---|
| `Output` のヒントを落とす | **1 件 FAIL** |
| CLI のゲートを外す | **1 ファイル FAIL** |

## 確認

- `go test -tags test ./internal/adapter/presenter/ -count=2` green（パッケージ全体）
- `golangci-lint run ./internal/adapter/presenter/` 0 issues
- `bun run test` / `bun run check` / `typecheck` green

## Test plan

- [ ] CI 全ジョブ green