### PR TITLE
fix: count the ace in the Indian Poker equity calculation

### DIFF
--- a/frontend/src/utils/indianPokerEquity.test.ts
+++ b/frontend/src/utils/indianPokerEquity.test.ts
@@ -6,33 +6,53 @@ describe('computeIndianPokerEquity', () => {
     expect(computeIndianPokerEquity([])).toBe(1);
   });
 
-  it('returns 0 when the only opponent shows a King (no rank above)', () => {
-    // Max opp = 13; ranks above = 0; remaining = 51; equity = 0/51 = 0.
-    expect(computeIndianPokerEquity([13])).toBe(0);
+  // **K は最強ではない。**ドメインがエースを 14 にリマップするので、K の上に
+  // A が 4 枚ある (#4690)。以前ここは 0 を期待しており、バグを固定していた。
+  it('returns the ace count when the only opponent shows a King', () => {
+    expect(computeIndianPokerEquity([13])).toBeCloseTo(4 / 51, 10);
   });
 
   it('returns a high equity when the only opponent shows a 2', () => {
-    // Max opp = 2; ranks above = 11 ranks × 4 = 44; remaining = 51.
+    // Max opp = 2; ranks above = 3..14 の 12 ランク × 4 = 48; remaining = 51。
     const eq = computeIndianPokerEquity([2]);
-    expect(eq).toBeCloseTo(44 / 51, 6);
+    expect(eq).toBeCloseTo(48 / 51, 6);
   });
 
   it('subtracts visible cards in the above-max range', () => {
-    // Three opponents: 10, 11, 12. Max = 12. Above = K(4 copies) only.
-    // No visible above-max cards, so above = 4. Remaining = 52 - 3 = 49.
-    expect(computeIndianPokerEquity([10, 11, 12])).toBeCloseTo(4 / 49, 6);
+    // Three opponents: 10, 11, 12. Max = 12. Above = K と A で 8 枚。
+    // 場に見えている above-max は無いので 8。Remaining = 52 - 3 = 49。
+    expect(computeIndianPokerEquity([10, 11, 12])).toBeCloseTo(8 / 49, 6);
   });
 
   it('ignores invalid rank values', () => {
-    expect(computeIndianPokerEquity([0, 14, NaN, 5])).toBeCloseTo(
-      // Only "5" is valid; max = 5; above = 8 ranks × 4 = 32; remaining = 51.
-      32 / 51,
-      6,
-    );
+    // **14 はもう有効値。**範囲外は 1 未満と 15 以上 (エースは 14 に来るので
+    // 1 は決して現れない)。max = 5; above = 6..14 の 9 ランク × 4 = 36。
+    expect(computeIndianPokerEquity([1, 15, NaN, 5])).toBeCloseTo(36 / 51, 6);
   });
 
   it('returns 0 when every remaining card is at or below the opponent max', () => {
-    // Two opponents with 13 each (theoretical edge case in larger deck).
-    expect(computeIndianPokerEquity([13, 13])).toBe(0);
+    // 2 人とも A(14) を見せている = これを超える札は無い。
+    expect(computeIndianPokerEquity([14, 14])).toBe(0);
+  });
+
+  // **ドメインはエースを 14 にリマップしている (indianPokerCardRank)。**
+  // ところがここは 1..13 で弾いていたので、相手のエースが「無効値」として
+  // 計算から丸ごと外れ、最も危険な場面ほど勝率を高く見せていた (#4690)。
+  it('counts an opponent ace instead of discarding it', () => {
+    // 相手がエース(14)1枚。これを超える札は存在しないので勝率 0。
+    expect(computeIndianPokerEquity([14])).toBe(0);
+  });
+
+  it('does not let an ace inflate the equity of a lower opponent', () => {
+    // K(13) と A(14)。A を無視すると「K 超え = A の4枚」で 4/50 になるが、
+    // 正しくは A を超える札が無いので 0。
+    expect(computeIndianPokerEquity([13, 14])).toBe(0);
+  });
+
+  // **14 を勝ち筋としても数える。**フィルタだけ直してループ上限が 13 のままだと、
+  // 相手が K のとき「A で勝てる」が数えられず勝率 0 になる。
+  it('counts aces as winning cards when the opponent shows a king', () => {
+    // 相手 K(13) 1枚 → 勝てるのは A の4枚。残り 51 枚。
+    expect(computeIndianPokerEquity([13])).toBeCloseTo(4 / 51, 10);
   });
 });

--- a/frontend/src/utils/indianPokerEquity.ts
+++ b/frontend/src/utils/indianPokerEquity.ts
@@ -7,16 +7,21 @@
  * highest opponent (cards are unique within a deck, but a defensive guard
  * still treats `>` strictly).
  *
- * Card ranks 1..13 each have 4 copies in a 52-card deck. After removing the
+ * **ランクは 2..14。**ドメインの `indianPokerCardRank` がエース(1) を 14 に
+ * リマップして返すので、1 は決して来ず 14 が最強になる。ここを 1..13 で
+ * 弾いていたため、相手のエースが無効値として計算から丸ごと外れ、最も危険な
+ * 場面ほど勝率を高く見せていた (#4690)。
+ *
+ * Card ranks 2..14 each have 4 copies in a 52-card deck. After removing the
  * opponents' visible cards, the remaining 52 - N cards are equally likely.
  * Equity = (# remaining cards strictly above the max opponent rank) / (52 - N).
  *
- * @param opponentRanks Visible opponent card ranks (1..13). Empty/invalid
+ * @param opponentRanks Visible opponent card ranks (2..14; ace is 14). Empty/invalid
  *   input yields equity = 1 (a no-opponent scenario is a guaranteed win).
  * @returns Equity in [0, 1].
  */
 export function computeIndianPokerEquity(opponentRanks: readonly number[]): number {
-  const valid = opponentRanks.filter((r) => Number.isInteger(r) && r >= 1 && r <= 13);
+  const valid = opponentRanks.filter((r) => Number.isInteger(r) && r >= 2 && r <= 14);
   if (valid.length === 0) return 1;
   const maxOpp = Math.max(...valid);
 
@@ -25,7 +30,7 @@ export function computeIndianPokerEquity(opponentRanks: readonly number[]): numb
     rankCounts.set(r, (rankCounts.get(r) ?? 0) + 1);
   }
   let above = 0;
-  for (let r = maxOpp + 1; r <= 13; r += 1) {
+  for (let r = maxOpp + 1; r <= 14; r += 1) {
     above += 4 - (rankCounts.get(r) ?? 0);
   }
   const remaining = 52 - valid.length;


### PR DESCRIPTION
## 背景

`indianPokerCardRank`（domain）は**エース(1) を 14 にリマップ**して返し、その値がそのまま API レスポンスの `cardRank` に乗ります。

ところが `computeIndianPokerEquity` は入力を `r >= 1 && r <= 13` で弾いていたため、**相手のエースが「無効値」として計算から丸ごと外れて**いました (#4690)。

結果、**相手が最強札を見せている最も危険な場面ほど、エクイティメーターとヒントが実際より高い勝率を表示する**という壊れ方をしていました。

## フィルタだけでは足りません

勝ち筋を数える内部ループも `r <= 13` 止まりで、**「K に対して A で勝てる」を数えられません**。両方を 14 に直しています。

## テスト

先に失敗するテストを書いて RED を確認しました:

| 入力 | 修正前 | 修正後 |
|---|---|---|
| `[14]`（相手が A） | A を無視 → 勝率が出る | **0** |
| `[13]`（相手が K） | 0 | **4/51**（A 4枚で勝てる） |

**既存テスト5件が「K が最強」という旧前提を固定していました。** 単に期待値を合わせるのではなく、1件ずつ算術を計算し直しています:

- `[2]`: above = 3..14 の 12 ランク × 4 = **48**/51（旧 44/51）
- `[10,11,12]`: above = K と A で **8**/49（旧 4/49）
- 無効値のテスト: `14` はもう有効なので `1` と `15` に差し替え（エースは 14 に来るので 1 は決して現れない）
- `[13,13]` → `[14,14]`: 「これを超える札が無い」局面を正しく表す

**負のコントロール**: 旧実装（1..13）に戻すと **7件**が落ちます。

## 検証

- `bun run check` ✅ / `bun run typecheck` ✅ / `indianPokerEquity` + `IndianPokerPage` 88 passed ✅

Closes #4690