### PR TITLE
feat: highlight the suggested trump button in Two Ten Jack

### DIFF
--- a/frontend/src/pages/TwoTenJackPage.test.tsx
+++ b/frontend/src/pages/TwoTenJackPage.test.tsx
@@ -414,4 +414,29 @@ describe('TwoTenJackPage', () => {
       Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: originalWidth });
     }
   });
+
+  // **同じページ内で非対称だった (#4741)。**プレイフェーズはヒント札を
+  // 光らせているのに、宣言フェーズはテキストで「♠」と言うだけで、4つの
+  // 宣言ボタンのどれが推奨か視覚的に分からなかった。
+  it('highlights the suggested trump button during the declare phase', async () => {
+    mockExec.mockResolvedValue(declarePhaseState);
+    renderWithProviders(<TwoTenJackPage />);
+    await waitFor(() => expect(screen.getByLabelText('スペード')).toBeInTheDocument());
+
+    // ヒントを要求すると、推奨スートのボタンだけが強調される。
+    mockExec.mockResolvedValue({ ...declarePhaseState, hint: { reason: 'declare', trumpSuit: 3 } });
+    fireEvent.click(screen.getByRole('button', { name: 'ヒント' }));
+
+    await waitFor(() => expect(document.querySelectorAll('[data-hint-suggested="true"]')).toHaveLength(1));
+    expect(screen.getByLabelText('ハート')).toHaveAttribute('data-hint-suggested', 'true');
+  });
+
+  // 逆側。ヒントを要求していなければ、どのボタンも強調しない。
+  it('highlights no trump button before a hint is requested', async () => {
+    mockExec.mockResolvedValue(declarePhaseState);
+    renderWithProviders(<TwoTenJackPage />);
+    await waitFor(() => expect(screen.getByLabelText('スペード')).toBeInTheDocument());
+
+    expect(document.querySelectorAll('[data-hint-suggested="true"]')).toHaveLength(0);
+  });
 });

--- a/frontend/src/pages/TwoTenJackPage.tsx
+++ b/frontend/src/pages/TwoTenJackPage.tsx
@@ -449,8 +449,12 @@ function TwoTenJackPageContent() {
                   <button
                     key={suit.key}
                     type="button"
-                    className={btnPrimary}
+                    // **プレイフェーズは既にヒント札を光らせているのに、宣言
+                    // フェーズはテキストで「♠」と言うだけだった。**同じページ内で
+                    // 非対称なので、推奨スートのボタンにも同じ強調を付ける。
+                    className={hint?.trumpSuit === suit.value ? `${btnPrimary} ring-2 ring-ds-warning` : btnPrimary}
                     aria-label={t(`suit.${suit.key}`)}
+                    data-hint-suggested={hint?.trumpSuit === suit.value ? 'true' : undefined}
                     onClick={() => handleDeclare(suit.value)}
                     disabled={loading}
                   >


### PR DESCRIPTION
## 背景

`TwoTenJackPage.tsx` は**同じページ内で非対称**でした。

- **プレイフェーズ**: `PlayerHandSection` に `highlightIndices={... [hint.cardIndex]}` を渡し、ヒントの推奨カードを実際にハイライト済み
- **宣言フェーズ**: `t('hintDeclare')` で「♠」とテキスト表示するだけ。4つの宣言ボタンのどれが推奨かは視覚的に分からない

## 変更

推奨スートのボタンに、カード側と統一感のある強調（`ring-2 ring-ds-warning`）を付けました。

ヒント元は**プレイフェーズと同じフックの `hint`** です。別経路にすると片方だけ古い値を見る余地が生まれます。

## テスト

- 宣言フェーズでヒントを要求すると、推奨スート（ハート）のボタン**だけ**が `data-hint-suggested="true"` になること（`toHaveLength(1)` で他が光っていないことも同時に確認）
- ヒントを要求する前はどのボタンも強調しないこと

**負のコントロール**: ハイライトを外すと1件が落ち、戻すと 34 passed。

## 検証

- `bun run check` ✅ / `bun run typecheck` ✅ / `TwoTenJackPage` 34 passed ✅

Closes #4741