### PR TITLE
feat(pishti): show provisional scores in the CUI

### DIFF
--- a/internal/adapter/presenter/PishtiCuiPresenter.go
+++ b/internal/adapter/presenter/PishtiCuiPresenter.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
@@ -19,6 +20,27 @@ func (p *PishtiCuiPresenter) Output(pg interfaces.PishtiGame, lastErr error) str
 	return buildCuiOutput(i18n.T("pishti.helpTitle"), func(b *strings.Builder) {
 		for i := 0; i < pg.GetPlayerCnt(); i++ {
 			b.WriteString(pishtiPlayerStr(pg.GetPlayer(i), i))
+		}
+		// **対局中の優劣を数値で出す。**ピシュティ賞と捕獲枚数を別々に出すだけ
+		// では、複数プレイヤー分を毎回暗算することになる (#4892)。ゲーム終了後は
+		// 下の最終スコアが出るので、ここでは出さない。
+		if !pg.GetGameEndFlag() {
+			prov := pg.GetProvisionalScores()
+			leader := pg.GetProvisionalLeader()
+			for i := 0; i < pg.GetPlayerCnt() && i < len(prov); i++ {
+				pl := pg.GetPlayer(i)
+				if pl == nil {
+					continue
+				}
+				line := i18n.Tf("pishti.provisional",
+					"name", cuiPlayerName(pl, i), "score", strconv.Itoa(prov[i]))
+				if i == leader {
+					line = color.Yellow(line)
+				}
+				b.WriteString(line + "\n")
+			}
+			// **カード点は含まないと断る。**確実な分だけの近似値なので。
+			b.WriteString(i18n.T("pishti.provisionalNote") + "\n")
 		}
 		b.WriteString("----------\n")
 

--- a/internal/adapter/presenter/PishtiCuiPresenter_test.go
+++ b/internal/adapter/presenter/PishtiCuiPresenter_test.go
@@ -2,11 +2,13 @@ package presenter_test
 
 import (
 	"errors"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 )
 
@@ -62,4 +64,43 @@ func TestPishtiCuiPresenter_ActionLog(t *testing.T) {
 	p := new(presenter.PishtiCuiPresenter)
 	g := newPishtiForPresenter()
 	assert.NotEmpty(t, p.ActionLogOutput(g))
+}
+
+// **対局中の優劣を数値で出す。**ピシュティ賞と捕獲枚数を別々に出すだけでは、
+// 複数プレイヤー分を毎回暗算することになる (#4892)。
+func TestPishtiCuiPresenter_ShowsProvisionalScores(t *testing.T) {
+	orig := color.NoColor()
+	color.SetNoColor(false) // リーダーの強調まで見る
+	defer color.SetNoColor(orig)
+
+	p := new(presenter.PishtiCuiPresenter)
+	g := newPishtiForPresenter()
+	g.Reset()
+	card := func() *domain.Card { return domain.NewCard(domain.CardDesignSpade, 2, false) }
+	give := func(seat, n int) {
+		cards := make([]*domain.Card, n)
+		for i := range cards {
+			cards[i] = card()
+		}
+		g.GetPlayer(seat).AddCaptured(cards)
+	}
+
+	// 単独リーダー → +3 が乗り、その行が強調される。
+	give(0, 5)
+	give(1, 3)
+	out := p.Output(g, nil)
+	assert.Contains(t, out, "暫定: "+strconv.Itoa(domain.PishtiScoreMostCards)+"点")
+	assert.Contains(t, out, "カード点は集計時に加算")
+
+	// **同数になったら誰にも +3 は付かない** (受け入れ条件2)。
+	give(1, 2)
+	tied := p.Output(g, nil)
+	assert.NotContains(t, tied, "暫定: "+strconv.Itoa(domain.PishtiScoreMostCards)+"点")
+	assert.Contains(t, tied, "暫定: 0点")
+
+	// **ゲーム終了後は最終スコアに切り替わる** (受け入れ条件3)。
+	g.SetGameEndFlagForTest(true)
+	ended := p.Output(g, nil)
+	assert.NotContains(t, ended, "暫定")
+	assert.NotContains(t, ended, "カード点は集計時に加算")
 }

--- a/internal/domain/Pishti.go
+++ b/internal/domain/Pishti.go
@@ -349,19 +349,14 @@ func (g *Pishti) calcFinalScore() []int {
 	cardCounts := make([]int, n)
 
 	// 最多枚数判定 (同点なら誰ももらえない)。
-	mostIdx := -1
-	mostVal := 0
-	tie := false
+	mostIdx := g.mostCapturedSeat()
 	for i, p := range g.players {
-		cnt := p.CapturedCount()
-		cardCounts[i] = cnt
-		if mostIdx == -1 || cnt > mostVal {
-			mostIdx = i
-			mostVal = cnt
-			tie = false
-		} else if cnt == mostVal {
-			tie = true
-		}
+		cardCounts[i] = p.CapturedCount()
+	}
+	tie := mostIdx < 0
+	mostVal := 0
+	if mostIdx >= 0 {
+		mostVal = g.players[mostIdx].CapturedCount()
 	}
 
 	for i, p := range g.players {
@@ -377,6 +372,44 @@ func (g *Pishti) calcFinalScore() []int {
 	}
 	return scores
 }
+
+// mostCapturedSeat は最多捕獲の単独リーダーの席を返す。同数、または誰も
+// 捕獲していなければ -1。
+func (g *Pishti) mostCapturedSeat() int {
+	best, bestSeat, tie := 0, -1, false
+	for i, p := range g.players {
+		cnt := p.CapturedCount()
+		if bestSeat == -1 || cnt > best {
+			best, bestSeat, tie = cnt, i, false
+		} else if cnt == best {
+			tie = true
+		}
+	}
+	if tie || best == 0 {
+		return -1
+	}
+	return bestSeat
+}
+
+// GetProvisionalScores は対局中の暫定スコアを返す。
+//
+// **カード点は含まない。**捕獲札の点数配分は最後に数えるので、途中で確実に
+// 分かるのはピシュティ賞と最多捕獲の +3 だけ。近似であることは呼び出し側が
+// 明示する (#4892)。**同数なら誰にも +3 は付かない。**
+func (g *Pishti) GetProvisionalScores() []int {
+	out := make([]int, len(g.players))
+	leader := g.mostCapturedSeat()
+	for i, p := range g.players {
+		out[i] = p.GetPistiBonus()
+		if i == leader {
+			out[i] += PishtiScoreMostCards
+		}
+	}
+	return out
+}
+
+// GetProvisionalLeader は暫定の最多捕獲リーダーの席を返す (同数なら -1)。
+func (g *Pishti) GetProvisionalLeader() int { return g.mostCapturedSeat() }
 
 // pishtiCardPoints は 1 枚のカードの基本得点を返す。
 //
@@ -548,6 +581,9 @@ func (g *Pishti) GetConfig() PishtiConfig { return g.config }
 
 // SetConfig は設定を変更する。
 func (g *Pishti) SetConfig(config PishtiConfig) { g.config = config }
+
+// SetGameEndFlagForTest はテスト用に終了フラグを設定する。
+func (g *Pishti) SetGameEndFlagForTest(v bool) { g.state.gameEndFlag = v }
 
 // GetActionLog は棋譜を返す。
 func (g *Pishti) GetActionLog() []*ActionLogEntry { return g.state.actionLog }

--- a/internal/domain/Pishti_test.go
+++ b/internal/domain/Pishti_test.go
@@ -366,3 +366,48 @@ func TestPishti_NextRound_RestartsGame(t *testing.T) {
 		t.Fatalf("NextRound phase = %s", g.GetPhase())
 	}
 }
+
+// **同数なら誰にも +3 は付かない。**暫定スコアと最終集計で規則が割れると、
+// 途中の順位表示が嘘になる (#4892)。
+func TestPishti_ProvisionalScores(t *testing.T) {
+	g := NewDefaultPishti()
+	g.Reset()
+	card := func() *Card { return NewCard(CardDesignSpade, 2, false) }
+	give := func(seat, n int) {
+		cards := make([]*Card, n)
+		for i := range cards {
+			cards[i] = card()
+		}
+		g.GetPlayer(seat).AddCaptured(cards)
+	}
+
+	// 誰も捕獲していなければリーダー無し。
+	if got := g.GetProvisionalLeader(); got != -1 {
+		t.Fatalf("no captures should mean no leader, got %d", got)
+	}
+
+	// 単独リーダーに +3。
+	give(0, 5)
+	give(1, 3)
+	if got := g.GetProvisionalLeader(); got != 0 {
+		t.Fatalf("leader = %d, want 0", got)
+	}
+	prov := g.GetProvisionalScores()
+	if prov[0] != PishtiScoreMostCards {
+		t.Fatalf("sole leader should get +%d, got %d", PishtiScoreMostCards, prov[0])
+	}
+	if prov[1] != 0 {
+		t.Fatalf("non-leader should get nothing, got %d", prov[1])
+	}
+
+	// **同数になったら誰にも付かない** (受け入れ条件2)。
+	give(1, 2)
+	if got := g.GetProvisionalLeader(); got != -1 {
+		t.Fatalf("a tie should have no leader, got %d", got)
+	}
+	for i, v := range g.GetProvisionalScores() {
+		if v != 0 {
+			t.Fatalf("seat %d got %d on a tie, want 0", i, v)
+		}
+	}
+}

--- a/internal/domain/interfaces/pishti.go
+++ b/internal/domain/interfaces/pishti.go
@@ -44,4 +44,8 @@ type PishtiGame interface {
 	GetWinners() []int
 	// GetFinalScores 各プレイヤーの最終得点を取得する
 	GetFinalScores() []int
+	// GetProvisionalScores 対局中の暫定スコアを取得する
+	GetProvisionalScores() []int
+	// GetProvisionalLeader 暫定の最多捕獲リーダーの席を取得する (同数なら -1)
+	GetProvisionalLeader() int
 }

--- a/internal/domain/interfaces/pishti_mock.go
+++ b/internal/domain/interfaces/pishti_mock.go
@@ -140,3 +140,15 @@ func (_m *MockPishtiGame) GetActionLog() []*domain.ActionLogEntry {
 	}
 	return nil
 }
+
+// GetProvisionalScores モック
+func (m *MockPishtiGame) GetProvisionalScores() []int {
+	ret := m.Called()
+	if v, ok := ret.Get(0).([]int); ok {
+		return v
+	}
+	return nil
+}
+
+// GetProvisionalLeader モック
+func (m *MockPishtiGame) GetProvisionalLeader() int { return m.Called().Int(0) }

--- a/internal/i18n/locales/en/pishti.json
+++ b/internal/i18n/locales/en/pishti.json
@@ -13,5 +13,7 @@
   "scoreEntry": "  {{name}}: {{score}} pts",
   "promptCurrentTurn": "Turn: {{name}}",
   "promptHelp": "p <hand> to play a card (capture the pile by matching rank or with a Jack)",
-  "result.scores": "Game over. Scores: {{scores}}"
+  "result.scores": "Game over. Scores: {{scores}}",
+  "provisional": "{{name}} provisional: {{score}}",
+  "provisionalNote": "Provisional totals count only pisti bonuses and most-cards (+3); card points are added at scoring"
 }

--- a/internal/i18n/locales/ja/pishti.json
+++ b/internal/i18n/locales/ja/pishti.json
@@ -13,5 +13,7 @@
   "scoreEntry": "  {{name}}: {{score}}点",
   "promptCurrentTurn": "手番: {{name}}",
   "promptHelp": "p <hand> で手札を場に出す (同ランクまたはJで場札を捕獲)",
-  "result.scores": "ゲーム終了。スコア: {{scores}}"
+  "result.scores": "ゲーム終了。スコア: {{scores}}",
+  "provisional": "{{name}} 暫定: {{score}}点",
+  "provisionalNote": "※ 暫定点はピシュティ賞と最多捕獲(+3)のみ。カード点は集計時に加算されます"
 }


### PR DESCRIPTION
Closes #4892

## 背景

`PishtiPage` は対局中ずっと `provisionalScore = pistiBonus + (単独リーダーなら +3)` を各プレイヤーに出す。一方 `pishtiPlayerStr` はピシュティ賞と `CapturedCount()` を**別々の数値**として出すだけで、CUI プレイヤーは優劣を掴むのに複数人分を毎回暗算することになる。

## 規則はドメインに置いた

issue は「presenter にヘルパーを追加する」案だが、最終集計 (`scoreRound`) が既に「最多枚数判定（同点なら誰ももらえない）」を持っている。**途中の順位表示と精算で規則が割れると、途中の表示が嘘になる。**そこで最多判定を `mostCapturedSeat()` に切り出し、`scoreRound` と新しい `GetProvisionalScores` / `GetProvisionalLeader` の両方がそれを通るようにした。

## テスト

**ドメイン** — 誰も捕獲していなければリーダー無し／単独リーダーに +3、他は 0／**同数になったら誰にも付かない**（受け入れ条件2）

**presenter** — 暫定点と注記が出る／同数では +3 が消えて 0 になる／**ゲーム終了後は「暫定」が消え最終スコアだけになる**（受け入れ条件3）

ネガティブコントロール: 出力ブロックの条件を潰すと落ちる。

`go test -tags test ./...` / `golangci-lint run ./internal/...` (0 issues) green。

## Test plan

- [ ] CI green