### PR TITLE
fix: stop Monte Carlo deal button from inviting an impossible deal

### DIFF
--- a/frontend/src/pages/MonteCarloPage.test.tsx
+++ b/frontend/src/pages/MonteCarloPage.test.tsx
@@ -297,3 +297,29 @@ describe('MonteCarloPage', () => {
     }
   });
 });
+
+// **山札が尽きたら「配る」は押せない (#4796)。**姉妹の Wasp / Spiderette は
+// stockCount === 0 を明示的にガードしている。ドメインも「隣接ペアなし かつ
+// 山札0 かつ 圧縮の余地なし」で手詰まりと判定するので、この状態は実際に起きる。
+describe('MonteCarloPage deal guard', () => {
+  it('disables the deal button once the stock is empty', async () => {
+    mockExec.mockResolvedValue({ ...playingState, stockCount: 0 });
+    renderWithProviders(<MonteCarloPage />);
+    expect(await screen.findByTestId('mc-deal-button')).toBeDisabled();
+  });
+
+  it('keeps the deal button live while cards remain', async () => {
+    mockExec.mockResolvedValue({ ...playingState, stockCount: 5 });
+    renderWithProviders(<MonteCarloPage />);
+    expect(await screen.findByTestId('mc-deal-button')).toBeEnabled();
+  });
+
+  // **無効な操作を「押せ」と誘導しない。**ペアが無くて山札も無いのは手詰まり
+  // であって、配れという合図ではない。
+  it('does not ring the deal button when there is nothing left to deal', async () => {
+    mockExec.mockResolvedValue({ ...playingState, stockCount: 0, board: [] });
+    renderWithProviders(<MonteCarloPage />);
+    const button = await screen.findByTestId('mc-deal-button');
+    expect(button.className).not.toContain('ring-ds-warning');
+  });
+});

--- a/frontend/src/pages/MonteCarloPage.tsx
+++ b/frontend/src/pages/MonteCarloPage.tsx
@@ -167,7 +167,13 @@ function MonteCarloPageContent() {
   // How many removable (adjacent, same-rank) pairs currently sit on the board.
   // Derived client-side from the board grid — 0 means it's time to Deal.
   const removablePairs = useMemo(() => (state ? countRemovablePairs(state.board) : 0), [state]);
-  const noRemovablePairs = isPlaying && removablePairs === 0;
+  // **山札が尽きたら「配る」は押せない (#4796)。**姉妹の Wasp / Spiderette は
+  // stockCount === 0 を明示的にガードしている。ドメインも「隣接ペアなし かつ
+  // 山札0 かつ 圧縮の余地なし」で手詰まりと判定するので、この状態は実際に起きる。
+  const canDeal = isPlaying && (state?.stockCount ?? 0) > 0;
+  // **山札が0なら警告リングも点けない。**無効な操作を「押せ」と誘導することに
+  // なるため。
+  const noRemovablePairs = isPlaying && removablePairs === 0 && canDeal;
 
   return (
     <GamePageShell
@@ -347,7 +353,7 @@ function MonteCarloPageContent() {
                     data-tutorial="mc-deal"
                     className={`${btnPrimary} ${dealHintActive || noRemovablePairs ? 'ring-2 ring-ds-warning' : ''}`}
                     onClick={handleDeal}
-                    disabled={loading}
+                    disabled={loading || !canDeal}
                   >
                     {t('button.deal')}
                   </button>


### PR DESCRIPTION
## 背景

`MonteCarloPage.tsx` の「配る」ボタンは `disabled={loading}` だけで、**山札が0でも押せます** (#4796)。姉妹の Wasp / Spiderette は `disabled={loading || state.stockCount === 0}` と明示的にガードしています。

ドメインの `checkMonteCarloStalemate` は「隣接ペアなし **かつ** 山札残り0 **かつ** 圧縮の余地なし」で手詰まりと判定するので、**山札が尽きた状態は実際に起こります**。

## 山札が0なら警告リングも点けません

`removablePairs === 0` のときボタンに警告リングを点ける演出がありますが、**山札0のときも点灯し続け、実際には無効な操作を「押せ」と誘導**していました。

ペアが無くて山札も無いのは**手詰まり**であって、配れという合図ではありません。

## 負のコントロール

| 壊し方 | 落ちる件数 |
|---|---|
| 山札0でも押せる（元の挙動） | 1 |
| 山札0でもリングを点ける（元の挙動） | 1 |

## 検証

- `bunx vitest run src/pages/MonteCarloPage.test.tsx` → 23 passed ✅
- `bun run typecheck` ✅ / `bun run check` exit 0 ✅

Closes #4796