### PR TITLE
feat: show the current best hand during Seven Card Stud play

### DIFF
--- a/internal/adapter/presenter/SevenCardStudCuiPresenter.go
+++ b/internal/adapter/presenter/SevenCardStudCuiPresenter.go
@@ -104,6 +104,14 @@ func (p *SevenCardStudCuiPresenter) Output(s interfaces.SevenCardStudGame, lastE
 						}
 						b.WriteString(i18n.Tf(key, "cards", cuiCardSliceStrEmoji(low)) + "\n")
 					}
+				} else if rank, best := player.PeekBestHand(); len(best) > 0 {
+					// **Web は常時「いまの最善役」を出しているのに、ハイ戦の CUI は
+					// ショーダウンまで役名を一切出していなかった (#4695)。**3rd〜7th
+					// street の間ずっと自分の手が何に達しているか分からない。
+					// PeekBestHand は状態を変えないので、描画から呼んで安全。
+					b.WriteString(i18n.Tf("sevencardstud.currentBestHand",
+						"hand", cuiPokerHandName(rank),
+						"cards", cuiCardSliceStrEmoji(best)) + "\n")
 				}
 			}
 		}

--- a/internal/adapter/presenter/SevenCardStudCuiPresenter_test.go
+++ b/internal/adapter/presenter/SevenCardStudCuiPresenter_test.go
@@ -38,6 +38,64 @@ func TestSevenCardStudCuiPresenter_Output(t *testing.T) {
 		assert.Contains(t, result, "♣5")
 	})
 
+	// **Web は常時「いまの最善役」を出しているのに、ハイ戦の CUI はショーダウン
+	// まで役名を一切出していなかった (#4695)。**3rd〜7th street の間ずっと
+	// 自分の手が何に達しているか分からない。
+	t.Run("high game shows the human's current best hand", func(t *testing.T) {
+		tc := domain.NewTrumpCards(0)
+		players := []*domain.SevenCardStudPlayer{
+			domain.NewSevenCardStudPlayer(true, domain.HoldemStyleTAG),
+			domain.NewSevenCardStudPlayer(false, domain.HoldemStyleLAP),
+		}
+		s := domain.NewSevenCardStud(tc, players, domain.DefaultSevenCardStudConfig())
+		s.SetPhase(domain.SevenCardStudPhaseFifthStreet)
+		// フラッシュ: ♠2 ♠5 ♠7 ♠9 ♠13
+		players[0].AddHoleCard(domain.NewCard(domain.CardDesignSpade, 2, false))
+		players[0].AddHoleCard(domain.NewCard(domain.CardDesignSpade, 5, false))
+		players[0].AddDoorCard(domain.NewCard(domain.CardDesignSpade, 7, false))
+		players[0].AddDoorCard(domain.NewCard(domain.CardDesignSpade, 9, false))
+		players[0].AddDoorCard(domain.NewCard(domain.CardDesignSpade, 13, false))
+
+		result := p.Output(s, nil)
+		assert.Contains(t, result, "現在の最善役")
+		assert.Contains(t, result, "フラッシュ")
+	})
+
+	// **5枚に満たないうちは出さない。**3rd street は3枚しかなく、そこで
+	// 「ハイカード」と出しても情報が無い。
+	t.Run("high game shows nothing before five cards", func(t *testing.T) {
+		tc := domain.NewTrumpCards(0)
+		players := []*domain.SevenCardStudPlayer{
+			domain.NewSevenCardStudPlayer(true, domain.HoldemStyleTAG),
+			domain.NewSevenCardStudPlayer(false, domain.HoldemStyleLAP),
+		}
+		s := domain.NewSevenCardStud(tc, players, domain.DefaultSevenCardStudConfig())
+		s.SetPhase(domain.SevenCardStudPhaseThirdStreet)
+		players[0].AddHoleCard(domain.NewCard(domain.CardDesignSpade, 2, false))
+		players[0].AddHoleCard(domain.NewCard(domain.CardDesignHeart, 5, false))
+		players[0].AddDoorCard(domain.NewCard(domain.CardDesignClover, 7, false))
+
+		assert.NotContains(t, p.Output(s, nil), "現在の最善役")
+	})
+
+	// **Razz では出さない。**ロー狙いなのにハイ役を出すと逆の助言になる。
+	t.Run("razz does not show the high-hand line", func(t *testing.T) {
+		tc := domain.NewTrumpCards(0)
+		players := []*domain.SevenCardStudPlayer{
+			domain.NewSevenCardStudPlayer(true, domain.HoldemStyleTAG),
+			domain.NewSevenCardStudPlayer(false, domain.HoldemStyleLAP),
+		}
+		s := domain.NewRazz(tc, players, domain.DefaultSevenCardStudConfig())
+		s.SetPhase(domain.SevenCardStudPhaseFifthStreet)
+		players[0].AddHoleCard(domain.NewCard(domain.CardDesignSpade, 2, false))
+		players[0].AddHoleCard(domain.NewCard(domain.CardDesignSpade, 5, false))
+		players[0].AddDoorCard(domain.NewCard(domain.CardDesignSpade, 7, false))
+		players[0].AddDoorCard(domain.NewCard(domain.CardDesignSpade, 9, false))
+		players[0].AddDoorCard(domain.NewCard(domain.CardDesignSpade, 13, false))
+
+		assert.NotContains(t, p.Output(s, nil), "現在の最善役")
+	})
+
 	t.Run("razz mode shows the human's current best low", func(t *testing.T) {
 		tc := domain.NewTrumpCards(0)
 		players := []*domain.SevenCardStudPlayer{

--- a/internal/domain/SevenCardStudPlayer.go
+++ b/internal/domain/SevenCardStudPlayer.go
@@ -169,31 +169,35 @@ func (p *SevenCardStudPlayer) GetComparisonCards() []*Card {
 	return cards
 }
 
-// EvalBestHand 全7枚からベスト5枚を評価
-func (p *SevenCardStudPlayer) EvalBestHand() int {
+// PeekBestHand は現在の持ち札から最善の 5 枚役を求めて返す。**状態を変えない。**
+//
+// 表示だけのために EvalBestHand を呼ぶと、描画のたびに handRank / bestHand を
+// 書き換えてしまう。CUI の途中経過表示はこちらを使う (#4695)。5 枚未満のときは
+// ハイカード扱いで、確定した組は返さない。
+func (p *SevenCardStudPlayer) PeekBestHand() (rank int, best []*Card) {
 	all := p.GetAllCards()
-
 	if len(all) < 5 {
-		p.handRank = PokerHandHighCard
-		p.bestHand = nil
-		return p.handRank
+		return PokerHandHighCard, nil
 	}
 
-	combos := combinations(all, 5)
 	bestRank := -1
 	var bestCards []*Card
-
-	for _, combo := range combos {
-		rank := evalFiveCardHand(combo)
-		if rank > bestRank || (rank == bestRank && compareHighCardsSlice(combo, bestCards) > 0) {
-			bestRank = rank
+	for _, combo := range combinations(all, 5) {
+		r := evalFiveCardHand(combo)
+		if r > bestRank || (r == bestRank && compareHighCardsSlice(combo, bestCards) > 0) {
+			bestRank = r
 			bestCards = make([]*Card, 5)
 			copy(bestCards, combo)
 		}
 	}
+	return bestRank, bestCards
+}
 
-	p.handRank = bestRank
-	p.bestHand = bestCards
+// EvalBestHand 全7枚からベスト5枚を評価し、結果をプレイヤーに記録する。
+func (p *SevenCardStudPlayer) EvalBestHand() int {
+	// **判定は PeekBestHand が唯一の出どころ。**同じ探索を2つ持つと、片方だけ
+	// 直したときに「表示とショーダウンで役が違う」ずれになる。
+	p.handRank, p.bestHand = p.PeekBestHand()
 	return p.handRank
 }
 

--- a/internal/i18n/locales/en/sevencardstud.json
+++ b/internal/i18n/locales/en/sevencardstud.json
@@ -67,5 +67,6 @@
   "hintReasonFlush": "three to a flush",
   "hintReasonStraight": "three to a straight",
   "hintReasonHigh": "three high cards",
-  "hintReasonFold": "no qualifying starting hand"
+  "hintReasonFold": "no qualifying starting hand",
+  "currentBestHand": "Best hand so far: {{hand}} ({{cards}})"
 }

--- a/internal/i18n/locales/ja/sevencardstud.json
+++ b/internal/i18n/locales/ja/sevencardstud.json
@@ -67,5 +67,6 @@
   "hintReasonFlush": "3枚同スート（フラッシュの目）",
   "hintReasonStraight": "3枚連続（ストレートの目）",
   "hintReasonHigh": "3枚とも高札",
-  "hintReasonFold": "続行条件を満たしません"
+  "hintReasonFold": "続行条件を満たしません",
+  "currentBestHand": "現在の最善役: {{hand}} ({{cards}})"
 }


### PR DESCRIPTION
## 背景

`SevenCardStudPage.tsx` は `doorCards` と `holeCards` からその場の最善役を計算し、`scs-current-hand` のバッジで**常時表示**しています。

一方 `SevenCardStudCuiPresenter.Output` は `GetIsLowball()`（Razz）のときだけベストローを出力し、**通常のハイ戦ではショーダウンまで役名を一切出しません**でした (#4695)。3rd〜7th street の間、自分の手が何に達しているか終始分かりません。

Razz 用の表示だけが実装済みで、ハイ戦が取り残されていた形です。

## 表示のために状態を書き換えない

既存の `EvalBestHand()` は `handRank` / `bestHand` を**書き換えます**。描画のたびにドメインの状態を変えるのは避けたいので、状態を変えない `PeekBestHand()` を切り出し、**`EvalBestHand` はそれを呼んで記録するだけ**にしました。

探索を2つ持つと「**表示とショーダウンで役が違う**」ずれになるため、実装は1つに保っています。

## 出さない条件

- **5枚未満**: 3rd street は3枚しかなく、そこで「ハイカード」と出しても情報がありません
- **Razz**: ロー狙いなのにハイ役を出すと逆の助言になります（既存のベストロー表示が担当）

## テスト

- 5th street でフラッシュ → 「現在の最善役 … フラッシュ」
- 3枚のみ → 出さない
- Razz で同じ手札 → 出さない（ロー表示のみ）

**負のコントロール**: 表示を潰すと1件、Razz ガードを外すと1件が落ちます。

## 検証

- `go test -tags test ./internal/...` ✅ / `golangci-lint` → `0 issues.` ✅ / `gofmt -l internal/` 空 ✅

Closes #4695