### PR TITLE
feat: point Oasis Poker web hint at the cards to exchange

### DIFF
--- a/frontend/src/pages/OasisPokerPage.test.tsx
+++ b/frontend/src/pages/OasisPokerPage.test.tsx
@@ -231,6 +231,27 @@ describe('OasisPokerPage', () => {
     await waitFor(() => expect(mockApi).toHaveBeenCalledWith('bet', 200, 10));
   });
 
+  // **CUI は交換すべき札をインデックスで列挙しているのに、Web は「交換すべき」
+  // としか言っていなかった (#4711)。**5枚を個別にクリックする UI があるのに、
+  // どれを選ぶかの案内が無い。
+  it('marks the cards worth exchanging when hints are enabled', async () => {
+    mockApi.mockResolvedValue(exchangePhaseState);
+    renderWithProviders(<OasisPokerPage />);
+    await waitFor(() => expect(screen.getByTestId('player-card-0')).toBeInTheDocument());
+
+    // トグルを入れるまでは印を付けない。
+    expect(screen.getByTestId('player-card-0')).not.toHaveAttribute('data-hint-card');
+
+    fireEvent.click(screen.getByLabelText('ヒント表示'));
+    // 手札は 10 / J / K / 5 / 7。J と K は残し、10・5・7 を交換する。
+    expect(screen.getByTestId('player-card-0')).toHaveAttribute('data-hint-card', 'true');
+    expect(screen.getByTestId('player-card-3')).toHaveAttribute('data-hint-card', 'true');
+    expect(screen.getByTestId('player-card-4')).toHaveAttribute('data-hint-card', 'true');
+    // **付かないことも確かめる。**全部に印を付ける実装でも「付く」だけなら通る。
+    expect(screen.getByTestId('player-card-1')).not.toHaveAttribute('data-hint-card');
+    expect(screen.getByTestId('player-card-2')).not.toHaveAttribute('data-hint-card');
+  });
+
   it('shows a play hint in the action phase when hints are enabled (strong hand)', async () => {
     const strongAction: OasisPokerResponse = { ...actionPhaseState, playerHandRank: 1 };
     mockApi.mockResolvedValue(strongAction);

--- a/frontend/src/pages/OasisPokerPage.tsx
+++ b/frontend/src/pages/OasisPokerPage.tsx
@@ -286,6 +286,10 @@ function OasisPokerPageContent() {
                   {state.playerHand.map((card, i) => {
                     const selected = selectedIndices.includes(i);
                     const selectable = isExchangePhase;
+                    // CUI は交換すべき札をインデックスで列挙しているのに、Web は
+                    // 「交換すべき」としか言っていなかった (#4711)。選択済みの
+                    // 枠と重ならないよう、推奨は破線で出す。
+                    const suggested = hintEnabled && (hint?.targetIndices?.includes(i) ?? false);
                     return (
                       <button
                         key={`p-${i}`}
@@ -294,12 +298,14 @@ function OasisPokerPageContent() {
                         aria-pressed={selectable ? selected : undefined}
                         data-testid={`player-card-${i}`}
                         data-selected={selected ? 'true' : 'false'}
+                        data-hint-card={suggested ? 'true' : undefined}
                         onClick={selectable ? () => toggleSelected(i) : undefined}
                         disabled={!selectable || loading}
                         className={[
                           'bg-transparent border-0 p-0 transition-transform',
                           selectable ? 'cursor-pointer hover:scale-105' : 'cursor-default',
                           selected ? 'ring-4 ring-ds-warning rounded-lg -translate-y-2' : '',
+                          suggested && !selected ? 'rounded-lg ring-2 ring-ds-info ring-dashed' : '',
                         ]
                           .filter(Boolean)
                           .join(' ')}

--- a/frontend/src/utils/hints/oasispokerHint.test.ts
+++ b/frontend/src/utils/hints/oasispokerHint.test.ts
@@ -66,11 +66,33 @@ describe('getOasisPokerHint', () => {
   });
 
   // --- Exchange phase ---
-  it('recommends standing with a made hand of pair or better (strong)', () => {
-    const hint = getOasisPokerHint(makeState({ phase: OasisPokerPhase.EXCHANGE, playerHandRank: 1 }));
+  // **ペアがあるだけでは "stand" ではない (#4711)。**この t.Run は以前
+  // playerHandRank だけを見て stand を期待していたが、低いペア + くず札3枚は
+  // 引き直したほうがよく、CUI はそう助言している。交換すべき札が無いときだけ
+  // stand になる。
+  it('stands on a hand where every card is worth keeping (strong)', () => {
+    const hint = getOasisPokerHint(
+      makeState({
+        phase: OasisPokerPhase.EXCHANGE,
+        playerHand: [card('SPADE', 1), card('HEART', 13), card('DIAMOND', 12), card('CLOVER', 11), card('SPADE', 11)],
+        playerHandRank: 1,
+      }),
+    );
     expect(hint?.targetAction).toBe('stand');
     expect(hint?.confidence).toBe('strong');
     expect(hint?.reason).toBe('hint.exchangeKeep');
+  });
+
+  it('swaps the kickers around a low pair rather than standing', () => {
+    const hint = getOasisPokerHint(
+      makeState({
+        phase: OasisPokerPhase.EXCHANGE,
+        playerHand: [card('SPADE', 5), card('HEART', 5), card('DIAMOND', 2), card('CLOVER', 8), card('SPADE', 3)],
+        playerHandRank: 1,
+      }),
+    );
+    expect(hint?.targetAction).toBe('exchange');
+    expect(hint?.confidence).toBe('strong');
   });
 
   it('recommends exchanging a weak hand (moderate)', () => {
@@ -78,5 +100,72 @@ describe('getOasisPokerHint', () => {
     expect(hint?.targetAction).toBe('exchange');
     expect(hint?.confidence).toBe('moderate');
     expect(hint?.reason).toBe('hint.exchangeImprove');
+  });
+});
+
+// **CUI はどの札を交換すべきかインデックスで列挙しているのに、Web は
+// 「交換すべき」としか言わなかった (#4711)。**5枚を個別にクリックして選ぶ UI が
+// あるのに、どれを選ぶかの案内が無い。
+describe('getOasisPokerHint — which cards to exchange (sync: oasisPokerExchangeIndices)', () => {
+  it('names the weak cards to swap out', () => {
+    const hint = getOasisPokerHint(
+      makeState({
+        phase: OasisPokerPhase.EXCHANGE,
+        // ♠A ♥K は高札、♦5 ♣8 ♠3 は捨てる。
+        playerHand: [card('SPADE', 1), card('HEART', 13), card('DIAMOND', 5), card('CLOVER', 8), card('SPADE', 3)],
+        playerHandRank: 0,
+      }),
+    );
+    expect(hint?.targetAction).toBe('exchange');
+    expect(hint?.targetIndices).toEqual([2, 3, 4]);
+  });
+
+  // **ペアは残す。**残す札まで交換対象に入れると、できている役を壊す。
+  it('keeps a pair and swaps only the rest', () => {
+    const hint = getOasisPokerHint(
+      makeState({
+        phase: OasisPokerPhase.EXCHANGE,
+        playerHand: [card('SPADE', 5), card('HEART', 5), card('DIAMOND', 2), card('CLOVER', 8), card('SPADE', 3)],
+        playerHandRank: 1,
+      }),
+    );
+    expect(hint?.targetIndices).toEqual([2, 3, 4]);
+  });
+
+  // **A/J/Q/K は残す。**エースは value 1 なので、素朴な大小比較だと捨ててしまう。
+  it('keeps an ace even though its raw value is 1', () => {
+    const hint = getOasisPokerHint(
+      makeState({
+        phase: OasisPokerPhase.EXCHANGE,
+        playerHand: [card('SPADE', 1), card('HEART', 4), card('DIAMOND', 6), card('CLOVER', 8), card('SPADE', 9)],
+        playerHandRank: 0,
+      }),
+    );
+    expect(hint?.targetIndices).not.toContain(0);
+  });
+
+  // **交換するものが無いときだけ stand。**低いペアを持っているだけで
+  // 「そのまま」と言うと、残り3枚を引き直す機会を捨てさせる。
+  it('stands only when there is nothing worth swapping', () => {
+    const hint = getOasisPokerHint(
+      makeState({
+        phase: OasisPokerPhase.EXCHANGE,
+        playerHand: [card('SPADE', 1), card('HEART', 13), card('DIAMOND', 12), card('CLOVER', 11), card('SPADE', 11)],
+        playerHandRank: 1,
+      }),
+    );
+    expect(hint?.targetAction).toBe('stand');
+    expect(hint?.targetIndices ?? []).toEqual([]);
+  });
+
+  it('does not tag the action phase with exchange indices', () => {
+    const hint = getOasisPokerHint(
+      makeState({
+        phase: OasisPokerPhase.ACTION,
+        playerHand: [card('SPADE', 1), card('HEART', 13), card('DIAMOND', 5), card('CLOVER', 8), card('SPADE', 3)],
+        playerHandRank: 0,
+      }),
+    );
+    expect(hint?.targetIndices).toBeUndefined();
   });
 });

--- a/frontend/src/utils/hints/oasispokerHint.ts
+++ b/frontend/src/utils/hints/oasispokerHint.ts
@@ -11,6 +11,34 @@ const ACE_VALUE = 1;
 /** Card value representing a King. */
 const KING_VALUE = 13;
 
+/** Lowest value counted as a high card to hold (Jack). */
+const JACK_VALUE = 11;
+
+/**
+ * Hand indices worth swapping out: cards that are neither part of a pair nor a
+ * high card (J/Q/K/A).
+ *
+ * Sync: `oasisPokerExchangeIndices` in `OasisPokerCuiPresenter.go`, which the
+ * CUI already prints as `[1]♠5 [3]♣2`. The Web hint only said "exchange" and
+ * left the player to work out which of the five to click (#4711).
+ *
+ * **An Ace is `value === 1`,** so a plain "is it big?" comparison throws away
+ * the best card in the hand.
+ */
+function exchangeIndices(hand: readonly Card[]): number[] {
+  const rankCount = new Map<number, number>();
+  for (const c of hand) {
+    rankCount.set(c.value, (rankCount.get(c.value) ?? 0) + 1);
+  }
+  const out: number[] = [];
+  hand.forEach((c, i) => {
+    const isPair = (rankCount.get(c.value) ?? 0) >= 2;
+    const isHigh = c.value === ACE_VALUE || c.value >= JACK_VALUE;
+    if (!isPair && !isHigh) out.push(i);
+  });
+  return out;
+}
+
 /**
  * Returns an Oasis Poker hint for the exchange and action phases.
  *
@@ -26,10 +54,19 @@ export function getOasisPokerHint(state: OasisPokerResponse): HintResult | null 
   if (!state.playerHand || state.playerHand.length === 0) return null;
 
   if (state.phase === OasisPokerPhase.EXCHANGE) {
-    if (state.playerHandRank >= RANK_ONE_PAIR) {
+    const toSwap = exchangeIndices(state.playerHand);
+    // **交換するものが無いときだけ stand。**低いペアがあるからと「そのまま」
+    // と言うと、残り3枚を引き直す機会を捨てさせる。CUI は ex が空のときだけ
+    // hintStand を出している。
+    if (toSwap.length === 0) {
       return { targetAction: 'stand', reason: 'hint.exchangeKeep', confidence: 'strong' };
     }
-    return { targetAction: 'exchange', reason: 'hint.exchangeImprove', confidence: 'moderate' };
+    return {
+      targetAction: 'exchange',
+      reason: 'hint.exchangeImprove',
+      confidence: state.playerHandRank >= RANK_ONE_PAIR ? 'strong' : 'moderate',
+      targetIndices: toSwap,
+    };
   }
 
   if (state.phase === OasisPokerPhase.ACTION) {


### PR DESCRIPTION
## 背景

`OasisPokerCuiPresenter.HintOutput` は交換すべき札を **`[1]♠5 [3]♣2` のようにインデックスで列挙**します。Web の `getOasisPokerHint` は `{ targetAction: 'exchange', reason: 'hint.exchangeImprove' }` を返すだけで、**どのカードかの情報を持っていませんでした** (#4711)。5枚を個別にクリックして `selectedIndices` に積む UI があるのにです。

## 判定は CUI と同じ規則です

`oasisPokerExchangeIndices` を移植しました。ペアと J/Q/K/A を残し、それ以外を交換します。

**エースは `value === 1`** なので、素朴な「大きいか？」の比較だと**手札で一番強い札を捨てさせます**。ここを壊すとテストが4件落ちます。

`HintResult.targetIndices`（#4851 の Anaconda で入ったもの）にそのまま載せ、ページは Anaconda と同じ形で該当カードに破線リングを付けます（選択済みの実線リングと重ならないように）。

## ペアがあるだけでは stand にしません

旧実装は `playerHandRank >= RANK_ONE_PAIR` だけを見て「そのまま」と言っていました。**低いペア + くず札3枚は引き直したほうがよく、CUI もそう助言しています**（`ex` が空のときだけ `hintStand`）。

この挙動を固定していたテスト（`recommends standing with a made hand of pair or better`）は、そもそも**ペアの無い手札に `playerHandRank: 1` を差し込んだだけ**のものでした。「全札が残す価値のある手」で stand を確かめるものと、「低いペアのキッカーを引き直す」ものの2本に置き換えています。

## 負のコントロール

| 壊し方 | 落ちる件数 |
|---|---|
| エースを捨てる | 4 |
| ペアも捨てる | 1 |
| `targetIndices` を返さない | 3 |
| ページが読まない | 1 |

## 検証

- `bunx vitest run` (hint 13 + page 26) 全通過 ✅
- `bun run typecheck` ✅ / `bun run check` 全ガード通過 ✅

Closes #4711