### PR TITLE
feat: tell the Klondike CUI when auto-complete becomes available

### DIFF
--- a/internal/adapter/presenter/KlondikeCuiPresenter.go
+++ b/internal/adapter/presenter/KlondikeCuiPresenter.go
@@ -114,6 +114,13 @@ func (p *KlondikeCuiPresenter) Output(k interfaces.KlondikeGame, lastErr error) 
 			if k.IsStalemate() {
 				b.WriteString(color.Red(i18n.T("cuiSolitaireStalemate")) + "\n")
 			}
+			// **もう自動で揃えられることを能動的に知らせる (#4776)。**Web は
+			// 条件が揃うとボタンを光らせバッジも出すのに、CUI は ac コマンドが
+			// あること自体も、いま使えるかも出していなかった。タブロー全体を
+			// 目で確認して自分で判断するしかない。
+			if k.CanAutoComplete() {
+				b.WriteString(color.Green(i18n.T("klondike.autoCompleteReady")) + "\n")
+			}
 			b.WriteString(i18n.Tf("cuiSolitaireMoves",
 				"count", strconv.Itoa(k.GetMoveCount())) + "\n")
 		case domain.KlondikePhaseGameClear:

--- a/internal/adapter/presenter/KlondikeCuiPresenter_test.go
+++ b/internal/adapter/presenter/KlondikeCuiPresenter_test.go
@@ -19,6 +19,7 @@ func setupKlondikeCuiMockDefaults(kg *interfaces.MockKlondikeGame) {
 	kg.On("GetStockCount").Return(24).Maybe()
 	kg.On("GetWaste").Return(([]*domain.Card)(nil)).Maybe()
 	kg.On("IsStalemate").Return(false).Maybe()
+	kg.On("CanAutoComplete").Return(false).Maybe()
 	kg.On("GetDrawCount").Return(1).Maybe()
 	kg.On("GetScore").Return(0).Maybe()
 	kg.On("GetScoringMode").Return(domain.KlondikeScoringNone).Maybe()
@@ -144,6 +145,7 @@ func TestKlondikeCuiPresenter_Output(t *testing.T) {
 		kg := new(interfaces.MockKlondikeGame)
 		setupKlondikeCuiMockDefaults(kg)
 		kg.ExpectedCalls = filterCalls(kg.ExpectedCalls, "IsStalemate")
+		kg.On("CanAutoComplete").Return(false).Maybe()
 		kg.On("IsStalemate").Return(true)
 
 		p := new(KlondikeCuiPresenter)
@@ -278,4 +280,34 @@ func filterCalls(calls []*mock.Call, methodName string) []*mock.Call {
 		}
 	}
 	return result
+}
+
+// **オートコンプリートが使える状態かを CUI は出していなかった (#4776)。**
+// ac コマンド自体はあるのに、その存在も、いま使えるかも分からない。
+func TestKlondikeCuiPresenter_AutoCompleteReady(t *testing.T) {
+	p := new(KlondikeCuiPresenter)
+	game := func(ready bool, phase domain.KlondikePhase) *interfaces.MockKlondikeGame {
+		kg := new(interfaces.MockKlondikeGame)
+		kg.On("CanAutoComplete").Return(ready)
+		kg.On("GetPhase").Return(phase)
+		setupKlondikeCuiMockDefaults(kg)
+		return kg
+	}
+
+	t.Run("announces the ready state with the command to use", func(t *testing.T) {
+		out := p.Output(game(true, domain.KlondikePhasePlaying), nil)
+		assert.Contains(t, out, "オートコンプリート可能")
+		// **コマンド名まで出す。**使えると分かってもコマンドが分からなければ同じ。
+		assert.Contains(t, out, "ac")
+	})
+
+	t.Run("says nothing while it is not available", func(t *testing.T) {
+		out := p.Output(game(false, domain.KlondikePhasePlaying), nil)
+		assert.NotContains(t, out, "オートコンプリート可能")
+	})
+
+	t.Run("says nothing once the game is cleared", func(t *testing.T) {
+		out := p.Output(game(false, domain.KlondikePhaseGameClear), nil)
+		assert.NotContains(t, out, "オートコンプリート可能")
+	})
 }

--- a/internal/domain/Klondike.go
+++ b/internal/domain/Klondike.go
@@ -479,6 +479,15 @@ func (k *Klondike) AutoComplete() error {
 	return nil
 }
 
+// CanAutoComplete はいまオートコンプリートが実行できるかを返す (#4776)。
+//
+// **AutoComplete が通る条件と同じものを見る。**Web は条件が揃うとボタンを
+// 光らせてバッジも出すのに、CUI は ac コマンドがあること自体もいま使えるかも
+// 出していなかった。表示と実行が別条件だと、光っているのに動かない。
+func (k *Klondike) CanAutoComplete() bool {
+	return k.phase == KlondikePhasePlaying && k.AllFaceUp()
+}
+
 // AllFaceUp 全カードが表向きかどうか（ストックとウェイストも含む）
 func (k *Klondike) AllFaceUp() bool {
 	if len(k.stock) > 0 {

--- a/internal/domain/Klondike_test.go
+++ b/internal/domain/Klondike_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 )
@@ -1272,4 +1273,55 @@ func TestKlondike_UndoN_Excessive(t *testing.T) {
 	err := k.UndoN(5)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "undo step")
+}
+
+// **もう自動で揃えられることを CUI は知らせていなかった (#4776)。**Web は
+// 条件が揃うとボタンを光らせバッジも出す。
+func TestKlondike_CanAutoComplete(t *testing.T) {
+	card := func(v int) *domain.Card { return domain.NewCard(domain.CardDesignSpade, v, false) }
+	board := func(stock []*domain.Card, faceDown bool) *domain.Klondike {
+		k := domain.NewKlondike(domain.NewTrumpCards(0))
+		k.Reset()
+		k.SetPhase(domain.KlondikePhasePlaying)
+		k.SetStock(stock)
+		var tableau [domain.KlondikeTableauCnt][]*domain.KlondikeTableauCard
+		for i := range tableau {
+			tableau[i] = []*domain.KlondikeTableauCard{{Card: card(i + 2), FaceUp: true}}
+		}
+		if faceDown {
+			tableau[0][0].FaceUp = false
+		}
+		k.SetTableau(tableau)
+		return k
+	}
+
+	t.Run("ready once the stock is empty and everything is face up", func(t *testing.T) {
+		assert.True(t, board(nil, false).CanAutoComplete())
+	})
+
+	// **山札が残っていれば駄目。**まだ引ける札があるうちは全部見えていない。
+	t.Run("not ready while cards remain in the stock", func(t *testing.T) {
+		assert.False(t, board([]*domain.Card{card(5)}, false).CanAutoComplete())
+	})
+
+	t.Run("not ready while a tableau card is face down", func(t *testing.T) {
+		assert.False(t, board(nil, true).CanAutoComplete())
+	})
+
+	t.Run("not ready outside the playing phase", func(t *testing.T) {
+		k := board(nil, false)
+		k.SetPhase(domain.KlondikePhaseGameClear)
+		assert.False(t, k.CanAutoComplete())
+	})
+
+	// **表示の条件と AutoComplete が通る条件は同じでなければならない。**
+	t.Run("agrees with AutoComplete", func(t *testing.T) {
+		ready := board(nil, false)
+		require.True(t, ready.CanAutoComplete())
+		assert.NoError(t, ready.AutoComplete())
+
+		blocked := board([]*domain.Card{card(5)}, false)
+		require.False(t, blocked.CanAutoComplete())
+		assert.Error(t, blocked.AutoComplete())
+	})
 }

--- a/internal/domain/interfaces/klondike.go
+++ b/internal/domain/interfaces/klondike.go
@@ -39,6 +39,8 @@ type KlondikeGame interface {
 	GetFoundation() [domain.KlondikeFoundationCnt][]*domain.Card
 	// AllFaceUp 全カードが表向きかを返す
 	AllFaceUp() bool
+	// CanAutoComplete いまオートコンプリートが実行できるかを返す
+	CanAutoComplete() bool
 	// GetDrawCount ドロー枚数設定を取得する
 	GetDrawCount() int
 	// GetScore 現在のスコアを取得する

--- a/internal/domain/interfaces/klondike_mock.go
+++ b/internal/domain/interfaces/klondike_mock.go
@@ -123,6 +123,11 @@ func (_m *MockKlondikeGame) AllFaceUp() bool {
 	return ret.Bool(0)
 }
 
+func (_m *MockKlondikeGame) CanAutoComplete() bool {
+	args := _m.Called()
+	return args.Bool(0)
+}
+
 func (_m *MockKlondikeGame) GetActionLog() []*domain.ActionLogEntry {
 	ret := _m.Called()
 	v := ret.Get(0)

--- a/internal/i18n/locales/en/klondike.json
+++ b/internal/i18n/locales/en/klondike.json
@@ -24,5 +24,6 @@
   "hintFromWaste": "waste",
   "hintToFoundation": "foundation",
   "hintToTableau": "tableau column {{col}}",
-  "hintLine": "Hint: {{from}} → {{to}}"
+  "hintLine": "Hint: {{from}} → {{to}}",
+  "autoCompleteReady": "Auto-complete is available (ac)"
 }

--- a/internal/i18n/locales/ja/klondike.json
+++ b/internal/i18n/locales/ja/klondike.json
@@ -24,5 +24,6 @@
   "hintFromWaste": "ウェイスト",
   "hintToFoundation": "ファンデーション",
   "hintToTableau": "タブロー列{{col}}",
-  "hintLine": "ヒント: {{from}} → {{to}}"
+  "hintLine": "ヒント: {{from}} → {{to}}",
+  "autoCompleteReady": "オートコンプリート可能です (ac)"
 }


### PR DESCRIPTION
## 背景

`KlondikePage.tsx` は `stockCount === 0 && isTableauAllFaceUp(...)` を計算し、条件が揃うと「オートコンプリート」ボタンに `animate-pulse ring-2 ring-ds-success` を付け、`AutoCompleteReadyBadge` も表示します。

`KlondikeCuiPresenter.Output` は**この状態に一切触れません** (#4776)。CUI には `ac` コマンド自体はあるので機能はありますが、**その存在も、いま使えるかも**、タブロー全体を目で確認して自分で判断するしかありませんでした。

```
オートコンプリート可能です (ac)
手数: 42
```

**コマンド名まで出します。**使えると分かってもコマンドが分からなければ同じことです。

## 表示の条件と `AutoComplete` が通る条件を同じにします

別々だと「**光っているのに動かない**」（あるいはその逆）が起きます。`CanAutoComplete` をドメインに置き、`AutoComplete` と同じ条件（プレイ中 かつ `AllFaceUp`）を見ます。「表示される ⇔ `AutoComplete` が成功する」をテストで固定しました。

## 負のコントロール

| 壊し方 | 落ちる件数 |
|---|---|
| 表向き判定を見ない | 4 |
| フェーズを見ない | 2 |
| presenter が行を出さない | 2 |

## 検証

- `go test -tags test ./internal/...` ✅ / `golangci-lint run ./internal/...` → `0 issues.` ✅ / `gofmt -l internal/` 空 ✅
- `check-message-codes: OK (all 775 codes …)` ✅

Closes #4776