### PR TITLE
feat: wire the Four Card Poker hint into the page

### DIFF
--- a/frontend/src/pages/FourCardPokerPage.test.tsx
+++ b/frontend/src/pages/FourCardPokerPage.test.tsx
@@ -275,7 +275,7 @@ describe('FourCardPokerPage', () => {
     // useGameHint はこのファイルで自動モック済み。既定は hint:null / enabled:false
     // なので、出す側を明示的に作る。
     vi.mocked(useGameHint).mockReturnValue({
-      hint: { targetAction: 'play', reason: 'hint.strong_hand', confidence: 'high' },
+      hint: { targetAction: 'play', reason: 'hint.strong_hand', confidence: 'strong' },
       hintEnabled: true,
       setHintEnabled: vi.fn(),
     });

--- a/frontend/src/pages/FourCardPokerPage.test.tsx
+++ b/frontend/src/pages/FourCardPokerPage.test.tsx
@@ -267,4 +267,38 @@ describe('FourCardPokerPage', () => {
     expect(screen.getByRole('alert')).toHaveTextContent(/残高/);
     expect(screen.getByRole('button', { name: 'ベット' })).toBeDisabled();
   });
+
+  // **ヒントロジックは 132 行のフル実装で hintFactories にも登録済みなのに、
+  // ページが useGameHint を import すらしておらず誰にも使われていなかった
+  // (#4715)。**4枚役特有のフラッシュ>ストレート順位まで踏まえた推奨が死んでいた。
+  it('shows the frontend hint once the toggle is on', async () => {
+    // useGameHint はこのファイルで自動モック済み。既定は hint:null / enabled:false
+    // なので、出す側を明示的に作る。
+    vi.mocked(useGameHint).mockReturnValue({
+      hint: { targetAction: 'play', reason: 'hint.strong_hand', confidence: 'high' },
+      hintEnabled: true,
+      setHintEnabled: vi.fn(),
+    });
+    mockExec.mockResolvedValue(betPhaseState);
+    renderWithProviders(<FourCardPokerPage />);
+
+    await waitFor(() => expect(screen.getByTestId('hint-tooltip')).toBeInTheDocument());
+  });
+
+  // 逆側。既定 (OFF) では出さない。
+  it('shows no hint while the toggle is off', async () => {
+    mockExec.mockResolvedValue(betPhaseState);
+    renderWithProviders(<FourCardPokerPage />);
+
+    await waitFor(() => expect(mockExec).toHaveBeenCalled());
+    expect(screen.queryByTestId('hint-tooltip')).not.toBeInTheDocument();
+  });
+
+  it('offers the hint toggle in the settings panel', async () => {
+    mockExec.mockResolvedValue(betPhaseState);
+    renderWithProviders(<FourCardPokerPage />);
+
+    await waitFor(() => expect(mockExec).toHaveBeenCalled());
+    expect(screen.getByLabelText(/ヒント/)).toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/FourCardPokerPage.tsx
+++ b/frontend/src/pages/FourCardPokerPage.tsx
@@ -11,6 +11,7 @@ import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
+import { FrontendHintTooltip } from '../components/hint/FrontendHintTooltip';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { AnimatedCardBack } from '../components/motion/AnimatedCardBack';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
@@ -20,6 +21,7 @@ import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
+import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useMountReset } from '../hooks/useMountReset';
 import { btnDanger, btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
@@ -31,6 +33,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { FOURCARDPOKER_HELP, parseFourCardPokerCommand } from '../utils/cli/commands/fourcardpokerCommands';
 import { formatFourCardPokerState } from '../utils/cli/formatters/fourcardpokerFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { hintCheckboxItem } from '../utils/settingsItems';
 
 /** Four Card Poker tutorial step definitions. */
 const FCP_TUTORIAL_STEPS: TutorialStep[] = [
@@ -83,6 +86,15 @@ function FourCardPokerPageContent() {
 
   const { cardWidth } = useCardDimensions();
   const { state, loading, error, exec: execApi, retry } = useGameApi(fourcardpokerApi.exec);
+
+  // **ヒントロジックは 132 行のフル実装で hintFactories にも登録済みなのに、
+  // ページが useGameHint を import すらしておらず誰にも使われていなかった
+  // (#4715)。**4枚役特有のフラッシュ>ストレート順位まで踏まえた推奨が死んでいた。
+  const {
+    hint: frontendHint,
+    hintEnabled: frontendHintEnabled,
+    setHintEnabled: setFrontendHintEnabled,
+  } = useGameHint('fourcardpoker', state);
 
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('fourcardpoker');
   const cliConfig: CliGameConfig<FourCardPokerResponse, Parameters<typeof execApi>> = useMemo(
@@ -309,7 +321,11 @@ function FourCardPokerPageContent() {
 
           <GameFooter className={`${gameTheme.fourcardpoker.footer} px-4 pt-3`}>
             <ErrorAlert message={error} onRetry={retry} />
-            <SettingsPanel title={t('settings.title')} groups={[]} />
+            <SettingsPanel
+              title={t('settings.title')}
+              groups={[{ items: [hintCheckboxItem(tc, frontendHintEnabled, setFrontendHintEnabled)] }]}
+            />
+            <FrontendHintTooltip hint={frontendHint} enabled={frontendHintEnabled} t={t} />
             {isBetPhase && (
               <div className="flex flex-col items-center gap-2 pb-2" data-tutorial="fcp-bet-controls">
                 <ChipBetInput


### PR DESCRIPTION
## 背景

`getFourCardPokerHint` は **132 行のフル実装**で、BET フェーズのアンテ推奨と ACTION フェーズのプレイ倍率（fold / play-1 / play-3）推奨を、**4枚役特有のフラッシュ > ストレート順位**まで踏まえて計算しています。`hintFactories` にも `fourcardpoker` として正しく登録済みです。

ところが `FourCardPokerPage.tsx` は `useGameHint` を **import すらしておらず**、`FrontendHintTooltip` も描画していませんでした (#4715)。フル実装のロジックが誰にも使われていない状態です。

`SettingsPanel` は `groups={[]}` と中身が空でした。

## 変更

- `useGameHint('fourcardpoker', state)` を配線
- 空だった設定パネルにヒントのトグル（`hintCheckboxItem`）を追加
- `FrontendHintTooltip` を描画

## テスト

- トグル ON でツールチップが出る
- 既定（OFF）では出ない
- 設定パネルにトグルが存在する

このファイルは `useGameHint` を自動モックしているため、素直に `localStorage` を立てても出ません。**モックの戻り値を明示的に作って**踏んでいます（そうしないと「常に出ない」実装でも通ってしまいます）。

**負のコントロール**: ツールチップを消すと1件、チェックボックスを消すと1件が落ちます（それぞれ独立に効いていることの確認）。

## 検証

- `bun run check` ✅（`hint-coverage` / `hint-gate` を含む）/ `bun run typecheck` ✅ / 21 passed ✅

なお issue は CUI 側の `HintOutput` 不在にも触れていますが、そちらはサーバー実装の新設（#4737 / #4740 と同規模）になるため、本 PR ではフロントの死んでいた配線に絞りました。

Closes #4715