### PR TITLE
feat: show the current best hand during Omaha play

### DIFF
--- a/internal/adapter/presenter/OmahaCuiPresenter.go
+++ b/internal/adapter/presenter/OmahaCuiPresenter.go
@@ -113,6 +113,15 @@ func (p *OmahaCuiPresenter) Output(o interfaces.OmahaGame, lastErr error) string
 
 			if player.GetIsHuman() && !player.GetFolded() {
 				b.WriteString(i18n.Tf("omaha.humanHand", "cards", cuiCardListStrEmoji(player)) + "\n")
+				// **Web は omaha-live-besthand で暫定ベストを常時出しているのに、
+				// CUI は「2枚使用」の注意書きだけで実際の役を出していなかった
+				// (#4680)。**手札4枚から必ず2枚という特殊ルールがあるぶん、
+				// 暫定表示はミスを防ぐ補助になる。PeekBestHand は状態を変えない。
+				if rank, best := player.PeekBestHand(cc); len(best) > 0 {
+					b.WriteString(i18n.Tf("omaha.currentBestHand",
+						"hand", cuiPokerHandName(rank),
+						"cards", cuiCardSliceStrEmoji(best)) + "\n")
+				}
 			}
 		}
 

--- a/internal/adapter/presenter/OmahaCuiPresenter_test.go
+++ b/internal/adapter/presenter/OmahaCuiPresenter_test.go
@@ -67,6 +67,60 @@ func TestOmahaCuiPresenter_Output(t *testing.T) {
 		assert.Contains(t, result, i18n.T("omaha.hiLoRuleLine"))
 	})
 
+	// **Web は omaha-live-besthand で暫定ベストを常時出しているのに、CUI は
+	// 「2枚使用」の注意書きだけで実際の役を出していなかった (#4680)。**
+	// 手札4枚から必ず2枚という特殊ルールがあるぶん、暫定表示はミスを防ぐ補助になる。
+	t.Run("shows the human's current best hand once the flop is out", func(t *testing.T) {
+		h, players := makeOmahaForPresenter()
+		h.SetPhase(domain.OmahaPhaseFlop)
+		// 手札 ♠2 ♠3 ♥11 ♥12、ボード ♠5 ♠7 ♠9 → ♠ のフラッシュ (手札2枚+場3枚)。
+		players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 2, false))
+		players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 3, false))
+		players[0].AddCard(domain.NewCard(domain.CardDesignHeart, 11, false))
+		players[0].AddCard(domain.NewCard(domain.CardDesignHeart, 12, false))
+		h.SetCommunityCards([]*domain.Card{
+			domain.NewCard(domain.CardDesignSpade, 5, false),
+			domain.NewCard(domain.CardDesignSpade, 7, false),
+			domain.NewCard(domain.CardDesignSpade, 9, false),
+		})
+
+		result := p.Output(h, nil)
+		assert.Contains(t, result, "現在の最善役")
+		assert.Contains(t, result, "フラッシュ")
+	})
+
+	// **プリフロップでは出さない。**ボードが3枚に満たないと役は決まらない。
+	t.Run("shows nothing before the flop", func(t *testing.T) {
+		h, players := makeOmahaForPresenter()
+		h.SetPhase(domain.OmahaPhasePreFlop)
+		players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 2, false))
+		players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 3, false))
+		players[0].AddCard(domain.NewCard(domain.CardDesignHeart, 11, false))
+		players[0].AddCard(domain.NewCard(domain.CardDesignHeart, 12, false))
+
+		assert.NotContains(t, p.Output(h, nil), "現在の最善役")
+	})
+
+	// **表示のために状態を変えない。**Peek を使っているので、描画しても
+	// プレイヤーの handRank は書き換わらない。
+	t.Run("rendering does not mutate the player state", func(t *testing.T) {
+		h, players := makeOmahaForPresenter()
+		h.SetPhase(domain.OmahaPhaseFlop)
+		players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 2, false))
+		players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 3, false))
+		players[0].AddCard(domain.NewCard(domain.CardDesignHeart, 11, false))
+		players[0].AddCard(domain.NewCard(domain.CardDesignHeart, 12, false))
+		h.SetCommunityCards([]*domain.Card{
+			domain.NewCard(domain.CardDesignSpade, 5, false),
+			domain.NewCard(domain.CardDesignSpade, 7, false),
+			domain.NewCard(domain.CardDesignSpade, 9, false),
+		})
+
+		before := players[0].GetBestHand()
+		_ = p.Output(h, nil)
+		assert.Equal(t, before, players[0].GetBestHand(), "描画でベストハンドが書き換わらない")
+	})
+
 	t.Run("community cards displayed", func(t *testing.T) {
 		h, _ := makeOmahaForPresenter()
 		h.SetPhase(domain.OmahaPhaseFlop)

--- a/internal/domain/OmahaPlayer.go
+++ b/internal/domain/OmahaPlayer.go
@@ -218,11 +218,15 @@ func (op *OmahaPlayer) UnmarshalJSON(data []byte) error {
 
 // EvalBestHand コミュニティカードとホールカード(4枚)からベスト5枚を評価
 // オマハルール: ホールカードから必ず2枚、コミュニティカードから必ず3枚を使う
-func (op *OmahaPlayer) EvalBestHand(communityCards []*Card) int {
+// PeekBestHand は現在の手札とボードから最善の 5 枚役を求めて返す。**状態を
+// 変えない。**
+//
+// 表示だけのために EvalBestHand を呼ぶと、描画のたびに handRank / bestHand を
+// 書き換えてしまう。CUI の途中経過表示はこちらを使う (#4680)。手札 2 枚・
+// ボード 3 枚に満たないときはハイカード扱いで、確定した組は返さない。
+func (op *OmahaPlayer) PeekBestHand(communityCards []*Card) (rank int, best []*Card) {
 	if len(op.cards) < 2 || len(communityCards) < 3 {
-		op.handRank = PokerHandHighCard
-		op.bestHand = nil
-		return op.handRank
+		return PokerHandHighCard, nil
 	}
 
 	holePairs := combinations(op.cards, 2)         // C(4,2) = 6
@@ -230,23 +234,26 @@ func (op *OmahaPlayer) EvalBestHand(communityCards []*Card) int {
 
 	bestRank := -1
 	var bestCards []*Card
-
 	for _, pair := range holePairs {
 		for _, triple := range commTriples {
 			hand := make([]*Card, 0, 5)
 			hand = append(hand, pair...)
 			hand = append(hand, triple...)
-			rank := evalFiveCardHand(hand)
-			if rank > bestRank || (rank == bestRank && compareHighCardsSlice(hand, bestCards) > 0) {
-				bestRank = rank
+			r := evalFiveCardHand(hand)
+			if r > bestRank || (r == bestRank && compareHighCardsSlice(hand, bestCards) > 0) {
+				bestRank = r
 				bestCards = make([]*Card, 5)
 				copy(bestCards, hand)
 			}
 		}
 	}
+	return bestRank, bestCards
+}
 
-	op.handRank = bestRank
-	op.bestHand = bestCards
+func (op *OmahaPlayer) EvalBestHand(communityCards []*Card) int {
+	// **判定は PeekBestHand が唯一の出どころ。**同じ探索を2つ持つと、片方だけ
+	// 直したときに「表示とショーダウンで役が違う」ずれになる。
+	op.handRank, op.bestHand = op.PeekBestHand(communityCards)
 	return op.handRank
 }
 

--- a/internal/i18n/locales/en/omaha.json
+++ b/internal/i18n/locales/en/omaha.json
@@ -44,5 +44,6 @@
   "rebuyPrompt": "Rebuy? ({{chips}} chips, used {{used}}/{{max}}) (rb=rebuy / sr=skip)",
   "addonPrompt": "Add-on? ({{chips}} chips) (ad=addon / sa=skip)",
   "gameEnd": "Game over",
-  "hiLoRuleLine": "Low: five distinct cards 8-or-lower (8 or Better); if none qualifies, Hi takes the whole pot"
+  "hiLoRuleLine": "Low: five distinct cards 8-or-lower (8 or Better); if none qualifies, Hi takes the whole pot",
+  "currentBestHand": "Best hand so far: {{hand}} ({{cards}})"
 }

--- a/internal/i18n/locales/ja/omaha.json
+++ b/internal/i18n/locales/ja/omaha.json
@@ -44,5 +44,6 @@
   "rebuyPrompt": "リバイしますか? ({{chips}}チップ, {{used}}/{{max}}回使用済) (rb=リバイ / sr=スキップ)",
   "addonPrompt": "アドオンしますか? ({{chips}}チップ) (ad=アドオン / sa=スキップ)",
   "gameEnd": "ゲーム終了",
-  "hiLoRuleLine": "※ロー: 8以下5枚(8 or Better)。不成立時はHiが総取り"
+  "hiLoRuleLine": "※ロー: 8以下5枚(8 or Better)。不成立時はHiが総取り",
+  "currentBestHand": "現在の最善役: {{hand}} ({{cards}})"
 }


### PR DESCRIPTION
## 背景

`OmahaPage.tsx` は `omahaBestFive` で暫定ベストを計算し、フロップ〜リバーの間 `omaha-live-besthand` として**常時表示**しています。オマハは**手札4枚のうち必ず2枚だけを使う**特殊ルールがあるため、この表示はミスを防ぐ重要な補助です。

一方 `OmahaCuiPresenter.Output` は「2枚使用」の注意書き（`mandatoryRuleLine`）は出しますが、**実際に作れる最強役そのものは計算も表示もしていません**でした (#4680)。

## 表示のために状態を書き換えない

既存の `EvalBestHand(communityCards)` は `handRank` / `bestHand` を**書き換えます**。#4695（Seven Card Stud）と同じく、状態を変えない `PeekBestHand()` を切り出し、**`EvalBestHand` はそれを呼んで記録するだけ**にしました。探索を2つ持つと「表示とショーダウンで役が違う」ずれになります。

## テスト

- フロップ後: 手札 ♠2 ♠3 ♥J ♥Q + ボード ♠5 ♠7 ♠9 → **フラッシュ**（手札2枚 + 場3枚のオマハ規則どおり）
- プリフロップ: 出さない（ボードが3枚に満たないと役が決まらない）
- **描画してもプレイヤーの `bestHand` が変わらないこと**

**負のコントロール**:

| 変更 | 結果 |
|------|------|
| 表示を潰す | 1件が落ちる |
| `PeekBestHand` を `EvalBestHand`（状態変更あり）に置換 | 1件が落ちる |

2つ目が落ちることで、「状態を変えない」テストが飾りでないことを確認しています。

## 検証

- `go test -tags test ./internal/...` ✅ / `golangci-lint` → `0 issues.` ✅ / `gofmt -l internal/` 空 ✅

Closes #4680