### PR TITLE
feat: star the legally playable cards in Euchre CUI hand

### DIFF
--- a/internal/adapter/presenter/EuchreCuiPresenter.go
+++ b/internal/adapter/presenter/EuchreCuiPresenter.go
@@ -14,7 +14,13 @@ import (
 
 // euchrePlayerStr returns the display string for a single Euchre player.
 // sittingOut appends a marker when this seat sits out a go-alone hand.
-func euchrePlayerStr(player *domain.EuchrePlayer, i int, sittingOut bool) string {
+// playable が非 nil のとき、そのインデックスの札に "*" を付ける。
+//
+// **レフトボーア (同色の別スートの J) が切り札扱いになる**という分かりにくい
+// ルールを含むので、CUI では自力でルールを再現するか、出せない札を選んで
+// エラーを受け取るまで気づけなかった (#4781)。Web は同じ判定で合法な札に
+// 枠線を付けている。
+func euchrePlayerStr(player *domain.EuchrePlayer, i int, sittingOut bool, playable []int) string {
 	var b strings.Builder
 	b.WriteString(i18n.Tf("euchre.playerLine",
 		"name", cuiPlayerName(player, i),
@@ -27,9 +33,46 @@ func euchrePlayerStr(player *domain.EuchrePlayer, i int, sittingOut bool) string
 	}
 	b.WriteString("\n")
 	if player.GetIsHuman() && player.GetCardsSize() > 0 {
-		b.WriteString(cuiIndexedCardListStr(player) + "\n")
+		b.WriteString(euchreHandStr(player, playable) + "\n")
 	}
 	return b.String()
+}
+
+// euchreHandStr renders the hand as an indexed list, starring the cards that
+// may legally be played right now.
+func euchreHandStr(player *domain.EuchrePlayer, playable []int) string {
+	if len(playable) == 0 {
+		return cuiIndexedCardListStr(player)
+	}
+	mark := make(map[int]bool, len(playable))
+	for _, idx := range playable {
+		mark[idx] = true
+	}
+	parts := make([]string, player.GetCardsSize())
+	for i := 0; i < player.GetCardsSize(); i++ {
+		parts[i] = "[" + strconv.Itoa(i) + "]" + cuiCardStr(player.GetCard(i))
+		if mark[i] {
+			parts[i] += "*"
+		}
+	}
+	return strings.Join(parts, "  ")
+}
+
+// euchrePlayableIndices returns the human's legal plays, or nil when it is not
+// the human's turn to play a card.
+//
+// **手番でないときは印を付けない。**別のプレイヤーの合法手を人間の手札に
+// 当てると、出せない札に印が付く。
+func euchrePlayableIndices(e interfaces.EuchreGame) []int {
+	if e.GetPhase() != domain.EuchrePhasePlay {
+		return nil
+	}
+	idx := e.GetCurrentPlayerIdx()
+	p := e.GetPlayer(idx)
+	if p == nil || !p.GetIsHuman() {
+		return nil
+	}
+	return e.GetValidPlayIndices(idx)
 }
 
 // euchreSittingOutIdx returns the seat that sits out during a go-alone hand —
@@ -91,8 +134,9 @@ func (p *EuchreCuiPresenter) Output(e interfaces.EuchreGame, lastErr error) stri
 			"t1", strconv.Itoa(e.GetTeamScore(1))) + "\n")
 
 		sittingOutIdx := euchreSittingOutIdx(e)
+		playable := euchrePlayableIndices(e)
 		for i := 0; i < e.GetPlayerCnt(); i++ {
-			b.WriteString(euchrePlayerStr(e.GetPlayer(i), i, i == sittingOutIdx))
+			b.WriteString(euchrePlayerStr(e.GetPlayer(i), i, i == sittingOutIdx, playable))
 		}
 
 		b.WriteString("----------\n")

--- a/internal/adapter/presenter/EuchreCuiPresenter_test.go
+++ b/internal/adapter/presenter/EuchreCuiPresenter_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
@@ -23,6 +24,7 @@ func setupEuchreCuiMock() *interfaces.MockEuchreGame {
 	m.On("GetGameEndFlag").Return(false)
 	m.On("GetPhase").Return(domain.EuchrePhasePlay)
 	m.On("GetCurrentPlayerIdx").Return(0)
+	m.On("GetValidPlayIndices", mock.Anything).Return(([]int)(nil)).Maybe()
 	m.On("GetBidPlayerIdx").Return(0)
 	m.On("GetDealerIdx").Return(0)
 	m.On("GetTrumpSuit").Return(1) // Spade
@@ -437,5 +439,52 @@ func TestEuchreCuiPresenter_HintOutput(t *testing.T) {
 			result := p.HintOutput(m)
 			assert.Contains(t, result, expected, "reason: "+key)
 		}
+	})
+}
+
+// **レフトボーア (同色の別スートの J) が切り札扱いになるという分かりにくい
+// ルールを含むので、CUI では出せない札を選んでエラーを受け取るまで気づけな
+// かった (#4781)。**Web は同じ判定で合法な札に枠線を付けている。
+func TestEuchreCuiPresenter_MarksPlayableCards(t *testing.T) {
+	origNoColor := color.NoColor()
+	color.SetNoColor(true)
+	defer color.SetNoColor(origNoColor)
+	p := new(presenter.EuchreCuiPresenter)
+
+	withPlayable := func(valid []int, phase domain.EuchrePhase, turn int) *interfaces.MockEuchreGame {
+		m, players := setupEuchreCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetValidPlayIndices")
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetCurrentPlayerIdx")
+		m.On("GetValidPlayIndices", mock.Anything).Return(valid).Maybe()
+		m.On("GetPhase").Return(phase)
+		m.On("GetCurrentPlayerIdx").Return(turn)
+		players[0].Reset()
+		for _, c := range []*domain.Card{
+			domain.NewCard(domain.CardDesignSpade, 11, false),
+			domain.NewCard(domain.CardDesignHeart, 9, false),
+			domain.NewCard(domain.CardDesignClover, 12, false),
+		} {
+			players[0].AddCard(c)
+		}
+		return m
+	}
+
+	t.Run("stars only the cards that may be played", func(t *testing.T) {
+		out := p.Output(withPlayable([]int{0, 2}, domain.EuchrePhasePlay, 0), nil)
+		assert.Equal(t, 2, strings.Count(out, "*"), "印が付くのは2枚だけ")
+		assert.Contains(t, out, "[0]")
+	})
+
+	// **手番でないときは印を付けない。**別のプレイヤーの合法手を人間の手札に
+	// 当てると、出せない札に印が付く。
+	t.Run("stars nothing while a CPU is to act", func(t *testing.T) {
+		out := p.Output(withPlayable([]int{0, 1, 2}, domain.EuchrePhasePlay, 1), nil)
+		assert.NotContains(t, out, "*")
+	})
+
+	t.Run("stars nothing outside the play phase", func(t *testing.T) {
+		out := p.Output(withPlayable([]int{0, 1, 2}, domain.EuchrePhasePickUp, 0), nil)
+		assert.NotContains(t, out, "*")
 	})
 }


### PR DESCRIPTION
## 背景

`EuchrePage.tsx` は `euchreLegalPlayIndices` で合法に出せる札に成功色の枠線を付けます。`EuchreCuiPresenter.euchrePlayerStr` は `cuiIndexedCardListStr` で番号付きに並べるだけでした (#4781)。

**レフトボーア（同色の別スートの J）が切り札扱いになる**という分かりにくいルールを含むため、CUI プレイヤーは自力でルールを再現するか、**出せない札を選んでエラーを受け取るまで気づけません**。

```
あなた (チーム0) トリック:0 手札:3
[0]♠J*  [1]♥9  [2]♣Q*
```

## 判定は新しく書きません

ドメインには **`PlayerPlay` と同じ `validatePlay` を通す `GetValidPlayIndices`** がすでにあり、`interfaces/euchre.go` にも出ています。**presenter がそれを呼んでいなかっただけ**です。移植も再実装もしていないので、CUI と Web と実際の検証がずれる余地がありません。

## 手番でないときは印を付けません

手番プレイヤーの合法手をそのまま人間の手札に当てると、**出せない札に印が付きます**。プレイフェーズ外でも同様です。

## 負のコントロール

| 壊し方 | 落ちる件数 |
|---|---|
| CPU 手番でも印を付ける | 2 |
| フェーズを見ない | 2 |
| presenter が印を出さない | 2 |

## 検証

- `go test -tags test ./internal/...` ✅ / `golangci-lint run ./internal/...` → `0 issues.` ✅ / `gofmt -l internal/` 空 ✅

Closes #4781