### PR TITLE
feat(jass): show each team's Weis points in the CUI

### DIFF
--- a/internal/adapter/presenter/JassCuiPresenter.go
+++ b/internal/adapter/presenter/JassCuiPresenter.go
@@ -53,6 +53,19 @@ func (p *JassCuiPresenter) Output(g interfaces.JassGame, lastErr error) string {
 			"t0", strconv.Itoa(g.GetTeamScore(0)),
 			"t1", strconv.Itoa(g.GetTeamScore(1))) + "\n")
 
+		// **Weis の内訳が無いとラウンド得点が説明できない。**Web は専用パネルを
+		// 出すのに、CUI は Weis で加点があったことすら伝えていなかった (#4918)。
+		// **勝ったチームだけが自陣の Weis を総取りする**ので、0 点のほうも
+		// 出さないと「なぜ入らなかったか」が読めない。
+		if g.GetConfig().EnableWeis {
+			w0, w1 := g.GetRoundWeisPoints(0), g.GetRoundWeisPoints(1)
+			if w0 > 0 || w1 > 0 {
+				out.WriteString(i18n.Tf("jass.weisLine",
+					"t0", strconv.Itoa(w0),
+					"t1", strconv.Itoa(w1)) + "\n")
+			}
+		}
+
 		for i := 0; i < g.GetPlayerCnt(); i++ {
 			out.WriteString(jassPlayerStr(g.GetPlayer(i), i))
 		}

--- a/internal/adapter/presenter/JassCuiPresenter_test.go
+++ b/internal/adapter/presenter/JassCuiPresenter_test.go
@@ -29,6 +29,8 @@ func setupJassCuiMock() *interfaces.MockJassGame {
 	m.On("GetWinnerTeam").Return(-1)
 	m.On("GetLeadPlayerIdx").Return(0)
 	m.On("GetConfig").Return(domain.DefaultJassConfig())
+	m.On("GetRoundWeisPoints", 0).Return(0)
+	m.On("GetRoundWeisPoints", 1).Return(0)
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
 	return m
 }
@@ -51,6 +53,45 @@ func setupJassCuiMockWithPlayers() (*interfaces.MockJassGame, []*domain.JassPlay
 	m.On("GetPlayer", 2).Return(players[2])
 	m.On("GetPlayer", 3).Return(players[3])
 	return m, players
+}
+
+// **Weis の内訳が無いとラウンド得点が説明できない。**Web は専用パネルを出すのに、
+// CUI は Weis で加点があったことすら伝えていなかった (#4918)。
+func TestJassCuiPresenter_ShowsTheRoundWeisPoints(t *testing.T) {
+	p := new(presenter.JassCuiPresenter)
+
+	weisMock := func(w0, w1 int, enable bool) *interfaces.MockJassGame {
+		m, _ := setupJassCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetRoundWeisPoints")
+		m.On("GetRoundWeisPoints", 0).Return(w0)
+		m.On("GetRoundWeisPoints", 1).Return(w1)
+		if !enable {
+			cfg := domain.DefaultJassConfig()
+			cfg.EnableWeis = false
+			m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetConfig")
+			m.On("GetConfig").Return(cfg)
+		}
+		return m
+	}
+
+	t.Run("shows both teams so the zero side is explained too", func(t *testing.T) {
+		out := p.Output(weisMock(150, 0, true), nil)
+		assert.Contains(t, out, "当ラウンドの Weis:")
+		assert.Contains(t, out, "チーム0 150点")
+		assert.Contains(t, out, "チーム1 0点")
+		// **総取りの規則を書かないと、0 点の側が理由不明になる。**
+		assert.Contains(t, out, "総取り")
+	})
+
+	// 誰も Weis を宣言していないラウンドでは行そのものを出さない。
+	t.Run("no line when neither team declared anything", func(t *testing.T) {
+		assert.NotContains(t, p.Output(weisMock(0, 0, true), nil), "当ラウンドの Weis")
+	})
+
+	// enableWeis が無効なら、点があっても出さない (受け入れ条件2)。
+	t.Run("no line when weis is disabled", func(t *testing.T) {
+		assert.NotContains(t, p.Output(weisMock(150, 0, false), nil), "当ラウンドの Weis")
+	})
 }
 
 func TestJassCuiPresenter_Output(t *testing.T) {

--- a/internal/i18n/locales/en/jass.json
+++ b/internal/i18n/locales/en/jass.json
@@ -12,6 +12,7 @@
   "trumpLine": "Trump: {{suit}} (Maker: Team {{team}})",
   "trumpUndecided": "Trump: undecided",
   "teamScoreLine": "Team 0: {{t0}}  Team 1: {{t1}}",
+  "weisLine": "Weis this round: Team 0 {{t0}}  Team 1 {{t1}} (only the team with the strongest Weis scores its own Weis)",
   "playerLine": "{{name}}: Team {{team}} tricks={{tricks}} cards={{cards}}",
   "gameEnd": "Game over! Team {{team}} wins!",
   "promptBidTrump": "Trump bid: {{name}} to choose",

--- a/internal/i18n/locales/ja/jass.json
+++ b/internal/i18n/locales/ja/jass.json
@@ -12,6 +12,7 @@
   "trumpLine": "切り札: {{suit}} (メイカー: チーム{{team}})",
   "trumpUndecided": "切り札: 未決定",
   "teamScoreLine": "チーム0: {{t0}}点  チーム1: {{t1}}点",
+  "weisLine": "当ラウンドの Weis: チーム0 {{t0}}点  チーム1 {{t1}}点（最も強い Weis を宣言したチームだけが自陣の Weis を総取りします）",
   "playerLine": "{{name}}: チーム{{team}} 獲得{{tricks}}トリック {{cards}}枚",
   "gameEnd": "ゲーム終了！ チーム{{team}}の勝利です！",
   "promptBidTrump": "切り札ビッド: {{name}}が選択",


### PR DESCRIPTION
Closes #4918

## 背景

`JassWebPresenter` は `RoundWeisPoints` を Web 応答に載せ、`JassPage.tsx` は専用パネルで両チームの Weis 得点・確定バッジ・仕組みの説明まで描画する。一方 `JassCuiPresenter.Output` は `GetRoundWeisPoints` を一度も呼んでおらず、`enableWeis` を有効にして CUI で遊んでも **Weis で加点が発生したこと自体が伝わらず**、ラウンド得点の内訳が説明不能だった。

## 変更

チーム合計得点の直後に 1 行:

```
チーム0: 0点  チーム1: 0点
当ラウンドの Weis: チーム0 150点  チーム1 0点（最も強い Weis を宣言したチームだけが自陣の Weis を総取りします）
```

判断:

- **0 点の側も併記する。**勝ったチームだけが自陣の Weis を総取りする規則なので、片側だけ出すと「なぜ入らなかったか」が読めない。総取りの規則そのものも一緒に書いた
- **誰も宣言していないラウンドは行を出さない。**`0点 / 0点` は毎ラウンド出しても情報がない
- **`enableWeis` が無効なら出さない**（受け入れ条件2 の「行自体を省略する」側を採った）

## テスト

- `shows both teams so the zero side is explained too` — 150 対 0 で両チームが出て、総取りの断りも出る
- `no line when neither team declared anything` — 0 対 0 では行を出さない
- `no line when weis is disabled` — **点があっても** `enableWeis` 無効なら出さない

ネガティブコントロール: 追加ブロックを外すと 1 件目が落ちる。

`go test -tags test ./...` / `golangci-lint run ./internal/...` (0 issues) green。

## Test plan

- [ ] CI green