### PR TITLE
refactor(cli): move the 263 game registrations onto BindCuiFor

### DIFF
--- a/internal/infrastructure/ui/GameManager.go
+++ b/internal/infrastructure/ui/GameManager.go
@@ -34,6 +34,38 @@ func cuiEntry(ctrl CuiExecer, spec CuiHelpSpec) cuiGame {
 	return newCuiGame(ctrl, BuildCuiHelp(spec))
 }
 
+// BindCuiFor assembles one gameRegistry entry, giving the CLI the same
+// registration shape the other four registration points already use:
+// games_server.go has BindWebControllerFor and the per-category worker packages
+// have RegisterKVGame, while this one was still hand-writing the nested
+// constructors internal/CLAUDE.md tells you not to write.
+//
+// Two type parameters, not one: interactor constructors return a concrete type
+// (*BlackJackInteractor) while CUI controller constructors take the interface
+// (BlackJackInteractorIF), and Go function types are not covariant in their
+// results. Constraining C by CuiExecer rather than returning it lets a
+// controller constructor be passed by name. newInteractor must still be an
+// interface-annotated closure for the same reason — which is why
+// BindWebControllerFor's call sites look the way they do.
+//
+// newInteractor is called inside the NewCui closure, never here: gameRegistry is
+// a package-level var, so building interactors eagerly would construct all 264
+// games' domain state at process start instead of when one is played.
+// See issue #5187.
+func BindCuiFor[I any, C CuiExecer](
+	name string,
+	newInteractor func() I,
+	newCtrl func(I) C,
+	spec CuiHelpSpec,
+) GameRegistryEntry {
+	return GameRegistryEntry{
+		Name: name,
+		NewCui: func() cuiGame {
+			return cuiEntry(newCtrl(newInteractor()), spec)
+		},
+	}
+}
+
 // Shared poker-family help keys live here so a label change (e.g. renaming
 // "small blind" wording) updates every entry that uses them. See issue #1511.
 var (

--- a/internal/infrastructure/ui/GameManager.go
+++ b/internal/infrastructure/ui/GameManager.go
@@ -114,4120 +114,4120 @@ var (
 // — this slice only holds the CLI-specific NewCui factory. Order mirrors the
 // games registry; drift is enforced by TestRegistryMatchesCLI.
 var gameRegistry = []GameRegistryEntry{
-	{Name: "blackjack", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewBlackJackCuiController(usecase.NewBlackJackInteractor(
-				domain.NewDefaultBlackJack(), new(presenter.BlackJackCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "blackjack.helpTitle",
-				CommandKeys: []string{
-					"blackjack.helpBet",
-					"blackjack.helpHit",
-					"blackjack.helpStand",
-					"blackjack.helpDouble",
-					"blackjack.helpSplit",
-					"blackjack.helpInsurance",
-					"blackjack.helpDeclineInsurance",
-				},
-				SettingKeys: []string{"blackjack.helpSetCpuCount"},
-			})
-	}},
-	{Name: "poker", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewPokerCuiController(usecase.NewPokerInteractor(
-				domain.NewDefaultPoker(), new(presenter.PokerCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "poker.helpTitle",
-				CommandKeys: []string{
-					"poker.helpBet",
-					"poker.helpCall",
-					"poker.helpRaise",
-					"poker.helpCheck",
-					"poker.helpFold",
-					"poker.helpAllIn",
-					"poker.helpExchange",
-					"poker.helpStand",
-				},
-				SettingKeys: []string{"poker.helpBettingLimit", "poker.helpLowball"},
-			})
-	}},
-	{Name: "oldmaid", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewOldMaidCuiController(usecase.NewOldMaidInteractor(
-				domain.NewDefaultOldMaid(), new(presenter.OldMaidCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:    "oldmaid.helpTitle",
-				CommandKeys: []string{"oldmaid.helpDraw", "oldmaid.helpShuffle", "oldmaid.helpReorder"},
-				SettingKeys: []string{"oldmaid.helpSetMode", "oldmaid.helpSetPlacement", "oldmaid.helpSetMemoryAI"},
-			})
-	}},
-	{Name: "daifugo", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewDaifugoCuiController(usecase.NewDaifugoInteractor(
-				domain.NewDefaultDaifugo(), new(presenter.DaifugoCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:    "daifugo.helpTitle",
-				CommandKeys: []string{"daifugo.helpPlay", "daifugo.helpSort"},
-				SettingKeys: []string{"daifugo.helpSetDifficulty", "daifugo.helpSetJoker", "daifugo.helpSetRule"},
-			})
-	}},
-	{Name: "bigtwo", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewBigTwoCuiController(usecase.NewBigTwoInteractor(
-				domain.NewDefaultBigTwo(), new(presenter.BigTwoCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:    "bigtwo.helpTitle",
-				CommandKeys: []string{"bigtwo.helpPlay"},
-				SettingKeys: []string{"bigtwo.helpSetDifficulty"},
-			})
-	}},
-	{Name: "sevens", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewSevensCuiController(usecase.NewSevensInteractor(
-				domain.NewDefaultSevens(), new(presenter.SevensCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:      "sevens.helpTitle",
-				CommandKeys:   []string{"sevens.helpPlay"},
-				ResetOverride: "  r [tunnel] [joker=N] [strategy] [passes=N]  reset with options",
-			})
-	}},
+	BindCuiFor("blackjack",
+		func() usecase.BlackJackInteractorIF {
+			return usecase.NewBlackJackInteractor(domain.NewDefaultBlackJack(), new(presenter.BlackJackCuiPresenter))
+		},
+		controller.NewBlackJackCuiController,
+		CuiHelpSpec{
+			TitleKey: "blackjack.helpTitle",
+			CommandKeys: []string{
+				"blackjack.helpBet",
+				"blackjack.helpHit",
+				"blackjack.helpStand",
+				"blackjack.helpDouble",
+				"blackjack.helpSplit",
+				"blackjack.helpInsurance",
+				"blackjack.helpDeclineInsurance",
+			},
+			SettingKeys: []string{"blackjack.helpSetCpuCount"},
+		}),
+	BindCuiFor("poker",
+		func() usecase.PokerInteractorIF {
+			return usecase.NewPokerInteractor(domain.NewDefaultPoker(), new(presenter.PokerCuiPresenter))
+		},
+		controller.NewPokerCuiController,
+		CuiHelpSpec{
+			TitleKey: "poker.helpTitle",
+			CommandKeys: []string{
+				"poker.helpBet",
+				"poker.helpCall",
+				"poker.helpRaise",
+				"poker.helpCheck",
+				"poker.helpFold",
+				"poker.helpAllIn",
+				"poker.helpExchange",
+				"poker.helpStand",
+			},
+			SettingKeys: []string{"poker.helpBettingLimit", "poker.helpLowball"},
+		}),
+	BindCuiFor("oldmaid",
+		func() usecase.OldMaidInteractorIF {
+			return usecase.NewOldMaidInteractor(domain.NewDefaultOldMaid(), new(presenter.OldMaidCuiPresenter))
+		},
+		controller.NewOldMaidCuiController,
+		CuiHelpSpec{
+			TitleKey:    "oldmaid.helpTitle",
+			CommandKeys: []string{"oldmaid.helpDraw", "oldmaid.helpShuffle", "oldmaid.helpReorder"},
+			SettingKeys: []string{"oldmaid.helpSetMode", "oldmaid.helpSetPlacement", "oldmaid.helpSetMemoryAI"},
+		}),
+	BindCuiFor("daifugo",
+		func() usecase.DaifugoInteractorIF {
+			return usecase.NewDaifugoInteractor(domain.NewDefaultDaifugo(), new(presenter.DaifugoCuiPresenter))
+		},
+		controller.NewDaifugoCuiController,
+		CuiHelpSpec{
+			TitleKey:    "daifugo.helpTitle",
+			CommandKeys: []string{"daifugo.helpPlay", "daifugo.helpSort"},
+			SettingKeys: []string{"daifugo.helpSetDifficulty", "daifugo.helpSetJoker", "daifugo.helpSetRule"},
+		}),
+	BindCuiFor("bigtwo",
+		func() usecase.BigTwoInteractorIF {
+			return usecase.NewBigTwoInteractor(domain.NewDefaultBigTwo(), new(presenter.BigTwoCuiPresenter))
+		},
+		controller.NewBigTwoCuiController,
+		CuiHelpSpec{
+			TitleKey:    "bigtwo.helpTitle",
+			CommandKeys: []string{"bigtwo.helpPlay"},
+			SettingKeys: []string{"bigtwo.helpSetDifficulty"},
+		}),
+	BindCuiFor("sevens",
+		func() usecase.SevensInteractorIF {
+			return usecase.NewSevensInteractor(domain.NewDefaultSevens(), new(presenter.SevensCuiPresenter))
+		},
+		controller.NewSevensCuiController,
+		CuiHelpSpec{
+			TitleKey:      "sevens.helpTitle",
+			CommandKeys:   []string{"sevens.helpPlay"},
+			ResetOverride: "  r [tunnel] [joker=N] [strategy] [passes=N]  reset with options",
+		}),
 	{Name: "doubt", NewCui: func() cuiGame { return NewDoubtCui() }},
-	{Name: "holdem", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewHoldemCuiController(usecase.NewHoldemInteractor(
-				domain.NewDefaultHoldem(), new(presenter.HoldemCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "holdem.helpTitle",
-				CommandKeys: append([]string{
-					"holdem.helpFold",
-					"holdem.helpCheck",
-					"holdem.helpCall",
-					"holdem.helpBet",
-					"holdem.helpRaise",
-					"holdem.helpAllIn",
-				}, tournamentRebuyAddOnKeys...),
-				SettingKeys: append([]string{
-					"holdem.helpBettingLimit", "holdem.helpTournament",
-				}, holdemBlindKeys...),
-			})
-	}},
-	{Name: "omaha", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewOmahaCuiController(usecase.NewOmahaInteractor(
-				domain.NewDefaultOmaha(), new(presenter.OmahaCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "omaha.helpTitle",
-				CommandKeys: append([]string{
-					"omaha.helpFold",
-					"omaha.helpCheck",
-					"omaha.helpCall",
-					"omaha.helpBet",
-					"omaha.helpRaise",
-					"omaha.helpAllIn",
-				}, tournamentRebuyAddOnKeys...),
-				SettingKeys: append([]string{
-					"omaha.helpBettingLimit", "omaha.helpTournament",
-				}, holdemBlindKeys...),
-			})
-	}},
-	{Name: "omahahilo", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewOmahaCuiController(usecase.NewOmahaInteractor(
-				domain.NewDefaultOmahaHiLo(), new(presenter.OmahaCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "omahahilo.helpTitle",
-				CommandKeys: append([]string{
-					"omaha.helpFold",
-					"omaha.helpCheck",
-					"omaha.helpCall",
-					"omaha.helpBet",
-					"omaha.helpRaise",
-					"omaha.helpAllIn",
-				}, tournamentRebuyAddOnKeys...),
-				SettingKeys: append([]string{
-					"omaha.helpBettingLimit", "omaha.helpTournament",
-				}, holdemBlindKeys...),
-			})
-	}},
-	{Name: "bigo", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewOmahaCuiController(usecase.NewOmahaInteractor(
-				domain.NewDefaultBigO(), new(presenter.OmahaCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "omaha.helpTitleBigO",
-				CommandKeys: append([]string{
-					"omaha.helpFold",
-					"omaha.helpCheck",
-					"omaha.helpCall",
-					"omaha.helpBet",
-					"omaha.helpRaise",
-					"omaha.helpAllIn",
-				}, tournamentRebuyAddOnKeys...),
-				SettingKeys: append([]string{
-					"omaha.helpBettingLimit", "omaha.helpTournament",
-				}, holdemBlindKeys...),
-			})
-	}},
-	{Name: "bigohilo", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewOmahaCuiController(usecase.NewOmahaInteractor(
-				domain.NewDefaultBigOHiLo(), new(presenter.OmahaCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "omaha.helpTitleBigOHiLo",
-				CommandKeys: append([]string{
-					"omaha.helpFold",
-					"omaha.helpCheck",
-					"omaha.helpCall",
-					"omaha.helpBet",
-					"omaha.helpRaise",
-					"omaha.helpAllIn",
-				}, tournamentRebuyAddOnKeys...),
-				SettingKeys: append([]string{
-					"omaha.helpBettingLimit", "omaha.helpTournament",
-				}, holdemBlindKeys...),
-			})
-	}},
-	{Name: "shortdeck", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewShortDeckCuiController(usecase.NewShortDeckInteractor(
-				domain.NewDefaultShortDeck(), new(presenter.ShortDeckCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "shortdeck.helpTitle",
-				CommandKeys: append([]string{
-					"shortdeck.helpFold",
-					"shortdeck.helpCheck",
-					"shortdeck.helpCall",
-					"shortdeck.helpBet",
-					"shortdeck.helpRaise",
-					"shortdeck.helpAllIn",
-				}, tournamentRebuyAddOnKeys...),
-				SettingKeys: append([]string{
-					"shortdeck.helpBettingLimit", "shortdeck.helpTournament",
-				}, holdemBlindKeys...),
-			})
-	}},
-	{Name: "pineapple", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewPineappleCuiController(usecase.NewPineappleInteractor(
-				domain.NewDefaultPineapple(), new(presenter.PineappleCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "pineapple.helpTitle",
-				CommandKeys: append([]string{
-					"pineapple.helpFold",
-					"pineapple.helpCheck",
-					"pineapple.helpCall",
-					"pineapple.helpBet",
-					"pineapple.helpRaise",
-					"pineapple.helpAllIn",
-				}, pineappleRebuyAddOnKeys...),
-				SettingKeys: append([]string{
-					"pineapple.helpBettingLimit", "pineapple.helpTournament",
-				}, holdemBlindKeys...),
-			})
-	}},
-	{Name: "crazypineapple", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewPineappleCuiController(usecase.NewPineappleInteractor(
-				domain.NewDefaultCrazyPineapple(), new(presenter.PineappleCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "crazypineapple.helpTitle",
-				CommandKeys: append([]string{
-					"crazypineapple.helpFold",
-					"crazypineapple.helpCheck",
-					"crazypineapple.helpCall",
-					"crazypineapple.helpBet",
-					"crazypineapple.helpRaise",
-					"crazypineapple.helpAllIn",
-				}, pineappleRebuyAddOnKeys...),
-				SettingKeys: append([]string{
-					"crazypineapple.helpBettingLimit", "crazypineapple.helpTournament",
-				}, holdemBlindKeys...),
-			})
-	}},
-	{Name: "irishpoker", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewPineappleCuiController(usecase.NewPineappleInteractor(
-				domain.NewDefaultIrishPoker(), new(presenter.PineappleCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "irishpoker.helpTitle",
-				CommandKeys: append([]string{
-					"irishpoker.helpFold",
-					"irishpoker.helpCheck",
-					"irishpoker.helpCall",
-					"irishpoker.helpBet",
-					"irishpoker.helpRaise",
-					"irishpoker.helpAllIn",
-				}, pineappleRebuyAddOnKeys...),
-				SettingKeys: append([]string{
-					"irishpoker.helpBettingLimit", "irishpoker.helpTournament",
-				}, holdemBlindKeys...),
-			})
-	}},
-	{Name: "hearts", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewHeartsCuiController(usecase.NewHeartsInteractor(
-				domain.NewDefaultHearts(), new(presenter.HeartsCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:          "hearts.helpTitle",
-				CommandKeys:       []string{"hearts.helpPass", "hearts.helpPlay", "hearts.helpNext", "hearts.helpNextRound"},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"hearts.helpSetDifficulty", "hearts.helpSetLimit"},
-			})
-	}},
-	{Name: "memory", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewMemoryCuiController(usecase.NewMemoryInteractor(
-				domain.NewDefaultMemory(), new(presenter.MemoryCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:          "memory.helpTitle",
-				CommandKeys:       []string{"memory.helpFlip", "memory.helpNext"},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"memory.helpSetDifficulty"},
-			})
-	}},
-	{Name: "klondike", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewKlondikeCuiController(usecase.NewKlondikeInteractor(
-				domain.NewDefaultKlondike(), new(presenter.KlondikeCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "klondike.helpTitle",
-				CommandKeys: []string{
-					"klondike.helpDraw",
-					"klondike.helpMove",
-					"klondike.helpMoveWF",
-					"klondike.helpMoveTF",
-					"klondike.helpMoveTT",
-					"klondike.helpGiveUp",
-					"klondike.helpHint",
-					"klondike.helpAutoComplete",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "freecell", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewFreeCellCuiController(usecase.NewFreeCellInteractor(
-				domain.NewDefaultFreeCell(), new(presenter.FreeCellCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "freecell.helpTitle",
-				CommandKeys: []string{
-					"freecell.helpMove",
-					"freecell.helpMoveTF",
-					"freecell.helpMoveTT",
-					"freecell.helpMoveTC",
-					"freecell.helpMoveCT",
-					"freecell.helpMoveCF",
-					"freecell.helpGiveUp",
-					"freecell.helpHint",
-					"freecell.helpAutoComplete",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "seahaventowers", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewSeahavenTowersCuiController(usecase.NewSeahavenTowersInteractor(
-				domain.NewDefaultSeahavenTowers(), new(presenter.SeahavenTowersCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "seahaventowers.helpTitle",
-				CommandKeys: []string{
-					"seahaventowers.helpMove",
-					"seahaventowers.helpMoveTF",
-					"seahaventowers.helpMoveTT",
-					"seahaventowers.helpMoveTC",
-					"seahaventowers.helpMoveCT",
-					"seahaventowers.helpMoveCF",
-					"seahaventowers.helpGiveUp",
-					"seahaventowers.helpHint",
-					"seahaventowers.helpAutoComplete",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "cruel", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewCruelCuiController(usecase.NewCruelInteractor(
-				domain.NewDefaultCruel(), new(presenter.CruelCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "cruel.helpTitle",
-				CommandKeys: []string{
-					"cruel.helpMove",
-					"cruel.helpMoveTF",
-					"cruel.helpShift",
-					"cruel.helpGiveUp",
-					"cruel.helpHint",
-					"cruel.helpAutoComplete",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "baccarat", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewBaccaratCuiController(usecase.NewBaccaratInteractor(
-				domain.NewDefaultBaccarat(), new(presenter.BaccaratCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:    "baccarat.helpTitle",
-				CommandKeys: []string{"baccarat.helpBet"},
-				ExtraCommandLines: []string{
-					"  log                  action log",
-					"  ch                   clear history",
-				},
-			})
-	}},
-	{Name: "spades", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewSpadesCuiController(usecase.NewSpadesInteractor(
-				domain.NewDefaultSpades(), new(presenter.SpadesCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:          "spades.helpTitle",
-				CommandKeys:       []string{"spades.helpBid", "spades.helpPlay", "spades.helpNext", "spades.helpNextRound"},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"spades.helpSetDifficulty", "spades.helpSetLimit"},
-			})
-	}},
-	{Name: "crazyeights", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewCrazyEightsCuiController(usecase.NewCrazyEightsInteractor(
-				domain.NewDefaultCrazyEights(), new(presenter.CrazyEightsCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:          "crazyeights.helpTitle",
-				CommandKeys:       []string{"crazyeights.helpPlay", "crazyeights.helpDraw", "crazyeights.helpSuit", "crazyeights.helpNextRound"},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"crazyeights.helpSetDifficulty", "crazyeights.helpSetLimit"},
-			})
-	}},
-	{Name: "ginrummy", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewGinRummyCuiController(usecase.NewGinRummyInteractor(
-				domain.NewDefaultGinRummy(), new(presenter.GinRummyCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "ginrummy.helpTitle",
-				CommandKeys: []string{
-					"ginrummy.helpDrawStock",
-					"ginrummy.helpDrawDiscard",
-					"ginrummy.helpDiscard",
-					"ginrummy.helpKnock",
-					"ginrummy.helpLayoff",
-					"ginrummy.helpNextRound",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"ginrummy.helpSetDifficulty", "ginrummy.helpSetLimit"},
-			})
-	}},
-	{Name: "indianrummy", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewIndianRummyCuiController(usecase.NewIndianRummyInteractor(
-				domain.NewDefaultIndianRummy(), new(presenter.IndianRummyCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "indianrummy.helpTitle",
-				CommandKeys: []string{
-					"indianrummy.helpDrawStock",
-					"indianrummy.helpDrawDiscard",
-					"indianrummy.helpDiscard",
-					"indianrummy.helpDeclare",
-					"indianrummy.helpNextRound",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"indianrummy.helpSetPlayers", "indianrummy.helpSetDifficulty", "indianrummy.helpSetRounds"},
-			})
-	}},
-	{Name: "canasta", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewCanastaCuiController(usecase.NewCanastaInteractor(
-				domain.NewDefaultCanasta(), new(presenter.CanastaCuiPresenter))),
-			CuiHelpSpec{Body: []string{
-				"Canasta (カナスタ) Help",
-				"",
-				"Game Commands:",
-				"  ds                   draw from stock",
-				"  dd <idx,idx>         pick up discard pile (natural pair indices)",
-				"  m <idx,idx;idx,idx>  meld (semicolon-separated groups)",
-				"  sm                   skip meld phase",
-				"  d <idx>              discard a card",
-				"  go                   go out (requires canasta)",
-				"  nr                   next round",
-				"  l                    action log",
-				"",
-				"Settings:",
-				"  sd <0-2>             set CPU difficulty (0=Easy, 1=Normal, 2=Hard)",
-				"  sl <n>               set point limit",
-				"",
-				"Session:",
-				"  r / reset            reset game",
-				"  q / quit             quit",
-				"  ? / help             show help",
-			}})
-	}},
-	{Name: "spider", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewSpiderCuiController(usecase.NewSpiderInteractor(
-				domain.NewDefaultSpider(), new(presenter.SpiderCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "spider.helpTitle",
-				CommandKeys: []string{
-					"spider.helpDeal",
-					"spider.helpMove",
-					"spider.helpGiveUp",
-					"spider.helpHint",
-					"spider.helpAutoComplete",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "napoleon", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewNapoleonCuiController(usecase.NewNapoleonInteractor(
-				domain.NewDefaultNapoleon(), new(presenter.NapoleonCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "napoleon.helpTitle",
-				CommandKeys: []string{
-					"napoleon.helpBid",
-					"napoleon.helpTrump",
-					"napoleon.helpExchange",
-					"napoleon.helpPlay",
-					"napoleon.helpNext",
-					"napoleon.helpNextRound",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"napoleon.helpSetDifficulty", "napoleon.helpSetLimit", "napoleon.helpSetMinBid"},
-			})
-	}},
-	{Name: "indianpoker", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewIndianPokerCuiController(usecase.NewIndianPokerInteractor(
-				domain.NewDefaultIndianPoker(), new(presenter.IndianPokerCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "indianpoker.helpTitle",
-				CommandKeys: []string{
-					"indianpoker.helpFold",
-					"indianpoker.helpCheck",
-					"indianpoker.helpCall",
-					"indianpoker.helpBet",
-					"indianpoker.helpRaise",
-					"indianpoker.helpAllIn",
-				},
-				SettingKeys: []string{"indianpoker.helpAnte", "indianpoker.helpBettingLimit", "indianpoker.helpMetaAI"},
-			})
-	}},
-	{Name: "videopoker", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewVideoPokerCuiController(usecase.NewVideoPokerInteractor(
-				domain.NewDefaultVideoPoker(), new(presenter.VideoPokerCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:          "videopoker.helpTitle",
-				CommandKeys:       []string{"videopoker.helpBet", "videopoker.helpHold", "videopoker.helpHint"},
-				ExtraCommandLines: []string{"  log                  action log"},
-			})
-	}},
-	{Name: "deuceswild", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewVideoPokerCuiController(usecase.NewVideoPokerInteractor(
-				domain.NewDeucesWildVideoPoker(), new(presenter.VideoPokerCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:          "deuceswild.helpTitle",
-				CommandKeys:       []string{"videopoker.helpBet", "videopoker.helpHold", "videopoker.helpHint"},
-				ExtraCommandLines: []string{"  log                  action log"},
-			})
-	}},
-	{Name: "jokerpoker", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewVideoPokerCuiController(usecase.NewVideoPokerInteractor(
-				domain.NewJokerPokerVideoPoker(), new(presenter.VideoPokerCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:          "jokerpoker.helpTitle",
-				CommandKeys:       []string{"videopoker.helpBet", "videopoker.helpHold", "videopoker.helpHint"},
-				ExtraCommandLines: []string{"  log                  action log"},
-			})
-	}},
-	{Name: "euchre", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewEuchreCuiController(usecase.NewEuchreInteractor(
-				domain.NewDefaultEuchre(), new(presenter.EuchreCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "euchre.helpTitle",
-				CommandKeys: []string{
-					"euchre.helpOrderUp",
-					"euchre.helpOrderUpAlone",
-					"euchre.helpPass",
-					"euchre.helpCall",
-					"euchre.helpCallAlone",
-					"euchre.helpDiscard",
-					"euchre.helpPlay",
-					"euchre.helpNext",
-					"euchre.helpNextRound",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"euchre.helpSetDifficulty", "euchre.helpSetLimit"},
-			})
-	}},
-	{Name: "pyramid", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewPyramidCuiController(usecase.NewPyramidInteractor(
-				domain.NewDefaultPyramid(), new(presenter.PyramidCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "pyramid.helpTitle",
-				CommandKeys: []string{
-					"pyramid.helpDraw",
-					"pyramid.helpRemoveKing",
-					"pyramid.helpRemovePair",
-					"pyramid.helpRemoveWaste",
-					"pyramid.helpRemoveWasteKing",
-					"pyramid.helpGiveUp",
-					"pyramid.helpHint",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "tripeaks", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewTriPeaksCuiController(usecase.NewTriPeaksInteractor(
-				domain.NewDefaultTriPeaks(), new(presenter.TriPeaksCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "tripeaks.helpTitle",
-				CommandKeys: []string{
-					"tripeaks.helpDraw",
-					"tripeaks.helpRemove",
-					"tripeaks.helpGiveUp",
-					"tripeaks.helpHint",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "cribbage", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewCribbageCuiController(usecase.NewCribbageInteractor(
-				domain.NewDefaultCribbage(), new(presenter.CribbageCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:          "cribbage.helpTitle",
-				CommandKeys:       []string{"cribbage.helpDiscard", "cribbage.helpCut", "cribbage.helpPeg", "cribbage.helpGo", "cribbage.helpHint", "cribbage.helpShowNext", "cribbage.helpNextRound"},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"cribbage.helpSetDifficulty", "cribbage.helpSetLimit"},
-			})
-	}},
-	{Name: "threecard", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewThreeCardCuiController(usecase.NewThreeCardInteractor(
-				domain.NewDefaultThreeCard(), new(presenter.ThreeCardCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:          "threecard.helpTitle",
-				CommandKeys:       []string{"threecard.helpBet", "threecard.helpPlay", "threecard.helpFold"},
-				ExtraCommandLines: []string{"  log                  action log"},
-			})
-	}},
-	{Name: "ohhell", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewOhHellCuiController(usecase.NewOhHellInteractor(
-				domain.NewDefaultOhHell(), new(presenter.OhHellCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:          "ohhell.helpTitle",
-				CommandKeys:       []string{"ohhell.helpBid", "ohhell.helpPlay", "ohhell.helpNext", "ohhell.helpNextRound"},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"ohhell.helpSetDifficulty", "ohhell.helpSetMaxHand"},
-			})
-	}},
-	{Name: "ninetynine", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewNinetyNineCuiController(usecase.NewNinetyNineInteractor(
-				domain.NewDefaultNinetyNine(), new(presenter.NinetyNineCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:          "ninetynine.helpTitle",
-				CommandKeys:       []string{"ninetynine.helpBid", "ninetynine.helpPlay", "ninetynine.helpNext", "ninetynine.helpNextRound"},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"ninetynine.helpSetDifficulty", "ninetynine.helpSetTarget"},
-			})
-	}},
-	{Name: "bridge", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewBridgeCuiController(usecase.NewBridgeInteractor(
-				domain.NewDefaultBridge(), new(presenter.BridgeCuiPresenter))),
-			CuiHelpSpec{Body: []string{
-				"=== Contract Bridge ===",
-				"",
-				"Game Commands:",
-				"  b <type> <level> <suit>  bid (type: 0=pass,1=bid,2=dbl,3=rdbl; level: 1-7; suit: 1-5)",
-				"  p <index>                play a card",
-				"  n                        next trick",
-				"  nr                       next round (score & proceed)",
-				"  h                        hint",
-				"  l                        action log",
-				"",
-				"Settings:",
-				"  sd <0-2>                 set CPU difficulty (0=Easy,1=Normal,2=Hard)",
-				"",
-				"Session:",
-				"  r                        reset game",
-				"  q                        quit",
-				"  help                     show this help",
-			}})
-	}},
-	{Name: "speed", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewSpeedCuiController(usecase.NewSpeedInteractor(
-				domain.NewDefaultSpeed(), new(presenter.SpeedCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:    "speed.helpTitle",
-				CommandKeys: []string{"speed.helpPlay", "speed.helpFlip", "speed.helpHint"},
-				SettingKeys: []string{"speed.helpSetDifficulty"},
-			})
-	}},
-	{Name: "gofish", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewGoFishCuiController(usecase.NewGoFishInteractor(
-				domain.NewDefaultGoFish(), new(presenter.GoFishCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:    "gofish.helpTitle",
-				CommandKeys: []string{"gofish.helpAsk"},
-				SettingKeys: []string{"gofish.helpSetDifficulty"},
-			})
-	}},
-	{Name: "pinochle", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewPinochleCuiController(usecase.NewPinochleInteractor(
-				domain.NewDefaultPinochle(), new(presenter.PinochleCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "pinochle.helpTitle",
-				CommandKeys: []string{
-					"pinochle.helpBid",
-					"pinochle.helpPass",
-					"pinochle.helpTrump",
-					"pinochle.helpMeld",
-					"pinochle.helpPlay",
-					"pinochle.helpNext",
-					"pinochle.helpNextRound",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"pinochle.helpSetDifficulty", "pinochle.helpSetLimit"},
-			})
-	}},
-	{Name: "golf", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewGolfCuiController(usecase.NewGolfInteractor(
-				domain.NewDefaultGolf(), new(presenter.GolfCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:          "golf.helpTitle",
-				CommandKeys:       []string{"golf.helpDraw", "golf.helpRemove", "golf.helpGiveUp", "golf.helpHint"},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "pigtail", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewPigsTailCuiController(usecase.NewPigsTailInteractor(
-				domain.NewDefaultPigsTail(), new(presenter.PigsTailCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:    "pigtail.helpTitle",
-				CommandKeys: []string{"pigtail.helpAction"},
-			})
-	}},
-	{Name: "sevencardstud", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewSevenCardStudCuiController(usecase.NewSevenCardStudInteractor(
-				domain.NewDefaultSevenCardStud(), new(presenter.SevenCardStudCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "sevencardstud.helpTitle",
-				CommandKeys: append([]string{
-					"sevencardstud.helpFold",
-					"sevencardstud.helpCheck",
-					"sevencardstud.helpCall",
-					"sevencardstud.helpBet",
-					"sevencardstud.helpRaise",
-					"sevencardstud.helpAllIn",
-				}, tournamentRebuyAddOnKeys...),
-				SettingKeys: append([]string{
-					"sevencardstud.helpBettingLimit", "sevencardstud.helpTournament",
-				}, studAnteKeys...),
-			})
-	}},
-	{Name: "clocksolitaire", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewClockSolitaireCuiController(usecase.NewClockSolitaireInteractor(
-				domain.NewDefaultClockSolitaire(), new(presenter.ClockSolitaireCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:          "clocksolitaire.helpTitle",
-				CommandKeys:       []string{"clocksolitaire.helpStep", "clocksolitaire.helpAutoPlay", "clocksolitaire.helpUndo"},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "durak", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewDurakCuiController(usecase.NewDurakInteractor(
-				domain.NewDefaultDurak(), new(presenter.DurakCuiPresenter))),
-			CuiHelpSpec{Body: []string{
-				i18n.T("durak.helpTitle"),
-				"",
-				i18n.T("gameCommands"),
-				"  a <idx>                  attack with card",
-				"  d <atkIdx> <handIdx>     defend attack card",
-				"  p                        pass (stop attacking)",
-				"  t                        take cards (give up defense)",
-				"  sort <0|1>               sort hand (0=suit, 1=value)",
-				"  sd <0-2>                 set CPU difficulty",
-				"  l                        action log",
-				"",
-				i18n.T("commonCommands"),
-			}})
-	}},
-	{Name: "fortythieves", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewFortyThievesCuiController(usecase.NewFortyThievesInteractor(
-				domain.NewDefaultFortyThieves(), new(presenter.FortyThievesCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "fortythieves.helpTitle",
-				CommandKeys: []string{
-					"fortythieves.helpDraw",
-					"fortythieves.helpMove",
-					"fortythieves.helpMoveWF",
-					"fortythieves.helpMoveTF",
-					"fortythieves.helpMoveTT",
-					"fortythieves.helpGiveUp",
-					"fortythieves.helpHint",
-					"fortythieves.helpAutoComplete",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "paigow", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewPaiGowCuiController(usecase.NewPaiGowInteractor(
-				domain.NewDefaultPaiGow(), new(presenter.PaiGowCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:          "paigow.helpTitle",
-				CommandKeys:       []string{"paigow.helpBet", "paigow.helpSet", "paigow.helpAuto", "paigow.helpHint"},
-				ExtraCommandLines: []string{"  log                  action log"},
-			})
-	}},
-	{Name: "twotenjack", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewTwoTenJackCuiController(usecase.NewTwoTenJackInteractor(
-				domain.NewDefaultTwoTenJack(), new(presenter.TwoTenJackCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "twotenjack.helpTitle",
-				CommandKeys: []string{
-					"twotenjack.helpDeclare",
-					"twotenjack.helpPlay",
-					"twotenjack.helpNext",
-					"twotenjack.helpNextRound",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"twotenjack.helpSetDifficulty", "twotenjack.helpSetLimit"},
-			})
-	}},
-	{Name: "caribbeanstud", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewCaribbeanStudCuiController(usecase.NewCaribbeanStudInteractor(
-				domain.NewDefaultCaribbeanStud(), new(presenter.CaribbeanStudCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:          "caribbeanstud.helpTitle",
-				CommandKeys:       []string{"caribbeanstud.helpBet", "caribbeanstud.helpPlay", "caribbeanstud.helpFold"},
-				ExtraCommandLines: []string{"  log                  action log"},
-			})
-	}},
-	{Name: "texasholdembonus", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewTexasHoldemBonusCuiController(usecase.NewTexasHoldemBonusInteractor(
-				domain.NewDefaultTexasHoldemBonus(), new(presenter.TexasHoldemBonusCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "texasholdembonus.helpTitle",
-				CommandKeys: []string{
-					"texasholdembonus.helpBet",
-					"texasholdembonus.helpPlay",
-					"texasholdembonus.helpFold",
-					"texasholdembonus.helpCheck",
-					"texasholdembonus.helpRaise",
-				},
-				ExtraCommandLines: []string{"  log                  action log"},
-			})
-	}},
-	{Name: "war", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewWarCuiController(usecase.NewWarInteractor(
-				domain.NewDefaultWar(), new(presenter.WarCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:    "war.helpTitle",
-				CommandKeys: []string{"war.helpStep", "war.helpAutoPlay"},
-				SettingKeys: []string{"war.helpSetMax"},
-			})
-	}},
-	{Name: "canfield", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewCanfieldCuiController(usecase.NewCanfieldInteractor(
-				domain.NewDefaultCanfield(), new(presenter.CanfieldCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "canfield.helpTitle",
-				CommandKeys: []string{
-					"canfield.helpDraw",
-					"canfield.helpMove",
-					"canfield.helpMoveWF",
-					"canfield.helpMoveRT",
-					"canfield.helpMoveRF",
-					"canfield.helpMoveTF",
-					"canfield.helpMoveTT",
-					"canfield.helpGiveUp",
-					"canfield.helpHint",
-					"canfield.helpAutoComplete",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "fiftyone", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewFiftyOneCuiController(usecase.NewFiftyOneInteractor(
-				domain.NewDefaultFiftyOne(), new(presenter.FiftyOneCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:    "fiftyone.helpTitle",
-				CommandKeys: []string{"fiftyone.helpPlay", "fiftyone.helpAll", "fiftyone.helpStop"},
-				SettingKeys: []string{"fiftyone.helpSetDifficulty"},
-			})
-	}},
-	{Name: "yukon", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewYukonCuiController(usecase.NewYukonInteractor(
-				domain.NewDefaultYukon(), new(presenter.YukonCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "yukon.helpTitle",
-				CommandKeys: []string{
-					"yukon.helpMove",
-					"yukon.helpMoveTF",
-					"yukon.helpMoveTT",
-					"yukon.helpGiveUp",
-					"yukon.helpHint",
-					"yukon.helpAutoComplete",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "russiansolitaire", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewRussianSolitaireCuiController(usecase.NewRussianSolitaireInteractor(
-				domain.NewDefaultRussianSolitaire(), new(presenter.RussianSolitaireCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "russiansolitaire.helpTitle",
-				CommandKeys: []string{
-					"russiansolitaire.helpMove",
-					"russiansolitaire.helpMoveTF",
-					"russiansolitaire.helpMoveTT",
-					"russiansolitaire.helpGiveUp",
-					"russiansolitaire.helpHint",
-					"russiansolitaire.helpAutoComplete",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "whist", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewWhistCuiController(usecase.NewWhistInteractor(
-				domain.NewDefaultWhist(), new(presenter.WhistCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:          "whist.helpTitle",
-				CommandKeys:       []string{"whist.helpPlay", "whist.helpNext", "whist.helpNextRound"},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"whist.helpSetDifficulty", "whist.helpSetLimit"},
-			})
-	}},
-	{Name: "catchten", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewCatchTenCuiController(usecase.NewCatchTenInteractor(
-				domain.NewDefaultCatchTen(), new(presenter.CatchTenCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:          "catchten.helpTitle",
-				CommandKeys:       []string{"catchten.helpPlay", "catchten.helpNext", "catchten.helpNextRound"},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"catchten.helpSetDifficulty", "catchten.helpSetLimit"},
-			})
-	}},
-	{Name: "letitride", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewLetItRideCuiController(usecase.NewLetItRideInteractor(
-				domain.NewDefaultLetItRide(), new(presenter.LetItRideCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:          "letitride.helpTitle",
-				CommandKeys:       []string{"letitride.helpBet", "letitride.helpPull", "letitride.helpLetItRide"},
-				ExtraCommandLines: []string{"  log                  action log"},
-			})
-	}},
-	{Name: "pokersquares", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewPokerSquaresCuiController(usecase.NewPokerSquaresInteractor(
-				domain.NewDefaultPokerSquares(), new(presenter.PokerSquaresCuiPresenter))),
-			CuiHelpSpec{Body: []string{
-				"Poker Squares (ポーカー・スクエアズ)",
-				"",
-				i18n.T("gameCommands"),
-				"  p <row> <col>            カードを配置 (0-4)",
-				"  u                        アンドゥ",
-				"  g                        ギブアップ",
-				"  h                        ヒント (現在のカードの最善配置)",
-				"  l                        action log",
-				"",
-				i18n.T("session"),
-				i18n.T("resetEntry"),
-				i18n.T("quitEntry"),
-				i18n.T("helpEntry"),
-			}})
-	}},
-	{Name: "pageone", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewPageOneCuiController(usecase.NewPageOneInteractor(
-				domain.NewDefaultPageOne(), new(presenter.PageOneCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "pageone.helpTitle",
-				CommandKeys: []string{
-					"pageone.helpPlay",
-					"pageone.helpDraw",
-					"pageone.helpDeclare",
-					"pageone.helpSkip",
-					"pageone.helpNextRound",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"pageone.helpSetDifficulty", "pageone.helpSetLimit"},
-			})
-	}},
-	{Name: "reddog", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewRedDogCuiController(usecase.NewRedDogInteractor(
-				domain.NewDefaultRedDog(), new(presenter.RedDogCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:          "reddog.helpTitle",
-				CommandKeys:       []string{"reddog.helpBet", "reddog.helpRaise", "reddog.helpStay", "reddog.helpHint"},
-				ExtraCommandLines: []string{"  log                  action log"},
-			})
-	}},
-	{Name: "badugi", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewBadugiCuiController(usecase.NewBadugiInteractor(
-				domain.NewDefaultBadugi(), new(presenter.BadugiCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "badugi.helpTitle",
-				CommandKeys: []string{
-					"badugi.helpBet",
-					"badugi.helpCall",
-					"badugi.helpRaise",
-					"badugi.helpCheck",
-					"badugi.helpFold",
-					"badugi.helpAllIn",
-					"badugi.helpExchange",
-					"badugi.helpStand",
-				},
-				SettingKeys: []string{"badugi.helpBettingLimit", "badugi.helpCpuCount"},
-			})
-	}},
-	{Name: "deucetoseven", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewDeuceToSevenCuiController(usecase.NewDeuceToSevenInteractor(
-				domain.NewDefaultDeuceToSeven(), new(presenter.DeuceToSevenCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "deucetoseven.helpTitle",
-				CommandKeys: []string{
-					"deucetoseven.helpBet",
-					"deucetoseven.helpCall",
-					"deucetoseven.helpRaise",
-					"deucetoseven.helpCheck",
-					"deucetoseven.helpFold",
-					"deucetoseven.helpAllIn",
-					"deucetoseven.helpExchange",
-					"deucetoseven.helpStand",
-					"deucetoseven.helpHint",
-				},
-				SettingKeys: []string{"deucetoseven.helpBettingLimit", "deucetoseven.helpCpuCount"},
-			})
-	}},
-	{Name: "razz", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewSevenCardStudCuiController(usecase.NewSevenCardStudInteractor(
-				domain.NewDefaultRazz(), new(presenter.SevenCardStudCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "razz.helpTitle",
-				CommandKeys: append([]string{
-					"sevencardstud.helpFold",
-					"sevencardstud.helpCheck",
-					"sevencardstud.helpCall",
-					"sevencardstud.helpBet",
-					"sevencardstud.helpRaise",
-					"sevencardstud.helpAllIn",
-				}, tournamentRebuyAddOnKeys...),
-				SettingKeys: append([]string{
-					"sevencardstud.helpBettingLimit", "sevencardstud.helpTournament",
-				}, studAnteKeys...),
-			})
-	}},
-	{Name: "sevencardstudhilo", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewSevenCardStudCuiController(usecase.NewSevenCardStudInteractor(
-				domain.NewDefaultSevenCardStudHiLo(), new(presenter.SevenCardStudCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "sevencardstudhilo.helpTitle",
-				CommandKeys: append([]string{
-					"sevencardstud.helpFold",
-					"sevencardstud.helpCheck",
-					"sevencardstud.helpCall",
-					"sevencardstud.helpBet",
-					"sevencardstud.helpRaise",
-					"sevencardstud.helpAllIn",
-				}, tournamentRebuyAddOnKeys...),
-				SettingKeys: append([]string{
-					"sevencardstud.helpBettingLimit", "sevencardstud.helpTournament",
-				}, studAnteKeys...),
-			})
-	}},
-	{Name: "scorpion", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewScorpionCuiController(usecase.NewScorpionInteractor(
-				domain.NewDefaultScorpion(), new(presenter.ScorpionCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "scorpion.helpTitle",
-				CommandKeys: []string{
-					"scorpion.helpMove",
-					"scorpion.helpMoveTT",
-					"scorpion.helpDeal",
-					"scorpion.helpGiveUp",
-					"scorpion.helpHint",
-					"scorpion.helpLegal",
-					"scorpion.helpAutoComplete",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "wasp", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewWaspCuiController(usecase.NewWaspInteractor(
-				domain.NewDefaultWasp(), new(presenter.WaspCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "wasp.helpTitle",
-				CommandKeys: []string{
-					"wasp.helpMove",
-					"wasp.helpMoveTT",
-					"wasp.helpDeal",
-					"wasp.helpGiveUp",
-					"wasp.helpHint",
-					"wasp.helpLegal",
-					"wasp.helpAutoComplete",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "accordion", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewAccordionCuiController(usecase.NewAccordionInteractor(
-				domain.NewDefaultAccordion(), new(presenter.AccordionCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "accordion.helpTitle",
-				CommandKeys: []string{
-					"accordion.helpMove",
-					"accordion.helpGiveup",
-					"accordion.helpHint",
-					"accordion.helpLog",
-					"accordion.helpUndo",
-				},
-			})
-	}},
-	{Name: "trash", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewTrashCuiController(usecase.NewTrashInteractor(
-				domain.NewDefaultTrash(), new(presenter.TrashCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "trash.helpTitle",
-				CommandKeys: []string{
-					"trash.helpDraw",
-					"trash.helpPlace",
-					"trash.helpCpu",
-					"trash.helpHint",
-					"trash.helpLog",
-				},
-			})
-	}},
-	{Name: "sevenbridge", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewSevenBridgeCuiController(usecase.NewSevenBridgeInteractor(
-				domain.NewDefaultSevenBridge(), new(presenter.SevenBridgeCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "sevenbridge.helpTitle",
-				CommandKeys: []string{
-					"sevenbridge.helpDrawStock",
-					"sevenbridge.helpPon",
-					"sevenbridge.helpChi",
-					"sevenbridge.helpMeld",
-					"sevenbridge.helpLayoff",
-					"sevenbridge.helpDiscard",
-					"sevenbridge.helpNextRound",
-					"sevenbridge.helpHint",
-				},
-				SettingKeys: []string{"sevenbridge.helpSetDifficulty", "sevenbridge.helpSetLimit"},
-			})
-	}},
-	{Name: "president", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewPresidentCuiController(usecase.NewPresidentInteractor(
-				domain.NewDefaultPresident(), new(presenter.PresidentCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "president.helpTitle",
-				CommandKeys: []string{
-					"president.helpPlay",
-					"president.helpPass",
-					"president.helpHint",
-					"president.helpLog",
-				},
-				SettingKeys: []string{
-					"president.helpSetDifficulty",
-					"president.helpSetRule",
-				},
-			})
-	}},
-	{Name: "cassino", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewCassinoCuiController(usecase.NewCassinoInteractor(
-				domain.NewDefaultCassino(), new(presenter.CassinoCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "cassino.helpTitle",
-				CommandKeys: []string{
-					"cassino.helpTake",
-					"cassino.helpBuild",
-					"cassino.helpTrail",
-					"cassino.helpNext",
-					"cassino.helpHint",
-					"cassino.helpLog",
-				},
-				SettingKeys: []string{
-					"cassino.helpSetDifficulty",
-					"cassino.helpSetRule",
-				},
-			})
-	}},
-	{Name: "spanish21", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewBlackJackCuiController(usecase.NewBlackJackInteractor(
-				domain.NewSpanish21BlackJack(), new(presenter.BlackJackCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "spanish21.helpTitle",
-				CommandKeys: []string{
-					"blackjack.helpBet",
-					"blackjack.helpHit",
-					"blackjack.helpStand",
-					"blackjack.helpDouble",
-					"blackjack.helpSplit",
-					"blackjack.helpInsurance",
-					"blackjack.helpDeclineInsurance",
-				},
-				SettingKeys: []string{"blackjack.helpSetCpuCount"},
-			})
-	}},
-	{Name: "calculation", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewCalculationCuiController(usecase.NewCalculationInteractor(
-				domain.NewDefaultCalculation(), new(presenter.CalculationCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "calculation.helpTitle",
-				CommandKeys: []string{
-					"calculation.helpStockToFoundation",
-					"calculation.helpStockToWaste",
-					"calculation.helpWasteToFoundation",
-					"calculation.helpGiveUp",
-					"calculation.helpHint",
-					"calculation.helpAutoComplete",
-					"calculation.helpUndo",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "sirtommy", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewSirTommyCuiController(usecase.NewSirTommyInteractor(
-				domain.NewDefaultSirTommy(), new(presenter.SirTommyCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "sirtommy.helpTitle",
-				CommandKeys: []string{
-					"sirtommy.helpStockToFoundation",
-					"sirtommy.helpStockToWaste",
-					"sirtommy.helpWasteToFoundation",
-					"sirtommy.helpGiveUp",
-					"sirtommy.helpHint",
-					"sirtommy.helpAutoComplete",
-					"sirtommy.helpUndo",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "bisley", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewBisleyCuiController(usecase.NewBisleyInteractor(
-				domain.NewDefaultBisley(), new(presenter.BisleyCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "bisley.helpTitle",
-				CommandKeys: []string{
-					"bisley.helpMoveTA",
-					"bisley.helpMoveTK",
-					"bisley.helpMoveTT",
-					"bisley.helpGiveUp",
-					"bisley.helpHint",
-					"bisley.helpAutoComplete",
-					"bisley.helpUndo",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "napoleonssquare", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewNapoleonsSquareCuiController(usecase.NewNapoleonsSquareInteractor(
-				domain.NewDefaultNapoleonsSquare(), new(presenter.NapoleonsSquareCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "napoleonssquare.helpTitle",
-				CommandKeys: []string{
-					"napoleonssquare.helpDraw",
-					"napoleonssquare.helpMoveWF",
-					"napoleonssquare.helpMoveWT",
-					"napoleonssquare.helpMoveTF",
-					"napoleonssquare.helpMoveTT",
-					"napoleonssquare.helpGiveUp",
-					"napoleonssquare.helpHint",
-					"napoleonssquare.helpAutoComplete",
-					"napoleonssquare.helpUndo",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "grandfathersclock", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewGrandfathersClockCuiController(usecase.NewGrandfathersClockInteractor(
-				domain.NewDefaultGrandfathersClock(), new(presenter.GrandfathersClockCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "grandfathersclock.helpTitle",
-				CommandKeys: []string{
-					"grandfathersclock.helpMoveTF",
-					"grandfathersclock.helpMoveTT",
-					"grandfathersclock.helpGiveUp",
-					"grandfathersclock.helpHint",
-					"grandfathersclock.helpAutoComplete",
-					"grandfathersclock.helpUndo",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "missmilligan", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewMissMilliganCuiController(usecase.NewMissMilliganInteractor(
-				domain.NewDefaultMissMilligan(), new(presenter.MissMilliganCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "missmilligan.helpTitle",
-				CommandKeys: []string{
-					"missmilligan.helpDeal",
-					"missmilligan.helpMoveTF",
-					"missmilligan.helpMoveTT",
-					"missmilligan.helpWaive",
-					"missmilligan.helpMoveWT",
-					"missmilligan.helpMoveWF",
-					"missmilligan.helpGiveUp",
-					"missmilligan.helpHint",
-					"missmilligan.helpAutoComplete",
-					"missmilligan.helpUndo",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "duchess", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewDuchessCuiController(usecase.NewDuchessInteractor(
-				domain.NewDefaultDuchess(), new(presenter.DuchessCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "duchess.helpTitle",
-				CommandKeys: []string{
-					"duchess.helpBase",
-					"duchess.helpDraw",
-					"duchess.helpMoveRF",
-					"duchess.helpMoveRT",
-					"duchess.helpMoveWF",
-					"duchess.helpMoveWT",
-					"duchess.helpMoveTF",
-					"duchess.helpMoveTT",
-					"duchess.helpGiveUp",
-					"duchess.helpHint",
-					"duchess.helpAutoComplete",
-					"duchess.helpUndo",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "windmill", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewWindmillCuiController(usecase.NewWindmillInteractor(
-				domain.NewDefaultWindmill(), new(presenter.WindmillCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "windmill.helpTitle",
-				CommandKeys: []string{
-					"windmill.helpDraw",
-					"windmill.helpMoveSC",
-					"windmill.helpMoveSK",
-					"windmill.helpMoveWC",
-					"windmill.helpMoveWK",
-					"windmill.helpMoveKC",
-					"windmill.helpGiveUp",
-					"windmill.helpHint",
-					"windmill.helpAutoComplete",
-					"windmill.helpUndo",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "americantoad", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewAmericanToadCuiController(usecase.NewAmericanToadInteractor(
-				domain.NewDefaultAmericanToad(), new(presenter.AmericanToadCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "americantoad.helpTitle",
-				CommandKeys: []string{
-					"americantoad.helpDraw",
-					"americantoad.helpMoveRF",
-					"americantoad.helpMoveRT",
-					"americantoad.helpMoveWF",
-					"americantoad.helpMoveWT",
-					"americantoad.helpMoveTF",
-					"americantoad.helpMoveTT",
-					"americantoad.helpGiveUp",
-					"americantoad.helpHint",
-					"americantoad.helpAutoComplete",
-					"americantoad.helpUndo",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "spiteandmalice", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewSpiteAndMaliceCuiController(usecase.NewSpiteAndMaliceInteractor(
-				domain.NewDefaultSpiteAndMalice(), new(presenter.SpiteAndMaliceCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "spiteandmalice.helpTitle",
-				CommandKeys: []string{
-					"spiteandmalice.helpPlayHand",
-					"spiteandmalice.helpPlayGoal",
-					"spiteandmalice.helpPlaySide",
-					"spiteandmalice.helpDiscard",
-					"spiteandmalice.helpCpu",
-					"spiteandmalice.helpHint",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "skat", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewSkatCuiController(usecase.NewSkatInteractor(
-				domain.NewDefaultSkat(), new(presenter.SkatCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "skat.helpTitle",
-				CommandKeys: []string{
-					"skat.helpBid",
-					"skat.helpPickSkat",
-					"skat.helpDiscard",
-					"skat.helpGame",
-					"skat.helpPlay",
-					"skat.helpNext",
-					"skat.helpNextRound",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"skat.helpSetDifficulty", "skat.helpSetTarget"},
-			})
-	}},
-	{Name: "congress", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewCongressCuiController(usecase.NewCongressInteractor(
-				domain.NewDefaultCongress(), new(presenter.CongressCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "congress.helpTitle",
-				CommandKeys: []string{
-					"congress.helpDraw",
-					"congress.helpMoveTF",
-					"congress.helpMoveTT",
-					"congress.helpMoveWF",
-					"congress.helpMoveWT",
-					"congress.helpMoveST",
-					"congress.helpGiveUp",
-					"congress.helpHint",
-					"congress.helpAutoComplete",
-					"congress.helpUndo",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "terrace", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewTerraceCuiController(usecase.NewTerraceInteractor(
-				domain.NewDefaultTerrace(), new(presenter.TerraceCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "terrace.helpTitle",
-				CommandKeys: []string{
-					"terrace.helpDraw",
-					"terrace.helpMoveRF",
-					"terrace.helpMoveWF",
-					"terrace.helpMoveWT",
-					"terrace.helpMoveTF",
-					"terrace.helpMoveTT",
-					"terrace.helpGiveUp",
-					"terrace.helpHint",
-					"terrace.helpAutoComplete",
-					"terrace.helpUndo",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "braid", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewBraidCuiController(usecase.NewBraidInteractor(
-				domain.NewDefaultBraid(), new(presenter.BraidCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "braid.helpTitle",
-				CommandKeys: []string{
-					"braid.helpDraw",
-					"braid.helpDirection",
-					"braid.helpMoveBrF",
-					"braid.helpMoveFdF",
-					"braid.helpMoveHpF",
-					"braid.helpMoveWF",
-					"braid.helpMoveWHp",
-					"braid.helpGiveUp",
-					"braid.helpHint",
-					"braid.helpAutoComplete",
-					"braid.helpUndo",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "pontoon", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewPontoonCuiController(usecase.NewPontoonInteractor(
-				domain.NewDefaultPontoon(), new(presenter.PontoonCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "pontoon.helpTitle",
-				CommandKeys: []string{
-					"pontoon.helpBet",
-					"pontoon.helpDeal",
-					"pontoon.helpStick",
-					"pontoon.helpTwist",
-					"pontoon.helpBuy",
-					"pontoon.helpSplit",
-					"pontoon.helpBankerTwist",
-					"pontoon.helpBankerStay",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "settemezzo", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewSetteEMezzoCuiController(usecase.NewSetteEMezzoInteractor(
-				domain.NewDefaultSetteEMezzo(), new(presenter.SetteEMezzoCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "settemezzo.helpTitle",
-				CommandKeys: []string{
-					"settemezzo.helpBet",
-					"settemezzo.helpDeal",
-					"settemezzo.helpHit",
-					"settemezzo.helpStand",
-					"settemezzo.helpMatta",
-					"settemezzo.helpBankerHit",
-					"settemezzo.helpBankerStand",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "niuniu", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewNiuNiuCuiController(usecase.NewNiuNiuInteractor(
-				domain.NewDefaultNiuNiu(), new(presenter.NiuNiuCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:          "niuniu.helpTitle",
-				CommandKeys:       []string{"niuniu.helpBet"},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "bura", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewBuraCuiController(usecase.NewBuraInteractor(
-				domain.NewDefaultBura(), new(presenter.BuraCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "bura.helpTitle",
-				CommandKeys: []string{
-					"bura.helpPlay",
-					"bura.helpClaim",
-					"bura.helpDeclare",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "mushi", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewMushiCuiController(usecase.NewMushiInteractor(
-				domain.NewDefaultMushi(), new(presenter.MushiCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "mushi.helpTitle",
-				CommandKeys: []string{
-					"mushi.helpPlay",
-					"mushi.helpSelect",
-					"mushi.helpNext",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "toepen", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewToepenCuiController(usecase.NewToepenInteractor(
-				domain.NewDefaultToepen(), new(presenter.ToepenCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "toepen.helpTitle",
-				CommandKeys: []string{
-					"toepen.helpPlay",
-					"toepen.helpToep",
-					"toepen.helpStay",
-					"toepen.helpFold",
-					"toepen.helpRedeal",
-					"toepen.helpNext",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "chineseten", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewChineseTenCuiController(usecase.NewChineseTenInteractor(
-				domain.NewDefaultChineseTen(), new(presenter.ChineseTenCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "chineseten.helpTitle",
-				CommandKeys: []string{
-					"chineseten.helpPlay",
-					"chineseten.helpSelect",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "trex", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewTrexCuiController(usecase.NewTrexInteractor(
-				domain.NewDefaultTrex(), new(presenter.TrexCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "trex.helpTitle",
-				CommandKeys: []string{
-					"trex.helpChoose",
-					"trex.helpPlay",
-					"trex.helpPass",
-					"trex.helpNext",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "skitgubbe", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewSkitgubbeCuiController(usecase.NewSkitgubbeInteractor(
-				domain.NewDefaultSkitgubbe(), new(presenter.SkitgubbeCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "skitgubbe.helpTitle",
-				CommandKeys: []string{
-					"skitgubbe.helpPlay",
-					"skitgubbe.helpPickUp",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "loba", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewLobaCuiController(usecase.NewLobaInteractor(
-				domain.NewDefaultLoba(), new(presenter.LobaCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "loba.helpTitle",
-				CommandKeys: []string{
-					"loba.helpDrawStock",
-					"loba.helpDrawDiscard",
-					"loba.helpMeld",
-					"loba.helpLayOff",
-					"loba.helpDiscard",
-					"loba.helpNext",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "sjavs", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewSjavsCuiController(usecase.NewSjavsInteractor(
-				domain.NewDefaultSjavs(), new(presenter.SjavsCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "sjavs.helpTitle",
-				CommandKeys: []string{
-					"sjavs.helpBid",
-					"sjavs.helpPlay",
-					"sjavs.helpNext",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "laughandliedown", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewLaughAndLieDownCuiController(usecase.NewLaughAndLieDownInteractor(
-				domain.NewDefaultLaughAndLieDown(), new(presenter.LaughAndLieDownCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "laughandliedown.helpTitle",
-				CommandKeys: []string{
-					"laughandliedown.helpPlay",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "shithead", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewShitheadCuiController(usecase.NewShitheadInteractor(
-				domain.NewDefaultShithead(), new(presenter.ShitheadCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "shithead.helpTitle",
-				CommandKeys: []string{
-					"shithead.helpPlay",
-					"shithead.helpPickup",
-					"shithead.helpLog",
-				},
-				SettingKeys: []string{
-					"shithead.helpSetDifficulty",
-					"shithead.helpSetRule",
-				},
-			})
-	}},
-	{Name: "nertz", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewNertzCuiController(usecase.NewNertzInteractor(
-				domain.NewDefaultNertz(), new(presenter.NertzCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "nertz.helpTitle",
-				CommandKeys: []string{
-					"nertz.helpDraw",
-					"nertz.helpMoveNF",
-					"nertz.helpMoveNT",
-					"nertz.helpMoveWF",
-					"nertz.helpMoveWT",
-					"nertz.helpMoveTF",
-					"nertz.helpMoveTT",
-					"nertz.helpTick",
-					"nertz.helpUndo",
-					"nertz.helpNextRound",
-					"nertz.helpHint",
-				},
-			})
-	}},
-	{Name: "slapjack", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewSlapjackCuiController(usecase.NewSlapjackInteractor(
-				domain.NewDefaultSlapjack(), new(presenter.SlapjackCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "slapjack.helpTitle",
-				CommandKeys: []string{
-					"slapjack.helpStep",
-					"slapjack.helpSlap",
-					"slapjack.helpTick",
-					"slapjack.helpLog",
-				},
-				SettingKeys: []string{"slapjack.helpSetDifficulty"},
-			})
-	}},
-	{Name: "egyptianratscrew", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewEgyptianRatscrewCuiController(usecase.NewEgyptianRatscrewInteractor(
-				domain.NewDefaultEgyptianRatscrew(), new(presenter.EgyptianRatscrewCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "egyptianratscrew.helpTitle",
-				CommandKeys: []string{
-					"egyptianratscrew.helpStep",
-					"egyptianratscrew.helpSlap",
-					"egyptianratscrew.helpTick",
-					"egyptianratscrew.helpLog",
-				},
-				SettingKeys: []string{"egyptianratscrew.helpSetDifficulty"},
-			})
-	}},
-	{Name: "bakersdozen", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewBakersDozenCuiController(usecase.NewBakersDozenInteractor(
-				domain.NewDefaultBakersDozen(), new(presenter.BakersDozenCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "bakersdozen.helpTitle",
-				CommandKeys: []string{
-					"bakersdozen.helpMoveTT",
-					"bakersdozen.helpMoveTF",
-					"bakersdozen.helpGiveUp",
-					"bakersdozen.helpHint",
-					"bakersdozen.helpAutoComplete",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "tonk", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewTonkCuiController(usecase.NewTonkInteractor(
-				domain.NewDefaultTonk(), new(presenter.TonkCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "tonk.helpTitle",
-				CommandKeys: []string{
-					"tonk.helpDrawStock",
-					"tonk.helpDrawDiscard",
-					"tonk.helpDiscard",
-					"tonk.helpKnock",
-					"tonk.helpNextRound",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"tonk.helpSetDifficulty", "tonk.helpSetLimit"},
-			})
-	}},
-	{Name: "casinowar", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewCasinoWarCuiController(usecase.NewCasinoWarInteractor(
-				domain.NewDefaultCasinoWar(), new(presenter.CasinoWarCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:          "casinowar.helpTitle",
-				CommandKeys:       []string{"casinowar.helpBet", "casinowar.helpSurrender", "casinowar.helpWar"},
-				ExtraCommandLines: []string{"  log                  action log"},
-			})
-	}},
-	{Name: "pitch", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewPitchCuiController(usecase.NewPitchInteractor(
-				domain.NewDefaultPitch(), new(presenter.PitchCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:          "pitch.helpTitle",
-				CommandKeys:       []string{"pitch.helpBid", "pitch.helpPlay", "pitch.helpNext", "pitch.helpNextRound"},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"pitch.helpSetDifficulty", "pitch.helpSetLimit"},
-			})
-	}},
-	{Name: "dragontiger", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewDragonTigerCuiController(usecase.NewDragonTigerInteractor(
-				domain.NewDefaultDragonTiger(), new(presenter.DragonTigerCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:          "dragontiger.helpTitle",
-				CommandKeys:       []string{"dragontiger.helpBet", "dragontiger.helpClear"},
-				ExtraCommandLines: []string{"  log                  action log"},
-			})
-	}},
-	{Name: "blackjackswitch", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewBlackJackSwitchCuiController(usecase.NewBlackJackSwitchInteractor(
-				domain.NewDefaultBlackJackSwitch(), new(presenter.BlackJackSwitchCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "blackjackswitch.helpTitle",
-				CommandKeys: []string{
-					"blackjackswitch.helpBet",
-					"blackjackswitch.helpSwitch",
-					"blackjackswitch.helpKeep",
-					"blackjackswitch.helpHit",
-					"blackjackswitch.helpStand",
-					"blackjackswitch.helpDoubleDown",
-				},
-				ExtraCommandLines: []string{"  log                  action log"},
-			})
-	}},
-	{Name: "montecarlo", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewMonteCarloCuiController(usecase.NewMonteCarloInteractor(
-				domain.NewDefaultMonteCarlo(), new(presenter.MonteCarloCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "montecarlo.helpTitle",
-				CommandKeys: []string{
-					"montecarlo.helpRemove",
-					"montecarlo.helpDeal",
-					"montecarlo.helpUndo",
-					"montecarlo.helpHint",
-					"montecarlo.helpGiveup",
-					"montecarlo.helpLog",
-				},
-			})
-	}},
-	{Name: "contractrummy", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewContractRummyCuiController(usecase.NewContractRummyInteractor(
-				domain.NewDefaultContractRummy(), new(presenter.ContractRummyCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "contractrummy.helpTitle",
-				CommandKeys: []string{
-					"contractrummy.helpDrawStock",
-					"contractrummy.helpDrawDiscard",
-					"contractrummy.helpMeldContract",
-					"contractrummy.helpMeldExtra",
-					"contractrummy.helpLayoff",
-					"contractrummy.helpDiscard",
-					"contractrummy.helpNextRound",
-				},
-				SettingKeys: []string{"contractrummy.helpSetDifficulty", "contractrummy.helpSetPenalty"},
-			})
-	}},
-	{Name: "ultimatetexasholdem", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewUltimateTexasHoldemCuiController(usecase.NewUltimateTexasHoldemInteractor(
-				domain.NewDefaultUltimateTexasHoldem(), new(presenter.UltimateTexasHoldemCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "ultimatetexasholdem.helpTitle",
-				CommandKeys: []string{
-					"ultimatetexasholdem.helpBet",
-					"ultimatetexasholdem.helpPlay",
-					"ultimatetexasholdem.helpCheck",
-					"ultimatetexasholdem.helpFold",
-				},
-				ExtraCommandLines: []string{"  log                  action log"},
-			})
-	}},
-	{Name: "crescent", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewCrescentCuiController(usecase.NewCrescentInteractor(
-				domain.NewDefaultCrescent(), new(presenter.CrescentCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "crescent.helpTitle",
-				CommandKeys: []string{
-					"crescent.helpMoveTT",
-					"crescent.helpMoveTF",
-					"crescent.helpRedeal",
-					"crescent.helpGiveUp",
-					"crescent.helpHint",
-					"crescent.helpAutoComplete",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "mississippistud", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewMississippiStudCuiController(usecase.NewMississippiStudInteractor(
-				domain.NewDefaultMississippiStud(), new(presenter.MississippiStudCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "mississippistud.helpTitle",
-				CommandKeys: []string{
-					"mississippistud.helpBet",
-					"mississippistud.helpPlay",
-					"mississippistud.helpFold",
-				},
-				ExtraCommandLines: []string{"  log                  action log"},
-			})
-	}},
-	{Name: "belote", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewBeloteCuiController(usecase.NewBeloteInteractor(
-				domain.NewDefaultBelote(), new(presenter.BeloteCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "belote.helpTitle",
-				CommandKeys: []string{
-					"belote.helpOrderUp",
-					"belote.helpPass",
-					"belote.helpCall",
-					"belote.helpPlay",
-					"belote.helpNext",
-					"belote.helpNextRound",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"belote.helpSetDifficulty", "belote.helpSetTarget"},
-			})
-	}},
-	{Name: "spiderette", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewSpideretteCuiController(usecase.NewSpideretteInteractor(
-				domain.NewDefaultSpiderette(), new(presenter.SpideretteCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "spiderette.helpTitle",
-				CommandKeys: []string{
-					"spiderette.helpDeal",
-					"spiderette.helpMove",
-					"spiderette.helpGiveUp",
-					"spiderette.helpHint",
-					"spiderette.helpAutoComplete",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "mighty", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewMightyCuiController(usecase.NewMightyInteractor(
-				domain.NewDefaultMighty(), new(presenter.MightyCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "mighty.helpTitle",
-				CommandKeys: []string{
-					"mighty.helpBid",
-					"mighty.helpTrump",
-					"mighty.helpExchange",
-					"mighty.helpPlay",
-					"mighty.helpJokerLead",
-					"mighty.helpNext",
-					"mighty.helpNextRound",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"mighty.helpSetDifficulty", "mighty.helpSetLimit", "mighty.helpSetMinBid", "mighty.helpSetNoTrumpExtra"},
-			})
-	}},
-	{Name: "oasispoker", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewOasisPokerCuiController(usecase.NewOasisPokerInteractor(
-				domain.NewDefaultOasisPoker(), new(presenter.OasisPokerCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "oasispoker.helpTitle",
-				CommandKeys: []string{
-					"oasispoker.helpBet",
-					"oasispoker.helpExchange",
-					"oasispoker.helpStand",
-					"oasispoker.helpPlay",
-					"oasispoker.helpFold",
-				},
-				ExtraCommandLines: []string{"  log                  action log"},
-			})
-	}},
-	{Name: "beleagueredcastle", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewBeleagueredCastleCuiController(usecase.NewBeleagueredCastleInteractor(
-				domain.NewDefaultBeleagueredCastle(), new(presenter.BeleagueredCastleCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "beleagueredcastle.helpTitle",
-				CommandKeys: []string{
-					"beleagueredcastle.helpMoveTT",
-					"beleagueredcastle.helpMoveTF",
-					"beleagueredcastle.helpGiveUp",
-					"beleagueredcastle.helpHint",
-					"beleagueredcastle.helpAutoComplete",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "streetsandalleys", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewStreetsAndAlleysCuiController(usecase.NewStreetsAndAlleysInteractor(
-				domain.NewDefaultStreetsAndAlleys(), new(presenter.StreetsAndAlleysCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "streetsandalleys.helpTitle",
-				CommandKeys: []string{
-					"streetsandalleys.helpMoveTT",
-					"streetsandalleys.helpMoveTF",
-					"streetsandalleys.helpGiveUp",
-					"streetsandalleys.helpHint",
-					"streetsandalleys.helpAutoComplete",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "kingalbert", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewKingAlbertCuiController(usecase.NewKingAlbertInteractor(
-				domain.NewDefaultKingAlbert(), new(presenter.KingAlbertCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "kingalbert.helpTitle",
-				CommandKeys: []string{
-					"kingalbert.helpMoveTT",
-					"kingalbert.helpMoveTF",
-					"kingalbert.helpMoveRT",
-					"kingalbert.helpMoveRF",
-					"kingalbert.helpGiveUp",
-					"kingalbert.helpHint",
-					"kingalbert.helpAutoComplete",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "flowergarden", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewFlowerGardenCuiController(usecase.NewFlowerGardenInteractor(
-				domain.NewDefaultFlowerGarden(), new(presenter.FlowerGardenCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "flowergarden.helpTitle",
-				CommandKeys: []string{
-					"flowergarden.helpMoveTT",
-					"flowergarden.helpMoveTF",
-					"flowergarden.helpMoveRT",
-					"flowergarden.helpMoveRF",
-					"flowergarden.helpGiveUp",
-					"flowergarden.helpHint",
-					"flowergarden.helpAutoComplete",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "fortyandeight", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewFortyAndEightCuiController(usecase.NewFortyAndEightInteractor(
-				domain.NewDefaultFortyAndEight(), new(presenter.FortyAndEightCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "fortyandeight.helpTitle",
-				CommandKeys: []string{
-					"fortyandeight.helpDraw",
-					"fortyandeight.helpRedeal",
-					"fortyandeight.helpMove",
-					"fortyandeight.helpMoveWF",
-					"fortyandeight.helpMoveTF",
-					"fortyandeight.helpMoveTT",
-					"fortyandeight.helpGiveUp",
-					"fortyandeight.helpHint",
-					"fortyandeight.helpAutoComplete",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "agnes", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewAgnesCuiController(usecase.NewAgnesInteractor(
-				domain.NewDefaultAgnes(), new(presenter.AgnesCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "agnes.helpTitle",
-				CommandKeys: []string{
-					"agnes.helpDeal",
-					"agnes.helpMoveTT",
-					"agnes.helpMoveTF",
-					"agnes.helpGiveUp",
-					"agnes.helpHint",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "sultan", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewSultanCuiController(usecase.NewSultanInteractor(
-				domain.NewDefaultSultan(), new(presenter.SultanCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "sultan.helpTitle",
-				CommandKeys: []string{
-					"sultan.helpDraw",
-					"sultan.helpRedeal",
-					"sultan.helpMoveDF",
-					"sultan.helpMoveWF",
-					"sultan.helpGiveUp",
-					"sultan.helpHint",
-					"sultan.helpAutoComplete",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "piquet", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewPiquetCuiController(usecase.NewPiquetInteractor(
-				domain.NewDefaultPiquet(), new(presenter.PiquetCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "piquet.helpTitle",
-				CommandKeys: []string{
-					"piquet.helpExchange",
-					"piquet.helpExchangeY",
-					"piquet.helpDeclare",
-					"piquet.helpPlay",
-					"piquet.helpNextDeal",
-					"piquet.helpHint",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "casinoholdem", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewCasinoHoldemCuiController(usecase.NewCasinoHoldemInteractor(
-				domain.NewDefaultCasinoHoldem(), new(presenter.CasinoHoldemCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "casinoholdem.helpTitle",
-				CommandKeys: []string{
-					"casinoholdem.helpBet",
-					"casinoholdem.helpCall",
-					"casinoholdem.helpFold",
-				},
-				ExtraCommandLines: []string{"  log                  action log"},
-			})
-	}},
-	{Name: "callbreak", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewCallBreakCuiController(usecase.NewCallBreakInteractor(
-				domain.NewDefaultCallBreak(), new(presenter.CallBreakCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:          "callbreak.helpTitle",
-				CommandKeys:       []string{"callbreak.helpBid", "callbreak.helpPlay", "callbreak.helpNext", "callbreak.helpNextRound"},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"callbreak.helpSetDifficulty", "callbreak.helpSetRounds"},
-			})
-	}},
-	{Name: "tarneeb", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewTarneebCuiController(usecase.NewTarneebInteractor(
-				domain.NewDefaultTarneeb(), new(presenter.TarneebCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "tarneeb.helpTitle",
-				CommandKeys: []string{
-					"tarneeb.helpBid",
-					"tarneeb.helpTrump",
-					"tarneeb.helpPlay",
-					"tarneeb.helpNext",
-					"tarneeb.helpNextRound",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"tarneeb.helpSetDifficulty", "tarneeb.helpSetLimit", "tarneeb.helpSetMinBid"},
-			})
-	}},
-	{Name: "highcardflush", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewHighCardFlushCuiController(usecase.NewHighCardFlushInteractor(
-				domain.NewDefaultHighCardFlush(), new(presenter.HighCardFlushCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:          "highcardflush.helpTitle",
-				CommandKeys:       []string{"highcardflush.helpBet", "highcardflush.helpRaise", "highcardflush.helpFold"},
-				ExtraCommandLines: []string{"  log                  action log"},
-			})
-	}},
-	{Name: "briscola", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewBriscolaCuiController(usecase.NewBriscolaInteractor(
-				domain.NewDefaultBriscola(), new(presenter.BriscolaCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:          "briscola.helpTitle",
-				CommandKeys:       []string{"briscola.helpPlay", "briscola.helpNext"},
-				ExtraCommandLines: []string{"  l                    action log"},
-			})
-	}},
-	{Name: "gaps", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewGapsCuiController(usecase.NewGapsInteractor(
-				domain.NewDefaultGaps(), new(presenter.GapsCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "gaps.helpTitle",
-				CommandKeys: []string{
-					"gaps.helpMove",
-					"gaps.helpRedeal",
-					"gaps.helpUndo",
-					"gaps.helpGiveUp",
-					"gaps.helpHint",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "fourcardpoker", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewFourCardPokerCuiController(usecase.NewFourCardPokerInteractor(
-				domain.NewDefaultFourCardPoker(), new(presenter.FourCardPokerCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:          "fourcardpoker.helpTitle",
-				CommandKeys:       []string{"fourcardpoker.helpBet", "fourcardpoker.helpPlay", "fourcardpoker.helpFold"},
-				ExtraCommandLines: []string{"  log                  action log"},
-			})
-	}},
-	{Name: "rummy500", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewRummy500CuiController(usecase.NewRummy500Interactor(
-				domain.NewDefaultRummy500(), new(presenter.Rummy500CuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "rummy500.helpTitle",
-				CommandKeys: []string{
-					"rummy500.helpDrawStock",
-					"rummy500.helpDrawDiscard",
-					"rummy500.helpMeld",
-					"rummy500.helpLayoff",
-					"rummy500.helpDiscard",
-					"rummy500.helpNextRound",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"rummy500.helpSetDifficulty", "rummy500.helpSetLimit"},
-			})
-	}},
-	{Name: "eightoff", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewEightOffCuiController(usecase.NewEightOffInteractor(
-				domain.NewDefaultEightOff(), new(presenter.EightOffCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "eightoff.helpTitle",
-				CommandKeys: []string{
-					"eightoff.helpMove",
-					"eightoff.helpMoveTF",
-					"eightoff.helpMoveTT",
-					"eightoff.helpMoveTC",
-					"eightoff.helpMoveCT",
-					"eightoff.helpMoveCF",
-					"eightoff.helpGiveUp",
-					"eightoff.helpHint",
-					"eightoff.helpAutoComplete",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "russianpoker", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewRussianPokerCuiController(usecase.NewRussianPokerInteractor(
-				domain.NewDefaultRussianPoker(), new(presenter.RussianPokerCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "russianpoker.helpTitle",
-				CommandKeys: []string{
-					"russianpoker.helpBet",
-					"russianpoker.helpExchange",
-					"russianpoker.helpBuy6th",
-					"russianpoker.helpSelect",
-					"russianpoker.helpPlay",
-					"russianpoker.helpFold",
-					"russianpoker.helpForce",
-					"russianpoker.helpDecline",
-				},
-				ExtraCommandLines: []string{"  log                  action log"},
-			})
-	}},
-	{Name: "penguin", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewPenguinCuiController(usecase.NewPenguinInteractor(
-				domain.NewDefaultPenguin(), new(presenter.PenguinCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "penguin.helpTitle",
-				CommandKeys: []string{
-					"penguin.helpMove",
-					"penguin.helpMoveTF",
-					"penguin.helpMoveTT",
-					"penguin.helpMoveTC",
-					"penguin.helpMoveCT",
-					"penguin.helpMoveCF",
-					"penguin.helpGiveUp",
-					"penguin.helpHint",
-					"penguin.helpAutoComplete",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "chinesepoker", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewChinesePokerCuiController(usecase.NewChinesePokerInteractor(
-				domain.NewDefaultChinesePoker(), new(presenter.ChinesePokerCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:          "chinesepoker.helpTitle",
-				CommandKeys:       []string{"chinesepoker.helpBet", "chinesepoker.helpSet"},
-				ExtraCommandLines: []string{"  l                                            action log"},
-			})
-	}},
-	{Name: "sixcardgolf", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewSixCardGolfCuiController(usecase.NewSixCardGolfInteractor(
-				domain.NewDefaultSixCardGolf(), new(presenter.SixCardGolfCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:    "sixcardgolf.helpTitle",
-				CommandKeys: []string{"sixcardgolf.helpFlipInitial", "sixcardgolf.helpDrawStock", "sixcardgolf.helpDrawDiscard", "sixcardgolf.helpSwap", "sixcardgolf.helpDiscard", "sixcardgolf.helpFlip", "sixcardgolf.helpSkipFlip", "sixcardgolf.helpNextRound"},
-				SettingKeys: []string{"sixcardgolf.helpSetDifficulty", "sixcardgolf.helpSetPlayers", "sixcardgolf.helpSetRounds"},
-			})
-	}},
-	{Name: "doudizhu", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewDoudizhuCuiController(usecase.NewDoudizhuInteractor(
-				domain.NewDefaultDoudizhu(), new(presenter.DoudizhuCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:    "doudizhu.helpTitle",
-				CommandKeys: []string{"doudizhu.helpPlay", "doudizhu.helpBid"},
-				SettingKeys: []string{"doudizhu.helpSetDifficulty"},
-			})
-	}},
-	{Name: "truco", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewTrucoCuiController(usecase.NewTrucoInteractor(
-				domain.NewDefaultTruco(), new(presenter.TrucoCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:    "truco.helpTitle",
-				CommandKeys: []string{"truco.helpPlay", "truco.helpTruco", "truco.helpRespond", "truco.helpNext"},
-			})
-	}},
-	{Name: "scopa", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewScopaCuiController(usecase.NewScopaInteractor(
-				domain.NewDefaultScopa(), new(presenter.ScopaCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:    "scopa.helpTitle",
-				CommandKeys: []string{"scopa.helpPlay", "scopa.helpNext"},
-				SettingKeys: []string{"scopa.helpSetDifficulty"},
-			})
-	}},
-	{Name: "acesup", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewAcesUpCuiController(usecase.NewAcesUpInteractor(
-				domain.NewDefaultAcesUp(), new(presenter.AcesUpCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:          "acesup.helpTitle",
-				CommandKeys:       []string{"acesup.helpDraw", "acesup.helpRemove", "acesup.helpMove", "acesup.helpGiveUp", "acesup.helpHint"},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "barbu", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewBarbuCuiController(usecase.NewBarbuInteractor(
-				domain.NewDefaultBarbu(), new(presenter.BarbuCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:    "barbu.helpTitle",
-				CommandKeys: []string{"barbu.helpContract", "barbu.helpPlay", "barbu.helpNext"},
-				SettingKeys: []string{"barbu.helpSetDifficulty"},
-			})
-	}},
-	{Name: "macau", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewMacauCuiController(usecase.NewMacauInteractor(
-				domain.NewDefaultMacau(), new(presenter.MacauCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:          "macau.helpTitle",
-				CommandKeys:       []string{"macau.helpPlay", "macau.helpDraw", "macau.helpSuit", "macau.helpDeclare", "macau.helpSkipDeclare", "macau.helpNextRound"},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"macau.helpSetDifficulty", "macau.helpSetLimit"},
-			})
-	}},
-	{Name: "thirtyone", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewThirtyOneCuiController(usecase.NewThirtyOneInteractor(
-				domain.NewDefaultThirtyOne(), new(presenter.ThirtyOneCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "thirtyone.helpTitle",
-				CommandKeys: []string{
-					"thirtyone.helpDrawStock",
-					"thirtyone.helpDrawDiscard",
-					"thirtyone.helpDiscard",
-					"thirtyone.helpKnock",
-					"thirtyone.helpNextRound",
-					"thirtyone.helpHint",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"thirtyone.helpSetDifficulty", "thirtyone.helpSetLives"},
-			})
-	}},
-	{Name: "tienlen", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewTienLenCuiController(usecase.NewTienLenInteractor(
-				domain.NewDefaultTienLen(), new(presenter.TienLenCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:    "tienlen.helpTitle",
-				CommandKeys: []string{"tienlen.helpPlay"},
-				SettingKeys: []string{"tienlen.helpSetDifficulty"},
-			})
-	}},
-	{Name: "osmosis", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewOsmosisCuiController(usecase.NewOsmosisInteractor(
-				domain.NewDefaultOsmosis(), new(presenter.OsmosisCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "osmosis.helpTitle",
-				CommandKeys: []string{
-					"osmosis.helpDraw",
-					"osmosis.helpMoveWF",
-					"osmosis.helpMoveRF",
-					"osmosis.helpGiveUp",
-					"osmosis.helpHint",
-					"osmosis.helpAutoComplete",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "fivehundred", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewFiveHundredCuiController(usecase.NewFiveHundredInteractor(
-				domain.NewDefaultFiveHundred(), new(presenter.FiveHundredCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "fivehundred.helpTitle",
-				CommandKeys: []string{
-					"fivehundred.helpBid",
-					"fivehundred.helpBidNoTrump",
-					"fivehundred.helpMisere",
-					"fivehundred.helpOpenMisere",
-					"fivehundred.helpPass",
-					"fivehundred.helpExchange",
-					"fivehundred.helpPlay",
-					"fivehundred.helpNext",
-					"fivehundred.helpNextRound",
-				},
-				SettingKeys: []string{
-					"fivehundred.helpSetDifficulty",
-					"fivehundred.helpSetTarget",
-				},
-			})
-	}},
-	{Name: "schnapsen", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewSchnapsenCuiController(usecase.NewSchnapsenInteractor(
-				domain.NewDefaultSchnapsen(), new(presenter.SchnapsenCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "schnapsen.helpTitle",
-				CommandKeys: []string{
-					"schnapsen.helpPlay",
-					"schnapsen.helpMarriage",
-					"schnapsen.helpNext",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-			})
-	}},
-	{Name: "burraco", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewBurracoCuiController(usecase.NewBurracoInteractor(
-				domain.NewDefaultBurraco(), new(presenter.BurracoCuiPresenter))),
-			CuiHelpSpec{Body: []string{
-				"Burraco (ブラーコ) Help",
-				"",
-				"Game Commands:",
-				"  ds                   draw from stock",
-				"  dd <idx,idx>         pick up discard pile (natural pair indices)",
-				"  m <idx,idx;idx,idx>  meld (semicolon-separated groups)",
-				"  sm                   skip meld phase",
-				"  d <idx>              discard a card",
-				"  go                   go out (requires the pozzetto + a burraco)",
-				"  nr                   next round",
-				"  h                    hint (recommended action)",
-				"  l                    action log",
-				"",
-				"Settings:",
-				"  sd <0-2>             set CPU difficulty (0=Easy, 1=Normal, 2=Hard)",
-				"  sl <n>               set point limit",
-				"",
-				"Session:",
-				"  r / reset            reset game",
-				"  q / quit             quit",
-				"  ? / help             show help",
-			}})
-	}},
-	{Name: "yaniv", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewYanivCuiController(usecase.NewYanivInteractor(
-				domain.NewDefaultYaniv(), new(presenter.YanivCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "yaniv.helpTitle",
-				CommandKeys: []string{
-					"yaniv.helpDiscard",
-					"yaniv.helpYaniv",
-					"yaniv.helpDrawStock",
-					"yaniv.helpDrawPickup",
-					"yaniv.helpNextRound",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"yaniv.helpSetDifficulty", "yaniv.helpSetLimit"},
-			})
-	}},
-	{Name: "gongzhu", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewGongZhuCuiController(usecase.NewGongZhuInteractor(
-				domain.NewDefaultGongZhu(), new(presenter.GongZhuCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "gongzhu.helpTitle",
-				CommandKeys: []string{
-					"gongzhu.helpExpose",
-					"gongzhu.helpPlay",
-					"gongzhu.helpNext",
-					"gongzhu.helpNextRound",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"gongzhu.helpSetDifficulty", "gongzhu.helpSetLimit"},
-			})
-	}},
-	{Name: "bristol", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewBristolCuiController(usecase.NewBristolInteractor(
-				domain.NewDefaultBristol(), new(presenter.BristolCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "bristol.helpTitle",
-				CommandKeys: []string{
-					"bristol.helpDraw",
-					"bristol.helpMoveTT",
-					"bristol.helpMoveTF",
-					"bristol.helpMoveNT",
-					"bristol.helpMoveNF",
-					"bristol.helpGiveUp",
-					"bristol.helpHint",
-					"bristol.helpAutoComplete",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-			})
-	}},
-	{Name: "bidwhist", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewBidWhistCuiController(usecase.NewBidWhistInteractor(
-				domain.NewDefaultBidWhist(), new(presenter.BidWhistCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "bidwhist.helpTitle",
-				CommandKeys: []string{
-					"bidwhist.helpBid",
-					"bidwhist.helpPass",
-					"bidwhist.helpTrump",
-					"bidwhist.helpExchange",
-					"bidwhist.helpPlay",
-					"bidwhist.helpNext",
-					"bidwhist.helpNextRound",
-				},
-				SettingKeys: []string{
-					"bidwhist.helpSetDifficulty",
-					"bidwhist.helpSetTarget",
-				},
-			})
-	}},
-	{Name: "tressette", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewTressetteCuiController(usecase.NewTressetteInteractor(
-				domain.NewDefaultTressette(), new(presenter.TressetteCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "tressette.helpTitle",
-				CommandKeys: []string{
-					"tressette.helpPlay",
-					"tressette.helpNext",
-					"tressette.helpNextRound",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys: []string{
-					"tressette.helpSetDifficulty",
-					"tressette.helpSetTarget",
-				},
-			})
-	}},
-	{Name: "easthaven", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewEasthavenCuiController(usecase.NewEasthavenInteractor(
-				domain.NewDefaultEasthaven(), new(presenter.EasthavenCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "easthaven.helpTitle",
-				CommandKeys: []string{
-					"easthaven.helpMove",
-					"easthaven.helpMoveTF",
-					"easthaven.helpMoveTT",
-					"easthaven.helpDeal",
-					"easthaven.helpGiveUp",
-					"easthaven.helpHint",
-					"easthaven.helpAutoComplete",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "tichu", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewTichuCuiController(usecase.NewTichuInteractor(
-				domain.NewDefaultTichu(), new(presenter.TichuCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:    "tichu.helpTitle",
-				CommandKeys: []string{"tichu.helpPlay", "tichu.helpDeclare"},
-				SettingKeys: []string{"tichu.helpSetDifficulty"},
-			})
-	}},
-	{Name: "bakersgame", NewCui: func() cuiGame {
-		// Baker's Game reuses the FreeCell interactor/controller; only the
-		// domain (same-suit stacking) and presenter (i18n namespace) differ.
-		return cuiEntry(
-			controller.NewFreeCellCuiController(usecase.NewFreeCellInteractor(
-				domain.NewDefaultBakersGame(), new(presenter.BakersGameCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "bakersgame.helpTitle",
-				CommandKeys: []string{
-					"bakersgame.helpMove",
-					"bakersgame.helpMoveTF",
-					"bakersgame.helpMoveTT",
-					"bakersgame.helpMoveTC",
-					"bakersgame.helpMoveCT",
-					"bakersgame.helpMoveCF",
-					"bakersgame.helpGiveUp",
-					"bakersgame.helpHint",
-					"bakersgame.helpAutoComplete",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "bourre", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewBourreCuiController(usecase.NewBourreInteractor(
-				domain.NewDefaultBourre(), new(presenter.BourreCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "bourre.helpTitle",
-				CommandKeys: []string{
-					"bourre.helpDecide",
-					"bourre.helpDraw",
-					"bourre.helpPlay",
-					"bourre.helpNext",
-					"bourre.helpSetDifficulty",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "sheepshead", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewSheepsheadCuiController(usecase.NewSheepsheadInteractor(
-				domain.NewDefaultSheepshead(), new(presenter.SheepsheadCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "sheepshead.helpTitle",
-				CommandKeys: []string{
-					"sheepshead.helpPick",
-					"sheepshead.helpPass",
-					"sheepshead.helpBury",
-					"sheepshead.helpCall",
-					"sheepshead.helpPlay",
-					"sheepshead.helpNext",
-					"sheepshead.helpNextRound",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys: []string{
-					"sheepshead.helpSetDifficulty",
-					"sheepshead.helpSetChips",
-				},
-			})
-	}},
-	{Name: "doppelkopf", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewDoppelkopfCuiController(usecase.NewDoppelkopfInteractor(
-				domain.NewDefaultDoppelkopf(), new(presenter.DoppelkopfCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "doppelkopf.helpTitle",
-				CommandKeys: []string{
-					"doppelkopf.helpPlay",
-					"doppelkopf.helpAnnounce",
-					"doppelkopf.helpNext",
-					"doppelkopf.helpNextRound",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys: []string{
-					"doppelkopf.helpSetDifficulty",
-					"doppelkopf.helpSetChips",
-				},
-			})
-	}},
-	{Name: "mus", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewMusCuiController(usecase.NewMusInteractor(
-				domain.NewDefaultMus(), new(presenter.MusCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "mus.helpTitle",
-				CommandKeys: []string{
-					"mus.helpMus",
-					"mus.helpCut",
-					"mus.helpDiscard",
-					"mus.helpPaso",
-					"mus.helpEnvido",
-					"mus.helpOrdago",
-					"mus.helpQuiero",
-					"mus.helpNoQuiero",
-					"mus.helpNext",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"mus.helpSetDifficulty"},
-			})
-	}},
-	{Name: "tute", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewTuteCuiController(usecase.NewTuteInteractor(
-				domain.NewDefaultTute(), new(presenter.TuteCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "tute.helpTitle",
-				CommandKeys: []string{
-					"tute.helpPlay",
-					"tute.helpMarriage",
-					"tute.helpTute",
-					"tute.helpNext",
-					"tute.helpNextRound",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"tute.helpSetDifficulty"},
-			})
-	}},
-	{Name: "sueca", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewSuecaCuiController(usecase.NewSuecaInteractor(
-				domain.NewDefaultSueca(), new(presenter.SuecaCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "sueca.helpTitle",
-				CommandKeys: []string{
-					"sueca.helpPlay",
-					"sueca.helpNext",
-					"sueca.helpNextRound",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"sueca.helpSetDifficulty"},
-			})
-	}},
-	{Name: "fortyfives", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewFortyFivesCuiController(usecase.NewFortyFivesInteractor(
-				domain.NewDefaultFortyFives(), new(presenter.FortyFivesCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "fortyfives.helpTitle",
-				CommandKeys: []string{
-					"fortyfives.helpBid",
-					"fortyfives.helpPass",
-					"fortyfives.helpPlay",
-					"fortyfives.helpNext",
-					"fortyfives.helpNextRound",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"fortyfives.helpSetDifficulty"},
-			})
-	}},
-	{Name: "twentynine", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewTwentyNineCuiController(usecase.NewTwentyNineInteractor(
-				domain.NewDefaultTwentyNine(), new(presenter.TwentyNineCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "twentynine.helpTitle",
-				CommandKeys: []string{
-					"twentynine.helpBid",
-					"twentynine.helpPass",
-					"twentynine.helpPlay",
-					"twentynine.helpNext",
-					"twentynine.helpNextRound",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"twentynine.helpSetDifficulty"},
-			})
-	}},
-	{Name: "klaverjas", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewKlaverjasCuiController(usecase.NewKlaverjasInteractor(
-				domain.NewDefaultKlaverjas(), new(presenter.KlaverjasCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "klaverjas.helpTitle",
-				CommandKeys: []string{
-					"klaverjas.helpPlay",
-					"klaverjas.helpNext",
-					"klaverjas.helpNextRound",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"klaverjas.helpSetDifficulty"},
-			})
-	}},
-	{Name: "manille", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewManilleCuiController(usecase.NewManilleInteractor(
-				domain.NewDefaultManille(), new(presenter.ManilleCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "manille.helpTitle",
-				CommandKeys: []string{
-					"manille.helpPlay",
-					"manille.helpNext",
-					"manille.helpNextRound",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"manille.helpSetDifficulty"},
-			})
-	}},
-	{Name: "marias", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewMariasCuiController(usecase.NewMariasInteractor(
-				domain.NewDefaultMarias(), new(presenter.MariasCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "marias.helpTitle",
-				CommandKeys: []string{
-					"marias.helpPlay",
-					"marias.helpNext",
-					"marias.helpNextRound",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"marias.helpSetDifficulty"},
-			})
-	}},
-	{Name: "sedma", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewSedmaCuiController(usecase.NewSedmaInteractor(
-				domain.NewDefaultSedma(), new(presenter.SedmaCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "sedma.helpTitle",
-				CommandKeys: []string{
-					"sedma.helpPlay",
-					"sedma.helpNext",
-					"sedma.helpNextRound",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"sedma.helpSetDifficulty"},
-			})
-	}},
-	{Name: "solowhist", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewSoloWhistCuiController(usecase.NewSoloWhistInteractor(
-				domain.NewDefaultSoloWhist(), new(presenter.SoloWhistCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "solowhist.helpTitle",
-				CommandKeys: []string{
-					"solowhist.helpBid",
-					"solowhist.helpPass",
-					"solowhist.helpPlay",
-					"solowhist.helpNext",
-					"solowhist.helpNextRound",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"solowhist.helpSetDifficulty"},
-			})
-	}},
-	{Name: "knockoutwhist", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewKnockoutWhistCuiController(usecase.NewKnockoutWhistInteractor(
-				domain.NewDefaultKnockoutWhist(), new(presenter.KnockoutWhistCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "knockoutwhist.helpTitle",
-				CommandKeys: []string{
-					"knockoutwhist.helpPlay",
-					"knockoutwhist.helpNext",
-					"knockoutwhist.helpNextRound",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"knockoutwhist.helpSetDifficulty"},
-			})
-	}},
-	{Name: "nap", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewNapCuiController(usecase.NewNapInteractor(
-				domain.NewDefaultNap(), new(presenter.NapCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "nap.helpTitle",
-				CommandKeys: []string{
-					"nap.helpBid",
-					"nap.helpPass",
-					"nap.helpPlay",
-					"nap.helpNext",
-					"nap.helpNextRound",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"nap.helpSetDifficulty"},
-			})
-	}},
-	{Name: "preference", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewPreferenceCuiController(usecase.NewPreferenceInteractor(
-				domain.NewDefaultPreference(), new(presenter.PreferenceCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "preference.helpTitle",
-				CommandKeys: []string{
-					"preference.helpBid",
-					"preference.helpPass",
-					"preference.helpPlay",
-					"preference.helpNext",
-					"preference.helpNextRound",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"preference.helpSetDifficulty"},
-			})
-	}},
-	{Name: "ganjifa", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewGanjifaCuiController(usecase.NewGanjifaInteractor(
-				domain.NewDefaultGanjifa(), new(presenter.GanjifaCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "ganjifa.helpTitle",
-				CommandKeys: []string{
-					"ganjifa.helpPlay",
-					"ganjifa.helpNext",
-					"ganjifa.helpNextRound",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"ganjifa.helpSetDifficulty"},
-			})
-	}},
-	{Name: "vira", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewViraCuiController(usecase.NewViraInteractor(
-				domain.NewDefaultVira(), new(presenter.ViraCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "vira.helpTitle",
-				CommandKeys: []string{
-					"vira.helpBid",
-					"vira.helpPass",
-					"vira.helpPlay",
-					"vira.helpNext",
-					"vira.helpNextRound",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"vira.helpSetDifficulty"},
-			})
-	}},
-	{Name: "spoilfive", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewSpoilFiveCuiController(usecase.NewSpoilFiveInteractor(
-				domain.NewDefaultSpoilFive(), new(presenter.SpoilFiveCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "spoilfive.helpTitle",
-				CommandKeys: []string{
-					"spoilfive.helpPlay",
-					"spoilfive.helpNext",
-					"spoilfive.helpNextRound",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"spoilfive.helpSetDifficulty"},
-			})
-	}},
-	{Name: "courtpiece", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewCourtPieceCuiController(usecase.NewCourtPieceInteractor(
-				domain.NewDefaultCourtPiece(), new(presenter.CourtPieceCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "courtpiece.helpTitle",
-				CommandKeys: []string{
-					"courtpiece.helpTrump",
-					"courtpiece.helpPlay",
-					"courtpiece.helpNext",
-					"courtpiece.helpNextRound",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"courtpiece.helpSetDifficulty"},
-			})
-	}},
-	{Name: "bezique", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewBeziqueCuiController(usecase.NewBeziqueInteractor(
-				domain.NewDefaultBezique(), new(presenter.BeziqueCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "bezique.helpTitle",
-				CommandKeys: []string{
-					"bezique.helpPlay",
-					"bezique.helpMeld",
-					"bezique.helpSkip",
-					"bezique.helpNext",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"bezique.helpSetDifficulty"},
-			})
-	}},
-	{Name: "ecarte", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewEcarteCuiController(usecase.NewEcarteInteractor(
-				domain.NewDefaultEcarte(), new(presenter.EcarteCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "ecarte.helpTitle",
-				CommandKeys: []string{
-					"ecarte.helpPropose",
-					"ecarte.helpStand",
-					"ecarte.helpDiscard",
-					"ecarte.helpPlay",
-					"ecarte.helpNext",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"ecarte.helpSetDifficulty"},
-			})
-	}},
-	{Name: "threecardbrag", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewThreeCardBragCuiController(usecase.NewThreeCardBragInteractor(
-				domain.NewDefaultThreeCardBrag(), new(presenter.ThreeCardBragCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "threecardbrag.helpTitle",
-				CommandKeys: []string{
-					"threecardbrag.helpSee",
-					"threecardbrag.helpBet",
-					"threecardbrag.helpRaise",
-					"threecardbrag.helpFold",
-					"threecardbrag.helpShow",
-					"threecardbrag.helpNext",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"threecardbrag.helpSetDifficulty"},
-			})
-	}},
-	{Name: "teenpatti", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewTeenPattiCuiController(usecase.NewTeenPattiInteractor(
-				domain.NewDefaultTeenPatti(), new(presenter.TeenPattiCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "teenpatti.helpTitle",
-				CommandKeys: []string{
-					"teenpatti.helpSee",
-					"teenpatti.helpBet",
-					"teenpatti.helpRaise",
-					"teenpatti.helpFold",
-					"teenpatti.helpShow",
-					"teenpatti.helpSideShow",
-					"teenpatti.helpNext",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"teenpatti.helpSetDifficulty"},
-			})
-	}},
-	{Name: "scopone", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewScoponeCuiController(usecase.NewScoponeInteractor(
-				domain.NewDefaultScopone(), new(presenter.ScoponeCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "scopone.helpTitle",
-				CommandKeys: []string{
-					"scopone.helpPlay",
-					"scopone.helpNext",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"scopone.helpSetDifficulty"},
-			})
-	}},
-	{Name: "escoba", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewEscobaCuiController(usecase.NewEscobaInteractor(
-				domain.NewDefaultEscoba(), new(presenter.EscobaCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "escoba.helpTitle",
-				CommandKeys: []string{
-					"escoba.helpPlay",
-					"escoba.helpNext",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"escoba.helpSetDifficulty"},
-			})
-	}},
-	{Name: "handandfoot", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewHandAndFootCuiController(usecase.NewHandAndFootInteractor(
-				domain.NewDefaultHandAndFoot(), new(presenter.HandAndFootCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "handandfoot.helpTitle",
-				CommandKeys: []string{
-					"handandfoot.helpDrawStock",
-					"handandfoot.helpDrawDiscard",
-					"handandfoot.helpMeld",
-					"handandfoot.helpSkipMeld",
-					"handandfoot.helpDiscard",
-					"handandfoot.helpGoOut",
-					"handandfoot.helpNextRound",
-					"handandfoot.helpHint",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys: []string{
-					"handandfoot.helpSetDifficulty",
-					"handandfoot.helpSetLimit",
-				},
-			})
-	}},
-	{Name: "conquian", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewConquianCuiController(usecase.NewConquianInteractor(
-				domain.NewDefaultConquian(), new(presenter.ConquianCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "conquian.helpTitle",
-				CommandKeys: []string{
-					"conquian.helpDrawStock",
-					"conquian.helpDrawDiscard",
-					"conquian.helpMeld",
-					"conquian.helpDiscard",
-					"conquian.helpNextRound",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys: []string{
-					"conquian.helpSetDifficulty",
-					"conquian.helpSetWins",
-				},
-			})
-	}},
-	{Name: "chinchon", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewChinchonCuiController(usecase.NewChinchonInteractor(
-				domain.NewDefaultChinchon(), new(presenter.ChinchonCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "chinchon.helpTitle",
-				CommandKeys: []string{
-					"chinchon.helpDrawStock",
-					"chinchon.helpDrawDiscard",
-					"chinchon.helpDiscard",
-					"chinchon.helpKnock",
-					"chinchon.helpLayoff",
-					"chinchon.helpNextRound",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys: []string{
-					"chinchon.helpSetDifficulty",
-					"chinchon.helpSetPlayers",
-				},
-			})
-	}},
-	{Name: "kalooki", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewKalookiCuiController(usecase.NewKalookiInteractor(
-				domain.NewDefaultKalooki(), new(presenter.KalookiCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "kalooki.helpTitle",
-				CommandKeys: []string{
-					"kalooki.helpDrawStock",
-					"kalooki.helpDrawDiscard",
-					"kalooki.helpMeld",
-					"kalooki.helpLayoff",
-					"kalooki.helpDiscard",
-					"kalooki.helpNextRound",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys: []string{
-					"kalooki.helpSetDifficulty",
-					"kalooki.helpSetPlayers",
-					"kalooki.helpSetThreshold",
-				},
-			})
-	}},
-	{Name: "threethirteen", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewThreeThirteenCuiController(usecase.NewThreeThirteenInteractor(
-				domain.NewDefaultThreeThirteen(), new(presenter.ThreeThirteenCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "threethirteen.helpTitle",
-				CommandKeys: []string{
-					"threethirteen.helpDrawStock",
-					"threethirteen.helpDrawDiscard",
-					"threethirteen.helpDiscard",
-					"threethirteen.helpKnock",
-					"threethirteen.helpNextRound",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys: []string{
-					"threethirteen.helpSetDifficulty",
-					"threethirteen.helpSetPlayers",
-				},
-			})
-	}},
-	{Name: "mao", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewMaoCuiController(usecase.NewMaoInteractor(
-				domain.NewDefaultMao(), new(presenter.MaoCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "mao.helpTitle",
-				CommandKeys: []string{
-					"mao.helpPlay",
-					"mao.helpDraw",
-					"mao.helpSuit",
-					"mao.helpDeclare",
-					"mao.helpDeclareWord",
-					"mao.helpSkipDeclare",
-					"mao.helpNextRound",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys: []string{
-					"mao.helpSetDifficulty",
-					"mao.helpSetLimit",
-				},
-			})
-	}},
-	{Name: "spoons", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewSpoonsCuiController(usecase.NewSpoonsInteractor(
-				domain.NewDefaultSpoons(), new(presenter.SpoonsCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "spoons.helpTitle",
-				CommandKeys: []string{
-					"spoons.helpPass",
-					"spoons.helpGrab",
-					"spoons.helpNext",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-			})
-	}},
-	{Name: "kemps", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewKempsCuiController(usecase.NewKempsInteractor(
-				domain.NewDefaultKemps(), new(presenter.KempsCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "kemps.helpTitle",
-				CommandKeys: []string{
-					"kemps.helpSwap",
-					"kemps.helpPass",
-					"kemps.helpSignal",
-					"kemps.helpKemps",
-					"kemps.helpCounter",
-					"kemps.helpNext",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-			})
-	}},
-	{Name: "cuckoo", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewCuckooCuiController(usecase.NewCuckooInteractor(
-				domain.NewDefaultCuckoo(), new(presenter.CuckooCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "cuckoo.helpTitle",
-				CommandKeys: []string{
-					"cuckoo.helpKeep",
-					"cuckoo.helpSwap",
-					"cuckoo.helpRefuse",
-					"cuckoo.helpAccept",
-					"cuckoo.helpNextRound",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys: []string{
-					"cuckoo.helpSetDifficulty",
-					"cuckoo.helpSetLives",
-				},
-			})
-	}},
-	{Name: "pishti", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewPishtiCuiController(usecase.NewPishtiInteractor(
-				domain.NewDefaultPishti(), new(presenter.PishtiCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "pishti.helpTitle",
-				CommandKeys: []string{
-					"pishti.helpPlay",
-					"pishti.helpNext",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys: []string{
-					"pishti.helpSetDifficulty",
-					"pishti.helpSetPlayers",
-				},
-			})
-	}},
-	{Name: "cuarenta", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewCuarentaCuiController(usecase.NewCuarentaInteractor(
-				domain.NewDefaultCuarenta(), new(presenter.CuarentaCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "cuarenta.helpTitle",
-				CommandKeys: []string{
-					"cuarenta.helpPlay",
-					"cuarenta.helpNext",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys: []string{
-					"cuarenta.helpSetDifficulty",
-				},
-			})
-	}},
-	{Name: "fivecardstud", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewFiveCardStudCuiController(usecase.NewFiveCardStudInteractor(
-				domain.NewDefaultFiveCardStud(), new(presenter.FiveCardStudCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "fivecardstud.helpTitle",
-				CommandKeys: []string{
-					"fivecardstud.helpFold",
-					"fivecardstud.helpCheck",
-					"fivecardstud.helpCall",
-					"fivecardstud.helpBet",
-					"fivecardstud.helpRaise",
-					"fivecardstud.helpAllIn",
-				},
-				SettingKeys: []string{
-					"fivecardstud.helpBettingLimit",
-					"fivecardstud.helpTournament",
-				},
-			})
-	}},
-	{Name: "faro", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewFaroCuiController(usecase.NewFaroInteractor(
-				domain.NewDefaultFaro(), new(presenter.FaroCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "faro.helpTitle",
-				CommandKeys: []string{
-					"faro.helpBet",
-					"faro.helpClearBet",
-					"faro.helpClearAll",
-					"faro.helpDeal",
-					"faro.helpCall",
-					"faro.helpNext",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-			})
-	}},
-	{Name: "openfacechinese", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewOpenFaceChineseCuiController(usecase.NewOpenFaceChineseInteractor(
-				domain.NewDefaultOpenFaceChinese(), new(presenter.OpenFaceChineseCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "openfacechinese.helpTitle",
-				CommandKeys: []string{
-					"openfacechinese.helpPlace",
-					"openfacechinese.helpFront",
-					"openfacechinese.helpMiddle",
-					"openfacechinese.helpBack",
-					"openfacechinese.helpNextRound",
-				},
-				SettingKeys: []string{
-					"openfacechinese.helpSetDifficulty",
-					"openfacechinese.helpSetPlayers",
-				},
-			})
-	}},
-	{Name: "russianbank", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewRussianBankCuiController(usecase.NewRussianBankInteractor(
-				domain.NewDefaultRussianBank(), new(presenter.RussianBankCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "russianbank.helpTitle",
-				CommandKeys: []string{
-					"russianbank.helpFoundation",
-					"russianbank.helpTableau",
-					"russianbank.helpDiscard",
-					"russianbank.helpStop",
-					"russianbank.helpUndo",
-				},
-				SettingKeys: []string{
-					"russianbank.helpSetDifficulty",
-				},
-			})
-	}},
-	{Name: "labellelucie", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewLaBelleLucieCuiController(usecase.NewLaBelleLucieInteractor(
-				domain.NewDefaultLaBelleLucie(), new(presenter.LaBelleLucieCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "labellelucie.helpTitle",
-				CommandKeys: []string{
-					"labellelucie.helpMove",
-					"labellelucie.helpRedeal",
-					"labellelucie.helpAutoComplete",
-					"labellelucie.helpUndo",
-					"labellelucie.helpGiveUp",
-				},
-			})
-	}},
-	{Name: "simplesimon", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewSimpleSimonCuiController(usecase.NewSimpleSimonInteractor(
-				domain.NewDefaultSimpleSimon(), new(presenter.SimpleSimonCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "simplesimon.helpTitle",
-				CommandKeys: []string{
-					"simplesimon.helpMove",
-					"simplesimon.helpUndo",
-					"simplesimon.helpGiveUp",
-				},
-			})
-	}},
-	{Name: "doubleklondike", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewDoubleKlondikeCuiController(usecase.NewDoubleKlondikeInteractor(
-				domain.NewDefaultDoubleKlondike(), new(presenter.DoubleKlondikeCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "doubleklondike.helpTitle",
-				CommandKeys: []string{
-					"doubleklondike.helpDraw",
-					"doubleklondike.helpMoveWaste",
-					"doubleklondike.helpMoveTableau",
-					"doubleklondike.helpAuto",
-					"doubleklondike.helpUndo",
-					"doubleklondike.helpGiveUp",
-				},
-			})
-	}},
-	{Name: "blackhole", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewBlackHoleCuiController(usecase.NewBlackHoleInteractor(
-				domain.NewDefaultBlackHole(), new(presenter.BlackHoleCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "blackhole.helpTitle",
-				CommandKeys: []string{
-					"blackhole.helpMove",
-					"blackhole.helpUndo",
-					"blackhole.helpGiveUp",
-				},
-			})
-	}},
-	{Name: "beggarmyneighbour", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewBeggarMyNeighbourCuiController(usecase.NewBeggarMyNeighbourInteractor(
-				domain.NewDefaultBeggarMyNeighbour(), new(presenter.BeggarMyNeighbourCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:    "beggarmyneighbour.helpTitle",
-				CommandKeys: []string{"beggarmyneighbour.helpStep", "beggarmyneighbour.helpAutoPlay"},
-				SettingKeys: []string{"beggarmyneighbour.helpSetMax"},
-			})
-	}},
-	{Name: "allfours", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewAllFoursCuiController(usecase.NewAllFoursInteractor(
-				domain.NewDefaultAllFours(), new(presenter.AllFoursCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "allfours.helpTitle",
-				CommandKeys: []string{
-					"allfours.helpStand", "allfours.helpBeg", "allfours.helpGift",
-					"allfours.helpRun", "allfours.helpPlay", "allfours.helpNext", "allfours.helpNextRound",
-				},
-				SettingKeys: []string{"allfours.helpSetDifficulty", "allfours.helpSetLimit"},
-			})
-	}},
-	{Name: "prsi", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewPrsiCuiController(usecase.NewPrsiInteractor(
-				domain.NewDefaultPrsi(), new(presenter.PrsiCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:          "prsi.helpTitle",
-				CommandKeys:       []string{"prsi.helpPlay", "prsi.helpDraw"},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"prsi.helpSetDifficulty"},
-			})
-	}},
-	{Name: "jass", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewJassCuiController(usecase.NewJassInteractor(
-				domain.NewDefaultJass(), new(presenter.JassCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "jass.helpTitle",
-				CommandKeys: []string{
-					"jass.helpCall",
-					"jass.helpSchieben",
-					"jass.helpPlay",
-					"jass.helpNext",
-					"jass.helpNextRound",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"jass.helpSetDifficulty", "jass.helpSetTarget"},
-			})
-	}},
-	{Name: "gaigel", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewGaigelCuiController(usecase.NewGaigelInteractor(
-				domain.NewDefaultGaigel(), new(presenter.GaigelCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "gaigel.helpTitle",
-				CommandKeys: []string{
-					"gaigel.helpPlay",
-					"gaigel.helpMarriage",
-					"gaigel.helpNext",
-					"gaigel.helpNextRound",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"gaigel.helpSetDifficulty", "gaigel.helpSetTarget"},
-			})
-	}},
-	{Name: "tysiac", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewTysiacCuiController(usecase.NewTysiacInteractor(
-				domain.NewDefaultTysiac(), new(presenter.TysiacCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "tysiac.helpTitle",
-				CommandKeys: []string{
-					"tysiac.helpBid",
-					"tysiac.helpDiscard",
-					"tysiac.helpPlay",
-					"tysiac.helpNext",
-					"tysiac.helpNextRound",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"tysiac.helpSetDifficulty"},
-			})
-	}},
-	{Name: "calabresella", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewCalabresellaCuiController(usecase.NewCalabresellaInteractor(
-				domain.NewDefaultCalabresella(), new(presenter.CalabresellaCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "calabresella.helpTitle",
-				CommandKeys: []string{
-					"calabresella.helpBid",
-					"calabresella.helpDiscard",
-					"calabresella.helpPlay",
-					"calabresella.helpNext",
-					"calabresella.helpNextRound",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"calabresella.helpSetDifficulty"},
-			})
-	}},
-	{Name: "ombre", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewOmbreCuiController(usecase.NewOmbreInteractor(
-				domain.NewDefaultOmbre(), new(presenter.OmbreCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "ombre.helpTitle",
-				CommandKeys: []string{
-					"ombre.helpBid",
-					"ombre.helpPlay",
-					"ombre.helpNext",
-					"ombre.helpNextRound",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"ombre.helpSetDifficulty"},
-			})
-	}},
-	{Name: "ulti", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewUltiCuiController(usecase.NewUltiInteractor(
-				domain.NewDefaultUlti(), new(presenter.UltiCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "ulti.helpTitle",
-				CommandKeys: []string{
-					"ulti.helpBid",
-					"ulti.helpDiscard",
-					"ulti.helpPlay",
-					"ulti.helpNext",
-					"ulti.helpNextRound",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"ulti.helpSetDifficulty"},
-			})
-	}},
-	{Name: "king", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewKingCuiController(usecase.NewKingInteractor(
-				domain.NewDefaultKing(), new(presenter.KingCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:          "king.helpTitle",
-				CommandKeys:       []string{"king.helpContract", "king.helpPlay", "king.helpNext"},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"king.helpSetDifficulty"},
-			})
-	}},
-	{Name: "cinch", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewCinchCuiController(usecase.NewCinchInteractor(
-				domain.NewDefaultCinch(), new(presenter.CinchCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:          "cinch.helpTitle",
-				CommandKeys:       []string{"cinch.helpBid", "cinch.helpTrump", "cinch.helpPlay", "cinch.helpNext"},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"cinch.helpSetDifficulty"},
-			})
-	}},
-	{Name: "loo", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewLooCuiController(usecase.NewLooInteractor(
-				domain.NewDefaultLoo(), new(presenter.LooCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:          "loo.helpTitle",
-				CommandKeys:       []string{"loo.helpDecide", "loo.helpPlay", "loo.helpNext"},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"loo.helpSetDifficulty"},
-			})
-	}},
-	{Name: "basra", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewBasraCuiController(usecase.NewBasraInteractor(
-				domain.NewDefaultBasra(), new(presenter.BasraCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:          "basra.helpTitle",
-				CommandKeys:       []string{"basra.helpPlay", "basra.helpNext"},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"basra.helpSetDifficulty"},
-			})
-	}},
-	{Name: "tablanet", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewTablanetCuiController(usecase.NewTablanetInteractor(
-				domain.NewDefaultTablanet(), new(presenter.TablanetCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:          "tablanet.helpTitle",
-				CommandKeys:       []string{"tablanet.helpPlay", "tablanet.helpNext"},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"tablanet.helpSetDifficulty"},
-			})
-	}},
-	{Name: "trenteetquarante", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewTrenteEtQuaranteCuiController(usecase.NewTrenteEtQuaranteInteractor(
-				domain.NewDefaultTrenteEtQuarante(), new(presenter.TrenteEtQuaranteCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:          "trenteetquarante.helpTitle",
-				CommandKeys:       []string{"trenteetquarante.helpBet", "trenteetquarante.helpNext"},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"trenteetquarante.helpSetDefaultBet"},
-			})
-	}},
-	{Name: "guts", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewGutsCuiController(usecase.NewGutsInteractor(
-				domain.NewDefaultGuts(), new(presenter.GutsCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:          "guts.helpTitle",
-				CommandKeys:       []string{"guts.helpDeclare", "guts.helpNext"},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"guts.helpSetPlayers", "guts.helpSetAnte", "guts.helpSetChips", "guts.helpSetRounds"},
-			})
-	}},
-	{Name: "bouillotte", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewBouillotteCuiController(usecase.NewBouillotteInteractor(
-				domain.NewDefaultBouillotte(), new(presenter.BouillotteCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:          "bouillotte.helpTitle",
-				CommandKeys:       []string{"bouillotte.helpBet", "bouillotte.helpNext"},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"bouillotte.helpSetPlayers", "bouillotte.helpSetAnte", "bouillotte.helpSetChips", "bouillotte.helpSetRounds"},
-			})
-	}},
-	{Name: "primero", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewPrimeroCuiController(usecase.NewPrimeroInteractor(
-				domain.NewDefaultPrimero(), new(presenter.PrimeroCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:          "primero.helpTitle",
-				CommandKeys:       []string{"primero.helpBet", "primero.helpNext"},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"primero.helpSetPlayers", "primero.helpSetAnte", "primero.helpSetChips", "primero.helpSetRounds"},
-			})
-	}},
-	{Name: "michigan", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewMichiganCuiController(usecase.NewMichiganInteractor(
-				domain.NewDefaultMichigan(), new(presenter.MichiganCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:          "michigan.helpTitle",
-				CommandKeys:       []string{"michigan.helpBet", "michigan.helpPlay", "michigan.helpNext"},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"michigan.helpSetPlayers", "michigan.helpSetAnte", "michigan.helpSetChips", "michigan.helpSetRounds"},
-			})
-	}},
-	{Name: "watten", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewWattenCuiController(usecase.NewWattenInteractor(
-				domain.NewDefaultWatten(), new(presenter.WattenCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "watten.helpTitle",
-				CommandKeys: []string{
-					"watten.helpDeclare",
-					"watten.helpPlay",
-					"watten.helpRaise",
-					"watten.helpRespond",
-					"watten.helpNextRound",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"watten.helpSetDifficulty", "watten.helpSetTarget"},
-			})
-	}},
-	{Name: "carioca", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewCariocaCuiController(usecase.NewCariocaInteractor(
-				domain.NewDefaultCarioca(), new(presenter.CariocaCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "carioca.helpTitle",
-				CommandKeys: []string{
-					"carioca.helpDrawStock",
-					"carioca.helpDrawDiscard",
-					"carioca.helpMeldContract",
-					"carioca.helpMeldExtra",
-					"carioca.helpLayoff",
-					"carioca.helpDiscard",
-					"carioca.helpNextRound",
-				},
-				SettingKeys: []string{"carioca.helpSetPlayers", "carioca.helpSetDifficulty", "carioca.helpSetPenalty"},
-			})
-	}},
-	{Name: "samba", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewSambaCuiController(usecase.NewSambaInteractor(
-				domain.NewDefaultSamba(), new(presenter.SambaCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "samba.helpTitle",
-				CommandKeys: []string{
-					"samba.helpDrawStock",
-					"samba.helpDrawDiscard",
-					"samba.helpMeld",
-					"samba.helpSkipMeld",
-					"samba.helpDiscard",
-					"samba.helpGoOut",
-					"samba.helpNextRound",
-				},
-				SettingKeys: []string{"samba.helpSetDifficulty", "samba.helpSetLimit"},
-			})
-	}},
-	{Name: "anaconda", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewAnacondaCuiController(usecase.NewAnacondaInteractor(
-				domain.NewDefaultAnaconda(), new(presenter.AnacondaCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:          "anaconda.helpTitle",
-				CommandKeys:       []string{"anaconda.helpPass", "anaconda.helpKeep", "anaconda.helpBet", "anaconda.helpNext"},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"anaconda.helpSetPlayers", "anaconda.helpSetAnte", "anaconda.helpSetChips", "anaconda.helpSetRounds"},
-			})
-	}},
-	{Name: "machiavelli", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewMachiavelliCuiController(usecase.NewMachiavelliInteractor(
-				domain.NewDefaultMachiavelli(), new(presenter.MachiavelliCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "machiavelli.helpTitle",
-				CommandKeys: []string{
-					"machiavelli.helpDraw",
-					"machiavelli.helpNewMeld",
-					"machiavelli.helpLayoff",
-					"machiavelli.helpNextRound",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"machiavelli.helpSetPlayers", "machiavelli.helpSetDifficulty", "machiavelli.helpSetRounds"},
-			})
-	}},
-	{Name: "pan", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewPanCuiController(usecase.NewPanInteractor(
-				domain.NewDefaultPan(), new(presenter.PanCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "pan.helpTitle",
-				CommandKeys: []string{
-					"pan.helpDrawStock",
-					"pan.helpDrawDiscard",
-					"pan.helpMeld",
-					"pan.helpLayoff",
-					"pan.helpDiscard",
-					"pan.helpNextRound",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"pan.helpSetPlayers", "pan.helpSetDifficulty", "pan.helpSetRounds"},
-			})
-	}},
-	{Name: "wizard", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewWizardCuiController(usecase.NewWizardInteractor(
-				domain.NewDefaultWizard(), new(presenter.WizardCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:          "wizard.helpTitle",
-				CommandKeys:       []string{"wizard.helpBid", "wizard.helpPlay", "wizard.helpNext", "wizard.helpNextRound"},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"wizard.helpSetDifficulty"},
-			})
-	}},
-	{Name: "oichokabu", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewOichoKabuCuiController(usecase.NewOichoKabuInteractor(
-				domain.NewDefaultOichoKabu(), new(presenter.OichoKabuCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:          "oichokabu.helpTitle",
-				CommandKeys:       []string{"oichokabu.helpBet", "oichokabu.helpDraw", "oichokabu.helpStand"},
-				ExtraCommandLines: []string{"  log                  action log"},
-			})
-	}},
-	{Name: "rook", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewRookCuiController(usecase.NewRookInteractor(
-				domain.NewDefaultRook(), new(presenter.RookCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:          "rook.helpTitle",
-				CommandKeys:       []string{"rook.helpBid", "rook.helpPass", "rook.helpExchange", "rook.helpPlay", "rook.helpNext", "rook.helpNextRound"},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"rook.helpSetDifficulty", "rook.helpSetTarget"},
-			})
-	}},
-	{Name: "koikoi", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewKoiKoiCuiController(usecase.NewKoiKoiInteractor(
-				domain.NewDefaultKoiKoi(), new(presenter.KoiKoiCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:          "koikoi.helpTitle",
-				CommandKeys:       []string{"koikoi.helpPlay", "koikoi.helpKoiKoi", "koikoi.helpStop", "koikoi.helpNextRound"},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"koikoi.helpSetDifficulty"},
-			})
-	}},
-	{Name: "gostop", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewGoStopCuiController(usecase.NewGoStopInteractor(
-				domain.NewDefaultGoStop(), new(presenter.GoStopCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:          "gostop.helpTitle",
-				CommandKeys:       []string{"gostop.helpPlay", "gostop.helpGo", "gostop.helpStop", "gostop.helpNextRound"},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"gostop.helpSetDifficulty"},
-			})
-	}},
-	{Name: "hachihachi", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewHachiHachiCuiController(usecase.NewHachiHachiInteractor(
-				domain.NewDefaultHachiHachi(), new(presenter.HachiHachiCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:          "hachihachi.helpTitle",
-				CommandKeys:       []string{"hachihachi.helpPlay", "hachihachi.helpNextRound"},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"hachihachi.helpSetDifficulty"},
-			})
-	}},
-	{Name: "frenchtarot", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewFrenchTarotCuiController(usecase.NewFrenchTarotInteractor(
-				domain.NewDefaultFrenchTarot(), new(presenter.FrenchTarotCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:          "frenchtarot.helpTitle",
-				CommandKeys:       []string{"frenchtarot.helpBid", "frenchtarot.helpPass", "frenchtarot.helpDiscard", "frenchtarot.helpPlay", "frenchtarot.helpNext", "frenchtarot.helpNextRound"},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"frenchtarot.helpSetDifficulty"},
-			})
-	}},
-	{Name: "koenigrufen", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewKoenigrufenCuiController(usecase.NewKoenigrufenInteractor(
-				domain.NewDefaultKoenigrufen(), new(presenter.KoenigrufenCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:          "koenigrufen.helpTitle",
-				CommandKeys:       []string{"koenigrufen.helpBid", "koenigrufen.helpPass", "koenigrufen.helpCallKing", "koenigrufen.helpDiscard", "koenigrufen.helpPlay", "koenigrufen.helpNext", "koenigrufen.helpNextRound"},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"koenigrufen.helpSetDifficulty"},
-			})
-	}},
-	{Name: "aluette", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewAluetteCuiController(usecase.NewAluetteInteractor(
-				domain.NewDefaultAluette(), new(presenter.AluetteCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "aluette.helpTitle",
-				CommandKeys: []string{
-					"aluette.helpPlay",
-					"aluette.helpNext",
-					"aluette.helpNextRound",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"aluette.helpSetDifficulty"},
-			})
-	}},
-	{Name: "minchiate", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewMinchiateCuiController(usecase.NewMinchiateInteractor(
-				domain.NewDefaultMinchiate(), new(presenter.MinchiateCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "minchiate.helpTitle",
-				CommandKeys: []string{
-					"minchiate.helpScarto",
-					"minchiate.helpPlay",
-					"minchiate.helpNext",
-					"minchiate.helpNextRound",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"minchiate.helpSetDifficulty"},
-			})
-	}},
-	{Name: "tarocchini", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewTarocchiniCuiController(usecase.NewTarocchiniInteractor(
-				domain.NewDefaultTarocchini(), new(presenter.TarocchiniCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "tarocchini.helpTitle",
-				CommandKeys: []string{
-					"tarocchini.helpScarto",
-					"tarocchini.helpPlay",
-					"tarocchini.helpNext",
-					"tarocchini.helpNextRound",
-				},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"tarocchini.helpSetDifficulty"},
-			})
-	}},
-	{Name: "scarto", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewScartoCuiController(usecase.NewScartoInteractor(
-				domain.NewDefaultScarto(), new(presenter.ScartoCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:          "scarto.helpTitle",
-				CommandKeys:       []string{"scarto.helpScarto", "scarto.helpPlay", "scarto.helpNext", "scarto.helpNextRound"},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"scarto.helpSetDifficulty"},
-			})
-	}},
-	{Name: "cego", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewCegoCuiController(usecase.NewCegoInteractor(
-				domain.NewDefaultCego(), new(presenter.CegoCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:          "cego.helpTitle",
-				CommandKeys:       []string{"cego.helpBid", "cego.helpPass", "cego.helpCego", "cego.helpHandspiel", "cego.helpDiscard", "cego.helpPlay", "cego.helpNext", "cego.helpNextRound"},
-				ExtraCommandLines: []string{"  l                    action log"},
-				SettingKeys:       []string{"cego.helpSetDifficulty"},
-			})
-	}},
-	{Name: "zheng", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewZhengCuiController(usecase.NewZhengInteractor(
-				domain.NewDefaultZheng(), new(presenter.ZhengCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey:    "zheng.helpTitle",
-				CommandKeys: []string{"zheng.helpPlay"},
-				SettingKeys: []string{"zheng.helpSetDifficulty"},
-			})
-	}},
-	{Name: "desmoche", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewDesmocheCuiController(usecase.NewDesmocheInteractor(
-				domain.NewDefaultDesmoche(), new(presenter.DesmocheCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "desmoche.helpTitle",
-				CommandKeys: []string{
-					"desmoche.helpDrawStock",
-					"desmoche.helpDrawDiscard",
-					"desmoche.helpMeld",
-					"desmoche.helpLayOff",
-					"desmoche.helpDesmoche",
-					"desmoche.helpDiscard",
-					"desmoche.helpNext",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "zwicker", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewZwickerCuiController(usecase.NewZwickerInteractor(
-				domain.NewDefaultZwicker(), new(presenter.ZwickerCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "zwicker.helpTitle",
-				CommandKeys: []string{
-					"zwicker.helpTake",
-					"zwicker.helpBuild",
-					"zwicker.helpTrail",
-					"zwicker.helpNext",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "poch", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewPochCuiController(usecase.NewPochInteractor(
-				domain.NewDefaultPoch(), new(presenter.PochCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "poch.helpTitle",
-				CommandKeys: []string{
-					"poch.helpBet",
-					"poch.helpFold",
-					"poch.helpPlay",
-					"poch.helpNext",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "popejoan", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewPopeJoanCuiController(usecase.NewPopeJoanInteractor(
-				domain.NewDefaultPopeJoan(), new(presenter.PopeJoanCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "popejoan.helpTitle",
-				CommandKeys: []string{
-					"popejoan.helpPlay",
-					"popejoan.helpNext",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "nainjaune", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewNainJauneCuiController(usecase.NewNainJauneInteractor(
-				domain.NewDefaultNainJaune(), new(presenter.NainJauneCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "nainjaune.helpTitle",
-				CommandKeys: []string{
-					"nainjaune.helpPlay",
-					"nainjaune.helpNext",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "kille", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewKilleCuiController(usecase.NewKilleInteractor(
-				domain.NewDefaultKille(), new(presenter.KilleCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "kille.helpTitle",
-				CommandKeys: []string{
-					"kille.helpExchange",
-					"kille.helpSatisfied",
-					"kille.helpReenter",
-					"kille.helpNextRound",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-				SettingKeys: []string{
-					"kille.helpSetStake",
-				},
-			})
-	}},
-	{Name: "klaberjass", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewKlaberjassCuiController(usecase.NewKlaberjassInteractor(
-				domain.NewDefaultKlaberjass(), new(presenter.KlaberjassCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "klaberjass.helpTitle",
-				CommandKeys: []string{
-					"klaberjass.helpAccept",
-					"klaberjass.helpCall",
-					"klaberjass.helpPass",
-					"klaberjass.helpSchmeiss",
-					"klaberjass.helpAnswer",
-					"klaberjass.helpPlay",
-					"klaberjass.helpNext",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-				SettingKeys: []string{
-					"klaberjass.helpSetTarget",
-				},
-			})
-	}},
-	{Name: "kaiser", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewKaiserCuiController(usecase.NewKaiserInteractor(
-				domain.NewDefaultKaiser(), new(presenter.KaiserCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "kaiser.helpTitle",
-				CommandKeys: []string{
-					"kaiser.helpBid",
-					"kaiser.helpPass",
-					"kaiser.helpTrump",
-					"kaiser.helpDiscard",
-					"kaiser.helpPlay",
-					"kaiser.helpNext",
-					"kaiser.helpHint",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "boston", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewBostonCuiController(usecase.NewBostonInteractor(
-				domain.NewDefaultBoston(), new(presenter.BostonCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "boston.helpTitle",
-				CommandKeys: []string{
-					"boston.helpBid",
-					"boston.helpPass",
-					"boston.helpCallPartner",
-					"boston.helpPlay",
-					"boston.helpNext",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "vint", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewVintCuiController(usecase.NewVintInteractor(
-				domain.NewDefaultVint(), new(presenter.VintCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "vint.helpTitle",
-				CommandKeys: []string{
-					"vint.helpBid",
-					"vint.helpPass",
-					"vint.helpPlay",
-					"vint.helpNext",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "bideuchre", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewBidEuchreCuiController(usecase.NewBidEuchreInteractor(
-				domain.NewDefaultBidEuchre(), new(presenter.BidEuchreCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "bideuchre.helpTitle",
-				CommandKeys: []string{
-					"bideuchre.helpBid",
-					"bideuchre.helpPass",
-					"bideuchre.helpTrump",
-					"bideuchre.helpPlay",
-					"bideuchre.helpNext",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "sixbidsolo", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewSixBidSoloCuiController(usecase.NewSixBidSoloInteractor(
-				domain.NewDefaultSixBidSolo(), new(presenter.SixBidSoloCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "sixbidsolo.helpTitle",
-				CommandKeys: []string{
-					"sixbidsolo.helpBid",
-					"sixbidsolo.helpPass",
-					"sixbidsolo.helpDeclare",
-					"sixbidsolo.helpPlay",
-					"sixbidsolo.helpNext",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "karnoffel", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewKarnoffelCuiController(usecase.NewKarnoffelInteractor(
-				domain.NewDefaultKarnoffel(), new(presenter.KarnoffelCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "karnoffel.helpTitle",
-				CommandKeys: []string{
-					"karnoffel.helpPlay",
-					"karnoffel.helpNext",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "literature", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewLiteratureCuiController(usecase.NewLiteratureInteractor(
-				domain.NewDefaultLiterature(), new(presenter.LiteratureCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "literature.helpTitle",
-				CommandKeys: []string{
-					"literature.helpAsk",
-					"literature.helpClaim",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "guandan", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewGuandanCuiController(usecase.NewGuandanInteractor(
-				domain.NewDefaultGuandan(), new(presenter.GuandanCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "guandan.helpTitle",
-				CommandKeys: []string{
-					"guandan.helpPlay",
-					"guandan.helpPass",
-					"guandan.helpTribute",
-					"guandan.helpNext",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
-	{Name: "shengji", NewCui: func() cuiGame {
-		return cuiEntry(
-			controller.NewShengJiCuiController(usecase.NewShengJiInteractor(
-				domain.NewDefaultShengJi(), new(presenter.ShengJiCuiPresenter))),
-			CuiHelpSpec{
-				TitleKey: "shengji.helpTitle",
-				CommandKeys: []string{
-					"shengji.helpDeclare",
-					"shengji.helpBury",
-					"shengji.helpPlay",
-					"shengji.helpNext",
-				},
-				ExtraCommandLines: []string{"  l                        action log"},
-			})
-	}},
+	BindCuiFor("holdem",
+		func() usecase.HoldemInteractorIF {
+			return usecase.NewHoldemInteractor(domain.NewDefaultHoldem(), new(presenter.HoldemCuiPresenter))
+		},
+		controller.NewHoldemCuiController,
+		CuiHelpSpec{
+			TitleKey: "holdem.helpTitle",
+			CommandKeys: append([]string{
+				"holdem.helpFold",
+				"holdem.helpCheck",
+				"holdem.helpCall",
+				"holdem.helpBet",
+				"holdem.helpRaise",
+				"holdem.helpAllIn",
+			}, tournamentRebuyAddOnKeys...),
+			SettingKeys: append([]string{
+				"holdem.helpBettingLimit", "holdem.helpTournament",
+			}, holdemBlindKeys...),
+		}),
+	BindCuiFor("omaha",
+		func() usecase.OmahaInteractorIF {
+			return usecase.NewOmahaInteractor(domain.NewDefaultOmaha(), new(presenter.OmahaCuiPresenter))
+		},
+		controller.NewOmahaCuiController,
+		CuiHelpSpec{
+			TitleKey: "omaha.helpTitle",
+			CommandKeys: append([]string{
+				"omaha.helpFold",
+				"omaha.helpCheck",
+				"omaha.helpCall",
+				"omaha.helpBet",
+				"omaha.helpRaise",
+				"omaha.helpAllIn",
+			}, tournamentRebuyAddOnKeys...),
+			SettingKeys: append([]string{
+				"omaha.helpBettingLimit", "omaha.helpTournament",
+			}, holdemBlindKeys...),
+		}),
+	BindCuiFor("omahahilo",
+		func() usecase.OmahaInteractorIF {
+			return usecase.NewOmahaInteractor(domain.NewDefaultOmahaHiLo(), new(presenter.OmahaCuiPresenter))
+		},
+		controller.NewOmahaCuiController,
+		CuiHelpSpec{
+			TitleKey: "omahahilo.helpTitle",
+			CommandKeys: append([]string{
+				"omaha.helpFold",
+				"omaha.helpCheck",
+				"omaha.helpCall",
+				"omaha.helpBet",
+				"omaha.helpRaise",
+				"omaha.helpAllIn",
+			}, tournamentRebuyAddOnKeys...),
+			SettingKeys: append([]string{
+				"omaha.helpBettingLimit", "omaha.helpTournament",
+			}, holdemBlindKeys...),
+		}),
+	BindCuiFor("bigo",
+		func() usecase.OmahaInteractorIF {
+			return usecase.NewOmahaInteractor(domain.NewDefaultBigO(), new(presenter.OmahaCuiPresenter))
+		},
+		controller.NewOmahaCuiController,
+		CuiHelpSpec{
+			TitleKey: "omaha.helpTitleBigO",
+			CommandKeys: append([]string{
+				"omaha.helpFold",
+				"omaha.helpCheck",
+				"omaha.helpCall",
+				"omaha.helpBet",
+				"omaha.helpRaise",
+				"omaha.helpAllIn",
+			}, tournamentRebuyAddOnKeys...),
+			SettingKeys: append([]string{
+				"omaha.helpBettingLimit", "omaha.helpTournament",
+			}, holdemBlindKeys...),
+		}),
+	BindCuiFor("bigohilo",
+		func() usecase.OmahaInteractorIF {
+			return usecase.NewOmahaInteractor(domain.NewDefaultBigOHiLo(), new(presenter.OmahaCuiPresenter))
+		},
+		controller.NewOmahaCuiController,
+		CuiHelpSpec{
+			TitleKey: "omaha.helpTitleBigOHiLo",
+			CommandKeys: append([]string{
+				"omaha.helpFold",
+				"omaha.helpCheck",
+				"omaha.helpCall",
+				"omaha.helpBet",
+				"omaha.helpRaise",
+				"omaha.helpAllIn",
+			}, tournamentRebuyAddOnKeys...),
+			SettingKeys: append([]string{
+				"omaha.helpBettingLimit", "omaha.helpTournament",
+			}, holdemBlindKeys...),
+		}),
+	BindCuiFor("shortdeck",
+		func() usecase.ShortDeckInteractorIF {
+			return usecase.NewShortDeckInteractor(domain.NewDefaultShortDeck(), new(presenter.ShortDeckCuiPresenter))
+		},
+		controller.NewShortDeckCuiController,
+		CuiHelpSpec{
+			TitleKey: "shortdeck.helpTitle",
+			CommandKeys: append([]string{
+				"shortdeck.helpFold",
+				"shortdeck.helpCheck",
+				"shortdeck.helpCall",
+				"shortdeck.helpBet",
+				"shortdeck.helpRaise",
+				"shortdeck.helpAllIn",
+			}, tournamentRebuyAddOnKeys...),
+			SettingKeys: append([]string{
+				"shortdeck.helpBettingLimit", "shortdeck.helpTournament",
+			}, holdemBlindKeys...),
+		}),
+	BindCuiFor("pineapple",
+		func() usecase.PineappleInteractorIF {
+			return usecase.NewPineappleInteractor(domain.NewDefaultPineapple(), new(presenter.PineappleCuiPresenter))
+		},
+		controller.NewPineappleCuiController,
+		CuiHelpSpec{
+			TitleKey: "pineapple.helpTitle",
+			CommandKeys: append([]string{
+				"pineapple.helpFold",
+				"pineapple.helpCheck",
+				"pineapple.helpCall",
+				"pineapple.helpBet",
+				"pineapple.helpRaise",
+				"pineapple.helpAllIn",
+			}, pineappleRebuyAddOnKeys...),
+			SettingKeys: append([]string{
+				"pineapple.helpBettingLimit", "pineapple.helpTournament",
+			}, holdemBlindKeys...),
+		}),
+	BindCuiFor("crazypineapple",
+		func() usecase.PineappleInteractorIF {
+			return usecase.NewPineappleInteractor(domain.NewDefaultCrazyPineapple(), new(presenter.PineappleCuiPresenter))
+		},
+		controller.NewPineappleCuiController,
+		CuiHelpSpec{
+			TitleKey: "crazypineapple.helpTitle",
+			CommandKeys: append([]string{
+				"crazypineapple.helpFold",
+				"crazypineapple.helpCheck",
+				"crazypineapple.helpCall",
+				"crazypineapple.helpBet",
+				"crazypineapple.helpRaise",
+				"crazypineapple.helpAllIn",
+			}, pineappleRebuyAddOnKeys...),
+			SettingKeys: append([]string{
+				"crazypineapple.helpBettingLimit", "crazypineapple.helpTournament",
+			}, holdemBlindKeys...),
+		}),
+	BindCuiFor("irishpoker",
+		func() usecase.PineappleInteractorIF {
+			return usecase.NewPineappleInteractor(domain.NewDefaultIrishPoker(), new(presenter.PineappleCuiPresenter))
+		},
+		controller.NewPineappleCuiController,
+		CuiHelpSpec{
+			TitleKey: "irishpoker.helpTitle",
+			CommandKeys: append([]string{
+				"irishpoker.helpFold",
+				"irishpoker.helpCheck",
+				"irishpoker.helpCall",
+				"irishpoker.helpBet",
+				"irishpoker.helpRaise",
+				"irishpoker.helpAllIn",
+			}, pineappleRebuyAddOnKeys...),
+			SettingKeys: append([]string{
+				"irishpoker.helpBettingLimit", "irishpoker.helpTournament",
+			}, holdemBlindKeys...),
+		}),
+	BindCuiFor("hearts",
+		func() usecase.HeartsInteractorIF {
+			return usecase.NewHeartsInteractor(domain.NewDefaultHearts(), new(presenter.HeartsCuiPresenter))
+		},
+		controller.NewHeartsCuiController,
+		CuiHelpSpec{
+			TitleKey:          "hearts.helpTitle",
+			CommandKeys:       []string{"hearts.helpPass", "hearts.helpPlay", "hearts.helpNext", "hearts.helpNextRound"},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"hearts.helpSetDifficulty", "hearts.helpSetLimit"},
+		}),
+	BindCuiFor("memory",
+		func() usecase.MemoryInteractorIF {
+			return usecase.NewMemoryInteractor(domain.NewDefaultMemory(), new(presenter.MemoryCuiPresenter))
+		},
+		controller.NewMemoryCuiController,
+		CuiHelpSpec{
+			TitleKey:          "memory.helpTitle",
+			CommandKeys:       []string{"memory.helpFlip", "memory.helpNext"},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"memory.helpSetDifficulty"},
+		}),
+	BindCuiFor("klondike",
+		func() usecase.KlondikeInteractorIF {
+			return usecase.NewKlondikeInteractor(domain.NewDefaultKlondike(), new(presenter.KlondikeCuiPresenter))
+		},
+		controller.NewKlondikeCuiController,
+		CuiHelpSpec{
+			TitleKey: "klondike.helpTitle",
+			CommandKeys: []string{
+				"klondike.helpDraw",
+				"klondike.helpMove",
+				"klondike.helpMoveWF",
+				"klondike.helpMoveTF",
+				"klondike.helpMoveTT",
+				"klondike.helpGiveUp",
+				"klondike.helpHint",
+				"klondike.helpAutoComplete",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("freecell",
+		func() usecase.FreeCellInteractorIF {
+			return usecase.NewFreeCellInteractor(domain.NewDefaultFreeCell(), new(presenter.FreeCellCuiPresenter))
+		},
+		controller.NewFreeCellCuiController,
+		CuiHelpSpec{
+			TitleKey: "freecell.helpTitle",
+			CommandKeys: []string{
+				"freecell.helpMove",
+				"freecell.helpMoveTF",
+				"freecell.helpMoveTT",
+				"freecell.helpMoveTC",
+				"freecell.helpMoveCT",
+				"freecell.helpMoveCF",
+				"freecell.helpGiveUp",
+				"freecell.helpHint",
+				"freecell.helpAutoComplete",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("seahaventowers",
+		func() usecase.SeahavenTowersInteractorIF {
+			return usecase.NewSeahavenTowersInteractor(domain.NewDefaultSeahavenTowers(), new(presenter.SeahavenTowersCuiPresenter))
+		},
+		controller.NewSeahavenTowersCuiController,
+		CuiHelpSpec{
+			TitleKey: "seahaventowers.helpTitle",
+			CommandKeys: []string{
+				"seahaventowers.helpMove",
+				"seahaventowers.helpMoveTF",
+				"seahaventowers.helpMoveTT",
+				"seahaventowers.helpMoveTC",
+				"seahaventowers.helpMoveCT",
+				"seahaventowers.helpMoveCF",
+				"seahaventowers.helpGiveUp",
+				"seahaventowers.helpHint",
+				"seahaventowers.helpAutoComplete",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("cruel",
+		func() usecase.CruelInteractorIF {
+			return usecase.NewCruelInteractor(domain.NewDefaultCruel(), new(presenter.CruelCuiPresenter))
+		},
+		controller.NewCruelCuiController,
+		CuiHelpSpec{
+			TitleKey: "cruel.helpTitle",
+			CommandKeys: []string{
+				"cruel.helpMove",
+				"cruel.helpMoveTF",
+				"cruel.helpShift",
+				"cruel.helpGiveUp",
+				"cruel.helpHint",
+				"cruel.helpAutoComplete",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("baccarat",
+		func() usecase.BaccaratInteractorIF {
+			return usecase.NewBaccaratInteractor(domain.NewDefaultBaccarat(), new(presenter.BaccaratCuiPresenter))
+		},
+		controller.NewBaccaratCuiController,
+		CuiHelpSpec{
+			TitleKey:    "baccarat.helpTitle",
+			CommandKeys: []string{"baccarat.helpBet"},
+			ExtraCommandLines: []string{
+				"  log                  action log",
+				"  ch                   clear history",
+			},
+		}),
+	BindCuiFor("spades",
+		func() usecase.SpadesInteractorIF {
+			return usecase.NewSpadesInteractor(domain.NewDefaultSpades(), new(presenter.SpadesCuiPresenter))
+		},
+		controller.NewSpadesCuiController,
+		CuiHelpSpec{
+			TitleKey:          "spades.helpTitle",
+			CommandKeys:       []string{"spades.helpBid", "spades.helpPlay", "spades.helpNext", "spades.helpNextRound"},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"spades.helpSetDifficulty", "spades.helpSetLimit"},
+		}),
+	BindCuiFor("crazyeights",
+		func() usecase.CrazyEightsInteractorIF {
+			return usecase.NewCrazyEightsInteractor(domain.NewDefaultCrazyEights(), new(presenter.CrazyEightsCuiPresenter))
+		},
+		controller.NewCrazyEightsCuiController,
+		CuiHelpSpec{
+			TitleKey:          "crazyeights.helpTitle",
+			CommandKeys:       []string{"crazyeights.helpPlay", "crazyeights.helpDraw", "crazyeights.helpSuit", "crazyeights.helpNextRound"},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"crazyeights.helpSetDifficulty", "crazyeights.helpSetLimit"},
+		}),
+	BindCuiFor("ginrummy",
+		func() usecase.GinRummyInteractorIF {
+			return usecase.NewGinRummyInteractor(domain.NewDefaultGinRummy(), new(presenter.GinRummyCuiPresenter))
+		},
+		controller.NewGinRummyCuiController,
+		CuiHelpSpec{
+			TitleKey: "ginrummy.helpTitle",
+			CommandKeys: []string{
+				"ginrummy.helpDrawStock",
+				"ginrummy.helpDrawDiscard",
+				"ginrummy.helpDiscard",
+				"ginrummy.helpKnock",
+				"ginrummy.helpLayoff",
+				"ginrummy.helpNextRound",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"ginrummy.helpSetDifficulty", "ginrummy.helpSetLimit"},
+		}),
+	BindCuiFor("indianrummy",
+		func() usecase.IndianRummyInteractorIF {
+			return usecase.NewIndianRummyInteractor(domain.NewDefaultIndianRummy(), new(presenter.IndianRummyCuiPresenter))
+		},
+		controller.NewIndianRummyCuiController,
+		CuiHelpSpec{
+			TitleKey: "indianrummy.helpTitle",
+			CommandKeys: []string{
+				"indianrummy.helpDrawStock",
+				"indianrummy.helpDrawDiscard",
+				"indianrummy.helpDiscard",
+				"indianrummy.helpDeclare",
+				"indianrummy.helpNextRound",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"indianrummy.helpSetPlayers", "indianrummy.helpSetDifficulty", "indianrummy.helpSetRounds"},
+		}),
+	BindCuiFor("canasta",
+		func() usecase.CanastaInteractorIF {
+			return usecase.NewCanastaInteractor(domain.NewDefaultCanasta(), new(presenter.CanastaCuiPresenter))
+		},
+		controller.NewCanastaCuiController,
+		CuiHelpSpec{Body: []string{
+			"Canasta (カナスタ) Help",
+			"",
+			"Game Commands:",
+			"  ds                   draw from stock",
+			"  dd <idx,idx>         pick up discard pile (natural pair indices)",
+			"  m <idx,idx;idx,idx>  meld (semicolon-separated groups)",
+			"  sm                   skip meld phase",
+			"  d <idx>              discard a card",
+			"  go                   go out (requires canasta)",
+			"  nr                   next round",
+			"  l                    action log",
+			"",
+			"Settings:",
+			"  sd <0-2>             set CPU difficulty (0=Easy, 1=Normal, 2=Hard)",
+			"  sl <n>               set point limit",
+			"",
+			"Session:",
+			"  r / reset            reset game",
+			"  q / quit             quit",
+			"  ? / help             show help",
+		}}),
+	BindCuiFor("spider",
+		func() usecase.SpiderInteractorIF {
+			return usecase.NewSpiderInteractor(domain.NewDefaultSpider(), new(presenter.SpiderCuiPresenter))
+		},
+		controller.NewSpiderCuiController,
+		CuiHelpSpec{
+			TitleKey: "spider.helpTitle",
+			CommandKeys: []string{
+				"spider.helpDeal",
+				"spider.helpMove",
+				"spider.helpGiveUp",
+				"spider.helpHint",
+				"spider.helpAutoComplete",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("napoleon",
+		func() usecase.NapoleonInteractorIF {
+			return usecase.NewNapoleonInteractor(domain.NewDefaultNapoleon(), new(presenter.NapoleonCuiPresenter))
+		},
+		controller.NewNapoleonCuiController,
+		CuiHelpSpec{
+			TitleKey: "napoleon.helpTitle",
+			CommandKeys: []string{
+				"napoleon.helpBid",
+				"napoleon.helpTrump",
+				"napoleon.helpExchange",
+				"napoleon.helpPlay",
+				"napoleon.helpNext",
+				"napoleon.helpNextRound",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"napoleon.helpSetDifficulty", "napoleon.helpSetLimit", "napoleon.helpSetMinBid"},
+		}),
+	BindCuiFor("indianpoker",
+		func() usecase.IndianPokerInteractorIF {
+			return usecase.NewIndianPokerInteractor(domain.NewDefaultIndianPoker(), new(presenter.IndianPokerCuiPresenter))
+		},
+		controller.NewIndianPokerCuiController,
+		CuiHelpSpec{
+			TitleKey: "indianpoker.helpTitle",
+			CommandKeys: []string{
+				"indianpoker.helpFold",
+				"indianpoker.helpCheck",
+				"indianpoker.helpCall",
+				"indianpoker.helpBet",
+				"indianpoker.helpRaise",
+				"indianpoker.helpAllIn",
+			},
+			SettingKeys: []string{"indianpoker.helpAnte", "indianpoker.helpBettingLimit", "indianpoker.helpMetaAI"},
+		}),
+	BindCuiFor("videopoker",
+		func() usecase.VideoPokerInteractorIF {
+			return usecase.NewVideoPokerInteractor(domain.NewDefaultVideoPoker(), new(presenter.VideoPokerCuiPresenter))
+		},
+		controller.NewVideoPokerCuiController,
+		CuiHelpSpec{
+			TitleKey:          "videopoker.helpTitle",
+			CommandKeys:       []string{"videopoker.helpBet", "videopoker.helpHold", "videopoker.helpHint"},
+			ExtraCommandLines: []string{"  log                  action log"},
+		}),
+	BindCuiFor("deuceswild",
+		func() usecase.VideoPokerInteractorIF {
+			return usecase.NewVideoPokerInteractor(domain.NewDeucesWildVideoPoker(), new(presenter.VideoPokerCuiPresenter))
+		},
+		controller.NewVideoPokerCuiController,
+		CuiHelpSpec{
+			TitleKey:          "deuceswild.helpTitle",
+			CommandKeys:       []string{"videopoker.helpBet", "videopoker.helpHold", "videopoker.helpHint"},
+			ExtraCommandLines: []string{"  log                  action log"},
+		}),
+	BindCuiFor("jokerpoker",
+		func() usecase.VideoPokerInteractorIF {
+			return usecase.NewVideoPokerInteractor(domain.NewJokerPokerVideoPoker(), new(presenter.VideoPokerCuiPresenter))
+		},
+		controller.NewVideoPokerCuiController,
+		CuiHelpSpec{
+			TitleKey:          "jokerpoker.helpTitle",
+			CommandKeys:       []string{"videopoker.helpBet", "videopoker.helpHold", "videopoker.helpHint"},
+			ExtraCommandLines: []string{"  log                  action log"},
+		}),
+	BindCuiFor("euchre",
+		func() usecase.EuchreInteractorIF {
+			return usecase.NewEuchreInteractor(domain.NewDefaultEuchre(), new(presenter.EuchreCuiPresenter))
+		},
+		controller.NewEuchreCuiController,
+		CuiHelpSpec{
+			TitleKey: "euchre.helpTitle",
+			CommandKeys: []string{
+				"euchre.helpOrderUp",
+				"euchre.helpOrderUpAlone",
+				"euchre.helpPass",
+				"euchre.helpCall",
+				"euchre.helpCallAlone",
+				"euchre.helpDiscard",
+				"euchre.helpPlay",
+				"euchre.helpNext",
+				"euchre.helpNextRound",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"euchre.helpSetDifficulty", "euchre.helpSetLimit"},
+		}),
+	BindCuiFor("pyramid",
+		func() usecase.PyramidInteractorIF {
+			return usecase.NewPyramidInteractor(domain.NewDefaultPyramid(), new(presenter.PyramidCuiPresenter))
+		},
+		controller.NewPyramidCuiController,
+		CuiHelpSpec{
+			TitleKey: "pyramid.helpTitle",
+			CommandKeys: []string{
+				"pyramid.helpDraw",
+				"pyramid.helpRemoveKing",
+				"pyramid.helpRemovePair",
+				"pyramid.helpRemoveWaste",
+				"pyramid.helpRemoveWasteKing",
+				"pyramid.helpGiveUp",
+				"pyramid.helpHint",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("tripeaks",
+		func() usecase.TriPeaksInteractorIF {
+			return usecase.NewTriPeaksInteractor(domain.NewDefaultTriPeaks(), new(presenter.TriPeaksCuiPresenter))
+		},
+		controller.NewTriPeaksCuiController,
+		CuiHelpSpec{
+			TitleKey: "tripeaks.helpTitle",
+			CommandKeys: []string{
+				"tripeaks.helpDraw",
+				"tripeaks.helpRemove",
+				"tripeaks.helpGiveUp",
+				"tripeaks.helpHint",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("cribbage",
+		func() usecase.CribbageInteractorIF {
+			return usecase.NewCribbageInteractor(domain.NewDefaultCribbage(), new(presenter.CribbageCuiPresenter))
+		},
+		controller.NewCribbageCuiController,
+		CuiHelpSpec{
+			TitleKey:          "cribbage.helpTitle",
+			CommandKeys:       []string{"cribbage.helpDiscard", "cribbage.helpCut", "cribbage.helpPeg", "cribbage.helpGo", "cribbage.helpHint", "cribbage.helpShowNext", "cribbage.helpNextRound"},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"cribbage.helpSetDifficulty", "cribbage.helpSetLimit"},
+		}),
+	BindCuiFor("threecard",
+		func() usecase.ThreeCardInteractorIF {
+			return usecase.NewThreeCardInteractor(domain.NewDefaultThreeCard(), new(presenter.ThreeCardCuiPresenter))
+		},
+		controller.NewThreeCardCuiController,
+		CuiHelpSpec{
+			TitleKey:          "threecard.helpTitle",
+			CommandKeys:       []string{"threecard.helpBet", "threecard.helpPlay", "threecard.helpFold"},
+			ExtraCommandLines: []string{"  log                  action log"},
+		}),
+	BindCuiFor("ohhell",
+		func() usecase.OhHellInteractorIF {
+			return usecase.NewOhHellInteractor(domain.NewDefaultOhHell(), new(presenter.OhHellCuiPresenter))
+		},
+		controller.NewOhHellCuiController,
+		CuiHelpSpec{
+			TitleKey:          "ohhell.helpTitle",
+			CommandKeys:       []string{"ohhell.helpBid", "ohhell.helpPlay", "ohhell.helpNext", "ohhell.helpNextRound"},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"ohhell.helpSetDifficulty", "ohhell.helpSetMaxHand"},
+		}),
+	BindCuiFor("ninetynine",
+		func() usecase.NinetyNineInteractorIF {
+			return usecase.NewNinetyNineInteractor(domain.NewDefaultNinetyNine(), new(presenter.NinetyNineCuiPresenter))
+		},
+		controller.NewNinetyNineCuiController,
+		CuiHelpSpec{
+			TitleKey:          "ninetynine.helpTitle",
+			CommandKeys:       []string{"ninetynine.helpBid", "ninetynine.helpPlay", "ninetynine.helpNext", "ninetynine.helpNextRound"},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"ninetynine.helpSetDifficulty", "ninetynine.helpSetTarget"},
+		}),
+	BindCuiFor("bridge",
+		func() usecase.BridgeInteractorIF {
+			return usecase.NewBridgeInteractor(domain.NewDefaultBridge(), new(presenter.BridgeCuiPresenter))
+		},
+		controller.NewBridgeCuiController,
+		CuiHelpSpec{Body: []string{
+			"=== Contract Bridge ===",
+			"",
+			"Game Commands:",
+			"  b <type> <level> <suit>  bid (type: 0=pass,1=bid,2=dbl,3=rdbl; level: 1-7; suit: 1-5)",
+			"  p <index>                play a card",
+			"  n                        next trick",
+			"  nr                       next round (score & proceed)",
+			"  h                        hint",
+			"  l                        action log",
+			"",
+			"Settings:",
+			"  sd <0-2>                 set CPU difficulty (0=Easy,1=Normal,2=Hard)",
+			"",
+			"Session:",
+			"  r                        reset game",
+			"  q                        quit",
+			"  help                     show this help",
+		}}),
+	BindCuiFor("speed",
+		func() usecase.SpeedInteractorIF {
+			return usecase.NewSpeedInteractor(domain.NewDefaultSpeed(), new(presenter.SpeedCuiPresenter))
+		},
+		controller.NewSpeedCuiController,
+		CuiHelpSpec{
+			TitleKey:    "speed.helpTitle",
+			CommandKeys: []string{"speed.helpPlay", "speed.helpFlip", "speed.helpHint"},
+			SettingKeys: []string{"speed.helpSetDifficulty"},
+		}),
+	BindCuiFor("gofish",
+		func() usecase.GoFishInteractorIF {
+			return usecase.NewGoFishInteractor(domain.NewDefaultGoFish(), new(presenter.GoFishCuiPresenter))
+		},
+		controller.NewGoFishCuiController,
+		CuiHelpSpec{
+			TitleKey:    "gofish.helpTitle",
+			CommandKeys: []string{"gofish.helpAsk"},
+			SettingKeys: []string{"gofish.helpSetDifficulty"},
+		}),
+	BindCuiFor("pinochle",
+		func() usecase.PinochleInteractorIF {
+			return usecase.NewPinochleInteractor(domain.NewDefaultPinochle(), new(presenter.PinochleCuiPresenter))
+		},
+		controller.NewPinochleCuiController,
+		CuiHelpSpec{
+			TitleKey: "pinochle.helpTitle",
+			CommandKeys: []string{
+				"pinochle.helpBid",
+				"pinochle.helpPass",
+				"pinochle.helpTrump",
+				"pinochle.helpMeld",
+				"pinochle.helpPlay",
+				"pinochle.helpNext",
+				"pinochle.helpNextRound",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"pinochle.helpSetDifficulty", "pinochle.helpSetLimit"},
+		}),
+	BindCuiFor("golf",
+		func() usecase.GolfInteractorIF {
+			return usecase.NewGolfInteractor(domain.NewDefaultGolf(), new(presenter.GolfCuiPresenter))
+		},
+		controller.NewGolfCuiController,
+		CuiHelpSpec{
+			TitleKey:          "golf.helpTitle",
+			CommandKeys:       []string{"golf.helpDraw", "golf.helpRemove", "golf.helpGiveUp", "golf.helpHint"},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("pigtail",
+		func() usecase.PigsTailInteractorIF {
+			return usecase.NewPigsTailInteractor(domain.NewDefaultPigsTail(), new(presenter.PigsTailCuiPresenter))
+		},
+		controller.NewPigsTailCuiController,
+		CuiHelpSpec{
+			TitleKey:    "pigtail.helpTitle",
+			CommandKeys: []string{"pigtail.helpAction"},
+		}),
+	BindCuiFor("sevencardstud",
+		func() usecase.SevenCardStudInteractorIF {
+			return usecase.NewSevenCardStudInteractor(domain.NewDefaultSevenCardStud(), new(presenter.SevenCardStudCuiPresenter))
+		},
+		controller.NewSevenCardStudCuiController,
+		CuiHelpSpec{
+			TitleKey: "sevencardstud.helpTitle",
+			CommandKeys: append([]string{
+				"sevencardstud.helpFold",
+				"sevencardstud.helpCheck",
+				"sevencardstud.helpCall",
+				"sevencardstud.helpBet",
+				"sevencardstud.helpRaise",
+				"sevencardstud.helpAllIn",
+			}, tournamentRebuyAddOnKeys...),
+			SettingKeys: append([]string{
+				"sevencardstud.helpBettingLimit", "sevencardstud.helpTournament",
+			}, studAnteKeys...),
+		}),
+	BindCuiFor("clocksolitaire",
+		func() usecase.ClockSolitaireInteractorIF {
+			return usecase.NewClockSolitaireInteractor(domain.NewDefaultClockSolitaire(), new(presenter.ClockSolitaireCuiPresenter))
+		},
+		controller.NewClockSolitaireCuiController,
+		CuiHelpSpec{
+			TitleKey:          "clocksolitaire.helpTitle",
+			CommandKeys:       []string{"clocksolitaire.helpStep", "clocksolitaire.helpAutoPlay", "clocksolitaire.helpUndo"},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("durak",
+		func() usecase.DurakInteractorIF {
+			return usecase.NewDurakInteractor(domain.NewDefaultDurak(), new(presenter.DurakCuiPresenter))
+		},
+		controller.NewDurakCuiController,
+		CuiHelpSpec{Body: []string{
+			i18n.T("durak.helpTitle"),
+			"",
+			i18n.T("gameCommands"),
+			"  a <idx>                  attack with card",
+			"  d <atkIdx> <handIdx>     defend attack card",
+			"  p                        pass (stop attacking)",
+			"  t                        take cards (give up defense)",
+			"  sort <0|1>               sort hand (0=suit, 1=value)",
+			"  sd <0-2>                 set CPU difficulty",
+			"  l                        action log",
+			"",
+			i18n.T("commonCommands"),
+		}}),
+	BindCuiFor("fortythieves",
+		func() usecase.FortyThievesInteractorIF {
+			return usecase.NewFortyThievesInteractor(domain.NewDefaultFortyThieves(), new(presenter.FortyThievesCuiPresenter))
+		},
+		controller.NewFortyThievesCuiController,
+		CuiHelpSpec{
+			TitleKey: "fortythieves.helpTitle",
+			CommandKeys: []string{
+				"fortythieves.helpDraw",
+				"fortythieves.helpMove",
+				"fortythieves.helpMoveWF",
+				"fortythieves.helpMoveTF",
+				"fortythieves.helpMoveTT",
+				"fortythieves.helpGiveUp",
+				"fortythieves.helpHint",
+				"fortythieves.helpAutoComplete",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("paigow",
+		func() usecase.PaiGowInteractorIF {
+			return usecase.NewPaiGowInteractor(domain.NewDefaultPaiGow(), new(presenter.PaiGowCuiPresenter))
+		},
+		controller.NewPaiGowCuiController,
+		CuiHelpSpec{
+			TitleKey:          "paigow.helpTitle",
+			CommandKeys:       []string{"paigow.helpBet", "paigow.helpSet", "paigow.helpAuto", "paigow.helpHint"},
+			ExtraCommandLines: []string{"  log                  action log"},
+		}),
+	BindCuiFor("twotenjack",
+		func() usecase.TwoTenJackInteractorIF {
+			return usecase.NewTwoTenJackInteractor(domain.NewDefaultTwoTenJack(), new(presenter.TwoTenJackCuiPresenter))
+		},
+		controller.NewTwoTenJackCuiController,
+		CuiHelpSpec{
+			TitleKey: "twotenjack.helpTitle",
+			CommandKeys: []string{
+				"twotenjack.helpDeclare",
+				"twotenjack.helpPlay",
+				"twotenjack.helpNext",
+				"twotenjack.helpNextRound",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"twotenjack.helpSetDifficulty", "twotenjack.helpSetLimit"},
+		}),
+	BindCuiFor("caribbeanstud",
+		func() usecase.CaribbeanStudInteractorIF {
+			return usecase.NewCaribbeanStudInteractor(domain.NewDefaultCaribbeanStud(), new(presenter.CaribbeanStudCuiPresenter))
+		},
+		controller.NewCaribbeanStudCuiController,
+		CuiHelpSpec{
+			TitleKey:          "caribbeanstud.helpTitle",
+			CommandKeys:       []string{"caribbeanstud.helpBet", "caribbeanstud.helpPlay", "caribbeanstud.helpFold"},
+			ExtraCommandLines: []string{"  log                  action log"},
+		}),
+	BindCuiFor("texasholdembonus",
+		func() usecase.TexasHoldemBonusInteractorIF {
+			return usecase.NewTexasHoldemBonusInteractor(domain.NewDefaultTexasHoldemBonus(), new(presenter.TexasHoldemBonusCuiPresenter))
+		},
+		controller.NewTexasHoldemBonusCuiController,
+		CuiHelpSpec{
+			TitleKey: "texasholdembonus.helpTitle",
+			CommandKeys: []string{
+				"texasholdembonus.helpBet",
+				"texasholdembonus.helpPlay",
+				"texasholdembonus.helpFold",
+				"texasholdembonus.helpCheck",
+				"texasholdembonus.helpRaise",
+			},
+			ExtraCommandLines: []string{"  log                  action log"},
+		}),
+	BindCuiFor("war",
+		func() usecase.WarInteractorIF {
+			return usecase.NewWarInteractor(domain.NewDefaultWar(), new(presenter.WarCuiPresenter))
+		},
+		controller.NewWarCuiController,
+		CuiHelpSpec{
+			TitleKey:    "war.helpTitle",
+			CommandKeys: []string{"war.helpStep", "war.helpAutoPlay"},
+			SettingKeys: []string{"war.helpSetMax"},
+		}),
+	BindCuiFor("canfield",
+		func() usecase.CanfieldInteractorIF {
+			return usecase.NewCanfieldInteractor(domain.NewDefaultCanfield(), new(presenter.CanfieldCuiPresenter))
+		},
+		controller.NewCanfieldCuiController,
+		CuiHelpSpec{
+			TitleKey: "canfield.helpTitle",
+			CommandKeys: []string{
+				"canfield.helpDraw",
+				"canfield.helpMove",
+				"canfield.helpMoveWF",
+				"canfield.helpMoveRT",
+				"canfield.helpMoveRF",
+				"canfield.helpMoveTF",
+				"canfield.helpMoveTT",
+				"canfield.helpGiveUp",
+				"canfield.helpHint",
+				"canfield.helpAutoComplete",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("fiftyone",
+		func() usecase.FiftyOneInteractorIF {
+			return usecase.NewFiftyOneInteractor(domain.NewDefaultFiftyOne(), new(presenter.FiftyOneCuiPresenter))
+		},
+		controller.NewFiftyOneCuiController,
+		CuiHelpSpec{
+			TitleKey:    "fiftyone.helpTitle",
+			CommandKeys: []string{"fiftyone.helpPlay", "fiftyone.helpAll", "fiftyone.helpStop"},
+			SettingKeys: []string{"fiftyone.helpSetDifficulty"},
+		}),
+	BindCuiFor("yukon",
+		func() usecase.YukonInteractorIF {
+			return usecase.NewYukonInteractor(domain.NewDefaultYukon(), new(presenter.YukonCuiPresenter))
+		},
+		controller.NewYukonCuiController,
+		CuiHelpSpec{
+			TitleKey: "yukon.helpTitle",
+			CommandKeys: []string{
+				"yukon.helpMove",
+				"yukon.helpMoveTF",
+				"yukon.helpMoveTT",
+				"yukon.helpGiveUp",
+				"yukon.helpHint",
+				"yukon.helpAutoComplete",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("russiansolitaire",
+		func() usecase.RussianSolitaireInteractorIF {
+			return usecase.NewRussianSolitaireInteractor(domain.NewDefaultRussianSolitaire(), new(presenter.RussianSolitaireCuiPresenter))
+		},
+		controller.NewRussianSolitaireCuiController,
+		CuiHelpSpec{
+			TitleKey: "russiansolitaire.helpTitle",
+			CommandKeys: []string{
+				"russiansolitaire.helpMove",
+				"russiansolitaire.helpMoveTF",
+				"russiansolitaire.helpMoveTT",
+				"russiansolitaire.helpGiveUp",
+				"russiansolitaire.helpHint",
+				"russiansolitaire.helpAutoComplete",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("whist",
+		func() usecase.WhistInteractorIF {
+			return usecase.NewWhistInteractor(domain.NewDefaultWhist(), new(presenter.WhistCuiPresenter))
+		},
+		controller.NewWhistCuiController,
+		CuiHelpSpec{
+			TitleKey:          "whist.helpTitle",
+			CommandKeys:       []string{"whist.helpPlay", "whist.helpNext", "whist.helpNextRound"},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"whist.helpSetDifficulty", "whist.helpSetLimit"},
+		}),
+	BindCuiFor("catchten",
+		func() usecase.CatchTenInteractorIF {
+			return usecase.NewCatchTenInteractor(domain.NewDefaultCatchTen(), new(presenter.CatchTenCuiPresenter))
+		},
+		controller.NewCatchTenCuiController,
+		CuiHelpSpec{
+			TitleKey:          "catchten.helpTitle",
+			CommandKeys:       []string{"catchten.helpPlay", "catchten.helpNext", "catchten.helpNextRound"},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"catchten.helpSetDifficulty", "catchten.helpSetLimit"},
+		}),
+	BindCuiFor("letitride",
+		func() usecase.LetItRideInteractorIF {
+			return usecase.NewLetItRideInteractor(domain.NewDefaultLetItRide(), new(presenter.LetItRideCuiPresenter))
+		},
+		controller.NewLetItRideCuiController,
+		CuiHelpSpec{
+			TitleKey:          "letitride.helpTitle",
+			CommandKeys:       []string{"letitride.helpBet", "letitride.helpPull", "letitride.helpLetItRide"},
+			ExtraCommandLines: []string{"  log                  action log"},
+		}),
+	BindCuiFor("pokersquares",
+		func() usecase.PokerSquaresInteractorIF {
+			return usecase.NewPokerSquaresInteractor(domain.NewDefaultPokerSquares(), new(presenter.PokerSquaresCuiPresenter))
+		},
+		controller.NewPokerSquaresCuiController,
+		CuiHelpSpec{Body: []string{
+			"Poker Squares (ポーカー・スクエアズ)",
+			"",
+			i18n.T("gameCommands"),
+			"  p <row> <col>            カードを配置 (0-4)",
+			"  u                        アンドゥ",
+			"  g                        ギブアップ",
+			"  h                        ヒント (現在のカードの最善配置)",
+			"  l                        action log",
+			"",
+			i18n.T("session"),
+			i18n.T("resetEntry"),
+			i18n.T("quitEntry"),
+			i18n.T("helpEntry"),
+		}}),
+	BindCuiFor("pageone",
+		func() usecase.PageOneInteractorIF {
+			return usecase.NewPageOneInteractor(domain.NewDefaultPageOne(), new(presenter.PageOneCuiPresenter))
+		},
+		controller.NewPageOneCuiController,
+		CuiHelpSpec{
+			TitleKey: "pageone.helpTitle",
+			CommandKeys: []string{
+				"pageone.helpPlay",
+				"pageone.helpDraw",
+				"pageone.helpDeclare",
+				"pageone.helpSkip",
+				"pageone.helpNextRound",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"pageone.helpSetDifficulty", "pageone.helpSetLimit"},
+		}),
+	BindCuiFor("reddog",
+		func() usecase.RedDogInteractorIF {
+			return usecase.NewRedDogInteractor(domain.NewDefaultRedDog(), new(presenter.RedDogCuiPresenter))
+		},
+		controller.NewRedDogCuiController,
+		CuiHelpSpec{
+			TitleKey:          "reddog.helpTitle",
+			CommandKeys:       []string{"reddog.helpBet", "reddog.helpRaise", "reddog.helpStay", "reddog.helpHint"},
+			ExtraCommandLines: []string{"  log                  action log"},
+		}),
+	BindCuiFor("badugi",
+		func() usecase.BadugiInteractorIF {
+			return usecase.NewBadugiInteractor(domain.NewDefaultBadugi(), new(presenter.BadugiCuiPresenter))
+		},
+		controller.NewBadugiCuiController,
+		CuiHelpSpec{
+			TitleKey: "badugi.helpTitle",
+			CommandKeys: []string{
+				"badugi.helpBet",
+				"badugi.helpCall",
+				"badugi.helpRaise",
+				"badugi.helpCheck",
+				"badugi.helpFold",
+				"badugi.helpAllIn",
+				"badugi.helpExchange",
+				"badugi.helpStand",
+			},
+			SettingKeys: []string{"badugi.helpBettingLimit", "badugi.helpCpuCount"},
+		}),
+	BindCuiFor("deucetoseven",
+		func() usecase.DeuceToSevenInteractorIF {
+			return usecase.NewDeuceToSevenInteractor(domain.NewDefaultDeuceToSeven(), new(presenter.DeuceToSevenCuiPresenter))
+		},
+		controller.NewDeuceToSevenCuiController,
+		CuiHelpSpec{
+			TitleKey: "deucetoseven.helpTitle",
+			CommandKeys: []string{
+				"deucetoseven.helpBet",
+				"deucetoseven.helpCall",
+				"deucetoseven.helpRaise",
+				"deucetoseven.helpCheck",
+				"deucetoseven.helpFold",
+				"deucetoseven.helpAllIn",
+				"deucetoseven.helpExchange",
+				"deucetoseven.helpStand",
+				"deucetoseven.helpHint",
+			},
+			SettingKeys: []string{"deucetoseven.helpBettingLimit", "deucetoseven.helpCpuCount"},
+		}),
+	BindCuiFor("razz",
+		func() usecase.SevenCardStudInteractorIF {
+			return usecase.NewSevenCardStudInteractor(domain.NewDefaultRazz(), new(presenter.SevenCardStudCuiPresenter))
+		},
+		controller.NewSevenCardStudCuiController,
+		CuiHelpSpec{
+			TitleKey: "razz.helpTitle",
+			CommandKeys: append([]string{
+				"sevencardstud.helpFold",
+				"sevencardstud.helpCheck",
+				"sevencardstud.helpCall",
+				"sevencardstud.helpBet",
+				"sevencardstud.helpRaise",
+				"sevencardstud.helpAllIn",
+			}, tournamentRebuyAddOnKeys...),
+			SettingKeys: append([]string{
+				"sevencardstud.helpBettingLimit", "sevencardstud.helpTournament",
+			}, studAnteKeys...),
+		}),
+	BindCuiFor("sevencardstudhilo",
+		func() usecase.SevenCardStudInteractorIF {
+			return usecase.NewSevenCardStudInteractor(domain.NewDefaultSevenCardStudHiLo(), new(presenter.SevenCardStudCuiPresenter))
+		},
+		controller.NewSevenCardStudCuiController,
+		CuiHelpSpec{
+			TitleKey: "sevencardstudhilo.helpTitle",
+			CommandKeys: append([]string{
+				"sevencardstud.helpFold",
+				"sevencardstud.helpCheck",
+				"sevencardstud.helpCall",
+				"sevencardstud.helpBet",
+				"sevencardstud.helpRaise",
+				"sevencardstud.helpAllIn",
+			}, tournamentRebuyAddOnKeys...),
+			SettingKeys: append([]string{
+				"sevencardstud.helpBettingLimit", "sevencardstud.helpTournament",
+			}, studAnteKeys...),
+		}),
+	BindCuiFor("scorpion",
+		func() usecase.ScorpionInteractorIF {
+			return usecase.NewScorpionInteractor(domain.NewDefaultScorpion(), new(presenter.ScorpionCuiPresenter))
+		},
+		controller.NewScorpionCuiController,
+		CuiHelpSpec{
+			TitleKey: "scorpion.helpTitle",
+			CommandKeys: []string{
+				"scorpion.helpMove",
+				"scorpion.helpMoveTT",
+				"scorpion.helpDeal",
+				"scorpion.helpGiveUp",
+				"scorpion.helpHint",
+				"scorpion.helpLegal",
+				"scorpion.helpAutoComplete",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("wasp",
+		func() usecase.WaspInteractorIF {
+			return usecase.NewWaspInteractor(domain.NewDefaultWasp(), new(presenter.WaspCuiPresenter))
+		},
+		controller.NewWaspCuiController,
+		CuiHelpSpec{
+			TitleKey: "wasp.helpTitle",
+			CommandKeys: []string{
+				"wasp.helpMove",
+				"wasp.helpMoveTT",
+				"wasp.helpDeal",
+				"wasp.helpGiveUp",
+				"wasp.helpHint",
+				"wasp.helpLegal",
+				"wasp.helpAutoComplete",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("accordion",
+		func() usecase.AccordionInteractorIF {
+			return usecase.NewAccordionInteractor(domain.NewDefaultAccordion(), new(presenter.AccordionCuiPresenter))
+		},
+		controller.NewAccordionCuiController,
+		CuiHelpSpec{
+			TitleKey: "accordion.helpTitle",
+			CommandKeys: []string{
+				"accordion.helpMove",
+				"accordion.helpGiveup",
+				"accordion.helpHint",
+				"accordion.helpLog",
+				"accordion.helpUndo",
+			},
+		}),
+	BindCuiFor("trash",
+		func() usecase.TrashInteractorIF {
+			return usecase.NewTrashInteractor(domain.NewDefaultTrash(), new(presenter.TrashCuiPresenter))
+		},
+		controller.NewTrashCuiController,
+		CuiHelpSpec{
+			TitleKey: "trash.helpTitle",
+			CommandKeys: []string{
+				"trash.helpDraw",
+				"trash.helpPlace",
+				"trash.helpCpu",
+				"trash.helpHint",
+				"trash.helpLog",
+			},
+		}),
+	BindCuiFor("sevenbridge",
+		func() usecase.SevenBridgeInteractorIF {
+			return usecase.NewSevenBridgeInteractor(domain.NewDefaultSevenBridge(), new(presenter.SevenBridgeCuiPresenter))
+		},
+		controller.NewSevenBridgeCuiController,
+		CuiHelpSpec{
+			TitleKey: "sevenbridge.helpTitle",
+			CommandKeys: []string{
+				"sevenbridge.helpDrawStock",
+				"sevenbridge.helpPon",
+				"sevenbridge.helpChi",
+				"sevenbridge.helpMeld",
+				"sevenbridge.helpLayoff",
+				"sevenbridge.helpDiscard",
+				"sevenbridge.helpNextRound",
+				"sevenbridge.helpHint",
+			},
+			SettingKeys: []string{"sevenbridge.helpSetDifficulty", "sevenbridge.helpSetLimit"},
+		}),
+	BindCuiFor("president",
+		func() usecase.PresidentInteractorIF {
+			return usecase.NewPresidentInteractor(domain.NewDefaultPresident(), new(presenter.PresidentCuiPresenter))
+		},
+		controller.NewPresidentCuiController,
+		CuiHelpSpec{
+			TitleKey: "president.helpTitle",
+			CommandKeys: []string{
+				"president.helpPlay",
+				"president.helpPass",
+				"president.helpHint",
+				"president.helpLog",
+			},
+			SettingKeys: []string{
+				"president.helpSetDifficulty",
+				"president.helpSetRule",
+			},
+		}),
+	BindCuiFor("cassino",
+		func() usecase.CassinoInteractorIF {
+			return usecase.NewCassinoInteractor(domain.NewDefaultCassino(), new(presenter.CassinoCuiPresenter))
+		},
+		controller.NewCassinoCuiController,
+		CuiHelpSpec{
+			TitleKey: "cassino.helpTitle",
+			CommandKeys: []string{
+				"cassino.helpTake",
+				"cassino.helpBuild",
+				"cassino.helpTrail",
+				"cassino.helpNext",
+				"cassino.helpHint",
+				"cassino.helpLog",
+			},
+			SettingKeys: []string{
+				"cassino.helpSetDifficulty",
+				"cassino.helpSetRule",
+			},
+		}),
+	BindCuiFor("spanish21",
+		func() usecase.BlackJackInteractorIF {
+			return usecase.NewBlackJackInteractor(domain.NewSpanish21BlackJack(), new(presenter.BlackJackCuiPresenter))
+		},
+		controller.NewBlackJackCuiController,
+		CuiHelpSpec{
+			TitleKey: "spanish21.helpTitle",
+			CommandKeys: []string{
+				"blackjack.helpBet",
+				"blackjack.helpHit",
+				"blackjack.helpStand",
+				"blackjack.helpDouble",
+				"blackjack.helpSplit",
+				"blackjack.helpInsurance",
+				"blackjack.helpDeclineInsurance",
+			},
+			SettingKeys: []string{"blackjack.helpSetCpuCount"},
+		}),
+	BindCuiFor("calculation",
+		func() usecase.CalculationInteractorIF {
+			return usecase.NewCalculationInteractor(domain.NewDefaultCalculation(), new(presenter.CalculationCuiPresenter))
+		},
+		controller.NewCalculationCuiController,
+		CuiHelpSpec{
+			TitleKey: "calculation.helpTitle",
+			CommandKeys: []string{
+				"calculation.helpStockToFoundation",
+				"calculation.helpStockToWaste",
+				"calculation.helpWasteToFoundation",
+				"calculation.helpGiveUp",
+				"calculation.helpHint",
+				"calculation.helpAutoComplete",
+				"calculation.helpUndo",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("sirtommy",
+		func() usecase.SirTommyInteractorIF {
+			return usecase.NewSirTommyInteractor(domain.NewDefaultSirTommy(), new(presenter.SirTommyCuiPresenter))
+		},
+		controller.NewSirTommyCuiController,
+		CuiHelpSpec{
+			TitleKey: "sirtommy.helpTitle",
+			CommandKeys: []string{
+				"sirtommy.helpStockToFoundation",
+				"sirtommy.helpStockToWaste",
+				"sirtommy.helpWasteToFoundation",
+				"sirtommy.helpGiveUp",
+				"sirtommy.helpHint",
+				"sirtommy.helpAutoComplete",
+				"sirtommy.helpUndo",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("bisley",
+		func() usecase.BisleyInteractorIF {
+			return usecase.NewBisleyInteractor(domain.NewDefaultBisley(), new(presenter.BisleyCuiPresenter))
+		},
+		controller.NewBisleyCuiController,
+		CuiHelpSpec{
+			TitleKey: "bisley.helpTitle",
+			CommandKeys: []string{
+				"bisley.helpMoveTA",
+				"bisley.helpMoveTK",
+				"bisley.helpMoveTT",
+				"bisley.helpGiveUp",
+				"bisley.helpHint",
+				"bisley.helpAutoComplete",
+				"bisley.helpUndo",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("napoleonssquare",
+		func() usecase.NapoleonsSquareInteractorIF {
+			return usecase.NewNapoleonsSquareInteractor(domain.NewDefaultNapoleonsSquare(), new(presenter.NapoleonsSquareCuiPresenter))
+		},
+		controller.NewNapoleonsSquareCuiController,
+		CuiHelpSpec{
+			TitleKey: "napoleonssquare.helpTitle",
+			CommandKeys: []string{
+				"napoleonssquare.helpDraw",
+				"napoleonssquare.helpMoveWF",
+				"napoleonssquare.helpMoveWT",
+				"napoleonssquare.helpMoveTF",
+				"napoleonssquare.helpMoveTT",
+				"napoleonssquare.helpGiveUp",
+				"napoleonssquare.helpHint",
+				"napoleonssquare.helpAutoComplete",
+				"napoleonssquare.helpUndo",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("grandfathersclock",
+		func() usecase.GrandfathersClockInteractorIF {
+			return usecase.NewGrandfathersClockInteractor(domain.NewDefaultGrandfathersClock(), new(presenter.GrandfathersClockCuiPresenter))
+		},
+		controller.NewGrandfathersClockCuiController,
+		CuiHelpSpec{
+			TitleKey: "grandfathersclock.helpTitle",
+			CommandKeys: []string{
+				"grandfathersclock.helpMoveTF",
+				"grandfathersclock.helpMoveTT",
+				"grandfathersclock.helpGiveUp",
+				"grandfathersclock.helpHint",
+				"grandfathersclock.helpAutoComplete",
+				"grandfathersclock.helpUndo",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("missmilligan",
+		func() usecase.MissMilliganInteractorIF {
+			return usecase.NewMissMilliganInteractor(domain.NewDefaultMissMilligan(), new(presenter.MissMilliganCuiPresenter))
+		},
+		controller.NewMissMilliganCuiController,
+		CuiHelpSpec{
+			TitleKey: "missmilligan.helpTitle",
+			CommandKeys: []string{
+				"missmilligan.helpDeal",
+				"missmilligan.helpMoveTF",
+				"missmilligan.helpMoveTT",
+				"missmilligan.helpWaive",
+				"missmilligan.helpMoveWT",
+				"missmilligan.helpMoveWF",
+				"missmilligan.helpGiveUp",
+				"missmilligan.helpHint",
+				"missmilligan.helpAutoComplete",
+				"missmilligan.helpUndo",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("duchess",
+		func() usecase.DuchessInteractorIF {
+			return usecase.NewDuchessInteractor(domain.NewDefaultDuchess(), new(presenter.DuchessCuiPresenter))
+		},
+		controller.NewDuchessCuiController,
+		CuiHelpSpec{
+			TitleKey: "duchess.helpTitle",
+			CommandKeys: []string{
+				"duchess.helpBase",
+				"duchess.helpDraw",
+				"duchess.helpMoveRF",
+				"duchess.helpMoveRT",
+				"duchess.helpMoveWF",
+				"duchess.helpMoveWT",
+				"duchess.helpMoveTF",
+				"duchess.helpMoveTT",
+				"duchess.helpGiveUp",
+				"duchess.helpHint",
+				"duchess.helpAutoComplete",
+				"duchess.helpUndo",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("windmill",
+		func() usecase.WindmillInteractorIF {
+			return usecase.NewWindmillInteractor(domain.NewDefaultWindmill(), new(presenter.WindmillCuiPresenter))
+		},
+		controller.NewWindmillCuiController,
+		CuiHelpSpec{
+			TitleKey: "windmill.helpTitle",
+			CommandKeys: []string{
+				"windmill.helpDraw",
+				"windmill.helpMoveSC",
+				"windmill.helpMoveSK",
+				"windmill.helpMoveWC",
+				"windmill.helpMoveWK",
+				"windmill.helpMoveKC",
+				"windmill.helpGiveUp",
+				"windmill.helpHint",
+				"windmill.helpAutoComplete",
+				"windmill.helpUndo",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("americantoad",
+		func() usecase.AmericanToadInteractorIF {
+			return usecase.NewAmericanToadInteractor(domain.NewDefaultAmericanToad(), new(presenter.AmericanToadCuiPresenter))
+		},
+		controller.NewAmericanToadCuiController,
+		CuiHelpSpec{
+			TitleKey: "americantoad.helpTitle",
+			CommandKeys: []string{
+				"americantoad.helpDraw",
+				"americantoad.helpMoveRF",
+				"americantoad.helpMoveRT",
+				"americantoad.helpMoveWF",
+				"americantoad.helpMoveWT",
+				"americantoad.helpMoveTF",
+				"americantoad.helpMoveTT",
+				"americantoad.helpGiveUp",
+				"americantoad.helpHint",
+				"americantoad.helpAutoComplete",
+				"americantoad.helpUndo",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("spiteandmalice",
+		func() usecase.SpiteAndMaliceInteractorIF {
+			return usecase.NewSpiteAndMaliceInteractor(domain.NewDefaultSpiteAndMalice(), new(presenter.SpiteAndMaliceCuiPresenter))
+		},
+		controller.NewSpiteAndMaliceCuiController,
+		CuiHelpSpec{
+			TitleKey: "spiteandmalice.helpTitle",
+			CommandKeys: []string{
+				"spiteandmalice.helpPlayHand",
+				"spiteandmalice.helpPlayGoal",
+				"spiteandmalice.helpPlaySide",
+				"spiteandmalice.helpDiscard",
+				"spiteandmalice.helpCpu",
+				"spiteandmalice.helpHint",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("skat",
+		func() usecase.SkatInteractorIF {
+			return usecase.NewSkatInteractor(domain.NewDefaultSkat(), new(presenter.SkatCuiPresenter))
+		},
+		controller.NewSkatCuiController,
+		CuiHelpSpec{
+			TitleKey: "skat.helpTitle",
+			CommandKeys: []string{
+				"skat.helpBid",
+				"skat.helpPickSkat",
+				"skat.helpDiscard",
+				"skat.helpGame",
+				"skat.helpPlay",
+				"skat.helpNext",
+				"skat.helpNextRound",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"skat.helpSetDifficulty", "skat.helpSetTarget"},
+		}),
+	BindCuiFor("congress",
+		func() usecase.CongressInteractorIF {
+			return usecase.NewCongressInteractor(domain.NewDefaultCongress(), new(presenter.CongressCuiPresenter))
+		},
+		controller.NewCongressCuiController,
+		CuiHelpSpec{
+			TitleKey: "congress.helpTitle",
+			CommandKeys: []string{
+				"congress.helpDraw",
+				"congress.helpMoveTF",
+				"congress.helpMoveTT",
+				"congress.helpMoveWF",
+				"congress.helpMoveWT",
+				"congress.helpMoveST",
+				"congress.helpGiveUp",
+				"congress.helpHint",
+				"congress.helpAutoComplete",
+				"congress.helpUndo",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("terrace",
+		func() usecase.TerraceInteractorIF {
+			return usecase.NewTerraceInteractor(domain.NewDefaultTerrace(), new(presenter.TerraceCuiPresenter))
+		},
+		controller.NewTerraceCuiController,
+		CuiHelpSpec{
+			TitleKey: "terrace.helpTitle",
+			CommandKeys: []string{
+				"terrace.helpDraw",
+				"terrace.helpMoveRF",
+				"terrace.helpMoveWF",
+				"terrace.helpMoveWT",
+				"terrace.helpMoveTF",
+				"terrace.helpMoveTT",
+				"terrace.helpGiveUp",
+				"terrace.helpHint",
+				"terrace.helpAutoComplete",
+				"terrace.helpUndo",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("braid",
+		func() usecase.BraidInteractorIF {
+			return usecase.NewBraidInteractor(domain.NewDefaultBraid(), new(presenter.BraidCuiPresenter))
+		},
+		controller.NewBraidCuiController,
+		CuiHelpSpec{
+			TitleKey: "braid.helpTitle",
+			CommandKeys: []string{
+				"braid.helpDraw",
+				"braid.helpDirection",
+				"braid.helpMoveBrF",
+				"braid.helpMoveFdF",
+				"braid.helpMoveHpF",
+				"braid.helpMoveWF",
+				"braid.helpMoveWHp",
+				"braid.helpGiveUp",
+				"braid.helpHint",
+				"braid.helpAutoComplete",
+				"braid.helpUndo",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("pontoon",
+		func() usecase.PontoonInteractorIF {
+			return usecase.NewPontoonInteractor(domain.NewDefaultPontoon(), new(presenter.PontoonCuiPresenter))
+		},
+		controller.NewPontoonCuiController,
+		CuiHelpSpec{
+			TitleKey: "pontoon.helpTitle",
+			CommandKeys: []string{
+				"pontoon.helpBet",
+				"pontoon.helpDeal",
+				"pontoon.helpStick",
+				"pontoon.helpTwist",
+				"pontoon.helpBuy",
+				"pontoon.helpSplit",
+				"pontoon.helpBankerTwist",
+				"pontoon.helpBankerStay",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("settemezzo",
+		func() usecase.SetteEMezzoInteractorIF {
+			return usecase.NewSetteEMezzoInteractor(domain.NewDefaultSetteEMezzo(), new(presenter.SetteEMezzoCuiPresenter))
+		},
+		controller.NewSetteEMezzoCuiController,
+		CuiHelpSpec{
+			TitleKey: "settemezzo.helpTitle",
+			CommandKeys: []string{
+				"settemezzo.helpBet",
+				"settemezzo.helpDeal",
+				"settemezzo.helpHit",
+				"settemezzo.helpStand",
+				"settemezzo.helpMatta",
+				"settemezzo.helpBankerHit",
+				"settemezzo.helpBankerStand",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("niuniu",
+		func() usecase.NiuNiuInteractorIF {
+			return usecase.NewNiuNiuInteractor(domain.NewDefaultNiuNiu(), new(presenter.NiuNiuCuiPresenter))
+		},
+		controller.NewNiuNiuCuiController,
+		CuiHelpSpec{
+			TitleKey:          "niuniu.helpTitle",
+			CommandKeys:       []string{"niuniu.helpBet"},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("bura",
+		func() usecase.BuraInteractorIF {
+			return usecase.NewBuraInteractor(domain.NewDefaultBura(), new(presenter.BuraCuiPresenter))
+		},
+		controller.NewBuraCuiController,
+		CuiHelpSpec{
+			TitleKey: "bura.helpTitle",
+			CommandKeys: []string{
+				"bura.helpPlay",
+				"bura.helpClaim",
+				"bura.helpDeclare",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("mushi",
+		func() usecase.MushiInteractorIF {
+			return usecase.NewMushiInteractor(domain.NewDefaultMushi(), new(presenter.MushiCuiPresenter))
+		},
+		controller.NewMushiCuiController,
+		CuiHelpSpec{
+			TitleKey: "mushi.helpTitle",
+			CommandKeys: []string{
+				"mushi.helpPlay",
+				"mushi.helpSelect",
+				"mushi.helpNext",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("toepen",
+		func() usecase.ToepenInteractorIF {
+			return usecase.NewToepenInteractor(domain.NewDefaultToepen(), new(presenter.ToepenCuiPresenter))
+		},
+		controller.NewToepenCuiController,
+		CuiHelpSpec{
+			TitleKey: "toepen.helpTitle",
+			CommandKeys: []string{
+				"toepen.helpPlay",
+				"toepen.helpToep",
+				"toepen.helpStay",
+				"toepen.helpFold",
+				"toepen.helpRedeal",
+				"toepen.helpNext",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("chineseten",
+		func() usecase.ChineseTenInteractorIF {
+			return usecase.NewChineseTenInteractor(domain.NewDefaultChineseTen(), new(presenter.ChineseTenCuiPresenter))
+		},
+		controller.NewChineseTenCuiController,
+		CuiHelpSpec{
+			TitleKey: "chineseten.helpTitle",
+			CommandKeys: []string{
+				"chineseten.helpPlay",
+				"chineseten.helpSelect",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("trex",
+		func() usecase.TrexInteractorIF {
+			return usecase.NewTrexInteractor(domain.NewDefaultTrex(), new(presenter.TrexCuiPresenter))
+		},
+		controller.NewTrexCuiController,
+		CuiHelpSpec{
+			TitleKey: "trex.helpTitle",
+			CommandKeys: []string{
+				"trex.helpChoose",
+				"trex.helpPlay",
+				"trex.helpPass",
+				"trex.helpNext",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("skitgubbe",
+		func() usecase.SkitgubbeInteractorIF {
+			return usecase.NewSkitgubbeInteractor(domain.NewDefaultSkitgubbe(), new(presenter.SkitgubbeCuiPresenter))
+		},
+		controller.NewSkitgubbeCuiController,
+		CuiHelpSpec{
+			TitleKey: "skitgubbe.helpTitle",
+			CommandKeys: []string{
+				"skitgubbe.helpPlay",
+				"skitgubbe.helpPickUp",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("loba",
+		func() usecase.LobaInteractorIF {
+			return usecase.NewLobaInteractor(domain.NewDefaultLoba(), new(presenter.LobaCuiPresenter))
+		},
+		controller.NewLobaCuiController,
+		CuiHelpSpec{
+			TitleKey: "loba.helpTitle",
+			CommandKeys: []string{
+				"loba.helpDrawStock",
+				"loba.helpDrawDiscard",
+				"loba.helpMeld",
+				"loba.helpLayOff",
+				"loba.helpDiscard",
+				"loba.helpNext",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("sjavs",
+		func() usecase.SjavsInteractorIF {
+			return usecase.NewSjavsInteractor(domain.NewDefaultSjavs(), new(presenter.SjavsCuiPresenter))
+		},
+		controller.NewSjavsCuiController,
+		CuiHelpSpec{
+			TitleKey: "sjavs.helpTitle",
+			CommandKeys: []string{
+				"sjavs.helpBid",
+				"sjavs.helpPlay",
+				"sjavs.helpNext",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("laughandliedown",
+		func() usecase.LaughAndLieDownInteractorIF {
+			return usecase.NewLaughAndLieDownInteractor(domain.NewDefaultLaughAndLieDown(), new(presenter.LaughAndLieDownCuiPresenter))
+		},
+		controller.NewLaughAndLieDownCuiController,
+		CuiHelpSpec{
+			TitleKey: "laughandliedown.helpTitle",
+			CommandKeys: []string{
+				"laughandliedown.helpPlay",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("shithead",
+		func() usecase.ShitheadInteractorIF {
+			return usecase.NewShitheadInteractor(domain.NewDefaultShithead(), new(presenter.ShitheadCuiPresenter))
+		},
+		controller.NewShitheadCuiController,
+		CuiHelpSpec{
+			TitleKey: "shithead.helpTitle",
+			CommandKeys: []string{
+				"shithead.helpPlay",
+				"shithead.helpPickup",
+				"shithead.helpLog",
+			},
+			SettingKeys: []string{
+				"shithead.helpSetDifficulty",
+				"shithead.helpSetRule",
+			},
+		}),
+	BindCuiFor("nertz",
+		func() usecase.NertzInteractorIF {
+			return usecase.NewNertzInteractor(domain.NewDefaultNertz(), new(presenter.NertzCuiPresenter))
+		},
+		controller.NewNertzCuiController,
+		CuiHelpSpec{
+			TitleKey: "nertz.helpTitle",
+			CommandKeys: []string{
+				"nertz.helpDraw",
+				"nertz.helpMoveNF",
+				"nertz.helpMoveNT",
+				"nertz.helpMoveWF",
+				"nertz.helpMoveWT",
+				"nertz.helpMoveTF",
+				"nertz.helpMoveTT",
+				"nertz.helpTick",
+				"nertz.helpUndo",
+				"nertz.helpNextRound",
+				"nertz.helpHint",
+			},
+		}),
+	BindCuiFor("slapjack",
+		func() usecase.SlapjackInteractorIF {
+			return usecase.NewSlapjackInteractor(domain.NewDefaultSlapjack(), new(presenter.SlapjackCuiPresenter))
+		},
+		controller.NewSlapjackCuiController,
+		CuiHelpSpec{
+			TitleKey: "slapjack.helpTitle",
+			CommandKeys: []string{
+				"slapjack.helpStep",
+				"slapjack.helpSlap",
+				"slapjack.helpTick",
+				"slapjack.helpLog",
+			},
+			SettingKeys: []string{"slapjack.helpSetDifficulty"},
+		}),
+	BindCuiFor("egyptianratscrew",
+		func() usecase.EgyptianRatscrewInteractorIF {
+			return usecase.NewEgyptianRatscrewInteractor(domain.NewDefaultEgyptianRatscrew(), new(presenter.EgyptianRatscrewCuiPresenter))
+		},
+		controller.NewEgyptianRatscrewCuiController,
+		CuiHelpSpec{
+			TitleKey: "egyptianratscrew.helpTitle",
+			CommandKeys: []string{
+				"egyptianratscrew.helpStep",
+				"egyptianratscrew.helpSlap",
+				"egyptianratscrew.helpTick",
+				"egyptianratscrew.helpLog",
+			},
+			SettingKeys: []string{"egyptianratscrew.helpSetDifficulty"},
+		}),
+	BindCuiFor("bakersdozen",
+		func() usecase.BakersDozenInteractorIF {
+			return usecase.NewBakersDozenInteractor(domain.NewDefaultBakersDozen(), new(presenter.BakersDozenCuiPresenter))
+		},
+		controller.NewBakersDozenCuiController,
+		CuiHelpSpec{
+			TitleKey: "bakersdozen.helpTitle",
+			CommandKeys: []string{
+				"bakersdozen.helpMoveTT",
+				"bakersdozen.helpMoveTF",
+				"bakersdozen.helpGiveUp",
+				"bakersdozen.helpHint",
+				"bakersdozen.helpAutoComplete",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("tonk",
+		func() usecase.TonkInteractorIF {
+			return usecase.NewTonkInteractor(domain.NewDefaultTonk(), new(presenter.TonkCuiPresenter))
+		},
+		controller.NewTonkCuiController,
+		CuiHelpSpec{
+			TitleKey: "tonk.helpTitle",
+			CommandKeys: []string{
+				"tonk.helpDrawStock",
+				"tonk.helpDrawDiscard",
+				"tonk.helpDiscard",
+				"tonk.helpKnock",
+				"tonk.helpNextRound",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"tonk.helpSetDifficulty", "tonk.helpSetLimit"},
+		}),
+	BindCuiFor("casinowar",
+		func() usecase.CasinoWarInteractorIF {
+			return usecase.NewCasinoWarInteractor(domain.NewDefaultCasinoWar(), new(presenter.CasinoWarCuiPresenter))
+		},
+		controller.NewCasinoWarCuiController,
+		CuiHelpSpec{
+			TitleKey:          "casinowar.helpTitle",
+			CommandKeys:       []string{"casinowar.helpBet", "casinowar.helpSurrender", "casinowar.helpWar"},
+			ExtraCommandLines: []string{"  log                  action log"},
+		}),
+	BindCuiFor("pitch",
+		func() usecase.PitchInteractorIF {
+			return usecase.NewPitchInteractor(domain.NewDefaultPitch(), new(presenter.PitchCuiPresenter))
+		},
+		controller.NewPitchCuiController,
+		CuiHelpSpec{
+			TitleKey:          "pitch.helpTitle",
+			CommandKeys:       []string{"pitch.helpBid", "pitch.helpPlay", "pitch.helpNext", "pitch.helpNextRound"},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"pitch.helpSetDifficulty", "pitch.helpSetLimit"},
+		}),
+	BindCuiFor("dragontiger",
+		func() usecase.DragonTigerInteractorIF {
+			return usecase.NewDragonTigerInteractor(domain.NewDefaultDragonTiger(), new(presenter.DragonTigerCuiPresenter))
+		},
+		controller.NewDragonTigerCuiController,
+		CuiHelpSpec{
+			TitleKey:          "dragontiger.helpTitle",
+			CommandKeys:       []string{"dragontiger.helpBet", "dragontiger.helpClear"},
+			ExtraCommandLines: []string{"  log                  action log"},
+		}),
+	BindCuiFor("blackjackswitch",
+		func() usecase.BlackJackSwitchInteractorIF {
+			return usecase.NewBlackJackSwitchInteractor(domain.NewDefaultBlackJackSwitch(), new(presenter.BlackJackSwitchCuiPresenter))
+		},
+		controller.NewBlackJackSwitchCuiController,
+		CuiHelpSpec{
+			TitleKey: "blackjackswitch.helpTitle",
+			CommandKeys: []string{
+				"blackjackswitch.helpBet",
+				"blackjackswitch.helpSwitch",
+				"blackjackswitch.helpKeep",
+				"blackjackswitch.helpHit",
+				"blackjackswitch.helpStand",
+				"blackjackswitch.helpDoubleDown",
+			},
+			ExtraCommandLines: []string{"  log                  action log"},
+		}),
+	BindCuiFor("montecarlo",
+		func() usecase.MonteCarloInteractorIF {
+			return usecase.NewMonteCarloInteractor(domain.NewDefaultMonteCarlo(), new(presenter.MonteCarloCuiPresenter))
+		},
+		controller.NewMonteCarloCuiController,
+		CuiHelpSpec{
+			TitleKey: "montecarlo.helpTitle",
+			CommandKeys: []string{
+				"montecarlo.helpRemove",
+				"montecarlo.helpDeal",
+				"montecarlo.helpUndo",
+				"montecarlo.helpHint",
+				"montecarlo.helpGiveup",
+				"montecarlo.helpLog",
+			},
+		}),
+	BindCuiFor("contractrummy",
+		func() usecase.ContractRummyInteractorIF {
+			return usecase.NewContractRummyInteractor(domain.NewDefaultContractRummy(), new(presenter.ContractRummyCuiPresenter))
+		},
+		controller.NewContractRummyCuiController,
+		CuiHelpSpec{
+			TitleKey: "contractrummy.helpTitle",
+			CommandKeys: []string{
+				"contractrummy.helpDrawStock",
+				"contractrummy.helpDrawDiscard",
+				"contractrummy.helpMeldContract",
+				"contractrummy.helpMeldExtra",
+				"contractrummy.helpLayoff",
+				"contractrummy.helpDiscard",
+				"contractrummy.helpNextRound",
+			},
+			SettingKeys: []string{"contractrummy.helpSetDifficulty", "contractrummy.helpSetPenalty"},
+		}),
+	BindCuiFor("ultimatetexasholdem",
+		func() usecase.UltimateTexasHoldemInteractorIF {
+			return usecase.NewUltimateTexasHoldemInteractor(domain.NewDefaultUltimateTexasHoldem(), new(presenter.UltimateTexasHoldemCuiPresenter))
+		},
+		controller.NewUltimateTexasHoldemCuiController,
+		CuiHelpSpec{
+			TitleKey: "ultimatetexasholdem.helpTitle",
+			CommandKeys: []string{
+				"ultimatetexasholdem.helpBet",
+				"ultimatetexasholdem.helpPlay",
+				"ultimatetexasholdem.helpCheck",
+				"ultimatetexasholdem.helpFold",
+			},
+			ExtraCommandLines: []string{"  log                  action log"},
+		}),
+	BindCuiFor("crescent",
+		func() usecase.CrescentInteractorIF {
+			return usecase.NewCrescentInteractor(domain.NewDefaultCrescent(), new(presenter.CrescentCuiPresenter))
+		},
+		controller.NewCrescentCuiController,
+		CuiHelpSpec{
+			TitleKey: "crescent.helpTitle",
+			CommandKeys: []string{
+				"crescent.helpMoveTT",
+				"crescent.helpMoveTF",
+				"crescent.helpRedeal",
+				"crescent.helpGiveUp",
+				"crescent.helpHint",
+				"crescent.helpAutoComplete",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("mississippistud",
+		func() usecase.MississippiStudInteractorIF {
+			return usecase.NewMississippiStudInteractor(domain.NewDefaultMississippiStud(), new(presenter.MississippiStudCuiPresenter))
+		},
+		controller.NewMississippiStudCuiController,
+		CuiHelpSpec{
+			TitleKey: "mississippistud.helpTitle",
+			CommandKeys: []string{
+				"mississippistud.helpBet",
+				"mississippistud.helpPlay",
+				"mississippistud.helpFold",
+			},
+			ExtraCommandLines: []string{"  log                  action log"},
+		}),
+	BindCuiFor("belote",
+		func() usecase.BeloteInteractorIF {
+			return usecase.NewBeloteInteractor(domain.NewDefaultBelote(), new(presenter.BeloteCuiPresenter))
+		},
+		controller.NewBeloteCuiController,
+		CuiHelpSpec{
+			TitleKey: "belote.helpTitle",
+			CommandKeys: []string{
+				"belote.helpOrderUp",
+				"belote.helpPass",
+				"belote.helpCall",
+				"belote.helpPlay",
+				"belote.helpNext",
+				"belote.helpNextRound",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"belote.helpSetDifficulty", "belote.helpSetTarget"},
+		}),
+	BindCuiFor("spiderette",
+		func() usecase.SpideretteInteractorIF {
+			return usecase.NewSpideretteInteractor(domain.NewDefaultSpiderette(), new(presenter.SpideretteCuiPresenter))
+		},
+		controller.NewSpideretteCuiController,
+		CuiHelpSpec{
+			TitleKey: "spiderette.helpTitle",
+			CommandKeys: []string{
+				"spiderette.helpDeal",
+				"spiderette.helpMove",
+				"spiderette.helpGiveUp",
+				"spiderette.helpHint",
+				"spiderette.helpAutoComplete",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("mighty",
+		func() usecase.MightyInteractorIF {
+			return usecase.NewMightyInteractor(domain.NewDefaultMighty(), new(presenter.MightyCuiPresenter))
+		},
+		controller.NewMightyCuiController,
+		CuiHelpSpec{
+			TitleKey: "mighty.helpTitle",
+			CommandKeys: []string{
+				"mighty.helpBid",
+				"mighty.helpTrump",
+				"mighty.helpExchange",
+				"mighty.helpPlay",
+				"mighty.helpJokerLead",
+				"mighty.helpNext",
+				"mighty.helpNextRound",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"mighty.helpSetDifficulty", "mighty.helpSetLimit", "mighty.helpSetMinBid", "mighty.helpSetNoTrumpExtra"},
+		}),
+	BindCuiFor("oasispoker",
+		func() usecase.OasisPokerInteractorIF {
+			return usecase.NewOasisPokerInteractor(domain.NewDefaultOasisPoker(), new(presenter.OasisPokerCuiPresenter))
+		},
+		controller.NewOasisPokerCuiController,
+		CuiHelpSpec{
+			TitleKey: "oasispoker.helpTitle",
+			CommandKeys: []string{
+				"oasispoker.helpBet",
+				"oasispoker.helpExchange",
+				"oasispoker.helpStand",
+				"oasispoker.helpPlay",
+				"oasispoker.helpFold",
+			},
+			ExtraCommandLines: []string{"  log                  action log"},
+		}),
+	BindCuiFor("beleagueredcastle",
+		func() usecase.BeleagueredCastleInteractorIF {
+			return usecase.NewBeleagueredCastleInteractor(domain.NewDefaultBeleagueredCastle(), new(presenter.BeleagueredCastleCuiPresenter))
+		},
+		controller.NewBeleagueredCastleCuiController,
+		CuiHelpSpec{
+			TitleKey: "beleagueredcastle.helpTitle",
+			CommandKeys: []string{
+				"beleagueredcastle.helpMoveTT",
+				"beleagueredcastle.helpMoveTF",
+				"beleagueredcastle.helpGiveUp",
+				"beleagueredcastle.helpHint",
+				"beleagueredcastle.helpAutoComplete",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("streetsandalleys",
+		func() usecase.StreetsAndAlleysInteractorIF {
+			return usecase.NewStreetsAndAlleysInteractor(domain.NewDefaultStreetsAndAlleys(), new(presenter.StreetsAndAlleysCuiPresenter))
+		},
+		controller.NewStreetsAndAlleysCuiController,
+		CuiHelpSpec{
+			TitleKey: "streetsandalleys.helpTitle",
+			CommandKeys: []string{
+				"streetsandalleys.helpMoveTT",
+				"streetsandalleys.helpMoveTF",
+				"streetsandalleys.helpGiveUp",
+				"streetsandalleys.helpHint",
+				"streetsandalleys.helpAutoComplete",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("kingalbert",
+		func() usecase.KingAlbertInteractorIF {
+			return usecase.NewKingAlbertInteractor(domain.NewDefaultKingAlbert(), new(presenter.KingAlbertCuiPresenter))
+		},
+		controller.NewKingAlbertCuiController,
+		CuiHelpSpec{
+			TitleKey: "kingalbert.helpTitle",
+			CommandKeys: []string{
+				"kingalbert.helpMoveTT",
+				"kingalbert.helpMoveTF",
+				"kingalbert.helpMoveRT",
+				"kingalbert.helpMoveRF",
+				"kingalbert.helpGiveUp",
+				"kingalbert.helpHint",
+				"kingalbert.helpAutoComplete",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("flowergarden",
+		func() usecase.FlowerGardenInteractorIF {
+			return usecase.NewFlowerGardenInteractor(domain.NewDefaultFlowerGarden(), new(presenter.FlowerGardenCuiPresenter))
+		},
+		controller.NewFlowerGardenCuiController,
+		CuiHelpSpec{
+			TitleKey: "flowergarden.helpTitle",
+			CommandKeys: []string{
+				"flowergarden.helpMoveTT",
+				"flowergarden.helpMoveTF",
+				"flowergarden.helpMoveRT",
+				"flowergarden.helpMoveRF",
+				"flowergarden.helpGiveUp",
+				"flowergarden.helpHint",
+				"flowergarden.helpAutoComplete",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("fortyandeight",
+		func() usecase.FortyAndEightInteractorIF {
+			return usecase.NewFortyAndEightInteractor(domain.NewDefaultFortyAndEight(), new(presenter.FortyAndEightCuiPresenter))
+		},
+		controller.NewFortyAndEightCuiController,
+		CuiHelpSpec{
+			TitleKey: "fortyandeight.helpTitle",
+			CommandKeys: []string{
+				"fortyandeight.helpDraw",
+				"fortyandeight.helpRedeal",
+				"fortyandeight.helpMove",
+				"fortyandeight.helpMoveWF",
+				"fortyandeight.helpMoveTF",
+				"fortyandeight.helpMoveTT",
+				"fortyandeight.helpGiveUp",
+				"fortyandeight.helpHint",
+				"fortyandeight.helpAutoComplete",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("agnes",
+		func() usecase.AgnesInteractorIF {
+			return usecase.NewAgnesInteractor(domain.NewDefaultAgnes(), new(presenter.AgnesCuiPresenter))
+		},
+		controller.NewAgnesCuiController,
+		CuiHelpSpec{
+			TitleKey: "agnes.helpTitle",
+			CommandKeys: []string{
+				"agnes.helpDeal",
+				"agnes.helpMoveTT",
+				"agnes.helpMoveTF",
+				"agnes.helpGiveUp",
+				"agnes.helpHint",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("sultan",
+		func() usecase.SultanInteractorIF {
+			return usecase.NewSultanInteractor(domain.NewDefaultSultan(), new(presenter.SultanCuiPresenter))
+		},
+		controller.NewSultanCuiController,
+		CuiHelpSpec{
+			TitleKey: "sultan.helpTitle",
+			CommandKeys: []string{
+				"sultan.helpDraw",
+				"sultan.helpRedeal",
+				"sultan.helpMoveDF",
+				"sultan.helpMoveWF",
+				"sultan.helpGiveUp",
+				"sultan.helpHint",
+				"sultan.helpAutoComplete",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("piquet",
+		func() usecase.PiquetInteractorIF {
+			return usecase.NewPiquetInteractor(domain.NewDefaultPiquet(), new(presenter.PiquetCuiPresenter))
+		},
+		controller.NewPiquetCuiController,
+		CuiHelpSpec{
+			TitleKey: "piquet.helpTitle",
+			CommandKeys: []string{
+				"piquet.helpExchange",
+				"piquet.helpExchangeY",
+				"piquet.helpDeclare",
+				"piquet.helpPlay",
+				"piquet.helpNextDeal",
+				"piquet.helpHint",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("casinoholdem",
+		func() usecase.CasinoHoldemInteractorIF {
+			return usecase.NewCasinoHoldemInteractor(domain.NewDefaultCasinoHoldem(), new(presenter.CasinoHoldemCuiPresenter))
+		},
+		controller.NewCasinoHoldemCuiController,
+		CuiHelpSpec{
+			TitleKey: "casinoholdem.helpTitle",
+			CommandKeys: []string{
+				"casinoholdem.helpBet",
+				"casinoholdem.helpCall",
+				"casinoholdem.helpFold",
+			},
+			ExtraCommandLines: []string{"  log                  action log"},
+		}),
+	BindCuiFor("callbreak",
+		func() usecase.CallBreakInteractorIF {
+			return usecase.NewCallBreakInteractor(domain.NewDefaultCallBreak(), new(presenter.CallBreakCuiPresenter))
+		},
+		controller.NewCallBreakCuiController,
+		CuiHelpSpec{
+			TitleKey:          "callbreak.helpTitle",
+			CommandKeys:       []string{"callbreak.helpBid", "callbreak.helpPlay", "callbreak.helpNext", "callbreak.helpNextRound"},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"callbreak.helpSetDifficulty", "callbreak.helpSetRounds"},
+		}),
+	BindCuiFor("tarneeb",
+		func() usecase.TarneebInteractorIF {
+			return usecase.NewTarneebInteractor(domain.NewDefaultTarneeb(), new(presenter.TarneebCuiPresenter))
+		},
+		controller.NewTarneebCuiController,
+		CuiHelpSpec{
+			TitleKey: "tarneeb.helpTitle",
+			CommandKeys: []string{
+				"tarneeb.helpBid",
+				"tarneeb.helpTrump",
+				"tarneeb.helpPlay",
+				"tarneeb.helpNext",
+				"tarneeb.helpNextRound",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"tarneeb.helpSetDifficulty", "tarneeb.helpSetLimit", "tarneeb.helpSetMinBid"},
+		}),
+	BindCuiFor("highcardflush",
+		func() usecase.HighCardFlushInteractorIF {
+			return usecase.NewHighCardFlushInteractor(domain.NewDefaultHighCardFlush(), new(presenter.HighCardFlushCuiPresenter))
+		},
+		controller.NewHighCardFlushCuiController,
+		CuiHelpSpec{
+			TitleKey:          "highcardflush.helpTitle",
+			CommandKeys:       []string{"highcardflush.helpBet", "highcardflush.helpRaise", "highcardflush.helpFold"},
+			ExtraCommandLines: []string{"  log                  action log"},
+		}),
+	BindCuiFor("briscola",
+		func() usecase.BriscolaInteractorIF {
+			return usecase.NewBriscolaInteractor(domain.NewDefaultBriscola(), new(presenter.BriscolaCuiPresenter))
+		},
+		controller.NewBriscolaCuiController,
+		CuiHelpSpec{
+			TitleKey:          "briscola.helpTitle",
+			CommandKeys:       []string{"briscola.helpPlay", "briscola.helpNext"},
+			ExtraCommandLines: []string{"  l                    action log"},
+		}),
+	BindCuiFor("gaps",
+		func() usecase.GapsInteractorIF {
+			return usecase.NewGapsInteractor(domain.NewDefaultGaps(), new(presenter.GapsCuiPresenter))
+		},
+		controller.NewGapsCuiController,
+		CuiHelpSpec{
+			TitleKey: "gaps.helpTitle",
+			CommandKeys: []string{
+				"gaps.helpMove",
+				"gaps.helpRedeal",
+				"gaps.helpUndo",
+				"gaps.helpGiveUp",
+				"gaps.helpHint",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("fourcardpoker",
+		func() usecase.FourCardPokerInteractorIF {
+			return usecase.NewFourCardPokerInteractor(domain.NewDefaultFourCardPoker(), new(presenter.FourCardPokerCuiPresenter))
+		},
+		controller.NewFourCardPokerCuiController,
+		CuiHelpSpec{
+			TitleKey:          "fourcardpoker.helpTitle",
+			CommandKeys:       []string{"fourcardpoker.helpBet", "fourcardpoker.helpPlay", "fourcardpoker.helpFold"},
+			ExtraCommandLines: []string{"  log                  action log"},
+		}),
+	BindCuiFor("rummy500",
+		func() usecase.Rummy500InteractorIF {
+			return usecase.NewRummy500Interactor(domain.NewDefaultRummy500(), new(presenter.Rummy500CuiPresenter))
+		},
+		controller.NewRummy500CuiController,
+		CuiHelpSpec{
+			TitleKey: "rummy500.helpTitle",
+			CommandKeys: []string{
+				"rummy500.helpDrawStock",
+				"rummy500.helpDrawDiscard",
+				"rummy500.helpMeld",
+				"rummy500.helpLayoff",
+				"rummy500.helpDiscard",
+				"rummy500.helpNextRound",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"rummy500.helpSetDifficulty", "rummy500.helpSetLimit"},
+		}),
+	BindCuiFor("eightoff",
+		func() usecase.EightOffInteractorIF {
+			return usecase.NewEightOffInteractor(domain.NewDefaultEightOff(), new(presenter.EightOffCuiPresenter))
+		},
+		controller.NewEightOffCuiController,
+		CuiHelpSpec{
+			TitleKey: "eightoff.helpTitle",
+			CommandKeys: []string{
+				"eightoff.helpMove",
+				"eightoff.helpMoveTF",
+				"eightoff.helpMoveTT",
+				"eightoff.helpMoveTC",
+				"eightoff.helpMoveCT",
+				"eightoff.helpMoveCF",
+				"eightoff.helpGiveUp",
+				"eightoff.helpHint",
+				"eightoff.helpAutoComplete",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("russianpoker",
+		func() usecase.RussianPokerInteractorIF {
+			return usecase.NewRussianPokerInteractor(domain.NewDefaultRussianPoker(), new(presenter.RussianPokerCuiPresenter))
+		},
+		controller.NewRussianPokerCuiController,
+		CuiHelpSpec{
+			TitleKey: "russianpoker.helpTitle",
+			CommandKeys: []string{
+				"russianpoker.helpBet",
+				"russianpoker.helpExchange",
+				"russianpoker.helpBuy6th",
+				"russianpoker.helpSelect",
+				"russianpoker.helpPlay",
+				"russianpoker.helpFold",
+				"russianpoker.helpForce",
+				"russianpoker.helpDecline",
+			},
+			ExtraCommandLines: []string{"  log                  action log"},
+		}),
+	BindCuiFor("penguin",
+		func() usecase.PenguinInteractorIF {
+			return usecase.NewPenguinInteractor(domain.NewDefaultPenguin(), new(presenter.PenguinCuiPresenter))
+		},
+		controller.NewPenguinCuiController,
+		CuiHelpSpec{
+			TitleKey: "penguin.helpTitle",
+			CommandKeys: []string{
+				"penguin.helpMove",
+				"penguin.helpMoveTF",
+				"penguin.helpMoveTT",
+				"penguin.helpMoveTC",
+				"penguin.helpMoveCT",
+				"penguin.helpMoveCF",
+				"penguin.helpGiveUp",
+				"penguin.helpHint",
+				"penguin.helpAutoComplete",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("chinesepoker",
+		func() usecase.ChinesePokerInteractorIF {
+			return usecase.NewChinesePokerInteractor(domain.NewDefaultChinesePoker(), new(presenter.ChinesePokerCuiPresenter))
+		},
+		controller.NewChinesePokerCuiController,
+		CuiHelpSpec{
+			TitleKey:          "chinesepoker.helpTitle",
+			CommandKeys:       []string{"chinesepoker.helpBet", "chinesepoker.helpSet"},
+			ExtraCommandLines: []string{"  l                                            action log"},
+		}),
+	BindCuiFor("sixcardgolf",
+		func() usecase.SixCardGolfInteractorIF {
+			return usecase.NewSixCardGolfInteractor(domain.NewDefaultSixCardGolf(), new(presenter.SixCardGolfCuiPresenter))
+		},
+		controller.NewSixCardGolfCuiController,
+		CuiHelpSpec{
+			TitleKey:    "sixcardgolf.helpTitle",
+			CommandKeys: []string{"sixcardgolf.helpFlipInitial", "sixcardgolf.helpDrawStock", "sixcardgolf.helpDrawDiscard", "sixcardgolf.helpSwap", "sixcardgolf.helpDiscard", "sixcardgolf.helpFlip", "sixcardgolf.helpSkipFlip", "sixcardgolf.helpNextRound"},
+			SettingKeys: []string{"sixcardgolf.helpSetDifficulty", "sixcardgolf.helpSetPlayers", "sixcardgolf.helpSetRounds"},
+		}),
+	BindCuiFor("doudizhu",
+		func() usecase.DoudizhuInteractorIF {
+			return usecase.NewDoudizhuInteractor(domain.NewDefaultDoudizhu(), new(presenter.DoudizhuCuiPresenter))
+		},
+		controller.NewDoudizhuCuiController,
+		CuiHelpSpec{
+			TitleKey:    "doudizhu.helpTitle",
+			CommandKeys: []string{"doudizhu.helpPlay", "doudizhu.helpBid"},
+			SettingKeys: []string{"doudizhu.helpSetDifficulty"},
+		}),
+	BindCuiFor("truco",
+		func() usecase.TrucoInteractorIF {
+			return usecase.NewTrucoInteractor(domain.NewDefaultTruco(), new(presenter.TrucoCuiPresenter))
+		},
+		controller.NewTrucoCuiController,
+		CuiHelpSpec{
+			TitleKey:    "truco.helpTitle",
+			CommandKeys: []string{"truco.helpPlay", "truco.helpTruco", "truco.helpRespond", "truco.helpNext"},
+		}),
+	BindCuiFor("scopa",
+		func() usecase.ScopaInteractorIF {
+			return usecase.NewScopaInteractor(domain.NewDefaultScopa(), new(presenter.ScopaCuiPresenter))
+		},
+		controller.NewScopaCuiController,
+		CuiHelpSpec{
+			TitleKey:    "scopa.helpTitle",
+			CommandKeys: []string{"scopa.helpPlay", "scopa.helpNext"},
+			SettingKeys: []string{"scopa.helpSetDifficulty"},
+		}),
+	BindCuiFor("acesup",
+		func() usecase.AcesUpInteractorIF {
+			return usecase.NewAcesUpInteractor(domain.NewDefaultAcesUp(), new(presenter.AcesUpCuiPresenter))
+		},
+		controller.NewAcesUpCuiController,
+		CuiHelpSpec{
+			TitleKey:          "acesup.helpTitle",
+			CommandKeys:       []string{"acesup.helpDraw", "acesup.helpRemove", "acesup.helpMove", "acesup.helpGiveUp", "acesup.helpHint"},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("barbu",
+		func() usecase.BarbuInteractorIF {
+			return usecase.NewBarbuInteractor(domain.NewDefaultBarbu(), new(presenter.BarbuCuiPresenter))
+		},
+		controller.NewBarbuCuiController,
+		CuiHelpSpec{
+			TitleKey:    "barbu.helpTitle",
+			CommandKeys: []string{"barbu.helpContract", "barbu.helpPlay", "barbu.helpNext"},
+			SettingKeys: []string{"barbu.helpSetDifficulty"},
+		}),
+	BindCuiFor("macau",
+		func() usecase.MacauInteractorIF {
+			return usecase.NewMacauInteractor(domain.NewDefaultMacau(), new(presenter.MacauCuiPresenter))
+		},
+		controller.NewMacauCuiController,
+		CuiHelpSpec{
+			TitleKey:          "macau.helpTitle",
+			CommandKeys:       []string{"macau.helpPlay", "macau.helpDraw", "macau.helpSuit", "macau.helpDeclare", "macau.helpSkipDeclare", "macau.helpNextRound"},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"macau.helpSetDifficulty", "macau.helpSetLimit"},
+		}),
+	BindCuiFor("thirtyone",
+		func() usecase.ThirtyOneInteractorIF {
+			return usecase.NewThirtyOneInteractor(domain.NewDefaultThirtyOne(), new(presenter.ThirtyOneCuiPresenter))
+		},
+		controller.NewThirtyOneCuiController,
+		CuiHelpSpec{
+			TitleKey: "thirtyone.helpTitle",
+			CommandKeys: []string{
+				"thirtyone.helpDrawStock",
+				"thirtyone.helpDrawDiscard",
+				"thirtyone.helpDiscard",
+				"thirtyone.helpKnock",
+				"thirtyone.helpNextRound",
+				"thirtyone.helpHint",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"thirtyone.helpSetDifficulty", "thirtyone.helpSetLives"},
+		}),
+	BindCuiFor("tienlen",
+		func() usecase.TienLenInteractorIF {
+			return usecase.NewTienLenInteractor(domain.NewDefaultTienLen(), new(presenter.TienLenCuiPresenter))
+		},
+		controller.NewTienLenCuiController,
+		CuiHelpSpec{
+			TitleKey:    "tienlen.helpTitle",
+			CommandKeys: []string{"tienlen.helpPlay"},
+			SettingKeys: []string{"tienlen.helpSetDifficulty"},
+		}),
+	BindCuiFor("osmosis",
+		func() usecase.OsmosisInteractorIF {
+			return usecase.NewOsmosisInteractor(domain.NewDefaultOsmosis(), new(presenter.OsmosisCuiPresenter))
+		},
+		controller.NewOsmosisCuiController,
+		CuiHelpSpec{
+			TitleKey: "osmosis.helpTitle",
+			CommandKeys: []string{
+				"osmosis.helpDraw",
+				"osmosis.helpMoveWF",
+				"osmosis.helpMoveRF",
+				"osmosis.helpGiveUp",
+				"osmosis.helpHint",
+				"osmosis.helpAutoComplete",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("fivehundred",
+		func() usecase.FiveHundredInteractorIF {
+			return usecase.NewFiveHundredInteractor(domain.NewDefaultFiveHundred(), new(presenter.FiveHundredCuiPresenter))
+		},
+		controller.NewFiveHundredCuiController,
+		CuiHelpSpec{
+			TitleKey: "fivehundred.helpTitle",
+			CommandKeys: []string{
+				"fivehundred.helpBid",
+				"fivehundred.helpBidNoTrump",
+				"fivehundred.helpMisere",
+				"fivehundred.helpOpenMisere",
+				"fivehundred.helpPass",
+				"fivehundred.helpExchange",
+				"fivehundred.helpPlay",
+				"fivehundred.helpNext",
+				"fivehundred.helpNextRound",
+			},
+			SettingKeys: []string{
+				"fivehundred.helpSetDifficulty",
+				"fivehundred.helpSetTarget",
+			},
+		}),
+	BindCuiFor("schnapsen",
+		func() usecase.SchnapsenInteractorIF {
+			return usecase.NewSchnapsenInteractor(domain.NewDefaultSchnapsen(), new(presenter.SchnapsenCuiPresenter))
+		},
+		controller.NewSchnapsenCuiController,
+		CuiHelpSpec{
+			TitleKey: "schnapsen.helpTitle",
+			CommandKeys: []string{
+				"schnapsen.helpPlay",
+				"schnapsen.helpMarriage",
+				"schnapsen.helpNext",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+		}),
+	BindCuiFor("burraco",
+		func() usecase.BurracoInteractorIF {
+			return usecase.NewBurracoInteractor(domain.NewDefaultBurraco(), new(presenter.BurracoCuiPresenter))
+		},
+		controller.NewBurracoCuiController,
+		CuiHelpSpec{Body: []string{
+			"Burraco (ブラーコ) Help",
+			"",
+			"Game Commands:",
+			"  ds                   draw from stock",
+			"  dd <idx,idx>         pick up discard pile (natural pair indices)",
+			"  m <idx,idx;idx,idx>  meld (semicolon-separated groups)",
+			"  sm                   skip meld phase",
+			"  d <idx>              discard a card",
+			"  go                   go out (requires the pozzetto + a burraco)",
+			"  nr                   next round",
+			"  h                    hint (recommended action)",
+			"  l                    action log",
+			"",
+			"Settings:",
+			"  sd <0-2>             set CPU difficulty (0=Easy, 1=Normal, 2=Hard)",
+			"  sl <n>               set point limit",
+			"",
+			"Session:",
+			"  r / reset            reset game",
+			"  q / quit             quit",
+			"  ? / help             show help",
+		}}),
+	BindCuiFor("yaniv",
+		func() usecase.YanivInteractorIF {
+			return usecase.NewYanivInteractor(domain.NewDefaultYaniv(), new(presenter.YanivCuiPresenter))
+		},
+		controller.NewYanivCuiController,
+		CuiHelpSpec{
+			TitleKey: "yaniv.helpTitle",
+			CommandKeys: []string{
+				"yaniv.helpDiscard",
+				"yaniv.helpYaniv",
+				"yaniv.helpDrawStock",
+				"yaniv.helpDrawPickup",
+				"yaniv.helpNextRound",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"yaniv.helpSetDifficulty", "yaniv.helpSetLimit"},
+		}),
+	BindCuiFor("gongzhu",
+		func() usecase.GongZhuInteractorIF {
+			return usecase.NewGongZhuInteractor(domain.NewDefaultGongZhu(), new(presenter.GongZhuCuiPresenter))
+		},
+		controller.NewGongZhuCuiController,
+		CuiHelpSpec{
+			TitleKey: "gongzhu.helpTitle",
+			CommandKeys: []string{
+				"gongzhu.helpExpose",
+				"gongzhu.helpPlay",
+				"gongzhu.helpNext",
+				"gongzhu.helpNextRound",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"gongzhu.helpSetDifficulty", "gongzhu.helpSetLimit"},
+		}),
+	BindCuiFor("bristol",
+		func() usecase.BristolInteractorIF {
+			return usecase.NewBristolInteractor(domain.NewDefaultBristol(), new(presenter.BristolCuiPresenter))
+		},
+		controller.NewBristolCuiController,
+		CuiHelpSpec{
+			TitleKey: "bristol.helpTitle",
+			CommandKeys: []string{
+				"bristol.helpDraw",
+				"bristol.helpMoveTT",
+				"bristol.helpMoveTF",
+				"bristol.helpMoveNT",
+				"bristol.helpMoveNF",
+				"bristol.helpGiveUp",
+				"bristol.helpHint",
+				"bristol.helpAutoComplete",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+		}),
+	BindCuiFor("bidwhist",
+		func() usecase.BidWhistInteractorIF {
+			return usecase.NewBidWhistInteractor(domain.NewDefaultBidWhist(), new(presenter.BidWhistCuiPresenter))
+		},
+		controller.NewBidWhistCuiController,
+		CuiHelpSpec{
+			TitleKey: "bidwhist.helpTitle",
+			CommandKeys: []string{
+				"bidwhist.helpBid",
+				"bidwhist.helpPass",
+				"bidwhist.helpTrump",
+				"bidwhist.helpExchange",
+				"bidwhist.helpPlay",
+				"bidwhist.helpNext",
+				"bidwhist.helpNextRound",
+			},
+			SettingKeys: []string{
+				"bidwhist.helpSetDifficulty",
+				"bidwhist.helpSetTarget",
+			},
+		}),
+	BindCuiFor("tressette",
+		func() usecase.TressetteInteractorIF {
+			return usecase.NewTressetteInteractor(domain.NewDefaultTressette(), new(presenter.TressetteCuiPresenter))
+		},
+		controller.NewTressetteCuiController,
+		CuiHelpSpec{
+			TitleKey: "tressette.helpTitle",
+			CommandKeys: []string{
+				"tressette.helpPlay",
+				"tressette.helpNext",
+				"tressette.helpNextRound",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys: []string{
+				"tressette.helpSetDifficulty",
+				"tressette.helpSetTarget",
+			},
+		}),
+	BindCuiFor("easthaven",
+		func() usecase.EasthavenInteractorIF {
+			return usecase.NewEasthavenInteractor(domain.NewDefaultEasthaven(), new(presenter.EasthavenCuiPresenter))
+		},
+		controller.NewEasthavenCuiController,
+		CuiHelpSpec{
+			TitleKey: "easthaven.helpTitle",
+			CommandKeys: []string{
+				"easthaven.helpMove",
+				"easthaven.helpMoveTF",
+				"easthaven.helpMoveTT",
+				"easthaven.helpDeal",
+				"easthaven.helpGiveUp",
+				"easthaven.helpHint",
+				"easthaven.helpAutoComplete",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("tichu",
+		func() usecase.TichuInteractorIF {
+			return usecase.NewTichuInteractor(domain.NewDefaultTichu(), new(presenter.TichuCuiPresenter))
+		},
+		controller.NewTichuCuiController,
+		CuiHelpSpec{
+			TitleKey:    "tichu.helpTitle",
+			CommandKeys: []string{"tichu.helpPlay", "tichu.helpDeclare"},
+			SettingKeys: []string{"tichu.helpSetDifficulty"},
+		}),
+	// Baker's Game reuses the FreeCell interactor/controller; only the
+	// domain (same-suit stacking) and presenter (i18n namespace) differ.
+	BindCuiFor("bakersgame",
+		func() usecase.FreeCellInteractorIF {
+			return usecase.NewFreeCellInteractor(domain.NewDefaultBakersGame(), new(presenter.BakersGameCuiPresenter))
+		},
+		controller.NewFreeCellCuiController,
+		CuiHelpSpec{
+			TitleKey: "bakersgame.helpTitle",
+			CommandKeys: []string{
+				"bakersgame.helpMove",
+				"bakersgame.helpMoveTF",
+				"bakersgame.helpMoveTT",
+				"bakersgame.helpMoveTC",
+				"bakersgame.helpMoveCT",
+				"bakersgame.helpMoveCF",
+				"bakersgame.helpGiveUp",
+				"bakersgame.helpHint",
+				"bakersgame.helpAutoComplete",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("bourre",
+		func() usecase.BourreInteractorIF {
+			return usecase.NewBourreInteractor(domain.NewDefaultBourre(), new(presenter.BourreCuiPresenter))
+		},
+		controller.NewBourreCuiController,
+		CuiHelpSpec{
+			TitleKey: "bourre.helpTitle",
+			CommandKeys: []string{
+				"bourre.helpDecide",
+				"bourre.helpDraw",
+				"bourre.helpPlay",
+				"bourre.helpNext",
+				"bourre.helpSetDifficulty",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("sheepshead",
+		func() usecase.SheepsheadInteractorIF {
+			return usecase.NewSheepsheadInteractor(domain.NewDefaultSheepshead(), new(presenter.SheepsheadCuiPresenter))
+		},
+		controller.NewSheepsheadCuiController,
+		CuiHelpSpec{
+			TitleKey: "sheepshead.helpTitle",
+			CommandKeys: []string{
+				"sheepshead.helpPick",
+				"sheepshead.helpPass",
+				"sheepshead.helpBury",
+				"sheepshead.helpCall",
+				"sheepshead.helpPlay",
+				"sheepshead.helpNext",
+				"sheepshead.helpNextRound",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys: []string{
+				"sheepshead.helpSetDifficulty",
+				"sheepshead.helpSetChips",
+			},
+		}),
+	BindCuiFor("doppelkopf",
+		func() usecase.DoppelkopfInteractorIF {
+			return usecase.NewDoppelkopfInteractor(domain.NewDefaultDoppelkopf(), new(presenter.DoppelkopfCuiPresenter))
+		},
+		controller.NewDoppelkopfCuiController,
+		CuiHelpSpec{
+			TitleKey: "doppelkopf.helpTitle",
+			CommandKeys: []string{
+				"doppelkopf.helpPlay",
+				"doppelkopf.helpAnnounce",
+				"doppelkopf.helpNext",
+				"doppelkopf.helpNextRound",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys: []string{
+				"doppelkopf.helpSetDifficulty",
+				"doppelkopf.helpSetChips",
+			},
+		}),
+	BindCuiFor("mus",
+		func() usecase.MusInteractorIF {
+			return usecase.NewMusInteractor(domain.NewDefaultMus(), new(presenter.MusCuiPresenter))
+		},
+		controller.NewMusCuiController,
+		CuiHelpSpec{
+			TitleKey: "mus.helpTitle",
+			CommandKeys: []string{
+				"mus.helpMus",
+				"mus.helpCut",
+				"mus.helpDiscard",
+				"mus.helpPaso",
+				"mus.helpEnvido",
+				"mus.helpOrdago",
+				"mus.helpQuiero",
+				"mus.helpNoQuiero",
+				"mus.helpNext",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"mus.helpSetDifficulty"},
+		}),
+	BindCuiFor("tute",
+		func() usecase.TuteInteractorIF {
+			return usecase.NewTuteInteractor(domain.NewDefaultTute(), new(presenter.TuteCuiPresenter))
+		},
+		controller.NewTuteCuiController,
+		CuiHelpSpec{
+			TitleKey: "tute.helpTitle",
+			CommandKeys: []string{
+				"tute.helpPlay",
+				"tute.helpMarriage",
+				"tute.helpTute",
+				"tute.helpNext",
+				"tute.helpNextRound",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"tute.helpSetDifficulty"},
+		}),
+	BindCuiFor("sueca",
+		func() usecase.SuecaInteractorIF {
+			return usecase.NewSuecaInteractor(domain.NewDefaultSueca(), new(presenter.SuecaCuiPresenter))
+		},
+		controller.NewSuecaCuiController,
+		CuiHelpSpec{
+			TitleKey: "sueca.helpTitle",
+			CommandKeys: []string{
+				"sueca.helpPlay",
+				"sueca.helpNext",
+				"sueca.helpNextRound",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"sueca.helpSetDifficulty"},
+		}),
+	BindCuiFor("fortyfives",
+		func() usecase.FortyFivesInteractorIF {
+			return usecase.NewFortyFivesInteractor(domain.NewDefaultFortyFives(), new(presenter.FortyFivesCuiPresenter))
+		},
+		controller.NewFortyFivesCuiController,
+		CuiHelpSpec{
+			TitleKey: "fortyfives.helpTitle",
+			CommandKeys: []string{
+				"fortyfives.helpBid",
+				"fortyfives.helpPass",
+				"fortyfives.helpPlay",
+				"fortyfives.helpNext",
+				"fortyfives.helpNextRound",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"fortyfives.helpSetDifficulty"},
+		}),
+	BindCuiFor("twentynine",
+		func() usecase.TwentyNineInteractorIF {
+			return usecase.NewTwentyNineInteractor(domain.NewDefaultTwentyNine(), new(presenter.TwentyNineCuiPresenter))
+		},
+		controller.NewTwentyNineCuiController,
+		CuiHelpSpec{
+			TitleKey: "twentynine.helpTitle",
+			CommandKeys: []string{
+				"twentynine.helpBid",
+				"twentynine.helpPass",
+				"twentynine.helpPlay",
+				"twentynine.helpNext",
+				"twentynine.helpNextRound",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"twentynine.helpSetDifficulty"},
+		}),
+	BindCuiFor("klaverjas",
+		func() usecase.KlaverjasInteractorIF {
+			return usecase.NewKlaverjasInteractor(domain.NewDefaultKlaverjas(), new(presenter.KlaverjasCuiPresenter))
+		},
+		controller.NewKlaverjasCuiController,
+		CuiHelpSpec{
+			TitleKey: "klaverjas.helpTitle",
+			CommandKeys: []string{
+				"klaverjas.helpPlay",
+				"klaverjas.helpNext",
+				"klaverjas.helpNextRound",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"klaverjas.helpSetDifficulty"},
+		}),
+	BindCuiFor("manille",
+		func() usecase.ManilleInteractorIF {
+			return usecase.NewManilleInteractor(domain.NewDefaultManille(), new(presenter.ManilleCuiPresenter))
+		},
+		controller.NewManilleCuiController,
+		CuiHelpSpec{
+			TitleKey: "manille.helpTitle",
+			CommandKeys: []string{
+				"manille.helpPlay",
+				"manille.helpNext",
+				"manille.helpNextRound",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"manille.helpSetDifficulty"},
+		}),
+	BindCuiFor("marias",
+		func() usecase.MariasInteractorIF {
+			return usecase.NewMariasInteractor(domain.NewDefaultMarias(), new(presenter.MariasCuiPresenter))
+		},
+		controller.NewMariasCuiController,
+		CuiHelpSpec{
+			TitleKey: "marias.helpTitle",
+			CommandKeys: []string{
+				"marias.helpPlay",
+				"marias.helpNext",
+				"marias.helpNextRound",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"marias.helpSetDifficulty"},
+		}),
+	BindCuiFor("sedma",
+		func() usecase.SedmaInteractorIF {
+			return usecase.NewSedmaInteractor(domain.NewDefaultSedma(), new(presenter.SedmaCuiPresenter))
+		},
+		controller.NewSedmaCuiController,
+		CuiHelpSpec{
+			TitleKey: "sedma.helpTitle",
+			CommandKeys: []string{
+				"sedma.helpPlay",
+				"sedma.helpNext",
+				"sedma.helpNextRound",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"sedma.helpSetDifficulty"},
+		}),
+	BindCuiFor("solowhist",
+		func() usecase.SoloWhistInteractorIF {
+			return usecase.NewSoloWhistInteractor(domain.NewDefaultSoloWhist(), new(presenter.SoloWhistCuiPresenter))
+		},
+		controller.NewSoloWhistCuiController,
+		CuiHelpSpec{
+			TitleKey: "solowhist.helpTitle",
+			CommandKeys: []string{
+				"solowhist.helpBid",
+				"solowhist.helpPass",
+				"solowhist.helpPlay",
+				"solowhist.helpNext",
+				"solowhist.helpNextRound",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"solowhist.helpSetDifficulty"},
+		}),
+	BindCuiFor("knockoutwhist",
+		func() usecase.KnockoutWhistInteractorIF {
+			return usecase.NewKnockoutWhistInteractor(domain.NewDefaultKnockoutWhist(), new(presenter.KnockoutWhistCuiPresenter))
+		},
+		controller.NewKnockoutWhistCuiController,
+		CuiHelpSpec{
+			TitleKey: "knockoutwhist.helpTitle",
+			CommandKeys: []string{
+				"knockoutwhist.helpPlay",
+				"knockoutwhist.helpNext",
+				"knockoutwhist.helpNextRound",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"knockoutwhist.helpSetDifficulty"},
+		}),
+	BindCuiFor("nap",
+		func() usecase.NapInteractorIF {
+			return usecase.NewNapInteractor(domain.NewDefaultNap(), new(presenter.NapCuiPresenter))
+		},
+		controller.NewNapCuiController,
+		CuiHelpSpec{
+			TitleKey: "nap.helpTitle",
+			CommandKeys: []string{
+				"nap.helpBid",
+				"nap.helpPass",
+				"nap.helpPlay",
+				"nap.helpNext",
+				"nap.helpNextRound",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"nap.helpSetDifficulty"},
+		}),
+	BindCuiFor("preference",
+		func() usecase.PreferenceInteractorIF {
+			return usecase.NewPreferenceInteractor(domain.NewDefaultPreference(), new(presenter.PreferenceCuiPresenter))
+		},
+		controller.NewPreferenceCuiController,
+		CuiHelpSpec{
+			TitleKey: "preference.helpTitle",
+			CommandKeys: []string{
+				"preference.helpBid",
+				"preference.helpPass",
+				"preference.helpPlay",
+				"preference.helpNext",
+				"preference.helpNextRound",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"preference.helpSetDifficulty"},
+		}),
+	BindCuiFor("ganjifa",
+		func() usecase.GanjifaInteractorIF {
+			return usecase.NewGanjifaInteractor(domain.NewDefaultGanjifa(), new(presenter.GanjifaCuiPresenter))
+		},
+		controller.NewGanjifaCuiController,
+		CuiHelpSpec{
+			TitleKey: "ganjifa.helpTitle",
+			CommandKeys: []string{
+				"ganjifa.helpPlay",
+				"ganjifa.helpNext",
+				"ganjifa.helpNextRound",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"ganjifa.helpSetDifficulty"},
+		}),
+	BindCuiFor("vira",
+		func() usecase.ViraInteractorIF {
+			return usecase.NewViraInteractor(domain.NewDefaultVira(), new(presenter.ViraCuiPresenter))
+		},
+		controller.NewViraCuiController,
+		CuiHelpSpec{
+			TitleKey: "vira.helpTitle",
+			CommandKeys: []string{
+				"vira.helpBid",
+				"vira.helpPass",
+				"vira.helpPlay",
+				"vira.helpNext",
+				"vira.helpNextRound",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"vira.helpSetDifficulty"},
+		}),
+	BindCuiFor("spoilfive",
+		func() usecase.SpoilFiveInteractorIF {
+			return usecase.NewSpoilFiveInteractor(domain.NewDefaultSpoilFive(), new(presenter.SpoilFiveCuiPresenter))
+		},
+		controller.NewSpoilFiveCuiController,
+		CuiHelpSpec{
+			TitleKey: "spoilfive.helpTitle",
+			CommandKeys: []string{
+				"spoilfive.helpPlay",
+				"spoilfive.helpNext",
+				"spoilfive.helpNextRound",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"spoilfive.helpSetDifficulty"},
+		}),
+	BindCuiFor("courtpiece",
+		func() usecase.CourtPieceInteractorIF {
+			return usecase.NewCourtPieceInteractor(domain.NewDefaultCourtPiece(), new(presenter.CourtPieceCuiPresenter))
+		},
+		controller.NewCourtPieceCuiController,
+		CuiHelpSpec{
+			TitleKey: "courtpiece.helpTitle",
+			CommandKeys: []string{
+				"courtpiece.helpTrump",
+				"courtpiece.helpPlay",
+				"courtpiece.helpNext",
+				"courtpiece.helpNextRound",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"courtpiece.helpSetDifficulty"},
+		}),
+	BindCuiFor("bezique",
+		func() usecase.BeziqueInteractorIF {
+			return usecase.NewBeziqueInteractor(domain.NewDefaultBezique(), new(presenter.BeziqueCuiPresenter))
+		},
+		controller.NewBeziqueCuiController,
+		CuiHelpSpec{
+			TitleKey: "bezique.helpTitle",
+			CommandKeys: []string{
+				"bezique.helpPlay",
+				"bezique.helpMeld",
+				"bezique.helpSkip",
+				"bezique.helpNext",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"bezique.helpSetDifficulty"},
+		}),
+	BindCuiFor("ecarte",
+		func() usecase.EcarteInteractorIF {
+			return usecase.NewEcarteInteractor(domain.NewDefaultEcarte(), new(presenter.EcarteCuiPresenter))
+		},
+		controller.NewEcarteCuiController,
+		CuiHelpSpec{
+			TitleKey: "ecarte.helpTitle",
+			CommandKeys: []string{
+				"ecarte.helpPropose",
+				"ecarte.helpStand",
+				"ecarte.helpDiscard",
+				"ecarte.helpPlay",
+				"ecarte.helpNext",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"ecarte.helpSetDifficulty"},
+		}),
+	BindCuiFor("threecardbrag",
+		func() usecase.ThreeCardBragInteractorIF {
+			return usecase.NewThreeCardBragInteractor(domain.NewDefaultThreeCardBrag(), new(presenter.ThreeCardBragCuiPresenter))
+		},
+		controller.NewThreeCardBragCuiController,
+		CuiHelpSpec{
+			TitleKey: "threecardbrag.helpTitle",
+			CommandKeys: []string{
+				"threecardbrag.helpSee",
+				"threecardbrag.helpBet",
+				"threecardbrag.helpRaise",
+				"threecardbrag.helpFold",
+				"threecardbrag.helpShow",
+				"threecardbrag.helpNext",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"threecardbrag.helpSetDifficulty"},
+		}),
+	BindCuiFor("teenpatti",
+		func() usecase.TeenPattiInteractorIF {
+			return usecase.NewTeenPattiInteractor(domain.NewDefaultTeenPatti(), new(presenter.TeenPattiCuiPresenter))
+		},
+		controller.NewTeenPattiCuiController,
+		CuiHelpSpec{
+			TitleKey: "teenpatti.helpTitle",
+			CommandKeys: []string{
+				"teenpatti.helpSee",
+				"teenpatti.helpBet",
+				"teenpatti.helpRaise",
+				"teenpatti.helpFold",
+				"teenpatti.helpShow",
+				"teenpatti.helpSideShow",
+				"teenpatti.helpNext",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"teenpatti.helpSetDifficulty"},
+		}),
+	BindCuiFor("scopone",
+		func() usecase.ScoponeInteractorIF {
+			return usecase.NewScoponeInteractor(domain.NewDefaultScopone(), new(presenter.ScoponeCuiPresenter))
+		},
+		controller.NewScoponeCuiController,
+		CuiHelpSpec{
+			TitleKey: "scopone.helpTitle",
+			CommandKeys: []string{
+				"scopone.helpPlay",
+				"scopone.helpNext",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"scopone.helpSetDifficulty"},
+		}),
+	BindCuiFor("escoba",
+		func() usecase.EscobaInteractorIF {
+			return usecase.NewEscobaInteractor(domain.NewDefaultEscoba(), new(presenter.EscobaCuiPresenter))
+		},
+		controller.NewEscobaCuiController,
+		CuiHelpSpec{
+			TitleKey: "escoba.helpTitle",
+			CommandKeys: []string{
+				"escoba.helpPlay",
+				"escoba.helpNext",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"escoba.helpSetDifficulty"},
+		}),
+	BindCuiFor("handandfoot",
+		func() usecase.HandAndFootInteractorIF {
+			return usecase.NewHandAndFootInteractor(domain.NewDefaultHandAndFoot(), new(presenter.HandAndFootCuiPresenter))
+		},
+		controller.NewHandAndFootCuiController,
+		CuiHelpSpec{
+			TitleKey: "handandfoot.helpTitle",
+			CommandKeys: []string{
+				"handandfoot.helpDrawStock",
+				"handandfoot.helpDrawDiscard",
+				"handandfoot.helpMeld",
+				"handandfoot.helpSkipMeld",
+				"handandfoot.helpDiscard",
+				"handandfoot.helpGoOut",
+				"handandfoot.helpNextRound",
+				"handandfoot.helpHint",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys: []string{
+				"handandfoot.helpSetDifficulty",
+				"handandfoot.helpSetLimit",
+			},
+		}),
+	BindCuiFor("conquian",
+		func() usecase.ConquianInteractorIF {
+			return usecase.NewConquianInteractor(domain.NewDefaultConquian(), new(presenter.ConquianCuiPresenter))
+		},
+		controller.NewConquianCuiController,
+		CuiHelpSpec{
+			TitleKey: "conquian.helpTitle",
+			CommandKeys: []string{
+				"conquian.helpDrawStock",
+				"conquian.helpDrawDiscard",
+				"conquian.helpMeld",
+				"conquian.helpDiscard",
+				"conquian.helpNextRound",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys: []string{
+				"conquian.helpSetDifficulty",
+				"conquian.helpSetWins",
+			},
+		}),
+	BindCuiFor("chinchon",
+		func() usecase.ChinchonInteractorIF {
+			return usecase.NewChinchonInteractor(domain.NewDefaultChinchon(), new(presenter.ChinchonCuiPresenter))
+		},
+		controller.NewChinchonCuiController,
+		CuiHelpSpec{
+			TitleKey: "chinchon.helpTitle",
+			CommandKeys: []string{
+				"chinchon.helpDrawStock",
+				"chinchon.helpDrawDiscard",
+				"chinchon.helpDiscard",
+				"chinchon.helpKnock",
+				"chinchon.helpLayoff",
+				"chinchon.helpNextRound",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys: []string{
+				"chinchon.helpSetDifficulty",
+				"chinchon.helpSetPlayers",
+			},
+		}),
+	BindCuiFor("kalooki",
+		func() usecase.KalookiInteractorIF {
+			return usecase.NewKalookiInteractor(domain.NewDefaultKalooki(), new(presenter.KalookiCuiPresenter))
+		},
+		controller.NewKalookiCuiController,
+		CuiHelpSpec{
+			TitleKey: "kalooki.helpTitle",
+			CommandKeys: []string{
+				"kalooki.helpDrawStock",
+				"kalooki.helpDrawDiscard",
+				"kalooki.helpMeld",
+				"kalooki.helpLayoff",
+				"kalooki.helpDiscard",
+				"kalooki.helpNextRound",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys: []string{
+				"kalooki.helpSetDifficulty",
+				"kalooki.helpSetPlayers",
+				"kalooki.helpSetThreshold",
+			},
+		}),
+	BindCuiFor("threethirteen",
+		func() usecase.ThreeThirteenInteractorIF {
+			return usecase.NewThreeThirteenInteractor(domain.NewDefaultThreeThirteen(), new(presenter.ThreeThirteenCuiPresenter))
+		},
+		controller.NewThreeThirteenCuiController,
+		CuiHelpSpec{
+			TitleKey: "threethirteen.helpTitle",
+			CommandKeys: []string{
+				"threethirteen.helpDrawStock",
+				"threethirteen.helpDrawDiscard",
+				"threethirteen.helpDiscard",
+				"threethirteen.helpKnock",
+				"threethirteen.helpNextRound",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys: []string{
+				"threethirteen.helpSetDifficulty",
+				"threethirteen.helpSetPlayers",
+			},
+		}),
+	BindCuiFor("mao",
+		func() usecase.MaoInteractorIF {
+			return usecase.NewMaoInteractor(domain.NewDefaultMao(), new(presenter.MaoCuiPresenter))
+		},
+		controller.NewMaoCuiController,
+		CuiHelpSpec{
+			TitleKey: "mao.helpTitle",
+			CommandKeys: []string{
+				"mao.helpPlay",
+				"mao.helpDraw",
+				"mao.helpSuit",
+				"mao.helpDeclare",
+				"mao.helpDeclareWord",
+				"mao.helpSkipDeclare",
+				"mao.helpNextRound",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys: []string{
+				"mao.helpSetDifficulty",
+				"mao.helpSetLimit",
+			},
+		}),
+	BindCuiFor("spoons",
+		func() usecase.SpoonsInteractorIF {
+			return usecase.NewSpoonsInteractor(domain.NewDefaultSpoons(), new(presenter.SpoonsCuiPresenter))
+		},
+		controller.NewSpoonsCuiController,
+		CuiHelpSpec{
+			TitleKey: "spoons.helpTitle",
+			CommandKeys: []string{
+				"spoons.helpPass",
+				"spoons.helpGrab",
+				"spoons.helpNext",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+		}),
+	BindCuiFor("kemps",
+		func() usecase.KempsInteractorIF {
+			return usecase.NewKempsInteractor(domain.NewDefaultKemps(), new(presenter.KempsCuiPresenter))
+		},
+		controller.NewKempsCuiController,
+		CuiHelpSpec{
+			TitleKey: "kemps.helpTitle",
+			CommandKeys: []string{
+				"kemps.helpSwap",
+				"kemps.helpPass",
+				"kemps.helpSignal",
+				"kemps.helpKemps",
+				"kemps.helpCounter",
+				"kemps.helpNext",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+		}),
+	BindCuiFor("cuckoo",
+		func() usecase.CuckooInteractorIF {
+			return usecase.NewCuckooInteractor(domain.NewDefaultCuckoo(), new(presenter.CuckooCuiPresenter))
+		},
+		controller.NewCuckooCuiController,
+		CuiHelpSpec{
+			TitleKey: "cuckoo.helpTitle",
+			CommandKeys: []string{
+				"cuckoo.helpKeep",
+				"cuckoo.helpSwap",
+				"cuckoo.helpRefuse",
+				"cuckoo.helpAccept",
+				"cuckoo.helpNextRound",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys: []string{
+				"cuckoo.helpSetDifficulty",
+				"cuckoo.helpSetLives",
+			},
+		}),
+	BindCuiFor("pishti",
+		func() usecase.PishtiInteractorIF {
+			return usecase.NewPishtiInteractor(domain.NewDefaultPishti(), new(presenter.PishtiCuiPresenter))
+		},
+		controller.NewPishtiCuiController,
+		CuiHelpSpec{
+			TitleKey: "pishti.helpTitle",
+			CommandKeys: []string{
+				"pishti.helpPlay",
+				"pishti.helpNext",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys: []string{
+				"pishti.helpSetDifficulty",
+				"pishti.helpSetPlayers",
+			},
+		}),
+	BindCuiFor("cuarenta",
+		func() usecase.CuarentaInteractorIF {
+			return usecase.NewCuarentaInteractor(domain.NewDefaultCuarenta(), new(presenter.CuarentaCuiPresenter))
+		},
+		controller.NewCuarentaCuiController,
+		CuiHelpSpec{
+			TitleKey: "cuarenta.helpTitle",
+			CommandKeys: []string{
+				"cuarenta.helpPlay",
+				"cuarenta.helpNext",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys: []string{
+				"cuarenta.helpSetDifficulty",
+			},
+		}),
+	BindCuiFor("fivecardstud",
+		func() usecase.FiveCardStudInteractorIF {
+			return usecase.NewFiveCardStudInteractor(domain.NewDefaultFiveCardStud(), new(presenter.FiveCardStudCuiPresenter))
+		},
+		controller.NewFiveCardStudCuiController,
+		CuiHelpSpec{
+			TitleKey: "fivecardstud.helpTitle",
+			CommandKeys: []string{
+				"fivecardstud.helpFold",
+				"fivecardstud.helpCheck",
+				"fivecardstud.helpCall",
+				"fivecardstud.helpBet",
+				"fivecardstud.helpRaise",
+				"fivecardstud.helpAllIn",
+			},
+			SettingKeys: []string{
+				"fivecardstud.helpBettingLimit",
+				"fivecardstud.helpTournament",
+			},
+		}),
+	BindCuiFor("faro",
+		func() usecase.FaroInteractorIF {
+			return usecase.NewFaroInteractor(domain.NewDefaultFaro(), new(presenter.FaroCuiPresenter))
+		},
+		controller.NewFaroCuiController,
+		CuiHelpSpec{
+			TitleKey: "faro.helpTitle",
+			CommandKeys: []string{
+				"faro.helpBet",
+				"faro.helpClearBet",
+				"faro.helpClearAll",
+				"faro.helpDeal",
+				"faro.helpCall",
+				"faro.helpNext",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+		}),
+	BindCuiFor("openfacechinese",
+		func() usecase.OpenFaceChineseInteractorIF {
+			return usecase.NewOpenFaceChineseInteractor(domain.NewDefaultOpenFaceChinese(), new(presenter.OpenFaceChineseCuiPresenter))
+		},
+		controller.NewOpenFaceChineseCuiController,
+		CuiHelpSpec{
+			TitleKey: "openfacechinese.helpTitle",
+			CommandKeys: []string{
+				"openfacechinese.helpPlace",
+				"openfacechinese.helpFront",
+				"openfacechinese.helpMiddle",
+				"openfacechinese.helpBack",
+				"openfacechinese.helpNextRound",
+			},
+			SettingKeys: []string{
+				"openfacechinese.helpSetDifficulty",
+				"openfacechinese.helpSetPlayers",
+			},
+		}),
+	BindCuiFor("russianbank",
+		func() usecase.RussianBankInteractorIF {
+			return usecase.NewRussianBankInteractor(domain.NewDefaultRussianBank(), new(presenter.RussianBankCuiPresenter))
+		},
+		controller.NewRussianBankCuiController,
+		CuiHelpSpec{
+			TitleKey: "russianbank.helpTitle",
+			CommandKeys: []string{
+				"russianbank.helpFoundation",
+				"russianbank.helpTableau",
+				"russianbank.helpDiscard",
+				"russianbank.helpStop",
+				"russianbank.helpUndo",
+			},
+			SettingKeys: []string{
+				"russianbank.helpSetDifficulty",
+			},
+		}),
+	BindCuiFor("labellelucie",
+		func() usecase.LaBelleLucieInteractorIF {
+			return usecase.NewLaBelleLucieInteractor(domain.NewDefaultLaBelleLucie(), new(presenter.LaBelleLucieCuiPresenter))
+		},
+		controller.NewLaBelleLucieCuiController,
+		CuiHelpSpec{
+			TitleKey: "labellelucie.helpTitle",
+			CommandKeys: []string{
+				"labellelucie.helpMove",
+				"labellelucie.helpRedeal",
+				"labellelucie.helpAutoComplete",
+				"labellelucie.helpUndo",
+				"labellelucie.helpGiveUp",
+			},
+		}),
+	BindCuiFor("simplesimon",
+		func() usecase.SimpleSimonInteractorIF {
+			return usecase.NewSimpleSimonInteractor(domain.NewDefaultSimpleSimon(), new(presenter.SimpleSimonCuiPresenter))
+		},
+		controller.NewSimpleSimonCuiController,
+		CuiHelpSpec{
+			TitleKey: "simplesimon.helpTitle",
+			CommandKeys: []string{
+				"simplesimon.helpMove",
+				"simplesimon.helpUndo",
+				"simplesimon.helpGiveUp",
+			},
+		}),
+	BindCuiFor("doubleklondike",
+		func() usecase.DoubleKlondikeInteractorIF {
+			return usecase.NewDoubleKlondikeInteractor(domain.NewDefaultDoubleKlondike(), new(presenter.DoubleKlondikeCuiPresenter))
+		},
+		controller.NewDoubleKlondikeCuiController,
+		CuiHelpSpec{
+			TitleKey: "doubleklondike.helpTitle",
+			CommandKeys: []string{
+				"doubleklondike.helpDraw",
+				"doubleklondike.helpMoveWaste",
+				"doubleklondike.helpMoveTableau",
+				"doubleklondike.helpAuto",
+				"doubleklondike.helpUndo",
+				"doubleklondike.helpGiveUp",
+			},
+		}),
+	BindCuiFor("blackhole",
+		func() usecase.BlackHoleInteractorIF {
+			return usecase.NewBlackHoleInteractor(domain.NewDefaultBlackHole(), new(presenter.BlackHoleCuiPresenter))
+		},
+		controller.NewBlackHoleCuiController,
+		CuiHelpSpec{
+			TitleKey: "blackhole.helpTitle",
+			CommandKeys: []string{
+				"blackhole.helpMove",
+				"blackhole.helpUndo",
+				"blackhole.helpGiveUp",
+			},
+		}),
+	BindCuiFor("beggarmyneighbour",
+		func() usecase.BeggarMyNeighbourInteractorIF {
+			return usecase.NewBeggarMyNeighbourInteractor(domain.NewDefaultBeggarMyNeighbour(), new(presenter.BeggarMyNeighbourCuiPresenter))
+		},
+		controller.NewBeggarMyNeighbourCuiController,
+		CuiHelpSpec{
+			TitleKey:    "beggarmyneighbour.helpTitle",
+			CommandKeys: []string{"beggarmyneighbour.helpStep", "beggarmyneighbour.helpAutoPlay"},
+			SettingKeys: []string{"beggarmyneighbour.helpSetMax"},
+		}),
+	BindCuiFor("allfours",
+		func() usecase.AllFoursInteractorIF {
+			return usecase.NewAllFoursInteractor(domain.NewDefaultAllFours(), new(presenter.AllFoursCuiPresenter))
+		},
+		controller.NewAllFoursCuiController,
+		CuiHelpSpec{
+			TitleKey: "allfours.helpTitle",
+			CommandKeys: []string{
+				"allfours.helpStand", "allfours.helpBeg", "allfours.helpGift",
+				"allfours.helpRun", "allfours.helpPlay", "allfours.helpNext", "allfours.helpNextRound",
+			},
+			SettingKeys: []string{"allfours.helpSetDifficulty", "allfours.helpSetLimit"},
+		}),
+	BindCuiFor("prsi",
+		func() usecase.PrsiInteractorIF {
+			return usecase.NewPrsiInteractor(domain.NewDefaultPrsi(), new(presenter.PrsiCuiPresenter))
+		},
+		controller.NewPrsiCuiController,
+		CuiHelpSpec{
+			TitleKey:          "prsi.helpTitle",
+			CommandKeys:       []string{"prsi.helpPlay", "prsi.helpDraw"},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"prsi.helpSetDifficulty"},
+		}),
+	BindCuiFor("jass",
+		func() usecase.JassInteractorIF {
+			return usecase.NewJassInteractor(domain.NewDefaultJass(), new(presenter.JassCuiPresenter))
+		},
+		controller.NewJassCuiController,
+		CuiHelpSpec{
+			TitleKey: "jass.helpTitle",
+			CommandKeys: []string{
+				"jass.helpCall",
+				"jass.helpSchieben",
+				"jass.helpPlay",
+				"jass.helpNext",
+				"jass.helpNextRound",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"jass.helpSetDifficulty", "jass.helpSetTarget"},
+		}),
+	BindCuiFor("gaigel",
+		func() usecase.GaigelInteractorIF {
+			return usecase.NewGaigelInteractor(domain.NewDefaultGaigel(), new(presenter.GaigelCuiPresenter))
+		},
+		controller.NewGaigelCuiController,
+		CuiHelpSpec{
+			TitleKey: "gaigel.helpTitle",
+			CommandKeys: []string{
+				"gaigel.helpPlay",
+				"gaigel.helpMarriage",
+				"gaigel.helpNext",
+				"gaigel.helpNextRound",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"gaigel.helpSetDifficulty", "gaigel.helpSetTarget"},
+		}),
+	BindCuiFor("tysiac",
+		func() usecase.TysiacInteractorIF {
+			return usecase.NewTysiacInteractor(domain.NewDefaultTysiac(), new(presenter.TysiacCuiPresenter))
+		},
+		controller.NewTysiacCuiController,
+		CuiHelpSpec{
+			TitleKey: "tysiac.helpTitle",
+			CommandKeys: []string{
+				"tysiac.helpBid",
+				"tysiac.helpDiscard",
+				"tysiac.helpPlay",
+				"tysiac.helpNext",
+				"tysiac.helpNextRound",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"tysiac.helpSetDifficulty"},
+		}),
+	BindCuiFor("calabresella",
+		func() usecase.CalabresellaInteractorIF {
+			return usecase.NewCalabresellaInteractor(domain.NewDefaultCalabresella(), new(presenter.CalabresellaCuiPresenter))
+		},
+		controller.NewCalabresellaCuiController,
+		CuiHelpSpec{
+			TitleKey: "calabresella.helpTitle",
+			CommandKeys: []string{
+				"calabresella.helpBid",
+				"calabresella.helpDiscard",
+				"calabresella.helpPlay",
+				"calabresella.helpNext",
+				"calabresella.helpNextRound",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"calabresella.helpSetDifficulty"},
+		}),
+	BindCuiFor("ombre",
+		func() usecase.OmbreInteractorIF {
+			return usecase.NewOmbreInteractor(domain.NewDefaultOmbre(), new(presenter.OmbreCuiPresenter))
+		},
+		controller.NewOmbreCuiController,
+		CuiHelpSpec{
+			TitleKey: "ombre.helpTitle",
+			CommandKeys: []string{
+				"ombre.helpBid",
+				"ombre.helpPlay",
+				"ombre.helpNext",
+				"ombre.helpNextRound",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"ombre.helpSetDifficulty"},
+		}),
+	BindCuiFor("ulti",
+		func() usecase.UltiInteractorIF {
+			return usecase.NewUltiInteractor(domain.NewDefaultUlti(), new(presenter.UltiCuiPresenter))
+		},
+		controller.NewUltiCuiController,
+		CuiHelpSpec{
+			TitleKey: "ulti.helpTitle",
+			CommandKeys: []string{
+				"ulti.helpBid",
+				"ulti.helpDiscard",
+				"ulti.helpPlay",
+				"ulti.helpNext",
+				"ulti.helpNextRound",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"ulti.helpSetDifficulty"},
+		}),
+	BindCuiFor("king",
+		func() usecase.KingInteractorIF {
+			return usecase.NewKingInteractor(domain.NewDefaultKing(), new(presenter.KingCuiPresenter))
+		},
+		controller.NewKingCuiController,
+		CuiHelpSpec{
+			TitleKey:          "king.helpTitle",
+			CommandKeys:       []string{"king.helpContract", "king.helpPlay", "king.helpNext"},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"king.helpSetDifficulty"},
+		}),
+	BindCuiFor("cinch",
+		func() usecase.CinchInteractorIF {
+			return usecase.NewCinchInteractor(domain.NewDefaultCinch(), new(presenter.CinchCuiPresenter))
+		},
+		controller.NewCinchCuiController,
+		CuiHelpSpec{
+			TitleKey:          "cinch.helpTitle",
+			CommandKeys:       []string{"cinch.helpBid", "cinch.helpTrump", "cinch.helpPlay", "cinch.helpNext"},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"cinch.helpSetDifficulty"},
+		}),
+	BindCuiFor("loo",
+		func() usecase.LooInteractorIF {
+			return usecase.NewLooInteractor(domain.NewDefaultLoo(), new(presenter.LooCuiPresenter))
+		},
+		controller.NewLooCuiController,
+		CuiHelpSpec{
+			TitleKey:          "loo.helpTitle",
+			CommandKeys:       []string{"loo.helpDecide", "loo.helpPlay", "loo.helpNext"},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"loo.helpSetDifficulty"},
+		}),
+	BindCuiFor("basra",
+		func() usecase.BasraInteractorIF {
+			return usecase.NewBasraInteractor(domain.NewDefaultBasra(), new(presenter.BasraCuiPresenter))
+		},
+		controller.NewBasraCuiController,
+		CuiHelpSpec{
+			TitleKey:          "basra.helpTitle",
+			CommandKeys:       []string{"basra.helpPlay", "basra.helpNext"},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"basra.helpSetDifficulty"},
+		}),
+	BindCuiFor("tablanet",
+		func() usecase.TablanetInteractorIF {
+			return usecase.NewTablanetInteractor(domain.NewDefaultTablanet(), new(presenter.TablanetCuiPresenter))
+		},
+		controller.NewTablanetCuiController,
+		CuiHelpSpec{
+			TitleKey:          "tablanet.helpTitle",
+			CommandKeys:       []string{"tablanet.helpPlay", "tablanet.helpNext"},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"tablanet.helpSetDifficulty"},
+		}),
+	BindCuiFor("trenteetquarante",
+		func() usecase.TrenteEtQuaranteInteractorIF {
+			return usecase.NewTrenteEtQuaranteInteractor(domain.NewDefaultTrenteEtQuarante(), new(presenter.TrenteEtQuaranteCuiPresenter))
+		},
+		controller.NewTrenteEtQuaranteCuiController,
+		CuiHelpSpec{
+			TitleKey:          "trenteetquarante.helpTitle",
+			CommandKeys:       []string{"trenteetquarante.helpBet", "trenteetquarante.helpNext"},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"trenteetquarante.helpSetDefaultBet"},
+		}),
+	BindCuiFor("guts",
+		func() usecase.GutsInteractorIF {
+			return usecase.NewGutsInteractor(domain.NewDefaultGuts(), new(presenter.GutsCuiPresenter))
+		},
+		controller.NewGutsCuiController,
+		CuiHelpSpec{
+			TitleKey:          "guts.helpTitle",
+			CommandKeys:       []string{"guts.helpDeclare", "guts.helpNext"},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"guts.helpSetPlayers", "guts.helpSetAnte", "guts.helpSetChips", "guts.helpSetRounds"},
+		}),
+	BindCuiFor("bouillotte",
+		func() usecase.BouillotteInteractorIF {
+			return usecase.NewBouillotteInteractor(domain.NewDefaultBouillotte(), new(presenter.BouillotteCuiPresenter))
+		},
+		controller.NewBouillotteCuiController,
+		CuiHelpSpec{
+			TitleKey:          "bouillotte.helpTitle",
+			CommandKeys:       []string{"bouillotte.helpBet", "bouillotte.helpNext"},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"bouillotte.helpSetPlayers", "bouillotte.helpSetAnte", "bouillotte.helpSetChips", "bouillotte.helpSetRounds"},
+		}),
+	BindCuiFor("primero",
+		func() usecase.PrimeroInteractorIF {
+			return usecase.NewPrimeroInteractor(domain.NewDefaultPrimero(), new(presenter.PrimeroCuiPresenter))
+		},
+		controller.NewPrimeroCuiController,
+		CuiHelpSpec{
+			TitleKey:          "primero.helpTitle",
+			CommandKeys:       []string{"primero.helpBet", "primero.helpNext"},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"primero.helpSetPlayers", "primero.helpSetAnte", "primero.helpSetChips", "primero.helpSetRounds"},
+		}),
+	BindCuiFor("michigan",
+		func() usecase.MichiganInteractorIF {
+			return usecase.NewMichiganInteractor(domain.NewDefaultMichigan(), new(presenter.MichiganCuiPresenter))
+		},
+		controller.NewMichiganCuiController,
+		CuiHelpSpec{
+			TitleKey:          "michigan.helpTitle",
+			CommandKeys:       []string{"michigan.helpBet", "michigan.helpPlay", "michigan.helpNext"},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"michigan.helpSetPlayers", "michigan.helpSetAnte", "michigan.helpSetChips", "michigan.helpSetRounds"},
+		}),
+	BindCuiFor("watten",
+		func() usecase.WattenInteractorIF {
+			return usecase.NewWattenInteractor(domain.NewDefaultWatten(), new(presenter.WattenCuiPresenter))
+		},
+		controller.NewWattenCuiController,
+		CuiHelpSpec{
+			TitleKey: "watten.helpTitle",
+			CommandKeys: []string{
+				"watten.helpDeclare",
+				"watten.helpPlay",
+				"watten.helpRaise",
+				"watten.helpRespond",
+				"watten.helpNextRound",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"watten.helpSetDifficulty", "watten.helpSetTarget"},
+		}),
+	BindCuiFor("carioca",
+		func() usecase.CariocaInteractorIF {
+			return usecase.NewCariocaInteractor(domain.NewDefaultCarioca(), new(presenter.CariocaCuiPresenter))
+		},
+		controller.NewCariocaCuiController,
+		CuiHelpSpec{
+			TitleKey: "carioca.helpTitle",
+			CommandKeys: []string{
+				"carioca.helpDrawStock",
+				"carioca.helpDrawDiscard",
+				"carioca.helpMeldContract",
+				"carioca.helpMeldExtra",
+				"carioca.helpLayoff",
+				"carioca.helpDiscard",
+				"carioca.helpNextRound",
+			},
+			SettingKeys: []string{"carioca.helpSetPlayers", "carioca.helpSetDifficulty", "carioca.helpSetPenalty"},
+		}),
+	BindCuiFor("samba",
+		func() usecase.SambaInteractorIF {
+			return usecase.NewSambaInteractor(domain.NewDefaultSamba(), new(presenter.SambaCuiPresenter))
+		},
+		controller.NewSambaCuiController,
+		CuiHelpSpec{
+			TitleKey: "samba.helpTitle",
+			CommandKeys: []string{
+				"samba.helpDrawStock",
+				"samba.helpDrawDiscard",
+				"samba.helpMeld",
+				"samba.helpSkipMeld",
+				"samba.helpDiscard",
+				"samba.helpGoOut",
+				"samba.helpNextRound",
+			},
+			SettingKeys: []string{"samba.helpSetDifficulty", "samba.helpSetLimit"},
+		}),
+	BindCuiFor("anaconda",
+		func() usecase.AnacondaInteractorIF {
+			return usecase.NewAnacondaInteractor(domain.NewDefaultAnaconda(), new(presenter.AnacondaCuiPresenter))
+		},
+		controller.NewAnacondaCuiController,
+		CuiHelpSpec{
+			TitleKey:          "anaconda.helpTitle",
+			CommandKeys:       []string{"anaconda.helpPass", "anaconda.helpKeep", "anaconda.helpBet", "anaconda.helpNext"},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"anaconda.helpSetPlayers", "anaconda.helpSetAnte", "anaconda.helpSetChips", "anaconda.helpSetRounds"},
+		}),
+	BindCuiFor("machiavelli",
+		func() usecase.MachiavelliInteractorIF {
+			return usecase.NewMachiavelliInteractor(domain.NewDefaultMachiavelli(), new(presenter.MachiavelliCuiPresenter))
+		},
+		controller.NewMachiavelliCuiController,
+		CuiHelpSpec{
+			TitleKey: "machiavelli.helpTitle",
+			CommandKeys: []string{
+				"machiavelli.helpDraw",
+				"machiavelli.helpNewMeld",
+				"machiavelli.helpLayoff",
+				"machiavelli.helpNextRound",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"machiavelli.helpSetPlayers", "machiavelli.helpSetDifficulty", "machiavelli.helpSetRounds"},
+		}),
+	BindCuiFor("pan",
+		func() usecase.PanInteractorIF {
+			return usecase.NewPanInteractor(domain.NewDefaultPan(), new(presenter.PanCuiPresenter))
+		},
+		controller.NewPanCuiController,
+		CuiHelpSpec{
+			TitleKey: "pan.helpTitle",
+			CommandKeys: []string{
+				"pan.helpDrawStock",
+				"pan.helpDrawDiscard",
+				"pan.helpMeld",
+				"pan.helpLayoff",
+				"pan.helpDiscard",
+				"pan.helpNextRound",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"pan.helpSetPlayers", "pan.helpSetDifficulty", "pan.helpSetRounds"},
+		}),
+	BindCuiFor("wizard",
+		func() usecase.WizardInteractorIF {
+			return usecase.NewWizardInteractor(domain.NewDefaultWizard(), new(presenter.WizardCuiPresenter))
+		},
+		controller.NewWizardCuiController,
+		CuiHelpSpec{
+			TitleKey:          "wizard.helpTitle",
+			CommandKeys:       []string{"wizard.helpBid", "wizard.helpPlay", "wizard.helpNext", "wizard.helpNextRound"},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"wizard.helpSetDifficulty"},
+		}),
+	BindCuiFor("oichokabu",
+		func() usecase.OichoKabuInteractorIF {
+			return usecase.NewOichoKabuInteractor(domain.NewDefaultOichoKabu(), new(presenter.OichoKabuCuiPresenter))
+		},
+		controller.NewOichoKabuCuiController,
+		CuiHelpSpec{
+			TitleKey:          "oichokabu.helpTitle",
+			CommandKeys:       []string{"oichokabu.helpBet", "oichokabu.helpDraw", "oichokabu.helpStand"},
+			ExtraCommandLines: []string{"  log                  action log"},
+		}),
+	BindCuiFor("rook",
+		func() usecase.RookInteractorIF {
+			return usecase.NewRookInteractor(domain.NewDefaultRook(), new(presenter.RookCuiPresenter))
+		},
+		controller.NewRookCuiController,
+		CuiHelpSpec{
+			TitleKey:          "rook.helpTitle",
+			CommandKeys:       []string{"rook.helpBid", "rook.helpPass", "rook.helpExchange", "rook.helpPlay", "rook.helpNext", "rook.helpNextRound"},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"rook.helpSetDifficulty", "rook.helpSetTarget"},
+		}),
+	BindCuiFor("koikoi",
+		func() usecase.KoiKoiInteractorIF {
+			return usecase.NewKoiKoiInteractor(domain.NewDefaultKoiKoi(), new(presenter.KoiKoiCuiPresenter))
+		},
+		controller.NewKoiKoiCuiController,
+		CuiHelpSpec{
+			TitleKey:          "koikoi.helpTitle",
+			CommandKeys:       []string{"koikoi.helpPlay", "koikoi.helpKoiKoi", "koikoi.helpStop", "koikoi.helpNextRound"},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"koikoi.helpSetDifficulty"},
+		}),
+	BindCuiFor("gostop",
+		func() usecase.GoStopInteractorIF {
+			return usecase.NewGoStopInteractor(domain.NewDefaultGoStop(), new(presenter.GoStopCuiPresenter))
+		},
+		controller.NewGoStopCuiController,
+		CuiHelpSpec{
+			TitleKey:          "gostop.helpTitle",
+			CommandKeys:       []string{"gostop.helpPlay", "gostop.helpGo", "gostop.helpStop", "gostop.helpNextRound"},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"gostop.helpSetDifficulty"},
+		}),
+	BindCuiFor("hachihachi",
+		func() usecase.HachiHachiInteractorIF {
+			return usecase.NewHachiHachiInteractor(domain.NewDefaultHachiHachi(), new(presenter.HachiHachiCuiPresenter))
+		},
+		controller.NewHachiHachiCuiController,
+		CuiHelpSpec{
+			TitleKey:          "hachihachi.helpTitle",
+			CommandKeys:       []string{"hachihachi.helpPlay", "hachihachi.helpNextRound"},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"hachihachi.helpSetDifficulty"},
+		}),
+	BindCuiFor("frenchtarot",
+		func() usecase.FrenchTarotInteractorIF {
+			return usecase.NewFrenchTarotInteractor(domain.NewDefaultFrenchTarot(), new(presenter.FrenchTarotCuiPresenter))
+		},
+		controller.NewFrenchTarotCuiController,
+		CuiHelpSpec{
+			TitleKey:          "frenchtarot.helpTitle",
+			CommandKeys:       []string{"frenchtarot.helpBid", "frenchtarot.helpPass", "frenchtarot.helpDiscard", "frenchtarot.helpPlay", "frenchtarot.helpNext", "frenchtarot.helpNextRound"},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"frenchtarot.helpSetDifficulty"},
+		}),
+	BindCuiFor("koenigrufen",
+		func() usecase.KoenigrufenInteractorIF {
+			return usecase.NewKoenigrufenInteractor(domain.NewDefaultKoenigrufen(), new(presenter.KoenigrufenCuiPresenter))
+		},
+		controller.NewKoenigrufenCuiController,
+		CuiHelpSpec{
+			TitleKey:          "koenigrufen.helpTitle",
+			CommandKeys:       []string{"koenigrufen.helpBid", "koenigrufen.helpPass", "koenigrufen.helpCallKing", "koenigrufen.helpDiscard", "koenigrufen.helpPlay", "koenigrufen.helpNext", "koenigrufen.helpNextRound"},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"koenigrufen.helpSetDifficulty"},
+		}),
+	BindCuiFor("aluette",
+		func() usecase.AluetteInteractorIF {
+			return usecase.NewAluetteInteractor(domain.NewDefaultAluette(), new(presenter.AluetteCuiPresenter))
+		},
+		controller.NewAluetteCuiController,
+		CuiHelpSpec{
+			TitleKey: "aluette.helpTitle",
+			CommandKeys: []string{
+				"aluette.helpPlay",
+				"aluette.helpNext",
+				"aluette.helpNextRound",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"aluette.helpSetDifficulty"},
+		}),
+	BindCuiFor("minchiate",
+		func() usecase.MinchiateInteractorIF {
+			return usecase.NewMinchiateInteractor(domain.NewDefaultMinchiate(), new(presenter.MinchiateCuiPresenter))
+		},
+		controller.NewMinchiateCuiController,
+		CuiHelpSpec{
+			TitleKey: "minchiate.helpTitle",
+			CommandKeys: []string{
+				"minchiate.helpScarto",
+				"minchiate.helpPlay",
+				"minchiate.helpNext",
+				"minchiate.helpNextRound",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"minchiate.helpSetDifficulty"},
+		}),
+	BindCuiFor("tarocchini",
+		func() usecase.TarocchiniInteractorIF {
+			return usecase.NewTarocchiniInteractor(domain.NewDefaultTarocchini(), new(presenter.TarocchiniCuiPresenter))
+		},
+		controller.NewTarocchiniCuiController,
+		CuiHelpSpec{
+			TitleKey: "tarocchini.helpTitle",
+			CommandKeys: []string{
+				"tarocchini.helpScarto",
+				"tarocchini.helpPlay",
+				"tarocchini.helpNext",
+				"tarocchini.helpNextRound",
+			},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"tarocchini.helpSetDifficulty"},
+		}),
+	BindCuiFor("scarto",
+		func() usecase.ScartoInteractorIF {
+			return usecase.NewScartoInteractor(domain.NewDefaultScarto(), new(presenter.ScartoCuiPresenter))
+		},
+		controller.NewScartoCuiController,
+		CuiHelpSpec{
+			TitleKey:          "scarto.helpTitle",
+			CommandKeys:       []string{"scarto.helpScarto", "scarto.helpPlay", "scarto.helpNext", "scarto.helpNextRound"},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"scarto.helpSetDifficulty"},
+		}),
+	BindCuiFor("cego",
+		func() usecase.CegoInteractorIF {
+			return usecase.NewCegoInteractor(domain.NewDefaultCego(), new(presenter.CegoCuiPresenter))
+		},
+		controller.NewCegoCuiController,
+		CuiHelpSpec{
+			TitleKey:          "cego.helpTitle",
+			CommandKeys:       []string{"cego.helpBid", "cego.helpPass", "cego.helpCego", "cego.helpHandspiel", "cego.helpDiscard", "cego.helpPlay", "cego.helpNext", "cego.helpNextRound"},
+			ExtraCommandLines: []string{"  l                    action log"},
+			SettingKeys:       []string{"cego.helpSetDifficulty"},
+		}),
+	BindCuiFor("zheng",
+		func() usecase.ZhengInteractorIF {
+			return usecase.NewZhengInteractor(domain.NewDefaultZheng(), new(presenter.ZhengCuiPresenter))
+		},
+		controller.NewZhengCuiController,
+		CuiHelpSpec{
+			TitleKey:    "zheng.helpTitle",
+			CommandKeys: []string{"zheng.helpPlay"},
+			SettingKeys: []string{"zheng.helpSetDifficulty"},
+		}),
+	BindCuiFor("desmoche",
+		func() usecase.DesmocheInteractorIF {
+			return usecase.NewDesmocheInteractor(domain.NewDefaultDesmoche(), new(presenter.DesmocheCuiPresenter))
+		},
+		controller.NewDesmocheCuiController,
+		CuiHelpSpec{
+			TitleKey: "desmoche.helpTitle",
+			CommandKeys: []string{
+				"desmoche.helpDrawStock",
+				"desmoche.helpDrawDiscard",
+				"desmoche.helpMeld",
+				"desmoche.helpLayOff",
+				"desmoche.helpDesmoche",
+				"desmoche.helpDiscard",
+				"desmoche.helpNext",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("zwicker",
+		func() usecase.ZwickerInteractorIF {
+			return usecase.NewZwickerInteractor(domain.NewDefaultZwicker(), new(presenter.ZwickerCuiPresenter))
+		},
+		controller.NewZwickerCuiController,
+		CuiHelpSpec{
+			TitleKey: "zwicker.helpTitle",
+			CommandKeys: []string{
+				"zwicker.helpTake",
+				"zwicker.helpBuild",
+				"zwicker.helpTrail",
+				"zwicker.helpNext",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("poch",
+		func() usecase.PochInteractorIF {
+			return usecase.NewPochInteractor(domain.NewDefaultPoch(), new(presenter.PochCuiPresenter))
+		},
+		controller.NewPochCuiController,
+		CuiHelpSpec{
+			TitleKey: "poch.helpTitle",
+			CommandKeys: []string{
+				"poch.helpBet",
+				"poch.helpFold",
+				"poch.helpPlay",
+				"poch.helpNext",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("popejoan",
+		func() usecase.PopeJoanInteractorIF {
+			return usecase.NewPopeJoanInteractor(domain.NewDefaultPopeJoan(), new(presenter.PopeJoanCuiPresenter))
+		},
+		controller.NewPopeJoanCuiController,
+		CuiHelpSpec{
+			TitleKey: "popejoan.helpTitle",
+			CommandKeys: []string{
+				"popejoan.helpPlay",
+				"popejoan.helpNext",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("nainjaune",
+		func() usecase.NainJauneInteractorIF {
+			return usecase.NewNainJauneInteractor(domain.NewDefaultNainJaune(), new(presenter.NainJauneCuiPresenter))
+		},
+		controller.NewNainJauneCuiController,
+		CuiHelpSpec{
+			TitleKey: "nainjaune.helpTitle",
+			CommandKeys: []string{
+				"nainjaune.helpPlay",
+				"nainjaune.helpNext",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("kille",
+		func() usecase.KilleInteractorIF {
+			return usecase.NewKilleInteractor(domain.NewDefaultKille(), new(presenter.KilleCuiPresenter))
+		},
+		controller.NewKilleCuiController,
+		CuiHelpSpec{
+			TitleKey: "kille.helpTitle",
+			CommandKeys: []string{
+				"kille.helpExchange",
+				"kille.helpSatisfied",
+				"kille.helpReenter",
+				"kille.helpNextRound",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+			SettingKeys: []string{
+				"kille.helpSetStake",
+			},
+		}),
+	BindCuiFor("klaberjass",
+		func() usecase.KlaberjassInteractorIF {
+			return usecase.NewKlaberjassInteractor(domain.NewDefaultKlaberjass(), new(presenter.KlaberjassCuiPresenter))
+		},
+		controller.NewKlaberjassCuiController,
+		CuiHelpSpec{
+			TitleKey: "klaberjass.helpTitle",
+			CommandKeys: []string{
+				"klaberjass.helpAccept",
+				"klaberjass.helpCall",
+				"klaberjass.helpPass",
+				"klaberjass.helpSchmeiss",
+				"klaberjass.helpAnswer",
+				"klaberjass.helpPlay",
+				"klaberjass.helpNext",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+			SettingKeys: []string{
+				"klaberjass.helpSetTarget",
+			},
+		}),
+	BindCuiFor("kaiser",
+		func() usecase.KaiserInteractorIF {
+			return usecase.NewKaiserInteractor(domain.NewDefaultKaiser(), new(presenter.KaiserCuiPresenter))
+		},
+		controller.NewKaiserCuiController,
+		CuiHelpSpec{
+			TitleKey: "kaiser.helpTitle",
+			CommandKeys: []string{
+				"kaiser.helpBid",
+				"kaiser.helpPass",
+				"kaiser.helpTrump",
+				"kaiser.helpDiscard",
+				"kaiser.helpPlay",
+				"kaiser.helpNext",
+				"kaiser.helpHint",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("boston",
+		func() usecase.BostonInteractorIF {
+			return usecase.NewBostonInteractor(domain.NewDefaultBoston(), new(presenter.BostonCuiPresenter))
+		},
+		controller.NewBostonCuiController,
+		CuiHelpSpec{
+			TitleKey: "boston.helpTitle",
+			CommandKeys: []string{
+				"boston.helpBid",
+				"boston.helpPass",
+				"boston.helpCallPartner",
+				"boston.helpPlay",
+				"boston.helpNext",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("vint",
+		func() usecase.VintInteractorIF {
+			return usecase.NewVintInteractor(domain.NewDefaultVint(), new(presenter.VintCuiPresenter))
+		},
+		controller.NewVintCuiController,
+		CuiHelpSpec{
+			TitleKey: "vint.helpTitle",
+			CommandKeys: []string{
+				"vint.helpBid",
+				"vint.helpPass",
+				"vint.helpPlay",
+				"vint.helpNext",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("bideuchre",
+		func() usecase.BidEuchreInteractorIF {
+			return usecase.NewBidEuchreInteractor(domain.NewDefaultBidEuchre(), new(presenter.BidEuchreCuiPresenter))
+		},
+		controller.NewBidEuchreCuiController,
+		CuiHelpSpec{
+			TitleKey: "bideuchre.helpTitle",
+			CommandKeys: []string{
+				"bideuchre.helpBid",
+				"bideuchre.helpPass",
+				"bideuchre.helpTrump",
+				"bideuchre.helpPlay",
+				"bideuchre.helpNext",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("sixbidsolo",
+		func() usecase.SixBidSoloInteractorIF {
+			return usecase.NewSixBidSoloInteractor(domain.NewDefaultSixBidSolo(), new(presenter.SixBidSoloCuiPresenter))
+		},
+		controller.NewSixBidSoloCuiController,
+		CuiHelpSpec{
+			TitleKey: "sixbidsolo.helpTitle",
+			CommandKeys: []string{
+				"sixbidsolo.helpBid",
+				"sixbidsolo.helpPass",
+				"sixbidsolo.helpDeclare",
+				"sixbidsolo.helpPlay",
+				"sixbidsolo.helpNext",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("karnoffel",
+		func() usecase.KarnoffelInteractorIF {
+			return usecase.NewKarnoffelInteractor(domain.NewDefaultKarnoffel(), new(presenter.KarnoffelCuiPresenter))
+		},
+		controller.NewKarnoffelCuiController,
+		CuiHelpSpec{
+			TitleKey: "karnoffel.helpTitle",
+			CommandKeys: []string{
+				"karnoffel.helpPlay",
+				"karnoffel.helpNext",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("literature",
+		func() usecase.LiteratureInteractorIF {
+			return usecase.NewLiteratureInteractor(domain.NewDefaultLiterature(), new(presenter.LiteratureCuiPresenter))
+		},
+		controller.NewLiteratureCuiController,
+		CuiHelpSpec{
+			TitleKey: "literature.helpTitle",
+			CommandKeys: []string{
+				"literature.helpAsk",
+				"literature.helpClaim",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("guandan",
+		func() usecase.GuandanInteractorIF {
+			return usecase.NewGuandanInteractor(domain.NewDefaultGuandan(), new(presenter.GuandanCuiPresenter))
+		},
+		controller.NewGuandanCuiController,
+		CuiHelpSpec{
+			TitleKey: "guandan.helpTitle",
+			CommandKeys: []string{
+				"guandan.helpPlay",
+				"guandan.helpPass",
+				"guandan.helpTribute",
+				"guandan.helpNext",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
+	BindCuiFor("shengji",
+		func() usecase.ShengJiInteractorIF {
+			return usecase.NewShengJiInteractor(domain.NewDefaultShengJi(), new(presenter.ShengJiCuiPresenter))
+		},
+		controller.NewShengJiCuiController,
+		CuiHelpSpec{
+			TitleKey: "shengji.helpTitle",
+			CommandKeys: []string{
+				"shengji.helpDeclare",
+				"shengji.helpBury",
+				"shengji.helpPlay",
+				"shengji.helpNext",
+			},
+			ExtraCommandLines: []string{"  l                        action log"},
+		}),
 }
 
 // GameRegistry returns a copy of the game registry for external use.

--- a/internal/infrastructure/ui/GameManager_test.go
+++ b/internal/infrastructure/ui/GameManager_test.go
@@ -354,3 +354,32 @@ func TestGameRegistry_AllConstructorsNonNil(t *testing.T) {
 		assert.NotNil(t, entry.NewCui, "NewCui must not be nil for %q", entry.Name)
 	}
 }
+
+// BindCuiFor must not build the interactor until the game is actually started.
+// gameRegistry is a package-level var, so an eager call would construct all 264
+// games' domain state at process start rather than when one is played. See #5187.
+func TestBindCuiFor_DoesNotBuildInteractorUntilNewCui(t *testing.T) {
+	built := 0
+	entry := BindCuiFor("probe",
+		func() CuiExecer {
+			built++
+			return stubExecer{}
+		},
+		func(e CuiExecer) CuiExecer { return e },
+		CuiHelpSpec{Body: []string{"help"}},
+	)
+
+	assert.Equal(t, "probe", entry.Name)
+	assert.Equal(t, 0, built, "registration must not construct the interactor")
+
+	g := entry.NewCui()
+	assert.Equal(t, 1, built, "NewCui must construct it exactly once")
+	assert.Equal(t, []string{"help"}, g.HelpLines())
+
+	entry.NewCui()
+	assert.Equal(t, 2, built, "each NewCui call gets a fresh game")
+}
+
+type stubExecer struct{}
+
+func (stubExecer) Exec(string) string { return "" }


### PR DESCRIPTION
## 概要

5つのゲーム登録ポイントのうち、**CLI だけが共通ヘルパを持たず**、264ゲーム分の入れ子コンストラクタを手書きしていました。`internal/CLAUDE.md` が「use these helpers, don't hand-roll boilerplate」と明記している対象そのものです。

| 登録ポイント | ヘルパ |
|---|---|
| Web サーバ (`games_server.go`) | ✅ `BindWebControllerFor` |
| Worker (`{casino,classic,...}/`) | ✅ `RegisterKVGame` |
| **CLI (`GameManager.go`)** | ❌ → **`BindCuiFor` を追加** |

## ⚠️ 削減行数はゼロです（issue の見積もりは誤りでした）

issue 本文は「約800〜1,000行削減」としていましたが、**実測は 4,113 追加 / 4,113 削除 = 差し引きゼロ**でした。[issue にも訂正済み](https://github.com/yuta-yoshinaga/go_trumpcards/issues/5187#issuecomment-5225577832)です。

理由: interactor コンストラクタは**具象型**を返し、controller コンストラクタは**interface** を取ります。Go の関数型は戻り値について共変ではないため、入れ子が畳める代わりに **interface 注釈クロージャが必要**になります。`games_server.go` の呼び出しが元々その形なのも同じ理由です。

```go
// 通らない: I = *BlackJackInteractor と推論され newCtrl の func(BlackJackInteractorIF) と不一致
BindCuiFor("blackjack", func() *usecase.BlackJackInteractor { … }, controller.NewBlackJackCuiController, spec)
```

**残る効用**は、型の取り違えがヘルパのシグネチャで弾かれること、および5登録ポイントで書き味が揃うこと（新ゲーム追加時に形を切り替えなくてよい）です。行数目的なら費用対効果は薄い、と issue で申し上げたうえで「予定どおり実施」とのご判断をいただいたので進めています。

## 実装上の注意点

**`NewCui` の遅延性を維持しています。** `gameRegistry` はパッケージレベル変数なので、`newInteractor()` を登録時に呼ぶと**プロセス起動時に264ゲーム分のドメイン状態を構築**してしまいます。ヘルパ内では `NewCui` クロージャの内側でのみ呼び、**専用テストで固定**しました。

```go
assert.Equal(t, 0, built, "registration must not construct the interactor")
g := entry.NewCui()
assert.Equal(t, 1, built, "NewCui must construct it exactly once")
```

**`doubt` は literal のまま**です（独自コンストラクタで `CuiHelpSpec` を持たないため、ヘルパが運ぶものがない）。

## テスト計画

- [x] `BindCuiFor` の遅延性テスト（登録時0回・`NewCui` で1回・2回目で2回）
- [x] **挙動が同一であることを実測**（推定ではなく）— 変更前後のバイナリを両方ビルドし比較:
  - `games --json` → **完全一致**
  - `games`（long, カテゴリ見出し付き）→ **完全一致**
  - `help <game>` を **264ゲーム全部** → **差分0件**
- [x] `go build ./...` / `gofmt -l` クリーン
- [x] `go test -tags test ./internal/infrastructure/... ./cmd/...` 通過（`TestRegistryMatchesCLI` を含む）
- [x] `golangci-lint run` → 0 issues

## 作業手順について

263エントリの機械的書き換えは、正規表現ではなく**波括弧を数えるパーサ**で行いました。最初に正規表現で試したところ 263件中257件しかマッチせず（インデント差異と先頭コメントの有無）、部分マッチのまま書き込んで隣接エントリの閉じ括弧を巻き込みビルドを破壊しました。**置換件数が期待値と一致しない場合は書き込まない**アサートを入れ直しています。`bakersgame` の「FreeCell の interactor を再利用している」旨のコメントも保持しています。

Closes #5187