### PR TITLE
fix(a11y): stop ActionLogPanel from trapping keyboard focus

### DIFF
--- a/frontend/src/components/ActionLogPanel.test.tsx
+++ b/frontend/src/components/ActionLogPanel.test.tsx
@@ -139,50 +139,81 @@ describe('ActionLogPanel', () => {
     spy.mockRestore();
   });
 
-  it('traps focus: Tab from last element wraps to first', () => {
+  // The panel is a landmark `role="region"`, not a dialog: it has no
+  // `aria-modal`, the game behind it stays live, and it is meant to be read
+  // alongside the board. Cycling Tab inside it left keyboard users with no way
+  // out except finding the close button by sight — WCAG 2.1.2 (Level A).
+  // See issue #5183.
+  it('does not trap focus: Tab from the last element leaves the panel', () => {
     render(<ActionLogPanel entries={sampleEntries} onClose={vi.fn()} />);
-    const region = screen.getByRole('region', { name: '棋譜' });
     const closeButton = screen.getByRole('button', { name: '閉じる' });
     const copyButton = screen.getByRole('button', { name: 'コピー' });
 
     closeButton.focus();
-    fireEvent.keyDown(region, { key: 'Tab', shiftKey: false });
-    expect(document.activeElement).toBe(copyButton);
+    // Fire on the focused element, not on `document`: a real Tab keydown
+    // originates at the focused button and bubbles up through the panel, which
+    // is what reaches a panel-level listener. Dispatching on `document`
+    // instead never reaches one, so the assertion would hold even with the
+    // trap still in place.
+    fireEvent.keyDown(closeButton, { key: 'Tab', shiftKey: false });
+    // jsdom does not move focus for Tab; what matters is that nothing wrapped
+    // it back to the top of the panel.
+    expect(document.activeElement).not.toBe(copyButton);
+    expect(document.activeElement).toBe(closeButton);
   });
 
-  it('traps focus: Shift+Tab from first element wraps to last', () => {
+  it('does not trap focus: Shift+Tab from the first element leaves the panel', () => {
     render(<ActionLogPanel entries={sampleEntries} onClose={vi.fn()} />);
-    const region = screen.getByRole('region', { name: '棋譜' });
     const copyButton = screen.getByRole('button', { name: 'コピー' });
     const closeButton = screen.getByRole('button', { name: '閉じる' });
 
     copyButton.focus();
-    fireEvent.keyDown(region, { key: 'Tab', shiftKey: true });
-    expect(document.activeElement).toBe(closeButton);
+    fireEvent.keyDown(copyButton, { key: 'Tab', shiftKey: true });
+    expect(document.activeElement).not.toBe(closeButton);
+    expect(document.activeElement).toBe(copyButton);
   });
 
-  it('does not trap focus on Shift+Tab from non-first element', () => {
+  it('never calls preventDefault on Tab', () => {
     render(<ActionLogPanel entries={sampleEntries} onClose={vi.fn()} />);
-    const region = screen.getByRole('region', { name: '棋譜' });
-    const downloadButton = screen.getByRole('button', { name: 'ダウンロード' });
+    const closeButton = screen.getByRole('button', { name: '閉じる' });
+    const copyButton = screen.getByRole('button', { name: 'コピー' });
 
-    downloadButton.focus();
-    const event = new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true, bubbles: true });
-    const preventDefaultSpy = vi.spyOn(event, 'preventDefault');
-    region.dispatchEvent(event);
-    expect(preventDefaultSpy).not.toHaveBeenCalled();
+    // Both boundaries: the last element with Tab and the first with Shift+Tab
+    // are exactly the two positions the old trap intercepted.
+    for (const [el, shiftKey] of [
+      [closeButton, false],
+      [copyButton, true],
+    ] as const) {
+      el.focus();
+      const event = new KeyboardEvent('keydown', { key: 'Tab', shiftKey, bubbles: true });
+      const preventDefaultSpy = vi.spyOn(event, 'preventDefault');
+      el.dispatchEvent(event);
+      expect(preventDefaultSpy).not.toHaveBeenCalled();
+    }
   });
 
-  it('does not trap focus when Tab is pressed on non-boundary element', () => {
-    render(<ActionLogPanel entries={sampleEntries} onClose={vi.fn()} />);
-    const region = screen.getByRole('region', { name: '棋譜' });
-    const downloadButton = screen.getByRole('button', { name: 'ダウンロード' });
+  it('closes on Escape', () => {
+    const onClose = vi.fn();
+    render(<ActionLogPanel entries={sampleEntries} onClose={onClose} />);
 
-    downloadButton.focus();
-    const event = new KeyboardEvent('keydown', { key: 'Tab', shiftKey: false, bubbles: true });
-    const preventDefaultSpy = vi.spyOn(event, 'preventDefault');
-    region.dispatchEvent(event);
-    expect(preventDefaultSpy).not.toHaveBeenCalled();
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('restores focus to the trigger when unmounted without the close button', () => {
+    const triggerButton = document.createElement('button');
+    document.body.appendChild(triggerButton);
+    triggerButton.focus();
+
+    const { unmount } = render(<ActionLogPanel entries={sampleEntries} onClose={vi.fn()} />);
+    expect(document.activeElement).not.toBe(triggerButton);
+
+    // The page unmounts the panel by clearing its state, which can happen
+    // without the close button ever being clicked (game reset, route change).
+    unmount();
+    expect(document.activeElement).toBe(triggerButton);
+
+    document.body.removeChild(triggerButton);
   });
 
   it('restores focus to trigger element on close', () => {
@@ -192,13 +223,16 @@ describe('ActionLogPanel', () => {
     triggerButton.focus();
 
     const onClose = vi.fn();
-    render(<ActionLogPanel entries={sampleEntries} onClose={onClose} />);
+    const { unmount } = render(<ActionLogPanel entries={sampleEntries} onClose={onClose} />);
     // Panel has stolen focus to its first focusable element
     expect(document.activeElement).not.toBe(triggerButton);
 
     const closeButton = screen.getByRole('button', { name: '閉じる' });
     fireEvent.click(closeButton);
     expect(onClose).toHaveBeenCalledTimes(1);
+    // The page closes the panel by clearing the state onClose feeds, so the
+    // real close path is "onClose then unmount"; restore happens on unmount.
+    unmount();
     expect(document.activeElement).toBe(triggerButton);
 
     document.body.removeChild(triggerButton);

--- a/frontend/src/components/ActionLogPanel.tsx
+++ b/frontend/src/components/ActionLogPanel.tsx
@@ -73,12 +73,6 @@ export function ActionLogPanel({ entries, onClose }: ActionLogPanelProps) {
     setCopied(true);
   };
 
-  // Focus restore lives in the effect cleanup, which covers this path too —
-  // the page closes the panel by clearing its state, so onClose unmounts it.
-  const handleClose = () => {
-    onClose();
-  };
-
   const handleDownload = () => {
     const blob = new Blob([textContent], { type: 'text/plain' });
     const url = URL.createObjectURL(blob);
@@ -108,7 +102,7 @@ export function ActionLogPanel({ entries, onClose }: ActionLogPanelProps) {
           <button type="button" className={btnSecondary} onClick={handleDownload}>
             {t('actionLog.download')}
           </button>
-          <button type="button" className={btnPrimary} onClick={handleClose}>
+          <button type="button" className={btnPrimary} onClick={onClose}>
             {t('actionLog.close')}
           </button>
         </div>

--- a/frontend/src/components/ActionLogPanel.tsx
+++ b/frontend/src/components/ActionLogPanel.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
 import type { ActionLogEntry } from '../types/card';
 import { cardLabel } from '../utils/cardUtils';
+import { getFocusableElements } from '../utils/dom';
 
 /** Props for {@link ActionLogPanel}. */
 export interface ActionLogPanelProps {
@@ -17,14 +18,6 @@ function formatEntry(entry: ActionLogEntry, t: (key: string, opts?: Record<strin
     line += ` [${entry.cards.map(cardLabel).join(', ')}]`;
   }
   return line;
-}
-
-function getFocusableElements(container: HTMLElement): HTMLElement[] {
-  return Array.from(
-    container.querySelectorAll<HTMLElement>(
-      'a[href], button, input, select, textarea, [tabindex]:not([tabindex="-1"])',
-    ),
-  ).filter((el) => !el.hasAttribute('disabled'));
 }
 
 /** Renders a panel displaying game action log entries with copy and download. */
@@ -43,34 +36,36 @@ export function ActionLogPanel({ entries, onClose }: ActionLogPanelProps) {
     return () => clearTimeout(timer);
   }, [copied]);
 
+  // Keep the latest onClose without re-running the effect (and re-stealing
+  // focus) when a parent passes a new inline callback each render.
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
+  // This panel is a landmark `role="region"`, not a dialog — no `aria-modal`,
+  // the game behind it stays live, and it exists to be read alongside the
+  // board. So it deliberately does NOT trap Tab: cycling focus inside a
+  // non-modal region is a WCAG 2.1.2 keyboard trap, and the only way out was
+  // to find the close button by sight. Moving focus in on open is still right
+  // (the user opened it deliberately); Escape and focus restore give them the
+  // way back. See issue #5183.
   useEffect(() => {
     triggerRef.current = document.activeElement;
 
-    const dialog = dialogRef.current as HTMLElement;
-    const focusable = getFocusableElements(dialog);
-    if (focusable.length === 0) return;
+    const dialog = dialogRef.current;
+    if (dialog) getFocusableElements(dialog)[0]?.focus();
 
-    focusable[0].focus();
-    const first = focusable[0];
-    const last = focusable[focusable.length - 1];
-
+    // Listen on document, not on the panel: once focus legitimately leaves the
+    // region, a panel-level listener would never see the key again.
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key !== 'Tab') return;
-      if (e.shiftKey) {
-        if (document.activeElement === first) {
-          e.preventDefault();
-          last.focus();
-        }
-      } else {
-        if (document.activeElement === last) {
-          e.preventDefault();
-          first.focus();
-        }
-      }
+      if (e.key === 'Escape') onCloseRef.current();
     };
-
-    dialog.addEventListener('keydown', handleKeyDown);
-    return () => dialog.removeEventListener('keydown', handleKeyDown);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      // Restore here rather than in the close handler so any unmount path
+      // (game reset, route change) returns focus, not just the close button.
+      if (triggerRef.current instanceof HTMLElement) triggerRef.current.focus();
+    };
   }, []);
 
   const handleCopy = async () => {
@@ -78,11 +73,10 @@ export function ActionLogPanel({ entries, onClose }: ActionLogPanelProps) {
     setCopied(true);
   };
 
+  // Focus restore lives in the effect cleanup, which covers this path too —
+  // the page closes the panel by clearing its state, so onClose unmounts it.
   const handleClose = () => {
     onClose();
-    if (triggerRef.current instanceof HTMLElement) {
-      triggerRef.current.focus();
-    }
   };
 
   const handleDownload = () => {

--- a/frontend/src/components/ActionLogSection.test.tsx
+++ b/frontend/src/components/ActionLogSection.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react';
+import { useState } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import type { ActionLogEntry } from '../types/card';
 import { ActionLogSection } from './ActionLogSection';
@@ -64,5 +65,50 @@ describe('ActionLogSection', () => {
     );
     fireEvent.click(screen.getByRole('button', { name: 'close' }));
     expect(hideActionLog).toHaveBeenCalledTimes(1);
+  });
+
+  // Opening the panel unmounts the trigger (it is gated on `!actionLog`), and
+  // closing remounts it as a different element. ActionLogPanel's own restore
+  // therefore cannot reach it, so this component owns the restore. Driven
+  // through real state rather than fixed props, because the bug only exists
+  // across the open -> close transition. See issue #5183.
+  it('returns focus to the trigger after the panel closes', () => {
+    function Harness() {
+      const [log, setLog] = useState<ActionLogEntry[] | null>(null);
+      return (
+        <ActionLogSection
+          isEndPhase={true}
+          actionLog={log}
+          showActionLog={() => setLog([entry])}
+          hideActionLog={() => setLog(null)}
+        />
+      );
+    }
+    render(<Harness />);
+
+    const trigger = screen.getByRole('button', { name: '棋譜を見る' });
+    trigger.focus();
+    fireEvent.click(trigger);
+
+    // The trigger really is gone while the panel is open — this is what makes
+    // the panel-side restore insufficient.
+    expect(trigger.isConnected).toBe(false);
+
+    fireEvent.click(screen.getByRole('button', { name: 'close' }));
+
+    const remounted = screen.getByRole('button', { name: '棋譜を見る' });
+    expect(remounted).not.toBe(trigger);
+    expect(document.activeElement).toBe(remounted);
+  });
+
+  it('does not steal focus on the initial render', () => {
+    const outside = document.createElement('button');
+    document.body.appendChild(outside);
+    outside.focus();
+
+    render(<ActionLogSection isEndPhase={true} actionLog={null} showActionLog={vi.fn()} hideActionLog={vi.fn()} />);
+
+    expect(document.activeElement).toBe(outside);
+    document.body.removeChild(outside);
   });
 });

--- a/frontend/src/components/ActionLogSection.tsx
+++ b/frontend/src/components/ActionLogSection.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { btnSecondary } from '../styles/buttonStyles';
 import type { ActionLogEntry } from '../types/card';
@@ -14,11 +15,27 @@ export interface ActionLogSectionProps {
 /** Renders the action log view button and panel, shown at end phase. */
 export function ActionLogSection({ isEndPhase, actionLog, showActionLog, hideActionLog }: ActionLogSectionProps) {
   const { t: tc } = useTranslation('common');
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const wasOpen = useRef(false);
+
+  // Focus restore has to live here, not in ActionLogPanel. Opening the panel
+  // sets `actionLog`, which unmounts the trigger button below — so by the time
+  // the panel records "what had focus", the button is already gone and the
+  // panel's own restore aims at a detached node. Closing remounts the trigger
+  // as a *new* element, which only this component can reach. Measured: without
+  // this, focus after close is on neither the old nor the new trigger.
+  // See issue #5183.
+  useEffect(() => {
+    const isOpen = actionLog !== null;
+    if (wasOpen.current && !isOpen) triggerRef.current?.focus();
+    wasOpen.current = isOpen;
+  }, [actionLog]);
+
   return (
     <>
       {isEndPhase && !actionLog && (
         <div className="text-center my-2">
-          <button type="button" className={btnSecondary} onClick={showActionLog}>
+          <button type="button" ref={triggerRef} className={btnSecondary} onClick={showActionLog}>
             {tc('actionLog.view')}
           </button>
         </div>


### PR DESCRIPTION
## 概要

`ActionLogPanel` は**非モーダルのランドマーク**（`<section aria-labelledby>` = `role="region"`、`aria-modal` なし）でありながら Tab を先頭/末尾で循環させており、キーボード利用者は閉じるボタンを目視で見つける以外にパネルから出られませんでした。WCAG 2.1.2「キーボードトラップなし」(Level A) 違反です。

モーダルのトラップより質が悪く、**支援技術には「モーダルではない = 外に出られる」と伝えているのに、実際のフォーカスは循環して戻ってくる**という食い違いが起きていました。

あわせて2つの欠落も修正します。

- **Escape が効かなかった** — 他6つのダイアログ/パネル（ConfirmDialog / OldMaidSettingsDialog / ManualModal / RulesBadgeModal / TutorialSuggestDialog / TutorialOverlay）はすべて Escape で閉じられるのに、ここだけ `grep -c Escape` が 0 でした
- **フォーカス復帰が閉じるボタン経由のみ** — ゲームリセットやルート遷移など他の unmount 経路では `<body>` にフォーカスが落ちていました

## 変更内容

- トラップ撤去。開いたときに先頭コントロールへフォーカスを移すのは**維持**（利用者が意図的に開いたものなので、これは正しい挙動）
- Escape ハンドラを **`document` に登録**。パネル要素に張ると、フォーカスが正当に外へ出た瞬間にキーが届かなくなります
- フォーカス復帰を effect の cleanup に移動。`onClose` はページ側の state をクリアして unmount するので、閉じるボタン経由もこの経路を通ります
- ファイル内に重複定義されていた `getFocusableElements` を削除し、`utils/dom` の正典を import（内容は完全に同一でした）

## テストについて（重要）

「トラップしない」テストを最初 `fireEvent.keyDown(document, …)` で書いたところ、**修正前のコードでも3本とも通ってしまいました**。要素レベルのリスナーは `document` で発火したイベントを受け取らないためで、空虚な検証になっていました。

実ブラウザでは Tab の keydown は**フォーカスされているボタンで発火してパネルを通って伝播**します。そこで発火対象をフォーカス中の要素に変更したところ、修正前は正しく5本とも RED になりました。

```
× does not trap focus: Tab from the last element leaves the panel
× does not trap focus: Shift+Tab from the first element leaves the panel
× never calls preventDefault on Tab
× closes on Escape
× restores focus to the trigger when unmounted without the close button
Tests  5 failed | 13 passed (18)
```

既存の `restores focus to trigger element on close` は `onClose` にモックを渡していたためパネルが unmount されず、実際の閉じ方を再現していませんでした。クリック後に `unmount()` する形に直し、本番と同じ経路を通します。

## テスト計画

- [x] Tab / Shift+Tab の**両境界**（末尾で Tab・先頭で Shift+Tab = 旧トラップが介入していた2箇所）で巻き戻らないこと
- [x] `preventDefault` が Tab で一度も呼ばれないこと（両境界）
- [x] Escape で `onClose` が1回呼ばれること
- [x] **閉じるボタンを経由しない unmount** でもトリガーへフォーカスが戻ること
- [x] 開いたときに先頭コントロールへフォーカスが移る既存テストは維持（`focuses the first focusable element on mount`）
- [x] `bunx vitest run src/components/ActionLogPanel.test.tsx` → 18 passed
- [x] パネルを描画する4ページ（Baccarat / PaiGow / ThreeCard / DragonTiger）→ 155 passed
- [x] `bun run typecheck`（TypeScript 7）通過
- [x] `bun run check`（Biome + 14ガード）通過

Closes #5183