### PR TITLE
test: verify design-doc identifiers against the real code

### DIFF
--- a/docs/design/backend.md
+++ b/docs/design/backend.md
@@ -301,7 +301,7 @@ classDiagram
         +Reset()
         +Bet(amount int) error
         +Pull() error
-        +LetItRide() error
+        +LetItRideAction() error
         +GetPhase() int
         +GetActionLog() []*ActionLogEntry
     }
@@ -3182,8 +3182,8 @@ stateDiagram-v2
 stateDiagram-v2
     [*] --> Bet : Reset()
     Bet --> Decision1 : Bet() (3等分ベット＋配布)
-    Decision1 --> Decision2 : Pull() or LetItRide() (1枚目コミュニティ公開)
-    Decision2 --> End : Pull() or LetItRide() (2枚目コミュニティ公開＋判定)
+    Decision1 --> Decision2 : Pull() or LetItRideAction() (1枚目コミュニティ公開)
+    Decision2 --> End : Pull() or LetItRideAction() (2枚目コミュニティ公開＋判定)
     End --> Bet : Reset() (次ラウンド)
     End --> [*]
 

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -121,9 +121,10 @@ bun run build && bun run check && bun run test
 
 ## Guard scripts (`scripts/check-*.mjs`)
 
-`bun run check` is Biome plus thirteen guard scripts, each pinning down an invariant that no
+`bun run check` is Biome plus fourteen guard scripts, each pinning down an invariant that no
 type or test covers (design tokens, discover blurbs, message codes, hint coverage, markdown
-tables, mermaid diagrams, dependency licences, trademark terms, asset provenance, …).
+tables, mermaid diagrams, design-doc identifiers, dependency licences, trademark terms,
+asset provenance, …).
 
 **Every guard that reports a discovered count must assert a floor under it.** A guard walks
 something and then reports on what it found; when the walk breaks, it finds nothing, nothing

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,7 @@
     "lint": "biome lint .",
     "lint:tokens": "bun scripts/check-design-tokens.mjs",
     "format": "biome format --write .",
-    "check": "biome check . && bun scripts/check-guard-floors.mjs && bun scripts/check-design-tokens.mjs && bun scripts/check-discover-blurbs.mjs && bun scripts/check-message-codes.mjs && bun scripts/check-hint-coverage.mjs && bun scripts/check-hint-reasons.mjs && bun scripts/check-markdown-tables.mjs && bun scripts/check-hint-gate.mjs && bun scripts/check-dependency-licenses.mjs && bun scripts/check-trademark-terms.mjs && bun scripts/check-asset-provenance.mjs && bun scripts/check-codecov-uploads.mjs && bun scripts/check-mermaid.mjs",
+    "check": "biome check . && bun scripts/check-guard-floors.mjs && bun scripts/check-design-tokens.mjs && bun scripts/check-discover-blurbs.mjs && bun scripts/check-message-codes.mjs && bun scripts/check-hint-coverage.mjs && bun scripts/check-hint-reasons.mjs && bun scripts/check-markdown-tables.mjs && bun scripts/check-hint-gate.mjs && bun scripts/check-dependency-licenses.mjs && bun scripts/check-trademark-terms.mjs && bun scripts/check-asset-provenance.mjs && bun scripts/check-codecov-uploads.mjs && bun scripts/check-mermaid.mjs && bun scripts/check-design-doc-identifiers.mjs",
     "check:write": "biome check --write .",
     "preview": "vite preview",
     "test": "vitest run",

--- a/frontend/scripts/check-design-doc-identifiers.mjs
+++ b/frontend/scripts/check-design-doc-identifiers.mjs
@@ -50,8 +50,12 @@ const SKIP = new Set(['node_modules', '.git', 'dist', 'coverage', 'playwright-re
 /** `export function X` / `export const X` / `export class X` / `export type X` … */
 const EXPORT_DECL =
   /export\s+(?:default\s+)?(?:async\s+)?(?:function|const|let|var|class|interface|type|enum)\s+([A-Za-z0-9_$]+)/g;
-/** `export { A, B as C }` — take the exported (right-hand) name. */
-const EXPORT_LIST = /export\s*\{([^}]*)\}/g;
+/**
+ * `export { A, B as C }` — take the exported (right-hand) name. The optional
+ * `type` keyword matters: `export type { A as B }` is a real re-export, and
+ * missing it would report a legitimately exported name as unresolved.
+ */
+const EXPORT_LIST = /export\s*(?:type\s+)?\{([^}]*)\}/g;
 /** `export default someIdentifier` — a bare re-export of an existing binding. */
 const EXPORT_DEFAULT_IDENT = /export\s+default\s+([A-Za-z0-9_$]+)\s*;/g;
 

--- a/frontend/scripts/check-design-doc-identifiers.mjs
+++ b/frontend/scripts/check-design-doc-identifiers.mjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env bun
+// Guard that every class named in a docs/design/frontend.md class diagram still
+// exists in frontend/src.
+//
+// Usage: check-design-doc-identifiers.mjs [srcDir] [docFile]
+//
+// The Go half of this pair lives in
+// internal/infrastructure/games/design_doc_identifiers_test.go. Together they
+// close the last hole found by the 2026-08-08 drift sweep (#5170): the two
+// design documents were the worst drift site in the repo and nothing checked
+// their identifiers. On the frontend side the sweep found four hooks that no
+// longer exist at all (`useGameSound`, `useCardGesture`, `useHaptics`,
+// `useBlackJackGame` and friends) still drawn as classes.
+//
+// Scope: class names only, not members. A hook's return shape and an object
+// literal's keys cannot be resolved without full type information, and a guard
+// that reports false positives gets switched off. Renamed *members* remain
+// unguarded here; renamed or deleted *components, hooks and modules* — which is
+// what actually rotted — do not.
+//
+// A diagram node resolves if it is any of:
+//   1. an exported binding somewhere under src/,
+//   2. a module: src/**/<name>.ts(x), or a directory src/**/<name>/,
+//   3. a listed placeholder (a node standing in for "the per-game page").
+
+import { readdir, readFile } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { assertFloor } from './lib/floor.mjs';
+
+const FRONTEND = fileURLToPath(new URL('..', import.meta.url));
+const REPO = join(FRONTEND, '..');
+
+const SRC = process.argv[2] ? resolve(process.argv[2]) : join(FRONTEND, 'src');
+const DOC = process.argv[3] ? resolve(process.argv[3]) : join(REPO, 'docs/design/frontend.md');
+const SCANNING_REPO = !process.argv[2];
+
+/** Nodes that deliberately stand for a family rather than one symbol. */
+const PLACEHOLDERS = new Set([
+  // One node standing for all 264 game pages.
+  'GamePage',
+  // Page-local phase constants, not exported enums. The document says so
+  // itself where it lists them.
+  'DurakPhase',
+  'PigsTailPhase',
+]);
+
+const SKIP = new Set(['node_modules', '.git', 'dist', 'coverage', 'playwright-report', 'test-results']);
+
+/** `export function X` / `export const X` / `export class X` / `export type X` … */
+const EXPORT_DECL =
+  /export\s+(?:default\s+)?(?:async\s+)?(?:function|const|let|var|class|interface|type|enum)\s+([A-Za-z0-9_$]+)/g;
+/** `export { A, B as C }` — take the exported (right-hand) name. */
+const EXPORT_LIST = /export\s*\{([^}]*)\}/g;
+/** `export default someIdentifier` — a bare re-export of an existing binding. */
+const EXPORT_DEFAULT_IDENT = /export\s+default\s+([A-Za-z0-9_$]+)\s*;/g;
+
+const CLASS_DECL = /^\s*class\s+([A-Za-z0-9_]+)/;
+
+async function* sourceFiles(dir) {
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    if (SKIP.has(entry.name)) continue;
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) yield* sourceFiles(full);
+    else if (/\.(ts|tsx)$/.test(entry.name) && !/\.test\.tsx?$/.test(entry.name)) yield full;
+  }
+}
+
+async function* directories(dir) {
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    if (SKIP.has(entry.name) || !entry.isDirectory()) continue;
+    const full = join(dir, entry.name);
+    yield entry.name;
+    yield* directories(full);
+  }
+}
+
+const known = new Set();
+let sourceCount = 0;
+
+for await (const file of sourceFiles(SRC)) {
+  sourceCount++;
+  const src = await readFile(file, 'utf8');
+  // The module itself is addressable as a diagram node.
+  known.add(
+    file
+      .split('/')
+      .pop()
+      .replace(/\.tsx?$/, ''),
+  );
+  for (const m of src.matchAll(EXPORT_DECL)) known.add(m[1]);
+  for (const m of src.matchAll(EXPORT_DEFAULT_IDENT)) known.add(m[1]);
+  for (const m of src.matchAll(EXPORT_LIST)) {
+    for (const part of m[1].split(',')) {
+      const name = part
+        .trim()
+        .split(/\s+as\s+/)
+        .pop()
+        ?.trim();
+      if (name) known.add(name);
+    }
+  }
+}
+for await (const name of directories(SRC)) known.add(name);
+
+const doc = await readFile(DOC, 'utf8');
+const classes = new Set();
+for (const block of doc.matchAll(/```mermaid\n([\s\S]*?)```/g)) {
+  if (!/^\s*classDiagram/m.test(block[1])) continue;
+  for (const line of block[1].split('\n')) {
+    const m = line.match(CLASS_DECL);
+    if (m) classes.add(m[1]);
+  }
+}
+
+if (SCANNING_REPO) {
+  assertFloor('design-doc-identifiers', sourceCount, 700, 'source files scanned');
+  assertFloor('design-doc-identifiers', known.size, 3000, 'known identifiers');
+  assertFloor('design-doc-identifiers', classes.size, 140, 'diagram classes');
+}
+
+const unknown = [...classes].filter((c) => !PLACEHOLDERS.has(c) && !known.has(c)).sort();
+
+if (unknown.length > 0) {
+  console.error(
+    `\ndesign-doc-identifiers: ${unknown.length} class(es) in the design doc have no counterpart in src/.\n`,
+  );
+  for (const name of unknown) console.error(`  ${name}`);
+  console.error(
+    '\nEither the symbol was renamed or deleted (update the diagram), or it is a\n' +
+      'deliberate placeholder (add it to PLACEHOLDERS in this script).\n',
+  );
+  process.exit(1);
+}
+
+console.log(`design-doc-identifiers: OK (${classes.size} diagram classes resolved against ${known.size} identifiers).`);

--- a/frontend/scripts/check-design-doc-identifiers.test.mjs
+++ b/frontend/scripts/check-design-doc-identifiers.test.mjs
@@ -74,6 +74,16 @@ describe('check-design-doc-identifiers', () => {
     expect(r.code).toBe(0);
   });
 
+  it('accepts a class exported through a type-only renamed re-export', () => {
+    // `export type { A as B }` — the `type` keyword sits between `export` and
+    // the brace, so a regex that only allows whitespace there misses it and
+    // reports a legitimately exported name as missing.
+    const r = check(
+      fixture({ sources: { 'a.ts': 'type A = { x: number };\nexport type { A as Renamed };' }, classes: ['Renamed'] }),
+    );
+    expect(r.code).toBe(0);
+  });
+
   it('accepts the documented placeholders', () => {
     const r = check(fixture({ sources: { 'a.ts': 'export const x = 1;' }, classes: ['GamePage', 'DurakPhase'] }));
     expect(r.code).toBe(0);

--- a/frontend/scripts/check-design-doc-identifiers.test.mjs
+++ b/frontend/scripts/check-design-doc-identifiers.test.mjs
@@ -1,0 +1,96 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, describe, expect, it } from 'vitest';
+
+// Vitest serves test modules under a non-file URL, so `import.meta.url` cannot be converted
+// with fileURLToPath here. The vitest root is `frontend/`, so resolve from cwd — and assert
+// the script is actually there, because a wrong cwd would otherwise turn every case below
+// into a spawn of a missing file rather than a visible failure.
+const SCRIPTS = join(process.cwd(), 'scripts');
+const GUARD = join(SCRIPTS, 'check-design-doc-identifiers.mjs');
+if (!existsSync(GUARD)) throw new Error(`guard not found at ${GUARD} (cwd: ${process.cwd()})`);
+
+const dirs = [];
+afterAll(() => {
+  for (const d of dirs) rmSync(d, { recursive: true, force: true });
+});
+
+/** A design doc whose diagram names the given classes. */
+function doc(...classes) {
+  const body = classes.map((c) => `    class ${c} {\n        +thing()\n    }`).join('\n');
+  return ['# Design', '', '```mermaid', 'classDiagram', body, '```', ''].join('\n');
+}
+
+function fixture({ sources = {}, classes = [] }) {
+  const dir = mkdtempSync(join(tmpdir(), 'design-doc-ids-'));
+  dirs.push(dir);
+  const src = join(dir, 'src');
+  mkdirSync(src, { recursive: true });
+  for (const [name, body] of Object.entries(sources)) {
+    const full = join(src, name);
+    mkdirSync(join(full, '..'), { recursive: true });
+    writeFileSync(full, body);
+  }
+  const docFile = join(dir, 'design.md');
+  writeFileSync(docFile, doc(...classes));
+  return { src, docFile };
+}
+
+function check({ src, docFile }) {
+  const r = spawnSync(process.execPath, [GUARD, src, docFile], { encoding: 'utf8', cwd: process.cwd() });
+  return { code: r.status, out: `${r.stdout}${r.stderr}` };
+}
+
+describe('check-design-doc-identifiers', () => {
+  // Positive control first: a guard that only ever fires proves nothing about
+  // the day it stays quiet.
+  it('accepts a class backed by a named export', () => {
+    const r = check(fixture({ sources: { 'a.ts': 'export function Widget() {}' }, classes: ['Widget'] }));
+    expect(r.code).toBe(0);
+    expect(r.out).toContain('design-doc-identifiers: OK');
+  });
+
+  it('rejects a class with no counterpart', () => {
+    const r = check(fixture({ sources: { 'a.ts': 'export function Widget() {}' }, classes: ['Ghost'] }));
+    expect(r.code).toBe(1);
+    expect(r.out).toContain('Ghost');
+  });
+
+  it('accepts a class that names a module rather than an export', () => {
+    // `gameApi`, `urlMoodCodec` and friends are drawn as module nodes.
+    const r = check(fixture({ sources: { 'gameApi.ts': 'export const x = 1;' }, classes: ['gameApi'] }));
+    expect(r.code).toBe(0);
+  });
+
+  it('accepts a class exported via `export default <ident>`', () => {
+    const r = check(fixture({ sources: { 'a.ts': 'const i18n = {};\nexport default i18n;' }, classes: ['i18n'] }));
+    expect(r.code).toBe(0);
+  });
+
+  it('accepts a class exported through an export list, using the renamed binding', () => {
+    const r = check(fixture({ sources: { 'a.ts': 'const a = 1;\nexport { a as Renamed };' }, classes: ['Renamed'] }));
+    expect(r.code).toBe(0);
+  });
+
+  it('accepts the documented placeholders', () => {
+    const r = check(fixture({ sources: { 'a.ts': 'export const x = 1;' }, classes: ['GamePage', 'DurakPhase'] }));
+    expect(r.code).toBe(0);
+  });
+
+  it('does not credit exports that live only in test files', () => {
+    const r = check(
+      fixture({ sources: { 'a.test.ts': 'export function OnlyInTests() {}' }, classes: ['OnlyInTests'] }),
+    );
+    expect(r.code).toBe(1);
+    expect(r.out).toContain('OnlyInTests');
+  });
+
+  it('reports every unresolved class, not just the first', () => {
+    const r = check(fixture({ sources: { 'a.ts': 'export const x = 1;' }, classes: ['GhostOne', 'GhostTwo'] }));
+    expect(r.code).toBe(1);
+    expect(r.out).toContain('GhostOne');
+    expect(r.out).toContain('GhostTwo');
+  });
+});

--- a/internal/infrastructure/games/design_doc_identifiers_test.go
+++ b/internal/infrastructure/games/design_doc_identifiers_test.go
@@ -1,0 +1,322 @@
+package games_test
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// docs/design/backend.md is ~90 Mermaid diagrams describing the Go backend, and
+// until now nothing checked that the names in them still exist. The 2026-08-08
+// sweep (#5170) found it naming two deleted types, a renamed SessionStore
+// method, a renamed controller entry point, and roughly 150 methods that had
+// been renamed out from under it. TestDesignDocCountsMatchRegistry (#5173)
+// covers the totals; this covers the identifiers, which is where the real rot
+// was.
+//
+// The check is structural, not textual: the Go side is parsed with go/ast so
+// that interfaces, generics, embedded types and constructors are all modelled
+// properly. Approximating any of those with a grep produces false positives,
+// and a guard that cries wolf gets deleted.
+
+// designDocPath is the diagram-heavy backend design document under test.
+const designDocPath = "docs/design/backend.md"
+
+// goSourceRoot is the tree whose exported surface the document describes.
+const goSourceRoot = "internal"
+
+// placeholderClasses are diagram nodes that stand for "the per-game
+// implementation" rather than naming one concrete Go type. They are a real
+// documentation device here -- there are 264 games and the diagrams show the
+// shape once -- so they are expected to have no counterpart in code.
+var placeholderClasses = map[string]bool{
+	"GameCui":           true,
+	"GameCuiController": true,
+	"GameCuiPresenter":  true,
+	"GameInteractor":    true,
+	"GameInteractorIF":  true,
+	"GameWebPresenter":  true,
+}
+
+var (
+	// mermaidBlockRe captures the body of a fenced mermaid block.
+	mermaidBlockRe = regexp.MustCompile("(?s)```mermaid\n(.*?)```")
+	// classDiagramRe detects the diagram kind, since only class diagrams
+	// declare types and members.
+	classDiagramRe = regexp.MustCompile(`(?m)^\s*classDiagram`)
+	// classOpenRe matches `class Foo {`, classBareRe a member-less `class Foo`.
+	classOpenRe = regexp.MustCompile(`^\s*class\s+([A-Za-z0-9_]+)\s*\{`)
+	classBareRe = regexp.MustCompile(`^\s*class\s+([A-Za-z0-9_]+)\s*$`)
+	// memberFuncRe matches a method entry such as `+GetPhase() int`. Fields
+	// (no parentheses) are deliberately not checked: the diagrams routinely
+	// rename a field for readability, and unexported fields are an
+	// implementation detail the document is allowed to paraphrase.
+	memberFuncRe = regexp.MustCompile(`^\s*[+\-#~]([A-Za-z0-9_]+)\s*\(`)
+	// closeBraceRe ends a class body.
+	closeBraceRe = regexp.MustCompile(`^\s*\}`)
+)
+
+// parseDesignDocClasses returns the classes declared in the document's class
+// diagrams, mapped to the method names listed under each.
+func parseDesignDocClasses(t *testing.T, path string) map[string]map[string]bool {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(repoRoot, path))
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+
+	classes := map[string]map[string]bool{}
+	for _, block := range mermaidBlockRe.FindAllSubmatch(data, -1) {
+		body := string(block[1])
+		if !classDiagramRe.MatchString(body) {
+			continue
+		}
+		current := ""
+		for line := range strings.SplitSeq(body, "\n") {
+			if m := classOpenRe.FindStringSubmatch(line); m != nil {
+				current = m[1]
+				if classes[current] == nil {
+					classes[current] = map[string]bool{}
+				}
+				continue
+			}
+			if current != "" && closeBraceRe.MatchString(line) {
+				current = ""
+				continue
+			}
+			if m := classBareRe.FindStringSubmatch(line); m != nil {
+				if classes[m[1]] == nil {
+					classes[m[1]] = map[string]bool{}
+				}
+				continue
+			}
+			if current != "" {
+				if m := memberFuncRe.FindStringSubmatch(line); m != nil {
+					classes[current][m[1]] = true
+				}
+			}
+		}
+	}
+	return classes
+}
+
+// goSurface is the parsed Go type surface: which named types exist, which
+// methods each has, and which types each struct embeds.
+type goSurface struct {
+	types    map[string]bool
+	methods  map[string]map[string]bool
+	embedded map[string][]string
+}
+
+// has reports whether typ (or anything it embeds) provides method. Embedding is
+// resolved transitively because the diagrams legitimately list a promoted
+// method -- GamePlayer's accessors show up on the per-game player classes -- and
+// treating those as missing would be a false positive on correct docs.
+func (s *goSurface) has(typ, method string, seen map[string]bool) bool {
+	if seen[typ] {
+		return false
+	}
+	seen[typ] = true
+	if s.methods[typ][method] {
+		return true
+	}
+	for _, base := range s.embedded[typ] {
+		if s.has(base, method, seen) {
+			return true
+		}
+	}
+	return false
+}
+
+// receiverName extracts the bare type name from a method receiver, unwrapping
+// pointers and generic instantiations (`*Foo[T]` -> `Foo`).
+func receiverName(expr ast.Expr) string {
+	switch e := expr.(type) {
+	case *ast.StarExpr:
+		return receiverName(e.X)
+	case *ast.IndexExpr:
+		return receiverName(e.X)
+	case *ast.IndexListExpr:
+		return receiverName(e.X)
+	case *ast.Ident:
+		return e.Name
+	}
+	return ""
+}
+
+// embeddedName extracts the type name of an embedded field, unwrapping
+// pointers, generics and qualified names.
+func embeddedName(expr ast.Expr) string {
+	switch e := expr.(type) {
+	case *ast.StarExpr:
+		return embeddedName(e.X)
+	case *ast.IndexExpr:
+		return embeddedName(e.X)
+	case *ast.IndexListExpr:
+		return embeddedName(e.X)
+	case *ast.SelectorExpr:
+		return e.Sel.Name
+	case *ast.Ident:
+		return e.Name
+	}
+	return ""
+}
+
+// parseGoSurface walks root and records every named type, its methods, its
+// embedded types, and its constructors. Test files are skipped: the document
+// describes production code.
+func parseGoSurface(t *testing.T, root string) *goSurface {
+	t.Helper()
+	s := &goSurface{
+		types:    map[string]bool{},
+		methods:  map[string]map[string]bool{},
+		embedded: map[string][]string{},
+	}
+	addMethod := func(typ, name string) {
+		if s.methods[typ] == nil {
+			s.methods[typ] = map[string]bool{}
+		}
+		s.methods[typ][name] = true
+	}
+
+	fset := token.NewFileSet()
+	walkErr := filepath.Walk(filepath.Join(repoRoot, root), func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		// Build tags split this tree (server vs WASM); parse every file
+		// regardless so the surface is the union, not one build's view.
+		file, perr := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+		if perr != nil {
+			return nil // an unparseable file is not this guard's business
+		}
+		for _, decl := range file.Decls {
+			switch d := decl.(type) {
+			case *ast.GenDecl:
+				for _, spec := range d.Specs {
+					ts, ok := spec.(*ast.TypeSpec)
+					if !ok {
+						continue
+					}
+					s.types[ts.Name.Name] = true
+					switch typ := ts.Type.(type) {
+					case *ast.InterfaceType:
+						for _, m := range typ.Methods.List {
+							for _, n := range m.Names {
+								addMethod(ts.Name.Name, n.Name)
+							}
+							if len(m.Names) == 0 {
+								if base := embeddedName(m.Type); base != "" {
+									s.embedded[ts.Name.Name] = append(s.embedded[ts.Name.Name], base)
+								}
+							}
+						}
+					case *ast.StructType:
+						for _, f := range typ.Fields.List {
+							if len(f.Names) == 0 {
+								if base := embeddedName(f.Type); base != "" {
+									s.embedded[ts.Name.Name] = append(s.embedded[ts.Name.Name], base)
+								}
+							}
+						}
+					}
+				}
+			case *ast.FuncDecl:
+				if d.Recv != nil && len(d.Recv.List) == 1 {
+					if typ := receiverName(d.Recv.List[0].Type); typ != "" {
+						addMethod(typ, d.Name.Name)
+					}
+					continue
+				}
+				// A package-level `NewFoo` is shown inside class Foo in the
+				// diagrams, which is the conventional way to draw a
+				// constructor. Credit it to Foo so that is not a false hit.
+				if typ, ok := strings.CutPrefix(d.Name.Name, "New"); ok {
+					addMethod(typ, d.Name.Name)
+				}
+			}
+		}
+		return nil
+	})
+	if walkErr != nil {
+		t.Fatalf("walk %s: %v", root, walkErr)
+	}
+	return s
+}
+
+// TestDesignDocClassesExistInGo asserts that every class named in a
+// docs/design/backend.md class diagram is a real Go type.
+//
+// This is what would have caught EuchreTrickCard and BridgeTrickCard, which
+// stayed in the diagrams for months after both were replaced by the shared
+// TrickCard -- while a comment in the same file already said the migration had
+// happened.
+func TestDesignDocClassesExistInGo(t *testing.T) {
+	classes := parseDesignDocClasses(t, designDocPath)
+	if len(classes) < 50 {
+		t.Fatalf("only %d classes parsed from %s -- the diagram format changed; update the regexes", len(classes), designDocPath)
+	}
+	surface := parseGoSurface(t, goSourceRoot)
+	if len(surface.types) < 500 {
+		t.Fatalf("only %d Go types parsed from %s/ -- the walk is broken", len(surface.types), goSourceRoot)
+	}
+
+	var unknown []string
+	for name := range classes {
+		if placeholderClasses[name] || surface.types[name] {
+			continue
+		}
+		unknown = append(unknown, name)
+	}
+	sort.Strings(unknown)
+
+	if len(unknown) > 0 {
+		t.Errorf("classes in %s with no Go type: %v\n"+
+			"Either the type was renamed or deleted (update the diagram), or it is a\n"+
+			"deliberate per-game placeholder (add it to placeholderClasses).", designDocPath, unknown)
+	}
+}
+
+// TestDesignDocMethodsExistInGo asserts that every method listed under a class
+// that does map to a real Go type actually exists on it.
+//
+// This is the check that bites: the sweep found SessionStore.GetOrCreate,
+// GameWebController.Handle, GameManager.Switch and a long tail of renames
+// (Phase -> GetPhase, ActionLog -> GetActionLog) still documented years after
+// the code moved on.
+func TestDesignDocMethodsExistInGo(t *testing.T) {
+	classes := parseDesignDocClasses(t, designDocPath)
+	surface := parseGoSurface(t, goSourceRoot)
+
+	checked := 0
+	var missing []string
+	for class, members := range classes {
+		if !surface.types[class] {
+			continue // covered by TestDesignDocClassesExistInGo
+		}
+		for method := range members {
+			checked++
+			if !surface.has(class, method, map[string]bool{}) {
+				missing = append(missing, class+"."+method)
+			}
+		}
+	}
+	if checked < 200 {
+		t.Fatalf("only %d methods checked -- the member regex stopped matching; update memberFuncRe", checked)
+	}
+	sort.Strings(missing)
+
+	if len(missing) > 0 {
+		t.Errorf("methods in %s that do not exist on the Go type (%d of %d checked):\n  %s\n"+
+			"Rename them in the diagram to match the code.", designDocPath, len(missing), checked, strings.Join(missing, "\n  "))
+	}
+}


### PR DESCRIPTION
## 概要

#5173 で **件数** は守ったが、`docs/design/*.md` の **識別子** は無防備のまま残っていた。#5170 の走査で最も乖離が大きかったのがまさにそこ —— 削除済みの型 2 件、`SessionStore` / `GameWebController` / `GameManager` のメソッド改名、`Phase()`→`GetPhase()` 系の約 150 箇所、実在しない hook 4 種。

その最後の穴を塞ぐ。

## backend.md — `go/ast` で構文解析

`internal/infrastructure/games/design_doc_identifiers_test.go`

| テスト | 内容 |
|---|---|
| `TestDesignDocClassesExistInGo` | 図の `class` が実在する Go 型か（116 クラス） |
| `TestDesignDocMethodsExistInGo` | その型に実際にそのメソッドがあるか（**516 メソッド**） |

**grep ではなく AST を使った理由**: プロトタイプの grep 版は 12 件の誤検出を出した。内訳は interface のメソッドセット（`PokerPresenter` 等はインターフェース）、ジェネリクス受信者（`GameWebController[I,P,O]`）、コンストラクタ（`NewTrumpCards` は慣習として `class TrumpCards` の中に描かれる）。**AST 版はこれらを正しく扱い、誤検出 0 件。** 鳴きすぎるガードは消されるので、ここは妥協していない。

埋め込みによる昇格メソッドも再帰的に解決している（`GamePlayer` のアクセサが各ゲームの Player クラスに現れるのは正しい記述であり、これを未検出扱いにすると正しい doc で落ちる）。

> **このガードが実際の乖離を 1 件検出した。** 図は `+LetItRide() error` だが実装は `LetItRideAction()`（状態遷移図の 2 箇所も同様）。修正済み。

**フィールドは意図的に対象外**。図は可読性のためにフィールド名を言い換えることがあり、非公開フィールドは doc が要約してよい実装詳細のため。

## frontend.md — エクスポート/モジュール解決

`frontend/scripts/check-design-doc-identifiers.mjs`（+ テスト 8 ケース）

ノードの解決規則（いずれか該当で OK）:
1. `src/` 配下のエクスポート名（`export default <ident>` と `export { a as B }` を含む）
2. **モジュール名** — `src/**/<name>.ts(x)` またはディレクトリ。`gameApi` / `urlMoodCodec` / `manualTexts` / `recommendationScoring` / `cuiManualTexts` は実際にモジュールノードとして描かれており、エクスポート名では解決できない
3. `PLACEHOLDERS` 3 件 — `GamePage`（264 ページの代表）、`DurakPhase` / `PigsTailPhase`（ページローカル定数。**doc 自身がそう明記している**）

結果: 219 クラスすべて解決、allowlist は 3 件のみ。

**メンバーは意図的に対象外**。hook の戻り値の形やオブジェクトリテラルのキーは型情報なしに解決できない。改名された「メンバー」は依然無防備だが、実際に腐っていた「削除・改名されたコンポーネント / hook / モジュール」は捕まる。この線引きは README ではなくスクリプト冒頭のコメントに明記した。

`bun run check` に配線（**13 → 14**）、`frontend/CLAUDE.md` も更新。

## 負のコントロール

| ガード | 壊し方 | 結果 |
|---|---|---|
| classes (Go) | 実在クラスを架空名に改名 | 検出 |
| methods (Go) | メソッドを改名 | 検出 |
| methods (Go) | **埋め込みを持つ型 `DurakPlayer` に架空メソッド** | 検出（昇格解決が緩すぎて全通しになっていないことの確認） |
| classes (Go) | mermaid フェンスを破壊 | `t.Fatal: only 0 classes parsed` |
| frontend | **実際に削除された `useHaptics` を図に戻す** | 検出 |
| frontend | 実在コンポーネントを架空名に改名 | 検出 |
| frontend | ソース走査を破壊 | `assertFloor: only 0 source files scanned` |
| frontend | テストファイル限定のエクスポート | 信用しない（専用ケース） |

正のコントロール（正しい doc で鳴らないこと）も全ガードで確認済み。

## Test plan

- [x] `go test -tags test ./internal/infrastructure/games/`
- [x] `gofmt -l` clean / `go vet` clean
- [x] `cd frontend && bun run check` — 14 ガードすべて green
- [x] `bunx vitest run scripts/check-design-doc-identifiers.test.mjs scripts/check-mermaid.test.mjs` — 14 passed
- [x] 上表の負のコントロール全件
- [ ] CI

Refs #5170
