### PR TITLE
feat(kalooki): total the staged melds against the opening requirement

### DIFF
--- a/frontend/src/i18n/locales/en/kalooki.json
+++ b/frontend/src/i18n/locales/en/kalooki.json
@@ -49,5 +49,6 @@
     "kalookiDrawStock": "The discard connects with nothing — draw from the stock",
     "kalookiDiscardHeavy": "Your heaviest unconnected card",
     "kalookiOpenFirst": "You have not opened yet — the threshold has to be met in one go, so keep building"
-  }
+  },
+  "openingProgress": "Opening: {{points}} / {{threshold}} points"
 }

--- a/frontend/src/i18n/locales/ja/kalooki.json
+++ b/frontend/src/i18n/locales/ja/kalooki.json
@@ -49,5 +49,6 @@
     "kalookiDrawStock": "捨て札は手札と繋がりません。山から引きましょう",
     "kalookiDiscardHeavy": "繋がっていない札のうち一番重い札です",
     "kalookiOpenFirst": "まだ開いていません。規定点を一度に満たす組を作りましょう"
-  }
+  },
+  "openingProgress": "オープニング: {{points}} / {{threshold}} 点"
 }

--- a/frontend/src/pages/KalookiPage.test.tsx
+++ b/frontend/src/pages/KalookiPage.test.tsx
@@ -375,4 +375,20 @@ describe('KalookiPage', () => {
     fireEvent.click(toggle);
     expect(await screen.findByTestId('hint-tooltip')).toBeInTheDocument();
   });
+
+  it('totals the staged groups against the opening threshold', async () => {
+    mockExec.mockResolvedValue(meldState);
+    renderWithProviders(<KalookiPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: /Add group|グループに追加/ })).toBeInTheDocument());
+    // Nothing staged yet.
+    expect(screen.getByTestId('kalooki-opening-progress')).toHaveTextContent('0 / 51');
+
+    stageGroup(0, 3); // three 5s = 15
+    expect(screen.getByTestId('kalooki-opening-progress')).toHaveTextContent('15 / 51');
+
+    stageGroup(3, 3); // three kings = 30, so 45 — still short of 51
+    const progress = screen.getByTestId('kalooki-opening-progress');
+    expect(progress).toHaveTextContent('45 / 51');
+    expect(progress.className).not.toContain('text-ds-success');
+  });
 });

--- a/frontend/src/pages/KalookiPage.tsx
+++ b/frontend/src/pages/KalookiPage.tsx
@@ -30,6 +30,7 @@ import { cardAlt } from '../utils/cardAlt';
 import { KALOOKI_HELP, parseKalookiCommand } from '../utils/cli/commands/kalookiCommands';
 import { formatKalookiState } from '../utils/cli/formatters/kalookiFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { kalookiOpeningPoints } from '../utils/kalookiScore';
 import { hintCheckboxItem } from '../utils/settingsItems';
 
 /** Phase identifiers for Kalooki (sync: internal/domain/Kalooki.go). */
@@ -112,11 +113,21 @@ function KalookiPageContent() {
   const [selectedCards, setSelectedCards] = useState<number[]>([]);
   // Meld groups being assembled (one card-index group per meld).
   const [meldGroups, setMeldGroups] = useState<number[][]>([]);
+
   // Layoff target: { playerIdx, meldIdx }.
   const [layoffTarget, setLayoffTarget] = useState<{ playerIdx: number; meldIdx: number } | null>(null);
 
   const humanIdx = 0;
   const humanPlayer = state?.players[humanIdx];
+  // Points the staged groups are worth toward the opening requirement. Hand and
+  // Foot shows the same readout; Kalooki only stated the target (#4839).
+  const openingPoints = useMemo(
+    () =>
+      kalookiOpeningPoints(
+        meldGroups.map((g) => g.map((i) => humanPlayer?.cards[i]).filter((card): card is Card => card !== undefined)),
+      ),
+    [meldGroups, humanPlayer],
+  );
   const isHumanTurn = state?.currentPlayerIdx === humanIdx && !state?.gameEndFlag;
   const isDrawPhase = isHumanTurn && state?.phase === KALOOKI_PHASE.DRAW;
   const isMeldPhase = isHumanTurn && state?.phase === KALOOKI_PHASE.MELD;
@@ -312,8 +323,20 @@ function KalookiPageContent() {
             </section>
 
             {isMeldPhase && humanPlayer && !humanPlayer.hasOpened && (
-              <section className="px-4 py-1 text-sm text-ds-warning" data-testid="kalooki-opening-hint">
-                {t('openingHint', { n: state.openingThreshold })}
+              <section className="px-4 py-1 text-sm" data-testid="kalooki-opening-hint">
+                <span className="text-ds-warning">{t('openingHint', { n: state.openingThreshold })}</span>{' '}
+                {/* The joker bonus applies per meld, so the running total is not
+                    the sum of the card values a player can add up by eye (#4839). */}
+                <span
+                  role="status"
+                  aria-live="polite"
+                  data-testid="kalooki-opening-progress"
+                  className={`font-bold ${
+                    openingPoints >= state.openingThreshold ? 'text-ds-success' : 'text-ds-text-muted'
+                  }`}
+                >
+                  {t('openingProgress', { points: openingPoints, threshold: state.openingThreshold })}
+                </span>
               </section>
             )}
 

--- a/frontend/src/utils/kalookiScore.test.ts
+++ b/frontend/src/utils/kalookiScore.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import type { Card, CardDesign } from '../types/card';
+import { kalookiCardValue, kalookiMeldValue, kalookiOpeningPoints } from './kalookiScore';
+
+const c = (design: CardDesign, value: number): Card => ({ design, value });
+
+describe('kalookiCardValue', () => {
+  it('scores an ace as 15, not 1', () => {
+    expect(kalookiCardValue(c('SPADE', 1))).toBe(15);
+  });
+
+  it('scores a joker as 15', () => {
+    expect(kalookiCardValue(c('JOKER', 0))).toBe(15);
+  });
+
+  it('scores ten and above as 10', () => {
+    expect([10, 11, 12, 13].map((v) => kalookiCardValue(c('HEART', v)))).toEqual([10, 10, 10, 10]);
+  });
+
+  it('scores the rest at face value', () => {
+    expect([2, 5, 9].map((v) => kalookiCardValue(c('HEART', v)))).toEqual([2, 5, 9]);
+  });
+});
+
+describe('kalookiMeldValue', () => {
+  it('sums a joker-free meld', () => {
+    expect(kalookiMeldValue([c('SPADE', 5), c('HEART', 5), c('CLOVER', 5)])).toBe(15);
+  });
+
+  it('applies the 1.5x joker bonus, floored', () => {
+    // 5 + 5 + 15 = 25 → 37.5 → 37, matching the domain's integer arithmetic.
+    expect(kalookiMeldValue([c('SPADE', 5), c('HEART', 5), c('JOKER', 0)])).toBe(37);
+  });
+});
+
+describe('kalookiOpeningPoints', () => {
+  it('is zero with nothing staged', () => {
+    expect(kalookiOpeningPoints([])).toBe(0);
+  });
+
+  it('adds the melds up, applying the joker bonus per meld rather than overall', () => {
+    const plain = [c('SPADE', 10), c('HEART', 10), c('CLOVER', 10)]; // 30
+    const withJoker = [c('SPADE', 5), c('HEART', 5), c('JOKER', 0)]; // 37
+    expect(kalookiOpeningPoints([plain, withJoker])).toBe(67);
+    // Summing the cards first and then applying one bonus would give 82 — the
+    // mistake a player doing this by eye would make.
+    expect(kalookiOpeningPoints([plain, withJoker])).not.toBe(82);
+  });
+});

--- a/frontend/src/utils/kalookiScore.ts
+++ b/frontend/src/utils/kalookiScore.ts
@@ -1,0 +1,44 @@
+import type { Card } from '../types/card';
+
+/** A joker's point value in Kalooki. Mirrors `KalookiJokerValue`. */
+export const KALOOKI_JOKER_VALUE = 15;
+
+/**
+ * Point value of a single card: joker and ace 15, ten and above 10, otherwise
+ * face value. Mirrors `kalookiCardValue` in `internal/domain/Kalooki.go`.
+ * @param card - The card to score.
+ * @returns Its point value.
+ */
+export function kalookiCardValue(card: Card): number {
+  if (card.design === 'JOKER') return KALOOKI_JOKER_VALUE;
+  if (card.value === 1) return 15;
+  if (card.value >= 10) return 10;
+  return card.value;
+}
+
+/**
+ * Point value of one meld: the sum of its cards, multiplied by 1.5 and floored
+ * when it contains a joker. Mirrors `kalookiMeldValue`.
+ * @param cards - The cards forming the meld.
+ * @returns The meld's points.
+ */
+export function kalookiMeldValue(cards: readonly Card[]): number {
+  const base = cards.reduce((sum, c) => sum + kalookiCardValue(c), 0);
+  const hasJoker = cards.some((c) => c.design === 'JOKER');
+  // Integer arithmetic, floored, exactly as the domain does it.
+  return hasJoker ? Math.floor((base * 3) / 2) : base;
+}
+
+/**
+ * Total points of the staged meld groups, which is what an unopened player's
+ * first meld is measured against.
+ *
+ * The joker bonus applies per meld, so the total is not simply the sum of the
+ * card values — which is why the player cannot reliably do this in their head
+ * and the readout is worth showing (#4839).
+ * @param groups - Staged melds, each a list of cards.
+ * @returns The combined points.
+ */
+export function kalookiOpeningPoints(groups: readonly (readonly Card[])[]): number {
+  return groups.reduce((sum, g) => sum + kalookiMeldValue(g), 0);
+}


### PR DESCRIPTION
## 変更

`KalookiPage` は「最初のメルドは合計51点以上が必要です」という**静的な文言だけ**を出し、ステージ中のメルド群が何点なのかは表示していませんでした。同じくメルドをステージする `HandAndFootPage` は `canastaSelectionPoints` でリアルタイム表示しています。

`オープニング: 45 / 51 点` の形で、達成時は success 色にします。

## 暗算に向かない計算だから出す価値がある

ジョーカーボーナスは **メルドごとに 1.5倍（floor）** です:

```go
if hasJoker { return base * 3 / 2 }   // kalookiMeldValue
```

つまり**カード値を全部足してから最後に1回ボーナスを掛けると答えが違います**。単体テストでこのケースを固定しました（30点のメルド + ジョーカー入り37点のメルド = 67点。まとめて計算すると82点になってしまう）。

## テストプラン

- [x] `kalookiScore.ts` に単体テスト8本（A=15・ジョーカー=15・10以上=10、メルド単位のボーナス、合算）
- [x] ページテスト: 未ステージで `0 / 51`、5が3枚で `15 / 51`、K3枚を足して `45 / 51`（未達なので success 色にならない）
- [x] **負のコントロール実測**: testid を潰すとテストが落ちる
- [x] `bunx vitest run` 対象2ファイル: 35 passed
- [x] `bun run check` / `bun run typecheck`

Closes #4839