### PR TITLE
refactor(domain): embed actionLogBase in the 122 games that can take it

### DIFF
--- a/internal/domain/AllFours.go
+++ b/internal/domain/AllFours.go
@@ -72,7 +72,7 @@ type AllFours struct {
 	giftAward        int   // gift で 1 点を得たプレイヤー (-1=gift なし)
 	gameEndFlag      bool
 	winnerIdx        int
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // NewAllFours コンストラクタ
@@ -699,9 +699,6 @@ func (a *AllFours) GetConfig() AllFoursConfig { return a.config }
 // SetConfig 設定変更
 func (a *AllFours) SetConfig(cfg AllFoursConfig) { a.config = cfg }
 
-// GetActionLog 棋譜取得
-func (a *AllFours) GetActionLog() []*ActionLogEntry { return a.actionLog }
-
 // GetValidPlayIndices プレイ可能なカードのインデックスリストを返す (Web用)
 func (a *AllFours) GetValidPlayIndices(playerIdx int) []int {
 	pl := a.players[playerIdx]
@@ -739,16 +736,6 @@ func (a *AllFours) playerName(idx int) string {
 		return "You"
 	}
 	return fmt.Sprintf("CPU %d", idx)
-}
-
-func (a *AllFours) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	a.actionLog = append(a.actionLog, &ActionLogEntry{
-		TurnNumber: len(a.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // allFoursSuitGlyph スートを Unicode グリフで返す。

--- a/internal/domain/Baccarat.go
+++ b/internal/domain/Baccarat.go
@@ -41,17 +41,17 @@ const (
 
 // Baccarat バカラクラス
 type Baccarat struct {
-	trumpCards     *TrumpCards         // トランプカード
-	playerHand     []*Card             // プレイヤーハンド
-	bankerHand     []*Card             // バンカーハンド
-	chips          ChipHolder          // チップ
-	betAmount      int                 // ベット額
-	betType        int                 // ベットタイプ
-	phase          int                 // 現在のフェーズ
-	gameEndFlag    bool                // ゲーム終了フラグ
-	result         GameResult          // ゲーム結果
-	payout         int                 // 配当金額
-	actionLog      []*ActionLogEntry   // 棋譜
+	trumpCards  *TrumpCards // トランプカード
+	playerHand  []*Card     // プレイヤーハンド
+	bankerHand  []*Card     // バンカーハンド
+	chips       ChipHolder  // チップ
+	betAmount   int         // ベット額
+	betType     int         // ベットタイプ
+	phase       int         // 現在のフェーズ
+	gameEndFlag bool        // ゲーム終了フラグ
+	result      GameResult  // ゲーム結果
+	payout      int         // 配当金額
+	actionLogBase
 	history        []int               // 罫線（Big Road）履歴
 	playerPairBet  int                 // プレイヤーペアベット額
 	bankerPairBet  int                 // バンカーペアベット額
@@ -312,17 +312,6 @@ func betTypeName(betType int) string {
 	}
 }
 
-// appendLog 棋譜にエントリを追加する
-func (b *Baccarat) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	b.actionLog = append(b.actionLog, &ActionLogEntry{
-		TurnNumber: len(b.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
-}
-
 // evaluateSideBets サイドベットを評価し、当選時はチップに加算する
 func (b *Baccarat) evaluateSideBets() {
 	b.sideBetResults = nil
@@ -392,9 +381,6 @@ func (b *Baccarat) GetPlayerHandValue() int { return b.CalculateHandValue(b.play
 
 // GetBankerHandValue バンカーハンド合計値
 func (b *Baccarat) GetBankerHandValue() int { return b.CalculateHandValue(b.bankerHand) }
-
-// GetActionLog 棋譜を取得する
-func (b *Baccarat) GetActionLog() []*ActionLogEntry { return b.actionLog }
 
 // GetHistory 罫線履歴を取得する
 func (b *Baccarat) GetHistory() []int { return b.history }

--- a/internal/domain/Barbu.go
+++ b/internal/domain/Barbu.go
@@ -91,7 +91,7 @@ type Barbu struct {
 	gameEndFlag     bool
 	lastDealDetail  *BarbuDealDetail
 	dealHistory     []*BarbuDealDetail // 完了した各ディールの得点内訳 (最大 BarbuTotalDeals 件)
-	actionLog       []*ActionLogEntry
+	actionLogBase
 }
 
 // NewBarbu はコンストラクタ。
@@ -441,17 +441,6 @@ func barbuSortHand(p *BarbuPlayer) {
 	}
 }
 
-// appendLog は棋譜にエントリを追加する。
-func (b *Barbu) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	b.actionLog = append(b.actionLog, &ActionLogEntry{
-		TurnNumber: len(b.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
-}
-
 // barbuContractName はコントラクトの英語名を返す (ログ用)。
 func barbuContractName(c int) string {
 	switch c {
@@ -557,9 +546,6 @@ func (b *Barbu) GetConfig() BarbuConfig { return b.config }
 
 // SetConfig はローカルルール設定を変更する。
 func (b *Barbu) SetConfig(config BarbuConfig) { b.config = config }
-
-// GetActionLog は棋譜を返す。
-func (b *Barbu) GetActionLog() []*ActionLogEntry { return b.actionLog }
 
 // GetRoundWinners は (ゲーム終了時) 最高得点プレイヤーのリストを返す。
 func (b *Barbu) GetRoundWinners() []int {

--- a/internal/domain/BeggarMyNeighbour.go
+++ b/internal/domain/BeggarMyNeighbour.go
@@ -56,7 +56,7 @@ type BeggarMyNeighbour struct {
 	gameEndFlag      bool
 	winnerIdx        int
 	roundsPlayed     int
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // NewBeggarMyNeighbour コンストラクタ
@@ -273,17 +273,6 @@ func (g *BeggarMyNeighbour) finishByTotal() {
 	}
 }
 
-// appendLog 棋譜にエントリを追加する
-func (g *BeggarMyNeighbour) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
-}
-
 // --- Getters ---
 
 // GetPhase フェーズ取得
@@ -332,9 +321,6 @@ func (g *BeggarMyNeighbour) SetConfig(cfg BeggarMyNeighbourConfig) { g.config = 
 
 // SetRoundsPlayedForTest はテスト用に消化ラウンド数を設定する。
 func (g *BeggarMyNeighbour) SetRoundsPlayedForTest(n int) { g.roundsPlayed = n }
-
-// GetActionLog 棋譜取得
-func (g *BeggarMyNeighbour) GetActionLog() []*ActionLogEntry { return g.actionLog }
 
 // IsHumanTurn 常に人間入力待ち
 func (g *BeggarMyNeighbour) IsHumanTurn() bool { return !g.gameEndFlag }

--- a/internal/domain/Belote.go
+++ b/internal/domain/Belote.go
@@ -84,7 +84,7 @@ type Belote struct {
 	bidPassCount      int // 連続パス数 (両ラウンド合計; 8で再配布)
 	gameEndFlag       bool
 	winnerTeam        int // 勝利チーム (-1 = 未確定)
-	actionLog         []*ActionLogEntry
+	actionLogBase
 }
 
 // NewBelote コンストラクタ
@@ -706,9 +706,6 @@ func (b *Belote) GetConfig() BeloteConfig { return b.config }
 // SetConfig 設定変更
 func (b *Belote) SetConfig(cfg BeloteConfig) { b.config = cfg }
 
-// GetActionLog 棋譜取得
-func (b *Belote) GetActionLog() []*ActionLogEntry { return b.actionLog }
-
 // CardRankPublic カードランク取得 (テスト用公開メソッド)
 func (b *Belote) CardRankPublic(card *Card) int { return b.cardRank(card) }
 
@@ -1096,16 +1093,6 @@ func (b *Belote) playerName(idx int) string {
 		return "You"
 	}
 	return fmt.Sprintf("CPU %d", idx)
-}
-
-func (b *Belote) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	b.actionLog = append(b.actionLog, &ActionLogEntry{
-		TurnNumber: len(b.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // --- Hints ---

--- a/internal/domain/Bezique.go
+++ b/internal/domain/Bezique.go
@@ -171,7 +171,7 @@ type Bezique struct {
 	meldsDeclared    []int // プレイヤー毎の宣言済みメルドビットマスク
 	gameEndFlag      bool
 	winnerIdx        int // -1: 未確定
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // NewBezique コンストラクタ
@@ -492,9 +492,6 @@ func (b *Bezique) GetConfig() BeziqueConfig { return b.config }
 
 // SetConfig 設定変更
 func (b *Bezique) SetConfig(cfg BeziqueConfig) { b.config = cfg }
-
-// GetActionLog 棋譜取得
-func (b *Bezique) GetActionLog() []*ActionLogEntry { return b.actionLog }
 
 // GetValidPlayIndices プレイ可能なカードのインデックスリストを返す。
 func (b *Bezique) GetValidPlayIndices(playerIdx int) []int {
@@ -938,17 +935,6 @@ func (b *Bezique) playerName(idx int) string {
 		return "You"
 	}
 	return fmt.Sprintf("CPU %d", idx)
-}
-
-// appendLog 棋譜エントリを追加する
-func (b *Bezique) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	b.actionLog = append(b.actionLog, &ActionLogEntry{
-		TurnNumber: len(b.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // playHintReason ヒント理由キーを判定する

--- a/internal/domain/BidWhist.go
+++ b/internal/domain/BidWhist.go
@@ -138,7 +138,7 @@ type BidWhist struct {
 	teamScores  [BidWhistTeamCnt]int
 	gameEndFlag bool
 	winnerTeam  int
-	actionLog   []*ActionLogEntry
+	actionLogBase
 }
 
 // NewBidWhist コンストラクタ
@@ -1200,9 +1200,6 @@ func (g *BidWhist) GetConfig() BidWhistConfig { return g.config }
 // SetConfig 設定変更
 func (g *BidWhist) SetConfig(cfg BidWhistConfig) { g.config = cfg }
 
-// GetActionLog 棋譜取得
-func (g *BidWhist) GetActionLog() []*ActionLogEntry { return g.actionLog }
-
 // CardRankPublic カードランク取得 (テスト用)
 func (g *BidWhist) CardRankPublic(card *Card) int { return g.cardRank(card) }
 
@@ -1260,17 +1257,6 @@ func (g *BidWhist) playerName(idx int) string {
 		return "You"
 	}
 	return fmt.Sprintf("CPU %d", idx)
-}
-
-// appendLog 棋譜にエントリを追加する
-func (g *BidWhist) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // bidWhistValidSuit 4スートのうちいずれかか

--- a/internal/domain/BlackJack.go
+++ b/internal/domain/BlackJack.go
@@ -60,8 +60,8 @@ type BlackJack struct {
 	twentyOnePlus3Bet  int                     // 21+3サイドベット額
 	sideBetResults     []*BJSideBetResult      // サイドベット結果
 	multiHandCount     int                     // マルチハンド数（0=デフォルト1）
-	actionLog          []*ActionLogEntry       // 棋譜
-	bonusKeys          []string                // 当ラウンドで成立したバリアントボーナスのi18nキー (Spanish 21 等)
+	actionLogBase
+	bonusKeys []string // 当ラウンドで成立したバリアントボーナスのi18nキー (Spanish 21 等)
 }
 
 // NewDefaultBlackJack デフォルト設定のブラックジャックを生成するファクトリ関数
@@ -739,20 +739,6 @@ func (b *BlackJack) advanceEarlySurrender() {
 	b.currentHandIdx = 0
 	b.phase = BJPhaseAction
 	b.checkNaturalBlackJack()
-}
-
-// GetActionLog 棋譜を取得する
-func (b *BlackJack) GetActionLog() []*ActionLogEntry { return b.actionLog }
-
-// appendLog 棋譜にエントリを追加する
-func (b *BlackJack) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	b.actionLog = append(b.actionLog, &ActionLogEntry{
-		TurnNumber: len(b.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // blackJackJSON is the JSON wire format for BlackJack.

--- a/internal/domain/BlackJackSwitch.go
+++ b/internal/domain/BlackJackSwitch.go
@@ -37,18 +37,18 @@ const BJSwitchDealerHitsSoft17 = true
 // 簡略化のため、スプリット / インシュランス / サレンダー / サイドベット
 // / CPU はサポートしない（標準BJ実装に任せる）。
 type BlackJackSwitch struct {
-	trumpCards     *TrumpCards       // 山札
-	player         *BlackJackPlayer  // プレイヤー（チップ保持）
-	dealer         *BlackJackPlayer  // ディーラー
-	hands          []*BlackJackHand  // 常に2ハンド
-	currentHandIdx int               // 現在操作中のハンドインデックス
-	phase          int               // 現在のフェーズ
-	gameEndFlag    bool              // ゲーム終了フラグ
-	switched       bool              // 直近のラウンドでスイッチを実行したか
-	handResults    []GameResult      // 各ハンドの勝敗結果
-	handPayouts    []int             // 各ハンドの配当（ベット返却込み）
-	dealerPushed22 bool              // ディーラー22プッシュが発生したか
-	actionLog      []*ActionLogEntry // 棋譜
+	trumpCards     *TrumpCards      // 山札
+	player         *BlackJackPlayer // プレイヤー（チップ保持）
+	dealer         *BlackJackPlayer // ディーラー
+	hands          []*BlackJackHand // 常に2ハンド
+	currentHandIdx int              // 現在操作中のハンドインデックス
+	phase          int              // 現在のフェーズ
+	gameEndFlag    bool             // ゲーム終了フラグ
+	switched       bool             // 直近のラウンドでスイッチを実行したか
+	handResults    []GameResult     // 各ハンドの勝敗結果
+	handPayouts    []int            // 各ハンドの配当（ベット返却込み）
+	dealerPushed22 bool             // ディーラー22プッシュが発生したか
+	actionLogBase
 }
 
 // NewBlackJackSwitch コンストラクタ
@@ -445,17 +445,6 @@ func (bs *BlackJackSwitch) overallResult() GameResult {
 	}
 }
 
-// appendLog 棋譜にエントリを追加する。
-func (bs *BlackJackSwitch) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	bs.actionLog = append(bs.actionLog, &ActionLogEntry{
-		TurnNumber: len(bs.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
-}
-
 // --- Getters ---
 
 // GetPlayer プレイヤー
@@ -499,9 +488,6 @@ func (bs *BlackJackSwitch) GetTotalPayout() int {
 
 // GetOverallResult 総合勝敗（一行サマリ用）
 func (bs *BlackJackSwitch) GetOverallResult() GameResult { return bs.overallResult() }
-
-// GetActionLog 棋譜
-func (bs *BlackJackSwitch) GetActionLog() []*ActionLogEntry { return bs.actionLog }
 
 // --- Test helpers ---
 

--- a/internal/domain/Bourre.go
+++ b/internal/domain/Bourre.go
@@ -67,7 +67,7 @@ type Bourre struct {
 	gameEndFlag      bool
 	winnerIdx        int
 	lastResults      []*BourreHandResult
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // NewBourre コンストラクタ
@@ -805,17 +805,6 @@ func (b *Bourre) playerName(idx int) string {
 	return fmt.Sprintf("CPU %d", idx)
 }
 
-// appendLog 棋譜にエントリを追加する
-func (b *Bourre) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	b.actionLog = append(b.actionLog, &ActionLogEntry{
-		TurnNumber: len(b.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
-}
-
 // bourreRank カードのランクを返す (エース=14、それ以外は額面値)
 func bourreRank(c *Card) int {
 	if c.GetValue() == 1 {
@@ -920,9 +909,6 @@ func (b *Bourre) GetConfig() BourreConfig { return b.config }
 
 // SetConfig 設定変更
 func (b *Bourre) SetConfig(cfg BourreConfig) { b.config = cfg }
-
-// GetActionLog 棋譜取得
-func (b *Bourre) GetActionLog() []*ActionLogEntry { return b.actionLog }
 
 // IsHumanTurn 現在の手番が人間かどうか
 func (b *Bourre) IsHumanTurn() bool {

--- a/internal/domain/Bridge.go
+++ b/internal/domain/Bridge.go
@@ -112,7 +112,7 @@ type Bridge struct {
 	leadPlayerIdx    int
 	gameEndFlag      bool
 	winnerTeam       int // 勝利チーム (-1 = 未確定)
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // NewBridge コンストラクタ
@@ -1020,9 +1020,6 @@ func (b *Bridge) GetConfig() BridgeConfig { return b.config }
 // SetConfig 設定変更
 func (b *Bridge) SetConfig(cfg BridgeConfig) { b.config = cfg }
 
-// GetActionLog 棋譜取得
-func (b *Bridge) GetActionLog() []*ActionLogEntry { return b.actionLog }
-
 // IsOpeningLeadDone オープニングリード完了か
 func (b *Bridge) IsOpeningLeadDone() bool { return b.openingLeadDone }
 
@@ -1270,17 +1267,6 @@ func (b *Bridge) playerName(idx int) string {
 		return fmt.Sprintf("You (%s)", positions[idx])
 	}
 	return fmt.Sprintf("CPU %d (%s)", idx, positions[idx])
-}
-
-// appendLog 棋譜にエントリを追加する
-func (b *Bridge) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	b.actionLog = append(b.actionLog, &ActionLogEntry{
-		TurnNumber: len(b.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // playHintReason プレイヒントの理由を判定する

--- a/internal/domain/Briscola.go
+++ b/internal/domain/Briscola.go
@@ -102,7 +102,7 @@ type Briscola struct {
 	playerPoints     []int
 	gameEndFlag      bool
 	winnerIdx        int // -1: 未確定または引き分け
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // NewBriscola コンストラクタ
@@ -348,9 +348,6 @@ func (b *Briscola) GetConfig() BriscolaConfig { return b.config }
 // SetConfig 設定変更
 func (b *Briscola) SetConfig(cfg BriscolaConfig) { b.config = cfg }
 
-// GetActionLog 棋譜取得
-func (b *Briscola) GetActionLog() []*ActionLogEntry { return b.actionLog }
-
 // GetValidPlayIndices プレイ可能なカードのインデックスリストを返す。
 // Briscola には must-follow 制約がないため、現在の手札全てが対象。
 func (b *Briscola) GetValidPlayIndices(playerIdx int) []int {
@@ -571,17 +568,6 @@ func (b *Briscola) playerName(idx int) string {
 		return "You"
 	}
 	return fmt.Sprintf("CPU %d", idx)
-}
-
-// appendLog 棋譜エントリを追加する
-func (b *Briscola) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	b.actionLog = append(b.actionLog, &ActionLogEntry{
-		TurnNumber: len(b.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // playHintReason ヒント理由キーを判定する

--- a/internal/domain/Calabresella.go
+++ b/internal/domain/Calabresella.go
@@ -125,7 +125,7 @@ type Calabresella struct {
 	lastTrickWinner  int                                    // 最終トリック勝者 (-1=未確定)
 	gameEndFlag      bool
 	winnerPlayer     int // -1=未確定
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // NewCalabresella コンストラクタ
@@ -790,17 +790,6 @@ func (g *Calabresella) findHumanIdx() int {
 	return -1
 }
 
-// appendLog 棋譜にエントリを追加する。
-func (g *Calabresella) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
-}
-
 // --- CPU AI (play) ---
 
 // cpuSelectPlayCard CPU がプレイするカードのインデックスを選ぶ。
@@ -1109,9 +1098,6 @@ func (g *Calabresella) GetConfig() CalabresellaConfig { return g.config }
 
 // SetConfig 設定変更
 func (g *Calabresella) SetConfig(cfg CalabresellaConfig) { g.config = cfg }
-
-// GetActionLog 棋譜取得
-func (g *Calabresella) GetActionLog() []*ActionLogEntry { return g.actionLog }
 
 // GetPlayableIndices プレイ可能なカードのインデックス一覧を返す。
 func (g *Calabresella) GetPlayableIndices(playerIdx int) []int {

--- a/internal/domain/CallBreak.go
+++ b/internal/domain/CallBreak.go
@@ -59,7 +59,7 @@ type CallBreak struct {
 	bidPlayerIdx     int
 	gameEndFlag      bool
 	winnerIdx        int
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // NewCallBreak コンストラクタ
@@ -415,9 +415,6 @@ func (cb *CallBreak) GetConfig() CallBreakConfig { return cb.config }
 // SetConfig 設定変更
 func (cb *CallBreak) SetConfig(cfg CallBreakConfig) { cb.config = cfg }
 
-// GetActionLog 棋譜取得
-func (cb *CallBreak) GetActionLog() []*ActionLogEntry { return cb.actionLog }
-
 // --- Private methods ---
 
 // findHumanIdx 人間プレイヤーのインデックスを返す (-1 = なし)
@@ -570,17 +567,6 @@ func (cb *CallBreak) playerName(idx int) string {
 		return "You"
 	}
 	return fmt.Sprintf("CPU %d", idx)
-}
-
-// appendLog 棋譜にエントリを追加する
-func (cb *CallBreak) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	cb.actionLog = append(cb.actionLog, &ActionLogEntry{
-		TurnNumber: len(cb.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // GetHint ヒントを取得する

--- a/internal/domain/Canasta.go
+++ b/internal/domain/Canasta.go
@@ -65,9 +65,9 @@ type Canasta struct {
 	gameEndFlag      bool
 	winnerIdx        int
 	roundNumber      int
-	actionLog        []*ActionLogEntry
-	drewFromDiscard  bool  // 現在のターンで捨て札の山から引いたか
-	drawnCard        *Card // 捨て札の山のトップカード (メルドバリデーション用)
+	actionLogBase
+	drewFromDiscard bool  // 現在のターンで捨て札の山から引いたか
+	drawnCard       *Card // 捨て札の山のトップカード (メルドバリデーション用)
 }
 
 // NewCanasta コンストラクタ
@@ -1444,9 +1444,6 @@ func (g *Canasta) GetConfig() CanastaConfig { return g.config }
 // SetConfig 設定変更
 func (g *Canasta) SetConfig(cfg CanastaConfig) { g.config = cfg }
 
-// GetActionLog 棋譜取得
-func (g *Canasta) GetActionLog() []*ActionLogEntry { return g.actionLog }
-
 // GetDrewFromDiscard 捨て札から引いたか取得
 func (g *Canasta) GetDrewFromDiscard() bool { return g.drewFromDiscard }
 
@@ -1538,17 +1535,6 @@ func (g *Canasta) playerName(idx int) string {
 		return "You"
 	}
 	return fmt.Sprintf("CPU %d", idx)
-}
-
-// appendLog 棋譜にエントリを追加する
-func (g *Canasta) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // canastaTypeStr カナスタの種別文字列を返す

--- a/internal/domain/CaribbeanStud.go
+++ b/internal/domain/CaribbeanStud.go
@@ -46,23 +46,23 @@ const (
 
 // CaribbeanStud カリビアンスタッドポーカークラス
 type CaribbeanStud struct {
-	trumpCards      *TrumpCards       // トランプカード
-	playerHand      []*Card           // プレイヤーハンド
-	dealerHand      []*Card           // ディーラーハンド
-	chips           ChipHolder        // チップ
-	anteBet         int               // アンテベット額
-	jackpotBet      int               // ジャックポットサイドベット額
-	playBet         int               // プレイ（コール）ベット額
-	phase           int               // 現在のフェーズ
-	gameEndFlag     bool              // ゲーム終了フラグ
-	result          GameResult        // ゲーム結果
-	antePayout      int               // アンテ配当
-	playPayout      int               // プレイ配当
-	jackpotPayout   int               // ジャックポット配当
-	dealerQualified bool              // ディーラークオリファイフラグ
-	playerHandRank  int               // プレイヤーハンドランク
-	dealerHandRank  int               // ディーラーハンドランク
-	actionLog       []*ActionLogEntry // 棋譜
+	trumpCards      *TrumpCards // トランプカード
+	playerHand      []*Card     // プレイヤーハンド
+	dealerHand      []*Card     // ディーラーハンド
+	chips           ChipHolder  // チップ
+	anteBet         int         // アンテベット額
+	jackpotBet      int         // ジャックポットサイドベット額
+	playBet         int         // プレイ（コール）ベット額
+	phase           int         // 現在のフェーズ
+	gameEndFlag     bool        // ゲーム終了フラグ
+	result          GameResult  // ゲーム結果
+	antePayout      int         // アンテ配当
+	playPayout      int         // プレイ配当
+	jackpotPayout   int         // ジャックポット配当
+	dealerQualified bool        // ディーラークオリファイフラグ
+	playerHandRank  int         // プレイヤーハンドランク
+	dealerHandRank  int         // ディーラーハンドランク
+	actionLogBase
 }
 
 // NewCaribbeanStud コンストラクタ
@@ -316,17 +316,6 @@ func (cs *CaribbeanStud) evaluateJackpot() {
 	}
 }
 
-// appendLog 棋譜にエントリを追加する
-func (cs *CaribbeanStud) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	cs.actionLog = append(cs.actionLog, &ActionLogEntry{
-		TurnNumber: len(cs.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
-}
-
 // --- Getters ---
 
 // GetPlayerHand プレイヤーハンド取得
@@ -378,9 +367,6 @@ func (cs *CaribbeanStud) GetDealerHandRank() int { return cs.dealerHandRank }
 
 // GetChips チップ
 func (cs *CaribbeanStud) GetChips() int { return cs.chips.GetChips() }
-
-// GetActionLog 棋譜を取得する
-func (cs *CaribbeanStud) GetActionLog() []*ActionLogEntry { return cs.actionLog }
 
 // --- Test helpers ---
 

--- a/internal/domain/Carioca.go
+++ b/internal/domain/Carioca.go
@@ -103,9 +103,9 @@ type Carioca struct {
 	gameEndFlag      bool
 	winnerIdx        int
 	roundNumber      int
-	actionLog        []*ActionLogEntry
-	roundWinnerIdx   int // 直近ラウンドの勝者（上がったプレイヤー）。-1 は山切れ流局
-	startingPlayer   int // 当該ラウンドの先手
+	actionLogBase
+	roundWinnerIdx int // 直近ラウンドの勝者（上がったプレイヤー）。-1 は山切れ流局
+	startingPlayer int // 当該ラウンドの先手
 }
 
 // NewCarioca コンストラクタ
@@ -821,9 +821,6 @@ func (g *Carioca) GetConfig() CariocaConfig { return g.config }
 // SetConfig 設定変更
 func (g *Carioca) SetConfig(c CariocaConfig) { g.config = c }
 
-// GetActionLog 棋譜取得
-func (g *Carioca) GetActionLog() []*ActionLogEntry { return g.actionLog }
-
 // GetRoundWinnerIdx 直近ラウンドの勝者
 func (g *Carioca) GetRoundWinnerIdx() int { return g.roundWinnerIdx }
 
@@ -861,16 +858,6 @@ func (g *Carioca) playerName(idx int) string {
 		return "You"
 	}
 	return fmt.Sprintf("CPU %d", idx)
-}
-
-func (g *Carioca) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // --- Pure Carioca helpers (joker-aware) ---

--- a/internal/domain/CasinoHoldem.go
+++ b/internal/domain/CasinoHoldem.go
@@ -54,26 +54,26 @@ const (
 
 // CasinoHoldem カジノホールデムクラス
 type CasinoHoldem struct {
-	trumpCards     *TrumpCards       // トランプカード
-	playerHand     []*Card           // プレイヤーホールカード
-	dealerHand     []*Card           // ディーラーホールカード
-	community      []*Card           // コミュニティカード
-	chips          ChipHolder        // チップ
-	anteBet        int               // アンテベット額
-	bonusBet       int               // AA ボーナスベット額
-	callBet        int               // コールベット額（2×アンテ）
-	phase          int               // 現在のフェーズ
-	gameEndFlag    bool              // ゲーム終了フラグ
-	result         GameResult        // ゲーム結果
-	dealerQualify  bool              // ディーラークオリファイフラグ
-	antePayout     int               // アンテ配当
-	callPayout     int               // コール配当
-	bonusPayout    int               // AA ボーナス配当
-	playerHandRank int               // プレイヤー最良5枚ランク
-	dealerHandRank int               // ディーラー最良5枚ランク
-	playerBest     []*Card           // プレイヤー最良5枚
-	dealerBest     []*Card           // ディーラー最良5枚
-	actionLog      []*ActionLogEntry // 棋譜
+	trumpCards     *TrumpCards // トランプカード
+	playerHand     []*Card     // プレイヤーホールカード
+	dealerHand     []*Card     // ディーラーホールカード
+	community      []*Card     // コミュニティカード
+	chips          ChipHolder  // チップ
+	anteBet        int         // アンテベット額
+	bonusBet       int         // AA ボーナスベット額
+	callBet        int         // コールベット額（2×アンテ）
+	phase          int         // 現在のフェーズ
+	gameEndFlag    bool        // ゲーム終了フラグ
+	result         GameResult  // ゲーム結果
+	dealerQualify  bool        // ディーラークオリファイフラグ
+	antePayout     int         // アンテ配当
+	callPayout     int         // コール配当
+	bonusPayout    int         // AA ボーナス配当
+	playerHandRank int         // プレイヤー最良5枚ランク
+	dealerHandRank int         // ディーラー最良5枚ランク
+	playerBest     []*Card     // プレイヤー最良5枚
+	dealerBest     []*Card     // ディーラー最良5枚
+	actionLogBase
 }
 
 // NewCasinoHoldem コンストラクタ
@@ -425,17 +425,6 @@ func casinoHoldemDealerQualifies(rank int, best []*Card) bool {
 	return false
 }
 
-// appendLog 棋譜にエントリを追加する
-func (c *CasinoHoldem) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	c.actionLog = append(c.actionLog, &ActionLogEntry{
-		TurnNumber: len(c.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
-}
-
 // --- Getters ---
 
 // GetPlayerHand プレイヤーホールカード取得
@@ -517,9 +506,6 @@ func (c *CasinoHoldem) GetDealerBest() []*Card { return c.dealerBest }
 
 // GetChips チップ
 func (c *CasinoHoldem) GetChips() int { return c.chips.GetChips() }
-
-// GetActionLog 棋譜を取得する
-func (c *CasinoHoldem) GetActionLog() []*ActionLogEntry { return c.actionLog }
 
 // --- Test helpers ---
 

--- a/internal/domain/CasinoWar.go
+++ b/internal/domain/CasinoWar.go
@@ -39,7 +39,7 @@ type CasinoWar struct {
 	gameEndFlag   bool
 	result        GameResult
 	totalPayout   int
-	actionLog     []*ActionLogEntry
+	actionLogBase
 }
 
 // NewCasinoWar コンストラクタ
@@ -215,17 +215,6 @@ func (cw *CasinoWar) ResolveWar() {
 	cw.phase = CasinoWarPhaseEnd
 }
 
-// appendLog 棋譜にエントリを追加する
-func (cw *CasinoWar) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	cw.actionLog = append(cw.actionLog, &ActionLogEntry{
-		TurnNumber: len(cw.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
-}
-
 // --- Getters ---
 
 // GetPlayerCard プレイヤーの初手カード
@@ -263,9 +252,6 @@ func (cw *CasinoWar) GetTotalPayout() int { return cw.totalPayout }
 
 // GetChips チップ
 func (cw *CasinoWar) GetChips() int { return cw.chips.GetChips() }
-
-// GetActionLog 棋譜
-func (cw *CasinoWar) GetActionLog() []*ActionLogEntry { return cw.actionLog }
 
 // --- Test helpers ---
 

--- a/internal/domain/CatchTen.go
+++ b/internal/domain/CatchTen.go
@@ -46,7 +46,7 @@ type CatchTen struct {
 	teamScores       [CatchTenTeamCnt]int
 	gameEndFlag      bool
 	winnerTeam       int // -1 = 未確定 / -2 = 引き分け
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // CatchTenDrawTeam は両チームが同時にポイント上限へ到達した際の引き分けを表す。
@@ -389,9 +389,6 @@ func (g *CatchTen) GetConfig() CatchTenConfig { return g.config }
 // SetConfig 設定変更
 func (g *CatchTen) SetConfig(cfg CatchTenConfig) { g.config = cfg }
 
-// GetActionLog 棋譜取得
-func (g *CatchTen) GetActionLog() []*ActionLogEntry { return g.actionLog }
-
 // GetValidPlayIndices プレイ可能なカードのインデックスリストを返す (Web用)
 func (g *CatchTen) GetValidPlayIndices(playerIdx int) []int {
 	return g.getValidPlayIndices(playerIdx)
@@ -575,17 +572,6 @@ func (g *CatchTen) playerName(idx int) string {
 		return "You"
 	}
 	return fmt.Sprintf("CPU %d", idx)
-}
-
-// appendLog 棋譜にエントリを追加する
-func (g *CatchTen) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // playHintReason プレイヒントの理由を判定する

--- a/internal/domain/Chinchon.go
+++ b/internal/domain/Chinchon.go
@@ -109,11 +109,11 @@ type Chinchon struct {
 	gameEndFlag      bool
 	winnerIdx        int // マッチ勝者 (-1 = 未確定)
 	roundNumber      int
-	actionLog        []*ActionLogEntry
-	knockerIdx       int       // ノックしたプレイヤー (-1 = ノックなし)
-	knockerMelds     [][]*Card // ノッカーのメルド (レイオフ用)
-	knockerDeadwood  []*Card   // ノッカーのデッドウッド
-	layoffQueue      []int     // 残りのレイオフ対象プレイヤー (順番)
+	actionLogBase
+	knockerIdx      int       // ノックしたプレイヤー (-1 = ノックなし)
+	knockerMelds    [][]*Card // ノッカーのメルド (レイオフ用)
+	knockerDeadwood []*Card   // ノッカーのデッドウッド
+	layoffQueue     []int     // 残りのレイオフ対象プレイヤー (順番)
 }
 
 // NewChinchon コンストラクタ
@@ -776,9 +776,6 @@ func (g *Chinchon) GetConfig() ChinchonConfig { return g.config }
 // SetConfig 設定変更
 func (g *Chinchon) SetConfig(cfg ChinchonConfig) { g.config = cfg }
 
-// GetActionLog 棋譜取得
-func (g *Chinchon) GetActionLog() []*ActionLogEntry { return g.actionLog }
-
 // GetKnockerIdx ノッカーのインデックス取得 (-1 = ノックなし)
 func (g *Chinchon) GetKnockerIdx() int { return g.knockerIdx }
 
@@ -851,17 +848,6 @@ func (g *Chinchon) playerName(idx int) string {
 		return "You"
 	}
 	return fmt.Sprintf("CPU %d", idx)
-}
-
-// appendLog 棋譜にエントリを追加する
-func (g *Chinchon) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // --- JSON ---

--- a/internal/domain/Cinch.go
+++ b/internal/domain/Cinch.go
@@ -116,7 +116,7 @@ type Cinch struct {
 	gameEndFlag      bool
 	winnerIdx        int
 	lastDealDetail   *CinchDealDetail
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // NewCinch はコンストラクタ。
@@ -853,16 +853,6 @@ func (g *Cinch) playerName(idx int) string {
 	return fmt.Sprintf("CPU %d", idx)
 }
 
-func (g *Cinch) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
-}
-
 func (g *Cinch) getValidPlayIndices(playerIdx int) []int {
 	player := g.players[playerIdx]
 	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
@@ -986,9 +976,6 @@ func (g *Cinch) GetConfig() CinchConfig { return g.config }
 
 // SetConfig はローカルルール設定を変更する。
 func (g *Cinch) SetConfig(cfg CinchConfig) { g.config = cfg }
-
-// GetActionLog は棋譜を返す。
-func (g *Cinch) GetActionLog() []*ActionLogEntry { return g.actionLog }
 
 // GetPlayableIndices はプレイフェーズでプレイ可能な手札インデックスを返す。
 func (g *Cinch) GetPlayableIndices(playerIdx int) []int {

--- a/internal/domain/Conquian.go
+++ b/internal/domain/Conquian.go
@@ -81,9 +81,9 @@ type Conquian struct {
 	winnerIdx        int // ラウンド勝者 (-1 = 未確定/引き分け)
 	matchWinnerIdx   int // マッチ全体の勝者 (-1 = 未確定)
 	roundNumber      int
-	actionLog        []*ActionLogEntry
-	tookDiscard      bool // 今ターン、捨て札を取って必ずメルドに使う必要があるか
-	pendingCard      *Card
+	actionLogBase
+	tookDiscard bool // 今ターン、捨て札を取って必ずメルドに使う必要があるか
+	pendingCard *Card
 }
 
 // NewConquian コンストラクタ
@@ -914,9 +914,6 @@ func (g *Conquian) GetConfig() ConquianConfig { return g.config }
 // SetConfig 設定変更
 func (g *Conquian) SetConfig(cfg ConquianConfig) { g.config = cfg }
 
-// GetActionLog 棋譜取得
-func (g *Conquian) GetActionLog() []*ActionLogEntry { return g.actionLog }
-
 // GetTookDiscard 今ターンに捨て札を取ったか (強制使用待ち) を返す
 func (g *Conquian) GetTookDiscard() bool { return g.tookDiscard }
 
@@ -957,17 +954,6 @@ func (g *Conquian) playerName(idx int) string {
 		return "You"
 	}
 	return fmt.Sprintf("CPU %d", idx)
-}
-
-// appendLog 棋譜にエントリを追加する
-func (g *Conquian) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // --- JSON ---

--- a/internal/domain/ContractRummy.go
+++ b/internal/domain/ContractRummy.go
@@ -101,9 +101,9 @@ type ContractRummy struct {
 	gameEndFlag      bool
 	winnerIdx        int
 	roundNumber      int
-	actionLog        []*ActionLogEntry
-	roundWinnerIdx   int // 直近ラウンドの勝者（上がったプレイヤー）。-1 は山切れ流局
-	startingPlayer   int // 当該ラウンドの先手
+	actionLogBase
+	roundWinnerIdx int // 直近ラウンドの勝者（上がったプレイヤー）。-1 は山切れ流局
+	startingPlayer int // 当該ラウンドの先手
 }
 
 // NewContractRummy コンストラクタ
@@ -828,9 +828,6 @@ func (g *ContractRummy) GetConfig() ContractRummyConfig { return g.config }
 // SetConfig 設定変更
 func (g *ContractRummy) SetConfig(c ContractRummyConfig) { g.config = c }
 
-// GetActionLog 棋譜取得
-func (g *ContractRummy) GetActionLog() []*ActionLogEntry { return g.actionLog }
-
 // GetRoundWinnerIdx 直近ラウンドの勝者
 func (g *ContractRummy) GetRoundWinnerIdx() int { return g.roundWinnerIdx }
 
@@ -868,16 +865,6 @@ func (g *ContractRummy) playerName(idx int) string {
 		return "You"
 	}
 	return fmt.Sprintf("CPU %d", idx)
-}
-
-func (g *ContractRummy) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // --- Pure helpers ---

--- a/internal/domain/CourtPiece.go
+++ b/internal/domain/CourtPiece.go
@@ -76,7 +76,7 @@ type CourtPiece struct {
 	lastRoundCourt   bool
 	gameEndFlag      bool
 	winnerTeam       int
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // NewCourtPiece コンストラクタ
@@ -492,9 +492,6 @@ func (c *CourtPiece) GetConfig() CourtPieceConfig { return c.config }
 // SetConfig 設定変更
 func (c *CourtPiece) SetConfig(cfg CourtPieceConfig) { c.config = cfg }
 
-// GetActionLog 棋譜取得
-func (c *CourtPiece) GetActionLog() []*ActionLogEntry { return c.actionLog }
-
 // IsHumanTurn 現在の手番が人間かどうか
 func (c *CourtPiece) IsHumanTurn() bool {
 	if c.currentPlayerIdx < 0 || c.currentPlayerIdx >= len(c.players) {
@@ -655,17 +652,6 @@ func (c *CourtPiece) playerName(idx int) string {
 		return "You"
 	}
 	return fmt.Sprintf("CPU %d", idx)
-}
-
-// appendLog 棋譜にエントリを追加する
-func (c *CourtPiece) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	c.actionLog = append(c.actionLog, &ActionLogEntry{
-		TurnNumber: len(c.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // playHintReason プレイヒントの理由キー

--- a/internal/domain/CrazyEights.go
+++ b/internal/domain/CrazyEights.go
@@ -43,7 +43,7 @@ type CrazyEights struct {
 	gameEndFlag      bool
 	winnerIdx        int
 	roundNumber      int
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // NewCrazyEights コンストラクタ
@@ -436,9 +436,6 @@ func (g *CrazyEights) GetConfig() CrazyEightsConfig { return g.config }
 // SetConfig 設定変更
 func (g *CrazyEights) SetConfig(cfg CrazyEightsConfig) { g.config = cfg }
 
-// GetActionLog 棋譜取得
-func (g *CrazyEights) GetActionLog() []*ActionLogEntry { return g.actionLog }
-
 // --- Private methods ---
 
 // isValidPlay カードがプレイ可能か判定
@@ -606,17 +603,6 @@ func (g *CrazyEights) playerName(idx int) string {
 		return "You"
 	}
 	return fmt.Sprintf("CPU %d", idx)
-}
-
-// appendLog 棋譜にエントリを追加する
-func (g *CrazyEights) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // --- CPU AI ---

--- a/internal/domain/Cuckoo.go
+++ b/internal/domain/Cuckoo.go
@@ -80,8 +80,8 @@ type Cuckoo struct {
 	roundNumber      int
 	roundLowest      int   // 直近ラウンドの最低カード値 (-1=未確定)
 	roundLosers      []int // 直近ラウンドでライフを失ったプレイヤー
-	actionLog        []*ActionLogEntry
-	rng              *rand.Rand
+	actionLogBase
+	rng *rand.Rand
 }
 
 // NewCuckoo コンストラクタ
@@ -620,9 +620,6 @@ func (g *Cuckoo) GetConfig() CuckooConfig { return g.config }
 // SetConfig ゲーム設定を設定する
 func (g *Cuckoo) SetConfig(cfg CuckooConfig) { g.config = cfg }
 
-// GetActionLog 棋譜を取得する
-func (g *Cuckoo) GetActionLog() []*ActionLogEntry { return g.actionLog }
-
 // playerName プレイヤー名を返す
 func (g *Cuckoo) playerName(idx int) string {
 	if idx < 0 || idx >= len(g.players) {
@@ -632,17 +629,6 @@ func (g *Cuckoo) playerName(idx int) string {
 		return "You"
 	}
 	return fmt.Sprintf("CPU %d", idx)
-}
-
-// appendLog 棋譜にエントリを追加する
-func (g *Cuckoo) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // --- JSON ---

--- a/internal/domain/Doppelkopf.go
+++ b/internal/domain/Doppelkopf.go
@@ -82,7 +82,7 @@ type Doppelkopf struct {
 	roundGamePts     int                       // 直近ラウンドのゲームポイント (倍率込み)
 	gameEndFlag      bool
 	winnerIdx        int // ゲーム勝者 (-1 = 未確定)
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // NewDoppelkopf コンストラクタ
@@ -520,17 +520,6 @@ func (g *Doppelkopf) playerName(idx int) string {
 	return fmt.Sprintf("CPU %d", idx)
 }
 
-// appendLog 棋譜にエントリを追加する。
-func (g *Doppelkopf) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
-}
-
 // indexOfPlayerInTrick currentTrick 内で playerIdx の札の位置を返す (-1=なし)。
 func (g *Doppelkopf) indexOfPlayerInTrick(playerIdx int) int {
 	for i, tc := range g.currentTrick {
@@ -795,9 +784,6 @@ func (g *Doppelkopf) GetConfig() DoppelkopfConfig { return g.config }
 
 // SetConfig 設定変更
 func (g *Doppelkopf) SetConfig(cfg DoppelkopfConfig) { g.config = cfg }
-
-// GetActionLog 棋譜取得
-func (g *Doppelkopf) GetActionLog() []*ActionLogEntry { return g.actionLog }
 
 // GetPlayableIndices プレイ可能なカードのインデックス一覧を返す。
 func (g *Doppelkopf) GetPlayableIndices(playerIdx int) []int {

--- a/internal/domain/Doubt.go
+++ b/internal/domain/Doubt.go
@@ -133,7 +133,7 @@ type Doubt struct {
 	turnCounter     int
 	humanProfile    *DoubtHumanProfile
 	lastHumanPlayMs int
-	actionLog       []*ActionLogEntry
+	actionLogBase
 }
 
 // NewDoubt コンストラクタ
@@ -633,20 +633,6 @@ func (d *Doubt) ImportProfile(data []byte) error {
 	d.humanProfile = &DoubtHumanProfile{}
 	d.humanProfile.Import(pd)
 	return nil
-}
-
-// GetActionLog 棋譜を取得する
-func (d *Doubt) GetActionLog() []*ActionLogEntry { return d.actionLog }
-
-// appendLog 棋譜にエントリを追加する
-func (d *Doubt) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	d.actionLog = append(d.actionLog, &ActionLogEntry{
-		TurnNumber: len(d.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // findHumanIdx 人間プレイヤーのインデックスを返す (-1=なし)

--- a/internal/domain/DragonTiger.go
+++ b/internal/domain/DragonTiger.go
@@ -50,8 +50,8 @@ type DragonTiger struct {
 	gameEndFlag bool
 	result      GameResult
 	payout      int
-	actionLog   []*ActionLogEntry
-	history     []int // 罫線（Big Road）履歴
+	actionLogBase
+	history []int // 罫線（Big Road）履歴
 }
 
 // NewDragonTiger コンストラクタ
@@ -211,17 +211,6 @@ func dragonTigerBetTypeName(betType int) string {
 	}
 }
 
-// appendLog 棋譜にエントリを追加する
-func (dt *DragonTiger) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	dt.actionLog = append(dt.actionLog, &ActionLogEntry{
-		TurnNumber: len(dt.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
-}
-
 // --- Getters ---
 
 // GetDragonCard ドラゴン枠のカード
@@ -250,9 +239,6 @@ func (dt *DragonTiger) GetPayout() int { return dt.payout }
 
 // GetChips チップ
 func (dt *DragonTiger) GetChips() int { return dt.chips.GetChips() }
-
-// GetActionLog 棋譜を取得する
-func (dt *DragonTiger) GetActionLog() []*ActionLogEntry { return dt.actionLog }
 
 // GetHistory 罫線履歴を取得する
 func (dt *DragonTiger) GetHistory() []int { return dt.history }

--- a/internal/domain/Ecarte.go
+++ b/internal/domain/Ecarte.go
@@ -108,7 +108,7 @@ type Ecarte struct {
 	refusalByDealer  bool
 	gameEndFlag      bool
 	winnerIdx        int // -1: 未確定
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // NewEcarte コンストラクタ
@@ -753,9 +753,6 @@ func (e *Ecarte) GetConfig() EcarteConfig { return e.config }
 // SetConfig 設定変更
 func (e *Ecarte) SetConfig(cfg EcarteConfig) { e.config = cfg }
 
-// GetActionLog 棋譜取得
-func (e *Ecarte) GetActionLog() []*ActionLogEntry { return e.actionLog }
-
 // GetValidPlayIndices プレイ可能なカードのインデックスリストを返す。
 func (e *Ecarte) GetValidPlayIndices(playerIdx int) []int {
 	if playerIdx < 0 || playerIdx >= len(e.players) || e.phase != EcartePhasePlay {
@@ -826,16 +823,6 @@ func (e *Ecarte) playerName(idx int) string {
 		return "You"
 	}
 	return fmt.Sprintf("CPU %d", idx)
-}
-
-func (e *Ecarte) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	e.actionLog = append(e.actionLog, &ActionLogEntry{
-		TurnNumber: len(e.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 func (e *Ecarte) playHintReason(playerIdx, chosenIdx int) string {

--- a/internal/domain/EgyptianRatscrew.go
+++ b/internal/domain/EgyptianRatscrew.go
@@ -93,7 +93,7 @@ type EgyptianRatscrew struct {
 	lastEvent     EgyptianRatscrewLastEvent
 	gameEndFlag   bool
 	winnerIdx     int
-	actionLog     []*ActionLogEntry
+	actionLogBase
 
 	// now 現在時刻取得関数 (テストで差し替え可能)
 	now func() time.Time
@@ -271,9 +271,6 @@ func (g *EgyptianRatscrew) GetPending() EgyptianRatscrewPending { return g.pendi
 
 // GetLastEvent 直近イベント
 func (g *EgyptianRatscrew) GetLastEvent() EgyptianRatscrewLastEvent { return g.lastEvent }
-
-// GetActionLog 棋譜取得
-func (g *EgyptianRatscrew) GetActionLog() []*ActionLogEntry { return g.actionLog }
 
 // --- アクション ---
 
@@ -552,17 +549,6 @@ func (g *EgyptianRatscrew) checkStuck() {
 	}
 	// 両者ストック空 + スラップ不可 + チャンスバトルなしで詰み。引き分けとする。
 	g.endGame(-1)
-}
-
-// appendLog 棋譜にエントリを追加する
-func (g *EgyptianRatscrew) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // slapReasonLabel スラップ理由のログ用ラベル

--- a/internal/domain/Escoba.go
+++ b/internal/domain/Escoba.go
@@ -69,7 +69,7 @@ type Escoba struct {
 	gameEndFlag     bool
 	winnerIdx       int // -1: 未確定
 	lastRoundDetail *EscobaScoreDetail
-	actionLog       []*ActionLogEntry
+	actionLogBase
 }
 
 // NewEscoba コンストラクタ
@@ -483,9 +483,6 @@ func (e *Escoba) GetConfig() EscobaConfig { return e.config }
 // SetConfig 設定変更
 func (e *Escoba) SetConfig(cfg EscobaConfig) { e.config = cfg }
 
-// GetActionLog 棋譜取得
-func (e *Escoba) GetActionLog() []*ActionLogEntry { return e.actionLog }
-
 // IsHumanTurn 現在の手番が人間かどうか
 func (e *Escoba) IsHumanTurn() bool {
 	if e.gameEndFlag || e.currentTurn < 0 || e.currentTurn >= len(e.players) {
@@ -504,16 +501,6 @@ func (e *Escoba) GetValidCaptures(handIdx int) [][]int {
 		return nil
 	}
 	return EscobaCaptures(p.GetCard(handIdx), e.tableCards)
-}
-
-func (e *Escoba) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	e.actionLog = append(e.actionLog, &ActionLogEntry{
-		TurnNumber: len(e.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // --- JSON ---

--- a/internal/domain/Euchre.go
+++ b/internal/domain/Euchre.go
@@ -72,7 +72,7 @@ type Euchre struct {
 	bidPlayerIdx        int // 現在のビッド手番
 	gameEndFlag         bool
 	winnerTeam          int // 勝利チーム (-1 = 未確定)
-	actionLog           []*ActionLogEntry
+	actionLogBase
 }
 
 // NewEuchre コンストラクタ
@@ -676,9 +676,6 @@ func (e *Euchre) GetConfig() EuchreConfig { return e.config }
 // SetConfig 設定変更
 func (e *Euchre) SetConfig(cfg EuchreConfig) { e.config = cfg }
 
-// GetActionLog 棋譜取得
-func (e *Euchre) GetActionLog() []*ActionLogEntry { return e.actionLog }
-
 // CardRankPublic カードランク取得 (テスト用公開メソッド)
 func (e *Euchre) CardRankPublic(card *Card) int { return e.cardRank(card) }
 
@@ -925,17 +922,6 @@ func (e *Euchre) playerName(idx int) string {
 }
 
 // suitStr スート名を返す
-
-// appendLog 棋譜にエントリを追加する
-func (e *Euchre) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	e.actionLog = append(e.actionLog, &ActionLogEntry{
-		TurnNumber: len(e.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
-}
 
 // GetHint ヒントを取得する
 func (e *Euchre) GetHint() *EuchreHint {

--- a/internal/domain/Faro.go
+++ b/internal/domain/Faro.go
@@ -87,7 +87,7 @@ type Faro struct {
 	phase       int
 	gameEndFlag bool
 	totalPayout int // 直近のラウンドのプレイヤー純損益（正=利得）。
-	actionLog   []*ActionLogEntry
+	actionLogBase
 }
 
 // NewFaro はトランプデッキを受け取りファロを生成する。
@@ -386,17 +386,6 @@ func ranksEqual(a, b []int) bool {
 	return true
 }
 
-// appendLog は棋譜にエントリを追加する。
-func (f *Faro) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	f.actionLog = append(f.actionLog, &ActionLogEntry{
-		TurnNumber: len(f.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
-}
-
 // --- Getters ---
 
 // GetPhase は現在のフェーズを返す。
@@ -473,9 +462,6 @@ func (f *Faro) GetBetRanks() []int {
 
 // GetConfig は設定を返す。
 func (f *Faro) GetConfig() FaroConfig { return f.config }
-
-// GetActionLog は棋譜を返す。
-func (f *Faro) GetActionLog() []*ActionLogEntry { return f.actionLog }
 
 // --- Test helpers ---
 

--- a/internal/domain/FiveCardStud.go
+++ b/internal/domain/FiveCardStud.go
@@ -60,30 +60,30 @@ var errFiveCardStudInvalid = fmt.Errorf("fivecardstud: invalid game state")
 
 // FiveCardStud ファイブカードスタッド
 type FiveCardStud struct {
-	trumpCards       *TrumpCards
-	players          []*FiveCardStudPlayer
-	communityCard    *Card // カード不足時の共有カード
-	pot              int
-	sidePots         []SidePot
-	dealerIdx        int
-	currentTurn      int
-	phase            int
-	config           FiveCardStudConfig
-	gameEndFlag      bool
-	lastBet          int
-	minRaise         int
-	raiseCount       int
-	actedFlags       []bool
-	roundResults     []FiveCardStudResult
-	cpuActions       []FiveCardStudCpuAction
-	startingChips    []int
-	vpipTracked      []bool
-	pfrTracked       []bool
-	threeBetTracked  []bool
-	tournamentBase   // handCount / rebuyCounts / addonUsed (issue #1463)
-	lastCpuError     error
-	rebuyPhaseType   int
-	actionLog        []*ActionLogEntry
+	trumpCards      *TrumpCards
+	players         []*FiveCardStudPlayer
+	communityCard   *Card // カード不足時の共有カード
+	pot             int
+	sidePots        []SidePot
+	dealerIdx       int
+	currentTurn     int
+	phase           int
+	config          FiveCardStudConfig
+	gameEndFlag     bool
+	lastBet         int
+	minRaise        int
+	raiseCount      int
+	actedFlags      []bool
+	roundResults    []FiveCardStudResult
+	cpuActions      []FiveCardStudCpuAction
+	startingChips   []int
+	vpipTracked     []bool
+	pfrTracked      []bool
+	threeBetTracked []bool
+	tournamentBase  // handCount / rebuyCounts / addonUsed (issue #1463)
+	lastCpuError    error
+	rebuyPhaseType  int
+	actionLogBase
 	humanProfile     *BettingHumanProfile
 	lastHumanPlayMs  int
 	bringInPlayerIdx int // ブリングインプレイヤーインデックス
@@ -753,16 +753,6 @@ func (s *FiveCardStud) getHandName(rank int) string {
 
 // --- 棋譜 ---
 
-func (s *FiveCardStud) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	s.actionLog = append(s.actionLog, &ActionLogEntry{
-		TurnNumber: len(s.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
-}
-
 func (s *FiveCardStud) logAction(playerIdx, action, amount int) {
 	switch action {
 	case FiveCardStudActionFold:
@@ -887,9 +877,6 @@ func (s *FiveCardStud) GetActedFlags() []bool {
 
 // GetHandCount ハンド数取得
 func (s *FiveCardStud) GetHandCount() int { return s.handCount }
-
-// GetActionLog 棋譜を取得する
-func (s *FiveCardStud) GetActionLog() []*ActionLogEntry { return s.actionLog }
 
 // GetBringInPlayerIdx ブリングインプレイヤーインデックス取得
 func (s *FiveCardStud) GetBringInPlayerIdx() int { return s.bringInPlayerIdx }

--- a/internal/domain/FiveHundred.go
+++ b/internal/domain/FiveHundred.go
@@ -161,7 +161,7 @@ type FiveHundred struct {
 	teamScores  [FiveHundredTeamCnt]int
 	gameEndFlag bool
 	winnerTeam  int // 勝利チーム (-1 = 未確定)
-	actionLog   []*ActionLogEntry
+	actionLogBase
 }
 
 // NewFiveHundred コンストラクタ
@@ -1282,9 +1282,6 @@ func (g *FiveHundred) GetConfig() FiveHundredConfig { return g.config }
 // SetConfig 設定変更
 func (g *FiveHundred) SetConfig(cfg FiveHundredConfig) { g.config = cfg }
 
-// GetActionLog 棋譜取得
-func (g *FiveHundred) GetActionLog() []*ActionLogEntry { return g.actionLog }
-
 // CardRankPublic カードランク取得 (テスト用)
 func (g *FiveHundred) CardRankPublic(card *Card) int { return g.cardRank(card) }
 
@@ -1339,17 +1336,6 @@ func (g *FiveHundred) playerName(idx int) string {
 		return "You"
 	}
 	return fmt.Sprintf("CPU %d", idx)
-}
-
-// appendLog 棋譜にエントリを追加する
-func (g *FiveHundred) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // fiveHundredCardLabel カードのログ表示文字列 (ジョーカー対応)

--- a/internal/domain/FortyFives.go
+++ b/internal/domain/FortyFives.go
@@ -98,7 +98,7 @@ type FortyFives struct {
 	roundTeamPts     [FortyFivesTeamCnt]int // 現ラウンドのチーム別トリック得点
 	gameEndFlag      bool
 	winnerTeam       int // -1=未確定
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // NewFortyFives コンストラクタ
@@ -652,17 +652,6 @@ func (g *FortyFives) findHumanIdx() int {
 	return -1
 }
 
-// appendLog 棋譜にエントリを追加する。
-func (g *FortyFives) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
-}
-
 // --- CPU AI ---
 
 // cpuSelectPlayCard CPU がプレイするカードのインデックスを選ぶ。
@@ -943,9 +932,6 @@ func (g *FortyFives) GetConfig() FortyFivesConfig { return g.config }
 
 // SetConfig 設定変更
 func (g *FortyFives) SetConfig(cfg FortyFivesConfig) { g.config = cfg }
-
-// GetActionLog 棋譜取得
-func (g *FortyFives) GetActionLog() []*ActionLogEntry { return g.actionLog }
 
 // GetPlayableIndices プレイ可能なカードのインデックス一覧を返す。
 func (g *FortyFives) GetPlayableIndices(playerIdx int) []int {

--- a/internal/domain/FourCardPoker.go
+++ b/internal/domain/FourCardPoker.go
@@ -68,7 +68,7 @@ type FourCardPoker struct {
 	acesUpPayout    int // returned acesUp wager + bonus
 	playerHandRank  int
 	dealerHandRank  int
-	actionLog       []*ActionLogEntry
+	actionLogBase
 }
 
 // NewFourCardPoker constructs an empty game bound to a deck.
@@ -315,16 +315,6 @@ func (fcp *FourCardPoker) pairIsAces(cards []*Card) bool {
 	return counts[1] == 2
 }
 
-func (fcp *FourCardPoker) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	fcp.actionLog = append(fcp.actionLog, &ActionLogEntry{
-		TurnNumber: len(fcp.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
-}
-
 // --- Getters ---
 
 // GetPlayerHand returns the 5-card player hand.
@@ -393,9 +383,6 @@ func (fcp *FourCardPoker) GetDealerHandRank() int { return fcp.dealerHandRank }
 
 // GetChips returns the current chip stack.
 func (fcp *FourCardPoker) GetChips() int { return fcp.chips.GetChips() }
-
-// GetActionLog returns the round action log.
-func (fcp *FourCardPoker) GetActionLog() []*ActionLogEntry { return fcp.actionLog }
 
 // --- Test helpers ---
 

--- a/internal/domain/Gaigel.go
+++ b/internal/domain/Gaigel.go
@@ -90,7 +90,7 @@ type Gaigel struct {
 	lastTrickWinner  int
 	gameEndFlag      bool
 	winnerTeam       int // -1: 未確定
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // NewGaigel コンストラクタ
@@ -762,9 +762,6 @@ func (g *Gaigel) GetConfig() GaigelConfig { return g.config }
 // SetConfig 設定変更
 func (g *Gaigel) SetConfig(cfg GaigelConfig) { g.config = cfg }
 
-// GetActionLog 棋譜取得
-func (g *Gaigel) GetActionLog() []*ActionLogEntry { return g.actionLog }
-
 // GetValidPlayIndices プレイ可能なカードのインデックスリストを返す。
 // 第1フェーズは制約なし。第2フェーズはマストフォローを適用する。
 func (g *Gaigel) GetValidPlayIndices(playerIdx int) []int {
@@ -1044,16 +1041,6 @@ func (g *Gaigel) playerName(idx int) string {
 		return "You"
 	}
 	return fmt.Sprintf("CPU %d", idx)
-}
-
-func (g *Gaigel) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // --- Test-only helpers ---

--- a/internal/domain/GinRummy.go
+++ b/internal/domain/GinRummy.go
@@ -54,11 +54,11 @@ type GinRummy struct {
 	gameEndFlag      bool
 	winnerIdx        int
 	roundNumber      int
-	actionLog        []*ActionLogEntry
-	knockerIdx       int       // ノックしたプレイヤーのインデックス (-1 = ノックなし)
-	knockerMelds     [][]*Card // ノッカーのメルド (レイオフ用)
-	knockerDeadwood  []*Card   // ノッカーのデッドウッド
-	isGin            bool      // ジンかどうか
+	actionLogBase
+	knockerIdx      int       // ノックしたプレイヤーのインデックス (-1 = ノックなし)
+	knockerMelds    [][]*Card // ノッカーのメルド (レイオフ用)
+	knockerDeadwood []*Card   // ノッカーのデッドウッド
+	isGin           bool      // ジンかどうか
 }
 
 // NewGinRummy コンストラクタ
@@ -806,9 +806,6 @@ func (g *GinRummy) GetConfig() GinRummyConfig { return g.config }
 // SetConfig 設定変更
 func (g *GinRummy) SetConfig(cfg GinRummyConfig) { g.config = cfg }
 
-// GetActionLog 棋譜取得
-func (g *GinRummy) GetActionLog() []*ActionLogEntry { return g.actionLog }
-
 // GetKnockerIdx ノッカーのインデックス取得
 func (g *GinRummy) GetKnockerIdx() int { return g.knockerIdx }
 
@@ -862,17 +859,6 @@ func (g *GinRummy) playerName(idx int) string {
 		return "You"
 	}
 	return fmt.Sprintf("CPU %d", idx)
-}
-
-// appendLog 棋譜にエントリを追加する
-func (g *GinRummy) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // --- Meld Detection ---

--- a/internal/domain/GongZhu.go
+++ b/internal/domain/GongZhu.go
@@ -63,7 +63,7 @@ type GongZhu struct {
 	leadPlayerIdx    int
 	gameEndFlag      bool
 	winnerIdx        int
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // NewGongZhu コンストラクタ
@@ -494,9 +494,6 @@ func (g *GongZhu) GetConfig() GongZhuConfig { return g.config }
 // SetConfig 設定変更
 func (g *GongZhu) SetConfig(cfg GongZhuConfig) { g.config = cfg }
 
-// GetActionLog 棋譜取得
-func (g *GongZhu) GetActionLog() []*ActionLogEntry { return g.actionLog }
-
 // SetRoundNumber ラウンド番号設定 (テスト用)
 func (g *GongZhu) SetRoundNumber(n int) { g.roundNumber = n }
 
@@ -725,17 +722,6 @@ func (g *GongZhu) playerName(idx int) string {
 		return "You"
 	}
 	return fmt.Sprintf("CPU %d", idx)
-}
-
-// appendLog 棋譜にエントリを追加する
-func (g *GongZhu) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // --- Card helpers ---

--- a/internal/domain/HandAndFoot.go
+++ b/internal/domain/HandAndFoot.go
@@ -78,9 +78,9 @@ type HandAndFoot struct {
 	gameEndFlag      bool
 	winnerTeam       int
 	roundNumber      int
-	actionLog        []*ActionLogEntry
-	drewFromDiscard  bool
-	drawnCard        *Card
+	actionLogBase
+	drewFromDiscard bool
+	drawnCard       *Card
 }
 
 // NewHandAndFoot コンストラクタ
@@ -1337,9 +1337,6 @@ func (g *HandAndFoot) GetConfig() HandAndFootConfig { return g.config }
 // SetConfig 設定変更
 func (g *HandAndFoot) SetConfig(cfg HandAndFootConfig) { g.config = cfg }
 
-// GetActionLog 棋譜取得
-func (g *HandAndFoot) GetActionLog() []*ActionLogEntry { return g.actionLog }
-
 // GetDrewFromDiscard 捨て札から引いたか取得
 func (g *HandAndFoot) GetDrewFromDiscard() bool { return g.drewFromDiscard }
 
@@ -1372,17 +1369,6 @@ func (g *HandAndFoot) playerName(idx int) string {
 		return "You"
 	}
 	return fmt.Sprintf("CPU %d", idx)
-}
-
-// appendLog 棋譜にエントリを追加する
-func (g *HandAndFoot) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // --- JSON serialization ---

--- a/internal/domain/Hearts.go
+++ b/internal/domain/Hearts.go
@@ -73,7 +73,7 @@ type Hearts struct {
 	leadPlayerIdx    int
 	gameEndFlag      bool
 	winnerIdx        int
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // NewHearts コンストラクタ
@@ -483,9 +483,6 @@ func (h *Hearts) GetConfig() HeartsConfig { return h.config }
 
 // SetConfig 設定変更
 func (h *Hearts) SetConfig(cfg HeartsConfig) { h.config = cfg }
-
-// GetActionLog 棋譜取得
-func (h *Hearts) GetActionLog() []*ActionLogEntry { return h.actionLog }
 
 // GetPassReady パス準備状態取得
 func (h *Hearts) GetPassReady() [HeartsPlayerCnt]bool { return h.passReady }
@@ -1160,17 +1157,6 @@ func (h *Hearts) playerName(idx int) string {
 		return "You"
 	}
 	return fmt.Sprintf("CPU %d", idx)
-}
-
-// appendLog 棋譜にエントリを追加する
-func (h *Hearts) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	h.actionLog = append(h.actionLog, &ActionLogEntry{
-		TurnNumber: len(h.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // heartsJSON is the JSON wire format for Hearts.

--- a/internal/domain/HighCardFlush.go
+++ b/internal/domain/HighCardFlush.go
@@ -54,26 +54,26 @@ type HighCardFlushHand struct {
 
 // HighCardFlush ハイカードフラッシュクラス
 type HighCardFlush struct {
-	trumpCards        *TrumpCards       // トランプカード
-	playerHand        []*Card           // プレイヤーハンド (7枚)
-	dealerHand        []*Card           // ディーラーハンド (7枚)
-	chips             ChipHolder        // チップ
-	anteBet           int               // アンテベット額
-	flushBonusBet     int               // Flush Bonus サイドベット額
-	straightFlushBet  int               // Straight Flush Bonus サイドベット額
-	raiseBet          int               // レイズベット額（プレイ時にante×倍率で決定）
-	phase             int               // 現在のフェーズ
-	gameEndFlag       bool              // ゲーム終了フラグ
-	result            GameResult        // ゲーム結果
-	antePayout        int               // アンテ配当（元ベットを含む合計返却）
-	raisePayout       int               // レイズ配当（元ベットを含む合計返却）
-	flushBonusPayout  int               // Flush Bonus 配当（元ベットを含む合計返却）
-	straightFlushPay  int               // Straight Flush Bonus 配当（元ベットを含む合計返却）
-	dealerQualified   bool              // ディーラークオリファイフラグ
-	playerFlushLen    int               // プレイヤーのフラッシュ長
-	dealerFlushLen    int               // ディーラーのフラッシュ長
-	playerStraightLen int               // プレイヤーのストレートフラッシュ長（最大0なら無し）
-	actionLog         []*ActionLogEntry // 棋譜
+	trumpCards        *TrumpCards // トランプカード
+	playerHand        []*Card     // プレイヤーハンド (7枚)
+	dealerHand        []*Card     // ディーラーハンド (7枚)
+	chips             ChipHolder  // チップ
+	anteBet           int         // アンテベット額
+	flushBonusBet     int         // Flush Bonus サイドベット額
+	straightFlushBet  int         // Straight Flush Bonus サイドベット額
+	raiseBet          int         // レイズベット額（プレイ時にante×倍率で決定）
+	phase             int         // 現在のフェーズ
+	gameEndFlag       bool        // ゲーム終了フラグ
+	result            GameResult  // ゲーム結果
+	antePayout        int         // アンテ配当（元ベットを含む合計返却）
+	raisePayout       int         // レイズ配当（元ベットを含む合計返却）
+	flushBonusPayout  int         // Flush Bonus 配当（元ベットを含む合計返却）
+	straightFlushPay  int         // Straight Flush Bonus 配当（元ベットを含む合計返却）
+	dealerQualified   bool        // ディーラークオリファイフラグ
+	playerFlushLen    int         // プレイヤーのフラッシュ長
+	dealerFlushLen    int         // ディーラーのフラッシュ長
+	playerStraightLen int         // プレイヤーのストレートフラッシュ長（最大0なら無し）
+	actionLogBase
 }
 
 // NewHighCardFlush コンストラクタ
@@ -446,17 +446,6 @@ func longestConsecutiveRun(set map[int]bool) int {
 	return best
 }
 
-// appendLog 棋譜にエントリを追加する
-func (hcf *HighCardFlush) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	hcf.actionLog = append(hcf.actionLog, &ActionLogEntry{
-		TurnNumber: len(hcf.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
-}
-
 // --- Getters ---
 
 // GetPlayerHand プレイヤーハンドを取得する
@@ -517,9 +506,6 @@ func (hcf *HighCardFlush) GetPlayerStraightFlushLen() int { return hcf.playerStr
 
 // GetChips チップ
 func (hcf *HighCardFlush) GetChips() int { return hcf.chips.GetChips() }
-
-// GetActionLog 棋譜を取得する
-func (hcf *HighCardFlush) GetActionLog() []*ActionLogEntry { return hcf.actionLog }
 
 // --- Test helpers ---
 

--- a/internal/domain/Holdem.go
+++ b/internal/domain/Holdem.go
@@ -87,7 +87,7 @@ type Holdem struct {
 	threeBetTracked []bool // 当該ハンドで3Bet追跡済みかどうか
 	lastCpuError    error  // CPU行動エラーの最後のフォールバック記録 (テスト検出用)
 	rebuyPhaseType  int    // 0=none, 1=rebuy pending, 2=addon pending
-	actionLog       []*ActionLogEntry
+	actionLogBase
 	humanProfile    *BettingHumanProfile
 	lastHumanPlayMs int
 }
@@ -702,20 +702,6 @@ func (h *Holdem) GetActedFlags() []bool {
 
 // GetHandCount ハンド数取得
 func (h *Holdem) GetHandCount() int { return h.handCount }
-
-// GetActionLog 棋譜を取得する
-func (h *Holdem) GetActionLog() []*ActionLogEntry { return h.actionLog }
-
-// appendLog 棋譜にエントリを追加する
-func (h *Holdem) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	h.actionLog = append(h.actionLog, &ActionLogEntry{
-		TurnNumber: len(h.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
-}
 
 // logAction ベッティングアクションを棋譜に記録する
 func (h *Holdem) logAction(playerIdx, action, amount int) {

--- a/internal/domain/IndianPoker.go
+++ b/internal/domain/IndianPoker.go
@@ -45,25 +45,25 @@ type IndianPokerCpuAction struct {
 
 // IndianPoker インディアンポーカークラス
 type IndianPoker struct {
-	trumpCards      *TrumpCards
-	players         []*IndianPokerPlayer
-	pot             int
-	sidePots        []SidePot
-	dealerIdx       int
-	currentTurn     int
-	phase           int
-	config          IndianPokerConfig
-	gameEndFlag     bool
-	lastBet         int
-	minRaise        int
-	raiseCount      int
-	actedFlags      []bool
-	roundResults    []IndianPokerResult
-	cpuActions      []IndianPokerCpuAction
-	startingChips   []int
-	handCount       int
-	lastCpuError    error
-	actionLog       []*ActionLogEntry
+	trumpCards    *TrumpCards
+	players       []*IndianPokerPlayer
+	pot           int
+	sidePots      []SidePot
+	dealerIdx     int
+	currentTurn   int
+	phase         int
+	config        IndianPokerConfig
+	gameEndFlag   bool
+	lastBet       int
+	minRaise      int
+	raiseCount    int
+	actedFlags    []bool
+	roundResults  []IndianPokerResult
+	cpuActions    []IndianPokerCpuAction
+	startingChips []int
+	handCount     int
+	lastCpuError  error
+	actionLogBase
 	humanProfile    *IndianPokerHumanProfile
 	lastHumanPlayMs int
 }
@@ -751,20 +751,6 @@ func (ip *IndianPoker) GetActedFlags() []bool {
 
 // GetHandCount ハンド数取得
 func (ip *IndianPoker) GetHandCount() int { return ip.handCount }
-
-// GetActionLog 棋譜を取得する
-func (ip *IndianPoker) GetActionLog() []*ActionLogEntry { return ip.actionLog }
-
-// appendLog 棋譜にエントリを追加する
-func (ip *IndianPoker) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	ip.actionLog = append(ip.actionLog, &ActionLogEntry{
-		TurnNumber: len(ip.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
-}
 
 // logAction ベッティングアクションを棋譜に記録する
 func (ip *IndianPoker) logAction(playerIdx, action, amount int) {

--- a/internal/domain/IndianRummy.go
+++ b/internal/domain/IndianRummy.go
@@ -110,7 +110,7 @@ type IndianRummy struct {
 	scored           bool // ラウンド終了スコアリングが完了したか（フェーズ再入時の二重加算防止）
 	declarerIdx      int  // 宣言したプレイヤー（-1 = 宣言なし／山切れ）
 	declarationValid bool // 直近の宣言が有効だったか
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // NewIndianRummy コンストラクタ
@@ -639,9 +639,6 @@ func (g *IndianRummy) SetDeclarerIdx(i int) { g.declarerIdx = i }
 // GetDeclarationValid 直近の宣言が有効だったか
 func (g *IndianRummy) GetDeclarationValid() bool { return g.declarationValid }
 
-// GetActionLog 棋譜取得
-func (g *IndianRummy) GetActionLog() []*ActionLogEntry { return g.actionLog }
-
 // PlayerDeadwoodValue プレイヤー i のデッドウッド採点値（キャップ・ピュアシーケンス規則を含む）。
 func (g *IndianRummy) PlayerDeadwoodValue(i int) int {
 	p := g.GetPlayer(i)
@@ -689,16 +686,6 @@ func (g *IndianRummy) playerName(idx int) string {
 		return "You"
 	}
 	return fmt.Sprintf("CPU %d", idx)
-}
-
-func (g *IndianRummy) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // indianRummyCollectCards プレイヤーの手札を []*Card で返す

--- a/internal/domain/Jass.go
+++ b/internal/domain/Jass.go
@@ -77,7 +77,7 @@ type Jass struct {
 	bidPlayerIdx     int
 	gameEndFlag      bool
 	winnerTeam       int // 勝利チーム (-1 = 未確定)
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // NewJass コンストラクタ
@@ -543,9 +543,6 @@ func (g *Jass) GetConfig() JassConfig { return g.config }
 
 // SetConfig 設定変更
 func (g *Jass) SetConfig(cfg JassConfig) { g.config = cfg }
-
-// GetActionLog 棋譜取得
-func (g *Jass) GetActionLog() []*ActionLogEntry { return g.actionLog }
 
 // CardRankPublic カードランク取得 (テスト用公開メソッド)
 func (g *Jass) CardRankPublic(card *Card) int { return g.cardRank(card) }
@@ -1102,16 +1099,6 @@ func (g *Jass) playerName(idx int) string {
 		return "You"
 	}
 	return fmt.Sprintf("CPU %d", idx)
-}
-
-func (g *Jass) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // --- Hints ---

--- a/internal/domain/Kalooki.go
+++ b/internal/domain/Kalooki.go
@@ -68,7 +68,7 @@ type Kalooki struct {
 	winnerIdx        int
 	roundWinnerIdx   int // 上がったプレイヤー。-1 は山切れ流局
 	turnCount        int // 暴走防止用ターンカウンタ
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // NewKalooki コンストラクタ
@@ -702,9 +702,6 @@ func (g *Kalooki) GetConfig() KalookiConfig { return g.config }
 // SetConfig 設定変更
 func (g *Kalooki) SetConfig(c KalookiConfig) { g.config = c }
 
-// GetActionLog 棋譜取得
-func (g *Kalooki) GetActionLog() []*ActionLogEntry { return g.actionLog }
-
 // GetRoundWinnerIdx 直近ラウンドの勝者
 func (g *Kalooki) GetRoundWinnerIdx() int { return g.roundWinnerIdx }
 
@@ -740,16 +737,6 @@ func (g *Kalooki) playerName(idx int) string {
 		return "You"
 	}
 	return fmt.Sprintf("CPU %d", idx)
-}
-
-func (g *Kalooki) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // --- Pure card-evaluation helpers ---

--- a/internal/domain/Kemps.go
+++ b/internal/domain/Kemps.go
@@ -80,7 +80,7 @@ type Kemps struct {
 	roundNumber      int
 	gameEndFlag      bool
 	winnerTeam       int
-	actionLog        []*ActionLogEntry
+	actionLogBase
 
 	// rng CPU 判断用 (テストで差し替え可能)
 	rng *rand.Rand
@@ -287,9 +287,6 @@ func (g *Kemps) GetRoundWinnerTeam() int { return g.roundWinnerTeam }
 
 // GetRoundNumber は現在のラウンド番号を返す。
 func (g *Kemps) GetRoundNumber() int { return g.roundNumber }
-
-// GetActionLog は棋譜を返す。
-func (g *Kemps) GetActionLog() []*ActionLogEntry { return g.actionLog }
 
 // IsPartnerSignaling は人間 (席 0) のチームにフォーオブアカインド保持者がいて、
 // 人間が宣言可能なシグナル状態かを返す (人間にだけ公開される情報)。
@@ -667,17 +664,6 @@ func (g *Kemps) endGame(winnerTeam int) {
 		}
 	}
 	g.appendLog(-1, "gameEnd", fmt.Sprintf("team %d wins", winnerTeam), nil)
-}
-
-// appendLog は棋譜にエントリを追加する。
-func (g *Kemps) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // --- テスト/復元用セッター ---

--- a/internal/domain/King.go
+++ b/internal/domain/King.go
@@ -116,7 +116,7 @@ type King struct {
 	lastTrickWinner int          // 直前トリックの勝者 (-1 = なし)
 	gameEndFlag     bool
 	lastDealDetail  *KingDealDetail
-	actionLog       []*ActionLogEntry
+	actionLogBase
 }
 
 // NewKing はコンストラクタ。
@@ -441,17 +441,6 @@ func kingSortHand(p *KingPlayer) {
 	}
 }
 
-// appendLog は棋譜にエントリを追加する。
-func (g *King) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
-}
-
 // kingContractName はコントラクトの英語名を返す (ログ用)。
 func kingContractName(c int) string {
 	switch c {
@@ -576,9 +565,6 @@ func (g *King) GetConfig() KingConfig { return g.config }
 
 // SetConfig はローカルルール設定を変更する。
 func (g *King) SetConfig(config KingConfig) { g.config = config }
-
-// GetActionLog は棋譜を返す。
-func (g *King) GetActionLog() []*ActionLogEntry { return g.actionLog }
 
 // GetPlayableIndices はプレイフェーズでプレイ可能な手札インデックスを返す。
 func (g *King) GetPlayableIndices(playerIdx int) []int {

--- a/internal/domain/Klaverjas.go
+++ b/internal/domain/Klaverjas.go
@@ -76,7 +76,7 @@ type Klaverjas struct {
 	roundRoem        [KlaverjasTeamCnt]int // 現ラウンドの Roem 点
 	gameEndFlag      bool
 	winnerTeam       int // -1=未確定
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // NewKlaverjas コンストラクタ
@@ -628,17 +628,6 @@ func (g *Klaverjas) findHumanIdx() int {
 	return -1
 }
 
-// appendLog 棋譜にエントリを追加する。
-func (g *Klaverjas) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
-}
-
 // --- CPU AI ---
 
 // cpuSelectPlayCard CPU がプレイするカードのインデックスを選ぶ。
@@ -850,9 +839,6 @@ func (g *Klaverjas) GetConfig() KlaverjasConfig { return g.config }
 
 // SetConfig 設定変更
 func (g *Klaverjas) SetConfig(cfg KlaverjasConfig) { g.config = cfg }
-
-// GetActionLog 棋譜取得
-func (g *Klaverjas) GetActionLog() []*ActionLogEntry { return g.actionLog }
 
 // GetPlayableIndices プレイ可能なカードのインデックス一覧を返す。
 func (g *Klaverjas) GetPlayableIndices(playerIdx int) []int {

--- a/internal/domain/KnockoutWhist.go
+++ b/internal/domain/KnockoutWhist.go
@@ -67,7 +67,7 @@ type KnockoutWhist struct {
 	roundWinnerIdx   int // 直近ラウンドの勝者 (次ラウンドのリード/切り札決定者)
 	gameEndFlag      bool
 	winnerPlayer     int // -1=未確定
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // NewKnockoutWhist コンストラクタ
@@ -524,17 +524,6 @@ func (g *KnockoutWhist) findHumanIdx() int {
 	return -1
 }
 
-// appendLog 棋譜にエントリを追加する。
-func (g *KnockoutWhist) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
-}
-
 // --- CPU AI ---
 
 // cpuSelectPlayCard CPU がプレイするカードのインデックスを選ぶ。
@@ -729,9 +718,6 @@ func (g *KnockoutWhist) GetConfig() KnockoutWhistConfig { return g.config }
 
 // SetConfig 設定変更
 func (g *KnockoutWhist) SetConfig(cfg KnockoutWhistConfig) { g.config = cfg }
-
-// GetActionLog 棋譜取得
-func (g *KnockoutWhist) GetActionLog() []*ActionLogEntry { return g.actionLog }
 
 // GetPlayableIndices プレイ可能なカードのインデックス一覧を返す。
 func (g *KnockoutWhist) GetPlayableIndices(playerIdx int) []int {

--- a/internal/domain/LetItRide.go
+++ b/internal/domain/LetItRide.go
@@ -39,23 +39,23 @@ const (
 
 // LetItRide レット・イット・ライドクラス
 type LetItRide struct {
-	trumpCards     *TrumpCards       // トランプカード
-	playerHand     []*Card           // プレイヤーハンド（3枚）
-	communityCards []*Card           // コミュニティカード（2枚）
-	chips          ChipHolder        // チップ
-	betAmount      int               // 1口あたりのベット額
-	bet1Active     bool              // ベット1（常にアクティブ）
-	bet2Active     bool              // ベット2（第2判断で取り下げ可能）
-	bet3Active     bool              // ベット3（第1判断で取り下げ可能）
-	phase          int               // 現在のフェーズ
-	gameEndFlag    bool              // ゲーム終了フラグ
-	result         GameResult        // ゲーム結果（Win/Lose）
-	handRank       int               // 最終ハンドランク
-	bet1Payout     int               // ベット1配当
-	bet2Payout     int               // ベット2配当
-	bet3Payout     int               // ベット3配当
-	totalPayout    int               // 合計配当
-	actionLog      []*ActionLogEntry // 棋譜
+	trumpCards     *TrumpCards // トランプカード
+	playerHand     []*Card     // プレイヤーハンド（3枚）
+	communityCards []*Card     // コミュニティカード（2枚）
+	chips          ChipHolder  // チップ
+	betAmount      int         // 1口あたりのベット額
+	bet1Active     bool        // ベット1（常にアクティブ）
+	bet2Active     bool        // ベット2（第2判断で取り下げ可能）
+	bet3Active     bool        // ベット3（第1判断で取り下げ可能）
+	phase          int         // 現在のフェーズ
+	gameEndFlag    bool        // ゲーム終了フラグ
+	result         GameResult  // ゲーム結果（Win/Lose）
+	handRank       int         // 最終ハンドランク
+	bet1Payout     int         // ベット1配当
+	bet2Payout     int         // ベット2配当
+	bet3Payout     int         // ベット3配当
+	totalPayout    int         // 合計配当
+	actionLogBase
 }
 
 // NewLetItRide コンストラクタ
@@ -294,17 +294,6 @@ func (lir *LetItRide) checkTensOrBetter() int {
 	return 0
 }
 
-// appendLog 棋譜にエントリを追加する
-func (lir *LetItRide) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	lir.actionLog = append(lir.actionLog, &ActionLogEntry{
-		TurnNumber: len(lir.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
-}
-
 // --- Getters ---
 
 // GetPlayerHand プレイヤーハンド取得
@@ -351,9 +340,6 @@ func (lir *LetItRide) GetTotalPayout() int { return lir.totalPayout }
 
 // GetChips チップ
 func (lir *LetItRide) GetChips() int { return lir.chips.GetChips() }
-
-// GetActionLog 棋譜を取得する
-func (lir *LetItRide) GetActionLog() []*ActionLogEntry { return lir.actionLog }
 
 // --- Test helpers ---
 

--- a/internal/domain/Loo.go
+++ b/internal/domain/Loo.go
@@ -88,8 +88,8 @@ type Loo struct {
 	roundTricks      [LooPlayerCnt]int
 	gameEndFlag      bool
 	lastDealDetail   *LooDealDetail
-	actionLog        []*ActionLogEntry
-	scored           bool // 現ディールが精算済みか (二重精算防止)
+	actionLogBase
+	scored bool // 現ディールが精算済みか (二重精算防止)
 }
 
 // NewLoo はコンストラクタ。
@@ -655,16 +655,6 @@ func (g *Loo) playerName(idx int) string {
 	return fmt.Sprintf("CPU %d", idx)
 }
 
-func (g *Loo) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
-}
-
 // indexOfPlayerInTrick は currentTrick 内で playerIdx の札の位置を返す (-1=なし)。
 func (g *Loo) indexOfPlayerInTrick(playerIdx int) int {
 	for i, tc := range g.currentTrick {
@@ -967,9 +957,6 @@ func (g *Loo) GetConfig() LooConfig { return g.config }
 
 // SetConfig はローカルルール設定を変更する。
 func (g *Loo) SetConfig(cfg LooConfig) { g.config = cfg }
-
-// GetActionLog は棋譜を返す。
-func (g *Loo) GetActionLog() []*ActionLogEntry { return g.actionLog }
 
 // GetPlayableIndices はプレイフェーズでプレイ可能な手札インデックスを返す。
 func (g *Loo) GetPlayableIndices(playerIdx int) []int {

--- a/internal/domain/Macau.go
+++ b/internal/domain/Macau.go
@@ -65,7 +65,7 @@ type Macau struct {
 	gameEndFlag      bool
 	winnerIdx        int
 	roundNumber      int
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // NewMacau コンストラクタ
@@ -477,9 +477,6 @@ func (g *Macau) GetConfig() MacauConfig { return g.config }
 // SetConfig 設定変更
 func (g *Macau) SetConfig(cfg MacauConfig) { g.config = cfg }
 
-// GetActionLog 棋譜取得
-func (g *Macau) GetActionLog() []*ActionLogEntry { return g.actionLog }
-
 // --- Private methods ---
 
 // IsValidPlay は現在の場状態 (捨て札トップ・宣言スート・ペナルティ連鎖) を踏まえ
@@ -722,17 +719,6 @@ func (g *Macau) playerName(idx int) string {
 		return "You"
 	}
 	return fmt.Sprintf("CPU %d", idx)
-}
-
-// appendLog 棋譜にエントリを追加する
-func (g *Macau) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // --- CPU AI ---

--- a/internal/domain/Machiavelli.go
+++ b/internal/domain/Machiavelli.go
@@ -104,7 +104,7 @@ type Machiavelli struct {
 	roundNumber      int
 	scored           bool // ラウンド終了スコアリングが完了したか（フェーズ再入時の二重加算防止）
 	roundWinnerIdx   int  // 直近ラウンドの勝者（-1 = 山切れ流局）
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // NewMachiavelli コンストラクタ
@@ -643,9 +643,6 @@ func (g *Machiavelli) SetConfig(c MachiavelliConfig) { g.config = c }
 // GetTargetRounds ゲーム終了までのラウンド数
 func (g *Machiavelli) GetTargetRounds() int { return g.config.TargetRounds }
 
-// GetActionLog 棋譜取得
-func (g *Machiavelli) GetActionLog() []*ActionLogEntry { return g.actionLog }
-
 // PlayerDeadwoodValue プレイヤー i の手札デッドウッド点。
 func (g *Machiavelli) PlayerDeadwoodValue(i int) int {
 	p := g.GetPlayer(i)
@@ -684,16 +681,6 @@ func (g *Machiavelli) playerName(idx int) string {
 		return "You"
 	}
 	return fmt.Sprintf("CPU %d", idx)
-}
-
-func (g *Machiavelli) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // machiavelliCollectCards プレイヤーの手札を []*Card で返す

--- a/internal/domain/Manille.go
+++ b/internal/domain/Manille.go
@@ -71,7 +71,7 @@ type Manille struct {
 	roundCardPts     [ManilleTeamCnt]int // 現ラウンドのカード得点
 	gameEndFlag      bool
 	winnerTeam       int // -1=未確定
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // NewManille コンストラクタ
@@ -467,17 +467,6 @@ func (g *Manille) findHumanIdx() int {
 	return -1
 }
 
-// appendLog 棋譜にエントリを追加する。
-func (g *Manille) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
-}
-
 // --- CPU AI ---
 
 // cpuSelectPlayCard CPU がプレイするカードのインデックスを選ぶ。
@@ -686,9 +675,6 @@ func (g *Manille) GetConfig() ManilleConfig { return g.config }
 
 // SetConfig 設定変更
 func (g *Manille) SetConfig(cfg ManilleConfig) { g.config = cfg }
-
-// GetActionLog 棋譜取得
-func (g *Manille) GetActionLog() []*ActionLogEntry { return g.actionLog }
 
 // GetPlayableIndices プレイ可能なカードのインデックス一覧を返す。
 func (g *Manille) GetPlayableIndices(playerIdx int) []int {

--- a/internal/domain/Mao.go
+++ b/internal/domain/Mao.go
@@ -105,7 +105,7 @@ type Mao struct {
 	gameEndFlag      bool
 	winnerIdx        int
 	roundNumber      int
-	actionLog        []*ActionLogEntry
+	actionLogBase
 
 	// --- 隠しルールシステム ---
 	hiddenRule         MaoHiddenRule // ゲーム開始時に決定的に選ばれる
@@ -646,9 +646,6 @@ func (g *Mao) GetConfig() MaoConfig { return g.config }
 // SetConfig 設定変更
 func (g *Mao) SetConfig(cfg MaoConfig) { g.config = cfg }
 
-// GetActionLog 棋譜取得
-func (g *Mao) GetActionLog() []*ActionLogEntry { return g.actionLog }
-
 // --- Hidden-rule getters/setters ---
 
 // GetAwaitingWord 人間が隠しルールに従って言葉を宣言すべき状態か
@@ -917,17 +914,6 @@ func (g *Mao) playerName(idx int) string {
 		return "You"
 	}
 	return fmt.Sprintf("CPU %d", idx)
-}
-
-// appendLog 棋譜にエントリを追加する
-func (g *Mao) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // --- CPU AI ---

--- a/internal/domain/Marias.go
+++ b/internal/domain/Marias.go
@@ -81,7 +81,7 @@ type Marias struct {
 	lastTrickWinner  int                  // 最終トリック勝者 (-1=未確定)
 	gameEndFlag      bool
 	winnerPlayer     int // -1=未確定
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // NewMarias コンストラクタ
@@ -530,17 +530,6 @@ func (g *Marias) findHumanIdx() int {
 	return -1
 }
 
-// appendLog 棋譜にエントリを追加する。
-func (g *Marias) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
-}
-
 // --- CPU AI ---
 
 // cpuSelectPlayCard CPU がプレイするカードのインデックスを選ぶ。
@@ -739,9 +728,6 @@ func (g *Marias) GetConfig() MariasConfig { return g.config }
 
 // SetConfig 設定変更
 func (g *Marias) SetConfig(cfg MariasConfig) { g.config = cfg }
-
-// GetActionLog 棋譜取得
-func (g *Marias) GetActionLog() []*ActionLogEntry { return g.actionLog }
 
 // GetPlayableIndices プレイ可能なカードのインデックス一覧を返す。
 func (g *Marias) GetPlayableIndices(playerIdx int) []int {

--- a/internal/domain/MississippiStud.go
+++ b/internal/domain/MississippiStud.go
@@ -66,7 +66,7 @@ type MississippiStud struct {
 	antePayout        int                           // アンティ部分の配当
 	streetPayouts     [MississippiStudStreetCnt]int // ストリートベット部分の配当
 	totalPayout       int                           // 合計配当
-	actionLog         []*ActionLogEntry             // 棋譜
+	actionLogBase
 }
 
 // NewMississippiStud コンストラクタ
@@ -483,17 +483,6 @@ func mississippiStudPairTier(hand []*Card) int {
 	return MississippiStudPayLoss
 }
 
-// appendLog 棋譜にエントリを追加する
-func (m *MississippiStud) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	m.actionLog = append(m.actionLog, &ActionLogEntry{
-		TurnNumber: len(m.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
-}
-
 // --- Getters ---
 
 // GetPlayerHand ホールカードを取得する。
@@ -555,9 +544,6 @@ func (m *MississippiStud) GetTotalPayout() int { return m.totalPayout }
 
 // GetChips チップ残高を取得する。
 func (m *MississippiStud) GetChips() int { return m.chips.GetChips() }
-
-// GetActionLog 棋譜を取得する。
-func (m *MississippiStud) GetActionLog() []*ActionLogEntry { return m.actionLog }
 
 // --- Test helpers ---
 

--- a/internal/domain/Mus.go
+++ b/internal/domain/Mus.go
@@ -138,7 +138,7 @@ type Mus struct {
 	// 終了
 	gameEndFlag bool
 	winnerTeam  int // -1=未確定
-	actionLog   []*ActionLogEntry
+	actionLogBase
 }
 
 // NewMus コンストラクタ
@@ -842,17 +842,6 @@ func musRoundName(ri int) string {
 	}
 }
 
-// appendLog 棋譜にエントリを追加する。
-func (g *Mus) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
-}
-
 // --- CPU ---
 
 // CpuPlay 現在の手番が CPU の場合に 1 アクション実行する。
@@ -1113,9 +1102,6 @@ func (g *Mus) GetConfig() MusConfig { return g.config }
 
 // SetConfig 設定変更
 func (g *Mus) SetConfig(cfg MusConfig) { g.config = cfg }
-
-// GetActionLog 棋譜取得
-func (g *Mus) GetActionLog() []*ActionLogEntry { return g.actionLog }
 
 // --- JSON ---
 

--- a/internal/domain/Nap.go
+++ b/internal/domain/Nap.go
@@ -91,7 +91,7 @@ type Nap struct {
 	roundTricks      [NapPlayerCnt]int
 	gameEndFlag      bool
 	winnerPlayer     int // -1=未確定
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // NewNap コンストラクタ
@@ -595,17 +595,6 @@ func (g *Nap) findHumanIdx() int {
 	return -1
 }
 
-// appendLog 棋譜にエントリを追加する。
-func (g *Nap) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
-}
-
 // --- CPU AI ---
 
 // cpuSelectPlayCard CPU がプレイするカードのインデックスを選ぶ。
@@ -864,9 +853,6 @@ func (g *Nap) GetConfig() NapConfig { return g.config }
 
 // SetConfig 設定変更
 func (g *Nap) SetConfig(cfg NapConfig) { g.config = cfg }
-
-// GetActionLog 棋譜取得
-func (g *Nap) GetActionLog() []*ActionLogEntry { return g.actionLog }
 
 // GetPlayableIndices プレイ可能なカードのインデックス一覧を返す。
 func (g *Nap) GetPlayableIndices(playerIdx int) []int {

--- a/internal/domain/NinetyNine.go
+++ b/internal/domain/NinetyNine.go
@@ -86,7 +86,7 @@ type NinetyNine struct {
 	trumpSuit        int // 切り札スート (CardDesignSpade..Diamond)
 	gameEndFlag      bool
 	winnerIdx        int
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // NewNinetyNine コンストラクタ
@@ -463,9 +463,6 @@ func (o *NinetyNine) GetConfig() NinetyNineConfig { return o.config }
 // SetConfig 設定変更
 func (o *NinetyNine) SetConfig(cfg NinetyNineConfig) { o.config = cfg }
 
-// GetActionLog 棋譜取得
-func (o *NinetyNine) GetActionLog() []*ActionLogEntry { return o.actionLog }
-
 // GetValidPlayIndices プレイ可能なカードのインデックスリストを返す
 func (o *NinetyNine) GetValidPlayIndices(playerIdx int) []int {
 	return o.getValidPlayIndices(playerIdx)
@@ -674,17 +671,6 @@ func (o *NinetyNine) playerName(idx int) string {
 		return "You"
 	}
 	return fmt.Sprintf("CPU %d", idx)
-}
-
-// appendLog 棋譜にエントリを追加する
-func (o *NinetyNine) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	o.actionLog = append(o.actionLog, &ActionLogEntry{
-		TurnNumber: len(o.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す

--- a/internal/domain/OasisPoker.go
+++ b/internal/domain/OasisPoker.go
@@ -67,7 +67,7 @@ type OasisPoker struct {
 	dealerQualified bool
 	playerHandRank  int
 	dealerHandRank  int
-	actionLog       []*ActionLogEntry
+	actionLogBase
 }
 
 // NewOasisPoker コンストラクタ
@@ -366,17 +366,6 @@ func (op *OasisPoker) evaluateJackpot() {
 	}
 }
 
-// appendLog 棋譜にエントリを追加する
-func (op *OasisPoker) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	op.actionLog = append(op.actionLog, &ActionLogEntry{
-		TurnNumber: len(op.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
-}
-
 // --- Getters ---
 
 // GetPlayerHand プレイヤーハンド取得
@@ -451,9 +440,6 @@ func (op *OasisPoker) GetDealerHandRank() int { return op.dealerHandRank }
 
 // GetChips チップ
 func (op *OasisPoker) GetChips() int { return op.chips.GetChips() }
-
-// GetActionLog 棋譜を取得する
-func (op *OasisPoker) GetActionLog() []*ActionLogEntry { return op.actionLog }
 
 // --- Test helpers ---
 

--- a/internal/domain/OhHell.go
+++ b/internal/domain/OhHell.go
@@ -52,7 +52,7 @@ type OhHell struct {
 	trumpSuit        int   // 切り札スート (-1 = 切り札なし)
 	gameEndFlag      bool
 	winnerIdx        int
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // NewOhHell コンストラクタ
@@ -427,9 +427,6 @@ func (o *OhHell) GetConfig() OhHellConfig { return o.config }
 // SetConfig 設定変更
 func (o *OhHell) SetConfig(cfg OhHellConfig) { o.config = cfg }
 
-// GetActionLog 棋譜取得
-func (o *OhHell) GetActionLog() []*ActionLogEntry { return o.actionLog }
-
 // GetRestrictedBid ディーラーが選択できないビッド値を返す (-1 = 制限なし)
 func (o *OhHell) GetRestrictedBid() int {
 	if o.phase != OhHellPhaseBid {
@@ -658,17 +655,6 @@ func (o *OhHell) playerName(idx int) string {
 		return "You"
 	}
 	return fmt.Sprintf("CPU %d", idx)
-}
-
-// appendLog 棋譜にエントリを追加する
-func (o *OhHell) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	o.actionLog = append(o.actionLog, &ActionLogEntry{
-		TurnNumber: len(o.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す

--- a/internal/domain/OichoKabu.go
+++ b/internal/domain/OichoKabu.go
@@ -62,7 +62,7 @@ type OichoKabu struct {
 	gameEndFlag bool
 	result      OichoKabuResult
 	totalPayout int
-	actionLog   []*ActionLogEntry
+	actionLogBase
 }
 
 // NewOichoKabu コンストラクタ。40 枚のカブ札を組み立ててシャッフルする。
@@ -230,17 +230,6 @@ func (o *OichoKabu) playerRank() int { return oichoKabuHandRank(o.playerHand) }
 // bankerRank 親の目
 func (o *OichoKabu) bankerRank() int { return oichoKabuHandRank(o.bankerHand) }
 
-// appendLog 棋譜にエントリを追加する。
-func (o *OichoKabu) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	o.actionLog = append(o.actionLog, &ActionLogEntry{
-		TurnNumber: len(o.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
-}
-
 // --- Getters ---
 
 // GetPlayerHand 子の手
@@ -272,9 +261,6 @@ func (o *OichoKabu) GetTotalPayout() int { return o.totalPayout }
 
 // GetChips チップ
 func (o *OichoKabu) GetChips() int { return o.chips.GetChips() }
-
-// GetActionLog 棋譜
-func (o *OichoKabu) GetActionLog() []*ActionLogEntry { return o.actionLog }
 
 // --- Test helpers ---
 

--- a/internal/domain/OldMaid.go
+++ b/internal/domain/OldMaid.go
@@ -67,7 +67,7 @@ type OldMaid struct {
 	cpuHighlightedCardIdx int                        // CPU心理戦: 奇数カードの位置 (-1=なし)
 	humanHandDirty        bool                       // 人間がシャッフル/並び替えしたフラグ
 	humanProfile          *OldMaidHumanProfile       // メタAIプロファイル
-	actionLog             []*ActionLogEntry          // 棋譜
+	actionLogBase
 }
 
 // NewOldMaid コンストラクタ
@@ -714,20 +714,6 @@ func (o *OldMaid) GetHumanAction() *OldMaidCpuAction {
 // GetDrawHistory ゲーム全体の引き履歴取得
 func (o *OldMaid) GetDrawHistory() []*OldMaidDrawHistoryEntry {
 	return o.drawHistory
-}
-
-// GetActionLog 棋譜を取得する
-func (o *OldMaid) GetActionLog() []*ActionLogEntry { return o.actionLog }
-
-// appendLog 棋譜にエントリを追加する
-func (o *OldMaid) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	o.actionLog = append(o.actionLog, &ActionLogEntry{
-		TurnNumber: len(o.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // --- JSON Serialization ---

--- a/internal/domain/Omaha.go
+++ b/internal/domain/Omaha.go
@@ -66,7 +66,7 @@ type Omaha struct {
 	tournamentBase  // handCount / rebuyCounts / addonUsed (issue #1463)
 	lastCpuError    error
 	rebuyPhaseType  int
-	actionLog       []*ActionLogEntry
+	actionLogBase
 	humanProfile    *BettingHumanProfile
 	lastHumanPlayMs int
 }
@@ -1382,20 +1382,6 @@ func (o *Omaha) GetActedFlags() []bool {
 
 // GetHandCount ハンド数取得
 func (o *Omaha) GetHandCount() int { return o.handCount }
-
-// GetActionLog 棋譜を取得する
-func (o *Omaha) GetActionLog() []*ActionLogEntry { return o.actionLog }
-
-// appendLog 棋譜にエントリを追加する
-func (o *Omaha) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	o.actionLog = append(o.actionLog, &ActionLogEntry{
-		TurnNumber: len(o.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
-}
 
 // logAction ベッティングアクションを棋譜に記録する
 func (o *Omaha) logAction(playerIdx, action, amount int) {

--- a/internal/domain/Ombre.go
+++ b/internal/domain/Ombre.go
@@ -165,7 +165,7 @@ type Ombre struct {
 	scored           bool                     // 当該ディールの得点計算済みか (RoundEnd 突入時に一度だけ)
 	gameEndFlag      bool
 	winnerPlayer     int // -1=未確定
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // NewOmbre コンストラクタ
@@ -997,17 +997,6 @@ func (g *Ombre) findHumanIdx() int {
 	return -1
 }
 
-// appendLog 棋譜にエントリを追加する。
-func (g *Ombre) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
-}
-
 // --- CPU AI (play) ---
 
 // cpuSelectPlayCard CPU がプレイするカードのインデックスを選ぶ。
@@ -1304,9 +1293,6 @@ func (g *Ombre) GetConfig() OmbreConfig { return g.config }
 
 // SetConfig 設定変更
 func (g *Ombre) SetConfig(cfg OmbreConfig) { g.config = cfg }
-
-// GetActionLog 棋譜取得
-func (g *Ombre) GetActionLog() []*ActionLogEntry { return g.actionLog }
 
 // GetPlayableIndices プレイ可能なカードのインデックス一覧を返す。
 func (g *Ombre) GetPlayableIndices(playerIdx int) []int {

--- a/internal/domain/OpenFaceChinese.go
+++ b/internal/domain/OpenFaceChinese.go
@@ -92,7 +92,7 @@ type OpenFaceChinese struct {
 	dealerIdx        int
 	gameEndFlag      bool
 	winnerIdx        int // -1=未確定/引き分け
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // NewOpenFaceChinese コンストラクタ
@@ -542,17 +542,6 @@ func (g *OpenFaceChinese) playerName(idx int) string {
 	return fmt.Sprintf("CPU %d", idx)
 }
 
-// appendLog 棋譜にエントリを追加する。
-func (g *OpenFaceChinese) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
-}
-
 // --- Getters ---
 
 // GetPhase 現在のフェーズ取得
@@ -603,9 +592,6 @@ func (g *OpenFaceChinese) SetConfig(cfg OpenFaceChineseConfig) {
 		g.players = ofcBuildPlayers(cfg.PlayerCount)
 	}
 }
-
-// GetActionLog 棋譜取得
-func (g *OpenFaceChinese) GetActionLog() []*ActionLogEntry { return g.actionLog }
 
 // GetCurrentCard 現在の手番プレイヤーが置こうとしている保留カードを返す（無ければ nil）。
 func (g *OpenFaceChinese) GetCurrentCard() *Card {

--- a/internal/domain/PageOne.go
+++ b/internal/domain/PageOne.go
@@ -42,7 +42,7 @@ type PageOne struct {
 	gameEndFlag      bool
 	winnerIdx        int
 	roundNumber      int
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // NewPageOne コンストラクタ
@@ -395,9 +395,6 @@ func (g *PageOne) GetConfig() PageOneConfig { return g.config }
 // SetConfig 設定変更
 func (g *PageOne) SetConfig(cfg PageOneConfig) { g.config = cfg }
 
-// GetActionLog 棋譜取得
-func (g *PageOne) GetActionLog() []*ActionLogEntry { return g.actionLog }
-
 // GetValidPlayIndices プレイ可能なカードのインデックスリストを返す
 func (g *PageOne) GetValidPlayIndices(playerIdx int) []int {
 	return g.getValidPlayIndices(playerIdx)
@@ -560,17 +557,6 @@ func (g *PageOne) playerName(idx int) string {
 		return "You"
 	}
 	return fmt.Sprintf("CPU %d", idx)
-}
-
-// appendLog 棋譜にエントリを追加する
-func (g *PageOne) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // --- CPU AI ---

--- a/internal/domain/PaiGow.go
+++ b/internal/domain/PaiGow.go
@@ -41,27 +41,27 @@ var PaiGowLowHandNames = []string{
 
 // PaiGow パイガオポーカークラス
 type PaiGow struct {
-	trumpCards     *TrumpCards       // トランプカード
-	playerCards    []*Card           // プレイヤーの7枚
-	dealerCards    []*Card           // ディーラーの7枚
-	playerHighHand []*Card           // プレイヤーハイハンド（5枚）
-	playerLowHand  []*Card           // プレイヤーローハンド（2枚）
-	dealerHighHand []*Card           // ディーラーハイハンド（5枚）
-	dealerLowHand  []*Card           // ディーラーローハンド（2枚）
-	chips          ChipHolder        // チップ
-	bet            int               // ベット額
-	phase          int               // 現在のフェーズ
-	gameEndFlag    bool              // ゲーム終了フラグ
-	result         GameResult        // ゲーム結果
-	highHandResult GameResult        // ハイハンド結果
-	lowHandResult  GameResult        // ローハンド結果
-	payout         int               // 配当
-	commission     int               // コミッション
-	playerHighRank int               // プレイヤーハイハンドランク
-	playerLowRank  int               // プレイヤーローハンドランク
-	dealerHighRank int               // ディーラーハイハンドランク
-	dealerLowRank  int               // ディーラーローハンドランク
-	actionLog      []*ActionLogEntry // 棋譜
+	trumpCards     *TrumpCards // トランプカード
+	playerCards    []*Card     // プレイヤーの7枚
+	dealerCards    []*Card     // ディーラーの7枚
+	playerHighHand []*Card     // プレイヤーハイハンド（5枚）
+	playerLowHand  []*Card     // プレイヤーローハンド（2枚）
+	dealerHighHand []*Card     // ディーラーハイハンド（5枚）
+	dealerLowHand  []*Card     // ディーラーローハンド（2枚）
+	chips          ChipHolder  // チップ
+	bet            int         // ベット額
+	phase          int         // 現在のフェーズ
+	gameEndFlag    bool        // ゲーム終了フラグ
+	result         GameResult  // ゲーム結果
+	highHandResult GameResult  // ハイハンド結果
+	lowHandResult  GameResult  // ローハンド結果
+	payout         int         // 配当
+	commission     int         // コミッション
+	playerHighRank int         // プレイヤーハイハンドランク
+	playerLowRank  int         // プレイヤーローハンドランク
+	dealerHighRank int         // ディーラーハイハンドランク
+	dealerLowRank  int         // ディーラーローハンドランク
+	actionLogBase
 }
 
 // NewPaiGow コンストラクタ
@@ -614,17 +614,6 @@ func paiGowHighHandSortedValues(cards []*Card) []int {
 	return vals
 }
 
-// appendLog 棋譜にエントリを追加する
-func (pg *PaiGow) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	pg.actionLog = append(pg.actionLog, &ActionLogEntry{
-		TurnNumber: len(pg.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
-}
-
 // --- Getters ---
 
 // GetPlayerCards プレイヤーの7枚を取得
@@ -683,9 +672,6 @@ func (pg *PaiGow) GetDealerLowRank() int { return pg.dealerLowRank }
 
 // GetChips チップ
 func (pg *PaiGow) GetChips() int { return pg.chips.GetChips() }
-
-// GetActionLog 棋譜を取得する
-func (pg *PaiGow) GetActionLog() []*ActionLogEntry { return pg.actionLog }
 
 // --- Test helpers ---
 

--- a/internal/domain/Pan.go
+++ b/internal/domain/Pan.go
@@ -122,7 +122,7 @@ type Pan struct {
 	roundNumber      int
 	scored           bool // ラウンド終了スコアリングが完了したか（フェーズ再入時の二重加算防止）
 	panDeclarerIdx   int  // 「パン」を宣言したプレイヤー（-1 = 宣言なし／山切れ）
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // NewPan コンストラクタ
@@ -708,9 +708,6 @@ func (g *Pan) GetPanDeclarerIdx() int { return g.panDeclarerIdx }
 // SetPanDeclarerIdx 宣言プレイヤー設定（テスト用）
 func (g *Pan) SetPanDeclarerIdx(i int) { g.panDeclarerIdx = i }
 
-// GetActionLog 棋譜取得
-func (g *Pan) GetActionLog() []*ActionLogEntry { return g.actionLog }
-
 // PlayerHandPoints プレイヤー i の手札ピップ点。
 func (g *Pan) PlayerHandPoints(i int) int {
 	p := g.GetPlayer(i)
@@ -755,16 +752,6 @@ func (g *Pan) playerName(idx int) string {
 		return "You"
 	}
 	return fmt.Sprintf("CPU %d", idx)
-}
-
-func (g *Pan) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // --- Scoring / meld helpers ---

--- a/internal/domain/PigsTail.go
+++ b/internal/domain/PigsTail.go
@@ -68,24 +68,24 @@ type PigsTail struct {
 	cpuActions   []*PigsTailCpuAction // CPUターンの行動履歴
 	humanAction  *PigsTailCpuAction   // 人間プレイヤーの最後の行動記録
 	config       PigsTailConfig       // ゲーム設定
-	actionLog    []*ActionLogEntry    // 棋譜
+	actionLogBase
 }
 
 // NewPigsTail コンストラクタ
 func NewPigsTail(trumpCards *TrumpCards, players []*PigsTailPlayer) *PigsTail {
 	return &PigsTail{
-		trumpCards:   trumpCards,
-		center:       make([]*Card, 0),
-		players:      players,
-		currentTurn:  0,
-		gameEndFlag:  false,
-		loserIdx:     -1,
-		lastDrawCard: nil,
-		lastPenalty:  false,
-		cpuActions:   nil,
-		humanAction:  nil,
-		config:       DefaultPigsTailConfig(),
-		actionLog:    nil,
+		trumpCards:    trumpCards,
+		center:        make([]*Card, 0),
+		players:       players,
+		currentTurn:   0,
+		gameEndFlag:   false,
+		loserIdx:      -1,
+		lastDrawCard:  nil,
+		lastPenalty:   false,
+		cpuActions:    nil,
+		humanAction:   nil,
+		config:        DefaultPigsTailConfig(),
+		actionLogBase: actionLogBase{actionLog: nil},
 	}
 }
 
@@ -330,20 +330,6 @@ func (pt *PigsTail) GetCpuActions() []*PigsTailCpuAction { return pt.cpuActions 
 
 // GetHumanAction 人間の最後の行動記録を取得する
 func (pt *PigsTail) GetHumanAction() *PigsTailCpuAction { return pt.humanAction }
-
-// GetActionLog 棋譜を取得する
-func (pt *PigsTail) GetActionLog() []*ActionLogEntry { return pt.actionLog }
-
-// appendLog 棋譜にエントリを追加する
-func (pt *PigsTail) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	pt.actionLog = append(pt.actionLog, &ActionLogEntry{
-		TurnNumber: len(pt.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
-}
 
 // cardShortStr カードの短い文字列表現を返す
 func cardShortStr(c *Card) string {

--- a/internal/domain/Pineapple.go
+++ b/internal/domain/Pineapple.go
@@ -59,7 +59,7 @@ type Pineapple struct {
 	tournamentBase  // handCount / rebuyCounts / addonUsed (issue #1463)
 	lastCpuError    error
 	rebuyPhaseType  int
-	actionLog       []*ActionLogEntry
+	actionLogBase
 	humanProfile    *BettingHumanProfile
 	lastHumanPlayMs int
 	discardDone     []bool // ディスカード済みフラグ
@@ -1240,25 +1240,11 @@ func (p *Pineapple) GetActedFlags() []bool {
 // GetHandCount ハンド数取得
 func (p *Pineapple) GetHandCount() int { return p.handCount }
 
-// GetActionLog 棋譜を取得する
-func (p *Pineapple) GetActionLog() []*ActionLogEntry { return p.actionLog }
-
 // GetDiscardDone ディスカード済みフラグ取得
 func (p *Pineapple) GetDiscardDone() []bool {
 	result := make([]bool, len(p.discardDone))
 	copy(result, p.discardDone)
 	return result
-}
-
-// appendLog 棋譜にエントリを追加する
-func (p *Pineapple) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	p.actionLog = append(p.actionLog, &ActionLogEntry{
-		TurnNumber: len(p.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // logAction ベッティングアクションを棋譜に記録する

--- a/internal/domain/Pitch.go
+++ b/internal/domain/Pitch.go
@@ -70,7 +70,7 @@ type Pitch struct {
 	trumpSuit        int // 切り札スート (PitchTrumpUnset=未確定)
 	gameEndFlag      bool
 	winnerIdx        int
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // NewPitch コンストラクタ
@@ -755,9 +755,6 @@ func (p *Pitch) GetConfig() PitchConfig { return p.config }
 // SetConfig 設定変更
 func (p *Pitch) SetConfig(cfg PitchConfig) { p.config = cfg }
 
-// GetActionLog 棋譜取得
-func (p *Pitch) GetActionLog() []*ActionLogEntry { return p.actionLog }
-
 // GetValidPlayIndices プレイ可能なカードのインデックスリストを返す (Web用)
 func (p *Pitch) GetValidPlayIndices(playerIdx int) []int {
 	return p.getValidPlayIndices(playerIdx)
@@ -797,16 +794,6 @@ func (p *Pitch) playerName(idx int) string {
 		return "You"
 	}
 	return fmt.Sprintf("CPU %d", idx)
-}
-
-func (p *Pitch) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	p.actionLog = append(p.actionLog, &ActionLogEntry{
-		TurnNumber: len(p.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 func (p *Pitch) getValidPlayIndices(playerIdx int) []int {

--- a/internal/domain/Preference.go
+++ b/internal/domain/Preference.go
@@ -119,7 +119,7 @@ type Preference struct {
 	roundTricks      [PreferencePlayerCnt]int
 	gameEndFlag      bool
 	winnerPlayer     int // -1=未確定
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // NewPreference コンストラクタ
@@ -618,17 +618,6 @@ func (g *Preference) findHumanIdx() int {
 	return -1
 }
 
-// appendLog 棋譜にエントリを追加する。
-func (g *Preference) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
-}
-
 // --- CPU AI ---
 
 // cpuSelectPlayCard CPU がプレイするカードのインデックスを選ぶ。
@@ -848,9 +837,6 @@ func (g *Preference) GetConfig() PreferenceConfig { return g.config }
 
 // SetConfig 設定変更
 func (g *Preference) SetConfig(cfg PreferenceConfig) { g.config = cfg }
-
-// GetActionLog 棋譜取得
-func (g *Preference) GetActionLog() []*ActionLogEntry { return g.actionLog }
 
 // GetPlayableIndices プレイ可能なカードのインデックス一覧を返す。
 func (g *Preference) GetPlayableIndices(playerIdx int) []int {

--- a/internal/domain/Prsi.go
+++ b/internal/domain/Prsi.go
@@ -58,7 +58,7 @@ type Prsi struct {
 	pendingSkips     int // 累積スキップ数 (Ace/Under)
 	gameEndFlag      bool
 	winnerIdx        int
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // NewPrsi コンストラクタ
@@ -283,9 +283,6 @@ func (g *Prsi) GetConfig() PrsiConfig { return g.config }
 // SetConfig 設定変更
 func (g *Prsi) SetConfig(cfg PrsiConfig) { g.config = cfg }
 
-// GetActionLog 棋譜取得
-func (g *Prsi) GetActionLog() []*ActionLogEntry { return g.actionLog }
-
 // --- Private methods ---
 
 // isValidPlay カードがプレイ可能か判定
@@ -460,17 +457,6 @@ func (g *Prsi) playerName(idx int) string {
 		return "You"
 	}
 	return fmt.Sprintf("CPU %d", idx)
-}
-
-// appendLog 棋譜にエントリを追加する
-func (g *Prsi) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // --- CPU AI ---

--- a/internal/domain/RedDog.go
+++ b/internal/domain/RedDog.go
@@ -46,7 +46,7 @@ type RedDog struct {
 	gameEndFlag  bool
 	result       GameResult
 	totalPayout  int
-	actionLog    []*ActionLogEntry
+	actionLogBase
 }
 
 // NewRedDog コンストラクタ
@@ -258,17 +258,6 @@ func (rd *RedDog) payoutMultiplier() int {
 	}
 }
 
-// appendLog 棋譜にエントリを追加する
-func (rd *RedDog) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	rd.actionLog = append(rd.actionLog, &ActionLogEntry{
-		TurnNumber: len(rd.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
-}
-
 // --- Getters ---
 
 // GetInitialCards 初手2枚
@@ -300,9 +289,6 @@ func (rd *RedDog) GetTotalPayout() int { return rd.totalPayout }
 
 // GetChips チップ
 func (rd *RedDog) GetChips() int { return rd.chips.GetChips() }
-
-// GetActionLog 棋譜
-func (rd *RedDog) GetActionLog() []*ActionLogEntry { return rd.actionLog }
 
 // --- Test helpers ---
 

--- a/internal/domain/Rook.go
+++ b/internal/domain/Rook.go
@@ -103,7 +103,7 @@ type Rook struct {
 	teamScores  [RookTeamCnt]int
 	gameEndFlag bool
 	winnerTeam  int // 勝利チーム (-1 = 未確定)
-	actionLog   []*ActionLogEntry
+	actionLogBase
 }
 
 // NewRook コンストラクタ
@@ -1159,9 +1159,6 @@ func (g *Rook) GetConfig() RookConfig { return g.config }
 // SetConfig 設定変更
 func (g *Rook) SetConfig(cfg RookConfig) { g.config = cfg }
 
-// GetActionLog 棋譜取得
-func (g *Rook) GetActionLog() []*ActionLogEntry { return g.actionLog }
-
 // CardRankPublic カードランク取得 (テスト用)
 func (g *Rook) CardRankPublic(card *Card) int { return g.cardRank(card) }
 
@@ -1219,17 +1216,6 @@ func (g *Rook) playerName(idx int) string {
 		return "You"
 	}
 	return fmt.Sprintf("CPU %d", idx)
-}
-
-// appendLog 棋譜にエントリを追加する
-func (g *Rook) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // rookColorName 色番号を英字ラベルにする (ログ用)

--- a/internal/domain/Rummy500.go
+++ b/internal/domain/Rummy500.go
@@ -46,8 +46,8 @@ type Rummy500 struct {
 	gameEndFlag      bool
 	winnerIdx        int
 	roundNumber      int
-	actionLog        []*ActionLogEntry
-	roundEnderIdx    int // ラウンド終了を引き起こしたプレイヤー（-1 = 山切れ）
+	actionLogBase
+	roundEnderIdx int // ラウンド終了を引き起こしたプレイヤー（-1 = 山切れ）
 }
 
 // NewRummy500 コンストラクタ
@@ -662,9 +662,6 @@ func (g *Rummy500) GetConfig() Rummy500Config { return g.config }
 // SetConfig 設定変更
 func (g *Rummy500) SetConfig(cfg Rummy500Config) { g.config = cfg }
 
-// GetActionLog 棋譜取得
-func (g *Rummy500) GetActionLog() []*ActionLogEntry { return g.actionLog }
-
 // GetRoundEnderIdx ラウンドを終わらせたプレイヤーのインデックス（-1=山切れ）
 func (g *Rummy500) GetRoundEnderIdx() int { return g.roundEnderIdx }
 
@@ -694,16 +691,6 @@ func (g *Rummy500) playerName(idx int) string {
 		return "You"
 	}
 	return fmt.Sprintf("CPU %d", idx)
-}
-
-func (g *Rummy500) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // --- Meld / Run / Set / Layoff helpers ---

--- a/internal/domain/RussianPoker.go
+++ b/internal/domain/RussianPoker.go
@@ -61,7 +61,7 @@ type RussianPoker struct {
 	dealerQualified  bool
 	playerHandRank   int
 	dealerHandRank   int
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // NewRussianPoker コンストラクタ
@@ -450,17 +450,6 @@ func cardSortValue(c *Card) int {
 	return c.GetValue()
 }
 
-// appendLog 棋譜にエントリを追加する
-func (rp *RussianPoker) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	rp.actionLog = append(rp.actionLog, &ActionLogEntry{
-		TurnNumber: len(rp.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
-}
-
 // --- Getters ---
 
 // GetPlayerHand プレイヤーハンド取得
@@ -524,9 +513,6 @@ func (rp *RussianPoker) GetDealerHandRank() int { return rp.dealerHandRank }
 
 // GetChips チップ
 func (rp *RussianPoker) GetChips() int { return rp.chips.GetChips() }
-
-// GetActionLog 棋譜を取得する
-func (rp *RussianPoker) GetActionLog() []*ActionLogEntry { return rp.actionLog }
 
 // --- Test helpers ---
 

--- a/internal/domain/Samba.go
+++ b/internal/domain/Samba.go
@@ -70,9 +70,9 @@ type Samba struct {
 	winnerIdx        int // 勝利チームのインデックス (0 or 1), -1 = 未確定
 	roundNumber      int
 	teamScores       []int // チーム累積スコア (length SambaTeamCnt)
-	actionLog        []*ActionLogEntry
-	drewFromDiscard  bool  // 現在のターンで捨て札の山から引いたか
-	drawnCard        *Card // 捨て札の山のトップカード (メルドバリデーション用)
+	actionLogBase
+	drewFromDiscard bool  // 現在のターンで捨て札の山から引いたか
+	drawnCard       *Card // 捨て札の山のトップカード (メルドバリデーション用)
 }
 
 // NewSamba コンストラクタ
@@ -1617,9 +1617,6 @@ func (g *Samba) GetConfig() SambaConfig { return g.config }
 // SetConfig 設定変更
 func (g *Samba) SetConfig(cfg SambaConfig) { g.config = cfg }
 
-// GetActionLog 棋譜取得
-func (g *Samba) GetActionLog() []*ActionLogEntry { return g.actionLog }
-
 // GetDrewFromDiscard 捨て札から引いたか取得
 func (g *Samba) GetDrewFromDiscard() bool { return g.drewFromDiscard }
 
@@ -1652,17 +1649,6 @@ func (g *Samba) playerName(idx int) string {
 		return "You"
 	}
 	return fmt.Sprintf("CPU %d", idx)
-}
-
-// appendLog 棋譜にエントリを追加する
-func (g *Samba) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // --- JSON serialization ---

--- a/internal/domain/Schnapsen.go
+++ b/internal/domain/Schnapsen.go
@@ -124,7 +124,7 @@ type Schnapsen struct {
 	marriageDeclared [CardDesignMax + 1]bool // suit -> 当ラウンドで宣言済か
 	gameEndFlag      bool
 	winnerIdx        int // -1: 未確定
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // NewSchnapsen コンストラクタ
@@ -403,9 +403,6 @@ func (s *Schnapsen) GetConfig() SchnapsenConfig { return s.config }
 
 // SetConfig 設定変更
 func (s *Schnapsen) SetConfig(cfg SchnapsenConfig) { s.config = cfg }
-
-// GetActionLog 棋譜取得
-func (s *Schnapsen) GetActionLog() []*ActionLogEntry { return s.actionLog }
 
 // GetValidPlayIndices プレイ可能なカードのインデックスリストを返す。
 // 第1フェーズは制約なし。第2フェーズはマストフォロー (同スート優先 →
@@ -788,17 +785,6 @@ func (s *Schnapsen) playerName(idx int) string {
 		return "You"
 	}
 	return fmt.Sprintf("CPU %d", idx)
-}
-
-// appendLog 棋譜エントリを追加する
-func (s *Schnapsen) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	s.actionLog = append(s.actionLog, &ActionLogEntry{
-		TurnNumber: len(s.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // playHintReason ヒント理由キーを判定する

--- a/internal/domain/Scopone.go
+++ b/internal/domain/Scopone.go
@@ -65,7 +65,7 @@ type Scopone struct {
 	gameEndFlag     bool
 	winnerTeam      int // -1: 未確定
 	lastRoundDetail *ScoponeScoreDetail
-	actionLog       []*ActionLogEntry
+	actionLogBase
 }
 
 // NewScopone コンストラクタ
@@ -431,9 +431,6 @@ func (s *Scopone) GetConfig() ScoponeConfig { return s.config }
 // SetConfig 設定変更
 func (s *Scopone) SetConfig(cfg ScoponeConfig) { s.config = cfg }
 
-// GetActionLog 棋譜取得
-func (s *Scopone) GetActionLog() []*ActionLogEntry { return s.actionLog }
-
 // IsHumanTurn 現在の手番が人間かどうか
 func (s *Scopone) IsHumanTurn() bool {
 	if s.gameEndFlag || s.currentTurn < 0 || s.currentTurn >= len(s.players) {
@@ -452,16 +449,6 @@ func (s *Scopone) GetValidCaptures(handIdx int) [][]int {
 		return nil
 	}
 	return EnumerateScopaCaptures(p.GetCard(handIdx), s.tableCards)
-}
-
-func (s *Scopone) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	s.actionLog = append(s.actionLog, &ActionLogEntry{
-		TurnNumber: len(s.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // --- JSON ---

--- a/internal/domain/Sedma.go
+++ b/internal/domain/Sedma.go
@@ -72,7 +72,7 @@ type Sedma struct {
 	roundCardPts     [SedmaTeamCnt]int // 現ラウンドのカード得点
 	gameEndFlag      bool
 	winnerTeam       int // -1=未確定
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // NewSedma コンストラクタ
@@ -366,17 +366,6 @@ func (g *Sedma) findHumanIdx() int {
 	return -1
 }
 
-// appendLog 棋譜にエントリを追加する。
-func (g *Sedma) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
-}
-
 // --- CPU AI ---
 
 // cpuSelectPlayCard CPU がプレイするカードのインデックスを選ぶ。
@@ -585,9 +574,6 @@ func (g *Sedma) GetConfig() SedmaConfig { return g.config }
 
 // SetConfig 設定変更
 func (g *Sedma) SetConfig(cfg SedmaConfig) { g.config = cfg }
-
-// GetActionLog 棋譜取得
-func (g *Sedma) GetActionLog() []*ActionLogEntry { return g.actionLog }
 
 // GetPlayableIndices プレイ可能なカードのインデックス一覧を返す。
 func (g *Sedma) GetPlayableIndices(playerIdx int) []int {

--- a/internal/domain/SevenBridge.go
+++ b/internal/domain/SevenBridge.go
@@ -51,9 +51,9 @@ type SevenBridge struct {
 	gameEndFlag      bool
 	winnerIdx        int
 	roundNumber      int
-	actionLog        []*ActionLogEntry
-	roundWinnerIdx   int  // ラウンド勝者（上がったプレイヤー）。-1 は山切れ流局
-	claimedThisTurn  bool // 直前のターンで discard を pon/chi で取得したか
+	actionLogBase
+	roundWinnerIdx  int  // ラウンド勝者（上がったプレイヤー）。-1 は山切れ流局
+	claimedThisTurn bool // 直前のターンで discard を pon/chi で取得したか
 }
 
 // NewSevenBridge コンストラクタ
@@ -945,9 +945,6 @@ func (g *SevenBridge) GetConfig() SevenBridgeConfig { return g.config }
 // SetConfig 設定変更
 func (g *SevenBridge) SetConfig(cfg SevenBridgeConfig) { g.config = cfg }
 
-// GetActionLog 棋譜取得
-func (g *SevenBridge) GetActionLog() []*ActionLogEntry { return g.actionLog }
-
 // GetRoundWinnerIdx 直近ラウンドの勝者
 func (g *SevenBridge) GetRoundWinnerIdx() int { return g.roundWinnerIdx }
 
@@ -980,16 +977,6 @@ func (g *SevenBridge) playerName(idx int) string {
 		return "You"
 	}
 	return fmt.Sprintf("CPU %d", idx)
-}
-
-func (g *SevenBridge) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // --- Pure helpers ---

--- a/internal/domain/SevenCardStud.go
+++ b/internal/domain/SevenCardStud.go
@@ -63,30 +63,30 @@ const (
 
 // SevenCardStud セブンカードスタッド
 type SevenCardStud struct {
-	trumpCards       *TrumpCards
-	players          []*SevenCardStudPlayer
-	communityCard    *Card // カード不足時の共有カード
-	pot              int
-	sidePots         []SidePot
-	dealerIdx        int
-	currentTurn      int
-	phase            int
-	config           SevenCardStudConfig
-	gameEndFlag      bool
-	lastBet          int
-	minRaise         int
-	raiseCount       int
-	actedFlags       []bool
-	roundResults     []SevenCardStudResult
-	cpuActions       []SevenCardStudCpuAction
-	startingChips    []int
-	vpipTracked      []bool
-	pfrTracked       []bool
-	threeBetTracked  []bool
-	tournamentBase   // handCount / rebuyCounts / addonUsed (issue #1463)
-	lastCpuError     error
-	rebuyPhaseType   int
-	actionLog        []*ActionLogEntry
+	trumpCards      *TrumpCards
+	players         []*SevenCardStudPlayer
+	communityCard   *Card // カード不足時の共有カード
+	pot             int
+	sidePots        []SidePot
+	dealerIdx       int
+	currentTurn     int
+	phase           int
+	config          SevenCardStudConfig
+	gameEndFlag     bool
+	lastBet         int
+	minRaise        int
+	raiseCount      int
+	actedFlags      []bool
+	roundResults    []SevenCardStudResult
+	cpuActions      []SevenCardStudCpuAction
+	startingChips   []int
+	vpipTracked     []bool
+	pfrTracked      []bool
+	threeBetTracked []bool
+	tournamentBase  // handCount / rebuyCounts / addonUsed (issue #1463)
+	lastCpuError    error
+	rebuyPhaseType  int
+	actionLogBase
 	humanProfile     *BettingHumanProfile
 	lastHumanPlayMs  int
 	bringInPlayerIdx int  // ブリングインプレイヤーインデックス
@@ -949,16 +949,6 @@ func getRazzHandName(rank int, bestHand []*Card) string {
 
 // --- 棋譜 ---
 
-func (s *SevenCardStud) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	s.actionLog = append(s.actionLog, &ActionLogEntry{
-		TurnNumber: len(s.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
-}
-
 func (s *SevenCardStud) logAction(playerIdx, action, amount int) {
 	switch action {
 	case SevenCardStudActionFold:
@@ -1083,9 +1073,6 @@ func (s *SevenCardStud) GetActedFlags() []bool {
 
 // GetHandCount ハンド数取得
 func (s *SevenCardStud) GetHandCount() int { return s.handCount }
-
-// GetActionLog 棋譜を取得する
-func (s *SevenCardStud) GetActionLog() []*ActionLogEntry { return s.actionLog }
 
 // GetBringInPlayerIdx ブリングインプレイヤーインデックス取得
 func (s *SevenCardStud) GetBringInPlayerIdx() int { return s.bringInPlayerIdx }

--- a/internal/domain/Sevens.go
+++ b/internal/domain/Sevens.go
@@ -35,7 +35,7 @@ type Sevens struct {
 	humanAction *SevensCpuAction   // 人間の最後の行動
 	jokerPlaced [5]uint16          // jokerPlaced[suit] = ジョーカーが配置されたポジションのビットマスク
 	jokerCards  []*Card            // ボード上のジョーカーカードオブジェクト (回収用)
-	actionLog   []*ActionLogEntry  // 棋譜
+	actionLogBase
 }
 
 // NewSevens コンストラクタ
@@ -1159,20 +1159,6 @@ func cardLogStr(card *Card) string {
 		return "joker"
 	}
 	return fmt.Sprintf("%s %d", suitLogStr(card.GetDesign()), card.GetValue())
-}
-
-// GetActionLog 棋譜を取得する
-func (s *Sevens) GetActionLog() []*ActionLogEntry { return s.actionLog }
-
-// appendLog 棋譜にエントリを追加する
-func (s *Sevens) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	s.actionLog = append(s.actionLog, &ActionLogEntry{
-		TurnNumber: len(s.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // sevensJSON is the JSON wire format for Sevens.

--- a/internal/domain/Sheepshead.go
+++ b/internal/domain/Sheepshead.go
@@ -91,7 +91,7 @@ type Sheepshead struct {
 	roundPickerWon   bool    // 直近ラウンドでピッカー組が勝ったか
 	gameEndFlag      bool
 	winnerIdx        int // ゲーム勝者 (-1 = 未確定)
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // NewSheepshead コンストラクタ
@@ -688,17 +688,6 @@ func (g *Sheepshead) playerName(idx int) string {
 	return fmt.Sprintf("CPU %d", idx)
 }
 
-// appendLog 棋譜にエントリを追加する。
-func (g *Sheepshead) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
-}
-
 // indexOfPlayerInTrick currentTrick 内で playerIdx の札の位置を返す (-1=なし)。
 func (g *Sheepshead) indexOfPlayerInTrick(playerIdx int) int {
 	for i, tc := range g.currentTrick {
@@ -952,9 +941,6 @@ func (g *Sheepshead) GetConfig() SheepsheadConfig { return g.config }
 
 // SetConfig 設定変更
 func (g *Sheepshead) SetConfig(cfg SheepsheadConfig) { g.config = cfg }
-
-// GetActionLog 棋譜取得
-func (g *Sheepshead) GetActionLog() []*ActionLogEntry { return g.actionLog }
 
 // GetPlayableIndices プレイ可能なカードのインデックス一覧を返す。
 func (g *Sheepshead) GetPlayableIndices(playerIdx int) []int {

--- a/internal/domain/ShortDeck.go
+++ b/internal/domain/ShortDeck.go
@@ -58,7 +58,7 @@ type ShortDeck struct {
 	tournamentBase  // handCount / rebuyCounts / addonUsed (issue #1463)
 	lastCpuError    error
 	rebuyPhaseType  int
-	actionLog       []*ActionLogEntry
+	actionLogBase
 	humanProfile    *BettingHumanProfile
 	lastHumanPlayMs int
 }
@@ -1207,20 +1207,6 @@ func (sd *ShortDeck) GetActedFlags() []bool {
 
 // GetHandCount ハンド数取得
 func (sd *ShortDeck) GetHandCount() int { return sd.handCount }
-
-// GetActionLog 棋譜を取得する
-func (sd *ShortDeck) GetActionLog() []*ActionLogEntry { return sd.actionLog }
-
-// appendLog 棋譜にエントリを追加する
-func (sd *ShortDeck) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	sd.actionLog = append(sd.actionLog, &ActionLogEntry{
-		TurnNumber: len(sd.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
-}
 
 // logAction ベッティングアクションを棋譜に記録する
 func (sd *ShortDeck) logAction(playerIdx, action, amount int) {

--- a/internal/domain/Slapjack.go
+++ b/internal/domain/Slapjack.go
@@ -73,7 +73,7 @@ type Slapjack struct {
 	lastEvent      SlapjackLastEvent
 	gameEndFlag    bool
 	winnerIdx      int
-	actionLog      []*ActionLogEntry
+	actionLogBase
 
 	// now 現在時刻取得関数 (テストで差し替え可能)
 	now func() time.Time
@@ -220,9 +220,6 @@ func (g *Slapjack) GetPending() SlapjackPending { return g.pending }
 
 // GetLastEvent 直近イベント
 func (g *Slapjack) GetLastEvent() SlapjackLastEvent { return g.lastEvent }
-
-// GetActionLog 棋譜取得
-func (g *Slapjack) GetActionLog() []*ActionLogEntry { return g.actionLog }
 
 // --- アクション ---
 
@@ -422,17 +419,6 @@ func (g *Slapjack) checkStuck() {
 	if !g.players[0].HasStock() && !g.players[1].HasStock() && !g.IsTopJack() {
 		g.endGame(0)
 	}
-}
-
-// appendLog 棋譜にエントリを追加する
-func (g *Slapjack) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // --- JSON ---

--- a/internal/domain/SoloWhist.go
+++ b/internal/domain/SoloWhist.go
@@ -112,7 +112,7 @@ type SoloWhist struct {
 	roundTricks      [SoloWhistPlayerCnt]int          // 現ラウンドの獲得トリック数
 	gameEndFlag      bool
 	winnerPlayer     int // -1=未確定
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // NewSoloWhist コンストラクタ
@@ -614,17 +614,6 @@ func (g *SoloWhist) findHumanIdx() int {
 	return -1
 }
 
-// appendLog 棋譜にエントリを追加する。
-func (g *SoloWhist) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
-}
-
 // --- CPU AI ---
 
 // cpuSelectPlayCard CPU がプレイするカードのインデックスを選ぶ。
@@ -846,9 +835,6 @@ func (g *SoloWhist) GetConfig() SoloWhistConfig { return g.config }
 
 // SetConfig 設定変更
 func (g *SoloWhist) SetConfig(cfg SoloWhistConfig) { g.config = cfg }
-
-// GetActionLog 棋譜取得
-func (g *SoloWhist) GetActionLog() []*ActionLogEntry { return g.actionLog }
 
 // GetPlayableIndices プレイ可能なカードのインデックス一覧を返す。
 func (g *SoloWhist) GetPlayableIndices(playerIdx int) []int {

--- a/internal/domain/Spades.go
+++ b/internal/domain/Spades.go
@@ -54,7 +54,7 @@ type Spades struct {
 	bidPlayerIdx     int
 	gameEndFlag      bool
 	winnerIdx        int
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // NewSpades コンストラクタ
@@ -423,9 +423,6 @@ func (s *Spades) GetConfig() SpadesConfig { return s.config }
 // SetConfig 設定変更
 func (s *Spades) SetConfig(cfg SpadesConfig) { s.config = cfg }
 
-// GetActionLog 棋譜取得
-func (s *Spades) GetActionLog() []*ActionLogEntry { return s.actionLog }
-
 // --- Private methods ---
 
 // findHumanIdx 人間プレイヤーのインデックスを返す (-1=なし)
@@ -634,17 +631,6 @@ func (s *Spades) playerName(idx int) string {
 		return "You"
 	}
 	return fmt.Sprintf("CPU %d", idx)
-}
-
-// appendLog 棋譜にエントリを追加する
-func (s *Spades) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	s.actionLog = append(s.actionLog, &ActionLogEntry{
-		TurnNumber: len(s.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // GetHint ヒントを取得する

--- a/internal/domain/Speed.go
+++ b/internal/domain/Speed.go
@@ -43,7 +43,7 @@ type Speed struct {
 	centerPiles [SpeedCenterPileCnt]*Card // 各台札のトップカード
 	gameEndFlag bool
 	winnerIdx   int
-	actionLog   []*ActionLogEntry
+	actionLogBase
 }
 
 // NewSpeed コンストラクタ
@@ -469,26 +469,12 @@ func (s *Speed) GetConfig() SpeedConfig { return s.config }
 // SetConfig 設定更新
 func (s *Speed) SetConfig(cfg SpeedConfig) { s.config = cfg }
 
-// GetActionLog 棋譜取得
-func (s *Speed) GetActionLog() []*ActionLogEntry { return s.actionLog }
-
 // IsHumanTurn Speedでは常に人間のターン (同時プレイ)
 func (s *Speed) IsHumanTurn() bool { return s.phase == SpeedPhasePlay }
 
 // UpdatePhase 外部からフェーズ更新 (Interactor用)
 func (s *Speed) UpdatePhase() {
 	s.updatePhase()
-}
-
-// appendLog 棋譜にエントリを追加する
-func (s *Speed) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	s.actionLog = append(s.actionLog, &ActionLogEntry{
-		TurnNumber: len(s.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // --- JSON ---

--- a/internal/domain/SpoilFive.go
+++ b/internal/domain/SpoilFive.go
@@ -75,7 +75,7 @@ type SpoilFive struct {
 	roundWinnerIdx   int // 直近ラウンドの勝者 (-1=Spoil/未確定)
 	gameEndFlag      bool
 	winnerPlayer     int // -1=未確定
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // NewSpoilFive コンストラクタ
@@ -516,17 +516,6 @@ func (g *SpoilFive) findHumanIdx() int {
 	return -1
 }
 
-// appendLog 棋譜にエントリを追加する。
-func (g *SpoilFive) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
-}
-
 // --- CPU AI ---
 
 // cpuSelectPlayCard CPU がプレイするカードのインデックスを選ぶ。
@@ -715,9 +704,6 @@ func (g *SpoilFive) GetConfig() SpoilFiveConfig { return g.config }
 
 // SetConfig 設定変更
 func (g *SpoilFive) SetConfig(cfg SpoilFiveConfig) { g.config = cfg }
-
-// GetActionLog 棋譜取得
-func (g *SpoilFive) GetActionLog() []*ActionLogEntry { return g.actionLog }
 
 // GetPlayableIndices プレイ可能なカードのインデックス一覧を返す。
 func (g *SpoilFive) GetPlayableIndices(playerIdx int) []int {

--- a/internal/domain/Spoons.go
+++ b/internal/domain/Spoons.go
@@ -78,7 +78,7 @@ type Spoons struct {
 	roundNumber      int
 	gameEndFlag      bool
 	winnerIdx        int
-	actionLog        []*ActionLogEntry
+	actionLogBase
 
 	// rng CPU グラブ抽選用 (テストで差し替え可能)
 	rng *rand.Rand
@@ -273,9 +273,6 @@ func (g *Spoons) GetRoundLoserIdx() int { return g.roundLoserIdx }
 
 // GetRoundNumber は現在のラウンド番号を返す。
 func (g *Spoons) GetRoundNumber() int { return g.roundNumber }
-
-// GetActionLog は棋譜を返す。
-func (g *Spoons) GetActionLog() []*ActionLogEntry { return g.actionLog }
 
 // IsHumanTurn は現在パス/グラブの手番が人間かを返す。
 // パスフェーズでは currentPlayerIdx、グラブフェーズでは人間が未グラブなら true。
@@ -610,17 +607,6 @@ func (g *Spoons) nextActive(idx int) int {
 		}
 	}
 	return idx
-}
-
-// appendLog は棋譜にエントリを追加する。
-func (g *Spoons) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // --- JSON ---

--- a/internal/domain/Sueca.go
+++ b/internal/domain/Sueca.go
@@ -75,7 +75,7 @@ type Sueca struct {
 	roundGamePts     int               // 直近ラウンドで勝者が得たゲームポイント
 	gameEndFlag      bool
 	winnerTeam       int // -1=未確定
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // NewSueca コンストラクタ
@@ -482,17 +482,6 @@ func (g *Sueca) findHumanIdx() int {
 	return -1
 }
 
-// appendLog 棋譜にエントリを追加する。
-func (g *Sueca) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
-}
-
 // --- CPU AI ---
 
 // cpuSelectPlayCard CPU がプレイするカードのインデックスを選ぶ。
@@ -728,9 +717,6 @@ func (g *Sueca) GetConfig() SuecaConfig { return g.config }
 
 // SetConfig 設定変更
 func (g *Sueca) SetConfig(cfg SuecaConfig) { g.config = cfg }
-
-// GetActionLog 棋譜取得
-func (g *Sueca) GetActionLog() []*ActionLogEntry { return g.actionLog }
 
 // GetPlayableIndices プレイ可能なカードのインデックス一覧を返す。
 func (g *Sueca) GetPlayableIndices(playerIdx int) []int {

--- a/internal/domain/Tarneeb.go
+++ b/internal/domain/Tarneeb.go
@@ -73,7 +73,7 @@ type Tarneeb struct {
 	teamScores       [TarneebTeamCnt]int
 	gameEndFlag      bool
 	winnerTeam       int
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // NewTarneeb コンストラクタ
@@ -544,9 +544,6 @@ func (t *Tarneeb) GetConfig() TarneebConfig { return t.config }
 // SetConfig 設定変更
 func (t *Tarneeb) SetConfig(cfg TarneebConfig) { t.config = cfg }
 
-// GetActionLog 棋譜取得
-func (t *Tarneeb) GetActionLog() []*ActionLogEntry { return t.actionLog }
-
 // IsHumanTurn 現在の手番が人間かどうか
 func (t *Tarneeb) IsHumanTurn() bool {
 	if t.currentPlayerIdx < 0 || t.currentPlayerIdx >= len(t.players) {
@@ -715,17 +712,6 @@ func (t *Tarneeb) playerName(idx int) string {
 		return "You"
 	}
 	return fmt.Sprintf("CPU %d", idx)
-}
-
-// appendLog 棋譜にエントリを追加する
-func (t *Tarneeb) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	t.actionLog = append(t.actionLog, &ActionLogEntry{
-		TurnNumber: len(t.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // isValidSuit 4スートのうちいずれかか

--- a/internal/domain/TeenPatti.go
+++ b/internal/domain/TeenPatti.go
@@ -78,7 +78,7 @@ type TeenPatti struct {
 	gameEndFlag       bool
 	matchWinnerIdx    int                // 試合の勝者 (-1: 未確定)
 	lastSideShow      *teenPattiSideShow // 直近で成立したサイドショー結果 (nil: なし)
-	actionLog         []*ActionLogEntry
+	actionLogBase
 }
 
 // NewTeenPatti コンストラクタ
@@ -668,16 +668,6 @@ func (g *TeenPatti) playerName(idx int) string {
 	return fmt.Sprintf("CPU %d", idx)
 }
 
-func (g *TeenPatti) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
-}
-
 // --- State getters ---
 
 // GetPhase 現在のフェーズ取得
@@ -763,9 +753,6 @@ func (g *TeenPatti) GetConfig() TeenPattiConfig { return g.config }
 
 // SetConfig 設定変更
 func (g *TeenPatti) SetConfig(cfg TeenPattiConfig) { g.config = cfg }
-
-// GetActionLog 棋譜取得
-func (g *TeenPatti) GetActionLog() []*ActionLogEntry { return g.actionLog }
 
 // IsHumanTurn 現在の手番が人間かどうか
 func (g *TeenPatti) IsHumanTurn() bool {

--- a/internal/domain/TexasHoldemBonus.go
+++ b/internal/domain/TexasHoldemBonus.go
@@ -48,27 +48,27 @@ const (
 
 // TexasHoldemBonus テキサスホールデムボーナスポーカークラス
 type TexasHoldemBonus struct {
-	trumpCards     *TrumpCards       // トランプカード
-	playerHand     []*Card           // プレイヤーホールカード
-	dealerHand     []*Card           // ディーラーホールカード
-	community      []*Card           // コミュニティカード
-	chips          ChipHolder        // チップ
-	anteBet        int               // アンテベット額
-	bonusBet       int               // ボーナスサイドベット額
-	flopBet        int               // フロップベット額（プリフロップで2×アンテ）
-	turnBet        int               // ターンベット額（フロップ後で1×アンテ）
-	riverBet       int               // リバーベット額（ターン後で1×アンテ）
-	phase          int               // 現在のフェーズ
-	gameEndFlag    bool              // ゲーム終了フラグ
-	result         GameResult        // ゲーム結果
-	antePayout     int               // アンテ＋アンテボーナス配当
-	playPayout     int               // プレイベット配当合計（フロップ＋ターン＋リバー）
-	bonusPayout    int               // ボーナスサイドベット配当
-	playerHandRank int               // プレイヤー最良5枚ランク
-	dealerHandRank int               // ディーラー最良5枚ランク
-	playerBest     []*Card           // プレイヤー最良5枚
-	dealerBest     []*Card           // ディーラー最良5枚
-	actionLog      []*ActionLogEntry // 棋譜
+	trumpCards     *TrumpCards // トランプカード
+	playerHand     []*Card     // プレイヤーホールカード
+	dealerHand     []*Card     // ディーラーホールカード
+	community      []*Card     // コミュニティカード
+	chips          ChipHolder  // チップ
+	anteBet        int         // アンテベット額
+	bonusBet       int         // ボーナスサイドベット額
+	flopBet        int         // フロップベット額（プリフロップで2×アンテ）
+	turnBet        int         // ターンベット額（フロップ後で1×アンテ）
+	riverBet       int         // リバーベット額（ターン後で1×アンテ）
+	phase          int         // 現在のフェーズ
+	gameEndFlag    bool        // ゲーム終了フラグ
+	result         GameResult  // ゲーム結果
+	antePayout     int         // アンテ＋アンテボーナス配当
+	playPayout     int         // プレイベット配当合計（フロップ＋ターン＋リバー）
+	bonusPayout    int         // ボーナスサイドベット配当
+	playerHandRank int         // プレイヤー最良5枚ランク
+	dealerHandRank int         // ディーラー最良5枚ランク
+	playerBest     []*Card     // プレイヤー最良5枚
+	dealerBest     []*Card     // ディーラー最良5枚
+	actionLogBase
 }
 
 // NewTexasHoldemBonus コンストラクタ
@@ -454,17 +454,6 @@ func bonusMultiplier(a, b *Card) int {
 	return 0
 }
 
-// appendLog 棋譜にエントリを追加する
-func (t *TexasHoldemBonus) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	t.actionLog = append(t.actionLog, &ActionLogEntry{
-		TurnNumber: len(t.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
-}
-
 // --- Getters ---
 
 // GetPlayerHand プレイヤーホールカード取得
@@ -531,9 +520,6 @@ func (t *TexasHoldemBonus) GetDealerBest() []*Card { return t.dealerBest }
 
 // GetChips チップ
 func (t *TexasHoldemBonus) GetChips() int { return t.chips.GetChips() }
-
-// GetActionLog 棋譜を取得する
-func (t *TexasHoldemBonus) GetActionLog() []*ActionLogEntry { return t.actionLog }
 
 // --- Test helpers ---
 

--- a/internal/domain/ThirtyOne.go
+++ b/internal/domain/ThirtyOne.go
@@ -52,8 +52,8 @@ type ThirtyOne struct {
 	thirtyOneIdx     int   // 31 を達成したプレイヤー (-1 = なし)
 	roundWinnerIdx   int   // 直近ラウンドの勝者 (-1 = 未確定)
 	roundLosers      []int // 直近ラウンドでライフを失ったプレイヤー
-	actionLog        []*ActionLogEntry
-	rng              *rand.Rand
+	actionLogBase
+	rng *rand.Rand
 }
 
 // NewThirtyOne コンストラクタ
@@ -709,9 +709,6 @@ func (g *ThirtyOne) GetConfig() ThirtyOneConfig { return g.config }
 // SetConfig ゲーム設定を設定する
 func (g *ThirtyOne) SetConfig(cfg ThirtyOneConfig) { g.config = cfg }
 
-// GetActionLog 棋譜を取得する
-func (g *ThirtyOne) GetActionLog() []*ActionLogEntry { return g.actionLog }
-
 // playerName プレイヤー名を返す
 func (g *ThirtyOne) playerName(idx int) string {
 	if idx < 0 || idx >= len(g.players) {
@@ -721,17 +718,6 @@ func (g *ThirtyOne) playerName(idx int) string {
 		return "You"
 	}
 	return fmt.Sprintf("CPU %d", idx)
-}
-
-// appendLog 棋譜にエントリを追加する
-func (g *ThirtyOne) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // --- JSON ---

--- a/internal/domain/ThreeCard.go
+++ b/internal/domain/ThreeCard.go
@@ -40,24 +40,24 @@ const (
 
 // ThreeCard スリーカードポーカークラス
 type ThreeCard struct {
-	trumpCards      *TrumpCards       // トランプカード
-	playerHand      []*Card           // プレイヤーハンド
-	dealerHand      []*Card           // ディーラーハンド
-	chips           ChipHolder        // チップ
-	anteBet         int               // アンテベット額
-	pairPlusBet     int               // ペアプラスベット額
-	playBet         int               // プレイベット額
-	phase           int               // 現在のフェーズ
-	gameEndFlag     bool              // ゲーム終了フラグ
-	result          GameResult        // ゲーム結果
-	antePayout      int               // アンテ配当
-	playPayout      int               // プレイ配当
-	anteBonusPayout int               // アンテボーナス配当
-	pairPlusPayout  int               // ペアプラス配当
-	dealerQualified bool              // ディーラークオリファイフラグ
-	playerHandRank  int               // プレイヤーハンドランク
-	dealerHandRank  int               // ディーラーハンドランク
-	actionLog       []*ActionLogEntry // 棋譜
+	trumpCards      *TrumpCards // トランプカード
+	playerHand      []*Card     // プレイヤーハンド
+	dealerHand      []*Card     // ディーラーハンド
+	chips           ChipHolder  // チップ
+	anteBet         int         // アンテベット額
+	pairPlusBet     int         // ペアプラスベット額
+	playBet         int         // プレイベット額
+	phase           int         // 現在のフェーズ
+	gameEndFlag     bool        // ゲーム終了フラグ
+	result          GameResult  // ゲーム結果
+	antePayout      int         // アンテ配当
+	playPayout      int         // プレイ配当
+	anteBonusPayout int         // アンテボーナス配当
+	pairPlusPayout  int         // ペアプラス配当
+	dealerQualified bool        // ディーラークオリファイフラグ
+	playerHandRank  int         // プレイヤーハンドランク
+	dealerHandRank  int         // ディーラーハンドランク
+	actionLogBase
 }
 
 // NewThreeCard コンストラクタ
@@ -287,17 +287,6 @@ func (tc *ThreeCard) evaluatePairPlus() {
 	}
 }
 
-// appendLog 棋譜にエントリを追加する
-func (tc *ThreeCard) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	tc.actionLog = append(tc.actionLog, &ActionLogEntry{
-		TurnNumber: len(tc.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
-}
-
 // --- Getters ---
 
 // GetPlayerHand プレイヤーハンド取得
@@ -352,9 +341,6 @@ func (tc *ThreeCard) GetDealerHandRank() int { return tc.dealerHandRank }
 
 // GetChips チップ
 func (tc *ThreeCard) GetChips() int { return tc.chips.GetChips() }
-
-// GetActionLog 棋譜を取得する
-func (tc *ThreeCard) GetActionLog() []*ActionLogEntry { return tc.actionLog }
 
 // --- Test helpers ---
 

--- a/internal/domain/ThreeCardBrag.go
+++ b/internal/domain/ThreeCardBrag.go
@@ -163,7 +163,7 @@ type ThreeCardBrag struct {
 	showdown         bool
 	gameEndFlag      bool
 	matchWinnerIdx   int // 試合の勝者 (-1: 未確定)
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // NewThreeCardBrag コンストラクタ
@@ -630,16 +630,6 @@ func (g *ThreeCardBrag) playerName(idx int) string {
 	return fmt.Sprintf("CPU %d", idx)
 }
 
-func (g *ThreeCardBrag) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
-}
-
 // --- State getters ---
 
 // GetPhase 現在のフェーズ取得
@@ -703,9 +693,6 @@ func (g *ThreeCardBrag) GetConfig() ThreeCardBragConfig { return g.config }
 
 // SetConfig 設定変更
 func (g *ThreeCardBrag) SetConfig(cfg ThreeCardBragConfig) { g.config = cfg }
-
-// GetActionLog 棋譜取得
-func (g *ThreeCardBrag) GetActionLog() []*ActionLogEntry { return g.actionLog }
 
 // IsHumanTurn 現在の手番が人間かどうか
 func (g *ThreeCardBrag) IsHumanTurn() bool {

--- a/internal/domain/ThreeThirteen.go
+++ b/internal/domain/ThreeThirteen.go
@@ -75,7 +75,7 @@ type ThreeThirteen struct {
 	gameEndFlag      bool
 	winnerIdx        int
 	turnCount        int
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // NewThreeThirteen コンストラクタ
@@ -584,9 +584,6 @@ func (g *ThreeThirteen) GetConfig() ThreeThirteenConfig { return g.config }
 // SetConfig 設定変更
 func (g *ThreeThirteen) SetConfig(c ThreeThirteenConfig) { g.config = c }
 
-// GetActionLog 棋譜取得
-func (g *ThreeThirteen) GetActionLog() []*ActionLogEntry { return g.actionLog }
-
 // GetPlayerDeadwoodValue プレイヤーの最善メルド分割でのデッドウッド点を返す（プレゼンター向け）。
 func (g *ThreeThirteen) GetPlayerDeadwoodValue(i int) int {
 	p := g.GetPlayer(i)
@@ -642,16 +639,6 @@ func (g *ThreeThirteen) playerName(idx int) string {
 		return "You"
 	}
 	return fmt.Sprintf("CPU %d", idx)
-}
-
-func (g *ThreeThirteen) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // collectThreeThirteenCards プレイヤーの手札を []*Card で返す

--- a/internal/domain/Tonk.go
+++ b/internal/domain/Tonk.go
@@ -54,7 +54,7 @@ type Tonk struct {
 	gameEndFlag      bool
 	winnerIdx        int
 	roundNumber      int
-	actionLog        []*ActionLogEntry
+	actionLogBase
 	knockerIdx       int       // ノック/Tonkしたプレイヤーのインデックス (-1 = 未確定)
 	knockerMelds     [][]*Card // ノッカーのメルド
 	knockerDeadwood  []*Card   // ノッカーのデッドウッド
@@ -687,9 +687,6 @@ func (g *Tonk) GetConfig() TonkConfig { return g.config }
 // SetConfig 設定変更
 func (g *Tonk) SetConfig(cfg TonkConfig) { g.config = cfg }
 
-// GetActionLog 棋譜取得
-func (g *Tonk) GetActionLog() []*ActionLogEntry { return g.actionLog }
-
 // GetKnockerIdx ノッカーのインデックス取得
 func (g *Tonk) GetKnockerIdx() int { return g.knockerIdx }
 
@@ -752,17 +749,6 @@ func (g *Tonk) playerName(idx int) string {
 		return "You"
 	}
 	return fmt.Sprintf("CPU %d", idx)
-}
-
-// appendLog 棋譜にエントリを追加する
-func (g *Tonk) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // tonkJSON is the JSON wire format for Tonk.

--- a/internal/domain/Tressette.go
+++ b/internal/domain/Tressette.go
@@ -74,7 +74,7 @@ type Tressette struct {
 	teamRoundThirds  [TressetteTeamCnt]int // 現ラウンドで獲得した 1/3点 の合計
 	gameEndFlag      bool
 	winnerTeam       int
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // NewTressette コンストラクタ
@@ -338,9 +338,6 @@ func (g *Tressette) GetConfig() TressetteConfig { return g.config }
 // SetConfig 設定変更
 func (g *Tressette) SetConfig(cfg TressetteConfig) { g.config = cfg }
 
-// GetActionLog 棋譜取得
-func (g *Tressette) GetActionLog() []*ActionLogEntry { return g.actionLog }
-
 // GetPlayableIndices プレイ可能な (マストフォローを満たす) カードのインデックス一覧を返す。
 func (g *Tressette) GetPlayableIndices(playerIdx int) []int {
 	if playerIdx < 0 || playerIdx >= len(g.players) {
@@ -459,17 +456,6 @@ func teamName(team int) string {
 		return "A"
 	}
 	return "B"
-}
-
-// appendLog 棋譜にエントリを追加する
-func (g *Tressette) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // --- Card helpers ---

--- a/internal/domain/Truco.go
+++ b/internal/domain/Truco.go
@@ -147,7 +147,7 @@ type Truco struct {
 	handWinnerIdx     int // 直近マノの勝者 (-1: 未確定)
 	gameEndFlag       bool
 	winnerIdx         int // マッチ勝者 (-1: 未確定)
-	actionLog         []*ActionLogEntry
+	actionLogBase
 }
 
 // NewTruco コンストラクタ
@@ -405,9 +405,6 @@ func (t *Truco) GetConfig() TrucoConfig { return t.config }
 
 // SetConfig 設定変更
 func (t *Truco) SetConfig(cfg TrucoConfig) { t.config = cfg }
-
-// GetActionLog 棋譜取得
-func (t *Truco) GetActionLog() []*ActionLogEntry { return t.actionLog }
 
 // IsHumanTurn 現在の手番 (プレイまたは応答) が人間かどうか
 func (t *Truco) IsHumanTurn() bool {
@@ -770,17 +767,6 @@ func trucoLevelName(level int) string {
 	default:
 		return "Truco"
 	}
-}
-
-// appendLog 棋譜エントリを追加する。
-func (t *Truco) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	t.actionLog = append(t.actionLog, &ActionLogEntry{
-		TurnNumber: len(t.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // playHintReason プレイ推奨の理由キーを判定する。

--- a/internal/domain/Tute.go
+++ b/internal/domain/Tute.go
@@ -81,7 +81,7 @@ type Tute struct {
 	roundTeamPts     [TuteTeamCnt]int        // 現ラウンドの得点 (カード+結婚+最終)
 	gameEndFlag      bool
 	winnerTeam       int // -1=未確定
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // NewTute コンストラクタ
@@ -569,17 +569,6 @@ func (g *Tute) findHumanIdx() int {
 	return -1
 }
 
-// appendLog 棋譜にエントリを追加する。
-func (g *Tute) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
-}
-
 // --- CPU AI ---
 
 // cpuMarriageSuit CPU がリード時に宣言する結婚スートを返す (0=なし)。切り札を優先。
@@ -872,9 +861,6 @@ func (g *Tute) GetConfig() TuteConfig { return g.config }
 
 // SetConfig 設定変更
 func (g *Tute) SetConfig(cfg TuteConfig) { g.config = cfg }
-
-// GetActionLog 棋譜取得
-func (g *Tute) GetActionLog() []*ActionLogEntry { return g.actionLog }
 
 // GetPlayableIndices プレイ可能なカードのインデックス一覧を返す。
 func (g *Tute) GetPlayableIndices(playerIdx int) []int {

--- a/internal/domain/TwentyNine.go
+++ b/internal/domain/TwentyNine.go
@@ -96,7 +96,7 @@ type TwentyNine struct {
 	roundTeamPts     [TwentyNineTeamCnt]int // 現ラウンドのチーム別カード得点
 	gameEndFlag      bool
 	winnerTeam       int // -1=未確定
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // NewTwentyNine コンストラクタ
@@ -632,17 +632,6 @@ func (g *TwentyNine) findHumanIdx() int {
 	return -1
 }
 
-// appendLog 棋譜にエントリを追加する。
-func (g *TwentyNine) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
-}
-
 // --- CPU AI ---
 
 // cpuSelectPlayCard CPU がプレイするカードのインデックスを選ぶ。
@@ -860,9 +849,6 @@ func (g *TwentyNine) GetConfig() TwentyNineConfig { return g.config }
 
 // SetConfig 設定変更
 func (g *TwentyNine) SetConfig(cfg TwentyNineConfig) { g.config = cfg }
-
-// GetActionLog 棋譜取得
-func (g *TwentyNine) GetActionLog() []*ActionLogEntry { return g.actionLog }
 
 // GetPlayableIndices プレイ可能なカードのインデックス一覧を返す。
 func (g *TwentyNine) GetPlayableIndices(playerIdx int) []int {

--- a/internal/domain/TwoTenJack.go
+++ b/internal/domain/TwoTenJack.go
@@ -57,7 +57,7 @@ type TwoTenJack struct {
 	trumpSuit        int // -1 = 未宣言
 	gameEndFlag      bool
 	winnerTeam       int // -1 = 未確定, 0 = (0,2), 1 = (1,3)
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // NewTwoTenJack コンストラクタ
@@ -421,9 +421,6 @@ func (t *TwoTenJack) GetConfig() TwoTenJackConfig { return t.config }
 // SetConfig 設定変更
 func (t *TwoTenJack) SetConfig(cfg TwoTenJackConfig) { t.config = cfg }
 
-// GetActionLog 棋譜取得
-func (t *TwoTenJack) GetActionLog() []*ActionLogEntry { return t.actionLog }
-
 // --- Private methods ---
 
 // startPlayPhase プレイフェーズ開始: 宣言者がリード
@@ -531,17 +528,6 @@ func (t *TwoTenJack) playerName(idx int) string {
 		return "You"
 	}
 	return fmt.Sprintf("CPU %d", idx)
-}
-
-// appendLog 棋譜にエントリを追加する
-func (t *TwoTenJack) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	t.actionLog = append(t.actionLog, &ActionLogEntry{
-		TurnNumber: len(t.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // twoTenJackSuitName スート名を返す

--- a/internal/domain/Tysiac.go
+++ b/internal/domain/Tysiac.go
@@ -104,7 +104,7 @@ type Tysiac struct {
 	lastTrickWinner  int                   // 最終トリック勝者 (-1=未確定)
 	gameEndFlag      bool
 	winnerPlayer     int // -1=未確定
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // NewTysiac コンストラクタ
@@ -877,17 +877,6 @@ func (g *Tysiac) findHumanIdx() int {
 	return -1
 }
 
-// appendLog 棋譜にエントリを追加する。
-func (g *Tysiac) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
-}
-
 // --- CPU AI (play) ---
 
 // cpuSelectPlayCard CPU がプレイするカードのインデックスを選ぶ。
@@ -1162,9 +1151,6 @@ func (g *Tysiac) GetConfig() TysiacConfig { return g.config }
 
 // SetConfig 設定変更
 func (g *Tysiac) SetConfig(cfg TysiacConfig) { g.config = cfg }
-
-// GetActionLog 棋譜取得
-func (g *Tysiac) GetActionLog() []*ActionLogEntry { return g.actionLog }
 
 // GetPlayableIndices プレイ可能なカードのインデックス一覧を返す。
 func (g *Tysiac) GetPlayableIndices(playerIdx int) []int {

--- a/internal/domain/Ulti.go
+++ b/internal/domain/Ulti.go
@@ -177,7 +177,7 @@ type Ulti struct {
 	scored           bool        // 当該ディールの得点計算済みか (RoundEnd 突入時に一度だけ)
 	gameEndFlag      bool
 	winnerPlayer     int // -1=未確定
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // NewUlti コンストラクタ
@@ -920,17 +920,6 @@ func (g *Ulti) findHumanIdx() int {
 	return -1
 }
 
-// appendLog 棋譜にエントリを追加する。
-func (g *Ulti) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
-}
-
 // --- CPU AI (play) ---
 
 // cpuSelectPlayCard CPU がプレイするカードのインデックスを選ぶ。
@@ -1299,9 +1288,6 @@ func (g *Ulti) GetConfig() UltiConfig { return g.config }
 
 // SetConfig 設定変更
 func (g *Ulti) SetConfig(cfg UltiConfig) { g.config = cfg }
-
-// GetActionLog 棋譜取得
-func (g *Ulti) GetActionLog() []*ActionLogEntry { return g.actionLog }
 
 // GetPlayableIndices プレイ可能なカードのインデックス一覧を返す。
 func (g *Ulti) GetPlayableIndices(playerIdx int) []int {

--- a/internal/domain/UltimateTexasHoldem.go
+++ b/internal/domain/UltimateTexasHoldem.go
@@ -57,29 +57,29 @@ const (
 
 // UltimateTexasHoldem アルティメット・テキサスホールデムクラス
 type UltimateTexasHoldem struct {
-	trumpCards      *TrumpCards       // トランプカード
-	playerHand      []*Card           // プレイヤーホールカード
-	dealerHand      []*Card           // ディーラーホールカード
-	community       []*Card           // コミュニティカード
-	chips           ChipHolder        // チップ
-	anteBet         int               // アンテベット額
-	blindBet        int               // ブラインドベット額（常に anteBet と同額）
-	tripsBet        int               // トリップス（任意のサイドベット）額
-	playBet         int               // プレイベット額（0/1×/2×/3×/4× アンテ）
-	folded          bool              // リバーでフォールドしたかどうか
-	phase           int               // 現在のフェーズ
-	gameEndFlag     bool              // ゲーム終了フラグ
-	result          GameResult        // ショーダウン結果（フォールド時は Lose）
-	dealerQualified bool              // ディーラークオリファイ（ペア以上）
-	antePayout      int               // アンテ配当（返却額込み）
-	blindPayout     int               // ブラインド配当（返却額込み）
-	playPayout      int               // プレイベット配当（返却額込み）
-	tripsPayout     int               // トリップス配当（返却額込み）
-	playerHandRank  int               // プレイヤー最良5枚ランク
-	dealerHandRank  int               // ディーラー最良5枚ランク
-	playerBest      []*Card           // プレイヤー最良5枚
-	dealerBest      []*Card           // ディーラー最良5枚
-	actionLog       []*ActionLogEntry // 棋譜
+	trumpCards      *TrumpCards // トランプカード
+	playerHand      []*Card     // プレイヤーホールカード
+	dealerHand      []*Card     // ディーラーホールカード
+	community       []*Card     // コミュニティカード
+	chips           ChipHolder  // チップ
+	anteBet         int         // アンテベット額
+	blindBet        int         // ブラインドベット額（常に anteBet と同額）
+	tripsBet        int         // トリップス（任意のサイドベット）額
+	playBet         int         // プレイベット額（0/1×/2×/3×/4× アンテ）
+	folded          bool        // リバーでフォールドしたかどうか
+	phase           int         // 現在のフェーズ
+	gameEndFlag     bool        // ゲーム終了フラグ
+	result          GameResult  // ショーダウン結果（フォールド時は Lose）
+	dealerQualified bool        // ディーラークオリファイ（ペア以上）
+	antePayout      int         // アンテ配当（返却額込み）
+	blindPayout     int         // ブラインド配当（返却額込み）
+	playPayout      int         // プレイベット配当（返却額込み）
+	tripsPayout     int         // トリップス配当（返却額込み）
+	playerHandRank  int         // プレイヤー最良5枚ランク
+	dealerHandRank  int         // ディーラー最良5枚ランク
+	playerBest      []*Card     // プレイヤー最良5枚
+	dealerBest      []*Card     // ディーラー最良5枚
+	actionLogBase
 }
 
 // NewUltimateTexasHoldem コンストラクタ
@@ -575,17 +575,6 @@ func (u *UltimateTexasHoldem) evaluateTrips() {
 	u.tripsPayout = u.tripsBet + u.tripsBet*mult
 }
 
-// appendLog 棋譜にエントリを追加する
-func (u *UltimateTexasHoldem) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	u.actionLog = append(u.actionLog, &ActionLogEntry{
-		TurnNumber: len(u.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
-}
-
 // --- Getters ---
 
 // GetPlayerHand プレイヤーホールカード取得
@@ -655,9 +644,6 @@ func (u *UltimateTexasHoldem) GetDealerBest() []*Card { return u.dealerBest }
 
 // GetChips チップ
 func (u *UltimateTexasHoldem) GetChips() int { return u.chips.GetChips() }
-
-// GetActionLog 棋譜を取得する
-func (u *UltimateTexasHoldem) GetActionLog() []*ActionLogEntry { return u.actionLog }
 
 // --- Test helpers ---
 

--- a/internal/domain/VideoPoker.go
+++ b/internal/domain/VideoPoker.go
@@ -36,8 +36,8 @@ type VideoPoker struct {
 	handRank    int
 	handName    string
 	handKey     string
-	actionLog   []*ActionLogEntry
-	config      *VideoPokerVariantConfig
+	actionLogBase
+	config *VideoPokerVariantConfig
 }
 
 // NewVideoPoker コンストラクタ
@@ -222,17 +222,6 @@ func videoPokerHandKey(handName string) string {
 	}
 }
 
-// appendLog 棋譜にエントリを追加する
-func (vp *VideoPoker) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	vp.actionLog = append(vp.actionLog, &ActionLogEntry{
-		TurnNumber: len(vp.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
-}
-
 // --- Getters ---
 
 // GetHand ハンド取得
@@ -267,9 +256,6 @@ func (vp *VideoPoker) GetHandKey() string { return vp.handKey }
 
 // GetHeldIndices ホールドインデックス
 func (vp *VideoPoker) GetHeldIndices() [VideoPokerHandSize]bool { return vp.heldIndices }
-
-// GetActionLog 棋譜を取得する
-func (vp *VideoPoker) GetActionLog() []*ActionLogEntry { return vp.actionLog }
 
 // GetVariantName バリアント名を取得する
 func (vp *VideoPoker) GetVariantName() string { return vp.config.Name }

--- a/internal/domain/War.go
+++ b/internal/domain/War.go
@@ -52,7 +52,7 @@ type War struct {
 	roundsPlayed    int
 	gameEndFlag     bool
 	winnerIdx       int
-	actionLog       []*ActionLogEntry
+	actionLogBase
 }
 
 // NewWar コンストラクタ
@@ -292,17 +292,6 @@ func (w *War) finishByTotal() {
 	w.players[w.winnerIdx].SetIsFinished(true)
 }
 
-// appendLog 棋譜にエントリを追加する
-func (w *War) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	w.actionLog = append(w.actionLog, &ActionLogEntry{
-		TurnNumber: len(w.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
-}
-
 // --- Getters ---
 
 // GetPhase フェーズ取得
@@ -348,9 +337,6 @@ func (w *War) GetConfig() WarConfig { return w.config }
 
 // SetConfig 設定更新
 func (w *War) SetConfig(cfg WarConfig) { w.config = cfg }
-
-// GetActionLog 棋譜取得
-func (w *War) GetActionLog() []*ActionLogEntry { return w.actionLog }
 
 // IsHumanTurn 戦争は常に人間入力待ち
 func (w *War) IsHumanTurn() bool { return !w.gameEndFlag }

--- a/internal/domain/Watten.go
+++ b/internal/domain/Watten.go
@@ -117,7 +117,7 @@ type Watten struct {
 	gameEndFlag      bool
 	winnerTeam       int          // マッチ勝者チーム (-1 = 未確定)
 	result           WattenResult // 人間 (チーム 0) 視点の結果
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // NewWatten コンストラクタ
@@ -849,16 +849,6 @@ func (g *Watten) playerName(idx int) string {
 	return fmt.Sprintf("CPU %d", idx)
 }
 
-func (g *Watten) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
-}
-
 // --- CPU AI ---
 
 // cpuBestDeclaration CPU の宣言: 最頻スートを T, 最頻ランクを R とする。
@@ -1234,9 +1224,6 @@ func (g *Watten) GetConfig() WattenConfig { return g.config }
 
 // SetConfig 設定変更
 func (g *Watten) SetConfig(cfg WattenConfig) { g.config = cfg }
-
-// GetActionLog 棋譜取得
-func (g *Watten) GetActionLog() []*ActionLogEntry { return g.actionLog }
 
 // --- Test-only helpers ---
 

--- a/internal/domain/Whist.go
+++ b/internal/domain/Whist.go
@@ -49,7 +49,7 @@ type Whist struct {
 	teamScores       [WhistTeamCnt]int
 	gameEndFlag      bool
 	winnerTeam       int
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // NewWhist コンストラクタ
@@ -338,9 +338,6 @@ func (w *Whist) GetConfig() WhistConfig { return w.config }
 // SetConfig 設定変更
 func (w *Whist) SetConfig(cfg WhistConfig) { w.config = cfg }
 
-// GetActionLog 棋譜取得
-func (w *Whist) GetActionLog() []*ActionLogEntry { return w.actionLog }
-
 // GetValidPlayIndices プレイ可能なカードのインデックスリストを返す (Web用)
 func (w *Whist) GetValidPlayIndices(playerIdx int) []int {
 	return w.getValidPlayIndices(playerIdx)
@@ -498,17 +495,6 @@ func (w *Whist) playerName(idx int) string {
 		return "You"
 	}
 	return fmt.Sprintf("CPU %d", idx)
-}
-
-// appendLog 棋譜にエントリを追加する
-func (w *Whist) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	w.actionLog = append(w.actionLog, &ActionLogEntry{
-		TurnNumber: len(w.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // playHintReason プレイヒントの理由を判定する

--- a/internal/domain/Wizard.go
+++ b/internal/domain/Wizard.go
@@ -66,7 +66,7 @@ type Wizard struct {
 	trumpSuit        int   // 切り札スート (-1 = 切り札なし)
 	gameEndFlag      bool
 	winnerIdx        int
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // NewWizard コンストラクタ
@@ -449,9 +449,6 @@ func (o *Wizard) GetConfig() WizardConfig { return o.config }
 // SetConfig 設定変更
 func (o *Wizard) SetConfig(cfg WizardConfig) { o.config = cfg }
 
-// GetActionLog 棋譜取得
-func (o *Wizard) GetActionLog() []*ActionLogEntry { return o.actionLog }
-
 // GetRestrictedBid ディーラーのビッド制限値を返す。
 // Wizardはフックルールを持たないため常に -1 (制限なし)。
 // トリックテイカー共通インタフェース/DTO との互換のために残している。
@@ -793,17 +790,6 @@ func (o *Wizard) playerName(idx int) string {
 		return "You"
 	}
 	return fmt.Sprintf("CPU %d", idx)
-}
-
-// appendLog 棋譜にエントリを追加する
-func (o *Wizard) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	o.actionLog = append(o.actionLog, &ActionLogEntry{
-		TurnNumber: len(o.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す

--- a/internal/domain/Yaniv.go
+++ b/internal/domain/Yaniv.go
@@ -51,8 +51,8 @@ type Yaniv struct {
 	asafWinnerIdx    int   // アサフで宣言者を下回ったプレイヤー (-1 = なし)
 	isAsaf           bool  // 直近の宣言がアサフだったか
 	roundScores      []int // 直近ラウンドで各プレイヤーが加算された失点
-	actionLog        []*ActionLogEntry
-	rng              *rand.Rand
+	actionLogBase
+	rng *rand.Rand
 }
 
 // NewYaniv コンストラクタ
@@ -810,9 +810,6 @@ func (g *Yaniv) GetConfig() YanivConfig { return g.config }
 // SetConfig ゲーム設定を設定する
 func (g *Yaniv) SetConfig(cfg YanivConfig) { g.config = cfg }
 
-// GetActionLog 棋譜を取得する
-func (g *Yaniv) GetActionLog() []*ActionLogEntry { return g.actionLog }
-
 // --- Private helpers ---
 
 // sortAllHands 全プレイヤーの手札をソートする
@@ -850,17 +847,6 @@ func (g *Yaniv) playerName(idx int) string {
 		return "You"
 	}
 	return fmt.Sprintf("CPU %d", idx)
-}
-
-// appendLog 棋譜にエントリを追加する
-func (g *Yaniv) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
 }
 
 // cardsStr 複数カードを空白区切りの文字列にする

--- a/internal/domain/action_log_base.go
+++ b/internal/domain/action_log_base.go
@@ -1,0 +1,35 @@
+package domain
+
+// actionLogBase holds a game's action log and the two operations every game
+// performs on it. It is embedded rather than duplicated: 223 games had written
+// their own `appendLog`, and 244 their own `GetActionLog`, from the same handful
+// of bodies. See issue #5185.
+//
+// Embedding keeps `g.actionLog` working verbatim at every existing call site —
+// promoted fields are readable and assignable — so `Reset` implementations that
+// do `g.actionLog = nil`, and the MarshalJSON/UnmarshalJSON pairs that map the
+// field to an exported DTO, need no changes. That matters: the action log is
+// persisted to KV for the Cloudflare Workers, and a codec change there would
+// silently drop history rather than fail loudly.
+//
+// This base carries the numbered variant, where TurnNumber counts entries.
+// Solitaire games number their entries by move count instead and keep their own
+// appendLog for now; collapsing those needs a different base, not this one.
+type actionLogBase struct {
+	actionLog []*ActionLogEntry
+}
+
+// GetActionLog returns the entries recorded so far, oldest first.
+func (b *actionLogBase) GetActionLog() []*ActionLogEntry { return b.actionLog }
+
+// appendLog records one action. TurnNumber is assigned from the number of
+// entries already present, so the first entry is turn 1.
+func (b *actionLogBase) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
+	b.actionLog = append(b.actionLog, &ActionLogEntry{
+		TurnNumber: len(b.actionLog) + 1,
+		PlayerIdx:  playerIdx,
+		ActionType: actionType,
+		Detail:     detail,
+		Cards:      cards,
+	})
+}

--- a/internal/domain/action_log_base_test.go
+++ b/internal/domain/action_log_base_test.go
@@ -1,0 +1,52 @@
+//go:build test
+
+package domain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestActionLogBase_AppendNumbersFromOne(t *testing.T) {
+	var b actionLogBase
+
+	assert.Empty(t, b.GetActionLog(), "a fresh log is empty")
+
+	b.appendLog(0, "play", "first", nil)
+	b.appendLog(2, "pass", "second", []*Card{NewCard(0, 1, true)})
+
+	got := b.GetActionLog()
+	assert.Len(t, got, 2)
+
+	assert.Equal(t, 1, got[0].TurnNumber, "first entry is turn 1, not 0")
+	assert.Equal(t, 0, got[0].PlayerIdx)
+	assert.Equal(t, "play", got[0].ActionType)
+	assert.Equal(t, "first", got[0].Detail)
+	assert.Nil(t, got[0].Cards)
+
+	assert.Equal(t, 2, got[1].TurnNumber)
+	assert.Equal(t, 2, got[1].PlayerIdx)
+	assert.Len(t, got[1].Cards, 1)
+}
+
+// Reset implementations clear the log by assigning to the promoted field. That
+// only compiles and behaves correctly because the field is promoted, so it is
+// worth pinning: renaming or unexporting it differently would break ~122 games
+// at once.
+func TestActionLogBase_PromotedFieldStaysAssignable(t *testing.T) {
+	type game struct {
+		actionLogBase
+		name string
+	}
+	g := &game{name: "x"}
+
+	g.appendLog(0, "a", "b", nil)
+	assert.Len(t, g.GetActionLog(), 1)
+
+	g.actionLog = nil
+	assert.Empty(t, g.GetActionLog(), "assigning nil through the promoted field clears it")
+
+	g.appendLog(1, "c", "d", nil)
+	assert.Equal(t, 1, g.GetActionLog()[0].TurnNumber, "numbering restarts after a clear")
+}


### PR DESCRIPTION
## 概要

`internal/domain` の重複（[#5185](https://github.com/yuta-yoshinaga/go_trumpcards/issues/5185) の147クラスタ・約8,559行）のうち、**最も安全に集約できるアクションログ系**を対象としたフェーズ1です。

**1,683行削除**（398追加 / 2,081削除）。122ゲームがそれぞれ持っていた `actionLog` フィールド・`appendLog`・`GetActionLog` を、埋め込みベース1つに置き換えます。

## 対象を122ゲームに絞っています

3つのアンカーが**完全一致**するゲームだけを対象にしました。

- 正典の4引数 `appendLog`（`TurnNumber: len(actionLog) + 1`）
- 同じ型の上の `GetActionLog() []*ActionLogEntry { return x.actionLog }`
- 素の `actionLog` フィールド（ネストしていない）

**残りは意図的に手つかず**です。実測した内訳:

| 種別 | 件数 | 理由 |
|---|---:|---|
| ソリティア系3引数 `appendLog` | 44 | `TurnNumber` に **`moveCount`** を使う（正典と別物） |
| `round.actionLog` にネスト | 18 | ベースをネスト側に埋める別対応が要る |
| `state.actionLog` にネスト | 12 | 同上 |
| `trickNumber` を使用 | 3 | 採番規則が違う |

これらを同じベースに押し込むと**採番規則を黙って変えてしまう**ため、別フェーズに回します。issue 本文の「223個の `appendLog`」は**ボディが22種類**あり、一括置換すると51件が壊れることは調査済みです。

## KV 永続化の安全性を実測しました

アクションログは Cloudflare Worker の KV に永続化される状態です。**コーデックが壊れると失敗せず履歴だけ静かに消える**ため、推定ではなく実測しました。

埋め込みでも `g.actionLog` は**昇格フィールド**として読み書きできるので、`Reset` の `g.actionLog = nil` も、各ゲームの `MarshalJSON` / `UnmarshalJSON` が明示 DTO へ写している箇所も**無変更で動きます**。ログ入りの Baccarat を marshal → unmarshal し、エントリを1件ずつ比較して確認済みです。

```
--- PASS: TestTmpBaccaratActionLogSurvivesJSON
```

`PigsTail` だけは複合リテラルで `actionLog:` を初期化していたため、`actionLogBase: actionLogBase{actionLog: nil}` に書き換えています（コンパイラが検出）。

## Worker バイナリサイズについて

`internal/domain` は Worker に**入ります**（`games/<category>/<category>.go` が import）。今回は**実際に呼ばれているメソッドの実体を1つにまとめる**変更なので、[#5193 の未使用コード削除とは違い](https://github.com/yuta-yoshinaga/go_trumpcards/pull/5193#issuecomment-5225539363)、サイズが動くはずです。CI の `tinygo-build` で確認します（現状の余裕は最小 extra3 で 127KB）。

## テスト計画

- [x] `actionLogBase` の単体テスト（1始まりの採番、`nil` 代入で採番リセット）
- [x] **昇格フィールドが代入可能であること**を明示的に固定（122ゲームの `Reset` がこれに依存）
- [x] Baccarat で **JSON ラウンドトリップ**を実測（KV 永続化の安全性）
- [x] `go build ./...` / `gofmt -l` クリーン
- [x] `go test -tags test ./internal/domain/... ./internal/usecase/...` 通過（domain 52.7s）
- [x] `golangci-lint run ./internal/domain/...` → 0 issues

## 作業手順

122ファイルの機械的変更は、**期待件数と一致しなければ書き込まない**アサート付きスクリプトで行いました。実際に2回止まっています（1回はインデント差異、1回は変数の末尾改行バグ）。先に1ゲーム（Baccarat）だけ手で変換して検証し、ベースは call site を触る前に別コミットにしてあります。

Refs #5185