### PR TITLE
perf: poll the Slapjack tick only while a CPU action is pending

### DIFF
--- a/frontend/src/pages/SlapjackPage.test.tsx
+++ b/frontend/src/pages/SlapjackPage.test.tsx
@@ -1,10 +1,10 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { slapjackApi } from '../api/gameApi';
 import { useCliMode } from '../hooks/useCliMode';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { SlapjackResponse } from '../types/card';
-import { SlapjackEventKind, SlapjackPhase } from '../types/phases';
+import { SlapjackEventKind, SlapjackPendingKind, SlapjackPhase } from '../types/phases';
 import { SlapjackPage } from './SlapjackPage';
 
 vi.mock('../hooks/useCliMode', () => ({
@@ -310,5 +310,49 @@ describe('SlapjackPage', () => {
     await waitFor(() => expect(screen.getByTestId('slap-button')).toBeInTheDocument());
     expect(mockPlaySound).not.toHaveBeenCalledWith('winFanfare');
     expect(mockPlaySound).not.toHaveBeenCalledWith('errorBuzz');
+  });
+
+  // **ドメインの Tick() は pending.Kind が None なら即座に何もせず返る。**それでも
+  // 100ms ごとに投げ続けており、人間が考えている間ずっと毎秒10回の無駄なリクエストが
+  // 飛んでいた (#4748)。
+  it('does not poll tick while no CPU action is pending', async () => {
+    vi.useFakeTimers();
+    try {
+      mockExec.mockReset().mockResolvedValue(baseState); // pendingKind: NONE
+      renderWithProviders(<SlapjackPage />);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      mockExec.mockClear();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000); // 従来なら 10 回飛ぶ
+      });
+      expect(mockExec).not.toHaveBeenCalledWith('tick');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // **逆側。**予約があるうちは従来どおり回さないとゲームが進まない。
+  // CPU のスラップは人間の手番中にも予約されるので、手番ではなく予約でゲートする。
+  it('keeps polling tick while a CPU slap is pending', async () => {
+    vi.useFakeTimers();
+    try {
+      const pendingSlapState: SlapjackResponse = { ...baseState, pendingKind: SlapjackPendingKind.SLAP };
+      mockExec.mockReset().mockResolvedValue(pendingSlapState);
+      renderWithProviders(<SlapjackPage />);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      mockExec.mockClear();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(300);
+      });
+      expect(mockExec).toHaveBeenCalledWith('tick');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/frontend/src/pages/SlapjackPage.tsx
+++ b/frontend/src/pages/SlapjackPage.tsx
@@ -28,7 +28,7 @@ import i18n from '../i18n';
 import { useSound } from '../providers/SoundProvider';
 import { gameTheme } from '../styles/gameTheme';
 import type { SlapjackResponse } from '../types/card';
-import { SlapjackEventKind, SlapjackPhase } from '../types/phases';
+import { SlapjackEventKind, SlapjackPendingKind, SlapjackPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { parseSlapjackCommand, slapjackHelp } from '../utils/cli/commands/slapjackCommands';
 import { formatSlapjackState } from '../utils/cli/formatters/slapjackFormatter';
@@ -130,15 +130,24 @@ function SlapjackPageContent() {
 
   useMountReset(execApi);
 
-  // CPU tick driver while the game is active.
+  // CPU tick driver: poll only while a CPU action is actually pending.
+  //
+  // **ドメインの Tick() は pending.Kind が None のとき即座に何もせず返る。**
+  // それでも 100ms ごとに投げ続けていたので、人間が考えている間ずっと毎秒10回の
+  // 無駄なリクエストが飛んでいた (#4748)。EgyptianRatscrewPage と同じゲートに揃える。
+  //
+  // **手番でゲートしてはいけない。**CPU のスラップは人間の手番中にも予約される
+  // (SlapjackPendingSlap)。「CPU の手番中だけ」に絞ると CPU が J を叩かなくなる。
+  // 予約の有無こそが正しい条件。
+  const isCpuPending = state?.pendingKind !== undefined && state.pendingKind !== SlapjackPendingKind.NONE;
+  const isGameRunning = !!state && !state.gameEndFlag;
   useEffect(() => {
-    if (!state) return;
-    if (state.gameEndFlag) return;
+    if (!isGameRunning || !isCpuPending) return;
     const id = window.setInterval(() => {
       void execApi('tick');
     }, SLAPJACK_TICK_INTERVAL_MS);
     return () => window.clearInterval(id);
-  }, [state, execApi]);
+  }, [isGameRunning, isCpuPending, execApi]);
 
   // CLI mode
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('slapjack');

--- a/frontend/src/pages/SlapjackPage.tsx
+++ b/frontend/src/pages/SlapjackPage.tsx
@@ -130,15 +130,10 @@ function SlapjackPageContent() {
 
   useMountReset(execApi);
 
-  // CPU tick driver: poll only while a CPU action is actually pending.
+  // CPU tick driver: poll only while a CPU action is pending (#4748).
   //
-  // **ドメインの Tick() は pending.Kind が None のとき即座に何もせず返る。**
-  // それでも 100ms ごとに投げ続けていたので、人間が考えている間ずっと毎秒10回の
-  // 無駄なリクエストが飛んでいた (#4748)。EgyptianRatscrewPage と同じゲートに揃える。
-  //
-  // **手番でゲートしてはいけない。**CPU のスラップは人間の手番中にも予約される
-  // (SlapjackPendingSlap)。「CPU の手番中だけ」に絞ると CPU が J を叩かなくなる。
-  // 予約の有無こそが正しい条件。
+  // **手番ではなく予約でゲートする。**CPU のスラップは人間の手番中にも予約される
+  // (SlapjackPendingSlap) ので、「CPU の手番中だけ」に絞ると CPU が J を叩かなくなる。
   const isCpuPending = state?.pendingKind !== undefined && state.pendingKind !== SlapjackPendingKind.NONE;
   const isGameRunning = !!state && !state.gameEndFlag;
   useEffect(() => {


### PR DESCRIPTION
## 背景

`SlapjackPage.tsx` の CPU tick 用 `useEffect` は `if (!state) return; if (state.gameEndFlag) return;` だけをガードにしており、ゲームが終わるまで常に 100ms 間隔で `tick` を投げ続けていました。ドメインの `Slapjack.Tick()` は `pending.Kind == SlapjackPendingNone` のとき即座に何もせず返るので、人間が考えている間の毎秒最大10回は完全に無駄なリクエストです (#4748)。

## issue の前提の訂正

issue は「CPU の手番中のみ tick を動かす」ことを提案していますが、**手番でゲートすると壊れます。**

Slapjack では CPU のスラップが**人間の手番中にも** `SlapjackPendingSlap` として予約されます（`Slapjack.Tick()` の `case SlapjackPendingSlap: g.Slap(g.cpuIdx())`）。「CPU の手番中だけ」に絞ると、CPU が J を叩かなくなってゲームとして成立しません。

正しい条件は**予約の有無**で、これは issue が参照している `EgyptianRatscrewPage` の `isCpuPending` パターンそのものです。`pendingKind` は既に `SlapjackWebOutput` にも `SlapjackResponse` にも存在し、ページが使っていなかっただけでした。

## テスト

- `pendingKind: NONE` で 1000ms 進めても `tick` が呼ばれない（従来なら10回）
- `pendingKind: SLAP` では従来どおり `tick` が呼ばれる

**負のコントロール**:

| 変更 | 結果 |
|------|------|
| `!isCpuPending` を落として従来の挙動に戻す | 1件目が落ちる |
| ゲートを反転 (`isCpuPending`) | 2件とも落ちる |
| 元に戻す | 26 passed |

## 検証

- `bunx vitest run src/pages/SlapjackPage.test.tsx` 26 passed ✅
- `bun run check` ✅ / `bun run typecheck` ✅
- `e2e/slapjack.spec.ts` は連続ポーリングに依存していません（human step の応答時点で CPU の次アクションが予約されるので `pendingKind` が立ち、ポーリングは再開します）

Closes #4748