### PR TITLE
feat: show Crazy Pineapple discard consequences in the CUI

### DIFF
--- a/internal/adapter/presenter/PineappleCuiPresenter.go
+++ b/internal/adapter/presenter/PineappleCuiPresenter.go
@@ -128,6 +128,15 @@ func (pp *PineappleCuiPresenter) Output(p interfaces.PineappleGame, lastErr erro
 			}
 		}
 
+		// **Crazy Pineapple / Irish Poker は捨てるのがフロップベットの「後」。**
+		// Web は cp-discard-upcoming-banner で事前告知しているのに CUI は無言で、
+		// 捨てる前提を知らないままベット額を決めることになっていた (#4686)。
+		if p.IsDiscardAfterFlopBetting() && p.GetPhase() == domain.PineapplePhaseFlop {
+			b.WriteString("----------\n")
+			b.WriteString(i18n.Tf("pineapple.discardUpcoming",
+				"count", strconv.Itoa(p.GetInitialDealCount()-2)) + "\n")
+		}
+
 		if p.GetPhase() == domain.PineapplePhaseDiscard {
 			b.WriteString("----------\n")
 			b.WriteString(i18n.T("pineapple.discardHeader") + "\n")
@@ -136,12 +145,26 @@ func (pp *PineappleCuiPresenter) Output(p interfaces.PineappleGame, lastErr erro
 			discardCount := p.GetInitialDealCount() - 2
 			b.WriteString(i18n.Tf("pineapple.discardPrompt", "count", strconv.Itoa(discardCount)) + "\n")
 
-			// **Web は残す2枚の性質 (ペア/スーテッド/コネクター) を候補ごとに
-			// 出しているのに、CUI はインデックス付きの手札一覧だけだった (#4685)。**
-			// ボードがまだ無い段階で唯一の判断材料になる。
-			if human := pineappleHumanPlayer(p); human != nil {
-				for _, line := range pineappleKeepFeatureLines(human) {
+			// **ボードがあるかどうかで出す手掛かりが変わる。**フロップ後に捨てる
+			// Crazy Pineapple では残る2枚の完成役を名指しできる (#4686) が、
+			// フロップ前に捨てるプレーンな Pineapple ではまだ役が決まらないので、
+			// スーテッド/コネクターといった性質を出すしかない (#4685)。
+			// Web も variant でこの2つを出し分けている。
+			if previews := p.GetHumanDiscardPreviews(); len(previews) > 0 {
+				for _, pv := range previews {
+					line := i18n.Tf("pineapple.discardCandidate",
+						"idx", strconv.Itoa(pv.CardIdx),
+						"hand", cuiPokerHandName(pv.HandRank))
+					if pv.Recommended {
+						line += color.BoldYellow(i18n.T("pineapple.discardRecommended"))
+					}
 					b.WriteString(line + "\n")
+				}
+			} else if !p.IsDiscardAfterFlopBetting() {
+				if human := pineappleHumanPlayer(p); human != nil {
+					for _, line := range pineappleKeepFeatureLines(human) {
+						b.WriteString(line + "\n")
+					}
 				}
 			}
 		}

--- a/internal/adapter/presenter/PineappleCuiPresenter_test.go
+++ b/internal/adapter/presenter/PineappleCuiPresenter_test.go
@@ -4,6 +4,7 @@ package presenter_test
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -37,6 +38,7 @@ func setupPineappleCuiMock() *interfaces.MockPineappleGame {
 	m.On("GetInitialDealCount").Return(3).Maybe()
 	m.On("IsDiscardAfterFlopBetting").Return(false).Maybe()
 	m.On("GetDiscardDone").Return(([]bool)(nil)).Maybe()
+	m.On("GetHumanDiscardPreviews").Return(([]domain.PineappleDiscardPreview)(nil)).Maybe()
 	return m
 }
 
@@ -166,6 +168,98 @@ func TestPineappleCuiPresenter_Output(t *testing.T) {
 		players[0].AddCard(domain.NewCard(domain.CardDesignClover, 2, false))
 
 		assert.Contains(t, p.Output(m, nil), "ペア")
+	})
+
+	// **Crazy Pineapple は捨てるのがフロップベットの「後」。**Web は事前告知の
+	// バナーを出しているのに、CUI は無言だった (#4686)。
+	t.Run("flop betting warns that a discard is still coming", func(t *testing.T) {
+		m, _ := setupPineappleCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "IsDiscardAfterFlopBetting")
+		m.On("GetPhase").Return(domain.PineapplePhaseFlop)
+		m.On("IsDiscardAfterFlopBetting").Return(true)
+
+		assert.Contains(t, p.Output(m, nil), "フロップベット終了後にカードを1枚捨てます")
+	})
+
+	t.Run("flop betting says two cards for a four-card deal (Irish)", func(t *testing.T) {
+		m, _ := setupPineappleCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "IsDiscardAfterFlopBetting")
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetInitialDealCount")
+		m.On("GetPhase").Return(domain.PineapplePhaseFlop)
+		m.On("IsDiscardAfterFlopBetting").Return(true)
+		m.On("GetInitialDealCount").Return(4)
+
+		assert.Contains(t, p.Output(m, nil), "カードを2枚捨てます")
+	})
+
+	// **プレーンな Pineapple は告知してはいけない。**フロップ前にもう捨て終えて
+	// いるので、「この後捨てる」は嘘になる。
+	t.Run("plain Pineapple gets no upcoming-discard notice", func(t *testing.T) {
+		m, _ := setupPineappleCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
+		m.On("GetPhase").Return(domain.PineapplePhaseFlop)
+
+		assert.NotContains(t, p.Output(m, nil), "捨てます")
+	})
+
+	// **ボードがある局面では完成役そのものを名指しできる (#4686)。**
+	t.Run("discard phase names the hand each discard would leave", func(t *testing.T) {
+		m, _ := setupPineappleCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHumanDiscardPreviews")
+		m.On("GetPhase").Return(domain.PineapplePhaseDiscard)
+		m.On("GetHumanDiscardPreviews").Return([]domain.PineappleDiscardPreview{
+			{CardIdx: 0, HandRank: domain.PokerHandOnePair},
+			{CardIdx: 1, HandRank: domain.PokerHandOnePair},
+			{CardIdx: 2, HandRank: domain.PokerHandFlush, Recommended: true},
+		})
+
+		result := p.Output(m, nil)
+		assert.Contains(t, result, "[0] これを捨てると: ワンペア")
+		assert.Contains(t, result, "[2] これを捨てると: フラッシュ")
+	})
+
+	t.Run("discard phase marks only the recommended discard", func(t *testing.T) {
+		m, _ := setupPineappleCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHumanDiscardPreviews")
+		m.On("GetPhase").Return(domain.PineapplePhaseDiscard)
+		m.On("GetHumanDiscardPreviews").Return([]domain.PineappleDiscardPreview{
+			{CardIdx: 0, HandRank: domain.PokerHandOnePair},
+			{CardIdx: 1, HandRank: domain.PokerHandOnePair},
+			{CardIdx: 2, HandRank: domain.PokerHandFlush, Recommended: true},
+		})
+
+		result := p.Output(m, nil)
+		assert.Equal(t, 1, strings.Count(result, "おすすめ"), "推奨は1枚だけのはず")
+		for _, line := range strings.Split(result, "\n") {
+			if strings.Contains(line, "おすすめ") {
+				assert.Contains(t, line, "フラッシュ", "推奨が付くのは最強の役が残る捨て札")
+			}
+		}
+	})
+
+	// **完成役が出せるときに性質だけの助言を重ねない。**役が言えるならそちらが
+	// 上位互換で、2種類が並ぶと読み手はどちらに従うのか分からなくなる。
+	t.Run("keep features give way to the hand preview", func(t *testing.T) {
+		m, players := setupPineappleCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHumanDiscardPreviews")
+		m.On("GetPhase").Return(domain.PineapplePhaseDiscard)
+		m.On("GetHumanDiscardPreviews").Return([]domain.PineappleDiscardPreview{
+			{CardIdx: 0, HandRank: domain.PokerHandOnePair},
+			{CardIdx: 1, HandRank: domain.PokerHandOnePair},
+			{CardIdx: 2, HandRank: domain.PokerHandFlush, Recommended: true},
+		})
+		players[0].Reset()
+		// ♠A ♠K ♥5 — #4685 の性質表示ならスーテッド/コネクターが出る手札。
+		players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 1, false))
+		players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 13, false))
+		players[0].AddCard(domain.NewCard(domain.CardDesignHeart, 5, false))
+
+		assert.NotContains(t, p.Output(m, nil), "スーテッド")
 	})
 
 	// **4枚配り (Irish) では出さない。**2枚捨てなので「1枚捨てたら残る2枚」

--- a/internal/domain/Pineapple.go
+++ b/internal/domain/Pineapple.go
@@ -857,6 +857,67 @@ func (p *Pineapple) GetEquity() *HoldemEquityResult {
 	return &result
 }
 
+// PineappleDiscardPreview は捨て札候補1枚ぶんの「これを捨てたら残る手」。
+type PineappleDiscardPreview struct {
+	// CardIdx はホールカードのインデックス (0 始まり)。
+	CardIdx int
+	// HandRank はこの札を捨てたときに残る5枚の役 (PokerHand*)。
+	HandRank int
+	// Recommended は最も強い役が残る捨て札に付く。同点なら全部に付く。
+	Recommended bool
+}
+
+// GetHumanDiscardPreviews は人間の3枚のホールカードそれぞれについて、
+// 「その1枚を捨てたら残る2枚がボードと作る最強の役」を返す。Crazy Pineapple の
+// 「3枚のうちどれを捨てるか」を横並びで比べられるようにするためのもの (#4686)。
+//
+// **ボードを見て役を名乗れるときしか返さない。**
+//   - プレーンな Pineapple のディスカードはフロップ前なので nil。残る2枚だけでは
+//     役が決まらない。代わりにスーテッド/コネクターの手掛かりが出る (#4685)。
+//   - Irish Poker は2枚捨てなので「1枚捨てたら残る手」の前提が成り立たず nil。
+//
+// 判定は CPU の捨て方 (cpuDiscard) と同じ bestRankWithBoard を通す。別実装に
+// すると、CPU 自身が選ばない捨て方を人間に勧めることになる。
+func (p *Pineapple) GetHumanDiscardPreviews() []PineappleDiscardPreview {
+	if p.phase != PineapplePhaseDiscard {
+		return nil
+	}
+	var human *PineapplePlayer
+	for _, pl := range p.players {
+		if pl.GetIsHuman() {
+			human = pl
+			break
+		}
+	}
+	// 手札3枚ちょうどのときだけ。捨て終わった後は2枚なのでここで弾かれる。
+	if human == nil || human.GetFolded() || human.GetCardsSize() != 3 {
+		return nil
+	}
+	if len(p.communityCards) < 3 {
+		return nil
+	}
+
+	previews := make([]PineappleDiscardPreview, human.GetCardsSize())
+	best := -1
+	for k := range previews {
+		keep := make([]*Card, 0, len(previews)-1)
+		for i := 0; i < human.GetCardsSize(); i++ {
+			if i != k {
+				keep = append(keep, human.GetCard(i))
+			}
+		}
+		rank := p.bestRankWithBoard(keep)
+		previews[k] = PineappleDiscardPreview{CardIdx: k, HandRank: rank}
+		if rank > best {
+			best = rank
+		}
+	}
+	for i := range previews {
+		previews[i].Recommended = previews[i].HandRank == best
+	}
+	return previews
+}
+
 // GetPotOdds ポットオッズを返す
 func (p *Pineapple) GetPotOdds() float64 {
 	if p.phase < PineapplePhasePreFlop || p.phase > PineapplePhaseRiver {

--- a/internal/domain/PineappleCPU.go
+++ b/internal/domain/PineappleCPU.go
@@ -376,6 +376,32 @@ func evalTwoCardStrength(c1, c2 *Card) int {
 	return clamp(score, 0, 100)
 }
 
+// bestRankWithBoard は渡したホールカードと現在のボードから作れる最強の役を返す。
+//
+// **5枚に届かないときはポーカーの役ではなくプリフロップ用スコア (0-100) を
+// 返す。**尺度が2つ混ざるので、同じ局面の中での大小比較にしか使えない。
+// 外向きに役を名乗る GetHumanDiscardPreviews はボードが揃うまで何も返さない。
+func (p *Pineapple) bestRankWithBoard(hole []*Card) int {
+	all := make([]*Card, 0, len(hole)+len(p.communityCards))
+	all = append(all, hole...)
+	all = append(all, p.communityCards...)
+
+	if len(all) < 5 {
+		if len(hole) == 2 {
+			return evalTwoCardStrength(hole[0], hole[1])
+		}
+		return -1
+	}
+
+	rank := -1
+	for _, combo := range combinations(all, 5) {
+		if r := evalFiveCardHand(combo); r > rank {
+			rank = r
+		}
+	}
+	return rank
+}
+
 // cpuDiscard CPUプレイヤーのディスカード意思決定
 // C(N,2)通りの2枚ペアを全評価し、最適な2枚を残すように1枚を捨てる。
 func (p *Pineapple) cpuDiscard(idx int) int {
@@ -390,21 +416,7 @@ func (p *Pineapple) cpuDiscard(idx int) int {
 
 	for i := 0; i < n; i++ {
 		for j := i + 1; j < n; j++ {
-			all := make([]*Card, 0, 2+len(p.communityCards))
-			all = append(all, pl.GetCard(i), pl.GetCard(j))
-			all = append(all, p.communityCards...)
-
-			rank := -1
-			if len(all) >= 5 {
-				for _, combo := range combinations(all, 5) {
-					if r := evalFiveCardHand(combo); r > rank {
-						rank = r
-					}
-				}
-			} else {
-				rank = evalTwoCardStrength(pl.GetCard(i), pl.GetCard(j))
-			}
-
+			rank := p.bestRankWithBoard([]*Card{pl.GetCard(i), pl.GetCard(j)})
 			if rank > bestRank {
 				bestRank = rank
 				bestKeepI, bestKeepJ = i, j

--- a/internal/domain/Pineapple_test.go
+++ b/internal/domain/Pineapple_test.go
@@ -569,3 +569,113 @@ func TestPineapple_DiscardCards(t *testing.T) {
 		assert.False(t, p.discardDone[0])
 	})
 }
+
+// pineappleDiscardFixture は「フロップ後のディスカード」局面を作る。
+// Reset() を通さないのは、配り次第で決まる属性 (ボード・手札) を固定するため。
+func pineappleDiscardFixture(t *testing.T, hole, board []*Card) *Pineapple {
+	t.Helper()
+	p := newTestPineapple()
+	p.discardAfterFlopBetting = true
+	p.phase = PineapplePhaseDiscard
+	p.communityCards = board
+	p.discardDone = make([]bool, len(p.players))
+	for i := 1; i < len(p.players); i++ {
+		p.discardDone[i] = true
+	}
+	p.players[0].Reset()
+	for _, c := range hole {
+		p.players[0].AddCard(c)
+	}
+	return p
+}
+
+func TestPineapple_GetHumanDiscardPreviews(t *testing.T) {
+	// ♠A ♠K ♥2 / ボード ♠2 ♠3 ♠4。
+	// ♥2 を捨てると ♠A ♠K が残ってスペード5枚 = フラッシュ。
+	// ♠A / ♠K を捨てるとどちらも 2 のワンペアにしかならない。
+	spadeFlushHole := []*Card{
+		NewCard(CardDesignSpade, 1, false),
+		NewCard(CardDesignSpade, 13, false),
+		NewCard(CardDesignHeart, 2, false),
+	}
+	spadeBoard := []*Card{
+		NewCard(CardDesignSpade, 2, false),
+		NewCard(CardDesignSpade, 3, false),
+		NewCard(CardDesignSpade, 4, false),
+	}
+
+	t.Run("ranks each discard by the hand the other two would make", func(t *testing.T) {
+		p := pineappleDiscardFixture(t, spadeFlushHole, spadeBoard)
+		previews := p.GetHumanDiscardPreviews()
+		require.Len(t, previews, 3)
+		assert.Equal(t, []int{0, 1, 2}, []int{previews[0].CardIdx, previews[1].CardIdx, previews[2].CardIdx})
+		assert.Equal(t, PokerHandOnePair, previews[0].HandRank)
+		assert.Equal(t, PokerHandOnePair, previews[1].HandRank)
+		assert.Equal(t, PokerHandFlush, previews[2].HandRank)
+	})
+
+	t.Run("recommends only the discard that leaves the strongest hand", func(t *testing.T) {
+		p := pineappleDiscardFixture(t, spadeFlushHole, spadeBoard)
+		previews := p.GetHumanDiscardPreviews()
+		require.Len(t, previews, 3)
+		assert.False(t, previews[0].Recommended)
+		assert.False(t, previews[1].Recommended)
+		assert.True(t, previews[2].Recommended, "捨てるとフラッシュが残る札が推奨されるべき")
+	})
+
+	t.Run("recommends every discard that ties for the best hand", func(t *testing.T) {
+		// ♠A ♥A ♦A / ボード ♣K ♥K ♦2。どの1枚を捨てても A のペア + K のペアで
+		// ツーペア。**同点は全部に推奨が付く** (どれを選んでも損しない)。
+		p := pineappleDiscardFixture(t, []*Card{
+			NewCard(CardDesignSpade, 1, false),
+			NewCard(CardDesignHeart, 1, false),
+			NewCard(CardDesignDiamond, 1, false),
+		}, []*Card{
+			NewCard(CardDesignClover, 13, false),
+			NewCard(CardDesignHeart, 13, false),
+			NewCard(CardDesignDiamond, 2, false),
+		})
+		previews := p.GetHumanDiscardPreviews()
+		require.Len(t, previews, 3)
+		for i, pv := range previews {
+			assert.True(t, pv.Recommended, "index %d も同点なので推奨されるべき", i)
+		}
+	})
+
+	// **推奨は CPU の捨て方と同じ規則でなければならない。**別々に実装すると
+	// 「CPU がやらない手」を人間に勧めることになる。
+	t.Run("agrees with the CPU's own discard choice", func(t *testing.T) {
+		p := pineappleDiscardFixture(t, spadeFlushHole, spadeBoard)
+		previews := p.GetHumanDiscardPreviews()
+		require.Len(t, previews, 3)
+		cpuPick := p.cpuDiscard(0)
+		assert.True(t, previews[cpuPick].Recommended,
+			"CPU が捨てる札 (index %d) は推奨に含まれるべき", cpuPick)
+	})
+
+	t.Run("returns nothing before the flop is on the table", func(t *testing.T) {
+		// プレーンな Pineapple はフロップ前に捨てる。残る2枚だけでは役を
+		// 名指しできないので、ここは何も返さない (#4685 の性質表示が出る)。
+		p := pineappleDiscardFixture(t, spadeFlushHole, nil)
+		assert.Nil(t, p.GetHumanDiscardPreviews())
+	})
+
+	t.Run("returns nothing for a four-card deal", func(t *testing.T) {
+		// Irish Poker は2枚捨てなので「1枚捨てたら残る手」の前提が崩れる。
+		p := pineappleDiscardFixture(t, append(append([]*Card{}, spadeFlushHole...),
+			NewCard(CardDesignClover, 9, false)), spadeBoard)
+		assert.Nil(t, p.GetHumanDiscardPreviews())
+	})
+
+	t.Run("returns nothing outside the discard phase", func(t *testing.T) {
+		p := pineappleDiscardFixture(t, spadeFlushHole, spadeBoard)
+		p.phase = PineapplePhaseFlop
+		assert.Nil(t, p.GetHumanDiscardPreviews())
+	})
+
+	t.Run("returns nothing when the human has folded", func(t *testing.T) {
+		p := pineappleDiscardFixture(t, spadeFlushHole, spadeBoard)
+		p.players[0].SetFolded(true)
+		assert.Nil(t, p.GetHumanDiscardPreviews())
+	})
+}

--- a/internal/domain/interfaces/pineapple.go
+++ b/internal/domain/interfaces/pineapple.go
@@ -75,6 +75,8 @@ type PineappleGame interface {
 	ExportProfile() interface{}
 	// ImportProfile JSONバイトからメタAIプロファイルをインポートする
 	ImportProfile(data []byte) error
+	// GetHumanDiscardPreviews 人間の各ホールカードについて「それを捨てたら残る手」を取得する
+	GetHumanDiscardPreviews() []domain.PineappleDiscardPreview
 	// GetEquity エクイティ計算結果を取得する
 	GetEquity() *domain.HoldemEquityResult
 	// GetPotOdds ポットオッズを取得する

--- a/internal/domain/interfaces/pineapple_mock.go
+++ b/internal/domain/interfaces/pineapple_mock.go
@@ -322,6 +322,15 @@ func (_m *MockPineappleGame) GetActionLog() []*domain.ActionLogEntry {
 	return nil
 }
 
+// GetHumanDiscardPreviews モック
+func (_m *MockPineappleGame) GetHumanDiscardPreviews() []domain.PineappleDiscardPreview {
+	ret := _m.Called()
+	if ret.Get(0) == nil {
+		return nil
+	}
+	return ret.Get(0).([]domain.PineappleDiscardPreview)
+}
+
 // GetEquity モック
 func (_m *MockPineappleGame) GetEquity() *domain.HoldemEquityResult {
 	ret := _m.Called()

--- a/internal/i18n/locales/en/pineapple.json
+++ b/internal/i18n/locales/en/pineapple.json
@@ -58,5 +58,8 @@
   "keepFeaturePair": "pair",
   "keepFeatureSuited": "suited",
   "keepFeatureConnector": "connector",
-  "keepFeatureHighCard": "high card"
+  "keepFeatureHighCard": "high card",
+  "discardUpcoming": "You will discard {{count}} card(s) after the flop betting round",
+  "discardCandidate": "  [{{idx}}] discard this and you keep: {{hand}}",
+  "discardRecommended": " <- recommended"
 }

--- a/internal/i18n/locales/ja/pineapple.json
+++ b/internal/i18n/locales/ja/pineapple.json
@@ -58,5 +58,8 @@
   "keepFeaturePair": "ペア",
   "keepFeatureSuited": "スーテッド",
   "keepFeatureConnector": "コネクター",
-  "keepFeatureHighCard": "ハイカード"
+  "keepFeatureHighCard": "ハイカード",
+  "discardUpcoming": "フロップベット終了後にカードを{{count}}枚捨てます",
+  "discardCandidate": "  [{{idx}}] これを捨てると: {{hand}}",
+  "discardRecommended": " ← おすすめ"
 }


### PR DESCRIPTION
## 背景

Crazy Pineapple は**フロップベットが終わってから**1枚捨てます。Web (`PineapplePage.tsx`) はそれを踏まえて2つ出しています。

1. フロップベット中に `cp-discard-upcoming-banner` で「この後に捨てる」と予告
2. 捨て札フェーズで候補ごとの完成役 (`candidatePreviews`) と推奨バッジ (`recommendedDiscards`)

`PineappleCuiPresenter.Output` はどちらも出していませんでした (#4686)。**捨てる前提を知らないままベット額を決め、役を計算せずに1枚選ぶ**ことになっていました。

## 推奨は CPU 自身の捨て方と同じ経路を通します

`cpuDiscard` はすでに「残す2枚 + ボードの最強役」を総当たりで評価しています。**これが捨て札の規則そのもの**なので、`bestRankWithBoard` に切り出し、人間向けの `GetHumanDiscardPreviews` も同じ関数を呼びます。

別実装にすると **CPU 自身が選ばない捨て方を人間に勧める**ことになるので、「CPU の選択が推奨に含まれる」をテストで固定しました。

## ボードの有無で出す手掛かりが変わります

| | 捨てるタイミング | CUI が出すもの |
|---|---|---|
| Pineapple | フロップ**前** | スーテッド/コネクター等の性質 (#4685) |
| Crazy Pineapple | フロップ**後** | **残る2枚の完成役 + 推奨** (本PR) |
| Irish Poker | フロップ後・2枚 | どちらも出さない |

役が名指しできるときに性質を重ねると、**読み手はどちらに従えばいいのか分からなくなる**ので出し分けます。Irish は2枚捨てなので「1枚捨てたら残る手」という前提自体が成り立ちません。

## 負のコントロール

新しいゲートは5つあり、**それぞれ壊すとテストが落ちる**ことを実測しました。

| 壊し方 | 落ちる件数 |
|---|---|
| ボード無しでも役を名乗る | 1 |
| 同点を全部おすすめにする | 1 |
| 4枚配りでも出す | 1 |
| 素の Pineapple にも告知を出す | 1 |
| 性質表示を役表示に重ねる | 1 |

## 検証

- `go test -tags test ./internal/...` ✅ / `golangci-lint run ./internal/...` → `0 issues.` ✅ / `gofmt -l internal/` 空 ✅
- `check-message-codes: OK (all 775 codes …)` ✅

Closes #4686