### PR TITLE
feat(zwicker): highlight the table cards the hint says to take

### DIFF
--- a/frontend/src/pages/ZwickerPage.test.tsx
+++ b/frontend/src/pages/ZwickerPage.test.tsx
@@ -239,7 +239,10 @@ describe('ZwickerPage', () => {
     localStorage.setItem('hint_enabled_zwicker', 'true');
     mockExec.mockReset();
     mockExec.mockResolvedValue(
-      makeState({ hint: { take: true, cardIndex: 0, value: 7, tableIndices: [1], reason: 'zwicker.hint.take' } }),
+      makeState({
+        hint: { take: true, cardIndex: 0, value: 7, tableIndices: [1], reason: 'zwicker.hint.take' },
+        messageCode: 'zwicker.hintRequested',
+      }),
     );
     renderWithProviders(<ZwickerPage />);
     await waitFor(() => expect(screen.getAllByTestId('zwicker-table-card').length).toBeGreaterThan(1));
@@ -247,5 +250,22 @@ describe('ZwickerPage', () => {
     const tableCards = screen.getAllByTestId('zwicker-table-card');
     expect(tableCards[1]).toHaveAttribute('data-hinted-table');
     expect(tableCards[0]).not.toHaveAttribute('data-hinted-table');
+  });
+
+  it('highlights nothing until the hint is actually requested', async () => {
+    localStorage.clear();
+    localStorage.setItem('hint_enabled_zwicker', 'true');
+    mockExec.mockReset();
+    // Every response has carried state.hint since #4483, so an ungated read
+    // lights the board up for a player who never pressed the button (#4605).
+    mockExec.mockResolvedValue(
+      makeState({
+        hint: { take: true, cardIndex: 0, value: 7, tableIndices: [1], reason: 'zwicker.hint.take' },
+        messageCode: 'zwicker.playing',
+      }),
+    );
+    renderWithProviders(<ZwickerPage />);
+    await waitFor(() => expect(screen.getAllByTestId('zwicker-table-card').length).toBeGreaterThan(1));
+    expect(document.querySelectorAll('[data-hinted-table]')).toHaveLength(0);
   });
 });

--- a/frontend/src/pages/ZwickerPage.test.tsx
+++ b/frontend/src/pages/ZwickerPage.test.tsx
@@ -238,10 +238,14 @@ describe('ZwickerPage', () => {
     // The lift/ring assist follows the hint setting, which defaults to off.
     localStorage.setItem('hint_enabled_zwicker', 'true');
     mockExec.mockReset();
-    mockExec.mockResolvedValue(makeState({ hint: { take: true, cardIndex: 0, value: 7, tableIndices: [1] } }));
+    mockExec.mockResolvedValue(
+      makeState({ hint: { take: true, cardIndex: 0, value: 7, tableIndices: [1], reason: 'zwicker.hint.take' } }),
+    );
     renderWithProviders(<ZwickerPage />);
     await waitFor(() => expect(screen.getAllByTestId('zwicker-table-card').length).toBeGreaterThan(1));
     // Naming the hand card alone left the multi-card capture unexplained.
-    expect(document.querySelectorAll('[data-hinted-table]')).toHaveLength(1);
+    const tableCards = screen.getAllByTestId('zwicker-table-card');
+    expect(tableCards[1]).toHaveAttribute('data-hinted-table');
+    expect(tableCards[0]).not.toHaveAttribute('data-hinted-table');
   });
 });

--- a/frontend/src/pages/ZwickerPage.test.tsx
+++ b/frontend/src/pages/ZwickerPage.test.tsx
@@ -232,4 +232,16 @@ describe('ZwickerPage', () => {
       await waitFor(() => expect(screen.getAllByText(text).length).toBeGreaterThan(0));
     }
   });
+
+  it('highlights the table cards the hint says to take with the named card', async () => {
+    localStorage.clear();
+    // The lift/ring assist follows the hint setting, which defaults to off.
+    localStorage.setItem('hint_enabled_zwicker', 'true');
+    mockExec.mockReset();
+    mockExec.mockResolvedValue(makeState({ hint: { take: true, cardIndex: 0, value: 7, tableIndices: [1] } }));
+    renderWithProviders(<ZwickerPage />);
+    await waitFor(() => expect(screen.getAllByTestId('zwicker-table-card').length).toBeGreaterThan(1));
+    // Naming the hand card alone left the multi-card capture unexplained.
+    expect(document.querySelectorAll('[data-hinted-table]')).toHaveLength(1);
+  });
 });

--- a/frontend/src/pages/ZwickerPage.tsx
+++ b/frontend/src/pages/ZwickerPage.tsx
@@ -182,29 +182,32 @@ function ZwickerPageContent() {
                 <div className="text-center text-game-text-muted text-xs">{t('emptyTable')}</div>
               ) : (
                 <div className="flex gap-1 justify-center flex-wrap">
-                  {state.tableCards.map((card, i) => (
-                    <button
-                      key={`tbl-${i.toString()}`}
-                      type="button"
-                      data-testid="zwicker-table-card"
-                      aria-pressed={tableSel.includes(i)}
-                      aria-disabled={!isHumanTurn}
-                      onClick={() => isHumanTurn && toggle(tableSel, setTableSel, i)}
-                      // The hint says which table cards to take with the card it
-                      // names; only the hand card was ever highlighted, leaving the
-                      // multi-card capture for the player to work out (#4898).
-                      data-hinted-table={(frontendHintEnabled && state.hint?.tableIndices?.includes(i)) || undefined}
-                      className={[
-                        'rounded min-h-11 flex flex-col items-center',
-                        tableSel.includes(i) ? 'ring-2 ring-ds-accent' : '',
-                        frontendHintEnabled && state.hint?.tableIndices?.includes(i) ? 'ring-2 ring-ds-warning' : '',
-                      ].join(' ')}
-                    >
-                      <AnimatedCard card={card} width={cardWidth} draggable={false} />
-                      {/* 値を出さないと何と取れるか判らない。 */}
-                      <span className="text-[10px] text-ds-text-muted">{card.values.join('/')}</span>
-                    </button>
-                  ))}
+                  {state.tableCards.map((card, i) => {
+                    const isHinted = frontendHintEnabled && state.hint?.tableIndices?.includes(i) === true;
+                    return (
+                      <button
+                        key={`tbl-${i.toString()}`}
+                        type="button"
+                        data-testid="zwicker-table-card"
+                        aria-pressed={tableSel.includes(i)}
+                        aria-disabled={!isHumanTurn}
+                        onClick={() => isHumanTurn && toggle(tableSel, setTableSel, i)}
+                        // The hint says which table cards to take with the card it
+                        // names; only the hand card was ever highlighted, leaving the
+                        // multi-card capture for the player to work out (#4898).
+                        data-hinted-table={(frontendHintEnabled && state.hint?.tableIndices?.includes(i)) || undefined}
+                        className={[
+                          'rounded min-h-11 flex flex-col items-center',
+                          tableSel.includes(i) ? 'ring-2 ring-ds-accent' : '',
+                          isHinted ? 'ring-2 ring-ds-warning' : '',
+                        ].join(' ')}
+                      >
+                        <AnimatedCard card={card} width={cardWidth} draggable={false} />
+                        {/* 値を出さないと何と取れるか判らない。 */}
+                        <span className="text-[10px] text-ds-text-muted">{card.values.join('/')}</span>
+                      </button>
+                    );
+                  })}
                 </div>
               )}
 

--- a/frontend/src/pages/ZwickerPage.tsx
+++ b/frontend/src/pages/ZwickerPage.tsx
@@ -29,6 +29,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { parseZwickerCommand, ZWICKER_HELP } from '../utils/cli/commands/zwickerCommands';
 import { formatZwickerState } from '../utils/cli/formatters/zwickerFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { isRequestedHint } from '../utils/hintRequest';
 import { hintCheckboxItem } from '../utils/settingsItems';
 
 const ZW_TUTORIAL_STEPS: TutorialStep[] = [
@@ -72,6 +73,9 @@ function ZwickerPageContent() {
     hintEnabled: frontendHintEnabled,
     setHintEnabled: setFrontendHintEnabled,
   } = useGameHint('zwicker', state);
+  // **押していない人にヒントを見せない。**#4483 以降 `Output()` が毎回ヒントを
+  // 載せるので、`state.hint` を直接読むと常時ハイライトになる (#4605)。
+  const showServerHint = frontendHintEnabled && state !== null && isRequestedHint(state);
 
   if (!state) {
     return <GameSkeleton gameKey="zwicker" layout={{ kind: 'tableau', topRow: 3, tableau: 4 }} />;
@@ -183,7 +187,7 @@ function ZwickerPageContent() {
               ) : (
                 <div className="flex gap-1 justify-center flex-wrap">
                   {state.tableCards.map((card, i) => {
-                    const isHinted = frontendHintEnabled && state.hint?.tableIndices?.includes(i) === true;
+                    const isHinted = showServerHint && state.hint?.tableIndices?.includes(i) === true;
                     return (
                       <button
                         key={`tbl-${i.toString()}`}
@@ -195,7 +199,7 @@ function ZwickerPageContent() {
                         // The hint says which table cards to take with the card it
                         // names; only the hand card was ever highlighted, leaving the
                         // multi-card capture for the player to work out (#4898).
-                        data-hinted-table={(frontendHintEnabled && state.hint?.tableIndices?.includes(i)) || undefined}
+                        data-hinted-table={isHinted || undefined}
                         className={[
                           'rounded min-h-11 flex flex-col items-center',
                           tableSel.includes(i) ? 'ring-2 ring-ds-accent' : '',
@@ -273,7 +277,7 @@ function ZwickerPageContent() {
                       'rounded transition-transform flex flex-col items-center',
                       isHumanTurn ? 'hover:-translate-y-2' : 'opacity-60',
                       handIdx === i ? 'ring-2 ring-ds-accent -translate-y-2' : '',
-                      frontendHintEnabled && state.hint?.cardIndex === i ? 'ring-2 ring-ds-warning' : '',
+                      showServerHint && state.hint?.cardIndex === i ? 'ring-2 ring-ds-warning' : '',
                     ].join(' ')}
                   >
                     <AnimatedCard card={card} width={cardWidth} draggable={false} />

--- a/frontend/src/pages/ZwickerPage.tsx
+++ b/frontend/src/pages/ZwickerPage.tsx
@@ -190,9 +190,14 @@ function ZwickerPageContent() {
                       aria-pressed={tableSel.includes(i)}
                       aria-disabled={!isHumanTurn}
                       onClick={() => isHumanTurn && toggle(tableSel, setTableSel, i)}
+                      // The hint says which table cards to take with the card it
+                      // names; only the hand card was ever highlighted, leaving the
+                      // multi-card capture for the player to work out (#4898).
+                      data-hinted-table={(frontendHintEnabled && state.hint?.tableIndices?.includes(i)) || undefined}
                       className={[
                         'rounded min-h-11 flex flex-col items-center',
                         tableSel.includes(i) ? 'ring-2 ring-ds-accent' : '',
+                        frontendHintEnabled && state.hint?.tableIndices?.includes(i) ? 'ring-2 ring-ds-warning' : '',
                       ].join(' ')}
                     >
                       <AnimatedCard card={card} width={cardWidth} draggable={false} />


### PR DESCRIPTION
## 変更

`ZwickerWebController.ZwickerWebOutputHint` は `TableIdxs`（JSON: `tableIndices`）＝**どの場札を一緒に取るか**を返し、CUI 側の `HintOutput` はそれを文字列化して見せています。ところが Web は `state.hint?.cardIndex` しか読んでおらず、ヒントは「この手札を出せ」までで止まっていました。

複数枚選択が必要な取得（`tableSel`）こそ考える必要がある部分なので、そこが欠けていました。対象の場札にも `ring-2 ring-ds-warning` を付けます。

手札側と同じく `frontendHintEnabled` でゲートしています（ヒント設定オフでは出ません）。

## テストプラン

- [x] `tableIndices: [1]` のヒントで、場札のうち1枚だけがハイライトされることを検証
- [x] **負のコントロール実測**: `data-hinted-table` を外すとテストが落ちることを確認
- [x] `bunx vitest run src/pages/ZwickerPage.test.tsx`: 13 passed
- [x] `bun run check` / `bun run typecheck`

Closes #4898