### PR TITLE
fix(kingalbert): do not print an escape line for zero or negative undos

### DIFF
--- a/internal/adapter/presenter/KingAlbertCuiPresenter.go
+++ b/internal/adapter/presenter/KingAlbertCuiPresenter.go
@@ -85,8 +85,13 @@ func (p *KingAlbertCuiPresenter) Output(bc interfaces.KingAlbertGame, lastErr er
 				b.WriteString(color.Red(i18n.T("cuiSolitaireStalemate")) + "\n")
 				// Point the player at the concrete escape (how many undos are
 				// needed), matching the web StalemateEscapeButton.
-				b.WriteString(color.Yellow(i18n.Tf("kingalbert.stalemateEscape",
-					"count", strconv.Itoa(bc.UndoToEscape()))) + "\n")
+				//
+				// 0 以下は「戻れる局面が無い」。そのまま出すと「undo を -1 回
+				// 実行してください」になる (#5052)。
+				if n := bc.UndoToEscape(); n > 0 {
+					b.WriteString(color.Yellow(i18n.Tf("kingalbert.stalemateEscape",
+						"count", strconv.Itoa(n))) + "\n")
+				}
 			}
 			b.WriteString(i18n.Tf("cuiSolitaireMoves",
 				"count", strconv.Itoa(bc.GetMoveCount())) + "\n")

--- a/internal/adapter/presenter/KingAlbertCuiPresenter_test.go
+++ b/internal/adapter/presenter/KingAlbertCuiPresenter_test.go
@@ -4,6 +4,7 @@ package presenter
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,6 +12,7 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func setupKingAlbertCuiMockDefaults(bg *interfaces.MockKingAlbertGame) {
@@ -102,6 +104,23 @@ func TestKingAlbertCuiPresenter_Output(t *testing.T) {
 		result := p.Output(bg, nil)
 		assert.Contains(t, result, "手詰まり")
 		assert.Contains(t, result, "脱出には undo を 3 回")
+	})
+
+	// **「undo を -1 回」は指示にならない (#5052)。**UndoToEscape は戻れる局面が
+	// 無いとき -1、手詰まりでないとき 0 を返す。
+	t.Run("no escape line when there is nowhere to undo to", func(t *testing.T) {
+		escapePrefix := strings.SplitN(i18n.T("kingalbert.stalemateEscape"), "{{", 2)[0]
+		for _, n := range []int{0, -1} {
+			bg := new(interfaces.MockKingAlbertGame)
+			setupKingAlbertCuiMockDefaults(bg)
+			bg.ExpectedCalls = filterCalls(bg.ExpectedCalls, "IsStalemate")
+			bg.On("IsStalemate").Return(true)
+			bg.On("UndoToEscape").Return(n)
+
+			out := new(KingAlbertCuiPresenter).Output(bg, nil)
+			assert.Contains(t, out, "手詰まり", "警告そのものは出る")
+			assert.NotContains(t, out, escapePrefix)
+		}
 	})
 
 	t.Run("empty column and depleted reserve", func(t *testing.T) {


### PR DESCRIPTION
Closes #5052

## 背景

PR #5051（スルタン）のレビュー指摘。`KingAlbertCuiPresenter` は手詰まりのとき脱出行を**無条件で**出していた。`UndoToEscape()` は戻れる局面が無いとき `-1`、手詰まりでないとき `0` を返すので、`脱出には undo を -1 回実行してください` という指示にならない文言が出うる。

## 変更

スルタンと同じ `n > 0` のガードを付ける。手詰まりの警告そのものは従来どおり。

## テスト

`0` と `-1` の両方で**脱出行が出ないこと**、かつ**手詰まりの警告は出ること**を確認。既存の「3 回」のテストはそのまま通る。

ネガティブコントロール: ガードを `true` に戻すと 1 件落ちる。

`golangci-lint` 0 issues。

## Test plan

- [ ] CI green