### PR TITLE
feat(sheepshead): list the callable suits in the CUI call phase

### DIFF
--- a/internal/adapter/presenter/SheepsheadCuiPresenter.go
+++ b/internal/adapter/presenter/SheepsheadCuiPresenter.go
@@ -120,6 +120,20 @@ func (p *SheepsheadCuiPresenter) Output(g interfaces.SheepsheadGame, lastErr err
 			pickerIdx := g.GetPickerIdx()
 			b.WriteString(i18n.Tf("sheepshead.promptCall",
 				"name", cuiPlayerName(g.GetPlayer(pickerIdx), pickerIdx)) + "\n")
+			// **どのスートを呼べるかを出す。**Web は呼べるスートだけボタンを
+			// 描くのに、CUI はコマンド構文しか示さず試行錯誤させていた (#4916)。
+			if suits := g.GetCallableSuits(); len(suits) > 0 {
+				labels := make([]string, len(suits))
+				for i, s := range suits {
+					// 番号を添える。c コマンドが取るのは記号ではなく数字。
+					labels[i] = strconv.Itoa(s) + "=" + sheepsheadSuitLabel(s)
+				}
+				b.WriteString(i18n.Tf("sheepshead.callableSuits",
+					"suits", strings.Join(labels, " ")) + "\n")
+			} else {
+				// 呼べるスートが 1 つも無い局面もある (フェイル A を全部持っている等)。
+				b.WriteString(i18n.T("sheepshead.callableNone") + "\n")
+			}
 			b.WriteString(i18n.T("sheepshead.promptCallHelp") + "\n")
 		case domain.SheepsheadPhasePlay:
 			currentIdx := g.GetCurrentPlayerIdx()

--- a/internal/adapter/presenter/SheepsheadCuiPresenter_test.go
+++ b/internal/adapter/presenter/SheepsheadCuiPresenter_test.go
@@ -33,6 +33,7 @@ func setupSheepsheadCuiMock() *interfaces.MockSheepsheadGame {
 	m.On("GetPickerIdx").Return(-1)
 	m.On("GetPartnerIdx").Return(-1)
 	m.On("GetCalledSuit").Return(0)
+	m.On("GetCallableSuits").Return([]int{domain.CardDesignSpade, domain.CardDesignHeart})
 	m.On("GetBlind").Return([]*domain.Card(nil))
 	m.On("GetPassCount").Return(0)
 	m.On("GetCurrentTrick").Return([]*domain.TrickCard(nil))
@@ -58,6 +59,44 @@ func setupSheepsheadCuiMockWithPlayers() (*interfaces.MockSheepsheadGame, []*dom
 	m.On("GetPlayer", 3).Return(players[3])
 	m.On("GetPlayer", 4).Return(players[4])
 	return m, players
+}
+
+// **どのスートを呼べるかを出す。**Web は呼べるスートだけボタンを描くのに、
+// CUI はコマンド構文しか示さず試行錯誤させていた (#4916)。
+func TestSheepsheadCuiPresenter_ListsTheCallableSuits(t *testing.T) {
+	p := new(presenter.SheepsheadCuiPresenter)
+
+	callMock := func(suits []int) *interfaces.MockSheepsheadGame {
+		m, _ := setupSheepsheadCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPickerIdx")
+		m.On("GetPhase").Return(domain.SheepsheadPhaseCall)
+		m.On("GetPickerIdx").Return(0)
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetCallableSuits")
+		m.On("GetCallableSuits").Return(suits)
+		return m
+	}
+
+	t.Run("lists the suits with the number the command takes", func(t *testing.T) {
+		out := p.Output(callMock([]int{domain.CardDesignSpade, domain.CardDesignHeart}), nil)
+		// **行ごと照合する。**promptCallHelp が `1=♠ 2=♣ 3=♥` を常に出しているので、
+		// 断片で見ると呼べない ♣ の有無を判定できない。
+		// 番号を添えるのは、c コマンドが取るのが記号ではなく数字だから。
+		assert.Contains(t, out, "呼べるスート: 1=♠ 3=♥\n")
+	})
+
+	// 呼べるスートが 0 件でもクラッシュしない (受け入れ条件2)。
+	t.Run("says so when no suit can be called", func(t *testing.T) {
+		out := p.Output(callMock(nil), nil)
+		assert.Contains(t, out, "呼べるスートがありません")
+		assert.NotContains(t, out, "呼べるスート: ")
+	})
+
+	// コールフェーズ以外には出さない。
+	t.Run("confined to the call phase", func(t *testing.T) {
+		m, _ := setupSheepsheadCuiMockWithPlayers()
+		assert.NotContains(t, p.Output(m, nil), "呼べるスート")
+	})
 }
 
 func TestSheepsheadCuiPresenter_Output(t *testing.T) {

--- a/internal/i18n/locales/en/sheepshead.json
+++ b/internal/i18n/locales/en/sheepshead.json
@@ -20,6 +20,8 @@
   "promptBury": "{{name}} — bury 2 cards",
   "promptBuryHelp": "b <idx1> <idx2> ... bury two cards from your hand",
   "promptCall": "{{name}} — call a partner suit",
+  "callableSuits": "Callable suits: {{suits}}",
+  "callableNone": "No suit can be called; you play without a partner",
   "promptCallHelp": "c <suit> ... call a fail suit (1=♠ 2=♣ 3=♥)",
   "promptPlay": "Turn: {{name}}",
   "promptPlayHelp": "play <idx> ... play a card (must follow suit)",

--- a/internal/i18n/locales/ja/sheepshead.json
+++ b/internal/i18n/locales/ja/sheepshead.json
@@ -20,6 +20,8 @@
   "promptBury": "{{name}} ― 2枚を埋めてください",
   "promptBuryHelp": "b <idx1> <idx2>・・・手札から2枚を埋める",
   "promptCall": "{{name}} ― 相棒スートを呼んでください",
+  "callableSuits": "呼べるスート: {{suits}}",
+  "callableNone": "呼べるスートがありません（相棒なしで進みます）",
   "promptCallHelp": "c <suit>・・・フェイルスートを指定（1=♠ 2=♣ 3=♥）",
   "promptPlay": "手番: {{name}}",
   "promptPlayHelp": "play <idx>・・・カードを出す（マストフォロー）",


### PR DESCRIPTION
Closes #4916

## 背景

`SheepsheadPage.tsx` は `state.callableSuits.map(...)` で**呼べるスートだけ**ボタンを描く。ところが `SheepsheadCuiPresenter` のコールフェーズは `promptCall`（ピッカー名）と `promptCallHelp`（コマンド構文）を出すだけで、`GetCallableSuits()` を一度も呼んでいなかった。CUI プレイヤーはどのスートが実際に呼べるか画面からは分からず、試行錯誤でコマンドを打つしかない。

## 変更

```
あなた ― 相棒スートを呼んでください
呼べるスート: 1=♠ 3=♥
c <suit>・・・フェイルスートを指定（1=♠ 2=♣ 3=♥）
```

- **番号を添える。**`c` コマンドが取るのは記号ではなく数字なので、`♠ ♥` とだけ並べても打ち直しが要る
- **0 件の局面**は「呼べるスートがありません（相棒なしで進みます）」を出す（受け入れ条件2）

## テスト

- `lists the suits with the number the command takes` — `呼べるスート: 1=♠ 3=♥\n` を**行ごと**照合。最初は `NotContains "2=♣"` で呼べない ♣ の不在を見ようとしたが、**`promptCallHelp` が `1=♠ 2=♣ 3=♥` を常に出している**ため空振りだった。行全体で照合すれば包含も除外も同時に固定できる
- `says so when no suit can be called` — 0 件でクラッシュせず、代替文が出る
- `confined to the call phase` — 他フェーズには出ない

ネガティブコントロール: 追加ブロックを外すと前 2 件が落ちる（`-run` のパターンを間違えて一度空振りしたので、テスト名を完全一致させて実行し直した）。

`go test -tags test ./...` / `golangci-lint run ./internal/...` (0 issues) green。

## Test plan

- [ ] CI green