### PR TITLE
feat: add a server-calculated hint to Durak

### DIFF
--- a/frontend/src/api/games/durak.ts
+++ b/frontend/src/api/games/durak.ts
@@ -7,7 +7,7 @@ import { gameExec } from '../gameExec';
 /** API client for the Durak /durak/exec endpoint. */
 export const durakApi = {
   exec: (
-    command: 'reset' | 'attack' | 'defend' | 'pass' | 'take' | 'sort',
+    command: 'reset' | 'attack' | 'defend' | 'pass' | 'take' | 'sort' | 'hint',
     cardIdx?: number,
     attackIdx?: number,
     config?: DurakConfigInput,

--- a/frontend/src/hooks/useDurakGame.ts
+++ b/frontend/src/hooks/useDurakGame.ts
@@ -1,8 +1,9 @@
 import { useCallback, useEffect, useState } from 'react';
 import { durakApi } from '../api/gameApi';
-import type { DurakConfig } from '../types/card';
+import type { DurakConfig, DurakHint } from '../types/card';
 import { useGameApi } from './useGameApi';
 import { useGameConfig } from './useGameConfig';
+import { useHintRequest } from './useHintRequest';
 
 /** Default Durak game configuration. */
 export const DEFAULT_DURAK_CONFIG: DurakConfig = {
@@ -34,6 +35,17 @@ export function useDurakGame() {
   }, []);
 
   const { state, loading, error, exec: gameExec, retry } = useGameApi(durakApi.exec, { onSuccess });
+
+  // **他のトリック系はサーバー計算の理由付きヒントを持つのに、Durak は
+  // クライアント完結の簡易ヒューリスティックだけだった (#4740)。**
+  const [hint, setHint] = useState<DurakHint | null>(null);
+  const [hintError, setHintError] = useState<string | null>(null);
+  const handleHint = useHintRequest({
+    fetchHint: () => durakApi.exec('hint'),
+    selectHint: (res) => res.hint ?? null,
+    setHint,
+    setHintError,
+  });
 
   useEffect(() => {
     gameExec('reset', undefined, undefined, DEFAULT_DURAK_CONFIG);
@@ -82,5 +94,8 @@ export function useDurakGame() {
     handlePass,
     handleTake,
     handleSort,
+    hint,
+    hintError,
+    handleHint,
   };
 }

--- a/frontend/src/i18n/locales/en/durak.json
+++ b/frontend/src/i18n/locales/en/durak.json
@@ -57,5 +57,15 @@
     "defendWithTrump": "Defend with a trump card",
     "takeBout": "Cannot defend — take the cards",
     "takeNothingToDefend": "Nothing to defend"
+  },
+  "hintCard": "Suggested: card [{{idx}}]",
+  "hintTake": "Suggested: pick up the cards",
+  "hintPass": "Suggested: pass",
+  "hintReason": {
+    "attack_weakest": "lead your weakest non-trump",
+    "attack_additional": "you can pile on the same rank",
+    "defend_beat": "this card beats it",
+    "take_cannot_beat": "nothing in hand beats it",
+    "pass_no_addition": "nothing left to pile on"
   }
 }

--- a/frontend/src/i18n/locales/ja/durak.json
+++ b/frontend/src/i18n/locales/ja/durak.json
@@ -57,5 +57,15 @@
     "defendWithTrump": "切り札で防御推奨",
     "takeBout": "防御不能 — 引き取り推奨",
     "takeNothingToDefend": "防御対象なし"
+  },
+  "hintCard": "おすすめ: [{{idx}}] のカード",
+  "hintTake": "おすすめ: カードを引き取る",
+  "hintPass": "おすすめ: パスする",
+  "hintReason": {
+    "attack_weakest": "最弱の非切り札で攻める",
+    "attack_additional": "同じ数字で追撃できる",
+    "defend_beat": "この札で返せる",
+    "take_cannot_beat": "返せる札が無い",
+    "pass_no_addition": "追撃できる札が無い"
   }
 }

--- a/frontend/src/pages/DurakPage.test.tsx
+++ b/frontend/src/pages/DurakPage.test.tsx
@@ -368,4 +368,40 @@ describe('DurakPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined, undefined, defaultConfig));
     expect(screen.queryByRole('button', { name: '確認' })).not.toBeInTheDocument();
   });
+
+  // **他のトリック系はサーバー計算の理由付きヒントを持つのに、Durak は CUI に
+  // hint コマンドすら無く、Web もクライアント完結の簡易ヒューリスティックだけ
+  // だった (#4740)。**
+  it('fetches a server hint and shows the recommended card with its reason', async () => {
+    renderWithProviders(<DurakPage />);
+    await waitFor(() => expect(screen.getByTestId('durak-hint-button')).toBeInTheDocument());
+
+    mockExec.mockResolvedValueOnce({ ...baseState, hint: { cardIndex: 1, reason: 'attack_weakest' } });
+    fireEvent.click(screen.getByTestId('durak-hint-button'));
+
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('hint'));
+    const shown = await screen.findByTestId('durak-server-hint');
+    expect(shown).toHaveTextContent('1');
+    expect(shown).toHaveTextContent('最弱の非切り札で攻める');
+  });
+
+  // **「引き取る」も助言のうち。**カードを勧められない局面で黙ると、手が無いのか
+  // 判断が付かない。cardIndex が無い分岐を踏む。
+  it('advises picking the cards up when nothing beats the attack', async () => {
+    renderWithProviders(<DurakPage />);
+    await waitFor(() => expect(screen.getByTestId('durak-hint-button')).toBeInTheDocument());
+
+    mockExec.mockResolvedValueOnce({ ...baseState, hint: { takeCards: true, reason: 'take_cannot_beat' } });
+    fireEvent.click(screen.getByTestId('durak-hint-button'));
+
+    const shown = await screen.findByTestId('durak-server-hint');
+    expect(shown).toHaveTextContent('返せる札が無い');
+  });
+
+  it('shows no server hint before the button is pressed', async () => {
+    renderWithProviders(<DurakPage />);
+
+    await waitFor(() => expect(mockExec).toHaveBeenCalled());
+    expect(screen.queryByTestId('durak-server-hint')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/DurakPage.tsx
+++ b/frontend/src/pages/DurakPage.tsx
@@ -93,6 +93,9 @@ function DurakPageContent() {
     handlePass,
     handleTake,
     handleSort,
+    hint: serverHint,
+    hintError,
+    handleHint,
   } = useDurakGame();
 
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('durak');
@@ -409,6 +412,19 @@ function DurakPageContent() {
 
             <ErrorAlert message={error} onRetry={retry} />
 
+            {serverHint && (
+              <p className="mt-2 text-sm text-ds-accent" data-testid="durak-server-hint">
+                {serverHint.takeCards
+                  ? t('hintTake')
+                  : serverHint.cardIndex === undefined
+                    ? t('hintPass')
+                    : t('hintCard', { idx: serverHint.cardIndex })}{' '}
+                ({t(`hintReason.${serverHint.reason}`)})
+              </p>
+            )}
+
+            <ErrorAlert message={hintError} onRetry={undefined} />
+
             {/* Action buttons */}
             <div className="text-center" data-tutorial="dk-action-buttons">
               <GameResetButton
@@ -458,6 +474,21 @@ function DurakPageContent() {
                   {t('takeButton')}
                 </button>
               )}
+              {/* **他のトリック系はサーバー計算の理由付きヒントを持つのに、
+                  Durak には無く、クライアント完結の簡易ヒューリスティックだけ
+                  だった (#4740)。** */}
+              {!isGameEnd && (
+                <button
+                  type="button"
+                  className={`${btnSuccess} min-w-[90px]`}
+                  disabled={loading}
+                  onClick={handleHint}
+                  data-testid="durak-hint-button"
+                >
+                  {tc('button.hint')}
+                </button>
+              )}
+
               {/* Sort buttons */}
               {!isGameEnd && (
                 <>

--- a/frontend/src/types/games/durak.ts
+++ b/frontend/src/types/games/durak.ts
@@ -37,7 +37,25 @@ export interface DurakConfig {
 export type DurakConfigInput = DurakConfig;
 
 /** Full Durak game state returned from the API. */
+/** サーバー計算の推奨手。 */
+export interface DurakHint {
+  /** 推奨する手札の位置。取る/パスを勧めるときは undefined。 */
+  cardIndex?: number;
+  /** 防御時に狙うテーブル上の攻撃カードの位置。 */
+  attackIdx?: number;
+  /** true なら「引き取る」を勧める。 */
+  takeCards?: boolean;
+  /** 理由キー。 */
+  reason: string;
+}
+
 export interface DurakResponse extends BaseGameResponse {
+  /**
+   * サーバー計算の推奨手。`hint` コマンドの応答にのみ載る。
+   *
+   * フロント完結の `getDurakHint` は全ゲーム共通の簡易ヒューリスティックで別物。
+   */
+  hint?: DurakHint;
   players: DurakPlayerData[];
   currentTurn: number;
   phase: number;

--- a/internal/adapter/controller/DurakCuiController.go
+++ b/internal/adapter/controller/DurakCuiController.go
@@ -29,7 +29,7 @@ func (c *DurakCuiController) Exec(command string) string {
 		},
 		[]string{
 			"a", "attack", "d", "defend", "p", "pass", "t", "take",
-			"sort", "sd", "setdifficulty", "log", "l",
+			"sort", "sd", "setdifficulty", "h", "hint", "log", "l",
 		},
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
@@ -74,7 +74,7 @@ func (c *DurakCuiController) Exec(command string) string {
 					return c.di.ResetWithConfig(cfg)
 				})
 			default:
-				return handleCuiLog(cmd, c.di.ActionLog)
+				return handleCuiHintAndLog(cmd, c.di.Hint, c.di.ActionLog)
 			}
 		},
 	)

--- a/internal/adapter/controller/usecase/DurakInteractor_mock.go
+++ b/internal/adapter/controller/usecase/DurakInteractor_mock.go
@@ -67,6 +67,12 @@ func (_m *MockDurakInteractor) ActionLog() string {
 	return ret.Get(0).(string)
 }
 
+// Hint モック
+func (_m *MockDurakInteractor) Hint() string {
+	ret := _m.Called()
+	return ret.Get(0).(string)
+}
+
 // Snapshot モック
 func (_m *MockDurakInteractor) Snapshot() ([]byte, error) {
 	ret := _m.Called()

--- a/internal/adapter/presenter/DurakCuiPresenter.go
+++ b/internal/adapter/presenter/DurakCuiPresenter.go
@@ -128,3 +128,42 @@ func (p *DurakCuiPresenter) Output(dg interfaces.DurakGame, lastErr error) strin
 func (p *DurakCuiPresenter) ActionLogOutput(dg interfaces.DurakGame) string {
 	return actionLogOutputText(dg)
 }
+
+// HintOutput emits the current Durak hint.
+//
+// **他のトリック系はサーバー計算の理由付きヒントを持つのに、Durak は CUI に
+// hint コマンドすら無かった (#4740)。**
+func (p *DurakCuiPresenter) HintOutput(g interfaces.DurakGame) string {
+	hint := g.GetHint()
+	if hint == nil {
+		return i18n.T("durak.hintNone") + "\n"
+	}
+	reason := hintReasonStr(hint.Reason, durakHintReasonKeys)
+	if hint.TakeCards {
+		return color.Yellow(i18n.Tf("durak.hintTake", "reason", reason)) + "\n"
+	}
+	if hint.CardIndex == nil {
+		return color.Yellow(i18n.Tf("durak.hintPass", "reason", reason)) + "\n"
+	}
+	card := g.GetPlayer(g.GetCurrentTurn()).GetCard(*hint.CardIndex)
+	if hint.AttackIdx != nil {
+		return color.Yellow(i18n.Tf("durak.hintDefend",
+			"idx", strconv.Itoa(*hint.CardIndex),
+			"card", cuiCardStr(card),
+			"atk", strconv.Itoa(*hint.AttackIdx),
+			"reason", reason)) + "\n"
+	}
+	return color.Yellow(i18n.Tf("durak.hintCard",
+		"idx", strconv.Itoa(*hint.CardIndex),
+		"card", cuiCardStr(card),
+		"reason", reason)) + "\n"
+}
+
+// durakHintReasonKeys maps hint-reason identifiers to their i18n keys.
+var durakHintReasonKeys = map[string]string{
+	"attack_weakest":    "durak.hintReasonAttackWeakest",
+	"attack_additional": "durak.hintReasonAttackAdditional",
+	"defend_beat":       "durak.hintReasonDefendBeat",
+	"take_cannot_beat":  "durak.hintReasonTakeCannotBeat",
+	"pass_no_addition":  "durak.hintReasonPassNoAddition",
+}

--- a/internal/adapter/presenter/DurakCuiPresenter_test.go
+++ b/internal/adapter/presenter/DurakCuiPresenter_test.go
@@ -138,3 +138,52 @@ func TestDurakCuiPresenter_ActionLogOutput(t *testing.T) {
 	result := p.ActionLogOutput(gameMock)
 	assert.NotEmpty(t, result)
 }
+
+// **他のトリック系はサーバー計算の理由付きヒントを持つのに、Durak は CUI に
+// hint コマンドすら無かった (#4740)。**
+func TestDurakCuiPresenter_HintOutput(t *testing.T) {
+	orig := color.NoColor()
+	color.SetNoColor(true)
+	defer color.SetNoColor(orig)
+	p := new(presenter.DurakCuiPresenter)
+
+	newMock := func(hint *domain.DurakHint) *interfaces.MockDurakGame {
+		m := new(interfaces.MockDurakGame)
+		m.On("GetHint").Return(hint)
+		m.On("GetCurrentTurn").Return(0).Maybe()
+		pl := domain.NewDurakPlayer(true)
+		pl.AddCard(domain.NewCard(domain.CardDesignSpade, 6, false))
+		m.On("GetPlayer", 0).Return(pl).Maybe()
+		return m
+	}
+
+	t.Run("attack hint names the card and the reason", func(t *testing.T) {
+		idx := 0
+		out := p.HintOutput(newMock(&domain.DurakHint{CardIndex: &idx, Reason: "attack_weakest"}))
+		assert.Contains(t, out, "SPADE 6")
+		assert.Contains(t, out, "最弱の非切り札で攻める")
+	})
+
+	t.Run("defend hint names which attack to beat", func(t *testing.T) {
+		idx, atk := 0, 1
+		out := p.HintOutput(newMock(&domain.DurakHint{CardIndex: &idx, AttackIdx: &atk, Reason: "defend_beat"}))
+		assert.Contains(t, out, "SPADE 6")
+		assert.Contains(t, out, "この札で返せる")
+	})
+
+	// **「引き取る」「パス」も助言のうち。**カードを勧められない局面で黙ると、
+	// プレイヤーは手が無いのか判断が付かない。
+	t.Run("take hint says to pick the cards up", func(t *testing.T) {
+		out := p.HintOutput(newMock(&domain.DurakHint{TakeCards: true, Reason: "take_cannot_beat"}))
+		assert.Contains(t, out, "返せる札が無い")
+	})
+
+	t.Run("pass hint says to pass", func(t *testing.T) {
+		out := p.HintOutput(newMock(&domain.DurakHint{Reason: "pass_no_addition"}))
+		assert.Contains(t, out, "追撃できる札が無い")
+	})
+
+	t.Run("no hint says so explicitly", func(t *testing.T) {
+		assert.Contains(t, p.HintOutput(newMock(nil)), "ヒントはありません")
+	})
+}

--- a/internal/adapter/presenter/DurakWebPresenter.go
+++ b/internal/adapter/presenter/DurakWebPresenter.go
@@ -115,3 +115,8 @@ func (dwp *DurakWebPresenter) buildResultMessage(dg interfaces.DurakGame) string
 func (dwp *DurakWebPresenter) ActionLogOutput(dg interfaces.DurakGame) string {
 	return actionLogOutputJSON(dg)
 }
+
+// HintOutput はサーバー計算のヒントを返す (`command: "hint"` 専用のレスポンス)。
+func (p *DurakWebPresenter) HintOutput(g interfaces.DurakGame) string {
+	return p.Output(g, nil)
+}

--- a/internal/adapter/presenter/DurakWebPresenter_test.go
+++ b/internal/adapter/presenter/DurakWebPresenter_test.go
@@ -122,3 +122,14 @@ func TestDurakWebPresenter_ActionLogOutput(t *testing.T) {
 	result := p.ActionLogOutput(gameMock)
 	assert.NotEmpty(t, result)
 }
+
+// **`command: "hint"` 専用のレスポンスも返す (#4740)。**Web はクライアント側でも
+// 簡易ヒントを出すが、これはサーバー計算のもの。
+func TestDurakWebPresenter_HintOutput(t *testing.T) {
+	d := domain.NewDefaultDurak()
+	d.Reset()
+
+	out := new(presenter.DurakWebPresenter).HintOutput(d)
+	assert.True(t, json.Valid([]byte(out)), "JSON として妥当")
+	assert.Contains(t, out, `"players"`, "状態も一緒に返る")
+}

--- a/internal/domain/Durak.go
+++ b/internal/domain/Durak.go
@@ -380,6 +380,63 @@ func (d *Durak) SetConfig(config DurakConfig) {
 // ---- 公開メソッド: ゲッター ----
 
 // GetGameEndFlag ゲーム終了フラグ取得
+// DurakHint はサーバーが計算した推奨手。
+type DurakHint struct {
+	// CardIndex は推奨する手札の位置。取る/パスを勧めるときは nil。
+	CardIndex *int
+	// AttackIdx は防御時に狙うテーブル上の攻撃カードの位置。攻撃時は nil。
+	AttackIdx *int
+	// TakeCards が true なら「引き取る」を勧める (防御できる札が無い)。
+	TakeCards bool
+	// Reason は理由キー (i18n で引く)。
+	Reason string
+}
+
+// GetHint は人間の手番での推奨手を返す。手番でなければ nil。
+//
+// **他のトリック系はサーバー計算の理由付きヒントを持つのに、Durak は CUI に
+// hint コマンドすら無く、Web もクライアント完結の簡易ヒューリスティックだけ
+// だった (#4740)。**推奨手は CPU の選択ロジック (cpuFind*) をそのまま使う。
+// 別ロジックを書くと「CPU は選ばない手を人間に勧める」ことになる。
+func (d *Durak) GetHint() *DurakHint {
+	if d.round.gameEndFlag || !d.IsHumanTurn() {
+		return nil
+	}
+	human := d.players[d.round.currentTurn]
+
+	switch d.round.phase {
+	case DurakPhaseAttack:
+		if len(d.round.tablePairs) == 0 {
+			idx := d.cpuFindWeakestAttackCard(human)
+			if idx < 0 {
+				return nil
+			}
+			return &DurakHint{CardIndex: &idx, Reason: "attack_weakest"}
+		}
+		idx := d.cpuFindAdditionalAttackCard(human)
+		if idx < 0 {
+			// 追撃できる札が無い = パスするしかない。
+			return &DurakHint{Reason: "pass_no_addition"}
+		}
+		return &DurakHint{CardIndex: &idx, Reason: "attack_additional"}
+
+	case DurakPhaseDefend:
+		for pairIdx, pair := range d.round.tablePairs {
+			if pair.Defense != nil {
+				continue
+			}
+			if idx := d.cpuFindDefenseCard(human, pair.Attack); idx >= 0 {
+				pi := pairIdx
+				return &DurakHint{CardIndex: &idx, AttackIdx: &pi, Reason: "defend_beat"}
+			}
+			// この攻撃を返せない = 引き取るしかない。
+			return &DurakHint{TakeCards: true, Reason: "take_cannot_beat"}
+		}
+		return nil
+	}
+	return nil
+}
+
 func (d *Durak) GetGameEndFlag() bool { return d.round.gameEndFlag }
 
 // IsHumanTurn 現在の手番が人間かを返す

--- a/internal/domain/Durak_test.go
+++ b/internal/domain/Durak_test.go
@@ -743,24 +743,12 @@ func TestDurak_NotAttackerTurn(t *testing.T) {
 
 // **他のトリック系はサーバー計算の理由付きヒントを持つのに、Durak は CUI に
 // hint コマンドすら無かった (#4740)。**推奨手は CPU の選択ロジックをそのまま使う。
+//
+// 配りに賭けず、既存の setupDurakForHuman* で局面を作って全分岐を踏む。
 func TestDurak_GetHint(t *testing.T) {
-	humanTurn := func(t *testing.T) *domain.Durak {
-		t.Helper()
-		// 人間が攻撃側になる配りを引くまで回す。Reset は攻撃側をランダムに決める。
-		for i := 0; i < 200; i++ {
-			g := domain.NewDefaultDurak()
-			g.Reset()
-			if g.IsHumanTurn() && g.GetPhase() == domain.DurakPhaseAttack {
-				return g
-			}
-		}
-		t.Fatal("人間が攻撃側になる配りを引けなかった")
-		return nil
-	}
-
-	t.Run("recommends an attack the rules actually allow", func(t *testing.T) {
-		g := humanTurn(t)
-		hint := g.GetHint()
+	t.Run("initial attack recommends a playable card", func(t *testing.T) {
+		d := setupDurakForHumanAttack()
+		hint := d.GetHint()
 		if hint == nil || hint.CardIndex == nil {
 			t.Fatal("初回攻撃では推奨カードが出る")
 		}
@@ -768,33 +756,90 @@ func TestDurak_GetHint(t *testing.T) {
 			t.Errorf("Reason = %q, want attack_weakest", hint.Reason)
 		}
 		// **勧めた手が本番の入口を通ること。**別ロジックで選ぶと出せない札を勧める。
-		if err := g.PlayerAttack(*hint.CardIndex); err != nil {
+		if err := d.PlayerAttack(*hint.CardIndex); err != nil {
 			t.Errorf("推奨札 (index %d) が実際には出せなかった: %v", *hint.CardIndex, err)
 		}
 	})
 
+	// 追撃: テーブルに札があるとき。手札に同じ数字があれば追撃、無ければパス。
+	t.Run("additional attack or pass depending on the hand", func(t *testing.T) {
+		d := setupDurakForHumanAttack()
+		human := d.GetPlayer(0)
+		for human.GetCardsSize() > 0 {
+			human.RemoveCard(0)
+		}
+		// テーブルに 7 が出ている状態で、手札にも 7 を持たせる → 追撃できる。
+		d.SetTablePairs([]*domain.DurakTablePair{
+			{Attack: domain.NewCard(domain.CardDesignClover, 7, false)},
+		})
+		human.AddCard(domain.NewCard(domain.CardDesignHeart, 7, false))
+
+		hint := d.GetHint()
+		if hint == nil || hint.CardIndex == nil || hint.Reason != "attack_additional" {
+			t.Fatalf("同じ数字を持っていれば追撃を勧める: %+v", hint)
+		}
+
+		// 手札を無関係な札だけにすると、追撃できずパスになる。
+		for human.GetCardsSize() > 0 {
+			human.RemoveCard(0)
+		}
+		human.AddCard(domain.NewCard(domain.CardDesignSpade, 3, false))
+		hint = d.GetHint()
+		if hint == nil || hint.CardIndex != nil || hint.Reason != "pass_no_addition" {
+			t.Fatalf("追撃できなければパスを勧める: %+v", hint)
+		}
+	})
+
+	t.Run("defend recommends a card that beats the attack", func(t *testing.T) {
+		d := setupDurakForHumanDefend()
+		human := d.GetPlayer(0)
+		for human.GetCardsSize() > 0 {
+			human.RemoveCard(0)
+		}
+		// 場は CLOVER 7。同スートの上位で返せる。
+		human.AddCard(domain.NewCard(domain.CardDesignClover, 10, false))
+
+		hint := d.GetHint()
+		if hint == nil || hint.CardIndex == nil || hint.AttackIdx == nil {
+			t.Fatalf("防御できる札があれば札と対象を示す: %+v", hint)
+		}
+		if hint.Reason != "defend_beat" {
+			t.Errorf("Reason = %q, want defend_beat", hint.Reason)
+		}
+		if err := d.PlayerDefend(*hint.AttackIdx, *hint.CardIndex); err != nil {
+			t.Errorf("推奨した防御が実際には通らなかった: %v", err)
+		}
+	})
+
+	// **「引き取る」も助言のうち。**返せる札が無い局面で黙ると、プレイヤーは
+	// 手が無いのか判断が付かない。
+	t.Run("advises taking the cards when nothing beats the attack", func(t *testing.T) {
+		d := setupDurakForHumanDefend()
+		human := d.GetPlayer(0)
+		for human.GetCardsSize() > 0 {
+			human.RemoveCard(0)
+		}
+		// 場は CLOVER 7。同スートの下位・切り札でない札しか持たない。
+		human.AddCard(domain.NewCard(domain.CardDesignClover, 3, false))
+
+		hint := d.GetHint()
+		if hint == nil || !hint.TakeCards || hint.Reason != "take_cannot_beat" {
+			t.Fatalf("返せなければ引き取りを勧める: %+v", hint)
+		}
+	})
+
 	t.Run("no hint on a CPU turn", func(t *testing.T) {
-		g := humanTurn(t)
-		// 人間が攻撃したら手番は防御側 (CPU) に移る。
-		h := g.GetHint()
-		if h == nil || h.CardIndex == nil {
-			t.Fatal("前提: 攻撃ヒントが出ること")
-		}
-		if err := g.PlayerAttack(*h.CardIndex); err != nil {
-			t.Fatalf("攻撃に失敗: %v", err)
-		}
-		if g.IsHumanTurn() {
-			t.Skip("この配りでは人間が防御側でもある (2人戦でない構成)")
-		}
-		if g.GetHint() != nil {
+		d := setupDurakForHumanAttack()
+		d.SetCurrentTurn(1)
+		if d.GetHint() != nil {
 			t.Error("CPU の手番ではヒントを出さない")
 		}
 	})
 
 	t.Run("no hint once the game has ended", func(t *testing.T) {
-		g := humanTurn(t)
-		g.SetPhase(domain.DurakPhaseGameEnd)
-		if g.GetHint() != nil {
+		d := setupDurakForHumanAttack()
+		d.SetPhase(domain.DurakPhaseGameEnd)
+		if d.GetHint() != nil {
 			t.Error("ゲーム終了フェーズではヒントを出さない")
 		}
 	})

--- a/internal/domain/Durak_test.go
+++ b/internal/domain/Durak_test.go
@@ -740,3 +740,62 @@ func TestDurak_NotAttackerTurn(t *testing.T) {
 	err := d.PlayerAttack(0)
 	assert.ErrorIs(t, err, domain.ErrWrongPhase)
 }
+
+// **他のトリック系はサーバー計算の理由付きヒントを持つのに、Durak は CUI に
+// hint コマンドすら無かった (#4740)。**推奨手は CPU の選択ロジックをそのまま使う。
+func TestDurak_GetHint(t *testing.T) {
+	humanTurn := func(t *testing.T) *domain.Durak {
+		t.Helper()
+		// 人間が攻撃側になる配りを引くまで回す。Reset は攻撃側をランダムに決める。
+		for i := 0; i < 200; i++ {
+			g := domain.NewDefaultDurak()
+			g.Reset()
+			if g.IsHumanTurn() && g.GetPhase() == domain.DurakPhaseAttack {
+				return g
+			}
+		}
+		t.Fatal("人間が攻撃側になる配りを引けなかった")
+		return nil
+	}
+
+	t.Run("recommends an attack the rules actually allow", func(t *testing.T) {
+		g := humanTurn(t)
+		hint := g.GetHint()
+		if hint == nil || hint.CardIndex == nil {
+			t.Fatal("初回攻撃では推奨カードが出る")
+		}
+		if hint.Reason != "attack_weakest" {
+			t.Errorf("Reason = %q, want attack_weakest", hint.Reason)
+		}
+		// **勧めた手が本番の入口を通ること。**別ロジックで選ぶと出せない札を勧める。
+		if err := g.PlayerAttack(*hint.CardIndex); err != nil {
+			t.Errorf("推奨札 (index %d) が実際には出せなかった: %v", *hint.CardIndex, err)
+		}
+	})
+
+	t.Run("no hint on a CPU turn", func(t *testing.T) {
+		g := humanTurn(t)
+		// 人間が攻撃したら手番は防御側 (CPU) に移る。
+		h := g.GetHint()
+		if h == nil || h.CardIndex == nil {
+			t.Fatal("前提: 攻撃ヒントが出ること")
+		}
+		if err := g.PlayerAttack(*h.CardIndex); err != nil {
+			t.Fatalf("攻撃に失敗: %v", err)
+		}
+		if g.IsHumanTurn() {
+			t.Skip("この配りでは人間が防御側でもある (2人戦でない構成)")
+		}
+		if g.GetHint() != nil {
+			t.Error("CPU の手番ではヒントを出さない")
+		}
+	})
+
+	t.Run("no hint once the game has ended", func(t *testing.T) {
+		g := humanTurn(t)
+		g.SetPhase(domain.DurakPhaseGameEnd)
+		if g.GetHint() != nil {
+			t.Error("ゲーム終了フェーズではヒントを出さない")
+		}
+	})
+}

--- a/internal/domain/interfaces/durak.go
+++ b/internal/domain/interfaces/durak.go
@@ -60,4 +60,6 @@ type DurakGame interface {
 	GetHumanAction() *domain.DurakCpuAction
 	// GetBoutNumber バウト番号を取得する
 	GetBoutNumber() int
+	// GetHint サーバー計算の推奨手を返す (手番でなければ nil)
+	GetHint() *domain.DurakHint
 }

--- a/internal/domain/interfaces/durak_mock.go
+++ b/internal/domain/interfaces/durak_mock.go
@@ -191,6 +191,12 @@ func (_m *MockDurakGame) GetBoutNumber() int {
 }
 
 // GetActionLog モック
+// GetHint はサーバー計算の推奨手を返すモック。
+func (_m *MockDurakGame) GetHint() *domain.DurakHint {
+	out, _ := _m.Called().Get(0).(*domain.DurakHint)
+	return out
+}
+
 func (_m *MockDurakGame) GetActionLog() []*domain.ActionLogEntry {
 	ret := _m.Called()
 	if val, ok := ret.Get(0).([]*domain.ActionLogEntry); ok {

--- a/internal/i18n/locales/en/durak.json
+++ b/internal/i18n/locales/en/durak.json
@@ -21,5 +21,15 @@
   "phaseGameEnd": "Phase: game over",
   "gameEndDraw": "Draw!",
   "gameEndHumanLost": "You are the durak (loser)!",
-  "gameEndCpuLost": "CPU {{idx}} is the durak (loser)!"
+  "gameEndCpuLost": "CPU {{idx}} is the durak (loser)!",
+  "hintNone": "No hint available",
+  "hintCard": "Suggested: [{{idx}}] {{card}} ({{reason}})",
+  "hintDefend": "Suggested: beat attack #{{atk}} with [{{idx}}] {{card}} ({{reason}})",
+  "hintTake": "Suggested: pick up the cards ({{reason}})",
+  "hintPass": "Suggested: pass ({{reason}})",
+  "hintReasonAttackWeakest": "lead your weakest non-trump",
+  "hintReasonAttackAdditional": "you can pile on the same rank",
+  "hintReasonDefendBeat": "this card beats it",
+  "hintReasonTakeCannotBeat": "nothing in hand beats it",
+  "hintReasonPassNoAddition": "nothing left to pile on"
 }

--- a/internal/i18n/locales/ja/durak.json
+++ b/internal/i18n/locales/ja/durak.json
@@ -21,5 +21,15 @@
   "phaseGameEnd": "フェーズ: ゲーム終了",
   "gameEndDraw": "引き分け！",
   "gameEndHumanLost": "あなたがドゥラーク（負け）です！",
-  "gameEndCpuLost": "CPU {{idx}} がドゥラーク（負け）です！"
+  "gameEndCpuLost": "CPU {{idx}} がドゥラーク（負け）です！",
+  "hintNone": "ヒントはありません",
+  "hintCard": "おすすめ: [{{idx}}] {{card}} ({{reason}})",
+  "hintDefend": "おすすめ: [{{idx}}] {{card}} で {{atk}} 番目の攻撃を防ぐ ({{reason}})",
+  "hintTake": "おすすめ: カードを引き取る ({{reason}})",
+  "hintPass": "おすすめ: パスする ({{reason}})",
+  "hintReasonAttackWeakest": "最弱の非切り札で攻める",
+  "hintReasonAttackAdditional": "同じ数字で追撃できる",
+  "hintReasonDefendBeat": "この札で返せる",
+  "hintReasonTakeCannotBeat": "返せる札が無い",
+  "hintReasonPassNoAddition": "追撃できる札が無い"
 }

--- a/internal/usecase/DurakInteractor.go
+++ b/internal/usecase/DurakInteractor.go
@@ -28,6 +28,8 @@ type DurakInteractorIF interface {
 	Sort(mode domain.DurakSortMode) string
 	// ActionLog 棋譜を出力する
 	ActionLog() string
+	// Hint サーバー計算の推奨手を出力する
+	Hint() string
 }
 
 // DurakInteractor ドゥラークインタラクタークラス
@@ -118,6 +120,11 @@ func (di *DurakInteractor) Sort(mode domain.DurakSortMode) string {
 // ActionLog 棋譜を出力する
 func (di *DurakInteractor) ActionLog() string {
 	return di.dp.ActionLogOutput(di.Game)
+}
+
+// Hint サーバー計算の推奨手を出力する
+func (di *DurakInteractor) Hint() string {
+	return di.dp.HintOutput(di.Game)
 }
 
 // runCpuTurns ゲームが終わるか人間の手番になるまでCPUターンを実行

--- a/internal/usecase/DurakInteractor_test.go
+++ b/internal/usecase/DurakInteractor_test.go
@@ -74,6 +74,18 @@ func TestDurakInteractor_Methods(t *testing.T) {
 	})
 }
 
+// **CUI に hint コマンドすら無かった (#4740)。**interactor が presenter へ
+// 委譲する経路を踏む。
+func TestDurakInteractor_Hint(t *testing.T) {
+	dpMock := new(presenter.MockDurakPresenter)
+	gameMock := new(interfaces.MockDurakGame)
+	dpMock.On("HintOutput", gameMock).Return(`{"hint":{"reason":"attack_weakest"}}`)
+
+	di := usecase.NewDurakInteractor(gameMock, dpMock)
+	assert.Equal(t, `{"hint":{"reason":"attack_weakest"}}`, di.Hint())
+	dpMock.AssertExpectations(t)
+}
+
 func TestDurakInteractor_ActionLog(t *testing.T) {
 	dpMock := new(presenter.MockDurakPresenter)
 	gameMock := new(interfaces.MockDurakGame)

--- a/internal/usecase/presenter/DurakPresenter.go
+++ b/internal/usecase/presenter/DurakPresenter.go
@@ -3,4 +3,8 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // DurakPresenter ドゥラークプレゼンターインタフェース
-type DurakPresenter = GamePresenter[interfaces.DurakGame]
+type DurakPresenter interface {
+	GamePresenter[interfaces.DurakGame]
+	// HintOutput ヒント情報を出力する
+	HintOutput(g interfaces.DurakGame) string
+}

--- a/internal/usecase/presenter/DurakPresenter_mock.go
+++ b/internal/usecase/presenter/DurakPresenter_mock.go
@@ -5,4 +5,12 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // MockDurakPresenter ドゥラークプレゼンターモック
-type MockDurakPresenter = MockGamePresenter[interfaces.DurakGame]
+type MockDurakPresenter struct {
+	MockGamePresenter[interfaces.DurakGame]
+}
+
+// HintOutput モック
+func (_m *MockDurakPresenter) HintOutput(g interfaces.DurakGame) string {
+	ret := _m.Called(g)
+	return ret.Get(0).(string)
+}


### PR DESCRIPTION
## 背景

`DurakCuiPresenter` には `Output` と `ActionLogOutput` しかなく、`OhHellCuiPresenter` / `NinetyNineCuiPresenter` / `TwoTenJackCuiPresenter` にある `HintOutput` がありませんでした。`DurakCuiController` にも `DurakInteractor` にも `hint` は一切登場せず、**CUI にはヒント手段が皆無**でした。

Web も `useDurakGame` からヒント関連を受け取っておらず、唯一の支援はクライアント完結の `getDurakHint`（全ゲーム共通の簡易ヒューリスティック）だけでした (#4740)。

## 変更

#4737（Crazy Eights）と同じ4段のパイプラインをそろえました:

| 段 | 追加したもの |
|---|---|
| domain | `DurakHint` / `GetHint()` |
| CUI | `HintOutput` + 理由キーの対応表、`h` / `hint` コマンド |
| usecase | `Hint()`（interactor IF・実装・モック） |
| Web | `HintOutput`、フックの `useHintRequest`、ページのヒントボタン |

### 推奨手は CPU の選択ロジックをそのまま使います

`cpuFindWeakestAttackCard` / `cpuFindAdditionalAttackCard` / `cpuFindDefenseCard` を呼びます。これらは**状態を変えない純粋な選択関数**なので、そのまま流用できます（`cpuAttack` / `cpuDefend` 本体は盤面を進めてしまうので使いません）。

### 「引き取る」「パス」も助言します

Durak はカードを出せない局面が普通にあります。**そこで黙ると、プレイヤーは手が無いのか判断が付きません。** 防御できる札が無ければ `TakeCards`、追撃できる札が無ければパスを勧めます。

## テスト

**domain**: 推奨手が**実際に `PlayerAttack` を通ること**／CPU 手番では出さない／ゲーム終了フェーズでは出さない

**CUI**: 攻撃 / 防御（どの攻撃を返すかも示す）/ 引き取り / パス / ヒント無し の5分岐

**page**: ヒント要求で推奨カードと理由が出る／**`cardIndex` が無い「引き取る」分岐**／要求前は出さない

**負のコントロール**: `selectHint` を `() => null` に潰すと2件が落ち、戻すと 33 passed。

## 検証

- `go test -tags test ./internal/...` ✅ / `golangci-lint` → `0 issues.` ✅ / `gofmt -l internal/` 空 ✅
- `bun run check` ✅ / `bun run typecheck` ✅ / `DurakPage` 33 passed ✅

Closes #4740