### PR TITLE
feat: give Pai Gow CUI the house-way split it already computes

### DIFF
--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -1434,7 +1434,8 @@
     "zwicker.win": "Your team wins",
     "bidwhist.hintRequested": "Hint available",
     "bidwhist.noHint": "No hint available",
-    "russianbank.stopAvailable": "The CPU missed a forced move — call Stop to penalise it"
+    "russianbank.stopAvailable": "The CPU missed a forced move — call Stop to penalise it",
+    "paigow.hintNone": "No hint is available now."
   },
   "manual": {
     "ariaLabel": "Game Manual",

--- a/frontend/src/i18n/locales/ja/common.json
+++ b/frontend/src/i18n/locales/ja/common.json
@@ -1434,7 +1434,8 @@
     "zwicker.win": "勝ちました",
     "bidwhist.hintRequested": "ヒントがあります",
     "bidwhist.noHint": "ヒントはありません",
-    "russianbank.stopAvailable": "CPU が強制手を取りこぼしています。「ストップ」で咎められます"
+    "russianbank.stopAvailable": "CPU が強制手を取りこぼしています。「ストップ」で咎められます",
+    "paigow.hintNone": "いまはヒントを出せません。"
   },
   "manual": {
     "ariaLabel": "ゲームマニュアル",

--- a/internal/adapter/controller/PaiGowCuiController.go
+++ b/internal/adapter/controller/PaiGowCuiController.go
@@ -27,7 +27,7 @@ func (pgc *PaiGowCuiController) Exec(command string) string {
 	return execCuiCommand(
 		command,
 		func(_ []string) string { return pgc.pi.Reset() },
-		[]string{"b", "bet", "s", "set", "log", "l"},
+		[]string{"b", "bet", "s", "set", "a", "auto", "h", "hint", "log", "l"},
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "b", "bet":
@@ -49,6 +49,10 @@ func (pgc *PaiGowCuiController) Exec(command string) string {
 					return errMsg, true
 				}
 				return pgc.pi.SetHands(low0, low1), true
+			case "a", "auto":
+				return pgc.pi.AutoSetHands(), true
+			case "h", "hint":
+				return pgc.pi.Hint(), true
 			default:
 				return handleCuiLog(cmd, pgc.pi.ActionLog)
 			}

--- a/internal/adapter/controller/PaiGowCuiController_test.go
+++ b/internal/adapter/controller/PaiGowCuiController_test.go
@@ -17,7 +17,39 @@ func newMockPaiGowInteractor() *usecase.MockPaiGowInteractor {
 	m.On("Bet", 100).Return("bet result")
 	m.On("SetHands", 0, 1).Return("set result")
 	m.On("ActionLog").Return("action log result")
+	m.On("AutoSetHands").Return("auto result")
+	m.On("Hint").Return("hint result")
 	return m
+}
+
+// **7枚から反則にならない分割を手作業で探すしかなかった (#4696)。**
+// Web には「自動設定」ボタンと反則チェックがあるのに CUI には無かった。
+func TestPaiGowCuiController_AutoSetHands(t *testing.T) {
+	m := newMockPaiGowInteractor()
+	c := controller.NewPaiGowCuiController(m)
+
+	assert.Equal(t, "auto result", c.Exec("a"))
+	assert.Equal(t, "auto result", c.Exec("auto"))
+}
+
+func TestPaiGowCuiController_Hint(t *testing.T) {
+	m := newMockPaiGowInteractor()
+	c := controller.NewPaiGowCuiController(m)
+
+	assert.Equal(t, "hint result", c.Exec("h"))
+	assert.Equal(t, "hint result", c.Exec("hint"))
+}
+
+// **既存コマンドは何も変わらない。**a/h を足したことで b/s が食われていないこと。
+func TestPaiGowCuiController_ExistingCommandsUnaffected(t *testing.T) {
+	m := newMockPaiGowInteractor()
+	c := controller.NewPaiGowCuiController(m)
+
+	assert.Equal(t, "bet result", c.Exec("b 100"))
+	assert.Equal(t, "set result", c.Exec("s 0 1"))
+	assert.Equal(t, "action log result", c.Exec("log"))
+	m.AssertNotCalled(t, "AutoSetHands")
+	m.AssertNotCalled(t, "Hint")
 }
 
 func TestPaiGowCuiController_Quit(t *testing.T) {

--- a/internal/adapter/controller/PaiGowWebController.go
+++ b/internal/adapter/controller/PaiGowWebController.go
@@ -18,25 +18,34 @@ type PaiGowWebInput struct {
 
 // PaiGowWebOutput パイガオポーカーWebアウトプット
 type PaiGowWebOutput struct {
-	PlayerCards    []*WebOutputCard `json:"playerCards"`
-	DealerCards    []*WebOutputCard `json:"dealerCards"`
-	PlayerHighHand []*WebOutputCard `json:"playerHighHand"`
-	PlayerLowHand  []*WebOutputCard `json:"playerLowHand"`
-	DealerHighHand []*WebOutputCard `json:"dealerHighHand"`
-	DealerLowHand  []*WebOutputCard `json:"dealerLowHand"`
-	Phase          int              `json:"phase"`
-	Chips          int              `json:"chips"`
-	Bet            int              `json:"bet"`
-	Result         int              `json:"result"`
-	HighHandResult int              `json:"highHandResult"`
-	LowHandResult  int              `json:"lowHandResult"`
-	Payout         int              `json:"payout"`
-	Commission     int              `json:"commission"`
-	PlayerHighRank int              `json:"playerHighRank"`
-	PlayerLowRank  int              `json:"playerLowRank"`
-	DealerHighRank int              `json:"dealerHighRank"`
-	DealerLowRank  int              `json:"dealerLowRank"`
+	PlayerCards    []*WebOutputCard     `json:"playerCards"`
+	DealerCards    []*WebOutputCard     `json:"dealerCards"`
+	PlayerHighHand []*WebOutputCard     `json:"playerHighHand"`
+	PlayerLowHand  []*WebOutputCard     `json:"playerLowHand"`
+	DealerHighHand []*WebOutputCard     `json:"dealerHighHand"`
+	DealerLowHand  []*WebOutputCard     `json:"dealerLowHand"`
+	Phase          int                  `json:"phase"`
+	Chips          int                  `json:"chips"`
+	Bet            int                  `json:"bet"`
+	Result         int                  `json:"result"`
+	HighHandResult int                  `json:"highHandResult"`
+	LowHandResult  int                  `json:"lowHandResult"`
+	Payout         int                  `json:"payout"`
+	Commission     int                  `json:"commission"`
+	PlayerHighRank int                  `json:"playerHighRank"`
+	PlayerLowRank  int                  `json:"playerLowRank"`
+	DealerHighRank int                  `json:"dealerHighRank"`
+	DealerLowRank  int                  `json:"dealerLowRank"`
+	Hint           *PaiGowWebOutputHint `json:"hint,omitempty"`
 	WebOutputBase
+}
+
+// PaiGowWebOutputHint はセットハンドフェーズの推奨分割。
+type PaiGowWebOutputHint struct {
+	LowIdx0   int    `json:"lowIdx0"`
+	LowIdx1   int    `json:"lowIdx1"`
+	LowIsPair bool   `json:"lowIsPair"`
+	Reason    string `json:"reason"`
 }
 
 // PaiGowWebController パイガオポーカーWebコントローラークラス

--- a/internal/adapter/controller/usecase/PaiGowInteractor_mock.go
+++ b/internal/adapter/controller/usecase/PaiGowInteractor_mock.go
@@ -24,6 +24,16 @@ func (m *MockPaiGowInteractor) SetHands(lowIdx0, lowIdx1 int) string {
 	return args.String(0)
 }
 
+func (m *MockPaiGowInteractor) AutoSetHands() string {
+	args := m.Called()
+	return args.String(0)
+}
+
+func (m *MockPaiGowInteractor) Hint() string {
+	args := m.Called()
+	return args.String(0)
+}
+
 func (m *MockPaiGowInteractor) ActionLog() string {
 	args := m.Called()
 	return args.String(0)

--- a/internal/adapter/presenter/PaiGowCuiPresenter.go
+++ b/internal/adapter/presenter/PaiGowCuiPresenter.go
@@ -98,6 +98,35 @@ func (pp *PaiGowCuiPresenter) Output(pg interfaces.PaiGowGame, lastErr error) st
 	return sb.String()
 }
 
+// HintOutput はセットハンドフェーズでの推奨分割を出力する。
+//
+// **どの2枚をローに置くかは、ディーラーのハウスウェイと同じ規則で選ぶ** (#4696)。
+// Web は「自動設定」ボタンと反則チェックを常時出しているのに、CUI は7枚から
+// 反則にならない分割を完全に手作業・無警告で探すしかなかった。
+func (pp *PaiGowCuiPresenter) HintOutput(pg interfaces.PaiGowGame) string {
+	hint := pg.GetHint()
+	if hint == nil {
+		return i18n.T("paigow.hintNone") + "\n"
+	}
+	cards := pg.GetPlayerCards()
+	low := ""
+	if hint.LowIdx0 < len(cards) && hint.LowIdx1 < len(cards) {
+		low = cuiCardStr(cards[hint.LowIdx0]) + " " + cuiCardStr(cards[hint.LowIdx1])
+	}
+	return color.Yellow(i18n.Tf("paigow.hintSplit",
+		"idx0", strconv.Itoa(hint.LowIdx0),
+		"idx1", strconv.Itoa(hint.LowIdx1),
+		"cards", low,
+		"reason", hintReasonStr(hint.Reason, paiGowHintReasonKeys),
+	)) + "\n"
+}
+
+// paiGowHintReasonKeys はパイガオ固有のヒント理由キー。
+var paiGowHintReasonKeys = map[string]string{
+	"house_way_pair": "paigow.hintReasonPair",
+	"house_way_high": "paigow.hintReasonHigh",
+}
+
 // ActionLogOutput 棋譜をテキスト出力
 func (pp *PaiGowCuiPresenter) ActionLogOutput(pg interfaces.PaiGowGame) string {
 	return actionLogOutputText(pg)

--- a/internal/adapter/presenter/PaiGowCuiPresenter_test.go
+++ b/internal/adapter/presenter/PaiGowCuiPresenter_test.go
@@ -20,6 +20,7 @@ func setupPaiGowCuiMockDefaults(m *interfaces.MockPaiGowGame) {
 	m.On("GetDealerHighHand").Return(([]*domain.Card)(nil)).Maybe()
 	m.On("GetDealerLowHand").Return(([]*domain.Card)(nil)).Maybe()
 	m.On("GetGameEndFlag").Return(false).Maybe()
+	m.On("GetHint").Return((*domain.PaiGowHint)(nil)).Maybe()
 	m.On("GetBet").Return(0).Maybe()
 	m.On("GetResult").Return(domain.GameResult(0)).Maybe()
 	m.On("GetHighHandResult").Return(domain.GameResult(0)).Maybe()
@@ -102,6 +103,7 @@ func TestPaiGowCuiPresenter_Output_PlayerWins(t *testing.T) {
 	m.On("GetDealerHighHand").Return(([]*domain.Card)(nil)).Maybe()
 	m.On("GetDealerLowHand").Return(([]*domain.Card)(nil)).Maybe()
 	m.On("GetGameEndFlag").Return(true).Maybe()
+	m.On("GetHint").Return((*domain.PaiGowHint)(nil)).Maybe()
 	m.On("GetBet").Return(100).Maybe()
 	m.On("GetResult").Return(domain.GameResultWin).Maybe()
 	m.On("GetHighHandResult").Return(domain.GameResultWin).Maybe()
@@ -132,6 +134,7 @@ func TestPaiGowCuiPresenter_Output_DealerWins(t *testing.T) {
 	m.On("GetDealerHighHand").Return(([]*domain.Card)(nil)).Maybe()
 	m.On("GetDealerLowHand").Return(([]*domain.Card)(nil)).Maybe()
 	m.On("GetGameEndFlag").Return(true).Maybe()
+	m.On("GetHint").Return((*domain.PaiGowHint)(nil)).Maybe()
 	m.On("GetBet").Return(100).Maybe()
 	m.On("GetResult").Return(domain.GameResultLose).Maybe()
 	m.On("GetHighHandResult").Return(domain.GameResultLose).Maybe()
@@ -160,6 +163,7 @@ func TestPaiGowCuiPresenter_Output_Push(t *testing.T) {
 	m.On("GetDealerHighHand").Return(([]*domain.Card)(nil)).Maybe()
 	m.On("GetDealerLowHand").Return(([]*domain.Card)(nil)).Maybe()
 	m.On("GetGameEndFlag").Return(true).Maybe()
+	m.On("GetHint").Return((*domain.PaiGowHint)(nil)).Maybe()
 	m.On("GetBet").Return(100).Maybe()
 	m.On("GetResult").Return(domain.GameResultDraw).Maybe()
 	m.On("GetHighHandResult").Return(domain.GameResultWin).Maybe()
@@ -207,6 +211,7 @@ func TestPaiGowCuiPresenter_Output_EndPhaseWithHands(t *testing.T) {
 		domain.NewCard(domain.CardDesignHeart, 3, false),
 	}).Maybe()
 	m.On("GetGameEndFlag").Return(true).Maybe()
+	m.On("GetHint").Return((*domain.PaiGowHint)(nil)).Maybe()
 	m.On("GetBet").Return(100).Maybe()
 	m.On("GetResult").Return(domain.GameResultWin).Maybe()
 	m.On("GetHighHandResult").Return(domain.GameResultWin).Maybe()
@@ -263,4 +268,54 @@ func TestPaiGowCuiPresenter_ActionLogOutput(t *testing.T) {
 
 	result := p.ActionLogOutput(m)
 	assert.Contains(t, result, "棋譜")
+}
+
+// **CUI には推奨分割を出す口が無く、7枚から反則にならない2枚を無警告で
+// 探すしかなかった (#4696)。**Web は「自動設定」ボタンと反則チェックを
+// 常時出していた。
+func TestPaiGowCuiPresenter_HintOutput(t *testing.T) {
+	p := new(PaiGowCuiPresenter)
+	cards := []*domain.Card{
+		domain.NewCard(domain.CardDesignSpade, 14, false),
+		domain.NewCard(domain.CardDesignHeart, 14, false),
+		domain.NewCard(domain.CardDesignSpade, 13, false),
+		domain.NewCard(domain.CardDesignHeart, 13, false),
+		domain.NewCard(domain.CardDesignClover, 5, false),
+		domain.NewCard(domain.CardDesignDiamond, 7, false),
+		domain.NewCard(domain.CardDesignSpade, 9, false),
+	}
+	withHint := func(h *domain.PaiGowHint) *interfaces.MockPaiGowGame {
+		m := new(interfaces.MockPaiGowGame)
+		m.On("GetPlayerCards").Return(cards).Maybe()
+		m.On("GetHint").Return(h)
+		return m
+	}
+
+	t.Run("names the recommended indices and the cards behind them", func(t *testing.T) {
+		out := p.HintOutput(withHint(&domain.PaiGowHint{
+			LowIdx0: 2, LowIdx1: 3, LowIsPair: true, Reason: "house_way_pair",
+		}))
+		assert.Contains(t, out, "[2]")
+		assert.Contains(t, out, "[3]")
+		// **インデックスだけでは足りない。**どの札を指しているか読み手に見えること。
+		assert.Contains(t, out, "13")
+	})
+
+	t.Run("explains why a pair split is safe", func(t *testing.T) {
+		out := p.HintOutput(withHint(&domain.PaiGowHint{
+			LowIdx0: 2, LowIdx1: 3, LowIsPair: true, Reason: "house_way_pair",
+		}))
+		assert.Contains(t, out, "反則")
+	})
+
+	// 理由キーごとに違う文言が出ること (どちらも同じ文なら理由は飾り)。
+	t.Run("high-card and pair splits give different reasons", func(t *testing.T) {
+		pair := p.HintOutput(withHint(&domain.PaiGowHint{LowIdx0: 2, LowIdx1: 3, LowIsPair: true, Reason: "house_way_pair"}))
+		high := p.HintOutput(withHint(&domain.PaiGowHint{LowIdx0: 0, LowIdx1: 2, Reason: "house_way_high"}))
+		assert.NotEqual(t, pair, high)
+	})
+
+	t.Run("says so when no hint is available", func(t *testing.T) {
+		assert.Contains(t, p.HintOutput(withHint(nil)), "ヒントを出せません")
+	})
 }

--- a/internal/adapter/presenter/PaiGowWebPresenter.go
+++ b/internal/adapter/presenter/PaiGowWebPresenter.go
@@ -35,6 +35,11 @@ func (pp *PaiGowWebPresenter) Output(pg interfaces.PaiGowGame, lastErr error) st
 	resObj.DealerHighRank = pg.GetDealerHighRank()
 	resObj.DealerLowRank = pg.GetDealerLowRank()
 
+	// **受動ヒントは Output() でも埋める。**HintOutput() は command:"hint" 専用の
+	// レスポンスで、ページの state にはマージされない。フェーズ判定は
+	// PaiGow.GetHint() 側が持つ。
+	resObj.Hint = paiGowWebHint(pg)
+
 	if lastErr != nil {
 		resObj.Message = lastErr.Error()
 	} else if pg.GetGameEndFlag() {
@@ -53,6 +58,31 @@ func (pp *PaiGowWebPresenter) Output(pg interfaces.PaiGowGame, lastErr error) st
 	}
 
 	return marshalOrError(resObj)
+}
+
+// HintOutput ヒント情報をJSON出力する
+func (pp *PaiGowWebPresenter) HintOutput(pg interfaces.PaiGowGame) string {
+	resObj := new(controller.PaiGowWebOutput)
+	resObj.Hint = paiGowWebHint(pg)
+	if resObj.Hint == nil {
+		resObj.Message = "No hint is available now."
+		resObj.MessageCode = "paigow.hintNone"
+	}
+	return marshalOrError(resObj)
+}
+
+// paiGowWebHint はドメインのヒントを JSON 用の形に移す。
+func paiGowWebHint(pg interfaces.PaiGowGame) *controller.PaiGowWebOutputHint {
+	hint := pg.GetHint()
+	if hint == nil {
+		return nil
+	}
+	return &controller.PaiGowWebOutputHint{
+		LowIdx0:   hint.LowIdx0,
+		LowIdx1:   hint.LowIdx1,
+		LowIsPair: hint.LowIsPair,
+		Reason:    hint.Reason,
+	}
 }
 
 // ActionLogOutput 棋譜をJSON出力

--- a/internal/adapter/presenter/PaiGowWebPresenter_test.go
+++ b/internal/adapter/presenter/PaiGowWebPresenter_test.go
@@ -22,6 +22,7 @@ func setupPaiGowWebMockDefaults(m *interfaces.MockPaiGowGame) {
 	m.On("GetDealerHighHand").Return(([]*domain.Card)(nil)).Maybe()
 	m.On("GetDealerLowHand").Return(([]*domain.Card)(nil)).Maybe()
 	m.On("GetGameEndFlag").Return(false).Maybe()
+	m.On("GetHint").Return((*domain.PaiGowHint)(nil)).Maybe()
 	m.On("GetBet").Return(0).Maybe()
 	m.On("GetResult").Return(domain.GameResult(0)).Maybe()
 	m.On("GetHighHandResult").Return(domain.GameResult(0)).Maybe()
@@ -76,6 +77,7 @@ func TestPaiGowWebPresenter_Output_PlayerWins(t *testing.T) {
 	m.On("GetDealerHighHand").Return(([]*domain.Card)(nil)).Maybe()
 	m.On("GetDealerLowHand").Return(([]*domain.Card)(nil)).Maybe()
 	m.On("GetGameEndFlag").Return(true).Maybe()
+	m.On("GetHint").Return((*domain.PaiGowHint)(nil)).Maybe()
 	m.On("GetBet").Return(100).Maybe()
 	m.On("GetResult").Return(domain.GameResultWin).Maybe()
 	m.On("GetHighHandResult").Return(domain.GameResultWin).Maybe()
@@ -105,6 +107,7 @@ func TestPaiGowWebPresenter_Output_DealerWins(t *testing.T) {
 	m.On("GetDealerHighHand").Return(([]*domain.Card)(nil)).Maybe()
 	m.On("GetDealerLowHand").Return(([]*domain.Card)(nil)).Maybe()
 	m.On("GetGameEndFlag").Return(true).Maybe()
+	m.On("GetHint").Return((*domain.PaiGowHint)(nil)).Maybe()
 	m.On("GetBet").Return(100).Maybe()
 	m.On("GetResult").Return(domain.GameResultLose).Maybe()
 	m.On("GetHighHandResult").Return(domain.GameResultLose).Maybe()
@@ -134,6 +137,7 @@ func TestPaiGowWebPresenter_Output_Push(t *testing.T) {
 	m.On("GetDealerHighHand").Return(([]*domain.Card)(nil)).Maybe()
 	m.On("GetDealerLowHand").Return(([]*domain.Card)(nil)).Maybe()
 	m.On("GetGameEndFlag").Return(true).Maybe()
+	m.On("GetHint").Return((*domain.PaiGowHint)(nil)).Maybe()
 	m.On("GetBet").Return(100).Maybe()
 	m.On("GetResult").Return(domain.GameResultDraw).Maybe()
 	m.On("GetHighHandResult").Return(domain.GameResultWin).Maybe()
@@ -159,4 +163,55 @@ func TestPaiGowWebPresenter_ActionLogOutput(t *testing.T) {
 
 	result := p.ActionLogOutput(m)
 	assert.Contains(t, result, "entries")
+}
+
+func TestPaiGowWebPresenter_Hint(t *testing.T) {
+	p := new(PaiGowWebPresenter)
+	hint := &domain.PaiGowHint{LowIdx0: 2, LowIdx1: 3, LowIsPair: true, Reason: "house_way_pair"}
+
+	// **受動ヒントは Output() でも埋める。**HintOutput() は command:"hint" 専用の
+	// レスポンスで、ページの state にはマージされない。ここが nil のままだと
+	// フロントの state.hint は常に undefined になる (#4483)。
+	t.Run("Output carries the hint into the page state", func(t *testing.T) {
+		m := new(interfaces.MockPaiGowGame)
+		// **先に登録した期待が勝つ。**defaults の GetHint(nil) より前に置く。
+		m.On("GetHint").Return(hint)
+		setupPaiGowWebMockDefaults(m)
+
+		out := parsePaiGowOutput(t, p.Output(m, nil))
+		if assert.NotNil(t, out.Hint) {
+			assert.Equal(t, 2, out.Hint.LowIdx0)
+			assert.Equal(t, 3, out.Hint.LowIdx1)
+			assert.True(t, out.Hint.LowIsPair)
+			assert.Equal(t, "house_way_pair", out.Hint.Reason)
+		}
+	})
+
+	t.Run("Output omits the hint outside the set hands phase", func(t *testing.T) {
+		m := new(interfaces.MockPaiGowGame)
+		setupPaiGowWebMockDefaults(m)
+
+		assert.Nil(t, parsePaiGowOutput(t, p.Output(m, nil)).Hint)
+	})
+
+	t.Run("HintOutput returns the split", func(t *testing.T) {
+		m := new(interfaces.MockPaiGowGame)
+		// **先に登録した期待が勝つ。**defaults の GetHint(nil) より前に置く。
+		m.On("GetHint").Return(hint)
+		setupPaiGowWebMockDefaults(m)
+
+		out := parsePaiGowOutput(t, p.HintOutput(m))
+		if assert.NotNil(t, out.Hint) {
+			assert.Equal(t, 2, out.Hint.LowIdx0)
+		}
+	})
+
+	t.Run("HintOutput reports when there is nothing to suggest", func(t *testing.T) {
+		m := new(interfaces.MockPaiGowGame)
+		setupPaiGowWebMockDefaults(m)
+
+		out := parsePaiGowOutput(t, p.HintOutput(m))
+		assert.Nil(t, out.Hint)
+		assert.Equal(t, "paigow.hintNone", out.MessageCode)
+	})
 }

--- a/internal/domain/PaiGow.go
+++ b/internal/domain/PaiGow.go
@@ -168,6 +168,53 @@ func (pg *PaiGow) SetHands(lowIdx0, lowIdx1 int) error {
 	return nil
 }
 
+// PaiGowHint はセットハンドフェーズでの推奨分割。
+type PaiGowHint struct {
+	// LowIdx0 / LowIdx1 はローハンドに回す2枚の手札インデックス。
+	LowIdx0 int
+	LowIdx1 int
+	// LowIsPair はローハンドがペアになるかどうか (推奨理由の出し分け用)。
+	LowIsPair bool
+	// Reason はヒント理由キー。
+	Reason string
+}
+
+// GetHint はセットハンドフェーズでの推奨分割を返す。それ以外では nil。
+//
+// **ディーラーのハウスウェイと同じ経路を通す** (paiGowHouseWayIndices)。
+// ハイハンドがローハンドを上回る分割しか候補にしないので、
+// この通りに置けば必ず反則 (foul) を回避できる。
+func (pg *PaiGow) GetHint() *PaiGowHint {
+	if pg.phase != PaiGowPhaseSetHands {
+		return nil
+	}
+	i, j, ok := paiGowHouseWayIndices(pg.playerCards)
+	if !ok {
+		return nil
+	}
+	lowIsPair := evalPaiGowLowHand([]*Card{pg.playerCards[i], pg.playerCards[j]}) == PaiGowLowHandPair
+	reason := "house_way_high"
+	if lowIsPair {
+		reason = "house_way_pair"
+	}
+	return &PaiGowHint{LowIdx0: i, LowIdx1: j, LowIsPair: lowIsPair, Reason: reason}
+}
+
+// AutoSetHands はハウスウェイの分割をそのまま適用する。
+//
+// 手作業の SetHands と同じ検証を通す (自前で分割を書き込まない) ので、
+// **自動でも反則ハンドが成立する抜け道にはならない。**
+func (pg *PaiGow) AutoSetHands() error {
+	if pg.phase != PaiGowPhaseSetHands {
+		return NewDomainError(ErrWrongPhase, "SetHands is only allowed during the set hands phase.")
+	}
+	i, j, ok := paiGowHouseWayIndices(pg.playerCards)
+	if !ok {
+		return NewDomainError(ErrInvalidPlay, "No legal split is available for this hand.")
+	}
+	return pg.SetHands(i, j)
+}
+
 // deal 7枚ずつ配る
 func (pg *PaiGow) deal() {
 	pg.playerCards = make([]*Card, 0, PaiGowHandSize)
@@ -438,13 +485,35 @@ func paiGowHighBeatsLow(highRank int, highHand []*Card, lowRank int, lowHand []*
 
 // paiGowHouseWay ディーラーのハウスウェイ（自動カード分割）
 func paiGowHouseWay(cards []*Card) (high []*Card, low []*Card) {
-	if len(cards) != PaiGowHandSize {
+	i, j, ok := paiGowHouseWayIndices(cards)
+	if !ok {
 		return cards, nil
+	}
+	low = []*Card{cards[i], cards[j]}
+	high = make([]*Card, 0, PaiGowHighHandSize)
+	for k, c := range cards {
+		if k != i && k != j {
+			high = append(high, c)
+		}
+	}
+	return high, low
+}
+
+// paiGowHouseWayIndices はハウスウェイが選ぶローハンド2枚の**インデックス**を返す。
+//
+// ディーラーの分割 (paiGowHouseWay) と人間への推奨 (GetHint / AutoSetHands) は
+// ここを共有する。**別実装にすると、ディーラー自身がやらない分割を人間に
+// 勧めることになる。**
+//
+// ok=false は7枚でないとき、および合法な分割が1つも無いとき。
+func paiGowHouseWayIndices(cards []*Card) (lowIdx0, lowIdx1 int, ok bool) {
+	if len(cards) != PaiGowHandSize {
+		return 0, 0, false
 	}
 
 	// 全組み合わせから最適な分割を探す（2枚選択 = C(7,2) = 21通り）
-	bestHigh := make([]*Card, 0)
-	bestLow := make([]*Card, 0)
+	bestI, bestJ := 0, 0
+	found := false
 	bestHighRank := -1
 	bestLowRank := -1
 	bestHighVals := []int{}
@@ -474,8 +543,8 @@ func paiGowHouseWay(cards []*Card) (high []*Card, low []*Card) {
 			// ハウスウェイ: ローハンドを最大化しつつハイハンドを維持
 			if paiGowBetterSplit(highRank, highVals, lowRank, lowVals,
 				bestHighRank, bestHighVals, bestLowRank, bestLowVals) {
-				bestHigh = highCandidate
-				bestLow = lowCandidate
+				bestI, bestJ = i, j
+				found = true
 				bestHighRank = highRank
 				bestLowRank = lowRank
 				bestHighVals = highVals
@@ -484,7 +553,7 @@ func paiGowHouseWay(cards []*Card) (high []*Card, low []*Card) {
 		}
 	}
 
-	return bestHigh, bestLow
+	return bestI, bestJ, found
 }
 
 // paiGowBetterSplit 新しい分割が現在のベストより良いか判定（ハウスウェイ基準）

--- a/internal/domain/PaiGowHint_internal_test.go
+++ b/internal/domain/PaiGowHint_internal_test.go
@@ -1,0 +1,149 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// paiGowSetHandsFixture は7枚を固定したセットハンドフェーズを作る。
+// Reset() を通さないのは、配り次第で決まる手札を固定するため。
+func paiGowSetHandsFixture(cards []*Card) *PaiGow {
+	pg := NewDefaultPaiGow()
+	pg.phase = PaiGowPhaseSetHands
+	pg.playerCards = cards
+	pg.dealerCards = []*Card{
+		NewCard(CardDesignClover, 2, false), NewCard(CardDesignClover, 3, false),
+		NewCard(CardDesignClover, 4, false), NewCard(CardDesignClover, 6, false),
+		NewCard(CardDesignHeart, 8, false), NewCard(CardDesignHeart, 10, false),
+		NewCard(CardDesignDiamond, 12, false),
+	}
+	return pg
+}
+
+func TestPaiGow_GetHint(t *testing.T) {
+	// **手札は配られているがフェーズが違う、を踏む。**素の NewDefaultPaiGow() は
+	// 手札が空なのでハウスウェイ側で弾かれてしまい、フェーズ判定を踏まない。
+	t.Run("returns nothing outside the set hands phase", func(t *testing.T) {
+		pg := paiGowSetHandsFixture([]*Card{
+			NewCard(CardDesignSpade, 14, false), NewCard(CardDesignHeart, 14, false),
+			NewCard(CardDesignSpade, 13, false), NewCard(CardDesignHeart, 13, false),
+			NewCard(CardDesignClover, 5, false), NewCard(CardDesignDiamond, 7, false),
+			NewCard(CardDesignSpade, 9, false),
+		})
+		require.NotNil(t, pg.GetHint(), "セットハンド中はヒントが出ること")
+		pg.phase = PaiGowPhaseBet
+		assert.Nil(t, pg.GetHint())
+	})
+
+	// **推奨はディーラーのハウスウェイと同じ分割でなければならない。**別実装だと
+	// ディーラー自身がやらない置き方を人間に勧めることになる。
+	t.Run("recommends the same split the dealer's house way would pick", func(t *testing.T) {
+		cards := []*Card{
+			NewCard(CardDesignSpade, 14, false), NewCard(CardDesignHeart, 14, false),
+			NewCard(CardDesignSpade, 5, false), NewCard(CardDesignHeart, 7, false),
+			NewCard(CardDesignClover, 9, false), NewCard(CardDesignDiamond, 11, false),
+			NewCard(CardDesignSpade, 13, false),
+		}
+		pg := paiGowSetHandsFixture(cards)
+		hint := pg.GetHint()
+		require.NotNil(t, hint)
+
+		_, houseLow := paiGowHouseWay(cards)
+		require.Len(t, houseLow, 2)
+		assert.ElementsMatch(t,
+			[]*Card{cards[hint.LowIdx0], cards[hint.LowIdx1]}, houseLow,
+			"推奨はハウスウェイと同じ2枚であるべき")
+	})
+
+	// **推奨どおりに置いたら必ず通らなければならない。**通らない推奨は害しかない。
+	t.Run("the recommended split is always legal", func(t *testing.T) {
+		cards := []*Card{
+			NewCard(CardDesignSpade, 14, false), NewCard(CardDesignHeart, 14, false),
+			NewCard(CardDesignSpade, 5, false), NewCard(CardDesignHeart, 7, false),
+			NewCard(CardDesignClover, 9, false), NewCard(CardDesignDiamond, 11, false),
+			NewCard(CardDesignSpade, 13, false),
+		}
+		pg := paiGowSetHandsFixture(cards)
+		hint := pg.GetHint()
+		require.NotNil(t, hint)
+		assert.NoError(t, pg.SetHands(hint.LowIdx0, hint.LowIdx1))
+	})
+
+	// **ローにペアを置けるとは限らない。**♠A ♥A + ばらばらの5枚だと、エースの
+	// ペアをローに回した瞬間ハイがハイカードになって反則。ハウスウェイは
+	// 合法な分割しか候補にしないので、ここはハイカードのローになる。
+	t.Run("does not offer a pair that would foul the hand", func(t *testing.T) {
+		pg := paiGowSetHandsFixture([]*Card{
+			NewCard(CardDesignSpade, 14, false), NewCard(CardDesignHeart, 14, false),
+			NewCard(CardDesignSpade, 5, false), NewCard(CardDesignHeart, 7, false),
+			NewCard(CardDesignClover, 9, false), NewCard(CardDesignDiamond, 11, false),
+			NewCard(CardDesignSpade, 13, false),
+		})
+		hint := pg.GetHint()
+		require.NotNil(t, hint)
+		assert.False(t, hint.LowIsPair)
+		assert.Equal(t, "house_way_high", hint.Reason)
+	})
+
+	// ツーペアなら弱い方のペアをローに置いても合法なので、ペアが推奨される。
+	t.Run("offers the lower pair when two pairs make it legal", func(t *testing.T) {
+		pg := paiGowSetHandsFixture([]*Card{
+			NewCard(CardDesignSpade, 14, false), NewCard(CardDesignHeart, 14, false),
+			NewCard(CardDesignSpade, 13, false), NewCard(CardDesignHeart, 13, false),
+			NewCard(CardDesignClover, 5, false), NewCard(CardDesignDiamond, 7, false),
+			NewCard(CardDesignSpade, 9, false),
+		})
+		hint := pg.GetHint()
+		require.NotNil(t, hint)
+		assert.True(t, hint.LowIsPair)
+		assert.Equal(t, "house_way_pair", hint.Reason)
+		assert.NoError(t, pg.SetHands(hint.LowIdx0, hint.LowIdx1))
+	})
+
+}
+
+func TestPaiGow_AutoSetHands(t *testing.T) {
+	sample := func() []*Card {
+		return []*Card{
+			NewCard(CardDesignSpade, 14, false), NewCard(CardDesignHeart, 14, false),
+			NewCard(CardDesignSpade, 5, false), NewCard(CardDesignHeart, 7, false),
+			NewCard(CardDesignClover, 9, false), NewCard(CardDesignDiamond, 11, false),
+			NewCard(CardDesignSpade, 13, false),
+		}
+	}
+
+	t.Run("splits the hand and resolves the round", func(t *testing.T) {
+		pg := paiGowSetHandsFixture(sample())
+		require.NoError(t, pg.AutoSetHands())
+		assert.Len(t, pg.GetPlayerLowHand(), 2)
+		assert.Len(t, pg.GetPlayerHighHand(), 5)
+		assert.Equal(t, PaiGowPhaseEnd, pg.GetPhase())
+	})
+
+	// **自動でも反則の抜け道にはならない。**手作業と同じ SetHands を通す。
+	t.Run("never produces a fouled split", func(t *testing.T) {
+		pg := paiGowSetHandsFixture(sample())
+		require.NoError(t, pg.AutoSetHands())
+		high := pg.GetPlayerHighHand()
+		low := pg.GetPlayerLowHand()
+		assert.True(t, paiGowHighBeatsLow(
+			evalPaiGowHighHand(high), high, evalPaiGowLowHand(low), low))
+	})
+
+	t.Run("applies exactly what GetHint recommended", func(t *testing.T) {
+		pg := paiGowSetHandsFixture(sample())
+		hint := pg.GetHint()
+		require.NotNil(t, hint)
+		require.NoError(t, pg.AutoSetHands())
+		assert.ElementsMatch(t,
+			[]*Card{sample()[hint.LowIdx0], sample()[hint.LowIdx1]},
+			pg.GetPlayerLowHand())
+	})
+
+	t.Run("rejected outside the set hands phase", func(t *testing.T) {
+		pg := NewDefaultPaiGow()
+		assert.Error(t, pg.AutoSetHands())
+	})
+}

--- a/internal/domain/interfaces/paigow.go
+++ b/internal/domain/interfaces/paigow.go
@@ -13,6 +13,10 @@ type PaiGowGame interface {
 	Bet(amount int) error
 	// SetHands ローハンドの2枚を指定してハンドを分割する
 	SetHands(lowIdx0, lowIdx1 int) error
+	// AutoSetHands ハウスウェイの分割をそのまま適用する
+	AutoSetHands() error
+	// GetHint セットハンドフェーズでの推奨分割を取得する
+	GetHint() *domain.PaiGowHint
 
 	// GetPlayerCards プレイヤーの7枚を取得する
 	GetPlayerCards() []*domain.Card

--- a/internal/domain/interfaces/paigow_mock.go
+++ b/internal/domain/interfaces/paigow_mock.go
@@ -27,6 +27,19 @@ func (m *MockPaiGowGame) SetHands(lowIdx0, lowIdx1 int) error {
 	return args.Error(0)
 }
 
+func (m *MockPaiGowGame) AutoSetHands() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *MockPaiGowGame) GetHint() *domain.PaiGowHint {
+	args := m.Called()
+	if args.Get(0) == nil {
+		return nil
+	}
+	return args.Get(0).(*domain.PaiGowHint)
+}
+
 func (m *MockPaiGowGame) GetPlayerCards() []*domain.Card {
 	args := m.Called()
 	if args.Get(0) == nil {

--- a/internal/i18n/locales/en/paigow.json
+++ b/internal/i18n/locales/en/paigow.json
@@ -19,5 +19,11 @@
   "dealerWins": "Dealer wins!",
   "push": "Push!",
   "payoutLine": "payout: {{payout}}",
-  "payoutWithCommissionLine": "payout: {{payout}} (commission: {{commission}})"
+  "payoutWithCommissionLine": "payout: {{payout}} (commission: {{commission}})",
+  "helpAuto": "  a                    auto-split using the house way",
+  "helpHint": "  h                    show the recommended split",
+  "hintNone": "No hint is available now.",
+  "hintSplit": "Recommended: put [{{idx0}}] [{{idx1}}] ({{cards}}) in the low hand - {{reason}}",
+  "hintReasonPair": "the strongest split where a pair in the low hand still does not foul",
+  "hintReasonHigh": "maximises the low hand without fouling"
 }

--- a/internal/i18n/locales/ja/paigow.json
+++ b/internal/i18n/locales/ja/paigow.json
@@ -19,5 +19,11 @@
   "dealerWins": "ディーラーの勝ち！",
   "push": "プッシュ！",
   "payoutLine": "払戻し: {{payout}}",
-  "payoutWithCommissionLine": "払戻し: {{payout}} (手数料: {{commission}})"
+  "payoutWithCommissionLine": "払戻し: {{payout}} (手数料: {{commission}})",
+  "helpAuto": "  a                    ハウスウェイで自動分割",
+  "helpHint": "  h                    推奨分割を表示",
+  "hintNone": "いまはヒントを出せません。",
+  "hintSplit": "推奨: [{{idx0}}] [{{idx1}}] ({{cards}}) をローハンドへ - {{reason}}",
+  "hintReasonPair": "ローにペアを置いても反則にならない最強の分割",
+  "hintReasonHigh": "反則にならない範囲でローを最大化した分割"
 }

--- a/internal/infrastructure/ui/GameManager.go
+++ b/internal/infrastructure/ui/GameManager.go
@@ -859,7 +859,7 @@ var gameRegistry = []GameRegistryEntry{
 				domain.NewDefaultPaiGow(), new(presenter.PaiGowCuiPresenter))),
 			CuiHelpSpec{
 				TitleKey:          "paigow.helpTitle",
-				CommandKeys:       []string{"paigow.helpBet", "paigow.helpSet"},
+				CommandKeys:       []string{"paigow.helpBet", "paigow.helpSet", "paigow.helpAuto", "paigow.helpHint"},
 				ExtraCommandLines: []string{"  log                  action log"},
 			})
 	}},

--- a/internal/usecase/PaiGowInteractor.go
+++ b/internal/usecase/PaiGowInteractor.go
@@ -18,6 +18,10 @@ type PaiGowInteractorIF interface {
 	Bet(amount int) string
 	// SetHands ハンド分割
 	SetHands(lowIdx0, lowIdx1 int) string
+	// AutoSetHands ハウスウェイで自動分割する
+	AutoSetHands() string
+	// Hint 推奨分割を出力する
+	Hint() string
 	// ActionLog 棋譜を出力する
 	ActionLog() string
 }
@@ -50,6 +54,16 @@ func (pi *PaiGowInteractor) Bet(amount int) string {
 // SetHands ハンド分割
 func (pi *PaiGowInteractor) SetHands(lowIdx0, lowIdx1 int) string {
 	return execAndPresent(pi.Game, pi.pp, func() error { return pi.Game.SetHands(lowIdx0, lowIdx1) })
+}
+
+// AutoSetHands ハウスウェイで自動分割する
+func (pi *PaiGowInteractor) AutoSetHands() string {
+	return execAndPresent(pi.Game, pi.pp, pi.Game.AutoSetHands)
+}
+
+// Hint 推奨分割を出力する
+func (pi *PaiGowInteractor) Hint() string {
+	return pi.pp.HintOutput(pi.Game)
 }
 
 // ActionLog 棋譜を出力する

--- a/internal/usecase/interactor_snapshot_test.go
+++ b/internal/usecase/interactor_snapshot_test.go
@@ -182,11 +182,12 @@ func (s *stubCribbagePresenter) Output(_ interfaces.CribbageGame, _ error) strin
 func (s *stubCribbagePresenter) ActionLogOutput(_ interfaces.CribbageGame) string { return `{}` }
 func (s *stubCribbagePresenter) HintOutput(_ interfaces.CribbageGame) string      { return `{}` }
 
-// stubPaiGowPresenter implements presenter.PaiGowPresenter (= GamePresenter[interfaces.PaiGowGame])
+// stubPaiGowPresenter implements presenter.PaiGowPresenter
 type stubPaiGowPresenter struct{}
 
 func (s *stubPaiGowPresenter) Output(_ interfaces.PaiGowGame, _ error) string { return `{}` }
 func (s *stubPaiGowPresenter) ActionLogOutput(_ interfaces.PaiGowGame) string { return `{}` }
+func (s *stubPaiGowPresenter) HintOutput(_ interfaces.PaiGowGame) string      { return `{}` }
 
 // --- tests ---
 

--- a/internal/usecase/presenter/PaiGowPresenter.go
+++ b/internal/usecase/presenter/PaiGowPresenter.go
@@ -5,4 +5,8 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // PaiGowPresenter パイガオポーカープレゼンターインタフェース
-type PaiGowPresenter = GamePresenter[interfaces.PaiGowGame]
+type PaiGowPresenter interface {
+	GamePresenter[interfaces.PaiGowGame]
+	// HintOutput ヒント情報を出力する
+	HintOutput(g interfaces.PaiGowGame) string
+}

--- a/internal/usecase/presenter/PaiGowPresenter_mock.go
+++ b/internal/usecase/presenter/PaiGowPresenter_mock.go
@@ -5,4 +5,12 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // MockPaiGowPresenter パイガオポーカープレゼンターモック
-type MockPaiGowPresenter = MockGamePresenter[interfaces.PaiGowGame]
+type MockPaiGowPresenter struct {
+	MockGamePresenter[interfaces.PaiGowGame]
+}
+
+// HintOutput モック
+func (_m *MockPaiGowPresenter) HintOutput(g interfaces.PaiGowGame) string {
+	ret := _m.Called(g)
+	return ret.Get(0).(string)
+}


### PR DESCRIPTION
## 背景

Web (`PaiGowPage.tsx`) は `paiGowAutoSplit` を「自動設定」ボタンに繋ぎ、`paiGowFoulCheck` の結果を `aria-live="assertive"` で常時出しています。一方 `PaiGowCuiController.Exec` は `b/bet`・`s/set`・`log` しか受け付けず、`PaiGowCuiPresenter` に `HintOutput` もありません。**CUI プレイヤーは7枚から反則にならない2枚を、完全に手作業・無警告で探すしかありませんでした** (#4696)。

## 規則はすでにドメインにあります

ディーラーの分割 `paiGowHouseWay` がまさにそれです。C(7,2)=21通りから、**ハイがローを上回る分割だけ**を候補にして、ローを最大化します。

インデックスを返す `paiGowHouseWayIndices` に切り出し、`paiGowHouseWay` / `GetHint` / `AutoSetHands` の3つがそこを通ります。別実装にすると**ディーラー自身がやらない置き方を人間に勧める**ことになるので、両者が一致することをテストで固定しました。

## 自動でも反則の抜け道になりません

`AutoSetHands` は自前で分割を書き込まず、**手作業と同じ `SetHands` を呼びます**。したがって既存の反則検証をそのまま通ります。

## ペアを常に勧めるわけではありません

♠A ♥A + ばらばらの5枚では、**エースのペアをローに回した瞬間ハイがハイカードになって反則**です。ハウスウェイは合法な分割しか候補にしないので、この手ではハイカードのローを勧めます。ツーペアなら弱い方のペアをローに置けるので、そちらはペアを勧めます。両方テストにしました。

## Web 側

`HintOutput` に加えて **`Output()` にも hint を載せます**。`command: "hint"` 専用のレスポンスはページの state にマージされないので、そこだけだと `state.hint` が永久に undefined になります (#4483)。

## 負のコントロール

| 壊し方 | 落ちる件数 |
|---|---|
| フェーズ判定を外す | 2 |
| SetHands の検証を迂回して自動分割 | 3 |
| 理由キーを常に `house_way_high` 固定 | 2 |
| `Output()` に hint を載せない | 2 |
| `a` コマンドの配線を間違える | 1 |

フェーズ判定のテストは当初 vacuous でした（素の `NewDefaultPaiGow()` は手札が空でハウスウェイ側で弾かれ、フェーズ判定を踏まない）。**手札を配ったうえでフェーズだけ変える**形に直しています。

## 検証

- `go test -tags test ./internal/...` ✅ / `golangci-lint run ./internal/...` → `0 issues.` ✅ / `gofmt -l internal/` 空 ✅
- `cd frontend && bun run check` 全ガード通過 ✅

Closes #4696