### PR TITLE
docs(pokersquares): document the hint command and response in openapi.yaml

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -39793,8 +39793,8 @@ components:
           type: string
           description: |
             Game command. Accepted values: `reset` (`r`), `place` (`p`),
-            `undo` (`u`), `giveup` (`g`), `log` (`l`).
-          enum: [r, reset, p, place, u, undo, g, giveup, log, l]
+            `undo` (`u`), `giveup` (`g`), `log` (`l`), `hint` (`h`).
+          enum: [r, reset, p, place, u, undo, g, giveup, log, l, h, hint]
           example: place
         row:
           type: integer
@@ -39887,6 +39887,41 @@ components:
           additionalProperties:
             type: string
           description: Interpolation parameters for the message template keyed by placeholder name.
+        hint:
+          description: |
+            Server-side synergy-aware suggestion for the current card. Omitted when
+            no suggestion is available (game complete, or no current card).
+          $ref: '#/components/schemas/PokerSquaresOutputHint'
+
+    PokerSquaresOutputHint:
+      type: object
+      description: Suggested cell for the current card, scored by row/column synergy.
+      required:
+        - row
+        - col
+        - score
+        - synergy
+      properties:
+        row:
+          type: integer
+          description: Row index (0-4) of the suggested cell.
+          minimum: 0
+          maximum: 4
+          example: 2
+        col:
+          type: integer
+          description: Column index (0-4) of the suggested cell.
+          minimum: 0
+          maximum: 4
+          example: 3
+        score:
+          type: integer
+          description: Combined row + column score the placement would create.
+          example: 8
+        synergy:
+          type: boolean
+          description: Whether the score is positive, i.e. the placement builds on cards already on the board.
+          example: true
 
     # -------------------------------------------------------------------------
     # Red Dog (レッドドッグ)

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -9160,6 +9160,7 @@ paths:
         | `undo`   | `u`  | Undo the last placement |
         | `giveup` | `g`  | Give up the current game |
         | `log`    | `l`  | View action log |
+        | `hint`   | `h`  | Get a synergy-aware placement suggestion |
       operationId: pokersquaresExec
       requestBody:
         required: true

--- a/frontend/src/pages/PokerSquaresPage.tsx
+++ b/frontend/src/pages/PokerSquaresPage.tsx
@@ -10,7 +10,6 @@ import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
 import { FrontendHintTooltip } from '../components/hint/FrontendHintTooltip';
-
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { CARD_DIMENSIONS, useCardDimensions, useWindowWidth } from '../hooks/useCardDimensions';

--- a/internal/adapter/controller/PokerSquaresWebController.go
+++ b/internal/adapter/controller/PokerSquaresWebController.go
@@ -36,7 +36,9 @@ type PokerSquaresWebOutput struct {
 
 // PokerSquaresWebOutputHint はサーバ側のシナジー考慮ヒント (#4790)。
 type PokerSquaresWebOutputHint struct {
+	// Row は推奨するマスの行 (0-4)。
 	Row int `json:"row"`
+	// Col は推奨するマスの列 (0-4)。
 	Col int `json:"col"`
 	// Score はその配置が生む行・列の相乗効果スコア。
 	Score int `json:"score"`


### PR DESCRIPTION
## 概要

#5154（#4790）のレビュー指摘の積み残し。マージ前にレビューを読み切れておらず、"Must fix before merge" とされた `api/openapi.yaml` の更新が漏れていた。

## 変更

- `PokerSquaresRequest.command` の enum に `h` / `hint` を追加（説明文も更新）
- `PokerSquaresResponse.hint` を追加し、`PokerSquaresOutputHint` スキーマ（row/col/score/synergy）を新設。Go 側の `PokerSquaresWebOutputHint` と `json:"hint,omitempty"` に一致
- nit 2件: `PokerSquaresWebOutputHint.Row`/`.Col` の doc コメント、`PokerSquaresPage.tsx` の import ブロックの余分な空行

## 検証

`yaml.safe_load` でパースし、`PokerSquaresResponse.properties.hint` と `PokerSquaresOutputHint.required` が意図どおり解決することを確認。