### PR TITLE
feat(hints): wire the frontend hint for Three Thirteen (#4557)

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -171,7 +171,7 @@ match on the code if you ever script against tsc output.
 | `TutorialProvider` | `src/providers/TutorialProvider.tsx` | Context provider; renders overlay (used internally by TutorialWrapper) |
 | `TutorialOverlay` | `src/components/tutorial/TutorialOverlay.tsx` | Full-screen overlay with SVG mask spotlight |
 | `useTutorial` | `src/hooks/useTutorial.ts` | State management (step progression, localStorage, resume/restart) |
-| `useGameHint` | `src/hooks/useGameHint.ts` | Frontend hints; registry-driven via `hintFactories` (covers most games; currently 237). `frontend/scripts/check-hint-coverage.mjs` fails the build for any new game without one. The supported set is the `HintGameName` union (`keyof typeof hintFactories`) — add a game by registering its factory there |
+| `useGameHint` | `src/hooks/useGameHint.ts` | Frontend hints; registry-driven via `hintFactories` (covers most games; currently 239). `frontend/scripts/check-hint-coverage.mjs` fails the build for any new game without one. The supported set is the `HintGameName` union (`keyof typeof hintFactories`) — add a game by registering its factory there |
 | `TutorialSuggestDialog` | `src/components/tutorial/TutorialSuggestDialog.tsx` | First-visit dialog; controlled by `useFirstVisit` hook |
 | `TutorialProgressPanel` | `src/components/tutorial/TutorialProgressPanel.tsx` | Progress overview in NavBar |
 

--- a/frontend/scripts/check-hint-coverage.mjs
+++ b/frontend/scripts/check-hint-coverage.mjs
@@ -68,7 +68,6 @@ const BACKLOG = new Set([
   'pishti',
   'scopone',
   'sixbidsolo',
-  'threethirteen',
   'vint',
 ]);
 

--- a/frontend/src/hooks/useGameHint.ts
+++ b/frontend/src/hooks/useGameHint.ts
@@ -192,6 +192,7 @@ import type {
   ThirtyOneResponse,
   ThreeCardBragResponse,
   ThreeCardResponse,
+  ThreeThirteenResponse,
   TichuResponse,
   TienLenResponse,
   ToepenResponse,
@@ -417,6 +418,7 @@ import { getTexasHoldemBonusHint } from '../utils/hints/texasHoldemBonusHint';
 import { getThirtyOneHint } from '../utils/hints/thirtyoneHint';
 import { getThreeCardBragHint } from '../utils/hints/threeCardBragHint';
 import { getThreeCardHint } from '../utils/hints/threecardHint';
+import { getThreeThirteenHint } from '../utils/hints/threethirteenHint';
 import { getTichuHint } from '../utils/hints/tichuHint';
 import { getTienLenHint } from '../utils/hints/tienlenHint';
 import { getToepenHint } from '../utils/hints/toepenHint';
@@ -485,6 +487,7 @@ export const hintFactories = {
   jass: (s) => getJassHint(s as JassResponse),
   gaigel: (s) => getGaigelHint(s as GaigelResponse),
   bigtwo: (s) => getBigTwoHint(s as BigTwoResponse),
+  threethirteen: (s) => getThreeThirteenHint(s as ThreeThirteenResponse),
   tienlen: (s) => getTienLenHint(s as TienLenResponse),
   zheng: (s) => getZhengHint(s as ZhengResponse),
   fivehundred: (s) => getFiveHundredHint(s as FiveHundredResponse),

--- a/frontend/src/i18n/locales/en/threethirteen.json
+++ b/frontend/src/i18n/locales/en/threethirteen.json
@@ -48,5 +48,10 @@
     "knockButton": "When your whole hand melds, pick the card to discard and knock.",
     "scoreTable": "Player scores are shown here. The lowest cumulative score wins.",
     "resetButton": "Press the reset button to start a new game."
+  },
+  "frontendHint": {
+    "threethirteenTakeDiscard": "The discard connects with your hand — take it",
+    "threethirteenDrawStock": "The discard is no use — draw from the stock",
+    "threethirteenDiscardHeavy": "Your heaviest unconnected card, wilds excluded"
   }
 }

--- a/frontend/src/i18n/locales/ja/threethirteen.json
+++ b/frontend/src/i18n/locales/ja/threethirteen.json
@@ -48,5 +48,10 @@
     "knockButton": "手札がすべてメルドになったら、捨てるカードを選んでノックできます。",
     "scoreTable": "各プレイヤーのスコアが表示されます。最終的に累計が最少の人が勝ちです。",
     "resetButton": "リセットボタンで新しいゲームを始められます。"
+  },
+  "frontendHint": {
+    "threethirteenTakeDiscard": "捨て札が手札と繋がります。拾いましょう",
+    "threethirteenDrawStock": "捨て札は使えません。山から引きましょう",
+    "threethirteenDiscardHeavy": "繋がっていない札のうち一番重い札です（ワイルドは残します）"
   }
 }

--- a/frontend/src/pages/ThreeThirteenPage.test.tsx
+++ b/frontend/src/pages/ThreeThirteenPage.test.tsx
@@ -321,4 +321,19 @@ describe('ThreeThirteenPage', () => {
     await waitFor(() => expect(actionLogApi.threethirteen).toHaveBeenCalledTimes(1));
     expect(screen.getByText('棋譜')).toBeInTheDocument();
   });
+
+  // **ヒント経路はページ側からも踏む。**ファクトリ単体テストだけだと
+  // `hintFactories` の登録行と、ページのトグル／ツールチップが一度も
+  // 実行されない（#4596 / #4600 のレビュー指摘）。
+  it('turns the frontend hint on from the settings panel', async () => {
+    localStorage.clear();
+    mockExec.mockResolvedValue(drawPhaseState);
+    renderWithProviders(<ThreeThirteenPage />);
+
+    const toggle = await screen.findByRole('checkbox', { name: 'ヒント表示' });
+    expect(screen.queryByTestId('hint-tooltip')).not.toBeInTheDocument();
+
+    fireEvent.click(toggle);
+    expect(await screen.findByTestId('hint-tooltip')).toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/ThreeThirteenPage.tsx
+++ b/frontend/src/pages/ThreeThirteenPage.tsx
@@ -10,6 +10,7 @@ import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
+import { FrontendHintTooltip } from '../components/hint/FrontendHintTooltip';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { withTutorial } from '../components/tutorial/withTutorial';
@@ -17,6 +18,7 @@ import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCardKeyboardNav } from '../hooks/useCardKeyboardNav';
 import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
+import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { CPU_DIFFICULTY_OPTIONS, PLAYER_COUNT_OPTIONS, useThreeThirteenGame } from '../hooks/useThreeThirteenGame';
@@ -32,6 +34,7 @@ import { parseThreeThirteenCommand, THREETHIRTEEN_HELP } from '../utils/cli/comm
 import { formatThreeThirteenState } from '../utils/cli/formatters/threethirteenFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
 import { playerName } from '../utils/playerUtils';
+import { hintCheckboxItem } from '../utils/settingsItems';
 import { bestThreeThirteenDeadwoodValue, bestThreeThirteenDiscardValue } from '../utils/threethirteenDeadwood';
 
 const THREETHIRTEEN_PHASE_KEYS: Readonly<Record<number, string>> = {
@@ -161,6 +164,14 @@ function ThreeThirteenPageContent() {
     return bestThreeThirteenDiscardValue(cards, state.wildRank);
   }, [state, selectedCardIndices]);
 
+  // **フックは早期 return より上。**`if (!state)` の下に置くと、初回レンダー
+  // だけフック数が変わってページが骨組みのまま固まる (#4561)。
+  const {
+    hint: frontendHint,
+    hintEnabled: frontendHintEnabled,
+    setHintEnabled: setFrontendHintEnabled,
+  } = useGameHint('threethirteen', state);
+
   if (!state)
     return (
       <GameSkeleton
@@ -235,6 +246,7 @@ function ThreeThirteenPageContent() {
                     options: PLAYER_COUNT_OPTIONS.map((v) => ({ value: v, label: String(v) })),
                     onSelect: (v) => handleConfigChange('playerCount', v),
                   },
+                  hintCheckboxItem(tc, frontendHintEnabled, setFrontendHintEnabled),
                 ],
               },
             ]}
@@ -389,6 +401,8 @@ function ThreeThirteenPageContent() {
                   </button>
                 </div>
               )}
+              <FrontendHintTooltip hint={frontendHint} enabled={frontendHintEnabled} t={t} />
+
               {isDiscardPhase && isHumanTurn && (
                 <>
                   <button

--- a/frontend/src/utils/hints/threethirteenHint.test.ts
+++ b/frontend/src/utils/hints/threethirteenHint.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import type { Card, ThreeThirteenResponse } from '../../types/card';
+import { ThreeThirteenPhase } from '../../types/phases';
+import { getThreeThirteenHint } from './threethirteenHint';
+
+const card = (design: Card['design'], value: number): Card => ({ design, value });
+
+type Extra = { hand?: Card[] };
+
+function base({
+  hand = [card('SPADE', 4), card('HEART', 12)],
+  ...overrides
+}: Partial<ThreeThirteenResponse> & Extra = {}) {
+  return {
+    players: [
+      { id: 0, isHuman: true, cardCount: hand.length, cards: hand, deadwood: 0, roundScore: 0, cumulativeScore: 0 },
+      { id: 1, isHuman: false, cardCount: 5, cards: [], deadwood: 0, roundScore: 0, cumulativeScore: 0 },
+    ],
+    phase: ThreeThirteenPhase.DISCARD,
+    round: 1,
+    wildRank: 3,
+    dealCount: 5,
+    currentPlayerIdx: 0,
+    knockerIdx: -1,
+    discardTop: card('CLOVER', 9),
+    drawPileCount: 20,
+    gameEndFlag: false,
+    winnerIdx: -1,
+    message: '',
+    config: { cpuDifficulty: 1 },
+    ...overrides,
+  } as ThreeThirteenResponse;
+}
+
+describe('getThreeThirteenHint', () => {
+  it('stays quiet once the game is over', () => {
+    expect(getThreeThirteenHint(base({ gameEndFlag: true }))).toBeNull();
+  });
+
+  it('stays quiet when another seat is on turn', () => {
+    expect(getThreeThirteenHint(base({ currentPlayerIdx: 1 }))).toBeNull();
+  });
+
+  it('stays quiet between rounds', () => {
+    expect(getThreeThirteenHint(base({ phase: ThreeThirteenPhase.ROUND_END }))).toBeNull();
+  });
+
+  it('takes a discard that connects with the hand', () => {
+    const hand = [card('SPADE', 9), card('HEART', 12)];
+    const s = base({ phase: ThreeThirteenPhase.DRAW, hand, discardTop: card('CLOVER', 9) });
+    expect(getThreeThirteenHint(s)).toEqual({
+      targetAction: 'takeDiscard',
+      reason: 'frontendHint.threethirteenTakeDiscard',
+      confidence: 'moderate',
+    });
+  });
+
+  // **ワイルドは何にでもなる。**繋がっていなくても拾う価値がある。
+  it('takes a wild discard even when nothing in hand touches it', () => {
+    const hand = [card('SPADE', 9), card('HEART', 12)];
+    const s = base({ phase: ThreeThirteenPhase.DRAW, hand, wildRank: 5, discardTop: card('CLOVER', 5) });
+    expect(getThreeThirteenHint(s)?.targetAction).toBe('takeDiscard');
+  });
+
+  it('draws from the stock when the discard is no use', () => {
+    const hand = [card('SPADE', 9), card('HEART', 12)];
+    const s = base({ phase: ThreeThirteenPhase.DRAW, hand, wildRank: 5, discardTop: card('CLOVER', 2) });
+    expect(getThreeThirteenHint(s)?.targetAction).toBe('drawStock');
+  });
+
+  it('discards the heaviest loose card', () => {
+    const hand = [card('SPADE', 6), card('SPADE', 7), card('HEART', 13), card('DIAMOND', 2)];
+    expect(getThreeThirteenHint(base({ hand }))).toEqual({
+      targetAction: 'card-2',
+      reason: 'frontendHint.threethirteenDiscardHeavy',
+      confidence: 'moderate',
+    });
+  });
+
+  // **ワイルドは捨てない。**一番重くても候補から外す。
+  it('never suggests discarding a wild card', () => {
+    const hand = [card('SPADE', 13), card('HEART', 4)];
+    expect(getThreeThirteenHint(base({ hand, wildRank: 13 }))?.targetAction).toBe('card-1');
+  });
+
+  // **札 0 も捨て札になりうる。**真偽値で見ると先頭だけ落ちる。
+  it('keeps a discard suggestion on card index 0', () => {
+    const hand = [card('HEART', 13), card('SPADE', 6), card('SPADE', 7)];
+    expect(getThreeThirteenHint(base({ hand }))?.targetAction).toBe('card-0');
+  });
+
+  it('falls back to the heaviest non-wild card when everything connects', () => {
+    const hand = [card('SPADE', 6), card('SPADE', 7), card('SPADE', 8)];
+    expect(getThreeThirteenHint(base({ hand }))?.targetAction).toBe('card-2');
+  });
+
+  // 手札が全部ワイルドなら捨てる先がない。
+  it('stays quiet when every card is wild', () => {
+    const hand = [card('SPADE', 3), card('HEART', 3)];
+    expect(getThreeThirteenHint(base({ hand, wildRank: 3 }))).toBeNull();
+  });
+
+  it('stays quiet without a visible hand', () => {
+    expect(getThreeThirteenHint(base({ hand: [] }))).toBeNull();
+  });
+});

--- a/frontend/src/utils/hints/threethirteenHint.ts
+++ b/frontend/src/utils/hints/threethirteenHint.ts
@@ -1,0 +1,71 @@
+import type { Card, ThreeThirteenResponse } from '../../types/card';
+import type { HintResult } from '../../types/hint';
+import { ThreeThirteenPhase } from '../../types/phases';
+
+/**
+ * Returns a frontend {@link HintResult} for Three Thirteen, or null when no
+ * suggestion is available.
+ *
+ * The response carries `deadwood` per player but not the melds behind it, so
+ * this does not try to prove a meld. It uses the same shallow
+ * "connects with something" test as the other rummies — same rank, or the
+ * neighbouring rank in the same suit.
+ *
+ * The round's `wildRank` is the piece specific to this game: a wild card
+ * substitutes for anything, so it is never the card to throw even when nothing
+ * in hand happens to touch it.
+ */
+export function getThreeThirteenHint(state: ThreeThirteenResponse): HintResult | null {
+  if (state.gameEndFlag) return null;
+
+  const human = state.players.find((p) => p.isHuman);
+  if (!human || human.cards.length === 0 || state.currentPlayerIdx !== human.id) return null;
+
+  if (state.phase === ThreeThirteenPhase.DRAW) {
+    const top = state.discardTop;
+    return top && (top.value === state.wildRank || connects(top, human.cards))
+      ? { targetAction: 'takeDiscard', reason: 'frontendHint.threethirteenTakeDiscard', confidence: 'moderate' }
+      : { targetAction: 'drawStock', reason: 'frontendHint.threethirteenDrawStock', confidence: 'moderate' };
+  }
+
+  if (state.phase !== ThreeThirteenPhase.DISCARD) return null;
+
+  const idx = heaviestLoose(human.cards, state.wildRank);
+  // **捨てられる札が無い。**全部がワイルドか繋がっている手では黙る。
+  if (idx < 0) return null;
+  return { targetAction: `card-${idx}`, reason: 'frontendHint.threethirteenDiscardHeavy', confidence: 'moderate' };
+}
+
+/** 同じランクがあるか、同じスートで隣のランクがあるか。メルドの証明ではない。 */
+function connects(c: Card, hand: Card[]): boolean {
+  return hand.some((o) => o.value === c.value || (o.design === c.design && Math.abs(o.value - c.value) === 1));
+}
+
+/**
+ * 捨てるべき札の位置。ワイルドは何にでもなるので候補から外す。
+ *
+ * 繋がっていない札があればその中で一番重いもの、無ければワイルド以外で
+ * 一番重いもの。候補がまったく無ければ -1。
+ */
+function heaviestLoose(hand: Card[], wildRank: number): number {
+  const candidates: number[] = [];
+  for (let i = 0; i < hand.length; i += 1) {
+    if (hand[i].value === wildRank) continue;
+    candidates.push(i);
+  }
+  if (candidates.length === 0) return -1;
+
+  const loose = candidates.filter(
+    (i) =>
+      !connects(
+        hand[i],
+        hand.filter((_, j) => j !== i),
+      ),
+  );
+  const pool = loose.length > 0 ? loose : candidates;
+  let best = pool[0];
+  for (const i of pool) {
+    if (hand[i].value > hand[best].value) best = i;
+  }
+  return best;
+}


### PR DESCRIPTION
## 概要

#4557 の 27 本目。

Refs #4557

## ワイルドランクがこのゲーム固有の要点

各ラウンドの `wildRank` は何にでもなる札です。したがって:

| 状況 | 助言 |
|---|---|
| 捨て札が**ワイルド** | **拾う**（手札と繋がっていなくても） |
| 捨て札が繋がる | 拾う |
| それ以外 | 山から引く |
| 捨てるとき | 繋がっていない札のうち一番重いもの。**ワイルドは候補から外す** |

**一番重くてもワイルドは捨てません。**手札が全部ワイルドなら捨てる先が無いので、何も言いません（`null`）。

## メルド判定はしない

`deadwood` は届きますが、その裏のメルドは届きません。他のラミー系と同じ**浅い「繋がっているか」**判定に留めています。

## 負のコントロール

ワイルド除外を外すと **12 件中 2 件 FAIL**。ファクトリは未到達分岐ゼロ。

## 確認

- `bun run check` → `239 of 259 games hinted; 20 still owed`
- `bun run typecheck` green
- `ThreeThirteenPage.test.tsx` 23 件 green（ページ側のヒント経路テスト込み）

## Test plan

- [ ] CI 全ジョブ green