### PR TITLE
feat: show the Cruel foundation progress on the web page

### DIFF
--- a/frontend/src/i18n/locales/en/cruel.json
+++ b/frontend/src/i18n/locales/en/cruel.json
@@ -57,5 +57,6 @@
       "usageMove": "Usage: m <fromCol> <toCol|f>",
       "unknownCommand": "Unknown command: {{cmd}}"
     }
-  }
+  },
+  "foundationProgress": "Progress: {{total}}/52"
 }

--- a/frontend/src/i18n/locales/ja/cruel.json
+++ b/frontend/src/i18n/locales/ja/cruel.json
@@ -57,5 +57,6 @@
       "usageMove": "使い方: m <移動元列> <移動先列|f>",
       "unknownCommand": "不明なコマンド: {{cmd}}"
     }
-  }
+  },
+  "foundationProgress": "進捗: {{total}}/52"
 }

--- a/frontend/src/pages/CruelPage.test.tsx
+++ b/frontend/src/pages/CruelPage.test.tsx
@@ -304,3 +304,44 @@ describe('CruelPage keyboard shortcuts', () => {
     expect(mockExec).not.toHaveBeenCalled();
   });
 });
+
+// **52枚すべてを組札に収めることが唯一の勝利条件 (#4779)。**CUI は
+// foundationProgress で合計を常に出しているのに、Web は各組札を個別に描くだけで、
+// あと何枚かを知るには目で数えるしかなかった。
+describe('CruelPage foundation progress', () => {
+  it('shows the total across all four foundations', async () => {
+    mockExec.mockResolvedValue({
+      ...playingState,
+      foundation: [
+        [
+          { design: 'SPADE', value: 1 },
+          { design: 'SPADE', value: 2 },
+        ],
+        [{ design: 'HEART', value: 1 }],
+        [],
+        [],
+      ],
+    });
+    renderWithProviders(<CruelPage />);
+    expect(await screen.findByTestId('cruel-foundation-progress')).toHaveTextContent('3/52');
+  });
+
+  // **1山だけ数えない。**合計でないと「あと何枚か」の見通しにならない。
+  it('sums every pile rather than only the first', async () => {
+    mockExec.mockResolvedValue({
+      ...playingState,
+      foundation: [[], [], [], [{ design: 'DIAMOND', value: 1 }]],
+    });
+    renderWithProviders(<CruelPage />);
+    expect(await screen.findByTestId('cruel-foundation-progress')).toHaveTextContent('1/52');
+  });
+
+  it('starts at zero on an empty foundation', async () => {
+    mockExec.mockResolvedValue({
+      ...playingState,
+      foundation: [[], [], [], []],
+    });
+    renderWithProviders(<CruelPage />);
+    expect(await screen.findByTestId('cruel-foundation-progress')).toHaveTextContent('0/52');
+  });
+});

--- a/frontend/src/pages/CruelPage.tsx
+++ b/frontend/src/pages/CruelPage.tsx
@@ -275,6 +275,9 @@ function CruelPageContent() {
 
   if (!state) return <GameSkeleton gameKey="cruel" layout={{ kind: 'tableau', topRow: 4, tableau: 12 }} />;
 
+  // 4つの組札の合計。52枚すべてが収まればクリア。
+  const foundationTotal = state.foundation.reduce((sum, pile) => sum + pile.length, 0);
+
   const isPlaying = state.phase === CruelPhase.PLAYING;
   const isGameClear = state.phase === CruelPhase.GAME_CLEAR;
   const isGameOver = state.phase === CruelPhase.GAME_OVER;
@@ -310,6 +313,10 @@ function CruelPageContent() {
       cancelGiveUp={cancelGiveUp}
       headerExtra={
         <>
+          {/* **52枚すべてを組札に収めることが唯一の勝利条件 (#4779)。**CUI は
+              foundationProgress で合計を常に出しているのに、Web は各組札を
+              個別に描くだけで、あと何枚かを知るには目で数えるしかなかった。 */}
+          <span data-testid="cruel-foundation-progress">{t('foundationProgress', { total: foundationTotal })}</span>
           <span>
             {t('moveCount')}: {state.moveCount}
           </span>


### PR DESCRIPTION
## 背景

`CruelCuiPresenter` は組札の表示直後に `cruel.foundationProgress` で「**進捗 X/52**」を常に出しています。`CruelPage.tsx` の `headerExtra` は `moveCount` だけで、**4つの組札を個別に描くだけ**でした (#4779)。

進捗を知る手段は各組札を目で数えるか、`foundationAriaLabel` をスクリーンリーダーで1つずつ確認するかしかなく、**CUI のほうが一目で分かる情報を Web が持っていない**ねじれが生じていました。

Cruel は **52枚すべてを組札に収めることが唯一の勝利条件**なので、この合計は「あと何枚か」の見通しに直結します。CUI と同じ i18n の形（`進捗: {{total}}/52`）に揃えました。

## 4山すべてを合計します

1山だけ数える実装にするとテストが2件落ちます（合計でないと見通しになりません）。

## 負のコントロール

| 壊し方 | 落ちる件数 |
|---|---|
| 進捗を出さない | 3 |
| 1山だけ数える | 2 |

## 検証

- `bunx vitest run src/pages/CruelPage.test.tsx` → 31 passed ✅
- `bun run typecheck` ✅ / `bun run check` exit 0 ✅

Closes #4779