### PR TITLE
feat: show the play-history statistics on the Five Card Stud web page

### DIFF
--- a/frontend/src/components/fivecardstud/PokerStatsBadge.test.tsx
+++ b/frontend/src/components/fivecardstud/PokerStatsBadge.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import i18n from '../../i18n';
+import { PokerStatsBadge } from './PokerStatsBadge';
+
+const t = i18n.getFixedT(null, 'fivecardstud');
+
+const stats = { totalHands: 40, vpip: 25, pfr: 12, threeBet: 5, af: '2.3' };
+
+describe('PokerStatsBadge', () => {
+  it('renders every statistic the CUI reports', () => {
+    render(<PokerStatsBadge stats={stats} t={t} />);
+    const badge = screen.getByTestId('fcs-stats');
+    for (const fragment of ['25', '12', '5', '2.3']) {
+      expect(badge).toHaveTextContent(fragment);
+    }
+  });
+
+  // **未プレイでは出さない。**統計として意味が無く、CUI も同じ条件で行ごと
+  // 省いている。ここを描画してしまうと「VPIP 0%」が実績のように読める。
+  it('renders nothing before any hand has been played', () => {
+    const { container } = render(<PokerStatsBadge stats={{ ...stats, totalHands: 0 }} t={t} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  // AF はバックエンドが整形済みの文字列で、割り算不能なとき "∞" が来る。
+  // 数値として扱うと NaN になるため、そのまま出せることを踏む。
+  it('passes the pre-formatted aggression factor through unchanged', () => {
+    render(<PokerStatsBadge stats={{ ...stats, af: '∞' }} t={t} />);
+    expect(screen.getByTestId('fcs-stats')).toHaveTextContent('∞');
+  });
+});

--- a/frontend/src/components/fivecardstud/PokerStatsBadge.tsx
+++ b/frontend/src/components/fivecardstud/PokerStatsBadge.tsx
@@ -1,0 +1,42 @@
+import type { TFunction } from 'i18next';
+
+/** The play-history fields the badge reports. */
+export interface PokerStats {
+  /** Hands played so far. The badge renders nothing while this is 0. */
+  totalHands: number;
+  /** Voluntarily put money in pot, as a percentage. */
+  vpip: number;
+  /** Pre-flop raise, as a percentage. */
+  pfr: number;
+  /** Three-bet frequency, as a percentage. */
+  threeBet: number;
+  /** Aggression factor, pre-formatted by the backend (may be "∞"). */
+  af: string;
+}
+
+/**
+ * Renders the VPIP / PFR / 3Bet / AF summary for one player.
+ *
+ * **CUI (`FiveCardStudCuiPresenter`) は `fivecardstud.playerStats` でこの4つを
+ * 全プレイヤー分出しているのに、Web はプレイスタイル名しか出していなかった。**
+ * 名前だけでは相手の実際の傾向が読めず、同じレスポンスに乗っている数字が
+ * Web だけ捨てられている状態だった (#4730)。
+ *
+ * `totalHands` が 0 のあいだは何も描画しない — 統計として意味を持たないうえ、
+ * CUI 側も同じ条件で行ごと出していない。
+ */
+export function PokerStatsBadge({ stats, t }: { stats: PokerStats; t: TFunction }) {
+  if (stats.totalHands <= 0) {
+    return null;
+  }
+  return (
+    <span className="ml-2 text-xs text-ds-text-muted" data-testid={'fcs-stats'}>
+      {t('stats.badge', {
+        vpip: stats.vpip,
+        pfr: stats.pfr,
+        tb: stats.threeBet,
+        af: stats.af,
+      })}
+    </span>
+  );
+}

--- a/frontend/src/i18n/locales/en/fivecardstud.json
+++ b/frontend/src/i18n/locales/en/fivecardstud.json
@@ -30,14 +30,7 @@
     "show": "Show"
   },
   "stats": {
-    "vpip": "VPIP",
-    "vpipTooltip": "VPIP (Voluntarily Put In Pot): % of hands where player voluntarily put chips in the pot",
-    "pfr": "PFR",
-    "pfrTooltip": "PFR (Pre-Flop Raise): % of hands where player raised in the first round",
-    "threeBet": "3Bet",
-    "threeBetTooltip": "3Bet: % of hands where player re-raised an opponent's raise",
-    "af": "AF",
-    "afTooltip": "AF (Aggression Factor): ratio of aggressive actions (bet/raise) to passive actions (call)"
+    "badge": "VPIP {{vpip}}% / PFR {{pfr}}% / 3Bet {{tb}}% / AF {{af}}"
   },
   "settings": {
     "cpuMetaAI": "Meta-AI (CPU learns your play style)"

--- a/frontend/src/i18n/locales/ja/fivecardstud.json
+++ b/frontend/src/i18n/locales/ja/fivecardstud.json
@@ -30,14 +30,7 @@
     "show": "ショー"
   },
   "stats": {
-    "vpip": "VPIP",
-    "vpipTooltip": "VPIP（ボランタリー・プット・イン・ポット）: 自発的にポットに参加した割合",
-    "pfr": "PFR",
-    "pfrTooltip": "PFR（プリフロップレイズ）: 最初のラウンドでレイズした割合",
-    "threeBet": "3Bet",
-    "threeBetTooltip": "3Bet（スリーベット）: 相手のレイズに対して再レイズした割合",
-    "af": "AF",
-    "afTooltip": "AF（アグレッションファクター）: ベット・レイズのコールに対する比率"
+    "badge": "VPIP {{vpip}}% / PFR {{pfr}}% / 3Bet {{tb}}% / AF {{af}}"
   },
   "settings": {
     "cpuMetaAI": "メタAI（CPUがプレイスタイルを学習）"

--- a/frontend/src/pages/FiveCardStudPage.test.tsx
+++ b/frontend/src/pages/FiveCardStudPage.test.tsx
@@ -447,4 +447,30 @@ describe('FiveCardStudPage keyboard shortcuts', () => {
     fireEvent.click(toggle);
     expect(await screen.findByTestId('hint-tooltip')).toBeInTheDocument();
   });
+
+  // **CUI は fivecardstud.playerStats で VPIP/PFR/3Bet/AF を全員分出しているのに、
+  // Web はプレイスタイル名しか出していなかった (#4730)。**同じレスポンスに乗って
+  // いる数字が Web だけ捨てられている状態だった。
+  it('shows the play-history statistics once hands have been played', async () => {
+    const stats = { totalHands: 40, vpip: 25, pfr: 12, threeBet: 5, af: '2.3' };
+    mockExec.mockResolvedValue({
+      ...secondStreetState,
+      players: [humanPlayer(stats), cpuPlayer(1, stats), cpuPlayer(2, stats), cpuPlayer(3, stats)],
+    });
+    renderWithProviders(<FiveCardStudPage />);
+
+    await waitFor(() => expect(mockExec).toHaveBeenCalled());
+    const badges = screen.getAllByTestId('fcs-stats');
+    expect(badges.length).toBeGreaterThan(0);
+    expect(badges[0]).toHaveTextContent('25');
+  });
+
+  // 逆側。1ハンドも打っていないうちは出さない (既定は totalHands: 0)。
+  it('shows no statistics before any hand has been played', async () => {
+    mockExec.mockResolvedValue(secondStreetState);
+    renderWithProviders(<FiveCardStudPage />);
+
+    await waitFor(() => expect(mockExec).toHaveBeenCalled());
+    expect(screen.queryAllByTestId('fcs-stats')).toHaveLength(0);
+  });
 });

--- a/frontend/src/pages/FiveCardStudPage.tsx
+++ b/frontend/src/pages/FiveCardStudPage.tsx
@@ -10,6 +10,7 @@ import { CliTerminal } from '../components/cli/CliTerminal';
 import { CliToggle } from '../components/cli/CliToggle';
 import { SettingsPanel } from '../components/common/SettingsPanel';
 import { ErrorAlert } from '../components/ErrorAlert';
+import { PokerStatsBadge } from '../components/fivecardstud/PokerStatsBadge';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
@@ -264,6 +265,7 @@ function FiveCardStudPageContent() {
                   <div className="text-ds-text-primary text-sm mb-1">
                     CPU {p.id}
                     <span className="ml-2 text-xs text-ds-text-muted">{p.playStyleName}</span>
+                    <PokerStatsBadge stats={p} t={t} />
                     <span className="ml-2 text-xs">
                       {tc('betting.chips')} {p.chips}
                     </span>
@@ -364,6 +366,7 @@ function FiveCardStudPageContent() {
               <div className="mb-2" data-tutorial="fcs-player-hand">
                 <div className="text-ds-text-primary text-lg mb-1">
                   {t('yourHand')}
+                  <PokerStatsBadge stats={humanPlayer} t={t} />
                   <span className="ml-3 text-xs">
                     {tc('betting.chips')} {humanPlayer.chips}
                   </span>


### PR DESCRIPTION
## 背景

`FiveCardStudCuiPresenter` は `fivecardstud.playerStats` で **VPIP・PFR・3ベット率・AF**（アグレッション係数）を全プレイヤー分表示しています。これらは `FiveCardStudPlayerData` として **API レスポンスにもそのまま乗っています**。

ところが `FiveCardStudPage.tsx` は `playStyleName` / `chips` / `currentBet` / `folded` / `handName` しか参照しておらず、`vpip` / `pfr` / `threeBet` / `af` はページ内で一度も使われていませんでした (#4730)。プレイスタイル名だけでは相手の実際の傾向が読めず、**同じレスポンスに乗っている数字が Web だけ捨てられている**状態でした。

## 変更

`PokerStatsBadge` を追加し、**CPU 行と自分の手札見出しの両方**に配置しました（受け入れ条件どおり）。

`totalHands` が 0 のあいだは描画しません。統計として意味を持たないうえ、**CUI も同じ条件で行ごと省いている**ためです。ここを描画してしまうと「VPIP 0%」が実績のように読めてしまいます。

`af` はバックエンドが整形済みの**文字列**（割り算不能なとき `∞`）なので、数値化せずそのまま通します。

## テスト

**component** (`PokerStatsBadge.test.tsx`):
- 4つの統計がすべて出ること
- `totalHands: 0` では何も描画しないこと
- `af: '∞'` がそのまま出ること（数値として扱うと NaN になる）

**page**:
- 統計付きの状態で `fcs-stats` が出て 25% を含むこと
- 既定（`totalHands: 0`）では1つも出ないこと

**負のコントロール**: `totalHands` のガードを外すと2件が落ち、戻すと 35 passed。

## 検証

- `bun run check` ✅ / `bun run typecheck` ✅ / 35 passed ✅

Closes #4730