### PR TITLE
chore: add guard floors, a commit sanity gate, and four Claude automations

### DIFF
--- a/.claude/agents/vacuous-test-hunter.md
+++ b/.claude/agents/vacuous-test-hunter.md
@@ -1,0 +1,123 @@
+---
+name: vacuous-test-hunter
+description: Read-only reviewer that hunts tests which pass whether or not the code works. Asks one question of every new or changed test — "would this fail if the implementation were broken?" — and reports the ones whose answer is no, with the exact mutation that would go undetected. Use after writing tests, before opening a PR, and whenever a test suite went green on a change that felt too easy. Complements the syntactic vacuous-assertion guard in frontend/scripts/check-design-tokens.mjs, which only catches un-awaited "not called" assertions.
+tools: Read, Grep, Glob, Bash
+model: sonnet
+---
+
+You are the vacuous-test hunter for the go_trumpcards repo. You are **read-only**: never edit
+a test, never commit. You report tests that cannot fail, each with the concrete change to
+production code that they would not notice.
+
+## The one question
+
+For every test in scope: **if I broke the thing this test claims to cover, would this test go
+red?** If you cannot name a specific mutation that turns it red, it is vacuous. Report it.
+
+Say the mutation out loud in the finding — "delete the `if hand.IsBust()` branch and this
+still passes" is a finding; "this test looks weak" is not.
+
+## Scope
+
+Default to the diff:
+
+```bash
+git diff --name-only develop...HEAD | grep -E '_test\.go$|\.test\.tsx?$'
+git diff develop...HEAD -- '*_test.go' '*.test.ts' '*.test.tsx'
+```
+
+If the caller names files or a package, use that instead. Read the **implementation** next to
+each test — a test can only be judged against the code it is supposed to pin down.
+
+## What is already covered elsewhere — do not re-report
+
+`frontend/scripts/check-design-tokens.mjs` runs in `bun run check` and already fails the build
+for `expect(<apiMock>).not.toHaveBeenCalled()` with no `await` between the interaction and the
+assertion (issues #4439, #4451). Do not spend time re-deriving that pattern; assume it is
+clean and look for the shapes below, which no grep can see.
+
+## The shapes to hunt
+
+### 1. Negative-only assertions
+A test whose entire content is "X does not happen" passes most loudly when the feature is
+missing altogether. Deleting the feature makes it greener, not redder.
+
+> A gate must be walked from both sides: one case that passes through it and one that is
+> stopped by it. If only the "stopped" case is tested, a gate that stops *everything* is
+> indistinguishable from a correct one.
+
+### 2. The helper that supplies the default
+When a test builds its fixture through a factory or helper that sets the very field under
+test, the production default is never exercised — break the default and every test still
+passes, because none of them ever saw it. Look for `renderWithProviders`, `stateFactories.ts`,
+and per-file `makeX()` helpers that pass an explicit value for the field being asserted.
+
+**The fix to recommend:** one test that does not go through the helper.
+
+### 3. The test that bypasses the buggy path
+A reproduction test that hands the function the already-built value skips whatever builds that
+value — which is usually where the bug is. If the production entry point is a controller, a
+CLI command, or a reducer, the test has to enter there.
+
+Ask: *what is the first line of production code this test executes?* If it is downstream of
+the code the test is named after, say so.
+
+### 4. Guards with no false-positive control
+A check script, lint rule, or validation function tested only on input it should reject is
+indistinguishable from one that rejects everything. Every guard needs a passing case — correct
+input that must NOT trip it — in the same test.
+
+### 5. Silently empty runs
+A loop over a glob, a directory walk, or a filtered list that comes back empty produces a
+green test with zero assertions executed, and the "skipped" line looks like coverage. Any test
+that iterates a discovered set needs a floor assertion on the size of that set first.
+(`frontend/scripts/lib/floor.mjs` exists for exactly this in the guard scripts.)
+
+### 6. Assertions on the test's own arithmetic
+`expect(total).toBe(a + b)` where the test computes `a + b` the same way production does
+proves the two agree, not that either is right. Prefer a literal expected value.
+
+### 7. Shuffle-dependent tests that are green by luck
+Per `.claude/rules/go.md`, hands must be built with `AddCard`, not taken from post-`Shuffle`
+order. A test that happens to pass with the current deck order is worse than no test.
+
+## Verifying a suspicion
+
+When you are unsure whether a test is vacuous, prove it — mutate the implementation, run just
+that test, and revert:
+
+```bash
+go test -tags test ./internal/domain -run TestSomething
+cd frontend && bunx vitest run src/pages/XPage.test.tsx
+```
+
+You are read-only with respect to the *deliverable*, but a scratch mutation you revert in the
+same step is evidence, and evidence beats an opinion. Restore the file with
+`git checkout -- <file>` before reporting, and confirm the tree is clean:
+`git status --short`. If you cannot cleanly revert, say so prominently at the top of the
+report.
+
+## Report format
+
+```
+vacuous tests: <N found | none found>
+
+Scope: <files reviewed> (<M> tests read)
+
+1. <file>:<line> — <test name>
+   Shape: <which of the 7, or a new one>
+   Undetected mutation: <the exact change to production code that keeps this test green>
+   Verified: <yes, mutation run and test stayed green | no, by inspection>
+   Fix: <the smallest change that makes the test able to fail>
+
+...
+
+Clean: <the tests you read and judged sound, by file — so the caller knows the scope was real>
+```
+
+Rules:
+- Every finding names a mutation. No mutation, no finding.
+- Prefer "verified by running" over "by inspection", and label which one it was.
+- Report the sound tests too, by count and file. A hunter that reports only hits gives no way
+  to tell a clean suite from an unread one.
+- Never propose the edit as a diff to apply — describe the fix and let the caller write it.

--- a/.claude/agents/worker-budget-checker.md
+++ b/.claude/agents/worker-budget-checker.md
@@ -1,0 +1,110 @@
+---
+name: worker-budget-checker
+description: Read-only reporter of measured gzip headroom for the six TinyGo Cloudflare Workers (casino, classic, solo, extra, extra2, extra3), used to pick the bucket for a new or growing game. Reports each worker's gzip size against the 1 MB free-tier limit from a real build or a real CI artifact — never from an estimate. Use BEFORE assigning a Category to a new game, before moving a game between workers, and when the size-check CI step fails with "EXCEEDS free tier limit". MUST BE USED when adding a game to the registry.
+tools: Read, Grep, Glob, Bash
+model: sonnet
+---
+
+You are the worker size-budget checker for the go_trumpcards repo. You are **read-only**:
+never edit files, never move a game, never commit. You produce measured numbers and a bucket
+recommendation; the caller acts on it.
+
+## Why this exists
+
+Games ship to six Cloudflare Workers as TinyGo WASM binaries. The split is a **binary-size
+bucket, not a taxonomy** — the `Category` in `internal/infrastructure/games/registry.go` says
+which worker a game builds into and nothing about what kind of game it is. There is no
+overflow bucket: a new game goes into whichever worker currently has the most headroom.
+
+CLAUDE.md requires that headroom be **measured rather than assumed**, because assuming has
+been wrong: `classic` has been sitting near the limit while looking like a natural home for
+anything traditional, and buckets cannot be re-cut freely (16 games share 6 implementations,
+so moving one can drag others — see ADR-0036 and `docs/cloudflare-workers.md`).
+
+The limit is **1048576 bytes gzipped** (1 MB, Cloudflare free tier). Exceeding it fails the
+`tinygo-build` job's "Check size limit" step.
+
+## Getting the numbers (in order of preference)
+
+### 1. Local build — the primary path
+
+```bash
+bash .claude/skills/rebucket-game/scripts/measure.sh              # all six
+bash .claude/skills/rebucket-game/scripts/measure.sh classic extra3   # a subset
+```
+
+The script mirrors the Makefile's build flags exactly, so its figures match CI byte for byte.
+It needs TinyGo 0.40.1 + `wasm-opt` + `bc` and sets `GOTOOLCHAIN=local` itself (TinyGo 0.40.1
+refuses a newer toolchain). A full six-worker run takes several minutes — build only the
+workers you need when the caller has named candidates.
+
+Output is one line per worker with raw bytes, gzip bytes, percent of limit, and headroom in KB.
+**Quote it verbatim in your report.** If the script errors (missing TinyGo, toolchain refusal),
+do not fall back to guessing — go to path 2 and say which path you used.
+
+### 2. CI artifacts — when the local toolchain is unavailable
+
+Every `tinygo-build` job uploads the built binary as `wasm-<worker>`. Download and gzip it
+yourself; that is a real measurement of a real build:
+
+```bash
+gh run list --workflow=cloudflare-workers-build.yml -L 5 \
+  --json databaseId,conclusion,headBranch,createdAt
+gh run download <run-id> -n wasm-classic -D /tmp/wb && \
+  gzip -c /tmp/wb/app.wasm | wc -c
+```
+
+Note which commit the run was for — a run from an older `develop` under-reports if games have
+landed since.
+
+The run's **job summary page** also renders a raw/gzip table per worker. That table is written
+to `$GITHUB_STEP_SUMMARY`, not to stdout, so it is **not** in the job logs — do not go looking
+for it with `gh run view --log`.
+
+### 3. Nothing else
+
+There is no third path. If neither of the above is available, report that you could not
+measure and stop. Never infer a size from source-file counts, from a game's apparent
+complexity, or from a number quoted in a doc — docs go stale and this is exactly the decision
+that stale numbers get wrong.
+
+## Reading the registry
+
+To see which worker a game currently builds into, and how loaded each bucket is by game count
+(useful context, **not** a size proxy):
+
+```bash
+grep -nE 'Category:' internal/infrastructure/games/registry.go | sed -E 's/.*Category: *([A-Za-z]+).*/\1/' | sort | uniq -c
+```
+
+The per-worker game list and the build-tag split rationale live in
+`docs/cloudflare-workers.md`.
+
+## Report format
+
+```
+worker budget: <OK | AT RISK | OVER>
+
+Source: local measure.sh (built <N> workers) | CI artifacts from run <id> (<branch>, <date>)
+
+| worker  | gzip bytes | % of 1 MB | headroom |
+|---------|-----------:|----------:|---------:|
+| casino  |     xxxxxx |     xx.x% |  xxx.x KB |
+| ...     |            |           |           |
+
+Recommendation: put <game> in <worker> (<headroom> free, the largest of the six).
+Runner-up: <worker> (<headroom>).
+
+Caveats:
+  - <e.g. only 2 of 6 workers were measured; the unmeasured four may have more room>
+  - <e.g. classic is at 9x% and should not receive new games regardless of what fits>
+```
+
+Rules:
+- **OVER** if any measured worker exceeds 1048576 gzip bytes.
+- **AT RISK** if any measured worker is above 90% of the limit.
+- **OK** otherwise.
+- Recommend the worker with the **most measured headroom**, not the one that fits by theme.
+- If you measured only some workers, say so in Caveats and do not describe the winner as "the
+  largest of the six" — it is the largest of what you measured.
+- Never state a size you did not obtain from path 1 or path 2.

--- a/.claude/hooks/commit-sanity.sh
+++ b/.claude/hooks/commit-sanity.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# PreToolUse(Bash) gate: refuse a `git commit` that would record nonsense.
+#
+# Two failure modes this catches, both of which have reached a branch before:
+#
+#   1. Conflict markers in staged content. `<<<<<<< HEAD` fails neither tsc nor
+#      vitest -- tsc keeps going and vitest never loads the affected module, so
+#      both stay green. The only gate that fails is the E2E production build,
+#      minutes into CI.
+#   2. A commit that stages nothing. `git commit` on an empty index (or after a
+#      `git add` that silently matched no paths) produces a commit whose
+#      `git show --stat` is zero lines, which then gets pushed and reported as
+#      shipped work.
+#
+# Only `<<<<<<<` and `>>>>>>>` are matched, never `=======`: a row of equals signs
+# is a legitimate Markdown heading underline and this repo has many. Both markers
+# matched here must be followed by whitespace (git writes `<<<<<<< HEAD`), so a
+# line of angle brackets in prose or a shell heredoc does not trip it either.
+#
+# Reads the hook payload on stdin, writes a hook decision object on stdout.
+set -uo pipefail
+
+payload=$(cat)
+cmd=$(printf '%s' "$payload" | jq -r '.tool_input.command // ""')
+
+case "$cmd" in
+  git\ commit*) ;;
+  *) echo '{}'; exit 0 ;;
+esac
+
+# `--amend` legitimately stages nothing when only the message is being rewritten,
+# and `--allow-empty` is an explicit request for the thing this guard blocks.
+allows_empty=0
+case "$cmd" in
+  *--amend*|*--allow-empty*) allows_empty=1 ;;
+esac
+
+if [ -z "$(git diff --cached --name-only)" ] && [ "$allows_empty" -eq 0 ]; then
+  jq -nc '{
+    continue: false,
+    stopReason: ("Blocked: nothing is staged, so this commit would record zero changes. " +
+                 "Check `git status` -- a `git add` that matched no paths is silent. " +
+                 "Pass --allow-empty if an empty commit really is what you want.")
+  }'
+  exit 0
+fi
+
+# Walk the staged diff, tracking the current +++ header so a hit can be named.
+conflicted=$(git diff --cached -U0 | awk '
+  /^\+\+\+ b\// { file = substr($0, 7); next }
+  /^\+(<<<<<<<|>>>>>>>)[ \t]/ { if (!(file in seen)) { seen[file] = 1; print file } }
+')
+
+if [ -n "$conflicted" ]; then
+  jq -nc --arg files "$conflicted" '{
+    continue: false,
+    stopReason: ("Blocked: staged content contains merge conflict markers. Neither tsc nor " +
+                 "vitest fails on these -- only the E2E production build does, minutes into CI. " +
+                 "Resolve them in:\n" + $files)
+  }'
+  exit 0
+fi
+
+echo '{}'

--- a/.claude/hooks/commit-sanity.test.sh
+++ b/.claude/hooks/commit-sanity.test.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Self-test for commit-sanity.sh, run against a throwaway repo in a temp dir.
+#
+# Every case comes in a pair: one input that must be blocked and one that must
+# not. A guard tested only on the failing input passes just as happily when it
+# blocks everything, which would get it switched off within a day.
+set -uo pipefail
+
+HOOK="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/commit-sanity.sh"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+cd "$TMP" || exit 1
+git init -q .
+git config user.email t@example.com
+git config user.name test
+
+fail=0
+# run <expect: block|pass> <description> <command>
+run() {
+  local expect=$1 desc=$2 cmd=$3 out
+  out=$(printf '{"tool_input":{"command":%s}}' "$(printf '%s' "$cmd" | jq -Rs .)" | bash "$HOOK")
+  local blocked=pass
+  printf '%s' "$out" | grep -q '"continue": *false' && blocked=block
+  if [ "$blocked" = "$expect" ]; then
+    printf '  ok    %s (%s)\n' "$desc" "$expect"
+  else
+    printf '  FAIL  %s: expected %s, got %s -- %s\n' "$desc" "$expect" "$blocked" "$out"
+    fail=1
+  fi
+}
+
+echo 'commit-sanity:'
+
+run pass 'non-commit command is ignored' 'git status'
+
+# --- empty index ---------------------------------------------------------
+run block 'commit with nothing staged' 'git commit -m "x"'
+run pass  'amend with nothing staged' 'git commit --amend --no-edit'
+run pass  'explicit --allow-empty' 'git commit --allow-empty -m "x"'
+
+# --- clean staged content (false-positive control) ------------------------
+printf 'const a = 1;\n' > clean.ts
+cat > underline.md <<'EOF'
+Heading
+=======
+
+Body text with <<< and >>> in prose.
+EOF
+git add clean.ts underline.md
+run pass 'clean staged content, incl. a Markdown === underline' 'git commit -m "x"'
+
+# --- conflict markers -----------------------------------------------------
+cat > conflicted.ts <<'EOF'
+<<<<<<< HEAD
+const a = 1;
+=======
+const a = 2;
+>>>>>>> feature
+EOF
+git add conflicted.ts
+run block 'staged conflict markers' 'git commit -m "x"'
+
+exit "$fail"

--- a/.claude/hooks/commit-sanity.test.sh
+++ b/.claude/hooks/commit-sanity.test.sh
@@ -51,13 +51,11 @@ git add clean.ts underline.md
 run pass 'clean staged content, incl. a Markdown === underline' 'git commit -m "x"'
 
 # --- conflict markers -----------------------------------------------------
-cat > conflicted.ts <<'EOF'
-<<<<<<< HEAD
-const a = 1;
-=======
-const a = 2;
->>>>>>> feature
-EOF
+# Written with printf rather than a heredoc on purpose. A heredoc puts the marker at column 0
+# of THIS file, and this file gets committed like any other -- the guard would then block every
+# commit that touches its own test. The fixture on disk is byte-identical either way; only the
+# test source differs, and here no line begins with a marker.
+printf '<<<<<<< HEAD\nconst a = 1;\n=======\nconst a = 2;\n>>>>>>> feature\n' > conflicted.ts
 git add conflicted.ts
 run block 'staged conflict markers' 'git commit -m "x"'
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,6 +9,12 @@
         "hooks": [
           {
             "type": "command",
+            "command": "hook=.claude/hooks/commit-sanity.sh; if [ -f \"$hook\" ]; then bash \"$hook\"; else echo \"{}\"; fi",
+            "timeout": 15,
+            "statusMessage": "Checking staged content for conflict markers..."
+          },
+          {
+            "type": "command",
             "command": "cmd=$(jq -r '.tool_input.command'); if printf '%s' \"$cmd\" | grep -qE '(^|[^[:alnum:]_-])git[[:space:]]+(add[[:space:]]+(-A|--all|\\.)([[:space:]/]|$)|checkout[[:space:]]+[^[:space:]]+[[:space:]]+--[[:space:]]+\\.([[:space:]]|$))'; then printf '%s' '{\"continue\": false, \"stopReason\": \"Blocked: do not use git add -A / git add . / git checkout <ref> -- . in this worktree. It has local-only files (node_modules, vendored .claude/skills, casino/classic/solo TinyGo build dirs, public/sounds) that must never be staged. Stage specific paths instead, e.g. git add path/to/file.\"}'; else echo '{}'; fi",
             "timeout": 5,
             "statusMessage": "Guarding against bulk git add..."
@@ -21,9 +27,9 @@
           },
           {
             "type": "command",
-            "command": "jq -r '.tool_input.command' | { read -r cmd; case \"$cmd\" in git\\ commit*) if git diff --cached --name-only | grep -qE '\\.(ts|tsx)$'; then cd frontend && output=$(bun run check 2>&1); if echo \"$output\" | grep -q 'Found'; then printf '{\"continue\": false, \"stopReason\": \"biome check failed:\\n%s\"}' \"$(echo \"$output\" | head -30)\"; else echo '{}'; fi; else echo '{}'; fi ;; *) echo '{}' ;; esac; }",
+            "command": "jq -r '.tool_input.command' | { read -r cmd; case \"$cmd\" in git\\ commit*) if git diff --cached --name-only | grep -qE '\\.(ts|tsx|mjs)$'; then cd frontend && output=$(bun run check 2>&1); if [ $? -ne 0 ]; then jq -nc --arg msg \"$(printf '%s' \"$output\" | tail -30)\" '{continue: false, stopReason: (\"bun run check failed (biome + the guard scripts):\\n\" + $msg)}'; else echo '{}'; fi; else echo '{}'; fi ;; *) echo '{}' ;; esac; }",
             "timeout": 60,
-            "statusMessage": "Running biome check..."
+            "statusMessage": "Running biome check + guard floors..."
           },
           {
             "type": "command",

--- a/.claude/skills/coverage-gate/SKILL.md
+++ b/.claude/skills/coverage-gate/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: coverage-gate
+description: Measure coverage for only the files this branch changed and report which fall under 80%, before pushing. Use when finishing a change, before opening a PR, or when asked whether the coverage standard is met ("カバレッジ足りてる?", "check coverage", "ready to push?").
+disable-model-invocation: true
+allowed-tools: Read, Grep, Glob, Bash
+argument-hint: "[base-ref]"
+---
+
+# Coverage Gate
+
+Self-review item 5 — "branch coverage is 80%+ for modified packages" — is the only item on the
+checklist with no command behind it. Codecov enforces the same 80% on project and patch, but
+only after a push, which makes the pre-push check either manual arithmetic or a full-suite run
+nobody waits for.
+
+This runs both suites **scoped to the changed files**, so the answer takes seconds.
+
+```bash
+bash .claude/skills/coverage-gate/scripts/coverage-gate.sh          # vs develop
+bash .claude/skills/coverage-gate/scripts/coverage-gate.sh master   # vs another base
+```
+
+Exit status is 0 when everything in scope clears 80%, 1 otherwise.
+
+## What it measures, precisely
+
+| Suite | Number reported | Scope |
+|---|---|---|
+| Go | **statement** coverage, `go test -cover` per changed package | `internal/**`, `api/**`, minus `internal/infrastructure/` |
+| Frontend | **branch** coverage, vitest v8 provider | `frontend/src/{api,components,pages,utils}` |
+
+Two things worth being exact about:
+
+- **Go has no branch-coverage mode.** The toolchain reports statements, and so does Codecov,
+  so the gate here is the same number CI gates on — but it is not C1, and a package at 85%
+  statements can still leave a branch untested. When a change is branch-heavy, read the
+  uncovered lines (`go test -coverprofile=/tmp/c.out ./pkg && go tool cover -html=/tmp/c.out`)
+  rather than trusting the percentage.
+- **`cmd/` and `internal/infrastructure/` are excluded** — `codecov.yml` ignores them, so a
+  number for them would be one nobody gates on.
+
+Frontend files are measured one at a time: each changed `X.tsx` is measured by running only
+`X.test.tsx`. This is deliberate — the full suite with coverage runs past ten minutes locally,
+and the question being asked is about the changed file, not the repo.
+
+## Reading the output
+
+```
+== Go ==
+  internal/usecase                                             76.4%  UNDER 80%
+== Frontend (branch coverage) ==
+  src/pages/HeartsPage.tsx                                     NO TEST FILE
+```
+
+- **UNDER 80%** — add tests before pushing; Codecov's patch target will fail otherwise.
+- **NO TEST FILE** — a source file with no `*.test.tsx?` next to it. Untracked files are
+  included in the scan, so a brand-new file with no test is caught here rather than in review.
+- **NO RESULT** — the suite failed to run. That is a broken test, not a coverage problem;
+  fix it and re-run.
+
+## What this does not do
+
+It does not run the full suite, and passing it is not a substitute for CI. Tests and lint
+belong on GitHub Actions; this is the narrow pre-push question of whether the *changed* files
+carry tests, answered locally because CI answers it too late to act on.

--- a/.claude/skills/coverage-gate/scripts/coverage-gate.sh
+++ b/.claude/skills/coverage-gate/scripts/coverage-gate.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Report coverage for what THIS branch changed, before pushing.
+#
+# Codecov enforces 80% on project and patch, but only after a push -- and the self-review
+# checklist asks for the same number before the work is called done, which today means running
+# it by hand or not at all. This runs the two suites scoped to the changed files only, so the
+# answer arrives in seconds rather than in a full-suite run.
+#
+# Go reports STATEMENT coverage (the toolchain has no branch mode); that is the same number
+# Codecov gates on, so it is the right proxy, but it is not C1 and this script does not claim
+# it is. Vitest's v8 provider does report branch coverage, and that column is what is shown
+# for the frontend.
+#
+# Usage: coverage-gate.sh [base-ref]      (default base: develop)
+set -uo pipefail
+
+cd "$(dirname "$0")/../../../.."
+BASE="${1:-develop}"
+THRESHOLD=80
+
+# Untracked files must be in this list. `git diff` never reports them, and a brand-new source
+# file is the single most likely thing on a branch to have no test at all -- the case the gate
+# exists for would have been the one case it could not see.
+changed=$(git diff --name-only "$BASE...HEAD"; git diff --name-only; git diff --cached --name-only
+          git ls-files --others --exclude-standard)
+changed=$(printf '%s\n' "$changed" | sort -u | grep -v '^$')
+
+if [ -z "$changed" ]; then
+  echo "no changes against $BASE -- nothing to measure."
+  exit 0
+fi
+
+fail=0
+
+# --- Go -------------------------------------------------------------------------------
+# cmd/ and internal/infrastructure/ are excluded from the coverage standard (codecov.yml
+# ignores them), so measuring them here would report a number nobody gates on.
+pkgs=$(printf '%s\n' "$changed" \
+  | grep -E '^(internal|api)/.*\.go$' \
+  | grep -v '_test\.go$' \
+  | grep -v '^internal/infrastructure/' \
+  | xargs -r -n1 dirname | sort -u)
+
+echo "== Go =="
+if [ -z "$pkgs" ]; then
+  echo "  (no in-scope Go packages changed)"
+else
+  for p in $pkgs; do
+    line=$(go test -tags test -cover "./$p" 2>&1 | tail -1)
+    pct=$(printf '%s' "$line" | sed -nE 's/.*coverage: ([0-9.]+)% of statements.*/\1/p')
+    if [ -z "$pct" ]; then
+      printf '  %-58s %s\n' "$p" "NO RESULT -- $line"
+      fail=1
+      continue
+    fi
+    verdict=OK
+    awk -v a="$pct" -v b="$THRESHOLD" 'BEGIN{exit !(a+0 < b+0)}' && { verdict="UNDER ${THRESHOLD}%"; fail=1; }
+    printf '  %-58s %6s%%  %s\n' "$p" "$pct" "$verdict"
+  done
+fi
+
+# --- Frontend -------------------------------------------------------------------------
+# Per changed source file, run only its own test file and measure only that file. Running the
+# whole suite for coverage takes over ten minutes locally; this keeps the answer scoped to the
+# question that was asked.
+srcs=$(printf '%s\n' "$changed" \
+  | grep -E '^frontend/src/(api|components|pages|utils)/.*\.tsx?$' \
+  | grep -v '\.test\.tsx\?$')
+
+echo
+echo "== Frontend (branch coverage) =="
+if [ -z "$srcs" ]; then
+  echo "  (no in-scope frontend sources changed)"
+else
+  for s in $srcs; do
+    rel=${s#frontend/}
+    test_file="${rel%.*}.test.${rel##*.}"
+    if [ ! -f "frontend/$test_file" ]; then
+      printf '  %-58s %s\n' "$rel" "NO TEST FILE"
+      fail=1
+      continue
+    fi
+    out=$(cd frontend && bunx vitest run "$test_file" --coverage --coverage.reporter=text \
+            --coverage.include="$rel" 2>&1)
+    # Read the "Coverage summary" block, not the per-file table: with --coverage.include
+    # narrowed to a single file the table is emitted with headers and no rows, so a row-based
+    # parser reports NO RESULT for a run that measured perfectly well. The summary block is
+    # scoped to the same include, so it is the file's own number.
+    br=$(printf '%s\n' "$out" | sed -nE 's/^Branches[[:space:]]*:[[:space:]]*([0-9.]+)%.*/\1/p' | head -1)
+    if [ -z "$br" ]; then
+      printf '  %-58s %s\n' "$rel" "NO RESULT (see: bunx vitest run $test_file --coverage)"
+      fail=1
+      continue
+    fi
+    verdict=OK
+    awk -v a="$br" -v b="$THRESHOLD" 'BEGIN{exit !(a+0 < b+0)}' && { verdict="UNDER ${THRESHOLD}%"; fail=1; }
+    printf '  %-58s %6s%%  %s\n' "$rel" "$br" "$verdict"
+  done
+fi
+
+echo
+if [ "$fail" -eq 0 ]; then
+  echo "coverage-gate: PASS (every changed in-scope file at or above ${THRESHOLD}%)"
+else
+  echo "coverage-gate: FAIL -- add tests for the files marked above before pushing."
+fi
+exit "$fail"

--- a/.claude/skills/flake-ledger/SKILL.md
+++ b/.claude/skills/flake-ledger/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: flake-ledger
+description: Record a test failure and decide whether it is actually a flake, by counting sightings at the same location instead of trusting a green re-run. Use when a test fails and you are tempted to re-run it, when CI is red on a change that could not have caused it, or to review which failures have repeated ("this test is flaky, right?", "re-run CI").
+disable-model-invocation: true
+allowed-tools: Read, Grep, Glob, Bash
+argument-hint: "[record|check|list] [test-id]"
+---
+
+# Flake Ledger
+
+**"I re-ran it and it passed" is not evidence of a flake.** It is one observation with nothing
+to compare it to — a real, intermittent bug produces exactly the same reading. The only thing
+that distinguishes a flake from a bug you got lucky on is *the same failure happening at the
+same location more than once*, and that requires writing the first one down.
+
+This skill writes it down.
+
+## When a test fails
+
+### 1. Read the actual result before naming it
+
+A failure has to be read from the run's own output, not from a wrapper's exit status:
+
+- **Background runs**: the completion notification's exit code is the code of the *echo* at the
+  end of the command, not the test run. Read the `EXIT` line in the log file.
+- **Vitest shards**: a worker that dies on a heap limit skips the tests queued behind it and
+  the run can still report green. Check the reported test count, not just the colour.
+- **Guard scripts**: an empty scan exits 0. A guard that printed no findings has not
+  necessarily checked anything (see `frontend/scripts/lib/floor.mjs`).
+
+### 2. Record the sighting
+
+```bash
+python3 .claude/skills/flake-ledger/scripts/ledger.py record \
+  --test 'TestKaiserAllPassRedeal' \
+  --where 'internal/domain' \
+  --run 'https://github.com/<owner>/<repo>/actions/runs/<id>' \
+  --note 'redeal loop asserted 4 hands, got 3'
+```
+
+`--where` is the package or file, and it matters: two different tests failing in the same
+package is a different signal from one test failing twice. Omit `--run` for a local run.
+
+The command prints the sighting count at that location and, with it, the verdict:
+
+| Sightings | Verdict | What to do |
+|---|---|---|
+| 1 | UNCONFIRMED | **Investigate as a real failure.** Do not re-run and move on. |
+| 2+ | CONFIRMED FLAKE | Open or update a GitHub issue with all the recorded runs. |
+
+### 3. Act on the verdict, not on the re-run
+
+On UNCONFIRMED, the next step is reading the test and the code under it — the same work you
+would do for a reproducible failure. Suspect your own branch before the suite: check whether
+your diff touches the failing package at all (`git diff --stat develop...HEAD -- <pkg>`).
+
+On CONFIRMED, the ledger rows are the issue body. Paste them; a flake report with two dated
+runs gets fixed, one that says "this is flaky sometimes" does not.
+
+## Reviewing the ledger
+
+```bash
+python3 .claude/skills/flake-ledger/scripts/ledger.py check          # everything, grouped
+python3 .claude/skills/flake-ledger/scripts/ledger.py check --test TestX
+python3 .claude/skills/flake-ledger/scripts/ledger.py list --since 2026-07-01
+```
+
+`check` splits the ledger into CONFIRMED (repeated at one location) and UNCONFIRMED
+(single sightings, which are still open questions rather than closed ones).
+
+## Where the ledger lives
+
+`.claude/.flake-ledger.jsonl`, gitignored — it is local observation, not shared truth. The
+shared artefact for a confirmed flake is a **GitHub issue**. Do not promote the ledger into a
+committed file; it would go stale the moment a flake is fixed and nobody deleted the row.
+
+## Known-flaky background
+
+Before recording, check whether the failure is already a known one — the repo has a running
+list of backend and E2E flakes, and re-litigating a known flake wastes the investigation. If
+it is already known, still record the sighting: the count is what tells you whether a "known
+flake" is getting worse.

--- a/.claude/skills/flake-ledger/scripts/ledger.py
+++ b/.claude/skills/flake-ledger/scripts/ledger.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Append-only ledger of test failures, so "flaky" becomes a count instead of a feeling.
+
+A test that failed once and passed on re-run is not evidence of a flake -- it is one
+observation with no comparison. The ledger keeps every sighting with where it happened, so
+the second sighting at the same location can be recognised as the second, which is the point
+at which a re-run stops being an explanation.
+
+Ledger lives at .claude/.flake-ledger.jsonl (gitignored, local knowledge). Confirmed flakes
+belong in a GitHub issue, not in this file.
+
+Usage:
+  ledger.py record --test <id> --where <loc> [--run <url>] [--branch <b>] [--note <text>]
+  ledger.py check  [--test <id>] [--min <n>]
+  ledger.py list   [--since <YYYY-MM-DD>]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[4]
+LEDGER = REPO / ".claude" / ".flake-ledger.jsonl"
+
+# Two sightings at the same location is the threshold at which a re-run stops being an
+# explanation. One is an observation; the ledger exists so the second can be seen as second.
+CONFIRM_AT = 2
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _branch() -> str:
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            cwd=REPO, capture_output=True, text=True, check=True,
+        )
+        return out.stdout.strip()
+    except (subprocess.CalledProcessError, OSError):
+        return "unknown"
+
+
+def _read() -> list[dict]:
+    if not LEDGER.exists():
+        return []
+    rows = []
+    for line in LEDGER.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rows.append(json.loads(line))
+        except json.JSONDecodeError:
+            # A corrupt line must not swallow the rest of the history, but it must also not
+            # pass unnoticed -- a ledger that silently drops rows undercounts, which is the
+            # one failure mode that matters here.
+            print(f"warning: skipping unparseable ledger line: {line[:80]}", file=sys.stderr)
+    return rows
+
+
+def cmd_record(args: argparse.Namespace) -> int:
+    LEDGER.parent.mkdir(parents=True, exist_ok=True)
+    row = {
+        "at": _now(),
+        "test": args.test,
+        "where": args.where,
+        "run": args.run or "",
+        "branch": args.branch or _branch(),
+        "note": args.note or "",
+    }
+    with LEDGER.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+    same = [r for r in _read() if r.get("test") == args.test and r.get("where") == args.where]
+    n = len(same)
+    verdict = "CONFIRMED FLAKE" if n >= CONFIRM_AT else "UNCONFIRMED (1 sighting)"
+    print(f"recorded: {args.test} @ {args.where}")
+    print(f"sightings at this location: {n} -> {verdict}")
+    if n < CONFIRM_AT:
+        print("A single failure is not a flake. Investigate it as a real failure until a")
+        print("second sighting at the same location says otherwise.")
+    else:
+        print(f"Seen {n}x. Open or update a GitHub issue; do not just re-run.")
+        for r in same:
+            print(f"  {r['at']}  {r.get('branch', '?')}  {r.get('run') or '(local)'}")
+    return 0
+
+
+def cmd_check(args: argparse.Namespace) -> int:
+    rows = _read()
+    if not rows:
+        print("ledger is empty -- no failures recorded yet.")
+        return 0
+
+    groups: dict[tuple[str, str], list[dict]] = defaultdict(list)
+    for r in rows:
+        groups[(r.get("test", "?"), r.get("where", "?"))].append(r)
+
+    if args.test:
+        groups = {k: v for k, v in groups.items() if k[0] == args.test}
+        if not groups:
+            print(f"no sightings recorded for {args.test}")
+            return 0
+
+    threshold = args.min if args.min is not None else CONFIRM_AT
+    confirmed = {k: v for k, v in groups.items() if len(v) >= threshold}
+    single = {k: v for k, v in groups.items() if len(v) < threshold}
+
+    print(f"ledger: {len(rows)} sightings across {len(groups)} test/location pairs\n")
+    if confirmed:
+        print(f"CONFIRMED (>= {threshold} sightings at the same location):")
+        for (test, where), v in sorted(confirmed.items(), key=lambda kv: -len(kv[1])):
+            runs = ", ".join(r.get("run") or "local" for r in v[-3:])
+            print(f"  {len(v):>2}x  {test} @ {where}")
+            print(f"       latest: {runs}")
+    if single:
+        print(f"\nUNCONFIRMED (< {threshold}) -- treat as real failures:")
+        for (test, where), v in sorted(single.items()):
+            print(f"  {len(v):>2}x  {test} @ {where}")
+    return 0
+
+
+def cmd_list(args: argparse.Namespace) -> int:
+    rows = _read()
+    if args.since:
+        rows = [r for r in rows if r.get("at", "") >= args.since]
+    for r in rows:
+        print(f"{r.get('at')}  {r.get('branch','?'):<24} {r.get('test')} @ {r.get('where')}"
+              f"  {r.get('run') or '(local)'}  {r.get('note','')}")
+    print(f"\n{len(rows)} row(s). Ledger: {LEDGER.relative_to(REPO)}")
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    rec = sub.add_parser("record", help="record one failure sighting")
+    rec.add_argument("--test", required=True, help="test identifier, e.g. TestKaiserRedeal or SpadesPage.test.tsx > bids")
+    rec.add_argument("--where", required=True, help="package/file the failure happened in, e.g. internal/domain")
+    rec.add_argument("--run", help="CI run URL, or omit for a local run")
+    rec.add_argument("--branch", help="branch (defaults to the current one)")
+    rec.add_argument("--note", help="one line on what the failure looked like")
+    rec.set_defaults(func=cmd_record)
+
+    chk = sub.add_parser("check", help="show which failures have repeated")
+    chk.add_argument("--test", help="restrict to one test id")
+    chk.add_argument("--min", type=int, help=f"sightings needed to confirm (default {CONFIRM_AT})")
+    chk.set_defaults(func=cmd_check)
+
+    lst = sub.add_parser("list", help="dump the raw ledger")
+    lst.add_argument("--since", help="ISO date lower bound, e.g. 2026-08-01")
+    lst.set_defaults(func=cmd_list)
+
+    args = p.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ TODOS.md
 # gstack (team mode — installed globally, not vendored)
 .claude/skills/gstack/
 public/sounds/
+
+# Local-only observation ledger (flake-ledger skill); confirmed flakes go to a GitHub issue
+.claude/.flake-ledger.jsonl

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "cloudflare-observability": {
+      "type": "http",
+      "url": "https://observability.mcp.cloudflare.com/mcp"
+    },
+    "cloudflare-bindings": {
+      "type": "http",
+      "url": "https://bindings.mcp.cloudflare.com/mcp"
+    }
+  }
+}

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -119,6 +119,38 @@ All exported symbols (types, interfaces, functions, components, constants, hooks
 bun run build && bun run check && bun run test
 ```
 
+## Guard scripts (`scripts/check-*.mjs`)
+
+`bun run check` is Biome plus eleven guard scripts, each pinning down an invariant that no
+type or test covers (design tokens, discover blurbs, message codes, hint coverage, markdown
+tables, dependency licences, trademark terms, asset provenance, …).
+
+**Every guard that reports a discovered count must assert a floor under it.** A guard walks
+something and then reports on what it found; when the walk breaks, it finds nothing, nothing
+has no violations in it, and the script exits 0 with a line that reads exactly like coverage.
+`check-dependency-licenses.mjs` once inspected 341 packages and reported 1, and the run looked
+perfect.
+
+```js
+import { assertFloor } from './lib/floor.mjs';
+
+const files = await walk(SRC_DIR);
+assertFloor('my-guard', files.length, 1200, 'source files scanned');   // <- before reporting
+console.log(`my-guard: OK (${files.length} source files scanned).`);
+```
+
+`check-guard-floors.mjs` enforces this and runs first in the chain: a guard with three counted
+`console.log` lines needs three `assertFloor` calls, and a floor of `0` is rejected outright
+(it holds for every input, including a walk that found nothing).
+
+Set the floor well below today's real number — enough that ordinary churn never trips it, and
+a walk that found a fraction of the truth does. Roughly two thirds of the current count works.
+
+Guard tests live next to the guard as `scripts/*.test.mjs` and run in the normal Vitest suite.
+Each must cover **both** directions: input the guard rejects, and correct input it must not
+flag. A guard tested only on the failing case is indistinguishable from one that fails
+everything.
+
 ## Type checking
 
 **Always type-check with `bun run typecheck`. Never with a bare `tsc` / `bunx tsc`.**

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,7 @@
     "lint": "biome lint .",
     "lint:tokens": "bun scripts/check-design-tokens.mjs",
     "format": "biome format --write .",
-    "check": "biome check . && bun scripts/check-design-tokens.mjs && bun scripts/check-discover-blurbs.mjs && bun scripts/check-message-codes.mjs && bun scripts/check-hint-coverage.mjs && bun scripts/check-hint-reasons.mjs && bun scripts/check-markdown-tables.mjs && bun scripts/check-hint-gate.mjs && bun scripts/check-dependency-licenses.mjs && bun scripts/check-trademark-terms.mjs && bun scripts/check-asset-provenance.mjs",
+    "check": "biome check . && bun scripts/check-guard-floors.mjs && bun scripts/check-design-tokens.mjs && bun scripts/check-discover-blurbs.mjs && bun scripts/check-message-codes.mjs && bun scripts/check-hint-coverage.mjs && bun scripts/check-hint-reasons.mjs && bun scripts/check-markdown-tables.mjs && bun scripts/check-hint-gate.mjs && bun scripts/check-dependency-licenses.mjs && bun scripts/check-trademark-terms.mjs && bun scripts/check-asset-provenance.mjs",
     "check:write": "biome check --write .",
     "preview": "vite preview",
     "test": "vitest run",

--- a/frontend/scripts/check-asset-provenance.mjs
+++ b/frontend/scripts/check-asset-provenance.mjs
@@ -16,6 +16,7 @@
 
 import { readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { assertFloor } from './lib/floor.mjs';
 
 /** Repository root — this file lives at frontend/scripts/. */
 const REPO_ROOT = new URL('../../', import.meta.url).pathname;
@@ -56,13 +57,7 @@ const declared = new Set(
     .flatMap((line) => expand(line.split('|')[0].trim())),
 );
 
-if (declared.size < MIN_FILES) {
-  console.error(
-    `check-asset-provenance: manifest declares only ${declared.size} files (expected >= ${MIN_FILES}).\n` +
-      'The manifest or its range syntax is broken, not the directory empty.',
-  );
-  process.exit(1);
-}
+assertFloor('asset-provenance', declared.size, MIN_FILES, 'files declared in the manifest');
 
 const present = new Set(readdirSync(IMAGES_DIR));
 

--- a/frontend/scripts/check-dependency-licenses.mjs
+++ b/frontend/scripts/check-dependency-licenses.mjs
@@ -17,6 +17,7 @@
 
 import { existsSync, readdirSync, readFileSync, realpathSync, statSync } from 'node:fs';
 import { join } from 'node:path';
+import { assertFloor } from './lib/floor.mjs';
 
 /** Root of the installed dependency tree. */
 const NODE_MODULES = new URL('../node_modules', import.meta.url).pathname;
@@ -165,13 +166,7 @@ for (const dir of packageDirs(NODE_MODULES)) {
   }
 }
 
-if (scanned < MIN_PACKAGES) {
-  console.error(
-    `check-dependency-licenses: only ${scanned} packages inspected (expected >= ${MIN_PACKAGES}).\n` +
-      'The scan is broken, not the tree clean. Run `bun install` and re-run.',
-  );
-  process.exit(1);
-}
+assertFloor('dependency-licenses', scanned, MIN_PACKAGES, 'packages inspected (run `bun install` first)');
 
 if (blocked.length > 0) {
   console.error(

--- a/frontend/scripts/check-design-tokens.mjs
+++ b/frontend/scripts/check-design-tokens.mjs
@@ -6,6 +6,7 @@
 import { readdir, readFile } from 'node:fs/promises';
 import { join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { assertFloor } from './lib/floor.mjs';
 
 const ROOT = fileURLToPath(new URL('..', import.meta.url));
 const SRC_DIR = join(ROOT, 'src');
@@ -90,6 +91,10 @@ if (!rmBlock.includes('*,') || !rmBlock.includes('animation-duration: 0.01ms')) 
   process.exit(1);
 }
 
+// 2020 source files under src/ today. Each sub-guard below floors its own walk: this file
+// holds eight independent checks, and a floor on one of them says nothing about the other
+// seven.
+assertFloor('design-tokens', files.length, 1200, 'source files scanned');
 console.log(`design-tokens: OK (${files.length} source files scanned, test files skipped).`);
 console.log('reduced-motion: OK (index.css uses the universal prefers-reduced-motion block).');
 
@@ -357,6 +362,10 @@ if (labelViolations.length > 0) {
   process.exit(1);
 }
 
+// 48 shared labels today, read out of common.json's kbd.action map. An empty or renamed map
+// means every label lookup misses -- which this guard reports as "resolves" for the zero
+// labels it went on to check.
+assertFloor('kbd-labels', knownLabels.size, 30, 'shared kbd.action labels');
 console.log(`kbd-labels: OK (every ActionBinding label resolves; ${knownLabels.size} shared labels).`);
 
 // --- Mobile shell-height contract (issue #4373) -----------------------------
@@ -509,6 +518,9 @@ if (unmountViolations.length > 0) {
   process.exit(1);
 }
 
+// 225 hooks today. This walk is a plain readdir of src/hooks with a name filter, so a moved
+// directory yields an empty list -- and an empty list has no unguarded writes in it.
+assertFloor('unmount-safety', hookFiles.length, 150, 'hook files');
 console.log(`unmount-safety: OK (${hookFiles.length} hooks; every await -> own-state write is guarded).`);
 
 // --- Vacuous "not called" assertions in tests (issues #4439, #4451) ---------
@@ -535,12 +547,14 @@ async function collectTests(dir) {
   }
   return out;
 }
+let vacuousInspected = 0;
 for (const file of await collectTests(SRC_DIR)) {
   const text = await readFile(file, 'utf8');
   // Only mocks of a game API — a plain `vi.fn()` prop callback IS synchronous and
   // needs no flush, so flagging those would be noise that gets the guard switched off.
   const apiMocks = new Set([...text.matchAll(/const (\w+) = vi\.mocked\((\w+Api)\.\w+\)/g)].map((m) => m[1]));
   if (apiMocks.size === 0) continue;
+  vacuousInspected += 1;
   const lines = text.split('\n');
   for (let i = 0; i < lines.length; i += 1) {
     const m = /^\s*expect\((\w+)\)\.not\.toHaveBeenCalled/.exec(lines[i]);
@@ -574,4 +588,11 @@ if (vacuousViolations.length > 0) {
   process.exit(1);
 }
 
-console.log('vacuous-assertions: OK (every "not called" assertion on an api mock is awaited first).');
+// 361 test files declare an api mock today. This guard is doubly conditional — it skips files
+// with no api mock, then looks only at `not.toHaveBeenCalled` lines inside them — so a change
+// to either the mock-declaration regex or the `collectTests` walk empties the scope without
+// emptying the output. #4451 already found 76 sites a narrower matcher could not see.
+assertFloor('vacuous-assertions', vacuousInspected, 250, 'test files declaring an api mock');
+console.log(
+  `vacuous-assertions: OK (${vacuousInspected} test files with api mocks; every "not called" assertion is awaited first).`,
+);

--- a/frontend/scripts/check-discover-blurbs.mjs
+++ b/frontend/scripts/check-discover-blurbs.mjs
@@ -19,6 +19,7 @@
 import { readFile } from 'node:fs/promises';
 import { join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { assertFloor } from './lib/floor.mjs';
 
 const FRONTEND = fileURLToPath(new URL('..', import.meta.url));
 const REPO = join(FRONTEND, '..');
@@ -43,10 +44,10 @@ async function registeredGames() {
 }
 
 const games = await registeredGames();
-if (games.size === 0) {
-  console.error(`discover-blurbs: found no game pages in ${relative(REPO, ROUTES)} — the regex has drifted.`);
-  process.exit(1);
-}
+// 264 games are registered today. A regex that has drifted usually still matches *some*
+// entries, so `> 0` is not the interesting boundary -- checking 12 games and declaring all
+// blurbs present is the failure this floor exists to catch.
+assertFloor('discover-blurbs', games.size, 200, `game pages in ${relative(REPO, ROUTES)}`);
 
 const gaps = [];
 const empties = [];

--- a/frontend/scripts/check-guard-floors.mjs
+++ b/frontend/scripts/check-guard-floors.mjs
@@ -1,0 +1,148 @@
+#!/usr/bin/env bun
+// Guard that every guard reports a count it has actually floored.
+//
+// The other scripts in this directory all end the same way: a line saying how much was
+// inspected, followed by exit 0. That line is what a reader takes as coverage -- "2020 source
+// files scanned", "774 codes", "6212 files". None of it is worth anything if the walk that
+// produced the number broke, because a broken walk finds no violations and exits 0 exactly
+// like a clean tree. check-dependency-licenses inspected 341 packages and reported 1, and the
+// run looked perfect.
+//
+// Three guards grew `MIN_*` constants after that. This one makes the practice enforceable:
+//
+//   Any guard that prints a discovered count must assert a floor under it.
+//
+// "Prints a discovered count" is read mechanically as a `console.log` containing a `${}`
+// interpolation -- exactly the lines that make a claim about scope. "Asserts a floor" is a
+// call to `assertFloor` from ./lib/floor.mjs. A guard with three such lines needs three
+// floors; one floor does not vouch for the other two walks.
+//
+// Floors of 0 are rejected. `assertFloor(x, 0)` passes for every possible input, which is the
+// shape of a guard that was added to satisfy a checker rather than to catch anything.
+//
+// Usage: check-guard-floors.mjs [dir]     (default: this scripts/ directory)
+
+import { readdir, readFile } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { assertFloor } from './lib/floor.mjs';
+
+const SCRIPTS = fileURLToPath(new URL('.', import.meta.url));
+const REPO = join(SCRIPTS, '../..');
+const DIR = process.argv[2] ? process.argv[2] : SCRIPTS;
+
+// This file is excluded from its own scan. It would otherwise count the `assertFloor(` and
+// `console.log` fragments that appear here as regex source and prose, and report on itself
+// using numbers that describe its own documentation. Its own walk is floored below instead.
+const SELF = 'check-guard-floors.mjs';
+
+/** Success lines that state a discovered count: `console.log` with an interpolation. */
+function countedLogs(src) {
+  // console.log( ... ) spanning lines, up to the matching close at column 0 or `);`
+  const logs = [...src.matchAll(/console\.log\(([\s\S]*?)\);/g)].map((m) => m[1]);
+  return logs.filter((body) => body.includes('${'));
+}
+
+/** Every `assertFloor(label, count, min, ...)` call, with the raw `min` argument. */
+function floorCalls(src) {
+  const calls = [];
+  for (const m of src.matchAll(/assertFloor\(([\s\S]*?)\);/g)) {
+    // Split only at top-level commas so a template literal holding a comma stays one argument.
+    // Backticks toggle rather than nest — counting them like brackets leaves the depth stuck
+    // above zero for the rest of the call, and every later argument merges into one.
+    const args = [];
+    let depth = 0;
+    let inTick = false;
+    let current = '';
+    for (const ch of m[1]) {
+      if (ch === '`') inTick = !inTick;
+      else if (!inTick && '([{'.includes(ch)) depth += 1;
+      else if (!inTick && ')]}'.includes(ch)) depth -= 1;
+      if (ch === ',' && depth === 0 && !inTick) {
+        args.push(current.trim());
+        current = '';
+        continue;
+      }
+      current += ch;
+    }
+    args.push(current.trim());
+    calls.push({ min: args[2] ?? '', raw: m[0] });
+  }
+  return calls;
+}
+
+/**
+ * Resolve a `min` argument to a number.
+ *
+ * Accepts a literal (`200`) or a same-file `const NAME = 200`. Anything computed at runtime
+ * is unresolvable here and is reported rather than waved through -- a floor nobody can read
+ * off the source is a floor nobody will notice going to zero.
+ */
+function resolveMin(arg, src) {
+  if (/^\d+$/.test(arg)) return Number(arg);
+  if (/^[A-Za-z_$][\w$]*$/.test(arg)) {
+    const decl = new RegExp(`const\\s+${arg}\\s*=\\s*(\\d+)\\s*;`).exec(src);
+    if (decl) return Number(decl[1]);
+  }
+  return null;
+}
+
+// `check-*.test.mjs` is excluded along with SELF: a guard's test file quotes broken guards as
+// fixtures, so scanning it reports the fixtures as real violations.
+const files = (await readdir(DIR))
+  .filter((f) => f.startsWith('check-') && f.endsWith('.mjs') && !f.endsWith('.test.mjs') && f !== SELF)
+  .sort();
+
+const problems = [];
+let floors = 0;
+
+for (const file of files) {
+  const src = await readFile(join(DIR, file), 'utf8');
+  const logs = countedLogs(src);
+  const calls = floorCalls(src);
+  floors += calls.length;
+  const where = relative(REPO, join(DIR, file));
+
+  if (calls.length < logs.length) {
+    problems.push(
+      `${where}: reports ${logs.length} discovered count(s) but asserts ${calls.length} floor(s).\n` +
+        `      Each of these lines claims a scope that nothing verifies:\n` +
+        logs
+          .slice(calls.length)
+          .map((l) => `        ${l.replace(/\s+/g, ' ').trim().slice(0, 96)}`)
+          .join('\n'),
+    );
+  }
+
+  for (const call of calls) {
+    const min = resolveMin(call.min, src);
+    if (min === null) {
+      problems.push(
+        `${where}: floor \`${call.min}\` is not a literal or a same-file const.\n` +
+          '      Use a number, so the floor can be read (and reviewed) off the source.',
+      );
+    } else if (min <= 0) {
+      problems.push(
+        `${where}: floor is ${min}. A floor of 0 holds for every input, including a walk\n` +
+          '      that found nothing — which is the case this whole mechanism exists to catch.',
+      );
+    }
+  }
+}
+
+// This guard has the failure mode it polices: point it at the wrong directory and it finds no
+// scripts, reports no problems, and exits 0. Ten guards live here.
+assertFloor('guard-floors', files.length, 8, `guard scripts in ${relative(REPO, DIR)}`);
+
+if (problems.length > 0) {
+  console.error('\nGuards that report a count without a floor under it:\n');
+  for (const p of problems) console.error(`  ${p}\n`);
+  console.error(
+    'Import assertFloor from ./lib/floor.mjs and assert the count before reporting it.\n' +
+      'Set the floor well below the real number — enough that ordinary churn never trips it,\n' +
+      'and a walk that found a fraction of the truth does.\n',
+  );
+  process.exit(1);
+}
+
+console.log(`guard-floors: OK (${files.length} guard scripts, ${floors} floors; every reported count is asserted).`);

--- a/frontend/scripts/check-guard-floors.test.mjs
+++ b/frontend/scripts/check-guard-floors.test.mjs
@@ -1,0 +1,151 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, describe, expect, it } from 'vitest';
+
+// Vitest serves test modules under a non-file URL, so `import.meta.url` cannot be converted
+// with fileURLToPath here. The vitest root is `frontend/`, so resolve from cwd — and assert
+// the script is actually there, because a wrong cwd would otherwise turn every case below
+// into a spawn of a missing file rather than a visible failure.
+const SCRIPTS = join(process.cwd(), 'scripts');
+const GUARD = join(SCRIPTS, 'check-guard-floors.mjs');
+if (!existsSync(GUARD)) throw new Error(`check-guard-floors.mjs not found at ${GUARD} (cwd: ${process.cwd()})`);
+
+const dirs = [];
+afterAll(() => {
+  for (const d of dirs) rmSync(d, { recursive: true, force: true });
+});
+
+/** A guard that reports one count and floors it — the shape the checker should accept. */
+const SOUND = `import { assertFloor } from './lib/floor.mjs';
+const items = await walk();
+assertFloor('demo', items.length, 100, 'items');
+console.log(\`demo: OK (\${items.length} items scanned).\`);
+`;
+
+/**
+ * Build a fixture directory of guard scripts.
+ *
+ * The default is eight sound guards because the checker floors its own walk at eight — a
+ * fixture of two would fail for the wrong reason and prove nothing about the rule under test.
+ */
+function fixture(extra = {}, sound = 8) {
+  const dir = mkdtempSync(join(tmpdir(), 'guard-floors-'));
+  dirs.push(dir);
+  for (let i = 0; i < sound; i += 1) writeFileSync(join(dir, `check-sound-${i}.mjs`), SOUND);
+  for (const [name, src] of Object.entries(extra)) writeFileSync(join(dir, name), src);
+  return dir;
+}
+
+function check(dir) {
+  const r = spawnSync(process.execPath, [GUARD, dir], { encoding: 'utf8' });
+  return { code: r.status, out: `${r.stdout}${r.stderr}` };
+}
+
+describe('check-guard-floors', () => {
+  it('accepts guards that floor every count they report', () => {
+    const r = check(fixture());
+    expect(r.code).toBe(0);
+    expect(r.out).toContain('guard-floors: OK');
+  });
+
+  it('rejects a guard that reports a count with no floor under it', () => {
+    const r = check(
+      fixture({
+        // biome-ignore lint/suspicious/noTemplateCurlyInString: fixture source text, not an interpolation
+        'check-unfloored.mjs': 'const items = await walk();\nconsole.log(`demo: OK (${items.length} scanned).`);\n',
+      }),
+    );
+    expect(r.code).toBe(1);
+    expect(r.out).toContain('check-unfloored.mjs');
+    expect(r.out).toContain('asserts 0 floor(s)');
+  });
+
+  it('rejects a guard with more reported counts than floors', () => {
+    const r = check(
+      fixture({
+        'check-partial.mjs': `import { assertFloor } from './lib/floor.mjs';
+assertFloor('partial', files.length, 50, 'files');
+console.log(\`a: OK (\${files.length} files).\`);
+console.log(\`b: OK (\${hooks.length} hooks).\`);
+`,
+      }),
+    );
+    expect(r.code).toBe(1);
+    expect(r.out).toContain('check-partial.mjs');
+    expect(r.out).toContain('2 discovered count(s) but asserts 1 floor(s)');
+  });
+
+  it('rejects a floor of zero, which holds for every possible input', () => {
+    const r = check(
+      fixture({
+        'check-zero.mjs': `import { assertFloor } from './lib/floor.mjs';
+assertFloor('zero', items.length, 0, 'items');
+console.log(\`zero: OK (\${items.length} items).\`);
+`,
+      }),
+    );
+    expect(r.code).toBe(1);
+    expect(r.out).toContain('floor is 0');
+  });
+
+  it('rejects a floor that cannot be read off the source', () => {
+    const r = check(
+      fixture({
+        'check-computed.mjs': `import { assertFloor } from './lib/floor.mjs';
+assertFloor('computed', items.length, items.length, 'items');
+console.log(\`computed: OK (\${items.length} items).\`);
+`,
+      }),
+    );
+    expect(r.code).toBe(1);
+    expect(r.out).toContain('is not a literal or a same-file const');
+  });
+
+  it('resolves a floor written as a same-file const', () => {
+    const r = check(
+      fixture({
+        'check-const.mjs': `import { assertFloor } from './lib/floor.mjs';
+const MIN_ITEMS = 300;
+assertFloor('constant', items.length, MIN_ITEMS, 'items');
+console.log(\`constant: OK (\${items.length} items).\`);
+`,
+      }),
+    );
+    expect(r.code).toBe(0);
+  });
+
+  it('accepts a guard whose success line reports no count', () => {
+    const r = check(
+      fixture({
+        'check-boolean.mjs': "console.log('boolean: OK (index.css has the universal block).');\n",
+      }),
+    );
+    expect(r.code).toBe(0);
+  });
+
+  it('ignores a guard’s own test file, whose fixtures are deliberately broken', () => {
+    const r = check(
+      fixture({
+        // biome-ignore lint/suspicious/noTemplateCurlyInString: fixture source text, not an interpolation
+        'check-sound-0.test.mjs': 'console.log(`fixture: OK (${n} items)`); // no floor, on purpose\n',
+      }),
+    );
+    expect(r.code).toBe(0);
+  });
+
+  it('fails on a directory holding too few guards to be the real one', () => {
+    const r = check(fixture({}, 3));
+    expect(r.code).toBe(1);
+    expect(r.out).toContain('only 3 guard scripts');
+  });
+
+  it('passes against the repository’s own guards', () => {
+    // The live control. Every case above uses synthetic input; without this one the suite
+    // would stay green after a change that rejects every real guard in the directory.
+    const r = check(SCRIPTS);
+    expect(r.code).toBe(0);
+    expect(r.out).toMatch(/guard-floors: OK \(\d+ guard scripts/);
+  });
+});

--- a/frontend/scripts/check-hint-coverage.mjs
+++ b/frontend/scripts/check-hint-coverage.mjs
@@ -22,6 +22,7 @@ import { readdir, readFile } from 'node:fs/promises';
 import { join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { splitRegistrations, stubbedFactoryNames } from '../src/utils/hintStubs.ts';
+import { assertFloor } from './lib/floor.mjs';
 
 const FRONTEND = fileURLToPath(new URL('..', import.meta.url));
 const REPO = join(FRONTEND, '..');
@@ -90,17 +91,21 @@ async function hintedGames() {
 }
 
 const games = await registeredGames();
-if (games.size === 0) {
-  console.error(`hint-coverage: found no routes in ${relative(REPO, ROUTES)} — the regex has drifted.`);
-  process.exit(1);
-}
+// 264 routes today. Drift usually narrows the match rather than emptying it, and a run that
+// found 20 routes with 20 factories reports "20 of 20 games hinted" -- a full-coverage line
+// for a fifth of the games.
+assertFloor('hint-coverage', games.size, 200, `routes in ${relative(REPO, ROUTES)}`);
 
 const result = await hintedGames();
-if (result === null || result.names.size === 0) {
+if (result === null) {
   console.error(`hint-coverage: found no factories in ${relative(REPO, HOOK)} — the regex has drifted.`);
   process.exit(1);
 }
 const { names: hinted, stubbed } = result;
+// Same reasoning on the other side of the join: a registration parser that recognises only a
+// few factories reports the rest as MISSING (loud, fine) -- but one that recognises only the
+// games it can also see in the route table reports nothing at all.
+assertFloor('hint-coverage', hinted.size, 200, `factories in ${relative(REPO, HOOK)}`);
 
 const missing = [];
 for (const game of games) {

--- a/frontend/scripts/check-hint-gate.mjs
+++ b/frontend/scripts/check-hint-gate.mjs
@@ -20,6 +20,7 @@
 import { readdir, readFile } from 'node:fs/promises';
 import { join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { assertFloor } from './lib/floor.mjs';
 
 const FRONTEND = fileURLToPath(new URL('..', import.meta.url));
 const REPO = join(FRONTEND, '..');
@@ -80,10 +81,12 @@ function testsBothSides(src) {
 
 const oneSided = [];
 const offenders = [];
+let inspected = 0;
 for (const file of await readdir(PAGES)) {
   if (!file.endsWith('Page.tsx')) continue;
   const game = file.replace(/Page\.tsx$/, '');
   if (ALLOWED.has(game)) continue;
+  inspected += 1;
   const src = await readFile(join(PAGES, file), 'utf8');
   // Two surfaces leak an unasked hint, and the second was missed at first:
   //
@@ -147,5 +150,9 @@ if (oneSided.length > 0) {
   process.exit(1);
 }
 
-const gated = (await readdir(PAGES)).filter((f) => f.endsWith('Page.tsx')).length;
-console.log(`hint-gate: OK (both sides tested on every gated page; ${gated} pages checked).`);
+// Count what the loop actually opened, not what the directory holds: pages in ALLOWED are
+// skipped, so the directory total reported a larger scope than was ever inspected. The floor
+// sits under the real number -- a `readdir` pointed at the wrong directory yields zero
+// iterations, zero offenders, and a cheerful pass.
+assertFloor('hint-gate', inspected, 200, 'game pages inspected');
+console.log(`hint-gate: OK (both sides tested on every gated page; ${inspected} pages checked).`);

--- a/frontend/scripts/check-hint-reasons.mjs
+++ b/frontend/scripts/check-hint-reasons.mjs
@@ -35,6 +35,7 @@
 import { readdir, readFile } from 'node:fs/promises';
 import { join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { assertFloor } from './lib/floor.mjs';
 
 const FRONTEND = fileURLToPath(new URL('..', import.meta.url));
 const REPO = join(FRONTEND, '..');
@@ -134,10 +135,11 @@ for (const game of await passthroughGames()) {
   }
 }
 
-if (checkedGames === 0) {
-  console.error('hint-reasons: matched no games — the reason-passthrough pattern in the adapters has drifted.');
-  process.exit(1);
-}
+// 49 games / 502 lookups today. The passthrough pattern is matched by regex against the hint
+// adapters, so drift trims the set rather than emptying it -- and a run down to three games
+// still prints an OK line, just a smaller one.
+assertFloor('hint-reasons', checkedGames, 30, 'games with passthrough hint reasons');
+assertFloor('hint-reasons', checkedKeys, 300, 'reason lookups');
 
 if (problems.length > 0) {
   console.error('Hint reason keys with no translation:\n');

--- a/frontend/scripts/check-markdown-tables.mjs
+++ b/frontend/scripts/check-markdown-tables.mjs
@@ -24,6 +24,7 @@
 import { readdir, readFile } from 'node:fs/promises';
 import { join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { assertFloor } from './lib/floor.mjs';
 
 const FRONTEND = fileURLToPath(new URL('..', import.meta.url));
 const REPO = join(FRONTEND, '..');
@@ -79,10 +80,10 @@ for await (const file of markdownFiles(REPO)) {
   }
 }
 
-if (tables === 0) {
-  console.error('markdown-tables: found no tables at all — the separator match has drifted.');
-  process.exit(1);
-}
+// 904 tables / 6474 rows today. `=== 0` only catches a walk that broke completely; a SKIP
+// entry that swallowed `docs/` would still leave a few hundred tables and read as a pass.
+assertFloor('markdown-tables', tables, 600, 'tables');
+assertFloor('markdown-tables', rows, 4000, 'table rows');
 
 if (problems.length > 0) {
   console.error('Markdown table rows that do not match their header:\n');

--- a/frontend/scripts/check-message-codes.mjs
+++ b/frontend/scripts/check-message-codes.mjs
@@ -23,6 +23,7 @@
 import { readdir, readFile } from 'node:fs/promises';
 import { join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { assertFloor } from './lib/floor.mjs';
 
 const FRONTEND = fileURLToPath(new URL('..', import.meta.url));
 const REPO = join(FRONTEND, '..');
@@ -109,6 +110,11 @@ async function emittedCodes() {
 }
 
 const emitted = await emittedCodes();
+// 774 codes today, parsed out of the presenter sources by regex. A parser change that stops
+// recognising most `return` forms would leave a handful of codes, all of them translated, and
+// this guard would announce full coverage of the codes it could still see.
+assertFloor('message-codes', emitted.size, 500, `codes emitted from ${relative(REPO, PRESENTER_DIR)}`);
+
 const ja = JSON.parse(await readFile(join(LOCALES, 'ja/common.json'), 'utf8')).messageCode ?? {};
 const en = JSON.parse(await readFile(join(LOCALES, 'en/common.json'), 'utf8')).messageCode ?? {};
 

--- a/frontend/scripts/check-trademark-terms.mjs
+++ b/frontend/scripts/check-trademark-terms.mjs
@@ -27,6 +27,7 @@
 
 import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { extname, join, relative } from 'node:path';
+import { assertFloor } from './lib/floor.mjs';
 
 /** Repository root — this file lives at frontend/scripts/. */
 const REPO_ROOT = new URL('../../', import.meta.url).pathname;
@@ -36,8 +37,13 @@ const TRADEMARKS_MD = join(REPO_ROOT, 'TRADEMARKS.md');
  * Sanity floor for scanned files. A walk that silently matches nothing exits 0
  * and reads exactly like a clean tree, which is how a license scanner fooled us
  * earlier in the same audit. Fail loudly instead.
+ *
+ * Raised from 200 to 4000: the walk covers 6212 files, so 200 was low enough that
+ * losing `internal/` entirely — 5000-odd Go files, where most display strings
+ * live — would still have cleared it. A floor has to sit under the real number,
+ * not under zero.
  */
-const MIN_FILES = 200;
+const MIN_FILES = 4000;
 
 /** Directories scanned, each with the extensions that carry display strings. */
 const TARGETS = [
@@ -127,13 +133,7 @@ for (const { dir, exts } of TARGETS) {
   }
 }
 
-if (scanned < MIN_FILES) {
-  console.error(
-    `check-trademark-terms: only ${scanned} files scanned (expected >= ${MIN_FILES}).\n` +
-      'The walk is broken, not the tree clean.',
-  );
-  process.exit(1);
-}
+assertFloor('trademark-terms', scanned, MIN_FILES, 'files scanned');
 
 if (violations.length > 0) {
   console.error(`check-trademark-terms: ${violations.length} user-visible use(s) of a retired trademark:`);

--- a/frontend/scripts/lib/floor.mjs
+++ b/frontend/scripts/lib/floor.mjs
@@ -1,0 +1,44 @@
+/**
+ * Sanity floors for guard scripts.
+ *
+ * Every guard in this directory walks something -- a directory tree, a route table, a JSON
+ * map -- and then reports on what it found. The walk is the part that breaks silently: a
+ * renamed directory, a tightened regex, or a glob that no longer matches leaves the guard
+ * finding nothing, finding nothing means finding no violations, and finding no violations
+ * exits 0. The build goes green and the line in the log reads exactly like coverage.
+ *
+ * This has already happened here: `check-dependency-licenses.mjs` inspected 341 packages and
+ * reported 1, and nothing about the run looked wrong. Three guards grew ad-hoc `MIN_*`
+ * constants afterwards; this module is those constants made shared and mandatory.
+ * `check-guard-floors.mjs` fails the build for any guard that reports a discovered count
+ * without asserting a floor under it.
+ *
+ * A floor is not a target. Set it well below today's real count -- low enough that ordinary
+ * churn never trips it, high enough that a walk finding a small fraction of the truth does.
+ * Roughly two thirds of the current count is a good default.
+ */
+
+/**
+ * Assert that a walk found a plausible number of things, and exit 1 if it did not.
+ *
+ * @param {string} label - The guard's name, used in the failure message (e.g. `'design-tokens'`).
+ * @param {number} count - How many items the walk actually found.
+ * @param {number} min - The floor. Must be a positive integer; a floor of 0 asserts nothing.
+ * @param {string} [what] - What is being counted, for the message (e.g. `'source files'`).
+ * @returns {number} `count`, so the call can wrap an expression.
+ */
+export function assertFloor(label, count, min, what = 'items') {
+  if (!Number.isInteger(min) || min <= 0) {
+    console.error(`${label}: floor must be a positive integer, got ${min}. A floor of 0 asserts nothing.`);
+    process.exit(1);
+  }
+  if (!Number.isFinite(count) || count < min) {
+    console.error(
+      `\n${label}: only ${count} ${what} found (expected at least ${min}).\n` +
+        'The walk itself is broken -- it is reporting no violations because it inspected\n' +
+        'almost nothing, not because there are none. Fix the walk before trusting this guard.\n',
+    );
+    process.exit(1);
+  }
+  return count;
+}

--- a/frontend/scripts/lib/floor.test.mjs
+++ b/frontend/scripts/lib/floor.test.mjs
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from 'vitest';
+import { assertFloor } from './floor.mjs';
+
+/**
+ * `assertFloor` reports by exiting the process, so each case swaps `process.exit` for a throw
+ * and asserts on whether it fired. Both directions are covered deliberately: a floor helper
+ * that rejected everything would satisfy every "must fail" test on its own.
+ */
+function run(fn) {
+  const exit = vi.spyOn(process, 'exit').mockImplementation((code) => {
+    throw new Error(`exit:${code}`);
+  });
+  const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+  try {
+    const value = fn();
+    return { exited: false, value, messages: err.mock.calls.map((c) => c.join(' ')) };
+  } catch (e) {
+    if (!String(e.message).startsWith('exit:')) throw e;
+    return { exited: true, code: e.message.slice(5), messages: err.mock.calls.map((c) => c.join(' ')) };
+  } finally {
+    exit.mockRestore();
+    err.mockRestore();
+  }
+}
+
+describe('assertFloor', () => {
+  it('passes a count above the floor and returns it', () => {
+    const r = run(() => assertFloor('demo', 264, 200, 'games'));
+    expect(r.exited).toBe(false);
+    expect(r.value).toBe(264);
+  });
+
+  it('passes a count exactly at the floor', () => {
+    const r = run(() => assertFloor('demo', 200, 200, 'games'));
+    expect(r.exited).toBe(false);
+    expect(r.value).toBe(200);
+  });
+
+  it('exits 1 when the count is below the floor', () => {
+    const r = run(() => assertFloor('demo', 12, 200, 'games'));
+    expect(r.exited).toBe(true);
+    expect(r.code).toBe('1');
+    expect(r.messages.join('\n')).toContain('only 12 games found (expected at least 200)');
+  });
+
+  it('exits 1 when the walk found nothing at all', () => {
+    const r = run(() => assertFloor('demo', 0, 1, 'files'));
+    expect(r.exited).toBe(true);
+  });
+
+  it.each([0, -5, 1.5, Number.NaN])('rejects a floor of %s as asserting nothing', (min) => {
+    const r = run(() => assertFloor('demo', 999, min, 'files'));
+    expect(r.exited).toBe(true);
+    expect(r.messages.join('\n')).toContain('floor must be a positive integer');
+  });
+
+  it('rejects a non-finite count rather than comparing it', () => {
+    const r = run(() => assertFloor('demo', Number.NaN, 10, 'files'));
+    expect(r.exited).toBe(true);
+  });
+
+  it('names the guard and what was counted, so the failure is actionable', () => {
+    const r = run(() => assertFloor('trademark-terms', 3, 4000, 'files scanned'));
+    expect(r.messages.join('\n')).toContain('trademark-terms');
+    expect(r.messages.join('\n')).toContain('files scanned');
+  });
+});


### PR DESCRIPTION
## What

Implements every recommendation from the automation audit, plus the prerequisite work that made two of them non-annoying.

### Guard floors (`frontend/scripts`)

Every guard walks something and then reports what it found. When the walk breaks it finds nothing, nothing has no violations in it, and the script exits 0 with a line that reads exactly like coverage — the shape that let `check-dependency-licenses` inspect 341 packages and report 1.

- **`scripts/lib/floor.mjs`** exports `assertFloor(label, count, min, what)`. All eleven guards now assert a floor before reporting a count.
- The three ad-hoc `MIN_*` constants move onto it. **`check-trademark-terms` goes from 200 to 4000** — it scans 6212 files, so 200 would have cleared even after losing `internal/` entirely.
- **`scripts/check-guard-floors.mjs`** enforces the rule and runs first in the chain: a guard with three counted `console.log` lines needs three `assertFloor` calls, and a floor of `0` is rejected because it holds for every possible input.
- `check-hint-gate` now floors and reports the pages it actually opened, not the directory total (which counted `ALLOWED`-skipped pages as inspected: 268 → 263).

### A commit hook that was not blocking

The hook running `bun run check` gated on the output containing `"Found"` — biome's phrasing, which no guard script emits. **Any of the eleven guards could fail without blocking the commit.** It now gates on the exit code, and fires for staged `.mjs` as well as `.ts`/`.tsx`.

### New `.claude/` automations

| | |
|---|---|
| `hooks/commit-sanity.sh` | Blocks a commit staging conflict markers (neither tsc nor vitest fails on those — only the E2E production build does) or staging nothing at all |
| `agents/worker-budget-checker.md` | Measured gzip headroom for the six TinyGo workers, from a real build or a real CI artifact, never an estimate |
| `agents/vacuous-test-hunter.md` | Reviews new tests for the ones that pass whether or not the code works; every finding names the mutation it would miss |
| `skills/coverage-gate` | Coverage for the changed files only, before pushing |
| `skills/flake-ledger` | Counts failure sightings, so "flaky" is a number rather than a green re-run |
| `.mcp.json` | Cloudflare observability + bindings MCP servers |

One recommendation was dropped: a vacuous-assertion gate already exists in `check-design-tokens.mjs:514`, with a broader matcher than the one proposed.

## Test plan

- [x] `bun run check` — 0, all eleven guards report their real counts
- [x] `bun run typecheck` — 0
- [x] `bunx vitest run scripts/` — 20 new tests pass
- [x] Negative control: a tripped floor breaks the whole `check` chain (exit 1)
- [x] `bash .claude/hooks/commit-sanity.test.sh` — 6 cases, both directions
- [x] `coverage-gate.sh` verified end to end, including an untracked file with no test
- [x] `ledger.py` verified across the 1-sighting → 2-sighting transition
- [ ] CI green

Every guard case is paired with correct input that must **not** trip it — the guard's own test file is the first thing that would go stale otherwise, and `commit-sanity` proved the point by blocking on its own fixture before that pairing was fixed.

## Follow-up for you

The two Cloudflare MCP servers are registered but need interactive OAuth: run `/mcp` and approve `cloudflare-observability` and `cloudflare-bindings`.