### PR TITLE
feat(shortdeck,badugi): localize the CUI hand names with per-game tables

### DIFF
--- a/internal/adapter/presenter/BadugiCuiPresenter.go
+++ b/internal/adapter/presenter/BadugiCuiPresenter.go
@@ -76,7 +76,7 @@ func (bcp *BadugiCuiPresenter) Output(g interfaces.BadugiGame, lastErr error) st
 				if isEnd {
 					b.WriteString(i18n.Tf("badugi.humanHandWithName",
 						"cards", handStr,
-						"name", pl.GetHandName()) + "\n")
+						"name", cuiBadugiHandName(pl.GetBestHand().Size)) + "\n")
 				} else {
 					b.WriteString(i18n.Tf("badugi.humanHand", "cards", handStr) + "\n")
 				}
@@ -84,7 +84,7 @@ func (bcp *BadugiCuiPresenter) Output(g interfaces.BadugiGame, lastErr error) st
 			if !pl.GetIsHuman() && isEnd && !pl.GetFolded() {
 				b.WriteString(i18n.Tf("badugi.humanHandWithName",
 					"cards", cuiCardListStrEmoji(pl),
-					"name", pl.GetHandName()) + "\n")
+					"name", cuiBadugiHandName(pl.GetBestHand().Size)) + "\n")
 			}
 		}
 

--- a/internal/adapter/presenter/BadugiCuiPresenter.go
+++ b/internal/adapter/presenter/BadugiCuiPresenter.go
@@ -12,6 +12,15 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
+// cuiBadugiHandName returns the localized name for a Badugi hand size (1-4).
+// Badugi's names ("Badugi", "3-card", …) have no counterpart in the poker table.
+func cuiBadugiHandName(size int) string {
+	if size < 1 || size >= len(domain.BadugiHandNames) {
+		return i18n.T("badugi.handRankUnknown")
+	}
+	return i18n.T("badugi.handRank" + strconv.Itoa(size))
+}
+
 // BadugiCuiPresenter renders Badugi state for the CLI.
 type BadugiCuiPresenter struct{}
 

--- a/internal/adapter/presenter/BadugiCuiPresenter_test.go
+++ b/internal/adapter/presenter/BadugiCuiPresenter_test.go
@@ -180,3 +180,55 @@ func TestBadugiCuiPresenter_ActionLogOutput(t *testing.T) {
 	out := pres.ActionLogOutput(bd)
 	assert.NotEmpty(t, out)
 }
+
+// TestBadugiCuiPresenter_LocalizedHandNames pins the Japanese hand names (#4987).
+//
+// **バドゥーギの役名はポーカー役表と対応しない。**共通表を流用できないので専用の
+// キーを持つ。役は成立枚数 (1-4) そのもので、4 が「バドゥーギ」。
+func TestBadugiCuiPresenter_LocalizedHandNames(t *testing.T) {
+	// 4枚とも異なるランク・異なるスート = バドゥーギ (4)。
+	// ランクを重ねると成立枚数が減る。
+	tests := []struct {
+		name  string
+		cards [4]*domain.Card
+		want  string
+	}{
+		{
+			"four distinct ranks and suits is a badugi",
+			[4]*domain.Card{
+				domain.NewCard(domain.CardDesignSpade, 1, false),
+				domain.NewCard(domain.CardDesignHeart, 2, false),
+				domain.NewCard(domain.CardDesignDiamond, 3, false),
+				domain.NewCard(domain.CardDesignClover, 4, false),
+			},
+			"バドゥーギ",
+		},
+		{
+			"a repeated suit drops it to a three-card hand",
+			[4]*domain.Card{
+				domain.NewCard(domain.CardDesignSpade, 1, false),
+				domain.NewCard(domain.CardDesignSpade, 2, false),
+				domain.NewCard(domain.CardDesignDiamond, 3, false),
+				domain.NewCard(domain.CardDesignClover, 4, false),
+			},
+			"3カード",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pres := new(presenter.BadugiCuiPresenter)
+			bd, players := makeBadugiForPresenter()
+			bd.SetPhase(domain.BadugiPhaseEnd)
+			bd.SetGameEndFlag(true)
+			for _, c := range tt.cards {
+				players[0].AddCard(c)
+			}
+			_ = players[0].EvalHand()
+
+			out := pres.Output(bd, nil)
+			assert.Contains(t, out, tt.want)
+			// 英語の生の役名が漏れていないこと。
+			assert.NotContains(t, out, "-card")
+		})
+	}
+}

--- a/internal/adapter/presenter/ShortDeckCuiPresenter.go
+++ b/internal/adapter/presenter/ShortDeckCuiPresenter.go
@@ -12,6 +12,18 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
+// cuiShortDeckHandName returns the localized name for a Short Deck hand rank.
+//
+// **標準の役表を流用してはいけない。**36枚デッキではフラッシュがフルハウスの上に
+// 来るので (`domain.ShortDeckHandNames`)、`cuiPokerHandName` に渡すと 5=Full House を
+// 「フラッシュ」と表示する。訳されないより誤訳のほうが悪い (#4987)。
+func cuiShortDeckHandName(rank int) string {
+	if rank < 0 || rank >= len(domain.ShortDeckHandNames) {
+		return ""
+	}
+	return i18n.T("shortdeck.handRank" + strconv.Itoa(rank))
+}
+
 // ShortDeckCuiPresenter renders the Short Deck Hold'em CUI view.
 type ShortDeckCuiPresenter struct{}
 

--- a/internal/adapter/presenter/ShortDeckCuiPresenter.go
+++ b/internal/adapter/presenter/ShortDeckCuiPresenter.go
@@ -125,7 +125,7 @@ func (p *ShortDeckCuiPresenter) Output(o interfaces.ShortDeckGame, lastErr error
 				case r.HandName != "":
 					b.WriteString(i18n.Tf("shortdeck.resultHand",
 						"name", name,
-						"hand", r.HandName,
+						"hand", cuiShortDeckHandName(r.HandRank),
 						"kickers", kickers))
 				default:
 					b.WriteString(i18n.Tf("shortdeck.resultName", "name", name))

--- a/internal/adapter/presenter/ShortDeckCuiPresenter_test.go
+++ b/internal/adapter/presenter/ShortDeckCuiPresenter_test.go
@@ -195,13 +195,13 @@ func TestShortDeckCuiPresenter_Output(t *testing.T) {
 		h, players := makeShortDeckForPresenter()
 		h.SetPhase(domain.ShortDeckPhaseEnd)
 		h.SetRoundResults([]domain.HoldemResult{
-			{PlayerIdx: 0, HandRank: domain.PokerHandFlush, HandName: "Flush", WonAmount: 100, BestHand: nil},
+			{PlayerIdx: 0, HandRank: domain.ShortDeckHandFlush, HandName: "Flush", WonAmount: 100, BestHand: nil},
 		})
 
 		_ = players[0]
 		result := p.Output(h, nil)
 		assert.Contains(t, result, "[結果]")
-		assert.Contains(t, result, "あなた: Flush")
+		assert.Contains(t, result, "あなた: フラッシュ")
 		assert.Contains(t, result, "100チップ獲得")
 	})
 
@@ -209,11 +209,11 @@ func TestShortDeckCuiPresenter_Output(t *testing.T) {
 		h, _ := makeShortDeckForPresenter()
 		h.SetPhase(domain.ShortDeckPhaseEnd)
 		h.SetRoundResults([]domain.HoldemResult{
-			{PlayerIdx: 0, HandRank: domain.PokerHandOnePair, HandName: "One Pair", Kickers: []int{14, 12, 10}, WonAmount: 100, BestHand: nil},
+			{PlayerIdx: 0, HandRank: domain.ShortDeckHandOnePair, HandName: "One Pair", Kickers: []int{14, 12, 10}, WonAmount: 100, BestHand: nil},
 		})
 
 		result := p.Output(h, nil)
-		assert.Contains(t, result, "あなた: One Pair (キッカー: A, Q, 10)")
+		assert.Contains(t, result, "あなた: ワンペア (キッカー: A, Q, 10)")
 		assert.Contains(t, result, "100チップ獲得")
 	})
 
@@ -221,11 +221,11 @@ func TestShortDeckCuiPresenter_Output(t *testing.T) {
 		h, _ := makeShortDeckForPresenter()
 		h.SetPhase(domain.ShortDeckPhaseEnd)
 		h.SetRoundResults([]domain.HoldemResult{
-			{PlayerIdx: 0, HandRank: domain.PokerHandFlush, HandName: "Flush", Kickers: nil, WonAmount: 100, BestHand: nil},
+			{PlayerIdx: 0, HandRank: domain.ShortDeckHandFlush, HandName: "Flush", Kickers: nil, WonAmount: 100, BestHand: nil},
 		})
 
 		result := p.Output(h, nil)
-		assert.Contains(t, result, "あなた: Flush")
+		assert.Contains(t, result, "あなた: フラッシュ")
 		assert.NotContains(t, result, "キッカー")
 	})
 
@@ -233,11 +233,11 @@ func TestShortDeckCuiPresenter_Output(t *testing.T) {
 		h, _ := makeShortDeckForPresenter()
 		h.SetPhase(domain.ShortDeckPhaseEnd)
 		h.SetRoundResults([]domain.HoldemResult{
-			{PlayerIdx: 1, HandRank: domain.PokerHandOnePair, HandName: "One Pair", Kickers: []int{13, 12, 11}, WonAmount: 50, BestHand: nil},
+			{PlayerIdx: 1, HandRank: domain.ShortDeckHandOnePair, HandName: "One Pair", Kickers: []int{13, 12, 11}, WonAmount: 50, BestHand: nil},
 		})
 
 		result := p.Output(h, nil)
-		assert.Contains(t, result, "CPU 1: One Pair (キッカー: K, Q, J)")
+		assert.Contains(t, result, "CPU 1: ワンペア (キッカー: K, Q, J)")
 		assert.Contains(t, result, "50チップ獲得")
 	})
 
@@ -257,7 +257,7 @@ func TestShortDeckCuiPresenter_Output(t *testing.T) {
 		h, _ := makeShortDeckForPresenter()
 		h.SetPhase(domain.ShortDeckPhaseEnd)
 		h.SetRoundResults([]domain.HoldemResult{
-			{PlayerIdx: 1, HandName: "High Card", WonAmount: 0, BestHand: nil},
+			{PlayerIdx: 1, HandRank: domain.ShortDeckHandHighCard, HandName: "High Card", WonAmount: 0, BestHand: nil},
 		})
 
 		result := p.Output(h, nil)
@@ -268,7 +268,7 @@ func TestShortDeckCuiPresenter_Output(t *testing.T) {
 		h, _ := makeShortDeckForPresenter()
 		h.SetPhase(domain.ShortDeckPhaseFlop)
 		h.SetRoundResults([]domain.HoldemResult{
-			{PlayerIdx: 0, HandName: "Flush", WonAmount: 100, BestHand: nil},
+			{PlayerIdx: 0, HandRank: domain.ShortDeckHandFlush, HandName: "Flush", WonAmount: 100, BestHand: nil},
 		})
 
 		result := p.Output(h, nil)
@@ -576,8 +576,8 @@ func TestShortDeckCuiPresenter_Output_Muck(t *testing.T) {
 		h, _ := makeShortDeckForPresenter()
 		h.SetPhase(domain.ShortDeckPhaseShowdown)
 		h.SetRoundResults([]domain.HoldemResult{
-			{PlayerIdx: 0, HandRank: domain.PokerHandOnePair, HandName: "One Pair", WonAmount: 0, BestHand: nil},
-			{PlayerIdx: 1, HandRank: domain.PokerHandFlush, HandName: "Flush", WonAmount: 100, BestHand: nil},
+			{PlayerIdx: 0, HandRank: domain.ShortDeckHandOnePair, HandName: "One Pair", WonAmount: 0, BestHand: nil},
+			{PlayerIdx: 1, HandRank: domain.ShortDeckHandFlush, HandName: "Flush", WonAmount: 100, BestHand: nil},
 		})
 
 		result := p.Output(h, nil)
@@ -588,7 +588,7 @@ func TestShortDeckCuiPresenter_Output_Muck(t *testing.T) {
 		h, _ := makeShortDeckForPresenter()
 		h.SetPhase(domain.ShortDeckPhaseEnd)
 		h.SetRoundResults([]domain.HoldemResult{
-			{PlayerIdx: 0, HandRank: domain.PokerHandFlush, HandName: "Flush", WonAmount: 100, BestHand: nil},
+			{PlayerIdx: 0, HandRank: domain.ShortDeckHandFlush, HandName: "Flush", WonAmount: 100, BestHand: nil},
 		})
 
 		result := p.Output(h, nil)
@@ -600,7 +600,7 @@ func TestShortDeckCuiPresenter_Output_Muck(t *testing.T) {
 		h.SetPhase(domain.ShortDeckPhaseEnd)
 		h.SetRoundResults([]domain.HoldemResult{
 			{PlayerIdx: 0, HandName: "One Pair", WonAmount: 0, Mucked: true, BestHand: nil},
-			{PlayerIdx: 1, HandRank: domain.PokerHandFlush, HandName: "Flush", WonAmount: 100, BestHand: nil},
+			{PlayerIdx: 1, HandRank: domain.ShortDeckHandFlush, HandName: "Flush", WonAmount: 100, BestHand: nil},
 		})
 
 		result := p.Output(h, nil)
@@ -612,12 +612,12 @@ func TestShortDeckCuiPresenter_Output_Muck(t *testing.T) {
 		h, _ := makeShortDeckForPresenter()
 		h.SetPhase(domain.ShortDeckPhaseShowdown)
 		h.SetRoundResults([]domain.HoldemResult{
-			{PlayerIdx: 0, HandRank: domain.PokerHandFlush, HandName: "Flush", WonAmount: 100, BestHand: nil},
+			{PlayerIdx: 0, HandRank: domain.ShortDeckHandFlush, HandName: "Flush", WonAmount: 100, BestHand: nil},
 		})
 
 		result := p.Output(h, nil)
 		assert.Contains(t, result, "[結果]")
-		assert.Contains(t, result, "あなた: Flush")
+		assert.Contains(t, result, "あなた: フラッシュ")
 	})
 }
 
@@ -663,4 +663,40 @@ func TestShortDeckCuiPresenter_ActionLogOutput(t *testing.T) {
 		assert.Contains(t, result, "棋譜はありません")
 		mockGame.AssertExpectations(t)
 	})
+}
+
+// TestShortDeckCuiPresenter_HandNameOrdering pins the short-deck ranking, where
+// the flush outranks the full house (#4987).
+//
+// **共通の役表を流用すると 5 が「フラッシュ」になる。**標準デッキでは 5=Flush /
+// 6=Full House だが、36枚デッキでは逆。訳されないより誤訳のほうが悪いので、
+// 入れ替わっている 2 ランクを名指しで固定する。
+func TestShortDeckCuiPresenter_HandNameOrdering(t *testing.T) {
+	origNoColor := color.NoColor()
+	color.SetNoColor(true)
+	defer color.SetNoColor(origNoColor)
+
+	p := new(presenter.ShortDeckCuiPresenter)
+	tests := []struct {
+		name string
+		rank int
+		want string
+		deny string
+	}{
+		{"rank 5 is the full house, not the flush", domain.ShortDeckHandFullHouse, "フルハウス", "フラッシュ"},
+		{"rank 6 is the flush, not the full house", domain.ShortDeckHandFlush, "フラッシュ", "フルハウス"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h, _ := makeShortDeckForPresenter()
+			h.SetPhase(domain.ShortDeckPhaseEnd)
+			h.SetRoundResults([]domain.HoldemResult{
+				{PlayerIdx: 0, HandRank: tt.rank, HandName: domain.ShortDeckHandNames[tt.rank], WonAmount: 100},
+			})
+
+			result := p.Output(h, nil)
+			assert.Contains(t, result, "あなた: "+tt.want)
+			assert.NotContains(t, result, "あなた: "+tt.deny)
+		})
+	}
 }

--- a/internal/adapter/presenter/cui_card_helper.go
+++ b/internal/adapter/presenter/cui_card_helper.go
@@ -140,27 +140,6 @@ func cuiPokerHandName(rank int) string {
 	return i18n.T("pokerHandRank" + strconv.Itoa(rank))
 }
 
-// cuiShortDeckHandName returns the localized name for a Short Deck hand rank.
-//
-// **標準の役表を流用してはいけない。**36枚デッキではフラッシュがフルハウスの上に
-// 来るので (`domain.ShortDeckHandNames`)、`cuiPokerHandName` に渡すと 5=Full House を
-// 「フラッシュ」と表示する。訳されないより誤訳のほうが悪い (#4987)。
-func cuiShortDeckHandName(rank int) string {
-	if rank < 0 || rank >= len(domain.ShortDeckHandNames) {
-		return ""
-	}
-	return i18n.T("shortdeck.handRank" + strconv.Itoa(rank))
-}
-
-// cuiBadugiHandName returns the localized name for a Badugi hand size (1-4).
-// Badugi's names ("Badugi", "3-card", …) have no counterpart in the poker table.
-func cuiBadugiHandName(size int) string {
-	if size < 1 || size >= len(domain.BadugiHandNames) {
-		return i18n.T("badugi.handRankUnknown")
-	}
-	return i18n.T("badugi.handRank" + strconv.Itoa(size))
-}
-
 // cuiPlayerName returns the human-friendly display name for a player:
 // "You" / "あなた" for the human, "CPU N" for CPU opponents, or
 // "UNKNOWN" if the player is nil/zero. Locale-aware via i18n.T (issue

--- a/internal/adapter/presenter/cui_card_helper.go
+++ b/internal/adapter/presenter/cui_card_helper.go
@@ -140,6 +140,27 @@ func cuiPokerHandName(rank int) string {
 	return i18n.T("pokerHandRank" + strconv.Itoa(rank))
 }
 
+// cuiShortDeckHandName returns the localized name for a Short Deck hand rank.
+//
+// **標準の役表を流用してはいけない。**36枚デッキではフラッシュがフルハウスの上に
+// 来るので (`domain.ShortDeckHandNames`)、`cuiPokerHandName` に渡すと 5=Full House を
+// 「フラッシュ」と表示する。訳されないより誤訳のほうが悪い (#4987)。
+func cuiShortDeckHandName(rank int) string {
+	if rank < 0 || rank >= len(domain.ShortDeckHandNames) {
+		return ""
+	}
+	return i18n.T("shortdeck.handRank" + strconv.Itoa(rank))
+}
+
+// cuiBadugiHandName returns the localized name for a Badugi hand size (1-4).
+// Badugi's names ("Badugi", "3-card", …) have no counterpart in the poker table.
+func cuiBadugiHandName(size int) string {
+	if size < 1 || size >= len(domain.BadugiHandNames) {
+		return i18n.T("badugi.handRankUnknown")
+	}
+	return i18n.T("badugi.handRank" + strconv.Itoa(size))
+}
+
 // cuiPlayerName returns the human-friendly display name for a player:
 // "You" / "あなた" for the human, "CPU N" for CPU opponents, or
 // "UNKNOWN" if the player is nil/zero. Locale-aware via i18n.T (issue

--- a/internal/i18n/locales/en/badugi.json
+++ b/internal/i18n/locales/en/badugi.json
@@ -38,5 +38,10 @@
   "gameEnd": "Game over",
   "betLimitsMax": "Min raise: {{min}} / Max bet: {{max}}",
   "betLimitsNoCap": "Min raise: {{min}} / Max bet: unlimited",
-  "betLimitsMin": "Min raise: {{min}}"
+  "betLimitsMin": "Min raise: {{min}}",
+  "handRank1": "1-card",
+  "handRank2": "2-card",
+  "handRank3": "3-card",
+  "handRank4": "Badugi",
+  "handRankUnknown": "Unknown"
 }

--- a/internal/i18n/locales/en/shortdeck.json
+++ b/internal/i18n/locales/en/shortdeck.json
@@ -37,5 +37,15 @@
   "muckPrompt": "Muck? (m=muck / sh=show)",
   "rebuyPrompt": "Rebuy? ({{chips}} chips, used {{used}}/{{max}}) (rb=rebuy / sr=skip)",
   "addonPrompt": "Add-on? ({{chips}} chips) (ad=addon / sa=skip)",
-  "gameEnd": "Game over"
+  "gameEnd": "Game over",
+  "handRank0": "High Card",
+  "handRank1": "One Pair",
+  "handRank2": "Two Pair",
+  "handRank3": "Three of a Kind",
+  "handRank4": "Straight",
+  "handRank5": "Full House",
+  "handRank6": "Flush",
+  "handRank7": "Four of a Kind",
+  "handRank8": "Straight Flush",
+  "handRank9": "Royal Flush"
 }

--- a/internal/i18n/locales/ja/badugi.json
+++ b/internal/i18n/locales/ja/badugi.json
@@ -38,5 +38,10 @@
   "gameEnd": "ゲーム終了",
   "betLimitsMax": "最小レイズ: {{min}} / 上限: {{max}}",
   "betLimitsNoCap": "最小レイズ: {{min}} / 上限: なし",
-  "betLimitsMin": "最小レイズ: {{min}}"
+  "betLimitsMin": "最小レイズ: {{min}}",
+  "handRank1": "1カード",
+  "handRank2": "2カード",
+  "handRank3": "3カード",
+  "handRank4": "バドゥーギ",
+  "handRankUnknown": "不明"
 }

--- a/internal/i18n/locales/ja/shortdeck.json
+++ b/internal/i18n/locales/ja/shortdeck.json
@@ -37,5 +37,15 @@
   "muckPrompt": "マックしますか? (m=マック / sh=ショー)",
   "rebuyPrompt": "リバイしますか? ({{chips}}チップ, {{used}}/{{max}}回使用済) (rb=リバイ / sr=スキップ)",
   "addonPrompt": "アドオンしますか? ({{chips}}チップ) (ad=アドオン / sa=スキップ)",
-  "gameEnd": "ゲーム終了"
+  "gameEnd": "ゲーム終了",
+  "handRank0": "ハイカード",
+  "handRank1": "ワンペア",
+  "handRank2": "ツーペア",
+  "handRank3": "スリーカード",
+  "handRank4": "ストレート",
+  "handRank5": "フルハウス",
+  "handRank6": "フラッシュ",
+  "handRank7": "フォーカード",
+  "handRank8": "ストレートフラッシュ",
+  "handRank9": "ロイヤルフラッシュ"
 }


### PR DESCRIPTION
## 概要

#4986 でポーカー系 CUI の役名を共通ヘルパ `cuiPokerHandName` に寄せたとき、序列が違うこの2ゲームは**意図的に対象外**にしてあった（#4987 として起票）。専用のキー表を用意して、英語のまま取り残された状態を解消する。

## なぜ共通表を使えないか

- **ショートデック**: 36枚デッキ用の独自序列で **5 = Full House / 6 = Flush**（`domain.ShortDeckHandNames`）。共通表は 5 = Flush / 6 = Full House なので、流用すると**フルハウスが「フラッシュ」と誤表示される**。
- **バドゥーギ**: 役名（`Badugi` / `3-card` / …）がポーカー役表と対応しない。役は成立枚数そのもの。

## 変更

- `cuiShortDeckHandName(rank)` / `cuiBadugiHandName(size)` を `cui_card_helper.go` に追加
- ショートデックの showdown は `r.HandRank`（結果が既に持っている）から引く。文字列一致はしない
- バドゥーギは `pl.GetBestHand().Size` から引く
- `internal/i18n/locales/{ja,en}/{shortdeck,badugi}.json` にキー追加

## 途中で見つけた既存の不整合

テストのフィクスチャが `domain.PokerHandFlush` (=5) を**短縮デッキの結果**に使っていた。本番の `ShortDeck.go` は `HandName: sd.getHandName(p.GetHandRank())` なので名前と rank は必ず一致するが、フィクスチャだけ食い違っており、rank 経由の表示に切り替えると別の役になる（実際 "Flush" が「フルハウス」と出た）。`ShortDeckHand*` 定数に直した。本番コードに同じ誤用は無い（grep 済み）。

## テスト

- **序列の入れ替わりを名指しで固定**: rank 5 は「フルハウス」で「フラッシュ」ではない / rank 6 はその逆
- バドゥーギ2件: 4枚成立＝「バドゥーギ」/ スート重複で「3カード」、英語の生役名 `-card` が漏れないこと
- 負のコントロール: 共通ヘルパ・生の `GetHandName()` に戻すと4サブテストとも落ちる

`go test -tags test ./internal/...` 全通、`golangci-lint` 0 issues。

Closes #4987