### PR TITLE
fix: stop a non-paying pair from burying a royal or flush draw

### DIFF
--- a/frontend/src/utils/hints/videoPokerBaseHint.test.ts
+++ b/frontend/src/utils/hints/videoPokerBaseHint.test.ts
@@ -229,4 +229,78 @@ describe('getVideoPokerBaseHint', () => {
     expect(result?.confidence).toBe('strong');
     expect(result?.targetAction).toContain('0');
   });
+
+  // **配当のつかない低いペアが、強いドローを潰していた (#4691)。**ペア判定が
+  // 最初に無条件でヒットするため、4枚ロイヤル・4枚フラッシュが同居しても
+  // 常に弱いペアが推奨されていた。
+  //
+  // 順序は Jacks or Better の標準戦略に合わせる:
+  //   4枚ロイヤル > 4枚フラッシュ > 低いペア > 4枚ストレート
+  // **issue は「3つのドローすべてを低ペアより優先」としているが、それは誤り。**
+  // 標準戦略では低ペアは4枚ストレートより上に来る。
+  describe('draw versus low pair ordering (Jacks or Better)', () => {
+    const hint = (cards: Card[]) => getVideoPokerBaseHint(makeState({ hand: cards }), noWild);
+
+    it('prefers a four-card royal draw over a non-paying pair', () => {
+      // ♠10 J Q K + ♥10 → 10 のペアがあるが、4枚ロイヤルの方が遥かに強い。
+      const h = hint([
+        makeCard('SPADE', 10),
+        makeCard('SPADE', 11),
+        makeCard('SPADE', 12),
+        makeCard('SPADE', 13),
+        makeCard('HEART', 10),
+      ]);
+      expect(h?.reason).toBe('hint.holdRoyalDraw');
+    });
+
+    it('prefers a four-card flush over a non-paying pair', () => {
+      // ♠3 5 8 K + ♥3 → 3 のペアより 4枚フラッシュ。
+      const h = hint([
+        makeCard('SPADE', 3),
+        makeCard('SPADE', 5),
+        makeCard('SPADE', 8),
+        makeCard('SPADE', 13),
+        makeCard('HEART', 3),
+      ]);
+      expect(h?.reason).toBe('hint.holdFlushDraw');
+    });
+
+    // **逆側。**低ペアは4枚ストレートより上。ここを一緒くたに「ドロー優先」と
+    // すると、標準戦略から外れる方向に壊れる。
+    it('keeps a low pair over a four-card straight', () => {
+      // ♠4 5 6 7 + ♥4 → 4枚ストレートより 4 のペア。
+      const h = hint([
+        makeCard('SPADE', 4),
+        makeCard('SPADE', 5),
+        makeCard('HEART', 6),
+        makeCard('CLOVER', 7),
+        makeCard('HEART', 4),
+      ]);
+      expect(h?.reason).toBe('hint.holdPair');
+    });
+
+    // 配当のつくペア (J 以上) は据え置き。4枚フラッシュより上。
+    it('keeps a paying high pair over a four-card flush', () => {
+      const h = hint([
+        makeCard('SPADE', 12),
+        makeCard('SPADE', 5),
+        makeCard('SPADE', 8),
+        makeCard('SPADE', 3),
+        makeCard('HEART', 12),
+      ]);
+      expect(h?.reason).toBe('hint.holdPair');
+    });
+
+    // 3カード以上は無条件で据え置き (ドローより強い)。
+    it('keeps trips over any draw', () => {
+      const h = hint([
+        makeCard('SPADE', 4),
+        makeCard('HEART', 4),
+        makeCard('CLOVER', 4),
+        makeCard('SPADE', 8),
+        makeCard('SPADE', 9),
+      ]);
+      expect(h?.reason).toBe('hint.holdTrips');
+    });
+  });
 });

--- a/frontend/src/utils/hints/videoPokerBaseHint.ts
+++ b/frontend/src/utils/hints/videoPokerBaseHint.ts
@@ -47,8 +47,13 @@ function getStandardHint(hand: Card[]): HintResult {
     .filter((indices) => indices.length >= 2)
     .flat();
 
-  if (allGroupIndices.length > 0) {
-    const maxCount = Math.max(...Array.from(groups.values()).map((g) => g.length));
+  const maxCount = allGroupIndices.length > 0 ? Math.max(...Array.from(groups.values()).map((g) => g.length)) : 0;
+  // **配当のつくペアかどうかで扱いが変わる。**Jacks or Better では J 未満の
+  // ペア単体には配当が無い。以前はこの分岐が無条件に最初へ来ていたため、
+  // 4枚ロイヤルや4枚フラッシュが同居していても常に弱いペアを勧めていた (#4691)。
+  const isPayingGroup = maxCount >= 3 || (maxCount === 2 && hasPayingPair(groups));
+
+  if (allGroupIndices.length > 0 && isPayingGroup) {
     const reason = maxCount >= 4 ? 'hint.holdQuads' : maxCount >= 3 ? 'hint.holdTrips' : 'hint.holdPair';
     return {
       targetAction: formatHoldAction(allGroupIndices, []),
@@ -57,10 +62,26 @@ function getStandardHint(hand: Card[]): HintResult {
     };
   }
 
-  // Check flush draw (4+ same suit)
+  // **4枚ロイヤルは低ペアより遥かに強い。**標準戦略ではフルハウスより上に来る。
+  const royalDraw = findRoyalDraw(hand);
+  if (royalDraw) {
+    return { targetAction: formatHoldAction(royalDraw, []), reason: 'hint.holdRoyalDraw', confidence: 'strong' };
+  }
+
+  // Check flush draw (4+ same suit) -- 標準戦略で低ペアより上。
   const flushDraw = findFlushDraw(hand);
   if (flushDraw) {
     return { targetAction: formatHoldAction(flushDraw, []), reason: 'hint.holdFlushDraw', confidence: 'moderate' };
+  }
+
+  // **低ペアは4枚ストレートより上。**ここを「ドロー優先」で一括りにすると、
+  // 標準戦略から外れる方向に壊れる。
+  if (allGroupIndices.length > 0) {
+    return {
+      targetAction: formatHoldAction(allGroupIndices, []),
+      reason: 'hint.holdPair',
+      confidence: 'moderate',
+    };
   }
 
   // Check straight draw (4+ sequential)
@@ -95,6 +116,41 @@ function groupByValue(hand: Card[]): Map<number, number[]> {
 }
 
 /** Find 4+ cards of the same suit (flush draw). */
+/**
+ * 配当のつくペア (J 以上、またはエース) を含むかどうか。
+ *
+ * `groupByValue` はカードの値をキーにするので、キーをそのまま見れば足りる。
+ * エースは実装によって 1 と 14 のどちらでも来るため両方を受ける。
+ */
+function hasPayingPair(groups: Map<number, number[]>): boolean {
+  for (const [value, indices] of groups) {
+    if (indices.length >= 2 && (value >= HIGH_CARD_THRESHOLD || value === 1 || value === ACE_HIGH)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** 同一スートで 10-J-Q-K-A のうち 4 枚そろっているか。 */
+function findRoyalDraw(hand: Card[]): number[] | null {
+  const bySuit = new Map<string, number[]>();
+  for (let i = 0; i < hand.length; i++) {
+    const v = hand[i].value;
+    const isRoyalRank = v >= 10 || v === 1 || v === ACE_HIGH;
+    if (!isRoyalRank) continue;
+    const arr = bySuit.get(hand[i].design) ?? [];
+    arr.push(i);
+    bySuit.set(hand[i].design, arr);
+  }
+  for (const indices of bySuit.values()) {
+    // 同じランクの重複は royal を構成しない。
+    const uniq = new Map<number, number>();
+    for (const i of indices) uniq.set(hand[i].value, i);
+    if (uniq.size >= FLUSH_DRAW_COUNT) return Array.from(uniq.values()).sort((a, b) => a - b);
+  }
+  return null;
+}
+
 function findFlushDraw(hand: Card[]): number[] | null {
   const suits = new Map<string, number[]>();
   for (let i = 0; i < hand.length; i++) {

--- a/internal/adapter/presenter/VideoPokerCuiPresenter.go
+++ b/internal/adapter/presenter/VideoPokerCuiPresenter.go
@@ -205,7 +205,20 @@ func videoPokerHold(hand []*domain.Card, variant string) ([]bool, string) {
 			}
 		}
 	}
-	if len(groupIdx) > 0 {
+	// **配当のつくペアかどうかで扱いが変わる。**Jacks or Better では J 未満の
+	// ペア単体には配当が無い。以前はこの分岐が無条件に最初へ来ていたため、
+	// 4枚ロイヤルや4枚フラッシュが同居していても常に弱いペアを勧めていた (#4691)。
+	paying := maxCount >= 3
+	if maxCount == 2 {
+		for v, idxs := range groups {
+			if len(idxs) >= 2 && (v == 1 || v >= videoPokerHighCardThreshold) {
+				paying = true
+				break
+			}
+		}
+	}
+
+	if len(groupIdx) > 0 && paying {
 		for _, i := range groupIdx {
 			hold[i] = true
 		}
@@ -219,12 +232,29 @@ func videoPokerHold(hand []*domain.Card, variant string) ([]bool, string) {
 		}
 	}
 
-	// Four-card flush draw.
+	// **4枚ロイヤルは低ペアより遥かに強い。**標準戦略ではフルハウスより上に来る。
+	if rd := videoPokerRoyalDraw(hand); rd != nil {
+		for _, i := range rd {
+			hold[i] = true
+		}
+		return hold, "holdRoyalDraw"
+	}
+
+	// Four-card flush draw -- 標準戦略で低ペアより上。
 	if fd := videoPokerFlushDraw(hand); fd != nil {
 		for _, i := range fd {
 			hold[i] = true
 		}
 		return hold, "holdFlushDraw"
+	}
+
+	// **低ペアは4枚ストレートより上。**ここを「ドロー優先」で一括りにすると、
+	// 標準戦略から外れる方向に壊れる。
+	if len(groupIdx) > 0 {
+		for _, i := range groupIdx {
+			hold[i] = true
+		}
+		return hold, "holdPair"
 	}
 
 	// Four-card straight draw.
@@ -273,6 +303,35 @@ func videoPokerGroupIndices(hand []*domain.Card, variant string) []int {
 
 // videoPokerFlushDraw returns the indices of four or more same-suit cards, or
 // nil if none.
+// videoPokerRoyalDraw は同一スートで 10-J-Q-K-A のうち 4 枚そろっていれば
+// その位置を返す。同じランクの重複はロイヤルを構成しないので除く。
+func videoPokerRoyalDraw(hand []*domain.Card) []int {
+	bySuit := map[int]map[int]int{}
+	for i, c := range hand {
+		v := c.GetValue()
+		if v != 1 && v < 10 {
+			continue
+		}
+		d := c.GetDesign()
+		if bySuit[d] == nil {
+			bySuit[d] = map[int]int{}
+		}
+		bySuit[d][v] = i
+	}
+	for _, byRank := range bySuit {
+		if len(byRank) < videoPokerDrawCount {
+			continue
+		}
+		out := make([]int, 0, len(byRank))
+		for _, i := range byRank {
+			out = append(out, i)
+		}
+		sort.Ints(out)
+		return out
+	}
+	return nil
+}
+
 func videoPokerFlushDraw(hand []*domain.Card) []int {
 	suits := map[int][]int{}
 	for i, c := range hand {

--- a/internal/adapter/presenter/VideoPokerCuiPresenter_test.go
+++ b/internal/adapter/presenter/VideoPokerCuiPresenter_test.go
@@ -399,6 +399,61 @@ func TestVideoPokerCuiPresenter_HintOutput(t *testing.T) {
 		assert.NotContains(t, out, "[2]")
 	})
 
+	// **配当のつかない低いペアが、強いドローを潰していた (#4691)。**ペア判定が
+	// 最初に無条件でヒットするため、4枚ロイヤル・4枚フラッシュが同居しても
+	// 常に弱いペアを勧めていた。順序は Jacks or Better の標準戦略に合わせる:
+	//   4枚ロイヤル > 4枚フラッシュ > 低いペア > 4枚ストレート
+	t.Run("jacks or better prefers a royal draw over a non-paying pair", func(t *testing.T) {
+		hand := []*domain.Card{
+			domain.NewCard(domain.CardDesignSpade, 10, false),
+			domain.NewCard(domain.CardDesignSpade, 11, false),
+			domain.NewCard(domain.CardDesignSpade, 12, false),
+			domain.NewCard(domain.CardDesignSpade, 13, false),
+			domain.NewCard(domain.CardDesignHeart, 10, false),
+		}
+		out := p.HintOutput(drawGame("jacksorbetter", hand))
+		assert.Contains(t, out, i18n.T("videopoker.holdRoyalDraw"))
+	})
+
+	t.Run("jacks or better prefers a flush draw over a non-paying pair", func(t *testing.T) {
+		hand := []*domain.Card{
+			domain.NewCard(domain.CardDesignSpade, 3, false),
+			domain.NewCard(domain.CardDesignSpade, 5, false),
+			domain.NewCard(domain.CardDesignSpade, 8, false),
+			domain.NewCard(domain.CardDesignSpade, 13, false),
+			domain.NewCard(domain.CardDesignHeart, 3, false),
+		}
+		out := p.HintOutput(drawGame("jacksorbetter", hand))
+		assert.Contains(t, out, i18n.T("videopoker.holdFlushDraw"))
+	})
+
+	// **逆側。**低ペアは4枚ストレートより上。ここを一緒くたに「ドロー優先」と
+	// すると、標準戦略から外れる方向に壊れる。
+	t.Run("jacks or better keeps a low pair over a straight draw", func(t *testing.T) {
+		hand := []*domain.Card{
+			domain.NewCard(domain.CardDesignSpade, 4, false),
+			domain.NewCard(domain.CardDesignSpade, 5, false),
+			domain.NewCard(domain.CardDesignHeart, 6, false),
+			domain.NewCard(domain.CardDesignClover, 7, false),
+			domain.NewCard(domain.CardDesignHeart, 4, false),
+		}
+		out := p.HintOutput(drawGame("jacksorbetter", hand))
+		assert.Contains(t, out, i18n.T("videopoker.holdPair"))
+	})
+
+	// 配当のつくペア (J 以上) は据え置き。4枚フラッシュより上。
+	t.Run("jacks or better keeps a paying high pair over a flush draw", func(t *testing.T) {
+		hand := []*domain.Card{
+			domain.NewCard(domain.CardDesignSpade, 12, false),
+			domain.NewCard(domain.CardDesignSpade, 5, false),
+			domain.NewCard(domain.CardDesignSpade, 8, false),
+			domain.NewCard(domain.CardDesignSpade, 3, false),
+			domain.NewCard(domain.CardDesignHeart, 12, false),
+		}
+		out := p.HintOutput(drawGame("jacksorbetter", hand))
+		assert.Contains(t, out, i18n.T("videopoker.holdPair"))
+	})
+
 	t.Run("jacks or better holds a flush draw", func(t *testing.T) {
 		hand := []*domain.Card{
 			domain.NewCard(domain.CardDesignSpade, 3, false),

--- a/internal/i18n/locales/en/videopoker.json
+++ b/internal/i18n/locales/en/videopoker.json
@@ -41,5 +41,6 @@
   "ptThreeOfAKind": "Three of a Kind",
   "ptTwoPair": "Two Pair",
   "ptJacksOrBetter": "Jacks or Better",
-  "ptKingsOrBetter": "Kings or Better"
+  "ptKingsOrBetter": "Kings or Better",
+  "holdRoyalDraw": "Hold four to a royal flush"
 }

--- a/internal/i18n/locales/ja/videopoker.json
+++ b/internal/i18n/locales/ja/videopoker.json
@@ -41,5 +41,6 @@
   "ptThreeOfAKind": "スリーカード",
   "ptTwoPair": "ツーペア",
   "ptJacksOrBetter": "ジャックス・オア・ベター",
-  "ptKingsOrBetter": "キングス・オア・ベター"
+  "ptKingsOrBetter": "キングス・オア・ベター",
+  "holdRoyalDraw": "ロイヤルフラッシュへの4枚を残す"
 }


### PR DESCRIPTION
## 背景

`getStandardHint`（TS）と `videoPokerHold`（Go）は、まず手札に2枚以上そろったランクがあるかを見て、**あれば即座に `holdPair` を返します**。この判定は Jacks or Better で**配当のつかない 2〜10 のペアにも無条件でヒット**し、後続の4枚フラッシュ・4枚ストレートの判定に到達できません。ロイヤルドロー専用の分岐もありませんでした (#4691)。

結果、**配当のつかない低いペアと、ロイヤル/フラッシュに4枚そろった強いドローが同居すると、常に弱い方が推奨される**状態でした。

## issue の提案を一部訂正しています

issue は「4枚のロイヤル/フラッシュ/**ストレート**を低ペアより優先する」としていますが、**これはそのまま実装すると別の誤りになります。**

Jacks or Better の標準戦略では **低ペアは4枚ストレートより上**です:

```
… 4枚フラッシュ > 低ペア > 4枚オープンエンドストレート …
```

そこで正しい順序に直しました:

| 優先度 | 手 |
|---|---|
| 1 | 3カード以上 / 配当のつくペア（J 以上・A） |
| 2 | **4枚ロイヤル** |
| 3 | **4枚フラッシュ** |
| 4 | 低いペア |
| 5 | 4枚ストレート |

## テスト（TS・Go 同じ4ケース）

- 4枚ロイヤル + 10 のペア → **ロイヤルドロー**
- 4枚フラッシュ + 3 のペア → **フラッシュドロー**
- **4枚ストレート + 4 のペア → ペア**（逆側。ここを「ドロー優先」で一括りにすると標準戦略から外れる方向に壊れる）
- 4枚フラッシュ + Q のペア → **ペア**（配当のつくペアは据え置き）

**負のコントロール**: TS は旧実装で2件、Go は `paying` を常に true（旧挙動）にして2件が落ちます。

Go 側の負のコントロールは最初 0 件と出ましたが、これは `paying` が未使用になってビルドが落ちていただけで、テストが通っていたわけではありませんでした。判定式だけを差し替える形に直して確認しています。

## 検証

- `go test -tags test ./internal/...` ✅ / `golangci-lint` → `0 issues.` ✅ / `gofmt -l internal/` 空 ✅
- `bun run check` ✅ / `bun run typecheck` ✅ / `videoPokerBaseHint` 21 passed ✅

Closes #4691