### PR TITLE
feat: give Accordion's native CUI an autocomplete command

### DIFF
--- a/internal/adapter/controller/AccordionCuiController.go
+++ b/internal/adapter/controller/AccordionCuiController.go
@@ -35,6 +35,8 @@ func (c *AccordionCuiController) Exec(command string) string {
 				return c.ai.GiveUp(), true
 			case "u", "undo":
 				return c.ai.Undo(), true
+			case "ac", "autocomplete":
+				return c.ai.AutoComplete(), true
 			default:
 				return handleCuiHintAndLog(cmd, c.ai.Hint, c.ai.ActionLog)
 			}

--- a/internal/adapter/controller/AccordionCuiController_test.go
+++ b/internal/adapter/controller/AccordionCuiController_test.go
@@ -94,3 +94,25 @@ func TestAccordionCuiControllerEmpty(t *testing.T) {
 	result := c.Exec("")
 	assert.NotEmpty(t, result)
 }
+
+// **Web は1クリックで最後まで自動化できるのに、ネイティブ CUI には
+// オートコンプリートが無かった (#4793)。**姉妹の Wasp は ac/autocomplete を
+// 公開している。
+func TestAccordionCuiControllerAutoComplete(t *testing.T) {
+	ai := newMockAccordionInteractor()
+	c := NewAccordionCuiController(ai)
+	ai.On("AutoComplete").Return("auto_output")
+
+	assert.Equal(t, "auto_output", c.Exec("ac"))
+	assert.Equal(t, "auto_output", c.Exec("autocomplete"))
+}
+
+// **既存コマンドは何も変わらない。**
+func TestAccordionCuiControllerAutoCompleteDoesNotShadowOthers(t *testing.T) {
+	ai := newMockAccordionInteractor()
+	c := NewAccordionCuiController(ai)
+	ai.On("GiveUp").Return("giveup_output")
+
+	assert.Equal(t, "giveup_output", c.Exec("g"))
+	ai.AssertNotCalled(t, "AutoComplete")
+}

--- a/internal/adapter/controller/usecase/AccordionInteractor_mock.go
+++ b/internal/adapter/controller/usecase/AccordionInteractor_mock.go
@@ -21,6 +21,10 @@ func (_m *MockAccordionInteractor) Move(fromIdx, toIdx int) string {
 	return ret.Get(0).(string)
 }
 
+func (_m *MockAccordionInteractor) AutoComplete() string {
+	return _m.Called().String(0)
+}
+
 func (_m *MockAccordionInteractor) GiveUp() string {
 	ret := _m.Called()
 	return ret.Get(0).(string)

--- a/internal/domain/Accordion.go
+++ b/internal/domain/Accordion.go
@@ -121,6 +121,40 @@ func (a *Accordion) Move(fromIdx, toIdx int) error {
 	return nil
 }
 
+// AutoComplete はヒントが示す手を、手が尽きるまで繰り返す (#4793)。
+//
+// **Web は同じことを1クリックでやっている**のに、ネイティブ CUI には
+// オートコンプリートが存在せず、同じ手を延々と打たされていた。姉妹の Wasp は
+// ac/autocomplete を公開している。
+//
+// **手を選ぶ規則は GetHint と共有する。**別実装だと、ヒントが勧める手と自動で
+// 打たれる手が食い違う。
+//
+// 1手も動かせなければエラー。押しても何も起きないより、押せない理由が返る
+// ほうがよい。
+func (a *Accordion) AutoComplete() error {
+	if a.phase != AccordionPhasePlaying {
+		return errors.New("game is not in playing phase")
+	}
+	moved := 0
+	// **上限を置く。**Move はパイルを1つ減らすので理屈の上では停まるが、
+	// 規則を変えたときに無限ループへ落ちない保険。
+	for range len(a.piles) {
+		hint := a.GetHint()
+		if hint == nil {
+			break
+		}
+		if err := a.Move(hint.FromIdx, hint.ToIdx); err != nil {
+			break
+		}
+		moved++
+	}
+	if moved == 0 {
+		return errors.New("no automatic move is available")
+	}
+	return nil
+}
+
 // GiveUp ギブアップ
 func (a *Accordion) GiveUp() {
 	if a.phase == AccordionPhasePlaying {

--- a/internal/domain/Accordion_test.go
+++ b/internal/domain/Accordion_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 )
@@ -310,4 +311,65 @@ func TestAccordion_UnmarshalJSON_SizeLimit(t *testing.T) {
 func TestNewDefaultAccordion(t *testing.T) {
 	a := domain.NewDefaultAccordion()
 	assert.NotNil(t, a)
+}
+
+// **Web は1クリックで最後まで自動化できるのに、ネイティブ CUI には
+// オートコンプリートが存在せず、同じ手を延々と打たされていた (#4793)。**
+func TestAccordion_AutoComplete(t *testing.T) {
+	card := func(design, value int) *domain.Card { return domain.NewCard(design, value, false) }
+	board := func(cards ...*domain.Card) *domain.Accordion {
+		a := newTestAccordion()
+		piles := make([][]*domain.Card, len(cards))
+		for i, c := range cards {
+			piles[i] = []*domain.Card{c}
+		}
+		a.SetPiles(piles)
+		return a
+	}
+
+	t.Run("merges until no move is left", func(t *testing.T) {
+		// 同スート4枚。offset=3 と offset=1 の手が続き、最後は1山になる。
+		a := board(
+			card(domain.CardDesignSpade, 1), card(domain.CardDesignSpade, 2),
+			card(domain.CardDesignSpade, 3), card(domain.CardDesignSpade, 4),
+		)
+		require.NoError(t, a.AutoComplete())
+		assert.Equal(t, 1, len(a.GetPiles()), "全部まとまるはず")
+		assert.Nil(t, a.GetHint(), "打てる手が残っていない")
+	})
+
+	// **1手も動かせなければエラー。**押しても何も起きないより、押せない理由が
+	// 返るほうがよい。
+	t.Run("reports an error when nothing can be merged", func(t *testing.T) {
+		a := board(
+			card(domain.CardDesignSpade, 1), card(domain.CardDesignHeart, 5),
+			card(domain.CardDesignClover, 9), card(domain.CardDesignDiamond, 12),
+		)
+		require.Nil(t, a.GetHint(), "前提: 打てる手が無い")
+		assert.Error(t, a.AutoComplete())
+	})
+
+	// **理由まで正しく返す。**GetHint もフェーズを見るのでエラーにはなるが、
+	// 「打てる手が無い」ではなく「フェーズが違う」と伝わるほうが親切。
+	t.Run("rejected outside the playing phase, with that reason", func(t *testing.T) {
+		a := board(card(domain.CardDesignSpade, 1), card(domain.CardDesignSpade, 2))
+		a.GiveUp()
+		err := a.AutoComplete()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "playing phase")
+	})
+
+	// **打つ手はヒントと同じ規則で選ぶ。**別実装だと、ヒントが勧める手と自動で
+	// 打たれる手が食い違う。
+	t.Run("takes the move the hint points at", func(t *testing.T) {
+		a := board(
+			card(domain.CardDesignSpade, 1), card(domain.CardDesignHeart, 5),
+			card(domain.CardDesignClover, 9), card(domain.CardDesignDiamond, 1),
+		)
+		hint := a.GetHint()
+		require.NotNil(t, hint)
+		before := len(a.GetPiles())
+		require.NoError(t, a.AutoComplete())
+		assert.Less(t, len(a.GetPiles()), before)
+	})
 }

--- a/internal/domain/interfaces/accordion.go
+++ b/internal/domain/interfaces/accordion.go
@@ -15,6 +15,8 @@ type AccordionGame interface {
 	Move(fromIdx, toIdx int) error
 	// GiveUp ギブアップする
 	GiveUp()
+	// AutoComplete ヒントが示す手を尽きるまで繰り返す
+	AutoComplete() error
 	// GetHint ヒントを取得する
 	GetHint() *domain.AccordionHint
 	// Undo 操作を元に戻す

--- a/internal/domain/interfaces/accordion_mock.go
+++ b/internal/domain/interfaces/accordion_mock.go
@@ -26,6 +26,10 @@ func (_m *MockAccordionGame) GiveUp() {
 	_m.Called()
 }
 
+func (_m *MockAccordionGame) AutoComplete() error {
+	return _m.Called().Error(0)
+}
+
 func (_m *MockAccordionGame) GetHint() *domain.AccordionHint {
 	ret := _m.Called()
 	v := ret.Get(0)

--- a/internal/usecase/AccordionInteractor.go
+++ b/internal/usecase/AccordionInteractor.go
@@ -17,6 +17,8 @@ type AccordionInteractorIF interface {
 	// Move パイルを重ねる
 	Move(fromIdx, toIdx int) string
 	// GiveUp ギブアップ
+	// AutoComplete ヒントが示す手を尽きるまで繰り返す
+	AutoComplete() string
 	GiveUp() string
 	// Hint ヒント取得
 	Hint() string
@@ -50,6 +52,11 @@ func (ai *AccordionInteractor) Move(fromIdx, toIdx int) string {
 	return execAndPresent(ai.Game, ai.ap, func() error {
 		return ai.Game.Move(fromIdx, toIdx)
 	})
+}
+
+// AutoComplete ヒントが示す手を尽きるまで繰り返す
+func (ai *AccordionInteractor) AutoComplete() string {
+	return execAndPresent(ai.Game, ai.ap, ai.Game.AutoComplete)
 }
 
 // GiveUp ギブアップ


### PR DESCRIPTION
## 背景

`AccordionPage.tsx` は `accordionNextAutoMove` をループ実行して**1クリックで最後まで自動化**できます（`ac-autocomplete` ボタン、キー `a`）。

バックエンドの `AccordionInteractorIF` には `AutoComplete` が無く、`AccordionCuiController` にも `ac`/`autocomplete` がありません (#4793)。ネイティブ CUI 利用者は同じ手を延々と打たされていました。姉妹の Wasp は `ac`/`autocomplete` を公開しています。

## 打つ手は `GetHint` と同じ規則で選びます

フロントのヒューリスティックのコメントも「`GetHint` の優先順（offset 3 → 1）に合わせている」と書いています。**別実装だと、ヒントが勧める手と自動で打たれる手が食い違います。**1手で止める実装にするとテストが2件落ちます。

## 1手も動かせなければエラーを返します

押しても何も起きないより、**押せない理由が返る**ほうがよいためです。フェーズ違いのときは「打てる手が無い」ではなく「**フェーズが違う**」と伝わるよう、理由まで固定しました（この負のコントロールは当初 0件でした — `GetHint` もフェーズを見るのでどちらにせよエラーになり、メッセージを検証して初めて意味のあるゲートになりました）。

ループには上限を置いています。`Move` はパイルを1つ減らすので理屈の上では停まりますが、規則を変えたときに無限ループへ落ちない保険です。

## 負のコントロール

| 壊し方 | 落ちる件数 |
|---|---|
| 動かなくても成功を返す | 2 |
| 1手で止める | 2 |
| フェーズを見ない（理由が変わる） | 2 |
| `ac` コマンドの配線ミス | 1 |

## 検証

- `go test -tags test ./internal/...` ✅ / `golangci-lint run ./internal/...` → `0 issues.` ✅ / `gofmt -l internal/` 空 ✅

Closes #4793