### PR TITLE
feat: name what each Pineapple discard would leave behind

### DIFF
--- a/internal/adapter/presenter/PineappleCuiPresenter.go
+++ b/internal/adapter/presenter/PineappleCuiPresenter.go
@@ -135,6 +135,15 @@ func (pp *PineappleCuiPresenter) Output(p interfaces.PineappleGame, lastErr erro
 			// 2 of 3, Irish Poker keeps 2 of 4), so derive it from the deal count.
 			discardCount := p.GetInitialDealCount() - 2
 			b.WriteString(i18n.Tf("pineapple.discardPrompt", "count", strconv.Itoa(discardCount)) + "\n")
+
+			// **Web は残す2枚の性質 (ペア/スーテッド/コネクター) を候補ごとに
+			// 出しているのに、CUI はインデックス付きの手札一覧だけだった (#4685)。**
+			// ボードがまだ無い段階で唯一の判断材料になる。
+			if human := pineappleHumanPlayer(p); human != nil {
+				for _, line := range pineappleKeepFeatureLines(human) {
+					b.WriteString(line + "\n")
+				}
+			}
 		}
 
 		results := p.GetRoundResults()
@@ -199,4 +208,82 @@ func (pp *PineappleCuiPresenter) Output(p interfaces.PineappleGame, lastErr erro
 			b.WriteString(i18n.T("pineapple.gameEnd") + "\n")
 		}
 	})
+}
+
+// pineappleHumanPlayer は人間プレイヤーを返す (見つからなければ nil)。
+func pineappleHumanPlayer(p interfaces.PineappleGame) *domain.PineapplePlayer {
+	for i := 0; i < p.GetPlayerCnt(); i++ {
+		if pl := p.GetPlayer(i); pl != nil && pl.GetIsHuman() {
+			return pl
+		}
+	}
+	return nil
+}
+
+// pineappleKeepFeatureLines は「この札を捨てたら残る2枚はどういう手か」を
+// 候補ごとに1行で返す。手札が3枚でないときは何も返さない。
+//
+// **判定はフロントの pineappleKeepFeatures と同じ規則。**ペアなら即ペア、
+// そうでなければスーテッド/コネクターを並べ、どちらでもなければハイカード。
+// ここがずれると同じ手札で CUI と Web が違う助言を出す。
+func pineappleKeepFeatureLines(pl *domain.PineapplePlayer) []string {
+	n := pl.GetCardsSize()
+	if n != 3 {
+		// 捨てて2枚残る形でなければ助言できない (Irish は4枚から2枚捨て)。
+		return nil
+	}
+	out := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		var keep []*domain.Card
+		for j := 0; j < n; j++ {
+			if j != i {
+				keep = append(keep, pl.GetCard(j))
+			}
+		}
+		out = append(out, i18n.Tf("pineapple.discardKeepFeature",
+			"idx", strconv.Itoa(i),
+			"card", cuiCardStrEmoji(pl.GetCard(i)),
+			"keep", cuiCardSliceStrEmoji(keep),
+			"feature", pineappleKeepFeatureLabel(keep[0], keep[1])))
+	}
+	return out
+}
+
+// pineappleKeepFeatureLabel は残る2枚の性質ラベルを返す。
+func pineappleKeepFeatureLabel(a, b *domain.Card) string {
+	if a.GetValue() == b.GetValue() {
+		return i18n.T("pineapple.keepFeaturePair")
+	}
+	labels := make([]string, 0, 2)
+	if a.GetDesign() == b.GetDesign() {
+		labels = append(labels, i18n.T("pineapple.keepFeatureSuited"))
+	}
+	if pineappleIsConnector(a.GetValue(), b.GetValue()) {
+		labels = append(labels, i18n.T("pineapple.keepFeatureConnector"))
+	}
+	if len(labels) == 0 {
+		return i18n.T("pineapple.keepFeatureHighCard")
+	}
+	return strings.Join(labels, "/")
+}
+
+// pineappleIsConnector は2枚が連番かを返す。
+//
+// **エースは 1 と 14 の両方で数える。**A-2 も A-K もコネクター。フロントの
+// isConnector と同じ扱いで、片方だけ直すと助言が食い違う。
+func pineappleIsConnector(v1, v2 int) bool {
+	expand := func(v int) []int {
+		if v == 1 {
+			return []int{1, 14}
+		}
+		return []int{v}
+	}
+	for _, a := range expand(v1) {
+		for _, b := range expand(v2) {
+			if a-b == 1 || b-a == 1 {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/internal/adapter/presenter/PineappleCuiPresenter_test.go
+++ b/internal/adapter/presenter/PineappleCuiPresenter_test.go
@@ -138,6 +138,57 @@ func TestPineappleCuiPresenter_Output(t *testing.T) {
 		assert.Contains(t, result, "手札から1枚選んで")
 	})
 
+	// **Web は残す2枚の性質を候補ごとに出しているのに、CUI はインデックス付きの
+	// 手札一覧だけだった (#4685)。**ボードがまだ無い段階で唯一の判断材料になる。
+	t.Run("discard phase names what each keep would leave", func(t *testing.T) {
+		m, players := setupPineappleCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
+		m.On("GetPhase").Return(domain.PineapplePhaseDiscard)
+		players[0].Reset()
+		// ♠1 ♠13 ♥5: [2] を捨てるとスーテッド かつ コネクター (A-K)。
+		players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 1, false))
+		players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 13, false))
+		players[0].AddCard(domain.NewCard(domain.CardDesignHeart, 5, false))
+
+		result := p.Output(m, nil)
+		assert.Contains(t, result, "スーテッド")
+		// **エースは 1 と 14 の両方で数える。**A-K がコネクターと出ること。
+		assert.Contains(t, result, "コネクター")
+	})
+
+	t.Run("discard phase reports a pair when the keep is paired", func(t *testing.T) {
+		m, players := setupPineappleCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
+		m.On("GetPhase").Return(domain.PineapplePhaseDiscard)
+		players[0].Reset()
+		players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 7, false))
+		players[0].AddCard(domain.NewCard(domain.CardDesignHeart, 7, false))
+		players[0].AddCard(domain.NewCard(domain.CardDesignClover, 2, false))
+
+		assert.Contains(t, p.Output(m, nil), "ペア")
+	})
+
+	// **4枚配り (Irish) では出さない。**2枚捨てなので「1枚捨てたら残る2枚」
+	// という前提が成り立たない。
+	t.Run("no keep features for a four-card deal", func(t *testing.T) {
+		m, players := setupPineappleCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetInitialDealCount")
+		m.On("GetPhase").Return(domain.PineapplePhaseDiscard)
+		m.On("GetInitialDealCount").Return(4)
+		players[0].Reset()
+		for _, c := range []*domain.Card{
+			domain.NewCard(domain.CardDesignSpade, 1, false),
+			domain.NewCard(domain.CardDesignSpade, 13, false),
+			domain.NewCard(domain.CardDesignHeart, 5, false),
+			domain.NewCard(domain.CardDesignClover, 9, false),
+		} {
+			players[0].AddCard(c)
+		}
+
+		assert.NotContains(t, p.Output(m, nil), "を捨てる →")
+	})
+
 	t.Run("discard prompt says 2 cards for a 4-card deal (Irish Poker)", func(t *testing.T) {
 		m, _ := setupPineappleCuiMockWithPlayers()
 		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")

--- a/internal/i18n/locales/en/pineapple.json
+++ b/internal/i18n/locales/en/pineapple.json
@@ -53,5 +53,10 @@
   "muckPrompt": "Muck? (m=muck / sh=show)",
   "rebuyPrompt": "Rebuy? ({{chips}} chips, used {{used}}/{{max}}) (rb=rebuy / sr=skip)",
   "addonPrompt": "Add-on? ({{chips}} chips) (ad=addon / sa=skip)",
-  "gameEnd": "Game over"
+  "gameEnd": "Game over",
+  "discardKeepFeature": "  discard [{{idx}}]{{card}} → keep {{keep}} ({{feature}})",
+  "keepFeaturePair": "pair",
+  "keepFeatureSuited": "suited",
+  "keepFeatureConnector": "connector",
+  "keepFeatureHighCard": "high card"
 }

--- a/internal/i18n/locales/ja/pineapple.json
+++ b/internal/i18n/locales/ja/pineapple.json
@@ -53,5 +53,10 @@
   "muckPrompt": "マックしますか? (m=マック / sh=ショー)",
   "rebuyPrompt": "リバイしますか? ({{chips}}チップ, {{used}}/{{max}}回使用済) (rb=リバイ / sr=スキップ)",
   "addonPrompt": "アドオンしますか? ({{chips}}チップ) (ad=アドオン / sa=スキップ)",
-  "gameEnd": "ゲーム終了"
+  "gameEnd": "ゲーム終了",
+  "discardKeepFeature": "  [{{idx}}]{{card}} を捨てる → 残り {{keep}} ({{feature}})",
+  "keepFeaturePair": "ペア",
+  "keepFeatureSuited": "スーテッド",
+  "keepFeatureConnector": "コネクター",
+  "keepFeatureHighCard": "ハイカード"
 }


### PR DESCRIPTION
## 背景

`PineapplePage.tsx` は捨て札選択時に `pineappleKeepFeatures` を使い、**「残す2枚がペア/スーテッド/コネクター/ハイカードのどれに該当するか」を各候補ごとに**表示します。ボードがまだ無い段階での判断材料になります。

一方 `PineappleCuiPresenter.Output` はディスカードフェーズで**枚数の指示とインデックス付きの手札一覧しか出しません**でした (#4685)。

## エースは 1 と 14 の両方で数えます

フロントの `isConnector` は、エースを `[1, 14]` に展開して連番判定します。つまり **A-2 も A-K もコネクター**です。

この扱いを Go 側でも同じにしました。**片方だけ直すと同じ手札で CUI と Web が違う助言を出します。**

## 3枚配りのときだけ出します

4枚配り（Irish Poker）は2枚捨てなので、**「1枚捨てたら残る2枚」という前提が成り立ちません**。手札が3枚でなければ何も出しません。

## テスト

- ♠A ♠K ♥5 → 「スーテッド」と**「コネクター」**（A-K がコネクターと出ること = エースを14で数えている証拠）
- ♠7 ♥7 ♣2 → 「ペア」
- 4枚配り → 候補行を出さない

**負のコントロール**: エースを 14 と数えない実装（`[1,14]` の展開を止める）にすると1件が落ちます。この1行が非自明な規則の本体なので、そこを直接踏んでいます。

## 検証

- `go test -tags test ./internal/...` ✅ / `golangci-lint` → `0 issues.` ✅ / `gofmt -l internal/` 空 ✅
- `check-message-codes: OK (all 775 codes …)` ✅

Closes #4685