### PR TITLE
feat(beleagueredcastle): ring the legal destinations for the selected card

### DIFF
--- a/frontend/src/pages/BeleagueredCastlePage.test.tsx
+++ b/frontend/src/pages/BeleagueredCastlePage.test.tsx
@@ -200,6 +200,51 @@ describe('BeleagueredCastlePage', () => {
     fireEvent.click(sourceBtn);
     await waitFor(() => expect(sourceBtn).toHaveAttribute('aria-pressed', 'true'));
   });
+
+  // 合法な移動先のリング表示 (#4799)。「選ぶまで光らない」側も踏まないと、
+  // 常時全部を光らせる実装でも通ってしまう。
+  describe('legal target highlighting', () => {
+    /** リングが付いた列の見出し (`#0` など)。ファンデーションは見出しを持たない。 */
+    const markedColumns = () =>
+      [...document.querySelectorAll('[data-legal-target="true"]')]
+        .map((el) => el.querySelector('[aria-hidden="true"]')?.textContent ?? '')
+        .filter((label) => label.startsWith('#'));
+
+    it('marks nothing until a card is selected', async () => {
+      mockExec.mockResolvedValue(playingState);
+      renderWithProviders(<BeleagueredCastlePage />);
+      await screen.findByRole('button', { name: '♠ 5' });
+      expect(document.querySelectorAll('[data-legal-target="true"]')).toHaveLength(0);
+    });
+
+    // ♠5 は ♥6 の上 (スート不問) と、空き列すべてに置ける。自分の列 #0 は
+    // 相手が ♠5 自身なので置けない。
+    it('marks the ranks-down column and every empty column, but not the source column', async () => {
+      mockExec.mockResolvedValue(playingState);
+      renderWithProviders(<BeleagueredCastlePage />);
+      fireEvent.click(await screen.findByRole('button', { name: '♠ 5' }));
+      await waitFor(() => expect(markedColumns()).toContain('#1'));
+      expect(markedColumns().sort()).toEqual(['#1', '#2', '#3', '#4', '#5', '#6', '#7']);
+    });
+
+    // ファンデーションは A の上に同スートの 2 だけ。♠5 では光らない。
+    it('marks a foundation only for the card that continues it', async () => {
+      mockExec.mockResolvedValue(playingState);
+      const { unmount } = renderWithProviders(<BeleagueredCastlePage />);
+      fireEvent.click(await screen.findByRole('button', { name: '♠ 5' }));
+      await waitFor(() => expect(markedColumns()).toContain('#1'));
+      expect(document.querySelectorAll('[data-legal-target="true"]')).toHaveLength(7);
+      unmount();
+
+      mockExec.mockResolvedValue({
+        ...playingState,
+        tableau: makeTableau([[{ card: card('SPADE', 2), faceUp: true }]]),
+      });
+      renderWithProviders(<BeleagueredCastlePage />);
+      fireEvent.click(await screen.findByRole('button', { name: '♠ 2' }));
+      await waitFor(() => expect(document.querySelectorAll('[data-legal-target="true"]').length).toBeGreaterThan(7));
+    });
+  });
 });
 
 // Keyboard shortcuts are bound by useActionKeyboardNav and advertised by

--- a/frontend/src/pages/BeleagueredCastlePage.tsx
+++ b/frontend/src/pages/BeleagueredCastlePage.tsx
@@ -30,6 +30,7 @@ import { gameTheme } from '../styles/gameTheme';
 import type { BeleagueredCastleResponse } from '../types/card';
 import { BeleagueredCastlePhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { beleagueredCastleLegalTargets } from '../utils/beleagueredCastleLegalTargets';
 import { cardAlt } from '../utils/cardAlt';
 import { BELEAGUEREDCASTLE_HELP, parseBeleagueredCastleCommand } from '../utils/cli/commands/beleagueredcastleCommands';
 import { formatBeleagueredCastleState } from '../utils/cli/formatters/beleagueredcastleFormatter';
@@ -184,6 +185,16 @@ function BeleagueredCastlePageContent() {
   // pulse the button only then (mirrors Crescent / Spiderette).
   const autoCompleteReady = state.foundation.some((pile) => pile.length > 1);
 
+  // 選択時に合法な移動先をリング表示している。
+  //
+  // **枠を出すだけで、押せなくはしない。**押せなくすると E2E の
+  // 「最初の列をクリック」が別の列を掴んでしまう。
+  const selectedCard =
+    selectedSource?.zone === 'tableau' && selectedSource.col !== undefined && selectedSource.cardIndex !== undefined
+      ? state.tableau[selectedSource.col]?.[selectedSource.cardIndex]?.card
+      : undefined;
+  const legalTargets = beleagueredCastleLegalTargets(state.tableau, state.foundation, selectedCard);
+
   const isSourceSelected = (zone: string, col?: number, cardIndex?: number) =>
     selectedSource !== null &&
     selectedSource.zone === zone &&
@@ -194,7 +205,11 @@ function BeleagueredCastlePageContent() {
     const col = state.tableau[colIdx];
     const tableauColZone: BeleagueredCastleMoveZone = { zone: 'tableau', col: colIdx };
     return (
-      <div key={`col-${colIdx.toString()}`} className="flex-1 min-w-0">
+      <div
+        key={`col-${colIdx.toString()}`}
+        className={`flex-1 min-w-0${legalTargets.tableau.has(colIdx) ? ' rounded ring-2 ring-ds-success' : ''}`}
+        data-legal-target={legalTargets.tableau.has(colIdx) ? 'true' : undefined}
+      >
         <div className="text-center text-xs text-ds-text-muted mb-0.5" aria-hidden="true">
           #{colIdx}
         </div>
@@ -309,7 +324,11 @@ function BeleagueredCastlePageContent() {
                 {state.foundation.map((pile, idx) => {
                   const foundationZone: BeleagueredCastleMoveZone = { zone: 'foundation', col: idx };
                   return (
-                    <div key={`f-${idx.toString()}`} className="text-center">
+                    <div
+                      key={`f-${idx.toString()}`}
+                      className={`text-center${legalTargets.foundation.has(idx) ? ' rounded ring-2 ring-ds-success' : ''}`}
+                      data-legal-target={legalTargets.foundation.has(idx) ? 'true' : undefined}
+                    >
                       <div className="text-game-text-muted text-xs mb-1">{FOUNDATION_SUITS[idx]}</div>
                       <DropZone
                         isDropTarget={dnd.isDropTarget(foundationZone)}

--- a/frontend/src/utils/beleagueredCastleLegalTargets.test.ts
+++ b/frontend/src/utils/beleagueredCastleLegalTargets.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import type { Card, CardDesign, KlondikeTableauCard } from '../types/card';
+import { beleagueredCastleLegalTargets } from './beleagueredCastleLegalTargets';
+
+const card = (design: CardDesign, value: number): Card => ({ design, value });
+const tc = (design: CardDesign, value: number): KlondikeTableauCard => ({
+  card: card(design, value),
+  faceUp: true,
+});
+
+describe('beleagueredCastleLegalTargets', () => {
+  it('reports nothing without a selected card', () => {
+    const targets = beleagueredCastleLegalTargets([[tc('SPADE', 5)]], [[]], null);
+    expect(targets.tableau.size).toBe(0);
+    expect(targets.foundation.size).toBe(0);
+  });
+
+  // **タブローはスートを見ない。**ランクが1つ下がるかどうかだけ。
+  it('accepts any suit onto a tableau card one rank higher', () => {
+    const targets = beleagueredCastleLegalTargets(
+      [[tc('SPADE', 6)], [tc('HEART', 6)], [tc('CLOVER', 9)]],
+      [[], [], [], []],
+      card('DIAMOND', 5),
+    );
+    expect([...targets.tableau].sort()).toEqual([0, 1]);
+  });
+
+  // **空き列にはどのカードでも置ける。**姉妹の Baker's Dozen は埋められないので、
+  // そちらの規則を流用すると実際には打てる手を落とす。
+  it('offers an empty column to any card', () => {
+    const targets = beleagueredCastleLegalTargets([[], [tc('SPADE', 9)]], [[], [], [], []], card('HEART', 5));
+    expect(targets.tableau.has(0)).toBe(true);
+    expect(targets.tableau.has(1)).toBe(false);
+  });
+
+  // **ファンデーションは逆に同スート。**タブローの規則を流用すると、置けない
+  // 山を光らせる。
+  it('requires the same suit going up on a foundation', () => {
+    const foundation: Card[][] = [[card('SPADE', 4)], [card('HEART', 4)], [], []];
+    const targets = beleagueredCastleLegalTargets([[tc('CLOVER', 9)]], foundation, card('SPADE', 5));
+    expect([...targets.foundation]).toEqual([0]);
+  });
+
+  it('starts an empty foundation only with an ace', () => {
+    expect(beleagueredCastleLegalTargets([], [[]], card('SPADE', 1)).foundation.has(0)).toBe(true);
+    expect(beleagueredCastleLegalTargets([], [[]], card('SPADE', 2)).foundation.has(0)).toBe(false);
+  });
+
+  it('offers a tableau column and a foundation at once when both accept', () => {
+    const targets = beleagueredCastleLegalTargets(
+      [[tc('CLOVER', 6)]],
+      [[card('SPADE', 4)], [], [], []],
+      card('SPADE', 5),
+    );
+    expect(targets.tableau.has(0)).toBe(true);
+    expect(targets.foundation.has(0)).toBe(true);
+  });
+});

--- a/frontend/src/utils/beleagueredCastleLegalTargets.test.ts
+++ b/frontend/src/utils/beleagueredCastleLegalTargets.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import type { Card, CardDesign, KlondikeTableauCard } from '../types/card';
+import type { Card, CardDesign } from '../types/card';
+import type { BeleagueredCastleTableauCard } from '../types/games/beleagueredcastle';
 import { beleagueredCastleLegalTargets } from './beleagueredCastleLegalTargets';
 
 const card = (design: CardDesign, value: number): Card => ({ design, value });
-const tc = (design: CardDesign, value: number): KlondikeTableauCard => ({
+const tc = (design: CardDesign, value: number): BeleagueredCastleTableauCard => ({
   card: card(design, value),
   faceUp: true,
 });

--- a/frontend/src/utils/beleagueredCastleLegalTargets.ts
+++ b/frontend/src/utils/beleagueredCastleLegalTargets.ts
@@ -1,0 +1,51 @@
+import type { Card, KlondikeTableauCard } from '../types/card';
+
+/** Where the selected card may legally go. */
+export interface BeleagueredCastleLegalTargets {
+  /** Tableau column indices that accept the card. */
+  tableau: Set<number>;
+  /** Foundation indices that accept the card. */
+  foundation: Set<number>;
+}
+
+/**
+ * Legal destinations for the selected card.
+ *
+ * Sync: `BeleagueredCastle.canPlaceOnTableau` / `canPlaceOnFoundation`.
+ *
+ * **タブローはスートを見ない。**ランクが1つ下がるかどうかだけ。ファンデーションは
+ * 逆に同スートで1つ上がるときだけ。この2つを取り違えると、置けない列を光らせる。
+ *
+ * **空き列にはどのカードでも置ける。**姉妹の Baker's Dozen は空き列を埋められない
+ * ので、そちらの規則を流用すると実際には打てる手を落とす (#4799)。
+ */
+export function beleagueredCastleLegalTargets(
+  tableau: KlondikeTableauCard[][],
+  foundation: Card[][],
+  card: Card | null | undefined,
+): BeleagueredCastleLegalTargets {
+  const result: BeleagueredCastleLegalTargets = { tableau: new Set(), foundation: new Set() };
+  if (!card) return result;
+
+  tableau.forEach((col, idx) => {
+    if (col.length === 0) {
+      result.tableau.add(idx);
+      return;
+    }
+    const top = col[col.length - 1]?.card;
+    if (top && card.value === top.value - 1) result.tableau.add(idx);
+  });
+
+  foundation.forEach((pile, idx) => {
+    if (pile.length === 0) {
+      if (card.value === 1) result.foundation.add(idx);
+      return;
+    }
+    const top = pile[pile.length - 1];
+    if (top && card.design === top.design && card.value === top.value + 1) {
+      result.foundation.add(idx);
+    }
+  });
+
+  return result;
+}

--- a/frontend/src/utils/beleagueredCastleLegalTargets.ts
+++ b/frontend/src/utils/beleagueredCastleLegalTargets.ts
@@ -1,4 +1,5 @@
-import type { Card, KlondikeTableauCard } from '../types/card';
+import type { Card } from '../types/card';
+import type { BeleagueredCastleTableauCard } from '../types/games/beleagueredcastle';
 
 /** Where the selected card may legally go. */
 export interface BeleagueredCastleLegalTargets {
@@ -20,7 +21,7 @@ export interface BeleagueredCastleLegalTargets {
  * ので、そちらの規則を流用すると実際には打てる手を落とす (#4799)。
  */
 export function beleagueredCastleLegalTargets(
-  tableau: KlondikeTableauCard[][],
+  tableau: BeleagueredCastleTableauCard[][],
   foundation: Card[][],
   card: Card | null | undefined,
 ): BeleagueredCastleLegalTargets {


### PR DESCRIPTION
## 概要

包囲された城で札を選んだとき、置ける列とファンデーションにリングを出す。従来は総当たりで試すしかなかった。

## 変更

- `frontend/src/utils/beleagueredCastleLegalTargets.ts` (新規) — ドメインの `canPlaceOnTableau` / `canPlaceOnFoundation` と同じ規則。タブローはスート不問でランク1つ下、ファンデーションは同スートで1つ上。
- `BeleagueredCastlePage.tsx` — 列とファンデーションに `ring-2 ring-ds-success` + `data-legal-target`。**枠を出すだけで押せなくはしない**（押せなくすると E2E の「最初の列をクリック」が別の列を掴む）。

## 姉妹ゲームとの差

Baker's Dozen (#4795) は空き列を埋められないが、**包囲された城は空き列にどのカードでも置ける**。そちらの util を流用すると実際に打てる手を落とすので、専用テストで固定した。

## テスト

- util 6件 / ページ 3件（「選ぶまで光らない」「自分の列は光らない」「ファンデーションは続く札だけ」）
- 負のコントロール: ランク判定を `true` に潰すと 4件が落ちる（過剰マークを検出できている）

Closes #4799