### PR TITLE
fix(contractrummy): validate the extra meld, not just its card count

### DIFF
--- a/frontend/src/i18n/locales/en/contractrummy.json
+++ b/frontend/src/i18n/locales/en/contractrummy.json
@@ -39,5 +39,6 @@
     "contractrummyDrawStock": "The discard is no use — draw from the stock",
     "contractrummyMeetContract": "The contract is not met yet — even heavy cards are material",
     "contractrummyDiscardHeavy": "Your heaviest unconnected card"
-  }
+  },
+  "invalidExtraMeld": "Not a valid set or run"
 }

--- a/frontend/src/i18n/locales/ja/contractrummy.json
+++ b/frontend/src/i18n/locales/ja/contractrummy.json
@@ -39,5 +39,6 @@
     "contractrummyDrawStock": "捨て札は使えません。山から引きましょう",
     "contractrummyMeetContract": "まだ契約を満たしていません。重い札も材料です",
     "contractrummyDiscardHeavy": "繋がっていない札のうち一番重い札です"
-  }
+  },
+  "invalidExtraMeld": "セットまたはランとして成立していません"
 }

--- a/frontend/src/pages/ContractRummyPage.test.tsx
+++ b/frontend/src/pages/ContractRummyPage.test.tsx
@@ -423,4 +423,35 @@ describe('ContractRummyPage', () => {
     fireEvent.click(toggle);
     expect(await screen.findByTestId('hint-tooltip')).toBeInTheDocument();
   });
+
+  it('refuses an extra meld that is not a set or a run', async () => {
+    const metState: ContractRummyResponse = {
+      ...playState,
+      players: [{ ...playState.players[0], contractMet: true }, playState.players[1], playState.players[2]],
+    };
+    mockExec.mockResolvedValue(metState);
+    renderWithProviders(<ContractRummyPage />);
+    const meldExtra = await screen.findByRole('button', { name: /Lay extra meld|追加メルド/ });
+    // Three cards, but neither a set nor a run — counting to three used to be enough.
+    fireEvent.click(screen.getByRole('button', { name: '♠ 5' }));
+    fireEvent.click(screen.getByRole('button', { name: '♥ 5' }));
+    fireEvent.click(screen.getByRole('button', { name: '♣ K' }));
+    expect(meldExtra).toBeDisabled();
+    expect(screen.getByTestId('cr-invalid-extra-meld')).toBeInTheDocument();
+  });
+
+  it('allows an extra meld that is a real set', async () => {
+    const metState: ContractRummyResponse = {
+      ...playState,
+      players: [{ ...playState.players[0], contractMet: true }, playState.players[1], playState.players[2]],
+    };
+    mockExec.mockResolvedValue(metState);
+    renderWithProviders(<ContractRummyPage />);
+    const meldExtra = await screen.findByRole('button', { name: /Lay extra meld|追加メルド/ });
+    fireEvent.click(screen.getByRole('button', { name: '♠ 5' }));
+    fireEvent.click(screen.getByRole('button', { name: '♥ 5' }));
+    fireEvent.click(screen.getByRole('button', { name: '♦ 5' }));
+    expect(meldExtra).toBeEnabled();
+    expect(screen.queryByTestId('cr-invalid-extra-meld')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/ContractRummyPage.tsx
+++ b/frontend/src/pages/ContractRummyPage.tsx
@@ -29,7 +29,7 @@ import { cardAlt } from '../utils/cardAlt';
 import { CONTRACTRUMMY_HELP, parseContractRummyCommand } from '../utils/cli/commands/contractrummyCommands';
 import { formatContractRummyState } from '../utils/cli/formatters/contractrummyFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
-import { evaluateContractSlot } from '../utils/contractRummyUtils';
+import { evaluateContractSlot, isContractRummyMeld } from '../utils/contractRummyUtils';
 
 /** Phase identifiers for Contract Rummy. */
 const CR_PHASE = {
@@ -113,6 +113,15 @@ function ContractRummyPageContent() {
 
   const humanIdx = 0;
   const humanPlayer = state?.players[humanIdx];
+  // The contract slots are pre-validated with the same set/run predicate the
+  // server uses; the extra meld only counted cards, so an invalid combination
+  // looked ready and came back as a server error (#4826).
+  const extraMeldCards = useMemo(
+    () => selectedCards.map((i) => humanPlayer?.cards[i]).filter((c): c is Card => c !== undefined),
+    [selectedCards, humanPlayer],
+  );
+  const extraMeldValid = isContractRummyMeld(extraMeldCards);
+
   const isHumanTurn = state?.currentPlayerIdx === humanIdx && !state?.gameEndFlag;
   const isDrawPhase = isHumanTurn && state?.phase === CR_PHASE.DRAW;
   const isPlayPhase = isHumanTurn && state?.phase === CR_PHASE.PLAY;
@@ -175,10 +184,10 @@ function ContractRummyPageContent() {
   }, [execApi, contractSlots, clearSelection]);
 
   const handleMeldExtra = useCallback(() => {
-    if (selectedCards.length < 3) return;
+    if (!extraMeldValid) return;
     void execApi('meldextra', { cardIndices: selectedCards });
     clearSelection();
-  }, [execApi, selectedCards, clearSelection]);
+  }, [execApi, selectedCards, clearSelection, extraMeldValid]);
 
   const handleLayoff = useCallback(() => {
     if (selectedCards.length !== 1 || !layoffTarget) return;
@@ -472,12 +481,16 @@ function ContractRummyPageContent() {
             )}
             {isPlayPhase && humanPlayer?.contractMet && (
               <>
-                <button
-                  type="button"
-                  onClick={handleMeldExtra}
-                  disabled={selectedCards.length < 3}
-                  className={btnOutline}
-                >
+                {selectedCards.length >= 3 && !extraMeldValid && (
+                  <p
+                    role="status"
+                    data-testid="cr-invalid-extra-meld"
+                    className="w-full text-center text-xs text-ds-warning"
+                  >
+                    {t('invalidExtraMeld')}
+                  </p>
+                )}
+                <button type="button" onClick={handleMeldExtra} disabled={!extraMeldValid} className={btnOutline}>
                   {t('meldExtra')}
                 </button>
                 <button

--- a/frontend/src/utils/contractRummyUtils.test.ts
+++ b/frontend/src/utils/contractRummyUtils.test.ts
@@ -4,6 +4,7 @@ import {
   CONTRACT_SLOT_RUN,
   CONTRACT_SLOT_SET,
   evaluateContractSlot,
+  isContractRummyMeld,
   isContractRun,
   isContractSet,
 } from './contractRummyUtils';
@@ -108,5 +109,29 @@ describe('evaluateContractSlot', () => {
     ]);
     expect(ev.invalid).toBe(true);
     expect(ev.satisfied).toBe(false);
+  });
+});
+
+describe('isContractRummyMeld', () => {
+  const c = (design: Card['design'], value: number): Card => ({ design, value });
+
+  it('accepts a set of three', () => {
+    expect(isContractRummyMeld([c('SPADE', 7), c('HEART', 7), c('CLOVER', 7)])).toBe(true);
+  });
+
+  it('accepts a run of three in one suit', () => {
+    expect(isContractRummyMeld([c('SPADE', 5), c('SPADE', 6), c('SPADE', 7)])).toBe(true);
+  });
+
+  it('rejects three unrelated cards, which the count-only check allowed', () => {
+    expect(isContractRummyMeld([c('SPADE', 5), c('HEART', 9), c('CLOVER', 13)])).toBe(false);
+  });
+
+  it('rejects a run split across suits', () => {
+    expect(isContractRummyMeld([c('SPADE', 5), c('HEART', 6), c('SPADE', 7)])).toBe(false);
+  });
+
+  it('rejects fewer than three', () => {
+    expect(isContractRummyMeld([c('SPADE', 7), c('HEART', 7)])).toBe(false);
   });
 });

--- a/frontend/src/utils/contractRummyUtils.ts
+++ b/frontend/src/utils/contractRummyUtils.ts
@@ -69,3 +69,14 @@ export function evaluateContractSlot(slot: ContractRummyContractSlot, cards: Car
   const ok = slot.kind === CONTRACT_SLOT_SET ? isContractSet(cards) : isContractRun(cards);
   return { required, placed, satisfied: ok, invalid: !ok };
 }
+
+/**
+ * Whether the cards form a valid extra meld — a set or a run of at least three.
+ * Mirrors `IsContractRummyMeld` in `internal/domain/ContractRummy.go`, which is
+ * the same predicate the contract slots are judged by.
+ * @param cards - The selected cards.
+ * @returns Whether they may be melded.
+ */
+export function isContractRummyMeld(cards: Card[]): boolean {
+  return isContractSet(cards) || isContractRun(cards);
+}


### PR DESCRIPTION
## 変更

契約メルドは `evaluateContractSlot` でスロットごとに事前検証し、全て満たすまで送信ボタンを無効化しています。ところが**契約達成後の追加メルド**は `selectedCards.length < 3` の枚数チェックだけで、**どんな3枚でもボタンが押せて**サーバーエラーで初めて分かる状態でした。

`isContractSet` / `isContractRun` は既に export されていたので、それを束ねた `isContractRummyMeld` を追加しました（サーバの `IsContractRummyMeld` と対応）。警告文は兄弟の `Rummy500Page` と同じ位置・同じ形にしています。

## テストプラン

- [x] `contractRummyUtils.ts` に単体テスト5本（セット/ラン/無関係な3枚/スート跨ぎのラン/3枚未満）
- [x] ページテスト**両側**: 無効な3枚では無効化＋警告表示 / 正しいセットでは有効・警告なし
- [x] **負のコントロール実測**: 枚数判定に戻すと無効側のテストが落ちる
- [x] `bunx vitest run` 対象2ファイル: 45 passed
- [x] `bun run check` / `bun run typecheck`

### 途中で踏んだ点

依存配列の追加が**別の `useCallback`（`handleDiscard`）に入ってしまい**、biome の `useExhaustiveDependencies` が両側から検出しました（不足と余分の2件）。汎用的な文字列で置換したため最初の一致に当たったのが原因です。

Closes #4826