### PR TITLE
feat(gofish): name each opponent in the keyboard-shortcut list

### DIFF
--- a/frontend/src/components/ActionShortcutsPanel.test.tsx
+++ b/frontend/src/components/ActionShortcutsPanel.test.tsx
@@ -37,6 +37,23 @@ describe('ActionShortcutsPanel', () => {
     expect(screen.getByText('コール')).toBeInTheDocument();
   });
 
+  // **同じラベルが並ぶと一覧が役に立たない。**Go Fish は相手ごとに 1 キーを
+  // 割り当てているのに、行は全部「対象のプレイヤーを選ぶ」だった (#4862)。
+  it('interpolates labelParams so per-target rows differ', () => {
+    render(
+      <ActionShortcutsPanel
+        bindings={[
+          { key: '1', action: vi.fn(), label: 'selectTargetNamed', labelParams: { name: 'CPU 1' } },
+          { key: '2', action: vi.fn(), label: 'selectTargetNamed', labelParams: { name: 'CPU 2' } },
+        ]}
+      />,
+    );
+    openPanel();
+    expect(screen.getByText('CPU 1 を選ぶ')).toBeInTheDocument();
+    expect(screen.getByText('CPU 2 を選ぶ')).toBeInTheDocument();
+    expect(screen.queryByText('{{name}} を選ぶ')).not.toBeInTheDocument();
+  });
+
   it('omits bindings with no label rather than showing a raw key name', () => {
     // A binding may be bound deliberately without being advertised; it must not
     // surface as an untranslated i18n key (the failure mode of #4374).

--- a/frontend/src/components/ActionShortcutsPanel.tsx
+++ b/frontend/src/components/ActionShortcutsPanel.tsx
@@ -34,7 +34,7 @@ export function ActionShortcutsPanel({ bindings, includeCardNav = false, ...rest
   const { t } = useTranslation('common');
   const shortcuts: KeyboardShortcut[] = bindings
     .filter((b) => b.label && b.enabled !== false)
-    .map((b) => ({ keys: [b.key], description: t(`kbd.action.${b.label}`) }));
+    .map((b) => ({ keys: [b.key], description: t(`kbd.action.${b.label}`, b.labelParams) }));
 
   if (includeCardNav) {
     shortcuts.push(

--- a/frontend/src/hooks/useActionKeyboardNav.ts
+++ b/frontend/src/hooks/useActionKeyboardNav.ts
@@ -24,6 +24,13 @@ export interface ActionBinding {
    * which fails the build if one has no `kbd.action.*` entry in common.json.
    */
   label?: string;
+  /**
+   * Interpolation values for the `kbd.action.*` label. Go Fish binds one key per
+   * opponent and every row read "対象のプレイヤーを選ぶ", so the list could not
+   * say which key meant which player (#4862). A label that names the target
+   * needs the name, and the name is only known at binding time.
+   */
+  labelParams?: Record<string, string>;
 }
 
 /** Options for {@link useActionKeyboardNav}. */

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -1515,6 +1515,7 @@
       "reset": "Restart the game",
       "selectNertzPile": "Select the Nertz pile",
       "selectTarget": "Select the target player",
+      "selectTargetNamed": "Select {{name}}",
       "selectWastePile": "Select the waste pile",
       "setHands": "Confirm the hands",
       "shift": "Shift a column",

--- a/frontend/src/i18n/locales/ja/common.json
+++ b/frontend/src/i18n/locales/ja/common.json
@@ -1515,6 +1515,7 @@
       "reset": "ゲームをやり直す",
       "selectNertzPile": "ナーツの山を選ぶ",
       "selectTarget": "対象のプレイヤーを選ぶ",
+      "selectTargetNamed": "{{name}} を選ぶ",
       "selectWastePile": "廃棄の山を選ぶ",
       "setHands": "手役を確定する",
       "shift": "列をずらす",

--- a/frontend/src/pages/GoFishPage.test.tsx
+++ b/frontend/src/pages/GoFishPage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { goFishApi } from '../api/gameApi';
 import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
@@ -140,6 +140,19 @@ describe('GoFishPage', () => {
     fireEvent.click(screen.getByRole('button', { name: '要求する' }));
 
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('ask', expect.any(Number), 7));
+  });
+
+  // **どのキーが誰なのかを一覧から読み取れること。**相手が何人いても全行が
+  // 「対象のプレイヤーを選ぶ」で、盤面と数え合わせるしかなかった (#4862)。
+  it('names each opponent in the shortcut list', async () => {
+    renderWithProviders(<GoFishPage />);
+    await waitFor(() => expect(screen.getByText(/CPU 2/)).toBeInTheDocument());
+    const panel = screen.getByTestId('go-fish-kbd-shortcuts');
+    fireEvent.click(panel.querySelector('summary') as HTMLElement);
+
+    expect(within(panel).getByText('CPU 1 を選ぶ')).toBeInTheDocument();
+    expect(within(panel).getByText('CPU 2 を選ぶ')).toBeInTheDocument();
+    expect(within(panel).queryByText('対象のプレイヤーを選ぶ')).not.toBeInTheDocument();
   });
 
   it('keyboard: number key selects an opponent and arrows cycle the rank, then "a" asks', async () => {

--- a/frontend/src/pages/GoFishPage.tsx
+++ b/frontend/src/pages/GoFishPage.tsx
@@ -167,7 +167,10 @@ function GoFishPageContent() {
         setKbdAnnounce(t('a11y.targetSelected', { name: playerName(p.id, false) }));
       },
       enabled: kbdIsHumanTurn,
-      label: 'selectTarget',
+      // 相手ごとに別のキーなので、一覧も相手ごとに別の文言にする。全部
+      // 「対象のプレイヤーを選ぶ」だと、どのキーが誰なのか読み取れない (#4862)。
+      label: 'selectTargetNamed',
+      labelParams: { name: playerName(p.id, false) },
     }));
     bindings.push({ key: 'ArrowRight', action: () => cycleRank(1), enabled: kbdIsHumanTurn, label: 'nextRank' });
     bindings.push({ key: 'ArrowLeft', action: () => cycleRank(-1), enabled: kbdIsHumanTurn, label: 'prevRank' });

--- a/frontend/src/pages/GoFishPage.tsx
+++ b/frontend/src/pages/GoFishPage.tsx
@@ -158,8 +158,8 @@ function GoFishPageContent() {
     [kbdHumanRanks, selectedRank, handleSelectRank, t],
   );
   const askBindings = useMemo(() => {
-    // Annotated so the pushes below can carry labelKey; inference from the map
-    // alone would fix the element type to exactly these three properties.
+    // Annotated so the pushes below can carry `label`; inference from the map
+    // alone would fix the element type to exactly the properties it sets.
     const bindings: ActionBinding[] = kbdCpuPlayers.map((p, i) => ({
       key: String(i + 1),
       action: () => {


### PR DESCRIPTION
Closes #4862

## 背景

`GoFishPage.tsx` の `askBindings` は相手が何人いても全キーに `label: 'selectTarget'` を付けていた。`ActionShortcutsPanel` は `t('kbd.action.' + b.label)` で描くので、一覧を開くと

```
1: 対象のプレイヤーを選ぶ
2: 対象のプレイヤーを選ぶ
3: 対象のプレイヤーを選ぶ
```

と同じ行が並び、**どのキーが誰なのかは盤面と数え合わせるしかなかった**。

## 変更

- `ActionBinding` に `labelParams?: Record<string, string>` を追加
- `ActionShortcutsPanel` が `t(\`kbd.action.${b.label}\`, b.labelParams)` と渡す
- Go Fish は `label: 'selectTargetNamed'` + `labelParams: { name: playerName(...) }`

```
1: CPU 1 を選ぶ
2: CPU 2 を選ぶ
```

**既存の構造は壊していない**: `label` は今も共有 `kbd.action.*` の名前で、`labelParams` は省略可。`selectTarget` のキーも他ページ用に残してある。`labelParams` を持たない既存の 55 ページは `t(key, undefined)` になり、挙動は同じ。

相手が 1 人でも「CPU 1 を選ぶ」と出るだけで破綻しない。

## テスト

- `ActionShortcutsPanel`: 同じ label でも `labelParams` が違えば行の文言が変わる（**`{{name}}` が生のまま出ないこと**も確認）
- `GoFishPage`: 一覧に `CPU 1 を選ぶ` / `CPU 2 を選ぶ` が出て、**`対象のプレイヤーを選ぶ` は出ない**

ネガティブコントロール: `t()` の第 2 引数を落とすと 2 件落ちる。

`bun run check`（kbd-label ガード含む）/ `bun run typecheck` green。

## Test plan

- [ ] CI green