### PR TITLE
feat(claude): add guards for the failure modes that actually recurred

### DIFF
--- a/.claude/agents/e2e-locator-auditor.md
+++ b/.claude/agents/e2e-locator-auditor.md
@@ -1,0 +1,116 @@
+---
+name: e2e-locator-auditor
+description: Read-only auditor that catches Playwright specs whose card locator can grab a card the page has disabled. Correlates each page's validIndices/aria-disabled wiring against the locator its spec clicks, and reports the specs that will start failing intermittently the moment the page restricts a play. Use after wiring validIndices into a page, after adding or editing an e2e spec that clicks hand cards, and before pushing any change that narrows which cards are playable. MUST BE USED when a page starts passing validIndices.
+tools: Read, Grep, Glob, Bash
+model: sonnet
+---
+
+You are an E2E locator auditor for the go_trumpcards repo. You are **read-only**: never edit
+files, never commit. You report findings with exact file:line evidence.
+
+## The bug you exist to catch
+
+`PlayerHandSection` renders every card in the hand as a button. When a page passes
+`validIndices`, the cards outside that set get `aria-disabled="true"` — they stay in the DOM
+and stay focusable (deliberately, for a11y), they are just not playable.
+
+A spec that does this:
+
+```ts
+const handCards = page.locator('button[aria-pressed]:has(img)');
+await handCards.first().click();
+```
+
+clicks whatever card happens to be dealt first. While the page accepts every card, it passes.
+The moment the page restricts plays, `.first()` starts landing on a disabled card **whenever
+the deal puts an illegal card in slot 0** — so it fails at the deal-dependent rate, not every
+run. That reads exactly like a flake and gets re-run rather than fixed.
+
+**This has recurred four times.** It is the single most repeated failure class in this repo.
+Its worst property: the PR that wires `validIndices` passes its own CI (its spec may not hit
+the bad deal), and then *every later PR* inherits a percentage failure.
+
+The fix is in the spec, not the page:
+
+```ts
+const handCards = page.locator('button[aria-pressed]:has(img):not([aria-disabled="true"])');
+```
+
+## What makes a finding real
+
+A spec is only at risk when **both** halves are true. Report nothing on one half alone.
+
+1. **The page can disable cards.** It passes `validIndices` (or otherwise renders
+   `aria-disabled`) — check the page component and anything it delegates the hand to.
+2. **The spec's locator does not exclude disabled cards**, and it then indexes positionally
+   (`.first()`, `.nth(n)`, `.last()`) or clicks without filtering.
+
+A spec that never clicks hand cards is not at risk. A page with no `validIndices` is not at
+risk *today* — mention it only if the change under review is adding `validIndices`.
+
+## Do NOT flag these
+
+- **Specs that already carry `:not([aria-disabled="true"])`.** Reference implementations:
+  `e2e/cribbage.spec.ts`, `e2e/gongzhu.spec.ts`, `e2e/tressette.spec.ts`, `e2e/spades.spec.ts`.
+- **Locators scoped to a single known-legal card** (e.g. selecting by an explicit index the
+  test itself computed from the response).
+- **Non-card buttons** — `aria-pressed` also appears on toggles. Require the `:has(img)` shape
+  or an equivalent hand-scoped container before calling it a card locator.
+- **Assertions that only count or check visibility** and never click.
+
+## Scope
+
+Default to the diff: `git diff --name-only` (and `origin/develop...HEAD` when on a branch),
+restricted to `frontend/e2e/*.spec.ts` and `frontend/src/pages/*Page.tsx`. For a changed page,
+audit its matching spec even if the spec itself is unchanged — **that is the exact shape of
+this bug**, a page change breaking an untouched spec. If asked for a full sweep, do all specs.
+
+## Procedure
+
+Run all of these; do not stop at the first finding.
+
+1. Find pages that can disable cards:
+   ```bash
+   grep -rln "validIndices" frontend/src/pages/*.tsx
+   ```
+2. Find specs using a hand-card locator and whether they guard:
+   ```bash
+   grep -rn "button\[aria-pressed\]" frontend/e2e/*.spec.ts
+   grep -rln 'not(\[aria-disabled' frontend/e2e/*.spec.ts
+   ```
+3. Map spec ↔ page by name (`e2e/hearts.spec.ts` ↔ `src/pages/HeartsPage.tsx`); when the names
+   do not line up, read the spec's `page.goto(...)` route and resolve it through
+   `frontend/src/constants/gameRoutes.ts`.
+4. For each spec that clicks hand cards, read the click site and classify.
+
+## Baseline (measured when this agent was written — re-measure, do not trust it)
+
+24 specs click `.first()` on a hand-card locator. 20 of them do **not** carry the guard. That
+number is the trap: **the real finding count was zero**, because none of those 20 pages passes
+`validIndices` today, and a spec on a page that never disables a card is not at risk.
+
+The four specs whose page *does* restrict plays — `gongzhu`, `spades`, `tressette` (plus
+`cribbage`, guarded pre-emptively) — were **already guarded**, each one fixed reactively after
+it broke.
+
+Two things follow:
+
+- Reporting "20 unguarded specs" would have been 20 false positives. The two-halves rule is the
+  entire value of this agent; without it you produce a list nobody can act on.
+- This agent's value is mostly **prospective**. It earns its keep on the diff that adds
+  `validIndices` to a page — which is precisely the change that caused all four recurrences.
+  When a page gains `validIndices`, its spec must gain the guard **in the same commit**.
+
+## Report
+
+State PASS or FINDINGS. For each finding:
+
+- `frontend/e2e/<game>.spec.ts:<line>` — the locator, verbatim
+- The page and line proving it can disable cards
+- The one-line fix (add `:not([aria-disabled="true"])` to that locator)
+
+Rank by likelihood of firing: a spec clicking `.first()` on a page that restricts plays early
+in the game (bidding, follow-suit) is far more likely to break than one restricting only in a
+rare endgame phase. Say so, and say when you could not determine the risk rather than guessing.
+
+Close with the exact commands you ran, so the next reader can re-derive the numbers.

--- a/.claude/agents/shuffle-determinism-auditor.md
+++ b/.claude/agents/shuffle-determinism-auditor.md
@@ -1,0 +1,90 @@
+---
+name: shuffle-determinism-auditor
+description: Read-only auditor that finds Go tests whose result depends on the shuffle. Checks new or changed domain/usecase tests for fixtures built on top of Reset(), assertions on dealt cards, and message assertions that a deal-dependent branch can change, then reports the ones that will fail at a percentage rate. Use after writing tests for a card game, and before pushing a change that adds a branch to a message string or a hand evaluation. MUST BE USED when a change adds a new game or a new deal-dependent branch.
+tools: Read, Grep, Glob, Bash
+model: sonnet
+---
+
+You are a shuffle-determinism auditor for the go_trumpcards repo. You are **read-only**: never
+edit files, never commit. You report findings with exact file:line evidence.
+
+## The bug you exist to catch
+
+Every game here shuffles. A test that depends on what the shuffle produced does not fail — it
+fails *sometimes*, at a rate set by the deck. That rate is high enough to hit CI and low enough
+to look like infrastructure noise, so it gets re-run instead of fixed, and it lands on
+everyone's branch rather than the author's.
+
+Measured instances in this repo:
+
+- **A fixture stacked on top of `Reset()`.** `Reset()` shuffles. Adding cards afterwards fixes
+  the *hand* but leaves the **trump card and the discard-pile top still random**. Three tests
+  written this way failed at **18%, 11% and 9%**.
+- **A new branch behind a pinned message string.** A test asserting an exact message passes for
+  the author, then a deal-dependent branch added later changes that message on some deals — the
+  author's PR goes green and every subsequent PR inherits a **9%** failure.
+
+`internal/CLAUDE.md` documents the counter-techniques; this agent checks they were actually
+applied.
+
+## What makes a finding real
+
+Report a test only when a **specific** shuffle-dependent value can reach an assertion:
+
+1. **Fixture on top of `Reset()`** — the test calls `Reset()` (or a `NewDefaultX()` that
+   shuffles) and then `AddCard`s a hand, but the assertion also depends on trump, the
+   discard-pile top, the stock order, or dealer position, which the fixture never pinned.
+   Read the code under test to see which of those the assertion actually reaches.
+2. **Assertion on a dealt card** — comparing against a card the test did not place itself.
+3. **Exact-message assertion on a code path with a deal-dependent branch** — the assertion
+   pins one string while the implementation can produce another depending on the deal.
+4. **Assertion on ordering** after a shuffle-dependent sort tie.
+
+## Do NOT flag these
+
+- Tests that build the whole relevant state by hand with `AddCard` and never call
+  `Reset()`/`Shuffle()` afterwards.
+- Tests that pin randomness through the seam the code offers (an injected source, a fixed seed,
+  or a constructor that takes the deck) — check for that seam before flagging.
+- **Retry loops up to ~1000 iterations**: this repo deliberately uses them to cover both sides
+  of a random decision. That is the documented technique, not a defect.
+- Dealer/CPU scores set high specifically to suppress an automatic draw (e.g. BlackJack dealer
+  ≥ 17, Poker dealer ≥ Two Pair). That is the documented technique too.
+- `_test.go` helpers that are themselves deterministic.
+- Assertions on *invariants* that hold for every deal (hand size, total card count, sum of
+  scores). These are the correct way to test a shuffled game — never flag them.
+
+## Scope
+
+Default to the diff — `git diff --name-only` and `origin/develop...HEAD` — restricted to
+`internal/**/*_test.go`. Prefer the tests a change adds or edits. If asked for a sweep, take a
+named package rather than all of `internal/`, and say what you skipped.
+
+## Procedure
+
+1. List changed test files. For each, find the fixture setup:
+   ```bash
+   grep -n "Reset()\|NewDefault\|AddCard\|Shuffle" <file>
+   ```
+2. For any test that calls `Reset()`/`NewDefault*` **before** building its fixture, read the
+   production code it exercises and determine which shuffle-dependent fields the assertion
+   reaches. Name the field — "trump suit", "discard top" — not just "randomness".
+3. For exact-string assertions, read the message-producing function and list every branch that
+   can change the string, then decide whether the deal can select a different one.
+4. Where you can, quantify: if the failure needs a specific suit to be trump, that is ~25%; a
+   specific rank, ~1/13. An estimated rate makes the finding actionable and makes a wrong
+   estimate falsifiable.
+
+## Report
+
+State PASS or FINDINGS. For each finding:
+
+- `internal/<pkg>/<file>_test.go:<line>` — the assertion at risk
+- The shuffle-dependent value that reaches it, and the production line that proves it
+- An estimated failure rate, or an explicit "could not estimate"
+- The fix: pin the value through the existing seam, assert an invariant instead, or wrap in the
+  documented retry loop — say which and why
+
+If you cannot prove a specific value reaches the assertion, do not report it. A false positive
+here costs more than a miss: it teaches the reader that this whole class of warning is noise,
+and the real 9% failures are the ones that then get waved through.

--- a/.claude/hooks/git-restore-guard.sh
+++ b/.claude/hooks/git-restore-guard.sh
@@ -29,13 +29,25 @@ set -uo pipefail
 payload=$(cat)
 cmd=$(printf '%s' "$payload" | jq -r '.tool_input.command // ""')
 
+# Split a command fragment into arguments the way a shell would quote them, without
+# evaluating anything. Plain word splitting loses `"docs/my file.md"` to two bogus
+# tokens, neither of which matches a real path, so `git status` comes back clean for
+# both and the guard waves the command through -- failing OPEN, which is the one
+# way a guard must never fail. xargs honours quotes and backslashes and performs no
+# substitution, so nothing in the command string can execute here.
+split_args() {
+  printf '%s' "$1" | xargs -n1 2>/dev/null
+}
+
 # Collect the paths a restoring command would overwrite. Empty = not our business.
 paths=()
+parse_failed=0
 case "$cmd" in
   # `git checkout ... -- <paths>` (with or without a ref before the --)
   *git\ checkout\ *--\ *)
     after_sep=${cmd#*--\ }
-    read -r -a paths <<<"$after_sep"
+    mapfile -t paths < <(split_args "$after_sep")
+    [ -n "$after_sep" ] && [ ${#paths[@]} -eq 0 ] && parse_failed=1
     ;;
   # `git restore <paths>`, unless it only touches the index.
   *git\ restore\ *)
@@ -46,7 +58,9 @@ case "$cmd" in
         ;;
     esac
     rest=${cmd#*git restore }
-    for tok in $rest; do
+    mapfile -t tokens < <(split_args "$rest")
+    [ -n "$rest" ] && [ ${#tokens[@]} -eq 0 ] && parse_failed=1
+    for tok in "${tokens[@]}"; do
       case "$tok" in -*) continue ;; esac
       paths+=("$tok")
     done
@@ -55,6 +69,19 @@ case "$cmd" in
     echo '{}'; exit 0
     ;;
 esac
+
+# Unbalanced quotes and the like leave xargs with nothing. Refuse rather than guess:
+# this is a data-loss guard, so an unparseable restore is exactly the case where
+# waving it through is worst.
+if [ "$parse_failed" -eq 1 ]; then
+  jq -nc '{
+    continue: false,
+    stopReason: ("Blocked: could not parse the paths out of this restore command (unbalanced quotes?), " +
+                 "so it cannot be checked for uncommitted work. Refusing to guess -- rerun with simple " +
+                 "quoting, or use `git stash push -- <paths>` which is recoverable either way.")
+  }'
+  exit 0
+fi
 
 [ ${#paths[@]} -eq 0 ] && { echo '{}'; exit 0; }
 

--- a/.claude/hooks/git-restore-guard.sh
+++ b/.claude/hooks/git-restore-guard.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# PreToolUse(Bash) gate: refuse a `git checkout -- <path>` / `git restore <path>`
+# that would silently discard uncommitted work.
+#
+# The sibling rule in settings.json already blocks `git checkout <ref> -- .`,
+# because that form once wiped eleven files. It does not catch the single-path
+# form, and that form has destroyed work twice in one session:
+#
+#   1. Six mermaid label fixes in docs/manual/cui/skat.md, reverted by a
+#      `git checkout --` that was only meant to undo a deliberately broken
+#      test fixture in the same file.
+#   2. A `LetItRide() -> LetItRideAction()` doc fix, reverted the same way
+#      while running negative controls against the file it lived in.
+#
+# Both times the command did exactly what it was asked to and the loss was
+# silent -- `git checkout --` prints nothing on success, so the next green test
+# run looks like confirmation rather than like the fix having vanished.
+#
+# This is NOT a blanket block: discarding changes is a legitimate thing to want.
+# It fires only when a named path actually has uncommitted modifications, which
+# is precisely the case where the command is unrecoverable. `git stash push`
+# does the same job and keeps the work reachable.
+#
+# `git restore --staged <path>` only rewrites the index, so it is left alone.
+#
+# Reads the hook payload on stdin, writes a hook decision object on stdout.
+set -uo pipefail
+
+payload=$(cat)
+cmd=$(printf '%s' "$payload" | jq -r '.tool_input.command // ""')
+
+# Collect the paths a restoring command would overwrite. Empty = not our business.
+paths=()
+case "$cmd" in
+  # `git checkout ... -- <paths>` (with or without a ref before the --)
+  *git\ checkout\ *--\ *)
+    after_sep=${cmd#*--\ }
+    read -r -a paths <<<"$after_sep"
+    ;;
+  # `git restore <paths>`, unless it only touches the index.
+  *git\ restore\ *)
+    case "$cmd" in
+      *--staged*)
+        # --staged alone is index-only and safe; --staged --worktree is not.
+        case "$cmd" in *--worktree*) ;; *) echo '{}'; exit 0 ;; esac
+        ;;
+    esac
+    rest=${cmd#*git restore }
+    for tok in $rest; do
+      case "$tok" in -*) continue ;; esac
+      paths+=("$tok")
+    done
+    ;;
+  *)
+    echo '{}'; exit 0
+    ;;
+esac
+
+[ ${#paths[@]} -eq 0 ] && { echo '{}'; exit 0; }
+
+# A path is at risk when git reports a worktree modification for it. The second
+# column of --porcelain is the worktree status; ' ' there means the change is
+# staged only, which `git checkout --` would still overwrite, so treat any
+# non-clean entry as at risk.
+at_risk=""
+for p in "${paths[@]}"; do
+  status=$(git status --porcelain -- "$p" 2>/dev/null)
+  [ -n "$status" ] && at_risk+="${status}"$'\n'
+done
+
+if [ -z "$at_risk" ]; then
+  echo '{}'
+  exit 0
+fi
+
+jq -nc --arg files "$(printf '%s' "$at_risk" | sed '/^$/d')" '{
+  continue: false,
+  stopReason: ("Blocked: this would discard uncommitted changes with no way back. " +
+               "It prints nothing on success, so the loss is silent and the next green " +
+               "test run reads like confirmation.\n\nAt risk:\n" + $files +
+               "\n\nUse `git stash push -- <paths>` instead (recoverable via `git stash pop`), " +
+               "or commit first. If you are restoring a file you deliberately broke for a " +
+               "test, stash before breaking it rather than restoring after.")
+}'

--- a/.claude/hooks/git-restore-guard.test.sh
+++ b/.claude/hooks/git-restore-guard.test.sh
@@ -18,6 +18,7 @@ git config user.name test
 
 printf 'clean\n' > clean.txt
 printf 'dirty\n' > dirty.txt
+printf 'spaced\n' > 'has space.txt'
 printf 'staged\n' > staged.txt
 mkdir -p docs
 printf 'nested\n' > docs/nested.txt
@@ -28,6 +29,7 @@ git commit -qm init
 printf 'dirty edited\n' > dirty.txt
 printf 'staged edited\n' > staged.txt && git add staged.txt
 printf 'nested edited\n' > docs/nested.txt
+printf 'spaced edited\n' > 'has space.txt'
 
 fail=0
 # run <expect: block|pass> <description> <command>
@@ -62,6 +64,17 @@ run block 'a dirty path among clean ones'   'git checkout -- clean.txt dirty.txt
 
 # A staged-only change is still overwritten by `git checkout --`, so it counts.
 run block 'checkout -- <staged-only file>'  'git checkout -- staged.txt'
+
+# --- quoted paths -------------------------------------------------------
+# Plain word splitting turns "has space.txt" into two tokens that match nothing,
+# so git reports both clean and the guard fails OPEN on a genuinely dirty file.
+run block 'checkout -- "<dirty path with space>"'  'git checkout -- "has space.txt"'
+run block "checkout -- '<dirty path with space>'"  "git checkout -- 'has space.txt'"
+run block 'restore "<dirty path with space>"'      'git restore "has space.txt"'
+run block 'quoted dirty path alongside a clean one' 'git checkout -- clean.txt "has space.txt"'
+
+# Unparseable input must fail closed, not silently allow.
+run block 'unbalanced quote'                       'git checkout -- "has space.txt'
 
 # --- the same commands where nothing would be lost -----------------------
 run pass 'checkout -- <clean file>'         'git checkout -- clean.txt'

--- a/.claude/hooks/git-restore-guard.test.sh
+++ b/.claude/hooks/git-restore-guard.test.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Self-test for git-restore-guard.sh, run against a throwaway repo in a temp dir.
+#
+# Every case comes in a pair: one input that must be blocked and one that must
+# not. A guard tested only on the failing input passes just as happily when it
+# blocks everything, and this one blocks a command people legitimately use, so
+# the "must not fire" half is the half that keeps it installed.
+set -uo pipefail
+
+HOOK="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/git-restore-guard.sh"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+cd "$TMP" || exit 1
+git init -q .
+git config user.email t@example.com
+git config user.name test
+
+printf 'clean\n' > clean.txt
+printf 'dirty\n' > dirty.txt
+printf 'staged\n' > staged.txt
+mkdir -p docs
+printf 'nested\n' > docs/nested.txt
+git add -A >/dev/null
+git commit -qm init
+
+# dirty.txt has an unstaged edit; staged.txt has a staged one; docs/nested.txt dirty.
+printf 'dirty edited\n' > dirty.txt
+printf 'staged edited\n' > staged.txt && git add staged.txt
+printf 'nested edited\n' > docs/nested.txt
+
+fail=0
+# run <expect: block|pass> <description> <command>
+run() {
+  local expect=$1 desc=$2 cmd=$3 out
+  out=$(printf '{"tool_input":{"command":%s}}' "$(printf '%s' "$cmd" | jq -Rs .)" | bash "$HOOK")
+  local blocked=pass
+  printf '%s' "$out" | grep -q '"continue": *false' && blocked=block
+  if [ "$blocked" = "$expect" ]; then
+    printf '  ok    %s (%s)\n' "$desc" "$expect"
+  else
+    printf '  FAIL  %s: expected %s, got %s -- %s\n' "$desc" "$expect" "$blocked" "$out"
+    fail=1
+  fi
+}
+
+echo 'git-restore-guard:'
+
+# --- not our business ----------------------------------------------------
+run pass 'unrelated command'                'git status'
+run pass 'branch-switching checkout'        'git checkout -b feature/x'
+run pass 'plain checkout of a branch'       'git checkout develop'
+
+# --- the destructive forms, on files that would actually lose work --------
+run block 'checkout -- <dirty file>'        'git checkout -- dirty.txt'
+run block 'checkout -- <dirty nested file>' 'git checkout -- docs/nested.txt'
+run block 'checkout <ref> -- <dirty file>'  'git checkout HEAD -- dirty.txt'
+run block 'restore <dirty file>'            'git restore dirty.txt'
+run block 'checkout -- . with dirt present' 'git checkout -- .'
+run block 'restore --staged --worktree'     'git restore --staged --worktree dirty.txt'
+run block 'a dirty path among clean ones'   'git checkout -- clean.txt dirty.txt'
+
+# A staged-only change is still overwritten by `git checkout --`, so it counts.
+run block 'checkout -- <staged-only file>'  'git checkout -- staged.txt'
+
+# --- the same commands where nothing would be lost -----------------------
+run pass 'checkout -- <clean file>'         'git checkout -- clean.txt'
+run pass 'restore <clean file>'             'git restore clean.txt'
+run pass 'restore --staged only (index)'    'git restore --staged dirty.txt'
+run pass 'checkout -- <untracked path>'     'git checkout -- nosuchfile.txt'
+
+if [ "$fail" -ne 0 ]; then
+  echo 'git-restore-guard: FAILED'
+  exit 1
+fi
+echo 'git-restore-guard: all cases passed'

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,6 +15,12 @@
           },
           {
             "type": "command",
+            "command": "hook=.claude/hooks/git-restore-guard.sh; if [ -f \"$hook\" ]; then bash \"$hook\"; else echo \"{}\"; fi",
+            "timeout": 15,
+            "statusMessage": "Checking staged content for conflict markers..."
+          },
+          {
+            "type": "command",
             "command": "cmd=$(jq -r '.tool_input.command'); if printf '%s' \"$cmd\" | grep -qE '(^|[^[:alnum:]_-])git[[:space:]]+(add[[:space:]]+(-A|--all|\\.)([[:space:]/]|$)|checkout[[:space:]]+[^[:space:]]+[[:space:]]+--[[:space:]]+\\.([[:space:]]|$))'; then printf '%s' '{\"continue\": false, \"stopReason\": \"Blocked: do not use git add -A / git add . / git checkout <ref> -- . in this worktree. It has local-only files (node_modules, vendored .claude/skills, casino/classic/solo TinyGo build dirs, public/sounds) that must never be staged. Stage specific paths instead, e.g. git add path/to/file.\"}'; else echo '{}'; fi",
             "timeout": 5,
             "statusMessage": "Guarding against bulk git add..."

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,7 +17,7 @@
             "type": "command",
             "command": "hook=.claude/hooks/git-restore-guard.sh; if [ -f \"$hook\" ]; then bash \"$hook\"; else echo \"{}\"; fi",
             "timeout": 15,
-            "statusMessage": "Checking staged content for conflict markers..."
+            "statusMessage": "Checking for uncommitted changes a restore would discard..."
           },
           {
             "type": "command",

--- a/.claude/skills/land-pr/SKILL.md
+++ b/.claude/skills/land-pr/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: land-pr
+description: Verify the merge gate for a PR (head-SHA match, zero pending, zero failing, check-count floor, reviews read) and then squash-merge it. Use when a PR looks ready ("マージして", "land it", "merge #NNNN", "ready to merge?"). Refuses to merge when any condition fails.
+disable-model-invocation: true
+allowed-tools: Read, Grep, Glob, Bash
+argument-hint: "<pr-number>"
+---
+
+# Land PR
+
+Merging looks like one command. It is not, and the two ways it goes wrong both merged real PRs
+early.
+
+## Why this exists
+
+**A watcher that waits for "no pending checks" lies right after a push.** The new run's checks
+are not registered yet, so `gh pr checks` reports the *previous* commit's green result and the
+loop exits immediately. Acting on that merged #4345 with 12 checks still pending. Pinning the
+watcher to the CI *workflow* was not enough either — `gh pr checks` aggregates several workflows
+(CodeQL, deploy jobs, codecov), so watching only `name=="CI"` reported success while
+`Analyze (go, autobuild)` was still running, and #4347 merged early a second time.
+
+The gate that actually holds needs **both** halves, every time:
+
+```sh
+[ "$(gh pr view N --json headRefOid --jq .headRefOid)" = "$(git rev-parse HEAD)" ]   # no newer push
+[ "$(gh pr checks N --json bucket --jq '[.[]|select(.bucket=="pending")]|length')" = 0 ]
+```
+
+The head-match alone passes while checks are queued. The pending check alone passes against a
+stale commit.
+
+**Auto-review does not re-run on push.** A green tick after a fix-up commit means CI re-ran; it
+does not mean anyone reviewed the fix-up. Read the review before merging, and know which commit
+it was written against.
+
+## Procedure
+
+1. **Run the gate.** It decides nothing and merges nothing — it prints conditions.
+
+   ```sh
+   bash .claude/skills/land-pr/scripts/merge-gate.sh <pr-number>
+   ```
+
+   Pass the expected SHA explicitly if you are not on the PR branch:
+   `merge-gate.sh <pr> <sha>`.
+
+2. **Read every review.** The script lists bot comments and inline threads but cannot judge
+   them. Open them:
+
+   ```sh
+   gh pr view <pr> --json comments --jq '.comments[].body'
+   gh api repos/{owner}/{repo}/pulls/<pr>/comments --jq '.[]|"\(.path):\(.line)\n\(.body)\n---"'
+   ```
+
+   An inline comment whose `line` is `null` is **outdated** — the code it pointed at changed.
+   That usually means it was addressed, but confirm rather than assume.
+
+3. **If the gate is BLOCKED**, stop. Do not merge. Fix, push, and re-run the gate against the
+   new SHA. A fix-up push invalidates the previous review, so say so when reporting.
+
+4. **Merge** — squash is this repo's convention (`develop` history is one commit per PR):
+
+   ```sh
+   gh pr merge <pr> --squash --delete-branch
+   ```
+
+5. **Verify it landed and sync**:
+
+   ```sh
+   gh pr view <pr> --json state,mergedAt
+   git checkout develop && git pull --ff-only
+   ```
+
+   If the PR closed an issue, confirm the issue actually closed — `Closes #N` only fires when
+   the PR merges into the default branch.
+
+## Do not
+
+- **Do not merge on a green tick alone.** That is the failure this skill exists to prevent.
+- **Do not lower the check-count floor** to make the gate pass. An empty check array satisfies
+  every "all green" test ever written; the floor is what distinguishes "all passed" from "none
+  ran".
+- **Do not rebase-force-push** to tidy history without asking. Squash-merge already collapses
+  fix-up commits into one, so the usual reason to force-push does not apply here.

--- a/.claude/skills/land-pr/scripts/merge-gate.sh
+++ b/.claude/skills/land-pr/scripts/merge-gate.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Report whether a PR is safe to merge. Exits 0 only when every condition holds.
+#
+# Usage: merge-gate.sh <pr-number> [expected-head-sha]
+#
+# Prints a line per condition and a verdict. Never merges anything -- deciding and
+# doing are separated on purpose, so the decision can be read before it is acted on.
+set -uo pipefail
+
+pr=${1:?usage: merge-gate.sh <pr-number> [expected-head-sha]}
+expected=${2:-$(git rev-parse HEAD 2>/dev/null)}
+
+fail=0
+say() { printf '  %-6s %s\n' "$1" "$2"; }
+
+echo "merge gate: PR #$pr"
+
+# 1. The PR head must be the commit whose checks we are about to read. Without this,
+#    a `gh pr checks` run moments after a push reports the PREVIOUS commit's green
+#    result -- the new run has not registered yet. That exact hole merged two PRs
+#    early (#4345, #4347).
+head=$(gh pr view "$pr" --json headRefOid --jq .headRefOid 2>/dev/null)
+if [ -z "$head" ]; then
+  say FAIL "cannot read PR #$pr (gh auth? wrong number?)"
+  exit 1
+fi
+if [ "$head" = "$expected" ]; then
+  say ok "head matches the commit under test ($head)"
+else
+  say FAIL "PR head $head != expected $expected -- a newer push exists, or you are on the wrong commit"
+  fail=1
+fi
+
+# 2. Zero pending. Checked separately from "no failures": a stale-commit read can
+#    show zero pending while the real run has not started.
+pending=$(gh pr checks "$pr" --json bucket --jq '[.[]|select(.bucket=="pending")]|length' 2>/dev/null || echo unknown)
+total=$(gh pr checks "$pr" --json bucket --jq 'length' 2>/dev/null || echo 0)
+if [ "$pending" = "0" ]; then
+  say ok "no pending checks ($total total)"
+else
+  say FAIL "$pending check(s) still pending"
+  fail=1
+fi
+
+# 3. Zero failures.
+failing=$(gh pr checks "$pr" --json bucket,name --jq '[.[]|select(.bucket=="fail")|.name]|join(", ")' 2>/dev/null)
+if [ -z "$failing" ]; then
+  say ok "no failing checks"
+else
+  say FAIL "failing: $failing"
+  fail=1
+fi
+
+# 4. Sanity floor on the number of checks. An empty array satisfies every "all
+#    green" test ever written, so assert the run actually reported something.
+#    Deliberately low: the count varies (mention-review does not always register).
+if [ "$total" -ge 10 ] 2>/dev/null; then
+  say ok "check count above floor ($total >= 10)"
+else
+  say FAIL "only $total checks reported -- the run has not registered yet, or gh returned nothing"
+  fail=1
+fi
+
+# 5. Review comments must be READ, not counted. Auto-review does not re-run on
+#    push, so a green tick after a fix-up commit does not mean the fix-up was
+#    reviewed. This cannot be automated; surface it and make the human look.
+reviews=$(gh pr view "$pr" --json comments --jq '[.comments[]|select(.author.login=="github-actions")]|length' 2>/dev/null || echo 0)
+say note "$reviews bot comment(s) -- READ them; auto-review does NOT re-run on push,"
+say note "  so a fix-up pushed after the review has not been reviewed at all"
+gh api "repos/{owner}/{repo}/pulls/$pr/comments" --jq '.[]|"  inline: \(.path):\(.line // "outdated") \(.user.login)"' 2>/dev/null | head -20
+
+if [ "$fail" -ne 0 ]; then
+  echo "VERDICT: BLOCKED"
+  exit 1
+fi
+echo "VERDICT: gate passed -- merge only after reading the reviews above"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,6 +206,7 @@ Key routing rules:
 - Per-game improvement proposals → GitHub issues ("各ゲームの改善提案", "全ゲームのissueを作って") → invoke game-improve
 - New-game candidates → GitHub issues ("追加した方が良いゲームを提案", "新規ゲーム候補をissueに") → invoke propose-games
 - Add a new game end-to-end ("ゲームを追加", "add a new game", "implement <game>") → invoke new-game (explicit `/new-game <name> <category>`) — it drives the New Game Addition Checklist so no registration point or hardcoded count is missed
+- Merge a PR ("マージして", "land it", "merge #NNNN") → invoke land-pr (explicit `/land-pr <#>`) — a green tick alone is not the gate; it also checks the head SHA still matches and that the checks actually ran
 - Docs out of sync with the code ("ドキュメントの乖離", "docs are stale") → invoke doc-drift-check (explicit `/doc-drift-check [--fix]`)
 - Coverage of only this branch's changes, before pushing → invoke coverage-gate
 - A test failed and you suspect a flake → invoke flake-ledger


### PR DESCRIPTION
## 概要

Claude Code 自動化の棚卸しをして、**既存設定に無い穴だけ**を埋めた。既存は 12 skills / 4 agents / PreToolUse 7 gate / PostToolUse フォーマッタ / MCP 2 本と既に充実しているので、format-on-save、lint gate、typecheck gate、conflict-marker gate、context7、Playwright、code-reviewer などは**すべて対象外**（既にある）。

根拠は一般論ではなく、**実際に繰り返し起きた失敗**に限定した。

## 1. hook: `git-restore-guard.sh`

`git checkout -- <path>` / `git restore <path>` が未コミットの変更を黙って消すのを、**消える変更が実在するときだけ**ブロックする。

既存の settings.json は `git checkout <ref> -- .` を止めるが、単一パス形は素通りだった。実際に検証:

```
BLOCKED : git checkout main -- .
allowed : git checkout -- docs/design/backend.md    ← 未コミット作業が消える
allowed : git restore docs/x.md                      ← 同上
```

**このセッションだけで 2 回作業を消している** —— `skat.md` の mermaid 修正 6 箇所と、`LetItRide` の doc 修正。どちらも成功時に何も出力しないため損失が無音で、次に緑になったテストが確認に見えるのが厄介だった。

全ブロックはしない（意図的な破棄は正当な操作）。対象パスに未コミット変更があるときだけ発火し、`git stash push` を案内する。`git restore --staged` は index のみなので対象外。

自己テスト **15 ケース**、両方向を網羅（`commit-sanity.test.sh` の先例に合わせた）。

## 2. agent: `e2e-locator-auditor`

`validIndices` を配線するとページが札を無効化し、spec の `.first().click()` が無効札を掴む——**記録上 4 回再発**している最頻出の失敗。自分の PR は通り、以降の全 PR が配り依存の率で落ちる。

**2 条件が揃ったときだけ報告する設計にしたのが要点。** 実測するとこうなった:

| | |
|---|---|
| `.first()` を叩く spec | 24 |
| うち未ガード | 20 |
| **そのページが `validIndices` を使っている** | **0** |
| → **現時点の真の指摘** | **0 件** |

`validIndices` を持つ 4 本（gongzhu / spades / tressette / cribbage）は**すでにガード済み**だった（過去に踏んで個別に直された跡）。

つまり「未ガード 20 本」と報告していたら **20 件全部が誤検出**になる。この agent の価値は主に予防的で、`validIndices` を足す diff で効く。この測定結果は agent 本体にも baseline として書き込んである。

## 3. agent: `shuffle-determinism-auditor`

`Reset()` の上に積んだ fixture は切り札／捨て札トップが乱数のまま残り、**実測 18% / 11% / 9%** で落ちた。固定文言アサートに配り依存の分岐が足されて 9% 落ちた例（#4817 → #5076）もある。

到達する乱数値を**具体的に特定できた場合のみ**報告し、リトライループや高スコアによる自動ドロー抑止など `internal/CLAUDE.md` が定める既定手法は誤検出しないよう明記した。

## 4. skill: `land-pr` + `scripts/merge-gate.sh`

マージ gate を毎回手で組み直していた（このセッションだけで 4 回）。素朴な `gh pr checks` 監視は **push 直後に前のコミットの緑を返す**ため、過去 2 回（#4345, #4347）早期マージしている。

head SHA 一致 + pending 0 + fail 0 + **チェック数の下限**を検査する。下限が要るのは、空配列があらゆる「全部緑」判定を満たしてしまうため。レビュー本文は「読め」と促す（auto-review は push で再実行されないので、fix-up は未レビューのまま緑になる——本セッションで 2 回該当した）。

判定と実行を分離してあり、スクリプト自体はマージしない。CLAUDE.md の routing にも追加した（**導線の無い skill は飛ばされる**、が直前の #5175 の教訓）。

3 経路すべて実行確認済み: gate 通過 / SHA 不一致でブロック / 存在しない PR でエラー。

## 採用しなかったもの: `go test` の commit gate

当初は「frontend は 2 gate、Go は lint だけ」という非対称を埋める案だったが、**計測して取り下げた**。

- `internal/domain` は uncached **43 秒**。最も編集頻度の高いパッケージで、毎コミット課金される。
- frontend も**テストは gate していない**（`check` と `typecheck` のみ）。非対称なのは静的検査ではなく、**両者とも test は CI 任せ**というのが実態だった。
- `golangci-lint` は `build-tags: test` + `default: standard` でテストファイルもコンパイルするため、これが `bun run typecheck` の対等物。

つまり当初の「非対称」という前提自体が誤りだった。

## Test plan

- [x] `.claude/hooks/git-restore-guard.test.sh` — 15 ケース全通過（block 8 / pass 7）
- [x] 実リポジトリに対する live 確認（dirty な settings.json をブロック、clean な README.md は素通り）
- [x] `commit-sanity.test.sh` — 既存も回帰なし
- [x] `merge-gate.sh` を実 PR (#5175) に対して 3 経路実行
- [x] agent frontmatter のパース確認
- [x] `.claude/settings.json` が valid JSON、PreToolUse hook 8 本
- [x] 全 13 skill が routing に載っていることを確認
- [x] `check-markdown-tables.mjs` OK
- [ ] CI

## 注意

hook と agent は**セッション開始時にスナップショットされる**ため、この PR の内容は次のセッションから有効になる。今回は hook をスクリプト直叩きで検証した（agent は今セッションでは呼び出せないことを確認済み）。
