### PR TITLE
feat(escoba): announce the sweep, as Scopone already does

### DIFF
--- a/frontend/src/i18n/locales/en/escoba.json
+++ b/frontend/src/i18n/locales/en/escoba.json
@@ -21,7 +21,9 @@
     "stockRemaining": "Stock {{count}} left",
     "cpuStats": "Hand {{cards}} / Captured {{captured}} / Escoba {{escoba}}",
     "humanStats": "Hand {{cards}} / Captured {{captured}} / Escoba {{escoba}}",
-    "playerScore": "P{{id}}: {{score}} pt"
+    "playerScore": "P{{id}}: {{score}} pt",
+    "escobaBadge": "Escoba!",
+    "escobaBadgeOwn": "Escoba! You"
   },
   "captured": {
     "title": "Captured cards",

--- a/frontend/src/i18n/locales/ja/escoba.json
+++ b/frontend/src/i18n/locales/ja/escoba.json
@@ -21,7 +21,9 @@
     "stockRemaining": "山札残り{{count}}枚",
     "cpuStats": "手札{{cards}}枚 / 捕獲{{captured}}枚 / エスコバ{{escoba}}",
     "humanStats": "手札{{cards}}枚 / 捕獲{{captured}}枚 / エスコバ{{escoba}}",
-    "playerScore": "P{{id}}: {{score}}pt"
+    "playerScore": "P{{id}}: {{score}}pt",
+    "escobaBadge": "エスコバ！",
+    "escobaBadgeOwn": "エスコバ！ あなた"
   },
   "captured": {
     "title": "獲得した札",

--- a/frontend/src/pages/EscobaPage.test.tsx
+++ b/frontend/src/pages/EscobaPage.test.tsx
@@ -299,6 +299,41 @@ describe('EscobaPage', () => {
     expect(counter).toHaveTextContent('16 / 15');
     expect(counter.className).toContain('text-ds-error');
   });
+
+  it('does not show the escoba badge on initial load', async () => {
+    localStorage.clear();
+    mockExec.mockReset();
+    mockExec.mockResolvedValue(makeEscobaState());
+    renderWithProviders(<EscobaPage />);
+    await waitFor(() => expect(screen.getByTestId('hand-card-0')).toBeInTheDocument());
+    expect(screen.queryByTestId('escoba-celebration')).not.toBeInTheDocument();
+  });
+
+  it('flashes the badge when a sweep lands, and clears it when the round resets', async () => {
+    localStorage.clear();
+    mockExec.mockReset();
+    mockExec.mockResolvedValue(makeEscobaState());
+    renderWithProviders(<EscobaPage />);
+    await waitFor(() => expect(screen.getByTestId('hand-card-0')).toBeInTheDocument());
+
+    // The human sweeps: escobaCount rises from 0 to 1.
+    const swept = makeEscobaState();
+    swept.players = swept.players.map((p) => (p.isHuman ? { ...p, escobaCount: 1 } : p));
+    mockExec.mockResolvedValue(swept);
+    fireEvent.click(screen.getByTestId('hand-card-0'));
+    fireEvent.click(screen.getByTestId('table-card-0'));
+    fireEvent.click(screen.getByTestId('take-button'));
+    const badge = await screen.findByTestId('escoba-celebration');
+    // Escoba has no teams, so the emphasised label is the human's own sweep.
+    expect(badge).toHaveTextContent('エスコバ！ あなた');
+
+    // A new round drops the count back to 0; the badge must not linger or re-fire.
+    mockExec.mockResolvedValue(makeEscobaState());
+    fireEvent.click(screen.getByTestId('hand-card-0'));
+    fireEvent.click(screen.getByTestId('table-card-0'));
+    fireEvent.click(screen.getByTestId('take-button'));
+    await waitFor(() => expect(screen.queryByTestId('escoba-celebration')).not.toBeInTheDocument());
+  });
 });
 
 describe('escoba capture-sum helpers', () => {

--- a/frontend/src/pages/EscobaPage.tsx
+++ b/frontend/src/pages/EscobaPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
 import { CliToggle } from '../components/cli/CliToggle';
@@ -17,6 +17,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useEscobaGame } from '../hooks/useEscobaGame';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useSound } from '../providers/SoundProvider';
 import { gameTheme } from '../styles/gameTheme';
 import type { Card, EscobaResponse } from '../types/card';
 import type { TutorialStep } from '../types/tutorial';
@@ -120,6 +121,43 @@ function EscobaPageContent() {
     retry,
   } = useEscobaGame();
   const { cardWidth } = useCardDimensions();
+
+  const { playSound } = useSound();
+  // Flash a badge and a click when any player's escobaCount rises — sweeping the
+  // table is the game's highlight and is easy to miss amid fast CPU turns, which
+  // is why Scopone got the same treatment (#3464). Escoba is free-for-all, so
+  // "own" is simply the human rather than a partner team. escobaCount resets to 0
+  // each round, so a drop clears a stale badge instead of re-firing (#4768).
+  const [escobaCelebration, setEscobaCelebration] = useState<{ key: number; own: boolean } | null>(null);
+  const prevEscobaRef = useRef<number[] | null>(null);
+  useEffect(() => {
+    if (!state) return;
+    const current = state.players.map((p) => p.escobaCount);
+    const prev = prevEscobaRef.current;
+    prevEscobaRef.current = current;
+    if (prev === null || prev.length !== current.length) {
+      if (prev !== null) setEscobaCelebration(null);
+      return;
+    }
+    let gain = false;
+    let own = false;
+    let dropped = false;
+    for (let i = 0; i < current.length; i++) {
+      const delta = (current[i] ?? 0) - (prev[i] ?? 0);
+      if (delta > 0) {
+        gain = true;
+        if (state.players[i]?.isHuman) own = true;
+      } else if (delta < 0) {
+        dropped = true;
+      }
+    }
+    if (gain) {
+      setEscobaCelebration((c) => ({ key: (c?.key ?? 0) + 1, own }));
+      playSound('chipClick', { pitchVariation: 0.1 });
+    } else if (dropped) {
+      setEscobaCelebration(null);
+    }
+  }, [state, playSound]);
 
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('escoba');
   const cliConfig: CliGameConfig<EscobaResponse, EscobaCliArgs> = useMemo(
@@ -226,7 +264,25 @@ function EscobaPageContent() {
             </div>
 
             {/* Table cards */}
-            <div className="py-3 bg-black/20 rounded-lg" data-tutorial="es-table-cards">
+            <div className="relative py-3 bg-black/20 rounded-lg" data-tutorial="es-table-cards">
+              {escobaCelebration && (
+                <div
+                  key={escobaCelebration.key}
+                  className="absolute inset-x-0 -top-3 z-10 flex justify-center motion-safe:animate-bounce pointer-events-none"
+                  role="status"
+                  data-testid="escoba-celebration"
+                >
+                  <span
+                    className={`rounded-full px-3 py-0.5 text-sm font-bold shadow-lg ${
+                      escobaCelebration.own
+                        ? 'bg-ds-accent text-ds-text-on-accent ring-2 ring-ds-accent'
+                        : 'bg-ds-info text-white'
+                    }`}
+                  >
+                    {escobaCelebration.own ? t('label.escobaBadgeOwn') : t('label.escobaBadge')}
+                  </span>
+                </div>
+              )}
               {selectionSum !== null && (
                 <div
                   role="status"

--- a/frontend/src/pages/EscobaPage.tsx
+++ b/frontend/src/pages/EscobaPage.tsx
@@ -29,6 +29,7 @@ import {
 } from '../utils/cli/commands/escobaCommands';
 import type { CliGameConfig } from '../utils/cli/types';
 import { hintCheckboxItem } from '../utils/settingsItems';
+import { sweepCelebration } from '../utils/sweepCelebration';
 
 const DIFFICULTY_OPTIONS = [
   { value: '0', label: 'Easy' },
@@ -135,26 +136,11 @@ function EscobaPageContent() {
     const current = state.players.map((p) => p.escobaCount);
     const prev = prevEscobaRef.current;
     prevEscobaRef.current = current;
-    if (prev === null || prev.length !== current.length) {
-      if (prev !== null) setEscobaCelebration(null);
-      return;
-    }
-    let gain = false;
-    let own = false;
-    let dropped = false;
-    for (let i = 0; i < current.length; i++) {
-      const delta = (current[i] ?? 0) - (prev[i] ?? 0);
-      if (delta > 0) {
-        gain = true;
-        if (state.players[i]?.isHuman) own = true;
-      } else if (delta < 0) {
-        dropped = true;
-      }
-    }
-    if (gain) {
-      setEscobaCelebration((c) => ({ key: (c?.key ?? 0) + 1, own }));
+    const action = sweepCelebration(prev, current, (i) => state.players[i]?.isHuman === true);
+    if (action.kind === 'fire') {
+      setEscobaCelebration((c) => ({ key: (c?.key ?? 0) + 1, own: action.own }));
       playSound('chipClick', { pitchVariation: 0.1 });
-    } else if (dropped) {
+    } else if (action.kind === 'clear') {
       setEscobaCelebration(null);
     }
   }, [state, playSound]);

--- a/frontend/src/pages/ScoponePage.tsx
+++ b/frontend/src/pages/ScoponePage.tsx
@@ -31,6 +31,7 @@ import {
 import type { CliGameConfig } from '../utils/cli/types';
 import { scoponeSelectionSum } from '../utils/scoponeSelectionSum';
 import { hintCheckboxItem } from '../utils/settingsItems';
+import { sweepCelebration } from '../utils/sweepCelebration';
 
 const DIFFICULTY_OPTIONS = [
   { value: '0', label: 'Easy' },
@@ -121,29 +122,12 @@ function ScoponePageContent() {
     const current = state.players.map((p) => p.scopaCount);
     const prev = prevScopaRef.current;
     prevScopaRef.current = current;
-    if (prev === null || prev.length !== current.length) {
-      // First render or a player-count change: seed the baseline without firing.
-      if (prev !== null) setScopaCelebration(null);
-      return;
-    }
     const humanTeam = state.players.find((p) => p.isHuman)?.team ?? -1;
-    let gain = false;
-    let own = false;
-    let dropped = false;
-    for (let i = 0; i < current.length; i++) {
-      const delta = current[i] - prev[i];
-      if (delta > 0) {
-        gain = true;
-        if (state.players[i].team === humanTeam) own = true;
-      } else if (delta < 0) {
-        dropped = true;
-      }
-    }
-    if (gain) {
-      setScopaCelebration((c) => ({ key: (c?.key ?? 0) + 1, own }));
+    const action = sweepCelebration(prev, current, (i) => state.players[i]?.team === humanTeam);
+    if (action.kind === 'fire') {
+      setScopaCelebration((c) => ({ key: (c?.key ?? 0) + 1, own: action.own }));
       playSound('chipClick', { pitchVariation: 0.1 });
-    } else if (dropped) {
-      // A reset / next round drops scopaCount back to 0; clear the stale badge.
+    } else if (action.kind === 'clear') {
       setScopaCelebration(null);
     }
   }, [state, playSound]);

--- a/frontend/src/utils/sweepCelebration.test.ts
+++ b/frontend/src/utils/sweepCelebration.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { sweepCelebration } from './sweepCelebration';
+
+const nobody = () => false;
+const everybody = () => true;
+
+describe('sweepCelebration', () => {
+  it('stays quiet on the first update, seeding the baseline', () => {
+    expect(sweepCelebration(null, [0, 0, 0, 0], nobody)).toEqual({ kind: 'none' });
+  });
+
+  it('stays quiet when nothing changed', () => {
+    expect(sweepCelebration([1, 0], [1, 0], nobody)).toEqual({ kind: 'none' });
+  });
+
+  it('fires when any counter rises', () => {
+    expect(sweepCelebration([0, 0], [0, 1], nobody)).toEqual({ kind: 'fire', own: false });
+  });
+
+  it('marks the viewer’s own sweep', () => {
+    expect(sweepCelebration([0, 0], [1, 0], (i) => i === 0)).toEqual({ kind: 'fire', own: true });
+  });
+
+  it('does not mark someone else’s sweep as the viewer’s', () => {
+    expect(sweepCelebration([0, 0], [0, 1], (i) => i === 0)).toEqual({ kind: 'fire', own: false });
+  });
+
+  it('clears on a drop, which is a new round rather than a sweep', () => {
+    expect(sweepCelebration([2, 1], [0, 0], everybody)).toEqual({ kind: 'clear' });
+  });
+
+  it('prefers firing when one counter rises while another resets', () => {
+    // A simultaneous deal boundary must not swallow a sweep that just landed.
+    expect(sweepCelebration([0, 3], [1, 0], (i) => i === 0)).toEqual({ kind: 'fire', own: true });
+  });
+
+  it('clears when the player count changes rather than firing on noise', () => {
+    expect(sweepCelebration([0, 0], [0, 0, 0], nobody)).toEqual({ kind: 'clear' });
+  });
+});

--- a/frontend/src/utils/sweepCelebration.ts
+++ b/frontend/src/utils/sweepCelebration.ts
@@ -1,0 +1,45 @@
+/** What a page should do with its sweep badge after a state update. */
+export type SweepCelebration =
+  | { kind: 'none' }
+  /** A sweep landed. `own` marks it as the local player's (or their team's). */
+  | { kind: 'fire'; own: boolean }
+  /** A counter dropped — a new round — so any showing badge is stale. */
+  | { kind: 'clear' };
+
+/**
+ * Decide whether a sweep badge should fire, clear, or stay put.
+ *
+ * Sweeping the table is the highlight of the Scopa family and is easy to miss
+ * amid fast CPU turns, so it is announced rather than left to the statistics
+ * row. The counters reset to zero each round, which is a drop rather than a
+ * sweep and must clear a stale badge instead of re-firing it.
+ * @param prev - Per-player sweep counts from the previous update, or null on the first.
+ * @param current - Per-player sweep counts now.
+ * @param isOwn - Whether the player at an index counts as the viewer's own.
+ * @returns The action to take.
+ */
+export function sweepCelebration(
+  prev: readonly number[] | null,
+  current: readonly number[],
+  isOwn: (index: number) => boolean,
+): SweepCelebration {
+  // First update, or the player count changed: re-seed without firing, and drop
+  // any badge left over from the previous shape.
+  if (prev === null) return { kind: 'none' };
+  if (prev.length !== current.length) return { kind: 'clear' };
+
+  let gain = false;
+  let own = false;
+  let dropped = false;
+  for (let i = 0; i < current.length; i += 1) {
+    const delta = (current[i] as number) - (prev[i] as number);
+    if (delta > 0) {
+      gain = true;
+      if (isOwn(i)) own = true;
+    } else if (delta < 0) {
+      dropped = true;
+    }
+  }
+  if (gain) return { kind: 'fire', own };
+  return dropped ? { kind: 'clear' } : { kind: 'none' };
+}


### PR DESCRIPTION
## 変更

`ScoponePage` は `scopaCount` の増加を検知してバウンスするバッジと効果音を出します（#3464「CPUの手番が速く見逃しやすい」）。`EscobaPage` は**同じドメインの `ScopaPlayer` 由来の `escobaCount`** を統計として表示するだけで、`useSound` の import すらありませんでした。テーブル一掃という同じハイライト瞬間が、片方だけ見逃しやすいままです。

Scopone の仕組み（state・useEffect・トースト・効果音）を移植しました。

**エスコバはチーム戦ではない**（`EscobaPlayerData` に team が無く、コメントにも free-for-all とある）ので、強調表示の条件は「自分のチーム」ではなく **`isHuman`** にしています。

## テストプラン

- [x] 初期表示ではバッジが出ないこと
- [x] `escobaCount` が 0→1 で「エスコバ！ あなた」が出ること
- [x] **ラウンドリセットで 1→0 に戻ったとき、バッジが消えること**（再点灯しないこと）
- [x] **負のコントロール実測**: testid を潰すとテストが落ちることを確認
- [x] `bunx vitest run src/pages/EscobaPage.test.tsx`: 26 passed
- [x] `bun run check` / `bun run typecheck`

Closes #4768