### PR TITLE
feat(yukon): state the any-order block-move rule in the CUI

### DIFF
--- a/internal/adapter/presenter/YukonCuiPresenter.go
+++ b/internal/adapter/presenter/YukonCuiPresenter.go
@@ -60,6 +60,10 @@ func (p *YukonCuiPresenter) Output(y interfaces.YukonGame, lastErr error) string
 			}
 			b.WriteString(i18n.Tf("cuiSolitaireMoves",
 				"count", strconv.Itoa(y.GetMoveCount())) + "\n")
+			// 盤面は Klondike とまったく同じ見た目なので、Klondike 経験者は
+			// 「揃った並びしか動かせない」と思い込んだままになる。Web 版が専用の
+			// ホバープレビューまで用意しているルールを、CUI でも明示する (#4788)。
+			b.WriteString(i18n.T("yukon.blockMoveRule") + "\n")
 		case domain.YukonPhaseGameClear:
 			b.WriteString(color.Green(i18n.T("cuiSolitaireGameClear")) + " " +
 				i18n.Tf("cuiSolitaireMoves", "count", strconv.Itoa(y.GetMoveCount())) + "\n")

--- a/internal/adapter/presenter/YukonCuiPresenter_test.go
+++ b/internal/adapter/presenter/YukonCuiPresenter_test.go
@@ -38,6 +38,24 @@ func TestYukonCuiPresenter_Output(t *testing.T) {
 		assert.Contains(t, result, "Yukon")
 		assert.Contains(t, result, "Foundation")
 		assert.Contains(t, result, "列0:")
+		// **Yukon 固有の一括移動ルールを常時出す (#4788)。**盤面は Klondike と
+		// 見分けが付かないので、Klondike の感覚だと「揃った並びしか動かせない」
+		// と思い込んだままになる。
+		assert.Contains(t, result, "順序に関係なく")
+	})
+
+	t.Run("does not advertise the block-move rule once the game has ended", func(t *testing.T) {
+		yg := new(interfaces.MockYukonGame)
+		yg.On("GetPhase").Return(domain.YukonPhaseGameClear).Maybe()
+		yg.On("GetMoveCount").Return(42).Maybe()
+		yg.On("IsStalemate").Return(false).Maybe()
+		var tableau [domain.YukonTableauCnt][]*domain.KlondikeTableauCard
+		yg.On("GetTableau").Return(tableau).Maybe()
+		var foundation [domain.YukonFoundationCnt][]*domain.Card
+		yg.On("GetFoundation").Return(foundation).Maybe()
+
+		p := new(YukonCuiPresenter)
+		assert.NotContains(t, p.Output(yg, nil), "順序に関係なく")
 	})
 
 	t.Run("with error", func(t *testing.T) {

--- a/internal/i18n/locales/en/yukon.json
+++ b/internal/i18n/locales/en/yukon.json
@@ -11,6 +11,7 @@
   "invalidFromZone": "Invalid source zone: {{.val}} (only t is valid)",
   "moveUsage": "Usage: m t <col> <cardIdx> t <col> or m t <col> f",
   "playing": "Move cards to build foundation",
+  "blockMoveRule": "Tip: grab any face-up card — everything stacked on it moves along, in any order (only the bottom card has to fit the destination).",
   "gameClear": "Game clear! Moves: {{.moveCount}}",
   "gameOver": "Game over",
   "stalemate": "Stalemate",

--- a/internal/i18n/locales/ja/yukon.json
+++ b/internal/i18n/locales/ja/yukon.json
@@ -11,6 +11,7 @@
   "invalidFromZone": "無効な移動元です: {{.val}} (t のみ有効)",
   "moveUsage": "使用法: m t <列> <カードID> t <列> または m t <列> f",
   "playing": "カードを移動してください",
+  "blockMoveRule": "ヒント: 表向きのカードならどれでも掴めます。その上に乗っているカードは順序に関係なくまとめて動きます（置ける条件は一番下のカードだけ）。",
   "gameClear": "ゲームクリア！ 手数: {{.moveCount}}",
   "gameOver": "ゲームオーバー",
   "stalemate": "手詰まりです",


### PR DESCRIPTION
## 概要

ユーコンの CUI が Yukon 固有の「順不同一括移動」ルールを一切説明していなかった。

`YukonCuiPresenter.Output` はタブローを `klondikeColumnStr` で描くだけなので、**盤面は Klondike とまったく同じ見た目**になる。Klondike / FreeCell 経験者は「交互色で揃った並びしか動かせない」と思い込んだまま遊び、実際には使える有利なルールに気づけない。

## 検証した前提

`internal/domain/Yukon.go:MoveTableauToTableau` — 表向きかどうかを確認したあと、検証するのは**一番下のカードの置き先だけ**（`canPlaceOnTableau(bottomCard, toCol)`）。上に乗ったカード群の整列は要求しない。コメントにも「移動するカード群の整列は不要」とある。Web 版はこのために `hoveredBlock` / `isInMoveBlock` の専用プレビュー（#3152）を持っている。

## 変更

- `internal/i18n/locales/{ja,en}/yukon.json` に `blockMoveRule` を追加
- `YukonCuiPresenter.Output` のプレイ中ブロックに1行出力

## テスト

- プレイ中の出力に文言が含まれること
- **ゲーム終了後には出ないこと** — 常に出す実装でも通ってしまわないよう、両側を踏む

`go test -tags test ./internal/...` 全通、`golangci-lint` 0 issues。

Closes #4788