### PR TITLE
feat(spoons): mark same-rank groups in the CUI hand

### DIFF
--- a/internal/adapter/presenter/SpoonsCuiPresenter.go
+++ b/internal/adapter/presenter/SpoonsCuiPresenter.go
@@ -111,23 +111,22 @@ func spoonsGroupedHandStr(player cuiCardList) string {
 			counts[c.GetValue()]++
 		}
 	}
-	parts := make([]string, player.GetCardsSize())
-	for i := range parts {
-		parts[i] = "[" + strconv.Itoa(i) + "]" + cuiCardStr(player.GetCard(i))
-		c := player.GetCard(i)
+	// 索引と区切りは他ゲームと同じ formatCardList に任せ、注記だけを足す
+	// (OmbreCuiPresenter と同じ形)。
+	return formatCardList(player, func(c *domain.Card) string {
+		out := cuiCardStr(c)
 		if c == nil {
-			continue
+			return out
 		}
 		n := counts[c.GetValue()]
 		if n < 2 {
-			continue
+			return out
 		}
 		tag := i18n.Tf("spoons.rankGroup", "count", strconv.Itoa(n))
 		// **3 枚は 1 枚違い。**2 枚と同じ見た目だと、脈があることが伝わらない。
 		if n >= 3 {
 			tag = color.Yellow(tag)
 		}
-		parts[i] += tag
-	}
-	return strings.Join(parts, "  ")
+		return out + tag
+	}, "  ", true)
 }

--- a/internal/adapter/presenter/SpoonsCuiPresenter.go
+++ b/internal/adapter/presenter/SpoonsCuiPresenter.go
@@ -41,7 +41,10 @@ func (p *SpoonsCuiPresenter) Output(g interfaces.SpoonsGame, lastErr error) stri
 			if i == 0 {
 				// 人間の手札のみ公開表示する。
 				b.WriteString(name + " " + letters + spoon + "\n")
-				b.WriteString("  " + cuiIndexedCardListStr(player) + "\n")
+				// **同ランクの組が最大の判断材料。**Web は色付きリングで囲み、
+				// 3 枚以上は脈ありとして強調するのに、CUI は素の一覧しか出さず、
+				// パスする札を暗算させていた (#4889)。
+				b.WriteString("  " + spoonsGroupedHandStr(player) + "\n")
 			} else {
 				b.WriteString(i18n.Tf("spoons.cpuHandLine",
 					"name", name,
@@ -97,4 +100,34 @@ func spoonsLetters(n int) string {
 		n = len(letters)
 	}
 	return strings.Join(letters[:n], "")
+}
+
+// spoonsGroupedHandStr は手札をインデックス付きで並べ、同ランクが 2 枚以上ある
+// 札に枚数を添える。3 枚以上（フォーカード目前）は強調する。
+func spoonsGroupedHandStr(player cuiCardList) string {
+	counts := map[int]int{}
+	for i := range player.GetCardsSize() {
+		if c := player.GetCard(i); c != nil {
+			counts[c.GetValue()]++
+		}
+	}
+	parts := make([]string, player.GetCardsSize())
+	for i := range parts {
+		parts[i] = "[" + strconv.Itoa(i) + "]" + cuiCardStr(player.GetCard(i))
+		c := player.GetCard(i)
+		if c == nil {
+			continue
+		}
+		n := counts[c.GetValue()]
+		if n < 2 {
+			continue
+		}
+		tag := i18n.Tf("spoons.rankGroup", "count", strconv.Itoa(n))
+		// **3 枚は 1 枚違い。**2 枚と同じ見た目だと、脈があることが伝わらない。
+		if n >= 3 {
+			tag = color.Yellow(tag)
+		}
+		parts[i] += tag
+	}
+	return strings.Join(parts, "  ")
 }

--- a/internal/adapter/presenter/SpoonsCuiPresenter_test.go
+++ b/internal/adapter/presenter/SpoonsCuiPresenter_test.go
@@ -79,3 +79,39 @@ func TestSpoonsCuiPresenter_ActionLogOutput(t *testing.T) {
 	g := setupSpoonsTest()
 	assert.NotEmpty(t, p.ActionLogOutput(g))
 }
+
+// **同ランクの組が最大の判断材料。**Web は色付きリングで示すのに、CUI は素の
+// 一覧しか出さず、パスする札を暗算させていた (#4889)。
+func TestSpoonsCuiPresenter_MarksRankGroups(t *testing.T) {
+	orig := color.NoColor()
+	color.SetNoColor(false) // 3 枚組の強調まで見る
+	defer color.SetNoColor(orig)
+	p := new(presenter.SpoonsCuiPresenter)
+
+	g := setupSpoonsTest()
+	human := g.GetPlayer(0)
+	setHand := func(vals []int) {
+		human.Reset()
+		designs := []int{domain.CardDesignSpade, domain.CardDesignHeart, domain.CardDesignClover, domain.CardDesignDiamond}
+		for i, v := range vals {
+			human.AddCard(domain.NewCard(designs[i%len(designs)], v, false))
+		}
+	}
+
+	// バラバラなら印は付かない。
+	setHand([]int{2, 5, 9, 13})
+	assert.NotContains(t, p.Output(g, nil), "(同")
+
+	// 2 枚組には枚数が付くが、強調はしない。
+	setHand([]int{7, 7, 9, 13})
+	two := p.Output(g, nil)
+	assert.Contains(t, two, "(同2枚)")
+	assert.NotContains(t, two, color.Yellow("(同2枚)"))
+
+	// **3 枚は 1 枚違い。**強調してフォーカードが近いことを示す。
+	setHand([]int{7, 7, 7, 13})
+	three := p.Output(g, nil)
+	assert.Contains(t, three, color.Yellow("(同3枚)"))
+	// 組に入らない札には付かない。
+	assert.NotContains(t, three, "(同1枚)")
+}

--- a/internal/i18n/locales/en/spoons.json
+++ b/internal/i18n/locales/en/spoons.json
@@ -19,5 +19,6 @@
   "winHuman": "You win!",
   "winCpu": "{{name}} wins...",
   "result.humanWin": "You win!",
-  "result.cpuWin": "CPU wins..."
+  "result.cpuWin": "CPU wins...",
+  "rankGroup": "(x{{count}})"
 }

--- a/internal/i18n/locales/ja/spoons.json
+++ b/internal/i18n/locales/ja/spoons.json
@@ -19,5 +19,6 @@
   "winHuman": "あなたの勝ちです！",
   "winCpu": "{{name}} の勝ちです...",
   "result.humanWin": "あなたの勝ちです！",
-  "result.cpuWin": "CPUの勝ちです..."
+  "result.cpuWin": "CPUの勝ちです...",
+  "rankGroup": "(同{{count}}枚)"
 }


### PR DESCRIPTION
Closes #4889

## 背景

`SpoonsPage` は `computeSpoonsRankGroups` で同ランクの手札を色付きリングで囲み、3 枚以上は `animate-pulse` で強調する（フォーカード完成に近い札を教える、このゲーム最大の判断材料）。一方 `SpoonsCuiPresenter` は `cuiIndexedCardListStr` で手札をそのまま並べるだけで、どれが組を成しているかを示さない。

## 変更

同ランクが 2 枚以上ある札に `(同2枚)` / `(同3枚)` を添え、**3 枚以上は強調**する。3 枚は 1 枚違いなので、2 枚と同じ見た目だと脈があることが伝わらない。

## テスト

- バラバラの手札には印が付かない
- 2 枚組には枚数が付くが**強調はしない**
- 3 枚組は強調される
- **組に入らない札に `(同1枚)` が付かない**こと（枚数を無条件に付けていないことの確認）

ネガティブコントロール: 付与を外すと落ちる。

`go test -tags test ./...` / `golangci-lint run ./internal/...` (0 issues) green。

## Test plan

- [ ] CI green