### PR TITLE
feat(shortdeck): highlight the winning five, using Short Deck's own rankings

### DIFF
--- a/frontend/src/pages/ShortDeckPage.test.tsx
+++ b/frontend/src/pages/ShortDeckPage.test.tsx
@@ -1175,4 +1175,46 @@ describe('ShortDeckPage', () => {
     expect(chip.className).not.toContain('bg-ds-warning/');
     expect(chip.className).not.toContain('border-ds-warning/');
   });
+
+  it('highlights the five cards that made the winning hand', async () => {
+    localStorage.clear();
+    mockExec.mockReset();
+    mockExec.mockResolvedValue(showdownState);
+    renderWithProviders(<ShortDeckPage />);
+    await waitFor(() => expect(document.querySelectorAll('[data-best5-board]').length).toBeGreaterThan(0));
+    const marked =
+      document.querySelectorAll('[data-best5-board]').length + document.querySelectorAll('[data-best5-hole]').length;
+    expect(marked).toBe(5);
+  });
+
+  it('highlights the Short Deck wheel, which the standard evaluator cannot see', async () => {
+    localStorage.clear();
+    mockExec.mockReset();
+    // A♠ 7♥ against 6♥ 8♦ 9♣ K♠ Q♦: A-6-7-8-9 is a straight here but nothing in
+    // standard poker, so a Hold'em evaluator would light up A K Q 9 8 instead.
+    mockExec.mockResolvedValue({
+      ...showdownState,
+      players: [
+        humanPlayer({
+          handName: 'ストレート',
+          cards: [
+            { design: 'SPADE', value: 1 },
+            { design: 'HEART', value: 7 },
+          ],
+        }),
+        ...showdownState.players.slice(1),
+      ],
+      communityCards: [
+        { design: 'HEART', value: 6 },
+        { design: 'DIAMOND', value: 8 },
+        { design: 'CLOVER', value: 9 },
+        { design: 'SPADE', value: 13 },
+        { design: 'DIAMOND', value: 12 },
+      ],
+    });
+    renderWithProviders(<ShortDeckPage />);
+    await waitFor(() => expect(document.querySelectorAll('[data-best5-hole]').length).toBe(2));
+    // Both hole cards belong to the wheel; the K and Q on the board do not.
+    expect(document.querySelectorAll('[data-best5-board]').length).toBe(3);
+  });
 });

--- a/frontend/src/pages/ShortDeckPage.tsx
+++ b/frontend/src/pages/ShortDeckPage.tsx
@@ -45,6 +45,7 @@ import { parseShortdeckCommand, SHORTDECK_HELP } from '../utils/cli/commands/sho
 import { formatShortdeckState } from '../utils/cli/formatters/shortdeckFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
 import { findPlayerName } from '../utils/playerUtils';
+import { shortDeckBestFive } from '../utils/shortDeckBestFive';
 
 /** Short Deck Hold'em tutorial step definitions. */
 const SD_TUTORIAL_STEPS: TutorialStep[] = [
@@ -168,6 +169,25 @@ function ShortDeckPageContent() {
   const humanAllIn = humanPlayer?.allIn ?? false;
   const canAct = isActive && !humanFolded && !humanAllIn && state?.currentTurn === humanPlayer?.id;
   const hasOutstandingBet = (state?.lastBet ?? 0) > (humanPlayer?.currentBet ?? 0);
+  // Short Deck reorders the hand rankings, so the standard holdemBestFive would
+  // sometimes mark five cards the server did not score — most visibly on the
+  // A-6-7-8-9 wheel, which it cannot see at all (#4684).
+  const showdownBest5 = useMemo(() => {
+    const empty = { holeSet: new Set<number>(), boardSet: new Set<number>() };
+    if (!isShowdown || !humanPlayer || humanPlayer.folded) return empty;
+    const hole = humanPlayer.cards ?? [];
+    const board = state?.communityCards ?? [];
+    if (hole.length !== 2 || board.length < 5) return empty;
+    const combined = [...hole, ...board.slice(0, 5)];
+    const holeSet = new Set<number>();
+    const boardSet = new Set<number>();
+    for (const i of shortDeckBestFive(combined) ?? []) {
+      if (i < hole.length) holeSet.add(i);
+      else boardSet.add(i - hole.length);
+    }
+    return { holeSet, boardSet };
+  }, [isShowdown, humanPlayer, state?.communityCards]);
+
   const minRaise = state?.minRaise ?? 0;
   const isMuckPhase = phase === HoldemPhase.SHOWDOWN && state?.muckAvailable === true;
   const isRebuyPhase = phase === HoldemPhase.REBUY && state?.rebuyPhaseType === HoldemRebuyPhaseType.REBUY;
@@ -277,14 +297,21 @@ function ShortDeckPageContent() {
                   </div>
                   <div className="flex flex-wrap gap-2">
                     {state?.communityCards?.length
-                      ? state.communityCards.map((card) => (
-                          <AnimatedCard
-                            key={`${card.design}-${card.value}`}
-                            card={card}
-                            width={cardWidth}
-                            style={placeholderCardStyle}
-                          />
-                        ))
+                      ? state.communityCards.map((card, idx) => {
+                          const inBest = showdownBest5.boardSet.has(idx);
+                          const dim = isShowdown && showdownBest5.boardSet.size > 0 && !inBest;
+                          return (
+                            <div
+                              key={`${card.design}-${card.value}`}
+                              className={`transition-all ${
+                                inBest ? '-translate-y-1 ring-2 ring-ds-success motion-safe:animate-pulse' : ''
+                              } ${dim ? 'opacity-50' : ''}`}
+                              data-best5-board={inBest || undefined}
+                            >
+                              <AnimatedCard card={card} width={cardWidth} style={placeholderCardStyle} />
+                            </div>
+                          );
+                        })
                       : Array.from({ length: 5 }).map((_, i) => <AnimatedCardBack key={i} width={cardWidth} />)}
                   </div>
                 </>
@@ -399,14 +426,21 @@ function ShortDeckPageContent() {
                 </div>
                 <div className="flex flex-wrap gap-1.5 mb-2">
                   {humanPlayer.cards?.length
-                    ? humanPlayer.cards.map((card) => (
-                        <AnimatedCard
-                          key={`${card.design}-${card.value}`}
-                          card={card}
-                          width={cardWidth}
-                          style={placeholderCardStyle}
-                        />
-                      ))
+                    ? humanPlayer.cards.map((card, idx) => {
+                        const inBest = showdownBest5.holeSet.has(idx);
+                        const dim = isShowdown && showdownBest5.holeSet.size > 0 && !inBest;
+                        return (
+                          <div
+                            key={`${card.design}-${card.value}`}
+                            className={`transition-all ${
+                              inBest ? '-translate-y-1 ring-2 ring-ds-success motion-safe:animate-pulse' : ''
+                            } ${dim ? 'opacity-50' : ''}`}
+                            data-best5-hole={inBest || undefined}
+                          >
+                            <AnimatedCard card={card} width={cardWidth} style={placeholderCardStyle} />
+                          </div>
+                        );
+                      })
                     : !humanPlayer.folded &&
                       Array.from({ length: 2 }).map((_, i) => <AnimatedCardBack key={i} width={cardWidth} />)}
                 </div>

--- a/frontend/src/utils/shortDeckBestFive.test.ts
+++ b/frontend/src/utils/shortDeckBestFive.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+import type { Card, CardDesign } from '../types/card';
+import { holdemBestFive } from './holdemBestFive';
+import { scoreFiveShortDeck, shortDeckBestFive, shortDeckStraightHigh } from './shortDeckBestFive';
+
+const c = (design: CardDesign, value: number): Card => ({ design, value });
+
+describe('shortDeckStraightHigh', () => {
+  it('reads A-6-7-8-9 as a nine-high wheel', () => {
+    expect(shortDeckStraightHigh([14, 9, 8, 7, 6])).toBe(9);
+  });
+
+  it('reads a normal run by its top card', () => {
+    expect(shortDeckStraightHigh([12, 11, 10, 9, 8])).toBe(12);
+  });
+
+  it('reads A-10-J-Q-K as broadway', () => {
+    expect(shortDeckStraightHigh([14, 13, 12, 11, 10])).toBe(14);
+  });
+
+  it('rejects a gap', () => {
+    expect(shortDeckStraightHigh([13, 12, 11, 10, 8])).toBeNull();
+  });
+
+  it('rejects fewer than five distinct ranks', () => {
+    expect(shortDeckStraightHigh([13, 12, 11, 10])).toBeNull();
+  });
+
+  it('rejects A-2-3-4-5, which is not a Short Deck hand', () => {
+    // Those ranks are not in a 36-card deck, and the standard wheel must not
+    // sneak in through the generic run check.
+    expect(shortDeckStraightHigh([14, 5, 4, 3, 2])).toBeNull();
+  });
+});
+
+describe('scoreFiveShortDeck', () => {
+  const flush = [c('SPADE', 1), c('SPADE', 7), c('SPADE', 9), c('SPADE', 11), c('SPADE', 13)];
+  const fullHouse = [c('SPADE', 8), c('HEART', 8), c('CLOVER', 8), c('SPADE', 10), c('HEART', 10)];
+
+  it('ranks a flush above a full house, unlike standard poker', () => {
+    // Mirrors TestShortDeckPlayer_EvalBestHand_FlushBeatsFullHouse.
+    expect(scoreFiveShortDeck(flush)[0]).toBeGreaterThan(scoreFiveShortDeck(fullHouse)[0] ?? 0);
+  });
+
+  it('still ranks four of a kind above a flush', () => {
+    const quads = [c('SPADE', 9), c('HEART', 9), c('CLOVER', 9), c('DIAMOND', 9), c('SPADE', 13)];
+    expect(scoreFiveShortDeck(quads)[0]).toBeGreaterThan(scoreFiveShortDeck(flush)[0] ?? 0);
+  });
+
+  it('ranks the wheel as the weakest straight', () => {
+    const wheel = [c('SPADE', 1), c('HEART', 6), c('CLOVER', 7), c('DIAMOND', 8), c('SPADE', 9)];
+    const higher = [c('SPADE', 7), c('HEART', 8), c('CLOVER', 9), c('DIAMOND', 10), c('SPADE', 11)];
+    expect(scoreFiveShortDeck(wheel)[0]).toBe(5);
+    expect(compareTuples(scoreFiveShortDeck(higher), scoreFiveShortDeck(wheel))).toBeGreaterThan(0);
+  });
+
+  it('ranks a straight flush above everything below it', () => {
+    const sf = [c('SPADE', 6), c('SPADE', 7), c('SPADE', 8), c('SPADE', 9), c('SPADE', 10)];
+    expect(scoreFiveShortDeck(sf)[0]).toBe(9);
+  });
+
+  it('orders the low categories as usual', () => {
+    const trips = [c('SPADE', 7), c('HEART', 7), c('CLOVER', 7), c('DIAMOND', 9), c('SPADE', 11)];
+    const twoPair = [c('SPADE', 7), c('HEART', 7), c('CLOVER', 9), c('DIAMOND', 9), c('SPADE', 11)];
+    const onePair = [c('SPADE', 7), c('HEART', 7), c('CLOVER', 9), c('DIAMOND', 10), c('SPADE', 11)];
+    const high = [c('SPADE', 6), c('HEART', 8), c('CLOVER', 10), c('DIAMOND', 12), c('SPADE', 1)];
+    const cats = [trips, twoPair, onePair, high].map((h) => scoreFiveShortDeck(h)[0] ?? 0);
+    expect(cats).toEqual([4, 3, 2, 1]);
+  });
+});
+
+describe('shortDeckBestFive', () => {
+  it('returns null with fewer than five cards', () => {
+    expect(shortDeckBestFive([c('SPADE', 7), c('HEART', 8)])).toBeNull();
+  });
+
+  it('cannot be asked to choose between a flush and a full house', () => {
+    // Seven cards can never hold both: the trips occupy three suits and the pair
+    // two, so at most two of them share the flush suit, leaving five more cards
+    // needed to complete it — eight in total. The flush/full-house swap therefore
+    // only decides showdowns between players, never which five to highlight.
+    const cards = [
+      c('SPADE', 8),
+      c('SPADE', 7),
+      c('CLOVER', 8),
+      c('HEART', 8),
+      c('SPADE', 10),
+      c('HEART', 10),
+      c('SPADE', 9),
+    ];
+    const picked = shortDeckBestFive(cards) ?? [];
+    expect(picked).toHaveLength(5);
+    // Four spades only, so the best available really is the full house.
+    expect(scoreFiveShortDeck(picked.map((i) => cards[i] as Card))[0]).toBe(6);
+  });
+
+  it('differs from the standard evaluator exactly where it must', () => {
+    // The reason this file exists: holdemBestFive does not know A-6-7-8-9, so on
+    // this board it highlights an ace-high nothing while the server scores a
+    // straight. Five spades never occur here, so the flush/full-house swap is
+    // not what drives the difference.
+    const cards = [
+      c('SPADE', 1),
+      c('HEART', 6),
+      c('CLOVER', 7),
+      c('DIAMOND', 8),
+      c('SPADE', 9),
+      c('HEART', 12),
+      c('CLOVER', 13),
+    ];
+    const short = shortDeckBestFive(cards) ?? [];
+    const standard = holdemBestFive(cards) ?? [];
+    expect(scoreFiveShortDeck(short.map((i) => cards[i] as Card))[0]).toBe(5);
+    expect([...short].sort()).not.toEqual([...standard].sort());
+  });
+
+  it('finds the wheel when it is the only straight', () => {
+    const cards = [
+      c('SPADE', 1),
+      c('HEART', 6),
+      c('CLOVER', 7),
+      c('DIAMOND', 8),
+      c('SPADE', 9),
+      c('HEART', 12),
+      c('CLOVER', 13),
+    ];
+    const picked = shortDeckBestFive(cards) ?? [];
+    expect(scoreFiveShortDeck(picked.map((i) => cards[i] as Card))[0]).toBe(5);
+  });
+});
+
+/** Lexicographic comparison mirroring the util's own ordering. */
+function compareTuples(a: number[], b: number[]): number {
+  for (let i = 0; i < Math.max(a.length, b.length); i += 1) {
+    const d = (a[i] ?? 0) - (b[i] ?? 0);
+    if (d !== 0) return d;
+  }
+  return 0;
+}

--- a/frontend/src/utils/shortDeckBestFive.ts
+++ b/frontend/src/utils/shortDeckBestFive.ts
@@ -1,0 +1,111 @@
+import type { Card } from '../types/card';
+import { compareScores } from './holdemBestFive';
+
+/**
+ * Short Deck (6+ Hold'em) hand scoring.
+ *
+ * Short Deck is played with a 36-card deck (A, 6–K) and differs from standard
+ * poker in exactly two ways, both mirrored from
+ * `internal/domain/shortdeck_hand_eval.go`:
+ *
+ * 1. A flush beats a full house (`ShortDeckHandFlush` = 6 > `ShortDeckHandFullHouse` = 5).
+ * 2. A-6-7-8-9 is the wheel — the lowest straight — since 2–5 are not in the deck.
+ *
+ * Reusing the standard evaluator would pick a full house over a flush and would
+ * not see the wheel at all, so a highlight built on it could mark five cards
+ * that are not the hand the server actually scored.
+ */
+
+/** Ace counts as 14 unless it is the low end of the A-6-7-8-9 wheel. */
+function rankValue(card: Card): number {
+  return card.value === 1 ? 14 : card.value;
+}
+
+/**
+ * High card of the straight these ranks form, or null when they do not form one.
+ * Returns 9 for the A-6-7-8-9 wheel, where the ace plays low.
+ * @param descendingUnique - Distinct ranks, highest first, aces as 14.
+ * @returns The straight's high rank, or null.
+ */
+export function shortDeckStraightHigh(descendingUnique: readonly number[]): number | null {
+  if (descendingUnique.length !== 5) return null;
+  // A-6-7-8-9: [14, 9, 8, 7, 6] with the ace playing below the six.
+  if (
+    descendingUnique[0] === 14 &&
+    descendingUnique[1] === 9 &&
+    descendingUnique[2] === 8 &&
+    descendingUnique[3] === 7 &&
+    descendingUnique[4] === 6
+  ) {
+    return 9;
+  }
+  for (let i = 1; i < descendingUnique.length; i += 1) {
+    if ((descendingUnique[i] ?? 0) !== (descendingUnique[i - 1] ?? 0) - 1) return null;
+  }
+  return descendingUnique[0] ?? null;
+}
+
+/**
+ * Score a 5-card Short Deck hand as a lexicographic tuple `[category, …]`,
+ * higher being stronger. Categories follow the Short Deck order, so a flush
+ * outranks a full house.
+ * @param hand - Exactly five cards.
+ * @returns The comparable score tuple.
+ */
+export function scoreFiveShortDeck(hand: readonly Card[]): number[] {
+  const ranks = hand.map(rankValue).sort((x, y) => y - x);
+  const suits = hand.map((c) => c.design);
+  const flush = suits.every((s) => s === suits[0]);
+  const uniq = Array.from(new Set(ranks)).sort((x, y) => y - x);
+  const straight = shortDeckStraightHigh(uniq);
+
+  const counts = new Map<number, number>();
+  for (const r of ranks) counts.set(r, (counts.get(r) ?? 0) + 1);
+  const grouped = Array.from(counts.entries()).sort((a, b) => b[1] - a[1] || b[0] - a[0]);
+  const top = grouped[0] ?? [0, 0];
+  const second = grouped[1];
+
+  if (flush && straight !== null) return [9, straight];
+  if (top[1] === 4) return [8, top[0], second?.[0] ?? 0];
+  // The Short Deck swap: flush above full house.
+  if (flush) return [7, ...ranks];
+  if (top[1] === 3 && second && second[1] === 2) return [6, top[0], second[0]];
+  if (straight !== null) return [5, straight];
+  if (top[1] === 3) return [4, top[0], ...grouped.slice(1).map(([r]) => r)];
+  if (top[1] === 2 && second && second[1] === 2) {
+    const [hi, lo] = top[0] > second[0] ? [top[0], second[0]] : [second[0], top[0]];
+    return [3, hi, lo, grouped[2]?.[0] ?? 0];
+  }
+  if (top[1] === 2) return [2, top[0], ...grouped.slice(1).map(([r]) => r)];
+  return [1, ...ranks];
+}
+
+/**
+ * Indices of the five cards forming the best Short Deck hand in the supplied
+ * set (2 hole + 5 community), or null with fewer than five cards.
+ * @param cards - The candidate cards.
+ * @returns Indices into `cards`, or null.
+ */
+export function shortDeckBestFive(cards: readonly Card[]): number[] | null {
+  if (cards.length < 5) return null;
+  let bestScore: number[] = [];
+  let bestIdx: number[] = [];
+  const n = cards.length;
+  for (let a = 0; a < n - 4; a += 1) {
+    for (let b = a + 1; b < n - 3; b += 1) {
+      for (let c = b + 1; c < n - 2; c += 1) {
+        for (let d = c + 1; d < n - 1; d += 1) {
+          for (let e = d + 1; e < n; e += 1) {
+            const idx = [a, b, c, d, e];
+            const score = scoreFiveShortDeck(idx.map((i) => cards[i] as Card));
+            if (compareScores(score, bestScore) > 0) {
+              bestScore = score;
+              bestIdx = idx;
+            }
+          }
+        }
+      }
+    }
+  }
+  return bestIdx;
+}


### PR DESCRIPTION
## 変更

ホールデムはショーダウンで役を構成した5枚に `ring-2 ring-ds-success` を付けますが、ショートデックは同じ2枚+5枚の構造なのにハイライトがありませんでした。**役順が入れ替わっている変種こそ、どのカードが役を決めたかの可視化が要る**ところです。

## `holdemBestFive` の流用は誤りでした

`internal/domain/shortdeck_hand_eval.go` を確認したところ、標準の役順と2点異なります。

1. **フラッシュ > フルハウス**（`ShortDeckHandFlush = 6` > `ShortDeckHandFullHouse = 5`）
2. **A-6-7-8-9 がホイール**（`checkShortDeckStraightValues`。2〜5 が無いデッキなので）

フロントの `holdemBestFive` は **A-6-7-8-9 を認識しません**。ホイールが成立している盤面では**まったく無関係の5枚をハイライトします**。`src/utils/shortDeckBestFive.ts` を追加し、Go 側と対応付けました。

**負のコントロールで実測済み**: import を `holdemBestFive` に差し替えると、ホイールのページテストが落ちます。

## 途中で判明したこと: フラッシュ/フルハウスの入れ替えは、この機能には影響しない

当初「7枚からフラッシュとフルハウスの両方が取れる盤面」でテストを書こうとしましたが、**そのような7枚は存在しません**。

> フルハウスはスリーカード（3スート）+ペア（2スート）で構成されるため、フラッシュのスートと一致するのは最大2枚。残り3枚をフラッシュのスートで補うと合計8枚必要になり、7枚に収まりません。

つまりこの入れ替えが効くのは**プレイヤー間のショーダウン比較のみ**で、自分のベスト5枚の選択には影響しません。実際に効いているのはホイールの方です。テストにこの事実をコメントとして残しました（将来「このケースのテストが無い」と言われないため）。評価器自体はドメインに忠実であるべきなので、入れ替えも実装しています。

## テストプラン

- [x] `shortDeckBestFive.test.ts` 15本（ホイール判定、役順、A-2-3-4-5 を誤って拾わないこと、標準評価器との差分）
- [x] `ShortDeckPage.test.tsx` に2本（5枚ハイライト、ホイール時のハイライト内容）
- [x] **負のコントロール実測**: 標準評価器に差し替えるとホイールのテストが落ちる
- [x] `bunx vitest run` 対象2ファイル: 103 passed
- [x] `bun run check` / `bun run typecheck`

Closes #4684