### PR TITLE
feat: show the meta-AI learning status on the Old Maid web page

### DIFF
--- a/frontend/src/i18n/locales/en/oldmaid.json
+++ b/frontend/src/i18n/locales/en/oldmaid.json
@@ -68,5 +68,8 @@
     "drewFrom": "← from {{from}}",
     "drewAndPaired": "← from {{from}} (paired)"
   },
-  "keyHints": "D: Draw / S: Shuffle"
+  "keyHints": "D: Draw / S: Shuffle",
+  "metaAI": {
+    "status": "[Meta AI] adapting (games: {{games}}, edge-pick rate: {{rate}}%)"
+  }
 }

--- a/frontend/src/i18n/locales/ja/oldmaid.json
+++ b/frontend/src/i18n/locales/ja/oldmaid.json
@@ -68,5 +68,8 @@
     "drewFrom": "← {{from}} から",
     "drewAndPaired": "← {{from}} から (ペア成立)"
   },
-  "keyHints": "D: 引く / S: シャッフル"
+  "keyHints": "D: 引く / S: シャッフル",
+  "metaAI": {
+    "status": "[メタAI] 適応中（ゲーム数: {{games}}、端ピック率: {{rate}}%）"
+  }
 }

--- a/frontend/src/pages/OldMaidPage.test.tsx
+++ b/frontend/src/pages/OldMaidPage.test.tsx
@@ -1404,4 +1404,26 @@ describe('OldMaidPage', () => {
       .filter((b) => b.dataset.drawnHighlight === 'true');
     expect(highlighted).toHaveLength(0);
   });
+
+  // **CUI は oldmaid.metaAILine で「自分の癖がどれだけ読まれているか」を毎回
+  // 出しているのに、Web は同じ値をレスポンスで受け取りながら一度も描画して
+  // いなかった (#4732)。**メタAI を ON にした意味が画面から分からない。
+  it('shows how much the meta AI has learned about the player', async () => {
+    mockExec.mockResolvedValue({ ...humanTurnState, metaAI: { enabled: true, gamesPlayed: 12, edgePickRate: 0.375 } });
+    renderWithProviders(<OldMaidPage />);
+
+    const badge = await screen.findByTestId('om-metaai');
+    expect(badge).toHaveTextContent('12');
+    // 0.375 -> 38% (CUI と同じく 100 倍して丸める)。
+    expect(badge).toHaveTextContent('38');
+  });
+
+  // 逆側。OFF のときは学習していないので数字に意味が無く、出さない。
+  it('shows no meta-AI status while the meta AI is off', async () => {
+    mockExec.mockResolvedValue({ ...humanTurnState, metaAI: { enabled: false, gamesPlayed: 12, edgePickRate: 0.375 } });
+    renderWithProviders(<OldMaidPage />);
+
+    await waitFor(() => expect(mockExec).toHaveBeenCalled());
+    expect(screen.queryByTestId('om-metaai')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/OldMaidPage.tsx
+++ b/frontend/src/pages/OldMaidPage.tsx
@@ -223,6 +223,24 @@ function OldMaidPageContent() {
               },
             ]}
           />
+          {/* **CUI は oldmaid.metaAILine で「自分の癖がどれだけ読まれているか」を
+              毎回出しているのに、Web は同じ値をレスポンスで受け取りながら一度も
+              描画していなかった。**メタAI を ON にした意味が画面から分からない。
+              enabled のときだけ出す -- OFF なら学習していないので数字に意味が無い。 */}
+          {state.metaAI?.enabled && (
+            <div
+              className="mx-4 lg:mx-8 mb-1 text-xs text-ds-text-muted"
+              role="status"
+              aria-live="polite"
+              data-testid="om-metaai"
+            >
+              {t('metaAI.status', {
+                games: state.metaAI.gamesPlayed,
+                rate: Math.round(state.metaAI.edgePickRate * 100),
+              })}
+            </div>
+          )}
+
           <ReplaySpeedSettingsPanel />
           {/* Scrollable: CPU rows + discard + status + logs + result */}
           <div className={`flex-1 overflow-y-auto pt-3 px-4 lg:px-8 ${lgCardAreaConstraint}`}>


### PR DESCRIPTION
## 背景

`OldMaidCuiPresenter` は `oldmaid.metaAILine` で **プレイ済みゲーム数**と**端カードの読まれやすさ率**（`PickRate(0) + PickRate(2)`）を毎回表示し、CPU が人間の癖をどれだけ学習したかを可視化しています。

Web も `OldMaidWebPresenter` が同じ計算で `metaAI`（`enabled` / `gamesPlayed` / `edgePickRate`）をレスポンスに載せており、型定義もあります。**ところがページは `state.metaAI` を一度も参照していませんでした** (#4732)。

`cpuMetaAI` という変数はページ内にありますが、これは設定用チェックボックスのローカル state で、レスポンスの `metaAI` とは無関係です。結果、メタAI を ON にしても**自分の癖がどれだけバレているか確認できませんでした**。

## 変更

`SettingsPanel` の直後に status バッジを追加しました。

`metaAI.enabled` が true のときだけ出します — OFF なら学習しておらず、`gamesPlayed` や `edgePickRate` に意味が無いためです。率は CUI と同じく 100 倍して丸めます（バックエンドが `PickRate(0) + PickRate(2)` を計算済みなので、フロントは書式だけ担当）。

## テスト

- `enabled: true` で `gamesPlayed: 12` と `edgePickRate: 0.375` → バッジに `12` と `38`（%）が出ること
- `enabled: false` では出さないこと（**同じ数字を持たせたまま** enabled だけ落として踏む）

**負のコントロール**: `enabled` ガードを外すと 102 件が落ちます。既定フィクスチャに `metaAI` が無いため `state.metaAI.gamesPlayed` が undefined 参照になり、ページ全体が壊れるためです — ガードが本当に効いていることの裏返しでもあります。

## 検証

- `bun run check` ✅ / `bun run typecheck` ✅ / `OldMaidPage` 105 passed ✅

Closes #4732