### PR TITLE
feat(primero,bouillotte): show the raise count against the per-round cap

### DIFF
--- a/frontend/src/i18n/locales/en/bouillotte.json
+++ b/frontend/src/i18n/locales/en/bouillotte.json
@@ -66,5 +66,6 @@
   "hintRequested": "Hint available",
   "noHint": "No hint available",
   "raiseCount": "Raises {{count}}/{{max}}",
-  "raiseCapReached": "Raise cap reached ({{max}})"
+  "raiseCapReached": "Raise cap reached ({{max}})",
+  "raiseNoChips": "Not enough chips to raise ({{cost}} needed)"
 }

--- a/frontend/src/i18n/locales/en/bouillotte.json
+++ b/frontend/src/i18n/locales/en/bouillotte.json
@@ -64,5 +64,7 @@
     "resetButton": "Reset the game and start over."
   },
   "hintRequested": "Hint available",
-  "noHint": "No hint available"
+  "noHint": "No hint available",
+  "raiseCount": "Raises {{count}}/{{max}}",
+  "raiseCapReached": "Raise cap reached ({{max}})"
 }

--- a/frontend/src/i18n/locales/en/primero.json
+++ b/frontend/src/i18n/locales/en/primero.json
@@ -70,5 +70,6 @@
   "hintRequested": "Hint available",
   "noHint": "No hint available",
   "raiseCount": "Raises {{count}}/{{max}}",
-  "raiseCapReached": "Raise cap reached ({{max}})"
+  "raiseCapReached": "Raise cap reached ({{max}})",
+  "raiseNoChips": "Not enough chips to raise ({{cost}} needed)"
 }

--- a/frontend/src/i18n/locales/en/primero.json
+++ b/frontend/src/i18n/locales/en/primero.json
@@ -68,5 +68,7 @@
     "resetButton": "Reset the game and start over."
   },
   "hintRequested": "Hint available",
-  "noHint": "No hint available"
+  "noHint": "No hint available",
+  "raiseCount": "Raises {{count}}/{{max}}",
+  "raiseCapReached": "Raise cap reached ({{max}})"
 }

--- a/frontend/src/i18n/locales/ja/bouillotte.json
+++ b/frontend/src/i18n/locales/ja/bouillotte.json
@@ -64,5 +64,7 @@
     "resetButton": "ゲームをリセットして最初からやり直します。"
   },
   "hintRequested": "ヒントがあります",
-  "noHint": "ヒントはありません"
+  "noHint": "ヒントはありません",
+  "raiseCount": "レイズ {{count}}/{{max}}回",
+  "raiseCapReached": "レイズ上限（{{max}}回）に達しました"
 }

--- a/frontend/src/i18n/locales/ja/bouillotte.json
+++ b/frontend/src/i18n/locales/ja/bouillotte.json
@@ -66,5 +66,6 @@
   "hintRequested": "ヒントがあります",
   "noHint": "ヒントはありません",
   "raiseCount": "レイズ {{count}}/{{max}}回",
-  "raiseCapReached": "レイズ上限（{{max}}回）に達しました"
+  "raiseCapReached": "レイズ上限（{{max}}回）に達しました",
+  "raiseNoChips": "チップが足りません（レイズに {{cost}} 必要）"
 }

--- a/frontend/src/i18n/locales/ja/primero.json
+++ b/frontend/src/i18n/locales/ja/primero.json
@@ -70,5 +70,6 @@
   "hintRequested": "ヒントがあります",
   "noHint": "ヒントはありません",
   "raiseCount": "レイズ {{count}}/{{max}}回",
-  "raiseCapReached": "レイズ上限（{{max}}回）に達しました"
+  "raiseCapReached": "レイズ上限（{{max}}回）に達しました",
+  "raiseNoChips": "チップが足りません（レイズに {{cost}} 必要）"
 }

--- a/frontend/src/i18n/locales/ja/primero.json
+++ b/frontend/src/i18n/locales/ja/primero.json
@@ -68,5 +68,7 @@
     "resetButton": "ゲームをリセットして最初からやり直します。"
   },
   "hintRequested": "ヒントがあります",
-  "noHint": "ヒントはありません"
+  "noHint": "ヒントはありません",
+  "raiseCount": "レイズ {{count}}/{{max}}回",
+  "raiseCapReached": "レイズ上限（{{max}}回）に達しました"
 }

--- a/frontend/src/pages/BouillottePage.test.tsx
+++ b/frontend/src/pages/BouillottePage.test.tsx
@@ -266,4 +266,29 @@ describe('BouillottePage', () => {
     expect(screen.getByTestId('retourne-card').className).not.toContain('ring-ds-accent');
     expect(screen.queryByTestId('retourne-note')).not.toBeInTheDocument();
   });
+
+  // **レイズが消えた理由を書く。**回数上限とチップ不足を区別できないと、
+  // 突然選択肢を奪われたように見える (#4924)。
+  describe('raise cap readout', () => {
+    it('shows the current count against the cap while raising is still open', async () => {
+      mockExec.mockResolvedValue(
+        makeBouillotteState({ phase: 0, isHumanTurn: true, canRaise: true, raiseCount: 1, maxRaises: 3 }),
+      );
+      renderWithProviders(<BouillottePage />);
+      const readout = await screen.findByTestId('bouillotte-raise-count');
+      expect(readout).toHaveTextContent('レイズ 1/3回');
+      expect(readout).not.toHaveTextContent('上限');
+    });
+
+    it('says the cap was reached rather than silently dropping the button', async () => {
+      mockExec.mockResolvedValue(
+        makeBouillotteState({ phase: 0, isHumanTurn: true, canRaise: false, raiseCount: 3, maxRaises: 3 }),
+      );
+      renderWithProviders(<BouillottePage />);
+      const readout = await screen.findByTestId('bouillotte-raise-count');
+      expect(readout).toHaveTextContent('レイズ上限（3回）に達しました');
+      // ボタン自体は消えたままでよい。理由が読めることが要点。
+      expect(screen.queryByRole('button', { name: /レイズ/ })).not.toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/src/pages/BouillottePage.test.tsx
+++ b/frontend/src/pages/BouillottePage.test.tsx
@@ -280,6 +280,30 @@ describe('BouillottePage', () => {
       expect(readout).not.toHaveTextContent('上限');
     });
 
+    // **枚数不足も理由として区別する。**上限に達していないのに押せないとき、
+    // 「レイズ 1/3回」とだけ出すと「まだできる」と読めてしまう（レビュー指摘）。
+    it('says the chips are short when the cap is not the reason', async () => {
+      mockExec.mockResolvedValue(
+        makeBouillotteState({
+          phase: 0,
+          isHumanTurn: true,
+          canRaise: false,
+          raiseCount: 1,
+          maxRaises: 3,
+          currentBet: 10,
+          ante: 5,
+          players: [
+            { ...makeBouillotteState().players[0], isHuman: true, chips: 3, roundBet: 0 },
+            ...makeBouillotteState().players.slice(1),
+          ],
+        }),
+      );
+      renderWithProviders(<BouillottePage />);
+      const readout = await screen.findByTestId('bouillotte-raise-count');
+      expect(readout).toHaveTextContent('チップが足りません');
+      expect(readout).not.toHaveTextContent('レイズ 1/3回');
+    });
+
     it('says the cap was reached rather than silently dropping the button', async () => {
       mockExec.mockResolvedValue(
         makeBouillotteState({ phase: 0, isHumanTurn: true, canRaise: false, raiseCount: 3, maxRaises: 3 }),

--- a/frontend/src/pages/BouillottePage.tsx
+++ b/frontend/src/pages/BouillottePage.tsx
@@ -363,6 +363,13 @@ function BouillottePageContent() {
                   <button type="button" className={btnPrimary} onClick={handleCall} disabled={loading}>
                     {potOdds.isFree ? t('callButton') : t('callButtonAmount', { amount: potOdds.callAmount })}
                   </button>
+                  {/* **レイズが消えた理由を書く。**回数上限とチップ不足を
+                      区別できないと、突然選択肢を奪われたように見える (#4924)。 */}
+                  <span className="text-ds-text-muted text-xs" data-testid="bouillotte-raise-count">
+                    {state.raiseCount >= state.maxRaises
+                      ? t('raiseCapReached', { max: state.maxRaises })
+                      : t('raiseCount', { count: state.raiseCount, max: state.maxRaises })}
+                  </span>
                   {state.canRaise && (
                     <button type="button" className={btnSuccess} onClick={handleRaise} disabled={loading}>
                       {t('raiseButtonAmount', { amount: raiseCost })}

--- a/frontend/src/pages/BouillottePage.tsx
+++ b/frontend/src/pages/BouillottePage.tsx
@@ -37,6 +37,7 @@ import { analyzeRetourneMatch } from '../utils/bouillotteRetourne';
 import { BOUILLOTTE_HELP, parseBouillotteCommand } from '../utils/cli/commands/bouillotteCommands';
 import { formatBouillotteState } from '../utils/cli/formatters/bouillotteFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { raiseAvailability, raiseCost } from '../utils/raiseAvailability';
 import { hintCheckboxItem } from '../utils/settingsItems';
 
 /** Bouillotte tutorial step definitions. */
@@ -124,12 +125,23 @@ function BouillottePageContent() {
     return <GameSkeleton gameKey="bouillotte" layout={{ kind: 'trick-taking', trickArea: true, footerHandSize: 3 }} />;
 
   const humanPlayer = state.players.find((p) => p.isHuman);
+  // **レイズが消えた理由は 2 つある。**上限と枚数不足を区別しないと、
+  // 「レイズ 1/3回」がボタンの無い画面で「まだできる」と読めてしまう。
+  const raiseInput = {
+    raiseCount: state.raiseCount,
+    maxRaises: state.maxRaises,
+    chips: humanPlayer?.chips ?? 0,
+    currentBet: state.currentBet,
+    roundBet: humanPlayer?.roundBet ?? 0,
+    ante: state.ante,
+  };
+  const raiseBlock = raiseAvailability(raiseInput);
+  const raiseNeeded = raiseCost(raiseInput);
   const humanIdx = state.players.findIndex((p) => p.isHuman);
 
   // Pot odds and chip costs facing the human at the Call/Raise/Fold decision.
   const humanRoundBet = humanPlayer?.roundBet ?? 0;
   const potOdds = computeBouillottePotOdds(state.pot, state.currentBet, humanRoundBet);
-  const raiseCost = Math.max(0, state.currentBet + state.ante - humanRoundBet);
 
   // Which of the human's cards share the retourne's rank, and any combo it completes.
   const retourneMatch = analyzeRetourneMatch(humanPlayer?.cards ?? [], state.retourne);
@@ -366,13 +378,15 @@ function BouillottePageContent() {
                   {/* **レイズが消えた理由を書く。**回数上限とチップ不足を
                       区別できないと、突然選択肢を奪われたように見える (#4924)。 */}
                   <span className="text-ds-text-muted text-xs" data-testid="bouillotte-raise-count">
-                    {state.raiseCount >= state.maxRaises
+                    {raiseBlock === 'cap'
                       ? t('raiseCapReached', { max: state.maxRaises })
-                      : t('raiseCount', { count: state.raiseCount, max: state.maxRaises })}
+                      : raiseBlock === 'chips'
+                        ? t('raiseNoChips', { cost: raiseNeeded })
+                        : t('raiseCount', { count: state.raiseCount, max: state.maxRaises })}
                   </span>
                   {state.canRaise && (
                     <button type="button" className={btnSuccess} onClick={handleRaise} disabled={loading}>
-                      {t('raiseButtonAmount', { amount: raiseCost })}
+                      {t('raiseButtonAmount', { amount: raiseNeeded })}
                     </button>
                   )}
                   <button type="button" className={btnDanger} onClick={handleFold} disabled={loading}>

--- a/frontend/src/pages/PrimeroPage.test.tsx
+++ b/frontend/src/pages/PrimeroPage.test.tsx
@@ -229,6 +229,30 @@ describe('PrimeroPage', () => {
       expect(readout).not.toHaveTextContent('上限');
     });
 
+    // **枚数不足も理由として区別する。**上限に達していないのに押せないとき、
+    // 「レイズ 1/3回」とだけ出すと「まだできる」と読めてしまう（レビュー指摘）。
+    it('says the chips are short when the cap is not the reason', async () => {
+      mockExec.mockResolvedValue(
+        makePrimeroState({
+          phase: 0,
+          isHumanTurn: true,
+          canRaise: false,
+          raiseCount: 1,
+          maxRaises: 3,
+          currentBet: 10,
+          ante: 5,
+          players: [
+            { ...makePrimeroState().players[0], isHuman: true, chips: 3, roundBet: 0 },
+            ...makePrimeroState().players.slice(1),
+          ],
+        }),
+      );
+      renderWithProviders(<PrimeroPage />);
+      const readout = await screen.findByTestId('primero-raise-count');
+      expect(readout).toHaveTextContent('チップが足りません');
+      expect(readout).not.toHaveTextContent('レイズ 1/3回');
+    });
+
     it('says the cap was reached rather than silently dropping the button', async () => {
       mockExec.mockResolvedValue(
         makePrimeroState({ phase: 0, isHumanTurn: true, canRaise: false, raiseCount: 3, maxRaises: 3 }),

--- a/frontend/src/pages/PrimeroPage.test.tsx
+++ b/frontend/src/pages/PrimeroPage.test.tsx
@@ -215,4 +215,29 @@ describe('PrimeroPage', () => {
     // A non-matching row is not marked current.
     expect(screen.getByTestId('primero-hand-legend-row-fluxus')).not.toHaveAttribute('aria-current');
   });
+
+  // **レイズが消えた理由を書く。**回数上限とチップ不足を区別できないと、
+  // 突然選択肢を奪われたように見える (#4925)。
+  describe('raise cap readout', () => {
+    it('shows the current count against the cap while raising is still open', async () => {
+      mockExec.mockResolvedValue(
+        makePrimeroState({ phase: 0, isHumanTurn: true, canRaise: true, raiseCount: 1, maxRaises: 3 }),
+      );
+      renderWithProviders(<PrimeroPage />);
+      const readout = await screen.findByTestId('primero-raise-count');
+      expect(readout).toHaveTextContent('レイズ 1/3回');
+      expect(readout).not.toHaveTextContent('上限');
+    });
+
+    it('says the cap was reached rather than silently dropping the button', async () => {
+      mockExec.mockResolvedValue(
+        makePrimeroState({ phase: 0, isHumanTurn: true, canRaise: false, raiseCount: 3, maxRaises: 3 }),
+      );
+      renderWithProviders(<PrimeroPage />);
+      const readout = await screen.findByTestId('primero-raise-count');
+      expect(readout).toHaveTextContent('レイズ上限（3回）に達しました');
+      // ボタン自体は消えたままでよい。理由が読めることが要点。
+      expect(screen.queryByRole('button', { name: /レイズ/ })).not.toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/src/pages/PrimeroPage.tsx
+++ b/frontend/src/pages/PrimeroPage.tsx
@@ -375,6 +375,13 @@ function PrimeroPageContent() {
                   <button type="button" className={btnPrimary} onClick={handleCall} disabled={loading}>
                     {t('callButton')}
                   </button>
+                  {/* **レイズが消えた理由を書く。**回数上限とチップ不足を
+                      区別できないと、突然選択肢を奪われたように見える (#4925)。 */}
+                  <span className="text-ds-text-muted text-xs" data-testid="primero-raise-count">
+                    {state.raiseCount >= state.maxRaises
+                      ? t('raiseCapReached', { max: state.maxRaises })
+                      : t('raiseCount', { count: state.raiseCount, max: state.maxRaises })}
+                  </span>
                   {state.canRaise && (
                     <button type="button" className={btnSuccess} onClick={handleRaise} disabled={loading}>
                       {t('raiseButton')}

--- a/frontend/src/pages/PrimeroPage.tsx
+++ b/frontend/src/pages/PrimeroPage.tsx
@@ -35,6 +35,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { PRIMERO_HELP, parsePrimeroCommand } from '../utils/cli/commands/primeroCommands';
 import { formatPrimeroState } from '../utils/cli/formatters/primeroFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { raiseAvailability, raiseCost } from '../utils/raiseAvailability';
 import { hintCheckboxItem } from '../utils/settingsItems';
 
 /** Primero tutorial step definitions. */
@@ -125,6 +126,18 @@ function PrimeroPageContent() {
     return <GameSkeleton gameKey="primero" layout={{ kind: 'trick-taking', trickArea: true, footerHandSize: 4 }} />;
 
   const humanPlayer = state.players.find((p) => p.isHuman);
+  // **レイズが消えた理由は 2 つある。**上限と枚数不足を区別しないと、
+  // 「レイズ 1/3回」がボタンの無い画面で「まだできる」と読めてしまう。
+  const raiseInput = {
+    raiseCount: state.raiseCount,
+    maxRaises: state.maxRaises,
+    chips: humanPlayer?.chips ?? 0,
+    currentBet: state.currentBet,
+    roundBet: humanPlayer?.roundBet ?? 0,
+    ante: state.ante,
+  };
+  const raiseBlock = raiseAvailability(raiseInput);
+  const raiseNeeded = raiseCost(raiseInput);
   const humanIdx = state.players.findIndex((p) => p.isHuman);
 
   const isBettingPhase = state.phase === PrimeroPhase.BETTING;
@@ -378,9 +391,11 @@ function PrimeroPageContent() {
                   {/* **レイズが消えた理由を書く。**回数上限とチップ不足を
                       区別できないと、突然選択肢を奪われたように見える (#4925)。 */}
                   <span className="text-ds-text-muted text-xs" data-testid="primero-raise-count">
-                    {state.raiseCount >= state.maxRaises
+                    {raiseBlock === 'cap'
                       ? t('raiseCapReached', { max: state.maxRaises })
-                      : t('raiseCount', { count: state.raiseCount, max: state.maxRaises })}
+                      : raiseBlock === 'chips'
+                        ? t('raiseNoChips', { cost: raiseNeeded })
+                        : t('raiseCount', { count: state.raiseCount, max: state.maxRaises })}
                   </span>
                   {state.canRaise && (
                     <button type="button" className={btnSuccess} onClick={handleRaise} disabled={loading}>

--- a/frontend/src/utils/raiseAvailability.test.ts
+++ b/frontend/src/utils/raiseAvailability.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { raiseAvailability, raiseCost } from './raiseAvailability';
+
+const base = { raiseCount: 0, maxRaises: 3, chips: 100, currentBet: 10, roundBet: 0, ante: 5 };
+
+describe('raiseCost', () => {
+  it('is what is still owed plus the ante', () => {
+    expect(raiseCost({ currentBet: 10, roundBet: 4, ante: 5 })).toBe(11);
+  });
+
+  // **すでに賭けた分が現在のベットを超えることがある。**負の need にすると
+  // アンテより安く見積もってしまう。
+  it('floors what is owed at zero rather than going negative', () => {
+    expect(raiseCost({ currentBet: 10, roundBet: 25, ante: 5 })).toBe(5);
+  });
+});
+
+describe('raiseAvailability', () => {
+  it('is open while under the cap and able to pay', () => {
+    expect(raiseAvailability(base)).toBe('open');
+  });
+
+  it('reports the cap once the round allowance is spent', () => {
+    expect(raiseAvailability({ ...base, raiseCount: 3 })).toBe('cap');
+    expect(raiseAvailability({ ...base, raiseCount: 4 })).toBe('cap');
+  });
+
+  // **枚数不足も理由として区別する。**上限に達していないのに押せないとき、
+  // 「レイズ 1/3回」とだけ出すと「まだできる」と読めてしまう。
+  it('reports the chip shortage while still under the cap', () => {
+    expect(raiseAvailability({ ...base, raiseCount: 1, chips: 14 })).toBe('chips');
+  });
+
+  it('is open at exactly the cost', () => {
+    expect(raiseAvailability({ ...base, chips: 15 })).toBe('open');
+  });
+
+  // 両方成り立つときは上限を先に言う。ラウンド内では回復しないほう。
+  it('prefers the cap when both hold', () => {
+    expect(raiseAvailability({ ...base, raiseCount: 3, chips: 0 })).toBe('cap');
+  });
+});

--- a/frontend/src/utils/raiseAvailability.ts
+++ b/frontend/src/utils/raiseAvailability.ts
@@ -1,0 +1,51 @@
+/** Why raising is unavailable, or `open` when it is still allowed. */
+export type RaiseAvailability = 'open' | 'cap' | 'chips';
+
+/** The inputs the backend's `canRaise` is computed from. */
+export interface RaiseAvailabilityInput {
+  /** Raises already made this round. */
+  raiseCount: number;
+  /** Raises allowed per round. */
+  maxRaises: number;
+  /** The human's remaining chips. */
+  chips: number;
+  /** The current bet to match. */
+  currentBet: number;
+  /** What the human has already put in this round. */
+  roundBet: number;
+  /** The ante, which a raise adds on top of the call. */
+  ante: number;
+}
+
+/**
+ * Why the raise button is missing, mirroring the backend's
+ *
+ * ```go
+ * canRaise := raiseCount < MaxRaises && chips >= need+ante
+ * ```
+ *
+ * in `Primero.go` / `Bouillotte.go`. **Both games hide the button rather than
+ * disabling it**, so without a reason the player cannot tell a spent raise
+ * allowance from an empty stack (#4924 / #4925).
+ *
+ * The cap is reported first when both hold: it is the condition that cannot be
+ * recovered from within the round.
+ * @param input - The round's raise state and the human's chips.
+ * @returns `cap` when the per-round limit is spent, `chips` when the stack
+ *   cannot cover call + ante, otherwise `open`.
+ */
+export function raiseAvailability(input: RaiseAvailabilityInput): RaiseAvailability {
+  if (input.raiseCount >= input.maxRaises) return 'cap';
+  if (input.chips < raiseCost(input)) return 'chips';
+  return 'open';
+}
+
+/**
+ * Chips a raise costs: what is still owed on the current bet, plus the ante.
+ * Mirrors `need + ante`, with `need` floored at zero.
+ * @param input - The current bet, what the human already staked, and the ante.
+ * @returns The chips needed to raise.
+ */
+export function raiseCost(input: Pick<RaiseAvailabilityInput, 'currentBet' | 'roundBet' | 'ante'>): number {
+  return Math.max(0, input.currentBet - input.roundBet) + input.ante;
+}


### PR DESCRIPTION
Closes #4925
Closes #4924

同型の 2 件。どちらも `raiseCount` / `maxRaises` を**すでに応答に載せている**のに、ページは `state.canRaise` の真偽だけを見てレイズボタンを出し入れしていた。ボタンが消えた理由が「チップ不足」なのか「このラウンドのレイズ回数上限に達した」のか区別できず、特に後者では唐突に選択肢を奪われたように見える。

## 変更

ベッティング UI に読み出しを 1 つ追加:

- まだ余地がある → `レイズ 1/3回`
- 上限に達した → `レイズ上限（3回）に達しました`

**ボタン自体は消えたままにした。**押せないものを disabled で残すより、なぜ選べないかが読めることが要点なので、`canRaise` の既存挙動は変えていない。

ワイヤ形式・バックエンドともに変更なし（フィールドは既にある）。

## テスト

各ページ 2 件:

- 余地があるとき `レイズ 1/3回` が出て「上限」の語が出ないこと
- 上限到達時に理由が出ること、かつ**レイズボタンが無いこと**（表示だけ足してボタンを復活させていない）

ネガティブコントロール: 三項を上限側なしに潰すと各 1 件が落ちる。

`bun run check` / `bun run typecheck` / vitest green。

## Test plan

- [ ] CI green