### PR TITLE
test: stop betting on the deal in the Crazy Eights hint test

### DIFF
--- a/internal/domain/CrazyEights_test.go
+++ b/internal/domain/CrazyEights_test.go
@@ -1113,9 +1113,33 @@ func TestCrazyEights_GetHint(t *testing.T) {
 
 	t.Run("recommends a card the rules actually allow", func(t *testing.T) {
 		g := setup(t)
+		// **配りに賭けない。**出せる札が1枚も無い配りでは GetHint が nil を返すのが
+		// 正しい挙動で、実測 22/200 (11%) でその配りを引いていた。捨て札の一番上と
+		// 同じスートを1枚持たせて、必ず出せる状態にする。
+		top := g.GetDiscardTop()
+		if top == nil {
+			t.Fatal("前提: 捨て札の一番上があること")
+		}
+		human := g.GetPlayer(0)
+		for human.GetCardsSize() > 0 {
+			human.RemoveCard(0)
+		}
+		// **index 0 は出せない札にする。**1枚だけ持たせると「常に先頭を勧める」
+		// 実装でも通ってしまい、推奨が正しいかを確かめられない。
+		otherSuit := domain.CardDesignSpade
+		if top.GetDesign() == domain.CardDesignSpade {
+			otherSuit = domain.CardDesignHeart
+		}
+		unplayable := top.GetValue()%13 + 1
+		if unplayable == top.GetValue() || unplayable == domain.CrazyEightsWildValue {
+			unplayable = (unplayable)%13 + 1
+		}
+		human.AddCard(domain.NewCard(otherSuit, unplayable, false))                // index 0: 出せない
+		human.AddCard(domain.NewCard(top.GetDesign(), top.GetValue()%13+1, false)) // index 1: 出せる
+
 		hint := g.GetHint()
 		if hint == nil {
-			t.Fatal("配り直後の人間の手番ではヒントが出る")
+			t.Fatal("出せる札があるのでヒントが出る")
 		}
 		if hint.CardIndex == nil {
 			t.Fatal("プレイフェーズでは CardIndex が入る")


### PR DESCRIPTION
## 症状

`TestCrazyEights_GetHint/recommends_a_card_the_rules_actually_allow` が断続的に落ちます。**私が #5093 で入れたテストです。**無関係な PR（Omaha の作業中）で踏んで発覚しました。

## 原因: 配りに賭けていた

テストは `Reset()` 後に「必ずヒントが出る」と仮定していましたが、**出せる札が1枚も無い配りでは `GetHint` が nil を返すのが正しい挙動**です（引くしかない局面で札を勧めたら嘘になります）。

実測 **22/200（11%）** でその配りを引いていました。

## 修正

捨て札の一番上と同じスートを持たせて、必ず出せる状態にします。

### ただし1枚だけでは不十分でした

最初 1枚だけ持たせたところ、**「常に index 0 を勧める」実装でも通ってしまいました**（60回中0回失敗）。唯一の札が index 0 なので当然です。推奨の正しさを何も確かめないテストになっていました。

**index 0 に出せない札を置き、index 1 を出せる札**にしています。

## 実測

| | 結果 |
|---|---|
| 修正前のフレーク率 | **22/200（11%）** |
| 修正後 | **0/300** |
| 「常に index 0 を勧める」実装での失敗 | **60/60** |

最後の行が、このテストが推奨の正しさを本当に見ていることの確認です。

## 検証

- `go test -tags test ./internal/...` ✅ / `golangci-lint` → `0 issues.` ✅ / `gofmt -l internal/` 空 ✅