### PR TITLE
feat: mark the lead seat and round winner in Knockout Whist CUI

### DIFF
--- a/internal/adapter/presenter/KnockoutWhistCuiPresenter.go
+++ b/internal/adapter/presenter/KnockoutWhistCuiPresenter.go
@@ -29,6 +29,15 @@ func knockoutWhistPlayerStr(g interfaces.KnockoutWhistGame, idx int) string {
 		return ""
 	}
 	var b strings.Builder
+	// **リード権と直前ラウンドの勝者が CUI に出ていなかった (#4762)。**Web は
+	// leader / roundWinner バッジを常時出している。SpoilFiveCuiPresenter に
+	// 同じ目的のマークがすでにあるので、体裁を揃える。
+	if idx == g.GetLeadPlayerIdx() {
+		b.WriteString(i18n.T("knockoutwhist.leaderMark"))
+	}
+	if idx == g.GetRoundWinnerIdx() {
+		b.WriteString(i18n.T("knockoutwhist.winnerMark"))
+	}
 	if player.GetEliminated() {
 		b.WriteString(i18n.Tf("knockoutwhist.playerLineEliminated",
 			"name", cuiPlayerName(player, idx)))

--- a/internal/adapter/presenter/KnockoutWhistCuiPresenter_test.go
+++ b/internal/adapter/presenter/KnockoutWhistCuiPresenter_test.go
@@ -4,6 +4,7 @@ package presenter_test
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,6 +30,8 @@ func setupKnockoutWhistCuiMock() *interfaces.MockKnockoutWhistGame {
 	m.On("GetHandSize").Return(7)
 	m.On("GetTrickNumber").Return(1)
 	m.On("GetTrumpSuit").Return(domain.CardDesignSpade)
+	m.On("GetLeadPlayerIdx").Return(-1).Maybe()
+	m.On("GetRoundWinnerIdx").Return(-1).Maybe()
 	m.On("GetCurrentTrick").Return(([]*domain.TrickCard)(nil))
 	m.On("GetGameEndFlag").Return(false)
 	m.On("GetPhase").Return(domain.KnockoutWhistPhasePlay)
@@ -152,8 +155,51 @@ func TestKnockoutWhistCuiPresenter_TrumpSelectPrompt(t *testing.T) {
 	m, _ := setupKnockoutWhistCuiMockWithPlayers()
 	m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
 	m.On("GetPhase").Return(domain.KnockoutWhistPhaseTrumpSelect)
+	m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetLeadPlayerIdx")
 	m.On("GetLeadPlayerIdx").Return(0)
 
 	result := p.Output(m, nil)
 	assert.Contains(t, result, "st <1-4>") // help line advertising the select-trump command
+}
+
+// **リード権と直前ラウンドの勝者が CUI に出ていなかった (#4762)。**Web は
+// leader / roundWinner バッジを常時出しており、SpoilFive の CUI にも同じ
+// 目的のマークがある。
+func TestKnockoutWhistCuiPresenter_LeaderAndWinnerMarks(t *testing.T) {
+	orig := color.NoColor()
+	color.SetNoColor(true)
+	defer color.SetNoColor(orig)
+	p := new(presenter.KnockoutWhistCuiPresenter)
+
+	withSeats := func(lead, winner int) *interfaces.MockKnockoutWhistGame {
+		m, _ := setupKnockoutWhistCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetLeadPlayerIdx")
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetRoundWinnerIdx")
+		m.On("GetLeadPlayerIdx").Return(lead)
+		m.On("GetRoundWinnerIdx").Return(winner)
+		return m
+	}
+
+	t.Run("marks the lead seat once", func(t *testing.T) {
+		out := p.Output(withSeats(1, -1), nil)
+		assert.Equal(t, 1, strings.Count(out, "▶(リード)"), "印が付くのは1席だけ")
+	})
+
+	t.Run("marks the round winner once", func(t *testing.T) {
+		out := p.Output(withSeats(-1, 2), nil)
+		assert.Equal(t, 1, strings.Count(out, "★(勝者)"))
+	})
+
+	// **同じ席がリードかつ勝者になることがある。**片方で上書きしない。
+	t.Run("marks a seat that is both lead and round winner", func(t *testing.T) {
+		out := p.Output(withSeats(0, 0), nil)
+		assert.Contains(t, out, "▶(リード)")
+		assert.Contains(t, out, "★(勝者)")
+	})
+
+	t.Run("marks nothing before either is decided", func(t *testing.T) {
+		out := p.Output(withSeats(-1, -1), nil)
+		assert.NotContains(t, out, "▶(リード)")
+		assert.NotContains(t, out, "★(勝者)")
+	})
 }

--- a/internal/i18n/locales/en/knockoutwhist.json
+++ b/internal/i18n/locales/en/knockoutwhist.json
@@ -21,5 +21,7 @@
   "hintReasonLeadHigh": "Lead a high card to seize the trick",
   "hintReasonFollowWin": "Win the trick to survive (trick tally matters)",
   "hintReasonFollowDuck": "Cannot win — follow with a low card",
-  "hintReasonDiscardLow": "Cannot follow suit — discard a low card"
+  "hintReasonDiscardLow": "Cannot follow suit — discard a low card",
+  "leaderMark": "▶(lead) ",
+  "winnerMark": "★(winner) "
 }

--- a/internal/i18n/locales/ja/knockoutwhist.json
+++ b/internal/i18n/locales/ja/knockoutwhist.json
@@ -21,5 +21,7 @@
   "hintReasonLeadHigh": "高い札でリードしてトリックを取りにいく",
   "hintReasonFollowWin": "トリックを取って生き残る（トリック数が重要）",
   "hintReasonFollowDuck": "取れないのでリードスートの低い札で受ける",
-  "hintReasonDiscardLow": "リードに従えないので低い札を捨てる"
+  "hintReasonDiscardLow": "リードに従えないので低い札を捨てる",
+  "leaderMark": "▶(リード) ",
+  "winnerMark": "★(勝者) "
 }


### PR DESCRIPTION
## 背景

`KnockoutWhistPage.tsx` の `renderPlayerPanel` は `leadPlayerIdx` / `roundWinnerIdx` から `leader` / `roundWinner` バッジを各プレイヤー行に常時表示します。

`knockoutWhistPlayerStr` は `GetEliminated()` で脱落表示を切り替えるだけで、**リード権も直前ラウンドの勝者も分かりません**でした (#4762)。

同じリポジトリの `SpoilFiveCuiPresenter` には**まったく同じ目的のマーク**（`spoilfive.leaderMark` / `spoilfive.winnerMark`）が実装済みなので、体裁を揃えました。

```
▶(リード) あなた: 5枚  トリック: 0  ドッグボーン: 0
★(勝者) CPU 1: 5枚  トリック: 0  ドッグボーン: 0
```

## 同じ席がリードかつ勝者になることがあります

**片方で上書きしません。**両方付くことをテストで固定しました。

判定に使う `GetLeadPlayerIdx` / `GetRoundWinnerIdx` は**どちらもインタフェースにすでに出ています**。presenter が読んでいなかっただけです。

## 負のコントロール

| 壊し方 | 落ちる件数 |
|---|---|
| リードマークを出さない | 3 |
| 勝者マークを出さない | 3 |
| リード判定を `>=` に緩める（複数席に付く） | 3 |

## 検証

- `go test -tags test ./internal/...` ✅ / `golangci-lint run ./internal/...` → `0 issues.` ✅ / `gofmt -l internal/` 空 ✅
- `check-message-codes: OK (all 775 codes …)` ✅

Closes #4762