### PR TITLE
feat: add a one-tap apply button to the Ninety-Nine play hint

### DIFF
--- a/frontend/src/pages/NinetyNinePage.test.tsx
+++ b/frontend/src/pages/NinetyNinePage.test.tsx
@@ -378,6 +378,27 @@ describe('NinetyNinePage', () => {
     expect(screen.getByTestId('nn-server-hint')).toHaveTextContent('推奨カード: [1] (リードスートに追随)');
   });
 
+  // **埋めヒントには「適用」があるのに、プレイヒントは数字を出すだけだった
+  // (#4739)。**プレイヤーは [N] を見て手札から目視で探す必要があり、同じヒント
+  // なのに体験が非対称だった。
+  it('play-phase hint Apply selects the recommended card', async () => {
+    renderWithProviders(<NinetyNinePage />);
+    await waitFor(() => expect(screen.getByTestId('nn-hint-button')).toBeInTheDocument());
+
+    mockExec.mockResolvedValueOnce({ ...playPhaseState, hint: { cardIndex: 1, reason: 'follow_suit' } });
+    fireEvent.click(screen.getByTestId('nn-hint-button'));
+    await waitFor(() => expect(screen.getByTestId('nn-hint-apply-play')).toBeInTheDocument());
+
+    // 適用前は何も選択されていない = 出すボタンは押せない。
+    const play = screen.getByRole('button', { name: 'カードを出す' });
+    expect(play).toBeDisabled();
+
+    fireEvent.click(screen.getByTestId('nn-hint-apply-play'));
+
+    // 適用すると推奨カードが選択され、そのまま出せる状態になる。
+    expect(play).not.toBeDisabled();
+  });
+
   it('bid-phase hint shows the bury recommendation and Apply selects those three cards', async () => {
     mockExec.mockResolvedValue(bidPhaseState);
     renderWithProviders(<NinetyNinePage />);

--- a/frontend/src/pages/NinetyNinePage.tsx
+++ b/frontend/src/pages/NinetyNinePage.tsx
@@ -188,6 +188,13 @@ function NinetyNinePageContent() {
     if (serverHint?.buryIndices) setSelected([...serverHint.buryIndices]);
   }, [serverHint, setSelected]);
 
+  // **埋めヒントには「適用」があるのに、プレイヒントは数字を出すだけだった。**
+  // プレイヤーは表示された [N] を見て手札から目視で探す必要があり、同じヒント
+  // なのに体験が非対称だった。埋めと同じく、選択に一発で反映する。
+  const handleApplyPlay = useCallback(() => {
+    if (serverHint?.cardIndex != null) setSelected([serverHint.cardIndex]);
+  }, [serverHint, setSelected]);
+
   const handleNextTrick = useCallback(() => void exec('next'), [exec]);
   const handleNextRound = useCallback(() => void exec('nextround'), [exec]);
   const handleManualReset = useCallback(() => {
@@ -473,9 +480,19 @@ function NinetyNinePageContent() {
                     </button>
                   </div>
                 ) : serverHint.cardIndex != null ? (
-                  <span>
-                    {t('hintPlay')}: [{serverHint.cardIndex}] ({t(`hintReason.${serverHint.reason}`)})
-                  </span>
+                  <div className="flex items-center gap-2">
+                    <span>
+                      {t('hintPlay')}: [{serverHint.cardIndex}] ({t(`hintReason.${serverHint.reason}`)})
+                    </span>
+                    <button
+                      type="button"
+                      className={btnSuccess}
+                      onClick={handleApplyPlay}
+                      data-testid="nn-hint-apply-play"
+                    >
+                      {t('hintApply')}
+                    </button>
+                  </div>
                 ) : null}
               </div>
             )}


### PR DESCRIPTION
## 背景

`NinetyNinePage.tsx` には埋め（bury）ヒント専用の `handleApplyBury` があり、`data-testid="nn-hint-apply"` の「適用」ボタンで推奨3枚を一発で選択状態にできます。

ところが**同じ `serverHint` オブジェクトの `cardIndex`**（プレイフェーズの推奨カード）については `[N]` とテキスト表示するだけで、対応する適用ボタンがありませんでした (#4739)。プレイヤーは数字を見て手札から目視で該当カードを探す必要があり、**同じヒントなのに体験が非対称**でした。

## 変更

埋めと同じ形で `handleApplyPlay` を追加し、推奨カードを選択に反映します。適用後はそのまま「カードを出す」が押せる状態になります。

## テスト

- 適用前は選択が空なので「カードを出す」が **disabled**
- 適用すると推奨カードが選択され、**押せる状態になる**

「ボタンが存在する」ではなく**「押した結果プレイできる状態になる」**ところまで踏んでいます。選択状態に入るだけで出せなければ、プレイヤーから見て意味が無いためです。

**負のコントロール**: 適用処理を no-op にすると1件が落ち、戻すと 27 passed。

## 検証

- `bun run check` ✅ / `bun run typecheck` ✅ / `NinetyNinePage` 27 passed ✅

Closes #4739