### PR TITLE
feat(tripeaks): show the playable-card total and draw hint on the web board

### DIFF
--- a/frontend/src/i18n/locales/en/tripeaks.json
+++ b/frontend/src/i18n/locales/en/tripeaks.json
@@ -9,6 +9,8 @@
   "waste": "Waste",
   "moveCount": "Moves",
   "score": "Score",
+  "playableSummary": "Playable now: {{count}}",
+  "drawRecommended": "Draw recommended",
   "bestScore": "Best",
   "newBest": "New best! {{score}} pts",
   "clears": "Clears {{wins}}/{{plays}}",

--- a/frontend/src/i18n/locales/ja/tripeaks.json
+++ b/frontend/src/i18n/locales/ja/tripeaks.json
@@ -9,6 +9,8 @@
   "waste": "捨て札",
   "moveCount": "手数",
   "score": "スコア",
+  "playableSummary": "今出せるカード: {{count}}枚",
+  "drawRecommended": "ドロー推奨",
   "bestScore": "ベスト",
   "newBest": "自己ベスト更新！ {{score}} 点",
   "clears": "クリア {{wins}}/{{plays}}",

--- a/frontend/src/pages/TriPeaksPage.test.tsx
+++ b/frontend/src/pages/TriPeaksPage.test.tsx
@@ -91,6 +91,39 @@ beforeEach(() => {
   mockPlaySound.mockClear();
 });
 
+describe('TriPeaksPage playable summary', () => {
+  // CUI は playableSummary / drawRecommended を毎回出していたのに、Web は
+  // 個々のリングだけで合計が無かった (#4783)。
+  it('shows how many cards are playable, and rings exactly that many', async () => {
+    renderWithProviders(<TriPeaksPage />);
+    // 捨て札トップは ♣4。露出している ♠5 だけが出せる。
+    await waitFor(() => expect(screen.getByTestId('tp-playable')).toHaveTextContent('今出せるカード: 1枚'));
+    expect(document.querySelectorAll('.ring-ds-success\\/70')).toHaveLength(1);
+    expect(screen.getByTestId('tp-playable')).not.toHaveTextContent('ドロー推奨');
+  });
+
+  it('recommends a draw when nothing is playable and the stock still has cards', async () => {
+    mockExec.mockResolvedValue({ ...playingState, waste: [card('CLOVER', 9)] });
+    renderWithProviders(<TriPeaksPage />);
+    await waitFor(() => expect(screen.getByTestId('tp-playable')).toHaveTextContent('今出せるカード: 0枚'));
+    expect(screen.getByTestId('tp-playable')).toHaveTextContent('ドロー推奨');
+  });
+
+  // **山札が尽きていれば勧めない。**この枝を踏まないと、常に推奨する実装でも通る。
+  it('does not recommend a draw once the stock is empty', async () => {
+    mockExec.mockResolvedValue({ ...playingState, waste: [card('CLOVER', 9)], stockCount: 0 });
+    renderWithProviders(<TriPeaksPage />);
+    await waitFor(() => expect(screen.getByTestId('tp-playable')).toHaveTextContent('今出せるカード: 0枚'));
+    expect(screen.getByTestId('tp-playable')).not.toHaveTextContent('ドロー推奨');
+  });
+
+  it('hides the summary once the game has ended', async () => {
+    mockExec.mockResolvedValue(gameClearState);
+    renderWithProviders(<TriPeaksPage />);
+    await waitFor(() => expect(screen.queryByTestId('tp-playable')).not.toBeInTheDocument());
+  });
+});
+
 describe('TriPeaksPage', () => {
   it('rings exposed cards adjacent to the waste top during play', async () => {
     renderWithProviders(<TriPeaksPage />);

--- a/frontend/src/pages/TriPeaksPage.tsx
+++ b/frontend/src/pages/TriPeaksPage.tsx
@@ -38,8 +38,8 @@ import { cardAlt } from '../utils/cardAlt';
 import { parseTripeaksCommand, TRIPEAKS_HELP } from '../utils/cli/commands/tripeaksCommands';
 import { formatTripeaksState } from '../utils/cli/formatters/tripeaksFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
-import { isTriPeaksAdjacent } from '../utils/hints/tripeaksHint';
 import { hintCheckboxItem } from '../utils/settingsItems';
+import { triPeaksPlayableCells } from '../utils/triPeaksPlayable';
 
 /** Valid column positions per row in the TriPeaks tableau. */
 const VALID_COLS: readonly number[][] = [
@@ -245,6 +245,9 @@ function TriPeaksPageContent() {
   const isPlaying = state.phase === TriPeaksPhase.PLAYING;
   // Rank of the waste top, used to ring playable (±1 with K-A wrap) tableau cards.
   const wasteTopValue = state.waste.length > 0 ? state.waste[state.waste.length - 1].value : undefined;
+  // **リングと合計は同じ集合を読む。**別々に数えると、光っている札の数と
+  // ヘッダーの数字がずれる。CUI の playableCount と揃える (#4783)。
+  const playableCells = isPlaying ? triPeaksPlayableCells(state.layout, wasteTopValue) : new Set<string>();
   const isGameClear = state.phase === TriPeaksPhase.GAME_CLEAR;
   const isGameOver = state.phase === TriPeaksPhase.GAME_OVER;
   const isEnded = isGameClear || isGameOver;
@@ -283,6 +286,14 @@ function TriPeaksPageContent() {
           <span data-testid="tp-score">
             {t('score')}: <span className="font-bold tabular-nums">{score}</span>
           </span>
+          {isPlaying && (
+            <span data-testid="tp-playable" className="text-xs">
+              {t('playableSummary', { count: playableCells.size })}
+              {playableCells.size === 0 && state.stockCount > 0 && (
+                <span className="ml-1 text-ds-warning">{t('drawRecommended')}</span>
+              )}
+            </span>
+          )}
           {isPlaying && (
             <span data-testid="peak-remaining" className="flex items-center gap-1 text-xs">
               <span className="sr-only">{t('peakRemaining')}</span>
@@ -353,11 +364,7 @@ function TriPeaksPageContent() {
                       if (!tc2.card) return null;
                       const exposed = tc2.exposed;
                       const isHinted = hint?.type === 'remove' && hint.row === rowIdx && hint.col === colIdx;
-                      const isPlayable =
-                        isPlaying &&
-                        exposed &&
-                        wasteTopValue !== undefined &&
-                        isTriPeaksAdjacent(tc2.card.value, wasteTopValue);
+                      const isPlayable = playableCells.has(`${rowIdx.toString()}-${colIdx.toString()}`);
                       return (
                         <div key={`tc-${rowIdx.toString()}-${colIdx.toString()}`} className="absolute" style={{ left }}>
                           <button

--- a/frontend/src/utils/triPeaksPlayable.test.ts
+++ b/frontend/src/utils/triPeaksPlayable.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import type { TriPeaksCard } from '../types/games/tripeaks';
+import { triPeaksPlayableCells } from './triPeaksPlayable';
+
+const cell = (value: number, over: Partial<TriPeaksCard> = {}): TriPeaksCard => ({
+  card: { design: 'SPADE', value },
+  removed: false,
+  exposed: true,
+  ...over,
+});
+
+describe('triPeaksPlayableCells', () => {
+  it('reports nothing while the waste is empty', () => {
+    expect(triPeaksPlayableCells([[cell(5)]], undefined).size).toBe(0);
+  });
+
+  it('counts only the exposed cards one rank away from the waste top', () => {
+    const layout = [[cell(6), cell(4), cell(9)]];
+    expect([...triPeaksPlayableCells(layout, 5)]).toEqual(['0-0', '0-1']);
+  });
+
+  // 伏せ札・除去済みは触れない。除外しないと CUI の playableCount とずれる。
+  it('skips cards that are removed or not yet exposed', () => {
+    const layout = [[cell(6, { exposed: false }), cell(4, { removed: true }), cell(6)]];
+    expect([...triPeaksPlayableCells(layout, 5)]).toEqual(['0-2']);
+  });
+
+  // K↔A は隣接する。ここを落とすと「出せるのに0枚」と表示される。
+  it('wraps between king and ace', () => {
+    expect(triPeaksPlayableCells([[cell(13)]], 1).size).toBe(1);
+    expect(triPeaksPlayableCells([[cell(1)]], 13).size).toBe(1);
+  });
+
+  it('reports the row and column of each playable cell', () => {
+    const layout = [[cell(9)], [cell(2), cell(4)]];
+    expect([...triPeaksPlayableCells(layout, 3)]).toEqual(['1-0', '1-1']);
+  });
+});

--- a/frontend/src/utils/triPeaksPlayable.ts
+++ b/frontend/src/utils/triPeaksPlayable.ts
@@ -1,0 +1,30 @@
+import type { TriPeaksCard } from '../types/games/tripeaks';
+import { isTriPeaksAdjacent } from './hints/tripeaksHint';
+
+/** Key identifying a tableau cell, as `row-col`. */
+export type TriPeaksCellKey = `${number}-${number}`;
+
+/**
+ * Exposed tableau cells that can be taken onto the current waste top.
+ *
+ * Sync: `TriPeaksCuiPresenter.Output`'s `playableCount`.
+ *
+ * **表示とリングは同じ集合を読む。**枚数を別に数え直すと、リングが付いた札の数と
+ * ヘッダーの数字がずれる (#4783)。
+ */
+export function triPeaksPlayableCells(
+  layout: TriPeaksCard[][],
+  wasteTopValue: number | undefined,
+): Set<TriPeaksCellKey> {
+  const cells = new Set<TriPeaksCellKey>();
+  if (wasteTopValue === undefined) return cells;
+
+  layout.forEach((row, rowIdx) => {
+    row.forEach((tc, colIdx) => {
+      if (!tc?.card || tc.removed || !tc.exposed) return;
+      if (isTriPeaksAdjacent(tc.card.value, wasteTopValue)) cells.add(`${rowIdx}-${colIdx}`);
+    });
+  });
+
+  return cells;
+}


### PR DESCRIPTION
## 概要

CUI (`TriPeaksCuiPresenter.Output`) は `playableSummary`（今出せる枚数）を毎回表示し、0枚かつ山札が残っていれば `drawRecommended` まで能動的に出す。Web はカード1枚ずつのリングだけで合計が無く、3つの山にまたがる札を目で数える必要があった。

## 変更

- `frontend/src/utils/triPeaksPlayable.ts`（新規）— `triPeaksPlayableCells(layout, wasteTopValue)`。CUI の `playableCount` と同じ条件（露出済み・未除去・ランク±1、K↔A ラップ）。
- `TriPeaksPage.tsx` — ヘッダーに合計を表示。**リングも合計も同じ集合を読む**（別々に数えると光っている札の数と数字がずれる）。0枚かつ `stockCount > 0` のときだけドロー推奨。
- i18n ja/en に `playableSummary` / `drawRecommended`。

## テスト

- util 5件（伏せ札・除去済みの除外、K↔A ラップ、座標）
- ページ4件：合計とリング枚数の一致 / 0枚+山札ありで推奨 / **山札が尽きたら推奨しない** / 終局後は非表示
- 負のコントロール: 露出フィルタを外すと 3件が落ちる

Closes #4783