### PR TITLE
chore(domain): seed every rng from rand.Int63() instead of the clock (closes #4664)

### DIFF
--- a/internal/domain/Cuckoo.go
+++ b/internal/domain/Cuckoo.go
@@ -33,7 +33,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
-	"time"
 )
 
 // CuckooPlayerCnt Cuckoo プレイヤー数 (人間 1 + CPU 3)
@@ -97,7 +96,7 @@ func NewCuckoo(trumpCards *TrumpCards, players []*CuckooPlayer, config CuckooCon
 		roundLowest:     -1,
 		revealedKings:   make([]bool, len(players)),
 		roundLosers:     make([]int, 0),
-		rng:             rand.New(rand.NewSource(time.Now().UnixNano())),
+		rng:             rand.New(rand.NewSource(rand.Int63())),
 	}
 }
 
@@ -775,7 +774,7 @@ func (g *Cuckoo) UnmarshalJSON(data []byte) error {
 		g.actionLog = make([]*ActionLogEntry, 0)
 	}
 	if g.rng == nil {
-		g.rng = rand.New(rand.NewSource(time.Now().UnixNano()))
+		g.rng = rand.New(rand.NewSource(rand.Int63()))
 	}
 	return nil
 }

--- a/internal/domain/EgyptianRatscrew.go
+++ b/internal/domain/EgyptianRatscrew.go
@@ -109,7 +109,7 @@ func NewEgyptianRatscrew(trumpCards *TrumpCards, players []*EgyptianRatscrewPlay
 		winnerIdx:     -1,
 		chanceFromIdx: -1,
 		now:           time.Now,
-		rng:           rand.New(rand.NewSource(time.Now().UnixNano())),
+		rng:           rand.New(rand.NewSource(rand.Int63())),
 	}
 	for i := 0; i < EgyptianRatscrewPlayerCnt && i < len(players); i++ {
 		g.players[i] = players[i]
@@ -638,7 +638,7 @@ func (g *EgyptianRatscrew) UnmarshalJSON(data []byte) error {
 		g.now = time.Now
 	}
 	if g.rng == nil {
-		g.rng = rand.New(rand.NewSource(time.Now().UnixNano()))
+		g.rng = rand.New(rand.NewSource(rand.Int63()))
 	}
 	return nil
 }

--- a/internal/domain/HoldemEquity.go
+++ b/internal/domain/HoldemEquity.go
@@ -6,7 +6,6 @@ import (
 	"math/rand"
 	"runtime"
 	"sync"
-	"time"
 )
 
 // HoldemEquityResult エクイティ計算結果
@@ -90,7 +89,7 @@ func runParallelSimulations(totalSims int, rng *rand.Rand, worker equityWorkerFn
 
 	// rng が nil の場合、一度だけ新しい RNG を生成してシード源とする
 	if rng == nil {
-		rng = rand.New(rand.NewSource(time.Now().UnixNano()))
+		rng = rand.New(rand.NewSource(rand.Int63()))
 	}
 	workerSeeds := make([]int64, numWorkers)
 	for i := range numWorkers {

--- a/internal/domain/SixCardGolf.go
+++ b/internal/domain/SixCardGolf.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
-	"time"
 )
 
 // SixCardGolfPhase ゲームフェーズ
@@ -151,7 +150,7 @@ func NewSixCardGolf(trumpCards *TrumpCards, config SixCardGolfConfig) *SixCardGo
 		config:           config,
 		winnerIdx:        -1,
 		finalTurnTrigger: -1,
-		rng:              rand.New(rand.NewSource(time.Now().UnixNano())),
+		rng:              rand.New(rand.NewSource(rand.Int63())),
 	}
 }
 
@@ -1019,7 +1018,7 @@ func (g *SixCardGolf) UnmarshalJSON(data []byte) error {
 		g.players[i] = p
 	}
 	if g.rng == nil {
-		g.rng = rand.New(rand.NewSource(time.Now().UnixNano()))
+		g.rng = rand.New(rand.NewSource(rand.Int63()))
 	}
 	return nil
 }

--- a/internal/domain/Slapjack.go
+++ b/internal/domain/Slapjack.go
@@ -88,7 +88,7 @@ func NewSlapjack(trumpCards *TrumpCards, players []*SlapjackPlayer, config Slapj
 		config:     config,
 		winnerIdx:  -1,
 		now:        time.Now,
-		rng:        rand.New(rand.NewSource(time.Now().UnixNano())),
+		rng:        rand.New(rand.NewSource(rand.Int63())),
 	}
 	for i := 0; i < SlapjackPlayerCnt && i < len(players); i++ {
 		g.players[i] = players[i]
@@ -490,7 +490,7 @@ func (g *Slapjack) UnmarshalJSON(data []byte) error {
 		g.now = time.Now
 	}
 	if g.rng == nil {
-		g.rng = rand.New(rand.NewSource(time.Now().UnixNano()))
+		g.rng = rand.New(rand.NewSource(rand.Int63()))
 	}
 	return nil
 }

--- a/internal/domain/ThirtyOne.go
+++ b/internal/domain/ThirtyOne.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
-	"time"
 )
 
 // ThirtyOnePlayerCnt ThirtyOne プレイヤー数 (人間 1 + CPU 3)
@@ -68,7 +67,7 @@ func NewThirtyOne(trumpCards *TrumpCards, players []*ThirtyOnePlayer, config Thi
 		thirtyOneIdx:   -1,
 		roundWinnerIdx: -1,
 		roundLosers:    make([]int, 0),
-		rng:            rand.New(rand.NewSource(time.Now().UnixNano())),
+		rng:            rand.New(rand.NewSource(rand.Int63())),
 	}
 }
 
@@ -787,7 +786,7 @@ func (g *ThirtyOne) UnmarshalJSON(data []byte) error {
 		g.actionLog = make([]*ActionLogEntry, 0)
 	}
 	if g.rng == nil {
-		g.rng = rand.New(rand.NewSource(time.Now().UnixNano()))
+		g.rng = rand.New(rand.NewSource(rand.Int63()))
 	}
 	return nil
 }

--- a/internal/domain/Tonk.go
+++ b/internal/domain/Tonk.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
-	"time"
 )
 
 // TonkPlayerCnt Tonkプレイヤー数
@@ -75,7 +74,7 @@ func NewTonk(trumpCards *TrumpCards, players []*TonkPlayer, config TonkConfig) *
 		winnerIdx:   -1,
 		roundNumber: 0,
 		knockerIdx:  -1,
-		rng:         rand.New(rand.NewSource(time.Now().UnixNano())),
+		rng:         rand.New(rand.NewSource(rand.Int63())),
 	}
 }
 

--- a/internal/domain/Yaniv.go
+++ b/internal/domain/Yaniv.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"math/rand"
 	"sort"
-	"time"
 )
 
 // YanivPlayerCnt Yaniv プレイヤー数 (人間 1 + CPU 3)
@@ -66,7 +65,7 @@ func NewYaniv(trumpCards *TrumpCards, players []*YanivPlayer, config YanivConfig
 		callerIdx:     -1,
 		asafWinnerIdx: -1,
 		roundScores:   make([]int, 0),
-		rng:           rand.New(rand.NewSource(time.Now().UnixNano())),
+		rng:           rand.New(rand.NewSource(rand.Int63())),
 	}
 }
 
@@ -969,7 +968,7 @@ func (g *Yaniv) UnmarshalJSON(data []byte) error {
 		g.actionLog = make([]*ActionLogEntry, 0)
 	}
 	if g.rng == nil {
-		g.rng = rand.New(rand.NewSource(time.Now().UnixNano()))
+		g.rng = rand.New(rand.NewSource(rand.Int63()))
 	}
 	return nil
 }

--- a/internal/domain/rng_restore_test.go
+++ b/internal/domain/rng_restore_test.go
@@ -59,3 +59,47 @@ func TestEveryRestoredGameReseedsItsRng(t *testing.T) {
 	require.Greater(t, checked, 8, "対象ゲームが少なすぎる — 検出の正規表現が実装とずれている")
 	t.Logf("checked %d restorable games with a struct rng", checked)
 }
+
+// TestNoDomainSeedsItsRngFromTheClock は「乱数の種に時計を使わない」規約を
+// ソースレベルで強制する。
+//
+// **同じナノ秒に作った 2 局が同じ配りになる。**`time.Now().UnixNano()` は
+// 時計の分解能が粗い環境や、Worker が短時間に複数セッションを立ち上げる状況で
+// 衝突しうる。Go 1.20 以降グローバル `rand` は起動時にランダムに初期化される
+// ので、`rand.Int63()` を種にすればこの衝突は起きない。
+//
+// **コメントは対象外。**「なぜ time を使わないか」を説明した行が数箇所あり、
+// 素朴に文字列検索するとそれを実装だと誤認する (実際 Ganjifa / Minchiate /
+// Tarocchini の 3 ファイルが該当する)。行頭のコメントを落としてから見る。
+func TestNoDomainSeedsItsRngFromTheClock(t *testing.T) {
+	entries, err := os.ReadDir(".")
+	require.NoError(t, err)
+
+	lineComment := regexp.MustCompile(`(?m)^\s*//.*$`)
+	clockSeed := regexp.MustCompile(`rand\.NewSource\(\s*time\.Now\(\)`)
+	anySeed := regexp.MustCompile(`rand\.NewSource\(`)
+
+	seeders := 0
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		src, err := os.ReadFile(name)
+		require.NoError(t, err)
+		code := lineComment.ReplaceAllString(string(src), "")
+		if !anySeed.MatchString(code) {
+			continue
+		}
+		seeders++
+		require.False(t, clockSeed.MatchString(code),
+			"%s: 乱数の種が time.Now() —— 同一ナノ秒に構築された 2 局が同じ配りになる。"+
+				"rand.NewSource(rand.Int63()) を使うこと (#4664)", name)
+	}
+
+	// **対象 0 件で素通りさせない。**正規表現が実装とずれたら、このガードは
+	// 黙って何も見ずに通る。
+	// 14 が現在の実測値。1 桁に落ちたら正規表現が実装から外れたと見てよい。
+	require.Greater(t, seeders, 10, "種を張るドメインが少なすぎる — 検出の正規表現が実装とずれている")
+	t.Logf("checked %d domains that seed an rng", seeders)
+}

--- a/internal/domain/rng_restore_test.go
+++ b/internal/domain/rng_restore_test.go
@@ -3,6 +3,10 @@
 package domain
 
 import (
+	"bytes"
+	"go/parser"
+	"go/printer"
+	"go/token"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -11,6 +15,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 )
+
+// dir はドメインのソースが並ぶディレクトリ。両ガードが同じ場所を読む。
+const dir = "."
 
 // TestEveryRestoredGameReseedsItsRng は「KV から復元するゲームは UnmarshalJSON で
 // 乱数源を張り直す」という規約をソースレベルで強制する。
@@ -24,7 +31,6 @@ import (
 // 規約: `rng *rand.Rand` フィールドを持ち、かつ UnmarshalJSON を実装している
 // ドメインは、UnmarshalJSON の中で `g.rng = ...` すること。
 func TestEveryRestoredGameReseedsItsRng(t *testing.T) {
-	dir := "."
 	entries, err := os.ReadDir(dir)
 	require.NoError(t, err)
 
@@ -68,15 +74,16 @@ func TestEveryRestoredGameReseedsItsRng(t *testing.T) {
 // 衝突しうる。Go 1.20 以降グローバル `rand` は起動時にランダムに初期化される
 // ので、`rand.Int63()` を種にすればこの衝突は起きない。
 //
-// **コメントは対象外。**「なぜ time を使わないか」を説明した行が数箇所あり、
-// 素朴に文字列検索するとそれを実装だと誤認する (実際 Ganjifa / Minchiate /
-// Tarocchini の 3 ファイルが該当する)。行頭のコメントを落としてから見る。
+// **コメントは go/parser に落としてから見る。**「なぜ time を使わないか」を
+// 説明した行が数箇所あり (Ganjifa / Minchiate / Tarocchini)、素朴に文字列検索
+// するとそれを実装だと誤認して正しいコードで落ちる。正規表現で `//` を剥ぐ手も
+// あるが、行末コメントとブロックコメントを取りこぼすうえ、文字列リテラル中の
+// `//` まで削ってしまう。構文解析なら 3 種すべてが確実に落ちる。
 func TestNoDomainSeedsItsRngFromTheClock(t *testing.T) {
-	entries, err := os.ReadDir(".")
+	entries, err := os.ReadDir(dir)
 	require.NoError(t, err)
 
-	lineComment := regexp.MustCompile(`(?m)^\s*//.*$`)
-	clockSeed := regexp.MustCompile(`rand\.NewSource\(\s*time\.Now\(\)`)
+	clockSeed := regexp.MustCompile(`rand\.NewSource\(\s*time\.Now\(`)
 	anySeed := regexp.MustCompile(`rand\.NewSource\(`)
 
 	seeders := 0
@@ -85,9 +92,7 @@ func TestNoDomainSeedsItsRngFromTheClock(t *testing.T) {
 		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
 			continue
 		}
-		src, err := os.ReadFile(name)
-		require.NoError(t, err)
-		code := lineComment.ReplaceAllString(string(src), "")
+		code := parseWithoutComments(t, filepath.Join(dir, name))
 		if !anySeed.MatchString(code) {
 			continue
 		}
@@ -98,8 +103,19 @@ func TestNoDomainSeedsItsRngFromTheClock(t *testing.T) {
 	}
 
 	// **対象 0 件で素通りさせない。**正規表現が実装とずれたら、このガードは
-	// 黙って何も見ずに通る。
-	// 14 が現在の実測値。1 桁に落ちたら正規表現が実装から外れたと見てよい。
+	// 黙って何も見ずに通る。14 が現在の実測値。
 	require.Greater(t, seeders, 10, "種を張るドメインが少なすぎる — 検出の正規表現が実装とずれている")
 	t.Logf("checked %d domains that seed an rng", seeders)
+}
+
+// parseWithoutComments はソースを構文解析し、コメントを落とした形に戻す。
+func parseWithoutComments(t *testing.T, path string) string {
+	t.Helper()
+	fset := token.NewFileSet()
+	// ParseComments を渡さないので、コメントはそもそも AST に載らない。
+	file, err := parser.ParseFile(fset, path, nil, 0)
+	require.NoError(t, err, "%s の構文解析に失敗", path)
+	var buf bytes.Buffer
+	require.NoError(t, printer.Fprint(&buf, fset, file))
+	return buf.String()
 }


### PR DESCRIPTION
Closes #4664

Follow-up to the #4663 review nit, split out so the hotfix stayed narrow.

## Why

`time.Now().UnixNano()` gives **two games built in the same nanosecond the same deal**. That is reachable on a coarse clock, and on a Worker opening several sessions in quick succession. Go 1.20+ seeds the global `rand` randomly at startup, so `rand.Int63()` has no such collision.

Not urgent, but two different idioms for the same thing across the domain is how the Tonk bug in #4663 hid — that file had **both**, one per constructor.

## What changed

**14 seed sites across 8 files** — Cuckoo, EgyptianRatscrew, HoldemEquity, SixCardGolf, Slapjack, ThirtyOne, Tonk, Yaniv.

The issue said 9 files; the real number is 8. My count was wrong: three of the hits I counted (Ganjifa, Minchiate, Tarocchini) are *comments* explaining why the clock is **not** used, not implementations.

`Slapjack` and `EgyptianRatscrew` keep their `"time"` import — they inject a clock to measure slap reaction times. The other six lose it.

## The guard

`TestNoDomainSeedsItsRngFromTheClock`, in the same file and shape as #4663's reseed guard.

Two things it does deliberately:

- **Strips line comments before matching.** A plain string search reads those three explanatory comments as implementation and fails on correct code. This was not hypothetical — the first version did exactly that.
- **Floors the inspected population at 10.** 14 domains call `rand.NewSource` today; if the regex drifts away from the code, the guard would otherwise inspect nothing and pass silently.

Negative-controlled in both directions: reintroducing a clock seed in `Yaniv.go` fails the guard naming the file, and removing it passes again.

## Test plan

- [x] `go test -tags test ./internal/...` — pass
- [x] The 8 affected domains at `-count=100` — pass (#4467 was a low-probability flake in this class, so this is not optional)
- [x] Guard negative-controlled both ways
- [x] `go vet` — clean, no stale or missing `"time"` imports

No behaviour changes, so no per-game docs to update.