### PR TITLE
feat: show Mississippi Stud made hand and bet size in the CUI

### DIFF
--- a/internal/adapter/controller/MississippiStudCuiController.go
+++ b/internal/adapter/controller/MississippiStudCuiController.go
@@ -25,7 +25,7 @@ func (mc *MississippiStudCuiController) Exec(command string) string {
 	return execCuiCommand(
 		command,
 		func(_ []string) string { return mc.ci.Reset() },
-		[]string{"b", "bet", "p", "play", "f", "fold", "log"},
+		[]string{"b", "bet", "p", "play", "f", "fold", "h", "hint", "log"},
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "b", "bet":
@@ -42,6 +42,8 @@ func (mc *MississippiStudCuiController) Exec(command string) string {
 				return mc.ci.Play(mult), true
 			case "f", "fold":
 				return mc.ci.Fold(), true
+			case "h", "hint":
+				return mc.ci.Hint(), true
 			default:
 				return handleCuiLog(cmd, mc.ci.ActionLog)
 			}

--- a/internal/adapter/controller/MississippiStudCuiController_test.go
+++ b/internal/adapter/controller/MississippiStudCuiController_test.go
@@ -20,6 +20,7 @@ func newMockMississippiStudInteractor() *usecase.MockMississippiStudInteractor {
 	m.On("Play", 3).Return("play 3 result")
 	m.On("Fold").Return("fold result")
 	m.On("ActionLog").Return("action log result")
+	m.On("Hint").Return("hint result")
 	return m
 }
 
@@ -117,4 +118,13 @@ func TestMississippiStudCuiController_Empty(t *testing.T) {
 	c := controller.NewMississippiStudCuiController(m)
 
 	assert.Contains(t, c.Exec(""), "'help' でコマンド一覧を表示します。")
+}
+
+// **CUI に 1x/3x/fold を選ぶ材料が無かった (#4710)。**
+func TestMississippiStudCuiController_Hint(t *testing.T) {
+	m := newMockMississippiStudInteractor()
+	c := controller.NewMississippiStudCuiController(m)
+
+	assert.Equal(t, "hint result", c.Exec("h"))
+	assert.Equal(t, "hint result", c.Exec("hint"))
 }

--- a/internal/adapter/controller/usecase/MississippiStudInteractor_mock.go
+++ b/internal/adapter/controller/usecase/MississippiStudInteractor_mock.go
@@ -29,6 +29,11 @@ func (m *MockMississippiStudInteractor) Fold() string {
 	return args.String(0)
 }
 
+func (m *MockMississippiStudInteractor) Hint() string {
+	args := m.Called()
+	return args.String(0)
+}
+
 func (m *MockMississippiStudInteractor) ActionLog() string {
 	args := m.Called()
 	return args.String(0)

--- a/internal/adapter/presenter/MississippiStudCuiPresenter.go
+++ b/internal/adapter/presenter/MississippiStudCuiPresenter.go
@@ -85,6 +85,38 @@ func (mp *MississippiStudCuiPresenter) Output(g interfaces.MississippiStudGame, 
 	})
 }
 
+// msHintKeys は推奨アクションから表示用の i18n キーへの対応。
+var msHintKeys = map[string]string{
+	domain.MSRecommendPlay3x: "mississippistud.hintPlay3x",
+	domain.MSRecommendPlay1x: "mississippistud.hintPlay1x",
+	domain.MSRecommendFold:   "mississippistud.hintFold",
+}
+
+// HintOutput は現在の役・配当対象かどうか・推奨倍率を出力する。
+//
+// **Web は ms-made-hand に役と配当対象かを常時出し、ヒントも表示している
+// のに、CUI にはどちらも無かった (#4710)。**判定はドメインの
+// GetCurrentMadeHand / RecommendBet 1か所に置いたので、CUI と Web が
+// 違うことを言うことはない。
+func (mp *MississippiStudCuiPresenter) HintOutput(g interfaces.MississippiStudGame) string {
+	key, ok := msHintKeys[g.RecommendBet()]
+	if !ok {
+		return i18n.T("mississippistud.hintNone") + "\n"
+	}
+	var b strings.Builder
+	// **役の名前だけでは足りない。**2 のペアは「ワンペア」でも配当が付かない。
+	if made := g.GetCurrentMadeHand(); made != nil {
+		eligible := i18n.T("mississippistud.madeHandNotEligible")
+		if made.PaytableEligible {
+			eligible = i18n.T("mississippistud.madeHandEligible")
+		}
+		b.WriteString(i18n.Tf("mississippistud.madeHandLine",
+			"hand", cuiPokerHandName(made.Rank), "eligible", eligible) + "\n")
+	}
+	b.WriteString(color.Yellow(i18n.T(key)) + "\n")
+	return b.String()
+}
+
 // ActionLogOutput 棋譜をテキスト出力する。
 func (mp *MississippiStudCuiPresenter) ActionLogOutput(g interfaces.MississippiStudGame) string {
 	return actionLogOutputText(g)

--- a/internal/adapter/presenter/MississippiStudCuiPresenter_test.go
+++ b/internal/adapter/presenter/MississippiStudCuiPresenter_test.go
@@ -208,3 +208,48 @@ func TestMississippiStudCuiPresenter_ActionLogOutput(t *testing.T) {
 	result := p.ActionLogOutput(m)
 	assert.NotEmpty(t, result)
 }
+
+// **CUI には役評価も配当対象判定も推奨倍率も無かった (#4710)。**
+func TestMississippiStudCuiPresenter_HintOutput(t *testing.T) {
+	p := new(MississippiStudCuiPresenter)
+	game := func(rec string, made *domain.MississippiStudMadeHand) *interfaces.MockMississippiStudGame {
+		m := new(interfaces.MockMississippiStudGame)
+		m.On("RecommendBet").Return(rec)
+		m.On("GetCurrentMadeHand").Return(made).Maybe()
+		return m
+	}
+
+	t.Run("names the hand and that it pays", func(t *testing.T) {
+		out := p.HintOutput(game(domain.MSRecommendPlay3x,
+			&domain.MississippiStudMadeHand{Rank: domain.PokerHandOnePair, PaytableEligible: true}))
+		assert.Contains(t, out, "ワンペア")
+		assert.Contains(t, out, "配当あり")
+	})
+
+	// **役名だけでは足りない。**2 のペアは「ワンペア」でも配当が付かない。
+	t.Run("says when a made hand does not pay", func(t *testing.T) {
+		out := p.HintOutput(game(domain.MSRecommendFold,
+			&domain.MississippiStudMadeHand{Rank: domain.PokerHandOnePair, PaytableEligible: false}))
+		assert.Contains(t, out, "配当なし")
+		assert.NotContains(t, out, "配当あり")
+	})
+
+	t.Run("each recommendation gets its own line", func(t *testing.T) {
+		seen := map[string]bool{}
+		for _, rec := range []string{domain.MSRecommendPlay3x, domain.MSRecommendPlay1x, domain.MSRecommendFold} {
+			out := p.HintOutput(game(rec, nil))
+			assert.False(t, seen[out], "%s の文言が他と重複している", rec)
+			seen[out] = true
+		}
+		assert.Len(t, seen, 3)
+	})
+
+	t.Run("omits the made-hand line when nothing is made", func(t *testing.T) {
+		out := p.HintOutput(game(domain.MSRecommendPlay1x, nil))
+		assert.NotContains(t, out, "現在の役")
+	})
+
+	t.Run("says so outside the betting streets", func(t *testing.T) {
+		assert.Contains(t, p.HintOutput(game("", nil)), i18n.T("mississippistud.hintNone"))
+	})
+}

--- a/internal/adapter/presenter/MississippiStudWebPresenter.go
+++ b/internal/adapter/presenter/MississippiStudWebPresenter.go
@@ -50,6 +50,13 @@ func (mp *MississippiStudWebPresenter) Output(g interfaces.MississippiStudGame, 
 	return marshalOrError(resObj)
 }
 
+// HintOutput ヒントを出力する。Web ではヒントはクライアント側 (useGameHint) で
+// 算出するため、通常の状態出力を返す。MississippiStudPresenter インタフェースを
+// 満たすための実装。
+func (mp *MississippiStudWebPresenter) HintOutput(g interfaces.MississippiStudGame) string {
+	return mp.Output(g, nil)
+}
+
 // ActionLogOutput 棋譜を JSON 出力する。
 func (mp *MississippiStudWebPresenter) ActionLogOutput(g interfaces.MississippiStudGame) string {
 	return actionLogOutputJSON(g)

--- a/internal/domain/MississippiStud.go
+++ b/internal/domain/MississippiStud.go
@@ -5,6 +5,7 @@ package domain
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 )
 
 // ミシシッピ・スタッドフェーズ定数
@@ -274,6 +275,190 @@ func mississippiStudPayoutMultiplier(rank int, hand []*Card) int {
 	default:
 		return MississippiStudPayLoss
 	}
+}
+
+// MississippiStudMadeHand は現在の手役と、それが配当表に載るかどうか。
+type MississippiStudMadeHand struct {
+	// Rank は既知のカードから作れる最良の役 (PokerHand*)。
+	Rank int
+	// PaytableEligible は配当表の対象か。6以上のペアかエースのペア、
+	// またはワンペアより上の役。
+	PaytableEligible bool
+}
+
+// 推奨アクション (#4710)。
+const (
+	// MSRecommendPlay3x 3倍を置く。
+	MSRecommendPlay3x = "play3x"
+	// MSRecommendPlay1x 1倍を置く。
+	MSRecommendPlay1x = "play1x"
+	// MSRecommendFold 降りる。
+	MSRecommendFold = "fold"
+)
+
+// knownCards はホールカードと**公開済みの**コミュニティカードを返す。
+//
+// **未公開のカードを混ぜない。**混ぜると、プレイヤーがまだ見ていない札を
+// 根拠にした助言になる。
+func (m *MississippiStud) knownCards() []*Card {
+	cards := append([]*Card{}, m.playerHand...)
+	for i, c := range m.communityCards {
+		if i < len(m.communityRevealed) && m.communityRevealed[i] {
+			cards = append(cards, c)
+		}
+	}
+	return cards
+}
+
+// GetCurrentMadeHand は既知のカードからできている役を返す。2枚未満、または
+// ハイカードどまりのときは nil。
+//
+// **Web は ms-made-hand に役と配当対象かを常時出しているのに、CUI には
+// どちらも無かった (#4710)。**
+func (m *MississippiStud) GetCurrentMadeHand() *MississippiStudMadeHand {
+	cards := m.knownCards()
+	if len(cards) < 2 {
+		return nil
+	}
+	rank := mississippiStudBestRank(cards)
+	if rank <= PokerHandHighCard {
+		return nil
+	}
+	if rank > PokerHandOnePair {
+		return &MississippiStudMadeHand{Rank: rank, PaytableEligible: true}
+	}
+	return &MississippiStudMadeHand{
+		Rank:             rank,
+		PaytableEligible: mississippiStudPairTier(cards) != MississippiStudPayLoss,
+	}
+}
+
+// mississippiStudBestRank は既知のカードから作れる最良の役を返す。
+// 5枚に満たないときは同ランクの重なりだけで判定する (フラッシュや
+// ストレートは5枚そろわないと成立しない)。
+func mississippiStudBestRank(cards []*Card) int {
+	if len(cards) >= 5 {
+		best := PokerHandHighCard
+		for _, combo := range combinations(cards, 5) {
+			if r := evalFiveCardHand(combo); r > best {
+				best = r
+			}
+		}
+		return best
+	}
+	counts := map[int]int{}
+	for _, c := range cards {
+		counts[c.GetValue()]++
+	}
+	maxCount, pairs := 0, 0
+	for _, n := range counts {
+		if n > maxCount {
+			maxCount = n
+		}
+		if n >= 2 {
+			pairs++
+		}
+	}
+	switch {
+	case maxCount >= 4:
+		return PokerHandFourOfAKind
+	case maxCount == 3:
+		return PokerHandThreeOfAKind
+	case pairs >= 2:
+		return PokerHandTwoPair
+	case maxCount == 2:
+		return PokerHandOnePair
+	default:
+		return PokerHandHighCard
+	}
+}
+
+// RecommendBet は現在のストリートでの推奨アクションを返す。判断のいらない
+// フェーズでは空文字。
+//
+// **判定はフロントの getMississippiStudHint と同じ規則。**配当対象の役が
+// できていれば 3x、まともなドローがあれば 1x、それ以外は降りる。ずれると
+// 同じ局面で CUI と Web が違う倍率を指す。
+func (m *MississippiStud) RecommendBet() string {
+	switch m.phase {
+	case MississippiStudPhaseThirdSt, MississippiStudPhaseFourthSt, MississippiStudPhaseFifthSt:
+	default:
+		return ""
+	}
+	cards := m.knownCards()
+	if len(cards) == 0 {
+		return ""
+	}
+	if made := m.GetCurrentMadeHand(); made != nil && made.PaytableEligible {
+		return MSRecommendPlay3x
+	}
+	if mississippiStudHasReasonableDraw(cards, m.phase) {
+		return MSRecommendPlay1x
+	}
+	return MSRecommendFold
+}
+
+// mississippiStudHasReasonableDraw はフラッシュ/ストレートのドロー、または
+// 3rd street でのハイカード2枚を「まだ賭ける価値がある」と見なす。
+func mississippiStudHasReasonableDraw(cards []*Card, phase int) bool {
+	slotsLeft := (MississippiStudHoleCardCnt + MississippiStudCommunityCnt) - len(cards)
+	if mississippiStudHasFlushDraw(cards, slotsLeft) || mississippiStudHasStraightDraw(cards, slotsLeft) {
+		return true
+	}
+	if phase != MississippiStudPhaseThirdSt {
+		return false
+	}
+	high := 0
+	for _, c := range cards {
+		if v := c.GetValue(); v == 1 || v >= 10 {
+			high++
+		}
+	}
+	return high >= 2
+}
+
+// mississippiStudHasFlushDraw は残り枚数でフラッシュが間に合うかを返す。
+func mississippiStudHasFlushDraw(cards []*Card, slotsLeft int) bool {
+	bySuit := map[int]int{}
+	for _, c := range cards {
+		bySuit[c.GetDesign()]++
+	}
+	for _, n := range bySuit {
+		if n >= 3 && n+slotsLeft >= (MississippiStudHoleCardCnt+MississippiStudCommunityCnt) {
+			return true
+		}
+	}
+	return false
+}
+
+// mississippiStudHasStraightDraw は残り枚数でストレートが間に合うかを返す。
+// **エースは 1 と 14 の両方で数える。**A-2-3-4-5 も 10-J-Q-K-A も成立する。
+func mississippiStudHasStraightDraw(cards []*Card, slotsLeft int) bool {
+	set := map[int]bool{}
+	for _, c := range cards {
+		v := c.GetValue()
+		set[v] = true
+		if v == 1 {
+			set[14] = true
+		}
+	}
+	values := make([]int, 0, len(set))
+	for v := range set {
+		values = append(values, v)
+	}
+	sort.Ints(values)
+	run := 1
+	for i := 1; i < len(values); i++ {
+		if values[i] == values[i-1]+1 {
+			run++
+		} else {
+			run = 1
+		}
+		if run+slotsLeft >= (MississippiStudHoleCardCnt + MississippiStudCommunityCnt) {
+			return true
+		}
+	}
+	return false
 }
 
 // mississippiStudPairTier はペア構成のティアを返す。

--- a/internal/domain/MississippiStud_test.go
+++ b/internal/domain/MississippiStud_test.go
@@ -421,3 +421,109 @@ func TestMississippiStud_ActionLog_Recorded(t *testing.T) {
 	assert.Contains(t, types, "fold")
 	assert.Contains(t, types, "result")
 }
+
+// **CUI には役評価も配当対象判定も推奨倍率も無かった (#4710)。**Web は
+// ms-made-hand に役と配当対象かを常時出している。
+func TestMississippiStud_CurrentMadeHandAndRecommendBet(t *testing.T) {
+	card := func(design, value int) *domain.Card { return domain.NewCard(design, value, false) }
+	street := func(phase int, hole []*domain.Card, community []*domain.Card, revealed [3]bool) *domain.MississippiStud {
+		m := domain.NewDefaultMississippiStud()
+		m.SetPhase(phase)
+		m.SetPlayerHand(hole)
+		m.SetCommunityCards(community)
+		m.SetCommunityRevealed(revealed)
+		return m
+	}
+	noBoard := []*domain.Card{
+		card(domain.CardDesignClover, 2), card(domain.CardDesignDiamond, 4), card(domain.CardDesignHeart, 9),
+	}
+	hidden := [3]bool{false, false, false}
+
+	t.Run("no made hand from two unpaired cards", func(t *testing.T) {
+		m := street(domain.MississippiStudPhaseThirdSt,
+			[]*domain.Card{card(domain.CardDesignSpade, 7), card(domain.CardDesignHeart, 3)}, noBoard, hidden)
+		assert.Nil(t, m.GetCurrentMadeHand())
+	})
+
+	// **2 のペアは「ワンペア」でも配当が付かない。**役名だけ出すと、
+	// 配当の付かない手で 3 倍を置かせる。
+	t.Run("a low pair is a made hand but does not pay", func(t *testing.T) {
+		m := street(domain.MississippiStudPhaseThirdSt,
+			[]*domain.Card{card(domain.CardDesignSpade, 2), card(domain.CardDesignHeart, 2)}, noBoard, hidden)
+		made := m.GetCurrentMadeHand()
+		if assert.NotNil(t, made) {
+			assert.Equal(t, domain.PokerHandOnePair, made.Rank)
+			assert.False(t, made.PaytableEligible)
+		}
+	})
+
+	t.Run("a pair of sixes pays", func(t *testing.T) {
+		m := street(domain.MississippiStudPhaseThirdSt,
+			[]*domain.Card{card(domain.CardDesignSpade, 6), card(domain.CardDesignHeart, 6)}, noBoard, hidden)
+		made := m.GetCurrentMadeHand()
+		if assert.NotNil(t, made) {
+			assert.True(t, made.PaytableEligible)
+		}
+		assert.Equal(t, domain.MSRecommendPlay3x, m.RecommendBet())
+	})
+
+	// **エースのペアも配当対象。**value が 1 なので「6以上」だけ見ると外れる。
+	t.Run("a pair of aces pays even though the value is 1", func(t *testing.T) {
+		m := street(domain.MississippiStudPhaseThirdSt,
+			[]*domain.Card{card(domain.CardDesignSpade, 1), card(domain.CardDesignHeart, 1)}, noBoard, hidden)
+		made := m.GetCurrentMadeHand()
+		if assert.NotNil(t, made) {
+			assert.True(t, made.PaytableEligible)
+		}
+	})
+
+	// **未公開のコミュニティカードは混ぜない。**プレイヤーがまだ見ていない
+	// 札を根拠にした助言になる。
+	t.Run("ignores community cards that are still face down", func(t *testing.T) {
+		hole := []*domain.Card{card(domain.CardDesignSpade, 7), card(domain.CardDesignHeart, 3)}
+		board := []*domain.Card{card(domain.CardDesignClover, 7), card(domain.CardDesignDiamond, 4), card(domain.CardDesignHeart, 9)}
+
+		assert.Nil(t, street(domain.MississippiStudPhaseThirdSt, hole, board, hidden).GetCurrentMadeHand())
+
+		shown := street(domain.MississippiStudPhaseFourthSt, hole, board, [3]bool{true, false, false})
+		made := shown.GetCurrentMadeHand()
+		if assert.NotNil(t, made) {
+			assert.Equal(t, domain.PokerHandOnePair, made.Rank, "公開された 7 でペアになる")
+		}
+	})
+
+	t.Run("bets 1x on a flush draw with nothing made", func(t *testing.T) {
+		m := street(domain.MississippiStudPhaseFourthSt,
+			[]*domain.Card{card(domain.CardDesignSpade, 2), card(domain.CardDesignSpade, 5)},
+			[]*domain.Card{card(domain.CardDesignSpade, 9), card(domain.CardDesignDiamond, 4), card(domain.CardDesignHeart, 11)},
+			[3]bool{true, false, false})
+		assert.Equal(t, domain.MSRecommendPlay1x, m.RecommendBet())
+	})
+
+	t.Run("folds a hand with nothing made and no draw", func(t *testing.T) {
+		m := street(domain.MississippiStudPhaseFourthSt,
+			[]*domain.Card{card(domain.CardDesignSpade, 2), card(domain.CardDesignHeart, 5)},
+			[]*domain.Card{card(domain.CardDesignClover, 9), card(domain.CardDesignDiamond, 4), card(domain.CardDesignHeart, 11)},
+			[3]bool{true, false, false})
+		assert.Equal(t, domain.MSRecommendFold, m.RecommendBet())
+	})
+
+	// **3rd street だけはハイカード2枚でも賭ける。**あと3枚めくれるので
+	// まだ伸びる。4th 以降で同じ手を賭けると、伸びない手に払い続ける。
+	t.Run("two high cards are worth 1x only on third street", func(t *testing.T) {
+		hole := []*domain.Card{card(domain.CardDesignSpade, 12), card(domain.CardDesignHeart, 11)}
+		third := street(domain.MississippiStudPhaseThirdSt, hole, noBoard, hidden)
+		assert.Equal(t, domain.MSRecommendPlay1x, third.RecommendBet())
+
+		fourth := street(domain.MississippiStudPhaseFourthSt, hole,
+			[]*domain.Card{card(domain.CardDesignClover, 2), card(domain.CardDesignDiamond, 4), card(domain.CardDesignHeart, 9)},
+			[3]bool{true, false, false})
+		assert.Equal(t, domain.MSRecommendFold, fourth.RecommendBet())
+	})
+
+	t.Run("no recommendation outside the betting streets", func(t *testing.T) {
+		m := street(domain.MississippiStudPhaseAnte,
+			[]*domain.Card{card(domain.CardDesignSpade, 6), card(domain.CardDesignHeart, 6)}, noBoard, hidden)
+		assert.Equal(t, "", m.RecommendBet())
+	})
+}

--- a/internal/domain/interfaces/mississippi_stud.go
+++ b/internal/domain/interfaces/mississippi_stud.go
@@ -38,6 +38,10 @@ type MississippiStudGame interface {
 	GetResult() domain.GameResult
 	// GetHandRank ハンドランクを取得する
 	GetHandRank() int
+	// GetCurrentMadeHand 既知のカードからできている役を取得する
+	GetCurrentMadeHand() *domain.MississippiStudMadeHand
+	// RecommendBet 現在のストリートでの推奨アクションを取得する
+	RecommendBet() string
 	// GetPayoutMultiplier 適用された配当倍率を取得する
 	GetPayoutMultiplier() int
 	// GetAntePayout アンティ部分の配当を取得する

--- a/internal/domain/interfaces/mississippi_stud_mock.go
+++ b/internal/domain/interfaces/mississippi_stud_mock.go
@@ -93,6 +93,19 @@ func (m *MockMississippiStudGame) GetHandRank() int {
 	return args.Int(0)
 }
 
+func (m *MockMississippiStudGame) GetCurrentMadeHand() *domain.MississippiStudMadeHand {
+	args := m.Called()
+	if args.Get(0) == nil {
+		return nil
+	}
+	return args.Get(0).(*domain.MississippiStudMadeHand)
+}
+
+func (m *MockMississippiStudGame) RecommendBet() string {
+	args := m.Called()
+	return args.String(0)
+}
+
 func (m *MockMississippiStudGame) GetPayoutMultiplier() int {
 	args := m.Called()
 	return args.Int(0)

--- a/internal/i18n/locales/en/mississippistud.json
+++ b/internal/i18n/locales/en/mississippistud.json
@@ -22,5 +22,12 @@
   "playerWins": "Player wins!",
   "playerLoses": "Player loses.",
   "push": "Push.",
-  "foldLossLine": "Loss on fold: {{loss}}"
+  "foldLossLine": "Loss on fold: {{loss}}",
+  "hintNone": "No hint is available now.",
+  "hintPlay3x": "Recommended: bet 3x",
+  "hintPlay1x": "Recommended: bet 1x",
+  "hintFold": "Recommended: fold",
+  "madeHandLine": "Current hand: {{hand}} ({{eligible}})",
+  "madeHandEligible": "pays",
+  "madeHandNotEligible": "does not pay"
 }

--- a/internal/i18n/locales/ja/mississippistud.json
+++ b/internal/i18n/locales/ja/mississippistud.json
@@ -22,5 +22,12 @@
   "playerWins": "プレイヤーの勝ち！",
   "playerLoses": "プレイヤーの負け。",
   "push": "プッシュ。",
-  "foldLossLine": "フォールド時の損失: {{loss}}"
+  "foldLossLine": "フォールド時の損失: {{loss}}",
+  "hintNone": "いまはヒントを出せません。",
+  "hintPlay3x": "推奨: 3倍を置く",
+  "hintPlay1x": "推奨: 1倍を置く",
+  "hintFold": "推奨: フォールド",
+  "madeHandLine": "現在の役: {{hand}} ({{eligible}})",
+  "madeHandEligible": "配当あり",
+  "madeHandNotEligible": "配当なし"
 }

--- a/internal/usecase/MississippiStudInteractor.go
+++ b/internal/usecase/MississippiStudInteractor.go
@@ -20,6 +20,8 @@ type MississippiStudInteractorIF interface {
 	Play(multiplier int) string
 	// Fold フォールド
 	Fold() string
+	// Hint ヒント取得
+	Hint() string
 	// ActionLog 棋譜を出力する
 	ActionLog() string
 }
@@ -57,6 +59,11 @@ func (mi *MississippiStudInteractor) Play(multiplier int) string {
 // Fold フォールド
 func (mi *MississippiStudInteractor) Fold() string {
 	return execAndPresent(mi.Game, mi.cp, mi.Game.Fold)
+}
+
+// Hint ヒント取得
+func (mi *MississippiStudInteractor) Hint() string {
+	return mi.cp.HintOutput(mi.Game)
 }
 
 // ActionLog 棋譜を出力する

--- a/internal/usecase/MississippiStudInteractor_snapshot_test.go
+++ b/internal/usecase/MississippiStudInteractor_snapshot_test.go
@@ -23,6 +23,10 @@ func (s *stubMississippiStudPresenter) ActionLogOutput(_ interfaces.MississippiS
 	return `{"log":[]}`
 }
 
+func (s *stubMississippiStudPresenter) HintOutput(_ interfaces.MississippiStudGame) string {
+	return `{}`
+}
+
 func TestMississippiStudInteractor_SnapshotRestore(t *testing.T) {
 	g := domain.NewDefaultMississippiStud()
 	mi := NewMississippiStudInteractor(g, new(stubMississippiStudPresenter))

--- a/internal/usecase/presenter/MississippiStudPresenter.go
+++ b/internal/usecase/presenter/MississippiStudPresenter.go
@@ -5,4 +5,8 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // MississippiStudPresenter ミシシッピ・スタッドプレゼンターインタフェース
-type MississippiStudPresenter = GamePresenter[interfaces.MississippiStudGame]
+type MississippiStudPresenter interface {
+	GamePresenter[interfaces.MississippiStudGame]
+	// HintOutput ヒント情報を出力する
+	HintOutput(g interfaces.MississippiStudGame) string
+}

--- a/internal/usecase/presenter/MississippiStudPresenter_mock.go
+++ b/internal/usecase/presenter/MississippiStudPresenter_mock.go
@@ -5,4 +5,12 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // MockMississippiStudPresenter ミシシッピ・スタッドプレゼンターモック
-type MockMississippiStudPresenter = MockGamePresenter[interfaces.MississippiStudGame]
+type MockMississippiStudPresenter struct {
+	MockGamePresenter[interfaces.MississippiStudGame]
+}
+
+// HintOutput モック
+func (_m *MockMississippiStudPresenter) HintOutput(g interfaces.MississippiStudGame) string {
+	ret := _m.Called(g)
+	return ret.Get(0).(string)
+}


### PR DESCRIPTION
## 背景

`MississippiStudCuiPresenter` に `HintOutput` がなく、**CUI プレイヤーは 3rd/4th/5th street での 1x/3x/fold の判断材料を得られませんでした** (#4710)。

Web は `useGameHint` のヒントに加え、`evaluateMississippiStudMadeHand` の結果を `ms-made-hand` に**現在の役と配当対象か**としてリアルタイム表示しています。CUI にはどちらもありませんでした。

## 役名だけでは足りません

**2 のペアは「ワンペア」でも配当が付きません。**役だけ出すと、配当の付かない手で 3 倍を置かせます。

```
現在の役: ワンペア (配当なし)
推奨: フォールド
```

配当対象の判定はドメインの `mississippiStudPairTier`（既存の配当表ロジック）を通します。**エースのペアも対象**です（`value` が 1 なので「6以上」だけ見ると外れる）。

## 未公開のコミュニティカードは混ぜません

混ぜると、**プレイヤーがまだ見ていない札を根拠にした助言**になります。混ぜる実装にするとテストが4件落ちます。

## 3rd street だけはハイカード2枚でも賭けます

あと3枚めくれるのでまだ伸びます。**4th 以降で同じ手を賭けると、伸びない手に払い続ける**ことになります。判定はフロントの `getMississippiStudHint` と同じ規則（配当対象の役→3x、フラッシュ/ストレートのドローか 3rd のハイカード2枚→1x、それ以外→fold）。

## 負のコントロール

| 壊し方 | 落ちる件数 |
|---|---|
| 未公開の札も混ぜる | 4 |
| 低いペアも配当ありにする | 2 |
| 4th 以降もハイカードで賭ける | 2 |
| 1x と 3x を同じ文言にする | 2 |

## 検証

- `go test -tags test ./internal/...` ✅ / `golangci-lint run ./internal/...` → `0 issues.` ✅ / `gofmt -l internal/` 空 ✅
- `check-message-codes: OK (all 775 codes …)` ✅

Closes #4710