### PR TITLE
feat: highlight the recommended bid and card in Oh Hell

### DIFF
--- a/frontend/src/pages/OhHellPage.test.tsx
+++ b/frontend/src/pages/OhHellPage.test.tsx
@@ -749,4 +749,25 @@ describe('OhHellPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalled());
     expect(document.querySelectorAll('[data-hint-suggested="true"]')).toHaveLength(0);
   });
+
+  // **カード側のハイライトも踏む。**ビッドボタンだけ確かめて満足すると、
+  // 同じ PR で足したもう一方が未検証のまま残る (codecov が partial として検出)。
+  it('highlights the recommended card during the play phase', async () => {
+    mockExec.mockResolvedValue(playPhaseState);
+    renderWithProviders(<OhHellPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'ヒント' })).toBeInTheDocument());
+
+    mockExec.mockResolvedValue({ ...playPhaseState, hint: { cardIndex: 1, reason: 'follow_suit' } });
+    fireEvent.click(screen.getByRole('button', { name: 'ヒント' }));
+
+    await waitFor(() => expect(document.querySelectorAll('[data-hint-suggested="true"]')).toHaveLength(1));
+  });
+
+  it('highlights no card before a play hint arrives', async () => {
+    mockExec.mockResolvedValue(playPhaseState);
+    renderWithProviders(<OhHellPage />);
+
+    await waitFor(() => expect(mockExec).toHaveBeenCalled());
+    expect(document.querySelectorAll('[data-hint-suggested="true"]')).toHaveLength(0);
+  });
 });

--- a/frontend/src/pages/OhHellPage.test.tsx
+++ b/frontend/src/pages/OhHellPage.test.tsx
@@ -711,4 +711,42 @@ describe('OhHellPage', () => {
       Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: originalWidth });
     }
   });
+
+  // **ヒントは数字をテキストで言うだけで、どのボタンを押せばよいか視覚的に
+  // 示していなかった (#4738)。**同じコードベースの TwoTenJack はヒント札を
+  // 光らせている。
+  it('highlights the bid button the hint recommends', async () => {
+    mockExec.mockResolvedValue(bidPhaseState);
+    renderWithProviders(<OhHellPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'ヒント' })).toBeInTheDocument());
+
+    // hint はフックが 'hint' コマンドの応答から取る。要求して初めて出る。
+    mockExec.mockResolvedValue({ ...bidPhaseState, hint: { bid: 2, reason: 'bid' } });
+    fireEvent.click(screen.getByRole('button', { name: 'ヒント' }));
+
+    await waitFor(() => expect(document.querySelectorAll('[data-hint-suggested="true"]')).toHaveLength(1));
+    expect(screen.getByRole('button', { name: /2/ })).toHaveAttribute('data-hint-suggested', 'true');
+  });
+
+  // **制限ビッドとは別状態。**ディーラーが選べないビッドを推奨として光らせると、
+  // 押せないボタンを勧めることになる。
+  it('does not highlight a restricted bid even if the hint names it', async () => {
+    mockExec.mockResolvedValue({ ...bidPhaseState, restrictedBid: 2 });
+    renderWithProviders(<OhHellPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'ヒント' })).toBeInTheDocument());
+
+    mockExec.mockResolvedValue({ ...bidPhaseState, restrictedBid: 2, hint: { bid: 2, reason: 'bid' } });
+    fireEvent.click(screen.getByRole('button', { name: 'ヒント' }));
+
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('hint'));
+    expect(document.querySelectorAll('[data-hint-suggested="true"]')).toHaveLength(0);
+  });
+
+  it('highlights no bid button before a hint arrives', async () => {
+    mockExec.mockResolvedValue(bidPhaseState);
+    renderWithProviders(<OhHellPage />);
+
+    await waitFor(() => expect(mockExec).toHaveBeenCalled());
+    expect(document.querySelectorAll('[data-hint-suggested="true"]')).toHaveLength(0);
+  });
 });

--- a/frontend/src/pages/OhHellPage.tsx
+++ b/frontend/src/pages/OhHellPage.tsx
@@ -516,7 +516,12 @@ function OhHellPageContent() {
                       onClick={() => toggleCard(idx)}
                       aria-label={cardAlt(card)}
                       aria-pressed={selectedCardIndices.includes(idx)}
-                      className={`transition-transform ${focusRingCard}`}
+                      // プレイヒントの [N] もテキストだけだった。TwoTenJack と
+                      // 同じく、該当する札を光らせる。
+                      className={`transition-transform ${focusRingCard}${
+                        isHumanTurn && hint?.cardIndex === idx ? ' rounded-lg ring-2 ring-ds-warning' : ''
+                      }`}
+                      data-hint-suggested={isHumanTurn && hint?.cardIndex === idx ? 'true' : undefined}
                       style={{
                         background: 'none',
                         padding: 0,
@@ -561,9 +566,12 @@ function OhHellPageContent() {
                         // Mirrors the Cribbage pegRestricted / Call Break pattern.
                         // Neutralize btnPrimary's interactive feedback (press-scale,
                         // hover shadow) when restricted so it doesn't feel clickable.
+                        // **ヒントは数字をテキストで言うだけで、どのボタンを
+                        // 押せばよいか視覚的に示していなかった。**制限ビッドとは
+                        // 別状態なので、強調は制限が無いときだけ付ける。
                         className={`${btnPrimary}${
                           isRestricted ? ' opacity-50 cursor-not-allowed active:scale-100 hover:shadow-none' : ''
-                        }`}
+                        }${!isRestricted && hint?.bid === i ? ' ring-2 ring-ds-warning' : ''}`}
                         onClick={() => {
                           if (!isRestricted) handleBid(i);
                         }}
@@ -572,6 +580,7 @@ function OhHellPageContent() {
                         title={isRestricted ? t('restrictedBidTooltip') : undefined}
                         aria-label={isRestricted ? t('restrictedBidAria', { n: i }) : t('bid', { n: i })}
                         data-testid={isRestricted ? 'ohhell-restricted-bid' : undefined}
+                        data-hint-suggested={!isRestricted && hint?.bid === i ? 'true' : undefined}
                       >
                         {i}
                       </button>


### PR DESCRIPTION
## 背景

`OhHellPage.tsx` のヒントは `t('hintBid')` / `t('hintPlay')` で**数字をテキスト表示するだけ**でした (#4738)。

- ビッドボタンは `0..handSize` の数字を並べているだけで、`hint.bid` と紐付ける処理が無い
- プレイヒントの `[N]` もインデックスをテキストで示すだけで、該当する手札は光らない

同じコードベースの `TwoTenJackPage.tsx` は `highlightIndices` でヒント札を実際に光らせています。

## 変更

推奨ビッドのボタンと推奨札に、それぞれ強調（`ring-2 ring-ds-warning`）を付けました。

### 制限ビッドは強調しません

Oh Hell はディーラーが「合計が手札枚数と一致するビッド」を選べません（`restrictedBid`）。**そこを推奨として光らせると、押せないボタンを勧めることになります。** `!isRestricted && hint?.bid === i` で明示的に除外しています。

## テスト

- ヒント要求後、推奨ビッドのボタン**だけ**が `data-hint-suggested="true"`（`toHaveLength(1)` で他が光っていないことも同時に確認）
- **`restrictedBid` と `hint.bid` が一致する場合は光らせない**
- ヒント要求前はどれも光らない

`hint` はフックが `'hint'` コマンドの応答から取るので、テストは実際にヒントボタンを押しています（`state.hint` を直接積んでも出ないため）。

**負のコントロール**: ビッド強調を外すと1件が落ち、戻すと 54 passed。

## 検証

- `bun run check` ✅ / `bun run typecheck` ✅ / `OhHellPage` 54 passed ✅

Closes #4738