### PR TITLE
ci: cancel superseded runs instead of letting them hold runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,20 @@ on:
   pull_request:
     branches: [ develop ]
 
+# **同じ ref の古い run を打ち切る。**1 回の CI は 17 ジョブに展開される
+# (FE 8 シャード + E2E 5 シャード + backend test/lint + typecheck + build) ので、
+# PR を押し直すたびに 17 スロットが二重に埋まる。並行 PR が増えると新しい run が
+# start すらできず、待ち時間の大半がジョブの実行ではなくキュー待ちになっていた。
+#
+# `deploy-*.yml` も同じ group を持つが、あちらは `cancel-in-progress: false` ——
+# デプロイを途中で切ると危険なため。検証は切ってよいので true にする。
+#
+# **master だけ除外する。**master への push はバージョン上げとタグ打ちを起動する
+# ので、後続の push でその run を殺すと未タグのコミットが残る。
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
 jobs:
   lint-backend:
     name: Backend Lint (golangci-lint)

--- a/.github/workflows/cloudflare-workers-build.yml
+++ b/.github/workflows/cloudflare-workers-build.yml
@@ -17,6 +17,15 @@ on:
       - 'Makefile'
       - 'internal/**'
 
+# **同じ ref の古いビルドを打ち切る。**このワークフローは `internal/**` の変更で
+# 発火し、6 つの Worker を TinyGo でビルドする —— CI の中で最も 1 ジョブが重い。
+# バックエンドを触る PR は押すたびに 6 ジョブを二重に積んでいた。
+#
+# サイズ検査が目的で成果物を配布しないので、途中で切っても失われるものはない。
+concurrency:
+  group: workers-build-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 


### PR DESCRIPTION
develop のランナー待ちが長い件。**実行時間ではなくキュー待ち**が原因だった。

## 測ったこと

- `ci.yml` は 1 run が **17 ジョブ**に展開される（FE 8 シャード + E2E 5 シャード + backend test/lint + typecheck + build）
- `cloudflare-workers-build.yml` は `internal/**` の変更で発火し、**6 ジョブ**を TinyGo でビルドする（1 ジョブあたり最も重い）
- **直近 60 run のうち 29 本（48%）が同じブランチの重複**。PR を押し直すたびに古い run が最後まで走り、17 スロットを掴んだままだった

つまり並行 PR が増えるほど、新しい run は「ジョブが遅い」のではなく **start できない**。

## 直したこと

両ワークフローに `concurrency` を足した。既存の `deploy-*.yml` と同じ形だが、あちらは `cancel-in-progress: false`（デプロイを途中で切ると危険）。検証とサイズ検査は切ってよいので `true`。

```yaml
concurrency:
  group: ci-${{ github.ref }}
  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
```

**master だけ除外した。**master への push はバージョン上げとタグ打ちを起動するので、後続の push でその run を殺すと未タグのコミットが残る。

`pull_request` イベントでは `github.ref` が `refs/pull/N/merge` になるため、group は PR ごとに分かれる。develop への push は `refs/heads/develop` で一本化されるので、**連続マージ時は最新の develop だけが走る** —— 検証したい状態はそれなので、これも望ましい。

## 触らなかったもの

- **`push: [develop]` は残した。** PR 側は自分のマージ結果しか見ないので、続けてマージした 2 本が個別には通るのに組み合わせで壊れる場合を develop の run が拾う。実際この形の失敗を踏んでいる（#4467）。concurrency が入ったので、連続マージしても最新 1 本に畳まれる。
- **`claude-review.yml`** は `opened` / `reopened` / `issue_comment` でしか発火せず push で積み上がらない。しかも打ち切ると書きかけのレビューが消えるので、そのまま。
- **シャード数は据え置き。** 8 分割はジョブ 1 本の時間を縮める最適化で、キュー待ちとは別の軸。むしろ待ち行列がある状態では分割数を増やすほど start が遅れるが、これは concurrency で待ち行列自体が短くなってから測り直すべきで、今同時に動かすと効果が切り分けられない。

## 検証

YAML パースと jobs 構造は確認済み（`ci.yml` 6 定義 / 17 展開、`cloudflare-workers-build.yml` 6 展開）。効果はマージ後の実測で確かめる。