### PR TITLE
feat(ombre): mark the matadors in the CUI hand

### DIFF
--- a/internal/adapter/presenter/OmbreCuiPresenter.go
+++ b/internal/adapter/presenter/OmbreCuiPresenter.go
@@ -77,15 +77,17 @@ var ombreMatadorKeys = map[int]string{
 // **マタドールは常にトリックに勝つ。**Web はバッジで示すのに、CUI は素の
 // 一覧しか出しておらず、序列を覚えていないと気づけなかった (#4919)。
 // 切り札が未確定なら注記は付かない。
+//
+// 索引と区切りは他ゲームと同じ formatCardList に任せる。自前で並べると
+// 区切り幅が揃わない。
 func ombreIndexedHandStr(player cuiCardList, trump int) string {
-	parts := make([]string, player.GetCardsSize())
-	for i := range parts {
-		parts[i] = "[" + strconv.Itoa(i) + "]" + cuiCardStr(player.GetCard(i))
-		if key := ombreMatadorKeys[domain.OmbreMatadorRank(player.GetCard(i), trump)]; key != "" {
-			parts[i] += "(" + i18n.T(key) + ")"
+	return formatCardList(player, func(c *domain.Card) string {
+		s := cuiCardStr(c)
+		if key := ombreMatadorKeys[domain.OmbreMatadorRank(c, trump)]; key != "" {
+			s += "(" + i18n.T(key) + ")"
 		}
-	}
-	return strings.Join(parts, " ")
+		return s
+	}, "  ", true)
 }
 
 // OmbreCuiPresenter renders the Ombre CUI view.

--- a/internal/adapter/presenter/OmbreCuiPresenter.go
+++ b/internal/adapter/presenter/OmbreCuiPresenter.go
@@ -60,9 +60,32 @@ func ombrePlayerStr(g interfaces.OmbreGame, idx int) string {
 	))
 	b.WriteString("\n")
 	if player.GetIsHuman() && player.GetCardsSize() > 0 {
-		b.WriteString(cuiIndexedCardListStr(player) + "\n")
+		b.WriteString(ombreIndexedHandStr(player, g.GetTrumpSuit()) + "\n")
 	}
 	return b.String()
+}
+
+// ombreMatadorKeys はマタドールの序列と表示名キーの対応。
+var ombreMatadorKeys = map[int]string{
+	1: "ombre.matadorSpadille",
+	2: "ombre.matadorManille",
+	3: "ombre.matadorBasto",
+}
+
+// ombreIndexedHandStr は手札をインデックス付きで並べ、マタドールに注記を付ける。
+//
+// **マタドールは常にトリックに勝つ。**Web はバッジで示すのに、CUI は素の
+// 一覧しか出しておらず、序列を覚えていないと気づけなかった (#4919)。
+// 切り札が未確定なら注記は付かない。
+func ombreIndexedHandStr(player cuiCardList, trump int) string {
+	parts := make([]string, player.GetCardsSize())
+	for i := range parts {
+		parts[i] = "[" + strconv.Itoa(i) + "]" + cuiCardStr(player.GetCard(i))
+		if key := ombreMatadorKeys[domain.OmbreMatadorRank(player.GetCard(i), trump)]; key != "" {
+			parts[i] += "(" + i18n.T(key) + ")"
+		}
+	}
+	return strings.Join(parts, " ")
 }
 
 // OmbreCuiPresenter renders the Ombre CUI view.

--- a/internal/adapter/presenter/OmbreCuiPresenter_test.go
+++ b/internal/adapter/presenter/OmbreCuiPresenter_test.go
@@ -109,6 +109,63 @@ func TestOmbreCuiPresenter_Output(t *testing.T) {
 	})
 }
 
+// **マタドールは常にトリックに勝つ。**Web はバッジで示すのに、CUI は素の一覧
+// しか出しておらず、序列を覚えていないと気づけなかった (#4919)。
+func TestOmbreCuiPresenter_AnnotatesMatadors(t *testing.T) {
+	orig := color.NoColor()
+	color.SetNoColor(true)
+	defer color.SetNoColor(orig)
+	p := new(presenter.OmbreCuiPresenter)
+
+	t.Run("marks all three matadors once trump is decided", func(t *testing.T) {
+		m, players := setupOmbreCuiMockWithPlayers()
+		players[0].Reset()
+		players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 1, false))  // スパディーユ
+		players[0].AddCard(domain.NewCard(domain.CardDesignHeart, 7, false))  // マニーユ (♥ が切り札)
+		players[0].AddCard(domain.NewCard(domain.CardDesignClover, 1, false)) // バスト
+		players[0].AddCard(domain.NewCard(domain.CardDesignHeart, 13, false)) // ただの切り札
+
+		out := p.Output(m, nil)
+		assert.Contains(t, out, "[0]SPADE 1(スパディーユ)")
+		assert.Contains(t, out, "[1]HEART 7(マニーユ)")
+		assert.Contains(t, out, "[2]CLOVER 1(バスト)")
+		// 切り札の K は平の切り札。注記は付かない。
+		assert.Contains(t, out, "[3]HEART 13")
+		assert.NotContains(t, out, "[3]HEART 13(")
+	})
+
+	// **マニーユは切り札スート次第。**♠ が切り札なら ♥7 はただの平札。
+	t.Run("the manille follows the trump suit", func(t *testing.T) {
+		m, players := setupOmbreCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetTrumpSuit")
+		m.On("GetTrumpSuit").Return(domain.CardDesignSpade)
+		players[0].Reset()
+		players[0].AddCard(domain.NewCard(domain.CardDesignHeart, 7, false))
+		players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 7, false))
+
+		out := p.Output(m, nil)
+		assert.NotContains(t, out, "[0]HEART 7(")
+		assert.Contains(t, out, "[1]SPADE 7(マニーユ)")
+	})
+
+	// 切り札未確定なら注記なし (受け入れ条件2)。
+	t.Run("no annotation before trump is decided", func(t *testing.T) {
+		m, players := setupOmbreCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetTrumpSuit")
+		m.On("GetTrumpSuit").Return(-1)
+		players[0].Reset()
+		players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 1, false))
+		players[0].AddCard(domain.NewCard(domain.CardDesignClover, 1, false))
+
+		out := p.Output(m, nil)
+		// 手札行に注記が付かないことを見る。序列の説明は promptPlayHelp が
+		// 常に出しているので、文言そのものの有無では判定できない。
+		assert.Contains(t, out, "[0]SPADE 1 [1]CLOVER 1")
+		assert.NotContains(t, out, "[0]SPADE 1(")
+		assert.NotContains(t, out, "[1]CLOVER 1(")
+	})
+}
+
 func TestOmbreCuiPresenter_HintOutput(t *testing.T) {
 	orig := color.NoColor()
 	color.SetNoColor(true)

--- a/internal/adapter/presenter/OmbreCuiPresenter_test.go
+++ b/internal/adapter/presenter/OmbreCuiPresenter_test.go
@@ -160,7 +160,7 @@ func TestOmbreCuiPresenter_AnnotatesMatadors(t *testing.T) {
 		out := p.Output(m, nil)
 		// 手札行に注記が付かないことを見る。序列の説明は promptPlayHelp が
 		// 常に出しているので、文言そのものの有無では判定できない。
-		assert.Contains(t, out, "[0]SPADE 1 [1]CLOVER 1")
+		assert.Contains(t, out, "[0]SPADE 1  [1]CLOVER 1")
 		assert.NotContains(t, out, "[0]SPADE 1(")
 		assert.NotContains(t, out, "[1]CLOVER 1(")
 	})

--- a/internal/domain/Ombre.go
+++ b/internal/domain/Ombre.go
@@ -797,7 +797,7 @@ func ombreCardStrength(c *Card, trump int) int {
 // **判定は ombreCardStrength をそのまま読む。**別に条件を書くと、序列を
 // 変えたときに表示だけ古いままになる。
 func OmbreMatadorRank(c *Card, trump int) int {
-	if c == nil || trump < CardDesignSpade || trump > CardDesignDiamond {
+	if c == nil || !ombreValidSuit(trump) {
 		return 0
 	}
 	switch ombreCardStrength(c, trump) {

--- a/internal/domain/Ombre.go
+++ b/internal/domain/Ombre.go
@@ -788,6 +788,29 @@ func ombreCardStrength(c *Card, trump int) int {
 	return ombrePlainRank(d, v)
 }
 
+// OmbreMatadorRank は札が三大マタドールのどれかを返す。
+//
+// 1 = スパディーユ (♠A)、2 = マニーユ (切り札の 7)、3 = バスト (♣A)、
+// 0 = マタドールでない。**切り札が未確定なら 0。**マニーユは切り札スート
+// 次第で決まるので、確定前に一部だけ示すと不揃いな案内になる。
+//
+// **判定は ombreCardStrength をそのまま読む。**別に条件を書くと、序列を
+// 変えたときに表示だけ古いままになる。
+func OmbreMatadorRank(c *Card, trump int) int {
+	if c == nil || trump < CardDesignSpade || trump > CardDesignDiamond {
+		return 0
+	}
+	switch ombreCardStrength(c, trump) {
+	case ombreStrSpadille:
+		return 1
+	case ombreStrManille:
+		return 2
+	case ombreStrBasto:
+		return 3
+	}
+	return 0
+}
+
 // ombreTrumpSuitRank 切り札スートの残り札 K>Q>J>6>5>4>3>2 の強さ。
 func ombreTrumpSuitRank(v int) int {
 	switch v {

--- a/internal/domain/Ombre_test.go
+++ b/internal/domain/Ombre_test.go
@@ -659,3 +659,34 @@ func TestOmbreConfig_Validate(t *testing.T) {
 	assert.Error(t, domain.OmbreConfig{CpuDifficulty: 99, TargetRounds: 5}.Validate())
 	assert.Error(t, domain.OmbreConfig{CpuDifficulty: domain.OmbreCpuDifficultyEasy, TargetRounds: 0}.Validate())
 }
+
+// **マタドールの判定は序列そのものから引く。**別に条件を書くと、序列を
+// 変えたときに表示だけ古いままになる (#4919)。
+func TestOmbre_MatadorRank(t *testing.T) {
+	spade, clover, heart := domain.CardDesignSpade, domain.CardDesignClover, domain.CardDesignHeart
+	card := func(d, v int) *domain.Card { return domain.NewCard(d, v, false) }
+
+	// 赤 (♥) が切り札のとき。
+	assert.Equal(t, 1, domain.OmbreMatadorRank(card(spade, 1), heart), "spadille")
+	assert.Equal(t, 2, domain.OmbreMatadorRank(card(heart, 7), heart), "manille")
+	assert.Equal(t, 3, domain.OmbreMatadorRank(card(clover, 1), heart), "basto")
+	// 切り札の A は Punto であってマタドールではない。
+	assert.Equal(t, 0, domain.OmbreMatadorRank(card(heart, 1), heart))
+	assert.Equal(t, 0, domain.OmbreMatadorRank(card(heart, 13), heart))
+	// 他スートの 7 はただの平札。
+	assert.Equal(t, 0, domain.OmbreMatadorRank(card(spade, 7), heart))
+
+	// **マニーユは切り札スート次第。**♠ が切り札なら ♠7 がマニーユ。
+	assert.Equal(t, 2, domain.OmbreMatadorRank(card(spade, 7), spade))
+	assert.Equal(t, 0, domain.OmbreMatadorRank(card(heart, 7), spade))
+	// ♠A は切り札が何であれスパディーユ。
+	assert.Equal(t, 1, domain.OmbreMatadorRank(card(spade, 1), spade))
+
+	// **切り札未確定なら 0。**マニーユだけ決まらないと不揃いな案内になる。
+	for _, trump := range []int{-1, 0, 5} {
+		assert.Equal(t, 0, domain.OmbreMatadorRank(card(spade, 1), trump), "trump %d", trump)
+		assert.Equal(t, 0, domain.OmbreMatadorRank(card(clover, 1), trump), "trump %d", trump)
+	}
+
+	assert.Equal(t, 0, domain.OmbreMatadorRank(nil, heart))
+}

--- a/internal/i18n/locales/en/ombre.json
+++ b/internal/i18n/locales/en/ombre.json
@@ -44,5 +44,8 @@
   "hintDecision": "[HINT: recommend {{action}} ({{reason}})]",
   "hintActionEntrar": "Entrar",
   "hintActionSolo": "Solo",
-  "hintActionPass": "Pass"
+  "hintActionPass": "Pass",
+  "matadorSpadille": "Spadille",
+  "matadorManille": "Manille",
+  "matadorBasto": "Basto"
 }

--- a/internal/i18n/locales/ja/ombre.json
+++ b/internal/i18n/locales/ja/ombre.json
@@ -44,5 +44,8 @@
   "hintDecision": "[HINT: {{action}} を推奨 ({{reason}})]",
   "hintActionEntrar": "エントラール",
   "hintActionSolo": "ソロ",
-  "hintActionPass": "パス"
+  "hintActionPass": "パス",
+  "matadorSpadille": "スパディーユ",
+  "matadorManille": "マニーユ",
+  "matadorBasto": "バスト"
 }


### PR DESCRIPTION
Closes #4919

## 背景

`OmbrePage.tsx` は `matadorRank` でスパディーユ (♠A) / マニーユ (切り札の7) / バスト (♣A) にバッジを付けて強調する。マタドールは常にトリックに勝つ重要札だが、判定はフロント専用のユーティリティで、`OmbreCuiPresenter` の手札表示は `cuiIndexedCardListStr` で並べるだけだった。CUI プレイヤーは序列を覚えていない限り気づけない。

## 変更

issue は「`matadorRank` 相当のロジックを presenter に移植する」と書いているが、**移植すると 3 実装目になる**（ドメインの `ombreCardStrength`、フロントの `matadorRank`、presenter）。代わりに `domain.OmbreMatadorRank(card, trump)` を置き、**中身は `ombreCardStrength` の結果を読むだけ**にした:

```go
switch ombreCardStrength(c, trump) {
case ombreStrSpadille: return 1
case ombreStrManille:  return 2
case ombreStrBasto:    return 3
}
```

こうすると序列を変えたときに表示だけ古いまま残ることがない。presenter は `[0]SPADE 1(スパディーユ)` の形で注記する。

**切り札未確定なら注記なし** (受け入れ条件2)。♠A と ♣A は切り札に関係なくマタドールだが、マニーユだけ切り札スート次第で決まるので、確定前に一部だけ示すと不揃いな案内になる（フロントの `matadorRank` も同じ判断で null を返す）。

## テスト

**ドメイン `TestOmbre_MatadorRank`** — 3 種すべて（受け入れ条件3）に加えて:

- **切り札の A は Punto であってマタドールではない**（`ombreStrPunto` は別枠）
- 他スートの 7 はただの平札
- **マニーユは切り札スート次第** — ♠ が切り札なら ♠7 がマニーユで ♥7 は平札
- 切り札未確定 (-1/0/5) と nil は 0

**presenter 3 件** — 3 種すべてに注記が付き平の切り札には付かない／マニーユが切り札スートに追随する／切り札未確定なら手札行に注記が付かない

最後のケースは最初「バスト」という語が出ないことで書いたが、**`promptPlayHelp` が序列の説明として常に同じ語を出している**ため空振りだった。手札行そのものを見るように直してある。

ネガティブコントロール: 注記の付与を外すと前 2 件が落ちる。

`go test -tags test ./...` / `golangci-lint run ./internal/...` (0 issues) green。

## Test plan

- [ ] CI green