### PR TITLE
feat(poker): carry Omaha's live previews across to the Hi-Lo and Big O tables

### DIFF
--- a/frontend/src/components/BoardLowBadge.tsx
+++ b/frontend/src/components/BoardLowBadge.tsx
@@ -1,0 +1,47 @@
+import { badgeInfoColors, badgeSuccessColors } from '../styles/badgeStyles';
+import type { Card } from '../types/card';
+import { type BoardLowStatus, boardLowPossibility } from '../utils/omahaLowCards';
+
+/** Design-system token classes per board-low status (live=success, possible=info, impossible=muted). */
+const BOARD_LOW_STATUS_CLASS: Readonly<Record<BoardLowStatus, string>> = {
+  live: badgeSuccessColors,
+  possible: badgeInfoColors,
+  impossible: 'border-ds-border bg-ds-surface text-ds-text-muted',
+};
+
+/** Props for {@link BoardLowBadge}. */
+export interface BoardLowBadgeProps {
+  /** Community cards to inspect. Only the board matters — hole cards are irrelevant. */
+  communityCards: Card[];
+  /** Translator bound to the calling game's namespace; it must own the `boardLow.*` keys. */
+  t: (key: string, opts?: Record<string, unknown>) => string;
+  /** Test hook. Defaults to the Omaha Hi-Lo id the badge was first written for. */
+  testId?: string;
+}
+
+/**
+ * Additive badge showing whether the community board can still make a qualifying
+ * Hi-Lo low (8-or-better): 3+ distinct low ranks on board = live, still
+ * reachable = possible, mathematically out = impossible. Inspects the board only.
+ */
+export function BoardLowBadge({ communityCards, t, testId = 'omahahilo-board-low-badge' }: BoardLowBadgeProps) {
+  const { status, needed } = boardLowPossibility(communityCards);
+  const aria =
+    status === 'live'
+      ? t('boardLow.ariaLive')
+      : status === 'possible'
+        ? t('boardLow.ariaPossible', { needed })
+        : t('boardLow.ariaImpossible');
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] font-semibold ${BOARD_LOW_STATUS_CLASS[status]}`}
+      data-testid={testId}
+      data-status={status}
+      title={aria}
+    >
+      <span aria-hidden="true">{t('boardLow.label')}:</span>
+      <span aria-hidden="true">{t(`boardLow.${status}`)}</span>
+      <span className="sr-only">{aria}</span>
+    </span>
+  );
+}

--- a/frontend/src/i18n/locales/en/bigo.json
+++ b/frontend/src/i18n/locales/en/bigo.json
@@ -81,5 +81,6 @@
     "strongHandRank": "Strong hand — raise recommended",
     "decentHandRank": "Decent hand — call recommended",
     "weakHandRank": "Weak hand — fold recommended"
-  }
+  },
+  "livePreview": "Current hand:"
 }

--- a/frontend/src/i18n/locales/en/bigo.json
+++ b/frontend/src/i18n/locales/en/bigo.json
@@ -82,5 +82,17 @@
     "decentHandRank": "Decent hand — call recommended",
     "weakHandRank": "Weak hand — fold recommended"
   },
-  "livePreview": "Current hand:"
+  "livePreview": "Current hand:",
+  "hand": {
+    "highCard": "High Card",
+    "onePair": "One Pair",
+    "twoPair": "Two Pair",
+    "threeOfAKind": "Three of a Kind",
+    "straight": "Straight",
+    "flush": "Flush",
+    "fullHouse": "Full House",
+    "fourOfAKind": "Four of a Kind",
+    "straightFlush": "Straight Flush",
+    "royalFlush": "Royal Flush"
+  }
 }

--- a/frontend/src/i18n/locales/en/bigohilo.json
+++ b/frontend/src/i18n/locales/en/bigohilo.json
@@ -92,5 +92,14 @@
     "lpTooltip": "Loose Passive: plays many hands but rarely raises",
     "balanced": "BAL",
     "balancedTooltip": "Balanced style"
+  },
+  "boardLow": {
+    "label": "Low",
+    "live": "Live",
+    "possible": "Possible",
+    "impossible": "No low",
+    "ariaLive": "The board shows 3 distinct low ranks (8 or lower); a low is live",
+    "ariaPossible": "{{needed}} more distinct low rank(s) of 8 or lower are needed for a low",
+    "ariaImpossible": "Fewer than 3 distinct low ranks on the board; no low is possible"
   }
 }

--- a/frontend/src/i18n/locales/en/omahahilo.json
+++ b/frontend/src/i18n/locales/en/omahahilo.json
@@ -99,5 +99,6 @@
     "lpTooltip": "Loose Passive: plays many hands but rarely raises",
     "balanced": "BAL",
     "balancedTooltip": "Balanced style"
-  }
+  },
+  "livePreview": "Current hand:"
 }

--- a/frontend/src/i18n/locales/en/omahahilo.json
+++ b/frontend/src/i18n/locales/en/omahahilo.json
@@ -100,5 +100,17 @@
     "balanced": "BAL",
     "balancedTooltip": "Balanced style"
   },
-  "livePreview": "Current hand:"
+  "livePreview": "Current hand:",
+  "hand": {
+    "highCard": "High Card",
+    "onePair": "One Pair",
+    "twoPair": "Two Pair",
+    "threeOfAKind": "Three of a Kind",
+    "straight": "Straight",
+    "flush": "Flush",
+    "fullHouse": "Full House",
+    "fourOfAKind": "Four of a Kind",
+    "straightFlush": "Straight Flush",
+    "royalFlush": "Royal Flush"
+  }
 }

--- a/frontend/src/i18n/locales/ja/bigo.json
+++ b/frontend/src/i18n/locales/ja/bigo.json
@@ -82,5 +82,17 @@
     "decentHandRank": "まずまずのハンド — コール推奨",
     "weakHandRank": "弱いハンド — フォールド推奨"
   },
-  "livePreview": "現在の役:"
+  "livePreview": "現在の役:",
+  "hand": {
+    "highCard": "ハイカード",
+    "onePair": "ワンペア",
+    "twoPair": "ツーペア",
+    "threeOfAKind": "スリーカード",
+    "straight": "ストレート",
+    "flush": "フラッシュ",
+    "fullHouse": "フルハウス",
+    "fourOfAKind": "フォーカード",
+    "straightFlush": "ストレートフラッシュ",
+    "royalFlush": "ロイヤルフラッシュ"
+  }
 }

--- a/frontend/src/i18n/locales/ja/bigo.json
+++ b/frontend/src/i18n/locales/ja/bigo.json
@@ -81,5 +81,6 @@
     "strongHandRank": "強いハンド — レイズ推奨",
     "decentHandRank": "まずまずのハンド — コール推奨",
     "weakHandRank": "弱いハンド — フォールド推奨"
-  }
+  },
+  "livePreview": "現在の役:"
 }

--- a/frontend/src/i18n/locales/ja/bigohilo.json
+++ b/frontend/src/i18n/locales/ja/bigohilo.json
@@ -92,5 +92,14 @@
     "lpTooltip": "Loose Passive：参加多めだがコール中心",
     "balanced": "BAL",
     "balancedTooltip": "バランス型のスタイル"
+  },
+  "boardLow": {
+    "label": "ロー",
+    "live": "成立圏",
+    "possible": "成立可能",
+    "impossible": "不成立確定",
+    "ariaLive": "ボードに8以下が3ランクあり、ロー成立圏です",
+    "ariaPossible": "ロー成立まであと{{needed}}ランク（8以下）が必要です",
+    "ariaImpossible": "ボードの8以下が3ランク未満のため、ローは不成立確定です"
   }
 }

--- a/frontend/src/i18n/locales/ja/omahahilo.json
+++ b/frontend/src/i18n/locales/ja/omahahilo.json
@@ -100,5 +100,17 @@
     "balanced": "BAL",
     "balancedTooltip": "バランス型のスタイル"
   },
-  "livePreview": "現在の役:"
+  "livePreview": "現在の役:",
+  "hand": {
+    "highCard": "ハイカード",
+    "onePair": "ワンペア",
+    "twoPair": "ツーペア",
+    "threeOfAKind": "スリーカード",
+    "straight": "ストレート",
+    "flush": "フラッシュ",
+    "fullHouse": "フルハウス",
+    "fourOfAKind": "フォーカード",
+    "straightFlush": "ストレートフラッシュ",
+    "royalFlush": "ロイヤルフラッシュ"
+  }
 }

--- a/frontend/src/i18n/locales/ja/omahahilo.json
+++ b/frontend/src/i18n/locales/ja/omahahilo.json
@@ -99,5 +99,6 @@
     "lpTooltip": "Loose Passive：参加多めだがコール中心",
     "balanced": "BAL",
     "balancedTooltip": "バランス型のスタイル"
-  }
+  },
+  "livePreview": "現在の役:"
 }

--- a/frontend/src/pages/BigOHiLoPage.test.tsx
+++ b/frontend/src/pages/BigOHiLoPage.test.tsx
@@ -1677,4 +1677,13 @@ describe('BigOHiLoPage', () => {
     renderWithProviders(<BigOHiLoPage />);
     await waitFor(() => expect(screen.getByTestId('bigohilo-board-low-badge')).toBeInTheDocument());
   });
+
+  it('withholds the board-low badge before the flop', async () => {
+    localStorage.clear();
+    mockExec.mockReset();
+    mockExec.mockResolvedValue(preFlopState);
+    renderWithProviders(<BigOHiLoPage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
+    expect(screen.queryByTestId('bigohilo-board-low-badge')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/BigOHiLoPage.test.tsx
+++ b/frontend/src/pages/BigOHiLoPage.test.tsx
@@ -1669,4 +1669,12 @@ describe('BigOHiLoPage', () => {
       expect((screen.getByLabelText(label) as HTMLInputElement).checked).toBe(!before);
     });
   });
+
+  it('shows whether the board can still make a low', async () => {
+    localStorage.clear();
+    mockExec.mockReset();
+    mockExec.mockResolvedValue(flopState);
+    renderWithProviders(<BigOHiLoPage />);
+    await waitFor(() => expect(screen.getByTestId('bigohilo-board-low-badge')).toBeInTheDocument());
+  });
 });

--- a/frontend/src/pages/BigOHiLoPage.tsx
+++ b/frontend/src/pages/BigOHiLoPage.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { bigOHiLoApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { BettingControls } from '../components/BettingControls';
+import { BoardLowBadge } from '../components/BoardLowBadge';
 import { CpuAccordion } from '../components/CpuAccordion';
 import { CpuActionLog } from '../components/CpuActionLog';
 import { CpuActionToast } from '../components/CpuActionToast';
@@ -219,7 +220,16 @@ function BigOHiLoPageContent() {
             {(() => {
               const communityCardsContent = (
                 <>
-                  <div className="text-ds-text-primary text-lg mb-1.5">{t('communityCards')}</div>
+                  <div className="mb-1.5 flex flex-wrap items-center gap-2">
+                    <span className="text-ds-text-primary text-lg">{t('communityCards')}</span>
+                    {phase >= OmahaPhase.FLOP && phase <= OmahaPhase.RIVER && (
+                      <BoardLowBadge
+                        communityCards={state?.communityCards ?? []}
+                        t={t}
+                        testId="bigohilo-board-low-badge"
+                      />
+                    )}
+                  </div>
                   <div className="flex flex-wrap gap-2">
                     {state?.communityCards?.length
                       ? state.communityCards.map((card, idx) => {

--- a/frontend/src/pages/BigOPage.test.tsx
+++ b/frontend/src/pages/BigOPage.test.tsx
@@ -1587,4 +1587,13 @@ describe('BigOPage', () => {
     renderWithProviders(<BigOPage />);
     await waitFor(() => expect(screen.getByTestId('bigo-live-besthand')).toBeInTheDocument());
   });
+
+  it('drops the preview at showdown, where the final hand is already shown', async () => {
+    localStorage.clear();
+    mockExec.mockReset();
+    mockExec.mockResolvedValue(showdownState);
+    renderWithProviders(<BigOPage />);
+    await waitFor(() => expect(screen.queryByTestId('bigo-live-besthand')).not.toBeInTheDocument());
+    expect(screen.getByTestId('bigo-rule-badge')).toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/BigOPage.test.tsx
+++ b/frontend/src/pages/BigOPage.test.tsx
@@ -1585,7 +1585,10 @@ describe('BigOPage', () => {
     mockExec.mockReset();
     mockExec.mockResolvedValue(flopState);
     renderWithProviders(<BigOPage />);
-    await waitFor(() => expect(screen.getByTestId('bigo-live-besthand')).toBeInTheDocument());
+    const badge = await screen.findByTestId('bigo-live-besthand-name');
+    // A missing hand.* key renders the key itself, which the presence check missed.
+    expect(badge.textContent).not.toMatch(/^hand\./);
+    expect(badge.textContent?.trim()).toBeTruthy();
   });
 
   it('drops the preview at showdown, where the final hand is already shown', async () => {

--- a/frontend/src/pages/BigOPage.test.tsx
+++ b/frontend/src/pages/BigOPage.test.tsx
@@ -1579,4 +1579,12 @@ describe('BigOPage', () => {
       expect((screen.getByLabelText(label) as HTMLInputElement).checked).toBe(!before);
     });
   });
+
+  it('previews the current best hand during play', async () => {
+    localStorage.clear();
+    mockExec.mockReset();
+    mockExec.mockResolvedValue(flopState);
+    renderWithProviders(<BigOPage />);
+    await waitFor(() => expect(screen.getByTestId('bigo-live-besthand')).toBeInTheDocument());
+  });
 });

--- a/frontend/src/pages/BigOPage.tsx
+++ b/frontend/src/pages/BigOPage.tsx
@@ -33,7 +33,7 @@ import { OmahaPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { OMAHA_HELP, parseOmahaCommand } from '../utils/cli/commands/omahaCommands';
 import { formatOmahaState } from '../utils/cli/formatters/omahaFormatter';
-import { omahaLiveHandKey } from '../utils/livePokerPreview';
+import { omahaLivePreviewKey } from '../utils/livePokerPreview';
 import { omahaBestFive } from '../utils/omahaBestFive';
 import { findPlayerName } from '../utils/playerUtils';
 
@@ -164,10 +164,10 @@ function BigOPageContent() {
   // Preview the hand the player currently holds under the must-use-exactly-2
   // rule. Big O deals five hole cards — ten pairings to weigh by eye — so the
   // preview matters more here than in plain Omaha, which already had it (#4681/#4682).
-  const liveBestHandKey = useMemo(() => {
-    if (!isActive || isShowdown || !humanPlayer || humanPlayer.folded) return null;
-    return omahaLiveHandKey(humanPlayer.cards ?? [], state?.communityCards ?? []);
-  }, [isActive, isShowdown, humanPlayer, state?.communityCards]);
+  const liveBestHandKey = useMemo(
+    () => omahaLivePreviewKey(humanPlayer, state?.communityCards ?? [], { isActive, isShowdown }),
+    [isActive, isShowdown, humanPlayer, state?.communityCards],
+  );
 
   if (!state)
     return (

--- a/frontend/src/pages/BigOPage.tsx
+++ b/frontend/src/pages/BigOPage.tsx
@@ -33,6 +33,7 @@ import { OmahaPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { OMAHA_HELP, parseOmahaCommand } from '../utils/cli/commands/omahaCommands';
 import { formatOmahaState } from '../utils/cli/formatters/omahaFormatter';
+import { omahaLiveHandKey } from '../utils/livePokerPreview';
 import { omahaBestFive } from '../utils/omahaBestFive';
 import { findPlayerName } from '../utils/playerUtils';
 
@@ -132,6 +133,7 @@ function BigOPageContent() {
     handleCommand,
     handleManualReset,
     phase,
+    isActive,
     isShowdown,
     humanPlayer,
     canAct,
@@ -158,6 +160,14 @@ function BigOPageContent() {
     if (!best) return empty;
     return { holeSet: new Set(best.holeIdx), boardSet: new Set(best.boardIdx) };
   }, [isShowdown, humanPlayer, state?.communityCards]);
+
+  // Preview the hand the player currently holds under the must-use-exactly-2
+  // rule. Big O deals five hole cards — ten pairings to weigh by eye — so the
+  // preview matters more here than in plain Omaha, which already had it (#4681/#4682).
+  const liveBestHandKey = useMemo(() => {
+    if (!isActive || isShowdown || !humanPlayer || humanPlayer.folded) return null;
+    return omahaLiveHandKey(humanPlayer.cards ?? [], state?.communityCards ?? []);
+  }, [isActive, isShowdown, humanPlayer, state?.communityCards]);
 
   if (!state)
     return (
@@ -343,6 +353,17 @@ function BigOPageContent() {
                   <span aria-hidden="true">🎯</span>
                   {t('mandatoryRule')}
                 </div>
+                {liveBestHandKey && (
+                  <div className="mb-1" data-testid="bigo-live-besthand">
+                    <span className="text-ds-text-primary text-xs">{t('livePreview')}</span>
+                    <span
+                      className={`inline-block ml-1.5 text-xs font-bold rounded px-2 py-0.5 ${handNameBadgeClass}`}
+                      data-testid="bigo-live-besthand-name"
+                    >
+                      {t(`hand.${liveBestHandKey}`)}
+                    </span>
+                  </div>
+                )}
                 {/* Big O deals 5 hole cards; on mobile keep them on a single
                     scrollable row (never wrap) so all 5 stay visible with
                     full-size tap targets. Desktop keeps the wrapping layout. */}

--- a/frontend/src/pages/OmahaHiLoPage.test.tsx
+++ b/frontend/src/pages/OmahaHiLoPage.test.tsx
@@ -1642,4 +1642,12 @@ describe('OmahaHiLoPage', () => {
       expect((screen.getByLabelText(label) as HTMLInputElement).checked).toBe(!before);
     });
   });
+
+  it('previews the current best hand during play', async () => {
+    localStorage.clear();
+    mockExec.mockReset();
+    mockExec.mockResolvedValue(flopState);
+    renderWithProviders(<OmahaHiLoPage />);
+    await waitFor(() => expect(screen.getByTestId('omahahilo-live-besthand')).toBeInTheDocument());
+  });
 });

--- a/frontend/src/pages/OmahaHiLoPage.test.tsx
+++ b/frontend/src/pages/OmahaHiLoPage.test.tsx
@@ -1650,4 +1650,13 @@ describe('OmahaHiLoPage', () => {
     renderWithProviders(<OmahaHiLoPage />);
     await waitFor(() => expect(screen.getByTestId('omahahilo-live-besthand')).toBeInTheDocument());
   });
+
+  it('drops the preview at showdown, where the final hand is already shown', async () => {
+    localStorage.clear();
+    mockExec.mockReset();
+    mockExec.mockResolvedValue(showdownState);
+    renderWithProviders(<OmahaHiLoPage />);
+    await waitFor(() => expect(screen.queryByTestId('omahahilo-live-besthand')).not.toBeInTheDocument());
+    expect(screen.getByTestId('omahahilo-rule-badge')).toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/OmahaHiLoPage.test.tsx
+++ b/frontend/src/pages/OmahaHiLoPage.test.tsx
@@ -1648,7 +1648,10 @@ describe('OmahaHiLoPage', () => {
     mockExec.mockReset();
     mockExec.mockResolvedValue(flopState);
     renderWithProviders(<OmahaHiLoPage />);
-    await waitFor(() => expect(screen.getByTestId('omahahilo-live-besthand')).toBeInTheDocument());
+    const badge = await screen.findByTestId('omahahilo-live-besthand-name');
+    // A missing hand.* key renders the key itself, which the presence check missed.
+    expect(badge.textContent).not.toMatch(/^hand\./);
+    expect(badge.textContent?.trim()).toBeTruthy();
   });
 
   it('drops the preview at showdown, where the final hand is already shown', async () => {

--- a/frontend/src/pages/OmahaHiLoPage.tsx
+++ b/frontend/src/pages/OmahaHiLoPage.tsx
@@ -36,7 +36,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { valueName } from '../utils/cardUtils';
 import { OMAHA_HELP, parseOmahaCommand } from '../utils/cli/commands/omahaCommands';
 import { formatOmahaState } from '../utils/cli/formatters/omahaFormatter';
-import { omahaLiveHandKey } from '../utils/livePokerPreview';
+import { omahaLivePreviewKey } from '../utils/livePokerPreview';
 import { omahaBestFive } from '../utils/omahaBestFive';
 import { lowCardIndexSets } from '../utils/omahaLowCards';
 import { findPlayerName } from '../utils/playerUtils';
@@ -219,10 +219,10 @@ function OmahaHiLoPageContent() {
   // Preview the hand the player currently holds under the must-use-exactly-2
   // rule. Big O deals five hole cards — ten pairings to weigh by eye — so the
   // preview matters more here than in plain Omaha, which already had it (#4681/#4682).
-  const liveBestHandKey = useMemo(() => {
-    if (!isActive || isShowdown || !humanPlayer || humanPlayer.folded) return null;
-    return omahaLiveHandKey(humanPlayer.cards ?? [], state?.communityCards ?? []);
-  }, [isActive, isShowdown, humanPlayer, state?.communityCards]);
+  const liveBestHandKey = useMemo(
+    () => omahaLivePreviewKey(humanPlayer, state?.communityCards ?? [], { isActive, isShowdown }),
+    [isActive, isShowdown, humanPlayer, state?.communityCards],
+  );
   // At showdown, highlight the human's qualifying low cards (hole + board), if any.
   const humanLowBestHand = isShowdown
     ? state?.roundResults?.find((r) => r.playerIdx === humanPlayer?.id)?.lowBestHand

--- a/frontend/src/pages/OmahaHiLoPage.tsx
+++ b/frontend/src/pages/OmahaHiLoPage.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { omahaHiLoApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { BettingControls } from '../components/BettingControls';
+import { BoardLowBadge } from '../components/BoardLowBadge';
 import { CpuAccordion } from '../components/CpuAccordion';
 import { CpuActionLog } from '../components/CpuActionLog';
 import { CpuActionToast } from '../components/CpuActionToast';
@@ -23,7 +24,7 @@ import { RoundResults } from '../components/RoundResults';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useCommunityPokerGame } from '../hooks/useCommunityPokerGame';
-import { badgeInfoColors, badgeSuccessColors } from '../styles/badgeStyles';
+import { badgeInfoColors } from '../styles/badgeStyles';
 import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
 import { placeholderCardStyle } from '../styles/cardStyles';
 import { handNameBadgeClass } from '../styles/gameConstants';
@@ -35,8 +36,9 @@ import type { TutorialStep } from '../types/tutorial';
 import { valueName } from '../utils/cardUtils';
 import { OMAHA_HELP, parseOmahaCommand } from '../utils/cli/commands/omahaCommands';
 import { formatOmahaState } from '../utils/cli/formatters/omahaFormatter';
+import { omahaLiveHandKey } from '../utils/livePokerPreview';
 import { omahaBestFive } from '../utils/omahaBestFive';
-import { type BoardLowStatus, boardLowPossibility, lowCardIndexSets } from '../utils/omahaLowCards';
+import { lowCardIndexSets } from '../utils/omahaLowCards';
 import { findPlayerName } from '../utils/playerUtils';
 
 /** Omaha Hi-Lo (8 or Better) tutorial step definitions. */
@@ -147,44 +149,6 @@ function OmahaLoCard({
   );
 }
 
-/** Design-system token classes per board-low status (live=success, possible=info, impossible=muted). */
-const BOARD_LOW_STATUS_CLASS: Readonly<Record<BoardLowStatus, string>> = {
-  live: badgeSuccessColors,
-  possible: badgeInfoColors,
-  impossible: 'border-ds-border bg-ds-surface text-ds-text-muted',
-};
-
-/** Additive badge showing whether the community board can still make a qualifying
- * Omaha Hi-Lo low (8-or-better): 3+ distinct low ranks on board = live, still
- * reachable = possible, mathematically out = impossible. Inspects the board only. */
-function BoardLowBadge({
-  communityCards,
-  t,
-}: {
-  communityCards: Card[];
-  t: (key: string, opts?: Record<string, unknown>) => string;
-}) {
-  const { status, needed } = boardLowPossibility(communityCards);
-  const aria =
-    status === 'live'
-      ? t('boardLow.ariaLive')
-      : status === 'possible'
-        ? t('boardLow.ariaPossible', { needed })
-        : t('boardLow.ariaImpossible');
-  return (
-    <span
-      className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] font-semibold ${BOARD_LOW_STATUS_CLASS[status]}`}
-      data-testid="omahahilo-board-low-badge"
-      data-status={status}
-      title={aria}
-    >
-      <span aria-hidden="true">{t('boardLow.label')}:</span>
-      <span aria-hidden="true">{t(`boardLow.${status}`)}</span>
-      <span className="sr-only">{aria}</span>
-    </span>
-  );
-}
-
 /** Renders the Omaha Hi-Lo (8 or Better) game page with community cards,
  * betting, and split-pot showdown. */
 export const OmahaHiLoPage = withTutorial(OmahaHiLoPageContent, 'omahahilo', OHL_TUTORIAL_STEPS);
@@ -225,6 +189,7 @@ function OmahaHiLoPageContent() {
     handleCommand,
     handleManualReset,
     phase,
+    isActive,
     isShowdown,
     humanPlayer,
     canAct,
@@ -250,6 +215,14 @@ function OmahaHiLoPageContent() {
     if (!best) return empty;
     return { holeSet: new Set(best.holeIdx), boardSet: new Set(best.boardIdx) };
   }, [isShowdown, humanPlayer, state?.communityCards]);
+
+  // Preview the hand the player currently holds under the must-use-exactly-2
+  // rule. Big O deals five hole cards — ten pairings to weigh by eye — so the
+  // preview matters more here than in plain Omaha, which already had it (#4681/#4682).
+  const liveBestHandKey = useMemo(() => {
+    if (!isActive || isShowdown || !humanPlayer || humanPlayer.folded) return null;
+    return omahaLiveHandKey(humanPlayer.cards ?? [], state?.communityCards ?? []);
+  }, [isActive, isShowdown, humanPlayer, state?.communityCards]);
   // At showdown, highlight the human's qualifying low cards (hole + board), if any.
   const humanLowBestHand = isShowdown
     ? state?.roundResults?.find((r) => r.playerIdx === humanPlayer?.id)?.lowBestHand
@@ -490,6 +463,17 @@ function OmahaHiLoPageContent() {
                   <span aria-hidden="true">🎯</span>
                   {t('mandatoryRule')}
                 </div>
+                {liveBestHandKey && (
+                  <div className="mb-1" data-testid="omahahilo-live-besthand">
+                    <span className="text-ds-text-primary text-xs">{t('livePreview')}</span>
+                    <span
+                      className={`inline-block ml-1.5 text-xs font-bold rounded px-2 py-0.5 ${handNameBadgeClass}`}
+                      data-testid="omahahilo-live-besthand-name"
+                    >
+                      {t(`hand.${liveBestHandKey}`)}
+                    </span>
+                  </div>
+                )}
                 <div className="flex flex-wrap gap-1.5 mb-2" data-tutorial="ohl-combination-rule">
                   {humanPlayer.cards?.length
                     ? humanPlayer.cards.map((card, idx) => {

--- a/frontend/src/pages/OmahaPage.tsx
+++ b/frontend/src/pages/OmahaPage.tsx
@@ -33,7 +33,7 @@ import { OmahaPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { OMAHA_HELP, parseOmahaCommand } from '../utils/cli/commands/omahaCommands';
 import { formatOmahaState } from '../utils/cli/formatters/omahaFormatter';
-import { omahaLiveHandKey } from '../utils/livePokerPreview';
+import { omahaLivePreviewKey } from '../utils/livePokerPreview';
 import { omahaBestFive } from '../utils/omahaBestFive';
 import { findPlayerName } from '../utils/playerUtils';
 
@@ -164,10 +164,10 @@ function OmahaPageContent() {
   // During play (flop..river), preview the human's current best hand name under
   // Omaha's must-use-exactly-2-hole + 3-board rule. Returns null pre-flop (fewer
   // than 3 board cards) or at showdown (where the winning hand is already shown).
-  const liveBestHandKey = useMemo(() => {
-    if (!isActive || isShowdown || !humanPlayer || humanPlayer.folded) return null;
-    return omahaLiveHandKey(humanPlayer.cards ?? [], state?.communityCards ?? []);
-  }, [isActive, isShowdown, humanPlayer, state?.communityCards]);
+  const liveBestHandKey = useMemo(
+    () => omahaLivePreviewKey(humanPlayer, state?.communityCards ?? [], { isActive, isShowdown }),
+    [isActive, isShowdown, humanPlayer, state?.communityCards],
+  );
 
   if (!state)
     return (

--- a/frontend/src/pages/OmahaPage.tsx
+++ b/frontend/src/pages/OmahaPage.tsx
@@ -33,9 +33,9 @@ import { OmahaPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { OMAHA_HELP, parseOmahaCommand } from '../utils/cli/commands/omahaCommands';
 import { formatOmahaState } from '../utils/cli/formatters/omahaFormatter';
+import { omahaLiveHandKey } from '../utils/livePokerPreview';
 import { omahaBestFive } from '../utils/omahaBestFive';
 import { findPlayerName } from '../utils/playerUtils';
-import { evaluateFiveCardHand, pokerHandKey } from '../utils/pokerSquaresUtils';
 
 /** Omaha Hold'em tutorial step definitions. */
 const OH_TUTORIAL_STEPS: TutorialStep[] = [
@@ -166,13 +166,7 @@ function OmahaPageContent() {
   // than 3 board cards) or at showdown (where the winning hand is already shown).
   const liveBestHandKey = useMemo(() => {
     if (!isActive || isShowdown || !humanPlayer || humanPlayer.folded) return null;
-    const hole = humanPlayer.cards ?? [];
-    const board = state?.communityCards ?? [];
-    const best = omahaBestFive(hole, board);
-    if (!best) return null;
-    const five = [...best.holeIdx.map((i) => hole[i]), ...best.boardIdx.map((i) => board[i])];
-    const rank = evaluateFiveCardHand(five);
-    return rank == null ? null : pokerHandKey(rank);
+    return omahaLiveHandKey(humanPlayer.cards ?? [], state?.communityCards ?? []);
   }, [isActive, isShowdown, humanPlayer, state?.communityCards]);
 
   if (!state)

--- a/frontend/src/utils/livePokerPreview.test.ts
+++ b/frontend/src/utils/livePokerPreview.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { Card, CardDesign } from '../types/card';
-import { omahaLiveHandKey } from './livePokerPreview';
+import { omahaLiveHandKey, omahaLivePreviewKey } from './livePokerPreview';
 
 const c = (design: CardDesign, value: number): Card => ({ design, value });
 
@@ -26,5 +26,36 @@ describe('omahaLiveHandKey', () => {
     const hole = [c('SPADE', 2), c('HEART', 5), c('HEART', 7), c('DIAMOND', 9)];
     const board = [c('SPADE', 6), c('SPADE', 8), c('SPADE', 10), c('SPADE', 12), c('CLOVER', 3)];
     expect(omahaLiveHandKey(hole, board)).not.toBe('flush');
+  });
+});
+
+describe('omahaLivePreviewKey', () => {
+  const hole = [c('SPADE', 2), c('SPADE', 4), c('HEART', 9), c('DIAMOND', 11)];
+  const board = [c('SPADE', 6), c('SPADE', 8), c('SPADE', 10)];
+  const live = { isActive: true, isShowdown: false };
+
+  it('previews a live, unfolded hand', () => {
+    expect(omahaLivePreviewKey({ cards: hole }, board, live)).toBe('flush');
+  });
+
+  it('is silent before the hand is live', () => {
+    expect(omahaLivePreviewKey({ cards: hole }, board, { isActive: false, isShowdown: false })).toBeNull();
+  });
+
+  it('is silent at showdown, where the final hand is already highlighted', () => {
+    expect(omahaLivePreviewKey({ cards: hole }, board, { isActive: true, isShowdown: true })).toBeNull();
+  });
+
+  it('is silent for a folded player', () => {
+    expect(omahaLivePreviewKey({ cards: hole, folded: true }, board, live)).toBeNull();
+  });
+
+  it('is silent with no seated player', () => {
+    expect(omahaLivePreviewKey(null, board, live)).toBeNull();
+    expect(omahaLivePreviewKey(undefined, board, live)).toBeNull();
+  });
+
+  it('treats a player with no cards as having nothing to preview', () => {
+    expect(omahaLivePreviewKey({}, board, live)).toBeNull();
   });
 });

--- a/frontend/src/utils/livePokerPreview.test.ts
+++ b/frontend/src/utils/livePokerPreview.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import type { Card, CardDesign } from '../types/card';
+import { omahaLiveHandKey } from './livePokerPreview';
+
+const c = (design: CardDesign, value: number): Card => ({ design, value });
+
+describe('omahaLiveHandKey', () => {
+  it('is null before the flop, when no five cards exist yet', () => {
+    expect(omahaLiveHandKey([c('SPADE', 1), c('SPADE', 2), c('HEART', 3), c('HEART', 4)], [])).toBeNull();
+  });
+
+  it('is null with no hole cards', () => {
+    expect(omahaLiveHandKey([], [c('SPADE', 5), c('SPADE', 6), c('SPADE', 7)])).toBeNull();
+  });
+
+  it('names the hand once the flop is out', () => {
+    // Two hole spades plus three board spades is a flush under the must-use-2 rule.
+    const hole = [c('SPADE', 2), c('SPADE', 4), c('HEART', 9), c('DIAMOND', 11)];
+    const board = [c('SPADE', 6), c('SPADE', 8), c('SPADE', 10)];
+    expect(omahaLiveHandKey(hole, board)).toBe('flush');
+  });
+
+  it('obeys the must-use-exactly-two rule rather than picking any five', () => {
+    // Four board spades would be a flush in Hold'em, but Omaha forces exactly two
+    // hole cards, and the only spade in hand is the 2 — so no flush is available.
+    const hole = [c('SPADE', 2), c('HEART', 5), c('HEART', 7), c('DIAMOND', 9)];
+    const board = [c('SPADE', 6), c('SPADE', 8), c('SPADE', 10), c('SPADE', 12), c('CLOVER', 3)];
+    expect(omahaLiveHandKey(hole, board)).not.toBe('flush');
+  });
+});

--- a/frontend/src/utils/livePokerPreview.ts
+++ b/frontend/src/utils/livePokerPreview.ts
@@ -16,10 +16,9 @@ import { evaluateFiveCardHand, pokerHandKey } from './pokerSquaresUtils';
 export function omahaLiveHandKey(hole: readonly Card[], board: readonly Card[]): string | null {
   const best = omahaBestFive(hole, board);
   if (!best) return null;
-  const five = [...best.holeIdx.map((i) => hole[i]), ...best.boardIdx.map((i) => board[i])].filter(
-    (c): c is Card => c !== undefined,
-  );
-  if (five.length !== 5) return null;
+  // omahaBestFive only returns a combination when it found five real cards, so
+  // the indices always resolve and evaluateFiveCardHand always scores.
+  const five = [...best.holeIdx.map((i) => hole[i]), ...best.boardIdx.map((i) => board[i])];
   const rank = evaluateFiveCardHand(five);
   return rank == null ? null : pokerHandKey(rank);
 }

--- a/frontend/src/utils/livePokerPreview.ts
+++ b/frontend/src/utils/livePokerPreview.ts
@@ -1,0 +1,25 @@
+import type { Card } from '../types/card';
+import { omahaBestFive } from './omahaBestFive';
+import { evaluateFiveCardHand, pokerHandKey } from './pokerSquaresUtils';
+
+/**
+ * i18n key of the best hand the player currently holds under Omaha's
+ * must-use-exactly-two-hole-cards rule, or null when no five-card hand exists
+ * yet (pre-flop) or the cards do not evaluate.
+ *
+ * The preview matters more the wider the hole set gets: Big O deals five hole
+ * cards, which is ten two-card combinations to weigh by eye every street.
+ * @param hole - The player's hole cards.
+ * @param board - The community cards.
+ * @returns The hand-name i18n key, or null.
+ */
+export function omahaLiveHandKey(hole: readonly Card[], board: readonly Card[]): string | null {
+  const best = omahaBestFive(hole, board);
+  if (!best) return null;
+  const five = [...best.holeIdx.map((i) => hole[i]), ...best.boardIdx.map((i) => board[i])].filter(
+    (c): c is Card => c !== undefined,
+  );
+  if (five.length !== 5) return null;
+  const rank = evaluateFiveCardHand(five);
+  return rank == null ? null : pokerHandKey(rank);
+}

--- a/frontend/src/utils/livePokerPreview.ts
+++ b/frontend/src/utils/livePokerPreview.ts
@@ -22,3 +22,31 @@ export function omahaLiveHandKey(hole: readonly Card[], board: readonly Card[]):
   const rank = evaluateFiveCardHand(five);
   return rank == null ? null : pokerHandKey(rank);
 }
+
+/** The subset of a poker player this preview needs. */
+export interface LivePreviewPlayer {
+  cards?: Card[];
+  folded?: boolean;
+}
+
+/**
+ * The preview key to show for a player mid-hand, or null when no preview
+ * belongs on screen: before the hand is live, at showdown (where the final
+ * hand is already highlighted), or for a player who has folded or is absent.
+ *
+ * The guard lives here rather than in each page so the three Omaha variants
+ * cannot disagree about when a preview is appropriate.
+ * @param player - The human player, if seated.
+ * @param board - The community cards.
+ * @param opts - Whether the hand is live and whether it has reached showdown.
+ * @returns The hand-name i18n key, or null.
+ */
+export function omahaLivePreviewKey(
+  player: LivePreviewPlayer | null | undefined,
+  board: readonly Card[],
+  opts: { isActive: boolean; isShowdown: boolean },
+): string | null {
+  if (!opts.isActive || opts.isShowdown) return null;
+  if (!player || player.folded) return null;
+  return omahaLiveHandKey(player.cards ?? [], board);
+}


### PR DESCRIPTION
## 変更

`OmahaPage` は毎ストリート暫定ベストハンドを、`OmahaHiLoPage` はボードのロー成立可能性バッジを出していますが、**それを最も必要とする変種に届いていませんでした**。

| ゲーム | 追加 |
|---|---|
| オマハ ハイロー (#4681) | 暫定ベストハンドのプレビュー |
| 5カードオマハ (#4682) | 同上 |
| 5カードオマハ ハイロー (#4683) | ボードのロー成立可能性バッジ |

Hi-Lo はハイとローを同時に追う必要があり、Big O は手札5枚＝**必須2枚ルール下で10通りの組み合わせ**を目で数えることになるため、通常のオマハより負荷が高い側です。

## 共有化

3つ目のコピーを作る代わりに、共通部分を切り出しました。

- `src/utils/livePokerPreview.ts` — `omahaLiveHandKey()`。**コピーすると最も壊しやすいのが「必ず2枚使う」制約**なので、そこを単体テストで固定しています（ボードにスペード4枚あってもハンドにスペードが1枚ならフラッシュにならない、というケースを含む）。
- `src/components/BoardLowBadge.tsx` — `OmahaHiLoPage` 内のローカル定義を移動。**既存の `data-testid` を default 値として残した**ので、Omaha Hi-Lo 側の既存テストはそのまま通ります。

## ショートデック (#4684) は別PRにします

同じバッチの #4684（ショーダウンの役ハイライト）は**単純な移植では誤りになる**ため分離しました。`internal/domain/shortdeck_hand_eval.go` を確認したところ、ショートデックは標準の役順と2点異なります:

1. **フラッシュ > フルハウス**（`ShortDeckHandFlush = 6` > `ShortDeckHandFullHouse = 5`）
2. **A-6-7-8-9 がホイールストレート**（`checkShortDeckStraightValues`）

フロントの `holdemBestFive` は標準順（フルハウス > フラッシュ）で、A-2-3-4-5 のホイールしか見ません。そのまま使うと**サーバの判定と違う5枚をハイライトする**ので、専用の評価器を書いて Go 側のテストと対応付けます。

## テストプラン

- [x] 3ページにテストを追加、`livePokerPreview.ts` に単体テスト4本
- [x] **負のコントロール実測**: 3実装を無効化すると対応する3テストが落ちることを確認
- [x] `BoardLowBadge` 抽出が挙動不変であることを Omaha Hi-Lo の既存122テストで確認
- [x] `bunx vitest run` 対象5ファイル: 489 passed
- [x] `bun run check` / `bun run typecheck`

Closes #4681
Closes #4682
Closes #4683