### PR TITLE
fix(hints): carry the passive hint for Michigan and Tablanet (#4483)

### DIFF
--- a/frontend/src/i18n/locales/en/michigan.json
+++ b/frontend/src/i18n/locales/en/michigan.json
@@ -64,5 +64,7 @@
     "new": "You can start a new sequence",
     "nextBadge": "Next",
     "leadBadge": "Lead"
-  }
+  },
+  "hintRequested": "Hint available",
+  "noHint": "No hint available"
 }

--- a/frontend/src/i18n/locales/en/tablanet.json
+++ b/frontend/src/i18n/locales/en/tablanet.json
@@ -50,5 +50,7 @@
   },
   "captureAnnounce": "{{player}} captured cards",
   "tablaAnnounce": "{{player}} scored a tabla (cleared the table)",
-  "listSeparator": ", "
+  "listSeparator": ", ",
+  "hintRequested": "Hint available",
+  "noHint": "No hint available"
 }

--- a/frontend/src/i18n/locales/ja/michigan.json
+++ b/frontend/src/i18n/locales/ja/michigan.json
@@ -64,5 +64,7 @@
     "new": "新しいシーケンスを開始できます",
     "nextBadge": "次",
     "leadBadge": "リード"
-  }
+  },
+  "hintRequested": "ヒントがあります",
+  "noHint": "ヒントはありません"
 }

--- a/frontend/src/i18n/locales/ja/tablanet.json
+++ b/frontend/src/i18n/locales/ja/tablanet.json
@@ -50,5 +50,7 @@
   },
   "captureAnnounce": "{{player}} が場札を捕獲しました",
   "tablaAnnounce": "{{player}} がタブラ（場を一掃）を達成しました",
-  "listSeparator": "、"
+  "listSeparator": "、",
+  "hintRequested": "ヒントがあります",
+  "noHint": "ヒントはありません"
 }

--- a/frontend/src/utils/cli/formatters/michiganFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/michiganFormatter.test.ts
@@ -54,7 +54,9 @@ describe('formatMichiganState', () => {
   });
 
   it('renders the playable indices and the backend hint line', () => {
-    const out = formatMichiganState(makeMichiganState({ hint: { cardIndex: 2, reason: 'claim_boodle' } }));
+    const out = formatMichiganState(
+      makeMichiganState({ messageCode: 'michigan.hintRequested', hint: { cardIndex: 2, reason: 'claim_boodle' } }),
+    );
     expect(out).toContain('playable:');
     expect(out).toContain('HINT: play 2 (claim_boodle)');
   });
@@ -62,5 +64,13 @@ describe('formatMichiganState', () => {
   it('renders the game-over line with the match winner', () => {
     const out = formatMichiganState(makeMichiganState({ gameEndFlag: true, matchWinnerIdx: 0, phase: 2 }));
     expect(out).toContain('Game Over!');
+  });
+
+  // **HINT 行は hint を頼んだときだけ。**受動ヒントが Output に載るように
+  // なった (#4483) ので、messageCode で「頼んだ応答か」を見分ける。
+  it('shows the hint only when the hint was requested', () => {
+    const hint = { cardIndex: 2, reason: 'claim_boodle' };
+    expect(formatMichiganState(makeMichiganState({ hint, messageCode: 'michigan.hintRequested' }))).toContain('HINT');
+    expect(formatMichiganState(makeMichiganState({ hint, messageCode: 'michigan.playing' }))).not.toContain('HINT');
   });
 });

--- a/frontend/src/utils/cli/formatters/michiganFormatter.ts
+++ b/frontend/src/utils/cli/formatters/michiganFormatter.ts
@@ -1,5 +1,12 @@
 import type { MichiganResponse } from '../../../types/card';
-import { formatCard, formatHeader, formatIndexedCards, formatPlayerName, formatSeparator } from '../formatterBase';
+import {
+  formatCard,
+  formatHeader,
+  formatIndexedCards,
+  formatPlayerName,
+  formatSeparator,
+  isRequestedHint,
+} from '../formatterBase';
 
 const PHASE_NAMES = ['Bet', 'Play', 'Result'];
 
@@ -40,7 +47,7 @@ export function formatMichiganState(state: MichiganResponse): string {
     lines.push(`playable: ${state.playableIndices.join(', ')}`);
   }
 
-  if (state.hint) {
+  if (state.hint && isRequestedHint(state)) {
     lines.push(`HINT: play ${state.hint.cardIndex} (${state.hint.reason})`);
   }
 

--- a/frontend/src/utils/cli/formatters/tablanetFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/tablanetFormatter.test.ts
@@ -46,7 +46,10 @@ describe('formatTablanetState', () => {
 
   it('renders a hint line when a hint is present', () => {
     const out = formatTablanetState(
-      makeTablanetState({ hint: { cardIndices: [0], tableIndices: [0], reason: 'tabla_sweep' } }),
+      makeTablanetState({
+        messageCode: 'tablanet.hintRequested',
+        hint: { cardIndices: [0], tableIndices: [0], reason: 'tabla_sweep' },
+      }),
     );
     expect(out).toContain('HINT:');
     expect(out).toContain('tabla_sweep');
@@ -55,5 +58,13 @@ describe('formatTablanetState', () => {
   it('appends the server message when present', () => {
     const out = formatTablanetState(makeTablanetState({ message: 'Game over.' }));
     expect(out).toContain('Game over.');
+  });
+
+  // **HINT 行は hint を頼んだときだけ。**受動ヒントが Output に載るように
+  // なった (#4483) ので、messageCode で「頼んだ応答か」を見分ける。
+  it('shows the hint only when the hint was requested', () => {
+    const hint = { cardIndices: [0], tableIndices: [0], reason: 'tabla_sweep' };
+    expect(formatTablanetState(makeTablanetState({ hint, messageCode: 'tablanet.hintRequested' }))).toContain('HINT');
+    expect(formatTablanetState(makeTablanetState({ hint, messageCode: 'tablanet.playing' }))).not.toContain('HINT');
   });
 });

--- a/frontend/src/utils/cli/formatters/tablanetFormatter.ts
+++ b/frontend/src/utils/cli/formatters/tablanetFormatter.ts
@@ -1,5 +1,5 @@
 import type { TablanetResponse } from '../../../types/card';
-import { formatHeader, formatIndexedCards, formatPlayerName, formatSeparator } from '../formatterBase';
+import { formatHeader, formatIndexedCards, formatPlayerName, formatSeparator, isRequestedHint } from '../formatterBase';
 
 const PHASE_NAMES = ['Play', 'GameEnd'];
 
@@ -36,7 +36,7 @@ export function formatTablanetState(state: TablanetResponse): string {
     }
   }
 
-  if (state.hint) {
+  if (state.hint && isRequestedHint(state)) {
     const cards = state.hint.cardIndices ?? [];
     const targets = state.hint.tableIndices ?? [];
     lines.push(`HINT: play [${cards.join(', ')}] capture [${targets.join(', ')}] (${state.hint.reason})`);

--- a/internal/adapter/presenter/MichiganWebPresenter.go
+++ b/internal/adapter/presenter/MichiganWebPresenter.go
@@ -17,6 +17,19 @@ type MichiganWebPresenter struct{}
 func (p *MichiganWebPresenter) Output(g interfaces.MichiganGame, lastErr error) string {
 	resObj := p.buildBase(g)
 	resObj.Message, resObj.MessageCode, resObj.MessageParams = p.buildMessage(g, lastErr)
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	//
+	// **手番の判定は Michigan.GetHint() を読んで確かめた。**他ゲームがそうだから、で
+	// 済ませない —— Pinochle は見ていなくて CPU の手が漏れた (#4585)。
+	if hint := g.GetHint(); hint != nil {
+		resObj.Hint = &controller.MichiganWebOutputHint{
+			CardIndex: hint.CardIndex,
+			Reason:    hint.Reason,
+		}
+	}
+
 	return marshalOrError(resObj)
 }
 
@@ -172,6 +185,13 @@ func (p *MichiganWebPresenter) HintOutput(g interfaces.MichiganGame) string {
 			CardIndex: hint.CardIndex,
 			Reason:    hint.Reason,
 		}
+	}
+	// **「頼んだヒントか」を CLI が見分けられるようにする。**このゲーム群の
+	// `hintAvailable` は画面のラベルとして既に使われているので、別キーを出す (#4483)。
+	if g.GetHint() != nil {
+		resObj.MessageCode = "michigan.hintRequested"
+	} else {
+		resObj.MessageCode = "michigan.noHint"
 	}
 	return marshalOrError(resObj)
 }

--- a/internal/adapter/presenter/MichiganWebPresenter_test.go
+++ b/internal/adapter/presenter/MichiganWebPresenter_test.go
@@ -195,3 +195,39 @@ func TestMichiganWebPresenter_ActionLog(t *testing.T) {
 	p := new(presenter.MichiganWebPresenter)
 	assert.NotEmpty(t, p.ActionLogOutput(g))
 }
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+func TestMichiganWebPresenterOutputCarriesTheHint(t *testing.T) {
+	// **配りに依存させない。**ベット直後にヒントが出ない配りが 300 回中 1 回ある
+	// ので、出る配りを引くまで回す。1000 回引けなければヒントが壊れている。
+	for range 1000 {
+		g := domain.NewDefaultMichigan()
+		require.NoError(t, g.PlaceHumanBet(michiganWebEvenBet(g.GetBetBudget())))
+		if g.GetHint() == nil {
+			continue
+		}
+
+		var decoded map[string]any
+		require.NoError(t, json.Unmarshal([]byte(new(presenter.MichiganWebPresenter).Output(g, nil)), &decoded))
+		assert.Contains(t, decoded, "hint", "Output must carry the hint -- the frontend reads state.hint")
+		// **Output は「頼んだヒント」の印を付けない。**付けると CLI が毎回 HINT 行を出す。
+		assert.NotEqual(t, "michigan.hintRequested", decoded["messageCode"])
+		return
+	}
+	t.Fatal("1000 deals and never once did a hint come back")
+}
+
+// **HintOutput は「頼んだヒント」だと分かる印を付ける。**
+func TestMichiganWebPresenterHintOutputMarksTheRequest(t *testing.T) {
+	for range 1000 {
+		g := domain.NewDefaultMichigan()
+		require.NoError(t, g.PlaceHumanBet(michiganWebEvenBet(g.GetBetBudget())))
+		if g.GetHint() == nil {
+			continue
+		}
+		assert.Contains(t, new(presenter.MichiganWebPresenter).HintOutput(g), "michigan.hintRequested")
+		return
+	}
+	t.Fatal("1000 deals and never once did a hint come back")
+}

--- a/internal/adapter/presenter/TablanetWebPresenter.go
+++ b/internal/adapter/presenter/TablanetWebPresenter.go
@@ -24,6 +24,20 @@ func (p *TablanetWebPresenter) Output(g interfaces.TablanetGame, lastErr error) 
 		resObj.MessageCode = "tablanet.result.scores"
 		resObj.MessageParams = map[string]string{"scores": p.encodeScoresParam(g)}
 	}
+	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
+	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと
+	// フロントの `state.hint` は常に undefined で、それを読む分岐は全部死ぬ (#4483)。
+	//
+	// **手番の判定は Tablanet.GetHint() を読んで確かめた。**他ゲームがそうだから、で
+	// 済ませない —— Pinochle は見ていなくて CPU の手が漏れた (#4585)。
+	if hint := g.GetHint(); hint != nil {
+		resObj.Hint = &controller.TablanetWebOutputHint{
+			CardIndices:  hint.CardIndices,
+			TableIndices: hint.TableIndices,
+			Reason:       hint.Reason,
+		}
+	}
+
 	return marshalOrError(resObj)
 }
 
@@ -132,6 +146,13 @@ func (p *TablanetWebPresenter) HintOutput(g interfaces.TablanetGame) string {
 			TableIndices: hint.TableIndices,
 			Reason:       hint.Reason,
 		}
+	}
+	// **「頼んだヒントか」を CLI が見分けられるようにする。**このゲーム群の
+	// `hintAvailable` は画面のラベルとして既に使われているので、別キーを出す (#4483)。
+	if g.GetHint() != nil {
+		resObj.MessageCode = "tablanet.hintRequested"
+	} else {
+		resObj.MessageCode = "tablanet.noHint"
 	}
 	return marshalOrError(resObj)
 }

--- a/internal/adapter/presenter/TablanetWebPresenter_test.go
+++ b/internal/adapter/presenter/TablanetWebPresenter_test.go
@@ -75,3 +75,33 @@ func TestTablanetWebPresenter_ActionLog(t *testing.T) {
 	p := new(presenter.TablanetWebPresenter)
 	assert.NotEmpty(t, p.ActionLogOutput(g))
 }
+
+// **受動ヒントは Output() に載る。**HintOutput() は `command: "hint"` 専用の
+// レスポンスで、ページの state にはマージされない (#4483)。
+func TestTablanetWebPresenterOutputCarriesTheHint(t *testing.T) {
+	// 既存の HintOutput テストと同じ組み立て。場と手札を固定するので配りに依存しない。
+	g := domain.NewDefaultTablanet()
+	g.Reset()
+	g.SetCurrentTurn(0)
+	g.SetTableCards([]*domain.Card{domain.NewCard(domain.CardDesignSpade, 5, false)})
+	g.GetPlayer(0).Reset()
+	g.GetPlayer(0).AddCard(domain.NewCard(domain.CardDesignHeart, 5, false))
+	require.NotNil(t, g.GetHint(), "fixture must actually produce a hint")
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal([]byte(new(presenter.TablanetWebPresenter).Output(g, nil)), &decoded))
+	assert.Contains(t, decoded, "hint", "Output must carry the hint -- the frontend reads state.hint")
+	assert.NotEqual(t, "tablanet.hintRequested", decoded["messageCode"])
+}
+
+// **HintOutput は「頼んだヒント」だと分かる印を付ける。**
+func TestTablanetWebPresenterHintOutputMarksTheRequest(t *testing.T) {
+	g := domain.NewDefaultTablanet()
+	g.Reset()
+	g.SetCurrentTurn(0)
+	g.SetTableCards([]*domain.Card{domain.NewCard(domain.CardDesignSpade, 5, false)})
+	g.GetPlayer(0).Reset()
+	g.GetPlayer(0).AddCard(domain.NewCard(domain.CardDesignHeart, 5, false))
+
+	assert.Contains(t, new(presenter.TablanetWebPresenter).HintOutput(g), "tablanet.hintRequested")
+}


### PR DESCRIPTION
## 概要

Michigan / Tablanet。

Refs #4483

## コメントを書く前に `GetHint()` を読みました

[#4585 の Pinochle](https://github.com/yuta-yoshinaga/go_trumpcards/pull/4585) で「`GetHint()` が人間の手番を確かめる」と書きながら**実際は確かめていなかった**ので、**1 本ずつ読んで確認**しています。

| ゲーム | 席の判定 |
|---|---|
| Michigan | `!g.IsHumanTurn()` で nil |
| Tablanet | `findHumanIdx()` と `currentTurn` を比較して nil |

コメントも「他ゲームがそうだから、で済ませない」と書き換えました。

## Michigan は 300 回に 1 回ヒントが出ません

ベット直後の配りによります。**引くまで回し、1000 回引けなければ失敗**させます。

```go
for range 1000 {
    g := domain.NewDefaultMichigan()
    require.NoError(t, g.PlaceHumanBet(...))
    if g.GetHint() == nil { continue }
    ...
    return
}
t.Fatal("1000 deals and never once did a hint come back")
```

Tablanet は既存テストと同じく**場と手札を固定**するので配りに依存しません。

## 負のコントロール

| 壊しかた | 結果 |
|---|---|
| `Output` のヒントを落とす | **2 件 FAIL** |
| CLI のゲートを外す | **2 ファイル FAIL** |

## 確認

- `go test -tags test ./internal/adapter/presenter/ -count=2` green（パッケージ全体）
- `golangci-lint run ./internal/adapter/presenter/` 0 issues
- `bun run test` / `bun run check` / `typecheck` green

## Test plan

- [ ] CI 全ジョブ green