### PR TITLE
feat(a11y): name the cards and destinations that only the eye could find

### DIFF
--- a/frontend/src/components/sevens/SevensBoard.tsx
+++ b/frontend/src/components/sevens/SevensBoard.tsx
@@ -54,7 +54,8 @@ function Board({
                 <span
                   className="flex items-center justify-center font-bold text-base sm:text-lg"
                   style={{ color }}
-                  aria-hidden="true"
+                  role="img"
+                  aria-label={t('suitRowAria', { suit: suitName(idx) })}
                 >
                   {label}
                   {tunnelEnabled && (
@@ -116,8 +117,21 @@ function Board({
                       </button>
                     );
                   }
+                  // The rank digit alone is meaningless out of the row's visual
+                  // context, which was aria-hidden — say which suit it belongs to
+                  // and whether the slot is filled (#4734).
                   return (
-                    <span key={v} className={`${baseClass}${bold}${border}`} style={colors} data-testid="board-cell">
+                    <span
+                      key={v}
+                      role="img"
+                      aria-label={t(placed ? 'cellPlacedAria' : 'cellEmptyAria', {
+                        suit: suitName(idx),
+                        value: valueName(v),
+                      })}
+                      className={`${baseClass}${bold}${border}`}
+                      style={colors}
+                      data-testid="board-cell"
+                    >
                       {valueName(v)}
                     </span>
                   );

--- a/frontend/src/i18n/locales/en/clocksolitaire.json
+++ b/frontend/src/i18n/locales/en/clocksolitaire.json
@@ -1,16 +1,22 @@
 {
+  "autoplay": "Auto Play",
+  "center": "Center(K)",
+  "currentCard": "Current Card",
+  "gameClear": "Game Clear! Steps: {{stepCount}}",
+  "gameOver": "Game Over",
+  "hint": {
+    "firstStep": "Step from the center pile to start.",
+    "continueStep": "Keep stepping the current card onto its clock-position pile."
+  },
+  "landscapeBanner": "Rotate to landscape for a better experience",
   "phase": {
     "playing": "Playing",
     "gameClear": "Game Clear",
     "gameOver": "Game Over"
   },
-  "title": "Clock Solitaire",
-  "stepCount": "Steps",
-  "step": "Step",
-  "autoplay": "Auto Play",
-  "stopAutoplay": "Stop",
-  "undo": "Undo",
-  "currentCard": "Current Card",
+  "placementHint": "goes to the {{hour}} o’clock pile",
+  "placementKing": "goes to the centre (K) pile",
+  "playing": "Playing",
   "settings": {
     "speed": "Animation Speed",
     "speedHelp": "Choose how fast each card's landing animation plays during auto play. Faster races through the placements.",
@@ -18,19 +24,15 @@
     "speedNormal": "Normal",
     "speedFast": "Fast"
   },
-  "center": "Center(K)",
-  "playing": "Playing",
-  "gameClear": "Game Clear! Steps: {{stepCount}}",
-  "gameOver": "Game Over",
+  "step": "Step",
+  "stepCount": "Steps",
+  "stopAutoplay": "Stop",
+  "title": "Clock Solitaire",
   "tutorial": {
     "clockFace": "Cards are arranged in clock positions.",
     "centerPile": "The center pile is for Kings.",
     "controls": "Step advances one card, Auto Play runs to completion.",
     "resetButton": "Press Reset to start a new game."
   },
-  "hint": {
-    "firstStep": "Step from the center pile to start.",
-    "continueStep": "Keep stepping the current card onto its clock-position pile."
-  },
-  "landscapeBanner": "Rotate to landscape for a better experience"
+  "undo": "Undo"
 }

--- a/frontend/src/i18n/locales/en/sevens.json
+++ b/frontend/src/i18n/locales/en/sevens.json
@@ -1,40 +1,13 @@
 {
-  "board": "Board",
-  "tunnel": "Tunnel",
-  "tunnelTag": "[Tunnel]",
-  "jokerSelectHint": "Select placement",
-  "cardCount": "{{count}} cards",
-  "passCount": "Pass: {{used}}/{{max}}",
-  "passUnlimited": "∞",
-  "clickPlayable": "Click a playable card",
-  "mustPass": "No playable cards — please pass",
-  "passRemaining": "Pass ({{count}} left)",
-  "playTitle": "Play: {{design}} {{value}}",
-  "rankLabel": "#{{rank}}",
-  "placeAriaLabel": "Place at {{suit}} {{value}}",
-  "tunnelConnection": "Tunnel connection",
-  "tunnelPortalLeft": "Tunnel portal left (A↔K wrap)",
-  "tunnelPortalRight": "Tunnel portal right (A↔K wrap)",
+  "actionForcedPass": "{{base}} ⚠ No playable cards!",
+  "actionPassed": "{{name}} passed",
   "actionPlayed": "{{name}} played: {{design}} {{value}}",
   "actionPlayedJoker": "{{name}} played: {{design}} {{value}} → {{targetSuit}} {{targetValue}}",
-  "actionPassed": "{{name}} passed",
-  "actionForcedPass": "{{base}} ⚠ No playable cards!",
-  "resultPrefix": "Game Over!",
-  "resultEntry": "{{name}}: {{rank}}",
-  "rules": {
-    "title": "Rules:",
-    "tunnelTag": "[Tunnel]",
-    "tunnelSkipTag": "[Tunnel Skip {{width}}]",
-    "jokerTag": "[Joker ×{{count}}]",
-    "cpuStrategy": "[CPU Strategy]",
-    "cpuHarassment": "[Harassment]",
-    "passUnlimited": "[Unlimited Pass]",
-    "passCount": "[Pass {{count}}×]",
-    "noJokerFinish": "[No Joker Finish]",
-    "jokerReclaim": "[Joker Reclaim]",
-    "endStop": "[End Stop]",
-    "jokerConsecutiveBanned": "[No Consecutive Joker]"
-  },
+  "board": "Board",
+  "cardCount": "{{count}} cards",
+  "cellEmptyAria": "{{suit}} {{value}} empty",
+  "cellPlacedAria": "{{suit}} {{value}} placed",
+  "clickPlayable": "Click a playable card",
   "config": {
     "title": "Rule Settings (applied on reset)",
     "tunnel": "Tunnel",
@@ -54,21 +27,51 @@
     "groupRules": "Rules",
     "groupGame": "Game Settings"
   },
+  "hint": {
+    "playExtend": "You have a playable card — extend the range",
+    "passAvailable": "No playable cards — pass",
+    "passLimitWarning": "Almost out of passes — be careful"
+  },
+  "jokerSelectHint": "Select placement",
+  "keyHints": "Number keys: play the matching card",
+  "mustPass": "No playable cards — please pass",
+  "passCount": "Pass: {{used}}/{{max}}",
+  "passRemaining": "Pass ({{count}} left)",
+  "passUnlimited": "∞",
+  "phase": {
+    "play": "Playing",
+    "end": "End"
+  },
+  "placeAriaLabel": "Place at {{suit}} {{value}}",
+  "playTitle": "Play: {{design}} {{value}}",
+  "rankLabel": "#{{rank}}",
+  "resultEntry": "{{name}}: {{rank}}",
+  "resultPrefix": "Game Over!",
+  "rules": {
+    "title": "Rules:",
+    "tunnelTag": "[Tunnel]",
+    "tunnelSkipTag": "[Tunnel Skip {{width}}]",
+    "jokerTag": "[Joker ×{{count}}]",
+    "cpuStrategy": "[CPU Strategy]",
+    "cpuHarassment": "[Harassment]",
+    "passUnlimited": "[Unlimited Pass]",
+    "passCount": "[Pass {{count}}×]",
+    "noJokerFinish": "[No Joker Finish]",
+    "jokerReclaim": "[Joker Reclaim]",
+    "endStop": "[End Stop]",
+    "jokerConsecutiveBanned": "[No Consecutive Joker]"
+  },
+  "suitRowAria": "{{suit}} row",
+  "tunnel": "Tunnel",
+  "tunnelConnection": "Tunnel connection",
+  "tunnelPortalLeft": "Tunnel portal left (A↔K wrap)",
+  "tunnelPortalRight": "Tunnel portal right (A↔K wrap)",
+  "tunnelTag": "[Tunnel]",
   "tutorial": {
     "board": "The board centered on 7s. Place cards adjacent in rank within the same suit.",
     "playerHand": "This is your hand. Playable cards are highlighted.",
     "playPass": "Pass if you have no playable cards. Pass count may be limited.",
     "settings": "Change rules and settings. Variations include tunnel and joker rules.",
     "resetButton": "Press the reset button to start a new game."
-  },
-  "phase": {
-    "play": "Playing",
-    "end": "End"
-  },
-  "hint": {
-    "playExtend": "You have a playable card — extend the range",
-    "passAvailable": "No playable cards — pass",
-    "passLimitWarning": "Almost out of passes — be careful"
-  },
-  "keyHints": "Number keys: play the matching card"
+  }
 }

--- a/frontend/src/i18n/locales/en/tablanet.json
+++ b/frontend/src/i18n/locales/en/tablanet.json
@@ -1,8 +1,32 @@
 {
-  "title": "Tablanet (Tablić)",
+  "captureAnnounce": "{{player}} captured cards",
+  "captureButton": "Capture",
+  "captured": "Captured: {{count}}",
+  "cards": "{{count}} cards",
+  "cpu": "CPU {{id}}",
+  "deal": "Deal {{n}}",
+  "deck": "Deck: {{count}}",
+  "hint": {
+    "tabla_sweep": "Clear the table for a Tabla bonus",
+    "jack_sweep": "Play a Jack to sweep the table",
+    "capture": "Capture the most valuable table cards",
+    "trail_low": "No capture — trail a low card"
+  },
+  "hintAvailable": "Hint",
+  "hintRequested": "Hint available",
+  "listSeparator": ", ",
+  "newGame": "New Game",
+  "noHint": "No hint available",
   "phase": {
     "play": "Play",
     "gameEnd": "Game Over"
+  },
+  "playButton": "Play",
+  "players": "Players",
+  "result": {
+    "title": "Final Scores",
+    "winner": "Winner: {{names}}",
+    "score": "{{name}}: {{score}} pts"
   },
   "settings": {
     "title": "Settings",
@@ -11,36 +35,18 @@
     "normal": "Normal",
     "hard": "Hard"
   },
-  "deal": "Deal {{n}}",
-  "deck": "Deck: {{count}}",
-  "table": "Table",
-  "tableEmpty": "(empty)",
-  "players": "Players",
-  "you": "You",
-  "cpu": "CPU {{id}}",
-  "cards": "{{count}} cards",
-  "captured": "Captured: {{count}}",
   "tabla": "Tabla: {{count}}",
-  "turnYours": "Your turn — pick a hand card, then tap table cards to capture (or none to trail).",
-  "turnCpu": "CPU {{id}} is playing…",
-  "playButton": "Play",
-  "captureButton": "Capture",
-  "trailButton": "Trail",
+  "tablaAnnounce": "{{player}} scored a tabla (cleared the table)",
   "tablaButton": "Tabla Capture!",
   "tablaReady": "Tabla!",
-  "newGame": "New Game",
-  "result": {
-    "title": "Final Scores",
-    "winner": "Winner: {{names}}",
-    "score": "{{name}}: {{score}} pts"
-  },
-  "hintAvailable": "Hint",
-  "hint": {
-    "tabla_sweep": "Clear the table for a Tabla bonus",
-    "jack_sweep": "Play a Jack to sweep the table",
-    "capture": "Capture the most valuable table cards",
-    "trail_low": "No capture — trail a low card"
-  },
+  "table": "Table",
+  "tableCandidateAria": "{{card}}, capturable",
+  "tableEmpty": "(empty)",
+  "tableSelectedAria": "{{card}}, selected",
+  "title": "Tablanet (Tablić)",
+  "trailButton": "Trail",
+  "turnCpu": "CPU {{id}} is playing…",
+  "turnYours": "Your turn — pick a hand card, then tap table cards to capture (or none to trail).",
   "tutorial": {
     "table": "These are the table cards. A number card you play captures table cards of the same rank and any set whose values add up to it; a Jack sweeps the whole table (except other Jacks). Clearing the table with a single non-Jack card scores a 'Tabla' bonus.",
     "playerHand": "This is your hand. Pick one card, then tap the table cards you want to capture. Tap none and press Play to trail (leave your card on the table).",
@@ -48,9 +54,5 @@
     "info": "Tablanet (Tablić) is a 4-player (you + 3 CPU) fishing game on a 52-card deck. You are dealt four cards with four on the table; fresh hands are dealt until the stock is exhausted. Score the most cards, the 10♦, the 2♣, each Ace, each Jack, and every Tabla sweep. Highest total wins.",
     "resetButton": "Use the reset button to start a new game."
   },
-  "captureAnnounce": "{{player}} captured cards",
-  "tablaAnnounce": "{{player}} scored a tabla (cleared the table)",
-  "listSeparator": ", ",
-  "hintRequested": "Hint available",
-  "noHint": "No hint available"
+  "you": "You"
 }

--- a/frontend/src/i18n/locales/en/terrace.json
+++ b/frontend/src/i18n/locales/en/terrace.json
@@ -19,7 +19,7 @@
   "foundationAriaLabel": "Foundation {{idx}}, {{count}} cards",
   "emptyFoundationAriaLabel": "Empty foundation {{idx}}",
   "emptyPileAriaLabel": "Empty pile {{pile}}",
-  "terraceAriaLabel": "Terrace, {{count}} cards left (foundations only)",
+  "terraceAriaLabel": "Terrace {{card}}, {{count}} cards left (foundations only)",
   "emptyTerraceAriaLabel": "The terrace is empty",
   "stockAriaLabel": "Stock, {{count}} cards left",
   "emptyStockAriaLabel": "The stock is empty (there is no redeal)",

--- a/frontend/src/i18n/locales/ja/clocksolitaire.json
+++ b/frontend/src/i18n/locales/ja/clocksolitaire.json
@@ -1,16 +1,22 @@
 {
+  "autoplay": "オートプレイ",
+  "center": "中央(K)",
+  "currentCard": "手持ちカード",
+  "gameClear": "ゲームクリア！ ステップ数: {{stepCount}}",
+  "gameOver": "ゲームオーバー",
+  "hint": {
+    "firstStep": "中央パイルからカードをめくってスタートしましょう",
+    "continueStep": "現在のカードに対応する位置のパイルにめくり続けます"
+  },
+  "landscapeBanner": "横向きにすると操作しやすくなります",
   "phase": {
     "playing": "プレイ中",
     "gameClear": "ゲームクリア",
     "gameOver": "ゲームオーバー"
   },
-  "title": "クロックソリティア",
-  "stepCount": "ステップ数",
-  "step": "ステップ",
-  "autoplay": "オートプレイ",
-  "stopAutoplay": "停止",
-  "undo": "元に戻す",
-  "currentCard": "手持ちカード",
+  "placementHint": "{{hour}}時の山へ",
+  "placementKing": "中央（K）の山へ",
+  "playing": "プレイ中",
   "settings": {
     "speed": "演出速度",
     "speedHelp": "オートプレイ中に1手ごとの着地演出をどれくらいの速さで再生するかを選びます。速いほど一気に配置が進みます。",
@@ -18,19 +24,15 @@
     "speedNormal": "普通",
     "speedFast": "高速"
   },
-  "center": "中央(K)",
-  "playing": "プレイ中",
-  "gameClear": "ゲームクリア！ ステップ数: {{stepCount}}",
-  "gameOver": "ゲームオーバー",
+  "step": "ステップ",
+  "stepCount": "ステップ数",
+  "stopAutoplay": "停止",
+  "title": "クロックソリティア",
   "tutorial": {
     "clockFace": "時計の文字盤の位置にカードが並んでいます。",
     "centerPile": "中央はKのパイルです。",
     "controls": "ステップで1枚ずつ、オートプレイで自動進行します。",
     "resetButton": "リセットボタンで新しいゲームを始められます。"
   },
-  "hint": {
-    "firstStep": "中央パイルからカードをめくってスタートしましょう",
-    "continueStep": "現在のカードに対応する位置のパイルにめくり続けます"
-  },
-  "landscapeBanner": "横向きにすると操作しやすくなります"
+  "undo": "元に戻す"
 }

--- a/frontend/src/i18n/locales/ja/sevens.json
+++ b/frontend/src/i18n/locales/ja/sevens.json
@@ -1,40 +1,13 @@
 {
-  "board": "ボード",
-  "tunnel": "トンネル",
-  "tunnelTag": "[トンネル]",
-  "jokerSelectHint": "配置先を選択してください",
-  "cardCount": "{{count}}枚",
-  "passCount": "パス: {{used}}/{{max}}",
-  "passUnlimited": "∞",
-  "clickPlayable": "出せるカードをクリック",
-  "mustPass": "出せるカードがありません — パスしてください",
-  "passRemaining": "パス (残り{{count}}回)",
-  "playTitle": "出す: {{design}} {{value}}",
-  "rankLabel": "{{rank}}位",
-  "placeAriaLabel": "{{suit}} {{value}} に配置",
-  "tunnelConnection": "トンネル接続",
-  "tunnelPortalLeft": "トンネル接続口 (左端: A↔K ループ)",
-  "tunnelPortalRight": "トンネル接続口 (右端: A↔K ループ)",
+  "actionForcedPass": "{{base}} ⚠ 出せるカードなし!",
+  "actionPassed": "{{name}}がパスしました",
   "actionPlayed": "{{name}}が出しました: {{design}} {{value}}",
   "actionPlayedJoker": "{{name}}が出しました: {{design}} {{value}} → {{targetSuit}} {{targetValue}}",
-  "actionPassed": "{{name}}がパスしました",
-  "actionForcedPass": "{{base}} ⚠ 出せるカードなし!",
-  "resultPrefix": "ゲーム終了！",
-  "resultEntry": "{{name}}:{{rank}}",
-  "rules": {
-    "title": "ルール:",
-    "tunnelTag": "[トンネル]",
-    "tunnelSkipTag": "[トンネルスキップ{{width}}]",
-    "jokerTag": "[ジョーカー×{{count}}]",
-    "cpuStrategy": "[CPU戦略]",
-    "cpuHarassment": "[嫌がらせ特化]",
-    "passUnlimited": "[パス無制限]",
-    "passCount": "[パス{{count}}回]",
-    "noJokerFinish": "[ジョーカー上がり禁止]",
-    "jokerReclaim": "[ジョーカー回収]",
-    "endStop": "[片側ストップ]",
-    "jokerConsecutiveBanned": "[ジョーカー連続禁止]"
-  },
+  "board": "ボード",
+  "cardCount": "{{count}}枚",
+  "cellEmptyAria": "{{suit}} {{value}} 空き",
+  "cellPlacedAria": "{{suit}} {{value}} 配置済み",
+  "clickPlayable": "出せるカードをクリック",
   "config": {
     "title": "ルール設定 (リセット時に適用)",
     "tunnel": "トンネル",
@@ -54,21 +27,51 @@
     "groupRules": "ルール",
     "groupGame": "ゲーム設定"
   },
+  "hint": {
+    "playExtend": "出せるカードがあります — 範囲を広げましょう",
+    "passAvailable": "出せるカードなし — パス",
+    "passLimitWarning": "パス残り回数わずか — 慎重に"
+  },
+  "jokerSelectHint": "配置先を選択してください",
+  "keyHints": "数字キー: 対応する手札をプレイ",
+  "mustPass": "出せるカードがありません — パスしてください",
+  "passCount": "パス: {{used}}/{{max}}",
+  "passRemaining": "パス (残り{{count}}回)",
+  "passUnlimited": "∞",
+  "phase": {
+    "play": "プレイ",
+    "end": "終了"
+  },
+  "placeAriaLabel": "{{suit}} {{value}} に配置",
+  "playTitle": "出す: {{design}} {{value}}",
+  "rankLabel": "{{rank}}位",
+  "resultEntry": "{{name}}:{{rank}}",
+  "resultPrefix": "ゲーム終了！",
+  "rules": {
+    "title": "ルール:",
+    "tunnelTag": "[トンネル]",
+    "tunnelSkipTag": "[トンネルスキップ{{width}}]",
+    "jokerTag": "[ジョーカー×{{count}}]",
+    "cpuStrategy": "[CPU戦略]",
+    "cpuHarassment": "[嫌がらせ特化]",
+    "passUnlimited": "[パス無制限]",
+    "passCount": "[パス{{count}}回]",
+    "noJokerFinish": "[ジョーカー上がり禁止]",
+    "jokerReclaim": "[ジョーカー回収]",
+    "endStop": "[片側ストップ]",
+    "jokerConsecutiveBanned": "[ジョーカー連続禁止]"
+  },
+  "suitRowAria": "{{suit}} の列",
+  "tunnel": "トンネル",
+  "tunnelConnection": "トンネル接続",
+  "tunnelPortalLeft": "トンネル接続口 (左端: A↔K ループ)",
+  "tunnelPortalRight": "トンネル接続口 (右端: A↔K ループ)",
+  "tunnelTag": "[トンネル]",
   "tutorial": {
     "board": "7を中心にカードを並べるボードです。同じスートで隣接する数字のカードを置けます。",
     "playerHand": "あなたの手札です。出せるカードがハイライトされます。",
     "playPass": "出せるカードがない場合はパスします。パス回数には制限があります。",
     "settings": "ルールや設定を変更できます。トンネルやジョーカーなどのバリエーションがあります。",
     "resetButton": "リセットボタンで新しいゲームを始められます。"
-  },
-  "phase": {
-    "play": "プレイ",
-    "end": "終了"
-  },
-  "hint": {
-    "playExtend": "出せるカードがあります — 範囲を広げましょう",
-    "passAvailable": "出せるカードなし — パス",
-    "passLimitWarning": "パス残り回数わずか — 慎重に"
-  },
-  "keyHints": "数字キー: 対応する手札をプレイ"
+  }
 }

--- a/frontend/src/i18n/locales/ja/tablanet.json
+++ b/frontend/src/i18n/locales/ja/tablanet.json
@@ -1,8 +1,32 @@
 {
-  "title": "タブラネット（Tablić）",
+  "captureAnnounce": "{{player}} が場札を捕獲しました",
+  "captureButton": "捕獲",
+  "captured": "捕獲: {{count}}",
+  "cards": "{{count}}枚",
+  "cpu": "CPU {{id}}",
+  "deal": "配布 {{n}}",
+  "deck": "山札: {{count}}",
+  "hint": {
+    "tabla_sweep": "場を一掃してタブラ・ボーナスを狙う",
+    "jack_sweep": "ジャックで場を一掃する",
+    "capture": "価値の高い場札を捕獲する",
+    "trail_low": "捕獲できないので低い札を捨てる"
+  },
+  "hintAvailable": "ヒント",
+  "hintRequested": "ヒントがあります",
+  "listSeparator": "、",
+  "newGame": "新しいゲーム",
+  "noHint": "ヒントはありません",
   "phase": {
     "play": "プレイ",
     "gameEnd": "ゲーム終了"
+  },
+  "playButton": "出す",
+  "players": "プレイヤー",
+  "result": {
+    "title": "最終得点",
+    "winner": "勝者: {{names}}",
+    "score": "{{name}}: {{score}}点"
   },
   "settings": {
     "title": "設定",
@@ -11,36 +35,18 @@
     "normal": "Normal",
     "hard": "Hard"
   },
-  "deal": "配布 {{n}}",
-  "deck": "山札: {{count}}",
-  "table": "場",
-  "tableEmpty": "（なし）",
-  "players": "プレイヤー",
-  "you": "あなた",
-  "cpu": "CPU {{id}}",
-  "cards": "{{count}}枚",
-  "captured": "捕獲: {{count}}",
   "tabla": "タブラ: {{count}}",
-  "turnYours": "あなたの手番です — 手札を1枚選び、捕獲する場札をタップ（何も選ばなければトレイル）。",
-  "turnCpu": "CPU {{id}} がプレイ中です…",
-  "playButton": "出す",
-  "captureButton": "捕獲",
-  "trailButton": "トレイル",
+  "tablaAnnounce": "{{player}} がタブラ（場を一掃）を達成しました",
   "tablaButton": "タブラ捕獲！",
   "tablaReady": "タブラ！",
-  "newGame": "新しいゲーム",
-  "result": {
-    "title": "最終得点",
-    "winner": "勝者: {{names}}",
-    "score": "{{name}}: {{score}}点"
-  },
-  "hintAvailable": "ヒント",
-  "hint": {
-    "tabla_sweep": "場を一掃してタブラ・ボーナスを狙う",
-    "jack_sweep": "ジャックで場を一掃する",
-    "capture": "価値の高い場札を捕獲する",
-    "trail_low": "捕獲できないので低い札を捨てる"
-  },
+  "table": "場",
+  "tableCandidateAria": "{{card}}、キャプチャ可能",
+  "tableEmpty": "（なし）",
+  "tableSelectedAria": "{{card}}、選択済み",
+  "title": "タブラネット（Tablić）",
+  "trailButton": "トレイル",
+  "turnCpu": "CPU {{id}} がプレイ中です…",
+  "turnYours": "あなたの手番です — 手札を1枚選び、捕獲する場札をタップ（何も選ばなければトレイル）。",
   "tutorial": {
     "table": "場の札です。出した数札は、同ランクの場札と、合計値が一致する組を捕獲します。ジャックは他のジャックを除く場札を一掃します。ジャック以外の1枚で場を空にすると「タブラ」ボーナス。",
     "playerHand": "あなたの手札です。1枚選んでから、捕獲したい場札をタップします。何も選ばずに「出す」を押すとトレイル（場に置く）になります。",
@@ -48,9 +54,5 @@
     "info": "タブラネット（Tablić）は52枚デッキを使う4人用（あなた＋CPU3人）の漁系カードゲームです。各自4枚＋場4枚で始め、山札が尽きるまで配り直します。最多枚数・10♦・2♣・各A・各J・各タブラを得点し、最高点が勝ちです。",
     "resetButton": "リセットボタンで新しいゲームを始められます。"
   },
-  "captureAnnounce": "{{player}} が場札を捕獲しました",
-  "tablaAnnounce": "{{player}} がタブラ（場を一掃）を達成しました",
-  "listSeparator": "、",
-  "hintRequested": "ヒントがあります",
-  "noHint": "ヒントはありません"
+  "you": "あなた"
 }

--- a/frontend/src/i18n/locales/ja/terrace.json
+++ b/frontend/src/i18n/locales/ja/terrace.json
@@ -19,7 +19,7 @@
   "foundationAriaLabel": "組札{{idx}} {{count}}枚",
   "emptyFoundationAriaLabel": "空の組札{{idx}}",
   "emptyPileAriaLabel": "空の山 {{pile}}",
-  "terraceAriaLabel": "テラス 残り{{count}}枚（組札にのみ出せます）",
+  "terraceAriaLabel": "テラス {{card}} 残り{{count}}枚（組札にのみ出せます）",
   "emptyTerraceAriaLabel": "テラスは空です",
   "stockAriaLabel": "山札 残り{{count}}枚",
   "emptyStockAriaLabel": "山札は空です（めくり直しはありません）",

--- a/frontend/src/pages/ClockSolitairePage.test.tsx
+++ b/frontend/src/pages/ClockSolitairePage.test.tsx
@@ -372,4 +372,20 @@ describe('ClockSolitairePage', () => {
     // The step/autoplay controls are hidden once the game has ended.
     expect(screen.queryByTestId('cs-step-button')).not.toBeInTheDocument();
   });
+
+  it('announces where the drawn card is heading', async () => {
+    localStorage.clear();
+    mockExec.mockReset();
+    mockExec.mockResolvedValue({ ...playingState, currentCard: { design: 'SPADE', value: 3 } });
+    renderWithProviders(<ClockSolitairePage />);
+    await waitFor(() => expect(screen.getByTestId('cs-live-region')).toHaveTextContent(/3時/));
+  });
+
+  it('announces the centre pile for a king', async () => {
+    localStorage.clear();
+    mockExec.mockReset();
+    mockExec.mockResolvedValue({ ...playingState, currentCard: { design: 'SPADE', value: 13 } });
+    renderWithProviders(<ClockSolitairePage />);
+    await waitFor(() => expect(screen.getByTestId('cs-live-region')).toHaveTextContent(/中央/));
+  });
 });

--- a/frontend/src/pages/ClockSolitairePage.tsx
+++ b/frontend/src/pages/ClockSolitairePage.tsx
@@ -230,12 +230,20 @@ function ClockSolitairePageContent() {
   // Resolve the same text GameMessageBox shows so it can also be announced in a
   // dedicated live region (the visible box is not guaranteed to be a live region).
   const liveMessage = (() => {
+    const parts: string[] = [];
     if (state.messageCode) {
       const key = `messageCode.${state.messageCode}`;
       const translated = tc(key, state.messageParams ?? {});
-      if (translated !== key) return translated;
+      parts.push(translated === key ? (state.message ?? '') : translated);
+    } else {
+      parts.push(state.message ?? '');
     }
-    return state.message ?? '';
+    // The pulsing ring on the destination pile is visual only. The CUI presenter
+    // already spells the same thing out every turn, so mirror it here (#4785).
+    const value = state.currentCard?.value ?? 0;
+    if (value >= 1 && value <= 12) parts.push(t('placementHint', { hour: value }));
+    else if (value === 13) parts.push(t('placementKing'));
+    return parts.filter(Boolean).join(' ');
   })();
 
   return (

--- a/frontend/src/pages/SevensPage.test.tsx
+++ b/frontend/src/pages/SevensPage.test.tsx
@@ -1748,4 +1748,14 @@ describe('SevensPage', () => {
     const btn = await screen.findByRole('button', { name: 'パス' });
     expect(btn.textContent).toBe('パス');
   });
+
+  it('names each board cell with its suit and slot state', async () => {
+    localStorage.clear();
+    mockExec.mockReset();
+    mockExec.mockResolvedValue(humanTurnState);
+    renderWithProviders(<SevensPage />);
+    // Suit naming follows the board's existing placeAriaLabel (suitName, not the glyph).
+    await waitFor(() => expect(screen.getAllByLabelText(/^SPADE \S+ (空き|配置済み)$/).length).toBeGreaterThan(0));
+    expect(screen.getAllByLabelText(/^SPADE の列$/).length).toBe(1);
+  });
 });

--- a/frontend/src/pages/TablanetPage.test.tsx
+++ b/frontend/src/pages/TablanetPage.test.tsx
@@ -207,4 +207,16 @@ describe('TablanetPage', () => {
     expect(screen.queryByTestId('tablanet-tabla-badge')).not.toBeInTheDocument();
     expect(screen.getByTestId('tablanet-play-button')).not.toHaveTextContent('タブラ捕獲！');
   });
+
+  it('names each table card and marks the selected one as pressed', async () => {
+    localStorage.clear();
+    mockExec.mockReset();
+    mockExec.mockResolvedValue(playPhaseState);
+    renderWithProviders(<TablanetPage />);
+    const first = await screen.findByTestId('table-card-0');
+    expect(first.getAttribute('aria-label')).toMatch(/./);
+    expect(first).toHaveAttribute('aria-pressed', 'false');
+    fireEvent.click(first);
+    await waitFor(() => expect(screen.getByTestId('table-card-0')).toHaveAttribute('aria-pressed', 'true'));
+  });
 });

--- a/frontend/src/pages/TablanetPage.tsx
+++ b/frontend/src/pages/TablanetPage.tsx
@@ -24,6 +24,7 @@ import { gameTheme } from '../styles/gameTheme';
 import type { TablanetResponse } from '../types/card';
 import { TablanetPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { cardAlt } from '../utils/cardAlt';
 import { parseTablanetCommand, TABLANET_HELP } from '../utils/cli/commands/tablanetCommands';
 import { formatTablanetState } from '../utils/cli/formatters/tablanetFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
@@ -247,14 +248,24 @@ function TablanetPageContent() {
                 ) : (
                   state.tableCards.map((c, i) => {
                     const isCandidate = captureCandidates.has(i);
+                    const isSelected = tableIndices.includes(i);
+                    // Without a name these read as a bare "button"; Basra already
+                    // spells out the same three states (#4923).
+                    const ariaLabel = isSelected
+                      ? t('tableSelectedAria', { card: cardAlt(c) })
+                      : isCandidate
+                        ? t('tableCandidateAria', { card: cardAlt(c) })
+                        : cardAlt(c);
                     return (
                       <button
                         key={i}
                         type="button"
+                        aria-label={ariaLabel}
+                        aria-pressed={isSelected}
                         onClick={() => isHumanTurn && toggleTable(i)}
                         disabled={!isHumanTurn}
                         className={`rounded transition-all ${
-                          tableIndices.includes(i)
+                          isSelected
                             ? 'ring-2 ring-ds-warning -translate-y-1'
                             : isCandidate
                               ? 'ring-2 ring-ds-success motion-safe:animate-pulse'

--- a/frontend/src/pages/TerracePage.test.tsx
+++ b/frontend/src/pages/TerracePage.test.tsx
@@ -114,7 +114,7 @@ describe('TerracePage', () => {
   it('sends the terrace top to a foundation and shows its depth', async () => {
     mockExec.mockResolvedValue(playingState);
     renderWithProviders(<TerracePage />);
-    const terrace = await screen.findByRole('button', { name: 'テラス 残り2枚（組札にのみ出せます）' });
+    const terrace = await screen.findByRole('button', { name: /^テラス .+ 残り2枚（組札にのみ出せます）$/ });
     fireEvent.click(terrace);
     await waitFor(() => expect(terrace).toHaveAttribute('aria-pressed', 'true'));
     mockExec.mockClear();
@@ -252,6 +252,16 @@ describe('TerracePage', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /CLI/i }));
     await waitFor(() => expect(screen.queryByText('#0')).not.toBeInTheDocument());
+  });
+
+  it('names the terrace top card, not just the count', async () => {
+    localStorage.clear();
+    mockExec.mockReset();
+    mockExec.mockResolvedValue(playingState);
+    renderWithProviders(<TerracePage />);
+    const terrace = await screen.findByTestId('terrace-pile');
+    // The count alone leaves a screen-reader user unable to plan the next move.
+    expect(terrace.getAttribute('aria-label')).toMatch(/[♠♣♥♦]/);
   });
 });
 

--- a/frontend/src/pages/TerracePage.tsx
+++ b/frontend/src/pages/TerracePage.tsx
@@ -289,9 +289,10 @@ function TerracePageContent() {
                 {terraceTop ? (
                   <button
                     type="button"
+                    data-testid="terrace-pile"
                     onClick={() => game.handleSelectSource(terraceZone)}
                     disabled={!isPlaying || loading}
-                    aria-label={t('terraceAriaLabel', { count: state.reserve.length })}
+                    aria-label={t('terraceAriaLabel', { card: cardAlt(terraceTop), count: state.reserve.length })}
                     aria-pressed={isSourceSelected('reserve', undefined)}
                     draggable={isPlaying && !loading}
                     onDragStart={dnd.handleDragStart(terraceZone)}


### PR DESCRIPTION
## 変更

バッチのアクセシビリティ枠の残り4件です。いずれも「晴眼者が読んでいる要素にアクセシブルネームが無い」型です。

| ゲーム | 現状 | 対応 |
|---|---|---|
| 7並べ (#4734) | スート見出しが `aria-hidden`、各セルはランク数字のみ | 見出しを `role="img"` + ラベルに、各セルにスート・ランク・空き/配置済みを付与 |
| タブラネット (#4923) | 場札ボタンに `aria-label`/`aria-pressed` が無い | Basra と同じ3状態（通常/捕獲候補/選択済み）を移植 |
| テラス (#4907) | リザーブのラベルが残枚数のみ | 先頭カードを追加（CUI の `reserveLine` は元から出している） |
| クロックソリティア (#4785) | 移動先のリングは視覚のみ、live region は message だけ | CUI の `placementHint`/`placementKing` と同じ内容を live region へ |

**7並べは影響が最も大きい**件でした。スート見出しが `aria-hidden="true"` で、セルは押せない `<span>` にランク数字だけ。読み上げは「1 2 3 4 …」の羅列になり、**どの数字がどのスートの列なのか判別する手段がありません**でした。

## 実装上の判断

**スート名の表記はサイトごとの既存慣習に合わせ、全体で統一はしていません。** 7並べの盤面は同じコンポーネント内の `placeAriaLabel` が既に `suitName`（`SPADE`）を使っているのでそれに揃え、タブラネット／テラスは姉妹ページと同じ `cardAlt`（`♠ 5`）を使っています。ここで片方に寄せると、同一画面内で表記が割れます。

## テストプラン

- [x] 4ページにテストを追加
- [x] **負のコントロール実測**: 4実装を無効化すると対応する5テストが落ちることを確認
- [x] `bunx vitest run` 対象6ファイル: 236 passed
- [x] `bun run check` / `bun run typecheck`

テスト作成中、当初 7並べのラベルを `/[♠♣♥♦]/` で検証していましたが、`suitName` はグリフではなく `SPADE` を返すため誤りでした。実装ではなくテストの前提が誤っていたので、既存慣習に合わせて検証側を直しています。

Closes #4734
Closes #4785
Closes #4907
Closes #4923