### PR TITLE
feat: suggest a Chinese Poker arrangement and warn about fouls in the CUI

### DIFF
--- a/internal/adapter/controller/ChinesePokerCuiController.go
+++ b/internal/adapter/controller/ChinesePokerCuiController.go
@@ -25,7 +25,7 @@ func (cc *ChinesePokerCuiController) Exec(command string) string {
 	return execCuiCommand(
 		command,
 		func(_ []string) string { return cc.ci.Reset() },
-		[]string{"b", "bet", "s", "set", "log", "l"},
+		[]string{"b", "bet", "s", "set", "h", "hint", "log", "l"},
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "b", "bet":
@@ -55,6 +55,8 @@ func (cc *ChinesePokerCuiController) Exec(command string) string {
 					middleIndices[i] = v
 				}
 				return cc.ci.SetHands(frontIndices, middleIndices), true
+			case "h", "hint":
+				return cc.ci.Hint(), true
 			default:
 				return handleCuiLog(cmd, cc.ci.ActionLog)
 			}

--- a/internal/adapter/controller/ChinesePokerCuiController_test.go
+++ b/internal/adapter/controller/ChinesePokerCuiController_test.go
@@ -76,3 +76,24 @@ func TestChinesePokerCuiController_Exec_Quit(t *testing.T) {
 	result := cc.Exec("q")
 	assert.NotEmpty(t, result)
 }
+
+// **CUI は13枚を自力で 3/5/5 に分けるしかなく、ファウルしても無警告だった
+// (#4717)。**
+func TestChinesePokerCuiController_Exec_Hint(t *testing.T) {
+	mock := new(mockusecase.MockChinesePokerInteractor)
+	mock.On("Hint").Return("hint ok")
+	cc := NewChinesePokerCuiController(mock)
+
+	assert.Equal(t, "hint ok", cc.Exec("h"))
+	assert.Equal(t, "hint ok", cc.Exec("hint"))
+}
+
+// **既存コマンドは何も変わらない。**
+func TestChinesePokerCuiController_Exec_HintDoesNotShadowSet(t *testing.T) {
+	mock := new(mockusecase.MockChinesePokerInteractor)
+	mock.On("Bet", 100).Return("bet ok")
+	cc := NewChinesePokerCuiController(mock)
+
+	assert.Equal(t, "bet ok", cc.Exec("b 100"))
+	mock.AssertNotCalled(t, "Hint")
+}

--- a/internal/adapter/controller/usecase/ChinesePokerInteractor_mock.go
+++ b/internal/adapter/controller/usecase/ChinesePokerInteractor_mock.go
@@ -33,6 +33,11 @@ func (m *MockChinesePokerInteractor) ActionLog() string {
 	return args.String(0)
 }
 
+func (m *MockChinesePokerInteractor) Hint() string {
+	args := m.Called()
+	return args.String(0)
+}
+
 // Snapshot スナップショット
 func (m *MockChinesePokerInteractor) Snapshot() ([]byte, error) {
 	ret := m.Called()

--- a/internal/adapter/presenter/ChinesePokerCuiPresenter.go
+++ b/internal/adapter/presenter/ChinesePokerCuiPresenter.go
@@ -120,6 +120,39 @@ func (pp *ChinesePokerCuiPresenter) Output(cp interfaces.ChinesePokerGame, lastE
 	return sb.String()
 }
 
+// HintOutput は13枚の推奨分割とファウル警告を出力する (#4717)。
+//
+// **Web にはファウル警告 (cp-foul-warning) も列プレビューもあるのに、CUI は
+// 13枚を自力で 3/5/5 に分けるしかなく、ファウルしても無警告だった。**
+func (cp *ChinesePokerCuiPresenter) HintOutput(g interfaces.ChinesePokerGame) string {
+	arr := g.GetSuggestedArrangement()
+	if arr == nil {
+		return i18n.T("chinesepoker.hintNone") + "\n"
+	}
+	cards := g.GetPlayerCards()
+	row := func(indices []int) string {
+		parts := make([]string, 0, len(indices))
+		for _, i := range indices {
+			if i < 0 || i >= len(cards) {
+				continue
+			}
+			parts = append(parts, "["+strconv.Itoa(i)+"]"+cuiCardStr(cards[i]))
+		}
+		return strings.Join(parts, " ")
+	}
+	var b strings.Builder
+	b.WriteString(i18n.Tf("chinesepoker.hintRowFront", "cards", row(arr.Front)) + "\n")
+	b.WriteString(i18n.Tf("chinesepoker.hintRowMiddle", "cards", row(arr.Middle)) + "\n")
+	b.WriteString(i18n.Tf("chinesepoker.hintRowBack", "cards", row(arr.Back)) + "\n")
+	// **ランク順に切るだけでは合法とは限らない。**そのまま置かせない。
+	if arr.Foul {
+		b.WriteString(color.BoldYellow(i18n.T("chinesepoker.hintFoulRisk")) + "\n")
+	} else {
+		b.WriteString(color.Yellow(i18n.T("chinesepoker.hintSplitOk")) + "\n")
+	}
+	return b.String()
+}
+
 // ActionLogOutput 棋譜をテキスト出力
 func (pp *ChinesePokerCuiPresenter) ActionLogOutput(cp interfaces.ChinesePokerGame) string {
 	return actionLogOutputText(cp)

--- a/internal/adapter/presenter/ChinesePokerCuiPresenter_test.go
+++ b/internal/adapter/presenter/ChinesePokerCuiPresenter_test.go
@@ -143,3 +143,57 @@ func TestChinesePokerCuiPresenter_FrontRankIsTranslated(t *testing.T) {
 	assert.NotContains(t, pp.frontRankStr(99), "pokerhand.")
 	assert.NotEmpty(t, pp.frontRankStr(99))
 }
+
+// **CUI には推奨分割もファウル警告も無かった (#4717)。**Web には
+// cp-foul-warning と列プレビューがある。
+func TestChinesePokerCuiPresenter_HintOutput(t *testing.T) {
+	p := new(ChinesePokerCuiPresenter)
+	card := func(design, value int) *domain.Card { return domain.NewCard(design, value, false) }
+	setHands := func(cards []*domain.Card) *domain.ChinesePoker {
+		cp := domain.NewDefaultChinesePoker()
+		cp.SetPhase(domain.ChinesePokerPhaseSetHands)
+		cp.SetPlayerCards(cards)
+		return cp
+	}
+	spread := []*domain.Card{
+		card(domain.CardDesignSpade, 1), card(domain.CardDesignHeart, 13), card(domain.CardDesignClover, 12),
+		card(domain.CardDesignDiamond, 11), card(domain.CardDesignSpade, 10), card(domain.CardDesignHeart, 9),
+		card(domain.CardDesignClover, 8), card(domain.CardDesignDiamond, 7), card(domain.CardDesignSpade, 6),
+		card(domain.CardDesignHeart, 5), card(domain.CardDesignClover, 4), card(domain.CardDesignDiamond, 3),
+		card(domain.CardDesignSpade, 2),
+	}
+
+	t.Run("prints all three rows with their indices", func(t *testing.T) {
+		out := p.HintOutput(setHands(spread))
+		assert.Contains(t, out, "前列(3枚)")
+		assert.Contains(t, out, "中列(5枚)")
+		assert.Contains(t, out, "後列(5枚)")
+		// **インデックスが要る。**set コマンドはインデックスで指定する。
+		assert.Contains(t, out, "[0]")
+	})
+
+	t.Run("says the split is safe when it does not foul", func(t *testing.T) {
+		out := p.HintOutput(setHands(spread))
+		assert.Contains(t, out, "ファウルにならない")
+	})
+
+	// **ランク順に切るだけでは合法とは限らない。**そのまま置かせない。
+	t.Run("warns when the rank-ordered split would foul", func(t *testing.T) {
+		fouling := []*domain.Card{
+			card(domain.CardDesignSpade, 1), card(domain.CardDesignHeart, 13), card(domain.CardDesignClover, 12),
+			card(domain.CardDesignDiamond, 11), card(domain.CardDesignSpade, 9), card(domain.CardDesignHeart, 8),
+			card(domain.CardDesignClover, 7), card(domain.CardDesignDiamond, 5), card(domain.CardDesignSpade, 4),
+			card(domain.CardDesignHeart, 3), card(domain.CardDesignClover, 2), card(domain.CardDesignDiamond, 2),
+			card(domain.CardDesignSpade, 2),
+		}
+		out := p.HintOutput(setHands(fouling))
+		assert.Contains(t, out, "ファウルになる")
+		assert.NotContains(t, out, "ファウルにならない")
+	})
+
+	t.Run("says so outside the set-hands phase", func(t *testing.T) {
+		cp := setHands(spread)
+		cp.SetPhase(domain.ChinesePokerPhaseBet)
+		assert.Contains(t, p.HintOutput(cp), "ヒントを出せません")
+	})
+}

--- a/internal/adapter/presenter/ChinesePokerWebPresenter.go
+++ b/internal/adapter/presenter/ChinesePokerWebPresenter.go
@@ -69,6 +69,13 @@ func (pp *ChinesePokerWebPresenter) Output(cp interfaces.ChinesePokerGame, lastE
 	return marshalOrError(resObj)
 }
 
+// HintOutput ヒントを出力する。Web ではヒントはクライアント側 (useGameHint) で
+// 算出するため、通常の状態出力を返す。ChinesePokerPresenter インタフェースを
+// 満たすための実装。
+func (cp *ChinesePokerWebPresenter) HintOutput(g interfaces.ChinesePokerGame) string {
+	return cp.Output(g, nil)
+}
+
 // ActionLogOutput 棋譜をJSON出力
 func (pp *ChinesePokerWebPresenter) ActionLogOutput(cp interfaces.ChinesePokerGame) string {
 	return actionLogOutputJSON(cp)

--- a/internal/domain/ChinesePoker.go
+++ b/internal/domain/ChinesePoker.go
@@ -316,6 +316,61 @@ func cpCompareFiveCardHands(a, b []*Card) int {
 
 // --- ファウルチェック ---
 
+// ChinesePokerSuggestedArrangement は推奨する13枚の分け方。
+type ChinesePokerSuggestedArrangement struct {
+	// Front / Middle / Back は手札のインデックス (前列3枚・中列5枚・後列5枚)。
+	Front  []int
+	Middle []int
+	Back   []int
+	// Foul はこの分け方がファウル (前列 > 中列、または中列 > 後列) になるか。
+	Foul bool
+}
+
+// GetSuggestedArrangement は13枚をランク順に「後列に強い5枚・中列に次の5枚・
+// 前列に残り3枚」で分けた案を返す (#4717)。セットハンドフェーズで13枚
+// そろっていないときは nil。
+//
+// **ランク順に切るだけでは合法とは限らない。**役のカテゴリは高い札の順に
+// 従わないので、前列に低いスリーカードが入ると中列のハイカードより強くなって
+// ファウルする。判定は実際の検証 cpValidateHands を通し、ファウルするなら
+// そう伝える。**総当たりで直さない**のは 13C3 × 10C5 = 72,072 通りになるため
+// で、フロントの getChinesePokerHint も同じ理由で同じ挙動にしている。
+func (c *ChinesePoker) GetSuggestedArrangement() *ChinesePokerSuggestedArrangement {
+	if c.phase != ChinesePokerPhaseSetHands || len(c.playerCards) != ChinesePokerHandSize {
+		return nil
+	}
+	idx := make([]int, len(c.playerCards))
+	for i := range idx {
+		idx[i] = i
+	}
+	// **エースは 14。**value は 1 なので、そのまま並べると最強の札が前列に落ちる。
+	rank := func(i int) int {
+		if v := c.playerCards[i].GetValue(); v == 1 {
+			return 14
+		}
+		return c.playerCards[i].GetValue()
+	}
+	sort.SliceStable(idx, func(a, b int) bool { return rank(idx[a]) > rank(idx[b]) })
+
+	back := idx[:ChinesePokerBackSize]
+	middle := idx[ChinesePokerBackSize : ChinesePokerBackSize+ChinesePokerMiddleSize]
+	front := idx[ChinesePokerBackSize+ChinesePokerMiddleSize:]
+
+	pick := func(indices []int) []*Card {
+		out := make([]*Card, len(indices))
+		for i, j := range indices {
+			out[i] = c.playerCards[j]
+		}
+		return out
+	}
+	return &ChinesePokerSuggestedArrangement{
+		Front:  front,
+		Middle: middle,
+		Back:   back,
+		Foul:   !cpValidateHands(pick(front), pick(middle), pick(back)),
+	}
+}
+
 // cpValidateHands Back ≥ Middle ≥ Front を検証する
 func cpValidateHands(front, middle, back []*Card) bool {
 	middleRank := evalFiveCardHand(middle)

--- a/internal/domain/ChinesePoker_test.go
+++ b/internal/domain/ChinesePoker_test.go
@@ -581,3 +581,92 @@ func TestCpPairValue_NoPair(t *testing.T) {
 	}
 	assert.Equal(t, 0, cpPairValue(cards))
 }
+
+// **CUI は13枚を自力で 3/5/5 に分けるしかなく、ファウルしても無警告だった
+// (#4717)。**Web には推奨分割もファウル警告 (cp-foul-warning) もある。
+func TestChinesePoker_GetSuggestedArrangement(t *testing.T) {
+	card := func(design, value int) *Card { return NewCard(design, value, false) }
+	setHands := func(cards []*Card) *ChinesePoker {
+		cp := NewDefaultChinesePoker()
+		cp.SetPhase(ChinesePokerPhaseSetHands)
+		cp.SetPlayerCards(cards)
+		return cp
+	}
+	// A K Q J 10 9 8 7 6 5 4 3 2 のばらばらな13枚。
+	spread := []*Card{
+		card(CardDesignSpade, 1), card(CardDesignHeart, 13), card(CardDesignClover, 12),
+		card(CardDesignDiamond, 11), card(CardDesignSpade, 10), card(CardDesignHeart, 9),
+		card(CardDesignClover, 8), card(CardDesignDiamond, 7), card(CardDesignSpade, 6),
+		card(CardDesignHeart, 5), card(CardDesignClover, 4), card(CardDesignDiamond, 3),
+		card(CardDesignSpade, 2),
+	}
+
+	t.Run("nothing to suggest outside the set-hands phase", func(t *testing.T) {
+		cp := setHands(spread)
+		cp.SetPhase(ChinesePokerPhaseBet)
+		assert.Nil(t, cp.GetSuggestedArrangement())
+	})
+
+	t.Run("nothing to suggest without a full hand", func(t *testing.T) {
+		assert.Nil(t, setHands(spread[:12]).GetSuggestedArrangement())
+	})
+
+	t.Run("splits the hand into three, five and five", func(t *testing.T) {
+		arr := setHands(spread).GetSuggestedArrangement()
+		require.NotNil(t, arr)
+		assert.Len(t, arr.Front, ChinesePokerFrontSize)
+		assert.Len(t, arr.Middle, ChinesePokerMiddleSize)
+		assert.Len(t, arr.Back, ChinesePokerBackSize)
+
+		// **13枚を過不足なく使う。**同じ札を二度置いたら成立しない。
+		seen := map[int]bool{}
+		for _, group := range [][]int{arr.Front, arr.Middle, arr.Back} {
+			for _, i := range group {
+				assert.False(t, seen[i], "index %d が重複している", i)
+				seen[i] = true
+			}
+		}
+		assert.Len(t, seen, ChinesePokerHandSize)
+	})
+
+	// **エースは 14 として並べる。**value が 1 のまま並べると、最強の札が
+	// 前列に落ちる。
+	t.Run("puts the ace in the back row, not the front", func(t *testing.T) {
+		cp := setHands(spread)
+		arr := cp.GetSuggestedArrangement()
+		require.NotNil(t, arr)
+		aceInBack := false
+		for _, i := range arr.Back {
+			if cp.GetPlayerCards()[i].GetValue() == 1 {
+				aceInBack = true
+			}
+		}
+		assert.True(t, aceInBack, "エースは後列に入るべき")
+		for _, i := range arr.Front {
+			assert.NotEqual(t, 1, cp.GetPlayerCards()[i].GetValue(), "エースが前列に落ちている")
+		}
+	})
+
+	t.Run("reports a clean split as legal", func(t *testing.T) {
+		arr := setHands(spread).GetSuggestedArrangement()
+		require.NotNil(t, arr)
+		assert.False(t, arr.Foul)
+	})
+
+	// **ランク順に切るだけでは合法とは限らない。**低いスリーカードが前列に
+	// 落ちると、中列のハイカードより強くなってファウルする。
+	t.Run("flags a rank-ordered split that would foul", func(t *testing.T) {
+		// 後列 A K Q J 9 / 中列 8 7 5 4 3 (どちらもハイカード) / 前列 2 2 2。
+		// 前列のスリーカードが中列のハイカードより強いのでファウル。
+		fouling := []*Card{
+			card(CardDesignSpade, 1), card(CardDesignHeart, 13), card(CardDesignClover, 12),
+			card(CardDesignDiamond, 11), card(CardDesignSpade, 9), card(CardDesignHeart, 8),
+			card(CardDesignClover, 7), card(CardDesignDiamond, 5), card(CardDesignSpade, 4),
+			card(CardDesignHeart, 3), card(CardDesignClover, 2), card(CardDesignDiamond, 2),
+			card(CardDesignSpade, 2),
+		}
+		arr := setHands(fouling).GetSuggestedArrangement()
+		require.NotNil(t, arr)
+		assert.True(t, arr.Foul, "前列が 2 のスリーカードになりファウルするはず")
+	})
+}

--- a/internal/domain/interfaces/chinesepoker.go
+++ b/internal/domain/interfaces/chinesepoker.go
@@ -14,6 +14,8 @@ type ChinesePokerGame interface {
 	// SetHands フロント3枚・ミドル5枚を指定してハンドを分割する
 	SetHands(frontIndices []int, middleIndices []int) error
 
+	// GetSuggestedArrangement 推奨する13枚の分け方を取得する
+	GetSuggestedArrangement() *domain.ChinesePokerSuggestedArrangement
 	// GetPlayerCards プレイヤーの13枚を取得する
 	GetPlayerCards() []*domain.Card
 	// GetDealerCards ディーラーの13枚を取得する

--- a/internal/i18n/locales/en/chinesepoker.json
+++ b/internal/i18n/locales/en/chinesepoker.json
@@ -21,5 +21,11 @@
   "dealerWins": "Dealer wins!",
   "dealerScoop": "Dealer scoop!",
   "payoutLine": "Payout: {{payout}}",
-  "royaltyLine": "Royalties: Player={{player}} / Dealer={{dealer}}"
+  "royaltyLine": "Royalties: Player={{player}} / Dealer={{dealer}}",
+  "hintNone": "No hint is available now.",
+  "hintRowFront": "Front (3): {{cards}}",
+  "hintRowMiddle": "Middle (5): {{cards}}",
+  "hintRowBack": "Back (5): {{cards}}",
+  "hintSplitOk": "This split does not foul",
+  "hintFoulRisk": "Careful: this split fouls. Rework the front and middle rows"
 }

--- a/internal/i18n/locales/ja/chinesepoker.json
+++ b/internal/i18n/locales/ja/chinesepoker.json
@@ -21,5 +21,11 @@
   "dealerWins": "ディーラーの勝ち！",
   "dealerScoop": "ディーラーのスクープ勝ち！",
   "payoutLine": "払戻し: {{payout}}",
-  "royaltyLine": "ロイヤリティ: プレイヤー={{player}} / ディーラー={{dealer}}"
+  "royaltyLine": "ロイヤリティ: プレイヤー={{player}} / ディーラー={{dealer}}",
+  "hintNone": "いまはヒントを出せません。",
+  "hintRowFront": "前列(3枚): {{cards}}",
+  "hintRowMiddle": "中列(5枚): {{cards}}",
+  "hintRowBack": "後列(5枚): {{cards}}",
+  "hintSplitOk": "この分け方ならファウルにならない",
+  "hintFoulRisk": "注意: この分け方はファウルになる。前列/中列を組み替えること"
 }

--- a/internal/usecase/ChinesePokerInteractor.go
+++ b/internal/usecase/ChinesePokerInteractor.go
@@ -14,6 +14,8 @@ type ChinesePokerInteractorIF interface {
 	Reset() string
 	Bet(amount int) string
 	SetHands(frontIndices []int, middleIndices []int) string
+	// Hint ヒント取得
+	Hint() string
 	ActionLog() string
 }
 
@@ -45,6 +47,11 @@ func (ci *ChinesePokerInteractor) Bet(amount int) string {
 // SetHands ハンド設定
 func (ci *ChinesePokerInteractor) SetHands(frontIndices []int, middleIndices []int) string {
 	return execAndPresent(ci.Game, ci.pp, func() error { return ci.Game.SetHands(frontIndices, middleIndices) })
+}
+
+// Hint ヒント取得
+func (ci *ChinesePokerInteractor) Hint() string {
+	return ci.pp.HintOutput(ci.Game)
 }
 
 // ActionLog 棋譜出力

--- a/internal/usecase/presenter/ChinesePokerPresenter.go
+++ b/internal/usecase/presenter/ChinesePokerPresenter.go
@@ -5,4 +5,8 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // ChinesePokerPresenter チャイニーズポーカープレゼンターインタフェース
-type ChinesePokerPresenter = GamePresenter[interfaces.ChinesePokerGame]
+type ChinesePokerPresenter interface {
+	GamePresenter[interfaces.ChinesePokerGame]
+	// HintOutput ヒント情報を出力する
+	HintOutput(g interfaces.ChinesePokerGame) string
+}

--- a/internal/usecase/presenter/ChinesePokerPresenter_mock.go
+++ b/internal/usecase/presenter/ChinesePokerPresenter_mock.go
@@ -5,4 +5,12 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // MockChinesePokerPresenter チャイニーズポーカープレゼンターモック
-type MockChinesePokerPresenter = MockGamePresenter[interfaces.ChinesePokerGame]
+type MockChinesePokerPresenter struct {
+	MockGamePresenter[interfaces.ChinesePokerGame]
+}
+
+// HintOutput モック
+func (_m *MockChinesePokerPresenter) HintOutput(g interfaces.ChinesePokerGame) string {
+	ret := _m.Called(g)
+	return ret.Get(0).(string)
+}


### PR DESCRIPTION
## 背景

`ChinesePokerCuiPresenter` に `HintOutput` がありません。**CUI プレイヤーは13枚を自力で前列3枚・中列5枚・後列5枚に分けるしかなく、ファウル（前列 > 中列、または中列 > 後列）になっても警告が一切出ません** (#4717)。

Web には推奨分割・`cp-foul-warning`・列プレビュー（`cp-row-preview`）が揃っています。

```
前列(3枚): [10]♣4 [11]♦3 [12]♠2
中列(5枚): [5]♥9 [6]♣8 [7]♦7 [8]♠6 [9]♥5
後列(5枚): [0]♠A [1]♥K [2]♣Q [3]♦J [4]♠10
この分け方ならファウルにならない
```

`set` コマンドはインデックスで指定するので、**インデックス付きで出します**。

## ランク順に切るだけでは合法とは限りません

役のカテゴリは高い札の順に従いません。**前列に低いスリーカードが入ると中列のハイカードより強くなってファウルします**（後列 A K Q J 9 / 中列 8 7 5 4 3 / 前列 2 2 2 が実例）。

判定は**実際の検証 `cpValidateHands`**（`set` が使うもの）を通します。常に `false` にするとテストが4件落ちます。

## 総当たりでは直しません

13C3 × 10C5 = **72,072 通り**になるためです。フロントの `getChinesePokerHint` も同じ理由で同じ挙動（ファウルするなら警告するだけ）なので、**CUI と Web で助言が食い違うこともありません**。

## 負のコントロール

| 壊し方 | 落ちる件数 |
|---|---|
| 並び順を逆にする | 5 |
| ファウル判定を常に false | 4 |
| エースを 14 で数えない | 2 |
| 警告を出さない | 2 |
| `h` コマンドの配線ミス | 1 |

## 検証

- `go test -tags test ./internal/...` ✅ / `golangci-lint run ./internal/...` → `0 issues.` ✅ / `gofmt -l internal/` 空 ✅
- `check-message-codes: OK (all 775 codes …)` ✅

Closes #4717