### PR TITLE
feat: show equity and pot odds during Poker betting rounds

### DIFF
--- a/frontend/src/pages/PokerPage.test.tsx
+++ b/frontend/src/pages/PokerPage.test.tsx
@@ -1524,4 +1524,29 @@ describe('PokerPage', () => {
     await screen.findByRole('button', { name: 'ベット' });
     expect(screen.queryByTestId('pk-lowball-reference')).not.toBeInTheDocument();
   });
+
+  // **Holdem 系は EquityDisplay を持つのに、5カードドローには仕組み自体が
+  // 無く、2巡目ベットで call/raise/fold を判断する材料が交換確率パネルしか
+  // 無かった (#4678)。**
+  it('shows the equity display during a betting round', async () => {
+    mockExec.mockResolvedValue({
+      ...secondBetState,
+      equity: { winProbability: 0.62, handOdds: [] },
+      potOdds: 25,
+    });
+    renderWithProviders(<PokerPage />);
+
+    await waitFor(() => expect(screen.getByTestId('equity-display')).toBeInTheDocument());
+  });
+
+  // **サーバーが送らないフェーズでは出さない。**交換中はまだ手が変わるので、
+  // 確定した勝率として読まれると誤解を招く。ページ側でフェーズを再判定せず、
+  // 値の有無だけで決める。
+  it('shows no equity display when the server sends none', async () => {
+    mockExec.mockResolvedValue(secondBetState);
+    renderWithProviders(<PokerPage />);
+
+    await waitFor(() => expect(mockExec).toHaveBeenCalled());
+    expect(screen.queryByTestId('equity-display')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/PokerPage.tsx
+++ b/frontend/src/pages/PokerPage.tsx
@@ -10,6 +10,7 @@ import { CpuPlayerCard } from '../components/CpuPlayerCard';
 import { CliTerminal } from '../components/cli/CliTerminal';
 import { CliToggle } from '../components/cli/CliToggle';
 import { SettingsPanel } from '../components/common/SettingsPanel';
+import { EquityDisplay } from '../components/EquityDisplay';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
@@ -381,6 +382,12 @@ function PokerPageContent() {
                 />
               </div>
             )}
+
+            {/* **2巡目ベットの判断材料。**Holdem 系は EquityDisplay を持つのに
+                5カードドローには仕組み自体が無く、交換確率パネルしか無かった
+                (#4678)。ベッティングフェーズ以外はサーバーが送らないので、
+                ここでフェーズを再判定しない。 */}
+            {state.equity && <EquityDisplay equity={state.equity} potOdds={state.potOdds ?? 0} />}
 
             {/* Draw odds panel */}
             {canExchange && odds?.some((o) => o.probability > 0) && (

--- a/frontend/src/types/games/poker.ts
+++ b/frontend/src/types/games/poker.ts
@@ -1,3 +1,4 @@
+import type { HoldemEquity } from './holdem';
 // Type declarations for poker. Split out of card.ts (issue #4366);
 // card.ts re-exports this file, so existing imports keep working.
 
@@ -62,6 +63,15 @@ export type PokerPhase = 0 | 1 | 2 | 3 | 4;
 export interface PokerResponse extends BaseGameResponse {
   players: PokerPlayerData[];
   pot: number;
+  /**
+   * 2 巡目ベットでの勝率。ベッティングフェーズ以外では undefined。
+   *
+   * Holdem 系と同じ `HoldemEquity` 形。判定はドメインの `GetEquity` が唯一の
+   * 出どころで、フロントは表示だけ担当する。
+   */
+  equity?: HoldemEquity;
+  /** コールに必要な額に対するポットオッズ (0-100)。 */
+  potOdds?: number;
   sidePots: PokerSidePot[];
   dealerIdx: number;
   currentTurn: number;

--- a/internal/adapter/controller/PokerWebController.go
+++ b/internal/adapter/controller/PokerWebController.go
@@ -89,12 +89,17 @@ type PokerWebOutputMetaAI struct {
 
 // PokerWebOutput ポーカーWebアウトプット
 type PokerWebOutput struct {
-	Players      []*PokerWebOutputPlayer         `json:"players"`
-	Pot          int                             `json:"pot"`
-	SidePots     []*PokerWebOutputSidePot        `json:"sidePots"`
-	DealerIdx    int                             `json:"dealerIdx"`
-	CurrentTurn  int                             `json:"currentTurn"`
-	Phase        int                             `json:"phase"`
+	Players     []*PokerWebOutputPlayer  `json:"players"`
+	Pot         int                      `json:"pot"`
+	SidePots    []*PokerWebOutputSidePot `json:"sidePots"`
+	DealerIdx   int                      `json:"dealerIdx"`
+	CurrentTurn int                      `json:"currentTurn"`
+	Phase       int                      `json:"phase"`
+	// Equity / PotOdds は 2 巡目ベットの判断材料。Holdem 系は EquityDisplay で
+	// 出しているのに、5 カードドローには仕組み自体が無かった (#4678)。
+	// ベッティングフェーズ以外では省略される。
+	Equity       *HoldemWebOutputEquity          `json:"equity,omitempty"`
+	PotOdds      *float64                        `json:"potOdds,omitempty"`
 	GameEndFlag  bool                            `json:"gameEndFlag"`
 	LastBet      int                             `json:"lastBet"`
 	MinRaise     int                             `json:"minRaise"`

--- a/internal/adapter/presenter/PokerWebPresenter.go
+++ b/internal/adapter/presenter/PokerWebPresenter.go
@@ -45,6 +45,22 @@ func (pwp *PokerWebPresenter) buildOutput(p interfaces.PokerGame, lastErr error)
 	resObj := new(controller.PokerWebOutput)
 	resObj.Phase = p.GetPhase()
 	resObj.Pot = p.GetPot()
+
+	// **判定はドメイン。**Holdem 系と同じ形で、ベッティングフェーズのときだけ
+	// 勝率とポットオッズを載せる (#4678)。
+	if eq := p.GetEquity(); eq != nil {
+		handOdds := make([]*controller.HoldemWebOutputHandOdds, len(eq.HandOdds))
+		for i, ho := range eq.HandOdds {
+			handOdds[i] = &controller.HoldemWebOutputHandOdds{
+				HandRank:    ho.HandRank,
+				HandName:    ho.HandName,
+				Probability: ho.Probability,
+			}
+		}
+		resObj.Equity = &controller.HoldemWebOutputEquity{WinProbability: eq.Equity, HandOdds: handOdds}
+		potOdds := p.GetPotOdds()
+		resObj.PotOdds = &potOdds
+	}
 	resObj.DealerIdx = p.GetDealerIdx()
 	resObj.CurrentTurn = p.GetCurrentTurn()
 	resObj.GameEndFlag = p.GetGameEndFlag()

--- a/internal/domain/Poker.go
+++ b/internal/domain/Poker.go
@@ -1036,6 +1036,62 @@ func (p *Poker) findStraightDrawDiscard(playerIdx int) int {
 // --- ゲッター ---
 
 // GetPhase フェーズ取得
+// pokerEquitySimulations はエクイティ計算のモンテカルロ試行回数。
+const pokerEquitySimulations = 2000
+
+// GetEquity はベッティングフェーズでの人間の勝率を返す。それ以外では nil。
+//
+// **Holdem 系は EquityDisplay でこれを出しているのに、5 カードドローには
+// 仕組み自体が無く、2巡目ベットで call/raise/fold を判断する材料が
+// 交換確率パネルしか無かった (#4678)。**
+func (p *Poker) GetEquity() *HoldemEquityResult {
+	if p.round.phase != PokerPhaseDeal && p.round.phase != PokerPhaseSecondBet {
+		return nil
+	}
+	human := p.findHumanPlayer()
+	if human == nil || human.GetFolded() {
+		return nil
+	}
+	cards := make([]*Card, human.GetCardsSize())
+	for i := range cards {
+		cards[i] = human.GetCard(i)
+	}
+	active := 0
+	for _, pl := range p.players {
+		if !pl.GetIsHuman() && !pl.GetFolded() {
+			active++
+		}
+	}
+	result := CalcPokerEquity(cards, active, pokerEquitySimulations, nil)
+	return &result
+}
+
+// GetPotOdds はコールに必要な額に対するポットオッズを返す (0-100)。
+func (p *Poker) GetPotOdds() float64 {
+	if p.round.phase != PokerPhaseDeal && p.round.phase != PokerPhaseSecondBet {
+		return 0.0
+	}
+	human := p.findHumanPlayer()
+	if human == nil {
+		return 0.0
+	}
+	callAmount := p.round.lastBet - human.GetCurrentBet()
+	if callAmount < 0 {
+		callAmount = 0
+	}
+	return CalcPotOdds(p.round.pot, callAmount)
+}
+
+// findHumanPlayer は人間プレイヤーを返す (見つからなければ nil)。
+func (p *Poker) findHumanPlayer() *PokerPlayer {
+	for _, pl := range p.players {
+		if pl.GetIsHuman() {
+			return pl
+		}
+	}
+	return nil
+}
+
 func (p *Poker) GetPhase() int { return p.round.phase }
 
 // GetPlayers プレイヤー一覧取得

--- a/internal/domain/PokerEquity.go
+++ b/internal/domain/PokerEquity.go
@@ -1,0 +1,40 @@
+//go:build !js || !wasm || casino
+
+package domain
+
+import (
+	"math/rand"
+)
+
+// pokerShowdownHandSize は 5 カードドローで各プレイヤーが持つ枚数。
+const pokerShowdownHandSize = 5
+
+// CalcPokerEquity は 5 カードドロー用のエクイティをモンテカルロで求める。
+//
+// **ホールデム系と違い、コミュニティカードが無い。**各プレイヤーは自分の 5 枚
+// だけで勝負するので、シミュレーションでは相手 1 人につき 5 枚を配り、
+// 共有カード無しで比較する。
+//
+// humanCards: 人間の手札(5枚), activePlayers: アクティブな相手の人数,
+// simulations: シミュレーション回数, rng: 乱数生成器 (nil ならグローバル)。
+func CalcPokerEquity(humanCards []*Card, activePlayers, simulations int, rng *rand.Rand) HoldemEquityResult {
+	return calcEquityCore(humanCards, nil, activePlayers, simulations, rng, equityConfig{
+		holeCardsPerOpponent: pokerShowdownHandSize,
+		handNames:            PokerHandNames,
+		buildPool:            buildFullDeckPool,
+		evalHuman:            evalFiveCardShowdown,
+		evalOpponent:         evalFiveCardShowdown,
+		compareHighCards:     compareHighCardsSlice,
+	})
+}
+
+// evalFiveCardShowdown は 5 枚をそのまま評価する。共有カードは無いので
+// simCommunity は使わない (エンジンの署名に合わせるための引数)。
+func evalFiveCardShowdown(cards, _ []*Card) (int, []*Card) {
+	if len(cards) < pokerShowdownHandSize {
+		return PokerHandHighCard, nil
+	}
+	best := make([]*Card, len(cards))
+	copy(best, cards)
+	return evalFiveCardHand(best), best
+}

--- a/internal/domain/Poker_test.go
+++ b/internal/domain/Poker_test.go
@@ -3408,3 +3408,73 @@ func TestPoker_PlayerAction_TransitionsToExchangeAndRunsCpuExchanges(t *testing.
 		)
 	}
 }
+
+// **Holdem 系は EquityDisplay で勝率とポットオッズを出しているのに、5 カード
+// ドローには仕組み自体が無く、2巡目ベットの判断材料が交換確率パネルしか
+// 無かった (#4678)。**
+func TestPoker_EquityAndPotOdds(t *testing.T) {
+	withHand := func(t *testing.T, cards []*Card) *Poker {
+		t.Helper()
+		pk, players := setupPokerForHumanAction(PokerPhaseSecondBet)
+		human := players[0]
+		human.Reset()
+		for _, c := range cards {
+			human.AddCard(c)
+		}
+		return pk
+	}
+	quads := []*Card{
+		NewCard(CardDesignSpade, 1, false),
+		NewCard(CardDesignHeart, 1, false),
+		NewCard(CardDesignClover, 1, false),
+		NewCard(CardDesignDiamond, 1, false),
+		NewCard(CardDesignSpade, 13, false),
+	}
+
+	t.Run("a strong hand beats a weak one", func(t *testing.T) {
+		strong := withHand(t, quads)
+		weak := withHand(t, []*Card{
+			NewCard(CardDesignSpade, 2, false),
+			NewCard(CardDesignHeart, 4, false),
+			NewCard(CardDesignClover, 6, false),
+			NewCard(CardDesignDiamond, 9, false),
+			NewCard(CardDesignSpade, 11, false),
+		})
+
+		se, we := strong.GetEquity(), weak.GetEquity()
+		if se == nil || we == nil {
+			t.Fatal("ベッティングフェーズではエクイティが出る")
+		}
+		// **順序だけを見る。**モンテカルロなので絶対値を固定するとフレークになる。
+		// フォーカードがハイカードに負ける確率はほぼ 0 なので、この比較は安定。
+		if se.Equity <= we.Equity {
+			t.Errorf("フォーカード %.3f がハイカード %.3f 以下", se.Equity, we.Equity)
+		}
+		if se.Equity <= 0.5 {
+			t.Errorf("フォーカードの勝率が %.3f は低すぎる", se.Equity)
+		}
+	})
+
+	// **交換フェーズでは出さない。**まだ手が変わるので、確定した勝率として
+	// 読まれると誤解を招く。
+	t.Run("no equity outside the betting phases", func(t *testing.T) {
+		pk := withHand(t, quads)
+		pk.SetPhase(PokerPhaseExchange)
+		if pk.GetEquity() != nil {
+			t.Error("交換フェーズではエクイティを出さない")
+		}
+		if pk.GetPotOdds() != 0 {
+			t.Error("交換フェーズではポットオッズを出さない")
+		}
+	})
+
+	t.Run("pot odds reflect the amount needed to call", func(t *testing.T) {
+		pk := withHand(t, quads)
+		pk.SetPot(90)
+		pk.SetLastBet(10)
+		// コール 10 / (ポット 90 + 10) = 10%
+		if got := pk.GetPotOdds(); got < 9.9 || got > 10.1 {
+			t.Errorf("GetPotOdds() = %.2f, want ~10", got)
+		}
+	})
+}

--- a/internal/domain/interfaces/poker.go
+++ b/internal/domain/interfaces/poker.go
@@ -59,4 +59,8 @@ type PokerGame interface {
 	ExportProfile() interface{}
 	// ImportProfile JSONバイトからメタAIプロファイルをインポートする
 	ImportProfile(data []byte) error
+	// GetEquity ベッティングフェーズでの人間の勝率 (それ以外は nil)
+	GetEquity() *domain.HoldemEquityResult
+	// GetPotOdds コールに必要な額に対するポットオッズ (0-100)
+	GetPotOdds() float64
 }

--- a/internal/domain/interfaces/poker_mock.go
+++ b/internal/domain/interfaces/poker_mock.go
@@ -50,6 +50,17 @@ func (_m *MockPokerGame) GetPhase() int {
 }
 
 // GetPot モック
+// GetEquity はエクイティを返すモック。
+func (_m *MockPokerGame) GetEquity() *domain.HoldemEquityResult {
+	out, _ := _m.Called().Get(0).(*domain.HoldemEquityResult)
+	return out
+}
+
+// GetPotOdds はポットオッズを返すモック。
+func (_m *MockPokerGame) GetPotOdds() float64 {
+	return _m.Called().Get(0).(float64)
+}
+
 func (_m *MockPokerGame) GetPot() int {
 	ret := _m.Called()
 	return ret.Get(0).(int)


### PR DESCRIPTION
## 背景

`HoldemPage` / `OmahaPage` / `ShortDeckPage` / `PineapplePage` は `<EquityDisplay equity={state.equity} potOdds={state.potOdds} />` を持ち、ベット判断の助けとして勝率とポットオッズを表示します。

一方 `PokerPage.tsx`（5カードドロー）には **`EquityDisplay` の import も仕組み自体もありません**でした (#4678)。提示されるのは交換フェーズの役完成確率パネルだけで、**2巡目ベットで call/raise/fold を判断する材料が何もありません**でした。

## エンジンは既に再利用可能でした

`calcEquityCore` はバリアント差分を `equityConfig` で受ける形になっており（Holdem / Omaha / ShortDeck が利用中）、**5カードドロー用の設定を足すだけ**で済みました:

- コミュニティカード無し
- 相手1人あたり **5枚**（ホールデム系は2枚）

`//go:build !js || !wasm || casino` のタグが付いた領域ですが、**poker も holdem も `CategoryCasino`** なので Worker ビルドでも解決します（レジストリで確認済み）。

## ベッティングフェーズ以外では送りません

交換中はまだ手が変わるので、確定した勝率として読まれると誤解を招きます。**ページ側でフェーズを再判定せず、値の有無だけで表示を決めます** — 判定が二重になると片方だけ直したときにずれます。

## テスト

**domain**:
- フォーカード > ハイカード の**順序だけ**を見る（モンテカルロなので絶対値を固定するとフレークになる。実測 0/200）
- 交換フェーズでは `nil` / ポットオッズ 0
- ポットオッズ: コール 10 / (ポット 90 + 10) = 10%

**page**: 値があれば表示 / サーバーが送らなければ非表示

**負のコントロール**: 表示を潰すと1件が落ちます。

## 検証

- `go test -tags test ./internal/...` ✅ / `golangci-lint` → `0 issues.` ✅ / `gofmt -l internal/` 空 ✅
- `bun run check` ✅ / `bun run typecheck` ✅ / `PokerPage` 120 passed ✅

Closes #4678