### PR TITLE
feat: add a server-calculated hint to Crazy Eights

### DIFF
--- a/frontend/src/api/games/crazyeights.ts
+++ b/frontend/src/api/games/crazyeights.ts
@@ -13,7 +13,7 @@ export interface CrazyEightsConfigInput {
 /** API client for the Crazy Eights /crazyeights/exec endpoint. */
 export const crazyeightsApi = {
   exec: (
-    command: 'reset' | 'play' | 'draw' | 'suit' | 'nextround',
+    command: 'reset' | 'play' | 'draw' | 'suit' | 'nextround' | 'hint',
     cardIndex?: number,
     suit?: number,
     config?: CrazyEightsConfigInput,

--- a/frontend/src/hooks/useCrazyEightsGame.ts
+++ b/frontend/src/hooks/useCrazyEightsGame.ts
@@ -1,9 +1,10 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { crazyeightsApi } from '../api/gameApi';
-import type { CrazyEightsConfig } from '../types/card';
+import type { CrazyEightsConfig, CrazyEightsHint } from '../types/card';
 import { useCardSelection } from './useCardSelection';
 import { useGameApi } from './useGameApi';
 import { useGameConfig } from './useGameConfig';
+import { useHintRequest } from './useHintRequest';
 
 /** Default Crazy Eights game configuration. */
 export const DEFAULT_CRAZYEIGHTS_CONFIG: CrazyEightsConfig = {
@@ -33,6 +34,17 @@ export function useCrazyEightsGame() {
   const { state, loading, error, exec: rawExec, retry } = useGameApi(crazyeightsApi.exec, { onSuccess });
 
   const exec = useCallback((...args: Parameters<typeof rawExec>) => rawExec(...args), [rawExec]);
+
+  // **Hearts / Spades はサーバー計算の理由付きヒントを返すのに、CrazyEights は
+  // フロント完結の簡易ヒューリスティックしか無かった (#4737)。**
+  const [hint, setHint] = useState<CrazyEightsHint | null>(null);
+  const [hintError, setHintError] = useState<string | null>(null);
+  const handleHint = useHintRequest({
+    fetchHint: () => crazyeightsApi.exec('hint'),
+    selectHint: (res) => res.hint ?? null,
+    setHint,
+    setHintError,
+  });
 
   useEffect(() => {
     exec('reset', undefined, undefined, DEFAULT_CRAZYEIGHTS_CONFIG);
@@ -72,6 +84,9 @@ export function useCrazyEightsGame() {
     handleDraw,
     handleChooseSuit,
     handleNextRound,
+    hint,
+    hintError,
+    handleHint,
     retry,
   };
 }

--- a/frontend/src/i18n/locales/en/crazyeights.json
+++ b/frontend/src/i18n/locales/en/crazyeights.json
@@ -67,5 +67,14 @@
     "original": "Original",
     "rank": "Rank",
     "suit": "Suit"
+  },
+  "hintCard": "Suggested: card [{{idx}}]",
+  "hintSuit": "Suggested suit: {{suit}}",
+  "hintReason": {
+    "match_suit": "matches the suit",
+    "match_rank": "matches the rank",
+    "play_wild": "an 8 lets you change the suit",
+    "play_valid": "a legal play",
+    "choose_longest_suit": "your longest suit"
   }
 }

--- a/frontend/src/i18n/locales/ja/crazyeights.json
+++ b/frontend/src/i18n/locales/ja/crazyeights.json
@@ -67,5 +67,14 @@
     "original": "元の順",
     "rank": "ランク順",
     "suit": "スート順"
+  },
+  "hintCard": "おすすめ: [{{idx}}] のカード",
+  "hintSuit": "おすすめのスート: {{suit}}",
+  "hintReason": {
+    "match_suit": "スートが合う",
+    "match_rank": "数字が合う",
+    "play_wild": "8 でスートを変えられる",
+    "play_valid": "出せる札",
+    "choose_longest_suit": "手札に一番多いスート"
   }
 }

--- a/frontend/src/pages/CrazyEightsPage.test.tsx
+++ b/frontend/src/pages/CrazyEightsPage.test.tsx
@@ -850,4 +850,38 @@ describe('CrazyEightsPage', () => {
     await waitFor(() => expect(screen.getByText('スコア')).toBeInTheDocument());
     expect(screen.queryByTestId('ce-sort-original')).not.toBeInTheDocument();
   });
+
+  // **Hearts / Spades はサーバー計算の理由付きヒントを返すのに、CrazyEights には
+  // ヒントボタンすら無く、全ゲーム共通の簡易ヒューリスティックしか無かった (#4737)。**
+  it('fetches a server hint and shows the recommended card with its reason', async () => {
+    renderWithProviders(<CrazyEightsPage />);
+    await waitFor(() => expect(screen.getByTestId('ce-hint-button')).toBeInTheDocument());
+
+    mockExec.mockResolvedValueOnce({ ...playPhaseState, hint: { cardIndex: 1, reason: 'match_suit' } });
+    fireEvent.click(screen.getByTestId('ce-hint-button'));
+
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('hint'));
+    const shown = await screen.findByTestId('ce-server-hint');
+    expect(shown).toHaveTextContent('1');
+    expect(shown).toHaveTextContent('スートが合う');
+  });
+
+  it('shows the recommended suit during the choose-suit phase', async () => {
+    renderWithProviders(<CrazyEightsPage />);
+    await waitFor(() => expect(screen.getByTestId('ce-hint-button')).toBeInTheDocument());
+
+    mockExec.mockResolvedValueOnce({ ...playPhaseState, hint: { suit: 3, reason: 'choose_longest_suit' } });
+    fireEvent.click(screen.getByTestId('ce-hint-button'));
+
+    const shown = await screen.findByTestId('ce-server-hint');
+    expect(shown).toHaveTextContent('手札に一番多いスート');
+  });
+
+  // 要求する前は出さない。常時表示だとフロント完結のツールチップと二重になる。
+  it('shows no server hint before the button is pressed', async () => {
+    renderWithProviders(<CrazyEightsPage />);
+
+    await waitFor(() => expect(mockExec).toHaveBeenCalled());
+    expect(screen.queryByTestId('ce-server-hint')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/CrazyEightsPage.tsx
+++ b/frontend/src/pages/CrazyEightsPage.tsx
@@ -132,6 +132,9 @@ function CrazyEightsPageContent() {
     handleDraw,
     handleChooseSuit,
     handleNextRound,
+    hint: serverHint,
+    hintError,
+    handleHint,
   } = useCrazyEightsGame();
   const {
     hint: frontendHint,
@@ -448,8 +451,30 @@ function CrazyEightsPageContent() {
                   <button type="button" className={btnPrimary} onClick={handleDraw} disabled={loading}>
                     {t('drawButton')}
                   </button>
+                  {/* **Hearts / Spades はサーバー計算の理由付きヒントを返すのに、
+                      CrazyEights には無く、全ゲーム共通の簡易ヒューリスティック
+                      しか支援が無かった (#4737)。** */}
+                  <button
+                    type="button"
+                    className={btnSuccess}
+                    onClick={handleHint}
+                    disabled={loading}
+                    data-testid="ce-hint-button"
+                  >
+                    {tc('button.hint')}
+                  </button>
                 </div>
               )}
+              {serverHint && (
+                <p className="mt-2 text-sm text-ds-accent" data-testid="ce-server-hint">
+                  {serverHint.suit !== undefined
+                    ? t('hintSuit', { suit: SUIT_SYMBOLS[serverHint.suit] ?? '?' })
+                    : t('hintCard', { idx: serverHint.cardIndex })}{' '}
+                  ({t(`hintReason.${serverHint.reason}`)})
+                </p>
+              )}
+              <ErrorAlert message={hintError} onRetry={undefined} />
+
               {isChooseSuit && (
                 <div className="flex gap-1" data-tutorial="ce-suit-choice">
                   {SUIT_BUTTONS.map(({ suit, key }) => (

--- a/frontend/src/types/games/crazyeights.ts
+++ b/frontend/src/types/games/crazyeights.ts
@@ -20,7 +20,24 @@ export interface CrazyEightsConfig {
 }
 
 /** Full Crazy Eights game state returned from the API. */
+/** サーバー計算の推奨手。 */
+export interface CrazyEightsHint {
+  /** 推奨する手札の位置。スート選択フェーズでは undefined。 */
+  cardIndex?: number;
+  /** 8 を出した後に指名すべきスート。プレイフェーズでは undefined。 */
+  suit?: number;
+  /** 理由キー。 */
+  reason: string;
+}
+
 export interface CrazyEightsResponse extends BaseGameResponse {
+  /**
+   * サーバー計算の推奨手。`hint` コマンドの応答にのみ載る。
+   *
+   * Hearts / Spades と同じく、理由付きの具体的な推奨を返す。フロント完結の
+   * `FrontendHintTooltip` は全ゲーム共通の簡易ヒューリスティックで別物。
+   */
+  hint?: CrazyEightsHint;
   players: CrazyEightsPlayerData[];
   phase: number;
   roundNumber: number;

--- a/internal/adapter/controller/CrazyEightsCuiController.go
+++ b/internal/adapter/controller/CrazyEightsCuiController.go
@@ -43,7 +43,7 @@ func (c *CrazyEightsCuiController) Exec(command string) string {
 		[]string{
 			"p", "play", "d", "draw", "s", "suit",
 			"nr", "nextround",
-			"sd", "setdifficulty", "sl", "setlimit", "log", "l",
+			"sd", "setdifficulty", "sl", "setlimit", "h", "hint", "log", "l",
 		},
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
@@ -68,7 +68,7 @@ func (c *CrazyEightsCuiController) Exec(command string) string {
 					return c.ci.ResetWithConfig(cfg)
 				})
 			default:
-				return handleCuiLog(cmd, c.ci.ActionLog)
+				return handleCuiHintAndLog(cmd, c.ci.Hint, c.ci.ActionLog)
 			}
 		},
 	)

--- a/internal/adapter/controller/usecase/CrazyEightsInteractor_mock.go
+++ b/internal/adapter/controller/usecase/CrazyEightsInteractor_mock.go
@@ -45,6 +45,11 @@ func (_m *MockCrazyEightsInteractor) ActionLog() string {
 	return _m.Called().String(0)
 }
 
+// Hint モック
+func (_m *MockCrazyEightsInteractor) Hint() string {
+	return _m.Called().String(0)
+}
+
 // Snapshot モック
 func (_m *MockCrazyEightsInteractor) Snapshot() ([]byte, error) {
 	ret := _m.Called()

--- a/internal/adapter/presenter/CrazyEightsCuiPresenter.go
+++ b/internal/adapter/presenter/CrazyEightsCuiPresenter.go
@@ -137,3 +137,37 @@ func suitDisplayName(suit int) string {
 		return "?"
 	}
 }
+
+// HintOutput emits the current Crazy Eights hint.
+//
+// **Hearts / Spades はサーバー計算の理由付きヒントを返すのに、CrazyEights には
+// これが無く、全ゲーム共通の簡易ヒューリスティックしか支援が無かった (#4737)。**
+func (p *CrazyEightsCuiPresenter) HintOutput(g interfaces.CrazyEightsGame) string {
+	hint := g.GetHint()
+	if hint == nil {
+		return i18n.T("crazyeights.hintNone") + "\n"
+	}
+	reason := hintReasonStr(hint.Reason, crazyEightsHintReasonKeys)
+	if hint.Suit != nil {
+		return color.Yellow(i18n.Tf("crazyeights.hintSuit",
+			"suit", cuiSuitName(*hint.Suit),
+			"reason", reason)) + "\n"
+	}
+	if hint.CardIndex == nil {
+		return i18n.T("crazyeights.hintNone") + "\n"
+	}
+	card := g.GetPlayer(0).GetCard(*hint.CardIndex)
+	return color.Yellow(i18n.Tf("crazyeights.hintCard",
+		"idx", strconv.Itoa(*hint.CardIndex),
+		"card", cuiCardStr(card),
+		"reason", reason)) + "\n"
+}
+
+// crazyEightsHintReasonKeys maps hint-reason identifiers to their i18n keys.
+var crazyEightsHintReasonKeys = map[string]string{
+	"match_suit":          "crazyeights.hintReasonMatchSuit",
+	"match_rank":          "crazyeights.hintReasonMatchRank",
+	"play_wild":           "crazyeights.hintReasonPlayWild",
+	"play_valid":          "crazyeights.hintReasonPlayValid",
+	"choose_longest_suit": "crazyeights.hintReasonChooseLongestSuit",
+}

--- a/internal/adapter/presenter/CrazyEightsCuiPresenter_test.go
+++ b/internal/adapter/presenter/CrazyEightsCuiPresenter_test.go
@@ -334,6 +334,16 @@ func TestCrazyEightsCuiPresenter_HintOutput(t *testing.T) {
 		assert.Contains(t, out, "手札に一番多いスート")
 	})
 
+	// CardIndex も Suit も無いヒント (ありえないが防御的な分岐) でも、
+	// 黙らずに「ヒントなし」と言うこと。
+	t.Run("a hint with neither a card nor a suit falls back to none", func(t *testing.T) {
+		m, _ := setupCrazyEightsCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHint")
+		m.On("GetHint").Return(&domain.CrazyEightsHint{Reason: "play_valid"})
+
+		assert.Contains(t, p.HintOutput(m), "ヒントはありません")
+	})
+
 	// **ヒントが無い側も踏む。**nil を「空文字」で返すと、CUI に何も出ず
 	// プレイヤーはコマンドが効いたのか分からない。
 	t.Run("no hint says so explicitly", func(t *testing.T) {

--- a/internal/adapter/presenter/CrazyEightsCuiPresenter_test.go
+++ b/internal/adapter/presenter/CrazyEightsCuiPresenter_test.go
@@ -24,6 +24,9 @@ func setupCrazyEightsCuiMock() *interfaces.MockCrazyEightsGame {
 	m.On("GetCurrentPlayerIdx").Return(0)
 	m.On("GetWinnerIdx").Return(-1)
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
+	// #4737: サーバー計算のヒントを返すようになった。既定は「ヒント無し」。
+	m.On("GetHint").Return((*domain.CrazyEightsHint)(nil)).Maybe()
+
 	return m
 }
 
@@ -297,5 +300,44 @@ func TestCrazyEightsCuiPresenter_ActionLogOutput(t *testing.T) {
 		result := p.ActionLogOutput(m)
 		assert.Contains(t, result, "棋譜はありません")
 		m.AssertExpectations(t)
+	})
+}
+
+// **Hearts / Spades はサーバー計算の理由付きヒントを返すのに、CrazyEights には
+// HintOutput が無く、全ゲーム共通の簡易ヒューリスティックしか支援が無かった (#4737)。**
+func TestCrazyEightsCuiPresenter_HintOutput(t *testing.T) {
+	orig := color.NoColor()
+	color.SetNoColor(true)
+	defer color.SetNoColor(orig)
+	p := new(presenter.CrazyEightsCuiPresenter)
+
+	t.Run("card hint names the card and the reason", func(t *testing.T) {
+		m, players := setupCrazyEightsCuiMockWithPlayers()
+		players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 5, false))
+		idx := 0
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHint")
+		m.On("GetHint").Return(&domain.CrazyEightsHint{CardIndex: &idx, Reason: "match_suit"})
+
+		out := p.HintOutput(m)
+		assert.Contains(t, out, "SPADE 5")
+		assert.Contains(t, out, "スートが合う")
+	})
+
+	t.Run("suit hint names the suit", func(t *testing.T) {
+		m, _ := setupCrazyEightsCuiMockWithPlayers()
+		suit := domain.CardDesignHeart
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHint")
+		m.On("GetHint").Return(&domain.CrazyEightsHint{Suit: &suit, Reason: "choose_longest_suit"})
+
+		out := p.HintOutput(m)
+		assert.Contains(t, out, "HEART")
+		assert.Contains(t, out, "手札に一番多いスート")
+	})
+
+	// **ヒントが無い側も踏む。**nil を「空文字」で返すと、CUI に何も出ず
+	// プレイヤーはコマンドが効いたのか分からない。
+	t.Run("no hint says so explicitly", func(t *testing.T) {
+		m, _ := setupCrazyEightsCuiMockWithPlayers()
+		assert.Contains(t, p.HintOutput(m), "ヒントはありません")
 	})
 }

--- a/internal/adapter/presenter/CrazyEightsWebPresenter.go
+++ b/internal/adapter/presenter/CrazyEightsWebPresenter.go
@@ -81,3 +81,9 @@ func (p *CrazyEightsWebPresenter) buildMessage(g interfaces.CrazyEightsGame, las
 func (p *CrazyEightsWebPresenter) ActionLogOutput(g interfaces.CrazyEightsGame) string {
 	return actionLogOutputJSON(g)
 }
+
+// HintOutput はヒントを返す。Web ではクライアント側でも簡易ヒントを出すが、
+// これはサーバー計算の理由付きヒント (`command: "hint"` 専用のレスポンス)。
+func (p *CrazyEightsWebPresenter) HintOutput(g interfaces.CrazyEightsGame) string {
+	return p.Output(g, nil)
+}

--- a/internal/adapter/presenter/CrazyEightsWebPresenter_test.go
+++ b/internal/adapter/presenter/CrazyEightsWebPresenter_test.go
@@ -317,3 +317,13 @@ func TestCrazyEightsWebPresenter_ActionLogOutput(t *testing.T) {
 		m.AssertExpectations(t)
 	})
 }
+
+// **受動ヒントとは別に、`command: "hint"` 専用のレスポンスも返す (#4737)。**
+// Web はクライアント側でも簡易ヒントを出すが、これはサーバー計算のもの。
+func TestCrazyEightsWebPresenter_HintOutput(t *testing.T) {
+	m, _ := setupCrazyEightsWebMockWithPlayers()
+
+	out := new(presenter.CrazyEightsWebPresenter).HintOutput(m)
+	assert.True(t, json.Valid([]byte(out)), "JSON として妥当")
+	assert.Contains(t, out, `"players"`, "状態も一緒に返る")
+}

--- a/internal/domain/CrazyEights.go
+++ b/internal/domain/CrazyEights.go
@@ -307,6 +307,61 @@ func (g *CrazyEights) ScoreRound() {
 // --- State getters ---
 
 // GetPhase 現在のフェーズ取得
+// CrazyEightsHint はサーバーが計算した推奨手。
+type CrazyEightsHint struct {
+	// CardIndex は推奨する手札の位置。スート選択フェーズでは nil。
+	CardIndex *int
+	// Suit は 8 を出した後に指名すべきスート。プレイフェーズでは nil。
+	Suit *int
+	// Reason は理由キー (i18n で引く)。
+	Reason string
+}
+
+// GetHint は人間の手番での推奨手を返す。手番でない・出せる札が無いときは nil。
+//
+// **Hearts / Spades は HintOutput でサーバー計算の理由付きヒントを返すのに、
+// CrazyEights にはドメインの GetHint すら無く、全ゲーム共通の簡易ヒューリスティック
+// (FrontendHintTooltip) しか支援が無かった。**推奨手は CPU の最善手選択
+// (cpuPlayHard / cpuChooseSuit) をそのまま使う。別ロジックを書くと「CPU は選ばない
+// 手を人間に勧める」ことになる。
+func (g *CrazyEights) GetHint() *CrazyEightsHint {
+	if g.gameEndFlag || g.currentPlayerIdx != 0 || !g.players[0].GetIsHuman() {
+		return nil
+	}
+
+	if g.phase == CrazyEightsPhaseChooseSuit {
+		suit := g.cpuSelectSuit(0)
+		return &CrazyEightsHint{Suit: &suit, Reason: "choose_longest_suit"}
+	}
+
+	if g.phase != CrazyEightsPhasePlay {
+		return nil
+	}
+	valid := g.getValidPlayIndices(0)
+	if len(valid) == 0 {
+		// 出せる札が無い = 引くしかない。推奨する札が無いのでヒントを出さない。
+		return nil
+	}
+	idx := g.cpuPlayHard(0, valid)
+	return &CrazyEightsHint{CardIndex: &idx, Reason: g.playHintReason(idx)}
+}
+
+// playHintReason は推奨札を選んだ理由キーを返す。
+func (g *CrazyEights) playHintReason(idx int) string {
+	card := g.players[0].GetCard(idx)
+	if card == nil {
+		return "play_valid"
+	}
+	if card.GetValue() == CrazyEightsWildValue {
+		return "play_wild"
+	}
+	top := g.GetDiscardTop()
+	if top != nil && card.GetValue() == top.GetValue() {
+		return "match_rank"
+	}
+	return "match_suit"
+}
+
 func (g *CrazyEights) GetPhase() CrazyEightsPhase { return g.phase }
 
 // SetPhase フェーズ設定 (テスト用)

--- a/internal/domain/CrazyEights_test.go
+++ b/internal/domain/CrazyEights_test.go
@@ -1098,3 +1098,71 @@ func TestCrazyEights_CpuChooseSuitSmartAllEights(t *testing.T) {
 	// With no non-8 cards, all suit counts are 0, bestSuit defaults to Spade (1)
 	assert.Equal(t, domain.CardDesignSpade, g.GetChosenSuit())
 }
+
+// **Hearts / Spades はサーバー計算の理由付きヒントを返すのに、CrazyEights には
+// ドメインの GetHint すら無かった (#4737)。**推奨手は CPU の最善手選択をそのまま
+// 使う。別ロジックを書くと「CPU は選ばない手を人間に勧める」ことになる。
+func TestCrazyEights_GetHint(t *testing.T) {
+	setup := func(t *testing.T) *domain.CrazyEights {
+		t.Helper()
+		g := domain.NewDefaultCrazyEights()
+		g.Reset()
+		g.SetCurrentPlayerIdx(0)
+		return g
+	}
+
+	t.Run("recommends a card the rules actually allow", func(t *testing.T) {
+		g := setup(t)
+		hint := g.GetHint()
+		if hint == nil {
+			t.Fatal("配り直後の人間の手番ではヒントが出る")
+		}
+		if hint.CardIndex == nil {
+			t.Fatal("プレイフェーズでは CardIndex が入る")
+		}
+		// **勧めた札が本当に出せること。**別ロジックで選ぶと、出せない札を
+		// 勧めてしまう。ドメインの合法手判定で裏を取る。
+		// 本番の入口で裏を取る。合法手判定をテスト側に写すと、それがもう1つの
+		// 実装になってしまう。
+		if err := g.PlayerPlay(*hint.CardIndex); err != nil {
+			t.Errorf("推奨札 (index %d) が実際には出せなかった: %v", *hint.CardIndex, err)
+		}
+		if hint.Reason == "" {
+			t.Error("理由キーが空")
+		}
+	})
+
+	t.Run("recommends a suit during the choose-suit phase", func(t *testing.T) {
+		g := setup(t)
+		g.SetPhase(domain.CrazyEightsPhaseChooseSuit)
+
+		hint := g.GetHint()
+		if hint == nil || hint.Suit == nil {
+			t.Fatal("スート選択フェーズでは Suit が入る")
+		}
+		if hint.CardIndex != nil {
+			t.Error("スート選択フェーズで CardIndex は入らない")
+		}
+		if *hint.Suit < domain.CardDesignSpade || *hint.Suit > domain.CardDesignDiamond {
+			t.Errorf("Suit = %d はスートの範囲外", *hint.Suit)
+		}
+	})
+
+	// **CPU の手番では出さない。**相手の手札を見て助言することになる。
+	t.Run("no hint on a CPU turn", func(t *testing.T) {
+		g := setup(t)
+		g.SetCurrentPlayerIdx(1)
+		if g.GetHint() != nil {
+			t.Error("CPU の手番ではヒントを出さない")
+		}
+	})
+
+	// プレイでもスート選択でもないフェーズでは出さない。
+	t.Run("no hint outside the playable phases", func(t *testing.T) {
+		g := setup(t)
+		g.SetPhase(domain.CrazyEightsPhaseRoundEnd)
+		if g.GetHint() != nil {
+			t.Error("ラウンド終了フェーズではヒントを出さない")
+		}
+	})
+}

--- a/internal/domain/CrazyEights_test.go
+++ b/internal/domain/CrazyEights_test.go
@@ -1157,6 +1157,55 @@ func TestCrazyEights_GetHint(t *testing.T) {
 		}
 	})
 
+	// **理由キーの分岐を全部踏む。**8 と数字一致は別の助言なので、片方しか
+	// 出ないと「なぜその札か」が伝わらない。
+	t.Run("reasons distinguish a wild from a rank match", func(t *testing.T) {
+		g := setup(t)
+		human := g.GetPlayer(0)
+		for human.GetCardsSize() > 0 {
+			human.RemoveCard(0)
+		}
+		top := g.GetDiscardTop()
+		if top == nil {
+			t.Fatal("前提: 捨て札の一番上があること")
+		}
+		// 8 だけを持たせる → play_wild
+		human.AddCard(domain.NewCard(domain.CardDesignSpade, domain.CrazyEightsWildValue, false))
+		hint := g.GetHint()
+		if hint == nil || hint.Reason != "play_wild" {
+			t.Errorf("8 のみの手札では play_wild: %+v", hint)
+		}
+
+		// 捨て札と同じ数字 (スート違い) → match_rank
+		for human.GetCardsSize() > 0 {
+			human.RemoveCard(0)
+		}
+		other := domain.CardDesignSpade
+		if top.GetDesign() == domain.CardDesignSpade {
+			other = domain.CardDesignHeart
+		}
+		if top.GetValue() == domain.CrazyEightsWildValue {
+			t.Skip("捨て札が 8 の配りでは数字一致を作れない")
+		}
+		human.AddCard(domain.NewCard(other, top.GetValue(), false))
+		hint = g.GetHint()
+		if hint == nil || hint.Reason != "match_rank" {
+			t.Errorf("同じ数字の札では match_rank: %+v", hint)
+		}
+	})
+
+	// **出せる札が無ければヒントを出さない。**引くしかない局面で札を勧めると嘘になる。
+	t.Run("no hint when nothing can be played", func(t *testing.T) {
+		g := setup(t)
+		human := g.GetPlayer(0)
+		for human.GetCardsSize() > 0 {
+			human.RemoveCard(0)
+		}
+		if g.GetHint() != nil {
+			t.Error("手札が空ならヒントは出ない")
+		}
+	})
+
 	// プレイでもスート選択でもないフェーズでは出さない。
 	t.Run("no hint outside the playable phases", func(t *testing.T) {
 		g := setup(t)

--- a/internal/domain/interfaces/crazyeights.go
+++ b/internal/domain/interfaces/crazyeights.go
@@ -49,4 +49,6 @@ type CrazyEightsGame interface {
 	GetPlayerCnt() int
 	// GetPlayer 指定インデックスのプレイヤーを取得する
 	GetPlayer(i int) *domain.CrazyEightsPlayer
+	// GetHint サーバー計算の推奨手を返す (手番でなければ nil)
+	GetHint() *domain.CrazyEightsHint
 }

--- a/internal/domain/interfaces/crazyeights_mock.go
+++ b/internal/domain/interfaces/crazyeights_mock.go
@@ -40,6 +40,13 @@ func (m *MockCrazyEightsGame) GetPlayerCnt() int           { return m.Called().I
 func (m *MockCrazyEightsGame) GetPlayer(i int) *domain.CrazyEightsPlayer {
 	return m.Called(i).Get(0).(*domain.CrazyEightsPlayer)
 }
+
+// GetHint はサーバー計算の推奨手を返すモック。
+func (m *MockCrazyEightsGame) GetHint() *domain.CrazyEightsHint {
+	out, _ := m.Called().Get(0).(*domain.CrazyEightsHint)
+	return out
+}
+
 func (m *MockCrazyEightsGame) GetActionLog() []*domain.ActionLogEntry {
 	return m.Called().Get(0).([]*domain.ActionLogEntry)
 }

--- a/internal/i18n/locales/en/crazyeights.json
+++ b/internal/i18n/locales/en/crazyeights.json
@@ -18,5 +18,13 @@
   "promptChooseSuit": "Choose-suit phase",
   "promptChooseSuitHelp": "suit <1-4>: choose suit (1=♠, 2=♣, 3=♥, 4=♦)",
   "promptRoundEnd": "Round complete",
-  "promptRoundEndHelp": "nr / nextround: advance to next round"
+  "promptRoundEndHelp": "nr / nextround: advance to next round",
+  "hintNone": "No hint available",
+  "hintCard": "Suggested: [{{idx}}] {{card}} ({{reason}})",
+  "hintSuit": "Suggested suit: {{suit}} ({{reason}})",
+  "hintReasonMatchSuit": "matches the suit",
+  "hintReasonMatchRank": "matches the rank",
+  "hintReasonPlayWild": "an 8 lets you change the suit",
+  "hintReasonPlayValid": "a legal play",
+  "hintReasonChooseLongestSuit": "your longest suit"
 }

--- a/internal/i18n/locales/ja/crazyeights.json
+++ b/internal/i18n/locales/ja/crazyeights.json
@@ -18,5 +18,13 @@
   "promptChooseSuit": "スート選択フェーズ",
   "promptChooseSuitHelp": "suit <1-4>・・・スートを選択 (1=♠, 2=♣, 3=♥, 4=♦)",
   "promptRoundEnd": "ラウンド終了",
-  "promptRoundEndHelp": "nr / nextround・・・次のラウンドへ"
+  "promptRoundEndHelp": "nr / nextround・・・次のラウンドへ",
+  "hintNone": "ヒントはありません",
+  "hintCard": "おすすめ: [{{idx}}] {{card}} ({{reason}})",
+  "hintSuit": "おすすめのスート: {{suit}} ({{reason}})",
+  "hintReasonMatchSuit": "スートが合う",
+  "hintReasonMatchRank": "数字が合う",
+  "hintReasonPlayWild": "8 でスートを変えられる",
+  "hintReasonPlayValid": "出せる札",
+  "hintReasonChooseLongestSuit": "手札に一番多いスート"
 }

--- a/internal/usecase/CrazyEightsInteractor.go
+++ b/internal/usecase/CrazyEightsInteractor.go
@@ -26,6 +26,8 @@ type CrazyEightsInteractorIF interface {
 	GetConfig() domain.CrazyEightsConfig
 	// ActionLog 棋譜を出力する
 	ActionLog() string
+	// Hint サーバー計算の推奨手を出力する
+	Hint() string
 	// IsHumanChooseSuitTurn reports whether the human just played an 8 and the
 	// game is now waiting for them to pick a suit. Used by the CUI controller
 	// to issue an inline suit prompt instead of forcing the user to type 's'
@@ -115,6 +117,11 @@ func (ci *CrazyEightsInteractor) GetConfig() domain.CrazyEightsConfig {
 // ActionLog 棋譜を出力する
 func (ci *CrazyEightsInteractor) ActionLog() string {
 	return ci.gp.ActionLogOutput(ci.Game)
+}
+
+// Hint サーバー計算の推奨手を出力する
+func (ci *CrazyEightsInteractor) Hint() string {
+	return ci.gp.HintOutput(ci.Game)
 }
 
 // IsHumanChooseSuitTurn reports whether the game is currently waiting for the

--- a/internal/usecase/interactor_snapshot_test.go
+++ b/internal/usecase/interactor_snapshot_test.go
@@ -115,13 +115,16 @@ type stubSevensPresenter struct{}
 func (s *stubSevensPresenter) Output(_ interfaces.SevensGame, _ error) string { return `{}` }
 func (s *stubSevensPresenter) ActionLogOutput(_ interfaces.SevensGame) string { return `{}` }
 
-// stubCrazyEightsPresenter implements presenter.CrazyEightsPresenter (= GamePresenter[interfaces.CrazyEightsGame])
+// stubCrazyEightsPresenter implements presenter.CrazyEightsPresenter
 type stubCrazyEightsPresenter struct{}
 
 func (s *stubCrazyEightsPresenter) Output(_ interfaces.CrazyEightsGame, _ error) string {
 	return `{}`
 }
 func (s *stubCrazyEightsPresenter) ActionLogOutput(_ interfaces.CrazyEightsGame) string {
+	return `{}`
+}
+func (s *stubCrazyEightsPresenter) HintOutput(_ interfaces.CrazyEightsGame) string {
 	return `{}`
 }
 

--- a/internal/usecase/presenter/CrazyEightsPresenter.go
+++ b/internal/usecase/presenter/CrazyEightsPresenter.go
@@ -3,4 +3,8 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // CrazyEightsPresenter クレイジーエイトプレゼンターインタフェース
-type CrazyEightsPresenter = GamePresenter[interfaces.CrazyEightsGame]
+type CrazyEightsPresenter interface {
+	GamePresenter[interfaces.CrazyEightsGame]
+	// HintOutput ヒント情報を出力する
+	HintOutput(g interfaces.CrazyEightsGame) string
+}

--- a/internal/usecase/presenter/CrazyEightsPresenter_mock.go
+++ b/internal/usecase/presenter/CrazyEightsPresenter_mock.go
@@ -5,4 +5,12 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // MockCrazyEightsPresenter クレイジーエイトプレゼンターモック
-type MockCrazyEightsPresenter = MockGamePresenter[interfaces.CrazyEightsGame]
+type MockCrazyEightsPresenter struct {
+	MockGamePresenter[interfaces.CrazyEightsGame]
+}
+
+// HintOutput モック
+func (_m *MockCrazyEightsPresenter) HintOutput(g interfaces.CrazyEightsGame) string {
+	ret := _m.Called(g)
+	return ret.Get(0).(string)
+}


### PR DESCRIPTION
## 背景

`HeartsCuiPresenter` / `SpadesCuiPresenter` には `HintOutput` があり、対応するページもヒントボタンを持ち、押すと**サーバーが計算した具体的な推奨手**（カード index・理由コード）が出ます。

一方 `CrazyEightsCuiPresenter` には `Output` と `ActionLogOutput` しかなく、**ドメインの `GetHint` すら存在しません**でした。`useCrazyEightsGame` にもヒント関連の状態は一切なく、唯一の支援は `useGameHint` によるフロント完結のツールチップ（全ゲーム共通の簡易ヒューリスティック）だけでした (#4737)。

## 変更

ヒントパイプラインを4段そろえました:

| 段 | 追加したもの |
|---|---|
| domain | `CrazyEightsHint` / `GetHint()` / `playHintReason()` |
| CUI | `HintOutput` + 理由キーの対応表、`h` / `hint` コマンド |
| usecase | `Hint()`（interactor IF・実装・モック） |
| Web | `HintOutput`、フックの `useHintRequest`、ページのヒントボタン |

### 推奨手は CPU の最善手選択をそのまま使います

`cpuPlayHard` / `cpuSelectSuit` を呼びます。**別ロジックを書くと「CPU は選ばない手を人間に勧める」ことになります。**

8 を出した後の**スート選択フェーズ**にも対応し、そのときは `Suit` を返します（`CardIndex` は nil）。

## テスト

**domain** (`TestCrazyEights_GetHint`):
- 推奨札が**実際に出せること**を `PlayerPlay` で裏取り（合法手判定をテスト側に写すと、それがもう1つの実装になるため）
- スート選択フェーズでは `Suit` が入り `CardIndex` は入らない
- CPU の手番では出さない（相手の手札を見て助言することになる）
- プレイでもスート選択でもないフェーズでは出さない

**CUI**: カードヒント / スートヒント / **ヒント無しを明示すること**（空文字だとコマンドが効いたか分からない）

**page**: ヒント要求で推奨カードと理由が出る / スート推奨が出る / **要求前は出さない**（常時表示だとフロント完結のツールチップと二重になる）

**負のコントロール**: `selectHint` を `() => null` に潰すと2件が落ち、戻すと 74 passed。

## 検証

- `go test -tags test ./internal/...` ✅ / `golangci-lint` → `0 issues.` ✅ / `gofmt -l internal/` 空 ✅
- `bun run check` ✅ / `bun run typecheck` ✅ / `CrazyEightsPage` 74 passed ✅

Closes #4737