### PR TITLE
fix(hint): treat the ace as adjacent to the king in Kalooki and Three Thirteen

### DIFF
--- a/frontend/src/utils/hints/kalookiHint.test.ts
+++ b/frontend/src/utils/hints/kalookiHint.test.ts
@@ -113,4 +113,24 @@ describe('getKalookiHint', () => {
   it('stays quiet without a visible hand', () => {
     expect(getKalookiHint(base({ hand: [] }))).toBeNull();
   });
+
+  it('treats the ace as adjacent to the king, not only to the two', () => {
+    // ドメインは Ace-high のランを認める。生の値で引くと A(1) と K(13) が
+    // 12 離れて見えるので、K を拾う理由を見落とす。
+    const s = base({
+      phase: 0,
+      hand: [card('SPADE', 1), card('HEART', 5)],
+      discardTop: card('SPADE', 13),
+    });
+    expect(getKalookiHint(s)?.targetAction).toBe('takeDiscard');
+  });
+
+  it('still requires the same suit for an ace-king neighbour', () => {
+    const s = base({
+      phase: 0,
+      hand: [card('SPADE', 1), card('HEART', 5)],
+      discardTop: card('CLOVER', 13),
+    });
+    expect(getKalookiHint(s)?.targetAction).toBe('drawStock');
+  });
 });

--- a/frontend/src/utils/hints/kalookiHint.ts
+++ b/frontend/src/utils/hints/kalookiHint.ts
@@ -8,6 +8,9 @@ import type { HintResult } from '../../types/hint';
  * 同じ表を持っている。ここから import すると循環するので、同期先を明記して
  * 持ち直している。
  */
+/** A(1) と K(13) の差。ランの端では隣り合う。 */
+const ACE_TO_KING_GAP = 12;
+
 const PHASE_DRAW = 0;
 const PHASE_MELD = 1;
 
@@ -50,9 +53,21 @@ export function getKalookiHint(state: KalookiResponse): HintResult | null {
   return { targetAction: `card-${idx}`, reason: 'frontendHint.kalookiDiscardHeavy', confidence: 'moderate' };
 }
 
-/** 同じランクがあるか、同じスートで隣のランクがあるか。メルドの証明ではない。 */
+/**
+ * 同じランクがあるか、同じスートで隣のランクがあるか。メルドの証明ではない。
+ *
+ * **A は 2 の隣であると同時に K の隣でもある** (internal/domain/Kalooki.go:822)。生の値で
+ * 引き算すると A(1) と K(13) が 12 離れて見え、A を持っている手で K を拾う
+ * 理由を見落とす。
+ */
 function connects(c: Card, hand: Card[]): boolean {
-  return hand.some((o) => o.value === c.value || (o.design === c.design && Math.abs(o.value - c.value) === 1));
+  return hand.some((o) => o.value === c.value || (o.design === c.design && adjacent(o.value, c.value)));
+}
+
+/** 隣のランクか。A(1) は 2 の隣であると同時に K(13) の隣でもある。 */
+function adjacent(a: number, b: number): boolean {
+  const gap = Math.abs(a - b);
+  return gap === 1 || gap === ACE_TO_KING_GAP;
 }
 
 /**

--- a/frontend/src/utils/hints/threethirteenHint.test.ts
+++ b/frontend/src/utils/hints/threethirteenHint.test.ts
@@ -103,4 +103,24 @@ describe('getThreeThirteenHint', () => {
   it('stays quiet without a visible hand', () => {
     expect(getThreeThirteenHint(base({ hand: [] }))).toBeNull();
   });
+
+  it('treats the ace as adjacent to the king, not only to the two', () => {
+    // ドメインは Ace-high のランを認める。生の値で引くと A(1) と K(13) が
+    // 12 離れて見えるので、K を拾う理由を見落とす。
+    const s = base({
+      phase: ThreeThirteenPhase.DRAW,
+      hand: [card('SPADE', 1), card('HEART', 5)],
+      discardTop: card('SPADE', 13),
+    });
+    expect(getThreeThirteenHint(s)?.targetAction).toBe('takeDiscard');
+  });
+
+  it('still requires the same suit for an ace-king neighbour', () => {
+    const s = base({
+      phase: ThreeThirteenPhase.DRAW,
+      hand: [card('SPADE', 1), card('HEART', 5)],
+      discardTop: card('CLOVER', 13),
+    });
+    expect(getThreeThirteenHint(s)?.targetAction).toBe('drawStock');
+  });
 });

--- a/frontend/src/utils/hints/threethirteenHint.ts
+++ b/frontend/src/utils/hints/threethirteenHint.ts
@@ -15,6 +15,9 @@ import { ThreeThirteenPhase } from '../../types/phases';
  * substitutes for anything, so it is never the card to throw even when nothing
  * in hand happens to touch it.
  */
+/** A(1) と K(13) の差。ランの端では隣り合う。 */
+const ACE_TO_KING_GAP = 12;
+
 export function getThreeThirteenHint(state: ThreeThirteenResponse): HintResult | null {
   if (state.gameEndFlag) return null;
 
@@ -36,9 +39,21 @@ export function getThreeThirteenHint(state: ThreeThirteenResponse): HintResult |
   return { targetAction: `card-${idx}`, reason: 'frontendHint.threethirteenDiscardHeavy', confidence: 'moderate' };
 }
 
-/** 同じランクがあるか、同じスートで隣のランクがあるか。メルドの証明ではない。 */
+/**
+ * 同じランクがあるか、同じスートで隣のランクがあるか。メルドの証明ではない。
+ *
+ * **A は 2 の隣であると同時に K の隣でもある** (internal/domain/ThreeThirteen.go:719)。生の値で
+ * 引き算すると A(1) と K(13) が 12 離れて見え、A を持っている手で K を拾う
+ * 理由を見落とす。
+ */
 function connects(c: Card, hand: Card[]): boolean {
-  return hand.some((o) => o.value === c.value || (o.design === c.design && Math.abs(o.value - c.value) === 1));
+  return hand.some((o) => o.value === c.value || (o.design === c.design && adjacent(o.value, c.value)));
+}
+
+/** 隣のランクか。A(1) は 2 の隣であると同時に K(13) の隣でもある。 */
+function adjacent(a: number, b: number): boolean {
+  const gap = Math.abs(a - b);
+  return gap === 1 || gap === ACE_TO_KING_GAP;
 }
 
 /**


### PR DESCRIPTION
どちらのヒントも「同スートで隣のランク」を `Math.abs(o.value - c.value) === 1` で判定していたので、**A と K が隣り合っていないことになっていた**。

ドメインは両方とも Ace-high のランを認める:

- `internal/domain/Kalooki.go:822` —— 「Ace は low (A-2-3) または high (Q-K-A) のいずれでも有効」
- `internal/domain/ThreeThirteen.go:719` —— 同じ文言。`ThreeThirteen.go:863` では「Ace-high 用に値 1 を 14 にもマップしたビューを作る」と明示している

生の値で引くと A(1) と K(13) は 12 離れるので、A を抱えている手で K が捨てられていても「材料にならない」と答えていた。

## 見つけ方

Contract Rummy (#4639) を書いたとき同じ判定を書き写していて、`isRun` を読み直して気づいた。Chinchón (#4614) の「40 枚デッキでは 7 と J が隣接する」も同じ形で、**デッキやランの規則を確認せずに `|差| === 1` を書き写す**のが再発している。そこで `Math.abs(o.value - c.value) === 1` を全ヒントで横断検索し、残っていたのがこの 2 件だった（Contract Rummy は同 PR 内で修正済み）。

## 負のコントロール

両方から A-K 隣接を落とすと 27 件中 2 件失敗。同スート条件は残しているので、♠A に対する ♣K は拾わないことも別途テストした。

## テスト

`kalookiHint.test.ts` / `threethirteenHint.test.ts` に各 2 件追加（計 27 件 green）。`bun run typecheck` / `bun run check` green。