### PR TITLE
feat: show All Fours High/Low/Jack/Game while the round is still running

### DIFF
--- a/frontend/src/i18n/locales/en/allfours.json
+++ b/frontend/src/i18n/locales/en/allfours.json
@@ -52,7 +52,8 @@
     "low": "Low",
     "jack": "Jack",
     "game": "Game",
-    "none": "−"
+    "none": "−",
+    "provisional": "(provisional — remaining trumps can change this)"
   },
   "hint": {
     "begBeg": "weak hand, so beg",

--- a/frontend/src/i18n/locales/ja/allfours.json
+++ b/frontend/src/i18n/locales/ja/allfours.json
@@ -52,7 +52,8 @@
     "low": "Low",
     "jack": "Jack",
     "game": "Game",
-    "none": "−"
+    "none": "−",
+    "provisional": "（暫定 — 残りのトランプで変わります）"
   },
   "hint": {
     "begBeg": "弱い手札なのでベグ",

--- a/frontend/src/pages/AllFoursPage.test.tsx
+++ b/frontend/src/pages/AllFoursPage.test.tsx
@@ -204,6 +204,7 @@ describe('AllFoursPage', () => {
         low: { winnerIdx: 1, card: { design: 'HEART', value: 2 } },
         jack: { winnerIdx: 0 },
         game: { winnerIdx: 0, points: [5, 0] },
+        provisional: false,
       },
     };
     mockExec.mockResolvedValueOnce(roundEndState);
@@ -225,6 +226,7 @@ describe('AllFoursPage', () => {
         low: { winnerIdx: 1, card: { design: 'HEART', value: 3 } },
         jack: { winnerIdx: -1 },
         game: { winnerIdx: -1, points: [0, 0] },
+        provisional: false,
       },
     };
     mockExec.mockResolvedValueOnce(roundEndState);
@@ -240,5 +242,43 @@ describe('AllFoursPage', () => {
     renderWithProviders(<AllFoursPage />);
     await waitFor(() => expect(mockExec).toHaveBeenCalled());
     expect(screen.queryByTestId('af-breakdown')).not.toBeInTheDocument();
+  });
+});
+
+// **High/Low/Jack/Game はトリックが進むたびに途中経過が確定していくのに、
+// ラウンド終了まで一切見えなかった (#4771)。**「今どちらが何を握っているか」は
+// このゲームの戦略そのもの。
+describe('AllFoursPage live breakdown', () => {
+  const playState = (provisional: boolean): AllFoursResponse => ({
+    ...baseState,
+    phase: provisional ? AllFoursPhase.PLAY : AllFoursPhase.ROUND_END,
+    roundBreakdown: {
+      high: { winnerIdx: 0, card: { design: 'HEART', value: 12 } },
+      low: { winnerIdx: 1, card: { design: 'HEART', value: 3 } },
+      jack: { winnerIdx: -1 },
+      game: { winnerIdx: 0, points: [5, 0] },
+      provisional,
+    },
+  });
+
+  it('shows the breakdown during the play phase', async () => {
+    mockExec.mockResolvedValueOnce(playState(true));
+    renderWithProviders(<AllFoursPage />);
+    expect(await screen.findByTestId('af-breakdown')).toBeInTheDocument();
+  });
+
+  // **暫定値を確定値として見せない。**まだ出ていないトランプで High も Low も
+  // 引っくり返る。
+  it('labels a mid-round breakdown as provisional', async () => {
+    mockExec.mockResolvedValueOnce(playState(true));
+    renderWithProviders(<AllFoursPage />);
+    expect(await screen.findByTestId('af-breakdown-provisional')).toBeInTheDocument();
+  });
+
+  it('does not label the settled breakdown as provisional', async () => {
+    mockExec.mockResolvedValueOnce(playState(false));
+    renderWithProviders(<AllFoursPage />);
+    await screen.findByTestId('af-breakdown');
+    expect(screen.queryByTestId('af-breakdown-provisional')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/AllFoursPage.tsx
+++ b/frontend/src/pages/AllFoursPage.tsx
@@ -278,12 +278,22 @@ function AllFoursPageContent() {
               </table>
             </div>
 
-            {(isRoundEnd || isGameEnd) && state.roundBreakdown && (
+            {state.roundBreakdown && (
               <div
                 data-testid="af-breakdown"
+                data-provisional={state.roundBreakdown.provisional ? 'true' : undefined}
                 className="border border-ds-border-subtle rounded p-2 mb-3 text-ds-text-primary"
               >
-                <div className="text-xs uppercase opacity-60 mb-1">{t('breakdown.title')}</div>
+                <div className="text-xs uppercase opacity-60 mb-1">
+                  {t('breakdown.title')}
+                  {/* **暫定値を確定値として見せない (#4771)。**まだ出ていない
+                      トランプで High も Low も引っくり返る。 */}
+                  {state.roundBreakdown.provisional && (
+                    <span className="ml-2 normal-case text-ds-warning" data-testid="af-breakdown-provisional">
+                      {t('breakdown.provisional')}
+                    </span>
+                  )}
+                </div>
                 <div className="overflow-x-auto">
                   <table className="text-sm w-full border-collapse">
                     <tbody>

--- a/frontend/src/types/games/allfours.ts
+++ b/frontend/src/types/games/allfours.ts
@@ -55,6 +55,14 @@ export interface AllFoursRoundBreakdown {
   jack: { winnerIdx: number };
   /** Game point (most card pips): winner (-1 on tie/zero) and per-player pip totals. */
   game: { winnerIdx: number; points: number[] };
+  /**
+   * Whether these are mid-round provisional values rather than the settled result.
+   *
+   * **High and Low are decided by the trumps that appear over the whole round,**
+   * so a trump still in someone's hand can take either away. The page labels a
+   * provisional table so it is not read as final (#4771).
+   */
+  provisional: boolean;
 }
 
 /** Full All Fours game state returned from the API. */
@@ -78,6 +86,7 @@ export interface AllFoursResponse extends BaseGameResponse {
   leadPlayerIdx: number;
   validPlayIndices: number[];
   /** Present only at ROUND_END / GAME_END: the High/Low/Jack/Game point breakdown. */
+  /** Present during PLAY (provisional) and at ROUND_END / GAME_END (settled). */
   roundBreakdown?: AllFoursRoundBreakdown;
   config: AllFoursConfig;
   hint?: AllFoursHint;

--- a/internal/adapter/controller/AllFoursWebController.go
+++ b/internal/adapter/controller/AllFoursWebController.go
@@ -69,6 +69,11 @@ type AllFoursWebOutputRoundBreakdown struct {
 	Low  AllFoursWebOutputBreakdownAward `json:"low"`
 	Jack AllFoursWebOutputBreakdownJack  `json:"jack"`
 	Game AllFoursWebOutputBreakdownGame  `json:"game"`
+	// Provisional はラウンド途中の暫定値であることを表す (#4771)。
+	//
+	// **途中経過を確定値として見せてはいけない。**High も Low も「そのラウンドで
+	// 出たトランプの中で」決まるので、まだ配られていない札で引っくり返る。
+	Provisional bool `json:"provisional"`
 }
 
 // AllFoursWebOutput All Fours Webアウトプット

--- a/internal/adapter/presenter/AllFoursWebPresenter.go
+++ b/internal/adapter/presenter/AllFoursWebPresenter.go
@@ -124,15 +124,23 @@ func allFoursPipValue(v int) int {
 // (場に出なければ -1)。Game = ピップ合計が単独最大のプレイヤー (同点・全員 0 なら -1)。
 func (p *AllFoursWebPresenter) buildRoundBreakdown(s interfaces.AllFoursGame) *controller.AllFoursWebOutputRoundBreakdown {
 	phase := s.GetPhase()
-	if phase != domain.AllFoursPhaseRoundEnd && phase != domain.AllFoursPhaseGameEnd {
+	// **プレイ中も出す (#4771)。**High / Low / Jack / Game はトリックが進むたびに
+	// 途中経過が確定していくのに、ラウンド終了まで隠れていた。「今どちらが何を
+	// 握っているか」はこのゲームの戦略そのもの。
+	//
+	// ただし途中の値は暫定。まだ出ていないトランプで High も Low も引っくり返る
+	// ので、Provisional を立てて画面側で確定値と区別させる。
+	final := phase == domain.AllFoursPhaseRoundEnd || phase == domain.AllFoursPhaseGameEnd
+	if !final && phase != domain.AllFoursPhasePlay {
 		return nil
 	}
 	playerCnt := s.GetPlayerCnt()
 	bd := &controller.AllFoursWebOutputRoundBreakdown{
-		High: controller.AllFoursWebOutputBreakdownAward{WinnerIdx: -1},
-		Low:  controller.AllFoursWebOutputBreakdownAward{WinnerIdx: -1},
-		Jack: controller.AllFoursWebOutputBreakdownJack{WinnerIdx: -1},
-		Game: controller.AllFoursWebOutputBreakdownGame{WinnerIdx: -1, Points: make([]int, playerCnt)},
+		High:        controller.AllFoursWebOutputBreakdownAward{WinnerIdx: -1},
+		Low:         controller.AllFoursWebOutputBreakdownAward{WinnerIdx: -1},
+		Jack:        controller.AllFoursWebOutputBreakdownJack{WinnerIdx: -1},
+		Game:        controller.AllFoursWebOutputBreakdownGame{WinnerIdx: -1, Points: make([]int, playerCnt)},
+		Provisional: !final,
 	}
 	trump := s.GetTrumpSuit()
 	if trump == domain.AllFoursTrumpUnset {

--- a/internal/adapter/presenter/AllFoursWebPresenter_test.go
+++ b/internal/adapter/presenter/AllFoursWebPresenter_test.go
@@ -142,8 +142,34 @@ func TestAllFoursWebPresenter_RoundBreakdown(t *testing.T) {
 		return resObj.RoundBreakdown
 	}
 
-	t.Run("nil breakdown while playing", func(t *testing.T) {
+	// **プレイ中も出す (#4771)。**High / Low / Jack / Game はトリックが進むたびに
+	// 途中経過が確定していくのに、ラウンド終了まで隠れていた。この t.Run は
+	// その挙動を「仕様」として固定していたので、中身を入れ替えた。
+	t.Run("breakdown is present during play, flagged provisional", func(t *testing.T) {
 		m, _ := setupAllFoursWebMockWithPlayers()
+		var resObj controller.AllFoursWebOutput
+		assert.NoError(t, json.Unmarshal([]byte(p.Output(m, nil)), &resObj))
+		if assert.NotNil(t, resObj.RoundBreakdown) {
+			assert.True(t, resObj.RoundBreakdown.Provisional,
+				"途中の値を確定値として渡してはいけない")
+		}
+	})
+
+	t.Run("the settled breakdown is not provisional", func(t *testing.T) {
+		m := setupRoundEnd(domain.CardDesignSpade, [][][]*domain.Card{
+			{{domain.NewCard(domain.CardDesignSpade, 1, false)}},
+			{{domain.NewCard(domain.CardDesignSpade, 2, false)}},
+		})
+		bd := decode(m)
+		if assert.NotNil(t, bd) {
+			assert.False(t, bd.Provisional)
+		}
+	})
+
+	t.Run("no breakdown before the trick play starts", func(t *testing.T) {
+		m, _ := setupAllFoursWebMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
+		m.On("GetPhase").Return(domain.AllFoursPhaseBeg)
 		var resObj controller.AllFoursWebOutput
 		assert.NoError(t, json.Unmarshal([]byte(p.Output(m, nil)), &resObj))
 		assert.Nil(t, resObj.RoundBreakdown)


### PR DESCRIPTION
## 背景

All Fours の得点源である **High（最高トランプ）・Low（最低トランプ）・Jack（トランプJ捕獲）・Game（ピップ合計最大）** は、いずれもトリックがプレイされるたびに途中経過が確定していきます。

ところが `buildRoundBreakdown` はフェーズが ROUND_END / GAME_END でなければ `nil` を返し、ページも `(isRoundEnd || isGameEnd)` でしか描画しません (#4771)。**「今どちらが何を握っているか」というこのゲームの戦略の核が、ラウンドが終わるまで隠れていました。**

## 計算は既存のものがそのまま使えます

`buildRoundBreakdown` は `GetTricksTaken()` から積み上げているので、**プレイ中でも正しい途中経過が出ます**。フェーズの門を広げるだけで済みました。

この挙動を「仕様」として固定するテスト（`nil breakdown while playing`）があったので、中身を入れ替えています。

## 途中の値を確定値として見せません

**High も Low も「そのラウンドで出たトランプの中で」決まる**ので、まだ誰かの手札にあるトランプで引っくり返ります。`provisional` フラグを立て、画面に「（暫定 — 残りのトランプで変わります）」と明示します。フラグを立てない実装にすると2件落ちます。

ベグ/ギフトなど配り直し前のフェーズでは今までどおり出しません（全フェーズで出す実装にすると2件落ちる）。

## 負のコントロール

| 壊し方 | 落ちる件数 |
|---|---|
| プレイ中は出さない（元の挙動） | 2 |
| 暫定フラグを立てない | 2 |
| 全フェーズで出す | 2 |
| 暫定ラベルを描画しない | 1 (vitest) |

## 検証

- `go test -tags test ./internal/...` ✅ / `gofmt -l internal/` 空 ✅
- `bunx vitest run src/pages/AllFoursPage.test.tsx` → 21 passed ✅
- `bun run typecheck` ✅ / `bun run check` exit 0 ✅

Closes #4771