### PR TITLE
fix(cli): accept --help/-h on the help subcommand

### DIFF
--- a/cmd/trumpcards/main.go
+++ b/cmd/trumpcards/main.go
@@ -718,6 +718,22 @@ func splitHelpLines(text string) []string {
 // positional arguments after the game name are warned about and ignored,
 // matching the behavior of other subcommands.
 func runHelpCommand(args []string, helpText string, stdout, stderr io.Writer) int {
+	// `help --help` / `help -h`: the other five subcommands get this from
+	// parseSubFlagsTo's flag.ErrHelp branch, but `help` never builds a FlagSet
+	// (its argument is a name, not a flag), so the flag would otherwise be
+	// looked up as a game and rejected with "unknown game". Answer with the
+	// same text `help help` already produced. Only args[0] is inspected: Go's
+	// flag package stops parsing at the first non-flag argument, so a trailing
+	// `--help` after a positional stays an extra arg here exactly as it does
+	// for `games extra --help`. See issue #5181.
+	if len(args) > 0 && hasHelpFlag(args[:1]) {
+		if lines, ok := subcommandHelp("help"); ok {
+			for _, line := range lines {
+				_, _ = fmt.Fprintln(stdout, line)
+			}
+		}
+		return 0
+	}
 	if len(args) > 1 {
 		_, _ = fmt.Fprintln(stderr, i18n.Tf("cliExtraArgsWarning", "args", strings.Join(args[1:], " ")))
 	}

--- a/cmd/trumpcards/main_test.go
+++ b/cmd/trumpcards/main_test.go
@@ -121,6 +121,79 @@ func TestRunHelpCommandExtraArgs(t *testing.T) {
 	}
 }
 
+// `trumpcards help --help` must print the help subcommand's own help, not an
+// "unknown game" error. Every other subcommand gets this from parseSubFlagsTo's
+// flag.ErrHelp branch; `help` never reaches a FlagSet, so runHelpCommand has to
+// recognise the flag itself. All four spellings Go's flag package treats as
+// equivalent are covered. See issue #5181.
+func TestRunHelpCommandHelpFlag(t *testing.T) {
+	want, ok := subcommandHelp("help")
+	if !ok {
+		t.Fatal("subcommandHelp(\"help\") missing; the help subcommand must have help text")
+	}
+	wantOut := strings.Join(want, "\n") + "\n"
+
+	for _, args := range [][]string{
+		{"--help"},
+		{"-h"},
+		{"-help"},
+		{"--h"},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			code := runHelpCommand(args, buildHelpText(), &stdout, &stderr)
+			if code != 0 {
+				t.Fatalf("runHelpCommand(%v) exit = %d, want 0", args, code)
+			}
+			if stderr.Len() != 0 {
+				t.Errorf("runHelpCommand(%v) stderr = %q, want empty", args, stderr.String())
+			}
+			if got := stdout.String(); got != wantOut {
+				t.Errorf("runHelpCommand(%v) stdout = %q, want %q", args, got, wantOut)
+			}
+		})
+	}
+}
+
+// Negative control for TestRunHelpCommandHelpFlag: a help flag AFTER a
+// positional is not a help request. Go's flag package stops parsing at the
+// first non-flag argument, so `trumpcards games extra --help` prints the game
+// list with an extra-args warning rather than the games help. `help` must
+// behave the same way, otherwise the help subcommand becomes the one place
+// where a trailing --help means something different. See issue #5181.
+func TestRunHelpCommandHelpFlagAfterPositionalIsExtraArg(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := runHelpCommand([]string{"blackjack", "--help"}, buildHelpText(), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("runHelpCommand(blackjack --help) exit = %d, want 0", code)
+	}
+	if !strings.Contains(stderr.String(), "--help") {
+		t.Errorf("expected an extra-args warning naming --help; got stderr %q", stderr.String())
+	}
+	// Blackjack's help, NOT the help subcommand's help.
+	if strings.Contains(stdout.String(), "trumpcards help [game|command]") {
+		t.Errorf("expected blackjack help, got the help subcommand's own help: %q", stdout.String())
+	}
+	if stdout.Len() == 0 {
+		t.Error("expected blackjack help on stdout")
+	}
+}
+
+// The two entry points to the help subcommand's own help must converge:
+// `help help` already worked before #5181, `help --help` did not.
+func TestRunHelpCommandHelpFlagMatchesHelpHelp(t *testing.T) {
+	var flagOut, wordOut, stderr bytes.Buffer
+	if code := runHelpCommand([]string{"--help"}, buildHelpText(), &flagOut, &stderr); code != 0 {
+		t.Fatalf("runHelpCommand(--help) exit = %d, want 0", code)
+	}
+	if code := runHelpCommand([]string{"help"}, buildHelpText(), &wordOut, &stderr); code != 0 {
+		t.Fatalf("runHelpCommand(help) exit = %d, want 0", code)
+	}
+	if flagOut.String() != wordOut.String() {
+		t.Errorf("`help --help` and `help help` diverged:\n--help: %q\nhelp:   %q", flagOut.String(), wordOut.String())
+	}
+}
+
 func TestRunHelpCommandUnknownGame(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	helpText := buildHelpText()


### PR DESCRIPTION
## 概要

`trumpcards help --help` だけが `Unknown game: "--help"` + exit 2 を返していた問題を修正します。他の5サブコマンド（`web` / `update` / `completion` / `games` / `version`）は `parseSubFlagsTo` の `flag.ErrHelp` 分岐でヘルプを出しますが、`help` は引数がフラグではなく名前のため FlagSet を作らず、未知ゲーム経路に落ちていました。

`help -h` に至っては Did-you-mean が `"ch"`（ゲームのエイリアス）を提案しており、ヘルプを求めた利用者を無関係なゲームへ誘導していました。

修正は `help help` が既に出していたテキストへ落とすもので、2つの入口が同じ結果に収束します。

## issue の提案からの変更点

issue #5181 では `hasHelpFlag(args)` を**全引数**に対して掛ける案を書きましたが、実装前に既存サブコマンドの挙動を実測したところ、これは**不整合を生む**ことが判明したため `args[0]` のみに変更しました。

\`\`\`console
$ trumpcards --lang en games extra --help
Warning: extra arguments ignored: extra --help
CASINO (55):
  ...
\`\`\`

Go の `flag` パッケージは最初の非フラグ引数で解析を止めるため、位置引数の後ろの `--help` はヘルプ要求として扱われません。`help blackjack --help` だけを別扱いにすると、`help` が「後置 `--help` の意味が違う唯一のサブコマンド」になってしまいます。この挙動は負のコントロールテストで固定しました。

## 変更内容

- `cmd/trumpcards/main.go`: `runHelpCommand` の先頭で `hasHelpFlag(args[:1])` を判定し、`subcommandHelp("help")` を出力して exit 0。既存ヘルパの再利用のみで、新規関数・新規 locale キーはありません。
- `cmd/trumpcards/main_test.go`: テスト3本を追加。

## テスト計画

- [x] `TestRunHelpCommandHelpFlag` — `--help` / `-h` / `-help` / `--h` の4綴りで exit 0 かつ stdout が `subcommandHelp("help")` と完全一致
- [x] `TestRunHelpCommandHelpFlagAfterPositionalIsExtraArg` — **負のコントロール**。`help blackjack --help` は blackjack のヘルプ + extra-args 警告のまま（「全引数を見る」実装に戻すと落ちる）
- [x] `TestRunHelpCommandHelpFlagMatchesHelpHelp` — `help --help` と `help help` の出力一致
- [x] 既存の `TestRunHelpCommandUnknownGame`（exit 2 + Did-you-mean）が通ることを確認済み — 「全部 exit 0」にする雑な修正では落ちる
- [x] `go test -tags test ./cmd/...` 通過
- [x] `golangci-lint run ./cmd/...` → 0 issues
- [x] `goimports -w` 実行済み
- [x] ビルド済みバイナリで6経路を実測（`help --help` / `-h` / `help help` / `help web` / `help blackjack --help` / `help <unknown>`）

Closes #5181