### PR TITLE
refactor(domain): reuse pickLowest/pickHighest instead of 36 minBy/maxBy copies

### DIFF
--- a/internal/domain/Calabresella.go
+++ b/internal/domain/Calabresella.go
@@ -813,7 +813,7 @@ func (g *Calabresella) cpuPlaySmart(playerIdx int, valid []int) int {
 
 	// リード: 得点・強さの低い札を出して温存する。
 	if len(g.currentTrick) == 0 {
-		return g.minBy(player, valid, func(c *Card) int {
+		return pickLowest(player, valid, func(c *Card) int {
 			return calabresellaThirds(c.GetValue())*100 + calabresellaStrength(c.GetValue())
 		})
 	}
@@ -836,7 +836,7 @@ func (g *Calabresella) cpuPlaySmart(playerIdx int, valid []int) int {
 
 	if len(follows) == 0 {
 		// ボイド: 得点・強さの低い札を捨てて温存する。
-		return g.minBy(player, valid, func(c *Card) int {
+		return pickLowest(player, valid, func(c *Card) int {
 			return calabresellaThirds(c.GetValue())*100 + calabresellaStrength(c.GetValue())
 		})
 	}
@@ -851,47 +851,21 @@ func (g *Calabresella) cpuPlaySmart(playerIdx int, valid []int) int {
 			return calabresellaStrength(player.GetCard(idx).GetValue()) < topStrength
 		})
 		if len(nonWinners) > 0 {
-			return g.maxBy(player, nonWinners, func(c *Card) int {
+			return pickHighest(player, nonWinners, func(c *Card) int {
 				return calabresellaThirds(c.GetValue())*100 - calabresellaStrength(c.GetValue())
 			})
 		}
-		return g.minBy(player, follows, func(c *Card) int { return calabresellaStrength(c.GetValue()) })
+		return pickLowest(player, follows, func(c *Card) int { return calabresellaStrength(c.GetValue()) })
 	}
 
 	// 相手が勝っている: 得点があり勝てるなら最小限の札で取りに行く。
 	if trickThirds > 0 && len(winners) > 0 {
-		return g.minBy(player, winners, func(c *Card) int { return calabresellaStrength(c.GetValue()) })
+		return pickLowest(player, winners, func(c *Card) int { return calabresellaStrength(c.GetValue()) })
 	}
 	// 取れない/取る価値がない: 得点・強さの低い札でダックする。
-	return g.minBy(player, follows, func(c *Card) int {
+	return pickLowest(player, follows, func(c *Card) int {
 		return calabresellaThirds(c.GetValue())*100 + calabresellaStrength(c.GetValue())
 	})
-}
-
-// minBy score が最小となるインデックスを返す。
-func (g *Calabresella) minBy(player *CalabresellaPlayer, indices []int, score func(*Card) int) int {
-	best := indices[0]
-	bestScore := score(player.GetCard(best))
-	for _, idx := range indices[1:] {
-		if s := score(player.GetCard(idx)); s < bestScore {
-			bestScore = s
-			best = idx
-		}
-	}
-	return best
-}
-
-// maxBy score が最大となるインデックスを返す。
-func (g *Calabresella) maxBy(player *CalabresellaPlayer, indices []int, score func(*Card) int) int {
-	best := indices[0]
-	bestScore := score(player.GetCard(best))
-	for _, idx := range indices[1:] {
-		if s := score(player.GetCard(idx)); s > bestScore {
-			bestScore = s
-			best = idx
-		}
-	}
-	return best
 }
 
 // calabresellaFilter 述語を満たすインデックスを抽出する。

--- a/internal/domain/Doppelkopf.go
+++ b/internal/domain/Doppelkopf.go
@@ -864,7 +864,7 @@ func (g *Doppelkopf) cpuPlaySmart(playerIdx int, valid []int) int {
 	player := g.players[playerIdx]
 
 	if len(g.currentTrick) == 0 {
-		return g.minBy(player, valid, func(c *Card) int {
+		return pickLowest(player, valid, func(c *Card) int {
 			return dkCardPoints(c.GetValue())*100 + dkStrength(c)
 		})
 	}
@@ -887,14 +887,14 @@ func (g *Doppelkopf) cpuPlaySmart(playerIdx int, valid []int) int {
 
 	if len(follows) == 0 {
 		if partnerWinning {
-			return g.maxBy(player, valid, func(c *Card) int {
+			return pickHighest(player, valid, func(c *Card) int {
 				if dkIsTrump(c) {
 					return -dkStrength(c)
 				}
 				return dkCardPoints(c.GetValue())*100 - dkStrength(c)
 			})
 		}
-		return g.minBy(player, valid, func(c *Card) int {
+		return pickLowest(player, valid, func(c *Card) int {
 			return dkCardPoints(c.GetValue())*100 + dkStrength(c)
 		})
 	}
@@ -908,45 +908,19 @@ func (g *Doppelkopf) cpuPlaySmart(playerIdx int, valid []int) int {
 			return dkStrength(player.GetCard(idx)) < topStrength
 		})
 		if len(nonWinners) > 0 {
-			return g.maxBy(player, nonWinners, func(c *Card) int {
+			return pickHighest(player, nonWinners, func(c *Card) int {
 				return dkCardPoints(c.GetValue())*100 - dkStrength(c)
 			})
 		}
-		return g.minBy(player, follows, func(c *Card) int { return dkStrength(c) })
+		return pickLowest(player, follows, func(c *Card) int { return dkStrength(c) })
 	}
 
 	if trickPts > 0 && len(winners) > 0 {
-		return g.minBy(player, winners, func(c *Card) int { return dkStrength(c) })
+		return pickLowest(player, winners, func(c *Card) int { return dkStrength(c) })
 	}
-	return g.minBy(player, follows, func(c *Card) int {
+	return pickLowest(player, follows, func(c *Card) int {
 		return dkCardPoints(c.GetValue())*100 + dkStrength(c)
 	})
-}
-
-// minBy score が最小となるインデックスを返す。
-func (g *Doppelkopf) minBy(player *DoppelkopfPlayer, indices []int, score func(*Card) int) int {
-	best := indices[0]
-	bestScore := score(player.GetCard(best))
-	for _, idx := range indices[1:] {
-		if s := score(player.GetCard(idx)); s < bestScore {
-			bestScore = s
-			best = idx
-		}
-	}
-	return best
-}
-
-// maxBy score が最大となるインデックスを返す。
-func (g *Doppelkopf) maxBy(player *DoppelkopfPlayer, indices []int, score func(*Card) int) int {
-	best := indices[0]
-	bestScore := score(player.GetCard(best))
-	for _, idx := range indices[1:] {
-		if s := score(player.GetCard(idx)); s > bestScore {
-			bestScore = s
-			best = idx
-		}
-	}
-	return best
 }
 
 // dkFilter 述語を満たすインデックスを抽出する。

--- a/internal/domain/FortyFives.go
+++ b/internal/domain/FortyFives.go
@@ -673,7 +673,7 @@ func (g *FortyFives) cpuSelectPlayCard(playerIdx int) int {
 func (g *FortyFives) cpuPlaySmart(playerIdx int, valid []int) int {
 	player := g.players[playerIdx]
 	if len(g.currentTrick) == 0 {
-		return g.maxBy(player, valid, func(c *Card) int { return g.fortyFivesRank(c) })
+		return pickHighest(player, valid, func(c *Card) int { return g.fortyFivesRank(c) })
 	}
 	winnerIdx := g.trickWinner()
 	topRank := g.trickTopRank(winnerIdx)
@@ -681,38 +681,12 @@ func (g *FortyFives) cpuPlaySmart(playerIdx int, valid []int) int {
 	winners := fortyFivesFilter(valid, func(idx int) bool { return g.fortyFivesRank(player.GetCard(idx)) > topRank })
 	if partnerWinning {
 		// 味方が勝っている: 最弱札を温存・捨てる。
-		return g.minBy(player, valid, func(c *Card) int { return g.fortyFivesRank(c) })
+		return pickLowest(player, valid, func(c *Card) int { return g.fortyFivesRank(c) })
 	}
 	if len(winners) > 0 {
-		return g.minBy(player, winners, func(c *Card) int { return g.fortyFivesRank(c) })
+		return pickLowest(player, winners, func(c *Card) int { return g.fortyFivesRank(c) })
 	}
-	return g.minBy(player, valid, func(c *Card) int { return g.fortyFivesRank(c) })
-}
-
-// minBy score が最小となるインデックスを返す。
-func (g *FortyFives) minBy(player *FortyFivesPlayer, indices []int, score func(*Card) int) int {
-	best := indices[0]
-	bestScore := score(player.GetCard(best))
-	for _, idx := range indices[1:] {
-		if s := score(player.GetCard(idx)); s < bestScore {
-			bestScore = s
-			best = idx
-		}
-	}
-	return best
-}
-
-// maxBy score が最大となるインデックスを返す。
-func (g *FortyFives) maxBy(player *FortyFivesPlayer, indices []int, score func(*Card) int) int {
-	best := indices[0]
-	bestScore := score(player.GetCard(best))
-	for _, idx := range indices[1:] {
-		if s := score(player.GetCard(idx)); s > bestScore {
-			bestScore = s
-			best = idx
-		}
-	}
-	return best
+	return pickLowest(player, valid, func(c *Card) int { return g.fortyFivesRank(c) })
 }
 
 // fortyFivesFilter 述語を満たすインデックスを抽出する。

--- a/internal/domain/Klaverjas.go
+++ b/internal/domain/Klaverjas.go
@@ -649,7 +649,7 @@ func (g *Klaverjas) cpuSelectPlayCard(playerIdx int) int {
 func (g *Klaverjas) cpuPlaySmart(playerIdx int, valid []int) int {
 	player := g.players[playerIdx]
 	if len(g.currentTrick) == 0 {
-		return g.minBy(player, valid, func(c *Card) int {
+		return pickLowest(player, valid, func(c *Card) int {
 			return g.cardPoints(c)*100 + g.klaverjasRank(c)
 		})
 	}
@@ -665,42 +665,16 @@ func (g *Klaverjas) cpuPlaySmart(playerIdx int, valid []int) int {
 		// 味方が勝っている: 得点の高い札を渡す (勝ち札以外があればそれ)。
 		nonWinners := klaverjasFilter(valid, func(idx int) bool { return g.klaverjasRank(player.GetCard(idx)) < topRank })
 		if len(nonWinners) > 0 {
-			return g.maxBy(player, nonWinners, func(c *Card) int { return g.cardPoints(c) })
+			return pickHighest(player, nonWinners, func(c *Card) int { return g.cardPoints(c) })
 		}
-		return g.minBy(player, valid, func(c *Card) int { return g.klaverjasRank(c) })
+		return pickLowest(player, valid, func(c *Card) int { return g.klaverjasRank(c) })
 	}
 	if trickPts > 0 && len(winners) > 0 {
-		return g.minBy(player, winners, func(c *Card) int { return g.klaverjasRank(c) })
+		return pickLowest(player, winners, func(c *Card) int { return g.klaverjasRank(c) })
 	}
-	return g.minBy(player, valid, func(c *Card) int {
+	return pickLowest(player, valid, func(c *Card) int {
 		return g.cardPoints(c)*100 + g.klaverjasRank(c)
 	})
-}
-
-// minBy score が最小となるインデックスを返す。
-func (g *Klaverjas) minBy(player *KlaverjasPlayer, indices []int, score func(*Card) int) int {
-	best := indices[0]
-	bestScore := score(player.GetCard(best))
-	for _, idx := range indices[1:] {
-		if s := score(player.GetCard(idx)); s < bestScore {
-			bestScore = s
-			best = idx
-		}
-	}
-	return best
-}
-
-// maxBy score が最大となるインデックスを返す。
-func (g *Klaverjas) maxBy(player *KlaverjasPlayer, indices []int, score func(*Card) int) int {
-	best := indices[0]
-	bestScore := score(player.GetCard(best))
-	for _, idx := range indices[1:] {
-		if s := score(player.GetCard(idx)); s > bestScore {
-			bestScore = s
-			best = idx
-		}
-	}
-	return best
 }
 
 // klaverjasFilter 述語を満たすインデックスを抽出する。

--- a/internal/domain/KnockoutWhist.go
+++ b/internal/domain/KnockoutWhist.go
@@ -546,43 +546,17 @@ func (g *KnockoutWhist) cpuPlaySmart(playerIdx int, valid []int) int {
 	player := g.players[playerIdx]
 	if len(g.currentTrick) == 0 {
 		// リード: 強い札で主導権を取る。
-		return g.maxBy(player, valid, func(c *Card) int { return g.knockoutRank(c) })
+		return pickHighest(player, valid, func(c *Card) int { return g.knockoutRank(c) })
 	}
 	winnerIdx := g.trickWinner()
 	topRank := g.trickTopRank(winnerIdx)
 	winners := knockoutFilter(valid, func(idx int) bool { return g.knockoutRank(player.GetCard(idx)) > topRank })
 	if len(winners) > 0 {
 		// 最小コストで勝てる札。
-		return g.minBy(player, winners, func(c *Card) int { return g.knockoutRank(c) })
+		return pickLowest(player, winners, func(c *Card) int { return g.knockoutRank(c) })
 	}
 	// 勝てない: 最弱札を捨てる。
-	return g.minBy(player, valid, func(c *Card) int { return g.knockoutRank(c) })
-}
-
-// minBy score が最小となるインデックスを返す。
-func (g *KnockoutWhist) minBy(player *KnockoutWhistPlayer, indices []int, score func(*Card) int) int {
-	best := indices[0]
-	bestScore := score(player.GetCard(best))
-	for _, idx := range indices[1:] {
-		if s := score(player.GetCard(idx)); s < bestScore {
-			bestScore = s
-			best = idx
-		}
-	}
-	return best
-}
-
-// maxBy score が最大となるインデックスを返す。
-func (g *KnockoutWhist) maxBy(player *KnockoutWhistPlayer, indices []int, score func(*Card) int) int {
-	best := indices[0]
-	bestScore := score(player.GetCard(best))
-	for _, idx := range indices[1:] {
-		if s := score(player.GetCard(idx)); s > bestScore {
-			bestScore = s
-			best = idx
-		}
-	}
-	return best
+	return pickLowest(player, valid, func(c *Card) int { return g.knockoutRank(c) })
 }
 
 // knockoutFilter 述語を満たすインデックスを抽出する。

--- a/internal/domain/Loo.go
+++ b/internal/domain/Loo.go
@@ -727,41 +727,17 @@ func (g *Loo) cpuPlaySmart(playerIdx int, valid []int) int {
 	player := g.players[playerIdx]
 	if len(g.currentTrick) == 0 {
 		// リード: 高い札で主導権を握る。
-		return g.maxBy(player, valid, func(c *Card) int { return g.looRank(c) })
+		return pickHighest(player, valid, func(c *Card) int { return g.looRank(c) })
 	}
 	winnerIdx := g.trickWinner()
 	top := g.trickTopRank(winnerIdx)
 	winners := looFilter(valid, func(idx int) bool { return g.looRank(player.GetCard(idx)) > top })
 	if len(winners) > 0 {
 		// 勝てるなら最小の勝ち札で勝つ。
-		return g.minBy(player, winners, func(c *Card) int { return g.looRank(c) })
+		return pickLowest(player, winners, func(c *Card) int { return g.looRank(c) })
 	}
 	// 勝てない: 最小の札を捨てる。
-	return g.minBy(player, valid, func(c *Card) int { return g.looRank(c) })
-}
-
-func (g *Loo) minBy(player *LooPlayer, indices []int, score func(*Card) int) int {
-	best := indices[0]
-	bestScore := score(player.GetCard(best))
-	for _, idx := range indices[1:] {
-		if s := score(player.GetCard(idx)); s < bestScore {
-			bestScore = s
-			best = idx
-		}
-	}
-	return best
-}
-
-func (g *Loo) maxBy(player *LooPlayer, indices []int, score func(*Card) int) int {
-	best := indices[0]
-	bestScore := score(player.GetCard(best))
-	for _, idx := range indices[1:] {
-		if s := score(player.GetCard(idx)); s > bestScore {
-			bestScore = s
-			best = idx
-		}
-	}
-	return best
+	return pickLowest(player, valid, func(c *Card) int { return g.looRank(c) })
 }
 
 func looFilter(indices []int, pred func(int) bool) []int {

--- a/internal/domain/Manille.go
+++ b/internal/domain/Manille.go
@@ -488,7 +488,7 @@ func (g *Manille) cpuSelectPlayCard(playerIdx int) int {
 func (g *Manille) cpuPlaySmart(playerIdx int, valid []int) int {
 	player := g.players[playerIdx]
 	if len(g.currentTrick) == 0 {
-		return g.minBy(player, valid, func(c *Card) int {
+		return pickLowest(player, valid, func(c *Card) int {
 			return manilleCardPoints(c)*100 + g.manilleRank(c)
 		})
 	}
@@ -504,42 +504,16 @@ func (g *Manille) cpuPlaySmart(playerIdx int, valid []int) int {
 		// 味方が勝っている: 得点の高い札を渡す。
 		nonWinners := manilleFilter(valid, func(idx int) bool { return g.manilleRank(player.GetCard(idx)) < topRank })
 		if len(nonWinners) > 0 {
-			return g.maxBy(player, nonWinners, func(c *Card) int { return manilleCardPoints(c) })
+			return pickHighest(player, nonWinners, func(c *Card) int { return manilleCardPoints(c) })
 		}
-		return g.minBy(player, valid, func(c *Card) int { return g.manilleRank(c) })
+		return pickLowest(player, valid, func(c *Card) int { return g.manilleRank(c) })
 	}
 	if trickPts > 0 && len(winners) > 0 {
-		return g.minBy(player, winners, func(c *Card) int { return g.manilleRank(c) })
+		return pickLowest(player, winners, func(c *Card) int { return g.manilleRank(c) })
 	}
-	return g.minBy(player, valid, func(c *Card) int {
+	return pickLowest(player, valid, func(c *Card) int {
 		return manilleCardPoints(c)*100 + g.manilleRank(c)
 	})
-}
-
-// minBy score が最小となるインデックスを返す。
-func (g *Manille) minBy(player *ManillePlayer, indices []int, score func(*Card) int) int {
-	best := indices[0]
-	bestScore := score(player.GetCard(best))
-	for _, idx := range indices[1:] {
-		if s := score(player.GetCard(idx)); s < bestScore {
-			bestScore = s
-			best = idx
-		}
-	}
-	return best
-}
-
-// maxBy score が最大となるインデックスを返す。
-func (g *Manille) maxBy(player *ManillePlayer, indices []int, score func(*Card) int) int {
-	best := indices[0]
-	bestScore := score(player.GetCard(best))
-	for _, idx := range indices[1:] {
-		if s := score(player.GetCard(idx)); s > bestScore {
-			bestScore = s
-			best = idx
-		}
-	}
-	return best
 }
 
 // manilleFilter 述語を満たすインデックスを抽出する。

--- a/internal/domain/Marias.go
+++ b/internal/domain/Marias.go
@@ -551,7 +551,7 @@ func (g *Marias) cpuSelectPlayCard(playerIdx int) int {
 func (g *Marias) cpuPlaySmart(playerIdx int, valid []int) int {
 	player := g.players[playerIdx]
 	if len(g.currentTrick) == 0 {
-		return g.minBy(player, valid, func(c *Card) int {
+		return pickLowest(player, valid, func(c *Card) int {
 			return mariasCardPoints(c)*100 + g.mariasRank(c)
 		})
 	}
@@ -563,24 +563,11 @@ func (g *Marias) cpuPlaySmart(playerIdx int, valid []int) int {
 	}
 	winners := mariasFilter(valid, func(idx int) bool { return g.mariasRank(player.GetCard(idx)) > topRank })
 	if trickPts > 0 && len(winners) > 0 {
-		return g.minBy(player, winners, func(c *Card) int { return g.mariasRank(c) })
+		return pickLowest(player, winners, func(c *Card) int { return g.mariasRank(c) })
 	}
-	return g.minBy(player, valid, func(c *Card) int {
+	return pickLowest(player, valid, func(c *Card) int {
 		return mariasCardPoints(c)*100 + g.mariasRank(c)
 	})
-}
-
-// minBy score が最小となるインデックスを返す。
-func (g *Marias) minBy(player *MariasPlayer, indices []int, score func(*Card) int) int {
-	best := indices[0]
-	bestScore := score(player.GetCard(best))
-	for _, idx := range indices[1:] {
-		if s := score(player.GetCard(idx)); s < bestScore {
-			bestScore = s
-			best = idx
-		}
-	}
-	return best
 }
 
 // mariasFilter 述語を満たすインデックスを抽出する。

--- a/internal/domain/Nap.go
+++ b/internal/domain/Nap.go
@@ -618,9 +618,9 @@ func (g *Nap) cpuPlaySmart(playerIdx int, valid []int) int {
 	isDeclarer := playerIdx == g.declarerIdx
 	if len(g.currentTrick) == 0 {
 		if isDeclarer {
-			return g.maxBy(player, valid, func(c *Card) int { return g.napRank(c) })
+			return pickHighest(player, valid, func(c *Card) int { return g.napRank(c) })
 		}
-		return g.minBy(player, valid, func(c *Card) int { return g.napRank(c) })
+		return pickLowest(player, valid, func(c *Card) int { return g.napRank(c) })
 	}
 	winnerIdx := g.trickWinner()
 	topRank := g.trickTopRank(winnerIdx)
@@ -629,35 +629,9 @@ func (g *Nap) cpuPlaySmart(playerIdx int, valid []int) int {
 	declarerWinning := winnerIdx == g.declarerIdx
 	wantWin := isDeclarer || !declarerWinning
 	if wantWin && len(winners) > 0 {
-		return g.minBy(player, winners, func(c *Card) int { return g.napRank(c) })
+		return pickLowest(player, winners, func(c *Card) int { return g.napRank(c) })
 	}
-	return g.minBy(player, valid, func(c *Card) int { return g.napRank(c) })
-}
-
-// minBy score が最小となるインデックスを返す。
-func (g *Nap) minBy(player *NapPlayer, indices []int, score func(*Card) int) int {
-	best := indices[0]
-	bestScore := score(player.GetCard(best))
-	for _, idx := range indices[1:] {
-		if s := score(player.GetCard(idx)); s < bestScore {
-			bestScore = s
-			best = idx
-		}
-	}
-	return best
-}
-
-// maxBy score が最大となるインデックスを返す。
-func (g *Nap) maxBy(player *NapPlayer, indices []int, score func(*Card) int) int {
-	best := indices[0]
-	bestScore := score(player.GetCard(best))
-	for _, idx := range indices[1:] {
-		if s := score(player.GetCard(idx)); s > bestScore {
-			bestScore = s
-			best = idx
-		}
-	}
-	return best
+	return pickLowest(player, valid, func(c *Card) int { return g.napRank(c) })
 }
 
 // napFilter 述語を満たすインデックスを抽出する。

--- a/internal/domain/Preference.go
+++ b/internal/domain/Preference.go
@@ -641,48 +641,22 @@ func (g *Preference) cpuPlaySmart(playerIdx int, valid []int) int {
 	isDeclarer := playerIdx == g.declarerIdx
 	misere := g.contract == PreferenceBidMisere
 	if isDeclarer && misere {
-		return g.minBy(player, valid, func(c *Card) int { return g.preferenceRank(c) })
+		return pickLowest(player, valid, func(c *Card) int { return g.preferenceRank(c) })
 	}
 	if len(g.currentTrick) == 0 {
 		if isDeclarer {
-			return g.maxBy(player, valid, func(c *Card) int { return g.preferenceRank(c) })
+			return pickHighest(player, valid, func(c *Card) int { return g.preferenceRank(c) })
 		}
-		return g.minBy(player, valid, func(c *Card) int { return g.preferenceRank(c) })
+		return pickLowest(player, valid, func(c *Card) int { return g.preferenceRank(c) })
 	}
 	winnerIdx := g.trickWinner()
 	topRank := g.trickTopRank(winnerIdx)
 	winners := preferenceFilter(valid, func(idx int) bool { return g.preferenceRank(player.GetCard(idx)) > topRank })
 	wantWin := isDeclarer != misere
 	if wantWin && len(winners) > 0 {
-		return g.minBy(player, winners, func(c *Card) int { return g.preferenceRank(c) })
+		return pickLowest(player, winners, func(c *Card) int { return g.preferenceRank(c) })
 	}
-	return g.minBy(player, valid, func(c *Card) int { return g.preferenceRank(c) })
-}
-
-// minBy score が最小となるインデックスを返す。
-func (g *Preference) minBy(player *PreferencePlayer, indices []int, score func(*Card) int) int {
-	best := indices[0]
-	bestScore := score(player.GetCard(best))
-	for _, idx := range indices[1:] {
-		if s := score(player.GetCard(idx)); s < bestScore {
-			bestScore = s
-			best = idx
-		}
-	}
-	return best
-}
-
-// maxBy score が最大となるインデックスを返す。
-func (g *Preference) maxBy(player *PreferencePlayer, indices []int, score func(*Card) int) int {
-	best := indices[0]
-	bestScore := score(player.GetCard(best))
-	for _, idx := range indices[1:] {
-		if s := score(player.GetCard(idx)); s > bestScore {
-			bestScore = s
-			best = idx
-		}
-	}
-	return best
+	return pickLowest(player, valid, func(c *Card) int { return g.preferenceRank(c) })
 }
 
 // preferenceFilter 述語を満たすインデックスを抽出する。

--- a/internal/domain/Sedma.go
+++ b/internal/domain/Sedma.go
@@ -388,7 +388,7 @@ func (g *Sedma) cpuPlaySmart(playerIdx int, valid []int) int {
 	player := g.players[playerIdx]
 	// リード時: 7 とポイント札を温存し、価値の低い札を出す。
 	if len(g.currentTrick) == 0 {
-		return g.minBy(player, valid, func(c *Card) int { return sedmaLeadCost(c) })
+		return pickLowest(player, valid, func(c *Card) int { return sedmaLeadCost(c) })
 	}
 	leadRank := g.currentTrick[0].Card.GetValue()
 	trickPts := 0
@@ -403,7 +403,7 @@ func (g *Sedma) cpuPlaySmart(playerIdx int, valid []int) int {
 	})
 	// 味方が奪取中ならポイント札を渡して温存。
 	if partnerWinning {
-		return g.maxBy(player, valid, func(c *Card) int { return sedmaCardPoints(c) })
+		return pickHighest(player, valid, func(c *Card) int { return sedmaCardPoints(c) })
 	}
 	// ポイントがあり奪取できるなら、まず同ランク、無ければ 7 で奪取。
 	if trickPts > 0 && len(captures) > 0 {
@@ -414,7 +414,7 @@ func (g *Sedma) cpuPlaySmart(playerIdx int, valid []int) int {
 		return captures[0]
 	}
 	// 奪取しない: 価値の低い非ポイント・非 7 札を捨てる。
-	return g.minBy(player, valid, func(c *Card) int { return sedmaLeadCost(c) })
+	return pickLowest(player, valid, func(c *Card) int { return sedmaLeadCost(c) })
 }
 
 // sedmaLeadCost リード/ディスカード時の温存コスト (低いほど捨ててよい)。
@@ -423,32 +423,6 @@ func sedmaLeadCost(c *Card) int {
 		return 100 // 7 は最後まで温存
 	}
 	return sedmaCardPoints(c)*10 + sedmaSortRank(c.GetValue())
-}
-
-// minBy score が最小となるインデックスを返す。
-func (g *Sedma) minBy(player *SedmaPlayer, indices []int, score func(*Card) int) int {
-	best := indices[0]
-	bestScore := score(player.GetCard(best))
-	for _, idx := range indices[1:] {
-		if s := score(player.GetCard(idx)); s < bestScore {
-			bestScore = s
-			best = idx
-		}
-	}
-	return best
-}
-
-// maxBy score が最大となるインデックスを返す。
-func (g *Sedma) maxBy(player *SedmaPlayer, indices []int, score func(*Card) int) int {
-	best := indices[0]
-	bestScore := score(player.GetCard(best))
-	for _, idx := range indices[1:] {
-		if s := score(player.GetCard(idx)); s > bestScore {
-			bestScore = s
-			best = idx
-		}
-	}
-	return best
 }
 
 // sedmaFilter 述語を満たすインデックスを抽出する。

--- a/internal/domain/Sheepshead.go
+++ b/internal/domain/Sheepshead.go
@@ -1113,7 +1113,7 @@ func (g *Sheepshead) cpuPlaySmart(playerIdx int, valid []int) int {
 
 	// リード: 得点・強さの低い札を出して温存する。
 	if len(g.currentTrick) == 0 {
-		return g.minBy(player, valid, func(c *Card) int {
+		return pickLowest(player, valid, func(c *Card) int {
 			return sheepsheadCardPoints(c.GetValue())*100 + sheepsheadStrength(c)
 		})
 	}
@@ -1137,14 +1137,14 @@ func (g *Sheepshead) cpuPlaySmart(playerIdx int, valid []int) int {
 	if len(follows) == 0 {
 		// ボイド: 味方が勝っていれば得点札を渡し、そうでなければ低得点札を捨てる。
 		if partnerWinning {
-			return g.maxBy(player, valid, func(c *Card) int {
+			return pickHighest(player, valid, func(c *Card) int {
 				if sheepsheadIsTrump(c) {
 					return -sheepsheadStrength(c) // 切り札は温存
 				}
 				return sheepsheadCardPoints(c.GetValue())*100 - sheepsheadStrength(c)
 			})
 		}
-		return g.minBy(player, valid, func(c *Card) int {
+		return pickLowest(player, valid, func(c *Card) int {
 			return sheepsheadCardPoints(c.GetValue())*100 + sheepsheadStrength(c)
 		})
 	}
@@ -1158,17 +1158,17 @@ func (g *Sheepshead) cpuPlaySmart(playerIdx int, valid []int) int {
 			return sheepsheadStrength(player.GetCard(idx)) < topStrength
 		})
 		if len(nonWinners) > 0 {
-			return g.maxBy(player, nonWinners, func(c *Card) int {
+			return pickHighest(player, nonWinners, func(c *Card) int {
 				return sheepsheadCardPoints(c.GetValue())*100 - sheepsheadStrength(c)
 			})
 		}
-		return g.minBy(player, follows, func(c *Card) int { return sheepsheadStrength(c) })
+		return pickLowest(player, follows, func(c *Card) int { return sheepsheadStrength(c) })
 	}
 
 	if trickPts > 0 && len(winners) > 0 {
-		return g.minBy(player, winners, func(c *Card) int { return sheepsheadStrength(c) })
+		return pickLowest(player, winners, func(c *Card) int { return sheepsheadStrength(c) })
 	}
-	return g.minBy(player, follows, func(c *Card) int {
+	return pickLowest(player, follows, func(c *Card) int {
 		return sheepsheadCardPoints(c.GetValue())*100 + sheepsheadStrength(c)
 	})
 }
@@ -1177,32 +1177,6 @@ func (g *Sheepshead) cpuPlaySmart(playerIdx int, valid []int) int {
 // CPU はチーム構成を把握しているものとして扱う (簡易 AI)。
 func (g *Sheepshead) cpuSameTeam(a, b int) bool {
 	return g.isPickerTeam(a) == g.isPickerTeam(b)
-}
-
-// minBy score が最小となるインデックスを返す。
-func (g *Sheepshead) minBy(player *SheepsheadPlayer, indices []int, score func(*Card) int) int {
-	best := indices[0]
-	bestScore := score(player.GetCard(best))
-	for _, idx := range indices[1:] {
-		if s := score(player.GetCard(idx)); s < bestScore {
-			bestScore = s
-			best = idx
-		}
-	}
-	return best
-}
-
-// maxBy score が最大となるインデックスを返す。
-func (g *Sheepshead) maxBy(player *SheepsheadPlayer, indices []int, score func(*Card) int) int {
-	best := indices[0]
-	bestScore := score(player.GetCard(best))
-	for _, idx := range indices[1:] {
-		if s := score(player.GetCard(idx)); s > bestScore {
-			bestScore = s
-			best = idx
-		}
-	}
-	return best
 }
 
 // sheepsheadFilter 述語を満たすインデックスを抽出する。

--- a/internal/domain/SoloWhist.go
+++ b/internal/domain/SoloWhist.go
@@ -638,49 +638,23 @@ func (g *SoloWhist) cpuPlaySmart(playerIdx int, valid []int) int {
 	misere := g.contract == SoloWhistBidMisere
 	// Misère の宣言者は勝ちたくないので最も弱い札を出す。
 	if isDeclarer && misere {
-		return g.minBy(player, valid, func(c *Card) int { return g.soloWhistRank(c) })
+		return pickLowest(player, valid, func(c *Card) int { return g.soloWhistRank(c) })
 	}
 	if len(g.currentTrick) == 0 {
 		// リード: 宣言者は強い札、防御は弱い札。
 		if isDeclarer {
-			return g.maxBy(player, valid, func(c *Card) int { return g.soloWhistRank(c) })
+			return pickHighest(player, valid, func(c *Card) int { return g.soloWhistRank(c) })
 		}
-		return g.minBy(player, valid, func(c *Card) int { return g.soloWhistRank(c) })
+		return pickLowest(player, valid, func(c *Card) int { return g.soloWhistRank(c) })
 	}
 	winnerIdx := g.trickWinner()
 	topRank := g.trickTopRank(winnerIdx)
 	winners := soloWhistFilter(valid, func(idx int) bool { return g.soloWhistRank(player.GetCard(idx)) > topRank })
 	wantWin := isDeclarer != misere // 宣言者(非Misère)は勝ちたい; 防御は宣言者を負かしたい
 	if wantWin && len(winners) > 0 {
-		return g.minBy(player, winners, func(c *Card) int { return g.soloWhistRank(c) })
+		return pickLowest(player, winners, func(c *Card) int { return g.soloWhistRank(c) })
 	}
-	return g.minBy(player, valid, func(c *Card) int { return g.soloWhistRank(c) })
-}
-
-// minBy score が最小となるインデックスを返す。
-func (g *SoloWhist) minBy(player *SoloWhistPlayer, indices []int, score func(*Card) int) int {
-	best := indices[0]
-	bestScore := score(player.GetCard(best))
-	for _, idx := range indices[1:] {
-		if s := score(player.GetCard(idx)); s < bestScore {
-			bestScore = s
-			best = idx
-		}
-	}
-	return best
-}
-
-// maxBy score が最大となるインデックスを返す。
-func (g *SoloWhist) maxBy(player *SoloWhistPlayer, indices []int, score func(*Card) int) int {
-	best := indices[0]
-	bestScore := score(player.GetCard(best))
-	for _, idx := range indices[1:] {
-		if s := score(player.GetCard(idx)); s > bestScore {
-			bestScore = s
-			best = idx
-		}
-	}
-	return best
+	return pickLowest(player, valid, func(c *Card) int { return g.soloWhistRank(c) })
 }
 
 // soloWhistFilter 述語を満たすインデックスを抽出する。

--- a/internal/domain/SpoilFive.go
+++ b/internal/domain/SpoilFive.go
@@ -538,43 +538,17 @@ func (g *SpoilFive) cpuPlaySmart(playerIdx int, valid []int) int {
 	player := g.players[playerIdx]
 	if len(g.currentTrick) == 0 {
 		// リード: 強い札で取りに行く。
-		return g.maxBy(player, valid, func(c *Card) int { return g.spoilRank(c) })
+		return pickHighest(player, valid, func(c *Card) int { return g.spoilRank(c) })
 	}
 	winnerIdx := g.trickWinner()
 	topRank := g.trickTopRank(winnerIdx)
 	winners := spoilFilter(valid, func(idx int) bool { return g.spoilRank(player.GetCard(idx)) > topRank })
 	if len(winners) > 0 {
 		// 最小コストで勝てる札。
-		return g.minBy(player, winners, func(c *Card) int { return g.spoilRank(c) })
+		return pickLowest(player, winners, func(c *Card) int { return g.spoilRank(c) })
 	}
 	// 勝てない: 最弱札を捨てる。
-	return g.minBy(player, valid, func(c *Card) int { return g.spoilRank(c) })
-}
-
-// minBy score が最小となるインデックスを返す。
-func (g *SpoilFive) minBy(player *SpoilFivePlayer, indices []int, score func(*Card) int) int {
-	best := indices[0]
-	bestScore := score(player.GetCard(best))
-	for _, idx := range indices[1:] {
-		if s := score(player.GetCard(idx)); s < bestScore {
-			bestScore = s
-			best = idx
-		}
-	}
-	return best
-}
-
-// maxBy score が最大となるインデックスを返す。
-func (g *SpoilFive) maxBy(player *SpoilFivePlayer, indices []int, score func(*Card) int) int {
-	best := indices[0]
-	bestScore := score(player.GetCard(best))
-	for _, idx := range indices[1:] {
-		if s := score(player.GetCard(idx)); s > bestScore {
-			bestScore = s
-			best = idx
-		}
-	}
-	return best
+	return pickLowest(player, valid, func(c *Card) int { return g.spoilRank(c) })
 }
 
 // spoilFilter 述語を満たすインデックスを抽出する。

--- a/internal/domain/Sueca.go
+++ b/internal/domain/Sueca.go
@@ -503,7 +503,7 @@ func (g *Sueca) cpuSelectPlayCard(playerIdx int) int {
 func (g *Sueca) cpuPlaySmart(playerIdx int, valid []int) int {
 	player := g.players[playerIdx]
 	if len(g.currentTrick) == 0 {
-		return g.minBy(player, valid, func(c *Card) int {
+		return pickLowest(player, valid, func(c *Card) int {
 			return suecaCardPoints(c.GetValue())*100 + suecaStrength(c.GetValue())
 		})
 	}
@@ -523,14 +523,14 @@ func (g *Sueca) cpuPlaySmart(playerIdx int, valid []int) int {
 	}
 	if len(follows) == 0 {
 		if partnerWinning {
-			return g.maxBy(player, valid, func(c *Card) int {
+			return pickHighest(player, valid, func(c *Card) int {
 				if c.GetDesign() == g.trumpSuit {
 					return -suecaStrength(c.GetValue())
 				}
 				return suecaCardPoints(c.GetValue())*100 - suecaStrength(c.GetValue())
 			})
 		}
-		return g.minBy(player, valid, func(c *Card) int {
+		return pickLowest(player, valid, func(c *Card) int {
 			return suecaCardPoints(c.GetValue())*100 + suecaStrength(c.GetValue())
 		})
 	}
@@ -538,44 +538,18 @@ func (g *Sueca) cpuPlaySmart(playerIdx int, valid []int) int {
 	if partnerWinning {
 		nonWinners := suecaFilter(follows, func(idx int) bool { return g.suecaRank(player.GetCard(idx)) < topRank })
 		if len(nonWinners) > 0 {
-			return g.maxBy(player, nonWinners, func(c *Card) int {
+			return pickHighest(player, nonWinners, func(c *Card) int {
 				return suecaCardPoints(c.GetValue())*100 - suecaStrength(c.GetValue())
 			})
 		}
-		return g.minBy(player, follows, func(c *Card) int { return suecaStrength(c.GetValue()) })
+		return pickLowest(player, follows, func(c *Card) int { return suecaStrength(c.GetValue()) })
 	}
 	if trickPts > 0 && len(winners) > 0 {
-		return g.minBy(player, winners, func(c *Card) int { return suecaStrength(c.GetValue()) })
+		return pickLowest(player, winners, func(c *Card) int { return suecaStrength(c.GetValue()) })
 	}
-	return g.minBy(player, follows, func(c *Card) int {
+	return pickLowest(player, follows, func(c *Card) int {
 		return suecaCardPoints(c.GetValue())*100 + suecaStrength(c.GetValue())
 	})
-}
-
-// minBy score が最小となるインデックスを返す。
-func (g *Sueca) minBy(player *SuecaPlayer, indices []int, score func(*Card) int) int {
-	best := indices[0]
-	bestScore := score(player.GetCard(best))
-	for _, idx := range indices[1:] {
-		if s := score(player.GetCard(idx)); s < bestScore {
-			bestScore = s
-			best = idx
-		}
-	}
-	return best
-}
-
-// maxBy score が最大となるインデックスを返す。
-func (g *Sueca) maxBy(player *SuecaPlayer, indices []int, score func(*Card) int) int {
-	best := indices[0]
-	bestScore := score(player.GetCard(best))
-	for _, idx := range indices[1:] {
-		if s := score(player.GetCard(idx)); s > bestScore {
-			bestScore = s
-			best = idx
-		}
-	}
-	return best
 }
 
 // suecaFilter 述語を満たすインデックスを抽出する。

--- a/internal/domain/Tressette.go
+++ b/internal/domain/Tressette.go
@@ -570,7 +570,7 @@ func (g *Tressette) cpuPlaySmart(playerIdx int, valid []int) int {
 
 	// リード: 得点・強さの低いカードを出して温存する。
 	if len(g.currentTrick) == 0 {
-		return g.minBy(player, valid, func(c *Card) int {
+		return pickLowest(player, valid, func(c *Card) int {
 			return tressetteThirds(c.GetValue())*100 + tressetteStrength(c.GetValue())
 		})
 	}
@@ -593,7 +593,7 @@ func (g *Tressette) cpuPlaySmart(playerIdx int, valid []int) int {
 
 	if len(follows) == 0 {
 		// ボイド: 得点・強さの低いカードを捨てて温存する。
-		return g.minBy(player, valid, func(c *Card) int {
+		return pickLowest(player, valid, func(c *Card) int {
 			return tressetteThirds(c.GetValue())*100 + tressetteStrength(c.GetValue())
 		})
 	}
@@ -609,48 +609,22 @@ func (g *Tressette) cpuPlaySmart(playerIdx int, valid []int) int {
 		})
 		if len(nonWinners) > 0 {
 			// 勝ちを取らない範囲で最も得点の高い札を渡す。
-			return g.maxBy(player, nonWinners, func(c *Card) int {
+			return pickHighest(player, nonWinners, func(c *Card) int {
 				return tressetteThirds(c.GetValue())*100 - tressetteStrength(c.GetValue())
 			})
 		}
 		// 上書きせざるを得ない場合は最弱札で被害を抑える。
-		return g.minBy(player, follows, func(c *Card) int { return tressetteStrength(c.GetValue()) })
+		return pickLowest(player, follows, func(c *Card) int { return tressetteStrength(c.GetValue()) })
 	}
 
 	// 相手が勝っている: 得点があり勝てるなら最小限の札で取りに行く。
 	if trickThirds > 0 && len(winners) > 0 {
-		return g.minBy(player, winners, func(c *Card) int { return tressetteStrength(c.GetValue()) })
+		return pickLowest(player, winners, func(c *Card) int { return tressetteStrength(c.GetValue()) })
 	}
 	// 取れない/取る価値がない: 得点・強さの低い札でダックする。
-	return g.minBy(player, follows, func(c *Card) int {
+	return pickLowest(player, follows, func(c *Card) int {
 		return tressetteThirds(c.GetValue())*100 + tressetteStrength(c.GetValue())
 	})
-}
-
-// minBy score が最小となるインデックスを返す
-func (g *Tressette) minBy(player *TressettePlayer, indices []int, score func(*Card) int) int {
-	best := indices[0]
-	bestScore := score(player.GetCard(best))
-	for _, idx := range indices[1:] {
-		if s := score(player.GetCard(idx)); s < bestScore {
-			bestScore = s
-			best = idx
-		}
-	}
-	return best
-}
-
-// maxBy score が最大となるインデックスを返す
-func (g *Tressette) maxBy(player *TressettePlayer, indices []int, score func(*Card) int) int {
-	best := indices[0]
-	bestScore := score(player.GetCard(best))
-	for _, idx := range indices[1:] {
-		if s := score(player.GetCard(idx)); s > bestScore {
-			bestScore = s
-			best = idx
-		}
-	}
-	return best
 }
 
 // tressetteFilter 述語を満たすインデックスを抽出する

--- a/internal/domain/Tute.go
+++ b/internal/domain/Tute.go
@@ -605,7 +605,7 @@ func (g *Tute) cpuPlaySmart(playerIdx int, valid []int) int {
 	player := g.players[playerIdx]
 	if len(g.currentTrick) == 0 {
 		// リード: 得点・強さの低い札を温存。
-		return g.minBy(player, valid, func(c *Card) int {
+		return pickLowest(player, valid, func(c *Card) int {
 			return tuteCardPoints(c.GetValue())*100 + tuteStrength(c.GetValue())
 		})
 	}
@@ -627,14 +627,14 @@ func (g *Tute) cpuPlaySmart(playerIdx int, valid []int) int {
 	if len(follows) == 0 {
 		if partnerWinning {
 			// 味方が勝っている: 得点札を渡す (切り札は温存)。
-			return g.maxBy(player, valid, func(c *Card) int {
+			return pickHighest(player, valid, func(c *Card) int {
 				if c.GetDesign() == g.trumpSuit {
 					return -tuteStrength(c.GetValue())
 				}
 				return tuteCardPoints(c.GetValue())*100 - tuteStrength(c.GetValue())
 			})
 		}
-		return g.minBy(player, valid, func(c *Card) int {
+		return pickLowest(player, valid, func(c *Card) int {
 			return tuteCardPoints(c.GetValue())*100 + tuteStrength(c.GetValue())
 		})
 	}
@@ -642,44 +642,18 @@ func (g *Tute) cpuPlaySmart(playerIdx int, valid []int) int {
 	if partnerWinning {
 		nonWinners := tuteFilter(follows, func(idx int) bool { return g.tuteRank(player.GetCard(idx)) < topRank })
 		if len(nonWinners) > 0 {
-			return g.maxBy(player, nonWinners, func(c *Card) int {
+			return pickHighest(player, nonWinners, func(c *Card) int {
 				return tuteCardPoints(c.GetValue())*100 - tuteStrength(c.GetValue())
 			})
 		}
-		return g.minBy(player, follows, func(c *Card) int { return tuteStrength(c.GetValue()) })
+		return pickLowest(player, follows, func(c *Card) int { return tuteStrength(c.GetValue()) })
 	}
 	if trickPts > 0 && len(winners) > 0 {
-		return g.minBy(player, winners, func(c *Card) int { return tuteStrength(c.GetValue()) })
+		return pickLowest(player, winners, func(c *Card) int { return tuteStrength(c.GetValue()) })
 	}
-	return g.minBy(player, follows, func(c *Card) int {
+	return pickLowest(player, follows, func(c *Card) int {
 		return tuteCardPoints(c.GetValue())*100 + tuteStrength(c.GetValue())
 	})
-}
-
-// minBy score が最小となるインデックスを返す。
-func (g *Tute) minBy(player *TutePlayer, indices []int, score func(*Card) int) int {
-	best := indices[0]
-	bestScore := score(player.GetCard(best))
-	for _, idx := range indices[1:] {
-		if s := score(player.GetCard(idx)); s < bestScore {
-			bestScore = s
-			best = idx
-		}
-	}
-	return best
-}
-
-// maxBy score が最大となるインデックスを返す。
-func (g *Tute) maxBy(player *TutePlayer, indices []int, score func(*Card) int) int {
-	best := indices[0]
-	bestScore := score(player.GetCard(best))
-	for _, idx := range indices[1:] {
-		if s := score(player.GetCard(idx)); s > bestScore {
-			bestScore = s
-			best = idx
-		}
-	}
-	return best
 }
 
 // tuteFilter 述語を満たすインデックスを抽出する。

--- a/internal/domain/TwentyNine.go
+++ b/internal/domain/TwentyNine.go
@@ -653,7 +653,7 @@ func (g *TwentyNine) cpuSelectPlayCard(playerIdx int) int {
 func (g *TwentyNine) cpuPlaySmart(playerIdx int, valid []int) int {
 	player := g.players[playerIdx]
 	if len(g.currentTrick) == 0 {
-		return g.minBy(player, valid, func(c *Card) int { return twentyNineCardPoints(c)*100 + g.twentyNineRank(c) })
+		return pickLowest(player, valid, func(c *Card) int { return twentyNineCardPoints(c)*100 + g.twentyNineRank(c) })
 	}
 	winnerIdx := g.trickWinner()
 	topRank := g.trickTopRank(winnerIdx)
@@ -661,38 +661,12 @@ func (g *TwentyNine) cpuPlaySmart(playerIdx int, valid []int) int {
 	winners := twentyNineFilter(valid, func(idx int) bool { return g.twentyNineRank(player.GetCard(idx)) > topRank })
 	if partnerWinning {
 		// 味方が勝っている: 得点札を渡す。
-		return g.maxBy(player, valid, func(c *Card) int { return twentyNineCardPoints(c) })
+		return pickHighest(player, valid, func(c *Card) int { return twentyNineCardPoints(c) })
 	}
 	if len(winners) > 0 {
-		return g.minBy(player, winners, func(c *Card) int { return g.twentyNineRank(c) })
+		return pickLowest(player, winners, func(c *Card) int { return g.twentyNineRank(c) })
 	}
-	return g.minBy(player, valid, func(c *Card) int { return twentyNineCardPoints(c)*100 + g.twentyNineRank(c) })
-}
-
-// minBy score が最小となるインデックスを返す。
-func (g *TwentyNine) minBy(player *TwentyNinePlayer, indices []int, score func(*Card) int) int {
-	best := indices[0]
-	bestScore := score(player.GetCard(best))
-	for _, idx := range indices[1:] {
-		if s := score(player.GetCard(idx)); s < bestScore {
-			bestScore = s
-			best = idx
-		}
-	}
-	return best
-}
-
-// maxBy score が最大となるインデックスを返す。
-func (g *TwentyNine) maxBy(player *TwentyNinePlayer, indices []int, score func(*Card) int) int {
-	best := indices[0]
-	bestScore := score(player.GetCard(best))
-	for _, idx := range indices[1:] {
-		if s := score(player.GetCard(idx)); s > bestScore {
-			bestScore = s
-			best = idx
-		}
-	}
-	return best
+	return pickLowest(player, valid, func(c *Card) int { return twentyNineCardPoints(c)*100 + g.twentyNineRank(c) })
 }
 
 // twentyNineFilter 述語を満たすインデックスを抽出する。

--- a/internal/domain/Tysiac.go
+++ b/internal/domain/Tysiac.go
@@ -902,7 +902,7 @@ func (g *Tysiac) cpuPlaySmart(playerIdx int, valid []int) int {
 		if idx := g.cpuMarriageLead(playerIdx, valid); idx >= 0 {
 			return idx
 		}
-		return g.minBy(player, valid, func(c *Card) int {
+		return pickLowest(player, valid, func(c *Card) int {
 			return tysiacCardPoints(c)*100 + g.tysiacRank(c)
 		})
 	}
@@ -914,9 +914,9 @@ func (g *Tysiac) cpuPlaySmart(playerIdx int, valid []int) int {
 	}
 	winners := tysiacFilter(valid, func(idx int) bool { return g.tysiacRank(player.GetCard(idx)) > topRank })
 	if trickPts > 0 && len(winners) > 0 {
-		return g.minBy(player, winners, func(c *Card) int { return g.tysiacRank(c) })
+		return pickLowest(player, winners, func(c *Card) int { return g.tysiacRank(c) })
 	}
-	return g.minBy(player, valid, func(c *Card) int {
+	return pickLowest(player, valid, func(c *Card) int {
 		return tysiacCardPoints(c)*100 + g.tysiacRank(c)
 	})
 }
@@ -937,19 +937,6 @@ func (g *Tysiac) cpuMarriageLead(playerIdx int, valid []int) int {
 		}
 		if pts := tysiacMarriagePoints(suit); pts > bestPts {
 			bestPts = pts
-			best = idx
-		}
-	}
-	return best
-}
-
-// minBy score が最小となるインデックスを返す。
-func (g *Tysiac) minBy(player *TysiacPlayer, indices []int, score func(*Card) int) int {
-	best := indices[0]
-	bestScore := score(player.GetCard(best))
-	for _, idx := range indices[1:] {
-		if s := score(player.GetCard(idx)); s < bestScore {
-			bestScore = s
 			best = idx
 		}
 	}


### PR DESCRIPTION
## 概要

[#5185](https://github.com/yuta-yoshinaga/go_trumpcards/issues/5185) フェーズ4の第1弾です。**466行削除**（90追加 / 556削除）。

## issue の提案を採らず、既存ヘルパを使いました

issue 本文とコメントでは「`minBy` / `maxBy` 用に**新しいジェネリックヘルパを追加する**」と提案していました。実装に入って調べたところ、**同じものが既にありました**。

```go
// internal/domain/trick_cpu_helpers.go — issue #4300 で追加済み
func pickLowest[P cardIndexer](player P, indices []int, rank func(*Card) int) int
func pickHighest[P cardIndexer](player P, indices []int, rank func(*Card) int) int
```

19個の `minBy` と17個の `maxBy` は互いにバイト同一であるだけでなく、**この2つとも同一のループ**でした。したがって本 PR は新しいヘルパを足さず、**36メソッドを削除して90箇所の呼び出しを既存ヘルパに向け替える**だけです。同じループの3つ目の綴りを増やすより筋が通ります。

## 挙動は変わりません

唯一の差は **`indices` が空のとき**です。

| | 空スライス |
|---|---|
| `minBy` | `indices[0]` で **panic** |
| `pickLowest` | **-1 を返す** |

呼び出し側は既にガードしています（`if len(winners) > 0` / `if len(nonWinners) > 0`、`follows` が空の分岐では `valid` に差し替え）。到達しないケースなので、実挙動は不変です。

## サイズについて（本 PR の要注意点）

`pickLowest` / `pickHighest` は**ジェネリック**なので、19の新しいプレイヤー型でインスタンス化されます。[これまでの実測](https://github.com/yuta-yoshinaga/go_trumpcards/pull/5198#issuecomment-5225885456)から、**単相化は gzip で不利に働きうる**と分かっています（重複は gzip でほぼ無料なので、削減益はほぼゼロ／単相化コストだけ残る）。

**CI の `tinygo-build` で6 worker すべてを前後比較し、増えるようなら本 PR は取り下げます。** 最逼迫は extra3（余裕 127.1KB）です。

## テスト計画

- [x] 36メソッドが**バイト同一の正典ボディ**であることを機械検証してから削除（不一致があれば中断する実装）
- [x] 90箇所の呼び出し書き換え
- [x] `go build ./...` / `gofmt -l` クリーン
- [x] `go test -tags test ./internal/domain/... ./internal/usecase/...` 通過（domain 41.9s）
- [x] `golangci-lint run ./internal/domain/...` → 0 issues
- [ ] **Worker サイズ前後比較（CI 待ち）** — 増えたら取り下げ

## 補足

36メソッドすべて**レシーバ `g` を一度も使っていません**でした。もともと自由関数の形をしており、メソッドである必要がなかったということです。#5185 の残りクラスタ（`playerName` 88 / `IsHumanTurn` 68 ほか）を見るときも、**まず既存ヘルパを探す**べきという教訓になりました。

Refs #5185