### PR TITLE
fix(cli): replace the flag-error help dump with a one-line hint

### DIFF
--- a/cmd/trumpcards/main.go
+++ b/cmd/trumpcards/main.go
@@ -292,8 +292,15 @@ func run() int {
 	if err := flag.CommandLine.Parse(os.Args[1:]); err != nil {
 		// NB: -h / --help are registered above so flag.Parse handles them
 		// itself and returns nil; flag.ErrHelp is therefore unreachable here.
+		//
+		// A one-line recovery hint, not the full help. Dumping all 103 lines
+		// pushed the error itself off a standard terminal, so the one thing
+		// the user needed — which flag was wrong — was the one thing they
+		// could not see. The other two usage-error paths already settled on
+		// this: the unknown-game path uses cliUnknownGameHint (#4305) and
+		// parseSubFlagsTo uses cliTryHelp (#4307). See issue #5180.
 		_, _ = fmt.Fprintln(os.Stderr, i18n.Tf("cliFlagError", "err", err.Error()))
-		_, _ = fmt.Fprint(os.Stderr, helpText)
+		_, _ = fmt.Fprintln(os.Stderr, i18n.T("cliTryHelpTop"))
 		return 2
 	}
 

--- a/cmd/trumpcards/main_test.go
+++ b/cmd/trumpcards/main_test.go
@@ -1007,6 +1007,7 @@ func TestRunUnknownTopLevelFlagIsI18nError(t *testing.T) {
 		wantExit    int
 		wantPrefix  string
 		wantInclude string
+		wantHint    string
 	}{
 		{
 			name:        "ja locale wraps error in cliFlagError",
@@ -1014,6 +1015,7 @@ func TestRunUnknownTopLevelFlagIsI18nError(t *testing.T) {
 			wantExit:    2,
 			wantPrefix:  "エラー: 不明なオプション",
 			wantInclude: "-bogus",
+			wantHint:    "trumpcards --help",
 		},
 		{
 			name:        "en locale wraps error in cliFlagError",
@@ -1021,6 +1023,7 @@ func TestRunUnknownTopLevelFlagIsI18nError(t *testing.T) {
 			wantExit:    2,
 			wantPrefix:  "Error: invalid option",
 			wantInclude: "-bogus",
+			wantHint:    "trumpcards --help",
 		},
 	}
 	for _, tc := range cases {
@@ -1058,10 +1061,22 @@ func TestRunUnknownTopLevelFlagIsI18nError(t *testing.T) {
 			if !strings.Contains(errStr, tc.wantInclude) {
 				t.Errorf("stderr should include offending flag %q; got: %q", tc.wantInclude, firstLine(errStr))
 			}
-			// Count a locale-independent USAGE command line rather than the
-			// now-localized "USAGE:" heading.
-			if n := strings.Count(errStr, "trumpcards [--lang ja|en] [game]"); n != 1 {
-				t.Errorf("help text should be printed exactly once; got %d usage-line markers", n)
+			// The full help must NOT be dumped: it buries the error line that
+			// says what was actually wrong. Counted via a locale-independent
+			// USAGE command line rather than the localized "USAGE:" heading.
+			// See issue #5180.
+			if n := strings.Count(errStr, "trumpcards [--lang ja|en] [game]"); n != 0 {
+				t.Errorf("full help must not be dumped on a flag error; got %d usage-line markers", n)
+			}
+			// A one-line recovery hint replaces it, matching the unknown-game
+			// path (cliUnknownGameHint) and the subcommand path (cliTryHelp).
+			if !strings.Contains(errStr, tc.wantHint) {
+				t.Errorf("stderr should carry the recovery hint %q; got: %q", tc.wantHint, errStr)
+			}
+			// Error line + hint, nothing more. Guards against a future change
+			// re-introducing a multi-line dump under a different heading.
+			if n := len(strings.Split(strings.TrimSuffix(errStr, "\n"), "\n")); n != 2 {
+				t.Errorf("expected exactly 2 stderr lines (error + hint); got %d:\n%s", n, errStr)
 			}
 		})
 	}

--- a/internal/i18n/locales/en/common.json
+++ b/internal/i18n/locales/en/common.json
@@ -59,6 +59,7 @@
   "cliGamesJSONIgnoredFlags": "Warning: --short / --aliases are ignored in --json mode (the JSON schema is fixed)",
   "cliSubcommandFlagError": "Error: trumpcards {{cmd}}: {{err}}",
   "cliTryHelp": "Run 'trumpcards help {{cmd}}' for usage.",
+  "cliTryHelpTop": "Run 'trumpcards --help' for usage.",
   "cliFlagError": "Error: invalid option ({{err}})",
   "cliInvalidColorMode": "Error: invalid --color mode \"{{mode}}\" (supported: auto, always, never)",
   "metaAIRequired": "Meta-AI setting is required (0=off, 1=on).",

--- a/internal/i18n/locales/ja/common.json
+++ b/internal/i18n/locales/ja/common.json
@@ -59,6 +59,7 @@
   "cliGamesJSONIgnoredFlags": "警告: --json モードでは --short / --aliases は無視されます (JSON スキーマは固定)",
   "cliSubcommandFlagError": "エラー: trumpcards {{cmd}}: {{err}}",
   "cliTryHelp": "使い方は 'trumpcards help {{cmd}}' を実行してください。",
+  "cliTryHelpTop": "使い方は 'trumpcards --help' を実行してください。",
   "cliFlagError": "エラー: 不明なオプションです ({{err}})",
   "cliInvalidColorMode": "エラー: 無効な --color モード「{{mode}}」です (対応: auto, always, never)",
   "metaAIRequired": "メタAI設定が必要です (0=オフ, 1=オン)。",


### PR DESCRIPTION
## 概要

トップレベルのフラグを打ち間違えると、エラー1行のあとに**ヘルプ全文103行が stderr に流れ、エラーが埋もれていた**問題を修正します。

```console
# Before
$ trumpcards --lang en --bogus 2>&1 >/dev/null | wc -l
103

# After
$ trumpcards --lang en --bogus 2>&1 >/dev/null
Error: invalid option (flag provided but not defined: -bogus)
Run 'trumpcards --help' for usage.
```

行数そのものより、**同じ exit 2 の usage error が経路ごとに3通りの振る舞いをしていた**ことが問題でした。

| 経路 | Before | After |
|---|---|---|
| `trumpcards blakjack`（ゲーム名タイポ） | 3行（#4305 で確立） | 変更なし |
| `trumpcards games --bogus`（サブコマンド） | 2行（#4307 で確立） | 変更なし |
| **`trumpcards --bogus`（トップレベル）** | **103行** | **2行** |

`cliUnknownGameHint` のコード内コメントが既に「instead of re-dumping the full help (which buries the error)」と明記しており、方針自体は合意済みでした。トップレベルだけが取り残されていた形です。

## 実装メモ

`cliTryHelp` を再利用せず `cliTryHelpTop` を新設しました。前者は `{{cmd}}` を補間するため、空文字を渡すと `trumpcards  --help` と**スペースが二重**になります。

`--help` の明示指定は**変更していません** — 従来どおり stdout に全文（99行）を出して exit 0 です。成功パスでは全文こそが求められている出力なので、今回の対象外です。

## 変更内容

- `cmd/trumpcards/main.go`: `flag.CommandLine.Parse` のエラー分岐で `helpText` の全文出力を `i18n.T("cliTryHelpTop")` に置換
- `internal/i18n/locales/{ja,en}/common.json`: `cliTryHelpTop` を1キー追加（`git diff --numstat` で各 `1 0` = 追加1行・削除0行を確認済み。JSON 再整形による差分汚染なし）
- `cmd/trumpcards/main_test.go`: 既存 `TestRunUnknownTopLevelFlagIsI18nError` のアサーションを反転・強化

## テスト計画

- [x] 「ヘルプ全文が出ない」— USAGE 行マーカー数が `1` → `0` に反転（このアサーションは修正前に**確実に落ちること**を確認済み）
- [x] 「復帰ヒントが出る」— stderr に `trumpcards --help` を含む
- [x] **stderr がちょうど2行**（エラー + ヒント）— 別の見出しで多行ダンプが復活しても落ちる
- [x] ja / en 両ロケールで検証（既存のテーブル駆動ケースを流用）
- [x] exit code 2 と、オフェンディングフラグ名 `-bogus` の表示は従来どおり維持
- [x] `go test -tags test ./cmd/... ./internal/i18n/...` 通過
- [x] `golangci-lint run ./cmd/...` → 0 issues
- [x] `goimports -w` 実行済み
- [x] ビルド済みバイナリで実測（`--bogus` が ja/en とも2行、`--help` は99行で exit 0）

Closes #5180