### PR TITLE
feat(bura): name the cards that form the combination when advising a declare

### DIFF
--- a/internal/adapter/presenter/BuraWebPresenter.go
+++ b/internal/adapter/presenter/BuraWebPresenter.go
@@ -138,7 +138,12 @@ func buraHint(b interfaces.BuraGame) ([]int, string) {
 	action := b.BuraCpuDecide(0)
 	switch {
 	case action.Declare:
-		return nil, "bura.hint.declare"
+		// **役はどれも手札 3 枚すべてで成る。**ブラ(全部切札)・モスクワ(全部 A)・
+		// 小モスクワ(全部 6 + 切札の 6)・モロトカ(全部同スート) はいずれも
+		// `BuraDetectCombination` が手札全体を見て判定しており、一部の札で
+		// 成立することはない。だから「どの 3 枚か」は常に全部で、検出器を
+		// 拡張する必要はない。**一番重要な瞬間だけ何も光らない**のを直す (#4909)。
+		return buraWholeHandIndices(b), "bura.hint.declare"
 	case action.Claim:
 		return nil, "bura.hint.claim"
 	case len(b.GetCurrentLead()) > 0:
@@ -146,4 +151,17 @@ func buraHint(b interfaces.BuraGame) ([]int, string) {
 	default:
 		return action.Indices, "bura.hint.lead"
 	}
+}
+
+// buraWholeHandIndices は人間の手札すべてのインデックスを返す。
+func buraWholeHandIndices(b interfaces.BuraGame) []int {
+	p := b.GetPlayer(0)
+	if p == nil {
+		return nil
+	}
+	out := make([]int, 0, p.GetCardsSize())
+	for i := range p.GetCardsSize() {
+		out = append(out, i)
+	}
+	return out
 }

--- a/internal/adapter/presenter/BuraWebPresenter_test.go
+++ b/internal/adapter/presenter/BuraWebPresenter_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 )
 
 // buraTestGame returns a dealt game with a known trump so the fixtures below
@@ -237,4 +238,12 @@ func TestBuraWebPresenter_DeclareHintNamesTheWholeHand(t *testing.T) {
 	require.True(t, ok)
 	assert.Len(t, idx, domain.BuraHandSize)
 	assert.Equal(t, []any{float64(0), float64(1), float64(2)}, idx)
+}
+
+// 席が取れないときに落ちない。**mock 越しには nil が返りうる**ので、
+// インデックスを組む前に確かめている。
+func TestBuraWholeHandIndices_ToleratesAMissingSeat(t *testing.T) {
+	m := new(interfaces.MockBuraGame)
+	m.On("GetPlayer", 0).Return((*domain.BuraPlayer)(nil))
+	assert.Nil(t, buraWholeHandIndices(m))
 }

--- a/internal/adapter/presenter/BuraWebPresenter_test.go
+++ b/internal/adapter/presenter/BuraWebPresenter_test.go
@@ -128,8 +128,15 @@ func TestBuraWebPresenter_HintOutputCarriesTheSameSuggestion(t *testing.T) {
 		switch hint["reason"] {
 		case "bura.hint.lead", "bura.hint.respond":
 			assert.NotEmpty(t, hint["cardIndices"], "a card suggestion must name the cards")
-		case "bura.hint.declare", "bura.hint.claim":
-			assert.Empty(t, hint["cardIndices"], "there are no cards to play when the advice is to declare")
+		case "bura.hint.declare":
+			// **役はどれも手札 3 枚すべてで成る。**一番重要な瞬間に何も
+			// 光らないのが元の不具合だった (#4909)。
+			idx, ok := hint["cardIndices"].([]any)
+			require.True(t, ok, "declaring must name the cards that form the combination")
+			assert.Len(t, idx, domain.BuraHandSize)
+		case "bura.hint.claim":
+			// クレームは得点の主張で、特定の札の話ではない。
+			assert.Empty(t, hint["cardIndices"], "a points claim is not about particular cards")
 		default:
 			t.Fatalf("unexpected hint reason on a live round: %v", hint["reason"])
 		}
@@ -203,4 +210,31 @@ func TestBuraWebPresenter_HintReportsAFinishedRound(t *testing.T) {
 	out := buraDecode(t, new(BuraWebPresenter).HintOutput(b))
 	hint := out["hint"].(map[string]any)
 	assert.Equal(t, "bura.hint.game_end", hint["reason"])
+}
+
+// **役があるときは必ず 3 枚すべてが挙がる。**ランダムな配りに任せると declare の
+// 分岐を一度も踏まないまま通ることがあるので、役のある手札を直接組んで踏む (#4909)。
+func TestBuraWebPresenter_DeclareHintNamesTheWholeHand(t *testing.T) {
+	b := buraTestGame(t)
+	// 全部切札 = ブラ。手札全体で成る役なので、挙がるのは 3 枚すべて。
+	trump := b.GetTrumpSuit()
+	p := b.GetPlayer(0)
+	p.Reset()
+	for _, v := range []int{1, 10, 13} {
+		p.AddCard(domain.NewCard(trump, v, false))
+	}
+	hand := make([]*domain.Card, p.GetCardsSize())
+	for i := range hand {
+		hand[i] = p.GetCard(i)
+	}
+	require.Equal(t, domain.BuraCombinationBura, domain.BuraDetectCombination(hand, trump))
+
+	out := buraDecode(t, new(BuraWebPresenter).HintOutput(b))
+	hint, ok := out["hint"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "bura.hint.declare", hint["reason"])
+	idx, ok := hint["cardIndices"].([]any)
+	require.True(t, ok)
+	assert.Len(t, idx, domain.BuraHandSize)
+	assert.Equal(t, []any{float64(0), float64(1), float64(2)}, idx)
 }


### PR DESCRIPTION
Closes #4909

## 背景

`buraHint` は `action.Declare` のとき `return nil, "bura.hint.declare"` としてインデックスを返さない。`BuraPage` は `hint.cardIndices` を黄色いリングで示すので、リード・レスポンスの助言は光るのに、**「手札に役が揃っています。宣言すれば即勝ちです」という一番重要な瞬間だけ何も光らない**。

## issue の提案より小さく済む

issue は `BuraDetectCombination` を「役を構成するカードのインデックスも返す」よう拡張する案だが、**ブラの役はどれも手札 3 枚すべてで成る**:

```go
case trumps == BuraHandSize:                 // ブラ: 全部切札
case aces == BuraHandSize:                   // モスクワ: 全部 A
case sixes == BuraHandSize && trumpSix:      // 小モスクワ: 全部 6 + 切札の 6
case sameSuit:                               // モロトカ: 全部同スート
```

いずれも手札全体を見る条件で、**一部の札で成立する役は無い**。だから「どの 3 枚か」の答えは常に「全部」で、検出器を拡張しても返るのは `[0,1,2]` に決まっている。手札全体のインデックスを返すだけで足りる。

クレーム (`action.Claim`) は得点の主張であって特定の札の話ではないので、従来どおりインデックスなしのまま。

フロント側は既に `hintedIndices` で描き分けているので変更不要。

## テスト

- 既存の pairing テストが **`declare` はインデックスを持たない**と不具合の側を固定していたので、`declare` は手札枚数ぶん持つ / `claim` は持たない、に分けた
- ランダムな配りだと `declare` 分岐を一度も踏まないまま通りうるので、**全部切札の手札を直接組んで**踏むテストを追加（`BuraDetectCombination` がブラと判定することも確認してから）

ネガティブコントロール: `nil` に戻すと 2 件が落ちる。

`go test -tags test ./...` / `golangci-lint run ./internal/...` (0 issues) green。

## Test plan

- [ ] CI green