### PR TITLE
feat(hints): wire the frontend hint for Russian Bank (#4557)

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -171,7 +171,7 @@ match on the code if you ever script against tsc output.
 | `TutorialProvider` | `src/providers/TutorialProvider.tsx` | Context provider; renders overlay (used internally by TutorialWrapper) |
 | `TutorialOverlay` | `src/components/tutorial/TutorialOverlay.tsx` | Full-screen overlay with SVG mask spotlight |
 | `useTutorial` | `src/hooks/useTutorial.ts` | State management (step progression, localStorage, resume/restart) |
-| `useGameHint` | `src/hooks/useGameHint.ts` | Frontend hints; registry-driven via `hintFactories` (covers most games; currently 225). `frontend/scripts/check-hint-coverage.mjs` fails the build for any new game without one. The supported set is the `HintGameName` union (`keyof typeof hintFactories`) — add a game by registering its factory there |
+| `useGameHint` | `src/hooks/useGameHint.ts` | Frontend hints; registry-driven via `hintFactories` (covers most games; currently 226). `frontend/scripts/check-hint-coverage.mjs` fails the build for any new game without one. The supported set is the `HintGameName` union (`keyof typeof hintFactories`) — add a game by registering its factory there |
 | `TutorialSuggestDialog` | `src/components/tutorial/TutorialSuggestDialog.tsx` | First-visit dialog; controlled by `useFirstVisit` hook |
 | `TutorialProgressPanel` | `src/components/tutorial/TutorialProgressPanel.tsx` | Progress overview in NavBar |
 

--- a/frontend/scripts/check-hint-coverage.mjs
+++ b/frontend/scripts/check-hint-coverage.mjs
@@ -76,7 +76,6 @@ const BACKLOG = new Set([
   'piquet',
   'pishti',
   'pontoon',
-  'russianbank',
   'scopone',
   'settemezzo',
   'sixbidsolo',

--- a/frontend/src/hooks/useGameHint.ts
+++ b/frontend/src/hooks/useGameHint.ts
@@ -139,6 +139,7 @@ import type {
   RedDogResponse,
   RookResponse,
   Rummy500Response,
+  RussianBankResponse,
   RussianPokerResponse,
   RussianSolitaireResponse,
   SambaResponse,
@@ -352,6 +353,7 @@ import { getRazzHint } from '../utils/hints/razzHint';
 import { getReddogHint } from '../utils/hints/reddogHint';
 import { getRookHint } from '../utils/hints/rookHint';
 import { getRummy500Hint } from '../utils/hints/rummy500Hint';
+import { getRussianBankHint } from '../utils/hints/russianbankHint';
 import { getRussianPokerHint } from '../utils/hints/russianpokerHint';
 import { getRussianSolitaireHint } from '../utils/hints/russianSolitaireHint';
 import { getSambaHint } from '../utils/hints/sambaHint';
@@ -548,6 +550,7 @@ export const hintFactories = {
   wasp: (s) => getWaspHint(s as WaspResponse),
   easthaven: (s) => getEasthavenHint(s as EasthavenResponse),
   accordion: (s) => getAccordionHint(s as AccordionResponse),
+  russianbank: (s) => getRussianBankHint(s as RussianBankResponse),
   acesup: (s) => getAcesUpHint(s as AcesUpResponse),
   blackhole: (s) => getBlackHoleHint(s as BlackHoleResponse),
   simplesimon: (s) => getSimpleSimonHint(s as SimpleSimonResponse),

--- a/frontend/src/i18n/locales/en/russianbank.json
+++ b/frontend/src/i18n/locales/en/russianbank.json
@@ -39,5 +39,9 @@
   },
   "slotCardZone": "{{card}} ({{zone}})",
   "slotEmptyZone": "{{zone}} (empty)",
-  "foundationZone": "foundation {{n}}"
+  "foundationZone": "foundation {{n}}",
+  "frontendHint": {
+    "russianbankToFoundation": "This card can go to a foundation",
+    "russianbankToTableau": "This card can move to another column"
+  }
 }

--- a/frontend/src/i18n/locales/ja/russianbank.json
+++ b/frontend/src/i18n/locales/ja/russianbank.json
@@ -39,5 +39,9 @@
   },
   "slotCardZone": "{{card}}（{{zone}}）",
   "slotEmptyZone": "{{zone}}（空き）",
-  "foundationZone": "ファウンデーション{{n}}"
+  "foundationZone": "ファウンデーション{{n}}",
+  "frontendHint": {
+    "russianbankToFoundation": "この札を台札へ上げられます",
+    "russianbankToTableau": "この札を別の列へ移せます"
+  }
 }

--- a/frontend/src/pages/RussianBankPage.test.tsx
+++ b/frontend/src/pages/RussianBankPage.test.tsx
@@ -196,4 +196,31 @@ describe('RussianBankPage', () => {
     await waitFor(() => expect(screen.getAllByText('ゲーム終了').length).toBeGreaterThan(0));
     expect(screen.queryByTestId('discard-button')).not.toBeInTheDocument();
   });
+
+  // **ヒント経路はページ側からも踏む。**ファクトリ単体テストだけだと
+  // `hintFactories` の登録行と、ページのトグル／ツールチップが一度も
+  // 実行されない（codecov が #4596 で同じ 3 ファイルを未到達と報告した）。
+  it('turns the frontend hint on from the checkbox', async () => {
+    localStorage.removeItem('hint_enabled_russianbank');
+    mockExec.mockResolvedValue(
+      makeState({ hint: { zone: 2, fromOpponent: false, col: 3, toFoundation: true, toCol: -1 } }),
+    );
+    renderWithProviders(<RussianBankPage />);
+
+    const toggle = await screen.findByRole('checkbox', { name: 'ヒント表示' });
+    expect(screen.queryByTestId('hint-tooltip')).not.toBeInTheDocument();
+
+    fireEvent.click(toggle);
+    expect(await screen.findByTestId('hint-tooltip')).toBeInTheDocument();
+  });
+
+  it('shows a single-pile hint when the toggle is already on', async () => {
+    localStorage.setItem('hint_enabled_russianbank', 'true');
+    mockExec.mockResolvedValue(
+      makeState({ hint: { zone: 0, fromOpponent: false, col: 0, toFoundation: false, toCol: 2 } }),
+    );
+    renderWithProviders(<RussianBankPage />);
+    expect(await screen.findByTestId('hint-tooltip')).toBeInTheDocument();
+    localStorage.removeItem('hint_enabled_russianbank');
+  });
 });

--- a/frontend/src/pages/RussianBankPage.tsx
+++ b/frontend/src/pages/RussianBankPage.tsx
@@ -2,15 +2,18 @@ import { useEffect, useRef, useState } from 'react';
 import { russianbankApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CardImage } from '../components/CardImage';
+import { SettingsPanel } from '../components/common/SettingsPanel';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
+import { FrontendHintTooltip } from '../components/hint/FrontendHintTooltip';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useGameApi } from '../hooks/useGameApi';
+import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { btnPrimary, btnSecondary, btnSuccess, btnWarning } from '../styles/buttonStyles';
@@ -19,6 +22,7 @@ import type { Card, RussianBankPlayer } from '../types/card';
 import { RussianBankPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
+import { hintCheckboxItem } from '../utils/settingsItems';
 
 /** Source-zone codes matching the Go `RussianBankZone` enum. */
 const ZONE_RESERVE = 0;
@@ -88,6 +92,12 @@ function RussianBankPageContent() {
   const phaseNames = usePhaseNames('russianbank', RB_PHASE_KEYS);
   const { cardWidth } = useCardDimensions();
   const w = Math.round(cardWidth * 0.62);
+
+  const {
+    hint: frontendHint,
+    hintEnabled: frontendHintEnabled,
+    setHintEnabled: setFrontendHintEnabled,
+  } = useGameHint('russianbank', state);
 
   if (!state) return <GameSkeleton gameKey="russianbank" layout={{ kind: 'tableau', topRow: 8, tableau: 4 }} />;
 
@@ -364,6 +374,13 @@ function RussianBankPageContent() {
         </div>
 
         <GameMessageBox message={state.message} messageCode={state.messageCode} messageParams={state.messageParams} />
+
+        <FrontendHintTooltip hint={frontendHint} enabled={frontendHintEnabled} t={t} />
+
+        <SettingsPanel
+          title={tc('settings.title')}
+          groups={[{ items: [hintCheckboxItem(tc, frontendHintEnabled, setFrontendHintEnabled)] }]}
+        />
 
         <ActionLogSection
           isEndPhase={isGameEnd}

--- a/frontend/src/utils/hints/russianbankHint.test.ts
+++ b/frontend/src/utils/hints/russianbankHint.test.ts
@@ -23,15 +23,17 @@ describe('getRussianBankHint', () => {
     expect(hint?.confidence).toBe('moderate');
   });
 
-  // **リザーブと廃札は 1 山なので列が無い。**col を付けると reserve--1 になる。
+  // **リザーブと廃札は 1 山なので列が無い。**バックエンドは Col を Go の
+  // ゼロ値 0 のまま送るので、col では区別できない。無条件に付けると
+  // `reserve-0` という存在しない列になる。
   it('names a single pile without a column', () => {
     const reserve = getRussianBankHint(
-      makeState({ hint: { zone: 0, fromOpponent: false, col: -1, toFoundation: true, toCol: -1 } }),
+      makeState({ hint: { zone: 0, fromOpponent: false, col: 0, toFoundation: true, toCol: -1 } }),
     );
     expect(reserve?.targetAction).toBe('reserve');
 
     const waste = getRussianBankHint(
-      makeState({ hint: { zone: 1, fromOpponent: false, col: -1, toFoundation: false, toCol: 2 } }),
+      makeState({ hint: { zone: 1, fromOpponent: false, col: 0, toFoundation: false, toCol: 2 } }),
     );
     expect(waste?.targetAction).toBe('waste');
   });

--- a/frontend/src/utils/hints/russianbankHint.test.ts
+++ b/frontend/src/utils/hints/russianbankHint.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import type { RussianBankResponse } from '../../types/card';
+import { getRussianBankHint } from './russianbankHint';
+
+function makeState(overrides?: Partial<RussianBankResponse>): RussianBankResponse {
+  return { phase: 1, message: '', ...overrides } as RussianBankResponse;
+}
+
+describe('getRussianBankHint', () => {
+  it('rates a foundation move as strong', () => {
+    const hint = getRussianBankHint(
+      makeState({ hint: { zone: 2, fromOpponent: false, col: 3, toFoundation: true, toCol: -1 } }),
+    );
+    expect(hint?.targetAction).toBe('tableau-3');
+    expect(hint?.confidence).toBe('strong');
+  });
+
+  it('rates a tableau move as moderate', () => {
+    const hint = getRussianBankHint(
+      makeState({ hint: { zone: 2, fromOpponent: false, col: 0, toFoundation: false, toCol: 5 } }),
+    );
+    expect(hint?.reason).toBe('frontendHint.russianbankToTableau');
+    expect(hint?.confidence).toBe('moderate');
+  });
+
+  // **リザーブと廃札は 1 山なので列が無い。**col を付けると reserve--1 になる。
+  it('names a single pile without a column', () => {
+    const reserve = getRussianBankHint(
+      makeState({ hint: { zone: 0, fromOpponent: false, col: -1, toFoundation: true, toCol: -1 } }),
+    );
+    expect(reserve?.targetAction).toBe('reserve');
+
+    const waste = getRussianBankHint(
+      makeState({ hint: { zone: 1, fromOpponent: false, col: -1, toFoundation: false, toCol: 2 } }),
+    );
+    expect(waste?.targetAction).toBe('waste');
+  });
+
+  it('returns null without a hint', () => {
+    expect(getRussianBankHint(makeState())).toBeNull();
+  });
+
+  it('returns null for a zone it does not know', () => {
+    expect(
+      getRussianBankHint(makeState({ hint: { zone: 9, fromOpponent: false, col: 0, toFoundation: true, toCol: -1 } })),
+    ).toBeNull();
+  });
+});

--- a/frontend/src/utils/hints/russianbankHint.ts
+++ b/frontend/src/utils/hints/russianbankHint.ts
@@ -18,8 +18,11 @@ export function getRussianBankHint(state: RussianBankResponse): HintResult | nul
   const zone = ZONE_NAMES[hint.zone];
   if (!zone) return null;
 
-  // The tableau is the only source with a column; the others are single piles.
-  const target = zone === 'tableau' && hint.col >= 0 ? `${zone}-${hint.col}` : zone;
+  // **列を持つのはタブローだけ。**リザーブと廃札は 1 山で、バックエンドは
+  // `RussianBankSource{Zone: RussianBankZoneReserve}` のように Col を Go の
+  // ゼロ値 0 のまま送る。つまり col では区別できないので、ゾーンで判定する。
+  // col を無条件に付けると `reserve-0`（存在しない列）になる。
+  const target = zone === 'tableau' ? `${zone}-${hint.col}` : zone;
   return {
     targetAction: target,
     reason: hint.toFoundation ? 'frontendHint.russianbankToFoundation' : 'frontendHint.russianbankToTableau',

--- a/frontend/src/utils/hints/russianbankHint.ts
+++ b/frontend/src/utils/hints/russianbankHint.ts
@@ -1,0 +1,28 @@
+import type { RussianBankResponse } from '../../types/card';
+import type { HintResult } from '../../types/hint';
+
+/** Russian Bank source zones, as the backend numbers them. */
+const ZONE_NAMES: Record<number, string> = { 0: 'reserve', 1: 'waste', 2: 'tableau' };
+
+/**
+ * Returns a Russian Bank frontend hint derived from the backend hint, or null.
+ *
+ * The suggestion rides along with every state response (see
+ * RussianBankWebPresenter.Output, #4483). A card reaching a foundation is
+ * always progress; anything else is a rearrangement that may or may not be.
+ */
+export function getRussianBankHint(state: RussianBankResponse): HintResult | null {
+  const hint = state.hint;
+  if (!hint) return null;
+
+  const zone = ZONE_NAMES[hint.zone];
+  if (!zone) return null;
+
+  // The tableau is the only source with a column; the others are single piles.
+  const target = zone === 'tableau' && hint.col >= 0 ? `${zone}-${hint.col}` : zone;
+  return {
+    targetAction: target,
+    reason: hint.toFoundation ? 'frontendHint.russianbankToFoundation' : 'frontendHint.russianbankToTableau',
+    confidence: hint.toFoundation ? 'strong' : 'moderate',
+  };
+}


### PR DESCRIPTION
## 概要

#4557 の 7 本目。

Refs #4557

## 列を持つのはタブローだけ

リザーブと廃札は **1 山**なので列がありません。バックエンドは `Col` を Go の**ゼロ値 0** のまま送ります。

```go
// internal/domain/RussianBank.go:499-501
{Zone: RussianBankZoneReserve},   // Col は 0
{Zone: RussianBankZoneWaste},
```

つまり `col` では**リザーブ／廃札とタブロー 0 列目を区別できません**。ゾーンで判定します。

```ts
const target = zone === 'tableau' ? `${zone}-${hint.col}` : zone;
```

無条件に付けると `reserve-0` という存在しない列になります。

> **訂正:** 初版の本文とコメントは「単一山は `col: -1` で来る」と書いていましたが、**そのような経路はありません**。レビュー指摘を受けてバックエンドを読み直し、コメント・フィクスチャ（`col: 0`）・本文を実際のペイロードに合わせました。あわせて意味を失った `hint.col >= 0` を削除し、ゾーン判定だけが `reserve-0` を防ぐ形にしています。

## 確度

| 移動先 | 確度 |
|---|---|
| 台札 | **strong** |
| それ以外 | moderate |

## 負のコントロール

状態のヒントを無視するよう壊すと **5 件中 3 件 FAIL**。

## 確認

- `bun run check` → `227 of 259 games hinted; 32 still owed`
- `bun run typecheck` green
- `RussianBankPage.test.tsx` + `russianbankHint.test.ts` + docCount 21 件 green

## Test plan

- [ ] CI 全ジョブ green
