### PR TITLE
feat(braid): ring the hinted cards instead of naming their zones

### DIFF
--- a/frontend/src/pages/BraidPage.test.tsx
+++ b/frontend/src/pages/BraidPage.test.tsx
@@ -312,6 +312,26 @@ describe('BraidPage', () => {
     fireEvent.click(screen.getByRole('button', { name: /CLI/i }));
     await waitFor(() => expect(screen.queryByLabelText(/空の組札0/)).not.toBeInTheDocument());
   });
+
+  it('rings the hinted cards, not just their names', async () => {
+    localStorage.clear();
+    mockExec.mockReset();
+    mockExec.mockResolvedValueOnce(playingState).mockResolvedValueOnce({
+      ...playingState,
+      hint: { fromZone: 'field', fromIdx: 2, toZone: 'foundation', toIdx: 3 },
+    });
+    renderWithProviders(<BraidPage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
+    expect(document.querySelectorAll('[data-hint-slot]')).toHaveLength(0);
+
+    fireEvent.click(screen.getByRole('button', { name: 'ヒント' }));
+    // Four fields, eight helpers and eight foundations: prose alone left the
+    // player hunting for the two cards named.
+    await waitFor(() => expect(screen.getAllByText(/組札3/).length).toBeGreaterThan(0));
+    expect(document.querySelectorAll('[data-hint-slot="from"]')).toHaveLength(1);
+    // The destination may be an empty foundation, which must ring too.
+    expect(document.querySelectorAll('[data-hint-slot="to"]')).toHaveLength(1);
+  });
 });
 
 // Keyboard shortcuts are bound by useActionKeyboardNav and advertised by

--- a/frontend/src/pages/BraidPage.test.tsx
+++ b/frontend/src/pages/BraidPage.test.tsx
@@ -332,6 +332,43 @@ describe('BraidPage', () => {
     // The destination may be an empty foundation, which must ring too.
     expect(document.querySelectorAll('[data-hint-slot="to"]')).toHaveLength(1);
   });
+
+  it('rings a helper destination and a foundation that already holds cards', async () => {
+    localStorage.clear();
+    mockExec.mockReset();
+    // The destination is a helper, and the source foundation is non-empty — the
+    // two render paths the field→empty-foundation case never reaches.
+    const withPile = {
+      ...playingState,
+      foundation: [[card('SPADE', 5)], [], [], [], [], [], [], []],
+    };
+    mockExec.mockResolvedValueOnce(withPile).mockResolvedValueOnce({
+      ...withPile,
+      hint: { fromZone: 'field', fromIdx: 0, toZone: 'helper', toIdx: 0 },
+    });
+    renderWithProviders(<BraidPage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { name: 'ヒント' }));
+    await waitFor(() => expect(document.querySelectorAll('[data-hint-slot="to"]')).toHaveLength(1));
+    expect(document.querySelectorAll('[data-hint-slot="from"]')).toHaveLength(1);
+  });
+
+  it('rings a non-empty foundation named as the destination', async () => {
+    localStorage.clear();
+    mockExec.mockReset();
+    const withPile = {
+      ...playingState,
+      foundation: [[card('SPADE', 5)], [], [], [], [], [], [], []],
+    };
+    mockExec.mockResolvedValueOnce(withPile).mockResolvedValueOnce({
+      ...withPile,
+      hint: { fromZone: 'field', fromIdx: 2, toZone: 'foundation', toIdx: 0 },
+    });
+    renderWithProviders(<BraidPage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { name: 'ヒント' }));
+    await waitFor(() => expect(document.querySelectorAll('[data-hint-slot="to"]')).toHaveLength(1));
+  });
 });
 
 // Keyboard shortcuts are bound by useActionKeyboardNav and advertised by

--- a/frontend/src/pages/BraidPage.tsx
+++ b/frontend/src/pages/BraidPage.tsx
@@ -187,6 +187,17 @@ function BraidPageContent() {
    * they refill: a field refills itself from the braid, so an empty one is not
    * a drop target, while an empty helper accepts the waste top.
    */
+  // The hint names its zones in prose across a board of 4 fields, 8 helpers and
+  // 8 foundations; every sibling page rings the card instead (#4877).
+  const isHintFrom = (zone: string, idx: number) => hint != null && hint.fromZone === zone && hint.fromIdx === idx;
+  const isHintTo = (zone: string, idx: number) => hint != null && hint.toZone === zone && hint.toIdx === idx;
+  const hintRingClass = (zone: string, idx: number) =>
+    isHintFrom(zone, idx)
+      ? 'ring-2 ring-ds-info motion-safe:animate-pulse'
+      : isHintTo(zone, idx)
+        ? 'ring-2 ring-ds-success motion-safe:animate-pulse'
+        : '';
+
   const renderSlot = (kind: 'field' | 'helper', idx: number) => {
     const card = (kind === 'field' ? state.fields[idx] : state.helpers[idx]) ?? null;
     const zone: BraidMoveZone = { zone: kind, col: idx };
@@ -207,7 +218,8 @@ function BraidPageContent() {
             draggable={isPlaying && !loading}
             onDragStart={dnd.handleDragStart(zone)}
             onDragEnd={dnd.handleDragEnd}
-            className={`p-0 border-0 bg-transparent cursor-pointer rounded ${focusRingWhite} ${isSourceSelected(kind, idx) ? 'ring-2 ring-ds-warning' : ''}`}
+            data-hint-slot={isHintFrom(kind, idx) ? 'from' : isHintTo(kind, idx) ? 'to' : undefined}
+            className={`p-0 border-0 bg-transparent cursor-pointer rounded ${focusRingWhite} ${isSourceSelected(kind, idx) ? 'ring-2 ring-ds-warning' : ''} ${hintRingClass(kind, idx)}`}
           >
             <AnimatedCard card={card} width={dims.cw} draggable={false} />
           </button>
@@ -348,7 +360,8 @@ function BraidPageContent() {
                             onClick={() => game.handleSelectTarget(foundationZone)}
                             disabled={!isPlaying || loading || isAutoCompleting || !selectedSource}
                             aria-label={t('foundationAriaLabel', { idx, count: pile.length })}
-                            className={`p-0 border-0 bg-transparent cursor-pointer rounded ${focusRingWhite}`}
+                            data-hint-slot={isHintTo('foundation', idx) ? 'to' : undefined}
+                            className={`p-0 border-0 bg-transparent cursor-pointer rounded ${focusRingWhite} ${hintRingClass('foundation', idx)}`}
                           >
                             <AnimatedCard
                               card={pile[pile.length - 1]}
@@ -364,7 +377,8 @@ function BraidPageContent() {
                             disabled={!isPlaying || loading || isAutoCompleting || !selectedSource}
                             aria-label={t('emptyFoundationAriaLabel', { idx })}
                             style={{ width: dims.cw, height: dims.ch }}
-                            className={`rounded border-2 border-dashed border-white/30 text-game-text-muted text-xs flex items-center justify-center ${focusRingWhite}`}
+                            data-hint-slot={isHintTo('foundation', idx) ? 'to' : undefined}
+                            className={`rounded border-2 border-dashed border-white/30 text-game-text-muted text-xs flex items-center justify-center ${focusRingWhite} ${hintRingClass('foundation', idx)}`}
                           >
                             {state.baseRank}
                           </button>


### PR DESCRIPTION
## 変更

`BraidCuiPresenter.HintOutput` は `fromZone`/`fromIdx`/`toZone`/`toIdx` を全て返しているのに、ページはそれを **「フィールド2 → 組札3」という一文**にするだけで、`renderSlot` も foundation の描画もこれらの値を一度も参照していませんでした。

ブレイドは **4フィールド + 8ヘルパー + 8ファウンデーション**の広い盤面で、文字だけでは該当カードを探すコストが高い側です。移動元（info 色）と移動先（success 色）にリングを付けます。

**空のファウンデーションにもリングを付けています。** 移動先として頻出するためで、最初に実装したときはカードが乗っている山だけを対象にしており、テストで気づきました。

## テストプラン

- [x] ヒント押下前は `data-hint-slot` が0件、押下後に from/to がそれぞれ1件になることを検証
- [x] **負のコントロール実測**: `data-hint-slot` を外すとテストが落ちることを確認
- [x] `bunx vitest run src/pages/BraidPage.test.tsx`: 34 passed
- [x] `bun run check` / `bun run typecheck`

Closes #4877