### PR TITLE
fix: render Blackjack Switch hint and stop mis-scoring the swap

### DIFF
--- a/frontend/src/pages/BlackJackSwitchPage.test.tsx
+++ b/frontend/src/pages/BlackJackSwitchPage.test.tsx
@@ -443,3 +443,19 @@ describe('BlackJackSwitchPage', () => {
     expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
   });
 });
+
+// **ヒントは前から算出されていたのに、ページが一度も読んでいなかった (#4708)。**
+// useGameHint に blackjackswitch の factory は登録済みで、結果を捨てていた。
+describe('BlackJackSwitchPage hint', () => {
+  it('shows a switch recommendation once hints are enabled', async () => {
+    mockApi.mockResolvedValue(switchState);
+    renderWithProviders(<BlackJackSwitchPage />);
+    await waitFor(() => expect(screen.getByTestId('card-area')).toBeInTheDocument());
+
+    // トグルを入れるまでは出さない。
+    expect(screen.queryByTestId('hint-tooltip')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText('ヒント表示'));
+    expect(screen.getByTestId('hint-tooltip')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/BlackJackSwitchPage.tsx
+++ b/frontend/src/pages/BlackJackSwitchPage.tsx
@@ -10,6 +10,7 @@ import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
+import { HintTooltip } from '../components/hint/HintTooltip';
 import { KbdBadge } from '../components/KbdBadge';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
@@ -19,6 +20,7 @@ import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
+import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useMountReset } from '../hooks/useMountReset';
 import { badgeErrorColors, badgeSuccessColors, badgeWarningColors } from '../styles/badgeStyles';
@@ -50,6 +52,9 @@ function BlackJackSwitchPageContent() {
   const [alwaysPreview, setAlwaysPreview] = useState(false);
   const { cardWidth } = useCardDimensions();
   const { state, loading, error, exec: execApi, retry } = useGameApi(blackjackswitchApi.exec);
+  // **ヒントは前から算出されていたが、ページが一度も読んでいなかった (#4708)。**
+  // useGameHint に blackjackswitch の factory は登録済みで、結果を捨てていた。
+  const { hint, hintEnabled, setHintEnabled } = useGameHint('blackjackswitch', state);
 
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('blackjackswitch');
   const cliConfig: CliGameConfig<BlackJackSwitchResponse, Parameters<typeof blackjackswitchApi.exec>> = useMemo(
@@ -158,6 +163,13 @@ function BlackJackSwitchPageContent() {
               messageCode={state.messageCode}
               messageParams={state.messageParams}
             />
+
+            <label className="flex items-center gap-1 text-ds-text-primary text-xs justify-center mb-2 cursor-pointer min-h-[44px]">
+              <input type="checkbox" checked={hintEnabled} onChange={(e) => setHintEnabled(e.target.checked)} />
+              {tc('hint.toggle', { ns: 'tutorial' })}
+            </label>
+
+            {hintEnabled && hint && <HintTooltip reason={t(hint.reason)} confidence={hint.confidence} />}
 
             {isBetPhase && <p className="text-ds-text-muted text-center text-sm py-3">{t('guide.bet')}</p>}
             {isSwitchPhase && <p className="text-ds-text-muted text-center text-sm py-2">{t('guide.switch')}</p>}

--- a/frontend/src/utils/hints/blackjackswitchHint.test.ts
+++ b/frontend/src/utils/hints/blackjackswitchHint.test.ts
@@ -110,3 +110,61 @@ describe('getBlackjackswitchHint', () => {
     expect(getBlackjackswitchHint(s)?.targetAction).toBe('hit');
   });
 });
+
+// **入れ替え後のスコアを引き算で作ってはいけない (#4708)。**エースは
+// 21 を超えると 11 → 1 に落ちるので、`score - 自分の2枚目 + 相手の2枚目`
+// は実際の点数と一致しない。判定は blackjackSwitchPreviewScores と同じ
+// 「手札を組み直して数え直す」やり方に揃える。
+describe('getBlackjackswitchHint — switch decision (sync: blackjackSwitchPreviewScores)', () => {
+  const switchState = (a: BlackJackSwitchHand, b: BlackJackSwitchHand): BlackJackSwitchResponse =>
+    base({ phase: BlackJackSwitchPhase.SWITCH, hands: [a, b] });
+
+  const handOf = (first: Card, second: Card, score: number): BlackJackSwitchHand =>
+    ({
+      cards: [first, second],
+      score,
+      bet: 10,
+      stood: false,
+      doubled: false,
+      busted: false,
+      isBJ: false,
+      result: 0,
+      payout: 0,
+    }) as BlackJackSwitchHand;
+
+  // ♠A ♥A (=12) と ♣9 ♦8 (=17)。2枚目を入れ替えると ♠A ♦8 (=19) と
+  // ♣9 ♥A (=20) で、**両手とも使える形になる**。
+  // 引き算で作ると 12 - 11 + 8 = 9 になり、この入れ替えを見逃す。
+  it('recommends switching a soft hand the subtraction shortcut would miss', () => {
+    const hint = getBlackjackswitchHint(
+      switchState(handOf(card('SPADE', 1), card('HEART', 1), 12), handOf(card('CLOVER', 9), card('DIAMOND', 8), 17)),
+    );
+    expect(hint?.targetAction).toBe('switch');
+  });
+
+  it('recommends keeping when the swap makes both hands worse', () => {
+    // ♠10 ♥9 (=19) と ♣10 ♦8 (=18)。入れ替えると 18 と 19 で改善しない。
+    const hint = getBlackjackswitchHint(
+      switchState(handOf(card('SPADE', 10), card('HEART', 9), 19), handOf(card('CLOVER', 10), card('DIAMOND', 8), 18)),
+    );
+    expect(hint?.targetAction).toBe('keep');
+  });
+
+  // ♠10 ♥10 (=20, 使える) と ♣7 ♦7 (=14, 使えない) → 入れ替えると 17 と 17 で
+  // **両手とも使える形になる**。使える手が 1 → 2 に増えるので入れ替える。
+  it('recommends switching when it turns one usable hand into two', () => {
+    const hint = getBlackjackswitchHint(
+      switchState(handOf(card('SPADE', 10), card('HEART', 10), 20), handOf(card('CLOVER', 7), card('DIAMOND', 7), 14)),
+    );
+    expect(hint?.targetAction).toBe('switch');
+  });
+
+  // **片方を強くして片方を潰す入れ替えは勧めない。**♠10 ♥2 (=12) と
+  // ♣9 ♦9 (=18) は入れ替えると 19 と 11 で、使える手の数は 1 のまま。
+  it('does not recommend a swap that just moves the problem', () => {
+    const hint = getBlackjackswitchHint(
+      switchState(handOf(card('SPADE', 10), card('HEART', 2), 12), handOf(card('CLOVER', 9), card('DIAMOND', 9), 18)),
+    );
+    expect(hint?.targetAction).toBe('keep');
+  });
+});

--- a/frontend/src/utils/hints/blackjackswitchHint.ts
+++ b/frontend/src/utils/hints/blackjackswitchHint.ts
@@ -1,6 +1,7 @@
 import type { BlackJackSwitchResponse } from '../../types/card';
 import type { HintResult } from '../../types/hint';
 import { BlackJackSwitchPhase } from '../../types/phases';
+import { blackjackSwitchPreviewScores } from '../blackjackSwitchPreview';
 
 /** ディーラーが 17 で止まる境目。ソフト 17 は引く (`BJSwitchDealerHitsSoft17`)。 */
 const DEALER_STANDS = 17;
@@ -74,26 +75,22 @@ function dealerUpcard(state: BlackJackSwitchResponse): number {
  *
  * 判定は素朴に「両手が 17 以上になる方を選ぶ」。片方を強くして片方を潰す入れ替えは
  * 合計では得しないので、**両手が使える形かどうか**で見る。
+ *
+ * **入れ替え後の点数は引き算で作らない。**エースは 21 を超えると 11 → 1 に
+ * 落ちるので、`score - 自分の2枚目 + 相手の2枚目` は実際の点数と一致しない
+ * (♠A ♥A は 12 で、♥A を 8 に替えれば 19 だが、引き算では 9 になる)。
+ * ページのホバープレビューと同じ blackjackSwitchPreviewScores に通して、
+ * 手札を組み直して数え直す (#4708)。
  */
 function switchImproves(state: BlackJackSwitchResponse): boolean {
   const [a, b] = state.hands;
   if (!a || !b) return false;
-  const now = usable(a.score) + usable(b.score);
-  // 2 枚目を入れ替えた後のスコアは (合計 - 自分の 2 枚目 + 相手の 2 枚目)。
-  const aSecond = cardValue(a.cards[1]);
-  const bSecond = cardValue(b.cards[1]);
-  const after = usable(a.score - aSecond + bSecond) + usable(b.score - bSecond + aSecond);
-  return after > now;
+  const after = blackjackSwitchPreviewScores(a.cards, b.cards);
+  if (after === null) return false;
+  return usable(after.a) + usable(after.b) > usable(a.score) + usable(b.score);
 }
 
 /** 17 以上 21 以下なら 1、それ以外は 0。 */
 function usable(score: number): number {
   return score >= DEALER_STANDS && score <= 21 ? 1 : 0;
-}
-
-/** 札の値。A は 11、絵札は 10。null は 0。 */
-function cardValue(c: { value: number } | null | undefined): number {
-  if (!c) return 0;
-  if (c.value === 1) return 11;
-  return Math.min(c.value, 10);
 }


### PR DESCRIPTION
## issue の前提は半分だけ正しい

issue は「`getBlackjackSwitchHint` を frontend に追加する」と提案していますが、**`getBlackjackswitchHint` はすでに存在し、`useGameHint` にも登録済み**でした。

問題は `BlackJackSwitchPage.tsx` が **`useGameHint` を一度も呼んでいない**ことです。ヒントは毎回計算されて、そのまま捨てられていました。トグルと `HintTooltip` を足して表示します。

## 入れ替え後の点数を引き算で作っていたのはバグです

```ts
const after = usable(a.score - aSecond + bSecond) + usable(b.score - bSecond + aSecond);
```

**エースは 21 を超えると 11 → 1 に落ちます。**♠A ♥A は 12 で、♥A を 8 に替えれば **19** になりますが、この式では `12 - 11 + 8 = 9`。**最も価値のある入れ替えを「keep」と言っていました。**

ページのホバープレビューと同じ `blackjackSwitchPreviewScores`（手札を組み直して数え直す）に通します。issue の受け入れ条件「推奨ロジックが `blackjackSwitchPreviewScores` の結果と整合する」は、**同じ関数を使うことで構造的に**満たします。ホバープレビュー自体には手を入れていません。

## テストの誤りも1つ直しました

当初「2つのスティフが両方スタンドできる形になる」ケースとして ♠10 ♥2 (12) と ♣9 ♦9 (18) を書きましたが、入れ替えても 19 と 11 で**使える手の数は 1 のまま**でした。実装ではなくテストの期待値が誤りだったので、♠10 ♥10 (20) と ♣7 ♦7 (14) → 17 と 17 という本当に改善するケースに差し替え、「片方を強くして片方を潰す入れ替えは勧めない」を別のテストとして残しています。

## 負のコントロール

| 壊し方 | 落ちる件数 |
|---|---|
| 引き算に戻す（旧バグ） | 1 |
| ページが `HintTooltip` を出さない | 1 |

## 検証

- `bunx vitest run` (hint 15 + page 32) 全通過 ✅
- `bun run typecheck` ✅ / `bun run check` exit 0 ✅

Closes #4708