### PR TITLE
feat: show whether Tonk can knock, from a single computation

### DIFF
--- a/frontend/src/hooks/useTonkGame.test.ts
+++ b/frontend/src/hooks/useTonkGame.test.ts
@@ -39,6 +39,8 @@ const defaultState: TonkResponse = {
   opponentDeadwood: [],
   isTonk: false,
   isUndercut: false,
+  bestDeadwood: -1,
+  knockThreshold: 5,
   message: '',
   config: { cpuDifficulty: 1, pointLimit: 50 },
 };

--- a/frontend/src/i18n/locales/en/tonk.json
+++ b/frontend/src/i18n/locales/en/tonk.json
@@ -58,5 +58,10 @@
     "tonkDrawStock": "The discard does not meld — draw from the stock",
     "tonkKnock": "One discard leaves you at five points or fewer — you can knock",
     "tonkDiscardHeavy": "Discard the card that leaves the least deadwood"
+  },
+  "deadwood": {
+    "current": "Best deadwood after discarding: {{value}}",
+    "knockable": "Can knock",
+    "notKnockable": "Cannot knock (needs {{threshold}} or less)"
   }
 }

--- a/frontend/src/i18n/locales/ja/tonk.json
+++ b/frontend/src/i18n/locales/ja/tonk.json
@@ -58,5 +58,10 @@
     "tonkDrawStock": "捨て札は組にならない。山札から引こう",
     "tonkKnock": "1 枚捨てれば端札が5点以下。ノックできる",
     "tonkDiscardHeavy": "端札が一番減る札を捨てよう"
+  },
+  "deadwood": {
+    "current": "最小デッドウッド(1枚捨て後): {{value}}",
+    "knockable": "ノック可能",
+    "notKnockable": "ノック不可（{{threshold}}点以下が必要）"
   }
 }

--- a/frontend/src/pages/TonkPage.test.tsx
+++ b/frontend/src/pages/TonkPage.test.tsx
@@ -43,6 +43,8 @@ function makeState(overrides: Partial<TonkResponse> = {}): TonkResponse {
     opponentDeadwood: [],
     isTonk: false,
     isUndercut: false,
+    bestDeadwood: -1,
+    knockThreshold: 5,
     message: '',
     config: { cpuDifficulty: 1, pointLimit: 250 },
     ...overrides,
@@ -226,5 +228,36 @@ describe('TonkPage', () => {
       expect(screen.getByRole('button', { name: /ノック/ })).not.toHaveAttribute('data-undercut-risk'),
     );
     expect(screen.queryByTestId('tonk-undercut-warning')).not.toBeInTheDocument();
+  });
+
+  // **CUI は毎ターン「ノック可能/不可」を出しているのに、Web はプレイヤーの
+  // 手計算に任せていた (#4750)。**ノックボタンは1枚選択されていれば常に活性化
+  // するので、実際に押すまで合法かどうか分からなかった。
+  it('says whether the hand can knock right now', async () => {
+    mockExec.mockResolvedValue(makeState({ bestDeadwood: 3, knockThreshold: 5 }));
+    renderWithProviders(<TonkPage />);
+
+    const badge = await screen.findByTestId('tonk-deadwood');
+    expect(badge).toHaveTextContent('3');
+    expect(badge).toHaveAttribute('data-knockable', 'true');
+  });
+
+  it('says when the hand cannot knock yet', async () => {
+    mockExec.mockResolvedValue(makeState({ bestDeadwood: 9, knockThreshold: 5 }));
+    renderWithProviders(<TonkPage />);
+
+    const badge = await screen.findByTestId('tonk-deadwood');
+    expect(badge).toHaveTextContent('9');
+    expect(badge).not.toHaveAttribute('data-knockable');
+  });
+
+  // **-1 は「まだ聞くべき場面でない」印。**0 と混同すると、ドローフェーズで
+  // 「デッドウッド0 = ノック可能」と誤って案内してしまう。
+  it('shows nothing outside the human discard turn', async () => {
+    mockExec.mockResolvedValue(makeState({ bestDeadwood: -1, knockThreshold: 5 }));
+    renderWithProviders(<TonkPage />);
+
+    await waitFor(() => expect(mockExec).toHaveBeenCalled());
+    expect(screen.queryByTestId('tonk-deadwood')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/TonkPage.tsx
+++ b/frontend/src/pages/TonkPage.tsx
@@ -423,6 +423,26 @@ function TonkPageContent() {
                   >
                     {t('discardButton')}
                   </button>
+                  {/* **CUI は毎ターン「ノック可能/不可」を出しているのに、Web は
+                      プレイヤーの手計算に任せていた。**ノックボタンは1枚選択されて
+                      いれば常に活性化するので、押すまで合法か分からなかった。
+                      -1 は「まだ聞くべき場面でない」印なので出さない。 */}
+                  {state.bestDeadwood >= 0 && (
+                    <span
+                      className={`self-center text-xs ${
+                        state.bestDeadwood <= state.knockThreshold ? 'text-ds-success' : 'text-ds-text-muted'
+                      }`}
+                      role="status"
+                      aria-live="polite"
+                      data-testid="tonk-deadwood"
+                      data-knockable={state.bestDeadwood <= state.knockThreshold ? 'true' : undefined}
+                    >
+                      {t('deadwood.current', { value: state.bestDeadwood })}{' '}
+                      {state.bestDeadwood <= state.knockThreshold
+                        ? t('deadwood.knockable')
+                        : t('deadwood.notKnockable', { threshold: state.knockThreshold })}
+                    </span>
+                  )}
                   <button
                     type="button"
                     className={knockBtnClass}

--- a/frontend/src/types/games/tonk.ts
+++ b/frontend/src/types/games/tonk.ts
@@ -41,6 +41,15 @@ export interface TonkResponse extends BaseGameResponse {
   opponentDeadwood: Card[];
   isTonk: boolean;
   isUndercut: boolean;
+  /**
+   * 1枚捨てて到達できる最小デッドウッド。人間のディスカードフェーズ以外は -1。
+   *
+   * **-1 は「まだ聞くべき場面でない」印であって 0 ではない。**0 にすると
+   * 「デッドウッド0 = 必ずノック可能」と読めてしまう。
+   */
+  bestDeadwood: number;
+  /** ノックできるデッドウッド上限。`domain.TonkKnockThreshold` をサーバーが送る。 */
+  knockThreshold: number;
   config: TonkConfig;
 }
 

--- a/internal/adapter/controller/TonkWebController.go
+++ b/internal/adapter/controller/TonkWebController.go
@@ -53,6 +53,13 @@ type TonkWebOutput struct {
 	OpponentDeadwood []*WebOutputCard       `json:"opponentDeadwood"`
 	IsTonk           bool                   `json:"isTonk"`
 	IsUndercut       bool                   `json:"isUndercut"`
+	// BestDeadwood は1枚捨てて到達できる最小デッドウッド。CUI は毎ターン
+	// これを閾値と比べて「ノック可能/不可」を出しているのに、Web は同じ判断を
+	// プレイヤーの手計算に任せていた。人間のディスカードフェーズ以外は -1。
+	BestDeadwood int `json:"bestDeadwood"`
+	// KnockThreshold はノックできるデッドウッド上限 (domain.TonkKnockThreshold)。
+	// フロントに数値を写さず、判断の基準ごと送る。
+	KnockThreshold int `json:"knockThreshold"`
 	WebOutputBase
 	Config TonkWebOutputConfig `json:"config"`
 }

--- a/internal/adapter/presenter/TonkCuiPresenter.go
+++ b/internal/adapter/presenter/TonkCuiPresenter.go
@@ -12,30 +12,6 @@ import (
 
 // tonkBestDeadwood returns the lowest deadwood value the player can reach by
 // discarding one card — the value that gates knocking (<= TonkKnockThreshold).
-func tonkBestDeadwood(player *domain.TonkPlayer) int {
-	n := player.GetCardsSize()
-	cards := make([]*domain.Card, n)
-	for i := 0; i < n; i++ {
-		cards[i] = player.GetCard(i)
-	}
-	best := -1
-	for skip := 0; skip < n; skip++ {
-		sub := make([]*domain.Card, 0, n-1)
-		for i, c := range cards {
-			if i != skip {
-				sub = append(sub, c)
-			}
-		}
-		_, deadwood := domain.FindBestMelds(sub)
-		if v := domain.CalcDeadwoodValue(deadwood); best < 0 || v < best {
-			best = v
-		}
-	}
-	if best < 0 {
-		best = 0
-	}
-	return best
-}
 
 // tonkPlayerStr returns the display string for a single Tonk player.
 func tonkPlayerStr(player *domain.TonkPlayer, i int) string {
@@ -133,7 +109,7 @@ func (p *TonkCuiPresenter) Output(g interfaces.TonkGame, lastErr error) string {
 			b.WriteString(i18n.Tf("tonk.promptDiscard",
 				"name", cuiPlayerName(g.GetPlayer(currentIdx), currentIdx)) + "\n")
 			if cur := g.GetPlayer(currentIdx); cur.GetIsHuman() {
-				best := tonkBestDeadwood(cur)
+				best, _ := g.GetBestDeadwood(currentIdx)
 				if best <= domain.TonkKnockThreshold {
 					b.WriteString(color.Yellow(i18n.Tf("tonk.currentDeadwood", "value", strconv.Itoa(best))) +
 						" " + color.Yellow(i18n.T("tonk.knockable")) + "\n")

--- a/internal/adapter/presenter/TonkCuiPresenter_test.go
+++ b/internal/adapter/presenter/TonkCuiPresenter_test.go
@@ -26,6 +26,9 @@ func setupTonkCuiMock() *interfaces.MockTonkGame {
 	m.On("GetIsTonk").Return(false)
 	m.On("GetKnockerMelds").Return(([][]*domain.Card)(nil)).Maybe()
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
+	// #4750: ディスカード表示が最小デッドウッドを引くようになった。
+	m.On("GetBestDeadwood", 0).Return(3, 0).Maybe()
+
 	return m
 }
 
@@ -134,11 +137,12 @@ func TestTonkCuiPresenter_Output(t *testing.T) {
 		m, players := setupTonkCuiMockWithPlayers()
 		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
 		m.On("GetPhase").Return(domain.TonkPhaseDiscard)
-		// A run plus a single low stray: discarding the stray leaves deadwood 0.
-		for _, v := range []int{1, 2, 3} {
-			players[0].AddCard(domain.NewCard(domain.CardDesignSpade, v, false))
-		}
-		players[0].AddCard(domain.NewCard(domain.CardDesignDiamond, 4, false))
+		// **計算はドメインの仕事になった (#4750)。**ここで確かめるのは
+		// 「閾値と比べて正しい文言を選ぶこと」だけ。値そのものの正しさは
+		// TestTonk_GetBestDeadwood が実際の手札で見ている。
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetBestDeadwood")
+		m.On("GetBestDeadwood", 0).Return(domain.TonkKnockThreshold, 0)
+		_ = players
 
 		result := p.Output(m, nil)
 		assert.Contains(t, result, "最小デッドウッド(1枚捨て後):")
@@ -149,11 +153,10 @@ func TestTonkCuiPresenter_Output(t *testing.T) {
 		m, players := setupTonkCuiMockWithPlayers()
 		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
 		m.On("GetPhase").Return(domain.TonkPhaseDiscard)
-		// Scattered high cards with no meld: deadwood stays above the threshold.
-		players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 13, false))
-		players[0].AddCard(domain.NewCard(domain.CardDesignHeart, 11, false))
-		players[0].AddCard(domain.NewCard(domain.CardDesignClover, 9, false))
-		players[0].AddCard(domain.NewCard(domain.CardDesignDiamond, 7, false))
+		// 閾値のすぐ上。境界 (== 閾値) は上の subtest が押さえている。
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetBestDeadwood")
+		m.On("GetBestDeadwood", 0).Return(domain.TonkKnockThreshold+1, 0)
+		_ = players
 
 		result := p.Output(m, nil)
 		assert.Contains(t, result, "最小デッドウッド(1枚捨て後):")

--- a/internal/adapter/presenter/TonkWebPresenter.go
+++ b/internal/adapter/presenter/TonkWebPresenter.go
@@ -13,6 +13,15 @@ type TonkWebPresenter struct{}
 func (p *TonkWebPresenter) Output(g interfaces.TonkGame, lastErr error) string {
 	resObj := new(controller.TonkWebOutput)
 	resObj.Phase = int(g.GetPhase())
+
+	// **CUI は毎ターン「ノック可能/不可」を出しているのに、Web は手計算だった。**
+	// 判断の基準ごと送るので、フロントは閾値の数値を写さずに済む。
+	resObj.KnockThreshold = domain.TonkKnockThreshold
+	resObj.BestDeadwood = -1
+	if g.GetPhase() == domain.TonkPhaseDiscard && g.IsHumanTurn() {
+		best, _ := g.GetBestDeadwood(g.GetCurrentPlayerIdx())
+		resObj.BestDeadwood = best
+	}
 	resObj.RoundNumber = g.GetRoundNumber()
 	resObj.CurrentPlayerIdx = g.GetCurrentPlayerIdx()
 	resObj.DrawPileCount = g.GetDrawPileCount()

--- a/internal/adapter/presenter/TonkWebPresenter_test.go
+++ b/internal/adapter/presenter/TonkWebPresenter_test.go
@@ -33,6 +33,10 @@ func setupTonkWebMock() *interfaces.MockTonkGame {
 	m.On("GetOpponentDeadwood").Return(([]*domain.Card)(nil))
 	m.On("GetIsTonk").Return(false)
 	m.On("GetIsUndercut").Return(false)
+	// #4750: ディスカードフェーズで最小デッドウッドを引く。
+	m.On("IsHumanTurn").Return(false).Maybe()
+	m.On("GetBestDeadwood", 0).Return(3, 0).Maybe()
+
 	return m
 }
 
@@ -199,6 +203,52 @@ func TestTonkWebPresenter_Output(t *testing.T) {
 		var resObj controller.TonkWebOutput
 		_ = json.Unmarshal([]byte(result), &resObj)
 		assert.Equal(t, "tonk.roundEnd", resObj.MessageCode)
+	})
+}
+
+// **CUI は毎ターン「ノック可能/不可」を出しているのに、Web はプレイヤーの
+// 手計算に任せていた (#4750)。**判断の基準 (閾値) ごと送るので、フロントは
+// 数値を写さずに済む。
+func TestTonkWebPresenter_BestDeadwood(t *testing.T) {
+	p := new(presenter.TonkWebPresenter)
+
+	decode := func(t *testing.T, m *interfaces.MockTonkGame) controller.TonkWebOutput {
+		t.Helper()
+		var out controller.TonkWebOutput
+		assert.NoError(t, json.Unmarshal([]byte(p.Output(m, nil)), &out))
+		return out
+	}
+
+	t.Run("human discard turn carries the domain's answer and the threshold", func(t *testing.T) {
+		m, _ := setupTonkWebMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "IsHumanTurn")
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetBestDeadwood")
+		m.On("GetPhase").Return(domain.TonkPhaseDiscard)
+		m.On("IsHumanTurn").Return(true)
+		m.On("GetBestDeadwood", 0).Return(4, 1)
+
+		out := decode(t, m)
+		assert.Equal(t, 4, out.BestDeadwood)
+		assert.Equal(t, domain.TonkKnockThreshold, out.KnockThreshold)
+	})
+
+	// **-1 は「まだ聞くべき場面でない」印。**0 にすると「デッドウッド0 =
+	// 必ずノック可能」と読めてしまい、ドローフェーズで誤った案内が出る。
+	t.Run("outside the human discard turn it is -1, not 0", func(t *testing.T) {
+		m, _ := setupTonkWebMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "IsHumanTurn")
+		m.On("IsHumanTurn").Return(true) // フェーズは Draw のまま
+
+		assert.Equal(t, -1, decode(t, m).BestDeadwood)
+	})
+
+	t.Run("cpu discard turn is -1 too", func(t *testing.T) {
+		m, _ := setupTonkWebMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
+		m.On("GetPhase").Return(domain.TonkPhaseDiscard) // IsHumanTurn は既定 false
+
+		assert.Equal(t, -1, decode(t, m).BestDeadwood)
 	})
 }
 

--- a/internal/domain/Tonk.go
+++ b/internal/domain/Tonk.go
@@ -411,23 +411,9 @@ func (g *Tonk) cpuDraw() {
 func (g *Tonk) cpuDiscardOrKnock() {
 	player := g.players[g.currentPlayerIdx]
 
-	bestDiscardIdx := 0
-	bestDeadwood := -1
-
-	for i := 0; i < player.GetCardsSize(); i++ {
-		testCards := make([]*Card, 0, player.GetCardsSize()-1)
-		for j := 0; j < player.GetCardsSize(); j++ {
-			if j != i {
-				testCards = append(testCards, player.GetCard(j))
-			}
-		}
-		_, dw := FindBestMelds(testCards)
-		dwVal := CalcDeadwoodValue(dw)
-
-		if bestDeadwood < 0 || dwVal < bestDeadwood {
-			bestDeadwood = dwVal
-			bestDiscardIdx = i
-		}
+	bestDeadwood, bestDiscardIdx := g.GetBestDeadwood(g.currentPlayerIdx)
+	if bestDiscardIdx < 0 {
+		bestDiscardIdx = 0
 	}
 
 	if bestDeadwood <= TonkKnockThreshold {
@@ -601,6 +587,38 @@ func (g *Tonk) checkGameEnd() {
 // --- State getters ---
 
 // GetPhase 現在のフェーズ取得
+// GetBestDeadwood は1枚捨てたときに到達できる最小デッドウッド値と、その捨て札の
+// 位置を返す。手札が空なら (0, -1)。
+//
+// **この計算は元々3箇所に散る寸前だった。**CPU の判断 (cpuDiscardOrKnock) と
+// CUI の表示 (tonkBestDeadwood) が別々に同じループを持っており、Web にも
+// 3つ目を書くところだった。TonkKnockThreshold と比べる値なので、実装が割れると
+// 「ノック可能と表示したのに弾かれる」ずれになる。
+func (g *Tonk) GetBestDeadwood(playerIdx int) (best int, discardIdx int) {
+	if playerIdx < 0 || playerIdx >= len(g.players) {
+		return 0, -1
+	}
+	player := g.players[playerIdx]
+	n := player.GetCardsSize()
+	best, discardIdx = -1, -1
+	for i := 0; i < n; i++ {
+		sub := make([]*Card, 0, n-1)
+		for j := 0; j < n; j++ {
+			if j != i {
+				sub = append(sub, player.GetCard(j))
+			}
+		}
+		_, dw := FindBestMelds(sub)
+		if v := CalcDeadwoodValue(dw); best < 0 || v < best {
+			best, discardIdx = v, i
+		}
+	}
+	if best < 0 {
+		return 0, -1
+	}
+	return best, discardIdx
+}
+
 func (g *Tonk) GetPhase() TonkPhase { return g.phase }
 
 // SetPhase フェーズ設定 (テスト用)

--- a/internal/domain/Tonk_test.go
+++ b/internal/domain/Tonk_test.go
@@ -809,3 +809,71 @@ func TestTonk_Setters(t *testing.T) {
 	g.SetKnockerIdx(0)
 	assert.Equal(t, 0, g.GetKnockerIdx())
 }
+
+// **計算を1箇所に寄せた (#4750)。**CPU の判断 (cpuDiscardOrKnock) と CUI の表示
+// (tonkBestDeadwood) が別々に同じループを持っており、Web にも3つ目を書く寸前だった。
+// TonkKnockThreshold と比べる値なので、実装が割れると「ノック可能と表示したのに
+// 弾かれる」ずれになる。
+func TestTonk_GetBestDeadwood(t *testing.T) {
+	newGame := func(t *testing.T, cards []*domain.Card) *domain.Tonk {
+		t.Helper()
+		g := domain.NewDefaultTonk()
+		g.Reset()
+		p := g.GetPlayer(0)
+		for p.GetCardsSize() > 0 {
+			p.RemoveCard(0)
+		}
+		for _, c := range cards {
+			p.AddCard(c)
+		}
+		return g
+	}
+
+	t.Run("a run plus one stray discards the stray for zero deadwood", func(t *testing.T) {
+		g := newGame(t, []*domain.Card{
+			domain.NewCard(domain.CardDesignSpade, 1, false),
+			domain.NewCard(domain.CardDesignSpade, 2, false),
+			domain.NewCard(domain.CardDesignSpade, 3, false),
+			domain.NewCard(domain.CardDesignDiamond, 4, false),
+		})
+		best, idx := g.GetBestDeadwood(0)
+		if best != 0 {
+			t.Errorf("best = %d, want 0 (ランを残して端を捨てる)", best)
+		}
+		if idx != 3 {
+			t.Errorf("discardIdx = %d, want 3 (捨てるべきは孤立札)", idx)
+		}
+		if best > domain.TonkKnockThreshold {
+			t.Errorf("この手はノック可能のはず")
+		}
+	})
+
+	t.Run("scattered high cards stay above the knock threshold", func(t *testing.T) {
+		g := newGame(t, []*domain.Card{
+			domain.NewCard(domain.CardDesignSpade, 13, false),
+			domain.NewCard(domain.CardDesignHeart, 11, false),
+			domain.NewCard(domain.CardDesignClover, 9, false),
+			domain.NewCard(domain.CardDesignDiamond, 7, false),
+		})
+		best, _ := g.GetBestDeadwood(0)
+		if best <= domain.TonkKnockThreshold {
+			t.Errorf("best = %d: 役なしの高札なので閾値 %d を超えるはず",
+				best, domain.TonkKnockThreshold)
+		}
+	})
+
+	t.Run("an empty hand is zero, not negative", func(t *testing.T) {
+		g := newGame(t, nil)
+		best, idx := g.GetBestDeadwood(0)
+		if best != 0 || idx != -1 {
+			t.Errorf("GetBestDeadwood = (%d, %d), want (0, -1)", best, idx)
+		}
+	})
+
+	t.Run("an out-of-range player does not panic", func(t *testing.T) {
+		g := newGame(t, nil)
+		if best, idx := g.GetBestDeadwood(99); best != 0 || idx != -1 {
+			t.Errorf("GetBestDeadwood(99) = (%d, %d), want (0, -1)", best, idx)
+		}
+	})
+}

--- a/internal/domain/interfaces/tonk.go
+++ b/internal/domain/interfaces/tonk.go
@@ -33,6 +33,8 @@ type TonkGame interface {
 	GetPhase() domain.TonkPhase
 	// IsHumanTurn 現在の手番が人間かを返す
 	IsHumanTurn() bool
+	// GetBestDeadwood 1枚捨てて到達できる最小デッドウッドとその捨て札位置
+	GetBestDeadwood(playerIdx int) (int, int)
 	// GetRoundNumber 現在のラウンド番号を取得する
 	GetRoundNumber() int
 	// GetCurrentPlayerIdx 現在のプレイヤーインデックスを取得する

--- a/internal/domain/interfaces/tonk_mock.go
+++ b/internal/domain/interfaces/tonk_mock.go
@@ -41,6 +41,13 @@ func (m *MockTonkGame) GetPlayerCnt() int     { return m.Called().Int(0) }
 func (m *MockTonkGame) GetPlayer(i int) *domain.TonkPlayer {
 	return m.Called(i).Get(0).(*domain.TonkPlayer)
 }
+
+// GetBestDeadwood は1枚捨てて到達できる最小デッドウッドを返すモック。
+func (m *MockTonkGame) GetBestDeadwood(playerIdx int) (int, int) {
+	ret := m.Called(playerIdx)
+	return ret.Int(0), ret.Int(1)
+}
+
 func (m *MockTonkGame) GetActionLog() []*domain.ActionLogEntry {
 	return m.Called().Get(0).([]*domain.ActionLogEntry)
 }


### PR DESCRIPTION
## 背景

`TonkCuiPresenter` は毎ターン「1枚捨てて到達できる最小デッドウッド」を `TonkKnockThreshold` と比べ、**「ノック可能／不可」を色付きで表示**しています。ところが `TonkPage.tsx` にはこの計算も表示も一切ありませんでした (#4750)。

ノックボタンは「1枚選択されていれば」常に活性化するため、**実際に押すまで合法かどうか分かりません**でした。

## 同じ計算が既に2箇所にありました

issue は「フロントに移植するか、レスポンスに追加する」を提案していますが、調べると**移植は3つ目の実装になる**ところでした:

| 場所 | 用途 |
|---|---|
| `Tonk.cpuDiscardOrKnock`（ドメイン） | CPU がノックするか判断 |
| `tonkBestDeadwood`（CUI presenter） | 「ノック可能/不可」の表示 |
| ← ここにフロント実装を足す予定だった | |

`TonkKnockThreshold` と比べる値なので、実装が割れると**「ノック可能と表示したのに弾かれる」**ずれになります。

`Tonk.GetBestDeadwood(playerIdx) (best, discardIdx)` に一本化し、**CPU・CUI・Web の3者が同じ答えを読む**形にしました。閾値もレスポンスで送るので、フロントは数値を写しません。

## `-1` は「まだ聞くべき場面でない」印

人間のディスカードフェーズ以外は `-1` を返します。`0` にすると「デッドウッド0 = 必ずノック可能」と読めてしまい、ドローフェーズで誤った案内が出ます。

## テスト

**domain** (`TestTonk_GetBestDeadwood`): 実際の手札で計算を検証 — ラン+孤立札→0（捨てるのは孤立札）、役なし高札→閾値超え、空の手札→`(0, -1)`、範囲外→panic しない

**CUI presenter**: 計算がドメインに移ったので、**閾値と比べて正しい文言を選ぶこと**だけを見る形に変更。境界（== 閾値）と閾値+1 を踏みます

**web presenter**: 人間のディスカード手番で値と閾値が載ること／それ以外は `-1`（フェーズ違い・CPU手番の両方）

**page**: 3 → `data-knockable="true"`、9 → 付かない、-1 → バッジ自体が出ない

**負のコントロール**: `-1` ガードを外すと1件が落ち、戻すと 11 passed。

### 既存テストを1つ作り直しました

CUI のテストは実際の手札を組んで「ノック不可」を期待していましたが、計算がドメイン側に移った結果、**モックが手札を無視して固定値を返すようになり、テストがバグの経路を迂回**していました。値の正しさはドメインテストが実際の手札で見る、という分担に直しています。

## 検証

- `go test -tags test ./internal/...` ✅ / `golangci-lint` → `0 issues.` ✅ / `gofmt -l internal/` 空 ✅
- `bun run check` ✅ / `bun run typecheck` ✅ / `TonkPage` 11 passed ✅

Closes #4750