### PR TITLE
feat(bideuchre): show the legal bid range in the CUI

### DIFF
--- a/internal/adapter/presenter/BidEuchreCuiPresenter.go
+++ b/internal/adapter/presenter/BidEuchreCuiPresenter.go
@@ -118,16 +118,10 @@ func (p *BidEuchreCuiPresenter) Output(g interfaces.BidEuchreGame, lastErr error
 			idx := g.GetBidPlayerIdx()
 			b.WriteString(i18n.Tf("bideuchre.promptBid", "name", cuiPlayerName(g.GetPlayer(idx), idx)) + "\n")
 			// **「立っている宣言＋1、親なら同額」を毎回暗算させない。**Web は
-			// 選べる値だけをドロップダウンに詰めている (#4899)。
-			floor := domain.BidEuchreMinBid
-			if high := g.GetHighBid(); high != nil && high.Value > 0 {
-				floor = high.Value + 1
-				// **親だけは同額で奪える。**
-				if idx == g.GetDealerIdx() {
-					floor = high.Value
-				}
-			}
-			if floor <= domain.BidEuchreMaxBid {
+			// 選べる値だけをドロップダウンに詰めている (#4899)。判定はドメインの
+			// BidEuchreCanBid を通す — 規則を presenter に書き写すと、案内した額が
+			// 拒否されることになる。
+			if floor, ok := g.BidEuchreMinLegalBid(idx); ok {
 				b.WriteString(i18n.Tf("bideuchre.bidRange",
 					"min", strconv.Itoa(floor),
 					"max", strconv.Itoa(domain.BidEuchreMaxBid)) + "\n")

--- a/internal/adapter/presenter/BidEuchreCuiPresenter.go
+++ b/internal/adapter/presenter/BidEuchreCuiPresenter.go
@@ -117,6 +117,23 @@ func (p *BidEuchreCuiPresenter) Output(g interfaces.BidEuchreGame, lastErr error
 		case domain.BidEuchrePhaseBid:
 			idx := g.GetBidPlayerIdx()
 			b.WriteString(i18n.Tf("bideuchre.promptBid", "name", cuiPlayerName(g.GetPlayer(idx), idx)) + "\n")
+			// **「立っている宣言＋1、親なら同額」を毎回暗算させない。**Web は
+			// 選べる値だけをドロップダウンに詰めている (#4899)。
+			floor := domain.BidEuchreMinBid
+			if high := g.GetHighBid(); high != nil && high.Value > 0 {
+				floor = high.Value + 1
+				// **親だけは同額で奪える。**
+				if idx == g.GetDealerIdx() {
+					floor = high.Value
+				}
+			}
+			if floor <= domain.BidEuchreMaxBid {
+				b.WriteString(i18n.Tf("bideuchre.bidRange",
+					"min", strconv.Itoa(floor),
+					"max", strconv.Itoa(domain.BidEuchreMaxBid)) + "\n")
+			} else {
+				b.WriteString(i18n.T("bideuchre.bidRangeNone") + "\n")
+			}
 			b.WriteString(i18n.T("bideuchre.promptBidHelp") + "\n")
 		case domain.BidEuchrePhaseChooseTrump:
 			idx := g.GetDeclarerIdx()

--- a/internal/adapter/presenter/BidEuchreCuiPresenter_test.go
+++ b/internal/adapter/presenter/BidEuchreCuiPresenter_test.go
@@ -4,6 +4,7 @@ package presenter_test
 
 import (
 	"errors"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -195,4 +196,37 @@ func TestBidEuchreCuiPresenter_ActionLogOutput(t *testing.T) {
 	m := setupBidEuchreCuiMock(defaultBidEuchreOpts())
 	m.On("GetActionLog").Return([]*domain.ActionLogEntry{})
 	assert.NotNil(t, new(presenter.BidEuchreCuiPresenter).ActionLogOutput(m))
+}
+
+// **「立っている宣言＋1、親なら同額」を毎回暗算させない** (#4899)。
+func TestBidEuchreCuiPresenter_ShowsTheLegalBidRange(t *testing.T) {
+	p := new(presenter.BidEuchreCuiPresenter)
+
+	build := func(high *domain.BidEuchreBid, bidder int) string {
+		o := defaultBidEuchreOpts()
+		o.phase = domain.BidEuchrePhaseBid
+		o.highBid = high
+		m := setupBidEuchreCuiMock(o)
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetBidPlayerIdx")
+		m.On("GetBidPlayerIdx").Return(bidder)
+		return p.Output(m, nil)
+	}
+
+	// 宣言が無ければ最低値から (受け入れ条件1)。
+	assert.Contains(t, build(nil, 1),
+		"有効な入札: "+strconv.Itoa(domain.BidEuchreMinBid)+"〜"+strconv.Itoa(domain.BidEuchreMaxBid))
+
+	// 非ディーラーは +1 から (受け入れ条件2)。
+	assert.Contains(t, build(&domain.BidEuchreBid{Player: 0, Value: 4}, 1), "有効な入札: 5〜")
+
+	// **親だけは同額で奪える** (受け入れ条件3)。ディーラーは席 3。
+	assert.Contains(t, build(&domain.BidEuchreBid{Player: 0, Value: 4}, 3), "有効な入札: 4〜")
+
+	// 上限まで宣言されたら、非ディーラーには選べる値が無い。
+	top := build(&domain.BidEuchreBid{Player: 0, Value: domain.BidEuchreMaxBid}, 1)
+	assert.Contains(t, top, "これ以上の入札はできません")
+	assert.NotContains(t, top, "有効な入札:")
+
+	// 同じ状況でも親は同額で奪えるので、範囲が出る。
+	assert.Contains(t, build(&domain.BidEuchreBid{Player: 0, Value: domain.BidEuchreMaxBid}, 3), "有効な入札:")
 }

--- a/internal/adapter/presenter/BidEuchreCuiPresenter_test.go
+++ b/internal/adapter/presenter/BidEuchreCuiPresenter_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
@@ -37,6 +38,7 @@ func setupBidEuchreCuiMock(o bidEuchreMockOpts) *interfaces.MockBidEuchreGame {
 	m.On("GetGameEndFlag").Return(o.gameEnd)
 	m.On("GetWinnerTeam").Return(o.winner)
 	m.On("GetHighBid").Return(o.highBid)
+	m.On("BidEuchreMinLegalBid", mock.Anything).Return(domain.BidEuchreMinBid, true).Maybe()
 	m.On("GetLastResult").Return(o.result)
 	m.On("GetPlayers").Return(players)
 	m.On("IsHumanTurn").Return(true)
@@ -202,31 +204,25 @@ func TestBidEuchreCuiPresenter_ActionLogOutput(t *testing.T) {
 func TestBidEuchreCuiPresenter_ShowsTheLegalBidRange(t *testing.T) {
 	p := new(presenter.BidEuchreCuiPresenter)
 
-	build := func(high *domain.BidEuchreBid, bidder int) string {
+	// **判定そのものはドメインでテストする** (TestBidEuchre_MinLegalBid)。
+	// ここは「返ってきた下限をそのまま出す / 無ければパスのみと言う」だけを見る。
+	build := func(floor int, ok bool, bidder int) string {
 		o := defaultBidEuchreOpts()
 		o.phase = domain.BidEuchrePhaseBid
-		o.highBid = high
 		m := setupBidEuchreCuiMock(o)
 		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetBidPlayerIdx")
 		m.On("GetBidPlayerIdx").Return(bidder)
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "BidEuchreMinLegalBid")
+		m.On("BidEuchreMinLegalBid", bidder).Return(floor, ok)
 		return p.Output(m, nil)
 	}
 
-	// 宣言が無ければ最低値から (受け入れ条件1)。
-	assert.Contains(t, build(nil, 1),
+	assert.Contains(t, build(domain.BidEuchreMinBid, true, 1),
 		"有効な入札: "+strconv.Itoa(domain.BidEuchreMinBid)+"〜"+strconv.Itoa(domain.BidEuchreMaxBid))
+	assert.Contains(t, build(5, true, 1), "有効な入札: 5〜")
 
-	// 非ディーラーは +1 から (受け入れ条件2)。
-	assert.Contains(t, build(&domain.BidEuchreBid{Player: 0, Value: 4}, 1), "有効な入札: 5〜")
-
-	// **親だけは同額で奪える** (受け入れ条件3)。ディーラーは席 3。
-	assert.Contains(t, build(&domain.BidEuchreBid{Player: 0, Value: 4}, 3), "有効な入札: 4〜")
-
-	// 上限まで宣言されたら、非ディーラーには選べる値が無い。
-	top := build(&domain.BidEuchreBid{Player: 0, Value: domain.BidEuchreMaxBid}, 1)
+	// 選べる値が無ければ、範囲を出さずにパスのみと言う。
+	top := build(0, false, 1)
 	assert.Contains(t, top, "これ以上の入札はできません")
 	assert.NotContains(t, top, "有効な入札:")
-
-	// 同じ状況でも親は同額で奪えるので、範囲が出る。
-	assert.Contains(t, build(&domain.BidEuchreBid{Player: 0, Value: domain.BidEuchreMaxBid}, 3), "有効な入札:")
 }

--- a/internal/domain/BidEuchre.go
+++ b/internal/domain/BidEuchre.go
@@ -380,6 +380,19 @@ func (b *BidEuchre) BidEuchreCanBid(player, value int) bool {
 	return value > b.highBid.Value
 }
 
+// BidEuchreMinLegalBid は player が通せる最も低い宣言を返す。無ければ ok=false。
+//
+// **判定は BidEuchreCanBid をそのまま試す。**規則を書き写すと、案内した額が
+// 拒否されることになる (#4899)。
+func (b *BidEuchre) BidEuchreMinLegalBid(player int) (int, bool) {
+	for v := BidEuchreMinBid; v <= BidEuchreMaxBid; v++ {
+		if b.BidEuchreCanBid(player, v) {
+			return v, true
+		}
+	}
+	return 0, false
+}
+
 // Bid はトリック数を宣言する。
 func (b *BidEuchre) Bid(player, value int) error {
 	if err := b.checkBidTurn(player); err != nil {

--- a/internal/domain/BidEuchre_test.go
+++ b/internal/domain/BidEuchre_test.go
@@ -5,6 +5,8 @@ package domain
 import (
 	"encoding/json"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func beCard(suit, value int) *Card { return NewCard(suit, value, true) }
@@ -822,4 +824,36 @@ func TestBidEuchreGetScoreOutOfRange(t *testing.T) {
 	if got := b.GetScore(1); got != 17 {
 		t.Errorf("GetScore(1) = %d, want 17", got)
 	}
+}
+
+// **「立っている宣言＋1、親なら同額」を 1 箇所で決める** (#4899)。
+func TestBidEuchre_MinLegalBid(t *testing.T) {
+	g := NewDefaultBidEuchre()
+	g.Reset()
+	g.SetDealerForTest(3)
+
+	// 宣言が無ければ最低値から (受け入れ条件1)。
+	g.highBid = nil
+	v, ok := g.BidEuchreMinLegalBid(1)
+	assert.True(t, ok)
+	assert.Equal(t, BidEuchreMinBid, v)
+
+	// 非ディーラーは +1 から (受け入れ条件2)。
+	g.highBid = &BidEuchreBid{Player: 0, Value: 4}
+	v, ok = g.BidEuchreMinLegalBid(1)
+	assert.True(t, ok)
+	assert.Equal(t, 5, v)
+
+	// **親だけは同額で奪える** (受け入れ条件3)。
+	v, ok = g.BidEuchreMinLegalBid(3)
+	assert.True(t, ok)
+	assert.Equal(t, 4, v)
+
+	// 上限まで宣言されたら非ディーラーには無い。親にはまだある。
+	g.highBid = &BidEuchreBid{Player: 0, Value: BidEuchreMaxBid}
+	_, ok = g.BidEuchreMinLegalBid(1)
+	assert.False(t, ok)
+	v, ok = g.BidEuchreMinLegalBid(3)
+	assert.True(t, ok)
+	assert.Equal(t, BidEuchreMaxBid, v)
 }

--- a/internal/domain/interfaces/bideuchre.go
+++ b/internal/domain/interfaces/bideuchre.go
@@ -47,6 +47,8 @@ type BidEuchreGame interface {
 	GetBids() []*domain.BidEuchreBid
 	// GetHighBid 現在の最高宣言を取得する
 	GetHighBid() *domain.BidEuchreBid
+	// BidEuchreMinLegalBid player が通せる最も低い宣言を返す (無ければ ok=false)
+	BidEuchreMinLegalBid(player int) (int, bool)
 	// GetDeclarerIdx 落札者を取得する
 	GetDeclarerIdx() int
 	// GetTrump 切札の宣言内容を取得する

--- a/internal/domain/interfaces/bideuchre_mock.go
+++ b/internal/domain/interfaces/bideuchre_mock.go
@@ -76,3 +76,9 @@ func (m *MockBidEuchreGame) GetPlayer(idx int) *domain.BidEuchrePlayer {
 func (m *MockBidEuchreGame) GetActionLog() []*domain.ActionLogEntry {
 	return m.Called().Get(0).([]*domain.ActionLogEntry)
 }
+
+// BidEuchreMinLegalBid モック
+func (m *MockBidEuchreGame) BidEuchreMinLegalBid(player int) (int, bool) {
+	ret := m.Called(player)
+	return ret.Int(0), ret.Bool(1)
+}

--- a/internal/i18n/locales/en/bideuchre.json
+++ b/internal/i18n/locales/en/bideuchre.json
@@ -20,6 +20,8 @@
   "trumpMenuTitle": "Trump choices:",
   "gameEnd": "Game over! Team {{team}} wins!",
   "promptBid": "Bidding: {{name}}",
+  "bidRange": "Legal bids: {{min}}-{{max}}",
+  "bidRangeNone": "No higher bid is possible; pass only",
   "promptBidHelp": "b <3-6> ... bid (three is the floor; you must beat the standing bid, but THE DEALER MAY EQUAL IT) / ps ... pass",
   "promptTrump": "Naming trump: {{name}}",
   "promptTrumpHelp": "t <0-5> ... name trump (AT NT LOW THE RANKING REVERSES and the nine is highest)",

--- a/internal/i18n/locales/ja/bideuchre.json
+++ b/internal/i18n/locales/ja/bideuchre.json
@@ -20,6 +20,8 @@
   "trumpMenuTitle": "切札の候補:",
   "gameEnd": "ゲーム終了！ チーム{{team}}の勝ち！",
   "promptBid": "宣言: {{name}}",
+  "bidRange": "有効な入札: {{min}}〜{{max}}",
+  "bidRangeNone": "これ以上の入札はできません。パスのみ",
   "promptBidHelp": "b <3-6> ・・・宣言（最低3。上回る宣言のみ有効ですが、【親だけは同額でも奪えます】）／ps ・・・見送る",
   "promptTrump": "切札指定: {{name}}",
   "promptTrumpHelp": "t <0-5> ・・・切札を指定（【NTローは序列が逆転し9が最強】になります）",


### PR DESCRIPTION
Closes #4899

## 背景

`BidEuchrePage` は

```ts
floor = highBid === null ? minBid : (dealer ? highBid.value : highBid.value + 1)
```

で選べる値だけをドロップダウンに詰める（**親だけ同額で奪える**規則をコード上で反映している）。一方 `BidEuchreCuiPresenter` は `promptBidHelp` の静的な説明文しか出さず、現在の `highBid` から実際に通る最小値は示さない。CUI プレイヤーは毎回暗算することになる。

## 変更

ビッドフェーズに `有効な入札: 5〜6` の 1 行を足す。上限まで宣言されて**非ディーラーに選べる値が無い**ときは「これ以上の入札はできません。パスのみ」と言う。

## テスト

受け入れ条件 3 つをそのまま:

- 宣言が無ければ最低値 (3) から
- 非ディーラーは `highBid + 1` から
- **親は `highBid` と同額から**

加えて境界:

- 上限まで宣言されると非ディーラーには範囲が出ず「パスのみ」になること
- **同じ状況でも親には範囲が出る**こと（同額で奪えるので）

ネガティブコントロール: 親の同額分岐を外すと 4 件が落ちる。

`go test -tags test ./...` / `golangci-lint run ./internal/...` (0 issues) green。

## Test plan

- [ ] CI green