### PR TITLE
feat(doubleklondike): ring the piles that will accept the selected card

### DIFF
--- a/frontend/src/pages/DoubleKlondikePage.test.tsx
+++ b/frontend/src/pages/DoubleKlondikePage.test.tsx
@@ -227,4 +227,36 @@ describe('DoubleKlondikePage', () => {
     expect(screen.getByTestId('card-0-0')).not.toHaveAttribute('data-move-target');
     expect(document.querySelectorAll('[data-move-target]')).toHaveLength(1);
   });
+
+  it('judges the foundation ring on the card the server would actually move', async () => {
+    localStorage.clear();
+    mockExec.mockReset();
+    // A run of ♠2 under ♥A on column 0. Selecting the buried ♠2 sends
+    // mtf { col: 0 }, and MoveTableauToFoundation takes the column top (♥A) —
+    // so the ring must follow ♥A, not the ♠2 the player clicked.
+    mockExec.mockResolvedValue(
+      makeState({
+        tableau: (() => {
+          const t = Array.from({ length: 9 }, () => []) as ReturnType<typeof makeState>['tableau'];
+          t[0] = [
+            { card: { design: 'SPADE', value: 2 }, faceUp: true },
+            { card: { design: 'HEART', value: 1 }, faceUp: true },
+          ];
+          return t;
+        })(),
+        waste: [],
+        foundation: (() => {
+          const f = Array.from({ length: 8 }, () => []) as ReturnType<typeof makeState>['foundation'];
+          f[0] = [{ design: 'SPADE', value: 1 }];
+          return f;
+        })(),
+      }),
+    );
+    renderWithProviders(<DoubleKlondikePage />);
+    await waitFor(() => expect(screen.getByTestId('card-0-0')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('card-0-0'));
+    // ♠2 would fit foundation 0 (which holds ♠A) but ♠2 is not what gets sent.
+    await waitFor(() => expect(screen.getByTestId('foundation-1')).toHaveAttribute('data-move-target'));
+    expect(screen.getByTestId('foundation-0')).not.toHaveAttribute('data-move-target');
+  });
 });

--- a/frontend/src/pages/DoubleKlondikePage.test.tsx
+++ b/frontend/src/pages/DoubleKlondikePage.test.tsx
@@ -199,4 +199,32 @@ describe('DoubleKlondikePage', () => {
     expect(board).toHaveClass('grid-cols-9');
     expect(board).not.toHaveClass('overflow-x-auto');
   });
+
+  it('rings only the piles that will accept the selected card', async () => {
+    localStorage.clear();
+    mockExec.mockReset();
+    mockExec.mockResolvedValue(makeState());
+    renderWithProviders(<DoubleKlondikePage />);
+    await waitFor(() => expect(screen.getByTestId('waste')).toBeInTheDocument());
+    expect(document.querySelectorAll('[data-move-target]')).toHaveLength(0);
+
+    // The waste holds ♦A: every empty foundation takes it, no tableau column does.
+    fireEvent.click(screen.getByTestId('waste'));
+    await waitFor(() => expect(document.querySelectorAll('[data-move-target]').length).toBe(8));
+    expect(screen.getByTestId('foundation-0')).toHaveAttribute('data-move-target');
+    expect(screen.getByTestId('card-0-0')).not.toHaveAttribute('data-move-target');
+  });
+
+  it('rings the tableau column that accepts the selected card', async () => {
+    localStorage.clear();
+    mockExec.mockReset();
+    // ♥8 sits on column 1; a black 7 in the waste belongs there and nowhere else.
+    mockExec.mockResolvedValue(makeState({ waste: [{ design: 'SPADE', value: 7 }] }));
+    renderWithProviders(<DoubleKlondikePage />);
+    await waitFor(() => expect(screen.getByTestId('waste')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('waste'));
+    await waitFor(() => expect(screen.getByTestId('card-1-1')).toHaveAttribute('data-move-target'));
+    expect(screen.getByTestId('card-0-0')).not.toHaveAttribute('data-move-target');
+    expect(document.querySelectorAll('[data-move-target]')).toHaveLength(1);
+  });
 });

--- a/frontend/src/pages/DoubleKlondikePage.tsx
+++ b/frontend/src/pages/DoubleKlondikePage.tsx
@@ -18,8 +18,10 @@ import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
+import type { Card } from '../types/card';
 import { DoubleKlondikePhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { doubleKlondikeCanPlaceOnFoundation, doubleKlondikeCanPlaceOnTableau } from '../utils/doubleKlondikeTargets';
 import { hintCheckboxItem } from '../utils/settingsItems';
 
 /** Double Klondike tutorial step definitions. */
@@ -110,6 +112,22 @@ function DoubleKlondikePageContent() {
     setSelected({ zone: 'waste' });
   };
 
+  // The board is nearly twice a Klondike's, and legality was only discoverable by
+  // making the move and reading the server's rejection. These mirror the domain's
+  // canPlaceOnTableau / canPlaceOnFoundation (#4895).
+  const selectedCard: Card | null =
+    selected === null
+      ? null
+      : selected.zone === 'waste'
+        ? (state.waste[state.waste.length - 1] ?? null)
+        : (state.tableau[selected.col]?.[selected.idx]?.card ?? null);
+  const isTableauTarget = (col: number) =>
+    selectedCard !== null &&
+    !(selected?.zone === 'tableau' && selected.col === col) &&
+    doubleKlondikeCanPlaceOnTableau(selectedCard, state.tableau, col);
+  const isFoundationTarget = (fIdx: number) =>
+    selectedCard !== null && doubleKlondikeCanPlaceOnFoundation(selectedCard, state.foundation, fIdx);
+
   // Click a tableau card: select it as a source, or move the current source here.
   const clickTableauCard = (col: number, idx: number) => {
     if (!canAct) return;
@@ -158,8 +176,11 @@ function DoubleKlondikePageContent() {
       {column.length === 0 ? (
         <button
           type="button"
-          className="rounded border border-dashed border-white/25 bg-black/20"
+          className={`rounded border border-dashed border-white/25 bg-black/20 ${
+            isTableauTarget(col) ? 'ring-2 ring-ds-success' : ''
+          }`}
           style={{ width: w, height: cardH }}
+          data-move-target={isTableauTarget(col) || undefined}
           onClick={canAct ? () => clickEmptyColumn(col) : undefined}
           disabled={!canAct}
           title={t('empty')}
@@ -170,7 +191,10 @@ function DoubleKlondikePageContent() {
           <button
             type="button"
             key={`col-${col}-${i}`}
-            className={`rounded ${selected?.zone === 'tableau' && selected.col === col && i >= selected.idx ? 'ring-2 ring-ds-warning' : ''}`}
+            className={`rounded ${selected?.zone === 'tableau' && selected.col === col && i >= selected.idx ? 'ring-2 ring-ds-warning' : ''} ${
+              i === column.length - 1 && isTableauTarget(col) ? 'ring-2 ring-ds-success' : ''
+            }`}
+            data-move-target={(i === column.length - 1 && isTableauTarget(col)) || undefined}
             style={{ marginTop: i === 0 ? 0 : -Math.round(w * 1.05) }}
             onClick={canAct && tc2.faceUp ? () => clickTableauCard(col, i) : undefined}
             disabled={!canAct || !tc2.faceUp}
@@ -271,7 +295,8 @@ function DoubleKlondikePageContent() {
                 <button
                   type="button"
                   key={`foundation-${i}`}
-                  className="rounded shrink-0"
+                  className={`rounded shrink-0 ${isFoundationTarget(i) ? 'ring-2 ring-ds-success' : ''}`}
+                  data-move-target={isFoundationTarget(i) || undefined}
                   onClick={canAct ? clickFoundation : undefined}
                   disabled={!canAct}
                   title={t('foundation')}

--- a/frontend/src/pages/DoubleKlondikePage.tsx
+++ b/frontend/src/pages/DoubleKlondikePage.tsx
@@ -115,18 +115,31 @@ function DoubleKlondikePageContent() {
   // The board is nearly twice a Klondike's, and legality was only discoverable by
   // making the move and reading the server's rejection. These mirror the domain's
   // canPlaceOnTableau / canPlaceOnFoundation (#4895).
+  //
+  // Two different cards are at stake. `mtt` carries the selected index, so a
+  // tableau target is judged on the selected card. `mtf` carries only the column
+  // and MoveTableauToFoundation always takes that column's *top* card, so a
+  // foundation must be judged on the top card — selecting a buried card of a run
+  // is normal play, and judging the ring on it would promise a move the server
+  // would never make.
   const selectedCard: Card | null =
     selected === null
       ? null
       : selected.zone === 'waste'
         ? (state.waste[state.waste.length - 1] ?? null)
         : (state.tableau[selected.col]?.[selected.idx]?.card ?? null);
+  const foundationSourceCard: Card | null =
+    selected === null
+      ? null
+      : selected.zone === 'waste'
+        ? selectedCard
+        : (state.tableau[selected.col]?.[state.tableau[selected.col].length - 1]?.card ?? null);
   const isTableauTarget = (col: number) =>
     selectedCard !== null &&
     !(selected?.zone === 'tableau' && selected.col === col) &&
     doubleKlondikeCanPlaceOnTableau(selectedCard, state.tableau, col);
   const isFoundationTarget = (fIdx: number) =>
-    selectedCard !== null && doubleKlondikeCanPlaceOnFoundation(selectedCard, state.foundation, fIdx);
+    foundationSourceCard !== null && doubleKlondikeCanPlaceOnFoundation(foundationSourceCard, state.foundation, fIdx);
 
   // Click a tableau card: select it as a source, or move the current source here.
   const clickTableauCard = (col: number, idx: number) => {

--- a/frontend/src/utils/doubleKlondikeTargets.test.ts
+++ b/frontend/src/utils/doubleKlondikeTargets.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import type { Card, CardDesign } from '../types/card';
+import type { DoubleKlondikeTableauCard } from '../types/games/doubleklondike';
+import { doubleKlondikeCanPlaceOnFoundation, doubleKlondikeCanPlaceOnTableau } from './doubleKlondikeTargets';
+
+const c = (design: CardDesign, value: number): Card => ({ design, value });
+const up = (design: CardDesign, value: number): DoubleKlondikeTableauCard => ({ card: c(design, value), faceUp: true });
+const down = (): DoubleKlondikeTableauCard => ({ card: null, faceUp: false });
+
+describe('doubleKlondikeCanPlaceOnTableau', () => {
+  const tableau = [[up('SPADE', 8)], [], [down()], [up('HEART', 8)]];
+
+  it('takes a red card one rank below a black top', () => {
+    expect(doubleKlondikeCanPlaceOnTableau(c('HEART', 7), tableau, 0)).toBe(true);
+  });
+
+  it('refuses the same colour', () => {
+    expect(doubleKlondikeCanPlaceOnTableau(c('CLOVER', 7), tableau, 0)).toBe(false);
+  });
+
+  it('refuses a rank that does not descend by one', () => {
+    expect(doubleKlondikeCanPlaceOnTableau(c('HEART', 6), tableau, 0)).toBe(false);
+    expect(doubleKlondikeCanPlaceOnTableau(c('HEART', 9), tableau, 0)).toBe(false);
+  });
+
+  it('accepts only a King on an empty column', () => {
+    expect(doubleKlondikeCanPlaceOnTableau(c('SPADE', 13), tableau, 1)).toBe(true);
+    expect(doubleKlondikeCanPlaceOnTableau(c('SPADE', 12), tableau, 1)).toBe(false);
+  });
+
+  it('refuses a column whose top is face down', () => {
+    expect(doubleKlondikeCanPlaceOnTableau(c('HEART', 7), tableau, 2)).toBe(false);
+  });
+
+  it('refuses a column that does not exist', () => {
+    expect(doubleKlondikeCanPlaceOnTableau(c('HEART', 7), tableau, 99)).toBe(false);
+  });
+});
+
+describe('doubleKlondikeCanPlaceOnFoundation', () => {
+  // Two decks: eight piles, so the same card can be legal on more than one.
+  const foundation = [[c('SPADE', 1)], [], [c('SPADE', 1)], [c('HEART', 1), c('HEART', 2)]];
+
+  it('accepts only an Ace on an empty pile', () => {
+    expect(doubleKlondikeCanPlaceOnFoundation(c('DIAMOND', 1), foundation, 1)).toBe(true);
+    expect(doubleKlondikeCanPlaceOnFoundation(c('DIAMOND', 2), foundation, 1)).toBe(false);
+  });
+
+  it('builds up in the same suit', () => {
+    expect(doubleKlondikeCanPlaceOnFoundation(c('SPADE', 2), foundation, 0)).toBe(true);
+    expect(doubleKlondikeCanPlaceOnFoundation(c('HEART', 2), foundation, 0)).toBe(false);
+    expect(doubleKlondikeCanPlaceOnFoundation(c('SPADE', 3), foundation, 0)).toBe(false);
+  });
+
+  it('is legal on either of the two piles holding the same suit', () => {
+    expect(doubleKlondikeCanPlaceOnFoundation(c('SPADE', 2), foundation, 0)).toBe(true);
+    expect(doubleKlondikeCanPlaceOnFoundation(c('SPADE', 2), foundation, 2)).toBe(true);
+  });
+
+  it('refuses a pile that does not exist', () => {
+    expect(doubleKlondikeCanPlaceOnFoundation(c('SPADE', 2), foundation, 99)).toBe(false);
+  });
+});

--- a/frontend/src/utils/doubleKlondikeTargets.ts
+++ b/frontend/src/utils/doubleKlondikeTargets.ts
@@ -1,0 +1,50 @@
+import type { Card } from '../types/card';
+import type { DoubleKlondikeTableauCard } from '../types/games/doubleklondike';
+import { isRedSuitDesign } from './cardAlt';
+
+/** King, the only rank an empty Double Klondike column accepts. */
+const KING = 13;
+
+/**
+ * Whether `card` may be stacked on tableau column `toCol`: an empty column takes
+ * a King only, otherwise the move must alternate colour and descend by one.
+ * Mirrors `canPlaceOnTableau` in `internal/domain/DoubleKlondike.go`.
+ * @param card - The card being moved.
+ * @param tableau - All tableau columns.
+ * @param toCol - Index of the destination column.
+ * @returns Whether the move is legal.
+ */
+export function doubleKlondikeCanPlaceOnTableau(
+  card: Card,
+  tableau: readonly (readonly DoubleKlondikeTableauCard[])[],
+  toCol: number,
+): boolean {
+  const pile = tableau[toCol];
+  if (!pile) return false;
+  if (pile.length === 0) return card.value === KING;
+  const top = pile[pile.length - 1];
+  if (!top?.faceUp || !top.card) return false;
+  return isRedSuitDesign(card.design) !== isRedSuitDesign(top.card.design) && card.value === top.card.value - 1;
+}
+
+/**
+ * Whether `card` may go onto foundation pile `fIdx`: an empty pile takes an Ace,
+ * otherwise it builds up in the same suit. Two decks mean eight piles, so a card
+ * can be legal on more than one — each index is asked separately, exactly as
+ * `canPlaceOnFoundation` in `internal/domain/DoubleKlondike.go` does.
+ * @param card - The card being moved.
+ * @param foundation - All foundation piles.
+ * @param fIdx - Index of the destination pile.
+ * @returns Whether the move is legal.
+ */
+export function doubleKlondikeCanPlaceOnFoundation(
+  card: Card,
+  foundation: readonly (readonly Card[])[],
+  fIdx: number,
+): boolean {
+  const pile = foundation[fIdx];
+  if (!pile) return false;
+  if (pile.length === 0) return card.value === 1;
+  const top = pile[pile.length - 1];
+  return top !== undefined && card.design === top.design && card.value === top.value + 1;
+}


### PR DESCRIPTION
## 変更

ダブル・クロンダイクは9列のタブローと8つのファウンデーションを持ちますが、**選択中のカードが何であれ全ての移動先が同じように押せる**状態でした。置けるかどうかは `exec` してサーバの `message` が返るまで分かりません。通常のクロンダイクの約2倍の盤面で、合法手を目視で探すコストが高い側です。

`selected` が立っている間、置ける先だけに `ring-2 ring-ds-success` を出します。

## ドメインの規則をそのまま写しています

`internal/domain/DoubleKlondike.go` の2つの述語に対応:

- `canPlaceOnTableau` — 空列は **K のみ**、それ以外は交互色かつ1つ下。**裏向きの top は不可**。
- `canPlaceOnFoundation` — 空は **A のみ**、それ以外は同スートの1つ上。

**2デッキ＝ファウンデーションが8つ**あるため、`canPlaceOnFoundation` は index ごとに問う形になっており（同じ ♠2 が2つの山に置ける）、その挙動も単体テストで固定しています。

## テストプラン

- [x] `doubleKlondikeTargets.ts` に単体テスト10本（裏向き top・存在しない index・2デッキで2箇所合法、などページテストでは作りにくいケース）
- [x] ページテスト2本: ♦A では**8つのファウンデーションだけ**が光りタブローは光らない / ♠7 では **♥8 の列だけ**が光る（件数も検証）
- [x] **負のコントロール実測**: `data-move-target` を外すと両テストが落ちることを確認
- [x] `bunx vitest run` 対象2ファイル: 29 passed
- [x] `bun run check` / `bun run typecheck`

Closes #4895