### PR TITLE
feat: confirm Let It Ride pull in the CUI before it commits

### DIFF
--- a/internal/adapter/controller/LetItRideCuiController.go
+++ b/internal/adapter/controller/LetItRideCuiController.go
@@ -12,6 +12,11 @@ import (
 // LetItRideCuiController レット・イット・ライドCUIコントローラークラス
 type LetItRideCuiController struct {
 	ci usecase.LetItRideInteractorIF
+	// pullPending は "p" が一度打たれ、確認待ちであることを表す。
+	//
+	// **Pull は取り消せない。**Web は専用ダイアログでリスクの前後を見せてから
+	// 実行するのに、CUI は "p" 一発で確定していた (#4699)。ここで一段挟む。
+	pullPending bool
 }
 
 // NewLetItRideCuiController コンストラクタ
@@ -27,8 +32,15 @@ func (lc *LetItRideCuiController) Exec(command string) string {
 	return execCuiCommand(
 		command,
 		func(_ []string) string { return lc.ci.Reset() },
-		[]string{"b", "bet", "p", "pull", "l", "letitride", "log"},
+		[]string{"b", "bet", "p", "pull", "y", "yes", "l", "letitride", "log"},
 		func(cmd string, args []string) (string, bool) {
+			// **確認待ちは "y" 以外のどのコマンドでも取り消す。**残したままだと、
+			// あとで打った "y" が意図しない Pull を確定させてしまう。
+			pending := lc.pullPending
+			if cmd != "y" && cmd != "yes" {
+				lc.pullPending = false
+			}
+
 			switch cmd {
 			case "b", "bet":
 				amount, errMsg, ok := cuiutil.ParseIntArg(args, "Bet amount is required.", "Invalid bet amount. Please enter a number.", 1, math.MaxInt)
@@ -37,6 +49,13 @@ func (lc *LetItRideCuiController) Exec(command string) string {
 				}
 				return lc.ci.Bet(amount), true
 			case "p", "pull":
+				lc.pullPending = true
+				return lc.ci.PullConfirm(), true
+			case "y", "yes":
+				if !pending {
+					return "Nothing to confirm.", true
+				}
+				lc.pullPending = false
 				return lc.ci.Pull(), true
 			case "l", "letitride":
 				return lc.ci.LetItRide(), true

--- a/internal/adapter/controller/LetItRideCuiController_test.go
+++ b/internal/adapter/controller/LetItRideCuiController_test.go
@@ -16,6 +16,7 @@ func newMockLetItRideInteractor() *usecase.MockLetItRideInteractor {
 	m.On("Reset").Return("reset result")
 	m.On("Bet", 100).Return("bet result")
 	m.On("Pull").Return("pull result")
+	m.On("PullConfirm").Return("pull confirm result")
 	m.On("LetItRide").Return("letitride result")
 	m.On("ActionLog").Return("action log result")
 	return m
@@ -75,12 +76,57 @@ func TestLetItRideCuiController_Bet_Errors(t *testing.T) {
 	})
 }
 
-func TestLetItRideCuiController_Pull(t *testing.T) {
+// **Pull は取り消せない。**Web は専用ダイアログでリスクの前後を見せてから
+// 実行するのに、CUI は "p" 一発で確定していた (#4699)。
+func TestLetItRideCuiController_Pull_RequiresConfirmation(t *testing.T) {
 	m := newMockLetItRideInteractor()
 	c := controller.NewLetItRideCuiController(m)
 
-	assert.Equal(t, "pull result", c.Exec("p"))
-	assert.Equal(t, "pull result", c.Exec("pull"))
+	assert.Equal(t, "pull confirm result", c.Exec("p"))
+	m.AssertNotCalled(t, "Pull")
+
+	assert.Equal(t, "pull result", c.Exec("y"))
+	m.AssertCalled(t, "Pull")
+}
+
+func TestLetItRideCuiController_Pull_ConfirmAliases(t *testing.T) {
+	m := newMockLetItRideInteractor()
+	c := controller.NewLetItRideCuiController(m)
+
+	assert.Equal(t, "pull confirm result", c.Exec("pull"))
+	assert.Equal(t, "pull result", c.Exec("yes"))
+}
+
+// **確認待ちを跨がせない。**別のコマンドを打った後の "y" が、忘れたころに
+// Pull を確定させてしまう事故を防ぐ。
+func TestLetItRideCuiController_Pull_AnyOtherCommandCancels(t *testing.T) {
+	m := newMockLetItRideInteractor()
+	c := controller.NewLetItRideCuiController(m)
+
+	c.Exec("p")
+	assert.Equal(t, "letitride result", c.Exec("l"))
+	assert.Equal(t, "Nothing to confirm.", c.Exec("y"))
+	m.AssertNotCalled(t, "Pull")
+}
+
+func TestLetItRideCuiController_Confirm_WithoutPendingPull(t *testing.T) {
+	m := newMockLetItRideInteractor()
+	c := controller.NewLetItRideCuiController(m)
+
+	assert.Equal(t, "Nothing to confirm.", c.Exec("y"))
+	m.AssertNotCalled(t, "Pull")
+}
+
+// **既存コマンドは何も変わらない。**
+func TestLetItRideCuiController_OtherCommandsUnaffected(t *testing.T) {
+	m := newMockLetItRideInteractor()
+	c := controller.NewLetItRideCuiController(m)
+
+	assert.Equal(t, "bet result", c.Exec("b 100"))
+	assert.Equal(t, "letitride result", c.Exec("l"))
+	assert.Equal(t, "action log result", c.Exec("log"))
+	m.AssertNotCalled(t, "Pull")
+	m.AssertNotCalled(t, "PullConfirm")
 }
 
 func TestLetItRideCuiController_LetItRide(t *testing.T) {

--- a/internal/adapter/controller/usecase/LetItRideInteractor_mock.go
+++ b/internal/adapter/controller/usecase/LetItRideInteractor_mock.go
@@ -24,6 +24,11 @@ func (m *MockLetItRideInteractor) Pull() string {
 	return args.String(0)
 }
 
+func (m *MockLetItRideInteractor) PullConfirm() string {
+	args := m.Called()
+	return args.String(0)
+}
+
 func (m *MockLetItRideInteractor) LetItRide() string {
 	args := m.Called()
 	return args.String(0)

--- a/internal/adapter/presenter/LetItRideCuiPresenter.go
+++ b/internal/adapter/presenter/LetItRideCuiPresenter.go
@@ -98,6 +98,23 @@ func (lp *LetItRideCuiPresenter) Output(lir interfaces.LetItRideGame, lastErr er
 	return sb.String()
 }
 
+// PullConfirmOutput は Pull を実行する前の確認内容を出力する。
+//
+// **Web は専用の確認ダイアログでリスクの前後を見せてから実行する** のに、CUI は
+// "p" で即座に取り下げていた (#4699)。戻る額と場に残る額が分からないまま、
+// 取り消せない操作を打つことになる。
+func (lp *LetItRideCuiPresenter) PullConfirmOutput(lir interfaces.LetItRideGame) string {
+	pv := lir.GetPullPreview()
+	if pv == nil {
+		return i18n.T("letitride.pullUnavailable") + "\n"
+	}
+	return color.BoldYellow(i18n.Tf("letitride.pullConfirm",
+		"amount", strconv.Itoa(pv.Returned),
+		"risk", strconv.Itoa(pv.RiskBefore),
+		"newRisk", strconv.Itoa(pv.RiskAfter))) + "\n" +
+		i18n.T("letitride.pullConfirmPrompt") + "\n"
+}
+
 // ActionLogOutput 棋譜をテキスト出力
 func (lp *LetItRideCuiPresenter) ActionLogOutput(lir interfaces.LetItRideGame) string {
 	return actionLogOutputText(lir)

--- a/internal/adapter/presenter/LetItRideCuiPresenter_test.go
+++ b/internal/adapter/presenter/LetItRideCuiPresenter_test.go
@@ -181,3 +181,35 @@ func TestLetItRideCuiPresenter_ActionLogOutput(t *testing.T) {
 	result := p.ActionLogOutput(m)
 	assert.NotEmpty(t, result)
 }
+
+func TestLetItRideCuiPresenter_PullConfirmOutput(t *testing.T) {
+	p := new(LetItRideCuiPresenter)
+	withPreview := func(pv *domain.LetItRidePullPreview) *interfaces.MockLetItRideGame {
+		m := new(interfaces.MockLetItRideGame)
+		m.On("GetPullPreview").Return(pv)
+		return m
+	}
+
+	// **金額が出ないと確認する意味がない。**取り消せない操作の前に、戻る額と
+	// 場に残る額の前後を見せる (#4699)。
+	t.Run("names the amount returned and the stake before and after", func(t *testing.T) {
+		out := p.PullConfirmOutput(withPreview(&domain.LetItRidePullPreview{
+			Returned: 100, RiskBefore: 300, RiskAfter: 200,
+		}))
+		assert.Contains(t, out, "100")
+		assert.Contains(t, out, "300")
+		assert.Contains(t, out, "200")
+	})
+
+	t.Run("says the action cannot be undone and how to go ahead", func(t *testing.T) {
+		out := p.PullConfirmOutput(withPreview(&domain.LetItRidePullPreview{
+			Returned: 100, RiskBefore: 300, RiskAfter: 200,
+		}))
+		assert.Contains(t, out, "取り消せません")
+		assert.Contains(t, out, "y")
+	})
+
+	t.Run("reports when pulling is not possible", func(t *testing.T) {
+		assert.Contains(t, p.PullConfirmOutput(withPreview(nil)), "引き下げられません")
+	})
+}

--- a/internal/adapter/presenter/LetItRideWebPresenter.go
+++ b/internal/adapter/presenter/LetItRideWebPresenter.go
@@ -51,6 +51,12 @@ func (lp *LetItRideWebPresenter) Output(lir interfaces.LetItRideGame, lastErr er
 	return marshalOrError(resObj)
 }
 
+// PullConfirmOutput は Pull 実行前の確認内容を JSON 出力する。
+// Web は自前のダイアログで確認するため、ここは状態をそのまま返す。
+func (lp *LetItRideWebPresenter) PullConfirmOutput(lir interfaces.LetItRideGame) string {
+	return lp.Output(lir, nil)
+}
+
 // ActionLogOutput 棋譜をJSON出力
 func (lp *LetItRideWebPresenter) ActionLogOutput(lir interfaces.LetItRideGame) string {
 	return actionLogOutputJSON(lir)

--- a/internal/domain/LetItRide.go
+++ b/internal/domain/LetItRide.go
@@ -143,6 +143,38 @@ func (lir *LetItRide) Pull() error {
 	}
 }
 
+// LetItRidePullPreview は Pull を実行したときの掛け金の動き。
+type LetItRidePullPreview struct {
+	// Returned は手元に戻る額 (1口分)。
+	Returned int
+	// RiskBefore / RiskAfter は場に残る総額の前後。
+	RiskBefore int
+	RiskAfter  int
+}
+
+// GetPullPreview は Pull を実行したときに戻る額とリスクの増減を返す。
+// 判断フェーズ以外では nil。
+//
+// **Pull はリスクを「下げる」操作。**1口ぶん取り下げて手元に戻すので、
+// 負ける額も勝てる額も減る。取り消せないのはそこで、危険だからではない。
+func (lir *LetItRide) GetPullPreview() *LetItRidePullPreview {
+	if lir.phase != LetItRidePhaseFirstDecision && lir.phase != LetItRidePhaseSecondDecision {
+		return nil
+	}
+	active := 0
+	for _, on := range []bool{lir.bet1Active, lir.bet2Active, lir.bet3Active} {
+		if on {
+			active++
+		}
+	}
+	before := lir.betAmount * active
+	after := before - lir.betAmount
+	if after < 0 {
+		after = 0
+	}
+	return &LetItRidePullPreview{Returned: lir.betAmount, RiskBefore: before, RiskAfter: after}
+}
+
 // LetItRideAction ベットをそのままにする（Let It Ride）。
 // Named "Action" to avoid a name collision with the LetItRide type itself;
 // the use-case layer exposes this as LetItRide() in its public interface.

--- a/internal/domain/LetItRide_test.go
+++ b/internal/domain/LetItRide_test.go
@@ -618,3 +618,47 @@ func TestLetItRide_FullFlow_PullThenRide(t *testing.T) {
 	assert.Equal(t, 0, lir.GetBet3Payout())
 	assert.Equal(t, 1800, lir.GetTotalPayout())
 }
+
+// **Pull はリスクを「下げる」操作。**issue #4699 は「掛け金を1つ引き上げる」と
+// 書いているが、ドメインは1口ぶん取り下げて手元に戻す。取り消せないのはそこで、
+// 危険だからではない。
+func TestLetItRide_GetPullPreview(t *testing.T) {
+	newDecisionGame := func(t *testing.T) *domain.LetItRide {
+		t.Helper()
+		lir := domain.NewDefaultLetItRide()
+		lir.Reset()
+		require.NoError(t, lir.Bet(100))
+		return lir
+	}
+
+	t.Run("returns nothing before any bet is placed", func(t *testing.T) {
+		lir := domain.NewDefaultLetItRide()
+		lir.Reset()
+		assert.Nil(t, lir.GetPullPreview())
+	})
+
+	t.Run("first decision returns one bet and lowers the stake", func(t *testing.T) {
+		lir := newDecisionGame(t)
+		pv := lir.GetPullPreview()
+		require.NotNil(t, pv)
+		assert.Equal(t, 100, pv.Returned)
+		assert.Equal(t, 300, pv.RiskBefore)
+		assert.Equal(t, 200, pv.RiskAfter, "リスクは下がる (上がらない)")
+	})
+
+	t.Run("second decision reflects the bet already pulled", func(t *testing.T) {
+		lir := newDecisionGame(t)
+		require.NoError(t, lir.Pull())
+		pv := lir.GetPullPreview()
+		require.NotNil(t, pv)
+		assert.Equal(t, 200, pv.RiskBefore, "1口取り下げた後の残りを見ていること")
+		assert.Equal(t, 100, pv.RiskAfter)
+	})
+
+	t.Run("returns nothing once the round is resolved", func(t *testing.T) {
+		lir := newDecisionGame(t)
+		require.NoError(t, lir.Pull())
+		require.NoError(t, lir.Pull())
+		assert.Nil(t, lir.GetPullPreview())
+	})
+}

--- a/internal/domain/interfaces/let_it_ride.go
+++ b/internal/domain/interfaces/let_it_ride.go
@@ -15,6 +15,8 @@ type LetItRideGame interface {
 	Pull() error
 	// LetItRideAction ベットをそのままにする
 	LetItRideAction() error
+	// GetPullPreview Pull を実行したときに戻る額とリスクの増減を取得する
+	GetPullPreview() *domain.LetItRidePullPreview
 
 	// GetPlayerHand プレイヤーハンドを取得する
 	GetPlayerHand() []*domain.Card

--- a/internal/domain/interfaces/let_it_ride_mock.go
+++ b/internal/domain/interfaces/let_it_ride_mock.go
@@ -27,6 +27,14 @@ func (m *MockLetItRideGame) Pull() error {
 	return args.Error(0)
 }
 
+func (m *MockLetItRideGame) GetPullPreview() *domain.LetItRidePullPreview {
+	args := m.Called()
+	if args.Get(0) == nil {
+		return nil
+	}
+	return args.Get(0).(*domain.LetItRidePullPreview)
+}
+
 func (m *MockLetItRideGame) LetItRideAction() error {
 	args := m.Called()
 	return args.Error(0)

--- a/internal/i18n/locales/en/letitride.json
+++ b/internal/i18n/locales/en/letitride.json
@@ -19,5 +19,8 @@
   "betStatusPull": "PULL",
   "playerWins": "Player wins!",
   "playerLoses": "Player loses.",
-  "totalPayoutLine": "total payout: {{payout}}"
+  "totalPayoutLine": "total payout: {{payout}}",
+  "pullConfirm": "Pull one bet back. {{amount}} returns to you and the amount at stake goes {{risk}} -> {{newRisk}}. This cannot be undone.",
+  "pullConfirmPrompt": "Enter y to go ahead (any other command cancels).",
+  "pullUnavailable": "You cannot pull right now."
 }

--- a/internal/i18n/locales/ja/letitride.json
+++ b/internal/i18n/locales/ja/letitride.json
@@ -19,5 +19,8 @@
   "betStatusPull": "PULL",
   "playerWins": "プレイヤーの勝ち！",
   "playerLoses": "プレイヤーの負け。",
-  "totalPayoutLine": "合計払戻し: {{payout}}"
+  "totalPayoutLine": "合計払戻し: {{payout}}",
+  "pullConfirm": "ベットを1口引き下げます。{{amount}} が戻り、場に残る額は {{risk}} → {{newRisk}} になります。この操作は取り消せません。",
+  "pullConfirmPrompt": "実行するには y を入力してください (他のコマンドで取り消し)。",
+  "pullUnavailable": "いまは引き下げられません。"
 }

--- a/internal/usecase/LetItRideInteractor.go
+++ b/internal/usecase/LetItRideInteractor.go
@@ -18,6 +18,8 @@ type LetItRideInteractorIF interface {
 	Bet(amount int) string
 	// Pull ベットを取り下げる
 	Pull() string
+	// PullConfirm Pull 実行前の確認内容を出力する
+	PullConfirm() string
 	// LetItRide ベットをそのままにする
 	LetItRide() string
 	// ActionLog 棋譜を出力する
@@ -52,6 +54,11 @@ func (li *LetItRideInteractor) Bet(amount int) string {
 // Pull ベットを取り下げる
 func (li *LetItRideInteractor) Pull() string {
 	return execAndPresent(li.Game, li.cp, li.Game.Pull)
+}
+
+// PullConfirm Pull 実行前の確認内容を出力する
+func (li *LetItRideInteractor) PullConfirm() string {
+	return li.cp.PullConfirmOutput(li.Game)
 }
 
 // LetItRide ベットをそのままにする

--- a/internal/usecase/LetItRideInteractor_snapshot_test.go
+++ b/internal/usecase/LetItRideInteractor_snapshot_test.go
@@ -23,6 +23,10 @@ func (s *stubLetItRidePresenter) ActionLogOutput(_ interfaces.LetItRideGame) str
 	return `{"log":[]}`
 }
 
+func (s *stubLetItRidePresenter) PullConfirmOutput(_ interfaces.LetItRideGame) string {
+	return `{}`
+}
+
 func TestLetItRideInteractor_SnapshotRestore(t *testing.T) {
 	lir := domain.NewDefaultLetItRide()
 	li := NewLetItRideInteractor(lir, new(stubLetItRidePresenter))

--- a/internal/usecase/presenter/LetItRidePresenter.go
+++ b/internal/usecase/presenter/LetItRidePresenter.go
@@ -5,4 +5,8 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // LetItRidePresenter レット・イット・ライドプレゼンターインタフェース
-type LetItRidePresenter = GamePresenter[interfaces.LetItRideGame]
+type LetItRidePresenter interface {
+	GamePresenter[interfaces.LetItRideGame]
+	// PullConfirmOutput Pull 実行前の確認内容を出力する
+	PullConfirmOutput(g interfaces.LetItRideGame) string
+}

--- a/internal/usecase/presenter/LetItRidePresenter_mock.go
+++ b/internal/usecase/presenter/LetItRidePresenter_mock.go
@@ -5,4 +5,12 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // MockLetItRidePresenter レット・イット・ライドプレゼンターモック
-type MockLetItRidePresenter = MockGamePresenter[interfaces.LetItRideGame]
+type MockLetItRidePresenter struct {
+	MockGamePresenter[interfaces.LetItRideGame]
+}
+
+// PullConfirmOutput モック
+func (_m *MockLetItRidePresenter) PullConfirmOutput(g interfaces.LetItRideGame) string {
+	ret := _m.Called(g)
+	return ret.Get(0).(string)
+}


### PR DESCRIPTION
## 背景

Web (`LetItRidePage.tsx`) は pull を `useConfirmDialog` の専用ダイアログで必ず確認し、**戻る額と場に残る額の前後**を見せてから実行します。`LetItRideCuiController.Exec` は `"p"` を受け取った瞬間に `ci.Pull()` を確定していました (#4699)。

## issue の前提は一部誤っています

issue は pull を「**掛け金を1つ引き上げる**不可逆操作」と書き、「引き上げ後の新リスク額」を出せとしています。

ドメインの `LetItRide.Pull()` は逆です。

```go
lir.bet3Active = false
lir.chips.AddChips(lir.betAmount)   // ← 手元に戻る
```

**1口ぶん取り下げて手元に戻すので、リスクは下がります。**Web の実際の文言も「{{amount}} が戻り、総リスクは {{risk}} → {{newRisk}} に減ります」です。

取り消せないのはそこ（戻した口は戻せない＝その口で勝てるはずだった配当を失う）であって、危険だからではありません。CUI の文言はドメインの実際の挙動に合わせました。**リスクが上がる計算にするとテストが3件落ちます。**

## 挙動

```
> p
ベットを1口引き下げます。100 が戻り、場に残る額は 300 → 200 になります。この操作は取り消せません。
実行するには y を入力してください (他のコマンドで取り消し)。
> y
（ここで初めて Pull が走る）
```

**確認待ちは "y" 以外のどのコマンドでも取り消します。**残したままだと、あとから打った "y" が忘れたころの Pull を確定させてしまいます。

## 負のコントロール

| 壊し方 | 落ちる件数 |
|---|---|
| 確認せず即 Pull（元の挙動に戻す） | 3 |
| 他コマンドで確認待ちを取り消さない | 1 |
| リスクが上がる計算にする | 3 |
| 確認方法を書かない | 2 |

## 検証

- `go test -tags test ./internal/...` ✅ / `golangci-lint run ./internal/...` → `0 issues.` ✅ / `gofmt -l internal/` 空 ✅
- `check-message-codes: OK (all 775 codes …)` ✅

Closes #4699