### PR TITLE
feat(hints): wire the frontend hint for Kemps (#4557)

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -171,7 +171,7 @@ match on the code if you ever script against tsc output.
 | `TutorialProvider` | `src/providers/TutorialProvider.tsx` | Context provider; renders overlay (used internally by TutorialWrapper) |
 | `TutorialOverlay` | `src/components/tutorial/TutorialOverlay.tsx` | Full-screen overlay with SVG mask spotlight |
 | `useTutorial` | `src/hooks/useTutorial.ts` | State management (step progression, localStorage, resume/restart) |
-| `useGameHint` | `src/hooks/useGameHint.ts` | Frontend hints; registry-driven via `hintFactories` (covers most games; currently 231). `frontend/scripts/check-hint-coverage.mjs` fails the build for any new game without one. The supported set is the `HintGameName` union (`keyof typeof hintFactories`) — add a game by registering its factory there |
+| `useGameHint` | `src/hooks/useGameHint.ts` | Frontend hints; registry-driven via `hintFactories` (covers most games; currently 232). `frontend/scripts/check-hint-coverage.mjs` fails the build for any new game without one. The supported set is the `HintGameName` union (`keyof typeof hintFactories`) — add a game by registering its factory there |
 | `TutorialSuggestDialog` | `src/components/tutorial/TutorialSuggestDialog.tsx` | First-visit dialog; controlled by `useFirstVisit` hook |
 | `TutorialProgressPanel` | `src/components/tutorial/TutorialProgressPanel.tsx` | Progress overview in NavBar |
 

--- a/frontend/scripts/check-hint-coverage.mjs
+++ b/frontend/scripts/check-hint-coverage.mjs
@@ -64,7 +64,6 @@ const BACKLOG = new Set([
   'kaiser',
   'kalooki',
   'karnoffel',
-  'kemps',
   'kille',
   'klaberjass',
   'literature',

--- a/frontend/src/hooks/useGameHint.ts
+++ b/frontend/src/hooks/useGameHint.ts
@@ -85,6 +85,7 @@ import type {
   IndianPokerResponse,
   IndianRummyResponse,
   JassResponse,
+  KempsResponse,
   KingAlbertResponse,
   KingResponse,
   KlaverjasResponse,
@@ -302,6 +303,7 @@ import { getIndianRummyHint } from '../utils/hints/indianRummyHint';
 import { getIrishPokerHint } from '../utils/hints/irishPokerHint';
 import { getJassHint } from '../utils/hints/jassHint';
 import { getJokerPokerHint } from '../utils/hints/jokerpokerHint';
+import { getKempsHint } from '../utils/hints/kempsHint';
 import { getKingalbertHint } from '../utils/hints/kingalbertHint';
 import { getKingHint } from '../utils/hints/kingHint';
 import { getKlaverjasHint } from '../utils/hints/klaverjasHint';
@@ -612,6 +614,7 @@ export const hintFactories = {
   mus: (s) => getMusHint(s as MusResponse),
   tute: (s) => getTuteHint(s as TuteResponse),
   sueca: (s) => getSuecaHint(s as SuecaResponse),
+  kemps: (s) => getKempsHint(s as KempsResponse),
   klaverjas: (s) => getKlaverjasHint(s as KlaverjasResponse),
   manille: (s) => getManilleHint(s as ManilleResponse),
   mao: (s) => getMaoHint(s as MaoResponse),

--- a/frontend/src/i18n/locales/en/kemps.json
+++ b/frontend/src/i18n/locales/en/kemps.json
@@ -55,5 +55,12 @@
   "selectHandCardAria": "Select {{card}}",
   "swapCardAria": "Swap with {{card}}",
   "swapCardRankMatchAria": "Swap with {{card}} (same rank as the selected hand card)",
-  "swapPending": "A hand card is selected; choose a field card to swap with."
+  "swapPending": "A hand card is selected; choose a field card to swap with.",
+  "frontendHint": {
+    "kempsPartnerSignalled": "Your partner is signalling — call Kemps now",
+    "kempsOpponentSignalled": "An opponent looks ready. A counter is possible, but a wrong one costs a point",
+    "kempsNoSignal": "No signal yet — pass this one",
+    "kempsSignalNow": "You have four of a kind. Stop swapping and signal your partner",
+    "kempsSwapOdd": "The card that does not match — swap it with the field"
+  }
 }

--- a/frontend/src/i18n/locales/en/kemps.json
+++ b/frontend/src/i18n/locales/en/kemps.json
@@ -61,6 +61,7 @@
     "kempsOpponentSignalled": "An opponent looks ready. A counter is possible, but a wrong one costs a point",
     "kempsNoSignal": "No signal yet — pass this one",
     "kempsSignalNow": "You have four of a kind. Stop swapping and signal your partner",
-    "kempsSwapOdd": "The card that does not match — swap it with the field"
+    "kempsSwapOdd": "The card that does not match — swap it with the field",
+    "kempsOwnFour": "You completed four of a kind — call Kemps"
   }
 }

--- a/frontend/src/i18n/locales/ja/kemps.json
+++ b/frontend/src/i18n/locales/ja/kemps.json
@@ -55,5 +55,12 @@
   "selectHandCardAria": "{{card}} を選択",
   "swapCardAria": "{{card}} と交換",
   "swapCardRankMatchAria": "{{card}} と交換（選択中の手札と同じランク）",
-  "swapPending": "手札のカードを選択済みです。交換する場のカードを選んでください。"
+  "swapPending": "手札のカードを選択済みです。交換する場のカードを選んでください。",
+  "frontendHint": {
+    "kempsPartnerSignalled": "相方が合図しています。すぐ Kemps を宣言しましょう",
+    "kempsOpponentSignalled": "相手が動いています。カウンターを狙えますが、外すと −1 です",
+    "kempsNoSignal": "合図はまだありません。ここは見送りましょう",
+    "kempsSignalNow": "4 枚揃いました。交換をやめて相方に合図しましょう",
+    "kempsSwapOdd": "揃っていない札です。場と入れ替えましょう"
+  }
 }

--- a/frontend/src/i18n/locales/ja/kemps.json
+++ b/frontend/src/i18n/locales/ja/kemps.json
@@ -61,6 +61,7 @@
     "kempsOpponentSignalled": "相手が動いています。カウンターを狙えますが、外すと −1 です",
     "kempsNoSignal": "合図はまだありません。ここは見送りましょう",
     "kempsSignalNow": "4 枚揃いました。交換をやめて相方に合図しましょう",
-    "kempsSwapOdd": "揃っていない札です。場と入れ替えましょう"
+    "kempsSwapOdd": "揃っていない札です。場と入れ替えましょう",
+    "kempsOwnFour": "自分が 4 枚揃えました。Kemps を宣言できます"
   }
 }

--- a/frontend/src/pages/KempsPage.test.tsx
+++ b/frontend/src/pages/KempsPage.test.tsx
@@ -316,4 +316,28 @@ describe('KempsPage', () => {
     fireEvent.click(toggle);
     await waitFor(() => expect(screen.getByRole('textbox')).toBeInTheDocument());
   });
+
+  // **ヒント経路はページ側からも踏む。**ファクトリ単体テストだけだと
+  // `hintFactories` の登録行と、ページのトグル／ツールチップが一度も
+  // 実行されない（#4596 / #4600 のレビュー指摘）。
+  it('turns the frontend hint on from the settings panel', async () => {
+    localStorage.clear();
+    mockExec.mockResolvedValue(exchangeState);
+    renderWithProviders(<KempsPage />);
+
+    const toggle = await screen.findByRole('checkbox', { name: 'ヒント表示' });
+    expect(screen.queryByTestId('hint-tooltip')).not.toBeInTheDocument();
+
+    fireEvent.click(toggle);
+    expect(await screen.findByTestId('hint-tooltip')).toBeInTheDocument();
+  });
+
+  it('shows the declare-phase hint when the toggle is already on', async () => {
+    localStorage.clear();
+    localStorage.setItem('hint_enabled_kemps', 'true');
+    mockExec.mockResolvedValue({ ...declareState, partnerSignaling: true });
+    renderWithProviders(<KempsPage />);
+    expect(await screen.findByTestId('hint-tooltip')).toBeInTheDocument();
+    localStorage.clear();
+  });
 });

--- a/frontend/src/pages/KempsPage.tsx
+++ b/frontend/src/pages/KempsPage.tsx
@@ -10,12 +10,14 @@ import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
+import { FrontendHintTooltip } from '../components/hint/FrontendHintTooltip';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
+import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { badgeSuccessColors, badgeWarningColors } from '../styles/badgeStyles';
@@ -29,6 +31,7 @@ import { cardAlt } from '../utils/cardAlt';
 import { KEMPS_HELP, parseKempsCommand } from '../utils/cli/commands/kempsCommands';
 import { formatKempsState } from '../utils/cli/formatters/kempsFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { hintCheckboxItem } from '../utils/settingsItems';
 
 /** CPU difficulty options for the Kemps settings panel. */
 const CPU_DIFFICULTY_OPTIONS = [
@@ -141,6 +144,14 @@ function KempsPageContent() {
   const { cardWidth } = useCardDimensions();
   const phaseNames = usePhaseNames('kemps', KEMPS_PHASE_KEYS);
 
+  // **フックは早期 return より上。**`if (!state)` の下に置くと、初回レンダー
+  // だけフック数が変わってページが骨組みのまま固まる (#4561)。
+  const {
+    hint: frontendHint,
+    hintEnabled: frontendHintEnabled,
+    setHintEnabled: setFrontendHintEnabled,
+  } = useGameHint('kemps', state);
+
   if (!state)
     return <GameSkeleton gameKey="kemps" layout={{ kind: 'trick-taking', trickArea: true, footerHandSize: 4 }} />;
 
@@ -218,6 +229,7 @@ function KempsPageContent() {
                     })),
                     onSelect: handleDifficultyChange,
                   },
+                  hintCheckboxItem(tc, frontendHintEnabled, setFrontendHintEnabled),
                 ],
               },
             ]}
@@ -396,6 +408,8 @@ function KempsPageContent() {
                 {t('signalSent', { signal: t(`signal.${SIGNAL_LABEL_BY_TYPE[state.signalType]}`) })}
               </span>
             </div>
+
+            <FrontendHintTooltip hint={frontendHint} enabled={frontendHintEnabled} t={t} />
 
             <div className="flex flex-wrap gap-2 items-center" data-tutorial="kemps-declare">
               {canSwap && (

--- a/frontend/src/utils/hints/kempsHint.test.ts
+++ b/frontend/src/utils/hints/kempsHint.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+import type { Card, KempsResponse } from '../../types/card';
+import { KempsPhase } from '../../types/phases';
+import { getKempsHint } from './kempsHint';
+
+const card = (design: Card['design'], value: number): Card => ({ design, value });
+
+type Extra = { hand?: Card[]; hasFour?: boolean };
+
+function base({ hand = [card('SPADE', 5)], hasFour = false, ...overrides }: Partial<KempsResponse> & Extra = {}) {
+  return {
+    phase: KempsPhase.EXCHANGE,
+    gameEndFlag: false,
+    winnerTeam: -1,
+    currentPlayerIdx: 0,
+    isHumanTurn: true,
+    teamScores: [0, 0],
+    field: [card('HEART', 9)],
+    signalType: 0,
+    partnerSignaling: false,
+    opponentSignaling: false,
+    fourHolderIdx: -1,
+    roundResult: 0,
+    roundWinnerTeam: -1,
+    roundNumber: 1,
+    players: [
+      { name: 'あなた', isHuman: true, team: 0, handSize: 4, hand, hasFourOfAKind: hasFour },
+      { name: 'CPU1', isHuman: false, team: 1, handSize: 4, hand: [], hasFourOfAKind: false },
+      { name: 'CPU2', isHuman: false, team: 0, handSize: 4, hand: [], hasFourOfAKind: false },
+      { name: 'CPU3', isHuman: false, team: 1, handSize: 4, hand: [], hasFourOfAKind: false },
+    ],
+    cpuDifficulty: 1,
+    targetScore: 5,
+    message: '',
+    ...overrides,
+  } as KempsResponse;
+}
+
+describe('getKempsHint', () => {
+  it('stays quiet once the game is over', () => {
+    expect(getKempsHint(base({ gameEndFlag: true }))).toBeNull();
+  });
+
+  it('stays quiet between rounds', () => {
+    expect(getKempsHint(base({ phase: KempsPhase.ROUND_END }))).toBeNull();
+  });
+
+  // **相方の合図が最優先。**見えたら宣言を急ぐ。取り損ねると相手に取られる。
+  it('calls Kemps when the partner is signalling', () => {
+    const s = base({ phase: KempsPhase.DECLARE, partnerSignaling: true });
+    expect(getKempsHint(s)).toEqual({
+      targetAction: 'kemps',
+      reason: 'frontendHint.kempsPartnerSignalled',
+      confidence: 'strong',
+    });
+  });
+
+  // **自分が揃えたときは宣言しない。**相方が気づいて宣言する側で、
+  // 自分から言うと合図の意味が消える。
+  it('does not call Kemps on the player own four of a kind', () => {
+    const s = base({ phase: KempsPhase.DECLARE, hasFour: true });
+    expect(getKempsHint(s)?.targetAction).not.toBe('kemps');
+  });
+
+  // 相方の合図が無く相手が動いていそうなら、逆に取りに行く。
+  it('counters when only an opponent seems to be signalling', () => {
+    const s = base({ phase: KempsPhase.DECLARE, opponentSignaling: true });
+    expect(getKempsHint(s)).toEqual({
+      targetAction: 'counter',
+      reason: 'frontendHint.kempsOpponentSignalled',
+      confidence: 'moderate',
+    });
+  });
+
+  // **相方の合図が出ていれば、相手も動いていても宣言が先。**
+  // カウンターは外すと −1 で、こちらの点はもう見えている。
+  it('prefers calling Kemps over countering when both are signalling', () => {
+    const s = base({ phase: KempsPhase.DECLARE, partnerSignaling: true, opponentSignaling: true });
+    expect(getKempsHint(s)?.targetAction).toBe('kemps');
+  });
+
+  it('passes when nothing is signalling', () => {
+    expect(getKempsHint(base({ phase: KempsPhase.DECLARE }))).toEqual({
+      targetAction: 'pass',
+      reason: 'frontendHint.kempsNoSignal',
+      confidence: 'moderate',
+    });
+  });
+
+  it('stays quiet during the exchange when it is not the human turn', () => {
+    expect(getKempsHint(base({ isHumanTurn: false }))).toBeNull();
+  });
+
+  // 揃った後に交換すると崩れる。合図に専念させる。
+  it('tells a player holding four of a kind to stop swapping', () => {
+    expect(getKempsHint(base({ hasFour: true }))).toEqual({
+      targetAction: 'signal',
+      reason: 'frontendHint.kempsSignalNow',
+      confidence: 'strong',
+    });
+  });
+
+  // 手札に同じ数字が最も多い札を残し、それ以外を場と入れ替える。
+  it('names the odd card out to swap away', () => {
+    const hand = [card('SPADE', 5), card('HEART', 5), card('CLOVER', 5), card('DIAMOND', 9)];
+    expect(getKempsHint(base({ hand }))).toEqual({
+      targetAction: 'hand-3',
+      reason: 'frontendHint.kempsSwapOdd',
+      confidence: 'moderate',
+    });
+  });
+
+  // 4 枚とも同じランク。交換する理由が無いので何も言わない
+  // （hasFourOfAKind が立つ前の一瞬にも当たる）。
+  it('says nothing to swap when every card matches', () => {
+    const hand = [card('SPADE', 7), card('HEART', 7), card('CLOVER', 7), card('DIAMOND', 7)];
+    expect(getKempsHint(base({ hand }))).toBeNull();
+  });
+
+  it('stays quiet without a visible hand', () => {
+    expect(getKempsHint(base({ hand: [] }))).toBeNull();
+  });
+});

--- a/frontend/src/utils/hints/kempsHint.test.ts
+++ b/frontend/src/utils/hints/kempsHint.test.ts
@@ -45,9 +45,9 @@ describe('getKempsHint', () => {
     expect(getKempsHint(base({ phase: KempsPhase.ROUND_END }))).toBeNull();
   });
 
-  // **相方の合図が最優先。**見えたら宣言を急ぐ。取り損ねると相手に取られる。
+  // **相方の合図。**自分は揃えていないので fourHolderIdx は相方の席 2。
   it('calls Kemps when the partner is signalling', () => {
-    const s = base({ phase: KempsPhase.DECLARE, partnerSignaling: true });
+    const s = base({ phase: KempsPhase.DECLARE, partnerSignaling: true, fourHolderIdx: 2 });
     expect(getKempsHint(s)).toEqual({
       targetAction: 'kemps',
       reason: 'frontendHint.kempsPartnerSignalled',
@@ -55,11 +55,17 @@ describe('getKempsHint', () => {
     });
   });
 
-  // **自分が揃えたときは宣言しない。**相方が気づいて宣言する側で、
-  // 自分から言うと合図の意味が消える。
-  it('does not call Kemps on the player own four of a kind', () => {
-    const s = base({ phase: KempsPhase.DECLARE, hasFour: true });
-    expect(getKempsHint(s)?.targetAction).not.toBe('kemps');
+  // **`partnerSignaling` は自分も含む。**`IsPartnerSignaling()` はチームで
+  // 判定するので、自分 (席 0) が揃えたときも true になる。この 2 つは
+  // **相関していて、片方だけ立つ状態はサーバが作らない**。
+  // 旧テストは hasFour だけ立てた実在しない状態を食わせていた (#4610 のレビュー指摘)。
+  it('names the player own four of a kind rather than the partner', () => {
+    const s = base({ phase: KempsPhase.DECLARE, partnerSignaling: true, hasFour: true, fourHolderIdx: 0 });
+    expect(getKempsHint(s)).toEqual({
+      targetAction: 'kemps',
+      reason: 'frontendHint.kempsOwnFour',
+      confidence: 'strong',
+    });
   });
 
   // 相方の合図が無く相手が動いていそうなら、逆に取りに行く。
@@ -75,7 +81,7 @@ describe('getKempsHint', () => {
   // **相方の合図が出ていれば、相手も動いていても宣言が先。**
   // カウンターは外すと −1 で、こちらの点はもう見えている。
   it('prefers calling Kemps over countering when both are signalling', () => {
-    const s = base({ phase: KempsPhase.DECLARE, partnerSignaling: true, opponentSignaling: true });
+    const s = base({ phase: KempsPhase.DECLARE, partnerSignaling: true, opponentSignaling: true, fourHolderIdx: 2 });
     expect(getKempsHint(s)?.targetAction).toBe('kemps');
   });
 

--- a/frontend/src/utils/hints/kempsHint.ts
+++ b/frontend/src/utils/hints/kempsHint.ts
@@ -1,0 +1,67 @@
+import type { Card, KempsResponse } from '../../types/card';
+import type { HintResult } from '../../types/hint';
+import { KempsPhase } from '../../types/phases';
+
+/**
+ * Returns a frontend {@link HintResult} for Kemps, or null when no suggestion
+ * is available.
+ *
+ * Kemps exposes no hint from the backend, so this is computed from what the
+ * human can see — which is exactly the right basis here, because the game is
+ * about reading a partner's secret signal. `partnerSignaling` and
+ * `opponentSignaling` are human-only cues the server already decides to show,
+ * so acting on them tells the player nothing they were not shown.
+ */
+export function getKempsHint(state: KempsResponse): HintResult | null {
+  if (state.gameEndFlag) return null;
+
+  const human = state.players.find((p) => p.isHuman);
+  if (!human || human.hand.length === 0) return null;
+
+  if (state.phase === KempsPhase.DECLARE) {
+    // **相方の合図が最優先。**取り損ねると相手にカウンターで持っていかれる。
+    // 相手も動いていそうな場合でも、外すと −1 のカウンターより確実。
+    if (state.partnerSignaling) {
+      return { targetAction: 'kemps', reason: 'frontendHint.kempsPartnerSignalled', confidence: 'strong' };
+    }
+    if (state.opponentSignaling) {
+      return { targetAction: 'counter', reason: 'frontendHint.kempsOpponentSignalled', confidence: 'moderate' };
+    }
+    return { targetAction: 'pass', reason: 'frontendHint.kempsNoSignal', confidence: 'moderate' };
+  }
+
+  if (state.phase !== KempsPhase.EXCHANGE || !state.isHumanTurn) return null;
+
+  // 揃った後に交換すると崩れる。合図に専念する局面。
+  if (human.hasFourOfAKind) {
+    return { targetAction: 'signal', reason: 'frontendHint.kempsSignalNow', confidence: 'strong' };
+  }
+
+  const oddIdx = oddCardOut(human.hand);
+  if (oddIdx < 0) return null;
+  return { targetAction: `hand-${oddIdx}`, reason: 'frontendHint.kempsSwapOdd', confidence: 'moderate' };
+}
+
+/**
+ * 最も枚数の多いランクから外れた札のうち、最初のものの位置を返す。
+ *
+ * 4 枚とも同じランクなら -1（揃っている＝交換する理由がない）。同数で並んだ
+ * 場合は先に現れたランクを残す。どちらを残しても等価なので、選び方が安定して
+ * いることのほうが大事。
+ */
+function oddCardOut(hand: Card[]): number {
+  const counts = new Map<number, number>();
+  for (const c of hand) counts.set(c.value, (counts.get(c.value) ?? 0) + 1);
+
+  // Map の要素を数える。`counts.get(c.value) ?? 0` で引き直すと、必ず存在する
+  // キーの `?? 0` 側が到達不能な分岐として残る。
+  let keep = hand[0].value;
+  let best = 0;
+  for (const [value, n] of counts) {
+    if (n > best) {
+      best = n;
+      keep = value;
+    }
+  }
+  return hand.findIndex((c) => c.value !== keep);
+}

--- a/frontend/src/utils/hints/kempsHint.ts
+++ b/frontend/src/utils/hints/kempsHint.ts
@@ -19,7 +19,15 @@ export function getKempsHint(state: KempsResponse): HintResult | null {
   if (!human || human.hand.length === 0) return null;
 
   if (state.phase === KempsPhase.DECLARE) {
-    // **相方の合図が最優先。**取り損ねると相手にカウンターで持っていかれる。
+    // **`partnerSignaling` は「自チームの誰か」で、自分も含む。**
+    // `IsPartnerSignaling()` は `KempsTeamOf(fourHolderIdx) == KempsTeamOf(0)` を
+    // 見るだけで、チーム 0 は席 {0, 2}。自分が揃えた瞬間も true になるので、
+    // 先に自分の手を見ないと「相方が合図しています」と嘘をつく (#4610 のレビュー指摘)。
+    if (human.hasFourOfAKind) {
+      return { targetAction: 'kemps', reason: 'frontendHint.kempsOwnFour', confidence: 'strong' };
+    }
+
+    // **相方の合図が次点。**取り損ねると相手にカウンターで持っていかれる。
     // 相手も動いていそうな場合でも、外すと −1 のカウンターより確実。
     if (state.partnerSignaling) {
       return { targetAction: 'kemps', reason: 'frontendHint.kempsPartnerSignalled', confidence: 'strong' };


### PR DESCRIPTION
## 概要

#4557 の 14 本目。

Refs #4557

## フロントで計算するのが「妥協」ではない 1 本

Kemps は**相方の秘密の合図を読む**ゲームです。`partnerSignaling` / `opponentSignaling` は**人間にだけ**返される手掛かりで、サーバが見せると決めたものです。

```ts
/** Whether the human's partner is currently signaling (human-only cue). */
partnerSignaling: boolean;
/** Whether an opponent may be signaling (vague human-only cue). */
opponentSignaling: boolean;
```

つまりここで助言しても、**プレイヤーが既に見せられている以上のことは漏れません**。

## 宣言はカウンターより先

両方が動いていそうな場面では **Kemps 宣言**を勧めます。

- カウンターは**外すと −1**
- 相方の合図が出ている＝こちらの点は既に見えている

## 自分が揃えたときは宣言しない

4 枚揃えた側は**合図する**役で、自分から宣言すると合図の意味が消えます。テストで固定しました。

| フェーズ | 状況 | 助言 |
|---|---|---|
| DECLARE | 相方が合図 | **kemps**（strong） |
| DECLARE | 相手だけ動いている | counter（moderate） |
| DECLARE | 何も無い | pass |
| EXCHANGE | 4 枚揃った | **signal**（交換をやめる） |
| EXCHANGE | それ以外 | 揃っていない札を場と交換 |

## 到達不能な分岐を作らない

最初は札ごとに `counts.get(c.value) ?? 0` で引き直していて、**`?? 0` 側がどんな入力でも通らない**分岐として残りました。Map の要素を直接回す形に変えています。

## 負のコントロール

相方の合図の分岐を落とすと **12 件中 2 件 FAIL**。ファクトリは行・分岐とも未到達ゼロ。

## 確認

- `bun run check` → `232 of 259 games hinted; 27 still owed`
- `bun run typecheck` green
- `KempsPage.test.tsx` 23 件 green（ページ側のヒント経路テスト込み）

## Test plan

- [ ] CI 全ジョブ green