### PR TITLE
feat(michigan): warn in the CUI about boodles already claimed

### DIFF
--- a/internal/adapter/presenter/MichiganCuiPresenter.go
+++ b/internal/adapter/presenter/MichiganCuiPresenter.go
@@ -79,25 +79,39 @@ func michiganBetHintStr(g interfaces.MichiganGame) string {
 	}
 	player := g.GetPlayer(human)
 	held := make([]string, 0, g.GetBoodleCnt())
+	claimed := make([]string, 0, g.GetBoodleCnt())
 	for i := 0; i < g.GetBoodleCnt(); i++ {
 		bd := g.GetBoodle(i)
 		if bd == nil || bd.GetCard() == nil {
 			continue
 		}
 		bc := bd.GetCard()
+		label := i18n.Tf("michigan.betHintHold", "card", cuiCardStr(bc), "idx", strconv.Itoa(i))
+		// **獲得済みのブードルに積んでも戻ってこない。**Web は betClaimedWarning で
+		// これを警告しているのに、CUI のベットヒントは黙っていた (#4926)。
+		if bd.GetClaimedBy() >= 0 {
+			claimed = append(claimed, label)
+			continue
+		}
 		for j := 0; j < player.GetCardsSize(); j++ {
 			hc := player.GetCard(j)
 			if hc != nil && hc.GetDesign() == bc.GetDesign() && hc.GetValue() == bc.GetValue() {
-				held = append(held, i18n.Tf("michigan.betHintHold",
-					"card", cuiCardStr(bc), "idx", strconv.Itoa(i)))
+				held = append(held, label)
 				break
 			}
 		}
 	}
-	if len(held) == 0 {
-		return i18n.T("michigan.betHintNone")
+
+	lines := make([]string, 0, 2)
+	if len(claimed) > 0 {
+		lines = append(lines, i18n.Tf("michigan.betHintClaimed", "boodles", strings.Join(claimed, ", ")))
 	}
-	return i18n.T("michigan.betHintHeader") + " " + strings.Join(held, ", ")
+	if len(held) == 0 {
+		lines = append(lines, i18n.T("michigan.betHintNone"))
+	} else {
+		lines = append(lines, i18n.T("michigan.betHintHeader")+" "+strings.Join(held, ", "))
+	}
+	return strings.Join(lines, "\n")
 }
 
 // Output renders the current game state for the active locale.

--- a/internal/adapter/presenter/MichiganCuiPresenter_test.go
+++ b/internal/adapter/presenter/MichiganCuiPresenter_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func TestMichiganCuiPresenter_OutputBetPhase(t *testing.T) {
@@ -37,6 +38,52 @@ func TestMichiganCuiPresenter_OutputBetHint(t *testing.T) {
 	g2.GetPlayer(0).ClearHand()
 	out2 := p.Output(g2, nil)
 	assert.Contains(t, out2, "均等")
+}
+
+// **確定済みブードルにも触れる。**Web は `betClaimedWarning` を出すのに CUI の
+// ベットヒントは「持っている札」しか案内せず、賭けても回収できないブードルを
+// 黙って見過ごしていた (#4926)。
+func TestMichiganCuiPresenter_BetHintWarnsAboutClaimedBoodles(t *testing.T) {
+	p := new(presenter.MichiganCuiPresenter)
+
+	// 未確定だけなら警告は出ない。
+	clean := domain.NewDefaultMichigan()
+	assert.NotContains(t, p.Output(clean, nil), "回収できません")
+
+	// boodle1 が確定済み。ヒントに警告が出る。
+	g := domain.NewDefaultMichigan()
+	g.GetBoodle(1).SetClaimedBy(2)
+	out := p.Output(g, nil)
+	assert.Contains(t, out, "回収できません")
+	assert.Contains(t, out, "boodle1")
+	assert.NotContains(t, out, "boodle0")
+
+	// **確定済みは推奨から外れる。**札を持っていても回収できない以上、
+	// 「厚めに賭けろ」と案内してはいけない。
+	g2 := domain.NewDefaultMichigan()
+	bc := g2.GetBoodle(0).GetCard()
+	g2.GetPlayer(0).AddCard(domain.NewCard(bc.GetDesign(), bc.GetValue(), false))
+	assert.Contains(t, p.Output(g2, nil), "厚めに")
+	g2.GetBoodle(0).SetClaimedBy(3)
+	out2 := p.Output(g2, nil)
+	assert.Contains(t, out2, "回収できません")
+	// 推奨行そのものが消え、「手札に無し」の案内に切り替わる。
+	assert.NotContains(t, out2, "厚めに")
+	assert.Contains(t, out2, "均等")
+}
+
+// ja / en 双方に訳がある。片方だけだと `--lang en` でキーが出る (#4926)。
+func TestMichiganBetHintClaimed_TranslatedInBothLanguages(t *testing.T) {
+	defer i18n.SetLang("ja")
+	for _, lang := range []string{"ja", "en"} {
+		i18n.SetLang(lang)
+		got := i18n.T("michigan.betHintClaimed")
+		assert.NotEqual(t, "michigan.betHintClaimed", got, "missing from %s", lang)
+	}
+	i18n.SetLang("ja")
+	ja := i18n.T("michigan.betHintClaimed")
+	i18n.SetLang("en")
+	assert.NotEqual(t, ja, i18n.T("michigan.betHintClaimed"))
 }
 
 func TestMichiganCuiPresenter_OutputPlayPhase(t *testing.T) {

--- a/internal/domain/MichiganBoodle.go
+++ b/internal/domain/MichiganBoodle.go
@@ -23,6 +23,9 @@ func (b *MichiganBoodle) GetChips() int { return b.chips }
 // GetClaimedBy はこのラウンドの獲得者の席を返す (-1 = 未獲得)。
 func (b *MichiganBoodle) GetClaimedBy() int { return b.claimedBy }
 
+// SetClaimedBy は獲得者の席を設定する (テスト用。-1 = 未獲得)。
+func (b *MichiganBoodle) SetClaimedBy(seat int) { b.claimedBy = seat }
+
 // michiganBoodleJSON is the JSON wire format for MichiganBoodle.
 type michiganBoodleJSON struct {
 	Card      *Card `json:"c"`

--- a/internal/i18n/locales/en/michigan.json
+++ b/internal/i18n/locales/en/michigan.json
@@ -22,6 +22,7 @@
   "betHintHeader": "Tip: weight the boodles whose card you hold →",
   "betHintHold": "{{card}}(boodle{{idx}})",
   "betHintNone": "Tip: you hold none of the boodle cards; spread your budget evenly.",
+  "betHintClaimed": "Careful: {{boodles}} already claimed — chips bet there cannot be won back.",
   "promptPlay": "Play a card: p <n> (playable: {{indices}})",
   "promptWait": "Waiting for other players...",
   "promptResult": "Round over. Use n for the next round.",

--- a/internal/i18n/locales/ja/michigan.json
+++ b/internal/i18n/locales/ja/michigan.json
@@ -22,6 +22,7 @@
   "betHintHeader": "推奨: 該当札を持つブードルに厚めに →",
   "betHintHold": "{{card}}(boodle{{idx}})",
   "betHintNone": "推奨: ブードル札は手札に無し。予算を均等に配分するのが無難。",
+  "betHintClaimed": "注意: {{boodles}} は獲得済み。ここに賭けても回収できません。",
   "promptPlay": "カードを出してください: p <n>（出せる: {{indices}}）",
   "promptWait": "他のプレイヤーの手番です…",
   "promptResult": "ラウンド終了。n で次のラウンドへ。",


### PR DESCRIPTION
Closes #4926

## 背景

Web は `michiganBoodleGuides` の `claimed` (`boodle.claimedBy >= 0`) を見て `betClaimedWarning` を賭け画面に出している。一方 CUI の `michiganBetHintStr` は**手札に該当札があるブードルの推奨だけ**を案内しており、既に獲得済みで賭けても回収できないブードルには一切触れていなかった。ブードル一覧の `[獲得済み（Pn）]` を自分で読み合わせないと気づけず、Web と非対称だった。

## 変更

- `michiganBetHintStr` — 獲得済みブードルを警告行 (`michigan.betHintClaimed`) として推奨行の**前**に出す
- あわせて**推奨リストからも外す**。札を持っていても回収できない以上、「該当札を持つブードルに厚めに」は誤った案内になる (issue の提案より一歩踏み込んだ部分)
- `MichiganBoodle.SetClaimedBy` — テスト用のセッター (`Mao.SetHiddenRule` と同じ位置づけ)
- `internal/i18n/locales/{ja,en}/michigan.json` に `betHintClaimed` を追加

`frontend/src/utils/michiganBoodleGuide.ts` も issue の対象ファイルに挙がっていたが、**フロントは既に `claimed` を計算して警告を出している**ので変更不要。非対称だったのは CUI 側だけ。

## テスト

`TestMichiganCuiPresenter_BetHintWarnsAboutClaimedBoodles`:

- 全ブードル未確定 → 警告が出ない
- boodle1 が確定済み → 警告が出て、boodle1 だけが挙がる (boodle0 は挙がらない)
- **該当札を持っているブードルが確定済みになったとき**、推奨行 (「厚めに」) が消えて「手札に無し」の案内に切り替わる

`TestMichiganBetHintClaimed_TranslatedInBothLanguages` — ja/en 双方に訳があり、かつ両者が別文字列であること。

ネガティブコントロール: `if bd.GetClaimedBy() >= 0 { ... }` の分岐を外すと新テストが落ちる。

`go test -tags test ./...` / `golangci-lint run ./internal/...` (0 issues) green。

## Test plan

- [ ] CI green