### PR TITLE
fix(domain): reseed rng on JSON restore, fixing a Tonk crash in production

### DIFF
--- a/internal/domain/Ganjifa.go
+++ b/internal/domain/Ganjifa.go
@@ -252,6 +252,11 @@ func (g *Ganjifa) UnmarshalJSON(data []byte) error {
 	g.gameEndFlag = j.GameEndFlag
 	g.winnerPlayer = j.WinnerPlayer
 	g.actionLog = j.ActionLog
+	// **復元したら必ず乱数源を張り直す。**Cloudflare Worker は毎リクエスト KV から
+	// 組み直すので SetRand は一度も呼ばれない。rng を nil のままにすると、
+	// シャッフル以外で rng を使う経路 (CPU の乱択など) が nil デリファレンスで
+	// 落ちる。呼び出し側ごとにガードするのではなく、ここで構造的に潰す。
+	g.rng = rand.New(rand.NewSource(rand.Int63()))
 	return nil
 }
 

--- a/internal/domain/Tonk.go
+++ b/internal/domain/Tonk.go
@@ -856,5 +856,10 @@ func (g *Tonk) UnmarshalJSON(data []byte) error {
 	}
 	g.isTonk = j.IsTonk
 	g.isUndercut = j.IsUndercut
+	// **復元したら必ず乱数源を張り直す。**Cloudflare Worker は毎リクエスト KV から
+	// 組み直すので SetRand は一度も呼ばれない。rng を nil のままにすると、
+	// シャッフル以外で rng を使う経路 (CPU の乱択など) が nil デリファレンスで
+	// 落ちる。呼び出し側ごとにガードするのではなく、ここで構造的に潰す。
+	g.rng = rand.New(rand.NewSource(rand.Int63()))
 	return nil
 }

--- a/internal/domain/TonkRng_test.go
+++ b/internal/domain/TonkRng_test.go
@@ -1,0 +1,40 @@
+//go:build test
+
+package domain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// **復元したゲームで Easy の CPU を動かす。**Cloudflare Worker は毎リクエスト
+// KV から組み直すので `SetRand` は一度も呼ばれない。`UnmarshalJSON` が rng を
+// 戻さないと、`cpuDraw` の Easy 分岐 (`g.rng.Intn(3)`) が nil の *rand.Rand を
+// 触って落ちる —— サーバー実行ではインタラクタがメモリに残るため再現しない。
+func TestTonk_RestoredGameSurvivesEasyCpu(t *testing.T) {
+	src := NewDefaultTonk()
+	src.Reset()
+	cfg := src.GetConfig()
+	cfg.CpuDifficulty = TonkCpuDifficultyEasy
+	src.SetConfig(cfg)
+
+	data, err := src.MarshalJSON()
+	require.NoError(t, err)
+
+	var restored Tonk
+	require.NoError(t, restored.UnmarshalJSON(data))
+	require.Equal(t, TonkCpuDifficultyEasy, restored.GetConfig().CpuDifficulty)
+
+	for i := 0; i < restored.GetPlayerCnt(); i++ {
+		if !restored.GetPlayer(i).GetIsHuman() {
+			restored.SetCurrentPlayerIdx(i)
+			break
+		}
+	}
+	// SetRand は意図的に呼ばない —— 本番の復元経路には無い一行なので、
+	// ここで呼ぶとこのテストが守るべき穴をそのまま隠してしまう。
+	assert.NotPanics(t, func() { restored.CpuPlay() },
+		"a restored game must not depend on SetRand having been called")
+}

--- a/internal/domain/Vira.go
+++ b/internal/domain/Vira.go
@@ -1033,6 +1033,11 @@ func (g *Vira) UnmarshalJSON(data []byte) error {
 	g.gameEndFlag = j.GameEndFlag
 	g.winnerPlayer = j.WinnerPlayer
 	g.actionLog = j.ActionLog
+	// **復元したら必ず乱数源を張り直す。**Cloudflare Worker は毎リクエスト KV から
+	// 組み直すので SetRand は一度も呼ばれない。rng を nil のままにすると、
+	// シャッフル以外で rng を使う経路 (CPU の乱択など) が nil デリファレンスで
+	// 落ちる。呼び出し側ごとにガードするのではなく、ここで構造的に潰す。
+	g.rng = rand.New(rand.NewSource(rand.Int63()))
 	return nil
 }
 

--- a/internal/domain/rng_restore_test.go
+++ b/internal/domain/rng_restore_test.go
@@ -1,0 +1,61 @@
+//go:build test
+
+package domain
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestEveryRestoredGameReseedsItsRng は「KV から復元するゲームは UnmarshalJSON で
+// 乱数源を張り直す」という規約をソースレベルで強制する。
+//
+// **なぜソースを読むテストなのか。**この穴はゲームごとに 1 行の抜けで生まれ、
+// 症状は Cloudflare Worker 上でしか出ない —— サーバーはインタラクタをメモリに
+// 保持するので、ローカルのテストもCUIも全部通る。実際 Tonk は本番でクラッシュ
+// する状態のまま出荷されていた (Easy 難易度で `g.rng.Intn` が nil を触る)。
+// ゲームごとに個別のテストを書く運用では、次に足すゲームで同じ抜けが起きる。
+//
+// 規約: `rng *rand.Rand` フィールドを持ち、かつ UnmarshalJSON を実装している
+// ドメインは、UnmarshalJSON の中で `g.rng = ...` すること。
+func TestEveryRestoredGameReseedsItsRng(t *testing.T) {
+	dir := "."
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+
+	rngField := regexp.MustCompile(`\brng\s+\*rand\.Rand`)
+	unmarshal := regexp.MustCompile(`(?s)func \(g \*\w+\) UnmarshalJSON.*?\n\}\n`)
+	reseed := regexp.MustCompile(`g\.rng\s*=`)
+
+	checked := 0
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		src, err := os.ReadFile(filepath.Join(dir, name))
+		require.NoError(t, err)
+		s := string(src)
+		if !rngField.MatchString(s) {
+			continue
+		}
+		body := unmarshal.FindString(s)
+		if body == "" {
+			continue // 復元しないドメイン (equity エンジン等) は対象外
+		}
+		checked++
+		require.True(t, reseed.MatchString(body),
+			"%s: UnmarshalJSON が g.rng を張り直していない。Worker は復元後に SetRand を"+
+				" 呼ばないので、シャッフル以外で rng を使う経路が nil で落ちる", name)
+	}
+
+	// **対象 0 件で素通りさせない。**正規表現が実装とずれたら、このガードは
+	// 黙って何も見ずに通る (#4662 のレビューで学んだ形)。
+	require.Greater(t, checked, 8, "対象ゲームが少なすぎる — 検出の正規表現が実装とずれている")
+	t.Logf("checked %d restorable games with a struct rng", checked)
+}


### PR DESCRIPTION
Found by generalising a review finding on #4662 (Tarocchini). **This is a live crash in a shipped game.**

## The bug

**Tonk panics on the Cloudflare Worker whenever CPU difficulty is "Easy".**

`Tonk.UnmarshalJSON` never restores `rng`, and the Worker rebuilds the game from KV on every request without calling `SetRand`. `cpuDraw`'s Easy branch then calls `g.rng.Intn(3)` on a nil `*rand.Rand`:

```go
default:
    shouldPickDiscard = g.rng.Intn(3) == 0   // nil on every request after the first
```

It does **not** reproduce on the standalone server, which keeps the interactor in memory — so local runs and CI are both green while the deployed game crashes. Easy is selectable straight from the settings dropdown, so this is a default-adjacent path, not an edge case.

Reproduced with a test that restores from JSON and drives a CPU turn **without** calling `SetRand` (the line the real restore path does not have).

## Scope

| game | reseeds on restore? | rng used outside a guarded `shuffle()`? | status |
|---|---|---|---|
| **Tonk** | ❌ | ✅ `cpuDraw` | **crashes in production** |
| **Ganjifa** | ❌ | — | safe today, one call site from the same crash |
| **Vira** | ❌ | — | safe today, same |

Ganjifa and Vira are fixed here too so the domain is safe *by construction* rather than by coincidence.

Auditing the domain showed **the convention already existed** — Cuckoo, EgyptianRatscrew, Kemps, SixCardGolf, Slapjack, Spoons, ThirtyOne and Yaniv all reseed on restore. Three games had drifted from it and nothing enforced it. (Tarocchini #4662 had drifted too; fixed on its own branch.)

## The guard

`TestEveryRestoredGameReseedsItsRng` enforces the convention from the source: a domain with an `rng *rand.Rand` field and an `UnmarshalJSON` must assign `g.rng` there.

A per-game test would not have helped. The omission is **one missing line per game**, and the symptom only appears on the Worker — so the next game added repeats it. That is exactly what happened: I wrote the Ganjifa RNG-seeding guard earlier this week, documented it in the Tarocchini PR description, and still shipped Tarocchini and Minchiate with the same hole, because that guard covered `shuffle()` and not the restore path.

The guard asserts it inspected **more than eight** games, so a regex that drifts from the implementation fails loudly instead of silently passing on an empty set — the failure mode I hit with `check-hint-reasons.mjs` earlier this week.

It currently inspects **11** restorable games (Cuckoo, EgyptianRatscrew, Ganjifa, Kemps, SixCardGolf, Slapjack, Spoons, ThirtyOne, Tonk, Vira, Yaniv). The four equity engines have no `UnmarshalJSON` and are correctly skipped rather than miscounted.

## Relation to the vision

> **世界中のあらゆるトランプゲームを、誰でも無料で遊べるようにする。**

"無料で" means the Cloudflare free tier, and that is precisely the environment where this crashes. A game that panics on the deployed target is not playable, so this is a direct regression against the vision rather than a cosmetic issue — hence a standalone fix ahead of the feature branches.

## Test plan

- [x] `go test -tags test ./internal/...` — green
- [x] Reproduction fails before the fix (nil pointer dereference), passes after
- [x] Negative-controlled: removing Tonk's reseed fails both the regression test and the guard
- [x] Guard confirmed to inspect 11 restorable games, not an empty set
- [x] CI — 18/18

## Follow-up, not in this PR

Seeding style is split evenly across the domain — 9 files use `time.Now().UnixNano()`, 9 use `rand.Int63()`. The former can hand two games constructed in the same nanosecond an identical deal. Tonk now has one of each (constructor vs. restore). That is a pre-existing, repo-wide tidy-up rather than part of this crash fix, so it is filed separately instead of widening a hotfix diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)