### PR TITLE
feat(fortyandeight): keep saying the redeal is spent instead of dropping the button

### DIFF
--- a/frontend/src/i18n/locales/en/fortyandeight.json
+++ b/frontend/src/i18n/locales/en/fortyandeight.json
@@ -11,6 +11,7 @@
   "moveCount": "Moves",
   "draw": "Draw",
   "redeal": "Redeal",
+  "redealUsed": "Redeal used",
   "giveup": "Give Up",
   "empty": "Empty",
   "foundationAriaLabel": "{{suit}} foundation {{pile}}, {{count}} cards",

--- a/frontend/src/i18n/locales/ja/fortyandeight.json
+++ b/frontend/src/i18n/locales/ja/fortyandeight.json
@@ -11,6 +11,7 @@
   "moveCount": "手数",
   "draw": "引く",
   "redeal": "リディール",
+  "redealUsed": "リディール使用済み",
   "giveup": "ギブアップ",
   "empty": "空",
   "foundationAriaLabel": "{{suit}} 組札 {{pile}} {{count}}枚",

--- a/frontend/src/pages/FortyAndEightPage.test.tsx
+++ b/frontend/src/pages/FortyAndEightPage.test.tsx
@@ -235,6 +235,19 @@ describe('FortyAndEightPage', () => {
     renderWithProviders(<FortyAndEightPage />);
     await waitFor(() => expect(screen.getByText('ウェイスト')).toBeInTheDocument());
     expect(screen.queryByRole('button', { name: 'リディール' })).not.toBeInTheDocument();
+    // まだ使っていないうちは「使用済み」も出さない。
+    expect(screen.queryByTestId('fe-redeal-used')).not.toBeInTheDocument();
+  });
+
+  // **消すと「使い切った」のか「元から無い」のか区別が付かない。**CUI は毎回
+  // どちらかを必ず案内している (#4914)。
+  it('says the redeal was used once it is spent', async () => {
+    mockExec.mockResolvedValue({ ...playingState, redealUsed: true, canRedeal: false });
+    renderWithProviders(<FortyAndEightPage />);
+    const note = await screen.findByTestId('fe-redeal-used');
+    expect(note).toHaveTextContent('リディール使用済み');
+    // ボタンは復活しない。
+    expect(screen.queryByRole('button', { name: 'リディール' })).not.toBeInTheDocument();
   });
 
   it('clicking hint button dispatches hint', async () => {

--- a/frontend/src/pages/FortyAndEightPage.tsx
+++ b/frontend/src/pages/FortyAndEightPage.tsx
@@ -510,7 +510,7 @@ function FortyAndEightPageContent() {
                     </button>
                   ) : (
                     state.redealUsed && (
-                      <span className="text-ds-text-muted text-xs self-center" data-testid="fe-redeal-used">
+                      <span className="mx-1.5 text-ds-text-muted text-xs" data-testid="fe-redeal-used">
                         {t('redealUsed')}
                       </span>
                     )

--- a/frontend/src/pages/FortyAndEightPage.tsx
+++ b/frontend/src/pages/FortyAndEightPage.tsx
@@ -497,7 +497,9 @@ function FortyAndEightPageContent() {
                   >
                     {t('draw')}
                   </button>
-                  {state.canRedeal && (
+                  {/* **消すと「使い切った」のか「元から無い」のか区別が付かない。**
+                      CUI は毎回どちらかを必ず案内している (#4914)。 */}
+                  {state.canRedeal ? (
                     <button
                       type="button"
                       className={btnPrimary}
@@ -506,6 +508,12 @@ function FortyAndEightPageContent() {
                     >
                       {t('redeal')}
                     </button>
+                  ) : (
+                    state.redealUsed && (
+                      <span className="text-ds-text-muted text-xs self-center" data-testid="fe-redeal-used">
+                        {t('redealUsed')}
+                      </span>
+                    )
                   )}
                   <button
                     type="button"


### PR DESCRIPTION
Closes #4914

## 背景

`FortyAndEightCuiPresenter` は毎回のストック行で `fortyandeight.redealUsed` / `redealAvailable` の**どちらかを必ず**案内する。一方 `FortyAndEightPage` は `{state.canRedeal && (<button ...>)}` の条件レンダリングだけで、リディールを使い切るとボタンごと画面から消える。**使い切ったのか、そもそもこのゲームにリディールが無いのか**を区別する手がかりが残らない。

## 変更

ボタンと同じ位置に「リディール使用済み」を出す。

- `canRedeal` が true → 従来どおりボタン（受け入れ条件1）
- `canRedeal` が false かつ `redealUsed` → 使用済みの表示
- **どちらでもない**（まだ使っておらず、今は使えない）→ 何も出さない。通常の進行であって、状態を説明する必要がない

`redealUsed` は既に `FortyAndEightResponse` にある（新しいワイヤは不要）。

## テスト

- 既存の「ボタンが消える」テストに、**まだ使っていないうちは使用済みも出ない**ことを追加
- `redealUsed: true` で使用済みが出て、**ボタンは復活しない**こと

ネガティブコントロール: 使用済み表示を `null` にすると 1 件が落ちる。

`bun run check` / `bun run typecheck` / vitest green。

## Test plan

- [ ] CI green