### PR TITLE
feat: wire the Russian Poker hint into the page

### DIFF
--- a/frontend/src/pages/RussianPokerPage.test.tsx
+++ b/frontend/src/pages/RussianPokerPage.test.tsx
@@ -43,6 +43,9 @@ function makeState(overrides: Partial<RussianPokerResponse> = {}): RussianPokerR
 }
 
 beforeEach(() => {
+  // **ヒントのトグルは localStorage に残る。**消さないと前のテストの状態を
+  // 引き継いで、以降のアサーションが何も確かめなくなる。
+  localStorage.removeItem('hint_enabled_russianpoker');
   mockExec.mockReset();
   mockExec.mockResolvedValue(makeState());
 });
@@ -184,5 +187,30 @@ describe('RussianPokerPage', () => {
     fireEvent.change(anteInput, { target: { value: '15' } });
     expect(screen.getByRole('alert')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'ベット' })).toBeDisabled();
+  });
+
+  // **ヒントロジックは実装済みで hintFactories にも登録されているのに、ページが
+  // useGameHint を import すらしておらず誰にも使われていなかった (#4716)。**
+  // 5 フェーズの複雑な意思決定を持つゲームなのに支援が皆無だった。
+  it('shows the frontend hint on the action phase once the toggle is on', async () => {
+    localStorage.setItem('hint_enabled_russianpoker', 'true');
+    renderWithProviders(<RussianPokerPage />);
+
+    await waitFor(() => expect(screen.getByTestId('hint-tooltip')).toBeInTheDocument());
+  });
+
+  // 逆側。既定 (OFF) では出さない。
+  it('shows no hint while the toggle is off', async () => {
+    renderWithProviders(<RussianPokerPage />);
+
+    await waitFor(() => expect(mockExec).toHaveBeenCalled());
+    expect(screen.queryByTestId('hint-tooltip')).not.toBeInTheDocument();
+  });
+
+  it('offers the hint toggle in the settings panel', async () => {
+    renderWithProviders(<RussianPokerPage />);
+
+    await waitFor(() => expect(mockExec).toHaveBeenCalled());
+    expect(screen.getByLabelText(/ヒント/)).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/RussianPokerPage.tsx
+++ b/frontend/src/pages/RussianPokerPage.tsx
@@ -11,6 +11,7 @@ import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
+import { FrontendHintTooltip } from '../components/hint/FrontendHintTooltip';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { AnimatedCardBack } from '../components/motion/AnimatedCardBack';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
@@ -21,6 +22,7 @@ import { useCardKeyboardNav } from '../hooks/useCardKeyboardNav';
 import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
+import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useMountReset } from '../hooks/useMountReset';
 import { btnDanger, btnPrimary, btnSecondary, btnSuccess, btnWarning } from '../styles/buttonStyles';
@@ -34,6 +36,7 @@ import { cardAlt } from '../utils/cardAlt';
 import { parseRussianpokerCommand, RUSSIANPOKER_HELP } from '../utils/cli/commands/russianpokerCommands';
 import { formatRussianpokerState } from '../utils/cli/formatters/russianpokerFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { hintCheckboxItem } from '../utils/settingsItems';
 
 /** Russian Poker tutorial step definitions. */
 const RUSSIAN_TUTORIAL_STEPS: TutorialStep[] = [
@@ -90,6 +93,15 @@ function RussianPokerPageContent() {
 
   const { cardWidth } = useCardDimensions();
   const { state, loading, error, exec: execApi, retry } = useGameApi(russianpokerApi.exec);
+
+  // **ヒントロジックは実装済みで hintFactories にも登録されているのに、
+  // ページが useGameHint を import すらしておらず誰にも使われていなかった
+  // (#4716)。**5 フェーズの複雑な意思決定を持つゲームなのに支援が皆無だった。
+  const {
+    hint: frontendHint,
+    hintEnabled: frontendHintEnabled,
+    setHintEnabled: setFrontendHintEnabled,
+  } = useGameHint('russianpoker', state);
 
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('russianpoker');
   const cliConfig: CliGameConfig<RussianPokerResponse, Parameters<typeof russianpokerApi.exec>> = useMemo(
@@ -425,7 +437,11 @@ function RussianPokerPageContent() {
 
           <GameFooter className={`${gameTheme.russianpoker.footer} px-4 pt-3`}>
             <ErrorAlert message={error} onRetry={retry} />
-            <SettingsPanel title={t('settings.title')} groups={[]} />
+            <SettingsPanel
+              title={t('settings.title')}
+              groups={[{ items: [hintCheckboxItem(tc, frontendHintEnabled, setFrontendHintEnabled)] }]}
+            />
+            <FrontendHintTooltip hint={frontendHint} enabled={frontendHintEnabled} t={t} />
             {isBetPhase && (
               <div className="flex flex-col items-center gap-2 pb-2" data-tutorial="russian-bet-controls">
                 <ChipBetInput


### PR DESCRIPTION
## 背景

`getRussianPokerHint` は ACTION / POST_ACTION フェーズで「ペア以上、または A-K ハイなら play、それ以外は fold」を返す実装済みロジックで、`hintFactories` にも登録済みです。

ところが `RussianPokerPage.tsx` は `useGameHint` を **import すらしておらず**、`HintTooltip` / `FrontendHintTooltip` も描画していませんでした (#4716)。

このゲームは **BET / ACTION / SELECT / POST_ACTION / FORCE_QUALIFY の5フェーズ**を持ち、交換枚数の選択・6th card 購入・force qualify のコスト判断と意思決定が複雑なのに、支援が皆無でした。`SettingsPanel` も `groups={[]}` と空でした。

## 変更

#4715（Four Card Poker）と同型です。

- `useGameHint('russianpoker', state)` を配線
- 空だった設定パネルにヒントのトグルを追加
- `FrontendHintTooltip` を描画

## テスト

- トグル ON で ACTION フェーズにツールチップが出る
- 既定（OFF）では出ない
- 設定パネルにトグルが存在する

**トグルが localStorage に残って次のテストを汚していました。** 「OFF では出ない」が前のテストの ON を引き継いで落ちたので、`beforeEach` で消しています。これが無いと、以降のアサーションが何も確かめません。

**負のコントロール**: ツールチップを消すと1件、チェックボックスを消すと1件が落ちます（それぞれ独立に効いていることの確認）。

## 検証

- `bun run check` ✅ / `bun run typecheck` ✅ / 17 passed ✅

issue は CUI 側の `HintOutput` 不在にも触れていますが、そちらはサーバー実装の新設（#4737 / #4740 と同規模）になるため、本 PR ではフロントの死んでいた配線に絞りました。

Closes #4716