### PR TITLE
fix: stop Casino Hold'em web hint from contradicting the CUI

### DIFF
--- a/frontend/src/i18n/locales/en/casinoholdem.json
+++ b/frontend/src/i18n/locales/en/casinoholdem.json
@@ -80,6 +80,7 @@
   },
   "hint": {
     "pairOrBetter": "Pair or better — recommend Call",
-    "weakHand": "Weak hand — consider Fold"
+    "weakHand": "Weak hand — consider Fold",
+    "aceKingHigh": "You hold an Ace or a King — call"
   }
 }

--- a/frontend/src/i18n/locales/ja/casinoholdem.json
+++ b/frontend/src/i18n/locales/ja/casinoholdem.json
@@ -80,6 +80,7 @@
   },
   "hint": {
     "pairOrBetter": "ペア以上 — コール推奨",
-    "weakHand": "弱い手札 — フォールド検討"
+    "weakHand": "弱い手札 — フォールド検討",
+    "aceKingHigh": "A か K を含む — コール推奨"
   }
 }

--- a/frontend/src/utils/hints/casinoholdemHint.test.ts
+++ b/frontend/src/utils/hints/casinoholdemHint.test.ts
@@ -71,3 +71,101 @@ describe('getCasinoHoldemHint', () => {
     expect(hint?.confidence).toBe('strong');
   });
 });
+
+// **CUI と Web が逆の助言を出していた (#4712)。**ドメインの RecommendCall は
+// 「ワンペア以上、または5枚のどこかに A か K があればコール」。CUI はこれを
+// そのまま使うのに、こちらはランクしか見ていなかった。
+describe('getCasinoHoldemHint — ace/king rule (sync: CasinoHoldem.RecommendCall)', () => {
+  it('calls on an ace in the hole with no made hand', () => {
+    const hint = getCasinoHoldemHint(
+      makeState({
+        playerHand: [
+          { design: 'SPADE', value: 1 },
+          { design: 'HEART', value: 6 },
+        ],
+        community: [
+          { design: 'DIAMOND', value: 3 },
+          { design: 'CLOVER', value: 9 },
+          { design: 'SPADE', value: 11 },
+        ],
+        playerHandRank: 0,
+      }),
+    );
+    expect(hint?.targetAction).toBe('call');
+  });
+
+  it('calls on a king in the hole with no made hand', () => {
+    const hint = getCasinoHoldemHint(
+      makeState({
+        playerHand: [
+          { design: 'SPADE', value: 13 },
+          { design: 'HEART', value: 6 },
+        ],
+        community: [
+          { design: 'DIAMOND', value: 3 },
+          { design: 'CLOVER', value: 9 },
+          { design: 'SPADE', value: 11 },
+        ],
+        playerHandRank: 0,
+      }),
+    );
+    expect(hint?.targetAction).toBe('call');
+  });
+
+  // **ボードの A / K も数える。**ドメインは hole と community を区別せず
+  // 5枚すべてを走査する。ここだけ手札に限ると、また CUI とずれる。
+  it('calls when the ace is on the board rather than in the hole', () => {
+    const hint = getCasinoHoldemHint(
+      makeState({
+        playerHand: [
+          { design: 'SPADE', value: 6 },
+          { design: 'HEART', value: 4 },
+        ],
+        community: [
+          { design: 'DIAMOND', value: 1 },
+          { design: 'CLOVER', value: 9 },
+          { design: 'SPADE', value: 11 },
+        ],
+        playerHandRank: 0,
+      }),
+    );
+    expect(hint?.targetAction).toBe('call');
+  });
+
+  // **A と K の両方は要らない。**oasispoker の hasAceKing とは規則が違う。
+  it('does not require both an ace and a king', () => {
+    const hint = getCasinoHoldemHint(
+      makeState({
+        playerHand: [
+          { design: 'SPADE', value: 1 },
+          { design: 'HEART', value: 4 },
+        ],
+        community: [
+          { design: 'DIAMOND', value: 6 },
+          { design: 'CLOVER', value: 9 },
+          { design: 'SPADE', value: 11 },
+        ],
+        playerHandRank: 0,
+      }),
+    );
+    expect(hint?.targetAction).toBe('call');
+  });
+
+  it('still folds when no card is an ace or a king', () => {
+    const hint = getCasinoHoldemHint(
+      makeState({
+        playerHand: [
+          { design: 'SPADE', value: 6 },
+          { design: 'HEART', value: 4 },
+        ],
+        community: [
+          { design: 'DIAMOND', value: 3 },
+          { design: 'CLOVER', value: 9 },
+          { design: 'SPADE', value: 11 },
+        ],
+        playerHandRank: 0,
+      }),
+    );
+    expect(hint?.targetAction).toBe('fold');
+  });
+});

--- a/frontend/src/utils/hints/casinoholdemHint.ts
+++ b/frontend/src/utils/hints/casinoholdemHint.ts
@@ -1,9 +1,27 @@
-import type { CasinoHoldemResponse } from '../../types/card';
+import type { Card, CasinoHoldemResponse } from '../../types/card';
 import type { HintResult } from '../../types/hint';
 import { CasinoHoldemPhase } from '../../types/phases';
 
 /** PokerHandOnePair = 1 (sync: internal/domain/PokerPlayer.go). */
 const RANK_ONE_PAIR = 1;
+
+/** Card value representing an Ace. */
+const ACE_VALUE = 1;
+
+/** Card value representing a King. */
+const KING_VALUE = 13;
+
+/**
+ * Whether any of the five cards is an Ace or a King.
+ *
+ * Sync: `CasinoHoldem.RecommendCall` scans hole **and** community and calls on
+ * *either* rank — unlike `oasispokerHint`'s `hasAceKing`, which needs both and
+ * looks only at the hand. Narrowing this puts the CUI and the Web back out of
+ * step, which is the bug this replaced (#4712).
+ */
+function hasAceOrKing(cards: readonly Card[]): boolean {
+  return cards.some((c) => c.value === ACE_VALUE || c.value === KING_VALUE);
+}
 
 /**
  * Returns a Casino Hold'em hint for the FLOP (call/fold) decision.
@@ -11,9 +29,14 @@ const RANK_ONE_PAIR = 1;
  * Casino Hold'em basic strategy: with ~82% positive EV on calls, the simplest
  * useful rule is "call any pair or better", and "call any flush draw" or
  * "call any open-ended straight draw". This implementation simplifies further
- * to: any pair-or-better → strong call recommendation; otherwise a moderate
- * fold suggestion. The backend hand rank already reflects the 5-card eval of
- * (hole + flop), so we lean on it directly instead of re-evaluating cards.
+ * to: any pair-or-better, or any Ace or King among the five cards → call;
+ * otherwise a moderate fold suggestion. The backend hand rank already reflects
+ * the 5-card eval of (hole + flop) (`updatePlayerCurrentRank`), so we lean on it
+ * directly instead of re-evaluating cards.
+ *
+ * **This must stay in step with `CasinoHoldem.RecommendCall`,** which the CUI
+ * calls directly. The Ace/King half used to be missing here, so an A-K-high
+ * hand got "call" in the CUI and "fold" on the Web (#4712).
  */
 export function getCasinoHoldemHint(state: CasinoHoldemResponse): HintResult | null {
   if (state.phase !== CasinoHoldemPhase.FLOP) return null;
@@ -21,6 +44,10 @@ export function getCasinoHoldemHint(state: CasinoHoldemResponse): HintResult | n
 
   if (state.playerHandRank >= RANK_ONE_PAIR) {
     return { targetAction: 'call', reason: 'hint.pairOrBetter', confidence: 'strong' };
+  }
+
+  if (hasAceOrKing([...state.playerHand, ...(state.community ?? [])])) {
+    return { targetAction: 'call', reason: 'hint.aceKingHigh', confidence: 'moderate' };
   }
 
   return { targetAction: 'fold', reason: 'hint.weakHand', confidence: 'moderate' };

--- a/internal/domain/CasinoHoldem_test.go
+++ b/internal/domain/CasinoHoldem_test.go
@@ -652,6 +652,16 @@ func TestCasinoHoldem_RecommendCall(t *testing.T) {
 		assert.True(t, g.RecommendCall())
 	})
 
+	// **ボードの A / K も数える。**hole だけ見る実装に狭めると、
+	// フロント側の casinoholdemHint.ts と食い違う (#4712)。
+	t.Run("call when the king is on the board rather than in the hole", func(t *testing.T) {
+		g := newFlop(
+			makeHandCH(cd{domain.CardDesignSpade, 3}, cd{domain.CardDesignHeart, 7}),
+			makeHandCH(cd{domain.CardDesignClover, 13}, cd{domain.CardDesignDiamond, 11}, cd{domain.CardDesignSpade, 5}),
+		)
+		assert.True(t, g.RecommendCall())
+	})
+
 	t.Run("fold with junk", func(t *testing.T) {
 		g := newFlop(
 			makeHandCH(cd{domain.CardDesignSpade, 3}, cd{domain.CardDesignHeart, 7}),


### PR DESCRIPTION
## 背景

`CasinoHoldem.RecommendCall()` は「**ワンペア以上、または5枚のどこかに A か K があればコール**」。`CasinoHoldemCuiPresenter.HintOutput` はこれをそのまま呼びます。

`casinoholdemHint.ts` は `state.playerHandRank >= RANK_ONE_PAIR` しか見ていませんでした。結果、**A-K ハイでペアが無い手では CUI が「call」、Web が「fold」と逆の助言**を出していました (#4712)。

## issue の提案どおりの `hasAceKing` にはしていません

issue は「`oasispokerHint.ts` と同様の `hasAceKing` 判定を追加」と提案しています。しかし規則が違います。

| | 探す範囲 | 条件 |
|---|---|---|
| `oasispokerHint.hasAceKing` | 手札のみ | A **と** K の**両方** |
| `CasinoHoldem.RecommendCall` | hole + community の5枚 | A **か** K の**どちらか** |

issue の案で直すと**規則そのものが変わり、また CUI とずれます**。権威はドメイン側（CUI が直接使っている方）なので、そちらに合わせました。**両方要求する実装にすると4件落ちます。**

## ボードの A/K も数えます

`playerHand` だけに狭めると再びずれるので、**Go 側にもその挙動をテストで固定**しました（`RecommendCall` を hole だけ見るようにすると2件落ちる）。フロント側も同じケースを持っています（ボードを見ない実装で1件落ちる）。

## 負のコントロール

| 壊し方 | 落ちる件数 |
|---|---|
| A と K の両方を要求する（issue の案） | 4 (vitest) |
| フロントがボードを見ない | 1 (vitest) |
| Go 側がボードを見ない | 2 (go test) |

## 検証

- `bunx vitest run src/utils/hints/casinoholdemHint.test.ts` → 11 passed ✅
- `bun run typecheck` ✅ / `bun run check` 全ガード通過 (exit 0) ✅
- `go test -tags test ./internal/...` ✅

Closes #4712