### PR TITLE
feat: show Penguin's supermove limit in the CUI

### DIFF
--- a/internal/adapter/presenter/PenguinCuiPresenter.go
+++ b/internal/adapter/presenter/PenguinCuiPresenter.go
@@ -81,6 +81,20 @@ func (p *PenguinCuiPresenter) Output(pg interfaces.PenguinGame, lastErr error) s
 			if pg.IsStalemate() {
 				b.WriteString(color.Red(i18n.T("cuiSolitaireStalemate")) + "\n")
 			}
+			// **上限が出ておらず、拒否されたコマンドで初めて気づく形だった
+			// (#4802)。**姉妹の Eight Off は supermoveLine を毎ターン出し、
+			// Web も pg-supermove-badge を常設している。
+			b.WriteString(i18n.Tf("penguin.supermoveLine",
+				"limit", strconv.Itoa(pg.GetMaxMovableCards()),
+				"cells", strconv.Itoa(penguinEmptyCells(pg)),
+				"cols", strconv.Itoa(penguinEmptyColumns(pg))))
+			// **空き列を移動先にすると上限は下がる。**その列自身を経由地に
+			// 使えないため。空き列があるときだけ出す。
+			if toEmpty := pg.GetMaxMovableCardsToEmptyColumn(); toEmpty > 0 {
+				b.WriteString(i18n.Tf("penguin.supermoveToEmpty",
+					"limit", strconv.Itoa(toEmpty)))
+			}
+			b.WriteString("\n")
 			b.WriteString(i18n.Tf("cuiSolitaireMoves",
 				"count", strconv.Itoa(pg.GetMoveCount())) + "\n")
 		case domain.PenguinPhaseGameClear:
@@ -125,4 +139,26 @@ func (p *PenguinCuiPresenter) ActionLogOutput(pg interfaces.PenguinGame) string 
 		return actionLogToText(nil)
 	}
 	return actionLogToText(pg.GetActionLog())
+}
+
+// penguinEmptyCells は空いているフリーセルの数を返す。
+func penguinEmptyCells(pg interfaces.PenguinGame) int {
+	n := 0
+	for _, c := range pg.GetFreeCells() {
+		if c == nil {
+			n++
+		}
+	}
+	return n
+}
+
+// penguinEmptyColumns は空いているタブロー列の数を返す。
+func penguinEmptyColumns(pg interfaces.PenguinGame) int {
+	n := 0
+	for _, col := range pg.GetTableau() {
+		if len(col) == 0 {
+			n++
+		}
+	}
+	return n
 }

--- a/internal/adapter/presenter/PenguinCuiPresenter_test.go
+++ b/internal/adapter/presenter/PenguinCuiPresenter_test.go
@@ -269,3 +269,56 @@ func TestPenguinCuiPresenterActionLogGameOver(t *testing.T) {
 
 	assert.Contains(t, result, "棋譜")
 }
+
+// **上限が出ておらず、拒否されたコマンドで初めて気づく形だった (#4802)。**
+// 姉妹の Eight Off は supermoveLine を毎ターン出し、Web も pg-supermove-badge を
+// 常設している。
+func TestPenguinCuiPresenterOutput_SupermoveLine(t *testing.T) {
+	p := new(PenguinCuiPresenter)
+	card := func(v int) *domain.Card { return domain.NewCard(domain.CardDesignSpade, v, false) }
+	board := func(filledCells, filledCols int) *domain.Penguin {
+		g := domain.NewPenguin(domain.NewTrumpCards(0))
+		g.Reset()
+		g.SetPhase(domain.PenguinPhasePlaying)
+		var cells [domain.PenguinCellCnt]*domain.Card
+		for i := 0; i < filledCells && i < domain.PenguinCellCnt; i++ {
+			cells[i] = card(i + 2)
+		}
+		g.SetFreeCells(cells)
+		var tableau [domain.PenguinTableauCnt][]*domain.Card
+		for i := 0; i < domain.PenguinTableauCnt; i++ {
+			if i < filledCols {
+				tableau[i] = []*domain.Card{card(5)}
+			}
+		}
+		g.SetTableau(tableau)
+		return g
+	}
+
+	t.Run("names the limit and what it is made of", func(t *testing.T) {
+		out := p.Output(board(0, domain.PenguinTableauCnt), nil)
+		assert.Contains(t, out, "一括移動")
+		assert.Contains(t, out, "空きセル")
+		assert.Contains(t, out, "空き列0")
+	})
+
+	// **空き列があるときだけ、そこへ置く上限も出す。**同じ数だと嘘になる。
+	t.Run("adds the lower empty-column limit when one exists", func(t *testing.T) {
+		assert.Contains(t, p.Output(board(0, domain.PenguinTableauCnt-1), nil), "空き列へは")
+	})
+
+	t.Run("omits the empty-column limit when no column is empty", func(t *testing.T) {
+		assert.NotContains(t, p.Output(board(0, domain.PenguinTableauCnt), nil), "空き列へは")
+	})
+
+	t.Run("shows a limit of one when the board is packed", func(t *testing.T) {
+		out := p.Output(board(domain.PenguinCellCnt, domain.PenguinTableauCnt), nil)
+		assert.Contains(t, out, "最大1枚")
+	})
+
+	t.Run("shows nothing once the game is cleared", func(t *testing.T) {
+		g := board(0, domain.PenguinTableauCnt)
+		g.SetPhase(domain.PenguinPhaseGameClear)
+		assert.NotContains(t, p.Output(g, nil), "一括移動")
+	})
+}

--- a/internal/domain/Penguin.go
+++ b/internal/domain/Penguin.go
@@ -609,6 +609,26 @@ func (p *Penguin) isValidTableauSequence(cards []*Card) bool {
 	return true
 }
 
+// GetMaxMovableCards はいま一度に動かせる最大枚数を返す (#4802)。
+//
+// **空き列を移動先にすると上限は下がる。**その列自身を経由地に使えないため。
+// 移動先を選ぶ前の一般的な上限がこちらで、空き列に置くときの上限は
+// GetMaxMovableCardsToEmptyColumn。
+func (p *Penguin) GetMaxMovableCards() int {
+	return p.maxMovableCards(-1)
+}
+
+// GetMaxMovableCardsToEmptyColumn は空き列へ動かすときの上限を返す。
+// 空き列が無いときは 0。
+func (p *Penguin) GetMaxMovableCardsToEmptyColumn() int {
+	for i := 0; i < PenguinTableauCnt; i++ {
+		if len(p.tableau[i]) == 0 {
+			return p.maxMovableCards(i)
+		}
+	}
+	return 0
+}
+
 // maxMovableCards 移動可能な最大カード枚数を計算
 func (p *Penguin) maxMovableCards(toCol int) int {
 	emptyFreeCells := 0

--- a/internal/domain/Penguin_test.go
+++ b/internal/domain/Penguin_test.go
@@ -1101,3 +1101,61 @@ func TestPenguinNewDefault(t *testing.T) {
 	p.Reset()
 	assert.Equal(t, PenguinPhasePlaying, p.GetPhase())
 }
+
+// **上限が出ておらず、拒否されたコマンドで初めて気づく形だった (#4802)。**
+// 姉妹の Eight Off は supermoveLine を毎ターン出している。
+func TestPenguin_GetMaxMovableCards(t *testing.T) {
+	card := func(v int) *Card { return NewCard(CardDesignSpade, v, false) }
+	board := func(filledCells, filledCols int) *Penguin {
+		p := NewDefaultPenguin()
+		p.Reset()
+		var cells [PenguinCellCnt]*Card
+		for i := 0; i < filledCells && i < PenguinCellCnt; i++ {
+			cells[i] = card(i + 2)
+		}
+		p.SetFreeCells(cells)
+		var tableau [PenguinTableauCnt][]*Card
+		for i := 0; i < PenguinTableauCnt; i++ {
+			if i < filledCols {
+				tableau[i] = []*Card{card(5)}
+			}
+		}
+		p.SetTableau(tableau)
+		return p
+	}
+
+	// **(1 + 空きセル) × 2^(空き列)。**セルは足し算、列は掛け算。
+	t.Run("counts free cells additively and empty columns as doubling", func(t *testing.T) {
+		assert.Equal(t, 1+PenguinCellCnt, board(0, PenguinTableauCnt).GetMaxMovableCards())
+		assert.Equal(t, (1+PenguinCellCnt)*2, board(0, PenguinTableauCnt-1).GetMaxMovableCards())
+	})
+
+	t.Run("with everything full only a single card moves", func(t *testing.T) {
+		assert.Equal(t, 1, board(PenguinCellCnt, PenguinTableauCnt).GetMaxMovableCards())
+	})
+
+	// **一般の上限はどの列も除外しない。**特定の列を除外した値を返すと、
+	// 空き列が1つ少ない前提の小さすぎる数を出すことになる。
+	t.Run("the general limit excludes no column, not even the first", func(t *testing.T) {
+		p := NewDefaultPenguin()
+		p.Reset()
+		p.SetFreeCells([PenguinCellCnt]*Card{})
+		var tableau [PenguinTableauCnt][]*Card
+		for i := 1; i < PenguinTableauCnt; i++ {
+			tableau[i] = []*Card{card(5)}
+		}
+		p.SetTableau(tableau)
+		assert.Equal(t, (1+PenguinCellCnt)*2, p.GetMaxMovableCards())
+	})
+
+	// **空き列を移動先にすると上限は下がる。**その列自身を経由地に使えない。
+	t.Run("moving onto an empty column halves the limit", func(t *testing.T) {
+		p := board(0, PenguinTableauCnt-1)
+		assert.Equal(t, (1+PenguinCellCnt)*2, p.GetMaxMovableCards())
+		assert.Equal(t, 1+PenguinCellCnt, p.GetMaxMovableCardsToEmptyColumn())
+	})
+
+	t.Run("reports zero when there is no empty column to move onto", func(t *testing.T) {
+		assert.Equal(t, 0, board(0, PenguinTableauCnt).GetMaxMovableCardsToEmptyColumn())
+	})
+}

--- a/internal/domain/interfaces/penguin.go
+++ b/internal/domain/interfaces/penguin.go
@@ -31,6 +31,10 @@ type PenguinGame interface {
 	GetTableau() [domain.PenguinTableauCnt][]*domain.Card
 	// GetFreeCells フリーセルを取得する
 	GetFreeCells() [domain.PenguinCellCnt]*domain.Card
+	// GetMaxMovableCards いま一度に動かせる最大枚数を取得する
+	GetMaxMovableCards() int
+	// GetMaxMovableCardsToEmptyColumn 空き列へ動かすときの上限を取得する
+	GetMaxMovableCardsToEmptyColumn() int
 	// GetFoundation ファンデーションを取得する
 	GetFoundation() [domain.PenguinFoundationCnt][]*domain.Card
 	// GetBaseRank ベースランクを取得する

--- a/internal/domain/interfaces/penguin_mock.go
+++ b/internal/domain/interfaces/penguin_mock.go
@@ -100,6 +100,16 @@ func (_m *MockPenguinGame) GetFreeCells() [domain.PenguinCellCnt]*domain.Card {
 	return ret.Get(0).([domain.PenguinCellCnt]*domain.Card)
 }
 
+func (_m *MockPenguinGame) GetMaxMovableCards() int {
+	args := _m.Called()
+	return args.Int(0)
+}
+
+func (_m *MockPenguinGame) GetMaxMovableCardsToEmptyColumn() int {
+	args := _m.Called()
+	return args.Int(0)
+}
+
 func (_m *MockPenguinGame) GetFoundation() [domain.PenguinFoundationCnt][]*domain.Card {
 	ret := _m.Called()
 	return ret.Get(0).([domain.PenguinFoundationCnt][]*domain.Card)

--- a/internal/i18n/locales/en/penguin.json
+++ b/internal/i18n/locales/en/penguin.json
@@ -26,5 +26,7 @@
   "hintToFoundation": "foundation",
   "hintToTableau": "tableau column {{col}}",
   "hintToFreeCell": "free cell {{col}}",
-  "hintLine": "Hint: {{from}} → {{to}}"
+  "hintLine": "Hint: {{from}} → {{to}}",
+  "supermoveLine": "Supermove: up to {{limit}} cards (free cells {{cells}} / empty columns {{cols}})",
+  "supermoveToEmpty": " / {{limit}} onto an empty column"
 }

--- a/internal/i18n/locales/ja/penguin.json
+++ b/internal/i18n/locales/ja/penguin.json
@@ -26,5 +26,7 @@
   "hintToFoundation": "ファンデーション",
   "hintToTableau": "タブロー列{{col}}",
   "hintToFreeCell": "フリーセル{{col}}",
-  "hintLine": "ヒント: {{from}} → {{to}}"
+  "hintLine": "ヒント: {{from}} → {{to}}",
+  "supermoveLine": "一括移動: 最大{{limit}}枚 (空きセル{{cells}} / 空き列{{cols}})",
+  "supermoveToEmpty": " / 空き列へは{{limit}}枚"
 }


### PR DESCRIPTION
## 背景

Penguin は Eight Off と同じスーパームーブ（空きフリーセル・空き列に応じた一括移動枚数上限）を実装しています。姉妹の `EightOffCuiPresenter` は毎ターン `eightoff.supermoveLine` を出し、Web も `pg-supermove-badge` を常設しているのに、**`PenguinCuiPresenter` にはこの行がありません**でした (#4802)。

ネイティブ CUI 利用者だけが上限を知らされず、**拒否されたコマンドで初めて気づく**形になっていました。

```
一括移動: 最大14枚 (空きセル6 / 空き列1) / 空き列へは7枚
```

## 空き列を移動先にすると上限は下がります

**その列自身を経由地に使えない**ためです。一般の上限と空き列への上限を分けて出します。同じ数を出すとテストが**5件**落ちます。

一般の上限は**どの列も除外しません**。特定の列を除外した値を返すと、空き列が1つ少ない前提の小さすぎる数になります（0列目だけを空にした盤面で踏んでいます）。

計算はドメインの `maxMovableCards`（移動の検証が使うもの）をそのまま使うので、**表示と実際に通る移動が同じ関数から出ます**。

## 負のコントロール

| 壊し方 | 落ちる件数 |
|---|---|
| 空き列への上限を一般の上限と同じにする | 5 |
| 行のキーを壊す（行が出ない） | 3 |
| 一般の上限で 0 列目を除外する | 2 |

## 検証

- `go test -tags test ./internal/...` ✅ / `golangci-lint run ./internal/...` → `0 issues.` ✅ / `gofmt -l internal/` 空 ✅
- `check-message-codes: OK (all 775 codes …)` ✅

Closes #4802