### PR TITLE
feat(loo): show the pot reward and loo penalty in the CUI decide phase

### DIFF
--- a/frontend/src/pages/LooPage.test.tsx
+++ b/frontend/src/pages/LooPage.test.tsx
@@ -103,13 +103,16 @@ describe('LooPage', () => {
   });
 
   it('shows the pot reward and loo risk at the decide phase', async () => {
-    // Default deal pot/potStart = 12 → win up to +12 (+2 per trick), loo penalty -12.
+    // Default deal pot/potStart = 12 → 2 per trick, so a sweep pays 10, not 12:
+    // the remainder stays in the pot. The penalty is the full 12 (#4921).
     mockExec.mockResolvedValue(decidePhaseState);
     renderWithProviders(<LooPage />);
     const potRisk = await screen.findByTestId('loo-pot-risk');
-    expect(potRisk).toHaveTextContent('+12');
+    expect(potRisk).toHaveTextContent('+10');
     expect(potRisk).toHaveTextContent('+2');
     expect(potRisk).toHaveTextContent('-12');
+    // **ポット全額は入らない。**「最大 +12」は実際より多く見せることになる。
+    expect(potRisk).not.toHaveTextContent('+12');
   });
 
   it('does not show the pot-risk block outside the human decide turn', async () => {

--- a/frontend/src/pages/LooPage.tsx
+++ b/frontend/src/pages/LooPage.tsx
@@ -324,14 +324,14 @@ function LooPageContent() {
             )}
             {canDecide &&
               (() => {
-                const { pot, looPenalty, perTrick } = computeLooPotRisk(state.pot, state.potStart);
+                const { looPenalty, perTrick, maxWin } = computeLooPotRisk(state.pot, state.potStart);
                 return (
                   <div
                     className="mb-2 mx-auto max-w-md p-2 rounded bg-black/30 text-center text-sm"
                     data-testid="loo-pot-risk"
                   >
                     <div className="text-ds-text-muted mb-0.5">{t('potRisk.label')}</div>
-                    <div className="text-ds-accent">{t('potRisk.win', { pot, perTrick })}</div>
+                    <div className="text-ds-accent">{t('potRisk.win', { pot: maxWin, perTrick })}</div>
                     <div className="text-ds-error">{t('potRisk.loss', { penalty: looPenalty })}</div>
                   </div>
                 );

--- a/frontend/src/utils/looPotRisk.test.ts
+++ b/frontend/src/utils/looPotRisk.test.ts
@@ -4,24 +4,31 @@ import { computeLooPotRisk } from './looPotRisk';
 describe('computeLooPotRisk', () => {
   it('derives the loo penalty from potStart and the per-trick share from potStart/5', () => {
     // Default deal: 4 players ante 3 → pot 12, potStart 12.
-    expect(computeLooPotRisk(12, 12)).toEqual({ pot: 12, looPenalty: 12, perTrick: 2 });
+    expect(computeLooPotRisk(12, 12)).toEqual({ pot: 12, looPenalty: 12, perTrick: 2, maxWin: 10 });
   });
 
   it('floors the per-trick share when potStart is not divisible by 5', () => {
     // potStart 18 → 18/5 = 3.6 → floored to 3; penalty stays the full 18.
-    expect(computeLooPotRisk(18, 18)).toEqual({ pot: 18, looPenalty: 18, perTrick: 3 });
+    expect(computeLooPotRisk(18, 18)).toEqual({ pot: 18, looPenalty: 18, perTrick: 3, maxWin: 15 });
   });
 
   it('keeps the shown pot independent of the potStart-based risk figures', () => {
     // Pot can differ from potStart mid-deal; the penalty always tracks potStart.
-    expect(computeLooPotRisk(20, 15)).toEqual({ pot: 20, looPenalty: 15, perTrick: 3 });
+    expect(computeLooPotRisk(20, 15)).toEqual({ pot: 20, looPenalty: 15, perTrick: 3, maxWin: 15 });
+  });
+
+  // **全トリック取っても pot 全額は入らない。**端数はポットに残る。
+  it('reports the reachable maximum, which is below the pot when it does not divide by five', () => {
+    const { pot, maxWin } = computeLooPotRisk(37, 37);
+    expect(maxWin).toBe(35);
+    expect(maxWin).toBeLessThan(pot);
   });
 
   it('clamps negative inputs to zero', () => {
-    expect(computeLooPotRisk(-5, -5)).toEqual({ pot: 0, looPenalty: 0, perTrick: 0 });
+    expect(computeLooPotRisk(-5, -5)).toEqual({ pot: 0, looPenalty: 0, perTrick: 0, maxWin: 0 });
   });
 
   it('yields a zero per-trick share for a pot smaller than one share', () => {
-    expect(computeLooPotRisk(4, 4)).toEqual({ pot: 4, looPenalty: 4, perTrick: 0 });
+    expect(computeLooPotRisk(4, 4)).toEqual({ pot: 4, looPenalty: 4, perTrick: 0, maxWin: 0 });
   });
 });

--- a/frontend/src/utils/looPotRisk.ts
+++ b/frontend/src/utils/looPotRisk.ts
@@ -12,17 +12,26 @@ export interface LooPotRisk {
   looPenalty: number;
   /**
    * Chips won per trick captured — one fifth of `potStart`, floored, matching
-   * the domain's `share := potStart / LooTrickCount` integer division.
+   * the domain's `LooPerTrickShare` integer division.
    */
   perTrick: number;
+  /**
+   * Chips actually won by taking all five tricks: `perTrick * 5`.
+   *
+   * **Not the whole pot.** The domain floors the per-trick share, so on a pot
+   * of 37 a player who sweeps collects 35 and the remaining 2 stays in the pot.
+   * Showing `pot` here promised more than the game pays (#4921).
+   */
+  maxWin: number;
 }
 
 /**
  * Computes the pot reward and loo risk facing the human at the Loo Play/Pass
  * decision.
  *
- * A participant wins `floor(potStart / 5)` chips per trick captured (up to the
- * whole pot across all five tricks), while a participant who plays but takes no
+ * A participant wins `floor(potStart / 5)` chips per trick captured (so a sweep
+ * pays {@link LooPotRisk.maxWin}, which is **less than the pot** when it does
+ * not divide by five), while a participant who plays but takes no
  * trick is "looed" and pays a penalty of `potStart` into the next deal's pot.
  * This is neutral informational display, not advice.
  *
@@ -33,9 +42,11 @@ export interface LooPotRisk {
 export function computeLooPotRisk(pot: number, potStart: number): LooPotRisk {
   const safePot = Math.max(0, pot);
   const safeStart = Math.max(0, potStart);
+  const perTrick = Math.floor(safeStart / LOO_TRICK_COUNT);
   return {
     pot: safePot,
     looPenalty: safeStart,
-    perTrick: Math.floor(safeStart / LOO_TRICK_COUNT),
+    perTrick,
+    maxWin: perTrick * LOO_TRICK_COUNT,
   };
 }

--- a/internal/adapter/presenter/LooCuiPresenter.go
+++ b/internal/adapter/presenter/LooCuiPresenter.go
@@ -86,11 +86,12 @@ func (p *LooCuiPresenter) Output(g interfaces.LooGame, lastErr error) string {
 				"name", cuiPlayerName(g.GetPlayer(deciderIdx), deciderIdx)) + "\n")
 			// **参加の損得を出す。**Web は potRisk パネルで示すのに、CUI は現在の
 			// ポット額しか見えず、取り分もルーの負担も暗算させていた (#4921)。
-			// **除算はドメインの share と同じ整数除算。**端数は切り捨て。
+			// **「最大」はポット全額ではない。**端数はポットに残るので、
+			// 37 のディールで全トリック取っても入るのは 35 (レビュー指摘)。
 			potStart := max(g.GetPotStart(), 0)
 			b.WriteString(i18n.Tf("loo.potRisk",
-				"pot", strconv.Itoa(potStart),
-				"perTrick", strconv.Itoa(potStart/domain.LooTrickCount),
+				"pot", strconv.Itoa(domain.LooMaxWin(potStart)),
+				"perTrick", strconv.Itoa(domain.LooPerTrickShare(potStart)),
 				"penalty", strconv.Itoa(potStart)) + "\n")
 		case domain.LooPhasePlay:
 			currentIdx := g.GetCurrentTurn()

--- a/internal/adapter/presenter/LooCuiPresenter.go
+++ b/internal/adapter/presenter/LooCuiPresenter.go
@@ -84,6 +84,14 @@ func (p *LooCuiPresenter) Output(g interfaces.LooGame, lastErr error) string {
 			deciderIdx := g.GetDecidePlayerIdx()
 			b.WriteString(i18n.Tf("loo.promptDecide",
 				"name", cuiPlayerName(g.GetPlayer(deciderIdx), deciderIdx)) + "\n")
+			// **参加の損得を出す。**Web は potRisk パネルで示すのに、CUI は現在の
+			// ポット額しか見えず、取り分もルーの負担も暗算させていた (#4921)。
+			// **除算はドメインの share と同じ整数除算。**端数は切り捨て。
+			potStart := max(g.GetPotStart(), 0)
+			b.WriteString(i18n.Tf("loo.potRisk",
+				"pot", strconv.Itoa(potStart),
+				"perTrick", strconv.Itoa(potStart/domain.LooTrickCount),
+				"penalty", strconv.Itoa(potStart)) + "\n")
 		case domain.LooPhasePlay:
 			currentIdx := g.GetCurrentTurn()
 			b.WriteString(i18n.Tf("loo.promptPlay",

--- a/internal/adapter/presenter/LooCuiPresenter_test.go
+++ b/internal/adapter/presenter/LooCuiPresenter_test.go
@@ -32,9 +32,12 @@ func TestLooCuiPresenter_DecidePhaseShowsThePotRisk(t *testing.T) {
 	g.SetPotStart(37) // 5 で割り切れない額。端数の扱いが見える。
 
 	out := new(presenter.LooCuiPresenter).Output(g, nil)
-	// 37 / 5 = 7 (切り捨て)。ドメインの share と同じ整数除算。
-	assert.Contains(t, out, "+37")
+	// 37 / 5 = 7 (切り捨て)。**全トリック取っても入るのは 35。**端数の 2 は
+	// ポットに残るので、「最大 +37」は実際より多く見せることになる。
+	assert.Contains(t, out, "+35")
 	assert.Contains(t, out, "+7")
+	assert.NotContains(t, out, "+37")
+	// 一方ペナルティはポット全額。
 	assert.Contains(t, out, "-37")
 	assert.NotContains(t, out, "7.4")
 }

--- a/internal/adapter/presenter/LooCuiPresenter_test.go
+++ b/internal/adapter/presenter/LooCuiPresenter_test.go
@@ -23,6 +23,43 @@ func TestLooCuiPresenter_Output_DecidePhase(t *testing.T) {
 	assert.Contains(t, out, "[0]") // human indexed hand
 }
 
+// **参加の損得を出す。**Web は potRisk パネルで示すのに、CUI は現在のポット額
+// しか見えず、取り分もルーの負担も暗算させていた (#4921)。
+func TestLooCuiPresenter_DecidePhaseShowsThePotRisk(t *testing.T) {
+	g := domain.NewDefaultLoo()
+	g.Reset()
+	g.SetDecidePlayerIdx(0)
+	g.SetPotStart(37) // 5 で割り切れない額。端数の扱いが見える。
+
+	out := new(presenter.LooCuiPresenter).Output(g, nil)
+	// 37 / 5 = 7 (切り捨て)。ドメインの share と同じ整数除算。
+	assert.Contains(t, out, "+37")
+	assert.Contains(t, out, "+7")
+	assert.Contains(t, out, "-37")
+	assert.NotContains(t, out, "7.4")
+}
+
+// **ポットが 0 のディールでも壊れない** (受け入れ条件2)。
+func TestLooCuiPresenter_DecidePhasePotRiskWithAnEmptyPot(t *testing.T) {
+	g := domain.NewDefaultLoo()
+	g.Reset()
+	g.SetDecidePlayerIdx(0)
+	g.SetPotStart(0)
+
+	out := new(presenter.LooCuiPresenter).Output(g, nil)
+	assert.Contains(t, out, "+0")
+	assert.Contains(t, out, "-0")
+}
+
+// ディサイド以外のフェーズには出さない。毎画面に出ると邪魔になる。
+func TestLooCuiPresenter_PotRiskIsConfinedToTheDecidePhase(t *testing.T) {
+	g := domain.NewDefaultLoo()
+	g.Reset()
+	g.SetPotStart(37)
+	g.SetPhase(domain.LooPhasePlay)
+	assert.NotContains(t, new(presenter.LooCuiPresenter).Output(g, nil), "参加した場合")
+}
+
 func TestLooCuiPresenter_Output_AllPhases(t *testing.T) {
 	p := new(presenter.LooCuiPresenter)
 

--- a/internal/domain/Loo.go
+++ b/internal/domain/Loo.go
@@ -906,6 +906,9 @@ func (g *Loo) SetPot(v int) { g.pot = v }
 // GetPotStart は現ディール開始時のポット額を返す。
 func (g *Loo) GetPotStart() int { return g.potStart }
 
+// SetPotStart は現ディール開始時のポット額を設定する (テスト用)。
+func (g *Loo) SetPotStart(v int) { g.potStart = v }
+
 // GetRoundTricks は現ディールの獲得トリック数を返す。
 func (g *Loo) GetRoundTricks() [LooPlayerCnt]int { return g.roundTricks }
 

--- a/internal/domain/Loo.go
+++ b/internal/domain/Loo.go
@@ -488,7 +488,7 @@ func (g *Loo) ScoreRound() {
 		g.pot = 0
 	default:
 		// 参加者でトリックに応じてポットを分配 (1 トリック = ポット/トリック数)。
-		share := potStart / LooTrickCount
+		share := LooPerTrickShare(potStart)
 		distributed := 0
 		for _, idx := range active {
 			win := g.roundTricks[idx] * share
@@ -905,6 +905,21 @@ func (g *Loo) SetPot(v int) { g.pot = v }
 
 // GetPotStart は現ディール開始時のポット額を返す。
 func (g *Loo) GetPotStart() int { return g.potStart }
+
+// LooPerTrickShare は 1 トリックあたりの取り分を返す。
+//
+// **端数はポットに残る。**5 で割り切れないディールでは、全トリック取っても
+// ポット全額は入らない (37 なら 7×5 = 35)。表示側もこの関数を通すこと —
+// 別に割ると、表示より少ない額しか入らない案内になる (#4921)。
+func LooPerTrickShare(potStart int) int {
+	if potStart <= 0 {
+		return 0
+	}
+	return potStart / LooTrickCount
+}
+
+// LooMaxWin は全トリック取ったときに実際に入る額を返す。
+func LooMaxWin(potStart int) int { return LooPerTrickShare(potStart) * LooTrickCount }
 
 // SetPotStart は現ディール開始時のポット額を設定する (テスト用)。
 func (g *Loo) SetPotStart(v int) { g.potStart = v }

--- a/internal/domain/Loo_test.go
+++ b/internal/domain/Loo_test.go
@@ -479,3 +479,21 @@ func TestLoo_Setters(t *testing.T) {
 	g.SetConfig(cfg)
 	assert.Equal(t, 5, g.GetConfig().Ante)
 }
+
+// **端数はポットに残る。**表示と精算で割り方が違うと、案内より少ない額しか入らない。
+func TestLoo_PerTrickShareAndMaxWin(t *testing.T) {
+	// 5 で割り切れる。
+	assert.Equal(t, 8, domain.LooPerTrickShare(40))
+	assert.Equal(t, 40, domain.LooMaxWin(40))
+
+	// 割り切れない。37 → 1 トリック 7、全部取っても 35。
+	assert.Equal(t, 7, domain.LooPerTrickShare(37))
+	assert.Equal(t, 35, domain.LooMaxWin(37))
+	assert.Less(t, domain.LooMaxWin(37), 37, "the remainder stays in the pot")
+
+	// 0 と負。
+	assert.Equal(t, 0, domain.LooPerTrickShare(0))
+	assert.Equal(t, 0, domain.LooMaxWin(0))
+	assert.Equal(t, 0, domain.LooPerTrickShare(-5))
+	assert.Equal(t, 0, domain.LooMaxWin(-5))
+}

--- a/internal/i18n/locales/en/loo.json
+++ b/internal/i18n/locales/en/loo.json
@@ -9,6 +9,7 @@
   "playing": "Play",
   "passed": "Pass",
   "promptDecide": "{{name}}'s decision (play/pass, or d 1 / d 0)",
+  "potRisk": "If you play: win up to +{{pot}} (+{{perTrick}} per trick); take no trick and you pay {{penalty}} into the pot (looed)",
   "promptPlay": "Turn: {{name}}",
   "promptTrickEnd": "Trick complete.",
   "promptRoundEnd": "Deal complete. Use nr to settle and start the next deal.",

--- a/internal/i18n/locales/ja/loo.json
+++ b/internal/i18n/locales/ja/loo.json
@@ -9,6 +9,7 @@
   "playing": "参加",
   "passed": "降り",
   "promptDecide": "{{name}} の判断です（play/pass、または d 1 / d 0）",
+  "potRisk": "参加した場合: 勝てば最大 +{{pot}}（1トリックにつき +{{perTrick}}）／0トリックなら -{{penalty}} をポットへ支払い（looed）",
   "promptPlay": "手番: {{name}}",
   "promptTrickEnd": "トリック終了。",
   "promptRoundEnd": "ディール終了。nr で精算・次のディールへ。",


### PR DESCRIPTION
Closes #4921

## 背景

`LooPage.tsx` は `computeLooPotRisk(pot, potStart)` を使って「勝てば最大 +pot（1トリックにつき +perTrick）／0トリックなら -penalty をポットへ」という potRisk パネルを出す。必要な `potStart` は `interfaces.LooGame.GetPotStart()` として既にドメインにある。ところが `LooCuiPresenter` の `LooPhaseDecide` は判断者の名前を出すだけで `GetPotStart()` を一度も呼んでおらず、CUI プレイヤーは現在のポット額しか見えないまま play/pass を決めさせられていた。

## 変更

ディサイドフェーズに 1 行追加:

```
あなた の判断です（play/pass、または d 1 / d 0）
参加した場合: 勝てば最大 +37（1トリックにつき +7）／0トリックなら -37 をポットへ支払い（looed）
```

**除算はドメインの `share := potStart / LooTrickCount` と同じ整数除算**にしてある。切り捨て方向を違えると、表示より少ない額しか入らないことになる。負の potStart は `max(..., 0)` で潰す（フロントの `Math.max(0, potStart)` と同じ扱い）。

テスト用に `Loo.SetPotStart` を追加（既存の `SetPot` と同じ位置づけ）。

## テスト

- `DecidePhaseShowsThePotRisk` — **5 で割り切れない 37** を使い、`+37` / `+7` / `-37` が出て `7.4` は出ないこと（端数の扱いが見える額を選んだ）
- `DecidePhasePotRiskWithAnEmptyPot` — potStart が 0 でも壊れず `+0` / `-0` が出る（受け入れ条件2）
- `PotRiskIsConfinedToTheDecidePhase` — プレイフェーズには出ない

ネガティブコントロール: 追加した行を外すと前 2 件が落ちる。

`go test -tags test ./...` / `golangci-lint run ./internal/...` (0 issues) green。

## Test plan

- [ ] CI green