### PR TITLE
fix(fortythieves): label foundations by what is on them, not a fixed suit

### DIFF
--- a/frontend/src/i18n/locales/en/fortythieves.json
+++ b/frontend/src/i18n/locales/en/fortythieves.json
@@ -13,7 +13,7 @@
   "giveup": "Give Up",
   "empty": "Empty",
   "foundationAriaLabel": "{{suit}} foundation {{count}} cards",
-  "emptyFoundationAriaLabel": "Empty foundation ({{suit}})",
+  "emptyFoundationAriaLabel": "Empty foundation {{idx}} (accepts an ace of any suit)",
   "landscapeBanner": "Landscape mode recommended",
   "hint": "Hint",
   "autoComplete": "Auto Complete",

--- a/frontend/src/i18n/locales/ja/fortythieves.json
+++ b/frontend/src/i18n/locales/ja/fortythieves.json
@@ -13,7 +13,7 @@
   "giveup": "ギブアップ",
   "empty": "空",
   "foundationAriaLabel": "{{suit}} 組札 {{count}}枚",
-  "emptyFoundationAriaLabel": "空の組札 ({{suit}})",
+  "emptyFoundationAriaLabel": "空の組札 {{idx}}（どのスートのAでも置けます）",
   "landscapeBanner": "横画面での表示を推奨します",
   "hint": "ヒント",
   "autoComplete": "自動完成",

--- a/frontend/src/pages/FortyThievesPage.test.tsx
+++ b/frontend/src/pages/FortyThievesPage.test.tsx
@@ -133,25 +133,36 @@ describe('FortyThievesPage', () => {
     expect(screen.getAllByText('空').length).toBeGreaterThanOrEqual(1);
   });
 
-  it('renders foundation piles with suit symbols', async () => {
+  // **空の組札にスートを断定しない (#4786)。**宛先インデックスはサーバに届かず
+  // findFoundation が置ける最初の山を選ぶので、固定ラベルは何も保証しなかった。
+  it('labels empty foundations neutrally instead of asserting a suit', async () => {
     renderWithProviders(<FortyThievesPage />);
-    await waitFor(() => expect(screen.getAllByText('♠').length).toBeGreaterThanOrEqual(1));
-    expect(screen.getAllByText('♣').length).toBeGreaterThanOrEqual(1);
-    expect(screen.getAllByText('♥').length).toBeGreaterThanOrEqual(1);
-    expect(screen.getAllByText('♦').length).toBeGreaterThanOrEqual(1);
+    await waitFor(() => expect(screen.getAllByText('—').length).toBe(8));
+    expect(screen.queryByText('♠')).not.toBeInTheDocument();
+    expect(screen.queryByText('♦')).not.toBeInTheDocument();
+  });
+
+  it('labels a populated foundation with the suit actually sitting on it', async () => {
+    mockExec.mockResolvedValue(withFoundationState);
+    renderWithProviders(<FortyThievesPage />);
+    // 山0 は ♠A、山2 は ♥A→♥2。残り6つは空のまま。
+    await waitFor(() => expect(screen.getAllByText('—').length).toBe(6));
+    expect(screen.getByText('♠')).toBeInTheDocument();
+    expect(screen.getByText('♥')).toBeInTheDocument();
+    expect(screen.queryByText('♣')).not.toBeInTheDocument();
   });
 
   it('renders foundation with cards', async () => {
     mockExec.mockResolvedValue(withFoundationState);
     renderWithProviders(<FortyThievesPage />);
-    await waitFor(() => expect(screen.getAllByText('♠').length).toBeGreaterThanOrEqual(1));
+    await waitFor(() => expect(screen.getByAltText('♠ A')).toBeInTheDocument());
     const imgs = screen.getAllByRole('img');
     expect(imgs.length).toBeGreaterThanOrEqual(1);
   });
 
   it('renders empty foundation placeholder with A', async () => {
     renderWithProviders(<FortyThievesPage />);
-    await waitFor(() => expect(screen.getAllByText('♠').length).toBeGreaterThanOrEqual(1));
+    await waitFor(() => expect(screen.getAllByText('—').length).toBe(8));
     const aElements = screen.getAllByText('A');
     expect(aElements.length).toBeGreaterThanOrEqual(1);
   });
@@ -369,7 +380,7 @@ describe('FortyThievesPage', () => {
   it('foundation with cards is clickable when source selected', async () => {
     mockExec.mockResolvedValue(withFoundationState);
     renderWithProviders(<FortyThievesPage />);
-    await waitFor(() => expect(screen.getAllByText('♠').length).toBeGreaterThanOrEqual(1));
+    await waitFor(() => expect(screen.getByAltText('♠ A')).toBeInTheDocument());
 
     // Select waste as source first
     const wasteImg = screen.getByAltText('♣ 3');
@@ -389,7 +400,7 @@ describe('FortyThievesPage', () => {
 
   it('foundation disabled when no source selected', async () => {
     renderWithProviders(<FortyThievesPage />);
-    await waitFor(() => expect(screen.getAllByText('♠').length).toBeGreaterThanOrEqual(1));
+    await waitFor(() => expect(screen.getAllByText('—').length).toBe(8));
 
     // Empty foundation buttons should be disabled when no source selected
     const aButtons = screen.getAllByRole('button').filter((btn) => btn.textContent === 'A');

--- a/frontend/src/pages/FortyThievesPage.tsx
+++ b/frontend/src/pages/FortyThievesPage.tsx
@@ -32,13 +32,23 @@ import { gameTheme } from '../styles/gameTheme';
 import type { Card } from '../types/card';
 import { FortyThievesPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
-import { cardAlt } from '../utils/cardAlt';
+import { cardAlt, suitSymbol } from '../utils/cardAlt';
 import { FORTYTHIEVES_HELP, parseFortythievesCommand } from '../utils/cli/commands/fortythievesCommands';
 import { formatFortythievesState } from '../utils/cli/formatters/fortythievesFormatter';
 import { hintCheckboxItem } from '../utils/settingsItems';
 import { isTableauAllFaceUp } from '../utils/solitaireUtils';
 
-const FOUNDATION_SUITS = ['♠', '♠', '♣', '♣', '♥', '♥', '♦', '♦'] as const;
+/**
+ * Suit glyph for a foundation pile, or `null` while it is empty.
+ *
+ * **空の山にスートを書かない。**`FortyThieves.MoveTableauToFoundation` は宛先
+ * インデックスを受け取らず、`findFoundation` が置ける最初の山を自動で選ぶ。
+ * 固定ラベルは空の山に対して何も保証しない見せかけだった (#4786)。
+ */
+function foundationSuit(pile: Card[]): string | null {
+  const top = pile[pile.length - 1];
+  return top ? suitSymbol(top.design) : null;
+}
 
 /** Forty Thieves tutorial step definitions. */
 const FT_TUTORIAL_STEPS: TutorialStep[] = [
@@ -326,7 +336,9 @@ function FortyThievesPageContent() {
                       key={`f-${idx.toString()}`}
                       className={`text-center rounded ${isHintTo('foundation', idx) ? HINT_RING : ''}`}
                     >
-                      <div className="text-game-text-muted text-xs mb-1">{FOUNDATION_SUITS[idx]}</div>
+                      <div className="text-game-text-muted text-xs mb-1" aria-hidden="true">
+                        {foundationSuit(pile) ?? '—'}
+                      </div>
                       <DropZone
                         isDropTarget={dnd.isDropTarget(foundationZone)}
                         onDragOver={dnd.handleDragOver(foundationZone)}
@@ -339,7 +351,7 @@ function FortyThievesPageContent() {
                             onClick={() => handleSelectTarget(foundationZone)}
                             disabled={!isPlaying || loading || isAutoCompleting || !selectedSource}
                             aria-label={t('foundationAriaLabel', {
-                              suit: FOUNDATION_SUITS[idx],
+                              suit: foundationSuit(pile),
                               count: pile.length,
                             })}
                             className={`p-0 border-0 bg-transparent cursor-pointer rounded ${focusRingWhite}`}
@@ -356,7 +368,7 @@ function FortyThievesPageContent() {
                             type="button"
                             onClick={() => handleSelectTarget(foundationZone)}
                             disabled={!isPlaying || loading || !selectedSource}
-                            aria-label={t('emptyFoundationAriaLabel', { suit: FOUNDATION_SUITS[idx] })}
+                            aria-label={t('emptyFoundationAriaLabel', { idx: idx + 1 })}
                             style={{ width: ft.cw, height: ft.ch }}
                             className={`rounded border-2 border-dashed border-white/30 text-game-text-muted text-xs flex items-center justify-center ${focusRingWhite}`}
                           >


### PR DESCRIPTION
## 概要

`FOUNDATION_SUITS = ['♠','♠','♣','♣','♥','♥','♦','♦']` を8つの組札に固定表示していたが、これは**何も保証しないラベル**だった。

- `FortyThieves.MoveTableauToFoundation` / `MoveWasteToFoundation` は宛先インデックスを受け取らない。`findFoundation(card)` が置ける最初の山を自動で選ぶ。
- `canPlaceOnFoundation` は空の山なら**任意のスートのA**を許可する。
- `fortyThievesMoveDispatch` も `toZone == "foundation"` のとき `param.To.Col` を捨てている。

つまり「♦の山」と書かれた空の山に♠Aが入ることが普通に起きる。

## 変更

- 組札のラベルを、実際にその山に乗っているカードのスートから算出。空の山は `—`。
- `emptyFoundationAriaLabel` を「空の組札 N（どのスートのAでも置けます）」に（ja/en）。
- ラベル `div` に `aria-hidden`（スート情報はボタンの aria-label 側にある）。

クリック挙動は変更していない（どの山を押してもサーバが自動で選ぶため、現状で正しく動く）。

## テスト

既存3件が固定ラベルを仕様として固定していたので書き換え：

- 空の組札8つが `—` になり、♠/♦ が出ないこと
- 山0=♠A、山2=♥A♥2 のとき ♠ と ♥ だけが出て、♣ は出ず、空きは6つであること

55件パス。

Closes #4786