### PR TITLE
feat(basra): annotate which table cards each hand card can capture in the CUI

### DIFF
--- a/internal/adapter/presenter/BasraCuiPresenter.go
+++ b/internal/adapter/presenter/BasraCuiPresenter.go
@@ -40,6 +40,12 @@ func basraPlayerStr(g interfaces.BasraGame, idx int) string {
 		"basra", strconv.Itoa(player.GetBasraCount())) + "\n")
 	if player.GetIsHuman() && player.GetCardsSize() > 0 {
 		b.WriteString(cuiIndexedCardListStr(player) + "\n")
+		// **どの札で何を取れるかを見せる。**Web は選択中の札が捕獲できる場札を
+		// リングとチェックで示すのに、CUI はヒントを叩かない限り分からなかった
+		// (#4922)。判定はドメインの GetCaptureOptions をそのまま使う。
+		if line := cuiCaptureHintLine(player, g.GetCaptureOptions(idx), "basra.captureHint"); line != "" {
+			b.WriteString(line + "\n")
+		}
 	}
 	return b.String()
 }

--- a/internal/adapter/presenter/BasraCuiPresenter_test.go
+++ b/internal/adapter/presenter/BasraCuiPresenter_test.go
@@ -20,6 +20,46 @@ func TestBasraCuiPresenter_Output_PlayPhase(t *testing.T) {
 	assert.Contains(t, out, "[0]") // human indexed hand + indexed table
 }
 
+// **どの札で何を取れるかを見せる。**Web は選択中の札が捕獲できる場札を
+// リングとチェックで示すのに、CUI はヒントを叩かない限り分からなかった (#4922)。
+func TestBasraCuiPresenter_AnnotatesCaptureOptions(t *testing.T) {
+	g := domain.NewDefaultBasra()
+	g.Reset()
+	g.SetPhase(domain.BasraPhasePlay)
+	g.SetCurrentTurn(0)
+
+	human := g.GetPlayer(0)
+	human.Reset()
+	human.AddCard(domain.NewCard(domain.CardDesignSpade, 5, false)) // 場の 5 を取れる
+	human.AddCard(domain.NewCard(domain.CardDesignHeart, 9, false)) // 何も取れない
+	g.SetTableCards([]*domain.Card{
+		domain.NewCard(domain.CardDesignClover, 5, false),
+		domain.NewCard(domain.CardDesignDiamond, 3, false),
+	})
+
+	out := new(presenter.BasraCuiPresenter).Output(g, nil)
+	// ♠5 は場[0] の ♣5 を取れる。
+	assert.Contains(t, out, "[0]SPADE 5 → 場[0]")
+	// 何も取れない札には注記が付かない (受け入れ条件2)。
+	assert.NotContains(t, out, "[1]HEART 9 →")
+}
+
+// CPU の手番でも人間の手札の注記は出す (手札はもともと公開されている)。
+// 一方、捕獲できる札が 1 枚も無ければ行そのものを出さない。
+func TestBasraCuiPresenter_NoCaptureLineWhenNothingCanBeTaken(t *testing.T) {
+	g := domain.NewDefaultBasra()
+	g.Reset()
+	g.SetPhase(domain.BasraPhasePlay)
+	g.SetCurrentTurn(0)
+
+	human := g.GetPlayer(0)
+	human.Reset()
+	human.AddCard(domain.NewCard(domain.CardDesignHeart, 9, false))
+	g.SetTableCards([]*domain.Card{domain.NewCard(domain.CardDesignDiamond, 3, false)})
+
+	assert.NotContains(t, new(presenter.BasraCuiPresenter).Output(g, nil), "→ 場")
+}
+
 func TestBasraCuiPresenter_Output_AllPhases(t *testing.T) {
 	p := new(presenter.BasraCuiPresenter)
 

--- a/internal/adapter/presenter/TablanetCuiPresenter.go
+++ b/internal/adapter/presenter/TablanetCuiPresenter.go
@@ -41,26 +41,9 @@ func tablanetPlayerStr(g interfaces.TablanetGame, idx int) string {
 	if player.GetIsHuman() && player.GetCardsSize() > 0 {
 		b.WriteString(cuiIndexedCardListStr(player) + "\n")
 		// Annotate which table cards each hand card can capture, reusing the
-		// domain's capture computation (GetCaptureOptions). Cards that capture
-		// nothing get no note; the map is empty outside the play phase.
-		if opts := g.GetCaptureOptions(idx); len(opts) > 0 {
-			var notes []string
-			for h := 0; h < player.GetCardsSize(); h++ {
-				tableIdxs := opts[h]
-				if len(tableIdxs) == 0 {
-					continue
-				}
-				marks := make([]string, len(tableIdxs))
-				for j, ti := range tableIdxs {
-					marks[j] = "[" + strconv.Itoa(ti) + "]"
-				}
-				notes = append(notes, i18n.Tf("tablanet.captureHint",
-					"hand", "["+strconv.Itoa(h)+"]"+cuiCardStr(player.GetCard(h)),
-					"table", strings.Join(marks, "")))
-			}
-			if len(notes) > 0 {
-				b.WriteString(strings.Join(notes, "  ") + "\n")
-			}
+		// domain's capture computation (GetCaptureOptions).
+		if line := cuiCaptureHintLine(player, g.GetCaptureOptions(idx), "tablanet.captureHint"); line != "" {
+			b.WriteString(line + "\n")
 		}
 	}
 	return b.String()

--- a/internal/adapter/presenter/cui_card_helper.go
+++ b/internal/adapter/presenter/cui_card_helper.go
@@ -201,3 +201,34 @@ func cuiCardSliceStr(cards []*domain.Card) string {
 func cuiCardSliceStrEmoji(cards []*domain.Card) string {
 	return formatCardSlice(cards, cuiCardStrEmoji, "  ")
 }
+
+// cuiCaptureHintLine annotates each hand card with the table cards it can
+// capture, e.g. `[0]♠5 → 場[1][3]`.
+//
+// Shared by the fishing games (Basra, Tablanet), which all get the pairing from
+// the domain's own `GetCaptureOptions`. **Recomputing it per presenter is how
+// the note starts disagreeing with what the server will accept** (#4922).
+// Cards that capture nothing get no note; an empty result means no line at all.
+func cuiCaptureHintLine(hand cuiCardList, opts map[int][]int, key string) string {
+	if len(opts) == 0 {
+		return ""
+	}
+	notes := make([]string, 0, hand.GetCardsSize())
+	for h := range hand.GetCardsSize() {
+		tableIdxs := opts[h]
+		if len(tableIdxs) == 0 {
+			continue
+		}
+		marks := make([]string, len(tableIdxs))
+		for j, ti := range tableIdxs {
+			marks[j] = "[" + strconv.Itoa(ti) + "]"
+		}
+		notes = append(notes, i18n.Tf(key,
+			"hand", "["+strconv.Itoa(h)+"]"+cuiCardStr(hand.GetCard(h)),
+			"table", strings.Join(marks, "")))
+	}
+	if len(notes) == 0 {
+		return ""
+	}
+	return strings.Join(notes, "  ")
+}

--- a/internal/adapter/presenter/cui_card_helper_test.go
+++ b/internal/adapter/presenter/cui_card_helper_test.go
@@ -545,3 +545,22 @@ func TestCuiPlayerNameColor(t *testing.T) {
 	got = cuiPlayerName[*mockCuiPlayer](nil, 0)
 	assert.Equal(t, "UNKNOWN", got)
 }
+
+// 共有ヘルパの境界。**空を返す条件を取り違えると、空行だけが出る。**
+func TestCuiCaptureHintLine(t *testing.T) {
+	hand := domain.NewBasraPlayer(true)
+	hand.AddCard(domain.NewCard(domain.CardDesignSpade, 5, false))
+	hand.AddCard(domain.NewCard(domain.CardDesignHeart, 9, false))
+
+	// 捕獲候補がある札だけ注記が付く。
+	line := cuiCaptureHintLine(hand, map[int][]int{0: {1, 3}}, "tablanet.captureHint")
+	assert.Contains(t, line, "[0]SPADE 5")
+	assert.Contains(t, line, "[1][3]")
+	assert.NotContains(t, line, "HEART 9")
+
+	// 候補が無ければ 1 行も出さない (空文字。空白 1 文字ではない)。
+	assert.Empty(t, cuiCaptureHintLine(hand, map[int][]int{}, "tablanet.captureHint"))
+	assert.Empty(t, cuiCaptureHintLine(hand, nil, "tablanet.captureHint"))
+	// 値が空スライスのキーしか無い場合も同じ。
+	assert.Empty(t, cuiCaptureHintLine(hand, map[int][]int{0: {}}, "tablanet.captureHint"))
+}

--- a/internal/i18n/locales/en/basra.json
+++ b/internal/i18n/locales/en/basra.json
@@ -15,5 +15,6 @@
   "hintReasonJack": "Play a Jack to sweep the table",
   "hintReasonCapture": "Capture the most valuable table cards",
   "hintReasonTrail": "No capture — trail a low card",
-  "result.scores": "Game over! Scores: {{scores}}"
+  "result.scores": "Game over! Scores: {{scores}}",
+  "captureHint": "{{hand}} → table {{table}}"
 }

--- a/internal/i18n/locales/ja/basra.json
+++ b/internal/i18n/locales/ja/basra.json
@@ -15,5 +15,6 @@
   "hintReasonJack": "ジャックで場を一掃する",
   "hintReasonCapture": "価値の高い場札を捕獲する",
   "hintReasonTrail": "捕獲できないので低い札を捨てる",
-  "result.scores": "ゲーム終了！ 得点: {{scores}}"
+  "result.scores": "ゲーム終了！ 得点: {{scores}}",
+  "captureHint": "{{hand}} → 場{{table}}"
 }


### PR DESCRIPTION
Closes #4922

## 背景

`BasraPage.tsx` は選択中の札が捕獲できる場札をリング＋チェックで強調する。姉妹ゲームの `TablanetCuiPresenter` も同じドメインメソッド `GetCaptureOptions` を使って `[h]♠5 → 場[0][2]` の注記を CUI に出している。ところが `BasraCuiPresenter.basraPlayerStr` はこのメソッドが使えるのに一切呼んでおらず、CUI プレイヤーはヒントコマンドを叩かない限りどの札で何を取れるか分からなかった。

## 変更

Tablanet 側にあった注記ロジックを `cuiCaptureHintLine(hand, opts, key)` として `cui_card_helper.go` に切り出し、**Basra と Tablanet の両方から呼ぶ**。issue は「Tablanet の captureHint ロジックを移植する」と書いているが、コピーすると 2 箇所に同じ規則が残る — **判定を presenter ごとに書き写すのは、注記とサーバが受け付ける手が食い違い始める道**なので、共有した。Tablanet の出力は変わらない (既存テストが通ったまま)。

`internal/i18n/locales/{ja,en}/basra.json` に `captureHint` を追加。

## テスト

- `AnnotatesCaptureOptions` — ♠5 が場の ♣5 を取れることが `[0]SPADE 5 → 場[0]` として出る。**何も取れない札には注記が付かない**（受け入れ条件2）
- `NoCaptureLineWhenNothingCanBeTaken` — 1 枚も取れなければ行そのものを出さない
- `TestCuiCaptureHintLine` — 共有ヘルパの境界を直接: 候補のある札だけ注記／`nil`・空マップ・**値が空スライスのキーしか無い場合**のいずれも空文字（空白 1 文字ではない）を返す

ネガティブコントロール: Basra 側の呼び出しを外すと `AnnotatesCaptureOptions` が落ちる。

`go test -tags test ./...` / `golangci-lint run ./internal/...` (0 issues) green。

## Test plan

- [ ] CI green