### PR TITLE
feat: show the current streak in the Baccarat CUI

### DIFF
--- a/internal/adapter/presenter/BaccaratCuiPresenter.go
+++ b/internal/adapter/presenter/BaccaratCuiPresenter.go
@@ -128,6 +128,14 @@ func (bp *BaccaratCuiPresenter) Output(b interfaces.BaccaratGame, lastErr error)
 			"p", strconv.Itoa(pCount),
 			"b", strconv.Itoa(bCount),
 			"t", strconv.Itoa(tCount)) + "\n")
+
+		// **Web の ShoeStatsPanel は連勝数も出しているのに CUI には無かった。**
+		// ロードマップと並んでシューの流れを読む材料になる (#4688)。
+		if side, count := baccaratStreak(history); count > 0 {
+			sb.WriteString(i18n.Tf("baccarat.historyStreak",
+				"side", baccaratSideLabel(side),
+				"count", strconv.Itoa(count)) + "\n")
+		}
 	}
 
 	return sb.String()
@@ -162,4 +170,36 @@ func (bp *BaccaratCuiPresenter) betTypeStr(betType int) string {
 	default:
 		return i18n.T("baccarat.betTypeUnknown")
 	}
+}
+
+// baccaratStreak は履歴末尾の連勝の side と長さを返す。連勝が無ければ (0, 0)。
+//
+// **タイは連勝を切らない。**フロントの computeBaccaratShoeStats と同じ規則で、
+// ここがずれると同じ履歴で CUI と Web が違う連勝数を出す。
+func baccaratStreak(history []int) (side int, count int) {
+	side, count = 0, 0
+	found := false
+	for i := len(history) - 1; i >= 0; i-- {
+		r := history[i]
+		if r != domain.BaccaratResultPlayer && r != domain.BaccaratResultBanker {
+			continue // タイは飛ばす
+		}
+		if !found {
+			side, count, found = r, 1, true
+			continue
+		}
+		if r != side {
+			break
+		}
+		count++
+	}
+	return side, count
+}
+
+// baccaratSideLabel は連勝表示用の side ラベルを返す。
+func baccaratSideLabel(side int) string {
+	if side == domain.BaccaratResultBanker {
+		return i18n.T("baccarat.sideBanker")
+	}
+	return i18n.T("baccarat.sidePlayer")
 }

--- a/internal/adapter/presenter/BaccaratCuiPresenter_test.go
+++ b/internal/adapter/presenter/BaccaratCuiPresenter_test.go
@@ -28,6 +28,23 @@ func setupBaccaratCuiMockDefaults(m *interfaces.MockBaccaratGame) {
 	m.On("GetSideBetResults").Return(([]*domain.BacSideBetResult)(nil)).Maybe()
 }
 
+// baccaratStreakMock は履歴だけを差し替えた最小のモックを返す。
+func baccaratStreakMock(t *testing.T, history []int) *interfaces.MockBaccaratGame {
+	t.Helper()
+	m := new(interfaces.MockBaccaratGame)
+	m.On("GetPhase").Return(domain.BaccaratPhaseBet).Maybe()
+	m.On("GetChips").Return(1000).Maybe()
+	m.On("GetBetType").Return(domain.BaccaratBetPlayer).Maybe()
+	m.On("GetBetAmount").Return(0).Maybe()
+	m.On("GetPlayerHand").Return(([]*domain.Card)(nil)).Maybe()
+	m.On("GetBankerHand").Return(([]*domain.Card)(nil)).Maybe()
+	m.On("GetPlayerHandValue").Return(0).Maybe()
+	m.On("GetBankerHandValue").Return(0).Maybe()
+	m.On("GetGameEndFlag").Return(false).Maybe()
+	m.On("GetHistory").Return(history).Maybe()
+	return m
+}
+
 func TestBaccaratCuiPresenter_Output_BetPhase(t *testing.T) {
 	origNoColor := color.NoColor()
 	color.SetNoColor(true)
@@ -64,6 +81,43 @@ func TestBaccaratCuiPresenter_Output_History(t *testing.T) {
 		result := p.Output(m, nil)
 		assert.Contains(t, result, "履歴: P B T")
 		assert.Contains(t, result, "集計: P:1 B:1 T:1")
+	})
+
+	// **Web の ShoeStatsPanel は連勝数も出しているのに CUI には無かった (#4688)。**
+	// ロードマップと並んでシューの流れを読む材料になる。
+	t.Run("reports the current streak", func(t *testing.T) {
+		m := baccaratStreakMock(t, []int{
+			domain.BaccaratResultPlayer,
+			domain.BaccaratResultBanker,
+			domain.BaccaratResultBanker,
+		})
+		assert.Contains(t, p.Output(m, nil), "バンカー が 2 連勝中")
+	})
+
+	// **タイは連勝を切らない。**フロントの computeBaccaratShoeStats と同じ規則。
+	// ここがずれると同じ履歴で CUI と Web が違う連勝数を出す。
+	t.Run("a tie does not break the streak", func(t *testing.T) {
+		m := baccaratStreakMock(t, []int{
+			domain.BaccaratResultBanker,
+			domain.BaccaratResultTie,
+			domain.BaccaratResultBanker,
+		})
+		assert.Contains(t, p.Output(m, nil), "バンカー が 2 連勝中")
+	})
+
+	t.Run("the opposite side ends the streak", func(t *testing.T) {
+		m := baccaratStreakMock(t, []int{
+			domain.BaccaratResultBanker,
+			domain.BaccaratResultBanker,
+			domain.BaccaratResultPlayer,
+		})
+		assert.Contains(t, p.Output(m, nil), "プレイヤー が 1 連勝中")
+	})
+
+	// タイだけの履歴には連勝が無い。行ごと出さない。
+	t.Run("ties only means no streak line", func(t *testing.T) {
+		m := baccaratStreakMock(t, []int{domain.BaccaratResultTie, domain.BaccaratResultTie})
+		assert.NotContains(t, p.Output(m, nil), "連勝中")
 	})
 
 	t.Run("omits the history line when empty", func(t *testing.T) {

--- a/internal/i18n/locales/en/baccarat.json
+++ b/internal/i18n/locales/en/baccarat.json
@@ -21,5 +21,8 @@
   "playerWins": "Player wins!",
   "bankerWins": "Banker wins!",
   "tie": "Tie!",
-  "payoutLine": "payout: {{payout}}"
+  "payoutLine": "payout: {{payout}}",
+  "historyStreak": "Current streak: {{side}} x{{count}}",
+  "sidePlayer": "Player",
+  "sideBanker": "Banker"
 }

--- a/internal/i18n/locales/ja/baccarat.json
+++ b/internal/i18n/locales/ja/baccarat.json
@@ -21,5 +21,8 @@
   "playerWins": "プレイヤーの勝ち！",
   "bankerWins": "バンカーの勝ち！",
   "tie": "タイ！",
-  "payoutLine": "払戻し: {{payout}}"
+  "payoutLine": "払戻し: {{payout}}",
+  "historyStreak": "現在 {{side}} が {{count}} 連勝中",
+  "sidePlayer": "プレイヤー",
+  "sideBanker": "バンカー"
 }


### PR DESCRIPTION
## 背景

Web の `ShoeStatsPanel` は `computeBaccaratShoeStats(history)` から **`streakSide` / `streakCount`（現在何連勝中か）** を表示し、ロードマップ（Big Road）と並んでシューの流れを判断する材料になっています。

一方 `BaccaratCuiPresenter.Output` は P/B/T の記号列と各回数までしか出しておらず、**連勝に相当する行がありません**でした (#4688)。

## タイは連勝を切らない

フロントの実装を読んで規則をそのまま写しました。**タイは読み飛ばして連勝を継続します**（`if (r !== ROAD_PLAYER && r !== ROAD_BANKER) continue;`）。

ここがずれると、**同じ履歴で CUI と Web が違う連勝数を出す**ことになります。

## テスト

- `P, B, B` → バンカー2連勝
- **`B, T, B` → バンカー2連勝**（タイを挟んでも切れない）
- `B, B, P` → プレイヤー1連勝（逆側で切れる）
- `T, T` → 連勝行を出さない

**負のコントロール**: タイで切る実装（`continue` → `break`）にすると1件が落ちます。この1行が規則の本体なので、そこを直接踏んでいます。

## 検証

- `go test -tags test ./internal/...` ✅ / `golangci-lint` → `0 issues.` ✅ / `gofmt -l internal/` 空 ✅
- `check-message-codes: OK (all 775 codes …)` ✅

Closes #4688