### PR TITLE
feat: explain the Scopa round score in the CUI

### DIFF
--- a/internal/adapter/presenter/ScopaCuiPresenter.go
+++ b/internal/adapter/presenter/ScopaCuiPresenter.go
@@ -41,6 +41,11 @@ func (p *ScopaCuiPresenter) Output(sg interfaces.ScopaGame, lastErr error) strin
 			}
 		}
 
+		// **なぜその点数になったのかを CUI は一切出していなかった (#4756)。**
+		// Web はカルテ/デナリ/プリミエラ/セッテベッロごとに誰が取ったかを
+		// 出している。CUI は最終合計しか見えなかった。
+		writeScopaBreakdown(b, sg)
+
 		cuiErrorBlock(b, lastErr)
 
 		if sg.GetGameEndFlag() {
@@ -152,4 +157,46 @@ func (p *ScopaCuiPresenter) HintOutput(sg interfaces.ScopaGame) string {
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *ScopaCuiPresenter) ActionLogOutput(sg interfaces.ScopaGame) string {
 	return actionLogOutputText(sg)
+}
+
+// writeScopaBreakdown は直前ラウンドの得点内訳を書く。まだ1ラウンドも
+// 終わっていなければ何も書かない。
+func writeScopaBreakdown(b *strings.Builder, sg interfaces.ScopaGame) {
+	det := sg.GetLastRoundDetail()
+	if det == nil {
+		return
+	}
+	rows := domain.ScopaCategoryWinners(det)
+	if len(rows) == 0 {
+		return
+	}
+	b.WriteString("----------\n")
+	b.WriteString(i18n.T("scopa.breakdownHeader") + "\n")
+	for _, row := range rows {
+		// **同点・該当なしも書く。**行が消えると「誰かが取った」と読める。
+		name := i18n.T("scopa.breakdownNobody")
+		if row.Winner >= 0 {
+			if pl := sg.GetPlayer(row.Winner); pl != nil {
+				name = cuiPlayerName(pl, row.Winner)
+			}
+		}
+		b.WriteString(i18n.Tf("scopa.breakdownRow",
+			"category", i18n.T("scopa.category."+row.Key),
+			"name", name,
+			"points", strconv.Itoa(row.Points)) + "\n")
+	}
+	// スコパ回数は単独勝者ではなく人数ぶんの回数なので別に出す。
+	for i := 0; i < sg.GetPlayerCnt(); i++ {
+		n := det.Scopas[i]
+		if n == 0 {
+			continue
+		}
+		pl := sg.GetPlayer(i)
+		if pl == nil {
+			continue
+		}
+		b.WriteString(i18n.Tf("scopa.breakdownScopa",
+			"name", cuiPlayerName(pl, i),
+			"count", strconv.Itoa(n)) + "\n")
+	}
 }

--- a/internal/adapter/presenter/ScopaCuiPresenter_test.go
+++ b/internal/adapter/presenter/ScopaCuiPresenter_test.go
@@ -4,8 +4,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 )
 
 func buildPlayedScopa(t *testing.T) *domain.Scopa {
@@ -92,4 +95,71 @@ func TestScopaCuiPresenter_ActionLogOutput(t *testing.T) {
 	if out := p.ActionLogOutput(s); out == "" {
 		t.Error("expected non-empty action log output")
 	}
+}
+
+// **なぜその点数になったのかを CUI は一切出していなかった (#4756)。**Web は
+// カルテ/デナリ/プリミエラ/セッテベッロごとに誰が取ったかを出している。
+func TestScopaCuiPresenter_Breakdown(t *testing.T) {
+	p := &presenter.ScopaCuiPresenter{}
+	players := []*domain.ScopaPlayer{domain.NewScopaPlayer(true), domain.NewScopaPlayer(false)}
+	withDetail := func(det *domain.ScopaScoreDetail) *interfaces.MockScopaGame {
+		m := new(interfaces.MockScopaGame)
+		m.On("GetLastRoundDetail").Return(det)
+		m.On("GetPlayerCnt").Return(2).Maybe()
+		m.On("GetPlayer", 0).Return(players[0]).Maybe()
+		m.On("GetPlayer", 1).Return(players[1]).Maybe()
+		m.On("GetTableCards").Return(([]*domain.Card)(nil)).Maybe()
+		m.On("GetActions").Return(([]*domain.ScopaAction)(nil)).Maybe()
+		m.On("GetHumanAction").Return((*domain.ScopaAction)(nil)).Maybe()
+		m.On("GetCpuActions").Return(([]*domain.ScopaAction)(nil)).Maybe()
+		m.On("GetPhase").Return(domain.ScopaPhasePlayerTurn).Maybe()
+		m.On("GetGameEndFlag").Return(false).Maybe()
+		m.On("GetCurrentTurn").Return(0).Maybe()
+		m.On("GetDeckCount").Return(0).Maybe()
+		m.On("GetRoundNumber").Return(1).Maybe()
+		return m
+	}
+
+	t.Run("names who took each category and for how much", func(t *testing.T) {
+		out := p.Output(withDetail(&domain.ScopaScoreDetail{
+			Cards:         map[int]int{0: 21, 1: 19},
+			Diamonds:      map[int]int{0: 6, 1: 4},
+			Sevens:        map[int]int{0: 1, 1: 3},
+			HasSetteBello: 1,
+			Scopas:        map[int]int{0: 2},
+			Gained:        map[int]int{},
+		}), nil)
+		assert.Contains(t, out, "カルテ")
+		assert.Contains(t, out, "プリミエラ")
+		assert.Contains(t, out, "セッテベッロ")
+		assert.Contains(t, out, "スコパ")
+	})
+
+	// **同点は行を消さずに「なし」と書く。**行が消えると「誰かが取った」と読める。
+	t.Run("says nobody took a tied category", func(t *testing.T) {
+		out := p.Output(withDetail(&domain.ScopaScoreDetail{
+			Cards:         map[int]int{0: 20, 1: 20},
+			Diamonds:      map[int]int{0: 5, 1: 5},
+			Sevens:        map[int]int{0: 2, 1: 2},
+			HasSetteBello: -1,
+			Scopas:        map[int]int{},
+			Gained:        map[int]int{},
+		}), nil)
+		assert.Contains(t, out, "なし(同点)")
+		assert.Contains(t, out, "カルテ")
+	})
+
+	// **スコパ0回のプレイヤーは並べない。**「× 0」は情報にならない。
+	t.Run("lists sweeps only for players who made one", func(t *testing.T) {
+		out := p.Output(withDetail(&domain.ScopaScoreDetail{
+			Cards: map[int]int{0: 21, 1: 19}, Diamonds: map[int]int{0: 6},
+			Sevens: map[int]int{0: 4}, HasSetteBello: 0,
+			Scopas: map[int]int{0: 2, 1: 0}, Gained: map[int]int{},
+		}), nil)
+		assert.Equal(t, 1, strings.Count(out, "スコパ:"))
+	})
+
+	t.Run("shows nothing before the first round ends", func(t *testing.T) {
+		assert.NotContains(t, p.Output(withDetail(nil), nil), "前ラウンドの内訳")
+	})
 }

--- a/internal/domain/Scopa.go
+++ b/internal/domain/Scopa.go
@@ -406,6 +406,41 @@ func (s *Scopa) scoreRound() *ScopaScoreDetail {
 	return det
 }
 
+// ScopaCategoryWinner は1カテゴリの勝者と得点。
+type ScopaCategoryWinner struct {
+	// Key はカテゴリ ("cards" / "denari" / "primiera" / "settebello")。
+	Key string
+	// Winner は勝者のインデックス。同点・該当なしは -1。
+	Winner int
+	// Points は与えられる点数 (該当なしは 0)。
+	Points int
+}
+
+// ScopaCategoryWinners は得点内訳のうち「単独勝者が決まる4カテゴリ」を返す。
+//
+// **CUI はなぜその点数になったのかを一切出していなかった (#4756)。**Web は
+// カルテ/デナリ/プリミエラ/セッテベッロごとに誰が取ったかを出している。
+//
+// 判定は得点計算そのものと同じ uniqueMaxIndex を通す。**別実装にすると、
+// 内訳の合計が実際の得点と合わなくなる。**
+func ScopaCategoryWinners(det *ScopaScoreDetail) []ScopaCategoryWinner {
+	if det == nil {
+		return nil
+	}
+	award := func(key string, winner, points int) ScopaCategoryWinner {
+		if winner < 0 {
+			return ScopaCategoryWinner{Key: key, Winner: -1}
+		}
+		return ScopaCategoryWinner{Key: key, Winner: winner, Points: points}
+	}
+	return []ScopaCategoryWinner{
+		award("cards", uniqueMaxIndex(det.Cards), ScopaScoreMostCards),
+		award("denari", uniqueMaxIndex(det.Diamonds), ScopaScoreMostDiamonds),
+		award("primiera", uniqueMaxIndex(det.Sevens), ScopaScoreMostSevens),
+		award("settebello", det.HasSetteBello, ScopaScoreSetteBello),
+	}
+}
+
 // removeTableCardsByIndex は降順に並び替えてから tableCards を削除する。
 func (s *Scopa) removeTableCardsByIndex(idxs []int) {
 	if len(idxs) == 0 {

--- a/internal/domain/Scopa_test.go
+++ b/internal/domain/Scopa_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNewDefaultScopa(t *testing.T) {
@@ -330,4 +332,67 @@ func TestScopaUnmarshalRejectsMissingDeck(t *testing.T) {
 	if err := json.Unmarshal([]byte(`{"pl":[]}`), &s); err == nil {
 		t.Error("expected error for missing trump cards")
 	}
+}
+
+// **なぜその点数になったのかを CUI は一切出していなかった (#4756)。**内訳は
+// 得点計算そのものと同じ判定 (uniqueMaxIndex) から出す。**別実装にすると、
+// 内訳の合計が実際の得点と合わなくなる。**
+func TestScopaCategoryWinners(t *testing.T) {
+	t.Run("nothing to report without a detail", func(t *testing.T) {
+		assert.Nil(t, ScopaCategoryWinners(nil))
+	})
+
+	t.Run("names the unique leader of each category", func(t *testing.T) {
+		rows := ScopaCategoryWinners(&ScopaScoreDetail{
+			Cards:         map[int]int{0: 21, 1: 19},
+			Diamonds:      map[int]int{0: 4, 1: 6},
+			Sevens:        map[int]int{0: 3, 1: 1},
+			HasSetteBello: 1,
+		})
+		byKey := map[string]ScopaCategoryWinner{}
+		for _, r := range rows {
+			byKey[r.Key] = r
+		}
+		assert.Equal(t, 0, byKey["cards"].Winner)
+		assert.Equal(t, 1, byKey["denari"].Winner)
+		assert.Equal(t, 0, byKey["primiera"].Winner)
+		assert.Equal(t, 1, byKey["settebello"].Winner)
+	})
+
+	// **同点は誰も取らない。**勝者を1人でっち上げると、内訳の合計が実際の
+	// 得点より大きくなる。
+	t.Run("awards nothing on a tie", func(t *testing.T) {
+		rows := ScopaCategoryWinners(&ScopaScoreDetail{
+			Cards:         map[int]int{0: 20, 1: 20},
+			Diamonds:      map[int]int{0: 5, 1: 5},
+			Sevens:        map[int]int{0: 2, 1: 2},
+			HasSetteBello: -1,
+		})
+		for _, r := range rows {
+			assert.Equal(t, -1, r.Winner, "%s に勝者が付いている", r.Key)
+			assert.Equal(t, 0, r.Points, "%s に点が付いている", r.Key)
+		}
+	})
+
+	// **内訳の合計は実際に加算された点数と一致しなければならない。**
+	t.Run("the category points add up to what the round awarded", func(t *testing.T) {
+		det := &ScopaScoreDetail{
+			Cards:         map[int]int{0: 21, 1: 19},
+			Diamonds:      map[int]int{0: 6, 1: 4},
+			Sevens:        map[int]int{0: 1, 1: 3},
+			HasSetteBello: 1,
+			Scopas:        map[int]int{0: 2},
+		}
+		perPlayer := map[int]int{}
+		for _, r := range ScopaCategoryWinners(det) {
+			if r.Winner >= 0 {
+				perPlayer[r.Winner] += r.Points
+			}
+		}
+		for i, n := range det.Scopas {
+			perPlayer[i] += n * ScopaScoreScopa
+		}
+		assert.Equal(t, ScopaScoreMostCards+ScopaScoreMostDiamonds+2*ScopaScoreScopa, perPlayer[0])
+		assert.Equal(t, ScopaScoreMostSevens+ScopaScoreSetteBello, perPlayer[1])
+	})
 }

--- a/internal/i18n/locales/en/scopa.json
+++ b/internal/i18n/locales/en/scopa.json
@@ -19,5 +19,13 @@
   "gameEnd": "Game over!",
   "scoreEntry": "  {{name}}: {{score}}pt",
   "promptCurrentTurn": "Current turn: {{name}}",
-  "promptHelp": "p <hand> [table...] to capture or lay / n for the next round"
+  "promptHelp": "p <hand> [table...] to capture or lay / n for the next round",
+  "breakdownHeader": "--- Last round breakdown ---",
+  "breakdownNobody": "nobody (tie)",
+  "breakdownRow": "{{category}}: {{name}} (+{{points}})",
+  "breakdownScopa": "Scopa: {{name}} x {{count}}",
+  "category.cards": "Carte (most cards)",
+  "category.denari": "Denari (most diamonds)",
+  "category.primiera": "Primiera (most sevens)",
+  "category.settebello": "Settebello (7 of diamonds)"
 }

--- a/internal/i18n/locales/ja/scopa.json
+++ b/internal/i18n/locales/ja/scopa.json
@@ -19,5 +19,13 @@
   "gameEnd": "ゲーム終了！",
   "scoreEntry": "  {{name}}: {{score}}点",
   "promptCurrentTurn": "手番: {{name}}",
-  "promptHelp": "p <hand> [table...] で捕獲または場に置く / n で次のラウンド"
+  "promptHelp": "p <hand> [table...] で捕獲または場に置く / n で次のラウンド",
+  "breakdownHeader": "--- 前ラウンドの内訳 ---",
+  "breakdownNobody": "なし(同点)",
+  "breakdownRow": "{{category}}: {{name}} (+{{points}})",
+  "breakdownScopa": "スコパ: {{name}} × {{count}}",
+  "category.cards": "カルテ(最多枚数)",
+  "category.denari": "デナリ(ダイヤ最多)",
+  "category.primiera": "プリミエラ(7最多)",
+  "category.settebello": "セッテベッロ(7♦)"
 }


### PR DESCRIPTION
## 背景

`ScopaPage.tsx` は `scopaScoreBreakdown` で**カルテ・デナリ・プリミエラ・セッテベッロ・スコパ回数**ごとに誰が何点取ったかを `<dl>` で表示します。

`ScopaCuiPresenter.Output` はラウンド途中の内訳を一切出さず、**ゲーム終了時の合計スコアしか出しません** (#4756)。CUI プレイヤーは、自分がなぜその点数になったのか（プリミエラを取ったのか、セッテベッロを取ったのか）を確認する手段がありませんでした。

```
--- 前ラウンドの内訳 ---
カルテ(最多枚数): あなた (+1)
デナリ(ダイヤ最多): あなた (+1)
プリミエラ(7最多): CPU 1 (+1)
セッテベッロ(7♦): CPU 1 (+1)
スコパ: あなた × 2
```

## 内訳は得点計算そのものと同じ判定を通します

`ScopaCategoryWinners` は得点計算が使う `uniqueMaxIndex` を共有します。**別実装にすると内訳の合計が実際の得点と合わなくなる**ので、「カテゴリ点の合計 = そのラウンドで加算された点」をテストで固定しました。

## 同点は行を消さずに「なし(同点)」と書きます

**行が消えると「誰かが取った」と読めます。**勝者をでっち上げる実装にすると2件落ちます。スコパ0回のプレイヤーは並べません（「× 0」は情報になりません）。

## 負のコントロール

| 壊し方 | 落ちる件数 |
|---|---|
| 同点でも勝者を作る | 2 |
| プリミエラの集計元を間違える | 2 |
| スコパ0回も並べる | 2 |
| 同点を空欄で出す | 2 |

## 検証

- `go test -tags test ./internal/...` ✅ / `golangci-lint run ./internal/...` → `0 issues.` ✅ / `gofmt -l internal/` 空 ✅
- `check-message-codes: OK (all 775 codes …)` ✅

Closes #4756