### PR TITLE
feat: highlight the legal cards in Tressette

### DIFF
--- a/frontend/e2e/tressette.spec.ts
+++ b/frontend/e2e/tressette.spec.ts
@@ -22,7 +22,10 @@ test.describe('Tressette E2E', () => {
     const playButton = page.getByRole('button', { name: '出す' });
     const nextTrickButton = page.getByRole('button', { name: '次のトリック' });
     const nextRoundButton = page.getByRole('button', { name: '次のラウンド' });
-    const handCards = page.locator('button[aria-pressed]:has(img)');
+    // マストフォローに反する札は aria-disabled で選択不可になる (#4718)。
+    // 全札から first() を取ると制限札を掴んでクリックが無反応になるため、
+    // 合法な札だけに絞る。
+    const handCards = page.locator('button[aria-pressed]:has(img):not([aria-disabled="true"])');
     const anyResetButton = page.getByRole('button', { name: /リセット|次のゲーム/ });
 
     const MAX_TURNS = 60;

--- a/frontend/src/pages/TressettePage.test.tsx
+++ b/frontend/src/pages/TressettePage.test.tsx
@@ -155,4 +155,31 @@ describe('TressettePage', () => {
     expect(legend).toHaveTextContent('+1/3点');
     expect(legend).toHaveTextContent('0点');
   });
+
+  // **合法手はサーバーが計算済みなのに画面が使っていなかった (#4718)。**
+  // マストフォローに反する札もクリックできてしまい、エラーが返って初めて分かる。
+  // Tute/Sueca と同じ validIndices 配線に揃える。
+  it('dims the cards that must-follow forbids on the human turn', async () => {
+    mockExec.mockResolvedValue(makeTressetteState({ playableIndices: [1] }));
+    renderWithProviders(<TressettePage />);
+
+    await waitFor(() => expect(mockExec).toHaveBeenCalled());
+    // 手札は SPADE 3 (index 0) と DIAMOND 13 (index 1)。合法なのは index 1 だけ。
+    const cards = screen.getAllByRole('button').filter((b) => b.hasAttribute('aria-pressed'));
+    expect(cards).toHaveLength(2);
+    expect(cards[0]).toHaveAttribute('aria-disabled', 'true');
+    expect(cards[1]).not.toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('leaves every card enabled when it is not the human turn', async () => {
+    mockExec.mockResolvedValue(makeTressetteState({ currentPlayerIdx: 1, playableIndices: [] }));
+    renderWithProviders(<TressettePage />);
+
+    await waitFor(() => expect(mockExec).toHaveBeenCalled());
+    const cards = screen.getAllByRole('button').filter((b) => b.hasAttribute('aria-pressed'));
+    expect(cards).toHaveLength(2);
+    for (const card of cards) {
+      expect(card).not.toHaveAttribute('aria-disabled', 'true');
+    }
+  });
 });

--- a/frontend/src/pages/TressettePage.tsx
+++ b/frontend/src/pages/TressettePage.tsx
@@ -414,6 +414,8 @@ function TressettePageContent() {
                 cardWidth={cardWidth}
                 isMobile={isMobile}
                 dataTutorialPrefix="tr"
+                validIndices={isHumanTurn ? state.playableIndices : undefined}
+                restrictedTooltip={t('playButton')}
               />
             )}
 


### PR DESCRIPTION
## 背景

`TressetteWebPresenter` は `resObj.PlayableIndices = p.playableIndices(g)` でマストフォローに合致する札を計算して送っており、`TressetteResponse` にも `playableIndices: number[]` があります。ところが `TressettePage.tsx` はそれを `PlayerHandSection` に渡していませんでした。結果、違反札もクリックでき、サーバーからエラーが返って初めて「出せない」と分かる状態でした (#4718)。

姉妹ゲームの `TutePage` / `SuecaPage` は同じデータを `validIndices` に渡して減光しており、Tressette だけ配線が漏れていました。

## 変更

`PlayerHandSection` に `validIndices={isHumanTurn ? state.playableIndices : undefined}` と `restrictedTooltip` を追加しただけです。判定はドメイン (`GetPlayableIndices`) のまま、フロントに複製していません。

presenter 側の `playableIndices()` が「プレイフェーズかつ人間の手番」を既にゲートしているので、ページは `isHumanTurn` のときだけ渡します。CPU 手番では `undefined` を渡す = 制限なし表示で、Tute/Sueca と挙動が一致します。

## テスト

- `playableIndices: [1]`（手札2枚のうち index 1 のみ合法）で index 0 が `aria-disabled="true"`、index 1 はそうでないことを検証
- CPU 手番では全札が有効のままであることを検証（`validIndices` を無条件に渡す実装だと落ちる）
- **負のコントロール**: `validIndices` の行を消すと1件落ち、戻すと green

state factory の既定は `playableIndices: [0, 1]` = 手札全部が合法なので、そのままではテストが素通りします。テスト側で `[1]` に上書きして実際に減光パスを踏んでいます。

## 検証

- `bunx vitest run src/pages/TressettePage.test.tsx` 14 passed ✅
- `bun run check` ✅ (biome + 11 ガード) / `bun run typecheck` ✅

Closes #4718