### PR TITLE
feat: add a Klaverjas card-strength legend

### DIFF
--- a/frontend/src/i18n/locales/en/klaverjas.json
+++ b/frontend/src/i18n/locales/en/klaverjas.json
@@ -56,5 +56,16 @@
     "resetButton": "Use the reset button to start a new game."
   },
   "hintRequested": "Hint available",
-  "noHint": "No hint available"
+  "noHint": "No hint available",
+  "strengthLegend": {
+    "title": "Card strength and points",
+    "trumpCol": "Trump (J>9>A>10>K>Q>8>7)",
+    "plainCol": "Non-trump (A>10>K>Q>J>9>8>7)",
+    "rankCol": "#",
+    "cardCol": "Card",
+    "pointCol": "Pts",
+    "jas": "Jas",
+    "nel": "Nel",
+    "note": "The order differs between trump and non-trump. 162 points in total, plus 10 for the last trick."
+  }
 }

--- a/frontend/src/i18n/locales/ja/klaverjas.json
+++ b/frontend/src/i18n/locales/ja/klaverjas.json
@@ -56,5 +56,16 @@
     "resetButton": "リセットボタンで新しいゲームを始められます。"
   },
   "hintRequested": "ヒントがあります",
-  "noHint": "ヒントはありません"
+  "noHint": "ヒントはありません",
+  "strengthLegend": {
+    "title": "カードの強さと得点",
+    "trumpCol": "切り札 (J>9>A>10>K>Q>8>7)",
+    "plainCol": "切り札以外 (A>10>K>Q>J>9>8>7)",
+    "rankCol": "順位",
+    "cardCol": "カード",
+    "pointCol": "点",
+    "jas": "ヤス",
+    "nel": "ネル",
+    "note": "切り札と切り札以外で順序が入れ替わります。合計162点 + 最終トリック10点。"
+  }
 }

--- a/frontend/src/pages/KlaverjasPage.test.tsx
+++ b/frontend/src/pages/KlaverjasPage.test.tsx
@@ -189,3 +189,31 @@ describe('KlaverjasPage', () => {
     expect(await screen.findByText(/\(\[0\]\)/)).toBeInTheDocument();
   });
 });
+
+// **切り札と非切り札で強さの順序が完全に違う (#4757)。**切り札は J > 9 > A > 10、
+// 非切り札は A > 10 > K。姉妹ゲームの Manille には早見表があるのに、より覚え
+// にくいこちらには無かった。
+describe('KlaverjasPage strength legend', () => {
+  it('shows both orders in the legend panel', async () => {
+    renderWithProviders(<KlaverjasPage />);
+    const legend = await screen.findByTestId('klaverjas-strength-legend');
+    expect(legend).toHaveTextContent('J>9>A>10>K>Q>8>7');
+    expect(legend).toHaveTextContent('A>10>K>Q>J>9>8>7');
+  });
+
+  // **点数まで出す。**順序だけ分かっても、どの札を取りに行くべきかは分からない。
+  it('lists the trump Jack at twenty points', async () => {
+    renderWithProviders(<KlaverjasPage />);
+    const legend = await screen.findByTestId('klaverjas-strength-legend');
+    expect(legend).toHaveTextContent('20');
+    expect(legend).toHaveTextContent('ヤス');
+    expect(legend).toHaveTextContent('ネル');
+  });
+
+  // **たたんだ状態で置く。**常時開いていると盤面を押し出す。
+  it('keeps the panel collapsed by default', async () => {
+    renderWithProviders(<KlaverjasPage />);
+    const legend = await screen.findByTestId('klaverjas-strength-legend');
+    expect(legend).not.toHaveAttribute('open');
+  });
+});

--- a/frontend/src/pages/KlaverjasPage.tsx
+++ b/frontend/src/pages/KlaverjasPage.tsx
@@ -37,6 +37,37 @@ import { hintCheckboxItem } from '../utils/settingsItems';
 /** Suit symbols indexed by suit number (1=♠ 2=♣ 3=♥ 4=♦; index 0 unused). */
 const SUIT_SYMBOLS = ['', '♠', '♣', '♥', '♦'] as const;
 
+/**
+ * Card strength and points, strongest first (sync: `Klaverjas.trumpStrength` /
+ * `klaverjasPlainStrength` / `cardPoints`).
+ *
+ * **切り札と非切り札で順序が完全に違う。**切り札は J > 9 > A > 10 …、非切り札は
+ * A > 10 > K …。姉妹ゲームの Manille には早見表があるのに、より覚えにくいこちら
+ * には無かった (#4757)。
+ */
+const KLAVERJAS_TRUMP_ROWS: ReadonlyArray<{ face: string; points: number; nameKey?: string }> = [
+  { face: 'J', points: 20, nameKey: 'strengthLegend.jas' },
+  { face: '9', points: 14, nameKey: 'strengthLegend.nel' },
+  { face: 'A', points: 11 },
+  { face: '10', points: 10 },
+  { face: 'K', points: 4 },
+  { face: 'Q', points: 3 },
+  { face: '8', points: 0 },
+  { face: '7', points: 0 },
+];
+
+/** Non-trump strength and points, strongest first. */
+const KLAVERJAS_PLAIN_ROWS: ReadonlyArray<{ face: string; points: number }> = [
+  { face: 'A', points: 11 },
+  { face: '10', points: 10 },
+  { face: 'K', points: 4 },
+  { face: 'Q', points: 3 },
+  { face: 'J', points: 2 },
+  { face: '9', points: 0 },
+  { face: '8', points: 0 },
+  { face: '7', points: 0 },
+];
+
 /** Klaverjas tutorial step definitions. */
 const KLAVERJAS_TUTORIAL_STEPS: TutorialStep[] = [
   {
@@ -291,6 +322,50 @@ function KlaverjasPageContent() {
                     ))}
                   </div>
                 )}
+
+                {/* **切り札と非切り札で強さの順序が完全に違う (#4757)。**切り札は
+                    J > 9 > A > 10、非切り札は A > 10 > K。姉妹ゲームの Manille には
+                    早見表があるのに、より覚えにくいこちらには無かった。 */}
+                <details className="mb-2 p-2 rounded bg-black/30" data-testid="klaverjas-strength-legend">
+                  <summary className="cursor-pointer select-none text-ds-text-muted text-sm">
+                    {t('strengthLegend.title')}
+                  </summary>
+                  <div className="mt-1 text-ds-text-muted text-xs">
+                    {(
+                      [
+                        ['trumpCol', KLAVERJAS_TRUMP_ROWS],
+                        ['plainCol', KLAVERJAS_PLAIN_ROWS],
+                      ] as const
+                    ).map(([headKey, rows]) => (
+                      <table className="w-full mb-1" key={headKey}>
+                        <caption className="text-left">{t(`strengthLegend.${headKey}`)}</caption>
+                        <thead>
+                          <tr>
+                            <th scope="col" className="text-left font-normal">
+                              {t('strengthLegend.rankCol')}
+                            </th>
+                            <th scope="col" className="text-left font-normal">
+                              {t('strengthLegend.cardCol')}
+                            </th>
+                            <th scope="col" className="text-right font-normal">
+                              {t('strengthLegend.pointCol')}
+                            </th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {rows.map((row, i) => (
+                            <tr key={row.face}>
+                              <td>{i + 1}</td>
+                              <td>{'nameKey' in row && row.nameKey ? `${row.face} (${t(row.nameKey)})` : row.face}</td>
+                              <td className="text-right">{row.points}</td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    ))}
+                    <div className="mt-1">{t('strengthLegend.note')}</div>
+                  </div>
+                </details>
 
                 {/* Round result */}
                 {(isRoundEnd || isGameEnd) && (


### PR DESCRIPTION
## 背景

Klaverjas は**切り札と非切り札で強さの順序が完全に違います**。

| | 強い順 |
|---|---|
| 切り札 | **J > 9 > A > 10** > K > Q > 8 > 7 |
| 切り札以外 | **A > 10 > K** > Q > J > 9 > 8 > 7 |

姉妹ゲームの `ManillePage.tsx` には `manille-strength-legend` の早見表があるのに、**より覚えにくいこちらには説明が一切ありません**でした (#4757)。

## 両方の順序を並べて出します

片方だけだと「**順序が入れ替わる**」という肝心の点が伝わりません。非切り札の表を落とすとテストが落ちます。

## 点数まで出します

順序だけ分かっても、**どの札を取りに行くべきか**は分かりません。切り札の J（ヤス）は 20 点、9（ネル）は 14 点です。値は `Klaverjas.cardPoints` と揃えてあり、切り札 J を 2 点にするとテストが落ちます。

たたんだ状態で置きます（常時開いていると盤面を押し出すため）。

## 負のコントロール

| 壊し方 | 落ちる件数 |
|---|---|
| 非切り札の表を落とす | 1 |
| 切り札 J の点を間違える | 1 |
| 常に開いた状態にする | 1 |

## 検証

- `bunx vitest run src/pages/KlaverjasPage.test.tsx` → 21 passed ✅
- `bun run typecheck` ✅ / `bun run check` exit 0 ✅

Closes #4757