### PR TITLE
feat(hints): wire the frontend hint for Bridge, and translate its reasons (#4557)

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -171,7 +171,7 @@ match on the code if you ever script against tsc output.
 | `TutorialProvider` | `src/providers/TutorialProvider.tsx` | Context provider; renders overlay (used internally by TutorialWrapper) |
 | `TutorialOverlay` | `src/components/tutorial/TutorialOverlay.tsx` | Full-screen overlay with SVG mask spotlight |
 | `useTutorial` | `src/hooks/useTutorial.ts` | State management (step progression, localStorage, resume/restart) |
-| `useGameHint` | `src/hooks/useGameHint.ts` | Frontend hints; registry-driven via `hintFactories` (covers most games; currently 225). `frontend/scripts/check-hint-coverage.mjs` fails the build for any new game without one. The supported set is the `HintGameName` union (`keyof typeof hintFactories`) — add a game by registering its factory there |
+| `useGameHint` | `src/hooks/useGameHint.ts` | Frontend hints; registry-driven via `hintFactories` (covers most games; currently 226). `frontend/scripts/check-hint-coverage.mjs` fails the build for any new game without one. The supported set is the `HintGameName` union (`keyof typeof hintFactories`) — add a game by registering its factory there |
 | `TutorialSuggestDialog` | `src/components/tutorial/TutorialSuggestDialog.tsx` | First-visit dialog; controlled by `useFirstVisit` hook |
 | `TutorialProgressPanel` | `src/components/tutorial/TutorialProgressPanel.tsx` | Progress overview in NavBar |
 

--- a/frontend/scripts/check-hint-coverage.mjs
+++ b/frontend/scripts/check-hint-coverage.mjs
@@ -52,7 +52,6 @@ const BACKLOG = new Set([
   'bideuchre',
   'boston',
   'bourre',
-  'bridge',
   'briscola',
   'chinchon',
   'conquian',

--- a/frontend/src/hooks/useGameHint.ts
+++ b/frontend/src/hooks/useGameHint.ts
@@ -23,6 +23,7 @@ import type {
   BlackJackSwitchResponse,
   BouillotteResponse,
   BraidResponse,
+  BridgeResponse,
   BristolResponse,
   BuraResponse,
   BurracoResponse,
@@ -230,6 +231,7 @@ import { getBlackjackHint } from '../utils/hints/blackjackHint';
 import { getBlackjackswitchHint } from '../utils/hints/blackjackswitchHint';
 import { getBouillotteHint } from '../utils/hints/bouillotteHint';
 import { getBraidHint } from '../utils/hints/braidHint';
+import { getBridgeHint } from '../utils/hints/bridgeHint';
 import { getBristolHint } from '../utils/hints/bristolHint';
 import { getBuraHint } from '../utils/hints/buraHint';
 import { getBurracoHint } from '../utils/hints/burracoHint';
@@ -499,6 +501,7 @@ export const hintFactories = {
   durak: (s) => getDurakHint(s as DurakResponse),
   canasta: (s) => getCanastaHint(s as CanastaResponse),
   samba: (s) => getSambaHint(s as SambaResponse),
+  bridge: (s) => getBridgeHint(s as BridgeResponse),
   bristol: (s) => getBristolHint(s as BristolResponse),
   burraco: (s) => getBurracoHint(s as BurracoResponse),
   canfield: (s) => getCanfieldHint(s as CanfieldResponse),

--- a/frontend/src/i18n/locales/en/bridge.json
+++ b/frontend/src/i18n/locales/en/bridge.json
@@ -70,12 +70,12 @@
   },
   "hintPlay": "Recommended card",
   "hintReason": {
+    "discard_weak": "This trick is out of reach — throw a weak card",
     "follow_suit": "Follow the lead suit",
+    "lead_strong": "Lead a strong card to keep the initiative",
     "lead_trump": "Lead with trump",
-    "lead_off_suit": "Lead with off-suit",
-    "trump_cut": "Cut with trump",
-    "bid_strong": "Bid with strong hand",
-    "pass_weak": "Pass with weak hand"
+    "strategic_bid": "A bid that matches the strength of your hand",
+    "trump_cut": "Cut with trump"
   },
   "tutorial": {
     "bidControls": "In the bid phase, choose a level and suit to bid. You can also pass, double, or redouble.",

--- a/frontend/src/i18n/locales/ja/bridge.json
+++ b/frontend/src/i18n/locales/ja/bridge.json
@@ -70,12 +70,12 @@
   },
   "hintPlay": "推奨カード",
   "hintReason": {
+    "discard_weak": "このトリックは取れません。弱い札を捨てましょう",
     "follow_suit": "リードスートに追随",
+    "lead_strong": "強い札でリードして主導権を取ります",
     "lead_trump": "切り札でリード",
-    "lead_off_suit": "切り札以外でリード",
-    "trump_cut": "切り札でカット",
-    "bid_strong": "強い手札でビッド",
-    "pass_weak": "手札が弱いのでパス"
+    "strategic_bid": "手札の強さに見合ったビッドです",
+    "trump_cut": "切り札でカット"
   },
   "tutorial": {
     "bidControls": "ビッドフェーズではレベルとスートを選んでビッドします。パス・ダブル・リダブルも可能です。",

--- a/frontend/src/pages/BridgePage.test.tsx
+++ b/frontend/src/pages/BridgePage.test.tsx
@@ -588,4 +588,30 @@ describe('BridgePage', () => {
       Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: originalWidth });
     }
   });
+
+  // **ヒント経路はページ側からも踏む。**ファクトリ単体テストだけだと
+  // `hintFactories` の登録行と、ページのトグル／ツールチップが一度も
+  // 実行されない（codecov が #4596 で同じ 3 ファイルを未到達と報告した）。
+  it('turns the frontend hint on from the settings panel', async () => {
+    localStorage.removeItem('hint_enabled_bridge');
+    mockExec.mockResolvedValue({ ...playPhaseState, hint: { cardIndex: 0, reason: 'follow_suit' } });
+    renderWithProviders(<BridgePage />);
+
+    const toggle = await screen.findByRole('checkbox', { name: 'ヒント表示' });
+    expect(screen.queryByTestId('hint-tooltip')).not.toBeInTheDocument();
+
+    fireEvent.click(toggle);
+    expect(await screen.findByTestId('hint-tooltip')).toBeInTheDocument();
+  });
+
+  it('shows the auction hint when the toggle is already on', async () => {
+    localStorage.setItem('hint_enabled_bridge', 'true');
+    mockExec.mockResolvedValue({
+      ...bidPhaseState,
+      hint: { bidType: 0, bidLevel: 3, bidSuit: 2, reason: 'strategic_bid' },
+    });
+    renderWithProviders(<BridgePage />);
+    expect(await screen.findByTestId('hint-tooltip')).toBeInTheDocument();
+    localStorage.removeItem('hint_enabled_bridge');
+  });
 });

--- a/frontend/src/pages/BridgePage.tsx
+++ b/frontend/src/pages/BridgePage.tsx
@@ -10,6 +10,7 @@ import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
+import { FrontendHintTooltip } from '../components/hint/FrontendHintTooltip';
 import { MobileHandGrid } from '../components/MobileHandGrid';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
@@ -20,6 +21,7 @@ import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCardKeyboardNav } from '../hooks/useCardKeyboardNav';
 import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
+import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
@@ -36,6 +38,7 @@ import { BRIDGE_HELP, parseBridgeCommand } from '../utils/cli/commands/bridgeCom
 import { formatBridgeState } from '../utils/cli/formatters/bridgeFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
 import { playerName } from '../utils/playerUtils';
+import { hintCheckboxItem } from '../utils/settingsItems';
 
 /** Denomination names used in bid controls. */
 const DENOMINATIONS: readonly { suit: number; labelKey: string }[] = [
@@ -182,6 +185,14 @@ function BridgePageContent() {
     });
   }, [apiExec, hideActionLog, bridgeConfig.cpuDifficulty]);
 
+  // **フックは早期 return より上。**`if (!state)` の下に置くと、初回レンダー
+  // だけフック数が変わってページが骨組みのまま固まる (#4561)。
+  const {
+    hint: frontendHint,
+    hintEnabled: frontendHintEnabled,
+    setHintEnabled: setFrontendHintEnabled,
+  } = useGameHint('bridge', state);
+
   if (!state)
     return <GameSkeleton gameKey="bridge" layout={{ kind: 'trick-taking', trickArea: true, footerHandSize: 13 }} />;
 
@@ -258,6 +269,7 @@ function BridgePageContent() {
                     })),
                     onSelect: (v) => handleConfigChange('cpuDifficulty', v),
                   },
+                  hintCheckboxItem(tc, frontendHintEnabled, setFrontendHintEnabled),
                 ],
               },
             ]}
@@ -579,6 +591,8 @@ function BridgePageContent() {
               ))}
 
             <ErrorAlert message={error ?? hintError} onRetry={retry} />
+
+            <FrontendHintTooltip hint={frontendHint} enabled={frontendHintEnabled} t={t} />
 
             {hint && (
               <div className="text-ds-warning text-sm mb-2">

--- a/frontend/src/utils/hints/bridgeHint.test.ts
+++ b/frontend/src/utils/hints/bridgeHint.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import i18n from '../../i18n';
+import type { BridgeResponse } from '../../types/card';
+import { getBridgeHint } from './bridgeHint';
+
+const state = (hint?: BridgeResponse['hint']): BridgeResponse => ({ hint }) as BridgeResponse;
+
+describe('getBridgeHint', () => {
+  it('returns null without a hint', () => {
+    expect(getBridgeHint(state())).toBeNull();
+  });
+
+  it('points at the card to play', () => {
+    expect(getBridgeHint(state({ cardIndex: 5, reason: 'follow_suit' }))).toEqual({
+      targetAction: 'card-5',
+      reason: 'hintReason.follow_suit',
+      confidence: 'moderate',
+    });
+  });
+
+  // **札 0 は正当な手。**cardIndex は省略可能なので真偽値で見ると、手札の
+  // 先頭を出せというヒントだけが黙って消える。
+  it('keeps a hint that points at card index 0', () => {
+    expect(getBridgeHint(state({ cardIndex: 0, reason: 'lead_strong' }))?.targetAction).toBe('card-0');
+  });
+
+  it('raises the confidence when the suggestion is forced by the lead', () => {
+    expect(getBridgeHint(state({ cardIndex: 2, reason: 'follow_suit' }))?.confidence).toBe('moderate');
+    expect(getBridgeHint(state({ cardIndex: 2, reason: 'trump_cut' }))?.confidence).toBe('strong');
+  });
+
+  it('points at the bid controls during the auction', () => {
+    expect(getBridgeHint(state({ bidType: 0, bidLevel: 3, bidSuit: 2, reason: 'strategic_bid' }))).toEqual({
+      targetAction: 'bid',
+      reason: 'hintReason.strategic_bid',
+      confidence: 'moderate',
+    });
+  });
+
+  // **パスも 0 の一種。**bidLevel 0 / bidSuit 0 のパス提案を真偽値で
+  // 落とさないこと。
+  it('keeps a pass suggestion', () => {
+    expect(getBridgeHint(state({ bidType: 1, bidLevel: 0, bidSuit: 0, reason: 'strategic_bid' }))?.targetAction).toBe(
+      'bid',
+    );
+  });
+
+  it('returns null when the hint names neither a card nor a bid', () => {
+    expect(getBridgeHint(state({ reason: 'strategic_bid' }))).toBeNull();
+  });
+});
+
+// **バックエンドが出す理由キーが、訳を持っているか。**`hintReason` には
+// `strategic_bid` / `lead_strong` / `discard_weak` が無く、ビッド局面の
+// ヒントは**キー文字列そのもの**を表示していた。ボタン式のヒントも同じ
+// キーを読むので、ここが落ちれば両方が落ちる。
+describe('bridge hintReason keys', () => {
+  // Bridge.GetHint と playHintReason が返しうる全て。
+  const REASONS = ['strategic_bid', 'lead_trump', 'lead_strong', 'follow_suit', 'trump_cut', 'discard_weak'];
+
+  it.each(REASONS)('translates %s', (key) => {
+    expect(i18n.t(`bridge:hintReason.${key}`)).not.toBe(`hintReason.${key}`);
+  });
+});

--- a/frontend/src/utils/hints/bridgeHint.ts
+++ b/frontend/src/utils/hints/bridgeHint.ts
@@ -1,0 +1,39 @@
+import type { BridgeResponse } from '../../types/card';
+import type { HintResult } from '../../types/hint';
+
+/**
+ * 手が「決まっている」理由。リードスートに従える札が 1 枚しかない場面や、
+ * 切り札で取りに行く場面は、選択の余地が小さいので確度を上げる。
+ */
+const DECISIVE = new Set(['trump_cut', 'lead_trump']);
+
+/**
+ * Returns a frontend {@link HintResult} for Bridge, or null when no suggestion
+ * is available.
+ *
+ * Bridge's hint is computed entirely by the Go backend and surfaced on the
+ * response's `hint` field, which carries **two mutually exclusive shapes**: a
+ * `cardIndex` during play, and a `bidType` / `bidLevel` / `bidSuit` triple
+ * during the auction. This adapter re-maps whichever one arrived into the
+ * frontend HintResult shape so the shared
+ * {@link hooks/useGameHint.useGameHint | useGameHint} tooltip can render it.
+ *
+ * The reason keys live under `hintReason.` rather than this directory's usual
+ * `frontendHint.` because the page's own hint line already reads them there.
+ */
+export function getBridgeHint(state: BridgeResponse): HintResult | null {
+  const hint = state.hint;
+  if (!hint) return null;
+
+  const confidence = DECISIVE.has(hint.reason) ? 'strong' : 'moderate';
+
+  // **札 0 は正当な手。**省略可能な数値なので、真偽値で見ると「手札の先頭を
+  // 出せ」というヒントだけが黙って消える。パスの bidLevel 0 も同じ。
+  if (hint.cardIndex !== undefined) {
+    return { targetAction: `card-${hint.cardIndex}`, reason: `hintReason.${hint.reason}`, confidence };
+  }
+  if (hint.bidType !== undefined) {
+    return { targetAction: 'bid', reason: `hintReason.${hint.reason}`, confidence };
+  }
+  return null;
+}


### PR DESCRIPTION
## 概要

#4557 の 11 本目。配線に加えて、**既存のヒント表示が壊れていたのを直します**。

Refs #4557

## ビッドのヒントは、ずっとキー文字列を出していた

`hintReason` の中身とバックエンドが出す理由を突き合わせました。

| | |
|---|---|
| **欠落**（出すのに訳が無い） | `strategic_bid` / `lead_strong` / `discard_weak` |
| **未使用**（訳はあるが誰も出さない） | `bid_strong` / `lead_off_suit` / `pass_weak` |

`Bridge.GetHint` のビッド分岐は `strategic_bid` **一択**です。つまりビッド局面でヒントボタンを押すと、画面には

```
(hintReason.strategic_bid)
```

と出ていました。これは今回の配線とは無関係に、**既存のボタン式ヒントの不具合**です。

### 裏を取った手順

新しいキー検査を書く → locale 修正を `git stash` → 実行:

```
AssertionError: strategic_bid: expected 'hintReason.strategic_bid' not to be 'hintReason.strategic_bid'
```

修正を戻すと green。推測ではなく再現で確認しています。

## 直したこと

- 欠落 3 キーを ja / en に追加
- 未使用 3 キーを削除（`bridge` 名前空間からの参照はゼロと全数確認。同名キーが cinch / anaconda にありますが別名前空間です）
- `GetHint` と `playHintReason` が返しうる **6 キー全部**を表引きで固定。ボタン式ヒントも同じキーを読むので、この 1 本が両方を守ります

## ファクトリ

プレイ中は `cardIndex`、オークション中は `bidType`/`bidLevel`/`bidSuit` という**排他の 2 形**です。

- `cardIndex !== undefined` で見ます。**札 0 は正当な手**、パスの `bidLevel: 0` も同様
- `trump_cut` / `lead_trump` は選択の余地が小さいので strong、それ以外は moderate
- reason キーは他ゲームの `frontendHint.` ではなく **`hintReason.`**。ページのヒント行が既にそこを読んでいるため

## 負のコントロール

状態のヒントを無視すると **13 件中 5 件 FAIL**。

## 確認

- `bun run check` → `226 of 259 games hinted; 33 still owed`
- `bun run typecheck` green
- `BridgePage.test.tsx` + factory + docCount green

## Test plan

- [ ] CI 全ジョブ green