### PR TITLE
feat(hints): wire the frontend hint for Escoba (#4557)

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -171,7 +171,7 @@ match on the code if you ever script against tsc output.
 | `TutorialProvider` | `src/providers/TutorialProvider.tsx` | Context provider; renders overlay (used internally by TutorialWrapper) |
 | `TutorialOverlay` | `src/components/tutorial/TutorialOverlay.tsx` | Full-screen overlay with SVG mask spotlight |
 | `useTutorial` | `src/hooks/useTutorial.ts` | State management (step progression, localStorage, resume/restart) |
-| `useGameHint` | `src/hooks/useGameHint.ts` | Frontend hints; registry-driven via `hintFactories` (covers most games; currently 232). `frontend/scripts/check-hint-coverage.mjs` fails the build for any new game without one. The supported set is the `HintGameName` union (`keyof typeof hintFactories`) — add a game by registering its factory there |
+| `useGameHint` | `src/hooks/useGameHint.ts` | Frontend hints; registry-driven via `hintFactories` (covers most games; currently 235). `frontend/scripts/check-hint-coverage.mjs` fails the build for any new game without one. The supported set is the `HintGameName` union (`keyof typeof hintFactories`) — add a game by registering its factory there |
 | `TutorialSuggestDialog` | `src/components/tutorial/TutorialSuggestDialog.tsx` | First-visit dialog; controlled by `useFirstVisit` hook |
 | `TutorialProgressPanel` | `src/components/tutorial/TutorialProgressPanel.tsx` | Progress overview in NavBar |
 

--- a/frontend/scripts/check-hint-coverage.mjs
+++ b/frontend/scripts/check-hint-coverage.mjs
@@ -56,7 +56,6 @@ const BACKLOG = new Set([
   'chinchon',
   'conquian',
   'cuarenta',
-  'escoba',
   'faro',
   'fivecardstud',
   'guandan',

--- a/frontend/src/hooks/useGameHint.ts
+++ b/frontend/src/hooks/useGameHint.ts
@@ -61,6 +61,7 @@ import type {
   EcarteResponse,
   EgyptianRatscrewResponse,
   EightOffResponse,
+  EscobaResponse,
   EuchreResponse,
   FiftyOneResponse,
   FiveHundredResponse,
@@ -279,6 +280,7 @@ import { getEasthavenHint } from '../utils/hints/easthavenHint';
 import { getEcarteHint } from '../utils/hints/ecarteHint';
 import { getEgyptianRatscrewHint } from '../utils/hints/egyptianratscrewHint';
 import { getEightOffHint } from '../utils/hints/eightoffHint';
+import { getEscobaHint } from '../utils/hints/escobaHint';
 import { getEuchreHint } from '../utils/hints/euchreHint';
 import { getFiftyOneHint } from '../utils/hints/fiftyoneHint';
 import { getFiveHundredHint } from '../utils/hints/fivehundredHint';
@@ -471,6 +473,7 @@ export const hintFactories = {
   threecard: (s) => getThreeCardHint(s as ThreeCardResponse),
   tichu: (s) => getTichuHint(s as TichuResponse),
   highcardflush: (s) => getHighCardFlushHint(s as HighCardFlushResponse),
+  escoba: (s) => getEscobaHint(s as EscobaResponse),
   euchre: (s) => getEuchreHint(s as EuchreResponse),
   belote: (s) => getBeloteHint(s as BeloteResponse),
   jass: (s) => getJassHint(s as JassResponse),

--- a/frontend/src/i18n/locales/en/escoba.json
+++ b/frontend/src/i18n/locales/en/escoba.json
@@ -66,5 +66,10 @@
     "actions": "Choose Take (select table cards summing to 15) or Lay (select none).",
     "resetButton": "Reset the game."
   },
-  "sumIndicator": "Sum {{sum}} / {{target}}"
+  "sumIndicator": "Sum {{sum}} / {{target}}",
+  "frontendHint": {
+    "escobaEscoba": "This clears the whole table — an escoba, worth a point on its own",
+    "escobaCaptureMost": "The card that captures the most",
+    "escobaLayLow": "Nothing sums to fifteen — lay off your lowest card"
+  }
 }

--- a/frontend/src/i18n/locales/ja/escoba.json
+++ b/frontend/src/i18n/locales/ja/escoba.json
@@ -66,5 +66,10 @@
     "actions": "取る（場札を選択して合計15）か、場に置く（場札を選ばない）を選びます。",
     "resetButton": "ゲームをリセットします。"
   },
-  "sumIndicator": "合計 {{sum}} / {{target}}"
+  "sumIndicator": "合計 {{sum}} / {{target}}",
+  "frontendHint": {
+    "escobaEscoba": "場の札を全部さらえます。エスコバで 1 点です",
+    "escobaCaptureMost": "一番多く取れる札です",
+    "escobaLayLow": "取れる組み合わせがありません。一番小さい札を置きましょう"
+  }
 }

--- a/frontend/src/pages/EscobaPage.test.tsx
+++ b/frontend/src/pages/EscobaPage.test.tsx
@@ -322,4 +322,19 @@ describe('escoba capture-sum helpers', () => {
     // Out-of-range indices are ignored.
     expect(escobaSelectionSum({ design: 'SPADE', value: 1 }, table, [9])).toBe(1);
   });
+
+  // **ヒント経路はページ側からも踏む。**ファクトリ単体テストだけだと
+  // `hintFactories` の登録行と、ページのトグル／ツールチップが一度も
+  // 実行されない（#4596 / #4600 のレビュー指摘）。
+  it('turns the frontend hint on from the settings panel', async () => {
+    localStorage.clear();
+    mockExec.mockResolvedValue(makeEscobaState());
+    renderWithProviders(<EscobaPage />);
+
+    const toggle = await screen.findByRole('checkbox', { name: 'ヒント表示' });
+    expect(screen.queryByTestId('hint-tooltip')).not.toBeInTheDocument();
+
+    fireEvent.click(toggle);
+    expect(await screen.findByTestId('hint-tooltip')).toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/EscobaPage.tsx
+++ b/frontend/src/pages/EscobaPage.tsx
@@ -7,6 +7,7 @@ import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
+import { FrontendHintTooltip } from '../components/hint/FrontendHintTooltip';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { AnimatedCardBack } from '../components/motion/AnimatedCardBack';
 import { withTutorial } from '../components/tutorial/withTutorial';
@@ -14,6 +15,7 @@ import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useEscobaGame } from '../hooks/useEscobaGame';
+import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { gameTheme } from '../styles/gameTheme';
 import type { Card, EscobaResponse } from '../types/card';
@@ -25,6 +27,7 @@ import {
   parseEscobaCommand,
 } from '../utils/cli/commands/escobaCommands';
 import type { CliGameConfig } from '../utils/cli/types';
+import { hintCheckboxItem } from '../utils/settingsItems';
 
 const DIFFICULTY_OPTIONS = [
   { value: '0', label: 'Easy' },
@@ -137,6 +140,13 @@ function EscobaPageContent() {
   // is still null.
   const human = state && state.players.length >= 4 ? state.players.find((p) => p.isHuman) : null;
   const isHumanTurn = !!state && !!human && state.currentTurn === human.id && state.isHumanTurn && !state.gameEndFlag;
+
+  // 早期 return より上。上のコメントが言うとおり、フック順を崩さないため。
+  const {
+    hint: frontendHint,
+    hintEnabled: frontendHintEnabled,
+    setHintEnabled: setFrontendHintEnabled,
+  } = useGameHint('escoba', state);
 
   if (!state || !human) {
     return (
@@ -387,12 +397,15 @@ function EscobaPageContent() {
                     options: TARGET_SCORE_OPTIONS,
                     onSelect: (v: string) => handleConfigChange('targetScore', Number.parseInt(v, 10)),
                   },
+                  hintCheckboxItem(tc, frontendHintEnabled, setFrontendHintEnabled),
                 ],
               },
             ]}
           />
 
           <GameFooter className={`${gameTheme.escoba.footer} px-4 py-2.5`}>
+            <FrontendHintTooltip hint={frontendHint} enabled={frontendHintEnabled} t={t} />
+
             <div className="flex gap-2 justify-center flex-wrap items-center" data-tutorial="es-actions">
               <button
                 type="button"

--- a/frontend/src/utils/hints/escobaHint.test.ts
+++ b/frontend/src/utils/hints/escobaHint.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest';
+import type { Card, EscobaResponse } from '../../types/card';
+import { getEscobaHint } from './escobaHint';
+
+const card = (design: Card['design'], value: number): Card => ({ design, value });
+
+type Extra = { hand?: Card[]; table?: Card[] };
+
+function base({
+  hand = [card('SPADE', 7), card('HEART', 3)],
+  table = [card('CLOVER', 8), card('DIAMOND', 4)],
+  ...overrides
+}: Partial<EscobaResponse> & Extra = {}) {
+  return {
+    players: [
+      {
+        id: 0,
+        isHuman: true,
+        handCount: hand.length,
+        cards: hand,
+        capturedCount: 0,
+        capturedCards: [],
+        escobaCount: 0,
+      },
+      { id: 1, isHuman: false, handCount: 3, cards: [], capturedCount: 0, capturedCards: [], escobaCount: 0 },
+    ],
+    tableCards: table,
+    phase: 'playerTurn',
+    roundNumber: 1,
+    currentTurn: 0,
+    dealerIdx: 1,
+    stockRemaining: 20,
+    lastCaptureIdx: -1,
+    winnerIdx: -1,
+    gameEndFlag: false,
+    isHumanTurn: true,
+    handCaptures: [[], []],
+    message: '',
+    config: { cpuDifficulty: 1, targetScore: 21 },
+    ...overrides,
+  } as EscobaResponse;
+}
+
+describe('getEscobaHint', () => {
+  it('stays quiet once the game is over', () => {
+    expect(getEscobaHint(base({ gameEndFlag: true }))).toBeNull();
+  });
+
+  it('stays quiet between rounds', () => {
+    expect(getEscobaHint(base({ phase: 'roundEnd' }))).toBeNull();
+  });
+
+  it('stays quiet when it is not the human turn', () => {
+    expect(getEscobaHint(base({ isHumanTurn: false }))).toBeNull();
+  });
+
+  // **場を全部さらうとエスコバで 1 点。**他のどの取り方より優先する。
+  it('takes the capture that clears the table', () => {
+    const s = base({
+      table: [card('CLOVER', 8), card('DIAMOND', 4)],
+      handCaptures: [[[0]], [[0, 1]]],
+    });
+    expect(getEscobaHint(s)).toEqual({
+      targetAction: 'card-1',
+      reason: 'frontendHint.escobaEscoba',
+      confidence: 'strong',
+    });
+  });
+
+  // 場が空にならないなら、枚数を多く取れる手を選ぶ。
+  it('prefers the capture that takes the most cards', () => {
+    const s = base({
+      table: [card('CLOVER', 8), card('DIAMOND', 4), card('SPADE', 2)],
+      handCaptures: [[[0]], [[1, 2]]],
+    });
+    expect(getEscobaHint(s)).toEqual({
+      targetAction: 'card-1',
+      reason: 'frontendHint.escobaCaptureMost',
+      confidence: 'moderate',
+    });
+  });
+
+  // **札 0 も取り手になりうる。**真偽値で見ると先頭だけ落ちる。
+  it('keeps a capture on card index 0', () => {
+    const s = base({ handCaptures: [[[0, 1]], []] });
+    expect(getEscobaHint(s)?.targetAction).toBe('card-0');
+  });
+
+  // 取れないときは一番小さい札を置く。相手に 15 を作らせにくい。
+  it('lays off the lowest card when nothing captures', () => {
+    const hand = [card('SPADE', 7), card('HEART', 3)];
+    expect(getEscobaHint(base({ hand, handCaptures: [[], []] }))).toEqual({
+      targetAction: 'card-1',
+      reason: 'frontendHint.escobaLayLow',
+      confidence: 'moderate',
+    });
+  });
+
+  // エスコバが 2 つあるときは、多く取れるほうを選ぶ。
+  it('prefers the larger of two table-clearing captures', () => {
+    const s = base({
+      table: [card('CLOVER', 8), card('DIAMOND', 4)],
+      handCaptures: [[[0, 1]], [[0, 1]]],
+    });
+    expect(getEscobaHint(s)?.targetAction).toBe('card-0');
+  });
+
+  // **場が空なら「全部さらう」は成立しない。**tableSize 0 をエスコバにしない。
+  it('does not call an empty table an escoba', () => {
+    const s = base({ table: [], handCaptures: [[], []] });
+    expect(getEscobaHint(s)?.reason).toBe('frontendHint.escobaLayLow');
+  });
+
+  // 一番小さい札が先頭でない場合も選べる（走査の後ろ側の分岐）。
+  it('finds the lowest card later in the hand', () => {
+    const hand = [card('SPADE', 7), card('HEART', 5), card('CLOVER', 2)];
+    expect(getEscobaHint(base({ hand, handCaptures: [[], [], []] }))?.targetAction).toBe('card-2');
+  });
+
+  // 先頭が既に一番小さい場合（走査で一度も更新されない側）。
+  it('keeps the first card when it is already the lowest', () => {
+    const hand = [card('CLOVER', 2), card('SPADE', 7), card('HEART', 5)];
+    expect(getEscobaHint(base({ hand, handCaptures: [[], [], []] }))?.targetAction).toBe('card-0');
+  });
+
+  it('stays quiet without a visible hand', () => {
+    expect(getEscobaHint(base({ hand: [], handCaptures: [] }))).toBeNull();
+  });
+
+  // handCaptures は手札と同じ長さで届く。短ければ読める範囲だけ見る。
+  it('survives a capture list shorter than the hand', () => {
+    const hand = [card('SPADE', 7), card('HEART', 3), card('CLOVER', 2)];
+    expect(getEscobaHint(base({ hand, handCaptures: [[[0]]] }))?.targetAction).toBe('card-0');
+  });
+});

--- a/frontend/src/utils/hints/escobaHint.ts
+++ b/frontend/src/utils/hints/escobaHint.ts
@@ -1,0 +1,64 @@
+import type { Card, EscobaResponse } from '../../types/card';
+import type { HintResult } from '../../types/hint';
+
+/** 人間の手番であることを示すフェーズ。 */
+const PLAYER_TURN = 'playerTurn';
+
+/**
+ * Returns a frontend {@link HintResult} for Escoba, or null when no suggestion
+ * is available.
+ *
+ * The legal captures are **not** recomputed here: `handCaptures` already lists,
+ * per hand card, every table subset summing to 15. Re-deriving that would
+ * duplicate the domain's search. What this adds is the choice between them —
+ * clearing the table is an escoba and worth a point on its own, so it outranks
+ * any larger-but-incomplete capture.
+ */
+export function getEscobaHint(state: EscobaResponse): HintResult | null {
+  if (state.gameEndFlag || state.phase !== PLAYER_TURN || !state.isHumanTurn) return null;
+
+  const human = state.players.find((p) => p.isHuman);
+  if (!human || human.cards.length === 0) return null;
+
+  const tableSize = state.tableCards.length;
+
+  // handCaptures は手札と同じ長さで届くが、短くても読める範囲だけ見る。
+  const upto = Math.min(human.cards.length, state.handCaptures.length);
+  let best = -1;
+  let bestTaken = 0;
+  let bestClears = false;
+  for (let i = 0; i < upto; i += 1) {
+    for (const set of state.handCaptures[i]) {
+      // **場を全部さらう手が最優先。**エスコバはそれ自体で 1 点。
+      const clears = tableSize > 0 && set.length === tableSize;
+      const better = bestClears ? clears && set.length > bestTaken : clears || set.length > bestTaken;
+      if (!better) continue;
+      best = i;
+      bestTaken = set.length;
+      bestClears = bestClears || clears;
+    }
+  }
+
+  // **札 0 も取り手になりうる。**真偽値で見ると先頭だけ落ちる。
+  if (best >= 0) {
+    return bestClears
+      ? { targetAction: `card-${best}`, reason: 'frontendHint.escobaEscoba', confidence: 'strong' }
+      : { targetAction: `card-${best}`, reason: 'frontendHint.escobaCaptureMost', confidence: 'moderate' };
+  }
+
+  // 取れないなら一番小さい札を置く。相手に 15 を作らせにくい。
+  return {
+    targetAction: `card-${lowestIdx(human.cards)}`,
+    reason: 'frontendHint.escobaLayLow',
+    confidence: 'moderate',
+  };
+}
+
+/** 手札で一番小さいランクの位置。 */
+function lowestIdx(hand: Card[]): number {
+  let best = 0;
+  for (let i = 1; i < hand.length; i += 1) {
+    if (hand[i].value < hand[best].value) best = i;
+  }
+  return best;
+}


### PR DESCRIPTION
## 概要

#4557 の 19 本目。

Refs #4557

## 探索を作り直さない

`handCaptures` が**手札の各札について、合計 15 になる場の組み合わせを全部**返しています。

```ts
/** Per human hand-card index, the list of valid table-index capture sets summing to 15. */
handCaptures: number[][][];
```

ヒントが足すのは**その中からの選択**です。

| 状況 | 助言 |
|---|---|
| 場を全部さらえる | **escoba**（strong）。それ自体で 1 点 |
| 取れるが場は残る | 一番多く取れる札（moderate） |
| 取れない | 一番小さい札を置く |

エスコバが 2 つある場合は多く取れるほうを選びます。

## 場が空のときを「全部さらう」にしない

`set.length === tableCards.length` は**場が空でも真**になります。そこを素通しすると「エスコバです」と嘘をつくので、`tableSize > 0` を条件に入れ、テストで固定しました。

## 到達しない分岐を残さない

最初の走査は `if (bestClears) continue;` を含む形で、**どんな入力でも通らない分岐が 3 つ**残りました。テストで埋めるのではなく、優先順位を 1 つの式にまとめて書き直しています。

```ts
const better = bestClears ? clears && set.length > bestTaken : clears || set.length > bestTaken;
```

## 負のコントロール

エスコバ判定を落とすと **13 件中 1 件 FAIL**。ファクトリは行・分岐とも未到達ゼロ。

## 確認

- `bun run check` → `235 of 259 games hinted; 24 still owed`
- `bun run typecheck` green
- `EscobaPage.test.tsx` 24 件 green（ページ側のヒント経路テスト込み）

## Test plan

- [ ] CI 全ジョブ green