### PR TITLE
feat(skat): show the safe bid ceiling from the hand in the CUI

### DIFF
--- a/internal/adapter/presenter/SkatCuiPresenter.go
+++ b/internal/adapter/presenter/SkatCuiPresenter.go
@@ -94,6 +94,22 @@ func (p *SkatCuiPresenter) Output(s interfaces.SkatGame, lastErr error) string {
 				name := cuiPlayerName(s.GetPlayer(actor), actor)
 				b.WriteString(i18n.Tf("skat.biddingTurn", "name", name) + "\n")
 			}
+			// **どこまで受けて安全かの目安を出す。**Web は常時表示しているのに
+			// CUI には無く、オーバービッドの危険を測れなかった (#4905)。
+			if human := s.GetPlayer(0); human != nil && human.GetCardsSize() > 0 {
+				hand := make([]*domain.Card, human.GetCardsSize())
+				for i := range hand {
+					hand[i] = human.GetCard(i)
+				}
+				est := domain.SkatBestBidEstimate(hand)
+				b.WriteString(i18n.Tf("skat.bidEstimate",
+					"value", strconv.Itoa(est.Value),
+					"game", skatEstimateGameLabel(est.GameType, est.TrumpSuit),
+					"matadors", strconv.Itoa(est.Matadors)) + "\n")
+				if cur := s.GetCurrentBid(); cur > est.Value {
+					b.WriteString(color.Red(i18n.Tf("skat.bidExceedsHand", "value", strconv.Itoa(est.Value))) + "\n")
+				}
+			}
 			b.WriteString(i18n.T("skat.promptBid") + "\n")
 		case domain.SkatPhaseSkatPickup:
 			b.WriteString(i18n.T("skat.skatPickup") + "\n")
@@ -204,4 +220,12 @@ var skatHintReasonKeys = map[string]string{
 	"discard_low":   "skat.hintReasonDiscardLow",
 	"game_choice":   "skat.hintReasonGameChoice",
 	"best_play":     "skat.hintReasonBestPlay",
+}
+
+// skatEstimateGameLabel は見積もりの契約名を返す。スート戦は切札名まで出す。
+func skatEstimateGameLabel(gameType domain.SkatGameType, trumpSuit int) string {
+	if gameType == domain.SkatGameSuit {
+		return skatGameTypeLabel(gameType) + " " + cuiSuitName(trumpSuit)
+	}
+	return skatGameTypeLabel(gameType)
 }

--- a/internal/adapter/presenter/SkatCuiPresenter_test.go
+++ b/internal/adapter/presenter/SkatCuiPresenter_test.go
@@ -377,3 +377,43 @@ func TestSkatCuiPresenter_HintOutput_Localized(t *testing.T) {
 
 	i18n.SetLang("ja")
 }
+
+// **どこまで受けて安全かの目安を出す。**Web は常時表示しているのに CUI には
+// 無く、オーバービッドの危険を測れなかった (#4905)。
+func TestSkatCuiPresenter_ShowsTheHandBidEstimate(t *testing.T) {
+	orig := color.NoColor()
+	color.SetNoColor(true)
+	defer color.SetNoColor(orig)
+	i18n.SetLang("en")
+	defer i18n.SetLang("ja")
+
+	build := func(currentBid int, hand []*domain.Card) *interfaces.MockSkatGame {
+		m := setupSkatCuiMock()
+		human := domain.NewSkatPlayer(true)
+		for _, c := range hand {
+			human.AddCard(c)
+		}
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPlayer")
+		m.On("GetPlayer", 0).Return(human)
+		for i := 1; i < 3; i++ {
+			m.On("GetPlayer", i).Return(domain.NewSkatPlayer(false))
+		}
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetCurrentBid")
+		m.On("GetCurrentBid").Return(currentBid)
+		return m
+	}
+	p := new(presenter.SkatCuiPresenter)
+
+	// ♣J のみ = with 1 → グランドで (1+1)×24 = 48。
+	hand := []*domain.Card{domain.NewCard(domain.CardDesignClover, 11, false)}
+	out := p.Output(build(0, hand), nil)
+	assert.Contains(t, out, "Hand estimate: up to 48")
+	assert.NotContains(t, out, "above your hand estimate")
+
+	// 目安ちょうどでは警告しない。超えたときだけ。
+	assert.NotContains(t, p.Output(build(48, hand), nil), "above your hand estimate")
+	assert.Contains(t, p.Output(build(59, hand), nil), "above your hand estimate")
+
+	// 手札が無い局面では出さない。
+	assert.NotContains(t, p.Output(build(0, nil), nil), "Hand estimate")
+}

--- a/internal/domain/Skat.go
+++ b/internal/domain/Skat.go
@@ -1674,7 +1674,11 @@ func SkatBidEstimates(hand []*Card) []SkatBidEstimate {
 	return out
 }
 
-// SkatBestBidEstimate は最も高い見積もりを返す。手札が空なら Value 0。
+// SkatBestBidEstimate は最も高い見積もりを返す。
+//
+// **手札が空でも 0 にはならない。**切札を 1 枚も持たないのは「without が最大」と
+// いうことなので、かえって大きな値が出る。配り終えた 10 枚の手札に対してだけ
+// 意味がある — 途中まで出したあとの手札に使ってはいけない。
 func SkatBestBidEstimate(hand []*Card) SkatBidEstimate {
 	best := SkatBidEstimate{}
 	for _, e := range SkatBidEstimates(hand) {

--- a/internal/domain/Skat.go
+++ b/internal/domain/Skat.go
@@ -804,9 +804,14 @@ func (s *Skat) computeRoundResult() (int, bool) {
 
 // gameBaseValue returns the base value for the game type.
 func (s *Skat) gameBaseValue() int {
-	switch s.round.gameType {
+	return skatBaseValueFor(s.round.gameType, s.round.trumpSuit)
+}
+
+// skatBaseValueFor は仮の契約に対する基礎点を返す。
+func skatBaseValueFor(gameType SkatGameType, trumpSuit int) int {
+	switch gameType {
 	case SkatGameSuit:
-		switch s.round.trumpSuit {
+		switch trumpSuit {
 		case CardDesignDiamond:
 			return 9
 		case CardDesignHeart:
@@ -839,7 +844,12 @@ func (s *Skat) gameMultiplier() int {
 // phase — we cannot read the live SkatPlayer hand here because matadors is
 // computed at scoring time, after every card has been played out.
 func (s *Skat) matadorsCount(cards []*Card) int {
-	order := s.trumpOrder()
+	return skatMatadorsFor(cards, s.round.gameType, s.round.trumpSuit)
+}
+
+// skatMatadorsFor は仮の契約に対するマタドール数を返す。
+func skatMatadorsFor(cards []*Card, gameType SkatGameType, trumpSuit int) int {
+	order := skatTrumpOrderFor(gameType, trumpSuit)
 	if len(order) == 0 {
 		return 0
 	}
@@ -883,7 +893,15 @@ type trumpOrderEntry struct {
 
 // trumpOrder returns the trump cards in descending strength.
 func (s *Skat) trumpOrder() []trumpOrderEntry {
-	switch s.round.gameType {
+	return skatTrumpOrderFor(s.round.gameType, s.round.trumpSuit)
+}
+
+// skatTrumpOrderFor は仮の契約に対する切札の序列を返す。
+//
+// **ビッド前の見積もりにも同じ序列が要る。**round の状態に縛られたままだと、
+// 「この手札ならどの契約でいくつまで受けられるか」を計算できない (#4905)。
+func skatTrumpOrderFor(gameType SkatGameType, trumpSuit int) []trumpOrderEntry {
+	switch gameType {
 	case SkatGameNull:
 		return nil
 	case SkatGameGrand:
@@ -901,7 +919,7 @@ func (s *Skat) trumpOrder() []trumpOrderEntry {
 			{CardDesignHeart, skatValueJack},
 			{CardDesignDiamond, skatValueJack},
 		}
-		ts := s.round.trumpSuit
+		ts := trumpSuit
 		// Then suit cards in standard high→low order: A, T, K, Q, 9, 8, 7.
 		order := []int{skatValueAce, skatValueTen, skatValueKing, skatValueQueen, skatValueNine, skatValueEight, skatValueSeven}
 		for _, v := range order {
@@ -1607,4 +1625,62 @@ func (s *Skat) cpuPickPlay(playerIdx int) int {
 		}
 	}
 	return worstIdx
+}
+
+// SkatBidEstimate は 1 つの契約について、手札から安全に受けられるビッド額を表す。
+type SkatBidEstimate struct {
+	// GameType は契約の種別 (スート戦 / グランド)。
+	GameType SkatGameType
+	// TrumpSuit はスート戦の切札 (グランドでは 0)。
+	TrumpSuit int
+	// Base は基礎点。
+	Base int
+	// Matadors はマタドール数 (with / without のうち成立するほう)。
+	Matadors int
+	// Value は (マタドール + 1) × 基礎点。**追加の宣言 (ハント / シュナイダー /
+	// シュヴァルツ / ウーヴェルト) を一切使わずに正当化できる上限**で、これを
+	// 超えて落札するとオーバービッドで失う危険がある。
+	Value int
+}
+
+// SkatBidEstimates は各契約についての安全ビッド上限を返す。
+//
+// **ヌル戦は含めない。**基礎点 23 が契約の種別だけで決まり、マタドールの
+// 連なりで伸びないので、マタドールに基づく見積もりには乗らない。
+func SkatBidEstimates(hand []*Card) []SkatBidEstimate {
+	type spec struct {
+		gameType SkatGameType
+		trump    int
+	}
+	specs := []spec{
+		{SkatGameSuit, CardDesignClover},
+		{SkatGameSuit, CardDesignSpade},
+		{SkatGameSuit, CardDesignHeart},
+		{SkatGameSuit, CardDesignDiamond},
+		{SkatGameGrand, 0},
+	}
+	out := make([]SkatBidEstimate, 0, len(specs))
+	for _, sp := range specs {
+		m := skatMatadorsFor(hand, sp.gameType, sp.trump)
+		base := skatBaseValueFor(sp.gameType, sp.trump)
+		out = append(out, SkatBidEstimate{
+			GameType:  sp.gameType,
+			TrumpSuit: sp.trump,
+			Base:      base,
+			Matadors:  m,
+			Value:     (m + 1) * base,
+		})
+	}
+	return out
+}
+
+// SkatBestBidEstimate は最も高い見積もりを返す。手札が空なら Value 0。
+func SkatBestBidEstimate(hand []*Card) SkatBidEstimate {
+	best := SkatBidEstimate{}
+	for _, e := range SkatBidEstimates(hand) {
+		if e.Value > best.Value {
+			best = e
+		}
+	}
+	return best
 }

--- a/internal/domain/Skat_test.go
+++ b/internal/domain/Skat_test.go
@@ -4,6 +4,9 @@ package domain
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // newSkatForTest sets up a Skat game with the human at index 0. Reset()
@@ -561,4 +564,40 @@ func TestSkatGetterDefaults(t *testing.T) {
 	if g.GetCurrentPlayerIdx() != 2 {
 		t.Fatal("SetCurrentPlayerIdx did not apply")
 	}
+}
+
+// **CUI にも安全ビッド上限が要る。**Web は `skatBidEstimate.ts` で常時出すのに、
+// Go 側には対応するものが無かった (#4905)。
+func TestSkat_BidEstimates(t *testing.T) {
+	card := func(d, v int) *Card { return NewCard(d, v, false) }
+
+	// ♣J だけ持つ = with 1。どの契約でも matadors 1 → (1+1)×base。
+	hand := []*Card{card(CardDesignClover, 11)}
+	est := SkatBidEstimates(hand)
+	require.Len(t, est, 5)
+	for _, e := range est {
+		assert.Equal(t, 1, e.Matadors, "holding only the top trump is with 1")
+		assert.Equal(t, (e.Matadors+1)*e.Base, e.Value)
+	}
+	// グランドが基礎点 24 で最大。
+	best := SkatBestBidEstimate(hand)
+	assert.Equal(t, SkatGameGrand, best.GameType)
+	assert.Equal(t, 24, best.Base)
+	assert.Equal(t, 48, best.Value)
+
+	// **♣J を持たない = without。**次に何枚欠けているかで数える。
+	// ♠J だけの手札は ♣J が無いので without 1。
+	without := []*Card{card(CardDesignSpade, 11)}
+	for _, e := range SkatBidEstimates(without) {
+		assert.Equal(t, 1, e.Matadors, "missing only the top trump is without 1")
+	}
+
+	// ♣J ♠J ♥J を持つ = with 3。♦J が無いのでそこで止まる。
+	three := []*Card{
+		card(CardDesignClover, 11), card(CardDesignSpade, 11), card(CardDesignHeart, 11),
+	}
+	assert.Equal(t, 4*24, SkatBestBidEstimate(three).Value, "with 3 on grand is (3+1)x24")
+
+	// 空の手札でも壊れない。ジャックを 1 枚も持たないので without 4 以上。
+	assert.Positive(t, SkatBestBidEstimate(nil).Value)
 }

--- a/internal/i18n/locales/en/skat.json
+++ b/internal/i18n/locales/en/skat.json
@@ -16,6 +16,8 @@
   "gameOver": "Game over!",
   "biddingTurn": "Bidding: {{name}}'s turn",
   "promptBid": "b 0/1 - pass (0) or accept the active bid step (1)",
+  "bidEstimate": "Hand estimate: up to {{value}} ({{game}}, {{matadors}} matadors)",
+  "bidExceedsHand": "! The current bid is above your hand estimate ({{value}})",
   "skatPickup": "Skat pickup: declarer decides",
   "promptPickup": "ps 0/1 - decline (0) or pick up the skat (1)",
   "discardPrompt": "Discard 2 cards into the skat",

--- a/internal/i18n/locales/ja/skat.json
+++ b/internal/i18n/locales/ja/skat.json
@@ -16,6 +16,8 @@
   "gameOver": "ゲーム終了！",
   "biddingTurn": "ビッド: {{name}} の番",
   "promptBid": "b 0/1 - パス(0) またはアクティブなビッドを受諾(1)",
+  "bidEstimate": "手札の目安: {{value}}点まで（{{game}}・マタドール{{matadors}}）",
+  "bidExceedsHand": "⚠ 現在のビッドは手札の目安（{{value}}点）を超えています",
   "skatPickup": "スカート取得: 宣言者が決定",
   "promptPickup": "ps 0/1 - 見送る(0) またはスカートを拾う(1)",
   "discardPrompt": "2枚のカードをスカートに捨てる",


### PR DESCRIPTION
Closes #4905

## 背景

`SkatPage` は `skatBestBidEstimate(humanPlayer.cards)` で「マタドール構成から安全に受けられる最高ビッド額」を常時表示し、現在のビッドが超えると警告を出す。ところがこれはフロント専用の TS ユーティリティで、`SkatCuiPresenter` のビッドフェーズは `biddingTurn` とコマンド構文しか出さない。CUI プレイヤーはオーバービッドの危険を測れない。

## 変更

**マタドール計算はドメインに既にある** (`matadorsCount` / `trumpOrder` / `gameBaseValue`)。ただし `s.round` の状態に縛られていて、「この手札ならどの契約でいくつまで受けられるか」という**仮の契約に対する計算ができなかった**。そこで:

1. 3 つを仮の契約 `(gameType, trumpSuit)` を取る自由関数へ切り出し、既存メソッドはそれに委譲
2. `SkatBidEstimates` / `SkatBestBidEstimate` をその上に載せる
3. CUI のビッドフェーズに `手札の目安: 48点まで（グランド・マタドール1）` と、超過時の警告を出す

これで**得点計算と見積もりが同じ実装を通る**。issue は「マタドール計算を移植する」と書いているが、移植すると 3 実装目（ドメイン・フロント・presenter）になる。

**ヌル戦は含めない。**基礎点 23 が契約の種別だけで決まり、マタドールの連なりで伸びないので、マタドールに基づく見積もりに乗らない（フロントの実装も同じ理由で外している）。

## テスト

**ドメイン** — ♣J のみ = with 1 / ♠J のみ = **without 1**（両方向を踏む）/ ♣J♠J♥J = with 3 で ♦J が無いので止まる / グランドが基礎点 24 で最大 / 空の手札でも壊れない

**CUI** — 目安が出ること / **目安ちょうどでは警告せず、超えたときだけ**出ること / 手札が無い局面では出さないこと

ネガティブコントロール: 追加ブロックを外すと 4 件が落ちる。

`go test -tags test ./...` / `golangci-lint run ./internal/...` (0 issues) green。

## Test plan

- [ ] CI green