### PR TITLE
fix(ui): tie the meld ring to the tooltip's verdict, and stop two rings fighting

### DIFF
--- a/frontend/src/pages/ChineseTenPage.tsx
+++ b/frontend/src/pages/ChineseTenPage.tsx
@@ -166,6 +166,7 @@ function ChineseTenPageContent() {
               <div className="flex gap-1 justify-center flex-wrap">
                 {state.layout.map((card, i) => {
                   const canTake = choosing && isHumanTurn && selectable.has(i);
+                  const isHintedLayout = showServerHint && state.hint?.layoutIndex === i;
                   return (
                     <button
                       key={`layout-${i.toString()}`}
@@ -174,15 +175,20 @@ function ChineseTenPageContent() {
                       // Kept focusable while it cannot act so the reason is
                       // announced rather than the control leaving the tab order.
                       aria-disabled={!canTake}
-                      data-hinted-layout={(showServerHint && state.hint?.layoutIndex === i) || undefined}
+                      data-hinted-layout={isHintedLayout || undefined}
                       onClick={() => canTake && game.handleSelect(i)}
                       className={[
                         'rounded transition-transform',
-                        canTake ? 'ring-2 ring-ds-accent hover:-translate-y-1' : '',
-                        choosing && !canTake ? 'opacity-50' : '',
                         // The hint carries layoutIndex — which table card to take —
-                        // and only the hand card was ever ringed (#4881).
-                        showServerHint && state.hint?.layoutIndex === i ? 'ring-2 ring-ds-warning' : '',
+                        // and only the hand card was ever ringed (#4881). Two ring-*
+                        // utilities on one element would fight, so the hint wins
+                        // outright when it names this card.
+                        isHintedLayout
+                          ? 'ring-2 ring-ds-warning'
+                          : canTake
+                            ? 'ring-2 ring-ds-accent hover:-translate-y-1'
+                            : '',
+                        choosing && !canTake ? 'opacity-50' : '',
                       ].join(' ')}
                     >
                       {renderCard(card, `layout-c${i.toString()}`)}

--- a/frontend/src/pages/MachiavelliPage.test.tsx
+++ b/frontend/src/pages/MachiavelliPage.test.tsx
@@ -575,4 +575,30 @@ describe('MachiavelliPage', () => {
     renderWithProviders(<MachiavelliPage />);
     await waitFor(() => expect(document.querySelectorAll('[data-meld-hint]')).toHaveLength(3));
   });
+
+  it('does not ring a meld while it is not the human turn', async () => {
+    localStorage.clear();
+    localStorage.setItem('hint_enabled_machiavelli', 'true');
+    mockExec.mockReset();
+    // Same three sevens, but the CPU is to act — there is no meld to make yet,
+    // so the ring must follow the tooltip's gating rather than the hand alone.
+    mockExec.mockResolvedValue({
+      ...turnState,
+      currentPlayerIdx: 1,
+      players: [
+        {
+          ...turnState.players[0],
+          cards: [
+            { design: 'SPADE', value: 7 },
+            { design: 'HEART', value: 7 },
+            { design: 'CLOVER', value: 7 },
+          ],
+        },
+        ...turnState.players.slice(1),
+      ],
+    });
+    renderWithProviders(<MachiavelliPage />);
+    await waitFor(() => expect(screen.getAllByRole('button').length).toBeGreaterThan(0));
+    expect(document.querySelectorAll('[data-meld-hint]')).toHaveLength(0);
+  });
 });

--- a/frontend/src/pages/MachiavelliPage.tsx
+++ b/frontend/src/pages/MachiavelliPage.tsx
@@ -175,11 +175,19 @@ function MachiavelliPageContent() {
   // getMachiavelliHint already asks findHandMeld which cards form a meld and then
   // throws the indices away, leaving the hint to say "make a meld" without saying
   // which cards. Pan rings its candidates; this does the same (#4852).
+  // Derived from the tooltip's own verdict rather than re-deriving the rules, so
+  // the ring cannot disagree with it: getMachiavelliHint already requires the
+  // human's turn, the TURN phase and a live game before suggesting a meld.
   // Above the early return: hooks must not be conditional.
   const hintHand = state?.players.find((p) => p.isHuman)?.cards;
   const meldHintIndices = useMemo(
-    () => new Set(frontendHintEnabled && hintHand ? (findHandMeld(hintHand) ?? []) : []),
-    [frontendHintEnabled, hintHand],
+    () =>
+      new Set(
+        frontendHintEnabled && frontendHint?.targetAction === 'newMeld' && hintHand
+          ? (findHandMeld(hintHand) ?? [])
+          : [],
+      ),
+    [frontendHintEnabled, frontendHint, hintHand],
   );
 
   if (!state)


### PR DESCRIPTION
## 背景

#4963 のレビュー指摘2件です。**指摘が届いた時点で既にマージ済み**だったため、追いかけて修正します。

## 1. マキャヴェッリのリングがツールチップより緩かった（Must fix）

`meldHintIndices` は `frontendHintEnabled` だけで判定していましたが、`getMachiavelliHint` は加えて

- `state.currentPlayerIdx === humanIdx`
- `state.phase === MachiavelliPhase.TURN`
- `!state.gameEndFlag`

を要求します。そのため**CPU の手番中やラウンド終了後でも、手札にセット/ランがあればリングが点灯**していました。実際にはメルドできない局面です。

`frontendHint?.targetAction === 'newMeld'` から導出する形に変え、**ツールチップと食い違えない**ようにしました。CPU 手番のテストを追加し、修正前のロジックでは落ちることを実測しています。

## 2. 撿紅點で ring-2 が2つ重なっていた

`canTake` の `ring-2 ring-ds-accent` と、新しい `ring-2 ring-ds-warning` が同じ要素に並んでおり、**どちらが出るかはスタイルシートの順序次第**でした。ヒントが指しているカードではヒント色が確実に勝つよう、排他にしています。

## テストプラン

- [x] CPU 手番でリングが出ないことを検証（**負のコントロール実測**: 旧ロジックに戻すと落ちる）
- [x] 既存の on/off 両側テストは維持
- [x] `bunx vitest run` 対象2ファイル: 51 passed
- [x] `bun run check` / `bun run typecheck`