### PR TITLE
fix(cui): route every hardcoded CPU name through cuiPlayerName

### DIFF
--- a/internal/adapter/presenter/BourreCuiPresenter.go
+++ b/internal/adapter/presenter/BourreCuiPresenter.go
@@ -94,11 +94,12 @@ func bourrePlayerStr(bg interfaces.BourreGame, player *domain.BourrePlayer, idx 
 	return b.String()
 }
 
+// bourreName はプレイヤー名を返す。
+//
+// CPU 名を自前で組むと英語リテラルがそのまま日本語ロケールに混ざるので、
+// 他ゲームと同じ cuiPlayerName に任せる (#4719)。
 func bourreName(bg interfaces.BourreGame, idx int) string {
-	if player := bg.GetPlayer(idx); player != nil && player.GetIsHuman() {
-		return i18n.T("bourre.you")
-	}
-	return fmt.Sprintf("CPU %d", idx)
+	return cuiPlayerName(bg.GetPlayer(idx), idx)
 }
 
 func bourrePhaseLabel(phase domain.BourrePhase) string {

--- a/internal/adapter/presenter/BourreCuiPresenter_test.go
+++ b/internal/adapter/presenter/BourreCuiPresenter_test.go
@@ -5,9 +5,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func TestBourreCuiPresenter_Output(t *testing.T) {
@@ -50,4 +53,40 @@ func TestBourreCuiPresenter_ActionLog(t *testing.T) {
 	bg.Reset()
 	p := new(presenter.BourreCuiPresenter)
 	assert.NotNil(t, p.ActionLogOutput(bg))
+}
+
+// **CPU 名も i18n と太字を通す。**bourreName は人間だけ i18n を通し、CPU は
+// `fmt.Sprintf("CPU %d")` の英語リテラルを返していた (#4719)。
+func TestBourreCuiPresenter_CpuNamesGoThroughTheSharedHelper(t *testing.T) {
+	origNoColor := color.NoColor()
+	color.SetNoColor(false)
+	defer color.SetNoColor(origNoColor)
+
+	bg := newBourreAllCpu()
+	bg.Reset()
+	p := new(presenter.BourreCuiPresenter)
+	// **リセット直後は bourreName を通らない。**トリックが場に出るまで進める。
+	var out string
+	for i := 0; i < 300000; i++ {
+		out = p.Output(bg, nil)
+		if strings.Contains(out, i18n.T("cuiPlayerCpu")) || len(bg.GetCurrentTrick()) > 0 {
+			break
+		}
+		if bg.GetPhase() == domain.BourrePhaseRoundEnd {
+			bg.NextHand()
+			continue
+		}
+		if bg.GetGameEndFlag() {
+			break
+		}
+		bg.CpuPlay()
+	}
+	require.NotEmpty(t, bg.GetCurrentTrick(), "no trick was ever rendered")
+
+	// **プレイヤー行は元から cuiPlayerName を使っている。**出力全体で探すと
+	// 修正前でも当たるので、素の "CPU 1" が 1 つも残っていないことで見る。
+	bold1 := color.Bold(i18n.Tf("cuiPlayerCpu", "idx", "1"))
+	assert.Contains(t, out, bold1)
+	assert.NotContains(t, strings.ReplaceAll(out, bold1, ""), "CPU 1")
+	assert.NotContains(t, strings.ReplaceAll(out, color.Bold(i18n.Tf("cuiPlayerCpu", "idx", "2")), ""), "CPU 2")
 }

--- a/internal/adapter/presenter/BourreCuiPresenter_test.go
+++ b/internal/adapter/presenter/BourreCuiPresenter_test.go
@@ -66,8 +66,10 @@ func TestBourreCuiPresenter_CpuNamesGoThroughTheSharedHelper(t *testing.T) {
 	bg.Reset()
 	p := new(presenter.BourreCuiPresenter)
 	// **リセット直後は bourreName を通らない。**トリックが場に出るまで進める。
+	// 上限はリポジトリの慣習どおり 1000。トリックは数手で場に出るので、
+	// これで届かないなら収束していないほうを疑う。
 	var out string
-	for i := 0; i < 300000; i++ {
+	for i := 0; i < 1000; i++ {
 		out = p.Output(bg, nil)
 		if strings.Contains(out, i18n.T("cuiPlayerCpu")) || len(bg.GetCurrentTrick()) > 0 {
 			break

--- a/internal/adapter/presenter/GoStopCuiPresenter.go
+++ b/internal/adapter/presenter/GoStopCuiPresenter.go
@@ -159,10 +159,9 @@ func gostopRoundResultStr(g interfaces.GoStopGame) string {
 	if res == nil || res.Winner < 0 {
 		return i18n.T("gostop.roundDraw")
 	}
-	name := "CPU"
-	if p := g.GetPlayer(res.Winner); p != nil && p.GetIsHuman() {
-		name = i18n.T("cuiPlayerYou")
-	}
+	// 人間側だけ i18n を通していて、CPU は英語リテラルのままだった。
+	// 名前の組み立ては他の表示と同じ cuiPlayerName に任せる (#4855)。
+	name := cuiPlayerName(g.GetPlayer(res.Winner), res.Winner)
 	bak := gostopBakStr(res)
 	return i18n.Tf("gostop.roundWin",
 		"name", name,

--- a/internal/adapter/presenter/GoStopCuiPresenter_test.go
+++ b/internal/adapter/presenter/GoStopCuiPresenter_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
@@ -108,7 +109,24 @@ func TestGoStopCuiPresenter_RoundResult_CpuWinner(t *testing.T) {
 	g.CpuDecide()
 	require.Equal(t, domain.GoStopPhaseRoundEnd, g.GetPhase())
 
+	// **CPU 名も i18n と太字を通す。**人間側だけ i18n を通し、CPU は英語
+	// リテラルのままだった (#4855)。色を有効にして太字の有無まで見る。
+	origNoColor := color.NoColor()
+	color.SetNoColor(false)
+	defer color.SetNoColor(origNoColor)
+
 	p := new(presenter.GoStopCuiPresenter)
 	out := p.Output(g, nil)
 	assert.NotEmpty(t, out)
+	// **ラウンド勝利行そのものを見る。**プレイヤー一覧は元から太字の CPU 名を
+	// 出しているので、出力全体で探すと修正前でも当たってしまう。
+	bold1 := color.Bold(i18n.Tf("cuiPlayerCpu", "idx", "1"))
+	var winLine string
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "ラウンド勝利") {
+			winLine = line
+		}
+	}
+	require.NotEmpty(t, winLine, "round-win line missing from output: %q", out)
+	assert.Contains(t, winLine, bold1)
 }

--- a/internal/adapter/presenter/KoiKoiCuiPresenter.go
+++ b/internal/adapter/presenter/KoiKoiCuiPresenter.go
@@ -159,10 +159,9 @@ func koikoiRoundResultStr(g interfaces.KoiKoiGame) string {
 	if res.Winner < 0 {
 		return i18n.T("koikoi.roundDraw")
 	}
-	name := "CPU"
-	if p := g.GetPlayer(res.Winner); p != nil && p.GetIsHuman() {
-		name = i18n.T("cuiPlayerYou")
-	}
+	// 人間側だけ i18n を通していて、CPU は英語リテラルのままだった。
+	// 名前の組み立ては他の表示と同じ cuiPlayerName に任せる (#4855)。
+	name := cuiPlayerName(g.GetPlayer(res.Winner), res.Winner)
 	return i18n.Tf("koikoi.roundWin",
 		"name", name,
 		"yaku", koikoiYakuStr(res.Yaku),

--- a/internal/adapter/presenter/KoiKoiCuiPresenter_test.go
+++ b/internal/adapter/presenter/KoiKoiCuiPresenter_test.go
@@ -2,13 +2,16 @@ package presenter_test
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func TestKoiKoiCuiPresenter_Output_PlayPhase(t *testing.T) {
@@ -119,7 +122,24 @@ func TestKoiKoiCuiPresenter_RoundResult_CpuWinner(t *testing.T) {
 	g.CpuDecide() // Easy → stop → CPU wins round
 	require.Equal(t, domain.KoiKoiPhaseRoundEnd, g.GetPhase())
 
+	// **CPU 名も i18n と太字を通す。**人間側だけ i18n を通し、CPU は英語
+	// リテラルのままだった (#4855 と同型)。色を有効にして太字の有無まで見る。
+	origNoColor := color.NoColor()
+	color.SetNoColor(false)
+	defer color.SetNoColor(origNoColor)
+
 	p := new(presenter.KoiKoiCuiPresenter)
 	out := p.Output(g, nil)
 	assert.NotEmpty(t, out)
+	// **ラウンド勝利行そのものを見る。**プレイヤー一覧は元から太字の CPU 名を
+	// 出しているので、出力全体で探すと修正前でも当たってしまう。
+	bold1 := color.Bold(i18n.Tf("cuiPlayerCpu", "idx", "1"))
+	var winLine string
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "ラウンド勝利") {
+			winLine = line
+		}
+	}
+	require.NotEmpty(t, winLine, "round-win line missing from output: %q", out)
+	assert.Contains(t, winLine, bold1)
 }

--- a/internal/adapter/presenter/TienLenCuiPresenter.go
+++ b/internal/adapter/presenter/TienLenCuiPresenter.go
@@ -79,12 +79,9 @@ func (p *TienLenCuiPresenter) Output(tg interfaces.TienLenGame, lastErr error) s
 			for i := 0; i < tg.GetPlayerCnt(); i++ {
 				player := tg.GetPlayer(i)
 				if player.GetRank() >= 1 {
-					var name string
-					if player.GetIsHuman() {
-						name = i18n.T("tienlen.playerYou")
-					} else {
-						name = fmt.Sprintf("CPU %d", i)
-					}
+					// 名前の組み立ては他の表示と同じ cuiPlayerName に任せる。
+					// 自前で組むと太字も i18n も抜ける (#4807)。
+					name := cuiPlayerName(player, i)
 					fmt.Fprintf(b, "  %s: %s\n", name, i18n.Tf("tienlen.rankN", "rank", strconv.Itoa(player.GetRank())))
 				}
 			}
@@ -96,7 +93,7 @@ func (p *TienLenCuiPresenter) Output(tg interfaces.TienLenGame, lastErr error) s
 				} else {
 					actionStr = cuiCardSliceStr(action.PlayedCards)
 				}
-				fmt.Fprintf(b, "CPU %d: %s\n", action.PlayerIdx, actionStr)
+				fmt.Fprintf(b, "%s: %s\n", cuiPlayerName(tg.GetPlayer(action.PlayerIdx), action.PlayerIdx), actionStr)
 			}
 			if tg.IsHumanTurn() {
 				b.WriteString(i18n.T("tienlen.yourTurn") + "\n")

--- a/internal/adapter/presenter/TienLenCuiPresenter_test.go
+++ b/internal/adapter/presenter/TienLenCuiPresenter_test.go
@@ -4,6 +4,7 @@ package presenter_test
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -141,4 +142,25 @@ func TestTienLenCuiPresenter_ActionLogOutput(t *testing.T) {
 		{TurnNumber: 1, PlayerIdx: 0, ActionType: "play", Detail: "played 1 card(s)"},
 	})
 	assert.Contains(t, p.ActionLogOutput(m), "play")
+}
+
+// **CPU 名も i18n と太字を通す。**順位表示と CPU 手番ログだけ `fmt.Sprintf("CPU %d")`
+// で自前に組んでいて、同じ画面の他の名前と見た目も経路も違っていた (#4807)。
+func TestTienLen_CpuNamesGoThroughTheSharedHelper(t *testing.T) {
+	origNoColor := color.NoColor()
+	color.SetNoColor(false)
+	defer color.SetNoColor(origNoColor)
+
+	bold1 := color.Bold(i18n.Tf("cuiPlayerCpu", "idx", "1"))
+	p := new(presenter.TienLenCuiPresenter)
+
+	t.Run("cpu action log", func(t *testing.T) {
+		m, _ := setupTienLenCuiMock()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetCpuActions")
+		m.On("GetCpuActions").Return([]*domain.TienLenAction{{PlayerIdx: 1, PlayedCards: nil}})
+		out := p.Output(m, nil)
+		assert.Contains(t, out, bold1)
+		// 素の "CPU 1" が太字の外に残っていないこと。
+		assert.NotContains(t, strings.ReplaceAll(out, bold1, ""), "CPU 1")
+	})
 }

--- a/internal/adapter/presenter/ZhengCuiPresenter.go
+++ b/internal/adapter/presenter/ZhengCuiPresenter.go
@@ -56,12 +56,9 @@ func (p *ZhengCuiPresenter) Output(zg interfaces.ZhengGame, lastErr error) strin
 					continue
 				}
 				if player.GetRank() >= 1 {
-					var name string
-					if player.GetIsHuman() {
-						name = i18n.T("zheng.playerYou")
-					} else {
-						name = fmt.Sprintf("CPU %d", i)
-					}
+					// 名前の組み立ては他の表示と同じ cuiPlayerName に任せる。
+					// 自前で組むと太字も i18n も抜ける (#4807)。
+					name := cuiPlayerName(player, i)
 					fmt.Fprintf(b, "  %s: %s\n", name, i18n.Tf("zheng.rankN", "rank", strconv.Itoa(player.GetRank())))
 				}
 			}
@@ -73,7 +70,7 @@ func (p *ZhengCuiPresenter) Output(zg interfaces.ZhengGame, lastErr error) strin
 				} else {
 					actionStr = cuiCardSliceStr(action.PlayedCards)
 				}
-				fmt.Fprintf(b, "CPU %d: %s\n", action.PlayerIdx, actionStr)
+				fmt.Fprintf(b, "%s: %s\n", cuiPlayerName(zg.GetPlayer(action.PlayerIdx), action.PlayerIdx), actionStr)
 			}
 			if zg.IsHumanTurn() {
 				b.WriteString(i18n.T("zheng.yourTurn") + "\n")

--- a/internal/adapter/presenter/ZhengCuiPresenter_test.go
+++ b/internal/adapter/presenter/ZhengCuiPresenter_test.go
@@ -4,6 +4,7 @@ package presenter_test
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,6 +13,7 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func setupZhengCuiMock() (*interfaces.MockZhengGame, []*domain.ZhengPlayer) {
@@ -107,4 +109,25 @@ func TestZhengCuiPresenter_ActionLogOutput(t *testing.T) {
 		{TurnNumber: 1, PlayerIdx: 0, ActionType: "play", Detail: "played 1 card(s)"},
 	})
 	assert.Contains(t, p.ActionLogOutput(m), "play")
+}
+
+// **CPU 名も i18n と太字を通す。**順位表示と CPU 手番ログだけ `fmt.Sprintf("CPU %d")`
+// で自前に組んでいて、同じ画面の他の名前と見た目も経路も違っていた (#4807)。
+func TestZheng_CpuNamesGoThroughTheSharedHelper(t *testing.T) {
+	origNoColor := color.NoColor()
+	color.SetNoColor(false)
+	defer color.SetNoColor(origNoColor)
+
+	bold1 := color.Bold(i18n.Tf("cuiPlayerCpu", "idx", "1"))
+	p := new(presenter.ZhengCuiPresenter)
+
+	t.Run("cpu action log", func(t *testing.T) {
+		m, _ := setupZhengCuiMock()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetCpuActions")
+		m.On("GetCpuActions").Return([]*domain.ZhengAction{{PlayerIdx: 1, PlayedCards: nil}})
+		out := p.Output(m, nil)
+		assert.Contains(t, out, bold1)
+		// 素の "CPU 1" が太字の外に残っていないこと。
+		assert.NotContains(t, strings.ReplaceAll(out, bold1, ""), "CPU 1")
+	})
 }


### PR DESCRIPTION
Closes #4855
Closes #4807
Closes #4719

## 背景

CUI presenter のいくつかは、人間側だけ `i18n.T("cuiPlayerYou")` を通しながら、CPU 側は英語リテラルを直接埋めていた。同じ画面の他の名前と**経路 (i18n) も見た目 (太字) も違う**。

`grep 'CPU %d\|"CPU"' --include=*CuiPresenter.go` で 5 ゲーム 6 箇所:

| ゲーム | 箇所 | issue |
|--------|------|-------|
| ゴーストップ | ラウンド結果の勝者 (`name := "CPU"`) | #4855 |
| Tien Len | 順位表示 + CPU 手番ログ | #4807 |
| ブーレ | `bourreName` | #4719 |
| こいこい | ラウンド結果の勝者 | （issue 無し・同一記述） |
| Zheng | 順位表示 + CPU 手番ログ | （issue 無し・同一記述） |

issue が挙げていたのは 3 ゲームだが、**同じ grep で残り 2 つも出た**ので併せて直した。3 本の PR に分けても CI が 3 回走るだけで内容は同じ。

すべて共有ヘルパ `cuiPlayerName(player, idx)` に寄せてある。

## テストで手こずった点

ja の `cuiPlayerCpu` は `"CPU {{idx}}"` なので、**表示される文字列は修正の前後で変わらない**。違うのは i18n を経由するかと `color.Bold` が付くかだけ。したがって:

- 色を有効 (`color.SetNoColor(false)`) にして、`color.Bold(i18n.Tf("cuiPlayerCpu", ...))` と一致するかで見る
- 最初は出力全体で `Contains` したが、**ゴーストップ・こいこい・ブーレはプレイヤー一覧が元から太字の CPU 名を出している**ため、修正を戻しても通ってしまった（空振り）。ラウンド勝利行そのものを取り出す／素の `"CPU 1"` が太字の外に残っていないことを見る、に改めた
- ブーレはさらに、リセット直後の出力が `bourreName` を一度も通らないため空振りしていた。トリックが場に出るまで進めてから検査する

**ネガティブコントロール（最終形）**: 5 ファイルの実装を `git stash` で戻すと、5 テストすべてが落ちる。

`go test -tags test ./...` / `golangci-lint run ./internal/...` (0 issues) green。

## Test plan

- [ ] CI green