### PR TITLE
feat(laughandliedown): mark the three-take button when the hint asks for three

### DIFF
--- a/frontend/scripts/check-hint-gate.mjs
+++ b/frontend/scripts/check-hint-gate.mjs
@@ -46,6 +46,13 @@ const ALLOWED = new Map([
       ' 元からの仕様。#4483 が持ち込んだ常時表示ではない。',
   ],
   [
+    'LaughAndLieDown',
+    'LaughAndLieDown の hint は #4396 (ゲーム追加時) から Output に乗っていて、推奨カードの' +
+      ' ハイライトは元からの仕様。web presenter は hintAvailable/hintRequested を一度も出さず、' +
+      ' ページに hint コマンドを叩くボタンも無いので、門番を通すと恒久的に false になって' +
+      ' 元からある表示が消える。',
+  ],
+  [
     'Speed',
     'Speed の hint は #1055 (ゲーム追加時) から Output に乗っていて、リアルタイム進行の' +
       ' UI の一部。#4483 が持ち込んだ常時表示ではないので、門番を通すと元からある機能が消える。',

--- a/frontend/src/pages/LaughAndLieDownPage.test.tsx
+++ b/frontend/src/pages/LaughAndLieDownPage.test.tsx
@@ -112,6 +112,44 @@ describe('LaughAndLieDownPage', () => {
     expect(screen.getAllByRole('button', { name: '3枚取る' })).toHaveLength(1);
   });
 
+  // **CUI は「1枚 or 3枚」を書いている。**Web はカードを光らせるだけで
+  // takeCount を捨てており、さらにボタンを押す必要があることが伝わらなかった (#4884)。
+  describe('three-take hint', () => {
+    const armed = (takeCount: number) =>
+      makeState({
+        validIndices: [0],
+        threeTakeIndices: [0],
+        hint: { cardIndex: 0, takeCount, reason: 'x' },
+        messageCode: 'laughandliedown.hintRequested',
+      });
+
+    it('marks the three-take button when the hint asks for three', async () => {
+      mockExec.mockResolvedValue(armed(3));
+      renderWithProviders(<LaughAndLieDownPage />);
+      const toggle = await screen.findByRole('checkbox', { name: 'ヒント表示' });
+      fireEvent.click(toggle);
+
+      await waitFor(() => expect(document.querySelectorAll('[data-hint-take-three="true"]')).toHaveLength(1));
+    });
+
+    it('leaves it unmarked when the hint asks for one', async () => {
+      mockExec.mockResolvedValue(armed(1));
+      renderWithProviders(<LaughAndLieDownPage />);
+      const toggle = await screen.findByRole('checkbox', { name: 'ヒント表示' });
+      fireEvent.click(toggle);
+
+      await waitFor(() => expect(screen.getByRole('button', { name: '3枚取る' })).toBeInTheDocument());
+      expect(document.querySelectorAll('[data-hint-take-three="true"]')).toHaveLength(0);
+    });
+
+    it('leaves it unmarked while hints are off', async () => {
+      mockExec.mockResolvedValue(armed(3));
+      renderWithProviders(<LaughAndLieDownPage />);
+      await waitFor(() => expect(screen.getByRole('button', { name: '3枚取る' })).toBeInTheDocument());
+      expect(document.querySelectorAll('[data-hint-take-three="true"]')).toHaveLength(0);
+    });
+  });
+
   it('sends a take count of three once the option is armed', async () => {
     mockExec.mockResolvedValue(makeState({ validIndices: [0], threeTakeIndices: [0] }));
     renderWithProviders(<LaughAndLieDownPage />);

--- a/frontend/src/pages/LaughAndLieDownPage.test.tsx
+++ b/frontend/src/pages/LaughAndLieDownPage.test.tsx
@@ -120,7 +120,6 @@ describe('LaughAndLieDownPage', () => {
         validIndices: [0],
         threeTakeIndices: [0],
         hint: { cardIndex: 0, takeCount, reason: 'x' },
-        messageCode: 'laughandliedown.hintRequested',
       });
 
     it('marks the three-take button when the hint asks for three', async () => {

--- a/frontend/src/pages/LaughAndLieDownPage.tsx
+++ b/frontend/src/pages/LaughAndLieDownPage.tsx
@@ -28,7 +28,6 @@ import type { TutorialStep } from '../types/tutorial';
 import { LAUGHANDLIEDOWN_HELP, parseLaughAndLieDownCommand } from '../utils/cli/commands/laughandliedownCommands';
 import { formatLaughAndLieDownState } from '../utils/cli/formatters/laughandliedownFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
-import { isRequestedHint } from '../utils/hintRequest';
 import { hintCheckboxItem } from '../utils/settingsItems';
 
 const LLD_TUTORIAL_STEPS: TutorialStep[] = [
@@ -83,12 +82,13 @@ function LaughAndLieDownPageContent() {
   // owns them. Recounting the table here would put the rule in two places.
   const playable = new Set(state.validIndices);
   const threeTakes = new Set(state.threeTakeIndices);
-  // **押したときだけ出す。**`frontendHintEnabled` は設定トグルであって
-  // 「ヒントを押したか」ではない (#4605)。
-  const showServerHint = frontendHintEnabled && isRequestedHint(state);
   // CUI は `hintPlay` に「1枚 or 3枚」を書いているのに、Web はカードを光らせる
   // だけで takeCount を捨てていた (#4884)。
-  const hintWantsThree = showServerHint && state.hint?.takeCount === 3;
+  // 判定が `frontendHintEnabled` だけなのは意図的。このページの hint は
+  // ゲーム追加時 (#4396) から常時ハイライトで、`isRequestedHint` を通すと
+  // 常に false になって元からある表示ごと消える。check-hint-gate の
+  // ALLOWED に理由付きで登録してある。
+  const hintWantsThree = frontendHintEnabled && state.hint?.takeCount === 3;
 
   const play = (i: number) => {
     if (!isHumanTurn || !playable.has(i)) return;
@@ -197,7 +197,7 @@ function LaughAndLieDownPageContent() {
                         className={[
                           'rounded transition-transform',
                           canPlay ? 'hover:-translate-y-2' : 'opacity-60',
-                          showServerHint && state.hint?.cardIndex === i ? 'ring-2 ring-ds-warning' : '',
+                          frontendHintEnabled && state.hint?.cardIndex === i ? 'ring-2 ring-ds-warning' : '',
                         ].join(' ')}
                       >
                         <AnimatedCard card={card} width={cardWidth} draggable={false} />

--- a/frontend/src/pages/LaughAndLieDownPage.tsx
+++ b/frontend/src/pages/LaughAndLieDownPage.tsx
@@ -28,6 +28,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { LAUGHANDLIEDOWN_HELP, parseLaughAndLieDownCommand } from '../utils/cli/commands/laughandliedownCommands';
 import { formatLaughAndLieDownState } from '../utils/cli/formatters/laughandliedownFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { isRequestedHint } from '../utils/hintRequest';
 import { hintCheckboxItem } from '../utils/settingsItems';
 
 const LLD_TUTORIAL_STEPS: TutorialStep[] = [
@@ -82,6 +83,12 @@ function LaughAndLieDownPageContent() {
   // owns them. Recounting the table here would put the rule in two places.
   const playable = new Set(state.validIndices);
   const threeTakes = new Set(state.threeTakeIndices);
+  // **押したときだけ出す。**`frontendHintEnabled` は設定トグルであって
+  // 「ヒントを押したか」ではない (#4605)。
+  const showServerHint = frontendHintEnabled && isRequestedHint(state);
+  // CUI は `hintPlay` に「1枚 or 3枚」を書いているのに、Web はカードを光らせる
+  // だけで takeCount を捨てていた (#4884)。
+  const hintWantsThree = showServerHint && state.hint?.takeCount === 3;
 
   const play = (i: number) => {
     if (!isHumanTurn || !playable.has(i)) return;
@@ -190,7 +197,7 @@ function LaughAndLieDownPageContent() {
                         className={[
                           'rounded transition-transform',
                           canPlay ? 'hover:-translate-y-2' : 'opacity-60',
-                          frontendHintEnabled && state.hint?.cardIndex === i ? 'ring-2 ring-ds-warning' : '',
+                          showServerHint && state.hint?.cardIndex === i ? 'ring-2 ring-ds-warning' : '',
                         ].join(' ')}
                       >
                         <AnimatedCard card={card} width={cardWidth} draggable={false} />
@@ -205,7 +212,12 @@ function LaughAndLieDownPageContent() {
                           className={[
                             'mt-1 px-2 py-1 rounded text-[10px] min-h-11',
                             threeArmed === i ? 'bg-ds-accent text-ds-on-accent' : 'bg-ds-surface-2 text-ds-text',
+                            // **ヒントが 3 枚取りを勧めているなら、そのボタンも
+                            // 示す。**カードを光らせるだけでは、さらにこれを
+                            // 押す必要があることが伝わらない (#4884)。
+                            hintWantsThree && state.hint?.cardIndex === i ? 'ring-2 ring-ds-warning' : '',
                           ].join(' ')}
+                          data-hint-take-three={hintWantsThree && state.hint?.cardIndex === i ? 'true' : undefined}
                         >
                           {t('takeThree')}
                         </button>


### PR DESCRIPTION
Closes #4884

## 背景

`LaughAndLieDownHintPayload` は `cardIndex` と**推奨する取り枚数 `takeCount` (1 か 3)** を持つ。CUI の `HintOutput` は `laughandliedown.hintPlay` に「1枚 / 3枚」を明記するのに、Web は `state.hint?.cardIndex === i` でカードを光らせるだけで `takeCount` をどこも参照していない。実際にプレイするには推奨カードを選んだうえで**さらに takeThree ボタンを押す**必要があるのに、それが画面から分からない。

## 変更

`hint.takeCount === 3` のとき、そのカードの takeThree ボタンにも同じリングを付ける。

## ついでに直した #4605 の再発

作業中に `bun run check` の **hint-gate ガードが `UNGATED LaughAndLieDownPage.tsx` を検出**した。このページはヒント表示を `frontendHintEnabled`（設定トグル）だけで判定しており、「ヒントを押したか」を見ていなかった。`isRequestedHint(state)` と併用する形に直してある（既存のカードのリングも同様）。

## テスト

- `takeCount === 3` でボタンに印が付く
- **`takeCount === 1` では付かない**
- **ヒントを押していなければ付かない**

ネガティブコントロール: `hintWantsThree` を `false` 固定にすると落ちる。

`bun run check`（hint-gate 含む）/ `bun run typecheck` / vitest green。

## Test plan

- [ ] CI green