### PR TITLE
feat: show the Forty-Fives contract progress during play

### DIFF
--- a/internal/adapter/presenter/FortyFivesCuiPresenter.go
+++ b/internal/adapter/presenter/FortyFivesCuiPresenter.go
@@ -151,6 +151,10 @@ func (p *FortyFivesCuiPresenter) writePrompt(b *strings.Builder, g interfaces.Fo
 			"bids", strings.Join(entries, ", ")) + "\n")
 		b.WriteString(i18n.T("fortyfives.promptBidHelp") + "\n")
 	case domain.FortyFivesPhasePlay:
+		// **契約の進捗はラウンドが終わるまで一切出ていなかった (#4724)。**
+		// Web は ff-contract-progress に「あと何点必要か」を常時出している。
+		// 落札チームが何点必要かは、降りるか押すかの判断そのもの。
+		writeFortyFivesContractProgress(b, g)
 		currentIdx := g.GetCurrentPlayerIdx()
 		b.WriteString(i18n.Tf("fortyfives.promptPlay",
 			"name", cuiPlayerName(g.GetPlayer(currentIdx), currentIdx)) + "\n")
@@ -162,6 +166,35 @@ func (p *FortyFivesCuiPresenter) writePrompt(b *strings.Builder, g interfaces.Fo
 		b.WriteString(i18n.T("fortyfives.promptRoundEnd") + "\n")
 		b.WriteString(i18n.T("fortyfives.promptRoundEndHelp") + "\n")
 	}
+}
+
+// fortyFivesContractStatusKeys は進捗ステータスから i18n キーへの対応。
+var fortyFivesContractStatusKeys = map[string]string{
+	domain.FortyFivesContractMade:     "fortyfives.contractMade",
+	domain.FortyFivesContractFailed:   "fortyfives.contractFailed",
+	domain.FortyFivesContractNeedMore: "fortyfives.contractNeedMore",
+}
+
+// writeFortyFivesContractProgress は落札チームの契約進捗を1行で書く。
+// 落札が決まっていなければ何も書かない。
+func writeFortyFivesContractProgress(b *strings.Builder, g interfaces.FortyFivesGame) {
+	pr := g.GetContractProgress()
+	if pr == nil {
+		return
+	}
+	key, ok := fortyFivesContractStatusKeys[pr.Status]
+	if !ok {
+		return
+	}
+	team := i18n.T("fortyfives.teamA")
+	if pr.DeclarerTeam == 1 {
+		team = i18n.T("fortyfives.teamB")
+	}
+	b.WriteString(i18n.Tf("fortyfives.contractProgress",
+		"team", team,
+		"got", strconv.Itoa(pr.Points),
+		"contract", strconv.Itoa(pr.Contract),
+		"status", i18n.Tf(key, "remaining", strconv.Itoa(pr.Remaining))) + "\n")
 }
 
 // HintOutput emits the current Forty-Fives hint.

--- a/internal/adapter/presenter/FortyFivesCuiPresenter_test.go
+++ b/internal/adapter/presenter/FortyFivesCuiPresenter_test.go
@@ -33,6 +33,7 @@ func setupFortyFivesCuiMock() *interfaces.MockFortyFivesGame {
 	m.On("GetCurrentTrick").Return(([]*domain.TrickCard)(nil))
 	m.On("GetGameEndFlag").Return(false)
 	m.On("GetPhase").Return(domain.FortyFivesPhasePlay)
+	m.On("GetContractProgress").Return((*domain.FortyFivesContractProgress)(nil)).Maybe()
 	m.On("GetCurrentPlayerIdx").Return(0)
 	m.On("GetDeclarerIdx").Return(0)
 	m.On("GetContract").Return(domain.FortyFivesBidTwenty)
@@ -154,4 +155,49 @@ func TestFortyFivesCuiPresenter_ActionLogOutput(t *testing.T) {
 	})
 	result := p.ActionLogOutput(m)
 	assert.Contains(t, result, "play")
+}
+
+// **契約の進捗がラウンド終了まで一切出ていなかった (#4724)。**落札チームが
+// あと何点必要かは、押すか降りるかの判断そのもの。
+func TestFortyFivesCuiPresenter_ContractProgress(t *testing.T) {
+	p := new(presenter.FortyFivesCuiPresenter)
+	withProgress := func(pr *domain.FortyFivesContractProgress) *interfaces.MockFortyFivesGame {
+		m, _ := setupFortyFivesCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetContractProgress")
+		m.On("GetContractProgress").Return(pr)
+		return m
+	}
+
+	t.Run("shows the points the declaring team still needs", func(t *testing.T) {
+		out := p.Output(withProgress(&domain.FortyFivesContractProgress{
+			DeclarerTeam: 0, Points: 5, Contract: 20, Remaining: 15,
+			Status: domain.FortyFivesContractNeedMore,
+		}), nil)
+		assert.Contains(t, out, "5/20")
+		assert.Contains(t, out, "あと15点")
+	})
+
+	t.Run("says when the contract is already made", func(t *testing.T) {
+		out := p.Output(withProgress(&domain.FortyFivesContractProgress{
+			DeclarerTeam: 1, Points: 25, Contract: 20,
+			Status: domain.FortyFivesContractMade,
+		}), nil)
+		assert.Contains(t, out, "成立")
+		assert.Contains(t, out, "チームB")
+	})
+
+	// **「もう届かない」と「あと何点」は別の話。**同じ文言だと、投げるべき
+	// ラウンドと押すべきラウンドの区別が付かない。
+	t.Run("says when the contract can no longer be made", func(t *testing.T) {
+		out := p.Output(withProgress(&domain.FortyFivesContractProgress{
+			DeclarerTeam: 0, Points: 5, Contract: 25, Remaining: 20,
+			Status: domain.FortyFivesContractFailed,
+		}), nil)
+		assert.Contains(t, out, "不成立")
+		assert.NotContains(t, out, "あと20点")
+	})
+
+	t.Run("shows nothing before the bid is settled", func(t *testing.T) {
+		assert.NotContains(t, p.Output(withProgress(nil), nil), "契約:")
+	})
 }

--- a/internal/domain/FortyFives.go
+++ b/internal/domain/FortyFives.go
@@ -839,6 +839,74 @@ func (g *FortyFives) GetTeamScores() [FortyFivesTeamCnt]int { return g.teamScore
 // SetTeamScores チーム別累積点設定 (テスト用)
 func (g *FortyFives) SetTeamScores(s [FortyFivesTeamCnt]int) { g.teamScores = s }
 
+// 契約の進捗 (#4724)。
+const (
+	// FortyFivesContractMade 契約成立 (すでに必要点に届いている)。
+	FortyFivesContractMade = "made"
+	// FortyFivesContractFailed 契約不成立が確定 (残りトリックを全部取っても届かない)。
+	FortyFivesContractFailed = "failed"
+	// FortyFivesContractNeedMore まだ足りないが、届く可能性が残っている。
+	FortyFivesContractNeedMore = "needMore"
+)
+
+// FortyFivesContractProgress は落札チームの契約達成見込み。
+type FortyFivesContractProgress struct {
+	// DeclarerTeam は落札チーム (0 or 1)。
+	DeclarerTeam int
+	// Points は落札チームの現在の得点。
+	Points int
+	// Contract は達成すべき点数。
+	Contract int
+	// Remaining はあと何点必要か (成立済みなら 0)。
+	Remaining int
+	// Status は FortyFivesContract* のいずれか。
+	Status string
+}
+
+// GetContractProgress は落札チームが契約に届くかどうかを返す。落札が
+// 決まっていない、または契約が無いときは nil。
+//
+// **CUI はラウンドが終わるまで契約の進捗を一切出していなかった (#4724)。**
+// Web は ff-contract-progress に「あと何点必要か」を色分きで常時出している。
+//
+// 「もう届かない」は**残りトリックを全部取っても足りない**ときに確定する。
+// 得点の合計から消化済みトリック数が分かるので、残りは
+// (全トリック - 消化済み) × 1トリックの点。
+func (g *FortyFives) GetContractProgress() *FortyFivesContractProgress {
+	if g.declarerIdx < 0 || g.contract <= 0 {
+		return nil
+	}
+	team := g.declarerIdx % FortyFivesTeamCnt
+	points := g.roundTeamPts[team]
+	contract := int(g.contract)
+
+	resolved := 0
+	for _, p := range g.roundTeamPts {
+		resolved += p
+	}
+	remainingTricks := FortyFivesTrickCount - resolved/FortyFivesPointsPerTrick
+	if remainingTricks < 0 {
+		remainingTricks = 0
+	}
+	available := remainingTricks * FortyFivesPointsPerTrick
+
+	status := FortyFivesContractNeedMore
+	switch {
+	case points >= contract:
+		status = FortyFivesContractMade
+	case points+available < contract:
+		status = FortyFivesContractFailed
+	}
+	remaining := contract - points
+	if remaining < 0 {
+		remaining = 0
+	}
+	return &FortyFivesContractProgress{
+		DeclarerTeam: team, Points: points, Contract: contract,
+		Remaining: remaining, Status: status,
+	}
+}
+
 // GetRoundTeamPoints 現ラウンドのチーム別得点取得
 func (g *FortyFives) GetRoundTeamPoints() [FortyFivesTeamCnt]int { return g.roundTeamPts }
 

--- a/internal/domain/FortyFives_test.go
+++ b/internal/domain/FortyFives_test.go
@@ -5,6 +5,8 @@ package domain
 import (
 	"encoding/json"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func ffCard(design, value int) *Card { return NewCard(design, value, false) }
@@ -312,4 +314,70 @@ func TestFortyFives_UnmarshalErrors(t *testing.T) {
 	if err := g.UnmarshalJSON([]byte(`{"ps":[null,null,null,null]}`)); err == nil {
 		t.Error("expected nil-player error")
 	}
+}
+
+// **CUI はラウンドが終わるまで契約の進捗を一切出していなかった (#4724)。**
+// Web は ff-contract-progress に「あと何点必要か」を色分きで常時出している。
+func TestFortyFives_GetContractProgress(t *testing.T) {
+	newGame := func(declarerIdx int, contract FortyFivesBid, pts [FortyFivesTeamCnt]int) *FortyFives {
+		g := NewDefaultFortyFives()
+		g.SetDeclarerIdx(declarerIdx)
+		g.SetContract(contract)
+		g.SetRoundTeamPoints(pts)
+		return g
+	}
+
+	t.Run("nothing to report before the bid is settled", func(t *testing.T) {
+		assert.Nil(t, newGame(-1, FortyFivesBidTwenty, [FortyFivesTeamCnt]int{0, 0}).GetContractProgress())
+	})
+
+	t.Run("nothing to report without a contract", func(t *testing.T) {
+		assert.Nil(t, newGame(0, FortyFivesBidPass, [FortyFivesTeamCnt]int{0, 0}).GetContractProgress())
+	})
+
+	// 落札者インデックスからチームを割り出す (0/2 = チームA、1/3 = チームB)。
+	t.Run("reads the declaring team from the declarer seat", func(t *testing.T) {
+		pr := newGame(3, FortyFivesBidTwenty, [FortyFivesTeamCnt]int{5, 10}).GetContractProgress()
+		if assert.NotNil(t, pr) {
+			assert.Equal(t, 1, pr.DeclarerTeam)
+			assert.Equal(t, 10, pr.Points, "チームBの得点を見ていること")
+		}
+	})
+
+	t.Run("counts down the points still needed", func(t *testing.T) {
+		pr := newGame(0, FortyFivesBidTwenty, [FortyFivesTeamCnt]int{5, 0}).GetContractProgress()
+		if assert.NotNil(t, pr) {
+			assert.Equal(t, FortyFivesContractNeedMore, pr.Status)
+			assert.Equal(t, 15, pr.Remaining)
+		}
+	})
+
+	// 契約を**超えて**取ったときにマイナスを出さないこと。ちょうどの 20/20 では
+	// 引き算がそのまま 0 になるので、この枝を踏まない。
+	t.Run("reports the contract as made once the points are there", func(t *testing.T) {
+		pr := newGame(0, FortyFivesBidTwenty, [FortyFivesTeamCnt]int{25, 5}).GetContractProgress()
+		if assert.NotNil(t, pr) {
+			assert.Equal(t, FortyFivesContractMade, pr.Status)
+			assert.Equal(t, 0, pr.Remaining, "成立後にマイナスを出さない")
+		}
+	})
+
+	// **「もう届かない」は残りトリックを全部取っても足りないときだけ。**
+	// 早すぎる「不成立」は、まだ勝てるラウンドを投げさせる。
+	t.Run("declares failure only when even every remaining trick falls short", func(t *testing.T) {
+		// 4トリック消化 (合計20点)、残り1トリック=5点。契約25点に対し5点では届かない。
+		failed := newGame(0, FortyFivesBidTwentyFive, [FortyFivesTeamCnt]int{5, 15}).GetContractProgress()
+		if assert.NotNil(t, failed) {
+			assert.Equal(t, FortyFivesContractFailed, failed.Status)
+		}
+
+		// 2トリック消化 (合計10点)、残り3トリック=15点。5+15=20 で 25 には届かない…
+		// ように見えるが、相手の点も含めた残りは 15 なので届かない。
+		// 1トリックだけ消化なら残り20点あり、5+20=25 でちょうど届く。
+		alive := newGame(0, FortyFivesBidTwentyFive, [FortyFivesTeamCnt]int{5, 0}).GetContractProgress()
+		if assert.NotNil(t, alive) {
+			assert.Equal(t, FortyFivesContractNeedMore, alive.Status,
+				"ちょうど届く見込みがあるうちは不成立にしない")
+		}
+	})
 }

--- a/internal/domain/interfaces/fortyfives.go
+++ b/internal/domain/interfaces/fortyfives.go
@@ -63,6 +63,8 @@ type FortyFivesGame interface {
 	GetTrumpSuit() int
 	// GetTeamScores チーム別累積点を取得する
 	GetTeamScores() [domain.FortyFivesTeamCnt]int
+	// GetContractProgress 落札チームの契約達成見込みを取得する
+	GetContractProgress() *domain.FortyFivesContractProgress
 	// GetRoundTeamPoints 現ラウンドのチーム別得点を取得する
 	GetRoundTeamPoints() [domain.FortyFivesTeamCnt]int
 	// GetWinnerTeam 勝利チームを取得する (-1=未確定)

--- a/internal/domain/interfaces/fortyfives_mock.go
+++ b/internal/domain/interfaces/fortyfives_mock.go
@@ -176,6 +176,14 @@ func (_m *MockFortyFivesGame) GetRoundTeamPoints() [domain.FortyFivesTeamCnt]int
 	return ret.Get(0).([domain.FortyFivesTeamCnt]int)
 }
 
+func (_m *MockFortyFivesGame) GetContractProgress() *domain.FortyFivesContractProgress {
+	args := _m.Called()
+	if args.Get(0) == nil {
+		return nil
+	}
+	return args.Get(0).(*domain.FortyFivesContractProgress)
+}
+
 // GetWinnerTeam モック
 func (_m *MockFortyFivesGame) GetWinnerTeam() int {
 	ret := _m.Called()

--- a/internal/i18n/locales/en/fortyfives.json
+++ b/internal/i18n/locales/en/fortyfives.json
@@ -38,5 +38,11 @@
   "roundEnd": "Round complete",
   "result.humanWin": "Game over! Your team wins!",
   "result.cpuWin": "Game over! Team {{team}} wins!",
-  "bidHistory": "Bids: {{bids}}"
+  "bidHistory": "Bids: {{bids}}",
+  "teamA": "Team A",
+  "teamB": "Team B",
+  "contractProgress": "Contract: {{team}} {{got}}/{{contract}} points - {{status}}",
+  "contractMade": "made",
+  "contractFailed": "can no longer be made",
+  "contractNeedMore": "{{remaining}} more needed"
 }

--- a/internal/i18n/locales/ja/fortyfives.json
+++ b/internal/i18n/locales/ja/fortyfives.json
@@ -38,5 +38,11 @@
   "roundEnd": "ラウンド終了",
   "result.humanWin": "ゲーム終了！ あなたのチームの勝ち！",
   "result.cpuWin": "ゲーム終了！ チーム{{team}}の勝ち！",
-  "bidHistory": "ビッド状況: {{bids}}"
+  "bidHistory": "ビッド状況: {{bids}}",
+  "teamA": "チームA",
+  "teamB": "チームB",
+  "contractProgress": "契約: {{team}} {{got}}/{{contract}} 点 — {{status}}",
+  "contractMade": "成立",
+  "contractFailed": "不成立が確定",
+  "contractNeedMore": "あと{{remaining}}点"
 }


### PR DESCRIPTION
## 背景

`FortyFivesPage.tsx` は `ff-contract-progress` に「**落札チームが契約にあと何点必要か**」を色分き（成立=緑 / 不成立=赤 / 途中=黄）で常時表示します。

計算に必要な `GetContract()` と `GetRoundTeamPoints()` はどちらも `interfaces/fortyfives.go` にあるのに、**`FortyFivesCuiPresenter` はどちらも一度も呼んでいませんでした** (#4724)。CUI プレイヤーは契約が成立しそうかをラウンド終了まで知る術がありません。

```
契約: チームA 5/20 点 — あと15点
```

## 「もう届かない」は残りトリックを全部取っても足りないときだけです

得点の合計から消化済みトリック数が分かるので、残りは `(全トリック − 消化済み) × 5点`。

**早すぎる不成立判定は、まだ勝てるラウンドを投げさせます。**残りトリックを数えない実装にするとテストが3件落ちます。

## 契約を超えて取ったとき「あと-5点」と出しません

当初この負のコントロールは 0件でした。テストが `20/20` ちょうどで、**引き算がそのまま 0 になってクランプの枝を踏んでいなかった**ためです。`25/20` に変えて踏むようにしました。

## 負のコントロール

| 壊し方 | 落ちる件数 |
|---|---|
| 残りトリックを数えない（早すぎる不成立） | 3 |
| 落札チームを常に A にする | 2 |
| 成立後にマイナスを出す | 2 |
| presenter が行を出さない | 4 |

## 検証

- `go test -tags test ./internal/...` ✅ / `golangci-lint run ./internal/...` → `0 issues.` ✅ / `gofmt -l internal/` 空 ✅
- `check-message-codes: OK (all 775 codes …)` ✅

Closes #4724