### PR TITLE
fix(a11y): keep tutorial focus inside the overlay across steps

### DIFF
--- a/frontend/src/components/ConfirmDialog.tsx
+++ b/frontend/src/components/ConfirmDialog.tsx
@@ -2,9 +2,6 @@ import { useId } from 'react';
 import { btnDanger, btnSecondary } from '../styles/buttonStyles';
 import { Modal } from './common/Modal';
 
-// Re-export for backward compatibility with existing imports
-export { getFocusableElements } from '../utils/dom';
-
 /** Props for the ConfirmDialog component. */
 export interface ConfirmDialogProps {
   open: boolean;

--- a/frontend/src/components/tutorial/TutorialOverlay.test.tsx
+++ b/frontend/src/components/tutorial/TutorialOverlay.test.tsx
@@ -199,6 +199,76 @@ describe('TutorialOverlay', () => {
     expect(overlayRect).toHaveAttribute('fill', 'rgba(0,0,0,0.75)');
   });
 
+  // Advancing a step used to throw focus out of the overlay: the effect that
+  // tracks `step.target` restored focus to the trigger in its cleanup, so it
+  // fired on every step change, while the focus-trap effect had `[]` deps and
+  // never put focus back. From step 2 on, focus sat outside an `aria-modal`
+  // dialog and the element-level Tab/Escape handlers stopped firing entirely.
+  // The two steps must use different targets, or the effect does not re-run
+  // and the bug is not reached. See issue #5184.
+  describe('advancing a step', () => {
+    let secondTarget: HTMLDivElement;
+    const stepTwo: TutorialStep = { ...step, target: '[data-tutorial="second-target"]' };
+
+    beforeEach(() => {
+      secondTarget = document.createElement('div');
+      secondTarget.setAttribute('data-tutorial', 'second-target');
+      secondTarget.getBoundingClientRect = vi.fn().mockReturnValue({
+        top: 200,
+        left: 60,
+        width: 120,
+        height: 30,
+        right: 180,
+        bottom: 230,
+      });
+      document.body.appendChild(secondTarget);
+    });
+
+    afterEach(() => {
+      secondTarget.remove();
+    });
+
+    it('keeps focus inside the overlay', () => {
+      const outside = document.createElement('button');
+      document.body.appendChild(outside);
+      outside.focus();
+
+      const { rerender } = render(<TutorialOverlay {...defaultProps} />);
+      expect(screen.getByRole('dialog').contains(document.activeElement)).toBe(true);
+
+      rerender(<TutorialOverlay {...defaultProps} step={stepTwo} stepIndex={1} />);
+      expect(screen.getByRole('dialog').contains(document.activeElement)).toBe(true);
+      expect(document.activeElement).not.toBe(outside);
+
+      outside.remove();
+    });
+
+    it('still skips on Escape', () => {
+      const onSkip = vi.fn();
+      const { rerender } = render(<TutorialOverlay {...defaultProps} onSkip={onSkip} />);
+      rerender(<TutorialOverlay {...defaultProps} onSkip={onSkip} step={stepTwo} stepIndex={1} />);
+
+      fireEvent.keyDown(document, { key: 'Escape' });
+      expect(onSkip).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not restore focus to the trigger mid-tutorial', () => {
+      const outside = document.createElement('button');
+      document.body.appendChild(outside);
+      outside.focus();
+
+      const { rerender, unmount } = render(<TutorialOverlay {...defaultProps} />);
+      rerender(<TutorialOverlay {...defaultProps} step={stepTwo} stepIndex={1} />);
+      expect(document.activeElement).not.toBe(outside);
+
+      // Only finishing the tutorial hands focus back.
+      unmount();
+      expect(document.activeElement).toBe(outside);
+
+      outside.remove();
+    });
+  });
+
   it('restores focus on unmount', () => {
     const triggerButton = document.createElement('button');
     document.body.appendChild(triggerButton);

--- a/frontend/src/components/tutorial/TutorialOverlay.tsx
+++ b/frontend/src/components/tutorial/TutorialOverlay.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useId, useLayoutEffect, useRef, useState } from 'react';
 import { useBodyScrollLock } from '../../hooks/useBodyScrollLock';
+import { useFocusTrap } from '../../hooks/useFocusTrap';
 import type { TutorialStep } from '../../types/tutorial';
-import { getFocusableElements } from '../ConfirmDialog';
 import { TutorialTooltip } from './TutorialTooltip';
 
 /** Rect representing position and size of an element. */
@@ -69,15 +69,17 @@ function getTooltipStyle(rect: SpotlightRect | null, placement: TutorialStep['pl
 export function TutorialOverlay({ step, stepIndex, totalSteps, onNext, onSkip, reducedMotion }: TutorialOverlayProps) {
   const maskId = useId();
   const dialogRef = useRef<HTMLDivElement>(null);
-  const triggerRef = useRef<Element | null>(null);
   const tooltipRef = useRef<HTMLDivElement>(null);
   const [spotlightRect, setSpotlightRect] = useState<SpotlightRect | null>(null);
 
   useBodyScrollLock(true);
 
-  // Find and observe the target element
+  // Track the spotlight target. This re-runs on every step, so it must not
+  // touch focus: restoring focus here fired on each step change and threw it
+  // out of the overlay for the rest of the tutorial (issue #5184). Focus is
+  // owned by useFocusTrap below, whose deps are stable so it neither re-steals
+  // focus per step nor hands it back before the tutorial ends.
   useEffect(() => {
-    triggerRef.current = document.activeElement;
     const targetEl = document.querySelector(step.target);
     setSpotlightRect(getSpotlightRect(targetEl));
 
@@ -88,12 +90,7 @@ export function TutorialOverlay({ step, stepIndex, totalSteps, onNext, onSkip, r
     });
     ro.observe(targetEl);
 
-    return () => {
-      ro.disconnect();
-      if (triggerRef.current instanceof HTMLElement) {
-        triggerRef.current.focus();
-      }
-    };
+    return () => ro.disconnect();
   }, [step.target]);
 
   // Listen for click on target when advanceOn is 'click'.
@@ -109,45 +106,19 @@ export function TutorialOverlay({ step, stepIndex, totalSteps, onNext, onSkip, r
     return () => targetEl.removeEventListener('click', handler);
   }, [step.target, step.advanceOn, onNext]);
 
-  // Focus trap
-  useEffect(() => {
-    const dialog = dialogRef.current;
-    if (!dialog) return;
+  // Focus trap, Escape, and focus restore, from the shared hook: it listens on
+  // `document` (so it keeps working if focus ever does leave) and re-queries
+  // focusable children on each Tab, unlike the copy this replaces.
+  useFocusTrap(dialogRef, true, onSkip);
 
-    const focusable = getFocusableElements(dialog);
-    if (focusable.length > 0) {
-      focusable[0].focus();
-    }
-
-    const handleTab = (e: KeyboardEvent) => {
-      if (e.key !== 'Tab') return;
-      const currentFocusable = getFocusableElements(dialog);
-      if (currentFocusable.length === 0) return;
-      const first = currentFocusable[0];
-      const last = currentFocusable[currentFocusable.length - 1];
-      if (e.shiftKey) {
-        if (document.activeElement === first) {
-          e.preventDefault();
-          last.focus();
-        }
-      } else {
-        if (document.activeElement === last) {
-          e.preventDefault();
-          first.focus();
-        }
-      }
-    };
-
-    dialog.addEventListener('keydown', handleTab);
-    return () => dialog.removeEventListener('keydown', handleTab);
-  }, []);
-
+  // Escape is handled by useFocusTrap. Handling it here as well would call
+  // onSkip twice for a single keypress, since this synthetic handler and the
+  // hook's document listener both see the same event.
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (e.key === 'Enter') onNext();
-      if (e.key === 'Escape') onSkip();
     },
-    [onNext, onSkip],
+    [onNext],
   );
 
   const tooltipStyle = getTooltipStyle(spotlightRect, step.placement);


### PR DESCRIPTION
## 概要

チュートリアルのステップを進めると、**フォーカスがオーバーレイの外へ飛び、以降 Tab 循環も Enter も Escape も効かなくなる**問題を修正します。

`step.target` を追う effect が cleanup で `triggerRef.current.focus()` を呼んでおり、**ステップが変わるたびに**発火していました。一方フォーカストラップ effect は `[]` deps で初回しか走らないため、フォーカスを戻す側がいません。結果、ステップ2以降は `aria-modal="true"` を宣言したままのダイアログの**外**にフォーカスが居座ります。

さらに悪いことに、Tab ハンドラも Enter/Escape ハンドラも**ダイアログ要素**に束縛されていました。DOM イベントはフォーカスされているノードで発火するため、フォーカスが外に出た時点でどれも呼ばれなくなります。

- Enter でステップを進められない
- Escape でチュートリアルを中断できない
- `useBodyScrollLock(true)` はスクロールをロックしたまま

→ **マウスで「スキップ」を押すまで詰み**、かつ暗幕（不透明度0.75）の裏なのでフォーカスリングは見えません。

## 変更内容

- `[step.target]` effect からフォーカス操作を削除。スポットライト追跡だけを担わせます
- 自前のフォーカストラップ effect（約30行）を削除し、共有の `useFocusTrap` に委譲。deps が安定しているためステップごとに再フォーカスせず、unmount まで返しません。`document` にリスナーを張り、Tab ごとに focusable を再クエリする点も自前版より堅牢です
- 合成ハンドラから Escape を削除。`useFocusTrap` が既に処理するため、両方残すと**1回のキー押下で `onSkip` が2回**呼ばれます（既存の `toHaveBeenCalledTimes(1)` が検出します）
- `ConfirmDialog` の `getFocusableElements` 再エクスポートを削除。`TutorialOverlay` が唯一のインポータだったため、この変更でゼロになりました

## テスト計画

新規3本はいずれも**修正前に RED** であることを確認済みです。

```
× keeps focus inside the overlay          → expected false to be true
× still skips on Escape                   → onSkip called 0 times
× does not restore focus mid-tutorial     → focus was on the trigger
Tests  3 failed | 26 passed (29)
```

- [x] `keeps focus inside the overlay` — ステップ送り後もフォーカスが dialog 内
- [x] `still skips on Escape` — **ステップ送り後**に Escape が効く
- [x] `does not restore focus to the trigger mid-tutorial` — 途中では返さず、unmount 時のみ返す
- [x] 2つのステップに**異なる `target` セレクタ**を使用。同一だと effect が再実行されず不具合を踏めません
- [x] 既存29本すべて通過（トラップ2本は `dialog` で発火→`document` にバブルするため hook 移行後も有効）
- [x] `bunx vitest run src/components/tutorial/ src/components/ConfirmDialog.test.tsx src/providers/` → 124 passed
- [x] `bun run typecheck`（TypeScript 7）通過
- [x] `bun run check`（Biome + 14ガード）通過

Closes #5184