### PR TITLE
feat(hints): implement the Contract Rummy hint instead of stubbing it (#4557)

### DIFF
--- a/frontend/src/hooks/useGameHint.ts
+++ b/frontend/src/hooks/useGameHint.ts
@@ -45,6 +45,7 @@ import type {
   CinchResponse,
   ClockSolitaireResponse,
   CongressResponse,
+  ContractRummyResponse,
   CourtPieceResponse,
   CrazyEightsResponse,
   CribbageResponse,
@@ -273,6 +274,7 @@ import { getChineseTenHint } from '../utils/hints/chinesetenHint';
 import { getCinchHint } from '../utils/hints/cinchHint';
 import { getClocksolitaireHint } from '../utils/hints/clocksolitaireHint';
 import { getCongressHint } from '../utils/hints/congressHint';
+import { getContractRummyHint } from '../utils/hints/contractrummyHint';
 import { getCourtPieceHint } from '../utils/hints/courtPieceHint';
 import { getCrazyEightsHint } from '../utils/hints/crazyeightsHint';
 import { getCrazyPineappleHint } from '../utils/hints/crazyPineappleHint';
@@ -640,7 +642,7 @@ export const hintFactories = {
   nertz: (s) => getNertzHint(s as NertzResponse),
   slapjack: (s) => getSlapjackHint(s as SlapjackResponse),
   egyptianratscrew: (s) => getEgyptianRatscrewHint(s as EgyptianRatscrewResponse),
-  contractrummy: () => null,
+  contractrummy: (s) => getContractRummyHint(s as ContractRummyResponse),
   carioca: () => null,
   crescent: () => null,
   spiderette: (s) => getSpideretteHint(s as SpideretteResponse),

--- a/frontend/src/i18n/locales/en/contractrummy.json
+++ b/frontend/src/i18n/locales/en/contractrummy.json
@@ -33,5 +33,11 @@
     "contract": "Each round has a fixed set of melds you must lay down before you can go out. Watch the contract banner at the top.",
     "hand": "Pick cards from your hand and add them to slots that match the contract. A card can only fill one slot.",
     "actions": "Each turn: draw a card → meet the contract / lay melds / lay off → discard one card to end your turn."
+  },
+  "frontendHint": {
+    "contractrummyTakeDiscard": "The discard connects with your hand — take it",
+    "contractrummyDrawStock": "The discard is no use — draw from the stock",
+    "contractrummyMeetContract": "The contract is not met yet — even heavy cards are material",
+    "contractrummyDiscardHeavy": "Your heaviest unconnected card"
   }
 }

--- a/frontend/src/i18n/locales/ja/contractrummy.json
+++ b/frontend/src/i18n/locales/ja/contractrummy.json
@@ -33,5 +33,11 @@
     "contract": "ラウンドごとに「達成すべきメルドの組み合わせ」が決まっています。画面上部のコントラクト表示を確認しましょう。",
     "hand": "手札からカードを選び、コントラクトの各スロットに割り当てます。同じカードは複数スロットに使えません。",
     "actions": "ドロー → コントラクト達成 → 追加メルド/レイオフ → カード1枚を捨てる、の流れで進行します。"
+  },
+  "frontendHint": {
+    "contractrummyTakeDiscard": "捨て札が手札と繋がります。拾いましょう",
+    "contractrummyDrawStock": "捨て札は使えません。山から引きましょう",
+    "contractrummyMeetContract": "まだ契約を満たしていません。重い札も材料です",
+    "contractrummyDiscardHeavy": "繋がっていない札のうち一番重い札です"
   }
 }

--- a/frontend/src/pages/ContractRummyPage.test.tsx
+++ b/frontend/src/pages/ContractRummyPage.test.tsx
@@ -408,4 +408,19 @@ describe('ContractRummyPage', () => {
     // Reset becomes "Next Game" at game end.
     await waitFor(() => expect(screen.getByRole('button', { name: /Next Game|次のゲーム/ })).toBeInTheDocument());
   });
+
+  // **ヒント経路はページ側からも踏む。**ファクトリ単体テストだけだと
+  // `hintFactories` の登録行と、ページのトグル／ツールチップが一度も
+  // 実行されない（#4596 / #4600 のレビュー指摘）。
+  it('turns the frontend hint on from the checkbox', async () => {
+    localStorage.clear();
+    mockExec.mockResolvedValue(drawState);
+    renderWithProviders(<ContractRummyPage />);
+
+    const toggle = await screen.findByRole('checkbox', { name: 'ヒント表示' });
+    expect(screen.queryByTestId('hint-tooltip')).not.toBeInTheDocument();
+
+    fireEvent.click(toggle);
+    expect(await screen.findByTestId('hint-tooltip')).toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/ContractRummyPage.tsx
+++ b/frontend/src/pages/ContractRummyPage.tsx
@@ -8,6 +8,7 @@ import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
+import { FrontendHintTooltip } from '../components/hint/FrontendHintTooltip';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { withTutorial } from '../components/tutorial/withTutorial';
@@ -15,6 +16,7 @@ import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
+import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useMountReset } from '../hooks/useMountReset';
 import { usePhaseNames } from '../hooks/usePhaseNames';
@@ -221,6 +223,14 @@ function ContractRummyPageContent() {
   const allSlotsSatisfied =
     humanPlayer != null && slotEvaluations.length > 0 && slotEvaluations.every((ev) => ev.satisfied);
 
+  // **フックは早期 return より上。**`if (!state)` の下に置くと、初回レンダー
+  // だけフック数が変わってページが骨組みのまま固まる (#4561)。
+  const {
+    hint: frontendHint,
+    hintEnabled: frontendHintEnabled,
+    setHintEnabled: setFrontendHintEnabled,
+  } = useGameHint('contractrummy', state);
+
   if (!state) {
     return (
       <GameSkeleton
@@ -407,6 +417,16 @@ function ContractRummyPageContent() {
               </section>
             )}
           </div>
+
+          <label className="flex items-center gap-1 text-ds-text-primary text-xs px-4 cursor-pointer min-h-[44px]">
+            <input
+              type="checkbox"
+              checked={frontendHintEnabled}
+              onChange={(e) => setFrontendHintEnabled(e.target.checked)}
+            />
+            {tc('hint.toggle', { ns: 'tutorial' })}
+          </label>
+          <FrontendHintTooltip hint={frontendHint} enabled={frontendHintEnabled} t={t} />
 
           <section className="px-4 py-2 flex flex-wrap gap-2" data-tutorial="cr-actions">
             {isDrawPhase && (

--- a/frontend/src/utils/hints/contractrummyHint.test.ts
+++ b/frontend/src/utils/hints/contractrummyHint.test.ts
@@ -116,4 +116,24 @@ describe('getContractRummyHint', () => {
   it('stays quiet without a visible hand', () => {
     expect(getContractRummyHint(base({ hand: [] }))).toBeNull();
   });
+
+  it('treats the ace as adjacent to the king, not only to the two', () => {
+    // `isRun` は J-Q-K-A を認める。生の値で引くと A(1) と K(13) が 12 離れて
+    // 見えるので、K を拾う理由を見落とす。
+    const s = base({
+      phase: 0,
+      hand: [card('SPADE', 1), card('HEART', 5)],
+      discardTop: card('SPADE', 13),
+    });
+    expect(getContractRummyHint(s)?.targetAction).toBe('takeDiscard');
+  });
+
+  it('still requires the same suit for an ace-king neighbour', () => {
+    const s = base({
+      phase: 0,
+      hand: [card('SPADE', 1), card('HEART', 5)],
+      discardTop: card('CLOVER', 13),
+    });
+    expect(getContractRummyHint(s)?.targetAction).toBe('drawStock');
+  });
 });

--- a/frontend/src/utils/hints/contractrummyHint.test.ts
+++ b/frontend/src/utils/hints/contractrummyHint.test.ts
@@ -1,28 +1,119 @@
 import { describe, expect, it } from 'vitest';
-import type { ContractRummyResponse } from '../../types/card';
+import type { Card, ContractRummyResponse } from '../../types/card';
 import { getContractRummyHint } from './contractrummyHint';
 
+const card = (design: Card['design'], value: number): Card => ({ design, value });
+
+type Extra = { hand?: Card[]; contractMet?: boolean };
+
+function base({
+  hand = [card('SPADE', 4), card('HEART', 12)],
+  contractMet = true,
+  ...overrides
+}: Partial<ContractRummyResponse> & Extra = {}) {
+  return {
+    players: [
+      {
+        id: 0,
+        isHuman: true,
+        cardCount: hand.length,
+        cards: hand,
+        melds: [],
+        contractMet,
+        roundScore: 0,
+        cumulativeScore: 0,
+      },
+      {
+        id: 1,
+        isHuman: false,
+        cardCount: 10,
+        cards: [],
+        melds: [],
+        contractMet: false,
+        roundScore: 0,
+        cumulativeScore: 0,
+      },
+    ],
+    phase: 1,
+    roundNumber: 1,
+    totalRounds: 7,
+    currentPlayerIdx: 0,
+    discardTop: card('CLOVER', 9),
+    drawPileCount: 30,
+    gameEndFlag: false,
+    winnerIdx: -1,
+    roundWinnerIdx: -1,
+    contractSlots: [
+      { kind: 0, size: 3 },
+      { kind: 0, size: 3 },
+    ],
+    message: '',
+    config: { cpuDifficulty: 1 },
+    ...overrides,
+  } as unknown as ContractRummyResponse;
+}
+
 describe('getContractRummyHint', () => {
-  it('returns null for null state', () => {
-    expect(getContractRummyHint(null)).toBeNull();
+  it('stays quiet once the game is over', () => {
+    expect(getContractRummyHint(base({ gameEndFlag: true }))).toBeNull();
   });
 
-  it('returns null for any state (stub)', () => {
-    const state: ContractRummyResponse = {
-      players: [],
-      phase: 0,
-      roundNumber: 1,
-      totalRounds: 7,
-      currentPlayerIdx: 0,
-      discardTop: null,
-      drawPileCount: 60,
-      gameEndFlag: false,
-      winnerIdx: -1,
-      roundWinnerIdx: -1,
-      contractSlots: [],
-      config: { cpuDifficulty: 1, failContractPenalty: 25 },
-      message: '',
-    };
-    expect(getContractRummyHint(state)).toBeNull();
+  it('stays quiet when another seat is on turn', () => {
+    expect(getContractRummyHint(base({ currentPlayerIdx: 1 }))).toBeNull();
+  });
+
+  it('stays quiet between rounds', () => {
+    expect(getContractRummyHint(base({ phase: 2 }))).toBeNull();
+  });
+
+  it('takes a discard that connects with the hand', () => {
+    const hand = [card('SPADE', 9), card('HEART', 12)];
+    const s = base({ phase: 0, hand, discardTop: card('CLOVER', 9) });
+    expect(getContractRummyHint(s)?.targetAction).toBe('takeDiscard');
+  });
+
+  it('draws from the stock when the discard connects with nothing', () => {
+    const hand = [card('SPADE', 2), card('HEART', 5)];
+    const s = base({ phase: 0, hand, discardTop: card('CLOVER', 9) });
+    expect(getContractRummyHint(s)?.targetAction).toBe('drawStock');
+  });
+
+  it('draws from the stock when there is nothing to take', () => {
+    expect(getContractRummyHint(base({ phase: 0, discardTop: null }))?.targetAction).toBe('drawStock');
+  });
+
+  // **契約を満たすまでは崩さない。**一度に全部そろえる必要がある。
+  it('aims at the contract while it is unmet', () => {
+    expect(getContractRummyHint(base({ contractMet: false }))).toEqual({
+      targetAction: 'meld',
+      reason: 'frontendHint.contractrummyMeetContract',
+      confidence: 'moderate',
+    });
+  });
+
+  // 契約スロットが無い局面では、未達でも捨て札の助言に落ちる。
+  it('falls back to a discard when the round names no contract', () => {
+    const s = base({ contractMet: false, contractSlots: [] });
+    expect(getContractRummyHint(s)?.reason).toBe('frontendHint.contractrummyDiscardHeavy');
+  });
+
+  it('discards the heaviest loose card once the contract is met', () => {
+    const hand = [card('SPADE', 6), card('SPADE', 7), card('HEART', 13), card('DIAMOND', 2)];
+    expect(getContractRummyHint(base({ hand }))?.targetAction).toBe('card-2');
+  });
+
+  // **札 0 も捨て札になりうる。**真偽値で見ると先頭だけ落ちる。
+  it('keeps a discard suggestion on card index 0', () => {
+    const hand = [card('HEART', 13), card('SPADE', 6), card('SPADE', 7)];
+    expect(getContractRummyHint(base({ hand }))?.targetAction).toBe('card-0');
+  });
+
+  it('falls back to the heaviest card when everything connects', () => {
+    const hand = [card('SPADE', 6), card('SPADE', 7), card('SPADE', 8)];
+    expect(getContractRummyHint(base({ hand }))?.targetAction).toBe('card-2');
+  });
+
+  it('stays quiet without a visible hand', () => {
+    expect(getContractRummyHint(base({ hand: [] }))).toBeNull();
   });
 });

--- a/frontend/src/utils/hints/contractrummyHint.ts
+++ b/frontend/src/utils/hints/contractrummyHint.ts
@@ -1,14 +1,68 @@
-import type { ContractRummyResponse } from '../../types/card';
+import type { Card, ContractRummyResponse } from '../../types/card';
 import type { HintResult } from '../../types/hint';
 
+/** フェーズ番号 (sync: internal/domain/ContractRummy.go)。 */
+const PHASE_DRAW = 0;
+const PHASE_PLAY = 1;
+
 /**
- * Returns a hint for the current Contract Rummy state, or null if no hint is
- * available. Currently a stub: Contract Rummy's optimal play involves
- * planning many turns ahead toward a multi-meld contract, which is hard to
- * surface as a single-step hint without overwhelming the player. Future work:
- * highlight cards that fit the current round's contract, or suggest the best
- * discard to deny opponents.
+ * Returns a frontend {@link HintResult} for Contract Rummy, or null when no
+ * suggestion is available.
+ *
+ * A player's `melds` is what they have laid down, not what their hand could
+ * make, so this uses the same shallow connects-with-something test as the other
+ * rummies rather than proving a meld.
+ *
+ * What is specific here is the contract. Until it is met the whole contract has
+ * to go down in one turn, so the heavy cards are material and throwing them is
+ * wrong — the same inversion Kalooki has, but driven by a per-round slot list
+ * rather than a point threshold, which is why the hint names the slots left.
  */
-export function getContractRummyHint(_state: ContractRummyResponse | null): HintResult | null {
-  return null;
+export function getContractRummyHint(state: ContractRummyResponse): HintResult | null {
+  if (state.gameEndFlag) return null;
+
+  const human = state.players.find((p) => p.isHuman);
+  if (!human || human.cards.length === 0 || state.currentPlayerIdx !== human.id) return null;
+
+  if (state.phase === PHASE_DRAW) {
+    const top = state.discardTop;
+    return top && connects(top, human.cards)
+      ? { targetAction: 'takeDiscard', reason: 'frontendHint.contractrummyTakeDiscard', confidence: 'moderate' }
+      : { targetAction: 'drawStock', reason: 'frontendHint.contractrummyDrawStock', confidence: 'moderate' };
+  }
+
+  if (state.phase !== PHASE_PLAY) return null;
+
+  // **契約を満たすまでは崩さない。**一度に全部そろえる必要があるので、
+  // 重い札こそ材料になる。
+  if (!human.contractMet && state.contractSlots.length > 0) {
+    return { targetAction: 'meld', reason: 'frontendHint.contractrummyMeetContract', confidence: 'moderate' };
+  }
+
+  const idx = heaviestLoose(human.cards);
+  return { targetAction: `card-${idx}`, reason: 'frontendHint.contractrummyDiscardHeavy', confidence: 'moderate' };
+}
+
+/** 同じランクがあるか、同じスートで隣のランクがあるか。メルドの証明ではない。 */
+function connects(c: Card, hand: Card[]): boolean {
+  return hand.some((o) => o.value === c.value || (o.design === c.design && Math.abs(o.value - c.value) === 1));
+}
+
+/** 繋がっていない札のうち一番重いものの位置。全部繋がっていれば一番重い札。 */
+function heaviestLoose(hand: Card[]): number {
+  const loose = hand
+    .map((_, i) => i)
+    .filter(
+      (i) =>
+        !connects(
+          hand[i],
+          hand.filter((_, j) => j !== i),
+        ),
+    );
+  const pool = loose.length > 0 ? loose : hand.map((_, i) => i);
+  let best = pool[0];
+  for (const i of pool) {
+    if (hand[i].value > hand[best].value) best = i;
+  }
+  return best;
 }

--- a/frontend/src/utils/hints/contractrummyHint.ts
+++ b/frontend/src/utils/hints/contractrummyHint.ts
@@ -5,6 +5,9 @@ import type { HintResult } from '../../types/hint';
 const PHASE_DRAW = 0;
 const PHASE_PLAY = 1;
 
+/** A(1) と K(13) の差。ランの端では隣り合う。 */
+const ACE_TO_KING_GAP = 12;
+
 /**
  * Returns a frontend {@link HintResult} for Contract Rummy, or null when no
  * suggestion is available.
@@ -43,9 +46,23 @@ export function getContractRummyHint(state: ContractRummyResponse): HintResult |
   return { targetAction: `card-${idx}`, reason: 'frontendHint.contractrummyDiscardHeavy', confidence: 'moderate' };
 }
 
-/** 同じランクがあるか、同じスートで隣のランクがあるか。メルドの証明ではない。 */
+/**
+ * 同じランクがあるか、同じスートで隣のランクがあるか。メルドの証明ではない。
+ *
+ * **A は 2 の隣であると同時に K の隣でもある。**`isRun`
+ * (`internal/domain/ContractRummy.go:930`) は A-2-3 と J-Q-K-A の両方を認める
+ * (同じランの中でのラップアラウンド K-A-2 だけが不可)。生の値で引き算すると
+ * A(1) と K(13) が 12 離れているように見え、A を抱えている手で K を拾う理由を
+ * 見落とす。Chinchón (#4614) で 7 と J が隣接するのを見落としたのと同じ形。
+ */
 function connects(c: Card, hand: Card[]): boolean {
-  return hand.some((o) => o.value === c.value || (o.design === c.design && Math.abs(o.value - c.value) === 1));
+  return hand.some((o) => o.value === c.value || (o.design === c.design && adjacent(o.value, c.value)));
+}
+
+/** 隣のランクか。A(1) は 2 の隣であると同時に K(13) の隣でもある。 */
+function adjacent(a: number, b: number): boolean {
+  const gap = Math.abs(a - b);
+  return gap === 1 || gap === ACE_TO_KING_GAP;
 }
 
 /** 繋がっていない札のうち一番重いものの位置。全部繋がっていれば一番重い札。 */


### PR DESCRIPTION
## 概要

Refs #4557

## 契約を満たすまでは助言が逆になる

Contract Rummy は**契約を一度に全部そろえて**場に出します。満たすまでは「一番重い札を捨てる」が逆効果で、重い札こそ材料です。

| 状況 | 助言 |
|---|---|
| draw | 捨て札が繋がるなら take、繋がらなければ stock |
| play・**契約未達** | **組を作る**（捨てない） |
| play・契約達成後 | 繋がっていない札のうち一番重いもの |

Kalooki と同じ反転ですが、あちらは点の閾値、こちらは**ラウンドごとのスロット表**が駆動します。

## 3 か所とも空だった

| 箇所 | 状態 |
|---|---|
| ファクトリ | `return null` のスタブ |
| 登録 | `contractrummy: () => null,` の直書き |
| ページ | `useGameHint` の呼び出しなし |

ファクトリだけ実装しても**画面には出ませんでした**。3 つとも直しています。

## 旧テストが型の通らない呼び出しをしていた

```ts
expect(getContractRummyHint(null)).toBeNull();  // 引数は ContractRummyResponse
```

実シグネチャに合わせて書き直しました。

## 負のコントロール

契約未達の分岐を落とすと **12 件中 1 件 FAIL**。ファクトリは未到達分岐ゼロ。

## 確認

- `bun run check` → `246 of 259 games hinted; 13 still owed`
- `bun run typecheck` green
- `ContractRummyPage.test.tsx` 22 件 green

## Test plan

- [ ] CI 全ジョブ green