### PR TITLE
feat(belote): announce the Belote/Rebelote bonus in the CUI

### DIFF
--- a/internal/adapter/presenter/BeloteCuiPresenter.go
+++ b/internal/adapter/presenter/BeloteCuiPresenter.go
@@ -57,6 +57,17 @@ func (p *BeloteCuiPresenter) Output(b interfaces.BeloteGame, lastErr error) stri
 			"t0", strconv.Itoa(b.GetTeamScore(0)),
 			"t1", strconv.Itoa(b.GetTeamScore(1))) + "\n")
 
+		// **20 点規模のボーナスに気づけない。**Web は専用バッジと読み上げまで
+		// 用意しているのに、CUI は累計点しか出しておらず、Belote/Rebelote が
+		// 成立したこと自体が伝わっていなかった (#4913)。
+		for team := range domain.BeloteTeamCnt {
+			if bonus := b.GetRoundBeloteBonus(team); bonus > 0 {
+				out.WriteString(i18n.Tf("belote.beloteBonusLine",
+					"team", strconv.Itoa(team),
+					"points", strconv.Itoa(bonus)) + "\n")
+			}
+		}
+
 		for i := 0; i < b.GetPlayerCnt(); i++ {
 			out.WriteString(belotePlayerStr(b.GetPlayer(i), i))
 		}

--- a/internal/adapter/presenter/BeloteCuiPresenter_test.go
+++ b/internal/adapter/presenter/BeloteCuiPresenter_test.go
@@ -1,6 +1,7 @@
 package presenter_test
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -56,6 +57,30 @@ func setupBeloteCuiMockWithPlayers() (*interfaces.MockBeloteGame, []*domain.Belo
 	m.On("GetPlayer", 2).Return(players[2])
 	m.On("GetPlayer", 3).Return(players[3])
 	return m, players
+}
+
+// **20 点規模のボーナスに気づけない。**Web は専用バッジと読み上げまで用意して
+// いるのに、CUI は累計点しか出していなかった (#4913)。
+func TestBeloteCuiPresenter_NamesTheBeloteRebeloteBonus(t *testing.T) {
+	p := new(presenter.BeloteCuiPresenter)
+
+	build := func(t0, t1 int) *interfaces.MockBeloteGame {
+		m, _ := setupBeloteCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetRoundBeloteBonus")
+		m.On("GetRoundBeloteBonus", 0).Return(t0)
+		m.On("GetRoundBeloteBonus", 1).Return(t1)
+		return m
+	}
+
+	out := p.Output(build(domain.BeloteRebeloteBonus, 0), nil)
+	assert.Contains(t, out, "ベロート・ルベロート成立")
+	assert.Contains(t, out, "チーム0")
+	assert.Contains(t, out, "+"+strconv.Itoa(domain.BeloteRebeloteBonus)+"点")
+	// 成立していないチームの行は出さない。
+	assert.NotContains(t, out, "チーム1 に")
+
+	// どちらも 0 なら行そのものを出さない。
+	assert.NotContains(t, p.Output(build(0, 0), nil), "ベロート・ルベロート成立")
 }
 
 func TestBeloteCuiPresenter_Output(t *testing.T) {

--- a/internal/i18n/locales/en/belote.json
+++ b/internal/i18n/locales/en/belote.json
@@ -14,6 +14,7 @@
   "trumpUndecided": "Trump: undecided",
   "faceUpCard": "Face-up card: {{card}}",
   "teamScoreLine": "Team 0: {{t0}}  Team 1: {{t1}}",
+  "beloteBonusLine": "Belote/Rebelote: +{{points}} to team {{team}} (K+Q of trumps)",
   "playerLine": "{{name}}: Team {{team}} tricks={{tricks}} cards={{cards}}",
   "gameEnd": "Game over! Team {{team}} wins!",
   "promptPickup": "Pickup phase: {{name}} to act",

--- a/internal/i18n/locales/ja/belote.json
+++ b/internal/i18n/locales/ja/belote.json
@@ -14,6 +14,7 @@
   "trumpUndecided": "切り札: 未決定",
   "faceUpCard": "表向きカード: {{card}}",
   "teamScoreLine": "チーム0: {{t0}}点  チーム1: {{t1}}点",
+  "beloteBonusLine": "ベロート・ルベロート成立: チーム{{team}} に +{{points}}点（切札の K+Q）",
   "playerLine": "{{name}}: チーム{{team}} 獲得{{tricks}}トリック {{cards}}枚",
   "gameEnd": "ゲーム終了！ チーム{{team}}の勝利です！",
   "promptPickup": "ピックアップフェーズ: {{name}}の番",


### PR DESCRIPTION
Closes #4913

## 背景

`interfaces.BeloteGame.GetRoundBeloteBonus(team)` は既にあり、`BelotePage` はこれを使って専用バッジ (`belote-rebelote-badge`)、成立時の `aria-live` 通知 (`belote-bonus-confirmed`)、勝利音まで用意している。ところが `BeloteCuiPresenter.Output` はこのアクセサを**一度も呼んでおらず**、`teamScoreLine` で累計点しか出していなかった。CUI プレイヤーは 20 点規模のボーナスが成立したことに気づけない。**配線漏れ**。

## 変更

チーム別スコア行の直後に、ボーナスが積まれているチームの行を出す:

```
チーム0: 32点  チーム1: 18点
ベロート・ルベロート成立: チーム0 に +20点（切札の K+Q）
```

- **成立したチームの行だけ**を出す（0 のチームは書かない）
- どちらも 0 のラウンドでは行そのものを出さない

## テスト

`TestBeloteCuiPresenter_NamesTheBeloteRebeloteBonus`:

- チーム0 に成立 → 行が出て、点数が `domain.BeloteRebeloteBonus` と一致すること
- **成立していないチーム1 の行は出ないこと**
- 両方 0 なら行そのものが出ないこと

ネガティブコントロール: 追加ブロックを外すと落ちる。

`go test -tags test ./...` / `golangci-lint run ./internal/...` (0 issues) green。

## Test plan

- [ ] CI green