### PR TITLE
feat: tell the La Belle Lucie CUI when the game is truly deadlocked

### DIFF
--- a/internal/adapter/presenter/LaBelleLucieCuiPresenter.go
+++ b/internal/adapter/presenter/LaBelleLucieCuiPresenter.go
@@ -58,8 +58,15 @@ func (p *LaBelleLucieCuiPresenter) Output(g interfaces.LaBelleLucieGame, lastErr
 			sb.WriteString(i18n.Tf("cuiSolitaireMoves", "count", strconv.Itoa(g.GetMoveCount())) + "\n")
 			// No legal move but redeals remain -> recommend a redeal, mirroring the
 			// web stuck banner.
-			if !g.HasAnyLegalMove() && g.GetRedealsLeft() > 0 {
-				sb.WriteString(color.Yellow(i18n.T("labellelucie.redealRecommended")) + "\n")
+			if !g.HasAnyLegalMove() {
+				// **再配札が尽きた真の手詰まりは別物 (#4769)。**Web は
+				// ll-deadlock-banner を出して giveup を点滅させるのに、CUI は
+				// 何も言わず、合法手が無いまま延々と手を探させていた。
+				if g.GetRedealsLeft() > 0 {
+					sb.WriteString(color.Yellow(i18n.T("labellelucie.redealRecommended")) + "\n")
+				} else {
+					sb.WriteString(color.Red(i18n.T("labellelucie.stuckDeadlock")) + "\n")
+				}
 			}
 		case domain.LaBelleLuciePhaseGameClear:
 			sb.WriteString(color.Green(i18n.T("cuiSolitaireGameClear")) + " " +

--- a/internal/adapter/presenter/LaBelleLucieCuiPresenter_test.go
+++ b/internal/adapter/presenter/LaBelleLucieCuiPresenter_test.go
@@ -59,6 +59,33 @@ func TestLaBelleLucieCuiPresenter_Output(t *testing.T) {
 		assert.NotContains(t, out, i18n.T("labellelucie.redealRecommended"))
 	})
 
+	// **再配札が尽きた真の手詰まりは別物 (#4769)。**Web は ll-deadlock-banner を
+	// 出して giveup を点滅させるのに、CUI は何も言わず、合法手が無いまま延々と
+	// 手を探させていた。
+	t.Run("names the deadlock when no redeal is left either", func(t *testing.T) {
+		ace, _ := json.Marshal(domain.NewCard(domain.CardDesignSpade, 1, true))
+		js := fmt.Sprintf(`{"ph":0,"rd":0,"fd":[[%s],[],[],[]],"fn":[[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[]]}`, ace)
+		out := p.Output(llState(t, js), nil)
+		assert.Contains(t, out, i18n.T("labellelucie.stuckDeadlock"))
+		// **再配札を勧めてはいけない。**もう配り直せない。
+		assert.NotContains(t, out, i18n.T("labellelucie.redealRecommended"))
+	})
+
+	t.Run("recommends a redeal rather than a giveup while redeals remain", func(t *testing.T) {
+		ace, _ := json.Marshal(domain.NewCard(domain.CardDesignSpade, 1, true))
+		js := fmt.Sprintf(`{"ph":0,"rd":2,"fd":[[%s],[],[],[]],"fn":[[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[]]}`, ace)
+		out := p.Output(llState(t, js), nil)
+		assert.NotContains(t, out, i18n.T("labellelucie.stuckDeadlock"))
+	})
+
+	t.Run("says neither while a legal move exists", func(t *testing.T) {
+		ace, _ := json.Marshal(domain.NewCard(domain.CardDesignSpade, 1, true))
+		js := fmt.Sprintf(`{"ph":0,"rd":0,"fd":[[],[],[],[]],"fn":[[%s],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[]]}`, ace)
+		out := p.Output(llState(t, js), nil)
+		assert.NotContains(t, out, i18n.T("labellelucie.stuckDeadlock"))
+		assert.NotContains(t, out, i18n.T("labellelucie.redealRecommended"))
+	})
+
 	t.Run("game clear banner", func(t *testing.T) {
 		assert.Contains(t, p.Output(llState(t, `{"ph":1,"mc":7}`), nil), "ゲームクリア")
 	})

--- a/internal/i18n/locales/en/labellelucie.json
+++ b/internal/i18n/locales/en/labellelucie.json
@@ -12,5 +12,6 @@
   "hintToFoundation": "a foundation",
   "hintLine": "[HINT: move fan {{from}} to {{to}}]",
   "foundationCount": "({{count}} cards)",
-  "redealRecommended": "No legal moves. Redeal recommended (nr)."
+  "redealRecommended": "No legal moves. Redeal recommended (nr).",
+  "stuckDeadlock": "No legal move remains and no redeals are left - type giveup to concede."
 }

--- a/internal/i18n/locales/ja/labellelucie.json
+++ b/internal/i18n/locales/ja/labellelucie.json
@@ -12,5 +12,6 @@
   "hintToFoundation": "ファウンデーション",
   "hintLine": "[HINT: 扇{{from}} を {{to}} へ]",
   "foundationCount": "(計{{count}}枚)",
-  "redealRecommended": "合法手がありません。nr でリディールを推奨します。"
+  "redealRecommended": "合法手がありません。nr でリディールを推奨します。",
+  "stuckDeadlock": "これ以上動かせる手がありません。再配札も残っていません — giveup でギブアップできます。"
 }


### PR DESCRIPTION
## 背景

`LaBelleLuciePage.tsx` は `stuck`（再配札推奨）と `deadlocked`（再配札も尽きた真の手詰まり）を区別し、後者では `ll-deadlock-banner` を出して `giveup` ボタンを点滅させます。

`LaBelleLucieCuiPresenter.Output` は `!HasAnyLegalMove() && GetRedealsLeft() > 0` のときだけ `redealRecommended` を出し、**再配札も尽きたケースには何も言いません** (#4769)。CLI プレイヤーは動かせる手が無いまま延々と探し続けることになります。

```
これ以上動かせる手がありません。再配札も残っていません — giveup でギブアップできます。
```

## 再配札が残っているかで言うことが変わります

残っていれば**配り直し**、尽きていれば **giveup**。同じ文言だと、**もう配り直せないのに配り直しを勧める**ことになります。常に手詰まり扱いにするとテストが3件落ちます。

合法手があるうちはどちらも出しません（出す実装にすると3件落ちる）。

## 負のコントロール

| 壊し方 | 落ちる件数 |
|---|---|
| 常に手詰まり扱いにする | 3 |
| 合法手があっても出す | 3 |
| 手詰まりを言わない（元の挙動） | 2 |

## 検証

- `go test -tags test ./internal/...` ✅ / `golangci-lint run ./internal/...` → `0 issues.` ✅ / `gofmt -l internal/` 空 ✅
- `check-message-codes: OK (all 775 codes …)` ✅

Closes #4769