### PR TITLE
feat(ui): show which cards the hint means, not just that it has one

### DIFF
--- a/frontend/src/pages/ChineseTenPage.test.tsx
+++ b/frontend/src/pages/ChineseTenPage.test.tsx
@@ -132,4 +132,34 @@ describe('ChineseTenPage', () => {
       await waitFor(() => expect(screen.getAllByText(text).length).toBeGreaterThan(0));
     }
   });
+
+  it('rings the table card the hint says to take, once the hint is requested', async () => {
+    localStorage.clear();
+    localStorage.setItem('hint_enabled_chineseten', 'true');
+    mockExec.mockReset();
+    mockExec.mockResolvedValue(
+      makeState({
+        hint: { cardIndex: 0, layoutIndex: 1, reason: 'chineseten.hint.select' },
+        messageCode: 'chineseten.hintRequested',
+      }),
+    );
+    renderWithProviders(<ChineseTenPage />);
+    await waitFor(() => expect(document.querySelectorAll('[data-hinted-layout]')).toHaveLength(1));
+  });
+
+  it('rings nothing until the hint is requested', async () => {
+    localStorage.clear();
+    localStorage.setItem('hint_enabled_chineseten', 'true');
+    mockExec.mockReset();
+    // Every response carries state.hint since #4483 (#4605).
+    mockExec.mockResolvedValue(
+      makeState({
+        hint: { cardIndex: 0, layoutIndex: 1, reason: 'chineseten.hint.select' },
+        messageCode: 'chineseten.playing',
+      }),
+    );
+    renderWithProviders(<ChineseTenPage />);
+    await waitFor(() => expect(screen.getAllByRole('button').length).toBeGreaterThan(0));
+    expect(document.querySelectorAll('[data-hinted-layout]')).toHaveLength(0);
+  });
 });

--- a/frontend/src/pages/ChineseTenPage.tsx
+++ b/frontend/src/pages/ChineseTenPage.tsx
@@ -28,6 +28,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { CHINESETEN_HELP, parseChineseTenCommand } from '../utils/cli/commands/chinesetenCommands';
 import { formatChineseTenState } from '../utils/cli/formatters/chinesetenFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { isRequestedHint } from '../utils/hintRequest';
 import { hintCheckboxItem } from '../utils/settingsItems';
 
 const CT_TUTORIAL_STEPS: TutorialStep[] = [
@@ -64,6 +65,9 @@ function ChineseTenPageContent() {
     hintEnabled: frontendHintEnabled,
     setHintEnabled: setFrontendHintEnabled,
   } = useGameHint('chineseten', state);
+  // **押していない人にヒントを見せない。**#4483 以降 `Output()` が毎回ヒントを
+  // 載せるので、`state.hint` を直接読むと常時ハイライトになる (#4605)。
+  const showServerHint = frontendHintEnabled && state !== null && isRequestedHint(state);
 
   if (!state) {
     return <GameSkeleton gameKey="chineseten" layout={{ kind: 'tableau', topRow: 4, tableau: 4 }} />;
@@ -170,11 +174,15 @@ function ChineseTenPageContent() {
                       // Kept focusable while it cannot act so the reason is
                       // announced rather than the control leaving the tab order.
                       aria-disabled={!canTake}
+                      data-hinted-layout={(showServerHint && state.hint?.layoutIndex === i) || undefined}
                       onClick={() => canTake && game.handleSelect(i)}
                       className={[
                         'rounded transition-transform',
                         canTake ? 'ring-2 ring-ds-accent hover:-translate-y-1' : '',
                         choosing && !canTake ? 'opacity-50' : '',
+                        // The hint carries layoutIndex — which table card to take —
+                        // and only the hand card was ever ringed (#4881).
+                        showServerHint && state.hint?.layoutIndex === i ? 'ring-2 ring-ds-warning' : '',
                       ].join(' ')}
                     >
                       {renderCard(card, `layout-c${i.toString()}`)}
@@ -216,7 +224,7 @@ function ChineseTenPageContent() {
                     className={[
                       'rounded transition-transform',
                       isHumanTurn && !choosing ? 'hover:-translate-y-2' : 'opacity-60',
-                      frontendHintEnabled && state.hint?.cardIndex === i ? 'ring-2 ring-ds-warning' : '',
+                      showServerHint && state.hint?.cardIndex === i ? 'ring-2 ring-ds-warning' : '',
                     ].join(' ')}
                   >
                     {renderCard(card, `hand-c${i.toString()}`)}

--- a/frontend/src/pages/MachiavelliPage.test.tsx
+++ b/frontend/src/pages/MachiavelliPage.test.tsx
@@ -545,4 +545,34 @@ describe('MachiavelliPage', () => {
       expect(screen.queryByTestId('machiavelli-rearrange-panel')).not.toBeInTheDocument();
     });
   });
+
+  it('rings the cards that form the meld the hint recommends', async () => {
+    localStorage.clear();
+    mockExec.mockReset();
+    mockExec.mockResolvedValue(turnState);
+    const { unmount } = renderWithProviders(<MachiavelliPage />);
+    await waitFor(() => expect(screen.getAllByRole('button').length).toBeGreaterThan(0));
+    // The assist follows the hint setting, which defaults to off.
+    expect(document.querySelectorAll('[data-meld-hint]')).toHaveLength(0);
+    unmount();
+
+    // Three sevens form a set, so with hints on the three cards must ring.
+    localStorage.setItem('hint_enabled_machiavelli', 'true');
+    mockExec.mockResolvedValue({
+      ...turnState,
+      players: [
+        {
+          ...turnState.players[0],
+          cards: [
+            { design: 'SPADE', value: 7 },
+            { design: 'HEART', value: 7 },
+            { design: 'CLOVER', value: 7 },
+          ],
+        },
+        ...turnState.players.slice(1),
+      ],
+    });
+    renderWithProviders(<MachiavelliPage />);
+    await waitFor(() => expect(document.querySelectorAll('[data-meld-hint]')).toHaveLength(3));
+  });
 });

--- a/frontend/src/pages/MachiavelliPage.tsx
+++ b/frontend/src/pages/MachiavelliPage.tsx
@@ -39,6 +39,7 @@ import { valueName } from '../utils/cardUtils';
 import { MACHIAVELLI_HELP, parseMachiavelliCommand } from '../utils/cli/commands/machiavelliCommands';
 import { formatMachiavelliState } from '../utils/cli/formatters/machiavelliFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { findHandMeld } from '../utils/hints/machiavelliHint';
 import { designToNum, evaluateRearrange, isMachiavelliValidMeld } from '../utils/machiavelliRearrange';
 import { playerName } from '../utils/playerUtils';
 import { hintCheckboxItem } from '../utils/settingsItems';
@@ -170,6 +171,16 @@ function MachiavelliPageContent() {
     machiavelliConfig.cpuDifficulty,
     machiavelliConfig.targetRounds,
   ]);
+
+  // getMachiavelliHint already asks findHandMeld which cards form a meld and then
+  // throws the indices away, leaving the hint to say "make a meld" without saying
+  // which cards. Pan rings its candidates; this does the same (#4852).
+  // Above the early return: hooks must not be conditional.
+  const hintHand = state?.players.find((p) => p.isHuman)?.cards;
+  const meldHintIndices = useMemo(
+    () => new Set(frontendHintEnabled && hintHand ? (findHandMeld(hintHand) ?? []) : []),
+    [frontendHintEnabled, hintHand],
+  );
 
   if (!state)
     return (
@@ -524,7 +535,12 @@ function MachiavelliPageContent() {
                     onClick={() => toggleCard(idx)}
                     aria-label={cardAlt(card)}
                     aria-pressed={selectedCardIndices.includes(idx)}
-                    className={`transition-transform ${focusRingCard}`}
+                    data-meld-hint={meldHintIndices.has(idx) || undefined}
+                    className={`transition-transform ${focusRingCard} ${
+                      meldHintIndices.has(idx) && !selectedCardIndices.includes(idx)
+                        ? 'ring-2 ring-ds-success rounded'
+                        : ''
+                    }`}
                     style={{
                       background: 'none',
                       padding: 0,


### PR DESCRIPTION
## 変更

| ゲーム | 現状 | 対応 |
|---|---|---|
| マキャヴェッリ (#4852) | `getMachiavelliHint` が `findHandMeld` でインデックスを得ながら**捨てている** | 手札の該当カードにリング（Pan の `candidateIndices` と同じ形） |
| 撿紅點 (#4881) | ヒントは `layoutIndex`（取るべき場札）を持つのに、手札しかハイライトされない | 場札にもリング |

`findHandMeld` は元から export されているので、ヒントの戻り値を変えずにページから直接呼べます。

## 既存の #4605 バグも直しています

撿紅點の**既存の手札リング**は `frontendHintEnabled && state.hint?.cardIndex === i` で、`isRequestedHint` を通していませんでした。#4483 以降すべてのレスポンスが `state.hint` を載せるので、**ヒントを押していないプレイヤーにも点灯しうる**状態です（#4950 で Scorpion/Wasp を直したのと同型）。新しい場札リングと合わせて `showServerHint` に集約しました。

## テストプラン

- [x] マキャヴェッリ: **ヒントoff→onの両方**を1テストで検証（7が3枚でセット成立 → 3枚がリング）
- [x] 撿紅點: **要求時に光る / 未要求では光らない**の両側
- [x] **負のコントロール実測**: 2実装を無効化すると対応テストが落ちることを確認
- [x] `bunx vitest run` 対象2ファイル: 50 passed
- [x] `bun run check` / `bun run typecheck`

### 途中で踏んだ点

`useMemo` を早期 return の下に置いてしまい、biome の `useHookAtTopLevel` に弾かれました（`frontend/CLAUDE.md` が警告している #4561 と同型）。フックを上へ移動し、`state?.players.find(...)` で防御的に手札を取るようにしています。

Closes #4852
Closes #4881