### PR TITLE
feat(faro): add the case keeper to the CUI

### DIFF
--- a/docs/manual/cui/faro.md
+++ b/docs/manual/cui/faro.md
@@ -64,7 +64,8 @@ flowchart TD
 chips: 1000
 phase: BETTING
 turns: 0/25
-cards left: 52
+cards left: 51
+Case keeper (remaining of 4 per rank): A:3 2:4 3:4 4:4 5:4 6:4 7:4 8:4 9:4 10:4 J:4 Q:4 K:4
 --- BETS ---
   rank 7: 100
   rank 13: 50 (copper)
@@ -73,6 +74,8 @@ cards left: 52
 
 - `chips` … 残りチップ
 - `phase` … 現在のフェーズ（BETTING / TURN / CALL / ROUND END / GAME END）
+- `cards left` … 山札の残り枚数
+- `Case keeper` … **ランクごとの残り枚数（各 4 枚中）**。カードカウンティングがこのゲームの核なので常時表示されます。出尽くしたランクも `A:0` のように 0 で残ります
 - `BETS` … 現在のベット一覧（`(copper)`はカッパー）
 
 ## 遊び方のコツ

--- a/internal/adapter/presenter/FaroCuiPresenter.go
+++ b/internal/adapter/presenter/FaroCuiPresenter.go
@@ -25,6 +25,15 @@ func (fp *FaroCuiPresenter) Output(f interfaces.FaroGame, lastErr error) string 
 	sb.WriteString(i18n.Tf("faro.turnsLine", "played", strconv.Itoa(f.GetTurnsPlayed()), "total", strconv.Itoa(f.GetTurnsTotal())) + "\n")
 	sb.WriteString(i18n.Tf("faro.remainingLine", "count", strconv.Itoa(f.GetRemainingCount())) + "\n")
 
+	// **ケースキーパーはこのゲームの中核。**Web はランク別の残数を常時出すのに、
+	// CUI は総枚数しか出しておらず、勘だけで賭けることになっていた (#4894)。
+	remaining := f.FaroRemainingByRank()
+	parts := make([]string, 0, domain.FaroMaxRank)
+	for r := 1; r <= domain.FaroMaxRank; r++ {
+		parts = append(parts, cuiRankLabel(r)+":"+strconv.Itoa(remaining[r]))
+	}
+	sb.WriteString(i18n.Tf("faro.caseKeeper", "counts", strings.Join(parts, " ")) + "\n")
+
 	ranks := f.GetBetRanks()
 	bets := f.GetBets()
 	if len(ranks) > 0 {

--- a/internal/adapter/presenter/FaroCuiPresenter.go
+++ b/internal/adapter/presenter/FaroCuiPresenter.go
@@ -27,9 +27,9 @@ func (fp *FaroCuiPresenter) Output(f interfaces.FaroGame, lastErr error) string 
 
 	// **ケースキーパーはこのゲームの中核。**Web はランク別の残数を常時出すのに、
 	// CUI は総枚数しか出しておらず、勘だけで賭けることになっていた (#4894)。
-	remaining := f.FaroRemainingByRank()
+	remaining := f.GetRemainingByRank()
 	parts := make([]string, 0, domain.FaroMaxRank)
-	for r := 1; r <= domain.FaroMaxRank; r++ {
+	for r := domain.FaroMinRank; r <= domain.FaroMaxRank; r++ {
 		parts = append(parts, cuiRankLabel(r)+":"+strconv.Itoa(remaining[r]))
 	}
 	sb.WriteString(i18n.Tf("faro.caseKeeper", "counts", strings.Join(parts, " ")) + "\n")

--- a/internal/adapter/presenter/FaroCuiPresenter_test.go
+++ b/internal/adapter/presenter/FaroCuiPresenter_test.go
@@ -16,6 +16,7 @@ func setupFaroCuiMockDefaults(m *interfaces.MockFaroGame) {
 	m.On("GetTurnsPlayed").Return(0).Maybe()
 	m.On("GetTurnsTotal").Return(domain.FaroTurnsPerDeal).Maybe()
 	m.On("GetRemainingCount").Return(51).Maybe()
+	m.On("FaroRemainingByRank").Return([domain.FaroMaxRank + 1]int{}).Maybe()
 	m.On("GetBetRanks").Return(([]int)(nil)).Maybe()
 	m.On("GetBets").Return((map[int]*domain.FaroBet)(nil)).Maybe()
 	m.On("GetLastTurn").Return((*domain.FaroTurnResult)(nil)).Maybe()
@@ -45,6 +46,7 @@ func TestFaroCuiPresenter_Output_FaceRankLabels(t *testing.T) {
 	m.On("GetTurnsPlayed").Return(0)
 	m.On("GetTurnsTotal").Return(domain.FaroTurnsPerDeal)
 	m.On("GetRemainingCount").Return(51)
+	m.On("FaroRemainingByRank").Return([domain.FaroMaxRank + 1]int{}).Maybe()
 	m.On("GetBetRanks").Return([]int{1, 11, 12, 13, 8})
 	m.On("GetBets").Return(map[int]*domain.FaroBet{
 		1: {Amount: 50}, 11: {Amount: 60}, 12: {Amount: 70}, 13: {Amount: 80}, 8: {Amount: 90},
@@ -82,6 +84,7 @@ func TestFaroCuiPresenter_Output_WithBetsAndTurn(t *testing.T) {
 	m.On("GetTurnsPlayed").Return(1)
 	m.On("GetTurnsTotal").Return(domain.FaroTurnsPerDeal)
 	m.On("GetRemainingCount").Return(49)
+	m.On("FaroRemainingByRank").Return([domain.FaroMaxRank + 1]int{}).Maybe()
 	m.On("GetBetRanks").Return([]int{7})
 	m.On("GetBets").Return(map[int]*domain.FaroBet{7: {Amount: 100, Copper: true}})
 	m.On("GetLastTurn").Return(&domain.FaroTurnResult{
@@ -110,6 +113,7 @@ func TestFaroCuiPresenter_Output_SplitAndCall(t *testing.T) {
 	m.On("GetTurnsPlayed").Return(domain.FaroTurnsPerDeal)
 	m.On("GetTurnsTotal").Return(domain.FaroTurnsPerDeal)
 	m.On("GetRemainingCount").Return(3)
+	m.On("FaroRemainingByRank").Return([domain.FaroMaxRank + 1]int{}).Maybe()
 	m.On("GetBetRanks").Return(([]int)(nil))
 	m.On("GetBets").Return((map[int]*domain.FaroBet)(nil))
 	m.On("GetLastTurn").Return(&domain.FaroTurnResult{
@@ -141,6 +145,7 @@ func TestFaroCuiPresenter_Output_RoundEndWonAndLost(t *testing.T) {
 	won.On("GetTurnsPlayed").Return(domain.FaroTurnsPerDeal)
 	won.On("GetTurnsTotal").Return(domain.FaroTurnsPerDeal)
 	won.On("GetRemainingCount").Return(0)
+	won.On("FaroRemainingByRank").Return([domain.FaroMaxRank + 1]int{}).Maybe()
 	won.On("GetBetRanks").Return(([]int)(nil))
 	won.On("GetBets").Return((map[int]*domain.FaroBet)(nil))
 	won.On("GetLastTurn").Return((*domain.FaroTurnResult)(nil))
@@ -157,6 +162,7 @@ func TestFaroCuiPresenter_Output_RoundEndWonAndLost(t *testing.T) {
 	lost.On("GetTurnsPlayed").Return(domain.FaroTurnsPerDeal)
 	lost.On("GetTurnsTotal").Return(domain.FaroTurnsPerDeal)
 	lost.On("GetRemainingCount").Return(0)
+	lost.On("FaroRemainingByRank").Return([domain.FaroMaxRank + 1]int{}).Maybe()
 	lost.On("GetBetRanks").Return(([]int)(nil))
 	lost.On("GetBets").Return((map[int]*domain.FaroBet)(nil))
 	lost.On("GetLastTurn").Return((*domain.FaroTurnResult)(nil))
@@ -178,6 +184,7 @@ func TestFaroCuiPresenter_Output_GameEnd(t *testing.T) {
 	m.On("GetTurnsPlayed").Return(0)
 	m.On("GetTurnsTotal").Return(domain.FaroTurnsPerDeal)
 	m.On("GetRemainingCount").Return(0)
+	m.On("FaroRemainingByRank").Return([domain.FaroMaxRank + 1]int{}).Maybe()
 	m.On("GetBetRanks").Return(([]int)(nil))
 	m.On("GetBets").Return((map[int]*domain.FaroBet)(nil))
 	m.On("GetLastTurn").Return((*domain.FaroTurnResult)(nil))
@@ -209,4 +216,38 @@ func TestFaroCuiPresenter_ActionLogOutput(t *testing.T) {
 	m := new(interfaces.MockFaroGame)
 	m.On("GetGameEndFlag").Return(false)
 	assert.NotEmpty(t, p.ActionLogOutput(m))
+}
+
+// **ケースキーパーはこのゲームの中核。**Web はランク別の残数を常時出すのに、
+// CUI は総枚数しか出していなかった (#4894)。
+func TestFaroCuiPresenter_ShowsTheCaseKeeper(t *testing.T) {
+	// defaults は FaroRemainingByRank を空で先に登録してしまう (testify は最初に
+	// 一致した期待値を使う) ので、この検査だけは自前で組む。
+	m := new(interfaces.MockFaroGame)
+	m.On("GetChips").Return(1000)
+	m.On("GetPhase").Return(domain.FaroPhaseBetting)
+	m.On("GetTurnsPlayed").Return(0)
+	m.On("GetTurnsTotal").Return(domain.FaroTurnsPerDeal)
+	m.On("GetRemainingCount").Return(51)
+	m.On("GetBetRanks").Return(([]int)(nil))
+	m.On("GetBets").Return((map[int]*domain.FaroBet)(nil))
+	m.On("GetLastTurn").Return((*domain.FaroTurnResult)(nil))
+	m.On("GetCallCards").Return(([]*domain.Card)(nil))
+	m.On("GetGameEndFlag").Return(false)
+	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil)).Maybe()
+
+	var counts [domain.FaroMaxRank + 1]int
+	for r := 1; r <= domain.FaroMaxRank; r++ {
+		counts[r] = 4
+	}
+	counts[1] = 0  // A は出尽くした
+	counts[13] = 2 // K は 2 枚残り
+	m.On("FaroRemainingByRank").Return(counts)
+
+	out := new(FaroCuiPresenter).Output(m, nil)
+	assert.Contains(t, out, "ケースキーパー")
+	// 出尽くしたランクも 0 として出す。**消すと「まだある」と読める。**
+	assert.Contains(t, out, "A:0")
+	assert.Contains(t, out, "K:2")
+	assert.Contains(t, out, "2:4")
 }

--- a/internal/adapter/presenter/FaroCuiPresenter_test.go
+++ b/internal/adapter/presenter/FaroCuiPresenter_test.go
@@ -16,7 +16,7 @@ func setupFaroCuiMockDefaults(m *interfaces.MockFaroGame) {
 	m.On("GetTurnsPlayed").Return(0).Maybe()
 	m.On("GetTurnsTotal").Return(domain.FaroTurnsPerDeal).Maybe()
 	m.On("GetRemainingCount").Return(51).Maybe()
-	m.On("FaroRemainingByRank").Return([domain.FaroMaxRank + 1]int{}).Maybe()
+	m.On("GetRemainingByRank").Return([domain.FaroMaxRank + 1]int{}).Maybe()
 	m.On("GetBetRanks").Return(([]int)(nil)).Maybe()
 	m.On("GetBets").Return((map[int]*domain.FaroBet)(nil)).Maybe()
 	m.On("GetLastTurn").Return((*domain.FaroTurnResult)(nil)).Maybe()
@@ -46,7 +46,7 @@ func TestFaroCuiPresenter_Output_FaceRankLabels(t *testing.T) {
 	m.On("GetTurnsPlayed").Return(0)
 	m.On("GetTurnsTotal").Return(domain.FaroTurnsPerDeal)
 	m.On("GetRemainingCount").Return(51)
-	m.On("FaroRemainingByRank").Return([domain.FaroMaxRank + 1]int{}).Maybe()
+	m.On("GetRemainingByRank").Return([domain.FaroMaxRank + 1]int{}).Maybe()
 	m.On("GetBetRanks").Return([]int{1, 11, 12, 13, 8})
 	m.On("GetBets").Return(map[int]*domain.FaroBet{
 		1: {Amount: 50}, 11: {Amount: 60}, 12: {Amount: 70}, 13: {Amount: 80}, 8: {Amount: 90},
@@ -84,7 +84,7 @@ func TestFaroCuiPresenter_Output_WithBetsAndTurn(t *testing.T) {
 	m.On("GetTurnsPlayed").Return(1)
 	m.On("GetTurnsTotal").Return(domain.FaroTurnsPerDeal)
 	m.On("GetRemainingCount").Return(49)
-	m.On("FaroRemainingByRank").Return([domain.FaroMaxRank + 1]int{}).Maybe()
+	m.On("GetRemainingByRank").Return([domain.FaroMaxRank + 1]int{}).Maybe()
 	m.On("GetBetRanks").Return([]int{7})
 	m.On("GetBets").Return(map[int]*domain.FaroBet{7: {Amount: 100, Copper: true}})
 	m.On("GetLastTurn").Return(&domain.FaroTurnResult{
@@ -113,7 +113,7 @@ func TestFaroCuiPresenter_Output_SplitAndCall(t *testing.T) {
 	m.On("GetTurnsPlayed").Return(domain.FaroTurnsPerDeal)
 	m.On("GetTurnsTotal").Return(domain.FaroTurnsPerDeal)
 	m.On("GetRemainingCount").Return(3)
-	m.On("FaroRemainingByRank").Return([domain.FaroMaxRank + 1]int{}).Maybe()
+	m.On("GetRemainingByRank").Return([domain.FaroMaxRank + 1]int{}).Maybe()
 	m.On("GetBetRanks").Return(([]int)(nil))
 	m.On("GetBets").Return((map[int]*domain.FaroBet)(nil))
 	m.On("GetLastTurn").Return(&domain.FaroTurnResult{
@@ -145,7 +145,7 @@ func TestFaroCuiPresenter_Output_RoundEndWonAndLost(t *testing.T) {
 	won.On("GetTurnsPlayed").Return(domain.FaroTurnsPerDeal)
 	won.On("GetTurnsTotal").Return(domain.FaroTurnsPerDeal)
 	won.On("GetRemainingCount").Return(0)
-	won.On("FaroRemainingByRank").Return([domain.FaroMaxRank + 1]int{}).Maybe()
+	won.On("GetRemainingByRank").Return([domain.FaroMaxRank + 1]int{}).Maybe()
 	won.On("GetBetRanks").Return(([]int)(nil))
 	won.On("GetBets").Return((map[int]*domain.FaroBet)(nil))
 	won.On("GetLastTurn").Return((*domain.FaroTurnResult)(nil))
@@ -162,7 +162,7 @@ func TestFaroCuiPresenter_Output_RoundEndWonAndLost(t *testing.T) {
 	lost.On("GetTurnsPlayed").Return(domain.FaroTurnsPerDeal)
 	lost.On("GetTurnsTotal").Return(domain.FaroTurnsPerDeal)
 	lost.On("GetRemainingCount").Return(0)
-	lost.On("FaroRemainingByRank").Return([domain.FaroMaxRank + 1]int{}).Maybe()
+	lost.On("GetRemainingByRank").Return([domain.FaroMaxRank + 1]int{}).Maybe()
 	lost.On("GetBetRanks").Return(([]int)(nil))
 	lost.On("GetBets").Return((map[int]*domain.FaroBet)(nil))
 	lost.On("GetLastTurn").Return((*domain.FaroTurnResult)(nil))
@@ -184,7 +184,7 @@ func TestFaroCuiPresenter_Output_GameEnd(t *testing.T) {
 	m.On("GetTurnsPlayed").Return(0)
 	m.On("GetTurnsTotal").Return(domain.FaroTurnsPerDeal)
 	m.On("GetRemainingCount").Return(0)
-	m.On("FaroRemainingByRank").Return([domain.FaroMaxRank + 1]int{}).Maybe()
+	m.On("GetRemainingByRank").Return([domain.FaroMaxRank + 1]int{}).Maybe()
 	m.On("GetBetRanks").Return(([]int)(nil))
 	m.On("GetBets").Return((map[int]*domain.FaroBet)(nil))
 	m.On("GetLastTurn").Return((*domain.FaroTurnResult)(nil))
@@ -221,7 +221,7 @@ func TestFaroCuiPresenter_ActionLogOutput(t *testing.T) {
 // **ケースキーパーはこのゲームの中核。**Web はランク別の残数を常時出すのに、
 // CUI は総枚数しか出していなかった (#4894)。
 func TestFaroCuiPresenter_ShowsTheCaseKeeper(t *testing.T) {
-	// defaults は FaroRemainingByRank を空で先に登録してしまう (testify は最初に
+	// defaults は GetRemainingByRank を空で先に登録してしまう (testify は最初に
 	// 一致した期待値を使う) ので、この検査だけは自前で組む。
 	m := new(interfaces.MockFaroGame)
 	m.On("GetChips").Return(1000)
@@ -237,12 +237,12 @@ func TestFaroCuiPresenter_ShowsTheCaseKeeper(t *testing.T) {
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil)).Maybe()
 
 	var counts [domain.FaroMaxRank + 1]int
-	for r := 1; r <= domain.FaroMaxRank; r++ {
+	for r := domain.FaroMinRank; r <= domain.FaroMaxRank; r++ {
 		counts[r] = 4
 	}
-	counts[1] = 0  // A は出尽くした
-	counts[13] = 2 // K は 2 枚残り
-	m.On("FaroRemainingByRank").Return(counts)
+	counts[domain.FaroMinRank] = 0 // A は出尽くした
+	counts[13] = 2                 // K は 2 枚残り
+	m.On("GetRemainingByRank").Return(counts)
 
 	out := new(FaroCuiPresenter).Output(m, nil)
 	assert.Contains(t, out, "ケースキーパー")

--- a/internal/domain/Faro.go
+++ b/internal/domain/Faro.go
@@ -408,6 +408,29 @@ func (f *Faro) GetGameEndFlag() bool { return f.gameEndFlag }
 // GetChips は現在のチップ数を返す。
 func (f *Faro) GetChips() int { return f.chips.GetChips() }
 
+// FaroRemainingByRank は各ランクの残り枚数を返す (index 1..13 が A..K)。
+//
+// **未配の山札から直接数える。**公開済みカードを別に蓄えると、リセットの
+// 取りこぼしや二重計上でケースキーパーが嘘をつく (#4894)。ソーダも配った
+// 時点で山札から抜けているので、自動的に除かれる。
+func (f *Faro) FaroRemainingByRank() [FaroMaxRank + 1]int {
+	var out [FaroMaxRank + 1]int
+	if f.trumpCards == nil {
+		return out
+	}
+	// 同じ package なので山札を直接見る。TrumpCards に新しい公開 API は要らない。
+	for _, c := range f.trumpCards.deck {
+		if c == nil || c.GetDraw() {
+			continue
+		}
+		v := c.GetValue()
+		if v >= 1 && v <= FaroMaxRank {
+			out[v]++
+		}
+	}
+	return out
+}
+
 // GetTurnsPlayed は消化済みターン数を返す。
 func (f *Faro) GetTurnsPlayed() int { return f.turnsPlayed }
 

--- a/internal/domain/Faro.go
+++ b/internal/domain/Faro.go
@@ -408,12 +408,12 @@ func (f *Faro) GetGameEndFlag() bool { return f.gameEndFlag }
 // GetChips は現在のチップ数を返す。
 func (f *Faro) GetChips() int { return f.chips.GetChips() }
 
-// FaroRemainingByRank は各ランクの残り枚数を返す (index 1..13 が A..K)。
+// GetRemainingByRank は各ランクの残り枚数を返す (index 1..13 が A..K)。
 //
 // **未配の山札から直接数える。**公開済みカードを別に蓄えると、リセットの
 // 取りこぼしや二重計上でケースキーパーが嘘をつく (#4894)。ソーダも配った
 // 時点で山札から抜けているので、自動的に除かれる。
-func (f *Faro) FaroRemainingByRank() [FaroMaxRank + 1]int {
+func (f *Faro) GetRemainingByRank() [FaroMaxRank + 1]int {
 	var out [FaroMaxRank + 1]int
 	if f.trumpCards == nil {
 		return out
@@ -424,7 +424,7 @@ func (f *Faro) FaroRemainingByRank() [FaroMaxRank + 1]int {
 			continue
 		}
 		v := c.GetValue()
-		if v >= 1 && v <= FaroMaxRank {
+		if v >= FaroMinRank && v <= FaroMaxRank {
 			out[v]++
 		}
 	}

--- a/internal/domain/Faro_test.go
+++ b/internal/domain/Faro_test.go
@@ -472,3 +472,59 @@ func TestFaro_DealTurn_DeckGuard(t *testing.T) {
 		t.Error("dealing past the last turn should error")
 	}
 }
+
+// **ケースキーパーはこのゲームの中核。**未配の山札から直接数えるので、
+// 公開済みカードの蓄積漏れや二重計上で嘘をつくことがない (#4894)。
+func TestFaro_RemainingByRank(t *testing.T) {
+	f := newFaroForTest()
+
+	// リセット直後: ソーダ 1 枚だけが抜けている。
+	start := f.FaroRemainingByRank()
+	total := 0
+	for r := 1; r <= FaroMaxRank; r++ {
+		if start[r] < 0 || start[r] > 4 {
+			t.Fatalf("rank %d = %d, want 0..4", r, start[r])
+		}
+		total += start[r]
+	}
+	if total != f.GetRemainingCount() {
+		t.Fatalf("per-rank total = %d, deck remaining = %d", total, f.GetRemainingCount())
+	}
+	// ソーダの分だけ 51。
+	if total != 51 {
+		t.Fatalf("after the soda burn the deck should hold 51, got %d", total)
+	}
+
+	// **ターンを重ねると減る。**2 枚めくるので合計は 2 減る。
+	if err := f.PlayerPlaceBet(1, 10, false); err != nil {
+		t.Fatalf("bet: %v", err)
+	}
+	if err := f.PlayerDealTurn(); err != nil {
+		t.Fatalf("deal: %v", err)
+	}
+	after := f.FaroRemainingByRank()
+	sum := 0
+	for r := 1; r <= FaroMaxRank; r++ {
+		if after[r] > start[r] {
+			t.Fatalf("rank %d went up: %d -> %d", r, start[r], after[r])
+		}
+		sum += after[r]
+	}
+	if sum != total-2 {
+		t.Fatalf("after one turn the deck should be 2 smaller: %d -> %d", total, sum)
+	}
+	if sum != f.GetRemainingCount() {
+		t.Fatalf("per-rank total = %d, deck remaining = %d", sum, f.GetRemainingCount())
+	}
+
+	// **リセットで元に戻る。**蓄積を持たないので取りこぼしようがない。
+	f.Reset()
+	again := f.FaroRemainingByRank()
+	back := 0
+	for r := 1; r <= FaroMaxRank; r++ {
+		back += again[r]
+	}
+	if back != 51 {
+		t.Fatalf("after a reset the deck should hold 51 again, got %d", back)
+	}
+}

--- a/internal/domain/Faro_test.go
+++ b/internal/domain/Faro_test.go
@@ -479,9 +479,9 @@ func TestFaro_RemainingByRank(t *testing.T) {
 	f := newFaroForTest()
 
 	// リセット直後: ソーダ 1 枚だけが抜けている。
-	start := f.FaroRemainingByRank()
+	start := f.GetRemainingByRank()
 	total := 0
-	for r := 1; r <= FaroMaxRank; r++ {
+	for r := FaroMinRank; r <= FaroMaxRank; r++ {
 		if start[r] < 0 || start[r] > 4 {
 			t.Fatalf("rank %d = %d, want 0..4", r, start[r])
 		}
@@ -502,9 +502,9 @@ func TestFaro_RemainingByRank(t *testing.T) {
 	if err := f.PlayerDealTurn(); err != nil {
 		t.Fatalf("deal: %v", err)
 	}
-	after := f.FaroRemainingByRank()
+	after := f.GetRemainingByRank()
 	sum := 0
-	for r := 1; r <= FaroMaxRank; r++ {
+	for r := FaroMinRank; r <= FaroMaxRank; r++ {
 		if after[r] > start[r] {
 			t.Fatalf("rank %d went up: %d -> %d", r, start[r], after[r])
 		}
@@ -519,9 +519,9 @@ func TestFaro_RemainingByRank(t *testing.T) {
 
 	// **リセットで元に戻る。**蓄積を持たないので取りこぼしようがない。
 	f.Reset()
-	again := f.FaroRemainingByRank()
+	again := f.GetRemainingByRank()
 	back := 0
-	for r := 1; r <= FaroMaxRank; r++ {
+	for r := FaroMinRank; r <= FaroMaxRank; r++ {
 		back += again[r]
 	}
 	if back != 51 {

--- a/internal/domain/interfaces/faro.go
+++ b/internal/domain/interfaces/faro.go
@@ -34,8 +34,8 @@ type FaroGame interface {
 	GetTurnsTotal() int
 	// GetRemainingCount デッキ残枚数
 	GetRemainingCount() int
-	// FaroRemainingByRank ランク別の残り枚数 (index 1..13 が A..K)
-	FaroRemainingByRank() [domain.FaroMaxRank + 1]int
+	// GetRemainingByRank ランク別の残り枚数 (index 1..13 が A..K)
+	GetRemainingByRank() [domain.FaroMaxRank + 1]int
 	// GetSoda 焼かれたソーダ札
 	GetSoda() *domain.Card
 	// GetLastTurn 直近ターンの結果

--- a/internal/domain/interfaces/faro.go
+++ b/internal/domain/interfaces/faro.go
@@ -34,6 +34,8 @@ type FaroGame interface {
 	GetTurnsTotal() int
 	// GetRemainingCount デッキ残枚数
 	GetRemainingCount() int
+	// FaroRemainingByRank ランク別の残り枚数 (index 1..13 が A..K)
+	FaroRemainingByRank() [domain.FaroMaxRank + 1]int
 	// GetSoda 焼かれたソーダ札
 	GetSoda() *domain.Card
 	// GetLastTurn 直近ターンの結果

--- a/internal/domain/interfaces/faro_mock.go
+++ b/internal/domain/interfaces/faro_mock.go
@@ -142,8 +142,8 @@ func (m *MockFaroGame) GetActionLog() []*domain.ActionLogEntry {
 	return args.Get(0).([]*domain.ActionLogEntry)
 }
 
-// FaroRemainingByRank モック
-func (m *MockFaroGame) FaroRemainingByRank() [domain.FaroMaxRank + 1]int {
+// GetRemainingByRank モック
+func (m *MockFaroGame) GetRemainingByRank() [domain.FaroMaxRank + 1]int {
 	ret := m.Called()
 	if v, ok := ret.Get(0).([domain.FaroMaxRank + 1]int); ok {
 		return v

--- a/internal/domain/interfaces/faro_mock.go
+++ b/internal/domain/interfaces/faro_mock.go
@@ -141,3 +141,12 @@ func (m *MockFaroGame) GetActionLog() []*domain.ActionLogEntry {
 	}
 	return args.Get(0).([]*domain.ActionLogEntry)
 }
+
+// FaroRemainingByRank モック
+func (m *MockFaroGame) FaroRemainingByRank() [domain.FaroMaxRank + 1]int {
+	ret := m.Called()
+	if v, ok := ret.Get(0).([domain.FaroMaxRank + 1]int); ok {
+		return v
+	}
+	return [domain.FaroMaxRank + 1]int{}
+}

--- a/internal/i18n/locales/en/faro.json
+++ b/internal/i18n/locales/en/faro.json
@@ -10,6 +10,7 @@
   "phaseLine": "phase: {{phase}}",
   "turnsLine": "turns: {{played}}/{{total}}",
   "remainingLine": "cards left: {{count}}",
+  "caseKeeper": "Case keeper (remaining of 4 per rank): {{counts}}",
   "betsHeader": "BETS",
   "betLine": "  rank {{rank}}: {{amount}}",
   "copperTag": "(copper)",

--- a/internal/i18n/locales/ja/faro.json
+++ b/internal/i18n/locales/ja/faro.json
@@ -10,6 +10,7 @@
   "phaseLine": "フェーズ: {{phase}}",
   "turnsLine": "ターン: {{played}}/{{total}}",
   "remainingLine": "山札残り: {{count}}",
+  "caseKeeper": "ケースキーパー（各ランクの残り／4枚中）: {{counts}}",
   "betsHeader": "ベット",
   "betLine": "  ランク {{rank}}: {{amount}}",
   "copperTag": "(カッパー)",


### PR DESCRIPTION
Closes #4894

## 背景

`FaroPage` は soda / losingCard / winningCard / callCards を `mergeSeenCards` で蓄積し、`remainingByRank` でランク別残数を `case-keeper` パネルに常時表示する。カードカウンティングが戦略の核であるこのゲームでは必須の補助機能。一方 `FaroCuiPresenter` は山札の**総枚数**しか出しておらず、CUI プレイヤーはケースキーパーを持たない。

## 蓄積ではなく山札から数える

issue は「公開済みカードを蓄積する状態を presenter か domain に持たせる」案だが、**蓄積は取りこぼしと二重計上で嘘をつく**（受け入れ条件3 が「リセット時にクリアされること」を要求しているのは、まさにその危険があるから）。

`Faro` は未配の山札 (`trumpCards.deck` の `GetDraw()` が false のもの) をそのまま持っているので、そこから数えれば

- ソーダも配った時点で山札から抜けているので自動的に除かれる
- **リセットの扱いが自動的に正しくなる**（クリアし忘れようがない）
- 総数が必ず `GetRemainingCount()` と一致する

`FaroRemainingByRank() [14]int` として公開した。

## テスト

**ドメイン** — リセット直後は 51 枚（ソーダの分だけ欠ける）／**ランク別合計が `GetRemainingCount()` と常に一致**／1 ターンで 2 枚減り、どのランクも増えない／リセットで 51 に戻る（受け入れ条件2・3）

**presenter** — `A:0`（出尽くしたランクも 0 として出す。**消すと「まだある」と読める**）／`K:2`／`2:4`

ネガティブコントロール: 追加ブロックを外すと 4 件が落ちる。

`go test -tags test ./...` / `golangci-lint run ./internal/...` (0 issues) green。

## Test plan

- [ ] CI green