### PR TITLE
fix: resolve the human seat in the Napoleon CUI hint display

### DIFF
--- a/internal/adapter/presenter/NapoleonCuiPresenter.go
+++ b/internal/adapter/presenter/NapoleonCuiPresenter.go
@@ -194,13 +194,15 @@ func (p *NapoleonCuiPresenter) HintOutput(n interfaces.NapoleonGame) string {
 			"suit", napoleonSuitGlyphs[*hint.TrumpSuit],
 			"reason", reason)) + "\n"
 	case hint.DiscardIndex != nil:
-		card := n.GetPlayer(0).GetCard(*hint.DiscardIndex)
+		// **人間が席 0 とは限らない。**ヒントの数値自体はドメインが
+		// findHumanIdx で解決しているのに、表示だけが決め打ちだった (#4689)。
+		card := n.GetPlayer(n.GetHumanIdx()).GetCard(*hint.DiscardIndex)
 		return color.Yellow(i18n.Tf("napoleon.hintDiscard",
 			"idx", strconv.Itoa(*hint.DiscardIndex),
 			"card", napoleonCuiCardStr(card),
 			"reason", reason)) + "\n"
 	case hint.CardIndex != nil:
-		card := n.GetPlayer(0).GetCard(*hint.CardIndex)
+		card := n.GetPlayer(n.GetHumanIdx()).GetCard(*hint.CardIndex)
 		return color.Yellow(i18n.Tf("napoleon.hintCard",
 			"idx", strconv.Itoa(*hint.CardIndex),
 			"card", napoleonCuiCardStr(card),

--- a/internal/adapter/presenter/NapoleonCuiPresenter_test.go
+++ b/internal/adapter/presenter/NapoleonCuiPresenter_test.go
@@ -454,12 +454,43 @@ func TestNapoleonCuiPresenter_HintOutput(t *testing.T) {
 		player.AddCard(domain.NewCard(domain.CardDesignDiamond, 10, false))
 		player.AddCard(domain.NewCard(domain.CardDesignHeart, 3, false))
 		m.On("GetPlayer", 0).Return(player)
+		m.On("GetHumanIdx").Return(0)
 
 		p := new(presenter.NapoleonCuiPresenter)
 		result := p.HintOutput(m)
 		assert.Contains(t, result, "HINT")
 		assert.Contains(t, result, "を捨てる")
 		assert.Contains(t, result, "戦略的な捨て")
+	})
+
+	// **人間が席 0 とは限らない。**ヒントの数値自体はドメインが findHumanIdx で
+	// 解決しているのに、表示だけが GetPlayer(0) を決め打ちしていた (#4689)。
+	// コンストラクタは任意の並び順を受け付けるので、席がずれると別人の手札を
+	// 見て「これを捨てろ」と言うことになる。
+	t.Run("resolves the human seat instead of assuming index 0", func(t *testing.T) {
+		idx := 1
+		m := new(interfaces.MockNapoleonGame)
+		m.On("GetHint").Return(&domain.NapoleonHint{DiscardIndex: &idx, Reason: "strategic_discard"})
+
+		// 席 2 が人間。席 0 には別人の手札を置く。
+		human := domain.NewNapoleonPlayer(true)
+		human.Reset()
+		human.AddCard(domain.NewCard(domain.CardDesignSpade, 1, false))
+		human.AddCard(domain.NewCard(domain.CardDesignHeart, 7, false))
+
+		other := domain.NewNapoleonPlayer(false)
+		other.Reset()
+		other.AddCard(domain.NewCard(domain.CardDesignClover, 2, false))
+		other.AddCard(domain.NewCard(domain.CardDesignDiamond, 4, false))
+
+		m.On("GetHumanIdx").Return(2)
+		m.On("GetPlayer", 2).Return(human)
+		m.On("GetPlayer", 0).Return(other).Maybe()
+
+		result := new(presenter.NapoleonCuiPresenter).HintOutput(m)
+		// 人間の index 1 は ♥7。席 0 を見ていると ♦4 と言ってしまう。
+		assert.Contains(t, result, "7")
+		assert.NotContains(t, result, "♦4")
 	})
 
 	t.Run("play hint", func(t *testing.T) {
@@ -474,6 +505,7 @@ func TestNapoleonCuiPresenter_HintOutput(t *testing.T) {
 		player.AddCard(domain.NewCard(domain.CardDesignClover, 5, false))
 		player.AddCard(domain.NewCard(domain.CardDesignDiamond, 10, false))
 		m.On("GetPlayer", 0).Return(player)
+		m.On("GetHumanIdx").Return(0)
 
 		p := new(presenter.NapoleonCuiPresenter)
 		result := p.HintOutput(m)
@@ -512,6 +544,7 @@ func TestNapoleonCuiPresenter_HintOutput(t *testing.T) {
 			player.Reset()
 			player.AddCard(domain.NewCard(domain.CardDesignClover, 5, false))
 			m.On("GetPlayer", 0).Return(player)
+			m.On("GetHumanIdx").Return(0)
 
 			p := new(presenter.NapoleonCuiPresenter)
 			result := p.HintOutput(m)

--- a/internal/domain/Napoleon.go
+++ b/internal/domain/Napoleon.go
@@ -686,6 +686,13 @@ func (n *Napoleon) GetHint() *NapoleonHint {
 
 // --- Private methods ---
 
+// GetHumanIdx は人間プレイヤーのインデックスを返す (-1=なし)。
+//
+// **コンストラクタは任意の並び順を受け付ける。**ドメイン内部は findHumanIdx で
+// 都度解決しているのに、CUI の表示だけが GetPlayer(0) を決め打ちしていて
+// 取り残されていた (#4689)。表示側も同じ解決を使えるように公開する。
+func (n *Napoleon) GetHumanIdx() int { return n.findHumanIdx() }
+
 // findHumanIdx 人間プレイヤーのインデックスを返す (-1=なし)
 func (n *Napoleon) findHumanIdx() int {
 	for i, p := range n.players {

--- a/internal/domain/Napoleon_test.go
+++ b/internal/domain/Napoleon_test.go
@@ -1181,3 +1181,43 @@ func TestNapoleon_TrickWinner_EmptyTrick(t *testing.T) {
 	n.SetCurrentTrick(nil) // empty
 	n.ResolveTrick()       // no-op because trick incomplete
 }
+
+// **人間の席はコンストラクタ次第 (#4689)。**CUI の表示が GetPlayer(0) を
+// 決め打ちしていた件で公開したアクセサ。並びを変えても正しく解決すること。
+func TestNapoleon_GetHumanIdx(t *testing.T) {
+	t.Run("default layout puts the human first", func(t *testing.T) {
+		n := domain.NewDefaultNapoleon()
+		n.Reset()
+		if got := n.GetHumanIdx(); got != 0 {
+			t.Errorf("GetHumanIdx() = %d, want 0", got)
+		}
+	})
+
+	// **席順を変えて踏む。**既定配置だけ試しても「0 を返すだけ」の実装と
+	// 区別が付かない。
+	t.Run("finds the human at a later seat", func(t *testing.T) {
+		players := []*domain.NapoleonPlayer{
+			domain.NewNapoleonPlayer(false),
+			domain.NewNapoleonPlayer(false),
+			domain.NewNapoleonPlayer(true),
+			domain.NewNapoleonPlayer(false),
+		}
+		n := domain.NewNapoleon(domain.NewTrumpCards(1), players, domain.DefaultNapoleonConfig())
+		if got := n.GetHumanIdx(); got != 2 {
+			t.Errorf("GetHumanIdx() = %d, want 2", got)
+		}
+	})
+
+	t.Run("reports -1 when no player is human", func(t *testing.T) {
+		players := []*domain.NapoleonPlayer{
+			domain.NewNapoleonPlayer(false),
+			domain.NewNapoleonPlayer(false),
+			domain.NewNapoleonPlayer(false),
+			domain.NewNapoleonPlayer(false),
+		}
+		n := domain.NewNapoleon(domain.NewTrumpCards(1), players, domain.DefaultNapoleonConfig())
+		if got := n.GetHumanIdx(); got != -1 {
+			t.Errorf("GetHumanIdx() = %d, want -1", got)
+		}
+	})
+}

--- a/internal/domain/interfaces/napoleon.go
+++ b/internal/domain/interfaces/napoleon.go
@@ -89,4 +89,6 @@ type NapoleonGame interface {
 	GetValidPlayIndices(playerIdx int) []int
 	// GetHint ヒントを取得する
 	GetHint() *domain.NapoleonHint
+	// GetHumanIdx 人間プレイヤーのインデックスを返す (-1=なし)
+	GetHumanIdx() int
 }

--- a/internal/domain/interfaces/napoleon_mock.go
+++ b/internal/domain/interfaces/napoleon_mock.go
@@ -192,6 +192,11 @@ func (m *MockNapoleonGame) GetWinnerTeam() int {
 	return args.Int(0)
 }
 
+// GetHumanIdx は人間プレイヤーのインデックスを返すモック。
+func (m *MockNapoleonGame) GetHumanIdx() int {
+	return m.Called().Int(0)
+}
+
 func (m *MockNapoleonGame) GetPlayerCnt() int {
 	args := m.Called()
 	return args.Int(0)


### PR DESCRIPTION
## 背景

`NapoleonCuiPresenter.HintOutput` は `hint.DiscardIndex` / `hint.CardIndex` に対応するカードを表示する際、`n.GetPlayer(0)` と**人間が常に席 0 である前提**で書かれていました (#4689)。

**ドメイン自身はこの前提を信用していません。** `GetHint` を含む主要ロジックは `findHumanIdx()` で都度解決しています。つまりヒントの数値インデックスは正しく計算されているのに、**表示用のカード参照だけが別経路**で取り残されていました。

`NewDefaultNapoleon()` が今は human, cpu, cpu, cpu 固定なので実害は出ていませんが、コンストラクタは任意の並び順を受け付けます。席がずれると**別人の手札を見て「これを捨てろ」と言う**ことになります。

## 変更

`findHumanIdx` を `GetHumanIdx` として公開し（インターフェース + モック）、表示側も同じ解決を使うようにしました。

## テスト

**席 2 が人間**という盤面を作り、席 0 には別人の手札を置いて踏んでいます:

- 人間の index 1 は ♥7 → これが出ること
- 席 0 を見ていると ♦4 と言ってしまう → **出ないこと**

現状の配置（人間が席 0）だけを試しても、この修正は何も確かめられません。

**負のコントロール**: `GetPlayer(0)` に戻すと1件が落ちます。

## 検証

- `go test -tags test ./internal/...` ✅ / `golangci-lint` → `0 issues.` ✅ / `gofmt -l internal/` 空 ✅

Closes #4689