### PR TITLE
feat: track session stats for Deuces Wild and Joker Poker too

### DIFF
--- a/frontend/src/components/VideoPokerGameContent.test.tsx
+++ b/frontend/src/components/VideoPokerGameContent.test.tsx
@@ -435,12 +435,24 @@ describe('VideoPokerGameContent', () => {
     expect(stored).toMatchObject({ hands: 0, wins: 0 });
   });
 
-  it('does not show the session stats panel for other variants (deuceswild)', async () => {
+  // **配当の分散が大きいバリアントほど収支を追う価値が高いのに、そこだけ
+  // 機能が丸ごと無かった (#4692)。**以前はこのテストが「出ないこと」を
+  // 期待しており、欠落を仕様として固定していた。
+  it('shows the session stats panel for Deuces Wild too', async () => {
     mockExec.mockResolvedValue({ ...resultPhaseWin, variantName: 'deuceswild' });
     renderContent('deuceswild');
-    await waitFor(() => expect(screen.getByRole('button', { name: /次のゲーム/ })).toBeInTheDocument());
-    expect(screen.queryByTestId('vp-session-stats')).not.toBeInTheDocument();
-    // And nothing is written to any stats bucket for the disabled variant.
-    expect(localStorage.getItem('vp_stats_deuceswild')).toBeNull();
+    await waitFor(() => expect(screen.getByTestId('vp-session-stats')).toBeInTheDocument());
+
+    // **バリアントごとに別バケットへ書く。**共有すると Jacks or Better の
+    // 収支に混ざる。
+    await waitFor(() => expect(localStorage.getItem('vp_stats_deuceswild')).not.toBeNull());
+    const stored = JSON.parse(localStorage.getItem('vp_stats_deuceswild') ?? '{}');
+    expect(stored).toMatchObject({ hands: 1 });
+  });
+
+  it('shows the session stats panel for Joker Poker too', async () => {
+    mockExec.mockResolvedValue({ ...resultPhaseWin, variantName: 'jokerpoker' });
+    renderContent('jokerpoker');
+    await waitFor(() => expect(screen.getByTestId('vp-session-stats')).toBeInTheDocument());
   });
 });

--- a/frontend/src/components/VideoPokerGameContent.tsx
+++ b/frontend/src/components/VideoPokerGameContent.tsx
@@ -189,12 +189,13 @@ export function VideoPokerGameContent({
   const isDrawPhase = state?.phase === VideoPokerPhase.DRAW;
   const isResultPhase = state?.phase === VideoPokerPhase.RESULT;
 
-  // Session statistics (hands / win rate / net) are scoped to the base
-  // Jacks-or-Better variant so the shared component leaves Deuces Wild and
-  // Joker Poker untouched. Storage is still keyed per variant, so enabling the
-  // others later needs no data migration.
-  const statsEnabled = gameName === 'videopoker';
-  const { stats, clear: clearStats } = useVideoPokerStats(gameName, state, isResultPhase, statsEnabled);
+  // Session statistics (hands / win rate / net) for every variant.
+  //
+  // **以前は Jacks or Better だけに絞っていた (#4692)。**配当の分散が大きい
+  // Deuces Wild / Joker Poker ほど収支を追う価値が高いのに、そこだけ機能が
+  // 丸ごと欠けていた。保存キーは元からバリアント別 (`vp_stats_<name>`) なので、
+  // 有効化してもデータ移行は要らないし、収支が混ざることもない。
+  const { stats, clear: clearStats } = useVideoPokerStats(gameName, state, isResultPhase, true);
 
   // Announce the draw outcome once per hand. Keying on the state reference (a
   // fresh object on every API result) re-fires the effect even for an identical
@@ -471,7 +472,7 @@ export function VideoPokerGameContent({
               gameName={gameName}
               betAmount={betAmount}
               winningRowKey={isResultPhase ? videoPokerRowKey(state.handKey, state.handName) : null}
-              handCounts={statsEnabled ? stats.handCounts : null}
+              handCounts={stats.handCounts}
             />
 
             {actionLog && <ActionLogPanel entries={actionLog} onClose={hideActionLog} />}
@@ -502,33 +503,31 @@ export function VideoPokerGameContent({
                 </button>
               </div>
             )}
-            {statsEnabled && (
-              <div
-                className="flex flex-wrap items-center justify-center gap-x-3 gap-y-1 pb-2 text-ds-text-muted text-xs lg:text-sm"
-                data-testid="vp-session-stats"
-              >
-                <span data-testid="vp-stats-summary">
-                  {stats.hands === 0
-                    ? tNs('stats.empty')
-                    : tNs('stats.summary', {
-                        hands: stats.hands,
-                        winRate: Math.round(videoPokerWinRate(stats) * 100),
-                        net: `${videoPokerNet(stats) >= 0 ? '+' : ''}${videoPokerNet(stats)}`,
-                      })}
-                </span>
-                {stats.hands > 0 && (
-                  <button
-                    type="button"
-                    className={btnSecondary}
-                    onClick={clearStats}
-                    disabled={loading}
-                    data-testid="vp-stats-clear"
-                  >
-                    {tNs('stats.clear')}
-                  </button>
-                )}
-              </div>
-            )}
+            <div
+              className="flex flex-wrap items-center justify-center gap-x-3 gap-y-1 pb-2 text-ds-text-muted text-xs lg:text-sm"
+              data-testid="vp-session-stats"
+            >
+              <span data-testid="vp-stats-summary">
+                {stats.hands === 0
+                  ? tNs('stats.empty')
+                  : tNs('stats.summary', {
+                      hands: stats.hands,
+                      winRate: Math.round(videoPokerWinRate(stats) * 100),
+                      net: `${videoPokerNet(stats) >= 0 ? '+' : ''}${videoPokerNet(stats)}`,
+                    })}
+              </span>
+              {stats.hands > 0 && (
+                <button
+                  type="button"
+                  className={btnSecondary}
+                  onClick={clearStats}
+                  disabled={loading}
+                  data-testid="vp-stats-clear"
+                >
+                  {tNs('stats.clear')}
+                </button>
+              )}
+            </div>
             <div className="flex flex-wrap justify-center gap-x-4 pb-2">
               <label className="text-ds-text-primary text-sm flex items-center gap-2 min-h-[44px]">
                 <input type="checkbox" checked={hintEnabled} onChange={(e) => setHintEnabled(e.target.checked)} />


### PR DESCRIPTION
## 背景

`VideoPokerGameContent.tsx` は3バリアント共通の実装ですが、`statsEnabled = gameName === 'videopoker'` という条件により、**ハンド数・勝率・収支のパネル（`vp-session-stats`）はジャックスオアベターでしか有効化されていません**でした (#4692)。

コメントには「Deuces Wild と Joker Poker は今後の対応で変更不要」とありましたが、実際には**この2バリアントだけ機能が丸ごと欠落**していました。Deuces Wild は4オブアカインドやワイルドロイヤルなど**配当の分散が非常に大きい**バリアントで、通常の Jacks or Better 以上に収支を追跡する価値があります。

## 変更

コメントが主張していた「保存キーはバリアント別なので移行不要」を実際に確認しました — `readVideoPokerStats(gameName)` は `vp_stats_<name>` を読むので、有効化しても**データ移行は不要で、収支が混ざることもありません**。

`statsEnabled` を削除し（3箇所すべて）、全バリアントで有効にしています。

## テスト

- Deuces Wild でパネルが出ること、かつ **`vp_stats_deuceswild` に書かれること**（Jacks or Better のバケットに混ざらないことの確認）
- Joker Poker でもパネルが出ること

**既存テストが欠落を仕様として固定していました。** 「deuceswild では出ないこと」を期待していたので、書き換えています。

**負のコントロール**: 旧ゲートに戻すと1件が落ちます。

## 検証

- `bun run check` ✅ / `bun run typecheck` ✅ / `VideoPokerGameContent` 31 passed ✅

Closes #4692