### PR TITLE
feat: mark the single-removable kings in Pyramid CUI board

### DIFF
--- a/internal/adapter/presenter/PyramidCuiPresenter.go
+++ b/internal/adapter/presenter/PyramidCuiPresenter.go
@@ -33,6 +33,14 @@ func (pr *PyramidCuiPresenter) Output(p interfaces.PyramidGame, lastErr error) s
 				switch {
 				case pc.Removed:
 					b.WriteString(pyramidRemovedPlaceholder)
+				case p.IsRemovableKing(row, col):
+					// **キングは相方が要らず単独で消せる (#4782)。**Web は常時
+					// ハイライトしているのに、CUI は数値を1枚ずつ見て 13 を
+					// 自分で探すしかなかった。
+					b.WriteString(i18n.Tf("pyramid.exposedKing",
+						"row", strconv.Itoa(row),
+						"col", strconv.Itoa(col),
+						"card", cuiCardStr(pc.Card)))
 				case p.IsExposed(row, col):
 					// Exposed cards carry their coordinates so they can be played.
 					b.WriteString(i18n.Tf("pyramid.exposedCard",
@@ -55,7 +63,11 @@ func (pr *PyramidCuiPresenter) Output(p interfaces.PyramidGame, lastErr error) s
 			"count", strconv.Itoa(p.GetStockCount())))
 		waste := p.GetWaste()
 		if len(waste) > 0 {
-			b.WriteString(i18n.Tf("pyramid.wasteCard",
+			wasteKey := "pyramid.wasteCard"
+			if p.IsWasteKingRemovable() {
+				wasteKey = "pyramid.wasteKing"
+			}
+			b.WriteString(i18n.Tf(wasteKey,
 				"card", cuiCardStr(waste[len(waste)-1])))
 		} else {
 			b.WriteString(i18n.T("pyramid.wasteEmpty"))

--- a/internal/adapter/presenter/PyramidCuiPresenter_test.go
+++ b/internal/adapter/presenter/PyramidCuiPresenter_test.go
@@ -3,6 +3,7 @@
 package presenter
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -17,6 +18,7 @@ func addPyramidExposedExpectations(pg *interfaces.MockPyramidGame) {
 	for row := range domain.PyramidRowCnt {
 		for col := range row + 1 {
 			pg.On("IsExposed", row, col).Return(row == domain.PyramidRowCnt-1).Maybe()
+			pg.On("IsRemovableKing", row, col).Return(false).Maybe()
 		}
 	}
 }
@@ -28,6 +30,7 @@ func setupPyramidCuiMock() *interfaces.MockPyramidGame {
 	pg.On("GetStockCount").Return(24).Maybe()
 	pg.On("GetWaste").Return(([]*domain.Card)(nil)).Maybe()
 	pg.On("IsStalemate").Return(false).Maybe()
+	pg.On("IsWasteKingRemovable").Return(false).Maybe()
 	addPyramidExposedExpectations(pg)
 
 	var pyramid [domain.PyramidRowCnt][]*domain.PyramidCard
@@ -184,6 +187,7 @@ func TestPyramidCuiPresenterOutput_StalemateAndNonEmptyWaste(t *testing.T) {
 		domain.NewCard(domain.CardDesignSpade, 7, false),
 	}).Maybe()
 	pg.On("IsStalemate").Return(true).Maybe()
+	pg.On("IsWasteKingRemovable").Return(false).Maybe()
 	addPyramidExposedExpectations(pg)
 
 	var pyramid [domain.PyramidRowCnt][]*domain.PyramidCard
@@ -211,4 +215,55 @@ func TestPyramidCuiPresenterActionLogOutput(t *testing.T) {
 	p := &PyramidCuiPresenter{}
 	result := p.ActionLogOutput(pg)
 	assert.Contains(t, result, "棋譜はありません")
+}
+
+// **キングは相方が要らず単独で消せる (#4782)。**Web は常時ハイライトして
+// いるのに、CUI は数値を1枚ずつ見て 13 を自分で探すしかなかった。
+func TestPyramidCuiPresenterOutput_MarksRemovableKings(t *testing.T) {
+	last := domain.PyramidRowCnt - 1
+	// kingAt で指定した1枚だけを「除去できるキング」にした盤面のモック。
+	board := func(kingCol int, waste []*domain.Card, wasteKing bool) *interfaces.MockPyramidGame {
+		pg := new(interfaces.MockPyramidGame)
+		pg.On("GetPhase").Return(domain.PyramidPhasePlaying).Maybe()
+		pg.On("GetMoveCount").Return(0).Maybe()
+		pg.On("GetStockCount").Return(24).Maybe()
+		pg.On("GetWaste").Return(waste).Maybe()
+		pg.On("IsStalemate").Return(false).Maybe()
+		pg.On("IsWasteKingRemovable").Return(wasteKing).Maybe()
+		for row := range domain.PyramidRowCnt {
+			for col := range row + 1 {
+				pg.On("IsExposed", row, col).Return(row == last).Maybe()
+				pg.On("IsRemovableKing", row, col).Return(row == last && col == kingCol).Maybe()
+			}
+		}
+		var pyramid [domain.PyramidRowCnt][]*domain.PyramidCard
+		for row := range domain.PyramidRowCnt {
+			pyramid[row] = make([]*domain.PyramidCard, row+1)
+			for col := range row + 1 {
+				pyramid[row][col] = &domain.PyramidCard{
+					Card:    domain.NewCard(domain.CardDesignSpade, 13, false),
+					Removed: false,
+				}
+			}
+		}
+		pg.On("GetPyramid").Return(pyramid).Maybe()
+		return pg
+	}
+	p := &PyramidCuiPresenter{}
+
+	// **印が付くのは1枚だけ。**全部に付ける実装でも「付く」だけなら通る。
+	t.Run("marks one king on the pyramid and leaves the rest bare", func(t *testing.T) {
+		out := p.Output(board(0, nil, false), nil)
+		assert.Equal(t, 1, strings.Count(out, "[K]"))
+	})
+
+	t.Run("marks a king on top of the waste", func(t *testing.T) {
+		out := p.Output(board(-1, []*domain.Card{domain.NewCard(domain.CardDesignSpade, 13, false)}, true), nil)
+		assert.Contains(t, out, "[K]")
+	})
+
+	t.Run("does not mark a non-king waste card", func(t *testing.T) {
+		out := p.Output(board(-1, []*domain.Card{domain.NewCard(domain.CardDesignSpade, 7, false)}, false), nil)
+		assert.NotContains(t, out, "[K]")
+	})
 }

--- a/internal/domain/Pyramid.go
+++ b/internal/domain/Pyramid.go
@@ -172,6 +172,31 @@ func (p *Pyramid) RemovePair(row1, col1, row2, col2 int) error {
 	return nil
 }
 
+// IsRemovableKing は (row, col) のカードが「いま単独で除去できるキング」かを返す。
+//
+// **RemoveKing が通る条件と同じものを見る (#4782)。**キングは相方が要らず
+// クリックだけで消せるので、Web は常時ハイライトしている。印を付ける条件と
+// 実際に通る条件が別々だと、消せない札に印が付く。
+func (p *Pyramid) IsRemovableKing(row, col int) bool {
+	if p.phase != PyramidPhasePlaying {
+		return false
+	}
+	if err := p.validatePyramidPos(row, col); err != nil {
+		return false
+	}
+	// isExposed が除去済みを弾くので、ここで Removed を見直さない
+	// (見ても常に同じ結果になる分岐が増えるだけ)。
+	return p.isExposed(row, col) && p.pyramid[row][col].Card.GetValue() == PyramidTargetSum
+}
+
+// IsWasteKingRemovable はウェイストのトップが単独で除去できるキングかを返す。
+func (p *Pyramid) IsWasteKingRemovable() bool {
+	if p.phase != PyramidPhasePlaying || len(p.waste) == 0 {
+		return false
+	}
+	return p.waste[len(p.waste)-1].GetValue() == PyramidTargetSum
+}
+
 // RemoveKing ピラミッド上のKを単独で除去
 func (p *Pyramid) RemoveKing(row, col int) error {
 	if p.phase != PyramidPhasePlaying {

--- a/internal/domain/Pyramid_test.go
+++ b/internal/domain/Pyramid_test.go
@@ -632,3 +632,79 @@ func TestPyramid_UndoN_Excessive(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "undo step")
 }
+
+// **キングは相方が要らず単独で消せる (#4782)。**Web は常時ハイライトして
+// いるのに、CUI は数値を1枚ずつ見て 13 を自分で探すしかなかった。
+func TestPyramid_IsRemovableKing(t *testing.T) {
+	// 最下段だけを持つ最小のピラミッドを組む (最下段は必ず露出している)。
+	newBoard := func(bottom ...*Card) *Pyramid {
+		p := NewDefaultPyramid()
+		p.Reset()
+		var rows [PyramidRowCnt][]*PyramidCard
+		for r := range PyramidRowCnt {
+			rows[r] = make([]*PyramidCard, r+1)
+			for c := range r + 1 {
+				card := NewCard(CardDesignSpade, 2, false)
+				removed := true
+				if r == PyramidRowCnt-1 && c < len(bottom) {
+					card = bottom[c]
+					removed = false
+				}
+				rows[r][c] = &PyramidCard{Card: card, Removed: removed}
+			}
+		}
+		p.SetPyramid(rows)
+		return p
+	}
+	last := PyramidRowCnt - 1
+
+	t.Run("an exposed king can be removed on its own", func(t *testing.T) {
+		p := newBoard(NewCard(CardDesignSpade, 13, false))
+		assert.True(t, p.IsRemovableKing(last, 0))
+	})
+
+	// **13 以外には印を付けない。**Q に印が付くと、通らない手を勧めることになる。
+	t.Run("a queen is not a removable king", func(t *testing.T) {
+		p := newBoard(NewCard(CardDesignSpade, 12, false))
+		assert.False(t, p.IsRemovableKing(last, 0))
+	})
+
+	// **除去済みの札に印を付けない。**RemoveKing で消した後も印が残ると、
+	// 通らない手を勧め続ける。(isExposed は除去済みを弾かないので、
+	// Removed の確認はここでしか踏めない。)
+	t.Run("a removed king is no longer removable", func(t *testing.T) {
+		p := newBoard(NewCard(CardDesignSpade, 13, false))
+		require.True(t, p.IsRemovableKing(last, 0))
+		require.NoError(t, p.RemoveKing(last, 0))
+		assert.False(t, p.IsRemovableKing(last, 0),
+			"消えた札に印が残っている")
+	})
+
+	// **印が付く条件と RemoveKing が通る条件は同じでなければならない。**
+	t.Run("agrees with RemoveKing", func(t *testing.T) {
+		p := newBoard(NewCard(CardDesignSpade, 13, false), NewCard(CardDesignHeart, 5, false))
+		require.True(t, p.IsRemovableKing(last, 0))
+		assert.NoError(t, p.RemoveKing(last, 0))
+
+		q := newBoard(NewCard(CardDesignSpade, 13, false), NewCard(CardDesignHeart, 5, false))
+		require.False(t, q.IsRemovableKing(last, 1))
+		assert.Error(t, q.RemoveKing(last, 1))
+	})
+
+	t.Run("out-of-range coordinates are not removable", func(t *testing.T) {
+		p := newBoard(NewCard(CardDesignSpade, 13, false))
+		assert.False(t, p.IsRemovableKing(-1, 0))
+		assert.False(t, p.IsRemovableKing(last, 99))
+	})
+
+	t.Run("the waste top is flagged only when it is a king", func(t *testing.T) {
+		p := newBoard(NewCard(CardDesignSpade, 2, false))
+		assert.False(t, p.IsWasteKingRemovable(), "空のウェイストに印は付かない")
+
+		p.SetWaste([]*Card{NewCard(CardDesignHeart, 5, false)})
+		assert.False(t, p.IsWasteKingRemovable())
+
+		p.SetWaste([]*Card{NewCard(CardDesignHeart, 5, false), NewCard(CardDesignClover, 13, false)})
+		assert.True(t, p.IsWasteKingRemovable(), "見るのは一番上の1枚")
+	})
+}

--- a/internal/domain/interfaces/pyramid.go
+++ b/internal/domain/interfaces/pyramid.go
@@ -48,6 +48,10 @@ type PyramidGame interface {
 	IsExposed(row, col int) bool
 	// AllRemoved 全ピラミッドカードが除去されたかを返す
 	AllRemoved() bool
+	// IsRemovableKing いま単独で除去できるキングかを返す
+	IsRemovableKing(row, col int) bool
+	// IsWasteKingRemovable ウェイストのトップが単独で除去できるキングかを返す
+	IsWasteKingRemovable() bool
 	// IsStalemate 手詰まり状態を取得する
 	IsStalemate() bool
 }

--- a/internal/domain/interfaces/pyramid_mock.go
+++ b/internal/domain/interfaces/pyramid_mock.go
@@ -118,6 +118,16 @@ func (_m *MockPyramidGame) IsExposed(row, col int) bool {
 	return ret.Bool(0)
 }
 
+func (_m *MockPyramidGame) IsRemovableKing(row, col int) bool {
+	args := _m.Called(row, col)
+	return args.Bool(0)
+}
+
+func (_m *MockPyramidGame) IsWasteKingRemovable() bool {
+	args := _m.Called()
+	return args.Bool(0)
+}
+
 func (_m *MockPyramidGame) AllRemoved() bool {
 	ret := _m.Called()
 	return ret.Bool(0)

--- a/internal/i18n/locales/en/pyramid.json
+++ b/internal/i18n/locales/en/pyramid.json
@@ -16,5 +16,7 @@
   "hintPair": "Hint: remove pair ({{row1}},{{col1}})+({{row2}},{{col2}})",
   "hintWasteKing": "Hint: remove king on waste",
   "hintWastePair": "Hint: pair waste with pyramid ({{row}},{{col}})",
-  "hintUnknown": "Hint: unknown"
+  "hintUnknown": "Hint: unknown",
+  "exposedKing": "({{row}},{{col}}){{card}}[K]",
+  "wasteKing": " | Waste: {{card}}[K]"
 }

--- a/internal/i18n/locales/ja/pyramid.json
+++ b/internal/i18n/locales/ja/pyramid.json
@@ -16,5 +16,7 @@
   "hintPair": "ヒント: ペア除去: ({{row1}},{{col1}})+({{row2}},{{col2}})",
   "hintWasteKing": "ヒント: ウェイストのキング除去",
   "hintWastePair": "ヒント: ウェイスト+ピラミッド({{row}},{{col}})",
-  "hintUnknown": "ヒント: 不明"
+  "hintUnknown": "ヒント: 不明",
+  "exposedKing": "({{row}},{{col}}){{card}}[K]",
+  "wasteKing": " | Waste: {{card}}[K]"
 }


### PR DESCRIPTION
## 背景

キングは相方が要らず**クリックだけで消せます**。Web はヒントを押さなくても常時、露出したキングに成功色のリングを付け、`data-king-removable` も設定します（ウェイストの一番上も同様、#3082）。

`PyramidCuiPresenter.Output` は `exposedCard` として座標とカード文字列を出すだけで、**単独除去できるかどうかの区別が一切ありません** (#4782)。CUI プレイヤーは表示された数値を1枚ずつ見て 13 を自分で探す必要がありました。

```
      [--] [--] (2,2)♠5 (2,3)♦K[K]
```

## 印を付ける条件と `RemoveKing` が通る条件を同じにします

別々だと**消せない札に印が付きます**。`IsRemovableKing` / `IsWasteKingRemovable` をドメインに置き、`RemoveKing` / `RemoveWasteKing` と同じ条件を見ます。「印が付く ⇔ RemoveKing が成功する」をテストで固定しました。

ウェイストは**一番上の1枚だけ**を見ます（底を見る実装にすると2件落ちる）。

## 冗長な条件を1つ落としました

当初 `!pc.Removed && p.isExposed(...)` と書きましたが、**`isExposed` の先頭がすでに `Removed` を弾いています**。負のコントロール（除去済みにも印を付ける）が 0件だったことで気づきました。常に同じ結果になる分岐なので消してあります（挙動自体はテストで固定済み）。

## 負のコントロール

| 壊し方 | 落ちる件数 |
|---|---|
| K 以外にも印を付ける | 3 |
| ウェイストの底を見る | 2 |
| presenter が印を出さない | 2 |

## 検証

- `go test -tags test ./internal/...` ✅ / `golangci-lint run ./internal/...` → `0 issues.` ✅ / `gofmt -l internal/` 空 ✅
- `check-message-codes: OK (all 775 codes …)` ✅

Closes #4782