### PR TITLE
feat: show the next required rank per Calculation foundation

### DIFF
--- a/internal/adapter/presenter/CalculationCuiPresenter.go
+++ b/internal/adapter/presenter/CalculationCuiPresenter.go
@@ -36,6 +36,13 @@ func (p *CalculationCuiPresenter) Output(g interfaces.CalculationGame, lastErr e
 					"count", strconv.Itoa(len(pile)),
 					"max", maxStr))
 			}
+			// **各列が +1/+2/+3/+4 ずつ 13 を法として進む (#4794)。**Web は
+			// 次に置けるランクをバッジで常時出しているのに、CUI は一番上の札
+			// しか出さず、毎手この暗算を強いていた。
+			if next := g.GetNextFoundationRank(i); next > 0 {
+				b.WriteString(i18n.Tf("calculation.nextRank",
+					"rank", strconv.Itoa(next)))
+			}
 			b.WriteString("\n")
 		}
 		b.WriteString("----------\n")

--- a/internal/adapter/presenter/CalculationCuiPresenter_test.go
+++ b/internal/adapter/presenter/CalculationCuiPresenter_test.go
@@ -3,9 +3,11 @@
 package presenter
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
@@ -23,6 +25,7 @@ func setupCalculationCuiMockDefaults(g *interfaces.MockCalculationGame) {
 		foundations[i] = []*domain.Card{domain.NewCard(domain.CardDesignSpade, i+1, false)}
 	}
 	g.On("GetFoundations").Return(foundations).Maybe()
+	g.On("GetNextFoundationRank", mock.Anything).Return(0).Maybe()
 
 	var wastes [domain.CalculationWasteCnt][]*domain.Card
 	wastes[0] = []*domain.Card{domain.NewCard(domain.CardDesignHeart, 11, false)}
@@ -59,6 +62,7 @@ func TestCalculationCuiPresenter_Output(t *testing.T) {
 		g.On("GetStockTop").Return((*domain.Card)(nil)).Maybe()
 		var foundations [domain.CalculationFoundationCnt][]*domain.Card
 		g.On("GetFoundations").Return(foundations).Maybe()
+		g.On("GetNextFoundationRank", mock.Anything).Return(0).Maybe()
 		var wastes [domain.CalculationWasteCnt][]*domain.Card
 		g.On("GetWastes").Return(wastes).Maybe()
 
@@ -75,6 +79,7 @@ func TestCalculationCuiPresenter_Output(t *testing.T) {
 		g.On("GetStockTop").Return((*domain.Card)(nil)).Maybe()
 		var foundations [domain.CalculationFoundationCnt][]*domain.Card
 		g.On("GetFoundations").Return(foundations).Maybe()
+		g.On("GetNextFoundationRank", mock.Anything).Return(0).Maybe()
 		var wastes [domain.CalculationWasteCnt][]*domain.Card
 		g.On("GetWastes").Return(wastes).Maybe()
 
@@ -91,6 +96,7 @@ func TestCalculationCuiPresenter_Output(t *testing.T) {
 		g.On("GetStockTop").Return((*domain.Card)(nil)).Maybe()
 		var foundations [domain.CalculationFoundationCnt][]*domain.Card
 		g.On("GetFoundations").Return(foundations).Maybe()
+		g.On("GetNextFoundationRank", mock.Anything).Return(0).Maybe()
 		var wastes [domain.CalculationWasteCnt][]*domain.Card
 		g.On("GetWastes").Return(wastes).Maybe()
 
@@ -143,5 +149,45 @@ func TestCalculationCuiPresenter_ActionLogOutput(t *testing.T) {
 		g.On("GetPhase").Return(domain.CalculationPhaseGameOver)
 		g.On("GetActionLog").Return([]*domain.ActionLogEntry{{TurnNumber: 1, ActionType: "move", Detail: "test"}})
 		assert.NotEmpty(t, new(CalculationCuiPresenter).ActionLogOutput(g))
+	})
+}
+
+// **各列が +1/+2/+3/+4 ずつ 13 を法として進む (#4794)。**CUI は一番上の札しか
+// 出さず、毎手この暗算を強いていた。
+func TestCalculationCuiPresenter_NextRank(t *testing.T) {
+	p := new(CalculationCuiPresenter)
+	card := func(v int) *domain.Card { return domain.NewCard(domain.CardDesignSpade, v, false) }
+	withRanks := func(ranks ...int) *interfaces.MockCalculationGame {
+		g := new(interfaces.MockCalculationGame)
+		var foundations [domain.CalculationFoundationCnt][]*domain.Card
+		for i := range foundations {
+			foundations[i] = []*domain.Card{card(i + 1)}
+		}
+		g.On("GetFoundations").Return(foundations).Maybe()
+		for i, r := range ranks {
+			g.On("GetNextFoundationRank", i).Return(r).Maybe()
+		}
+		g.On("GetNextFoundationRank", mock.Anything).Return(0).Maybe()
+		g.On("GetWastes").Return([domain.CalculationWasteCnt][]*domain.Card{}).Maybe()
+		g.On("GetStockCount").Return(0).Maybe()
+		g.On("GetStockTop").Return((*domain.Card)(nil)).Maybe()
+		g.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil)).Maybe()
+		g.On("GetPhase").Return(domain.CalculationPhasePlaying).Maybe()
+		g.On("GetMoveCount").Return(0).Maybe()
+		g.On("IsStalemate").Return(false).Maybe()
+		return g
+	}
+
+	t.Run("names the next rank for each pile", func(t *testing.T) {
+		out := p.Output(withRanks(2, 4, 6, 8), nil)
+		assert.Equal(t, 4, strings.Count(out, "→ 次:"))
+		assert.Contains(t, out, "→ 次: 2")
+		assert.Contains(t, out, "→ 次: 8")
+	})
+
+	// **もう置けない山には出さない。**13枚そろった山に「次」は無い。
+	t.Run("omits the hint for a pile that is finished", func(t *testing.T) {
+		out := p.Output(withRanks(2, 0, 6, 0), nil)
+		assert.Equal(t, 2, strings.Count(out, "→ 次:"))
 	})
 }

--- a/internal/domain/Calculation.go
+++ b/internal/domain/Calculation.go
@@ -348,6 +348,26 @@ func (c *Calculation) canPlaceOnFoundation(card *Card, fIdx int) bool {
 	return card.GetValue() == calculationNextValue(topCard.GetValue(), fIdx+1)
 }
 
+// GetNextFoundationRank は fIdx のファンデーションに次に置けるランクを返す。
+// もう置けない (山が空 / 13枚そろった) ときは 0。
+//
+// **各列が +1/+2/+3/+4 ずつ 13 を法として進む (#4794)。**Web はバッジと
+// 「次のカード列」で常時出しているのに、CUI は現在の一番上の札しか出さず、
+// 毎手この暗算を強いていた。
+//
+// 判定は配置の検証 canPlaceOnFoundation が使う calculationNextValue を通す。
+// **別実装にすると、案内したランクが実際には置けないことが起きる。**
+func (c *Calculation) GetNextFoundationRank(fIdx int) int {
+	if fIdx < 0 || fIdx >= len(c.foundations) {
+		return 0
+	}
+	pile := c.foundations[fIdx]
+	if len(pile) == 0 || len(pile) >= CardValueMax {
+		return 0
+	}
+	return calculationNextValue(pile[len(pile)-1].GetValue(), fIdx+1)
+}
+
 // calculationNextValue ファンデーションの次に置くべき値を返す（step は 1..4、V は 1..13）。
 // v+step は最大で 13+4 = 17 なので、mod 13 は一度の減算で十分（ループ不要）。
 func calculationNextValue(v, step int) int {

--- a/internal/domain/Calculation_test.go
+++ b/internal/domain/Calculation_test.go
@@ -535,3 +535,55 @@ func TestCalculation_FindFoundation_NotFound(t *testing.T) {
 	// J (11) fits nowhere at initial state (foundations need 2,4,6,8)
 	assert.Equal(t, -1, c.findFoundation(NewCard(CardDesignSpade, 11, false)))
 }
+
+// **各列が +1/+2/+3/+4 ずつ 13 を法として進む (#4794)。**Web は次に置ける
+// ランクをバッジで常時出しているのに、CUI は毎手この暗算を強いていた。
+func TestCalculation_GetNextFoundationRank(t *testing.T) {
+	c := newTestCalculation()
+
+	// 初期状態は各ファンデーションに A,2,3,4 が1枚ずつ。
+	// 列0 (+1) は A の次で 2、列1 (+2) は 2 の次で 4、列2 (+3) は 3 の次で 6、
+	// 列3 (+4) は 4 の次で 8。
+	t.Run("applies each pile's own step", func(t *testing.T) {
+		assert.Equal(t, 2, c.GetNextFoundationRank(0))
+		assert.Equal(t, 4, c.GetNextFoundationRank(1))
+		assert.Equal(t, 6, c.GetNextFoundationRank(2))
+		assert.Equal(t, 8, c.GetNextFoundationRank(3))
+	})
+
+	// **13 を超えたら折り返す。**単なる足し算だと 14 以上を案内してしまう。
+	t.Run("wraps past the king", func(t *testing.T) {
+		assert.Equal(t, calculationNextValue(13, 1), 1, "K の次は A (+1 列)")
+		assert.Equal(t, calculationNextValue(12, 4), 3, "Q の +4 は 3")
+	})
+
+	// **13枚そろった山に「次」は無い。**出すと、置けない札を案内することになる。
+	t.Run("reports nothing once a pile is complete", func(t *testing.T) {
+		full := newTestCalculation()
+		pile := make([]*Card, CardValueMax)
+		for i := range pile {
+			pile[i] = NewCard(CardDesignSpade, i+1, false)
+		}
+		full.foundations[0] = pile
+		assert.Equal(t, 0, full.GetNextFoundationRank(0))
+	})
+
+	t.Run("reports nothing for an out-of-range pile", func(t *testing.T) {
+		assert.Equal(t, 0, c.GetNextFoundationRank(-1))
+		assert.Equal(t, 0, c.GetNextFoundationRank(CalculationFoundationCnt))
+	})
+
+	// **案内したランクは実際に置ける。**別実装だと置けない札を案内する。
+	t.Run("the rank it names is the one canPlaceOnFoundation accepts", func(t *testing.T) {
+		for i := range CalculationFoundationCnt {
+			next := c.GetNextFoundationRank(i)
+			require.NotEqual(t, 0, next, "foundation %d", i)
+			assert.True(t, c.canPlaceOnFoundation(NewCard(CardDesignSpade, next, false), i),
+				"foundation %d に %d が置けない", i, next)
+			// ひとつ違うランクは弾かれる。
+			wrong := next%CardValueMax + 1
+			assert.False(t, c.canPlaceOnFoundation(NewCard(CardDesignSpade, wrong, false), i),
+				"foundation %d に %d が置けてしまう", i, wrong)
+		}
+	})
+}

--- a/internal/domain/interfaces/calculation.go
+++ b/internal/domain/interfaces/calculation.go
@@ -31,6 +31,8 @@ type CalculationGame interface {
 	GetWastes() [domain.CalculationWasteCnt][]*domain.Card
 	// GetFoundations ファンデーション一覧を取得する
 	GetFoundations() [domain.CalculationFoundationCnt][]*domain.Card
+	// GetNextFoundationRank そのファンデーションに次に置けるランクを取得する (0=置けない)
+	GetNextFoundationRank(fIdx int) int
 	// IsStalemate 手詰まり状態を取得する
 	IsStalemate() bool
 }

--- a/internal/domain/interfaces/calculation_mock.go
+++ b/internal/domain/interfaces/calculation_mock.go
@@ -73,6 +73,11 @@ func (_m *MockCalculationGame) GetFoundations() [domain.CalculationFoundationCnt
 	return _m.Called().Get(0).([domain.CalculationFoundationCnt][]*domain.Card)
 }
 
+func (_m *MockCalculationGame) GetNextFoundationRank(fIdx int) int {
+	args := _m.Called(fIdx)
+	return args.Int(0)
+}
+
 func (_m *MockCalculationGame) IsStalemate() bool { return _m.Called().Bool(0) }
 
 func (_m *MockCalculationGame) GetActionLog() []*domain.ActionLogEntry {

--- a/internal/i18n/locales/en/calculation.json
+++ b/internal/i18n/locales/en/calculation.json
@@ -27,5 +27,6 @@
   "stockLine": "Stock: {{count}}",
   "stockNext": " next: {{card}}",
   "hintStock": "Hint: stock → foundation {{foundation}}",
-  "hintWaste": "Hint: waste {{waste}} → foundation {{foundation}}"
+  "hintWaste": "Hint: waste {{waste}} → foundation {{foundation}}",
+  "nextRank": " -> next: {{rank}}"
 }

--- a/internal/i18n/locales/ja/calculation.json
+++ b/internal/i18n/locales/ja/calculation.json
@@ -27,5 +27,6 @@
   "stockLine": "ストック: {{count}}枚",
   "stockNext": " 次のカード: {{card}}",
   "hintStock": "ヒント: ストック → ファンデーション{{foundation}}",
-  "hintWaste": "ヒント: ウェイスト{{waste}} → ファンデーション{{foundation}}"
+  "hintWaste": "ヒント: ウェイスト{{waste}} → ファンデーション{{foundation}}",
+  "nextRank": " → 次: {{rank}}"
 }


### PR DESCRIPTION
## 背景

Calculation は**各列が +1/+2/+3/+4 ずつ 13 を法として進む**ので、次に必要なランクを暗算で求めるのは難しいゲームです。

`CalculationPage.tsx` は `calculationNextRank` をバッジ（`nextRankBadge`）と「次のカード列」で常時表示します。`CalculationCuiPresenter.Output` は**一番上の札と枚数しか出しません** (#4794)。CUI プレイヤーは毎手この暗算を強いられていました。

```
[0] +1: SPADE 1 (1/13) → 次: 2
[1] +2: SPADE 2 (1/13) → 次: 4
[2] +3: SPADE 3 (1/13) → 次: 6
[3] +4: SPADE 4 (1/13) → 次: 8
```

## 判定は配置の検証そのものを通します

`calculationNextValue` は `canPlaceOnFoundation` が使う関数です。**別実装だと、案内したランクが実際には置けないことが起きます。**

「**案内したランクは `canPlaceOnFoundation` が受け付け、隣のランクは弾かれる**」をテストで固定しました。全列を +1 扱いにすると3件落ちます。

## 13枚そろった山には出しません

出すと**置けない札を案内する**ことになります。この負のコントロールは当初 0件でした（テストに完成した山が無かった）。13枚の山を組んだケースを足して 2件にしています。

## 負のコントロール

| 壊し方 | 落ちる件数 |
|---|---|
| 全列を +1 扱いにする | 3 |
| presenter が出さない | 3 |
| 完成した山にも出す | 2 |

## 検証

- `go test -tags test ./internal/...` ✅ / `golangci-lint run ./internal/...` → `0 issues.` ✅ / `gofmt -l internal/` 空 ✅
- `check-message-codes: OK (all 775 codes …)` ✅

Closes #4794