### PR TITLE
refactor(a11y): put every modal on the shared focus trap, and guard it

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,7 @@
     "lint": "biome lint .",
     "lint:tokens": "bun scripts/check-design-tokens.mjs",
     "format": "biome format --write .",
-    "check": "biome check . && bun scripts/check-guard-floors.mjs && bun scripts/check-design-tokens.mjs && bun scripts/check-discover-blurbs.mjs && bun scripts/check-message-codes.mjs && bun scripts/check-hint-coverage.mjs && bun scripts/check-hint-reasons.mjs && bun scripts/check-markdown-tables.mjs && bun scripts/check-hint-gate.mjs && bun scripts/check-dependency-licenses.mjs && bun scripts/check-trademark-terms.mjs && bun scripts/check-asset-provenance.mjs && bun scripts/check-codecov-uploads.mjs && bun scripts/check-mermaid.mjs && bun scripts/check-design-doc-identifiers.mjs",
+    "check": "biome check . && bun scripts/check-guard-floors.mjs && bun scripts/check-design-tokens.mjs && bun scripts/check-modal-focus-trap.mjs && bun scripts/check-discover-blurbs.mjs && bun scripts/check-message-codes.mjs && bun scripts/check-hint-coverage.mjs && bun scripts/check-hint-reasons.mjs && bun scripts/check-markdown-tables.mjs && bun scripts/check-hint-gate.mjs && bun scripts/check-dependency-licenses.mjs && bun scripts/check-trademark-terms.mjs && bun scripts/check-asset-provenance.mjs && bun scripts/check-codecov-uploads.mjs && bun scripts/check-mermaid.mjs && bun scripts/check-design-doc-identifiers.mjs",
     "check:write": "biome check --write .",
     "preview": "vite preview",
     "test": "vitest run",

--- a/frontend/scripts/check-modal-focus-trap.mjs
+++ b/frontend/scripts/check-modal-focus-trap.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env bun
+// Guard that anything claiming to be a modal actually traps focus.
+//
+// `aria-modal="true"` tells assistive tech that everything outside the dialog is
+// inert. If focus can still walk out of it, the AT's model and the real focus
+// disagree, and the user lands on elements they were told do not exist — worse
+// than never having claimed modality at all.
+//
+// Issue #4312 consolidated eight hand-rolled dialogs onto `common/Modal` +
+// `useFocusTrap`, but four kept private copies that then drifted: all four lost
+// the "pull focus back if it escaped" branch, and three bound their key handler
+// to the dialog element rather than `document`, so once focus did leave, the
+// handler stopped firing and the trap was dead for the rest of the dialog's life
+// (issues #5182, #5183, #5184). Every one of those had tests that passed.
+//
+// The rule is therefore structural rather than behavioural: a component that
+// declares `aria-modal` must get its focus handling from the shared hook or the
+// shared component, not from an effect of its own.
+//
+// Non-modal panels are deliberately out of scope. `ActionLogPanel` is a landmark
+// `role="region"` and must NOT trap (WCAG 2.1.2) — it opts out with
+// `useFocusTrap(..., { trap: false })`, and since it never declares `aria-modal`
+// this guard does not look at it. So the guard says "claim modality ⇒ trap", not
+// "trap everywhere".
+//
+// Usage: check-modal-focus-trap.mjs [srcDir]
+
+import { readdir, readFile } from 'node:fs/promises';
+import { join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { assertFloor } from './lib/floor.mjs';
+
+const ROOT = fileURLToPath(new URL('..', import.meta.url));
+const SRC_DIR = process.argv[2] ? resolve(process.argv[2]) : join(ROOT, 'src');
+
+/** Comments are blanked, not removed, so reported line numbers stay accurate. */
+function stripComments(text) {
+  return text
+    .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' '))
+    .replace(/\/\/[^\n]*/g, (m) => ' '.repeat(m.length));
+}
+
+async function walk(dir) {
+  const out = [];
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...(await walk(full)));
+    else if (entry.name.endsWith('.tsx') && !/\.(test|spec)\.tsx$/.test(entry.name)) out.push(full);
+  }
+  return out;
+}
+
+const files = await walk(SRC_DIR);
+
+// Blanking comments matters here: ActionLogPanel's source explains *why* it has
+// no `aria-modal`, and a raw substring search flags it for saying so.
+const ARIA_MODAL = /aria-modal\s*=\s*[{"']?\s*(?:true|"true"|'true')/;
+const USES_HOOK = /\buseFocusTrap\s*\(/;
+const USES_MODAL = /<Modal[\s/>]/;
+
+const violations = [];
+let declaringModality = 0;
+
+for (const file of files) {
+  const src = stripComments(await readFile(file, 'utf8'));
+  if (!ARIA_MODAL.test(src)) continue;
+  declaringModality += 1;
+  if (USES_HOOK.test(src) || USES_MODAL.test(src)) continue;
+  const lines = src.split('\n');
+  const line = lines.findIndex((l) => ARIA_MODAL.test(l)) + 1;
+  violations.push({ file: relative(ROOT, file), line });
+}
+
+if (violations.length > 0) {
+  console.error('\nComponents declaring aria-modal without a shared focus trap:\n');
+  for (const v of violations) {
+    console.error(`  ${v.file}:${v.line}  declares aria-modal but uses neither useFocusTrap nor <Modal>`);
+  }
+  console.error(
+    '\nUse <Modal> (components/common/Modal.tsx) or useFocusTrap (hooks/useFocusTrap.ts).\n' +
+      'A private copy loses the escaped-focus recovery and the document-level listener;\n' +
+      'that is what issues #5182 / #5183 / #5184 were. For a NON-modal panel, drop\n' +
+      'aria-modal and use useFocusTrap(..., { trap: false }) instead.\n',
+  );
+  process.exit(1);
+}
+
+// Three components declare aria-modal today: the shared Modal itself, plus the
+// two bespoke overlays (manual, tutorial spotlight) whose layouts do not fit it.
+// The count is low because adopting <Modal> *removes* the attribute from the
+// caller — it moves into Modal. Floored at 2 so ordinary churn does not trip it,
+// but a walk that stops finding .tsx files — or a regex that stops matching the
+// attribute — fails loudly instead of reporting a clean tree it never inspected.
+assertFloor('modal-focus-trap', declaringModality, 2, 'components declaring aria-modal');
+console.log(`modal-focus-trap: OK (${declaringModality} components declare aria-modal; all use the shared trap).`);

--- a/frontend/scripts/check-modal-focus-trap.mjs
+++ b/frontend/scripts/check-modal-focus-trap.mjs
@@ -23,6 +23,13 @@
 // this guard does not look at it. So the guard says "claim modality ⇒ trap", not
 // "trap everywhere".
 //
+// Known limitation: the two checks below are file-level, not scoped to the
+// element that declares aria-modal. A file holding two dialogs — one correctly
+// on <Modal>, one hand-rolled that also sets aria-modal — would pass. Scoping it
+// properly needs an AST, which is a lot of machinery for a codebase that keeps
+// one dialog per file; if that convention ever breaks, tighten this rather than
+// trusting it. Raised in review on PR #5195.
+//
 // Usage: check-modal-focus-trap.mjs [srcDir]
 
 import { readdir, readFile } from 'node:fs/promises';

--- a/frontend/scripts/check-modal-focus-trap.test.mjs
+++ b/frontend/scripts/check-modal-focus-trap.test.mjs
@@ -1,0 +1,124 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, describe, expect, it } from 'vitest';
+
+// Vitest serves test modules under a non-file URL, so resolve from cwd (the
+// vitest root is `frontend/`) and assert the script is there — a wrong cwd would
+// otherwise turn every case below into a spawn of a missing file rather than a
+// visible failure.
+const SCRIPTS = join(process.cwd(), 'scripts');
+const GUARD = join(SCRIPTS, 'check-modal-focus-trap.mjs');
+if (!existsSync(GUARD)) throw new Error(`check-modal-focus-trap.mjs not found at ${GUARD} (cwd: ${process.cwd()})`);
+
+const dirs = [];
+afterAll(() => {
+  for (const d of dirs) rmSync(d, { recursive: true, force: true });
+});
+
+/**
+ * Build a src fixture. The guard floors its walk at 2 components declaring
+ * aria-modal, so every fixture ships at least that many compliant ones —
+ * otherwise a case would fail on the floor rather than on the rule under test.
+ */
+function fixture(extra = {}) {
+  const dir = mkdtempSync(join(tmpdir(), 'modal-trap-'));
+  dirs.push(dir);
+  const files = {
+    'Modal.tsx': `import { useFocusTrap } from '../hooks/useFocusTrap';
+export function Modal() {
+  useFocusTrap(ref, open, onClose);
+  return <div role="dialog" aria-modal="true" />;
+}
+`,
+    'ManualModal.tsx': `import { useFocusTrap } from '../hooks/useFocusTrap';
+export function ManualModal() {
+  useFocusTrap(ref, open, onClose);
+  return <div role="dialog" aria-modal="true" />;
+}
+`,
+    ...extra,
+  };
+  for (const [name, body] of Object.entries(files)) {
+    const full = join(dir, name);
+    mkdirSync(join(full, '..'), { recursive: true });
+    writeFileSync(full, body);
+  }
+  return dir;
+}
+
+const run = (dir) => spawnSync('bun', [GUARD, dir], { encoding: 'utf8' });
+
+describe('check-modal-focus-trap', () => {
+  it('accepts components that use useFocusTrap', () => {
+    const r = run(fixture());
+    expect(r.stdout).toContain('modal-focus-trap: OK');
+    expect(r.status).toBe(0);
+  });
+
+  it('accepts a component that delegates to <Modal> instead of declaring its own trap', () => {
+    const r = run(
+      fixture({
+        'Suggest.tsx': `import { Modal } from './Modal';
+export function Suggest() {
+  return <Modal open onClose={x} aria-modal="true"><p>hi</p></Modal>;
+}
+`,
+      }),
+    );
+    expect(r.status).toBe(0);
+  });
+
+  it('rejects a component declaring aria-modal with a hand-rolled trap', () => {
+    const r = run(
+      fixture({
+        'Rogue.tsx': `export function Rogue() {
+  useEffect(() => {
+    dialog.addEventListener('keydown', handleTab);
+  }, []);
+  return <div role="dialog" aria-modal="true" />;
+}
+`,
+      }),
+    );
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain('Rogue.tsx');
+    expect(r.stderr).toContain('aria-modal');
+  });
+
+  // The bug that motivated stripping comments: ActionLogPanel's source explains
+  // why it has NO aria-modal, and a raw substring search flagged it for saying so.
+  it('does not flag a component that only mentions aria-modal in a comment', () => {
+    const r = run(
+      fixture({
+        'Panel.tsx': `export function Panel() {
+  // This panel is a landmark role="region", not a dialog — no aria-modal="true" here.
+  /* Nor in a block comment: aria-modal="true". */
+  return <section aria-labelledby="t" />;
+}
+`,
+      }),
+    );
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain('2 components declare aria-modal');
+  });
+
+  it('fails on an empty walk rather than reporting a clean tree', () => {
+    const empty = mkdtempSync(join(tmpdir(), 'modal-trap-empty-'));
+    dirs.push(empty);
+    const r = run(empty);
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain('modal-focus-trap');
+  });
+
+  it('ignores test files', () => {
+    const r = run(
+      fixture({
+        'Rogue.test.tsx': `it('x', () => { render(<div role="dialog" aria-modal="true" />); });
+`,
+      }),
+    );
+    expect(r.status).toBe(0);
+  });
+});

--- a/frontend/src/components/ActionLogPanel.tsx
+++ b/frontend/src/components/ActionLogPanel.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useId, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useFocusTrap } from '../hooks/useFocusTrap';
 import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
 import type { ActionLogEntry } from '../types/card';
 import { cardLabel } from '../utils/cardUtils';
-import { getFocusableElements } from '../utils/dom';
 
 /** Props for {@link ActionLogPanel}. */
 export interface ActionLogPanelProps {
@@ -25,7 +25,6 @@ export function ActionLogPanel({ entries, onClose }: ActionLogPanelProps) {
   const { t } = useTranslation('common');
   const [copied, setCopied] = useState(false);
   const dialogRef = useRef<HTMLElement>(null);
-  const triggerRef = useRef<Element | null>(null);
   const titleId = useId();
 
   const textContent = entries.length === 0 ? t('actionLog.empty') : entries.map((e) => formatEntry(e, t)).join('\n');
@@ -36,37 +35,13 @@ export function ActionLogPanel({ entries, onClose }: ActionLogPanelProps) {
     return () => clearTimeout(timer);
   }, [copied]);
 
-  // Keep the latest onClose without re-running the effect (and re-stealing
-  // focus) when a parent passes a new inline callback each render.
-  const onCloseRef = useRef(onClose);
-  onCloseRef.current = onClose;
-
-  // This panel is a landmark `role="region"`, not a dialog — no `aria-modal`,
-  // the game behind it stays live, and it exists to be read alongside the
-  // board. So it deliberately does NOT trap Tab: cycling focus inside a
-  // non-modal region is a WCAG 2.1.2 keyboard trap, and the only way out was
-  // to find the close button by sight. Moving focus in on open is still right
-  // (the user opened it deliberately); Escape and focus restore give them the
-  // way back. See issue #5183.
-  useEffect(() => {
-    triggerRef.current = document.activeElement;
-
-    const dialog = dialogRef.current;
-    if (dialog) getFocusableElements(dialog)[0]?.focus();
-
-    // Listen on document, not on the panel: once focus legitimately leaves the
-    // region, a panel-level listener would never see the key again.
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onCloseRef.current();
-    };
-    document.addEventListener('keydown', handleKeyDown);
-    return () => {
-      document.removeEventListener('keydown', handleKeyDown);
-      // Restore here rather than in the close handler so any unmount path
-      // (game reset, route change) returns focus, not just the close button.
-      if (triggerRef.current instanceof HTMLElement) triggerRef.current.focus();
-    };
-  }, []);
+  // Landmark `role="region"`, not a dialog: no `aria-modal`, the game behind it
+  // stays live, and it exists to be read alongside the board. So Tab is NOT
+  // cycled — that would be a WCAG 2.1.2 keyboard trap with no way out but
+  // finding the close button by sight (issue #5183). Everything else the hook
+  // provides is still wanted: focus in on open, Escape to leave, and restore on
+  // any unmount path (game reset, route change), not just the close button.
+  useFocusTrap(dialogRef, true, onClose, { trap: false });
 
   const handleCopy = async () => {
     await navigator.clipboard.writeText(textContent);

--- a/frontend/src/components/common/Modal.tsx
+++ b/frontend/src/components/common/Modal.tsx
@@ -21,6 +21,14 @@ export interface ModalProps {
   ariaDescribedBy?: string;
   /** Classes for the inner dialog panel. */
   panelClassName?: string;
+  /**
+   * Classes for the backdrop scrim, including how the panel is aligned within
+   * it. Defaults to a centered panel over the standard dim. Override only to
+   * preserve a dialog's existing look when adopting this primitive — the
+   * first-visit tutorial dialog uses a heavier blurred scrim, and Daifugo's
+   * rules modal is a bottom sheet on mobile (`items-end sm:items-center`).
+   */
+  backdropClassName?: string;
   /** Whether a backdrop click closes the modal (default true). */
   dismissOnBackdrop?: boolean;
 }
@@ -43,6 +51,7 @@ export function Modal({
   ariaLabelledBy,
   ariaDescribedBy,
   panelClassName = '',
+  backdropClassName = 'items-center justify-center bg-black/50',
   dismissOnBackdrop = true,
 }: ModalProps) {
   const dialogRef = useRef<HTMLDivElement>(null);
@@ -54,7 +63,7 @@ export function Modal({
   return createPortal(
     // biome-ignore lint/a11y/noStaticElementInteractions: overlay backdrop dismisses the dialog on click
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      className={`fixed inset-0 z-50 flex ${backdropClassName}`}
       role="presentation"
       onClick={dismissOnBackdrop ? onClose : undefined}
     >

--- a/frontend/src/components/daifugo/DaifugoRulesBadges.tsx
+++ b/frontend/src/components/daifugo/DaifugoRulesBadges.tsx
@@ -1,9 +1,8 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useBodyScrollLock } from '../../hooks/useBodyScrollLock';
 import { useIsMobile } from '../../hooks/useCardDimensions';
 import type { DaifugoResponse } from '../../types/card';
-import { getFocusableElements } from '../../utils/dom';
+import { Modal } from '../common/Modal';
 
 const badgeClass = 'inline-block rounded-[6px] px-2.5 py-0.5 mr-1.5 mb-1 text-xs font-bold';
 
@@ -89,88 +88,41 @@ function RulesBadgeModal({
   summaryLabel: string;
   closeLabel: string;
 }) {
-  const dialogRef = useRef<HTMLDivElement>(null);
-
-  useBodyScrollLock(true);
-
-  useEffect(() => {
-    const previousFocus = document.activeElement as HTMLElement;
-    const dialog = dialogRef.current as HTMLElement;
-    const focusable = getFocusableElements(dialog);
-    if (focusable.length > 0) focusable[0].focus();
-
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        onClose();
-        return;
-      }
-      // Focus trap
-      if (e.key !== 'Tab' || focusable.length === 0) return;
-      const first = focusable[0];
-      const last = focusable[focusable.length - 1];
-      if (e.shiftKey) {
-        if (document.activeElement === first) {
-          e.preventDefault();
-          last.focus();
-        }
-      } else {
-        if (document.activeElement === last) {
-          e.preventDefault();
-          first.focus();
-        }
-      }
-    };
-    document.addEventListener('keydown', handleKeyDown);
-    return () => {
-      document.removeEventListener('keydown', handleKeyDown);
-      previousFocus?.focus();
-    };
-  }, [onClose]);
-
   return (
-    // biome-ignore lint/a11y/noStaticElementInteractions: overlay backdrop dismisses on click
-    <div
-      className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/50"
-      onClick={onClose}
-      role="presentation"
+    <Modal
+      open
+      onClose={onClose}
+      ariaLabelledBy="rules-modal-title"
+      panelClassName="glass-panel rounded-t-lg sm:rounded-lg shadow-xl p-4 w-full sm:max-w-sm sm:mx-4 max-h-[70vh] overflow-y-auto"
+      backdropClassName="items-end sm:items-center justify-center bg-black/50"
     >
-      {/* biome-ignore lint/a11y/useKeyWithClickEvents: keyboard events handled at document level */}
-      <div
-        ref={dialogRef}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="rules-modal-title"
-        className="glass-panel rounded-t-lg sm:rounded-lg shadow-xl p-4 w-full sm:max-w-sm sm:mx-4 max-h-[70vh] overflow-y-auto"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div className="flex justify-between items-center mb-3">
-          <h2 id="rules-modal-title" className="text-sm font-bold text-ds-text-primary">
-            {summaryLabel}
-          </h2>
-          <button
-            type="button"
-            onClick={onClose}
-            className="text-ds-text-primary/60 hover:text-ds-text-primary text-lg leading-none"
-            aria-label={closeLabel}
-          >
-            ✕
-          </button>
-        </div>
-        <ul className="space-y-2">
-          {badges.map((b) => (
-            <li key={b.label} className="flex items-start gap-2">
-              <span
-                className="shrink-0 rounded px-2 py-0.5 text-xs font-bold"
-                style={{ background: b.bg, color: b.color }}
-              >
-                {b.label}
-              </span>
-              <span className="text-xs text-ds-text-primary/80">{b.description}</span>
-            </li>
-          ))}
-        </ul>
+      <div className="flex justify-between items-center mb-3">
+        <h2 id="rules-modal-title" className="text-sm font-bold text-ds-text-primary">
+          {summaryLabel}
+        </h2>
+        <button
+          type="button"
+          onClick={onClose}
+          className="text-ds-text-primary/60 hover:text-ds-text-primary text-lg leading-none"
+          aria-label={closeLabel}
+        >
+          ✕
+        </button>
       </div>
-    </div>
+      <ul className="space-y-2">
+        {badges.map((b) => (
+          <li key={b.label} className="flex items-start gap-2">
+            <span
+              className="shrink-0 rounded px-2 py-0.5 text-xs font-bold"
+              style={{ background: b.bg, color: b.color }}
+            >
+              {b.label}
+            </span>
+            <span className="text-xs text-ds-text-primary/80">{b.description}</span>
+          </li>
+        ))}
+      </ul>
+    </Modal>
   );
 }
 

--- a/frontend/src/components/tutorial/TutorialSuggestDialog.tsx
+++ b/frontend/src/components/tutorial/TutorialSuggestDialog.tsx
@@ -1,8 +1,6 @@
-import { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useBodyScrollLock } from '../../hooks/useBodyScrollLock';
 import { btnPrimary, btnSecondary } from '../../styles/buttonStyles';
-import { getFocusableElements } from '../../utils/dom';
+import { Modal } from '../common/Modal';
 
 /** Props for the TutorialSuggestDialog component. */
 export interface TutorialSuggestDialogProps {
@@ -27,92 +25,39 @@ export function TutorialSuggestDialog({
   onDontShowAgainChange,
 }: TutorialSuggestDialogProps) {
   const { t } = useTranslation('tutorial');
-  const dialogRef = useRef<HTMLDivElement>(null);
-  const triggerRef = useRef<Element | null>(null);
-
-  useBodyScrollLock(open);
-
-  useEffect(() => {
-    if (!open) return;
-    triggerRef.current = document.activeElement;
-
-    const dialog = dialogRef.current as HTMLElement;
-    const focusable = getFocusableElements(dialog);
-    if (focusable.length > 0) focusable[0].focus();
-
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key !== 'Tab') return;
-      const elements = getFocusableElements(dialog);
-      if (elements.length === 0) return;
-      const first = elements[0];
-      const last = elements[elements.length - 1];
-      if (e.shiftKey) {
-        if (document.activeElement === first) {
-          e.preventDefault();
-          last.focus();
-        }
-      } else {
-        if (document.activeElement === last) {
-          e.preventDefault();
-          first.focus();
-        }
-      }
-    };
-
-    dialog.addEventListener('keydown', handleKeyDown);
-    return () => {
-      dialog.removeEventListener('keydown', handleKeyDown);
-      if (triggerRef.current instanceof HTMLElement) {
-        triggerRef.current.focus();
-      }
-    };
-  }, [open]);
-
-  if (!open) return null;
-
   return (
-    // biome-ignore lint/a11y/noStaticElementInteractions: overlay backdrop dismisses dialog on click
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm"
-      onClick={onSkip}
-      role="presentation"
+    <Modal
+      open={open}
+      onClose={onSkip}
+      role="alertdialog"
+      ariaLabelledBy="suggest-dialog-title"
+      ariaDescribedBy="suggest-dialog-desc"
+      panelClassName="glass-panel rounded-lg shadow-xl p-6 max-w-sm mx-4"
+      backdropClassName="items-center justify-center bg-black/80 backdrop-blur-sm"
     >
-      <div
-        ref={dialogRef}
-        role="alertdialog"
-        aria-modal="true"
-        aria-labelledby="suggest-dialog-title"
-        aria-describedby="suggest-dialog-desc"
-        className="glass-panel rounded-lg shadow-xl p-6 max-w-sm mx-4"
-        onClick={(e) => e.stopPropagation()}
-        onKeyDown={(e) => {
-          if (e.key === 'Escape') onSkip();
-        }}
-      >
-        <h2 id="suggest-dialog-title" className="text-lg font-bold text-ds-text-primary mb-2">
-          {t('firstVisit.title')}
-        </h2>
-        <p id="suggest-dialog-desc" className="text-ds-text-primary mb-4">
-          {t('firstVisit.message')}
-        </p>
-        <label className="flex items-center gap-2 text-sm text-ds-text-muted mb-4 cursor-pointer min-h-[44px]">
-          <input
-            type="checkbox"
-            checked={dontShowAgain}
-            onChange={(e) => onDontShowAgainChange(e.target.checked)}
-            className="rounded"
-          />
-          {t('firstVisit.dontShowAgain')}
-        </label>
-        <div className="flex justify-end gap-2">
-          <button type="button" className={btnSecondary} onClick={onSkip}>
-            {t('firstVisit.skip')}
-          </button>
-          <button type="button" className={btnPrimary} onClick={onStartTutorial}>
-            {t('firstVisit.start')}
-          </button>
-        </div>
+      <h2 id="suggest-dialog-title" className="text-lg font-bold text-ds-text-primary mb-2">
+        {t('firstVisit.title')}
+      </h2>
+      <p id="suggest-dialog-desc" className="text-ds-text-primary mb-4">
+        {t('firstVisit.message')}
+      </p>
+      <label className="flex items-center gap-2 text-sm text-ds-text-muted mb-4 cursor-pointer min-h-[44px]">
+        <input
+          type="checkbox"
+          checked={dontShowAgain}
+          onChange={(e) => onDontShowAgainChange(e.target.checked)}
+          className="rounded"
+        />
+        {t('firstVisit.dontShowAgain')}
+      </label>
+      <div className="flex justify-end gap-2">
+        <button type="button" className={btnSecondary} onClick={onSkip}>
+          {t('firstVisit.skip')}
+        </button>
+        <button type="button" className={btnPrimary} onClick={onStartTutorial}>
+          {t('firstVisit.start')}
+        </button>
       </div>
-    </div>
+    </Modal>
   );
 }

--- a/frontend/src/hooks/useFocusTrap.test.ts
+++ b/frontend/src/hooks/useFocusTrap.test.ts
@@ -98,4 +98,73 @@ describe('useFocusTrap', () => {
     expect(onClose).not.toHaveBeenCalled();
     cleanup();
   });
+  // Non-modal panels (a landmark `role="region"`, say) still want the open /
+  // Escape / restore half of this hook, but cycling Tab inside them is a
+  // WCAG 2.1.2 keyboard trap. `trap: false` keeps everything except the
+  // cycling. See issues #5182 and #5183.
+  describe('trap: false', () => {
+    it('does not cycle Tab at either boundary', () => {
+      const { ref, cleanup } = mountContainer(2);
+      renderHook(() => useFocusTrap(ref, true, () => {}, { trap: false }));
+      const [first, last] = Array.from(ref.current.querySelectorAll('button'));
+
+      last.focus();
+      const fwd = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true });
+      const fwdSpy = vi.spyOn(fwd, 'preventDefault');
+      act(() => {
+        document.dispatchEvent(fwd);
+      });
+      expect(fwdSpy).not.toHaveBeenCalled();
+      expect(document.activeElement).toBe(last);
+
+      first.focus();
+      const back = new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true, bubbles: true });
+      const backSpy = vi.spyOn(back, 'preventDefault');
+      act(() => {
+        document.dispatchEvent(back);
+      });
+      expect(backSpy).not.toHaveBeenCalled();
+      expect(document.activeElement).toBe(first);
+
+      cleanup();
+    });
+
+    it('still focuses on open, closes on Escape, and restores on close', () => {
+      const outside = document.createElement('button');
+      document.body.appendChild(outside);
+      outside.focus();
+
+      const { ref, cleanup } = mountContainer(2);
+      const onClose = vi.fn();
+      const { unmount } = renderHook(() => useFocusTrap(ref, true, onClose, { trap: false }));
+
+      expect(document.activeElement).toBe(ref.current.querySelector('button'));
+
+      act(() => {
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+      });
+      expect(onClose).toHaveBeenCalledTimes(1);
+
+      unmount();
+      expect(document.activeElement).toBe(outside);
+
+      outside.remove();
+      cleanup();
+    });
+  });
+
+  // Negative control: the default must still trap, or `trap: false` proves nothing.
+  it('traps by default when no options are passed', () => {
+    const { ref, cleanup } = mountContainer(2);
+    renderHook(() => useFocusTrap(ref, true, () => {}));
+    const [first, last] = Array.from(ref.current.querySelectorAll('button'));
+
+    last.focus();
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }));
+    });
+    expect(document.activeElement).toBe(first);
+
+    cleanup();
+  });
 });

--- a/frontend/src/hooks/useFocusTrap.ts
+++ b/frontend/src/hooks/useFocusTrap.ts
@@ -13,7 +13,24 @@ import { getFocusableElements } from '../utils/dom';
  * wired in the shared `Modal` component) so this hook stays focus-only and
  * reusable by dialogs that manage their own overlay.
  */
-export function useFocusTrap(containerRef: RefObject<HTMLElement | null>, open: boolean, onClose: () => void): void {
+export interface FocusTrapOptions {
+  /**
+   * Cycle Tab within the container. Defaults to true.
+   *
+   * Pass false for a non-modal panel — a landmark `role="region"` with the page
+   * behind it still live. Cycling Tab there is a WCAG 2.1.2 keyboard trap, but
+   * the rest of this hook (focus on open, Escape, restore on close) is still
+   * wanted. See issues #5182 and #5183.
+   */
+  trap?: boolean;
+}
+
+export function useFocusTrap(
+  containerRef: RefObject<HTMLElement | null>,
+  open: boolean,
+  onClose: () => void,
+  { trap = true }: FocusTrapOptions = {},
+): void {
   const triggerRef = useRef<Element | null>(null);
   // Keep the latest onClose without re-running the trap effect when a parent
   // passes a new inline callback each render.
@@ -28,15 +45,19 @@ export function useFocusTrap(containerRef: RefObject<HTMLElement | null>, open: 
     // Focus the first focusable child, or the container itself (if it is
     // programmatically focusable, e.g. has tabIndex={-1}) when it has none — so
     // a content-less modal still traps focus rather than leaving it in the page.
+    // That fallback exists for the trap, so it does not apply without one: a
+    // non-modal panel with nothing focusable should leave focus where it is
+    // rather than pull it onto a container the user cannot Tab out of usefully.
     const focusable = getFocusableElements(container);
-    (focusable[0] ?? container).focus();
+    const target = focusable[0] ?? (trap ? container : null);
+    target?.focus();
 
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
         onCloseRef.current();
         return;
       }
-      if (e.key !== 'Tab') return;
+      if (e.key !== 'Tab' || !trap) return;
       const items = getFocusableElements(container);
       if (items.length === 0) return;
       const first = items[0];
@@ -61,5 +82,5 @@ export function useFocusTrap(containerRef: RefObject<HTMLElement | null>, open: 
         triggerRef.current.focus();
       }
     };
-  }, [open, containerRef]);
+  }, [open, containerRef, trap]);
 }


### PR DESCRIPTION
## 概要

[#4312](https://github.com/yuta-yoshinaga/go_trumpcards/issues/4312) が8つのダイアログを `common/Modal` + `useFocusTrap` に統合しましたが、**4つが自前コピーを保持し、いずれも同じ2点で正典から乖離**していました。

- 正典にある「フォーカスが外に出たら引き戻す」ガード（`!container.contains(document.activeElement)`）が**全コピーで欠落**
- うち3つは keydown リスナーを `document` ではなく**ダイアログ要素**に登録。フォーカスが外に出た瞬間にリスナーが呼ばれなくなり、**トラップが恒久的に死ぬ**

**4つとも「フォーカストラップ」のテストを持っていて、全部通っていました。**

`TutorialOverlay` と `ActionLogPanel` は #5191 / #5190 で対応済みなので、本 PR は残り2つと、再発防止のガードです。

## 変更内容

**`TutorialSuggestDialog` / `daifugo/RulesBadgeModal` を `<Modal>` へ** — あわせて両者に無かった **portal**（クリッピング祖先からの脱出）も得られます。

**`ActionLogPanel` の自前 effect を削除** — #5190 で残っていた「`useFocusTrap` から Tab 循環だけを抜いたもの」を、フック本体のオプションに置き換えました。

**`useFocusTrap` に `{ trap: false }` を追加** — ランドマーク `role="region"` はフォーカス移動・Escape・復帰は欲しいが、Tab 循環は WCAG 2.1.2 のキーボードトラップ（#5183）。**オプションが無いと選択肢が「自前コピー」しか無く、それがこの問題の始まりでした。** コンテナへのフォールバックフォーカスも `trap: false` では行いません（あれは「中身が空のモーダルでもトラップを維持する」ための挙動で、トラップが無いなら維持するものがない）。

## 視覚的変更を出さないための追加（重要）

`<Modal>` への移行で**2つのデザインが黙って変わるところでした**。テストが検出しました。

| ダイアログ | 元の見た目 | `Modal` の既定 |
|---|---|---|
| 初回訪問ダイアログ | `bg-black/80 backdrop-blur-sm` | `bg-black/50`（ブラー無し） |
| 大富豪ルールモーダル | `items-end sm:items-center`（**モバイルはボトムシート**） | `items-center` 固定 |

`backdropClassName` を追加し、パネルの配置クラスもそちらへ移して上書き可能にしました。**DESIGN.md の指示どおり、承認なくビジュアルは変更していません。**

## ガード: `check-modal-focus-trap.mjs`

ルールを構造的にしました — **`aria-modal` を宣言するなら、フォーカス処理はフックか共有コンポーネントから得ること。**

- **コメントを空白化してから走査します。** `ActionLogPanel` は「なぜ `aria-modal` を持たないか」をコメントで説明しており、素の部分文字列検索だとそれを違反として拾います（実際に踏みました）
- 非モーダルのパネルは**構造的に対象外**。`aria-modal` を宣言しないので見ません。つまり「モーダルを名乗るならトラップせよ」であって「どこでもトラップせよ」ではありません
- `assertFloor('modal-focus-trap', n, 2, ...)` — 走査が壊れたときに黙って通過しないため

## テスト計画

- [x] `useFocusTrap` の `trap: false`: **両境界で `preventDefault` が呼ばれない**こと、フォーカス移動・Escape・復帰は従来どおり動くこと
- [x] **負のコントロール**: オプション未指定なら従来どおりトラップすること（これが無いと `trap:false` のテストは何も証明しない）
- [x] ガードのテスト6本 — 受理2種（フック使用 / `<Modal>` 委譲）、**拒否1種**、**コメントのみの誤検出**、**空の走査で落ちる**、テストファイル除外
- [x] **実ソースでの負のコントロール**: `TutorialOverlay` から `useFocusTrap` を一時的に外すとガードが exit 1（クリーン時は exit 0）を実測
- [x] 影響範囲の全スイート → 262 passed（daifugo / tutorial / common / ActionLog* / useFocusTrap / ConfirmDialog）
- [x] `bun run check`（Biome + 15ガード）通過。`guard-floors` が新ガードを受理（14 scripts, 25 floors）
- [x] `bun run typecheck`（TypeScript 7）通過

Closes #5182