### PR TITLE
feat(canfield): show when auto-complete is actually available

### DIFF
--- a/frontend/src/i18n/locales/en/canfield.json
+++ b/frontend/src/i18n/locales/en/canfield.json
@@ -16,6 +16,7 @@
   "giveup": "Give up",
   "hint": "Hint",
   "autoComplete": "Auto complete",
+  "autoCompleteNotReady": "Available once the reserve, stock and waste are all empty",
   "undo": "Undo",
   "empty": "empty",
   "gameClear": "Game cleared! Moves: {{moveCount}}",

--- a/frontend/src/i18n/locales/ja/canfield.json
+++ b/frontend/src/i18n/locales/ja/canfield.json
@@ -16,6 +16,7 @@
   "giveup": "ギブアップ",
   "hint": "ヒント",
   "autoComplete": "自動完成",
+  "autoCompleteNotReady": "リザーブ・山札・捨て札がすべて空になるとクリックできます",
   "undo": "元に戻す",
   "empty": "空",
   "gameClear": "ゲームクリア！ 手数: {{moveCount}}",

--- a/frontend/src/pages/CanfieldPage.test.tsx
+++ b/frontend/src/pages/CanfieldPage.test.tsx
@@ -181,12 +181,30 @@ describe('CanfieldPage', () => {
     await waitFor(() => expect(screen.getByTestId('cf-hint-display')).not.toHaveTextContent('ヒントがあります'));
   });
 
-  it('autocomplete button triggers autocomplete command', async () => {
+  // 自動完成はリザーブ・山札・捨て札が空のときだけ通る (#4787)。押せる/押せない
+  // の両側を踏まないと、常に押せる実装でも常に押せない実装でも通ってしまう。
+  const readyState = { ...playingState, reserve: [], stockCount: 0, waste: [] };
+
+  it('autocomplete button triggers autocomplete command once the board is ready', async () => {
+    mockExec.mockResolvedValue(readyState);
     renderWithProviders(<CanfieldPage />);
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
-    const btn = screen.getByRole('button', { name: '自動完成' });
+    const btn = await screen.findByTestId('autocomplete-button');
+    await waitFor(() => expect(btn).toBeEnabled());
+    expect(btn).toHaveClass('animate-pulse');
+    expect(screen.getByTestId('canfield-autocomplete-ready-badge')).toBeInTheDocument();
     btn.click();
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('autocomplete'));
+  });
+
+  it('keeps the autocomplete button dark and disabled while the stock still holds cards', async () => {
+    renderWithProviders(<CanfieldPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    const btn = await screen.findByTestId('autocomplete-button');
+    expect(btn).toBeDisabled();
+    expect(btn).not.toHaveClass('animate-pulse');
+    expect(btn).toHaveAttribute('title');
+    expect(screen.queryByTestId('canfield-autocomplete-ready-badge')).not.toBeInTheDocument();
   });
 
   it('giveup button opens a confirm dialog and only dispatches giveup after confirm', async () => {

--- a/frontend/src/pages/CanfieldPage.tsx
+++ b/frontend/src/pages/CanfieldPage.tsx
@@ -1,6 +1,7 @@
 import { type DragEvent, useCallback, useMemo } from 'react';
 import { type CanfieldMoveZone, canfieldApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
+import { AutoCompleteReadyBadge } from '../components/AutoCompleteReadyBadge';
 import { CliTerminal } from '../components/cli/CliTerminal';
 import { CliToggle } from '../components/cli/CliToggle';
 import { SettingsPanel } from '../components/common/SettingsPanel';
@@ -30,6 +31,7 @@ import { gameTheme } from '../styles/gameTheme';
 import type { CanfieldResponse } from '../types/card';
 import { CanfieldPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { canfieldAutoCompleteReady } from '../utils/canfieldAutoComplete';
 import { cardAlt } from '../utils/cardAlt';
 import { CANFIELD_HELP, parseCanfieldCommand } from '../utils/cli/commands/canfieldCommands';
 import { formatCanfieldState } from '../utils/cli/formatters/canfieldFormatter';
@@ -200,6 +202,10 @@ function CanfieldPageContent() {
 
   if (error) return <ErrorAlert message={error} onRetry={retry} />;
   if (!state) return null;
+
+  // 自動完成はリザーブ・山札・捨て札が空でないとサーバが弾く。押してみるまで
+  // 分からなかったので、他のソリティアと同じくリング+バッジで知らせる (#4787)。
+  const autoCompleteReady = canfieldAutoCompleteReady(state);
 
   const topWaste = state.waste.length > 0 ? state.waste[state.waste.length - 1] : null;
   const topReserve = state.reserve.length > 0 ? state.reserve[state.reserve.length - 1] : null;
@@ -539,12 +545,17 @@ function CanfieldPageContent() {
                   </button>
                   <button
                     type="button"
-                    className={`${btnSuccess} ${focusRingWhite}`}
+                    className={`${btnSuccess} ${focusRingWhite}${
+                      autoCompleteReady && !loading ? ' animate-pulse ring-2 ring-ds-success' : ''
+                    }`}
                     onClick={handleAutoComplete}
-                    disabled={loading}
+                    disabled={loading || !autoCompleteReady}
+                    data-testid="autocomplete-button"
+                    title={autoCompleteReady ? undefined : t('autoCompleteNotReady')}
                   >
                     {t('autoComplete')}
                   </button>
+                  <AutoCompleteReadyBadge ready={autoCompleteReady} testId="canfield-autocomplete-ready-badge" />
                   <button
                     type="button"
                     className={`${btnOutline} ${focusRingWhite}`}

--- a/frontend/src/utils/canfieldAutoComplete.test.ts
+++ b/frontend/src/utils/canfieldAutoComplete.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import type { Card } from '../types/card';
+import { canfieldAutoCompleteReady } from './canfieldAutoComplete';
+
+const c = (value: number): Card => ({ design: 'SPADE', value });
+const base = { reserve: [] as Card[], stockCount: 0, waste: [] as Card[] };
+
+describe('canfieldAutoCompleteReady', () => {
+  it('is ready once reserve, stock and waste are all empty', () => {
+    expect(canfieldAutoCompleteReady(base)).toBe(true);
+  });
+
+  // ドメインの AutoComplete が弾く3条件。1つずつ踏まないと、
+  // 「常に true」の実装でも通ってしまう。
+  it.each([
+    ['reserve', { ...base, reserve: [c(5)] }],
+    ['stock', { ...base, stockCount: 1 }],
+    ['waste', { ...base, waste: [c(5)] }],
+  ])('is not ready while the %s still holds a card', (_name, state) => {
+    expect(canfieldAutoCompleteReady(state)).toBe(false);
+  });
+});

--- a/frontend/src/utils/canfieldAutoComplete.ts
+++ b/frontend/src/utils/canfieldAutoComplete.ts
@@ -1,0 +1,14 @@
+import type { CanfieldResponse } from '../types/games/canfield';
+
+/**
+ * Whether Canfield's auto-complete can run right now.
+ *
+ * Sync: `Canfield.AutoComplete` (`internal/domain/Canfield.go`), which rejects the
+ * command unless the reserve, stock and waste are all empty.
+ *
+ * **サーバが弾く条件をそのまま読む。**別の条件で光らせると、押せる見た目のまま
+ * エラーになる (#4787)。
+ */
+export function canfieldAutoCompleteReady(state: Pick<CanfieldResponse, 'reserve' | 'stockCount' | 'waste'>): boolean {
+  return state.reserve.length === 0 && state.stockCount === 0 && state.waste.length === 0;
+}


### PR DESCRIPTION
## 概要

Klondike / FreeCell / SeahavenTowers / Spider / FortyThieves は `autoCompleteReady` を算出してパルスリングと `AutoCompleteReadyBadge` を出すのに、Canfield のボタンは `disabled={loading}` だけだった。押してみるまで揃えられる状態か分からず、他ページで確立された体験から Canfield だけ外れていた。

## 判定の出どころ

`internal/domain/Canfield.go:AutoComplete` は `len(reserve) != 0 || len(stock) != 0 || len(waste) != 0` でコマンドを弾く。util はこの条件をそのまま読む。**別の条件で光らせると、押せる見た目のままサーバがエラーを返す。**

## 変更

- `frontend/src/utils/canfieldAutoComplete.ts`（新規）
- `CanfieldPage.tsx` — FreeCell と同じ形（パルスリング / `disabled` / `title` / `AutoCompleteReadyBadge`）
- i18n ja/en に `autoCompleteNotReady`

## テスト

- util 4件（3つの阻害条件を1つずつ）
- ページ2件：**押せる側**（リング+バッジ+コマンド発火）と**押せない側**（disabled・リング無し・title あり・バッジ無し）。既存の「autocomplete を発火する」テストは常に押せる前提だったので、ready な state を渡すよう更新。

Closes #4787