### PR TITLE
feat(sixcardgolf): highlight the grid slot the hint already computed

### DIFF
--- a/frontend/src/pages/SixCardGolfPage.test.tsx
+++ b/frontend/src/pages/SixCardGolfPage.test.tsx
@@ -1,6 +1,7 @@
 import { screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { sixcardgolfApi } from '../api/gameApi';
+import { useGameHint } from '../hooks/useGameHint';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, SixCardGolfResponse, SixCardGolfSlot } from '../types/card';
 import { SixCardGolfPage } from './SixCardGolfPage';
@@ -8,6 +9,10 @@ import { SixCardGolfPage } from './SixCardGolfPage';
 vi.mock('../api/gameApi', () => ({
   sixcardgolfApi: { exec: vi.fn() },
   actionLogApi: { sixcardgolf: vi.fn() },
+}));
+
+vi.mock('../hooks/useGameHint', () => ({
+  useGameHint: vi.fn(() => ({ hint: null, hintEnabled: false, setHintEnabled: vi.fn() })),
 }));
 
 const mockExec = vi.mocked(sixcardgolfApi.exec);
@@ -112,5 +117,44 @@ describe('SixCardGolfPage', () => {
     // Column 0 has a hidden bottom card → uncertain "+?" display; column 1 is fully revealed.
     expect(screen.getByTestId('scg-column-score-0')).toHaveTextContent('+?');
     expect(screen.getByTestId('scg-column-score-1')).not.toHaveTextContent('+?');
+  });
+
+  // **ヒントは既にどのマスかを算出している。**渡さないと 6 マスから目視で
+  // 探し直させることになる (#4887)。
+  describe('hinted slot highlight', () => {
+    it('marks the slot the hint points at', async () => {
+      vi.mocked(useGameHint).mockReturnValue({
+        hint: { targetAction: 'swap', reason: 'hintReason.swapHigh', confidence: 'strong', targetPos: 1 },
+        hintEnabled: true,
+        setHintEnabled: vi.fn(),
+      });
+      renderWithProviders(<SixCardGolfPage />);
+      await waitFor(() => expect(mockExec).toHaveBeenCalled());
+
+      const hinted = document.querySelectorAll('[data-hinted="true"]');
+      expect(hinted).toHaveLength(1);
+    });
+
+    it('marks nothing while hints are off', async () => {
+      vi.mocked(useGameHint).mockReturnValue({
+        hint: { targetAction: 'swap', reason: 'hintReason.swapHigh', confidence: 'strong', targetPos: 1 },
+        hintEnabled: false,
+        setHintEnabled: vi.fn(),
+      });
+      renderWithProviders(<SixCardGolfPage />);
+      await waitFor(() => expect(mockExec).toHaveBeenCalled());
+      expect(document.querySelectorAll('[data-hinted="true"]')).toHaveLength(0);
+    });
+
+    it('marks nothing when the hint carries no position', async () => {
+      vi.mocked(useGameHint).mockReturnValue({
+        hint: { targetAction: 'discard', reason: 'hintReason.discardHigh', confidence: 'strong' },
+        hintEnabled: true,
+        setHintEnabled: vi.fn(),
+      });
+      renderWithProviders(<SixCardGolfPage />);
+      await waitFor(() => expect(mockExec).toHaveBeenCalled());
+      expect(document.querySelectorAll('[data-hinted="true"]')).toHaveLength(0);
+    });
   });
 });

--- a/frontend/src/pages/SixCardGolfPage.test.tsx
+++ b/frontend/src/pages/SixCardGolfPage.test.tsx
@@ -119,8 +119,6 @@ describe('SixCardGolfPage', () => {
     expect(screen.getByTestId('scg-column-score-1')).not.toHaveTextContent('+?');
   });
 
-  // **ヒントは既にどのマスかを算出している。**渡さないと 6 マスから目視で
-  // 探し直させることになる (#4887)。
   describe('hinted slot highlight', () => {
     it('marks the slot the hint points at', async () => {
       vi.mocked(useGameHint).mockReturnValue({

--- a/frontend/src/pages/SixCardGolfPage.tsx
+++ b/frontend/src/pages/SixCardGolfPage.tsx
@@ -206,8 +206,6 @@ function SixCardGolfPageContent() {
                     faceDownLabel={t('gridSlotFaceDownAria', { pos: sIdx + 1 })}
                     cardWidth={cardWidth}
                     isHumanGrid={player.isHuman}
-                    // **ヒントは既にどのマスかを算出している。**渡さないと
-                    // 6 マスから目視で探し直させることになる (#4887)。
                     hinted={hintEnabled && player.isHuman && hint?.targetPos === sIdx}
                     phase={phase}
                     canFlip={state.canFlip}
@@ -387,7 +385,7 @@ function GridSlotButton({
         clickable
           ? `cursor-pointer ring-2 ring-ds-warning hover:ring-ds-warning-hover ${focusRingWhite}`
           : 'cursor-default',
-        // ヒントの指す 1 マスは、押せる枠より強い印にする。
+        // 押せる枠より強い印にする。
         hinted ? 'ring-4 ring-ds-accent' : '',
       ].join(' ')}
       data-hinted={hinted ? 'true' : undefined}

--- a/frontend/src/pages/SixCardGolfPage.tsx
+++ b/frontend/src/pages/SixCardGolfPage.tsx
@@ -206,6 +206,9 @@ function SixCardGolfPageContent() {
                     faceDownLabel={t('gridSlotFaceDownAria', { pos: sIdx + 1 })}
                     cardWidth={cardWidth}
                     isHumanGrid={player.isHuman}
+                    // **ヒントは既にどのマスかを算出している。**渡さないと
+                    // 6 マスから目視で探し直させることになる (#4887)。
+                    hinted={hintEnabled && player.isHuman && hint?.targetPos === sIdx}
                     phase={phase}
                     canFlip={state.canFlip}
                     isHumanTurn={isHumanTurn}
@@ -339,6 +342,7 @@ function GridSlotButton({
   faceDownLabel,
   cardWidth,
   isHumanGrid,
+  hinted,
   phase,
   canFlip,
   isHumanTurn,
@@ -351,6 +355,7 @@ function GridSlotButton({
   faceDownLabel: string;
   cardWidth: number;
   isHumanGrid: boolean;
+  hinted: boolean;
   phase: number;
   canFlip: boolean;
   isHumanTurn: boolean;
@@ -377,11 +382,15 @@ function GridSlotButton({
   return (
     <button
       type="button"
-      className={`relative flex items-center justify-center rounded transition-all ${
+      className={[
+        'relative flex items-center justify-center rounded transition-all',
         clickable
           ? `cursor-pointer ring-2 ring-ds-warning hover:ring-ds-warning-hover ${focusRingWhite}`
-          : 'cursor-default'
-      }`}
+          : 'cursor-default',
+        // ヒントの指す 1 マスは、押せる枠より強い印にする。
+        hinted ? 'ring-4 ring-ds-accent' : '',
+      ].join(' ')}
+      data-hinted={hinted ? 'true' : undefined}
       style={{ width: cardWidth + 8 }}
       onClick={handleClick}
       disabled={!clickable}

--- a/frontend/src/types/hint.ts
+++ b/frontend/src/types/hint.ts
@@ -9,4 +9,12 @@ export interface HintResult {
   reason: string;
   /** Confidence level of the recommendation. */
   confidence: HintConfidence;
+  /**
+   * Board position the advice points at, when the hint knows one.
+   *
+   * A hint that says "swap with your highest card" has already worked out
+   * *which* card it means; dropping the index leaves the player to redo that
+   * search by eye (#4887). Pages use it to highlight the slot.
+   */
+  targetPos?: number;
 }

--- a/frontend/src/utils/hints/sixcardgolfHint.test.ts
+++ b/frontend/src/utils/hints/sixcardgolfHint.test.ts
@@ -92,6 +92,9 @@ describe('getSixcardgolfHint', () => {
       targetAction: 'swap',
       reason: 'hintReason.swapHigh',
       confidence: 'strong',
+      // **どのマスかまで返す。**返さないと 6 マスから目視で探し直させる (#4887)。
+      // 既定グリッドの表向きは 5(0) と 8(1)。最も高いのは 8 なので位置 1。
+      targetPos: 1,
     });
   });
 
@@ -136,6 +139,8 @@ describe('getSixcardgolfHint', () => {
       targetAction: 'swap',
       reason: 'hintReason.columnMatch',
       confidence: 'strong',
+      // 列を揃えられるマスそのもの（grid[0] の相方 = grid[3]）を指す。
+      targetPos: 3,
     });
   });
 });

--- a/frontend/src/utils/hints/sixcardgolfHint.test.ts
+++ b/frontend/src/utils/hints/sixcardgolfHint.test.ts
@@ -92,7 +92,6 @@ describe('getSixcardgolfHint', () => {
       targetAction: 'swap',
       reason: 'hintReason.swapHigh',
       confidence: 'strong',
-      // **どのマスかまで返す。**返さないと 6 マスから目視で探し直させる (#4887)。
       // 既定グリッドの表向きは 5(0) と 8(1)。最も高いのは 8 なので位置 1。
       targetPos: 1,
     });

--- a/frontend/src/utils/hints/sixcardgolfHint.test.ts
+++ b/frontend/src/utils/hints/sixcardgolfHint.test.ts
@@ -142,4 +142,35 @@ describe('getSixcardgolfHint', () => {
       targetPos: 3,
     });
   });
+
+  // 伏せ札を勧める 2 経路。どちらも位置を返す (#4887)。
+  it('points at the first face-down slot when a low card has no visible target', () => {
+    // 表向きが 1 枚も無ければ「最も高い表札」は選べない。
+    const grid = makeDefaultGrid().map((slot) => makeSlot(slot.card, false));
+    const state = makeState({
+      phase: 2,
+      drawnCard: makeCard(2),
+      players: [
+        { id: 0, isHuman: true, grid, roundScore: 0, cumulativeScore: 0, allFaceUp: false },
+        { id: 1, isHuman: false, grid: makeDefaultGrid(), roundScore: 0, cumulativeScore: 0, allFaceUp: false },
+      ],
+    });
+    expect(getSixcardgolfHint(state)).toEqual({
+      targetAction: 'swap',
+      reason: 'hintReason.swapFaceDown',
+      confidence: 'moderate',
+      targetPos: 0,
+    });
+  });
+
+  it('points at the first face-down slot for a middling card', () => {
+    // 6 は低くも高くもないので、伏せ札との交換になる。既定グリッドの伏せ札は位置 2。
+    const result = getSixcardgolfHint(makeState({ phase: 2, drawnCard: makeCard(6) }));
+    expect(result).toEqual({
+      targetAction: 'swap',
+      reason: 'hintReason.swapFaceDown',
+      confidence: 'moderate',
+      targetPos: 2,
+    });
+  });
 });

--- a/frontend/src/utils/hints/sixcardgolfHint.ts
+++ b/frontend/src/utils/hints/sixcardgolfHint.ts
@@ -48,18 +48,33 @@ export function getSixcardgolfHint(state: SixCardGolfResponse): HintResult | nul
     // Check column match opportunity: if drawn card matches a visible card in the same column
     const columnMatchIdx = findColumnMatchSwap(human.grid, state.drawnCard.value);
     if (columnMatchIdx !== -1) {
-      return { targetAction: 'swap', reason: 'hintReason.columnMatch', confidence: 'strong' };
+      return {
+        targetAction: 'swap',
+        reason: 'hintReason.columnMatch',
+        confidence: 'strong',
+        targetPos: columnMatchIdx,
+      };
     }
 
     // Low drawn card: suggest swapping with highest visible or face-down
     if (LOW_VALUES.has(drawnValue)) {
       const highVisibleIdx = findHighestVisibleCard(human.grid);
       if (highVisibleIdx !== -1) {
-        return { targetAction: 'swap', reason: 'hintReason.swapHigh', confidence: 'strong' };
+        return {
+          targetAction: 'swap',
+          reason: 'hintReason.swapHigh',
+          confidence: 'strong',
+          targetPos: highVisibleIdx,
+        };
       }
       const faceDownIdx = human.grid.findIndex((s) => !s.faceUp);
       if (faceDownIdx !== -1) {
-        return { targetAction: 'swap', reason: 'hintReason.swapFaceDown', confidence: 'moderate' };
+        return {
+          targetAction: 'swap',
+          reason: 'hintReason.swapFaceDown',
+          confidence: 'moderate',
+          targetPos: faceDownIdx,
+        };
       }
     }
 
@@ -71,7 +86,12 @@ export function getSixcardgolfHint(state: SixCardGolfResponse): HintResult | nul
     // Medium value: suggest swapping with face-down if available
     const faceDownIdx = human.grid.findIndex((s) => !s.faceUp);
     if (faceDownIdx !== -1) {
-      return { targetAction: 'swap', reason: 'hintReason.swapFaceDown', confidence: 'moderate' };
+      return {
+        targetAction: 'swap',
+        reason: 'hintReason.swapFaceDown',
+        confidence: 'moderate',
+        targetPos: faceDownIdx,
+      };
     }
 
     return { targetAction: 'discard', reason: 'hintReason.discardHigh', confidence: 'moderate' };


### PR DESCRIPTION
Closes #4887

## 背景

`getSixcardgolfHint` は内部で `findColumnMatchSwap`（列を揃えられるマス）、`findHighestVisibleCard`（交換すべき最も高いカード）、`faceDownIdx`（伏せ札の交換先）といった**具体的なグリッド位置を計算している**のに、返り値は `targetAction: 'swap'` と汎用の理由キーだけで、その位置を捨てていた。プレイヤーは「高いカードと交換」という助言を受けて、6 マスから目視で探し直すことになる。

## 変更

- `HintResult` に任意の `targetPos?: number` を追加（**任意**なので他ゲームのヒントは無変更）
- スワップを勧める 4 分岐（列マッチ / 低い札で高い表札と交換 / 低い札で伏せ札と交換 / 中間札で伏せ札と交換）がそれぞれ算出済みの位置を返す
- `GridSlotButton` にヒント印を追加（押せる枠より強い `ring-4 ring-ds-accent`）

## テスト

**hint util** — 既存の 2 テストに `targetPos` を追加。既定グリッドの表向きは 5(0)/8(1) なので最高は位置 1、列マッチは `grid[0]` の相方の位置 3

**ページ 3 件** — 指すマスが 1 つだけ光る／**ヒントを切っていれば光らない**／**位置を持たないヒント（discard）では光らない**

ネガティブコントロール: `hinted` を `false` 固定にすると落ちる。

`bun run check` / `bun run typecheck` / vitest green。

## Test plan

- [ ] CI green