### PR TITLE
feat: show FreeCell supermove limit in the CUI

### DIFF
--- a/internal/adapter/presenter/FreeCellCuiPresenter.go
+++ b/internal/adapter/presenter/FreeCellCuiPresenter.go
@@ -13,6 +13,28 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
+// freeCellEmptyCells は空いているフリーセルの数を返す。
+func freeCellEmptyCells(f interfaces.FreeCellGame) int {
+	n := 0
+	for _, c := range f.GetFreeCells() {
+		if c == nil {
+			n++
+		}
+	}
+	return n
+}
+
+// freeCellEmptyColumns は空いているタブロー列の数を返す。
+func freeCellEmptyColumns(f interfaces.FreeCellGame) int {
+	n := 0
+	for _, col := range f.GetTableau() {
+		if len(col) == 0 {
+			n++
+		}
+	}
+	return n
+}
+
 // FreeCellCuiPresenter renders the FreeCell Solitaire CUI view.
 type FreeCellCuiPresenter struct{}
 
@@ -76,6 +98,21 @@ func (p *FreeCellCuiPresenter) Output(f interfaces.FreeCellGame, lastErr error) 
 			if f.IsStalemate() {
 				b.WriteString(color.Red(i18n.T("cuiSolitaireStalemate")) + "\n")
 			}
+			// **何枚まとめて動かせるかは CUI に出ていなかった (#4777)。**Web は
+			// fc-supermove-limit で常時出し、上限を超える列には赤いリングまで
+			// 付けている。CUI は空きフリーセル数と空き列数から暗算するか、
+			// 実際に動かしてエラーになるまで分からなかった。
+			b.WriteString(i18n.Tf("freecell.supermoveLine",
+				"limit", strconv.Itoa(f.GetMaxMovableCards()),
+				"cells", strconv.Itoa(freeCellEmptyCells(f)),
+				"cols", strconv.Itoa(freeCellEmptyColumns(f))))
+			// **空き列を移動先にすると上限は下がる。**その列自身を経由地に
+			// 使えないため。空き列があるときだけ出す。
+			if toEmpty := f.GetMaxMovableCardsToEmptyColumn(); toEmpty > 0 {
+				b.WriteString(i18n.Tf("freecell.supermoveToEmpty",
+					"limit", strconv.Itoa(toEmpty)))
+			}
+			b.WriteString("\n")
 			b.WriteString(i18n.Tf("cuiSolitaireMoves",
 				"count", strconv.Itoa(f.GetMoveCount())) + "\n")
 		case domain.FreeCellPhaseGameClear:

--- a/internal/adapter/presenter/FreeCellCuiPresenter_test.go
+++ b/internal/adapter/presenter/FreeCellCuiPresenter_test.go
@@ -234,3 +234,58 @@ func TestFreeCellCuiPresenterActionLogGameOver(t *testing.T) {
 
 	assert.Contains(t, result, "棋譜")
 }
+
+// **何枚まとめて動かせるかが CUI に出ていなかった (#4777)。**姉妹ゲームの
+// Seahaven Towers は supermoveLine を出している。
+func TestFreeCellCuiPresenterOutput_SupermoveLine(t *testing.T) {
+	p := new(FreeCellCuiPresenter)
+	card := func(v int) *domain.Card { return domain.NewCard(domain.CardDesignSpade, v, false) }
+	board := func(filledCells, filledCols int) *domain.FreeCell {
+		f := domain.NewFreeCell(domain.NewTrumpCards(0))
+		f.Reset()
+		f.SetPhase(domain.FreeCellPhasePlaying)
+		var cells [domain.FreeCellCellCnt]*domain.Card
+		for i := 0; i < filledCells && i < domain.FreeCellCellCnt; i++ {
+			cells[i] = card(i + 2)
+		}
+		f.SetFreeCells(cells)
+		var tableau [domain.FreeCellTableauCnt][]*domain.Card
+		for i := 0; i < domain.FreeCellTableauCnt; i++ {
+			if i < filledCols {
+				tableau[i] = []*domain.Card{card(5)}
+			}
+		}
+		f.SetTableau(tableau)
+		return f
+	}
+
+	t.Run("names the limit and what it is made of", func(t *testing.T) {
+		out := p.Output(board(0, domain.FreeCellTableauCnt), nil)
+		assert.Contains(t, out, "最大5枚")
+		assert.Contains(t, out, "空きセル4")
+		assert.Contains(t, out, "空き列0")
+	})
+
+	// **空き列があるときだけ、そこへ置く上限も出す。**同じ数だと嘘になる。
+	t.Run("adds the lower empty-column limit when one exists", func(t *testing.T) {
+		out := p.Output(board(0, domain.FreeCellTableauCnt-1), nil)
+		assert.Contains(t, out, "最大10枚")
+		assert.Contains(t, out, "空き列へは5枚")
+	})
+
+	t.Run("omits the empty-column limit when no column is empty", func(t *testing.T) {
+		out := p.Output(board(0, domain.FreeCellTableauCnt), nil)
+		assert.NotContains(t, out, "空き列へは")
+	})
+
+	t.Run("shows a limit of one when the board is packed", func(t *testing.T) {
+		out := p.Output(board(domain.FreeCellCellCnt, domain.FreeCellTableauCnt), nil)
+		assert.Contains(t, out, "最大1枚")
+	})
+
+	t.Run("shows nothing once the game is cleared", func(t *testing.T) {
+		f := board(0, domain.FreeCellTableauCnt)
+		f.SetPhase(domain.FreeCellPhaseGameClear)
+		assert.NotContains(t, p.Output(f, nil), "一括移動")
+	})
+}

--- a/internal/domain/FreeCell.go
+++ b/internal/domain/FreeCell.go
@@ -685,6 +685,26 @@ func (f *FreeCell) isValidTableauSequence(cards []*Card) bool {
 	return true
 }
 
+// GetMaxMovableCards はいま一度に動かせる最大枚数を返す (#4777)。
+//
+// **空き列を移動先にすると上限は下がる。**その列自身は「経由地」に使えない
+// ため。移動先を選ぶ前の一般的な上限がこちらで、空き列に置くときの上限は
+// GetMaxMovableCardsToEmptyColumn。
+func (f *FreeCell) GetMaxMovableCards() int {
+	return f.maxMovableCards(-1)
+}
+
+// GetMaxMovableCardsToEmptyColumn は空き列へ動かすときの上限を返す。
+// 空き列が無いときは 0。
+func (f *FreeCell) GetMaxMovableCardsToEmptyColumn() int {
+	for i := 0; i < FreeCellTableauCnt; i++ {
+		if len(f.tableau[i]) == 0 {
+			return f.maxMovableCards(i)
+		}
+	}
+	return 0
+}
+
 // maxMovableCards 移動可能な最大カード枚数を計算
 // (1 + emptyFreeCells) * 2^(emptyTableauCols) ただしtoColが空の場合はそのcolを除外
 func (f *FreeCell) maxMovableCards(toCol int) int {

--- a/internal/domain/FreeCell_test.go
+++ b/internal/domain/FreeCell_test.go
@@ -1178,3 +1178,70 @@ func TestFreeCellUndoN_Excessive(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "undo step")
 }
+
+// **何枚まとめて動かせるかは CUI に出ていなかった (#4777)。**Web は
+// fc-supermove-limit で常時出している。
+func TestFreeCell_GetMaxMovableCards(t *testing.T) {
+	card := func(v int) *Card { return NewCard(CardDesignSpade, v, false) }
+	board := func(filledCells int, filledCols int) *FreeCell {
+		f := NewFreeCell(NewTrumpCards(0))
+		f.Reset()
+		var cells [FreeCellCellCnt]*Card
+		for i := 0; i < filledCells && i < FreeCellCellCnt; i++ {
+			cells[i] = card(i + 2)
+		}
+		f.SetFreeCells(cells)
+		var tableau [FreeCellTableauCnt][]*Card
+		for i := 0; i < FreeCellTableauCnt; i++ {
+			if i < filledCols {
+				tableau[i] = []*Card{card(5)}
+			}
+		}
+		f.SetTableau(tableau)
+		return f
+	}
+
+	// **(1 + 空きセル) × 2^(空き列)。**セルは足し算、列は掛け算。
+	t.Run("counts free cells additively and empty columns as doubling", func(t *testing.T) {
+		// セル4つ空き・列は全部埋まり → (1+4) << 0 = 5。
+		assert.Equal(t, 5, board(0, FreeCellTableauCnt).GetMaxMovableCards())
+		// セル4つ空き・列1つ空き → (1+4) << 1 = 10。
+		assert.Equal(t, 10, board(0, FreeCellTableauCnt-1).GetMaxMovableCards())
+		// セル4つ空き・列2つ空き → (1+4) << 2 = 20。
+		assert.Equal(t, 20, board(0, FreeCellTableauCnt-2).GetMaxMovableCards())
+	})
+
+	// **一般の上限はどの列も除外しない。**特定の列を除外した値を返すと、
+	// 空き列が1つ少ない前提の小さすぎる数を出すことになる。
+	t.Run("the general limit excludes no column, not even the first", func(t *testing.T) {
+		f := NewFreeCell(NewTrumpCards(0))
+		f.Reset()
+		f.SetFreeCells([FreeCellCellCnt]*Card{})
+		var tableau [FreeCellTableauCnt][]*Card
+		// 0 列目だけを空にし、残りを埋める。
+		for i := 1; i < FreeCellTableauCnt; i++ {
+			tableau[i] = []*Card{card(5)}
+		}
+		f.SetTableau(tableau)
+		assert.Equal(t, 10, f.GetMaxMovableCards(), "(1+4) << 1")
+	})
+
+	t.Run("a filled free cell lowers the limit", func(t *testing.T) {
+		assert.Equal(t, 4, board(1, FreeCellTableauCnt).GetMaxMovableCards())
+	})
+
+	t.Run("with everything full only a single card moves", func(t *testing.T) {
+		assert.Equal(t, 1, board(FreeCellCellCnt, FreeCellTableauCnt).GetMaxMovableCards())
+	})
+
+	// **空き列を移動先にすると上限は下がる。**その列自身を経由地に使えない。
+	t.Run("moving onto an empty column halves the limit", func(t *testing.T) {
+		f := board(0, FreeCellTableauCnt-1)
+		assert.Equal(t, 10, f.GetMaxMovableCards())
+		assert.Equal(t, 5, f.GetMaxMovableCardsToEmptyColumn())
+	})
+
+	t.Run("reports zero when there is no empty column to move onto", func(t *testing.T) {
+		assert.Equal(t, 0, board(0, FreeCellTableauCnt).GetMaxMovableCardsToEmptyColumn())
+	})
+}

--- a/internal/domain/interfaces/freecell.go
+++ b/internal/domain/interfaces/freecell.go
@@ -29,6 +29,10 @@ type FreeCellGame interface {
 	GetMoveCount() int
 	// GetTableau タブローを取得する
 	GetTableau() [domain.FreeCellTableauCnt][]*domain.Card
+	// GetMaxMovableCards いま一度に動かせる最大枚数を取得する
+	GetMaxMovableCards() int
+	// GetMaxMovableCardsToEmptyColumn 空き列へ動かすときの上限を取得する
+	GetMaxMovableCardsToEmptyColumn() int
 	// GetFreeCells フリーセルを取得する
 	GetFreeCells() [domain.FreeCellCellCnt]*domain.Card
 	// GetFoundation ファンデーションを取得する

--- a/internal/domain/interfaces/freecell_mock.go
+++ b/internal/domain/interfaces/freecell_mock.go
@@ -100,6 +100,16 @@ func (_m *MockFreeCellGame) GetFreeCells() [domain.FreeCellCellCnt]*domain.Card 
 	return ret.Get(0).([domain.FreeCellCellCnt]*domain.Card)
 }
 
+func (_m *MockFreeCellGame) GetMaxMovableCards() int {
+	args := _m.Called()
+	return args.Int(0)
+}
+
+func (_m *MockFreeCellGame) GetMaxMovableCardsToEmptyColumn() int {
+	args := _m.Called()
+	return args.Int(0)
+}
+
 func (_m *MockFreeCellGame) GetFoundation() [domain.FreeCellFoundationCnt][]*domain.Card {
 	ret := _m.Called()
 	return ret.Get(0).([domain.FreeCellFoundationCnt][]*domain.Card)

--- a/internal/i18n/locales/en/freecell.json
+++ b/internal/i18n/locales/en/freecell.json
@@ -19,5 +19,7 @@
   "hintToFoundation": "foundation",
   "hintToTableau": "tableau column {{col}}",
   "hintToFreeCell": "free cell {{col}}",
-  "hintLine": "Hint: {{from}} → {{to}}"
+  "hintLine": "Hint: {{from}} → {{to}}",
+  "supermoveLine": "Supermove: up to {{limit}} cards (free cells {{cells}} / empty columns {{cols}})",
+  "supermoveToEmpty": " / {{limit}} onto an empty column"
 }

--- a/internal/i18n/locales/ja/freecell.json
+++ b/internal/i18n/locales/ja/freecell.json
@@ -19,5 +19,7 @@
   "hintToFoundation": "ファンデーション",
   "hintToTableau": "タブロー列{{col}}",
   "hintToFreeCell": "フリーセル{{col}}",
-  "hintLine": "ヒント: {{from}} → {{to}}"
+  "hintLine": "ヒント: {{from}} → {{to}}",
+  "supermoveLine": "一括移動: 最大{{limit}}枚 (空きセル{{cells}} / 空き列{{cols}})",
+  "supermoveToEmpty": " / 空き列へは{{limit}}枚"
 }


### PR DESCRIPTION
## 背景

`FreeCellPage.tsx` は `(1 + emptyFreeCells) * 2 ** emptyTableauCols` を `fc-supermove-limit` で常時表示し、上限を超えるカード列には赤いリングとツールチップまで付けます。

姉妹ゲームの `SeahavenTowersCuiPresenter` も `supermoveLine` を出しているのに、**FreeCell の CUI だけ何も出していませんでした** (#4777)。空きフリーセル数と空き列数から暗算するか、実際に動かしてエラーになるまで分かりません。

```
一括移動: 最大10枚 (空きセル4 / 空き列1) / 空き列へは5枚
```

## 空き列を移動先にすると上限は下がります

**その列自身を経由地に使えない**ためです。一般の上限と空き列への上限を分けて出します（空き列が無いときは後者を出しません）。同じ数を出すと嘘になるので、一般の上限をそのまま使うとテストが**6件**落ちます。

## 一般の上限はどの列も除外しません

特定の列を除外した値を返すと、**空き列が1つ少ない前提の小さすぎる数**になります。この負のコントロールは当初 0件でした（テスト盤面で 0 列目が常に埋まっていて、除外しても値が変わらなかった）。**0 列目だけを空にした盤面**を足して踏むようにしています。

## 計算はドメインのものをそのまま使います

`maxMovableCards` は `MoveCards` の検証が使っている関数です。**移動が通る条件と表示が同じ関数から出る**ので、ずれません。

## 負のコントロール

| 壊し方 | 落ちる件数 |
|---|---|
| 空き列への上限を一般の上限と同じにする | 6 |
| 行のキーを壊す（行が出ない） | 4 |
| 一般の上限で 0 列目を除外する | 2 |
| 空き列が無くても空き列上限を出す | 2 |

## 検証

- `go test -tags test ./internal/...` ✅ / `golangci-lint run ./internal/...` → `0 issues.` ✅ / `gofmt -l internal/` 空 ✅
- `check-message-codes: OK (all 775 codes …)` ✅

Closes #4777