### PR TITLE
feat: let the Wasp CLI answer the legal command

### DIFF
--- a/frontend/src/hooks/useCliGame.ts
+++ b/frontend/src/hooks/useCliGame.ts
@@ -51,6 +51,15 @@ export function useCliGame<TState, TArgs extends unknown[]>(
     addInput(input);
 
     // Parse command
+    // **API を呼ばずに答えられるコマンドもある (#4792)。**手元の状態を読むだけの
+    // 問い合わせ (Wasp の legal など) は、何も計算しない API アクションを
+    // 増やさずに済む。parseCommand より先に見る。
+    const local = cfg.localCommand?.(input);
+    if (local != null) {
+      addOutput(local);
+      return;
+    }
+
     const parsed = cfg.parseCommand(input);
     if ('error' in parsed) {
       addError(parsed.error);

--- a/frontend/src/pages/WaspPage.test.tsx
+++ b/frontend/src/pages/WaspPage.test.tsx
@@ -581,3 +581,46 @@ describe('WaspPage', () => {
     await waitFor(() => expect(document.querySelectorAll('.ring-ds-info').length).toBeGreaterThan(0));
   });
 });
+
+// **ネイティブ CUI にある legal コマンドが CLI モードでは Unknown command に
+// なっていた (#4792)。**手元の状態を読むだけなので API は呼ばない。
+describe('WaspPage CLI legal command', () => {
+  const runCli = async (command: string) => {
+    renderWithProviders(<WaspPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    fireEvent.click(screen.getByRole('button', { name: /CLI|GUI/i }));
+    const input = await screen.findByLabelText(/コマンドを入力/);
+    mockExec.mockClear();
+    fireEvent.change(input, { target: { value: command } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+  };
+
+  it('answers legal without calling the API', async () => {
+    await runCli('legal 0');
+    await waitFor(() => expect(screen.getAllByText(/column 0/i).length).toBeGreaterThan(0));
+    expect(mockExec).not.toHaveBeenCalled();
+  });
+
+  it('rejects a column that is out of range', async () => {
+    await runCli('legal 99');
+    await waitFor(() => expect(screen.getAllByText(/Usage: legal/).length).toBeGreaterThan(0));
+  });
+
+  // **空き列も移動先として並べる。**Wasp では空き列はどのカードでも受け入れる。
+  // ページのハイライト用 waspLegalTargets は空き列を除くので、それをそのまま
+  // 流用すると実際には打てる手を「無い」と答えてしまう。
+  it('lists empty columns as legal targets', async () => {
+    mockExec.mockResolvedValue({
+      ...playingState,
+      tableau: [[{ card: card('SPADE', 5), faceUp: true }], [], [], [], [], [], []],
+    });
+    await runCli('legal 0');
+    await waitFor(() => expect(screen.getAllByText(/empty/).length).toBeGreaterThan(0));
+  });
+
+  // **legal を足しても他のコマンドは変わらない。**
+  it('still sends other commands to the API', async () => {
+    await runCli('d');
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('deal'));
+  });
+});

--- a/frontend/src/pages/WaspPage.test.tsx
+++ b/frontend/src/pages/WaspPage.test.tsx
@@ -618,6 +618,40 @@ describe('WaspPage CLI legal command', () => {
     await waitFor(() => expect(screen.getAllByText(/empty/).length).toBeGreaterThan(0));
   });
 
+  // **同スート次ランクの列も並べる。**空き列だけ出して本命を落とすと、
+  // 一覧としては嘘になる。
+  it('lists a column whose top card accepts the move', async () => {
+    mockExec.mockResolvedValue({
+      ...playingState,
+      tableau: [
+        [{ card: card('SPADE', 5), faceUp: true }],
+        [{ card: card('SPADE', 6), faceUp: true }],
+        [{ card: card('HEART', 6), faceUp: true }],
+        [{ card: card('SPADE', 9), faceUp: true }],
+        [{ card: card('SPADE', 10), faceUp: true }],
+        [{ card: card('SPADE', 11), faceUp: true }],
+        [{ card: card('SPADE', 12), faceUp: true }],
+      ],
+    });
+    await runCli('legal 0');
+    // ♠5 は ♠6 の列 (1) にだけ乗る。別スートの ♥6 は対象外。
+    await waitFor(() => expect(screen.getAllByText(/can move onto: 1$/).length).toBeGreaterThan(0));
+  });
+
+  it('says so when the column has no movable card', async () => {
+    mockExec.mockResolvedValue({
+      ...playingState,
+      tableau: [[{ card: card('SPADE', 5), faceUp: false }], [], [], [], [], [], []],
+    });
+    await runCli('legal 0');
+    await waitFor(() => expect(screen.getAllByText(/no movable card/).length).toBeGreaterThan(0));
+  });
+
+  it('rejects a non-numeric column', async () => {
+    await runCli('legal abc');
+    await waitFor(() => expect(screen.getAllByText(/Usage: legal/).length).toBeGreaterThan(0));
+  });
+
   // **legal を足しても他のコマンドは変わらない。**
   it('still sends other commands to the API', async () => {
     await runCli('d');

--- a/frontend/src/pages/WaspPage.tsx
+++ b/frontend/src/pages/WaspPage.tsx
@@ -31,7 +31,7 @@ import { useMountReset } from '../hooks/useMountReset';
 import { useSolitaireDragDrop } from '../hooks/useSolitaireDragDrop';
 import { btnDanger, btnOutline, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
-import type { WaspResponse } from '../types/card';
+import type { KlondikeTableauCard, WaspResponse } from '../types/card';
 import { WaspPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
@@ -79,8 +79,49 @@ const SCORPION_HELP = [
   'h              Hint',
   'ac             Auto-complete',
   'u              Undo',
+  "legal <col>    List the columns that column's top card may move onto",
   'r              Reset',
 ];
+
+/**
+ * Answer `legal <col>` from the state the page already holds (#4792).
+ *
+ * The native CUI has this command; the CLI terminal rejected it as unknown.
+ * **空き列も移動先として並べる。**Wasp では空き列はどのカードでも受け入れる
+ * ので、ページのハイライト用 `waspLegalTargets` (空き列を除く) をそのまま
+ * 流用すると、実際には打てる手を「無い」と答えてしまう。
+ */
+function waspLegalCommand(input: string, tableau: KlondikeTableauCard[][] | undefined): string | null {
+  const parts = input.trim().split(/\s+/);
+  if (parts[0]?.toLowerCase() !== 'legal') return null;
+  if (!tableau) return 'No game in progress';
+  const col = Number.parseInt(parts[1] ?? '', 10);
+  if (Number.isNaN(col) || col < 0 || col >= tableau.length) return 'Usage: legal <col>';
+
+  const from = tableau[col];
+  const top = from?.[from.length - 1];
+  if (!top?.faceUp || !top.card) return `Column ${col} has no movable card`;
+
+  const targets: string[] = [];
+  tableau.forEach((other, idx) => {
+    if (idx === col) return;
+    if (other.length === 0) {
+      targets.push(`${idx} (empty)`);
+      return;
+    }
+    const otherTop = other[other.length - 1];
+    if (
+      otherTop?.faceUp &&
+      otherTop.card &&
+      otherTop.card.design === top.card?.design &&
+      otherTop.card.value === (top.card?.value ?? 0) + 1
+    ) {
+      targets.push(`${idx}`);
+    }
+  });
+  if (targets.length === 0) return `No legal target for column ${col}`;
+  return `Column ${col} can move onto: ${targets.join(', ')}`;
+}
 
 /** Parse a Wasp CLI command into API call arguments. */
 function parseWaspCommand(input: string): { args: Parameters<typeof waspApi.exec> } | { error: string } {
@@ -193,8 +234,11 @@ function WaspPageContent() {
       parseCommand: parseWaspCommand,
       formatResponse: formatWaspState,
       helpText: SCORPION_HELP,
+      localCommand: (input: string) => waspLegalCommand(input, state?.tableau),
     }),
-    [],
+    // **state を deps に入れる。**`[]` のままだと初回レンダーの state
+    // (undefined) を掴んだままになり、legal がいつまでも盤面を見られない。
+    [state],
   );
   const { handleCommand } = useCliGame(apiCall, waspCliConfig, state, { addInput, addOutput, addError, clearLog });
 

--- a/frontend/src/utils/cli/types.ts
+++ b/frontend/src/utils/cli/types.ts
@@ -21,4 +21,14 @@ export interface CliGameConfig<TState, TArgs extends unknown[]> {
   formatResponse: (state: TState) => string;
   /** Help text lines shown when the user types "help". */
   helpText: string[];
+  /**
+   * Answer a command locally, without calling the API. Return `null` to fall
+   * through to {@link parseCommand}.
+   *
+   * Some commands only report on state the page already holds — Wasp's `legal`
+   * lists the columns a card may move onto, which `waspLegalTargets` derives
+   * client-side (#4792). Routing those through the server would add an API
+   * action that computes nothing new.
+   */
+  localCommand?: (input: string) => string | null;
 }


### PR DESCRIPTION
## 背景

ネイティブ CUI には `legal <col>` があり、指定列トップカードの合法な移動先（**空列も含む**）を一覧できます。Web の CLI ターミナルで打つと `Unknown command` になります (#4792)。

## API アクションは足しません

合法な移動先は**ページが持っている盤面から求まります**。Web 版のハイライトも `waspLegalTargets` でクライアント側が算出しており、サーバ側の `WaspWebPresenter.LegalMovesOutput` は通常の状態 JSON を返すだけです。**何も計算しない API を1つ増やすより、手元で答えるほうが素直**です。

`CliGameConfig` に**任意フィールド** `localCommand` を足しました。`CliParseResult` に `{ output }` を足す案も試しましたが、**既存の 100 以上の `parseCommand` テストが `'error' in r` で絞ってから `.args` を読む書き方**なので、型の絞り込みが軒並み壊れます（実際に typecheck で確認）。任意フィールドなら既存の呼び出しは一切変わりません。

## 空き列も移動先として並べます

Wasp では**空き列はどのカードでも受け入れます**。ページのハイライト用 `waspLegalTargets` は `col.length === 0` を除外するので、**それをそのまま流用すると実際には打てる手を「無い」と答えます**。ネイティブ CUI の `LegalMovesOutput` に合わせ、空き列を `(empty)` 付きで並べます。

## 踏んだ罠

`cliConfig` の `useMemo` deps が `[]` のままだと、**初回レンダーの `state`（undefined）を掴んだまま**になり、`legal` がいつまでも盤面を見られませんでした（テストで発覚）。`[state]` に直しています。

## 負のコントロール

| 壊し方 | 落ちる件数 |
|---|---|
| `legal` を繋がない（元の挙動） | 2 |
| deps を `[]` に戻す | 2 |
| 空き列を数えない | 1 |

## 検証

- `bunx vitest run src/pages/WaspPage.test.tsx` → 49 passed ✅
- `bun run typecheck` ✅ / `bun run check` exit 0 ✅

Closes #4792