### PR TITLE
fix(hints): stop recommending a play the called suit forbids (closes #4598)

### DIFF
--- a/frontend/src/utils/hints/crazyeightsHint.test.ts
+++ b/frontend/src/utils/hints/crazyeightsHint.test.ts
@@ -123,3 +123,71 @@ describe('getCrazyEightsHint', () => {
     expect(result?.confidence).toBe('strong');
   });
 });
+
+// **8 の後は指定スートだけが通る。**ドメインは chosenSuit > 0 のとき
+// `card.GetDesign() == g.chosenSuit` だけを見て、場札のランクは見ない。
+// ランク一致を門番していないと、出せない札を strong で勧める (#4598)。
+describe('getCrazyEightsHint with a called suit', () => {
+  const calledDiamond = {
+    chosenSuit: 4,
+    discardTop: card('HEART', 9),
+  };
+
+  it('does not offer a rank match that the called suit forbids', () => {
+    const state = makeState({
+      ...calledDiamond,
+      players: [
+        {
+          id: 0,
+          isHuman: true,
+          cardCount: 2,
+          cards: [card('SPADE', 9), card('CLOVER', 2)],
+          roundScore: 0,
+          cumulativeScore: 0,
+        },
+        { id: 1, isHuman: false, cardCount: 3, cards: [], roundScore: 0, cumulativeScore: 0 },
+      ],
+    });
+    expect(getCrazyEightsHint(state)).toEqual({
+      targetAction: 'draw',
+      reason: 'hint.drawCard',
+      confidence: 'moderate',
+    });
+  });
+
+  it('does not tell the player to save the only card they can play', () => {
+    const state = makeState({
+      ...calledDiamond,
+      players: [
+        {
+          id: 0,
+          isHuman: true,
+          cardCount: 2,
+          cards: [card('SPADE', 9), card('CLOVER', 8)],
+          roundScore: 0,
+          cumulativeScore: 0,
+        },
+        { id: 1, isHuman: false, cardCount: 3, cards: [], roundScore: 0, cumulativeScore: 0 },
+      ],
+    });
+    expect(getCrazyEightsHint(state)?.reason).toBe('hint.playEight');
+  });
+
+  it('still offers a card of the called suit', () => {
+    const state = makeState({
+      ...calledDiamond,
+      players: [
+        {
+          id: 0,
+          isHuman: true,
+          cardCount: 2,
+          cards: [card('DIAMOND', 2), card('SPADE', 3)],
+          roundScore: 0,
+          cumulativeScore: 0,
+        },
+        { id: 1, isHuman: false, cardCount: 3, cards: [], roundScore: 0, cumulativeScore: 0 },
+      ],
+    });
+    expect(getCrazyEightsHint(state)?.reason).toBe('hint.playMatchingSuit');
+  });
+});

--- a/frontend/src/utils/hints/crazyeightsHint.ts
+++ b/frontend/src/utils/hints/crazyeightsHint.ts
@@ -55,13 +55,17 @@ function getPlayHint(cards: Card[], state: CrazyEightsResponse): HintResult {
     return { targetAction: 'play', reason: 'hint.playMatchingSuit', confidence: 'moderate' };
   }
 
-  const effectiveSuit = state.chosenSuit > 0 ? SUIT_NUM_TO_DESIGN[state.chosenSuit] : top.design;
+  // **8 の後は指定スートだけが通る。**ドメインは chosenSuit > 0 のとき
+  // `card.GetDesign() == g.chosenSuit` だけを見て、場札のランクは見ない。
+  // ランク一致をここで門番しないと、出せない札を strong で勧める (#4598)。
+  const called = state.chosenSuit > 0 ? SUIT_NUM_TO_DESIGN[state.chosenSuit] : undefined;
+  const effectiveSuit = called ?? top.design;
 
   const eights = cards.filter((c) => c.value === EIGHT);
   const nonEights = cards.filter((c) => c.value !== EIGHT);
 
   const suitMatch = nonEights.some((c) => c.design === effectiveSuit);
-  const valueMatch = nonEights.some((c) => c.value === top.value);
+  const valueMatch = called === undefined && nonEights.some((c) => c.value === top.value);
   const hasNonEightPlay = suitMatch || valueMatch;
 
   if (hasNonEightPlay && eights.length > 0) {

--- a/frontend/src/utils/hints/macauHint.test.ts
+++ b/frontend/src/utils/hints/macauHint.test.ts
@@ -125,3 +125,70 @@ describe('getMacauHint', () => {
     expect(getMacauHint(state)?.reason).toBe('hint.playMatchingSuit');
   });
 });
+
+// **8 の後は指定スートだけが通る。**ドメインは chosenSuit > 0 のとき
+// `card.GetDesign() == g.chosenSuit` だけを見て、場札のランクは見ない。
+// ランク一致を門番していないと、出せない札を strong で勧める (#4598)。
+describe('getMacauHint with a called suit', () => {
+  const calledDiamond = {
+    chosenSuit: 4,
+    discardTop: card('HEART', 9),
+  };
+
+  it('does not offer a rank match that the called suit forbids', () => {
+    const state = makeState({
+      ...calledDiamond,
+      players: [
+        {
+          id: 0,
+          isHuman: true,
+          cardCount: 2,
+          cards: [card('SPADE', 9), card('CLOVER', 2)],
+          roundScore: 0,
+          cumulativeScore: 0,
+          hasDeclared: false,
+        },
+        { id: 1, isHuman: false, cardCount: 3, cards: [], roundScore: 0, cumulativeScore: 0, hasDeclared: false },
+      ],
+    });
+    expect(getMacauHint(state)).toEqual({ targetAction: 'draw', reason: 'hint.drawCard', confidence: 'moderate' });
+  });
+
+  it('does not tell the player to save the only card they can play', () => {
+    const state = makeState({
+      ...calledDiamond,
+      players: [
+        {
+          id: 0,
+          isHuman: true,
+          cardCount: 2,
+          cards: [card('SPADE', 9), card('CLOVER', 8)],
+          roundScore: 0,
+          cumulativeScore: 0,
+          hasDeclared: false,
+        },
+        { id: 1, isHuman: false, cardCount: 3, cards: [], roundScore: 0, cumulativeScore: 0, hasDeclared: false },
+      ],
+    });
+    expect(getMacauHint(state)?.reason).toBe('hint.playEight');
+  });
+
+  it('still offers a card of the called suit', () => {
+    const state = makeState({
+      ...calledDiamond,
+      players: [
+        {
+          id: 0,
+          isHuman: true,
+          cardCount: 2,
+          cards: [card('DIAMOND', 2), card('SPADE', 3)],
+          roundScore: 0,
+          cumulativeScore: 0,
+          hasDeclared: false,
+        },
+        { id: 1, isHuman: false, cardCount: 3, cards: [], roundScore: 0, cumulativeScore: 0, hasDeclared: false },
+      ],
+    });
+    expect(getMacauHint(state)?.reason).toBe('hint.playMatchingSuit');
+  });
+});

--- a/frontend/src/utils/hints/macauHint.ts
+++ b/frontend/src/utils/hints/macauHint.ts
@@ -63,13 +63,17 @@ function getPlayHint(cards: Card[], state: MacauResponse): HintResult {
     return { targetAction: 'play', reason: 'hint.playMatchingSuit', confidence: 'moderate' };
   }
 
-  const effectiveSuit = state.chosenSuit > 0 ? SUIT_NUM_TO_DESIGN[state.chosenSuit] : top.design;
+  // **8 の後は指定スートだけが通る。**ドメインは chosenSuit > 0 のとき
+  // `card.GetDesign() == g.chosenSuit` だけを見て、場札のランクは見ない。
+  // ランク一致をここで門番しないと、出せない札を strong で勧める (#4598)。
+  const called = state.chosenSuit > 0 ? SUIT_NUM_TO_DESIGN[state.chosenSuit] : undefined;
+  const effectiveSuit = called ?? top.design;
 
   const eights = cards.filter((c) => c.value === EIGHT);
   const nonEights = cards.filter((c) => c.value !== EIGHT);
 
   const suitMatch = nonEights.some((c) => c.design === effectiveSuit);
-  const valueMatch = nonEights.some((c) => c.value === top.value);
+  const valueMatch = called === undefined && nonEights.some((c) => c.value === top.value);
 
   if ((suitMatch || valueMatch) && eights.length > 0) {
     return { targetAction: 'play', reason: 'hint.saveEight', confidence: 'moderate' };


### PR DESCRIPTION
## 概要

Closes #4598

8 が出てスートが指定された直後、`crazyeightsHint` と `macauHint` が**サーバが拒否する手**を `confidence: 'strong'` で勧めていました。

| | |
|---|---|
| 指定スート | ♦ |
| 場札 | ♥9 |
| 手札 | ♠9, ♣2 |

- 修正前: `hint.playMatchingValue` (**strong**) — ♠9 は出せません
- 修正後: `hint.drawCard`

手札が ♠9, ♣8 のときは `hint.saveEight`＝**唯一出せる 8 を温存しろ**でした。修正後は `hint.playEight`。

## 原因

ドメインは指定スートだけを見ます。

```go
// CrazyEights.go:395 / Macau.go:501
if g.chosenSuit > 0 {
    return card.GetDesign() == g.chosenSuit   // ランクは見ない
}
```

ファクトリはスートだけ差し替え、ランク一致を門番していませんでした。

```ts
const effectiveSuit = state.chosenSuit > 0 ? SUIT_NUM_TO_DESIGN[state.chosenSuit] : top.design;
const valueMatch    = nonEights.some((c) => c.value === top.value);   // ← 素通り
```

## 修正

```ts
const called = state.chosenSuit > 0 ? SUIT_NUM_TO_DESIGN[state.chosenSuit] : undefined;
const effectiveSuit = called ?? top.design;
const valueMatch = called === undefined && nonEights.some((c) => c.value === top.value);
```

#4597 で Mao に書いた形と同じです。

## 影響範囲

`chosenSuit` を計算に使うファクトリを全数走査し、**この 2 本のみ**と確認しました。

## テスト

各ゲームに 3 件ずつ追加（違法なランク一致／唯一の 8 を温存しない／指定スートの札は今まで通り勧める）。

**負のコントロール: 門番を戻すと 33 件中 4 件 FAIL**（各ゲーム 2 件）。集計行で数えました。

## 途中で見つけた別件

`crazyeightsHint.test.ts` のフィクスチャに `CrazyEightsPlayerData` に存在しない `hasDeclared` が入っていました。**vitest は 98 件 green のまま**で、`bun run typecheck` だけが落としました。ついでに除去しています。

## 確認

- `bun run typecheck` green
- `bun run check` green（残る警告 1 件は既存の `doubleklondikeHint.ts`）
- `MacauPage` / `CrazyEightsPage` 98 件 green

## Test plan

- [ ] CI 全ジョブ green