### PR TITLE
feat(cribbage): announce His Heels in the CUI

### DIFF
--- a/internal/adapter/presenter/CribbageCuiPresenter.go
+++ b/internal/adapter/presenter/CribbageCuiPresenter.go
@@ -54,6 +54,12 @@ func (p *CribbageCuiPresenter) Output(g interfaces.CribbageGame, lastErr error) 
 		if starter := g.GetStarter(); starter != nil {
 			b.WriteString(i18n.Tf("cribbage.starterLine",
 				"card", cuiCardStr(starter)) + "\n")
+			// **スターターが J ならディーラーに 2 点** (`cutStarter` の His Heels)。
+			// Web は専用バッジで出すのに CUI は黙っており、ディーラーの点が
+			// 唐突に 2 増える理由が分からなかった (#4902)。
+			if starter.GetValue() == domain.CribbageJackValue {
+				b.WriteString(color.Yellow(i18n.T("cribbage.hisHeels")) + "\n")
+			}
 		}
 
 		// Pegging info

--- a/internal/adapter/presenter/CribbageCuiPresenter_test.go
+++ b/internal/adapter/presenter/CribbageCuiPresenter_test.go
@@ -76,6 +76,20 @@ func TestCribbageCuiPresenter_Output(t *testing.T) {
 
 		result := p.Output(m, nil)
 		assert.Contains(t, result, "スターター: HEART 7")
+		// J でなければ His Heels は出ない。
+		assert.NotContains(t, result, "His Heels")
+	})
+
+	// **スターターが J ならディーラーに 2 点。**Web は専用バッジで出すのに CUI は
+	// 黙っており、ディーラーの点が唐突に 2 増える理由が分からなかった (#4902)。
+	t.Run("his heels announced when the starter is a jack", func(t *testing.T) {
+		m, _ := setupCribbageCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetStarter")
+		m.On("GetStarter").Return(domain.NewCard(domain.CardDesignSpade, domain.CribbageJackValue, false))
+
+		result := p.Output(m, nil)
+		assert.Contains(t, result, "His Heels")
+		assert.Contains(t, result, "ディーラーに2点")
 	})
 
 	t.Run("starter nil hides section", func(t *testing.T) {

--- a/internal/domain/Cribbage.go
+++ b/internal/domain/Cribbage.go
@@ -20,10 +20,6 @@ const CribbageHandSize = 4
 // CribbageDiscardSize クリブに捨てる枚数
 const CribbageDiscardSize = 2
 
-// CribbageJackValue は J の値。**スターターが J なら His Heels でディーラーに 2 点**。
-// 判定を presenter でも書くので、リテラルを 2 箇所に散らさない。
-const CribbageJackValue = 11
-
 // CribbagePegLimit ペギングの上限値
 const CribbagePegLimit = 31
 

--- a/internal/domain/Cribbage.go
+++ b/internal/domain/Cribbage.go
@@ -20,6 +20,10 @@ const CribbageHandSize = 4
 // CribbageDiscardSize クリブに捨てる枚数
 const CribbageDiscardSize = 2
 
+// CribbageJackValue は J の値。**スターターが J なら His Heels でディーラーに 2 点**。
+// 判定を presenter でも書くので、リテラルを 2 箇所に散らさない。
+const CribbageJackValue = 11
+
 // CribbagePegLimit ペギングの上限値
 const CribbagePegLimit = 31
 
@@ -263,7 +267,7 @@ func (g *Cribbage) doCut() {
 	g.addLog(-1, "cut", "スターターカード公開", []*Card{g.starter})
 
 	// His Heels: スターターがJなら、ディーラーに2点
-	if g.starter != nil && g.starter.GetValue() == 11 {
+	if g.starter != nil && g.starter.GetValue() == CribbageJackValue {
 		g.addScore(g.dealerIdx, 2, "His Heels (スターターがJ)")
 		if g.checkWin() {
 			return

--- a/internal/domain/cribbage_scoring.go
+++ b/internal/domain/cribbage_scoring.go
@@ -157,7 +157,7 @@ func CribbageScoreNobs(hand []*Card, starter *Card) int {
 		return 0
 	}
 	for _, c := range hand {
-		if c.GetValue() == 11 && c.GetDesign() == starter.GetDesign() {
+		if c.GetValue() == CribbageJackValue && c.GetDesign() == starter.GetDesign() {
 			return 1
 		}
 	}

--- a/internal/domain/cribbage_scoring.go
+++ b/internal/domain/cribbage_scoring.go
@@ -2,6 +2,14 @@ package domain
 
 import "encoding/json"
 
+// CribbageJackValue は J の値。**スターターが J なら His Heels でディーラーに 2 点**、
+// 手札の J が スターターと同スートなら Nobs で 1 点。判定を presenter でも書くので、
+// リテラルを散らさない。
+//
+// **ビルドタグの無いこのファイルに置く。**`Cribbage.go` は worker のバケット外だと
+// コンパイルされず、ここから参照できなくなる。
+const CribbageJackValue = 11
+
 // CribbageScoreDetail クリベッジのスコア内訳
 type CribbageScoreDetail struct {
 	Fifteens int

--- a/internal/i18n/locales/en/cribbage.json
+++ b/internal/i18n/locales/en/cribbage.json
@@ -11,6 +11,7 @@
   "helpSetLimit": "  sl <n>               point limit",
   "header": "Round: {{round}}  Dealer: Player{{dealer}}",
   "starterLine": "Starter: {{card}}",
+  "hisHeels": "His Heels! Starter is a Jack — dealer scores 2",
   "peggingTotal": "Pegging total: {{count}}/31",
   "peggingCards": "Played cards: {{cards}}",
   "playerLine": "{{name}}{{dealerMark}}: cumulative {{cum}} round {{round}} cards {{cards}}",

--- a/internal/i18n/locales/ja/cribbage.json
+++ b/internal/i18n/locales/ja/cribbage.json
@@ -11,6 +11,7 @@
   "helpSetLimit": "  sl <n>               ポイント上限",
   "header": "ラウンド: {{round}}  ディーラー: Player{{dealer}}",
   "starterLine": "スターター: {{card}}",
+  "hisHeels": "His Heels! スターターがJのためディーラーに2点",
   "peggingTotal": "ペギング合計: {{count}}/31",
   "peggingCards": "出されたカード: {{cards}}",
   "playerLine": "{{name}}{{dealerMark}}: 累積{{cum}}点 ラウンド{{round}}点 {{cards}}枚",


### PR DESCRIPTION
Closes #4902

## 背景

`CribbagePage` はスターターが J のとき `cb-his-heels` バッジで「His Heels! スターターがJのためディーラーに2点」と出す。一方 `CribbageCuiPresenter.Output` はスターターを `starterLine` で 1 行出すだけで J かどうかの分岐が無く、**ディーラーの累計点が唐突に 2 増える理由が分からない**。

## 変更

スターター行の直後に His Heels の行を足す。あわせて、判定のリテラル `11` を `domain.CribbageJackValue` として切り出し、**得点側 (`cutStarter`) と presenter の両方が同じ定数を引く**ようにした。同じ数字を 2 箇所に散らすと、片方だけ直したときに表示と得点が食い違う。

## テスト

- 既存の「スターター表示」テストに、**J でなければ His Heels が出ない**ことを追加
- スターターが J のとき行が出ること

ネガティブコントロール: 追加ブロックを外すと 2 件が落ちる。

`go test -tags test ./...` / `golangci-lint run ./internal/...` (0 issues) green。

## Test plan

- [ ] CI green