### PR TITLE
feat: add the settings panel to the Shithead web page

### DIFF
--- a/frontend/src/hooks/useShitheadGame.ts
+++ b/frontend/src/hooks/useShitheadGame.ts
@@ -25,7 +25,11 @@ export const CPU_DIFFICULTY_OPTIONS = [
 /** Hook that manages Shithead game state and player actions. */
 export function useShitheadGame() {
   const { selected: selectedCardIndices, toggle: toggleCard, clear: clearSelection } = useCardSelection();
-  const { config: shitheadConfig, handleConfigChange } = useGameConfig<ShitheadConfig>(DEFAULT_SHITHEAD_CONFIG);
+  const {
+    config: shitheadConfig,
+    handleConfigChange,
+    handleToggle: handleMagicToggle,
+  } = useGameConfig<ShitheadConfig>(DEFAULT_SHITHEAD_CONFIG);
 
   const onSuccess = useCallback(() => {
     clearSelection();
@@ -66,6 +70,7 @@ export function useShitheadGame() {
     toggleCard,
     clearSelection,
     handleConfigChange,
+    handleMagicToggle,
     handlePlay,
     handlePickup,
     handleResetWithConfig,

--- a/frontend/src/i18n/locales/en/shithead.json
+++ b/frontend/src/i18n/locales/en/shithead.json
@@ -53,5 +53,17 @@
     "burnTen": "Burn the pile with 10 to seize the initiative.",
     "resetTwo": "Reset with 2 to escape pressure from a high top card.",
     "playLowest": "Play the lowest card that beats or matches the top."
+  },
+  "settings": {
+    "title": "Settings",
+    "cpuDifficulty": "CPU difficulty",
+    "easy": "Easy",
+    "normal": "Normal",
+    "hard": "Hard",
+    "magicTwo": "Magic 2 (reset)",
+    "magicSeven": "Magic 7 (play under)",
+    "magicEight": "Magic 8 (skip)",
+    "magicTen": "Magic 10 (burn)",
+    "fourOfAKindBurn": "Four of a kind burns the pile"
   }
 }

--- a/frontend/src/i18n/locales/ja/shithead.json
+++ b/frontend/src/i18n/locales/ja/shithead.json
@@ -53,5 +53,17 @@
     "burnTen": "10で場札を焼却すると一気に主導権を握れます",
     "resetTwo": "2でリセットして高いカードのプレッシャーから抜けましょう",
     "playLowest": "場札に勝てる中でもっとも小さい値のカードを選びます"
+  },
+  "settings": {
+    "title": "設定",
+    "cpuDifficulty": "CPU難易度",
+    "easy": "かんたん",
+    "normal": "ふつう",
+    "hard": "むずかしい",
+    "magicTwo": "2 のマジック（リセット）",
+    "magicSeven": "7 のマジック（以下縛り）",
+    "magicEight": "8 のマジック（スキップ）",
+    "magicTen": "10 のマジック（場を焼く）",
+    "fourOfAKindBurn": "同じ数字4枚で場を焼く"
   }
 }

--- a/frontend/src/pages/ShitheadPage.test.tsx
+++ b/frontend/src/pages/ShitheadPage.test.tsx
@@ -375,4 +375,41 @@ describe('ShitheadPage', () => {
     await waitFor(() => expect(screen.getAllByAltText('ジョーカー').length).toBeGreaterThan(0));
     expect(screen.queryByText(/\?0/)).not.toBeInTheDocument();
   });
+
+  // **フックは設定機構を全部エクスポートしていたのに、ページが一切使っておらず
+  // 常に既定値固定だった (#4747)。**マジックカードの有無はゲーム性そのものを
+  // 変えるのに、Web からは touch できなかった。
+  it('lets the player turn a magic card off, and reshuffles with the new rules', async () => {
+    renderWithProviders(<ShitheadPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalled());
+
+    const toggle = screen.getByLabelText(/10 のマジック/);
+    expect(toggle).toBeChecked();
+
+    mockExec.mockClear();
+    fireEvent.click(toggle);
+
+    // 配りが変わるので、設定変更は即リセットを伴う。
+    await waitFor(() =>
+      expect(mockExec).toHaveBeenCalledWith(
+        'reset',
+        expect.objectContaining({ config: expect.objectContaining({ magicTen: false }) }),
+      ),
+    );
+  });
+
+  it('lets the player change the CPU difficulty', async () => {
+    renderWithProviders(<ShitheadPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalled());
+
+    mockExec.mockClear();
+    fireEvent.change(screen.getByLabelText('CPU難易度'), { target: { value: '2' } });
+
+    await waitFor(() =>
+      expect(mockExec).toHaveBeenCalledWith(
+        'reset',
+        expect.objectContaining({ config: expect.objectContaining({ cpuDifficulty: 2 }) }),
+      ),
+    );
+  });
 });

--- a/frontend/src/pages/ShitheadPage.tsx
+++ b/frontend/src/pages/ShitheadPage.tsx
@@ -3,6 +3,7 @@ import type { shitheadApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
 import { CliToggle } from '../components/cli/CliToggle';
+import { SettingsPanel } from '../components/common/SettingsPanel';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
@@ -17,7 +18,7 @@ import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { useShitheadGame } from '../hooks/useShitheadGame';
+import { CPU_DIFFICULTY_OPTIONS, useShitheadGame } from '../hooks/useShitheadGame';
 import { badgeInfoColors, badgeWarningColors } from '../styles/badgeStyles';
 import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
 import { focusRingCard } from '../styles/cardStyles';
@@ -57,6 +58,12 @@ const SOURCE_FACE_DOWN = 'facedown';
 
 /** Renders the Shithead / Karma game page. */
 export const ShitheadPage = withTutorial(ShitheadPageContent, 'shithead', SHITHEAD_TUTORIAL_STEPS);
+/**
+ * ルールを切り替えられるマジックカード。値は `ShitheadConfig` のキーで、
+ * 文言は `settings.<key>` を引く。
+ */
+const MAGIC_TOGGLES = ['magicTwo', 'magicSeven', 'magicEight', 'magicTen', 'fourOfAKindBurn'] as const;
+
 /** Inner content of the Shithead page. */
 function ShitheadPageContent() {
   const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
@@ -72,6 +79,10 @@ function ShitheadPageContent() {
     handleReset,
     retry,
     dispatch,
+    shitheadConfig,
+    handleConfigChange,
+    handleMagicToggle,
+    handleResetWithConfig,
   } = useShitheadGame();
   const { cardWidth } = useCardDimensions();
   const { hint, hintEnabled, setHintEnabled } = useGameHint('shithead', state);
@@ -301,6 +312,45 @@ function ShitheadPageContent() {
             </div>
           </GameFooter>
           {hintEnabled && hint && <HintTooltip reason={t(hint.reason)} confidence={hint.confidence} />}
+
+          <SettingsPanel
+            title={t('settings.title')}
+            groups={[
+              {
+                items: [
+                  {
+                    type: 'select',
+                    id: 'shitheadCpuDifficulty',
+                    label: t('settings.cpuDifficulty'),
+                    value: shitheadConfig.cpuDifficulty,
+                    options: CPU_DIFFICULTY_OPTIONS.map((o) => ({
+                      value: o.value,
+                      label: t(`settings.${o.label.toLowerCase()}`),
+                    })),
+                    onSelect: (v) => {
+                      handleConfigChange('cpuDifficulty', String(v));
+                      handleResetWithConfig({ ...shitheadConfig, cpuDifficulty: Number(v) });
+                    },
+                  },
+                  ...MAGIC_TOGGLES.map((key) => ({
+                    type: 'checkbox' as const,
+                    id: `shithead-${key}`,
+                    label: t(`settings.${key}`),
+                    checked: shitheadConfig[key],
+                    onToggle: (checked: boolean) => {
+                      handleMagicToggle(key, checked);
+                      handleResetWithConfig({ ...shitheadConfig, [key]: checked });
+                    },
+                  })),
+                ],
+              },
+            ]}
+          />
+
+          {/* **フックは設定機構を全部エクスポートしていたのに、ページが一切
+              使っておらず常に既定値固定だった。**マジックカードの有無は
+              ゲーム性そのものを変えるのに、Web からは触れなかった (#4747)。
+              変更は即リセットが必要 (配りが変わる) ので handleResetWithConfig を通す。 */}
         </>
       )}
     </GamePageShell>


### PR DESCRIPTION
## 背景

`useShitheadGame` は `shitheadConfig` / `handleConfigChange` / `handleResetWithConfig` / `DEFAULT_SHITHEAD_CONFIG` という**完全な設定機構をすでにエクスポート**しています。ところが `ShitheadPage.tsx` はこれらを一切分割代入しておらず、`SettingsPanel` の import もありませんでした (#4747)。

結果、**常に `DEFAULT_SHITHEAD_CONFIG` 固定**で、マジックカード（2/7/8/10）や4枚バーンの有無を Web から変更する手段がありませんでした。これらは**ゲーム性そのものを変える**ルールです。Whist・CatchTen・Tonk・CallBreak・President・Cassino・Pitch など他のほぼ全ての設定可能ゲームは `SettingsPanel` を出しています。

## 変更

他ゲームと同じ `SettingsPanel` を追加しました（CPU難易度セレクト + マジックカード5つのチェックボックス）。

**設定変更は即リセットを伴います** — マジックカードの有無は配りではなく進行に効きますが、途中変更は不整合になるため `handleResetWithConfig` を通します。

### フックに `handleToggle` を足しました

`useGameConfig` は数値用の `handleConfigChange`（`NumberKeys` + string）と真偽値用の `handleToggle`（`BooleanKeys` + boolean）を返しますが、`useShitheadGame` は前者しか通していませんでした。真偽値の更新をページで自前実装すると二系統になるので、`handleMagicToggle` として公開しています。

## テスト

- マジック10のチェックを外すと `reset` が `magicTen: false` を含む config で呼ばれること
- CPU難易度を変えると `reset` が `cpuDifficulty: 2` で呼ばれること

どちらも「トグルが動く」ではなく **「新しい設定で配り直される」** ところまで踏んでいます。設定が state に入るだけでサーバーに届かなければ、プレイヤーから見て何も変わらないためです。

**負のコントロール**: パネルを丸ごと外すと2件が落ち、戻すと 24 passed。

## 検証

- `bun run check` ✅ / `bun run typecheck` ✅ / `ShitheadPage` 24 passed ✅

Closes #4747