### PR TITLE
feat: highlight the legal cards in Tarneeb

### DIFF
--- a/frontend/src/i18n/locales/en/tarneeb.json
+++ b/frontend/src/i18n/locales/en/tarneeb.json
@@ -87,5 +87,6 @@
     "discardLowest": "Discard your lowest card"
   },
   "hintRequested": "Hint available",
-  "noHint": "No hint available"
+  "noHint": "No hint available",
+  "restrictedCard": "You cannot play this card (follow the led suit)"
 }

--- a/frontend/src/i18n/locales/ja/tarneeb.json
+++ b/frontend/src/i18n/locales/ja/tarneeb.json
@@ -87,5 +87,6 @@
     "discardLowest": "最も低いカードを捨てることを推奨"
   },
   "hintRequested": "ヒントがあります",
-  "noHint": "ヒントはありません"
+  "noHint": "ヒントはありません",
+  "restrictedCard": "このカードは出せません（リードスートに従ってください）"
 }

--- a/frontend/src/pages/TarneebPage.test.tsx
+++ b/frontend/src/pages/TarneebPage.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { tarneebApi } from '../api/gameApi';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, TarneebResponse } from '../types/card';
+import { TarneebPhase } from '../types/phases';
 import { TarneebPage } from './TarneebPage';
 
 vi.mock('../api/gameApi', () => ({
@@ -46,6 +47,7 @@ function makeState(overrides: Partial<TarneebResponse> = {}): TarneebResponse {
     gameEndFlag: false,
     winnerTeam: -1,
     leadPlayerIdx: 0,
+    validPlayIndices: [],
     config: { cpuDifficulty: 1, pointLimit: 31, minBid: 7 },
     message: '',
     ...overrides,
@@ -158,5 +160,59 @@ describe('TarneebPage', () => {
     mockExec.mockClear();
     fireEvent.click(screen.getByRole('button', { name: 'パス' }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('bid', 0));
+  });
+
+  // **ドメインは合法手を判定済みなのに、画面が使っていなかった (#4713)。**
+  // マストフォローに反する札もクリックでき、サーバーのエラーが返って初めて
+  // 出せないと分かる状態だった。
+  it('dims the cards that must-follow forbids on the human play turn', async () => {
+    mockExec.mockResolvedValue(
+      makeState({
+        phase: TarneebPhase.PLAY,
+        currentPlayerIdx: 0,
+        players: [
+          { ...player(0, true, 0, 3), cards: [card('SPADE', 1), card('HEART', 13)] },
+          player(1, false, 1, 2),
+          player(2, false, 0, 1),
+          player(3, false, 1, 0),
+        ],
+        // 合法なのは index 1 だけ。
+        validPlayIndices: [1],
+      }),
+    );
+    renderWithProviders(<TarneebPage />);
+
+    await waitFor(() => expect(mockExec).toHaveBeenCalled());
+    const cards = screen.getAllByRole('button').filter((b) => b.hasAttribute('aria-pressed'));
+    expect(cards).toHaveLength(2);
+    expect(cards[0]).toHaveAttribute('aria-disabled', 'true');
+    expect(cards[1]).not.toHaveAttribute('aria-disabled', 'true');
+  });
+
+  // **空を「制限なし」と読まない。**CPU の手番では制限そのものを送っていないので
+  // 全札が有効のまま。ここを validPlayIndices.length で判定すると、
+  // 「1枚も出せない」局面と区別が付かなくなる。
+  it('leaves every card enabled when it is not the human turn', async () => {
+    mockExec.mockResolvedValue(
+      makeState({
+        phase: TarneebPhase.PLAY,
+        currentPlayerIdx: 1,
+        players: [
+          { ...player(0, true, 0, 3), cards: [card('SPADE', 1), card('HEART', 13)] },
+          player(1, false, 1, 2),
+          player(2, false, 0, 1),
+          player(3, false, 1, 0),
+        ],
+        validPlayIndices: [],
+      }),
+    );
+    renderWithProviders(<TarneebPage />);
+
+    await waitFor(() => expect(mockExec).toHaveBeenCalled());
+    const cards = screen.getAllByRole('button').filter((b) => b.hasAttribute('aria-pressed'));
+    expect(cards).toHaveLength(2);
+    for (const c of cards) {
+      expect(c).not.toHaveAttribute('aria-disabled', 'true');
+    }
   });
 });

--- a/frontend/src/pages/TarneebPage.tsx
+++ b/frontend/src/pages/TarneebPage.tsx
@@ -431,6 +431,8 @@ function TarneebPageContent() {
                 cardWidth={cardWidth}
                 isMobile={isMobile}
                 dataTutorialPrefix="tn"
+                validIndices={isHumanTurn ? state.validPlayIndices : undefined}
+                restrictedTooltip={t('restrictedCard')}
               />
             )}
 

--- a/frontend/src/types/games/tarneeb.ts
+++ b/frontend/src/types/games/tarneeb.ts
@@ -55,6 +55,14 @@ export interface TarneebResponse extends BaseGameResponse {
   gameEndFlag: boolean;
   winnerTeam: number;
   leadPlayerIdx: number;
+  /**
+   * 人間がいま出せる手札の位置。
+   *
+   * マストフォローの判定はドメインの `GetValidPlayIndices` が持っており、
+   * フロントで組み立て直すと片方だけ直したときに黙って食い違う (#4713)。
+   * プレイフェーズで人間の手番でなければ空 — **空を「制限なし」と読まないこと**。
+   */
+  validPlayIndices: number[];
   config: TarneebConfig;
   hint?: TarneebHint;
 }

--- a/frontend/src/utils/cli/formatters/tarneebFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/tarneebFormatter.test.ts
@@ -35,6 +35,7 @@ function makeState(overrides?: Partial<TarneebResponse>): TarneebResponse {
     gameEndFlag: false,
     winnerTeam: -1,
     leadPlayerIdx: 0,
+    validPlayIndices: [],
     config: { cpuDifficulty: 1, pointLimit: 31, minBid: 7 },
     message: '',
     ...overrides,

--- a/frontend/src/utils/hints/tarneebHint.test.ts
+++ b/frontend/src/utils/hints/tarneebHint.test.ts
@@ -43,6 +43,7 @@ function makeState(overrides: Partial<TarneebResponse> = {}): TarneebResponse {
     gameEndFlag: false,
     winnerTeam: -1,
     leadPlayerIdx: -1,
+    validPlayIndices: [],
     message: '',
     config: { cpuDifficulty: 1, pointLimit: 31, minBid: 7 },
     ...overrides,

--- a/internal/adapter/controller/TarneebWebController.go
+++ b/internal/adapter/controller/TarneebWebController.go
@@ -73,6 +73,11 @@ type TarneebWebOutput struct {
 	WinnerTeam       int                       `json:"winnerTeam"`
 	LeadPlayerIdx    int                       `json:"leadPlayerIdx"`
 	Hint             *TarneebWebOutputHint     `json:"hint,omitempty"`
+	// ValidPlayIndices は人間がいま出せる手札の位置。**ドメインの
+	// GetValidPlayIndices がマストフォローを判定済みなのに、Web には送って
+	// おらず、違反札をクリックしてエラーで確かめるしかなかった (#4713)。**
+	// プレイフェーズで人間の手番のときだけ埋まり、それ以外は空。
+	ValidPlayIndices []int `json:"validPlayIndices"`
 	WebOutputBase
 	Config TarneebWebOutputConfig `json:"config"`
 }

--- a/internal/adapter/presenter/TarneebWebPresenter.go
+++ b/internal/adapter/presenter/TarneebWebPresenter.go
@@ -36,6 +36,24 @@ func (p *TarneebWebPresenter) Output(t interfaces.TarneebGame, lastErr error) st
 }
 
 // buildBase 共通フィールドを構築
+// validPlayIndices は人間がいま出せる手札の位置を返す。
+//
+// **判定はドメインの GetValidPlayIndices をそのまま呼ぶ。**マストフォローの
+// 規則をフロントに複製すると、ドメインだけ直したときに黙って食い違う。
+// プレイフェーズで人間の手番でなければ空 -- そもそも制限が決まっていない
+// 状態と「1枚も出せない」を混同しないため、呼び出し側は空を「制限なし」とは
+// 解釈せず、手番かどうかで先に分岐する (#4713)。
+func (p *TarneebWebPresenter) validPlayIndices(t interfaces.TarneebGame) []int {
+	if t.GetPhase() != domain.TarneebPhasePlay || !t.IsHumanTurn() {
+		return make([]int, 0)
+	}
+	idx := t.GetValidPlayIndices(t.GetCurrentPlayerIdx())
+	if idx == nil {
+		return make([]int, 0)
+	}
+	return idx
+}
+
 func (p *TarneebWebPresenter) buildBase(t interfaces.TarneebGame) *controller.TarneebWebOutput {
 	resObj := new(controller.TarneebWebOutput)
 	resObj.Phase = int(t.GetPhase())
@@ -49,6 +67,7 @@ func (p *TarneebWebPresenter) buildBase(t interfaces.TarneebGame) *controller.Ta
 	resObj.RedealCount = t.GetRedealCount()
 	resObj.DealerIdx = t.GetDealerIdx()
 	resObj.GameEndFlag = t.GetGameEndFlag()
+	resObj.ValidPlayIndices = p.validPlayIndices(t)
 	resObj.WinnerTeam = t.GetWinnerTeam()
 	resObj.LeadPlayerIdx = t.GetLeadPlayerIdx()
 

--- a/internal/adapter/presenter/TarneebWebPresenter_test.go
+++ b/internal/adapter/presenter/TarneebWebPresenter_test.go
@@ -29,6 +29,8 @@ type webOutPartial struct {
 	Players     []json.RawMessage `json:"players"`
 	GameEndFlag bool              `json:"gameEndFlag"`
 	WinnerTeam  int               `json:"winnerTeam"`
+	// #4713 で追加。合法手の位置。
+	ValidPlayIndices []int `json:"validPlayIndices"`
 }
 
 func TestTarneebWebPresenter_Output(t *testing.T) {
@@ -151,6 +153,51 @@ func TestTarneebWebPresenter_Output(t *testing.T) {
 		require.NoError(t, json.Unmarshal([]byte(p.Output(tn, nil)), &got))
 		assert.Equal(t, "tarneeb.gameEndCpuWin", got.MessageCode)
 		assert.Equal(t, 1, got.WinnerTeam)
+	})
+}
+
+// **ドメインは合法手を判定済みなのに Web に送っていなかった (#4713)。**
+// 違反札をクリックしてサーバーのエラーが返って初めて出せないと分かる状態だった。
+func TestTarneebWebPresenter_ValidPlayIndices(t *testing.T) {
+	p := new(presenter.TarneebWebPresenter)
+
+	decode := func(t *testing.T, tn *domain.Tarneeb) webOutPartial {
+		t.Helper()
+		var got webOutPartial
+		require.NoError(t, json.Unmarshal([]byte(p.Output(tn, nil)), &got))
+		return got
+	}
+
+	t.Run("human play turn reports the domain's own answer", func(t *testing.T) {
+		tn := newTarneebForWebTest()
+		tn.SetPhase(domain.TarneebPhasePlay)
+		tn.SetCurrentPlayerIdx(0) // 席 0 が人間
+		require.True(t, tn.IsHumanTurn(), "前提: 人間の手番であること")
+
+		got := decode(t, tn)
+		// **ドメインと一致することを見る。**ここで固定値を期待すると、配りに
+		// 依存して落ちるうえ、presenter が独自計算していても気づけない。
+		assert.Equal(t, tn.GetValidPlayIndices(0), got.ValidPlayIndices)
+		assert.NotEmpty(t, got.ValidPlayIndices, "リード時は全札が合法なので空にはならない")
+	})
+
+	t.Run("cpu turn reports nothing", func(t *testing.T) {
+		tn := newTarneebForWebTest()
+		tn.SetPhase(domain.TarneebPhasePlay)
+		tn.SetCurrentPlayerIdx(1) // CPU
+		require.False(t, tn.IsHumanTurn())
+
+		assert.Empty(t, decode(t, tn).ValidPlayIndices)
+	})
+
+	// **プレイフェーズ以外も踏む。**ビッド中は制限そのものが決まっていないので、
+	// ここで合法手を送ると「いま出せる」と誤って伝えることになる。
+	t.Run("bid phase reports nothing", func(t *testing.T) {
+		tn := newTarneebForWebTest()
+		tn.SetCurrentPlayerIdx(0)
+		require.Equal(t, domain.TarneebPhaseBid, tn.GetPhase(), "前提: 配り直後はビッド")
+
+		assert.Empty(t, decode(t, tn).ValidPlayIndices)
 	})
 }
 


### PR DESCRIPTION
## 背景

ドメインの `Tarneeb.GetValidPlayIndices` はマストフォローを判定済みで、interface にも公開されています。ところが `TarneebWebPresenter` はそれを出力に載せておらず、`TarneebPage.tsx` も `PlayerHandSection` に `validIndices` を渡していませんでした。結果、違反札もクリックでき、サーバーのエラーが返って初めて「出せない」と分かる状態でした (#4713)。

## 変更

判定はドメインのままにして、presenter が `validPlayIndices` として載せ、ページがそれを渡すだけです。**マストフォローの規則をフロントに複製していません** — 複製すると、ドメインだけ直したときに黙って食い違います。

### 空を「制限なし」と読まない

presenter は**プレイフェーズかつ人間の手番のときだけ**埋め、それ以外は空を返します。ページ側も `isHumanTurn ? state.validPlayIndices : undefined` と、長さではなく手番で分岐します。

`validPlayIndices.length === 0` を「制限なし」と解釈すると、**「1枚も出せない」局面と「そもそも制限を送っていない」状態が区別できなくなります**（Macau #4805 で実際に踏んだ罠です）。

## テスト

**presenter** (`TestTarneebWebPresenter_ValidPlayIndices`):
- 人間のプレイ手番 → **`tn.GetValidPlayIndices(0)` と一致すること**を検証。固定値を期待すると配りに依存して落ちるうえ、presenter が独自計算していても気づけません
- CPU の手番 → 空
- ビッドフェーズ → 空（制限そのものが決まっていないため）

**page**:
- `validPlayIndices: [1]` で index 0 が `aria-disabled`、index 1 はそうでない
- CPU 手番では全札が有効のまま

**負のコントロール**:

| 変更 | 結果 |
|------|------|
| presenter のガードを `if false` に潰す | CPU手番・ビッド の2件が落ちる |
| presenter のガードを `if true` で無条件化 | 人間手番の1件が落ちる |
| ページを `validIndices={state.validPlayIndices}` に（長さ判定バグ） | 1件が落ちる |
| 元に戻す | green |

## 検証

- `go test -tags test ./internal/...` ✅ / `golangci-lint` → `0 issues.` ✅ / `gofmt -l internal/` 空 ✅
- `bun run check` ✅ / `bun run typecheck` ✅ / 26 passed ✅
- `e2e/tarneeb.spec.ts` は手札をクリックしないので、`aria-disabled` によるロケータ破綻はありません（確認済み）

Closes #4713