### PR TITLE
feat(sevenbridge): advise on pon and chi during the draw phase

### DIFF
--- a/internal/adapter/presenter/SevenBridgeCuiPresenter.go
+++ b/internal/adapter/presenter/SevenBridgeCuiPresenter.go
@@ -139,21 +139,24 @@ func sevenBridgeDrawHint(g interfaces.SevenBridgeGame) string {
 	if human == nil {
 		return i18n.T("sevenbridge.hintNotYourTurn") + "\n"
 	}
-	label := func(is []int) string {
+	// idxs と cards は近隣の hintMeld / hintDiscard と同じく別々に渡す。
+	label := func(is []int) (string, string) {
 		idxStrs := make([]string, len(is))
 		cards := make([]string, len(is))
 		for i, hi := range is {
 			idxStrs[i] = strconv.Itoa(hi)
 			cards[i] = cuiCardStr(human.GetCard(hi))
 		}
-		return strings.Join(idxStrs, ", ") + " (" + strings.Join(cards, ",") + ")"
+		return strings.Join(idxStrs, ", "), strings.Join(cards, ",")
 	}
 	// **ポンが先。**同ランク 3 枚は連番より確実に面子になる。
 	if pon := g.SuggestPon(idx); len(pon) > 0 {
-		return color.Yellow(i18n.Tf("sevenbridge.hintPon", "cards", label(pon))) + "\n"
+		idxs, cards := label(pon)
+		return color.Yellow(i18n.Tf("sevenbridge.hintPon", "idxs", idxs, "cards", cards)) + "\n"
 	}
 	if chi := g.SuggestChi(idx); len(chi) > 0 {
-		return color.Yellow(i18n.Tf("sevenbridge.hintChi", "cards", label(chi))) + "\n"
+		idxs, cards := label(chi)
+		return color.Yellow(i18n.Tf("sevenbridge.hintChi", "idxs", idxs, "cards", cards)) + "\n"
 	}
 	return i18n.T("sevenbridge.hintDraw") + "\n"
 }

--- a/internal/adapter/presenter/SevenBridgeCuiPresenter.go
+++ b/internal/adapter/presenter/SevenBridgeCuiPresenter.go
@@ -95,6 +95,10 @@ func (p *SevenBridgeCuiPresenter) Output(g interfaces.SevenBridgeGame, lastErr e
 // HintOutput suggests a meld (or a discard when no meld is available) for the
 // human's play phase, reusing the shared domain suggestion logic.
 func (p *SevenBridgeCuiPresenter) HintOutput(g interfaces.SevenBridgeGame) string {
+	// **ドローフェーズこそ一番迷う。**ポン・チーの判断を無支援にしていた (#4904)。
+	if g.GetPhase() == domain.SevenBridgePhaseDraw && g.IsHumanTurn() {
+		return sevenBridgeDrawHint(g)
+	}
 	if g.GetPhase() != domain.SevenBridgePhasePlay || !g.IsHumanTurn() {
 		return i18n.T("sevenbridge.hintNotYourTurn") + "\n"
 	}
@@ -123,4 +127,33 @@ func (p *SevenBridgeCuiPresenter) HintOutput(g interfaces.SevenBridgeGame) strin
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *SevenBridgeCuiPresenter) ActionLogOutput(g interfaces.SevenBridgeGame) string {
 	return actionLogOutputText(g)
+}
+
+// sevenBridgeDrawHint はドローフェーズの助言を返す。
+//
+// ポンとチーの判定は claim 経路と同じ `SuggestPon` / `SuggestChi` を通す。
+// 別に書くと、案内した組が拒否されることになる。
+func sevenBridgeDrawHint(g interfaces.SevenBridgeGame) string {
+	idx := g.GetCurrentPlayerIdx()
+	human := g.GetPlayer(idx)
+	if human == nil {
+		return i18n.T("sevenbridge.hintNotYourTurn") + "\n"
+	}
+	label := func(is []int) string {
+		idxStrs := make([]string, len(is))
+		cards := make([]string, len(is))
+		for i, hi := range is {
+			idxStrs[i] = strconv.Itoa(hi)
+			cards[i] = cuiCardStr(human.GetCard(hi))
+		}
+		return strings.Join(idxStrs, ", ") + " (" + strings.Join(cards, ",") + ")"
+	}
+	// **ポンが先。**同ランク 3 枚は連番より確実に面子になる。
+	if pon := g.SuggestPon(idx); len(pon) > 0 {
+		return color.Yellow(i18n.Tf("sevenbridge.hintPon", "cards", label(pon))) + "\n"
+	}
+	if chi := g.SuggestChi(idx); len(chi) > 0 {
+		return color.Yellow(i18n.Tf("sevenbridge.hintChi", "cards", label(chi))) + "\n"
+	}
+	return i18n.T("sevenbridge.hintDraw") + "\n"
 }

--- a/internal/adapter/presenter/SevenBridgeCuiPresenter_test.go
+++ b/internal/adapter/presenter/SevenBridgeCuiPresenter_test.go
@@ -182,7 +182,39 @@ func TestSevenBridgeCuiPresenter_HintOutput(t *testing.T) {
 	t.Run("declines outside the human's play phase", func(t *testing.T) {
 		m := new(interfaces.MockSevenBridgeGame)
 		m.On("GetPhase").Return(domain.SevenBridgePhaseDraw)
+		// **ドローフェーズでも人間の手番でなければ断る。**手番のときは
+		// ポン・チーを案内するようになった (#4904)。
+		m.On("IsHumanTurn").Return(false)
 		assert.Contains(t, p.HintOutput(m), "プレイフェーズではありません")
+	})
+
+	// **ドローフェーズこそ一番迷う。**ポン・チーの判断を無支援にしていた (#4904)。
+	t.Run("advises pon, chi or drawing during the draw phase", func(t *testing.T) {
+		build := func(pon, chi []int) *interfaces.MockSevenBridgeGame {
+			m := new(interfaces.MockSevenBridgeGame)
+			m.On("GetPhase").Return(domain.SevenBridgePhaseDraw)
+			m.On("IsHumanTurn").Return(true)
+			m.On("GetCurrentPlayerIdx").Return(0)
+			human := domain.NewSevenBridgePlayer(true)
+			human.AddCard(domain.NewCard(domain.CardDesignSpade, 5, false))
+			human.AddCard(domain.NewCard(domain.CardDesignHeart, 5, false))
+			m.On("GetPlayer", 0).Return(human)
+			m.On("SuggestPon", 0).Return(pon)
+			m.On("SuggestChi", 0).Return(chi)
+			return m
+		}
+
+		// **ポンが先。**同ランク 3 枚は連番より確実に面子になる。
+		both := p.HintOutput(build([]int{0, 1}, []int{0, 1}))
+		assert.Contains(t, both, "ポンできます")
+		assert.NotContains(t, both, "チーできます")
+
+		assert.Contains(t, p.HintOutput(build(nil, []int{0, 1})), "チーできます")
+
+		// どちらも無ければ山札を勧める。黙らない。
+		none := p.HintOutput(build(nil, nil))
+		assert.Contains(t, none, "山札から引きましょう")
+		assert.NotContains(t, none, "プレイフェーズではありません")
 	})
 }
 

--- a/internal/domain/SevenBridge.go
+++ b/internal/domain/SevenBridge.go
@@ -692,6 +692,35 @@ func (g *SevenBridge) findChiIndices(playerIdx int, top *Card) ([]int, bool) {
 	return nil, false
 }
 
+// SuggestPon は playerIdx が捨て札の上札でポンできる手札インデックスを返す。
+// できなければ nil。**判定は claim 経路と同じ findPonIndices を通す** — 別に
+// 書くと、案内した組が拒否されることになる (#4904)。
+func (g *SevenBridge) SuggestPon(playerIdx int) []int {
+	top := g.GetDiscardTop()
+	if top == nil || playerIdx < 0 || playerIdx >= len(g.players) {
+		return nil
+	}
+	idx, ok := g.findPonIndices(playerIdx, top)
+	if !ok {
+		return nil
+	}
+	return idx
+}
+
+// SuggestChi は playerIdx が捨て札の上札でチーできる手札インデックスを返す。
+// できなければ nil。
+func (g *SevenBridge) SuggestChi(playerIdx int) []int {
+	top := g.GetDiscardTop()
+	if top == nil || playerIdx < 0 || playerIdx >= len(g.players) {
+		return nil
+	}
+	idx, ok := g.findChiIndices(playerIdx, top)
+	if !ok {
+		return nil
+	}
+	return idx
+}
+
 // findBestMeldIndices プレイヤーの手札から最大のメルド（3 枚以上）を探す
 // SuggestMeld は playerIdx の最善メルド (手札インデックス) を返す。メルドできる組が
 // 無ければ nil。CUI ヒント用に findBestMeldIndices を公開する薄いラッパー。

--- a/internal/domain/SevenBridge_test.go
+++ b/internal/domain/SevenBridge_test.go
@@ -1256,3 +1256,53 @@ func TestSevenBridge_CpuDraw_FromDiscardViaChi(t *testing.T) {
 	g.CpuPlay()
 	assert.Equal(t, 1, g.GetPlayer(1).GetMeldCount())
 }
+
+// **判定は claim 経路と同じ finder を通す。**別に書くと、案内した組が拒否される
+// ことになる (#4904)。
+func TestSevenBridge_SuggestPonAndChi(t *testing.T) {
+	g := newTestSevenBridge()
+	g.Reset()
+	g.SetDiscardPile([]*domain.Card{domain.NewCard(domain.CardDesignHeart, 7, true)})
+
+	// 同ランク 2 枚 → ポン。
+	setHand(g.GetPlayer(0), []*domain.Card{
+		domain.NewCard(domain.CardDesignSpade, 7, true),
+		domain.NewCard(domain.CardDesignClover, 7, true),
+		domain.NewCard(domain.CardDesignDiamond, 2, true),
+	})
+	assert.Equal(t, []int{0, 1}, g.SuggestPon(0))
+	// **チーは同スートの連番。**♥7 に対して ♠7 ♣7 は繋がらない。
+	assert.Nil(t, g.SuggestChi(0))
+
+	// 同スートの連番 2 枚 → チー。ポンは成立しない。
+	setHand(g.GetPlayer(0), []*domain.Card{
+		domain.NewCard(domain.CardDesignHeart, 5, true),
+		domain.NewCard(domain.CardDesignHeart, 6, true),
+		domain.NewCard(domain.CardDesignSpade, 13, true),
+	})
+	assert.Nil(t, g.SuggestPon(0))
+	assert.Equal(t, []int{0, 1}, g.SuggestChi(0))
+
+	// またぎ (6, 8) でもチーになる。
+	setHand(g.GetPlayer(0), []*domain.Card{
+		domain.NewCard(domain.CardDesignHeart, 6, true),
+		domain.NewCard(domain.CardDesignHeart, 8, true),
+	})
+	assert.Equal(t, []int{0, 1}, g.SuggestChi(0))
+
+	// どちらも成立しない手札。
+	setHand(g.GetPlayer(0), []*domain.Card{
+		domain.NewCard(domain.CardDesignSpade, 2, true),
+		domain.NewCard(domain.CardDesignClover, 13, true),
+	})
+	assert.Nil(t, g.SuggestPon(0))
+	assert.Nil(t, g.SuggestChi(0))
+
+	// 捨て札が無ければどちらも nil。範囲外の席も nil。
+	g.SetDiscardPile(nil)
+	assert.Nil(t, g.SuggestPon(0))
+	assert.Nil(t, g.SuggestChi(0))
+	g.SetDiscardPile([]*domain.Card{domain.NewCard(domain.CardDesignHeart, 7, true)})
+	assert.Nil(t, g.SuggestPon(99))
+	assert.Nil(t, g.SuggestChi(-1))
+}

--- a/internal/domain/interfaces/sevenbridge.go
+++ b/internal/domain/interfaces/sevenbridge.go
@@ -25,6 +25,10 @@ type SevenBridgeGame interface {
 	PlayerDiscard(cardIndex int) error
 	// SuggestMeld playerIdx の最善メルド (手札インデックス) を返す。無ければ nil
 	SuggestMeld(playerIdx int) []int
+	// SuggestPon playerIdx がポンできる手札インデックスを返す。無ければ nil
+	SuggestPon(playerIdx int) []int
+	// SuggestChi playerIdx がチーできる手札インデックスを返す。無ければ nil
+	SuggestChi(playerIdx int) []int
 	// SuggestDiscard playerIdx の推奨ディスカード手札インデックスを返す。無ければ -1
 	SuggestDiscard(playerIdx int) int
 	// CpuPlay CPU プレイヤーが 1 ターン実行する

--- a/internal/domain/interfaces/sevenbridge_mock.go
+++ b/internal/domain/interfaces/sevenbridge_mock.go
@@ -62,3 +62,21 @@ func (m *MockSevenBridgeGame) GetActionLog() []*domain.ActionLogEntry {
 }
 func (m *MockSevenBridgeGame) GetRoundWinnerIdx() int   { return m.Called().Int(0) }
 func (m *MockSevenBridgeGame) GetClaimedThisTurn() bool { return m.Called().Bool(0) }
+
+// SuggestPon モック
+func (m *MockSevenBridgeGame) SuggestPon(playerIdx int) []int {
+	ret := m.Called(playerIdx)
+	if v, ok := ret.Get(0).([]int); ok {
+		return v
+	}
+	return nil
+}
+
+// SuggestChi モック
+func (m *MockSevenBridgeGame) SuggestChi(playerIdx int) []int {
+	ret := m.Called(playerIdx)
+	if v, ok := ret.Get(0).([]int); ok {
+		return v
+	}
+	return nil
+}

--- a/internal/i18n/locales/en/sevenbridge.json
+++ b/internal/i18n/locales/en/sevenbridge.json
@@ -28,5 +28,8 @@
   "hintMeld": "Suggestion: meld hand [{{idxs}}] ({{cards}}) with m {{idxs}}",
   "hintDiscard": "Suggestion: discard hand {{idx}} ({{card}}) with d {{idx}}",
   "hintNoMove": "No move can be recommended.",
-  "hintNotYourTurn": "It is not your play phase right now."
+  "hintNotYourTurn": "It is not your play phase right now.",
+  "hintPon": "You can pon with {{cards}}",
+  "hintChi": "You can chi with {{cards}}",
+  "hintDraw": "The discard is no use here; draw from the stock."
 }

--- a/internal/i18n/locales/en/sevenbridge.json
+++ b/internal/i18n/locales/en/sevenbridge.json
@@ -29,7 +29,7 @@
   "hintDiscard": "Suggestion: discard hand {{idx}} ({{card}}) with d {{idx}}",
   "hintNoMove": "No move can be recommended.",
   "hintNotYourTurn": "It is not your play phase right now.",
-  "hintPon": "You can pon with {{cards}}",
-  "hintChi": "You can chi with {{cards}}",
+  "hintPon": "You can pon with {{idxs}} ({{cards}})",
+  "hintChi": "You can chi with {{idxs}} ({{cards}})",
   "hintDraw": "The discard is no use here; draw from the stock."
 }

--- a/internal/i18n/locales/ja/sevenbridge.json
+++ b/internal/i18n/locales/ja/sevenbridge.json
@@ -28,5 +28,8 @@
   "hintMeld": "推奨: 手札 [{{idxs}}] ({{cards}}) でメルド (m {{idxs}})",
   "hintDiscard": "推奨: 手札 {{idx}} ({{card}}) を捨てる (d {{idx}})",
   "hintNoMove": "推奨できる手がありません。",
-  "hintNotYourTurn": "今はあなたのプレイフェーズではありません。"
+  "hintNotYourTurn": "今はあなたのプレイフェーズではありません。",
+  "hintPon": "ポンできます: 手札 {{cards}}",
+  "hintChi": "チーできます: 手札 {{cards}}",
+  "hintDraw": "捨て札は使えません。山札から引きましょう。"
 }

--- a/internal/i18n/locales/ja/sevenbridge.json
+++ b/internal/i18n/locales/ja/sevenbridge.json
@@ -29,7 +29,7 @@
   "hintDiscard": "推奨: 手札 {{idx}} ({{card}}) を捨てる (d {{idx}})",
   "hintNoMove": "推奨できる手がありません。",
   "hintNotYourTurn": "今はあなたのプレイフェーズではありません。",
-  "hintPon": "ポンできます: 手札 {{cards}}",
-  "hintChi": "チーできます: 手札 {{cards}}",
+  "hintPon": "ポンできます: 手札 {{idxs}} ({{cards}})",
+  "hintChi": "チーできます: 手札 {{idxs}} ({{cards}})",
   "hintDraw": "捨て札は使えません。山札から引きましょう。"
 }


### PR DESCRIPTION
Closes #4904

## 背景

`SevenBridgeCuiPresenter.HintOutput` は冒頭で

```go
if g.GetPhase() != domain.SevenBridgePhasePlay || !g.IsHumanTurn() {
    return i18n.T("sevenbridge.hintNotYourTurn")
}
```

としており、**ドローフェーズは自分の手番でもヒントを返さない**。Web の `getSevenbridgeHint` はポン・チーの機会を案内するので、ゲーム中で一番迷う局面だけ CUI が無支援だった。

## 変更

ドローフェーズ + 人間の手番のときに助言を返す。**判定は claim 経路と同じ `findPonIndices` / `findChiIndices`** を `SuggestPon` / `SuggestChi` として公開して通す。issue は「`getSevenbridgeHint` と同じロジックを Go 側にも実装する」と書いているが、移植すると 3 実装目（ドメイン・フロント・presenter）になるうえ、**案内した組が claim で拒否されうる**。

- **ポンを先に出す。**同ランク 3 枚は連番より確実に面子になる
- どちらも無ければ「山札から引きましょう」。黙って `hintNotYourTurn` を返すより情報がある

## テスト

- 既存の「プレイフェーズ以外は断る」テストは**ドローフェーズを例に使っていた**ので、人間の手番でない場合に変更（挙動が変わった側を明示）
- ポンとチーが両方成立するとき**ポンだけが出る**こと
- チーのみのとき
- どちらも無ければ山札を勧め、`hintNotYourTurn` にはならないこと

ネガティブコントロール: 追加した分岐を外すと 5 件が落ちる。

`go test -tags test ./...` / `golangci-lint run ./internal/...` (0 issues) green。

## Test plan

- [ ] CI green