### PR TITLE
feat(ui): show where a selected card can go, and guard the claim

### DIFF
--- a/frontend/src/i18n/locales/en/literature.json
+++ b/frontend/src/i18n/locales/en/literature.json
@@ -55,5 +55,7 @@
   "frontendHint": {
     "literatureAskHeldSuit": "You may only ask for a half-suit you already hold a card of",
     "literatureMustClaim": "Every half-suit you hold is settled — a claim is all that is left"
-  }
+  },
+  "claimConfirmTitle": "Confirm the claim",
+  "claimConfirmMessage": "A single wrong seat voids the set or hands it to the opposing team. Claim with these answers?"
 }

--- a/frontend/src/i18n/locales/ja/literature.json
+++ b/frontend/src/i18n/locales/ja/literature.json
@@ -55,5 +55,7 @@
   "frontendHint": {
     "literatureAskHeldSuit": "自分が 1 枚以上持っているハーフスートだけ聞けます",
     "literatureMustClaim": "持っている札のハーフスートは決着済みです。宣言しか残っていません"
-  }
+  },
+  "claimConfirmTitle": "所在宣言の確認",
+  "claimConfirmMessage": "1枚でも間違えると、その組は無効になるか相手チームのものになります。この内容で宣言しますか？"
 }

--- a/frontend/src/pages/KingAlbertPage.test.tsx
+++ b/frontend/src/pages/KingAlbertPage.test.tsx
@@ -172,6 +172,20 @@ describe('KingAlbertPage', () => {
     renderWithProviders(<KingAlbertPage />);
     await waitFor(() => expect(screen.getByTestId('stalemate-escape-button')).toBeInTheDocument());
   });
+
+  it('rings every zone that can accept the selected card', async () => {
+    localStorage.clear();
+    mockExec.mockReset();
+    mockExec.mockResolvedValue(playingState);
+    renderWithProviders(<KingAlbertPage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
+    expect(document.querySelectorAll('[data-target-candidate]')).toHaveLength(0);
+
+    const source = screen.getAllByRole('button').find((b) => b.querySelector('img')) as HTMLButtonElement;
+    fireEvent.click(source);
+    // Foundations accept the card as readily as the tableau does.
+    await waitFor(() => expect(document.querySelectorAll('[data-target-candidate]').length).toBeGreaterThan(1));
+  });
 });
 
 // Keyboard shortcuts are bound by useActionKeyboardNav and advertised by

--- a/frontend/src/pages/KingAlbertPage.tsx
+++ b/frontend/src/pages/KingAlbertPage.tsx
@@ -215,7 +215,10 @@ function KingAlbertPageContent() {
                 onClick={() => game.handleSelectTarget(tableauColZone)}
                 disabled={!isPlaying || loading || !selectedSource}
                 style={{ height: dims.ch }}
-                className={`w-full rounded border-2 border-dashed border-white/20 text-game-text-muted text-xs flex items-center justify-center bg-transparent ${focusRingWhite}`}
+                data-target-candidate={selectedSource ? true : undefined}
+                className={`w-full rounded border-2 border-dashed border-white/20 text-game-text-muted text-xs flex items-center justify-center bg-transparent ${focusRingWhite} ${
+                  selectedSource ? 'ring-1 ring-ds-info' : ''
+                }`}
               >
                 {t('empty')}
               </button>
@@ -227,6 +230,7 @@ function KingAlbertPageContent() {
                   cardIndex: cardIdx,
                 };
                 const isTop = cardIdx === col.length - 1;
+                const isTargetCandidate = !!selectedSource && isTop && !isSourceSelected('tableau', colIdx, cardIdx);
                 return (
                   <div
                     key={`tc-${colIdx.toString()}-${cardIdx.toString()}`}
@@ -249,7 +253,10 @@ function KingAlbertPageContent() {
                         draggable={isPlaying && !loading && isTop}
                         onDragStart={dnd.handleDragStart(cardZone)}
                         onDragEnd={dnd.handleDragEnd}
-                        className={`p-0 border-0 bg-transparent w-full rounded ${focusRingWhite} ${isTop ? 'cursor-pointer' : 'cursor-default'} ${isSourceSelected('tableau', colIdx, cardIdx) ? 'ring-2 ring-ds-warning' : ''} ${dnd.isDragSource(cardZone) ? 'opacity-50' : ''}`}
+                        // With a card in hand every top card is a possible
+                        // destination; only the source said so before (#4828).
+                        data-target-candidate={isTargetCandidate || undefined}
+                        className={`p-0 border-0 bg-transparent w-full rounded ${focusRingWhite} ${isTop ? 'cursor-pointer' : 'cursor-default'} ${isSourceSelected('tableau', colIdx, cardIdx) ? 'ring-2 ring-ds-warning' : ''} ${isTargetCandidate ? 'ring-1 ring-ds-info motion-safe:hover:ring-2 focus:ring-2' : ''} ${dnd.isDragSource(cardZone) ? 'opacity-50' : ''}`}
                       >
                         <AnimatedCard
                           card={tc.card}
@@ -375,7 +382,10 @@ function KingAlbertPageContent() {
                               suit: FOUNDATION_SUITS[idx],
                               count: pile.length,
                             })}
-                            className={`p-0 border-0 bg-transparent cursor-pointer rounded ${focusRingWhite}`}
+                            data-target-candidate={selectedSource ? true : undefined}
+                            className={`p-0 border-0 bg-transparent cursor-pointer rounded ${focusRingWhite} ${
+                              selectedSource ? 'ring-1 ring-ds-info motion-safe:hover:ring-2 focus:ring-2' : ''
+                            }`}
                           >
                             <AnimatedCard
                               card={pile[pile.length - 1]}

--- a/frontend/src/pages/LiteraturePage.test.tsx
+++ b/frontend/src/pages/LiteraturePage.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { literatureApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { CardDesign, LiteraturePlayer, LiteratureResponse } from '../types/card';
 import { LiteraturePhase } from '../types/phases';
@@ -164,6 +165,7 @@ describe('LiteraturePage', () => {
     fireEvent.change(holderSelects[0], { target: { value: '2' } });
     mockExec.mockClear();
     fireEvent.click(screen.getByRole('button', { name: '宣言する' }));
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('claim', { halfSuit: 0, holders: [2, 0, 0, 0, 0, 0] }));
   });
 
@@ -188,6 +190,7 @@ describe('LiteraturePage', () => {
     // 送られるのも初期値。
     mockExec.mockClear();
     fireEvent.click(screen.getByRole('button', { name: '宣言する' }));
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('claim', { halfSuit: 2, holders: [0, 0, 0, 0, 0, 0] }));
   });
 
@@ -279,5 +282,22 @@ describe('LiteraturePage', () => {
 
     fireEvent.click(toggle);
     expect(await screen.findByTestId('hint-tooltip')).toBeInTheDocument();
+  });
+
+  it('confirms before sending a claim', async () => {
+    localStorage.clear();
+    mockExec.mockReset();
+    mockExec.mockResolvedValue(makeState());
+    renderWithProviders(<LiteraturePage />);
+    const claim = await screen.findByRole('button', { name: '宣言する' });
+    mockExec.mockClear();
+    fireEvent.click(claim);
+    // One wrong seat voids the set, so the click must not send anything yet.
+    await flushPendingDispatch();
+    expect(mockExec).not.toHaveBeenCalled();
+    expect(screen.getByText('所在宣言の確認')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
+    await waitFor(() => expect(mockExec).toHaveBeenCalled());
   });
 });

--- a/frontend/src/pages/LiteraturePage.tsx
+++ b/frontend/src/pages/LiteraturePage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { literatureApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CardImage } from '../components/CardImage';
+import { ConfirmDialog } from '../components/ConfirmDialog';
 import { CliTerminal } from '../components/cli/CliTerminal';
 import { CliToggle } from '../components/cli/CliToggle';
 import { ErrorAlert } from '../components/ErrorAlert';
@@ -117,6 +118,11 @@ function LiteraturePageContent() {
 
   const { cardWidth } = useCardDimensions();
   const phaseNames = usePhaseNames('literature', LITERATURE_PHASE_KEYS);
+
+  // A claim is the heaviest move in the game: one wrong seat voids the set or
+  // gifts it to the opponents. Every other irreversible action here is confirmed
+  // (#2099); this one was not (#4822).
+  const [claimConfirmOpen, setClaimConfirmOpen] = useState(false);
 
   // **フックは早期 return より上。**`if (!state)` の下に置くと、初回レンダー
   // だけフック数が変わってページが骨組みのまま固まる (#4561)。
@@ -394,7 +400,12 @@ function LiteraturePageContent() {
                       </select>
                     </label>
                   ))}
-                  <button type="button" className={btnSuccess} onClick={handleClaim} disabled={loading}>
+                  <button
+                    type="button"
+                    className={btnSuccess}
+                    onClick={() => setClaimConfirmOpen(true)}
+                    disabled={loading}
+                  >
                     {t('claimButton')}
                   </button>
                 </div>
@@ -419,6 +430,18 @@ function LiteraturePageContent() {
           </GameFooter>
         </>
       )}
+      <ConfirmDialog
+        open={claimConfirmOpen}
+        title={t('claimConfirmTitle')}
+        message={t('claimConfirmMessage')}
+        confirmLabel={tc('button.confirm')}
+        cancelLabel={tc('button.cancel')}
+        onConfirm={() => {
+          setClaimConfirmOpen(false);
+          handleClaim();
+        }}
+        onCancel={() => setClaimConfirmOpen(false)}
+      />
     </GamePageShell>
   );
 }

--- a/frontend/src/pages/StreetsAndAlleysPage.test.tsx
+++ b/frontend/src/pages/StreetsAndAlleysPage.test.tsx
@@ -255,4 +255,18 @@ describe('StreetsAndAlleysPage', () => {
     fireEvent.click(sourceBtn);
     await waitFor(() => expect(sourceBtn).toHaveAttribute('aria-pressed', 'true'));
   });
+
+  it('rings every zone that can accept the selected card', async () => {
+    localStorage.clear();
+    mockExec.mockReset();
+    mockExec.mockResolvedValue(playingState);
+    renderWithProviders(<StreetsAndAlleysPage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
+    expect(document.querySelectorAll('[data-target-candidate]')).toHaveLength(0);
+
+    // ♠5 is the top of column 0 — the page's own tests use it as the source.
+    fireEvent.click(screen.getByRole('button', { name: '♠ 5' }));
+    // Foundations accept the card as readily as the tableau does.
+    await waitFor(() => expect(document.querySelectorAll('[data-target-candidate]').length).toBeGreaterThan(1));
+  });
 });

--- a/frontend/src/pages/StreetsAndAlleysPage.tsx
+++ b/frontend/src/pages/StreetsAndAlleysPage.tsx
@@ -328,7 +328,12 @@ function StreetsAndAlleysPageContent() {
                               suit: FOUNDATION_SUITS[idx],
                               count: pile.length,
                             })}
-                            className={`p-0 border-0 bg-transparent cursor-pointer rounded ${focusRingWhite}`}
+                            // Foundations accept the selection just as tableau tops do,
+                            // but only the tableau said so (#4827).
+                            data-target-candidate={selectedSource ? true : undefined}
+                            className={`p-0 border-0 bg-transparent cursor-pointer rounded ${focusRingWhite} ${
+                              selectedSource ? 'ring-1 ring-ds-info motion-safe:hover:ring-2 focus:ring-2' : ''
+                            }`}
                           >
                             <AnimatedCard
                               card={pile[pile.length - 1]}

--- a/frontend/src/pages/ViraPage.test.tsx
+++ b/frontend/src/pages/ViraPage.test.tsx
@@ -351,4 +351,14 @@ describe('ViraPage', () => {
     }
     expect(line).toHaveTextContent('ソロ');
   });
+
+  it('keeps the running bid visible while the CPUs bid', async () => {
+    localStorage.clear();
+    mockExec.mockReset();
+    mockExec.mockResolvedValue(makeViraState({ phase: 0, isHumanBidTurn: false, currentPlayerIdx: 1 }));
+    renderWithProviders(<ViraPage />);
+    // The auction was invisible from the player's side until it ended.
+    await waitFor(() => expect(screen.getByTestId('vira-highest-bid')).toBeInTheDocument());
+    expect(screen.queryByTestId('bid-0')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/ViraPage.tsx
+++ b/frontend/src/pages/ViraPage.tsx
@@ -422,17 +422,22 @@ function ViraPageContent() {
             <FrontendHintTooltip hint={frontendHint} enabled={frontendHintEnabled} t={t} />
 
             <div className="flex flex-wrap gap-2 items-center" data-tutorial="vira-action-buttons">
+              {/* The running bid stays visible while the CPUs bid; only the buttons
+                  are gated on the human's turn. Otherwise the whole auction is
+                  invisible until it is over (#4835). */}
+              {isBidPhase && (
+                <span
+                  className="text-xs font-semibold text-ds-text-primary self-center mr-1"
+                  data-testid="vira-highest-bid"
+                >
+                  {t('bidHighest', {
+                    name: highestBid > 0 ? t(`bid.${CONTRACT_KEYS[highestBid]}`) : t('bidNone'),
+                  })}
+                </span>
+              )}
               {isBidPhase && isHumanBidTurn && (
                 <>
                   <span className="text-xs text-ds-text-muted self-center mr-1">{t('bidPrompt')}</span>
-                  <span
-                    className="text-xs font-semibold text-ds-text-primary self-center mr-1"
-                    data-testid="vira-highest-bid"
-                  >
-                    {t('bidHighest', {
-                      name: highestBid > 0 ? t(`bid.${CONTRACT_KEYS[highestBid]}`) : t('bidNone'),
-                    })}
-                  </span>
                   {BIDS.map((b) => {
                     // Pass (0) is always allowed; a non-pass bid must beat the current highest.
                     const tooLow = b.value !== ViraContract.PASS && b.value <= highestBid;

--- a/frontend/src/utils/karnoffelRanks.ts
+++ b/frontend/src/utils/karnoffelRanks.ts
@@ -26,7 +26,6 @@ export const KARNOFFEL_RANK_KEYS: Readonly<Record<number, string>> = {
  * @returns The rank key, or null for a plain card.
  */
 export function karnoffelRankKey(card: Card, chosenSuit: number): string | null {
-  if (card.value === undefined) return null;
   if (suitIndex(card.design) !== chosenSuit) return null;
   return KARNOFFEL_RANK_KEYS[card.value] ?? null;
 }


### PR DESCRIPTION
## 変更

| ゲーム | 現状 | 対応 |
|---|---|---|
| ストリート・アンド・アレイズ (#4827) | タブロー最上段にはリングが付くが、ファンデーションには付かない | ファンデーションにも同じリング |
| キング・アルバート (#4828) | 移動先候補のハイライトが皆無 | タブロー最上段・空列・ファンデーションにリング |
| ヴィーラ (#4835) | `highestBid` は毎レンダー計算済みなのに、自分の入札番のときしか表示されない | 入札フェーズ中は常時表示（ボタンだけ従来どおりガード） |
| リテラチャー (#4822) | claim がクリック即送信。1枚間違えると組が無効か相手のもの | 確認ダイアログを追加 |

## キング・アルバートのリザーブには**あえてリングを付けていません**

issue は「タブロー・リザーブ・ファンデーション」の3つを求めていますが、`internal/domain/KingAlbert.go` の移動メソッドは4つだけです:

```
MoveTableauToTableau / MoveTableauToFoundation / MoveReserveToTableau / MoveReserveToFoundation
```

**リザーブへ入れるメソッドが存在しません。** リザーブは供給専用なので、そこに「ここへ置けます」のリングを出すと、実行できない移動を約束することになります。

## リテラチャーは専用の文言にしています

`GameGiveUpDialog` は文言が「投了」に固定なので流用せず、汎用の `ConfirmDialog` に claim 専用の文言（「1枚でも間違えると、その組は無効になるか相手チームのものになります」）を渡しています。

## テストプラン

- [x] 4ページにテストを追加
- [x] **負のコントロール実測**: 4実装を無効化すると7テストが落ちることを確認
- [x] リテラチャーの既存 claim テスト2件を確認ダイアログ経由に更新
- [x] `bunx vitest run` 対象5ファイル: 90 passed
- [x] `bun run check` / `bun run typecheck`

### 途中で踏んだ点

`useState` を早期 return の**下**に足してしまい、`Rendered more hooks than during the previous render` で既存テストが落ちました（`frontend/CLAUDE.md` が警告している #4561 と同型）。フックを早期 return の上へ移動しています。

あわせて #4953 のレビュー指摘（`karnoffelRanks.ts` の到達不能な `card.value === undefined` チェック）も除去しました。

Closes #4822
Closes #4827
Closes #4828
Closes #4835