### PR TITLE
feat(kaiser): add the hint command to the CUI

### DIFF
--- a/internal/adapter/controller/KaiserCuiController.go
+++ b/internal/adapter/controller/KaiserCuiController.go
@@ -31,7 +31,7 @@ func (c *KaiserCuiController) Exec(command string) string {
 		},
 		[]string{
 			"b", "bid", "ps", "pass", "t", "trump",
-			"d", "discard", "p", "play", "n", "next", "log", "l",
+			"d", "discard", "p", "play", "n", "next", "h", "hint", "log", "l",
 		},
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
@@ -52,7 +52,7 @@ func (c *KaiserCuiController) Exec(command string) string {
 			case "n", "next":
 				return c.ki.NextHand(), true
 			default:
-				return handleCuiLog(cmd, c.ki.ActionLog)
+				return handleCuiHintAndLog(cmd, c.ki.Hint, c.ki.ActionLog)
 			}
 		},
 	)

--- a/internal/adapter/controller/KaiserCuiController_test.go
+++ b/internal/adapter/controller/KaiserCuiController_test.go
@@ -27,8 +27,22 @@ func TestKaiserCuiController_Exec(t *testing.T) {
 		m.On("PlayCard", mock.Anything).Return(mockOutput)
 		m.On("NextHand").Return(mockOutput)
 		m.On("ActionLog").Return(mockOutput)
+		m.On("Hint").Return(mockOutput)
 		return m
 	}
+
+	// **CUI にもヒントが要る。**Web にはあるのに hint/h が未登録で、
+	// 「そんなコマンドは無い」と弾かれていた (#4938)。
+	t.Run("hint", func(t *testing.T) {
+		m := newMock()
+		c := controller.NewKaiserCuiController(m)
+		assert.Equal(t, mockOutput, c.Exec("h"))
+		assert.Equal(t, mockOutput, c.Exec("hint"))
+		m.AssertNumberOfCalls(t, "Hint", 2)
+		// 既存コマンドは巻き添えを食わない。
+		assert.Equal(t, mockOutput, c.Exec("log"))
+		m.AssertCalled(t, "ActionLog")
+	})
 
 	t.Run("quit and reset", func(t *testing.T) {
 		m := newMock()

--- a/internal/adapter/controller/usecase/KaiserInteractor_mock.go
+++ b/internal/adapter/controller/usecase/KaiserInteractor_mock.go
@@ -53,6 +53,11 @@ func (_m *MockKaiserInteractor) ActionLog() string {
 	return _m.Called().String(0)
 }
 
+// Hint モック
+func (_m *MockKaiserInteractor) Hint() string {
+	return _m.Called().String(0)
+}
+
 // Snapshot モック
 func (_m *MockKaiserInteractor) Snapshot() ([]byte, error) {
 	ret := _m.Called()

--- a/internal/adapter/presenter/KaiserCuiPresenter.go
+++ b/internal/adapter/presenter/KaiserCuiPresenter.go
@@ -3,6 +3,7 @@
 package presenter
 
 import (
+	"sort"
 	"strconv"
 	"strings"
 
@@ -153,4 +154,197 @@ func (p *KaiserCuiPresenter) Output(g interfaces.KaiserGame, lastErr error) stri
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *KaiserCuiPresenter) ActionLogOutput(g interfaces.KaiserGame) string {
 	return actionLogOutputText(g)
+}
+
+// kaiserHintKey は今の局面で出すべき助言の i18n キーと、必要なら添える手札
+// インデックスを返す。キーが空なら助言なし。
+//
+// **Web のヒントはプレイ局面しか扱わない** (`utils/hints/kaiserHint.ts` は
+// `phase !== Play` で null を返す)。CUI はビッド・切札・捨て札まで面倒を見る。
+// 判断点が多いのに CUI 側は今まで一切の補助が無かった (#4938)。
+func kaiserHintKey(g interfaces.KaiserGame) (key string, idxs []int, suits []int) {
+	if g.GetGameEndFlag() {
+		return "kaiser.hintGameEnd", nil, nil
+	}
+	human := kaiserHumanIdx(g)
+	if human < 0 {
+		return "kaiser.hintNone", nil, nil
+	}
+	p := g.GetPlayer(human)
+
+	switch g.GetPhase() {
+	case domain.KaiserPhaseBid:
+		if g.GetBidPlayerIdx() != human {
+			return "kaiser.hintNotYourTurn", nil, nil
+		}
+		return kaiserBidHint(g, p), nil, nil
+	case domain.KaiserPhaseDiscard:
+		if g.GetDeclarerIdx() != human {
+			return "kaiser.hintNotYourTurn", nil, nil
+		}
+		// **切札が先。**指定前に捨てるとドメインに弾かれる。
+		if g.GetContract() == domain.KaiserContractTrump && g.GetTrumpSuit() == 0 {
+			return "kaiser.hintTrump", nil, kaiserLongestSuits(p)
+		}
+		return "kaiser.hintDiscard", kaiserDiscardCandidates(g, p), nil
+	case domain.KaiserPhasePlay:
+		if g.GetCurrentPlayerIdx() != human {
+			return "kaiser.hintNotYourTurn", nil, nil
+		}
+		k, i := kaiserPlayHint(g, p)
+		return k, i, nil
+	case domain.KaiserPhaseHandEnd:
+		return "kaiser.hintHandEnd", nil, nil
+	}
+	return "kaiser.hintNone", nil, nil
+}
+
+// kaiserHumanIdx は人間の席を返す (居なければ -1)。
+func kaiserHumanIdx(g interfaces.KaiserGame) int {
+	for i, p := range g.GetPlayers() {
+		if p != nil && p.GetIsHuman() {
+			return i
+		}
+	}
+	return -1
+}
+
+// kaiserBidHint はビッドすべきかを返す。
+//
+// **1 局で動くのは 10 点しかなく、最低ビッドが 7。**強い手でなければ降りる。
+// 目安は「最長スートが 4 枚以上あり、その A か K を持っている」か「♥5 を
+// 持っている」(単独で 5 点)。加えて 45 点以上ではビッドしないと加点できない
+// ので、そのときは降りるより取りに行くほうがよい。
+func kaiserBidHint(g interfaces.KaiserGame, p *domain.KaiserPlayer) string {
+	if g.GetScore(domain.KaiserTeamOf(kaiserHumanIdx(g))) >= domain.KaiserMustBidThreshold {
+		return "kaiser.hintBidMust"
+	}
+	strong := false
+	for _, suit := range kaiserLongestSuits(p) {
+		length, hasTop := 0, false
+		for j := range p.GetCardsSize() {
+			c := p.GetCard(j)
+			if c.GetDesign() != suit {
+				continue
+			}
+			length++
+			if c.GetValue() == 1 || c.GetValue() == 13 {
+				hasTop = true
+			}
+		}
+		if length >= 4 && hasTop {
+			strong = true
+		}
+	}
+	for j := range p.GetCardsSize() {
+		if domain.IsKaiserHeartFive(p.GetCard(j)) {
+			strong = true
+		}
+	}
+	if strong {
+		return "kaiser.hintBid"
+	}
+	return "kaiser.hintPass"
+}
+
+// kaiserLongestSuits は手札で最も長いスートを返す (同数なら複数)。
+func kaiserLongestSuits(p *domain.KaiserPlayer) []int {
+	counts := map[int]int{}
+	for j := range p.GetCardsSize() {
+		counts[p.GetCard(j).GetDesign()]++
+	}
+	best := 0
+	for _, n := range counts {
+		if n > best {
+			best = n
+		}
+	}
+	out := []int{}
+	// スート番号の昇順で返す。map の反復順に任せると出力が揺れる。
+	for suit := domain.CardDesignSpade; suit <= domain.CardDesignDiamond; suit++ {
+		if best > 0 && counts[suit] == best {
+			out = append(out, suit)
+		}
+	}
+	return out
+}
+
+// kaiserDiscardCandidates は捨てる 2 枚の候補インデックスを返す。
+//
+// **♥5 と ♠3 は捨てられない** (ドメインが拒否する)。切札も残す。残りから
+// 低いものを 2 枚。
+func kaiserDiscardCandidates(g interfaces.KaiserGame, p *domain.KaiserPlayer) []int {
+	trump := g.GetTrumpSuit()
+	type cand struct{ idx, value int }
+	cands := []cand{}
+	for j := range p.GetCardsSize() {
+		c := p.GetCard(j)
+		if domain.IsKaiserHeartFive(c) || domain.IsKaiserSpadeThree(c) {
+			continue
+		}
+		if trump != 0 && c.GetDesign() == trump {
+			continue
+		}
+		// A は最強なので最後に落とす。
+		v := c.GetValue()
+		if v == 1 {
+			v = 14
+		}
+		cands = append(cands, cand{j, v})
+	}
+	sort.Slice(cands, func(a, b int) bool {
+		if cands[a].value != cands[b].value {
+			return cands[a].value < cands[b].value
+		}
+		return cands[a].idx < cands[b].idx
+	})
+	out := []int{}
+	for i := 0; i < len(cands) && i < domain.KaiserKittySize; i++ {
+		out = append(out, cands[i].idx)
+	}
+	sort.Ints(out)
+	return out
+}
+
+// kaiserPlayHint は出す札の助言を返す。Web の getKaiserHint と同じ判断:
+// 強制手 → ♠3 を手放す → ♥5 は自分から出さない。
+func kaiserPlayHint(g interfaces.KaiserGame, p *domain.KaiserPlayer) (string, []int) {
+	plays := g.KaiserValidPlays(g.GetCurrentPlayerIdx())
+	if len(plays) == 0 {
+		return "kaiser.hintNone", nil
+	}
+	if len(plays) == 1 {
+		return "kaiser.hintForced", plays
+	}
+	for _, i := range plays {
+		if domain.IsKaiserSpadeThree(p.GetCard(i)) {
+			return "kaiser.hintDumpSpadeThree", []int{i}
+		}
+	}
+	for _, i := range plays {
+		if !domain.IsKaiserHeartFive(p.GetCard(i)) {
+			return "kaiser.hintChoose", []int{i}
+		}
+	}
+	return "kaiser.hintChoose", plays[:1]
+}
+
+// HintOutput emits the current Kaiser hint.
+func (p *KaiserCuiPresenter) HintOutput(g interfaces.KaiserGame) string {
+	key, idxs, suits := kaiserHintKey(g)
+	if key == "" {
+		key = "kaiser.hintNone"
+	}
+	msg := i18n.T(key)
+	parts := make([]string, 0, len(idxs)+len(suits))
+	for _, v := range idxs {
+		parts = append(parts, "["+strconv.Itoa(v)+"]")
+	}
+	for _, s := range suits {
+		parts = append(parts, kaiserSuitName(s))
+	}
+	if len(parts) > 0 {
+		msg = i18n.Tf("kaiser.hintWith", "hint", msg, "list", strings.Join(parts, ", "))
+	}
+	return color.Yellow(msg) + "\n"
 }

--- a/internal/adapter/presenter/KaiserCuiPresenter.go
+++ b/internal/adapter/presenter/KaiserCuiPresenter.go
@@ -177,7 +177,7 @@ func kaiserHintKey(g interfaces.KaiserGame) (key string, idxs []int, suits []int
 		if g.GetBidPlayerIdx() != human {
 			return "kaiser.hintNotYourTurn", nil, nil
 		}
-		return kaiserBidHint(g, p), nil, nil
+		return kaiserBidHint(g, p, human), nil, nil
 	case domain.KaiserPhaseDiscard:
 		if g.GetDeclarerIdx() != human {
 			return "kaiser.hintNotYourTurn", nil, nil
@@ -215,8 +215,8 @@ func kaiserHumanIdx(g interfaces.KaiserGame) int {
 // 目安は「最長スートが 4 枚以上あり、その A か K を持っている」か「♥5 を
 // 持っている」(単独で 5 点)。加えて 45 点以上ではビッドしないと加点できない
 // ので、そのときは降りるより取りに行くほうがよい。
-func kaiserBidHint(g interfaces.KaiserGame, p *domain.KaiserPlayer) string {
-	if g.GetScore(domain.KaiserTeamOf(kaiserHumanIdx(g))) >= domain.KaiserMustBidThreshold {
+func kaiserBidHint(g interfaces.KaiserGame, p *domain.KaiserPlayer, human int) string {
+	if g.GetScore(domain.KaiserTeamOf(human)) >= domain.KaiserMustBidThreshold {
 		return "kaiser.hintBidMust"
 	}
 	strong := false

--- a/internal/adapter/presenter/KaiserCuiPresenter_test.go
+++ b/internal/adapter/presenter/KaiserCuiPresenter_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func setupKaiserCuiMock(phase domain.KaiserPhase, trump int, contract domain.KaiserContract, highBid *domain.KaiserBid) *interfaces.MockKaiserGame {
@@ -183,4 +184,149 @@ func TestKaiserCuiPresenter_ActionLogOutput(t *testing.T) {
 		&domain.KaiserBid{Player: 1, Value: 8})
 	m.On("GetActionLog").Return([]*domain.ActionLogEntry{})
 	assert.NotNil(t, new(presenter.KaiserCuiPresenter).ActionLogOutput(m))
+}
+
+// kaiserHintMock は指定の手札・局面でヒントだけを取るためのモック。
+func kaiserHintMock(phase domain.KaiserPhase, trump int, contract domain.KaiserContract,
+	hand []*domain.Card, plays []int, score int,
+) *interfaces.MockKaiserGame {
+	m := new(interfaces.MockKaiserGame)
+	players := makeKaiserPlayers(hand, nil, nil, nil)
+	m.On("GetPhase").Return(phase)
+	m.On("GetGameEndFlag").Return(false)
+	m.On("GetCurrentPlayerIdx").Return(0)
+	m.On("GetBidPlayerIdx").Return(0)
+	m.On("GetDeclarerIdx").Return(0)
+	m.On("GetTrumpSuit").Return(trump)
+	m.On("GetContract").Return(contract)
+	m.On("GetPlayers").Return(players)
+	m.On("KaiserValidPlays", 0).Return(plays)
+	for i := range players {
+		m.On("GetPlayer", i).Return(players[i])
+	}
+	for team := range domain.KaiserTeamCnt {
+		m.On("GetScore", team).Return(score)
+	}
+	return m
+}
+
+// **CUI にもヒントが要る。**Web にはチェックボックスとツールチップがあるのに、
+// CUI は判断点の多いゲームで一切の補助を受けられなかった (#4938)。
+func TestKaiserCuiPresenter_HintOutput(t *testing.T) {
+	p := new(presenter.KaiserCuiPresenter)
+
+	t.Run("bid: a strong hand is worth bidding", func(t *testing.T) {
+		hand := []*domain.Card{
+			kzTestCard(domain.CardDesignClover, 1), kzTestCard(domain.CardDesignClover, 9),
+			kzTestCard(domain.CardDesignClover, 10), kzTestCard(domain.CardDesignClover, 12),
+			kzTestCard(domain.CardDesignSpade, 2),
+		}
+		out := p.HintOutput(kaiserHintMock(domain.KaiserPhaseBid, 0, domain.KaiserContractTrump, hand, nil, 0))
+		assert.Contains(t, out, "ビッドを検討")
+	})
+
+	t.Run("bid: a weak hand should pass", func(t *testing.T) {
+		hand := []*domain.Card{
+			kzTestCard(domain.CardDesignClover, 2), kzTestCard(domain.CardDesignSpade, 4),
+			kzTestCard(domain.CardDesignDiamond, 6), kzTestCard(domain.CardDesignHeart, 8),
+		}
+		out := p.HintOutput(kaiserHintMock(domain.KaiserPhaseBid, 0, domain.KaiserContractTrump, hand, nil, 0))
+		assert.Contains(t, out, "パス")
+	})
+
+	// **45 点以上ではビッドしないと加点できない。**弱くても降りる選択が無い。
+	t.Run("bid: past the threshold there is no passing", func(t *testing.T) {
+		hand := []*domain.Card{kzTestCard(domain.CardDesignClover, 2), kzTestCard(domain.CardDesignSpade, 4)}
+		out := p.HintOutput(kaiserHintMock(domain.KaiserPhaseBid, 0, domain.KaiserContractTrump, hand,
+			nil, domain.KaiserMustBidThreshold))
+		assert.Contains(t, out, "45 点以上")
+		assert.NotContains(t, out, "パス")
+	})
+
+	t.Run("discard: names the longest suit before trump is set", func(t *testing.T) {
+		hand := []*domain.Card{
+			kzTestCard(domain.CardDesignDiamond, 2), kzTestCard(domain.CardDesignDiamond, 4),
+			kzTestCard(domain.CardDesignDiamond, 9), kzTestCard(domain.CardDesignSpade, 4),
+		}
+		out := p.HintOutput(kaiserHintMock(domain.KaiserPhaseDiscard, 0, domain.KaiserContractTrump, hand, nil, 0))
+		assert.Contains(t, out, "切札")
+		assert.Contains(t, out, "♦")
+	})
+
+	// **♥5 と ♠3 は捨てられない。**知らずに指定するとドメインに弾かれる。
+	t.Run("discard: never offers the five of hearts or three of spades", func(t *testing.T) {
+		hand := []*domain.Card{
+			kzTestCard(domain.CardDesignHeart, 5), kzTestCard(domain.CardDesignSpade, 3),
+			kzTestCard(domain.CardDesignClover, 2), kzTestCard(domain.CardDesignDiamond, 4),
+			kzTestCard(domain.CardDesignHeart, 13),
+		}
+		out := p.HintOutput(kaiserHintMock(domain.KaiserPhaseDiscard, domain.CardDesignHeart,
+			domain.KaiserContractTrump, hand, nil, 0))
+		assert.Contains(t, out, "捨てられません")
+		// ♣2 (idx 2) と ♦4 (idx 3) が最も低い。♥ は切札なので残す。
+		assert.Contains(t, out, "[2], [3]")
+		assert.NotContains(t, out, "[0]")
+		assert.NotContains(t, out, "[1]")
+	})
+
+	t.Run("play: a single legal card is forced", func(t *testing.T) {
+		hand := []*domain.Card{kzTestCard(domain.CardDesignClover, 2), kzTestCard(domain.CardDesignSpade, 4)}
+		out := p.HintOutput(kaiserHintMock(domain.KaiserPhasePlay, domain.CardDesignHeart,
+			domain.KaiserContractTrump, hand, []int{1}, 0))
+		assert.Contains(t, out, "1 枚しかありません")
+		assert.Contains(t, out, "[1]")
+	})
+
+	t.Run("play: sheds the three of spades while it still can", func(t *testing.T) {
+		hand := []*domain.Card{kzTestCard(domain.CardDesignClover, 2), kzTestCard(domain.CardDesignSpade, 3)}
+		out := p.HintOutput(kaiserHintMock(domain.KaiserPhasePlay, domain.CardDesignHeart,
+			domain.KaiserContractTrump, hand, []int{0, 1}, 0))
+		assert.Contains(t, out, "♠3")
+		assert.Contains(t, out, "[1]")
+	})
+
+	t.Run("play: keeps the five of hearts back when something else will do", func(t *testing.T) {
+		hand := []*domain.Card{kzTestCard(domain.CardDesignHeart, 5), kzTestCard(domain.CardDesignClover, 2)}
+		out := p.HintOutput(kaiserHintMock(domain.KaiserPhasePlay, domain.CardDesignHeart,
+			domain.KaiserContractTrump, hand, []int{0, 1}, 0))
+		assert.Contains(t, out, "♥5")
+		assert.Contains(t, out, "[1]")
+	})
+
+	t.Run("not your turn", func(t *testing.T) {
+		hand := []*domain.Card{kzTestCard(domain.CardDesignClover, 2)}
+		m := kaiserHintMock(domain.KaiserPhasePlay, domain.CardDesignHeart, domain.KaiserContractTrump,
+			hand, []int{0}, 0)
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetCurrentPlayerIdx")
+		m.On("GetCurrentPlayerIdx").Return(2)
+		assert.Contains(t, p.HintOutput(m), "あなたの手番ではありません")
+	})
+
+	t.Run("game over", func(t *testing.T) {
+		hand := []*domain.Card{kzTestCard(domain.CardDesignClover, 2)}
+		m := kaiserHintMock(domain.KaiserPhasePlay, domain.CardDesignHeart, domain.KaiserContractTrump,
+			hand, []int{0}, 0)
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetGameEndFlag")
+		m.On("GetGameEndFlag").Return(true)
+		assert.Contains(t, p.HintOutput(m), "終了")
+	})
+}
+
+// ヒント文が ja / en 双方にあり、かつ別文字列であること。
+func TestKaiserHintKeys_TranslatedInBothLanguages(t *testing.T) {
+	defer i18n.SetLang("ja")
+	keys := []string{
+		"kaiser.hintNone", "kaiser.hintNotYourTurn", "kaiser.hintGameEnd", "kaiser.hintHandEnd",
+		"kaiser.hintBid", "kaiser.hintPass", "kaiser.hintBidMust", "kaiser.hintTrump",
+		"kaiser.hintDiscard", "kaiser.hintForced", "kaiser.hintDumpSpadeThree", "kaiser.hintChoose",
+	}
+	for _, key := range keys {
+		i18n.SetLang("ja")
+		ja := i18n.T(key)
+		assert.NotEqual(t, key, ja, "%s missing from ja", key)
+		i18n.SetLang("en")
+		en := i18n.T(key)
+		assert.NotEqual(t, key, en, "%s missing from en", key)
+		assert.NotEqual(t, ja, en, "%s is the same in both languages", key)
+	}
 }

--- a/internal/adapter/presenter/KaiserWebPresenter.go
+++ b/internal/adapter/presenter/KaiserWebPresenter.go
@@ -155,3 +155,12 @@ func (p *KaiserWebPresenter) buildMessage(g interfaces.KaiserGame, lastErr error
 func (p *KaiserWebPresenter) ActionLogOutput(g interfaces.KaiserGame) string {
 	return actionLogOutputJSON(g)
 }
+
+// HintOutput ヒント情報を出力する。
+//
+// **Web のヒントはフロント側が組み立てる** (`utils/hints/kaiserHint.ts`)。
+// サーバがもう一つ別の助言を載せると二重になるので、ここは通常の状態出力を
+// そのまま返す。CUI のヒントは KaiserCuiPresenter.HintOutput にある (#4938)。
+func (p *KaiserWebPresenter) HintOutput(g interfaces.KaiserGame) string {
+	return p.Output(g, nil)
+}

--- a/internal/i18n/locales/en/kaiser.json
+++ b/internal/i18n/locales/en/kaiser.json
@@ -6,6 +6,7 @@
   "helpDiscard": "  d <i> <j>                 Discard two after taking the kitty",
   "helpPlay": "  p <i>                     Play hand card i",
   "helpNext": "  n / next                  Deal the next hand",
+  "helpHint": "  h / hint                  show a hint",
   "header": "Hand: {{hand}}  Target: {{target}}  Team 0: {{t0}}  Team 1: {{t1}}",
   "contractLine": "Contract: {{value}} {{kind}} trump: {{trump}}",
   "withTrump": "with trump",
@@ -35,5 +36,18 @@
   "handMade": "The declaring side made its bid",
   "handSet": "The declaring side is set; the bid comes off its score",
   "result.humanWin": "Game over! Your team wins!",
-  "result.cpuWin": "Game over! The other team wins."
+  "result.cpuWin": "Game over! The other team wins.",
+  "hintNone": "There is nothing to advise right now.",
+  "hintNotYourTurn": "It is not your turn.",
+  "hintGameEnd": "The game is over.",
+  "hintHandEnd": "The hand is over. Press n for the next one.",
+  "hintBid": "A strong hand — consider bidding (only 10 points are in play and the minimum bid is 7).",
+  "hintPass": "Not strong enough for a bid; passing (ps) is the safe call.",
+  "hintBidMust": "Your team is at 45 or more, and can only score by bidding — you have to go for it.",
+  "hintTrump": "Naming your longest suit as trump is the usual choice.",
+  "hintDiscard": "The five of hearts and three of spades cannot be discarded. Shed low cards outside trump.",
+  "hintForced": "Only one card is legal.",
+  "hintDumpSpadeThree": "The three of spades costs its taker 3 points — shed it while you still have a choice.",
+  "hintChoose": "The five of hearts is worth 5 to whoever takes it, so leading it invites the opponents to grab it.",
+  "hintWith": "{{hint}} -> {{list}}"
 }

--- a/internal/i18n/locales/ja/kaiser.json
+++ b/internal/i18n/locales/ja/kaiser.json
@@ -6,6 +6,7 @@
   "helpDiscard": "  d <i> <j>                 キティを取り込んだあと2枚捨てる",
   "helpPlay": "  p <i>                     手札 i を出す",
   "helpNext": "  n / next                  次の局へ",
+  "helpHint": "  h / hint                  ヒントを表示",
   "header": "局: {{hand}}  目標: {{target}}点  チーム0: {{t0}}  チーム1: {{t1}}",
   "contractLine": "契約: {{value}} {{kind}} 切札: {{trump}}",
   "withTrump": "切札あり",
@@ -35,5 +36,18 @@
   "handMade": "宣言側が達成しました",
   "handSet": "宣言側が未達。宣言額がマイナスになります",
   "result.humanWin": "ゲーム終了！ あなたのチームの勝ち！",
-  "result.cpuWin": "ゲーム終了！ 相手チームの勝ち！"
+  "result.cpuWin": "ゲーム終了！ 相手チームの勝ち！",
+  "hintNone": "今は助言できることがありません。",
+  "hintNotYourTurn": "あなたの手番ではありません。",
+  "hintGameEnd": "ゲームは終了しています。",
+  "hintHandEnd": "局が終わりました。n で次の局へ進みます。",
+  "hintBid": "強い手です。ビッドを検討してください（1 局で動くのは 10 点、最低ビッドは 7 点）。",
+  "hintPass": "ビッドに見合う強さがありません。パス（ps）が無難です。",
+  "hintBidMust": "自チームは 45 点以上です。自分がビッドしない限り加点できないので、取りに行くほかありません。",
+  "hintTrump": "最も長いスートを切札にするのが基本です。",
+  "hintDiscard": "♥5 と ♠3 は捨てられません。切札以外の低い札を落とします。",
+  "hintForced": "出せる札が 1 枚しかありません。",
+  "hintDumpSpadeThree": "♠3 は取った側が −3 点です。選べるうちに手放します。",
+  "hintChoose": "♥5 は +5 点なので、自分から出すと相手に取られかねません。",
+  "hintWith": "{{hint}} → {{list}}"
 }

--- a/internal/infrastructure/ui/GameManager.go
+++ b/internal/infrastructure/ui/GameManager.go
@@ -4069,6 +4069,7 @@ var gameRegistry = []GameRegistryEntry{
 					"kaiser.helpDiscard",
 					"kaiser.helpPlay",
 					"kaiser.helpNext",
+					"kaiser.helpHint",
 				},
 				ExtraCommandLines: []string{"  l                        action log"},
 			})

--- a/internal/usecase/KaiserInteractor.go
+++ b/internal/usecase/KaiserInteractor.go
@@ -32,6 +32,8 @@ type KaiserInteractorIF interface {
 	GetConfig() domain.KaiserConfig
 	// ActionLog 棋譜を出力する
 	ActionLog() string
+	// Hint ヒント取得
+	Hint() string
 }
 
 // KaiserInteractor カイザー (Kaiser) のインタラクタークラス
@@ -118,6 +120,9 @@ func (ki *KaiserInteractor) GetConfig() domain.KaiserConfig {
 func (ki *KaiserInteractor) ActionLog() string {
 	return ki.gp.ActionLogOutput(ki.Game)
 }
+
+// Hint ヒント取得
+func (ki *KaiserInteractor) Hint() string { return ki.gp.HintOutput(ki.Game) }
 
 // kaiserMaxCpuSteps bounds runCpuTurns so a malformed state can never spin the
 // CPU loop forever (defensive — normal play always reaches a human turn, the

--- a/internal/usecase/KaiserInteractor_test.go
+++ b/internal/usecase/KaiserInteractor_test.go
@@ -249,6 +249,17 @@ func TestKaiserInteractor_GetConfigAndActionLog(t *testing.T) {
 	assert.Equal(t, `[]`, ki.ActionLog())
 }
 
+// **CUI のヒントはここを通る。**presenter の HintOutput に素通しする (#4938)。
+func TestKaiserInteractor_Hint(t *testing.T) {
+	pMock := new(presenter.MockKaiserPresenter)
+	pMock.On("HintOutput", mock.Anything).Return("advice")
+	gameMock := new(interfaces.MockKaiserGame)
+
+	ki := usecase.NewKaiserInteractor(gameMock, pMock)
+	assert.Equal(t, "advice", ki.Hint())
+	pMock.AssertCalled(t, "HintOutput", gameMock)
+}
+
 func TestKaiserInteractor_SnapshotAndRestore(t *testing.T) {
 	pMock := new(presenter.MockKaiserPresenter)
 	pMock.On("Output", mock.Anything, mock.Anything).Return(kaiserMockOutput)

--- a/internal/usecase/presenter/KaiserPresenter.go
+++ b/internal/usecase/presenter/KaiserPresenter.go
@@ -5,4 +5,8 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // KaiserPresenter カイザー (Kaiser) プレゼンターインタフェース
-type KaiserPresenter = GamePresenter[interfaces.KaiserGame]
+type KaiserPresenter interface {
+	GamePresenter[interfaces.KaiserGame]
+	// HintOutput ヒント情報を出力する
+	HintOutput(g interfaces.KaiserGame) string
+}

--- a/internal/usecase/presenter/KaiserPresenter_mock.go
+++ b/internal/usecase/presenter/KaiserPresenter_mock.go
@@ -5,4 +5,12 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // MockKaiserPresenter カイザー (Kaiser) プレゼンターモック
-type MockKaiserPresenter = MockGamePresenter[interfaces.KaiserGame]
+type MockKaiserPresenter struct {
+	MockGamePresenter[interfaces.KaiserGame]
+}
+
+// HintOutput モック
+func (_m *MockKaiserPresenter) HintOutput(g interfaces.KaiserGame) string {
+	ret := _m.Called(g)
+	return ret.Get(0).(string)
+}


### PR DESCRIPTION
Closes #4938

## 背景

Web の `KaiserPage` にはヒントのチェックボックスと `FrontendHintTooltip` があるのに、`KaiserCuiController` は `hint`/`h` を有効コマンドとして登録しておらず、`KaiserInteractor` に `Hint()` も `KaiserCuiPresenter` に `HintOutput` も無かった。3手のビッド・切札の指定・キティの取捨と判断点が多いのに、CUI プレイヤーは一切の補助を受けられなかった。

## issue の前提の訂正

issue は「`getKaiserHint` がビッド・切札・捨て札・プレイの各局面で助言を返す」と書いているが、**フロントのヒントはプレイ局面しか扱わない** — `kaiserHint.ts` は `state.phase !== PLAY_PHASE` で `null` を返す。なので「Web の判断ロジックを踏襲する」だけでは受け入れ条件 (4フェーズで意味のある助言) を満たさない。CUI 側で 4 局面すべてを書いた。

## 助言の中身

| 局面 | 助言 | 根拠 |
|------|------|------|
| ビッド | ビッド or パス | **1 局で動くのは 10 点しかなく、最低ビッドが 7。**「最長スートが 4 枚以上でその A/K を持つ」か「♥5 を持つ」(単独で 5 点) を強い手とみなす |
| ビッド (45点以上) | 降りる選択は無い | `KaiserMustBidThreshold` — 自分がビッドしない限り加点できない |
| 切札 | 最長スート | 同数なら複数を並べる |
| 捨て札 | **♥5 と ♠3 は捨てられない** + 切札以外の低い 2 枚 | `Discard` がこの 2 枚を明示的に拒否する。知らずに指定して初めて分かる規則 |
| プレイ | 強制手 → ♠3 を手放す → ♥5 は自分から出さない | フロントの `getKaiserHint` と同じ判断 |

## 配線

`KaiserPresenter` を `GamePresenter` の別名から `HintOutput` を持つインタフェースに変更したため、Web presenter にも実装が要る。**Web のヒントはフロントが組み立てる**ので、サーバがもう一つ載せると二重になる。よって `KaiserWebPresenter.HintOutput` は通常の状態出力をそのまま返す (Burraco / Macau / Cribbage / HandAndFoot と同じ扱い)。ワイヤ形式は変わらない。

CUI ヘルプにも `h / hint` を追加した。

## テスト

- presenter 10 ケース: ビッド(強/弱/45点以上)、切札の提示、**捨て札が ♥5/♠3 を決して挙げないこと**、強制手、♠3 の放出、♥5 の温存、他人の手番、ゲーム終了
- controller: `h` と `hint` が `Hint()` を呼ぶこと + **既存の `log` が巻き添えを食わないこと** (受け入れ条件3)
- interactor: `Hint()` が presenter に素通しすること
- ヒント文 12 キーが ja/en 双方にあり、かつ別文字列であること

ネガティブコントロール: 捨て札から ♥5/♠3 の除外を外す・プレイの ♠3 分岐を外す → それぞれ該当テストが落ちる。

`go test -tags test ./...` / `golangci-lint run ./internal/...` (0 issues) green。

## Test plan

- [ ] CI green