### PR TITLE
refactor(hint): share the rummy connects/discard shape across four hints

### DIFF
--- a/frontend/src/utils/hints/chinchonHint.ts
+++ b/frontend/src/utils/hints/chinchonHint.ts
@@ -1,6 +1,7 @@
-import type { Card, ChinchonResponse } from '../../types/card';
+import type { ChinchonResponse } from '../../types/card';
 import type { HintResult } from '../../types/hint';
 import { ChinchonPhase } from '../../types/phases';
+import { heaviestSpare, isMaterial } from './rummyHintShape';
 
 /**
  * Returns a frontend {@link HintResult} for Chinchón, or null when no
@@ -22,7 +23,7 @@ export function getChinchonHint(state: ChinchonResponse): HintResult | null {
 
   if (state.phase === ChinchonPhase.DRAW) {
     const top = state.discardTop;
-    return top && connects(top, human.cards)
+    return top && isMaterial(top, human.cards, chinchonAdjacent)
       ? { targetAction: 'takeDiscard', reason: 'frontendHint.chinchonTakeDiscard', confidence: 'moderate' }
       : { targetAction: 'drawStock', reason: 'frontendHint.chinchonDrawStock', confidence: 'moderate' };
   }
@@ -33,7 +34,7 @@ export function getChinchonHint(state: ChinchonResponse): HintResult | null {
   // 全部繋がっているときも、崩すなら一番重い札。
   // **札 0 も捨て札になりうる。**手札が空でないことは上で確かめてあるので、
   // heaviestLoose は必ず 0 以上を返す。`idx < 0` を書くと到達しない分岐が残る。
-  const idx = heaviestLoose(human.cards);
+  const idx = heaviestSpare(human.cards, chinchonAdjacent);
   return { targetAction: `card-${idx}`, reason: 'frontendHint.chinchonDiscardHeavy', confidence: 'moderate' };
 }
 
@@ -53,31 +54,15 @@ function rankPosition(value: number): number {
   return 0; // 8/9/10/Joker — このデッキには存在しない
 }
 
-/** 同じランクがあるか、同じスートで隣のランクがあるか。メルドの証明ではない。 */
-function connects(c: Card, hand: Card[]): boolean {
-  const pos = rankPosition(c.value);
-  return hand.some(
-    (o) =>
-      o.value === c.value ||
-      (o.design === c.design && pos > 0 && rankPosition(o.value) > 0 && Math.abs(rankPosition(o.value) - pos) === 1),
-  );
-}
-
 /**
- * 繋がっていない札のうち一番重いものの位置。全部繋がっていれば一番重い札。
+ * 40 枚デッキでの隣接判定。
  *
- * 呼び出し側が手札の非空を確かめているので、必ず有効な位置を返す。
+ * `rankPosition` に写してから隣り合うかを見る。**7 と J は隣接する** ——
+ * 生の値では `|11-7| = 4` になり、繋がっていないと誤判定する。
+ * 位置 0 はこのデッキに存在しない札 (8/9/10/Joker) なので繋がらない。
  */
-function heaviestLoose(hand: Card[]): number {
-  const loose: number[] = [];
-  for (let i = 0; i < hand.length; i += 1) {
-    const rest = hand.filter((_, j) => j !== i);
-    if (!connects(hand[i], rest)) loose.push(i);
-  }
-  const pool = loose.length > 0 ? loose : hand.map((_, i) => i);
-  let best = pool[0];
-  for (const i of pool) {
-    if (hand[i].value > hand[best].value) best = i;
-  }
-  return best;
+function chinchonAdjacent(a: number, b: number): boolean {
+  const pa = rankPosition(a);
+  const pb = rankPosition(b);
+  return pa > 0 && pb > 0 && Math.abs(pa - pb) === 1;
 }

--- a/frontend/src/utils/hints/contractrummyHint.ts
+++ b/frontend/src/utils/hints/contractrummyHint.ts
@@ -1,12 +1,10 @@
-import type { Card, ContractRummyResponse } from '../../types/card';
+import type { ContractRummyResponse } from '../../types/card';
 import type { HintResult } from '../../types/hint';
+import { aceHighAdjacent, heaviestSpare, isMaterial } from './rummyHintShape';
 
 /** フェーズ番号 (sync: internal/domain/ContractRummy.go)。 */
 const PHASE_DRAW = 0;
 const PHASE_PLAY = 1;
-
-/** A(1) と K(13) の差。ランの端では隣り合う。 */
-const ACE_TO_KING_GAP = 12;
 
 /**
  * Returns a frontend {@link HintResult} for Contract Rummy, or null when no
@@ -29,7 +27,7 @@ export function getContractRummyHint(state: ContractRummyResponse): HintResult |
 
   if (state.phase === PHASE_DRAW) {
     const top = state.discardTop;
-    return top && connects(top, human.cards)
+    return top && isMaterial(top, human.cards, aceHighAdjacent)
       ? { targetAction: 'takeDiscard', reason: 'frontendHint.contractrummyTakeDiscard', confidence: 'moderate' }
       : { targetAction: 'drawStock', reason: 'frontendHint.contractrummyDrawStock', confidence: 'moderate' };
   }
@@ -42,44 +40,6 @@ export function getContractRummyHint(state: ContractRummyResponse): HintResult |
     return { targetAction: 'meld', reason: 'frontendHint.contractrummyMeetContract', confidence: 'moderate' };
   }
 
-  const idx = heaviestLoose(human.cards);
+  const idx = heaviestSpare(human.cards, aceHighAdjacent);
   return { targetAction: `card-${idx}`, reason: 'frontendHint.contractrummyDiscardHeavy', confidence: 'moderate' };
-}
-
-/**
- * 同じランクがあるか、同じスートで隣のランクがあるか。メルドの証明ではない。
- *
- * **A は 2 の隣であると同時に K の隣でもある。**`isRun`
- * (`internal/domain/ContractRummy.go:930`) は A-2-3 と J-Q-K-A の両方を認める
- * (同じランの中でのラップアラウンド K-A-2 だけが不可)。生の値で引き算すると
- * A(1) と K(13) が 12 離れているように見え、A を抱えている手で K を拾う理由を
- * 見落とす。Chinchón (#4614) で 7 と J が隣接するのを見落としたのと同じ形。
- */
-function connects(c: Card, hand: Card[]): boolean {
-  return hand.some((o) => o.value === c.value || (o.design === c.design && adjacent(o.value, c.value)));
-}
-
-/** 隣のランクか。A(1) は 2 の隣であると同時に K(13) の隣でもある。 */
-function adjacent(a: number, b: number): boolean {
-  const gap = Math.abs(a - b);
-  return gap === 1 || gap === ACE_TO_KING_GAP;
-}
-
-/** 繋がっていない札のうち一番重いものの位置。全部繋がっていれば一番重い札。 */
-function heaviestLoose(hand: Card[]): number {
-  const loose = hand
-    .map((_, i) => i)
-    .filter(
-      (i) =>
-        !connects(
-          hand[i],
-          hand.filter((_, j) => j !== i),
-        ),
-    );
-  const pool = loose.length > 0 ? loose : hand.map((_, i) => i);
-  let best = pool[0];
-  for (const i of pool) {
-    if (hand[i].value > hand[best].value) best = i;
-  }
-  return best;
 }

--- a/frontend/src/utils/hints/kalookiHint.ts
+++ b/frontend/src/utils/hints/kalookiHint.ts
@@ -1,5 +1,6 @@
-import type { Card, KalookiResponse } from '../../types/card';
+import type { KalookiResponse } from '../../types/card';
 import type { HintResult } from '../../types/hint';
+import { aceHighAdjacent, heaviestSpare, isMaterial } from './rummyHintShape';
 
 /**
  * フェーズ番号 (sync: internal/domain/Kalooki.go)。
@@ -8,9 +9,6 @@ import type { HintResult } from '../../types/hint';
  * 同じ表を持っている。ここから import すると循環するので、同期先を明記して
  * 持ち直している。
  */
-/** A(1) と K(13) の差。ランの端では隣り合う。 */
-const ACE_TO_KING_GAP = 12;
-
 const PHASE_DRAW = 0;
 const PHASE_MELD = 1;
 
@@ -36,7 +34,7 @@ export function getKalookiHint(state: KalookiResponse): HintResult | null {
 
   if (state.phase === PHASE_DRAW) {
     const top = state.discardTop;
-    return top && connects(top, human.cards)
+    return top && isMaterial(top, human.cards, aceHighAdjacent)
       ? { targetAction: 'takeDiscard', reason: 'frontendHint.kalookiTakeDiscard', confidence: 'moderate' }
       : { targetAction: 'drawStock', reason: 'frontendHint.kalookiDrawStock', confidence: 'moderate' };
   }
@@ -49,42 +47,6 @@ export function getKalookiHint(state: KalookiResponse): HintResult | null {
     return { targetAction: 'meld', reason: 'frontendHint.kalookiOpenFirst', confidence: 'moderate' };
   }
 
-  const idx = heaviestLoose(human.cards);
+  const idx = heaviestSpare(human.cards, aceHighAdjacent);
   return { targetAction: `card-${idx}`, reason: 'frontendHint.kalookiDiscardHeavy', confidence: 'moderate' };
-}
-
-/**
- * 同じランクがあるか、同じスートで隣のランクがあるか。メルドの証明ではない。
- *
- * **A は 2 の隣であると同時に K の隣でもある** (internal/domain/Kalooki.go:822)。生の値で
- * 引き算すると A(1) と K(13) が 12 離れて見え、A を持っている手で K を拾う
- * 理由を見落とす。
- */
-function connects(c: Card, hand: Card[]): boolean {
-  return hand.some((o) => o.value === c.value || (o.design === c.design && adjacent(o.value, c.value)));
-}
-
-/** 隣のランクか。A(1) は 2 の隣であると同時に K(13) の隣でもある。 */
-function adjacent(a: number, b: number): boolean {
-  const gap = Math.abs(a - b);
-  return gap === 1 || gap === ACE_TO_KING_GAP;
-}
-
-/**
- * 繋がっていない札のうち一番重いものの位置。全部繋がっていれば一番重い札。
- *
- * 呼び出し側が手札の非空を確かめているので、必ず有効な位置を返す。
- */
-function heaviestLoose(hand: Card[]): number {
-  const loose: number[] = [];
-  for (let i = 0; i < hand.length; i += 1) {
-    const rest = hand.filter((_, j) => j !== i);
-    if (!connects(hand[i], rest)) loose.push(i);
-  }
-  const pool = loose.length > 0 ? loose : hand.map((_, i) => i);
-  let best = pool[0];
-  for (const i of pool) {
-    if (hand[i].value > hand[best].value) best = i;
-  }
-  return best;
 }

--- a/frontend/src/utils/hints/rummyHintShape.test.ts
+++ b/frontend/src/utils/hints/rummyHintShape.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import type { Card } from '../../types/card';
+import { aceHighAdjacent, heaviestSpare, isMaterial } from './rummyHintShape';
+
+const card = (design: Card['design'], value: number): Card => ({ design, value });
+
+describe('aceHighAdjacent', () => {
+  it('joins neighbouring ranks', () => {
+    expect(aceHighAdjacent(5, 6)).toBe(true);
+    expect(aceHighAdjacent(6, 5)).toBe(true);
+  });
+
+  it('joins the ace to the king as well as to the two', () => {
+    expect(aceHighAdjacent(1, 2)).toBe(true);
+    expect(aceHighAdjacent(1, 13)).toBe(true);
+  });
+
+  it('does not join ranks two apart', () => {
+    expect(aceHighAdjacent(5, 7)).toBe(false);
+  });
+
+  it('does not wrap the king round to the two', () => {
+    // K-A-2 は同じランの中では不可。A を両端に置けることと、輪になることは別。
+    expect(aceHighAdjacent(13, 2)).toBe(false);
+  });
+});
+
+describe('isMaterial', () => {
+  it('matches a card of the same rank in any suit', () => {
+    expect(isMaterial(card('SPADE', 9), [card('HEART', 9)], aceHighAdjacent)).toBe(true);
+  });
+
+  it('matches a neighbour only in the same suit', () => {
+    expect(isMaterial(card('SPADE', 9), [card('SPADE', 10)], aceHighAdjacent)).toBe(true);
+    expect(isMaterial(card('SPADE', 9), [card('HEART', 10)], aceHighAdjacent)).toBe(false);
+  });
+
+  it('finds nothing in an empty hand', () => {
+    expect(isMaterial(card('SPADE', 9), [], aceHighAdjacent)).toBe(false);
+  });
+
+  it('takes the adjacency rule from its caller', () => {
+    // 隣接を「差が 4」と定義すれば 7 と J が繋がる。Chinchón の 40 枚デッキが
+    // これに相当する（あちらは位置に写してから比べる）。
+    const gapFour = (a: number, b: number) => Math.abs(a - b) === 4;
+    expect(isMaterial(card('SPADE', 7), [card('SPADE', 11)], gapFour)).toBe(true);
+    expect(isMaterial(card('SPADE', 7), [card('SPADE', 11)], aceHighAdjacent)).toBe(false);
+  });
+});
+
+describe('heaviestSpare', () => {
+  it('throws the heaviest card that connects with nothing', () => {
+    // 5♠6♠ は繋がっている。K♥ と 3♦ が浮いており、重いのは K。
+    const hand = [card('SPADE', 5), card('SPADE', 6), card('HEART', 13), card('DIAMOND', 3)];
+    expect(heaviestSpare(hand, aceHighAdjacent)).toBe(2);
+  });
+
+  it('keeps index 0 as a valid answer', () => {
+    // **札 0 も捨て札になりうる。**真偽値で見ると先頭だけ落ちる。
+    const hand = [card('HEART', 13), card('SPADE', 5), card('SPADE', 6)];
+    expect(heaviestSpare(hand, aceHighAdjacent)).toBe(0);
+  });
+
+  it('falls back to the heaviest card when everything is material', () => {
+    const hand = [card('SPADE', 5), card('SPADE', 6), card('SPADE', 7)];
+    expect(heaviestSpare(hand, aceHighAdjacent)).toBe(2);
+  });
+
+  it('never picks a skipped card, even when it is the heaviest', () => {
+    // Three Thirteen のワイルドがこれ。捨てると手が弱くなるだけ。
+    const hand = [card('HEART', 13), card('SPADE', 4), card('DIAMOND', 9)];
+    const idx = heaviestSpare(hand, aceHighAdjacent, (c) => c.value === 13);
+    expect(idx).not.toBe(0);
+    expect(idx).toBe(2);
+  });
+
+  it('returns -1 when skipping leaves nothing', () => {
+    // ワイルドしか持っていない手。呼び出し側が -1 を扱う必要がある。
+    const hand = [card('HEART', 13), card('SPADE', 13)];
+    expect(heaviestSpare(hand, aceHighAdjacent, (c) => c.value === 13)).toBe(-1);
+  });
+
+  it('returns -1 for an empty hand', () => {
+    expect(heaviestSpare([], aceHighAdjacent)).toBe(-1);
+  });
+});

--- a/frontend/src/utils/hints/rummyHintShape.ts
+++ b/frontend/src/utils/hints/rummyHintShape.ts
@@ -1,0 +1,84 @@
+import type { Card } from '../../types/card';
+
+/**
+ * The shallow "is this card material" test the rummy-family hints share, and the
+ * discard choice built on it.
+ *
+ * Four hints had grown their own copy — Chinchón, Kalooki, Contract Rummy and
+ * Three Thirteen — and the reviewer on #4639 flagged it before a fifth appeared.
+ * Extracting it is not just deduplication: **each copy had already drifted**, and
+ * the drift was invisible because every copy looked plausible on its own.
+ *
+ * - Contract Rummy and Kalooki treated the ace as adjacent only to the two, while
+ *   both domains accept a high ace (J-Q-K-A). Fixed separately in #4646.
+ * - Chinchón plays a 40-card deck where the seven and the jack are neighbours,
+ *   so raw value arithmetic is wrong there. That copy already knew; the others
+ *   would have inherited the bug had anyone copied it the other way.
+ *
+ * So the shared piece takes the adjacency rule as an argument rather than
+ * assuming one. What is genuinely common is the *shape*: a card is material when
+ * some other card shares its rank or sits next to it in suit, and the card to
+ * throw is the heaviest that is material to nothing.
+ *
+ * **This is not a claim that a meld exists.** Melds need three cards; a pair is
+ * only progress toward one. Where a hint asserts legality rather than progress —
+ * Tonk's knock, which the server refuses above five points of deadwood — this
+ * shape is the wrong tool and an exact search is required (see `tonkHint.ts`).
+ */
+
+/** Two ranks are adjacent for a run. Values are raw card values, ace = 1. */
+export type Adjacency = (a: number, b: number) => boolean;
+
+/** A(1) と K(13) の差。エースを高くも使えるゲームではランの端で隣り合う。 */
+const ACE_TO_KING_GAP = 12;
+
+/**
+ * Ace-high adjacency: neighbouring ranks, plus the ace beside the king.
+ *
+ * Used by Kalooki (`Kalooki.go:822`), Three Thirteen (`ThreeThirteen.go:719`) and
+ * Contract Rummy (`ContractRummy.go:930`), all of which accept A-2-3 and
+ * J-Q-K-A while refusing to wrap around inside one run (K-A-2).
+ */
+export function aceHighAdjacent(a: number, b: number): boolean {
+  const gap = Math.abs(a - b);
+  return gap === 1 || gap === ACE_TO_KING_GAP;
+}
+
+/**
+ * Whether `c` shares a rank with, or sits next to, some other card in `hand`.
+ *
+ * `hand` may include `c` itself; identity is not checked, so pass the rest of the
+ * hand when asking about a specific position.
+ */
+export function isMaterial(c: Card, hand: Card[], adjacent: Adjacency): boolean {
+  return hand.some((o) => o.value === c.value || (o.design === c.design && adjacent(o.value, c.value)));
+}
+
+/**
+ * Index of the heaviest card that connects with nothing, or of the heaviest card
+ * outright when every card connects.
+ *
+ * `skip` drops positions from consideration entirely — Three Thirteen uses it for
+ * the round's wild rank, which should never be thrown. Returns -1 when `skip`
+ * leaves nothing, which is a real state there (a hand of nothing but wilds).
+ */
+export function heaviestSpare(hand: Card[], adjacent: Adjacency, skip?: (c: Card) => boolean): number {
+  const candidates = hand.map((_, i) => i).filter((i) => !skip?.(hand[i]));
+  if (candidates.length === 0) return -1;
+
+  const loose = candidates.filter(
+    (i) =>
+      !isMaterial(
+        hand[i],
+        hand.filter((_, j) => j !== i),
+        adjacent,
+      ),
+  );
+  // 全部が材料なら、材料の中から一番重いものを出すしかない。
+  const pool = loose.length > 0 ? loose : candidates;
+  let best = pool[0];
+  for (const i of pool) {
+    if (hand[i].value > hand[best].value) best = i;
+  }
+  return best;
+}

--- a/frontend/src/utils/hints/threethirteenHint.ts
+++ b/frontend/src/utils/hints/threethirteenHint.ts
@@ -1,6 +1,7 @@
 import type { Card, ThreeThirteenResponse } from '../../types/card';
 import type { HintResult } from '../../types/hint';
 import { ThreeThirteenPhase } from '../../types/phases';
+import { aceHighAdjacent, heaviestSpare, isMaterial } from './rummyHintShape';
 
 /**
  * Returns a frontend {@link HintResult} for Three Thirteen, or null when no
@@ -15,9 +16,6 @@ import { ThreeThirteenPhase } from '../../types/phases';
  * substitutes for anything, so it is never the card to throw even when nothing
  * in hand happens to touch it.
  */
-/** A(1) と K(13) の差。ランの端では隣り合う。 */
-const ACE_TO_KING_GAP = 12;
-
 export function getThreeThirteenHint(state: ThreeThirteenResponse): HintResult | null {
   if (state.gameEndFlag) return null;
 
@@ -26,61 +24,15 @@ export function getThreeThirteenHint(state: ThreeThirteenResponse): HintResult |
 
   if (state.phase === ThreeThirteenPhase.DRAW) {
     const top = state.discardTop;
-    return top && (top.value === state.wildRank || connects(top, human.cards))
+    return top && (top.value === state.wildRank || isMaterial(top, human.cards, aceHighAdjacent))
       ? { targetAction: 'takeDiscard', reason: 'frontendHint.threethirteenTakeDiscard', confidence: 'moderate' }
       : { targetAction: 'drawStock', reason: 'frontendHint.threethirteenDrawStock', confidence: 'moderate' };
   }
 
   if (state.phase !== ThreeThirteenPhase.DISCARD) return null;
 
-  const idx = heaviestLoose(human.cards, state.wildRank);
+  const idx = heaviestSpare(human.cards, aceHighAdjacent, (c: Card) => c.value === state.wildRank);
   // **捨てられる札が無い。**全部がワイルドか繋がっている手では黙る。
   if (idx < 0) return null;
   return { targetAction: `card-${idx}`, reason: 'frontendHint.threethirteenDiscardHeavy', confidence: 'moderate' };
-}
-
-/**
- * 同じランクがあるか、同じスートで隣のランクがあるか。メルドの証明ではない。
- *
- * **A は 2 の隣であると同時に K の隣でもある** (internal/domain/ThreeThirteen.go:719)。生の値で
- * 引き算すると A(1) と K(13) が 12 離れて見え、A を持っている手で K を拾う
- * 理由を見落とす。
- */
-function connects(c: Card, hand: Card[]): boolean {
-  return hand.some((o) => o.value === c.value || (o.design === c.design && adjacent(o.value, c.value)));
-}
-
-/** 隣のランクか。A(1) は 2 の隣であると同時に K(13) の隣でもある。 */
-function adjacent(a: number, b: number): boolean {
-  const gap = Math.abs(a - b);
-  return gap === 1 || gap === ACE_TO_KING_GAP;
-}
-
-/**
- * 捨てるべき札の位置。ワイルドは何にでもなるので候補から外す。
- *
- * 繋がっていない札があればその中で一番重いもの、無ければワイルド以外で
- * 一番重いもの。候補がまったく無ければ -1。
- */
-function heaviestLoose(hand: Card[], wildRank: number): number {
-  const candidates: number[] = [];
-  for (let i = 0; i < hand.length; i += 1) {
-    if (hand[i].value === wildRank) continue;
-    candidates.push(i);
-  }
-  if (candidates.length === 0) return -1;
-
-  const loose = candidates.filter(
-    (i) =>
-      !connects(
-        hand[i],
-        hand.filter((_, j) => j !== i),
-      ),
-  );
-  const pool = loose.length > 0 ? loose : candidates;
-  let best = pool[0];
-  for (const i of pool) {
-    if (hand[i].value > hand[best].value) best = i;
-  }
-  return best;
 }


### PR DESCRIPTION
#4639 のレビューで「これで 3 つ目のコピーだ、4 つ目が出る前に共通化を検討」と指摘があった。数えたら**既に 4 つ**あった: Chinchón / Kalooki / Contract Rummy / Three Thirteen。

`frontend/src/utils/hints/rummyHintShape.ts` に切り出した。**164 行削って 23 行**、挙動は変えていない（4 ゲームの既存テスト 56 件がそのまま通る）。

## 単なる重複除去ではない

**4 つのコピーは既にドリフトしていて、しかも個別に見ると全部もっともらしかった。**

- Contract Rummy と Kalooki は A を 2 の隣としか見ておらず、両ドメインが認める J-Q-K-A を取りこぼしていた（#4646 で別途修正）
- Chinchón は 8/9/10 を抜いた 40 枚デッキなので 7 と J が隣接する。生の値の引き算が使えない。そのコピーだけが知っていた

なので共通部分は**隣接規則を引数に取る**。共通なのは規則ではなく形の方だった:「同ランクか同スートの隣があれば材料」「捨てるのは何にも繋がらない中で一番重い札」。

```ts
export type Adjacency = (a: number, b: number) => boolean;
export function aceHighAdjacent(a, b)                       // A を K の隣にも認める
export function isMaterial(c, hand, adjacent)
export function heaviestSpare(hand, adjacent, skip?)        // skip は Three Thirteen のワイルド用
```

`heaviestSpare` は `skip` で候補が尽きたとき **-1** を返す。Three Thirteen の「ワイルドしか持っていない手」は実在する状態で、呼び出し側は元から `idx < 0` を見ていた。その扱いは変えていない。

## 適用範囲の線

**これはメルドの存在を主張しない。**メルドは 3 枚以上必要で、ペアは前進でしかない。合法性を主張する場面 —— Tonk のノック（サーバが 5 点超で拒否する）—— にこの形を使うと**拒否される手を勧める**ことになり、実際 #4640 でそれをやった。モジュールの doc にその線を明記してある。

## テスト

`rummyHintShape.test.ts` 14 件を新規。エースが K と 2 の両方に繋がること、K-A-2 では輪にならないこと、`skip` が最重量札でも選ばれないこと、候補が尽きたら -1 を返すこと、**隣接規則が呼び出し側から来ること**（差 4 を隣接と定義すれば 7 と J が繋がる）を固定。

4 ゲームのテストは 1 行も変えていない。合計 70 件 green。`bun run typecheck` / `bun run check` green。