### PR TITLE
feat: show the running card points during Doppelkopf play

### DIFF
--- a/frontend/src/i18n/locales/en/doppelkopf.json
+++ b/frontend/src/i18n/locales/en/doppelkopf.json
@@ -65,5 +65,10 @@
     "badgeTitle": "Trump"
   },
   "hintRequested": "Hint available",
-  "noHint": "No hint available"
+  "noHint": "No hint available",
+  "livePoints": {
+    "title": "Card points so far",
+    "re": "Re: {{points}} (needs {{target}})",
+    "kontra": "Kontra: {{points}} (needs {{target}})"
+  }
 }

--- a/frontend/src/i18n/locales/ja/doppelkopf.json
+++ b/frontend/src/i18n/locales/ja/doppelkopf.json
@@ -65,5 +65,10 @@
     "badgeTitle": "切り札"
   },
   "hintRequested": "ヒントがあります",
-  "noHint": "ヒントはありません"
+  "noHint": "ヒントはありません",
+  "livePoints": {
+    "title": "現在の獲得点",
+    "re": "Re: {{points}}点（勝利ライン {{target}}点）",
+    "kontra": "Kontra: {{points}}点（勝利ライン {{target}}点）"
+  }
 }

--- a/frontend/src/pages/DoppelkopfPage.test.tsx
+++ b/frontend/src/pages/DoppelkopfPage.test.tsx
@@ -215,4 +215,27 @@ describe('DoppelkopfPage', () => {
     renderWithProviders(<DoppelkopfPage />);
     expect(await screen.findByText(/\(\[0\]\)/)).toBeInTheDocument();
   });
+
+  // **同じ値が毎レスポンスに乗っているのに、ラウンド終了まで出していなかった。**
+  // 最初のトリックで Re/Kontra をアナウンスできるので、いま何点取れているかは
+  // 実戦上の判断材料になる (#4720)。
+  it('shows the running card points during play', async () => {
+    mockExec.mockResolvedValue(makeDoppelkopfState({ phase: 0, roundRePoints: 85 }));
+    renderWithProviders(<DoppelkopfPage />);
+
+    const panel = await screen.findByTestId('dk-live-points');
+    expect(panel).toHaveTextContent('85');
+    // Kontra 側は 240 - 85 = 155。合計から引いて出していることを踏む。
+    expect(panel).toHaveTextContent('155');
+    expect(panel).toHaveTextContent('121');
+  });
+
+  // 逆側。ラウンド終了後は下の内訳が引き継ぐので、二重に出さない。
+  it('hides the running panel once the round has ended', async () => {
+    mockExec.mockResolvedValue(makeDoppelkopfState({ phase: 2, roundRePoints: 85 }));
+    renderWithProviders(<DoppelkopfPage />);
+
+    await waitFor(() => expect(mockExec).toHaveBeenCalled());
+    expect(screen.queryByTestId('dk-live-points')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/DoppelkopfPage.tsx
+++ b/frontend/src/pages/DoppelkopfPage.tsx
@@ -75,6 +75,15 @@ const DOPPELKOPF_PHASE_KEYS: Readonly<Record<number, string>> = {
 export const DoppelkopfPage = withTutorial(DoppelkopfPageContent, 'doppelkopf', DK_TUTORIAL_STEPS);
 
 /** Inner content of the Doppelkopf page, wrapped by TutorialProvider. */
+/**
+ * Re が勝つのに必要なカード得点。`domain.DoppelkopfReWinPoints` の写し。
+ * Kontra は 120 点で勝つ (引き分けが無いよう Re 側だけ 1 点多く必要)。
+ */
+const DOPPELKOPF_RE_WIN_POINTS = 121;
+
+/** 1 ラウンドのカード得点合計。`domain.DoppelkopfTotalPoints` の写し。 */
+const DOPPELKOPF_TOTAL_POINTS = 240;
+
 function DoppelkopfPageContent() {
   const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
     useGamePageSetup('doppelkopf');
@@ -280,6 +289,33 @@ function DoppelkopfPageContent() {
                         {t('chips', { count: p.chips })} | {t('tricks', { count: p.trickCount })}
                       </div>
                     ))}
+                  </div>
+                )}
+
+                {/* ラウンド中の獲得点。**同じ値がレスポンスに毎回乗っているのに、
+                    ラウンド終了まで画面に出していなかった。**最初のトリックで
+                    Re/Kontra をアナウンスできるので、いま何点取れているかは
+                    実戦上の判断材料になる。終了後は下の内訳が引き継ぐ。 */}
+                {!(isRoundEnd || isGameEnd) && (
+                  <div
+                    className="my-3 p-2 rounded bg-black/30 text-ds-text-muted text-sm"
+                    role="status"
+                    aria-live="polite"
+                    data-testid="dk-live-points"
+                  >
+                    <div className="mb-1 text-ds-text-primary">{t('livePoints.title')}</div>
+                    <div>
+                      {t('livePoints.re', {
+                        points: state.roundRePoints,
+                        target: DOPPELKOPF_RE_WIN_POINTS,
+                      })}
+                    </div>
+                    <div>
+                      {t('livePoints.kontra', {
+                        points: DOPPELKOPF_TOTAL_POINTS - state.roundRePoints,
+                        target: DOPPELKOPF_TOTAL_POINTS - DOPPELKOPF_RE_WIN_POINTS + 1,
+                      })}
+                    </div>
                   </div>
                 )}
 

--- a/internal/domain/Doppelkopf.go
+++ b/internal/domain/Doppelkopf.go
@@ -33,6 +33,12 @@ const DoppelkopfTrickCount = 12
 // DoppelkopfTotalPoints 1 ラウンドのカードポイント合計
 const DoppelkopfTotalPoints = 240
 
+// DoppelkopfReWinPoints は Re チームが勝つのに必要なカード得点。
+//
+// 全 240 点の過半数。Kontra は 120 点で勝つ (引き分けが無いよう Re 側だけ
+// 1 点多く必要) ため、この非対称は仕様であって誤差ではない。
+const DoppelkopfReWinPoints = 121
+
 // DoppelkopfPhase ゲームフェーズ
 type DoppelkopfPhase int
 
@@ -320,7 +326,7 @@ func (g *Doppelkopf) ScoreRound() {
 
 	rePts := g.teamPoints(true)
 	kontraPts := DoppelkopfTotalPoints - rePts
-	reWon := rePts >= 121 // Re は 121 点以上で勝利 (Kontra は 120 点で勝利)
+	reWon := rePts >= DoppelkopfReWinPoints
 	loserPts := kontraPts
 	if !reWon {
 		loserPts = rePts


### PR DESCRIPTION
## 背景

`DoppelkopfResponse.roundRePoints`（Re チームが今ラウンドで獲得したカード得点）は**毎レスポンスに含まれています**。ところが `DoppelkopfPage.tsx` はこれを `(isRoundEnd || isGameEnd)` の中でしか表示しておらず、PLAY フェーズ中はどれだけ得点しているか一切分かりませんでした (#4720)。

Doppelkopf は最初のトリックで **Re/Kontra のアナウンス**ができる（`state.canAnnounce`）ため、現在の得点差は実戦上の判断材料になります。

## 変更

姉妹ゲームの `SuecaPage.tsx` と同じライブ得点パネル（`role="status" aria-live="polite"`）を追加しました。ラウンド終了後は既存の内訳ブロックが引き継ぐので、二重には出しません。

Kontra 側の点は合計から引いて出しています（`240 - roundRePoints`）。

### 121 を定数化しました

判定は `rePts >= 121` とマジックナンバーで書かれていたので、`DoppelkopfReWinPoints` として名前を付けました。**Kontra は 120 点で勝つ**（引き分けを作らないよう Re 側だけ 1 点多く必要）という非対称は仕様なので、誤差と誤解されないようコメントに明記しています。

フロント側はこの写しを定数として持ちます。

## テスト

- PLAY 中に `dk-live-points` が出て、Re 85 / Kontra 155（= 240 − 85）/ 勝利ライン 121 を含むこと
- ラウンド終了後は出さないこと（内訳と二重にならない）

**負のコントロール**: パネルの条件を `true` に潰すと1件が落ち、戻すと 18 passed。

## 検証

- `go test -tags test ./internal/...` ✅ / `golangci-lint` → `0 issues.` ✅ / `gofmt -l internal/` 空 ✅
- `bun run check` ✅ / `bun run typecheck` ✅ / `DoppelkopfPage` 18 passed ✅

Closes #4720