### PR TITLE
feat: wire the Sheng Ji hint into its page

### DIFF
--- a/frontend/src/pages/ShengJiPage.test.tsx
+++ b/frontend/src/pages/ShengJiPage.test.tsx
@@ -322,3 +322,21 @@ describe('ShengJiPage', () => {
     await waitFor(() => expect(screen.getByTestId('hand-card-0')).toBeDisabled());
   });
 });
+
+// **ヒントは前から算出されていたのに、ページが一度も読んでいなかった (#4774)。**
+// getShengJiHint も hintFactories への登録もあるのに、画面にトグルもツール
+// チップも無かった。check-hint-coverage はファクトリの有無しか見ないので
+// CI をすり抜けていた。
+describe('ShengJiPage hint', () => {
+  it('shows the hint once the toggle is enabled', async () => {
+    mockExec.mockResolvedValue(makeState({ phase: ShengJiPhase.DECLARE, declarableSuits: { '3': 2 } }));
+    renderWithProviders(<ShengJiPage />);
+    await waitFor(() => expect(screen.getByLabelText('ヒント表示')).toBeInTheDocument());
+
+    // トグルを入れるまでは出さない。
+    expect(screen.queryByTestId('hint-tooltip')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText('ヒント表示'));
+    expect(screen.getByTestId('hint-tooltip')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/ShengJiPage.tsx
+++ b/frontend/src/pages/ShengJiPage.tsx
@@ -9,6 +9,7 @@ import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
+import { FrontendHintTooltip } from '../components/hint/FrontendHintTooltip';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useCardDimensions } from '../hooks/useCardDimensions';
@@ -16,6 +17,7 @@ import { useCardSelection } from '../hooks/useCardSelection';
 import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
+import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
@@ -108,6 +110,17 @@ function ShengJiPageContent() {
 
   const { cardWidth } = useCardDimensions();
   const phaseNames = usePhaseNames('shengji', SHENGJI_PHASE_KEYS);
+  // **ヒントは前から算出されていた。**getShengJiHint も hintFactories への
+  // 登録もあるのに、このページが一度も読んでいなかった (#4774)。
+  // check-hint-coverage はファクトリの有無しか見ないので CI をすり抜けていた。
+  //
+  // **フックは早期 return より上。**下に置くと初回レンダーだけフック数が
+  // 変わってページが骨組みのまま固まる。
+  const {
+    hint: frontendHint,
+    hintEnabled: frontendHintEnabled,
+    setHintEnabled: setFrontendHintEnabled,
+  } = useGameHint('shengji', state);
 
   if (!state)
     return <GameSkeleton gameKey="shengji" layout={{ kind: 'trick-taking', trickArea: true, footerHandSize: 12 }} />;
@@ -281,6 +294,16 @@ function ShengJiPageContent() {
               messageCode={state.messageCode}
               messageParams={state.messageParams}
             />
+
+            <label className="flex items-center gap-1 text-ds-text-primary text-xs w-full justify-center cursor-pointer min-h-[44px]">
+              <input
+                type="checkbox"
+                checked={frontendHintEnabled}
+                onChange={(e) => setFrontendHintEnabled(e.target.checked)}
+              />
+              {tc('hint.toggle', { ns: 'tutorial' })}
+            </label>
+            <FrontendHintTooltip hint={frontendHint} enabled={frontendHintEnabled} t={t} />
 
             <ActionLogSection
               isEndPhase={isGameEnd}


### PR DESCRIPTION
## 背景

`getShengJiHint` は宣言（DECLARE）・底牌埋め（KITTY）・プレイの**3フェーズすべてに理由付きのヒントを返す完成した実装**で、`hintFactories` にも `shengji:` として登録済みです。

ところが `ShengJiPage.tsx` は `useGameHint` を一度も呼んでおらず、**トグルもツールチップも画面にありません**でした (#4774)。ヒントは毎回計算されて捨てられていました。

## CI をすり抜ける形です

`check-hint-coverage.mjs` は**ファクトリの登録有無しか見ません**。「登録されているのに画面で一度も使われない」欠落は検出されません。**#4708（ブラックジャック・スイッチ）と同じ形**で、このバッチで2件目です。

（全ページを走査するガードも検討しましたが、`useGameHint` を持たないページ17件のうち大半は正当です — BlackJack/Spanish21 はバックエンド駆動の `suggestedAction`、Discover/Legal/NotFound は非ゲーム、CrazyPineapple/IrishPoker/Omaha 系などは共有ページコンポーネントの薄いラッパー。誤検知だらけのガードは入れませんでした。）

## 実装

Karnoffel / Nap と同じ位置・同じ組（チェックボックス + `FrontendHintTooltip`）に揃えました。**フックは早期 return より上**に置いています（下に置くと初回レンダーだけフック数が変わり、ページが骨組みのまま固まる）。

## 負のコントロール

| 壊し方 | 落ちる件数 |
|---|---|
| ツールチップを出さない | 1 |
| フックを呼ばない（元の挙動） | 1 |

## 検証

- `bunx vitest run src/pages/ShengJiPage.test.tsx` → 22 passed ✅
- `bun run typecheck` ✅ / `bun run check` exit 0 ✅

Closes #4774