### PR TITLE
test(e2e): let the Kaiser spec pass through an all-pass redeal (closes #4668)

### DIFF
--- a/frontend/e2e/kaiser.spec.ts
+++ b/frontend/e2e/kaiser.spec.ts
@@ -21,7 +21,13 @@ test.describe('Kaiser E2E', () => {
     // two unrelated PRs (#4665, #4667) before anyone measured it.
     const bidSeven = page.getByRole('button', { name: '7 を宣言' });
     for (let round = 0; round < 12; round++) {
-      if (!(await isVisibleWithin(bidSeven, TIMEOUT_ACTION))) break;
+      // The first check waits the full game-loop budget: the CPUs may still be
+      // bidding, and on a slow runner a short timeout here would break the loop
+      // early and drop us into the four-way check while the page is still
+      // showing bid buttons -- trading this flake for a rarer one. Later rounds
+      // follow a redeal we just triggered, so the shorter budget is enough.
+      const budget = round === 0 ? TIMEOUT_GAME_LOOP : TIMEOUT_ACTION;
+      if (!(await isVisibleWithin(bidSeven, budget))) break;
       // Six is below the floor, so no such button should ever exist.
       await expect(page.getByRole('button', { name: '6 を宣言' })).toHaveCount(0);
       await page.getByRole('button', { name: 'パス' }).click();

--- a/frontend/e2e/kaiser.spec.ts
+++ b/frontend/e2e/kaiser.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { isVisibleWithin, navigateTo, TIMEOUT_GAME_LOOP, waitForLoaded } from './helpers';
+import { isVisibleWithin, navigateTo, TIMEOUT_ACTION, TIMEOUT_GAME_LOOP, waitForLoaded } from './helpers';
 
 test.describe('Kaiser E2E', () => {
   test('shows the scoring cards, bids and reaches play', async ({ page }) => {
@@ -14,9 +14,14 @@ test.describe('Kaiser E2E', () => {
 
     await expect(page.getByTestId('kaiser-player')).toHaveCount(4, { timeout: TIMEOUT_GAME_LOOP });
 
-    // The human may open the bidding, or the CPUs may already have taken it.
+    // **The human can be asked to bid more than once.** If everybody passes the
+    // domain redeals the same hand (`advanceBid` -> `beginHand`), which puts the
+    // bidding back in front of the human. Passing exactly once and then expecting
+    // play/discard/trump/next left this test failing on ~1 deal in 4 -- it reddened
+    // two unrelated PRs (#4665, #4667) before anyone measured it.
     const bidSeven = page.getByRole('button', { name: '7 を宣言' });
-    if (await isVisibleWithin(bidSeven, TIMEOUT_GAME_LOOP)) {
+    for (let round = 0; round < 12; round++) {
+      if (!(await isVisibleWithin(bidSeven, TIMEOUT_ACTION))) break;
       // Six is below the floor, so no such button should ever exist.
       await expect(page.getByRole('button', { name: '6 を宣言' })).toHaveCount(0);
       await page.getByRole('button', { name: 'パス' }).click();
@@ -24,7 +29,9 @@ test.describe('Kaiser E2E', () => {
     }
 
     // The hand must progress rather than hang: either we play, we name trump /
-    // discard as declarer, or the hand is already settled.
+    // discard as declarer, or the hand is already settled. Still bidding after
+    // twelve all-pass redeals is vanishingly unlikely, and would mean the page
+    // stopped responding rather than that the deal was unlucky.
     const play = page.getByRole('button', { name: '出す' });
     const discard = page.getByRole('button', { name: '捨てる' });
     const next = page.getByRole('button', { name: '次の局へ' });


### PR DESCRIPTION
Closes #4668

`e2e/kaiser.spec.ts` has been failing on **roughly a quarter of runs** and taking unrelated PRs down with it — #4665 (Minchiate) and #4667 (RNG seeding). I reran the first one and moved on, which is why it took a second hit to get looked at.

## It is the test, not the game

Kaiser redeals when everybody passes, which is correct:

```go
if k.highBid == nil && k.passCount >= KaiserPlayerCnt {
    // **全員パスなら配り直し。**同じディーラーでもう一度配る。
    k.handNumber--
    k.beginHand()
    return
}
```

The spec pressed パス **once**, then asserted that one of four controls was visible — play, discard, name-trump, next-hand. After a redeal the human is asked to bid again, so the screen shows **bid** buttons, all four `isVisibleWithin` calls return false, and `expect(...).toBe(true)` fails. A fifth legitimate state with no branch.

## Measured, not assumed

| | |
|---|---|
| Local runs before the fix | **3 failures in 15 (20%)** |
| Domain driven through the same sequence | **1,399 of 5,000 deals (28%)** land back in bidding |
| Local runs after the fix | **25 / 25** |

## The fix

Passing becomes a bounded loop. Twelve consecutive all-pass redeals is about `0.28^12` ≈ 2e-7, so if the assertion is reached while still bidding, the page has stopped responding rather than the deal being unlucky — which is what the test was trying to say in the first place.

## Note on the reproduction

My first domain probe reported "every deal is stuck" — false. It compared `GetCurrentPlayerIdx()` before and after each CPU step, but during bidding the index that moves is `bidIdx`, not `currentIdx`. Checking a signature of the whole state (phase, both indices, trick number, hand number) instead gave the correct answer: **0 stuck states in 3,000 deals**, i.e. the domain always leaves the human something to do.

## Test plan

- [x] 25 consecutive local runs of `e2e/kaiser.spec.ts` — all pass
- [x] Confirmed the pre-fix rate on the same machine (12/15)
- [x] `bun run check` — biome clean
- [ ] CI E2E shard