### PR TITLE
feat(wizard): mark the legally playable cards in the CUI hand

### DIFF
--- a/internal/adapter/presenter/WizardCuiPresenter.go
+++ b/internal/adapter/presenter/WizardCuiPresenter.go
@@ -57,7 +57,6 @@ func wizardIndexedCardListStr(hand cuiCardList, legal []bool) string {
 		if i < len(legal) && legal[i] {
 			parts[i] += WizardLegalMark
 		}
-
 	}
 	return strings.Join(parts, "  ")
 }
@@ -129,7 +128,9 @@ func (p *WizardCuiPresenter) Output(o interfaces.WizardGame, lastErr error) stri
 			// 出せる札の印は、人間の手番のプレイフェーズだけ付ける。
 			var legal []bool
 			pl := o.GetPlayer(i)
-			if pl != nil && pl.GetIsHuman() && o.GetPhase() == domain.WizardPhasePlay && o.IsHumanTurn() {
+			// 手番の判定は席番号で行う。IsHumanTurn() は「人間は 1 人」という
+			// 暗黙の前提に寄りかかる。
+			if pl != nil && pl.GetIsHuman() && o.GetPhase() == domain.WizardPhasePlay && i == o.GetCurrentPlayerIdx() {
 				legal = wizardLegalIndices(pl, o.GetCurrentTrick())
 				legalShown = legalShown || legal != nil
 			}

--- a/internal/adapter/presenter/WizardCuiPresenter.go
+++ b/internal/adapter/presenter/WizardCuiPresenter.go
@@ -1,6 +1,7 @@
 package presenter
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -44,13 +45,43 @@ func wizardLeadSuit(trick []*domain.TrickCard) int {
 	return -1
 }
 
+// WizardLegalMark は「この札は今のトリックに出せる」ことを示す印。
+const WizardLegalMark = "*"
+
 // wizardIndexedCardListStr は手札をインデックス付き (ウィザード/ジェスター対応) で描画する。
-func wizardIndexedCardListStr(hand cuiCardList) string {
-	return formatCardList(hand, wizardCuiCardStr, "  ", true)
+// legal が非 nil なら、出せる札に WizardLegalMark を付ける。
+func wizardIndexedCardListStr(hand cuiCardList, legal []bool) string {
+	parts := make([]string, hand.GetCardsSize())
+	for i := range parts {
+		parts[i] = fmt.Sprintf("[%d]%s", i, wizardCuiCardStr(hand.GetCard(i)))
+		if i < len(legal) && legal[i] {
+			parts[i] += WizardLegalMark
+		}
+
+	}
+	return strings.Join(parts, "  ")
+}
+
+// wizardLegalIndices は手札の各札が今のトリックに出せるかを返す。
+// **全部出せるなら nil を返す。**リード時のように全部に印が付くだけの場面では、
+// 印も凡例もノイズにしかならない。
+func wizardLegalIndices(player *domain.WizardPlayer, trick []*domain.TrickCard) []bool {
+	legal := make([]bool, player.GetCardsSize())
+	all := true
+	for i := range legal {
+		legal[i] = domain.WizardIsLegalPlay(player.GetCard(i), trick, player)
+		if !legal[i] {
+			all = false
+		}
+	}
+	if all {
+		return nil
+	}
+	return legal
 }
 
 // wizardPlayerStr returns the display string for a single Wizard player.
-func wizardPlayerStr(player *domain.WizardPlayer, i int) string {
+func wizardPlayerStr(player *domain.WizardPlayer, i int, legal []bool) string {
 	var b strings.Builder
 	bidStr := i18n.T("wizard.bidPending")
 	if player.GetBid() >= 0 {
@@ -66,7 +97,7 @@ func wizardPlayerStr(player *domain.WizardPlayer, i int) string {
 	))
 	b.WriteString("\n")
 	if player.GetIsHuman() && player.GetCardsSize() > 0 {
-		b.WriteString(wizardIndexedCardListStr(player) + "\n")
+		b.WriteString(wizardIndexedCardListStr(player, legal) + "\n")
 	}
 	return b.String()
 }
@@ -93,8 +124,16 @@ func (p *WizardCuiPresenter) Output(o interfaces.WizardGame, lastErr error) stri
 		b.WriteString(i18n.Tf("wizard.dealer",
 			"name", cuiPlayerName(o.GetPlayer(dealerIdx), dealerIdx)) + "\n")
 
+		legalShown := false
 		for i := 0; i < o.GetPlayerCnt(); i++ {
-			b.WriteString(wizardPlayerStr(o.GetPlayer(i), i))
+			// 出せる札の印は、人間の手番のプレイフェーズだけ付ける。
+			var legal []bool
+			pl := o.GetPlayer(i)
+			if pl != nil && pl.GetIsHuman() && o.GetPhase() == domain.WizardPhasePlay && o.IsHumanTurn() {
+				legal = wizardLegalIndices(pl, o.GetCurrentTrick())
+				legalShown = legalShown || legal != nil
+			}
+			b.WriteString(wizardPlayerStr(pl, i, legal))
 		}
 
 		b.WriteString("----------\n")
@@ -142,6 +181,9 @@ func (p *WizardCuiPresenter) Output(o interfaces.WizardGame, lastErr error) stri
 			b.WriteString(i18n.Tf("wizard.promptLead",
 				"trick", strconv.Itoa(o.GetTrickNumber()),
 				"lead", leadName) + "\n")
+			if legalShown {
+				b.WriteString(i18n.T("wizard.legalMark") + "\n")
+			}
 			b.WriteString(i18n.T("wizard.promptPlayHelp") + "\n")
 		case domain.WizardPhaseTrickEnd:
 			b.WriteString(i18n.T("wizard.promptTrickEnd") + "\n")

--- a/internal/adapter/presenter/WizardCuiPresenter_test.go
+++ b/internal/adapter/presenter/WizardCuiPresenter_test.go
@@ -31,7 +31,6 @@ func setupWizardCuiMock() *interfaces.MockWizardGame {
 	m.On("GetRestrictedBid").Return(-1)
 	m.On("GetWinnerIdx").Return(-1)
 	m.On("GetLeadPlayerIdx").Return(0)
-	m.On("IsHumanTurn").Return(true)
 	m.On("GetConfig").Return(domain.DefaultWizardConfig())
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
 	return m
@@ -109,6 +108,23 @@ func TestWizardCuiPresenter_Output(t *testing.T) {
 		assert.Contains(t, result, "[3]Jester"+presenter.WizardLegalMark)
 		// 凡例が無いと印の意味が分からない。
 		assert.Contains(t, result, i18n.T("wizard.legalMark"))
+	})
+
+	// 他人の手番なら印は出ない。出せる札は手番が来てから分かればよい。
+	t.Run("no marks while it is not the human's turn", func(t *testing.T) {
+		m, players := setupWizardCuiMockWithPlayers()
+		players[0].Reset()
+		players[0].AddCard(domain.NewCard(domain.CardDesignHeart, 9, false))
+		players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 3, false))
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetCurrentTrick")
+		m.On("GetCurrentTrick").Return([]*domain.TrickCard{
+			{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignHeart, 5, false)},
+		})
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetCurrentPlayerIdx")
+		m.On("GetCurrentPlayerIdx").Return(2)
+		result := p.Output(m, nil)
+		assert.NotContains(t, result, presenter.WizardLegalMark)
+		assert.NotContains(t, result, i18n.T("wizard.legalMark"))
 	})
 
 	// 全部出せるときは印だらけになるだけなので、印も凡例も出さない。

--- a/internal/adapter/presenter/WizardCuiPresenter_test.go
+++ b/internal/adapter/presenter/WizardCuiPresenter_test.go
@@ -31,6 +31,7 @@ func setupWizardCuiMock() *interfaces.MockWizardGame {
 	m.On("GetRestrictedBid").Return(-1)
 	m.On("GetWinnerIdx").Return(-1)
 	m.On("GetLeadPlayerIdx").Return(0)
+	m.On("IsHumanTurn").Return(true)
 	m.On("GetConfig").Return(domain.DefaultWizardConfig())
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
 	return m
@@ -86,6 +87,51 @@ func TestWizardCuiPresenter_Output(t *testing.T) {
 		result := p.Output(m, nil)
 		assert.Contains(t, result, "Wizard")
 		assert.Contains(t, result, "Jester")
+	})
+
+	// **出せる札に印を付ける。**リードスート名だけ出しても、CUI プレイヤーは
+	// 毎トリック自分の手札と暗算で照合させられる (#4927)。
+	t.Run("play phase marks the cards that may legally be played", func(t *testing.T) {
+		m, players := setupWizardCuiMockWithPlayers()
+		players[0].Reset()
+		players[0].AddCard(domain.NewCard(domain.CardDesignHeart, 9, false))    // follows
+		players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 3, false))    // must not
+		players[0].AddCard(domain.NewCard(domain.WizardDesignWizard, 1, false)) // always legal
+		players[0].AddCard(domain.NewCard(domain.WizardDesignJester, 1, false)) // always legal
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetCurrentTrick")
+		m.On("GetCurrentTrick").Return([]*domain.TrickCard{
+			{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignHeart, 5, false)},
+		})
+		result := p.Output(m, nil)
+		assert.Contains(t, result, "[0]HEART 9"+presenter.WizardLegalMark)
+		assert.NotContains(t, result, "[1]SPADE 3"+presenter.WizardLegalMark)
+		assert.Contains(t, result, "[2]Wizard"+presenter.WizardLegalMark)
+		assert.Contains(t, result, "[3]Jester"+presenter.WizardLegalMark)
+		// 凡例が無いと印の意味が分からない。
+		assert.Contains(t, result, i18n.T("wizard.legalMark"))
+	})
+
+	// 全部出せるときは印だらけになるだけなので、印も凡例も出さない。
+	t.Run("no marks while leading, where every card is legal", func(t *testing.T) {
+		m, players := setupWizardCuiMockWithPlayers()
+		players[0].Reset()
+		players[0].AddCard(domain.NewCard(domain.CardDesignHeart, 9, false))
+		players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 3, false))
+		result := p.Output(m, nil) // 既定のトリックは空 = リード
+		assert.NotContains(t, result, presenter.WizardLegalMark)
+		assert.NotContains(t, result, i18n.T("wizard.legalMark"))
+	})
+
+	// ja / en 双方に凡例がある。片方だけだと `--lang en` でキーが出る。
+	t.Run("legal-mark legend is translated in both languages", func(t *testing.T) {
+		defer i18n.SetLang("ja")
+		i18n.SetLang("ja")
+		ja := i18n.T("wizard.legalMark")
+		assert.NotEqual(t, "wizard.legalMark", ja)
+		i18n.SetLang("en")
+		en := i18n.T("wizard.legalMark")
+		assert.NotEqual(t, "wizard.legalMark", en)
+		assert.NotEqual(t, ja, en)
 	})
 
 	t.Run("bid phase", func(t *testing.T) {

--- a/internal/domain/Wizard.go
+++ b/internal/domain/Wizard.go
@@ -614,7 +614,13 @@ func (o *Wizard) playCard(playerIdx int, card *Card) {
 // 先頭から順に見て、ウィザードが最初に出ていればリードスートなし、
 // ジェスターは読み飛ばし、最初のスート札 (design 1..4) をリードスートとする。
 func (o *Wizard) leadSuitOfTrick() int {
-	for _, tc := range o.currentTrick {
+	return WizardLeadSuitOfTrick(o.currentTrick)
+}
+
+// WizardLeadSuitOfTrick はトリックのリードスートを返す (-1 = 未確定)。
+// ウィザードがリードすればスートは立たず、ジェスターは読み飛ばす。
+func WizardLeadSuitOfTrick(trick []*TrickCard) int {
+	for _, tc := range trick {
 		d := tc.Card.GetDesign()
 		if d == WizardDesignWizard {
 			return -1
@@ -629,38 +635,46 @@ func (o *Wizard) leadSuitOfTrick() int {
 
 // validatePlay カードのプレイが有効か検証する
 func (o *Wizard) validatePlay(playerIdx int, card *Card) error {
-	if len(o.currentTrick) == 0 {
-		// リード: ウィザード/ジェスターを含め何でもリード可能。
+	if WizardIsLegalPlay(card, o.currentTrick, o.players[playerIdx]) {
 		return nil
+	}
+	return NewDomainError(ErrInvalidPlay, "リードスートに従ってください")
+}
+
+// WizardIsLegalPlay は card を現在のトリックに出せるかを返す。
+//
+// リードなら何でも出せる。ウィザード/ジェスターはフォロー義務を免除される。
+// リードスートが確定していて、そのスートをまだ持っているなら従わねばならない。
+//
+// **判定はここ 1 箇所に置く。**presenter が「出せる札」を印付けするのに
+// 同じ規則を書き写すと、片方だけ直したときに嘘の案内になる (#4927)。
+func WizardIsLegalPlay(card *Card, trick []*TrickCard, hand *WizardPlayer) bool {
+	if len(trick) == 0 {
+		// リード: ウィザード/ジェスターを含め何でもリード可能。
+		return true
 	}
 
 	d := card.GetDesign()
 	// ウィザード/ジェスターはいつでもプレイ可能 (フォロー義務の免除)。
 	if d == WizardDesignWizard || d == WizardDesignJester {
-		return nil
+		return true
 	}
 
-	leadSuit := o.leadSuitOfTrick()
+	leadSuit := WizardLeadSuitOfTrick(trick)
 	if leadSuit < 0 {
 		// リードスートが未確定 (ウィザードがリード、または全てジェスター)。
-		return nil
+		return true
 	}
-	if d != leadSuit && o.playerHasSuit(playerIdx, leadSuit) {
-		return NewDomainError(ErrInvalidPlay, "リードスートに従ってください")
+	if d == leadSuit {
+		return true
 	}
-
-	return nil
-}
-
-// playerHasSuit プレイヤーが特定のスートを持っているか
-func (o *Wizard) playerHasSuit(playerIdx int, design int) bool {
-	p := o.players[playerIdx]
-	for i := 0; i < p.GetCardsSize(); i++ {
-		if p.GetCard(i).GetDesign() == design {
-			return true
+	// リードスートを持っていなければ何を出してもよい。
+	for i := 0; i < hand.GetCardsSize(); i++ {
+		if c := hand.GetCard(i); c != nil && c.GetDesign() == leadSuit {
+			return false
 		}
 	}
-	return false
+	return true
 }
 
 // trickWinner トリックの勝者を決定する

--- a/internal/i18n/locales/en/wizard.json
+++ b/internal/i18n/locales/en/wizard.json
@@ -17,6 +17,7 @@
   "promptBidHelp": "b <n> — declare a bid (0–handSize)",
   "promptPlay": "Turn: {{name}}",
   "promptPlayHelp": "play <idx> — play a card",
+  "legalMark": "Cards marked * may be played into the current trick.",
   "promptTrickEnd": "Trick ended",
   "promptTrickEndHelp": "next — advance to the next trick",
   "promptRoundEnd": "Round ended",

--- a/internal/i18n/locales/ja/wizard.json
+++ b/internal/i18n/locales/ja/wizard.json
@@ -17,6 +17,7 @@
   "promptBidHelp": "b <n>・・・ビッドを宣言 (0-手札枚数)",
   "promptPlay": "手番: {{name}}",
   "promptPlayHelp": "play <idx>・・・カードを出す",
+  "legalMark": "* 印の付いた札が今のトリックに出せます。",
   "promptTrickEnd": "トリック終了",
   "promptTrickEndHelp": "next・・・次のトリックへ",
   "promptRoundEnd": "ラウンド終了",


### PR DESCRIPTION
Closes #4927

## 背景

`WizardPage.tsx` は `isWizardLegalPlay` を使って合法な手札にリング、非合法には半透明と `aria-describedby` 付きの理由を出す。一方 `WizardCuiPresenter` は `promptLead` でリードスート名を出すだけで、手札一覧 (`wizardIndexedCardListStr`) には各札が合法かどうかの注記が無く、CUI プレイヤーは毎トリック手札と暗算で照合させられていた。

## 変更

**判定はドメインに 1 箇所だけ置く。** issue は「`isWizardLegalPlay` と同等の判定を Go 側に用意する」と書いているが、presenter に同じ規則を書き写すと片方だけ直したときに**嘘の案内**になる。そこで `validatePlay` の中身をそのまま切り出した:

- `domain.WizardIsLegalPlay(card, trick, hand)` — `validatePlay` はこれを呼ぶだけになった
- `domain.WizardLeadSuitOfTrick(trick)` — 同様に `leadSuitOfTrick` から公開
- presenter は `wizardLegalIndices` でこれを呼び、合法な札に `*` を付ける

表示の判断:

- 印は**人間の手番のプレイフェーズだけ**。ビッド中や CPU の手番に出しても意味が無い
- **全札が合法なら印も凡例も出さない。**リード時はどれも出せるので、全部に `*` が付くだけでノイズになる
- 凡例 (`wizard.legalMark`) は印を出したときだけ添える

切り出しで使われなくなった `Wizard.playerHasSuit` を削除 (dead code 規則)。

## テスト

`TestWizardCuiPresenter_Output` に 3 ケース追加:

- **印が付く** — ♥がリードされた状況で `[0]HEART 9*` が付き、`[1]SPADE 3` には付かない。ウィザード/ジェスターは常に合法なので付く (受け入れ条件2)
- **印が付かない** — リード時 (トリック空) は全札合法なので、印も凡例も出ない
- **凡例が ja/en 双方にあり、かつ別文字列**

ネガティブコントロール: `parts[i] += WizardLegalMark` を外すと印のテストが落ちる。既存の `validatePlay` 経由のドメインテスト群は切り出し後もそのまま green なので、規則の意味は変わっていない。

`go test -tags test ./...` / `golangci-lint run ./internal/...` (0 issues) green。

## Test plan

- [ ] CI green