### PR TITLE
refactor(domain): replace 62 findHumanIdx methods with the shared helper

### DIFF
--- a/internal/domain/Aluette.go
+++ b/internal/domain/Aluette.go
@@ -693,19 +693,9 @@ type AluetteHint struct {
 	Reason      string // ヒント理由キー
 }
 
-// findHumanIdx 人間の席を返す (居なければ -1)。
-func (g *Aluette) findHumanIdx() int {
-	for i, p := range g.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
-}
-
 // GetHint 人間プレイヤーへのヒント。手番でなければ nil。
 func (g *Aluette) GetHint() *AluetteHint {
-	human := g.findHumanIdx()
+	human := findHumanIdx(g.players)
 	if human < 0 || g.phase != AluettePhasePlay || g.currentPlayerIdx != human {
 		return nil
 	}

--- a/internal/domain/Basra.go
+++ b/internal/domain/Basra.go
@@ -754,7 +754,7 @@ func (g *Basra) GetHint() *BasraHint {
 	if g.state.gameEndFlag || g.state.phase != BasraPhasePlay {
 		return nil
 	}
-	human := g.findHumanIdx()
+	human := findHumanIdx(g.players)
 	if human < 0 || g.state.currentTurn != human {
 		return nil
 	}
@@ -792,15 +792,6 @@ func (g *Basra) GetHint() *BasraHint {
 }
 
 // --- ヘルパー ---
-
-func (g *Basra) findHumanIdx() int {
-	for i, p := range g.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
-}
 
 // sortHumanHand は人間の手札を表示用にスート→ランク順で並べ替える。
 func (g *Basra) sortHumanHand() {

--- a/internal/domain/Belote.go
+++ b/internal/domain/Belote.go
@@ -254,7 +254,7 @@ func (b *Belote) PlayerPickUp(orderUp bool) error {
 	if b.phase != BelotePhaseBidPickUp {
 		return ErrWrongPhase
 	}
-	humanIdx := b.findHumanIdx()
+	humanIdx := findHumanIdx(b.players)
 	if humanIdx < 0 || b.bidPlayerIdx != humanIdx {
 		return ErrNotHumanTurn
 	}
@@ -322,7 +322,7 @@ func (b *Belote) PlayerCallTrump(suit int) error {
 	if b.phase != BelotePhaseBidCallTrump {
 		return ErrWrongPhase
 	}
-	humanIdx := b.findHumanIdx()
+	humanIdx := findHumanIdx(b.players)
 	if humanIdx < 0 || b.bidPlayerIdx != humanIdx {
 		return ErrNotHumanTurn
 	}
@@ -344,7 +344,7 @@ func (b *Belote) PlayerPassCall() error {
 	if b.phase != BelotePhaseBidCallTrump {
 		return ErrWrongPhase
 	}
-	humanIdx := b.findHumanIdx()
+	humanIdx := findHumanIdx(b.players)
 	if humanIdx < 0 || b.bidPlayerIdx != humanIdx {
 		return ErrNotHumanTurn
 	}
@@ -1076,15 +1076,6 @@ func beloteSortHand(p *BelotePlayer, b *Belote) {
 	})
 }
 
-func (b *Belote) findHumanIdx() int {
-	for i, p := range b.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
-}
-
 func (b *Belote) playerName(idx int) string {
 	if idx < 0 || idx >= len(b.players) {
 		return fmt.Sprintf("Player %d", idx)
@@ -1099,7 +1090,7 @@ func (b *Belote) playerName(idx int) string {
 
 // GetHint 現フェーズのヒントを返す (人間プレイヤー視点)
 func (b *Belote) GetHint() *BeloteHint {
-	humanIdx := b.findHumanIdx()
+	humanIdx := findHumanIdx(b.players)
 	if humanIdx < 0 {
 		return nil
 	}
@@ -1134,7 +1125,7 @@ func (b *Belote) GetHint() *BeloteHint {
 }
 
 func (b *Belote) playHintReason(chosenIdx int) string {
-	humanIdx := b.findHumanIdx()
+	humanIdx := findHumanIdx(b.players)
 	if humanIdx < 0 {
 		return ""
 	}

--- a/internal/domain/BidWhist.go
+++ b/internal/domain/BidWhist.go
@@ -240,7 +240,7 @@ func (g *BidWhist) PlayerBid(tricks, direction int) error {
 	if g.phase != BidWhistPhaseBid {
 		return ErrWrongPhase
 	}
-	humanIdx := g.findHumanIdx()
+	humanIdx := findHumanIdx(g.players)
 	if humanIdx < 0 || g.bidPlayerIdx != humanIdx {
 		return ErrNotHumanTurn
 	}
@@ -263,7 +263,7 @@ func (g *BidWhist) PlayerPass() error {
 	if g.phase != BidWhistPhaseBid {
 		return ErrWrongPhase
 	}
-	humanIdx := g.findHumanIdx()
+	humanIdx := findHumanIdx(g.players)
 	if humanIdx < 0 || g.bidPlayerIdx != humanIdx {
 		return ErrNotHumanTurn
 	}
@@ -958,7 +958,7 @@ func (g *BidWhist) currentWinnerScore(ls int) int {
 
 // GetHint 現在の人間の手番に対するヒントを返す
 func (g *BidWhist) GetHint() *BidWhistHint {
-	humanIdx := g.findHumanIdx()
+	humanIdx := findHumanIdx(g.players)
 	if humanIdx < 0 || g.gameEndFlag {
 		return nil
 	}
@@ -1207,16 +1207,6 @@ func (g *BidWhist) CardRankPublic(card *Card) int { return g.cardRank(card) }
 func (g *BidWhist) EffectiveSuitPublic(card *Card) int { return g.effectiveSuit(card) }
 
 // --- Private helpers ---
-
-// findHumanIdx 人間プレイヤーのインデックスを返す (-1=なし)
-func (g *BidWhist) findHumanIdx() int {
-	for i, p := range g.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
-}
 
 // sortAllHands 全プレイヤーの手札をソートする
 func (g *BidWhist) sortAllHands() {

--- a/internal/domain/Bourre.go
+++ b/internal/domain/Bourre.go
@@ -594,7 +594,7 @@ func (b *Bourre) checkGameEnd() {
 			solvent++
 		}
 	}
-	humanIdx := b.findHumanIdx()
+	humanIdx := findHumanIdx(b.players)
 	humanBroke := humanIdx >= 0 && b.players[humanIdx].GetChips() <= 0
 	if solvent > 1 && !humanBroke {
 		return
@@ -670,16 +670,6 @@ func (b *Bourre) activeCount() int {
 		}
 	}
 	return cnt
-}
-
-// findHumanIdx 人間プレイヤーのインデックス (-1 = なし)
-func (b *Bourre) findHumanIdx() int {
-	for i, p := range b.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
 }
 
 // isLegalPlay card のプレイが合法か (legalPlays への所属で判定)

--- a/internal/domain/Bridge.go
+++ b/internal/domain/Bridge.go
@@ -225,7 +225,7 @@ func (b *Bridge) PlayerBid(bidType int, level int, suit int) error {
 	if b.phase != BridgePhaseBid {
 		return ErrWrongPhase
 	}
-	humanIdx := b.findHumanIdx()
+	humanIdx := findHumanIdx(b.players)
 	if humanIdx < 0 || b.bidPlayerIdx != humanIdx {
 		return ErrNotHumanTurn
 	}
@@ -490,7 +490,7 @@ func (b *Bridge) PlayerPlay(cardIndex int) error {
 
 	// デクレアラーはダミーのカードもプレイできる
 	actingPlayer := b.currentPlayerIdx
-	humanIdx := b.findHumanIdx()
+	humanIdx := findHumanIdx(b.players)
 	if humanIdx < 0 {
 		return ErrNotHumanTurn
 	}
@@ -995,7 +995,7 @@ func (b *Bridge) IsHumanTurn() bool {
 	if b.phase != BridgePhasePlay {
 		return false
 	}
-	humanIdx := b.findHumanIdx()
+	humanIdx := findHumanIdx(b.players)
 	if humanIdx < 0 {
 		return false
 	}
@@ -1043,7 +1043,7 @@ func (b *Bridge) GetValidPlayIndices(playerIdx int) []int {
 
 // GetHint ヒントを取得する
 func (b *Bridge) GetHint() *BridgeHint {
-	humanIdx := b.findHumanIdx()
+	humanIdx := findHumanIdx(b.players)
 	if humanIdx < 0 {
 		return nil
 	}
@@ -1076,16 +1076,6 @@ func (b *Bridge) GetHint() *BridgeHint {
 }
 
 // --- Private methods ---
-
-// findHumanIdx 人間プレイヤーのインデックスを返す (-1=なし)
-func (b *Bridge) findHumanIdx() int {
-	for i, p := range b.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
-}
 
 // playCard カードをプレイする共通処理
 func (b *Bridge) playCard(playerIdx int, card *Card) {

--- a/internal/domain/Calabresella.go
+++ b/internal/domain/Calabresella.go
@@ -780,16 +780,6 @@ func (g *Calabresella) indexOfPlayerInTrick(playerIdx int) int {
 	return -1
 }
 
-// findHumanIdx 人間プレイヤーのインデックス (-1=なし)。
-func (g *Calabresella) findHumanIdx() int {
-	for i, p := range g.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
-}
-
 // --- CPU AI (play) ---
 
 // cpuSelectPlayCard CPU がプレイするカードのインデックスを選ぶ。
@@ -883,7 +873,7 @@ func calabresellaFilter(indices []int, pred func(int) bool) []int {
 
 // GetHint 人間プレイヤーの手番における推奨アクションを返す。
 func (g *Calabresella) GetHint() *CalabresellaHint {
-	human := g.findHumanIdx()
+	human := findHumanIdx(g.players)
 	if human < 0 {
 		return nil
 	}

--- a/internal/domain/CallBreak.go
+++ b/internal/domain/CallBreak.go
@@ -151,7 +151,7 @@ func (cb *CallBreak) PlayerBid(bid int) error {
 		return ErrWrongPhase
 	}
 
-	humanIdx := cb.findHumanIdx()
+	humanIdx := findHumanIdx(cb.players)
 	if humanIdx < 0 {
 		return ErrNotHumanTurn
 	}
@@ -416,16 +416,6 @@ func (cb *CallBreak) GetConfig() CallBreakConfig { return cb.config }
 func (cb *CallBreak) SetConfig(cfg CallBreakConfig) { cb.config = cfg }
 
 // --- Private methods ---
-
-// findHumanIdx 人間プレイヤーのインデックスを返す (-1 = なし)
-func (cb *CallBreak) findHumanIdx() int {
-	for i, p := range cb.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
-}
 
 // checkBidComplete 全員がビッドしたかチェックし、プレイフェーズに移行
 func (cb *CallBreak) checkBidComplete() {

--- a/internal/domain/CallBreak_internal_test.go
+++ b/internal/domain/CallBreak_internal_test.go
@@ -21,7 +21,7 @@ func newInternalCallBreak() *CallBreak {
 
 func TestCallBreak_findHumanIdx(t *testing.T) {
 	cb := newInternalCallBreak()
-	assert.Equal(t, 0, cb.findHumanIdx())
+	assert.Equal(t, 0, findHumanIdx(cb.players))
 
 	allCpu := []*CallBreakPlayer{
 		NewCallBreakPlayer(false),
@@ -30,7 +30,7 @@ func TestCallBreak_findHumanIdx(t *testing.T) {
 		NewCallBreakPlayer(false),
 	}
 	cb2 := NewCallBreak(NewTrumpCards(0), allCpu, DefaultCallBreakConfig())
-	assert.Equal(t, -1, cb2.findHumanIdx())
+	assert.Equal(t, -1, findHumanIdx(cb2.players))
 }
 
 func TestCallBreak_playerHasSuit(t *testing.T) {

--- a/internal/domain/Cego.go
+++ b/internal/domain/Cego.go
@@ -848,7 +848,7 @@ func (g *Cego) checkGameEnd() {
 
 // humanResult 人間 (seat 0) 視点でマッチ結果を返す。単独トップなら Win、トップ同点なら None。
 func (g *Cego) humanResult(leader int, tie bool) CegoResult {
-	human := g.findHumanIdx()
+	human := findHumanIdx(g.players)
 	if human < 0 {
 		return CegoResultNone
 	}
@@ -1317,7 +1317,7 @@ func cegoPlayRank(c *Card, led int) int {
 
 // GetHint 人間プレイヤーの手番における推奨アクションを返す。
 func (g *Cego) GetHint() *CegoHint {
-	human := g.findHumanIdx()
+	human := findHumanIdx(g.players)
 	if human < 0 || g.gameEndFlag {
 		return nil
 	}
@@ -1418,16 +1418,6 @@ func (g *Cego) playerName(idx int) string {
 		return "You"
 	}
 	return fmt.Sprintf("CPU %d", idx)
-}
-
-// findHumanIdx 人間プレイヤーのインデックス (-1=なし)。
-func (g *Cego) findHumanIdx() int {
-	for i, p := range g.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
 }
 
 // isHumanBidTurn 現在の入札手番が人間か。

--- a/internal/domain/Cinch.go
+++ b/internal/domain/Cinch.go
@@ -366,7 +366,7 @@ func (g *Cinch) PlayerBid(bid int) error {
 	if g.phase != CinchPhaseBid {
 		return ErrWrongPhase
 	}
-	humanIdx := g.findHumanIdx()
+	humanIdx := findHumanIdx(g.players)
 	if humanIdx < 0 || g.bidPlayerIdx != humanIdx {
 		return ErrNotHumanTurn
 	}
@@ -809,15 +809,6 @@ func (g *Cinch) finishGame(winner int) {
 }
 
 // --- ヘルパー ---
-
-func (g *Cinch) findHumanIdx() int {
-	for i, p := range g.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
-}
 
 func (g *Cinch) sortAllHands() {
 	for _, p := range g.players {

--- a/internal/domain/CinchCPU.go
+++ b/internal/domain/CinchCPU.go
@@ -278,7 +278,7 @@ func (g *Cinch) pickSafeDiscard(p *CinchPlayer, valid []int) int {
 
 // GetHint は人間プレイヤーの手番における推奨アクションを返す。
 func (g *Cinch) GetHint() *CinchHint {
-	humanIdx := g.findHumanIdx()
+	humanIdx := findHumanIdx(g.players)
 	if humanIdx < 0 {
 		return nil
 	}

--- a/internal/domain/CourtPiece.go
+++ b/internal/domain/CourtPiece.go
@@ -515,7 +515,7 @@ func (c *CourtPiece) GetValidPlayIndices(playerIdx int) []int {
 
 // GetHint ヒントを取得する
 func (c *CourtPiece) GetHint() *CourtPieceHint {
-	humanIdx := c.findHumanIdx()
+	humanIdx := findHumanIdx(c.players)
 	if humanIdx < 0 {
 		return nil
 	}
@@ -541,16 +541,6 @@ func (c *CourtPiece) GetHint() *CourtPieceHint {
 }
 
 // --- Private helpers ---
-
-// findHumanIdx 人間プレイヤーのインデックス (-1 = なし)
-func (c *CourtPiece) findHumanIdx() int {
-	for i, p := range c.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
-}
 
 // playCard カードをプレイする共通処理
 func (c *CourtPiece) playCard(playerIdx int, card *Card) {

--- a/internal/domain/Doppelkopf.go
+++ b/internal/domain/Doppelkopf.go
@@ -209,7 +209,7 @@ func (g *Doppelkopf) PlayerAnnounce() error {
 	if g.phase != DoppelkopfPhasePlay {
 		return ErrWrongPhase
 	}
-	human := g.findHumanIdx()
+	human := findHumanIdx(g.players)
 	if human < 0 {
 		return ErrNotHumanTurn
 	}
@@ -540,16 +540,6 @@ func (g *Doppelkopf) trickTopStrength(winnerIdx int) int {
 	return dkStrength(g.currentTrick[idx].Card)
 }
 
-// findHumanIdx 人間プレイヤーのインデックスを返す (-1=なし)。
-func (g *Doppelkopf) findHumanIdx() int {
-	for i, p := range g.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
-}
-
 // --- Card classification ---
 
 // dkIsTrump 切り札 (ダイヤ全札, 全 Q, 全 J, ♥10=Dulle) か。
@@ -741,7 +731,7 @@ func (g *Doppelkopf) IsKontraAnnounced() bool { return g.kontraAnnounced }
 
 // CanHumanAnnounce 人間プレイヤーが今宣言できるか
 func (g *Doppelkopf) CanHumanAnnounce() bool {
-	human := g.findHumanIdx()
+	human := findHumanIdx(g.players)
 	return human >= 0 && g.canAnnounce(human)
 }
 
@@ -797,7 +787,7 @@ func (g *Doppelkopf) GetPlayableIndices(playerIdx int) []int {
 
 // GetHint 人間プレイヤーの手番における推奨プレイを返す。
 func (g *Doppelkopf) GetHint() *DoppelkopfHint {
-	human := g.findHumanIdx()
+	human := findHumanIdx(g.players)
 	if human < 0 || g.phase != DoppelkopfPhasePlay || g.currentPlayerIdx != human {
 		return nil
 	}

--- a/internal/domain/Doubt.go
+++ b/internal/domain/Doubt.go
@@ -415,7 +415,7 @@ func (d *Doubt) decideCpuDoubters() {
 			d.cpuDoubters = append(d.cpuDoubters, i)
 		} else {
 			effectiveChance := randomDoubtChance
-			if d.config.CpuMetaAI && d.humanProfile != nil && cardPlayerIdx == d.findHumanIdx() {
+			if d.config.CpuMetaAI && d.humanProfile != nil && cardPlayerIdx == findHumanIdx(d.players) {
 				bracket := doubtHandSizeBracket(d.players[cardPlayerIdx].GetCardsSize())
 				effectiveChance = d.humanProfile.AdjustedDoubtChance(randomDoubtChance, bracket, d.lastHumanPlayMs)
 			}
@@ -475,7 +475,7 @@ func (d *Doubt) ResolveDoubt(doubterIndices []int) {
 
 	// メタAI: 人間がダウターの場合に結果を記録
 	if d.config.CpuMetaAI && d.humanProfile != nil {
-		humanIdx := d.findHumanIdx()
+		humanIdx := findHumanIdx(d.players)
 		for _, di := range doubterIndices {
 			if di == humanIdx {
 				d.humanProfile.RecordDoubt(wasLying)
@@ -633,16 +633,6 @@ func (d *Doubt) ImportProfile(data []byte) error {
 	d.humanProfile = &DoubtHumanProfile{}
 	d.humanProfile.Import(pd)
 	return nil
-}
-
-// findHumanIdx 人間プレイヤーのインデックスを返す (-1=なし)
-func (d *Doubt) findHumanIdx() int {
-	for i, p := range d.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
 }
 
 // memoryDecayRate 記憶力レベルに対応する記憶減衰率を返す

--- a/internal/domain/Euchre.go
+++ b/internal/domain/Euchre.go
@@ -190,7 +190,7 @@ func (e *Euchre) PlayerPickUp(orderUp bool, goAlone bool) error {
 	if e.phase != EuchrePhasePickUp {
 		return ErrWrongPhase
 	}
-	humanIdx := e.findHumanIdx()
+	humanIdx := findHumanIdx(e.players)
 	if humanIdx < 0 || e.bidPlayerIdx != humanIdx {
 		return ErrNotHumanTurn
 	}
@@ -274,7 +274,7 @@ func (e *Euchre) PlayerCallTrump(suit int, goAlone bool) error {
 	if e.phase != EuchrePhaseCallTrump {
 		return ErrWrongPhase
 	}
-	humanIdx := e.findHumanIdx()
+	humanIdx := findHumanIdx(e.players)
 	if humanIdx < 0 || e.bidPlayerIdx != humanIdx {
 		return ErrNotHumanTurn
 	}
@@ -297,7 +297,7 @@ func (e *Euchre) PlayerPassCall() error {
 	if e.phase != EuchrePhaseCallTrump {
 		return ErrWrongPhase
 	}
-	humanIdx := e.findHumanIdx()
+	humanIdx := findHumanIdx(e.players)
 	if humanIdx < 0 || e.bidPlayerIdx != humanIdx {
 		return ErrNotHumanTurn
 	}
@@ -742,16 +742,6 @@ func (e *Euchre) cardRank(card *Card) int {
 
 // --- Private methods ---
 
-// findHumanIdx 人間プレイヤーのインデックスを返す (-1=なし)
-func (e *Euchre) findHumanIdx() int {
-	for i, p := range e.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
-}
-
 // startPlayPhase プレイフェーズを開始する
 func (e *Euchre) startPlayPhase() {
 	e.trickNumber = 1
@@ -925,7 +915,7 @@ func (e *Euchre) playerName(idx int) string {
 
 // GetHint ヒントを取得する
 func (e *Euchre) GetHint() *EuchreHint {
-	humanIdx := e.findHumanIdx()
+	humanIdx := findHumanIdx(e.players)
 	if humanIdx < 0 {
 		return nil
 	}
@@ -972,7 +962,7 @@ func (e *Euchre) GetHint() *EuchreHint {
 
 // playHintReason プレイヒントの理由を判定する
 func (e *Euchre) playHintReason(chosenIdx int) string {
-	player := e.players[e.findHumanIdx()]
+	player := e.players[findHumanIdx(e.players)]
 	card := player.GetCard(chosenIdx)
 
 	if len(e.currentTrick) == 0 {

--- a/internal/domain/FiveHundred.go
+++ b/internal/domain/FiveHundred.go
@@ -265,7 +265,7 @@ func (g *FiveHundred) PlayerBid(kind FiveHundredContractKind, tricks, suit int) 
 	if g.phase != FiveHundredPhaseBid {
 		return ErrWrongPhase
 	}
-	humanIdx := g.findHumanIdx()
+	humanIdx := findHumanIdx(g.players)
 	if humanIdx < 0 || g.bidPlayerIdx != humanIdx {
 		return ErrNotHumanTurn
 	}
@@ -288,7 +288,7 @@ func (g *FiveHundred) PlayerPass() error {
 	if g.phase != FiveHundredPhaseBid {
 		return ErrWrongPhase
 	}
-	humanIdx := g.findHumanIdx()
+	humanIdx := findHumanIdx(g.players)
 	if humanIdx < 0 || g.bidPlayerIdx != humanIdx {
 		return ErrNotHumanTurn
 	}
@@ -1079,7 +1079,7 @@ func (g *FiveHundred) getValidPlayIndices(playerIdx int) []int {
 
 // GetHint 現在の人間の手番に対するヒントを返す
 func (g *FiveHundred) GetHint() *FiveHundredHint {
-	humanIdx := g.findHumanIdx()
+	humanIdx := findHumanIdx(g.players)
 	if humanIdx < 0 || g.gameEndFlag {
 		return nil
 	}
@@ -1289,16 +1289,6 @@ func (g *FiveHundred) CardRankPublic(card *Card) int { return g.cardRank(card) }
 func (g *FiveHundred) EffectiveSuitPublic(card *Card) int { return g.effectiveSuit(card) }
 
 // --- Private helpers ---
-
-// findHumanIdx 人間プレイヤーのインデックスを返す (-1=なし)
-func (g *FiveHundred) findHumanIdx() int {
-	for i, p := range g.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
-}
 
 // sortAllHands 全プレイヤーの手札をソートする
 func (g *FiveHundred) sortAllHands() {

--- a/internal/domain/FortyFives.go
+++ b/internal/domain/FortyFives.go
@@ -642,16 +642,6 @@ func (g *FortyFives) trickTopRank(winnerIdx int) int {
 	return g.fortyFivesRank(g.currentTrick[idx].Card)
 }
 
-// findHumanIdx 人間プレイヤーのインデックス (-1=なし)。
-func (g *FortyFives) findHumanIdx() int {
-	for i, p := range g.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
-}
-
 // --- CPU AI ---
 
 // cpuSelectPlayCard CPU がプレイするカードのインデックスを選ぶ。
@@ -704,7 +694,7 @@ func fortyFivesFilter(indices []int, pred func(int) bool) []int {
 
 // GetHint 人間プレイヤーの手番における推奨プレイを返す。
 func (g *FortyFives) GetHint() *FortyFivesHint {
-	human := g.findHumanIdx()
+	human := findHumanIdx(g.players)
 	if human < 0 || g.phase != FortyFivesPhasePlay || g.currentPlayerIdx != human {
 		return nil
 	}

--- a/internal/domain/FrenchTarot.go
+++ b/internal/domain/FrenchTarot.go
@@ -823,7 +823,7 @@ func (g *FrenchTarot) checkGameEnd() {
 
 // humanResult 人間 (seat 0) 視点でマッチ結果を返す。単独トップなら Win、トップ同点なら None。
 func (g *FrenchTarot) humanResult(leader int, tie bool) FrenchTarotResult {
-	human := g.findHumanIdx()
+	human := findHumanIdx(g.players)
 	if human < 0 {
 		return FrenchTarotResultNone
 	}
@@ -1380,7 +1380,7 @@ func frenchTarotPlayRank(c *Card, led int) int {
 
 // GetHint 人間プレイヤーの手番における推奨アクションを返す。
 func (g *FrenchTarot) GetHint() *FrenchTarotHint {
-	human := g.findHumanIdx()
+	human := findHumanIdx(g.players)
 	if human < 0 || g.gameEndFlag {
 		return nil
 	}
@@ -1471,16 +1471,6 @@ func (g *FrenchTarot) playerName(idx int) string {
 		return "You"
 	}
 	return fmt.Sprintf("CPU %d", idx)
-}
-
-// findHumanIdx 人間プレイヤーのインデックス (-1=なし)。
-func (g *FrenchTarot) findHumanIdx() int {
-	for i, p := range g.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
 }
 
 // isHumanBidTurn 現在の入札手番が人間か。

--- a/internal/domain/Ganjifa.go
+++ b/internal/domain/Ganjifa.go
@@ -764,19 +764,9 @@ func (g *Ganjifa) GetActionLog() []*ActionLogEntry {
 	return g.actionLog
 }
 
-// findHumanIdx 人間プレイヤーの席。いなければ -1。
-func (g *Ganjifa) findHumanIdx() int {
-	for i, p := range g.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
-}
-
 // GetHint 人間プレイヤーへのヒント。手番でなければ nil。
 func (g *Ganjifa) GetHint() *GanjifaHint {
-	human := g.findHumanIdx()
+	human := findHumanIdx(g.players)
 	if human < 0 || g.phase != GanjifaPhasePlay || g.currentPlayerIdx != human {
 		return nil
 	}

--- a/internal/domain/GoStop.go
+++ b/internal/domain/GoStop.go
@@ -933,7 +933,7 @@ func (g *GoStop) GetHint() *GoStopHint {
 	if g.state.gameEndFlag {
 		return nil
 	}
-	human := g.findHumanIdx()
+	human := findHumanIdx(g.players)
 	if human < 0 || g.state.currentTurn != human {
 		return nil
 	}
@@ -959,15 +959,6 @@ func (g *GoStop) GetHint() *GoStopHint {
 }
 
 // --- ヘルパー ---
-
-func (g *GoStop) findHumanIdx() int {
-	for i, p := range g.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
-}
 
 // sortHumanHand は人間の手札を月→インデックス順に並べ替える。
 func (g *GoStop) sortHumanHand() {
@@ -1118,7 +1109,7 @@ func (g *GoStop) GetResult() GoStopResult {
 	if !g.state.gameEndFlag {
 		return GoStopResultNone
 	}
-	human := g.findHumanIdx()
+	human := findHumanIdx(g.players)
 	switch {
 	case g.state.winner < 0:
 		return GoStopResultDraw

--- a/internal/domain/GongZhu.go
+++ b/internal/domain/GongZhu.go
@@ -154,7 +154,7 @@ func (g *GongZhu) PlayerExpose(cardIndices []int) error {
 		return ErrWrongPhase
 	}
 
-	humanIdx := g.findHumanIdx()
+	humanIdx := findHumanIdx(g.players)
 	if humanIdx < 0 {
 		return ErrNotHumanTurn
 	}
@@ -502,16 +502,6 @@ func (g *GongZhu) SetTrickNumber(n int) { g.trickNumber = n }
 
 // --- Private methods ---
 
-// findHumanIdx 人間プレイヤーのインデックスを返す (-1=なし)
-func (g *GongZhu) findHumanIdx() int {
-	for i, p := range g.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
-}
-
 // markExposed 公開対象カードに応じて公開フラグを立てる
 func (g *GongZhu) markExposed(c *Card) {
 	switch {
@@ -787,7 +777,7 @@ func gzRankValue(c *Card) int {
 
 // GetHint ヒントを取得する
 func (g *GongZhu) GetHint() *GongZhuHint {
-	human := g.findHumanIdx()
+	human := findHumanIdx(g.players)
 	if human < 0 {
 		return nil
 	}

--- a/internal/domain/HachiHachi.go
+++ b/internal/domain/HachiHachi.go
@@ -795,7 +795,7 @@ func (g *HachiHachi) GetHint() *HachiHachiHint {
 	if g.state.gameEndFlag {
 		return nil
 	}
-	human := g.findHumanIdx()
+	human := findHumanIdx(g.players)
 	if human < 0 || g.state.currentTurn != human || g.state.phase != HachiHachiPhasePlay {
 		return nil
 	}
@@ -811,15 +811,6 @@ func (g *HachiHachi) GetHint() *HachiHachiHint {
 }
 
 // --- ヘルパー ---
-
-func (g *HachiHachi) findHumanIdx() int {
-	for i, p := range g.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
-}
 
 // sortHumanHand は人間の手札を月→インデックス順に並べ替える。
 func (g *HachiHachi) sortHumanHand() {
@@ -961,7 +952,7 @@ func (g *HachiHachi) GetResult() HachiHachiResult {
 	if !g.state.gameEndFlag {
 		return HachiHachiResultNone
 	}
-	human := g.findHumanIdx()
+	human := findHumanIdx(g.players)
 	if g.state.winner < 0 {
 		return HachiHachiResultDraw
 	}

--- a/internal/domain/Hearts.go
+++ b/internal/domain/Hearts.go
@@ -174,7 +174,7 @@ func (h *Hearts) PlayerPass(cardIndices []int) error {
 		return ErrWrongPhase
 	}
 
-	humanIdx := h.findHumanIdx()
+	humanIdx := findHumanIdx(h.players)
 	if humanIdx < 0 {
 		return ErrNotHumanTurn
 	}
@@ -497,16 +497,6 @@ func (h *Hearts) SetRoundNumber(n int) { h.roundNumber = n }
 func (h *Hearts) SetTrickNumber(n int) { h.trickNumber = n }
 
 // --- Private methods ---
-
-// findHumanIdx 人間プレイヤーのインデックスを返す (-1=なし)
-func (h *Hearts) findHumanIdx() int {
-	for i, p := range h.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
-}
 
 // startPlayPhase プレイフェーズ開始: 2♣を持つプレイヤーをリードに設定
 func (h *Hearts) startPlayPhase() {

--- a/internal/domain/IndianPoker.go
+++ b/internal/domain/IndianPoker.go
@@ -539,7 +539,7 @@ func (ip *IndianPoker) cpuDecide(idx int) (int, int) {
 	if ip.config.CpuMetaAI && ip.humanProfile != nil && ip.lastHumanPlayMs > 0 {
 		if action == IndianPokerActionFold && callAmount > 0 {
 			// CPUは人間のカードが見える → 人間のカードランクブラケットで判定
-			humanIdx := ip.findHumanIdx()
+			humanIdx := findHumanIdx(ip.players)
 			if humanIdx >= 0 && ip.players[humanIdx].GetCardsSize() > 0 {
 				humanCardRank := indianPokerCardRank(ip.players[humanIdx].GetCard(0))
 				bracket := indianPokerCardBracket(humanCardRank)
@@ -624,16 +624,6 @@ func (ip *IndianPoker) estimateOwnStrength(idx int) int {
 
 	strength := min(cardsAbove*100/totalRemaining, 100)
 	return strength
-}
-
-// findHumanIdx 人間プレイヤーのインデックスを返す (-1 = 見つからない)
-func (ip *IndianPoker) findHumanIdx() int {
-	for i, p := range ip.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
 }
 
 // cpuPotBet ポット比率ベースのベット額を計算 (最低Ante, 最低minRaise)

--- a/internal/domain/IndianPoker_test.go
+++ b/internal/domain/IndianPoker_test.go
@@ -1643,7 +1643,7 @@ func TestIndianPokerFindHumanIdx(t *testing.T) {
 	t.Run("returns human index", func(t *testing.T) {
 		cfg := defaultTestConfig()
 		ip, _ := newIndianPokerTestGame(cfg)
-		assert.Equal(t, 0, ip.findHumanIdx())
+		assert.Equal(t, 0, findHumanIdx(ip.players))
 	})
 
 	t.Run("returns -1 when no human", func(t *testing.T) {
@@ -1654,6 +1654,6 @@ func TestIndianPokerFindHumanIdx(t *testing.T) {
 			NewIndianPokerPlayer(false, HoldemStyleLAP),
 		}
 		ip := NewIndianPoker(tc, players, cfg)
-		assert.Equal(t, -1, ip.findHumanIdx())
+		assert.Equal(t, -1, findHumanIdx(ip.players))
 	})
 }

--- a/internal/domain/Jass.go
+++ b/internal/domain/Jass.go
@@ -1082,15 +1082,6 @@ func jassSortHand(p *JassPlayer, g *Jass) {
 	})
 }
 
-func (g *Jass) findHumanIdx() int {
-	for i, p := range g.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
-}
-
 func (g *Jass) playerName(idx int) string {
 	if idx < 0 || idx >= len(g.players) {
 		return fmt.Sprintf("Player %d", idx)
@@ -1105,7 +1096,7 @@ func (g *Jass) playerName(idx int) string {
 
 // GetHint 現フェーズのヒントを返す (人間プレイヤー視点)
 func (g *Jass) GetHint() *JassHint {
-	humanIdx := g.findHumanIdx()
+	humanIdx := findHumanIdx(g.players)
 	if humanIdx < 0 {
 		return nil
 	}
@@ -1141,7 +1132,7 @@ func (g *Jass) GetHint() *JassHint {
 }
 
 func (g *Jass) playHintReason(chosenIdx int) string {
-	humanIdx := g.findHumanIdx()
+	humanIdx := findHumanIdx(g.players)
 	if humanIdx < 0 {
 		return ""
 	}

--- a/internal/domain/Klaverjas.go
+++ b/internal/domain/Klaverjas.go
@@ -618,16 +618,6 @@ func (g *Klaverjas) trickTopRank(winnerIdx int) int {
 	return g.klaverjasRank(g.currentTrick[idx].Card)
 }
 
-// findHumanIdx 人間プレイヤーのインデックス (-1=なし)。
-func (g *Klaverjas) findHumanIdx() int {
-	for i, p := range g.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
-}
-
 // --- CPU AI ---
 
 // cpuSelectPlayCard CPU がプレイするカードのインデックスを選ぶ。
@@ -692,7 +682,7 @@ func klaverjasFilter(indices []int, pred func(int) bool) []int {
 
 // GetHint 人間プレイヤーの手番における推奨プレイを返す。
 func (g *Klaverjas) GetHint() *KlaverjasHint {
-	human := g.findHumanIdx()
+	human := findHumanIdx(g.players)
 	if human < 0 || g.phase != KlaverjasPhasePlay || g.currentPlayerIdx != human {
 		return nil
 	}

--- a/internal/domain/KnockoutWhist.go
+++ b/internal/domain/KnockoutWhist.go
@@ -514,16 +514,6 @@ func (g *KnockoutWhist) trickTopRank(winnerIdx int) int {
 	return g.knockoutRank(g.currentTrick[idx].Card)
 }
 
-// findHumanIdx 人間プレイヤーのインデックス (-1=なし)。
-func (g *KnockoutWhist) findHumanIdx() int {
-	for i, p := range g.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
-}
-
 // --- CPU AI ---
 
 // cpuSelectPlayCard CPU がプレイするカードのインデックスを選ぶ。
@@ -574,7 +564,7 @@ func knockoutFilter(indices []int, pred func(int) bool) []int {
 
 // GetHint 人間プレイヤーの手番における推奨プレイを返す。
 func (g *KnockoutWhist) GetHint() *KnockoutWhistHint {
-	human := g.findHumanIdx()
+	human := findHumanIdx(g.players)
 	if human < 0 || g.phase != KnockoutWhistPhasePlay || g.currentPlayerIdx != human {
 		return nil
 	}

--- a/internal/domain/Koenigrufen.go
+++ b/internal/domain/Koenigrufen.go
@@ -903,7 +903,7 @@ func (g *Koenigrufen) checkGameEnd() {
 
 // humanResult 人間 (seat 0) 視点でマッチ結果を返す。単独トップなら Win、トップ同点なら None。
 func (g *Koenigrufen) humanResult(leader int, tie bool) KoenigrufenResult {
-	human := g.findHumanIdx()
+	human := findHumanIdx(g.players)
 	if human < 0 {
 		return KoenigrufenResultNone
 	}
@@ -1440,7 +1440,7 @@ func koenigrufenPlayRank(c *Card, led int) int {
 
 // GetHint 人間プレイヤーの手番における推奨アクションを返す。
 func (g *Koenigrufen) GetHint() *KoenigrufenHint {
-	human := g.findHumanIdx()
+	human := findHumanIdx(g.players)
 	if human < 0 || g.gameEndFlag {
 		return nil
 	}
@@ -1534,16 +1534,6 @@ func (g *Koenigrufen) playerName(idx int) string {
 		return "You"
 	}
 	return fmt.Sprintf("CPU %d", idx)
-}
-
-// findHumanIdx 人間プレイヤーのインデックス (-1=なし)。
-func (g *Koenigrufen) findHumanIdx() int {
-	for i, p := range g.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
 }
 
 // isHumanBidTurn 現在の入札手番が人間か。

--- a/internal/domain/KoiKoi.go
+++ b/internal/domain/KoiKoi.go
@@ -858,7 +858,7 @@ func (g *KoiKoi) GetHint() *KoiKoiHint {
 	if g.state.gameEndFlag {
 		return nil
 	}
-	human := g.findHumanIdx()
+	human := findHumanIdx(g.players)
 	if human < 0 || g.state.currentTurn != human {
 		return nil
 	}
@@ -884,15 +884,6 @@ func (g *KoiKoi) GetHint() *KoiKoiHint {
 }
 
 // --- ヘルパー ---
-
-func (g *KoiKoi) findHumanIdx() int {
-	for i, p := range g.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
-}
 
 // sortHumanHand は人間の手札を月→インデックス順に並べ替える。
 func (g *KoiKoi) sortHumanHand() {

--- a/internal/domain/Loo.go
+++ b/internal/domain/Loo.go
@@ -612,15 +612,6 @@ func (g *Loo) getValidPlayIndices(playerIdx int) []int {
 
 // --- ヘルパー ---
 
-func (g *Loo) findHumanIdx() int {
-	for i, p := range g.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
-}
-
 func (g *Loo) sortAllHands() {
 	for _, p := range g.players {
 		looSortHand(p)
@@ -754,7 +745,7 @@ func looFilter(indices []int, pred func(int) bool) []int {
 
 // GetHint は人間プレイヤーの手番における推奨を返す (decide / play フェーズ)。
 func (g *Loo) GetHint() *LooHint {
-	human := g.findHumanIdx()
+	human := findHumanIdx(g.players)
 	if human < 0 {
 		return nil
 	}

--- a/internal/domain/Manille.go
+++ b/internal/domain/Manille.go
@@ -457,16 +457,6 @@ func (g *Manille) trickTopRank(winnerIdx int) int {
 	return g.manilleRank(g.currentTrick[idx].Card)
 }
 
-// findHumanIdx 人間プレイヤーのインデックス (-1=なし)。
-func (g *Manille) findHumanIdx() int {
-	for i, p := range g.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
-}
-
 // --- CPU AI ---
 
 // cpuSelectPlayCard CPU がプレイするカードのインデックスを選ぶ。
@@ -531,7 +521,7 @@ func manilleFilter(indices []int, pred func(int) bool) []int {
 
 // GetHint 人間プレイヤーの手番における推奨プレイを返す。
 func (g *Manille) GetHint() *ManilleHint {
-	human := g.findHumanIdx()
+	human := findHumanIdx(g.players)
 	if human < 0 || g.phase != ManillePhasePlay || g.currentPlayerIdx != human {
 		return nil
 	}

--- a/internal/domain/Marias.go
+++ b/internal/domain/Marias.go
@@ -520,16 +520,6 @@ func (g *Marias) trickTopRank(winnerIdx int) int {
 	return g.mariasRank(g.currentTrick[idx].Card)
 }
 
-// findHumanIdx 人間プレイヤーのインデックス (-1=なし)。
-func (g *Marias) findHumanIdx() int {
-	for i, p := range g.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
-}
-
 // --- CPU AI ---
 
 // cpuSelectPlayCard CPU がプレイするカードのインデックスを選ぶ。
@@ -585,7 +575,7 @@ func mariasFilter(indices []int, pred func(int) bool) []int {
 
 // GetHint 人間プレイヤーの手番における推奨プレイを返す。
 func (g *Marias) GetHint() *MariasHint {
-	human := g.findHumanIdx()
+	human := findHumanIdx(g.players)
 	if human < 0 || g.phase != MariasPhasePlay || g.currentPlayerIdx != human {
 		return nil
 	}

--- a/internal/domain/Mighty.go
+++ b/internal/domain/Mighty.go
@@ -217,7 +217,7 @@ func (m *Mighty) PlayerBid(bid int, noTrump bool) error {
 		return ErrWrongPhase
 	}
 
-	humanIdx := m.findHumanIdx()
+	humanIdx := findHumanIdx(m.players)
 	if humanIdx < 0 || m.round.bidPlayerIdx != humanIdx {
 		return ErrNotHumanTurn
 	}
@@ -783,7 +783,7 @@ func (m *Mighty) GetValidPlayIndices(playerIdx int) []int {
 
 // GetHint ヒントを取得する
 func (m *Mighty) GetHint() *MightyHint {
-	humanIdx := m.findHumanIdx()
+	humanIdx := findHumanIdx(m.players)
 	if humanIdx < 0 {
 		return nil
 	}
@@ -835,16 +835,6 @@ func (m *Mighty) GetHint() *MightyHint {
 }
 
 // --- Private methods ---
-
-// findHumanIdx 人間プレイヤーのインデックスを返す (-1=なし)
-func (m *Mighty) findHumanIdx() int {
-	for i, p := range m.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
-}
 
 // dealCards 53枚を配る: 10枚×5人 + 場札3枚
 func (m *Mighty) dealCards() {
@@ -1423,7 +1413,7 @@ func mightyCardStr(card *Card) string {
 
 // playHintReason プレイヒントの理由を判定する
 func (m *Mighty) playHintReason(chosenIdx int) string {
-	humanIdx := m.findHumanIdx()
+	humanIdx := findHumanIdx(m.players)
 	if humanIdx < 0 {
 		return ""
 	}

--- a/internal/domain/Minchiate.go
+++ b/internal/domain/Minchiate.go
@@ -807,19 +807,9 @@ type MinchiateHint struct {
 	Reason      string // ヒント理由キー
 }
 
-// findHumanIdx 人間の席を返す (居なければ -1)。
-func (g *Minchiate) findHumanIdx() int {
-	for i, p := range g.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
-}
-
 // GetHint 人間プレイヤーへのヒント。手番でなければ nil。
 func (g *Minchiate) GetHint() *MinchiateHint {
-	human := g.findHumanIdx()
+	human := findHumanIdx(g.players)
 	if human < 0 || g.phase != MinchiatePhasePlay || g.currentPlayerIdx != human {
 		return nil
 	}

--- a/internal/domain/Mus.go
+++ b/internal/domain/Mus.go
@@ -783,16 +783,6 @@ func (g *Mus) humanTeam() int {
 	return -1
 }
 
-// findHumanIdx 人間プレイヤーのインデックス (-1=なし)。
-func (g *Mus) findHumanIdx() int {
-	for i, p := range g.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
-}
-
 // sortAllHands 全プレイヤーの手札をソートする。
 func (g *Mus) sortAllHands() {
 	for _, p := range g.players {
@@ -953,7 +943,7 @@ func (g *Mus) teamStrength(team, ri int) int {
 
 // GetHint 人間の手番における推奨アクションを返す。
 func (g *Mus) GetHint() *MusHint {
-	human := g.findHumanIdx()
+	human := findHumanIdx(g.players)
 	if human < 0 {
 		return nil
 	}

--- a/internal/domain/Nap.go
+++ b/internal/domain/Nap.go
@@ -585,16 +585,6 @@ func (g *Nap) trickTopRank(winnerIdx int) int {
 	return g.napRank(g.currentTrick[idx].Card)
 }
 
-// findHumanIdx 人間プレイヤーのインデックス (-1=なし)。
-func (g *Nap) findHumanIdx() int {
-	for i, p := range g.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
-}
-
 // --- CPU AI ---
 
 // cpuSelectPlayCard CPU がプレイするカードのインデックスを選ぶ。
@@ -649,7 +639,7 @@ func napFilter(indices []int, pred func(int) bool) []int {
 
 // GetHint 人間プレイヤーの手番における推奨プレイを返す。
 func (g *Nap) GetHint() *NapHint {
-	human := g.findHumanIdx()
+	human := findHumanIdx(g.players)
 	if human < 0 || g.phase != NapPhasePlay || g.currentPlayerIdx != human {
 		return nil
 	}

--- a/internal/domain/Napoleon.go
+++ b/internal/domain/Napoleon.go
@@ -204,7 +204,7 @@ func (n *Napoleon) PlayerBid(bid int) error {
 		return ErrWrongPhase
 	}
 
-	humanIdx := n.findHumanIdx()
+	humanIdx := findHumanIdx(n.players)
 	if humanIdx < 0 || n.round.bidPlayerIdx != humanIdx {
 		return ErrNotHumanTurn
 	}
@@ -642,7 +642,7 @@ func (n *Napoleon) GetValidPlayIndices(playerIdx int) []int {
 
 // GetHint ヒントを取得する
 func (n *Napoleon) GetHint() *NapoleonHint {
-	humanIdx := n.findHumanIdx()
+	humanIdx := findHumanIdx(n.players)
 	if humanIdx < 0 {
 		return nil
 	}
@@ -691,17 +691,7 @@ func (n *Napoleon) GetHint() *NapoleonHint {
 // **コンストラクタは任意の並び順を受け付ける。**ドメイン内部は findHumanIdx で
 // 都度解決しているのに、CUI の表示だけが GetPlayer(0) を決め打ちしていて
 // 取り残されていた (#4689)。表示側も同じ解決を使えるように公開する。
-func (n *Napoleon) GetHumanIdx() int { return n.findHumanIdx() }
-
-// findHumanIdx 人間プレイヤーのインデックスを返す (-1=なし)
-func (n *Napoleon) findHumanIdx() int {
-	for i, p := range n.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
-}
+func (n *Napoleon) GetHumanIdx() int { return findHumanIdx(n.players) }
 
 // dealCards 53枚を配る: 13枚×4人 + 場札1枚
 func (n *Napoleon) dealCards() {
@@ -1088,7 +1078,7 @@ func napoleonCardStr(card *Card) string {
 
 // playHintReason プレイヒントの理由を判定する
 func (n *Napoleon) playHintReason(chosenIdx int) string {
-	player := n.players[n.findHumanIdx()]
+	player := n.players[findHumanIdx(n.players)]
 	card := player.GetCard(chosenIdx)
 
 	if len(n.round.currentTrick) == 0 {

--- a/internal/domain/NinetyNine.go
+++ b/internal/domain/NinetyNine.go
@@ -164,7 +164,7 @@ func (o *NinetyNine) PlayerBid(buryIndices []int) error {
 		return ErrWrongPhase
 	}
 
-	humanIdx := o.findHumanIdx()
+	humanIdx := findHumanIdx(o.players)
 	if humanIdx < 0 || o.bidPlayerIdx != humanIdx {
 		return ErrNotHumanTurn
 	}
@@ -470,16 +470,6 @@ func (o *NinetyNine) GetValidPlayIndices(playerIdx int) []int {
 
 // --- Private methods ---
 
-// findHumanIdx 人間プレイヤーのインデックスを返す (-1=なし)
-func (o *NinetyNine) findHumanIdx() int {
-	for i, p := range o.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
-}
-
 // deal カードを配り、切り札を決める
 func (o *NinetyNine) deal() {
 	o.trumpCards = NewTrumpCardsNinetyNine()
@@ -683,7 +673,7 @@ func (o *NinetyNine) getValidPlayIndices(playerIdx int) []int {
 
 // GetHint ヒントを取得する
 func (o *NinetyNine) GetHint() *NinetyNineHint {
-	humanIdx := o.findHumanIdx()
+	humanIdx := findHumanIdx(o.players)
 	if humanIdx < 0 {
 		return nil
 	}

--- a/internal/domain/OhHell.go
+++ b/internal/domain/OhHell.go
@@ -139,7 +139,7 @@ func (o *OhHell) PlayerBid(bid int) error {
 		return ErrWrongPhase
 	}
 
-	humanIdx := o.findHumanIdx()
+	humanIdx := findHumanIdx(o.players)
 	if humanIdx < 0 {
 		return ErrNotHumanTurn
 	}
@@ -456,16 +456,6 @@ func (o *OhHell) GetValidPlayIndices(playerIdx int) []int {
 
 // --- Private methods ---
 
-// findHumanIdx 人間プレイヤーのインデックスを返す (-1=なし)
-func (o *OhHell) findHumanIdx() int {
-	for i, p := range o.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
-}
-
 // calcTotalRounds 総ラウンド数を計算する
 func (o *OhHell) calcTotalRounds() int {
 	max := o.config.MaxHandSize
@@ -667,7 +657,7 @@ func (o *OhHell) getValidPlayIndices(playerIdx int) []int {
 
 // GetHint ヒントを取得する
 func (o *OhHell) GetHint() *OhHellHint {
-	humanIdx := o.findHumanIdx()
+	humanIdx := findHumanIdx(o.players)
 	if humanIdx < 0 {
 		return nil
 	}

--- a/internal/domain/Ombre.go
+++ b/internal/domain/Ombre.go
@@ -649,7 +649,7 @@ func (g *Ombre) checkGameEnd() {
 
 // humanResult 人間 (seat 0) の視点でマッチ結果を返す。単独トップなら Win、トップ同点なら None、他は Lose。
 func (g *Ombre) humanResult(leader int, tie bool) OmbreResult {
-	human := g.findHumanIdx()
+	human := findHumanIdx(g.players)
 	if human < 0 {
 		return OmbreResultNone
 	}
@@ -987,16 +987,6 @@ func (g *Ombre) indexOfPlayerInTrick(playerIdx int) int {
 	return -1
 }
 
-// findHumanIdx 人間プレイヤーのインデックス (-1=なし)。
-func (g *Ombre) findHumanIdx() int {
-	for i, p := range g.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
-}
-
 // --- CPU AI (play) ---
 
 // cpuSelectPlayCard CPU がプレイするカードのインデックスを選ぶ。
@@ -1100,7 +1090,7 @@ func ombreFilter(indices []int, pred func(int) bool) []int {
 
 // GetHint 人間プレイヤーの手番における推奨アクションを返す。
 func (g *Ombre) GetHint() *OmbreHint {
-	human := g.findHumanIdx()
+	human := findHumanIdx(g.players)
 	if human < 0 {
 		return nil
 	}

--- a/internal/domain/Pitch.go
+++ b/internal/domain/Pitch.go
@@ -179,7 +179,7 @@ func (p *Pitch) PlayerBid(bid int) error {
 	if p.phase != PitchPhaseBid {
 		return ErrWrongPhase
 	}
-	humanIdx := p.findHumanIdx()
+	humanIdx := findHumanIdx(p.players)
 	if humanIdx < 0 || p.bidPlayerIdx != humanIdx {
 		return ErrNotHumanTurn
 	}
@@ -762,15 +762,6 @@ func (p *Pitch) GetValidPlayIndices(playerIdx int) []int {
 
 // --- private helpers ---
 
-func (p *Pitch) findHumanIdx() int {
-	for i, pl := range p.players {
-		if pl.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
-}
-
 func (p *Pitch) sortAllHands() {
 	for _, pl := range p.players {
 		pitchSortHand(pl)
@@ -1129,7 +1120,7 @@ func pickLowestNonTrumpFollow(pl *PitchPlayer, validIndices []int, leadSuit, tru
 
 // GetHint ヒントを取得する
 func (p *Pitch) GetHint() *PitchHint {
-	humanIdx := p.findHumanIdx()
+	humanIdx := findHumanIdx(p.players)
 	if humanIdx < 0 {
 		return nil
 	}

--- a/internal/domain/Preference.go
+++ b/internal/domain/Preference.go
@@ -608,16 +608,6 @@ func (g *Preference) trickTopRank(winnerIdx int) int {
 	return g.preferenceRank(g.currentTrick[idx].Card)
 }
 
-// findHumanIdx 人間プレイヤーのインデックス (-1=なし)。
-func (g *Preference) findHumanIdx() int {
-	for i, p := range g.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
-}
-
 // --- CPU AI ---
 
 // cpuSelectPlayCard CPU がプレイするカードのインデックスを選ぶ。
@@ -674,7 +664,7 @@ func preferenceFilter(indices []int, pred func(int) bool) []int {
 
 // GetHint 人間プレイヤーの手番における推奨プレイを返す。
 func (g *Preference) GetHint() *PreferenceHint {
-	human := g.findHumanIdx()
+	human := findHumanIdx(g.players)
 	if human < 0 || g.phase != PreferencePhasePlay || g.currentPlayerIdx != human {
 		return nil
 	}

--- a/internal/domain/Rook.go
+++ b/internal/domain/Rook.go
@@ -233,7 +233,7 @@ func (g *Rook) PlayerBid(bid int) error {
 	if g.phase != RookPhaseBid {
 		return ErrWrongPhase
 	}
-	humanIdx := g.findHumanIdx()
+	humanIdx := findHumanIdx(g.players)
 	if humanIdx < 0 || g.bidPlayerIdx != humanIdx {
 		return ErrNotHumanTurn
 	}
@@ -260,7 +260,7 @@ func (g *Rook) PlayerPass() error {
 	if g.phase != RookPhaseBid {
 		return ErrWrongPhase
 	}
-	humanIdx := g.findHumanIdx()
+	humanIdx := findHumanIdx(g.players)
 	if humanIdx < 0 || g.bidPlayerIdx != humanIdx {
 		return ErrNotHumanTurn
 	}
@@ -950,7 +950,7 @@ func (g *Rook) getValidPlayIndices(playerIdx int) []int {
 
 // GetHint 現在の人間の手番に対するヒントを返す
 func (g *Rook) GetHint() *RookHint {
-	humanIdx := g.findHumanIdx()
+	humanIdx := findHumanIdx(g.players)
 	if humanIdx < 0 || g.gameEndFlag {
 		return nil
 	}
@@ -1169,16 +1169,6 @@ func (g *Rook) EffectiveSuitPublic(card *Card) int { return g.effectiveSuit(card
 func (g *Rook) CardPointsPublic(card *Card) int { return rookCardPoints(card) }
 
 // --- Private helpers ---
-
-// findHumanIdx 人間プレイヤーのインデックスを返す (-1=なし)
-func (g *Rook) findHumanIdx() int {
-	for i, p := range g.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
-}
 
 // sortAllHands 全プレイヤーの手札をソートする
 func (g *Rook) sortAllHands() {

--- a/internal/domain/Scarto.go
+++ b/internal/domain/Scarto.go
@@ -554,7 +554,7 @@ func (g *Scarto) capturedHalfPoints() [ScartoPlayerCnt]int {
 
 // humanOutcome 人間の deal 精算符号から結果を返す。
 func (g *Scarto) humanOutcome() ScartoOutcome {
-	human := g.findHumanIdx()
+	human := findHumanIdx(g.players)
 	if human < 0 {
 		return ScartoOutcomeNone
 	}
@@ -598,7 +598,7 @@ func (g *Scarto) checkGameEnd() {
 
 // humanResult 人間 (seat 0) 視点でマッチ結果を返す。単独トップなら Win、トップ同点なら None。
 func (g *Scarto) humanResult(leader int, tie bool) ScartoResult {
-	human := g.findHumanIdx()
+	human := findHumanIdx(g.players)
 	if human < 0 {
 		return ScartoResultNone
 	}
@@ -1022,7 +1022,7 @@ func scartoPlayRank(c *Card, led int) int {
 
 // GetHint 人間プレイヤーの手番における推奨アクションを返す。
 func (g *Scarto) GetHint() *ScartoHint {
-	human := g.findHumanIdx()
+	human := findHumanIdx(g.players)
 	if human < 0 || g.gameEndFlag {
 		return nil
 	}
@@ -1105,16 +1105,6 @@ func (g *Scarto) playerName(idx int) string {
 		return "You"
 	}
 	return fmt.Sprintf("CPU %d", idx)
-}
-
-// findHumanIdx 人間プレイヤーのインデックス (-1=なし)。
-func (g *Scarto) findHumanIdx() int {
-	for i, p := range g.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
 }
 
 // isHumanScartoTurn 現在のスカルト手番が人間 (=人間が親) か。

--- a/internal/domain/Sedma.go
+++ b/internal/domain/Sedma.go
@@ -356,16 +356,6 @@ func (g *Sedma) playerName(idx int) string {
 	return fmt.Sprintf("CPU %d", idx)
 }
 
-// findHumanIdx 人間プレイヤーのインデックス (-1=なし)。
-func (g *Sedma) findHumanIdx() int {
-	for i, p := range g.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
-}
-
 // --- CPU AI ---
 
 // cpuSelectPlayCard CPU がプレイするカードのインデックスを選ぶ。
@@ -440,7 +430,7 @@ func sedmaFilter(indices []int, pred func(int) bool) []int {
 
 // GetHint 人間プレイヤーの手番における推奨プレイを返す。
 func (g *Sedma) GetHint() *SedmaHint {
-	human := g.findHumanIdx()
+	human := findHumanIdx(g.players)
 	if human < 0 || g.phase != SedmaPhasePlay || g.currentPlayerIdx != human {
 		return nil
 	}

--- a/internal/domain/Sheepshead.go
+++ b/internal/domain/Sheepshead.go
@@ -960,7 +960,7 @@ func (g *Sheepshead) GetCallableSuits() []int { return g.callableSuits() }
 
 // GetHint 人間プレイヤーの手番における推奨アクションを返す。
 func (g *Sheepshead) GetHint() *SheepsheadHint {
-	human := g.findHumanIdx()
+	human := findHumanIdx(g.players)
 	if human < 0 {
 		return nil
 	}
@@ -998,16 +998,6 @@ func (g *Sheepshead) GetHint() *SheepsheadHint {
 	default:
 		return nil
 	}
-}
-
-// findHumanIdx 人間プレイヤーのインデックスを返す (-1=なし)。
-func (g *Sheepshead) findHumanIdx() int {
-	for i, p := range g.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
 }
 
 // playHintReason プレイヒントの理由キーを判定する。

--- a/internal/domain/Skat.go
+++ b/internal/domain/Skat.go
@@ -284,7 +284,7 @@ func (s *Skat) PlayerBid(accept bool) error {
 	if s.round.phase != SkatPhaseBid {
 		return ErrWrongPhase
 	}
-	humanIdx := s.findHumanIdx()
+	humanIdx := findHumanIdx(s.players)
 	if humanIdx < 0 {
 		return ErrNotHumanTurn
 	}
@@ -1168,16 +1168,6 @@ func (s *Skat) findIndex(p *SkatPlayer) int {
 	return -1
 }
 
-// findHumanIdx returns the human player index (-1 if none).
-func (s *Skat) findHumanIdx() int {
-	for i, p := range s.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
-}
-
 // IsHumanTurn reports whether the current player is human (play phase).
 func (s *Skat) IsHumanTurn() bool {
 	if s.round.currentPlayerIdx < 0 || s.round.currentPlayerIdx >= len(s.players) {
@@ -1212,7 +1202,7 @@ func (s *Skat) GetValidPlayIndices(playerIdx int) []int {
 
 // GetHint returns a hint for the human player based on the current phase.
 func (s *Skat) GetHint() *SkatHint {
-	humanIdx := s.findHumanIdx()
+	humanIdx := findHumanIdx(s.players)
 	if humanIdx < 0 {
 		return nil
 	}

--- a/internal/domain/SoloWhist.go
+++ b/internal/domain/SoloWhist.go
@@ -604,16 +604,6 @@ func (g *SoloWhist) trickTopRank(winnerIdx int) int {
 	return g.soloWhistRank(g.currentTrick[idx].Card)
 }
 
-// findHumanIdx 人間プレイヤーのインデックス (-1=なし)。
-func (g *SoloWhist) findHumanIdx() int {
-	for i, p := range g.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
-}
-
 // --- CPU AI ---
 
 // cpuSelectPlayCard CPU がプレイするカードのインデックスを選ぶ。
@@ -672,7 +662,7 @@ func soloWhistFilter(indices []int, pred func(int) bool) []int {
 
 // GetHint 人間プレイヤーの手番における推奨プレイを返す。
 func (g *SoloWhist) GetHint() *SoloWhistHint {
-	human := g.findHumanIdx()
+	human := findHumanIdx(g.players)
 	if human < 0 || g.phase != SoloWhistPhasePlay || g.currentPlayerIdx != human {
 		return nil
 	}

--- a/internal/domain/Spades.go
+++ b/internal/domain/Spades.go
@@ -145,7 +145,7 @@ func (s *Spades) PlayerBid(bid int) error {
 		return ErrWrongPhase
 	}
 
-	humanIdx := s.findHumanIdx()
+	humanIdx := findHumanIdx(s.players)
 	if humanIdx < 0 {
 		return ErrNotHumanTurn
 	}
@@ -424,16 +424,6 @@ func (s *Spades) GetConfig() SpadesConfig { return s.config }
 func (s *Spades) SetConfig(cfg SpadesConfig) { s.config = cfg }
 
 // --- Private methods ---
-
-// findHumanIdx 人間プレイヤーのインデックスを返す (-1=なし)
-func (s *Spades) findHumanIdx() int {
-	for i, p := range s.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
-}
 
 // checkBidComplete 全員がビッドしたかチェックし、プレイフェーズに移行
 func (s *Spades) checkBidComplete() {

--- a/internal/domain/Spades_internal_test.go
+++ b/internal/domain/Spades_internal_test.go
@@ -20,7 +20,7 @@ func newInternalTestSpades() *Spades {
 
 func TestSpades_findHumanIdx(t *testing.T) {
 	s := newInternalTestSpades()
-	assert.Equal(t, 0, s.findHumanIdx())
+	assert.Equal(t, 0, findHumanIdx(s.players))
 
 	// All CPU
 	allCpu := []*SpadesPlayer{
@@ -30,7 +30,7 @@ func TestSpades_findHumanIdx(t *testing.T) {
 		NewSpadesPlayer(false),
 	}
 	s2 := NewSpades(NewTrumpCards(0), allCpu, DefaultSpadesConfig())
-	assert.Equal(t, -1, s2.findHumanIdx())
+	assert.Equal(t, -1, findHumanIdx(s2.players))
 }
 
 func TestSpades_findTwoOfClubs(t *testing.T) {

--- a/internal/domain/SpoilFive.go
+++ b/internal/domain/SpoilFive.go
@@ -506,16 +506,6 @@ func (g *SpoilFive) trickTopRank(winnerIdx int) int {
 	return g.spoilRank(g.currentTrick[idx].Card)
 }
 
-// findHumanIdx 人間プレイヤーのインデックス (-1=なし)。
-func (g *SpoilFive) findHumanIdx() int {
-	for i, p := range g.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
-}
-
 // --- CPU AI ---
 
 // cpuSelectPlayCard CPU がプレイするカードのインデックスを選ぶ。
@@ -566,7 +556,7 @@ func spoilFilter(indices []int, pred func(int) bool) []int {
 
 // GetHint 人間プレイヤーの手番における推奨プレイを返す。
 func (g *SpoilFive) GetHint() *SpoilFiveHint {
-	human := g.findHumanIdx()
+	human := findHumanIdx(g.players)
 	if human < 0 || g.phase != SpoilFivePhasePlay || g.currentPlayerIdx != human {
 		return nil
 	}

--- a/internal/domain/Sueca.go
+++ b/internal/domain/Sueca.go
@@ -472,16 +472,6 @@ func (g *Sueca) trickTopRank(winnerIdx int) int {
 	return g.suecaRank(g.currentTrick[idx].Card)
 }
 
-// findHumanIdx 人間プレイヤーのインデックス (-1=なし)。
-func (g *Sueca) findHumanIdx() int {
-	for i, p := range g.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
-}
-
 // --- CPU AI ---
 
 // cpuSelectPlayCard CPU がプレイするカードのインデックスを選ぶ。
@@ -567,7 +557,7 @@ func suecaFilter(indices []int, pred func(int) bool) []int {
 
 // GetHint 人間プレイヤーの手番における推奨プレイを返す。
 func (g *Sueca) GetHint() *SuecaHint {
-	human := g.findHumanIdx()
+	human := findHumanIdx(g.players)
 	if human < 0 || g.phase != SuecaPhasePlay || g.currentPlayerIdx != human {
 		return nil
 	}

--- a/internal/domain/Tablanet.go
+++ b/internal/domain/Tablanet.go
@@ -769,7 +769,7 @@ func (g *Tablanet) GetHint() *TablanetHint {
 	if g.state.gameEndFlag || g.state.phase != TablanetPhasePlay {
 		return nil
 	}
-	human := g.findHumanIdx()
+	human := findHumanIdx(g.players)
 	if human < 0 || g.state.currentTurn != human {
 		return nil
 	}
@@ -807,15 +807,6 @@ func (g *Tablanet) GetHint() *TablanetHint {
 }
 
 // --- ヘルパー ---
-
-func (g *Tablanet) findHumanIdx() int {
-	for i, p := range g.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
-}
 
 // sortHumanHand は人間の手札を表示用にスート→ランク順で並べ替える。
 func (g *Tablanet) sortHumanHand() {

--- a/internal/domain/Tarneeb.go
+++ b/internal/domain/Tarneeb.go
@@ -575,7 +575,7 @@ func (t *Tarneeb) GetValidPlayIndices(playerIdx int) []int {
 
 // GetHint ヒントを取得する
 func (t *Tarneeb) GetHint() *TarneebHint {
-	humanIdx := t.findHumanIdx()
+	humanIdx := findHumanIdx(t.players)
 	if humanIdx < 0 {
 		return nil
 	}
@@ -613,16 +613,6 @@ func hintBidReason(bid int) string {
 		return "bid_pass"
 	}
 	return "bid_estimate"
-}
-
-// findHumanIdx 人間プレイヤーのインデックス (-1 = なし)
-func (t *Tarneeb) findHumanIdx() int {
-	for i, p := range t.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
 }
 
 // playCard カードをプレイする共通処理

--- a/internal/domain/Tarocchini.go
+++ b/internal/domain/Tarocchini.go
@@ -922,19 +922,9 @@ type TarocchiniHint struct {
 	Reason      string // ヒント理由キー
 }
 
-// findHumanIdx 人間の席を返す (居なければ -1)。
-func (g *Tarocchini) findHumanIdx() int {
-	for i, p := range g.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
-}
-
 // GetHint 人間プレイヤーへのヒント。手番でなければ nil。
 func (g *Tarocchini) GetHint() *TarocchiniHint {
-	human := g.findHumanIdx()
+	human := findHumanIdx(g.players)
 	if human < 0 || g.phase != TarocchiniPhasePlay || g.currentPlayerIdx != human {
 		return nil
 	}

--- a/internal/domain/Tressette.go
+++ b/internal/domain/Tressette.go
@@ -348,16 +348,6 @@ func (g *Tressette) GetPlayableIndices(playerIdx int) []int {
 
 // --- Private methods ---
 
-// findHumanIdx 人間プレイヤーのインデックスを返す (-1=なし)
-func (g *Tressette) findHumanIdx() int {
-	for i, p := range g.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
-}
-
 // playCard カードをプレイする共通処理
 func (g *Tressette) playCard(playerIdx int, card *Card) {
 	g.currentTrick = append(g.currentTrick, &TrickCard{
@@ -504,7 +494,7 @@ func tressetteThirds(value int) int {
 
 // GetHint 人間プレイヤーの手番における推奨プレイを返す。
 func (g *Tressette) GetHint() *TressetteHint {
-	human := g.findHumanIdx()
+	human := findHumanIdx(g.players)
 	if human < 0 || g.phase != TressettePhasePlay || g.currentPlayerIdx != human {
 		return nil
 	}

--- a/internal/domain/Tute.go
+++ b/internal/domain/Tute.go
@@ -559,16 +559,6 @@ func (g *Tute) trickTopRank(winnerIdx int) int {
 	return g.tuteRank(g.currentTrick[idx].Card)
 }
 
-// findHumanIdx 人間プレイヤーのインデックス (-1=なし)。
-func (g *Tute) findHumanIdx() int {
-	for i, p := range g.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
-}
-
 // --- CPU AI ---
 
 // cpuMarriageSuit CPU がリード時に宣言する結婚スートを返す (0=なし)。切り札を優先。
@@ -671,7 +661,7 @@ func tuteFilter(indices []int, pred func(int) bool) []int {
 
 // GetHint 人間プレイヤーの手番における推奨アクションを返す。
 func (g *Tute) GetHint() *TuteHint {
-	human := g.findHumanIdx()
+	human := findHumanIdx(g.players)
 	if human < 0 || g.phase != TutePhasePlay || g.currentPlayerIdx != human {
 		return nil
 	}
@@ -800,7 +790,7 @@ func (g *Tute) IsHumanTurn() bool {
 
 // CanHumanDeclareMarriage 人間が今いずれかのスートで結婚宣言できるか。
 func (g *Tute) CanHumanDeclareMarriage() bool {
-	human := g.findHumanIdx()
+	human := findHumanIdx(g.players)
 	if human < 0 || g.currentPlayerIdx != human {
 		return false
 	}
@@ -811,7 +801,7 @@ func (g *Tute) CanHumanDeclareMarriage() bool {
 // the human may currently declare a K+Q marriage — the human leads and holds an
 // unclaimed suit's King and Queen. Empty when no declaration is possible now.
 func (g *Tute) GetHumanDeclarableMarriageSuits() []int {
-	human := g.findHumanIdx()
+	human := findHumanIdx(g.players)
 	if human < 0 {
 		return nil
 	}
@@ -826,7 +816,7 @@ func (g *Tute) GetHumanDeclarableMarriageSuits() []int {
 
 // CanHumanDeclareTute 人間が今 Tute を宣言できるか。
 func (g *Tute) CanHumanDeclareTute() bool {
-	human := g.findHumanIdx()
+	human := findHumanIdx(g.players)
 	return human >= 0 && g.currentPlayerIdx == human && len(g.currentTrick) == 0 && g.hasTute(human)
 }
 

--- a/internal/domain/TwentyNine.go
+++ b/internal/domain/TwentyNine.go
@@ -622,16 +622,6 @@ func (g *TwentyNine) trickTopRank(winnerIdx int) int {
 	return g.twentyNineRank(g.currentTrick[idx].Card)
 }
 
-// findHumanIdx 人間プレイヤーのインデックス (-1=なし)。
-func (g *TwentyNine) findHumanIdx() int {
-	for i, p := range g.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
-}
-
 // --- CPU AI ---
 
 // cpuSelectPlayCard CPU がプレイするカードのインデックスを選ぶ。
@@ -684,7 +674,7 @@ func twentyNineFilter(indices []int, pred func(int) bool) []int {
 
 // GetHint 人間プレイヤーの手番における推奨プレイを返す。
 func (g *TwentyNine) GetHint() *TwentyNineHint {
-	human := g.findHumanIdx()
+	human := findHumanIdx(g.players)
 	if human < 0 || g.phase != TwentyNinePhasePlay || g.currentPlayerIdx != human {
 		return nil
 	}

--- a/internal/domain/Tysiac.go
+++ b/internal/domain/Tysiac.go
@@ -867,16 +867,6 @@ func (g *Tysiac) trickTopRank(winnerIdx int) int {
 	return g.tysiacRank(g.currentTrick[idx].Card)
 }
 
-// findHumanIdx 人間プレイヤーのインデックス (-1=なし)。
-func (g *Tysiac) findHumanIdx() int {
-	for i, p := range g.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
-}
-
 // --- CPU AI (play) ---
 
 // cpuSelectPlayCard CPU がプレイするカードのインデックスを選ぶ。
@@ -958,7 +948,7 @@ func tysiacFilter(indices []int, pred func(int) bool) []int {
 
 // GetHint 人間プレイヤーの手番における推奨アクションを返す。
 func (g *Tysiac) GetHint() *TysiacHint {
-	human := g.findHumanIdx()
+	human := findHumanIdx(g.players)
 	if human < 0 {
 		return nil
 	}

--- a/internal/domain/Ulti.go
+++ b/internal/domain/Ulti.go
@@ -238,7 +238,7 @@ func (g *Ulti) startRound() {
 	g.trickNumber = 1
 	g.currentTrick = nil
 	g.lastTrickWinner = -1
-	g.declarerIdx = g.findHumanIdx()
+	g.declarerIdx = findHumanIdx(g.players)
 	if g.declarerIdx < 0 {
 		g.declarerIdx = 0
 	}
@@ -593,7 +593,7 @@ func (g *Ulti) checkGameEnd() {
 
 // humanResult 人間 (seat 0) の視点でマッチ結果を返す。単独トップなら Win、トップ同点なら None、他は Lose。
 func (g *Ulti) humanResult(leader int, tie bool) UltiResult {
-	human := g.findHumanIdx()
+	human := findHumanIdx(g.players)
 	if human < 0 {
 		return UltiResultNone
 	}
@@ -910,16 +910,6 @@ func (g *Ulti) indexOfPlayerInTrick(playerIdx int) int {
 	return -1
 }
 
-// findHumanIdx 人間プレイヤーのインデックス (-1=なし)。
-func (g *Ulti) findHumanIdx() int {
-	for i, p := range g.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
-}
-
 // --- CPU AI (play) ---
 
 // cpuSelectPlayCard CPU がプレイするカードのインデックスを選ぶ。
@@ -1027,7 +1017,7 @@ func (g *Ulti) maxByStrength(playerIdx int, indices []int) int {
 
 // GetHint 人間プレイヤーの手番における推奨アクションを返す。
 func (g *Ulti) GetHint() *UltiHint {
-	human := g.findHumanIdx()
+	human := findHumanIdx(g.players)
 	if human < 0 {
 		return nil
 	}

--- a/internal/domain/Vira.go
+++ b/internal/domain/Vira.go
@@ -1058,19 +1058,9 @@ func (g *Vira) GetPlayableIndices(playerIdx int) []int {
 	return g.GetValidPlayIndices(playerIdx)
 }
 
-// findHumanIdx 人間プレイヤーの席。いなければ -1。
-func (g *Vira) findHumanIdx() int {
-	for i, p := range g.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
-}
-
 // GetHint 人間プレイヤーへのヒント。手番でなければ nil。
 func (g *Vira) GetHint() *ViraHint {
-	human := g.findHumanIdx()
+	human := findHumanIdx(g.players)
 	if human < 0 || g.phase != ViraPhasePlay || g.currentPlayerIdx != human {
 		return nil
 	}

--- a/internal/domain/Watten.go
+++ b/internal/domain/Watten.go
@@ -830,15 +830,6 @@ func (g *Watten) sortAllHands() {
 	}
 }
 
-func (g *Watten) findHumanIdx() int {
-	for i, p := range g.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
-}
-
 func (g *Watten) playerName(idx int) string {
 	if idx < 0 || idx >= len(g.players) {
 		return fmt.Sprintf("Player %d", idx)
@@ -1022,7 +1013,7 @@ func (g *Watten) cpuWantsToHold(playerIdx int) bool {
 
 // GetHint 現フェーズのヒントを返す (人間プレイヤー視点)。
 func (g *Watten) GetHint() *WattenHint {
-	humanIdx := g.findHumanIdx()
+	humanIdx := findHumanIdx(g.players)
 	if humanIdx < 0 {
 		return nil
 	}

--- a/internal/domain/Whist.go
+++ b/internal/domain/Whist.go
@@ -358,16 +358,6 @@ func (w *Whist) GetHint() *WhistHint {
 
 // --- Private methods ---
 
-// findHumanIdx 人間プレイヤーのインデックスを返す (-1=なし)
-func (w *Whist) findHumanIdx() int {
-	for i, p := range w.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
-}
-
 // dealAndSetTrump カードを配布し、ディーラーの最後のカードのスートをトランプに設定する
 func (w *Whist) dealAndSetTrump() {
 	dealAllCards(w.trumpCards, w.players)

--- a/internal/domain/Whist_internal_test.go
+++ b/internal/domain/Whist_internal_test.go
@@ -173,7 +173,7 @@ func TestWhist_isPartnerWinning(t *testing.T) {
 
 func TestWhist_findHumanIdx(t *testing.T) {
 	w := newInternalTestWhist()
-	assert.Equal(t, 0, w.findHumanIdx())
+	assert.Equal(t, 0, findHumanIdx(w.players))
 }
 
 func TestWhist_playerName(t *testing.T) {

--- a/internal/domain/Wizard.go
+++ b/internal/domain/Wizard.go
@@ -169,7 +169,7 @@ func (o *Wizard) PlayerBid(bid int) error {
 		return ErrWrongPhase
 	}
 
-	humanIdx := o.findHumanIdx()
+	humanIdx := findHumanIdx(o.players)
 	if humanIdx < 0 {
 		return ErrNotHumanTurn
 	}
@@ -460,16 +460,6 @@ func (o *Wizard) GetValidPlayIndices(playerIdx int) []int {
 }
 
 // --- Private methods ---
-
-// findHumanIdx 人間プレイヤーのインデックスを返す (-1=なし)
-func (o *Wizard) findHumanIdx() int {
-	for i, p := range o.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
-}
 
 // calcTotalRounds 総ラウンド数を計算する (60枚 / 4人 = 15ラウンド、昇順のみ)。
 func (o *Wizard) calcTotalRounds() int {
@@ -802,7 +792,7 @@ func (o *Wizard) getValidPlayIndices(playerIdx int) []int {
 
 // GetHint ヒントを取得する
 func (o *Wizard) GetHint() *WizardHint {
-	humanIdx := o.findHumanIdx()
+	humanIdx := findHumanIdx(o.players)
 	if humanIdx < 0 {
 		return nil
 	}

--- a/internal/domain/player_helpers.go
+++ b/internal/domain/player_helpers.go
@@ -33,6 +33,24 @@ type finishable interface {
 	GetIsFinished() bool
 }
 
+// humanReporter is the minimal view needed to tell the human player apart from
+// the CPUs.
+type humanReporter interface {
+	GetIsHuman() bool
+}
+
+// findHumanIdx returns the index of the human player, or -1 when every seat is
+// a CPU. 62 games had written this loop out; the receiver was unused in all of
+// them, which is what made it free-function-shaped. See issue #5185.
+func findHumanIdx[T humanReporter](players []T) int {
+	for i, p := range players {
+		if p.GetIsHuman() {
+			return i
+		}
+	}
+	return -1
+}
+
 // nextActivePlayer performs a circular search for the next non-finished player.
 // direction: 1 = forward, -1 = reverse (e.g. Daifugo 9-reverse).
 // Returns -1 if no active player is found.

--- a/internal/domain/player_helpers_internal_test.go
+++ b/internal/domain/player_helpers_internal_test.go
@@ -174,3 +174,24 @@ func TestSortPlayerHand_Empty(t *testing.T) {
 	sortPlayerHand(h, func(ci, cj *Card) bool { return ci.GetValue() < cj.GetValue() })
 	assert.Equal(t, 0, h.GetCardsSize())
 }
+
+type fakeSeat struct{ human bool }
+
+func (f fakeSeat) GetIsHuman() bool { return f.human }
+
+func TestFindHumanIdx(t *testing.T) {
+	assert.Equal(t, 0, findHumanIdx([]fakeSeat{{true}, {false}, {false}}))
+	assert.Equal(t, 2, findHumanIdx([]fakeSeat{{false}, {false}, {true}}))
+}
+
+// -1 rather than 0 when nobody is human: callers compare against -1, and
+// returning a valid-looking index would silently designate seat 0 as the human.
+func TestFindHumanIdx_AllCPU(t *testing.T) {
+	assert.Equal(t, -1, findHumanIdx([]fakeSeat{{false}, {false}}))
+	assert.Equal(t, -1, findHumanIdx([]fakeSeat{}))
+}
+
+// The first human wins, matching what the 62 hand-written loops did.
+func TestFindHumanIdx_FirstHumanWins(t *testing.T) {
+	assert.Equal(t, 1, findHumanIdx([]fakeSeat{{false}, {true}, {true}}))
+}


### PR DESCRIPTION
## 概要

[#5185](https://github.com/yuta-yoshinaga/go_trumpcards/issues/5185) フェーズ4の第2弾。**609行削除**（114追加 / 723削除）。

62ゲームが同じ4行ループを書いていました。

```go
func (g *X) findHumanIdx() int {
	for i, p := range g.players {
		if p.GetIsHuman() {
			return i
		}
	}
	return -1
}
```

**62個中62個がレシーバを一度も使っていません。** 2つの「異なるボディ」が検出されましたが、差はループ変数が `p` か `pl` かだけでした。

## 既存ヘルパを先に探しました

[前 PR の教訓](https://github.com/yuta-yoshinaga/go_trumpcards/pull/5200)を踏まえ、まず既存ヘルパを確認しました。`player_helpers.go` には `sortPlayerHand` / `nextActivePlayer` / `resetPlayers` / `countPlayers` がありますが、**インデックスを返す検索は無い**ため、同ファイルに新規追加しています（既存の `handHolder` / `finishable` / `resettable` と同じ制約インタフェースの流儀）。

## サイズについて（前 PR との違い）

[#5200 は既存ジェネリックの再利用だったので単相化が増えず、6worker中5つが縮みました](https://github.com/yuta-yoshinaga/go_trumpcards/pull/5200#issuecomment-5226258994)。**本 PR は新規ジェネリックヘルパなので、インスタンス化は純増**です。CI の `tinygo-build` で前後比較し、**増えるようなら取り下げます**（最逼迫 extra3 の余裕は 127.6KB）。

## テストのみで壊れる変更でした（記録）

最初の書き換えはプロダクションコードだけを対象にしており、**`go build ./...` は通りました**。壊れていたのは `-tags test` のときだけです。

```
CallBreak_internal_test.go:24:24: cb.findHumanIdx undefined
IndianPoker_test.go:1646:25: ip.findHumanIdx undefined
Spades_internal_test.go:23:23: s.findHumanIdx undefined
Whist_internal_test.go:176:23: w.findHumanIdx undefined
```

**プロダクションビルドが通ることは、メソッド削除が完了した証拠になりません。** テストファイル4件・7箇所も書き換えました。

## テスト計画

- [x] `findHumanIdx` ヘルパの単体テスト（先頭/末尾の人間、**全員CPUで -1**、空スライスで -1、複数人間なら先頭優先）
- [x] 62メソッドが**正典ボディであること**を正規表現で検証してから削除（不一致なら中断）
- [x] プロダクション107箇所 + **テスト7箇所**の呼び出し書き換え
- [x] `go vet -tags test ./internal/domain/` 通過（本番ビルドだけでなく）
- [x] `go test -tags test ./internal/domain/... ./internal/usecase/...` 通過（domain 40.3s）
- [x] `golangci-lint run ./internal/domain/...` → 0 issues
- [ ] **Worker サイズ前後比較（CI 待ち）** — 増えたら取り下げ

Refs #5185