### PR TITLE
feat(hints): wire the frontend hint for Spoons (#4557)

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -171,7 +171,7 @@ match on the code if you ever script against tsc output.
 | `TutorialProvider` | `src/providers/TutorialProvider.tsx` | Context provider; renders overlay (used internally by TutorialWrapper) |
 | `TutorialOverlay` | `src/components/tutorial/TutorialOverlay.tsx` | Full-screen overlay with SVG mask spotlight |
 | `useTutorial` | `src/hooks/useTutorial.ts` | State management (step progression, localStorage, resume/restart) |
-| `useGameHint` | `src/hooks/useGameHint.ts` | Frontend hints; registry-driven via `hintFactories` (covers most games; currently 231). `frontend/scripts/check-hint-coverage.mjs` fails the build for any new game without one. The supported set is the `HintGameName` union (`keyof typeof hintFactories`) — add a game by registering its factory there |
+| `useGameHint` | `src/hooks/useGameHint.ts` | Frontend hints; registry-driven via `hintFactories` (covers most games; currently 232). `frontend/scripts/check-hint-coverage.mjs` fails the build for any new game without one. The supported set is the `HintGameName` union (`keyof typeof hintFactories`) — add a game by registering its factory there |
 | `TutorialSuggestDialog` | `src/components/tutorial/TutorialSuggestDialog.tsx` | First-visit dialog; controlled by `useFirstVisit` hook |
 | `TutorialProgressPanel` | `src/components/tutorial/TutorialProgressPanel.tsx` | Progress overview in NavBar |
 

--- a/frontend/scripts/check-hint-coverage.mjs
+++ b/frontend/scripts/check-hint-coverage.mjs
@@ -74,7 +74,6 @@ const BACKLOG = new Set([
   'scopone',
   'settemezzo',
   'sixbidsolo',
-  'spoons',
   'threethirteen',
   'vint',
 ]);

--- a/frontend/src/hooks/useGameHint.ts
+++ b/frontend/src/hooks/useGameHint.ts
@@ -175,6 +175,7 @@ import type {
   SpiderResponse,
   SpiteAndMaliceResponse,
   SpoilFiveResponse,
+  SpoonsResponse,
   StreetsAndAlleysResponse,
   SuecaResponse,
   TablanetResponse,
@@ -393,6 +394,7 @@ import { getSpideretteHint } from '../utils/hints/spideretteHint';
 import { getSpiderHint } from '../utils/hints/spiderHint';
 import { getSpiteAndMaliceHint } from '../utils/hints/spiteAndMaliceHint';
 import { getSpoilFiveHint } from '../utils/hints/spoilFiveHint';
+import { getSpoonsHint } from '../utils/hints/spoonsHint';
 import { getStreetsandalleysHint } from '../utils/hints/streetsandalleysHint';
 import { getSuecaHint } from '../utils/hints/suecaHint';
 import { getTablanetHint } from '../utils/hints/tablanetHint';
@@ -442,6 +444,7 @@ export const hintFactories = {
   poker: (s) => getPokerHint(s as PokerResponse),
   hearts: (s) => getHeartsHint(s as HeartsResponse),
   gongzhu: (s) => getGongZhuHint(s as GongZhuResponse),
+  spoons: (s) => getSpoonsHint(s as SpoonsResponse),
   spades: (s) => getSpadesHint(s as SpadesResponse),
   callbreak: (s) => getCallBreakHint(s as CallBreakResponse),
   tarneeb: (s) => getTarneebHint(s as TarneebResponse),

--- a/frontend/src/i18n/locales/en/spoons.json
+++ b/frontend/src/i18n/locales/en/spoons.json
@@ -45,5 +45,10 @@
     "grab": "When someone gets four of a kind, everyone races to grab a spoon from here. Whoever misses out gains a letter.",
     "resetButton": "Use this button to reset the game at any time."
   },
-  "passCardAria": "Pass {{card}}"
+  "passCardAria": "Pass {{card}}",
+  "frontendHint": {
+    "spoonsGrabNow": "The race is on — take a spoon now",
+    "spoonsFourOfAKind": "Four of a kind. Start the race yourself",
+    "spoonsPassOdd": "The card that does not match — pass it on"
+  }
 }

--- a/frontend/src/i18n/locales/ja/spoons.json
+++ b/frontend/src/i18n/locales/ja/spoons.json
@@ -45,5 +45,10 @@
     "grab": "フォーオブアカインドが成立するとここからスプーンを奪い合います。乗り遅れた人が文字を獲得します。",
     "resetButton": "このボタンでいつでもゲームをリセットできます。"
   },
-  "passCardAria": "{{card}} を渡す"
+  "passCardAria": "{{card}} を渡す",
+  "frontendHint": {
+    "spoonsGrabNow": "取り合いが始まりました。すぐスプーンを取りましょう",
+    "spoonsFourOfAKind": "4 枚揃いました。自分から取りに行きましょう",
+    "spoonsPassOdd": "揃っていない札です。次の人に回しましょう"
+  }
 }

--- a/frontend/src/pages/SpoonsPage.test.tsx
+++ b/frontend/src/pages/SpoonsPage.test.tsx
@@ -328,4 +328,19 @@ describe('SpoonsPage', () => {
     fireEvent.click(toggle);
     await waitFor(() => expect(screen.getByRole('textbox')).toBeInTheDocument());
   });
+
+  // **ヒント経路はページ側からも踏む。**ファクトリ単体テストだけだと
+  // `hintFactories` の登録行と、ページのトグル／ツールチップが一度も
+  // 実行されない（#4596 / #4600 のレビュー指摘）。
+  it('turns the frontend hint on from the settings panel', async () => {
+    localStorage.clear();
+    mockExec.mockResolvedValue(passState);
+    renderWithProviders(<SpoonsPage />);
+
+    const toggle = await screen.findByRole('checkbox', { name: 'ヒント表示' });
+    expect(screen.queryByTestId('hint-tooltip')).not.toBeInTheDocument();
+
+    fireEvent.click(toggle);
+    expect(await screen.findByTestId('hint-tooltip')).toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/SpoonsPage.tsx
+++ b/frontend/src/pages/SpoonsPage.tsx
@@ -10,12 +10,14 @@ import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
+import { FrontendHintTooltip } from '../components/hint/FrontendHintTooltip';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
+import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
@@ -29,6 +31,7 @@ import { cardAlt } from '../utils/cardAlt';
 import { parseSpoonsCommand, SPOONS_HELP } from '../utils/cli/commands/spoonsCommands';
 import { formatSpoonsState } from '../utils/cli/formatters/spoonsFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { hintCheckboxItem } from '../utils/settingsItems';
 import { computeSpoonsRankGroups } from '../utils/spoonsRankGroups';
 
 /**
@@ -141,6 +144,14 @@ function SpoonsPageContent() {
   const { playSound } = useSound();
   const phaseNames = usePhaseNames('spoons', SPOONS_PHASE_KEYS);
 
+  // **フックは早期 return より上。**`if (!state)` の下に置くと、初回レンダー
+  // だけフック数が変わってページが骨組みのまま固まる (#4561)。
+  const {
+    hint: frontendHint,
+    hintEnabled: frontendHintEnabled,
+    setHintEnabled: setFrontendHintEnabled,
+  } = useGameHint('spoons', state);
+
   // Chime the instant the grab window opens (false→true) — a static "grab now!"
   // text alone was easy to miss in this reflex game.
   const prevGrabOpenRef = useRef(false);
@@ -216,6 +227,7 @@ function SpoonsPageContent() {
                     })),
                     onSelect: handleConfigChange,
                   },
+                  hintCheckboxItem(tc, frontendHintEnabled, setFrontendHintEnabled),
                 ],
               },
             ]}
@@ -378,6 +390,8 @@ function SpoonsPageContent() {
             )}
 
             <ErrorAlert message={error} onRetry={retry} />
+
+            <FrontendHintTooltip hint={frontendHint} enabled={frontendHintEnabled} t={t} />
 
             <div className="flex flex-wrap gap-2 items-center" data-tutorial="spoons-grab">
               {state.grabWindowOpen && !isGameEnd && (

--- a/frontend/src/utils/hints/spoonsHint.test.ts
+++ b/frontend/src/utils/hints/spoonsHint.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import type { Card, SpoonsResponse } from '../../types/card';
+import { SpoonsPhase } from '../../types/phases';
+import { getSpoonsHint } from './spoonsHint';
+
+const card = (design: Card['design'], value: number): Card => ({ design, value });
+
+type Extra = { hand?: Card[]; hasSpoon?: boolean };
+
+function base({ hand = [card('SPADE', 5)], hasSpoon = false, ...overrides }: Partial<SpoonsResponse> & Extra = {}) {
+  return {
+    phase: SpoonsPhase.PASS,
+    gameEndFlag: false,
+    winnerIdx: -1,
+    currentPlayerIdx: 0,
+    feederIdx: 0,
+    isHumanTurn: true,
+    spoonsRemaining: 3,
+    grabWindowOpen: false,
+    firstGrabberIdx: -1,
+    roundLoserIdx: -1,
+    roundNumber: 1,
+    drawPileSize: 20,
+    players: [
+      { name: 'あなた', isHuman: true, handSize: hand.length, hand, letters: 0, eliminated: false, hasSpoon },
+      { name: 'CPU1', isHuman: false, handSize: 4, hand: [], letters: 0, eliminated: false, hasSpoon: false },
+    ],
+    cpuDifficulty: 1,
+    message: '',
+    ...overrides,
+  } as SpoonsResponse;
+}
+
+describe('getSpoonsHint', () => {
+  it('stays quiet once the game is over', () => {
+    expect(getSpoonsHint(base({ gameEndFlag: true }))).toBeNull();
+  });
+
+  it('stays quiet between rounds', () => {
+    expect(getSpoonsHint(base({ phase: SpoonsPhase.ROUND_END }))).toBeNull();
+  });
+
+  // **掴む窓が開いたら理屈より速さ。**遅れた 1 人が文字を負う。
+  it('grabs while the window is open', () => {
+    const s = base({ phase: SpoonsPhase.GRAB, grabWindowOpen: true });
+    expect(getSpoonsHint(s)).toEqual({
+      targetAction: 'grab',
+      reason: 'frontendHint.spoonsGrabNow',
+      confidence: 'strong',
+    });
+  });
+
+  it('says nothing once the player already holds a spoon', () => {
+    const s = base({ phase: SpoonsPhase.GRAB, grabWindowOpen: true, hasSpoon: true });
+    expect(getSpoonsHint(s)).toBeNull();
+  });
+
+  // 窓が閉じている GRAB フェーズ（全部取られた後）は掴めない。
+  it('says nothing when the window is closed', () => {
+    expect(getSpoonsHint(base({ phase: SpoonsPhase.GRAB }))).toBeNull();
+  });
+
+  // **4 枚揃ったら自分から始める。**待つ理由がない。
+  it('starts the race on four of a kind', () => {
+    const hand = [card('SPADE', 7), card('HEART', 7), card('CLOVER', 7), card('DIAMOND', 7)];
+    expect(getSpoonsHint(base({ hand }))).toEqual({
+      targetAction: 'grab',
+      reason: 'frontendHint.spoonsFourOfAKind',
+      confidence: 'strong',
+    });
+  });
+
+  it('names the odd card out to pass on', () => {
+    const hand = [card('SPADE', 5), card('HEART', 5), card('CLOVER', 5), card('DIAMOND', 9)];
+    expect(getSpoonsHint(base({ hand }))).toEqual({
+      targetAction: 'hand-3',
+      reason: 'frontendHint.spoonsPassOdd',
+      confidence: 'moderate',
+    });
+  });
+
+  // 全部同じランクだが 4 枚に満たない（配り途中）。取りに行ける状態ではない。
+  it('does not start the race before the hand is full', () => {
+    const hand = [card('SPADE', 7), card('HEART', 7)];
+    expect(getSpoonsHint(base({ hand }))).toBeNull();
+  });
+
+  it('stays quiet when it is not the human turn', () => {
+    expect(getSpoonsHint(base({ isHumanTurn: false }))).toBeNull();
+  });
+
+  it('stays quiet without a visible hand', () => {
+    expect(getSpoonsHint(base({ hand: [] }))).toBeNull();
+  });
+
+  it('stays quiet for an eliminated player', () => {
+    const s = base();
+    s.players[0].eliminated = true;
+    expect(getSpoonsHint(s)).toBeNull();
+  });
+});

--- a/frontend/src/utils/hints/spoonsHint.ts
+++ b/frontend/src/utils/hints/spoonsHint.ts
@@ -1,0 +1,62 @@
+import type { Card, SpoonsResponse } from '../../types/card';
+import type { HintResult } from '../../types/hint';
+import { SpoonsPhase } from '../../types/phases';
+
+/** 手札の枚数。4 枚揃えばスプーンを取りに行ける。 */
+const HAND_SIZE = 4;
+
+/**
+ * Returns a frontend {@link HintResult} for Spoons, or null when no suggestion
+ * is available.
+ *
+ * Spoons exposes no hint from the backend, so this is computed from the human's
+ * own hand and the race state. There is not much to reason about — that is the
+ * game — so the hint mostly makes sure the player does not miss the two moments
+ * that decide a round: the grab window opening, and their own fourth card
+ * arriving.
+ */
+export function getSpoonsHint(state: SpoonsResponse): HintResult | null {
+  if (state.gameEndFlag) return null;
+
+  const human = state.players.find((p) => p.isHuman);
+  if (!human || human.eliminated || human.hand.length === 0) return null;
+
+  if (state.phase === SpoonsPhase.GRAB) {
+    // 既に持っているなら急ぐことはない。窓が閉じていれば取れない。
+    if (!state.grabWindowOpen || human.hasSpoon) return null;
+    return { targetAction: 'grab', reason: 'frontendHint.spoonsGrabNow', confidence: 'strong' };
+  }
+
+  if (state.phase !== SpoonsPhase.PASS || !state.isHumanTurn) return null;
+
+  // **4 枚揃ったら自分から始める。**待つ理由がない。
+  const oddIdx = oddCardOut(human.hand);
+  if (oddIdx < 0) {
+    return human.hand.length === HAND_SIZE
+      ? { targetAction: 'grab', reason: 'frontendHint.spoonsFourOfAKind', confidence: 'strong' }
+      : null;
+  }
+  return { targetAction: `hand-${oddIdx}`, reason: 'frontendHint.spoonsPassOdd', confidence: 'moderate' };
+}
+
+/**
+ * 最も枚数の多いランクから外れた札のうち、最初のものの位置を返す。全部同じ
+ * ランクなら -1。
+ *
+ * 集計を数え直さず Map の要素を回すのは、`counts.get(...) ?? 0` の `?? 0` 側が
+ * どんな入力でも通らない分岐として残るため。
+ */
+function oddCardOut(hand: Card[]): number {
+  const counts = new Map<number, number>();
+  for (const c of hand) counts.set(c.value, (counts.get(c.value) ?? 0) + 1);
+
+  let keep = hand[0].value;
+  let best = 0;
+  for (const [value, n] of counts) {
+    if (n > best) {
+      best = n;
+      keep = value;
+    }
+  }
+  return hand.findIndex((c) => c.value !== keep);
+}


### PR DESCRIPTION
## 概要

#4557 の 15 本目。

Refs #4557

## 助言することが少ないのが正しい

Spoons は反射のゲームです。読み合いを足すのではなく、**1 ラウンドを決める 2 つの瞬間**を逃さないようにします。

| 状況 | 助言 |
|---|---|
| 取り合いの窓が開いた | **grab**（strong） |
| 4 枚揃った | **grab**（自分から始める） |
| それ以外（自分の手番） | 揃っていない札を次へ回す |
| 既にスプーンを持っている／窓が閉じている | 何も言わない |

## 到達不能な分岐を作らない

Kemps (#4610) と同じく、集計を札ごとに引き直すと `counts.get(...) ?? 0` の `?? 0` 側がどんな入力でも通らない分岐として残ります。Map の要素を直接回しています。

「全部同じランクだが 4 枚未満」（配り途中）も分岐として存在するので、テストで踏んでいます。

## 重複について

揃い札の走査は #4610（Kemps）と同じ形です。**どちらも 10 行程度で、両方とも未マージ**です。今の段階で共有モジュールにすると 2 つのレビューが結合するだけなので、**先回りして抽出せず、重複を記録するに留めました**。両方マージされた後にまとめるのが素直です。

## 負のコントロール

揃い札の走査を固定すると **11 件中 3 件 FAIL**。ファクトリは行・分岐とも未到達ゼロ。

## 確認

- `bun run check` → `232 of 259 games hinted; 27 still owed`
- `bun run typecheck` green
- `SpoonsPage.test.tsx` 23 件 green（ページ側のヒント経路テスト込み）

## Test plan

- [ ] CI 全ジョブ green