### PR TITLE
refactor(pontoon): move the buy range into a bet util, dropping a dead branch

### DIFF
--- a/frontend/src/pages/PontoonPage.tsx
+++ b/frontend/src/pages/PontoonPage.tsx
@@ -30,6 +30,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { PONTOON_HELP, parsePontoonCommand } from '../utils/cli/commands/pontoonCommands';
 import { formatPontoonState } from '../utils/cli/formatters/pontoonFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { PONTOON_MIN_BET, pontoonBuyChoices, pontoonClampBuy, pontoonMaxBuy } from '../utils/pontoonBet';
 
 const BET_OPTIONS = [10, 50, 100, 500];
 
@@ -51,16 +52,6 @@ function rankLabelKey(rank: number): string | null {
   if (rank === PontoonRank.FIVE_CARD) return 'rank.fiveCard';
   if (rank === PontoonRank.BUST) return 'rank.bust';
   return null;
-}
-
-/** Domain floor for any stake (`PontoonMinBet`). */
-const PONTOON_MIN_BET = 10;
-
-/** Stakes offered between the floor and twice the current bet, in floor-sized steps. */
-function buyChoices(maxBuy: number): number[] {
-  const out: number[] = [];
-  for (let v = PONTOON_MIN_BET; v <= maxBuy; v += PONTOON_MIN_BET) out.push(v);
-  return out.length > 0 ? out : [PONTOON_MIN_BET];
 }
 
 function PontoonPageContent() {
@@ -88,11 +79,12 @@ function PontoonPageContent() {
   // stake, and the CUI's `buy <amount>` has always exposed that. The web page
   // sent the minimum every time, so the choice existed only in the CUI (#4878).
   const activeBet = state?.seats[0]?.hands[state.activeHand]?.bet ?? PONTOON_MIN_BET;
-  const maxBuy = Math.max(PONTOON_MIN_BET, activeBet * 2);
   // Null means "follow the stake", which is what the page always sent before, so
-  // the default action is unchanged and the range is purely additive.
+  // the default action is unchanged and the range is purely additive. A chosen
+  // stake persists across hands (as bet controls elsewhere do) but is clamped,
+  // so it can never become illegal when the next hand's stake differs.
   const [buyAmount, setBuyAmount] = useState<number | null>(null);
-  const clampedBuy = Math.min(Math.max(buyAmount ?? activeBet, PONTOON_MIN_BET), maxBuy);
+  const clampedBuy = pontoonClampBuy(buyAmount, activeBet);
 
   const handleBuyOnce = useCallback(() => {
     game.handleBuy(clampedBuy);
@@ -335,9 +327,9 @@ function PontoonPageContent() {
                     value={clampedBuy}
                     onChange={(e) => setBuyAmount(Number(e.target.value))}
                     data-testid="pontoon-buy-amount"
-                    aria-label={t('actions.buyRange', { min: PONTOON_MIN_BET, max: maxBuy })}
+                    aria-label={t('actions.buyRange', { min: PONTOON_MIN_BET, max: pontoonMaxBuy(activeBet) })}
                   >
-                    {buyChoices(maxBuy).map((v) => (
+                    {pontoonBuyChoices(activeBet).map((v) => (
                       <option key={v} value={v}>
                         {v}
                       </option>

--- a/frontend/src/utils/pontoonBet.test.ts
+++ b/frontend/src/utils/pontoonBet.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { PONTOON_MIN_BET, pontoonBuyChoices, pontoonClampBuy, pontoonMaxBuy } from './pontoonBet';
+
+describe('pontoonMaxBuy', () => {
+  it('is twice the current bet', () => {
+    expect(pontoonMaxBuy(100)).toBe(200);
+  });
+
+  it('never drops below the floor, even at a zero bet', () => {
+    expect(pontoonMaxBuy(0)).toBe(PONTOON_MIN_BET);
+  });
+});
+
+describe('pontoonBuyChoices', () => {
+  it('walks the floor to twice the bet in floor-sized steps', () => {
+    expect(pontoonBuyChoices(30)).toEqual([10, 20, 30, 40, 50, 60]);
+  });
+
+  it('still offers the floor when the bet is below it', () => {
+    expect(pontoonBuyChoices(0)).toEqual([PONTOON_MIN_BET]);
+  });
+});
+
+describe('pontoonClampBuy', () => {
+  it('follows the current bet when nothing was chosen', () => {
+    expect(pontoonClampBuy(null, 100)).toBe(100);
+  });
+
+  it('keeps a legal choice', () => {
+    expect(pontoonClampBuy(150, 100)).toBe(150);
+  });
+
+  it('pulls a choice down when the next hand has a smaller stake', () => {
+    // Picked 150 on a 100 hand, then the stake drops to 20: 40 is the new ceiling.
+    expect(pontoonClampBuy(150, 20)).toBe(40);
+  });
+
+  it('pulls a choice up to the floor', () => {
+    expect(pontoonClampBuy(5, 100)).toBe(PONTOON_MIN_BET);
+  });
+});

--- a/frontend/src/utils/pontoonBet.ts
+++ b/frontend/src/utils/pontoonBet.ts
@@ -1,0 +1,39 @@
+/**
+ * Minimum stake for Pontoon. Mirrors the backend `PontoonMinBet` constant in
+ * `internal/domain/Pontoon.go`, so the buy control and the server agree on the
+ * floor without either silently drifting.
+ */
+export const PONTOON_MIN_BET = 10;
+
+/**
+ * Largest stake `Pontoon.Buy` will accept: twice the current bet, never below
+ * the floor. Mirrors the guard `extra < PontoonMinBet || extra > h.bet*2`.
+ * @param currentBet - The stake on the hand being played.
+ * @returns The highest legal buy.
+ */
+export function pontoonMaxBuy(currentBet: number): number {
+  return Math.max(PONTOON_MIN_BET, currentBet * 2);
+}
+
+/**
+ * Every legal buy stake for the current bet, in floor-sized steps.
+ * @param currentBet - The stake on the hand being played.
+ * @returns Ascending stakes from the floor to {@link pontoonMaxBuy}.
+ */
+export function pontoonBuyChoices(currentBet: number): number[] {
+  const max = pontoonMaxBuy(currentBet);
+  const out: number[] = [];
+  for (let v = PONTOON_MIN_BET; v <= max; v += PONTOON_MIN_BET) out.push(v);
+  return out;
+}
+
+/**
+ * Bring a chosen stake inside the legal range for the current bet, so a choice
+ * made on one hand cannot become illegal when the next hand's stake differs.
+ * @param chosen - The player's chosen stake, or null to follow the current bet.
+ * @param currentBet - The stake on the hand being played.
+ * @returns A stake the server will accept.
+ */
+export function pontoonClampBuy(chosen: number | null, currentBet: number): number {
+  return Math.min(Math.max(chosen ?? currentBet, PONTOON_MIN_BET), pontoonMaxBuy(currentBet));
+}


### PR DESCRIPTION
## 背景

#4967 のレビュー nit 3件です（マージ済みのため追いかけ）。

## 1. 既存の慣習に合わせて `src/utils/*Bet.ts` へ

`blackjackBet.ts` / `reddogBet.ts` / `utHoldemBet.ts` と同じく、賭け金の算術は**独立してテストできるモジュール**に置く慣習でした。ページ内にインラインで書いていたので移動しています。

副産物として、**ページテストでは作りにくいケース**を単体テストで固定できました:
- 賭け金 0（下限を下回る）のとき
- **賭け金100の手で150を選び、次の手の賭け金が20になったとき** → 上限40にクランプ

## 2. 到達不能な分岐を削除

`out.length > 0 ? out : [PONTOON_MIN_BET]` の false 側は、`maxBuy` が常に下限以上なのでループが必ず1回は回るため**到達しません**でした。削除しています。

## 3. 選択の持ち越しは意図的（コメント追加）

一度選んだ額は次の手にも持ち越されます。他の賭け金コントロールと同じ挙動で、**クランプがあるので不正にはなりません**。意図が読めるようコメントを追加しました。

## テストプラン

- [x] `pontoonBet.ts` に単体テスト8本
- [x] 既存のページテスト（範囲・選択額の送信）はそのまま通過
- [x] `bunx vitest run` 対象2ファイル: 35 passed
- [x] `bun run check` / `bun run typecheck`