### PR TITLE
feat(russiansolitaire): teach the same-suit rule in the always-on note

### DIFF
--- a/frontend/src/i18n/locales/en/russiansolitaire.json
+++ b/frontend/src/i18n/locales/en/russiansolitaire.json
@@ -38,7 +38,7 @@
   "nav": {
     "russiansolitaire": "Russian Solitaire"
   },
-  "tableauRule": "Tableau moves must be same suit, one rank down — unlike Yukon, alternating colours will not connect. Face-down cards can’t be moved.",
+  "tableauRule": "Tableau moves must be same suit, one rank down — unlike Yukon, alternating colours will not connect. Face-down cards can't be moved.",
   "faceDownRule": "Face-down cards can't be moved — only face-up cards are playable",
   "dismissRule": "Dismiss rule note",
   "faceDownCardLabel": "Column {{col}}, card {{pos}} from top, face down"

--- a/frontend/src/i18n/locales/en/russiansolitaire.json
+++ b/frontend/src/i18n/locales/en/russiansolitaire.json
@@ -38,6 +38,7 @@
   "nav": {
     "russiansolitaire": "Russian Solitaire"
   },
+  "tableauRule": "Tableau moves must be same suit, one rank down — unlike Yukon, alternating colours will not connect. Face-down cards can’t be moved.",
   "faceDownRule": "Face-down cards can't be moved — only face-up cards are playable",
   "dismissRule": "Dismiss rule note",
   "faceDownCardLabel": "Column {{col}}, card {{pos}} from top, face down"

--- a/frontend/src/i18n/locales/ja/russiansolitaire.json
+++ b/frontend/src/i18n/locales/ja/russiansolitaire.json
@@ -38,6 +38,7 @@
   "nav": {
     "russiansolitaire": "ロシアンソリティア"
   },
+  "tableauRule": "タブロー間の移動は「同じスートで1つ下」のみ。Yukonと違い交互色では繋げません。裏向きのカードは動かせません。",
   "faceDownRule": "裏向きのカードは移動できません（表向きのカードのみ操作可能）",
   "dismissRule": "ルール説明を閉じる",
   "faceDownCardLabel": "列{{col}}、上から{{pos}}枚目、裏向き"

--- a/frontend/src/pages/RussianSolitairePage.test.tsx
+++ b/frontend/src/pages/RussianSolitairePage.test.tsx
@@ -82,6 +82,10 @@ describe('RussianSolitairePage', () => {
   it('shows the face-down rule note and gives face-down cards concise positional labels', async () => {
     renderWithProviders(<RussianSolitairePage />);
     await waitFor(() => expect(screen.getByTestId('rs-facedown-rule')).toBeInTheDocument());
+    // **Yukon との唯一の違いを伝える (#4789)。**裏向きは動かせないという汎用ルール
+    // だけでは、交互色で積もうとして詰まるプレイヤーを救えない。
+    expect(screen.getByTestId('rs-facedown-rule')).toHaveTextContent('同じスートで1つ下');
+    expect(screen.getByTestId('rs-facedown-rule')).toHaveTextContent('交互色では繋げません');
     // The rule text lives only in the note, not repeated on every card label.
     expect(screen.queryByLabelText(/移動できません/)).not.toBeInTheDocument();
     // Each face-down card exposes a short label with its column and position.

--- a/frontend/src/pages/RussianSolitairePage.tsx
+++ b/frontend/src/pages/RussianSolitairePage.tsx
@@ -390,7 +390,9 @@ function RussianSolitairePageContent() {
             {/* Tableau */}
             {!rulesDismissed && (
               <div className="flex items-center justify-center gap-1 mb-1" data-testid="rs-facedown-rule" role="note">
-                <p className="text-game-text-muted text-xs text-center">{t('faceDownRule')}</p>
+                {/* Yukon との唯一の違いである「同スート降順」を伝える。裏向きは動かせない
+                    という汎用ルールしか出ていなかった (#4789)。testid は既存のまま。 */}
+                <p className="text-game-text-muted text-xs text-center">{t('tableauRule')}</p>
                 <button
                   type="button"
                   onClick={() => setRulesDismissed(true)}


### PR DESCRIPTION
## 概要

ロシアンソリティアの常時表示ノート（`rs-facedown-rule`）が、Yukon との**唯一の違い**である「タブロー間は同スートで1つ下のみ」を伝えていなかった。出ていたのは「裏向きは動かせない」というほぼ全ソリティア共通の自明なルールだけで、この制約は `RS_TUTORIAL_STEPS` の中にしか書かれていない。チュートリアルを開かない／既に閉じたプレイヤーは、Yukon の感覚で交互色に積もうとして詰まるまで気づけない。

## 変更

- `tableauRule` を新設し、ノートの文言をそれに差し替え（ja/en）。Yukon との違いを明示。
- `faceDownRule` は**残す** — 裏向き札の `title` 属性で今も使われている。
- `data-testid` と `russiansolitaire-rules-dismissed` の閉じる／永続化挙動は変更なし。

## 検証

`internal/domain/RussianSolitaire.go` の `canPlaceOnTableau` を確認：`card.GetDesign() == topCard.GetDesign() && card.GetValue() == topCard.GetValue()-1`。文言はこの実装そのまま。

## テスト

ノートが「同じスートで1つ下」「交互色では繋げません」を含むことをアサート（27件パス）。文言を元に戻すと落ちる。

Closes #4789