### PR TITLE
fix: read the low side of Seven Card Stud Hi-Lo in the CUI hint

### DIFF
--- a/internal/adapter/presenter/SevenCardStudCuiPresenter.go
+++ b/internal/adapter/presenter/SevenCardStudCuiPresenter.go
@@ -331,6 +331,9 @@ func (p *SevenCardStudCuiPresenter) HintOutput(s interfaces.SevenCardStudGame) s
 	if s.GetIsLowball() {
 		return razzHintOutput(s)
 	}
+	if s.GetIsHiLo() {
+		return sevenCardStudHiLoHintOutput(s)
+	}
 	if s.GetPhase() != domain.SevenCardStudPhaseThirdStreet {
 		return i18n.T("sevencardstud.hintNone") + "\n"
 	}
@@ -345,6 +348,78 @@ func (p *SevenCardStudCuiPresenter) HintOutput(s interfaces.SevenCardStudGame) s
 	}
 	return color.Yellow(i18n.Tf("sevencardstud.hint",
 		"action", action, "reason", i18n.T(reasonKey))) + "\n"
+}
+
+// sevenCardStudLowQualifier は Hi-Lo でローに数える上限 (8 or Better)。
+const sevenCardStudLowQualifier = 8
+
+// sevenCardStudLowCardsNeeded はロー成立に必要な枚数。
+const sevenCardStudLowCardsNeeded = 5
+
+// sevenCardStudHiLoHintOutput は Hi-Lo (8 or Better) 向けのヒント行を返す。
+//
+// **ハイ専用の基本戦略をそのまま当てない (#4704)。**Hi-Lo はポットの半分が
+// ローに行くので、ハイとしては弱くてもロー札がそろっていれば続ける価値がある。
+// ハイ用の判定 (ペア/3フラッシュ/3ストレート/3ハイカード) だけで見ると、
+// 勝ち目のある手を降ろすことになる。
+//
+// **ハイと違って全ストリートで出す。**ロー札は5枚必要なので、3枚しか無い
+// 3rd street ではロー分岐に永遠に届かない。フロントの getSevenCardStudHint も
+// 全ベッティングストリートで判定している。
+func sevenCardStudHiLoHintOutput(s interfaces.SevenCardStudGame) string {
+	if !razzBettingPhases[s.GetPhase()] {
+		return i18n.T("sevencardstud.hintNone") + "\n"
+	}
+	player := s.GetPlayer(s.GetCurrentTurn())
+	if player == nil || player.GetFolded() || len(player.GetAllCards()) == 0 {
+		return i18n.T("sevencardstud.hintNone") + "\n"
+	}
+	cards := player.GetAllCards()
+	action, reasonKey := i18n.T("sevencardstud.hintFold"), "sevencardstud.hintReasonFold"
+	switch {
+	case sevenCardStudHasPair(cards):
+		action, reasonKey = i18n.T("sevencardstud.hintContinue"), "sevencardstud.hintReasonPair"
+	case sevenCardStudLowCards(cards) >= sevenCardStudLowCardsNeeded:
+		action, reasonKey = i18n.T("sevencardstud.hintContinue"), "sevencardstud.hintReasonHiLoLow"
+	case sevenCardStudHasHighCard(cards):
+		action, reasonKey = i18n.T("sevencardstud.hintContinue"), "sevencardstud.hintReasonHigh"
+	}
+	return color.Yellow(i18n.Tf("sevencardstud.hint",
+		"action", action, "reason", i18n.T(reasonKey))) + "\n"
+}
+
+// sevenCardStudHasPair は同じランクが2枚以上あるかを返す。
+func sevenCardStudHasPair(cards []*domain.Card) bool {
+	seen := map[int]bool{}
+	for _, c := range cards {
+		if seen[c.GetValue()] {
+			return true
+		}
+		seen[c.GetValue()] = true
+	}
+	return false
+}
+
+// sevenCardStudLowCards は8以下の札の枚数を返す。**エースはローの最強札**
+// なので 1 のまま数えて問題ない。
+func sevenCardStudLowCards(cards []*domain.Card) int {
+	n := 0
+	for _, c := range cards {
+		if c.GetValue() <= sevenCardStudLowQualifier {
+			n++
+		}
+	}
+	return n
+}
+
+// sevenCardStudHasHighCard は 10 以上またはエースを持っているかを返す。
+func sevenCardStudHasHighCard(cards []*domain.Card) bool {
+	for _, c := range cards {
+		if v := c.GetValue(); v == 1 || v >= 10 {
+			return true
+		}
+	}
+	return false
 }
 
 // razzHintOutput はラズ (Lowball) 向けのヒント行を返す。

--- a/internal/adapter/presenter/SevenCardStudCuiPresenter_test.go
+++ b/internal/adapter/presenter/SevenCardStudCuiPresenter_test.go
@@ -676,6 +676,62 @@ func TestSevenCardStudCuiPresenter_HintOutput(t *testing.T) {
 		assert.NotContains(t, p.HintOutput(s), i18n.T("sevencardstud.hintNone"))
 	})
 
+	// **Hi-Lo にハイ専用の基本戦略をそのまま当てていた (#4704)。**ポットの
+	// 半分がローに行くので、ハイとして弱くてもロー札がそろっていれば続ける
+	// 価値がある。
+	newHiLo := func(cards ...*domain.Card) *domain.SevenCardStud {
+		players := []*domain.SevenCardStudPlayer{
+			domain.NewSevenCardStudPlayer(true, domain.HoldemStyleTAG),
+			domain.NewSevenCardStudPlayer(false, domain.HoldemStyleLAP),
+		}
+		s := domain.NewSevenCardStudHiLo(domain.NewTrumpCards(0), players, domain.DefaultSevenCardStudConfig())
+		s.SetPhase(domain.SevenCardStudPhaseFifthStreet)
+		s.SetCurrentTurn(0)
+		for i, c := range cards {
+			if i < 2 {
+				players[0].AddHoleCard(c)
+			} else {
+				players[0].AddDoorCard(c)
+			}
+		}
+		return s
+	}
+
+	t.Run("Hi-Lo keeps going on five low cards a high-only read would fold", func(t *testing.T) {
+		// 2 3 4 6 8: ハイとしてはハイカードすら無い (ハイ専用判定なら降りる)。
+		out := p.HintOutput(newHiLo(
+			card(domain.CardDesignSpade, 2), card(domain.CardDesignHeart, 3),
+			card(domain.CardDesignClover, 4), card(domain.CardDesignDiamond, 6),
+			card(domain.CardDesignSpade, 8)))
+		assert.Contains(t, out, i18n.T("sevencardstud.hintContinue"))
+		assert.Contains(t, out, i18n.T("sevencardstud.hintReasonHiLoLow"))
+	})
+
+	// **ロー札が4枚では足りない。**5枚そろって初めてローが成立する。
+	t.Run("Hi-Lo does not claim a low on four low cards", func(t *testing.T) {
+		out := p.HintOutput(newHiLo(
+			card(domain.CardDesignSpade, 2), card(domain.CardDesignHeart, 3),
+			card(domain.CardDesignClover, 4), card(domain.CardDesignDiamond, 6),
+			card(domain.CardDesignSpade, 9)))
+		assert.NotContains(t, out, i18n.T("sevencardstud.hintReasonHiLoLow"))
+	})
+
+	t.Run("Hi-Lo still leads with a pair", func(t *testing.T) {
+		out := p.HintOutput(newHiLo(
+			card(domain.CardDesignSpade, 7), card(domain.CardDesignHeart, 7),
+			card(domain.CardDesignClover, 4), card(domain.CardDesignDiamond, 6),
+			card(domain.CardDesignSpade, 8)))
+		assert.Contains(t, out, i18n.T("sevencardstud.hintReasonPair"))
+	})
+
+	t.Run("Hi-Lo folds a hand with neither a low nor a high card", func(t *testing.T) {
+		out := p.HintOutput(newHiLo(
+			card(domain.CardDesignSpade, 2), card(domain.CardDesignHeart, 4),
+			card(domain.CardDesignClover, 6), card(domain.CardDesignDiamond, 9),
+			card(domain.CardDesignSpade, 3)))
+		assert.Contains(t, out, i18n.T("sevencardstud.hintFold"))
+	})
+
 	t.Run("Razz gives no hint at showdown", func(t *testing.T) {
 		s := newRazz(
 			card(domain.CardDesignSpade, 1), card(domain.CardDesignHeart, 3),

--- a/internal/i18n/locales/en/sevencardstud.json
+++ b/internal/i18n/locales/en/sevencardstud.json
@@ -74,5 +74,6 @@
   "hintReasonRazzPair": "you have a pair, which is weak for a low hand",
   "hintReasonRazzStrong": "you have plenty of low cards",
   "hintReasonRazzDecent": "you have a fair number of low cards",
-  "hintReasonRazzWeak": "you do not have enough low cards"
+  "hintReasonRazzWeak": "you do not have enough low cards",
+  "hintReasonHiLoLow": "a qualifying low is live (five cards of eight or lower)"
 }

--- a/internal/i18n/locales/ja/sevencardstud.json
+++ b/internal/i18n/locales/ja/sevencardstud.json
@@ -74,5 +74,6 @@
   "hintReasonRazzPair": "ペアがあり、ローとしては弱い",
   "hintReasonRazzStrong": "ロー札が十分そろっている",
   "hintReasonRazzDecent": "ロー札はそこそこある",
-  "hintReasonRazzWeak": "ロー札が足りない"
+  "hintReasonRazzWeak": "ロー札が足りない",
+  "hintReasonHiLoLow": "ロー役が狙える (8以下が5枚)"
 }


### PR DESCRIPTION
## 背景

`SevenCardStudCuiPresenter.HintOutput` は `GetIsLowball()` しか見ておらず、`GetIsHiLo()` を一度も参照していませんでした。**Hi-Lo でもハイ専用の基本戦略**（ペア / 3フラッシュ / 3ストレート / 3ハイカード）がそのまま当たります (#4704)。

ポットの半分がローに行くのに、ロー方向を一切見ない助言になっていました。

## ハイとして弱くてもローが成立していれば続けます

2-3-4-6-8 は**ハイカードすら無い**のでハイ専用判定なら降ります。しかしローは成立しているので、Web の `getSevenCardStudHint` は「続ける」と助言します。

規則はフロントに合わせました。

| 手札 | 助言 |
|---|---|
| ペアあり | 続行 |
| 8以下が**5枚** | 続行（ロー狙い） |
| ハイカード（10以上 or A） | 続行 |
| それ以外 | 降り |

## 全ベッティングストリートで出します

**ロー札は5枚必要**なので、3枚しか無い 3rd street ではロー分岐に永遠に届きません。ハイの助言は 3rd street だけですが、Hi-Lo はフロント同様5つのストリート全部で判定します。

## 負のコントロール

| 壊し方 | 落ちる件数 |
|---|---|
| Hi-Lo を分岐しない（元の挙動） | 4 |
| ロー方向を見ない | 2 |
| ロー成立を4枚にする | 3 |
| ロー札の上限を9にする | 3 |

## 検証

- `go test -tags test ./internal/...` ✅ / `golangci-lint run ./internal/...` → `0 issues.` ✅ / `gofmt -l internal/` 空 ✅
- `check-message-codes: OK (all 775 codes …)` ✅

Closes #4704