### PR TITLE
refactor(domain): embed actionLogBase in the 44 solitaire games

### DIFF
--- a/internal/domain/Accordion.go
+++ b/internal/domain/Accordion.go
@@ -41,11 +41,11 @@ type AccordionHint struct {
 
 // Accordion アコーディオンゲームクラス
 type Accordion struct {
-	trumpCards  *TrumpCards
-	piles       [][]*Card
-	phase       AccordionPhase
-	moveCount   int
-	actionLog   []*ActionLogEntry
+	trumpCards *TrumpCards
+	piles      [][]*Card
+	phase      AccordionPhase
+	moveCount  int
+	actionLogBase
 	history     []*accordionSnapshot
 	isStalemate bool
 }
@@ -240,9 +240,6 @@ func (a *Accordion) GetPiles() [][]*Card { return a.piles }
 // GetPileCount 残りパイル数取得
 func (a *Accordion) GetPileCount() int { return len(a.piles) }
 
-// GetActionLog 棋譜取得
-func (a *Accordion) GetActionLog() []*ActionLogEntry { return a.actionLog }
-
 // GetGameEndFlag returns true once the game has left the playing phase.
 func (a *Accordion) GetGameEndFlag() bool { return a.phase != AccordionPhasePlaying }
 
@@ -319,13 +316,7 @@ func (a *Accordion) restoreSnapshot(snap *accordionSnapshot) {
 
 // appendLog 棋譜エントリを追加
 func (a *Accordion) appendLog(actionType, detail string, cards []*Card) {
-	a.actionLog = append(a.actionLog, &ActionLogEntry{
-		TurnNumber: a.moveCount,
-		PlayerIdx:  0,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	a.appendLogAt(a.moveCount, 0, actionType, detail, cards)
 }
 
 // accordionJSON is the JSON wire format for Accordion.

--- a/internal/domain/AcesUp.go
+++ b/internal/domain/AcesUp.go
@@ -40,13 +40,13 @@ type AcesUpHint struct {
 
 // AcesUp エースアップ（四つ葉のクローバー）ゲームクラス
 type AcesUp struct {
-	trumpCards  *TrumpCards
-	columns     [AcesUpColCnt][]*Card
-	stock       []*Card
-	discard     []*Card
-	phase       AcesUpPhase
-	moveCount   int
-	actionLog   []*ActionLogEntry
+	trumpCards *TrumpCards
+	columns    [AcesUpColCnt][]*Card
+	stock      []*Card
+	discard    []*Card
+	phase      AcesUpPhase
+	moveCount  int
+	actionLogBase
 	history     []*acesUpSnapshot
 	isStalemate bool
 }
@@ -284,9 +284,6 @@ func (a *AcesUp) GetDiscardTop() *Card {
 
 // GetColumns 場札の列を取得
 func (a *AcesUp) GetColumns() [AcesUpColCnt][]*Card { return a.columns }
-
-// GetActionLog 棋譜取得
-func (a *AcesUp) GetActionLog() []*ActionLogEntry { return a.actionLog }
 
 // GetGameEndFlag returns true once the game has left the playing phase.
 func (a *AcesUp) GetGameEndFlag() bool { return a.phase != AcesUpPhasePlaying }
@@ -542,13 +539,7 @@ func cloneCards(src []*Card) []*Card {
 
 // appendLog 棋譜エントリを追加
 func (a *AcesUp) appendLog(actionType, detail string, cards []*Card) {
-	a.actionLog = append(a.actionLog, &ActionLogEntry{
-		TurnNumber: a.moveCount,
-		PlayerIdx:  0,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	a.appendLogAt(a.moveCount, 0, actionType, detail, cards)
 }
 
 // acesUpJSON is the JSON wire format for AcesUp.

--- a/internal/domain/Agnes.go
+++ b/internal/domain/Agnes.go
@@ -51,8 +51,8 @@ type Agnes struct {
 	baseRank   int
 	phase      AgnesPhase
 	moveCount  int
-	actionLog  []*ActionLogEntry
-	history    []*agnesSnapshot
+	actionLogBase
+	history []*agnesSnapshot
 }
 
 // agnesSnapshot アンドゥ用スナップショット
@@ -298,9 +298,6 @@ func (a *Agnes) GetTableau() [AgnesTableauCnt][]*AgnesTableauCard { return a.tab
 // GetFoundation ファンデーション取得
 func (a *Agnes) GetFoundation() [AgnesFoundationCnt][]*Card { return a.foundation }
 
-// GetActionLog 棋譜取得
-func (a *Agnes) GetActionLog() []*ActionLogEntry { return a.actionLog }
-
 // GetGameEndFlag returns true once the game has left the playing phase.
 func (a *Agnes) GetGameEndFlag() bool { return a.phase != AgnesPhasePlaying }
 
@@ -429,13 +426,7 @@ func (a *Agnes) restoreSnapshot(snap *agnesSnapshot) {
 }
 
 func (a *Agnes) appendLog(actionType, detail string, cards []*Card) {
-	a.actionLog = append(a.actionLog, &ActionLogEntry{
-		TurnNumber: a.moveCount,
-		PlayerIdx:  0,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	a.appendLogAt(a.moveCount, 0, actionType, detail, cards)
 }
 
 // agnesJSON is the JSON wire format for Agnes.

--- a/internal/domain/AmericanToad.go
+++ b/internal/domain/AmericanToad.go
@@ -99,17 +99,17 @@ type AmericanToadHint struct {
 // 主要な実装と bvssolitaire の記述に合わせ、任意の連番グループを動かせるものとした。
 // このリポジトリの他のソリティアとも操作感が揃う。
 type AmericanToad struct {
-	trumpCards  *TrumpCards
-	reserve     []*Card
-	tableau     [AmericanToadTableauCnt][]*AmericanToadTableauCard
-	foundation  [AmericanToadFoundationCnt][]*Card
-	stock       []*Card
-	waste       []*Card
-	baseRank    int
-	passesUsed  int
-	phase       AmericanToadPhase
-	moveCount   int
-	actionLog   []*ActionLogEntry
+	trumpCards *TrumpCards
+	reserve    []*Card
+	tableau    [AmericanToadTableauCnt][]*AmericanToadTableauCard
+	foundation [AmericanToadFoundationCnt][]*Card
+	stock      []*Card
+	waste      []*Card
+	baseRank   int
+	passesUsed int
+	phase      AmericanToadPhase
+	moveCount  int
+	actionLogBase
 	history     []*americanToadSnapshot
 	isStalemate bool
 }
@@ -590,9 +590,6 @@ func (at *AmericanToad) CanRedeal() bool {
 		len(at.stock) == 0 && len(at.waste) > 0 && at.passesUsed < AmericanToadMaxPasses-1
 }
 
-// GetActionLog 棋譜取得
-func (at *AmericanToad) GetActionLog() []*ActionLogEntry { return at.actionLog }
-
 // GetGameEndFlag ゲーム終了フラグ
 func (at *AmericanToad) GetGameEndFlag() bool { return at.phase != AmericanToadPhasePlaying }
 
@@ -815,13 +812,7 @@ func (at *AmericanToad) takeSnapshot() {
 
 // appendLog 棋譜エントリを追加
 func (at *AmericanToad) appendLog(actionType, detail string, cards []*Card) {
-	at.actionLog = append(at.actionLog, &ActionLogEntry{
-		TurnNumber: at.moveCount,
-		PlayerIdx:  0,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	at.appendLogAt(at.moveCount, 0, actionType, detail, cards)
 }
 
 // americanToadJSON is the JSON wire format for AmericanToad.

--- a/internal/domain/BakersDozen.go
+++ b/internal/domain/BakersDozen.go
@@ -46,12 +46,12 @@ type BakersDozenConfig struct{}
 
 // BakersDozen ベーカーズダズンゲームクラス
 type BakersDozen struct {
-	trumpCards  *TrumpCards
-	tableau     [BakersDozenTableauCnt][]*BakersDozenTableauCard
-	foundation  [BakersDozenFoundationCnt][]*Card
-	phase       BakersDozenPhase
-	moveCount   int
-	actionLog   []*ActionLogEntry
+	trumpCards *TrumpCards
+	tableau    [BakersDozenTableauCnt][]*BakersDozenTableauCard
+	foundation [BakersDozenFoundationCnt][]*Card
+	phase      BakersDozenPhase
+	moveCount  int
+	actionLogBase
 	history     []*bakersDozenSnapshot
 	isStalemate bool
 }
@@ -294,9 +294,6 @@ func (bd *BakersDozen) GetTableau() [BakersDozenTableauCnt][]*BakersDozenTableau
 // GetFoundation ファンデーション取得
 func (bd *BakersDozen) GetFoundation() [BakersDozenFoundationCnt][]*Card { return bd.foundation }
 
-// GetActionLog 棋譜取得
-func (bd *BakersDozen) GetActionLog() []*ActionLogEntry { return bd.actionLog }
-
 // GetGameEndFlag returns true once the game has left the playing phase.
 func (bd *BakersDozen) GetGameEndFlag() bool { return bd.phase != BakersDozenPhasePlaying }
 
@@ -445,13 +442,7 @@ func (bd *BakersDozen) restoreSnapshot(snap *bakersDozenSnapshot) {
 
 // appendLog 棋譜エントリを追加
 func (bd *BakersDozen) appendLog(actionType, detail string, cards []*Card) {
-	bd.actionLog = append(bd.actionLog, &ActionLogEntry{
-		TurnNumber: bd.moveCount,
-		PlayerIdx:  0,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	bd.appendLogAt(bd.moveCount, 0, actionType, detail, cards)
 }
 
 // bakersDozenJSON is the JSON wire format for BakersDozen.

--- a/internal/domain/BeleagueredCastle.go
+++ b/internal/domain/BeleagueredCastle.go
@@ -49,12 +49,12 @@ type BeleagueredCastleConfig struct{}
 
 // BeleagueredCastle ゲームクラス
 type BeleagueredCastle struct {
-	trumpCards  *TrumpCards
-	tableau     [BeleagueredCastleTableauCnt][]*BeleagueredCastleTableauCard
-	foundation  [BeleagueredCastleFoundationCnt][]*Card
-	phase       BeleagueredCastlePhase
-	moveCount   int
-	actionLog   []*ActionLogEntry
+	trumpCards *TrumpCards
+	tableau    [BeleagueredCastleTableauCnt][]*BeleagueredCastleTableauCard
+	foundation [BeleagueredCastleFoundationCnt][]*Card
+	phase      BeleagueredCastlePhase
+	moveCount  int
+	actionLogBase
 	history     []*beleagueredCastleSnapshot
 	isStalemate bool
 }
@@ -318,9 +318,6 @@ func (bc *BeleagueredCastle) GetFoundation() [BeleagueredCastleFoundationCnt][]*
 	return bc.foundation
 }
 
-// GetActionLog 棋譜取得
-func (bc *BeleagueredCastle) GetActionLog() []*ActionLogEntry { return bc.actionLog }
-
 // GetGameEndFlag returns true once the game has left the playing phase.
 func (bc *BeleagueredCastle) GetGameEndFlag() bool { return bc.phase != BeleagueredCastlePhasePlaying }
 
@@ -471,13 +468,7 @@ func (bc *BeleagueredCastle) restoreSnapshot(snap *beleagueredCastleSnapshot) {
 
 // appendLog 棋譜エントリを追加
 func (bc *BeleagueredCastle) appendLog(actionType, detail string, cards []*Card) {
-	bc.actionLog = append(bc.actionLog, &ActionLogEntry{
-		TurnNumber: bc.moveCount,
-		PlayerIdx:  0,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	bc.appendLogAt(bc.moveCount, 0, actionType, detail, cards)
 }
 
 // beleagueredCastleJSON is the JSON wire format for BeleagueredCastle.

--- a/internal/domain/Bisley.go
+++ b/internal/domain/Bisley.go
@@ -78,9 +78,9 @@ type Bisley struct {
 	tableau         [BisleyTableauCnt][]*BisleyTableauCard
 	phase           BisleyPhase
 	moveCount       int
-	actionLog       []*ActionLogEntry
-	history         []*bisleySnapshot
-	isStalemate     bool
+	actionLogBase
+	history     []*bisleySnapshot
+	isStalemate bool
 }
 
 // bisleySnapshot アンドゥ用スナップショット
@@ -371,9 +371,6 @@ func (b *Bisley) GetKingFoundations() [BisleyFoundationCnt][]*Card { return b.ki
 // GetTableau タブローを取得
 func (b *Bisley) GetTableau() [BisleyTableauCnt][]*BisleyTableauCard { return b.tableau }
 
-// GetActionLog 棋譜取得
-func (b *Bisley) GetActionLog() []*ActionLogEntry { return b.actionLog }
-
 // GetGameEndFlag ゲーム終了フラグ
 func (b *Bisley) GetGameEndFlag() bool { return b.phase != BisleyPhasePlaying }
 
@@ -484,13 +481,7 @@ func (b *Bisley) takeSnapshot() {
 
 // appendLog 棋譜エントリを追加
 func (b *Bisley) appendLog(actionType, detail string, cards []*Card) {
-	b.actionLog = append(b.actionLog, &ActionLogEntry{
-		TurnNumber: b.moveCount,
-		PlayerIdx:  0,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	b.appendLogAt(b.moveCount, 0, actionType, detail, cards)
 }
 
 // bisleyMaxSliceLen caps slice sizes during deserialisation.

--- a/internal/domain/Braid.go
+++ b/internal/domain/Braid.go
@@ -97,19 +97,19 @@ type BraidHint struct {
 //   - **カードは基礎札にしか動かせない**（issue は触れていない）
 //   - 基礎札は**同スート**で積む（issue は触れていない）
 type Braid struct {
-	trumpCards  *TrumpCards
-	braid       []*Card
-	fields      [BraidFieldCnt]*Card
-	helpers     [BraidHelperCnt]*Card
-	foundation  [BraidFoundationCnt][]*Card
-	stock       []*Card
-	waste       []*Card
-	baseRank    int
-	direction   BraidDirection
-	passesUsed  int
-	phase       BraidPhase
-	moveCount   int
-	actionLog   []*ActionLogEntry
+	trumpCards *TrumpCards
+	braid      []*Card
+	fields     [BraidFieldCnt]*Card
+	helpers    [BraidHelperCnt]*Card
+	foundation [BraidFoundationCnt][]*Card
+	stock      []*Card
+	waste      []*Card
+	baseRank   int
+	direction  BraidDirection
+	passesUsed int
+	phase      BraidPhase
+	moveCount  int
+	actionLogBase
 	history     []*braidSnapshot
 	isStalemate bool
 }
@@ -555,9 +555,6 @@ func (b *Braid) GetFoundation() [BraidFoundationCnt][]*Card { return b.foundatio
 // GetPassesUsed 山札を通した回数
 func (b *Braid) GetPassesUsed() int { return b.passesUsed }
 
-// GetActionLog 棋譜取得
-func (b *Braid) GetActionLog() []*ActionLogEntry { return b.actionLog }
-
 // GetGameEndFlag ゲーム終了フラグ
 func (b *Braid) GetGameEndFlag() bool { return b.phase != BraidPhasePlaying }
 
@@ -743,13 +740,7 @@ func (b *Braid) takeSnapshot() {
 
 // appendLog 棋譜エントリを追加
 func (b *Braid) appendLog(actionType, detail string, cards []*Card) {
-	b.actionLog = append(b.actionLog, &ActionLogEntry{
-		TurnNumber: b.moveCount,
-		PlayerIdx:  0,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	b.appendLogAt(b.moveCount, 0, actionType, detail, cards)
 }
 
 // braidSnapshotJSON is the wire format for a single undo snapshot.

--- a/internal/domain/Bristol.go
+++ b/internal/domain/Bristol.go
@@ -61,8 +61,8 @@ type Bristol struct {
 	foundation [BristolFoundationCnt][]*Card
 	phase      BristolPhase
 	moveCount  int
-	actionLog  []*ActionLogEntry
-	history    []*bristolSnapshot
+	actionLogBase
+	history []*bristolSnapshot
 }
 
 // bristolSnapshot アンドゥ用スナップショット
@@ -387,9 +387,6 @@ func (b *Bristol) GetFan() [BristolFanCnt][]*Card { return b.fan }
 // GetFoundation ファウンデーション取得
 func (b *Bristol) GetFoundation() [BristolFoundationCnt][]*Card { return b.foundation }
 
-// GetActionLog 棋譜取得
-func (b *Bristol) GetActionLog() []*ActionLogEntry { return b.actionLog }
-
 // GetGameEndFlag returns true once the game has left the playing phase.
 func (b *Bristol) GetGameEndFlag() bool { return b.phase != BristolPhasePlaying }
 
@@ -552,13 +549,7 @@ func (b *Bristol) restoreSnapshot(snap *bristolSnapshot) {
 }
 
 func (b *Bristol) appendLog(actionType, detail string, cards []*Card) {
-	b.actionLog = append(b.actionLog, &ActionLogEntry{
-		TurnNumber: b.moveCount,
-		PlayerIdx:  0,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	b.appendLogAt(b.moveCount, 0, actionType, detail, cards)
 }
 
 // bristolJSON is the JSON wire format for Bristol.

--- a/internal/domain/Calculation.go
+++ b/internal/domain/Calculation.go
@@ -45,7 +45,7 @@ type Calculation struct {
 	stock       []*Card
 	phase       CalculationPhase
 	moveCount   int
-	actionLog   []*ActionLogEntry
+	actionLogBase
 	history     []*calculationSnapshot
 	isStalemate bool
 }
@@ -316,9 +316,6 @@ func (c *Calculation) GetWastes() [CalculationWasteCnt][]*Card { return c.wastes
 // GetFoundations ファンデーション取得
 func (c *Calculation) GetFoundations() [CalculationFoundationCnt][]*Card { return c.foundations }
 
-// GetActionLog 棋譜取得
-func (c *Calculation) GetActionLog() []*ActionLogEntry { return c.actionLog }
-
 // GetGameEndFlag returns true once the game has left the playing phase.
 func (c *Calculation) GetGameEndFlag() bool { return c.phase != CalculationPhasePlaying }
 
@@ -448,13 +445,7 @@ func (c *Calculation) restoreSnapshot(snap *calculationSnapshot) {
 
 // appendLog 棋譜エントリを追加
 func (c *Calculation) appendLog(actionType, detail string, cards []*Card) {
-	c.actionLog = append(c.actionLog, &ActionLogEntry{
-		TurnNumber: c.moveCount,
-		PlayerIdx:  0,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	c.appendLogAt(c.moveCount, 0, actionType, detail, cards)
 }
 
 // calculationJSON is the JSON wire format for Calculation.

--- a/internal/domain/Canfield.go
+++ b/internal/domain/Canfield.go
@@ -58,8 +58,8 @@ type Canfield struct {
 	baseRank   int
 	phase      CanfieldPhase
 	moveCount  int
-	actionLog  []*ActionLogEntry
-	history    []*canfieldSnapshot
+	actionLogBase
+	history []*canfieldSnapshot
 }
 
 // canfieldSnapshot アンドゥ用スナップショット
@@ -445,9 +445,6 @@ func (c *Canfield) GetTableau() [CanfieldTableauCnt][]*CanfieldTableauCard { ret
 // GetFoundation ファンデーション取得
 func (c *Canfield) GetFoundation() [CanfieldFoundationCnt][]*Card { return c.foundation }
 
-// GetActionLog 棋譜取得
-func (c *Canfield) GetActionLog() []*ActionLogEntry { return c.actionLog }
-
 // GetGameEndFlag returns true once the game has left the playing phase.
 func (c *Canfield) GetGameEndFlag() bool { return c.phase != CanfieldPhasePlaying }
 
@@ -595,13 +592,7 @@ func (c *Canfield) restoreSnapshot(snap *canfieldSnapshot) {
 }
 
 func (c *Canfield) appendLog(actionType, detail string, cards []*Card) {
-	c.actionLog = append(c.actionLog, &ActionLogEntry{
-		TurnNumber: c.moveCount,
-		PlayerIdx:  0,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	c.appendLogAt(c.moveCount, 0, actionType, detail, cards)
 }
 
 // canfieldJSON is the JSON wire format for Canfield.

--- a/internal/domain/Congress.go
+++ b/internal/domain/Congress.go
@@ -78,14 +78,14 @@ type CongressHint struct {
 //     前者は 32 枚にしかならず 104 枚を吸収できない
 //   - **空き山は山札か捨て札から埋める**（issue は触れていない）
 type Congress struct {
-	trumpCards  *TrumpCards
-	tableau     [CongressTableauCnt][]*Card
-	foundation  [CongressFoundationCnt][]*Card
-	stock       []*Card
-	waste       []*Card
-	phase       CongressPhase
-	moveCount   int
-	actionLog   []*ActionLogEntry
+	trumpCards *TrumpCards
+	tableau    [CongressTableauCnt][]*Card
+	foundation [CongressFoundationCnt][]*Card
+	stock      []*Card
+	waste      []*Card
+	phase      CongressPhase
+	moveCount  int
+	actionLogBase
 	history     []*congressSnapshot
 	isStalemate bool
 }
@@ -470,9 +470,6 @@ func (c *Congress) GetTableau() [CongressTableauCnt][]*Card { return c.tableau }
 // GetFoundation 基礎札を取得
 func (c *Congress) GetFoundation() [CongressFoundationCnt][]*Card { return c.foundation }
 
-// GetActionLog 棋譜取得
-func (c *Congress) GetActionLog() []*ActionLogEntry { return c.actionLog }
-
 // GetGameEndFlag ゲーム終了フラグ
 func (c *Congress) GetGameEndFlag() bool { return c.phase != CongressPhasePlaying }
 
@@ -617,13 +614,7 @@ func (c *Congress) takeSnapshot() {
 
 // appendLog 棋譜エントリを追加
 func (c *Congress) appendLog(actionType, detail string, cards []*Card) {
-	c.actionLog = append(c.actionLog, &ActionLogEntry{
-		TurnNumber: c.moveCount,
-		PlayerIdx:  0,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	c.appendLogAt(c.moveCount, 0, actionType, detail, cards)
 }
 
 // congressSnapshotJSON is the wire format for a single undo snapshot.

--- a/internal/domain/Crescent.go
+++ b/internal/domain/Crescent.go
@@ -66,9 +66,9 @@ type Crescent struct {
 	phase            CrescentPhase
 	moveCount        int
 	redealsRemaining int
-	actionLog        []*ActionLogEntry
-	history          []*crescentSnapshot
-	isStalemate      bool
+	actionLogBase
+	history     []*crescentSnapshot
+	isStalemate bool
 }
 
 // crescentSnapshot アンドゥ用スナップショット。
@@ -349,9 +349,6 @@ func (cr *Crescent) GetTableau() [CrescentTableauCnt][]*CrescentTableauCard { re
 // GetFoundation ファンデーションを返す。
 func (cr *Crescent) GetFoundation() [CrescentFoundationCnt][]*Card { return cr.foundation }
 
-// GetActionLog 棋譜を返す。
-func (cr *Crescent) GetActionLog() []*ActionLogEntry { return cr.actionLog }
-
 // GetGameEndFlag プレイ中でなくなったかを返す。
 func (cr *Crescent) GetGameEndFlag() bool { return cr.phase != CrescentPhasePlaying }
 
@@ -574,13 +571,7 @@ func (cr *Crescent) restoreSnapshot(snap *crescentSnapshot) {
 
 // appendLog 棋譜エントリを追加。
 func (cr *Crescent) appendLog(actionType, detail string, cards []*Card) {
-	cr.actionLog = append(cr.actionLog, &ActionLogEntry{
-		TurnNumber: cr.moveCount,
-		PlayerIdx:  0,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	cr.appendLogAt(cr.moveCount, 0, actionType, detail, cards)
 }
 
 // crescentJSON Crescent の永続化用ワイヤーフォーマット。

--- a/internal/domain/Cruel.go
+++ b/internal/domain/Cruel.go
@@ -44,12 +44,12 @@ type CruelHint struct {
 // 残り48枚を12列×4枚のタブローに表向きで配る。カード移動は同スートの降順のみ、
 // 空の列にはカードを置けない。手詰まりのときは Shift で盤面を再構築できる。
 type Cruel struct {
-	trumpCards  *TrumpCards
-	tableau     [CruelTableauCnt][]*KlondikeTableauCard
-	foundation  [CruelFoundationCnt][]*Card
-	phase       CruelPhase
-	moveCount   int
-	actionLog   []*ActionLogEntry
+	trumpCards *TrumpCards
+	tableau    [CruelTableauCnt][]*KlondikeTableauCard
+	foundation [CruelFoundationCnt][]*Card
+	phase      CruelPhase
+	moveCount  int
+	actionLogBase
 	history     []*cruelSnapshot
 	isStalemate bool
 }
@@ -356,9 +356,6 @@ func (c *Cruel) GetFoundation() [CruelFoundationCnt][]*Card {
 	return c.foundation
 }
 
-// GetActionLog 棋譜取得
-func (c *Cruel) GetActionLog() []*ActionLogEntry { return c.actionLog }
-
 // GetGameEndFlag returns true once the game has left the playing phase.
 func (c *Cruel) GetGameEndFlag() bool { return c.phase != CruelPhasePlaying }
 
@@ -500,13 +497,7 @@ func (c *Cruel) restoreSnapshot(snap *cruelSnapshot) {
 
 // appendLog 棋譜エントリを追加
 func (c *Cruel) appendLog(actionType, detail string, cards []*Card) {
-	c.actionLog = append(c.actionLog, &ActionLogEntry{
-		TurnNumber: c.moveCount,
-		PlayerIdx:  0,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	c.appendLogAt(c.moveCount, 0, actionType, detail, cards)
 }
 
 // cruelJSON is the JSON wire format for Cruel.

--- a/internal/domain/Duchess.go
+++ b/internal/domain/Duchess.go
@@ -88,16 +88,16 @@ type DuchessHint struct {
 // いないものの実際の規則と違うため、実ゲームに合わせた。issue が触れていない
 // 「空き列はリザーブ優先」も本来の規則なので実装している。
 type Duchess struct {
-	trumpCards  *TrumpCards
-	reserve     [DuchessReserveCnt][]*Card
-	tableau     [DuchessTableauCnt][]*DuchessTableauCard
-	foundation  [DuchessFoundationCnt][]*Card
-	stock       []*Card
-	waste       []*Card
-	baseRank    int
-	phase       DuchessPhase
-	moveCount   int
-	actionLog   []*ActionLogEntry
+	trumpCards *TrumpCards
+	reserve    [DuchessReserveCnt][]*Card
+	tableau    [DuchessTableauCnt][]*DuchessTableauCard
+	foundation [DuchessFoundationCnt][]*Card
+	stock      []*Card
+	waste      []*Card
+	baseRank   int
+	phase      DuchessPhase
+	moveCount  int
+	actionLogBase
 	history     []*duchessSnapshot
 	isStalemate bool
 }
@@ -603,9 +603,6 @@ func (d *Duchess) GetTableau() [DuchessTableauCnt][]*DuchessTableauCard { return
 // GetFoundation 基礎札を取得
 func (d *Duchess) GetFoundation() [DuchessFoundationCnt][]*Card { return d.foundation }
 
-// GetActionLog 棋譜取得
-func (d *Duchess) GetActionLog() []*ActionLogEntry { return d.actionLog }
-
 // GetGameEndFlag ゲーム終了フラグ
 func (d *Duchess) GetGameEndFlag() bool { return d.phase != DuchessPhasePlaying }
 
@@ -823,13 +820,7 @@ func (d *Duchess) takeSnapshot() {
 
 // appendLog 棋譜エントリを追加
 func (d *Duchess) appendLog(actionType, detail string, cards []*Card) {
-	d.actionLog = append(d.actionLog, &ActionLogEntry{
-		TurnNumber: d.moveCount,
-		PlayerIdx:  0,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	d.appendLogAt(d.moveCount, 0, actionType, detail, cards)
 }
 
 // duchessMaxSliceLen caps slice sizes during deserialisation.

--- a/internal/domain/Easthaven.go
+++ b/internal/domain/Easthaven.go
@@ -40,13 +40,13 @@ type EasthavenHint struct {
 
 // Easthaven イーストヘイブンゲームクラス
 type Easthaven struct {
-	trumpCards  *TrumpCards
-	tableau     [EasthavenTableauCnt][]*KlondikeTableauCard
-	stock       []*Card
-	foundation  [EasthavenFoundationCnt][]*Card
-	phase       EasthavenPhase
-	moveCount   int
-	actionLog   []*ActionLogEntry
+	trumpCards *TrumpCards
+	tableau    [EasthavenTableauCnt][]*KlondikeTableauCard
+	stock      []*Card
+	foundation [EasthavenFoundationCnt][]*Card
+	phase      EasthavenPhase
+	moveCount  int
+	actionLogBase
 	history     []*easthavenSnapshot
 	isStalemate bool
 }
@@ -384,9 +384,6 @@ func (e *Easthaven) GetTableau() [EasthavenTableauCnt][]*KlondikeTableauCard { r
 // GetFoundation ファンデーション取得
 func (e *Easthaven) GetFoundation() [EasthavenFoundationCnt][]*Card { return e.foundation }
 
-// GetActionLog 棋譜取得
-func (e *Easthaven) GetActionLog() []*ActionLogEntry { return e.actionLog }
-
 // GetGameEndFlag returns true once the game has left the playing phase.
 func (e *Easthaven) GetGameEndFlag() bool { return e.phase != EasthavenPhasePlaying }
 
@@ -596,13 +593,7 @@ func (e *Easthaven) restoreSnapshot(snap *easthavenSnapshot) {
 
 // appendLog 棋譜エントリを追加
 func (e *Easthaven) appendLog(actionType, detail string, cards []*Card) {
-	e.actionLog = append(e.actionLog, &ActionLogEntry{
-		TurnNumber: e.moveCount,
-		PlayerIdx:  0,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	e.appendLogAt(e.moveCount, 0, actionType, detail, cards)
 }
 
 // easthavenMaxSliceLen caps slice sizes during deserialisation.

--- a/internal/domain/EightOff.go
+++ b/internal/domain/EightOff.go
@@ -44,13 +44,13 @@ type EightOffHint struct {
 
 // EightOff エイトオフゲームクラス
 type EightOff struct {
-	trumpCards  *TrumpCards
-	tableau     [EightOffTableauCnt][]*Card
-	freeCells   [EightOffCellCnt]*Card
-	foundation  [EightOffFoundationCnt][]*Card
-	phase       EightOffPhase
-	moveCount   int
-	actionLog   []*ActionLogEntry
+	trumpCards *TrumpCards
+	tableau    [EightOffTableauCnt][]*Card
+	freeCells  [EightOffCellCnt]*Card
+	foundation [EightOffFoundationCnt][]*Card
+	phase      EightOffPhase
+	moveCount  int
+	actionLogBase
 	history     []*eightOffSnapshot
 	isStalemate bool
 }
@@ -517,9 +517,6 @@ func (e *EightOff) GetFreeCells() [EightOffCellCnt]*Card { return e.freeCells }
 // GetFoundation ファンデーション取得
 func (e *EightOff) GetFoundation() [EightOffFoundationCnt][]*Card { return e.foundation }
 
-// GetActionLog 棋譜取得
-func (e *EightOff) GetActionLog() []*ActionLogEntry { return e.actionLog }
-
 // GetGameEndFlag returns true once the game has left the playing phase.
 func (e *EightOff) GetGameEndFlag() bool { return e.phase != EightOffPhasePlaying }
 
@@ -646,13 +643,7 @@ func (e *EightOff) checkStalemate() {
 
 // appendLog 棋譜エントリを追加
 func (e *EightOff) appendLog(actionType, detail string, cards []*Card) {
-	e.actionLog = append(e.actionLog, &ActionLogEntry{
-		TurnNumber: e.moveCount,
-		PlayerIdx:  0,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	e.appendLogAt(e.moveCount, 0, actionType, detail, cards)
 }
 
 // eightOffJSON is the JSON wire format for EightOff.

--- a/internal/domain/FlowerGarden.go
+++ b/internal/domain/FlowerGarden.go
@@ -55,13 +55,13 @@ type FlowerGardenConfig struct{}
 
 // FlowerGarden ゲームクラス
 type FlowerGarden struct {
-	trumpCards  *TrumpCards
-	tableau     [FlowerGardenTableauCnt][]*FlowerGardenTableauCard
-	reserve     []*Card // 16 slots; nil entries mark depleted cells (one-way)
-	foundation  [FlowerGardenFoundationCnt][]*Card
-	phase       FlowerGardenPhase
-	moveCount   int
-	actionLog   []*ActionLogEntry
+	trumpCards *TrumpCards
+	tableau    [FlowerGardenTableauCnt][]*FlowerGardenTableauCard
+	reserve    []*Card // 16 slots; nil entries mark depleted cells (one-way)
+	foundation [FlowerGardenFoundationCnt][]*Card
+	phase      FlowerGardenPhase
+	moveCount  int
+	actionLogBase
 	history     []*flowerGardenSnapshot
 	isStalemate bool
 }
@@ -467,9 +467,6 @@ func (fg *FlowerGarden) GetFoundation() [FlowerGardenFoundationCnt][]*Card {
 	return fg.foundation
 }
 
-// GetActionLog 棋譜取得
-func (fg *FlowerGarden) GetActionLog() []*ActionLogEntry { return fg.actionLog }
-
 // GetGameEndFlag returns true once the game has left the playing phase.
 func (fg *FlowerGarden) GetGameEndFlag() bool { return fg.phase != FlowerGardenPhasePlaying }
 
@@ -626,13 +623,7 @@ func (fg *FlowerGarden) restoreSnapshot(snap *flowerGardenSnapshot) {
 
 // appendLog 棋譜エントリを追加
 func (fg *FlowerGarden) appendLog(actionType, detail string, cards []*Card) {
-	fg.actionLog = append(fg.actionLog, &ActionLogEntry{
-		TurnNumber: fg.moveCount,
-		PlayerIdx:  0,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	fg.appendLogAt(fg.moveCount, 0, actionType, detail, cards)
 }
 
 // flowerGardenJSON is the JSON wire format for FlowerGarden.

--- a/internal/domain/FortyAndEight.go
+++ b/internal/domain/FortyAndEight.go
@@ -47,14 +47,14 @@ type FortyAndEightConfig struct{}
 
 // FortyAndEight フォーティ・アンド・エイトゲームクラス
 type FortyAndEight struct {
-	trumpCards  *TrumpCards
-	tableau     [FortyAndEightTableauCnt][]*FortyAndEightTableauCard
-	stock       []*Card
-	waste       []*Card
-	foundation  [FortyAndEightFoundationCnt][]*Card
-	phase       FortyAndEightPhase
-	moveCount   int
-	actionLog   []*ActionLogEntry
+	trumpCards *TrumpCards
+	tableau    [FortyAndEightTableauCnt][]*FortyAndEightTableauCard
+	stock      []*Card
+	waste      []*Card
+	foundation [FortyAndEightFoundationCnt][]*Card
+	phase      FortyAndEightPhase
+	moveCount  int
+	actionLogBase
 	history     []*fortyAndEightSnapshot
 	isStalemate bool
 	redealUsed  bool
@@ -445,9 +445,6 @@ func (ft *FortyAndEight) GetTableau() [FortyAndEightTableauCnt][]*FortyAndEightT
 // GetFoundation ファンデーション取得
 func (ft *FortyAndEight) GetFoundation() [FortyAndEightFoundationCnt][]*Card { return ft.foundation }
 
-// GetActionLog 棋譜取得
-func (ft *FortyAndEight) GetActionLog() []*ActionLogEntry { return ft.actionLog }
-
 // GetGameEndFlag returns true once the game has left the playing phase.
 func (ft *FortyAndEight) GetGameEndFlag() bool { return ft.phase != FortyAndEightPhasePlaying }
 
@@ -644,13 +641,7 @@ func (ft *FortyAndEight) restoreSnapshot(snap *fortyAndEightSnapshot) {
 
 // appendLog 棋譜エントリを追加
 func (ft *FortyAndEight) appendLog(actionType, detail string, cards []*Card) {
-	ft.actionLog = append(ft.actionLog, &ActionLogEntry{
-		TurnNumber: ft.moveCount,
-		PlayerIdx:  0,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	ft.appendLogAt(ft.moveCount, 0, actionType, detail, cards)
 }
 
 // fortyAndEightJSON is the JSON wire format for FortyAndEight.

--- a/internal/domain/FortyThieves.go
+++ b/internal/domain/FortyThieves.go
@@ -47,14 +47,14 @@ type FortyThievesConfig struct{}
 
 // FortyThieves フォーティシーブスゲームクラス
 type FortyThieves struct {
-	trumpCards  *TrumpCards
-	tableau     [FortyThievesTableauCnt][]*FortyThievesTableauCard
-	stock       []*Card
-	waste       []*Card
-	foundation  [FortyThievesFoundationCnt][]*Card
-	phase       FortyThievesPhase
-	moveCount   int
-	actionLog   []*ActionLogEntry
+	trumpCards *TrumpCards
+	tableau    [FortyThievesTableauCnt][]*FortyThievesTableauCard
+	stock      []*Card
+	waste      []*Card
+	foundation [FortyThievesFoundationCnt][]*Card
+	phase      FortyThievesPhase
+	moveCount  int
+	actionLogBase
 	history     []*fortyThievesSnapshot
 	isStalemate bool
 }
@@ -413,9 +413,6 @@ func (ft *FortyThieves) GetTableau() [FortyThievesTableauCnt][]*FortyThievesTabl
 // GetFoundation ファンデーション取得
 func (ft *FortyThieves) GetFoundation() [FortyThievesFoundationCnt][]*Card { return ft.foundation }
 
-// GetActionLog 棋譜取得
-func (ft *FortyThieves) GetActionLog() []*ActionLogEntry { return ft.actionLog }
-
 // GetGameEndFlag returns true once the game has left the playing phase.
 func (ft *FortyThieves) GetGameEndFlag() bool { return ft.phase != FortyThievesPhasePlaying }
 
@@ -595,13 +592,7 @@ func (ft *FortyThieves) restoreSnapshot(snap *fortyThievesSnapshot) {
 
 // appendLog 棋譜エントリを追加
 func (ft *FortyThieves) appendLog(actionType, detail string, cards []*Card) {
-	ft.actionLog = append(ft.actionLog, &ActionLogEntry{
-		TurnNumber: ft.moveCount,
-		PlayerIdx:  0,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	ft.appendLogAt(ft.moveCount, 0, actionType, detail, cards)
 }
 
 // fortyThievesJSON is the JSON wire format for FortyThieves.

--- a/internal/domain/FreeCell.go
+++ b/internal/domain/FreeCell.go
@@ -41,13 +41,13 @@ type FreeCellHint struct {
 
 // FreeCell フリーセルゲームクラス
 type FreeCell struct {
-	trumpCards  *TrumpCards
-	tableau     [FreeCellTableauCnt][]*Card
-	freeCells   [FreeCellCellCnt]*Card
-	foundation  [FreeCellFoundationCnt][]*Card
-	phase       FreeCellPhase
-	moveCount   int
-	actionLog   []*ActionLogEntry
+	trumpCards *TrumpCards
+	tableau    [FreeCellTableauCnt][]*Card
+	freeCells  [FreeCellCellCnt]*Card
+	foundation [FreeCellFoundationCnt][]*Card
+	phase      FreeCellPhase
+	moveCount  int
+	actionLogBase
 	history     []*freeCellSnapshot
 	isStalemate bool
 	// sameSuit が true のときタブロー積み上げ条件を「同じスートの降順」にする
@@ -605,9 +605,6 @@ func (f *FreeCell) GetFreeCells() [FreeCellCellCnt]*Card { return f.freeCells }
 // GetFoundation ファンデーション取得
 func (f *FreeCell) GetFoundation() [FreeCellFoundationCnt][]*Card { return f.foundation }
 
-// GetActionLog 棋譜取得
-func (f *FreeCell) GetActionLog() []*ActionLogEntry { return f.actionLog }
-
 // GetGameEndFlag returns true once the game has left the playing phase.
 func (f *FreeCell) GetGameEndFlag() bool { return f.phase != FreeCellPhasePlaying }
 
@@ -776,13 +773,7 @@ func (f *FreeCell) checkStalemate() {
 
 // appendLog 棋譜エントリを追加
 func (f *FreeCell) appendLog(actionType, detail string, cards []*Card) {
-	f.actionLog = append(f.actionLog, &ActionLogEntry{
-		TurnNumber: f.moveCount,
-		PlayerIdx:  0,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	f.appendLogAt(f.moveCount, 0, actionType, detail, cards)
 }
 
 // freeCellJSON is the JSON wire format for FreeCell.

--- a/internal/domain/Gaps.go
+++ b/internal/domain/Gaps.go
@@ -54,7 +54,7 @@ type Gaps struct {
 	phase       GapsPhase
 	moveCount   int
 	redealsUsed int
-	actionLog   []*ActionLogEntry
+	actionLogBase
 	history     []*gapsSnapshot
 	isStalemate bool
 }
@@ -472,13 +472,7 @@ func (g *Gaps) restoreSnapshot(snap *gapsSnapshot) {
 
 // appendLog はアクションログにエントリを追加する。
 func (g *Gaps) appendLog(actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: g.moveCount,
-		PlayerIdx:  0,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	g.appendLogAt(g.moveCount, 0, actionType, detail, cards)
 }
 
 // --- Getters / setters ---
@@ -510,9 +504,6 @@ func (g *Gaps) SetRedealsUsed(n int) { g.redealsUsed = n }
 
 // GetRedealsRemaining は残りの再配り回数を返す。
 func (g *Gaps) GetRedealsRemaining() int { return GapsMaxRedeals - g.redealsUsed }
-
-// GetActionLog はアクションログを返す。
-func (g *Gaps) GetActionLog() []*ActionLogEntry { return g.actionLog }
 
 // GetGameEndFlag は終了状態かどうかを返す。
 func (g *Gaps) GetGameEndFlag() bool { return g.phase != GapsPhasePlaying }

--- a/internal/domain/Golf.go
+++ b/internal/domain/Golf.go
@@ -44,13 +44,13 @@ type GolfHint struct {
 
 // Golf ゴルフソリティアゲームクラス
 type Golf struct {
-	trumpCards  *TrumpCards
-	layout      [GolfColCnt][GolfRowCnt]*GolfCard
-	stock       []*Card
-	waste       []*Card
-	phase       GolfPhase
-	moveCount   int
-	actionLog   []*ActionLogEntry
+	trumpCards *TrumpCards
+	layout     [GolfColCnt][GolfRowCnt]*GolfCard
+	stock      []*Card
+	waste      []*Card
+	phase      GolfPhase
+	moveCount  int
+	actionLogBase
 	history     []*golfSnapshot
 	isStalemate bool
 }
@@ -275,9 +275,6 @@ func (g *Golf) GetLayout() [GolfColCnt][GolfRowCnt]*GolfCard {
 	return g.layout
 }
 
-// GetActionLog 棋譜取得
-func (g *Golf) GetActionLog() []*ActionLogEntry { return g.actionLog }
-
 // GetGameEndFlag returns true once the game has left the playing phase.
 func (g *Golf) GetGameEndFlag() bool { return g.phase != GolfPhasePlaying }
 
@@ -422,13 +419,7 @@ func (g *Golf) restoreSnapshot(snap *golfSnapshot) {
 
 // appendLog 棋譜エントリを追加
 func (g *Golf) appendLog(actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: g.moveCount,
-		PlayerIdx:  0,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	g.appendLogAt(g.moveCount, 0, actionType, detail, cards)
 }
 
 // golfJSON is the JSON wire format for Golf.

--- a/internal/domain/GrandfathersClock.go
+++ b/internal/domain/GrandfathersClock.go
@@ -89,12 +89,12 @@ type GrandfathersClockHint struct {
 // するランクに達したら完成で、それ以上は受け付けない。タブローはスートを無視
 // して降順に 1 枚ずつ動かせ、空き列には任意の札を置ける。
 type GrandfathersClock struct {
-	trumpCards  *TrumpCards
-	foundation  [GrandfathersClockFoundationCnt][]*Card
-	tableau     [GrandfathersClockTableauCnt][]*GrandfathersClockTableauCard
-	phase       GrandfathersClockPhase
-	moveCount   int
-	actionLog   []*ActionLogEntry
+	trumpCards *TrumpCards
+	foundation [GrandfathersClockFoundationCnt][]*Card
+	tableau    [GrandfathersClockTableauCnt][]*GrandfathersClockTableauCard
+	phase      GrandfathersClockPhase
+	moveCount  int
+	actionLogBase
 	history     []*grandfathersClockSnapshot
 	isStalemate bool
 }
@@ -380,9 +380,6 @@ func (gc *GrandfathersClock) GetTableau() [GrandfathersClockTableauCnt][]*Grandf
 	return gc.tableau
 }
 
-// GetActionLog 棋譜取得
-func (gc *GrandfathersClock) GetActionLog() []*ActionLogEntry { return gc.actionLog }
-
 // GetGameEndFlag ゲーム終了フラグ
 func (gc *GrandfathersClock) GetGameEndFlag() bool {
 	return gc.phase != GrandfathersClockPhasePlaying
@@ -528,13 +525,7 @@ func (gc *GrandfathersClock) takeSnapshot() {
 
 // appendLog 棋譜エントリを追加
 func (gc *GrandfathersClock) appendLog(actionType, detail string, cards []*Card) {
-	gc.actionLog = append(gc.actionLog, &ActionLogEntry{
-		TurnNumber: gc.moveCount,
-		PlayerIdx:  0,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	gc.appendLogAt(gc.moveCount, 0, actionType, detail, cards)
 }
 
 // grandfathersClockMaxSliceLen caps slice sizes during deserialisation.

--- a/internal/domain/KingAlbert.go
+++ b/internal/domain/KingAlbert.go
@@ -55,13 +55,13 @@ type KingAlbertConfig struct{}
 
 // KingAlbert ゲームクラス
 type KingAlbert struct {
-	trumpCards  *TrumpCards
-	tableau     [KingAlbertTableauCnt][]*KingAlbertTableauCard
-	reserve     []*Card // 7 slots; nil entries mark depleted cells (one-way)
-	foundation  [KingAlbertFoundationCnt][]*Card
-	phase       KingAlbertPhase
-	moveCount   int
-	actionLog   []*ActionLogEntry
+	trumpCards *TrumpCards
+	tableau    [KingAlbertTableauCnt][]*KingAlbertTableauCard
+	reserve    []*Card // 7 slots; nil entries mark depleted cells (one-way)
+	foundation [KingAlbertFoundationCnt][]*Card
+	phase      KingAlbertPhase
+	moveCount  int
+	actionLogBase
 	history     []*kingAlbertSnapshot
 	isStalemate bool
 }
@@ -467,9 +467,6 @@ func (ka *KingAlbert) GetFoundation() [KingAlbertFoundationCnt][]*Card {
 	return ka.foundation
 }
 
-// GetActionLog 棋譜取得
-func (ka *KingAlbert) GetActionLog() []*ActionLogEntry { return ka.actionLog }
-
 // GetGameEndFlag returns true once the game has left the playing phase.
 func (ka *KingAlbert) GetGameEndFlag() bool { return ka.phase != KingAlbertPhasePlaying }
 
@@ -636,13 +633,7 @@ func (ka *KingAlbert) restoreSnapshot(snap *kingAlbertSnapshot) {
 
 // appendLog 棋譜エントリを追加
 func (ka *KingAlbert) appendLog(actionType, detail string, cards []*Card) {
-	ka.actionLog = append(ka.actionLog, &ActionLogEntry{
-		TurnNumber: ka.moveCount,
-		PlayerIdx:  0,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	ka.appendLogAt(ka.moveCount, 0, actionType, detail, cards)
 }
 
 // kingAlbertJSON is the JSON wire format for KingAlbert.

--- a/internal/domain/Klondike.go
+++ b/internal/domain/Klondike.go
@@ -61,14 +61,14 @@ const (
 
 // Klondike クロンダイクゲームクラス
 type Klondike struct {
-	trumpCards           *TrumpCards
-	tableau              [KlondikeTableauCnt][]*KlondikeTableauCard
-	stock                []*Card
-	waste                []*Card
-	foundation           [KlondikeFoundationCnt][]*Card
-	phase                KlondikePhase
-	moveCount            int
-	actionLog            []*ActionLogEntry
+	trumpCards *TrumpCards
+	tableau    [KlondikeTableauCnt][]*KlondikeTableauCard
+	stock      []*Card
+	waste      []*Card
+	foundation [KlondikeFoundationCnt][]*Card
+	phase      KlondikePhase
+	moveCount  int
+	actionLogBase
 	drawCount            int
 	history              []*klondikeSnapshot
 	scoringMode          KlondikeScoringMode
@@ -526,9 +526,6 @@ func (k *Klondike) GetTableau() [KlondikeTableauCnt][]*KlondikeTableauCard { ret
 // GetFoundation ファンデーション取得
 func (k *Klondike) GetFoundation() [KlondikeFoundationCnt][]*Card { return k.foundation }
 
-// GetActionLog 棋譜取得
-func (k *Klondike) GetActionLog() []*ActionLogEntry { return k.actionLog }
-
 // GetGameEndFlag returns true once the game has left the playing phase.
 func (k *Klondike) GetGameEndFlag() bool { return k.phase != KlondikePhasePlaying }
 
@@ -716,13 +713,7 @@ func (k *Klondike) restoreSnapshot(snap *klondikeSnapshot) {
 
 // appendLog 棋譜エントリを追加
 func (k *Klondike) appendLog(actionType, detail string, cards []*Card) {
-	k.actionLog = append(k.actionLog, &ActionLogEntry{
-		TurnNumber: k.moveCount,
-		PlayerIdx:  0,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	k.appendLogAt(k.moveCount, 0, actionType, detail, cards)
 }
 
 // klondikeJSON is the JSON wire format for Klondike.

--- a/internal/domain/MissMilligan.go
+++ b/internal/domain/MissMilligan.go
@@ -70,14 +70,14 @@ type MissMilliganHint struct {
 // ミス・ミリガンに捨て札は無く、山札は 8 枚単位で配り足す。実際の規則を採った。
 // また issue が触れていない「空き列はキングのみ」も本来の規則なので実装している。
 type MissMilligan struct {
-	trumpCards  *TrumpCards
-	tableau     [MissMilliganTableauCnt][]*MissMilliganTableauCard
-	stock       []*Card
-	foundation  [MissMilliganFoundationCnt][]*Card
-	waived      []*Card
-	phase       MissMilliganPhase
-	moveCount   int
-	actionLog   []*ActionLogEntry
+	trumpCards *TrumpCards
+	tableau    [MissMilliganTableauCnt][]*MissMilliganTableauCard
+	stock      []*Card
+	foundation [MissMilliganFoundationCnt][]*Card
+	waived     []*Card
+	phase      MissMilliganPhase
+	moveCount  int
+	actionLogBase
 	history     []*missMilliganSnapshot
 	isStalemate bool
 }
@@ -524,9 +524,6 @@ func (mm *MissMilligan) GetTableau() [MissMilliganTableauCnt][]*MissMilliganTabl
 // GetFoundation 基礎札を取得
 func (mm *MissMilligan) GetFoundation() [MissMilliganFoundationCnt][]*Card { return mm.foundation }
 
-// GetActionLog 棋譜取得
-func (mm *MissMilligan) GetActionLog() []*ActionLogEntry { return mm.actionLog }
-
 // GetGameEndFlag ゲーム終了フラグ
 func (mm *MissMilligan) GetGameEndFlag() bool { return mm.phase != MissMilliganPhasePlaying }
 
@@ -688,13 +685,7 @@ func (mm *MissMilligan) takeSnapshot() {
 
 // appendLog 棋譜エントリを追加
 func (mm *MissMilligan) appendLog(actionType, detail string, cards []*Card) {
-	mm.actionLog = append(mm.actionLog, &ActionLogEntry{
-		TurnNumber: mm.moveCount,
-		PlayerIdx:  0,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	mm.appendLogAt(mm.moveCount, 0, actionType, detail, cards)
 }
 
 // missMilliganMaxSliceLen caps slice sizes during deserialisation.

--- a/internal/domain/NapoleonsSquare.go
+++ b/internal/domain/NapoleonsSquare.go
@@ -71,14 +71,14 @@ type NapoleonsSquareHint struct {
 // しているが 12×4 = 48 であって 96 ではない。列構成の方が実際のルールと一致する
 // ため、48 枚をタブローに配り残り 48 枚を山札としている。
 type NapoleonsSquare struct {
-	trumpCards  *TrumpCards
-	tableau     [NapoleonsSquareTableauCnt][]*NapoleonsSquareTableauCard
-	stock       []*Card
-	waste       []*Card
-	foundation  [NapoleonsSquareFoundationCnt][]*Card
-	phase       NapoleonsSquarePhase
-	moveCount   int
-	actionLog   []*ActionLogEntry
+	trumpCards *TrumpCards
+	tableau    [NapoleonsSquareTableauCnt][]*NapoleonsSquareTableauCard
+	stock      []*Card
+	waste      []*Card
+	foundation [NapoleonsSquareFoundationCnt][]*Card
+	phase      NapoleonsSquarePhase
+	moveCount  int
+	actionLogBase
 	history     []*napoleonsSquareSnapshot
 	isStalemate bool
 }
@@ -485,9 +485,6 @@ func (ns *NapoleonsSquare) GetFoundation() [NapoleonsSquareFoundationCnt][]*Card
 	return ns.foundation
 }
 
-// GetActionLog 棋譜取得
-func (ns *NapoleonsSquare) GetActionLog() []*ActionLogEntry { return ns.actionLog }
-
 // GetGameEndFlag ゲーム終了フラグ
 func (ns *NapoleonsSquare) GetGameEndFlag() bool { return ns.phase != NapoleonsSquarePhasePlaying }
 
@@ -609,13 +606,7 @@ func (ns *NapoleonsSquare) takeSnapshot() {
 
 // appendLog 棋譜エントリを追加
 func (ns *NapoleonsSquare) appendLog(actionType, detail string, cards []*Card) {
-	ns.actionLog = append(ns.actionLog, &ActionLogEntry{
-		TurnNumber: ns.moveCount,
-		PlayerIdx:  0,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	ns.appendLogAt(ns.moveCount, 0, actionType, detail, cards)
 }
 
 // napoleonsSquareMaxSliceLen caps slice sizes during deserialisation.

--- a/internal/domain/Osmosis.go
+++ b/internal/domain/Osmosis.go
@@ -53,8 +53,8 @@ type Osmosis struct {
 	baseRank   int
 	phase      OsmosisPhase
 	moveCount  int
-	actionLog  []*ActionLogEntry
-	history    []*osmosisSnapshot
+	actionLogBase
+	history []*osmosisSnapshot
 }
 
 // osmosisSnapshot アンドゥ用スナップショット
@@ -335,9 +335,6 @@ func (o *Osmosis) GetReserve() [OsmosisReserveCnt][]*Card { return o.reserve }
 // GetFoundation ファンデーション取得
 func (o *Osmosis) GetFoundation() [OsmosisFoundationCnt][]*Card { return o.foundation }
 
-// GetActionLog 棋譜取得
-func (o *Osmosis) GetActionLog() []*ActionLogEntry { return o.actionLog }
-
 // GetGameEndFlag returns true once the game has left the playing phase.
 func (o *Osmosis) GetGameEndFlag() bool { return o.phase != OsmosisPhasePlaying }
 
@@ -499,13 +496,7 @@ func (o *Osmosis) restoreSnapshot(snap *osmosisSnapshot) {
 }
 
 func (o *Osmosis) appendLog(actionType, detail string, cards []*Card) {
-	o.actionLog = append(o.actionLog, &ActionLogEntry{
-		TurnNumber: o.moveCount,
-		PlayerIdx:  0,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	o.appendLogAt(o.moveCount, 0, actionType, detail, cards)
 }
 
 // osmosisJSON is the JSON wire format for Osmosis.

--- a/internal/domain/Penguin.go
+++ b/internal/domain/Penguin.go
@@ -44,14 +44,14 @@ type PenguinHint struct {
 
 // Penguin ペンギンゲームクラス
 type Penguin struct {
-	trumpCards  *TrumpCards
-	tableau     [PenguinTableauCnt][]*Card
-	freeCells   [PenguinCellCnt]*Card
-	foundation  [PenguinFoundationCnt][]*Card
-	baseRank    int
-	phase       PenguinPhase
-	moveCount   int
-	actionLog   []*ActionLogEntry
+	trumpCards *TrumpCards
+	tableau    [PenguinTableauCnt][]*Card
+	freeCells  [PenguinCellCnt]*Card
+	foundation [PenguinFoundationCnt][]*Card
+	baseRank   int
+	phase      PenguinPhase
+	moveCount  int
+	actionLogBase
 	history     []*penguinSnapshot
 	isStalemate bool
 }
@@ -541,9 +541,6 @@ func (p *Penguin) GetBaseRank() int { return p.baseRank }
 // SetBaseRank ベースランク設定 (テスト用)
 func (p *Penguin) SetBaseRank(r int) { p.baseRank = r }
 
-// GetActionLog 棋譜取得
-func (p *Penguin) GetActionLog() []*ActionLogEntry { return p.actionLog }
-
 // GetGameEndFlag returns true once the game has left the playing phase.
 func (p *Penguin) GetGameEndFlag() bool { return p.phase != PenguinPhasePlaying }
 
@@ -698,13 +695,7 @@ func (p *Penguin) checkStalemate() {
 
 // appendLog 棋譜エントリを追加
 func (p *Penguin) appendLog(actionType, detail string, cards []*Card) {
-	p.actionLog = append(p.actionLog, &ActionLogEntry{
-		TurnNumber: p.moveCount,
-		PlayerIdx:  0,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	p.appendLogAt(p.moveCount, 0, actionType, detail, cards)
 }
 
 // penguinJSON is the JSON wire format for Penguin.

--- a/internal/domain/Pyramid.go
+++ b/internal/domain/Pyramid.go
@@ -47,13 +47,13 @@ type PyramidHint struct {
 
 // Pyramid ピラミッドソリティアゲームクラス
 type Pyramid struct {
-	trumpCards  *TrumpCards
-	pyramid     [PyramidRowCnt][]*PyramidCard
-	stock       []*Card
-	waste       []*Card
-	phase       PyramidPhase
-	moveCount   int
-	actionLog   []*ActionLogEntry
+	trumpCards *TrumpCards
+	pyramid    [PyramidRowCnt][]*PyramidCard
+	stock      []*Card
+	waste      []*Card
+	phase      PyramidPhase
+	moveCount  int
+	actionLogBase
 	history     []*pyramidSnapshot
 	isStalemate bool
 }
@@ -412,9 +412,6 @@ func (p *Pyramid) GetWaste() []*Card { return p.waste }
 // GetPyramid ピラミッド取得
 func (p *Pyramid) GetPyramid() [PyramidRowCnt][]*PyramidCard { return p.pyramid }
 
-// GetActionLog 棋譜取得
-func (p *Pyramid) GetActionLog() []*ActionLogEntry { return p.actionLog }
-
 // GetGameEndFlag returns true once the game has left the playing phase.
 func (p *Pyramid) GetGameEndFlag() bool { return p.phase != PyramidPhasePlaying }
 
@@ -554,13 +551,7 @@ func (p *Pyramid) restoreSnapshot(snap *pyramidSnapshot) {
 
 // appendLog 棋譜エントリを追加
 func (p *Pyramid) appendLog(actionType, detail string, cards []*Card) {
-	p.actionLog = append(p.actionLog, &ActionLogEntry{
-		TurnNumber: p.moveCount,
-		PlayerIdx:  0,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	p.appendLogAt(p.moveCount, 0, actionType, detail, cards)
 }
 
 // pyramidJSON is the JSON wire format for Pyramid.

--- a/internal/domain/RussianSolitaire.go
+++ b/internal/domain/RussianSolitaire.go
@@ -37,12 +37,12 @@ type RussianSolitaireHint struct {
 
 // RussianSolitaire ロシアンソリティアゲームクラス
 type RussianSolitaire struct {
-	trumpCards  *TrumpCards
-	tableau     [RussianSolitaireTableauCnt][]*KlondikeTableauCard
-	foundation  [RussianSolitaireFoundationCnt][]*Card
-	phase       RussianSolitairePhase
-	moveCount   int
-	actionLog   []*ActionLogEntry
+	trumpCards *TrumpCards
+	tableau    [RussianSolitaireTableauCnt][]*KlondikeTableauCard
+	foundation [RussianSolitaireFoundationCnt][]*Card
+	phase      RussianSolitairePhase
+	moveCount  int
+	actionLogBase
 	history     []*russianSolitaireSnapshot
 	isStalemate bool
 }
@@ -350,9 +350,6 @@ func (y *RussianSolitaire) GetFoundation() [RussianSolitaireFoundationCnt][]*Car
 	return y.foundation
 }
 
-// GetActionLog 棋譜取得
-func (y *RussianSolitaire) GetActionLog() []*ActionLogEntry { return y.actionLog }
-
 // GetGameEndFlag returns true once the game has left the playing phase.
 func (y *RussianSolitaire) GetGameEndFlag() bool { return y.phase != RussianSolitairePhasePlaying }
 
@@ -505,13 +502,7 @@ func (y *RussianSolitaire) restoreSnapshot(snap *russianSolitaireSnapshot) {
 
 // appendLog 棋譜エントリを追加
 func (y *RussianSolitaire) appendLog(actionType, detail string, cards []*Card) {
-	y.actionLog = append(y.actionLog, &ActionLogEntry{
-		TurnNumber: y.moveCount,
-		PlayerIdx:  0,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	y.appendLogAt(y.moveCount, 0, actionType, detail, cards)
 }
 
 // russianSolitaireJSON is the JSON wire format for RussianSolitaire.

--- a/internal/domain/Scorpion.go
+++ b/internal/domain/Scorpion.go
@@ -63,9 +63,9 @@ type Scorpion struct {
 	completedSuits int
 	phase          ScorpionPhase
 	moveCount      int
-	actionLog      []*ActionLogEntry
-	history        []*scorpionSnapshot
-	isStalemate    bool
+	actionLogBase
+	history     []*scorpionSnapshot
+	isStalemate bool
 }
 
 // scorpionSnapshot アンドゥ用スナップショット
@@ -394,9 +394,6 @@ func (s *Scorpion) GetTableau() [ScorpionTableauCnt][]*KlondikeTableauCard { ret
 // GetCompletedSuits 完成スート数取得
 func (s *Scorpion) GetCompletedSuits() int { return s.completedSuits }
 
-// GetActionLog 棋譜取得
-func (s *Scorpion) GetActionLog() []*ActionLogEntry { return s.actionLog }
-
 // GetGameEndFlag returns true once the game has left the playing phase.
 func (s *Scorpion) GetGameEndFlag() bool { return s.phase != ScorpionPhasePlaying }
 
@@ -524,13 +521,7 @@ func (s *Scorpion) restoreSnapshot(snap *scorpionSnapshot) {
 
 // appendLog 棋譜エントリを追加
 func (s *Scorpion) appendLog(actionType, detail string, cards []*Card) {
-	s.actionLog = append(s.actionLog, &ActionLogEntry{
-		TurnNumber: s.moveCount,
-		PlayerIdx:  0,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	s.appendLogAt(s.moveCount, 0, actionType, detail, cards)
 }
 
 // scorpionJSON is the JSON wire format for Scorpion.

--- a/internal/domain/SeahavenTowers.go
+++ b/internal/domain/SeahavenTowers.go
@@ -48,13 +48,13 @@ type SeahavenTowersHint struct {
 //   - 空列には King のみ置ける (FreeCell は任意のカードを置ける)
 //   - 配り: タブロー 10 列 × 5 枚 + 上部リザーブセル 2 枚 (合計 52 枚)
 type SeahavenTowers struct {
-	trumpCards  *TrumpCards
-	tableau     [SeahavenTowersTableauCnt][]*Card
-	freeCells   [SeahavenTowersCellCnt]*Card
-	foundation  [SeahavenTowersFoundationCnt][]*Card
-	phase       SeahavenTowersPhase
-	moveCount   int
-	actionLog   []*ActionLogEntry
+	trumpCards *TrumpCards
+	tableau    [SeahavenTowersTableauCnt][]*Card
+	freeCells  [SeahavenTowersCellCnt]*Card
+	foundation [SeahavenTowersFoundationCnt][]*Card
+	phase      SeahavenTowersPhase
+	moveCount  int
+	actionLogBase
 	history     []*seahavenTowersSnapshot
 	isStalemate bool
 }
@@ -512,9 +512,6 @@ func (s *SeahavenTowers) GetFreeCells() [SeahavenTowersCellCnt]*Card { return s.
 // GetFoundation ファンデーション取得
 func (s *SeahavenTowers) GetFoundation() [SeahavenTowersFoundationCnt][]*Card { return s.foundation }
 
-// GetActionLog 棋譜取得
-func (s *SeahavenTowers) GetActionLog() []*ActionLogEntry { return s.actionLog }
-
 // GetGameEndFlag returns true once the game has left the playing phase.
 func (s *SeahavenTowers) GetGameEndFlag() bool { return s.phase != SeahavenTowersPhasePlaying }
 
@@ -638,13 +635,7 @@ func (s *SeahavenTowers) checkStalemate() {
 
 // appendLog 棋譜エントリを追加
 func (s *SeahavenTowers) appendLog(actionType, detail string, cards []*Card) {
-	s.actionLog = append(s.actionLog, &ActionLogEntry{
-		TurnNumber: s.moveCount,
-		PlayerIdx:  0,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	s.appendLogAt(s.moveCount, 0, actionType, detail, cards)
 }
 
 // seahavenTowersJSON is the JSON wire format for SeahavenTowers.

--- a/internal/domain/SirTommy.go
+++ b/internal/domain/SirTommy.go
@@ -52,7 +52,7 @@ type SirTommy struct {
 	stock       []*Card
 	phase       SirTommyPhase
 	moveCount   int
-	actionLog   []*ActionLogEntry
+	actionLogBase
 	history     []*sirTommySnapshot
 	isStalemate bool
 }
@@ -305,9 +305,6 @@ func (s *SirTommy) GetWastes() [SirTommyWasteCnt][]*Card { return s.wastes }
 // GetFoundations ファンデーション取得
 func (s *SirTommy) GetFoundations() [SirTommyFoundationCnt][]*Card { return s.foundations }
 
-// GetActionLog 棋譜取得
-func (s *SirTommy) GetActionLog() []*ActionLogEntry { return s.actionLog }
-
 // GetGameEndFlag ゲーム終了フラグ
 func (s *SirTommy) GetGameEndFlag() bool { return s.phase != SirTommyPhasePlaying }
 
@@ -402,13 +399,7 @@ func (s *SirTommy) restoreSnapshot(snap *sirTommySnapshot) {
 
 // appendLog 棋譜エントリを追加
 func (s *SirTommy) appendLog(actionType, detail string, cards []*Card) {
-	s.actionLog = append(s.actionLog, &ActionLogEntry{
-		TurnNumber: s.moveCount,
-		PlayerIdx:  0,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	s.appendLogAt(s.moveCount, 0, actionType, detail, cards)
 }
 
 // sirTommyMaxSliceLen caps slice sizes during deserialisation.

--- a/internal/domain/Spider.go
+++ b/internal/domain/Spider.go
@@ -52,10 +52,10 @@ type Spider struct {
 	phase          SpiderPhase
 	moveCount      int
 	score          int
-	actionLog      []*ActionLogEntry
-	history        []*spiderSnapshot
-	difficulty     SpiderDifficulty
-	isStalemate    bool
+	actionLogBase
+	history     []*spiderSnapshot
+	difficulty  SpiderDifficulty
+	isStalemate bool
 }
 
 // spiderSnapshot アンドゥ用スナップショット
@@ -412,9 +412,6 @@ func (s *Spider) GetTableau() [SpiderTableauCnt][]*SpiderTableauCard { return s.
 // GetCompletedSuits 完成スート数取得
 func (s *Spider) GetCompletedSuits() int { return s.completedSuits }
 
-// GetActionLog 棋譜取得
-func (s *Spider) GetActionLog() []*ActionLogEntry { return s.actionLog }
-
 // GetGameEndFlag returns true once the game has left the playing phase.
 func (s *Spider) GetGameEndFlag() bool { return s.phase != SpiderPhasePlaying }
 
@@ -603,13 +600,7 @@ func (s *Spider) restoreSnapshot(snap *spiderSnapshot) {
 
 // appendLog 棋譜エントリを追加
 func (s *Spider) appendLog(actionType, detail string, cards []*Card) {
-	s.actionLog = append(s.actionLog, &ActionLogEntry{
-		TurnNumber: s.moveCount,
-		PlayerIdx:  0,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	s.appendLogAt(s.moveCount, 0, actionType, detail, cards)
 }
 
 // spiderJSON is the JSON wire format for Spider.

--- a/internal/domain/Spiderette.go
+++ b/internal/domain/Spiderette.go
@@ -56,9 +56,9 @@ type Spiderette struct {
 	phase          SpiderettePhase
 	moveCount      int
 	score          int
-	actionLog      []*ActionLogEntry
-	history        []*spideretteSnapshot
-	isStalemate    bool
+	actionLogBase
+	history     []*spideretteSnapshot
+	isStalemate bool
 }
 
 // spideretteSnapshot アンドゥ用スナップショット
@@ -388,9 +388,6 @@ func (s *Spiderette) GetTableau() [SpideretteTableauCnt][]*SpideretteTableauCard
 // GetCompletedSuits 完成スート数取得
 func (s *Spiderette) GetCompletedSuits() int { return s.completedSuits }
 
-// GetActionLog 棋譜取得
-func (s *Spiderette) GetActionLog() []*ActionLogEntry { return s.actionLog }
-
 // GetGameEndFlag returns true once the game has left the playing phase.
 func (s *Spiderette) GetGameEndFlag() bool { return s.phase != SpiderettePhasePlaying }
 
@@ -566,13 +563,7 @@ func (s *Spiderette) restoreSnapshot(snap *spideretteSnapshot) {
 
 // appendLog 棋譜エントリを追加
 func (s *Spiderette) appendLog(actionType, detail string, cards []*Card) {
-	s.actionLog = append(s.actionLog, &ActionLogEntry{
-		TurnNumber: s.moveCount,
-		PlayerIdx:  0,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	s.appendLogAt(s.moveCount, 0, actionType, detail, cards)
 }
 
 // spideretteJSON is the JSON wire format for Spiderette.

--- a/internal/domain/StreetsAndAlleys.go
+++ b/internal/domain/StreetsAndAlleys.go
@@ -63,12 +63,12 @@ type StreetsAndAlleysConfig struct{}
 
 // StreetsAndAlleys ゲームクラス
 type StreetsAndAlleys struct {
-	trumpCards  *TrumpCards
-	tableau     [StreetsAndAlleysTableauCnt][]*StreetsAndAlleysTableauCard
-	foundation  [StreetsAndAlleysFoundationCnt][]*Card
-	phase       StreetsAndAlleysPhase
-	moveCount   int
-	actionLog   []*ActionLogEntry
+	trumpCards *TrumpCards
+	tableau    [StreetsAndAlleysTableauCnt][]*StreetsAndAlleysTableauCard
+	foundation [StreetsAndAlleysFoundationCnt][]*Card
+	phase      StreetsAndAlleysPhase
+	moveCount  int
+	actionLogBase
 	history     []*streetsAndAlleysSnapshot
 	isStalemate bool
 }
@@ -313,9 +313,6 @@ func (sa *StreetsAndAlleys) GetFoundation() [StreetsAndAlleysFoundationCnt][]*Ca
 	return sa.foundation
 }
 
-// GetActionLog 棋譜取得
-func (sa *StreetsAndAlleys) GetActionLog() []*ActionLogEntry { return sa.actionLog }
-
 // GetGameEndFlag returns true once the game has left the playing phase.
 func (sa *StreetsAndAlleys) GetGameEndFlag() bool { return sa.phase != StreetsAndAlleysPhasePlaying }
 
@@ -466,13 +463,7 @@ func (sa *StreetsAndAlleys) restoreSnapshot(snap *streetsAndAlleysSnapshot) {
 
 // appendLog 棋譜エントリを追加
 func (sa *StreetsAndAlleys) appendLog(actionType, detail string, cards []*Card) {
-	sa.actionLog = append(sa.actionLog, &ActionLogEntry{
-		TurnNumber: sa.moveCount,
-		PlayerIdx:  0,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	sa.appendLogAt(sa.moveCount, 0, actionType, detail, cards)
 }
 
 // streetsAndAlleysJSON is the JSON wire format for StreetsAndAlleys.

--- a/internal/domain/Sultan.go
+++ b/internal/domain/Sultan.go
@@ -48,14 +48,14 @@ type SultanConfig struct{}
 
 // Sultan スルタンゲームクラス
 type Sultan struct {
-	trumpCards  *TrumpCards
-	foundation  [SultanFoundationCnt][]*Card
-	divan       []*Card // 8 スロット。プレイ済みでストックが空のスロットは nil。
-	stock       []*Card
-	waste       []*Card
-	phase       SultanPhase
-	moveCount   int
-	actionLog   []*ActionLogEntry
+	trumpCards *TrumpCards
+	foundation [SultanFoundationCnt][]*Card
+	divan      []*Card // 8 スロット。プレイ済みでストックが空のスロットは nil。
+	stock      []*Card
+	waste      []*Card
+	phase      SultanPhase
+	moveCount  int
+	actionLogBase
 	history     []*sultanSnapshot
 	isStalemate bool
 	redealCount int
@@ -338,9 +338,6 @@ func (su *Sultan) GetDivan() []*Card { return su.divan }
 // GetFoundation ファンデーション取得
 func (su *Sultan) GetFoundation() [SultanFoundationCnt][]*Card { return su.foundation }
 
-// GetActionLog 棋譜取得
-func (su *Sultan) GetActionLog() []*ActionLogEntry { return su.actionLog }
-
 // GetGameEndFlag returns true once the game has left the playing phase.
 func (su *Sultan) GetGameEndFlag() bool { return su.phase != SultanPhasePlaying }
 
@@ -523,13 +520,7 @@ func (su *Sultan) restoreSnapshot(snap *sultanSnapshot) {
 
 // appendLog 棋譜エントリを追加
 func (su *Sultan) appendLog(actionType, detail string, cards []*Card) {
-	su.actionLog = append(su.actionLog, &ActionLogEntry{
-		TurnNumber: su.moveCount,
-		PlayerIdx:  0,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	su.appendLogAt(su.moveCount, 0, actionType, detail, cards)
 }
 
 // sultanJSON is the JSON wire format for Sultan.

--- a/internal/domain/Terrace.go
+++ b/internal/domain/Terrace.go
@@ -77,16 +77,16 @@ type TerraceHint struct {
 //     テラスは減る一方で補充されない
 //   - タブローは 9 山（issue は数に触れていない）
 type Terrace struct {
-	trumpCards  *TrumpCards
-	reserve     []*Card
-	tableau     [TerraceTableauCnt][]*Card
-	foundation  [TerraceFoundationCnt][]*Card
-	stock       []*Card
-	waste       []*Card
-	baseRank    int
-	phase       TerracePhase
-	moveCount   int
-	actionLog   []*ActionLogEntry
+	trumpCards *TrumpCards
+	reserve    []*Card
+	tableau    [TerraceTableauCnt][]*Card
+	foundation [TerraceFoundationCnt][]*Card
+	stock      []*Card
+	waste      []*Card
+	baseRank   int
+	phase      TerracePhase
+	moveCount  int
+	actionLogBase
 	history     []*terraceSnapshot
 	isStalemate bool
 }
@@ -497,9 +497,6 @@ func (t *Terrace) GetTableau() [TerraceTableauCnt][]*Card { return t.tableau }
 // GetFoundation 基礎札を取得
 func (t *Terrace) GetFoundation() [TerraceFoundationCnt][]*Card { return t.foundation }
 
-// GetActionLog 棋譜取得
-func (t *Terrace) GetActionLog() []*ActionLogEntry { return t.actionLog }
-
 // GetGameEndFlag ゲーム終了フラグ
 func (t *Terrace) GetGameEndFlag() bool { return t.phase != TerracePhasePlaying }
 
@@ -721,13 +718,7 @@ func (t *Terrace) takeSnapshot() {
 
 // appendLog 棋譜エントリを追加
 func (t *Terrace) appendLog(actionType, detail string, cards []*Card) {
-	t.actionLog = append(t.actionLog, &ActionLogEntry{
-		TurnNumber: t.moveCount,
-		PlayerIdx:  0,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	t.appendLogAt(t.moveCount, 0, actionType, detail, cards)
 }
 
 // terraceSnapshotJSON is the wire format for a single undo snapshot.

--- a/internal/domain/TriPeaks.go
+++ b/internal/domain/TriPeaks.go
@@ -45,13 +45,13 @@ type TriPeaksHint struct {
 
 // TriPeaks トリピークスソリティアゲームクラス
 type TriPeaks struct {
-	trumpCards  *TrumpCards
-	layout      [TriPeaksRowCnt][TriPeaksColCnt]*TriPeaksCard
-	stock       []*Card
-	waste       []*Card
-	phase       TriPeaksPhase
-	moveCount   int
-	actionLog   []*ActionLogEntry
+	trumpCards *TrumpCards
+	layout     [TriPeaksRowCnt][TriPeaksColCnt]*TriPeaksCard
+	stock      []*Card
+	waste      []*Card
+	phase      TriPeaksPhase
+	moveCount  int
+	actionLogBase
 	history     []*triPeaksSnapshot
 	isStalemate bool
 }
@@ -334,9 +334,6 @@ func (t *TriPeaks) GetLayout() [TriPeaksRowCnt][TriPeaksColCnt]*TriPeaksCard {
 	return t.layout
 }
 
-// GetActionLog 棋譜取得
-func (t *TriPeaks) GetActionLog() []*ActionLogEntry { return t.actionLog }
-
 // GetGameEndFlag returns true once the game has left the playing phase.
 func (t *TriPeaks) GetGameEndFlag() bool { return t.phase != TriPeaksPhasePlaying }
 
@@ -495,13 +492,7 @@ func (t *TriPeaks) restoreSnapshot(snap *triPeaksSnapshot) {
 
 // appendLog 棋譜エントリを追加
 func (t *TriPeaks) appendLog(actionType, detail string, cards []*Card) {
-	t.actionLog = append(t.actionLog, &ActionLogEntry{
-		TurnNumber: t.moveCount,
-		PlayerIdx:  0,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	t.appendLogAt(t.moveCount, 0, actionType, detail, cards)
 }
 
 // triPeaksJSON is the JSON wire format for TriPeaks.

--- a/internal/domain/Wasp.go
+++ b/internal/domain/Wasp.go
@@ -63,9 +63,9 @@ type Wasp struct {
 	completedSuits int
 	phase          WaspPhase
 	moveCount      int
-	actionLog      []*ActionLogEntry
-	history        []*waspSnapshot
-	isStalemate    bool
+	actionLogBase
+	history     []*waspSnapshot
+	isStalemate bool
 }
 
 // waspSnapshot アンドゥ用スナップショット
@@ -394,9 +394,6 @@ func (s *Wasp) GetTableau() [WaspTableauCnt][]*KlondikeTableauCard { return s.ta
 // GetCompletedSuits 完成スート数取得
 func (s *Wasp) GetCompletedSuits() int { return s.completedSuits }
 
-// GetActionLog 棋譜取得
-func (s *Wasp) GetActionLog() []*ActionLogEntry { return s.actionLog }
-
 // GetGameEndFlag returns true once the game has left the playing phase.
 func (s *Wasp) GetGameEndFlag() bool { return s.phase != WaspPhasePlaying }
 
@@ -525,13 +522,7 @@ func (s *Wasp) restoreSnapshot(snap *waspSnapshot) {
 
 // appendLog 棋譜エントリを追加
 func (s *Wasp) appendLog(actionType, detail string, cards []*Card) {
-	s.actionLog = append(s.actionLog, &ActionLogEntry{
-		TurnNumber: s.moveCount,
-		PlayerIdx:  0,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	s.appendLogAt(s.moveCount, 0, actionType, detail, cards)
 }
 
 // waspJSON is the JSON wire format for Wasp.

--- a/internal/domain/Windmill.go
+++ b/internal/domain/Windmill.go
@@ -82,9 +82,9 @@ type Windmill struct {
 	transferBlocked bool
 	phase           WindmillPhase
 	moveCount       int
-	actionLog       []*ActionLogEntry
-	history         []*windmillSnapshot
-	isStalemate     bool
+	actionLogBase
+	history     []*windmillSnapshot
+	isStalemate bool
 }
 
 // windmillSnapshot アンドゥ用スナップショット
@@ -466,9 +466,6 @@ func (w *Windmill) GetCorners() [WindmillCornerCnt][]*Card { return w.corners }
 // 直前にその手を打った直後だけ真になる。
 func (w *Windmill) IsTransferBlocked() bool { return w.transferBlocked }
 
-// GetActionLog 棋譜取得
-func (w *Windmill) GetActionLog() []*ActionLogEntry { return w.actionLog }
-
 // GetGameEndFlag ゲーム終了フラグ
 func (w *Windmill) GetGameEndFlag() bool { return w.phase != WindmillPhasePlaying }
 
@@ -643,13 +640,7 @@ func (w *Windmill) takeSnapshot() {
 
 // appendLog 棋譜エントリを追加
 func (w *Windmill) appendLog(actionType, detail string, cards []*Card) {
-	w.actionLog = append(w.actionLog, &ActionLogEntry{
-		TurnNumber: w.moveCount,
-		PlayerIdx:  0,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	w.appendLogAt(w.moveCount, 0, actionType, detail, cards)
 }
 
 // windmillMaxSliceLen caps slice sizes during deserialisation.

--- a/internal/domain/Yukon.go
+++ b/internal/domain/Yukon.go
@@ -37,12 +37,12 @@ type YukonHint struct {
 
 // Yukon ユーコンゲームクラス
 type Yukon struct {
-	trumpCards  *TrumpCards
-	tableau     [YukonTableauCnt][]*KlondikeTableauCard
-	foundation  [YukonFoundationCnt][]*Card
-	phase       YukonPhase
-	moveCount   int
-	actionLog   []*ActionLogEntry
+	trumpCards *TrumpCards
+	tableau    [YukonTableauCnt][]*KlondikeTableauCard
+	foundation [YukonFoundationCnt][]*Card
+	phase      YukonPhase
+	moveCount  int
+	actionLogBase
 	history     []*yukonSnapshot
 	isStalemate bool
 }
@@ -346,9 +346,6 @@ func (y *Yukon) GetTableau() [YukonTableauCnt][]*KlondikeTableauCard { return y.
 // GetFoundation ファンデーション取得
 func (y *Yukon) GetFoundation() [YukonFoundationCnt][]*Card { return y.foundation }
 
-// GetActionLog 棋譜取得
-func (y *Yukon) GetActionLog() []*ActionLogEntry { return y.actionLog }
-
 // GetGameEndFlag returns true once the game has left the playing phase.
 func (y *Yukon) GetGameEndFlag() bool { return y.phase != YukonPhasePlaying }
 
@@ -511,13 +508,7 @@ func (y *Yukon) restoreSnapshot(snap *yukonSnapshot) {
 
 // appendLog 棋譜エントリを追加
 func (y *Yukon) appendLog(actionType, detail string, cards []*Card) {
-	y.actionLog = append(y.actionLog, &ActionLogEntry{
-		TurnNumber: y.moveCount,
-		PlayerIdx:  0,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	y.appendLogAt(y.moveCount, 0, actionType, detail, cards)
 }
 
 // yukonJSON is the JSON wire format for Yukon.

--- a/internal/domain/action_log_base.go
+++ b/internal/domain/action_log_base.go
@@ -12,9 +12,12 @@ package domain
 // persisted to KV for the Cloudflare Workers, and a codec change there would
 // silently drop history rather than fail loudly.
 //
-// This base carries the numbered variant, where TurnNumber counts entries.
-// Solitaire games number their entries by move count instead and keep their own
-// appendLog for now; collapsing those needs a different base, not this one.
+// Two numbering schemes share this one base. `appendLog` numbers by entry
+// count, which is what most games want and what they get through promotion.
+// The solitaires number by move count instead, so they define their own
+// 3-arg `appendLog` — which shadows the promoted one by name — and delegate to
+// `appendLogAt`, supplying the number themselves. Neither scheme can drift into
+// the other: they are pinned by separate tests.
 type actionLogBase struct {
 	actionLog []*ActionLogEntry
 }

--- a/internal/domain/action_log_base.go
+++ b/internal/domain/action_log_base.go
@@ -25,8 +25,16 @@ func (b *actionLogBase) GetActionLog() []*ActionLogEntry { return b.actionLog }
 // appendLog records one action. TurnNumber is assigned from the number of
 // entries already present, so the first entry is turn 1.
 func (b *actionLogBase) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
+	b.appendLogAt(len(b.actionLog)+1, playerIdx, actionType, detail, cards)
+}
+
+// appendLogAt records one action under a caller-supplied turn number, for games
+// that number entries by something other than the entry count. The solitaires
+// number by move count, which lives on the game struct and so is not visible
+// from here — they pass it in rather than each keeping a copy of this body.
+func (b *actionLogBase) appendLogAt(turnNumber, playerIdx int, actionType, detail string, cards []*Card) {
 	b.actionLog = append(b.actionLog, &ActionLogEntry{
-		TurnNumber: len(b.actionLog) + 1,
+		TurnNumber: turnNumber,
 		PlayerIdx:  playerIdx,
 		ActionType: actionType,
 		Detail:     detail,

--- a/internal/domain/action_log_base_test.go
+++ b/internal/domain/action_log_base_test.go
@@ -50,3 +50,34 @@ func TestActionLogBase_PromotedFieldStaysAssignable(t *testing.T) {
 	g.appendLog(1, "c", "d", nil)
 	assert.Equal(t, 1, g.GetActionLog()[0].TurnNumber, "numbering restarts after a clear")
 }
+
+// appendLogAt is what lets the solitaires share this base: they number entries
+// by move count, not by how many entries exist, so the turn number has to come
+// from the caller. Pinning it separately from appendLog because the two now
+// share a body and a regression in the shared half would be easy to miss.
+func TestActionLogBase_AppendLogAtUsesCallerTurnNumber(t *testing.T) {
+	var b actionLogBase
+
+	b.appendLogAt(7, 0, "move", "t1->f0", nil)
+	b.appendLogAt(7, 0, "move", "same turn again", nil)
+	b.appendLogAt(9, 3, "draw", "later", nil)
+
+	got := b.GetActionLog()
+	assert.Len(t, got, 3)
+	assert.Equal(t, 7, got[0].TurnNumber)
+	assert.Equal(t, 7, got[1].TurnNumber, "the caller's number is used verbatim, not incremented")
+	assert.Equal(t, 9, got[2].TurnNumber, "gaps are preserved")
+	assert.Equal(t, 3, got[2].PlayerIdx)
+}
+
+// appendLog must keep numbering from the entry count even though it now
+// delegates -- that is the contract the 122 phase-1 games depend on.
+func TestActionLogBase_AppendLogStillNumbersByCount(t *testing.T) {
+	var b actionLogBase
+	b.appendLogAt(99, 0, "seed", "", nil)
+	b.appendLog(0, "next", "", nil)
+
+	got := b.GetActionLog()
+	assert.Equal(t, 99, got[0].TurnNumber)
+	assert.Equal(t, 2, got[1].TurnNumber, "appendLog counts entries, ignoring the seeded number")
+}


### PR DESCRIPTION
## 概要

[#5185](https://github.com/yuta-yoshinaga/go_trumpcards/issues/5185) のフェーズ2です。[#5197](https://github.com/yuta-yoshinaga/go_trumpcards/pull/5197)（122ゲーム・1,683行）で対象外にしたソリティア系44ゲームを、同じ埋め込みベースに載せます。

**396行削除**（302追加 / 698削除）。

## なぜフェーズ1に含められなかったか

ソリティアの `appendLog` は **`TurnNumber` に `moveCount` を使います**。

```go
func (a *Agnes) appendLog(actionType, detail string, cards []*Card) {
	a.actionLog = append(a.actionLog, &ActionLogEntry{
		TurnNumber: a.moveCount,   // ← エントリ数ではなく手数
		PlayerIdx:  0,
		…
	})
}
```

`moveCount` はゲーム構造体側にあり**ベースからは見えない**ため、フェーズ1の `appendLog`（`len(actionLog)+1` で採番）には載せられませんでした。

## 対応: `appendLogAt` を足して番号を渡す

```go
func (b *actionLogBase) appendLogAt(turnNumber, playerIdx int, actionType, detail string, cards []*Card)
```

各ゲームの `appendLog` は**1行の委譲**になります。

```go
func (a *Agnes) appendLog(actionType, detail string, cards []*Card) {
	a.appendLogAt(a.moveCount, 0, actionType, detail, cards)
}
```

**採番は一切変わりません。** 各ゲームが従来どおり自分の `moveCount` と `PlayerIdx: 0` を渡すためです。エントリ数ベースのベースに強引に寄せると**全ソリティアのログ番号が静かに変わってしまう**ので、そうせず引数で受け取る形にしています。

既存の `appendLog`（4引数）も `appendLogAt` に委譲するようにしましたが、**エントリ数採番の契約は維持**しています（#5197 の122ゲームが依存）。両者は本体を共有することになったので、**それぞれ別テストで固定**しました。

## 対象を44件に絞っています

3引数 `appendLog` は全59件ありますが、**ボディが完全一致する44件のみ**が対象です。残り15件は書式差ではなく実質的に違います。

- 4件: 引数名が `action`（`actionType` ではない）
- 2件: `PlayerIdx` に `R.current` を使う
- ほか9件: それぞれ別ボディ

これらは別途対応します。

## テスト計画

- [x] `appendLogAt` が**呼び出し側の番号をそのまま使う**こと（インクリメントしない・番号の飛びを保つ）
- [x] `appendLog` が**委譲後もエントリ数で採番する**こと（seed した番号を無視する負のコントロール付き）
- [x] 1ゲーム（Agnes）を手で変換して検証してからスクリプト化
- [x] `go build ./...` / `gofmt -l` クリーン
- [x] `go test -tags test ./internal/domain/... ./internal/usecase/...` 通過（domain 44.0s）
- [x] `golangci-lint run ./internal/domain/...` → 0 issues

## サイズについて（先に申し添えます）

[#5197 で実測したとおり](https://github.com/yuta-yoshinaga/go_trumpcards/pull/5197#issuecomment-5225811081)、**重複削減による gzip 削減はほぼゼロ**です（1,683行削除で全worker合計 -3,671バイト、うち extra3 は逆に +213）。本 PR も同様に横ばいの見込みで、**効用は保守性のみ**です。サイズを根拠には挙げません。

Refs #5185