### PR TITLE
docs: fix broken instructions and stale routing in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ go test -tags test ./...                                              # Run all 
 go test -tags test -coverprofile=coverage.out -covermode=set ./...    # Coverage report
 
 # Format
-goimports -w ./...           # Format and organize imports (use goimports, not gofmt)
+goimports -w .               # Format and organize imports (use goimports, not gofmt; `./...` is a go tool pattern goimports does not accept)
 
 # Lint
 golangci-lint run ./...      # Run Go linter (must pass before commit)
@@ -100,7 +100,7 @@ When making code changes, update the relevant documentation **in the same commit
 
 ## Cloudflare Workers (WASM)
 
-Games ship to six Cloudflare Workers (`casino`, `classic`, `solo`, `extra`, `extra2`, `extra3`) as TinyGo WASM binaries, split purely to keep each binary under the 1 MB gzipped free-tier limit ([ADR-0032](docs/adr/0032-fourth-worker-capacity.md) added the fourth, [ADR-0036](docs/adr/0036-fifth-sixth-worker-capacity.md) the fifth and sixth). The `Category` in the registry is a binary-size bucket, **not** a user-facing taxonomy, and there is no overflow bucket: **put a new game in whichever worker currently has the most headroom, measured rather than assumed.** `.claude/skills/rebucket-game/scripts/measure.sh` reports every worker's gzip size, and a recent CI run's `tinygo-build` logs give the same figures without a local TinyGo. Adding/modifying a game touches 5 registration points (registry, `games_server.go`, the category sub-package, the `gameRegistry` CLI wiring in `internal/infrastructure/ui/GameManager.go`, and `gameApi.ts`) plus the per-category count assertions in `registry_test.go`. Full per-worker game list, the build-tag split rationale, and build commands: [`docs/cloudflare-workers.md`](docs/cloudflare-workers.md).
+Games ship to six Cloudflare Workers (`casino`, `classic`, `solo`, `extra`, `extra2`, `extra3`) as TinyGo WASM binaries, split purely to keep each binary under the 1 MB gzipped free-tier limit ([ADR-0032](docs/adr/0032-fourth-worker-capacity.md) added the fourth, [ADR-0036](docs/adr/0036-fifth-sixth-worker-capacity.md) the fifth and sixth). The `Category` in the registry is a binary-size bucket, **not** a user-facing taxonomy, and there is no overflow bucket: **put a new game in whichever worker currently has the most headroom, measured rather than assumed.** `.claude/skills/rebucket-game/scripts/measure.sh` reports every worker's gzip size, and a recent CI run's `tinygo-build` logs give the same figures without a local TinyGo. Adding/modifying a game touches 5 registration points (registry, `games_server.go`, the category sub-package, the `gameRegistry` CLI wiring in `internal/infrastructure/ui/GameManager.go`, and `gameApi.ts`) plus the per-category count assertions in `registry_test.go`. Skipping the doc updates now fails CI rather than only review: the README game table, `docs/games.md` and `api/openapi.yaml`'s root `tags:` block are each asserted against the registry. Full per-worker game list, the build-tag split rationale, and build commands: [`docs/cloudflare-workers.md`](docs/cloudflare-workers.md).
 
 ## New Game Addition Checklist
 
@@ -205,5 +205,11 @@ Key routing rules:
 - Code quality, health check → invoke health
 - Per-game improvement proposals → GitHub issues ("各ゲームの改善提案", "全ゲームのissueを作って") → invoke game-improve
 - New-game candidates → GitHub issues ("追加した方が良いゲームを提案", "新規ゲーム候補をissueに") → invoke propose-games
+- Add a new game end-to-end ("ゲームを追加", "add a new game", "implement <game>") → invoke new-game (explicit `/new-game <name> <category>`) — it drives the New Game Addition Checklist so no registration point or hardcoded count is missed
+- Docs out of sync with the code ("ドキュメントの乖離", "docs are stale") → invoke doc-drift-check (explicit `/doc-drift-check [--fix]`)
+- Coverage of only this branch's changes, before pushing → invoke coverage-gate
+- A test failed and you suspect a flake → invoke flake-ledger
+- Move a game between worker size buckets → invoke rebucket-game
+- DRY/KISS/YAGNI 観点のソース解析を issue 化 → invoke make-issue; CUI 側だけなら invoke make-issue-cli, Web GUI 側だけなら invoke make-issue-web
 - Implement a single GitHub issue end-to-end ("issueに着手して", "#NNNN を対応して", "implement issue #N") → invoke improve-issue (explicit `/improve-issue <#>`)
 - Clear a whole batch of improvement issues, lowest-effort first ("issueバッチを片付けて", "#NNNN〜#MMMM を全部対応", "残りの改善issueを全部やって") → invoke improve-batch (explicit `/improve-batch <range>`)

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -40,7 +40,7 @@ Shared building blocks:
 
 **TDD cycle (Red-Green-Refactor):**
 
-1. **Red** -- Write a failing test (`bun run test -- --run TestName` confirms failure)
+1. **Red** -- Write a failing test (`bunx vitest run <file> -t "<test name>"` confirms failure; a bare argument filters by filename, not by test name)
 2. **Green** -- Write the minimum code to pass the test
 3. **Refactor** -- Clean up while keeping all tests green (`bun run test`)
 

--- a/internal/CLAUDE.md
+++ b/internal/CLAUDE.md
@@ -54,7 +54,7 @@ The `internal/infrastructure/games/` package provides DRY helpers for the per-ga
 |--------|-------|---------|
 | `BindWebControllerFor[I, P, O]` | `games/server_helper.go` | One-call HTTP-server registration. Used by `games_server.go` (server build only, build tag `!js \|\| !wasm`). |
 | `RegisterKVGame[I, P, O]` | `games/worker_helper.go` | One-call Cloudflare-Worker (KV-backed) registration. Used by per-category sub-packages (`casino/`, `classic/`, `solo/`, `extra/`, `extra2/`, `extra3/`) under build tag `js && wasm`. |
-| `webControllerPair[I, P, O]` | `adapter/controller/web_controller_pair.go` | Generates `NewXWebController` + `NewXWebControllerWithProvider` together. Called inside per-game `*WebController.go`. |
+| `webControllerPair[I, P, O]` | `adapter/controller/game_web_controller.go` | Generates `NewXWebController` + `NewXWebControllerWithProvider` together. Called inside per-game `*WebController.go`. |
 | `execCuiCommand` + `handleCuiLog` | `adapter/controller/cui_controller_helper.go` | Common CUI command parsing (`q`/`quit`/`r`/`reset` + suggestion-based unknown-command messages). Every `*CuiController.Exec` should delegate to it. |
 
 The build-tag split (`!js \|\| !wasm` for the server, `js && wasm` for workers) is what keeps each Cloudflare Worker binary under the 1 MB gzipped free-tier limit by letting TinyGo dead-code-eliminate the games from the other categories. See the package doc comment in `games/registry.go` for the full design rationale.


### PR DESCRIPTION
## 概要

CLAUDE.md 3 ファイル（root / `frontend/` / `internal/`）を監査した。**記述を読んで妥当そうか判断するのではなく、書かれているコマンドを実際に実行して検証**したところ、「常にこうしろ」の位置に**動かない指示が 2 件**あった。

## 動かなかった指示

### 1. `goimports -w ./...` が失敗する（`CLAUDE.md`）

```
$ goimports -w ./...
stat ./...: no such file or directory
```

`./...` は go ツールのパッケージパターンで、`goimports` はファイルパスしか受け取らない。しかもこれは Commands ブロックにあり、**自己レビューチェックリストが「コミット前に必ず実行」と指しているコマンド**そのもの。`goimports -w .` に修正し、実行できることを確認した。

### 2. `web_controller_pair.go` が存在しない（`internal/CLAUDE.md`）

`webControllerPair` の実体は `internal/adapter/controller/game_web_controller.go:60`。この行は

> Game registration helpers (**use these — don't hand-roll boilerplate**)

という表の中にある。つまり失敗の形は「エージェントが存在しないファイルを開き、結局この表が防ごうとしているボイラープレート手書きに戻る」。

## 導線の欠落

### 3. Skill routing が 12 個中 8 個を落としていた（`CLAUDE.md`）

とくに `new-game`。この skill 自身の description はこう書いている:

> Scaffold and wire a new card game across every backend, frontend, worker, doc, and count-assertion touchpoint. **Drives the full New Game Addition Checklist so no registration point or hardcoded count is missed.**

にもかかわらず CLAUDE.md の「New Game Addition Checklist」節は markdown doc を指すだけで、skill への導線が無かった。**#5170 で README の表が 30 ゲーム遅れていたのと同じ構図**（書いてあるが導線が無い手順は飛ばされる）。

追加したエントリ: `new-game` / `doc-drift-check` / `coverage-gate` / `flake-ledger` / `rebucket-game` / `make-issue` / `make-issue-cli` / `make-issue-web`

### 4. CI で落ちる範囲の記述が古い（`CLAUDE.md`）

ゲーム追加時に更新を飛ばすと落ちるものとして `registry_test.go` の件数アサートだけを挙げていたが、#5173 / #5174 以降は README のゲーム表・`docs/games.md`・`openapi.yaml` の `tags:` も registry と突き合わされる。

## 記述の不正確

### 5. vitest のテスト名フィルタ（`frontend/CLAUDE.md`）

`bun run test -- --run TestName` は**ファイル名**フィルタ。実測では対象ファイルの 10 件すべてが走った。テスト名で絞るのは `-t`（同条件で 10 件中 2 件）。壊れてはいないが、Red フェーズの説明として意図と違う。

## 検証したうえで「変更しなかった」もの

pre-commit ブロックが `typecheck` を挙げていない点を疑ったが、`"build": "bun run typecheck && vite build"` であり **build が先に typecheck を走らせている**。記述は正しいので、冗長な行を足さなかった。

その他、確認して問題が無かったもの: 参照されている doc パス 12 本すべて解決 / Go・Node・Bun・jq のバージョンが `go.mod`・`package.json`・CI と一致 / 「5 registration points」が正しい / レイヤ依存表がコードと一致 / `frontend/CLAUDE.md` のガード数 14 と `discover.json` の記述が最新。

## 監査スコア

| ファイル | 変更前 | 変更後 | 主因 |
|---|---|---|---|
| `frontend/CLAUDE.md` | 92 (A) | 92 (A) | もともと最新。`tsc` 5.9 vs 7 の節は実際に効く知識 |
| `CLAUDE.md` | 82 (B) | ~92 (A) | 動かないコマンドと古い routing が足を引っ張っていた |
| `internal/CLAUDE.md` | 78 (B) | ~86 (B) | 実在しないファイルへのポインタが主因 |

## Test plan

- [x] 修正後の `goimports` が実際に動くことを確認
- [x] `game_web_controller.go` の実在と `webControllerPair` の定義位置を確認
- [x] `.claude/skills/` の 12 skill すべてが routing に載っていることをスクリプトで確認
- [x] `frontend/scripts/check-markdown-tables.mjs` — OK (6511 rows / 905 tables)
- [x] push 後の remote 実体を検証
- [ ] CI

差分は +10 / −4。構成変更や一般論の追加はしていない。
