### PR TITLE
fix(koenigrufen): name the called king's suit in the CUI hint

### DIFF
--- a/internal/adapter/presenter/BigTwoCuiPresenter_test.go
+++ b/internal/adapter/presenter/BigTwoCuiPresenter_test.go
@@ -141,3 +141,41 @@ func TestBigTwoCuiPresenter_Output(t *testing.T) {
 		assert.Contains(t, p.Output(m, errors.New("invalid play")), "invalid play")
 	})
 }
+
+// 8 種類の役名が全部揃っていること。#5024 で switch にしたとき、patch coverage が
+// 落ちた分をここで埋める。名前の抜けは Web のバッジとの食い違いになる。
+func TestBigTwoCuiPresenter_NamesEveryPlayType(t *testing.T) {
+	orig := color.NoColor()
+	color.SetNoColor(true)
+	defer color.SetNoColor(orig)
+	p := new(presenter.BigTwoCuiPresenter)
+
+	cases := []struct {
+		playType domain.BigTwoPlayType
+		want     string
+	}{
+		{domain.BigTwoPlaySingle, "[シングル]"},
+		{domain.BigTwoPlayPair, "[ペア]"},
+		{domain.BigTwoPlayTriple, "[トリプル]"},
+		{domain.BigTwoPlayStraight, "[ストレート]"},
+		{domain.BigTwoPlayFlush, "[フラッシュ]"},
+		{domain.BigTwoPlayFullHouse, "[フルハウス]"},
+		{domain.BigTwoPlayFourOfAKind, "[フォーカード]"},
+		{domain.BigTwoPlayStraightFlush, "[ストレートフラッシュ]"},
+	}
+	for _, tc := range cases {
+		m := new(interfaces.MockBigTwoGame)
+		players := makeBigTwoPlayers()
+		m.On("GetTableCards").Return([]*domain.Card{domain.NewCard(domain.CardDesignSpade, 3, false)})
+		m.On("GetTablePlayType").Return(tc.playType)
+		m.On("GetGameEndFlag").Return(false)
+		m.On("GetCpuActions").Return(([]*domain.BigTwoAction)(nil))
+		m.On("IsHumanTurn").Return(true)
+		m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
+		m.On("GetPlayerCnt").Return(4)
+		for i := 0; i < 4; i++ {
+			m.On("GetPlayer", i).Return(players[i])
+		}
+		assert.Contains(t, p.Output(m, nil), tc.want)
+	}
+}

--- a/internal/adapter/presenter/KoenigrufenCuiPresenter.go
+++ b/internal/adapter/presenter/KoenigrufenCuiPresenter.go
@@ -204,11 +204,11 @@ func (p *KoenigrufenCuiPresenter) HintOutput(g interfaces.KoenigrufenGame) strin
 			"cards", strings.Join(cards, ", "),
 			"reason", reason)) + "\n"
 	}
+	// **スート名に直す。**呼び王のスート番号 (1..4) はカードの design と同じ値なので、
+	// 他ゲーム (Cinch/King/Watten) と同じく名前で出す。`callking <1-4>` の入力構文は
+	// 数値のまま (#4858)。
 	if hint.CallSuit != nil {
 		return color.Yellow(i18n.Tf("koenigrufen.hintCard",
-			// **スート名に直す。**呼び王のスート番号 (1..4) はカードの design と
-			// 同じ値なので、他ゲーム (Cinch/King/Watten) と同じく名前で出す。
-			// `callking <1-4>` の入力構文は数値のまま (#4858)。
 			"cards", i18n.Tf("koenigrufen.hintCallSuit", "suit", cuiSuitName(*hint.CallSuit)),
 			"reason", reason)) + "\n"
 	}

--- a/internal/adapter/presenter/KoenigrufenCuiPresenter.go
+++ b/internal/adapter/presenter/KoenigrufenCuiPresenter.go
@@ -206,7 +206,10 @@ func (p *KoenigrufenCuiPresenter) HintOutput(g interfaces.KoenigrufenGame) strin
 	}
 	if hint.CallSuit != nil {
 		return color.Yellow(i18n.Tf("koenigrufen.hintCard",
-			"cards", i18n.Tf("koenigrufen.hintCallSuit", "suit", strconv.Itoa(*hint.CallSuit)),
+			// **スート名に直す。**呼び王のスート番号 (1..4) はカードの design と
+			// 同じ値なので、他ゲーム (Cinch/King/Watten) と同じく名前で出す。
+			// `callking <1-4>` の入力構文は数値のまま (#4858)。
+			"cards", i18n.Tf("koenigrufen.hintCallSuit", "suit", cuiSuitName(*hint.CallSuit)),
 			"reason", reason)) + "\n"
 	}
 	return color.Yellow(i18n.Tf("koenigrufen.hintCard", "cards", "-", "reason", reason)) + "\n"

--- a/internal/adapter/presenter/KoenigrufenCuiPresenter_test.go
+++ b/internal/adapter/presenter/KoenigrufenCuiPresenter_test.go
@@ -116,11 +116,16 @@ func TestKoenigrufenCuiPresenter_HintOutput(t *testing.T) {
 		assert.NotEmpty(t, p.HintOutput(g))
 	})
 
-	t.Run("call hint shows suit", func(t *testing.T) {
+	// **スート名で出す。**生の数値だと「スート 3」がどのスートか分からない。
+	// 番号はカードの design と同じ値なので名前に直せる (#4858)。
+	t.Run("call hint names the suit", func(t *testing.T) {
 		g := koenigrufenCuiGame()
 		g.SetDeclarerIdx(0)
 		g.SetPhase(domain.KoenigrufenPhaseCall)
-		assert.NotEmpty(t, p.HintOutput(g))
+		out := p.HintOutput(g)
+		assert.Regexp(t, `(SPADE|CLOVER|HEART|DIAMOND) のキングを呼ぶ`, out)
+		assert.NotRegexp(t, `スート [0-9]+`, out)
+		assert.NotContains(t, out, "UNKNOWN")
 	})
 
 	t.Run("play hint with card index", func(t *testing.T) {

--- a/internal/i18n/locales/en/koenigrufen.json
+++ b/internal/i18n/locales/en/koenigrufen.json
@@ -33,7 +33,7 @@
   "promptRoundEndHelp": "nr / nextround ... go to the next deal",
   "hintNone": "No hint available.",
   "hintCard": "[HINT: {{cards}} ({{reason}})]",
-  "hintCallSuit": "call the King of suit {{suit}}",
+  "hintCallSuit": "call the King of {{suit}}",
   "hintReasonBidTake": "Strong hand — take the contract",
   "hintReasonBidPass": "Weak hand — pass",
   "hintReasonCallKing": "Call a king you do not hold to gain a secret partner",

--- a/internal/i18n/locales/ja/koenigrufen.json
+++ b/internal/i18n/locales/ja/koenigrufen.json
@@ -33,7 +33,7 @@
   "promptRoundEndHelp": "nr / nextround ... 次のディールへ",
   "hintNone": "ヒントはありません。",
   "hintCard": "[ヒント: {{cards}} ({{reason}})]",
-  "hintCallSuit": "スート {{suit}} のキングを呼ぶ",
+  "hintCallSuit": "{{suit}} のキングを呼ぶ",
   "hintReasonBidTake": "強い手札 — コントラクトを取りに行く",
   "hintReasonBidPass": "弱い手札 — パス",
   "hintReasonCallKing": "自分の持たないキングを呼んで秘密のパートナーを得る",


### PR DESCRIPTION
Closes #4858

## 背景

`KoenigrufenCuiPresenter.HintOutput` は `hintCallSuit` に `strconv.Itoa(*hint.CallSuit)` をそのまま渡していて、CUI には**「スート 3 のキングを呼ぶ」**と出ていた。どのスートなのかが読めない。Cinch の `cinchTrumpLabel`、King の `kingTrumpLabel`、Watten の `cuiSuitName` と、このリポジトリではスート番号を必ず名前に直してから出す形が定着している。

## 変更

`cuiSuitName(*hint.CallSuit)` を通す。呼び王のスート番号はカードの `design` と同じ値（`playerHoldsKing` が `c.GetDesign() == suit` で比較している）なので、既存ヘルパーがそのまま使える。

```
- スート 3 のキングを呼ぶ
+ HEART のキングを呼ぶ
```

`callking <1-4>` の**入力構文は数値のまま**。bid / discard / lead / follow のヒントは触っていない。

## テスト

既存の `call hint shows suit` は `assert.NotEmpty` しか見ておらず、**生の数値のままでも通る**空振りテストだった。スート名で出ること・`スート <数字>` が出ないこと・`UNKNOWN` が出ないことを見るように直した。

ネガティブコントロール: `strconv.Itoa` に戻すと 2 件落ちる。

## 併せて (2 コミット目)

直前の #5024 で play-type の lookup を map から switch に変えたぶん codecov/patch が落ちていたので、大老二の役名 8 種類すべてを踏むテストを足した。名前の抜けは Web のバッジとの食い違いになる。

## Test plan

- [ ] CI green