### PR TITLE
feat(a11y): surface shortcuts, contract semantics and reserve slots

### DIFF
--- a/frontend/src/i18n/locales/en/dragontiger.json
+++ b/frontend/src/i18n/locales/en/dragontiger.json
@@ -17,6 +17,9 @@
     "rebet": "Rebet ({{type}} {{amount}})"
   },
   "kbd": {
+    "betDragon": "D",
+    "betTie": "E",
+    "betTiger": "T",
     "rebet": "E"
   },
   "phase": {

--- a/frontend/src/i18n/locales/en/flowergarden.json
+++ b/frontend/src/i18n/locales/en/flowergarden.json
@@ -1,29 +1,39 @@
 {
+  "autoComplete": "Auto Complete",
+  "autoCompleteNotReady": "Available once a foundation builds past its ace",
+  "empty": "Empty",
+  "emptyFoundationAriaLabel": "Empty foundation ({{suit}})",
+  "emptyReserveSlot": "Empty reserve slot {{idx}}",
+  "foundation": "Foundation",
+  "foundationAriaLabel": "{{suit}} foundation {{count}} cards",
+  "frontendHint": {
+    "tableau": "Flower bed {{col}}",
+    "reserve": "Bouquet {{col}}",
+    "foundation": "Foundation"
+  },
+  "gameClear": "Game Clear! Moves: {{moveCount}}",
+  "gameOver": "Game Over",
+  "gameOverSummary": "Reached {{count}}/52 cards on the foundations ({{percent}}%)",
+  "giveup": "Give Up",
+  "hint": "Hint",
+  "hintAvailable": "Hint available",
+  "hintReason": {
+    "toFoundation": "Send this card to the foundation to free up the flower bed.",
+    "toTableau": "Apply the suggested flower-bed move to unlock buried cards."
+  },
+  "landscapeBanner": "Landscape mode recommended",
+  "moveCount": "Moves",
+  "noHint": "No hint available",
   "phase": {
     "playing": "Playing",
     "gameClear": "Game Clear",
     "gameOver": "Game Over"
   },
-  "foundation": "Foundation",
-  "tableau": "Flower bed",
-  "reserve": "Bouquet",
-  "moveCount": "Moves",
-  "giveup": "Give Up",
-  "empty": "Empty",
-  "foundationAriaLabel": "{{suit}} foundation {{count}} cards",
-  "emptyFoundationAriaLabel": "Empty foundation ({{suit}})",
-  "landscapeBanner": "Landscape mode recommended",
-  "hint": "Hint",
-  "autoComplete": "Auto Complete",
-  "autoCompleteNotReady": "Available once a foundation builds past its ace",
-  "undo": "Undo",
-  "stalemate": "Stalemate",
   "playing": "Move cards to build foundations",
-  "gameClear": "Game Clear! Moves: {{moveCount}}",
-  "gameOver": "Game Over",
-  "gameOverSummary": "Reached {{count}}/52 cards on the foundations ({{percent}}%)",
-  "hintAvailable": "Hint available",
-  "noHint": "No hint available",
+  "reserve": "Bouquet",
+  "reserveCardAriaLabel": "{{card}} (reserve slot {{idx}})",
+  "stalemate": "Stalemate",
+  "tableau": "Flower bed",
   "tutorial": {
     "foundation": "Four empty foundations sit beside the bouquet. Build each pile by suit from Ace to King.",
     "reserve": "The bouquet holds sixteen single face-up cards. They can leave for the flower beds or a foundation, but nothing ever moves back into the bouquet.",
@@ -31,13 +41,5 @@
     "moves": "Pack the flower beds in descending rank, suit ignored (any card on the next-higher rank). Empty beds accept any card.",
     "controls": "Use hint, undo, and auto-complete buttons."
   },
-  "frontendHint": {
-    "tableau": "Flower bed {{col}}",
-    "reserve": "Bouquet {{col}}",
-    "foundation": "Foundation"
-  },
-  "hintReason": {
-    "toFoundation": "Send this card to the foundation to free up the flower bed.",
-    "toTableau": "Apply the suggested flower-bed move to unlock buried cards."
-  }
+  "undo": "Undo"
 }

--- a/frontend/src/i18n/locales/en/solowhist.json
+++ b/frontend/src/i18n/locales/en/solowhist.json
@@ -1,4 +1,42 @@
 {
+  "bid": {
+    "pass": "Pass",
+    "solo": "Solo",
+    "misere": "Misère",
+    "abundance": "Abundance"
+  },
+  "bidHighest": "Highest bid: {{bid}} ({{player}})",
+  "bidLabel": "Bid",
+  "bidNone": "No bids yet",
+  "bidPrompt": "Place a bid (only a higher bid is allowed):",
+  "bidTooLow": "Must beat the current highest bid",
+  "cards": "{{count}} cards",
+  "contract": "Contract: {{contract}}",
+  "contractName": {
+    "pass": "Pass",
+    "solo": "Solo (8 tricks)",
+    "misere": "Misère (0 tricks, no trump)",
+    "abundance": "Abundance (9 tricks)"
+  },
+  "contractUndecided": "Contract: undecided",
+  "cpu": "CPU {{id}}",
+  "currentTrick": "Current Trick",
+  "declarerBadge": "Declarer",
+  "declarerLine": "Declarer: {{name}} — {{contract}}",
+  "hint": {
+    "lead_low": "Lead a low card to conserve strength",
+    "follow_win": "Win this trick",
+    "follow_duck": "Cannot/should not win — duck",
+    "discard_low": "Cannot follow suit — discard a low card"
+  },
+  "hintAvailable": "Hint",
+  "hintRequested": "Hint available",
+  "misereBadge": "Special",
+  "misereDesc": "Misère is a special contract aiming to win no tricks; failing it costs heavily.",
+  "nextRound": "Next Round",
+  "nextTrick": "Next Trick",
+  "noHint": "No hint available",
+  "noTrump": "none",
   "phase": {
     "bid": "Bid",
     "play": "Play",
@@ -6,6 +44,21 @@
     "roundEnd": "Round End",
     "gameEnd": "Game End"
   },
+  "playButton": "Play",
+  "playerScore": "{{name}}: {{score}} pts",
+  "players": "Players",
+  "progress": {
+    "line": "Declarer progress: {{won}} / {{needed}} tricks",
+    "misere": "Declarer progress: {{won}} tricks (Misère, target 0)",
+    "made": "Contract made",
+    "failed": "Contract failed"
+  },
+  "round": "Round {{n}}",
+  "roundResult": {
+    "title": "Round Result",
+    "tricks": "{{name}} tricks: {{count}}"
+  },
+  "score": "Score: {{score}}",
   "settings": {
     "title": "Settings",
     "cpuDifficulty": "CPU Difficulty",
@@ -14,67 +67,16 @@
     "normal": "Normal",
     "hard": "Hard"
   },
-  "round": "Round {{n}}",
-  "trick": "Trick {{n}}",
-  "trump": "Trump: {{suit}}",
-  "noTrump": "none",
-  "cards": "{{count}} cards",
-  "tricks": "{{count}} tricks",
-  "currentTrick": "Current Trick",
-  "trickEmpty": "(no cards yet)",
-  "players": "Players",
-  "you": "You",
-  "cpu": "CPU {{id}}",
-  "declarerBadge": "Declarer",
-  "score": "Score: {{score}}",
-  "playerScore": "{{name}}: {{score}} pts",
-  "contract": "Contract: {{contract}}",
-  "contractUndecided": "Contract: undecided",
-  "declarerLine": "Declarer: {{name}} — {{contract}}",
-  "progress": {
-    "line": "Declarer progress: {{won}} / {{needed}} tricks",
-    "misere": "Declarer progress: {{won}} tricks (Misère, target 0)",
-    "made": "Contract made",
-    "failed": "Contract failed"
-  },
-  "bidLabel": "Bid",
-  "playButton": "Play",
-  "nextTrick": "Next Trick",
-  "nextRound": "Next Round",
   "target": "Target: {{points}} pts",
-  "bidPrompt": "Place a bid (only a higher bid is allowed):",
-  "bidHighest": "Highest bid: {{bid}} ({{player}})",
-  "bidNone": "No bids yet",
-  "bidTooLow": "Must beat the current highest bid",
-  "bid": {
-    "pass": "Pass",
-    "solo": "Solo",
-    "misere": "Misère",
-    "abundance": "Abundance"
-  },
-  "contractName": {
-    "pass": "Pass",
-    "solo": "Solo (8 tricks)",
-    "misere": "Misère (0 tricks, no trump)",
-    "abundance": "Abundance (9 tricks)"
-  },
-  "roundResult": {
-    "title": "Round Result",
-    "tricks": "{{name}} tricks: {{count}}"
-  },
-  "hintAvailable": "Hint",
-  "hint": {
-    "lead_low": "Lead a low card to conserve strength",
-    "follow_win": "Win this trick",
-    "follow_duck": "Cannot/should not win — duck",
-    "discard_low": "Cannot follow suit — discard a low card"
-  },
+  "trick": "Trick {{n}}",
+  "trickEmpty": "(no cards yet)",
+  "tricks": "{{count}} tricks",
+  "trump": "Trump: {{suit}}",
   "tutorial": {
     "info": "Round, contract (declarer and type), trump, and each player's score are shown here. The first player to reach the target points (default 21) wins. The ★ marks the declarer.",
     "trick": "Cards played to the current trick appear here. You must follow the led suit, ace high. The highest card wins the trick.",
     "hand": "This is your hand. During play, click a playable card and press Play.",
     "actions": "In the bidding phase, buttons appear for Pass / Solo (win 8 tricks alone) / Misère (win 0 tricks, no trump) / Abundance (win 9 tricks alone). Only a bid higher than the current highest is selectable. The highest bidder becomes the declarer and plays against the other 3 defenders."
   },
-  "hintRequested": "Hint available",
-  "noHint": "No hint available"
+  "you": "You"
 }

--- a/frontend/src/i18n/locales/ja/dragontiger.json
+++ b/frontend/src/i18n/locales/ja/dragontiger.json
@@ -17,6 +17,9 @@
     "rebet": "再ベット ({{type}} {{amount}})"
   },
   "kbd": {
+    "betDragon": "D",
+    "betTie": "E",
+    "betTiger": "T",
     "rebet": "E"
   },
   "phase": {

--- a/frontend/src/i18n/locales/ja/flowergarden.json
+++ b/frontend/src/i18n/locales/ja/flowergarden.json
@@ -1,29 +1,39 @@
 {
+  "autoComplete": "自動完成",
+  "autoCompleteNotReady": "ファンデーションを2枚目以降まで進めると有効になります",
+  "empty": "空",
+  "emptyFoundationAriaLabel": "空の組札 ({{suit}})",
+  "emptyReserveSlot": "空のリザーブ枠 {{idx}}",
+  "foundation": "組札",
+  "foundationAriaLabel": "{{suit}} 組札 {{count}}枚",
+  "frontendHint": {
+    "tableau": "フラワーベッド{{col}}",
+    "reserve": "ブーケ{{col}}",
+    "foundation": "組札"
+  },
+  "gameClear": "ゲームクリア！ 手数: {{moveCount}}",
+  "gameOver": "ゲームオーバー",
+  "gameOverSummary": "ファウンデーション {{count}}/52 枚（{{percent}}%）まで到達",
+  "giveup": "ギブアップ",
+  "hint": "ヒント",
+  "hintAvailable": "ヒントがあります",
+  "hintReason": {
+    "toFoundation": "このカードを組札に上げると後の展開が楽になります",
+    "toTableau": "示唆されたフラワーベッドへの移動でロックされたカードを動かしましょう"
+  },
+  "landscapeBanner": "横画面での表示を推奨します",
+  "moveCount": "手数",
+  "noHint": "ヒントはありません",
   "phase": {
     "playing": "プレイ中",
     "gameClear": "ゲームクリア",
     "gameOver": "ゲームオーバー"
   },
-  "foundation": "組札",
-  "tableau": "フラワーベッド",
-  "reserve": "ブーケ",
-  "moveCount": "手数",
-  "giveup": "ギブアップ",
-  "empty": "空",
-  "foundationAriaLabel": "{{suit}} 組札 {{count}}枚",
-  "emptyFoundationAriaLabel": "空の組札 ({{suit}})",
-  "landscapeBanner": "横画面での表示を推奨します",
-  "hint": "ヒント",
-  "autoComplete": "自動完成",
-  "autoCompleteNotReady": "ファンデーションを2枚目以降まで進めると有効になります",
-  "undo": "元に戻す",
-  "stalemate": "手詰まりです",
   "playing": "カードを移動してください",
-  "gameClear": "ゲームクリア！ 手数: {{moveCount}}",
-  "gameOver": "ゲームオーバー",
-  "gameOverSummary": "ファウンデーション {{count}}/52 枚（{{percent}}%）まで到達",
-  "hintAvailable": "ヒントがあります",
-  "noHint": "ヒントはありません",
+  "reserve": "ブーケ",
+  "reserveCardAriaLabel": "{{card}}（リザーブ枠 {{idx}}）",
+  "stalemate": "手詰まりです",
+  "tableau": "フラワーベッド",
   "tutorial": {
     "foundation": "ブーケの隣に4つの空の組札があります。同じスートでA→Kの順に積み上げます。",
     "reserve": "ブーケには16枚の表向きカードが1枚ずつ置かれます。フラワーベッドや組札へ出せますが、一度出すと二度と戻せません。",
@@ -31,13 +41,5 @@
     "moves": "フラワーベッドへはスートを問わず1つ下のランクのカードに重ねます（1つ上のランクに置く）。空のベッドには任意のカードを置けます。",
     "controls": "ヒント・元に戻す・自動完成などの操作ボタンです。"
   },
-  "frontendHint": {
-    "tableau": "フラワーベッド{{col}}",
-    "reserve": "ブーケ{{col}}",
-    "foundation": "組札"
-  },
-  "hintReason": {
-    "toFoundation": "このカードを組札に上げると後の展開が楽になります",
-    "toTableau": "示唆されたフラワーベッドへの移動でロックされたカードを動かしましょう"
-  }
+  "undo": "元に戻す"
 }

--- a/frontend/src/i18n/locales/ja/solowhist.json
+++ b/frontend/src/i18n/locales/ja/solowhist.json
@@ -1,4 +1,42 @@
 {
+  "bid": {
+    "pass": "パス",
+    "solo": "ソロ",
+    "misere": "ミゼール",
+    "abundance": "アバンダンス"
+  },
+  "bidHighest": "現在の最高ビッド: {{bid}}（{{player}}）",
+  "bidLabel": "入札",
+  "bidNone": "まだ入札なし",
+  "bidPrompt": "入札してください（上回る入札のみ可）:",
+  "bidTooLow": "現在の最高ビッドを上回る必要があります",
+  "cards": "{{count}}枚",
+  "contract": "契約: {{contract}}",
+  "contractName": {
+    "pass": "パス",
+    "solo": "ソロ (8トリック)",
+    "misere": "ミゼール (0トリック・切り札なし)",
+    "abundance": "アバンダンス (9トリック)"
+  },
+  "contractUndecided": "契約: 未決定",
+  "cpu": "CPU {{id}}",
+  "currentTrick": "現在のトリック",
+  "declarerBadge": "宣言者",
+  "declarerLine": "宣言者: {{name}} — {{contract}}",
+  "hint": {
+    "lead_low": "低い札でリードして温存することを推奨",
+    "follow_win": "このトリックを取りに行く",
+    "follow_duck": "取れない／取る価値がないのでダック推奨",
+    "discard_low": "フォローできないので低い札を捨てる"
+  },
+  "hintAvailable": "ヒント",
+  "hintRequested": "ヒントがあります",
+  "misereBadge": "特殊",
+  "misereDesc": "ミゼールは1トリックも取らないことを目指す特殊契約で、失敗すると大きな失点になります。",
+  "nextRound": "次のラウンド",
+  "nextTrick": "次のトリック",
+  "noHint": "ヒントはありません",
+  "noTrump": "なし",
   "phase": {
     "bid": "ビッド",
     "play": "プレイ",
@@ -6,6 +44,21 @@
     "roundEnd": "ラウンド終了",
     "gameEnd": "ゲーム終了"
   },
+  "playButton": "出す",
+  "playerScore": "{{name}}: {{score}}点",
+  "players": "プレイヤー",
+  "progress": {
+    "line": "宣言者の進捗: {{won}} / {{needed}} トリック",
+    "misere": "宣言者の進捗: {{won}} トリック（ミゼール・目標0）",
+    "made": "達成",
+    "failed": "失敗確定"
+  },
+  "round": "ラウンド {{n}}",
+  "roundResult": {
+    "title": "ラウンド結果",
+    "tricks": "{{name}} トリック: {{count}}"
+  },
+  "score": "得点: {{score}}",
   "settings": {
     "title": "設定",
     "cpuDifficulty": "CPU難易度",
@@ -14,67 +67,16 @@
     "normal": "Normal",
     "hard": "Hard"
   },
-  "round": "ラウンド {{n}}",
-  "trick": "トリック {{n}}",
-  "trump": "切り札: {{suit}}",
-  "noTrump": "なし",
-  "cards": "{{count}}枚",
-  "tricks": "{{count}}トリック",
-  "currentTrick": "現在のトリック",
-  "trickEmpty": "(まだカードがありません)",
-  "players": "プレイヤー",
-  "you": "あなた",
-  "cpu": "CPU {{id}}",
-  "declarerBadge": "宣言者",
-  "score": "得点: {{score}}",
-  "playerScore": "{{name}}: {{score}}点",
-  "contract": "契約: {{contract}}",
-  "contractUndecided": "契約: 未決定",
-  "declarerLine": "宣言者: {{name}} — {{contract}}",
-  "progress": {
-    "line": "宣言者の進捗: {{won}} / {{needed}} トリック",
-    "misere": "宣言者の進捗: {{won}} トリック（ミゼール・目標0）",
-    "made": "達成",
-    "failed": "失敗確定"
-  },
-  "bidLabel": "入札",
-  "playButton": "出す",
-  "nextTrick": "次のトリック",
-  "nextRound": "次のラウンド",
   "target": "目標: {{points}}点",
-  "bidPrompt": "入札してください（上回る入札のみ可）:",
-  "bidHighest": "現在の最高ビッド: {{bid}}（{{player}}）",
-  "bidNone": "まだ入札なし",
-  "bidTooLow": "現在の最高ビッドを上回る必要があります",
-  "bid": {
-    "pass": "パス",
-    "solo": "ソロ",
-    "misere": "ミゼール",
-    "abundance": "アバンダンス"
-  },
-  "contractName": {
-    "pass": "パス",
-    "solo": "ソロ (8トリック)",
-    "misere": "ミゼール (0トリック・切り札なし)",
-    "abundance": "アバンダンス (9トリック)"
-  },
-  "roundResult": {
-    "title": "ラウンド結果",
-    "tricks": "{{name}} トリック: {{count}}"
-  },
-  "hintAvailable": "ヒント",
-  "hint": {
-    "lead_low": "低い札でリードして温存することを推奨",
-    "follow_win": "このトリックを取りに行く",
-    "follow_duck": "取れない／取る価値がないのでダック推奨",
-    "discard_low": "フォローできないので低い札を捨てる"
-  },
+  "trick": "トリック {{n}}",
+  "trickEmpty": "(まだカードがありません)",
+  "tricks": "{{count}}トリック",
+  "trump": "切り札: {{suit}}",
   "tutorial": {
     "info": "ここにラウンド・契約（宣言者と種別）・切り札・各プレイヤーの得点が表示されます。先に目標ポイント（初期値21）へ達したプレイヤーの勝ちです。★が宣言者です。",
     "trick": "場に出されたカードがここに並びます。リードスートにマストフォロー、A高。最強のカードを出したプレイヤーがトリックを取ります。",
     "hand": "あなたの手札です。プレイ時は出せるカードをクリックして「出す」を押します。",
     "actions": "入札フェーズでは、パス／ソロ（8トリック単独）／ミゼール（0トリック・切り札なし）／アバンダンス（9トリック単独）のボタンが出ます。現在の最高入札を上回る入札のみ選べます。最高入札者が宣言者となり、残り3人のディフェンダーと対戦します。"
   },
-  "hintRequested": "ヒントがあります",
-  "noHint": "ヒントはありません"
+  "you": "あなた"
 }

--- a/frontend/src/pages/DragonTigerPage.test.tsx
+++ b/frontend/src/pages/DragonTigerPage.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
+import i18n from 'i18next';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { dragontigerApi } from '../api/gameApi';
 import { useCliMode } from '../hooks/useCliMode';
@@ -304,5 +305,24 @@ describe('DragonTigerPage', () => {
     renderWithProviders(<DragonTigerPage />);
     expect(screen.getByTestId('skeleton')).toBeInTheDocument();
     expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+  });
+
+  it('shows the keyboard shortcut on each bet button', async () => {
+    localStorage.clear();
+    mockApi.mockReset();
+    mockApi.mockResolvedValue(betState);
+    renderWithProviders(<DragonTigerPage />);
+    for (const [name, key] of [
+      ['button.betDragon', 'd'],
+      ['button.betTiger', 't'],
+      ['button.betTie', 'e'],
+    ] as const) {
+      // The labels contain regex metacharacters ("タイ (8:1)"), so match on the
+      // accessible name directly rather than building a RegExp from them.
+      const label = i18n.t(`dragontiger:${name}`);
+      const btn = await screen.findByRole('button', { name: (accessibleName) => accessibleName.includes(label) });
+      expect(btn).toHaveAttribute('aria-keyshortcuts', key);
+      expect(btn).toHaveTextContent(key.toUpperCase());
+    }
   });
 });

--- a/frontend/src/pages/DragonTigerPage.tsx
+++ b/frontend/src/pages/DragonTigerPage.tsx
@@ -290,24 +290,30 @@ function DragonTigerPageContent() {
                     className={btnWarning}
                     onClick={() => handleBet(DragonTigerBetType.DRAGON)}
                     disabled={loading}
+                    aria-keyshortcuts="d"
                   >
                     {t('button.betDragon')}
+                    <KbdBadge label={t('kbd.betDragon')} />
                   </button>
                   <button
                     type="button"
                     className={btnSuccess}
                     onClick={() => handleBet(DragonTigerBetType.TIGER)}
                     disabled={loading}
+                    aria-keyshortcuts="t"
                   >
                     {t('button.betTiger')}
+                    <KbdBadge label={t('kbd.betTiger')} />
                   </button>
                   <button
                     type="button"
                     className={btnPrimary}
                     onClick={() => handleBet(DragonTigerBetType.TIE)}
                     disabled={loading}
+                    aria-keyshortcuts="e"
                   >
                     {t('button.betTie')}
+                    <KbdBadge label={t('kbd.betTie')} />
                   </button>
                 </div>
               </div>

--- a/frontend/src/pages/FlowerGardenPage.test.tsx
+++ b/frontend/src/pages/FlowerGardenPage.test.tsx
@@ -89,7 +89,7 @@ describe('FlowerGardenPage', () => {
   it('renders a reserve card', async () => {
     mockExec.mockResolvedValue(playingState);
     renderWithProviders(<FlowerGardenPage />);
-    await waitFor(() => expect(screen.getByRole('button', { name: '♦ 7' })).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole('button', { name: /^♦ 7（リザーブ枠/ })).toBeInTheDocument());
   });
 
   it('labels all 16 bouquet slots with their 0-based index (matching hint text)', async () => {
@@ -121,7 +121,7 @@ describe('FlowerGardenPage', () => {
   it('selecting a reserve card marks it as selected', async () => {
     mockExec.mockResolvedValue(playingState);
     renderWithProviders(<FlowerGardenPage />);
-    const reserveBtn = await screen.findByRole('button', { name: '♦ 7' });
+    const reserveBtn = await screen.findByRole('button', { name: /^♦ 7（リザーブ枠/ });
     fireEvent.click(reserveBtn);
     await waitFor(() => expect(reserveBtn).toHaveAttribute('aria-pressed', 'true'));
   });
@@ -176,6 +176,17 @@ describe('FlowerGardenPage', () => {
     mockExec.mockResolvedValue(stalemate);
     renderWithProviders(<FlowerGardenPage />);
     await waitFor(() => expect(screen.getByTestId('stalemate-escape-button')).toBeInTheDocument());
+  });
+
+  it('names every bouquet reserve slot, filled or empty', async () => {
+    localStorage.clear();
+    mockExec.mockReset();
+    mockExec.mockResolvedValue(playingState);
+    renderWithProviders(<FlowerGardenPage />);
+    // Filled slots carry the card plus its slot number; empty slots announce
+    // the number alone, so no slot is a nameless blank to a screen reader.
+    await waitFor(() => expect(screen.getAllByLabelText(/リザーブ枠 \d+/).length).toBeGreaterThan(0));
+    expect(screen.getAllByLabelText(/空のリザーブ枠 \d+/).length).toBeGreaterThan(0);
   });
 });
 

--- a/frontend/src/pages/FlowerGardenPage.tsx
+++ b/frontend/src/pages/FlowerGardenPage.tsx
@@ -283,7 +283,7 @@ function FlowerGardenPageContent() {
             type="button"
             onClick={() => game.handleSelectSource(reserveZone)}
             disabled={!isPlaying || loading}
-            aria-label={cardAlt(reserveCard)}
+            aria-label={t('reserveCardAriaLabel', { card: cardAlt(reserveCard), idx: cellIdx })}
             aria-pressed={isSourceSelected('reserve', cellIdx)}
             draggable={isPlaying && !loading}
             onDragStart={dnd.handleDragStart(reserveZone)}
@@ -293,7 +293,12 @@ function FlowerGardenPageContent() {
             <AnimatedCard card={reserveCard} width={dims.cw} draggable={false} />
           </button>
         ) : (
-          <div className="rounded border border-dashed border-white/10" style={{ width: dims.cw, height: dims.ch }} />
+          <div
+            role="img"
+            aria-label={t('emptyReserveSlot', { idx: cellIdx })}
+            className="rounded border border-dashed border-white/10"
+            style={{ width: dims.cw, height: dims.ch }}
+          />
         )}
         <span className="text-xs text-ds-text-muted mt-0.5" aria-hidden="true">
           #{cellIdx}

--- a/frontend/src/pages/KingPage.test.tsx
+++ b/frontend/src/pages/KingPage.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
+import i18n from 'i18next';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { kingApi } from '../api/gameApi';
 import { renderWithProviders } from '../test/renderWithProviders';
@@ -74,7 +75,7 @@ describe('KingPage', () => {
     mockExec.mockResolvedValue(selectPhaseState);
     renderWithProviders(<KingPage />);
     await waitFor(() => expect(screen.getByTestId('king-select-prompt')).toBeInTheDocument());
-    expect(screen.getByRole('button', { name: 'ノートリック' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^ノートリック —/ })).toBeInTheDocument();
   });
 
   it('shows achieve/avoid badges on the contract buttons', async () => {
@@ -93,7 +94,7 @@ describe('KingPage', () => {
   it('choosing a non-trump contract dispatches contract with trumpSuit -1', async () => {
     mockExec.mockResolvedValue(selectPhaseState);
     renderWithProviders(<KingPage />);
-    const btn = await screen.findByRole('button', { name: 'ノートリック' });
+    const btn = await screen.findByRole('button', { name: /^ノートリック —/ });
     mockExec.mockClear();
     mockExec.mockResolvedValue(selectPhaseState);
     fireEvent.click(btn);
@@ -103,7 +104,7 @@ describe('KingPage', () => {
   it('choosing King (Trump) shows a trump picker then dispatches the chosen suit', async () => {
     mockExec.mockResolvedValue(selectPhaseState);
     renderWithProviders(<KingPage />);
-    const kingBtn = await screen.findByRole('button', { name: 'キング（切り札）' });
+    const kingBtn = await screen.findByRole('button', { name: /^キング（切り札） —/ });
     fireEvent.click(kingBtn);
     // The trump prompt and suit buttons appear.
     await waitFor(() => expect(screen.getByTestId('king-trump-prompt')).toBeInTheDocument());
@@ -199,5 +200,21 @@ describe('KingPage', () => {
     });
     renderWithProviders(<KingPage />);
     expect(await screen.findByText(/\(\[0\]\)/)).toBeInTheDocument();
+  });
+
+  it('carries the contract type and description into the accessible name', async () => {
+    localStorage.clear();
+    mockExec.mockReset();
+    mockExec.mockResolvedValue(selectPhaseState);
+    renderWithProviders(<KingPage />);
+    // The badge is aria-hidden, so the same information has to reach the
+    // accessible name or a screen reader hears only the contract's name.
+    const avoid = await screen.findByTestId('king-contract-1');
+    const achieve = await screen.findByTestId('king-contract-6');
+    const descId = avoid.getAttribute('aria-describedby');
+    expect(descId).toBe('king-contract-desc-1');
+    expect(document.getElementById(descId ?? '')).toHaveTextContent(i18n.t('king:contractDesc.1'));
+    expect(avoid).toHaveAccessibleName(new RegExp(i18n.t('king:contractType.avoid')));
+    expect(achieve).toHaveAccessibleName(new RegExp(i18n.t('king:contractType.achieve')));
   });
 });

--- a/frontend/src/pages/KingPage.tsx
+++ b/frontend/src/pages/KingPage.tsx
@@ -378,6 +378,11 @@ function KingPageContent() {
                         onClick={() => handleContractClick(contract)}
                         disabled={loading || used}
                         title={t(`contractDesc.${contract}`)}
+                        // The badge below is aria-hidden (it is icon + colour), so
+                        // the achieve/avoid distinction has to be restated here or a
+                        // screen reader hears only the contract's name (#4844).
+                        aria-label={`${t(`contracts.${contract}`)} — ${t(`contractType.${isAchieve ? 'achieve' : 'avoid'}`)}`}
+                        aria-describedby={`king-contract-desc-${contract}`}
                         data-testid={`king-contract-${contract}`}
                       >
                         <span className={used ? 'line-through opacity-60' : ''}>{t(`contracts.${contract}`)}</span>
@@ -390,6 +395,9 @@ function KingPageContent() {
                             {t(`contractType.${isAchieve ? 'achieve' : 'avoid'}`)}
                           </span>
                           <span>{t(`contractIcon.${contract}`)}</span>
+                        </span>
+                        <span id={`king-contract-desc-${contract}`} className="sr-only">
+                          {t(`contractDesc.${contract}`)}
                         </span>
                       </button>
                     );

--- a/frontend/src/pages/SoloWhistPage.test.tsx
+++ b/frontend/src/pages/SoloWhistPage.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { soloWhistApi } from '../api/gameApi';
 import { renderWithProviders } from '../test/renderWithProviders';
 import { makeSoloWhistState } from '../test/stateFactories';
+import { SoloWhistContract } from '../types/phases';
 import { SoloWhistPage } from './SoloWhistPage';
 
 vi.mock('../api/gameApi', () => ({
@@ -280,5 +281,18 @@ describe('SoloWhistPage', () => {
     });
     renderWithProviders(<SoloWhistPage />);
     expect(await screen.findByText(/\(\[0\]\)/)).toBeInTheDocument();
+  });
+
+  it('describes the misere contract for screen readers', async () => {
+    localStorage.clear();
+    mockExec.mockReset();
+    mockExec.mockResolvedValue(bidPhaseState);
+    renderWithProviders(<SoloWhistPage />);
+    const misere = await screen.findByTestId(`bid-${SoloWhistContract.MISERE}`);
+    const descId = misere.getAttribute('aria-describedby');
+    expect(descId).toBe('solowhist-misere-desc');
+    expect(document.getElementById(descId ?? '')).toHaveTextContent('1トリックも取らない');
+    // Non-misere bids must not borrow the description.
+    expect(screen.getByTestId(`bid-${SoloWhistContract.PASS}`)).not.toHaveAttribute('aria-describedby');
   });
 });

--- a/frontend/src/pages/SoloWhistPage.tsx
+++ b/frontend/src/pages/SoloWhistPage.tsx
@@ -458,21 +458,34 @@ function SoloWhistPageContent() {
                     const tooLow = b.value !== SoloWhistContract.PASS && b.value <= highestBid;
                     const disabled = loading || tooLow;
                     const reason = tooLow ? t('bidTooLow') : undefined;
+                    // Misere wins by taking NO tricks — the opposite of every other
+                    // bid here — so it carries an explicit description rather than
+                    // relying on the player inferring it from the name (#4761).
+                    const isMisere = b.value === SoloWhistContract.MISERE;
                     // The title lives on the wrapping span: browsers suppress native tooltips on
                     // disabled buttons, so hovering the span still surfaces the reason.
                     return (
                       <span key={b.value} title={reason} data-testid={`bid-wrap-${b.value}`}>
                         <button
                           type="button"
-                          className="px-3 py-2 rounded-lg bg-ds-info text-white text-sm disabled:opacity-40"
+                          className={`px-3 py-2 rounded-lg text-white text-sm disabled:opacity-40 ${
+                            isMisere ? 'bg-ds-warning ring-1 ring-ds-warning' : 'bg-ds-info'
+                          }`}
                           onClick={() => handleBid(b.value)}
                           disabled={disabled}
                           aria-disabled={disabled}
                           aria-label={reason ? `${t(b.key)} — ${reason}` : undefined}
+                          aria-describedby={isMisere ? 'solowhist-misere-desc' : undefined}
                           data-testid={`bid-${b.value}`}
                         >
                           {t(b.key)}
+                          {isMisere && <span className="ml-1 text-[10px] opacity-80">{t('misereBadge')}</span>}
                         </button>
+                        {isMisere && (
+                          <span id="solowhist-misere-desc" className="sr-only">
+                            {t('misereDesc')}
+                          </span>
+                        )}
                       </span>
                     );
                   })}


### PR DESCRIPTION
## 変更

「晴眼のプレイヤーが画面から読み取れる情報が、アクセシビリティツリーに一切届いていない」4件です。

| ゲーム | 現状 | 対応 |
|---|---|---|
| ドラゴンタイガー (#4707) | BETフェーズで `d`/`t`/`e` を bind しているのに、`KbdBadge` は END フェーズの Rebet だけ | 3ボタンに `KbdBadge` + `aria-keyshortcuts` を追加（Rebet と同じ形） |
| ソロ・ホイスト (#4761) | ミゼールは「1トリックも取らない」＝他の全入札と逆なのに、説明があるのは Préférence だけ | Préférence の `aria-describedby` + sr-only 説明 + 「特殊」バッジを移植 |
| フラワーガーデン (#4829) | 空きリザーブ枠が素の `div`。**カード入りの枠も `cardAlt` だけで枠番号なし** | 両方に枠番号入りのラベルを付与 |
| キング (#4844) | achieve/avoid バッジが `aria-hidden`（色＋アイコン）なので、読み上げは契約名のみ | 種別をアクセシブル名に、説明を sr-only 要素に |

## issue の範囲を超えた判断（2点）

1. **#4829 は空き枠だけを指摘していましたが、カードが入っている枠も同じ欠落を持っていました**（`aria-label={cardAlt(reserveCard)}` で、可視の `#{cellIdx}` は `aria-hidden`）。片方だけ直すと枠番号が飛び飛びに読み上げられるので、両方直しています。
2. その枠番号は **0起点**にしました。issue が参照先に挙げた `KingAlbertPage.tsx` は `cellIdx + 1` ですが、FlowerGarden はコード上のコメントどおり **CUI の `[r0]..[r15]` と可視の `#{cellIdx}` に合わせて 0起点**です。参照先をそのまま複製すると、このページ内でだけ番号がずれます。

## テストプラン

- [x] 4ページそれぞれにテストを追加
- [x] **負のコントロール実測**: SoloWhist / FlowerGarden / King の実装を戻すと該当テストが落ちることを確認
- [x] ラベル変更で壊れた既存クエリを更新（King 3件、FlowerGarden 2件）
- [x] `bunx vitest run` 対象4ファイル: 81 passed
- [x] `bun run check` / `bun run typecheck`

### テストで踏んだ点

ドラゴンタイガーの表示名は `タイ (8:1)` のように**正規表現メタ文字を含む**ため、`new RegExp(i18n.t(...))` は壊れます。アクセシブル名を関数マッチャで直接比較しています。

Closes #4707
Closes #4761
Closes #4829
Closes #4844