### PR TITLE
fix(koikoi): apply the koi-koi multiplier to the decision panel

### DIFF
--- a/frontend/src/i18n/locales/en/koikoi.json
+++ b/frontend/src/i18n/locales/en/koikoi.json
@@ -37,7 +37,8 @@
     "title": "You completed a yaku! Koi-Koi or Shobu?",
     "points": "{{points}} pts",
     "koikoi": "Koi-Koi",
-    "shobu": "Shobu"
+    "shobu": "Shobu",
+    "multiplier": "(x{{mult}})"
   },
   "roundResult": {
     "title": "Round Result",

--- a/frontend/src/i18n/locales/ja/koikoi.json
+++ b/frontend/src/i18n/locales/ja/koikoi.json
@@ -37,7 +37,8 @@
     "title": "役が成立しました！ こいこい？ それとも勝負？",
     "points": "{{points}}文",
     "koikoi": "こいこい",
-    "shobu": "勝負"
+    "shobu": "勝負",
+    "multiplier": "（倍率×{{mult}}）"
   },
   "roundResult": {
     "title": "ラウンド結果",

--- a/frontend/src/pages/KoiKoiPage.test.tsx
+++ b/frontend/src/pages/KoiKoiPage.test.tsx
@@ -212,4 +212,31 @@ describe('KoiKoiPage', () => {
     expect(screen.getAllByText('獲得札なし').length).toBeGreaterThanOrEqual(2);
     expect(screen.queryByTestId('koikoi-human-group-bright')).not.toBeInTheDocument();
   });
+
+  // **こいこいを一度でも宣言していれば確定点は 2 倍。**生の pendingPoints を
+  // 出すと、実際より低い「今止めた場合の点数」を見せることになる (#4929)。
+  describe('decision panel multiplier', () => {
+    it('shows the raw points on the first decision', async () => {
+      mockExec.mockResolvedValue(
+        makeKoiKoiState({ phase: 1, pendingYaku: [{ key: 'tane', points: 3 }], pendingPoints: 3, koikoiCount: 0 }),
+      );
+      renderWithProviders(<KoiKoiPage />);
+      const panel = await screen.findByTestId('koikoi-decision-points');
+      expect(panel).toHaveTextContent('3文');
+      expect(panel).not.toHaveTextContent('倍率');
+    });
+
+    it('doubles the points once a koi-koi has been declared', async () => {
+      mockExec.mockResolvedValue(
+        makeKoiKoiState({ phase: 1, pendingYaku: [{ key: 'tane', points: 3 }], pendingPoints: 3, koikoiCount: 1 }),
+      );
+      renderWithProviders(<KoiKoiPage />);
+      const panel = await screen.findByTestId('koikoi-decision-points');
+      expect(panel).toHaveTextContent('6文');
+      // 倍率が効いていることを明示する。
+      expect(panel).toHaveTextContent('倍率×2');
+      // 生の値をそのまま出していないこと。
+      expect(panel).not.toHaveTextContent('3文');
+    });
+  });
 });

--- a/frontend/src/pages/KoiKoiPage.tsx
+++ b/frontend/src/pages/KoiKoiPage.tsx
@@ -145,6 +145,8 @@ function KoiKoiPageContent() {
 
   const isPlayPhase = state.phase === KoiKoiPhase.PLAY;
   const isDecisionPhase = state.phase === KoiKoiPhase.KOIKOI_DECISION;
+  // **こいこいを一度でも宣言していれば確定点は 2 倍** (KoiKoi.endRound と同じ)。
+  const decisionMultiplier = state.koikoiCount >= 1 ? 2 : 1;
   const isRoundEnd = state.phase === KoiKoiPhase.ROUND_END;
   const isGameEnd = state.phase === KoiKoiPhase.GAME_END || state.gameEndFlag;
   const isHumanTurn = state.isHumanTurn && !isGameEnd;
@@ -324,8 +326,13 @@ function KoiKoiPageContent() {
                 data-testid="koikoi-decision"
               >
                 <div className="text-ds-text-primary font-semibold mb-1">{t('decision.title')}</div>
-                <div className="text-ds-warning text-sm mb-2">
-                  {yakuList(state.pendingYaku)} = {t('decision.points', { points: state.pendingPoints })}
+                <div className="text-ds-warning text-sm mb-2" data-testid="koikoi-decision-points">
+                  {/* **こいこい 1 回以降は倍。**生の pendingPoints を出すと、
+                      実際より低い「今止めた場合の点数」を見せることになる
+                      (#4929)。CUI は koikoiDecisionInfoStr で倍率を掛けている。 */}
+                  {yakuList(state.pendingYaku)} ={' '}
+                  {t('decision.points', { points: state.pendingPoints * decisionMultiplier })}
+                  {decisionMultiplier > 1 && ` ${t('decision.multiplier', { mult: decisionMultiplier })}`}
                 </div>
                 <div className="flex gap-3 justify-center">
                   <button type="button" className={btnWarning} onClick={callKoiKoi} disabled={loading}>


### PR DESCRIPTION
Closes #4929

## 背景

CUI の `koikoiDecisionInfoStr` は

```go
mult := 1
if g.GetKoikoiCount() >= 1 {
    mult = 2
}
confirmed := g.GetPendingPoints() * mult
```

として「今 勝負を止めた場合の確定点数」を出す（`KoiKoi.endRound` と同じ規則）。ところが Web の判断パネルは生の `state.pendingPoints` をそのまま表示していた。**2 回目以降の判断で、実際より低い点数を見せていた** — こいこいを続けるか止めるかの判断材料そのものが間違っていたことになる。`state.koikoiCount` は同じ画面の 226 行目で既に使っている。

## 変更

倍率を掛け、掛かっているときは `（倍率×2）` を併記する。CUI と同じ判定（`koikoiCount >= 1`）。

## テスト

- 初回（`koikoiCount: 0`）は 3 文のまま、「倍率」の語が出ない
- 2 回目（`koikoiCount: 1`）は 6 文になり `倍率×2` が出て、**生の 3 文が出ていない**

最後の否定は要る。`3文` が残ったまま `6文` を足しただけでも前の 2 つは通るので。

ネガティブコントロール: 倍率を 1 に固定すると 1 件が落ちる。

`bun run check` / `bun run typecheck` / vitest green。

## Test plan

- [ ] CI green