### PR TITLE
feat: spell out the Spoil Five ranking in the CUI

### DIFF
--- a/internal/adapter/presenter/SpoilFiveCuiPresenter.go
+++ b/internal/adapter/presenter/SpoilFiveCuiPresenter.go
@@ -92,6 +92,10 @@ func (p *SpoilFiveCuiPresenter) Output(g interfaces.SpoilFiveGame, lastErr error
 			b.WriteString(i18n.Tf("spoilfive.promptPlay",
 				"name", cuiPlayerName(g.GetPlayer(currentIdx), currentIdx)) + "\n")
 			b.WriteString(i18n.T("spoilfive.promptPlayHelp") + "\n")
+			// **固定序列が Spoil Five の核心ルール (#4765)。**Web は折りたたみ
+			// パネルで常時出しているのに、CUI は切り札の記号を出すだけで、
+			// 「なぜこのカードで負けたか」がルールブック無しには分からなかった。
+			writeSpoilFiveTopTrumps(b, g)
 		case domain.SpoilFivePhaseTrickEnd:
 			b.WriteString(i18n.T("spoilfive.promptTrickEnd") + "\n")
 			b.WriteString(i18n.T("spoilfive.promptTrickEndHelp") + "\n")
@@ -147,4 +151,18 @@ var spoilFiveHintReasonKeys = map[string]string{
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *SpoilFiveCuiPresenter) ActionLogOutput(g interfaces.SpoilFiveGame) string {
 	return actionLogOutputText(g)
+}
+
+// writeSpoilFiveTopTrumps は固定序列を強い順に1行で書く。
+func writeSpoilFiveTopTrumps(b *strings.Builder, g interfaces.SpoilFiveGame) {
+	tops := g.GetTopTrumps()
+	if len(tops) == 0 {
+		return
+	}
+	parts := make([]string, len(tops))
+	for i, c := range tops {
+		parts[i] = cuiCardStr(c)
+	}
+	b.WriteString(i18n.Tf("spoilfive.topTrumpLine",
+		"cards", strings.Join(parts, " > ")) + "\n")
 }

--- a/internal/adapter/presenter/SpoilFiveCuiPresenter_test.go
+++ b/internal/adapter/presenter/SpoilFiveCuiPresenter_test.go
@@ -30,6 +30,7 @@ func setupSpoilFiveCuiMock() *interfaces.MockSpoilFiveGame {
 	m.On("GetRoundNumber").Return(1)
 	m.On("GetTrickNumber").Return(1)
 	m.On("GetTrumpSuit").Return(domain.CardDesignSpade)
+	m.On("GetTopTrumps").Return(([]*domain.Card)(nil)).Maybe()
 	m.On("GetPot").Return(5)
 	m.On("GetLeadPlayerIdx").Return(0)
 	m.On("GetRoundWinnerIdx").Return(-1)
@@ -151,4 +152,34 @@ func TestSpoilFiveCuiPresenter_ActionLogOutput(t *testing.T) {
 	})
 	result := p.ActionLogOutput(m)
 	assert.Contains(t, result, "play")
+}
+
+// **固定序列が Spoil Five の核心ルール (#4765)。**Web は折りたたみパネルで
+// 常時出しているのに、CUI は切り札の記号を出すだけだった。
+func TestSpoilFiveCuiPresenter_TopTrumpLine(t *testing.T) {
+	orig := color.NoColor()
+	color.SetNoColor(true)
+	defer color.SetNoColor(orig)
+	p := new(presenter.SpoilFiveCuiPresenter)
+
+	withTops := func(tops []*domain.Card) *interfaces.MockSpoilFiveGame {
+		m, _ := setupSpoilFiveCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetTopTrumps")
+		m.On("GetTopTrumps").Return(tops)
+		return m
+	}
+
+	t.Run("prints the ranking strongest first", func(t *testing.T) {
+		out := p.Output(withTops([]*domain.Card{
+			domain.NewCard(domain.CardDesignSpade, 5, false),
+			domain.NewCard(domain.CardDesignSpade, 11, false),
+			domain.NewCard(domain.CardDesignHeart, 1, false),
+		}), nil)
+		assert.Contains(t, out, "強さ順")
+		assert.Contains(t, out, ">")
+	})
+
+	t.Run("says nothing when there is no ranking to show", func(t *testing.T) {
+		assert.NotContains(t, p.Output(withTops(nil), nil), "強さ順")
+	})
 }

--- a/internal/domain/SpoilFive.go
+++ b/internal/domain/SpoilFive.go
@@ -368,6 +368,43 @@ func (g *SpoilFive) trickWinner() int {
 	return winnerIdx
 }
 
+// GetTopTrumps は固定序列の上位札を強い順に返す (#4765)。
+//
+// **この序列が Spoil Five の核心ルール。**5 > J > ♥A > 切り札A > K > Q で、
+// ♥A は切り札でなくても常に3番目に強い。Web は折りたたみパネルで常時出して
+// いるのに、CUI は切り札スートの記号を出すだけで、CLI プレイヤーは
+// 「なぜこのカードで負けたか」をルールブック無しに理解できなかった。
+//
+// **ハートが切り札のときは ♥A を重複させない。**そのとき ♥A は切り札の A
+// そのものなので、2度並べると6枚あるように見える。
+//
+// 並びは spoilRank そのものから導く。順序を手で書き写すと、ランクを直した
+// ときに説明だけ古くなる。
+func (g *SpoilFive) GetTopTrumps() []*Card {
+	candidates := []*Card{
+		NewCard(g.trumpSuit, 5, false),
+		NewCard(g.trumpSuit, 11, false),
+		NewCard(CardDesignHeart, 1, false),
+		NewCard(g.trumpSuit, 1, false),
+		NewCard(g.trumpSuit, 13, false),
+		NewCard(g.trumpSuit, 12, false),
+	}
+	out := make([]*Card, 0, len(candidates))
+	seen := map[[2]int]bool{}
+	for _, c := range candidates {
+		key := [2]int{c.GetDesign(), c.GetValue()}
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, c)
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		return g.spoilRank(out[i]) > g.spoilRank(out[j])
+	})
+	return out
+}
+
 // spoilRank Spoil Five の固定ランクを返す (高いほど強い)。
 func (g *SpoilFive) spoilRank(card *Card) int {
 	d, v := card.GetDesign(), card.GetValue()

--- a/internal/domain/SpoilFive_test.go
+++ b/internal/domain/SpoilFive_test.go
@@ -5,6 +5,9 @@ package domain
 import (
 	"encoding/json"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func sfCard(design, value int) *Card { return NewCard(design, value, false) }
@@ -282,4 +285,78 @@ func TestSpoilFive_UnmarshalErrors(t *testing.T) {
 	if err := g.UnmarshalJSON([]byte(`{"ps":[null,null,null,null,null]}`)); err == nil {
 		t.Error("expected nil-player error")
 	}
+}
+
+// **固定序列が Spoil Five の核心ルール (#4765)。**5 > J > ♥A > 切り札A > K > Q。
+// Web は折りたたみパネルで常時出しているのに、CUI には無かった。
+func TestSpoilFive_GetTopTrumps(t *testing.T) {
+	label := func(cards []*Card) []string {
+		out := make([]string, len(cards))
+		for i, c := range cards {
+			out[i] = string(rune('0'+c.GetDesign())) + ":" + string(rune('0'+c.GetValue()))
+		}
+		return out
+	}
+	game := func(trump int) *SpoilFive {
+		g := NewDefaultSpoilFive()
+		g.Reset()
+		g.SetTrumpSuit(trump)
+		return g
+	}
+
+	t.Run("orders the six named cards strongest first", func(t *testing.T) {
+		tops := game(CardDesignSpade).GetTopTrumps()
+		require.Len(t, tops, 6)
+		want := [][2]int{
+			{CardDesignSpade, 5}, {CardDesignSpade, 11}, {CardDesignHeart, 1},
+			{CardDesignSpade, 1}, {CardDesignSpade, 13}, {CardDesignSpade, 12},
+		}
+		for i, w := range want {
+			assert.Equal(t, w[0], tops[i].GetDesign(), "位置 %d のスート", i)
+			assert.Equal(t, w[1], tops[i].GetValue(), "位置 %d の値", i)
+		}
+	})
+
+	// **♥A は切り札でなくても常に3番目。**普通のトリックテイキングの直感
+	// (切り札が全部上) とは違う。
+	t.Run("keeps the heart ace third even when hearts are not trump", func(t *testing.T) {
+		tops := game(CardDesignClover).GetTopTrumps()
+		require.Len(t, tops, 6)
+		assert.Equal(t, CardDesignHeart, tops[2].GetDesign())
+		assert.Equal(t, 1, tops[2].GetValue())
+		assert.Equal(t, CardDesignClover, tops[3].GetDesign(), "4番目は切り札のA")
+	})
+
+	// **ハートが切り札のときは重複させない。**そのとき ♥A は切り札の A その
+	// ものなので、2度並べると6枚あるように見える。
+	t.Run("does not list the heart ace twice when hearts are trump", func(t *testing.T) {
+		tops := game(CardDesignHeart).GetTopTrumps()
+		assert.Len(t, tops, 5)
+		assert.Len(t, label(tops), len(uniqueStrings(label(tops))), "同じ札が2度出ている")
+	})
+
+	// 並びは spoilRank から導く。手で書き写した順序だとランクを直したときに
+	// 説明だけ古くなる。
+	t.Run("the order agrees with spoilRank", func(t *testing.T) {
+		g := game(CardDesignDiamond)
+		tops := g.GetTopTrumps()
+		for i := 1; i < len(tops); i++ {
+			assert.Greater(t, g.spoilRank(tops[i-1]), g.spoilRank(tops[i]),
+				"位置 %d と %d の順序が逆", i-1, i)
+		}
+	})
+}
+
+// uniqueStrings は重複を除いた文字列スライスを返す (テスト用)。
+func uniqueStrings(in []string) []string {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if seen[s] {
+			continue
+		}
+		seen[s] = true
+		out = append(out, s)
+	}
+	return out
 }

--- a/internal/domain/interfaces/spoilfive.go
+++ b/internal/domain/interfaces/spoilfive.go
@@ -45,6 +45,8 @@ type SpoilFiveGame interface {
 	GetLeadPlayerIdx() int
 	// GetDealerIdx ディーラーインデックスを取得する
 	GetDealerIdx() int
+	// GetTopTrumps 固定序列の上位札を強い順に取得する
+	GetTopTrumps() []*domain.Card
 	// GetTrumpSuit 切り札スートを取得する (1-4)
 	GetTrumpSuit() int
 	// GetPot 現在のポット額を取得する

--- a/internal/domain/interfaces/spoilfive_mock.go
+++ b/internal/domain/interfaces/spoilfive_mock.go
@@ -123,6 +123,14 @@ func (_m *MockSpoilFiveGame) GetTrumpSuit() int {
 	return ret.Get(0).(int)
 }
 
+func (_m *MockSpoilFiveGame) GetTopTrumps() []*domain.Card {
+	args := _m.Called()
+	if args.Get(0) == nil {
+		return nil
+	}
+	return args.Get(0).([]*domain.Card)
+}
+
 // GetPot モック
 func (_m *MockSpoilFiveGame) GetPot() int {
 	ret := _m.Called()

--- a/internal/i18n/locales/en/spoilfive.json
+++ b/internal/i18n/locales/en/spoilfive.json
@@ -20,5 +20,6 @@
   "hintReasonTakeTrick": "Play to win this trick (3 tricks takes the pot)",
   "hintReasonDiscardLow": "Cannot win — discard a low card",
   "leaderMark": "▶(lead) ",
-  "winnerMark": "★(winner) "
+  "winnerMark": "★(winner) ",
+  "topTrumpLine": "Ranking: {{cards}} > other trumps > non-trumps"
 }

--- a/internal/i18n/locales/ja/spoilfive.json
+++ b/internal/i18n/locales/ja/spoilfive.json
@@ -20,5 +20,6 @@
   "hintReasonTakeTrick": "このトリックを取りにいく（3トリックでポット獲得）",
   "hintReasonDiscardLow": "取れないので低い札を捨てる",
   "leaderMark": "▶(リード) ",
-  "winnerMark": "★(勝者) "
+  "winnerMark": "★(勝者) ",
+  "topTrumpLine": "強さ順: {{cards}} > その他の切り札 > 非切り札"
 }


### PR DESCRIPTION
## 背景

Spoil Five の核心ルールは**固定序列**です: `5 > J > ♥A > 切り札A > K > Q > その他の切り札 > 非切り札`。

`SpoilFivePage.tsx` は `spoilfive-trump-legend` の折りたたみパネルで常時アクセスできる形で出しています。`SpoilFiveCuiPresenter.Output` には**一切登場しません** (#4765)。CLI プレイヤーは「なぜこのカードで負けたか」をルールブック無しに理解できませんでした。

```
強さ順: ♠5 > ♠J > ♥A > ♠A > ♠K > ♠Q > その他の切り札 > 非切り札
```

## 並びは `spoilRank` そのものから導きます

順序を手で書き写すと、**ランクを直したときに説明だけ古くなります**。候補を挙げて `spoilRank` で並べ替え、「隣り合う2枚のランクが必ず降順」をテストで固定しました。弱い順に並べる実装にすると4件落ちます。

## ♥A は切り札でなくても常に3番目

普通のトリックテイキングの直感（切り札が全部上）とは違います。序列から落とすと3件落ちます。

## ハートが切り札のときは重複させません

そのとき **♥A は切り札の A そのもの**なので、2度並べると6枚あるように見えます。重複を許すと2件落ちます。

## 負のコントロール

| 壊し方 | 落ちる件数 |
|---|---|
| 並びを弱い順にする | 4 |
| ♥A を序列から落とす | 3 |
| ハート切り札で ♥A を重複させる | 2 |
| presenter が行を出さない | 2 |

## 検証

- `go test -tags test ./internal/...` ✅ / `golangci-lint run ./internal/...` → `0 issues.` ✅ / `gofmt -l internal/` 空 ✅
- `check-message-codes: OK (all 775 codes …)` ✅

Closes #4765