### PR TITLE
feat: advise Play or Fold in Caribbean Stud CUI

### DIFF
--- a/internal/adapter/controller/CaribbeanStudCuiController.go
+++ b/internal/adapter/controller/CaribbeanStudCuiController.go
@@ -27,7 +27,7 @@ func (cc *CaribbeanStudCuiController) Exec(command string) string {
 	return execCuiCommand(
 		command,
 		func(_ []string) string { return cc.ci.Reset() },
-		[]string{"b", "bet", "p", "play", "f", "fold", "log", "l"},
+		[]string{"b", "bet", "p", "play", "f", "fold", "h", "hint", "log", "l"},
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "b", "bet":
@@ -47,6 +47,8 @@ func (cc *CaribbeanStudCuiController) Exec(command string) string {
 				return cc.ci.Play(), true
 			case "f", "fold":
 				return cc.ci.Fold(), true
+			case "h", "hint":
+				return cc.ci.Hint(), true
 			default:
 				return handleCuiLog(cmd, cc.ci.ActionLog)
 			}

--- a/internal/adapter/controller/CaribbeanStudCuiController_test.go
+++ b/internal/adapter/controller/CaribbeanStudCuiController_test.go
@@ -19,6 +19,7 @@ func newMockCaribbeanStudInteractor() *usecase.MockCaribbeanStudInteractor {
 	m.On("Play").Return("play result")
 	m.On("Fold").Return("fold result")
 	m.On("ActionLog").Return("action log result")
+	m.On("Hint").Return("hint result")
 	return m
 }
 
@@ -123,4 +124,13 @@ func TestCaribbeanStudCuiController_Empty(t *testing.T) {
 
 	result := c.Exec("")
 	assert.Contains(t, result, "'help' でコマンド一覧を表示します。")
+}
+
+// **カリビアンスタッドだけ CUI に戦略アシストが無かった (#4697)。**
+func TestCaribbeanStudCuiController_Hint(t *testing.T) {
+	m := newMockCaribbeanStudInteractor()
+	c := controller.NewCaribbeanStudCuiController(m)
+
+	assert.Equal(t, "hint result", c.Exec("h"))
+	assert.Equal(t, "hint result", c.Exec("hint"))
 }

--- a/internal/adapter/controller/usecase/CaribbeanStudInteractor_mock.go
+++ b/internal/adapter/controller/usecase/CaribbeanStudInteractor_mock.go
@@ -34,6 +34,11 @@ func (m *MockCaribbeanStudInteractor) ActionLog() string {
 	return args.String(0)
 }
 
+func (m *MockCaribbeanStudInteractor) Hint() string {
+	args := m.Called()
+	return args.String(0)
+}
+
 // Snapshot モック
 func (m *MockCaribbeanStudInteractor) Snapshot() ([]byte, error) {
 	ret := m.Called()

--- a/internal/adapter/presenter/CaribbeanStudCuiPresenter.go
+++ b/internal/adapter/presenter/CaribbeanStudCuiPresenter.go
@@ -101,6 +101,46 @@ func (cp *CaribbeanStudCuiPresenter) Output(cs interfaces.CaribbeanStudGame, las
 	return sb.String()
 }
 
+// caribbeanStudAceValue / caribbeanStudKingValue はエースとキングのカード値。
+const (
+	caribbeanStudAceValue  = 1
+	caribbeanStudKingValue = 13
+)
+
+// HintOutput はアクションフェーズで Play / Fold を助言する。
+//
+// **判定はフロントの getCaribbeanStudHint と同じ規則。**ワンペア以上なら Play、
+// 役なしでも A と K を持っていれば Play、それ以外は Fold。ずれると同じ手札で
+// CUI と Web が逆の助言を出す。
+func (cp *CaribbeanStudCuiPresenter) HintOutput(cs interfaces.CaribbeanStudGame) string {
+	if cs.GetPhase() != domain.CaribbeanStudPhaseAction || len(cs.GetPlayerHand()) == 0 {
+		return i18n.T("caribbeanstud.hintNone") + "\n"
+	}
+	action, reason := i18n.T("caribbeanstud.hintFold"), "caribbeanstud.hintWeakHand"
+	switch {
+	case cs.GetPlayerHandRank() >= domain.PokerHandOnePair:
+		action, reason = i18n.T("caribbeanstud.hintPlay"), "caribbeanstud.hintPairOrBetter"
+	case caribbeanStudHasAceKing(cs.GetPlayerHand()):
+		action, reason = i18n.T("caribbeanstud.hintPlay"), "caribbeanstud.hintAceKingHigh"
+	}
+	return color.Yellow(i18n.Tf("caribbeanstud.hintDecision",
+		"action", action, "reason", i18n.T(reason))) + "\n"
+}
+
+// caribbeanStudHasAceKing は手札に A と K の両方があるかを返す。
+func caribbeanStudHasAceKing(cards []*domain.Card) bool {
+	hasAce, hasKing := false, false
+	for _, c := range cards {
+		switch c.GetValue() {
+		case caribbeanStudAceValue:
+			hasAce = true
+		case caribbeanStudKingValue:
+			hasKing = true
+		}
+	}
+	return hasAce && hasKing
+}
+
 // ActionLogOutput 棋譜をテキスト出力
 func (cp *CaribbeanStudCuiPresenter) ActionLogOutput(cs interfaces.CaribbeanStudGame) string {
 	return actionLogOutputText(cs)

--- a/internal/adapter/presenter/CaribbeanStudCuiPresenter_test.go
+++ b/internal/adapter/presenter/CaribbeanStudCuiPresenter_test.go
@@ -178,3 +178,93 @@ func TestCaribbeanStudCuiPresenter_ActionLogOutput(t *testing.T) {
 	result := p.ActionLogOutput(m)
 	assert.Contains(t, result, "棋譜はありません")
 }
+
+// **同じバッチの RedDog / Badugi / DeuceToSeven / SevenCardStud には HintOutput が
+// あるのに、カリビアンスタッドだけ CUI に戦略アシストが無かった (#4697)。**
+func TestCaribbeanStudCuiPresenter_HintOutput(t *testing.T) {
+	p := new(CaribbeanStudCuiPresenter)
+	game := func(phase, rank int, hand []*domain.Card) *interfaces.MockCaribbeanStudGame {
+		m := new(interfaces.MockCaribbeanStudGame)
+		m.On("GetPhase").Return(phase)
+		m.On("GetPlayerHand").Return(hand).Maybe()
+		m.On("GetPlayerHandRank").Return(rank).Maybe()
+		return m
+	}
+	aceKing := []*domain.Card{
+		domain.NewCard(domain.CardDesignSpade, 1, false),
+		domain.NewCard(domain.CardDesignHeart, 13, false),
+		domain.NewCard(domain.CardDesignClover, 7, false),
+		domain.NewCard(domain.CardDesignDiamond, 4, false),
+		domain.NewCard(domain.CardDesignSpade, 2, false),
+	}
+	junk := []*domain.Card{
+		domain.NewCard(domain.CardDesignSpade, 9, false),
+		domain.NewCard(domain.CardDesignHeart, 7, false),
+		domain.NewCard(domain.CardDesignClover, 5, false),
+		domain.NewCard(domain.CardDesignDiamond, 4, false),
+		domain.NewCard(domain.CardDesignSpade, 2, false),
+	}
+
+	t.Run("recommends play with one pair or better", func(t *testing.T) {
+		out := p.HintOutput(game(domain.CaribbeanStudPhaseAction, domain.PokerHandOnePair, junk))
+		assert.Contains(t, out, "プレイ")
+		assert.Contains(t, out, "ワンペア以上")
+	})
+
+	// **役が無くても A-K なら降りない。**ここを落とすと期待値上正しい手を
+	// フォールドさせる。
+	t.Run("recommends play on Ace-King high with no made hand", func(t *testing.T) {
+		out := p.HintOutput(game(domain.CaribbeanStudPhaseAction, domain.PokerHandHighCard, aceKing))
+		assert.Contains(t, out, "プレイ")
+		assert.Contains(t, out, "A と K")
+	})
+
+	t.Run("recommends folding a hand below Ace-King", func(t *testing.T) {
+		out := p.HintOutput(game(domain.CaribbeanStudPhaseAction, domain.PokerHandHighCard, junk))
+		assert.Contains(t, out, "フォールド")
+	})
+
+	// **A だけ、K だけでは足りない。**両方揃って初めて A-K ハイ。片方で Play を
+	// 勧めると、期待値上フォールドすべき手を打たせる。
+	t.Run("folds an ace without a king", func(t *testing.T) {
+		aceOnly := []*domain.Card{
+			domain.NewCard(domain.CardDesignSpade, 1, false),
+			domain.NewCard(domain.CardDesignHeart, 9, false),
+			domain.NewCard(domain.CardDesignClover, 7, false),
+			domain.NewCard(domain.CardDesignDiamond, 4, false),
+			domain.NewCard(domain.CardDesignSpade, 2, false),
+		}
+		out := p.HintOutput(game(domain.CaribbeanStudPhaseAction, domain.PokerHandHighCard, aceOnly))
+		assert.Contains(t, out, "フォールド")
+	})
+
+	t.Run("folds a king without an ace", func(t *testing.T) {
+		kingOnly := []*domain.Card{
+			domain.NewCard(domain.CardDesignSpade, 13, false),
+			domain.NewCard(domain.CardDesignHeart, 9, false),
+			domain.NewCard(domain.CardDesignClover, 7, false),
+			domain.NewCard(domain.CardDesignDiamond, 4, false),
+			domain.NewCard(domain.CardDesignSpade, 2, false),
+		}
+		out := p.HintOutput(game(domain.CaribbeanStudPhaseAction, domain.PokerHandHighCard, kingOnly))
+		assert.Contains(t, out, "フォールド")
+	})
+
+	t.Run("gives no hint in the bet phase", func(t *testing.T) {
+		assert.Contains(t,
+			p.HintOutput(game(domain.CaribbeanStudPhaseBet, domain.PokerHandHighCard, nil)),
+			"ヒントを出せません")
+	})
+
+	t.Run("gives no hint once the round is over", func(t *testing.T) {
+		assert.Contains(t,
+			p.HintOutput(game(domain.CaribbeanStudPhaseEnd, domain.PokerHandOnePair, junk)),
+			"ヒントを出せません")
+	})
+
+	t.Run("gives no hint before any card is dealt", func(t *testing.T) {
+		assert.Contains(t,
+			p.HintOutput(game(domain.CaribbeanStudPhaseAction, domain.PokerHandHighCard, nil)),
+			"ヒントを出せません")
+	})
+}

--- a/internal/adapter/presenter/CaribbeanStudWebPresenter.go
+++ b/internal/adapter/presenter/CaribbeanStudWebPresenter.go
@@ -69,6 +69,13 @@ func (cp *CaribbeanStudWebPresenter) Output(cs interfaces.CaribbeanStudGame, las
 	return marshalOrError(resObj)
 }
 
+// HintOutput ヒントを出力する。Web ではヒントはクライアント側 (useGameHint) で
+// 算出するため、通常の状態出力を返す。CaribbeanStudPresenter インタフェースを
+// 満たすための実装。
+func (cp *CaribbeanStudWebPresenter) HintOutput(cs interfaces.CaribbeanStudGame) string {
+	return cp.Output(cs, nil)
+}
+
 // ActionLogOutput 棋譜をJSON出力
 func (cp *CaribbeanStudWebPresenter) ActionLogOutput(cs interfaces.CaribbeanStudGame) string {
 	return actionLogOutputJSON(cs)

--- a/internal/i18n/locales/en/caribbeanstud.json
+++ b/internal/i18n/locales/en/caribbeanstud.json
@@ -20,5 +20,12 @@
   "dealerWins": "Dealer wins!",
   "playerFolded": "Player folded.",
   "push": "Push!",
-  "totalPayoutLine": "total payout: {{payout}}"
+  "totalPayoutLine": "total payout: {{payout}}",
+  "hintNone": "No hint is available now.",
+  "hintDecision": "Recommended: {{action}} - {{reason}}",
+  "hintPlay": "play (raise)",
+  "hintFold": "fold",
+  "hintPairOrBetter": "you have one pair or better",
+  "hintAceKingHigh": "no made hand, but you hold an Ace and a King",
+  "hintWeakHand": "no made hand and nothing as high as Ace-King"
 }

--- a/internal/i18n/locales/ja/caribbeanstud.json
+++ b/internal/i18n/locales/ja/caribbeanstud.json
@@ -20,5 +20,12 @@
   "dealerWins": "ディーラーの勝ち！",
   "playerFolded": "プレイヤーがフォールド。",
   "push": "プッシュ！",
-  "totalPayoutLine": "合計払戻し: {{payout}}"
+  "totalPayoutLine": "合計払戻し: {{payout}}",
+  "hintNone": "いまはヒントを出せません。",
+  "hintDecision": "推奨: {{action}} - {{reason}}",
+  "hintPlay": "プレイ (レイズ)",
+  "hintFold": "フォールド",
+  "hintPairOrBetter": "ワンペア以上ある",
+  "hintAceKingHigh": "役は無いが A と K を持っている",
+  "hintWeakHand": "役が無く A-K にも届かない"
 }

--- a/internal/usecase/CaribbeanStudInteractor.go
+++ b/internal/usecase/CaribbeanStudInteractor.go
@@ -20,6 +20,8 @@ type CaribbeanStudInteractorIF interface {
 	Play() string
 	// Fold フォールド
 	Fold() string
+	// Hint ヒント取得
+	Hint() string
 	// ActionLog 棋譜を出力する
 	ActionLog() string
 }
@@ -57,6 +59,11 @@ func (ci *CaribbeanStudInteractor) Play() string {
 // Fold フォールド
 func (ci *CaribbeanStudInteractor) Fold() string {
 	return execAndPresent(ci.Game, ci.cp, ci.Game.Fold)
+}
+
+// Hint ヒント取得
+func (ci *CaribbeanStudInteractor) Hint() string {
+	return ci.cp.HintOutput(ci.Game)
 }
 
 // ActionLog 棋譜を出力する

--- a/internal/usecase/CaribbeanStudInteractor_snapshot_test.go
+++ b/internal/usecase/CaribbeanStudInteractor_snapshot_test.go
@@ -23,6 +23,10 @@ func (s *stubCaribbeanStudPresenter) ActionLogOutput(_ interfaces.CaribbeanStudG
 	return `{"log":[]}`
 }
 
+func (s *stubCaribbeanStudPresenter) HintOutput(_ interfaces.CaribbeanStudGame) string {
+	return `{}`
+}
+
 func TestCaribbeanStudInteractor_SnapshotRestore(t *testing.T) {
 	cs := domain.NewDefaultCaribbeanStud()
 	ci := NewCaribbeanStudInteractor(cs, new(stubCaribbeanStudPresenter))

--- a/internal/usecase/presenter/CaribbeanStudPresenter.go
+++ b/internal/usecase/presenter/CaribbeanStudPresenter.go
@@ -5,4 +5,8 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // CaribbeanStudPresenter カリビアンスタッドポーカープレゼンターインタフェース
-type CaribbeanStudPresenter = GamePresenter[interfaces.CaribbeanStudGame]
+type CaribbeanStudPresenter interface {
+	GamePresenter[interfaces.CaribbeanStudGame]
+	// HintOutput ヒント情報を出力する
+	HintOutput(cs interfaces.CaribbeanStudGame) string
+}

--- a/internal/usecase/presenter/CaribbeanStudPresenter_mock.go
+++ b/internal/usecase/presenter/CaribbeanStudPresenter_mock.go
@@ -5,4 +5,12 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // MockCaribbeanStudPresenter カリビアンスタッドポーカープレゼンターモック
-type MockCaribbeanStudPresenter = MockGamePresenter[interfaces.CaribbeanStudGame]
+type MockCaribbeanStudPresenter struct {
+	MockGamePresenter[interfaces.CaribbeanStudGame]
+}
+
+// HintOutput モック
+func (_m *MockCaribbeanStudPresenter) HintOutput(cs interfaces.CaribbeanStudGame) string {
+	ret := _m.Called(cs)
+	return ret.Get(0).(string)
+}


### PR DESCRIPTION
## 背景

`CaribbeanStudPage.tsx` は `useGameHint('caribbeanstud', state)` で `getCaribbeanStudHint` を呼び、Play/Fold の助言を常設トグルで出しています。

一方 `CaribbeanStudCuiPresenter` には `Output` と `ActionLogOutput` しかありません。**同じバッチの `RedDogCuiPresenter` / `BadugiCuiPresenter` / `DeuceToSevenCuiPresenter` / `SevenCardStudCuiPresenter` はどれも `HintOutput` を持っている**のに、カリビアンスタッドだけ CUI に戦略アシストがありませんでした (#4697)。

## 判定はフロントと同じ規則

| 手札 | 助言 |
|---|---|
| ワンペア以上 | プレイ |
| 役なし・A と K を**両方**持っている | プレイ |
| それ以外 | フォールド |

ずれると同じ手札で CUI と Web が**逆の**助言を出します。

**A だけ・K だけでは足りません。**片方で Play を勧めると、期待値上フォールドすべき手を打たせることになります。`&&` を `||` にすると3件落ちるテストを置きました（当初この分岐はテストが無く、負のコントロールが 0件でした）。

## 実装

`RedDog` と同じ形に揃えました。判定は presenter、Web presenter は `Output` を返してインタフェースを満たすだけ（Web のヒントは `useGameHint` がクライアント側で出すため）。

## 負のコントロール

| 壊し方 | 落ちる件数 |
|---|---|
| A-K でも降ろす | 2 |
| フェーズを見ない | 2 |
| A か K の片方だけで Play | 3 |
| `h` コマンドの配線ミス | 1 |

## 検証

- `go test -tags test ./internal/...` ✅ / `golangci-lint run ./internal/...` → `0 issues.` ✅ / `gofmt -l internal/` 空 ✅
- `check-message-codes: OK (all 775 codes …)` ✅

Closes #4697