### PR TITLE
fix(ui): keep the rule that decides the game on screen

### DIFF
--- a/frontend/src/i18n/locales/en/bakersgame.json
+++ b/frontend/src/i18n/locales/en/bakersgame.json
@@ -35,5 +35,6 @@
     "useFreeCells": "Consider moving a card to a free cell to open up moves"
   },
   "emptyTableauColumnLabel": "Any",
-  "emptyTableauColumnAriaLabel": "Empty tableau column {{idx}} (any card can be placed)"
+  "emptyTableauColumnAriaLabel": "Empty tableau column {{idx}} (any card can be placed)",
+  "tableauRule": "Tableau stacks descend in the SAME suit — the Free Cell difference"
 }

--- a/frontend/src/i18n/locales/en/tysiac.json
+++ b/frontend/src/i18n/locales/en/tysiac.json
@@ -27,7 +27,7 @@
   "bidRaiseTo": "Raise ({{points}})",
   "bidPass": "Pass",
   "giveCard": "Give card",
-  "marriageAvailable": "Marriage available: {{list}}",
+  "marriageAvailable": "Marriage available: {{list}} (scores only when you LEAD the K or Q)",
   "cards": "{{count}} cards",
   "tricks": "{{count}} tricks",
   "currentTrick": "Current Trick",

--- a/frontend/src/i18n/locales/ja/bakersgame.json
+++ b/frontend/src/i18n/locales/ja/bakersgame.json
@@ -35,5 +35,6 @@
     "useFreeCells": "フリーセルにカードを移動して手を広げましょう"
   },
   "emptyTableauColumnLabel": "任意",
-  "emptyTableauColumnAriaLabel": "空のタブロー列 {{idx}}（任意のカードを置けます）"
+  "emptyTableauColumnAriaLabel": "空のタブロー列 {{idx}}（任意のカードを置けます）",
+  "tableauRule": "タブローは【同じスートの降順】でのみ積めます（フリーセルとの違い）"
 }

--- a/frontend/src/i18n/locales/ja/tysiac.json
+++ b/frontend/src/i18n/locales/ja/tysiac.json
@@ -27,7 +27,7 @@
   "bidRaiseTo": "レイズ（{{points}}）",
   "bidPass": "パス",
   "giveCard": "カードを渡す",
-  "marriageAvailable": "マリッジ可能: {{list}}",
+  "marriageAvailable": "マリッジ可能: {{list}}（K か Q を【リードで】出すと成立）",
   "cards": "{{count}}枚",
   "tricks": "{{count}}トリック",
   "currentTrick": "現在のトリック",

--- a/frontend/src/pages/BakersGamePage.test.tsx
+++ b/frontend/src/pages/BakersGamePage.test.tsx
@@ -958,4 +958,14 @@ describe('BakersGamePage', () => {
       expect(cardButton).toHaveAttribute('aria-pressed', 'true');
     });
   });
+
+  it('states the same-suit tableau rule outside the tutorial', async () => {
+    localStorage.clear();
+    mockExec.mockReset();
+    mockExec.mockResolvedValue(playingState);
+    renderWithProviders(<BakersGamePage />);
+    // Anyone who skipped the tutorial would otherwise play it as Free Cell.
+    const rule = await screen.findByTestId('bg-tableau-rule');
+    expect(rule.textContent).toMatch(/同じスート/);
+  });
 });

--- a/frontend/src/pages/BakersGamePage.tsx
+++ b/frontend/src/pages/BakersGamePage.tsx
@@ -363,6 +363,11 @@ function BakersGamePageContent() {
 
             {/* Tableau */}
             <div className="relative">
+              {/* The same-suit restriction is this game's whole point of difference
+                  from Free Cell, and it was only ever stated in the tutorial (#4816). */}
+              <div className="mb-0.5 text-center text-xs text-ds-text-muted" data-testid="bg-tableau-rule">
+                {t('tableauRule')}
+              </div>
               <div className="flex gap-0.5 sm:gap-2 mb-3" data-tutorial="fc-tableau">
                 {state.tableau.map((col: (Card | null)[], colIdx: number) => {
                   const tableauColZone: FreeCellMoveZone = { zone: 'tableau', col: colIdx };

--- a/frontend/src/pages/TysiacPage.test.tsx
+++ b/frontend/src/pages/TysiacPage.test.tsx
@@ -257,4 +257,12 @@ describe('TysiacPage', () => {
     renderWithProviders(<TysiacPage />);
     expect(await screen.findByText(/\(\[0\]\)/)).toBeInTheDocument();
   });
+
+  it('says a marriage only scores when the K or Q is led', async () => {
+    // Holding the pair is not enough — the CUI has always said so, the web page
+    // only listed the pairs.
+    renderWithProviders(<TysiacPage />);
+    const banner = await screen.findByTestId('tysiac-marriage');
+    expect(banner.textContent).toMatch(/リード/);
+  });
 });


### PR DESCRIPTION
## 変更

| ゲーム | 現状 | 対応 |
|---|---|---|
| ベーカーズ・ゲーム (#4816) | 「同スート降順」＝フリーセルとの唯一の違いが、初回チュートリアルにしか出ない | Bristol の `tableauRule` と同じ常設バナーを追加 |
| トゥシオンツ (#4842) | マリッジのバナーは所持ペアを並べるだけで、**成立条件を書いていない** | 「K か Q を**リードで**出すと成立」を明記 |

トゥシオンツの成立条件は `internal/domain/Tysiac.go` の `maybeDeclareMarriage` が「リード時に K/Q を出したとき」だけ宣言する実装で、CUI の `promptMarriageHelp` は毎ターンそれを書いています。Web だけ、**専用の宣言ボタンも無いまま条件が伏せられていました**。

## テストプラン

- [x] 2ページにテストを追加
- [x] **負のコントロール実測**: バナーの testid を潰す／文言を元に戻すと、対応テストが落ちることを確認
- [x] `bunx vitest run` 対象2ファイル: 94 passed
- [x] `bun run check` / `bun run typecheck`

Closes #4816
Closes #4842