### PR TITLE
feat: star the playable cards in Daifugo CUI hand

### DIFF
--- a/internal/adapter/presenter/DaifugoCuiPresenter.go
+++ b/internal/adapter/presenter/DaifugoCuiPresenter.go
@@ -12,7 +12,12 @@ import (
 )
 
 // daifugoPlayerStr returns the display string for a single Daifugo player.
-func daifugoPlayerStr(player *domain.DaifugoPlayer, i int) string {
+//
+// playable が非 nil のとき、そのインデックスのカードに "*" を付ける。大富豪は
+// 革命・11バック・スートロック・階段縛りで場ごとに強弱と枚数の条件が変わるのに、
+// CUI はどれが出せるかを自力で計算させていた (#4733)。CrazyEights の
+// crazyEightsHandStr と同じ見せ方に揃える。
+func daifugoPlayerStr(player *domain.DaifugoPlayer, i int, playable []int) string {
 	var b strings.Builder
 	b.WriteString(cuiPlayerName(player, i))
 	if player.GetIsFinished() {
@@ -20,10 +25,30 @@ func daifugoPlayerStr(player *domain.DaifugoPlayer, i int) string {
 	} else {
 		b.WriteString(i18n.Tf("daifugo.playerCardCount", "count", strconv.Itoa(player.GetCardsSize())) + "\n")
 		if player.GetIsHuman() {
-			b.WriteString(cuiIndexedCardListStr(player) + "\n")
+			b.WriteString(daifugoHandStr(player, playable) + "\n")
 		}
 	}
 	return b.String()
+}
+
+// daifugoHandStr renders the hand as an indexed list, starring the cards that
+// take part in at least one legal play right now.
+func daifugoHandStr(player *domain.DaifugoPlayer, playable []int) string {
+	if len(playable) == 0 {
+		return cuiIndexedCardListStr(player)
+	}
+	mark := make(map[int]bool, len(playable))
+	for _, idx := range playable {
+		mark[idx] = true
+	}
+	parts := make([]string, player.GetCardsSize())
+	for i := 0; i < player.GetCardsSize(); i++ {
+		parts[i] = "[" + strconv.Itoa(i) + "]" + cuiCardStr(player.GetCard(i))
+		if mark[i] {
+			parts[i] += "*"
+		}
+	}
+	return strings.Join(parts, "  ")
 }
 
 // DaifugoCuiPresenter renders the Daifugo CUI view.
@@ -32,8 +57,9 @@ type DaifugoCuiPresenter struct{}
 // Output renders the current game state for the active locale (#1699).
 func (p *DaifugoCuiPresenter) Output(dg interfaces.DaifugoGame, lastErr error) string {
 	return buildCuiOutput(i18n.T("daifugo.helpTitle"), func(b *strings.Builder) {
+		playable := dg.GetPlayableCardIndices()
 		for i := 0; i < dg.GetPlayerCnt(); i++ {
-			b.WriteString(daifugoPlayerStr(dg.GetPlayer(i), i))
+			b.WriteString(daifugoPlayerStr(dg.GetPlayer(i), i, playable))
 		}
 
 		b.WriteString("----------\n")

--- a/internal/adapter/presenter/DaifugoCuiPresenter_test.go
+++ b/internal/adapter/presenter/DaifugoCuiPresenter_test.go
@@ -479,3 +479,74 @@ func TestDaifugoCuiPresenter_ActionLogOutput(t *testing.T) {
 		mockGame.AssertExpectations(t)
 	})
 }
+
+// **どの手札が出せるかを自力で計算させていた (#4733)。**CrazyEights は
+// 出せる札に "*" を付けているのに、遥かにルールが複雑な大富豪には無かった。
+func TestDaifugoCuiPresenter_MarksPlayableCards(t *testing.T) {
+	origNoColor := color.NoColor()
+	color.SetNoColor(true)
+	defer color.SetNoColor(origNoColor)
+	tdp := new(presenter.DaifugoCuiPresenter)
+
+	newGame := func(hand ...*domain.Card) (*domain.Daifugo, []*domain.DaifugoPlayer) {
+		players := makeDaifugoPlayersForPresenter()
+		dg := domain.NewDaifugo(domain.NewTrumpCards(0), players, domain.DefaultDaifugoConfig())
+		dg.SetCurrentTurn(0)
+		for _, c := range hand {
+			players[0].AddCard(c)
+		}
+		for i := 1; i < len(players); i++ {
+			players[i].AddCard(domain.NewCard(domain.CardDesignHeart, 7, false))
+		}
+		return dg, players
+	}
+	card := func(design, value int) *domain.Card { return domain.NewCard(design, value, false) }
+
+	t.Run("stars the card that beats the table and leaves the other bare", func(t *testing.T) {
+		dg, _ := newGame(card(domain.CardDesignSpade, 5), card(domain.CardDesignHeart, 12))
+		dg.SetTableCards([]*domain.Card{card(domain.CardDesignClover, 9)})
+
+		result := tdp.Output(dg, nil)
+		assert.Contains(t, result, "[1]HEART 12*")
+		// **付かないことも確かめる。**全部に星が付く実装でも「付く」だけなら通る。
+		assert.NotContains(t, result, "[0]SPADE 5*")
+	})
+
+	t.Run("stars every card when the table is empty", func(t *testing.T) {
+		dg, _ := newGame(card(domain.CardDesignSpade, 5), card(domain.CardDesignHeart, 12))
+
+		result := tdp.Output(dg, nil)
+		assert.Contains(t, result, "[0]SPADE 5*")
+		assert.Contains(t, result, "[1]HEART 12*")
+	})
+
+	t.Run("stars nothing when no card can be played", func(t *testing.T) {
+		dg, _ := newGame(card(domain.CardDesignSpade, 4), card(domain.CardDesignHeart, 5))
+		dg.SetTableCards([]*domain.Card{card(domain.CardDesignClover, 13)})
+
+		assert.NotContains(t, tdp.Output(dg, nil), "*")
+	})
+
+	// **CPU の手番では人間の手札に印を付けない。**手番プレイヤーの手札で
+	// 計算したインデックスをそのまま人間の手札に当てると、出せない札に
+	// 印が付く。
+	t.Run("stars nothing while a CPU is to act", func(t *testing.T) {
+		dg, _ := newGame(card(domain.CardDesignSpade, 4), card(domain.CardDesignHeart, 5))
+		dg.SetTableCards([]*domain.Card{card(domain.CardDesignClover, 13)})
+		dg.SetCurrentTurn(1)
+
+		assert.NotContains(t, tdp.Output(dg, nil), "*")
+	})
+
+	// **革命中は印の付く札が入れ替わる。**場の状態を見ていない実装だと
+	// ここで通らない。
+	t.Run("a revolution moves the star to the weaker card", func(t *testing.T) {
+		dg, _ := newGame(card(domain.CardDesignSpade, 5), card(domain.CardDesignHeart, 12))
+		dg.SetTableCards([]*domain.Card{card(domain.CardDesignClover, 9)})
+		dg.SetRevolutionActive(true)
+
+		result := tdp.Output(dg, nil)
+		assert.Contains(t, result, "[0]SPADE 5*")
+		assert.NotContains(t, result, "[1]HEART 12*")
+	})
+}

--- a/internal/domain/DaifugoEval.go
+++ b/internal/domain/DaifugoEval.go
@@ -245,3 +245,106 @@ func (d *Daifugo) hasMatchingSuit(cards []*Card, suit int) bool {
 	}
 	return false
 }
+
+// daifugoMaxPlayableCombos は出せるカードを探すときに調べる組み合わせ数の上限。
+//
+// **超えたら印を付けない。**中途半端に一部だけ調べて印を付けると、印の無い
+// カードが「出せない」と読めてしまう。今までどおり無印のほうがまだ正直。
+const daifugoMaxPlayableCombos = 50000
+
+// GetPlayableCardIndices は現在の手番プレイヤーの手札のうち、**いま出せる
+// 組み合わせに1つでも含まれる**カードのインデックスを返す (#4733)。
+//
+// 判定は PlayerPlay が使う isPlayable そのものを通す。革命・11バック・
+// スートロック・階段縛り・スペ3返しといった場の状態は全部そちらが見るので、
+// ここで規則を書き直さない。**別実装にすると「出せる」と印を付けた札が
+// 実際には弾かれる。**
+//
+// nil を返すのは次の場合:
+//   - 人間の手番でない / ゲーム終了 / ペンディングアクション待ち
+//   - 場が空で階段縛り中 (階段の全長を数え上げると組み合わせが爆発する)
+//   - 調べるべき組み合わせが daifugoMaxPlayableCombos を超える
+//
+// **場が空 (階段縛り無し) なら全札。**単騎はいつでも出せる。
+func (d *Daifugo) GetPlayableCardIndices() []int {
+	if d.round.gameEndFlag || d.round.pendingActionType != DaifugoPendingNone {
+		return nil
+	}
+	player := d.players[d.round.currentTurn]
+	if !player.GetIsHuman() {
+		return nil
+	}
+	n := player.GetCardsSize()
+	if n == 0 {
+		return nil
+	}
+
+	if d.round.tableCards == nil {
+		if d.round.sequenceLocked {
+			return nil
+		}
+		all := make([]int, n)
+		for i := range all {
+			all[i] = i
+		}
+		return all
+	}
+
+	k := len(d.round.tableCards)
+	if k > n || combinationCountCapped(n, k, daifugoMaxPlayableCombos) > daifugoMaxPlayableCombos {
+		return nil
+	}
+
+	marked := make([]bool, n)
+	idx := make([]int, k)
+	cards := make([]*Card, k)
+	var walk func(start, depth int)
+	walk = func(start, depth int) {
+		if depth == k {
+			for i, j := range idx {
+				cards[i] = player.GetCard(j)
+			}
+			if d.isPlayable(cards) {
+				for _, j := range idx {
+					marked[j] = true
+				}
+			}
+			return
+		}
+		for i := start; i <= n-(k-depth); i++ {
+			idx[depth] = i
+			walk(i+1, depth+1)
+		}
+	}
+	walk(0, 0)
+
+	out := make([]int, 0, n)
+	for i, ok := range marked {
+		if ok {
+			out = append(out, i)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// combinationCountCapped は C(n, k) を返す。cap を超えた時点で打ち切って
+// cap+1 を返すので、大きな n でも桁あふれしない。
+func combinationCountCapped(n, k, cap int) int {
+	if k < 0 || k > n {
+		return 0
+	}
+	if k > n-k {
+		k = n - k
+	}
+	result := 1
+	for i := 1; i <= k; i++ {
+		result = result * (n - k + i) / i
+		if result > cap {
+			return cap + 1
+		}
+	}
+	return result
+}

--- a/internal/domain/Daifugo_test.go
+++ b/internal/domain/Daifugo_test.go
@@ -7884,3 +7884,96 @@ func TestDaifugo_SetSequenceLocked(t *testing.T) {
 	dg.SetSequenceLocked(false)
 	assert.False(t, dg.GetSequenceLocked())
 }
+
+// **CUI はどの手札が出せるかを自力で計算させていた (#4733)。**革命・11バック・
+// スートロック・階段縛りで場ごとに条件が変わるのに、CrazyEights にはある
+// 「出せる札に印」が大富豪には無かった。
+func TestDaifugo_GetPlayableCardIndices(t *testing.T) {
+	newGame := func(hand []*domain.Card) *domain.Daifugo {
+		players := []*domain.DaifugoPlayer{
+			domain.NewDaifugoPlayer(true),
+			domain.NewDaifugoPlayer(false),
+			domain.NewDaifugoPlayer(false),
+			domain.NewDaifugoPlayer(false),
+		}
+		d := domain.NewDaifugo(domain.NewTrumpCards(0), players, domain.DefaultDaifugoConfig())
+		d.SetCurrentTurn(0)
+		for _, c := range hand {
+			players[0].AddCard(c)
+		}
+		return d
+	}
+	card := func(design, value int) *domain.Card { return domain.NewCard(design, value, false) }
+
+	t.Run("every card is playable onto an empty table", func(t *testing.T) {
+		d := newGame([]*domain.Card{
+			card(domain.CardDesignSpade, 3), card(domain.CardDesignHeart, 9),
+		})
+		assert.Equal(t, []int{0, 1}, d.GetPlayableCardIndices())
+	})
+
+	// **枚数が一致し、かつ場より強い札だけ。**単に枚数が合うだけでは出せない。
+	t.Run("only cards stronger than a single on the table", func(t *testing.T) {
+		d := newGame([]*domain.Card{
+			card(domain.CardDesignSpade, 5), card(domain.CardDesignHeart, 12),
+		})
+		d.SetTableCards([]*domain.Card{card(domain.CardDesignClover, 9)})
+		assert.Equal(t, []int{1}, d.GetPlayableCardIndices(), "9 より弱い 5 に印は付かない")
+	})
+
+	// **革命中は強弱が逆転する。**同じ手札・同じ場でも印の付く札が入れ替わる。
+	t.Run("a revolution flips which cards are playable", func(t *testing.T) {
+		hand := []*domain.Card{card(domain.CardDesignSpade, 5), card(domain.CardDesignHeart, 12)}
+		table := []*domain.Card{card(domain.CardDesignClover, 9)}
+
+		normal := newGame(hand)
+		normal.SetTableCards(table)
+		revolution := newGame(hand)
+		revolution.SetTableCards(table)
+		revolution.SetRevolutionActive(true)
+
+		assert.Equal(t, []int{1}, normal.GetPlayableCardIndices())
+		assert.Equal(t, []int{0}, revolution.GetPlayableCardIndices(),
+			"革命中は 5 のほうが 9 より強い")
+	})
+
+	// **2枚出しの場には2枚組しか出せない。**ペアを作れない札には印を付けない。
+	t.Run("marks only the cards that can form a legal pair", func(t *testing.T) {
+		d := newGame([]*domain.Card{
+			card(domain.CardDesignSpade, 12), card(domain.CardDesignHeart, 12),
+			card(domain.CardDesignClover, 4),
+		})
+		d.SetTableCards([]*domain.Card{
+			card(domain.CardDesignSpade, 9), card(domain.CardDesignHeart, 9),
+		})
+		assert.Equal(t, []int{0, 1}, d.GetPlayableCardIndices(), "ペアを作れない 4 は対象外")
+	})
+
+	t.Run("nothing is marked when no card can be played", func(t *testing.T) {
+		d := newGame([]*domain.Card{
+			card(domain.CardDesignSpade, 4), card(domain.CardDesignHeart, 5),
+		})
+		d.SetTableCards([]*domain.Card{card(domain.CardDesignClover, 13)})
+		assert.Nil(t, d.GetPlayableCardIndices())
+	})
+
+	// **CPU の手番では何も返さない。**手番プレイヤーの手札で計算した
+	// インデックスを人間の手札に当てると、無関係な札に印が付く。
+	// (CPU にも手札を持たせないと「手札0枚だから nil」で素通りする。)
+	t.Run("nothing is marked on a CPU turn", func(t *testing.T) {
+		d := newGame([]*domain.Card{card(domain.CardDesignSpade, 3)})
+		d.GetPlayer(1).AddCard(card(domain.CardDesignHeart, 8))
+		d.SetCurrentTurn(1)
+		assert.Nil(t, d.GetPlayableCardIndices())
+	})
+
+	// 階段縛り + 場が空は数え上げが爆発するので、印を付けずに従来どおりにする。
+	t.Run("nothing is marked while a sequence lock holds an empty table", func(t *testing.T) {
+		d := newGame([]*domain.Card{
+			card(domain.CardDesignSpade, 3), card(domain.CardDesignSpade, 4),
+			card(domain.CardDesignSpade, 5),
+		})
+		d.SetSequenceLocked(true)
+		assert.Nil(t, d.GetPlayableCardIndices())
+	})
+}

--- a/internal/domain/interfaces/daifugo.go
+++ b/internal/domain/interfaces/daifugo.go
@@ -46,6 +46,8 @@ type DaifugoGame interface {
 	GetHumanAction() *domain.DaifugoCpuAction
 	// GetCpuActions CPU行動記録一覧を取得する
 	GetCpuActions() []*domain.DaifugoCpuAction
+	// GetPlayableCardIndices いま出せる組み合わせに含まれる手札インデックスを取得する
+	GetPlayableCardIndices() []int
 	// GetCurrentTurn 現在の手番プレイヤーインデックスを取得する
 	GetCurrentTurn() int
 	// GetConfig ゲーム設定を取得する

--- a/internal/domain/interfaces/daifugo_mock.go
+++ b/internal/domain/interfaces/daifugo_mock.go
@@ -129,6 +129,14 @@ func (_m *MockDaifugoGame) GetCpuActions() []*domain.DaifugoCpuAction {
 }
 
 // GetCurrentTurn モック
+func (_m *MockDaifugoGame) GetPlayableCardIndices() []int {
+	ret := _m.Called()
+	if ret.Get(0) == nil {
+		return nil
+	}
+	return ret.Get(0).([]int)
+}
+
 func (_m *MockDaifugoGame) GetCurrentTurn() int {
 	ret := _m.Called()
 	return ret.Int(0)


### PR DESCRIPTION
## 背景

`CrazyEightsCuiPresenter.crazyEightsHandStr` は出せるカードに `"*"` を付けています。一方 `DaifugoCuiPresenter.daifugoPlayerStr` は `cuiIndexedCardListStr` で一覧を出すだけでした (#4733)。

大富豪は**革命・11バック・スートロック・階段縛り・スペ3返し**で場ごとに強弱と枚数の条件が変わります。遥かにルールが複雑なほうに支援が無い状態でした。

```
あなた: 2枚
[0]SPADE 5  [1]HEART 12*
```

## 判定は `PlayerPlay` と同じ `isPlayable` を通します

場の状態を読む規則をここで書き直すと、**「出せる」と印を付けた札が実際には弾かれます**。革命中に印が入れ替わることをテストで固定しました。

| | 場が ♣9 | 印が付く札 |
|---|---|---|
| 通常 | ♠5 ♥12 | ♥12 |
| 革命中 | ♠5 ♥12 | **♠5** |

## 数え上げが爆発する場合は印を付けません

- 場が空で**階段縛り中**（階段の全長を数え上げる必要がある）
- 組み合わせが **50000 を超える**とき

**一部だけ調べて印を付けると、印の無い札が「出せない」と読めてしまいます。**無印は従来どおりの表示なので、この場合も何も後退しません。場が空で階段縛りが無いときは、単騎がいつでも出せるので全札に印が付きます。

## CPU の手番では付けません

手番プレイヤーの手札で計算したインデックスをそのまま人間の手札に当てると、**無関係な札に印が付きます**。

## 負のコントロール

| 壊し方 | 落ちる件数 |
|---|---|
| 全部に星を付ける | 9 |
| CPU 手番でも印を付ける | 2 |
| 階段縛りを無視する | 2 |
| presenter が印を出さない | 4 |

CPU 手番のケースは当初 0件でした（テストの CPU が手札0枚で、「手札が空だから nil」の経路で素通りしていた）。CPU にも札を持たせて踏むようにしています。

## 検証

- `go test -tags test ./internal/...` ✅ / `golangci-lint run ./internal/...` → `0 issues.` ✅ / `gofmt -l internal/` 空 ✅

Closes #4733