### PR TITLE
feat: show the Nap declarer's contract progress in the CUI

### DIFF
--- a/internal/adapter/presenter/NapCuiPresenter.go
+++ b/internal/adapter/presenter/NapCuiPresenter.go
@@ -108,7 +108,29 @@ func (p *NapCuiPresenter) Output(g interfaces.NapGame, lastErr error) string {
 	})
 }
 
-// writePrompt renders the phase-specific prompt block.
+// writeNapDeclarerProgress は宣言者の契約達成状況を1行で書く。
+//
+// **CUI は宣言者が何トリック取ったかを一切知らせていなかった (#4763)。**
+// Web は nap-declarer-progress で常時出しているのに、CLI プレイヤーは自分で
+// トリック数を数えるしかなかった。
+func writeNapDeclarerProgress(b *strings.Builder, g interfaces.NapGame) {
+	pr := g.GetDeclarerProgress()
+	if pr == nil {
+		return
+	}
+	line := i18n.Tf("nap.declarerProgress",
+		"won", strconv.Itoa(pr.Won),
+		"needed", strconv.Itoa(pr.Needed),
+		"remaining", strconv.Itoa(pr.Remaining))
+	// **もう届かないなら押す意味が変わる。**同じ文言だと区別が付かない。
+	if pr.Unreachable {
+		b.WriteString(color.BoldYellow(line+i18n.T("nap.contractUnreachable")) + "\n")
+		return
+	}
+	b.WriteString(line + "\n")
+}
+
+// writePrompt// writePrompt renders the phase-specific prompt block.
 func (p *NapCuiPresenter) writePrompt(b *strings.Builder, g interfaces.NapGame) {
 	switch g.GetPhase() {
 	case domain.NapPhaseBid:
@@ -124,11 +146,13 @@ func (p *NapCuiPresenter) writePrompt(b *strings.Builder, g interfaces.NapGame) 
 		}
 		b.WriteString(i18n.T("nap.promptBidHelp") + "\n")
 	case domain.NapPhasePlay:
+		writeNapDeclarerProgress(b, g)
 		currentIdx := g.GetCurrentPlayerIdx()
 		b.WriteString(i18n.Tf("nap.promptPlay",
 			"name", cuiPlayerName(g.GetPlayer(currentIdx), currentIdx)) + "\n")
 		b.WriteString(i18n.T("nap.promptPlayHelp") + "\n")
 	case domain.NapPhaseTrickEnd:
+		writeNapDeclarerProgress(b, g)
 		b.WriteString(i18n.T("nap.promptTrickEnd") + "\n")
 		b.WriteString(i18n.T("nap.promptTrickEndHelp") + "\n")
 	case domain.NapPhaseRoundEnd:

--- a/internal/adapter/presenter/NapCuiPresenter_test.go
+++ b/internal/adapter/presenter/NapCuiPresenter_test.go
@@ -41,6 +41,7 @@ func setupNapCuiMock() *interfaces.MockNapGame {
 	m.On("GetPhase").Return(domain.NapPhasePlay)
 	m.On("GetCurrentPlayerIdx").Return(0)
 	m.On("GetDeclarerIdx").Return(0)
+	m.On("GetDeclarerProgress").Return((*domain.NapDeclarerProgress)(nil)).Maybe()
 	m.On("GetContract").Return(domain.NapBidThree)
 	m.On("GetWinnerPlayer").Return(-1)
 	m.On("GetPlayerScores").Return([domain.NapPlayerCnt]int{0, 0, 0, 0})
@@ -172,4 +173,57 @@ func TestNapCuiPresenter_ActionLogOutput(t *testing.T) {
 	})
 	result := p.ActionLogOutput(m)
 	assert.Contains(t, result, "play")
+}
+
+// **CUI は宣言者が何トリック取ったかを一切知らせていなかった (#4763)。**
+// CLI プレイヤーは自分でトリック数を数えるしかなかった。
+func TestNapCuiPresenter_DeclarerProgress(t *testing.T) {
+	origNoColor := color.NoColor()
+	color.SetNoColor(true)
+	defer color.SetNoColor(origNoColor)
+	p := new(presenter.NapCuiPresenter)
+
+	withProgress := func(pr *domain.NapDeclarerProgress, phase domain.NapPhase) *interfaces.MockNapGame {
+		m, _ := setupNapCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetDeclarerProgress")
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
+		m.On("GetDeclarerProgress").Return(pr)
+		m.On("GetPhase").Return(phase)
+		return m
+	}
+
+	t.Run("shows tricks won, needed and remaining", func(t *testing.T) {
+		out := p.Output(withProgress(&domain.NapDeclarerProgress{
+			Won: 1, Needed: 3, Remaining: 3,
+		}, domain.NapPhasePlay), nil)
+		assert.Contains(t, out, "1/3")
+		assert.Contains(t, out, "残り3")
+	})
+
+	// **もう届かないなら押す意味が変わる。**同じ文言だと区別が付かない。
+	t.Run("calls out a contract that can no longer be made", func(t *testing.T) {
+		out := p.Output(withProgress(&domain.NapDeclarerProgress{
+			Won: 0, Needed: 5, Remaining: 4, Unreachable: true,
+		}, domain.NapPhasePlay), nil)
+		assert.Contains(t, out, "達成不可能")
+	})
+
+	t.Run("does not call a reachable contract unreachable", func(t *testing.T) {
+		out := p.Output(withProgress(&domain.NapDeclarerProgress{
+			Won: 1, Needed: 3, Remaining: 3,
+		}, domain.NapPhasePlay), nil)
+		assert.NotContains(t, out, "達成不可能")
+	})
+
+	t.Run("shows the progress at trick end too", func(t *testing.T) {
+		out := p.Output(withProgress(&domain.NapDeclarerProgress{
+			Won: 2, Needed: 3, Remaining: 2,
+		}, domain.NapPhaseTrickEnd), nil)
+		assert.Contains(t, out, "2/3")
+	})
+
+	t.Run("shows nothing when there is no declarer yet", func(t *testing.T) {
+		// 既存の「宣言者: あなた — スリー」行とは別物なので、進捗行だけを狙う。
+		assert.NotContains(t, p.Output(withProgress(nil, domain.NapPhasePlay), nil), "トリック (残り")
+	})
 }

--- a/internal/domain/Nap.go
+++ b/internal/domain/Nap.go
@@ -756,6 +756,51 @@ func (g *Nap) SetLeadPlayerIdx(idx int) { g.leadPlayerIdx = idx }
 // GetDealerIdx ディーラーインデックス取得
 func (g *Nap) GetDealerIdx() int { return g.dealerIdx }
 
+// NapDeclarerProgress は宣言者の契約達成状況。
+type NapDeclarerProgress struct {
+	// Won は宣言者がこれまでに取ったトリック数。
+	Won int
+	// Needed は契約に必要なトリック数。
+	Needed int
+	// Remaining は残りのトリック数。
+	Remaining int
+	// Unreachable はもう契約に届かないことが確定したか。
+	Unreachable bool
+}
+
+// GetDeclarerProgress は宣言者の契約達成状況を返す。宣言者が決まっていない、
+// またはプレイ中/トリック終了以外のフェーズでは nil。
+//
+// **CUI は宣言者が何トリック取ったかを一切知らせていなかった (#4763)。**
+// Web は nap-declarer-progress で常時出している。CLI プレイヤーは自分で
+// トリック数を数えるしかなかった。
+//
+// Nap は1ラウンド5トリックで、契約値 (2/3/4/5) がそのまま必要トリック数。
+func (g *Nap) GetDeclarerProgress() *NapDeclarerProgress {
+	if g.phase != NapPhasePlay && g.phase != NapPhaseTrickEnd {
+		return nil
+	}
+	if g.declarerIdx < 0 || g.declarerIdx >= len(g.players) {
+		return nil
+	}
+	played := 0
+	for _, p := range g.players {
+		played += p.GetTrickCount()
+	}
+	remaining := NapTrickCount - played
+	if remaining < 0 {
+		remaining = 0
+	}
+	won := g.players[g.declarerIdx].GetTrickCount()
+	needed := int(g.contract)
+	return &NapDeclarerProgress{
+		Won: won, Needed: needed, Remaining: remaining,
+		// **「もう届かない」は残りを全部取っても足りないときだけ。**早すぎる
+		// 判定は、まだ勝てるラウンドを投げさせる。
+		Unreachable: needed-won > remaining,
+	}
+}
+
 // GetDeclarerIdx 宣言者インデックス取得 (-1=未確定)
 func (g *Nap) GetDeclarerIdx() int { return g.declarerIdx }
 

--- a/internal/domain/Nap_test.go
+++ b/internal/domain/Nap_test.go
@@ -5,6 +5,8 @@ package domain
 import (
 	"encoding/json"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func napCard(design, value int) *Card { return NewCard(design, value, false) }
@@ -297,4 +299,69 @@ func TestNap_UnmarshalErrors(t *testing.T) {
 	if err := g.UnmarshalJSON([]byte(`{"ps":[null,null,null,null]}`)); err == nil {
 		t.Error("expected nil-player error")
 	}
+}
+
+// **CUI は宣言者が何トリック取ったかを一切知らせていなかった (#4763)。**
+// Web は nap-declarer-progress で常時出している。
+func TestNap_GetDeclarerProgress(t *testing.T) {
+	card := func(v int) *Card { return NewCard(CardDesignSpade, v, false) }
+	// declarer が won トリック、他プレイヤーが others トリック取った局面。
+	setup := func(contract NapBid, won, others int) *Nap {
+		g := NewDefaultNap()
+		g.Reset()
+		g.SetPhase(NapPhasePlay)
+		g.SetDeclarerIdx(0)
+		g.SetContract(contract)
+		for i := 0; i < won; i++ {
+			g.GetPlayer(0).AddTrick([]*Card{card(2)})
+		}
+		for i := 0; i < others; i++ {
+			g.GetPlayer(1).AddTrick([]*Card{card(3)})
+		}
+		return g
+	}
+
+	t.Run("nothing to report before a declarer is settled", func(t *testing.T) {
+		g := setup(NapBidThree, 0, 0)
+		g.SetDeclarerIdx(-1)
+		assert.Nil(t, g.GetDeclarerProgress())
+	})
+
+	t.Run("nothing to report outside the play phases", func(t *testing.T) {
+		g := setup(NapBidThree, 1, 1)
+		g.SetPhase(NapPhaseRoundEnd)
+		assert.Nil(t, g.GetDeclarerProgress())
+	})
+
+	t.Run("counts the declarer's tricks and what is left", func(t *testing.T) {
+		pr := setup(NapBidThree, 1, 1).GetDeclarerProgress()
+		if assert.NotNil(t, pr) {
+			assert.Equal(t, 1, pr.Won)
+			assert.Equal(t, 3, pr.Needed)
+			assert.Equal(t, NapTrickCount-2, pr.Remaining, "全員のトリックを引く")
+			assert.False(t, pr.Unreachable)
+		}
+	})
+
+	// **「もう届かない」は残りを全部取っても足りないときだけ。**早すぎる判定は
+	// まだ勝てるラウンドを投げさせる。
+	t.Run("declares failure only when even every remaining trick falls short", func(t *testing.T) {
+		// 契約5、宣言者0勝ち、相手1勝ち → 残り4。5-0=5 > 4 で不可能。
+		unreachable := setup(NapBidNap, 0, 1).GetDeclarerProgress()
+		if assert.NotNil(t, unreachable) {
+			assert.True(t, unreachable.Unreachable)
+		}
+		// 契約5、まだ誰も取っていない → 残り5。ちょうど届く見込みがある。
+		alive := setup(NapBidNap, 0, 0).GetDeclarerProgress()
+		if assert.NotNil(t, alive) {
+			assert.False(t, alive.Unreachable, "ちょうど届くうちは不可能にしない")
+		}
+	})
+
+	t.Run("stays reachable once the contract is already made", func(t *testing.T) {
+		pr := setup(NapBidThree, 3, 1).GetDeclarerProgress()
+		if assert.NotNil(t, pr) {
+			assert.False(t, pr.Unreachable)
+		}
+	})
 }

--- a/internal/domain/interfaces/nap.go
+++ b/internal/domain/interfaces/nap.go
@@ -51,6 +51,8 @@ type NapGame interface {
 	GetLeadPlayerIdx() int
 	// GetDealerIdx ディーラーインデックスを取得する
 	GetDealerIdx() int
+	// GetDeclarerProgress 宣言者の契約達成状況を取得する
+	GetDeclarerProgress() *domain.NapDeclarerProgress
 	// GetDeclarerIdx 宣言者インデックスを取得する (-1=未確定)
 	GetDeclarerIdx() int
 	// GetContract 確定した契約を取得する

--- a/internal/domain/interfaces/nap_mock.go
+++ b/internal/domain/interfaces/nap_mock.go
@@ -140,6 +140,14 @@ func (_m *MockNapGame) GetDeclarerIdx() int {
 	return ret.Get(0).(int)
 }
 
+func (_m *MockNapGame) GetDeclarerProgress() *domain.NapDeclarerProgress {
+	args := _m.Called()
+	if args.Get(0) == nil {
+		return nil
+	}
+	return args.Get(0).(*domain.NapDeclarerProgress)
+}
+
 // GetContract モック
 func (_m *MockNapGame) GetContract() domain.NapBid {
 	ret := _m.Called()

--- a/internal/i18n/locales/en/nap.json
+++ b/internal/i18n/locales/en/nap.json
@@ -39,5 +39,7 @@
   "roundEnd": "Round complete",
   "result.humanWin": "Game over! You win!",
   "result.cpuWin": "Game over! Player {{player}} wins!",
-  "promptBidHolder": "Current high bidder: {{name}}"
+  "promptBidHolder": "Current high bidder: {{name}}",
+  "declarerProgress": "Declarer: {{won}}/{{needed}} tricks ({{remaining}} left)",
+  "contractUnreachable": " - the contract can no longer be made"
 }

--- a/internal/i18n/locales/ja/nap.json
+++ b/internal/i18n/locales/ja/nap.json
@@ -39,5 +39,7 @@
   "roundEnd": "ラウンド終了",
   "result.humanWin": "ゲーム終了！ あなたの勝ち！",
   "result.cpuWin": "ゲーム終了！ プレイヤー{{player}}の勝ち！",
-  "promptBidHolder": "現在の最高入札者: {{name}}"
+  "promptBidHolder": "現在の最高入札者: {{name}}",
+  "declarerProgress": "宣言者: {{won}}/{{needed}} トリック (残り{{remaining}})",
+  "contractUnreachable": " — 達成不可能が確定"
 }


### PR DESCRIPTION
## 背景

`NapPage.tsx` は `nap-declarer-progress` で「**宣言者が何トリック取ったか / 必要数 / 残り**」を常時表示し、達成不可能になれば色を変えて知らせます。

`NapCuiPresenter.writePrompt` は `promptPlay` / `promptTrickEnd` と Help 文しか出しません (#4763)。**CLI プレイヤーは自分でトリック数を数えるしかありませんでした。**

```
宣言者: 1/3 トリック (残り3)
手番: あなた
```

## 「もう届かない」は残りを全部取っても足りないときだけ

**早すぎる判定は、まだ勝てるラウンドを投げさせます。**`needed - won > remaining` で見ます。単に `needed > won`（=まだ達成していない）とするとテストが3件落ちます。

残りトリック数は**全員の獲得数を引いて**出します（引かない実装にすると3件落ちる）。

## 負のコントロール

| 壊し方 | 落ちる件数 |
|---|---|
| 早すぎる不可能判定 | 3 |
| 消化済みトリックを引かない | 3 |
| プレイ中に出さない | 3 |
| 不可能警告を出さない | 2 |

## 検証

- `go test -tags test ./internal/...` ✅ / `golangci-lint run ./internal/...` → `0 issues.` ✅ / `gofmt -l internal/` 空 ✅
- `check-message-codes: OK (all 775 codes …)` ✅

Closes #4763