### PR TITLE
fix: give Razz a real CUI hint instead of always saying "no hint"

### DIFF
--- a/internal/adapter/presenter/SevenCardStudCuiPresenter.go
+++ b/internal/adapter/presenter/SevenCardStudCuiPresenter.go
@@ -276,11 +276,62 @@ func sevenCardStudThirdStreetAdvice(cards []*domain.Card) (cont bool, reasonKey 
 	return false, "sevencardstud.hintReasonFold"
 }
 
-// HintOutput advises continue/fold on third street using basic starting-hand
-// strategy. It applies to the high game only (Razz inverts hand strength, and
-// already surfaces the best low), and to the human's turn on third street.
+// razzLowCardMax はラズで「ロー札」と数える上限 (A-8)。フロントの
+// razzHint.ts の LOW_CARD_MAX と同じ。
+const razzLowCardMax = 8
+
+// razzBettingPhases はラズのヒントを出すストリート。
+//
+// **ハイの助言と違って全ストリートで出す。**フロントの getRazzHint が
+// そうなっている。ラズは引くたびにロー札の枚数が変わるので、3rd だけでは
+// 足りない。
+var razzBettingPhases = map[int]bool{
+	domain.SevenCardStudPhaseThirdStreet:   true,
+	domain.SevenCardStudPhaseFourthStreet:  true,
+	domain.SevenCardStudPhaseFifthStreet:   true,
+	domain.SevenCardStudPhaseSixthStreet:   true,
+	domain.SevenCardStudPhaseSeventhStreet: true,
+}
+
+// razzAdvice はラズの助言を返す。判定はフロントの getRazzHint と同じ規則:
+// ペアがあれば降りる、ロー札が十分あればレイズ、そこそこならコール。
+//
+// **ラズは役の強弱が逆。**ハイの基本戦略 (ペアがあれば続行) をそのまま
+// 当てると、最悪の手で押すことになる。
+func razzAdvice(cards []*domain.Card) (actionKey, reasonKey string) {
+	seen := map[int]bool{}
+	low := 0
+	for _, c := range cards {
+		v := c.GetValue()
+		if seen[v] {
+			return "sevencardstud.hintFold", "sevencardstud.hintReasonRazzPair"
+		}
+		seen[v] = true
+		if v <= razzLowCardMax {
+			low++
+		}
+	}
+	total := len(cards)
+	if low >= min(5, total) {
+		return "sevencardstud.hintRaise", "sevencardstud.hintReasonRazzStrong"
+	}
+	if low >= min(4, total-1) {
+		return "sevencardstud.hintCall", "sevencardstud.hintReasonRazzDecent"
+	}
+	return "sevencardstud.hintFold", "sevencardstud.hintReasonRazzWeak"
+}
+
+// HintOutput advises on the human's turn. The high game uses basic
+// starting-hand strategy on third street; Razz inverts hand strength, so it
+// gets its own fold/call/raise advice on every betting street (#4703).
 func (p *SevenCardStudCuiPresenter) HintOutput(s interfaces.SevenCardStudGame) string {
-	if s.GetIsLowball() || !s.IsHumanTurn() || s.GetPhase() != domain.SevenCardStudPhaseThirdStreet {
+	if !s.IsHumanTurn() {
+		return i18n.T("sevencardstud.hintNone") + "\n"
+	}
+	if s.GetIsLowball() {
+		return razzHintOutput(s)
+	}
+	if s.GetPhase() != domain.SevenCardStudPhaseThirdStreet {
 		return i18n.T("sevencardstud.hintNone") + "\n"
 	}
 	player := s.GetPlayer(s.GetCurrentTurn())
@@ -294,4 +345,18 @@ func (p *SevenCardStudCuiPresenter) HintOutput(s interfaces.SevenCardStudGame) s
 	}
 	return color.Yellow(i18n.Tf("sevencardstud.hint",
 		"action", action, "reason", i18n.T(reasonKey))) + "\n"
+}
+
+// razzHintOutput はラズ (Lowball) 向けのヒント行を返す。
+func razzHintOutput(s interfaces.SevenCardStudGame) string {
+	if !razzBettingPhases[s.GetPhase()] {
+		return i18n.T("sevencardstud.hintNone") + "\n"
+	}
+	player := s.GetPlayer(s.GetCurrentTurn())
+	if player == nil || player.GetFolded() || len(player.GetAllCards()) == 0 {
+		return i18n.T("sevencardstud.hintNone") + "\n"
+	}
+	actionKey, reasonKey := razzAdvice(player.GetAllCards())
+	return color.Yellow(i18n.Tf("sevencardstud.hint",
+		"action", i18n.T(actionKey), "reason", i18n.T(reasonKey))) + "\n"
 }

--- a/internal/adapter/presenter/SevenCardStudCuiPresenter_test.go
+++ b/internal/adapter/presenter/SevenCardStudCuiPresenter_test.go
@@ -620,18 +620,67 @@ func TestSevenCardStudCuiPresenter_HintOutput(t *testing.T) {
 		assert.Contains(t, p.HintOutput(s), i18n.T("sevencardstud.hintNone"))
 	})
 
-	t.Run("no hint in Razz (lowball)", func(t *testing.T) {
-		tc := domain.NewTrumpCards(0)
+	// **ラズは以前ここで常に「ヒントなし」だった (#4703)。**Web は razzHint.ts で
+	// fold/call/raise を助言しているのに、CUI だけ黙っていた。この t.Run は
+	// その挙動を「仕様」として固定してしまっていたので、中身を入れ替えた。
+	newRazz := func(cards ...*domain.Card) *domain.SevenCardStud {
 		players := []*domain.SevenCardStudPlayer{
 			domain.NewSevenCardStudPlayer(true, domain.HoldemStyleTAG),
 			domain.NewSevenCardStudPlayer(false, domain.HoldemStyleLAP),
 		}
-		s := domain.NewRazz(tc, players, domain.DefaultSevenCardStudConfig())
+		s := domain.NewRazz(domain.NewTrumpCards(0), players, domain.DefaultSevenCardStudConfig())
 		s.SetPhase(domain.SevenCardStudPhaseThirdStreet)
 		s.SetCurrentTurn(0)
-		players[0].AddHoleCard(domain.NewCard(domain.CardDesignSpade, 8, false))
-		players[0].AddHoleCard(domain.NewCard(domain.CardDesignHeart, 8, false))
-		players[0].AddDoorCard(domain.NewCard(domain.CardDesignClover, 2, false))
+		for i, c := range cards {
+			if i < 2 {
+				players[0].AddHoleCard(c)
+			} else {
+				players[0].AddDoorCard(c)
+			}
+		}
+		return s
+	}
+	card := func(design, value int) *domain.Card { return domain.NewCard(design, value, false) }
+
+	// **ラズは役の強弱が逆。**ペアはハイなら続行材料だが、ローでは弱い。
+	t.Run("Razz folds a pair instead of continuing on it", func(t *testing.T) {
+		out := p.HintOutput(newRazz(
+			card(domain.CardDesignSpade, 8), card(domain.CardDesignHeart, 8),
+			card(domain.CardDesignClover, 2)))
+		assert.Contains(t, out, i18n.T("sevencardstud.hintFold"))
+		assert.Contains(t, out, i18n.T("sevencardstud.hintReasonRazzPair"))
+		assert.NotContains(t, out, i18n.T("sevencardstud.hintNone"))
+	})
+
+	t.Run("Razz raises on three low cards", func(t *testing.T) {
+		out := p.HintOutput(newRazz(
+			card(domain.CardDesignSpade, 1), card(domain.CardDesignHeart, 3),
+			card(domain.CardDesignClover, 5)))
+		assert.Contains(t, out, i18n.T("sevencardstud.hintRaise"))
+	})
+
+	t.Run("Razz folds a hand made of high cards", func(t *testing.T) {
+		out := p.HintOutput(newRazz(
+			card(domain.CardDesignSpade, 12), card(domain.CardDesignHeart, 11),
+			card(domain.CardDesignClover, 9)))
+		assert.Contains(t, out, i18n.T("sevencardstud.hintFold"))
+		assert.Contains(t, out, i18n.T("sevencardstud.hintReasonRazzWeak"))
+	})
+
+	// **ハイと違って全ストリートで出す。**引くたびにロー札の枚数が変わる。
+	t.Run("Razz still advises on fifth street", func(t *testing.T) {
+		s := newRazz(
+			card(domain.CardDesignSpade, 1), card(domain.CardDesignHeart, 3),
+			card(domain.CardDesignClover, 5), card(domain.CardDesignDiamond, 7))
+		s.SetPhase(domain.SevenCardStudPhaseFifthStreet)
+		assert.NotContains(t, p.HintOutput(s), i18n.T("sevencardstud.hintNone"))
+	})
+
+	t.Run("Razz gives no hint at showdown", func(t *testing.T) {
+		s := newRazz(
+			card(domain.CardDesignSpade, 1), card(domain.CardDesignHeart, 3),
+			card(domain.CardDesignClover, 5))
+		s.SetPhase(domain.SevenCardStudPhaseShowdown)
 		assert.Contains(t, p.HintOutput(s), i18n.T("sevencardstud.hintNone"))
 	})
 }

--- a/internal/i18n/locales/en/sevencardstud.json
+++ b/internal/i18n/locales/en/sevencardstud.json
@@ -68,5 +68,11 @@
   "hintReasonStraight": "three to a straight",
   "hintReasonHigh": "three high cards",
   "hintReasonFold": "no qualifying starting hand",
-  "currentBestHand": "Best hand so far: {{hand}} ({{cards}})"
+  "currentBestHand": "Best hand so far: {{hand}} ({{cards}})",
+  "hintCall": "call",
+  "hintRaise": "raise",
+  "hintReasonRazzPair": "you have a pair, which is weak for a low hand",
+  "hintReasonRazzStrong": "you have plenty of low cards",
+  "hintReasonRazzDecent": "you have a fair number of low cards",
+  "hintReasonRazzWeak": "you do not have enough low cards"
 }

--- a/internal/i18n/locales/ja/sevencardstud.json
+++ b/internal/i18n/locales/ja/sevencardstud.json
@@ -68,5 +68,11 @@
   "hintReasonStraight": "3枚連続（ストレートの目）",
   "hintReasonHigh": "3枚とも高札",
   "hintReasonFold": "続行条件を満たしません",
-  "currentBestHand": "現在の最善役: {{hand}} ({{cards}})"
+  "currentBestHand": "現在の最善役: {{hand}} ({{cards}})",
+  "hintCall": "コール",
+  "hintRaise": "レイズ",
+  "hintReasonRazzPair": "ペアがあり、ローとしては弱い",
+  "hintReasonRazzStrong": "ロー札が十分そろっている",
+  "hintReasonRazzDecent": "ロー札はそこそこある",
+  "hintReasonRazzWeak": "ロー札が足りない"
 }


### PR DESCRIPTION
## 背景

`SevenCardStudCuiPresenter.HintOutput` は先頭でこう弾いていました。

```go
if s.GetIsLowball() || !s.IsHumanTurn() || s.GetPhase() != domain.SevenCardStudPhaseThirdStreet {
    return i18n.T("sevencardstud.hintNone") + "\n"
}
```

**ラズ (Lowball) は何をしても「ヒントなし」**です。一方 Web は `useGameHint` に `razz: (s) => getRazzHint(s)` を登録し、fold/call/raise を実際に助言しています (#4703)。

## この挙動を「仕様」として固定するテストがありました

```go
t.Run("no hint in Razz (lowball)", func(t *testing.T) {
    ...
    assert.Contains(t, p.HintOutput(s), i18n.T("sevencardstud.hintNone"))
})
```

バグを保存していたので、中身をラズの実際の助言を検証するものに入れ替えました。

## ラズは役の強弱が逆です

| 手札 | ハイの基本戦略 | ラズ |
|---|---|---|
| ペアあり | 続行 | **降りる** |
| ロー札が十分 | — | レイズ |
| ロー札がそこそこ | — | コール |

ハイの戦略をそのまま当てると、**最悪の手で押す**ことになります。閾値はフロントの `getRazzHint` と同じ（ペア→fold、`low >= min(5, total)`→raise、`low >= min(4, total-1)`→call）。

## 全ストリートで出します

ハイの助言は 3rd street だけですが、ラズは**引くたびにロー札の枚数が変わる**ので、フロント同様5つのベッティングストリート全部で出します。

## 負のコントロール

| 壊し方 | 落ちる件数 |
|---|---|
| ラズを常に「ヒントなし」に戻す | 5 |
| ペアを弱いと見なさない | 2 |
| ロー札の判定を逆向きにする | 3 |
| 5th street でヒントを出さない | 2 |

## 検証

- `go test -tags test ./internal/...` ✅ / `golangci-lint run ./internal/...` → `0 issues.` ✅ / `gofmt -l internal/` 空 ✅
- `check-message-codes: OK (all 775 codes …)` ✅

Closes #4703