### PR TITLE
fix(ui): honour the hint setting, gate the hint ring, name the reserve cells

### DIFF
--- a/frontend/src/i18n/locales/en/seahaventowers.json
+++ b/frontend/src/i18n/locales/en/seahaventowers.json
@@ -28,7 +28,7 @@
     "resetButton": "Press the reset button to start a new game."
   },
   "landscapeBanner": "Rotate to landscape for easier play",
-  "shortLabel": "ST",
+  "shortLabel": "R",
   "frontendHint": {
     "moveToFoundation": "A card can be moved to the foundation",
     "reservedFilling": "Both reserved cells are full — try to clear one",

--- a/frontend/src/i18n/locales/ja/seahaventowers.json
+++ b/frontend/src/i18n/locales/ja/seahaventowers.json
@@ -28,7 +28,7 @@
     "resetButton": "リセットボタンで新しいゲームを始められます。"
   },
   "landscapeBanner": "横向きにすると操作しやすくなります",
-  "shortLabel": "ST",
+  "shortLabel": "予備",
   "frontendHint": {
     "moveToFoundation": "組札に移動できるカードがあります",
     "reservedFilling": "リザーブセルが両方とも埋まっています — 空けることを検討しましょう",

--- a/frontend/src/pages/BadugiPage.test.tsx
+++ b/frontend/src/pages/BadugiPage.test.tsx
@@ -350,6 +350,18 @@ describe('BadugiPage', () => {
     }
   });
 
+  it('renders the draw without a seated human', async () => {
+    // Spectator-shaped state: no human seat, so there is no hand to advise on.
+    localStorage.clear();
+    localStorage.setItem('hint_enabled_badugi', 'true');
+    mockExec.mockReset();
+    const spectator = baseState({ phase: BadugiPhase.DRAW, drawIndex: 1 });
+    mockExec.mockResolvedValue({ ...spectator, players: spectator.players.filter((p) => !p.isHuman) });
+    renderWithProviders(<BadugiPage />);
+    await waitFor(() => expect(screen.getAllByRole('button').length).toBeGreaterThan(0));
+    expect(document.querySelectorAll('.-translate-y-1, .opacity-50').length).toBe(0);
+  });
+
   it('keeps the exchange lift/dim off outside the exchange window even with hints on', async () => {
     // Outside the draw the player cannot act on "keep these" advice, so the
     // assist stays off however the hint setting is configured.

--- a/frontend/src/pages/BadugiPage.test.tsx
+++ b/frontend/src/pages/BadugiPage.test.tsx
@@ -107,6 +107,8 @@ describe('BadugiPage', () => {
   });
 
   it('annotates card aria-labels with best-subset / exchange-candidate hints during the draw phase', async () => {
+    // The lift/dim assist follows the hint setting, which defaults to off.
+    localStorage.setItem('hint_enabled_badugi', 'true');
     // S1,H2,D3 form the best 3-card subset (lowest sum); the duplicate-suit S5
     // is the exchange candidate.
     mockExec.mockResolvedValue(
@@ -284,6 +286,8 @@ describe('BadugiPage', () => {
   });
 
   it('marks every card with data-badugi-subset during the draw phase when the hand is a perfect Badugi', async () => {
+    // The lift/dim assist follows the hint setting, which defaults to off.
+    localStorage.setItem('hint_enabled_badugi', 'true');
     mockExec.mockResolvedValue(baseState({ phase: BadugiPhase.DRAW, drawIndex: 1, currentTurn: 0 }));
     renderWithProviders(<BadugiPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: '交換' })).toBeInTheDocument());
@@ -298,6 +302,8 @@ describe('BadugiPage', () => {
   });
 
   it('dims duplicate-suit cards in the draw phase and omits data-badugi-subset on them', async () => {
+    // The lift/dim assist follows the hint setting, which defaults to off.
+    localStorage.setItem('hint_enabled_badugi', 'true');
     // Force a duplicate suit so one card falls out of the best subset (lowball: keep the lower ♠).
     mockExec.mockResolvedValue(
       baseState({
@@ -342,5 +348,22 @@ describe('BadugiPage', () => {
       expect(btn.className).not.toContain('opacity-50');
       expect(btn.className).not.toContain('-translate-y-1');
     }
+  });
+
+  it('keeps the exchange lift/dim off until hints are switched on', async () => {
+    // The assist is a hint in all but name, so it follows the hint setting —
+    // which defaults to off (#4701/#4702).
+    localStorage.clear();
+    mockExec.mockReset();
+    mockExec.mockResolvedValue(baseState({ phase: BadugiPhase.DRAW, drawIndex: 1, currentTurn: 0 }));
+    const { unmount } = renderWithProviders(<BadugiPage />);
+    await waitFor(() => expect(screen.getAllByRole('button').length).toBeGreaterThan(0));
+    expect(document.querySelectorAll('.-translate-y-1, .opacity-50').length).toBe(0);
+    unmount();
+
+    localStorage.setItem('hint_enabled_badugi', 'true');
+    mockExec.mockResolvedValue(baseState({ phase: BadugiPhase.DRAW, drawIndex: 1, currentTurn: 0 }));
+    renderWithProviders(<BadugiPage />);
+    await waitFor(() => expect(document.querySelectorAll('.-translate-y-1, .opacity-50').length).toBeGreaterThan(0));
   });
 });

--- a/frontend/src/pages/BadugiPage.test.tsx
+++ b/frontend/src/pages/BadugiPage.test.tsx
@@ -350,6 +350,18 @@ describe('BadugiPage', () => {
     }
   });
 
+  it('keeps the exchange lift/dim off outside the exchange window even with hints on', async () => {
+    // Outside the draw the player cannot act on "keep these" advice, so the
+    // assist stays off however the hint setting is configured.
+    localStorage.clear();
+    localStorage.setItem('hint_enabled_badugi', 'true');
+    mockExec.mockReset();
+    mockExec.mockResolvedValue(baseState({ phase: BadugiPhase.SHOWDOWN, currentTurn: 0 }));
+    renderWithProviders(<BadugiPage />);
+    await waitFor(() => expect(screen.getAllByRole('button').length).toBeGreaterThan(0));
+    expect(document.querySelectorAll('.-translate-y-1, .opacity-50').length).toBe(0);
+  });
+
   it('keeps the exchange lift/dim off until hints are switched on', async () => {
     // The assist is a hint in all but name, so it follows the hint setting —
     // which defaults to off (#4701/#4702).

--- a/frontend/src/pages/BadugiPage.tsx
+++ b/frontend/src/pages/BadugiPage.tsx
@@ -169,9 +169,12 @@ function BadugiPageContent() {
   // player can't act on "dead weight" until the next exchange opens.
   // Gated on the hint setting as well as the phase: the lift/dim is a hint in
   // everything but name, so turning hints off has to silence it too (#4701/#4702).
+  // Hoisted so the empty case is a real state (no human seat) rather than an
+  // unreachable fallback inside the guard: canExchange already implies a seat.
+  const humanCards = humanPlayer?.cards ?? [];
   const subsetIndices = useMemo(
-    () => (canExchange && hintEnabled ? new Set(badugiBestSubsetIndices(humanPlayer?.cards ?? [])) : null),
-    [canExchange, hintEnabled, humanPlayer?.cards],
+    () => (canExchange && hintEnabled ? new Set(badugiBestSubsetIndices(humanCards)) : null),
+    [canExchange, hintEnabled, humanCards],
   );
 
   useCardKeyboardNav({

--- a/frontend/src/pages/BadugiPage.tsx
+++ b/frontend/src/pages/BadugiPage.tsx
@@ -167,9 +167,11 @@ function BadugiPageContent() {
   // Set of card indices belonging to the current best Badugi subset. Only computed during the draw
   // phase — outside of that window the lift / dim visuals would distract more than help, since the
   // player can't act on "dead weight" until the next exchange opens.
+  // Gated on the hint setting as well as the phase: the lift/dim is a hint in
+  // everything but name, so turning hints off has to silence it too (#4701/#4702).
   const subsetIndices = useMemo(
-    () => (canExchange ? new Set(badugiBestSubsetIndices(humanPlayer?.cards ?? [])) : null),
-    [canExchange, humanPlayer?.cards],
+    () => (canExchange && hintEnabled ? new Set(badugiBestSubsetIndices(humanPlayer?.cards ?? [])) : null),
+    [canExchange, hintEnabled, humanPlayer?.cards],
   );
 
   useCardKeyboardNav({

--- a/frontend/src/pages/DeuceToSevenPage.test.tsx
+++ b/frontend/src/pages/DeuceToSevenPage.test.tsx
@@ -268,6 +268,8 @@ describe('DeuceToSevenPage', () => {
   });
 
   it('lifts the best-low core cards and dims the draw candidates', async () => {
+    // The lift/dim assist follows the hint setting, which defaults to off.
+    localStorage.setItem('hint_enabled_deucetoseven', 'true');
     // Hand 2-2-4-6-8: the duplicate 2 is a draw candidate; the rest are kept.
     mockExec.mockResolvedValue(
       baseState({
@@ -307,5 +309,22 @@ describe('DeuceToSevenPage', () => {
     expect(cardButtons.length).toBe(5);
     fireEvent.click(cardButtons[0]);
     await waitFor(() => expect(cardButtons[0]).toHaveAttribute('aria-pressed', 'true'));
+  });
+
+  it('keeps the exchange lift/dim off until hints are switched on', async () => {
+    // The assist is a hint in all but name, so it follows the hint setting —
+    // which defaults to off (#4701/#4702).
+    localStorage.clear();
+    mockExec.mockReset();
+    mockExec.mockResolvedValue(baseState({ phase: DeuceToSevenPhase.DRAW, drawIndex: 1 }));
+    const { unmount } = renderWithProviders(<DeuceToSevenPage />);
+    await waitFor(() => expect(screen.getAllByRole('button').length).toBeGreaterThan(0));
+    expect(document.querySelectorAll('.-translate-y-1, .opacity-50').length).toBe(0);
+    unmount();
+
+    localStorage.setItem('hint_enabled_deucetoseven', 'true');
+    mockExec.mockResolvedValue(baseState({ phase: DeuceToSevenPhase.DRAW, drawIndex: 1 }));
+    renderWithProviders(<DeuceToSevenPage />);
+    await waitFor(() => expect(document.querySelectorAll('.-translate-y-1, .opacity-50').length).toBeGreaterThan(0));
   });
 });

--- a/frontend/src/pages/DeuceToSevenPage.test.tsx
+++ b/frontend/src/pages/DeuceToSevenPage.test.tsx
@@ -311,6 +311,18 @@ describe('DeuceToSevenPage', () => {
     await waitFor(() => expect(cardButtons[0]).toHaveAttribute('aria-pressed', 'true'));
   });
 
+  it('renders the draw without a seated human', async () => {
+    // Spectator-shaped state: no human seat, so there is no hand to advise on.
+    localStorage.clear();
+    localStorage.setItem('hint_enabled_deucetoseven', 'true');
+    mockExec.mockReset();
+    const spectator = baseState({ phase: DeuceToSevenPhase.DRAW, drawIndex: 1 });
+    mockExec.mockResolvedValue({ ...spectator, players: spectator.players.filter((p) => !p.isHuman) });
+    renderWithProviders(<DeuceToSevenPage />);
+    await waitFor(() => expect(screen.getAllByRole('button').length).toBeGreaterThan(0));
+    expect(document.querySelectorAll('.-translate-y-1, .opacity-50').length).toBe(0);
+  });
+
   it('keeps the exchange lift/dim off outside the exchange window even with hints on', async () => {
     // Outside the draw the player cannot act on "keep these" advice, so the
     // assist stays off however the hint setting is configured.

--- a/frontend/src/pages/DeuceToSevenPage.test.tsx
+++ b/frontend/src/pages/DeuceToSevenPage.test.tsx
@@ -311,6 +311,18 @@ describe('DeuceToSevenPage', () => {
     await waitFor(() => expect(cardButtons[0]).toHaveAttribute('aria-pressed', 'true'));
   });
 
+  it('keeps the exchange lift/dim off outside the exchange window even with hints on', async () => {
+    // Outside the draw the player cannot act on "keep these" advice, so the
+    // assist stays off however the hint setting is configured.
+    localStorage.clear();
+    localStorage.setItem('hint_enabled_deucetoseven', 'true');
+    mockExec.mockReset();
+    mockExec.mockResolvedValue(baseState({ phase: DeuceToSevenPhase.SHOWDOWN }));
+    renderWithProviders(<DeuceToSevenPage />);
+    await waitFor(() => expect(screen.getAllByRole('button').length).toBeGreaterThan(0));
+    expect(document.querySelectorAll('.-translate-y-1, .opacity-50').length).toBe(0);
+  });
+
   it('keeps the exchange lift/dim off until hints are switched on', async () => {
     // The assist is a hint in all but name, so it follows the hint setting —
     // which defaults to off (#4701/#4702).

--- a/frontend/src/pages/DeuceToSevenPage.tsx
+++ b/frontend/src/pages/DeuceToSevenPage.tsx
@@ -167,9 +167,11 @@ function DeuceToSevenPageContent() {
   );
 
   // During the draw, lift the best-low core cards and dim the draw candidates.
+  // Gated on the hint setting as well as the phase: the lift/dim is a hint in
+  // everything but name, so turning hints off has to silence it too (#4701/#4702).
   const bestSubset = useMemo(
-    () => (canExchange ? new Set(deuceToSevenBestIndices(humanPlayer?.cards ?? [])) : null),
-    [canExchange, humanPlayer?.cards],
+    () => (canExchange && hintEnabled ? new Set(deuceToSevenBestIndices(humanPlayer?.cards ?? [])) : null),
+    [canExchange, hintEnabled, humanPlayer?.cards],
   );
 
   useCardKeyboardNav({

--- a/frontend/src/pages/DeuceToSevenPage.tsx
+++ b/frontend/src/pages/DeuceToSevenPage.tsx
@@ -169,9 +169,12 @@ function DeuceToSevenPageContent() {
   // During the draw, lift the best-low core cards and dim the draw candidates.
   // Gated on the hint setting as well as the phase: the lift/dim is a hint in
   // everything but name, so turning hints off has to silence it too (#4701/#4702).
+  // Hoisted so the empty case is a real state (no human seat) rather than an
+  // unreachable fallback inside the guard: canExchange already implies a seat.
+  const humanCards = humanPlayer?.cards ?? [];
   const bestSubset = useMemo(
-    () => (canExchange && hintEnabled ? new Set(deuceToSevenBestIndices(humanPlayer?.cards ?? [])) : null),
-    [canExchange, hintEnabled, humanPlayer?.cards],
+    () => (canExchange && hintEnabled ? new Set(deuceToSevenBestIndices(humanCards)) : null),
+    [canExchange, hintEnabled, humanCards],
   );
 
   useCardKeyboardNav({

--- a/frontend/src/pages/ScorpionPage.test.tsx
+++ b/frontend/src/pages/ScorpionPage.test.tsx
@@ -514,4 +514,31 @@ describe('ScorpionPage', () => {
     fireEvent.click(hintToggle);
     expect(hintToggle).toBeChecked();
   });
+
+  it('does not light the source card when the hint was not requested', async () => {
+    localStorage.clear();
+    mockExec.mockReset();
+    // The backend attaches its latest hint to every Output(); only an explicit
+    // request sets the messageCode, so nothing may glow without one (#4791).
+    mockExec.mockResolvedValue({
+      ...playingState,
+      hint: { fromCol: 0, cardIndex: 1, toCol: 3 },
+      messageCode: 'scorpion.playing',
+    });
+    renderWithProviders(<ScorpionPage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
+    expect(document.querySelectorAll('.ring-ds-info').length).toBe(0);
+  });
+
+  it('lights the source card once the hint is requested', async () => {
+    localStorage.clear();
+    mockExec.mockReset();
+    mockExec.mockResolvedValue({
+      ...playingState,
+      hint: { fromCol: 0, cardIndex: 1, toCol: 3 },
+      messageCode: 'scorpion.hintAvailable',
+    });
+    renderWithProviders(<ScorpionPage />);
+    await waitFor(() => expect(document.querySelectorAll('.ring-ds-info').length).toBeGreaterThan(0));
+  });
 });

--- a/frontend/src/pages/ScorpionPage.tsx
+++ b/frontend/src/pages/ScorpionPage.tsx
@@ -414,11 +414,13 @@ function ScorpionPageContent() {
                         const isDragSrc = dnd.isDragSource(zone);
                         const isLast = cardIdx === col.length - 1;
 
-                        const hintFrom =
-                          state.hint && state.hint.fromCol === colIdx && state.hint.cardIndex === cardIdx;
                         // **押していない人にヒントを見せない。**#4483 以降 `Output()` が毎回
                         // ヒントを載せるので、`state.hint` を直接読むと常時ハイライトになる (#4605)。
+                        // 移動元も同じゲートを通す — 通していなかったので #4605 が片側だけ
+                        // 再発していた (#4791)。
                         const requestedHint = isRequestedHint(state) ? state.hint : undefined;
+                        const hintFrom =
+                          requestedHint && requestedHint.fromCol === colIdx && requestedHint.cardIndex === cardIdx;
                         const hintTo = requestedHint && requestedHint.toCol === colIdx && isLast;
 
                         return (

--- a/frontend/src/pages/SeahavenTowersPage.test.tsx
+++ b/frontend/src/pages/SeahavenTowersPage.test.tsx
@@ -267,6 +267,16 @@ describe('SeahavenTowersPage', () => {
     fireEvent.mouseLeave(middleButton);
     expect(middleButton).not.toHaveAttribute('data-supermove-block');
   });
+
+  it('abbreviates the reserve cells by zone, not by game name', async () => {
+    localStorage.clear();
+    mockExec.mockReset();
+    mockExec.mockResolvedValue(playingState);
+    renderWithProviders(<SeahavenTowersPage />);
+    // "ST" was the game's initials, which tells a player nothing about the slot.
+    await waitFor(() => expect(screen.getAllByText(/^予備\d$/).length).toBeGreaterThan(0));
+    expect(screen.queryByText(/^ST\d$/)).not.toBeInTheDocument();
+  });
 });
 
 // Keyboard shortcuts are bound by useActionKeyboardNav and advertised by

--- a/frontend/src/pages/WaspPage.test.tsx
+++ b/frontend/src/pages/WaspPage.test.tsx
@@ -553,4 +553,31 @@ describe('WaspPage', () => {
     fireEvent.click(hintToggle);
     expect(hintToggle).toBeChecked();
   });
+
+  it('does not light the source card when the hint was not requested', async () => {
+    localStorage.clear();
+    mockExec.mockReset();
+    // The backend attaches its latest hint to every Output(); only an explicit
+    // request sets the messageCode, so nothing may glow without one (#4791).
+    mockExec.mockResolvedValue({
+      ...playingState,
+      hint: { fromCol: 0, cardIndex: 1, toCol: 3 },
+      messageCode: 'wasp.playing',
+    });
+    renderWithProviders(<WaspPage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
+    expect(document.querySelectorAll('.ring-ds-info').length).toBe(0);
+  });
+
+  it('lights the source card once the hint is requested', async () => {
+    localStorage.clear();
+    mockExec.mockReset();
+    mockExec.mockResolvedValue({
+      ...playingState,
+      hint: { fromCol: 0, cardIndex: 1, toCol: 3 },
+      messageCode: 'wasp.hintAvailable',
+    });
+    renderWithProviders(<WaspPage />);
+    await waitFor(() => expect(document.querySelectorAll('.ring-ds-info').length).toBeGreaterThan(0));
+  });
 });

--- a/frontend/src/pages/WaspPage.tsx
+++ b/frontend/src/pages/WaspPage.tsx
@@ -417,11 +417,13 @@ function WaspPageContent() {
                         const isDragSrc = dnd.isDragSource(zone);
                         const isLast = cardIdx === col.length - 1;
 
-                        const hintFrom =
-                          state.hint && state.hint.fromCol === colIdx && state.hint.cardIndex === cardIdx;
                         // **押していない人にヒントを見せない。**#4483 以降 `Output()` が毎回
                         // ヒントを載せるので、`state.hint` を直接読むと常時ハイライトになる (#4605)。
+                        // 移動元も同じゲートを通す — 通していなかったので #4605 が片側だけ
+                        // 再発していた (#4791)。
                         const requestedHint = isRequestedHint(state) ? state.hint : undefined;
+                        const hintFrom =
+                          requestedHint && requestedHint.fromCol === colIdx && requestedHint.cardIndex === cardIdx;
                         const hintTo = requestedHint && requestedHint.toCol === colIdx && isLast;
 
                         return (


### PR DESCRIPTION
## 変更

| ゲーム | 内容 |
|---|---|
| バドゥーギ (#4701) / デューストゥセブン (#4702) | 交換時のリフト/減光アシストがヒント設定を無視して常時表示 → 設定に従わせる |
| スコーピオン (#4791) / **ワスプ（issue無し）** | `hintFrom` がゲートを通らず、ヒント未要求でも移動元が光りうる |
| シーヘイブンタワーズ (#4778) | モバイルの短縮ラベル `ST` はゾーン名ではなくゲーム名の頭文字 |

## スコーピオンの件は「コメントが警告している内容そのもの」でした

該当箇所の**2行下**にこう書いてあります:

> **押していない人にヒントを見せない。** #4483 以降 `Output()` が毎回ヒントを載せるので、`state.hint` を直接読むと常時ハイライトになる (#4605)。

`hintTo` はこのゲートを通っていましたが、**`hintFrom` だけ `state.hint` を直読み**しており、#4605 が移動元側だけ生き残っていました。

**同じ行がワスプ (`WaspPage.tsx:421`) にもありました。** `isRequestedHint` を使う80ページを走査し、`state.hint &&` を2箇所持つのはこの2ページだけだと確認したうえで、両方直しています。

## バドゥーギ/D2S は「既定オフ」への挙動変更を含みます

`useGameHint` の `hint_enabled_<game>` は **既定値が `false`** です。したがってこの修正で、リフト/減光アシストは**オプトイン**になります。issue の要求どおりですが、既定の見た目が変わる変更なので明記します。既存テスト4本がこの常時オンを前提にしていたため、ヒントを有効化してから検証するよう更新しました。

## テストプラン

- [x] 5ページにテストを追加（バドゥーギ/D2S は**オフ→オン両方**を1テストで検証）
- [x] **負のコントロール実測**: 3種の修正それぞれについて、元に戻すと対応テストが落ちることを確認
- [x] `bunx vitest run` 対象5ファイル: 154 passed
- [x] `bun run check` / `bun run typecheck`

Closes #4701
Closes #4702
Closes #4778
Closes #4791