### PR TITLE
feat(tichu): show the running score and bomb count in the CUI

### DIFF
--- a/internal/adapter/presenter/TichuCuiPresenter.go
+++ b/internal/adapter/presenter/TichuCuiPresenter.go
@@ -40,6 +40,21 @@ func (p *TichuCuiPresenter) Output(tg interfaces.TichuGame, lastErr error) strin
 			}
 		}
 
+		// **得点差もボムの使用状況も終局まで分からなかった。**Web は常時
+		// スコアバーに出している (#4888)。終局時は下でもう一度出すので、
+		// ここは進行中だけ。
+		if phase != domain.TichuPhaseEnd {
+			scores := tg.GetScores()
+			fmt.Fprintf(b, "%s (P0/P2): %d  %s (P1/P3): %d\n",
+				i18n.T("tichu.teamA"), scores[0], i18n.T("tichu.teamB"), scores[1])
+			if n := tg.GetBombCount(); n > 0 {
+				b.WriteString(i18n.Tf("tichu.bombCount", "count", strconv.Itoa(n)) + "\n")
+			}
+			if tg.GetIsOneTwo() {
+				b.WriteString(color.BoldYellow(i18n.T("tichu.oneTwo")) + "\n")
+			}
+		}
+
 		if phase == domain.TichuPhaseEnd {
 			scores := tg.GetScores()
 			b.WriteString(color.BoldYellow(i18n.T("tichu.gameEnd")) + "\n")

--- a/internal/adapter/presenter/TichuCuiPresenter_test.go
+++ b/internal/adapter/presenter/TichuCuiPresenter_test.go
@@ -41,3 +41,31 @@ func TestTichuCuiPresenter_ActionLog(t *testing.T) {
 	p := new(presenter.TichuCuiPresenter)
 	assert.NotEmpty(t, p.ActionLogOutput(tg))
 }
+
+// **得点差もボムの使用状況も終局まで分からなかった。**Web は常時スコアバーに
+// 出している (#4888)。
+func TestTichuCuiPresenter_ShowsRunningScoreAndBombs(t *testing.T) {
+	tg := newTichuAllCpu()
+	tg.Reset()
+	p := new(presenter.TichuCuiPresenter)
+
+	// 宣言フェーズから既にスコアが出る。
+	declare := p.Output(tg, nil)
+	assert.Contains(t, declare, "チームA (P0/P2):")
+	assert.Contains(t, declare, "チームB (P1/P3):")
+	// まだボムは使われていないので行は出さない。
+	assert.NotContains(t, declare, "ボム使用")
+
+	for tg.GetPhase() == domain.TichuPhaseDeclare {
+		tg.CpuPlay()
+	}
+	assert.Contains(t, p.Output(tg, nil), "チームA (P0/P2):")
+
+	// **終局時に二重に出さない。**下の gameEnd ブロックが出す。
+	for !tg.GetGameEndFlag() {
+		tg.CpuPlay()
+	}
+	end := p.Output(tg, nil)
+	assert.Equal(t, 1, strings.Count(end, "チームA (P0/P2):"))
+	assert.Contains(t, end, "ディール終了")
+}

--- a/internal/adapter/presenter/TichuCuiPresenter_test.go
+++ b/internal/adapter/presenter/TichuCuiPresenter_test.go
@@ -61,6 +61,14 @@ func TestTichuCuiPresenter_ShowsRunningScoreAndBombs(t *testing.T) {
 	}
 	assert.Contains(t, p.Output(tg, nil), "チームA (P0/P2):")
 
+	// ボムが使われたら回数が出る。
+	tg.SetBombCountForTest(2)
+	assert.Contains(t, p.Output(tg, nil), "ボム使用: 2回")
+
+	// ワンツーが成立したらその旨も出る。
+	tg.SetIsOneTwoForTest(true)
+	assert.Contains(t, p.Output(tg, nil), "ワンツー成立")
+
 	// **終局時に二重に出さない。**下の gameEnd ブロックが出す。
 	for !tg.GetGameEndFlag() {
 		tg.CpuPlay()

--- a/internal/domain/Tichu.go
+++ b/internal/domain/Tichu.go
@@ -595,6 +595,12 @@ func (t *Tichu) GetConfig() TichuConfig { return t.config }
 // SetConfig 設定変更
 func (t *Tichu) SetConfig(config TichuConfig) { t.config = config }
 
+// SetBombCountForTest はテスト用にボム使用回数を設定する。
+func (t *Tichu) SetBombCountForTest(n int) { t.round.bombCount = n }
+
+// SetIsOneTwoForTest はテスト用にワンツー成立を設定する。
+func (t *Tichu) SetIsOneTwoForTest(v bool) { t.round.oneTwo = v }
+
 // HasPendingAction ペンディングアクションがあるか (常にfalse)
 func (t *Tichu) HasPendingAction() bool { return false }
 

--- a/internal/domain/Tichu_test.go
+++ b/internal/domain/Tichu_test.go
@@ -5,6 +5,8 @@ package domain
 import (
 	"encoding/json"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func newAllCpuTichu() *Tichu {
@@ -244,4 +246,15 @@ func TestTichuConfigValidate(t *testing.T) {
 	if err := json.Unmarshal(data, &c); err != nil {
 		t.Fatalf("config unmarshal: %v", err)
 	}
+}
+
+// テスト用セッターが効くこと。presenter からしか呼ばないとドメインの
+// カバレッジに乗らない。
+func TestTichu_TestSetters(t *testing.T) {
+	g := newAllCpuTichu()
+	g.Reset()
+	g.SetBombCountForTest(3)
+	assert.Equal(t, 3, g.GetBombCount())
+	g.SetIsOneTwoForTest(true)
+	assert.True(t, g.GetIsOneTwo())
 }

--- a/internal/i18n/locales/en/tichu.json
+++ b/internal/i18n/locales/en/tichu.json
@@ -14,5 +14,7 @@
   "grandTichu": "Grand Tichu",
   "you": "You",
   "playerRank": " (finished #{{rank}})",
-  "playerCardCount": " ({{count}} cards)"
+  "playerCardCount": " ({{count}} cards)",
+  "bombCount": "Bombs played: {{count}}",
+  "oneTwo": "One-two! (the same team went out first and second)"
 }

--- a/internal/i18n/locales/ja/tichu.json
+++ b/internal/i18n/locales/ja/tichu.json
@@ -14,5 +14,7 @@
   "grandTichu": "グランドティチュー",
   "you": "あなた",
   "playerRank": " (上がり {{rank}}位)",
-  "playerCardCount": " ({{count}}枚)"
+  "playerCardCount": " ({{count}}枚)",
+  "bombCount": "ボム使用: {{count}}回",
+  "oneTwo": "ワンツー成立！ (同チームが 1・2 位)"
 }


### PR DESCRIPTION
Closes #4888

## 背景

`TichuPage` はプレイ中ずっと `tichu-score-bar` にチーム得点・`bombCount`・`isOneTwo` を出す。一方 `TichuCuiPresenter.Output` は `GetScores()` を `TichuPhaseEnd` の分岐内でしか呼ばず、`GetBombCount()` と `GetIsOneTwo()` は**一度も呼んでいない**（interfaces には両方ある）。CUI プレイヤーは終局まで得点差もボムの使用状況も分からない。

## 変更

進行中のブロックに:

```
チームA (P0/P2): 55  チームB (P1/P3): 45
ボム使用: 2回
ワンツー成立！ (同チームが 1・2 位)
```

- **終局時は出さない。**既存の `TichuPhaseEnd` ブロックが同じ内容を出すので、二重になる
- ボムが使われていなければ行そのものを出さない（`0回` は毎回出しても情報がない）

## テスト

- 宣言フェーズから既にスコアが出ること、**まだボムが無いうちは行が出ない**こと
- プレイフェーズでも出ること
- **終局時にスコア行が 1 回しか出ないこと**（`strings.Count` で数える。二重表示は Contains では見つからない）

ネガティブコントロール: 追加ブロックを外すと落ちる。

`go test -tags test ./...` / `golangci-lint run ./internal/...` (0 issues) green。

## Test plan

- [ ] CI green