### PR TITLE
feat(poch,popejoan,nainjaune): show which cards may be played before the server rejects one

### DIFF
--- a/frontend/e2e/nainjaune.spec.ts
+++ b/frontend/e2e/nainjaune.spec.ts
@@ -18,7 +18,8 @@ test.describe('Le Nain Jaune E2E', () => {
     // Nothing is selected yet, so playing is refused.
     await expect(play).toBeDisabled();
 
-    await page.locator('[data-hint-action="play"]').first().click();
+    // **出せない札は disabled。**先頭の札が常に選べるとは限らない (#4933-#4935)。
+    await page.locator('[data-hint-action="play"]:not([disabled])').first().click();
     await expect(play).toBeEnabled();
     await play.click();
     await waitForLoaded(page);

--- a/frontend/e2e/popejoan.spec.ts
+++ b/frontend/e2e/popejoan.spec.ts
@@ -18,7 +18,8 @@ test.describe('Pope Joan E2E', () => {
     // Nothing is selected yet, so playing is refused.
     await expect(play).toBeDisabled();
 
-    await page.locator('[data-hint-action="play"]').first().click();
+    // **出せない札は disabled。**先頭の札が常に選べるとは限らない (#4933-#4935)。
+    await page.locator('[data-hint-action="play"]:not([disabled])').first().click();
     await expect(play).toBeEnabled();
     await play.click();
     await waitForLoaded(page);

--- a/frontend/src/pages/NainJaunePage.test.tsx
+++ b/frontend/src/pages/NainJaunePage.test.tsx
@@ -41,6 +41,7 @@ function makeState(overrides?: Partial<NainJauneResponse>): NainJauneResponse {
   return {
     players: [seat(0, true), seat(1, false), seat(2, false), seat(3, false)],
     phase: NainJaunePhase.PLAY,
+    validPlays: [],
     currentPlayerIdx: 0,
     boxes: BOXES,
     talonCount: 4,
@@ -149,5 +150,34 @@ describe('NainJaunePage', () => {
       renderWithProviders(<NainJaunePage />);
       await waitFor(() => expect(screen.getAllByText(text).length).toBeGreaterThan(0));
     }
+  });
+
+  // **並びに従う義務がある。**出せない札を押せてしまうと、サーバに弾かれて
+  // 初めて分かる (#4935)。
+  describe('playable-card restriction', () => {
+    it('disables and dims the cards that cannot legally be played', async () => {
+      mockExec.mockResolvedValue(makeState({ validPlays: [0] }));
+      renderWithProviders(<NainJaunePage />);
+      await waitFor(() => expect(mockExec).toHaveBeenCalled());
+
+      const buttons = screen.getAllByRole('button').filter((b) => b.hasAttribute('data-hint-action'));
+      expect(buttons.length).toBeGreaterThan(1);
+      expect(buttons[0]).not.toBeDisabled();
+      expect(buttons[0]).not.toHaveAttribute('data-unplayable');
+      expect(buttons[1]).toBeDisabled();
+      expect(buttons[1]).toHaveAttribute('data-unplayable', 'true');
+    });
+
+    // **空リストは「一枚も出せない」ではなく「情報が無い」。**空で全部塞ぐと
+    // 盤面が操作不能になる。
+    it('does not restrict anything when the server sent no list', async () => {
+      mockExec.mockResolvedValue(makeState({ validPlays: [] }));
+      renderWithProviders(<NainJaunePage />);
+      await waitFor(() => expect(mockExec).toHaveBeenCalled());
+
+      for (const b of screen.getAllByRole('button').filter((x) => x.hasAttribute('data-hint-action'))) {
+        expect(b).not.toBeDisabled();
+      }
+    });
   });
 });

--- a/frontend/src/pages/NainJaunePage.tsx
+++ b/frontend/src/pages/NainJaunePage.tsx
@@ -203,24 +203,34 @@ function NainJaunePageContent() {
                 {t('yourPoints', { n: human?.points ?? 0 })}
               </div>
               <div className="flex gap-1 justify-center flex-wrap">
-                {(human?.cards ?? []).map((card, i) => (
-                  <button
-                    key={`hand-${i.toString()}`}
-                    type="button"
-                    data-hint-action="play"
-                    aria-pressed={handIdx === i}
-                    aria-disabled={!isHumanTurn}
-                    onClick={() => isHumanTurn && setHandIdx(handIdx === i ? null : i)}
-                    className={[
-                      'rounded transition-transform',
-                      isHumanTurn ? 'hover:-translate-y-2' : 'opacity-60',
-                      handIdx === i ? 'ring-2 ring-ds-accent -translate-y-2' : '',
-                      frontendHintEnabled && state.hint?.cardIndex === i ? 'ring-2 ring-ds-warning' : '',
-                    ].join(' ')}
-                  >
-                    <AnimatedCard card={card} width={cardWidth} draggable={false} />
-                  </button>
-                ))}
+                {(human?.cards ?? []).map((card, i) => {
+                  // **並びに従う義務がある。**出せない札を押せてしまうと、
+                  // サーバに弾かれて初めて分かる (#4935)。空リストは「情報が
+                  // 無い」なので制限しない。
+                  const restricting = isHumanTurn && (state.validPlays?.length ?? 0) > 0;
+                  const canPlay = !restricting || state.validPlays.includes(i);
+                  return (
+                    <button
+                      key={`hand-${i.toString()}`}
+                      type="button"
+                      data-hint-action="play"
+                      data-unplayable={restricting && !canPlay ? 'true' : undefined}
+                      aria-pressed={handIdx === i}
+                      disabled={restricting && !canPlay}
+                      aria-disabled={!isHumanTurn || !canPlay}
+                      onClick={() => isHumanTurn && canPlay && setHandIdx(handIdx === i ? null : i)}
+                      className={[
+                        'rounded transition-transform',
+                        restricting && !canPlay ? 'opacity-40' : '',
+                        isHumanTurn ? 'hover:-translate-y-2' : 'opacity-60',
+                        handIdx === i ? 'ring-2 ring-ds-accent -translate-y-2' : '',
+                        frontendHintEnabled && state.hint?.cardIndex === i ? 'ring-2 ring-ds-warning' : '',
+                      ].join(' ')}
+                    >
+                      <AnimatedCard card={card} width={cardWidth} draggable={false} />
+                    </button>
+                  );
+                })}
               </div>
               {isHumanTurn && (
                 <div className="text-[10px] text-ds-text-muted mt-1">

--- a/frontend/src/pages/PochPage.test.tsx
+++ b/frontend/src/pages/PochPage.test.tsx
@@ -36,6 +36,7 @@ function makeState(overrides?: Partial<PochResponse>): PochResponse {
   return {
     players: [seat(0, true), seat(1, false), seat(2, false), seat(3, false)],
     phase: PochPhase.POCHEN,
+    validPlays: [],
     currentPlayerIdx: 0,
     pools: POOLS.map((name, i) => ({ name, chips: i === 5 ? 12 : 4 })),
     paySuit: 1,
@@ -166,5 +167,34 @@ describe('PochPage', () => {
       renderWithProviders(<PochPage />);
       await waitFor(() => expect(screen.getAllByText(text).length).toBeGreaterThan(0));
     }
+  });
+
+  // **並びに従う義務がある。**出せない札を押せてしまうと、サーバに弾かれて
+  // 初めて分かる (#4933)。
+  describe('playable-card restriction', () => {
+    it('disables and dims the cards that cannot legally be played', async () => {
+      mockExec.mockResolvedValue(makeState({ phase: PochPhase.STOPS, validPlays: [0] }));
+      renderWithProviders(<PochPage />);
+      await waitFor(() => expect(mockExec).toHaveBeenCalled());
+
+      const buttons = screen.getAllByRole('button').filter((b) => b.hasAttribute('data-hint-action'));
+      expect(buttons.length).toBeGreaterThan(1);
+      expect(buttons[0]).not.toBeDisabled();
+      expect(buttons[0]).not.toHaveAttribute('data-unplayable');
+      expect(buttons[1]).toBeDisabled();
+      expect(buttons[1]).toHaveAttribute('data-unplayable', 'true');
+    });
+
+    // **空リストは「一枚も出せない」ではなく「情報が無い」。**空で全部塞ぐと
+    // 盤面が操作不能になる。
+    it('does not restrict anything when the server sent no list', async () => {
+      mockExec.mockResolvedValue(makeState({ phase: PochPhase.STOPS, validPlays: [] }));
+      renderWithProviders(<PochPage />);
+      await waitFor(() => expect(mockExec).toHaveBeenCalled());
+
+      for (const b of screen.getAllByRole('button').filter((x) => x.hasAttribute('data-hint-action'))) {
+        expect(b).not.toBeDisabled();
+      }
+    });
   });
 });

--- a/frontend/src/pages/PochPage.tsx
+++ b/frontend/src/pages/PochPage.tsx
@@ -225,24 +225,34 @@ function PochPageContent() {
                 {betting && ` · ${t('yourBet', { n: human?.bet ?? 0, target: state.betTarget })}`}
               </div>
               <div className="flex gap-1 justify-center flex-wrap">
-                {(human?.cards ?? []).map((card, i) => (
-                  <button
-                    key={`hand-${i.toString()}`}
-                    type="button"
-                    data-hint-action="play"
-                    aria-pressed={handIdx === i}
-                    aria-disabled={!isHumanTurn || !playing}
-                    onClick={() => isHumanTurn && playing && setHandIdx(handIdx === i ? null : i)}
-                    className={[
-                      'rounded transition-transform',
-                      isHumanTurn && playing ? 'hover:-translate-y-2' : 'opacity-60',
-                      handIdx === i ? 'ring-2 ring-ds-accent -translate-y-2' : '',
-                      frontendHintEnabled && state.hint?.cardIndex === i ? 'ring-2 ring-ds-warning' : '',
-                    ].join(' ')}
-                  >
-                    <AnimatedCard card={card} width={cardWidth} draggable={false} />
-                  </button>
-                ))}
+                {(human?.cards ?? []).map((card, i) => {
+                  // **並びに従う義務がある。**出せない札を押せてしまうと、
+                  // サーバに弾かれて初めて分かる (#4933)。空リストは「情報が
+                  // 無い」なので制限しない。
+                  const restricting = isHumanTurn && playing && (state.validPlays?.length ?? 0) > 0;
+                  const canPlay = !restricting || state.validPlays.includes(i);
+                  return (
+                    <button
+                      key={`hand-${i.toString()}`}
+                      type="button"
+                      data-hint-action="play"
+                      data-unplayable={restricting && !canPlay ? 'true' : undefined}
+                      aria-pressed={handIdx === i}
+                      disabled={restricting && !canPlay}
+                      aria-disabled={!isHumanTurn || !playing || !canPlay}
+                      onClick={() => isHumanTurn && playing && canPlay && setHandIdx(handIdx === i ? null : i)}
+                      className={[
+                        'rounded transition-transform',
+                        restricting && !canPlay ? 'opacity-40' : '',
+                        isHumanTurn && playing ? 'hover:-translate-y-2' : 'opacity-60',
+                        handIdx === i ? 'ring-2 ring-ds-accent -translate-y-2' : '',
+                        frontendHintEnabled && state.hint?.cardIndex === i ? 'ring-2 ring-ds-warning' : '',
+                      ].join(' ')}
+                    >
+                      <AnimatedCard card={card} width={cardWidth} draggable={false} />
+                    </button>
+                  );
+                })}
               </div>
               {isHumanTurn && playing && (
                 <div className="text-[10px] text-ds-text-muted mt-1">

--- a/frontend/src/pages/PopeJoanPage.test.tsx
+++ b/frontend/src/pages/PopeJoanPage.test.tsx
@@ -36,6 +36,7 @@ function makeState(overrides?: Partial<PopeJoanResponse>): PopeJoanResponse {
   return {
     players: [seat(0, true), seat(1, false), seat(2, false), seat(3, false)],
     phase: PopeJoanPhase.PLAY,
+    validPlays: [],
     currentPlayerIdx: 0,
     compartments: COMPS.map((name, i) => ({ name, chips: DRESS[i] })),
     trumpSuit: 1,
@@ -151,5 +152,34 @@ describe('PopeJoanPage', () => {
       renderWithProviders(<PopeJoanPage />);
       await waitFor(() => expect(screen.getAllByText(text).length).toBeGreaterThan(0));
     }
+  });
+
+  // **並びに従う義務がある。**出せない札を押せてしまうと、サーバに弾かれて
+  // 初めて分かる (#4934)。
+  describe('playable-card restriction', () => {
+    it('disables and dims the cards that cannot legally be played', async () => {
+      mockExec.mockResolvedValue(makeState({ validPlays: [0] }));
+      renderWithProviders(<PopeJoanPage />);
+      await waitFor(() => expect(mockExec).toHaveBeenCalled());
+
+      const buttons = screen.getAllByRole('button').filter((b) => b.hasAttribute('data-hint-action'));
+      expect(buttons.length).toBeGreaterThan(1);
+      expect(buttons[0]).not.toBeDisabled();
+      expect(buttons[0]).not.toHaveAttribute('data-unplayable');
+      expect(buttons[1]).toBeDisabled();
+      expect(buttons[1]).toHaveAttribute('data-unplayable', 'true');
+    });
+
+    // **空リストは「一枚も出せない」ではなく「情報が無い」。**空で全部塞ぐと
+    // 盤面が操作不能になる。
+    it('does not restrict anything when the server sent no list', async () => {
+      mockExec.mockResolvedValue(makeState({ validPlays: [] }));
+      renderWithProviders(<PopeJoanPage />);
+      await waitFor(() => expect(mockExec).toHaveBeenCalled());
+
+      for (const b of screen.getAllByRole('button').filter((x) => x.hasAttribute('data-hint-action'))) {
+        expect(b).not.toBeDisabled();
+      }
+    });
   });
 });

--- a/frontend/src/pages/PopeJoanPage.tsx
+++ b/frontend/src/pages/PopeJoanPage.tsx
@@ -222,24 +222,34 @@ function PopeJoanPageContent() {
                 {human?.holdsPope && ` · ${t('holdsPope')}`}
               </div>
               <div className="flex gap-1 justify-center flex-wrap">
-                {(human?.cards ?? []).map((card, i) => (
-                  <button
-                    key={`hand-${i.toString()}`}
-                    type="button"
-                    data-hint-action="play"
-                    aria-pressed={handIdx === i}
-                    aria-disabled={!isHumanTurn}
-                    onClick={() => isHumanTurn && setHandIdx(handIdx === i ? null : i)}
-                    className={[
-                      'rounded transition-transform',
-                      isHumanTurn ? 'hover:-translate-y-2' : 'opacity-60',
-                      handIdx === i ? 'ring-2 ring-ds-accent -translate-y-2' : '',
-                      frontendHintEnabled && state.hint?.cardIndex === i ? 'ring-2 ring-ds-warning' : '',
-                    ].join(' ')}
-                  >
-                    <AnimatedCard card={card} width={cardWidth} draggable={false} />
-                  </button>
-                ))}
+                {(human?.cards ?? []).map((card, i) => {
+                  // **並びに従う義務がある。**出せない札を押せてしまうと、
+                  // サーバに弾かれて初めて分かる (#4934)。空リストは「情報が
+                  // 無い」なので制限しない。
+                  const restricting = isHumanTurn && (state.validPlays?.length ?? 0) > 0;
+                  const canPlay = !restricting || state.validPlays.includes(i);
+                  return (
+                    <button
+                      key={`hand-${i.toString()}`}
+                      type="button"
+                      data-hint-action="play"
+                      data-unplayable={restricting && !canPlay ? 'true' : undefined}
+                      aria-pressed={handIdx === i}
+                      disabled={restricting && !canPlay}
+                      aria-disabled={!isHumanTurn || !canPlay}
+                      onClick={() => isHumanTurn && canPlay && setHandIdx(handIdx === i ? null : i)}
+                      className={[
+                        'rounded transition-transform',
+                        restricting && !canPlay ? 'opacity-40' : '',
+                        isHumanTurn ? 'hover:-translate-y-2' : 'opacity-60',
+                        handIdx === i ? 'ring-2 ring-ds-accent -translate-y-2' : '',
+                        frontendHintEnabled && state.hint?.cardIndex === i ? 'ring-2 ring-ds-warning' : '',
+                      ].join(' ')}
+                    >
+                      <AnimatedCard card={card} width={cardWidth} draggable={false} />
+                    </button>
+                  );
+                })}
               </div>
               {isHumanTurn && (
                 <div className="text-[10px] text-ds-text-muted mt-1">

--- a/frontend/src/types/games/nainjaune.ts
+++ b/frontend/src/types/games/nainjaune.ts
@@ -55,6 +55,11 @@ export interface NainJauneResponse extends BaseGameResponse {
   players: NainJaunePlayer[];
   /** 0 = Play, 1 = DealEnd, 2 = GameEnd. */
   phase: number;
+  /**
+   * Hand indices the human may legally play, filled only on their turn.
+   * runRank の次のランクを続ける義務があるので、出す前に示さないと押して初めて弾かれる (#4935)。
+   */
+  validPlays: number[];
   currentPlayerIdx: number;
   /** All five, always. */
   boxes: NainJauneBox[];

--- a/frontend/src/types/games/poch.ts
+++ b/frontend/src/types/games/poch.ts
@@ -54,6 +54,11 @@ export interface PochResponse extends BaseGameResponse {
   players: PochPlayer[];
   /** 0 = Staking, 1 = Pochen, 2 = Stops, 3 = DealEnd, 4 = GameEnd. */
   phase: number;
+  /**
+   * Hand indices the human may legally play, filled only on their turn.
+   * stopsSuit に従う義務があるので、出す前に示さないと押して初めて弾かれる (#4933)。
+   */
+  validPlays: number[];
   currentPlayerIdx: number;
   /** All nine, always. */
   pools: PochPool[];

--- a/frontend/src/types/games/popejoan.ts
+++ b/frontend/src/types/games/popejoan.ts
@@ -55,6 +55,11 @@ export interface PopeJoanResponse extends BaseGameResponse {
   players: PopeJoanPlayer[];
   /** 0 = Play, 1 = DealEnd, 2 = GameEnd. */
   phase: number;
+  /**
+   * Hand indices the human may legally play, filled only on their turn.
+   * runSuit に従う義務があり、**自由リードでも自分の最も低い札に限られる**ので、出す前に示さないと押して初めて弾かれる (#4934)。
+   */
+  validPlays: number[];
   currentPlayerIdx: number;
   /** All eight, always. */
   compartments: PopeJoanCompartment[];

--- a/frontend/src/utils/cli/formatters/nainjauneFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/nainjauneFormatter.test.ts
@@ -29,6 +29,7 @@ function makeState(overrides?: Partial<NainJauneResponse>): NainJauneResponse {
   return {
     players: [seat(0, true), seat(1, false)],
     phase: 0,
+    validPlays: [],
     currentPlayerIdx: 0,
     boxes: BOXES,
     talonCount: 4,

--- a/frontend/src/utils/cli/formatters/pochFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/pochFormatter.test.ts
@@ -24,6 +24,7 @@ function makeState(overrides?: Partial<PochResponse>): PochResponse {
   return {
     players: [seat(0, true), seat(1, false)],
     phase: 1,
+    validPlays: [],
     currentPlayerIdx: 0,
     pools: POOLS.map((name, i) => ({ name, chips: i === 5 ? 12 : 4 })),
     paySuit: 1,

--- a/frontend/src/utils/cli/formatters/popejoanFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/popejoanFormatter.test.ts
@@ -24,6 +24,7 @@ function makeState(overrides?: Partial<PopeJoanResponse>): PopeJoanResponse {
   return {
     players: [seat(0, true), seat(1, false)],
     phase: 0,
+    validPlays: [],
     currentPlayerIdx: 0,
     compartments: COMPS.map((name, i) => ({ name, chips: DRESS[i] })),
     trumpSuit: 1,

--- a/frontend/src/utils/hints/nainjauneHint.test.ts
+++ b/frontend/src/utils/hints/nainjauneHint.test.ts
@@ -5,6 +5,7 @@ import { getNainJauneHint } from './nainjauneHint';
 const base = {
   players: [],
   phase: 0,
+  validPlays: [],
   currentPlayerIdx: 0,
   boxes: [],
   talonCount: 4,

--- a/frontend/src/utils/hints/pochHint.test.ts
+++ b/frontend/src/utils/hints/pochHint.test.ts
@@ -5,6 +5,7 @@ import { getPochHint } from './pochHint';
 const base = {
   players: [],
   phase: 1,
+  validPlays: [],
   currentPlayerIdx: 0,
   pools: [],
   paySuit: 1,

--- a/frontend/src/utils/hints/popejoanHint.test.ts
+++ b/frontend/src/utils/hints/popejoanHint.test.ts
@@ -5,6 +5,7 @@ import { getPopeJoanHint } from './popejoanHint';
 const base = {
   players: [],
   phase: 0,
+  validPlays: [],
   currentPlayerIdx: 0,
   compartments: [],
   trumpSuit: 1,

--- a/internal/adapter/controller/NainJauneWebController.go
+++ b/internal/adapter/controller/NainJauneWebController.go
@@ -63,10 +63,13 @@ type NainJauneWebOutputHint struct {
 
 // NainJauneWebOutput ル・ナン・ジョーヌWebアウトプット
 type NainJauneWebOutput struct {
-	Players          []*NainJauneWebOutputPlayer `json:"players"`
-	Phase            int                         `json:"phase"`
-	CurrentPlayerIdx int                         `json:"currentPlayerIdx"`
-	Boxes            []*NainJauneWebOutputBox    `json:"boxes"`
+	Players []*NainJauneWebOutputPlayer `json:"players"`
+	Phase   int                         `json:"phase"`
+	// ValidPlays は人間の手番でのみ埋まる、今出せる手札のインデックス。
+	// **並びに従う義務がある**ので、出す前に示さないと押して初めて弾かれる。
+	ValidPlays       []int                    `json:"validPlays"`
+	CurrentPlayerIdx int                      `json:"currentPlayerIdx"`
+	Boxes            []*NainJauneWebOutputBox `json:"boxes"`
 	// TalonCount は配り切らなかった残りの枚数。誰も使わない。
 	TalonCount int                        `json:"talonCount"`
 	Awards     []*NainJauneWebOutputAward `json:"awards"`

--- a/internal/adapter/controller/PochWebController.go
+++ b/internal/adapter/controller/PochWebController.go
@@ -64,10 +64,13 @@ type PochWebOutputHint struct {
 
 // PochWebOutput ポッホWebアウトプット
 type PochWebOutput struct {
-	Players          []*PochWebOutputPlayer `json:"players"`
-	Phase            int                    `json:"phase"`
-	CurrentPlayerIdx int                    `json:"currentPlayerIdx"`
-	Pools            []*PochWebOutputPool   `json:"pools"`
+	Players []*PochWebOutputPlayer `json:"players"`
+	Phase   int                    `json:"phase"`
+	// ValidPlays は人間の手番でのみ埋まる、今出せる手札のインデックス。
+	// **並びに従う義務がある**ので、出す前に示さないと押して初めて弾かれる。
+	ValidPlays       []int                `json:"validPlays"`
+	CurrentPlayerIdx int                  `json:"currentPlayerIdx"`
+	Pools            []*PochWebOutputPool `json:"pools"`
 	// PaySuit は表向きの余り札のスート。第 1 段階はこれだけで決まる。
 	PaySuit int `json:"paySuit"`
 	// TurnUp は表向きにした余り札そのもの。

--- a/internal/adapter/controller/PopeJoanWebController.go
+++ b/internal/adapter/controller/PopeJoanWebController.go
@@ -62,8 +62,11 @@ type PopeJoanWebOutputHint struct {
 
 // PopeJoanWebOutput ポープ・ジョーンWebアウトプット
 type PopeJoanWebOutput struct {
-	Players          []*PopeJoanWebOutputPlayer      `json:"players"`
-	Phase            int                             `json:"phase"`
+	Players []*PopeJoanWebOutputPlayer `json:"players"`
+	Phase   int                        `json:"phase"`
+	// ValidPlays は人間の手番でのみ埋まる、今出せる手札のインデックス。
+	// **並びに従う義務がある**ので、出す前に示さないと押して初めて弾かれる。
+	ValidPlays       []int                           `json:"validPlays"`
 	CurrentPlayerIdx int                             `json:"currentPlayerIdx"`
 	Compartments     []*PopeJoanWebOutputCompartment `json:"compartments"`
 	// TrumpSuit は dead hand の最後の 1 枚で決まる。区画はこのスートでしか払わない。

--- a/internal/adapter/presenter/NainJaunePresenter_test.go
+++ b/internal/adapter/presenter/NainJaunePresenter_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
@@ -44,6 +45,7 @@ func njAntedBoard() domain.NainJauneBoard {
 func njStub(phase domain.NainJaunePhase, gameEnd bool, winner int, awards []*domain.NainJauneAward) *interfaces.MockNainJauneGame {
 	g := new(interfaces.MockNainJauneGame)
 	g.On("GetPhase").Return(phase)
+	g.On("NainJauneValidPlays", mock.Anything).Return([]int{}).Maybe()
 	g.On("GetGameEndFlag").Return(gameEnd)
 	g.On("GetWinnerIdx").Return(winner)
 	g.On("GetCurrentPlayerIdx").Return(0)
@@ -291,4 +293,28 @@ func TestNainJauneCuiPresenter_HintReasonKeysAreAllMapped(t *testing.T) {
 
 func TestNainJauneCuiPresenter_ActionLog(t *testing.T) {
 	assert.NotEmpty(t, new(NainJauneCuiPresenter).ActionLogOutput(njTestGame(t)))
+}
+
+// **出せる札を応答に載せる。**フロントは押して弾かれるまで違反を示せない (#4935)。
+func TestNainJauneWebPresenter_ValidPlays(t *testing.T) {
+	decode := func(raw string) controller.NainJauneWebOutput {
+		var parsed controller.NainJauneWebOutput
+		if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		return parsed
+	}
+
+	g := domain.NewDefaultNainJaune()
+	g.Reset()
+	raw := new(NainJauneWebPresenter).Output(g, nil)
+	got := decode(raw).ValidPlays
+	// **null ではなく空配列。**フロントが `?? []` を忘れても壊れない。
+	if got == nil {
+		t.Fatal("validPlays must be [] rather than null")
+	}
+	// 応答に必ず現れる。
+	if !strings.Contains(raw, `"validPlays"`) {
+		t.Fatalf("validPlays missing from the response: %s", raw)
+	}
 }

--- a/internal/adapter/presenter/NainJaunePresenter_test.go
+++ b/internal/adapter/presenter/NainJaunePresenter_test.go
@@ -317,4 +317,15 @@ func TestNainJauneWebPresenter_ValidPlays(t *testing.T) {
 	if !strings.Contains(raw, `"validPlays"`) {
 		t.Fatalf("validPlays missing from the response: %s", raw)
 	}
+
+	// **人間の手番でなければ空。**ドメインは nil を返すので、presenter 側で
+	// 空スライスに寄せている。ここを通さないと null が漏れる。
+	g.SetCurrentPlayerForTest(1)
+	off := decode(new(NainJauneWebPresenter).Output(g, nil)).ValidPlays
+	if off == nil {
+		t.Fatal("off-turn validPlays must be [] rather than null")
+	}
+	if len(off) != 0 {
+		t.Fatalf("off-turn validPlays must be empty, got %v", off)
+	}
 }

--- a/internal/adapter/presenter/NainJauneWebPresenter.go
+++ b/internal/adapter/presenter/NainJauneWebPresenter.go
@@ -50,6 +50,11 @@ func (p *NainJauneWebPresenter) Output(c interfaces.NainJauneGame, lastErr error
 func (p *NainJauneWebPresenter) buildBase(c interfaces.NainJauneGame) *controller.NainJauneWebOutput {
 	resObj := new(controller.NainJauneWebOutput)
 	resObj.Phase = int(c.GetPhase())
+	// 人間の手番でないときは null ではなく空スライス。
+	resObj.ValidPlays = c.NainJauneValidPlays(0)
+	if resObj.ValidPlays == nil {
+		resObj.ValidPlays = make([]int, 0)
+	}
 	resObj.CurrentPlayerIdx = c.GetCurrentPlayerIdx()
 	resObj.TalonCount = c.GetTalonCount()
 	resObj.RunRank = c.GetRunRank()

--- a/internal/adapter/presenter/PochPresenter_test.go
+++ b/internal/adapter/presenter/PochPresenter_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
@@ -44,6 +45,7 @@ func pcBoardWith(n int) domain.PochBoard {
 func pcStub(phase domain.PochPhase, gameEnd bool, winner int, awards []*domain.PochStakingAward) *interfaces.MockPochGame {
 	g := new(interfaces.MockPochGame)
 	g.On("GetPhase").Return(phase)
+	g.On("PochValidPlays", mock.Anything).Return([]int{}).Maybe()
 	g.On("GetGameEndFlag").Return(gameEnd)
 	g.On("GetWinnerIdx").Return(winner)
 	g.On("GetCurrentPlayerIdx").Return(0)
@@ -300,4 +302,28 @@ func TestPochCuiPresenter_HintReasonKeysAreAllMapped(t *testing.T) {
 
 func TestPochCuiPresenter_ActionLog(t *testing.T) {
 	assert.NotEmpty(t, new(PochCuiPresenter).ActionLogOutput(pcTestGame(t)))
+}
+
+// **出せる札を応答に載せる。**フロントは押して弾かれるまで違反を示せない (#4933)。
+func TestPochWebPresenter_ValidPlays(t *testing.T) {
+	decode := func(raw string) controller.PochWebOutput {
+		var parsed controller.PochWebOutput
+		if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		return parsed
+	}
+
+	g := domain.NewDefaultPoch()
+	g.Reset()
+	raw := new(PochWebPresenter).Output(g, nil)
+	got := decode(raw).ValidPlays
+	// **null ではなく空配列。**フロントが `?? []` を忘れても壊れない。
+	if got == nil {
+		t.Fatal("validPlays must be [] rather than null")
+	}
+	// 応答に必ず現れる。
+	if !strings.Contains(raw, `"validPlays"`) {
+		t.Fatalf("validPlays missing from the response: %s", raw)
+	}
 }

--- a/internal/adapter/presenter/PochPresenter_test.go
+++ b/internal/adapter/presenter/PochPresenter_test.go
@@ -326,4 +326,15 @@ func TestPochWebPresenter_ValidPlays(t *testing.T) {
 	if !strings.Contains(raw, `"validPlays"`) {
 		t.Fatalf("validPlays missing from the response: %s", raw)
 	}
+
+	// **人間の手番でなければ空。**ドメインは nil を返すので、presenter 側で
+	// 空スライスに寄せている。ここを通さないと null が漏れる。
+	g.SetCurrentPlayerForTest(1)
+	off := decode(new(PochWebPresenter).Output(g, nil)).ValidPlays
+	if off == nil {
+		t.Fatal("off-turn validPlays must be [] rather than null")
+	}
+	if len(off) != 0 {
+		t.Fatalf("off-turn validPlays must be empty, got %v", off)
+	}
 }

--- a/internal/adapter/presenter/PochWebPresenter.go
+++ b/internal/adapter/presenter/PochWebPresenter.go
@@ -33,6 +33,11 @@ func (p *PochWebPresenter) Output(c interfaces.PochGame, lastErr error) string {
 func (p *PochWebPresenter) buildBase(c interfaces.PochGame) *controller.PochWebOutput {
 	resObj := new(controller.PochWebOutput)
 	resObj.Phase = int(c.GetPhase())
+	// 人間の手番でないときは null ではなく空スライス。
+	resObj.ValidPlays = c.PochValidPlays(0)
+	if resObj.ValidPlays == nil {
+		resObj.ValidPlays = make([]int, 0)
+	}
 	resObj.CurrentPlayerIdx = c.GetCurrentPlayerIdx()
 	resObj.PaySuit = c.GetPaySuit()
 	resObj.BetTarget = c.GetBetTarget()

--- a/internal/adapter/presenter/PopeJoanPresenter_test.go
+++ b/internal/adapter/presenter/PopeJoanPresenter_test.go
@@ -315,4 +315,15 @@ func TestPopeJoanWebPresenter_ValidPlays(t *testing.T) {
 	if !strings.Contains(raw, `"validPlays"`) {
 		t.Fatalf("validPlays missing from the response: %s", raw)
 	}
+
+	// **人間の手番でなければ空。**ドメインは nil を返すので、presenter 側で
+	// 空スライスに寄せている。ここを通さないと null が漏れる。
+	g.SetCurrentPlayerForTest(1)
+	off := decode(new(PopeJoanWebPresenter).Output(g, nil)).ValidPlays
+	if off == nil {
+		t.Fatal("off-turn validPlays must be [] rather than null")
+	}
+	if len(off) != 0 {
+		t.Fatalf("off-turn validPlays must be empty, got %v", off)
+	}
 }

--- a/internal/adapter/presenter/PopeJoanPresenter_test.go
+++ b/internal/adapter/presenter/PopeJoanPresenter_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
@@ -44,6 +45,7 @@ func pjDressedBoard() domain.PopeJoanBoard {
 func pjStub(phase domain.PopeJoanPhase, gameEnd bool, winner int, awards []*domain.PopeJoanAward) *interfaces.MockPopeJoanGame {
 	g := new(interfaces.MockPopeJoanGame)
 	g.On("GetPhase").Return(phase)
+	g.On("PopeJoanValidPlays", mock.Anything).Return([]int{}).Maybe()
 	g.On("GetGameEndFlag").Return(gameEnd)
 	g.On("GetWinnerIdx").Return(winner)
 	g.On("GetCurrentPlayerIdx").Return(0)
@@ -289,4 +291,28 @@ func TestPopeJoanCuiPresenter_HintReasonKeysAreAllMapped(t *testing.T) {
 
 func TestPopeJoanCuiPresenter_ActionLog(t *testing.T) {
 	assert.NotEmpty(t, new(PopeJoanCuiPresenter).ActionLogOutput(pjTestGame(t)))
+}
+
+// **出せる札を応答に載せる。**フロントは押して弾かれるまで違反を示せない (#4934)。
+func TestPopeJoanWebPresenter_ValidPlays(t *testing.T) {
+	decode := func(raw string) controller.PopeJoanWebOutput {
+		var parsed controller.PopeJoanWebOutput
+		if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		return parsed
+	}
+
+	g := domain.NewDefaultPopeJoan()
+	g.Reset()
+	raw := new(PopeJoanWebPresenter).Output(g, nil)
+	got := decode(raw).ValidPlays
+	// **null ではなく空配列。**フロントが `?? []` を忘れても壊れない。
+	if got == nil {
+		t.Fatal("validPlays must be [] rather than null")
+	}
+	// 応答に必ず現れる。
+	if !strings.Contains(raw, `"validPlays"`) {
+		t.Fatalf("validPlays missing from the response: %s", raw)
+	}
 }

--- a/internal/adapter/presenter/PopeJoanWebPresenter.go
+++ b/internal/adapter/presenter/PopeJoanWebPresenter.go
@@ -33,6 +33,11 @@ func (p *PopeJoanWebPresenter) Output(c interfaces.PopeJoanGame, lastErr error) 
 func (p *PopeJoanWebPresenter) buildBase(c interfaces.PopeJoanGame) *controller.PopeJoanWebOutput {
 	resObj := new(controller.PopeJoanWebOutput)
 	resObj.Phase = int(c.GetPhase())
+	// 人間の手番でないときは null ではなく空スライス。
+	resObj.ValidPlays = c.PopeJoanValidPlays(0)
+	if resObj.ValidPlays == nil {
+		resObj.ValidPlays = make([]int, 0)
+	}
 	resObj.CurrentPlayerIdx = c.GetCurrentPlayerIdx()
 	resObj.TrumpSuit = c.GetTrumpSuit()
 	resObj.RunSuit = c.GetRunSuit()

--- a/internal/domain/NainJaune.go
+++ b/internal/domain/NainJaune.go
@@ -239,6 +239,27 @@ func (n *NainJaune) playable(card *Card) bool {
 	return card.GetValue() == n.runRank+1
 }
 
+// NainJauneValidPlays は player が今出せる手札インデックスを返す。
+//
+// **判定は playable をそのまま呼ぶ。**規則を書き写すと、示した手が拒否される
+// ようになる (#4935)。手番でない場合は nil。
+func (n *NainJaune) NainJauneValidPlays(player int) []int {
+	if player != n.currentIdx {
+		return nil
+	}
+	pl := n.GetPlayer(player)
+	if pl == nil {
+		return nil
+	}
+	out := make([]int, 0, pl.GetCardsSize())
+	for i := range pl.GetCardsSize() {
+		if n.playable(pl.GetCard(i)) {
+			out = append(out, i)
+		}
+	}
+	return out
+}
+
 // payForCard は出した札が区画を取るかを判定する。
 func (n *NainJaune) payForCard(player int, card *Card) {
 	box, ok := NainJauneBoxForCard(card)

--- a/internal/domain/NainJaune_test.go
+++ b/internal/domain/NainJaune_test.go
@@ -573,3 +573,39 @@ func TestNainJauneUnmarshalKeepsALiveRun(t *testing.T) {
 		t.Errorf("runRank = %d, want 8 preserved", got)
 	}
 }
+
+// **並びに従う義務がある。**出せる札を先に示さないと、押して初めて弾かれる (#4935)。
+func TestNainJaune_NainJauneValidPlays(t *testing.T) {
+	g := NewDefaultNainJaune()
+	g.Reset()
+	g.SetCurrentPlayerForTest(0)
+
+	p := g.GetPlayer(0)
+	p.Reset()
+	p.AddCard(njCard(CardDesignSpade, 5))
+	p.AddCard(njCard(CardDesignHeart, 9))
+	p.AddCard(njCard(CardDesignClover, 5))
+
+	// runRank 0 なら並びが止まっていて自由リード。
+	g.SetRunRankForTest(0)
+	if got := g.NainJauneValidPlays(0); len(got) != 3 {
+		t.Fatalf("a stopped run should allow every card, got %v", got)
+	}
+
+	// **スートは問わない。**次のランクでありさえすればよい。
+	g.SetRunRankForTest(4)
+	if got := g.NainJauneValidPlays(0); len(got) != 2 || got[0] != 0 || got[1] != 2 {
+		t.Fatalf("both fives should be playable regardless of suit, got %v", got)
+	}
+
+	// 続けられる札が無ければ空。
+	g.SetRunRankForTest(11)
+	if got := g.NainJauneValidPlays(0); len(got) != 0 {
+		t.Fatalf("nothing should be playable, got %v", got)
+	}
+
+	// 手番でなければ nil。
+	if got := g.NainJauneValidPlays(1); got != nil {
+		t.Fatalf("off-turn must be nil, got %v", got)
+	}
+}

--- a/internal/domain/Poch.go
+++ b/internal/domain/Poch.go
@@ -485,6 +485,27 @@ func (p *Poch) playable(card *Card) bool {
 	return card.GetDesign() == p.stopsSuit && pochRankOrder(card.GetValue()) == p.stopsRank+1
 }
 
+// PochValidPlays は player が今出せる手札インデックスを返す。
+//
+// **判定は playable をそのまま呼ぶ。**規則を書き写すと、示した手が拒否される
+// ようになる (#4933)。ストップス以外・手番でない場合は nil。
+func (p *Poch) PochValidPlays(player int) []int {
+	if p.phase != PochPhaseStops || player != p.currentIdx {
+		return nil
+	}
+	pl := p.GetPlayer(player)
+	if pl == nil {
+		return nil
+	}
+	out := make([]int, 0, pl.GetCardsSize())
+	for i := range pl.GetCardsSize() {
+		if p.playable(pl.GetCard(i)) {
+			out = append(out, i)
+		}
+	}
+	return out
+}
+
 // advanceStops は次に出せる人へ手番を回す。誰も次を持っていなければ stop で、
 // **最後に最高札を出した人**が好きな札から再開する。
 func (p *Poch) advanceStops(lastPlayer int) {

--- a/internal/domain/Poch_test.go
+++ b/internal/domain/Poch_test.go
@@ -775,3 +775,44 @@ func TestPochUnmarshalKeepsAStoppedRun(t *testing.T) {
 		t.Errorf("stopsRank = %d, want 8", got)
 	}
 }
+
+// **並びに従う義務がある。**出せる札を先に示さないと、押して初めて弾かれる (#4933)。
+func TestPoch_PochValidPlays(t *testing.T) {
+	g := NewDefaultPoch()
+	g.Reset()
+	g.SetPhaseForTest(PochPhaseStops)
+	g.SetCurrentPlayerForTest(0)
+
+	p := g.GetPlayer(0)
+	p.Reset()
+	p.AddCard(NewCard(CardDesignSpade, 9, false))
+	p.AddCard(NewCard(CardDesignHeart, 9, false))
+	p.AddCard(NewCard(CardDesignSpade, 10, false))
+
+	// 自由リード (stopsSuit < 0) では全部出せる。
+	g.SetStopsForTest(-1, 0)
+	if got := g.PochValidPlays(0); len(got) != 3 {
+		t.Fatalf("free lead should allow every card, got %v", got)
+	}
+
+	// ♠8 の次は ♠9 だけ。同ランクの ♥9 も ♠10 も続けられない。
+	g.SetStopsForTest(CardDesignSpade, pochRankOrder(8))
+	if got := g.PochValidPlays(0); len(got) != 1 || got[0] != 0 {
+		t.Fatalf("only the next higher card of the run suit is legal, got %v", got)
+	}
+
+	// 続けられる札が 1 枚も無ければ空。
+	g.SetStopsForTest(CardDesignSpade, pochRankOrder(2))
+	if got := g.PochValidPlays(0); len(got) != 0 {
+		t.Fatalf("nothing should be playable, got %v", got)
+	}
+
+	// 手番でない/フェーズ違いは nil。
+	if got := g.PochValidPlays(1); got != nil {
+		t.Fatalf("off-turn must be nil, got %v", got)
+	}
+	g.SetPhaseForTest(PochPhasePochen)
+	if got := g.PochValidPlays(0); got != nil {
+		t.Fatalf("outside the stops phase must be nil, got %v", got)
+	}
+}

--- a/internal/domain/PopeJoan.go
+++ b/internal/domain/PopeJoan.go
@@ -306,6 +306,28 @@ func (p *PopeJoan) Play(player, handIdx int) error {
 	return nil
 }
 
+// PopeJoanValidPlays は player が今出せる手札インデックスを返す。
+//
+// **判定は checkPlayable をそのまま呼ぶ。**規則を書き写すと、示した手が拒否
+// されるようになる (#4934)。**自由リードでも全部が出せるわけではない** —
+// 新しい並びは自分の最も低い札で始めなければならない。手番でない場合は nil。
+func (p *PopeJoan) PopeJoanValidPlays(player int) []int {
+	if player != p.currentIdx {
+		return nil
+	}
+	pl := p.GetPlayer(player)
+	if pl == nil {
+		return nil
+	}
+	out := make([]int, 0, pl.GetCardsSize())
+	for i := range pl.GetCardsSize() {
+		if p.checkPlayable(player, pl.GetCard(i)) == nil {
+			out = append(out, i)
+		}
+	}
+	return out
+}
+
 // checkPlayable は card が今出せるかを確かめる。
 func (p *PopeJoan) checkPlayable(player int, card *Card) error {
 	if card == nil {

--- a/internal/domain/PopeJoan_test.go
+++ b/internal/domain/PopeJoan_test.go
@@ -801,3 +801,41 @@ func TestPopeJoanIntrigueNeedsBothFromOneHand(t *testing.T) {
 		t.Errorf("intrigue = %d, want it left standing when J and Q come from different hands", got)
 	}
 }
+
+// **並びに従う義務がある。**さらに自由リードでも「自分の最も低い札」に限られる
+// ので、全部出せるわけではない (#4934)。
+func TestPopeJoan_PopeJoanValidPlays(t *testing.T) {
+	g := NewDefaultPopeJoan()
+	g.Reset()
+	g.SetCurrentPlayerForTest(0)
+
+	p := g.GetPlayer(0)
+	p.Reset()
+	p.AddCard(pjCard(CardDesignSpade, 5))
+	p.AddCard(pjCard(CardDesignHeart, 9))
+	p.AddCard(pjCard(CardDesignSpade, 6))
+
+	// **自由リードでも最も低い札だけ。**issue は「全部選択可能」と書いているが、
+	// ドメインは新しい並びを最低札で始めることを要求する。
+	g.SetRunForTest(-1, 0)
+	if got := g.PopeJoanValidPlays(0); len(got) != 1 || got[0] != 0 {
+		t.Fatalf("a new run must be led with the lowest card, got %v", got)
+	}
+
+	// ♠5 の次は ♠6 だけ。♥9 はスート違い。
+	g.SetRunForTest(CardDesignSpade, popeJoanRankOrder(5))
+	if got := g.PopeJoanValidPlays(0); len(got) != 1 || got[0] != 2 {
+		t.Fatalf("only the next higher card of the run suit is legal, got %v", got)
+	}
+
+	// 続けられる札が無ければ空。
+	g.SetRunForTest(CardDesignClover, popeJoanRankOrder(2))
+	if got := g.PopeJoanValidPlays(0); len(got) != 0 {
+		t.Fatalf("nothing should be playable, got %v", got)
+	}
+
+	// 手番でなければ nil。
+	if got := g.PopeJoanValidPlays(1); got != nil {
+		t.Fatalf("off-turn must be nil, got %v", got)
+	}
+}

--- a/internal/domain/interfaces/nainjaune.go
+++ b/internal/domain/interfaces/nainjaune.go
@@ -25,6 +25,8 @@ type NainJauneGame interface {
 	GetGameEndFlag() bool
 	// GetPhase 現在のフェーズを取得する
 	GetPhase() domain.NainJaunePhase
+	// NainJauneValidPlays は今出せる手札インデックスを返す
+	NainJauneValidPlays(player int) []int
 	// GetCurrentPlayerIdx 手番のプレイヤー添字を取得する
 	GetCurrentPlayerIdx() int
 	// GetBoard 5区画の残高を取得する

--- a/internal/domain/interfaces/nainjaune_mock.go
+++ b/internal/domain/interfaces/nainjaune_mock.go
@@ -85,3 +85,12 @@ func (_m *MockNainJauneGame) GetActionLog() []*domain.ActionLogEntry {
 	}
 	return nil
 }
+
+// NainJauneValidPlays モック
+func (_m *MockNainJauneGame) NainJauneValidPlays(player int) []int {
+	ret := _m.Called(player)
+	if v, ok := ret.Get(0).([]int); ok {
+		return v
+	}
+	return nil
+}

--- a/internal/domain/interfaces/poch.go
+++ b/internal/domain/interfaces/poch.go
@@ -29,6 +29,8 @@ type PochGame interface {
 	GetGameEndFlag() bool
 	// GetPhase 現在のフェーズを取得する
 	GetPhase() domain.PochPhase
+	// PochValidPlays は今出せる手札インデックスを返す
+	PochValidPlays(player int) []int
 	// GetCurrentPlayerIdx 手番のプレイヤー添字を取得する
 	GetCurrentPlayerIdx() int
 	// GetBoard 9プールの残高を取得する

--- a/internal/domain/interfaces/poch_mock.go
+++ b/internal/domain/interfaces/poch_mock.go
@@ -106,3 +106,12 @@ func (_m *MockPochGame) GetActionLog() []*domain.ActionLogEntry {
 	}
 	return nil
 }
+
+// PochValidPlays モック
+func (_m *MockPochGame) PochValidPlays(player int) []int {
+	ret := _m.Called(player)
+	if v, ok := ret.Get(0).([]int); ok {
+		return v
+	}
+	return nil
+}

--- a/internal/domain/interfaces/popejoan.go
+++ b/internal/domain/interfaces/popejoan.go
@@ -25,6 +25,8 @@ type PopeJoanGame interface {
 	GetGameEndFlag() bool
 	// GetPhase 現在のフェーズを取得する
 	GetPhase() domain.PopeJoanPhase
+	// PopeJoanValidPlays は今出せる手札インデックスを返す
+	PopeJoanValidPlays(player int) []int
 	// GetCurrentPlayerIdx 手番のプレイヤー添字を取得する
 	GetCurrentPlayerIdx() int
 	// GetBoard 8区画の残高を取得する

--- a/internal/domain/interfaces/popejoan_mock.go
+++ b/internal/domain/interfaces/popejoan_mock.go
@@ -94,3 +94,12 @@ func (_m *MockPopeJoanGame) GetActionLog() []*domain.ActionLogEntry {
 	}
 	return nil
 }
+
+// PopeJoanValidPlays モック
+func (_m *MockPopeJoanGame) PopeJoanValidPlays(player int) []int {
+	ret := _m.Called(player)
+	if v, ok := ret.Get(0).([]int); ok {
+		return v
+	}
+	return nil
+}


### PR DESCRIPTION
Closes #4933
Closes #4934
Closes #4935

同型の 3 件をまとめた。いずれも手札ボタンが `isHumanTurn` でしか活性を切り替えておらず、**並びに従っているかを判定していない**。ドメイン側は弾いているので、押して初めて分かる。

| ゲーム | 規則 |
|--------|------|
| ポッホ | `stopsSuit` に従い、同スートの次のランクを続ける |
| ポープ・ジョーン | `runSuit` に従い、同スートの次のランクを続ける |
| ル・ナン・ジョーヌ | `runRank` の**次のランク**を続ける（スートは問わない） |

## 変更

各ドメインに `ValidPlays(player) []int` を足した。**判定は既存の `playable` / `checkPlayable` をそのまま呼ぶ** — 規則を書き写すと、示した手が拒否されるようになる。Web 応答に `validPlays` として載せ（人間の手番でなければ `null` ではなく `[]`）、3 ページとも出せない札を `opacity-40` + `disabled` にする。

**空リストは「一枚も出せない」ではなく「情報が無い」**として扱う。空で全部塞ぐと盤面が操作不能になる。3 ページとも専用のテストを置いた。

## issue の前提の訂正（ポープ・ジョーン）

issue #4934 の受け入れ条件は「自由リード（`runSuit < 0`）では全ての手札が選択可能なままである」と書いているが、**ドメインはそうなっていない**:

```go
if p.runSuit < 0 {
    // **スートは自由。条件は「自分の最も低い札」であること。**
    if !p.isLowestInHand(player, card) {
        return fmt.Errorf("a new run must be led with your lowest card")
    }
```

自由リードでも出せるのは最低札 1 枚だけ。`checkPlayable` をそのまま呼ぶ実装なのでこの規則も正しく反映され、ドメインテストでも明示的に固定してある。issue の記述に合わせて「全部出せる」ようにすると、**画面の案内とサーバの判定が食い違う**ことになるので採らなかった。

## テスト

- **ドメイン 3 件** — 自由リード / 追随 / 出せる札ゼロ / 手番外・フェーズ外は nil。ル・ナン・ジョーヌは**スートを問わない**こと、ポープ・ジョーンは**自由リードでも最低札だけ**であることを個別に固定
- **Web presenter 3 件** — `validPlays` が応答に必ず現れ、`null` ではなく `[]` であること
- **ページ 3 件 × 2** — 出せない札が薄く・押せない / 空リストなら制限しない

ネガティブコントロール: 3 ページの `canPlay` を `true` に固定すると 3 テストが落ちる。

`go test -tags test ./...` / `golangci-lint run ./internal/...` (0 issues) / `bun run check` / `bun run typecheck` / vitest green。

## Test plan

- [ ] CI green