### PR TITLE
feat(sixbidsolo): mark the ladder steps that can no longer be bid

### DIFF
--- a/internal/adapter/presenter/SixBidSoloCuiPresenter.go
+++ b/internal/adapter/presenter/SixBidSoloCuiPresenter.go
@@ -189,11 +189,23 @@ func (p *SixBidSoloCuiPresenter) Output(g interfaces.SixBidSoloGame, lastErr err
 func sixBidSoloLadderLine(g interfaces.SixBidSoloGame) string {
 	var b strings.Builder
 	b.WriteString(i18n.T("sixbidsolo.ladderTitle") + " ")
+	// **上回れない段階は選べない。**Web は選択肢からそもそも外すのに、CUI は
+	// 6 段階を常に並べるだけで、現在ビッドと突き合わせる暗算を強いていた (#4900)。
+	high := g.GetHighBid()
 	for k := domain.SixBidSoloMinBid; k <= domain.SixBidSoloMaxBid; k++ {
 		if k > domain.SixBidSoloMinBid {
 			b.WriteString(" < ")
 		}
-		b.WriteString(strconv.Itoa(int(k)) + ":" + sixBidSoloBidLabel(k))
+		entry := strconv.Itoa(int(k)) + ":" + sixBidSoloBidLabel(k)
+		if high != nil && k <= high.Kind {
+			// 消さずに残す。序列そのものは判断材料なので。
+			entry = i18n.Tf("sixbidsolo.ladderTaken", "bid", entry)
+		}
+		b.WriteString(entry)
+	}
+	// 最高段階まで取られたら「選べる段階はもう無い」と言い切る。
+	if high != nil && high.Kind >= domain.SixBidSoloMaxBid {
+		b.WriteString("  " + i18n.T("sixbidsolo.ladderNoneLeft"))
 	}
 	return b.String()
 }

--- a/internal/adapter/presenter/SixBidSoloCuiPresenter.go
+++ b/internal/adapter/presenter/SixBidSoloCuiPresenter.go
@@ -205,7 +205,7 @@ func sixBidSoloLadderLine(g interfaces.SixBidSoloGame) string {
 	}
 	// 最高段階まで取られたら「選べる段階はもう無い」と言い切る。
 	if high != nil && high.Kind >= domain.SixBidSoloMaxBid {
-		b.WriteString("  " + i18n.T("sixbidsolo.ladderNoneLeft"))
+		b.WriteString(" " + i18n.T("sixbidsolo.ladderNoneLeft"))
 	}
 	return b.String()
 }

--- a/internal/adapter/presenter/SixBidSoloCuiPresenter_test.go
+++ b/internal/adapter/presenter/SixBidSoloCuiPresenter_test.go
@@ -106,6 +106,35 @@ func TestSixBidSoloCuiPresenter_ShowsTheLadderWhileBidding(t *testing.T) {
 	// 並びは低い順。
 	assert.Less(t, strings.Index(out, "1:ソロ"), strings.Index(out, "6:コール・ソロ"))
 	assert.Contains(t, out, "61点以上")
+	// 場にビッドが無いので、どの段階にも取られた印は付かない (受け入れ条件1)。
+	assert.NotContains(t, out, "[1:ソロ]")
+	assert.NotContains(t, out, "これ以上の段階はありません")
+}
+
+// **上回れない段階は選べない。**Web は選択肢から外すのに、CUI は 6 段階を常に
+// 並べるだけで、現在ビッドと突き合わせる暗算を強いていた (#4900)。
+func TestSixBidSoloCuiPresenter_MarksTheLadderStepsAlreadyTaken(t *testing.T) {
+	build := func(kind domain.SixBidSoloBidKind) string {
+		o := defaultSixBidSoloOpts()
+		o.phase = domain.SixBidSoloPhaseBid
+		o.highBid = &domain.SixBidSoloBid{Kind: kind}
+		return new(presenter.SixBidSoloCuiPresenter).Output(setupSixBidSoloCuiMock(o), nil)
+	}
+
+	// ミゼール(3)が立っている → 1〜3 は選べない、4〜6 は選べる。
+	out := build(domain.SixBidSoloBidMisere)
+	assert.Contains(t, out, "[1:ソロ]")
+	assert.Contains(t, out, "[3:ミゼール]")
+	assert.NotContains(t, out, "[4:ギャランティー・ソロ]")
+	assert.NotContains(t, out, "[6:コール・ソロ]")
+	// 序列そのものは残す。判断材料なので消さない。
+	assert.Contains(t, out, "4:ギャランティー・ソロ")
+	assert.NotContains(t, out, "これ以上の段階はありません")
+
+	// **最高段階まで取られたら破綻せず言い切る** (受け入れ条件3)。
+	top := build(domain.SixBidSoloBidCall)
+	assert.Contains(t, top, "[6:コール・ソロ]")
+	assert.Contains(t, top, "これ以上の段階はありません")
 }
 
 // **コール・ソロの指名札を見せる。**交換が起きたことが読めないと意味が通らない。

--- a/internal/i18n/locales/en/sixbidsolo.json
+++ b/internal/i18n/locales/en/sixbidsolo.json
@@ -19,6 +19,8 @@
   "trick": "Trick: {{cards}}",
   "playable": "Playable: {{indexes}}",
   "ladderTitle": "Bid ladder:",
+  "ladderTaken": "[{{bid}}]",
+  "ladderNoneLeft": "(nothing higher remains; pass only)",
   "bid.pass": "pass",
   "bid.solo": "Solo",
   "bid.heartSolo": "Heart Solo",

--- a/internal/i18n/locales/ja/sixbidsolo.json
+++ b/internal/i18n/locales/ja/sixbidsolo.json
@@ -19,6 +19,8 @@
   "trick": "場: {{cards}}",
   "playable": "出せる札: {{indexes}}",
   "ladderTitle": "ビッドの序列:",
+  "ladderTaken": "[{{bid}}]",
+  "ladderNoneLeft": "（これ以上の段階はありません。パスのみ）",
   "bid.pass": "パス",
   "bid.solo": "ソロ",
   "bid.heartSolo": "ハート・ソロ",


### PR DESCRIPTION
Closes #4900

## 背景

`SixBidSoloPage` は `BIDS.filter(b => state.highBid === null || b > state.highBid.kind)` で、上回れない選択肢をそもそもドロップダウンから外す。一方 `sixBidSoloLadderLine` は `SixBidSoloMinBid`〜`SixBidSoloMaxBid` の 6 段階を**常に無条件で**並べるだけで、現在の `highBid` は反映されない。CUI プレイヤーは契約行と序列表を自分で突き合わせることになる。

## 変更

上回れない段階を `[3:ミゼール]` のように角括弧で囲む。

```
ビッドの序列: [1:ソロ] < [2:ハート・ソロ] < [3:ミゼール] < 4:ギャランティー・ソロ < 5:… < 6:…
```

**一覧から消さずに残した。**issue は「除いたうえで『選択可能: n以上』を添える」案も挙げているが、序列そのもの（どの宣言がどの上か、目標点がいくつか）は消えた段階も含めて判断材料になる。ミゼールが取られたと分かることに意味がある。

最高段階（コール・ソロ）まで取られたら `（これ以上の段階はありません。パスのみ）` と言い切る（受け入れ条件3）。

## テスト

- 既存の序列テストに、**ビッドが無いときは印が付かない**ことを追加（受け入れ条件1）
- ミゼール(3)が立つと 1〜3 に印が付き 4〜6 には付かない／**序列の文字列自体は残る**こと
- 最高段階まで取られたときに破綻せず言い切ること

ネガティブコントロール: 印を付ける分岐を外すと落ちる。

`go test -tags test ./...` / `golangci-lint run ./internal/...` (0 issues) green。

## Test plan

- [ ] CI green