### PR TITLE
feat(kemps): announce a four of a kind in the CUI

### DIFF
--- a/internal/adapter/presenter/KempsCuiPresenter.go
+++ b/internal/adapter/presenter/KempsCuiPresenter.go
@@ -48,7 +48,8 @@ func (p *KempsCuiPresenter) Output(g interfaces.KempsGame, lastErr error) string
 				// **揃ったことに気づかないと宣言する権利ごと失う。**Web は交換中
 				// からバナーとボタン強調で知らせるのに、CUI は手札を自分で見て
 				// 判断するしかなかった (#4890)。
-				if player.HasFourOfAKind() {
+				// 終局後は宣言できないので出さない (Web も同様に隠す)。
+				if player.HasFourOfAKind() && !g.GetGameEndFlag() {
 					b.WriteString("  " + color.Green(i18n.T("kemps.fourOfAKindReady")) + "\n")
 				}
 			} else {

--- a/internal/adapter/presenter/KempsCuiPresenter.go
+++ b/internal/adapter/presenter/KempsCuiPresenter.go
@@ -45,6 +45,12 @@ func (p *KempsCuiPresenter) Output(g interfaces.KempsGame, lastErr error) string
 				// 人間の手札のみ公開表示する。
 				b.WriteString(name + " " + team + "\n")
 				b.WriteString("  " + cuiIndexedCardListStr(player) + "\n")
+				// **揃ったことに気づかないと宣言する権利ごと失う。**Web は交換中
+				// からバナーとボタン強調で知らせるのに、CUI は手札を自分で見て
+				// 判断するしかなかった (#4890)。
+				if player.HasFourOfAKind() {
+					b.WriteString("  " + color.Green(i18n.T("kemps.fourOfAKindReady")) + "\n")
+				}
 			} else {
 				b.WriteString(i18n.Tf("kemps.cpuHandLine",
 					"name", name,

--- a/internal/adapter/presenter/KempsCuiPresenter_test.go
+++ b/internal/adapter/presenter/KempsCuiPresenter_test.go
@@ -86,3 +86,39 @@ func TestKempsCuiPresenter_ActionLogOutput(t *testing.T) {
 	g := setupKempsTest()
 	assert.NotEmpty(t, p.ActionLogOutput(g))
 }
+
+// **揃ったことに気づかないと宣言する権利ごと失う。**Web は交換中からバナーと
+// ボタン強調で知らせるのに、CUI は手札を自分で見て判断するしかなかった (#4890)。
+func TestKempsCuiPresenter_AnnouncesFourOfAKind(t *testing.T) {
+	orig := color.NoColor()
+	color.SetNoColor(true)
+	defer color.SetNoColor(orig)
+	p := new(presenter.KempsCuiPresenter)
+
+	// 配られたままでは普通そろっていない。まず出ないことを確かめる。
+	g := setupKempsTest()
+	human := g.GetPlayer(0)
+	human.Reset()
+	for _, d := range []int{domain.CardDesignSpade, domain.CardDesignHeart, domain.CardDesignClover, domain.CardDesignDiamond} {
+		human.AddCard(domain.NewCard(d, 7, false))
+	}
+	// 1 枚だけ別ランクに差し替えると成立しない。
+	human.Reset()
+	for i, d := range []int{domain.CardDesignSpade, domain.CardDesignHeart, domain.CardDesignClover, domain.CardDesignDiamond} {
+		v := 7
+		if i == 3 {
+			v = 8
+		}
+		human.AddCard(domain.NewCard(d, v, false))
+	}
+	assert.NotContains(t, p.Output(g, nil), "4枚が同ランク")
+
+	// 4 枚そろえば出る。
+	human.Reset()
+	for _, d := range []int{domain.CardDesignSpade, domain.CardDesignHeart, domain.CardDesignClover, domain.CardDesignDiamond} {
+		human.AddCard(domain.NewCard(d, 7, false))
+	}
+	out := p.Output(g, nil)
+	assert.Contains(t, out, "4枚が同ランク")
+	assert.Contains(t, out, "ケンプスを宣言できます")
+}

--- a/internal/adapter/presenter/KempsCuiPresenter_test.go
+++ b/internal/adapter/presenter/KempsCuiPresenter_test.go
@@ -95,14 +95,9 @@ func TestKempsCuiPresenter_AnnouncesFourOfAKind(t *testing.T) {
 	defer color.SetNoColor(orig)
 	p := new(presenter.KempsCuiPresenter)
 
-	// 配られたままでは普通そろっていない。まず出ないことを確かめる。
 	g := setupKempsTest()
 	human := g.GetPlayer(0)
-	human.Reset()
-	for _, d := range []int{domain.CardDesignSpade, domain.CardDesignHeart, domain.CardDesignClover, domain.CardDesignDiamond} {
-		human.AddCard(domain.NewCard(d, 7, false))
-	}
-	// 1 枚だけ別ランクに差し替えると成立しない。
+	// 1 枚だけ別ランクなら成立しない。
 	human.Reset()
 	for i, d := range []int{domain.CardDesignSpade, domain.CardDesignHeart, domain.CardDesignClover, domain.CardDesignDiamond} {
 		v := 7
@@ -121,4 +116,9 @@ func TestKempsCuiPresenter_AnnouncesFourOfAKind(t *testing.T) {
 	out := p.Output(g, nil)
 	assert.Contains(t, out, "4枚が同ランク")
 	assert.Contains(t, out, "ケンプスを宣言できます")
+
+	// **終局後は出さない。**宣言できないので案内する意味がなく、Web も
+	// `humanHasFour && !isGameEnd` で隠している（レビュー指摘）。
+	g.SetGameEndFlagForTest(true)
+	assert.NotContains(t, p.Output(g, nil), "4枚が同ランク")
 }

--- a/internal/domain/Kemps.go
+++ b/internal/domain/Kemps.go
@@ -150,6 +150,9 @@ func (g *Kemps) GetConfig() KempsConfig { return g.config }
 // SetConfig は設定を更新する。
 func (g *Kemps) SetConfig(cfg KempsConfig) { g.config = cfg }
 
+// SetGameEndFlagForTest はテスト用に終了フラグを設定する。
+func (g *Kemps) SetGameEndFlagForTest(v bool) { g.gameEndFlag = v }
+
 // ResetWithConfig は設定を更新してゲームを初期化する。
 func (g *Kemps) ResetWithConfig(cfg KempsConfig) {
 	g.config = cfg

--- a/internal/domain/Kemps_test.go
+++ b/internal/domain/Kemps_test.go
@@ -394,3 +394,17 @@ func TestKemps_PlayerJSONRoundTrip(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(`{}`), &empty))
 	assert.NotNil(t, empty.GamePlayer)
 }
+
+// テスト用セッターが実際にフラグを立てること。presenter 側からしか呼ばれないと
+// ドメインのカバレッジに乗らない。
+func TestKemps_SetGameEndFlagForTest(t *testing.T) {
+	g := NewDefaultKemps()
+	g.Reset()
+	if g.GetGameEndFlag() {
+		t.Fatal("a fresh game must not be over")
+	}
+	g.SetGameEndFlagForTest(true)
+	if !g.GetGameEndFlag() {
+		t.Fatal("the setter did not take effect")
+	}
+}

--- a/internal/i18n/locales/en/kemps.json
+++ b/internal/i18n/locales/en/kemps.json
@@ -25,5 +25,6 @@
   "winHuman": "Your team wins!",
   "winCpu": "The opposing team wins...",
   "result.humanWin": "Your team wins!",
-  "result.cpuWin": "The opposing team wins..."
+  "result.cpuWin": "The opposing team wins...",
+  "fourOfAKindReady": "* Four of a kind! You may declare Kemps (declare / d)"
 }

--- a/internal/i18n/locales/ja/kemps.json
+++ b/internal/i18n/locales/ja/kemps.json
@@ -25,5 +25,6 @@
   "winHuman": "あなたのチームの勝ちです！",
   "winCpu": "相手チームの勝ちです...",
   "result.humanWin": "あなたのチームの勝ちです！",
-  "result.cpuWin": "相手チームの勝ちです..."
+  "result.cpuWin": "相手チームの勝ちです...",
+  "fourOfAKindReady": "★ 4枚が同ランクです！ ケンプスを宣言できます（declare / d）"
 }


### PR DESCRIPTION
Closes #4890

## 背景

`KempsPage` は `hasFourOfAKind` が立つと、交換フェーズ中から `kemps-four-ready` の `aria-live` バナーと宣言ボタンの強調で知らせる（#3553 で入った、宣言タイミングを逃さないための中核機能）。一方 `KempsCuiPresenter` は `HasFourOfAKind()` を**一度も呼んでいない**。CUI プレイヤーは手札を自分で見て判断するしかなく、**見落とすと宣言する権利ごと失う**。

## 変更

人間の手札行の直後に `★ 4枚が同ランクです！ ケンプスを宣言できます（declare / d）` を出す。

## テスト

- **1 枚だけ別ランク**の手札では出ないこと（「4 枚あれば出る」だけだと、判定が常に true でも通る）
- 4 枚そろえば出ること

ネガティブコントロール: 追加ブロックを外すと落ちる。

`go test -tags test ./...` / `golangci-lint run ./internal/...` (0 issues) green。

## Test plan

- [ ] CI green