### PR TITLE
feat: let the Poker Squares web page ask for the server's synergy hint

### DIFF
--- a/frontend/src/api/games/pokersquares.ts
+++ b/frontend/src/api/games/pokersquares.ts
@@ -6,6 +6,6 @@ import { gameExec } from '../gameExec';
 
 /** API client for the Poker Squares /pokersquares/exec endpoint. */
 export const pokersquaresApi = {
-  exec: (command: 'reset' | 'place' | 'undo' | 'giveup' | 'log', row?: number, col?: number) =>
+  exec: (command: 'reset' | 'place' | 'undo' | 'giveup' | 'hint' | 'log', row?: number, col?: number) =>
     gameExec<PokerSquaresResponse>('pokersquares', { command, row, col }),
 };

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -1435,7 +1435,9 @@
     "bidwhist.hintRequested": "Hint available",
     "bidwhist.noHint": "No hint available",
     "russianbank.stopAvailable": "The CPU missed a forced move — call Stop to penalise it",
-    "paigow.hintNone": "No hint is available now."
+    "paigow.hintNone": "No hint is available now.",
+    "pokersquares.hintAvailable": "Here is a hint",
+    "pokersquares.noHint": "No hint is available right now"
   },
   "manual": {
     "ariaLabel": "Game Manual",

--- a/frontend/src/i18n/locales/en/pokersquares.json
+++ b/frontend/src/i18n/locales/en/pokersquares.json
@@ -15,7 +15,8 @@
   "button": {
     "reset": "Reset",
     "undo": "Undo",
-    "giveup": "Give up"
+    "giveup": "Give up",
+    "hint": "Hint"
   },
   "settings": {
     "title": "Settings"
@@ -28,7 +29,9 @@
   },
   "hint": {
     "placeSynergy": "Place here to build toward a stronger poker hand",
-    "placeAny": "Place in any empty cell"
+    "placeAny": "Place in any empty cell",
+    "synergy": "Suggested: ({{row}},{{col}}) - works with the cards already there (+{{score}})",
+    "plain": "Suggested: ({{row}},{{col}}) - no synergy available"
   },
   "hand": {
     "highCard": "High Card",

--- a/frontend/src/i18n/locales/ja/common.json
+++ b/frontend/src/i18n/locales/ja/common.json
@@ -1435,7 +1435,9 @@
     "bidwhist.hintRequested": "ヒントがあります",
     "bidwhist.noHint": "ヒントはありません",
     "russianbank.stopAvailable": "CPU が強制手を取りこぼしています。「ストップ」で咎められます",
-    "paigow.hintNone": "いまはヒントを出せません。"
+    "paigow.hintNone": "いまはヒントを出せません。",
+    "pokersquares.hintAvailable": "ヒントを表示しました",
+    "pokersquares.noHint": "いま出せるヒントはありません"
   },
   "manual": {
     "ariaLabel": "ゲームマニュアル",

--- a/frontend/src/i18n/locales/ja/pokersquares.json
+++ b/frontend/src/i18n/locales/ja/pokersquares.json
@@ -15,7 +15,8 @@
   "button": {
     "reset": "リセット",
     "undo": "元に戻す",
-    "giveup": "ギブアップ"
+    "giveup": "ギブアップ",
+    "hint": "ヒント"
   },
   "settings": {
     "title": "設定"
@@ -28,7 +29,9 @@
   },
   "hint": {
     "placeSynergy": "役ができやすいマスに配置することを推奨",
-    "placeAny": "いずれかの空きマスに配置します"
+    "placeAny": "いずれかの空きマスに配置します",
+    "synergy": "推奨: ({{row}},{{col}}) — 既存のカードと相乗効果あり (+{{score}})",
+    "plain": "推奨: ({{row}},{{col}}) — 相乗効果は無し"
   },
   "hand": {
     "highCard": "ハイカード",

--- a/frontend/src/pages/PokerSquaresPage.test.tsx
+++ b/frontend/src/pages/PokerSquaresPage.test.tsx
@@ -454,3 +454,49 @@ describe('PokerSquaresPage', () => {
     expect(preview.textContent).toContain('+50');
   });
 });
+
+// **シナジーを考慮した本格的なヒントは CUI しか受け取れていなかった (#4790)。**
+// ページ側の useGameHint はシナジーを見ない単純なヒューリスティックなので、
+// Web プレイヤーのほうが弱い助言しか使えないという逆転が起きていた。
+describe('PokerSquaresPage server hint', () => {
+  it('asks the server when the hint button is pressed', async () => {
+    renderWithProviders(<PokerSquaresPage />);
+    const button = await screen.findByTestId('ps-hint-button');
+    fireEvent.click(button);
+    await waitFor(() => expect(mockApi).toHaveBeenCalledWith('hint'));
+  });
+
+  it('shows the suggested cell and that it has synergy', async () => {
+    mockApi.mockResolvedValue({
+      ...playingState,
+      hint: { row: 2, col: 3, score: 12, synergy: true },
+      messageCode: 'pokersquares.hintAvailable',
+    });
+    renderWithProviders(<PokerSquaresPage />);
+    const hint = await screen.findByTestId('ps-server-hint');
+    expect(hint).toHaveTextContent('2');
+    expect(hint).toHaveTextContent('3');
+    expect(hint).toHaveTextContent('12');
+  });
+
+  // **押していないのに出さない。**Output() は毎回 hint を載せるので、要求印が
+  // 無ければ黙る。
+  it('stays quiet until the hint is actually requested', async () => {
+    mockApi.mockResolvedValue({ ...playingState, hint: { row: 2, col: 3, score: 12, synergy: true } });
+    renderWithProviders(<PokerSquaresPage />);
+    await waitFor(() => expect(screen.getByTestId('ps-hint-button')).toBeInTheDocument());
+    expect(screen.queryByTestId('ps-server-hint')).not.toBeInTheDocument();
+  });
+
+  // **相乗効果の有無で文言を変える。**同じ文だと「置くだけ」と「効く」の
+  // 区別が付かない。
+  it('words a synergy-free suggestion differently', async () => {
+    mockApi.mockResolvedValue({
+      ...playingState,
+      hint: { row: 0, col: 0, score: 0, synergy: false },
+      messageCode: 'pokersquares.hintAvailable',
+    });
+    renderWithProviders(<PokerSquaresPage />);
+    expect(await screen.findByTestId('ps-server-hint')).toHaveTextContent('相乗効果は無し');
+  });
+});

--- a/frontend/src/pages/PokerSquaresPage.tsx
+++ b/frontend/src/pages/PokerSquaresPage.tsx
@@ -10,6 +10,7 @@ import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
 import { FrontendHintTooltip } from '../components/hint/FrontendHintTooltip';
+
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { CARD_DIMENSIONS, useCardDimensions, useWindowWidth } from '../hooks/useCardDimensions';
@@ -30,6 +31,7 @@ import { cardAlt } from '../utils/cardAlt';
 import { POKERSQUARES_HELP, parsePokerSquaresCommand } from '../utils/cli/commands/pokersquaresCommands';
 import { formatPokerSquaresState } from '../utils/cli/formatters/pokersquaresFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { isRequestedHint } from '../utils/hintRequest';
 import {
   evaluateFiveCardHand,
   evaluatePartialHand,
@@ -222,6 +224,10 @@ function PokerSquaresPageContent() {
     execApi('place', row, col);
   };
   const handleUndo = () => execApi('undo');
+  // **シナジーを考慮した本格的なヒントは CUI しか受け取れていなかった (#4790)。**
+  // ページ側の useGameHint はシナジーを見ない単純なヒューリスティックなので、
+  // Web プレイヤーのほうが弱い助言しか使えないという逆転が起きていた。
+  const handleHint = () => execApi('hint');
   const handleGiveUp = useCallback(() => execApi('giveup'), [execApi]);
   const handleReset = useCallback(() => execApi('reset'), [execApi]);
 
@@ -467,6 +473,16 @@ function PokerSquaresPageContent() {
           <GameFooter className={`${gameTheme.pokersquares.footer} px-4 py-2.5`}>
             <ErrorAlert message={error} onRetry={retry} />
             <FrontendHintTooltip hint={frontendHint} enabled={frontendHintEnabled} t={t} />
+            {/* サーバ側のシナジー考慮ヒント。ボタンを押したときだけ出す。 */}
+            {state?.hint && isRequestedHint(state) && (
+              <p className="text-center text-sm text-ds-accent mt-1" data-testid="ps-server-hint">
+                {t(state.hint.synergy ? 'hint.synergy' : 'hint.plain', {
+                  row: state.hint.row,
+                  col: state.hint.col,
+                  score: state.hint.score,
+                })}
+              </p>
+            )}
             <div className="flex gap-2 items-center flex-wrap" data-tutorial="ps-controls">
               {isPlaying && (
                 <>
@@ -477,6 +493,15 @@ function PokerSquaresPageContent() {
                     disabled={loading || !state?.canUndo}
                   >
                     {t('button.undo')}
+                  </button>
+                  <button
+                    type="button"
+                    className={btnPrimary}
+                    onClick={handleHint}
+                    disabled={loading}
+                    data-testid="ps-hint-button"
+                  >
+                    {t('button.hint')}
                   </button>
                   <button type="button" className={btnDanger} onClick={confirmGiveUpAction} disabled={loading}>
                     {t('button.giveup')}

--- a/frontend/src/types/games/pokersquares.ts
+++ b/frontend/src/types/games/pokersquares.ts
@@ -27,6 +27,24 @@ export interface PokerSquaresResponse extends BaseGameResponse {
   colScores: number[];
   /** Sum of all row and column scores. */
   totalScore: number;
+  /**
+   * Server-side placement hint, weighing row/column synergy.
+   *
+   * **The CUI had this and the Web did not (#4790).** The page's own
+   * `useGameHint` heuristic does not look at synergy, so a Web player got the
+   * weaker advice of the two.
+   */
+  hint?: PokerSquaresHint;
+}
+
+/** Server-side Poker Squares hint (sync: `domain.PokerSquaresHint`). */
+export interface PokerSquaresHint {
+  row: number;
+  col: number;
+  /** Row/column synergy score the placement would create. */
+  score: number;
+  /** Whether the score is positive (it works with the cards already there). */
+  synergy: boolean;
 }
 
 // --- Monte Carlo Solitaire (モンテカルロ・ソリティア) ---

--- a/internal/adapter/controller/PokerSquaresWebController.go
+++ b/internal/adapter/controller/PokerSquaresWebController.go
@@ -30,7 +30,18 @@ type PokerSquaresWebOutput struct {
 	RowScores   []int                          `json:"rowScores"`
 	ColScores   []int                          `json:"colScores"`
 	TotalScore  int                            `json:"totalScore"`
+	Hint        *PokerSquaresWebOutputHint     `json:"hint,omitempty"`
 	WebOutputBase
+}
+
+// PokerSquaresWebOutputHint はサーバ側のシナジー考慮ヒント (#4790)。
+type PokerSquaresWebOutputHint struct {
+	Row int `json:"row"`
+	Col int `json:"col"`
+	// Score はその配置が生む行・列の相乗効果スコア。
+	Score int `json:"score"`
+	// Synergy はスコアが正 (既存カードと相乗効果あり) かどうか。
+	Synergy bool `json:"synergy"`
 }
 
 // PokerSquaresWebController はポーカー・スクエアズ Web コントローラー。
@@ -62,6 +73,8 @@ func pokerSquaresDispatch(bc *baseController, w http.ResponseWriter, pi usecase.
 		bc.writePresenterResponse(w, pi.Undo())
 	case "g", "giveup":
 		bc.writePresenterResponse(w, pi.GiveUp())
+	case "h", "hint":
+		bc.writePresenterResponse(w, pi.Hint())
 	default:
 		return dispatchResetAndLog(param.Command, bc, w, pi.Reset, pi.ActionLog)
 	}

--- a/internal/adapter/controller/PokerSquaresWebController_test.go
+++ b/internal/adapter/controller/PokerSquaresWebController_test.go
@@ -57,6 +57,9 @@ func TestPokerSquaresWebController_Commands(t *testing.T) {
 	piMock.On("Undo").Return(mockOutput)
 	piMock.On("GiveUp").Return(mockOutput)
 	piMock.On("ActionLog").Return(mockOutput)
+	// **hint は Web からも呼べる (#4790)。**シナジー考慮ヒントは CUI しか
+	// 受け取れていなかった。
+	piMock.On("Hint").Return(mockOutput)
 
 	tests := []struct {
 		name    string
@@ -66,6 +69,8 @@ func TestPokerSquaresWebController_Commands(t *testing.T) {
 		{"undo", `{"command":"undo","sessionId":"s1"}`},
 		{"giveup", `{"command":"giveup","sessionId":"s1"}`},
 		{"log", `{"command":"log","sessionId":"s1"}`},
+		{"hint", `{"command":"hint","sessionId":"s1"}`},
+		{"hint short", `{"command":"h","sessionId":"s1"}`},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/adapter/presenter/PokerSquaresWebPresenter.go
+++ b/internal/adapter/presenter/PokerSquaresWebPresenter.go
@@ -3,6 +3,7 @@
 package presenter
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
@@ -42,6 +43,11 @@ func (pr *PokerSquaresWebPresenter) Output(p interfaces.PokerSquaresGame, lastEr
 		resObj.TotalScore += resObj.RowScores[i] + resObj.ColScores[i]
 	}
 
+	// **受動ヒントは Output() でも埋める。**command:"hint" 専用のレスポンスは
+	// ページの state にマージされないので、ここで埋めないと state.hint が
+	// 永久に undefined になる (#4483)。
+	resObj.Hint = pokerSquaresWebHint(p)
+
 	if lastErr != nil {
 		resObj.Message = lastErr.Error()
 	} else {
@@ -62,7 +68,31 @@ func (pr *PokerSquaresWebPresenter) Output(p interfaces.PokerSquaresGame, lastEr
 // ヒューリスティックヒントを使うため、ここでは JSON 化した状態を返して
 // PokerSquaresPresenter インタフェースを満たす (CUI のみが利用する)。
 func (pr *PokerSquaresWebPresenter) HintOutput(p interfaces.PokerSquaresGame) string {
-	return pr.Output(p, nil)
+	out := pr.Output(p, nil)
+	// **押したときだけ出す印を付ける。**ページは isRequestedHint で
+	// 「今まさに要求されたヒント」かを見分ける。Output() が常に載せる hint と
+	// 区別が付かないと、ボタンを押していないのに助言が出続ける。
+	var resObj controller.PokerSquaresWebOutput
+	if err := json.Unmarshal([]byte(out), &resObj); err != nil {
+		return out
+	}
+	if resObj.Hint != nil {
+		resObj.MessageCode = "pokersquares.hintAvailable"
+	} else {
+		resObj.MessageCode = "pokersquares.noHint"
+	}
+	return marshalOrError(&resObj)
+}
+
+// pokerSquaresWebHint はドメインのヒントを JSON 用の形に移す。
+func pokerSquaresWebHint(p interfaces.PokerSquaresGame) *controller.PokerSquaresWebOutputHint {
+	hint := p.GetHint()
+	if hint == nil {
+		return nil
+	}
+	return &controller.PokerSquaresWebOutputHint{
+		Row: hint.Row, Col: hint.Col, Score: hint.Score, Synergy: hint.Synergy,
+	}
 }
 
 // ActionLogOutput は棋譜を JSON で出力する。

--- a/internal/adapter/presenter/PokerSquaresWebPresenter_test.go
+++ b/internal/adapter/presenter/PokerSquaresWebPresenter_test.go
@@ -16,6 +16,7 @@ import (
 
 func setupPokerSquaresWebMockDefaults(pg *interfaces.MockPokerSquaresGame) {
 	pg.On("GetPhase").Return(domain.PokerSquaresPhasePlaying).Maybe()
+	pg.On("GetHint").Return((*domain.PokerSquaresHint)(nil)).Maybe()
 	pg.On("GetPlacedCount").Return(0).Maybe()
 	pg.On("CanUndo").Return(false).Maybe()
 	pg.On("GetCurrentCard").Return(domain.NewCard(domain.CardDesignSpade, 5, false)).Maybe()
@@ -61,6 +62,7 @@ func TestPokerSquaresWebPresenter_Output_Error(t *testing.T) {
 func TestPokerSquaresWebPresenter_Output_Complete(t *testing.T) {
 	pg := new(interfaces.MockPokerSquaresGame)
 	pg.On("GetPhase").Return(domain.PokerSquaresPhaseComplete).Maybe()
+	pg.On("GetHint").Return((*domain.PokerSquaresHint)(nil)).Maybe()
 	pg.On("GetPlacedCount").Return(25).Maybe()
 	pg.On("CanUndo").Return(false).Maybe()
 	pg.On("GetCurrentCard").Return((*domain.Card)(nil)).Maybe()
@@ -87,6 +89,7 @@ func TestPokerSquaresWebPresenter_Output_Complete(t *testing.T) {
 func TestPokerSquaresWebPresenter_ActionLog_Playing(t *testing.T) {
 	pg := new(interfaces.MockPokerSquaresGame)
 	pg.On("GetPhase").Return(domain.PokerSquaresPhasePlaying)
+	pg.On("GetHint").Return((*domain.PokerSquaresHint)(nil)).Maybe()
 	pg.On("GetGameEndFlag").Return(false)
 	p := &PokerSquaresWebPresenter{}
 	result := p.ActionLogOutput(pg)
@@ -96,6 +99,7 @@ func TestPokerSquaresWebPresenter_ActionLog_Playing(t *testing.T) {
 func TestPokerSquaresWebPresenter_ActionLog_Complete(t *testing.T) {
 	pg := new(interfaces.MockPokerSquaresGame)
 	pg.On("GetPhase").Return(domain.PokerSquaresPhaseComplete)
+	pg.On("GetHint").Return((*domain.PokerSquaresHint)(nil)).Maybe()
 	pg.On("GetGameEndFlag").Return(true)
 	pg.On("GetActionLog").Return([]*domain.ActionLogEntry{
 		{TurnNumber: 1, ActionType: "place", Detail: "test"},

--- a/internal/adapter/presenter/PokerSquaresWebPresenter_test.go
+++ b/internal/adapter/presenter/PokerSquaresWebPresenter_test.go
@@ -108,3 +108,56 @@ func TestPokerSquaresWebPresenter_ActionLog_Complete(t *testing.T) {
 	result := p.ActionLogOutput(pg)
 	assert.Contains(t, result, "place")
 }
+
+// **シナジー考慮ヒントは CUI しか受け取れていなかった (#4790)。**Web の
+// HintOutput は状態をそのまま返すだけだった。
+func TestPokerSquaresWebPresenter_HintOutput(t *testing.T) {
+	pr := new(PokerSquaresWebPresenter)
+	decode := func(js string) *controller.PokerSquaresWebOutput {
+		var out controller.PokerSquaresWebOutput
+		assert.NoError(t, json.Unmarshal([]byte(js), &out))
+		return &out
+	}
+	game := func(hint *domain.PokerSquaresHint) *interfaces.MockPokerSquaresGame {
+		m := new(interfaces.MockPokerSquaresGame)
+		// **先に登録した期待が勝つ。**defaults の GetHint(nil) より前に置く。
+		m.On("GetHint").Return(hint)
+		setupPokerSquaresWebMockDefaults(m)
+		return m
+	}
+
+	t.Run("carries the suggested cell and its synergy", func(t *testing.T) {
+		out := decode(pr.HintOutput(game(&domain.PokerSquaresHint{Row: 2, Col: 3, Score: 12, Synergy: true})))
+		if assert.NotNil(t, out.Hint) {
+			assert.Equal(t, 2, out.Hint.Row)
+			assert.Equal(t, 3, out.Hint.Col)
+			assert.Equal(t, 12, out.Hint.Score)
+			assert.True(t, out.Hint.Synergy)
+		}
+		assert.Equal(t, "pokersquares.hintAvailable", out.MessageCode)
+	})
+
+	// **押したときだけ出す印を付ける。**Output() は常に hint を載せるので、
+	// 要求印が無いとページが「押していないのに助言」を出す。
+	t.Run("marks the response as a requested hint", func(t *testing.T) {
+		plain := decode(pr.Output(game(&domain.PokerSquaresHint{Row: 0, Col: 0}), nil))
+		assert.NotEqual(t, "pokersquares.hintAvailable", plain.MessageCode)
+	})
+
+	t.Run("reports when there is no hint", func(t *testing.T) {
+		out := decode(pr.HintOutput(game(nil)))
+		assert.Nil(t, out.Hint)
+		assert.Equal(t, "pokersquares.noHint", out.MessageCode)
+	})
+
+	// **Output() でも hint を載せる。**command:"hint" 専用のレスポンスは
+	// ページの state にマージされないので、ここが nil だと state.hint が
+	// 永久に undefined になる (#4483)。
+	t.Run("Output carries the hint into the page state", func(t *testing.T) {
+		out := decode(pr.Output(game(&domain.PokerSquaresHint{Row: 1, Col: 4, Score: 5, Synergy: true}), nil))
+		if assert.NotNil(t, out.Hint) {
+			assert.Equal(t, 1, out.Hint.Row)
+			assert.Equal(t, 4, out.Hint.Col)
+		}
+	})
+}


### PR DESCRIPTION
## 背景

ドメインの `PokerSquares.GetHint` は**行・列の相乗効果（`Synergy`）を見て最善のマスを返す**本格的な実装で、`PokerSquaresCuiPresenter.HintOutput` はそれを理由付きで提示します。

`PokerSquaresPage.tsx` には**ヒントボタンも `hint` コマンドの呼び出しもありません** (#4790)。使えるのは `useGameHint` のシナジーを見ない単純なヒューリスティックだけで、**CUI ユーザーのほうが良い助言を受けられる逆転**が起きていました。

## 実装

- `PokerSquaresWebOutput` に `hint` を追加（`row` / `col` / `score` / `synergy`）
- Web の `HintOutput` が状態をそのまま返していたのを、ヒントを載せて `messageCode` で要求印を付けるように
- Web コントローラに `h`/`hint` を dispatch
- ページにヒントボタン（他ゲームと同じ footer 位置）と表示行

**`Output()` でも hint を載せます。**`command: "hint"` 専用のレスポンスはページの state にマージされないので、そこだけだと `state.hint` が永久に undefined になります (#4483)。

**押したときだけ出します。**`Output()` が常に hint を載せるようになったため、要求印が無いと**押していないのに助言が出続け**ます。`isRequestedHint` で見分けます。

相乗効果の有無で文言を変えます（同じ文だと「置くだけ」と「効く」の区別が付きません）。

## 検証

- `go test -tags test ./internal/...` ✅ / `gofmt -l internal/` 空 ✅
- `bunx vitest run src/pages/PokerSquaresPage.test.tsx` → 30 passed ✅
- `bun run typecheck` ✅ / `bun run check` exit 0 ✅

Closes #4790