### PR TITLE
fix: stop the Mariáš marriage banner from vanishing when the K is played

### DIFF
--- a/frontend/src/i18n/locales/en/marias.json
+++ b/frontend/src/i18n/locales/en/marias.json
@@ -63,5 +63,6 @@
     "resetButton": "Use the reset button to start a new game."
   },
   "hintRequested": "Hint available",
-  "noHint": "No hint available"
+  "noHint": "No hint available",
+  "marriageEarned": "Marriage bonus secured: +{{points}} (playing the K or Q does not take it away)"
 }

--- a/frontend/src/i18n/locales/ja/marias.json
+++ b/frontend/src/i18n/locales/ja/marias.json
@@ -63,5 +63,6 @@
     "resetButton": "リセットボタンで新しいゲームを始められます。"
   },
   "hintRequested": "ヒントがあります",
-  "noHint": "ヒントはありません"
+  "noHint": "ヒントはありません",
+  "marriageEarned": "結婚ボーナス確定: +{{points}}（K・Qを出しても消えません）"
 }

--- a/frontend/src/pages/MariasPage.test.tsx
+++ b/frontend/src/pages/MariasPage.test.tsx
@@ -64,32 +64,54 @@ describe('MariasPage', () => {
     expect(screen.getByText('ソリスト')).toBeInTheDocument();
   });
 
-  it('shows a marriage banner during play (trump-suit K-Q scores +40)', async () => {
-    // Default hand: ♥K + ♥Q with trump ♥ → a +40 marriage.
+  // **結婚ボーナスは配った時点で確定している (#4759)。**以前このバナーは毎
+  // レンダー手札を走査して K と Q の両方を持っているかを見ていたので、どちらかを
+  // 出した瞬間に消え、「出したのでボーナスを失った」という誤解を与えていた。
+  it('shows the settled marriage bonus during play', async () => {
+    mockExec.mockResolvedValue(makeMariasState({ roundMarriage: [40, 0, 0] }));
     renderWithProviders(<MariasPage />);
     const banner = await screen.findByTestId('marias-marriage');
-    expect(banner).toHaveTextContent('マリッジ可能');
-    expect(banner).toHaveTextContent('♥ K-Q (+40)');
+    expect(banner).toHaveTextContent('40');
   });
 
-  it('labels a non-trump marriage as +20', async () => {
-    mockExec.mockResolvedValue(makeMariasState({ trumpSuit: 1 })); // trump ♠, ♥ K-Q now +20
+  // **これがこの issue の本体。**K を場に出しても点数は動かないので、バナーも
+  // 消えてはいけない。
+  it('keeps the banner after the king has been played', async () => {
+    mockExec.mockResolvedValue(
+      makeMariasState({
+        // 手札から ♥K が消え、♥Q だけが残った状態。roundMarriage は確定のまま。
+        roundMarriage: [40, 0, 0],
+        players: [
+          {
+            id: 0,
+            isHuman: true,
+            cardCount: 1,
+            cards: [{ design: 'HEART', value: 12 }],
+            trickCount: 1,
+            score: 0,
+            isSoloist: true,
+          },
+          { id: 1, isHuman: false, cardCount: 10, cards: [], trickCount: 0, score: 0, isSoloist: false },
+          { id: 2, isHuman: false, cardCount: 10, cards: [], trickCount: 0, score: 0, isSoloist: false },
+        ],
+      }),
+    );
     renderWithProviders(<MariasPage />);
-    await waitFor(() => expect(screen.getByTestId('marias-marriage')).toHaveTextContent('♥ K-Q (+20)'));
+    expect(await screen.findByTestId('marias-marriage')).toHaveTextContent('40');
   });
 
-  it('announces the marriage banner with a spoken suit name (symbol hidden from SR)', async () => {
-    // Default hand: ♥K + ♥Q with trump ♥ → +40. SR reads the suit name, not the glyph.
+  it('announces the banner in a live region', async () => {
+    mockExec.mockResolvedValue(makeMariasState({ roundMarriage: [40, 0, 0] }));
     renderWithProviders(<MariasPage />);
     const banner = await screen.findByTestId('marias-marriage');
     expect(banner).toHaveAttribute('role', 'status');
     expect(banner).toHaveAttribute('aria-live', 'polite');
-    expect(banner).toHaveAttribute('aria-label', 'マリッジ可能: ハート K-Q +40');
   });
 
-  it('shows no marriage banner when the hand has no K-Q pair', async () => {
+  it('shows no marriage banner when no marriage was dealt', async () => {
     mockExec.mockResolvedValue(
       makeMariasState({
+        roundMarriage: [0, 0, 0],
         players: [
           {
             id: 0,

--- a/frontend/src/pages/MariasPage.tsx
+++ b/frontend/src/pages/MariasPage.tsx
@@ -38,12 +38,6 @@ import { hintCheckboxItem } from '../utils/settingsItems';
 /** Suit symbols indexed by suit number (1=♠ 2=♣ 3=♥ 4=♦; index 0 unused). */
 const SUIT_SYMBOLS = ['', '♠', '♣', '♥', '♦'] as const;
 
-/** Suit-name i18n keys indexed by suit number (1=♠ 2=♣ 3=♥ 4=♦; index 0 unused). */
-const SUIT_KEYS = ['', 'spade', 'club', 'heart', 'diamond'] as const;
-
-/** Card design string → suit number (1=♠ 2=♣ 3=♥ 4=♦), to align with SUIT_SYMBOLS / trumpSuit. */
-const DESIGN_TO_SUIT: Readonly<Record<string, number>> = { SPADE: 1, CLOVER: 2, HEART: 3, DIAMOND: 4 };
-
 /** Mariáš tutorial step definitions. */
 const MARIAS_TUTORIAL_STEPS: TutorialStep[] = [
   {
@@ -145,23 +139,15 @@ function MariasPageContent() {
   const canPlay = isPlayPhase && isHumanTurn;
   const trumpSymbol = SUIT_SYMBOLS[state.trumpSuit] ?? '?';
 
-  // Suits where the human holds both K (13) and Q (12) — a marriage worth 40 in
-  // the trump suit, otherwise 20. Surfaced as a banner during play so the bonus
-  // (otherwise only shown at round end) is visible while it can still be earned.
-  const marriages = isPlayPhase
-    ? [1, 2, 3, 4]
-        .filter((suit) => {
-          const cards = humanPlayer?.cards ?? [];
-          const hasK = cards.some((c) => DESIGN_TO_SUIT[c.design] === suit && c.value === 13);
-          const hasQ = cards.some((c) => DESIGN_TO_SUIT[c.design] === suit && c.value === 12);
-          return hasK && hasQ;
-        })
-        .map((suit) => ({
-          symbol: SUIT_SYMBOLS[suit] ?? '?',
-          suitKey: SUIT_KEYS[suit],
-          points: suit === state.trumpSuit ? 40 : 20,
-        }))
-    : [];
+  // **結婚ボーナスは配った時点で確定している。**`detectMarriages` はラウンド
+  // 開始時に一度だけ走って `roundMarriage` に加点し、以後 K・Q を場に出しても
+  // 点数は動かない (Marias.go の startRound → detectMarriages)。
+  //
+  // 以前はここで毎レンダー手札を走査して「K と Q を両方持っているか」を
+  // 判定していたため、どちらかを出した瞬間にバナーが消え、**「出したので
+  // ボーナスを失った」という誤解**を与えていた (#4759)。確定済みの点数
+  // そのものを根拠にする。
+  const marriagePoints = isPlayPhase ? (state.roundMarriage[humanPlayer?.id ?? 0] ?? 0) : 0;
 
   const handleManualReset = () => {
     hideActionLog();
@@ -351,21 +337,14 @@ function MariasPageContent() {
 
           {/* Footer */}
           <GameFooter className={`${gameTheme.marias.footer} px-4 py-2.5`}>
-            {marriages.length > 0 && (
+            {marriagePoints > 0 && (
               <div
                 className="mb-1 text-center text-sm text-ds-accent font-semibold"
                 data-testid="marias-marriage"
                 role="status"
                 aria-live="polite"
-                aria-label={t('marriageAvailable', {
-                  list: marriages.map((m) => `${t(`suitName.${m.suitKey}`)} K-Q +${m.points}`).join('、'),
-                })}
               >
-                <span aria-hidden="true">
-                  {t('marriageAvailable', {
-                    list: marriages.map((m) => `${m.symbol} K-Q (+${m.points})`).join('  '),
-                  })}
-                </span>
+                {t('marriageEarned', { points: marriagePoints })}
               </div>
             )}
             {humanPlayer && (


### PR DESCRIPTION
## 背景

`Marias.detectMarriages` は **ラウンド開始時に一度だけ**走り、その時点の K+Q を検出して `roundMarriage` に加点します。**以後 K・Q を場に出しても点数は動きません。**

ところが `MariasPage.tsx` のバナーは `isPlayPhase` の間ずっと `humanPlayer.cards` を毎レンダー走査して「K と Q の両方を保持しているか」を再判定していました (#4759)。

**どちらかを出した瞬間にバナーが消え、「出したのでボーナスを失った」という誤解**を与えます。しかも同じ画面のスコア欄（`roundMarriage`）は点数を出し続けるので、**画面の中で言っていることが食い違って**いました。

## 確定済みの点数そのものを根拠にします

```
結婚ボーナス確定: +40（K・Qを出しても消えません）
```

**K を出した後もバナーが残る**ことをテストで固定しました。手札から再判定する実装に戻すと落ちます。

## トレードオフ

`roundMarriage` は合計値なので、**スート別の内訳（♥ K-Q +40 のような表示）は出せなくなります**。確定値と食い違う表示を続けるよりよい、と判断しました。内訳が必要なら API 側に per-suit の情報を足す必要があり、それはこの issue の範囲を超えます。

使われなくなった `SUIT_KEYS` / `DESIGN_TO_SUIT` は削除しました。

## 負のコントロール

| 壊し方 | 落ちる件数 |
|---|---|
| バナーを出さない | 3 |
| 手札から再判定する（旧バグ） | 1 |

## 検証

- `bunx vitest run src/pages/MariasPage.test.tsx` → 16 passed ✅
- `bun run typecheck` ✅ / `bun run check` exit 0 ✅

Closes #4759