### PR TITLE
feat(pontoon): let the player choose the buy stake, as the CUI already can

### DIFF
--- a/frontend/src/i18n/locales/en/pontoon.json
+++ b/frontend/src/i18n/locales/en/pontoon.json
@@ -27,7 +27,9 @@
     "bankerTwist": "Draw",
     "bankerStay": "Stop",
     "deal": "Deal",
-    "nextRound": "Next round"
+    "nextRound": "Next round",
+    "buyAmount": "Buy stake",
+    "buyRange": "{{min}}–{{max}} chips"
   },
   "hint": {
     "stick": "Only on a total of 15 or more",

--- a/frontend/src/i18n/locales/ja/pontoon.json
+++ b/frontend/src/i18n/locales/ja/pontoon.json
@@ -27,7 +27,9 @@
     "bankerTwist": "引く",
     "bankerStay": "止める",
     "deal": "配る",
-    "nextRound": "次の局へ"
+    "nextRound": "次の局へ",
+    "buyAmount": "バイ額",
+    "buyRange": "{{min}}〜{{max}}チップ"
   },
   "hint": {
     "stick": "合計15以上でのみ宣言できます",

--- a/frontend/src/pages/PontoonPage.test.tsx
+++ b/frontend/src/pages/PontoonPage.test.tsx
@@ -229,6 +229,32 @@ describe('PontoonPage', () => {
     fireEvent.click(screen.getByRole('button', { name: /CLI/i }));
     await waitFor(() => expect(screen.queryByRole('button', { name: 'ツイスト' })).not.toBeInTheDocument());
   });
+
+  it('offers every legal buy stake, up to twice the current bet', async () => {
+    localStorage.clear();
+    mockExec.mockReset();
+    mockExec.mockResolvedValue(makeState({ canBuy: true }));
+    renderWithProviders(<PontoonPage />);
+    const select = (await screen.findByTestId('pontoon-buy-amount')) as HTMLSelectElement;
+    // Pontoon.Buy accepts PontoonMinBet..bet*2; the stake here is 100.
+    const offered = Array.from(select.options).map((o) => Number(o.value));
+    expect(offered[0]).toBe(10);
+    expect(offered[offered.length - 1]).toBe(200);
+    // The default is the current stake, which is what the page always sent.
+    expect(Number(select.value)).toBe(100);
+  });
+
+  it('buys for the chosen stake rather than always the minimum', async () => {
+    localStorage.clear();
+    mockExec.mockReset();
+    mockExec.mockResolvedValue(makeState({ canBuy: true }));
+    renderWithProviders(<PontoonPage />);
+    const select = await screen.findByTestId('pontoon-buy-amount');
+    fireEvent.change(select, { target: { value: '150' } });
+    mockExec.mockClear();
+    fireEvent.click(screen.getByRole('button', { name: 'バイ' }));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('buy', 150));
+  });
 });
 
 // Keyboard shortcuts are bound by useActionKeyboardNav and advertised by

--- a/frontend/src/pages/PontoonPage.tsx
+++ b/frontend/src/pages/PontoonPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import type { pontoonApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { ActionShortcutsPanel } from '../components/ActionShortcutsPanel';
@@ -53,6 +53,16 @@ function rankLabelKey(rank: number): string | null {
   return null;
 }
 
+/** Domain floor for any stake (`PontoonMinBet`). */
+const PONTOON_MIN_BET = 10;
+
+/** Stakes offered between the floor and twice the current bet, in floor-sized steps. */
+function buyChoices(maxBuy: number): number[] {
+  const out: number[] = [];
+  for (let v = PONTOON_MIN_BET; v <= maxBuy; v += PONTOON_MIN_BET) out.push(v);
+  return out.length > 0 ? out : [PONTOON_MIN_BET];
+}
+
 function PontoonPageContent() {
   const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
     useGamePageSetup('pontoon');
@@ -74,13 +84,19 @@ function PontoonPageContent() {
 
   const isPlayerTurn = state?.phase === PontoonPhase.PLAYER_TURN;
 
-  // Buy raises by the current bet, which is the smallest legal raise. The
-  // backend accepts anything from the minimum up to twice the stake; offering
-  // one sensible amount keeps the control simple.
+  // Pontoon.Buy accepts anything from PontoonMinBet up to twice the current
+  // stake, and the CUI's `buy <amount>` has always exposed that. The web page
+  // sent the minimum every time, so the choice existed only in the CUI (#4878).
+  const activeBet = state?.seats[0]?.hands[state.activeHand]?.bet ?? PONTOON_MIN_BET;
+  const maxBuy = Math.max(PONTOON_MIN_BET, activeBet * 2);
+  // Null means "follow the stake", which is what the page always sent before, so
+  // the default action is unchanged and the range is purely additive.
+  const [buyAmount, setBuyAmount] = useState<number | null>(null);
+  const clampedBuy = Math.min(Math.max(buyAmount ?? activeBet, PONTOON_MIN_BET), maxBuy);
+
   const handleBuyOnce = useCallback(() => {
-    const hand = state?.seats[0]?.hands[state.activeHand];
-    game.handleBuy(hand?.bet ?? 10);
-  }, [game, state]);
+    game.handleBuy(clampedBuy);
+  }, [game, clampedBuy]);
 
   const actionBindings = useMemo(
     () => [
@@ -310,6 +326,24 @@ function PontoonPageContent() {
                 >
                   {t('actions.twist')}
                 </button>
+              )}
+              {isPlayerTurn && state.canBuy && (
+                <label className="flex items-center gap-1 text-xs text-ds-text-muted">
+                  <span>{t('actions.buyAmount')}</span>
+                  <select
+                    className="rounded bg-ds-surface-elevated text-ds-text-primary px-1 py-0.5 min-h-11"
+                    value={clampedBuy}
+                    onChange={(e) => setBuyAmount(Number(e.target.value))}
+                    data-testid="pontoon-buy-amount"
+                    aria-label={t('actions.buyRange', { min: PONTOON_MIN_BET, max: maxBuy })}
+                  >
+                    {buyChoices(maxBuy).map((v) => (
+                      <option key={v} value={v}>
+                        {v}
+                      </option>
+                    ))}
+                  </select>
+                </label>
               )}
               {isPlayerTurn && state.canBuy && (
                 <button


### PR DESCRIPTION
## 変更

`Pontoon.Buy(extra)` は `PontoonMinBet`（10）から **現在の賭け金の2倍**まで受け付けます。ところが `handleBuyOnce` は常に `hand.bet` を渡すだけで、**ページ自身のコメントに「backend accepts anything from the minimum up to twice the stake」と書きながら**選択肢を出していませんでした。CUI の `buy <amount>` では任意額を指定できるため、**同じゲームで CUI にだけ戦略的選択肢がある**状態でした。

10刻みで全範囲を選べるセレクトを追加しています。

## 既定値は変えていません

既定は**現在の賭け金**＝これまで送っていた額そのものです。最小額に落とすと既存の挙動が変わるので、**範囲の追加は純粋に加算的**にしました（既存テスト `buys for the current stake` はそのまま通ります）。手が変わって賭け金が動いたときは、選択値を範囲内にクランプします。

## テストプラン

- [x] 選択肢が 10〜200（賭け金100の2倍）で、既定が100であることを検証
- [x] 150 を選ぶと `('buy', 150)` が送られることを検証
- [x] **負のコントロール実測**: 常に `activeBet` を送る実装に戻すと後者が落ちる
- [x] `bunx vitest run src/pages/PontoonPage.test.tsx`: 27 passed
- [x] `bun run check` / `bun run typecheck`

Closes #4878