### PR TITLE
test(lld): stop the cpu-hand assertion depending on the deal

### DIFF
--- a/internal/adapter/presenter/LaughAndLieDownPresenter_test.go
+++ b/internal/adapter/presenter/LaughAndLieDownPresenter_test.go
@@ -61,7 +61,15 @@ func lldStub(valid []int, canThree bool, gameEnd bool, score int) *interfaces.Mo
 
 func TestLaughAndLieDownWebPresenter_HidesTheCpuHandButNeverItsWonCount(t *testing.T) {
 	// 取り札の枚数は 8 との差がそのまま収支なので、隠すと精算が読めなくなる。
-	out := lldDecode(t, new(LaughAndLieDownWebPresenter).Output(lldTestGame(t), nil))
+	//
+	// **CPU の手札が 0 枚で配り終わることがある。**Reset() は最後に
+	// skipPlayersWhoCannotCapture() を呼び、取れる札が無い席の手札を場に置く。
+	// そのため `cardCount > 0` を主張すると配り次第で落ちる —— 隣の
+	// SendsTheWholeFaceUpTable が #4626 で直したのと同じ形が、この 1 件に
+	// 残っていた (#4650 の CI で再発)。見たいのは「隠した手札の枚数だけは
+	// 送っているか」なので、ゲームが持つ枚数そのものと比べる。
+	g := lldTestGame(t)
+	out := lldDecode(t, new(LaughAndLieDownWebPresenter).Output(g, nil))
 	players, ok := out["players"].([]any)
 	require.True(t, ok)
 	require.Len(t, players, domain.LaughAndLieDownPlayerCnt)
@@ -73,7 +81,7 @@ func TestLaughAndLieDownWebPresenter_HidesTheCpuHandButNeverItsWonCount(t *testi
 	cpu, _ := players[1].(map[string]any)
 	assert.True(t, cpu["hidden"].(bool))
 	assert.Empty(t, cpu["cards"], "the opponent's hand must not reach the browser")
-	assert.Positive(t, cpu["cardCount"], "but its size is public")
+	assert.Equal(t, float64(g.GetPlayer(1).GetCardsSize()), cpu["cardCount"], "but its size is public")
 	assert.NotNil(t, cpu["wonCount"], "and so is what it has captured")
 }
 


### PR DESCRIPTION
#4650（CI の concurrency 追加）の Backend Tests が落ちたが、変更内容とは無関係のフレークだった。

```
--- FAIL: TestLaughAndLieDownWebPresenter_HidesTheCpuHandButNeverItsWonCount
    Error: "0" is not positive
    Messages: but its size is public
```

## 原因

`Reset()` は最後に `skipPlayersWhoCannotCapture()` を呼び、**取れる札が無い席の手札を場に置く**。その席の手札は 0 枚で配り終わる。`assert.Positive(t, cpu["cardCount"])` は配り次第で落ちる。

**#4626 が直したのと同じ形が、この 1 件に残っていた。** あちらは `SendsTheWholeFaceUpTable` で「場の枚数を定数と比べる」のをやめた。同じファイルの隣のテストが同じ依存を持っていたのを見落としていた。

## 頻度を測った

20,000 回配って **48 回（0.24%）** CPU の手札が 0 枚になる。CI で稀に落ちる頻度と合う。

`-count=300` では再現しない —— `-count` はテスト関数を回すだけで、この確率は 1 回の配りに対するものなので、300 回では期待値 0.7 回にしかならない。**フレークを `-count` で追い込めなかったときは、確率そのものを別に測る。**

## 直したこと

「隠した手札の枚数は送る」という不変条件はそのままに、比較相手をゲーム自身の値にした:

```go
assert.Equal(t, float64(g.GetPlayer(1).GetCardsSize()), cpu["cardCount"], "but its size is public")
```

0 枚でも「送っている」ことは検証できる。`cards` が空であること（手札の中身は隠す）の主張は変えていない。

## 検証

`-count=300` green。修正前の版も確率的にしか落ちないので、上の 20,000 回測定を再現手段として本文に残す。