### PR TITLE
feat: give Ultimate Texas Hold'em CUI a bet-strategy hint

### DIFF
--- a/internal/adapter/controller/UltimateTexasHoldemCuiController.go
+++ b/internal/adapter/controller/UltimateTexasHoldemCuiController.go
@@ -27,7 +27,7 @@ func (uc *UltimateTexasHoldemCuiController) Exec(command string) string {
 	return execCuiCommand(
 		command,
 		func(_ []string) string { return uc.ui.Reset() },
-		[]string{"b", "bet", "p", "play", "c", "check", "f", "fold", "log", "l"},
+		[]string{"b", "bet", "p", "play", "c", "check", "f", "fold", "h", "hint", "log", "l"},
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "b", "bet":
@@ -53,6 +53,8 @@ func (uc *UltimateTexasHoldemCuiController) Exec(command string) string {
 				return uc.ui.Check(), true
 			case "f", "fold":
 				return uc.ui.Fold(), true
+			case "h", "hint":
+				return uc.ui.Hint(), true
 			default:
 				return handleCuiLog(cmd, uc.ui.ActionLog)
 			}

--- a/internal/adapter/controller/UltimateTexasHoldemCuiController_test.go
+++ b/internal/adapter/controller/UltimateTexasHoldemCuiController_test.go
@@ -23,6 +23,7 @@ func newMockUltimateTexasHoldemInteractor() *usecase.MockUltimateTexasHoldemInte
 	m.On("Check").Return("check result")
 	m.On("Fold").Return("fold result")
 	m.On("ActionLog").Return("action log result")
+	m.On("Hint").Return("hint result")
 	return m
 }
 
@@ -132,4 +133,22 @@ func TestUltimateTexasHoldemCuiController_Empty(t *testing.T) {
 	c := controller.NewUltimateTexasHoldemCuiController(m)
 	result := c.Exec("")
 	assert.Contains(t, result, "'help' でコマンド一覧を表示します。")
+}
+
+// **CUI には 4x/3x/2x/1x/check/fold を選ぶ材料が何も無かった (#4709)。**
+func TestUltimateTexasHoldemCuiController_Hint(t *testing.T) {
+	m := newMockUltimateTexasHoldemInteractor()
+	c := controller.NewUltimateTexasHoldemCuiController(m)
+
+	assert.Equal(t, "hint result", c.Exec("h"))
+	assert.Equal(t, "hint result", c.Exec("hint"))
+}
+
+// **既存コマンドは何も変わらない。**
+func TestUltimateTexasHoldemCuiController_HintDoesNotShadowOthers(t *testing.T) {
+	m := newMockUltimateTexasHoldemInteractor()
+	c := controller.NewUltimateTexasHoldemCuiController(m)
+
+	assert.Equal(t, "check result", c.Exec("c"))
+	m.AssertNotCalled(t, "Hint")
 }

--- a/internal/adapter/controller/usecase/UltimateTexasHoldemInteractor_mock.go
+++ b/internal/adapter/controller/usecase/UltimateTexasHoldemInteractor_mock.go
@@ -39,6 +39,11 @@ func (m *MockUltimateTexasHoldemInteractor) ActionLog() string {
 	return args.String(0)
 }
 
+func (m *MockUltimateTexasHoldemInteractor) Hint() string {
+	args := m.Called()
+	return args.String(0)
+}
+
 // Snapshot モック
 func (m *MockUltimateTexasHoldemInteractor) Snapshot() ([]byte, error) {
 	ret := m.Called()

--- a/internal/adapter/presenter/UltimateTexasHoldemCuiPresenter.go
+++ b/internal/adapter/presenter/UltimateTexasHoldemCuiPresenter.go
@@ -126,6 +126,29 @@ func (up *UltimateTexasHoldemCuiPresenter) Output(g interfaces.UltimateTexasHold
 	return sb.String()
 }
 
+// uthHintKeys は推奨アクションから表示用の i18n キーへの対応。
+var uthHintKeys = map[string]string{
+	domain.UTHRecommendPlay4x: "ultimatetexasholdem.hintPlay4x",
+	domain.UTHRecommendPlay3x: "ultimatetexasholdem.hintPlay3x",
+	domain.UTHRecommendPlay2x: "ultimatetexasholdem.hintPlay2x",
+	domain.UTHRecommendPlay1x: "ultimatetexasholdem.hintPlay1x",
+	domain.UTHRecommendCheck:  "ultimatetexasholdem.hintCheck",
+	domain.UTHRecommendFold:   "ultimatetexasholdem.hintFold",
+}
+
+// HintOutput は現在のフェーズでの推奨アクションを出力する。
+//
+// **CUI には 4x/3x/2x/1x/check/fold を選ぶ材料が何も無かった (#4709)。**
+// Web はプリフロップの強さで 4x / 3x ボタンを光らせている。判定はドメインの
+// RecommendPlay 1か所に置いたので、CUI と Web が違う倍率を指すことはない。
+func (up *UltimateTexasHoldemCuiPresenter) HintOutput(g interfaces.UltimateTexasHoldemGame) string {
+	key, ok := uthHintKeys[g.RecommendPlay()]
+	if !ok {
+		return i18n.T("ultimatetexasholdem.hintNone") + "\n"
+	}
+	return color.Yellow(i18n.T(key)) + "\n"
+}
+
 // ActionLogOutput 棋譜をテキスト出力
 func (up *UltimateTexasHoldemCuiPresenter) ActionLogOutput(g interfaces.UltimateTexasHoldemGame) string {
 	return actionLogOutputText(g)

--- a/internal/adapter/presenter/UltimateTexasHoldemCuiPresenter_test.go
+++ b/internal/adapter/presenter/UltimateTexasHoldemCuiPresenter_test.go
@@ -205,3 +205,41 @@ func TestUltimateTexasHoldemCuiPresenter_ActionLogOutput(t *testing.T) {
 	result := p.ActionLogOutput(m)
 	assert.Contains(t, result, "bet")
 }
+
+// **CUI に 4x/3x/2x/1x/check/fold を選ぶ材料が何も無かった (#4709)。**
+func TestUltimateTexasHoldemCuiPresenter_HintOutput(t *testing.T) {
+	p := new(UltimateTexasHoldemCuiPresenter)
+	game := func(rec string) *interfaces.MockUltimateTexasHoldemGame {
+		m := new(interfaces.MockUltimateTexasHoldemGame)
+		m.On("RecommendPlay").Return(rec)
+		return m
+	}
+
+	// **倍率ごとに違う文言。**同じ文なら「レイズしろ」までしか伝わらない。
+	t.Run("each multiplier gets its own line", func(t *testing.T) {
+		seen := map[string]bool{}
+		for _, rec := range []string{
+			domain.UTHRecommendPlay4x, domain.UTHRecommendPlay3x,
+			domain.UTHRecommendPlay2x, domain.UTHRecommendPlay1x,
+			domain.UTHRecommendCheck, domain.UTHRecommendFold,
+		} {
+			out := p.HintOutput(game(rec))
+			assert.False(t, seen[out], "%s の文言が他と重複している", rec)
+			seen[out] = true
+			assert.NotContains(t, out, i18n.T("ultimatetexasholdem.hintNone"))
+		}
+		assert.Len(t, seen, 6)
+	})
+
+	t.Run("names the 4x multiplier", func(t *testing.T) {
+		assert.Contains(t, p.HintOutput(game(domain.UTHRecommendPlay4x)), "4倍")
+	})
+
+	t.Run("names the 2x multiplier", func(t *testing.T) {
+		assert.Contains(t, p.HintOutput(game(domain.UTHRecommendPlay2x)), "2倍")
+	})
+
+	t.Run("says so when there is no decision to make", func(t *testing.T) {
+		assert.Contains(t, p.HintOutput(game("")), i18n.T("ultimatetexasholdem.hintNone"))
+	})
+}

--- a/internal/adapter/presenter/UltimateTexasHoldemWebPresenter.go
+++ b/internal/adapter/presenter/UltimateTexasHoldemWebPresenter.go
@@ -64,6 +64,13 @@ func (up *UltimateTexasHoldemWebPresenter) Output(g interfaces.UltimateTexasHold
 	return marshalOrError(resObj)
 }
 
+// HintOutput ヒントを出力する。Web ではヒントはクライアント側 (useGameHint) で
+// 算出するため、通常の状態出力を返す。UltimateTexasHoldemPresenter インタフェースを
+// 満たすための実装。
+func (up *UltimateTexasHoldemWebPresenter) HintOutput(g interfaces.UltimateTexasHoldemGame) string {
+	return up.Output(g, nil)
+}
+
 // ActionLogOutput 棋譜をJSON出力
 func (up *UltimateTexasHoldemWebPresenter) ActionLogOutput(g interfaces.UltimateTexasHoldemGame) string {
 	return actionLogOutputJSON(g)

--- a/internal/domain/UltimateTexasHoldem.go
+++ b/internal/domain/UltimateTexasHoldem.go
@@ -307,6 +307,126 @@ func (u *UltimateTexasHoldem) updatePlayerCurrentRank() {
 	u.playerHandRank, _ = evalBestFromSeven(all)
 }
 
+// 推奨アクション。CUI のヒント表示 (#4709) と Web のボタン強調が同じ判断を
+// 出すよう、判定はここ1か所に置く。
+const (
+	// UTHRecommendPlay4x プリフロップで 4x を置く。
+	UTHRecommendPlay4x = "play4x"
+	// UTHRecommendPlay3x プリフロップで 3x を置く。
+	UTHRecommendPlay3x = "play3x"
+	// UTHRecommendPlay2x フロップで 2x を置く。
+	UTHRecommendPlay2x = "play2x"
+	// UTHRecommendPlay1x リバーで 1x を置く。
+	UTHRecommendPlay1x = "play1x"
+	// UTHRecommendCheck チェックして次のストリートを見る。
+	UTHRecommendCheck = "check"
+	// UTHRecommendFold リバーで降りる。
+	UTHRecommendFold = "fold"
+)
+
+// RecommendPlay は現在のフェーズでの推奨アクションを返す。判断のいらない
+// フェーズでは空文字。
+//
+// **倍率まで返す。**Web はプリフロップの強さで 4x / 3x ボタンを光らせるのに、
+// CUI には 4x/3x/2x/1x/check/fold を選ぶ材料が何も無かった (#4709)。
+//
+// 判定はフロントの utHoldemPreflopStrength と同じ規則 (strong→4x、
+// moderate→3x、weak→check)。フロップ以降はワンペア以上かどうかで決める。
+func (u *UltimateTexasHoldem) RecommendPlay() string {
+	switch u.phase {
+	case UltimateTexasHoldemPhasePreFlop:
+		switch uthPreflopStrength(u.playerHand) {
+		case uthStrengthStrong:
+			return UTHRecommendPlay4x
+		case uthStrengthModerate:
+			return UTHRecommendPlay3x
+		default:
+			return UTHRecommendCheck
+		}
+	case UltimateTexasHoldemPhaseFlop:
+		if u.currentBestRank() >= PokerHandOnePair {
+			return UTHRecommendPlay2x
+		}
+		return UTHRecommendCheck
+	case UltimateTexasHoldemPhaseRiver:
+		if u.currentBestRank() >= PokerHandOnePair {
+			return UTHRecommendPlay1x
+		}
+		return UTHRecommendFold
+	default:
+		return ""
+	}
+}
+
+// currentBestRank はホールカードとボードから今の最良ランクを評価する。
+//
+// **保存済みの playerHandRank は読まない。**あれは配札のたびに更新される
+// フィールドで、いつ更新されたかに助言が依存してしまう。
+func (u *UltimateTexasHoldem) currentBestRank() int {
+	all := append([]*Card{}, u.playerHand...)
+	all = append(all, u.community...)
+	if len(all) < 5 {
+		return PokerHandHighCard
+	}
+	rank, _ := evalBestFromSeven(all)
+	return rank
+}
+
+// uthStrength はプリフロップの手の強さ。
+type uthStrength int
+
+const (
+	uthStrengthWeak uthStrength = iota
+	uthStrengthModerate
+	uthStrengthStrong
+)
+
+// uthPreflopStrength はホールカード2枚の強さを返す。
+//
+// **フロントの utHoldemPreflopStrength と同じ規則。**ずれると同じ手札で
+// CUI が 3x、Web のボタン強調が 4x を指すことになる。エースは 14 として
+// 数える (value は 1)。
+func uthPreflopStrength(hand []*Card) uthStrength {
+	if len(hand) < 2 {
+		return uthStrengthWeak
+	}
+	rank := func(c *Card) int {
+		if v := c.GetValue(); v == 1 {
+			return 14
+		}
+		return c.GetValue()
+	}
+	ra, rb := rank(hand[0]), rank(hand[1])
+	hi, lo := ra, rb
+	if lo > hi {
+		hi, lo = lo, hi
+	}
+	suited := hand[0].GetDesign() == hand[1].GetDesign()
+
+	switch {
+	case ra == rb: // any pair
+		return uthStrengthStrong
+	case hi == 14: // any ace
+		return uthStrengthStrong
+	case hi == 13 && suited: // suited king
+		return uthStrengthStrong
+	case hi == 13 && lo >= 11: // K-Q / K-J offsuit
+		return uthStrengthStrong
+	case hi == 12 && lo == 11 && suited: // Q-J suited
+		return uthStrengthStrong
+	case hi == 13: // K-x offsuit
+		return uthStrengthModerate
+	case hi == 12 && lo == 11: // Q-J offsuit
+		return uthStrengthModerate
+	case suited && hi-lo <= 2 && lo >= 6: // suited connector mid+
+		return uthStrengthModerate
+	case suited && hi >= 12: // Q-x suited
+		return uthStrengthModerate
+	default:
+		return uthStrengthWeak
+	}
+}
+
 // resolve ショーダウン処理。
 func (u *UltimateTexasHoldem) resolve() {
 	playerAll := append([]*Card{}, u.playerHand...)

--- a/internal/domain/UltimateTexasHoldem_test.go
+++ b/internal/domain/UltimateTexasHoldem_test.go
@@ -552,3 +552,88 @@ func TestUltimateTexasHoldem_JSONUnmarshal_RejectsHugeSlices(t *testing.T) {
 	err = json.Unmarshal(payload, dst)
 	assert.Error(t, err)
 }
+
+// **CUI には 4x/3x/2x/1x/check/fold を選ぶ材料が何も無かった (#4709)。**
+// Web はプリフロップの強さで 4x / 3x ボタンを光らせている。
+func TestUltimateTexasHoldem_RecommendPlay(t *testing.T) {
+	card := func(design, value int) *domain.Card { return domain.NewCard(design, value, false) }
+	preflop := func(hand ...*domain.Card) *domain.UltimateTexasHoldem {
+		u := domain.NewDefaultUltimateTexasHoldem()
+		u.SetPhase(domain.UltimateTexasHoldemPhasePreFlop)
+		u.SetPlayerHand(hand)
+		return u
+	}
+
+	t.Run("no recommendation before the cards are out", func(t *testing.T) {
+		u := domain.NewDefaultUltimateTexasHoldem()
+		u.SetPhase(domain.UltimateTexasHoldemPhaseBet)
+		assert.Equal(t, "", u.RecommendPlay())
+	})
+
+	t.Run("4x on a pocket pair", func(t *testing.T) {
+		assert.Equal(t, domain.UTHRecommendPlay4x,
+			preflop(card(domain.CardDesignSpade, 7), card(domain.CardDesignHeart, 7)).RecommendPlay())
+	})
+
+	// **エースは 14 として数える。**value は 1 なので、素朴な大小比較だと
+	// 最強のスターターを「弱い」と判定して 4x を逃す。
+	t.Run("4x on any ace", func(t *testing.T) {
+		assert.Equal(t, domain.UTHRecommendPlay4x,
+			preflop(card(domain.CardDesignSpade, 1), card(domain.CardDesignHeart, 4)).RecommendPlay())
+	})
+
+	t.Run("3x on a king with a low kicker", func(t *testing.T) {
+		assert.Equal(t, domain.UTHRecommendPlay3x,
+			preflop(card(domain.CardDesignSpade, 13), card(domain.CardDesignHeart, 4)).RecommendPlay())
+	})
+
+	// **スーテッドかどうかで段が変わる。**同じ K-4 でも同スートなら 4x。
+	t.Run("a suited king moves up from 3x to 4x", func(t *testing.T) {
+		assert.Equal(t, domain.UTHRecommendPlay4x,
+			preflop(card(domain.CardDesignSpade, 13), card(domain.CardDesignSpade, 4)).RecommendPlay())
+	})
+
+	t.Run("check on a weak offsuit holding", func(t *testing.T) {
+		assert.Equal(t, domain.UTHRecommendCheck,
+			preflop(card(domain.CardDesignSpade, 8), card(domain.CardDesignHeart, 3)).RecommendPlay())
+	})
+
+	t.Run("2x on the flop once a pair is made", func(t *testing.T) {
+		u := preflop(card(domain.CardDesignSpade, 8), card(domain.CardDesignHeart, 3))
+		u.SetPhase(domain.UltimateTexasHoldemPhaseFlop)
+		u.SetCommunity([]*domain.Card{
+			card(domain.CardDesignClover, 8), card(domain.CardDesignDiamond, 11), card(domain.CardDesignSpade, 2),
+		})
+		assert.Equal(t, domain.UTHRecommendPlay2x, u.RecommendPlay())
+	})
+
+	t.Run("check on the flop with nothing made", func(t *testing.T) {
+		u := preflop(card(domain.CardDesignSpade, 8), card(domain.CardDesignHeart, 3))
+		u.SetPhase(domain.UltimateTexasHoldemPhaseFlop)
+		u.SetCommunity([]*domain.Card{
+			card(domain.CardDesignClover, 9), card(domain.CardDesignDiamond, 11), card(domain.CardDesignSpade, 2),
+		})
+		assert.Equal(t, domain.UTHRecommendCheck, u.RecommendPlay())
+	})
+
+	t.Run("1x on the river with a made hand", func(t *testing.T) {
+		u := preflop(card(domain.CardDesignSpade, 8), card(domain.CardDesignHeart, 3))
+		u.SetPhase(domain.UltimateTexasHoldemPhaseRiver)
+		u.SetCommunity([]*domain.Card{
+			card(domain.CardDesignClover, 8), card(domain.CardDesignDiamond, 11), card(domain.CardDesignSpade, 2),
+			card(domain.CardDesignHeart, 5), card(domain.CardDesignClover, 6),
+		})
+		assert.Equal(t, domain.UTHRecommendPlay1x, u.RecommendPlay())
+	})
+
+	// **リバーで役が無ければ降りる。**チェックは選べないので check とは違う。
+	t.Run("fold on the river with nothing made", func(t *testing.T) {
+		u := preflop(card(domain.CardDesignSpade, 8), card(domain.CardDesignHeart, 3))
+		u.SetPhase(domain.UltimateTexasHoldemPhaseRiver)
+		u.SetCommunity([]*domain.Card{
+			card(domain.CardDesignClover, 9), card(domain.CardDesignDiamond, 11), card(domain.CardDesignSpade, 2),
+			card(domain.CardDesignHeart, 5), card(domain.CardDesignClover, 7),
+		})
+		assert.Equal(t, domain.UTHRecommendFold, u.RecommendPlay())
+	})
+}

--- a/internal/domain/interfaces/ultimate_texas_holdem.go
+++ b/internal/domain/interfaces/ultimate_texas_holdem.go
@@ -54,6 +54,8 @@ type UltimateTexasHoldemGame interface {
 	GetTotalPayout() int
 	// GetPlayerHandRank プレイヤーハンドランクを取得する
 	GetPlayerHandRank() int
+	// RecommendPlay 現在のフェーズでの推奨アクションを取得する
+	RecommendPlay() string
 	// GetDealerHandRank ディーラーハンドランクを取得する
 	GetDealerHandRank() int
 	// GetPlayerBest プレイヤー最良5枚を取得する

--- a/internal/domain/interfaces/ultimate_texas_holdem_mock.go
+++ b/internal/domain/interfaces/ultimate_texas_holdem_mock.go
@@ -136,6 +136,11 @@ func (m *MockUltimateTexasHoldemGame) GetPlayerHandRank() int {
 	return args.Int(0)
 }
 
+func (m *MockUltimateTexasHoldemGame) RecommendPlay() string {
+	args := m.Called()
+	return args.String(0)
+}
+
 func (m *MockUltimateTexasHoldemGame) GetDealerHandRank() int {
 	args := m.Called()
 	return args.Int(0)

--- a/internal/i18n/locales/en/ultimatetexasholdem.json
+++ b/internal/i18n/locales/en/ultimatetexasholdem.json
@@ -26,5 +26,12 @@
   "dealerWins": "Dealer wins!",
   "playerFolded": "Player folded.",
   "push": "Push!",
-  "totalPayoutLine": "Total payout: {{payout}}"
+  "totalPayoutLine": "Total payout: {{payout}}",
+  "hintNone": "No hint is available now.",
+  "hintPlay4x": "Recommended: play 4x (strong starting hand)",
+  "hintPlay3x": "Recommended: play 3x (decent starting hand)",
+  "hintPlay2x": "Recommended: play 2x (one pair or better)",
+  "hintPlay1x": "Recommended: play 1x (you have a made hand)",
+  "hintCheck": "Recommended: check (wait for the next card)",
+  "hintFold": "Recommended: fold (no made hand)"
 }

--- a/internal/i18n/locales/ja/ultimatetexasholdem.json
+++ b/internal/i18n/locales/ja/ultimatetexasholdem.json
@@ -26,5 +26,12 @@
   "dealerWins": "ディーラーの勝ち！",
   "playerFolded": "プレイヤーがフォールド。",
   "push": "プッシュ！",
-  "totalPayoutLine": "合計払戻し: {{payout}}"
+  "totalPayoutLine": "合計払戻し: {{payout}}",
+  "hintNone": "いまはヒントを出せません。",
+  "hintPlay4x": "推奨: 4倍でプレイ（強いスターティングハンド）",
+  "hintPlay3x": "推奨: 3倍でプレイ（そこそこのスターティングハンド）",
+  "hintPlay2x": "推奨: 2倍でプレイ（ワンペア以上）",
+  "hintPlay1x": "推奨: 1倍でプレイ（役ができている）",
+  "hintCheck": "推奨: チェック（次のカードを待つ）",
+  "hintFold": "推奨: フォールド（役ができていない）"
 }

--- a/internal/usecase/UltimateTexasHoldemInteractor.go
+++ b/internal/usecase/UltimateTexasHoldemInteractor.go
@@ -22,6 +22,8 @@ type UltimateTexasHoldemInteractorIF interface {
 	Check() string
 	// Fold リバーでフォールド
 	Fold() string
+	// Hint ヒント取得
+	Hint() string
 	// ActionLog 棋譜を出力する
 	ActionLog() string
 }
@@ -64,6 +66,11 @@ func (ui *UltimateTexasHoldemInteractor) Check() string {
 // Fold フォールド
 func (ui *UltimateTexasHoldemInteractor) Fold() string {
 	return execAndPresent(ui.Game, ui.up, ui.Game.Fold)
+}
+
+// Hint ヒント取得
+func (ui *UltimateTexasHoldemInteractor) Hint() string {
+	return ui.up.HintOutput(ui.Game)
 }
 
 // ActionLog 棋譜を出力する

--- a/internal/usecase/presenter/UltimateTexasHoldemPresenter.go
+++ b/internal/usecase/presenter/UltimateTexasHoldemPresenter.go
@@ -5,4 +5,8 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // UltimateTexasHoldemPresenter アルティメット・テキサスホールデムプレゼンターインタフェース
-type UltimateTexasHoldemPresenter = GamePresenter[interfaces.UltimateTexasHoldemGame]
+type UltimateTexasHoldemPresenter interface {
+	GamePresenter[interfaces.UltimateTexasHoldemGame]
+	// HintOutput ヒント情報を出力する
+	HintOutput(g interfaces.UltimateTexasHoldemGame) string
+}

--- a/internal/usecase/presenter/UltimateTexasHoldemPresenter_mock.go
+++ b/internal/usecase/presenter/UltimateTexasHoldemPresenter_mock.go
@@ -5,4 +5,12 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // MockUltimateTexasHoldemPresenter アルティメット・テキサスホールデムプレゼンターモック
-type MockUltimateTexasHoldemPresenter = MockGamePresenter[interfaces.UltimateTexasHoldemGame]
+type MockUltimateTexasHoldemPresenter struct {
+	MockGamePresenter[interfaces.UltimateTexasHoldemGame]
+}
+
+// HintOutput モック
+func (_m *MockUltimateTexasHoldemPresenter) HintOutput(g interfaces.UltimateTexasHoldemGame) string {
+	ret := _m.Called(g)
+	return ret.Get(0).(string)
+}


### PR DESCRIPTION
## 背景

`UltimateTexasHoldemCuiPresenter` に `HintOutput` がありません（`OasisPokerCuiPresenter` / `CasinoHoldemCuiPresenter` にはある）。**CUI プレイヤーは 4x/3x/2x/1x/check/fold を選ぶ材料を一切得られませんでした** (#4709)。Web はプリフロップで `utHoldemPreflopStrength` の結果に応じて `play-4x` / `play-3x` ボタンを光らせています。

## 判定はドメイン1か所に置きました

`UltimateTexasHoldem.RecommendPlay()` を追加し、CUI はそれを表示するだけにしました。

| フェーズ | 条件 | 推奨 |
|---|---|---|
| プリフロップ | strong | 4倍 |
| プリフロップ | moderate | 3倍 |
| プリフロップ | weak | チェック |
| フロップ | ワンペア以上 | 2倍 |
| リバー | ワンペア以上 | 1倍 / なければフォールド |

プリフロップの強さはフロントの `utHoldemPreflopStrength` と同じ規則です。**倍率ごとに別の文言**を出すので「レイズしろ」で止まりません（6種類が全部違う文言であることをテストで確かめています）。

## 細かいが実害のある3点

- **エースは 14 として数えます**（`value` は 1）。素朴な大小比較だと最強のスターターを弱いと判定して 4x を逃します。
- **スーテッドかどうかで段が変わります。**K-4 はオフスートなら 3x、同スートなら 4x。
- **リバーは check ではなく fold。**チェックできないフェーズで「待て」と言うと、選べない選択肢を勧めることになります。

## 保存済みの `playerHandRank` は読みません

あのフィールドは配札のたびに更新されるので、**いつ更新されたかに助言が依存**します。その場でホール+ボードを評価します。

## 負のコントロール

| 壊し方 | 落ちる件数 |
|---|---|
| エースを 14 で数えない | 2 |
| スーテッド K を 3x に落とす | 2 |
| リバーで check を返す | 2 |
| 3x と 4x を同じ文言にする | 2 |
| `h` コマンドの配線ミス | 1 |

## 検証

- `go test -tags test ./internal/...` ✅ / `golangci-lint run ./internal/...` → `0 issues.` ✅ / `gofmt -l internal/` 空 ✅
- `check-message-codes: OK (all 775 codes …)` ✅

Closes #4709