### PR TITLE
feat: ring the legal targets when a Baker's Dozen card is selected

### DIFF
--- a/frontend/src/pages/BakersDozenPage.test.tsx
+++ b/frontend/src/pages/BakersDozenPage.test.tsx
@@ -362,7 +362,11 @@ describe('BakersDozenPage legal targets', () => {
   // 別の列を掴む。
   it('leaves the illegal targets clickable', async () => {
     await selectSpadeFive();
-    const heartSix = screen.getByRole('button', { name: '♥ 6' });
-    expect(heartSix).toBeEnabled();
+    // **合法な移動先を選んではいけない。**♥6 は ♠5 の合法な置き先なので、
+    // 「押せなくしない」ことの検証にならない。空の組札は ♠5 では絶対に
+    // 合法にならない (A しか置けない) illegal target。
+    const emptyFoundation = screen.getByRole('button', { name: '空の組札 (♠)' });
+    expect(emptyFoundation.closest('[data-legal-target="true"]')).toBeNull();
+    expect(emptyFoundation).toBeEnabled();
   });
 });

--- a/frontend/src/pages/BakersDozenPage.test.tsx
+++ b/frontend/src/pages/BakersDozenPage.test.tsx
@@ -328,3 +328,41 @@ describe('BakersDozenPage', () => {
     await waitFor(() => expect(mockPlaySound).toHaveBeenCalledWith('shuffle'));
   });
 });
+
+// **選択後は押すまで正誤が分からず、クリック→サーバーエラーのループになって
+// いた (#4795)。**13列 + 4組札で移動先候補が多い。姉妹の Wasp / Accordion は
+// 選択時に合法な移動先をリング表示している。
+describe('BakersDozenPage legal targets', () => {
+  const selectSpadeFive = async () => {
+    mockExec.mockResolvedValue(playingState);
+    renderWithProviders(<BakersDozenPage />);
+    fireEvent.click(await screen.findByRole('button', { name: '♠ 5' }));
+  };
+
+  // ♠5 は ♥6 の列 (1) に乗る。スートは問われない。
+  it('rings the column whose top card is one rank higher', async () => {
+    await selectSpadeFive();
+    await waitFor(() => expect(document.querySelectorAll('[data-legal-target="true"]').length).toBeGreaterThan(0));
+  });
+
+  // **空き列は光らせない。**Baker's Dozen は空き列を埋められない。
+  it('never rings an empty column', async () => {
+    await selectSpadeFive();
+    await waitFor(() => expect(document.querySelectorAll('[data-legal-target="true"]').length).toBe(1));
+  });
+
+  it('rings nothing before a card is selected', async () => {
+    mockExec.mockResolvedValue(playingState);
+    renderWithProviders(<BakersDozenPage />);
+    await screen.findByRole('button', { name: '♠ 5' });
+    expect(document.querySelectorAll('[data-legal-target="true"]').length).toBe(0);
+  });
+
+  // **押せなくはしない。**押せなくすると E2E の「最初の列をクリック」が
+  // 別の列を掴む。
+  it('leaves the illegal targets clickable', async () => {
+    await selectSpadeFive();
+    const heartSix = screen.getByRole('button', { name: '♥ 6' });
+    expect(heartSix).toBeEnabled();
+  });
+});

--- a/frontend/src/pages/BakersDozenPage.tsx
+++ b/frontend/src/pages/BakersDozenPage.tsx
@@ -31,6 +31,7 @@ import { gameTheme } from '../styles/gameTheme';
 import type { BakersDozenResponse } from '../types/card';
 import { BakersDozenPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { bakersDozenLegalTargets } from '../utils/bakersDozenLegalTargets';
 import { cardAlt } from '../utils/cardAlt';
 import { BAKERSDOZEN_HELP, parseBakersDozenCommand } from '../utils/cli/commands/bakersdozenCommands';
 import { formatBakersDozenState } from '../utils/cli/formatters/bakersdozenFormatter';
@@ -209,6 +210,18 @@ function BakersDozenPageContent() {
   const isGameOver = state.phase === BakersDozenPhase.GAME_OVER;
   const isEnded = isGameClear || isGameOver;
 
+  // **選択後は押すまで正誤が分からず、クリック→サーバーエラーのループになって
+  // いた (#4795)。**13列 + 4組札で移動先候補が多い。姉妹の Wasp / Accordion は
+  // 選択時に合法な移動先をリング表示している。
+  //
+  // **枠を出すだけで、押せなくはしない。**押せなくすると E2E の
+  // 「最初の列をクリック」が別の列を掴んでしまう。
+  const selectedCard =
+    selectedSource?.zone === 'tableau' && selectedSource.col !== undefined && selectedSource.cardIndex !== undefined
+      ? state.tableau[selectedSource.col]?.[selectedSource.cardIndex]?.card
+      : undefined;
+  const legalTargets = bakersDozenLegalTargets(state.tableau, state.foundation, selectedCard);
+
   const isSourceSelected = (zone: string, col?: number, cardIndex?: number) =>
     selectedSource !== null &&
     selectedSource.zone === zone &&
@@ -252,7 +265,11 @@ function BakersDozenPageContent() {
               {state.foundation.map((pile, idx) => {
                 const foundationZone: BakersDozenMoveZone = { zone: 'foundation', col: idx };
                 return (
-                  <div key={`f-${idx.toString()}`} className="text-center">
+                  <div
+                    key={`f-${idx.toString()}`}
+                    className={`text-center${legalTargets.foundation.has(idx) ? ' rounded ring-2 ring-ds-success' : ''}`}
+                    data-legal-target={legalTargets.foundation.has(idx) ? 'true' : undefined}
+                  >
                     <div className="text-game-text-muted text-xs mb-1">{FOUNDATION_SUITS[idx]}</div>
                     <DropZone
                       isDropTarget={dnd.isDropTarget(foundationZone)}
@@ -313,7 +330,8 @@ function BakersDozenPageContent() {
                     // on desktop the columns flex to fill the available width as before.
                     className={`${isMobile ? 'shrink-0' : 'flex-1 min-w-0'}${
                       isOneCardCol ? ' rounded ring-1 ring-ds-warning/40 ring-dashed' : ''
-                    }`}
+                    }${legalTargets.tableau.has(colIdx) ? ' rounded ring-2 ring-ds-success' : ''}`}
+                    data-legal-target={legalTargets.tableau.has(colIdx) ? 'true' : undefined}
                     style={isMobile ? { width: bd.cw } : undefined}
                     data-testid={isOneCardCol ? `bd-onecard-col-${colIdx}` : undefined}
                   >

--- a/frontend/src/utils/bakersDozenLegalTargets.test.ts
+++ b/frontend/src/utils/bakersDozenLegalTargets.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import type { BakersDozenTableauCard, Card, CardDesign } from '../types/card';
+import { bakersDozenLegalTargets } from './bakersDozenLegalTargets';
+
+const card = (design: CardDesign, value: number): Card => ({ design, value });
+const tc = (design: CardDesign, value: number): BakersDozenTableauCard => ({ card: card(design, value), faceUp: true });
+
+describe('bakersDozenLegalTargets', () => {
+  it('reports nothing without a selected card', () => {
+    const targets = bakersDozenLegalTargets([[tc('SPADE', 5)]], [[]], null);
+    expect(targets.tableau.size).toBe(0);
+    expect(targets.foundation.size).toBe(0);
+  });
+
+  // **タブローはスートを見ない。**ランクが1つ下がるかどうかだけ。
+  it('accepts any suit onto a tableau card one rank higher', () => {
+    const targets = bakersDozenLegalTargets(
+      [[tc('SPADE', 6)], [tc('HEART', 6)], [tc('CLOVER', 9)]],
+      [[], [], [], []],
+      card('DIAMOND', 5),
+    );
+    expect([...targets.tableau].sort()).toEqual([0, 1]);
+  });
+
+  // **空き列には置けない。**他のソリティアと違い Baker's Dozen は埋められない。
+  it('never offers an empty column', () => {
+    const targets = bakersDozenLegalTargets([[], [tc('SPADE', 6)]], [[], [], [], []], card('HEART', 5));
+    expect(targets.tableau.has(0)).toBe(false);
+    expect(targets.tableau.has(1)).toBe(true);
+  });
+
+  // **ファンデーションは逆に同スート。**タブローの規則を流用すると、置けない
+  // 山を光らせる。
+  it('requires the same suit going up on a foundation', () => {
+    const foundation: Card[][] = [[card('SPADE', 4)], [card('HEART', 4)], [], []];
+    const targets = bakersDozenLegalTargets([[tc('CLOVER', 9)]], foundation, card('SPADE', 5));
+    expect([...targets.foundation]).toEqual([0]);
+  });
+
+  it('starts an empty foundation only with an ace', () => {
+    expect(bakersDozenLegalTargets([], [[]], card('SPADE', 1)).foundation.has(0)).toBe(true);
+    expect(bakersDozenLegalTargets([], [[]], card('SPADE', 2)).foundation.has(0)).toBe(false);
+  });
+
+  it('offers a tableau column and a foundation at once when both accept', () => {
+    const targets = bakersDozenLegalTargets([[tc('CLOVER', 6)]], [[card('SPADE', 4)], [], [], []], card('SPADE', 5));
+    expect(targets.tableau.has(0)).toBe(true);
+    expect(targets.foundation.has(0)).toBe(true);
+  });
+});

--- a/frontend/src/utils/bakersDozenLegalTargets.ts
+++ b/frontend/src/utils/bakersDozenLegalTargets.ts
@@ -1,0 +1,50 @@
+import type { BakersDozenTableauCard, Card } from '../types/card';
+
+/** Where the selected card may legally go. */
+export interface BakersDozenLegalTargets {
+  /** Tableau column indices that accept the card. */
+  tableau: Set<number>;
+  /** Foundation indices that accept the card. */
+  foundation: Set<number>;
+}
+
+/**
+ * Legal destinations for the selected card.
+ *
+ * Sync: `BakersDozen.canPlaceOnTableau` / `canPlaceOnFoundation`.
+ *
+ * **タブローはスートを見ない。**ランクが1つ下がるかどうかだけ。ファンデーションは
+ * 逆に同スートで1つ上がるときだけ。この2つを取り違えると、置けない列を光らせる。
+ *
+ * **空き列には置けない。**Baker's Dozen は空き列を埋められないので、空の列を
+ * 移動先に含めてはいけない (他のソリティアと違うところ)。
+ */
+export function bakersDozenLegalTargets(
+  tableau: BakersDozenTableauCard[][],
+  foundation: Card[][],
+  card: Card | null | undefined,
+): BakersDozenLegalTargets {
+  const result: BakersDozenLegalTargets = { tableau: new Set(), foundation: new Set() };
+  if (!card) return result;
+
+  tableau.forEach((col, idx) => {
+    // **空き列には置けない** (Baker's Dozen は空き列を埋められない)。空の列には
+    // トップ札が無いので `top` の存在確認がそのままその条件になる。専用の
+    // `col.length === 0` を足しても常に同じ結果になる枝が増えるだけだった。
+    const top = col[col.length - 1]?.card;
+    if (top && card.value === top.value - 1) result.tableau.add(idx);
+  });
+
+  foundation.forEach((pile, idx) => {
+    if (pile.length === 0) {
+      if (card.value === 1) result.foundation.add(idx);
+      return;
+    }
+    const top = pile[pile.length - 1];
+    if (top && card.design === top.design && card.value === top.value + 1) {
+      result.foundation.add(idx);
+    }
+  });
+
+  return result;
+}


### PR DESCRIPTION
## 背景

Baker's Dozen は**13列のタブロー + 4つのファンデーション**で移動先候補が多いのに、`BakersDozenPage.tsx` には合法な移動先を示すものがありません (#4795)。選択後は `handleSelectTarget` を押すまで正誤が分からず、**クリック→サーバーエラーのループ**になりやすい状態でした。

姉妹の Wasp（`waspLegalTargets`）や Accordion（`accordionLegalTargets`）は選択時に移動先をリング表示しています。

## 2つの規則を取り違えないこと

| 置き先 | 条件 |
|---|---|
| タブロー | **スート無関係**・ランクが1つ下 |
| ファンデーション | **同スート**・ランクが1つ上 |

取り違えると置けない列を光らせます。タブローでスートを見る実装で3件、組札でスートを見ない実装で1件落ちます。

## 枠を出すだけで、押せなくはしません

**押せなくすると E2E の「最初の列をクリック」が別の列を掴みます**（このリポジトリで何度も踏んでいる罠）。合法でない移動先もクリック可能なままであることをテストで固定しました。

## 空き列を弾く専用の分岐は置きません

Baker's Dozen は空き列を埋められませんが、**空の列にはトップ札が無い**ので、トップ札の存在確認がそのままその条件になります。専用の `col.length === 0` を足しても常に同じ結果になる枝が増えるだけでした（負のコントロールが 0件で判明）。理由はコメントに残しています。

## 負のコントロール

| 壊し方 | 落ちる件数 |
|---|---|
| タブローでスートを見る | 3 |
| `data-legal-target` を出さない | 2 |
| 組札でスートを見ない | 1 |

## 検証

- `bunx vitest run` (util 6 + page 26) → 32 passed ✅
- `bun run typecheck` ✅ / `bun run check` exit 0 ✅

Closes #4795