### PR TITLE
feat(cuckoo): add sound cues for life loss, king reveals and defeat

### DIFF
--- a/frontend/src/pages/CuckooPage.test.tsx
+++ b/frontend/src/pages/CuckooPage.test.tsx
@@ -10,6 +10,17 @@ vi.mock('../api/gameApi', () => ({
   actionLogApi: { cuckoo: vi.fn() },
 }));
 
+const mockPlaySound = vi.fn();
+const mockSoundValue = { playSound: mockPlaySound, muted: false, toggleMute: vi.fn() };
+/** 中央のタップ (useGameApi / GamePageShell) も同じ mock を通るので、名前で絞る。 */
+const soundCalls = (name: string) => mockPlaySound.mock.calls.filter((c) => c[0] === name).length;
+
+vi.mock('../providers/SoundProvider', () => ({
+  SoundProvider: ({ children }: { children: React.ReactNode }) => children,
+  useSound: () => mockSoundValue,
+  useOptionalSound: () => mockSoundValue,
+}));
+
 const mockExec = vi.mocked(cuckooApi.exec);
 
 function makePlayer(overrides: Partial<CuckooPlayer> = {}): CuckooPlayer {
@@ -299,5 +310,54 @@ describe('CuckooPage', () => {
     renderWithProviders(<CuckooPage />);
     expect(await screen.findByTestId('hint-tooltip')).toBeInTheDocument();
     localStorage.removeItem('hint_enabled_cuckoo');
+  });
+
+  // **山場が全部無音だった。**CPU の手番が自動で進むテンポの速いゲームなので、
+  // バッジだけだとライフ喪失やキング公開を見落とす (#4891)。
+  describe('sound cues', () => {
+    beforeEach(() => {
+      mockPlaySound.mockClear();
+    });
+
+    it('thuds when the human loses a life', async () => {
+      mockExec.mockResolvedValue(makeState({ players: [makePlayer({ id: 0, isHuman: true, lives: 3 })] }));
+      renderWithProviders(<CuckooPage />);
+      await waitFor(() => expect(mockExec).toHaveBeenCalled());
+      // 初回描画だけでは鳴らない (前回値が無いので減ったと判定しない)。
+      expect(soundCalls('lossThud')).toBe(0);
+
+      // **手を打って次の応答を受けると減る。**リセットは確認ダイアログ越しなので
+      // 直接は再取得されない。
+      mockExec.mockResolvedValue(makeState({ players: [makePlayer({ id: 0, isHuman: true, lives: 2 })] }));
+      fireEvent.click(screen.getAllByRole('button', { name: /キープ|交換/ })[0]);
+      await waitFor(() => expect(soundCalls('lossThud')).toBe(1));
+    });
+
+    it('flips when a king is newly revealed', async () => {
+      mockExec.mockResolvedValue(makeState({ players: [makePlayer({ id: 0, isHuman: true })] }));
+      renderWithProviders(<CuckooPage />);
+      await waitFor(() => expect(mockExec).toHaveBeenCalled());
+      expect(soundCalls('cardFlip')).toBe(0);
+
+      mockExec.mockResolvedValue(makeState({ players: [makePlayer({ id: 0, isHuman: true, kingRevealed: true })] }));
+      fireEvent.click(screen.getAllByRole('button', { name: /キープ|交換/ })[0]);
+      await waitFor(() => expect(soundCalls('cardFlip')).toBe(1));
+    });
+
+    // **勝敗の音は GamePageShell が持つ設計。**ページで鳴らすと二重になるので、
+    // lossShow を渡して shell に任せる（勝ちの fanfare は元から shell が鳴らす）。
+    it('lets the shell thud when the human loses the game', async () => {
+      mockExec.mockResolvedValue(makeState({ gameEndFlag: true, winnerIdx: 1 }));
+      renderWithProviders(<CuckooPage />);
+      await waitFor(() => expect(soundCalls('lossThud')).toBe(1));
+      expect(soundCalls('winFanfare')).toBe(0);
+    });
+
+    it('does not thud when the human wins', async () => {
+      mockExec.mockResolvedValue(makeState({ gameEndFlag: true, winnerIdx: 0 }));
+      renderWithProviders(<CuckooPage />);
+      await waitFor(() => expect(mockExec).toHaveBeenCalled());
+      expect(soundCalls('lossThud')).toBe(0);
+    });
   });
 });

--- a/frontend/src/pages/CuckooPage.tsx
+++ b/frontend/src/pages/CuckooPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { cuckooApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CardImage } from '../components/CardImage';
@@ -22,6 +22,7 @@ import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
+import { useSound } from '../providers/SoundProvider';
 import { badgeWarningColors } from '../styles/badgeStyles';
 import { btnPrimary, btnSuccess, btnWarning } from '../styles/buttonStyles';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
@@ -151,6 +152,29 @@ function CuckooPageContent() {
     setHintEnabled: setFrontendHintEnabled,
   } = useGameHint('cuckoo', state);
 
+  // **山場が全部無音だった。**CPU の手番が自動で進むテンポの速いゲームなので、
+  // バッジだけだとライフ喪失やキング公開を見落とす (#4891)。
+  // **フックは早期 return より上。**下に置くと初回だけフック数が変わる。
+  const { playSound } = useSound();
+  const humanLives = state?.players.find((p) => p.isHuman)?.lives ?? null;
+  const prevLivesRef = useRef<number | null>(null);
+  useEffect(() => {
+    if (humanLives !== null && prevLivesRef.current !== null && humanLives < prevLivesRef.current) {
+      playSound('lossThud');
+    }
+    prevLivesRef.current = humanLives;
+  }, [humanLives, playSound]);
+
+  // キング公開は席ごとのフラグ。誰かが新たに公開した瞬間が山場 (スワップ拒否)。
+  const kingRevealed = state?.players.some((p) => p.kingRevealed) ?? false;
+  const prevKingRef = useRef(false);
+  useEffect(() => {
+    if (kingRevealed && !prevKingRef.current) {
+      playSound('cardFlip', { pitchVariation: 0.1 });
+    }
+    prevKingRef.current = kingRevealed;
+  }, [kingRevealed, playSound]);
+
   if (!state)
     return <GameSkeleton gameKey="cuckoo" layout={{ kind: 'trick-taking', trickArea: true, footerHandSize: 1 }} />;
 
@@ -184,6 +208,8 @@ function CuckooPageContent() {
       gamePath="/cuckoo"
       gameEndFlag={isGameEnd}
       winShow={humanWon}
+      // 勝敗の効果音は GamePageShell が持つ設計。ページ側で鳴らすと二重になる。
+      lossShow={isGameEnd && !humanWon}
       loading={loading}
       confirmOpen={confirmOpen}
       confirmReset={confirmReset}


### PR DESCRIPTION
Closes #4891

## 背景

同じ extra2 バケットの姉妹ゲーム（Spoons / Pishti / Cuarenta）は軒並み `useSound` を入れているのに、`CuckooPage` には import も `playSound` も無く、**ライフ喪失・キング公開・勝敗といった山場がすべて無音**だった。CPU の手番が自動で進むテンポの速いゲームなので、視覚情報だけでは見落としやすい。

## 変更

| 契機 | 音 |
|------|-----|
| 人間のライフが減った瞬間 | `lossThud` |
| 誰かがキングを新たに公開した瞬間（スワップ拒否） | `cardFlip` |
| 敗北 | `lossThud`（**shell 経由**） |

新規音源は追加していない（受け入れ条件どおり既存のものを流用）。

## 勝敗音は shell に任せた

最初はページ側で `gameEndFlag` を見て `winFanfare` / `lossThud` を鳴らしたが、**ネガティブコントロールで 3 件中 1 件しか落ちなかった**ことで気づいた: `GamePageShell` が既に

```
winFanfare ── WinCelebration の発火に乗る
lossThud ──── lossShow === true のとき、ゲーム終了ごとに 1 回
```

を担当している（"sound-centralization design"）。ページで鳴らすと勝利ファンファーレが二重になる。Cuckoo は `lossShow` を渡していなかっただけなので、**自前の効果音をやめて `lossShow` を渡す**形にした。

## テスト

- ライフ喪失: 初回描画では鳴らず（前回値が無いので減ったと判定しない）、減った応答で 1 回
- キング公開: 立っていない状態からの遷移で 1 回
- 敗北で `lossThud`、**勝利では鳴らない**

ネガティブコントロール: 3 つの条件をそれぞれ潰すと該当テストが落ちる。

`bun run check` / `bun run typecheck` / vitest green。

## Test plan

- [ ] CI green