### PR TITLE
feat: show the ante and the real cost of Play/Raise during the action

### DIFF
--- a/internal/adapter/presenter/TexasHoldemBonusCuiPresenter.go
+++ b/internal/adapter/presenter/TexasHoldemBonusCuiPresenter.go
@@ -24,6 +24,20 @@ func (tp *TexasHoldemBonusCuiPresenter) Output(g interfaces.TexasHoldemBonusGame
 	fmt.Fprintf(&sb, "%s\n", i18n.Tf("texasholdembonus.chipsLine", "chips", strconv.Itoa(g.GetChips())))
 	fmt.Fprintf(&sb, "%s\n", i18n.Tf("texasholdembonus.phaseLine", "phase", tp.phaseStr(g.GetPhase())))
 
+	// **アクション中はアンテ額も実コストも画面に無かった (#4698)。**Web は
+	// Play/Raise ボタンに ante×倍率をラベル表示している。CUI 側はアンテを
+	// 暗記して暗算するしかなかった。END の anteLine は結果表示なので別。
+	if cost := g.GetNextBetCost(); cost > 0 {
+		action := i18n.T("texasholdembonus.costRaise")
+		if g.GetPhase() == domain.TexasHoldemBonusPhasePreFlop {
+			action = i18n.T("texasholdembonus.costPlay")
+		}
+		fmt.Fprintf(&sb, "%s\n", i18n.Tf("texasholdembonus.betCostLine",
+			"ante", strconv.Itoa(g.GetAnteBet()),
+			"action", action,
+			"cost", strconv.Itoa(cost)))
+	}
+
 	if community := g.GetCommunity(); len(community) > 0 {
 		sb.WriteString("--- " + color.Bold(i18n.T("texasholdembonus.boardHeader")) + " ---\n")
 		parts := make([]string, len(community))

--- a/internal/adapter/presenter/TexasHoldemBonusCuiPresenter_test.go
+++ b/internal/adapter/presenter/TexasHoldemBonusCuiPresenter_test.go
@@ -17,6 +17,7 @@ func setupTexasHoldemBonusCuiMockDefaults(m *interfaces.MockTexasHoldemBonusGame
 	m.On("GetCommunity").Return(([]*domain.Card)(nil)).Maybe()
 	m.On("GetGameEndFlag").Return(false).Maybe()
 	m.On("GetAnteBet").Return(0).Maybe()
+	m.On("GetNextBetCost").Return(0).Maybe()
 	m.On("GetBonusBet").Return(0).Maybe()
 	m.On("GetFlopBet").Return(0).Maybe()
 	m.On("GetTurnBet").Return(0).Maybe()
@@ -60,6 +61,7 @@ func TestTexasHoldemBonusCuiPresenter_Output_PreFlopPhase(t *testing.T) {
 	m.On("GetCommunity").Return(([]*domain.Card)(nil)).Maybe()
 	m.On("GetGameEndFlag").Return(false).Maybe()
 	m.On("GetAnteBet").Return(100).Maybe()
+	m.On("GetNextBetCost").Return(0).Maybe()
 	m.On("GetBonusBet").Return(0).Maybe()
 	m.On("GetFlopBet").Return(0).Maybe()
 	m.On("GetTurnBet").Return(0).Maybe()
@@ -102,6 +104,7 @@ func TestTexasHoldemBonusCuiPresenter_Output_FlopPhase(t *testing.T) {
 	}).Maybe()
 	m.On("GetGameEndFlag").Return(false).Maybe()
 	m.On("GetAnteBet").Return(100).Maybe()
+	m.On("GetNextBetCost").Return(0).Maybe()
 	m.On("GetBonusBet").Return(0).Maybe()
 	m.On("GetFlopBet").Return(200).Maybe()
 	m.On("GetTurnBet").Return(0).Maybe()
@@ -143,6 +146,7 @@ func TestTexasHoldemBonusCuiPresenter_Output_EndPhase_PlayerWins(t *testing.T) {
 	}).Maybe()
 	m.On("GetGameEndFlag").Return(true).Maybe()
 	m.On("GetAnteBet").Return(100).Maybe()
+	m.On("GetNextBetCost").Return(0).Maybe()
 	m.On("GetBonusBet").Return(0).Maybe()
 	m.On("GetFlopBet").Return(200).Maybe()
 	m.On("GetTurnBet").Return(0).Maybe()
@@ -179,6 +183,7 @@ func TestTexasHoldemBonusCuiPresenter_Output_EndPhase_Fold(t *testing.T) {
 	m.On("GetCommunity").Return(([]*domain.Card)(nil)).Maybe()
 	m.On("GetGameEndFlag").Return(true).Maybe()
 	m.On("GetAnteBet").Return(100).Maybe()
+	m.On("GetNextBetCost").Return(0).Maybe()
 	m.On("GetBonusBet").Return(0).Maybe()
 	m.On("GetFlopBet").Return(0).Maybe()
 	m.On("GetTurnBet").Return(0).Maybe()
@@ -219,6 +224,7 @@ func TestTexasHoldemBonusCuiPresenter_Output_EndPhase_Push(t *testing.T) {
 	}).Maybe()
 	m.On("GetGameEndFlag").Return(true).Maybe()
 	m.On("GetAnteBet").Return(100).Maybe()
+	m.On("GetNextBetCost").Return(0).Maybe()
 	m.On("GetBonusBet").Return(0).Maybe()
 	m.On("GetFlopBet").Return(200).Maybe()
 	m.On("GetTurnBet").Return(0).Maybe()
@@ -259,6 +265,7 @@ func TestTexasHoldemBonusCuiPresenter_Output_EndPhase_DealerWins(t *testing.T) {
 	}).Maybe()
 	m.On("GetGameEndFlag").Return(true).Maybe()
 	m.On("GetAnteBet").Return(100).Maybe()
+	m.On("GetNextBetCost").Return(0).Maybe()
 	m.On("GetBonusBet").Return(0).Maybe()
 	m.On("GetFlopBet").Return(200).Maybe()
 	m.On("GetTurnBet").Return(0).Maybe()
@@ -301,6 +308,7 @@ func TestTexasHoldemBonusCuiPresenter_PhaseStr_Unknown(t *testing.T) {
 	m := new(interfaces.MockTexasHoldemBonusGame)
 	m.On("GetChips").Return(0).Maybe()
 	m.On("GetPhase").Return(999).Maybe()
+	m.On("GetNextBetCost").Return(0).Maybe()
 	m.On("GetPlayerHand").Return(([]*domain.Card)(nil)).Maybe()
 	m.On("GetDealerHand").Return(([]*domain.Card)(nil)).Maybe()
 	m.On("GetCommunity").Return(([]*domain.Card)(nil)).Maybe()
@@ -308,4 +316,51 @@ func TestTexasHoldemBonusCuiPresenter_PhaseStr_Unknown(t *testing.T) {
 
 	result := p.Output(m, nil)
 	assert.Contains(t, result, "フェーズ: UNKNOWN")
+}
+
+// **アクション中はアンテ額も実コストも画面のどこにも出ていなかった (#4698)。**
+// Web は Play/Raise ボタンに ante×倍率をラベル表示している。
+func TestTexasHoldemBonusCuiPresenter_BetCostLine(t *testing.T) {
+	p := new(TexasHoldemBonusCuiPresenter)
+	game := func(phase, ante, cost int) *interfaces.MockTexasHoldemBonusGame {
+		m := new(interfaces.MockTexasHoldemBonusGame)
+		// **先に登録した期待が勝つ。**defaults より前に置く。
+		m.On("GetPhase").Return(phase)
+		m.On("GetAnteBet").Return(ante)
+		m.On("GetNextBetCost").Return(cost)
+		setupTexasHoldemBonusCuiMockDefaults(m)
+		return m
+	}
+
+	t.Run("pre-flop shows the ante and the 2x Play cost", func(t *testing.T) {
+		out := p.Output(game(domain.TexasHoldemBonusPhasePreFlop, 100, 200), nil)
+		assert.Contains(t, out, "アンテ: 100")
+		assert.Contains(t, out, "プレイ: 200")
+	})
+
+	// **プリフロップとフロップで倍率が違う。**同じ文言だと 2× と 1× の
+	// 区別が付かない。
+	t.Run("flop shows the 1x Raise cost under its own label", func(t *testing.T) {
+		out := p.Output(game(domain.TexasHoldemBonusPhaseFlop, 100, 100), nil)
+		assert.Contains(t, out, "レイズ: 100")
+		assert.NotContains(t, out, "プレイ: ")
+	})
+
+	t.Run("turn shows the raise cost too", func(t *testing.T) {
+		assert.Contains(t,
+			p.Output(game(domain.TexasHoldemBonusPhaseTurn, 50, 50), nil),
+			"レイズ: 50")
+	})
+
+	// **END の anteLine と重ならないこと。**結果表示の行とは別物。
+	t.Run("no cost line once the round is over", func(t *testing.T) {
+		out := p.Output(game(domain.TexasHoldemBonusPhaseEnd, 100, 0), nil)
+		assert.NotContains(t, out, "レイズ: ")
+		assert.NotContains(t, out, "プレイ: ")
+	})
+
+	t.Run("no cost line before the ante is placed", func(t *testing.T) {
+		out := p.Output(game(domain.TexasHoldemBonusPhaseBet, 0, 0), nil)
+		assert.NotContains(t, out, "チップ / ")
+	})
 }

--- a/internal/domain/TexasHoldemBonus.go
+++ b/internal/domain/TexasHoldemBonus.go
@@ -149,7 +149,7 @@ func (t *TexasHoldemBonus) Play() error {
 	if t.phase != TexasHoldemBonusPhasePreFlop {
 		return NewDomainError(ErrWrongPhase, "Play is only allowed during the pre-flop phase.")
 	}
-	bet := t.anteBet * 2
+	bet := t.GetNextBetCost()
 	if !t.chips.SubtractChips(bet) {
 		return NewDomainError(ErrInsufficientChips, "Insufficient chips for flop bet.")
 	}
@@ -199,7 +199,7 @@ func (t *TexasHoldemBonus) Check() error {
 
 // Raise フロップ後またはターン後に1×アンテを置いて次フェーズへ進む。
 func (t *TexasHoldemBonus) Raise() error {
-	bet := t.anteBet
+	bet := t.GetNextBetCost()
 	switch t.phase {
 	case TexasHoldemBonusPhaseFlop:
 		if !t.chips.SubtractChips(bet) {
@@ -221,6 +221,30 @@ func (t *TexasHoldemBonus) Raise() error {
 		return nil
 	default:
 		return NewDomainError(ErrWrongPhase, "Raise is only allowed during the flop or turn phase.")
+	}
+}
+
+// アクションで置く額はアンテの何倍か。
+const (
+	// TexasHoldemBonusFlopMultiplier プリフロップの Play は 2×アンテ。
+	TexasHoldemBonusFlopMultiplier = 2
+	// TexasHoldemBonusRaiseMultiplier フロップ/ターンの Raise は 1×アンテ。
+	TexasHoldemBonusRaiseMultiplier = 1
+)
+
+// GetNextBetCost は現在のフェーズで Play / Raise に必要なチップ額を返す。
+// アクションフェーズ以外では 0。
+//
+// **Play() と Raise() が実際に引く額もここから取る。**別々に計算すると、
+// 画面に出す額と引かれる額がずれる余地が残る。
+func (t *TexasHoldemBonus) GetNextBetCost() int {
+	switch t.phase {
+	case TexasHoldemBonusPhasePreFlop:
+		return t.anteBet * TexasHoldemBonusFlopMultiplier
+	case TexasHoldemBonusPhaseFlop, TexasHoldemBonusPhaseTurn:
+		return t.anteBet * TexasHoldemBonusRaiseMultiplier
+	default:
+		return 0
 	}
 }
 

--- a/internal/domain/TexasHoldemBonus_test.go
+++ b/internal/domain/TexasHoldemBonus_test.go
@@ -737,3 +737,55 @@ func TestTexasHoldemBonus_JSONUnmarshal_TooLarge(t *testing.T) {
 	err = json.Unmarshal(data, &restored)
 	assert.Error(t, err)
 }
+
+// **画面に出す額と実際に引かれる額は同じ関数から来なければならない。**
+// 別々に計算すると、表示だけ正しくて請求がずれる余地が残る (#4698)。
+func TestTexasHoldemBonus_GetNextBetCost(t *testing.T) {
+	newBetGame := func(t *testing.T) *domain.TexasHoldemBonus {
+		t.Helper()
+		g := domain.NewDefaultTexasHoldemBonus()
+		g.Reset()
+		require.NoError(t, g.Bet(100, 0))
+		return g
+	}
+
+	t.Run("no cost before the ante is placed", func(t *testing.T) {
+		g := domain.NewDefaultTexasHoldemBonus()
+		g.Reset()
+		assert.Equal(t, 0, g.GetNextBetCost())
+	})
+
+	t.Run("pre-flop Play costs twice the ante", func(t *testing.T) {
+		assert.Equal(t, 200, newBetGame(t).GetNextBetCost())
+	})
+
+	// Play が実際に引いた額 = 直前に表示していた額。
+	t.Run("Play charges exactly what it advertised", func(t *testing.T) {
+		g := newBetGame(t)
+		cost := g.GetNextBetCost()
+		before := g.GetChips()
+		require.NoError(t, g.Play())
+		assert.Equal(t, before-cost, g.GetChips())
+		assert.Equal(t, cost, g.GetFlopBet())
+	})
+
+	t.Run("flop and turn Raise cost one ante", func(t *testing.T) {
+		g := newBetGame(t)
+		require.NoError(t, g.Play())
+		assert.Equal(t, 100, g.GetNextBetCost())
+
+		cost := g.GetNextBetCost()
+		before := g.GetChips()
+		require.NoError(t, g.Raise())
+		assert.Equal(t, before-cost, g.GetChips())
+		assert.Equal(t, 100, g.GetNextBetCost(), "ターンも1×アンテ")
+	})
+
+	t.Run("no cost once the round is resolved", func(t *testing.T) {
+		g := newBetGame(t)
+		require.NoError(t, g.Play())
+		require.NoError(t, g.Raise())
+		require.NoError(t, g.Raise())
+		assert.Equal(t, 0, g.GetNextBetCost())
+	})
+}

--- a/internal/domain/interfaces/texasholdembonus.go
+++ b/internal/domain/interfaces/texasholdembonus.go
@@ -32,6 +32,8 @@ type TexasHoldemBonusGame interface {
 	GetGameEndFlag() bool
 	// GetAnteBet アンテベット額を取得する
 	GetAnteBet() int
+	// GetNextBetCost 現在のフェーズで Play / Raise に必要なチップ額を取得する
+	GetNextBetCost() int
 	// GetBonusBet ボーナスサイドベット額を取得する
 	GetBonusBet() int
 	// GetFlopBet フロップベット額を取得する

--- a/internal/domain/interfaces/texasholdembonus_mock.go
+++ b/internal/domain/interfaces/texasholdembonus_mock.go
@@ -81,6 +81,11 @@ func (m *MockTexasHoldemBonusGame) GetAnteBet() int {
 	return args.Int(0)
 }
 
+func (m *MockTexasHoldemBonusGame) GetNextBetCost() int {
+	args := m.Called()
+	return args.Int(0)
+}
+
 func (m *MockTexasHoldemBonusGame) GetBonusBet() int {
 	args := m.Called()
 	return args.Int(0)

--- a/internal/i18n/locales/en/texasholdembonus.json
+++ b/internal/i18n/locales/en/texasholdembonus.json
@@ -24,5 +24,8 @@
   "dealerWins": "Dealer wins!",
   "playerFolded": "Player folded.",
   "push": "Push!",
-  "totalPayoutLine": "total payout: {{payout}}"
+  "totalPayoutLine": "total payout: {{payout}}",
+  "betCostLine": "Ante: {{ante}} / {{action}}: {{cost}} chips",
+  "costPlay": "Play",
+  "costRaise": "Raise"
 }

--- a/internal/i18n/locales/ja/texasholdembonus.json
+++ b/internal/i18n/locales/ja/texasholdembonus.json
@@ -24,5 +24,8 @@
   "dealerWins": "ディーラーの勝ち！",
   "playerFolded": "プレイヤーがフォールド。",
   "push": "プッシュ！",
-  "totalPayoutLine": "合計払戻し: {{payout}}"
+  "totalPayoutLine": "合計払戻し: {{payout}}",
+  "betCostLine": "アンテ: {{ante}} / {{action}}: {{cost}} チップ",
+  "costPlay": "プレイ",
+  "costRaise": "レイズ"
 }


### PR DESCRIPTION
## 背景

`TexasHoldemBonusPage.tsx` は `texasHoldemBonusBetCost(state.anteBet, ...)` で Play ボタンに **2×アンテ**、Raise ボタンに **1×アンテ** を実コストとしてラベル表示します。

`TexasHoldemBonusCuiPresenter.Output()` はアンテ額を `GetGameEndFlag()` の中（結果表示）でしか出していませんでした。**アクション中はアンテ額が画面のどこにもなく、自分で暗記して倍率を暗算するしかない** (#4698)。

## 表示する額と引かれる額を同じ関数から取ります

倍率の `2` と `1` は `Play()` / `Raise()` の中に直書きされていました。

```go
bet := t.anteBet * 2   // Play()
bet := t.anteBet       // Raise()
```

名前付き定数と `GetNextBetCost()` に集約し、**`Play()` / `Raise()` 自身も引く額をそこから取る**ようにしました。別々に計算していると、表示だけ正しくて請求がずれる余地が残ります。「**Play が広告どおりの額を引く**」ことをテストで固定しました。

```go
cost := g.GetNextBetCost()
before := g.GetChips()
require.NoError(t, g.Play())
assert.Equal(t, before-cost, g.GetChips())
```

## 文言はフェーズで分けます

プリフロップは「プレイ: 200」、フロップ/ターンは「レイズ: 100」。**同じ文言だと 2× と 1× の違いが読み取れません。**END では出ないので、既存の `anteLine`（結果表示）とは重なりません。

## 負のコントロール

| 壊し方 | 落ちる件数 |
|---|---|
| プリフロップを1倍にする | 5 |
| ターンでコストを出さない | 4 |
| Play と Raise を同じ文言にする | 2 |
| 行そのものを出さない | 4 |

## 検証

- `go test -tags test ./internal/...` ✅ / `golangci-lint run ./internal/...` → `0 issues.` ✅ / `gofmt -l internal/` 空 ✅
- `check-message-codes: OK (all 775 codes …)` ✅

Closes #4698