### PR TITLE
feat: put the Eight Off supermove limit in the header

### DIFF
--- a/frontend/src/i18n/locales/en/eightoff.json
+++ b/frontend/src/i18n/locales/en/eightoff.json
@@ -35,5 +35,7 @@
     "useFreeCells": "Consider moving a card to a free cell to open up moves"
   },
   "hintAnnouncement": "Hint: move {{card}} from {{from}} to {{to}}",
-  "hintNoMoves": "No moves available"
+  "hintNoMoves": "No moves available",
+  "supermoveBadge": "Max move: {{limit}}",
+  "supermoveBadgeTooltip": "Cards movable at once (free cells {{cells}}, empty columns {{cols}}). More empties means more cards."
 }

--- a/frontend/src/i18n/locales/ja/eightoff.json
+++ b/frontend/src/i18n/locales/ja/eightoff.json
@@ -35,5 +35,7 @@
     "useFreeCells": "フリーセルにカードを移動して手を広げましょう"
   },
   "hintAnnouncement": "ヒント: {{card}} を {{from}} から {{to}} へ移動",
-  "hintNoMoves": "移動可能な手がありません"
+  "hintNoMoves": "移動可能な手がありません",
+  "supermoveBadge": "最大移動: {{limit}}枚",
+  "supermoveBadgeTooltip": "一度に動かせる最大枚数（空きセル{{cells}}・空き列{{cols}}）。空きが増えるほど多く動かせます"
 }

--- a/frontend/src/pages/EightOffPage.test.tsx
+++ b/frontend/src/pages/EightOffPage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { actionLogApi, eightoffApi } from '../api/gameApi';
 import { useGameHint } from '../hooks/useGameHint';
@@ -1099,5 +1099,33 @@ describe('EightOffPage', () => {
         ),
       );
     });
+  });
+});
+
+// **上限を知るには赤くなった札にマウスを乗せるしかなかった (#4801)。**後追いの
+// 体験になる。ほぼ同型の Penguin は同じ計算式のバッジをヘッダーに常設している。
+describe('EightOffPage supermove badge', () => {
+  it('shows the current limit without any interaction', async () => {
+    renderWithProviders(<EightOffPage />);
+    const badge = await screen.findByTestId('eo-supermove-badge');
+    expect(badge).toBeInTheDocument();
+  });
+
+  // **空きセルが増えると上限も増える。**固定値を出すと、空きを作った意味が
+  // 見えない。
+  it('tracks the free cells rather than showing a fixed number', async () => {
+    mockExec.mockResolvedValue({ ...playingState, freeCells: [null, null, null, null, null, null, null, null] });
+    renderWithProviders(<EightOffPage />);
+    const withAllFree = (await screen.findByTestId('eo-supermove-badge')).textContent;
+
+    cleanup();
+    mockExec.mockResolvedValue({
+      ...playingState,
+      freeCells: [{ design: 'SPADE', value: 5 }, { design: 'HEART', value: 6 }, null, null, null, null, null, null],
+    });
+    renderWithProviders(<EightOffPage />);
+    const withTwoUsed = (await screen.findByTestId('eo-supermove-badge')).textContent;
+
+    expect(withAllFree).not.toEqual(withTwoUsed);
   });
 });

--- a/frontend/src/pages/EightOffPage.tsx
+++ b/frontend/src/pages/EightOffPage.tsx
@@ -269,6 +269,15 @@ function EightOffPageContent() {
           <span>
             {t('moveCount')}: {state.moveCount}
           </span>
+          {/* **上限を知るには赤くなった札にマウスを乗せるしかなかった (#4801)。**
+              後追いの体験になる。ほぼ同型の Penguin は同じ計算式のバッジを
+              ヘッダーに常設している。 */}
+          <span
+            data-testid="eo-supermove-badge"
+            title={t('supermoveBadgeTooltip', { cells: emptyFreeCells, cols: emptyTableauCols })}
+          >
+            {t('supermoveBadge', { limit: supermoveLimit })}
+          </span>
           <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
         </>
       }


### PR DESCRIPTION
## 背景

`EightOffPage.tsx` は `supermoveLimit` を計算して**上限を超えるスタックに赤リング + ホバー時のツールチップ**を出しますが、常時見えるバッジがありません (#4801)。

上限を知るには「**赤くなった札にマウスを乗せて初めて気づく**」後追いの体験になります。ほぼ同型のコードを持つ `PenguinPage.tsx` は同じ計算式のバッジ（`pg-supermove-badge`）をヘッダーに常設しています。

```
手数: 12   最大移動: 14枚
```

内訳（空きセル数・空き列数）は Penguin と同じく `title` 属性のツールチップに載せています。

## 空きセル・空き列に追従させます

固定値を出すと、**空きを作った意味が画面から見えません**。空きセルを2つ埋めた盤面と表示が変わることをテストで固定しました。

## 負のコントロール

| 壊し方 | 落ちる件数 |
|---|---|
| バッジを出さない | 2 |
| 固定値を出す | 1 |

## 検証

- `bunx vitest run src/pages/EightOffPage.test.tsx` → 80 passed ✅
- `bun run typecheck` ✅ / `bun run check` exit 0 ✅

Closes #4801