### PR TITLE
feat: show what each Gaps gap needs in the CUI

### DIFF
--- a/internal/adapter/presenter/GapsCuiPresenter.go
+++ b/internal/adapter/presenter/GapsCuiPresenter.go
@@ -27,7 +27,9 @@ func (pr *GapsCuiPresenter) Output(g interfaces.GapsGame, lastErr error) string 
 				}
 				cell := grid[r][c]
 				if cell == nil {
-					b.WriteString("[ . ]")
+					// **どのカードが入るかも詰みかも分からなかった (#4800)。**
+					// Web はゴーストカードと 🚫 で常時プレビューしている。
+					b.WriteString(gapsGapCell(g, r, c))
 				} else {
 					b.WriteString(i18n.Tf("gaps.gridCard",
 						"row", strconv.Itoa(r),
@@ -84,4 +86,23 @@ func (pr *GapsCuiPresenter) ActionLogOutput(g interfaces.GapsGame) string {
 		return actionLogToText(nil)
 	}
 	return actionLogToText(g.GetActionLog())
+}
+
+// gapsGapCell は空きマスの表示を返す。何が入るか決まらないときは従来どおり
+// [ . ] のまま。**決まらないものを決まったように見せない。**
+func gapsGapCell(g interfaces.GapsGame, row, col int) string {
+	need := g.GetGapNeed(row, col)
+	if need == nil {
+		return "[ . ]"
+	}
+	switch need.Kind {
+	case domain.GapsNeedBlocked:
+		return i18n.T("gaps.gapBlocked")
+	case domain.GapsNeedAnySuit:
+		return i18n.Tf("gaps.gapAnySuit", "rank", strconv.Itoa(need.Value))
+	case domain.GapsNeedCard:
+		return i18n.Tf("gaps.gapNeeded",
+			"card", cuiCardStr(domain.NewCard(need.Design, need.Value, false)))
+	}
+	return "[ . ]"
 }

--- a/internal/adapter/presenter/GapsCuiPresenter_test.go
+++ b/internal/adapter/presenter/GapsCuiPresenter_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
@@ -32,6 +33,7 @@ func setupGapsCuiMock() *interfaces.MockGapsGame {
 		}
 	}
 	g.On("GetGrid").Return(grid).Maybe()
+	g.On("GetGapNeed", mock.Anything, mock.Anything).Return((*domain.GapsGapNeed)(nil)).Maybe()
 	g.On("GetLockedPrefixLengths").Return([domain.GapsRowCnt]int{3, 0, 0, 0}).Maybe()
 	g.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil)).Maybe()
 	return g
@@ -61,6 +63,7 @@ func TestGapsCuiPresenter_Output_GameClear(t *testing.T) {
 	g.On("UndoToEscape").Return(0).Maybe()
 	var grid [domain.GapsRowCnt][domain.GapsColCnt]domain.GapsCell
 	g.On("GetGrid").Return(grid).Maybe()
+	g.On("GetGapNeed", mock.Anything, mock.Anything).Return((*domain.GapsGapNeed)(nil)).Maybe()
 	g.On("GetLockedPrefixLengths").Return([domain.GapsRowCnt]int{}).Maybe()
 	g.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil)).Maybe()
 
@@ -81,6 +84,7 @@ func TestGapsCuiPresenter_Output_GameOver(t *testing.T) {
 	g.On("UndoToEscape").Return(-1).Maybe()
 	var grid [domain.GapsRowCnt][domain.GapsColCnt]domain.GapsCell
 	g.On("GetGrid").Return(grid).Maybe()
+	g.On("GetGapNeed", mock.Anything, mock.Anything).Return((*domain.GapsGapNeed)(nil)).Maybe()
 	g.On("GetLockedPrefixLengths").Return([domain.GapsRowCnt]int{}).Maybe()
 	g.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil)).Maybe()
 	p := &GapsCuiPresenter{}
@@ -118,4 +122,46 @@ func TestGapsCuiPresenter_ActionLogOutput(t *testing.T) {
 	// Phase==Playing returns empty action log
 	out := p.ActionLogOutput(g)
 	assert.NotNil(t, out)
+}
+
+// **どのカードが入るかも詰みかも CUI から分からなかった (#4800)。**Web は
+// ゴーストカードと 🚫 で常時プレビューしている。
+func TestGapsCuiPresenter_GapNeeds(t *testing.T) {
+	p := new(GapsCuiPresenter)
+	withNeed := func(need *domain.GapsGapNeed) *interfaces.MockGapsGame {
+		g := new(interfaces.MockGapsGame)
+		var grid [domain.GapsRowCnt][domain.GapsColCnt]domain.GapsCell
+		g.On("GetGrid").Return(grid).Maybe()
+		g.On("GetGapNeed", 0, 0).Return(need).Maybe()
+		g.On("GetGapNeed", mock.Anything, mock.Anything).Return((*domain.GapsGapNeed)(nil)).Maybe()
+		g.On("GetLockedPrefixLengths").Return([domain.GapsRowCnt]int{}).Maybe()
+		g.On("GetPhase").Return(domain.GapsPhasePlaying).Maybe()
+		g.On("GetMoveCount").Return(0).Maybe()
+		g.On("GetRedealsLeft").Return(2).Maybe()
+		g.On("GetRedealsUsed").Return(0).Maybe()
+		g.On("GetMaxRedeals").Return(2).Maybe()
+		g.On("GetRedealsRemaining").Return(2).Maybe()
+		g.On("IsStalemate").Return(false).Maybe()
+		g.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil)).Maybe()
+		return g
+	}
+
+	t.Run("names the exact card a gap needs", func(t *testing.T) {
+		out := p.Output(withNeed(&domain.GapsGapNeed{
+			Kind: domain.GapsNeedCard, Design: domain.CardDesignHeart, Value: 6,
+		}), nil)
+		assert.Contains(t, out, "HEART 6")
+	})
+
+	t.Run("marks a blocked gap differently from an open one", func(t *testing.T) {
+		blocked := p.Output(withNeed(&domain.GapsGapNeed{Kind: domain.GapsNeedBlocked}), nil)
+		anySuit := p.Output(withNeed(&domain.GapsGapNeed{Kind: domain.GapsNeedAnySuit, Value: 2}), nil)
+		assert.NotEqual(t, blocked, anySuit, "詰みと空きが同じ見た目になっている")
+		assert.Contains(t, blocked, "[ x ]")
+	})
+
+	// **決まらないマスは従来どおり。**左隣も空きのときは何が入るか決まらない。
+	t.Run("leaves an undetermined gap as the plain placeholder", func(t *testing.T) {
+		assert.Contains(t, p.Output(withNeed(nil), nil), "[ . ]")
+	})
 }

--- a/internal/domain/Gaps.go
+++ b/internal/domain/Gaps.go
@@ -140,6 +140,58 @@ func (g *Gaps) Move(fromRow, fromCol, toRow, toCol int) error {
 	return nil
 }
 
+// ギャップが受け入れる札の種類 (#4800)。
+const (
+	// GapsNeedAnySuit どのスートでもよい (0列目)。
+	GapsNeedAnySuit = "anySuit"
+	// GapsNeedCard 特定の1枚だけが入る。
+	GapsNeedCard = "needed"
+	// GapsNeedBlocked 何も置けない (左が K)。
+	GapsNeedBlocked = "blocked"
+)
+
+// GapsGapNeed はギャップが受け入れる札。
+type GapsGapNeed struct {
+	// Kind は GapsNeed* のいずれか。
+	Kind string
+	// Design は GapsNeedCard のときのスート。
+	Design int
+	// Value は GapsNeedAnySuit / GapsNeedCard のときのランク。
+	Value int
+}
+
+// GetGapNeed は (row, col) のギャップに何が入るかを返す。
+//
+// **各ギャップが受け入れる次ランクを追うのが Gaps の根幹戦略 (#4800)。**Web は
+// ゴーストカードと 🚫 で常時プレビューしているのに、CUI は空きマスを一律
+// [ . ] としか出さず、どのカードが入るかも詰みかも分からなかった。
+//
+// nil を返すのは、そのマスがギャップでないとき、座標が範囲外のとき、および
+// **左隣も空きで何が入るか決まらないとき**。決まらないものを決まったように
+// 見せない。
+//
+// 判定は移動の検証 isLegalMove と同じ条件を見る。**別実装にすると、案内した
+// 札が実際には置けない。**
+func (g *Gaps) GetGapNeed(row, col int) *GapsGapNeed {
+	if err := validateGapsPos(row, col); err != nil {
+		return nil
+	}
+	if g.grid[row][col] != nil {
+		return nil
+	}
+	if col == 0 {
+		return &GapsGapNeed{Kind: GapsNeedAnySuit, Value: GapsAnchorRank}
+	}
+	left := g.grid[row][col-1]
+	if left == nil {
+		return nil
+	}
+	if left.GetValue() == GapsKingRank {
+		return &GapsGapNeed{Kind: GapsNeedBlocked}
+	}
+	return &GapsGapNeed{Kind: GapsNeedCard, Design: left.GetDesign(), Value: left.GetValue() + 1}
+}
+
 // isLegalMove は (fromRow,fromCol) のカードが (toRow,toCol) の隙間へ置けるかを判定する。
 // 呼び出し側は事前に src!=nil, dst==nil および領域境界をチェックすること。
 func (g *Gaps) isLegalMove(fromRow, fromCol, toRow, toCol int) bool {

--- a/internal/domain/Gaps_test.go
+++ b/internal/domain/Gaps_test.go
@@ -2,6 +2,9 @@ package domain
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // newTestGaps returns a Gaps with the standard Reset() layout.
@@ -614,4 +617,77 @@ func TestSetters_AndGetters(t *testing.T) {
 		// allow empty but not nil
 		t.Log("action log is nil after Reset — acceptable if we never call appendLog")
 	}
+}
+
+// **各ギャップが受け入れる次ランクを追うのが Gaps の根幹戦略 (#4800)。**Web は
+// ゴーストカードと 🚫 で常時プレビューしているのに、CUI は空きマスを一律
+// [ . ] としか出していなかった。
+func TestGaps_GetGapNeed(t *testing.T) {
+	card := func(design, value int) *Card { return NewCard(design, value, false) }
+	// row0 に指定のセルを並べた盤面 (残りは空き)。
+	board := func(cells ...*Card) *Gaps {
+		g := NewDefaultGaps()
+		g.Reset()
+		var grid [GapsRowCnt][GapsColCnt]GapsCell
+		for i, c := range cells {
+			if i < GapsColCnt {
+				grid[0][i] = c
+			}
+		}
+		g.SetGrid(grid)
+		return g
+	}
+
+	// 0列目は「どのスートでもよい 2」。
+	t.Run("the leftmost column takes any two", func(t *testing.T) {
+		need := board().GetGapNeed(0, 0)
+		if assert.NotNil(t, need) {
+			assert.Equal(t, GapsNeedAnySuit, need.Kind)
+			assert.Equal(t, GapsAnchorRank, need.Value)
+		}
+	})
+
+	// **左隣が K なら詰み。**K の次は無いので何も置けない。
+	t.Run("a king on the left blocks the gap", func(t *testing.T) {
+		need := board(card(CardDesignSpade, GapsKingRank)).GetGapNeed(0, 1)
+		if assert.NotNil(t, need) {
+			assert.Equal(t, GapsNeedBlocked, need.Kind)
+		}
+	})
+
+	t.Run("names the exact card a gap needs", func(t *testing.T) {
+		need := board(card(CardDesignHeart, 5)).GetGapNeed(0, 1)
+		if assert.NotNil(t, need) {
+			assert.Equal(t, GapsNeedCard, need.Kind)
+			assert.Equal(t, CardDesignHeart, need.Design)
+			assert.Equal(t, 6, need.Value, "同スートの次のランク")
+		}
+	})
+
+	// **左隣も空きなら何も言わない。**決まらないものを決まったように見せない。
+	t.Run("says nothing when the left neighbour is itself a gap", func(t *testing.T) {
+		assert.Nil(t, board().GetGapNeed(0, 2))
+	})
+
+	t.Run("says nothing for a filled cell or an out-of-range one", func(t *testing.T) {
+		g := board(card(CardDesignSpade, 5))
+		assert.Nil(t, g.GetGapNeed(0, 0), "埋まっているマス")
+		assert.Nil(t, g.GetGapNeed(-1, 0))
+		assert.Nil(t, g.GetGapNeed(0, GapsColCnt))
+	})
+
+	// **案内した札は実際に置ける。**別実装だと置けない札を案内する。
+	t.Run("the card it names is the one isLegalMove accepts", func(t *testing.T) {
+		g := board(card(CardDesignHeart, 5))
+		// 別の行に ♥6 と ♥7 を置いて、案内どおりの札だけが通ることを見る。
+		grid := g.GetGrid()
+		grid[1][0] = card(CardDesignHeart, 6)
+		grid[1][1] = card(CardDesignHeart, 7)
+		g.SetGrid(grid)
+
+		need := g.GetGapNeed(0, 1)
+		require.NotNil(t, need)
+		assert.True(t, g.isLegalMove(1, 0, 0, 1), "案内した ♥6 は置ける")
+		assert.False(t, g.isLegalMove(1, 1, 0, 1), "♥7 は置けない")
+	})
 }

--- a/internal/domain/interfaces/gaps.go
+++ b/internal/domain/interfaces/gaps.go
@@ -33,6 +33,8 @@ type GapsGame interface {
 	GetMoveCount() int
 	// GetGrid は盤面を返す。
 	GetGrid() [domain.GapsRowCnt][domain.GapsColCnt]domain.GapsCell
+	// GetGapNeed そのギャップに何が入るかを取得する (nil=対象外/未確定)
+	GetGapNeed(row, col int) *domain.GapsGapNeed
 	// GetLockedPrefixLengths は各行のロック済み接頭辞の長さ（再配布で保持される先頭カード数）を返す。
 	GetLockedPrefixLengths() [domain.GapsRowCnt]int
 	// GetRedealsUsed は使用済み再配り回数を返す。

--- a/internal/domain/interfaces/gaps_mock.go
+++ b/internal/domain/interfaces/gaps_mock.go
@@ -75,6 +75,14 @@ func (_m *MockGapsGame) GetGrid() [domain.GapsRowCnt][domain.GapsColCnt]domain.G
 	return ret.Get(0).([domain.GapsRowCnt][domain.GapsColCnt]domain.GapsCell)
 }
 
+func (_m *MockGapsGame) GetGapNeed(row, col int) *domain.GapsGapNeed {
+	args := _m.Called(row, col)
+	if args.Get(0) == nil {
+		return nil
+	}
+	return args.Get(0).(*domain.GapsGapNeed)
+}
+
 // GetLockedPrefixLengths モック
 func (_m *MockGapsGame) GetLockedPrefixLengths() [domain.GapsRowCnt]int {
 	ret := _m.Called()

--- a/internal/i18n/locales/en/gaps.json
+++ b/internal/i18n/locales/en/gaps.json
@@ -15,5 +15,8 @@
   "hintAvailable": "Hint available",
   "noHint": "No hint",
   "lockedMark": "*",
-  "lockedLegend": "* = kept on redeal"
+  "lockedLegend": "* = kept on redeal",
+  "gapBlocked": "[ x ]",
+  "gapAnySuit": "[{{rank}}?]",
+  "gapNeeded": "[{{card}}]"
 }

--- a/internal/i18n/locales/ja/gaps.json
+++ b/internal/i18n/locales/ja/gaps.json
@@ -15,5 +15,8 @@
   "hintAvailable": "ヒントあり",
   "noHint": "ヒントなし",
   "lockedMark": "*",
-  "lockedLegend": "* = 再配布で保持されるカード"
+  "lockedLegend": "* = 再配布で保持されるカード",
+  "gapBlocked": "[ x ]",
+  "gapAnySuit": "[{{rank}}?]",
+  "gapNeeded": "[{{card}}]"
 }


### PR DESCRIPTION
## 背景

**各ギャップが受け入れる次ランクを追うのが Gaps の根幹戦略**です。`GapsPage.tsx` は `computeGapsGhostHint` で「必要な特定カード」「任意スートでよいランク」「詰み」の3状態を常時プレビューし、スクリーンリーダー向けの説明も出しています。

`GapsCuiPresenter.Output` は空きマスを**一律 `[ . ]` としか表示しません** (#4800)。どのカードが入るかも、そもそも詰みかも分かりませんでした。

```
[0,0]SPADE 5 [♥6] [ x ] [ . ]
              ↑    ↑     ↑
        必要な札  詰み  未確定
```

## 判定は移動の検証と同じ条件を見ます

`isLegalMove` と同じ条件（0列目は 2、左が K なら不可、それ以外は同スートの次ランク）です。**別実装だと、案内した札が実際には置けません。**

「**案内した札は `isLegalMove` が通し、隣のランクは弾かれる**」をテストで固定しました。同ランクを案内する実装にすると2件落ちます。

## 左隣も空きなら何も言いません

何が入るか**決まらない**ので、従来どおり `[ . ]` のままです。決まらないものを決まったように見せません（未確定を確定扱いにすると2件落ちます）。

## 負のコントロール

| 壊し方 | 落ちる件数 |
|---|---|
| presenter が出さない | 3 |
| K の右も普通に案内する | 2 |
| 未確定を確定扱いにする | 2 |
| 同ランクを案内する | 2 |

## 検証

- `go test -tags test ./internal/...` ✅ / `golangci-lint run ./internal/...` → `0 issues.` ✅ / `gofmt -l internal/` 空 ✅
- `check-message-codes: OK (all 775 codes …)` ✅

Closes #4800