### PR TITLE
fix(cui): translate poker hand names across the remaining CUI presenters

### DIFF
--- a/internal/adapter/presenter/ChinesePokerCuiPresenter.go
+++ b/internal/adapter/presenter/ChinesePokerCuiPresenter.go
@@ -141,8 +141,10 @@ func (pp *ChinesePokerCuiPresenter) phaseStr(phase int) string {
 
 // frontRankStr フロントハンドランク文字列（3枚ポーカー）
 func (pp *ChinesePokerCuiPresenter) frontRankStr(rank int) string {
+	// 3 枚役の名前はスリーカードポーカーと同じ表を引く。英語の
+	// `ThreeCardHandNames` を直接返すと日本語ロケールでも英語で出る。
 	if rank >= 0 && rank < len(domain.ThreeCardHandNames) {
-		return domain.ThreeCardHandNames[rank]
+		return threeCardHandName(rank)
 	}
 	return i18n.T("chinesepoker.rankUnknown")
 }

--- a/internal/adapter/presenter/ChinesePokerCuiPresenter_test.go
+++ b/internal/adapter/presenter/ChinesePokerCuiPresenter_test.go
@@ -131,3 +131,15 @@ func TestChinesePokerCuiPresenter_RankStr(t *testing.T) {
 	assert.NotEmpty(t, pp.fiveCardRankStr(domain.PokerHandFlush))
 	assert.NotEmpty(t, pp.fiveCardRankStr(99))
 }
+
+// **フロントの役名も日本語ロケールで日本語。**英語の ThreeCardHandNames を
+// そのまま返していた (#4985 レビュー指摘の follow-up)。
+func TestChinesePokerCuiPresenter_FrontRankIsTranslated(t *testing.T) {
+	pp := new(ChinesePokerCuiPresenter)
+	assert.Equal(t, "ハイカード", pp.frontRankStr(domain.ThreeCardHandHighCard))
+	assert.Equal(t, "ストレートフラッシュ", pp.frontRankStr(domain.ThreeCardHandStraightFlush))
+	assert.NotContains(t, pp.frontRankStr(domain.ThreeCardHandFlush), "Flush")
+	// 範囲外は未知ランクの文言に落ちる。キー文字列を出さない。
+	assert.NotContains(t, pp.frontRankStr(99), "pokerhand.")
+	assert.NotEmpty(t, pp.frontRankStr(99))
+}

--- a/internal/adapter/presenter/DeuceToSevenCuiPresenter.go
+++ b/internal/adapter/presenter/DeuceToSevenCuiPresenter.go
@@ -60,7 +60,7 @@ func (dcp *DeuceToSevenCuiPresenter) Output(g interfaces.DeuceToSevenGame, lastE
 				if isEnd {
 					b.WriteString(i18n.Tf("deucetoseven.humanHandWithName",
 						"cards", handStr,
-						"name", pl.GetHandName()) + "\n")
+						"name", cuiPokerHandName(pl.GetHandRank())) + "\n")
 				} else {
 					b.WriteString(i18n.Tf("deucetoseven.humanHand", "cards", handStr) + "\n")
 				}
@@ -68,7 +68,7 @@ func (dcp *DeuceToSevenCuiPresenter) Output(g interfaces.DeuceToSevenGame, lastE
 			if !pl.GetIsHuman() && isEnd && !pl.GetFolded() {
 				b.WriteString(i18n.Tf("deucetoseven.humanHandWithName",
 					"cards", cuiCardListStrEmoji(pl),
-					"name", pl.GetHandName()) + "\n")
+					"name", cuiPokerHandName(pl.GetHandRank())) + "\n")
 			}
 		}
 
@@ -109,7 +109,7 @@ func (dcp *DeuceToSevenCuiPresenter) Output(g interfaces.DeuceToSevenGame, lastE
 				if r.HandName != "" {
 					b.WriteString(i18n.Tf("deucetoseven.resultHand",
 						"name", name,
-						"hand", r.HandName))
+						"hand", cuiPokerHandName(r.HandRank)))
 				} else {
 					b.WriteString(i18n.Tf("deucetoseven.resultName", "name", name))
 				}

--- a/internal/adapter/presenter/DeuceToSevenCuiPresenter_test.go
+++ b/internal/adapter/presenter/DeuceToSevenCuiPresenter_test.go
@@ -75,7 +75,9 @@ func TestDeuceToSevenCuiPresenter_Output_EndPhaseShowsHandName(t *testing.T) {
 	dt.SetRoundResults([]domain.DeuceToSevenResult{{PlayerIdx: 1, HandRank: domain.PokerHandHighCard, HandName: "High Card", WonAmount: 100}})
 
 	out := pres.Output(dt, nil)
-	assert.Contains(t, out, "High Card")
+	// 役名は日本語ロケールで日本語 (英語の PokerHandNames 直埋めをやめた)。
+	assert.Contains(t, out, "ハイカード")
+	assert.NotContains(t, out, "High Card")
 	assert.Contains(t, out, "ゲーム終了")
 	assert.Contains(t, strings.ToLower(out), "100")
 }

--- a/internal/adapter/presenter/FiveCardStudCuiPresenter.go
+++ b/internal/adapter/presenter/FiveCardStudCuiPresenter.go
@@ -127,7 +127,7 @@ func (p *FiveCardStudCuiPresenter) Output(s interfaces.FiveCardStudGame, lastErr
 				case r.HandName != "":
 					b.WriteString(i18n.Tf("fivecardstud.resultHand",
 						"name", name,
-						"hand", r.HandName,
+						"hand", cuiPokerHandName(r.HandRank),
 						"kickers", kickers))
 				default:
 					b.WriteString(i18n.Tf("fivecardstud.resultName", "name", name))

--- a/internal/adapter/presenter/FiveCardStudCuiPresenter_test.go
+++ b/internal/adapter/presenter/FiveCardStudCuiPresenter_test.go
@@ -126,7 +126,7 @@ func TestFiveCardStudCuiPresenter_Output(t *testing.T) {
 
 		result := p.Output(s, nil)
 		assert.Contains(t, result, "[結果]")
-		assert.Contains(t, result, "あなた: Flush")
+		assert.Contains(t, result, "あなた: フラッシュ")
 		assert.Contains(t, result, "100チップ獲得")
 	})
 
@@ -138,7 +138,7 @@ func TestFiveCardStudCuiPresenter_Output(t *testing.T) {
 		})
 
 		result := p.Output(s, nil)
-		assert.Contains(t, result, "あなた: One Pair (キッカー: A, Q, 10)")
+		assert.Contains(t, result, "あなた: ワンペア (キッカー: A, Q, 10)")
 	})
 
 	t.Run("showdown results with CPU winner", func(t *testing.T) {
@@ -149,14 +149,14 @@ func TestFiveCardStudCuiPresenter_Output(t *testing.T) {
 		})
 
 		result := p.Output(s, nil)
-		assert.Contains(t, result, "CPU 1: One Pair (キッカー: K, Q, J)")
+		assert.Contains(t, result, "CPU 1: ワンペア (キッカー: K, Q, J)")
 	})
 
 	t.Run("results not shown in non-end phase", func(t *testing.T) {
 		s, _ := makeFiveCardStudForPresenter()
 		s.SetPhase(domain.FiveCardStudPhaseSecondStreet)
 		s.SetRoundResults([]domain.FiveCardStudResult{
-			{PlayerIdx: 0, HandName: "Flush", WonAmount: 100},
+			{PlayerIdx: 0, HandRank: domain.PokerHandFlush, HandName: "Flush", WonAmount: 100},
 		})
 
 		result := p.Output(s, nil)
@@ -183,13 +183,13 @@ func TestFiveCardStudCuiPresenter_Output(t *testing.T) {
 		s, _ := makeFiveCardStudForPresenter()
 		s.SetPhase(domain.FiveCardStudPhaseEnd)
 		s.SetRoundResults([]domain.FiveCardStudResult{
-			{PlayerIdx: 0, HandName: "One Pair", WonAmount: 0, Mucked: true},
+			{PlayerIdx: 0, HandRank: domain.PokerHandOnePair, HandName: "One Pair", WonAmount: 0, Mucked: true},
 			{PlayerIdx: 1, HandRank: domain.PokerHandFlush, HandName: "Flush", WonAmount: 100},
 		})
 
 		result := p.Output(s, nil)
 		assert.Contains(t, result, "あなた: マック")
-		assert.NotContains(t, result, "あなた: One Pair")
+		assert.NotContains(t, result, "あなた: ワンペア")
 	})
 
 	t.Run("results shown in showdown phase", func(t *testing.T) {
@@ -201,7 +201,7 @@ func TestFiveCardStudCuiPresenter_Output(t *testing.T) {
 
 		result := p.Output(s, nil)
 		assert.Contains(t, result, "[結果]")
-		assert.Contains(t, result, "あなた: Flush")
+		assert.Contains(t, result, "あなた: フラッシュ")
 	})
 
 	t.Run("HUD stats shown when totalHands > 0", func(t *testing.T) {

--- a/internal/adapter/presenter/HoldemCuiPresenter.go
+++ b/internal/adapter/presenter/HoldemCuiPresenter.go
@@ -142,7 +142,7 @@ func (p *HoldemCuiPresenter) Output(h interfaces.HoldemGame, lastErr error) stri
 				case r.HandName != "":
 					b.WriteString(i18n.Tf("holdem.resultHand",
 						"name", name,
-						"hand", r.HandName,
+						"hand", cuiPokerHandName(r.HandRank),
 						"kickers", kickers))
 				default:
 					b.WriteString(i18n.Tf("holdem.resultName", "name", name))

--- a/internal/adapter/presenter/HoldemCuiPresenter_test.go
+++ b/internal/adapter/presenter/HoldemCuiPresenter_test.go
@@ -198,7 +198,7 @@ func TestHoldemCuiPresenter_Output(t *testing.T) {
 		_ = players[0]
 		result := p.Output(h, nil)
 		assert.Contains(t, result, "[結果]")
-		assert.Contains(t, result, "あなた: Flush")
+		assert.Contains(t, result, "あなた: フラッシュ")
 		assert.Contains(t, result, "100チップ獲得")
 	})
 
@@ -210,7 +210,7 @@ func TestHoldemCuiPresenter_Output(t *testing.T) {
 		})
 
 		result := p.Output(h, nil)
-		assert.Contains(t, result, "あなた: One Pair (キッカー: A, Q, 10)")
+		assert.Contains(t, result, "あなた: ワンペア (キッカー: A, Q, 10)")
 		assert.Contains(t, result, "100チップ獲得")
 	})
 
@@ -222,7 +222,7 @@ func TestHoldemCuiPresenter_Output(t *testing.T) {
 		})
 
 		result := p.Output(h, nil)
-		assert.Contains(t, result, "あなた: Flush")
+		assert.Contains(t, result, "あなた: フラッシュ")
 		assert.NotContains(t, result, "キッカー")
 	})
 
@@ -234,7 +234,7 @@ func TestHoldemCuiPresenter_Output(t *testing.T) {
 		})
 
 		result := p.Output(h, nil)
-		assert.Contains(t, result, "CPU 1: One Pair (キッカー: K, Q, J)")
+		assert.Contains(t, result, "CPU 1: ワンペア (キッカー: K, Q, J)")
 		assert.Contains(t, result, "50チップ獲得")
 	})
 
@@ -254,7 +254,7 @@ func TestHoldemCuiPresenter_Output(t *testing.T) {
 		h, _ := makeHoldemForPresenter()
 		h.SetPhase(domain.HoldemPhaseEnd)
 		h.SetRoundResults([]domain.HoldemResult{
-			{PlayerIdx: 1, HandName: "High Card", WonAmount: 0, BestHand: nil},
+			{PlayerIdx: 1, HandRank: domain.PokerHandHighCard, HandName: "High Card", WonAmount: 0, BestHand: nil},
 		})
 
 		result := p.Output(h, nil)
@@ -265,7 +265,7 @@ func TestHoldemCuiPresenter_Output(t *testing.T) {
 		h, _ := makeHoldemForPresenter()
 		h.SetPhase(domain.HoldemPhaseFlop)
 		h.SetRoundResults([]domain.HoldemResult{
-			{PlayerIdx: 0, HandName: "Flush", WonAmount: 100, BestHand: nil},
+			{PlayerIdx: 0, HandRank: domain.PokerHandFlush, HandName: "Flush", WonAmount: 100, BestHand: nil},
 		})
 
 		result := p.Output(h, nil)
@@ -680,13 +680,13 @@ func TestHoldemCuiPresenter_Output_Muck(t *testing.T) {
 		h, _ := makeHoldemForPresenter()
 		h.SetPhase(domain.HoldemPhaseEnd)
 		h.SetRoundResults([]domain.HoldemResult{
-			{PlayerIdx: 0, HandName: "One Pair", WonAmount: 0, Mucked: true, BestHand: nil},
+			{PlayerIdx: 0, HandRank: domain.PokerHandOnePair, HandName: "One Pair", WonAmount: 0, Mucked: true, BestHand: nil},
 			{PlayerIdx: 1, HandRank: domain.PokerHandFlush, HandName: "Flush", WonAmount: 100, BestHand: nil},
 		})
 
 		result := p.Output(h, nil)
 		assert.Contains(t, result, "あなた: マック")
-		assert.NotContains(t, result, "あなた: One Pair")
+		assert.NotContains(t, result, "あなた: ワンペア")
 	})
 
 	t.Run("results shown in showdown phase", func(t *testing.T) {
@@ -698,7 +698,7 @@ func TestHoldemCuiPresenter_Output_Muck(t *testing.T) {
 
 		result := p.Output(h, nil)
 		assert.Contains(t, result, "[結果]")
-		assert.Contains(t, result, "あなた: Flush")
+		assert.Contains(t, result, "あなた: フラッシュ")
 	})
 }
 

--- a/internal/adapter/presenter/OmahaCuiPresenter.go
+++ b/internal/adapter/presenter/OmahaCuiPresenter.go
@@ -143,7 +143,7 @@ func (p *OmahaCuiPresenter) Output(o interfaces.OmahaGame, lastErr error) string
 				case r.Mucked:
 					b.WriteString(i18n.Tf("omaha.resultMucked", "name", name))
 				case r.HandName != "":
-					b.WriteString(i18n.Tf("omaha.resultHand", "name", name, "hand", r.HandName, "kickers", kickers))
+					b.WriteString(i18n.Tf("omaha.resultHand", "name", name, "hand", cuiPokerHandName(r.HandRank), "kickers", kickers))
 				default:
 					b.WriteString(i18n.Tf("omaha.resultPlayerOnly", "name", name))
 				}

--- a/internal/adapter/presenter/OmahaCuiPresenter_test.go
+++ b/internal/adapter/presenter/OmahaCuiPresenter_test.go
@@ -221,7 +221,7 @@ func TestOmahaCuiPresenter_Output(t *testing.T) {
 		_ = players[0]
 		result := p.Output(h, nil)
 		assert.Contains(t, result, "[結果]")
-		assert.Contains(t, result, "あなた: Flush")
+		assert.Contains(t, result, "あなた: フラッシュ")
 		assert.Contains(t, result, "100チップ獲得")
 	})
 
@@ -233,7 +233,7 @@ func TestOmahaCuiPresenter_Output(t *testing.T) {
 		})
 
 		result := p.Output(h, nil)
-		assert.Contains(t, result, "あなた: One Pair (キッカー: A, Q, 10)")
+		assert.Contains(t, result, "あなた: ワンペア (キッカー: A, Q, 10)")
 		assert.Contains(t, result, "100チップ獲得")
 	})
 
@@ -245,7 +245,7 @@ func TestOmahaCuiPresenter_Output(t *testing.T) {
 		})
 
 		result := p.Output(h, nil)
-		assert.Contains(t, result, "あなた: Flush")
+		assert.Contains(t, result, "あなた: フラッシュ")
 		assert.NotContains(t, result, "キッカー")
 	})
 
@@ -257,7 +257,7 @@ func TestOmahaCuiPresenter_Output(t *testing.T) {
 		})
 
 		result := p.Output(h, nil)
-		assert.Contains(t, result, "CPU 1: One Pair (キッカー: K, Q, J)")
+		assert.Contains(t, result, "CPU 1: ワンペア (キッカー: K, Q, J)")
 		assert.Contains(t, result, "50チップ獲得")
 	})
 
@@ -277,7 +277,7 @@ func TestOmahaCuiPresenter_Output(t *testing.T) {
 		h, _ := makeOmahaForPresenter()
 		h.SetPhase(domain.OmahaPhaseEnd)
 		h.SetRoundResults([]domain.HoldemResult{
-			{PlayerIdx: 1, HandName: "High Card", WonAmount: 0, BestHand: nil},
+			{PlayerIdx: 1, HandRank: domain.PokerHandHighCard, HandName: "High Card", WonAmount: 0, BestHand: nil},
 		})
 
 		result := p.Output(h, nil)
@@ -288,7 +288,7 @@ func TestOmahaCuiPresenter_Output(t *testing.T) {
 		h, _ := makeOmahaForPresenter()
 		h.SetPhase(domain.OmahaPhaseFlop)
 		h.SetRoundResults([]domain.HoldemResult{
-			{PlayerIdx: 0, HandName: "Flush", WonAmount: 100, BestHand: nil},
+			{PlayerIdx: 0, HandRank: domain.PokerHandFlush, HandName: "Flush", WonAmount: 100, BestHand: nil},
 		})
 
 		result := p.Output(h, nil)
@@ -623,13 +623,13 @@ func TestOmahaCuiPresenter_Output_Muck(t *testing.T) {
 		h, _ := makeOmahaForPresenter()
 		h.SetPhase(domain.OmahaPhaseEnd)
 		h.SetRoundResults([]domain.HoldemResult{
-			{PlayerIdx: 0, HandName: "One Pair", WonAmount: 0, Mucked: true, BestHand: nil},
+			{PlayerIdx: 0, HandRank: domain.PokerHandOnePair, HandName: "One Pair", WonAmount: 0, Mucked: true, BestHand: nil},
 			{PlayerIdx: 1, HandRank: domain.PokerHandFlush, HandName: "Flush", WonAmount: 100, BestHand: nil},
 		})
 
 		result := p.Output(h, nil)
 		assert.Contains(t, result, "あなた: マック")
-		assert.NotContains(t, result, "あなた: One Pair")
+		assert.NotContains(t, result, "あなた: ワンペア")
 	})
 
 	t.Run("results shown in showdown phase", func(t *testing.T) {
@@ -641,7 +641,7 @@ func TestOmahaCuiPresenter_Output_Muck(t *testing.T) {
 
 		result := p.Output(h, nil)
 		assert.Contains(t, result, "[結果]")
-		assert.Contains(t, result, "あなた: Flush")
+		assert.Contains(t, result, "あなた: フラッシュ")
 	})
 }
 

--- a/internal/adapter/presenter/PineappleCuiPresenter.go
+++ b/internal/adapter/presenter/PineappleCuiPresenter.go
@@ -153,7 +153,7 @@ func (pp *PineappleCuiPresenter) Output(p interfaces.PineappleGame, lastErr erro
 				case r.HandName != "":
 					b.WriteString(i18n.Tf("pineapple.resultHand",
 						"name", name,
-						"hand", r.HandName,
+						"hand", cuiPokerHandName(r.HandRank),
 						"kickers", kickers))
 				default:
 					b.WriteString(i18n.Tf("pineapple.resultName", "name", name))

--- a/internal/adapter/presenter/PineappleCuiPresenter_test.go
+++ b/internal/adapter/presenter/PineappleCuiPresenter_test.go
@@ -109,10 +109,10 @@ func TestPineappleCuiPresenter_Output(t *testing.T) {
 		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetRoundResults")
 		m.On("GetPhase").Return(domain.PineapplePhaseEnd)
 		m.On("GetRoundResults").Return([]domain.HoldemResult{
-			{PlayerIdx: 0, HandName: "Flush", WonAmount: 100},
+			{PlayerIdx: 0, HandRank: domain.PokerHandFlush, HandName: "Flush", WonAmount: 100},
 		})
 		result := p.Output(m, nil)
-		assert.Contains(t, result, "あなた: Flush")
+		assert.Contains(t, result, "あなた: フラッシュ")
 		assert.Contains(t, result, "100チップ獲得")
 	})
 

--- a/internal/adapter/presenter/PokerCuiPresenter.go
+++ b/internal/adapter/presenter/PokerCuiPresenter.go
@@ -64,7 +64,7 @@ func (pcp *PokerCuiPresenter) Output(p interfaces.PokerGame, lastErr error) stri
 				if isEnd {
 					b.WriteString(i18n.Tf("poker.humanHandWithName",
 						"cards", handStr,
-						"name", player.GetHandName()) + "\n")
+						"name", cuiPokerHandName(player.GetHandRank())) + "\n")
 				} else {
 					b.WriteString(i18n.Tf("poker.humanHand", "cards", handStr) + "\n")
 				}
@@ -74,7 +74,7 @@ func (pcp *PokerCuiPresenter) Output(p interfaces.PokerGame, lastErr error) stri
 			if !player.GetIsHuman() && isEnd && !player.GetFolded() {
 				b.WriteString(i18n.Tf("poker.humanHandWithName",
 					"cards", cuiCardListStrEmoji(player),
-					"name", player.GetHandName()) + "\n")
+					"name", cuiPokerHandName(player.GetHandRank())) + "\n")
 			}
 		}
 
@@ -117,7 +117,7 @@ func (pcp *PokerCuiPresenter) Output(p interfaces.PokerGame, lastErr error) stri
 				if r.HandName != "" {
 					b.WriteString(i18n.Tf("poker.resultHand",
 						"name", name,
-						"hand", r.HandName,
+						"hand", cuiPokerHandName(r.HandRank),
 						"kickers", kickers))
 				} else {
 					b.WriteString(i18n.Tf("poker.resultName", "name", name))
@@ -181,7 +181,7 @@ func (pcp *PokerCuiPresenter) OutputWithOdds(p interfaces.PokerGame, lastErr err
 	oddsBuilder.WriteString(color.Bold(i18n.T("poker.drawOddsHeader")) + "\n")
 	for _, o := range odds {
 		oddsBuilder.WriteString(i18n.Tf("poker.drawOddsLine",
-			"name", o.HandName,
+			"name", cuiPokerHandName(o.HandRank),
 			"prob", fmt.Sprintf("%.2f", o.Probability*100),
 			"count", strconv.Itoa(o.Count),
 			"total", strconv.Itoa(o.Total)) + "\n")

--- a/internal/adapter/presenter/PokerCuiPresenter_test.go
+++ b/internal/adapter/presenter/PokerCuiPresenter_test.go
@@ -195,7 +195,7 @@ func TestPokerCuiPresenter_Output(t *testing.T) {
 		players[0].EvalHand()
 
 		result := pres.Output(p, nil)
-		assert.Contains(t, result, "[Straight Flush]")
+		assert.Contains(t, result, "[ストレートフラッシュ]")
 	})
 
 	t.Run("human hand name not shown in non-end phase", func(t *testing.T) {
@@ -209,7 +209,7 @@ func TestPokerCuiPresenter_Output(t *testing.T) {
 		players[0].EvalHand()
 
 		result := pres.Output(p, nil)
-		assert.NotContains(t, result, "[Straight Flush]")
+		assert.NotContains(t, result, "[ストレートフラッシュ]")
 	})
 
 	t.Run("CPU cards shown at end phase when not folded", func(t *testing.T) {
@@ -225,7 +225,10 @@ func TestPokerCuiPresenter_Output(t *testing.T) {
 		result := pres.Output(p, nil)
 		assert.Contains(t, result, "♠5")
 		assert.Contains(t, result, "♥5")
-		assert.Contains(t, result, "[Two Pair]")
+		// **役名も日本語ロケールで日本語。**英語の PokerHandNames をそのまま
+		// 埋めていて、このテストがその挙動を固定していた。
+		assert.Contains(t, result, "[ツーペア]")
+		assert.NotContains(t, result, "[Two Pair]")
 	})
 
 	t.Run("CPU cards hidden when not end phase", func(t *testing.T) {
@@ -332,7 +335,7 @@ func TestPokerCuiPresenter_Output(t *testing.T) {
 
 		result := pres.Output(p, nil)
 		assert.Contains(t, result, "[結果]")
-		assert.Contains(t, result, "あなた: Flush")
+		assert.Contains(t, result, "あなた: フラッシュ")
 		assert.Contains(t, result, "100チップ獲得")
 	})
 
@@ -344,7 +347,7 @@ func TestPokerCuiPresenter_Output(t *testing.T) {
 		})
 
 		result := pres.Output(p, nil)
-		assert.Contains(t, result, "あなた: One Pair (キッカー: A, Q, 10)")
+		assert.Contains(t, result, "あなた: ワンペア (キッカー: A, Q, 10)")
 		assert.Contains(t, result, "100チップ獲得")
 	})
 
@@ -356,7 +359,7 @@ func TestPokerCuiPresenter_Output(t *testing.T) {
 		})
 
 		result := pres.Output(p, nil)
-		assert.Contains(t, result, "あなた: Flush")
+		assert.Contains(t, result, "あなた: フラッシュ")
 		assert.NotContains(t, result, "キッカー")
 	})
 
@@ -368,7 +371,7 @@ func TestPokerCuiPresenter_Output(t *testing.T) {
 		})
 
 		result := pres.Output(p, nil)
-		assert.Contains(t, result, "CPU 1: One Pair (キッカー: K, Q, J)")
+		assert.Contains(t, result, "CPU 1: ワンペア (キッカー: K, Q, J)")
 		assert.Contains(t, result, "50チップ獲得")
 	})
 
@@ -388,7 +391,7 @@ func TestPokerCuiPresenter_Output(t *testing.T) {
 		p, _ := makePokerCuiForPresenter()
 		p.SetPhase(domain.PokerPhaseEnd)
 		p.SetRoundResults([]domain.PokerResult{
-			{PlayerIdx: 1, HandName: "High Card", WonAmount: 0},
+			{PlayerIdx: 1, HandRank: domain.PokerHandHighCard, HandName: "High Card", WonAmount: 0},
 		})
 
 		result := pres.Output(p, nil)
@@ -399,7 +402,7 @@ func TestPokerCuiPresenter_Output(t *testing.T) {
 		p, _ := makePokerCuiForPresenter()
 		p.SetPhase(domain.PokerPhaseDeal)
 		p.SetRoundResults([]domain.PokerResult{
-			{PlayerIdx: 0, HandName: "Flush", WonAmount: 100},
+			{PlayerIdx: 0, HandRank: domain.PokerHandFlush, HandName: "Flush", WonAmount: 100},
 		})
 
 		result := pres.Output(p, nil)
@@ -584,8 +587,8 @@ func TestPokerCuiPresenter_OutputWithOdds(t *testing.T) {
 
 	result := pres.OutputWithOdds(p, nil, odds)
 	assert.Contains(t, result, "[ドローオッズ]")
-	assert.Contains(t, result, "High Card: 50.00% (50/100)")
-	assert.Contains(t, result, "One Pair: 30.00% (30/100)")
+	assert.Contains(t, result, "ハイカード: 50.00% (50/100)")
+	assert.Contains(t, result, "ワンペア: 30.00% (30/100)")
 }
 
 func TestPokerCuiPresenter_OutputWithOdds_NilOdds(t *testing.T) {

--- a/internal/adapter/presenter/SevenCardStudCuiPresenter.go
+++ b/internal/adapter/presenter/SevenCardStudCuiPresenter.go
@@ -161,7 +161,7 @@ func (p *SevenCardStudCuiPresenter) Output(s interfaces.SevenCardStudGame, lastE
 				case r.HandName != "":
 					b.WriteString(i18n.Tf("sevencardstud.resultHand",
 						"name", name,
-						"hand", r.HandName,
+						"hand", cuiPokerHandName(r.HandRank),
 						"kickers", kickers))
 				default:
 					b.WriteString(i18n.Tf("sevencardstud.resultName", "name", name))

--- a/internal/adapter/presenter/SevenCardStudCuiPresenter_test.go
+++ b/internal/adapter/presenter/SevenCardStudCuiPresenter_test.go
@@ -198,7 +198,7 @@ func TestSevenCardStudCuiPresenter_Output(t *testing.T) {
 
 		result := p.Output(s, nil)
 		assert.Contains(t, result, "[結果]")
-		assert.Contains(t, result, "あなた: Flush")
+		assert.Contains(t, result, "あなた: フラッシュ")
 		assert.Contains(t, result, "100チップ獲得")
 	})
 
@@ -210,7 +210,7 @@ func TestSevenCardStudCuiPresenter_Output(t *testing.T) {
 		})
 
 		result := p.Output(s, nil)
-		assert.Contains(t, result, "あなた: One Pair (キッカー: A, Q, 10)")
+		assert.Contains(t, result, "あなた: ワンペア (キッカー: A, Q, 10)")
 	})
 
 	t.Run("showdown results with CPU winner", func(t *testing.T) {
@@ -221,14 +221,14 @@ func TestSevenCardStudCuiPresenter_Output(t *testing.T) {
 		})
 
 		result := p.Output(s, nil)
-		assert.Contains(t, result, "CPU 1: One Pair (キッカー: K, Q, J)")
+		assert.Contains(t, result, "CPU 1: ワンペア (キッカー: K, Q, J)")
 	})
 
 	t.Run("results not shown in non-end phase", func(t *testing.T) {
 		s, _ := makeSevenCardStudForPresenter()
 		s.SetPhase(domain.SevenCardStudPhaseThirdStreet)
 		s.SetRoundResults([]domain.SevenCardStudResult{
-			{PlayerIdx: 0, HandName: "Flush", WonAmount: 100},
+			{PlayerIdx: 0, HandRank: domain.PokerHandFlush, HandName: "Flush", WonAmount: 100},
 		})
 
 		result := p.Output(s, nil)
@@ -255,13 +255,13 @@ func TestSevenCardStudCuiPresenter_Output(t *testing.T) {
 		s, _ := makeSevenCardStudForPresenter()
 		s.SetPhase(domain.SevenCardStudPhaseEnd)
 		s.SetRoundResults([]domain.SevenCardStudResult{
-			{PlayerIdx: 0, HandName: "One Pair", WonAmount: 0, Mucked: true},
+			{PlayerIdx: 0, HandRank: domain.PokerHandOnePair, HandName: "One Pair", WonAmount: 0, Mucked: true},
 			{PlayerIdx: 1, HandRank: domain.PokerHandFlush, HandName: "Flush", WonAmount: 100},
 		})
 
 		result := p.Output(s, nil)
 		assert.Contains(t, result, "あなた: マック")
-		assert.NotContains(t, result, "あなた: One Pair")
+		assert.NotContains(t, result, "あなた: ワンペア")
 	})
 
 	t.Run("results shown in showdown phase", func(t *testing.T) {
@@ -273,7 +273,7 @@ func TestSevenCardStudCuiPresenter_Output(t *testing.T) {
 
 		result := p.Output(s, nil)
 		assert.Contains(t, result, "[結果]")
-		assert.Contains(t, result, "あなた: Flush")
+		assert.Contains(t, result, "あなた: フラッシュ")
 	})
 
 	t.Run("HUD stats shown when totalHands > 0", func(t *testing.T) {


### PR DESCRIPTION
#4985 のレビューで指摘された follow-up。

> Several other CUI presenters have the same underlying pattern this PR just fixed — e.g. `PokerCuiPresenter.go:67,77,120,184` write `player.GetHandName()` / `r.HandName` straight to the CUI output, which is the same raw English `domain.PokerHandNames` string.

## 変更

`cuiPokerHandName(rank)`（既存の共有ヘルパ、`pokerHandRank<N>` キーを引く）に寄せた:

| ゲーム | 直した箇所 |
|--------|-----------|
| ポーカー | 人間/CPU の手札表示、ショーダウン結果、**ドローオッズ** |
| ホールデム / オマハ / パイナップル | ショーダウン結果 |
| 5カードスタッド / 7カードスタッド | ショーダウン結果 |
| デュース・トゥ・セブン | 手札表示、ショーダウン結果 |
| 中国式ポーカー | フロントハンド（3枚役、スリーカードと同じ表） |

## 対象外にしたもの

- **ショートデック** — `ShortDeckHandNames` は**フラッシュがフルハウスの上**に来る独自序列。共通表を引くとランク 5 が「フラッシュ」と誤表示される（実際はフルハウス）。**訳されないより誤訳のほうが悪い**ので、専用の対応表が必要。分けた
- **バドゥーギ** — `BadugiHandNames` は独自の役名体系（バドゥーギ/3カード…）で、ポーカー役表と対応しない

## テスト

既存の 25 サブテストが英語役名を固定していたので日本語に改めた（`[Two Pair]` → `[ツーペア]` など）。英語名が出ないことも併せて固定している。

あわせて **`HandRank` を省いたフィクスチャに rank を補った**。`{PlayerIdx: 0, HandName: "Flush"}` のように名前だけ設定して rank を 0 のままにしていたテストがあり、ランク経由の表示に切り替えると「ハイカード」と出る。名前と rank が食い違うフィクスチャは、どちらの経路を使っているかで結果が変わってしまう。

ネガティブコントロール: presenter 側の変更だけ `git stash` で戻すと 25 サブテストが落ちる。

`go test -tags test ./...` / `golangci-lint run ./internal/...` (0 issues) green。

## Test plan

- [ ] CI green