### PR TITLE
feat(boston): tag the exposed and partner-callable levels in the CUI ladder

### DIFF
--- a/internal/adapter/presenter/BostonCuiPresenter.go
+++ b/internal/adapter/presenter/BostonCuiPresenter.go
@@ -153,6 +153,15 @@ func bostonLadderLine() string {
 			b.WriteString(" < ")
 		}
 		b.WriteString(strconv.Itoa(int(l)) + ":" + bostonBidLabel(l))
+		// **どの段が手札を晒し、どの段で味方を呼べるかまで見せる。**段の名前
+		// だけでは、自分の宣言が第 1 トリックのあとに手札を公開する羽目になるか
+		// も、単独で戦うことになるかも分からないまま競らせることになる (#4939)。
+		if domain.BostonBidIsExposed(l) {
+			b.WriteString(i18n.T("boston.ladderExposedTag"))
+		}
+		if domain.BostonBidCanCallPartner(l) {
+			b.WriteString(i18n.T("boston.ladderPartnerTag"))
+		}
 	}
 	return b.String()
 }

--- a/internal/adapter/presenter/BostonCuiPresenter_test.go
+++ b/internal/adapter/presenter/BostonCuiPresenter_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func setupBostonCuiMock(o bostonMockOpts) *interfaces.MockBostonGame {
@@ -56,6 +57,44 @@ func TestBostonCuiPresenter_HidesOpponentHands(t *testing.T) {
 	assert.Contains(t, out, "[親]")
 	assert.Contains(t, out, "[宣言]")
 	assert.Contains(t, out, "場:")
+}
+
+// **どの段が手札を晒し、どの段で味方を呼べるかを見せる。**Web の宣言ラダーは
+// タグで示しているのに、CUI は level:name を並べるだけで、自分の宣言が第1
+// トリック後に手札を晒す羽目になるか知らないままビッドさせていた (#4939)。
+func TestBostonCuiPresenter_LadderTagsExposedAndPartnerLevels(t *testing.T) {
+	o := defaultBostonOpts()
+	o.phase = domain.BostonPhaseBid
+	o.highBid = nil
+	out := new(presenter.BostonCuiPresenter).Output(setupBostonCuiMock(o), nil)
+
+	// トリック宣言は味方を呼べるが手札は晒さない。
+	assert.Contains(t, out, "1:5トリック[相方]")
+	assert.Contains(t, out, "2:6トリック[相方]")
+	// 11 トリック以上は単独固定。呼べない。
+	assert.Contains(t, out, "12:11トリック <")
+	// ミゼールの公開版は晒す側。味方は呼べない。
+	assert.Contains(t, out, "9:リトル・ミゼール（公開）[公開]")
+	assert.Contains(t, out, "11:グランド・ミゼール（公開）[公開]")
+	// 素のミゼールにはどちらも付かない。
+	assert.Contains(t, out, "3:リトル・ミゼール <")
+	assert.Contains(t, out, "7:グランド・ミゼール <")
+	// 既存の区切り記号とレベル番号の形式は変えない (受け入れ条件3)。
+	assert.Contains(t, out, " < ")
+}
+
+// ja / en 双方にタグの訳があり、席の [味方] マークとは別のキーであること。
+// 同じキーを使い回すと、片方を直したときにもう片方が巻き添えを食う。
+func TestBostonLadderTags_TranslatedAndDistinctFromTheSeatMarker(t *testing.T) {
+	defer i18n.SetLang("ja")
+	for _, lang := range []string{"ja", "en"} {
+		i18n.SetLang(lang)
+		for _, key := range []string{"boston.ladderExposedTag", "boston.ladderPartnerTag"} {
+			assert.NotEqual(t, key, i18n.T(key), "%s missing from %s", key, lang)
+		}
+		assert.NotEqual(t, i18n.T("boston.partnerTag"), i18n.T("boston.ladderPartnerTag"),
+			"the seat marker and the ladder tag must not share a key (%s)", lang)
+	}
 }
 
 // **序列を見せないと競りの判断ができない。**ミゼールが間に挟まるため。

--- a/internal/adapter/presenter/BostonCuiPresenter_test.go
+++ b/internal/adapter/presenter/BostonCuiPresenter_test.go
@@ -4,6 +4,7 @@ package presenter_test
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -79,6 +80,8 @@ func TestBostonCuiPresenter_LadderTagsExposedAndPartnerLevels(t *testing.T) {
 	// 素のミゼールにはどちらも付かない。
 	assert.Contains(t, out, "3:リトル・ミゼール <")
 	assert.Contains(t, out, "7:グランド・ミゼール <")
+	// 最上段のシュレム（公開）も晒す側。
+	assert.Contains(t, out, "15:シュレム（公開）[公開]")
 	// 既存の区切り記号とレベル番号の形式は変えない (受け入れ条件3)。
 	assert.Contains(t, out, " < ")
 }
@@ -92,8 +95,11 @@ func TestBostonLadderTags_TranslatedAndDistinctFromTheSeatMarker(t *testing.T) {
 		for _, key := range []string{"boston.ladderExposedTag", "boston.ladderPartnerTag"} {
 			assert.NotEqual(t, key, i18n.T(key), "%s missing from %s", key, lang)
 		}
-		assert.NotEqual(t, i18n.T("boston.partnerTag"), i18n.T("boston.ladderPartnerTag"),
-			"the seat marker and the ladder tag must not share a key (%s)", lang)
+		// **大文字小文字だけの違いにしない。**CUI 出力を貼られたときに
+		// 席マーカーと見分けが付かなくなる。
+		assert.NotEqual(t, strings.ToLower(i18n.T("boston.partnerTag")),
+			strings.ToLower(i18n.T("boston.ladderPartnerTag")),
+			"the seat marker and the ladder tag must read differently (%s)", lang)
 	}
 }
 

--- a/internal/i18n/locales/en/boston.json
+++ b/internal/i18n/locales/en/boston.json
@@ -17,7 +17,7 @@
   "playable": "Playable: {{indexes}}",
   "ladderTitle": "Ladder:",
   "ladderExposedTag": "[exposed]",
-  "ladderPartnerTag": "[partner]",
+  "ladderPartnerTag": "[can call partner]",
   "gameEnd": "Game over! {{name}} wins!",
   "promptBid": "Bid: {{name}}",
   "promptBidHelp": "b <step> [suit] ... bid (the miseres sit BETWEEN the trick bids) / ps ... pass",

--- a/internal/i18n/locales/en/boston.json
+++ b/internal/i18n/locales/en/boston.json
@@ -16,6 +16,8 @@
   "trick": "Trick: {{cards}}",
   "playable": "Playable: {{indexes}}",
   "ladderTitle": "Ladder:",
+  "ladderExposedTag": "[exposed]",
+  "ladderPartnerTag": "[partner]",
   "gameEnd": "Game over! {{name}} wins!",
   "promptBid": "Bid: {{name}}",
   "promptBidHelp": "b <step> [suit] ... bid (the miseres sit BETWEEN the trick bids) / ps ... pass",

--- a/internal/i18n/locales/ja/boston.json
+++ b/internal/i18n/locales/ja/boston.json
@@ -16,6 +16,8 @@
   "trick": "場: {{cards}}",
   "playable": "出せる札: {{indexes}}",
   "ladderTitle": "序列:",
+  "ladderExposedTag": "[公開]",
+  "ladderPartnerTag": "[相方]",
   "gameEnd": "ゲーム終了！ {{name}}の勝ち！",
   "promptBid": "宣言: {{name}}",
   "promptBidHelp": "b <段の番号> [スート] ・・・宣言（ミゼールはトリック宣言の間に挟まります）／ps ・・・見送る",


### PR DESCRIPTION
Closes #4939

## 背景

Web の宣言ラダー (`boston-ladder`) は各レベルに `[公開]` / `[味方を呼べる]` を併記しているのに、CUI の `bostonLadderLine` は `level:name` を ` < ` で繋ぐだけだった。CUI プレイヤーは、自分の宣言が第 1 トリック後に手札を晒す羽目になるか、味方を呼べるかを知らないままビッドすることになる。

## 変更

`bostonLadderLine` が `domain.BostonBidIsExposed` / `BostonBidCanCallPartner` を引いて、各レベルの末尾にタグを足す:

```
序列: 1:5トリック[相方] < 2:6トリック[相方] < 3:リトル・ミゼール < …
      … < 9:リトル・ミゼール（公開）[公開] < … < 12:11トリック < …
```

**レベル番号・名前・区切り記号の形式は変えていない** (受け入れ条件3)。タグを末尾に足すだけ。

### キーを分けた理由

席の「この人が味方」マークは既存の `boston.partnerTag` (`[味方]`) で、ラダーのタグとは意味が違う。最初これを流用しかけたが、既存の `TestBostonCuiPresenter_MarksThePartner` が落ちて気づいた。別キー (`ladderExposedTag` / `ladderPartnerTag`) にしてある — 共有すると片方の文言を直したときにもう片方が巻き添えを食う。テストでもこの 2 つが別物であることを固定した。

## テスト

`TestBostonCuiPresenter_LadderTagsExposedAndPartnerLevels`:

- トリック宣言 (5/6) に `[相方]` が付く
- **11 トリック以上は単独固定**なので付かない
- ミゼールの公開版 (9/11 段) に `[公開]` が付き、`[相方]` は付かない
- 素のミゼール (3/7 段) にはどちらも付かない
- ` < ` 区切りが残っている

`TestBostonLadderTags_TranslatedAndDistinctFromTheSeatMarker` — ja/en 双方に訳があり、席マーカーとキーが別であること。

ネガティブコントロール: `BostonBidIsExposed` の分岐を外すと落ちる。既存の席マーカーのテストも通ったまま。

`go test -tags test ./...` / `golangci-lint run ./internal/...` (0 issues) green。

## Test plan

- [ ] CI green