### PR TITLE
fix(i18n): replace hardcoded "Loading..." fallbacks with GameSkeleton

### DIFF
--- a/frontend/src/pages/BlackJackSwitchPage.test.tsx
+++ b/frontend/src/pages/BlackJackSwitchPage.test.tsx
@@ -435,4 +435,11 @@ describe('BlackJackSwitchPage', () => {
     await waitFor(() => expect(mockApi).toHaveBeenCalled());
     expect(screen.queryByTestId('dealer-area')).not.toBeInTheDocument();
   });
+
+  it('renders the i18n skeleton instead of a hardcoded Loading label before state loads', () => {
+    mockApi.mockReturnValue(new Promise(() => {}));
+    renderWithProviders(<BlackJackSwitchPage />);
+    expect(screen.getByTestId('skeleton')).toBeInTheDocument();
+    expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/BlackJackSwitchPage.tsx
+++ b/frontend/src/pages/BlackJackSwitchPage.tsx
@@ -12,6 +12,7 @@ import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
 import { KbdBadge } from '../components/KbdBadge';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
+import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCardDimensions } from '../hooks/useCardDimensions';
@@ -106,13 +107,7 @@ function BlackJackSwitchPageContent() {
   );
   useActionKeyboardNav({ bindings: actionBindings, enabled: !!state && !loading });
 
-  if (!state) {
-    return (
-      <div className={`flex-1 flex items-center justify-center ${gameTheme.blackjackswitch.bg}`}>
-        <div className="text-ds-text-primary">Loading...</div>
-      </div>
-    );
-  }
+  if (!state) return <GameSkeleton gameKey="blackjackswitch" layout={{ kind: 'casino-table', sections: [5, 2, 2] }} />;
 
   const phaseName = isBetPhase
     ? t('phase.bet')

--- a/frontend/src/pages/CasinoWarPage.test.tsx
+++ b/frontend/src/pages/CasinoWarPage.test.tsx
@@ -349,4 +349,11 @@ describe('CasinoWarPage', () => {
     expect(screen.getAllByTestId('cw-history-pip')).toHaveLength(3);
     expect(screen.getByTestId('cw-tally')).toHaveTextContent('2勝 1敗 0分');
   });
+
+  it('renders the i18n skeleton instead of a hardcoded Loading label before state loads', () => {
+    mockApi.mockReturnValue(new Promise(() => {}));
+    renderWithProviders(<CasinoWarPage />);
+    expect(screen.getByTestId('skeleton')).toBeInTheDocument();
+    expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/CasinoWarPage.tsx
+++ b/frontend/src/pages/CasinoWarPage.tsx
@@ -14,6 +14,7 @@ import { HintTooltip } from '../components/hint/HintTooltip';
 import { KbdBadge } from '../components/KbdBadge';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { RoadmapTrendBar } from '../components/RoadmapTrendBar';
+import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCardDimensions } from '../hooks/useCardDimensions';
@@ -128,13 +129,7 @@ function CasinoWarPageContent() {
 
   useActionKeyboardNav({ bindings: actionBindings, enabled: !!state && !loading });
 
-  if (!state) {
-    return (
-      <div className={`flex-1 flex items-center justify-center ${gameTheme.casinowar.bg}`}>
-        <div className="text-ds-text-primary">Loading...</div>
-      </div>
-    );
-  }
+  if (!state) return <GameSkeleton gameKey="casinowar" layout={{ kind: 'casino-table', sections: [1, 1] }} />;
 
   const phaseName = isBetPhase
     ? t('phase.bet')

--- a/frontend/src/pages/DragonTigerPage.test.tsx
+++ b/frontend/src/pages/DragonTigerPage.test.tsx
@@ -298,4 +298,11 @@ describe('DragonTigerPage', () => {
     fireEvent.click(toggle);
     expect(await screen.findByTestId('hint-tooltip')).toBeInTheDocument();
   });
+
+  it('renders the i18n skeleton instead of a hardcoded Loading label before state loads', () => {
+    mockApi.mockReturnValue(new Promise(() => {}));
+    renderWithProviders(<DragonTigerPage />);
+    expect(screen.getByTestId('skeleton')).toBeInTheDocument();
+    expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/DragonTigerPage.tsx
+++ b/frontend/src/pages/DragonTigerPage.tsx
@@ -14,6 +14,7 @@ import { FrontendHintTooltip } from '../components/hint/FrontendHintTooltip';
 import { KbdBadge } from '../components/KbdBadge';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { RoadmapTrendBar } from '../components/RoadmapTrendBar';
+import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCardDimensions } from '../hooks/useCardDimensions';
@@ -116,13 +117,7 @@ function DragonTigerPageContent() {
     setHintEnabled: setFrontendHintEnabled,
   } = useGameHint('dragontiger', state);
 
-  if (!state) {
-    return (
-      <div className={`flex-1 flex items-center justify-center ${gameTheme.dragontiger.bg}`}>
-        <div className="text-ds-text-primary">Loading...</div>
-      </div>
-    );
-  }
+  if (!state) return <GameSkeleton gameKey="dragontiger" layout={{ kind: 'casino-table', sections: [1, 1] }} />;
 
   const handleReset = () => execApi('reset');
   const handleClearHistory = () => execApi('clear');

--- a/frontend/src/pages/OichoKabuPage.test.tsx
+++ b/frontend/src/pages/OichoKabuPage.test.tsx
@@ -260,4 +260,11 @@ describe('OichoKabuPage', () => {
     await waitFor(() => expect(input.value).toBe('300'));
     await waitFor(() => expect(screen.queryByTestId('ok-previous-bet')).not.toBeInTheDocument());
   });
+
+  it('renders the i18n skeleton instead of a hardcoded Loading label before state loads', () => {
+    mockApi.mockReturnValue(new Promise(() => {}));
+    renderWithProviders(<OichoKabuPage />);
+    expect(screen.getByTestId('skeleton')).toBeInTheDocument();
+    expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/OichoKabuPage.tsx
+++ b/frontend/src/pages/OichoKabuPage.tsx
@@ -13,6 +13,7 @@ import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
+import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCardDimensions } from '../hooks/useCardDimensions';
@@ -116,13 +117,7 @@ function OichoKabuPageContent() {
 
   useActionKeyboardNav({ bindings: actionBindings, enabled: !!state && !loading });
 
-  if (!state) {
-    return (
-      <div className={`flex-1 flex items-center justify-center ${gameTheme.oichokabu.bg}`}>
-        <div className="text-ds-text-primary">Loading...</div>
-      </div>
-    );
-  }
+  if (!state) return <GameSkeleton gameKey="oichokabu" layout={{ kind: 'casino-table', sections: [3, 3] }} />;
 
   const phaseName = isBetPhase ? t('phase.bet') : isDrawPhase ? t('phase.draw') : t('phase.end');
 

--- a/frontend/src/pages/PitchPage.test.tsx
+++ b/frontend/src/pages/PitchPage.test.tsx
@@ -315,4 +315,11 @@ describe('PitchPage', () => {
     renderWithProviders(<PitchPage />);
     await waitFor(() => expect(screen.getByTestId('pt-previous-trick-empty')).toBeInTheDocument());
   });
+
+  it('renders the i18n skeleton instead of a hardcoded Loading label before state loads', () => {
+    mockApi.mockReturnValue(new Promise(() => {}));
+    renderWithProviders(<PitchPage />);
+    expect(screen.getByTestId('skeleton')).toBeInTheDocument();
+    expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/PitchPage.tsx
+++ b/frontend/src/pages/PitchPage.tsx
@@ -13,6 +13,7 @@ import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { KbdBadge } from '../components/KbdBadge';
+import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { TrickDisplay } from '../components/TrickDisplay';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
@@ -245,13 +246,8 @@ function PitchPageContent() {
   );
   useActionKeyboardNav({ bindings: actionBindings, enabled: !!state });
 
-  if (!state) {
-    return (
-      <div className={`flex-1 flex items-center justify-center ${gameTheme.pitch.bg}`}>
-        <div className="text-ds-text-primary">Loading...</div>
-      </div>
-    );
-  }
+  if (!state)
+    return <GameSkeleton gameKey="pitch" layout={{ kind: 'trick-taking', trickArea: true, footerHandSize: 6 }} />;
 
   const phaseName = t(`phase.${PHASE_KEYS[state.phase] ?? 'bid'}`);
 

--- a/frontend/src/pages/RedDogPage.test.tsx
+++ b/frontend/src/pages/RedDogPage.test.tsx
@@ -205,4 +205,11 @@ describe('RedDogPage keyboard shortcuts', () => {
     await flushPendingDispatch();
     expect(mockApi).not.toHaveBeenCalled();
   });
+
+  it('renders the i18n skeleton instead of a hardcoded Loading label before state loads', () => {
+    mockApi.mockReturnValue(new Promise(() => {}));
+    renderWithProviders(<RedDogPage />);
+    expect(screen.getByTestId('skeleton')).toBeInTheDocument();
+    expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/RedDogPage.test.tsx
+++ b/frontend/src/pages/RedDogPage.test.tsx
@@ -174,6 +174,13 @@ describe('RedDogPage', () => {
     const hitChip = screen.getByTestId('reddog-ghost-7');
     expect(hitChip.className).toContain('bg-ds-success');
   });
+
+  it('renders the i18n skeleton instead of a hardcoded Loading label before state loads', () => {
+    mockApi.mockReturnValue(new Promise(() => {}));
+    renderWithProviders(<RedDogPage />);
+    expect(screen.getByTestId('skeleton')).toBeInTheDocument();
+    expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+  });
 });
 
 // --- keyboard shortcut execution (#4429) ---
@@ -204,12 +211,5 @@ describe('RedDogPage keyboard shortcuts', () => {
     fireEvent.keyDown(document, { key: 's' });
     await flushPendingDispatch();
     expect(mockApi).not.toHaveBeenCalled();
-  });
-
-  it('renders the i18n skeleton instead of a hardcoded Loading label before state loads', () => {
-    mockApi.mockReturnValue(new Promise(() => {}));
-    renderWithProviders(<RedDogPage />);
-    expect(screen.getByTestId('skeleton')).toBeInTheDocument();
-    expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/RedDogPage.tsx
+++ b/frontend/src/pages/RedDogPage.tsx
@@ -12,6 +12,7 @@ import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
+import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCardDimensions } from '../hooks/useCardDimensions';
@@ -90,13 +91,7 @@ function RedDogPageContent() {
 
   useActionKeyboardNav({ bindings: actionBindings, enabled: !!state && !loading });
 
-  if (!state) {
-    return (
-      <div className={`flex-1 flex items-center justify-center ${gameTheme.reddog.bg}`}>
-        <div className="text-ds-text-primary">Loading...</div>
-      </div>
-    );
-  }
+  if (!state) return <GameSkeleton gameKey="reddog" layout={{ kind: 'casino-table', sections: [3] }} />;
 
   const handleBet = () => execApi('bet', betAmount);
   const handleRaise = () => execApi('raise', Math.min(raiseAmount, state.ante, state.chips));

--- a/frontend/src/pages/TrenteEtQuarantePage.test.tsx
+++ b/frontend/src/pages/TrenteEtQuarantePage.test.tsx
@@ -287,4 +287,11 @@ describe('TrenteEtQuarantePage keyboard shortcuts', () => {
     await flushPendingDispatch();
     expect(mockApi).not.toHaveBeenCalled();
   });
+
+  it('renders the i18n skeleton instead of a hardcoded Loading label before state loads', () => {
+    mockApi.mockReturnValue(new Promise(() => {}));
+    renderWithProviders(<TrenteEtQuarantePage />);
+    expect(screen.getByTestId('skeleton')).toBeInTheDocument();
+    expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/TrenteEtQuarantePage.test.tsx
+++ b/frontend/src/pages/TrenteEtQuarantePage.test.tsx
@@ -226,6 +226,13 @@ describe('TrenteEtQuarantePage', () => {
     renderWithProviders(<TrenteEtQuarantePage />);
     await waitFor(() => expect(screen.queryByTestId('teq-deal-button')).not.toBeInTheDocument());
   });
+
+  it('renders the i18n skeleton instead of a hardcoded Loading label before state loads', () => {
+    mockApi.mockReturnValue(new Promise(() => {}));
+    renderWithProviders(<TrenteEtQuarantePage />);
+    expect(screen.getByTestId('skeleton')).toBeInTheDocument();
+    expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+  });
 });
 
 // --- keyboard shortcut execution (#4429) ---
@@ -286,12 +293,5 @@ describe('TrenteEtQuarantePage keyboard shortcuts', () => {
     fireEvent.keyDown(document, { key: 'd' });
     await flushPendingDispatch();
     expect(mockApi).not.toHaveBeenCalled();
-  });
-
-  it('renders the i18n skeleton instead of a hardcoded Loading label before state loads', () => {
-    mockApi.mockReturnValue(new Promise(() => {}));
-    renderWithProviders(<TrenteEtQuarantePage />);
-    expect(screen.getByTestId('skeleton')).toBeInTheDocument();
-    expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/TrenteEtQuarantePage.tsx
+++ b/frontend/src/pages/TrenteEtQuarantePage.tsx
@@ -12,6 +12,7 @@ import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
+import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCardDimensions } from '../hooks/useCardDimensions';
@@ -112,13 +113,7 @@ function TrenteEtQuarantePageContent() {
   );
   useActionKeyboardNav({ bindings: actionBindings, enabled: !!state && !loading });
 
-  if (!state) {
-    return (
-      <div className={`flex-1 flex items-center justify-center ${gameTheme.trenteetquarante.bg}`}>
-        <div className="text-ds-text-primary">Loading...</div>
-      </div>
-    );
-  }
+  if (!state) return <GameSkeleton gameKey="trenteetquarante" layout={{ kind: 'casino-table', sections: [5, 5] }} />;
 
   const phaseName = isBetPhase ? t('phase.bet') : t('phase.result');
   const hasRows = state.noirRow.length > 0 || state.rougeRow.length > 0;


### PR DESCRIPTION
## 背景

7つのゲームページが `state` が null の間、姉妹ページが使う i18n 対応の `<GameSkeleton>` ではなく、独自の `<div className="text-ds-text-primary">Loading...</div>` を返していました。`t()` を経由しないため、日本語ロケールでも初回描画は必ず英語になります。

issue は4件（reddog / casinowar / trenteetquarante / oichokabu）でしたが、`grep` で同一リテラルを持つページを調べたところ **BlackJackSwitch / DragonTiger / Pitch** の3件も同じ状態でした。既知の同一バグを残す理由がないため、7ページまとめて修正しています。

## 変更

各ページを、そのテーブル形状に合う layout の `GameSkeleton` に置き換え:

| ページ | layout |
|---|---|
| BlackJackSwitch | `casino-table` sections `[5, 2, 2]`（ディーラー + 2ハンド） |
| CasinoWar | `casino-table` sections `[1, 1]` |
| DragonTiger | `casino-table` sections `[1, 1]` |
| OichoKabu | `casino-table` sections `[3, 3]` |
| RedDog | `casino-table` sections `[3]` |
| TrenteEtQuarante | `casino-table` sections `[5, 5]` |
| Pitch | `trick-taking` `footerHandSize: 6`（`PitchHandSize = 6`） |

## テストプラン

- [x] 7ページそれぞれに「state ロード前に skeleton が出る / `Loading...` が出ない」テストを追加（Red → Green で確認）
- [x] `bunx vitest run` 対象7ファイル: 153 passed
- [x] `bun run check`（biome + design-tokens + 各種ガード）
- [x] `bun run typecheck`
- [x] `grep -rn 'Loading\.\.\.' src/pages/*.tsx` が0件

Closes #4700
Closes #4706
Closes #4846
Closes #4854