### PR TITLE
fix(congress): disable the empty pile while a tableau card is selected

### DIFF
--- a/frontend/src/pages/CongressPage.test.tsx
+++ b/frontend/src/pages/CongressPage.test.tsx
@@ -99,6 +99,21 @@ describe('CongressPage', () => {
     );
   });
 
+  // **空き山はタブローからは埋められない。**`MoveTableauToTableau` が明示的に
+  // 拒否する。押せてしまうとサーバに弾かれるまで気づけない (#4906)。
+  it('disables an empty pile while a tableau card is selected', async () => {
+    mockExec.mockResolvedValue(playingState);
+    renderWithProviders(<CongressPage />);
+    const empty = await screen.findByRole('button', { name: /空の山 3/ });
+    // まだ何も選んでいなければ、当然押せない。
+    expect(empty).toBeDisabled();
+
+    fireEvent.click(screen.getByRole('button', { name: '♠ 9' }));
+    await waitFor(() => expect(screen.getByRole('button', { name: '♠ 9' })).toHaveAttribute('aria-pressed', 'true'));
+    // タブローの札を選んでも押せないまま。
+    expect(empty).toBeDisabled();
+  });
+
   // The stock doubles as a move source: with a card selected it fills a gap
   // directly instead of turning to the waste.
   it('fills an empty pile straight from the stock', async () => {

--- a/frontend/src/pages/CongressPage.test.tsx
+++ b/frontend/src/pages/CongressPage.test.tsx
@@ -114,6 +114,65 @@ describe('CongressPage', () => {
     expect(empty).toBeDisabled();
   });
 
+  // **ドラッグ経路も同じ規則を守る。**クリックはボタンを無効化して防いでいるが、
+  // ドラッグは dispatchMove を直接通る（レビュー指摘）。
+  it('ignores a tableau card dragged onto an empty pile', async () => {
+    const buildDataTransfer = () => {
+      const store: Record<string, string> = {};
+      return {
+        setData: (type: string, val: string) => {
+          store[type] = val;
+        },
+        getData: (type: string) => store[type] ?? '',
+        effectAllowed: '',
+        dropEffect: '',
+      };
+    };
+
+    mockExec.mockResolvedValue(playingState);
+    renderWithProviders(<CongressPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: '♠ 9' })).toBeInTheDocument());
+    mockExec.mockClear();
+
+    const dataTransfer = buildDataTransfer();
+    fireEvent.dragStart(screen.getByRole('button', { name: '♠ 9' }), { dataTransfer });
+    const empty = screen.getByRole('button', { name: /空の山 3/ });
+    fireEvent.dragOver(empty, { dataTransfer });
+    fireEvent.drop(empty, { dataTransfer });
+
+    await flushPendingDispatch();
+    expect(mockExec).not.toHaveBeenCalledWith('move', expect.anything(), expect.anything());
+  });
+
+  // 捨て札からのドラッグは通る。上の否定が「ドロップ経路そのものが死んでいる」
+  // ことで通っていないかを確かめる。
+  it('still accepts a waste card dragged onto an empty pile', async () => {
+    const buildDataTransfer = () => {
+      const store: Record<string, string> = {};
+      return {
+        setData: (type: string, val: string) => {
+          store[type] = val;
+        },
+        getData: (type: string) => store[type] ?? '',
+        effectAllowed: '',
+        dropEffect: '',
+      };
+    };
+
+    mockExec.mockResolvedValue({ ...playingState, waste: [card('DIAMOND', 4)] });
+    renderWithProviders(<CongressPage />);
+    const wasteCard = await screen.findByRole('button', { name: '♦ 4' });
+    mockExec.mockClear();
+
+    const dataTransfer = buildDataTransfer();
+    fireEvent.dragStart(wasteCard, { dataTransfer });
+    const empty = screen.getByRole('button', { name: /空の山 3/ });
+    fireEvent.dragOver(empty, { dataTransfer });
+    fireEvent.drop(empty, { dataTransfer });
+
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('move', { zone: 'waste' }, { zone: 'tableau', col: 3 }));
+  });
+
   // The stock doubles as a move source: with a card selected it fills a gap
   // directly instead of turning to the waste.
   it('fills an empty pile straight from the stock', async () => {

--- a/frontend/src/pages/CongressPage.tsx
+++ b/frontend/src/pages/CongressPage.tsx
@@ -116,9 +116,15 @@ function CongressPageContent() {
 
   const dispatchMove = useCallback(
     (source: CongressMoveZone, target: CongressMoveZone) => {
+      // **空き山はタブローからは埋められない** (`MoveTableauToTableau` が拒否)。
+      // クリック経路はボタンを無効化して防いでいるが、**ドラッグ経路はここを
+      // 通る**ので、同じ規則をここでも見る (#4906)。
+      const targetIsEmptyPile =
+        target.zone === 'tableau' && target.col !== undefined && (state?.tableau[target.col]?.length ?? 0) === 0;
+      if (targetIsEmptyPile && source.zone === 'tableau') return;
       void game.exec('move', source, target);
     },
-    [game],
+    [game, state],
   );
   const dnd = useSolitaireDragDrop<CongressMoveZone>({
     onMove: dispatchMove,

--- a/frontend/src/pages/CongressPage.tsx
+++ b/frontend/src/pages/CongressPage.tsx
@@ -189,7 +189,10 @@ function CongressPageContent() {
               <button
                 type="button"
                 onClick={() => game.handleSelectTarget(pileZone)}
-                disabled={!isPlaying || loading || !selectedSource}
+                // **空き山はタブローからは埋められない。**山札か捨て札からだけ
+                // (`MoveTableauToTableau` が明示的に拒否する)。押せてしまうと
+                // サーバに弾かれるまで気づけない (#4906)。
+                disabled={!isPlaying || loading || !selectedSource || selectedSource.zone === 'tableau'}
                 aria-label={t('emptyPileAriaLabel', { pile: pileIdx })}
                 style={{ height: dims.ch }}
                 className={`w-full rounded border-2 border-dashed border-white/20 text-game-text-muted text-xs flex items-center justify-center bg-transparent ${focusRingWhite}`}


### PR DESCRIPTION
Closes #4906

## 背景

`Congress.MoveTableauToTableau` は

```go
if len(c.tableau[toPile]) == 0 {
    return errors.New("an empty pile can only be filled from the stock or the waste")
}
```

と明示的に拒否する。ところが空き山ボタンの `disabled` は `!isPlaying || loading || !selectedSource` だけで、**選択中のソースがタブローの札でも押せた**。押すとサーバに弾かれるまで気づけない。CUI は「空きの山は山札か捨て札からしか埋められない」と注記しており、Web だけが事前に伝えていなかった。

## 変更

`selectedSource.zone === 'tableau'` のときも無効化する。`aria-label` は元から「(山札か捨て札からのみ置けます)」と説明しているので、文言の追加は不要。

## テスト

- 何も選んでいないときは押せない（従来どおり）
- **タブローの札を選んでも押せないまま**

ネガティブコントロール: 追加した条件を外すと落ちる。

`bun run check` / `bun run typecheck` / vitest green。

## Test plan

- [ ] CI green