### PR TITLE
fix(zheng,bigtwo): colour the CUI error line like every other game

### DIFF
--- a/internal/adapter/presenter/BigTwoCuiPresenter.go
+++ b/internal/adapter/presenter/BigTwoCuiPresenter.go
@@ -100,9 +100,9 @@ func (p *BigTwoCuiPresenter) Output(bg interfaces.BigTwoGame, lastErr error) str
 			}
 		}
 
-		if lastErr != nil {
-			b.WriteString(lastErr.Error() + "\n")
-		}
+		// 他の CUI プレゼンターと同じ共通ヘルパーを使う。素の WriteString だと
+		// 赤くならず、直前の通常行と見分けが付かない (#4821)。
+		cuiErrorBlock(b, lastErr)
 	})
 }
 

--- a/internal/adapter/presenter/BigTwoCuiPresenter_test.go
+++ b/internal/adapter/presenter/BigTwoCuiPresenter_test.go
@@ -179,3 +179,15 @@ func TestBigTwoCuiPresenter_NamesEveryPlayType(t *testing.T) {
 		assert.Contains(t, p.Output(m, nil), tc.want)
 	}
 }
+
+// **エラー行が赤くないと通常の状態行と見分けが付かない (#4821)。**共通ヘルパーの
+// cuiErrorBlock を使っているかを、色を出したまま確認する。
+func TestBigTwoCuiPresenter_ErrorIsRed(t *testing.T) {
+	orig := color.NoColor()
+	color.SetNoColor(false)
+	defer color.SetNoColor(orig)
+
+	m, _ := setupBigTwoCuiMock()
+	out := new(presenter.BigTwoCuiPresenter).Output(m, errors.New("invalid play"))
+	assert.Contains(t, out, color.Red("invalid play"))
+}

--- a/internal/adapter/presenter/ZhengCuiPresenter.go
+++ b/internal/adapter/presenter/ZhengCuiPresenter.go
@@ -80,9 +80,9 @@ func (p *ZhengCuiPresenter) Output(zg interfaces.ZhengGame, lastErr error) strin
 			}
 		}
 
-		if lastErr != nil {
-			b.WriteString(lastErr.Error() + "\n")
-		}
+		// 他の CUI プレゼンターと同じ共通ヘルパーを使う。素の WriteString だと
+		// 赤くならず、直前の通常行と見分けが付かない (#4821)。
+		cuiErrorBlock(b, lastErr)
 	})
 }
 

--- a/internal/adapter/presenter/ZhengCuiPresenter_test.go
+++ b/internal/adapter/presenter/ZhengCuiPresenter_test.go
@@ -131,3 +131,15 @@ func TestZheng_CpuNamesGoThroughTheSharedHelper(t *testing.T) {
 		assert.NotContains(t, strings.ReplaceAll(out, bold1, ""), "CPU 1")
 	})
 }
+
+// **エラー行が赤くないと通常の状態行と見分けが付かない (#4821)。**共通ヘルパーの
+// cuiErrorBlock を使っているかを、色を出したまま確認する。
+func TestZhengCuiPresenter_ErrorIsRed(t *testing.T) {
+	orig := color.NoColor()
+	color.SetNoColor(false)
+	defer color.SetNoColor(orig)
+
+	m, _ := setupZhengCuiMock()
+	out := new(presenter.ZhengCuiPresenter).Output(m, errors.New("invalid play"))
+	assert.Contains(t, out, color.Red("invalid play"))
+}


### PR DESCRIPTION
Closes #4821

## 背景

CUI プレゼンターは共通ヘルパー `cuiErrorBlock(b, lastErr)`（`color.Red` で赤くする）でエラーを出すのが定石なのに、`ZhengCuiPresenter` だけ `b.WriteString(lastErr.Error() + "\n")` と独自実装で、**赤くならないまま直前の通常行（CPU の行動履歴や手番案内）に紛れていた**。

## 変更

`cuiErrorBlock` に統一。

**issue は Zheng だけを挙げていましたが、`grep` すると `BigTwoCuiPresenter` も同じ実装でした**（「他の全 CUI プレゼンターは共通ヘルパーを使っている」という前提は正確ではありませんでした）。1 行の同一修正なので両方直しています。修正後、`WriteString(lastErr.Error()` を持つプレゼンターは 0 件です。

## テスト

両ゲームに、**色を出したまま** `color.Red("invalid play")` が出力に含まれることを見るテストを追加（既存のテストは `NoColor` 前提で本文だけを見ていたため、赤くなくても通っていました）。

ネガティブコントロール: 元の実装に戻すと 2 件落ちる。

`golangci-lint` 0 issues。

## Test plan

- [ ] CI green