### PR TITLE
feat: preview the Pitch hand's game pips before bidding

### DIFF
--- a/internal/adapter/presenter/PitchCuiPresenter.go
+++ b/internal/adapter/presenter/PitchCuiPresenter.go
@@ -105,6 +105,9 @@ func (p *PitchCuiPresenter) Output(s interfaces.PitchGame, lastErr error) string
 			bidIdx := s.GetBidPlayerIdx()
 			b.WriteString(i18n.Tf("pitch.promptBid",
 				"name", cuiPlayerName(s.GetPlayer(bidIdx), bidIdx)) + "\n")
+			// **入札前に手札の得点価値を暗算させていた (#4751)。**Web は入札中に
+			// ゲーム得点バッジと内訳を出している。強気に入札してよいかの判断材料。
+			writePitchHandPips(b, s)
 			b.WriteString(i18n.T("pitch.promptBidHelp") + "\n")
 		case domain.PitchPhasePlay:
 			currentIdx := s.GetCurrentPlayerIdx()
@@ -166,4 +169,28 @@ var pitchHintReasonKeys = map[string]string{
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *PitchCuiPresenter) ActionLogOutput(s interfaces.PitchGame) string {
 	return actionLogOutputText(s)
+}
+
+// writePitchHandPips は人間の手札のゲームピップ合計と内訳を書く。
+// 人間が見つからない、または手札が空なら何も書かない。
+func writePitchHandPips(b *strings.Builder, s interfaces.PitchGame) {
+	for i := 0; i < s.GetPlayerCnt(); i++ {
+		pl := s.GetPlayer(i)
+		if pl == nil || !pl.GetIsHuman() || pl.GetCardsSize() == 0 {
+			continue
+		}
+		cards := make([]*domain.Card, 0, pl.GetCardsSize())
+		// **0点の札も内訳に並べる。**並べないと「見落としている札がある」
+		// のか「その札が0点」なのか区別が付かない。
+		parts := make([]string, 0, pl.GetCardsSize())
+		for j := 0; j < pl.GetCardsSize(); j++ {
+			c := pl.GetCard(j)
+			cards = append(cards, c)
+			parts = append(parts, cuiCardStr(c)+"="+strconv.Itoa(domain.PitchHandPips([]*domain.Card{c})))
+		}
+		b.WriteString(i18n.Tf("pitch.handPips",
+			"total", strconv.Itoa(domain.PitchHandPips(cards)),
+			"breakdown", strings.Join(parts, " ")) + "\n")
+		return
+	}
 }

--- a/internal/adapter/presenter/PitchCuiPresenter_test.go
+++ b/internal/adapter/presenter/PitchCuiPresenter_test.go
@@ -158,3 +158,52 @@ func TestPitchCuiPresenter_ActionLogOutput(t *testing.T) {
 	out := p.ActionLogOutput(m)
 	assert.Contains(t, out, "You bid 3")
 }
+
+// **入札前に手札の得点価値を暗算させていた (#4751)。**Web は入札中にゲーム
+// 得点バッジと内訳ポップオーバーを出している。
+func TestPitchCuiPresenter_HandPips(t *testing.T) {
+	orig := color.NoColor()
+	color.SetNoColor(true)
+	defer color.SetNoColor(orig)
+	p := new(presenter.PitchCuiPresenter)
+
+	withHand := func(values ...int) *interfaces.MockPitchGame {
+		m, players := setupPitchCuiMockWithPlayers()
+		players[0].Reset()
+		for _, v := range values {
+			players[0].AddCard(domain.NewCard(domain.CardDesignSpade, v, false))
+		}
+		return m
+	}
+
+	t.Run("totals the game pips in the human hand", func(t *testing.T) {
+		// ♠10(10) ♠A(4) ♠K(3) ♠7(0) = 17
+		out := p.Output(withHand(10, 1, 13, 7), nil)
+		assert.Contains(t, out, "手札のゲーム得点: 17")
+	})
+
+	// **0点の札も内訳に並べる。**並べないと「見落とし」なのか「0点」なのか
+	// 区別が付かない。
+	t.Run("lists worthless cards in the breakdown too", func(t *testing.T) {
+		out := p.Output(withHand(10, 7), nil)
+		assert.Contains(t, out, "=10")
+		assert.Contains(t, out, "=0")
+	})
+
+	// **人間の手札だけを見る。**手札を持っている最初の席を拾う実装だと、
+	// 人間が配り終える前に CPU の手札を人間の得点として出してしまう。
+	t.Run("shows nothing when only a CPU holds cards", func(t *testing.T) {
+		m, players := setupPitchCuiMockWithPlayers()
+		players[0].Reset()
+		players[1].Reset()
+		players[1].AddCard(domain.NewCard(domain.CardDesignSpade, 10, false))
+		assert.NotContains(t, p.Output(m, nil), "手札のゲーム得点")
+	})
+
+	t.Run("shows nothing outside the bid phase", func(t *testing.T) {
+		m := withHand(10, 1)
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
+		m.On("GetPhase").Return(domain.PitchPhasePlay)
+		assert.NotContains(t, p.Output(m, nil), "手札のゲーム得点")
+	})
+}

--- a/internal/domain/Pitch.go
+++ b/internal/domain/Pitch.go
@@ -459,6 +459,24 @@ func pitchRankValue(v int) int {
 	return v
 }
 
+// PitchHandPips は手札のゲームピップ合計を返す。
+//
+// **CUI は入札前に手札の得点価値を暗算させていた (#4751)。**Web は入札中に
+// バッジと内訳ポップオーバーを出している。
+//
+// 集計は Game ポイントの計算そのものと同じ pitchPipValue を通す。**別実装に
+// すると、プレビューした値と実際に数えられる値がずれる。**
+func PitchHandPips(cards []*Card) int {
+	total := 0
+	for _, c := range cards {
+		if c == nil {
+			continue
+		}
+		total += pitchPipValue(c.GetValue())
+	}
+	return total
+}
+
 // pitchPipValue Game ポイント計算用のピップ値: A=4 K=3 Q=2 J=1 10=10 他=0
 func pitchPipValue(v int) int {
 	switch v {

--- a/internal/domain/Pitch_test.go
+++ b/internal/domain/Pitch_test.go
@@ -667,3 +667,38 @@ func diffName(d domain.PitchCpuDifficulty) string {
 	}
 	return "?"
 }
+
+// **入札前に手札の得点価値を暗算させていた (#4751)。**Web は入札中にバッジと
+// 内訳を出している。集計は Game ポイント計算そのものと同じ pitchPipValue を通す。
+func TestPitchHandPips(t *testing.T) {
+	card := func(v int) *domain.Card { return domain.NewCard(domain.CardDesignSpade, v, false) }
+
+	t.Run("an empty hand is worth nothing", func(t *testing.T) {
+		assert.Equal(t, 0, domain.PitchHandPips(nil))
+	})
+
+	// **10 が一番重く、A は 4。**素朴に「大きい札ほど高い」と思うと 10 を捨てる。
+	t.Run("scores ten highest, then king queen jack, with the ace at four", func(t *testing.T) {
+		assert.Equal(t, 10, domain.PitchHandPips([]*domain.Card{card(10)}))
+		assert.Equal(t, 4, domain.PitchHandPips([]*domain.Card{card(1)}))
+		assert.Equal(t, 3, domain.PitchHandPips([]*domain.Card{card(13)}))
+		assert.Equal(t, 2, domain.PitchHandPips([]*domain.Card{card(12)}))
+		assert.Equal(t, 1, domain.PitchHandPips([]*domain.Card{card(11)}))
+	})
+
+	t.Run("spot cards are worth nothing", func(t *testing.T) {
+		for v := 2; v <= 9; v++ {
+			assert.Equal(t, 0, domain.PitchHandPips([]*domain.Card{card(v)}), "%d が 0 でない", v)
+		}
+	})
+
+	t.Run("sums the whole hand", func(t *testing.T) {
+		assert.Equal(t, 20, domain.PitchHandPips([]*domain.Card{
+			card(1), card(10), card(13), card(12), card(11), card(7),
+		}))
+	})
+
+	t.Run("skips nil entries instead of panicking", func(t *testing.T) {
+		assert.Equal(t, 10, domain.PitchHandPips([]*domain.Card{nil, card(10), nil}))
+	})
+}

--- a/internal/i18n/locales/en/pitch.json
+++ b/internal/i18n/locales/en/pitch.json
@@ -22,5 +22,6 @@
   "hintReasonSetTrumpLead": "declare trump on lead",
   "hintReasonTrumpCut": "cut with trump",
   "hintReasonBidStrong": "bid with a strong hand",
-  "hintReasonBidPass": "pass with a weak hand"
+  "hintReasonBidPass": "pass with a weak hand",
+  "handPips": "Game pips in hand: {{total}} ({{breakdown}})"
 }

--- a/internal/i18n/locales/ja/pitch.json
+++ b/internal/i18n/locales/ja/pitch.json
@@ -22,5 +22,6 @@
   "hintReasonSetTrumpLead": "リードでトランプを宣言",
   "hintReasonTrumpCut": "トランプでカット",
   "hintReasonBidStrong": "強い手札なので入札",
-  "hintReasonBidPass": "弱い手札なのでパス"
+  "hintReasonBidPass": "弱い手札なのでパス",
+  "handPips": "手札のゲーム得点: {{total}} ({{breakdown}})"
 }


### PR DESCRIPTION
## 背景

`PitchPage.tsx` は入札フェーズ中に `pitchHandPips` / `pitchHandPipBreakdown` で**手札のゲーム得点バッジと内訳ポップオーバー**を出し、どれだけ強気に入札してよいかの判断を助けます。

`PitchCuiPresenter.Output` にはこれに相当する出力が一切ありません (#4751)。CUI プレイヤーは生のカード一覧しか見えず、**入札前に手札の得点価値を自分で暗算**する必要がありました。

```
手札のゲーム得点: 17 (♠10=10 ♠A=4 ♠K=3 ♠7=0)
```

## 集計は Game ポイント計算そのものを通します

`PitchHandPips` は得点計算が使う `pitchPipValue` を共有します。**別実装だとプレビューした値と実際に数えられる値がずれます。**カード値をそのまま足す実装にするとテストが**8件**落ちます。

配点は直感に反します（**10 が最重の 10 点、A は 4 点**、K=3 Q=2 J=1、2〜9 は 0）。「大きい札ほど高い」と思って 10 を捨てないよう、この並びをテストで固定しました。

## 0点の札も内訳に並べます

並べないと「**見落としている札がある**」のか「**その札が 0 点**」なのか区別が付きません。

## 人間の手札だけを見ます

手札を持っている最初の席を拾う実装だと、**配り終える前に CPU の手札を人間の得点として出します**。この負のコントロールは当初 0件でした（人間が席 0 なので、条件を外しても同じ席を拾っていた）。CPU だけが手札を持つ局面を足して 2件にしています。

## 負のコントロール

| 壊し方 | 落ちる件数 |
|---|---|
| カード値をそのまま足す | 8 |
| 行を出さない | 3 |
| CPU の手札も拾う | 2 |

## 検証

- `go test -tags test ./internal/...` ✅ / `golangci-lint run ./internal/...` → `0 issues.` ✅ / `gofmt -l internal/` 空 ✅
- `check-message-codes: OK (all 775 codes …)` ✅

Closes #4751