### PR TITLE
refactor(domain): embed actionLogBase in the 30 nested-state games

### DIFF
--- a/internal/domain/Anaconda.go
+++ b/internal/domain/Anaconda.go
@@ -145,7 +145,7 @@ type anacondaState struct {
 	result          AnacondaResult
 	gameEndFlag     bool
 	scored          bool // ラウンド結果を確定済みか (二重確定防止)
-	actionLog       []*ActionLogEntry
+	actionLogBase
 }
 
 // Anaconda はアナコンダの状態を保持する集約ルート。
@@ -166,7 +166,7 @@ func NewAnaconda(trumpCards *TrumpCards, players []*AnacondaPlayer, config Anaco
 			phase:          AnacondaPhasePass,
 			winnerIdx:      -1,
 			matchWinnerIdx: -1,
-			actionLog:      make([]*ActionLogEntry, 0),
+			actionLogBase:  actionLogBase{actionLog: make([]*ActionLogEntry, 0)},
 		},
 	}
 }
@@ -200,7 +200,7 @@ func (g *Anaconda) Reset() {
 		dealerIdx:      0,
 		winnerIdx:      -1,
 		matchWinnerIdx: -1,
-		actionLog:      make([]*ActionLogEntry, 0),
+		actionLogBase:  actionLogBase{actionLog: make([]*ActionLogEntry, 0)},
 	}
 	g.startRound()
 }
@@ -919,13 +919,7 @@ func anacondaValidateIndices(indices []int, want, handSize int) error {
 }
 
 func (g *Anaconda) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.state.actionLog = append(g.state.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.state.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	g.state.appendLog(playerIdx, actionType, detail, cards)
 }
 
 // --- 公開カード ---
@@ -1290,7 +1284,7 @@ func (g *Anaconda) UnmarshalJSON(data []byte) error {
 		result:          j.Result,
 		gameEndFlag:     j.GameEndFlag,
 		scored:          j.Scored,
-		actionLog:       j.ActionLog,
+		actionLogBase:   actionLogBase{actionLog: j.ActionLog},
 	}
 	if g.state.actionLog == nil {
 		g.state.actionLog = make([]*ActionLogEntry, 0)

--- a/internal/domain/Badugi.go
+++ b/internal/domain/Badugi.go
@@ -65,20 +65,20 @@ type BadugiCpuExchange struct {
 // badugiRoundState holds the mutable per-hand state. Kept separate so Reset
 // can recreate it cleanly without touching config / players.
 type badugiRoundState struct {
-	phase           int
-	drawIndex       int // 0 during initial deal bet, 1..3 during/after the n-th draw
-	pot             int
-	currentTurn     int
-	lastBet         int
-	minRaise        int
-	raiseCount      int
-	actedFlags      []bool
-	sidePots        []SidePot
-	startingChips   []int
-	roundResults    []BadugiResult
-	cpuActions      []BadugiCpuAction
-	cpuExchanges    []BadugiCpuExchange
-	actionLog       []*ActionLogEntry
+	phase         int
+	drawIndex     int // 0 during initial deal bet, 1..3 during/after the n-th draw
+	pot           int
+	currentTurn   int
+	lastBet       int
+	minRaise      int
+	raiseCount    int
+	actedFlags    []bool
+	sidePots      []SidePot
+	startingChips []int
+	roundResults  []BadugiResult
+	cpuActions    []BadugiCpuAction
+	cpuExchanges  []BadugiCpuExchange
+	actionLogBase
 	gameEndFlag     bool
 	lastCpuError    error
 	lastHumanPlayMs int
@@ -895,13 +895,7 @@ func (b *Badugi) ImportProfile(data []byte) error {
 func (b *Badugi) GetActionLog() []*ActionLogEntry { return b.round.actionLog }
 
 func (b *Badugi) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	b.round.actionLog = append(b.round.actionLog, &ActionLogEntry{
-		TurnNumber: len(b.round.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	b.round.appendLog(playerIdx, actionType, detail, cards)
 }
 
 func (b *Badugi) logBettingAction(playerIdx, action, _ int) {
@@ -1039,7 +1033,7 @@ func (b *Badugi) UnmarshalJSON(data []byte) error {
 		roundResults:    j.Round.RoundResults,
 		cpuActions:      j.Round.CpuActions,
 		cpuExchanges:    j.Round.CpuExchanges,
-		actionLog:       j.Round.ActionLog,
+		actionLogBase:   actionLogBase{actionLog: j.Round.ActionLog},
 		gameEndFlag:     j.Round.GameEndFlag,
 		lastHumanPlayMs: j.Round.LastHumanPlayMs,
 	}

--- a/internal/domain/Basra.go
+++ b/internal/domain/Basra.go
@@ -117,7 +117,7 @@ type basraState struct {
 	scored         bool // 最終得点を確定済みか (二重確定防止)
 	winners        []int
 	lastDealDetail *BasraScoreDetail
-	actionLog      []*ActionLogEntry
+	actionLogBase
 }
 
 // Basra はバスラゲームの状態を保持する集約ルート。
@@ -175,7 +175,7 @@ func (g *Basra) Reset() {
 		phase:          BasraPhasePlay,
 		currentTurn:    0,
 		lastCaptureIdx: -1,
-		actionLog:      make([]*ActionLogEntry, 0),
+		actionLogBase:  actionLogBase{actionLog: make([]*ActionLogEntry, 0)},
 	}
 	g.dealHands()
 	g.dealInitialTable()
@@ -836,13 +836,7 @@ func (g *Basra) playerName(idx int) string {
 }
 
 func (g *Basra) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.state.actionLog = append(g.state.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.state.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	g.state.appendLog(playerIdx, actionType, detail, cards)
 }
 
 // --- 状態アクセサ ---
@@ -1055,7 +1049,7 @@ func (g *Basra) UnmarshalJSON(data []byte) error {
 		scored:         j.Scored,
 		winners:        j.Winners,
 		lastDealDetail: j.LastDealDetail,
-		actionLog:      j.ActionLog,
+		actionLogBase:  actionLogBase{actionLog: j.ActionLog},
 	}
 	if g.state.tableCards == nil {
 		g.state.tableCards = make([]*Card, 0)

--- a/internal/domain/BigTwo.go
+++ b/internal/domain/BigTwo.go
@@ -20,16 +20,16 @@ type BigTwoAction struct {
 
 // bigTwoRoundState ラウンドごとにリセットされる状態
 type bigTwoRoundState struct {
-	currentTurn       int               // 現在の手番プレイヤーインデックス
-	tableCards        []*Card           // 場に出されているカード (nil = 場はクリア)
-	tablePlayType     BigTwoPlayType    // 場のプレイタイプ
-	lastPlayPlayerIdx int               // 最後にカードを出したプレイヤーインデックス (-1 = なし)
-	firstPlayDone     bool              // 最初のプレイ（♦3必須）が完了したか
-	gameEndFlag       bool              // ゲーム終了フラグ
-	passCount         int               // 最後の出し以降の連続パス数
-	cpuActions        []*BigTwoAction   // 人間ターン後のCPUの行動履歴
-	humanAction       *BigTwoAction     // 人間の最後の行動
-	actionLog         []*ActionLogEntry // 棋譜
+	currentTurn       int             // 現在の手番プレイヤーインデックス
+	tableCards        []*Card         // 場に出されているカード (nil = 場はクリア)
+	tablePlayType     BigTwoPlayType  // 場のプレイタイプ
+	lastPlayPlayerIdx int             // 最後にカードを出したプレイヤーインデックス (-1 = なし)
+	firstPlayDone     bool            // 最初のプレイ（♦3必須）が完了したか
+	gameEndFlag       bool            // ゲーム終了フラグ
+	passCount         int             // 最後の出し以降の連続パス数
+	cpuActions        []*BigTwoAction // 人間ターン後のCPUの行動履歴
+	humanAction       *BigTwoAction   // 人間の最後の行動
+	actionLogBase
 }
 
 // BigTwo Big Twoゲームクラス
@@ -48,7 +48,7 @@ func NewBigTwo(trumpCards *TrumpCards, players []*BigTwoPlayer, config BigTwoCon
 		config:     config,
 		round: bigTwoRoundState{
 			lastPlayPlayerIdx: -1,
-			actionLog:         make([]*ActionLogEntry, 0),
+			actionLogBase:     actionLogBase{actionLog: make([]*ActionLogEntry, 0)},
 		},
 	}
 }
@@ -69,7 +69,7 @@ func NewDefaultBigTwo() *BigTwo {
 func (bt *BigTwo) Reset() {
 	bt.round = bigTwoRoundState{
 		lastPlayPlayerIdx: -1,
-		actionLog:         make([]*ActionLogEntry, 0),
+		actionLogBase:     actionLogBase{actionLog: make([]*ActionLogEntry, 0)},
 	}
 
 	bt.trumpCards.Shuffle()
@@ -335,13 +335,7 @@ func (bt *BigTwo) GetActionLog() []*ActionLogEntry { return bt.round.actionLog }
 
 // appendLog 棋譜にエントリを追加する
 func (bt *BigTwo) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	bt.round.actionLog = append(bt.round.actionLog, &ActionLogEntry{
-		TurnNumber: len(bt.round.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	bt.round.appendLog(playerIdx, actionType, detail, cards)
 }
 
 // --- JSON Serialization ---
@@ -439,7 +433,7 @@ func (bt *BigTwo) UnmarshalJSON(data []byte) error {
 		passCount:         j.PassCount,
 		cpuActions:        j.CpuActions,
 		humanAction:       j.HumanAction,
-		actionLog:         j.ActionLog,
+		actionLogBase:     actionLogBase{actionLog: j.ActionLog},
 	}
 	if bt.round.actionLog == nil {
 		bt.round.actionLog = make([]*ActionLogEntry, 0)

--- a/internal/domain/Bouillotte.go
+++ b/internal/domain/Bouillotte.go
@@ -119,7 +119,7 @@ type bouillotteState struct {
 	result          BouillotteResult
 	gameEndFlag     bool
 	scored          bool // ラウンド結果を確定済みか (二重確定防止)
-	actionLog       []*ActionLogEntry
+	actionLogBase
 }
 
 // Bouillotte はブイヨットの状態を保持する集約ルート。
@@ -140,7 +140,7 @@ func NewBouillotte(trumpCards *TrumpCards, players []*BouillottePlayer, config B
 			phase:          BouillottePhaseBetting,
 			winnerIdx:      -1,
 			matchWinnerIdx: -1,
-			actionLog:      make([]*ActionLogEntry, 0),
+			actionLogBase:  actionLogBase{actionLog: make([]*ActionLogEntry, 0)},
 		},
 	}
 }
@@ -191,7 +191,7 @@ func (g *Bouillotte) Reset() {
 		dealerIdx:      0,
 		winnerIdx:      -1,
 		matchWinnerIdx: -1,
-		actionLog:      make([]*ActionLogEntry, 0),
+		actionLogBase:  actionLogBase{actionLog: make([]*ActionLogEntry, 0)},
 	}
 	g.startRound()
 }
@@ -666,13 +666,7 @@ func (g *Bouillotte) playerName(idx int) string {
 }
 
 func (g *Bouillotte) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.state.actionLog = append(g.state.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.state.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	g.state.appendLog(playerIdx, actionType, detail, cards)
 }
 
 // --- Hint ---
@@ -953,7 +947,7 @@ func (g *Bouillotte) UnmarshalJSON(data []byte) error {
 		result:          j.Result,
 		gameEndFlag:     j.GameEndFlag,
 		scored:          j.Scored,
-		actionLog:       j.ActionLog,
+		actionLogBase:   actionLogBase{actionLog: j.ActionLog},
 	}
 	if g.state.actionLog == nil {
 		g.state.actionLog = make([]*ActionLogEntry, 0)

--- a/internal/domain/Cassino.go
+++ b/internal/domain/Cassino.go
@@ -52,14 +52,14 @@ type CassinoAction struct {
 
 // cassinoRoundState はラウンドごとにリセットされる状態。
 type cassinoRoundState struct {
-	phase           string           // 現在のフェーズ
-	currentTurn     int              // 現在の手番
-	tableCards      []*Card          // 場の単独カード (ビルド除く)
-	builds          []*CassinoBuild  // 場のビルド
-	lastCaptureIdx  int              // 最後に捕獲したプレイヤー (-1 = なし)
-	humanAction     *CassinoAction   // 人間の最後の行動
-	cpuActions      []*CassinoAction // 人間ターン後の CPU 行動履歴
-	actionLog       []*ActionLogEntry
+	phase          string           // 現在のフェーズ
+	currentTurn    int              // 現在の手番
+	tableCards     []*Card          // 場の単独カード (ビルド除く)
+	builds         []*CassinoBuild  // 場のビルド
+	lastCaptureIdx int              // 最後に捕獲したプレイヤー (-1 = なし)
+	humanAction    *CassinoAction   // 人間の最後の行動
+	cpuActions     []*CassinoAction // 人間ターン後の CPU 行動履歴
+	actionLogBase
 	packsDealt      int  // これまでに配ったパック数 (1 回の配布 = 4 枚/人)
 	gameEndFlag     bool // ゲーム終了フラグ (TargetScore 到達)
 	roundWinners    []int
@@ -127,7 +127,7 @@ func (c *Cassino) Reset() {
 	c.round = cassinoRoundState{
 		phase:          CassinoPhaseDealing,
 		lastCaptureIdx: -1,
-		actionLog:      make([]*ActionLogEntry, 0),
+		actionLogBase:  actionLogBase{actionLog: make([]*ActionLogEntry, 0)},
 	}
 
 	c.startRound(true)
@@ -662,13 +662,7 @@ func (c *Cassino) removeBuildsByIndex(idxs []int) {
 
 // appendLog 棋譜にエントリを追加する。
 func (c *Cassino) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	c.round.actionLog = append(c.round.actionLog, &ActionLogEntry{
-		TurnNumber: len(c.round.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	c.round.appendLog(playerIdx, actionType, detail, cards)
 }
 
 // --- 状態アクセサ ---
@@ -889,7 +883,7 @@ func (c *Cassino) UnmarshalJSON(data []byte) error {
 		lastCaptureIdx:  j.LastCaptureIdx,
 		humanAction:     j.HumanAction,
 		cpuActions:      j.CpuActions,
-		actionLog:       j.ActionLog,
+		actionLogBase:   actionLogBase{actionLog: j.ActionLog},
 		packsDealt:      j.PacksDealt,
 		gameEndFlag:     j.GameEndFlag,
 		roundWinners:    j.RoundWinners,

--- a/internal/domain/Cuarenta.go
+++ b/internal/domain/Cuarenta.go
@@ -101,10 +101,10 @@ type cuarentaRoundState struct {
 	lastLaidCard   *Card           // 直前の手番が「置いた」カード (caída 判定用、捕獲時は nil)
 	humanAction    *CuarentaAction // 人間の最後の行動
 	cpuActions     []*CuarentaAction
-	actionLog      []*ActionLogEntry
-	gameEndFlag    bool
-	roundWinners   []int // ゲーム終了時の勝者チーム
-	lastDetail     *CuarentaRoundDetail
+	actionLogBase
+	gameEndFlag  bool
+	roundWinners []int // ゲーム終了時の勝者チーム
+	lastDetail   *CuarentaRoundDetail
 }
 
 // Cuarenta はクアレンタゲームの状態を保持する集約ルート。
@@ -154,7 +154,7 @@ func (g *Cuarenta) Reset() {
 	g.round = cuarentaRoundState{
 		phase:          CuarentaPhasePlay,
 		lastCaptureIdx: -1,
-		actionLog:      make([]*ActionLogEntry, 0),
+		actionLogBase:  actionLogBase{actionLog: make([]*ActionLogEntry, 0)},
 	}
 	g.startRound()
 }
@@ -441,13 +441,7 @@ func (g *Cuarenta) removeTableCardsByIndex(idxs []int) {
 
 // appendLog 棋譜にエントリを追加する。
 func (g *Cuarenta) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.round.actionLog = append(g.round.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.round.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	g.round.appendLog(playerIdx, actionType, detail, cards)
 }
 
 // --- 状態アクセサ ---
@@ -695,7 +689,7 @@ func (g *Cuarenta) UnmarshalJSON(data []byte) error {
 		lastLaidCard:   j.LastLaidCard,
 		humanAction:    j.HumanAction,
 		cpuActions:     j.CpuActions,
-		actionLog:      j.ActionLog,
+		actionLogBase:  actionLogBase{actionLog: j.ActionLog},
 		gameEndFlag:    j.GameEndFlag,
 		roundWinners:   j.RoundWinners,
 		lastDetail:     j.LastDetail,

--- a/internal/domain/Daifugo.go
+++ b/internal/domain/Daifugo.go
@@ -117,7 +117,7 @@ type daifugoRoundState struct {
 	reverseDirection    bool                     // 9リバース: ターン方向が逆か
 	numberLocked        bool                     // 激シバ: 連番縛り発動中
 	sequenceLocked      bool                     // 階段縛り: 階段のみ出せる
-	actionLog           []*ActionLogEntry        // 棋譜
+	actionLogBase
 }
 
 // Daifugo 大富豪ゲームクラス
@@ -492,13 +492,7 @@ func (d *Daifugo) GetActionLog() []*ActionLogEntry { return d.round.actionLog }
 
 // appendLog 棋譜にエントリを追加する
 func (d *Daifugo) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	d.round.actionLog = append(d.round.actionLog, &ActionLogEntry{
-		TurnNumber: len(d.round.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	d.round.appendLog(playerIdx, actionType, detail, cards)
 }
 
 // --- JSON Serialization ---
@@ -655,7 +649,7 @@ func (d *Daifugo) UnmarshalJSON(data []byte) error {
 		reverseDirection:    j.ReverseDirection,
 		numberLocked:        j.NumberLocked,
 		sequenceLocked:      j.SequenceLocked,
-		actionLog:           j.ActionLog,
+		actionLogBase:       actionLogBase{actionLog: j.ActionLog},
 	}
 	if d.round.actionLog == nil {
 		d.round.actionLog = make([]*ActionLogEntry, 0)

--- a/internal/domain/DeuceToSeven.go
+++ b/internal/domain/DeuceToSeven.go
@@ -65,20 +65,20 @@ type DeuceToSevenCpuExchange struct {
 // deuceToSevenRoundState holds the mutable per-hand state. Kept separate so
 // Reset can recreate it cleanly without touching config / players.
 type deuceToSevenRoundState struct {
-	phase           int
-	drawIndex       int // 0 during initial deal bet, 1..3 during/after the n-th draw
-	pot             int
-	currentTurn     int
-	lastBet         int
-	minRaise        int
-	raiseCount      int
-	actedFlags      []bool
-	sidePots        []SidePot
-	startingChips   []int
-	roundResults    []DeuceToSevenResult
-	cpuActions      []DeuceToSevenCpuAction
-	cpuExchanges    []DeuceToSevenCpuExchange
-	actionLog       []*ActionLogEntry
+	phase         int
+	drawIndex     int // 0 during initial deal bet, 1..3 during/after the n-th draw
+	pot           int
+	currentTurn   int
+	lastBet       int
+	minRaise      int
+	raiseCount    int
+	actedFlags    []bool
+	sidePots      []SidePot
+	startingChips []int
+	roundResults  []DeuceToSevenResult
+	cpuActions    []DeuceToSevenCpuAction
+	cpuExchanges  []DeuceToSevenCpuExchange
+	actionLogBase
 	gameEndFlag     bool
 	lastCpuError    error
 	lastHumanPlayMs int
@@ -977,13 +977,7 @@ func (d *DeuceToSeven) ImportProfile(data []byte) error {
 func (d *DeuceToSeven) GetActionLog() []*ActionLogEntry { return d.round.actionLog }
 
 func (d *DeuceToSeven) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	d.round.actionLog = append(d.round.actionLog, &ActionLogEntry{
-		TurnNumber: len(d.round.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	d.round.appendLog(playerIdx, actionType, detail, cards)
 }
 
 func (d *DeuceToSeven) logBettingAction(playerIdx, action, _ int) {
@@ -1121,7 +1115,7 @@ func (d *DeuceToSeven) UnmarshalJSON(data []byte) error {
 		roundResults:    j.Round.RoundResults,
 		cpuActions:      j.Round.CpuActions,
 		cpuExchanges:    j.Round.CpuExchanges,
-		actionLog:       j.Round.ActionLog,
+		actionLogBase:   actionLogBase{actionLog: j.Round.ActionLog},
 		gameEndFlag:     j.Round.GameEndFlag,
 		lastHumanPlayMs: j.Round.LastHumanPlayMs,
 	}

--- a/internal/domain/Doudizhu.go
+++ b/internal/domain/Doudizhu.go
@@ -62,7 +62,7 @@ type doudizhuRoundState struct {
 	cpuActions    []*DoudizhuCpuAction
 	humanAction   *DoudizhuCpuAction
 	scores        [DoudizhuPlayerCnt]int
-	actionLog     []*ActionLogEntry
+	actionLogBase
 }
 
 // Doudizhu 斗地主ゲーム
@@ -461,13 +461,7 @@ func (d *Doudizhu) GetActionLog() []*ActionLogEntry { return d.round.actionLog }
 
 // appendLog 棋譜にエントリを追加する
 func (d *Doudizhu) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	d.round.actionLog = append(d.round.actionLog, &ActionLogEntry{
-		TurnNumber: len(d.round.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	d.round.appendLog(playerIdx, actionType, detail, cards)
 }
 
 // --- JSON Serialization ---
@@ -622,7 +616,7 @@ func (d *Doudizhu) UnmarshalJSON(data []byte) error {
 		cpuActions:    j.CpuActions,
 		humanAction:   j.HumanAction,
 		scores:        j.Scores,
-		actionLog:     j.ActionLog,
+		actionLogBase: actionLogBase{actionLog: j.ActionLog},
 	}
 	if d.round.actionLog == nil {
 		d.round.actionLog = make([]*ActionLogEntry, 0)

--- a/internal/domain/Durak.go
+++ b/internal/domain/Durak.go
@@ -66,7 +66,7 @@ type durakRoundState struct {
 	cpuActions  []*DurakCpuAction // CPU行動記録
 	humanAction *DurakCpuAction   // 人間の最後の行動
 	boutNumber  int               // バウト番号
-	actionLog   []*ActionLogEntry // 棋譜
+	actionLogBase
 }
 
 // Durak ドゥラークゲームクラス
@@ -784,13 +784,7 @@ func (d *Durak) sortAllHands() {
 
 // appendLog 棋譜にエントリを追加
 func (d *Durak) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	d.round.actionLog = append(d.round.actionLog, &ActionLogEntry{
-		TurnNumber: d.round.boutNumber,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	d.round.appendLog(playerIdx, actionType, detail, cards)
 }
 
 // ---- 内部メソッド: CPU AI ----

--- a/internal/domain/GoStop.go
+++ b/internal/domain/GoStop.go
@@ -426,7 +426,7 @@ type gostopState struct {
 	lastRoundResult  *GoStopRoundResult
 	pendingBreakdown *GoStopBreakdown
 	pendingPoints    int // 決断フェーズのカテゴリ合計
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // GoStop はゴーストップゲームの状態を保持する集約ルート。
@@ -478,11 +478,11 @@ func (g *GoStop) Reset() {
 		p.ResetScore()
 	}
 	g.state = gostopState{
-		phase:       GoStopPhasePlay,
-		roundWinner: -1,
-		winner:      -1,
-		roundNumber: 1,
-		actionLog:   make([]*ActionLogEntry, 0),
+		phase:         GoStopPhasePlay,
+		roundWinner:   -1,
+		winner:        -1,
+		roundNumber:   1,
+		actionLogBase: actionLogBase{actionLog: make([]*ActionLogEntry, 0)},
 	}
 	g.startRound()
 }
@@ -1003,13 +1003,7 @@ func (g *GoStop) playerName(idx int) string {
 }
 
 func (g *GoStop) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.state.actionLog = append(g.state.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.state.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	g.state.appendLog(playerIdx, actionType, detail, cards)
 }
 
 // gostopCardStr は札を "松·光" のように表す (ログ/デバッグ用)。
@@ -1310,7 +1304,7 @@ func (g *GoStop) UnmarshalJSON(data []byte) error {
 		lastRoundResult:  j.LastRoundResult,
 		pendingBreakdown: j.PendingBreakdown,
 		pendingPoints:    j.PendingPoints,
-		actionLog:        j.ActionLog,
+		actionLogBase:    actionLogBase{actionLog: j.ActionLog},
 	}
 	if g.state.fieldCards == nil {
 		g.state.fieldCards = make([]*Card, 0)

--- a/internal/domain/Guts.go
+++ b/internal/domain/Guts.go
@@ -109,7 +109,7 @@ type gutsState struct {
 	result         GutsResult
 	gameEndFlag    bool
 	scored         bool // ラウンド結果を確定済みか (二重確定防止)
-	actionLog      []*ActionLogEntry
+	actionLogBase
 }
 
 // Guts はガッツの状態を保持する集約ルート。
@@ -131,7 +131,7 @@ func NewGuts(trumpCards *TrumpCards, players []*GutsPlayer, config GutsConfig) *
 			winnerIdx:      -1,
 			matchWinnerIdx: -1,
 			matchers:       make([]int, 0),
-			actionLog:      make([]*ActionLogEntry, 0),
+			actionLogBase:  actionLogBase{actionLog: make([]*ActionLogEntry, 0)},
 		},
 	}
 }
@@ -166,7 +166,7 @@ func (g *Guts) Reset() {
 		winnerIdx:      -1,
 		matchWinnerIdx: -1,
 		matchers:       make([]int, 0),
-		actionLog:      make([]*ActionLogEntry, 0),
+		actionLogBase:  actionLogBase{actionLog: make([]*ActionLogEntry, 0)},
 	}
 	g.startRound()
 }
@@ -470,13 +470,7 @@ func gutsDeclareText(idx int, stay bool) string {
 }
 
 func (g *Guts) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.state.actionLog = append(g.state.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.state.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	g.state.appendLog(playerIdx, actionType, detail, cards)
 }
 
 // --- Hint ---
@@ -687,7 +681,7 @@ func (g *Guts) UnmarshalJSON(data []byte) error {
 		result:         j.Result,
 		gameEndFlag:    j.GameEndFlag,
 		scored:         j.Scored,
-		actionLog:      j.ActionLog,
+		actionLogBase:  actionLogBase{actionLog: j.ActionLog},
 	}
 	if g.state.matchers == nil {
 		g.state.matchers = make([]int, 0)

--- a/internal/domain/HachiHachi.go
+++ b/internal/domain/HachiHachi.go
@@ -378,7 +378,7 @@ type hachihachiState struct {
 	gameEndFlag     bool
 	winner          int // 終局時の勝者 (-1 = 引き分け)
 	lastRoundResult *HachiHachiRoundResult
-	actionLog       []*ActionLogEntry
+	actionLogBase
 }
 
 // HachiHachi は八八ゲームの状態を保持する集約ルート。
@@ -431,11 +431,11 @@ func (g *HachiHachi) Reset() {
 		p.ResetScore()
 	}
 	g.state = hachihachiState{
-		phase:        HachiHachiPhasePlay,
-		lastCapturer: -1,
-		winner:       -1,
-		roundNumber:  1,
-		actionLog:    make([]*ActionLogEntry, 0),
+		phase:         HachiHachiPhasePlay,
+		lastCapturer:  -1,
+		winner:        -1,
+		roundNumber:   1,
+		actionLogBase: actionLogBase{actionLog: make([]*ActionLogEntry, 0)},
 	}
 	g.startRound()
 }
@@ -855,13 +855,7 @@ func (g *HachiHachi) playerName(idx int) string {
 }
 
 func (g *HachiHachi) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.state.actionLog = append(g.state.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.state.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	g.state.appendLog(playerIdx, actionType, detail, cards)
 }
 
 // hachihachiCardStr は札を "松·光" のように表す (ログ/デバッグ用)。
@@ -1175,7 +1169,7 @@ func (g *HachiHachi) UnmarshalJSON(data []byte) error {
 		gameEndFlag:     j.GameEndFlag,
 		winner:          j.Winner,
 		lastRoundResult: j.LastRoundResult,
-		actionLog:       j.ActionLog,
+		actionLogBase:   actionLogBase{actionLog: j.ActionLog},
 	}
 	if g.state.fieldCards == nil {
 		g.state.fieldCards = make([]*Card, 0)

--- a/internal/domain/KoiKoi.go
+++ b/internal/domain/KoiKoi.go
@@ -364,7 +364,7 @@ type koikoiState struct {
 	lastRoundResult *KoiKoiRoundResult
 	pendingYaku     []KoiKoiYaku // 決断フェーズで表示する役
 	pendingPoints   int          // 決断フェーズの役合計
-	actionLog       []*ActionLogEntry
+	actionLogBase
 }
 
 // KoiKoi はこいこいゲームの状態を保持する集約ルート。
@@ -416,11 +416,11 @@ func (g *KoiKoi) Reset() {
 		p.ResetScore()
 	}
 	g.state = koikoiState{
-		phase:       KoiKoiPhasePlay,
-		roundWinner: -1,
-		winner:      -1,
-		roundNumber: 1,
-		actionLog:   make([]*ActionLogEntry, 0),
+		phase:         KoiKoiPhasePlay,
+		roundWinner:   -1,
+		winner:        -1,
+		roundNumber:   1,
+		actionLogBase: actionLogBase{actionLog: make([]*ActionLogEntry, 0)},
 	}
 	g.startRound()
 }
@@ -928,13 +928,7 @@ func (g *KoiKoi) playerName(idx int) string {
 }
 
 func (g *KoiKoi) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.state.actionLog = append(g.state.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.state.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	g.state.appendLog(playerIdx, actionType, detail, cards)
 }
 
 // koikoiCardStr は札を "松·光" のように表す (ログ/デバッグ用)。
@@ -1229,7 +1223,7 @@ func (g *KoiKoi) UnmarshalJSON(data []byte) error {
 		lastRoundResult: j.LastRoundResult,
 		pendingYaku:     j.PendingYaku,
 		pendingPoints:   j.PendingPoints,
-		actionLog:       j.ActionLog,
+		actionLogBase:   actionLogBase{actionLog: j.ActionLog},
 	}
 	if g.state.fieldCards == nil {
 		g.state.fieldCards = make([]*Card, 0)

--- a/internal/domain/Michigan.go
+++ b/internal/domain/Michigan.go
@@ -101,7 +101,7 @@ type michiganState struct {
 	result          MichiganResult
 	gameEndFlag     bool
 	scored          bool // ラウンド結果を確定済みか (二重確定防止)
-	actionLog       []*ActionLogEntry
+	actionLogBase
 }
 
 // Michigan はミシガンの状態を保持する集約ルート。
@@ -123,7 +123,7 @@ func NewMichigan(trumpCards *TrumpCards, players []*MichiganPlayer, config Michi
 			winnerIdx:      -1,
 			matchWinnerIdx: -1,
 			boodles:        newMichiganBoodles(),
-			actionLog:      make([]*ActionLogEntry, 0),
+			actionLogBase:  actionLogBase{actionLog: make([]*ActionLogEntry, 0)},
 		},
 	}
 }
@@ -158,7 +158,7 @@ func (g *Michigan) Reset() {
 		winnerIdx:      -1,
 		matchWinnerIdx: -1,
 		boodles:        newMichiganBoodles(),
-		actionLog:      make([]*ActionLogEntry, 0),
+		actionLogBase:  actionLogBase{actionLog: make([]*ActionLogEntry, 0)},
 	}
 	g.startRound()
 }
@@ -676,13 +676,7 @@ func michiganValidCard(c *Card) bool {
 }
 
 func (g *Michigan) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.state.actionLog = append(g.state.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.state.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	g.state.appendLog(playerIdx, actionType, detail, cards)
 }
 
 // --- 状態アクセサ ---
@@ -1015,7 +1009,7 @@ func (g *Michigan) UnmarshalJSON(data []byte) error {
 		result:          j.Result,
 		gameEndFlag:     j.GameEndFlag,
 		scored:          j.Scored,
-		actionLog:       actionLog,
+		actionLogBase:   actionLogBase{actionLog: actionLog},
 	}
 	return nil
 }

--- a/internal/domain/Mighty.go
+++ b/internal/domain/Mighty.go
@@ -107,7 +107,7 @@ type mightyRoundState struct {
 	jokerPlayed       bool    // ジョーカーがこのラウンドで既にプレイされたか (ジョーカーコール抑止用)
 	gameEndFlag       bool
 	winnerTeam        int // MightyWinnerUndecided / MightyWinnerDeclarer / MightyWinnerOpposition
-	actionLog         []*ActionLogEntry
+	actionLogBase
 }
 
 // Mighty マイティ (韓国式マイティ) ゲームクラス
@@ -1407,13 +1407,7 @@ func (m *Mighty) playerName(idx int) string {
 
 // appendLog 棋譜にエントリを追加する
 func (m *Mighty) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	m.round.actionLog = append(m.round.actionLog, &ActionLogEntry{
-		TurnNumber: len(m.round.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	m.round.appendLog(playerIdx, actionType, detail, cards)
 }
 
 // mightyCardStr カードの文字列表現 (ジョーカー対応)
@@ -2335,7 +2329,7 @@ func (m *Mighty) UnmarshalJSON(data []byte) error {
 		jokerPlayed:       j.JokerPlayed,
 		gameEndFlag:       j.GameEndFlag,
 		winnerTeam:        j.WinnerTeam,
-		actionLog:         j.ActionLog,
+		actionLogBase:     actionLogBase{actionLog: j.ActionLog},
 	}
 	if m.round.actionLog == nil {
 		m.round.actionLog = make([]*ActionLogEntry, 0)

--- a/internal/domain/Napoleon.go
+++ b/internal/domain/Napoleon.go
@@ -98,7 +98,7 @@ type napoleonRoundState struct {
 	passCount        int     // パスしたプレイヤー数
 	gameEndFlag      bool
 	winnerTeam       int // NapoleonWinnerUndecided / NapoleonWinnerNapoleon / NapoleonWinnerAllied
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // Napoleon ナポレオンゲームクラス
@@ -1075,13 +1075,7 @@ func (n *Napoleon) playerName(idx int) string {
 
 // appendLog 棋譜にエントリを追加する
 func (n *Napoleon) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	n.round.actionLog = append(n.round.actionLog, &ActionLogEntry{
-		TurnNumber: len(n.round.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	n.round.appendLog(playerIdx, actionType, detail, cards)
 }
 
 // napoleonCardStr カードの文字列表現 (ジョーカー対応)
@@ -1890,7 +1884,7 @@ func (n *Napoleon) UnmarshalJSON(data []byte) error {
 		passCount:        j.PassCount,
 		gameEndFlag:      j.GameEndFlag,
 		winnerTeam:       j.WinnerTeam,
-		actionLog:        j.ActionLog,
+		actionLogBase:    actionLogBase{actionLog: j.ActionLog},
 	}
 	if n.round.actionLog == nil {
 		n.round.actionLog = make([]*ActionLogEntry, 0)

--- a/internal/domain/Pishti.go
+++ b/internal/domain/Pishti.go
@@ -83,7 +83,7 @@ type pishtiState struct {
 	lastCaptureIdx int     // 最後に捕獲したプレイヤー (-1 = なし)
 	gameEndFlag    bool
 	winners        []int
-	actionLog      []*ActionLogEntry
+	actionLogBase
 }
 
 // Pishti は Pişti ゲームの状態を保持する集約ルート。
@@ -139,7 +139,7 @@ func (g *Pishti) Reset() {
 		phase:          PishtiPhasePlay,
 		currentTurn:    0,
 		lastCaptureIdx: -1,
-		actionLog:      make([]*ActionLogEntry, 0),
+		actionLogBase:  actionLogBase{actionLog: make([]*ActionLogEntry, 0)},
 	}
 	g.dealHands()
 	g.dealInitialPile()
@@ -525,13 +525,7 @@ func (g *Pishti) lowestValueCardIdx(player *PishtiPlayer) int {
 
 // appendLog は棋譜にエントリを追加する。
 func (g *Pishti) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.state.actionLog = append(g.state.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.state.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	g.state.appendLog(playerIdx, actionType, detail, cards)
 }
 
 // --- 状態アクセサ ---
@@ -686,7 +680,7 @@ func (g *Pishti) UnmarshalJSON(data []byte) error {
 		lastCaptureIdx: j.LastCaptureIdx,
 		gameEndFlag:    j.GameEndFlag,
 		winners:        j.Winners,
-		actionLog:      j.ActionLog,
+		actionLogBase:  actionLogBase{actionLog: j.ActionLog},
 	}
 	if g.state.pile == nil {
 		g.state.pile = make([]*Card, 0)

--- a/internal/domain/Poker.go
+++ b/internal/domain/Poker.go
@@ -88,19 +88,19 @@ func findOpenEndedDraw(cards []straightDrawCardInfo, check func(remaining []int)
 
 // pokerRoundState ラウンドごとにリセットされる状態
 type pokerRoundState struct {
-	phase           int
-	pot             int
-	currentTurn     int
-	lastBet         int
-	minRaise        int
-	raiseCount      int
-	actedFlags      []bool
-	sidePots        []SidePot
-	startingChips   []int
-	roundResults    []PokerResult
-	cpuActions      []PokerCpuAction
-	cpuExchanges    []PokerCpuExchange
-	actionLog       []*ActionLogEntry
+	phase         int
+	pot           int
+	currentTurn   int
+	lastBet       int
+	minRaise      int
+	raiseCount    int
+	actedFlags    []bool
+	sidePots      []SidePot
+	startingChips []int
+	roundResults  []PokerResult
+	cpuActions    []PokerCpuAction
+	cpuExchanges  []PokerCpuExchange
+	actionLogBase
 	gameEndFlag     bool
 	lastCpuError    error // CPU行動エラーの最後のフォールバック記録 (テスト検出用)
 	lastHumanPlayMs int
@@ -1176,13 +1176,7 @@ func (p *Poker) GetActionLog() []*ActionLogEntry { return p.round.actionLog }
 
 // appendLog 棋譜にエントリを追加する
 func (p *Poker) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	p.round.actionLog = append(p.round.actionLog, &ActionLogEntry{
-		TurnNumber: len(p.round.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	p.round.appendLog(playerIdx, actionType, detail, cards)
 }
 
 // pokerRoundStateJSON is the JSON wire format for pokerRoundState.
@@ -1288,7 +1282,7 @@ func (p *Poker) UnmarshalJSON(data []byte) error {
 		roundResults:    j.Round.RoundResults,
 		cpuActions:      j.Round.CpuActions,
 		cpuExchanges:    j.Round.CpuExchanges,
-		actionLog:       j.Round.ActionLog,
+		actionLogBase:   actionLogBase{actionLog: j.Round.ActionLog},
 		gameEndFlag:     j.Round.GameEndFlag,
 		lastHumanPlayMs: j.Round.LastHumanPlayMs,
 	}

--- a/internal/domain/President.go
+++ b/internal/domain/President.go
@@ -53,7 +53,7 @@ type presidentRoundState struct {
 	humanAction       *PresidentCpuAction        // 人間の最後の行動
 	revolutionActive  bool                       // 革命フラグ
 	exchangeActions   []*PresidentExchangeAction // カード交換記録
-	actionLog         []*ActionLogEntry          // 棋譜
+	actionLogBase
 }
 
 // President プレジデント (President / Scum) ゲームクラス
@@ -371,13 +371,7 @@ func dedupSortedInts(in []int) []int {
 
 // appendLog 棋譜にエントリを追加する
 func (p *President) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	p.round.actionLog = append(p.round.actionLog, &ActionLogEntry{
-		TurnNumber: len(p.round.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	p.round.appendLog(playerIdx, actionType, detail, cards)
 }
 
 // --- 状態アクセサ ---
@@ -558,7 +552,7 @@ func (p *President) UnmarshalJSON(data []byte) error {
 		humanAction:       j.HumanAction,
 		revolutionActive:  j.RevolutionActive,
 		exchangeActions:   j.ExchangeActions,
-		actionLog:         j.ActionLog,
+		actionLogBase:     actionLogBase{actionLog: j.ActionLog},
 	}
 	if p.round.actionLog == nil {
 		p.round.actionLog = make([]*ActionLogEntry, 0)

--- a/internal/domain/Primero.go
+++ b/internal/domain/Primero.go
@@ -129,7 +129,7 @@ type primeroState struct {
 	result          PrimeroResult
 	gameEndFlag     bool
 	scored          bool // ラウンド結果を確定済みか (二重確定防止)
-	actionLog       []*ActionLogEntry
+	actionLogBase
 }
 
 // Primero はプリメロの状態を保持する集約ルート。
@@ -150,7 +150,7 @@ func NewPrimero(trumpCards *TrumpCards, players []*PrimeroPlayer, config Primero
 			phase:          PrimeroPhaseBetting,
 			winnerIdx:      -1,
 			matchWinnerIdx: -1,
-			actionLog:      make([]*ActionLogEntry, 0),
+			actionLogBase:  actionLogBase{actionLog: make([]*ActionLogEntry, 0)},
 		},
 	}
 }
@@ -200,7 +200,7 @@ func (g *Primero) Reset() {
 		dealerIdx:      0,
 		winnerIdx:      -1,
 		matchWinnerIdx: -1,
-		actionLog:      make([]*ActionLogEntry, 0),
+		actionLogBase:  actionLogBase{actionLog: make([]*ActionLogEntry, 0)},
 	}
 	g.startRound()
 }
@@ -697,13 +697,7 @@ func (g *Primero) playerName(idx int) string {
 }
 
 func (g *Primero) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.state.actionLog = append(g.state.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.state.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	g.state.appendLog(playerIdx, actionType, detail, cards)
 }
 
 // --- Hint ---
@@ -977,7 +971,7 @@ func (g *Primero) UnmarshalJSON(data []byte) error {
 		result:          j.Result,
 		gameEndFlag:     j.GameEndFlag,
 		scored:          j.Scored,
-		actionLog:       j.ActionLog,
+		actionLogBase:   actionLogBase{actionLog: j.ActionLog},
 	}
 	if g.state.actionLog == nil {
 		g.state.actionLog = make([]*ActionLogEntry, 0)

--- a/internal/domain/Scopa.go
+++ b/internal/domain/Scopa.go
@@ -46,13 +46,13 @@ type ScopaAction struct {
 
 // scopaRoundState はラウンドごとにリセットされる状態。
 type scopaRoundState struct {
-	phase           string         // 現在のフェーズ
-	currentTurn     int            // 現在の手番
-	tableCards      []*Card        // 場札
-	lastCaptureIdx  int            // 最後に捕獲したプレイヤー (-1 = なし)
-	humanAction     *ScopaAction   // 人間の最後の行動
-	cpuActions      []*ScopaAction // 人間ターン後の CPU 行動履歴
-	actionLog       []*ActionLogEntry
+	phase          string         // 現在のフェーズ
+	currentTurn    int            // 現在の手番
+	tableCards     []*Card        // 場札
+	lastCaptureIdx int            // 最後に捕獲したプレイヤー (-1 = なし)
+	humanAction    *ScopaAction   // 人間の最後の行動
+	cpuActions     []*ScopaAction // 人間ターン後の CPU 行動履歴
+	actionLogBase
 	packsDealt      int  // これまでに配ったパック数 (1 回の配布 = 3 枚/人)
 	gameEndFlag     bool // ゲーム終了フラグ (TargetScore 到達)
 	roundWinners    []int
@@ -119,7 +119,7 @@ func (s *Scopa) Reset() {
 	s.round = scopaRoundState{
 		phase:          ScopaPhaseDealing,
 		lastCaptureIdx: -1,
-		actionLog:      make([]*ActionLogEntry, 0),
+		actionLogBase:  actionLogBase{actionLog: make([]*ActionLogEntry, 0)},
 	}
 
 	s.startRound()
@@ -455,13 +455,7 @@ func (s *Scopa) removeTableCardsByIndex(idxs []int) {
 
 // appendLog 棋譜にエントリを追加する。
 func (s *Scopa) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	s.round.actionLog = append(s.round.actionLog, &ActionLogEntry{
-		TurnNumber: len(s.round.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	s.round.appendLog(playerIdx, actionType, detail, cards)
 }
 
 // --- 状態アクセサ ---
@@ -666,7 +660,7 @@ func (s *Scopa) UnmarshalJSON(data []byte) error {
 		lastCaptureIdx:  j.LastCaptureIdx,
 		humanAction:     j.HumanAction,
 		cpuActions:      j.CpuActions,
-		actionLog:       j.ActionLog,
+		actionLogBase:   actionLogBase{actionLog: j.ActionLog},
 		packsDealt:      j.PacksDealt,
 		gameEndFlag:     j.GameEndFlag,
 		roundWinners:    j.RoundWinners,

--- a/internal/domain/Shithead.go
+++ b/internal/domain/Shithead.go
@@ -54,8 +54,8 @@ type shitheadRoundState struct {
 	cpuActions  []*ShitheadCpuAction // 人間ターン後のCPU行動履歴
 	humanAction *ShitheadCpuAction   // 人間の最後の行動
 	nextRank    int                  // 次に上がったプレイヤーに付与するランク
-	actionLog   []*ActionLogEntry    // 棋譜
-	turnNumber  int                  // 内部ターン番号 (棋譜用)
+	actionLogBase
+	turnNumber int // 内部ターン番号 (棋譜用)
 }
 
 // Shithead シットヘッドゲームクラス
@@ -736,13 +736,7 @@ func (s *Shithead) recordAction(_ int, action *ShitheadCpuAction, isHuman bool) 
 
 // appendLog adds an entry to the action log.
 func (s *Shithead) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	s.round.actionLog = append(s.round.actionLog, &ActionLogEntry{
-		TurnNumber: s.round.turnNumber,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	s.round.appendLog(playerIdx, actionType, detail, cards)
 }
 
 // buildPlayDetail constructs a human-readable description of a play.
@@ -851,17 +845,17 @@ func (s *Shithead) UnmarshalJSON(data []byte) error {
 	s.players = j.Players
 	s.config = j.Config
 	s.round = shitheadRoundState{
-		currentTurn: j.Round.CurrentTurn,
-		discardPile: j.Round.DiscardPile,
-		stockPile:   j.Round.StockPile,
-		skipNext:    j.Round.SkipNext,
-		sevenActive: j.Round.SevenActive,
-		gameEndFlag: j.Round.GameEndFlag,
-		cpuActions:  j.Round.CpuActions,
-		humanAction: j.Round.HumanAction,
-		nextRank:    j.Round.NextRank,
-		actionLog:   j.Round.ActionLog,
-		turnNumber:  j.Round.TurnNumber,
+		currentTurn:   j.Round.CurrentTurn,
+		discardPile:   j.Round.DiscardPile,
+		stockPile:     j.Round.StockPile,
+		skipNext:      j.Round.SkipNext,
+		sevenActive:   j.Round.SevenActive,
+		gameEndFlag:   j.Round.GameEndFlag,
+		cpuActions:    j.Round.CpuActions,
+		humanAction:   j.Round.HumanAction,
+		nextRank:      j.Round.NextRank,
+		actionLogBase: actionLogBase{actionLog: j.Round.ActionLog},
+		turnNumber:    j.Round.TurnNumber,
 	}
 	if s.round.discardPile == nil {
 		s.round.discardPile = make([]*Card, 0)

--- a/internal/domain/Skat.go
+++ b/internal/domain/Skat.go
@@ -128,7 +128,7 @@ type skatRoundState struct {
 	defendersCardPts int
 	winnerSide       int // SkatWinner*
 	gameEndFlag      bool
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // Skat game class
@@ -1301,13 +1301,7 @@ func skatSuitName(suit int) string {
 
 // appendLog appends an entry to the round action log.
 func (s *Skat) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	s.round.actionLog = append(s.round.actionLog, &ActionLogEntry{
-		TurnNumber: len(s.round.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	s.round.appendLog(playerIdx, actionType, detail, cards)
 }
 
 // sortAllHands sorts every player's hand.

--- a/internal/domain/Tablanet.go
+++ b/internal/domain/Tablanet.go
@@ -124,7 +124,7 @@ type tablanetState struct {
 	scored         bool // 最終得点を確定済みか (二重確定防止)
 	winners        []int
 	lastDealDetail *TablanetScoreDetail
-	actionLog      []*ActionLogEntry
+	actionLogBase
 }
 
 // Tablanet はタブラネットゲームの状態を保持する集約ルート。
@@ -182,7 +182,7 @@ func (g *Tablanet) Reset() {
 		phase:          TablanetPhasePlay,
 		currentTurn:    0,
 		lastCaptureIdx: -1,
-		actionLog:      make([]*ActionLogEntry, 0),
+		actionLogBase:  actionLogBase{actionLog: make([]*ActionLogEntry, 0)},
 	}
 	g.dealHands()
 	g.dealInitialTable()
@@ -851,13 +851,7 @@ func (g *Tablanet) playerName(idx int) string {
 }
 
 func (g *Tablanet) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.state.actionLog = append(g.state.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.state.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	g.state.appendLog(playerIdx, actionType, detail, cards)
 }
 
 // --- 状態アクセサ ---
@@ -1070,7 +1064,7 @@ func (g *Tablanet) UnmarshalJSON(data []byte) error {
 		scored:         j.Scored,
 		winners:        j.Winners,
 		lastDealDetail: j.LastDealDetail,
-		actionLog:      j.ActionLog,
+		actionLogBase:  actionLogBase{actionLog: j.ActionLog},
 	}
 	if g.state.tableCards == nil {
 		g.state.tableCards = make([]*Card, 0)

--- a/internal/domain/Tichu.go
+++ b/internal/domain/Tichu.go
@@ -57,7 +57,7 @@ type tichuRoundState struct {
 	bombCount   int
 	cpuActions  []*TichuCpuAction
 	humanAction *TichuCpuAction
-	actionLog   []*ActionLogEntry
+	actionLogBase
 }
 
 // Tichu ティチューゲーム
@@ -609,13 +609,7 @@ func (t *Tichu) GetActionLog() []*ActionLogEntry { return t.round.actionLog }
 
 // appendLog 棋譜にエントリを追加する
 func (t *Tichu) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	t.round.actionLog = append(t.round.actionLog, &ActionLogEntry{
-		TurnNumber: len(t.round.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	t.round.appendLog(playerIdx, actionType, detail, cards)
 }
 
 // --- JSON Serialization ---
@@ -767,23 +761,23 @@ func (t *Tichu) UnmarshalJSON(data []byte) error {
 	}
 	t.config = j.Config
 	t.round = tichuRoundState{
-		phase:       j.Phase,
-		currentTurn: j.CurrentTurn,
-		tableCombo:  j.TableCombo,
-		lastPlayIdx: j.LastPlayIdx,
-		trickCards:  j.TrickCards,
-		passCount:   j.PassCount,
-		declCount:   j.DeclCount,
-		dragonOnTop: j.DragonOnTop,
-		gameEndFlag: j.GameEndFlag,
-		oneTwo:      j.OneTwo,
-		startLeader: j.StartLeader,
-		finishOrder: j.FinishOrder,
-		scores:      j.Scores,
-		bombCount:   j.BombCount,
-		cpuActions:  j.CpuActions,
-		humanAction: j.HumanAction,
-		actionLog:   j.ActionLog,
+		phase:         j.Phase,
+		currentTurn:   j.CurrentTurn,
+		tableCombo:    j.TableCombo,
+		lastPlayIdx:   j.LastPlayIdx,
+		trickCards:    j.TrickCards,
+		passCount:     j.PassCount,
+		declCount:     j.DeclCount,
+		dragonOnTop:   j.DragonOnTop,
+		gameEndFlag:   j.GameEndFlag,
+		oneTwo:        j.OneTwo,
+		startLeader:   j.StartLeader,
+		finishOrder:   j.FinishOrder,
+		scores:        j.Scores,
+		bombCount:     j.BombCount,
+		cpuActions:    j.CpuActions,
+		humanAction:   j.HumanAction,
+		actionLogBase: actionLogBase{actionLog: j.ActionLog},
 	}
 	if t.round.actionLog == nil {
 		t.round.actionLog = make([]*ActionLogEntry, 0)

--- a/internal/domain/TienLen.go
+++ b/internal/domain/TienLen.go
@@ -22,16 +22,16 @@ type TienLenAction struct {
 
 // tienLenRoundState ラウンドごとにリセットされる状態
 type tienLenRoundState struct {
-	currentTurn       int               // 現在の手番プレイヤーインデックス
-	tableCards        []*Card           // 場に出されているカード (nil = 場はクリア)
-	tablePlayType     TienLenPlayType   // 場のプレイタイプ
-	lastPlayPlayerIdx int               // 最後にカードを出したプレイヤーインデックス (-1 = なし)
-	firstPlayDone     bool              // 最初のプレイ（♠3必須）が完了したか
-	gameEndFlag       bool              // ゲーム終了フラグ
-	passCount         int               // 最後の出し以降の連続パス数
-	cpuActions        []*TienLenAction  // 人間ターン後のCPUの行動履歴
-	humanAction       *TienLenAction    // 人間の最後の行動
-	actionLog         []*ActionLogEntry // 棋譜
+	currentTurn       int              // 現在の手番プレイヤーインデックス
+	tableCards        []*Card          // 場に出されているカード (nil = 場はクリア)
+	tablePlayType     TienLenPlayType  // 場のプレイタイプ
+	lastPlayPlayerIdx int              // 最後にカードを出したプレイヤーインデックス (-1 = なし)
+	firstPlayDone     bool             // 最初のプレイ（♠3必須）が完了したか
+	gameEndFlag       bool             // ゲーム終了フラグ
+	passCount         int              // 最後の出し以降の連続パス数
+	cpuActions        []*TienLenAction // 人間ターン後のCPUの行動履歴
+	humanAction       *TienLenAction   // 人間の最後の行動
+	actionLogBase
 }
 
 // TienLen Tien Lenゲームクラス
@@ -50,7 +50,7 @@ func NewTienLen(trumpCards *TrumpCards, players []*TienLenPlayer, config TienLen
 		config:     config,
 		round: tienLenRoundState{
 			lastPlayPlayerIdx: -1,
-			actionLog:         make([]*ActionLogEntry, 0),
+			actionLogBase:     actionLogBase{actionLog: make([]*ActionLogEntry, 0)},
 		},
 	}
 }
@@ -71,7 +71,7 @@ func NewDefaultTienLen() *TienLen {
 func (tl *TienLen) Reset() {
 	tl.round = tienLenRoundState{
 		lastPlayPlayerIdx: -1,
-		actionLog:         make([]*ActionLogEntry, 0),
+		actionLogBase:     actionLogBase{actionLog: make([]*ActionLogEntry, 0)},
 	}
 
 	tl.trumpCards.Shuffle()
@@ -351,13 +351,7 @@ func (tl *TienLen) GetActionLog() []*ActionLogEntry { return tl.round.actionLog 
 
 // appendLog 棋譜にエントリを追加する
 func (tl *TienLen) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	tl.round.actionLog = append(tl.round.actionLog, &ActionLogEntry{
-		TurnNumber: len(tl.round.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	tl.round.appendLog(playerIdx, actionType, detail, cards)
 }
 
 // --- JSON Serialization ---
@@ -455,7 +449,7 @@ func (tl *TienLen) UnmarshalJSON(data []byte) error {
 		passCount:         j.PassCount,
 		cpuActions:        j.CpuActions,
 		humanAction:       j.HumanAction,
-		actionLog:         j.ActionLog,
+		actionLogBase:     actionLogBase{actionLog: j.ActionLog},
 	}
 	if tl.round.actionLog == nil {
 		tl.round.actionLog = make([]*ActionLogEntry, 0)

--- a/internal/domain/TrenteEtQuarante.go
+++ b/internal/domain/TrenteEtQuarante.go
@@ -130,7 +130,7 @@ type trenteEtQuaranteState struct {
 	roundNumber  int
 	gameEndFlag  bool
 	scored       bool // ラウンド結果を確定済みか (二重確定防止)
-	actionLog    []*ActionLogEntry
+	actionLogBase
 }
 
 // TrenteEtQuarante はトラント・エ・カラントの状態を保持する集約ルート。
@@ -148,10 +148,10 @@ func NewTrenteEtQuarante(trumpCards *TrumpCards, player *TrenteEtQuarantePlayer,
 		player:     player,
 		config:     config,
 		state: trenteEtQuaranteState{
-			phase:      TrenteEtQuarantePhaseBet,
-			currentBet: config.DefaultBet,
-			winningRow: TrenteEtQuaranteRowNone,
-			actionLog:  make([]*ActionLogEntry, 0),
+			phase:         TrenteEtQuarantePhaseBet,
+			currentBet:    config.DefaultBet,
+			winningRow:    TrenteEtQuaranteRowNone,
+			actionLogBase: actionLogBase{actionLog: make([]*ActionLogEntry, 0)},
 		},
 	}
 	return g
@@ -190,10 +190,10 @@ func (g *TrenteEtQuarante) Reset() {
 	g.trumpCards = newTrenteEtQuaranteShoe()
 	g.trumpCards.Shuffle()
 	g.state = trenteEtQuaranteState{
-		phase:      TrenteEtQuarantePhaseBet,
-		currentBet: g.config.DefaultBet,
-		winningRow: TrenteEtQuaranteRowNone,
-		actionLog:  make([]*ActionLogEntry, 0),
+		phase:         TrenteEtQuarantePhaseBet,
+		currentBet:    g.config.DefaultBet,
+		winningRow:    TrenteEtQuaranteRowNone,
+		actionLogBase: actionLogBase{actionLog: make([]*ActionLogEntry, 0)},
 	}
 }
 
@@ -203,11 +203,11 @@ func (g *TrenteEtQuarante) NextRound() {
 	round := g.state.roundNumber
 	log := g.state.actionLog
 	g.state = trenteEtQuaranteState{
-		phase:       TrenteEtQuarantePhaseBet,
-		currentBet:  g.config.DefaultBet,
-		winningRow:  TrenteEtQuaranteRowNone,
-		roundNumber: round,
-		actionLog:   log,
+		phase:         TrenteEtQuarantePhaseBet,
+		currentBet:    g.config.DefaultBet,
+		winningRow:    TrenteEtQuaranteRowNone,
+		roundNumber:   round,
+		actionLogBase: actionLogBase{actionLog: log},
 	}
 }
 
@@ -413,13 +413,7 @@ func (g *TrenteEtQuarante) GetHint() *TrenteEtQuaranteHint {
 // --- ヘルパー ---
 
 func (g *TrenteEtQuarante) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.state.actionLog = append(g.state.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.state.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	g.state.appendLog(playerIdx, actionType, detail, cards)
 }
 
 // --- 状態アクセサ ---
@@ -639,22 +633,22 @@ func (g *TrenteEtQuarante) UnmarshalJSON(data []byte) error {
 	}
 	g.config = j.Config
 	g.state = trenteEtQuaranteState{
-		phase:        j.Phase,
-		currentBet:   j.CurrentBet,
-		stake:        j.Stake,
-		noirRow:      j.NoirRow,
-		rougeRow:     j.RougeRow,
-		noirTotal:    j.NoirTotal,
-		rougeTotal:   j.RougeTotal,
-		winningRow:   j.WinningRow,
-		firstCardRed: j.FirstCardRed,
-		refait:       j.Refait,
-		result:       j.Result,
-		payout:       j.Payout,
-		roundNumber:  j.RoundNumber,
-		gameEndFlag:  j.GameEndFlag,
-		scored:       j.Scored,
-		actionLog:    j.ActionLog,
+		phase:         j.Phase,
+		currentBet:    j.CurrentBet,
+		stake:         j.Stake,
+		noirRow:       j.NoirRow,
+		rougeRow:      j.RougeRow,
+		noirTotal:     j.NoirTotal,
+		rougeTotal:    j.RougeTotal,
+		winningRow:    j.WinningRow,
+		firstCardRed:  j.FirstCardRed,
+		refait:        j.Refait,
+		result:        j.Result,
+		payout:        j.Payout,
+		roundNumber:   j.RoundNumber,
+		gameEndFlag:   j.GameEndFlag,
+		scored:        j.Scored,
+		actionLogBase: actionLogBase{actionLog: j.ActionLog},
 	}
 	if g.state.noirRow == nil {
 		g.state.noirRow = make([]*Card, 0)

--- a/internal/domain/Zheng.go
+++ b/internal/domain/Zheng.go
@@ -26,15 +26,15 @@ type ZhengAction struct {
 
 // zhengRoundState ラウンドごとにリセットされる状態
 type zhengRoundState struct {
-	currentTurn       int               // 現在の手番プレイヤーインデックス
-	tableCards        []*Card           // 場に出されているカード (nil = 場はクリア)
-	tablePlayType     ZhengPlayType     // 場のプレイタイプ
-	lastPlayPlayerIdx int               // 最後にカードを出したプレイヤーインデックス (-1 = なし)
-	gameEndFlag       bool              // ゲーム終了フラグ
-	passCount         int               // 最後の出し以降の連続パス数
-	cpuActions        []*ZhengAction    // 人間ターン後のCPUの行動履歴
-	humanAction       *ZhengAction      // 人間の最後の行動
-	actionLog         []*ActionLogEntry // 棋譜
+	currentTurn       int            // 現在の手番プレイヤーインデックス
+	tableCards        []*Card        // 場に出されているカード (nil = 場はクリア)
+	tablePlayType     ZhengPlayType  // 場のプレイタイプ
+	lastPlayPlayerIdx int            // 最後にカードを出したプレイヤーインデックス (-1 = なし)
+	gameEndFlag       bool           // ゲーム終了フラグ
+	passCount         int            // 最後の出し以降の連続パス数
+	cpuActions        []*ZhengAction // 人間ターン後のCPUの行動履歴
+	humanAction       *ZhengAction   // 人間の最後の行動
+	actionLogBase
 }
 
 // Zheng 争上游ゲームクラス
@@ -53,7 +53,7 @@ func NewZheng(trumpCards *TrumpCards, players []*ZhengPlayer, config ZhengConfig
 		config:     config,
 		round: zhengRoundState{
 			lastPlayPlayerIdx: -1,
-			actionLog:         make([]*ActionLogEntry, 0),
+			actionLogBase:     actionLogBase{actionLog: make([]*ActionLogEntry, 0)},
 		},
 	}
 }
@@ -75,7 +75,7 @@ func NewDefaultZheng() *Zheng {
 func (z *Zheng) Reset() {
 	z.round = zhengRoundState{
 		lastPlayPlayerIdx: -1,
-		actionLog:         make([]*ActionLogEntry, 0),
+		actionLogBase:     actionLogBase{actionLog: make([]*ActionLogEntry, 0)},
 	}
 
 	z.trumpCards.Shuffle()
@@ -340,13 +340,7 @@ func (z *Zheng) GetActionLog() []*ActionLogEntry { return z.round.actionLog }
 
 // appendLog 棋譜にエントリを追加する
 func (z *Zheng) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	z.round.actionLog = append(z.round.actionLog, &ActionLogEntry{
-		TurnNumber: len(z.round.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	z.round.appendLog(playerIdx, actionType, detail, cards)
 }
 
 // --- JSON Serialization ---
@@ -528,7 +522,7 @@ func (z *Zheng) UnmarshalJSON(data []byte) error {
 		passCount:         max(j.PassCount, 0),
 		cpuActions:        j.CpuActions,
 		humanAction:       j.HumanAction,
-		actionLog:         j.ActionLog,
+		actionLogBase:     actionLogBase{actionLog: j.ActionLog},
 	}
 	if z.round.actionLog == nil {
 		z.round.actionLog = make([]*ActionLogEntry, 0)


### PR DESCRIPTION
## 概要

[#5185](https://github.com/yuta-yoshinaga/go_trumpcards/issues/5185) のフェーズ3、**埋め込み方式の最終段**です。ログを `round` / `state` のネストした構造体に持つ30ゲームを対象にします。

**180行削除**（260追加 / 440削除）。

## 前2フェーズとの違い

| | 対象 | 削除 |
|---|---:|---:|
| [#5197](https://github.com/yuta-yoshinaga/go_trumpcards/pull/5197) フェーズ1 | 122ゲーム | -1,683 |
| [#5198](https://github.com/yuta-yoshinaga/go_trumpcards/pull/5198) フェーズ2 | 44ゲーム（ソリティア） | -396 |
| **本PR** フェーズ3 | **30ゲーム（ネスト）** | **-180** |
| 累計 | **196ゲーム** | **-2,259** |

**1ゲームあたりの削減が小さいのは、ゲーム側の `GetActionLog` を残す必要があるためです。**

```go
// これは残る: round はフィールドであって埋め込みではないので、
// round のメソッドは BigTwo に昇格しない
func (bt *BigTwo) GetActionLog() []*ActionLogEntry { return bt.round.actionLog }
```

畳めるのは**ネスト構造体のフィールド宣言**と**ゲームの `appendLog` 本体**（1行委譲に）だけです。

## 複合リテラルが56箇所

ネスト構造体は `round: bigTwoRoundState{...}` のように複合リテラルで初期化されるため、`actionLog:` を直接設定している箇所が**30ファイルに56箇所**あります。すべて `actionLogBase: actionLogBase{actionLog: ...}` に書き換えました。#5197 で `PigsTail` 1件に対して行ったのと同じ変更が、こちらでは大量にあった形です。

## テスト計画

- [x] 1ゲーム（BigTwo）を手で変換して検証してからスクリプト化
- [x] **スクリプトを書き込み無効のドライランで先に実行**し、30件すべてがアンカーに一致することを確認（`git status` が空であることも確認）
- [x] 移行後に「ネストブロックに `actionLogBase` があり、旧 `actionLog` フィールドが残っていない」ことを全30ゲームで機械検証 → 残件0
- [x] `go build ./...` / `gofmt -l` クリーン
- [x] `go test -tags test ./internal/domain/... ./internal/usecase/...` 通過（domain 43.6s）
- [x] `golangci-lint run ./internal/domain/...` → 0 issues

## サイズについて

前2フェーズの実測（[phase1](https://github.com/yuta-yoshinaga/go_trumpcards/pull/5197#issuecomment-5225811081) / [phase2](https://github.com/yuta-yoshinaga/go_trumpcards/pull/5198#issuecomment-5225885456)）のとおり、**重複削減による gzip 削減はほぼゼロ**です（累計2,079行削除で -3,987バイト、うち複数 worker は逆に増加）。本 PR も横ばい見込みで、**効用は保守性のみ**です。

## #5185 の残り

本 PR で**埋め込みで解ける分は完了**します。残るのは `playerName` 88件・`IsHumanTurn` 68件・`findHumanIdx` 61件・`minBy`/`maxBy` 36件など約380メソッドで、これらは `[]*XPlayer`（ゲーム固有型）に触るため**ジェネリクスが必要**です。

実測から、そちらは**サイズ面で純粋にマイナス**と判明しています（TinyGo の単相化はインスタンスごとに異なるコードを生み、gzip の効きが悪い。最逼迫の extra3 は余裕127KB）。実施するなら保守性のみを根拠にすべきで、判断を仰いでから着手します。

Refs #5185