### PR TITLE
test: stop betting on the shuffle in the Russian Bank presenter test

### DIFF
--- a/internal/adapter/presenter/RussianBankWebPresenter_test.go
+++ b/internal/adapter/presenter/RussianBankWebPresenter_test.go
@@ -14,12 +14,44 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 )
 
+// rbWithoutForcedMove は配り直後の盤面から CPU のリザーブを空にして返す。
+//
+// 配り直後は CPU の捨て札も空なので、リザーブを空にすれば強制手は必ず消える
+// (シャッフル依存ではない)。TestRussianBankWebPresenter_StopAvailableMessage の
+// 「呼べない側」と同じ作り方。
+func rbWithoutForcedMove(t *testing.T) *domain.RussianBank {
+	t.Helper()
+	g := domain.NewDefaultRussianBank()
+	g.Reset()
+
+	data, err := json.Marshal(g)
+	assert.NoError(t, err)
+	var raw map[string]json.RawMessage
+	assert.NoError(t, json.Unmarshal(data, &raw))
+	var players []map[string]json.RawMessage
+	assert.NoError(t, json.Unmarshal(raw["pl"], &players))
+	players[1]["r"], err = json.Marshal([]*domain.Card{})
+	assert.NoError(t, err)
+	raw["pl"], err = json.Marshal(players)
+	assert.NoError(t, err)
+	patched, err := json.Marshal(raw)
+	assert.NoError(t, err)
+	assert.NoError(t, json.Unmarshal(patched, g))
+	return g
+}
+
 func TestRussianBankWebPresenter_Output(t *testing.T) {
 	p := new(presenter.RussianBankWebPresenter)
 
 	t.Run("playing state serialises the board and players", func(t *testing.T) {
-		g := domain.NewDefaultRussianBank()
-		g.Reset()
+		// **配りに賭けない (#4817 で入り込んだフレーク)。**`russianbank.playing` は
+		// CanCallStop() が false のときだけ出る。素の Reset() では CPU のリザーブ
+		// トップ次第で強制手が生まれ、`russianbank.stopAvailable` になる。実測で
+		// 300 回中 27 回 (9%) 落ちていた。CPU のリザーブを空にして、強制手が
+		// 生まれないことを確かめてから固定する。
+		g := rbWithoutForcedMove(t)
+		assert.False(t, g.CanCallStop(), "この盤面では stop を呼べない")
+
 		out := p.Output(g, nil)
 		for _, frag := range []string{`"phase"`, `"players"`, `"tableau"`, `"foundations"`, `"reserveCount"`, `"canCallStop"`, `"messageCode":"russianbank.playing"`} {
 			assert.Contains(t, out, frag)

--- a/internal/adapter/presenter/RussianBankWebPresenter_test.go
+++ b/internal/adapter/presenter/RussianBankWebPresenter_test.go
@@ -14,29 +14,35 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 )
 
-// rbWithoutForcedMove は配り直後の盤面から CPU のリザーブを空にして返す。
+// rbSetCpuReserve は盤面の CPU (席 1) のリザーブを差し替える。ドメインに
+// セッターが無いので JSON 経由で組み替える。
 //
-// 配り直後は CPU の捨て札も空なので、リザーブを空にすれば強制手は必ず消える
-// (シャッフル依存ではない)。TestRussianBankWebPresenter_StopAvailableMessage の
-// 「呼べない側」と同じ作り方。
-func rbWithoutForcedMove(t *testing.T) *domain.RussianBank {
+// 強制手の有無は CPU のリザーブトップだけで決まる (配り直後は CPU の捨て札も
+// 空なので) ため、ここを固定すれば `CanCallStop()` はシャッフルに依存しない。
+func rbSetCpuReserve(t *testing.T, g *domain.RussianBank, cards []*domain.Card) {
 	t.Helper()
-	g := domain.NewDefaultRussianBank()
-	g.Reset()
-
 	data, err := json.Marshal(g)
 	assert.NoError(t, err)
 	var raw map[string]json.RawMessage
 	assert.NoError(t, json.Unmarshal(data, &raw))
 	var players []map[string]json.RawMessage
 	assert.NoError(t, json.Unmarshal(raw["pl"], &players))
-	players[1]["r"], err = json.Marshal([]*domain.Card{})
+	players[1]["r"], err = json.Marshal(cards)
 	assert.NoError(t, err)
 	raw["pl"], err = json.Marshal(players)
 	assert.NoError(t, err)
 	patched, err := json.Marshal(raw)
 	assert.NoError(t, err)
 	assert.NoError(t, json.Unmarshal(patched, g))
+}
+
+// rbWithoutForcedMove は配り直後の盤面から CPU のリザーブを空にして返す。
+// 強制手が必ず消えるので `CanCallStop()` は false で確定する。
+func rbWithoutForcedMove(t *testing.T) *domain.RussianBank {
+	t.Helper()
+	g := domain.NewDefaultRussianBank()
+	g.Reset()
+	rbSetCpuReserve(t, g, []*domain.Card{})
 	return g
 }
 
@@ -116,22 +122,10 @@ func TestRussianBankWebPresenter_StopAvailableMessage(t *testing.T) {
 	p := new(presenter.RussianBankWebPresenter)
 
 	// CPU (席 1) のリザーブトップを A にすると、ファウンデーションへ必ず置ける
-	// = 強制手の取りこぼし。JSON 経由で盤面を作る。
+	// = 強制手の取りこぼし。
 	g := domain.NewDefaultRussianBank()
 	g.Reset()
-	data, err := json.Marshal(g)
-	assert.NoError(t, err)
-	var raw map[string]json.RawMessage
-	assert.NoError(t, json.Unmarshal(data, &raw))
-	var players []map[string]json.RawMessage
-	assert.NoError(t, json.Unmarshal(raw["pl"], &players))
-	players[1]["r"], err = json.Marshal([]*domain.Card{domain.NewCard(domain.CardDesignSpade, 1, false)})
-	assert.NoError(t, err)
-	raw["pl"], err = json.Marshal(players)
-	assert.NoError(t, err)
-	newData, err := json.Marshal(raw)
-	assert.NoError(t, err)
-	assert.NoError(t, json.Unmarshal(newData, g))
+	rbSetCpuReserve(t, g, []*domain.Card{domain.NewCard(domain.CardDesignSpade, 1, false)})
 
 	assert.True(t, g.CanCallStop(), "この盤面では stop を呼べる")
 	var out controller.RussianBankWebOutput
@@ -139,15 +133,7 @@ func TestRussianBankWebPresenter_StopAvailableMessage(t *testing.T) {
 	assert.Equal(t, "russianbank.stopAvailable", out.MessageCode)
 
 	// 呼べない盤面では従来どおり。
-	players[1]["r"], err = json.Marshal([]*domain.Card{})
-	assert.NoError(t, err)
-	raw["pl"], err = json.Marshal(players)
-	assert.NoError(t, err)
-	newData, err = json.Marshal(raw)
-	assert.NoError(t, err)
-	assert.NoError(t, json.Unmarshal(newData, g))
-	// 配り直後は CPU の捨て札が空なので、リザーブを空にすれば強制手は必ず消える
-	// (シャッフル依存ではない)。
+	rbSetCpuReserve(t, g, []*domain.Card{})
 	assert.False(t, g.CanCallStop())
 	var out2 controller.RussianBankWebOutput
 	assert.NoError(t, json.Unmarshal([]byte(p.Output(g, nil)), &out2))


### PR DESCRIPTION
## 症状

`TestRussianBankWebPresenter_Output/playing_state_serialises_the_board_and_players` が PR CI で断続的に落ちます。既知フレークの一覧（`project_backend_test_flakes`）には無い、**新しいフレーク**です。

## 原因

私が #4817 で入れた `russianbank.stopAvailable` の副作用です。

このサブテストは素の `Reset()` の後に `"messageCode":"russianbank.playing"` を固定していますが、`playing` は **`CanCallStop()` が false のときだけ**出ます。`CanCallStop()` は CPU のリザーブトップに依存するので、**配り次第で強制手が生まれ** `russianbank.stopAvailable` になります。

#4817 で分岐を足したとき、既存テストが配りに賭けていることを見落としていました。テストは「配りの検証」ではなく「配りへの賭け」だったわけです。

## 実測

develop で 300 回:

```
failures: 27 / 300     (9%)
```

修正後、同じ 300 回:

```
after fix: 0 / 300
```

## 修正

同ファイルの `TestRussianBankWebPresenter_StopAvailableMessage` が「呼べない側」を作るのに使っているのと同じ手順を、`rbWithoutForcedMove` ヘルパに切り出して使います。**配り直後は CPU の捨て札も空なので、リザーブを空にすれば強制手は必ず消えます**（ここはシャッフル依存ではありません）。

賭けを消すだけでなく、`assert.False(t, g.CanCallStop())` で**前提そのものを踏んでから**メッセージを固定するようにしました。将来 `CanCallStop()` の条件が変わってこの盤面で true になったら、曖昧に落ちるのではなくその行で落ちます。

## 検証

- 300 回連続実行で 0 失敗（修正前は 27 失敗）
- **負のコントロール**: presenter の `russianbank.playing` を別の文字列に潰すと3件落ち、戻すと green
- `go test -tags test ./internal/...` ✅ / `golangci-lint` → `0 issues.` ✅ / `gofmt -l internal/` 空 ✅