### PR TITLE
feat(spider): preview the movable run on tap, not just on hover

### DIFF
--- a/frontend/src/pages/SpiderPage.test.tsx
+++ b/frontend/src/pages/SpiderPage.test.tsx
@@ -757,6 +757,54 @@ describe('SpiderPage', () => {
       await waitFor(() => expect(btnFor('♥ 6')).toHaveAttribute('data-movable-run', 'true'));
     });
 
+    // **タップにはホバーもフォーカスも無い (#4780)。**クリックで選んだだけの
+    // 状態で、一緒に動く連番が見えなければならない。
+    it('rings the whole run after a plain tap, with no hover involved', async () => {
+      mockExec.mockResolvedValue(runState);
+      renderWithProviders(<SpiderPage />);
+      await waitFor(() => expect(screen.getByAltText('♠ K')).toBeInTheDocument());
+
+      fireEvent.click(btnFor('♠ K'));
+      await waitFor(() => expect(btnFor('♠ Q')).toHaveAttribute('data-selected-block', 'true'));
+      expect(btnFor('♠ J')).toHaveAttribute('data-selected-block', 'true');
+      expect(btnFor('♠ Q').className).toContain('ring-ds-info');
+      // 選んだ札自身は従来どおり選択リング。
+      expect(btnFor('♠ K').className).toContain('ring-ds-warning');
+      // 別の列の札は巻き込まない。
+      expect(btnFor('♥ 6')).not.toHaveAttribute('data-selected-block');
+    });
+
+    // **同じ列でも連番の外は光らせない。**列で絞るだけの実装だと、選んだ札より
+    // 上に積まれた札まで「一緒に動く」ように見えてしまう。
+    it('leaves cards above the tapped one out of the block', async () => {
+      mockExec.mockResolvedValue(runState);
+      renderWithProviders(<SpiderPage />);
+      await waitFor(() => expect(screen.getByAltText('♠ Q')).toBeInTheDocument());
+
+      fireEvent.click(btnFor('♠ Q'));
+      await waitFor(() => expect(btnFor('♠ J')).toHaveAttribute('data-selected-block', 'true'));
+      expect(btnFor('♠ K')).not.toHaveAttribute('data-selected-block');
+    });
+
+    // 連番が途切れていれば、タップしても何も光らない (動かせないため)。
+    it('marks nothing when the tapped card cannot lift its tail', async () => {
+      mockExec.mockResolvedValue(runState);
+      renderWithProviders(<SpiderPage />);
+      await waitFor(() => expect(screen.getByAltText('♣ 7')).toBeInTheDocument());
+
+      fireEvent.click(btnFor('♣ 7'));
+      await waitFor(() => expect(btnFor('♣ 7')).toHaveAttribute('aria-pressed', 'true'));
+      expect(btnFor('♣ 7')).not.toHaveAttribute('data-selected-block');
+      expect(btnFor('♥ 6')).not.toHaveAttribute('data-selected-block');
+    });
+
+    it('marks nothing as a selected block before anything is tapped', async () => {
+      mockExec.mockResolvedValue(runState);
+      renderWithProviders(<SpiderPage />);
+      await waitFor(() => expect(screen.getByAltText('♠ K')).toBeInTheDocument());
+      expect(document.querySelectorAll('[data-selected-block]')).toHaveLength(0);
+    });
+
     it('highlights the run on keyboard focus too', async () => {
       mockExec.mockResolvedValue(runState);
       renderWithProviders(<SpiderPage />);

--- a/frontend/src/pages/SpiderPage.tsx
+++ b/frontend/src/pages/SpiderPage.tsx
@@ -383,11 +383,21 @@ function SpiderPageContent() {
                                 cardIndex: cardIdx,
                               };
                               const inMovableRun = hoveredRun?.col === colIdx && hoveredRun.indices.includes(cardIdx);
+                              // タップ選択でのプレビュー。onMouseEnter も onFocus も発火しない
+                              // タッチ端末では、選んだ札と一緒に動く連番がどこまでかを
+                              // 事前に確かめる手段が無かった (#4780, Yukon の #3152 と同じ)。
+                              const inSelectedRun =
+                                selectedSource?.zone === 'tableau' &&
+                                selectedSource.col === colIdx &&
+                                selectedSource.cardIndex !== undefined &&
+                                spiderMovableRun(col, selectedSource.cardIndex).includes(cardIdx);
                               const ringClass = isSourceSelected(colIdx, cardIdx)
                                 ? 'ring-2 ring-ds-warning'
                                 : inMovableRun
                                   ? 'ring-2 ring-ds-success'
-                                  : '';
+                                  : inSelectedRun
+                                    ? 'ring-2 ring-ds-info'
+                                    : '';
                               return (
                                 <div
                                   key={`tc-${colIdx.toString()}-${cardIdx.toString()}`}
@@ -406,6 +416,7 @@ function SpiderPageContent() {
                                       }
                                       onBlur={() => setHoveredRun(null)}
                                       data-movable-run={inMovableRun ? 'true' : undefined}
+                                      data-selected-block={inSelectedRun || undefined}
                                       onClick={() => {
                                         if (selectedSource) {
                                           // If clicking a different column, treat as move target

--- a/frontend/src/pages/SpiderPage.tsx
+++ b/frontend/src/pages/SpiderPage.tsx
@@ -353,6 +353,16 @@ function SpiderPageContent() {
               <div className="flex gap-0.5 sm:gap-1 mb-3" data-tutorial="spd-tableau">
                 {state.tableau.map((col, colIdx) => {
                   const tableauColZone: SpiderMoveZone = { zone: 'tableau', col: colIdx };
+                  // タップ選択でのプレビュー。onMouseEnter も onFocus も発火しない
+                  // タッチ端末では、選んだ札と一緒に動く連番がどこまでかを事前に
+                  // 確かめる手段が無かった (#4780, Yukon の #3152 と同じ)。
+                  // 連番は列ごとに1度だけ求める (ホバー側の setHoveredRun と同じ形)。
+                  const selectedRun =
+                    selectedSource?.zone === 'tableau' &&
+                    selectedSource.col === colIdx &&
+                    selectedSource.cardIndex !== undefined
+                      ? spiderMovableRun(col, selectedSource.cardIndex)
+                      : null;
                   return (
                     <div key={`col-${colIdx.toString()}`} className="flex-1 min-w-0">
                       <DropZone
@@ -383,14 +393,7 @@ function SpiderPageContent() {
                                 cardIndex: cardIdx,
                               };
                               const inMovableRun = hoveredRun?.col === colIdx && hoveredRun.indices.includes(cardIdx);
-                              // タップ選択でのプレビュー。onMouseEnter も onFocus も発火しない
-                              // タッチ端末では、選んだ札と一緒に動く連番がどこまでかを
-                              // 事前に確かめる手段が無かった (#4780, Yukon の #3152 と同じ)。
-                              const inSelectedRun =
-                                selectedSource?.zone === 'tableau' &&
-                                selectedSource.col === colIdx &&
-                                selectedSource.cardIndex !== undefined &&
-                                spiderMovableRun(col, selectedSource.cardIndex).includes(cardIdx);
+                              const inSelectedRun = selectedRun?.includes(cardIdx) ?? false;
                               const ringClass = isSourceSelected(colIdx, cardIdx)
                                 ? 'ring-2 ring-ds-warning'
                                 : inMovableRun


### PR DESCRIPTION
## 概要

`hoveredRun` は `onMouseEnter` / `onFocus` でしか立たない。タッチ端末の単純なタップではどちらも発火しないため、スマートフォンのプレイヤーは**どこまでのカードが一緒に動くのか事前に確認できなかった**。

Yukon / RussianSolitaire は同じ問題に対して `inSelectedBlock`（#3152）で対策済み。Spider だけ取り残されていた。

## 変更

- `SpiderPage.tsx` — `selectedSource` から `spiderMovableRun` で連番を求め、`ring-ds-info` + `data-selected-block` を付ける。**連番の算出はホバー側と同じ関数**（別に書くと、光る範囲と実際に動く範囲がずれる）。
- データ属性名は Yukon / RussianSolitaire に合わせて `data-selected-block`。

リングの優先順位は 選択札(warning) > ホバー連番(success) > 選択連番(info) で、既存のホバー表示と衝突しない。

## テスト

4件追加：

- タップだけで連番全体が光る（ホバーを一切使わない）
- **同じ列でも連番の外は光らない**（選んだ札より上の ♠K）
- 連番が途切れていればタップしても光らない
- 何も選んでいなければ `data-selected-block` は0件

負のコントロール: 連番判定を `true` に潰すと2件が落ちる。最初に書いた2件では**落ちなかった**ので、区別できるケースを足した。

Closes #4780