### PR TITLE
fix(doubt): measure bluff intent, not incidental value mismatch

### DIFF
--- a/internal/domain/Doubt_test.go
+++ b/internal/domain/Doubt_test.go
@@ -932,10 +932,47 @@ func TestDoubt_MetaAI_CpuUsesAdjustedDoubtChance(t *testing.T) {
 	})
 }
 
+// doubtUniformHandValue is the rank every card in the CPU's hand gets in the
+// meta-AI bluff test. Any rank works; it only has to be a single one.
+const doubtUniformHandValue = 7
+
+// setUniformDoubtHand replaces a player's whole hand with n cards of one rank.
+//
+// This is what makes the meta-AI bluff test measure what it claims to. The meta
+// profile scales `intentBluff` (Doubt.go: AdjustedBluffChance), but the recorded
+// `IsBluff` is `isActuallyBluff` -- "did the declared value differ from the cards
+// played" -- and those two come apart on the honest path: an honest CPU playing
+// several cards declares only played[0]'s rank while dumping the rest of the
+// front of its hand, so with a mixed hand it is recorded as bluffing even though
+// it never intended to. With 26 cards of mixed ranks that path swallowed ~96% of
+// plays, both arms measured ~94.9%, and the strict `assert.Less` came down to
+// binomial noise -- it tied at 18980 vs 18980 in CI (issue #5177).
+//
+// A single-rank hand collapses the difference: every honest play (plain or the
+// mixed-bluff branch, which falls back to the first n cards when it cannot find a
+// non-matching one) declares that rank and plays only that rank, so it is not a
+// bluff; an intentional bluff declares a random rank and mismatches 12/13 of the
+// time. `IsBluff` then tracks intent, which is the thing under test.
+func setUniformDoubtHand(p *domain.DoubtPlayer, value, n int) {
+	if size := p.GetCardsSize(); size > 0 {
+		indices := make([]int, size)
+		for i := range indices {
+			indices[i] = i
+		}
+		p.RemoveCards(indices)
+	}
+	for i := 0; i < n; i++ {
+		p.AddCard(domain.NewCard(domain.CardDesignSpade, value, false))
+	}
+}
+
 func TestDoubt_MetaAI_CpuUsesAdjustedBluffChance(t *testing.T) {
 	// When human has high doubt accuracy, CPU should bluff less
 	t.Run("CPU bluffs less when human has high doubt accuracy", func(t *testing.T) {
 		trials := 20000
+		// Large enough that most plays leave >1 card behind, so calcBluffChance
+		// uses the normal base rather than its last-card special case.
+		const handSize = 26
 
 		// Count bluffs WITHOUT meta-AI
 		baselineBluffs := 0
@@ -943,9 +980,7 @@ func TestDoubt_MetaAI_CpuUsesAdjustedBluffChance(t *testing.T) {
 			game, players := makeDoubtGame()
 			game.SetConfig(domain.DoubtConfig{DoubtWindowSec: 10, CpuMetaAI: false})
 			advanceToCpuTurn(game)
-			for v := 1; v <= 13; v++ {
-				players[1].AddCard(domain.NewCard(domain.CardDesignSpade, v, false))
-			}
+			setUniformDoubtHand(players[1], doubtUniformHandValue, handSize)
 			game.CpuPlay()
 			cpuActions := game.GetCpuActions()
 			if len(cpuActions) > 0 && cpuActions[0].IsBluff {
@@ -958,13 +993,12 @@ func TestDoubt_MetaAI_CpuUsesAdjustedBluffChance(t *testing.T) {
 		for i := 0; i < trials; i++ {
 			game, players := makeDoubtGame()
 			game.SetConfig(domain.DoubtConfig{DoubtWindowSec: 10, CpuMetaAI: true})
-			// High doubt accuracy: 95%, max adapt
+			// High doubt accuracy: 95%, max adapt (AdaptStrength caps at 0.2, so
+			// the adjustment is base x (1 - 0.95*0.2) = base x 0.81).
 			profile := &domain.DoubtHumanProfile{GamesPlayed: 5, DoubtCorrect: 19, DoubtTotal: 20}
 			game.SetHumanProfile(profile)
 			advanceToCpuTurn(game)
-			for v := 1; v <= 13; v++ {
-				players[1].AddCard(domain.NewCard(domain.CardDesignSpade, v, false))
-			}
+			setUniformDoubtHand(players[1], doubtUniformHandValue, handSize)
 			game.CpuPlay()
 			cpuActions := game.GetCpuActions()
 			if len(cpuActions) > 0 && cpuActions[0].IsBluff {
@@ -972,7 +1006,15 @@ func TestDoubt_MetaAI_CpuUsesAdjustedBluffChance(t *testing.T) {
 			}
 		}
 
-		// Meta-AI with high doubt accuracy should produce fewer bluffs than baseline
+		// Both arms must actually bluff sometimes, otherwise "meta < baseline"
+		// could be satisfied by a code path that stopped bluffing entirely.
+		assert.Positive(t, metaBluffs, "meta arm recorded no bluffs at all -- the measurement is broken, not the AI")
+		assert.Positive(t, baselineBluffs, "baseline arm recorded no bluffs at all -- the measurement is broken, not the AI")
+
+		// Meta-AI with high doubt accuracy should produce fewer bluffs than baseline.
+		// The expected gap is ~19% of the baseline (AdjustedBluffChance x 0.81) against
+		// a binomial sigma of ~90 at these counts, so this is a many-sigma margin
+		// rather than the coin-flip it used to be.
 		assert.Less(t, metaBluffs, baselineBluffs,
 			"meta-AI with high doubt accuracy should cause CPU to bluff less (meta=%d, baseline=%d)", metaBluffs, baselineBluffs)
 	})

--- a/internal/domain/Doubt_test.go
+++ b/internal/domain/Doubt_test.go
@@ -970,8 +970,10 @@ func TestDoubt_MetaAI_CpuUsesAdjustedBluffChance(t *testing.T) {
 	// When human has high doubt accuracy, CPU should bluff less
 	t.Run("CPU bluffs less when human has high doubt accuracy", func(t *testing.T) {
 		trials := 20000
-		// Large enough that most plays leave >1 card behind, so calcBluffChance
-		// uses the normal base rather than its last-card special case.
+		// numCards is Uniform{1..handSize}, and calcBluffChance falls back to its
+		// last-card special case when handSize-numCards <= 1 -- that is numCards
+		// 25 or 26, so 2/26 (~7.7%) of plays. The other ~92% exercise the normal
+		// base, which is the path the meta-AI adjustment matters on.
 		const handSize = 26
 
 		// Count bluffs WITHOUT meta-AI


### PR DESCRIPTION
## 概要

`TestDoubt_MetaAI_CpuUsesAdjustedBluffChance` が概ね 10% で落ちていた件。**統計的マージンが薄いのではなく、アサート対象を取り違えていた。**

診断の詳細は #5177。

## 原因

メタAIが動かすのは `intentBluff`（`Doubt.go:295-299`）。一方テストが数える `IsBluff` は `isActuallyBluff` = 「宣言値と実際に出した札が食い違うか」（同 324-344）。

この 2 つは**正直プレイで乖離する**。正直な CPU が複数枚出すとき、宣言するのは `played[0]` のランクだけで手札先頭の残りをそのまま捨てるため、テストが 1〜13 の全ランクを積んでいた以上、正直に出してもほぼ必ずブラフとして記録される。

`numCards` は 1〜26 の一様分布なので、intent が測定値に効くのは `numCards == 1` の約 3.8% のみ。残り 96% は両群とも構造的にブラフ計上され、`assert.Less` はほぼ同一の二項サンプルへの厳密比較になっていた。CI では 18980 対 18980 の**同点**で落ちた。

## 修正

CPU の手札を単一ランクに揃える（`setUniformDoubtHand`）。すると:

- **正直プレイ**は宣言値と出す札が一致 → ブラフでない
  （通常経路も、非一致札が無く先頭 N 枚にフォールバックする `selectMixedCards` 経路も）
- **意図的ブラフ**は宣言値がランダムなので 12/13 で不一致 → ブラフ

これで `IsBluff` が intent を追う。手札は 26 枚のままなので `calcBluffChance` の通常分岐（last-card 特例ではない方）も従来どおり通る。

## 実測

**修正前**: 両群とも 18980/20000 = 94.9%、差は二項ノイズ。期待差 ≈ 54 に対し σ ≈ 44 で **約 1.2σ**（失敗率 10〜12%）。

**修正後**（5 回）:

| meta | baseline | diff |
|---|---|---|
| 4708 | 5744 | 1036 |
| 4683 | 5732 | 1049 |
| 4566 | 5786 | 1220 |
| 4548 | 5723 | 1175 |
| 4594 | 5697 | 1103 |

平均差 ≈ **1117**、σ_diff ≈ **88** → **約 12.7σ**。

さらに比 `4594/5697 ≈ 0.806` が `AdjustedBluffChance` の係数 `1 − 0.95×0.2 = 0.81` とほぼ一致する。測りたい量をそのまま測れている裏付け。

## 検証

- **負のコントロール**: `AdjustedBluffChance` の適用を外すとテストは落ちる（`meta=5897 baseline=5817`）。**効果が無いと通らない**ことを確認済み——壊れていても通るテストになっていない。
- 反復 **25/25** 通過、フルパッケージ通過（RNG の消費列が単体実行と異なるため両方確認）
- `golangci-lint run ./internal/domain/` → 0 issues
- 両群が 0 件でないことの `assert.Positive` を追加。ブラフが完全に止まる実装でも `meta < baseline` は成立してしまうため。

## ついでに確認したが変更不要だったもの

姉妹テスト `TestDoubt_MetaAI_CpuUsesAdjustedDoubtChance` も同じ型の欠陥が無いか調べた。こちらは `len(game.GetCpuDoubters())` を直接数えており**測定対象の取り違えは無い**。マージンも実測して健全だった（meta ≈ 5444 / baseline ≈ 4500、差 ≈ 944 に対し σ ≈ 84 で約 11σ）。変更していない。

## Test plan

- [x] 負のコントロール（効果を外すと落ちる）
- [x] 反復 25/25
- [x] フルパッケージ `go test -tags test ./internal/domain`
- [x] `golangci-lint` 0 issues / `gofmt` clean
- [x] マージン実測 12.7σ
- [x] 姉妹テストのマージンも実測（11σ、変更不要）
- [ ] CI

Closes #5177
