### PR TITLE
feat: name the five cards that made the hand at Holdem showdown

### DIFF
--- a/internal/adapter/presenter/HoldemCuiPresenter.go
+++ b/internal/adapter/presenter/HoldemCuiPresenter.go
@@ -144,6 +144,14 @@ func (p *HoldemCuiPresenter) Output(h interfaces.HoldemGame, lastErr error) stri
 						"name", name,
 						"hand", cuiPokerHandName(r.HandRank),
 						"kickers", kickers))
+					// **Web は勝利役を構成する5枚をハイライトしているのに、CUI は
+					// 役名とキッカーだけだった (#4679)。**僅差の役 (ツーペアの
+					// キッカー勝負など) でどのカードが決め手か分からない。
+					// ショーダウン時点で bestHand は確定済みなので、そのまま出す。
+					if best := h.GetPlayer(r.PlayerIdx).GetBestHand(); len(best) > 0 {
+						b.WriteString(i18n.Tf("holdem.resultBestFive",
+							"cards", cuiCardSliceStrEmoji(best)))
+					}
 				default:
 					b.WriteString(i18n.Tf("holdem.resultName", "name", name))
 				}

--- a/internal/adapter/presenter/HoldemCuiPresenter_test.go
+++ b/internal/adapter/presenter/HoldemCuiPresenter_test.go
@@ -202,6 +202,44 @@ func TestHoldemCuiPresenter_Output(t *testing.T) {
 		assert.Contains(t, result, "100チップ獲得")
 	})
 
+	// **Web は勝利役を構成する5枚をハイライトしているのに、CUI は役名と
+	// キッカーだけだった (#4679)。**僅差の役でどのカードが決め手か分からない。
+	t.Run("showdown names the five cards that made the hand", func(t *testing.T) {
+		h, players := makeHoldemForPresenter()
+		h.SetPhase(domain.HoldemPhaseEnd)
+		// ショーダウン時点で bestHand は確定済み。
+		players[0].SetBestHand([]*domain.Card{
+			domain.NewCard(domain.CardDesignSpade, 2, false),
+			domain.NewCard(domain.CardDesignSpade, 5, false),
+			domain.NewCard(domain.CardDesignSpade, 7, false),
+			domain.NewCard(domain.CardDesignSpade, 9, false),
+			domain.NewCard(domain.CardDesignSpade, 13, false),
+		})
+		h.SetRoundResults([]domain.HoldemResult{
+			{PlayerIdx: 0, HandRank: domain.PokerHandFlush, HandName: "Flush", WonAmount: 100},
+		})
+
+		result := p.Output(h, nil)
+		assert.Contains(t, result, "♠13")
+		assert.Contains(t, result, "♠2")
+	})
+
+	// **マックしたプレイヤーの手は見せない。**降りた相手の札が漏れる。
+	t.Run("a mucked hand does not reveal its cards", func(t *testing.T) {
+		h, players := makeHoldemForPresenter()
+		h.SetPhase(domain.HoldemPhaseEnd)
+		players[0].SetBestHand([]*domain.Card{
+			domain.NewCard(domain.CardDesignSpade, 2, false),
+			domain.NewCard(domain.CardDesignSpade, 5, false),
+			domain.NewCard(domain.CardDesignSpade, 7, false),
+			domain.NewCard(domain.CardDesignSpade, 9, false),
+			domain.NewCard(domain.CardDesignSpade, 13, false),
+		})
+		h.SetRoundResults([]domain.HoldemResult{{PlayerIdx: 0, Mucked: true}})
+
+		assert.NotContains(t, p.Output(h, nil), "♠13")
+	})
+
 	t.Run("showdown results with kickers", func(t *testing.T) {
 		h, _ := makeHoldemForPresenter()
 		h.SetPhase(domain.HoldemPhaseEnd)

--- a/internal/i18n/locales/en/holdem.json
+++ b/internal/i18n/locales/en/holdem.json
@@ -54,5 +54,6 @@
   "muckPrompt": "Muck? (m=muck / sh=show)",
   "rebuyPrompt": "Rebuy? ({{chips}} chips, used {{used}}/{{max}}) (rb=rebuy / sr=skip)",
   "addonPrompt": "Add-on? ({{chips}} chips) (ad=addon / sa=skip)",
-  "gameEnd": "Game over"
+  "gameEnd": "Game over",
+  "resultBestFive": " [{{cards}}]"
 }

--- a/internal/i18n/locales/ja/holdem.json
+++ b/internal/i18n/locales/ja/holdem.json
@@ -54,5 +54,6 @@
   "muckPrompt": "マックしますか? (m=マック / sh=ショー)",
   "rebuyPrompt": "リバイしますか? ({{chips}}チップ, {{used}}/{{max}}回使用済) (rb=リバイ / sr=スキップ)",
   "addonPrompt": "アドオンしますか? ({{chips}}チップ) (ad=アドオン / sa=スキップ)",
-  "gameEnd": "ゲーム終了"
+  "gameEnd": "ゲーム終了",
+  "resultBestFive": " [{{cards}}]"
 }


### PR DESCRIPTION
## 背景

`HoldemPage.tsx` は `showdownBest5` で、**7枚のうちどの5枚が勝利役を構成しているか**を `ring-2 ring-ds-success` でハイライトします。

一方 `HoldemCuiPresenter.Output` はショーダウン結果を役名 + キッカーのテキストで出すだけで、**どのカードが実際に採用されたかは示しません**でした (#4679)。役名だけでは、特に僅差の役（ツーペアのキッカー勝負など）でどのカードが決め手だったか分かりません。

## 新しい評価は不要でした

#4695 / #4680 では表示用に非破壊の評価関数を切り出しましたが、**Holdem のショーダウンでは `bestHand` が既に確定済み**です（`GetBestHand()`）。そのまま出せばよく、再計算も状態変更も発生しません。

## マックした手は出さない

`r.Mucked` の分岐では出力しません。**降りた相手の札が漏れます。**

## テスト

- ショーダウンで採用された5枚（♠2 ♠5 ♠7 ♠9 ♠K）が出ること
- **マック時は同じ `bestHand` を持たせても出ないこと**

**負のコントロール**: 表示を潰すと1件が落ちます。

## 検証

- `go test -tags test ./internal/...` ✅ / `golangci-lint` → `0 issues.` ✅ / `gofmt -l internal/` 空 ✅

Closes #4679