### PR TITLE
test: stop the Durak hint test from handing over a trump card

### DIFF
--- a/internal/domain/Durak_test.go
+++ b/internal/domain/Durak_test.go
@@ -769,10 +769,19 @@ func TestDurak_GetHint(t *testing.T) {
 			human.RemoveCard(0)
 		}
 		// テーブルに 7 が出ている状態で、手札にも 7 を持たせる → 追撃できる。
+		//
+		// **切り札を渡してはいけない。**Normal 難易度の追撃は
+		// cpuFindMatchingCard(..., includeTrumps=false) で切り札を除外するため、
+		// 渡した 7 がたまたま切り札スートだと追撃されず pass になる。切り札は
+		// 配りごとにランダムなので、固定スートだと実測 36/200 (18%) で落ちた。
+		follow := domain.CardDesignHeart
+		if d.GetTrumpSuit() == follow {
+			follow = domain.CardDesignSpade
+		}
 		d.SetTablePairs([]*domain.DurakTablePair{
 			{Attack: domain.NewCard(domain.CardDesignClover, 7, false)},
 		})
-		human.AddCard(domain.NewCard(domain.CardDesignHeart, 7, false))
+		human.AddCard(domain.NewCard(follow, 7, false))
 
 		hint := d.GetHint()
 		if hint == nil || hint.CardIndex == nil || hint.Reason != "attack_additional" {
@@ -783,7 +792,13 @@ func TestDurak_GetHint(t *testing.T) {
 		for human.GetCardsSize() > 0 {
 			human.RemoveCard(0)
 		}
-		human.AddCard(domain.NewCard(domain.CardDesignSpade, 3, false))
+		// 追撃できない札。こちらも切り札だと「切り札は除外」以前に数字が
+		// 合わないので pass になるが、意図を明示するため非切り札にする。
+		noMatch := domain.CardDesignSpade
+		if d.GetTrumpSuit() == noMatch {
+			noMatch = domain.CardDesignHeart
+		}
+		human.AddCard(domain.NewCard(noMatch, 3, false))
 		hint = d.GetHint()
 		if hint == nil || hint.CardIndex != nil || hint.Reason != "pass_no_addition" {
 			t.Fatalf("追撃できなければパスを勧める: %+v", hint)


### PR DESCRIPTION
## 症状

`TestDurak_GetHint/additional_attack_or_pass_depending_on_the_hand` が断続的に落ちます。**私が #5094 で入れたテストです。**無関係な PR（#5104 Omaha）で踏んで発覚しました。

## 原因: 渡した札がたまたま切り札だった

テストは追撃できることを確かめるため、手札に **`HEART` の 7 を固定で**渡していました。

ところが Normal 難易度の追撃判定は:

```go
default:
    // Normalは非切り札のみ追加攻撃
    return d.cpuFindMatchingCard(p, ranks, false)  // includeTrumps=false
```

**切り札を除外します。**切り札スートは配りごとにランダムなので、ハートが切り札になった配りでは追撃されず `pass_no_addition` が返り、テストが落ちていました。

実測 **36/200（18%）**。

## 修正

`GetTrumpSuit()` を見て**非切り札のスート**を選びます。同じ理由で、後半の「追撃できない札」も非切り札にして意図を明示しました。

## 実測

| | 結果 |
|---|---|
| 修正前 | **36/200（18%）** |
| 修正後 | **0/300** |
| 追撃を常に `-1` にした場合 | **1件が落ちる** |

最後の行が、このテストが追撃判定を本当に見ていることの確認です。

## 検証

- `go test -tags test ./internal/...` ✅ / `golangci-lint` → `0 issues.` ✅ / `gofmt -l internal/` 空 ✅