### PR TITLE
fix: collapse Briscola's two hint surfaces into one

### DIFF
--- a/frontend/src/pages/BriscolaPage.test.tsx
+++ b/frontend/src/pages/BriscolaPage.test.tsx
@@ -46,6 +46,10 @@ function makeState(overrides: Partial<BriscolaResponse> = {}): BriscolaResponse 
 }
 
 beforeEach(() => {
+  // ヒントのオン/オフは localStorage に残る。消さないと前のテストの状態を
+  // 引き継いで、以降のアサーションが何も確かめなくなる。
+  // (clear() だと初回訪問フラグまで消え、チュートリアル案内ダイアログが出る。)
+  localStorage.removeItem('hint_enabled_briscola');
   mockExec.mockResolvedValue(makeState());
 });
 
@@ -234,5 +238,32 @@ describe('BriscolaPage', () => {
     renderWithProviders(<BriscolaPage />);
     const hint = await screen.findByTestId('briscola-hint');
     expect(hint).toHaveTextContent('切り札でリードして主導権を握りましょう');
+  });
+
+  // **ヒントの窓口は1つ (#4753)。**バナーとツールチップはどちらも同じ
+  // `state.hint` から出ている (getBriscolaHint がそれを読んでいる) ので矛盾は
+  // しないが、要求すると同じ助言が2箇所に重複して出ていた。Cassino と同じく、
+  // 明示的に要求したサーバー側の答えを優先して片方に畳む。
+  it('hides the frontend hint tooltip while the server hint is shown', async () => {
+    localStorage.setItem('hint_enabled_briscola', 'true');
+    mockExec.mockResolvedValue(
+      makeState({ hint: { cardIndex: 2, reason: 'lead_trump' }, messageCode: 'briscola.hintRequested' }),
+    );
+    renderWithProviders(<BriscolaPage />);
+
+    await screen.findByTestId('briscola-hint');
+    expect(screen.queryByTestId('hint-tooltip')).not.toBeInTheDocument();
+  });
+
+  // 逆側。**同じ state.hint** を積んだまま messageCode だけ外すと、バナーは
+  // 出ずツールチップだけが残る -- 排他が「常にツールチップを消す」に退化して
+  // いないことを確かめる。
+  it('still shows the frontend hint tooltip when no server hint was requested', async () => {
+    localStorage.setItem('hint_enabled_briscola', 'true');
+    mockExec.mockResolvedValue(makeState({ hint: { cardIndex: 2, reason: 'lead_trump' } }));
+    renderWithProviders(<BriscolaPage />);
+
+    await screen.findByTestId('hint-tooltip');
+    expect(screen.queryByTestId('briscola-hint')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/BriscolaPage.tsx
+++ b/frontend/src/pages/BriscolaPage.tsx
@@ -126,6 +126,12 @@ function BriscolaPageContent() {
   const isGameEnd = state.phase === BriscolaPhase.GAME_END || state.gameEndFlag;
   const isHumanTurn = isPlayPhase && state.players[state.currentPlayerIdx]?.isHuman === true;
 
+  // 要求済みのサーバーヒント (hint コマンドの結果)。要求していなければ null。
+  // 下の FrontendHintTooltip とは排他 -- どちらも同じ state.hint を出すので、
+  // 要求したときは具体的なバナーだけを残す。
+  // (真偽値ではなく値にしているのは、null チェックで state.hint を絞るため。)
+  const serverHint = state.hint && isRequestedHint(state) ? state.hint : null;
+
   const phaseName = isGameEnd ? t('phase.gameEnd') : isTrickEnd ? t('phase.trickEnd') : t('phase.play');
 
   const resultBanner = (() => {
@@ -272,10 +278,10 @@ function BriscolaPageContent() {
         )}
 
         {/* Server hint text (populated by the hint command). */}
-        {state.hint && isRequestedHint(state) && (
+        {serverHint && (
           <p className="mt-3 text-sm text-ds-accent" data-testid="briscola-hint">
-            {t('hint.available')}: {t(`hint.${state.hint.reason}`)}
-            {state.hint.cardIndex !== undefined && ` ${t('hint.card', { index: state.hint.cardIndex })}`}
+            {t('hint.available')}: {t(`hint.${serverHint.reason}`)}
+            {serverHint.cardIndex !== undefined && ` ${t('hint.card', { index: serverHint.cardIndex })}`}
           </p>
         )}
 
@@ -297,7 +303,14 @@ function BriscolaPageContent() {
         </div>
       </div>
 
-      <FrontendHintTooltip hint={frontendHint} enabled={frontendHintEnabled} t={t} />
+      {/*
+       * Single hint surface: the server hint (requested with the `hint` command and
+       * evaluated against the real game state) and the frontend heuristic tooltip are
+       * mutually exclusive. When the player has explicitly asked the backend, that
+       * answer supersedes the local approximation so the two can never contradict
+       * each other on screen (#4753 -- CassinoPage.tsx uses the same pattern).
+       */}
+      {!serverHint && <FrontendHintTooltip hint={frontendHint} enabled={frontendHintEnabled} t={t} />}
 
       <SettingsPanel
         title={tc('settings.title')}


### PR DESCRIPTION
## 背景

`BriscolaPage.tsx` は、`hint` コマンドで要求するサーバーヒントのバナー (`briscola-hint`) と、`useGameHint('briscola', state)` による `FrontendHintTooltip` の両方を同時にレンダリングし得ます。排他制御がありません (#4753)。

## issue の前提の訂正

issue は「2つは互いに独立したロジック（バックエンドの実際の手番評価と、フロントエンドの簡易ヒューリスティック）から生成されており、2つの矛盾したヒントが同時に出る可能性がある」としています。**これは正しくありません。**

`frontend/src/utils/hints/briscolaHint.ts` の `getBriscolaHint` は `state.hint` — つまりバナーと同じバックエンドのヒント — をそのまま読んで詰め替えているだけです（同ファイルの doc コメントにもそう書かれています）。したがって2つが矛盾することはあり得ません。

実際の不具合は**同じ助言が画面の2箇所に重複して出ること**でした。修正の方向（片方に畳む）は issue の提案どおりなので、そのまま実装しています。

## 変更

Cassino (`CassinoPage.tsx:352-360`) と同じく、要求済みのサーバーヒントがあるときはツールチップを隠します。

真偽値 `serverHintShown` ではなく絞り込んだ値 `serverHint` にしてあるのは、バナー本体が読む `state.hint` の null チェックを型に効かせるためです（真偽値フラグだと TS18048 で `'state.hint' is possibly 'undefined'` になります）。

## テスト

- 要求済み (`messageCode: 'briscola.hintRequested'`) + トグル ON → バナーが出て `hint-tooltip` は出ない
- **同じ `state.hint` を積んだまま** messageCode だけ外す + トグル ON → ツールチップが出てバナーは出ない（排他が「常にツールチップを消す」に退化していないことの確認）
- **負のコントロール**: `{!serverHint && ...}` のガードを外すと1件落ち、戻すと 20 passed

`beforeEach` でヒントのトグルキーだけを消しています。`localStorage.clear()` にすると初回訪問フラグまで消え、チュートリアル案内ダイアログが出て既存のリセット確認テストが `alertdialog` の重複で落ちます。

## 検証

- `bunx vitest run src/pages/BriscolaPage.test.tsx` 20 passed ✅
- `bun run check` ✅（`hint-gate: OK (both sides tested on every gated page; 260 pages checked)` を含む）
- `bun run typecheck` ✅

Closes #4753