### PR TITLE
feat(golf): keep a 9-hole scorecard in the CUI

### DIFF
--- a/internal/adapter/presenter/GolfCuiPresenter.go
+++ b/internal/adapter/presenter/GolfCuiPresenter.go
@@ -23,8 +23,67 @@ func golfAdjacentRank(v1, v2 int) bool {
 	return diff == 1 || diff == 12
 }
 
+// golfTotalHoles is the number of deals that make up a full round, matching the
+// web GUI's GOLF_TOTAL_HOLES.
+const golfTotalHoles = 9
+
 // GolfCuiPresenter renders the Golf Solitaire CUI view.
-type GolfCuiPresenter struct{}
+//
+// **スコアカードはプレゼンターが持つ (#4784)。**9ホールは Web では
+// localStorage に置かれた表示層の状態で、ドメインには存在しない。同じものを
+// ドメインへ足すと KV 復元やスナップショットの対象になり、CUI にしか要らない
+// 値のために Web 側の永続化を触ることになる。CUI では GameManager が
+// セッションごとに1つ生成するので、ここがちょうど同じ寿命になる。
+type GolfCuiPresenter struct {
+	// holes は記録済みホールのスコア (ディール終了時にタブローに残った枚数)。
+	holes []int
+	// dealRecorded は今のディールを既に記録したか。1回のディール終了で
+	// Output が何度呼ばれても二重計上しない。
+	dealRecorded bool
+}
+
+// golfRemainingCount counts the cards still on the tableau — the deal's score.
+// Mirrors the web GUI's countGolfRemaining; lower is better, 0 on a clear.
+func golfRemainingCount(layout [domain.GolfColCnt][domain.GolfRowCnt]*domain.GolfCard) int {
+	n := 0
+	for col := range domain.GolfColCnt {
+		for _, gc := range layout[col] {
+			if gc != nil && !gc.Removed {
+				n++
+			}
+		}
+	}
+	return n
+}
+
+// recordHole appends the finished deal's score, ignoring calls once the round is
+// full so an extra Output cannot inflate the card.
+func (pr *GolfCuiPresenter) recordHole(score int) {
+	if len(pr.holes) >= golfTotalHoles {
+		return
+	}
+	pr.holes = append(pr.holes, score)
+}
+
+// golfHoleLines writes the hole number, this deal's score and the running total,
+// plus the final line once all holes are in.
+func (pr *GolfCuiPresenter) golfHoleLines(b *strings.Builder) {
+	if len(pr.holes) == 0 {
+		return
+	}
+	total := 0
+	for _, s := range pr.holes {
+		total += s
+	}
+	b.WriteString(i18n.Tf("golf.holeScore",
+		"hole", strconv.Itoa(len(pr.holes)),
+		"holes", strconv.Itoa(golfTotalHoles),
+		"score", strconv.Itoa(pr.holes[len(pr.holes)-1]),
+		"total", strconv.Itoa(total)) + "\n")
+	if len(pr.holes) >= golfTotalHoles {
+		b.WriteString(color.Green(i18n.Tf("golf.roundComplete", "total", strconv.Itoa(total))) + "\n")
+	}
+}
 
 // Output renders the current game state for the active locale (#1699).
 func (pr *GolfCuiPresenter) Output(g interfaces.GolfGame, lastErr error) string {
@@ -81,6 +140,15 @@ func (pr *GolfCuiPresenter) Output(g interfaces.GolfGame, lastErr error) string 
 
 		cuiErrorBlock(b, lastErr)
 
+		// ディールが終わった最初の Output で1ホール分を記録する。次のディールが
+		// 始まったら (= Playing に戻ったら) また記録できるようにする。
+		if g.GetPhase() == domain.GolfPhasePlaying {
+			pr.dealRecorded = false
+		} else if !pr.dealRecorded {
+			pr.recordHole(golfRemainingCount(layout))
+			pr.dealRecorded = true
+		}
+
 		switch g.GetPhase() {
 		case domain.GolfPhasePlaying:
 			if g.IsStalemate() {
@@ -94,6 +162,8 @@ func (pr *GolfCuiPresenter) Output(g interfaces.GolfGame, lastErr error) string 
 		case domain.GolfPhaseGameOver:
 			b.WriteString(color.Red(i18n.T("cuiSolitaireGameOver")) + "\n")
 		}
+
+		pr.golfHoleLines(b)
 	})
 }
 

--- a/internal/adapter/presenter/GolfCuiPresenter.go
+++ b/internal/adapter/presenter/GolfCuiPresenter.go
@@ -81,7 +81,9 @@ func (pr *GolfCuiPresenter) golfHoleLines(b *strings.Builder) {
 		"score", strconv.Itoa(pr.holes[len(pr.holes)-1]),
 		"total", strconv.Itoa(total)) + "\n")
 	if len(pr.holes) >= golfTotalHoles {
-		b.WriteString(color.Green(i18n.Tf("golf.roundComplete", "total", strconv.Itoa(total))) + "\n")
+		b.WriteString(color.Green(i18n.Tf("golf.roundComplete",
+			"total", strconv.Itoa(total),
+			"holes", strconv.Itoa(golfTotalHoles))) + "\n")
 	}
 }
 

--- a/internal/adapter/presenter/GolfCuiPresenter_test.go
+++ b/internal/adapter/presenter/GolfCuiPresenter_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 )
@@ -235,5 +236,75 @@ func TestGolfCuiPresenterActionLogOutput(t *testing.T) {
 		p := &GolfCuiPresenter{}
 		result := p.ActionLogOutput(gg)
 		assert.NotEmpty(t, result)
+	})
+}
+
+// TestGolfCuiPresenter_NineHoleScorecard confirms the CUI accumulates a 9-hole
+// card across deals, the way the web GUI's useGolfNineHole does (#4784).
+func TestGolfCuiPresenter_NineHoleScorecard(t *testing.T) {
+	origNoColor := color.NoColor()
+	color.SetNoColor(true)
+	defer color.SetNoColor(origNoColor)
+
+	// remaining は「タブローに残す枚数」。0 ならクリア相当のスコア。
+	endedGame := func(remaining int, phase domain.GolfPhase) *interfaces.MockGolfGame {
+		g := new(interfaces.MockGolfGame)
+		var layout [domain.GolfColCnt][domain.GolfRowCnt]*domain.GolfCard
+		for i := 0; i < remaining; i++ {
+			layout[i%domain.GolfColCnt][i/domain.GolfColCnt] =
+				&domain.GolfCard{Card: domain.NewCard(domain.CardDesignSpade, i%13+1, false)}
+		}
+		g.On("GetLayout").Return(layout).Maybe()
+		g.On("GetWaste").Return(([]*domain.Card)(nil)).Maybe()
+		g.On("GetStockCount").Return(0).Maybe()
+		g.On("GetMoveCount").Return(10).Maybe()
+		g.On("IsStalemate").Return(false).Maybe()
+		g.On("IsExposed", mock.Anything, mock.Anything).Return(false).Maybe()
+		g.On("GetPhase").Return(phase).Maybe()
+		return g
+	}
+
+	t.Run("no scorecard before any deal has ended", func(t *testing.T) {
+		p := &GolfCuiPresenter{}
+		assert.NotContains(t, p.Output(endedGame(5, domain.GolfPhasePlaying), nil), "ホール")
+	})
+
+	t.Run("records each finished deal and keeps a running total", func(t *testing.T) {
+		p := &GolfCuiPresenter{}
+		assert.Contains(t, p.Output(endedGame(4, domain.GolfPhaseGameOver), nil), "ホール 1/9  今回: 4  合計: 4")
+
+		// 次のディールが始まる。
+		p.Output(endedGame(9, domain.GolfPhasePlaying), nil)
+		assert.Contains(t, p.Output(endedGame(3, domain.GolfPhaseGameClear), nil), "ホール 2/9  今回: 3  合計: 7")
+	})
+
+	// **1ディールは1回しか数えない。**終局後は Output が何度も呼ばれる。
+	t.Run("does not count the same deal twice", func(t *testing.T) {
+		p := &GolfCuiPresenter{}
+		p.Output(endedGame(4, domain.GolfPhaseGameOver), nil)
+		result := p.Output(endedGame(4, domain.GolfPhaseGameOver), nil)
+		assert.Contains(t, result, "ホール 1/9")
+		assert.NotContains(t, result, "ホール 2/9")
+	})
+
+	t.Run("announces the total once all nine holes are in", func(t *testing.T) {
+		p := &GolfCuiPresenter{}
+		for i := 0; i < 9; i++ {
+			p.Output(endedGame(2, domain.GolfPhaseGameOver), nil)
+			p.Output(endedGame(2, domain.GolfPhasePlaying), nil)
+		}
+		result := p.Output(endedGame(2, domain.GolfPhasePlaying), nil)
+		assert.Contains(t, result, "9ホール終了")
+		assert.Contains(t, result, "合計 18 打")
+	})
+
+	// 9ホールを超えて記録しない。10ディール目は無視される。
+	t.Run("stops recording past the ninth hole", func(t *testing.T) {
+		p := &GolfCuiPresenter{}
+		for i := 0; i < 10; i++ {
+			p.Output(endedGame(2, domain.GolfPhaseGameOver), nil)
+			p.Output(endedGame(2, domain.GolfPhasePlaying), nil)
+		}
+		assert.Contains(t, p.Output(endedGame(2, domain.GolfPhasePlaying), nil), "合計 18 打")
 	})
 }

--- a/internal/i18n/locales/en/golf.json
+++ b/internal/i18n/locales/en/golf.json
@@ -10,7 +10,7 @@
   "wasteCard": " | Waste: {{card}}",
   "wasteEmpty": " | Waste: [empty]",
   "holeScore": "Hole {{hole}}/{{holes}}  this deal: {{score}}  total: {{total}}",
-  "roundComplete": "Round complete — {{total}} strokes over 9 holes",
+  "roundComplete": "Round complete — {{total}} strokes over {{holes}} holes",
   "hintRemove": "Hint: remove column {{col}}",
   "hintDraw": "Hint: draw from stock",
   "hintUnknown": "Hint: unknown"

--- a/internal/i18n/locales/en/golf.json
+++ b/internal/i18n/locales/en/golf.json
@@ -9,6 +9,8 @@
   "stockLine": "Stock: {{count}}",
   "wasteCard": " | Waste: {{card}}",
   "wasteEmpty": " | Waste: [empty]",
+  "holeScore": "Hole {{hole}}/{{holes}}  this deal: {{score}}  total: {{total}}",
+  "roundComplete": "Round complete — {{total}} strokes over 9 holes",
   "hintRemove": "Hint: remove column {{col}}",
   "hintDraw": "Hint: draw from stock",
   "hintUnknown": "Hint: unknown"

--- a/internal/i18n/locales/ja/golf.json
+++ b/internal/i18n/locales/ja/golf.json
@@ -9,6 +9,8 @@
   "stockLine": "Stock: {{count}}枚",
   "wasteCard": " | Waste: {{card}}",
   "wasteEmpty": " | Waste: [空]",
+  "holeScore": "ホール {{hole}}/{{holes}}  今回: {{score}}  合計: {{total}}",
+  "roundComplete": "9ホール終了！ 合計 {{total}} 打",
   "hintRemove": "ヒント: カード除去: 列{{col}}",
   "hintDraw": "ヒント: ストックからカードを引いてください",
   "hintUnknown": "ヒント: 不明"

--- a/internal/i18n/locales/ja/golf.json
+++ b/internal/i18n/locales/ja/golf.json
@@ -10,7 +10,7 @@
   "wasteCard": " | Waste: {{card}}",
   "wasteEmpty": " | Waste: [空]",
   "holeScore": "ホール {{hole}}/{{holes}}  今回: {{score}}  合計: {{total}}",
-  "roundComplete": "9ホール終了！ 合計 {{total}} 打",
+  "roundComplete": "{{holes}}ホール終了！ 合計 {{total}} 打",
   "hintRemove": "ヒント: カード除去: 列{{col}}",
   "hintDraw": "ヒント: ストックからカードを引いてください",
   "hintUnknown": "ヒント: 不明"


### PR DESCRIPTION
## 概要

Web (`useGolfNineHole`, #3114) はディールごとの残カード数を積み上げ、ホール別スコアと合計を専用テーブルで表示する。CUI には**ホール番号も累計も9ホール完了判定も一切なく**、単発のディールをリセットのたびに繰り返すことしかできなかった。

## なぜプレゼンターに置くか

9ホールは Web でも `localStorage` に置かれた**表示層の状態**で、ドメインには存在しない。同じものを `internal/domain/Golf.go` に足すと `MarshalJSON` / スナップショット / KV 復元の対象になり、**CUI にしか要らない値のために Web 側の永続化を触る**ことになる（取りこぼすと Worker で毎リクエスト消える種類のバグ）。

`GameManager` は CUI プレゼンターを `new(presenter.GolfCuiPresenter)` でセッションごとに1つ生成するので、ここがちょうど localStorage と同じ寿命になる。

## 変更

- `GolfCuiPresenter` に `holes []int` / `dealRecorded bool`
- `golfRemainingCount` — Web の `countGolfRemaining` と同じ「タブローに残った枚数」（少ないほど良い、クリアで0）
- ディール終了後の**最初の** `Output` で1ホール記録。`Playing` に戻ると次を記録できる
- `golf.holeScore` / `golf.roundComplete` (ja/en)

## テスト

5件：

- ディール終了前は何も出さない
- ホールごとに記録して累計が伸びる
- **同じディールを二重計上しない**（終局後 `Output` は何度も呼ばれる）
- 9ホール目で合計を告知
- 10ディール目は無視

負のコントロール: 二重計上ガードを外すと2件が落ちる。

`go test -tags test ./internal/...` 全通、`golangci-lint` 0 issues。

Closes #4784