### PR TITLE
fix(docs): retake the hint-factory count that a merge left behind

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -171,7 +171,7 @@ match on the code if you ever script against tsc output.
 | `TutorialProvider` | `src/providers/TutorialProvider.tsx` | Context provider; renders overlay (used internally by TutorialWrapper) |
 | `TutorialOverlay` | `src/components/tutorial/TutorialOverlay.tsx` | Full-screen overlay with SVG mask spotlight |
 | `useTutorial` | `src/hooks/useTutorial.ts` | State management (step progression, localStorage, resume/restart) |
-| `useGameHint` | `src/hooks/useGameHint.ts` | Frontend hints; registry-driven via `hintFactories` (covers most games; currently 247). `frontend/scripts/check-hint-coverage.mjs` fails the build for any new game without one. The supported set is the `HintGameName` union (`keyof typeof hintFactories`) — add a game by registering its factory there |
+| `useGameHint` | `src/hooks/useGameHint.ts` | Frontend hints; registry-driven via `hintFactories` (covers most games; currently 248). `frontend/scripts/check-hint-coverage.mjs` fails the build for any new game without one. The supported set is the `HintGameName` union (`keyof typeof hintFactories`) — add a game by registering its factory there |
 | `TutorialSuggestDialog` | `src/components/tutorial/TutorialSuggestDialog.tsx` | First-visit dialog; controlled by `useFirstVisit` hook |
 | `TutorialProgressPanel` | `src/components/tutorial/TutorialProgressPanel.tsx` | Progress overview in NavBar |
 


### PR DESCRIPTION
**develop が赤い。** `useGameHint.docCount.test.ts` が落ちる:

```
frontend/CLAUDE.md says 247 hint factories, but useGameHint.ts has 248
```

#4626 のマージで登録が 1 件増えたが、`frontend/CLAUDE.md` の "currently N" が取り直されないまま入った。この行はマージのたびに競合し、解消時に数え直す必要がある——毎回それをやってきたが、1 本すり抜けた。

数字を 248 に直しただけ。`check-hint-coverage.mjs` も 248 で一致している。

## 経緯

#4650 (CI concurrency) の Frontend Tests シャード 2 が落ちたので調べたところ、変更内容と無関係で、**develop 側が既に壊れていた**。他の in-flight PR も全部これで落ちる。

## 恒久対策の候補

この行が競合の常連なので、doc に数字を書くのをやめてテストが数える側だけにする案がある（#4602 / #4603 が近い議論をしている）。ただし CLAUDE.md の数字は人間が読む文脈で意味があるので、別途 issue で扱う方がよいと考えてここでは数字だけ直した。