### PR TITLE
feat(hints): wire the frontend hint for Scopone (#4557)

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -171,7 +171,7 @@ match on the code if you ever script against tsc output.
 | `TutorialProvider` | `src/providers/TutorialProvider.tsx` | Context provider; renders overlay (used internally by TutorialWrapper) |
 | `TutorialOverlay` | `src/components/tutorial/TutorialOverlay.tsx` | Full-screen overlay with SVG mask spotlight |
 | `useTutorial` | `src/hooks/useTutorial.ts` | State management (step progression, localStorage, resume/restart) |
-| `useGameHint` | `src/hooks/useGameHint.ts` | Frontend hints; registry-driven via `hintFactories` (covers most games; currently 235). `frontend/scripts/check-hint-coverage.mjs` fails the build for any new game without one. The supported set is the `HintGameName` union (`keyof typeof hintFactories`) — add a game by registering its factory there |
+| `useGameHint` | `src/hooks/useGameHint.ts` | Frontend hints; registry-driven via `hintFactories` (covers most games; currently 237). `frontend/scripts/check-hint-coverage.mjs` fails the build for any new game without one. The supported set is the `HintGameName` union (`keyof typeof hintFactories`) — add a game by registering its factory there |
 | `TutorialSuggestDialog` | `src/components/tutorial/TutorialSuggestDialog.tsx` | First-visit dialog; controlled by `useFirstVisit` hook |
 | `TutorialProgressPanel` | `src/components/tutorial/TutorialProgressPanel.tsx` | Progress overview in NavBar |
 

--- a/frontend/scripts/check-hint-coverage.mjs
+++ b/frontend/scripts/check-hint-coverage.mjs
@@ -68,7 +68,6 @@ const BACKLOG = new Set([
   'literature',
   'niuniu',
   'pishti',
-  'scopone',
   'sixbidsolo',
   'threethirteen',
   'vint',

--- a/frontend/src/hooks/useGameHint.ts
+++ b/frontend/src/hooks/useGameHint.ts
@@ -154,6 +154,7 @@ import type {
   ScartoResponse,
   SchnapsenResponse,
   ScopaResponse,
+  ScoponeResponse,
   ScorpionResponse,
   SeahavenTowersResponse,
   SedmaResponse,
@@ -378,6 +379,7 @@ import { getSambaHint } from '../utils/hints/sambaHint';
 import { getScartoHint } from '../utils/hints/scartoHint';
 import { getSchnapsenHint } from '../utils/hints/schnapsenHint';
 import { getScopaHint } from '../utils/hints/scopaHint';
+import { getScoponeHint } from '../utils/hints/scoponeHint';
 import { getScorpionHint } from '../utils/hints/scorpionHint';
 import { getSeahavenTowersHint } from '../utils/hints/seahavenTowersHint';
 import { getSedmaHint } from '../utils/hints/sedmaHint';
@@ -573,6 +575,7 @@ export const hintFactories = {
   yukon: (s) => getYukonHint(s as YukonResponse),
   russiansolitaire: (s) => getRussianSolitaireHint(s as RussianSolitaireResponse),
   cruel: (s) => getCruelHint(s as CruelResponse),
+  scopone: (s) => getScoponeHint(s as ScoponeResponse),
   scorpion: (s) => getScorpionHint(s as ScorpionResponse),
   wasp: (s) => getWaspHint(s as WaspResponse),
   easthaven: (s) => getEasthavenHint(s as EasthavenResponse),

--- a/frontend/src/i18n/locales/en/scopone.json
+++ b/frontend/src/i18n/locales/en/scopone.json
@@ -59,5 +59,10 @@
     "playerHand": "Your hand. Select a card to act.",
     "actions": "Choose Take (with table cards selected) or Lay (with none selected).",
     "resetButton": "Reset the game."
+  },
+  "frontendHint": {
+    "scoponeScopa": "This clears the whole table — a scopa, worth a point on its own",
+    "scoponeCaptureMost": "The card that captures the most",
+    "scoponeLayLow": "Nothing captures — lay off your lowest card"
   }
 }

--- a/frontend/src/i18n/locales/ja/scopone.json
+++ b/frontend/src/i18n/locales/ja/scopone.json
@@ -59,5 +59,10 @@
     "playerHand": "あなたの手札です。カードを選んでアクションします。",
     "actions": "取る（場札を選択）か、場に置く（場札を選ばない）を選びます。",
     "resetButton": "ゲームをリセットします。"
+  },
+  "frontendHint": {
+    "scoponeScopa": "場の札を全部さらえます。スコパで 1 点です",
+    "scoponeCaptureMost": "一番多く取れる札です",
+    "scoponeLayLow": "取れる組み合わせがありません。一番小さい札を置きましょう"
   }
 }

--- a/frontend/src/pages/ScoponePage.test.tsx
+++ b/frontend/src/pages/ScoponePage.test.tsx
@@ -273,4 +273,19 @@ describe('ScoponePage', () => {
     fireEvent.click(screen.getByTestId('lay-button'));
     await waitFor(() => expect(screen.queryByTestId('scopone-scopa-celebration')).not.toBeInTheDocument());
   });
+
+  // **ヒント経路はページ側からも踏む。**ファクトリ単体テストだけだと
+  // `hintFactories` の登録行と、ページのトグル／ツールチップが一度も
+  // 実行されない（#4596 / #4600 のレビュー指摘）。
+  it('turns the frontend hint on from the settings panel', async () => {
+    localStorage.clear();
+    mockExec.mockResolvedValue(makeScoponeState());
+    renderWithProviders(<ScoponePage />);
+
+    const toggle = await screen.findByRole('checkbox', { name: 'ヒント表示' });
+    expect(screen.queryByTestId('hint-tooltip')).not.toBeInTheDocument();
+
+    fireEvent.click(toggle);
+    expect(await screen.findByTestId('hint-tooltip')).toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/ScoponePage.tsx
+++ b/frontend/src/pages/ScoponePage.tsx
@@ -7,6 +7,7 @@ import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
+import { FrontendHintTooltip } from '../components/hint/FrontendHintTooltip';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { AnimatedCardBack } from '../components/motion/AnimatedCardBack';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
@@ -14,6 +15,7 @@ import { withTutorial } from '../components/tutorial/withTutorial';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
+import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useScoponeGame } from '../hooks/useScoponeGame';
 import { useSound } from '../providers/SoundProvider';
@@ -27,6 +29,7 @@ import {
   type ScoponeCliArgs,
 } from '../utils/cli/commands/scoponeCommands';
 import type { CliGameConfig } from '../utils/cli/types';
+import { hintCheckboxItem } from '../utils/settingsItems';
 
 const DIFFICULTY_OPTIONS = [
   { value: '0', label: 'Easy' },
@@ -163,6 +166,13 @@ function ScoponePageContent() {
   // is still null.
   const human = state && state.players.length >= 4 ? state.players.find((p) => p.isHuman) : null;
   const isHumanTurn = !!state && !!human && state.currentTurn === human.id && state.isHumanTurn && !state.gameEndFlag;
+
+  // **フックは早期 return より上。**フック順を崩さないため。
+  const {
+    hint: frontendHint,
+    hintEnabled: frontendHintEnabled,
+    setHintEnabled: setFrontendHintEnabled,
+  } = useGameHint('scopone', state);
 
   if (!state || !human) {
     return (
@@ -381,12 +391,15 @@ function ScoponePageContent() {
                     options: TARGET_SCORE_OPTIONS,
                     onSelect: (v: string) => handleConfigChange('targetScore', Number.parseInt(v, 10)),
                   },
+                  hintCheckboxItem(tc, frontendHintEnabled, setFrontendHintEnabled),
                 ],
               },
             ]}
           />
 
           <GameFooter className={`${gameTheme.scopone.footer} px-4 py-2.5`}>
+            <FrontendHintTooltip hint={frontendHint} enabled={frontendHintEnabled} t={t} />
+
             <div className="flex gap-2 justify-center flex-wrap items-center" data-tutorial="sp-actions">
               <button
                 type="button"

--- a/frontend/src/utils/hints/scoponeHint.test.ts
+++ b/frontend/src/utils/hints/scoponeHint.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+import type { Card, ScoponeResponse } from '../../types/card';
+import { getScoponeHint } from './scoponeHint';
+
+const card = (design: Card['design'], value: number): Card => ({ design, value });
+
+type Extra = { hand?: Card[]; table?: Card[] };
+
+function base({
+  hand = [card('SPADE', 7), card('HEART', 3)],
+  table = [card('CLOVER', 8), card('DIAMOND', 4)],
+  ...overrides
+}: Partial<ScoponeResponse> & Extra = {}) {
+  return {
+    players: [
+      { id: 0, isHuman: true, team: 0, handCount: hand.length, cards: hand, capturedCount: 0, scopaCount: 0 },
+      { id: 1, isHuman: false, team: 1, handCount: 3, cards: [], capturedCount: 0, scopaCount: 0 },
+    ],
+    tableCards: table,
+    phase: 'playerTurn',
+    roundNumber: 1,
+    currentTurn: 0,
+    dealerIdx: 1,
+    teamScores: [0, 0],
+    lastCaptureIdx: -1,
+    winnerTeam: -1,
+    gameEndFlag: false,
+    isHumanTurn: true,
+    handCaptures: [[], []],
+    message: '',
+    config: { cpuDifficulty: 1, targetScore: 11 },
+    ...overrides,
+  } as ScoponeResponse;
+}
+
+describe('getScoponeHint', () => {
+  it('stays quiet once the game is over', () => {
+    expect(getScoponeHint(base({ gameEndFlag: true }))).toBeNull();
+  });
+
+  it('stays quiet between rounds', () => {
+    expect(getScoponeHint(base({ phase: 'roundEnd' }))).toBeNull();
+  });
+
+  it('stays quiet when it is not the human turn', () => {
+    expect(getScoponeHint(base({ isHumanTurn: false }))).toBeNull();
+  });
+
+  // **場を全部さらうとスコパで 1 点。**他のどの取り方より優先する。
+  it('takes the capture that clears the table', () => {
+    const s = base({
+      table: [card('CLOVER', 8), card('DIAMOND', 4)],
+      handCaptures: [[[0]], [[0, 1]]],
+    });
+    expect(getScoponeHint(s)).toEqual({
+      targetAction: 'card-1',
+      reason: 'frontendHint.scoponeScopa',
+      confidence: 'strong',
+    });
+  });
+
+  // 場が空にならないなら、枚数を多く取れる手を選ぶ。
+  it('prefers the capture that takes the most cards', () => {
+    const s = base({
+      table: [card('CLOVER', 8), card('DIAMOND', 4), card('SPADE', 2)],
+      handCaptures: [[[0]], [[1, 2]]],
+    });
+    expect(getScoponeHint(s)).toEqual({
+      targetAction: 'card-1',
+      reason: 'frontendHint.scoponeCaptureMost',
+      confidence: 'moderate',
+    });
+  });
+
+  // **札 0 も取り手になりうる。**真偽値で見ると先頭だけ落ちる。
+  it('keeps a capture on card index 0', () => {
+    const s = base({ handCaptures: [[[0, 1]], []] });
+    expect(getScoponeHint(s)?.targetAction).toBe('card-0');
+  });
+
+  // 取れないときは一番小さい札を置く。相手に 15 を作らせにくい。
+  it('lays off the lowest card when nothing captures', () => {
+    const hand = [card('SPADE', 7), card('HEART', 3)];
+    expect(getScoponeHint(base({ hand, handCaptures: [[], []] }))).toEqual({
+      targetAction: 'card-1',
+      reason: 'frontendHint.scoponeLayLow',
+      confidence: 'moderate',
+    });
+  });
+
+  // スコパが 2 つあるときは、多く取れるほうを選ぶ。
+  it('prefers the larger of two table-clearing captures', () => {
+    const s = base({
+      table: [card('CLOVER', 8), card('DIAMOND', 4)],
+      handCaptures: [[[0, 1]], [[0, 1]]],
+    });
+    expect(getScoponeHint(s)?.targetAction).toBe('card-0');
+  });
+
+  // **場が空なら「全部さらう」は成立しない。**tableSize 0 をスコパにしない。
+  it('does not call an empty table an escoba', () => {
+    const s = base({ table: [], handCaptures: [[], []] });
+    expect(getScoponeHint(s)?.reason).toBe('frontendHint.scoponeLayLow');
+  });
+
+  // 一番小さい札が先頭でない場合も選べる（走査の後ろ側の分岐）。
+  it('finds the lowest card later in the hand', () => {
+    const hand = [card('SPADE', 7), card('HEART', 5), card('CLOVER', 2)];
+    expect(getScoponeHint(base({ hand, handCaptures: [[], [], []] }))?.targetAction).toBe('card-2');
+  });
+
+  // 先頭が既に一番小さい場合（走査で一度も更新されない側）。
+  it('keeps the first card when it is already the lowest', () => {
+    const hand = [card('CLOVER', 2), card('SPADE', 7), card('HEART', 5)];
+    expect(getScoponeHint(base({ hand, handCaptures: [[], [], []] }))?.targetAction).toBe('card-0');
+  });
+
+  it('stays quiet without a visible hand', () => {
+    expect(getScoponeHint(base({ hand: [], handCaptures: [] }))).toBeNull();
+  });
+
+  // handCaptures は手札と同じ長さで届く。短ければ読める範囲だけ見る。
+  it('survives a capture list shorter than the hand', () => {
+    const hand = [card('SPADE', 7), card('HEART', 3), card('CLOVER', 2)];
+    expect(getScoponeHint(base({ hand, handCaptures: [[[0]]] }))?.targetAction).toBe('card-0');
+  });
+});

--- a/frontend/src/utils/hints/scoponeHint.ts
+++ b/frontend/src/utils/hints/scoponeHint.ts
@@ -1,0 +1,70 @@
+import type { Card, ScoponeResponse } from '../../types/card';
+import type { HintResult } from '../../types/hint';
+
+/** 人間の手番であることを示すフェーズ。 */
+const PLAYER_TURN = 'playerTurn';
+
+/**
+ * Returns a frontend {@link HintResult} for Scopone, or null when no suggestion
+ * is available.
+ *
+ * The legal captures are **not** recomputed here: `handCaptures` already lists,
+ * per hand card, every table subset that is a legal take. Re-deriving that would
+ * duplicate the domain's search. What this adds is the choice between them —
+ * clearing the table is an escoba and worth a point on its own, so it outranks
+ * any larger-but-incomplete capture.
+ *
+ * This is the same shape as `escobaHint`, because both games hand the frontend
+ * the same `handCaptures` structure. They are deliberately not shared: Escoba's
+ * captures must sum to fifteen while Scopone's match a rank or sum to it, so one
+ * helper would have to know which rule it was under to describe itself
+ * honestly.
+ */
+export function getScoponeHint(state: ScoponeResponse): HintResult | null {
+  if (state.gameEndFlag || state.phase !== PLAYER_TURN || !state.isHumanTurn) return null;
+
+  const human = state.players.find((p) => p.isHuman);
+  if (!human || human.cards.length === 0) return null;
+
+  const tableSize = state.tableCards.length;
+
+  // handCaptures は手札と同じ長さで届くが、短くても読める範囲だけ見る。
+  const upto = Math.min(human.cards.length, state.handCaptures.length);
+  let best = -1;
+  let bestTaken = 0;
+  let bestClears = false;
+  for (let i = 0; i < upto; i += 1) {
+    for (const set of state.handCaptures[i]) {
+      // **場を全部さらう手が最優先。**スコパはそれ自体で 1 点。
+      const clears = tableSize > 0 && set.length === tableSize;
+      const better = bestClears ? clears && set.length > bestTaken : clears || set.length > bestTaken;
+      if (!better) continue;
+      best = i;
+      bestTaken = set.length;
+      bestClears = bestClears || clears;
+    }
+  }
+
+  // **札 0 も取り手になりうる。**真偽値で見ると先頭だけ落ちる。
+  if (best >= 0) {
+    return bestClears
+      ? { targetAction: `card-${best}`, reason: 'frontendHint.scoponeScopa', confidence: 'strong' }
+      : { targetAction: `card-${best}`, reason: 'frontendHint.scoponeCaptureMost', confidence: 'moderate' };
+  }
+
+  // 取れないなら一番小さい札を置く。相手に取らせにくい。
+  return {
+    targetAction: `card-${lowestIdx(human.cards)}`,
+    reason: 'frontendHint.scoponeLayLow',
+    confidence: 'moderate',
+  };
+}
+
+/** 手札で一番小さいランクの位置。 */
+function lowestIdx(hand: Card[]): number {
+  let best = 0;
+  for (let i = 1; i < hand.length; i += 1) {
+    if (hand[i].value < hand[best].value) best = i;
+  }
+  return best;
+}


### PR DESCRIPTION
## 概要

#4557 の 22 本目。

Refs #4557

## Escoba と同じ形、ただし共有しない

Scopone は Escoba と**同じ `handCaptures` 構造**をフロントへ渡します。

```ts
/** Per human hand-card index, the list of valid table-index capture sets. */
handCaptures: number[][][];
```

したがってファクトリの形も同じです（場を全部さらう手＝**スコパ**を最優先、次に枚数、無ければ一番小さい札）。

**共有はしませんでした。**Escoba は「合計 15」、Scopone は「同じランク、または合計」で取れます。1 つのヘルパーにすると、**自分がどちらの規則の下にいるかを知らないと正直な説明が書けません**。この 2 本はコメントが価値の大半なので、分けたままにしています。

## コピー元の型を引きずっていた

フィクスチャを Escoba から複製したため、`escobaCount` / `capturedCards` / `stockRemaining` という **Scopone に無いフィールド**が入っていました。

`as ScoponeResponse` のキャストがあるため、**vitest も typecheck も通ります**。実際の型（`team` / `scopaCount` / `teamScores` / `winnerTeam`）に直しました。

## 負のコントロール

スコパ判定を落とすと **13 件中 1 件 FAIL**。ファクトリは未到達分岐ゼロ。

## 確認

- `bun run check` → `237 of 259 games hinted; 22 still owed`
- `bun run typecheck` green
- `ScoponePage.test.tsx` 21 件 green（ページ側のヒント経路テスト込み）

## Test plan

- [ ] CI 全ジョブ green