### PR TITLE
feat: lay out all six Irish Poker discard pairs in the CUI

### DIFF
--- a/internal/adapter/presenter/PineappleCuiPresenter.go
+++ b/internal/adapter/presenter/PineappleCuiPresenter.go
@@ -150,7 +150,21 @@ func (pp *PineappleCuiPresenter) Output(p interfaces.PineappleGame, lastErr erro
 			// フロップ前に捨てるプレーンな Pineapple ではまだ役が決まらないので、
 			// スーテッド/コネクターといった性質を出すしかない (#4685)。
 			// Web も variant でこの2つを出し分けている。
-			if previews := p.GetHumanDiscardPreviews(); len(previews) > 0 {
+			// **4枚配り (Irish) は2枚まとめて捨てるので、候補は C(4,2)=6 通り。**
+			// Web は1枚目を選んだ後の3択しか出せないが、CUI には選択途中という
+			// 状態が無いので6通りを最初から並べる (#4687)。
+			if pairs := p.GetHumanDiscardPairPreviews(); len(pairs) > 0 {
+				for _, pv := range pairs {
+					line := i18n.Tf("pineapple.discardCandidatePair",
+						"idx0", strconv.Itoa(pv.DiscardIdx0),
+						"idx1", strconv.Itoa(pv.DiscardIdx1),
+						"hand", cuiPokerHandName(pv.HandRank))
+					if pv.Recommended {
+						line += color.BoldYellow(i18n.T("pineapple.discardRecommended"))
+					}
+					b.WriteString(line + "\n")
+				}
+			} else if previews := p.GetHumanDiscardPreviews(); len(previews) > 0 {
 				for _, pv := range previews {
 					line := i18n.Tf("pineapple.discardCandidate",
 						"idx", strconv.Itoa(pv.CardIdx),

--- a/internal/adapter/presenter/PineappleCuiPresenter_test.go
+++ b/internal/adapter/presenter/PineappleCuiPresenter_test.go
@@ -38,6 +38,7 @@ func setupPineappleCuiMock() *interfaces.MockPineappleGame {
 	m.On("GetInitialDealCount").Return(3).Maybe()
 	m.On("IsDiscardAfterFlopBetting").Return(false).Maybe()
 	m.On("GetDiscardDone").Return(([]bool)(nil)).Maybe()
+	m.On("GetHumanDiscardPairPreviews").Return(([]domain.PineappleDiscardPairPreview)(nil)).Maybe()
 	m.On("GetHumanDiscardPreviews").Return(([]domain.PineappleDiscardPreview)(nil)).Maybe()
 	return m
 }
@@ -260,6 +261,32 @@ func TestPineappleCuiPresenter_Output(t *testing.T) {
 		players[0].AddCard(domain.NewCard(domain.CardDesignHeart, 5, false))
 
 		assert.NotContains(t, p.Output(m, nil), "スーテッド")
+	})
+
+	// **4枚配り (Irish) は2枚まとめて捨てる。**Web は1枚目を選んだ後の3択しか
+	// 出せないが、CUI には選択途中が無いので6通りを最初から並べる (#4687)。
+	t.Run("four-card deal lists every discard pair", func(t *testing.T) {
+		m, _ := setupPineappleCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetInitialDealCount")
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHumanDiscardPairPreviews")
+		m.On("GetPhase").Return(domain.PineapplePhaseDiscard)
+		m.On("GetInitialDealCount").Return(4)
+		m.On("GetHumanDiscardPairPreviews").Return([]domain.PineappleDiscardPairPreview{
+			{DiscardIdx0: 0, DiscardIdx1: 1, HandRank: domain.PokerHandOnePair},
+			{DiscardIdx0: 0, DiscardIdx1: 2, HandRank: domain.PokerHandOnePair},
+			{DiscardIdx0: 0, DiscardIdx1: 3, HandRank: domain.PokerHandTwoPair, Recommended: true},
+			{DiscardIdx0: 1, DiscardIdx1: 2, HandRank: domain.PokerHandHighCard},
+			{DiscardIdx0: 1, DiscardIdx1: 3, HandRank: domain.PokerHandOnePair},
+			{DiscardIdx0: 2, DiscardIdx1: 3, HandRank: domain.PokerHandOnePair},
+		})
+
+		result := p.Output(m, nil)
+		// **6通り全部。**一部だけ出すと「載っていない組み合わせは弱い」と
+		// 読めてしまう。
+		assert.Equal(t, 6, strings.Count(result, "を捨てると:"))
+		assert.Contains(t, result, "[0] [3] を捨てると: ツーペア")
+		assert.Equal(t, 1, strings.Count(result, "おすすめ"))
 	})
 
 	// **4枚配り (Irish) では出さない。**2枚捨てなので「1枚捨てたら残る2枚」

--- a/internal/domain/Pineapple.go
+++ b/internal/domain/Pineapple.go
@@ -918,6 +918,70 @@ func (p *Pineapple) GetHumanDiscardPreviews() []PineappleDiscardPreview {
 	return previews
 }
 
+// PineappleDiscardPairPreview は「この2枚を捨てたら残る手」。
+// Irish Poker のように2枚まとめて捨てる変種で使う。
+type PineappleDiscardPairPreview struct {
+	// DiscardIdx0 / DiscardIdx1 は捨てるホールカードのインデックス。
+	DiscardIdx0 int
+	DiscardIdx1 int
+	// HandRank は残る2枚がボードと作る最強の役 (PokerHand*)。
+	HandRank int
+	// Recommended は最も強い役が残る組み合わせに付く。同点なら全部に付く。
+	Recommended bool
+}
+
+// GetHumanDiscardPairPreviews は4枚配りで「どの2枚を捨てるか」の C(4,2)=6 通りを
+// すべて評価して返す (#4687)。
+//
+// **Web は1枚目を選んだ後の3択しか出せない**（残り3択の絞り込み表示）。CUI には
+// 選択途中という状態が無いので、代わりに6通りを最初から並べる。暗算の負荷を
+// 消すという目的は同じで、情報量はこちらが多い。
+//
+// 3枚配り (Pineapple / Crazy Pineapple) では nil。そちらは1枚捨てなので
+// GetHumanDiscardPreviews の担当。
+func (p *Pineapple) GetHumanDiscardPairPreviews() []PineappleDiscardPairPreview {
+	if p.phase != PineapplePhaseDiscard {
+		return nil
+	}
+	var human *PineapplePlayer
+	for _, pl := range p.players {
+		if pl.GetIsHuman() {
+			human = pl
+			break
+		}
+	}
+	if human == nil || human.GetFolded() || human.GetCardsSize() != 4 {
+		return nil
+	}
+	if len(p.communityCards) < 3 {
+		return nil
+	}
+
+	previews := make([]PineappleDiscardPairPreview, 0, 6)
+	best := -1
+	for i := 0; i < human.GetCardsSize(); i++ {
+		for j := i + 1; j < human.GetCardsSize(); j++ {
+			keep := make([]*Card, 0, 2)
+			for k := 0; k < human.GetCardsSize(); k++ {
+				if k != i && k != j {
+					keep = append(keep, human.GetCard(k))
+				}
+			}
+			rank := p.bestRankWithBoard(keep)
+			previews = append(previews, PineappleDiscardPairPreview{
+				DiscardIdx0: i, DiscardIdx1: j, HandRank: rank,
+			})
+			if rank > best {
+				best = rank
+			}
+		}
+	}
+	for i := range previews {
+		previews[i].Recommended = previews[i].HandRank == best
+	}
+	return previews
+}
+
 // GetPotOdds ポットオッズを返す
 func (p *Pineapple) GetPotOdds() float64 {
 	if p.phase < PineapplePhasePreFlop || p.phase > PineapplePhaseRiver {

--- a/internal/domain/Pineapple_test.go
+++ b/internal/domain/Pineapple_test.go
@@ -679,3 +679,62 @@ func TestPineapple_GetHumanDiscardPreviews(t *testing.T) {
 		assert.Nil(t, p.GetHumanDiscardPreviews())
 	})
 }
+
+func TestPineapple_GetHumanDiscardPairPreviews(t *testing.T) {
+	// ♠A ♠K ♥2 ♣2 / ボード ♠2 ♠3 ♠4。
+	// [2][3] (♥2 ♣2) を捨てると ♠A ♠K が残ってスペード5枚 = フラッシュ。
+	irishHole := []*Card{
+		NewCard(CardDesignSpade, 1, false),
+		NewCard(CardDesignSpade, 13, false),
+		NewCard(CardDesignHeart, 2, false),
+		NewCard(CardDesignClover, 2, false),
+	}
+	spadeBoard := []*Card{
+		NewCard(CardDesignSpade, 2, false),
+		NewCard(CardDesignSpade, 3, false),
+		NewCard(CardDesignSpade, 4, false),
+	}
+
+	// **6通り全部返す。**一部だけだと「載っていない組み合わせは弱い」と
+	// 読めてしまう。
+	t.Run("covers every one of the six discard pairs", func(t *testing.T) {
+		p := pineappleDiscardFixture(t, irishHole, spadeBoard)
+		previews := p.GetHumanDiscardPairPreviews()
+		require.Len(t, previews, 6)
+		seen := map[[2]int]bool{}
+		for _, pv := range previews {
+			seen[[2]int{pv.DiscardIdx0, pv.DiscardIdx1}] = true
+		}
+		assert.Len(t, seen, 6, "同じ組み合わせが重複していないこと")
+	})
+
+	t.Run("recommends the pair that leaves the strongest hand", func(t *testing.T) {
+		p := pineappleDiscardFixture(t, irishHole, spadeBoard)
+		for _, pv := range p.GetHumanDiscardPairPreviews() {
+			if pv.DiscardIdx0 == 2 && pv.DiscardIdx1 == 3 {
+				assert.Equal(t, PokerHandFlush, pv.HandRank)
+				assert.True(t, pv.Recommended)
+			} else {
+				assert.False(t, pv.Recommended,
+					"[%d][%d] は最強ではない", pv.DiscardIdx0, pv.DiscardIdx1)
+			}
+		}
+	})
+
+	// 3枚配りは1枚捨てなので GetHumanDiscardPreviews の担当。両方出すと重複する。
+	t.Run("returns nothing for a three-card deal", func(t *testing.T) {
+		p := pineappleDiscardFixture(t, irishHole[:3], spadeBoard)
+		assert.Nil(t, p.GetHumanDiscardPairPreviews())
+	})
+
+	t.Run("returns nothing before the flop is on the table", func(t *testing.T) {
+		p := pineappleDiscardFixture(t, irishHole, nil)
+		assert.Nil(t, p.GetHumanDiscardPairPreviews())
+	})
+
+	t.Run("returns nothing outside the discard phase", func(t *testing.T) {
+		p := pineappleDiscardFixture(t, irishHole, spadeBoard)
+		p.phase = PineapplePhaseFlop
+		assert.Nil(t, p.GetHumanDiscardPairPreviews())
+	})
+}

--- a/internal/domain/interfaces/pineapple.go
+++ b/internal/domain/interfaces/pineapple.go
@@ -75,6 +75,8 @@ type PineappleGame interface {
 	ExportProfile() interface{}
 	// ImportProfile JSONバイトからメタAIプロファイルをインポートする
 	ImportProfile(data []byte) error
+	// GetHumanDiscardPairPreviews 4枚配りで「どの2枚を捨てるか」の全6通りを取得する
+	GetHumanDiscardPairPreviews() []domain.PineappleDiscardPairPreview
 	// GetHumanDiscardPreviews 人間の各ホールカードについて「それを捨てたら残る手」を取得する
 	GetHumanDiscardPreviews() []domain.PineappleDiscardPreview
 	// GetEquity エクイティ計算結果を取得する

--- a/internal/domain/interfaces/pineapple_mock.go
+++ b/internal/domain/interfaces/pineapple_mock.go
@@ -322,6 +322,15 @@ func (_m *MockPineappleGame) GetActionLog() []*domain.ActionLogEntry {
 	return nil
 }
 
+// GetHumanDiscardPairPreviews モック
+func (_m *MockPineappleGame) GetHumanDiscardPairPreviews() []domain.PineappleDiscardPairPreview {
+	ret := _m.Called()
+	if ret.Get(0) == nil {
+		return nil
+	}
+	return ret.Get(0).([]domain.PineappleDiscardPairPreview)
+}
+
 // GetHumanDiscardPreviews モック
 func (_m *MockPineappleGame) GetHumanDiscardPreviews() []domain.PineappleDiscardPreview {
 	ret := _m.Called()

--- a/internal/i18n/locales/en/pineapple.json
+++ b/internal/i18n/locales/en/pineapple.json
@@ -61,5 +61,6 @@
   "keepFeatureHighCard": "high card",
   "discardUpcoming": "You will discard {{count}} card(s) after the flop betting round",
   "discardCandidate": "  [{{idx}}] discard this and you keep: {{hand}}",
-  "discardRecommended": " <- recommended"
+  "discardRecommended": " <- recommended",
+  "discardCandidatePair": "  discard [{{idx0}}] [{{idx1}}] and you keep: {{hand}}"
 }

--- a/internal/i18n/locales/ja/pineapple.json
+++ b/internal/i18n/locales/ja/pineapple.json
@@ -61,5 +61,6 @@
   "keepFeatureHighCard": "ハイカード",
   "discardUpcoming": "フロップベット終了後にカードを{{count}}枚捨てます",
   "discardCandidate": "  [{{idx}}] これを捨てると: {{hand}}",
-  "discardRecommended": " ← おすすめ"
+  "discardRecommended": " ← おすすめ",
+  "discardCandidatePair": "  [{{idx0}}] [{{idx1}}] を捨てると: {{hand}}"
 }


### PR DESCRIPTION
## 背景

Irish Poker は4枚配って2枚捨てます。組み合わせは **C(4,2)=6通り**。CUI は `discardPrompt`（「2枚選んでください」）しか出さないので、**どの2枚を残せば何の役になるかは全部暗算**でした (#4687)。

## Web と同じにはしません（できません）

Web は1枚目を選んだ後に `irishCandidatePreviews` で残り3択を出します。**選択途中という状態があるから段階的に絞り込める**わけです。

CUI にはその状態がありません。なので**6通りを最初から並べます**。暗算をやめさせるという目的は同じで、情報量はむしろこちらが多くなります。

```
--- ディスカードフェーズ ---
手札から2枚選んでディスカードしてください
  [0] [1] を捨てると: ワンペア
  [0] [2] を捨てると: ワンペア
  [0] [3] を捨てると: ツーペア ← おすすめ
  [1] [2] を捨てると: ハイカード
  [1] [3] を捨てると: ワンペア
  [2] [3] を捨てると: ワンペア
```

**6通り全部出します。**一部だけ出すと「載っていない組み合わせは弱い」と読めてしまいます。

## 実装

評価は #4686 で切り出した `bestRankWithBoard` を共有します。3枚配り（Pineapple / Crazy Pineapple）は1枚捨てなので従来どおり `GetHumanDiscardPreviews` が担当し、こちらは nil を返します。

## 負のコントロール

| 壊し方 | 落ちる件数 |
|---|---|
| 3枚配りでも6通り出す | 2 |
| 組み合わせを1つ落とす | 3 |
| 同点を全部おすすめにする | 2 |
| presenter が読まない | 2 |

## 検証

- `go test -tags test ./internal/...` ✅ / `golangci-lint run ./internal/...` → `0 issues.` ✅ / `gofmt -l internal/` 空 ✅
- `check-message-codes: OK (all 775 codes …)` ✅

Closes #4687