### PR TITLE
feat(cuarenta): show each team's capture total against the bonus in the CUI

### DIFF
--- a/frontend/src/pages/CuarentaPage.tsx
+++ b/frontend/src/pages/CuarentaPage.tsx
@@ -34,10 +34,14 @@ import type { CliGameConfig } from '../utils/cli/types';
 import { cuarentaCaptureIndices } from '../utils/cuarentaCapture';
 import { hintCheckboxItem } from '../utils/settingsItems';
 
-/** Cards a team must capture in a round to earn the extra "más de veinte" points. */
-const CUARENTA_CAPTURE_BONUS = 20;
+/**
+ * Threshold a team must **exceed** to earn the extra "más de veinte" points.
+ * The domain scores it on `CapturedCount[t] > CuarentaMostCardsThreshold`
+ * (`internal/domain/Cuarenta.go`), so 20 captured is not enough — 21 is.
+ */
+const CUARENTA_CAPTURE_THRESHOLD = 20;
 /** Captured-card count from which a team's counter is highlighted as approaching the bonus. */
-const CUARENTA_CAPTURE_NEAR = CUARENTA_CAPTURE_BONUS - 1;
+const CUARENTA_CAPTURE_NEAR = CUARENTA_CAPTURE_THRESHOLD - 1;
 
 /** CPU difficulty options for the Cuarenta settings panel. */
 const CPU_DIFFICULTY_OPTIONS = [
@@ -275,7 +279,7 @@ function CuarentaPageContent() {
               <span>{t('deck', { count: state.remainingDeck })}</span>
             </div>
 
-            {/* Team scores + running captured-card totals (20+ earns a bonus) */}
+            {/* Team scores + running captured-card totals (more than 20 earns a bonus) */}
             <div className="mb-2 p-2 rounded bg-black/30 flex justify-center gap-6" data-tutorial="cuarenta-teams">
               {state.teamScores.map((score, team) => {
                 const captured = teamCaptured[team] ?? 0;

--- a/internal/adapter/presenter/CuarentaCuiPresenter.go
+++ b/internal/adapter/presenter/CuarentaCuiPresenter.go
@@ -24,6 +24,27 @@ func (p *CuarentaCuiPresenter) Output(cg interfaces.CuarentaGame, lastErr error)
 				"team", strconv.Itoa(t),
 				"score", strconv.Itoa(cg.GetTeamScore(t))) + "\n")
 		}
+		// **ボーナスまでの残りをチーム単位で出す。**プレイヤー単位の捕獲数しか
+		// 出しておらず、2 人分を毎回自分で合計させていた (#4893)。
+		// **閾値は「超えた」チーム** — 20 枚ちょうどでは付かない。
+		captured := [domain.CuarentaTeamCnt]int{}
+		for i := 0; i < cg.GetPlayerCnt(); i++ {
+			if pl := cg.GetPlayer(i); pl != nil {
+				captured[domain.CuarentaTeamOf(i)] += pl.CapturedCount()
+			}
+		}
+		for t := 0; t < domain.CuarentaTeamCnt; t++ {
+			line := i18n.Tf("cuarenta.teamCaptured",
+				"team", strconv.Itoa(t),
+				"count", strconv.Itoa(captured[t]),
+				"need", strconv.Itoa(domain.CuarentaMostCardsThreshold+1),
+				"bonus", strconv.Itoa(domain.CuarentaScoreMostCards))
+			// Web と同じく、閾値の 1 つ手前から強調する (あと 2 枚)。
+			if captured[t] >= domain.CuarentaMostCardsThreshold-1 {
+				line = color.Yellow(line)
+			}
+			b.WriteString(line + "\n")
+		}
 		b.WriteString("----------\n")
 
 		for i := 0; i < cg.GetPlayerCnt(); i++ {

--- a/internal/adapter/presenter/CuarentaCuiPresenter.go
+++ b/internal/adapter/presenter/CuarentaCuiPresenter.go
@@ -27,20 +27,15 @@ func (p *CuarentaCuiPresenter) Output(cg interfaces.CuarentaGame, lastErr error)
 		// **ボーナスまでの残りをチーム単位で出す。**プレイヤー単位の捕獲数しか
 		// 出しておらず、2 人分を毎回自分で合計させていた (#4893)。
 		// **閾値は「超えた」チーム** — 20 枚ちょうどでは付かない。
-		captured := [domain.CuarentaTeamCnt]int{}
-		for i := 0; i < cg.GetPlayerCnt(); i++ {
-			if pl := cg.GetPlayer(i); pl != nil {
-				captured[domain.CuarentaTeamOf(i)] += pl.CapturedCount()
-			}
-		}
 		for t := 0; t < domain.CuarentaTeamCnt; t++ {
+			captured := cg.GetTeamCapturedCount(t)
 			line := i18n.Tf("cuarenta.teamCaptured",
 				"team", strconv.Itoa(t),
-				"count", strconv.Itoa(captured[t]),
+				"count", strconv.Itoa(captured),
 				"need", strconv.Itoa(domain.CuarentaMostCardsThreshold+1),
 				"bonus", strconv.Itoa(domain.CuarentaScoreMostCards))
 			// Web と同じく、閾値の 1 つ手前から強調する (あと 2 枚)。
-			if captured[t] >= domain.CuarentaMostCardsThreshold-1 {
+			if captured >= domain.CuarentaMostCardsThreshold-1 {
 				line = color.Yellow(line)
 			}
 			b.WriteString(line + "\n")

--- a/internal/adapter/presenter/CuarentaCuiPresenter_test.go
+++ b/internal/adapter/presenter/CuarentaCuiPresenter_test.go
@@ -1,11 +1,14 @@
 package presenter_test
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func buildPlayedCuarenta(t *testing.T) *domain.Cuarenta {
@@ -69,5 +72,55 @@ func TestCuarentaCuiPresenter_ActionLogOutput(t *testing.T) {
 	g := buildPlayedCuarenta(t)
 	if out := p.ActionLogOutput(g); out == "" {
 		t.Error("expected non-empty action log output")
+	}
+}
+
+// **ボーナスまでの残りをチーム単位で出す。**プレイヤー単位の捕獲数しか出して
+// おらず、2 人分を毎回自分で合計させていた (#4893)。
+func TestCuarentaCuiPresenter_ShowsTheTeamCaptureTotals(t *testing.T) {
+	orig := color.NoColor()
+	color.SetNoColor(false) // 強調の有無まで見る
+	defer color.SetNoColor(orig)
+
+	p := &presenter.CuarentaCuiPresenter{}
+	g := buildPlayedCuarenta(t)
+
+	card := func() *domain.Card { return domain.NewCard(domain.CardDesignSpade, 2, false) }
+	give := func(seat, n int) {
+		cards := make([]*domain.Card, n)
+		for i := range cards {
+			cards[i] = card()
+		}
+		g.GetPlayer(seat).AddCaptured(cards)
+	}
+
+	// **チーム単位で合算する。**席 0 と 2 が同じチーム。
+	give(0, 7)
+	give(2, 5)
+	out := p.Output(g, nil)
+	if !strings.Contains(out, "チーム0 捕獲: 12枚") {
+		t.Fatalf("team total should be the sum of both seats: %q", out)
+	}
+	// **必要枚数は「閾値を超える」枚数。**20 ちょうどでは付かない。
+	if !strings.Contains(out, strconv.Itoa(domain.CuarentaMostCardsThreshold+1)+"枚以上で") {
+		t.Fatalf("the stated requirement must be one above the threshold: %q", out)
+	}
+	// まだ遠いので強調しない。
+	// 色は行全体を包むので、行ごと組み立てて照合する。
+	line := func(team, count int) string {
+		return i18n.Tf("cuarenta.teamCaptured",
+			"team", strconv.Itoa(team), "count", strconv.Itoa(count),
+			"need", strconv.Itoa(domain.CuarentaMostCardsThreshold+1),
+			"bonus", strconv.Itoa(domain.CuarentaScoreMostCards))
+	}
+	if strings.Contains(out, color.Yellow(line(0, 12))) {
+		t.Fatal("12 captured is not close to the bonus")
+	}
+
+	// Web と同じく閾値の 1 つ手前から強調する。
+	give(0, domain.CuarentaMostCardsThreshold-1-12)
+	near := p.Output(g, nil)
+	if !strings.Contains(near, color.Yellow(line(0, domain.CuarentaMostCardsThreshold-1))) {
+		t.Fatalf("one card short of the bonus should be highlighted: %q", near)
 	}
 }

--- a/internal/domain/Cuarenta.go
+++ b/internal/domain/Cuarenta.go
@@ -58,6 +58,20 @@ const (
 // CuarentaTeamOf 席インデックスからチーム番号を返す (i % 2)。
 func CuarentaTeamOf(i int) int { return i % 2 }
 
+// GetTeamCapturedCount はチームの捕獲枚数合計を返す。
+//
+// **合算は 1 箇所に置く。**精算・CUI・Web で別々に足すと、席とチームの対応を
+// 変えたときに片方だけ古いままになる (#4893)。
+func (g *Cuarenta) GetTeamCapturedCount(team int) int {
+	total := 0
+	for i, p := range g.players {
+		if p != nil && CuarentaTeamOf(i) == team {
+			total += p.CapturedCount()
+		}
+	}
+	return total
+}
+
 // CuarentaAction はプレイヤー 1 ターン分の行動記録。
 type CuarentaAction struct {
 	PlayerIdx     int     // 行動したプレイヤーインデックス
@@ -395,8 +409,8 @@ func (g *Cuarenta) scoreRound() *CuarentaRoundDetail {
 		Gained:        make(map[int]int),
 		MostCards:     -1,
 	}
-	for i, p := range g.players {
-		det.CapturedCount[CuarentaTeamOf(i)] += p.CapturedCount()
+	for t := 0; t < CuarentaTeamCnt; t++ {
+		det.CapturedCount[t] = g.GetTeamCapturedCount(t)
 	}
 	// 即時加点の内訳をログ用に再構成 (humanAction + cpuActions では網羅できないため
 	// 表示は概算。Gained は最多取りボーナスのみを担当する)。

--- a/internal/domain/Cuarenta_test.go
+++ b/internal/domain/Cuarenta_test.go
@@ -2,7 +2,11 @@
 
 package domain
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 // cuCard はテスト用に 1 枚のカードを生成するヘルパー (design, value は plain int)。
 func cuCard(d, v int) *Card { return NewCard(d, v, false) }
@@ -412,4 +416,29 @@ func TestCuarentaConfigValidate(t *testing.T) {
 	if err := bad2.Validate(); err == nil {
 		t.Errorf("difficulty 9 should be invalid")
 	}
+}
+
+// **合算は 1 箇所に置く。**精算・CUI で別々に足すと、席とチームの対応を変えた
+// ときに片方だけ古いままになる (#4893)。
+func TestCuarenta_GetTeamCapturedCount(t *testing.T) {
+	g := NewDefaultCuarenta()
+	g.Reset()
+	card := func() *Card { return NewCard(CardDesignSpade, 2, false) }
+	give := func(seat, n int) {
+		cards := make([]*Card, n)
+		for i := range cards {
+			cards[i] = card()
+		}
+		g.GetPlayer(seat).AddCaptured(cards)
+	}
+
+	// 席 0 と 2 が同じチーム、1 と 3 がもう一方。
+	give(0, 7)
+	give(2, 5)
+	give(1, 3)
+	assert.Equal(t, 12, g.GetTeamCapturedCount(0))
+	assert.Equal(t, 3, g.GetTeamCapturedCount(1))
+
+	// 範囲外のチーム番号は 0。
+	assert.Equal(t, 0, g.GetTeamCapturedCount(99))
 }

--- a/internal/domain/interfaces/cuarenta.go
+++ b/internal/domain/interfaces/cuarenta.go
@@ -28,6 +28,8 @@ type CuarentaGame interface {
 	GetPlayer(i int) *domain.CuarentaPlayer
 	// GetTeamScore 指定チームの累計点を取得する
 	GetTeamScore(team int) int
+	// GetTeamCapturedCount チームの捕獲枚数合計を取得する
+	GetTeamCapturedCount(team int) int
 	// GetTableCards 場札一覧を取得する
 	GetTableCards() []*domain.Card
 	// GetLastCaptureIdx 最後に捕獲したプレイヤーを返す (-1 = なし)

--- a/internal/domain/interfaces/cuarenta_mock.go
+++ b/internal/domain/interfaces/cuarenta_mock.go
@@ -150,3 +150,6 @@ func (_m *MockCuarentaGame) GetActionLog() []*domain.ActionLogEntry {
 	}
 	return nil
 }
+
+// GetTeamCapturedCount モック
+func (m *MockCuarentaGame) GetTeamCapturedCount(team int) int { return m.Called(team).Int(0) }

--- a/internal/i18n/locales/en/cuarenta.json
+++ b/internal/i18n/locales/en/cuarenta.json
@@ -18,5 +18,6 @@
   "gameEnd": "Game over!",
   "scoreEntry": "  Team {{team}}: {{score}} pts",
   "promptCurrentTurn": "Turn: {{name}}",
-  "promptHelp": "p <hand> to capture or lay / n for next round"
+  "promptHelp": "p <hand> to capture or lay / n for next round",
+  "teamCaptured": "Team {{team}} captured: {{count}} ({{need}}+ earns +{{bonus}})"
 }

--- a/internal/i18n/locales/ja/cuarenta.json
+++ b/internal/i18n/locales/ja/cuarenta.json
@@ -18,5 +18,6 @@
   "gameEnd": "ゲーム終了！",
   "scoreEntry": "  チーム{{team}}: {{score}}点",
   "promptCurrentTurn": "手番: {{name}}",
-  "promptHelp": "p <hand> で捕獲または場に置く / n で次のラウンド"
+  "promptHelp": "p <hand> で捕獲または場に置く / n で次のラウンド",
+  "teamCaptured": "チーム{{team}} 捕獲: {{count}}枚（{{need}}枚以上で +{{bonus}}）"
 }


### PR DESCRIPTION
Closes #4893

## 背景

`CuarentaPage` はチームごとの捕獲枚数合計を毎ターン再計算し、接近すると色を変えて「más de veinte」ボーナスが近いことを知らせる。一方 `CuarentaCuiPresenter` は**プレイヤー単位**の `CapturedCount()` しか出しておらず、CUI プレイヤーは自チーム 2 人分を毎回自分で合計しないと残り枚数が分からない。

## 変更

チームスコアの直後に合計と必要枚数を出す:

```
チーム0 捕獲: 12枚（21枚以上で +6）
チーム1 捕獲: 8枚（21枚以上で +6）
```

## 必要枚数は 21 枚（20 ではない）

ドメインは

```go
if det.CapturedCount[t] > CuarentaMostCardsThreshold {   // 20 を「超えた」
```

でボーナスを付ける。**20 枚ちょうどでは付かない。**ところがフロントの定数コメントは

```ts
/** Cards a team must capture in a round to earn the extra "más de veinte" points. */
const CUARENTA_CAPTURE_BONUS = 20;
```

と「20 枚で獲得」と書いていて規則を取り違えていた（JSX のコメントも `20+ earns a bonus`）。定数名を `CUARENTA_CAPTURE_THRESHOLD` に改め、「**超える**必要がある」ことを明記した。

**強調の閾値そのものは変えていない。**既存テストが 19 枚での強調を固定しており、そちらは「接近」の指標として妥当なので、CUI も同じ 19 枚に揃えた（両画面で挙動が割れないように）。

## テスト

- **席 0 と席 2 の合算**がチーム合計として出ること（チーム単位であることの確認）
- 必要枚数が**閾値 +1** として出ること
- 遠いうちは強調せず、接近すると強調すること（色付きの行そのものと照合）

ネガティブコントロール: 追加ブロックを外すと落ちる。

`go test -tags test ./...` / `golangci-lint run ./internal/...` (0 issues) / `bun run check` / `bun run typecheck` / vitest green。

## Test plan

- [ ] CI green