### PR TITLE
feat: show the Manille target score in the header bar

### DIFF
--- a/frontend/src/i18n/locales/en/manille.json
+++ b/frontend/src/i18n/locales/en/manille.json
@@ -61,5 +61,6 @@
     "resetButton": "Use the reset button to start a new game."
   },
   "hintRequested": "Hint available",
-  "noHint": "No hint available"
+  "noHint": "No hint available",
+  "target": "Target: {{points}}"
 }

--- a/frontend/src/i18n/locales/ja/manille.json
+++ b/frontend/src/i18n/locales/ja/manille.json
@@ -61,5 +61,6 @@
     "resetButton": "リセットボタンで新しいゲームを始められます。"
   },
   "hintRequested": "ヒントがあります",
-  "noHint": "ヒントはありません"
+  "noHint": "ヒントはありません",
+  "target": "目標: {{points}}点"
 }

--- a/frontend/src/pages/ManillePage.test.tsx
+++ b/frontend/src/pages/ManillePage.test.tsx
@@ -183,3 +183,22 @@ describe('ManillePage', () => {
     expect(await screen.findByText(/\(\[0\]\)/)).toBeInTheDocument();
   });
 });
+
+// **目標点を確認するのに設定パネルを開き直す必要があった (#4758)。**姉妹ゲームの
+// Mariáš は同じ位置に出している。現在のチームスコアと突き合わせられないと、
+// あと何点で終わるか分からない。
+describe('ManillePage target points', () => {
+  it('shows the target score in the header bar', async () => {
+    mockExec.mockResolvedValue(makeManilleState({ config: { cpuDifficulty: 1, targetPoints: 21 } }));
+    renderWithProviders(<ManillePage />);
+    await waitFor(() => expect(screen.getByText('目標: 21点')).toBeInTheDocument());
+  });
+
+  // **設定した値をそのまま出す。**固定値を出すと、設定を変えても嘘のままになる。
+  it('follows the configured target rather than a fixed number', async () => {
+    mockExec.mockResolvedValue(makeManilleState({ config: { cpuDifficulty: 1, targetPoints: 41 } }));
+    renderWithProviders(<ManillePage />);
+    await waitFor(() => expect(screen.getByText('目標: 41点')).toBeInTheDocument());
+    expect(screen.queryByText('目標: 21点')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/ManillePage.tsx
+++ b/frontend/src/pages/ManillePage.tsx
@@ -232,7 +232,11 @@ function ManillePageContent() {
             <div className="text-ds-text-primary text-center mb-2">
               <span className="mr-4">{t('round', { n: state.roundNumber })}</span>
               <span className="mr-4">{t('trick', { n: state.trickNumber })}</span>
-              <span>{t('trump', { suit: trumpSymbol })}</span>
+              <span className="mr-4">{t('trump', { suit: trumpSymbol })}</span>
+              {/* **目標点を確認するのに設定パネルを開き直す必要があった (#4758)。**
+                  姉妹ゲームの Mariáš は同じ位置に出している。現在のチーム
+                  スコアと突き合わせられないと、あと何点で終わるか分からない。 */}
+              <span>{t('target', { points: state.config.targetPoints })}</span>
             </div>
 
             <div className={lgTwoColGrid}>


### PR DESCRIPTION
## 背景

`ManillePage.tsx` の設定パネルでは `targetPoints` を選べますが、**対局中のヘッダー情報バーには round / trick / trump しか出ていません** (#4758)。目標点を確認するには設定パネルを開き直す必要がありました。

チームスコアはサイドバーに出るので、**突き合わせられないと「あと何点で終わるか」が分かりません**。

姉妹ゲームの `MariasPage.tsx` は同じ位置に `<span>{t('target', { points: state.config.targetPoints })}</span>` を出しています。同じパターンに揃えました。

```
ラウンド: 1   トリック: 3   切り札: ♥   目標: 21点
```

## 設定した値をそのまま出します

固定値を出す実装にすると、**設定を変えても嘘のまま**になります。異なる目標点を設定した状態で、その値が出て古い値が出ないことをテストで確かめています。

## 負のコントロール

| 壊し方 | 落ちる件数 |
|---|---|
| 目標点を出さない | 2 |
| 固定値を出す | 1 |

## 検証

- `bunx vitest run src/pages/ManillePage.test.tsx` → 18 passed ✅
- `bun run typecheck` ✅ / `bun run check` exit 0 ✅

Closes #4758