### PR TITLE
fix(cui): translate poker hand names in Three Card and Joker Poker

### DIFF
--- a/internal/adapter/presenter/ThreeCardCuiPresenter.go
+++ b/internal/adapter/presenter/ThreeCardCuiPresenter.go
@@ -30,7 +30,7 @@ func (tp *ThreeCardCuiPresenter) Output(tc interfaces.ThreeCardGame, lastErr err
 		sb.WriteString("--- " + color.Bold(i18n.T("threecard.playerHeader")) + " ---\n")
 		rank := tc.GetPlayerHandRank()
 		if rank > 0 && rank < len(domain.ThreeCardHandNames) {
-			sb.WriteString(i18n.Tf("threecard.handLine", "hand", domain.ThreeCardHandNames[rank]) + "\n")
+			sb.WriteString(i18n.Tf("threecard.handLine", "hand", threeCardHandName(rank)) + "\n")
 		}
 		parts := make([]string, len(playerHand))
 		for i, card := range playerHand {
@@ -45,7 +45,7 @@ func (tp *ThreeCardCuiPresenter) Output(tc interfaces.ThreeCardGame, lastErr err
 		sb.WriteString("--- " + color.Bold(i18n.T("threecard.dealerHeader")) + " ---\n")
 		rank := tc.GetDealerHandRank()
 		if rank > 0 && rank < len(domain.ThreeCardHandNames) {
-			sb.WriteString(i18n.Tf("threecard.handLine", "hand", domain.ThreeCardHandNames[rank]) + "\n")
+			sb.WriteString(i18n.Tf("threecard.handLine", "hand", threeCardHandName(rank)) + "\n")
 		}
 		if tc.GetDealerQualified() {
 			sb.WriteString(i18n.T("threecard.qualified") + "\n")
@@ -154,4 +154,33 @@ func (tp *ThreeCardCuiPresenter) phaseStr(phase int) string {
 	default:
 		return i18n.T("threecard.phaseUnknown")
 	}
+}
+
+// threeCardHandKeys は役ランクと共通役名キーの対応。
+var threeCardHandKeys = []string{
+	"", // 0 は未使用
+	"highCard",
+	"pair",
+	"flush",
+	"straight",
+	"threeOfAKind",
+	"straightFlush",
+}
+
+// threeCardHandName は役名をロケールに応じて返す。
+//
+// **`domain.ThreeCardHandNames` は英語の表示名配列。**そのまま埋めていたので
+// 日本語ロケールでも Straight / Flush と出ていた (#4694)。訳は 3 カード固有では
+// ないので、ポーカー役の共通表 `pokerhand` を引く。訳が無ければ英語名に落とす。
+func threeCardHandName(rank int) string {
+	if rank > 0 && rank < len(threeCardHandKeys) {
+		full := "pokerhand." + threeCardHandKeys[rank]
+		if name := i18n.T(full); name != full {
+			return name
+		}
+	}
+	if rank > 0 && rank < len(domain.ThreeCardHandNames) {
+		return domain.ThreeCardHandNames[rank]
+	}
+	return ""
 }

--- a/internal/adapter/presenter/ThreeCardCuiPresenter_test.go
+++ b/internal/adapter/presenter/ThreeCardCuiPresenter_test.go
@@ -120,7 +120,10 @@ func TestThreeCardCuiPresenter_Output_ActionPhase(t *testing.T) {
 	result := p.Output(m, nil)
 	assert.Contains(t, result, "フェーズ: ACTION")
 	assert.Contains(t, result, "PLAYER")
-	assert.Contains(t, result, "High Card")
+	// 役名は日本語ロケールで日本語。以前は英語の表示名配列をそのまま
+	// 埋めていて、このテストがその挙動を固定していた (#4694)。
+	assert.Contains(t, result, "ハイカード")
+	assert.NotContains(t, result, "High Card")
 }
 
 func TestThreeCardCuiPresenter_Output_EndPhase_PlayerWins(t *testing.T) {
@@ -195,6 +198,12 @@ func TestThreeCardCuiPresenter_Output_EndPhase_PayoutBreakdown(t *testing.T) {
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil)).Maybe()
 
 	result := p.Output(m, nil)
+	// **役名も日本語で出す。**`domain.ThreeCardHandNames` は英語の表示名配列で、
+	// そのまま埋めていたので日本語ロケールでも Straight Flush と出ていた (#4694)。
+	assert.Contains(t, result, "ストレートフラッシュ")
+	assert.Contains(t, result, "ハイカード")
+	assert.NotContains(t, result, "Straight Flush")
+	assert.NotContains(t, result, "High Card")
 	assert.Contains(t, result, "アンテボーナス配当: 500")
 	assert.Contains(t, result, "ペアプラス配当: 4000")
 	assert.Contains(t, result, "合計払戻し: 4900")

--- a/internal/adapter/presenter/VideoPokerCuiPresenter.go
+++ b/internal/adapter/presenter/VideoPokerCuiPresenter.go
@@ -102,15 +102,22 @@ func (vpp *VideoPokerCuiPresenter) paytableStr(variantName string) string {
 	return sb.String()
 }
 
-// handNameForWin は勝利行に表示する役名を返す。Deuces Wild は安定キー
-// (GetHandKey) 経由で "deuceswild.hand.<key>" を翻訳し、ja/en それぞれの
-// ロケールで役名を表示する。他バリアント (videopoker / jokerpoker) は従来通り
-// 英語の GetHandName をそのまま返し、後方互換を保つ。
+// handNameForWin は勝利行に表示する役名を返す。
+//
+// **役名はバリアントに依らず共通。**以前は Deuces Wild だけ安定キー
+// (GetHandKey) 経由で翻訳し、Joker Poker と Video Poker は英語の GetHandName に
+// フォールバックしていたため、日本語ロケールでも勝敗行だけ英語で出ていた
+// (#4693)。翻訳表は 3 バリアント共通の `pokerhand` に置いてある。
+//
+// キーが無い、または訳が無い場合だけ英語名に落とす。
 func (vpp *VideoPokerCuiPresenter) handNameForWin(vp interfaces.VideoPokerGame) string {
-	if vp.GetVariantName() == "deuceswild" {
-		if key := vp.GetHandKey(); key != "" {
-			return i18n.T("deuceswild.hand." + key)
-		}
+	key := vp.GetHandKey()
+	if key == "" {
+		return vp.GetHandName()
+	}
+	full := "pokerhand." + key
+	if name := i18n.T(full); name != full {
+		return name
 	}
 	return vp.GetHandName()
 }

--- a/internal/adapter/presenter/VideoPokerCuiPresenter_test.go
+++ b/internal/adapter/presenter/VideoPokerCuiPresenter_test.go
@@ -133,8 +133,10 @@ func TestVideoPokerCuiPresenter_Output_ResultPhase_Win(t *testing.T) {
 
 	result := p.Output(m, nil)
 	assert.Contains(t, result, "フェーズ: リザルト")
-	// videopoker keeps the English hand name (backward compatible).
-	assert.Contains(t, result, "Four of a Kind! あなたの勝利です！")
+	// **役名は全バリアントで訳す。**以前はここが英語のままで、その挙動を
+	// このテストが固定していた (#4693 / #4694)。
+	assert.Contains(t, result, "フォーカード! あなたの勝利です！")
+	assert.NotContains(t, result, "Four of a Kind!")
 	assert.Contains(t, result, "払戻し: 25")
 }
 
@@ -180,6 +182,21 @@ func TestVideoPokerCuiPresenter_Output_ResultPhase_Win_DeucesWildTranslated(t *t
 	t.Run("empty key falls back to the raw hand name", func(t *testing.T) {
 		result := p.Output(winMock("deuceswild", "Wild Royal Flush", ""), nil)
 		assert.Contains(t, result, "Wild Royal Flush! あなたの勝利です！")
+	})
+
+	// **Joker Poker も訳す。**deuceswild だけ分岐していたので、日本語ロケール
+	// でも勝敗行だけ英語で出ていた (#4693)。
+	t.Run("joker poker is translated too", func(t *testing.T) {
+		result := p.Output(winMock("jokerpoker", "Five of a Kind", "fiveOfAKind"), nil)
+		assert.Contains(t, result, "ファイブカード! あなたの勝利です！")
+		assert.NotContains(t, result, "Five of a Kind!")
+	})
+
+	// 訳の無いキーは英語名に落とす。キー文字列を画面に出さない。
+	t.Run("an untranslated key falls back rather than printing the key", func(t *testing.T) {
+		result := p.Output(winMock("jokerpoker", "Mystery Hand", "mysteryHand"), nil)
+		assert.Contains(t, result, "Mystery Hand! あなたの勝利です！")
+		assert.NotContains(t, result, "pokerhand.")
 	})
 }
 

--- a/internal/i18n/locales/en/pokerhand.json
+++ b/internal/i18n/locales/en/pokerhand.json
@@ -1,0 +1,18 @@
+{
+  "royalFlush": "Royal Flush",
+  "naturalRoyalFlush": "Natural Royal Flush",
+  "wildRoyalFlush": "Wild Royal Flush",
+  "fourDeuces": "Four Deuces",
+  "fiveOfAKind": "Five of a Kind",
+  "straightFlush": "Straight Flush",
+  "fourOfAKind": "Four of a Kind",
+  "fullHouse": "Full House",
+  "flush": "Flush",
+  "straight": "Straight",
+  "threeOfAKind": "Three of a Kind",
+  "twoPair": "Two Pair",
+  "pair": "Pair",
+  "jacksOrBetter": "Jacks or Better",
+  "kingsOrBetter": "Kings or Better",
+  "highCard": "High Card"
+}

--- a/internal/i18n/locales/ja/pokerhand.json
+++ b/internal/i18n/locales/ja/pokerhand.json
@@ -1,0 +1,18 @@
+{
+  "royalFlush": "ロイヤルフラッシュ",
+  "naturalRoyalFlush": "ナチュラルロイヤルフラッシュ",
+  "wildRoyalFlush": "ワイルドロイヤルフラッシュ",
+  "fourDeuces": "フォーデューシーズ",
+  "fiveOfAKind": "ファイブカード",
+  "straightFlush": "ストレートフラッシュ",
+  "fourOfAKind": "フォーカード",
+  "fullHouse": "フルハウス",
+  "flush": "フラッシュ",
+  "straight": "ストレート",
+  "threeOfAKind": "スリーカード",
+  "twoPair": "ツーペア",
+  "pair": "ペア",
+  "jacksOrBetter": "ジャックス・オア・ベター",
+  "kingsOrBetter": "キングス・オア・ベター",
+  "highCard": "ハイカード"
+}


### PR DESCRIPTION
Closes #4694
Closes #4693

## 背景

| ゲーム | 症状 |
|--------|------|
| スリーカードポーカー (#4694) | `domain.ThreeCardHandNames` という**英語の表示名配列**を `threecard.handLine` にそのまま埋めていた |
| Joker Poker / Video Poker (#4693) | `handNameForWin` が `deuceswild` のときだけ i18n キー経由で訳し、他は `GetHandName()`（英語）にフォールバック |

どちらも日本語ロケールで遊んでいるのに、役名だけ Straight Flush / Two Pair と英語で出ていた。

## 変更

**訳を 1 箇所にまとめた。** issue はそれぞれ「`threecard.handRank.<rank>` を作る」「`jokerpoker.hand.<key>` を作る」と提案しているが、役名はゲーム固有ではない。ゲームごとに同じ 15 個を複製すると、片方だけ直したときに表記が割れる。共通の `internal/i18n/locales/{ja,en}/pokerhand.json` を 1 つ置き、

- `VideoPokerCuiPresenter.handNameForWin` — バリアント分岐をやめ、`GetHandKey()` が返す安定キーで `pokerhand.<key>` を引く（`videoPokerHandKey` は 3 バリアントすべてでキーを埋めている）
- `ThreeCardCuiPresenter` — ランク → キーの対応表を置いて同じ表を引く

の 2 箇所から参照する。**訳が無いキーは英語名に落とす** — キー文字列 (`pokerhand.foo`) を画面に出さない。

## 既存テストが不具合を固定していた

3 つの既存アサーションが英語名を期待していた:

- `VideoPokerCuiPresenter_test.go:137` — コメントまで付けて `// videopoker keeps the English hand name (backward compatible).`
- `ThreeCardCuiPresenter_test.go:123` — `assert.Contains(result, "High Card")`

いずれも日本語名を期待するよう改め、**英語名が出ないこと**も併せて固定した。追加したケース:

- Joker Poker が訳されること（`ファイブカード`）
- **訳の無いキーは英語名に落ち、`pokerhand.` というキー文字列が画面に出ないこと**
- スリーカードの役名がプレイヤー・ディーラー両方で訳されること

ネガティブコントロール: 両 presenter の実装を戻すと 6 テストが落ちる。

`go test -tags test ./...` / `golangci-lint run ./internal/...` (0 issues) / `bun run check` green。

## Test plan

- [ ] CI green