### PR TITLE
fix(docs): restore the table row a merge collapsed into one line

### DIFF
--- a/docs/manual/cui/dragontiger.md
+++ b/docs/manual/cui/dragontiger.md
@@ -54,8 +54,8 @@ flowchart TD
 | コマンド | 説明 |
 |---|---|
 | `r` / `reset` | ゲームリセット |
-| `b <amount> <d|t|e>` | ベット（`d`=ドラゴン, `t`=タイガー, `e`=タイ） |
-| `bet <amount> <dragon|tiger|tie>` | 上記の長い形式 |
+| `b <amount> <d\|t\|e>` | ベット（`d`=ドラゴン, `t`=タイガー, `e`=タイ） |
+| `bet <amount> <dragon\|tiger\|tie>` | 上記の長い形式 |
 | `clear` | Big Road（履歴）をクリア |
 | `log` | 棋譜を表示 |
 | `q` / `quit` | 終了 |

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -172,7 +172,8 @@ match on the code if you ever script against tsc output.
 | `TutorialOverlay` | `src/components/tutorial/TutorialOverlay.tsx` | Full-screen overlay with SVG mask spotlight |
 | `useTutorial` | `src/hooks/useTutorial.ts` | State management (step progression, localStorage, resume/restart) |
 | `useGameHint` | `src/hooks/useGameHint.ts` | Frontend hints; registry-driven via `hintFactories` (covers most games; currently 248). `frontend/scripts/check-hint-coverage.mjs` fails the build for any new game without one. The supported set is the `HintGameName` union (`keyof typeof hintFactories`) — add a game by registering its factory there |
-| `TutorialSuggestDialog` | `src/components/tutorial/TutorialSuggestDialog.tsx` | First-visit dialog; controlled by `useFirstVisit` hook || `TutorialProgressPanel` | `src/components/tutorial/TutorialProgressPanel.tsx` | Progress overview in NavBar |
+| `TutorialSuggestDialog` | `src/components/tutorial/TutorialSuggestDialog.tsx` | First-visit dialog; controlled by `useFirstVisit` hook |
+| `TutorialProgressPanel` | `src/components/tutorial/TutorialProgressPanel.tsx` | Progress overview in NavBar |
 
 ### Adding a tutorial to a new game
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,7 @@
     "lint": "biome lint .",
     "lint:tokens": "bun scripts/check-design-tokens.mjs",
     "format": "biome format --write .",
-    "check": "biome check . && bun scripts/check-design-tokens.mjs && bun scripts/check-discover-blurbs.mjs && bun scripts/check-message-codes.mjs && bun scripts/check-hint-coverage.mjs && bun scripts/check-hint-reasons.mjs",
+    "check": "biome check . && bun scripts/check-design-tokens.mjs && bun scripts/check-discover-blurbs.mjs && bun scripts/check-message-codes.mjs && bun scripts/check-hint-coverage.mjs && bun scripts/check-hint-reasons.mjs && bun scripts/check-markdown-tables.mjs",
     "check:write": "biome check --write .",
     "preview": "vite preview",
     "test": "vitest run",

--- a/frontend/scripts/check-markdown-tables.mjs
+++ b/frontend/scripts/check-markdown-tables.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env bun
+// Guard that every Markdown table row has the same number of cells as its
+// header separator.
+//
+// Two ways a row breaks, both of which render as garbage and neither of which
+// any existing check looks at:
+//
+//   1. **A merge collapses two rows into one.** `frontend/CLAUDE.md` had
+//      `… | First-visit dialog … hook || \`TutorialProgressPanel\` | … |` — one
+//      line holding two rows. It survived because the `useGameHint` row directly
+//      above it carries the hint-factory count, which conflicts on nearly every
+//      parallel PR (#4652), so that spot gets machine-resolved constantly. tsc,
+//      Biome and vitest all ignore `.md`, so nothing caught it; it was found by
+//      eye, and by then a *third* row had been lost entirely.
+//
+//   2. **An unescaped pipe inside a cell.** `docs/manual/cui/dragontiger.md`
+//      documented `b <amount> <d|t|e>`, and those pipes split the row into five
+//      cells. The other 30-odd manuals escape them (`<d\|t\|e>`); these two did
+//      not.
+//
+// The check is deliberately shallow — cell counts only, no rendering — because
+// that is enough to catch both shapes and cannot produce opinions about style.
+
+import { readdir, readFile } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const FRONTEND = fileURLToPath(new URL('..', import.meta.url));
+const REPO = join(FRONTEND, '..');
+
+/** Directories that are not ours to police. */
+const SKIP = new Set(['node_modules', '.git', 'dist', 'coverage', 'playwright-report', 'test-results']);
+
+/** Count unescaped pipes — `\|` is a literal inside a cell, not a separator. */
+function cellCount(line) {
+  return (line.match(/(?<!\\)\|/g) ?? []).length;
+}
+
+/** A separator row: only dashes, colons, pipes and spaces, with real dashes. */
+function isSeparator(line) {
+  const stripped = line.replace(/[|\s]/g, '');
+  return stripped.length > 0 && /^[-:]+$/.test(stripped) && line.includes('---');
+}
+
+async function* markdownFiles(dir) {
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    if (SKIP.has(entry.name)) continue;
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) yield* markdownFiles(full);
+    else if (entry.name.endsWith('.md')) yield full;
+  }
+}
+
+const problems = [];
+let tables = 0;
+let rows = 0;
+
+for await (const file of markdownFiles(REPO)) {
+  const lines = (await readFile(file, 'utf8')).split('\n');
+  let expected = null;
+  for (const [i, line] of lines.entries()) {
+    if (!line.trimStart().startsWith('|')) {
+      expected = null;
+      continue;
+    }
+    const cells = cellCount(line);
+    if (isSeparator(line)) {
+      expected = cells;
+      tables += 1;
+      continue;
+    }
+    if (expected === null) continue;
+    rows += 1;
+    if (cells !== expected) {
+      problems.push(
+        `${relative(REPO, file)}:${i + 1} — ${cells} cell separators, header has ${expected}\n      ${line.trim().slice(0, 90)}`,
+      );
+    }
+  }
+}
+
+if (tables === 0) {
+  console.error('markdown-tables: found no tables at all — the separator match has drifted.');
+  process.exit(1);
+}
+
+if (problems.length > 0) {
+  console.error('Markdown table rows that do not match their header:\n');
+  for (const p of problems) console.error(`  ${p}`);
+  console.error('\nA row split by a merge, or a `|` inside a cell that needs escaping as `\\|`.');
+  process.exit(1);
+}
+
+console.log(`markdown-tables: OK (${rows} rows across ${tables} tables).`);


### PR DESCRIPTION
`frontend/CLAUDE.md` の共有部品テーブルで、2 行が 1 行に潰れていた。

```
| `TutorialSuggestDialog` | ... | First-visit dialog; ... hook || `TutorialProgressPanel` | ... |
```

`TutorialProgressPanel` の行が前の行の末尾に飲み込まれ、テーブルとして描画されない。

## 原因

この行は `useGameHint` の "currently N" のすぐ下にあり、**あの数字が競合するたびに巻き添えになる**。機械的な競合解消（ハンクの連結）は行末の改行を落とすことがあり、typecheck も lint も Markdown は見ないので誰も気づかない。

今日だけで同じ形を 3 回踏んでいる:

- `useGameHint.ts` で `briscola: ...,  acesup: ...` が 1 行に（#4594、`check-hint-coverage.mjs` の MISSING が拾った）
- `useGameHint.ts` で import 2 本が 1 行に（#4594）
- この行（誰も拾わなかった。目視で見つけた）

## 直したこと

行を分けただけ。他の Markdown テーブルも `| ... || \`` の形で全文検索したが、この 1 件だけだった。

## 根っこ

競合の元は "currently N" で、issue #4652 に上げてある（doc から数字を消し、正確な数を出す `check-hint-coverage.mjs` に委ねる案）。それが入るまでは同じ巻き添えが起きうる。