### PR TITLE
fix(scarto): show that the score change is the average difference times the seats

### DIFF
--- a/frontend/src/i18n/locales/en/scarto.json
+++ b/frontend/src/i18n/locales/en/scarto.json
@@ -47,7 +47,8 @@
     "outcome": "Your result: {{outcome}}",
     "playerLine": "{{name}}: {{delta}} (total {{score}})",
     "average": "Table average: {{avg}} pts",
-    "earnedLine": "{{name}}: earned {{points}} pts (vs avg {{diff}})"
+    "earnedLine": "{{name}}: earned {{points}} pts (vs avg {{diff}} -> change {{scaled}})",
+    "formula": "Change = difference from the average x players ({{n}})"
   },
   "hintAvailable": "Hint",
   "hint": {

--- a/frontend/src/i18n/locales/en/scarto.json
+++ b/frontend/src/i18n/locales/en/scarto.json
@@ -47,8 +47,8 @@
     "outcome": "Your result: {{outcome}}",
     "playerLine": "{{name}}: {{delta}} (total {{score}})",
     "average": "Table average: {{avg}} pts",
-    "earnedLine": "{{name}}: earned {{points}} pts (vs avg {{diff}} -> change {{scaled}})",
-    "formula": "Change = difference from the average x players ({{n}})"
+    "earnedLine": "{{name}}: earned {{points}} pts (vs avg {{diff}} → change {{scaled}})",
+    "formula": "Change = difference from the average × players ({{n}})"
   },
   "hintAvailable": "Hint",
   "hint": {

--- a/frontend/src/i18n/locales/ja/scarto.json
+++ b/frontend/src/i18n/locales/ja/scarto.json
@@ -47,7 +47,8 @@
     "outcome": "あなたの結果: {{outcome}}",
     "playerLine": "{{name}}: {{delta}}（累計 {{score}}）",
     "average": "全体平均: {{avg}}点",
-    "earnedLine": "{{name}}: 獲得 {{points}}点（平均差 {{diff}}）"
+    "earnedLine": "{{name}}: 獲得 {{points}}点（平均差 {{diff}} → 変動 {{scaled}}）",
+    "formula": "変動 = 平均差 × プレイヤー数（{{n}}人）"
   },
   "hintAvailable": "ヒント",
   "hint": {

--- a/frontend/src/pages/ScartoPage.test.tsx
+++ b/frontend/src/pages/ScartoPage.test.tsx
@@ -245,6 +245,21 @@ describe('ScartoPage', () => {
     expect(screen.getByTestId('scarto-result')).toHaveTextContent('+28');
   });
 
+  // **平均差と実際の変動は N 倍ちがう。**式を書かないと、同じ箱の中で「+28」と
+  // 「平均差 +9.3」が並んで計算が合わないように見える (#4930)。
+  it('spells out that the change is the average difference times the player count', async () => {
+    mockExec.mockResolvedValue(settlementState);
+    renderWithProviders(<ScartoPage />);
+    const breakdown = await screen.findByTestId('scarto-breakdown');
+
+    expect(screen.getByTestId('scarto-formula')).toHaveTextContent('平均差 × プレイヤー数（3人）');
+    // 70 - 60.666… = +9.3、×3 で +28。上の行の dealScores と一致する。
+    expect(breakdown).toHaveTextContent('平均差 +9.3');
+    expect(breakdown).toHaveTextContent('変動 +28.0');
+    // 負の側も出る。52 - 60.666… = -8.7、×3 で -26。
+    expect(breakdown).toHaveTextContent('平均差 -8.7');
+  });
+
   it('dispatches nextround from round end', async () => {
     mockExec.mockResolvedValue(roundEndState);
     renderWithProviders(<ScartoPage />);

--- a/frontend/src/pages/ScartoPage.test.tsx
+++ b/frontend/src/pages/ScartoPage.test.tsx
@@ -245,8 +245,7 @@ describe('ScartoPage', () => {
     expect(screen.getByTestId('scarto-result')).toHaveTextContent('+28');
   });
 
-  // **平均差と実際の変動は N 倍ちがう。**式を書かないと、同じ箱の中で「+28」と
-  // 「平均差 +9.3」が並んで計算が合わないように見える (#4930)。
+  // 上段の dealScores と内訳の平均差が N 倍で結び付くことを固定する (#4930)。
   it('spells out that the change is the average difference times the player count', async () => {
     mockExec.mockResolvedValue(settlementState);
     renderWithProviders(<ScartoPage />);

--- a/frontend/src/pages/ScartoPage.tsx
+++ b/frontend/src/pages/ScartoPage.tsx
@@ -327,12 +327,17 @@ function ScartoPageContent() {
                     {/* Average-difference breakdown: each seat's captured points vs. the table mean. */}
                     <div className="mt-1 pt-1 border-t border-white/10" data-testid="scarto-breakdown">
                       <div>{t('roundResult.average', { avg: formatPoints(averageCardPoints) })}</div>
+                      {/* **平均差と実際の変動は N 倍ちがう。**式を書かないと、同じ
+                          箱の中で「+15」と「平均差 +5」が並んで計算が合わないように
+                          見える (#4930)。 */}
+                      <div data-testid="scarto-formula">{t('roundResult.formula', { n: state.players.length })}</div>
                       {state.players.map((p) => (
                         <div key={p.id}>
                           {t('roundResult.earnedLine', {
                             name: playerName(p.id, p.isHuman),
                             points: p.cardPoints,
                             diff: formatSigned(p.cardPoints - averageCardPoints),
+                            scaled: formatSigned((p.cardPoints - averageCardPoints) * state.players.length),
                           })}
                         </div>
                       ))}


### PR DESCRIPTION
Closes #4930

## 背景

スカルトの得点は `dealScore_i = N × (cardPoints_i − average)`。ラウンド結果パネルは上段で **N 倍済み**の `state.dealScores[i]` を出し、その直下の内訳では **N 倍前**の生差分を「平均差」として出していた。3人プレイで平均より 9.3 高いプレイヤーは、同じ箱の中で

```
あなた: +28（累計 28）
...
あなた: 獲得 70点（平均差 +9.3）
```

を並べて見ることになり、N の掛け算がどこにも書かれていないので**計算が合わないように見える**。

## 変更

- 内訳に式を 1 行: `変動 = 平均差 × プレイヤー数（3人）`
- 各行に N 倍後の値も併記: `獲得 70点（平均差 +9.3 → 変動 +28.0）`

**どちらの数字も残した**（受け入れ条件2）。平均差は「どれだけ勝ったか」、変動は「点数がどう動いたか」で、別のことを言っている。

## テスト

既存のフィクスチャ（70/60/52 点、平均 60.7、`dealScores: [28, -2, -34]`）をそのまま使い、

- 式が出ること
- `平均差 +9.3` と `変動 +28.0` が並び、**上段の `dealScores` と一致する**こと
- 負の側（`平均差 -8.7`）も出ること

ネガティブコントロール: `scaled` を空文字にすると落ちる。

`bun run check` / `bun run typecheck` / vitest green。

## Test plan

- [ ] CI green