### PR TITLE
feat(hints): wire the frontend hint for Kalooki (#4557)

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -171,7 +171,7 @@ match on the code if you ever script against tsc output.
 | `TutorialProvider` | `src/providers/TutorialProvider.tsx` | Context provider; renders overlay (used internally by TutorialWrapper) |
 | `TutorialOverlay` | `src/components/tutorial/TutorialOverlay.tsx` | Full-screen overlay with SVG mask spotlight |
 | `useTutorial` | `src/hooks/useTutorial.ts` | State management (step progression, localStorage, resume/restart) |
-| `useGameHint` | `src/hooks/useGameHint.ts` | Frontend hints; registry-driven via `hintFactories` (covers most games; currently 235). `frontend/scripts/check-hint-coverage.mjs` fails the build for any new game without one. The supported set is the `HintGameName` union (`keyof typeof hintFactories`) — add a game by registering its factory there |
+| `useGameHint` | `src/hooks/useGameHint.ts` | Frontend hints; registry-driven via `hintFactories` (covers most games; currently 237). `frontend/scripts/check-hint-coverage.mjs` fails the build for any new game without one. The supported set is the `HintGameName` union (`keyof typeof hintFactories`) — add a game by registering its factory there |
 | `TutorialSuggestDialog` | `src/components/tutorial/TutorialSuggestDialog.tsx` | First-visit dialog; controlled by `useFirstVisit` hook |
 | `TutorialProgressPanel` | `src/components/tutorial/TutorialProgressPanel.tsx` | Progress overview in NavBar |
 

--- a/frontend/scripts/check-hint-coverage.mjs
+++ b/frontend/scripts/check-hint-coverage.mjs
@@ -62,7 +62,6 @@ const BACKLOG = new Set([
   'guandan',
   'handandfoot',
   'kaiser',
-  'kalooki',
   'karnoffel',
   'kille',
   'literature',

--- a/frontend/src/hooks/useGameHint.ts
+++ b/frontend/src/hooks/useGameHint.ts
@@ -85,6 +85,7 @@ import type {
   IndianPokerResponse,
   IndianRummyResponse,
   JassResponse,
+  KalookiResponse,
   KempsResponse,
   KingAlbertResponse,
   KingResponse,
@@ -307,6 +308,7 @@ import { getIndianRummyHint } from '../utils/hints/indianRummyHint';
 import { getIrishPokerHint } from '../utils/hints/irishPokerHint';
 import { getJassHint } from '../utils/hints/jassHint';
 import { getJokerPokerHint } from '../utils/hints/jokerpokerHint';
+import { getKalookiHint } from '../utils/hints/kalookiHint';
 import { getKempsHint } from '../utils/hints/kempsHint';
 import { getKingalbertHint } from '../utils/hints/kingalbertHint';
 import { getKingHint } from '../utils/hints/kingHint';
@@ -625,6 +627,7 @@ export const hintFactories = {
   mus: (s) => getMusHint(s as MusResponse),
   tute: (s) => getTuteHint(s as TuteResponse),
   sueca: (s) => getSuecaHint(s as SuecaResponse),
+  kalooki: (s) => getKalookiHint(s as KalookiResponse),
   kemps: (s) => getKempsHint(s as KempsResponse),
   klaberjass: (s) => getKlaberjassHint(s as KlaberjassResponse),
   klaverjas: (s) => getKlaverjasHint(s as KlaverjasResponse),

--- a/frontend/src/i18n/locales/en/kalooki.json
+++ b/frontend/src/i18n/locales/en/kalooki.json
@@ -43,5 +43,11 @@
     "hand": "Pick cards from your hand to build meld groups. Jokers act as wild cards.",
     "actions": "Draw → meld/lay off → discard one card, in that order."
   },
-  "cardInGroup": "{{card}} (added to group {{group}})"
+  "cardInGroup": "{{card}} (added to group {{group}})",
+  "frontendHint": {
+    "kalookiTakeDiscard": "The discard connects with your hand — take it",
+    "kalookiDrawStock": "The discard connects with nothing — draw from the stock",
+    "kalookiDiscardHeavy": "Your heaviest unconnected card",
+    "kalookiOpenFirst": "You have not opened yet — the threshold has to be met in one go, so keep building"
+  }
 }

--- a/frontend/src/i18n/locales/ja/kalooki.json
+++ b/frontend/src/i18n/locales/ja/kalooki.json
@@ -43,5 +43,11 @@
     "hand": "手札からカードを選び、メルドのグループに割り当てます。ジョーカーはワイルドカードとして使えます。",
     "actions": "ドロー → メルド/レイオフ → カード1枚を捨てる、の流れで進行します。"
   },
-  "cardInGroup": "{{card}}（グループ{{group}}に追加済み）"
+  "cardInGroup": "{{card}}（グループ{{group}}に追加済み）",
+  "frontendHint": {
+    "kalookiTakeDiscard": "捨て札が手札と繋がります。拾いましょう",
+    "kalookiDrawStock": "捨て札は手札と繋がりません。山から引きましょう",
+    "kalookiDiscardHeavy": "繋がっていない札のうち一番重い札です",
+    "kalookiOpenFirst": "まだ開いていません。規定点を一度に満たす組を作りましょう"
+  }
 }

--- a/frontend/src/pages/KalookiPage.test.tsx
+++ b/frontend/src/pages/KalookiPage.test.tsx
@@ -360,4 +360,19 @@ describe('KalookiPage', () => {
       expect(resetWithConfig.length).toBeGreaterThan(0);
     });
   });
+
+  // **ヒント経路はページ側からも踏む。**ファクトリ単体テストだけだと
+  // `hintFactories` の登録行と、ページのトグル／ツールチップが一度も
+  // 実行されない（#4596 / #4600 のレビュー指摘）。
+  it('turns the frontend hint on from the settings panel', async () => {
+    localStorage.clear();
+    mockExec.mockResolvedValue(drawState);
+    renderWithProviders(<KalookiPage />);
+
+    const toggle = await screen.findByRole('checkbox', { name: 'ヒント表示' });
+    expect(screen.queryByTestId('hint-tooltip')).not.toBeInTheDocument();
+
+    fireEvent.click(toggle);
+    expect(await screen.findByTestId('hint-tooltip')).toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/KalookiPage.tsx
+++ b/frontend/src/pages/KalookiPage.tsx
@@ -9,6 +9,7 @@ import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
+import { FrontendHintTooltip } from '../components/hint/FrontendHintTooltip';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { withTutorial } from '../components/tutorial/withTutorial';
@@ -16,6 +17,7 @@ import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
+import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useMountReset } from '../hooks/useMountReset';
 import { usePhaseNames } from '../hooks/usePhaseNames';
@@ -28,6 +30,7 @@ import { cardAlt } from '../utils/cardAlt';
 import { KALOOKI_HELP, parseKalookiCommand } from '../utils/cli/commands/kalookiCommands';
 import { formatKalookiState } from '../utils/cli/formatters/kalookiFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { hintCheckboxItem } from '../utils/settingsItems';
 
 /** Phase identifiers for Kalooki (sync: internal/domain/Kalooki.go). */
 const KALOOKI_PHASE = {
@@ -219,6 +222,14 @@ function KalookiPageContent() {
     return phaseNames[state.phase] ?? '';
   }, [phaseNames, state]);
 
+  // **フックは早期 return より上。**`if (!state)` の下に置くと、初回レンダー
+  // だけフック数が変わってページが骨組みのまま固まる (#4561)。
+  const {
+    hint: frontendHint,
+    hintEnabled: frontendHintEnabled,
+    setHintEnabled: setFrontendHintEnabled,
+  } = useGameHint('kalooki', state);
+
   if (!state) {
     return (
       <GameSkeleton gameKey="kalooki" layout={{ kind: 'card-grid', count: 13, cols: 'repeat(13, minmax(0, 1fr))' }} />
@@ -275,6 +286,7 @@ function KalookiPageContent() {
                     options: OPENING_THRESHOLD_OPTIONS.map((v) => ({ value: v, label: String(v) })),
                     onSelect: (v) => handleConfigChange('openingThreshold', v),
                   },
+                  hintCheckboxItem(tc, frontendHintEnabled, setFrontendHintEnabled),
                 ],
               },
             ]}
@@ -452,6 +464,8 @@ function KalookiPageContent() {
               </section>
             )}
           </div>
+
+          <FrontendHintTooltip hint={frontendHint} enabled={frontendHintEnabled} t={t} />
 
           <section className="px-4 py-2 flex flex-wrap gap-2" data-tutorial="kalooki-actions">
             {isDrawPhase && (

--- a/frontend/src/utils/hints/kalookiHint.test.ts
+++ b/frontend/src/utils/hints/kalookiHint.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+import type { Card, KalookiResponse } from '../../types/card';
+import { getKalookiHint } from './kalookiHint';
+
+const card = (design: Card['design'], value: number): Card => ({ design, value });
+
+type Extra = { hand?: Card[]; hasOpened?: boolean };
+
+function base({
+  hand = [card('SPADE', 3), card('HEART', 11)],
+  hasOpened = true,
+  ...overrides
+}: Partial<KalookiResponse> & Extra = {}) {
+  return {
+    players: [
+      {
+        id: 0,
+        isHuman: true,
+        cardCount: hand.length,
+        cards: hand,
+        melds: [],
+        hasOpened,
+        roundScore: 0,
+        cumulativeScore: 0,
+      },
+      {
+        id: 1,
+        isHuman: false,
+        cardCount: 13,
+        cards: [],
+        melds: [],
+        hasOpened: false,
+        roundScore: 0,
+        cumulativeScore: 0,
+      },
+    ],
+    phase: 1,
+    openingThreshold: 51,
+    currentPlayerIdx: 0,
+    discardTop: card('CLOVER', 9),
+    drawPileCount: 20,
+    gameEndFlag: false,
+    winnerIdx: -1,
+    roundWinnerIdx: -1,
+    message: '',
+    config: { cpuDifficulty: 1, targetScore: 150 },
+    ...overrides,
+  } as KalookiResponse;
+}
+
+describe('getKalookiHint', () => {
+  it('stays quiet once the game is over', () => {
+    expect(getKalookiHint(base({ gameEndFlag: true }))).toBeNull();
+  });
+
+  it('stays quiet when another seat is on turn', () => {
+    expect(getKalookiHint(base({ currentPlayerIdx: 1 }))).toBeNull();
+  });
+
+  it('stays quiet between rounds', () => {
+    expect(getKalookiHint(base({ phase: 2 }))).toBeNull();
+  });
+
+  it('takes a discard that matches a rank in hand', () => {
+    const hand = [card('SPADE', 9), card('HEART', 2)];
+    const s = base({ phase: 0, hand, discardTop: card('CLOVER', 9) });
+    expect(getKalookiHint(s)).toEqual({
+      targetAction: 'takeDiscard',
+      reason: 'frontendHint.kalookiTakeDiscard',
+      confidence: 'moderate',
+    });
+  });
+
+  it('draws from the stock when the discard connects with nothing', () => {
+    const hand = [card('SPADE', 2), card('HEART', 5)];
+    const s = base({ phase: 0, hand, discardTop: card('CLOVER', 9) });
+    expect(getKalookiHint(s)?.targetAction).toBe('drawStock');
+  });
+
+  it('draws from the stock when there is nothing to take', () => {
+    expect(getKalookiHint(base({ phase: 0, discardTop: null }))?.targetAction).toBe('drawStock');
+  });
+
+  // **開く前は崩さない。**規定点を一度に満たす必要があり、重い札こそ材料になる。
+  it('tells an unopened player to build the opening meld', () => {
+    expect(getKalookiHint(base({ hasOpened: false }))).toEqual({
+      targetAction: 'meld',
+      reason: 'frontendHint.kalookiOpenFirst',
+      confidence: 'moderate',
+    });
+  });
+
+  it('discards the heaviest loose card once opened', () => {
+    const hand = [card('SPADE', 3), card('SPADE', 4), card('HEART', 11), card('DIAMOND', 2)];
+    expect(getKalookiHint(base({ hand }))).toEqual({
+      targetAction: 'card-2',
+      reason: 'frontendHint.kalookiDiscardHeavy',
+      confidence: 'moderate',
+    });
+  });
+
+  // **札 0 も捨て札になりうる。**真偽値で見ると先頭だけ落ちる。
+  it('keeps a discard suggestion on card index 0', () => {
+    const hand = [card('HEART', 12), card('SPADE', 3), card('SPADE', 4)];
+    expect(getKalookiHint(base({ hand }))?.targetAction).toBe('card-0');
+  });
+
+  it('falls back to the heaviest card when everything connects', () => {
+    const hand = [card('SPADE', 3), card('SPADE', 4), card('SPADE', 5)];
+    expect(getKalookiHint(base({ hand }))?.targetAction).toBe('card-2');
+  });
+
+  it('stays quiet without a visible hand', () => {
+    expect(getKalookiHint(base({ hand: [] }))).toBeNull();
+  });
+});

--- a/frontend/src/utils/hints/kalookiHint.ts
+++ b/frontend/src/utils/hints/kalookiHint.ts
@@ -1,0 +1,75 @@
+import type { Card, KalookiResponse } from '../../types/card';
+import type { HintResult } from '../../types/hint';
+
+/**
+ * フェーズ番号 (sync: internal/domain/Kalooki.go)。
+ *
+ * `KalookiPhase` は `types/phases.ts` に無く、`KalookiPage` がページ内で
+ * 同じ表を持っている。ここから import すると循環するので、同期先を明記して
+ * 持ち直している。
+ */
+const PHASE_DRAW = 0;
+const PHASE_MELD = 1;
+
+/**
+ * Returns a frontend {@link HintResult} for Kalooki, or null when no suggestion
+ * is available.
+ *
+ * `melds` on a player is what they have **laid down**, not what their hand could
+ * make, so this does not try to prove a meld in hand. It uses the same shallow
+ * "connects with something" test as Chinchón — same rank, or the neighbouring
+ * rank in the same suit — which is enough for the two decisions taken every
+ * turn without re-implementing the domain's meld detection.
+ *
+ * Before opening, the useful thing to say is different: the threshold has to be
+ * met in one go, so the hint says to keep building rather than to throw the
+ * heaviest card away.
+ */
+export function getKalookiHint(state: KalookiResponse): HintResult | null {
+  if (state.gameEndFlag) return null;
+
+  const human = state.players.find((p) => p.isHuman);
+  if (!human || human.cards.length === 0 || state.currentPlayerIdx !== human.id) return null;
+
+  if (state.phase === PHASE_DRAW) {
+    const top = state.discardTop;
+    return top && connects(top, human.cards)
+      ? { targetAction: 'takeDiscard', reason: 'frontendHint.kalookiTakeDiscard', confidence: 'moderate' }
+      : { targetAction: 'drawStock', reason: 'frontendHint.kalookiDrawStock', confidence: 'moderate' };
+  }
+
+  if (state.phase !== PHASE_MELD) return null;
+
+  // **開いていないうちは崩さない。**規定点を一度に満たす必要があるので、
+  // 重い札こそ組の材料になる。
+  if (!human.hasOpened) {
+    return { targetAction: 'meld', reason: 'frontendHint.kalookiOpenFirst', confidence: 'moderate' };
+  }
+
+  const idx = heaviestLoose(human.cards);
+  return { targetAction: `card-${idx}`, reason: 'frontendHint.kalookiDiscardHeavy', confidence: 'moderate' };
+}
+
+/** 同じランクがあるか、同じスートで隣のランクがあるか。メルドの証明ではない。 */
+function connects(c: Card, hand: Card[]): boolean {
+  return hand.some((o) => o.value === c.value || (o.design === c.design && Math.abs(o.value - c.value) === 1));
+}
+
+/**
+ * 繋がっていない札のうち一番重いものの位置。全部繋がっていれば一番重い札。
+ *
+ * 呼び出し側が手札の非空を確かめているので、必ず有効な位置を返す。
+ */
+function heaviestLoose(hand: Card[]): number {
+  const loose: number[] = [];
+  for (let i = 0; i < hand.length; i += 1) {
+    const rest = hand.filter((_, j) => j !== i);
+    if (!connects(hand[i], rest)) loose.push(i);
+  }
+  const pool = loose.length > 0 ? loose : hand.map((_, i) => i);
+  let best = pool[0];
+  for (const i of pool) {
+    if (hand[i].value > hand[best].value) best = i;
+  }
+  return best;
+}


### PR DESCRIPTION
## 概要

#4557 の 24 本目。

Refs #4557

## 開く前と開いた後で助言が逆になる

Kalooki は**規定点を一度に満たす**まで開けません。開いていない段階で「一番重い札を捨てましょう」と言うのは**逆効果**です——重い札こそ組の材料だからです。

| 状況 | 助言 |
|---|---|
| draw | 捨て札が繋がるなら take、繋がらなければ stock |
| meld・**未開き** | **組を作る**（捨てない） |
| meld・開き済み | 繋がっていない札のうち一番重いもの |

## melds は「場に出した組」

`KalookiPlayer.melds` は**場に出したもの**で、手札が作れる組ではありません。したがってメルド判定はせず、Chinchón と同じ**浅い「繋がっているか」**（同ランク／同スート隣接）で判断します。

## フェーズ番号を持ち直している

`types/phases.ts` に `KalookiPhase` は無く、`KalookiPage` がページ内に同じ表を持っています。ページから import すると循環するので、**同期先をコメントに明記**して定数を持ち直しました。

## 負のコントロール

未開きの分岐を落とすと **11 件中 1 件 FAIL**。ファクトリは未到達分岐ゼロ。

## 確認

- `bun run check` → `237 of 259 games hinted; 22 still owed`
- `bun run typecheck` green
- `KalookiPage.test.tsx` 26 件 green（ページ側のヒント経路テスト込み）

## Test plan

- [ ] CI 全ジョブ green