### PR TITLE
feat: sound the Egyptian Ratscrew slap result

### DIFF
--- a/frontend/src/pages/EgyptianRatscrewPage.test.tsx
+++ b/frontend/src/pages/EgyptianRatscrewPage.test.tsx
@@ -26,6 +26,22 @@ vi.mock('../api/gameApi', () => ({
   actionLogApi: { egyptianratscrew: vi.fn() },
 }));
 
+const mockPlaySound = vi.fn();
+const mockSoundValue = {
+  playSound: mockPlaySound,
+  muted: false,
+  toggleMute: vi.fn(),
+  claimExecSound: vi.fn(),
+  consumeExecClaim: () => false,
+};
+vi.mock('../providers/SoundProvider', () => ({
+  SoundProvider: ({ children }: { children: React.ReactNode }) => children,
+  useSound: () => mockSoundValue,
+  // AnimatedCard と中央のタップ (useGameApi / GamePageShell) は useOptionalSound を
+  // 使う。同じスパイに向けて、音の名前で絞って検証する。
+  useOptionalSound: () => mockSoundValue,
+}));
+
 const mockExec = vi.mocked(egyptianRatscrewApi.exec);
 
 const baseState: EgyptianRatscrewResponse = {
@@ -83,6 +99,9 @@ const gameEndState: EgyptianRatscrewResponse = {
 };
 
 beforeEach(() => {
+  // **音のスパイはテストごとに消す。**残ると、前のテストで鳴った音を
+  // 「CPU のスラップで鳴った」と誤検知する。
+  mockPlaySound.mockClear();
   mockExec.mockResolvedValue(baseState);
   mockUseCliMode.mockReturnValue({
     cliEnabled: false,
@@ -276,5 +295,46 @@ describe('EgyptianRatscrewPage', () => {
     mockExec.mockClear();
     fireEvent.keyDown(window, { key: 'Enter' });
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('step'));
+  });
+});
+
+// **姉妹ゲームの Slapjack には正誤の音があるのに、ERS は完全に無音だった
+// (#4749)。**視覚 (SlapBurst) と読み上げ (aria-live) はほぼ同じ実装なのに、
+// 音のフィードバックだけ欠けていた。
+describe('EgyptianRatscrewPage slap sounds', () => {
+  it('plays a fanfare on the human’s correct slap', async () => {
+    mockExec.mockResolvedValue({
+      ...baseState,
+      lastEventKind: EgyptianRatscrewEventKind.SLAP_CORRECT,
+      lastEventPlayerIdx: 0,
+      lastSlapReason: EgyptianRatscrewSlapReason.PAIR,
+    });
+    renderWithProviders(<EgyptianRatscrewPage />);
+    await waitFor(() => expect(mockPlaySound).toHaveBeenCalledWith('winFanfare'));
+  });
+
+  it('plays an error buzz on the human’s false slap', async () => {
+    mockExec.mockResolvedValue({
+      ...baseState,
+      lastEventKind: EgyptianRatscrewEventKind.SLAP_WRONG,
+      lastEventPlayerIdx: 0,
+    });
+    renderWithProviders(<EgyptianRatscrewPage />);
+    await waitFor(() => expect(mockPlaySound).toHaveBeenCalledWith('errorBuzz'));
+  });
+
+  // **CPU のスラップでは鳴らさない。**CPU の成功でファンファーレが鳴ったり、
+  // CPU のミスでブザーが鳴って人間が責められたように感じたりしないため。
+  it('stays silent for a CPU slap', async () => {
+    mockExec.mockResolvedValue({
+      ...baseState,
+      lastEventKind: EgyptianRatscrewEventKind.SLAP_CORRECT,
+      lastEventPlayerIdx: 1,
+      lastSlapReason: EgyptianRatscrewSlapReason.PAIR,
+    });
+    renderWithProviders(<EgyptianRatscrewPage />);
+    await waitFor(() => expect(screen.getByTestId('step-button')).toBeInTheDocument());
+    expect(mockPlaySound).not.toHaveBeenCalledWith('winFanfare');
+    expect(mockPlaySound).not.toHaveBeenCalledWith('errorBuzz');
   });
 });

--- a/frontend/src/pages/EgyptianRatscrewPage.tsx
+++ b/frontend/src/pages/EgyptianRatscrewPage.tsx
@@ -22,6 +22,7 @@ import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useMountReset } from '../hooks/useMountReset';
 import { useReflexShortcuts } from '../hooks/useReflexShortcuts';
+import { useSound } from '../providers/SoundProvider';
 import { badgeWarningColors } from '../styles/badgeStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { EgyptianRatscrewResponse } from '../types/card';
@@ -73,6 +74,7 @@ function EgyptianRatscrewPageContent() {
     useGamePageSetup('egyptianratscrew');
   const { state, loading, error, exec: execApi, retry } = useGameApi(egyptianRatscrewApi.exec);
   const { cardWidth } = useCardDimensions();
+  const { playSound } = useSound();
   const {
     hint: frontendHint,
     hintEnabled: frontendHintEnabled,
@@ -125,9 +127,16 @@ function EgyptianRatscrewPageContent() {
       } else {
         setSlapAnnounce(t('egyptianratscrew.slapAnnounce.wrong', { player: slapper }));
       }
+      // **人間自身のスラップのときだけ鳴らす (#4749)。**姉妹ゲームの Slapjack と
+      // 同じ扱い。CPU の成功でファンファーレが鳴ったり、CPU のミスでブザーが
+      // 鳴って人間が責められたように感じたりしないため。ミュートは
+      // SoundProvider が全体で見る。
+      if (player === 0) {
+        playSound(outcome === 'correct' ? 'winFanfare' : 'errorBuzz');
+      }
       prevSlapEventRef.current = { kind, player };
     }
-  }, [state, t, tc]);
+  }, [state, t, tc, playSound]);
 
   useMountReset(execApi);
 


### PR DESCRIPTION
## 背景

姉妹ゲームの `SlapjackPage.tsx` は人間のスラップが正解なら `'winFanfare'`、誤りなら `'errorBuzz'` を鳴らします。

`EgyptianRatscrewPage.tsx` は `SlapBurst`・`aria-live` の読み上げ・チャンス残数ドットまでほぼ同じ実装を持ちながら、**`useSound` の import すら無く完全に無音**でした (#4749)。同じ反射神経ゲームで音のフィードバックだけ欠けていました。

## 人間自身のスラップのときだけ鳴らします

CPU の成功でファンファーレが鳴ったり、**CPU のミスでブザーが鳴って人間が責められたように感じたり**しないためです（Slapjack と同じ扱い）。CPU でも鳴らす実装にするとテストが落ちます。

## テストの罠を1つ踏みました

音のスパイを `beforeEach` で消さないと、**前のテストで鳴った音を「CPU のスラップで鳴った」と誤検知**します（単体では通り、ファイル全体で落ちる形で表面化しました）。`mockPlaySound.mockClear()` を足しています。

## 負のコントロール

| 壊し方 | 落ちる件数 |
|---|---|
| 音を鳴らさない（元の挙動） | 2 |
| CPU のスラップでも鳴らす | 1 |
| 誤スラップも祝う | 1 |

## 検証

- `bunx vitest run src/pages/EgyptianRatscrewPage.test.tsx` → 25 passed ✅
- `bun run typecheck` ✅ / `bun run check` exit 0 ✅

Closes #4749