### PR TITLE
fix(hints): write the Cinch formatter test, then carry its passive hint (#4483)

### DIFF
--- a/frontend/src/i18n/locales/en/cinch.json
+++ b/frontend/src/i18n/locales/en/cinch.json
@@ -72,5 +72,7 @@
     "heart": "Heart",
     "diamond": "Diamond"
   },
-  "trumpLabel": "Trump"
+  "trumpLabel": "Trump",
+  "hintRequested": "Hint available",
+  "noHint": "No hint available"
 }

--- a/frontend/src/i18n/locales/ja/cinch.json
+++ b/frontend/src/i18n/locales/ja/cinch.json
@@ -72,5 +72,7 @@
     "heart": "ハート",
     "diamond": "ダイヤ"
   },
-  "trumpLabel": "切り札"
+  "trumpLabel": "切り札",
+  "hintRequested": "ヒントがあります",
+  "noHint": "ヒントはありません"
 }

--- a/frontend/src/utils/cli/formatters/cinchFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/cinchFormatter.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import type { CinchPlayer, CinchResponse } from '../../../types/card';
+import { formatCinchState } from './cinchFormatter';
+
+function makePlayer(overrides?: Partial<CinchPlayer>): CinchPlayer {
+  return {
+    id: 0,
+    isHuman: true,
+    cardCount: 6,
+    cards: [{ design: 'SPADE', value: 1 }],
+    trickCount: 2,
+    bid: 3,
+    totalScore: 14,
+    ...overrides,
+  };
+}
+
+function makeState(overrides?: Partial<CinchResponse>): CinchResponse {
+  return {
+    players: [makePlayer(), makePlayer({ id: 1, isHuman: false, cards: [], totalScore: 9 })],
+    phase: 2,
+    roundNumber: 2,
+    trickNumber: 3,
+    totalTricks: 6,
+    dealerIdx: 1,
+    currentTurn: 0,
+    bidPlayerIdx: 0,
+    currentBid: 3,
+    bidWinnerIdx: 0,
+    trumpSuit: 1,
+    currentTrick: [],
+    lastTrick: [],
+    lastTrickWinner: -1,
+    playableIndices: [0],
+    gameEndFlag: false,
+    winnerIdx: -1,
+    roundWinners: [],
+    isHumanTurn: true,
+    config: { cpuDifficulty: 1, pointLimit: 21 },
+    message: '',
+    ...overrides,
+  };
+}
+
+describe('formatCinchState', () => {
+  it('renders the header, the high bid and the trump', () => {
+    const out = formatCinchState(makeState());
+    expect(out).toContain('Cinch');
+    expect(out).toContain('high bid: 3');
+    expect(out).toContain('trump:');
+  });
+
+  it('renders every player score on the summary line', () => {
+    const out = formatCinchState(makeState());
+    expect(out).toContain('P0=14');
+    expect(out).toContain('P1=9');
+  });
+
+  // **入札を取った席にだけ印が付く。**取っていなければ誰にも付かない。
+  it('marks the bid winner', () => {
+    expect(formatCinchState(makeState())).toContain('(Bidder)');
+    expect(formatCinchState(makeState({ bidWinnerIdx: -1 }))).not.toContain('(Bidder)');
+  });
+
+  it("renders each player's cards, tricks and bid", () => {
+    const out = formatCinchState(makeState());
+    expect(out).toContain('cards=6');
+    expect(out).toContain('tricks=2');
+    expect(out).toContain('bid=3');
+  });
+
+  it('renders the message when present', () => {
+    expect(formatCinchState(makeState({ message: 'done' }))).toContain('done');
+  });
+
+  // **HINT 行は hint を頼んだときだけ。**受動ヒントが Output に載るように
+  // なった (#4483) ので、messageCode で「頼んだ応答か」を見分ける。
+  it('shows the hint only when the hint was requested', () => {
+    const hint = { cardIndices: [1], reason: 'follow_suit' };
+    expect(formatCinchState(makeState({ hint, messageCode: 'cinch.hintRequested' }))).toContain('HINT');
+    expect(formatCinchState(makeState({ hint, messageCode: 'cinch.playing' }))).not.toContain('HINT');
+  });
+});

--- a/frontend/src/utils/cli/formatters/cinchFormatter.ts
+++ b/frontend/src/utils/cli/formatters/cinchFormatter.ts
@@ -1,5 +1,12 @@
 import type { CinchResponse } from '../../../types/card';
-import { formatCard, formatHeader, formatIndexedCards, formatPlayerName, formatSeparator } from '../formatterBase';
+import {
+  formatCard,
+  formatHeader,
+  formatIndexedCards,
+  formatPlayerName,
+  formatSeparator,
+  isRequestedHint,
+} from '../formatterBase';
 
 const PHASE_NAMES = ['Bid', 'NameTrump', 'Play', 'TrickEnd', 'RoundEnd', 'GameEnd'];
 const SUIT_SYMBOLS = ['-', '♠', '♣', '♥', '♦'];
@@ -41,7 +48,7 @@ export function formatCinchState(state: CinchResponse): string {
     lines.push(`deal result: gained ${gained}`);
   }
 
-  if (state.hint) {
+  if (state.hint && isRequestedHint(state)) {
     const indices = state.hint.cardIndices ?? [];
     lines.push(`HINT: card indices [${indices.join(', ')}] (${state.hint.reason})`);
   }

--- a/internal/adapter/presenter/CinchWebPresenter.go
+++ b/internal/adapter/presenter/CinchWebPresenter.go
@@ -24,6 +24,21 @@ func (p *CinchWebPresenter) Output(g interfaces.CinchGame, lastErr error) string
 		resObj.MessageCode = "cinch.result.scores"
 		resObj.MessageParams = map[string]string{"scores": p.encodeScoresParam(g)}
 	}
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	//
+	// **フェーズと手番はここでは見ない。**Cinch.GetHint() が自分で
+	// 「人間の手番で、かつ行動を選べる状態か」を確かめて nil を返す。
+	if hint := g.GetHint(); hint != nil {
+		resObj.Hint = &controller.CinchWebOutputHint{
+			CardIndices: hint.CardIndices,
+			Bid:         hint.Bid,
+			TrumpSuit:   hint.TrumpSuit,
+			Reason:      hint.Reason,
+		}
+	}
+
 	return marshalOrError(resObj)
 }
 
@@ -153,6 +168,13 @@ func (p *CinchWebPresenter) HintOutput(g interfaces.CinchGame) string {
 			TrumpSuit:   hint.TrumpSuit,
 			Reason:      hint.Reason,
 		}
+	}
+	// **「頼んだヒントか」を CLI が見分けられるようにする。**このゲーム群の
+	// `hintAvailable` は画面のラベルとして既に使われているので、別キーを出す (#4483)。
+	if g.GetHint() != nil {
+		resObj.MessageCode = "cinch.hintRequested"
+	} else {
+		resObj.MessageCode = "cinch.noHint"
 	}
 	return marshalOrError(resObj)
 }

--- a/internal/adapter/presenter/CinchWebPresenter_test.go
+++ b/internal/adapter/presenter/CinchWebPresenter_test.go
@@ -133,3 +133,25 @@ func TestCinchWebPresenter_HintOutput_TrumpAndCard(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(p.HintOutput(gp)), &playHint))
 	assert.Contains(t, playHint, "hint")
 }
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+func TestCinchWebPresenterOutputCarriesTheHint(t *testing.T) {
+	// Reset 直後は入札フェーズの人間手番。500 回試して nil 0 件で確認済み。
+	g := domain.NewDefaultCinch()
+	g.Reset()
+	require.NotNil(t, g.GetHint(), "fixture must actually produce a hint")
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal([]byte(new(presenter.CinchWebPresenter).Output(g, nil)), &decoded))
+	assert.Contains(t, decoded, "hint", "Output must carry the hint -- the frontend reads state.hint")
+	// **Output は「頼んだヒント」の印を付けない。**付けると CLI が毎回 HINT 行を出す。
+	assert.NotEqual(t, "cinch.hintRequested", decoded["messageCode"])
+}
+
+// **HintOutput は「頼んだヒント」だと分かる印を付ける。**
+func TestCinchWebPresenterHintOutputMarksTheRequest(t *testing.T) {
+	g := domain.NewDefaultCinch()
+	g.Reset()
+	assert.Contains(t, new(presenter.CinchWebPresenter).HintOutput(g), "cinch.hintRequested")
+}


### PR DESCRIPTION
## 概要

Cinch。フォーマッタのテストが無かったので先に作りました。

Refs #4483

## `(Bidder)` の印は入札が決まってから

```ts
const badge = p.id === state.bidWinnerIdx ? ' (Bidder)' : '';
```

`bidWinnerIdx` が -1 のあいだは**誰にも付きません。**両方向を assert しています。

## typecheck が config の項目名を捕まえました

フィクスチャに `targetScore` と書いていましたが、正しくは **`pointLimit`** です。

**vitest は先に通っていました** —— 実行時には余分なキーが無害なためです。**`bun run test` だけでは足りず、`typecheck` が要る**例です。

## Go 側

既存の `HintOutput` テストと同じ状態（`Reset()` 直後の入札フェーズ・人間手番）を使い、**500 回中 500 回ヒントが出ること**を先に確認しています。

## 負のコントロール

| 壊しかた | 結果 |
|---|---|
| `Output` のヒントを落とす | **1 件 FAIL** |
| CLI のゲートを外す | **1 ファイル FAIL** |

## 確認

- `go test -tags test ./internal/adapter/presenter/ -count=2` green（パッケージ全体）
- `golangci-lint run ./internal/adapter/presenter/` 0 issues
- `bun run test` / `bun run check` / `typecheck` green

## Test plan

- [ ] CI 全ジョブ green