### PR TITLE
feat: show how many deals are left in Spiderette's CUI

### DIFF
--- a/internal/adapter/presenter/SpideretteCuiPresenter.go
+++ b/internal/adapter/presenter/SpideretteCuiPresenter.go
@@ -36,7 +36,12 @@ func (p *SpideretteCuiPresenter) Output(s interfaces.SpideretteGame, lastErr err
 			"completed", strconv.Itoa(s.GetCompletedSuits()),
 			"total", strconv.Itoa(domain.SpideretteFoundationCnt),
 			"stock", strconv.Itoa(s.GetStockCount()),
-			"score", strconv.Itoa(s.GetScore())) + "\n")
+			"score", strconv.Itoa(s.GetScore())))
+		// **生の残り枚数だけでは「あと何回配れるか」が分からない (#4798)。**
+		// 1回の配布は最大7枚で、端数の最終配布も1回として数える。Web は同じ
+		// 切り上げをバッジに出しているのに、CUI は暗算を強いていた。
+		b.WriteString(i18n.Tf("spiderette.dealsRemaining",
+			"count", strconv.Itoa(s.GetDealsRemaining())) + "\n")
 
 		b.WriteString("----------\n")
 

--- a/internal/adapter/presenter/SpideretteCuiPresenter_test.go
+++ b/internal/adapter/presenter/SpideretteCuiPresenter_test.go
@@ -16,6 +16,7 @@ func setupSpideretteCuiMockDefaults(sg *interfaces.MockSpideretteGame) {
 	sg.On("GetPhase").Return(domain.SpiderettePhasePlaying).Maybe()
 	sg.On("GetMoveCount").Return(0).Maybe()
 	sg.On("GetStockCount").Return(24).Maybe()
+	sg.On("GetDealsRemaining").Return(0).Maybe()
 	sg.On("GetCompletedSuits").Return(0).Maybe()
 	sg.On("GetScore").Return(500).Maybe()
 	sg.On("IsStalemate").Return(false).Maybe()
@@ -175,5 +176,30 @@ func TestSpideretteCuiPresenter_ActionLogOutput(t *testing.T) {
 		p := new(SpideretteCuiPresenter)
 		result := p.ActionLogOutput(sg)
 		assert.Contains(t, result, "棋譜はありません")
+	})
+}
+
+// **生の残り枚数だけでは「あと何回配れるか」が分からない (#4798)。**Web は
+// 切り上げたバッジを出しているのに、CUI は7で割る暗算を強いていた。
+func TestSpideretteCuiPresenter_DealsRemaining(t *testing.T) {
+	p := new(SpideretteCuiPresenter)
+	withDeals := func(stock, deals int) *interfaces.MockSpideretteGame {
+		sg := new(interfaces.MockSpideretteGame)
+		sg.On("GetStockCount").Return(stock)
+		sg.On("GetDealsRemaining").Return(deals)
+		setupSpideretteCuiMockDefaults(sg)
+		return sg
+	}
+
+	t.Run("prints the deal count alongside the raw stock", func(t *testing.T) {
+		out := p.Output(withDeals(15, 3), nil)
+		assert.Contains(t, out, "15")
+		assert.Contains(t, out, "残り配布: 3回")
+	})
+
+	// **0回でも出す。**行が消えると「まだ配れるのに表示が無い」のか
+	// 「もう配れない」のか区別が付かない。
+	t.Run("still says zero once the stock is spent", func(t *testing.T) {
+		assert.Contains(t, p.Output(withDeals(0, 0), nil), "残り配布: 0回")
 	})
 }

--- a/internal/domain/Spiderette.go
+++ b/internal/domain/Spiderette.go
@@ -123,6 +123,22 @@ func (s *Spiderette) Reset() {
 // Deal ストックからタブローに1枚ずつ配る。空列がある場合は配れない。
 // 山札が SpideretteDealCnt 未満の場合は残り全カードを左の列から配る
 // (標準 Spiderette ルール) ので、最後の3枚も到達可能。
+// GetDealsRemaining は「配る」をあと何回押せるかを返す (#4798)。
+//
+// **生の残り枚数だけでは分からない。**1回の配布は最大 SpideretteDealCnt 枚で、
+// 端数 (1〜6枚) の最終配布も1回として数える。Web は同じ切り上げをバッジに
+// 出しているのに、CUI は7で割って切り上げる暗算を強いていた。
+//
+// 空き列があると Deal は弾かれるが、それは一時的な状態なのでここでは見ない
+// (回数そのものは変わらない)。
+func (s *Spiderette) GetDealsRemaining() int {
+	n := len(s.stock)
+	if n <= 0 {
+		return 0
+	}
+	return (n + SpideretteDealCnt - 1) / SpideretteDealCnt
+}
+
 func (s *Spiderette) Deal() error {
 	if s.phase != SpiderettePhasePlaying {
 		return errors.New("game is not in playing phase")

--- a/internal/domain/Spiderette_test.go
+++ b/internal/domain/Spiderette_test.go
@@ -613,3 +613,52 @@ func TestSpideretteUnmarshalRejectsOversize(t *testing.T) {
 	var s Spiderette
 	assert.Error(t, json.Unmarshal(payload, &s))
 }
+
+// **生の残り枚数だけでは「あと何回配れるか」が分からない (#4798)。**Web は
+// 7で割った切り上げをバッジに出しているのに、CUI は暗算を強いていた。
+func TestSpiderette_GetDealsRemaining(t *testing.T) {
+	stock := func(n int) *Spiderette {
+		s := NewSpiderette(NewTrumpCards(0))
+		s.Reset()
+		cards := make([]*Card, n)
+		for i := range cards {
+			cards[i] = NewCard(CardDesignSpade, (i%13)+1, false)
+		}
+		s.SetStock(cards)
+		return s
+	}
+
+	t.Run("an empty stock leaves no deals", func(t *testing.T) {
+		assert.Equal(t, 0, stock(0).GetDealsRemaining())
+	})
+
+	// **端数も1回として数える。**残り1枚でも「配る」は押せる。切り捨てると
+	// 「もう配れない」と誤解させる。
+	t.Run("counts a partial deal as a full one", func(t *testing.T) {
+		assert.Equal(t, 1, stock(1).GetDealsRemaining())
+		assert.Equal(t, 1, stock(SpideretteDealCnt-1).GetDealsRemaining())
+	})
+
+	t.Run("counts one deal per full batch", func(t *testing.T) {
+		assert.Equal(t, 1, stock(SpideretteDealCnt).GetDealsRemaining())
+		assert.Equal(t, 2, stock(SpideretteDealCnt+1).GetDealsRemaining())
+		assert.Equal(t, 3, stock(SpideretteDealCnt*3).GetDealsRemaining())
+	})
+
+	// **実際に配り切るまでの回数と一致すること。**回数だけ別に数えると、
+	// 表示と実際に押せる回数がずれる。
+	t.Run("matches how many batches the stock actually splits into", func(t *testing.T) {
+		total := SpideretteDealCnt*2 + 3
+		s := stock(total)
+		want := s.GetDealsRemaining()
+		got, left := 0, total
+		for left > 0 {
+			left -= SpideretteDealCnt
+			if left < 0 {
+				left = 0
+			}
+			got++
+		}
+		assert.Equal(t, want, got)
+	})
+}

--- a/internal/domain/interfaces/spiderette.go
+++ b/internal/domain/interfaces/spiderette.go
@@ -23,6 +23,8 @@ type SpideretteGame interface {
 	GetMoveCount() int
 	// GetStockCount 山札の残り枚数を取得する
 	GetStockCount() int
+	// GetDealsRemaining 「配る」をあと何回押せるかを取得する
+	GetDealsRemaining() int
 	// GetTableau タブローを取得する
 	GetTableau() [domain.SpideretteTableauCnt][]*domain.SpideretteTableauCard
 	// GetCompletedSuits 完成スート数を取得する

--- a/internal/domain/interfaces/spiderette_mock.go
+++ b/internal/domain/interfaces/spiderette_mock.go
@@ -93,6 +93,11 @@ func (_m *MockSpideretteGame) GetStockCount() int {
 	return ret.Int(0)
 }
 
+func (_m *MockSpideretteGame) GetDealsRemaining() int {
+	args := _m.Called()
+	return args.Int(0)
+}
+
 // GetTableau mocks the GetTableau call.
 func (_m *MockSpideretteGame) GetTableau() [domain.SpideretteTableauCnt][]*domain.SpideretteTableauCard {
 	ret := _m.Called()

--- a/internal/i18n/locales/en/spiderette.json
+++ b/internal/i18n/locales/en/spiderette.json
@@ -9,5 +9,6 @@
   "header": "Completed: {{completed}}/{{total}} | Stock: {{stock}} | Score: {{score}}",
   "columnLabel": "Column {{col}}:",
   "gameClearLine": "Game clear! Moves: {{moves}} Score: {{score}}",
-  "hintLine": "Hint: tableau column {{fromCol}}[{{idx}}] → tableau column {{toCol}}"
+  "hintLine": "Hint: tableau column {{fromCol}}[{{idx}}] → tableau column {{toCol}}",
+  "dealsRemaining": " | Deals left: {{count}}"
 }

--- a/internal/i18n/locales/ja/spiderette.json
+++ b/internal/i18n/locales/ja/spiderette.json
@@ -9,5 +9,6 @@
   "header": "完成スーツ: {{completed}}/{{total}} | 山札: {{stock}}枚 | スコア: {{score}}",
   "columnLabel": "列{{col}}:",
   "gameClearLine": "ゲームクリア！ 手数: {{moves}} スコア: {{score}}",
-  "hintLine": "ヒント: タブロー列{{fromCol}}[{{idx}}] → タブロー列{{toCol}}"
+  "hintLine": "ヒント: タブロー列{{fromCol}}[{{idx}}] → タブロー列{{toCol}}",
+  "dealsRemaining": " | 残り配布: {{count}}回"
 }


### PR DESCRIPTION
## 背景

`SpiderettePage.tsx` は `Math.ceil(state.stockCount / TABLEAU_COLS)` を計算し、「端数の最終配布も1回の配布機会として切り上げる」注記付きで `dealsRemaining` バッジを出します。

`SpideretteCuiPresenter.Output` は**生の `GetStockCount()` しか出しません** (#4798)。CUI プレイヤーは7で割って切り上げる暗算をしないと、あと何回「配る」を押せるか把握できませんでした。

```
完成スーツ: 0/4 | 山札: 15枚 | スコア: 0 | 残り配布: 3回
```

## 端数も1回として数えます

**残り1枚でも「配る」は押せます。**切り捨てると「もう配れない」と誤解させます。切り捨てる実装にするとテストが4件落ちます。

0回のときも行を出します（行が消えると「まだ配れるのに表示が無い」のか「もう配れない」のか区別が付きません）。

## 負のコントロール

| 壊し方 | 落ちる件数 |
|---|---|
| 端数を切り捨てる | 4 |
| 生の枚数をそのまま返す | 4 |
| 行のキーを壊す | 3 |

## 検証

- `go test -tags test ./internal/...` ✅ / `golangci-lint run ./internal/...` → `0 issues.` ✅ / `gofmt -l internal/` 空 ✅
- `check-message-codes: OK (all 775 codes …)` ✅

Closes #4798