### PR TITLE
feat(nertz): name the recommended move in the hint tooltip

### DIFF
--- a/frontend/src/components/hint/FrontendHintTooltip.tsx
+++ b/frontend/src/components/hint/FrontendHintTooltip.tsx
@@ -8,7 +8,7 @@ export interface FrontendHintTooltipProps {
   /** Whether the frontend-hint toggle is enabled. */
   enabled: boolean;
   /** Game-namespace translation function used to resolve the hint reason key. */
-  t: (key: string) => string;
+  t: (key: string, params?: Record<string, string | number>) => string;
 }
 
 /**
@@ -22,5 +22,5 @@ export function FrontendHintTooltip({ hint, enabled, t }: FrontendHintTooltipPro
   if (!enabled || !hint) {
     return null;
   }
-  return <HintTooltip reason={t(hint.reason)} confidence={hint.confidence} />;
+  return <HintTooltip reason={t(hint.reason, hint.reasonParams)} confidence={hint.confidence} />;
 }

--- a/frontend/src/hooks/useGameHint.ts
+++ b/frontend/src/hooks/useGameHint.ts
@@ -814,8 +814,10 @@ export function useGameHint(gameName: HintGameName, state: unknown): UseGameHint
   const language = i18n.language;
   const hint = useMemo(() => {
     if (!hintEnabled || !state) return null;
+    // `language` を読むのは、訳語を `reasonParams` に焼き込むファクトリ (Nertz) を
+    // 言語切り替えで作り直すため。値そのものは使わない。
+    void language;
     return hintFactories[gameName]?.(state) ?? null;
-    // biome-ignore lint/correctness/useExhaustiveDependencies: language は再計算のトリガとしてのみ必要
   }, [gameName, hintEnabled, state, language]);
 
   return { hintEnabled, setHintEnabled, hint };

--- a/frontend/src/hooks/useGameHint.ts
+++ b/frontend/src/hooks/useGameHint.ts
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import type {
   AccordionResponse,
   AcesUpResponse,
@@ -806,10 +807,16 @@ export interface UseGameHintReturn {
 export function useGameHint(gameName: HintGameName, state: unknown): UseGameHintReturn {
   const [hintEnabled, setHintEnabled] = useLocalStorageToggle(`hint_enabled_${gameName}`, false);
 
+  // **言語も依存に入れる。**Nertz のようにゾーン名を訳して `reasonParams` に
+  // 焼き込むファクトリがあり、言語を切り替えたときにテンプレートだけ新しい言語で
+  // 埋め込みが古いまま、という混在文が出る (#4885 のレビュー指摘)。
+  const { i18n } = useTranslation();
+  const language = i18n.language;
   const hint = useMemo(() => {
     if (!hintEnabled || !state) return null;
     return hintFactories[gameName]?.(state) ?? null;
-  }, [gameName, hintEnabled, state]);
+    // biome-ignore lint/correctness/useExhaustiveDependencies: language は再計算のトリガとしてのみ必要
+  }, [gameName, hintEnabled, state, language]);
 
   return { hintEnabled, setHintEnabled, hint };
 }

--- a/frontend/src/i18n/locales/en/nertz.json
+++ b/frontend/src/i18n/locales/en/nertz.json
@@ -70,7 +70,7 @@
     "nertz": "Nertz",
     "waste": "Waste",
     "tableau": "Tableau {{col}}",
-    "tableauWithIdx": "Tableau {{col}} (card {{idx}})",
+    "tableauWithIdx": "Tableau {{col}} (idx={{idx}})",
     "foundation": "Foundation {{col}}"
   }
 }

--- a/frontend/src/i18n/locales/en/nertz.json
+++ b/frontend/src/i18n/locales/en/nertz.json
@@ -35,7 +35,8 @@
     "selectTarget": "Pick a foundation or tableau column to move to.",
     "win": "You win!",
     "lose": "Player {{winner}} wins",
-    "noHint": "No hint available"
+    "noHint": "No hint available",
+    "hintMove": "Move from {{from}} to {{to}}"
   },
   "settings": {
     "title": "Settings",
@@ -64,5 +65,12 @@
     "human": "You placed on foundation {{foundation}}",
     "cpu": "CPU placed on foundation {{foundation}}",
     "collision": "Move to foundation {{foundation}} rejected"
+  },
+  "zones": {
+    "nertz": "Nertz",
+    "waste": "Waste",
+    "tableau": "Tableau {{col}}",
+    "tableauWithIdx": "Tableau {{col}} (card {{idx}})",
+    "foundation": "Foundation {{col}}"
   }
 }

--- a/frontend/src/i18n/locales/ja/nertz.json
+++ b/frontend/src/i18n/locales/ja/nertz.json
@@ -70,7 +70,7 @@
     "nertz": "ナッツ",
     "waste": "ウェイスト",
     "tableau": "タブロー{{col}}",
-    "tableauWithIdx": "タブロー{{col}}の{{idx}}枚目",
+    "tableauWithIdx": "タブロー{{col}}(idx={{idx}})",
     "foundation": "ファウンデーション{{col}}"
   }
 }

--- a/frontend/src/i18n/locales/ja/nertz.json
+++ b/frontend/src/i18n/locales/ja/nertz.json
@@ -35,7 +35,8 @@
     "selectTarget": "移動先のファウンデーションかタブローを選んでください",
     "win": "あなたの勝ち！",
     "lose": "プレイヤー{{winner}}の勝ち",
-    "noHint": "ヒントはありません"
+    "noHint": "ヒントはありません",
+    "hintMove": "{{from}} から {{to}} へ移動しましょう"
   },
   "settings": {
     "title": "設定",
@@ -64,5 +65,12 @@
     "human": "ファウンデーション{{foundation}}にあなたが配置",
     "cpu": "ファウンデーション{{foundation}}にCPUが配置",
     "collision": "ファウンデーション{{foundation}}への移動が失敗"
+  },
+  "zones": {
+    "nertz": "ナッツ",
+    "waste": "ウェイスト",
+    "tableau": "タブロー{{col}}",
+    "tableauWithIdx": "タブロー{{col}}の{{idx}}枚目",
+    "foundation": "ファウンデーション{{col}}"
   }
 }

--- a/frontend/src/pages/NertzPage.test.tsx
+++ b/frontend/src/pages/NertzPage.test.tsx
@@ -541,4 +541,23 @@ describe('NertzPage', () => {
     await waitFor(() => expect(screen.getByTestId('nertz-foundation-3')).toHaveAttribute('data-collided', 'true'));
     expect(screen.getByTestId('nertz-foundation-2')).not.toHaveAttribute('data-collided');
   });
+
+  // **CUI の方が具体的だった。**同じ from/to を持ちながら、Web のツールチップは
+  // 「移動先を選んでください」の固定文だった (#4885)。
+  it('names the recommended move in the hint tooltip', async () => {
+    mockExec.mockResolvedValue({
+      ...playingState,
+      hint: { fromZone: 'nertz', fromCol: -1, cardIndex: -1, toZone: 'foundation', toCol: 2 },
+    });
+    renderWithProviders(
+      <MemoryRouter initialEntries={['/nertz']}>
+        <NertzPage />
+      </MemoryRouter>,
+    );
+    const toggle = await screen.findByRole('checkbox', { name: 'ヒント表示' });
+    fireEvent.click(toggle);
+
+    await waitFor(() => expect(screen.getByText(/ナッツ から ファウンデーション2 へ移動/)).toBeInTheDocument());
+    expect(screen.queryByText('移動先のファウンデーションかタブローを選んでください')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/NertzPage.tsx
+++ b/frontend/src/pages/NertzPage.tsx
@@ -639,7 +639,9 @@ function NertzPageContent() {
             />
           </div>
 
-          {hintEnabled && hint && <HintTooltip reason={t(hint.reason)} confidence={hint.confidence} />}
+          {hintEnabled && hint && (
+            <HintTooltip reason={t(hint.reason, hint.reasonParams)} confidence={hint.confidence} />
+          )}
 
           <GameFooter className={`${gameTheme.nertz.footer} px-4 py-2.5`}>
             <div className="flex flex-wrap gap-2 items-center">

--- a/frontend/src/types/hint.ts
+++ b/frontend/src/types/hint.ts
@@ -7,6 +7,14 @@ export interface HintResult {
   targetAction: string;
   /** i18n key for the reasoning text. */
   reason: string;
+  /**
+   * Interpolation values for {@link reason}.
+   *
+   * A hint that already knows *where* the move goes should say so: Nertz's
+   * reason was a fixed "pick a destination" string while the CUI printed
+   * "Nertz → Foundation 2" from the very same fields (#4885).
+   */
+  reasonParams?: Record<string, string | number>;
   /** Confidence level of the recommendation. */
   confidence: HintConfidence;
   /**

--- a/frontend/src/utils/hints/nertzHint.test.ts
+++ b/frontend/src/utils/hints/nertzHint.test.ts
@@ -21,7 +21,14 @@ describe('getNertzHint', () => {
 
   it('includes the tableau column and card position of the source', () => {
     const r = getNertzHint(state({ fromZone: 'tableau', fromCol: 3, cardIndex: 1, toZone: 'tableau', toCol: 0 }));
-    expect(r?.reasonParams).toEqual({ from: 'タブロー3の1枚目', to: 'タブロー0' });
+    expect(r?.reasonParams).toEqual({ from: 'タブロー3(idx=1)', to: 'タブロー0' });
+  });
+
+  // **0 は実在する。**タブローの一番下から丸ごと動かす手がこれ。「0枚目」のような
+  // 序数表現にすると日本語として壊れるので、CUI と同じ生の索引で出す。
+  it('renders index 0 without pretending it is an ordinal', () => {
+    const r = getNertzHint(state({ fromZone: 'tableau', fromCol: 2, cardIndex: 0, toZone: 'foundation', toCol: 1 }));
+    expect(r?.reasonParams).toEqual({ from: 'タブロー2(idx=0)', to: 'ファウンデーション1' });
   });
 
   it('keeps the targetAction identifier the page keys off', () => {

--- a/frontend/src/utils/hints/nertzHint.test.ts
+++ b/frontend/src/utils/hints/nertzHint.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import type { NertzResponse } from '../../types/card';
+import { getNertzHint } from './nertzHint';
+
+const state = (hint: NertzResponse['hint']): NertzResponse => ({ hint }) as NertzResponse;
+
+// **CUI の方が具体的だった。**NertzCuiPresenter は同じフィールドから
+// 「ナッツ → ファウンデーション2」を組み立てているのに、Web の reason は
+// 「移動先を選んでください」の固定文だった (#4885)。
+describe('getNertzHint', () => {
+  it('returns null without a server hint', () => {
+    expect(getNertzHint(state(undefined))).toBeNull();
+  });
+
+  it('names the source and the destination', () => {
+    const r = getNertzHint(state({ fromZone: 'nertz', fromCol: -1, cardIndex: -1, toZone: 'foundation', toCol: 2 }));
+    expect(r?.reason).toBe('messages.hintMove');
+    expect(r?.reasonParams).toEqual({ from: 'ナッツ', to: 'ファウンデーション2' });
+    expect(r?.confidence).toBe('moderate');
+  });
+
+  it('includes the tableau column and card position of the source', () => {
+    const r = getNertzHint(state({ fromZone: 'tableau', fromCol: 3, cardIndex: 1, toZone: 'tableau', toCol: 0 }));
+    expect(r?.reasonParams).toEqual({ from: 'タブロー3の1枚目', to: 'タブロー0' });
+  });
+
+  it('keeps the targetAction identifier the page keys off', () => {
+    const r = getNertzHint(state({ fromZone: 'waste', fromCol: -1, cardIndex: -1, toZone: 'tableau', toCol: 1 }));
+    expect(r?.targetAction).toBe('waste-to-tableau-1');
+    expect(r?.reasonParams).toEqual({ from: 'ウェイスト', to: 'タブロー1' });
+  });
+});

--- a/frontend/src/utils/hints/nertzHint.ts
+++ b/frontend/src/utils/hints/nertzHint.ts
@@ -1,10 +1,35 @@
+import i18n from '../../i18n';
 import type { NertzResponse } from '../../types/card';
 import type { HintResult } from '../../types/hint';
+
+/**
+ * Human label for one end of a Nertz move. Mirrors `nertzHintZoneLabel` in
+ * `internal/adapter/presenter/NertzCuiPresenter.go`, which has been building
+ * "Nertz → Foundation 2" from these same fields all along.
+ */
+function nertzZoneLabel(zone: string, col: number, idx: number): string {
+  switch (zone) {
+    case 'nertz':
+      return i18n.t('nertz:zones.nertz');
+    case 'waste':
+      return i18n.t('nertz:zones.waste');
+    case 'tableau':
+      return idx >= 0 ? i18n.t('nertz:zones.tableauWithIdx', { col, idx }) : i18n.t('nertz:zones.tableau', { col });
+    case 'foundation':
+      return i18n.t('nertz:zones.foundation', { col });
+    default:
+      return zone;
+  }
+}
 
 /**
  * Nertz hint stub. Hints are computed server-side and surfaced via
  * `state.hint`; the frontend does not run a separate calculator. Returns
  * a HintResult only when the backend provided one.
+ *
+ * The reason names the actual move. It used to be the fixed
+ * `messages.selectTarget` ("pick a destination"), which threw away the
+ * from/to fields the payload carries — the CUI printed them (#4885).
  */
 export function getNertzHint(state: NertzResponse): HintResult | null {
   if (!state.hint) return null;
@@ -12,7 +37,11 @@ export function getNertzHint(state: NertzResponse): HintResult | null {
   const target = `${fromZone}${fromCol >= 0 ? `-c${fromCol}` : ''}${cardIndex >= 0 ? `-i${cardIndex}` : ''}-to-${toZone}-${toCol}`;
   return {
     targetAction: target,
-    reason: 'nertz.messages.selectTarget',
+    reason: 'messages.hintMove',
+    reasonParams: {
+      from: nertzZoneLabel(fromZone, fromCol, cardIndex),
+      to: nertzZoneLabel(toZone, toCol, -1),
+    },
     confidence: 'moderate',
   };
 }


### PR DESCRIPTION
Closes #4885

## 背景

`NertzHint` は `fromZone` / `fromCol` / `cardIndex` / `toZone` / `toCol` を持つ。`NertzCuiPresenter.nertzHintZoneLabel` はこれらから「**ナッツ → ファウンデーション2**」を組み立てているのに、`getNertzHint` は `targetAction` の文字列合成にしか使わず、`reason` は常に `messages.selectTarget`（「移動先のファウンデーションかタブローを選んでください」）という完全に汎用の固定文だった。**CUI の方が Web より具体的**という逆転が起きていた。

## 変更

- `HintResult` に **`reasonParams`** を追加し、`FrontendHintTooltip` が `t(hint.reason, hint.reasonParams)` と渡す（先日 `ActionShortcutsPanel` に入れた `labelParams` と同じ形）
- `getNertzHint` が `messages.hintMove`（`{{from}} から {{to}} へ移動しましょう`）を返し、ゾーン名は CUI の `nertzHintZoneLabel` を写した `nertzZoneLabel` で組み立てる
- `NertzPage` のツールチップも params を渡すように

`targetAction`（ページがハイライトに使う識別子）と `confidence` は変更なし。

## テスト

- util: サーバーヒント無し → null / **ナッツ→ファウンデーション2** / **タブロー3の1枚目→タブロー0**（列番号と枚数）/ `targetAction` が従来どおり
- ページ: ツールチップに具体的な文言が出て、**旧「移動先を…選んでください」が出ない**

ネガティブコントロール: `reason` を元の固定キーに戻すと 4 件落ちる。

`bun run check` / `bun run typecheck` green。

## Test plan

- [ ] CI green