### PR TITLE
refactor(domain): replace 91 playerName methods with the shared helper

### DIFF
--- a/internal/domain/AllFours.go
+++ b/internal/domain/AllFours.go
@@ -134,7 +134,7 @@ func (a *AllFours) startDeal() {
 	a.sortAllHands()
 	a.phase = AllFoursPhaseBeg
 	a.appendLog(AllFoursNonDealerIdx, "beg_phase",
-		fmt.Sprintf("%s to stand or beg", a.playerName(AllFoursNonDealerIdx)), nil)
+		fmt.Sprintf("%s to stand or beg", playerName(a.players, AllFoursNonDealerIdx)), nil)
 }
 
 // dealHands 各プレイヤーへ n 枚配る
@@ -189,12 +189,12 @@ func (a *AllFours) CpuBeg() {
 func (a *AllFours) applyBeg(beg bool) {
 	if !beg {
 		a.appendLog(AllFoursNonDealerIdx, "stand",
-			fmt.Sprintf("%s stands", a.playerName(AllFoursNonDealerIdx)), nil)
+			fmt.Sprintf("%s stands", playerName(a.players, AllFoursNonDealerIdx)), nil)
 		a.startPlay()
 		return
 	}
 	a.appendLog(AllFoursNonDealerIdx, "beg",
-		fmt.Sprintf("%s begs", a.playerName(AllFoursNonDealerIdx)), nil)
+		fmt.Sprintf("%s begs", playerName(a.players, AllFoursNonDealerIdx)), nil)
 	a.phase = AllFoursPhaseGift
 	// 親がCPUの場合は即応答 (デフォルト構成)。人間親なら respond を待つ。
 	if !a.players[AllFoursDealerIdx].GetIsHuman() {
@@ -227,7 +227,7 @@ func (a *AllFours) applyGiftResponse(run bool) {
 		a.giftAward = AllFoursNonDealerIdx
 		a.appendLog(AllFoursNonDealerIdx, "gift",
 			fmt.Sprintf("%s gifts 1 point to %s (take-it)",
-				a.playerName(AllFoursDealerIdx), a.playerName(AllFoursNonDealerIdx)), nil)
+				playerName(a.players, AllFoursDealerIdx), playerName(a.players, AllFoursNonDealerIdx)), nil)
 		a.startPlay()
 		return
 	}
@@ -292,7 +292,7 @@ func (a *AllFours) redeal() {
 	a.sortAllHands()
 	a.phase = AllFoursPhaseBeg
 	a.appendLog(AllFoursNonDealerIdx, "beg_phase",
-		fmt.Sprintf("%s to stand or beg (re-deal)", a.playerName(AllFoursNonDealerIdx)), nil)
+		fmt.Sprintf("%s to stand or beg (re-deal)", playerName(a.players, AllFoursNonDealerIdx)), nil)
 }
 
 // startPlay プレイフェーズを開始する。非親 (elder hand) が最初にリードする。
@@ -304,7 +304,7 @@ func (a *AllFours) startPlay() {
 	a.phase = AllFoursPhasePlay
 	a.appendLog(AllFoursNonDealerIdx, "play_start",
 		fmt.Sprintf("Trump is %s. %s leads.",
-			allFoursSuitGlyph(a.trumpSuit), a.playerName(AllFoursNonDealerIdx)), nil)
+			allFoursSuitGlyph(a.trumpSuit), playerName(a.players, AllFoursNonDealerIdx)), nil)
 }
 
 // PlayerPlay 人間プレイヤーがカードをプレイする
@@ -355,7 +355,7 @@ func (a *AllFours) CpuPlay() {
 func (a *AllFours) playCard(playerIdx int, card *Card) {
 	a.currentTrick = append(a.currentTrick, &TrickCard{PlayerIdx: playerIdx, Card: card})
 	a.appendLog(playerIdx, "play",
-		fmt.Sprintf("%s plays %s", a.playerName(playerIdx), cardStr(card)), []*Card{card})
+		fmt.Sprintf("%s plays %s", playerName(a.players, playerIdx), cardStr(card)), []*Card{card})
 	if len(a.currentTrick) == AllFoursPlayerCnt {
 		a.phase = AllFoursPhaseTrickEnd
 	} else {
@@ -406,7 +406,7 @@ func (a *AllFours) ResolveTrick() {
 	}
 	a.players[winnerIdx].AddTrick(trickCards)
 	a.appendLog(winnerIdx, "trick_win",
-		fmt.Sprintf("%s wins trick %d", a.playerName(winnerIdx), a.trickNumber), trickCards)
+		fmt.Sprintf("%s wins trick %d", playerName(a.players, winnerIdx), a.trickNumber), trickCards)
 	a.leadPlayerIdx = winnerIdx
 	if a.players[AllFoursNonDealerIdx].GetCardsSize() == 0 &&
 		a.players[AllFoursDealerIdx].GetCardsSize() == 0 {
@@ -506,7 +506,7 @@ func (a *AllFours) ScoreRound() {
 		base[aw.player]++
 		a.players[aw.player].SetRoundScore(a.players[aw.player].GetRoundScore() + 1)
 		a.appendLog(aw.player, "score_"+aw.kind,
-			fmt.Sprintf("%s scores %s", a.playerName(aw.player), aw.kind), nil)
+			fmt.Sprintf("%s scores %s", playerName(a.players, aw.player), aw.kind), nil)
 		if winner < 0 && base[aw.player] >= limit {
 			winner = aw.player
 		}
@@ -515,14 +515,14 @@ func (a *AllFours) ScoreRound() {
 	for i := 0; i < AllFoursPlayerCnt; i++ {
 		a.players[i].CommitRoundScore()
 		a.appendLog(i, "cumulative_score",
-			fmt.Sprintf("%s: total=%d", a.playerName(i), a.players[i].GetCumulativeScore()), nil)
+			fmt.Sprintf("%s: total=%d", playerName(a.players, i), a.players[i].GetCumulativeScore()), nil)
 	}
 
 	if winner >= 0 {
 		a.gameEndFlag = true
 		a.phase = AllFoursPhaseGameEnd
 		a.winnerIdx = winner
-		a.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game!", a.playerName(winner)), nil)
+		a.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game!", playerName(a.players, winner)), nil)
 	}
 }
 
@@ -726,16 +726,6 @@ func allFoursSortHand(pl *AllFoursPlayer) {
 		}
 		return allFoursRankValue(ci.GetValue()) < allFoursRankValue(cj.GetValue())
 	})
-}
-
-func (a *AllFours) playerName(idx int) string {
-	if idx < 0 || idx >= len(a.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if a.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // allFoursSuitGlyph スートを Unicode グリフで返す。

--- a/internal/domain/Anaconda.go
+++ b/internal/domain/Anaconda.go
@@ -303,7 +303,7 @@ func (g *Anaconda) executePass(humanIndices []int) {
 		}
 		outgoing[k] = p.RemoveCards(idxs)
 		g.appendLog(seat, "pass",
-			fmt.Sprintf("%s passes %d card(s) left", g.playerName(seat), len(outgoing[k])), append([]*Card(nil), outgoing[k]...))
+			fmt.Sprintf("%s passes %d card(s) left", playerName(g.players, seat), len(outgoing[k])), append([]*Card(nil), outgoing[k]...))
 	}
 	for k := range participants {
 		recipient := participants[(k+1)%n]
@@ -378,7 +378,7 @@ func (g *Anaconda) applyKeep(seat int, keep []int) {
 	}
 	removed := p.RemoveCards(discard)
 	g.appendLog(seat, "keep",
-		fmt.Sprintf("%s discards %d card(s)", g.playerName(seat), len(removed)), append([]*Card(nil), removed...))
+		fmt.Sprintf("%s discards %d card(s)", playerName(g.players, seat), len(removed)), append([]*Card(nil), removed...))
 }
 
 // cpuBestKeepIndices は 7 枚から最良の 5 枚を残すインデックス列を返す (捨てる 2 枚を総当り)。
@@ -497,7 +497,7 @@ func (g *Anaconda) applyCall(idx int) {
 	}
 	g.state.actedSinceRaise++
 	g.state.actionCount++
-	g.appendLog(idx, "call", fmt.Sprintf("%s calls %d (pot %d)", g.playerName(idx), need, g.state.pot), nil)
+	g.appendLog(idx, "call", fmt.Sprintf("%s calls %d (pot %d)", playerName(g.players, idx), need, g.state.pot), nil)
 	g.advanceOrClose(idx)
 }
 
@@ -518,7 +518,7 @@ func (g *Anaconda) applyRaise(idx int) {
 	g.state.pot += need
 	g.state.actedSinceRaise = 1
 	g.state.actionCount++
-	g.appendLog(idx, "raise", fmt.Sprintf("%s raises to %d, pays %d (pot %d)", g.playerName(idx), newBet, need, g.state.pot), nil)
+	g.appendLog(idx, "raise", fmt.Sprintf("%s raises to %d, pays %d (pot %d)", playerName(g.players, idx), newBet, need, g.state.pot), nil)
 	g.advanceOrClose(idx)
 }
 
@@ -526,7 +526,7 @@ func (g *Anaconda) applyRaise(idx int) {
 func (g *Anaconda) applyFold(idx int) {
 	g.players[idx].SetFolded(true)
 	g.state.actionCount++
-	g.appendLog(idx, "fold", fmt.Sprintf("%s folds", g.playerName(idx)), nil)
+	g.appendLog(idx, "fold", fmt.Sprintf("%s folds", playerName(g.players, idx)), nil)
 	g.advanceOrClose(idx)
 }
 
@@ -568,7 +568,7 @@ func (g *Anaconda) resolveShowdown() {
 	if winner >= 0 {
 		g.players[winner].AddChips(g.state.pot)
 		g.appendLog(winner, "win",
-			fmt.Sprintf("%s wins the pot (%d)", g.playerName(winner), g.state.pot), nil)
+			fmt.Sprintf("%s wins the pot (%d)", playerName(g.players, winner), g.state.pot), nil)
 	}
 	g.setHumanResult(winner)
 	g.state.pot = 0
@@ -605,7 +605,7 @@ func (g *Anaconda) endGame() {
 	g.state.phase = AnacondaPhaseResult
 	g.state.matchWinnerIdx = g.richestIdx()
 	g.appendLog(g.state.matchWinnerIdx, "game_end",
-		fmt.Sprintf("%s wins the game", g.playerName(g.state.matchWinnerIdx)), nil)
+		fmt.Sprintf("%s wins the game", playerName(g.players, g.state.matchWinnerIdx)), nil)
 }
 
 // --- CPU ---
@@ -887,17 +887,6 @@ func (g *Anaconda) richestIdx() int {
 		}
 	}
 	return best
-}
-
-// playerName は表示用のプレイヤー名を返す。
-func (g *Anaconda) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // anacondaValidateIndices はカードインデックス列の妥当性 (枚数・範囲・重複なし) を検証する。

--- a/internal/domain/Basra.go
+++ b/internal/domain/Basra.go
@@ -477,7 +477,7 @@ func (g *Basra) applyPlay(playerIdx, handIdx int, tableIdxs []int) {
 	if len(tableIdxs) == 0 {
 		// トレイル: 場に置く。
 		g.state.tableCards = append(g.state.tableCards, card)
-		g.appendLog(playerIdx, "trail", fmt.Sprintf("%s trails %s", g.playerName(playerIdx), cardStr(card)),
+		g.appendLog(playerIdx, "trail", fmt.Sprintf("%s trails %s", playerName(g.players, playerIdx), cardStr(card)),
 			[]*Card{card})
 		g.advanceTurn()
 		return
@@ -498,15 +498,15 @@ func (g *Basra) applyPlay(playerIdx, handIdx int, tableIdxs []int) {
 	if isBasra {
 		player.IncrementBasra()
 		g.appendLog(playerIdx, "basra",
-			fmt.Sprintf("%s scores a Basra! captured %d card(s)", g.playerName(playerIdx), len(captured)-1),
+			fmt.Sprintf("%s scores a Basra! captured %d card(s)", playerName(g.players, playerIdx), len(captured)-1),
 			captured)
 	} else if basraIsJack(card) {
 		g.appendLog(playerIdx, "sweep",
-			fmt.Sprintf("%s sweeps %d card(s) with a Jack", g.playerName(playerIdx), len(captured)-1),
+			fmt.Sprintf("%s sweeps %d card(s) with a Jack", playerName(g.players, playerIdx), len(captured)-1),
 			captured)
 	} else {
 		g.appendLog(playerIdx, "capture",
-			fmt.Sprintf("%s captures %d card(s)", g.playerName(playerIdx), len(captured)-1),
+			fmt.Sprintf("%s captures %d card(s)", playerName(g.players, playerIdx), len(captured)-1),
 			captured)
 	}
 	g.advanceTurn()
@@ -814,16 +814,6 @@ func (g *Basra) sortHumanHand() {
 			p.AddCard(c)
 		}
 	}
-}
-
-func (g *Basra) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 func (g *Basra) appendLog(playerIdx int, actionType, detail string, cards []*Card) {

--- a/internal/domain/Belote.go
+++ b/internal/domain/Belote.go
@@ -262,7 +262,7 @@ func (b *Belote) PlayerPickUp(orderUp bool) error {
 	if orderUp {
 		b.doOrderUp(humanIdx)
 	} else {
-		b.appendLog(humanIdx, "pass", fmt.Sprintf("%s passes", b.playerName(humanIdx)), nil)
+		b.appendLog(humanIdx, "pass", fmt.Sprintf("%s passes", playerName(b.players, humanIdx)), nil)
 		b.advanceBidPickUp()
 	}
 	return nil
@@ -283,7 +283,7 @@ func (b *Belote) CpuPickUp() {
 	if b.cpuSelectPickUp(b.bidPlayerIdx) {
 		b.doOrderUp(b.bidPlayerIdx)
 	} else {
-		b.appendLog(b.bidPlayerIdx, "pass", fmt.Sprintf("%s passes", b.playerName(b.bidPlayerIdx)), nil)
+		b.appendLog(b.bidPlayerIdx, "pass", fmt.Sprintf("%s passes", playerName(b.players, b.bidPlayerIdx)), nil)
 		b.advanceBidPickUp()
 	}
 }
@@ -294,7 +294,7 @@ func (b *Belote) doOrderUp(playerIdx int) {
 	b.makerTeam = b.players[playerIdx].GetTeam()
 	b.makerPlayerIdx = playerIdx
 	b.appendLog(playerIdx, "order_up",
-		fmt.Sprintf("%s takes %s as trump", b.playerName(playerIdx), cardStr(b.faceUpCard)),
+		fmt.Sprintf("%s takes %s as trump", playerName(b.players, playerIdx), cardStr(b.faceUpCard)),
 		[]*Card{b.faceUpCard})
 
 	b.dealRemainder(playerIdx)
@@ -348,7 +348,7 @@ func (b *Belote) PlayerPassCall() error {
 	if humanIdx < 0 || b.bidPlayerIdx != humanIdx {
 		return ErrNotHumanTurn
 	}
-	b.appendLog(humanIdx, "pass", fmt.Sprintf("%s passes", b.playerName(humanIdx)), nil)
+	b.appendLog(humanIdx, "pass", fmt.Sprintf("%s passes", playerName(b.players, humanIdx)), nil)
 	b.advanceBidCallTrump()
 	return nil
 }
@@ -366,7 +366,7 @@ func (b *Belote) CpuCallTrump() {
 	if suit > 0 {
 		b.doCallTrump(b.bidPlayerIdx, suit)
 	} else {
-		b.appendLog(b.bidPlayerIdx, "pass", fmt.Sprintf("%s passes", b.playerName(b.bidPlayerIdx)), nil)
+		b.appendLog(b.bidPlayerIdx, "pass", fmt.Sprintf("%s passes", playerName(b.players, b.bidPlayerIdx)), nil)
 		b.advanceBidCallTrump()
 	}
 }
@@ -378,7 +378,7 @@ func (b *Belote) doCallTrump(playerIdx int, suit int) {
 	b.makerPlayerIdx = playerIdx
 	suitName := suitStr(suit)
 	b.appendLog(playerIdx, "call_trump",
-		fmt.Sprintf("%s calls %s as trump", b.playerName(playerIdx), suitName), nil)
+		fmt.Sprintf("%s calls %s as trump", playerName(b.players, playerIdx), suitName), nil)
 
 	b.dealRemainder(playerIdx)
 	b.startPlayPhase()
@@ -469,7 +469,7 @@ func (b *Belote) ResolveTrick() {
 	b.players[winnerIdx].AddTrick(trickCards)
 	b.roundPoints[b.players[winnerIdx].GetTeam()] += trickPoints
 
-	winnerName := b.playerName(winnerIdx)
+	winnerName := playerName(b.players, winnerIdx)
 	b.appendLog(winnerIdx, "trick_win",
 		fmt.Sprintf("%s wins trick %d (%d pts)", winnerName, b.trickNumber, trickPoints),
 		trickCards)
@@ -829,7 +829,7 @@ func (b *Belote) playCard(playerIdx int, card *Card) {
 	})
 	b.maybeDeclareBeloteRebelote(playerIdx, card)
 	b.appendLog(playerIdx, "play",
-		fmt.Sprintf("%s plays %s", b.playerName(playerIdx), cardStr(card)), []*Card{card})
+		fmt.Sprintf("%s plays %s", playerName(b.players, playerIdx), cardStr(card)), []*Card{card})
 
 	if len(b.currentTrick) == BelotePlayerCnt {
 		b.phase = BelotePhaseTrickEnd
@@ -863,7 +863,7 @@ func (b *Belote) maybeDeclareBeloteRebelote(playerIdx int, card *Card) {
 		b.beloteDeclared = true
 		b.appendLog(playerIdx, "belote_rebelote",
 			fmt.Sprintf("%s declares Belote/Rebelote (+%d)",
-				b.playerName(playerIdx), BeloteRebeloteBonus), nil)
+				playerName(b.players, playerIdx), BeloteRebeloteBonus), nil)
 	}
 }
 
@@ -1074,16 +1074,6 @@ func beloteSortHand(p *BelotePlayer, b *Belote) {
 		// strong card instead of the weakest.
 		return b.cardRank(ci) > b.cardRank(cj)
 	})
-}
-
-func (b *Belote) playerName(idx int) string {
-	if idx < 0 || idx >= len(b.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if b.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // --- Hints ---

--- a/internal/domain/Bezique.go
+++ b/internal/domain/Bezique.go
@@ -329,7 +329,7 @@ func (b *Bezique) PlayerSkipMeld() error {
 	if !b.players[b.currentPlayerIdx].GetIsHuman() {
 		return ErrNotHumanTurn
 	}
-	b.appendLog(b.currentPlayerIdx, "meld_skip", fmt.Sprintf("%s declares no meld", b.playerName(b.currentPlayerIdx)), nil)
+	b.appendLog(b.currentPlayerIdx, "meld_skip", fmt.Sprintf("%s declares no meld", playerName(b.players, b.currentPlayerIdx)), nil)
 	b.afterMeld()
 	return nil
 }
@@ -345,7 +345,7 @@ func (b *Bezique) CpuMeld() {
 	}
 	melds := b.availableMelds(idx)
 	if len(melds) == 0 {
-		b.appendLog(idx, "meld_skip", fmt.Sprintf("%s declares no meld", b.playerName(idx)), nil)
+		b.appendLog(idx, "meld_skip", fmt.Sprintf("%s declares no meld", playerName(b.players, idx)), nil)
 		b.afterMeld()
 		return
 	}
@@ -544,7 +544,7 @@ func (b *Bezique) GetHint() *BeziqueHint {
 // playCard カードをプレイする共通処理。2枚出そろったらトリックを解決する。
 func (b *Bezique) playCard(playerIdx int, card *Card) {
 	b.currentTrick = append(b.currentTrick, &TrickCard{PlayerIdx: playerIdx, Card: card})
-	b.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", b.playerName(playerIdx), cardStr(card)), []*Card{card})
+	b.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", playerName(b.players, playerIdx), cardStr(card)), []*Card{card})
 	if len(b.currentTrick) == BeziquePlayerCnt {
 		b.resolveTrick()
 		return
@@ -566,14 +566,14 @@ func (b *Bezique) resolveTrick() {
 	b.leadPlayerIdx = winnerIdx
 	b.currentPlayerIdx = winnerIdx
 	b.appendLog(winnerIdx, "trick_win",
-		fmt.Sprintf("%s wins trick %d (%d pt)", b.playerName(winnerIdx), b.trickNumber, trickPoints), trickCards)
+		fmt.Sprintf("%s wins trick %d (%d pt)", playerName(b.players, winnerIdx), b.trickNumber, trickPoints), trickCards)
 
 	if b.IsEndgame() {
 		// 第2フェーズ: 役宣言・補充なし。
 		if b.allHandsEmpty() {
 			b.dealPoints[winnerIdx] += BeziqueLastTrickBonus
 			b.appendLog(winnerIdx, "last_trick",
-				fmt.Sprintf("%s takes the last trick (+%d)", b.playerName(winnerIdx), BeziqueLastTrickBonus), nil)
+				fmt.Sprintf("%s takes the last trick (+%d)", playerName(b.players, winnerIdx), BeziqueLastTrickBonus), nil)
 			b.scoreDeal()
 			return
 		}
@@ -837,7 +837,7 @@ func (b *Bezique) applyMeld(playerIdx int, m BeziqueMeld) {
 	b.dealPoints[playerIdx] += m.Points
 	b.dealMeldPoints[playerIdx] += m.Points
 	b.appendLog(playerIdx, "meld",
-		fmt.Sprintf("%s declares %s (+%d)", b.playerName(playerIdx), beziqueMeldName(m), m.Points), nil)
+		fmt.Sprintf("%s declares %s (+%d)", playerName(b.players, playerIdx), beziqueMeldName(m), m.Points), nil)
 }
 
 // beziqueMeldBit メルドの宣言済みビット位置を返す。
@@ -924,17 +924,6 @@ func (b *Bezique) sortHand(p *BeziquePlayer) {
 		}
 		return BeziqueRankOrder(ci) < BeziqueRankOrder(cj)
 	})
-}
-
-// playerName プレイヤー名を返す (ログ用)
-func (b *Bezique) playerName(idx int) string {
-	if idx < 0 || idx >= len(b.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if b.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // playHintReason ヒント理由キーを判定する

--- a/internal/domain/Bouillotte.go
+++ b/internal/domain/Bouillotte.go
@@ -327,7 +327,7 @@ func (g *Bouillotte) applyCall(idx int) {
 	}
 	g.state.actedSinceRaise++
 	g.state.actionCount++
-	g.appendLog(idx, "call", fmt.Sprintf("%s calls %d (pot %d)", g.playerName(idx), need, g.state.pot), nil)
+	g.appendLog(idx, "call", fmt.Sprintf("%s calls %d (pot %d)", playerName(g.players, idx), need, g.state.pot), nil)
 	g.advanceOrClose(idx)
 }
 
@@ -349,7 +349,7 @@ func (g *Bouillotte) applyRaise(idx int) {
 	// レイズ後は本人を含め 1 人がアクション済み。他のアクティブは応答が必要。
 	g.state.actedSinceRaise = 1
 	g.state.actionCount++
-	g.appendLog(idx, "raise", fmt.Sprintf("%s raises to %d, pays %d (pot %d)", g.playerName(idx), newBet, need, g.state.pot), nil)
+	g.appendLog(idx, "raise", fmt.Sprintf("%s raises to %d, pays %d (pot %d)", playerName(g.players, idx), newBet, need, g.state.pot), nil)
 	g.advanceOrClose(idx)
 }
 
@@ -357,7 +357,7 @@ func (g *Bouillotte) applyRaise(idx int) {
 func (g *Bouillotte) applyFold(idx int) {
 	g.players[idx].SetFolded(true)
 	g.state.actionCount++
-	g.appendLog(idx, "fold", fmt.Sprintf("%s folds", g.playerName(idx)), nil)
+	g.appendLog(idx, "fold", fmt.Sprintf("%s folds", playerName(g.players, idx)), nil)
 	g.advanceOrClose(idx)
 }
 
@@ -392,7 +392,7 @@ func (g *Bouillotte) resolveRound() {
 	if winner >= 0 {
 		g.players[winner].AddChips(g.state.pot)
 		g.appendLog(winner, "win",
-			fmt.Sprintf("%s wins the pot (%d)", g.playerName(winner), g.state.pot), nil)
+			fmt.Sprintf("%s wins the pot (%d)", playerName(g.players, winner), g.state.pot), nil)
 	}
 	g.setHumanResult(winner)
 	g.state.pot = 0
@@ -429,7 +429,7 @@ func (g *Bouillotte) endGame() {
 	g.state.phase = BouillottePhaseResult
 	g.state.matchWinnerIdx = g.richestIdx()
 	g.appendLog(g.state.matchWinnerIdx, "game_end",
-		fmt.Sprintf("%s wins the game", g.playerName(g.state.matchWinnerIdx)), nil)
+		fmt.Sprintf("%s wins the game", playerName(g.players, g.state.matchWinnerIdx)), nil)
 }
 
 // --- CPU ---
@@ -652,17 +652,6 @@ func (g *Bouillotte) richestIdx() int {
 		}
 	}
 	return best
-}
-
-// playerName は表示用のプレイヤー名を返す。
-func (g *Bouillotte) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 func (g *Bouillotte) appendLog(playerIdx int, actionType, detail string, cards []*Card) {

--- a/internal/domain/Bourre.go
+++ b/internal/domain/Bourre.go
@@ -143,7 +143,7 @@ func (b *Bourre) startHand() {
 		ante := min(BourreAnte, p.GetChips())
 		p.SubtractChips(ante)
 		b.pot += ante
-		b.appendLog(i, "ante", fmt.Sprintf("%s antes %d", b.playerName(i), ante), nil)
+		b.appendLog(i, "ante", fmt.Sprintf("%s antes %d", playerName(b.players, i), ante), nil)
 	}
 
 	// 配札 (ディーラーの左から、ディーラーが最後)
@@ -226,10 +226,10 @@ func (b *Bourre) applyDecide(idx int, play bool) {
 	p.SetDecided(true)
 	p.SetFolded(!play)
 	action := "play"
-	detail := fmt.Sprintf("%s plays", b.playerName(idx))
+	detail := fmt.Sprintf("%s plays", playerName(b.players, idx))
 	if !play {
 		action = "fold"
-		detail = fmt.Sprintf("%s folds", b.playerName(idx))
+		detail = fmt.Sprintf("%s folds", playerName(b.players, idx))
 	}
 	b.appendLog(idx, action, detail, nil)
 	b.advanceDecide()
@@ -323,7 +323,7 @@ func (b *Bourre) applyDraw(idx int, indices []int) {
 	}
 	b.sortHand(p)
 	p.SetDrawn(true)
-	b.appendLog(idx, "draw", fmt.Sprintf("%s draws %d", b.playerName(idx), len(removed)), nil)
+	b.appendLog(idx, "draw", fmt.Sprintf("%s draws %d", playerName(b.players, idx), len(removed)), nil)
 	b.advanceDraw()
 }
 
@@ -415,7 +415,7 @@ func (b *Bourre) CpuPlay() {
 // playCard カードをトリックに加える共通処理
 func (b *Bourre) playCard(playerIdx int, card *Card) {
 	b.currentTrick = append(b.currentTrick, &TrickCard{PlayerIdx: playerIdx, Card: card})
-	b.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", b.playerName(playerIdx), cardStr(card)), []*Card{card})
+	b.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", playerName(b.players, playerIdx), cardStr(card)), []*Card{card})
 
 	if len(b.currentTrick) == b.activeCount() {
 		b.resolveTrick()
@@ -432,7 +432,7 @@ func (b *Bourre) resolveTrick() {
 		trickCards[i] = tc.Card
 	}
 	b.players[winner].AddTrick(trickCards)
-	b.appendLog(winner, "trick_win", fmt.Sprintf("%s wins trick %d", b.playerName(winner), b.trickNumber), trickCards)
+	b.appendLog(winner, "trick_win", fmt.Sprintf("%s wins trick %d", playerName(b.players, winner), b.trickNumber), trickCards)
 
 	b.leadPlayerIdx = winner
 	b.lastTrick = b.currentTrick
@@ -499,7 +499,7 @@ func (b *Bourre) resolveNoContest() {
 	}
 	if soleWinner >= 0 {
 		b.players[soleWinner].AddChips(potValue)
-		b.appendLog(soleWinner, "pot_win", fmt.Sprintf("%s takes the pot (%d) uncontested", b.playerName(soleWinner), potValue), nil)
+		b.appendLog(soleWinner, "pot_win", fmt.Sprintf("%s takes the pot (%d) uncontested", playerName(b.players, soleWinner), potValue), nil)
 	} else {
 		b.carryPot += potValue
 		b.appendLog(-1, "pot_carry", fmt.Sprintf("All folded — pot of %d carries over", potValue), nil)
@@ -534,7 +534,7 @@ func (b *Bourre) scoreHand() {
 			pen := min(potValue, b.players[i].GetChips())
 			b.players[i].SubtractChips(pen)
 			b.carryPot += pen
-			b.appendLog(i, "bourre", fmt.Sprintf("%s is bourréd! pays %d penalty", b.playerName(i), pen), nil)
+			b.appendLog(i, "bourre", fmt.Sprintf("%s is bourréd! pays %d penalty", playerName(b.players, i), pen), nil)
 		}
 	}
 
@@ -542,7 +542,7 @@ func (b *Bourre) scoreHand() {
 	if len(winners) == 1 {
 		winnerIdx = winners[0]
 		b.players[winnerIdx].AddChips(potValue)
-		b.appendLog(winnerIdx, "pot_win", fmt.Sprintf("%s wins the pot (%d) with %d tricks", b.playerName(winnerIdx), potValue, maxTricks), nil)
+		b.appendLog(winnerIdx, "pot_win", fmt.Sprintf("%s wins the pot (%d) with %d tricks", playerName(b.players, winnerIdx), potValue, maxTricks), nil)
 	} else {
 		b.carryPot += potValue
 		b.appendLog(-1, "pot_carry", fmt.Sprintf("Tie for most tricks — pot of %d carries over", potValue), nil)
@@ -607,7 +607,7 @@ func (b *Bourre) checkGameEnd() {
 			b.winnerIdx = i
 		}
 	}
-	b.appendLog(b.winnerIdx, "game_end", fmt.Sprintf("%s wins the game with %d chips!", b.playerName(b.winnerIdx), b.players[b.winnerIdx].GetChips()), nil)
+	b.appendLog(b.winnerIdx, "game_end", fmt.Sprintf("%s wins the game with %d chips!", playerName(b.players, b.winnerIdx), b.players[b.winnerIdx].GetChips()), nil)
 }
 
 // --- 補助 ---
@@ -782,17 +782,6 @@ func (b *Bourre) sortHand(p *BourrePlayer) {
 	for _, c := range cards {
 		p.AddCard(c)
 	}
-}
-
-// playerName プレイヤー表示名
-func (b *Bourre) playerName(idx int) string {
-	if idx < 0 || idx >= len(b.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if b.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // bourreRank カードのランクを返す (エース=14、それ以外は額面値)

--- a/internal/domain/Bridge_test.go
+++ b/internal/domain/Bridge_test.go
@@ -1117,10 +1117,14 @@ func TestBridgeCardDesignToBidSuit(t *testing.T) {
 
 func TestBridgePlayerName(t *testing.T) {
 	b := newTestBridge()
-	assert.Contains(t, playerName(b.players, 0), "You")
-	assert.Contains(t, playerName(b.players, 1), "CPU")
-	assert.Contains(t, playerName(b.players, -1), "Player")
-	assert.Contains(t, playerName(b.players, 10), "Player")
+	// Bridge names seats by compass position, which is why it keeps its own
+	// playerName rather than using the shared helper. Assert the whole string:
+	// a Contains check on "You" alone would still pass if the position were
+	// dropped, which is exactly the regression this test exists to catch.
+	assert.Equal(t, "You (North)", b.playerName(0))
+	assert.Equal(t, "CPU 1 (East)", b.playerName(1))
+	assert.Equal(t, "Player -1", b.playerName(-1))
+	assert.Equal(t, "Player 10", b.playerName(10))
 }
 
 func TestBridgeResolveTrickWrongPhase(t *testing.T) {

--- a/internal/domain/Bridge_test.go
+++ b/internal/domain/Bridge_test.go
@@ -1117,10 +1117,10 @@ func TestBridgeCardDesignToBidSuit(t *testing.T) {
 
 func TestBridgePlayerName(t *testing.T) {
 	b := newTestBridge()
-	assert.Contains(t, b.playerName(0), "You")
-	assert.Contains(t, b.playerName(1), "CPU")
-	assert.Contains(t, b.playerName(-1), "Player")
-	assert.Contains(t, b.playerName(10), "Player")
+	assert.Contains(t, playerName(b.players, 0), "You")
+	assert.Contains(t, playerName(b.players, 1), "CPU")
+	assert.Contains(t, playerName(b.players, -1), "Player")
+	assert.Contains(t, playerName(b.players, 10), "Player")
 }
 
 func TestBridgeResolveTrickWrongPhase(t *testing.T) {

--- a/internal/domain/Briscola.go
+++ b/internal/domain/Briscola.go
@@ -216,7 +216,7 @@ func (b *Briscola) ResolveTrick() {
 	b.playerPoints[winnerIdx] += trickPoints
 
 	b.appendLog(winnerIdx, "trick_win",
-		fmt.Sprintf("%s wins trick %d (%d pt)", b.playerName(winnerIdx), b.trickNumber, trickPoints),
+		fmt.Sprintf("%s wins trick %d (%d pt)", playerName(b.players, winnerIdx), b.trickNumber, trickPoints),
 		trickCards)
 
 	b.leadPlayerIdx = winnerIdx
@@ -411,7 +411,7 @@ func (b *Briscola) playCard(playerIdx int, card *Card) {
 		Card:      card,
 	})
 	b.appendLog(playerIdx, "play",
-		fmt.Sprintf("%s plays %s", b.playerName(playerIdx), cardStr(card)),
+		fmt.Sprintf("%s plays %s", playerName(b.players, playerIdx), cardStr(card)),
 		[]*Card{card})
 
 	if len(b.currentTrick) == BriscolaPlayerCnt {
@@ -557,17 +557,6 @@ func (b *Briscola) sortHand(p *BriscolaPlayer) {
 		}
 		return BriscolaRankOrder(ci) < BriscolaRankOrder(cj)
 	})
-}
-
-// playerName プレイヤー名を返す (ログ用)
-func (b *Briscola) playerName(idx int) string {
-	if idx < 0 || idx >= len(b.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if b.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // playHintReason ヒント理由キーを判定する

--- a/internal/domain/Calabresella.go
+++ b/internal/domain/Calabresella.go
@@ -284,10 +284,10 @@ func (g *Calabresella) applyBid(playerIdx int, bid CalabresellaBid) {
 	g.bidActed[playerIdx] = true
 	if bid == CalabresellaBidNone {
 		g.appendLog(playerIdx, "bid_pass",
-			fmt.Sprintf("%s passes", g.playerName(playerIdx)), nil)
+			fmt.Sprintf("%s passes", playerName(g.players, playerIdx)), nil)
 	} else {
 		g.appendLog(playerIdx, "bid",
-			fmt.Sprintf("%s bids %s", g.playerName(playerIdx), calabresellaBidName(bid)), nil)
+			fmt.Sprintf("%s bids %s", playerName(g.players, playerIdx), calabresellaBidName(bid)), nil)
 	}
 
 	if g.allBidsActed() {
@@ -340,7 +340,7 @@ func (g *Calabresella) finalizeAuction() {
 	g.soloistIdx = soloist
 	g.winningBid = best
 	g.appendLog(soloist, "soloist",
-		fmt.Sprintf("%s is soloist with %s", g.playerName(soloist), calabresellaBidName(best)), nil)
+		fmt.Sprintf("%s is soloist with %s", playerName(g.players, soloist), calabresellaBidName(best)), nil)
 
 	g.startDiscard()
 }
@@ -387,7 +387,7 @@ func (g *Calabresella) startDiscard() {
 	g.monte = nil
 	calabresellaSortHand(g.players[g.soloistIdx])
 	g.appendLog(g.soloistIdx, "monte_take",
-		fmt.Sprintf("%s takes the monte", g.playerName(g.soloistIdx)), revealed)
+		fmt.Sprintf("%s takes the monte", playerName(g.players, g.soloistIdx)), revealed)
 	g.discardCount = 0
 	g.currentPlayerIdx = g.soloistIdx
 
@@ -425,7 +425,7 @@ func (g *Calabresella) discardOne(cardIndex int) {
 	g.players[g.soloistIdx].AddTrick([]*Card{card})
 	g.roundThirds[g.soloistIdx] += calabresellaThirds(card.GetValue())
 	g.appendLog(g.soloistIdx, "discard",
-		fmt.Sprintf("%s discards %s", g.playerName(g.soloistIdx), cardStr(card)), []*Card{card})
+		fmt.Sprintf("%s discards %s", playerName(g.players, g.soloistIdx), cardStr(card)), []*Card{card})
 	g.discardCount++
 }
 
@@ -512,7 +512,7 @@ func (g *Calabresella) CpuPlay() {
 // playCard カードをプレイする共通処理。
 func (g *Calabresella) playCard(playerIdx int, card *Card) {
 	g.currentTrick = append(g.currentTrick, &TrickCard{PlayerIdx: playerIdx, Card: card})
-	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", g.playerName(playerIdx), cardStr(card)), []*Card{card})
+	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", playerName(g.players, playerIdx), cardStr(card)), []*Card{card})
 
 	if len(g.currentTrick) == CalabresellaPlayerCnt {
 		g.phase = CalabresellaPhaseTrickEnd
@@ -541,7 +541,7 @@ func (g *Calabresella) ResolveTrick() {
 	}
 	g.roundThirds[winnerIdx] += thirds
 	g.appendLog(winnerIdx, "trick_win",
-		fmt.Sprintf("%s wins trick %d (+%d/3%s)", g.playerName(winnerIdx), g.trickNumber, thirds, bonus), trickCards)
+		fmt.Sprintf("%s wins trick %d (+%d/3%s)", playerName(g.players, winnerIdx), g.trickNumber, thirds, bonus), trickCards)
 
 	g.leadPlayerIdx = winnerIdx
 	if g.trickNumber >= CalabresellaTrickCount {
@@ -597,7 +597,7 @@ func (g *Calabresella) ScoreRound() {
 	}
 	g.appendLog(-1, "round_score",
 		fmt.Sprintf("round %d: soloist(%s) %s (%d/3, stake=%d)",
-			g.roundNumber, g.playerName(g.soloistIdx), result, soloistThirds, stake), nil)
+			g.roundNumber, playerName(g.players, g.soloistIdx), result, soloistThirds, stake), nil)
 	g.checkGameEnd()
 }
 
@@ -614,7 +614,7 @@ func (g *Calabresella) checkGameEnd() {
 		g.gameEndFlag = true
 		g.winnerPlayer = leader
 		g.phase = CalabresellaPhaseGameEnd
-		g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the match!", g.playerName(leader)), nil)
+		g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the match!", playerName(g.players, leader)), nil)
 	}
 }
 
@@ -745,17 +745,6 @@ func calabresellaSortHand(p *CalabresellaPlayer) {
 	for _, c := range cards {
 		p.AddCard(c)
 	}
-}
-
-// playerName プレイヤー名を返す。
-func (g *Calabresella) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // calabresellaBidName ビッドの表示名を返す。

--- a/internal/domain/CallBreak.go
+++ b/internal/domain/CallBreak.go
@@ -163,7 +163,7 @@ func (cb *CallBreak) PlayerBid(bid int) error {
 	}
 
 	cb.players[humanIdx].SetBid(bid)
-	cb.appendLog(humanIdx, "bid", fmt.Sprintf("%s bids %d", cb.playerName(humanIdx), bid), nil)
+	cb.appendLog(humanIdx, "bid", fmt.Sprintf("%s bids %d", playerName(cb.players, humanIdx), bid), nil)
 
 	cb.bidPlayerIdx++
 	cb.checkBidComplete()
@@ -184,7 +184,7 @@ func (cb *CallBreak) CpuBid() {
 
 	bid := cb.cpuSelectBid(cb.bidPlayerIdx)
 	cb.players[cb.bidPlayerIdx].SetBid(bid)
-	cb.appendLog(cb.bidPlayerIdx, "bid", fmt.Sprintf("%s bids %d", cb.playerName(cb.bidPlayerIdx), bid), nil)
+	cb.appendLog(cb.bidPlayerIdx, "bid", fmt.Sprintf("%s bids %d", playerName(cb.players, cb.bidPlayerIdx), bid), nil)
 
 	cb.bidPlayerIdx++
 	cb.checkBidComplete()
@@ -251,7 +251,7 @@ func (cb *CallBreak) ResolveTrick() {
 	}
 
 	cb.players[winnerIdx].AddTrick(trickCards)
-	cb.appendLog(winnerIdx, "trick_win", fmt.Sprintf("%s wins trick %d", cb.playerName(winnerIdx), cb.trickNumber), trickCards)
+	cb.appendLog(winnerIdx, "trick_win", fmt.Sprintf("%s wins trick %d", playerName(cb.players, winnerIdx), cb.trickNumber), trickCards)
 
 	cb.leadPlayerIdx = winnerIdx
 
@@ -299,7 +299,7 @@ func (cb *CallBreak) ScoreRound() {
 		p.SetRoundScore(score)
 
 		cb.appendLog(i, "round_score", fmt.Sprintf("%s: bid=%d tricks=%d round=%s",
-			cb.playerName(i), bid, tricks, FormatCallBreakScore(score)), nil)
+			playerName(cb.players, i), bid, tricks, FormatCallBreakScore(score)), nil)
 	}
 
 	// 累積スコアに加算
@@ -310,7 +310,7 @@ func (cb *CallBreak) ScoreRound() {
 	// スコアログ
 	for i := 0; i < CallBreakPlayerCnt; i++ {
 		cb.appendLog(i, "cumulative_score", fmt.Sprintf("%s: total=%s",
-			cb.playerName(i), FormatCallBreakScore(cb.players[i].GetCumulativeScore())), nil)
+			playerName(cb.players, i), FormatCallBreakScore(cb.players[i].GetCumulativeScore())), nil)
 	}
 
 	cb.checkGameEnd()
@@ -444,7 +444,7 @@ func (cb *CallBreak) playCard(playerIdx int, card *Card) {
 		cb.spadesBroken = true
 	}
 
-	cb.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", cb.playerName(playerIdx), cardStr(card)), []*Card{card})
+	cb.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", playerName(cb.players, playerIdx), cardStr(card)), []*Card{card})
 
 	if len(cb.currentTrick) == CallBreakPlayerCnt {
 		cb.phase = CallBreakPhaseTrickEnd
@@ -528,7 +528,7 @@ func (cb *CallBreak) checkGameEnd() {
 			cb.winnerIdx = i
 		}
 	}
-	cb.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game!", cb.playerName(cb.winnerIdx)), nil)
+	cb.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game!", playerName(cb.players, cb.winnerIdx)), nil)
 }
 
 // sortAllHands 全プレイヤーの手札をソートする (スート → 値)
@@ -546,17 +546,6 @@ func callBreakSortHand(p *CallBreakPlayer) {
 		}
 		return ci.GetValue() < cj.GetValue()
 	})
-}
-
-// playerName プレイヤー名を返す
-func (cb *CallBreak) playerName(idx int) string {
-	if idx < 0 || idx >= len(cb.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if cb.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // GetHint ヒントを取得する

--- a/internal/domain/Canasta.go
+++ b/internal/domain/Canasta.go
@@ -225,7 +225,7 @@ func (g *Canasta) autoLayRed3s(playerIdx int) {
 			if CanastaIsRed3(card) {
 				player.RemoveCard(i)
 				player.AddRed3(card)
-				g.appendLog(playerIdx, "red3", fmt.Sprintf("%s lays down red 3: %s", g.playerName(playerIdx), cardStr(card)), []*Card{card})
+				g.appendLog(playerIdx, "red3", fmt.Sprintf("%s lays down red 3: %s", playerName(g.players, playerIdx), cardStr(card)), []*Card{card})
 				// 山札から補充
 				if len(g.drawPile) > 0 {
 					replacement := g.drawPile[len(g.drawPile)-1]
@@ -255,7 +255,7 @@ func (g *Canasta) takePozzetto(playerIdx int) bool {
 		player.AddCard(c)
 	}
 	player.tookPozzetto = true
-	g.appendLog(playerIdx, "pozzetto", fmt.Sprintf("%s takes the pozzetto (%d cards)", g.playerName(playerIdx), len(pile)), nil)
+	g.appendLog(playerIdx, "pozzetto", fmt.Sprintf("%s takes the pozzetto (%d cards)", playerName(g.players, playerIdx), len(pile)), nil)
 	// 獲得した手札に赤3があれば自動的に場に出す
 	g.autoLayRed3s(playerIdx)
 	g.sortHand(playerIdx)
@@ -293,7 +293,7 @@ func (g *Canasta) PlayerDrawFromStock() error {
 	g.drawPile = g.drawPile[:len(g.drawPile)-1]
 	g.players[g.currentPlayerIdx].AddCard(card)
 
-	g.appendLog(g.currentPlayerIdx, "draw_stock", fmt.Sprintf("%s draws from stock", g.playerName(g.currentPlayerIdx)), nil)
+	g.appendLog(g.currentPlayerIdx, "draw_stock", fmt.Sprintf("%s draws from stock", playerName(g.players, g.currentPlayerIdx)), nil)
 
 	// 赤3を引いた場合は自動的に場に出す (autoLayRed3s が補充まで処理する)
 	if CanastaIsRed3(card) {
@@ -389,7 +389,7 @@ func (g *Canasta) PlayerDrawFromDiscard(naturalPairIndices []int) error {
 	g.discardPile = nil
 	g.isFrozen = false
 
-	g.appendLog(g.currentPlayerIdx, "draw_discard", fmt.Sprintf("%s picks up the discard pile (%d cards)", g.playerName(g.currentPlayerIdx), pileSize), []*Card{topCard})
+	g.appendLog(g.currentPlayerIdx, "draw_discard", fmt.Sprintf("%s picks up the discard pile (%d cards)", playerName(g.players, g.currentPlayerIdx), pileSize), []*Card{topCard})
 
 	// 手札に赤3があれば自動的に場に出す
 	g.autoLayRed3s(g.currentPlayerIdx)
@@ -548,7 +548,7 @@ func (g *Canasta) PlayerMeld(meldGroups [][]int) error {
 				IsNatural: isNatural,
 			}
 			player.AddMeld(meld)
-			g.appendLog(g.currentPlayerIdx, "meld", fmt.Sprintf("%s melds %d cards (rank %d)", g.playerName(g.currentPlayerIdx), len(action.cards), meld.GetRank()), action.cards)
+			g.appendLog(g.currentPlayerIdx, "meld", fmt.Sprintf("%s melds %d cards (rank %d)", playerName(g.players, g.currentPlayerIdx), len(action.cards), meld.GetRank()), action.cards)
 		} else {
 			existing := player.melds[action.existingIdx]
 			for _, c := range action.cards {
@@ -557,7 +557,7 @@ func (g *Canasta) PlayerMeld(meldGroups [][]int) error {
 					existing.IsNatural = false
 				}
 			}
-			g.appendLog(g.currentPlayerIdx, "meld_add", fmt.Sprintf("%s adds %d cards to meld (rank %d)", g.playerName(g.currentPlayerIdx), len(action.cards), existing.GetRank()), action.cards)
+			g.appendLog(g.currentPlayerIdx, "meld_add", fmt.Sprintf("%s adds %d cards to meld (rank %d)", playerName(g.players, g.currentPlayerIdx), len(action.cards), existing.GetRank()), action.cards)
 		}
 	}
 
@@ -573,7 +573,7 @@ func (g *Canasta) PlayerMeld(meldGroups [][]int) error {
 	// カナスタ完成チェック
 	for _, m := range player.melds {
 		if m.IsCanasta() {
-			g.appendLog(g.currentPlayerIdx, "canasta", fmt.Sprintf("%s completes a %s canasta!", g.playerName(g.currentPlayerIdx), canastaTypeStr(m.IsNatural)), nil)
+			g.appendLog(g.currentPlayerIdx, "canasta", fmt.Sprintf("%s completes a %s canasta!", playerName(g.players, g.currentPlayerIdx), canastaTypeStr(m.IsNatural)), nil)
 		}
 	}
 
@@ -643,7 +643,7 @@ func (g *Canasta) PlayerDiscard(cardIndex int) error {
 		g.isFrozen = true
 	}
 
-	g.appendLog(g.currentPlayerIdx, "discard", fmt.Sprintf("%s discards %s", g.playerName(g.currentPlayerIdx), cardStr(discarded)), []*Card{discarded})
+	g.appendLog(g.currentPlayerIdx, "discard", fmt.Sprintf("%s discards %s", playerName(g.players, g.currentPlayerIdx), cardStr(discarded)), []*Card{discarded})
 
 	// Burraco: 捨て札で手札を出し切り、まだポゼット未獲得なら獲得する
 	if g.config.UsePozzetto && player.GetCardsSize() == 0 && !player.tookPozzetto {
@@ -686,7 +686,7 @@ func (g *Canasta) PlayerGoOut() error {
 		if CanastaIsWild(discarded) {
 			g.isFrozen = true
 		}
-		g.appendLog(g.currentPlayerIdx, "discard", fmt.Sprintf("%s discards %s", g.playerName(g.currentPlayerIdx), cardStr(discarded)), []*Card{discarded})
+		g.appendLog(g.currentPlayerIdx, "discard", fmt.Sprintf("%s discards %s", playerName(g.players, g.currentPlayerIdx), cardStr(discarded)), []*Card{discarded})
 	} else if player.GetCardsSize() > 1 {
 		return NewDomainError(ErrInvalidPlay, "上がるには手札が0枚または1枚でなければなりません")
 	}
@@ -702,7 +702,7 @@ func (g *Canasta) goOut(playerIdx int, concealed bool) {
 	if concealed {
 		bonus = CanastaConcealedGoingOutBonus
 	}
-	g.appendLog(playerIdx, "go_out", fmt.Sprintf("%s goes out! (bonus: %d)", g.playerName(playerIdx), bonus), nil)
+	g.appendLog(playerIdx, "go_out", fmt.Sprintf("%s goes out! (bonus: %d)", playerName(g.players, playerIdx), bonus), nil)
 	g.scoreRound(playerIdx, bonus)
 }
 
@@ -763,7 +763,7 @@ func (g *Canasta) cpuDraw() {
 						pileSize := len(g.discardPile)
 						g.discardPile = nil
 						g.isFrozen = false
-						g.appendLog(g.currentPlayerIdx, "draw_discard", fmt.Sprintf("%s picks up the discard pile (%d cards)", g.playerName(g.currentPlayerIdx), pileSize), []*Card{topCard})
+						g.appendLog(g.currentPlayerIdx, "draw_discard", fmt.Sprintf("%s picks up the discard pile (%d cards)", playerName(g.players, g.currentPlayerIdx), pileSize), []*Card{topCard})
 						g.autoLayRed3s(g.currentPlayerIdx)
 						g.sortHand(g.currentPlayerIdx)
 						g.phase = CanastaPhaseMeld
@@ -783,7 +783,7 @@ func (g *Canasta) cpuDraw() {
 	card := g.drawPile[len(g.drawPile)-1]
 	g.drawPile = g.drawPile[:len(g.drawPile)-1]
 	player.AddCard(card)
-	g.appendLog(g.currentPlayerIdx, "draw_stock", fmt.Sprintf("%s draws from stock", g.playerName(g.currentPlayerIdx)), nil)
+	g.appendLog(g.currentPlayerIdx, "draw_stock", fmt.Sprintf("%s draws from stock", playerName(g.players, g.currentPlayerIdx)), nil)
 
 	// 赤3の処理 (autoLayRed3s が補充まで処理する)
 	if CanastaIsRed3(card) {
@@ -840,7 +840,7 @@ func (g *Canasta) cpuMeld() {
 					existing.IsNatural = false
 				}
 			}
-			g.appendLog(g.currentPlayerIdx, "meld_add", fmt.Sprintf("%s adds %d cards to meld (rank %d)", g.playerName(g.currentPlayerIdx), len(group), existing.GetRank()), group)
+			g.appendLog(g.currentPlayerIdx, "meld_add", fmt.Sprintf("%s adds %d cards to meld (rank %d)", playerName(g.players, g.currentPlayerIdx), len(group), existing.GetRank()), group)
 		} else {
 			isNatural := true
 			for _, c := range group {
@@ -851,7 +851,7 @@ func (g *Canasta) cpuMeld() {
 			}
 			meld := &CanastaMeld{Cards: group, IsNatural: isNatural}
 			player.AddMeld(meld)
-			g.appendLog(g.currentPlayerIdx, "meld", fmt.Sprintf("%s melds %d cards (rank %d)", g.playerName(g.currentPlayerIdx), len(group), meld.GetRank()), group)
+			g.appendLog(g.currentPlayerIdx, "meld", fmt.Sprintf("%s melds %d cards (rank %d)", playerName(g.players, g.currentPlayerIdx), len(group), meld.GetRank()), group)
 		}
 
 		// メルドに使ったカードを手札から削除
@@ -912,7 +912,7 @@ func (g *Canasta) cpuDiscard() {
 			if CanastaIsWild(discarded) {
 				g.isFrozen = true
 			}
-			g.appendLog(g.currentPlayerIdx, "discard", fmt.Sprintf("%s discards %s", g.playerName(g.currentPlayerIdx), cardStr(discarded)), []*Card{discarded})
+			g.appendLog(g.currentPlayerIdx, "discard", fmt.Sprintf("%s discards %s", playerName(g.players, g.currentPlayerIdx), cardStr(discarded)), []*Card{discarded})
 			g.goOut(g.currentPlayerIdx, false)
 			return
 		}
@@ -927,7 +927,7 @@ func (g *Canasta) cpuDiscard() {
 		g.isFrozen = true
 	}
 
-	g.appendLog(g.currentPlayerIdx, "discard", fmt.Sprintf("%s discards %s", g.playerName(g.currentPlayerIdx), cardStr(discarded)), []*Card{discarded})
+	g.appendLog(g.currentPlayerIdx, "discard", fmt.Sprintf("%s discards %s", playerName(g.players, g.currentPlayerIdx), cardStr(discarded)), []*Card{discarded})
 	g.advanceTurn()
 }
 
@@ -1134,7 +1134,7 @@ func (g *Canasta) scoreRound(goOutPlayerIdx int, goOutBonus int) {
 		}
 
 		player.SetRoundScore(score)
-		g.appendLog(i, "score", fmt.Sprintf("%s scores %d points this round", g.playerName(i), score), nil)
+		g.appendLog(i, "score", fmt.Sprintf("%s scores %d points this round", playerName(g.players, i), score), nil)
 	}
 
 	for i := range g.players {
@@ -1193,7 +1193,7 @@ func (g *Canasta) checkGameEnd() {
 			g.winnerIdx = i
 		}
 	}
-	g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game!", g.playerName(g.winnerIdx)), nil)
+	g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game!", playerName(g.players, g.winnerIdx)), nil)
 }
 
 // --- Meld Validation ---
@@ -1524,17 +1524,6 @@ func (g *Canasta) sortHand(playerIdx int) {
 		}
 		return ci.GetValue() < cj.GetValue()
 	})
-}
-
-// playerName プレイヤー名を返す
-func (g *Canasta) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // canastaTypeStr カナスタの種別文字列を返す

--- a/internal/domain/Carioca.go
+++ b/internal/domain/Carioca.go
@@ -253,7 +253,7 @@ func (g *Carioca) drawFromStock() error {
 	g.players[g.currentPlayerIdx].AddCard(card)
 	g.sortHand(g.currentPlayerIdx)
 
-	g.appendLog(g.currentPlayerIdx, "draw_stock", fmt.Sprintf("%s draws from stock", g.playerName(g.currentPlayerIdx)), nil)
+	g.appendLog(g.currentPlayerIdx, "draw_stock", fmt.Sprintf("%s draws from stock", playerName(g.players, g.currentPlayerIdx)), nil)
 	g.phase = CariocaPhasePlay
 	return nil
 }
@@ -267,7 +267,7 @@ func (g *Carioca) drawFromDiscard() error {
 	g.players[g.currentPlayerIdx].AddCard(card)
 	g.sortHand(g.currentPlayerIdx)
 
-	g.appendLog(g.currentPlayerIdx, "draw_discard", fmt.Sprintf("%s draws %s from discard", g.playerName(g.currentPlayerIdx), cardStr(card)), []*Card{card})
+	g.appendLog(g.currentPlayerIdx, "draw_discard", fmt.Sprintf("%s draws %s from discard", playerName(g.players, g.currentPlayerIdx), cardStr(card)), []*Card{card})
 	g.phase = CariocaPhasePlay
 	return nil
 }
@@ -369,7 +369,7 @@ func (g *Carioca) applyContractMeld(indicesPerSlot [][]int) error {
 		player.RemoveCard(idx)
 	}
 
-	g.appendLog(g.currentPlayerIdx, "meld_contract", fmt.Sprintf("%s meets the contract (round %d)", g.playerName(g.currentPlayerIdx), g.roundNumber), nil)
+	g.appendLog(g.currentPlayerIdx, "meld_contract", fmt.Sprintf("%s meets the contract (round %d)", playerName(g.players, g.currentPlayerIdx), g.roundNumber), nil)
 
 	if player.GetCardsSize() == 0 {
 		g.finishRound(g.currentPlayerIdx)
@@ -423,7 +423,7 @@ func (g *Carioca) applyExtraMeld(indices []int) error {
 		player.RemoveCard(idx)
 	}
 
-	g.appendLog(g.currentPlayerIdx, "meld_extra", fmt.Sprintf("%s melds %d extra cards", g.playerName(g.currentPlayerIdx), len(cards)), cards)
+	g.appendLog(g.currentPlayerIdx, "meld_extra", fmt.Sprintf("%s melds %d extra cards", playerName(g.players, g.currentPlayerIdx), len(cards)), cards)
 	if player.GetCardsSize() == 0 {
 		g.finishRound(g.currentPlayerIdx)
 	}
@@ -472,7 +472,7 @@ func (g *Carioca) applyLayoff(targetPlayerIdx, meldIdx, cardIndex int) error {
 	target.AddCardToMeld(meldIdx, card)
 	current.RemoveCard(cardIndex)
 
-	g.appendLog(g.currentPlayerIdx, "layoff", fmt.Sprintf("%s lays off %s on player %d's meld", g.playerName(g.currentPlayerIdx), cardStr(card), targetPlayerIdx), []*Card{card})
+	g.appendLog(g.currentPlayerIdx, "layoff", fmt.Sprintf("%s lays off %s on player %d's meld", playerName(g.players, g.currentPlayerIdx), cardStr(card), targetPlayerIdx), []*Card{card})
 	if current.GetCardsSize() == 0 {
 		g.finishRound(g.currentPlayerIdx)
 	}
@@ -505,7 +505,7 @@ func (g *Carioca) applyDiscard(cardIndex int) error {
 
 	discarded := player.RemoveCard(cardIndex)
 	g.discardPile = append(g.discardPile, discarded)
-	g.appendLog(g.currentPlayerIdx, "discard", fmt.Sprintf("%s discards %s", g.playerName(g.currentPlayerIdx), cardStr(discarded)), []*Card{discarded})
+	g.appendLog(g.currentPlayerIdx, "discard", fmt.Sprintf("%s discards %s", playerName(g.players, g.currentPlayerIdx), cardStr(discarded)), []*Card{discarded})
 
 	if player.GetCardsSize() == 0 && player.IsContractMet() {
 		g.finishRound(g.currentPlayerIdx)
@@ -721,7 +721,7 @@ func (g *Carioca) finishRound(winnerIdx int) {
 	}
 
 	if winnerIdx >= 0 {
-		g.appendLog(winnerIdx, "round_win", fmt.Sprintf("%s goes out (round %d)", g.playerName(winnerIdx), g.roundNumber), nil)
+		g.appendLog(winnerIdx, "round_win", fmt.Sprintf("%s goes out (round %d)", playerName(g.players, winnerIdx), g.roundNumber), nil)
 	} else {
 		g.appendLog(-1, "draw", "Round ends in a draw (stock empty)", nil)
 	}
@@ -755,7 +755,7 @@ func (g *Carioca) finalizeGameEnd() {
 			g.winnerIdx = i
 		}
 	}
-	g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game with %d penalty points!", g.playerName(g.winnerIdx), minScore), nil)
+	g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game with %d penalty points!", playerName(g.players, g.winnerIdx), minScore), nil)
 }
 
 // --- Getters / Setters ---
@@ -848,16 +848,6 @@ func (g *Carioca) sortHand(playerIdx int) {
 	for _, c := range cards {
 		p.AddCard(c)
 	}
-}
-
-func (g *Carioca) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // --- Pure Carioca helpers (joker-aware) ---

--- a/internal/domain/Carioca_test.go
+++ b/internal/domain/Carioca_test.go
@@ -829,10 +829,10 @@ func TestCarioca_Penalty(t *testing.T) {
 
 func TestCarioca_PlayerNameFallback(t *testing.T) {
 	g := helperCariocaHand(t)
-	if got := g.playerName(-1); got == "" {
+	if got := playerName(g.players, -1); got == "" {
 		t.Error("playerName(-1) should return non-empty fallback")
 	}
-	if got := g.playerName(99); got == "" {
+	if got := playerName(g.players, 99); got == "" {
 		t.Error("playerName(99) should return non-empty fallback")
 	}
 }

--- a/internal/domain/CatchTen.go
+++ b/internal/domain/CatchTen.go
@@ -245,7 +245,7 @@ func (g *CatchTen) ResolveTrick() {
 		winner.SetRoundScore(winner.GetRoundScore() + honor)
 	}
 
-	winnerName := g.playerName(winnerIdx)
+	winnerName := playerName(g.players, winnerIdx)
 	g.appendLog(winnerIdx, "trick_win",
 		fmt.Sprintf("%s wins trick %d (honors: %d)", winnerName, g.trickNumber, honor), trickCards)
 
@@ -441,7 +441,7 @@ func (g *CatchTen) playCard(playerIdx int, card *Card) {
 		Card:      card,
 	})
 
-	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", g.playerName(playerIdx), cardStr(card)), []*Card{card})
+	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", playerName(g.players, playerIdx), cardStr(card)), []*Card{card})
 
 	if len(g.currentTrick) == CatchTenPlayerCnt {
 		g.phase = CatchTenPhaseTrickEnd
@@ -561,17 +561,6 @@ func catchTenSortHand(p *CatchTenPlayer) {
 		}
 		return ci.GetValue() < cj.GetValue()
 	})
-}
-
-// playerName プレイヤー名を返す
-func (g *CatchTen) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // playHintReason プレイヒントの理由を判定する

--- a/internal/domain/Cego.go
+++ b/internal/domain/Cego.go
@@ -442,14 +442,14 @@ func (g *Cego) CpuBid() {
 func (g *Cego) applyBid(idx int, bid CegoBid) {
 	g.highestBid = bid
 	g.highestBidder = idx
-	g.appendLog(idx, "bid", fmt.Sprintf("%s bids %s", g.playerName(idx), cegoBidName(bid)), nil)
+	g.appendLog(idx, "bid", fmt.Sprintf("%s bids %s", playerName(g.players, idx), cegoBidName(bid)), nil)
 	g.advanceBid()
 }
 
 // applyPass パスを適用する。
 func (g *Cego) applyPass(idx int) {
 	g.passed[idx] = true
-	g.appendLog(idx, "pass", fmt.Sprintf("%s passes", g.playerName(idx)), nil)
+	g.appendLog(idx, "pass", fmt.Sprintf("%s passes", playerName(g.players, idx)), nil)
 	g.advanceBid()
 }
 
@@ -470,12 +470,12 @@ func (g *Cego) finalizeBid() {
 		g.declarerIdx = (g.dealerIdx + 1) % CegoPlayerCnt
 		g.contract = CegoBidPlay
 		g.appendLog(g.declarerIdx, "forced",
-			fmt.Sprintf("all passed — %s is forced to declare", g.playerName(g.declarerIdx)), nil)
+			fmt.Sprintf("all passed — %s is forced to declare", playerName(g.players, g.declarerIdx)), nil)
 	} else {
 		g.declarerIdx = g.highestBidder
 		g.contract = g.highestBid
 		g.appendLog(g.declarerIdx, "win_bid",
-			fmt.Sprintf("%s takes the declaration", g.playerName(g.declarerIdx)), nil)
+			fmt.Sprintf("%s takes the declaration", playerName(g.players, g.declarerIdx)), nil)
 	}
 	g.currentPlayerIdx = g.declarerIdx
 	g.phase = CegoPhaseContract
@@ -517,7 +517,7 @@ func (g *Cego) CpuChooseContract() {
 func (g *Cego) applyContract(ct CegoContract) {
 	g.contractType = ct
 	g.appendLog(g.declarerIdx, "contract",
-		fmt.Sprintf("%s chooses %s", g.playerName(g.declarerIdx), cegoContractName(ct)), nil)
+		fmt.Sprintf("%s chooses %s", playerName(g.players, g.declarerIdx), cegoContractName(ct)), nil)
 	if ct == CegoContractHandspiel {
 		// 場札は対戦側の得点山に渡る (伏せたまま公開しない)。
 		g.stash = g.blind
@@ -608,7 +608,7 @@ func (g *Cego) doExchange(keepIndices []int) error {
 	}
 	g.blind = make([]*Card, 0)
 	g.appendLog(g.declarerIdx, "exchange",
-		fmt.Sprintf("%s lays down %d cards and takes the Cego", g.playerName(g.declarerIdx), len(discarded)), discarded)
+		fmt.Sprintf("%s lays down %d cards and takes the Cego", playerName(g.players, g.declarerIdx), len(discarded)), discarded)
 	g.sortAllHands()
 	g.startPlay()
 	return nil
@@ -708,7 +708,7 @@ func (g *Cego) CpuPlay() {
 // playCard カードをプレイする共通処理。
 func (g *Cego) playCard(playerIdx int, card *Card) {
 	g.currentTrick = append(g.currentTrick, &TrickCard{PlayerIdx: playerIdx, Card: card})
-	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", g.playerName(playerIdx), cegoCardStr(card)), []*Card{card})
+	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", playerName(g.players, playerIdx), cegoCardStr(card)), []*Card{card})
 	if len(g.currentTrick) == CegoPlayerCnt {
 		g.phase = CegoPhaseTrickEnd
 	} else {
@@ -729,7 +729,7 @@ func (g *Cego) ResolveTrick() {
 	}
 	g.players[winnerIdx].AddTrick(allCards)
 	g.appendLog(winnerIdx, "trick_win",
-		fmt.Sprintf("%s wins trick %d", g.playerName(winnerIdx), g.trickNumber), allCards)
+		fmt.Sprintf("%s wins trick %d", playerName(g.players, winnerIdx), g.trickNumber), allCards)
 
 	g.leadPlayerIdx = winnerIdx
 	if g.trickNumber >= CegoTrickCount {
@@ -782,7 +782,7 @@ func (g *Cego) enterRoundEnd() {
 	}
 	g.appendLog(-1, "round_score",
 		fmt.Sprintf("deal %d: declarer(%s) %s declPts=%d/%d won=%t base=%d",
-			g.roundNumber, g.playerName(g.declarerIdx), cegoContractName(g.contractType),
+			g.roundNumber, playerName(g.players, g.declarerIdx), cegoContractName(g.contractType),
 			bd.DeclarerPoints, CegoTotalPoints, bd.Won, bd.Base), nil)
 	g.checkGameEnd()
 }
@@ -842,7 +842,7 @@ func (g *Cego) checkGameEnd() {
 		g.appendLog(-1, "game_end", "the match ends in a draw", nil)
 	} else {
 		g.winnerPlayer = leader
-		g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the match!", g.playerName(leader)), nil)
+		g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the match!", playerName(g.players, leader)), nil)
 	}
 }
 
@@ -1407,17 +1407,6 @@ func cegoSortHand(p *CegoPlayer) {
 	for _, c := range cards {
 		p.AddCard(c)
 	}
-}
-
-// playerName プレイヤー名を返す。
-func (g *Cego) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // isHumanBidTurn 現在の入札手番が人間か。

--- a/internal/domain/Chinchon.go
+++ b/internal/domain/Chinchon.go
@@ -284,7 +284,7 @@ func (g *Chinchon) doDrawStock(idx int) {
 	g.drawPile = g.drawPile[:len(g.drawPile)-1]
 	g.players[idx].AddCard(card)
 	g.sortHand(idx)
-	g.appendLog(idx, "draw_stock", fmt.Sprintf("%s draws from stock", g.playerName(idx)), nil)
+	g.appendLog(idx, "draw_stock", fmt.Sprintf("%s draws from stock", playerName(g.players, idx)), nil)
 	g.phase = ChinchonPhaseDiscard
 }
 
@@ -294,7 +294,7 @@ func (g *Chinchon) doDrawDiscard(idx int) {
 	g.discardPile = g.discardPile[:len(g.discardPile)-1]
 	g.players[idx].AddCard(card)
 	g.sortHand(idx)
-	g.appendLog(idx, "draw_discard", fmt.Sprintf("%s draws %s from discard", g.playerName(idx), cardStr(card)), []*Card{card})
+	g.appendLog(idx, "draw_discard", fmt.Sprintf("%s draws %s from discard", playerName(g.players, idx), cardStr(card)), []*Card{card})
 	g.phase = ChinchonPhaseDiscard
 }
 
@@ -316,7 +316,7 @@ func (g *Chinchon) PlayerDiscard(cardIndex int) error {
 
 	discarded := player.RemoveCard(cardIndex)
 	g.discardPile = append(g.discardPile, discarded)
-	g.appendLog(g.currentPlayerIdx, "discard", fmt.Sprintf("%s discards %s", g.playerName(g.currentPlayerIdx), cardStr(discarded)), []*Card{discarded})
+	g.appendLog(g.currentPlayerIdx, "discard", fmt.Sprintf("%s discards %s", playerName(g.players, g.currentPlayerIdx), cardStr(discarded)), []*Card{discarded})
 	// 捨てた後に7枚同スート連続が残ればチンチョン (即時ゲーム勝利)。
 	if g.checkChinchon(g.currentPlayerIdx) {
 		return nil
@@ -368,7 +368,7 @@ func (g *Chinchon) executeKnock(idx, cardIndex int) {
 	g.knockerIdx = idx
 	g.knockerMelds = melds
 	g.knockerDeadwood = deadwood
-	g.appendLog(idx, "knock", fmt.Sprintf("%s knocks (deadwood: %d)", g.playerName(idx), deadwoodValue), []*Card{discarded})
+	g.appendLog(idx, "knock", fmt.Sprintf("%s knocks (deadwood: %d)", playerName(g.players, idx), deadwoodValue), []*Card{discarded})
 
 	// レイオフ対象はノッカー以外のアクティブプレイヤー (席順)。
 	g.layoffQueue = g.layoffQueue[:0]
@@ -420,7 +420,7 @@ func (g *Chinchon) PlayerLayoff(cardIndices []int) error {
 		card := player.GetCard(idx)
 		g.layoffCard(card)
 		player.RemoveCard(idx)
-		g.appendLog(g.currentPlayerIdx, "layoff", fmt.Sprintf("%s lays off %s", g.playerName(g.currentPlayerIdx), cardStr(card)), []*Card{card})
+		g.appendLog(g.currentPlayerIdx, "layoff", fmt.Sprintf("%s lays off %s", playerName(g.players, g.currentPlayerIdx), cardStr(card)), []*Card{card})
 	}
 
 	g.advanceLayoff()
@@ -477,14 +477,14 @@ func (g *Chinchon) scoreRound() {
 		}
 		p.SetRoundScore(deadwoodValue)
 		p.CommitRoundScore()
-		g.appendLog(i, "score", fmt.Sprintf("%s scores %d (total %d)", g.playerName(i), deadwoodValue, p.GetCumulativeScore()), nil)
+		g.appendLog(i, "score", fmt.Sprintf("%s scores %d (total %d)", playerName(g.players, i), deadwoodValue, p.GetCumulativeScore()), nil)
 	}
 
 	// 脱落判定
 	for i, p := range g.players {
 		if !p.GetEliminated() && p.GetCumulativeScore() > g.config.EliminationLimit {
 			p.SetEliminated(true)
-			g.appendLog(i, "eliminate", fmt.Sprintf("%s is eliminated (%d)", g.playerName(i), p.GetCumulativeScore()), nil)
+			g.appendLog(i, "eliminate", fmt.Sprintf("%s is eliminated (%d)", playerName(g.players, i), p.GetCumulativeScore()), nil)
 		}
 	}
 
@@ -521,7 +521,7 @@ func (g *Chinchon) checkChinchon(idx int) bool {
 		return false
 	}
 	if hasChinchon(handCards(p)) {
-		g.appendLog(idx, "chinchon", fmt.Sprintf("%s declares Chinchón and wins the game!", g.playerName(idx)), nil)
+		g.appendLog(idx, "chinchon", fmt.Sprintf("%s declares Chinchón and wins the game!", playerName(g.players, idx)), nil)
 		g.winnerIdx = idx
 		g.gameEndFlag = true
 		g.phase = ChinchonPhaseGameEnd
@@ -543,7 +543,7 @@ func (g *Chinchon) checkMatchEnd() {
 		g.phase = ChinchonPhaseGameEnd
 		if len(active) == 1 {
 			g.winnerIdx = active[0]
-			g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the match!", g.playerName(g.winnerIdx)), nil)
+			g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the match!", playerName(g.players, g.winnerIdx)), nil)
 		} else {
 			g.winnerIdx = -1
 			g.appendLog(-1, "game_end", "Match ends with no survivor", nil)
@@ -639,7 +639,7 @@ func (g *Chinchon) cpuDiscardOrKnock() {
 
 	discarded := player.RemoveCard(bestDiscardIdx)
 	g.discardPile = append(g.discardPile, discarded)
-	g.appendLog(idx, "discard", fmt.Sprintf("%s discards %s", g.playerName(idx), cardStr(discarded)), []*Card{discarded})
+	g.appendLog(idx, "discard", fmt.Sprintf("%s discards %s", playerName(g.players, idx), cardStr(discarded)), []*Card{discarded})
 	if g.checkChinchon(idx) {
 		return
 	}
@@ -656,7 +656,7 @@ func (g *Chinchon) cpuLayoff() {
 			if g.canLayoff(card) {
 				g.layoffCard(card)
 				player.RemoveCard(i)
-				g.appendLog(g.currentPlayerIdx, "layoff", fmt.Sprintf("%s lays off %s", g.playerName(g.currentPlayerIdx), cardStr(card)), []*Card{card})
+				g.appendLog(g.currentPlayerIdx, "layoff", fmt.Sprintf("%s lays off %s", playerName(g.players, g.currentPlayerIdx), cardStr(card)), []*Card{card})
 				found = true
 				break
 			}
@@ -837,17 +837,6 @@ func (g *Chinchon) sortHand(playerIdx int) {
 	for _, c := range cards {
 		p.AddCard(c)
 	}
-}
-
-// playerName プレイヤー名を返す
-func (g *Chinchon) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // --- JSON ---

--- a/internal/domain/Cinch.go
+++ b/internal/domain/Cinch.go
@@ -423,7 +423,7 @@ func (g *Cinch) applyBid(playerIdx, bid int) {
 	if bid == CinchPassBid {
 		logBid = "pass"
 	}
-	g.appendLog(playerIdx, "bid", fmt.Sprintf("%s bids %s", g.playerName(playerIdx), logBid), nil)
+	g.appendLog(playerIdx, "bid", fmt.Sprintf("%s bids %s", playerName(g.players, playerIdx), logBid), nil)
 }
 
 // advanceBid は次のビッド手番へ進める。全員終わればトランプ宣言へ移る (stuck dealer も処理)。
@@ -434,7 +434,7 @@ func (g *Cinch) advanceBid() {
 		// 親に到達し、かつ全員パス済みの場合 stuck 強制。
 		if g.bidPlayerIdx == g.dealerIdx && g.currentBid == 0 && bidsDone == CinchPlayerCnt-1 {
 			g.applyBid(g.dealerIdx, CinchMinBid)
-			g.appendLog(g.dealerIdx, "stuck", fmt.Sprintf("%s is stuck with %d", g.playerName(g.dealerIdx), CinchMinBid), nil)
+			g.appendLog(g.dealerIdx, "stuck", fmt.Sprintf("%s is stuck with %d", playerName(g.players, g.dealerIdx), CinchMinBid), nil)
 			g.startNameTrump()
 		}
 		return
@@ -463,7 +463,7 @@ func (g *Cinch) startNameTrump() {
 	}
 	g.phase = CinchPhaseNameTrump
 	g.appendLog(g.bidWinnerIdx, "bid_won",
-		fmt.Sprintf("%s wins the bid at %d and will name trump", g.playerName(g.bidWinnerIdx), g.currentBid), nil)
+		fmt.Sprintf("%s wins the bid at %d and will name trump", playerName(g.players, g.bidWinnerIdx), g.currentBid), nil)
 }
 
 // NameTrump は人間のビッド勝者が切り札スートを宣言する。
@@ -558,7 +558,7 @@ func (g *Cinch) CpuPlay() {
 // playCard はカードをプレイする共通処理。
 func (g *Cinch) playCard(playerIdx int, card *Card) {
 	g.currentTrick = append(g.currentTrick, &TrickCard{PlayerIdx: playerIdx, Card: card})
-	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", g.playerName(playerIdx), cardStr(card)), []*Card{card})
+	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", playerName(g.players, playerIdx), cardStr(card)), []*Card{card})
 
 	if len(g.currentTrick) == CinchPlayerCnt {
 		g.phase = CinchPhaseTrickEnd
@@ -638,7 +638,7 @@ func (g *Cinch) ResolveTrick() {
 	g.lastTrick = g.currentTrick
 	g.lastTrickWinner = winnerIdx
 	g.appendLog(winnerIdx, "trick_win",
-		fmt.Sprintf("%s wins trick %d", g.playerName(winnerIdx), g.trickNumber), trickCards)
+		fmt.Sprintf("%s wins trick %d", playerName(g.players, winnerIdx), g.trickNumber), trickCards)
 	g.leadPlayerIdx = winnerIdx
 	if g.trickNumber >= CinchTotalTricks {
 		g.phase = CinchPhaseRoundEnd
@@ -716,17 +716,17 @@ func (g *Cinch) ScoreRound() {
 				setBack = true
 				g.appendLog(i, "set_back",
 					fmt.Sprintf("%s set back: bid=%d earned=%d -> %d",
-						g.playerName(i), g.currentBid, pts, -g.currentBid), nil)
+						playerName(g.players, i), g.currentBid, pts, -g.currentBid), nil)
 			} else {
 				gained[i] = pts
 				g.appendLog(i, "bid_made",
 					fmt.Sprintf("%s makes bid: bid=%d earned=%d -> +%d",
-						g.playerName(i), g.currentBid, pts, pts), nil)
+						playerName(g.players, i), g.currentBid, pts, pts), nil)
 			}
 		} else {
 			gained[i] = pts
 			if pts > 0 {
-				g.appendLog(i, "non_bidder_score", fmt.Sprintf("%s scores %d", g.playerName(i), pts), nil)
+				g.appendLog(i, "non_bidder_score", fmt.Sprintf("%s scores %d", playerName(g.players, i), pts), nil)
 			}
 		}
 	}
@@ -743,7 +743,7 @@ func (g *Cinch) ScoreRound() {
 	}
 	for i := 0; i < CinchPlayerCnt; i++ {
 		g.appendLog(i, "cumulative_score",
-			fmt.Sprintf("%s: total=%d", g.playerName(i), g.players[i].GetTotalScore()), nil)
+			fmt.Sprintf("%s: total=%d", playerName(g.players, i), g.players[i].GetTotalScore()), nil)
 	}
 	g.checkGameEnd()
 }
@@ -765,7 +765,7 @@ func (g *Cinch) computeRoundPoints() map[int]int {
 				if pv := cinchPointValue(card, g.trumpSuit); pv > 0 {
 					points[playerIdx] += pv
 					g.appendLog(playerIdx, "score_point",
-						fmt.Sprintf("%s captures %s (%d pt)", g.playerName(playerIdx), cardStr(card), pv), nil)
+						fmt.Sprintf("%s captures %s (%d pt)", playerName(g.players, playerIdx), cardStr(card), pv), nil)
 				}
 			}
 		}
@@ -805,7 +805,7 @@ func (g *Cinch) finishGame(winner int) {
 	g.gameEndFlag = true
 	g.phase = CinchPhaseGameEnd
 	g.winnerIdx = winner
-	g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game!", g.playerName(winner)), nil)
+	g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game!", playerName(g.players, winner)), nil)
 }
 
 // --- ヘルパー ---
@@ -832,16 +832,6 @@ func cinchSortHand(p *CinchPlayer) {
 	for _, c := range cards {
 		p.AddCard(c)
 	}
-}
-
-func (g *Cinch) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 func (g *Cinch) getValidPlayIndices(playerIdx int) []int {

--- a/internal/domain/Conquian.go
+++ b/internal/domain/Conquian.go
@@ -267,7 +267,7 @@ func (g *Conquian) PlayerDrawFromStock() error {
 	g.tookDiscard = false
 	g.pendingCard = nil
 
-	g.appendLog(g.currentPlayerIdx, "draw_stock", fmt.Sprintf("%s draws from stock", g.playerName(g.currentPlayerIdx)), nil)
+	g.appendLog(g.currentPlayerIdx, "draw_stock", fmt.Sprintf("%s draws from stock", playerName(g.players, g.currentPlayerIdx)), nil)
 	g.phase = ConquianPhaseMeld
 	return nil
 }
@@ -298,7 +298,7 @@ func (g *Conquian) PlayerDrawFromDiscard() error {
 	g.tookDiscard = true
 	g.pendingCard = card
 
-	g.appendLog(g.currentPlayerIdx, "draw_discard", fmt.Sprintf("%s draws %s from discard", g.playerName(g.currentPlayerIdx), cardStr(card)), []*Card{card})
+	g.appendLog(g.currentPlayerIdx, "draw_discard", fmt.Sprintf("%s draws %s from discard", playerName(g.players, g.currentPlayerIdx), cardStr(card)), []*Card{card})
 	g.phase = ConquianPhaseMeld
 	return nil
 }
@@ -408,11 +408,11 @@ func (g *Conquian) PlayerMeldWithTargets(meldGroups [][]int, extendTargets []int
 	for _, pm := range pending {
 		if pm.extendIdx >= 0 {
 			player.melds[pm.extendIdx] = append(player.melds[pm.extendIdx], pm.cards[0])
-			g.appendLog(g.currentPlayerIdx, "extend", fmt.Sprintf("%s extends a meld with %s", g.playerName(g.currentPlayerIdx), cardStr(pm.cards[0])), pm.cards)
+			g.appendLog(g.currentPlayerIdx, "extend", fmt.Sprintf("%s extends a meld with %s", playerName(g.players, g.currentPlayerIdx), cardStr(pm.cards[0])), pm.cards)
 		} else {
 			meldCopy := append([]*Card{}, pm.cards...)
 			player.AddMeld(meldCopy)
-			g.appendLog(g.currentPlayerIdx, "meld", fmt.Sprintf("%s lays a meld", g.playerName(g.currentPlayerIdx)), meldCopy)
+			g.appendLog(g.currentPlayerIdx, "meld", fmt.Sprintf("%s lays a meld", playerName(g.players, g.currentPlayerIdx)), meldCopy)
 		}
 	}
 
@@ -453,7 +453,7 @@ func (g *Conquian) PlayerDiscard(cardIndex int) error {
 
 	discarded := player.RemoveCard(cardIndex)
 	g.discardPile = append(g.discardPile, discarded)
-	g.appendLog(g.currentPlayerIdx, "discard", fmt.Sprintf("%s discards %s", g.playerName(g.currentPlayerIdx), cardStr(discarded)), []*Card{discarded})
+	g.appendLog(g.currentPlayerIdx, "discard", fmt.Sprintf("%s discards %s", playerName(g.players, g.currentPlayerIdx), cardStr(discarded)), []*Card{discarded})
 
 	g.advanceTurn()
 	return nil
@@ -593,7 +593,7 @@ func (g *Conquian) cpuDraw() {
 			g.sortHand(idx)
 			g.tookDiscard = true
 			g.pendingCard = top
-			g.appendLog(idx, "draw_discard", fmt.Sprintf("%s draws %s from discard", g.playerName(idx), cardStr(top)), []*Card{top})
+			g.appendLog(idx, "draw_discard", fmt.Sprintf("%s draws %s from discard", playerName(g.players, idx), cardStr(top)), []*Card{top})
 			g.phase = ConquianPhaseMeld
 			return
 		}
@@ -608,7 +608,7 @@ func (g *Conquian) cpuDraw() {
 	g.sortHand(idx)
 	g.tookDiscard = false
 	g.pendingCard = nil
-	g.appendLog(idx, "draw_stock", fmt.Sprintf("%s draws from stock", g.playerName(idx)), nil)
+	g.appendLog(idx, "draw_stock", fmt.Sprintf("%s draws from stock", playerName(g.players, idx)), nil)
 	g.phase = ConquianPhaseMeld
 }
 
@@ -638,7 +638,7 @@ func (g *Conquian) cpuMeldAndDiscard() {
 	}
 	discarded := player.RemoveCard(discardIdx)
 	g.discardPile = append(g.discardPile, discarded)
-	g.appendLog(idx, "discard", fmt.Sprintf("%s discards %s", g.playerName(idx), cardStr(discarded)), []*Card{discarded})
+	g.appendLog(idx, "discard", fmt.Sprintf("%s discards %s", playerName(g.players, idx), cardStr(discarded)), []*Card{discarded})
 	g.advanceTurn()
 }
 
@@ -666,7 +666,7 @@ func (g *Conquian) cpuLayMelds(idx int) {
 			}
 		}
 		player.AddMeld(append([]*Card{}, meld...))
-		g.appendLog(idx, "meld", fmt.Sprintf("%s lays a meld", g.playerName(idx)), meld)
+		g.appendLog(idx, "meld", fmt.Sprintf("%s lays a meld", playerName(g.players, idx)), meld)
 		sort.Sort(sort.Reverse(sort.IntSlice(removeIdx)))
 		for _, ri := range removeIdx {
 			player.RemoveCard(ri)
@@ -680,7 +680,7 @@ func (g *Conquian) cpuLayMelds(idx int) {
 			ext := g.findExtendableMeld(idx, card)
 			if ext >= 0 {
 				player.melds[ext] = append(player.melds[ext], card)
-				g.appendLog(idx, "extend", fmt.Sprintf("%s extends a meld with %s", g.playerName(idx), cardStr(card)), []*Card{card})
+				g.appendLog(idx, "extend", fmt.Sprintf("%s extends a meld with %s", playerName(g.players, idx), cardStr(card)), []*Card{card})
 				player.RemoveCard(i)
 				extended = true
 				break
@@ -769,7 +769,7 @@ func (g *Conquian) winRound(playerIdx int) {
 	g.winnerIdx = playerIdx
 	g.players[playerIdx].AddWin()
 	g.players[playerIdx].SetIsFinished(true)
-	g.appendLog(playerIdx, "round_win", fmt.Sprintf("%s goes out and wins the round!", g.playerName(playerIdx)), nil)
+	g.appendLog(playerIdx, "round_win", fmt.Sprintf("%s goes out and wins the round!", playerName(g.players, playerIdx)), nil)
 	g.checkMatchEnd()
 	if !g.gameEndFlag {
 		g.phase = ConquianPhaseRoundEnd
@@ -816,7 +816,7 @@ func (g *Conquian) checkMatchEnd() {
 			g.gameEndFlag = true
 			g.matchWinnerIdx = i
 			g.phase = ConquianPhaseGameEnd
-			g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the match!", g.playerName(i)), nil)
+			g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the match!", playerName(g.players, i)), nil)
 			return
 		}
 	}
@@ -943,17 +943,6 @@ func (g *Conquian) sortHand(playerIdx int) {
 	for _, c := range cards {
 		p.AddCard(c)
 	}
-}
-
-// playerName プレイヤー名を返す
-func (g *Conquian) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // --- JSON ---

--- a/internal/domain/ContractRummy.go
+++ b/internal/domain/ContractRummy.go
@@ -260,7 +260,7 @@ func (g *ContractRummy) drawFromStock() error {
 	g.players[g.currentPlayerIdx].AddCard(card)
 	g.sortHand(g.currentPlayerIdx)
 
-	g.appendLog(g.currentPlayerIdx, "draw_stock", fmt.Sprintf("%s draws from stock", g.playerName(g.currentPlayerIdx)), nil)
+	g.appendLog(g.currentPlayerIdx, "draw_stock", fmt.Sprintf("%s draws from stock", playerName(g.players, g.currentPlayerIdx)), nil)
 	g.phase = ContractRummyPhasePlay
 	return nil
 }
@@ -274,7 +274,7 @@ func (g *ContractRummy) drawFromDiscard() error {
 	g.players[g.currentPlayerIdx].AddCard(card)
 	g.sortHand(g.currentPlayerIdx)
 
-	g.appendLog(g.currentPlayerIdx, "draw_discard", fmt.Sprintf("%s draws %s from discard", g.playerName(g.currentPlayerIdx), cardStr(card)), []*Card{card})
+	g.appendLog(g.currentPlayerIdx, "draw_discard", fmt.Sprintf("%s draws %s from discard", playerName(g.players, g.currentPlayerIdx), cardStr(card)), []*Card{card})
 	g.phase = ContractRummyPhasePlay
 	return nil
 }
@@ -376,7 +376,7 @@ func (g *ContractRummy) applyContractMeld(indicesPerSlot [][]int) error {
 		player.RemoveCard(idx)
 	}
 
-	g.appendLog(g.currentPlayerIdx, "meld_contract", fmt.Sprintf("%s meets the contract (round %d)", g.playerName(g.currentPlayerIdx), g.roundNumber), nil)
+	g.appendLog(g.currentPlayerIdx, "meld_contract", fmt.Sprintf("%s meets the contract (round %d)", playerName(g.players, g.currentPlayerIdx), g.roundNumber), nil)
 
 	if player.GetCardsSize() == 0 {
 		g.finishRound(g.currentPlayerIdx)
@@ -430,7 +430,7 @@ func (g *ContractRummy) applyExtraMeld(indices []int) error {
 		player.RemoveCard(idx)
 	}
 
-	g.appendLog(g.currentPlayerIdx, "meld_extra", fmt.Sprintf("%s melds %d extra cards", g.playerName(g.currentPlayerIdx), len(cards)), cards)
+	g.appendLog(g.currentPlayerIdx, "meld_extra", fmt.Sprintf("%s melds %d extra cards", playerName(g.players, g.currentPlayerIdx), len(cards)), cards)
 	if player.GetCardsSize() == 0 {
 		g.finishRound(g.currentPlayerIdx)
 	}
@@ -479,7 +479,7 @@ func (g *ContractRummy) applyLayoff(targetPlayerIdx, meldIdx, cardIndex int) err
 	target.AddCardToMeld(meldIdx, card)
 	current.RemoveCard(cardIndex)
 
-	g.appendLog(g.currentPlayerIdx, "layoff", fmt.Sprintf("%s lays off %s on player %d's meld", g.playerName(g.currentPlayerIdx), cardStr(card), targetPlayerIdx), []*Card{card})
+	g.appendLog(g.currentPlayerIdx, "layoff", fmt.Sprintf("%s lays off %s on player %d's meld", playerName(g.players, g.currentPlayerIdx), cardStr(card), targetPlayerIdx), []*Card{card})
 	if current.GetCardsSize() == 0 {
 		g.finishRound(g.currentPlayerIdx)
 	}
@@ -512,7 +512,7 @@ func (g *ContractRummy) applyDiscard(cardIndex int) error {
 
 	discarded := player.RemoveCard(cardIndex)
 	g.discardPile = append(g.discardPile, discarded)
-	g.appendLog(g.currentPlayerIdx, "discard", fmt.Sprintf("%s discards %s", g.playerName(g.currentPlayerIdx), cardStr(discarded)), []*Card{discarded})
+	g.appendLog(g.currentPlayerIdx, "discard", fmt.Sprintf("%s discards %s", playerName(g.players, g.currentPlayerIdx), cardStr(discarded)), []*Card{discarded})
 
 	if player.GetCardsSize() == 0 && player.IsContractMet() {
 		g.finishRound(g.currentPlayerIdx)
@@ -728,7 +728,7 @@ func (g *ContractRummy) finishRound(winnerIdx int) {
 	}
 
 	if winnerIdx >= 0 {
-		g.appendLog(winnerIdx, "round_win", fmt.Sprintf("%s goes out (round %d)", g.playerName(winnerIdx), g.roundNumber), nil)
+		g.appendLog(winnerIdx, "round_win", fmt.Sprintf("%s goes out (round %d)", playerName(g.players, winnerIdx), g.roundNumber), nil)
 	} else {
 		g.appendLog(-1, "draw", "Round ends in a draw (stock empty)", nil)
 	}
@@ -762,7 +762,7 @@ func (g *ContractRummy) finalizeGameEnd() {
 			g.winnerIdx = i
 		}
 	}
-	g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game with %d penalty points!", g.playerName(g.winnerIdx), minScore), nil)
+	g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game with %d penalty points!", playerName(g.players, g.winnerIdx), minScore), nil)
 }
 
 // --- Getters / Setters ---
@@ -855,16 +855,6 @@ func (g *ContractRummy) sortHand(playerIdx int) {
 	for _, c := range cards {
 		p.AddCard(c)
 	}
-}
-
-func (g *ContractRummy) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // --- Pure helpers ---

--- a/internal/domain/ContractRummy_test.go
+++ b/internal/domain/ContractRummy_test.go
@@ -807,10 +807,10 @@ func TestContractRummy_Penalty(t *testing.T) {
 
 func TestContractRummy_PlayerNameFallback(t *testing.T) {
 	g := helperContractRummyHand(t)
-	if got := g.playerName(-1); got == "" {
+	if got := playerName(g.players, -1); got == "" {
 		t.Error("playerName(-1) should return non-empty fallback")
 	}
-	if got := g.playerName(99); got == "" {
+	if got := playerName(g.players, 99); got == "" {
 		t.Error("playerName(99) should return non-empty fallback")
 	}
 }

--- a/internal/domain/CourtPiece.go
+++ b/internal/domain/CourtPiece.go
@@ -162,7 +162,7 @@ func (c *CourtPiece) startRound() {
 	courtPieceSortHand(caller)
 
 	c.appendLog(c.callerIdx, "deal",
-		fmt.Sprintf("%s peeks at the first %d cards", c.playerName(c.callerIdx), CourtPiecePeekSize), nil)
+		fmt.Sprintf("%s peeks at the first %d cards", playerName(c.players, c.callerIdx), CourtPiecePeekSize), nil)
 	c.currentPlayerIdx = c.callerIdx
 	c.phase = CourtPiecePhaseTrumpDeclaration
 }
@@ -223,7 +223,7 @@ func (c *CourtPiece) CpuDeclareTrump() {
 func (c *CourtPiece) applyTrumpDeclaration(suit int) {
 	c.trumpSuit = suit
 	c.appendLog(c.callerIdx, "trump",
-		fmt.Sprintf("%s declares %s as trump", c.playerName(c.callerIdx), suitName(suit)), nil)
+		fmt.Sprintf("%s declares %s as trump", playerName(c.players, c.callerIdx), suitName(suit)), nil)
 
 	// Stage 2: 残りのカードを配り切る。
 	c.dealRemaining()
@@ -295,7 +295,7 @@ func (c *CourtPiece) ResolveTrick() {
 	}
 	c.players[winnerIdx].AddTrick(trickCards)
 	c.appendLog(winnerIdx, "trick_win",
-		fmt.Sprintf("%s wins trick %d", c.playerName(winnerIdx), c.trickNumber), trickCards)
+		fmt.Sprintf("%s wins trick %d", playerName(c.players, winnerIdx), c.trickNumber), trickCards)
 
 	c.leadPlayerIdx = winnerIdx
 	if c.trickNumber >= CourtPieceHandSize {
@@ -549,7 +549,7 @@ func (c *CourtPiece) playCard(playerIdx int, card *Card) {
 		Card:      card,
 	})
 	c.appendLog(playerIdx, "play",
-		fmt.Sprintf("%s plays %s", c.playerName(playerIdx), cardStr(card)), []*Card{card})
+		fmt.Sprintf("%s plays %s", playerName(c.players, playerIdx), cardStr(card)), []*Card{card})
 	if len(c.currentTrick) == CourtPiecePlayerCnt {
 		c.phase = CourtPiecePhaseTrickEnd
 		return
@@ -631,17 +631,6 @@ func courtPieceSortHand(p *CourtPiecePlayer) {
 		}
 		return courtPieceRank(ci.GetValue()) < courtPieceRank(cj.GetValue())
 	})
-}
-
-// playerName プレイヤー名を返す
-func (c *CourtPiece) playerName(idx int) string {
-	if idx < 0 || idx >= len(c.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if c.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // playHintReason プレイヒントの理由キー

--- a/internal/domain/CrazyEights.go
+++ b/internal/domain/CrazyEights.go
@@ -199,7 +199,7 @@ func (g *CrazyEights) PlayerChooseSuit(suit int) error {
 	}
 
 	g.chosenSuit = suit
-	g.appendLog(g.currentPlayerIdx, "choose_suit", fmt.Sprintf("%s chooses %s", g.playerName(g.currentPlayerIdx), suitName(suit)), nil)
+	g.appendLog(g.currentPlayerIdx, "choose_suit", fmt.Sprintf("%s chooses %s", playerName(g.players, g.currentPlayerIdx), suitName(suit)), nil)
 
 	g.advanceTurn()
 	return nil
@@ -257,7 +257,7 @@ func (g *CrazyEights) CpuChooseSuit() {
 
 	suit := g.cpuSelectSuit(g.currentPlayerIdx)
 	g.chosenSuit = suit
-	g.appendLog(g.currentPlayerIdx, "choose_suit", fmt.Sprintf("%s chooses %s", g.playerName(g.currentPlayerIdx), suitName(suit)), nil)
+	g.appendLog(g.currentPlayerIdx, "choose_suit", fmt.Sprintf("%s chooses %s", playerName(g.players, g.currentPlayerIdx), suitName(suit)), nil)
 	g.advanceTurn()
 }
 
@@ -291,11 +291,11 @@ func (g *CrazyEights) ScoreRound() {
 			score += crazyEightsCardScore(p.GetCard(j))
 		}
 		totalScore += score
-		g.appendLog(i, "hand_score", fmt.Sprintf("%s: %d points remaining", g.playerName(i), score), nil)
+		g.appendLog(i, "hand_score", fmt.Sprintf("%s: %d points remaining", playerName(g.players, i), score), nil)
 	}
 
 	g.players[winnerIdx].roundScore = totalScore
-	g.appendLog(winnerIdx, "round_win", fmt.Sprintf("%s wins round %d (+%d points)", g.playerName(winnerIdx), g.roundNumber, totalScore), nil)
+	g.appendLog(winnerIdx, "round_win", fmt.Sprintf("%s wins round %d (+%d points)", playerName(g.players, winnerIdx), g.roundNumber, totalScore), nil)
 
 	// 累積スコアに加算
 	g.players[winnerIdx].CommitRoundScore()
@@ -464,7 +464,7 @@ func (g *CrazyEights) playCard(playerIdx int, card *Card) {
 	g.discardPile = append(g.discardPile, card)
 	g.chosenSuit = -1
 
-	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", g.playerName(playerIdx), cardStr(card)), []*Card{card})
+	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", playerName(g.players, playerIdx), cardStr(card)), []*Card{card})
 
 	// 手札が空になったらラウンド終了
 	if g.players[playerIdx].GetCardsSize() == 0 {
@@ -496,7 +496,7 @@ func (g *CrazyEights) drawCard(playerIdx int) error {
 
 	if len(g.drawPile) == 0 {
 		// 引けるカードがない→パス
-		g.appendLog(playerIdx, "pass", fmt.Sprintf("%s passes (no cards to draw)", g.playerName(playerIdx)), nil)
+		g.appendLog(playerIdx, "pass", fmt.Sprintf("%s passes (no cards to draw)", playerName(g.players, playerIdx)), nil)
 		g.advanceTurn()
 		return nil
 	}
@@ -506,7 +506,7 @@ func (g *CrazyEights) drawCard(playerIdx int) error {
 	g.players[playerIdx].AddCard(card)
 	g.sortHand(playerIdx)
 
-	g.appendLog(playerIdx, "draw", fmt.Sprintf("%s draws a card", g.playerName(playerIdx)), nil)
+	g.appendLog(playerIdx, "draw", fmt.Sprintf("%s draws a card", playerName(g.players, playerIdx)), nil)
 
 	// 引いたカードが出せるなら手番を保持 (プレイヤーが次に出す)
 	// 出せないなら次へ
@@ -573,7 +573,7 @@ func (g *CrazyEights) checkGameEnd() {
 			g.winnerIdx = i
 		}
 	}
-	g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game!", g.playerName(g.winnerIdx)), nil)
+	g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game!", playerName(g.players, g.winnerIdx)), nil)
 }
 
 // sortAllHands 全プレイヤーの手札をソートする
@@ -592,17 +592,6 @@ func (g *CrazyEights) sortHand(playerIdx int) {
 		}
 		return ci.GetValue() < cj.GetValue()
 	})
-}
-
-// playerName プレイヤー名を返す
-func (g *CrazyEights) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // --- CPU AI ---

--- a/internal/domain/CrazyEights_internal_test.go
+++ b/internal/domain/CrazyEights_internal_test.go
@@ -437,14 +437,14 @@ func TestCrazyEights_suitName(t *testing.T) {
 func TestCrazyEights_playerName(t *testing.T) {
 	g := newInternalTestCrazyEights()
 
-	assert.Equal(t, "You", g.playerName(0))
-	assert.Equal(t, "CPU 1", g.playerName(1))
-	assert.Equal(t, "CPU 2", g.playerName(2))
-	assert.Equal(t, "CPU 3", g.playerName(3))
+	assert.Equal(t, "You", playerName(g.players, 0))
+	assert.Equal(t, "CPU 1", playerName(g.players, 1))
+	assert.Equal(t, "CPU 2", playerName(g.players, 2))
+	assert.Equal(t, "CPU 3", playerName(g.players, 3))
 
 	// Out of range
-	assert.Equal(t, "Player -1", g.playerName(-1))
-	assert.Equal(t, "Player 4", g.playerName(4))
+	assert.Equal(t, "Player -1", playerName(g.players, -1))
+	assert.Equal(t, "Player 4", playerName(g.players, 4))
 }
 
 // --- crazyEightsCardScore ---

--- a/internal/domain/Cuckoo.go
+++ b/internal/domain/Cuckoo.go
@@ -259,7 +259,7 @@ func (g *Cuckoo) guardHumanTurn() error {
 
 // keep 手札を保持してターンを進める
 func (g *Cuckoo) keep(idx int) {
-	g.appendLog(idx, "keep", fmt.Sprintf("%s keeps", g.playerName(idx)), nil)
+	g.appendLog(idx, "keep", fmt.Sprintf("%s keeps", playerName(g.players, idx)), nil)
 	g.advanceTurn()
 }
 
@@ -300,13 +300,13 @@ func (g *Cuckoo) performSwap(a, b int) {
 	cb := g.players[b].Card()
 	g.players[a].SetCard(cb)
 	g.players[b].SetCard(ca)
-	g.appendLog(a, "swap", fmt.Sprintf("%s swaps with %s", g.playerName(a), g.playerName(b)), nil)
+	g.appendLog(a, "swap", fmt.Sprintf("%s swaps with %s", playerName(g.players, a), playerName(g.players, b)), nil)
 }
 
 // swapWithStock ディーラーが山札から新しいカードを引いて交換する
 func (g *Cuckoo) swapWithStock(idx int) {
 	if len(g.stock) == 0 {
-		g.appendLog(idx, "keep", fmt.Sprintf("%s keeps (stock empty)", g.playerName(idx)), nil)
+		g.appendLog(idx, "keep", fmt.Sprintf("%s keeps (stock empty)", playerName(g.players, idx)), nil)
 		return
 	}
 	newCard := g.stock[len(g.stock)-1]
@@ -316,7 +316,7 @@ func (g *Cuckoo) swapWithStock(idx int) {
 	if old != nil {
 		g.stock = append([]*Card{old}, g.stock...)
 	}
-	g.appendLog(idx, "swap_stock", fmt.Sprintf("%s swaps with the stock", g.playerName(idx)), nil)
+	g.appendLog(idx, "swap_stock", fmt.Sprintf("%s swaps with the stock", playerName(g.players, idx)), nil)
 }
 
 // resolveRefuse 拒否フェーズを解決する。refused=true なら King 公開で交換は不成立、
@@ -328,7 +328,7 @@ func (g *Cuckoo) resolveRefuse(refused bool) {
 		if to >= 0 && to < len(g.revealedKings) {
 			g.revealedKings[to] = true
 		}
-		g.appendLog(to, "refuse", fmt.Sprintf("%s reveals a King and refuses", g.playerName(to)), nil)
+		g.appendLog(to, "refuse", fmt.Sprintf("%s reveals a King and refuses", playerName(g.players, to)), nil)
 	} else {
 		g.performSwap(from, to)
 	}
@@ -425,7 +425,7 @@ func (g *Cuckoo) endRound() {
 		if p.CardValue() == lowest {
 			p.LoseLife()
 			g.roundLosers = append(g.roundLosers, i)
-			g.appendLog(i, "lose_life", fmt.Sprintf("%s loses a life (lowest: %d)", g.playerName(i), lowest), nil)
+			g.appendLog(i, "lose_life", fmt.Sprintf("%s loses a life (lowest: %d)", playerName(g.players, i), lowest), nil)
 		}
 	}
 
@@ -441,7 +441,7 @@ func (g *Cuckoo) endRound() {
 			}
 		}
 		g.players[survivor].SetLives(1)
-		g.appendLog(survivor, "survive", fmt.Sprintf("%s survives the tie-break", g.playerName(survivor)), nil)
+		g.appendLog(survivor, "survive", fmt.Sprintf("%s survives the tie-break", playerName(g.players, survivor)), nil)
 	}
 
 	g.finishRound()
@@ -468,7 +468,7 @@ func (g *Cuckoo) checkGameEnd() {
 	g.gameEndFlag = true
 	g.phase = CuckooPhaseGameEnd
 	g.winnerIdx = g.leaderIdx()
-	g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game!", g.playerName(g.winnerIdx)), nil)
+	g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game!", playerName(g.players, g.winnerIdx)), nil)
 }
 
 // forceGameEnd 防御的なラウンド上限到達時に強制終了する
@@ -619,17 +619,6 @@ func (g *Cuckoo) GetConfig() CuckooConfig { return g.config }
 
 // SetConfig ゲーム設定を設定する
 func (g *Cuckoo) SetConfig(cfg CuckooConfig) { g.config = cfg }
-
-// playerName プレイヤー名を返す
-func (g *Cuckoo) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
-}
 
 // --- JSON ---
 

--- a/internal/domain/Doppelkopf.go
+++ b/internal/domain/Doppelkopf.go
@@ -235,10 +235,10 @@ func (g *Doppelkopf) canAnnounce(playerIdx int) bool {
 func (g *Doppelkopf) applyAnnounce(playerIdx int) {
 	if g.reTeam[playerIdx] {
 		g.reAnnounced = true
-		g.appendLog(playerIdx, "announce_re", fmt.Sprintf("%s announces Re", g.playerName(playerIdx)), nil)
+		g.appendLog(playerIdx, "announce_re", fmt.Sprintf("%s announces Re", playerName(g.players, playerIdx)), nil)
 	} else {
 		g.kontraAnnounced = true
-		g.appendLog(playerIdx, "announce_kontra", fmt.Sprintf("%s announces Kontra", g.playerName(playerIdx)), nil)
+		g.appendLog(playerIdx, "announce_kontra", fmt.Sprintf("%s announces Kontra", playerName(g.players, playerIdx)), nil)
 	}
 }
 
@@ -270,7 +270,7 @@ func (g *Doppelkopf) CpuPlay() {
 // playCard カードをプレイする共通処理。
 func (g *Doppelkopf) playCard(playerIdx int, card *Card) {
 	g.currentTrick = append(g.currentTrick, &TrickCard{PlayerIdx: playerIdx, Card: card})
-	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", g.playerName(playerIdx), cardStr(card)), []*Card{card})
+	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", playerName(g.players, playerIdx), cardStr(card)), []*Card{card})
 
 	if len(g.currentTrick) == DoppelkopfPlayerCnt {
 		g.phase = DoppelkopfPhaseTrickEnd
@@ -293,7 +293,7 @@ func (g *Doppelkopf) ResolveTrick() {
 	}
 	g.players[winnerIdx].AddTrick(trickCards)
 	g.appendLog(winnerIdx, "trick_win",
-		fmt.Sprintf("%s wins trick %d (%d pts)", g.playerName(winnerIdx), g.trickNumber, pts), trickCards)
+		fmt.Sprintf("%s wins trick %d (%d pts)", playerName(g.players, winnerIdx), g.trickNumber, pts), trickCards)
 
 	g.leadPlayerIdx = winnerIdx
 	// Clear the resolved trick so a spurious second ResolveTrick call cannot
@@ -346,7 +346,7 @@ func (g *Doppelkopf) ScoreRound() {
 		g.gameEndFlag = true
 		g.winnerIdx = w
 		g.phase = DoppelkopfPhaseGameEnd
-		g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game!", g.playerName(w)), nil)
+		g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game!", playerName(g.players, w)), nil)
 	}
 }
 
@@ -507,17 +507,6 @@ func dkSortHand(p *DoppelkopfPlayer) {
 	for _, c := range cards {
 		p.AddCard(c)
 	}
-}
-
-// playerName プレイヤー名を返す。
-func (g *Doppelkopf) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // indexOfPlayerInTrick currentTrick 内で playerIdx の札の位置を返す (-1=なし)。

--- a/internal/domain/Ecarte.go
+++ b/internal/domain/Ecarte.go
@@ -185,7 +185,7 @@ func (e *Ecarte) startDeal() {
 		if e.trumpCard.GetValue() == 13 {
 			e.dealPoints[e.dealerIdx]++
 			e.appendLog(e.dealerIdx, "king_turn",
-				fmt.Sprintf("%s scores the turned King (+1)", e.playerName(e.dealerIdx)), nil)
+				fmt.Sprintf("%s scores the turned King (+1)", playerName(e.players, e.dealerIdx)), nil)
 		}
 	}
 	e.sortAllHands()
@@ -202,7 +202,7 @@ func (e *Ecarte) PlayerPropose() error {
 	if err := e.checkNeg(EcarteNegElderDecide); err != nil {
 		return err
 	}
-	e.appendLog(e.currentPlayerIdx, "propose", fmt.Sprintf("%s proposes", e.playerName(e.currentPlayerIdx)), nil)
+	e.appendLog(e.currentPlayerIdx, "propose", fmt.Sprintf("%s proposes", playerName(e.players, e.currentPlayerIdx)), nil)
 	e.negStep = EcarteNegDealerRespond
 	e.currentPlayerIdx = e.dealerIdx
 	return nil
@@ -213,7 +213,7 @@ func (e *Ecarte) PlayerStand() error {
 	if err := e.checkNeg(EcarteNegElderDecide); err != nil {
 		return err
 	}
-	e.appendLog(e.currentPlayerIdx, "stand", fmt.Sprintf("%s stands", e.playerName(e.currentPlayerIdx)), nil)
+	e.appendLog(e.currentPlayerIdx, "stand", fmt.Sprintf("%s stands", playerName(e.players, e.currentPlayerIdx)), nil)
 	e.startPlay()
 	return nil
 }
@@ -225,11 +225,11 @@ func (e *Ecarte) PlayerRespond(accept bool) error {
 	}
 	if !accept {
 		e.refusalByDealer = true
-		e.appendLog(e.currentPlayerIdx, "refuse", fmt.Sprintf("%s refuses", e.playerName(e.currentPlayerIdx)), nil)
+		e.appendLog(e.currentPlayerIdx, "refuse", fmt.Sprintf("%s refuses", playerName(e.players, e.currentPlayerIdx)), nil)
 		e.startPlay()
 		return nil
 	}
-	e.appendLog(e.currentPlayerIdx, "accept", fmt.Sprintf("%s accepts", e.playerName(e.currentPlayerIdx)), nil)
+	e.appendLog(e.currentPlayerIdx, "accept", fmt.Sprintf("%s accepts", playerName(e.players, e.currentPlayerIdx)), nil)
 	e.negStep = EcarteNegElderDiscard
 	e.currentPlayerIdx = e.elderIdx()
 	return nil
@@ -292,7 +292,7 @@ func (e *Ecarte) applyDiscard(playerIdx int, indices []int) error {
 	}
 	e.sortHand(p)
 	e.appendLog(playerIdx, "discard",
-		fmt.Sprintf("%s exchanges %d card(s)", e.playerName(playerIdx), n), nil)
+		fmt.Sprintf("%s exchanges %d card(s)", playerName(e.players, playerIdx), n), nil)
 
 	if e.negStep == EcarteNegElderDiscard {
 		e.negStep = EcarteNegDealerDiscard
@@ -314,7 +314,7 @@ func (e *Ecarte) startPlay() {
 	for i, p := range e.players {
 		if e.handHasTrumpKing(p) {
 			e.dealPoints[i]++
-			e.appendLog(i, "king", fmt.Sprintf("%s declares the King of trumps (+1)", e.playerName(i)), nil)
+			e.appendLog(i, "king", fmt.Sprintf("%s declares the King of trumps (+1)", playerName(e.players, i)), nil)
 		}
 	}
 	e.phase = EcartePhasePlay
@@ -395,17 +395,17 @@ func (e *Ecarte) CpuExchange() {
 		if e.cpuWantsExchange(idx) {
 			_ = e.PlayerProposeCPU()
 		} else {
-			e.appendLog(idx, "stand", fmt.Sprintf("%s stands", e.playerName(idx)), nil)
+			e.appendLog(idx, "stand", fmt.Sprintf("%s stands", playerName(e.players, idx)), nil)
 			e.startPlay()
 		}
 	case EcarteNegDealerRespond:
 		if e.cpuWantsExchange(idx) {
-			e.appendLog(idx, "accept", fmt.Sprintf("%s accepts", e.playerName(idx)), nil)
+			e.appendLog(idx, "accept", fmt.Sprintf("%s accepts", playerName(e.players, idx)), nil)
 			e.negStep = EcarteNegElderDiscard
 			e.currentPlayerIdx = e.elderIdx()
 		} else {
 			e.refusalByDealer = true
-			e.appendLog(idx, "refuse", fmt.Sprintf("%s refuses", e.playerName(idx)), nil)
+			e.appendLog(idx, "refuse", fmt.Sprintf("%s refuses", playerName(e.players, idx)), nil)
 			e.startPlay()
 		}
 	case EcarteNegElderDiscard, EcarteNegDealerDiscard:
@@ -415,7 +415,7 @@ func (e *Ecarte) CpuExchange() {
 
 // PlayerProposeCPU は CPU 用の propose 内部実装 (検証なし)。
 func (e *Ecarte) PlayerProposeCPU() error {
-	e.appendLog(e.currentPlayerIdx, "propose", fmt.Sprintf("%s proposes", e.playerName(e.currentPlayerIdx)), nil)
+	e.appendLog(e.currentPlayerIdx, "propose", fmt.Sprintf("%s proposes", playerName(e.players, e.currentPlayerIdx)), nil)
 	e.negStep = EcarteNegDealerRespond
 	e.currentPlayerIdx = e.dealerIdx
 	return nil
@@ -424,7 +424,7 @@ func (e *Ecarte) PlayerProposeCPU() error {
 // playCard カードをプレイする共通処理。2枚出そろったらトリックを解決する。
 func (e *Ecarte) playCard(playerIdx int, card *Card) {
 	e.currentTrick = append(e.currentTrick, &TrickCard{PlayerIdx: playerIdx, Card: card})
-	e.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", e.playerName(playerIdx), cardStr(card)), []*Card{card})
+	e.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", playerName(e.players, playerIdx), cardStr(card)), []*Card{card})
 	if len(e.currentTrick) == EcartePlayerCnt {
 		e.resolveTrick()
 		return
@@ -442,7 +442,7 @@ func (e *Ecarte) resolveTrick() {
 	e.players[winnerIdx].AddTrick(trickCards)
 	e.leadPlayerIdx = winnerIdx
 	e.appendLog(winnerIdx, "trick_win",
-		fmt.Sprintf("%s wins trick %d", e.playerName(winnerIdx), e.trickNumber), trickCards)
+		fmt.Sprintf("%s wins trick %d", playerName(e.players, winnerIdx), e.trickNumber), trickCards)
 
 	if e.allHandsEmpty() {
 		e.scoreDeal()
@@ -813,16 +813,6 @@ func (e *Ecarte) sortHand(p *EcartePlayer) {
 		}
 		return EcarteRankOrder(ci) < EcarteRankOrder(cj)
 	})
-}
-
-func (e *Ecarte) playerName(idx int) string {
-	if idx < 0 || idx >= len(e.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if e.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 func (e *Ecarte) playHintReason(playerIdx, chosenIdx int) string {

--- a/internal/domain/Euchre.go
+++ b/internal/domain/Euchre.go
@@ -198,7 +198,7 @@ func (e *Euchre) PlayerPickUp(orderUp bool, goAlone bool) error {
 	if orderUp {
 		e.doOrderUp(humanIdx, goAlone)
 	} else {
-		e.appendLog(humanIdx, "pass", fmt.Sprintf("%s passes", e.playerName(humanIdx)), nil)
+		e.appendLog(humanIdx, "pass", fmt.Sprintf("%s passes", playerName(e.players, humanIdx)), nil)
 		e.advanceBidPickUp()
 	}
 	return nil
@@ -220,7 +220,7 @@ func (e *Euchre) CpuPickUp() {
 	if orderUp {
 		e.doOrderUp(e.bidPlayerIdx, goAlone)
 	} else {
-		e.appendLog(e.bidPlayerIdx, "pass", fmt.Sprintf("%s passes", e.playerName(e.bidPlayerIdx)), nil)
+		e.appendLog(e.bidPlayerIdx, "pass", fmt.Sprintf("%s passes", playerName(e.players, e.bidPlayerIdx)), nil)
 		e.advanceBidPickUp()
 	}
 }
@@ -238,10 +238,10 @@ func (e *Euchre) doOrderUp(playerIdx int, goAlone bool) {
 		e.goingAlone = true
 		e.goingAlonePlayerIdx = playerIdx
 		e.appendLog(playerIdx, "order_up_alone",
-			fmt.Sprintf("%s orders up %s and goes alone", e.playerName(playerIdx), cardStr(e.faceUpCard)), []*Card{e.faceUpCard})
+			fmt.Sprintf("%s orders up %s and goes alone", playerName(e.players, playerIdx), cardStr(e.faceUpCard)), []*Card{e.faceUpCard})
 	} else {
 		e.appendLog(playerIdx, "order_up",
-			fmt.Sprintf("%s orders up %s", e.playerName(playerIdx), cardStr(e.faceUpCard)), []*Card{e.faceUpCard})
+			fmt.Sprintf("%s orders up %s", playerName(e.players, playerIdx), cardStr(e.faceUpCard)), []*Card{e.faceUpCard})
 	}
 
 	e.faceUpCard = nil
@@ -306,7 +306,7 @@ func (e *Euchre) PlayerPassCall() error {
 		return NewDomainError(ErrCannotPass, "ディーラーは必ずスートを選ばなければなりません")
 	}
 
-	e.appendLog(humanIdx, "pass", fmt.Sprintf("%s passes", e.playerName(humanIdx)), nil)
+	e.appendLog(humanIdx, "pass", fmt.Sprintf("%s passes", playerName(e.players, humanIdx)), nil)
 	e.advanceBidCallTrump()
 	return nil
 }
@@ -329,7 +329,7 @@ func (e *Euchre) CpuCallTrump() {
 			forcedSuit := e.cpuForceCallTrump(e.bidPlayerIdx)
 			e.doCallTrump(e.bidPlayerIdx, forcedSuit, false)
 		} else {
-			e.appendLog(e.bidPlayerIdx, "pass", fmt.Sprintf("%s passes", e.playerName(e.bidPlayerIdx)), nil)
+			e.appendLog(e.bidPlayerIdx, "pass", fmt.Sprintf("%s passes", playerName(e.players, e.bidPlayerIdx)), nil)
 			e.advanceBidCallTrump()
 		}
 	}
@@ -345,10 +345,10 @@ func (e *Euchre) doCallTrump(playerIdx int, suit int, goAlone bool) {
 		e.goingAlone = true
 		e.goingAlonePlayerIdx = playerIdx
 		e.appendLog(playerIdx, "call_trump_alone",
-			fmt.Sprintf("%s calls %s as trump and goes alone", e.playerName(playerIdx), suitName), nil)
+			fmt.Sprintf("%s calls %s as trump and goes alone", playerName(e.players, playerIdx), suitName), nil)
 	} else {
 		e.appendLog(playerIdx, "call_trump",
-			fmt.Sprintf("%s calls %s as trump", e.playerName(playerIdx), suitName), nil)
+			fmt.Sprintf("%s calls %s as trump", playerName(e.players, playerIdx), suitName), nil)
 	}
 
 	e.startPlayPhase()
@@ -380,7 +380,7 @@ func (e *Euchre) PlayerDiscard(cardIndex int) error {
 	}
 
 	discarded := player.RemoveCard(cardIndex)
-	e.appendLog(e.dealerIdx, "discard", fmt.Sprintf("%s discards a card", e.playerName(e.dealerIdx)), []*Card{discarded})
+	e.appendLog(e.dealerIdx, "discard", fmt.Sprintf("%s discards a card", playerName(e.players, e.dealerIdx)), []*Card{discarded})
 	e.sortAllHands()
 	e.startPlayPhase()
 	return nil
@@ -397,7 +397,7 @@ func (e *Euchre) CpuDiscard() {
 
 	idx := e.cpuSelectDiscard(e.dealerIdx)
 	discarded := e.players[e.dealerIdx].RemoveCard(idx)
-	e.appendLog(e.dealerIdx, "discard", fmt.Sprintf("%s discards a card", e.playerName(e.dealerIdx)), []*Card{discarded})
+	e.appendLog(e.dealerIdx, "discard", fmt.Sprintf("%s discards a card", playerName(e.players, e.dealerIdx)), []*Card{discarded})
 	e.sortAllHands()
 	e.startPlayPhase()
 }
@@ -467,7 +467,7 @@ func (e *Euchre) ResolveTrick() {
 
 	e.players[winnerIdx].AddTrick(trickCards)
 
-	winnerName := e.playerName(winnerIdx)
+	winnerName := playerName(e.players, winnerIdx)
 	e.appendLog(winnerIdx, "trick_win", fmt.Sprintf("%s wins trick %d", winnerName, e.trickNumber), trickCards)
 
 	e.leadPlayerIdx = winnerIdx
@@ -789,7 +789,7 @@ func (e *Euchre) playCard(playerIdx int, card *Card) {
 		Card:      card,
 	})
 
-	e.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", e.playerName(playerIdx), cardStr(card)), []*Card{card})
+	e.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", playerName(e.players, playerIdx), cardStr(card)), []*Card{card})
 
 	expectedCards := e.activePlayerCount()
 	if len(e.currentTrick) == expectedCards {
@@ -898,17 +898,6 @@ func euchreSortHand(p *EuchrePlayer, e *Euchre) {
 		}
 		return e.cardRank(ci) < e.cardRank(cj)
 	})
-}
-
-// playerName プレイヤー名を返す
-func (e *Euchre) playerName(idx int) string {
-	if idx < 0 || idx >= len(e.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if e.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // suitStr スート名を返す

--- a/internal/domain/FiveHundred.go
+++ b/internal/domain/FiveHundred.go
@@ -320,7 +320,7 @@ func (g *FiveHundred) applyBid(idx int, bid FiveHundredBid) {
 	g.players[idx].SetBid(&b)
 	g.highestBid = &b
 	g.highestBidder = idx
-	g.appendLog(idx, "bid", fmt.Sprintf("%s bids %s", g.playerName(idx), fiveHundredBidLabel(b)), nil)
+	g.appendLog(idx, "bid", fmt.Sprintf("%s bids %s", playerName(g.players, idx), fiveHundredBidLabel(b)), nil)
 	g.advanceBid()
 }
 
@@ -328,7 +328,7 @@ func (g *FiveHundred) applyBid(idx int, bid FiveHundredBid) {
 func (g *FiveHundred) applyPass(idx int) {
 	g.passed[idx] = true
 	g.players[idx].SetPassed(true)
-	g.appendLog(idx, "pass", fmt.Sprintf("%s passes", g.playerName(idx)), nil)
+	g.appendLog(idx, "pass", fmt.Sprintf("%s passes", playerName(g.players, idx)), nil)
 	g.advanceBid()
 }
 
@@ -384,7 +384,7 @@ func (g *FiveHundred) finalizeBid() {
 	}
 	g.kitty = nil
 	g.appendLog(g.declarerIdx, "win_bid",
-		fmt.Sprintf("%s wins the contract: %s", g.playerName(g.declarerIdx), fiveHundredBidLabel(g.contract)), nil)
+		fmt.Sprintf("%s wins the contract: %s", playerName(g.players, g.declarerIdx), fiveHundredBidLabel(g.contract)), nil)
 	g.sortAllHands()
 	g.phase = FiveHundredPhaseKittyExchange
 	g.currentPlayerIdx = g.declarerIdx
@@ -436,7 +436,7 @@ func (g *FiveHundred) doExchange(discardIndices []int) error {
 	discarded := player.RemoveCards(discardIndices)
 	g.kitty = discarded
 	g.appendLog(g.declarerIdx, "exchange",
-		fmt.Sprintf("%s discards %d cards", g.playerName(g.declarerIdx), len(discarded)), discarded)
+		fmt.Sprintf("%s discards %d cards", playerName(g.players, g.declarerIdx), len(discarded)), discarded)
 	g.sortAllHands()
 	g.startPlayPhase()
 	return nil
@@ -518,7 +518,7 @@ func (g *FiveHundred) playCard(playerIdx int, card *Card, jokerSuit int) {
 	}
 	g.currentTrick = append(g.currentTrick, &TrickCard{PlayerIdx: playerIdx, Card: card})
 	g.appendLog(playerIdx, "play",
-		fmt.Sprintf("%s plays %s", g.playerName(playerIdx), fiveHundredCardLabel(card)), []*Card{card})
+		fmt.Sprintf("%s plays %s", playerName(g.players, playerIdx), fiveHundredCardLabel(card)), []*Card{card})
 	if len(g.currentTrick) == g.activePlayerCount() {
 		g.phase = FiveHundredPhaseTrickEnd
 	} else {
@@ -538,7 +538,7 @@ func (g *FiveHundred) ResolveTrick() {
 	}
 	g.players[winnerIdx].AddTrick(cards)
 	g.appendLog(winnerIdx, "trick_win",
-		fmt.Sprintf("%s wins trick %d", g.playerName(winnerIdx), g.trickNumber), cards)
+		fmt.Sprintf("%s wins trick %d", playerName(g.players, winnerIdx), g.trickNumber), cards)
 	g.leadPlayerIdx = winnerIdx
 	if g.trickNumber >= FiveHundredTrickCnt {
 		g.phase = FiveHundredPhaseRoundEnd
@@ -1315,17 +1315,6 @@ func (g *FiveHundred) sortHand(p *FiveHundredPlayer) {
 	for _, c := range cards {
 		p.AddCard(c)
 	}
-}
-
-// playerName プレイヤー名を返す
-func (g *FiveHundred) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // fiveHundredCardLabel カードのログ表示文字列 (ジョーカー対応)

--- a/internal/domain/FortyFives.go
+++ b/internal/domain/FortyFives.go
@@ -237,9 +237,9 @@ func (g *FortyFives) applyBid(idx int, bid FortyFivesBid) error {
 	g.bids[idx] = bid
 	g.bidDone[idx] = true
 	if bid != FortyFivesBidPass {
-		g.appendLog(idx, "bid", fmt.Sprintf("%s bids %d", g.playerName(idx), int(bid)), nil)
+		g.appendLog(idx, "bid", fmt.Sprintf("%s bids %d", playerName(g.players, idx), int(bid)), nil)
 	} else {
-		g.appendLog(idx, "bid", fmt.Sprintf("%s passes", g.playerName(idx)), nil)
+		g.appendLog(idx, "bid", fmt.Sprintf("%s passes", playerName(g.players, idx)), nil)
 	}
 	for k := 1; k <= FortyFivesPlayerCnt; k++ {
 		ni := (idx + k) % FortyFivesPlayerCnt
@@ -265,7 +265,7 @@ func (g *FortyFives) resolveBidding() {
 	g.contract = bid
 	g.trumpSuit = g.longestSuit(idx)
 	g.appendLog(idx, "contract",
-		fmt.Sprintf("%s (team %s) bids %d, trump %d", g.playerName(idx), fortyFivesTeamName(FortyFivesTeamOf(idx)), int(bid), g.trumpSuit), nil)
+		fmt.Sprintf("%s (team %s) bids %d, trump %d", playerName(g.players, idx), fortyFivesTeamName(FortyFivesTeamOf(idx)), int(bid), g.trumpSuit), nil)
 	g.leadPlayerIdx = idx // declarer leads
 	g.currentPlayerIdx = g.leadPlayerIdx
 	g.phase = FortyFivesPhasePlay
@@ -365,7 +365,7 @@ func (g *FortyFives) CpuPlay() {
 // playCard カードをプレイする共通処理。
 func (g *FortyFives) playCard(playerIdx int, card *Card) {
 	g.currentTrick = append(g.currentTrick, &TrickCard{PlayerIdx: playerIdx, Card: card})
-	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", g.playerName(playerIdx), cardStr(card)), []*Card{card})
+	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", playerName(g.players, playerIdx), cardStr(card)), []*Card{card})
 
 	if len(g.currentTrick) == FortyFivesPlayerCnt {
 		g.phase = FortyFivesPhaseTrickEnd
@@ -388,7 +388,7 @@ func (g *FortyFives) ResolveTrick() {
 	g.players[winnerIdx].IncRoundTricks()
 	g.roundTeamPts[FortyFivesTeamOf(winnerIdx)] += FortyFivesPointsPerTrick
 	g.appendLog(winnerIdx, "trick_win",
-		fmt.Sprintf("%s wins trick %d (+%d)", g.playerName(winnerIdx), g.trickNumber, FortyFivesPointsPerTrick), trickCards)
+		fmt.Sprintf("%s wins trick %d (+%d)", playerName(g.players, winnerIdx), g.trickNumber, FortyFivesPointsPerTrick), trickCards)
 
 	g.leadPlayerIdx = winnerIdx
 	if g.trickNumber >= FortyFivesTrickCount {
@@ -610,17 +610,6 @@ func (g *FortyFives) fortyFivesSortHand(p *FortyFivesPlayer) {
 	for _, c := range cards {
 		p.AddCard(c)
 	}
-}
-
-// playerName プレイヤー名を返す。
-func (g *FortyFives) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // indexOfPlayerInTrick currentTrick 内で playerIdx の札の位置を返す (-1=なし)。

--- a/internal/domain/FrenchTarot.go
+++ b/internal/domain/FrenchTarot.go
@@ -433,14 +433,14 @@ func (g *FrenchTarot) CpuBid() {
 func (g *FrenchTarot) applyBid(idx int, bid FrenchTarotBid) {
 	g.highestBid = bid
 	g.highestBidder = idx
-	g.appendLog(idx, "bid", fmt.Sprintf("%s bids %s", g.playerName(idx), frenchTarotBidName(bid)), nil)
+	g.appendLog(idx, "bid", fmt.Sprintf("%s bids %s", playerName(g.players, idx), frenchTarotBidName(bid)), nil)
 	g.advanceBid()
 }
 
 // applyPass パスを適用する。
 func (g *FrenchTarot) applyPass(idx int) {
 	g.passed[idx] = true
-	g.appendLog(idx, "pass", fmt.Sprintf("%s passes", g.playerName(idx)), nil)
+	g.appendLog(idx, "pass", fmt.Sprintf("%s passes", playerName(g.players, idx)), nil)
 	g.advanceBid()
 }
 
@@ -470,7 +470,7 @@ func (g *FrenchTarot) finalizeBid() {
 	g.declarerIdx = g.highestBidder
 	g.contract = g.highestBid
 	g.appendLog(g.declarerIdx, "win_bid",
-		fmt.Sprintf("%s takes the contract %s", g.playerName(g.declarerIdx), frenchTarotBidName(g.contract)), nil)
+		fmt.Sprintf("%s takes the contract %s", playerName(g.players, g.declarerIdx), frenchTarotBidName(g.contract)), nil)
 	switch g.contract {
 	case FrenchTarotBidPetite, FrenchTarotBidGarde:
 		// シアンを公開してデクレアラーの手札に加え、エカルトを待つ。
@@ -547,7 +547,7 @@ func (g *FrenchTarot) doDiscard(cardIndices []int) error {
 	g.stash = discarded
 	g.stashOwner = 0
 	g.appendLog(g.declarerIdx, "discard",
-		fmt.Sprintf("%s discards %d cards to the chien", g.playerName(g.declarerIdx), len(discarded)), discarded)
+		fmt.Sprintf("%s discards %d cards to the chien", playerName(g.players, g.declarerIdx), len(discarded)), discarded)
 	g.sortAllHands()
 	g.startPlay()
 	return nil
@@ -650,7 +650,7 @@ func (g *FrenchTarot) CpuPlay() {
 // playCard カードをプレイする共通処理。
 func (g *FrenchTarot) playCard(playerIdx int, card *Card) {
 	g.currentTrick = append(g.currentTrick, &TrickCard{PlayerIdx: playerIdx, Card: card})
-	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", g.playerName(playerIdx), frenchTarotCardStr(card)), []*Card{card})
+	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", playerName(g.players, playerIdx), frenchTarotCardStr(card)), []*Card{card})
 	if len(g.currentTrick) == FrenchTarotPlayerCnt {
 		g.phase = FrenchTarotPhaseTrickEnd
 	} else {
@@ -684,7 +684,7 @@ func (g *FrenchTarot) ResolveTrick() {
 		g.players[excuseOwner].AddTrick([]*Card{excuseCard})
 	}
 	g.appendLog(winnerIdx, "trick_win",
-		fmt.Sprintf("%s wins trick %d", g.playerName(winnerIdx), g.trickNumber), allCards)
+		fmt.Sprintf("%s wins trick %d", playerName(g.players, winnerIdx), g.trickNumber), allCards)
 
 	g.leadPlayerIdx = winnerIdx
 	if g.trickNumber >= FrenchTarotTrickCount {
@@ -737,7 +737,7 @@ func (g *FrenchTarot) enterRoundEnd() {
 	}
 	g.appendLog(-1, "round_score",
 		fmt.Sprintf("deal %d: declarer(%s) %s target=%d pts=%d/2 bouts=%d base=%d",
-			g.roundNumber, g.playerName(g.declarerIdx), frenchTarotBidName(g.contract),
+			g.roundNumber, playerName(g.players, g.declarerIdx), frenchTarotBidName(g.contract),
 			bd.Target, bd.DeclarerHalfPoints, bd.Bouts, bd.Base), nil)
 	g.checkGameEnd()
 }
@@ -817,7 +817,7 @@ func (g *FrenchTarot) checkGameEnd() {
 		g.appendLog(-1, "game_end", "the match ends in a draw", nil)
 	} else {
 		g.winnerPlayer = leader
-		g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the match!", g.playerName(leader)), nil)
+		g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the match!", playerName(g.players, leader)), nil)
 	}
 }
 
@@ -1460,17 +1460,6 @@ func frenchTarotSortHand(p *FrenchTarotPlayer) {
 	for _, c := range cards {
 		p.AddCard(c)
 	}
-}
-
-// playerName プレイヤー名を返す。
-func (g *FrenchTarot) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // isHumanBidTurn 現在の入札手番が人間か。

--- a/internal/domain/Gaigel.go
+++ b/internal/domain/Gaigel.go
@@ -364,7 +364,7 @@ func (g *Gaigel) declareMarriage(playerIdx, cardIndex int) error {
 	g.roundMarriage[team] += bonus
 	g.appendLog(playerIdx, "marriage",
 		fmt.Sprintf("%s declares marriage in %s (+%d for team %d)",
-			g.playerName(playerIdx), suitStr(suit), bonus, team), nil)
+			playerName(g.players, playerIdx), suitStr(suit), bonus, team), nil)
 
 	played := player.RemoveCard(cardIndex)
 	g.playCard(playerIdx, played)
@@ -401,7 +401,7 @@ func (g *Gaigel) playCard(playerIdx int, card *Card) {
 		Card:      card,
 	})
 	g.appendLog(playerIdx, "play",
-		fmt.Sprintf("%s plays %s", g.playerName(playerIdx), cardStr(card)),
+		fmt.Sprintf("%s plays %s", playerName(g.players, playerIdx), cardStr(card)),
 		[]*Card{card})
 
 	if len(g.currentTrick) == GaigelPlayerCnt {
@@ -429,7 +429,7 @@ func (g *Gaigel) ResolveTrick() {
 	g.roundPoints[g.players[winnerIdx].GetTeam()] += trickPoints
 
 	g.appendLog(winnerIdx, "trick_win",
-		fmt.Sprintf("%s wins trick %d (%d pt)", g.playerName(winnerIdx), g.trickNumber, trickPoints),
+		fmt.Sprintf("%s wins trick %d (%d pt)", playerName(g.players, winnerIdx), g.trickNumber, trickPoints),
 		trickCards)
 
 	g.leadPlayerIdx = winnerIdx
@@ -1031,16 +1031,6 @@ func (g *Gaigel) sortHand(p *GaigelPlayer) {
 		}
 		return GaigelRankOrder(ci) < GaigelRankOrder(cj)
 	})
-}
-
-func (g *Gaigel) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // --- Test-only helpers ---

--- a/internal/domain/GinRummy.go
+++ b/internal/domain/GinRummy.go
@@ -195,7 +195,7 @@ func (g *GinRummy) PlayerDrawFromStock() error {
 	g.players[g.currentPlayerIdx].AddCard(card)
 	g.sortHand(g.currentPlayerIdx)
 
-	g.appendLog(g.currentPlayerIdx, "draw_stock", fmt.Sprintf("%s draws from stock", g.playerName(g.currentPlayerIdx)), nil)
+	g.appendLog(g.currentPlayerIdx, "draw_stock", fmt.Sprintf("%s draws from stock", playerName(g.players, g.currentPlayerIdx)), nil)
 
 	g.phase = GinRummyPhaseDiscard
 	return nil
@@ -222,7 +222,7 @@ func (g *GinRummy) PlayerDrawFromDiscard() error {
 	g.players[g.currentPlayerIdx].AddCard(card)
 	g.sortHand(g.currentPlayerIdx)
 
-	g.appendLog(g.currentPlayerIdx, "draw_discard", fmt.Sprintf("%s draws %s from discard", g.playerName(g.currentPlayerIdx), cardStr(card)), []*Card{card})
+	g.appendLog(g.currentPlayerIdx, "draw_discard", fmt.Sprintf("%s draws %s from discard", playerName(g.players, g.currentPlayerIdx), cardStr(card)), []*Card{card})
 
 	g.phase = GinRummyPhaseDiscard
 	return nil
@@ -248,7 +248,7 @@ func (g *GinRummy) PlayerDiscard(cardIndex int) error {
 	discarded := player.RemoveCard(cardIndex)
 	g.discardPile = append(g.discardPile, discarded)
 
-	g.appendLog(g.currentPlayerIdx, "discard", fmt.Sprintf("%s discards %s", g.playerName(g.currentPlayerIdx), cardStr(discarded)), []*Card{discarded})
+	g.appendLog(g.currentPlayerIdx, "discard", fmt.Sprintf("%s discards %s", playerName(g.players, g.currentPlayerIdx), cardStr(discarded)), []*Card{discarded})
 
 	g.advanceTurn()
 	return nil
@@ -294,11 +294,11 @@ func (g *GinRummy) PlayerKnock(cardIndex int) error {
 	g.knockerDeadwood = deadwood
 	g.isGin = deadwoodValue == 0
 
-	g.appendLog(g.currentPlayerIdx, "knock", fmt.Sprintf("%s knocks (deadwood: %d)", g.playerName(g.currentPlayerIdx), deadwoodValue), []*Card{discarded})
+	g.appendLog(g.currentPlayerIdx, "knock", fmt.Sprintf("%s knocks (deadwood: %d)", playerName(g.players, g.currentPlayerIdx), deadwoodValue), []*Card{discarded})
 
 	if g.isGin {
 		// ジン → レイオフなしでスコアリング
-		g.appendLog(g.currentPlayerIdx, "gin", fmt.Sprintf("%s has Gin!", g.playerName(g.currentPlayerIdx)), nil)
+		g.appendLog(g.currentPlayerIdx, "gin", fmt.Sprintf("%s has Gin!", playerName(g.players, g.currentPlayerIdx)), nil)
 		g.scoreRound()
 	} else {
 		// 相手のレイオフフェーズへ
@@ -358,7 +358,7 @@ func (g *GinRummy) PlayerLayoff(cardIndices []int) error {
 		card := player.GetCard(idx)
 		g.layoffCard(card)
 		player.RemoveCard(idx)
-		g.appendLog(g.currentPlayerIdx, "layoff", fmt.Sprintf("%s lays off %s", g.playerName(g.currentPlayerIdx), cardStr(card)), []*Card{card})
+		g.appendLog(g.currentPlayerIdx, "layoff", fmt.Sprintf("%s lays off %s", playerName(g.players, g.currentPlayerIdx), cardStr(card)), []*Card{card})
 	}
 
 	g.scoreRound()
@@ -512,7 +512,7 @@ func (g *GinRummy) cpuDraw() {
 			g.discardPile = g.discardPile[:len(g.discardPile)-1]
 			g.players[g.currentPlayerIdx].AddCard(card)
 			g.sortHand(g.currentPlayerIdx)
-			g.appendLog(g.currentPlayerIdx, "draw_discard", fmt.Sprintf("%s draws %s from discard", g.playerName(g.currentPlayerIdx), cardStr(card)), []*Card{card})
+			g.appendLog(g.currentPlayerIdx, "draw_discard", fmt.Sprintf("%s draws %s from discard", playerName(g.players, g.currentPlayerIdx), cardStr(card)), []*Card{card})
 			g.phase = GinRummyPhaseDiscard
 			return
 		}
@@ -528,7 +528,7 @@ func (g *GinRummy) cpuDraw() {
 	g.drawPile = g.drawPile[:len(g.drawPile)-1]
 	g.players[g.currentPlayerIdx].AddCard(card)
 	g.sortHand(g.currentPlayerIdx)
-	g.appendLog(g.currentPlayerIdx, "draw_stock", fmt.Sprintf("%s draws from stock", g.playerName(g.currentPlayerIdx)), nil)
+	g.appendLog(g.currentPlayerIdx, "draw_stock", fmt.Sprintf("%s draws from stock", playerName(g.players, g.currentPlayerIdx)), nil)
 	g.phase = GinRummyPhaseDiscard
 }
 
@@ -593,10 +593,10 @@ func (g *GinRummy) cpuDiscardOrKnock() {
 			g.knockerDeadwood = deadwood
 			g.isGin = deadwoodValue == 0
 
-			g.appendLog(g.currentPlayerIdx, "knock", fmt.Sprintf("%s knocks (deadwood: %d)", g.playerName(g.currentPlayerIdx), deadwoodValue), []*Card{discarded})
+			g.appendLog(g.currentPlayerIdx, "knock", fmt.Sprintf("%s knocks (deadwood: %d)", playerName(g.players, g.currentPlayerIdx), deadwoodValue), []*Card{discarded})
 
 			if g.isGin {
-				g.appendLog(g.currentPlayerIdx, "gin", fmt.Sprintf("%s has Gin!", g.playerName(g.currentPlayerIdx)), nil)
+				g.appendLog(g.currentPlayerIdx, "gin", fmt.Sprintf("%s has Gin!", playerName(g.players, g.currentPlayerIdx)), nil)
 				g.scoreRound()
 			} else {
 				g.phase = GinRummyPhaseLayoff
@@ -609,7 +609,7 @@ func (g *GinRummy) cpuDiscardOrKnock() {
 	// 通常のディスカード
 	discarded := player.RemoveCard(bestDiscardIdx)
 	g.discardPile = append(g.discardPile, discarded)
-	g.appendLog(g.currentPlayerIdx, "discard", fmt.Sprintf("%s discards %s", g.playerName(g.currentPlayerIdx), cardStr(discarded)), []*Card{discarded})
+	g.appendLog(g.currentPlayerIdx, "discard", fmt.Sprintf("%s discards %s", playerName(g.players, g.currentPlayerIdx), cardStr(discarded)), []*Card{discarded})
 	g.advanceTurn()
 }
 
@@ -625,7 +625,7 @@ func (g *GinRummy) cpuLayoff() {
 			if g.canLayoff(card) {
 				g.layoffCard(card)
 				player.RemoveCard(i)
-				g.appendLog(g.currentPlayerIdx, "layoff", fmt.Sprintf("%s lays off %s", g.playerName(g.currentPlayerIdx), cardStr(card)), []*Card{card})
+				g.appendLog(g.currentPlayerIdx, "layoff", fmt.Sprintf("%s lays off %s", playerName(g.players, g.currentPlayerIdx), cardStr(card)), []*Card{card})
 				found = true
 				break // re-iterate from start since indices shifted
 			}
@@ -659,17 +659,17 @@ func (g *GinRummy) scoreRound() {
 		// ジン: ノッカーが相手のデッドウッド + ボーナスを獲得
 		score := opponentDeadwoodValue + GinRummyGinBonus
 		g.players[knockerIdx].roundScore = score
-		g.appendLog(knockerIdx, "score", fmt.Sprintf("%s scores %d (Gin bonus %d + deadwood %d)", g.playerName(knockerIdx), score, GinRummyGinBonus, opponentDeadwoodValue), nil)
+		g.appendLog(knockerIdx, "score", fmt.Sprintf("%s scores %d (Gin bonus %d + deadwood %d)", playerName(g.players, knockerIdx), score, GinRummyGinBonus, opponentDeadwoodValue), nil)
 	} else if opponentDeadwoodValue <= knockerDeadwoodValue {
 		// アンダーカット: 相手がデッドウッド差 + ボーナスを獲得
 		score := knockerDeadwoodValue - opponentDeadwoodValue + GinRummyUndercutBonus
 		g.players[opponentIdx].roundScore = score
-		g.appendLog(opponentIdx, "undercut", fmt.Sprintf("%s undercuts! Scores %d (bonus %d + difference %d)", g.playerName(opponentIdx), score, GinRummyUndercutBonus, knockerDeadwoodValue-opponentDeadwoodValue), nil)
+		g.appendLog(opponentIdx, "undercut", fmt.Sprintf("%s undercuts! Scores %d (bonus %d + difference %d)", playerName(g.players, opponentIdx), score, GinRummyUndercutBonus, knockerDeadwoodValue-opponentDeadwoodValue), nil)
 	} else {
 		// 通常ノック: ノッカーがデッドウッド差を獲得
 		score := opponentDeadwoodValue - knockerDeadwoodValue
 		g.players[knockerIdx].roundScore = score
-		g.appendLog(knockerIdx, "score", fmt.Sprintf("%s scores %d (deadwood difference)", g.playerName(knockerIdx), score), nil)
+		g.appendLog(knockerIdx, "score", fmt.Sprintf("%s scores %d (deadwood difference)", playerName(g.players, knockerIdx), score), nil)
 	}
 
 	// 累積スコアに加算
@@ -732,7 +732,7 @@ func (g *GinRummy) checkGameEnd() {
 			g.winnerIdx = i
 		}
 	}
-	g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game!", g.playerName(g.winnerIdx)), nil)
+	g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game!", playerName(g.players, g.winnerIdx)), nil)
 }
 
 // --- State getters ---
@@ -848,17 +848,6 @@ func (g *GinRummy) sortHand(playerIdx int) {
 		}
 		return ci.GetValue() < cj.GetValue()
 	})
-}
-
-// playerName プレイヤー名を返す
-func (g *GinRummy) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // --- Meld Detection ---

--- a/internal/domain/GinRummy_internal_test.go
+++ b/internal/domain/GinRummy_internal_test.go
@@ -286,12 +286,12 @@ func TestGinRummy_findAllPossibleMelds(t *testing.T) {
 func TestGinRummy_playerName(t *testing.T) {
 	g := newInternalTestGinRummy()
 
-	assert.Equal(t, "You", g.playerName(0))
-	assert.Equal(t, "CPU 1", g.playerName(1))
+	assert.Equal(t, "You", playerName(g.players, 0))
+	assert.Equal(t, "CPU 1", playerName(g.players, 1))
 
 	// Out of range
-	assert.Equal(t, "Player -1", g.playerName(-1))
-	assert.Equal(t, "Player 2", g.playerName(2))
+	assert.Equal(t, "Player -1", playerName(g.players, -1))
+	assert.Equal(t, "Player 2", playerName(g.players, 2))
 }
 
 // --- appendLog ---

--- a/internal/domain/GongZhu.go
+++ b/internal/domain/GongZhu.go
@@ -275,7 +275,7 @@ func (g *GongZhu) ResolveTrick() {
 	for _, c := range trickCards {
 		rawPts += gzCardRawPoints(c)
 	}
-	g.appendLog(winnerIdx, "trick_win", fmt.Sprintf("%s wins trick %d (raw %+d)", g.playerName(winnerIdx), g.trickNumber, rawPts), trickCards)
+	g.appendLog(winnerIdx, "trick_win", fmt.Sprintf("%s wins trick %d (raw %+d)", playerName(g.players, winnerIdx), g.trickNumber, rawPts), trickCards)
 
 	g.leadPlayerIdx = winnerIdx
 	if g.trickNumber >= GongZhuHandSize {
@@ -304,7 +304,7 @@ func (g *GongZhu) ScoreRound() {
 
 	for i := 0; i < GongZhuPlayerCnt; i++ {
 		if g.playerHeartCount(i) == GongZhuHandSize {
-			g.appendLog(i, "all_hearts", fmt.Sprintf("%s collected all hearts!", g.playerName(i)), nil)
+			g.appendLog(i, "all_hearts", fmt.Sprintf("%s collected all hearts!", playerName(g.players, i)), nil)
 		}
 		g.players[i].SetRoundScore(g.scoreForPlayer(i))
 	}
@@ -315,7 +315,7 @@ func (g *GongZhu) ScoreRound() {
 
 	for i := 0; i < GongZhuPlayerCnt; i++ {
 		g.appendLog(i, "round_score", fmt.Sprintf("%s: round=%+d, total=%+d",
-			g.playerName(i), g.players[i].GetRoundScore(), g.players[i].GetCumulativeScore()), nil)
+			playerName(g.players, i), g.players[i].GetRoundScore(), g.players[i].GetCumulativeScore()), nil)
 	}
 
 	ended := false
@@ -338,7 +338,7 @@ func (g *GongZhu) ScoreRound() {
 				g.winnerIdx = i
 			}
 		}
-		g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game!", g.playerName(g.winnerIdx)), nil)
+		g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game!", playerName(g.players, g.winnerIdx)), nil)
 	}
 }
 
@@ -586,7 +586,7 @@ func (g *GongZhu) playCard(playerIdx int, card *Card) {
 		g.heartsBroken = true
 	}
 
-	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", g.playerName(playerIdx), cardStr(card)), []*Card{card})
+	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", playerName(g.players, playerIdx), cardStr(card)), []*Card{card})
 
 	if len(g.currentTrick) == GongZhuPlayerCnt {
 		g.phase = GongZhuPhaseTrickEnd
@@ -701,17 +701,6 @@ func gzSortHand(p *GongZhuPlayer) {
 		}
 		return ci.GetValue() < cj.GetValue()
 	})
-}
-
-// playerName プレイヤー名を返す
-func (g *GongZhu) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // --- Card helpers ---

--- a/internal/domain/Guts.go
+++ b/internal/domain/Guts.go
@@ -289,7 +289,7 @@ func (g *Guts) settle() {
 		g.state.carryCount = 0
 		g.players[winner].AddChips(g.state.pot)
 		g.appendLog(winner, "win",
-			fmt.Sprintf("%s wins the pot (%d)", g.playerName(winner), g.state.pot), nil)
+			fmt.Sprintf("%s wins the pot (%d)", playerName(g.players, winner), g.state.pot), nil)
 		// 勝者以外の「イン」プレイヤーはポット額をマッチして次ラウンドの種銭に積む。
 		for _, idx := range inPlayers {
 			if idx == winner {
@@ -301,7 +301,7 @@ func (g *Guts) settle() {
 			g.state.carryPot += pay
 			g.state.matchers = append(g.state.matchers, idx)
 			g.appendLog(idx, "match",
-				fmt.Sprintf("%s matches the pot (pays %d)", g.playerName(idx), pay), nil)
+				fmt.Sprintf("%s matches the pot (pays %d)", playerName(g.players, idx), pay), nil)
 		}
 		g.setHumanResult(winner)
 	}
@@ -340,7 +340,7 @@ func (g *Guts) endGame() {
 	g.state.phase = GutsPhaseResult
 	g.state.matchWinnerIdx = g.richestIdx()
 	g.appendLog(g.state.matchWinnerIdx, "game_end",
-		fmt.Sprintf("%s wins the game", g.playerName(g.state.matchWinnerIdx)), nil)
+		fmt.Sprintf("%s wins the game", playerName(g.players, g.state.matchWinnerIdx)), nil)
 }
 
 // --- 手役評価 (インライン) ---
@@ -447,17 +447,6 @@ func (g *Guts) richestIdx() int {
 		}
 	}
 	return best
-}
-
-// playerName は表示用のプレイヤー名を返す。
-func (g *Guts) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // gutsDeclareText は宣言の棋譜テキストを返す。

--- a/internal/domain/HandAndFoot.go
+++ b/internal/domain/HandAndFoot.go
@@ -233,7 +233,7 @@ func (g *HandAndFoot) autoLayRed3s(playerIdx int) {
 			if CanastaIsRed3(card) {
 				player.RemoveCard(i)
 				g.teamRed3s[team] = append(g.teamRed3s[team], card)
-				g.appendLog(playerIdx, "red3", fmt.Sprintf("%s lays down red 3: %s", g.playerName(playerIdx), cardStr(card)), []*Card{card})
+				g.appendLog(playerIdx, "red3", fmt.Sprintf("%s lays down red 3: %s", playerName(g.players, playerIdx), cardStr(card)), []*Card{card})
 				if len(g.drawPile) > 0 {
 					replacement := g.drawPile[len(g.drawPile)-1]
 					g.drawPile = g.drawPile[:len(g.drawPile)-1]
@@ -261,7 +261,7 @@ func (g *HandAndFoot) enterFootIfEmpty(playerIdx int) bool {
 	}
 	player.SetFoot(make([]*Card, 0))
 	player.SetInFoot(true)
-	g.appendLog(playerIdx, "foot", fmt.Sprintf("%s picks up the foot (%d cards)", g.playerName(playerIdx), len(foot)), nil)
+	g.appendLog(playerIdx, "foot", fmt.Sprintf("%s picks up the foot (%d cards)", playerName(g.players, playerIdx), len(foot)), nil)
 	g.autoLayRed3s(playerIdx)
 	g.sortHand(playerIdx)
 	return true
@@ -363,7 +363,7 @@ func (g *HandAndFoot) PlayerDrawFromStock() error {
 			g.autoLayRed3s(g.currentPlayerIdx)
 		}
 	}
-	g.appendLog(g.currentPlayerIdx, "draw_stock", fmt.Sprintf("%s draws 2 from stock", g.playerName(g.currentPlayerIdx)), nil)
+	g.appendLog(g.currentPlayerIdx, "draw_stock", fmt.Sprintf("%s draws 2 from stock", playerName(g.players, g.currentPlayerIdx)), nil)
 
 	g.drewFromDiscard = false
 	g.drawnCard = nil
@@ -430,7 +430,7 @@ func (g *HandAndFoot) PlayerDrawFromDiscard(naturalPairIndices []int) error {
 	}
 	g.isFrozen = false
 
-	g.appendLog(g.currentPlayerIdx, "draw_discard", fmt.Sprintf("%s picks up %d cards from the discard pile", g.playerName(g.currentPlayerIdx), len(taken)), []*Card{topCard})
+	g.appendLog(g.currentPlayerIdx, "draw_discard", fmt.Sprintf("%s picks up %d cards from the discard pile", playerName(g.players, g.currentPlayerIdx), len(taken)), []*Card{topCard})
 
 	g.autoLayRed3s(g.currentPlayerIdx)
 	g.sortHand(g.currentPlayerIdx)
@@ -560,7 +560,7 @@ func (g *HandAndFoot) PlayerMeld(meldGroups [][]int) error {
 			}
 			meld := &CanastaMeld{Cards: action.cards, IsNatural: isNatural}
 			g.teamMelds[team] = append(g.teamMelds[team], meld)
-			g.appendLog(g.currentPlayerIdx, "meld", fmt.Sprintf("%s melds %d cards (rank %d)", g.playerName(g.currentPlayerIdx), len(action.cards), meld.GetRank()), action.cards)
+			g.appendLog(g.currentPlayerIdx, "meld", fmt.Sprintf("%s melds %d cards (rank %d)", playerName(g.players, g.currentPlayerIdx), len(action.cards), meld.GetRank()), action.cards)
 		} else {
 			existing := g.teamMelds[team][action.existingIdx]
 			for _, c := range action.cards {
@@ -569,7 +569,7 @@ func (g *HandAndFoot) PlayerMeld(meldGroups [][]int) error {
 					existing.IsNatural = false
 				}
 			}
-			g.appendLog(g.currentPlayerIdx, "meld_add", fmt.Sprintf("%s adds %d cards to meld (rank %d)", g.playerName(g.currentPlayerIdx), len(action.cards), existing.GetRank()), action.cards)
+			g.appendLog(g.currentPlayerIdx, "meld_add", fmt.Sprintf("%s adds %d cards to meld (rank %d)", playerName(g.players, g.currentPlayerIdx), len(action.cards), existing.GetRank()), action.cards)
 		}
 	}
 
@@ -582,7 +582,7 @@ func (g *HandAndFoot) PlayerMeld(meldGroups [][]int) error {
 
 	for _, m := range g.teamMelds[team] {
 		if m.IsCanasta() {
-			g.appendLog(g.currentPlayerIdx, "canasta", fmt.Sprintf("%s completes a %s canasta!", g.playerName(g.currentPlayerIdx), canastaTypeStr(m.IsNatural)), nil)
+			g.appendLog(g.currentPlayerIdx, "canasta", fmt.Sprintf("%s completes a %s canasta!", playerName(g.players, g.currentPlayerIdx), canastaTypeStr(m.IsNatural)), nil)
 		}
 	}
 
@@ -641,7 +641,7 @@ func (g *HandAndFoot) PlayerDiscard(cardIndex int) error {
 	if CanastaIsWild(discarded) {
 		g.isFrozen = true
 	}
-	g.appendLog(g.currentPlayerIdx, "discard", fmt.Sprintf("%s discards %s", g.playerName(g.currentPlayerIdx), cardStr(discarded)), []*Card{discarded})
+	g.appendLog(g.currentPlayerIdx, "discard", fmt.Sprintf("%s discards %s", playerName(g.players, g.currentPlayerIdx), cardStr(discarded)), []*Card{discarded})
 
 	// 捨て札で手札を出し切ったらフットを取り込む
 	g.enterFootIfEmpty(g.currentPlayerIdx)
@@ -677,7 +677,7 @@ func (g *HandAndFoot) PlayerGoOut() error {
 		if CanastaIsWild(discarded) {
 			g.isFrozen = true
 		}
-		g.appendLog(g.currentPlayerIdx, "discard", fmt.Sprintf("%s discards %s", g.playerName(g.currentPlayerIdx), cardStr(discarded)), []*Card{discarded})
+		g.appendLog(g.currentPlayerIdx, "discard", fmt.Sprintf("%s discards %s", playerName(g.players, g.currentPlayerIdx), cardStr(discarded)), []*Card{discarded})
 	} else if player.GetCardsSize() > 1 {
 		return NewDomainError(ErrInvalidPlay, "上がるには手札が0枚または1枚でなければなりません")
 	}
@@ -688,7 +688,7 @@ func (g *HandAndFoot) PlayerGoOut() error {
 
 // goOut 上がり処理
 func (g *HandAndFoot) goOut(playerIdx int) {
-	g.appendLog(playerIdx, "go_out", fmt.Sprintf("%s goes out! (bonus: %d)", g.playerName(playerIdx), HandAndFootGoingOutBonus), nil)
+	g.appendLog(playerIdx, "go_out", fmt.Sprintf("%s goes out! (bonus: %d)", playerName(g.players, playerIdx), HandAndFootGoingOutBonus), nil)
 	g.scoreRound(HandAndFootTeamOf(playerIdx))
 }
 
@@ -736,7 +736,7 @@ func (g *HandAndFoot) cpuDraw() {
 					player.AddCard(c)
 				}
 				g.isFrozen = false
-				g.appendLog(g.currentPlayerIdx, "draw_discard", fmt.Sprintf("%s picks up %d cards from the discard pile", g.playerName(g.currentPlayerIdx), len(taken)), []*Card{topCard})
+				g.appendLog(g.currentPlayerIdx, "draw_discard", fmt.Sprintf("%s picks up %d cards from the discard pile", playerName(g.players, g.currentPlayerIdx), len(taken)), []*Card{topCard})
 				g.autoLayRed3s(g.currentPlayerIdx)
 				g.sortHand(g.currentPlayerIdx)
 				g.phase = HandAndFootPhaseMeld
@@ -758,7 +758,7 @@ func (g *HandAndFoot) cpuDraw() {
 			g.autoLayRed3s(g.currentPlayerIdx)
 		}
 	}
-	g.appendLog(g.currentPlayerIdx, "draw_stock", fmt.Sprintf("%s draws 2 from stock", g.playerName(g.currentPlayerIdx)), nil)
+	g.appendLog(g.currentPlayerIdx, "draw_stock", fmt.Sprintf("%s draws 2 from stock", playerName(g.players, g.currentPlayerIdx)), nil)
 
 	g.drewFromDiscard = false
 	g.drawnCard = nil
@@ -789,7 +789,7 @@ func (g *HandAndFoot) cpuMeld() {
 					existing.IsNatural = false
 				}
 			}
-			g.appendLog(g.currentPlayerIdx, "meld_add", fmt.Sprintf("%s adds %d cards to meld (rank %d)", g.playerName(g.currentPlayerIdx), len(group), existing.GetRank()), group)
+			g.appendLog(g.currentPlayerIdx, "meld_add", fmt.Sprintf("%s adds %d cards to meld (rank %d)", playerName(g.players, g.currentPlayerIdx), len(group), existing.GetRank()), group)
 		} else {
 			isNatural := true
 			for _, c := range group {
@@ -800,7 +800,7 @@ func (g *HandAndFoot) cpuMeld() {
 			}
 			meld := &CanastaMeld{Cards: group, IsNatural: isNatural}
 			g.teamMelds[team] = append(g.teamMelds[team], meld)
-			g.appendLog(g.currentPlayerIdx, "meld", fmt.Sprintf("%s melds %d cards (rank %d)", g.playerName(g.currentPlayerIdx), len(group), meld.GetRank()), group)
+			g.appendLog(g.currentPlayerIdx, "meld", fmt.Sprintf("%s melds %d cards (rank %d)", playerName(g.players, g.currentPlayerIdx), len(group), meld.GetRank()), group)
 		}
 
 		for _, c := range group {
@@ -850,7 +850,7 @@ func (g *HandAndFoot) cpuDiscard() {
 			if CanastaIsWild(discarded) {
 				g.isFrozen = true
 			}
-			g.appendLog(g.currentPlayerIdx, "discard", fmt.Sprintf("%s discards %s", g.playerName(g.currentPlayerIdx), cardStr(discarded)), []*Card{discarded})
+			g.appendLog(g.currentPlayerIdx, "discard", fmt.Sprintf("%s discards %s", playerName(g.players, g.currentPlayerIdx), cardStr(discarded)), []*Card{discarded})
 			g.goOut(g.currentPlayerIdx)
 			return
 		}
@@ -862,7 +862,7 @@ func (g *HandAndFoot) cpuDiscard() {
 	if CanastaIsWild(discarded) {
 		g.isFrozen = true
 	}
-	g.appendLog(g.currentPlayerIdx, "discard", fmt.Sprintf("%s discards %s", g.playerName(g.currentPlayerIdx), cardStr(discarded)), []*Card{discarded})
+	g.appendLog(g.currentPlayerIdx, "discard", fmt.Sprintf("%s discards %s", playerName(g.players, g.currentPlayerIdx), cardStr(discarded)), []*Card{discarded})
 
 	g.enterFootIfEmpty(g.currentPlayerIdx)
 	g.advanceTurn()
@@ -1358,17 +1358,6 @@ func (g *HandAndFoot) sortHand(playerIdx int) {
 		}
 		return ci.GetValue() < cj.GetValue()
 	})
-}
-
-// playerName プレイヤー名を返す
-func (g *HandAndFoot) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // --- JSON serialization ---

--- a/internal/domain/Hearts.go
+++ b/internal/domain/Hearts.go
@@ -316,7 +316,7 @@ func (h *Hearts) ResolveTrick() {
 	}
 	h.players[winnerIdx].roundScore += points
 
-	winnerName := h.playerName(winnerIdx)
+	winnerName := playerName(h.players, winnerIdx)
 	h.appendLog(winnerIdx, "trick_win", fmt.Sprintf("%s wins trick %d (%+d pts)", winnerName, h.trickNumber, points), trickCards)
 
 	h.leadPlayerIdx = winnerIdx
@@ -365,7 +365,7 @@ func (h *Hearts) ScoreRound() {
 	}
 
 	if moonShooter >= 0 {
-		h.appendLog(moonShooter, "shoot_moon", fmt.Sprintf("%s shot the moon!", h.playerName(moonShooter)), nil)
+		h.appendLog(moonShooter, "shoot_moon", fmt.Sprintf("%s shot the moon!", playerName(h.players, moonShooter)), nil)
 		h.players[moonShooter].roundScore = 0
 		for i := 0; i < HeartsPlayerCnt; i++ {
 			if i != moonShooter {
@@ -382,7 +382,7 @@ func (h *Hearts) ScoreRound() {
 	// スコアログ
 	for i := 0; i < HeartsPlayerCnt; i++ {
 		h.appendLog(i, "round_score", fmt.Sprintf("%s: round=%d, total=%d",
-			h.playerName(i), h.players[i].roundScore, h.players[i].cumulativeScore), nil)
+			playerName(h.players, i), h.players[i].roundScore, h.players[i].cumulativeScore), nil)
 	}
 
 	// ゲーム終了判定
@@ -406,7 +406,7 @@ func (h *Hearts) ScoreRound() {
 				h.winnerIdx = i
 			}
 		}
-		h.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game!", h.playerName(h.winnerIdx)), nil)
+		h.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game!", playerName(h.players, h.winnerIdx)), nil)
 	}
 }
 
@@ -542,7 +542,7 @@ func (h *Hearts) playCard(playerIdx int, card *Card) {
 		h.heartsBroken = true
 	}
 
-	h.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", h.playerName(playerIdx), cardStr(card)), []*Card{card})
+	h.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", playerName(h.players, playerIdx), cardStr(card)), []*Card{card})
 
 	if len(h.currentTrick) == HeartsPlayerCnt {
 		h.phase = HeartsPhaseTrickEnd
@@ -1136,17 +1136,6 @@ func (h *Hearts) getValidPlayIndices(playerIdx int) []int {
 	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
 		return h.validatePlay(playerIdx, player.GetCard(i)) == nil
 	})
-}
-
-// playerName プレイヤー名を返す
-func (h *Hearts) playerName(idx int) string {
-	if idx < 0 || idx >= len(h.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if h.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // heartsJSON is the JSON wire format for Hearts.

--- a/internal/domain/Hearts_internal_test.go
+++ b/internal/domain/Hearts_internal_test.go
@@ -52,8 +52,8 @@ func TestHearts_passDirectionStr_DefaultCase(t *testing.T) {
 
 func TestHearts_playerName_OutOfBounds(t *testing.T) {
 	h := newInternalTestHearts()
-	assert.Equal(t, "Player -1", h.playerName(-1))
-	assert.Equal(t, "Player 10", h.playerName(10))
+	assert.Equal(t, "Player -1", playerName(h.players, -1))
+	assert.Equal(t, "Player 10", playerName(h.players, 10))
 }
 
 func TestHearts_startPlayPhase_NotFirstTrick(t *testing.T) {

--- a/internal/domain/IndianRummy.go
+++ b/internal/domain/IndianRummy.go
@@ -280,7 +280,7 @@ func (g *IndianRummy) drawFromStock() error {
 	g.players[g.currentPlayerIdx].AddCard(card)
 	g.sortHand(g.currentPlayerIdx)
 
-	g.appendLog(g.currentPlayerIdx, "draw_stock", fmt.Sprintf("%s draws from stock", g.playerName(g.currentPlayerIdx)), nil)
+	g.appendLog(g.currentPlayerIdx, "draw_stock", fmt.Sprintf("%s draws from stock", playerName(g.players, g.currentPlayerIdx)), nil)
 	g.phase = IndianRummyPhaseDiscard
 	return nil
 }
@@ -294,7 +294,7 @@ func (g *IndianRummy) drawFromDiscard() error {
 	g.players[g.currentPlayerIdx].AddCard(card)
 	g.sortHand(g.currentPlayerIdx)
 
-	g.appendLog(g.currentPlayerIdx, "draw_discard", fmt.Sprintf("%s draws %s from discard", g.playerName(g.currentPlayerIdx), cardStr(card)), []*Card{card})
+	g.appendLog(g.currentPlayerIdx, "draw_discard", fmt.Sprintf("%s draws %s from discard", playerName(g.players, g.currentPlayerIdx), cardStr(card)), []*Card{card})
 	g.phase = IndianRummyPhaseDiscard
 	return nil
 }
@@ -334,7 +334,7 @@ func (g *IndianRummy) applyDiscard(cardIndex int) error {
 	}
 	discarded := player.RemoveCard(cardIndex)
 	g.discardPile = append(g.discardPile, discarded)
-	g.appendLog(g.currentPlayerIdx, "discard", fmt.Sprintf("%s discards %s", g.playerName(g.currentPlayerIdx), cardStr(discarded)), []*Card{discarded})
+	g.appendLog(g.currentPlayerIdx, "discard", fmt.Sprintf("%s discards %s", playerName(g.players, g.currentPlayerIdx), cardStr(discarded)), []*Card{discarded})
 	g.advanceTurn()
 	return nil
 }
@@ -370,7 +370,7 @@ func (g *IndianRummy) applyDeclare(cardIndex int) error {
 	if !g.declarationValid {
 		status = "invalid"
 	}
-	g.appendLog(g.currentPlayerIdx, "declare", fmt.Sprintf("%s declares (%s)", g.playerName(g.currentPlayerIdx), status), nil)
+	g.appendLog(g.currentPlayerIdx, "declare", fmt.Sprintf("%s declares (%s)", playerName(g.players, g.currentPlayerIdx), status), nil)
 
 	g.enterRoundEnd()
 	return nil
@@ -526,9 +526,9 @@ func (g *IndianRummy) scoreRound() {
 	}
 
 	if g.declarerIdx >= 0 && g.declarationValid {
-		g.appendLog(g.declarerIdx, "round_win", fmt.Sprintf("%s wins the round with a valid declaration", g.playerName(g.declarerIdx)), nil)
+		g.appendLog(g.declarerIdx, "round_win", fmt.Sprintf("%s wins the round with a valid declaration", playerName(g.players, g.declarerIdx)), nil)
 	} else if g.declarerIdx >= 0 {
-		g.appendLog(g.declarerIdx, "round_end", fmt.Sprintf("%s made an invalid declaration (+%d penalty)", g.playerName(g.declarerIdx), IndianRummyDeadwoodCap), nil)
+		g.appendLog(g.declarerIdx, "round_end", fmt.Sprintf("%s made an invalid declaration (+%d penalty)", playerName(g.players, g.declarerIdx), IndianRummyDeadwoodCap), nil)
 	}
 
 	for i := range g.players {
@@ -549,7 +549,7 @@ func (g *IndianRummy) finalizeGameEnd() {
 			g.winnerIdx = i
 		}
 	}
-	g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game with %d points!", g.playerName(g.winnerIdx), minScore), nil)
+	g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game with %d points!", playerName(g.players, g.winnerIdx), minScore), nil)
 }
 
 // --- Getters / Setters ---
@@ -676,16 +676,6 @@ func (g *IndianRummy) sortHand(playerIdx int) {
 	for _, c := range cards {
 		p.AddCard(c)
 	}
-}
-
-func (g *IndianRummy) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // indianRummyCollectCards プレイヤーの手札を []*Card で返す

--- a/internal/domain/Jass.go
+++ b/internal/domain/Jass.go
@@ -261,7 +261,7 @@ func (g *Jass) CpuBid() {
 func (g *Jass) doSchieben(playerIdx int) {
 	g.schieben = true
 	g.appendLog(playerIdx, "schieben",
-		fmt.Sprintf("%s schiebt (passes to partner)", g.playerName(playerIdx)), nil)
+		fmt.Sprintf("%s schiebt (passes to partner)", playerName(g.players, playerIdx)), nil)
 	g.bidPlayerIdx = (playerIdx + 2) % JassPlayerCnt
 	g.phase = JassPhaseBidPartner
 }
@@ -272,7 +272,7 @@ func (g *Jass) doChooseTrump(playerIdx, suit int) {
 	g.makerTeam = g.players[playerIdx].GetTeam()
 	g.makerPlayerIdx = playerIdx
 	g.appendLog(playerIdx, "choose_trump",
-		fmt.Sprintf("%s chooses %s as trump", g.playerName(playerIdx), suitStr(suit)), nil)
+		fmt.Sprintf("%s chooses %s as trump", playerName(g.players, playerIdx), suitStr(suit)), nil)
 
 	g.sortAllHands()
 	g.resolveWeis()
@@ -347,7 +347,7 @@ func (g *Jass) ResolveTrick() {
 	g.players[winnerIdx].AddTrick(trickCards)
 	g.roundPoints[g.players[winnerIdx].GetTeam()] += trickPoints
 
-	winnerName := g.playerName(winnerIdx)
+	winnerName := playerName(g.players, winnerIdx)
 	g.appendLog(winnerIdx, "trick_win",
 		fmt.Sprintf("%s wins trick %d (%d pts)", winnerName, g.trickNumber, trickPoints),
 		trickCards)
@@ -900,7 +900,7 @@ func (g *Jass) resolveStock() {
 			g.roundStockPoints[team] += JassStockBonus
 			g.appendLog(i, "stock",
 				fmt.Sprintf("%s has Stöck (+%d for team %d)",
-					g.playerName(i), JassStockBonus, team), nil)
+					playerName(g.players, i), JassStockBonus, team), nil)
 		}
 	}
 }
@@ -923,7 +923,7 @@ func (g *Jass) playCard(playerIdx int, card *Card) {
 		Card:      card,
 	})
 	g.appendLog(playerIdx, "play",
-		fmt.Sprintf("%s plays %s", g.playerName(playerIdx), cardStr(card)), []*Card{card})
+		fmt.Sprintf("%s plays %s", playerName(g.players, playerIdx), cardStr(card)), []*Card{card})
 
 	if len(g.currentTrick) == JassPlayerCnt {
 		g.phase = JassPhaseTrickEnd
@@ -1080,16 +1080,6 @@ func jassSortHand(p *JassPlayer, g *Jass) {
 		}
 		return g.cardRank(ci) > g.cardRank(cj)
 	})
-}
-
-func (g *Jass) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // --- Hints ---

--- a/internal/domain/Kalooki.go
+++ b/internal/domain/Kalooki.go
@@ -213,7 +213,7 @@ func (g *Kalooki) drawFromStock() error {
 	g.players[g.currentPlayerIdx].AddCard(card)
 	g.sortHand(g.currentPlayerIdx)
 
-	g.appendLog(g.currentPlayerIdx, "draw_stock", fmt.Sprintf("%s draws from stock", g.playerName(g.currentPlayerIdx)), nil)
+	g.appendLog(g.currentPlayerIdx, "draw_stock", fmt.Sprintf("%s draws from stock", playerName(g.players, g.currentPlayerIdx)), nil)
 	g.phase = KalookiPhaseMeld
 	return nil
 }
@@ -227,7 +227,7 @@ func (g *Kalooki) drawFromDiscard() error {
 	g.players[g.currentPlayerIdx].AddCard(card)
 	g.sortHand(g.currentPlayerIdx)
 
-	g.appendLog(g.currentPlayerIdx, "draw_discard", fmt.Sprintf("%s draws %s from discard", g.playerName(g.currentPlayerIdx), cardStr(card)), []*Card{card})
+	g.appendLog(g.currentPlayerIdx, "draw_discard", fmt.Sprintf("%s draws %s from discard", playerName(g.players, g.currentPlayerIdx), cardStr(card)), []*Card{card})
 	g.phase = KalookiPhaseMeld
 	return nil
 }
@@ -322,7 +322,7 @@ func (g *Kalooki) applyMeld(meldGroups [][]int) error {
 		player.RemoveCard(idx)
 	}
 
-	g.appendLog(g.currentPlayerIdx, "meld", fmt.Sprintf("%s melds %d group(s)", g.playerName(g.currentPlayerIdx), len(groupCards)), nil)
+	g.appendLog(g.currentPlayerIdx, "meld", fmt.Sprintf("%s melds %d group(s)", playerName(g.players, g.currentPlayerIdx), len(groupCards)), nil)
 
 	if player.GetCardsSize() == 0 {
 		g.finishRound(g.currentPlayerIdx)
@@ -372,7 +372,7 @@ func (g *Kalooki) applyLayoff(targetPlayerIdx, meldIdx, cardIndex int) error {
 	target.AddCardToMeld(meldIdx, card)
 	current.RemoveCard(cardIndex)
 
-	g.appendLog(g.currentPlayerIdx, "layoff", fmt.Sprintf("%s lays off %s on player %d's meld", g.playerName(g.currentPlayerIdx), cardStr(card), targetPlayerIdx), []*Card{card})
+	g.appendLog(g.currentPlayerIdx, "layoff", fmt.Sprintf("%s lays off %s on player %d's meld", playerName(g.players, g.currentPlayerIdx), cardStr(card), targetPlayerIdx), []*Card{card})
 	if current.GetCardsSize() == 0 {
 		g.finishRound(g.currentPlayerIdx)
 	}
@@ -401,7 +401,7 @@ func (g *Kalooki) applyDiscard(cardIndex int) error {
 
 	discarded := player.RemoveCard(cardIndex)
 	g.discardPile = append(g.discardPile, discarded)
-	g.appendLog(g.currentPlayerIdx, "discard", fmt.Sprintf("%s discards %s", g.playerName(g.currentPlayerIdx), cardStr(discarded)), []*Card{discarded})
+	g.appendLog(g.currentPlayerIdx, "discard", fmt.Sprintf("%s discards %s", playerName(g.players, g.currentPlayerIdx), cardStr(discarded)), []*Card{discarded})
 
 	if player.GetCardsSize() == 0 {
 		g.finishRound(g.currentPlayerIdx)
@@ -611,7 +611,7 @@ func (g *Kalooki) finishRound(winnerIdx int) {
 	}
 
 	if winnerIdx >= 0 {
-		g.appendLog(winnerIdx, "round_win", fmt.Sprintf("%s goes out!", g.playerName(winnerIdx)), nil)
+		g.appendLog(winnerIdx, "round_win", fmt.Sprintf("%s goes out!", playerName(g.players, winnerIdx)), nil)
 	} else {
 		g.appendLog(-1, "draw", "Round ends in a draw (stock empty)", nil)
 	}
@@ -642,7 +642,7 @@ func (g *Kalooki) finalizeGameEnd() {
 			}
 		}
 	}
-	g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game!", g.playerName(g.winnerIdx)), nil)
+	g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game!", playerName(g.players, g.winnerIdx)), nil)
 }
 
 // --- Getters / Setters ---
@@ -727,16 +727,6 @@ func (g *Kalooki) sortHand(playerIdx int) {
 	for _, c := range cards {
 		p.AddCard(c)
 	}
-}
-
-func (g *Kalooki) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // --- Pure card-evaluation helpers ---

--- a/internal/domain/Klaverjas.go
+++ b/internal/domain/Klaverjas.go
@@ -171,7 +171,7 @@ func (g *Klaverjas) detectRoem() {
 		roem := klaverjasHandRoem(g.players[i])
 		if roem > 0 {
 			g.roundRoem[KlaverjasTeamOf(i)] += roem
-			g.appendLog(i, "roem", fmt.Sprintf("%s scores %d roem", g.playerName(i), roem), nil)
+			g.appendLog(i, "roem", fmt.Sprintf("%s scores %d roem", playerName(g.players, i), roem), nil)
 		}
 	}
 }
@@ -223,7 +223,7 @@ func (g *Klaverjas) CpuPlay() {
 // playCard カードをプレイする共通処理。
 func (g *Klaverjas) playCard(playerIdx int, card *Card) {
 	g.currentTrick = append(g.currentTrick, &TrickCard{PlayerIdx: playerIdx, Card: card})
-	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", g.playerName(playerIdx), cardStr(card)), []*Card{card})
+	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", playerName(g.players, playerIdx), cardStr(card)), []*Card{card})
 
 	if len(g.currentTrick) == KlaverjasPlayerCnt {
 		g.phase = KlaverjasPhaseTrickEnd
@@ -253,7 +253,7 @@ func (g *Klaverjas) ResolveTrick() {
 		bonus = fmt.Sprintf(" +%d last", KlaverjasLastTrickBonus)
 	}
 	g.appendLog(winnerIdx, "trick_win",
-		fmt.Sprintf("%s wins trick %d (+%d%s)", g.playerName(winnerIdx), g.trickNumber, pts, bonus), trickCards)
+		fmt.Sprintf("%s wins trick %d (+%d%s)", playerName(g.players, winnerIdx), g.trickNumber, pts, bonus), trickCards)
 
 	g.leadPlayerIdx = winnerIdx
 	if g.trickNumber >= KlaverjasTrickCount {
@@ -586,17 +586,6 @@ func klaverjasSortHand(p *KlaverjasPlayer) {
 	for _, c := range cards {
 		p.AddCard(c)
 	}
-}
-
-// playerName プレイヤー名を返す。
-func (g *Klaverjas) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // indexOfPlayerInTrick currentTrick 内で playerIdx の札の位置を返す (-1=なし)。

--- a/internal/domain/KnockoutWhist.go
+++ b/internal/domain/KnockoutWhist.go
@@ -174,7 +174,7 @@ func (g *KnockoutWhist) startRound() {
 		g.phase = KnockoutWhistPhaseTrumpSelect
 		g.appendLog(g.leadPlayerIdx, "trump_select",
 			fmt.Sprintf("round %d: %d cards each, %s chooses trump",
-				g.roundNumber, g.handSize, g.playerName(g.leadPlayerIdx)), nil)
+				g.roundNumber, g.handSize, playerName(g.players, g.leadPlayerIdx)), nil)
 		return
 	}
 
@@ -182,7 +182,7 @@ func (g *KnockoutWhist) startRound() {
 	g.phase = KnockoutWhistPhasePlay
 	g.appendLog(g.leadPlayerIdx, "round_start",
 		fmt.Sprintf("round %d: %d cards each, trump %d, %s leads",
-			g.roundNumber, g.handSize, g.trumpSuit, g.playerName(g.leadPlayerIdx)), nil)
+			g.roundNumber, g.handSize, g.trumpSuit, playerName(g.players, g.leadPlayerIdx)), nil)
 }
 
 // PlayerSelectTrump 人間のラウンド勝者が次ラウンドの切り札スートを選択する (1-4)。
@@ -203,7 +203,7 @@ func (g *KnockoutWhist) PlayerSelectTrump(suit int) error {
 	g.phase = KnockoutWhistPhasePlay
 	g.appendLog(g.leadPlayerIdx, "round_start",
 		fmt.Sprintf("round %d: %d cards each, trump %d, %s leads",
-			g.roundNumber, g.handSize, g.trumpSuit, g.playerName(g.leadPlayerIdx)), nil)
+			g.roundNumber, g.handSize, g.trumpSuit, playerName(g.players, g.leadPlayerIdx)), nil)
 	return nil
 }
 
@@ -286,7 +286,7 @@ func (g *KnockoutWhist) CpuPlay() {
 // playCard カードをプレイする共通処理。
 func (g *KnockoutWhist) playCard(playerIdx int, card *Card) {
 	g.currentTrick = append(g.currentTrick, &TrickCard{PlayerIdx: playerIdx, Card: card})
-	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", g.playerName(playerIdx), cardStr(card)), []*Card{card})
+	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", playerName(g.players, playerIdx), cardStr(card)), []*Card{card})
 
 	if len(g.currentTrick) >= g.activeCount() {
 		g.phase = KnockoutWhistPhaseTrickEnd
@@ -308,7 +308,7 @@ func (g *KnockoutWhist) ResolveTrick() {
 	g.players[winnerIdx].AddTrick(trickCards)
 	g.players[winnerIdx].IncRoundTricks()
 	g.appendLog(winnerIdx, "trick_win",
-		fmt.Sprintf("%s wins trick %d", g.playerName(winnerIdx), g.trickNumber), trickCards)
+		fmt.Sprintf("%s wins trick %d", playerName(g.players, winnerIdx), g.trickNumber), trickCards)
 
 	g.leadPlayerIdx = winnerIdx
 	if g.trickNumber >= g.handSize {
@@ -346,10 +346,10 @@ func (g *KnockoutWhist) ScoreRound() {
 		if p.GetRoundTricks() == 0 {
 			if p.GetDogbones() > 0 {
 				p.SetDogbones(p.GetDogbones() - 1)
-				g.appendLog(i, "dogbone", fmt.Sprintf("%s spends a dogbone to survive", g.playerName(i)), nil)
+				g.appendLog(i, "dogbone", fmt.Sprintf("%s spends a dogbone to survive", playerName(g.players, i)), nil)
 			} else {
 				p.SetEliminated(true)
-				g.appendLog(i, "eliminated", fmt.Sprintf("%s is knocked out", g.playerName(i)), nil)
+				g.appendLog(i, "eliminated", fmt.Sprintf("%s is knocked out", playerName(g.players, i)), nil)
 			}
 		}
 	}
@@ -364,7 +364,7 @@ func (g *KnockoutWhist) ScoreRound() {
 			// 全滅 (同時 0 トリック) や最終ラウンド到達時はラウンド勝者を優勝とする。
 			g.winnerPlayer = g.roundWinnerIdx
 		}
-		g.appendLog(g.winnerPlayer, "game_end", fmt.Sprintf("%s wins the match!", g.playerName(g.winnerPlayer)), nil)
+		g.appendLog(g.winnerPlayer, "game_end", fmt.Sprintf("%s wins the match!", playerName(g.players, g.winnerPlayer)), nil)
 	}
 }
 
@@ -482,17 +482,6 @@ func knockoutSortHand(p *KnockoutWhistPlayer) {
 	for _, c := range cards {
 		p.AddCard(c)
 	}
-}
-
-// playerName プレイヤー名を返す。
-func (g *KnockoutWhist) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // indexOfPlayerInTrick currentTrick 内で playerIdx の札の位置を返す (-1=なし)。

--- a/internal/domain/Koenigrufen.go
+++ b/internal/domain/Koenigrufen.go
@@ -440,14 +440,14 @@ func (g *Koenigrufen) CpuBid() {
 func (g *Koenigrufen) applyBid(idx int, bid KoenigrufenBid) {
 	g.highestBid = bid
 	g.highestBidder = idx
-	g.appendLog(idx, "bid", fmt.Sprintf("%s bids %s", g.playerName(idx), koenigrufenBidName(bid)), nil)
+	g.appendLog(idx, "bid", fmt.Sprintf("%s bids %s", playerName(g.players, idx), koenigrufenBidName(bid)), nil)
 	g.advanceBid()
 }
 
 // applyPass パスを適用する。
 func (g *Koenigrufen) applyPass(idx int) {
 	g.passed[idx] = true
-	g.appendLog(idx, "pass", fmt.Sprintf("%s passes", g.playerName(idx)), nil)
+	g.appendLog(idx, "pass", fmt.Sprintf("%s passes", playerName(g.players, idx)), nil)
 	g.advanceBid()
 }
 
@@ -468,12 +468,12 @@ func (g *Koenigrufen) finalizeBid() {
 		g.declarerIdx = (g.dealerIdx + 1) % KoenigrufenPlayerCnt
 		g.contract = KoenigrufenBidRufer
 		g.appendLog(g.declarerIdx, "forced",
-			fmt.Sprintf("all passed — %s is forced to take Rufer", g.playerName(g.declarerIdx)), nil)
+			fmt.Sprintf("all passed — %s is forced to take Rufer", playerName(g.players, g.declarerIdx)), nil)
 	} else {
 		g.declarerIdx = g.highestBidder
 		g.contract = g.highestBid
 		g.appendLog(g.declarerIdx, "win_bid",
-			fmt.Sprintf("%s takes the contract %s", g.playerName(g.declarerIdx), koenigrufenBidName(g.contract)), nil)
+			fmt.Sprintf("%s takes the contract %s", playerName(g.players, g.declarerIdx), koenigrufenBidName(g.contract)), nil)
 	}
 	g.enterCallOrSolo()
 }
@@ -485,7 +485,7 @@ func (g *Koenigrufen) enterCallOrSolo() {
 		g.calledKing = -1
 		g.partnerIdx = -1
 		g.appendLog(g.declarerIdx, "solo",
-			fmt.Sprintf("%s holds all four kings and plays solo", g.playerName(g.declarerIdx)), nil)
+			fmt.Sprintf("%s holds all four kings and plays solo", playerName(g.players, g.declarerIdx)), nil)
 		g.finalizeCall()
 		return
 	}
@@ -534,7 +534,7 @@ func (g *Koenigrufen) applyCallKing(suit int) {
 	g.partnerIdx = g.findKingHolder(suit)
 	// ログにはパートナーの正体を書かず、呼んだキングのみを記録する。
 	g.appendLog(g.declarerIdx, "call_king",
-		fmt.Sprintf("%s calls the King of suit %d", g.playerName(g.declarerIdx), suit), nil)
+		fmt.Sprintf("%s calls the King of suit %d", playerName(g.players, g.declarerIdx), suit), nil)
 	g.finalizeCall()
 }
 
@@ -654,7 +654,7 @@ func (g *Koenigrufen) doDiscard(cardIndices []int) error {
 	g.stash = discarded
 	g.stashOwner = 0
 	g.appendLog(g.declarerIdx, "discard",
-		fmt.Sprintf("%s discards %d cards to the talon", g.playerName(g.declarerIdx), len(discarded)), discarded)
+		fmt.Sprintf("%s discards %d cards to the talon", playerName(g.players, g.declarerIdx), len(discarded)), discarded)
 	g.sortAllHands()
 	g.startPlay()
 	return nil
@@ -755,7 +755,7 @@ func (g *Koenigrufen) playCard(playerIdx int, card *Card) {
 	if koenigrufenIsCalledKing(card, g.calledKing) {
 		g.partnerRevealed = true
 	}
-	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", g.playerName(playerIdx), koenigrufenCardStr(card)), []*Card{card})
+	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", playerName(g.players, playerIdx), koenigrufenCardStr(card)), []*Card{card})
 	if len(g.currentTrick) == KoenigrufenPlayerCnt {
 		g.phase = KoenigrufenPhaseTrickEnd
 	} else {
@@ -776,7 +776,7 @@ func (g *Koenigrufen) ResolveTrick() {
 	}
 	g.players[winnerIdx].AddTrick(allCards)
 	g.appendLog(winnerIdx, "trick_win",
-		fmt.Sprintf("%s wins trick %d", g.playerName(winnerIdx), g.trickNumber), allCards)
+		fmt.Sprintf("%s wins trick %d", playerName(g.players, winnerIdx), g.trickNumber), allCards)
 
 	g.leadPlayerIdx = winnerIdx
 	if g.trickNumber >= KoenigrufenTrickCount {
@@ -834,7 +834,7 @@ func (g *Koenigrufen) enterRoundEnd() {
 	}
 	g.appendLog(-1, "round_score",
 		fmt.Sprintf("deal %d: declarer(%s) %s teamPts=%d/%d won=%t base=%d",
-			g.roundNumber, g.playerName(g.declarerIdx), koenigrufenBidName(g.contract),
+			g.roundNumber, playerName(g.players, g.declarerIdx), koenigrufenBidName(g.contract),
 			bd.TeamPoints, KoenigrufenTotalPoints, bd.Won, bd.Base), nil)
 	g.checkGameEnd()
 }
@@ -897,7 +897,7 @@ func (g *Koenigrufen) checkGameEnd() {
 		g.appendLog(-1, "game_end", "the match ends in a draw", nil)
 	} else {
 		g.winnerPlayer = leader
-		g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the match!", g.playerName(leader)), nil)
+		g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the match!", playerName(g.players, leader)), nil)
 	}
 }
 
@@ -1523,17 +1523,6 @@ func koenigrufenSortHand(p *KoenigrufenPlayer) {
 	for _, c := range cards {
 		p.AddCard(c)
 	}
-}
-
-// playerName プレイヤー名を返す。
-func (g *Koenigrufen) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // isHumanBidTurn 現在の入札手番が人間か。

--- a/internal/domain/Loo.go
+++ b/internal/domain/Loo.go
@@ -248,9 +248,9 @@ func (g *Loo) applyDecide(idx int, play bool) {
 	g.players[idx].SetPlaying(play)
 	g.decideDone[idx] = true
 	if play {
-		g.appendLog(idx, "decide", fmt.Sprintf("%s plays", g.playerName(idx)), nil)
+		g.appendLog(idx, "decide", fmt.Sprintf("%s plays", playerName(g.players, idx)), nil)
 	} else {
-		g.appendLog(idx, "decide", fmt.Sprintf("%s passes", g.playerName(idx)), nil)
+		g.appendLog(idx, "decide", fmt.Sprintf("%s passes", playerName(g.players, idx)), nil)
 	}
 	for k := 1; k <= LooPlayerCnt; k++ {
 		ni := (idx + k) % LooPlayerCnt
@@ -274,7 +274,7 @@ func (g *Loo) resolveDecide() {
 	case 1:
 		// 1 人だけ参加: プレイせずにポットを総取り (トリックは戦われない)。
 		winner := active[0]
-		g.appendLog(winner, "walkover", fmt.Sprintf("%s is the only player and takes the pot", g.playerName(winner)), nil)
+		g.appendLog(winner, "walkover", fmt.Sprintf("%s is the only player and takes the pot", playerName(g.players, winner)), nil)
 		g.enterRoundEnd()
 	default:
 		g.startPlayPhase(active[0])
@@ -379,7 +379,7 @@ func (g *Loo) CpuPlay() {
 // playCard はカードをプレイする共通処理。
 func (g *Loo) playCard(playerIdx int, card *Card) {
 	g.currentTrick = append(g.currentTrick, &TrickCard{PlayerIdx: playerIdx, Card: card})
-	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", g.playerName(playerIdx), cardStr(card)), []*Card{card})
+	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", playerName(g.players, playerIdx), cardStr(card)), []*Card{card})
 
 	if len(g.currentTrick) == len(g.activePlayers()) {
 		g.phase = LooPhaseTrickEnd
@@ -403,7 +403,7 @@ func (g *Loo) ResolveTrick() {
 	g.lastTrick = g.currentTrick
 	g.lastTrickWinner = winnerIdx
 	g.appendLog(winnerIdx, "trick_win",
-		fmt.Sprintf("%s wins trick %d", g.playerName(winnerIdx), g.trickNumber), trickCards)
+		fmt.Sprintf("%s wins trick %d", playerName(g.players, winnerIdx), g.trickNumber), trickCards)
 
 	g.leadPlayerIdx = winnerIdx
 	if g.trickNumber >= LooTrickCount {
@@ -484,7 +484,7 @@ func (g *Loo) ScoreRound() {
 		winner := active[0]
 		g.players[winner].AddChips(g.pot)
 		gained[winner] += g.pot
-		g.appendLog(winner, "settle", fmt.Sprintf("%s takes the whole pot %d", g.playerName(winner), g.pot), nil)
+		g.appendLog(winner, "settle", fmt.Sprintf("%s takes the whole pot %d", playerName(g.players, winner), g.pot), nil)
 		g.pot = 0
 	default:
 		// 参加者でトリックに応じてポットを分配 (1 トリック = ポット/トリック数)。
@@ -510,7 +510,7 @@ func (g *Loo) ScoreRound() {
 				g.pot += penalty
 				looed = append(looed, idx)
 				g.appendLog(idx, "looed",
-					fmt.Sprintf("%s is looed and pays %d to the pot", g.playerName(idx), penalty), nil)
+					fmt.Sprintf("%s is looed and pays %d to the pot", playerName(g.players, idx), penalty), nil)
 			}
 		}
 	}
@@ -526,7 +526,7 @@ func (g *Loo) ScoreRound() {
 	}
 	for i := 0; i < LooPlayerCnt; i++ {
 		g.appendLog(i, "cumulative_chips",
-			fmt.Sprintf("%s: total=%d", g.playerName(i), g.players[i].GetChips()), nil)
+			fmt.Sprintf("%s: total=%d", playerName(g.players, i), g.players[i].GetChips()), nil)
 	}
 }
 
@@ -634,16 +634,6 @@ func looSortHand(p *LooPlayer) {
 	for _, c := range cards {
 		p.AddCard(c)
 	}
-}
-
-func (g *Loo) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // indexOfPlayerInTrick は currentTrick 内で playerIdx の札の位置を返す (-1=なし)。

--- a/internal/domain/Macau.go
+++ b/internal/domain/Macau.go
@@ -226,7 +226,7 @@ func (g *Macau) PlayerChooseSuit(suit int) error {
 	}
 
 	g.chosenSuit = suit
-	g.appendLog(g.currentPlayerIdx, "choose_suit", fmt.Sprintf("%s chooses %s", g.playerName(g.currentPlayerIdx), suitName(suit)), nil)
+	g.appendLog(g.currentPlayerIdx, "choose_suit", fmt.Sprintf("%s chooses %s", playerName(g.players, g.currentPlayerIdx), suitName(suit)), nil)
 
 	g.finishTurn(g.currentPlayerIdx)
 	return nil
@@ -314,7 +314,7 @@ func (g *Macau) CpuChooseSuit() {
 
 	suit := g.cpuSelectSuit(g.currentPlayerIdx)
 	g.chosenSuit = suit
-	g.appendLog(g.currentPlayerIdx, "choose_suit", fmt.Sprintf("%s chooses %s", g.playerName(g.currentPlayerIdx), suitName(suit)), nil)
+	g.appendLog(g.currentPlayerIdx, "choose_suit", fmt.Sprintf("%s chooses %s", playerName(g.players, g.currentPlayerIdx), suitName(suit)), nil)
 	g.finishTurn(g.currentPlayerIdx)
 }
 
@@ -337,14 +337,14 @@ func (g *Macau) CpuDeclare() {
 // doDeclare 宣言処理の共通実装
 func (g *Macau) doDeclare(playerIdx int) {
 	g.players[playerIdx].SetHasDeclared(true)
-	g.appendLog(playerIdx, "declare", fmt.Sprintf("%s declares Macau!", g.playerName(playerIdx)), nil)
+	g.appendLog(playerIdx, "declare", fmt.Sprintf("%s declares Macau!", playerName(g.players, playerIdx)), nil)
 	g.advanceTurn()
 }
 
 // applyDeclarePenalty 宣言忘れペナルティとして規定枚数を引かせる
 func (g *Macau) applyDeclarePenalty(playerIdx int) {
 	drawn := g.drawCards(playerIdx, MacauForgotPenalty)
-	g.appendLog(playerIdx, "penalty", fmt.Sprintf("%s forgot to declare Macau! (+%d cards)", g.playerName(playerIdx), drawn), nil)
+	g.appendLog(playerIdx, "penalty", fmt.Sprintf("%s forgot to declare Macau! (+%d cards)", playerName(g.players, playerIdx), drawn), nil)
 	g.sortHand(playerIdx)
 	g.advanceTurn()
 }
@@ -377,11 +377,11 @@ func (g *Macau) ScoreRound() {
 			score += crazyEightsCardScore(p.GetCard(j))
 		}
 		totalScore += score
-		g.appendLog(i, "hand_score", fmt.Sprintf("%s: %d points remaining", g.playerName(i), score), nil)
+		g.appendLog(i, "hand_score", fmt.Sprintf("%s: %d points remaining", playerName(g.players, i), score), nil)
 	}
 
 	g.players[winnerIdx].roundScore = totalScore
-	g.appendLog(winnerIdx, "round_win", fmt.Sprintf("%s wins round %d (+%d points)", g.playerName(winnerIdx), g.roundNumber, totalScore), nil)
+	g.appendLog(winnerIdx, "round_win", fmt.Sprintf("%s wins round %d (+%d points)", playerName(g.players, winnerIdx), g.roundNumber, totalScore), nil)
 
 	g.players[winnerIdx].CommitRoundScore()
 
@@ -514,7 +514,7 @@ func (g *Macau) playCard(playerIdx int, card *Card) {
 	g.discardPile = append(g.discardPile, card)
 	g.chosenSuit = -1
 
-	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", g.playerName(playerIdx), cardStr(card)), []*Card{card})
+	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", playerName(g.players, playerIdx), cardStr(card)), []*Card{card})
 
 	// マジックカードの状態更新
 	switch card.GetValue() {
@@ -585,7 +585,7 @@ func (g *Macau) drawCard(playerIdx int) error {
 	if g.penaltyDrawCount > 0 {
 		drawn := g.drawCards(playerIdx, g.penaltyDrawCount)
 		g.penaltyDrawCount = 0
-		g.appendLog(playerIdx, "take_penalty", fmt.Sprintf("%s takes %d penalty cards", g.playerName(playerIdx), drawn), nil)
+		g.appendLog(playerIdx, "take_penalty", fmt.Sprintf("%s takes %d penalty cards", playerName(g.players, playerIdx), drawn), nil)
 		g.sortHand(playerIdx)
 		g.advanceTurn()
 		return nil
@@ -597,7 +597,7 @@ func (g *Macau) drawCard(playerIdx int) error {
 
 	if len(g.drawPile) == 0 {
 		// 引けるカードがない→パス
-		g.appendLog(playerIdx, "pass", fmt.Sprintf("%s passes (no cards to draw)", g.playerName(playerIdx)), nil)
+		g.appendLog(playerIdx, "pass", fmt.Sprintf("%s passes (no cards to draw)", playerName(g.players, playerIdx)), nil)
 		g.advanceTurn()
 		return nil
 	}
@@ -607,7 +607,7 @@ func (g *Macau) drawCard(playerIdx int) error {
 	g.players[playerIdx].AddCard(card)
 	g.sortHand(playerIdx)
 
-	g.appendLog(playerIdx, "draw", fmt.Sprintf("%s draws a card", g.playerName(playerIdx)), nil)
+	g.appendLog(playerIdx, "draw", fmt.Sprintf("%s draws a card", playerName(g.players, playerIdx)), nil)
 
 	// 引いたカードが出せないなら次へ
 	if !g.hasPlayableCard(playerIdx) {
@@ -689,7 +689,7 @@ func (g *Macau) checkGameEnd() {
 			g.winnerIdx = i
 		}
 	}
-	g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game!", g.playerName(g.winnerIdx)), nil)
+	g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game!", playerName(g.players, g.winnerIdx)), nil)
 }
 
 // sortAllHands 全プレイヤーの手札をソートする
@@ -708,17 +708,6 @@ func (g *Macau) sortHand(playerIdx int) {
 		}
 		return ci.GetValue() < cj.GetValue()
 	})
-}
-
-// playerName プレイヤー名を返す
-func (g *Macau) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // --- CPU AI ---

--- a/internal/domain/Macau_internal_test.go
+++ b/internal/domain/Macau_internal_test.go
@@ -470,10 +470,10 @@ func TestMacau_countSuits(t *testing.T) {
 
 func TestMacau_playerName(t *testing.T) {
 	g := newInternalTestMacau()
-	assert.Equal(t, "You", g.playerName(0))
-	assert.Equal(t, "CPU 1", g.playerName(1))
-	assert.Equal(t, "Player -1", g.playerName(-1))
-	assert.Equal(t, "Player 4", g.playerName(4))
+	assert.Equal(t, "You", playerName(g.players, 0))
+	assert.Equal(t, "CPU 1", playerName(g.players, 1))
+	assert.Equal(t, "Player -1", playerName(g.players, -1))
+	assert.Equal(t, "Player 4", playerName(g.players, 4))
 }
 
 // --- checkGameEnd ---

--- a/internal/domain/Machiavelli.go
+++ b/internal/domain/Machiavelli.go
@@ -227,7 +227,7 @@ func (g *Machiavelli) drawFromStock() error {
 	g.players[g.currentPlayerIdx].AddCard(card)
 	g.sortHand(g.currentPlayerIdx)
 
-	g.appendLog(g.currentPlayerIdx, "draw", fmt.Sprintf("%s draws from stock", g.playerName(g.currentPlayerIdx)), nil)
+	g.appendLog(g.currentPlayerIdx, "draw", fmt.Sprintf("%s draws from stock", playerName(g.players, g.currentPlayerIdx)), nil)
 	g.advanceTurn()
 	return nil
 }
@@ -334,7 +334,7 @@ func (g *Machiavelli) applyPlay(newTable [][]*Card, handIndices []int) error {
 	}
 	g.table = newTable
 
-	g.appendLog(g.currentPlayerIdx, "play", fmt.Sprintf("%s plays %d card(s) to the table", g.playerName(g.currentPlayerIdx), len(handIndices)), playedCards)
+	g.appendLog(g.currentPlayerIdx, "play", fmt.Sprintf("%s plays %d card(s) to the table", playerName(g.players, g.currentPlayerIdx), len(handIndices)), playedCards)
 
 	if player.GetCardsSize() == 0 {
 		g.finishRound(g.currentPlayerIdx)
@@ -542,7 +542,7 @@ func (g *Machiavelli) finishRound(winnerIdx int) {
 	}
 
 	if winnerIdx >= 0 {
-		g.appendLog(winnerIdx, "round_win", fmt.Sprintf("%s goes out (round %d)", g.playerName(winnerIdx), g.roundNumber), nil)
+		g.appendLog(winnerIdx, "round_win", fmt.Sprintf("%s goes out (round %d)", playerName(g.players, winnerIdx), g.roundNumber), nil)
 	} else {
 		g.appendLog(-1, "draw", "Round ends (stock exhausted)", nil)
 	}
@@ -576,7 +576,7 @@ func (g *Machiavelli) finalizeGameEnd() {
 			g.winnerIdx = i
 		}
 	}
-	g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game with %d points!", g.playerName(g.winnerIdx), minScore), nil)
+	g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game with %d points!", playerName(g.players, g.winnerIdx), minScore), nil)
 }
 
 // --- Getters / Setters ---
@@ -671,16 +671,6 @@ func (g *Machiavelli) sortHand(playerIdx int) {
 	for _, c := range cards {
 		p.AddCard(c)
 	}
-}
-
-func (g *Machiavelli) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // machiavelliCollectCards プレイヤーの手札を []*Card で返す

--- a/internal/domain/Manille.go
+++ b/internal/domain/Manille.go
@@ -203,7 +203,7 @@ func (g *Manille) CpuPlay() {
 // playCard カードをプレイする共通処理。
 func (g *Manille) playCard(playerIdx int, card *Card) {
 	g.currentTrick = append(g.currentTrick, &TrickCard{PlayerIdx: playerIdx, Card: card})
-	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", g.playerName(playerIdx), cardStr(card)), []*Card{card})
+	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", playerName(g.players, playerIdx), cardStr(card)), []*Card{card})
 
 	if len(g.currentTrick) == ManillePlayerCnt {
 		g.phase = ManillePhaseTrickEnd
@@ -228,7 +228,7 @@ func (g *Manille) ResolveTrick() {
 	team := ManilleTeamOf(winnerIdx)
 	g.roundCardPts[team] += pts
 	g.appendLog(winnerIdx, "trick_win",
-		fmt.Sprintf("%s wins trick %d (+%d)", g.playerName(winnerIdx), g.trickNumber, pts), trickCards)
+		fmt.Sprintf("%s wins trick %d (+%d)", playerName(g.players, winnerIdx), g.trickNumber, pts), trickCards)
 
 	g.leadPlayerIdx = winnerIdx
 	if g.trickNumber >= ManilleTrickCount {
@@ -425,17 +425,6 @@ func manilleSortHand(p *ManillePlayer) {
 	for _, c := range cards {
 		p.AddCard(c)
 	}
-}
-
-// playerName プレイヤー名を返す。
-func (g *Manille) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // indexOfPlayerInTrick currentTrick 内で playerIdx の札の位置を返す (-1=なし)。

--- a/internal/domain/Mao.go
+++ b/internal/domain/Mao.go
@@ -352,7 +352,7 @@ func (g *Mao) resolvePendingWord(playerIdx int, complied bool) {
 	g.awaitingWord = false
 	if complied {
 		g.playerCorrectCount++
-		g.appendLog(playerIdx, "rule_ok", fmt.Sprintf("%s follows the secret rule", g.playerName(playerIdx)), nil)
+		g.appendLog(playerIdx, "rule_ok", fmt.Sprintf("%s follows the secret rule", playerName(g.players, playerIdx)), nil)
 		if g.playerCorrectCount >= MaoHintThreshold {
 			g.hintUnlocked = true
 		}
@@ -366,7 +366,7 @@ func (g *Mao) applyRulePenalty(playerIdx int) {
 	g.playerCorrectCount = 0
 	g.rulePenaltyFlag = true
 	drawn := g.drawCards(playerIdx, MaoRulePenalty)
-	g.appendLog(playerIdx, "penalty", fmt.Sprintf("%s receives a penalty (+%d card)", g.playerName(playerIdx), drawn), nil)
+	g.appendLog(playerIdx, "penalty", fmt.Sprintf("%s receives a penalty (+%d card)", playerName(g.players, playerIdx), drawn), nil)
 	g.sortHand(playerIdx)
 }
 
@@ -387,7 +387,7 @@ func (g *Mao) PlayerChooseSuit(suit int) error {
 	}
 
 	g.chosenSuit = suit
-	g.appendLog(g.currentPlayerIdx, "choose_suit", fmt.Sprintf("%s chooses %s", g.playerName(g.currentPlayerIdx), suitName(suit)), nil)
+	g.appendLog(g.currentPlayerIdx, "choose_suit", fmt.Sprintf("%s chooses %s", playerName(g.players, g.currentPlayerIdx), suitName(suit)), nil)
 
 	g.finishTurn(g.currentPlayerIdx)
 	return nil
@@ -483,7 +483,7 @@ func (g *Mao) CpuChooseSuit() {
 
 	suit := g.cpuSelectSuit(g.currentPlayerIdx)
 	g.chosenSuit = suit
-	g.appendLog(g.currentPlayerIdx, "choose_suit", fmt.Sprintf("%s chooses %s", g.playerName(g.currentPlayerIdx), suitName(suit)), nil)
+	g.appendLog(g.currentPlayerIdx, "choose_suit", fmt.Sprintf("%s chooses %s", playerName(g.players, g.currentPlayerIdx), suitName(suit)), nil)
 	g.finishTurn(g.currentPlayerIdx)
 }
 
@@ -506,14 +506,14 @@ func (g *Mao) CpuDeclare() {
 // doDeclare 宣言処理の共通実装
 func (g *Mao) doDeclare(playerIdx int) {
 	g.players[playerIdx].SetHasDeclared(true)
-	g.appendLog(playerIdx, "declare", fmt.Sprintf("%s declares Mao!", g.playerName(playerIdx)), nil)
+	g.appendLog(playerIdx, "declare", fmt.Sprintf("%s declares Mao!", playerName(g.players, playerIdx)), nil)
 	g.advanceTurn()
 }
 
 // applyDeclarePenalty 宣言忘れペナルティとして規定枚数を引かせる
 func (g *Mao) applyDeclarePenalty(playerIdx int) {
 	drawn := g.drawCards(playerIdx, MaoForgotPenalty)
-	g.appendLog(playerIdx, "penalty", fmt.Sprintf("%s forgot to declare Mao! (+%d cards)", g.playerName(playerIdx), drawn), nil)
+	g.appendLog(playerIdx, "penalty", fmt.Sprintf("%s forgot to declare Mao! (+%d cards)", playerName(g.players, playerIdx), drawn), nil)
 	g.sortHand(playerIdx)
 	g.advanceTurn()
 }
@@ -546,11 +546,11 @@ func (g *Mao) ScoreRound() {
 			score += crazyEightsCardScore(p.GetCard(j))
 		}
 		totalScore += score
-		g.appendLog(i, "hand_score", fmt.Sprintf("%s: %d points remaining", g.playerName(i), score), nil)
+		g.appendLog(i, "hand_score", fmt.Sprintf("%s: %d points remaining", playerName(g.players, i), score), nil)
 	}
 
 	g.players[winnerIdx].roundScore = totalScore
-	g.appendLog(winnerIdx, "round_win", fmt.Sprintf("%s wins round %d (+%d points)", g.playerName(winnerIdx), g.roundNumber, totalScore), nil)
+	g.appendLog(winnerIdx, "round_win", fmt.Sprintf("%s wins round %d (+%d points)", playerName(g.players, winnerIdx), g.roundNumber, totalScore), nil)
 
 	g.players[winnerIdx].CommitRoundScore()
 
@@ -712,7 +712,7 @@ func (g *Mao) playCard(playerIdx int, card *Card) {
 	g.discardPile = append(g.discardPile, card)
 	g.chosenSuit = -1
 
-	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", g.playerName(playerIdx), cardStr(card)), []*Card{card})
+	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", playerName(g.players, playerIdx), cardStr(card)), []*Card{card})
 
 	// マジックカードの状態更新
 	switch card.GetValue() {
@@ -780,7 +780,7 @@ func (g *Mao) drawCard(playerIdx int) error {
 	if g.penaltyDrawCount > 0 {
 		drawn := g.drawCards(playerIdx, g.penaltyDrawCount)
 		g.penaltyDrawCount = 0
-		g.appendLog(playerIdx, "take_penalty", fmt.Sprintf("%s takes %d penalty cards", g.playerName(playerIdx), drawn), nil)
+		g.appendLog(playerIdx, "take_penalty", fmt.Sprintf("%s takes %d penalty cards", playerName(g.players, playerIdx), drawn), nil)
 		g.sortHand(playerIdx)
 		g.advanceTurn()
 		return nil
@@ -792,7 +792,7 @@ func (g *Mao) drawCard(playerIdx int) error {
 
 	if len(g.drawPile) == 0 {
 		// 引けるカードがない→パス
-		g.appendLog(playerIdx, "pass", fmt.Sprintf("%s passes (no cards to draw)", g.playerName(playerIdx)), nil)
+		g.appendLog(playerIdx, "pass", fmt.Sprintf("%s passes (no cards to draw)", playerName(g.players, playerIdx)), nil)
 		g.advanceTurn()
 		return nil
 	}
@@ -802,7 +802,7 @@ func (g *Mao) drawCard(playerIdx int) error {
 	g.players[playerIdx].AddCard(card)
 	g.sortHand(playerIdx)
 
-	g.appendLog(playerIdx, "draw", fmt.Sprintf("%s draws a card", g.playerName(playerIdx)), nil)
+	g.appendLog(playerIdx, "draw", fmt.Sprintf("%s draws a card", playerName(g.players, playerIdx)), nil)
 
 	// 引いたカードが出せないなら次へ
 	if !g.hasPlayableCard(playerIdx) {
@@ -884,7 +884,7 @@ func (g *Mao) checkGameEnd() {
 			g.winnerIdx = i
 		}
 	}
-	g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game!", g.playerName(g.winnerIdx)), nil)
+	g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game!", playerName(g.players, g.winnerIdx)), nil)
 }
 
 // sortAllHands 全プレイヤーの手札をソートする
@@ -903,17 +903,6 @@ func (g *Mao) sortHand(playerIdx int) {
 		}
 		return ci.GetValue() < cj.GetValue()
 	})
-}
-
-// playerName プレイヤー名を返す
-func (g *Mao) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // --- CPU AI ---

--- a/internal/domain/Marias.go
+++ b/internal/domain/Marias.go
@@ -189,7 +189,7 @@ func (g *Marias) detectMarriages() {
 		}
 		if pts > 0 {
 			g.roundMarriage[i] += pts
-			g.appendLog(i, "marriage", fmt.Sprintf("%s declares marriages worth %d", g.playerName(i), pts), nil)
+			g.appendLog(i, "marriage", fmt.Sprintf("%s declares marriages worth %d", playerName(g.players, i), pts), nil)
 		}
 	}
 }
@@ -253,7 +253,7 @@ func (g *Marias) CpuPlay() {
 // playCard カードをプレイする共通処理。
 func (g *Marias) playCard(playerIdx int, card *Card) {
 	g.currentTrick = append(g.currentTrick, &TrickCard{PlayerIdx: playerIdx, Card: card})
-	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", g.playerName(playerIdx), cardStr(card)), []*Card{card})
+	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", playerName(g.players, playerIdx), cardStr(card)), []*Card{card})
 
 	if len(g.currentTrick) == MariasPlayerCnt {
 		g.phase = MariasPhaseTrickEnd
@@ -277,7 +277,7 @@ func (g *Marias) ResolveTrick() {
 	g.players[winnerIdx].AddTrick(trickCards)
 	g.roundCardPts[winnerIdx] += pts
 	g.appendLog(winnerIdx, "trick_win",
-		fmt.Sprintf("%s wins trick %d (+%d)", g.playerName(winnerIdx), g.trickNumber, pts), trickCards)
+		fmt.Sprintf("%s wins trick %d (+%d)", playerName(g.players, winnerIdx), g.trickNumber, pts), trickCards)
 
 	g.leadPlayerIdx = winnerIdx
 	if g.trickNumber >= MariasTrickCount {
@@ -320,7 +320,7 @@ func (g *Marias) ScoreRound() {
 	}
 	g.appendLog(-1, "round_score",
 		fmt.Sprintf("round %d: soloist(%s)=%d defense=%d -> %s",
-			g.roundNumber, g.playerName(g.soloistIdx), soloistTotal, defenseTotal,
+			g.roundNumber, playerName(g.players, g.soloistIdx), soloistTotal, defenseTotal,
 			map[bool]string{true: "soloist wins", false: "defense wins"}[soloistWon]), nil)
 
 	g.checkGameEnd()
@@ -353,7 +353,7 @@ func (g *Marias) checkGameEnd() {
 		g.gameEndFlag = true
 		g.winnerPlayer = leader
 		g.phase = MariasPhaseGameEnd
-		g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the match!", g.playerName(leader)), nil)
+		g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the match!", playerName(g.players, leader)), nil)
 	}
 }
 
@@ -488,17 +488,6 @@ func mariasSortHand(p *MariasPlayer) {
 	for _, c := range cards {
 		p.AddCard(c)
 	}
-}
-
-// playerName プレイヤー名を返す。
-func (g *Marias) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // indexOfPlayerInTrick currentTrick 内で playerIdx の札の位置を返す (-1=なし)。

--- a/internal/domain/Michigan.go
+++ b/internal/domain/Michigan.go
@@ -264,7 +264,7 @@ func (g *Michigan) applyBet(seat int, dist []int) {
 		total += amt
 	}
 	p.AddRoundBet(total)
-	g.appendLog(seat, "bet", fmt.Sprintf("%s bets %d across boodles", g.playerName(seat), total), nil)
+	g.appendLog(seat, "bet", fmt.Sprintf("%s bets %d across boodles", playerName(g.players, seat), total), nil)
 }
 
 // PlaceHumanBet は人間 (seat 0) のブードル賭けを適用する。bets は 4 要素、各非負、
@@ -405,14 +405,14 @@ func (g *Michigan) doPlay(seat, idx int) {
 			if won > 0 {
 				p.AddChips(won)
 			}
-			g.appendLog(seat, "boodle", fmt.Sprintf("%s hits a boodle and collects %d", g.playerName(seat), won), []*Card{removed})
+			g.appendLog(seat, "boodle", fmt.Sprintf("%s hits a boodle and collects %d", playerName(g.players, seat), won), []*Card{removed})
 		}
 	}
 	// シーケンス更新。
 	g.state.seqSuit = removed.GetDesign()
 	g.state.seqHighValue = removed.GetValue()
 	g.state.lastPlayerIdx = seat
-	g.appendLog(seat, "play", fmt.Sprintf("%s plays %s", g.playerName(seat), michiganCardStr(removed)), []*Card{removed})
+	g.appendLog(seat, "play", fmt.Sprintf("%s plays %s", playerName(g.players, seat), michiganCardStr(removed)), []*Card{removed})
 	// 手札を出し切ったらラウンド終了。
 	if p.GetCardsSize() == 0 {
 		g.enterRoundEnd(seat)
@@ -559,7 +559,7 @@ func (g *Michigan) enterRoundEnd(goOutSeat int) {
 	g.state.winnerIdx = goOutSeat
 	g.state.result = g.computeHumanResult()
 	g.state.scored = true
-	g.appendLog(goOutSeat, "round_end", fmt.Sprintf("%s empties their hand; round over", g.playerName(goOutSeat)), nil)
+	g.appendLog(goOutSeat, "round_end", fmt.Sprintf("%s empties their hand; round over", playerName(g.players, goOutSeat)), nil)
 	g.checkGameEnd()
 }
 
@@ -594,7 +594,7 @@ func (g *Michigan) endGame() {
 	g.state.phase = MichiganPhaseResult
 	g.state.matchWinnerIdx = g.richestIdx()
 	g.appendLog(g.state.matchWinnerIdx, "game_end",
-		fmt.Sprintf("%s wins the game", g.playerName(g.state.matchWinnerIdx)), nil)
+		fmt.Sprintf("%s wins the game", playerName(g.players, g.state.matchWinnerIdx)), nil)
 }
 
 // richestIdx はチップが最多のプレイヤーのインデックスを返す (同数は座席番号の小さい方)。
@@ -639,17 +639,6 @@ func (g *Michigan) GetHint() *MichiganHint {
 }
 
 // --- ヘルパー ---
-
-// playerName は表示用のプレイヤー名を返す。
-func (g *Michigan) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
-}
 
 // michiganCardStr はカードを棋譜用文字列に変換する。
 func michiganCardStr(c *Card) string {

--- a/internal/domain/Mighty.go
+++ b/internal/domain/Mighty.go
@@ -482,7 +482,7 @@ func (m *Mighty) ResolveTrick() {
 	pointCount := m.countPointCards(trickCards)
 	m.players[winnerIdx].pointCards += pointCount
 
-	winnerName := m.playerName(winnerIdx)
+	winnerName := playerName(m.players, winnerIdx)
 	s := fmt.Sprintf("%s wins trick %d", winnerName, m.round.trickNumber)
 	if pointCount > 0 {
 		s += fmt.Sprintf(" (+%d point cards)", pointCount)
@@ -581,7 +581,7 @@ func (m *Mighty) ScoreRound() {
 			}
 		}
 		p.roundScore = score
-		m.appendLog(i, "round_score", fmt.Sprintf("%s: round=%d", m.playerName(i), p.roundScore), nil)
+		m.appendLog(i, "round_score", fmt.Sprintf("%s: round=%d", playerName(m.players, i), p.roundScore), nil)
 	}
 
 	// 累積スコアに加算
@@ -592,7 +592,7 @@ func (m *Mighty) ScoreRound() {
 	// 累積スコアログ
 	for i := range MightyPlayerCnt {
 		m.appendLog(i, "cumulative_score", fmt.Sprintf("%s: total=%d",
-			m.playerName(i), m.players[i].cumulativeScore), nil)
+			playerName(m.players, i), m.players[i].cumulativeScore), nil)
 	}
 
 	// ゲーム終了判定
@@ -865,10 +865,10 @@ func (m *Mighty) applyBid(playerIdx int, bid int, noTrump bool) {
 	m.players[playerIdx].SetBidNoTrump(noTrump)
 
 	if bid == 0 {
-		m.appendLog(playerIdx, "bid", fmt.Sprintf("%s passes", m.playerName(playerIdx)), nil)
+		m.appendLog(playerIdx, "bid", fmt.Sprintf("%s passes", playerName(m.players, playerIdx)), nil)
 		m.round.passCount++
 	} else {
-		desc := fmt.Sprintf("%s bids %d", m.playerName(playerIdx), bid)
+		desc := fmt.Sprintf("%s bids %d", playerName(m.players, playerIdx), bid)
 		if noTrump {
 			desc += " (no trump)"
 		}
@@ -896,13 +896,13 @@ func (m *Mighty) checkBidComplete() {
 		m.players[0].SetBid(m.config.MinBid)
 		m.players[0].SetBidNoTrump(false)
 		m.appendLog(0, "forced_bid",
-			fmt.Sprintf("%s is forced to bid %d (all pass)", m.playerName(0), m.config.MinBid), nil)
+			fmt.Sprintf("%s is forced to bid %d (all pass)", playerName(m.players, 0), m.config.MinBid), nil)
 	}
 
 	m.round.declarerIdx = m.round.highestBidder
 	m.players[m.round.declarerIdx].SetIsDeclarer(true)
 	m.appendLog(m.round.declarerIdx, "declarer",
-		fmt.Sprintf("%s becomes Declarer (bid %d)", m.playerName(m.round.declarerIdx), m.round.highestBid), nil)
+		fmt.Sprintf("%s becomes Declarer (bid %d)", playerName(m.players, m.round.declarerIdx), m.round.highestBid), nil)
 
 	m.round.phase = MightyPhaseTrumpAndFriend
 }
@@ -919,13 +919,13 @@ func (m *Mighty) applyDeclareTrumpAndFriend(suit int, partnerSuit int, partnerVa
 	}
 	if suit == MightyTrumpNone {
 		m.appendLog(m.round.declarerIdx, "declare_trump",
-			fmt.Sprintf("%s declares No-Trump", m.playerName(m.round.declarerIdx)), nil)
+			fmt.Sprintf("%s declares No-Trump", playerName(m.players, m.round.declarerIdx)), nil)
 	} else {
 		m.appendLog(m.round.declarerIdx, "declare_trump",
-			fmt.Sprintf("%s declares %s as trump", m.playerName(m.round.declarerIdx), suitNames[suit]), nil)
+			fmt.Sprintf("%s declares %s as trump", playerName(m.players, m.round.declarerIdx), suitNames[suit]), nil)
 	}
 	m.appendLog(m.round.declarerIdx, "declare_partner",
-		fmt.Sprintf("%s names %s as partner card", m.playerName(m.round.declarerIdx), mightyCardStr(m.round.partnerCard)), nil)
+		fmt.Sprintf("%s names %s as partner card", playerName(m.players, m.round.declarerIdx), mightyCardStr(m.round.partnerCard)), nil)
 
 	// パートナーを特定 (手札中)
 	holder := m.findPartnerHolder()
@@ -937,7 +937,7 @@ func (m *Mighty) applyDeclareTrumpAndFriend(suit int, partnerSuit int, partnerVa
 			m.round.partnerRevealed = true
 			m.players[holder].SetPartnerRevealed(true)
 			m.appendLog(holder, "partner_self",
-				fmt.Sprintf("%s holds the partner card themselves (solo declarer)", m.playerName(holder)), nil)
+				fmt.Sprintf("%s holds the partner card themselves (solo declarer)", playerName(m.players, holder)), nil)
 		}
 	} else {
 		// 場札にある可能性 → 場札交換後に再判定
@@ -968,7 +968,7 @@ func (m *Mighty) applyExchangeKitty(discardIndices []int) {
 	player.AddTrick(discarded)
 
 	m.appendLog(m.round.declarerIdx, "exchange",
-		fmt.Sprintf("%s discards %d kitty cards", m.playerName(m.round.declarerIdx), len(discarded)), discarded)
+		fmt.Sprintf("%s discards %d kitty cards", playerName(m.players, m.round.declarerIdx), len(discarded)), discarded)
 
 	// 場札交換後、パートナー保有者がまだ不明 (= 場札に居た) なら再特定
 	if m.round.partnerIdx < 0 && m.round.partnerCard != nil {
@@ -980,7 +980,7 @@ func (m *Mighty) applyExchangeKitty(discardIndices []int) {
 				m.round.partnerRevealed = true
 				m.players[m.round.declarerIdx].SetPartnerRevealed(true)
 				m.appendLog(m.round.declarerIdx, "partner_self",
-					fmt.Sprintf("%s discards the partner card (solo declarer)", m.playerName(m.round.declarerIdx)), nil)
+					fmt.Sprintf("%s discards the partner card (solo declarer)", playerName(m.players, m.round.declarerIdx)), nil)
 				break
 			}
 		}
@@ -1020,7 +1020,7 @@ func (m *Mighty) playCard(playerIdx int, card *Card, isJokerLead bool, demandSui
 		LeadDemandSuit: demandSuit,
 	})
 
-	desc := fmt.Sprintf("%s plays %s", m.playerName(playerIdx), mightyCardStr(card))
+	desc := fmt.Sprintf("%s plays %s", playerName(m.players, playerIdx), mightyCardStr(card))
 	if isJokerLead {
 		suitNames := map[int]string{
 			CardDesignSpade: "Spade", CardDesignClover: "Club",
@@ -1292,7 +1292,7 @@ func (m *Mighty) checkPartnerReveal(playerIdx int, card *Card) {
 			m.players[playerIdx].SetIsPartner(true)
 		}
 		m.appendLog(playerIdx, "partner_reveal",
-			fmt.Sprintf("%s is revealed as the partner!", m.playerName(playerIdx)), []*Card{card})
+			fmt.Sprintf("%s is revealed as the partner!", playerName(m.players, playerIdx)), []*Card{card})
 	}
 }
 
@@ -1363,7 +1363,7 @@ func (m *Mighty) checkGameEnd() {
 			winnerIdx = i
 		}
 	}
-	m.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game!", m.playerName(winnerIdx)), nil)
+	m.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game!", playerName(m.players, winnerIdx)), nil)
 }
 
 // sortAllHands 全プレイヤーの手札をソートする
@@ -1382,17 +1382,6 @@ func (m *Mighty) sortHand(p *MightyPlayer) {
 		}
 		return ci.GetValue() < cj.GetValue()
 	})
-}
-
-// playerName プレイヤー名を返す
-func (m *Mighty) playerName(idx int) string {
-	if idx < 0 || idx >= len(m.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if m.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // appendLog 棋譜にエントリを追加する

--- a/internal/domain/Mus.go
+++ b/internal/domain/Mus.go
@@ -247,11 +247,11 @@ func (g *Mus) resolveMus(mus bool) {
 		mus = false
 	}
 	if !mus {
-		g.appendLog(g.musTurn, "corte", fmt.Sprintf("%s cuts (no mus)", g.playerName(g.musTurn)), nil)
+		g.appendLog(g.musTurn, "corte", fmt.Sprintf("%s cuts (no mus)", playerName(g.players, g.musTurn)), nil)
 		g.beginBetting()
 		return
 	}
-	g.appendLog(g.musTurn, "mus", fmt.Sprintf("%s wants mus", g.playerName(g.musTurn)), nil)
+	g.appendLog(g.musTurn, "mus", fmt.Sprintf("%s wants mus", playerName(g.players, g.musTurn)), nil)
 	g.musAgreed++
 	if g.musAgreed >= MusPlayerCnt {
 		// 全員合意 → 交換フェーズ。
@@ -313,7 +313,7 @@ func (g *Mus) applyDiscard(indices []int) {
 		musSortHand(p)
 	}
 	g.appendLog(g.discardTurn, "discard",
-		fmt.Sprintf("%s exchanges %d cards", g.playerName(g.discardTurn), len(indices)), nil)
+		fmt.Sprintf("%s exchanges %d cards", playerName(g.players, g.discardTurn), len(indices)), nil)
 
 	if g.discardTurn == (g.manoIdx+MusPlayerCnt-1)%MusPlayerCnt {
 		// 全員交換完了 → 再び Mus 宣言へ。
@@ -803,17 +803,6 @@ func musSortHand(p *MusPlayer) {
 	for _, c := range cards {
 		p.AddCard(c)
 	}
-}
-
-// playerName プレイヤー名。
-func (g *Mus) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // musRoundName ラウンド名。

--- a/internal/domain/Nap.go
+++ b/internal/domain/Nap.go
@@ -219,9 +219,9 @@ func (g *Nap) applyBid(idx int, bid NapBid) error {
 	g.bids[idx] = bid
 	g.bidDone[idx] = true
 	if bid != NapBidPass {
-		g.appendLog(idx, "bid", fmt.Sprintf("%s bids %s", g.playerName(idx), napBidName(bid)), nil)
+		g.appendLog(idx, "bid", fmt.Sprintf("%s bids %s", playerName(g.players, idx), napBidName(bid)), nil)
 	} else {
-		g.appendLog(idx, "bid", fmt.Sprintf("%s passes", g.playerName(idx)), nil)
+		g.appendLog(idx, "bid", fmt.Sprintf("%s passes", playerName(g.players, idx)), nil)
 	}
 	for k := 1; k <= NapPlayerCnt; k++ {
 		ni := (idx + k) % NapPlayerCnt
@@ -247,7 +247,7 @@ func (g *Nap) resolveBidding() {
 	g.contract = bid
 	g.trumpSuit = g.longestSuit(idx)
 	g.appendLog(idx, "contract",
-		fmt.Sprintf("%s declares %s (trump %d)", g.playerName(idx), napBidName(bid), g.trumpSuit), nil)
+		fmt.Sprintf("%s declares %s (trump %d)", playerName(g.players, idx), napBidName(bid), g.trumpSuit), nil)
 	g.leadPlayerIdx = idx // declarer leads in Nap
 	g.currentPlayerIdx = g.leadPlayerIdx
 	g.phase = NapPhasePlay
@@ -350,7 +350,7 @@ func (g *Nap) CpuPlay() {
 // playCard カードをプレイする共通処理。
 func (g *Nap) playCard(playerIdx int, card *Card) {
 	g.currentTrick = append(g.currentTrick, &TrickCard{PlayerIdx: playerIdx, Card: card})
-	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", g.playerName(playerIdx), cardStr(card)), []*Card{card})
+	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", playerName(g.players, playerIdx), cardStr(card)), []*Card{card})
 
 	if len(g.currentTrick) == NapPlayerCnt {
 		g.phase = NapPhaseTrickEnd
@@ -372,7 +372,7 @@ func (g *Nap) ResolveTrick() {
 	g.players[winnerIdx].AddTrick(trickCards)
 	g.roundTricks[winnerIdx]++
 	g.appendLog(winnerIdx, "trick_win",
-		fmt.Sprintf("%s wins trick %d", g.playerName(winnerIdx), g.trickNumber), trickCards)
+		fmt.Sprintf("%s wins trick %d", playerName(g.players, winnerIdx), g.trickNumber), trickCards)
 
 	g.leadPlayerIdx = winnerIdx
 	if g.trickNumber >= NapTrickCount {
@@ -453,7 +453,7 @@ func (g *Nap) checkGameEnd() {
 		g.gameEndFlag = true
 		g.winnerPlayer = leader
 		g.phase = NapPhaseGameEnd
-		g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the match!", g.playerName(leader)), nil)
+		g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the match!", playerName(g.players, leader)), nil)
 	}
 }
 
@@ -553,17 +553,6 @@ func napSortHand(p *NapPlayer) {
 	for _, c := range cards {
 		p.AddCard(c)
 	}
-}
-
-// playerName プレイヤー名を返す。
-func (g *Nap) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // indexOfPlayerInTrick currentTrick 内で playerIdx の札の位置を返す (-1=なし)。

--- a/internal/domain/Napoleon.go
+++ b/internal/domain/Napoleon.go
@@ -385,7 +385,7 @@ func (n *Napoleon) ResolveTrick() {
 	picCount := n.countPictureCards(trickCards)
 	n.players[winnerIdx].pictureCards += picCount
 
-	winnerName := n.playerName(winnerIdx)
+	winnerName := playerName(n.players, winnerIdx)
 	s := fmt.Sprintf("%s wins trick %d", winnerName, n.round.trickNumber)
 	if picCount > 0 {
 		s += fmt.Sprintf(" (+%d picture cards)", picCount)
@@ -458,7 +458,7 @@ func (n *Napoleon) ScoreRound() {
 				p.roundScore = bid
 			}
 		}
-		n.appendLog(i, "round_score", fmt.Sprintf("%s: round=%d", n.playerName(i), p.roundScore), nil)
+		n.appendLog(i, "round_score", fmt.Sprintf("%s: round=%d", playerName(n.players, i), p.roundScore), nil)
 	}
 
 	// 累積スコアに加算
@@ -469,7 +469,7 @@ func (n *Napoleon) ScoreRound() {
 	// 累積スコアログ
 	for i := range NapoleonPlayerCnt {
 		n.appendLog(i, "cumulative_score", fmt.Sprintf("%s: total=%d",
-			n.playerName(i), n.players[i].cumulativeScore), nil)
+			playerName(n.players, i), n.players[i].cumulativeScore), nil)
 	}
 
 	// ゲーム終了判定
@@ -717,10 +717,10 @@ func (n *Napoleon) applyBid(playerIdx int, bid int) {
 	n.players[playerIdx].SetBid(bid)
 
 	if bid == 0 {
-		n.appendLog(playerIdx, "bid", fmt.Sprintf("%s passes", n.playerName(playerIdx)), nil)
+		n.appendLog(playerIdx, "bid", fmt.Sprintf("%s passes", playerName(n.players, playerIdx)), nil)
 		n.round.passCount++
 	} else {
-		n.appendLog(playerIdx, "bid", fmt.Sprintf("%s bids %d", n.playerName(playerIdx), bid), nil)
+		n.appendLog(playerIdx, "bid", fmt.Sprintf("%s bids %d", playerName(n.players, playerIdx), bid), nil)
 		n.round.highestBid = bid
 		n.round.highestBidder = playerIdx
 	}
@@ -740,12 +740,12 @@ func (n *Napoleon) checkBidComplete() {
 		n.round.highestBid = n.config.MinBid
 		n.round.highestBidder = 0
 		n.players[0].SetBid(n.config.MinBid)
-		n.appendLog(0, "forced_bid", fmt.Sprintf("%s is forced to bid %d (all pass)", n.playerName(0), n.config.MinBid), nil)
+		n.appendLog(0, "forced_bid", fmt.Sprintf("%s is forced to bid %d (all pass)", playerName(n.players, 0), n.config.MinBid), nil)
 	}
 
 	n.round.napoleonIdx = n.round.highestBidder
 	n.players[n.round.napoleonIdx].SetIsNapoleon(true)
-	n.appendLog(n.round.napoleonIdx, "napoleon", fmt.Sprintf("%s becomes Napoleon (bid %d)", n.playerName(n.round.napoleonIdx), n.round.highestBid), nil)
+	n.appendLog(n.round.napoleonIdx, "napoleon", fmt.Sprintf("%s becomes Napoleon (bid %d)", playerName(n.players, n.round.napoleonIdx), n.round.highestBid), nil)
 
 	n.round.phase = NapoleonPhaseTrumpDeclaration
 }
@@ -761,9 +761,9 @@ func (n *Napoleon) applyDeclareTrump(suit int, adjSuit int, adjVal int) {
 		CardDesignJoker: "Joker",
 	}
 	n.appendLog(n.round.napoleonIdx, "declare_trump",
-		fmt.Sprintf("%s declares %s as trump", n.playerName(n.round.napoleonIdx), suitNames[suit]), nil)
+		fmt.Sprintf("%s declares %s as trump", playerName(n.players, n.round.napoleonIdx), suitNames[suit]), nil)
 	n.appendLog(n.round.napoleonIdx, "declare_adjutant",
-		fmt.Sprintf("%s names %s as adjutant card", n.playerName(n.round.napoleonIdx), napoleonCardStr(n.round.adjutantCard)), nil)
+		fmt.Sprintf("%s names %s as adjutant card", playerName(n.players, n.round.napoleonIdx), napoleonCardStr(n.round.adjutantCard)), nil)
 
 	// 副官を特定
 	n.round.adjutantIdx = n.findAdjutantHolder()
@@ -791,7 +791,7 @@ func (n *Napoleon) applyExchangeKitty(discardIndex int) {
 	discarded := player.RemoveCard(discardIndex)
 	n.round.kitty = []*Card{discarded}
 
-	n.appendLog(n.round.napoleonIdx, "exchange", fmt.Sprintf("%s exchanges kitty card", n.playerName(n.round.napoleonIdx)), nil)
+	n.appendLog(n.round.napoleonIdx, "exchange", fmt.Sprintf("%s exchanges kitty card", playerName(n.players, n.round.napoleonIdx)), nil)
 
 	n.sortHand(player)
 	n.startPlayPhase()
@@ -813,7 +813,7 @@ func (n *Napoleon) playCard(playerIdx int, card *Card) {
 		Card:      card,
 	})
 
-	n.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", n.playerName(playerIdx), napoleonCardStr(card)), []*Card{card})
+	n.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", playerName(n.players, playerIdx), napoleonCardStr(card)), []*Card{card})
 
 	// 副官カードが出されたら公開
 	n.checkAdjutantReveal(playerIdx, card)
@@ -981,7 +981,7 @@ func (n *Napoleon) checkAdjutantReveal(playerIdx int, card *Card) {
 			n.round.adjutantIdx = playerIdx
 			n.players[playerIdx].SetIsAdjutant(true)
 		}
-		n.appendLog(playerIdx, "adjutant_reveal", fmt.Sprintf("%s is revealed as the adjutant!", n.playerName(playerIdx)), []*Card{card})
+		n.appendLog(playerIdx, "adjutant_reveal", fmt.Sprintf("%s is revealed as the adjutant!", playerName(n.players, playerIdx)), []*Card{card})
 	}
 }
 
@@ -1031,7 +1031,7 @@ func (n *Napoleon) checkGameEnd() {
 			winnerIdx = i
 		}
 	}
-	n.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game!", n.playerName(winnerIdx)), nil)
+	n.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game!", playerName(n.players, winnerIdx)), nil)
 }
 
 // sortAllHands 全プレイヤーの手札をソートする
@@ -1050,17 +1050,6 @@ func (n *Napoleon) sortHand(p *NapoleonPlayer) {
 		}
 		return ci.GetValue() < cj.GetValue()
 	})
-}
-
-// playerName プレイヤー名を返す
-func (n *Napoleon) playerName(idx int) string {
-	if idx < 0 || idx >= len(n.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if n.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // appendLog 棋譜にエントリを追加する

--- a/internal/domain/NinetyNine.go
+++ b/internal/domain/NinetyNine.go
@@ -261,7 +261,7 @@ func (o *NinetyNine) ResolveTrick() {
 
 	o.players[winnerIdx].AddTrick(trickCards)
 
-	winnerName := o.playerName(winnerIdx)
+	winnerName := playerName(o.players, winnerIdx)
 	o.appendLog(winnerIdx, "trick_win", fmt.Sprintf("%s wins trick %d", winnerName, o.trickNumber), trickCards)
 
 	o.leadPlayerIdx = winnerIdx
@@ -316,11 +316,11 @@ func (o *NinetyNine) ScoreRound() {
 		if tricks == bid {
 			p.SetRoundScore(10 + bid + bonus)
 			o.appendLog(i, "bid_success", fmt.Sprintf("%s declared %d, took %d: +%d (bonus +%d)",
-				o.playerName(i), bid, tricks, p.GetRoundScore(), bonus), nil)
+				playerName(o.players, i), bid, tricks, p.GetRoundScore(), bonus), nil)
 		} else {
 			p.SetRoundScore(0)
 			o.appendLog(i, "bid_fail", fmt.Sprintf("%s declared %d, took %d: 0",
-				o.playerName(i), bid, tricks), nil)
+				playerName(o.players, i), bid, tricks), nil)
 		}
 	}
 
@@ -330,7 +330,7 @@ func (o *NinetyNine) ScoreRound() {
 
 	for i := range NinetyNinePlayerCnt {
 		o.appendLog(i, "cumulative_score", fmt.Sprintf("%s: total=%d",
-			o.playerName(i), o.players[i].GetCumulativeScore()), nil)
+			playerName(o.players, i), o.players[i].GetCumulativeScore()), nil)
 	}
 
 	// ゲーム終了判定: いずれかが TargetScore 以上に達したら終了
@@ -528,7 +528,7 @@ func (o *NinetyNine) applyBury(playerIdx int, descIndices []int) {
 	}
 	player.SetBuried(buried)
 	player.SetBid(bid)
-	o.appendLog(playerIdx, "bid", fmt.Sprintf("%s buries 3 and declares %d", o.playerName(playerIdx), bid), buried)
+	o.appendLog(playerIdx, "bid", fmt.Sprintf("%s buries 3 and declares %d", playerName(o.players, playerIdx), bid), buried)
 }
 
 // advanceBid ビッドプレイヤーを次に進める
@@ -562,7 +562,7 @@ func (o *NinetyNine) playCard(playerIdx int, card *Card) {
 		Card:      card,
 	})
 
-	o.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", o.playerName(playerIdx), cardStr(card)), []*Card{card})
+	o.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", playerName(o.players, playerIdx), cardStr(card)), []*Card{card})
 
 	if len(o.currentTrick) == NinetyNinePlayerCnt {
 		o.phase = NinetyNinePhaseTrickEnd
@@ -620,7 +620,7 @@ func (o *NinetyNine) determineWinner() {
 		}
 	}
 	o.winnerIdx = best
-	o.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game!", o.playerName(o.winnerIdx)), nil)
+	o.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game!", playerName(o.players, o.winnerIdx)), nil)
 }
 
 // ninetyNineBeats プレイヤー a がプレイヤー b に勝るか (タイブレーク込み)
@@ -650,17 +650,6 @@ func ninetyNineSortHand(p *NinetyNinePlayer) {
 		}
 		return ninetyNineRankValue(ci) < ninetyNineRankValue(cj)
 	})
-}
-
-// playerName プレイヤー名を返す
-func (o *NinetyNine) playerName(idx int) string {
-	if idx < 0 || idx >= len(o.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if o.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す

--- a/internal/domain/OhHell.go
+++ b/internal/domain/OhHell.go
@@ -154,7 +154,7 @@ func (o *OhHell) PlayerBid(bid int) error {
 	}
 
 	o.players[humanIdx].SetBid(bid)
-	o.appendLog(humanIdx, "bid", fmt.Sprintf("%s bids %d", o.playerName(humanIdx), bid), nil)
+	o.appendLog(humanIdx, "bid", fmt.Sprintf("%s bids %d", playerName(o.players, humanIdx), bid), nil)
 
 	o.advanceBid()
 	return nil
@@ -174,7 +174,7 @@ func (o *OhHell) CpuBid() {
 
 	bid := o.cpuSelectBid(o.bidPlayerIdx)
 	o.players[o.bidPlayerIdx].SetBid(bid)
-	o.appendLog(o.bidPlayerIdx, "bid", fmt.Sprintf("%s bids %d", o.playerName(o.bidPlayerIdx), bid), nil)
+	o.appendLog(o.bidPlayerIdx, "bid", fmt.Sprintf("%s bids %d", playerName(o.players, o.bidPlayerIdx), bid), nil)
 
 	o.advanceBid()
 }
@@ -241,7 +241,7 @@ func (o *OhHell) ResolveTrick() {
 
 	o.players[winnerIdx].AddTrick(trickCards)
 
-	winnerName := o.playerName(winnerIdx)
+	winnerName := playerName(o.players, winnerIdx)
 	o.appendLog(winnerIdx, "trick_win", fmt.Sprintf("%s wins trick %d", winnerName, o.trickNumber), trickCards)
 
 	o.leadPlayerIdx = winnerIdx
@@ -279,7 +279,7 @@ func (o *OhHell) ScoreRound() {
 			// ビッド的中: 10 + bid ポイント
 			p.roundScore = 10 + bid
 			o.appendLog(i, "bid_success", fmt.Sprintf("%s bid %d, took %d: +%d",
-				o.playerName(i), bid, tricks, p.roundScore), nil)
+				playerName(o.players, i), bid, tricks, p.roundScore), nil)
 		} else {
 			switch o.config.ScoringVariant {
 			case OhHellScoringPenalty:
@@ -289,11 +289,11 @@ func (o *OhHell) ScoreRound() {
 				}
 				p.roundScore = -diff
 				o.appendLog(i, "bid_fail", fmt.Sprintf("%s bid %d, took %d: %d",
-					o.playerName(i), bid, tricks, p.roundScore), nil)
+					playerName(o.players, i), bid, tricks, p.roundScore), nil)
 			default:
 				p.roundScore = 0
 				o.appendLog(i, "bid_fail", fmt.Sprintf("%s bid %d, took %d: 0",
-					o.playerName(i), bid, tricks), nil)
+					playerName(o.players, i), bid, tricks), nil)
 			}
 		}
 	}
@@ -306,7 +306,7 @@ func (o *OhHell) ScoreRound() {
 	// スコアログ
 	for i := range OhHellPlayerCnt {
 		o.appendLog(i, "cumulative_score", fmt.Sprintf("%s: total=%d",
-			o.playerName(i), o.players[i].cumulativeScore), nil)
+			playerName(o.players, i), o.players[i].cumulativeScore), nil)
 	}
 
 	// ゲーム終了判定
@@ -563,7 +563,7 @@ func (o *OhHell) playCard(playerIdx int, card *Card) {
 		Card:      card,
 	})
 
-	o.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", o.playerName(playerIdx), cardStr(card)), []*Card{card})
+	o.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", playerName(o.players, playerIdx), cardStr(card)), []*Card{card})
 
 	if len(o.currentTrick) == OhHellPlayerCnt {
 		o.phase = OhHellPhaseTrickEnd
@@ -616,7 +616,7 @@ func (o *OhHell) determineWinner() {
 			o.winnerIdx = i
 		}
 	}
-	o.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game!", o.playerName(o.winnerIdx)), nil)
+	o.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game!", playerName(o.players, o.winnerIdx)), nil)
 }
 
 // sortAllHands 全プレイヤーの手札をソートする
@@ -634,17 +634,6 @@ func ohHellSortHand(p *OhHellPlayer) {
 		}
 		return ci.GetValue() < cj.GetValue()
 	})
-}
-
-// playerName ���レイヤー名を返す
-func (o *OhHell) playerName(idx int) string {
-	if idx < 0 || idx >= len(o.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if o.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す

--- a/internal/domain/Ombre.go
+++ b/internal/domain/Ombre.go
@@ -342,11 +342,11 @@ func (g *Ombre) applyBid(playerIdx int, bid OmbreBid, trumpSuit int) {
 	if bid == OmbreBidNone {
 		g.bidTrump[playerIdx] = -1
 		g.appendLog(playerIdx, "bid_pass",
-			fmt.Sprintf("%s passes", g.playerName(playerIdx)), nil)
+			fmt.Sprintf("%s passes", playerName(g.players, playerIdx)), nil)
 	} else {
 		g.bidTrump[playerIdx] = trumpSuit
 		g.appendLog(playerIdx, "bid",
-			fmt.Sprintf("%s bids %s (trump %s)", g.playerName(playerIdx), ombreBidName(bid), ombreSuitName(trumpSuit)), nil)
+			fmt.Sprintf("%s bids %s (trump %s)", playerName(g.players, playerIdx), ombreBidName(bid), ombreSuitName(trumpSuit)), nil)
 	}
 
 	if g.allBidsActed() {
@@ -405,7 +405,7 @@ func (g *Ombre) finalizeAuction() {
 		g.trumpSuit = g.cpuChooseTrump(ombre)
 	}
 	g.appendLog(ombre, "ombre",
-		fmt.Sprintf("%s is Ombre with %s (trump %s)", g.playerName(ombre), ombreBidName(best), ombreSuitName(g.trumpSuit)), nil)
+		fmt.Sprintf("%s is Ombre with %s (trump %s)", playerName(g.players, ombre), ombreBidName(best), ombreSuitName(g.trumpSuit)), nil)
 	g.startPlay()
 }
 
@@ -518,7 +518,7 @@ func (g *Ombre) CpuPlay() {
 // playCard カードをプレイする共通処理。
 func (g *Ombre) playCard(playerIdx int, card *Card) {
 	g.currentTrick = append(g.currentTrick, &TrickCard{PlayerIdx: playerIdx, Card: card})
-	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", g.playerName(playerIdx), cardStr(card)), []*Card{card})
+	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", playerName(g.players, playerIdx), cardStr(card)), []*Card{card})
 
 	if len(g.currentTrick) == OmbrePlayerCnt {
 		g.phase = OmbrePhaseTrickEnd
@@ -539,7 +539,7 @@ func (g *Ombre) ResolveTrick() {
 	}
 	g.players[winnerIdx].AddTrick(trickCards)
 	g.appendLog(winnerIdx, "trick_win",
-		fmt.Sprintf("%s wins trick %d", g.playerName(winnerIdx), g.trickNumber), trickCards)
+		fmt.Sprintf("%s wins trick %d", playerName(g.players, winnerIdx), g.trickNumber), trickCards)
 
 	g.leadPlayerIdx = winnerIdx
 	if g.trickNumber >= OmbreTrickCount {
@@ -576,7 +576,7 @@ func (g *Ombre) enterRoundEnd() {
 	}
 	g.appendLog(-1, "round_score",
 		fmt.Sprintf("round %d: Ombre(%s) %s (stake=%d)",
-			g.roundNumber, g.playerName(g.ombreIdx), ombreOutcomeName(g.outcome), stake), nil)
+			g.roundNumber, playerName(g.players, g.ombreIdx), ombreOutcomeName(g.outcome), stake), nil)
 	g.checkGameEnd()
 }
 
@@ -644,7 +644,7 @@ func (g *Ombre) checkGameEnd() {
 	g.winnerPlayer = leader
 	g.phase = OmbrePhaseGameEnd
 	g.result = g.humanResult(leader, tie)
-	g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the match!", g.playerName(leader)), nil)
+	g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the match!", playerName(g.players, leader)), nil)
 }
 
 // humanResult 人間 (seat 0) の視点でマッチ結果を返す。単独トップなら Win、トップ同点なら None、他は Lose。
@@ -917,17 +917,6 @@ func ombreSortHand(p *OmbrePlayer, trump int) {
 	for _, c := range cards {
 		p.AddCard(c)
 	}
-}
-
-// playerName プレイヤー名を返す。
-func (g *Ombre) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // ombreBidName ビッドの表示名を返す。

--- a/internal/domain/OpenFaceChinese.go
+++ b/internal/domain/OpenFaceChinese.go
@@ -207,7 +207,7 @@ func (g *OpenFaceChinese) place(playerIdx, row int) error {
 	if err := p.placeCard(row); err != nil {
 		return err
 	}
-	g.appendLog(playerIdx, "place", fmt.Sprintf("%s places %s on row %d", g.playerName(playerIdx), cardStr(card), row), []*Card{card})
+	g.appendLog(playerIdx, "place", fmt.Sprintf("%s places %s on row %d", playerName(g.players, playerIdx), cardStr(card), row), []*Card{card})
 	g.afterPlace(playerIdx)
 	return nil
 }
@@ -530,17 +530,6 @@ func ofcHintReason(card *Card, row int) string {
 }
 
 // --- Misc ---
-
-// playerName プレイヤー表示名を返す。
-func (g *OpenFaceChinese) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
-}
 
 // --- Getters ---
 

--- a/internal/domain/PageOne.go
+++ b/internal/domain/PageOne.go
@@ -263,13 +263,13 @@ func (g *PageOne) CpuDeclare() {
 // doDeclare 宣言処理の共通実装
 func (g *PageOne) doDeclare(playerIdx int) {
 	g.players[playerIdx].SetHasDeclared(true)
-	g.appendLog(playerIdx, "declare", fmt.Sprintf("%s declares Page One!", g.playerName(playerIdx)), nil)
+	g.appendLog(playerIdx, "declare", fmt.Sprintf("%s declares Page One!", playerName(g.players, playerIdx)), nil)
 	g.advanceTurn()
 }
 
 // applyDeclarePenalty 宣言忘れペナルティとして2枚引かせる
 func (g *PageOne) applyDeclarePenalty(playerIdx int) {
-	g.appendLog(playerIdx, "penalty", fmt.Sprintf("%s forgot to declare Page One! (+%d cards)", g.playerName(playerIdx), PageOnePenaltyDraw), nil)
+	g.appendLog(playerIdx, "penalty", fmt.Sprintf("%s forgot to declare Page One! (+%d cards)", playerName(g.players, playerIdx), PageOnePenaltyDraw), nil)
 	for i := 0; i < PageOnePenaltyDraw; i++ {
 		if len(g.drawPile) == 0 {
 			g.recycleDrawPile()
@@ -313,11 +313,11 @@ func (g *PageOne) ScoreRound() {
 			score += pageOneCardScore(p.GetCard(j))
 		}
 		totalScore += score
-		g.appendLog(i, "hand_score", fmt.Sprintf("%s: %d points remaining", g.playerName(i), score), nil)
+		g.appendLog(i, "hand_score", fmt.Sprintf("%s: %d points remaining", playerName(g.players, i), score), nil)
 	}
 
 	g.players[winnerIdx].roundScore = totalScore
-	g.appendLog(winnerIdx, "round_win", fmt.Sprintf("%s wins round %d (+%d points)", g.playerName(winnerIdx), g.roundNumber, totalScore), nil)
+	g.appendLog(winnerIdx, "round_win", fmt.Sprintf("%s wins round %d (+%d points)", playerName(g.players, winnerIdx), g.roundNumber, totalScore), nil)
 
 	g.players[winnerIdx].CommitRoundScore()
 
@@ -418,7 +418,7 @@ func (g *PageOne) isValidPlay(card *Card) bool {
 func (g *PageOne) playCard(playerIdx int, card *Card) {
 	g.discardPile = append(g.discardPile, card)
 
-	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", g.playerName(playerIdx), cardStr(card)), []*Card{card})
+	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", playerName(g.players, playerIdx), cardStr(card)), []*Card{card})
 
 	remaining := g.players[playerIdx].GetCardsSize()
 
@@ -455,7 +455,7 @@ func (g *PageOne) drawCard(playerIdx int) error {
 	}
 
 	if len(g.drawPile) == 0 {
-		g.appendLog(playerIdx, "pass", fmt.Sprintf("%s passes (no cards to draw)", g.playerName(playerIdx)), nil)
+		g.appendLog(playerIdx, "pass", fmt.Sprintf("%s passes (no cards to draw)", playerName(g.players, playerIdx)), nil)
 		g.advanceTurn()
 		return nil
 	}
@@ -465,7 +465,7 @@ func (g *PageOne) drawCard(playerIdx int) error {
 	g.players[playerIdx].AddCard(card)
 	g.sortHand(playerIdx)
 
-	g.appendLog(playerIdx, "draw", fmt.Sprintf("%s draws a card", g.playerName(playerIdx)), nil)
+	g.appendLog(playerIdx, "draw", fmt.Sprintf("%s draws a card", playerName(g.players, playerIdx)), nil)
 
 	if !g.hasPlayableCard(playerIdx) {
 		g.advanceTurn()
@@ -527,7 +527,7 @@ func (g *PageOne) checkGameEnd() {
 			g.winnerIdx = i
 		}
 	}
-	g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game!", g.playerName(g.winnerIdx)), nil)
+	g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game!", playerName(g.players, g.winnerIdx)), nil)
 }
 
 // sortAllHands 全プレイヤーの手札をソートする
@@ -546,17 +546,6 @@ func (g *PageOne) sortHand(playerIdx int) {
 		}
 		return ci.GetValue() < cj.GetValue()
 	})
-}
-
-// playerName プレイヤー名を返す
-func (g *PageOne) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // --- CPU AI ---

--- a/internal/domain/Pan.go
+++ b/internal/domain/Pan.go
@@ -256,7 +256,7 @@ func (g *Pan) drawFromStock() error {
 	g.players[g.currentPlayerIdx].AddCard(card)
 	g.sortHand(g.currentPlayerIdx)
 
-	g.appendLog(g.currentPlayerIdx, "draw_stock", fmt.Sprintf("%s draws from stock", g.playerName(g.currentPlayerIdx)), nil)
+	g.appendLog(g.currentPlayerIdx, "draw_stock", fmt.Sprintf("%s draws from stock", playerName(g.players, g.currentPlayerIdx)), nil)
 	g.phase = PanPhasePlay
 	return nil
 }
@@ -270,7 +270,7 @@ func (g *Pan) drawFromDiscard() error {
 	g.players[g.currentPlayerIdx].AddCard(card)
 	g.sortHand(g.currentPlayerIdx)
 
-	g.appendLog(g.currentPlayerIdx, "draw_discard", fmt.Sprintf("%s draws %s from discard", g.playerName(g.currentPlayerIdx), cardStr(card)), []*Card{card})
+	g.appendLog(g.currentPlayerIdx, "draw_discard", fmt.Sprintf("%s draws %s from discard", playerName(g.players, g.currentPlayerIdx), cardStr(card)), []*Card{card})
 	g.phase = PanPhasePlay
 	return nil
 }
@@ -321,7 +321,7 @@ func (g *Pan) executeMeld(playerIdx int, cardIndices []int) error {
 
 	cardsCopy := make([]*Card, len(meld))
 	copy(cardsCopy, meld)
-	g.appendLog(playerIdx, "meld", fmt.Sprintf("%s melds %s", g.playerName(playerIdx), formatCards(meld)), cardsCopy)
+	g.appendLog(playerIdx, "meld", fmt.Sprintf("%s melds %s", playerName(g.players, playerIdx), formatCards(meld)), cardsCopy)
 
 	g.payChipConditions(playerIdx, meld)
 	g.checkPanDeclaration(playerIdx)
@@ -359,7 +359,7 @@ func (g *Pan) executeLayoff(playerIdx, meldOwner, meldIdx, cardIndex int) error 
 	owner.AppendToLaidMeld(meldIdx, card)
 	player.RemoveCard(cardIndex)
 
-	g.appendLog(playerIdx, "layoff", fmt.Sprintf("%s lays off %s", g.playerName(playerIdx), cardStr(card)), []*Card{card})
+	g.appendLog(playerIdx, "layoff", fmt.Sprintf("%s lays off %s", playerName(g.players, playerIdx), cardStr(card)), []*Card{card})
 
 	// レイオフ先の所有者が 11 枚に到達したらその所有者があがる。
 	g.checkPanDeclaration(meldOwner)
@@ -382,7 +382,7 @@ func (g *Pan) payChipConditions(playerIdx int, meld []*Card) {
 		}
 	}
 	g.players[playerIdx].AddChips(units * opponents)
-	g.appendLog(playerIdx, "chips", fmt.Sprintf("%s collects %d chip(s) from each opponent", g.playerName(playerIdx), units), nil)
+	g.appendLog(playerIdx, "chips", fmt.Sprintf("%s collects %d chip(s) from each opponent", playerName(g.players, playerIdx), units), nil)
 }
 
 // checkPanDeclaration playerIdx が 11 枚を場に出していれば「パン」あがりとしてラウンドを終える。
@@ -395,7 +395,7 @@ func (g *Pan) checkPanDeclaration(playerIdx int) {
 	}
 	g.panDeclarerIdx = playerIdx
 	g.players[playerIdx].SetIsFinished(true)
-	g.appendLog(playerIdx, "pan", fmt.Sprintf("%s declares Pan!", g.playerName(playerIdx)), nil)
+	g.appendLog(playerIdx, "pan", fmt.Sprintf("%s declares Pan!", playerName(g.players, playerIdx)), nil)
 	g.enterRoundEnd()
 }
 
@@ -416,7 +416,7 @@ func (g *Pan) applyDiscard(cardIndex int) error {
 	}
 	discarded := player.RemoveCard(cardIndex)
 	g.discardPile = append(g.discardPile, discarded)
-	g.appendLog(g.currentPlayerIdx, "discard", fmt.Sprintf("%s discards %s", g.playerName(g.currentPlayerIdx), cardStr(discarded)), []*Card{discarded})
+	g.appendLog(g.currentPlayerIdx, "discard", fmt.Sprintf("%s discards %s", playerName(g.players, g.currentPlayerIdx), cardStr(discarded)), []*Card{discarded})
 	g.advanceTurn()
 	return nil
 }
@@ -609,7 +609,7 @@ func (g *Pan) scoreRound() {
 	}
 
 	if g.panDeclarerIdx >= 0 {
-		g.appendLog(g.panDeclarerIdx, "round_win", fmt.Sprintf("%s wins the round with Pan", g.playerName(g.panDeclarerIdx)), nil)
+		g.appendLog(g.panDeclarerIdx, "round_win", fmt.Sprintf("%s wins the round with Pan", playerName(g.players, g.panDeclarerIdx)), nil)
 	}
 
 	for i := range g.players {
@@ -630,7 +630,7 @@ func (g *Pan) finalizeGameEnd() {
 			g.winnerIdx = i
 		}
 	}
-	g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game with %d points!", g.playerName(g.winnerIdx), minScore), nil)
+	g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game with %d points!", playerName(g.players, g.winnerIdx), minScore), nil)
 }
 
 // --- Getters / Setters ---
@@ -742,16 +742,6 @@ func (g *Pan) sortHand(playerIdx int) {
 		}
 		return ci.GetValue() < cj.GetValue()
 	})
-}
-
-func (g *Pan) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // --- Scoring / meld helpers ---

--- a/internal/domain/Pitch.go
+++ b/internal/domain/Pitch.go
@@ -237,7 +237,7 @@ func (p *Pitch) applyBid(playerIdx, bid int) {
 	if bid == PitchPassBid {
 		logBid = "pass"
 	}
-	p.appendLog(playerIdx, "bid", fmt.Sprintf("%s bids %s", p.playerName(playerIdx), logBid), nil)
+	p.appendLog(playerIdx, "bid", fmt.Sprintf("%s bids %s", playerName(p.players, playerIdx), logBid), nil)
 }
 
 // advanceBid 次のビッド手番へ進める。全員終わればプレイ開始 (stuck dealer も処理)
@@ -248,7 +248,7 @@ func (p *Pitch) advanceBid() {
 		// 親に到達し、かつ全員パス済みの場合 stuck 強制
 		if p.bidPlayerIdx == p.dealerIdx && p.currentBid == 0 && bidsDone == PitchPlayerCnt-1 {
 			p.applyBid(p.dealerIdx, PitchMinBid)
-			p.appendLog(p.dealerIdx, "stuck", fmt.Sprintf("%s is stuck with %d", p.playerName(p.dealerIdx), PitchMinBid), nil)
+			p.appendLog(p.dealerIdx, "stuck", fmt.Sprintf("%s is stuck with %d", playerName(p.players, p.dealerIdx), PitchMinBid), nil)
 			p.startPlayPhase()
 		}
 		return
@@ -281,7 +281,7 @@ func (p *Pitch) startPlayPhase() {
 	p.currentTrick = nil
 	p.phase = PitchPhasePlay
 	p.appendLog(p.bidWinnerIdx, "bid_won",
-		fmt.Sprintf("%s wins the bid at %d (will lead first card to set trump)", p.playerName(p.bidWinnerIdx), p.currentBid),
+		fmt.Sprintf("%s wins the bid at %d (will lead first card to set trump)", playerName(p.players, p.bidWinnerIdx), p.currentBid),
 		nil)
 }
 
@@ -342,7 +342,7 @@ func (p *Pitch) playCard(playerIdx int, card *Card) {
 		Card:      card,
 	})
 	p.appendLog(playerIdx, "play",
-		fmt.Sprintf("%s plays %s", p.playerName(playerIdx), cardStr(card)),
+		fmt.Sprintf("%s plays %s", playerName(p.players, playerIdx), cardStr(card)),
 		[]*Card{card})
 
 	if len(p.currentTrick) == PitchPlayerCnt {
@@ -395,7 +395,7 @@ func (p *Pitch) ResolveTrick() {
 	}
 	p.players[winnerIdx].AddTrick(trickCards)
 	p.appendLog(winnerIdx, "trick_win",
-		fmt.Sprintf("%s wins trick %d", p.playerName(winnerIdx), p.trickNumber),
+		fmt.Sprintf("%s wins trick %d", playerName(p.players, winnerIdx), p.trickNumber),
 		trickCards)
 	p.leadPlayerIdx = winnerIdx
 	if p.trickNumber >= PitchTotalTricks {
@@ -509,18 +509,18 @@ func (p *Pitch) ScoreRound() {
 				pl.SetRoundScore(-p.currentBid)
 				p.appendLog(i, "set_back",
 					fmt.Sprintf("%s set back: bid=%d earned=%d -> %d",
-						p.playerName(i), p.currentBid, points, -p.currentBid), nil)
+						playerName(p.players, i), p.currentBid, points, -p.currentBid), nil)
 			} else {
 				pl.SetRoundScore(points)
 				p.appendLog(i, "bid_made",
 					fmt.Sprintf("%s makes bid: bid=%d earned=%d -> +%d",
-						p.playerName(i), p.currentBid, points, points), nil)
+						playerName(p.players, i), p.currentBid, points, points), nil)
 			}
 		} else {
 			pl.SetRoundScore(points)
 			if points > 0 {
 				p.appendLog(i, "non_bidder_score",
-					fmt.Sprintf("%s scores %d", p.playerName(i), points), nil)
+					fmt.Sprintf("%s scores %d", playerName(p.players, i), points), nil)
 			}
 		}
 	}
@@ -529,7 +529,7 @@ func (p *Pitch) ScoreRound() {
 	}
 	for i := 0; i < PitchPlayerCnt; i++ {
 		p.appendLog(i, "cumulative_score",
-			fmt.Sprintf("%s: total=%d", p.playerName(i), p.players[i].GetCumulativeScore()), nil)
+			fmt.Sprintf("%s: total=%d", playerName(p.players, i), p.players[i].GetCumulativeScore()), nil)
 	}
 	p.checkGameEnd()
 }
@@ -572,17 +572,17 @@ func (p *Pitch) computeRoundPoints() []int {
 	if highPlayer >= 0 {
 		points[highPlayer]++
 		p.appendLog(highPlayer, "score_high",
-			fmt.Sprintf("%s scores High", p.playerName(highPlayer)), nil)
+			fmt.Sprintf("%s scores High", playerName(p.players, highPlayer)), nil)
 	}
 	if lowPlayer >= 0 {
 		points[lowPlayer]++
 		p.appendLog(lowPlayer, "score_low",
-			fmt.Sprintf("%s scores Low", p.playerName(lowPlayer)), nil)
+			fmt.Sprintf("%s scores Low", playerName(p.players, lowPlayer)), nil)
 	}
 	if jackPlayer >= 0 {
 		points[jackPlayer]++
 		p.appendLog(jackPlayer, "score_jack",
-			fmt.Sprintf("%s scores Jack", p.playerName(jackPlayer)), nil)
+			fmt.Sprintf("%s scores Jack", playerName(p.players, jackPlayer)), nil)
 	}
 	// Game ポイント: 全カードのピップ値合計, 最大が単独なら +1
 	gameTotals := make([]int, PitchPlayerCnt)
@@ -608,7 +608,7 @@ func (p *Pitch) computeRoundPoints() []int {
 	if !tied && gameWinner >= 0 && maxTotal > 0 {
 		points[gameWinner]++
 		p.appendLog(gameWinner, "score_game",
-			fmt.Sprintf("%s scores Game (%d pip)", p.playerName(gameWinner), maxTotal), nil)
+			fmt.Sprintf("%s scores Game (%d pip)", playerName(p.players, gameWinner), maxTotal), nil)
 	}
 	return points
 }
@@ -622,7 +622,7 @@ func (p *Pitch) checkGameEnd() {
 		p.phase = PitchPhaseGameEnd
 		p.winnerIdx = bidder
 		p.appendLog(-1, "game_end",
-			fmt.Sprintf("%s wins the game!", p.playerName(p.winnerIdx)), nil)
+			fmt.Sprintf("%s wins the game!", playerName(p.players, p.winnerIdx)), nil)
 		return
 	}
 	maxScore := -1 << 30
@@ -645,7 +645,7 @@ func (p *Pitch) checkGameEnd() {
 	p.phase = PitchPhaseGameEnd
 	p.winnerIdx = winner
 	p.appendLog(-1, "game_end",
-		fmt.Sprintf("%s wins the game!", p.playerName(p.winnerIdx)), nil)
+		fmt.Sprintf("%s wins the game!", playerName(p.players, p.winnerIdx)), nil)
 }
 
 // --- State getters / setters ---
@@ -775,16 +775,6 @@ func pitchSortHand(pl *PitchPlayer) {
 		}
 		return pitchRankValue(ci.GetValue()) < pitchRankValue(cj.GetValue())
 	})
-}
-
-func (p *Pitch) playerName(idx int) string {
-	if idx < 0 || idx >= len(p.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if p.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 func (p *Pitch) getValidPlayIndices(playerIdx int) []int {

--- a/internal/domain/Preference.go
+++ b/internal/domain/Preference.go
@@ -247,9 +247,9 @@ func (g *Preference) applyBid(idx int, bid PreferenceBid) error {
 	g.bids[idx] = bid
 	g.bidDone[idx] = true
 	if bid != PreferenceBidPass {
-		g.appendLog(idx, "bid", fmt.Sprintf("%s bids %s", g.playerName(idx), preferenceBidName(bid)), nil)
+		g.appendLog(idx, "bid", fmt.Sprintf("%s bids %s", playerName(g.players, idx), preferenceBidName(bid)), nil)
 	} else {
-		g.appendLog(idx, "bid", fmt.Sprintf("%s passes", g.playerName(idx)), nil)
+		g.appendLog(idx, "bid", fmt.Sprintf("%s passes", playerName(g.players, idx)), nil)
 	}
 	for k := 1; k <= PreferencePlayerCnt; k++ {
 		ni := (idx + k) % PreferencePlayerCnt
@@ -279,7 +279,7 @@ func (g *Preference) resolveBidding() {
 		g.trumpSuit = g.longestSuit(idx)
 	}
 	g.appendLog(idx, "contract",
-		fmt.Sprintf("%s declares %s (trump %d)", g.playerName(idx), preferenceBidName(bid), g.trumpSuit), nil)
+		fmt.Sprintf("%s declares %s (trump %d)", playerName(g.players, idx), preferenceBidName(bid), g.trumpSuit), nil)
 	g.leadPlayerIdx = (g.dealerIdx + 1) % PreferencePlayerCnt
 	g.currentPlayerIdx = g.leadPlayerIdx
 	g.phase = PreferencePhasePlay
@@ -382,7 +382,7 @@ func (g *Preference) CpuPlay() {
 // playCard カードをプレイする共通処理。
 func (g *Preference) playCard(playerIdx int, card *Card) {
 	g.currentTrick = append(g.currentTrick, &TrickCard{PlayerIdx: playerIdx, Card: card})
-	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", g.playerName(playerIdx), cardStr(card)), []*Card{card})
+	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", playerName(g.players, playerIdx), cardStr(card)), []*Card{card})
 
 	if len(g.currentTrick) == PreferencePlayerCnt {
 		g.phase = PreferencePhaseTrickEnd
@@ -404,7 +404,7 @@ func (g *Preference) ResolveTrick() {
 	g.players[winnerIdx].AddTrick(trickCards)
 	g.roundTricks[winnerIdx]++
 	g.appendLog(winnerIdx, "trick_win",
-		fmt.Sprintf("%s wins trick %d", g.playerName(winnerIdx), g.trickNumber), trickCards)
+		fmt.Sprintf("%s wins trick %d", playerName(g.players, winnerIdx), g.trickNumber), trickCards)
 
 	g.leadPlayerIdx = winnerIdx
 	if g.trickNumber >= PreferenceTrickCount {
@@ -473,7 +473,7 @@ func (g *Preference) checkGameEnd() {
 		g.gameEndFlag = true
 		g.winnerPlayer = leader
 		g.phase = PreferencePhaseGameEnd
-		g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the match!", g.playerName(leader)), nil)
+		g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the match!", playerName(g.players, leader)), nil)
 	}
 }
 
@@ -576,17 +576,6 @@ func preferenceSortHand(p *PreferencePlayer) {
 	for _, c := range cards {
 		p.AddCard(c)
 	}
-}
-
-// playerName プレイヤー名を返す。
-func (g *Preference) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // indexOfPlayerInTrick currentTrick 内で playerIdx の札の位置を返す (-1=なし)。

--- a/internal/domain/Primero.go
+++ b/internal/domain/Primero.go
@@ -334,7 +334,7 @@ func (g *Primero) applyCall(idx int) {
 	}
 	g.state.actedSinceRaise++
 	g.state.actionCount++
-	g.appendLog(idx, "call", fmt.Sprintf("%s calls %d (pot %d)", g.playerName(idx), need, g.state.pot), nil)
+	g.appendLog(idx, "call", fmt.Sprintf("%s calls %d (pot %d)", playerName(g.players, idx), need, g.state.pot), nil)
 	g.advanceOrClose(idx)
 }
 
@@ -356,7 +356,7 @@ func (g *Primero) applyRaise(idx int) {
 	// レイズ後は本人を含め 1 人がアクション済み。他のアクティブは応答が必要。
 	g.state.actedSinceRaise = 1
 	g.state.actionCount++
-	g.appendLog(idx, "raise", fmt.Sprintf("%s raises to %d, pays %d (pot %d)", g.playerName(idx), newBet, need, g.state.pot), nil)
+	g.appendLog(idx, "raise", fmt.Sprintf("%s raises to %d, pays %d (pot %d)", playerName(g.players, idx), newBet, need, g.state.pot), nil)
 	g.advanceOrClose(idx)
 }
 
@@ -364,7 +364,7 @@ func (g *Primero) applyRaise(idx int) {
 func (g *Primero) applyFold(idx int) {
 	g.players[idx].SetFolded(true)
 	g.state.actionCount++
-	g.appendLog(idx, "fold", fmt.Sprintf("%s folds", g.playerName(idx)), nil)
+	g.appendLog(idx, "fold", fmt.Sprintf("%s folds", playerName(g.players, idx)), nil)
 	g.advanceOrClose(idx)
 }
 
@@ -399,7 +399,7 @@ func (g *Primero) resolveRound() {
 	if winner >= 0 {
 		g.players[winner].AddChips(g.state.pot)
 		g.appendLog(winner, "win",
-			fmt.Sprintf("%s wins the pot (%d)", g.playerName(winner), g.state.pot), nil)
+			fmt.Sprintf("%s wins the pot (%d)", playerName(g.players, winner), g.state.pot), nil)
 	}
 	g.setHumanResult(winner)
 	g.state.pot = 0
@@ -436,7 +436,7 @@ func (g *Primero) endGame() {
 	g.state.phase = PrimeroPhaseResult
 	g.state.matchWinnerIdx = g.richestIdx()
 	g.appendLog(g.state.matchWinnerIdx, "game_end",
-		fmt.Sprintf("%s wins the game", g.playerName(g.state.matchWinnerIdx)), nil)
+		fmt.Sprintf("%s wins the game", playerName(g.players, g.state.matchWinnerIdx)), nil)
 }
 
 // --- CPU ---
@@ -683,17 +683,6 @@ func (g *Primero) richestIdx() int {
 		}
 	}
 	return best
-}
-
-// playerName は表示用のプレイヤー名を返す。
-func (g *Primero) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 func (g *Primero) appendLog(playerIdx int, actionType, detail string, cards []*Card) {

--- a/internal/domain/Prsi.go
+++ b/internal/domain/Prsi.go
@@ -305,7 +305,7 @@ func (g *Prsi) isValidPlay(card *Card) bool {
 func (g *Prsi) playCard(playerIdx int, card *Card) {
 	g.discardPile = append(g.discardPile, card)
 
-	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", g.playerName(playerIdx), cardStr(card)), []*Card{card})
+	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", playerName(g.players, playerIdx), cardStr(card)), []*Card{card})
 
 	// アクションカードの状態更新
 	switch card.GetValue() {
@@ -326,7 +326,7 @@ func (g *Prsi) playCard(playerIdx int, card *Card) {
 		g.winnerIdx = playerIdx
 		g.gameEndFlag = true
 		g.phase = PrsiPhaseGameEnd
-		g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game!", g.playerName(playerIdx)), nil)
+		g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game!", playerName(g.players, playerIdx)), nil)
 		return
 	}
 
@@ -345,7 +345,7 @@ func (g *Prsi) advanceTurn() {
 func (g *Prsi) drawCard(playerIdx int) error {
 	if g.penaltyDrawCount > 0 {
 		drawn := g.drawCards(playerIdx, g.penaltyDrawCount)
-		g.appendLog(playerIdx, "take_penalty", fmt.Sprintf("%s takes %d penalty cards", g.playerName(playerIdx), drawn), nil)
+		g.appendLog(playerIdx, "take_penalty", fmt.Sprintf("%s takes %d penalty cards", playerName(g.players, playerIdx), drawn), nil)
 		g.penaltyDrawCount = 0
 		g.sortHand(playerIdx)
 		g.advanceTurn()
@@ -358,7 +358,7 @@ func (g *Prsi) drawCard(playerIdx int) error {
 
 	if len(g.drawPile) == 0 {
 		// 引けるカードがない→パス
-		g.appendLog(playerIdx, "pass", fmt.Sprintf("%s passes (no cards to draw)", g.playerName(playerIdx)), nil)
+		g.appendLog(playerIdx, "pass", fmt.Sprintf("%s passes (no cards to draw)", playerName(g.players, playerIdx)), nil)
 		g.advanceTurn()
 		return nil
 	}
@@ -368,7 +368,7 @@ func (g *Prsi) drawCard(playerIdx int) error {
 	g.players[playerIdx].AddCard(card)
 	g.sortHand(playerIdx)
 
-	g.appendLog(playerIdx, "draw", fmt.Sprintf("%s draws a card", g.playerName(playerIdx)), nil)
+	g.appendLog(playerIdx, "draw", fmt.Sprintf("%s draws a card", playerName(g.players, playerIdx)), nil)
 
 	// プルシーでは引いたら手番終了 (引いたカードを即座に出すことはできない)
 	g.advanceTurn()
@@ -446,17 +446,6 @@ func (g *Prsi) sortHand(playerIdx int) {
 		}
 		return ci.GetValue() < cj.GetValue()
 	})
-}
-
-// playerName プレイヤー名を返す
-func (g *Prsi) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // --- CPU AI ---

--- a/internal/domain/Rook.go
+++ b/internal/domain/Rook.go
@@ -291,7 +291,7 @@ func (g *Rook) applyBid(idx, bid int) {
 	g.players[idx].SetBid(bid)
 	g.highestBid = bid
 	g.highestBidder = idx
-	g.appendLog(idx, "bid", fmt.Sprintf("%s bids %d", g.playerName(idx), bid), nil)
+	g.appendLog(idx, "bid", fmt.Sprintf("%s bids %d", playerName(g.players, idx), bid), nil)
 	g.advanceBid()
 }
 
@@ -299,7 +299,7 @@ func (g *Rook) applyBid(idx, bid int) {
 func (g *Rook) applyPass(idx int) {
 	g.passed[idx] = true
 	g.players[idx].SetPassed(true)
-	g.appendLog(idx, "pass", fmt.Sprintf("%s passes", g.playerName(idx)), nil)
+	g.appendLog(idx, "pass", fmt.Sprintf("%s passes", playerName(g.players, idx)), nil)
 	g.advanceBid()
 }
 
@@ -350,7 +350,7 @@ func (g *Rook) finalizeBid() {
 	}
 	g.nest = nil
 	g.appendLog(g.declarerIdx, "win_bid",
-		fmt.Sprintf("%s wins the auction for %d", g.playerName(g.declarerIdx), g.contractBid), nil)
+		fmt.Sprintf("%s wins the auction for %d", playerName(g.players, g.declarerIdx), g.contractBid), nil)
 	g.sortAllHands()
 	g.phase = RookPhaseNestExchange
 	g.currentPlayerIdx = g.declarerIdx
@@ -413,7 +413,7 @@ func (g *Rook) doExchange(discardIndices []int, trumpColor int) error {
 	}
 	g.trumpColor = trumpColor
 	g.appendLog(g.declarerIdx, "exchange",
-		fmt.Sprintf("%s discards %d cards, trump=%s", g.playerName(g.declarerIdx), len(discarded), rookColorName(trumpColor)), discarded)
+		fmt.Sprintf("%s discards %d cards, trump=%s", playerName(g.players, g.declarerIdx), len(discarded), rookColorName(trumpColor)), discarded)
 	g.sortAllHands()
 	g.startPlayPhase()
 	return nil
@@ -477,7 +477,7 @@ func (g *Rook) CpuPlay() {
 func (g *Rook) playCard(playerIdx int, card *Card) {
 	g.currentTrick = append(g.currentTrick, &TrickCard{PlayerIdx: playerIdx, Card: card})
 	g.appendLog(playerIdx, "play",
-		fmt.Sprintf("%s plays %s", g.playerName(playerIdx), rookCardLabel(card)), []*Card{card})
+		fmt.Sprintf("%s plays %s", playerName(g.players, playerIdx), rookCardLabel(card)), []*Card{card})
 	if len(g.currentTrick) == RookPlayerCnt {
 		g.phase = RookPhaseTrickEnd
 	} else {
@@ -503,13 +503,13 @@ func (g *Rook) ResolveTrick() {
 	if g.trickNumber >= RookTrickCnt {
 		g.players[winnerIdx].AddPoints(g.nestPoints)
 		g.appendLog(winnerIdx, "trick_win",
-			fmt.Sprintf("%s wins the last trick %d (+%d nest)", g.playerName(winnerIdx), g.trickNumber, g.nestPoints), cards)
+			fmt.Sprintf("%s wins the last trick %d (+%d nest)", playerName(g.players, winnerIdx), g.trickNumber, g.nestPoints), cards)
 		g.leadPlayerIdx = winnerIdx
 		g.phase = RookPhaseRoundEnd
 		return
 	}
 	g.appendLog(winnerIdx, "trick_win",
-		fmt.Sprintf("%s wins trick %d (+%d)", g.playerName(winnerIdx), g.trickNumber, trickPts), cards)
+		fmt.Sprintf("%s wins trick %d (+%d)", playerName(g.players, winnerIdx), g.trickNumber, trickPts), cards)
 	g.leadPlayerIdx = winnerIdx
 	g.phase = RookPhaseTrickEnd
 }
@@ -1195,17 +1195,6 @@ func (g *Rook) sortHand(p *RookPlayer) {
 	for _, c := range cards {
 		p.AddCard(c)
 	}
-}
-
-// playerName プレイヤー名を返す
-func (g *Rook) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // rookColorName 色番号を英字ラベルにする (ログ用)

--- a/internal/domain/Rummy500.go
+++ b/internal/domain/Rummy500.go
@@ -180,7 +180,7 @@ func (g *Rummy500) PlayerDrawFromStock() error {
 	g.players[g.currentPlayerIdx].AddCard(card)
 	g.sortHand(g.currentPlayerIdx)
 
-	g.appendLog(g.currentPlayerIdx, "draw_stock", fmt.Sprintf("%s draws from stock", g.playerName(g.currentPlayerIdx)), nil)
+	g.appendLog(g.currentPlayerIdx, "draw_stock", fmt.Sprintf("%s draws from stock", playerName(g.players, g.currentPlayerIdx)), nil)
 
 	g.phase = Rummy500PhasePlay
 	return nil
@@ -216,7 +216,7 @@ func (g *Rummy500) PlayerDrawFromDiscard(idx int) error {
 	g.sortHand(g.currentPlayerIdx)
 
 	first := taken[0]
-	detail := fmt.Sprintf("%s draws %s from discard (+%d card(s))", g.playerName(g.currentPlayerIdx), cardStr(first), len(taken)-1)
+	detail := fmt.Sprintf("%s draws %s from discard (+%d card(s))", playerName(g.players, g.currentPlayerIdx), cardStr(first), len(taken)-1)
 	g.appendLog(g.currentPlayerIdx, "draw_discard", detail, taken)
 
 	g.phase = Rummy500PhasePlay
@@ -277,7 +277,7 @@ func (g *Rummy500) executeMeld(playerIdx int, cardIndices []int) error {
 	cardsCopy := make([]*Card, len(meld))
 	copy(cardsCopy, meld)
 	g.appendLog(playerIdx, "meld",
-		fmt.Sprintf("%s melds %s", g.playerName(playerIdx), formatCards(meld)), cardsCopy)
+		fmt.Sprintf("%s melds %s", playerName(g.players, playerIdx), formatCards(meld)), cardsCopy)
 
 	return nil
 }
@@ -320,7 +320,7 @@ func (g *Rummy500) executeLayoff(playerIdx, meldOwner, meldIdx, cardIndex int) e
 	player.RemoveCard(cardIndex)
 
 	g.appendLog(playerIdx, "layoff",
-		fmt.Sprintf("%s lays off %s", g.playerName(playerIdx), cardStr(card)), []*Card{card})
+		fmt.Sprintf("%s lays off %s", playerName(g.players, playerIdx), cardStr(card)), []*Card{card})
 	return nil
 }
 
@@ -345,13 +345,13 @@ func (g *Rummy500) PlayerDiscard(cardIndex int) error {
 	g.discardPile = append(g.discardPile, discarded)
 
 	g.appendLog(g.currentPlayerIdx, "discard",
-		fmt.Sprintf("%s discards %s", g.playerName(g.currentPlayerIdx), cardStr(discarded)), []*Card{discarded})
+		fmt.Sprintf("%s discards %s", playerName(g.players, g.currentPlayerIdx), cardStr(discarded)), []*Card{discarded})
 
 	if player.GetCardsSize() == 0 {
 		// あがり
 		g.roundEnderIdx = g.currentPlayerIdx
 		g.appendLog(g.currentPlayerIdx, "go_out",
-			fmt.Sprintf("%s goes out!", g.playerName(g.currentPlayerIdx)), nil)
+			fmt.Sprintf("%s goes out!", playerName(g.players, g.currentPlayerIdx)), nil)
 		g.scoreRound()
 		return nil
 	}
@@ -385,7 +385,7 @@ func (g *Rummy500) cpuDraw() {
 		g.drawPile = g.drawPile[:len(g.drawPile)-1]
 		g.players[g.currentPlayerIdx].AddCard(card)
 		g.sortHand(g.currentPlayerIdx)
-		g.appendLog(g.currentPlayerIdx, "draw_stock", fmt.Sprintf("%s draws from stock", g.playerName(g.currentPlayerIdx)), nil)
+		g.appendLog(g.currentPlayerIdx, "draw_stock", fmt.Sprintf("%s draws from stock", playerName(g.players, g.currentPlayerIdx)), nil)
 		g.phase = Rummy500PhasePlay
 		return
 	}
@@ -396,7 +396,7 @@ func (g *Rummy500) cpuDraw() {
 		g.players[g.currentPlayerIdx].AddCard(top)
 		g.sortHand(g.currentPlayerIdx)
 		g.appendLog(g.currentPlayerIdx, "draw_discard",
-			fmt.Sprintf("%s draws %s from discard", g.playerName(g.currentPlayerIdx), cardStr(top)), []*Card{top})
+			fmt.Sprintf("%s draws %s from discard", playerName(g.players, g.currentPlayerIdx), cardStr(top)), []*Card{top})
 		g.phase = Rummy500PhasePlay
 		return
 	}
@@ -429,7 +429,7 @@ func (g *Rummy500) cpuPlayMelds() {
 		// → ラウンド終了（あがり扱い）
 		g.roundEnderIdx = idx
 		g.appendLog(idx, "go_out",
-			fmt.Sprintf("%s goes out!", g.playerName(idx)), nil)
+			fmt.Sprintf("%s goes out!", playerName(g.players, idx)), nil)
 		g.scoreRound()
 		return
 	}
@@ -439,12 +439,12 @@ func (g *Rummy500) cpuPlayMelds() {
 	discarded := player.RemoveCard(discardIdx)
 	g.discardPile = append(g.discardPile, discarded)
 	g.appendLog(idx, "discard",
-		fmt.Sprintf("%s discards %s", g.playerName(idx), cardStr(discarded)), []*Card{discarded})
+		fmt.Sprintf("%s discards %s", playerName(g.players, idx), cardStr(discarded)), []*Card{discarded})
 
 	if player.GetCardsSize() == 0 {
 		g.roundEnderIdx = idx
 		g.appendLog(idx, "go_out",
-			fmt.Sprintf("%s goes out!", g.playerName(idx)), nil)
+			fmt.Sprintf("%s goes out!", playerName(g.players, idx)), nil)
 		g.scoreRound()
 		return
 	}
@@ -533,7 +533,7 @@ func (g *Rummy500) scoreRound() {
 		round := meldScore - handPenalty
 		p.SetRoundScore(round)
 		g.appendLog(i, "score",
-			fmt.Sprintf("%s scores %d (melds %d - hand %d)", g.playerName(i), round, meldScore, handPenalty), nil)
+			fmt.Sprintf("%s scores %d (melds %d - hand %d)", playerName(g.players, i), round, meldScore, handPenalty), nil)
 	}
 
 	for i := range g.players {
@@ -588,7 +588,7 @@ func (g *Rummy500) checkGameEnd() {
 			g.winnerIdx = i
 		}
 	}
-	g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game!", g.playerName(g.winnerIdx)), nil)
+	g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game!", playerName(g.players, g.winnerIdx)), nil)
 }
 
 // --- State getters ---
@@ -681,16 +681,6 @@ func (g *Rummy500) sortHand(playerIdx int) {
 		}
 		return ci.GetValue() < cj.GetValue()
 	})
-}
-
-func (g *Rummy500) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // --- Meld / Run / Set / Layoff helpers ---

--- a/internal/domain/Samba.go
+++ b/internal/domain/Samba.go
@@ -216,7 +216,7 @@ func (g *Samba) autoLayRed3s(playerIdx int) {
 			if SambaIsRed3(card) {
 				player.RemoveCard(i)
 				player.AddRed3(card)
-				g.appendLog(playerIdx, "red3", fmt.Sprintf("%s lays down red 3: %s", g.playerName(playerIdx), cardStr(card)), []*Card{card})
+				g.appendLog(playerIdx, "red3", fmt.Sprintf("%s lays down red 3: %s", playerName(g.players, playerIdx), cardStr(card)), []*Card{card})
 				if len(g.drawPile) > 0 {
 					replacement := g.drawPile[len(g.drawPile)-1]
 					g.drawPile = g.drawPile[:len(g.drawPile)-1]
@@ -269,7 +269,7 @@ func (g *Samba) PlayerDrawFromStock() error {
 	g.drawPile = g.drawPile[:len(g.drawPile)-1]
 	g.players[g.currentPlayerIdx].AddCard(card)
 
-	g.appendLog(g.currentPlayerIdx, "draw_stock", fmt.Sprintf("%s draws from stock", g.playerName(g.currentPlayerIdx)), nil)
+	g.appendLog(g.currentPlayerIdx, "draw_stock", fmt.Sprintf("%s draws from stock", playerName(g.players, g.currentPlayerIdx)), nil)
 
 	if SambaIsRed3(card) {
 		g.autoLayRed3s(g.currentPlayerIdx)
@@ -355,7 +355,7 @@ func (g *Samba) PlayerDrawFromDiscard(naturalPairIndices []int) error {
 	g.discardPile = nil
 	g.isFrozen = false
 
-	g.appendLog(g.currentPlayerIdx, "draw_discard", fmt.Sprintf("%s picks up the discard pile (%d cards)", g.playerName(g.currentPlayerIdx), pileSize), []*Card{topCard})
+	g.appendLog(g.currentPlayerIdx, "draw_discard", fmt.Sprintf("%s picks up the discard pile (%d cards)", playerName(g.players, g.currentPlayerIdx), pileSize), []*Card{topCard})
 
 	g.autoLayRed3s(g.currentPlayerIdx)
 	g.sortHand(g.currentPlayerIdx)
@@ -550,7 +550,7 @@ func (g *Samba) applyResolvedMeld(playerIdx int, res sambaMeldResolution, cards 
 		}
 		meld := &SambaMeld{Cards: cards, Kind: res.kind, IsNatural: isNatural}
 		player.AddMeld(meld)
-		g.appendLog(playerIdx, "meld", fmt.Sprintf("%s melds a %s of %d cards", g.playerName(playerIdx), sambaMeldKindStr(res.kind), len(cards)), cards)
+		g.appendLog(playerIdx, "meld", fmt.Sprintf("%s melds a %s of %d cards", playerName(g.players, playerIdx), sambaMeldKindStr(res.kind), len(cards)), cards)
 		return
 	}
 	existing := player.melds[res.existingIdx]
@@ -560,7 +560,7 @@ func (g *Samba) applyResolvedMeld(playerIdx int, res sambaMeldResolution, cards 
 			existing.IsNatural = false
 		}
 	}
-	g.appendLog(playerIdx, "meld_add", fmt.Sprintf("%s adds %d cards to a %s meld", g.playerName(playerIdx), len(cards), sambaMeldKindStr(existing.Kind)), cards)
+	g.appendLog(playerIdx, "meld_add", fmt.Sprintf("%s adds %d cards to a %s meld", playerName(g.players, playerIdx), len(cards), sambaMeldKindStr(existing.Kind)), cards)
 }
 
 // logCompletedMelds 完成したカナスタ/サンバをログに記録する
@@ -568,9 +568,9 @@ func (g *Samba) logCompletedMelds(playerIdx int) {
 	player := g.players[playerIdx]
 	for _, m := range player.melds {
 		if m.IsSamba() {
-			g.appendLog(playerIdx, "samba", fmt.Sprintf("%s completes a samba!", g.playerName(playerIdx)), nil)
+			g.appendLog(playerIdx, "samba", fmt.Sprintf("%s completes a samba!", playerName(g.players, playerIdx)), nil)
 		} else if m.IsCanasta() {
-			g.appendLog(playerIdx, "canasta", fmt.Sprintf("%s completes a %s canasta!", g.playerName(playerIdx), sambaCanastaTypeStr(m.IsNatural)), nil)
+			g.appendLog(playerIdx, "canasta", fmt.Sprintf("%s completes a %s canasta!", playerName(g.players, playerIdx), sambaCanastaTypeStr(m.IsNatural)), nil)
 		}
 	}
 }
@@ -623,7 +623,7 @@ func (g *Samba) PlayerDiscard(cardIndex int) error {
 		g.isFrozen = true
 	}
 
-	g.appendLog(g.currentPlayerIdx, "discard", fmt.Sprintf("%s discards %s", g.playerName(g.currentPlayerIdx), cardStr(discarded)), []*Card{discarded})
+	g.appendLog(g.currentPlayerIdx, "discard", fmt.Sprintf("%s discards %s", playerName(g.players, g.currentPlayerIdx), cardStr(discarded)), []*Card{discarded})
 
 	g.advanceTurn()
 	return nil
@@ -657,7 +657,7 @@ func (g *Samba) PlayerGoOut() error {
 		if SambaIsWild(discarded) {
 			g.isFrozen = true
 		}
-		g.appendLog(g.currentPlayerIdx, "discard", fmt.Sprintf("%s discards %s", g.playerName(g.currentPlayerIdx), cardStr(discarded)), []*Card{discarded})
+		g.appendLog(g.currentPlayerIdx, "discard", fmt.Sprintf("%s discards %s", playerName(g.players, g.currentPlayerIdx), cardStr(discarded)), []*Card{discarded})
 	} else if player.GetCardsSize() > 1 {
 		return NewDomainError(ErrInvalidPlay, "上がるには手札が0枚または1枚でなければなりません")
 	}
@@ -669,7 +669,7 @@ func (g *Samba) PlayerGoOut() error {
 // goOut 上がり処理
 func (g *Samba) goOut(playerIdx int) {
 	bonus := SambaGoingOutBonus
-	g.appendLog(playerIdx, "go_out", fmt.Sprintf("%s goes out! (bonus: %d)", g.playerName(playerIdx), bonus), nil)
+	g.appendLog(playerIdx, "go_out", fmt.Sprintf("%s goes out! (bonus: %d)", playerName(g.players, playerIdx), bonus), nil)
 	g.scoreRound(playerIdx, bonus)
 }
 
@@ -727,7 +727,7 @@ func (g *Samba) cpuDraw() {
 						pileSize := len(g.discardPile)
 						g.discardPile = nil
 						g.isFrozen = false
-						g.appendLog(g.currentPlayerIdx, "draw_discard", fmt.Sprintf("%s picks up the discard pile (%d cards)", g.playerName(g.currentPlayerIdx), pileSize), []*Card{topCard})
+						g.appendLog(g.currentPlayerIdx, "draw_discard", fmt.Sprintf("%s picks up the discard pile (%d cards)", playerName(g.players, g.currentPlayerIdx), pileSize), []*Card{topCard})
 						g.autoLayRed3s(g.currentPlayerIdx)
 						g.sortHand(g.currentPlayerIdx)
 						g.phase = SambaPhaseMeld
@@ -746,7 +746,7 @@ func (g *Samba) cpuDraw() {
 	card := g.drawPile[len(g.drawPile)-1]
 	g.drawPile = g.drawPile[:len(g.drawPile)-1]
 	player.AddCard(card)
-	g.appendLog(g.currentPlayerIdx, "draw_stock", fmt.Sprintf("%s draws from stock", g.playerName(g.currentPlayerIdx)), nil)
+	g.appendLog(g.currentPlayerIdx, "draw_stock", fmt.Sprintf("%s draws from stock", playerName(g.players, g.currentPlayerIdx)), nil)
 
 	if SambaIsRed3(card) {
 		g.autoLayRed3s(g.currentPlayerIdx)
@@ -806,7 +806,7 @@ func (g *Samba) cpuMeld() {
 					existing.IsNatural = false
 				}
 			}
-			g.appendLog(g.currentPlayerIdx, "meld_add", fmt.Sprintf("%s adds %d cards to a %s meld", g.playerName(g.currentPlayerIdx), len(grp.cards), sambaMeldKindStr(existing.Kind)), grp.cards)
+			g.appendLog(g.currentPlayerIdx, "meld_add", fmt.Sprintf("%s adds %d cards to a %s meld", playerName(g.players, g.currentPlayerIdx), len(grp.cards), sambaMeldKindStr(existing.Kind)), grp.cards)
 		} else {
 			isNatural := true
 			for _, c := range grp.cards {
@@ -817,7 +817,7 @@ func (g *Samba) cpuMeld() {
 			}
 			meld := &SambaMeld{Cards: grp.cards, Kind: grp.kind, IsNatural: isNatural}
 			player.AddMeld(meld)
-			g.appendLog(g.currentPlayerIdx, "meld", fmt.Sprintf("%s melds a %s of %d cards", g.playerName(g.currentPlayerIdx), sambaMeldKindStr(grp.kind), len(grp.cards)), grp.cards)
+			g.appendLog(g.currentPlayerIdx, "meld", fmt.Sprintf("%s melds a %s of %d cards", playerName(g.players, g.currentPlayerIdx), sambaMeldKindStr(grp.kind), len(grp.cards)), grp.cards)
 		}
 
 		for _, c := range grp.cards {
@@ -865,7 +865,7 @@ func (g *Samba) cpuDiscard() {
 			if SambaIsWild(discarded) {
 				g.isFrozen = true
 			}
-			g.appendLog(g.currentPlayerIdx, "discard", fmt.Sprintf("%s discards %s", g.playerName(g.currentPlayerIdx), cardStr(discarded)), []*Card{discarded})
+			g.appendLog(g.currentPlayerIdx, "discard", fmt.Sprintf("%s discards %s", playerName(g.players, g.currentPlayerIdx), cardStr(discarded)), []*Card{discarded})
 			g.goOut(g.currentPlayerIdx)
 			return
 		}
@@ -879,7 +879,7 @@ func (g *Samba) cpuDiscard() {
 		g.isFrozen = true
 	}
 
-	g.appendLog(g.currentPlayerIdx, "discard", fmt.Sprintf("%s discards %s", g.playerName(g.currentPlayerIdx), cardStr(discarded)), []*Card{discarded})
+	g.appendLog(g.currentPlayerIdx, "discard", fmt.Sprintf("%s discards %s", playerName(g.players, g.currentPlayerIdx), cardStr(discarded)), []*Card{discarded})
 	g.advanceTurn()
 }
 
@@ -1205,7 +1205,7 @@ func (g *Samba) scoreRound(goOutPlayerIdx int, goOutBonus int) {
 			team = i % SambaTeamCnt
 		}
 		teamRound[team] += score
-		g.appendLog(i, "score", fmt.Sprintf("%s contributes %d points to team %d", g.playerName(i), score, team), nil)
+		g.appendLog(i, "score", fmt.Sprintf("%s contributes %d points to team %d", playerName(g.players, i), score, team), nil)
 	}
 
 	for t := 0; t < SambaTeamCnt; t++ {
@@ -1638,17 +1638,6 @@ func (g *Samba) sortHand(playerIdx int) {
 		}
 		return ci.GetValue() < cj.GetValue()
 	})
-}
-
-// playerName プレイヤー名を返す
-func (g *Samba) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // --- JSON serialization ---

--- a/internal/domain/Scarto.go
+++ b/internal/domain/Scarto.go
@@ -339,7 +339,7 @@ func (g *Scarto) doScarto(cardIndices []int) error {
 	discarded := player.RemoveCards(cardIndices)
 	g.scarto = discarded
 	g.appendLog(g.dealerIdx, "scarto",
-		fmt.Sprintf("%s discards %d cards (scarto)", g.playerName(g.dealerIdx), len(discarded)), discarded)
+		fmt.Sprintf("%s discards %d cards (scarto)", playerName(g.players, g.dealerIdx), len(discarded)), discarded)
 	g.sortAllHands()
 	g.startPlay()
 	return nil
@@ -446,7 +446,7 @@ func (g *Scarto) CpuPlay() {
 // playCard カードをプレイする共通処理。
 func (g *Scarto) playCard(playerIdx int, card *Card) {
 	g.currentTrick = append(g.currentTrick, &TrickCard{PlayerIdx: playerIdx, Card: card})
-	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", g.playerName(playerIdx), scartoCardStr(card)), []*Card{card})
+	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", playerName(g.players, playerIdx), scartoCardStr(card)), []*Card{card})
 	if len(g.currentTrick) == ScartoPlayerCnt {
 		g.phase = ScartoPhaseTrickEnd
 	} else {
@@ -482,7 +482,7 @@ func (g *Scarto) ResolveTrick() {
 		g.players[excuseOwner].AddTrick([]*Card{excuseCard})
 	}
 	g.appendLog(winnerIdx, "trick_win",
-		fmt.Sprintf("%s wins trick %d", g.playerName(winnerIdx), g.trickNumber), allCards)
+		fmt.Sprintf("%s wins trick %d", playerName(g.players, winnerIdx), g.trickNumber), allCards)
 
 	g.leadPlayerIdx = winnerIdx
 	if g.trickNumber >= ScartoTrickCount {
@@ -592,7 +592,7 @@ func (g *Scarto) checkGameEnd() {
 		g.appendLog(-1, "game_end", "the match ends in a draw", nil)
 	} else {
 		g.winnerPlayer = leader
-		g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the match!", g.playerName(leader)), nil)
+		g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the match!", playerName(g.players, leader)), nil)
 	}
 }
 
@@ -1094,17 +1094,6 @@ func scartoSortHand(p *ScartoPlayer) {
 	for _, c := range cards {
 		p.AddCard(c)
 	}
-}
-
-// playerName プレイヤー名を返す。
-func (g *Scarto) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // isHumanScartoTurn 現在のスカルト手番が人間 (=人間が親) か。

--- a/internal/domain/Schnapsen.go
+++ b/internal/domain/Schnapsen.go
@@ -263,7 +263,7 @@ func (s *Schnapsen) ResolveTrick() {
 	s.playerPoints[winnerIdx] += trickPoints
 
 	s.appendLog(winnerIdx, "trick_win",
-		fmt.Sprintf("%s wins trick %d (%d pt)", s.playerName(winnerIdx), s.trickNumber, trickPoints),
+		fmt.Sprintf("%s wins trick %d (%d pt)", playerName(s.players, winnerIdx), s.trickNumber, trickPoints),
 		trickCards)
 
 	s.leadPlayerIdx = winnerIdx
@@ -503,7 +503,7 @@ func (s *Schnapsen) declareMarriage(playerIdx, cardIndex int) error {
 	s.marriageDeclared[suit] = true
 	s.playerPoints[playerIdx] += bonus
 	s.appendLog(playerIdx, "marriage",
-		fmt.Sprintf("%s declares marriage in %s (+%d)", s.playerName(playerIdx), suitStr(suit), bonus), nil)
+		fmt.Sprintf("%s declares marriage in %s (+%d)", playerName(s.players, playerIdx), suitStr(suit), bonus), nil)
 
 	// 宣言だけで 66 点に達したら即ラウンド終了 (カードは出さない)
 	if s.playerPoints[playerIdx] >= SchnapsenWinThreshold {
@@ -546,7 +546,7 @@ func (s *Schnapsen) playCard(playerIdx int, card *Card) {
 		Card:      card,
 	})
 	s.appendLog(playerIdx, "play",
-		fmt.Sprintf("%s plays %s", s.playerName(playerIdx), cardStr(card)),
+		fmt.Sprintf("%s plays %s", playerName(s.players, playerIdx), cardStr(card)),
 		[]*Card{card})
 
 	if len(s.currentTrick) == SchnapsenPlayerCnt {
@@ -774,17 +774,6 @@ func (s *Schnapsen) sortHand(p *SchnapsenPlayer) {
 		}
 		return SchnapsenRankOrder(ci) < SchnapsenRankOrder(cj)
 	})
-}
-
-// playerName プレイヤー名を返す (ログ用)
-func (s *Schnapsen) playerName(idx int) string {
-	if idx < 0 || idx >= len(s.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if s.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // playHintReason ヒント理由キーを判定する

--- a/internal/domain/Sedma.go
+++ b/internal/domain/Sedma.go
@@ -195,7 +195,7 @@ func (g *Sedma) CpuPlay() {
 // playCard カードをプレイする共通処理。
 func (g *Sedma) playCard(playerIdx int, card *Card) {
 	g.currentTrick = append(g.currentTrick, &TrickCard{PlayerIdx: playerIdx, Card: card})
-	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", g.playerName(playerIdx), cardStr(card)), []*Card{card})
+	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", playerName(g.players, playerIdx), cardStr(card)), []*Card{card})
 
 	if len(g.currentTrick) == SedmaPlayerCnt {
 		g.phase = SedmaPhaseTrickEnd
@@ -225,7 +225,7 @@ func (g *Sedma) ResolveTrick() {
 		bonus = fmt.Sprintf(" +%d last", SedmaLastTrickBonus)
 	}
 	g.appendLog(winnerIdx, "trick_win",
-		fmt.Sprintf("%s captures trick %d (+%d%s)", g.playerName(winnerIdx), g.trickNumber, pts, bonus), trickCards)
+		fmt.Sprintf("%s captures trick %d (+%d%s)", playerName(g.players, winnerIdx), g.trickNumber, pts, bonus), trickCards)
 
 	g.leadPlayerIdx = winnerIdx
 	if g.trickNumber >= SedmaTrickCount {
@@ -343,17 +343,6 @@ func sedmaSortRank(value int) int {
 		return 14 // Ace high for display
 	}
 	return value
-}
-
-// playerName プレイヤー名を返す。
-func (g *Sedma) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // --- CPU AI ---

--- a/internal/domain/SevenBridge.go
+++ b/internal/domain/SevenBridge.go
@@ -228,7 +228,7 @@ func (g *SevenBridge) drawFromStock() error {
 	g.players[g.currentPlayerIdx].AddCard(card)
 	g.sortHand(g.currentPlayerIdx)
 
-	g.appendLog(g.currentPlayerIdx, "draw_stock", fmt.Sprintf("%s draws from stock", g.playerName(g.currentPlayerIdx)), nil)
+	g.appendLog(g.currentPlayerIdx, "draw_stock", fmt.Sprintf("%s draws from stock", playerName(g.players, g.currentPlayerIdx)), nil)
 	g.claimedThisTurn = false
 	g.phase = SevenBridgePhasePlay
 	return nil
@@ -296,7 +296,7 @@ func (g *SevenBridge) applyPonClaim(cardIndices []int) error {
 		player.RemoveCard(idx)
 	}
 
-	g.appendLog(g.currentPlayerIdx, "pon", fmt.Sprintf("%s calls Pon on %s", g.playerName(g.currentPlayerIdx), cardStr(claimed)), []*Card{claimed, c1, c2})
+	g.appendLog(g.currentPlayerIdx, "pon", fmt.Sprintf("%s calls Pon on %s", playerName(g.players, g.currentPlayerIdx), cardStr(claimed)), []*Card{claimed, c1, c2})
 	g.claimedThisTurn = true
 	if player.GetCardsSize() == 0 {
 		g.finishRound(g.currentPlayerIdx)
@@ -343,7 +343,7 @@ func (g *SevenBridge) applyChiClaim(cardIndices []int) error {
 		player.RemoveCard(idx)
 	}
 
-	g.appendLog(g.currentPlayerIdx, "chi", fmt.Sprintf("%s calls Chi on %s", g.playerName(g.currentPlayerIdx), cardStr(claimed)), []*Card{claimed, c1, c2})
+	g.appendLog(g.currentPlayerIdx, "chi", fmt.Sprintf("%s calls Chi on %s", playerName(g.players, g.currentPlayerIdx), cardStr(claimed)), []*Card{claimed, c1, c2})
 	g.claimedThisTurn = true
 	if player.GetCardsSize() == 0 {
 		g.finishRound(g.currentPlayerIdx)
@@ -402,7 +402,7 @@ func (g *SevenBridge) applyMeld(cardIndices []int) error {
 		player.RemoveCard(idx)
 	}
 
-	g.appendLog(g.currentPlayerIdx, "meld", fmt.Sprintf("%s melds %d cards", g.playerName(g.currentPlayerIdx), len(cards)), cards)
+	g.appendLog(g.currentPlayerIdx, "meld", fmt.Sprintf("%s melds %d cards", playerName(g.players, g.currentPlayerIdx), len(cards)), cards)
 	if player.GetCardsSize() == 0 {
 		g.finishRound(g.currentPlayerIdx)
 	}
@@ -447,7 +447,7 @@ func (g *SevenBridge) applyLayoff(targetPlayerIdx, meldIdx, cardIndex int) error
 	target.AddCardToMeld(meldIdx, card)
 	player.RemoveCard(cardIndex)
 
-	g.appendLog(g.currentPlayerIdx, "layoff", fmt.Sprintf("%s lays off %s", g.playerName(g.currentPlayerIdx), cardStr(card)), []*Card{card})
+	g.appendLog(g.currentPlayerIdx, "layoff", fmt.Sprintf("%s lays off %s", playerName(g.players, g.currentPlayerIdx), cardStr(card)), []*Card{card})
 	if player.GetCardsSize() == 0 {
 		g.finishRound(g.currentPlayerIdx)
 	}
@@ -491,7 +491,7 @@ func (g *SevenBridge) applyDiscard(cardIndex int) error {
 
 	discarded := player.RemoveCard(cardIndex)
 	g.discardPile = append(g.discardPile, discarded)
-	g.appendLog(g.currentPlayerIdx, "discard", fmt.Sprintf("%s discards %s", g.playerName(g.currentPlayerIdx), cardStr(discarded)), []*Card{discarded})
+	g.appendLog(g.currentPlayerIdx, "discard", fmt.Sprintf("%s discards %s", playerName(g.players, g.currentPlayerIdx), cardStr(discarded)), []*Card{discarded})
 
 	// 上がり判定（手札 0）
 	if player.GetCardsSize() == 0 && player.GetMeldCount() > 0 {
@@ -816,7 +816,7 @@ func (g *SevenBridge) finishRound(winnerIdx int) {
 		}
 		// 勝者のラウンドスコア = 相手のペナルティ
 		g.players[winnerIdx].SetRoundScore(loserTotal)
-		g.appendLog(winnerIdx, "round_win", fmt.Sprintf("%s goes out! Opponent penalty: %d", g.playerName(winnerIdx), loserTotal), nil)
+		g.appendLog(winnerIdx, "round_win", fmt.Sprintf("%s goes out! Opponent penalty: %d", playerName(g.players, winnerIdx), loserTotal), nil)
 	} else {
 		g.appendLog(-1, "draw", "Round ends in a draw (stock empty)", nil)
 	}
@@ -859,7 +859,7 @@ func (g *SevenBridge) checkGameEnd() {
 			g.winnerIdx = i
 		}
 	}
-	g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game!", g.playerName(g.winnerIdx)), nil)
+	g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game!", playerName(g.players, g.winnerIdx)), nil)
 }
 
 // hasAnyLegalDiscard 手札に top に対して合法な捨て札があるか
@@ -967,16 +967,6 @@ func (g *SevenBridge) sortHand(playerIdx int) {
 		}
 		return ci.GetValue() < cj.GetValue()
 	})
-}
-
-func (g *SevenBridge) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // --- Pure helpers ---

--- a/internal/domain/Sheepshead.go
+++ b/internal/domain/Sheepshead.go
@@ -215,7 +215,7 @@ func (g *Sheepshead) resolvePick(playerIdx int, pick bool) {
 		return
 	}
 	g.passCount++
-	g.appendLog(playerIdx, "pass", fmt.Sprintf("%s passes", g.playerName(playerIdx)), nil)
+	g.appendLog(playerIdx, "pass", fmt.Sprintf("%s passes", playerName(g.players, playerIdx)), nil)
 	g.currentPlayerIdx = (g.currentPlayerIdx + 1) % SheepsheadPlayerCnt
 }
 
@@ -228,7 +228,7 @@ func (g *Sheepshead) becomePicker(playerIdx int) {
 	}
 	g.blind = nil
 	sheepsheadSortHand(picker)
-	g.appendLog(playerIdx, "pick", fmt.Sprintf("%s picks up the blind", g.playerName(playerIdx)), nil)
+	g.appendLog(playerIdx, "pick", fmt.Sprintf("%s picks up the blind", playerName(g.players, playerIdx)), nil)
 	g.currentPlayerIdx = playerIdx
 	g.phase = SheepsheadPhaseBury
 }
@@ -274,12 +274,12 @@ func (g *Sheepshead) validateBury(indices []int) error {
 func (g *Sheepshead) applyBury(indices []int) {
 	picker := g.players[g.pickerIdx]
 	g.buried = picker.RemoveCards(indices)
-	g.appendLog(g.pickerIdx, "bury", fmt.Sprintf("%s buries %d cards", g.playerName(g.pickerIdx), len(g.buried)), nil)
+	g.appendLog(g.pickerIdx, "bury", fmt.Sprintf("%s buries %d cards", playerName(g.players, g.pickerIdx), len(g.buried)), nil)
 
 	if len(g.callableSuits()) == 0 {
 		// 呼べる札がない: ピッカーは単独で戦う。
 		g.partnerIdx = -1
-		g.appendLog(g.pickerIdx, "alone", fmt.Sprintf("%s plays alone", g.playerName(g.pickerIdx)), nil)
+		g.appendLog(g.pickerIdx, "alone", fmt.Sprintf("%s plays alone", playerName(g.players, g.pickerIdx)), nil)
 		g.beginPlay()
 		return
 	}
@@ -309,7 +309,7 @@ func (g *Sheepshead) applyCall(suit int) {
 	g.calledSuit = suit
 	g.partnerIdx = g.holderOfCalledAce(suit)
 	g.appendLog(g.pickerIdx, "call",
-		fmt.Sprintf("%s calls the %s Ace", g.playerName(g.pickerIdx), suitStr(suit)), nil)
+		fmt.Sprintf("%s calls the %s Ace", playerName(g.players, g.pickerIdx), suitStr(suit)), nil)
 	g.beginPlay()
 }
 
@@ -390,14 +390,14 @@ func (g *Sheepshead) CpuPlay() {
 // playCard カードをプレイする共通処理。
 func (g *Sheepshead) playCard(playerIdx int, card *Card) {
 	g.currentTrick = append(g.currentTrick, &TrickCard{PlayerIdx: playerIdx, Card: card})
-	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", g.playerName(playerIdx), cardStr(card)), []*Card{card})
+	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", playerName(g.players, playerIdx), cardStr(card)), []*Card{card})
 
 	// 呼びカードがプレイされたら相棒が判明する。
 	if g.calledSuit != 0 && !g.partnerRevealed &&
 		card.GetValue() == 1 && card.GetDesign() == g.calledSuit && !sheepsheadIsTrump(card) {
 		g.partnerRevealed = true
 		g.appendLog(playerIdx, "partner_reveal",
-			fmt.Sprintf("%s is the picker's partner", g.playerName(playerIdx)), nil)
+			fmt.Sprintf("%s is the picker's partner", playerName(g.players, playerIdx)), nil)
 	}
 
 	if len(g.currentTrick) == SheepsheadPlayerCnt {
@@ -421,7 +421,7 @@ func (g *Sheepshead) ResolveTrick() {
 	}
 	g.players[winnerIdx].AddTrick(trickCards)
 	g.appendLog(winnerIdx, "trick_win",
-		fmt.Sprintf("%s wins trick %d (%d pts)", g.playerName(winnerIdx), g.trickNumber, pts), trickCards)
+		fmt.Sprintf("%s wins trick %d (%d pts)", playerName(g.players, winnerIdx), g.trickNumber, pts), trickCards)
 
 	g.leadPlayerIdx = winnerIdx
 	// Clear the resolved trick so a spurious second ResolveTrick call cannot
@@ -473,7 +473,7 @@ func (g *Sheepshead) ScoreRound() {
 		g.gameEndFlag = true
 		g.winnerIdx = w
 		g.phase = SheepsheadPhaseGameEnd
-		g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game!", g.playerName(w)), nil)
+		g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game!", playerName(g.players, w)), nil)
 	}
 }
 
@@ -675,17 +675,6 @@ func sheepsheadSortHand(p *SheepsheadPlayer) {
 		}
 		return sheepsheadStrength(ci) > sheepsheadStrength(cj)
 	})
-}
-
-// playerName プレイヤー名を返す。
-func (g *Sheepshead) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // indexOfPlayerInTrick currentTrick 内で playerIdx の札の位置を返す (-1=なし)。

--- a/internal/domain/Skat.go
+++ b/internal/domain/Skat.go
@@ -228,7 +228,7 @@ func (s *Skat) startRound() {
 
 	s.round.phase = SkatPhaseBid
 
-	s.appendLog(-1, "round_start", fmt.Sprintf("Round %d: dealer=%s", s.round.roundNumber, s.playerName(s.round.dealerIdx)), nil)
+	s.appendLog(-1, "round_start", fmt.Sprintf("Round %d: dealer=%s", s.round.roundNumber, playerName(s.players, s.round.dealerIdx)), nil)
 }
 
 // NextRound advances to the next round.
@@ -352,14 +352,14 @@ func (s *Skat) applyBidStep(actorIdx int, accept bool) {
 		if accept {
 			s.round.currentBid = SkatBidLadder[0]
 			s.appendLog(actorIdx, "bid_call",
-				fmt.Sprintf("%s calls %d", s.playerName(actorIdx), s.round.currentBid), nil)
+				fmt.Sprintf("%s calls %d", playerName(s.players, actorIdx), s.round.currentBid), nil)
 			s.round.bidStep = 1
 			return
 		}
 		// Bidder passed without calling.
 		s.round.passedAtCall[actorIdx] = true
 		s.appendLog(actorIdx, "bid_pass",
-			fmt.Sprintf("%s passes", s.playerName(actorIdx)), nil)
+			fmt.Sprintf("%s passes", playerName(s.players, actorIdx)), nil)
 		s.bidderDroppedOut()
 		return
 	}
@@ -367,11 +367,11 @@ func (s *Skat) applyBidStep(actorIdx int, accept bool) {
 	// Responder turn.
 	if accept {
 		s.appendLog(actorIdx, "bid_yes",
-			fmt.Sprintf("%s answers yes at %d", s.playerName(actorIdx), s.round.currentBid), nil)
+			fmt.Sprintf("%s answers yes at %d", playerName(s.players, actorIdx), s.round.currentBid), nil)
 		if s.round.bidStep < len(SkatBidLadder) {
 			s.round.currentBid = SkatBidLadder[s.round.bidStep]
 			s.appendLog(s.round.bidderIdx, "bid_call",
-				fmt.Sprintf("%s calls %d", s.playerName(s.round.bidderIdx), s.round.currentBid), nil)
+				fmt.Sprintf("%s calls %d", playerName(s.players, s.round.bidderIdx), s.round.currentBid), nil)
 			s.round.bidStep++
 			return
 		}
@@ -383,7 +383,7 @@ func (s *Skat) applyBidStep(actorIdx int, accept bool) {
 	// Responder passes — bidder is round survivor.
 	s.round.passedAtCall[actorIdx] = true
 	s.appendLog(actorIdx, "bid_pass",
-		fmt.Sprintf("%s passes", s.playerName(actorIdx)), nil)
+		fmt.Sprintf("%s passes", playerName(s.players, actorIdx)), nil)
 	s.responderDroppedOut()
 }
 
@@ -440,7 +440,7 @@ func (s *Skat) declareDeclarer(idx int) {
 	s.players[idx].SetIsDeclarer(true)
 	s.players[idx].SetBid(s.round.currentBid)
 	s.appendLog(idx, "declarer",
-		fmt.Sprintf("%s wins the auction at %d", s.playerName(idx), s.round.currentBid), nil)
+		fmt.Sprintf("%s wins the auction at %d", playerName(s.players, idx), s.round.currentBid), nil)
 	s.round.phase = SkatPhaseSkatPickup
 }
 
@@ -483,7 +483,7 @@ func (s *Skat) applyPickSkat(pickup bool) {
 		}
 		s.sortHand(declarer)
 		s.appendLog(s.round.declarerIdx, "pick_skat",
-			fmt.Sprintf("%s picks up the skat", s.playerName(s.round.declarerIdx)), s.round.skat)
+			fmt.Sprintf("%s picks up the skat", playerName(s.players, s.round.declarerIdx)), s.round.skat)
 		s.round.skat = nil
 		s.round.phase = SkatPhaseDiscard
 		return
@@ -491,7 +491,7 @@ func (s *Skat) applyPickSkat(pickup bool) {
 
 	// Hand game — skat stays face-down; go straight to game declaration.
 	s.appendLog(s.round.declarerIdx, "hand_game",
-		fmt.Sprintf("%s plays a hand game", s.playerName(s.round.declarerIdx)), nil)
+		fmt.Sprintf("%s plays a hand game", playerName(s.players, s.round.declarerIdx)), nil)
 	s.round.phase = SkatPhaseGameDeclaration
 }
 
@@ -545,7 +545,7 @@ func (s *Skat) applyDiscard(idxA, idxB int) {
 	s.round.skat = []*Card{cardLo, cardHi}
 	s.sortHand(declarer)
 	s.appendLog(s.round.declarerIdx, "discard",
-		fmt.Sprintf("%s discards 2 cards into the skat", s.playerName(s.round.declarerIdx)),
+		fmt.Sprintf("%s discards 2 cards into the skat", playerName(s.players, s.round.declarerIdx)),
 		[]*Card{cardLo, cardHi})
 	s.round.phase = SkatPhaseGameDeclaration
 }
@@ -594,7 +594,7 @@ func (s *Skat) applyGameDeclaration(gt SkatGameType, trumpSuit int) {
 		s.round.trumpSuit = 0
 	}
 	s.appendLog(s.round.declarerIdx, "declare_game",
-		fmt.Sprintf("%s declares %s", s.playerName(s.round.declarerIdx), s.gameTypeName()), nil)
+		fmt.Sprintf("%s declares %s", playerName(s.players, s.round.declarerIdx), s.gameTypeName()), nil)
 	s.startPlay()
 }
 
@@ -664,7 +664,7 @@ func (s *Skat) CpuPlay() {
 func (s *Skat) playCard(playerIdx int, card *Card) {
 	s.round.currentTrick = append(s.round.currentTrick, &TrickCard{PlayerIdx: playerIdx, Card: card})
 	s.appendLog(playerIdx, "play",
-		fmt.Sprintf("%s plays %s", s.playerName(playerIdx), cardStr(card)), []*Card{card})
+		fmt.Sprintf("%s plays %s", playerName(s.players, playerIdx), cardStr(card)), []*Card{card})
 	if len(s.round.currentTrick) == SkatPlayerCnt {
 		s.round.phase = SkatPhaseTrickEnd
 		return
@@ -687,7 +687,7 @@ func (s *Skat) ResolveTrick() {
 	s.players[winnerIdx].AddTrick(cards)
 	s.players[winnerIdx].SetCardPoints(s.players[winnerIdx].GetCardPoints() + pts)
 	s.appendLog(winnerIdx, "trick_win",
-		fmt.Sprintf("%s wins trick %d (%d card points)", s.playerName(winnerIdx), s.round.trickNumber, pts), cards)
+		fmt.Sprintf("%s wins trick %d (%d card points)", playerName(s.players, winnerIdx), s.round.trickNumber, pts), cards)
 	s.round.leadPlayerIdx = winnerIdx
 	if s.round.trickNumber >= SkatTricksPerRound {
 		s.round.phase = SkatPhaseRoundEnd
@@ -741,18 +741,18 @@ func (s *Skat) ScoreRound() {
 		declarer.SetRoundScore(gameValue)
 		declarer.IncRoundsWon()
 		s.appendLog(declarerIdx, "round_result",
-			fmt.Sprintf("%s wins (+%d)", s.playerName(declarerIdx), gameValue), nil)
+			fmt.Sprintf("%s wins (+%d)", playerName(s.players, declarerIdx), gameValue), nil)
 	} else {
 		s.round.winnerSide = SkatWinnerDefenders
 		declarer.SetRoundScore(-gameValue)
 		declarer.IncRoundsLost()
 		s.appendLog(declarerIdx, "round_result",
-			fmt.Sprintf("%s loses (-%d)", s.playerName(declarerIdx), gameValue), nil)
+			fmt.Sprintf("%s loses (-%d)", playerName(s.players, declarerIdx), gameValue), nil)
 	}
 
 	declarer.CommitRoundScore()
 	s.appendLog(declarerIdx, "cumulative_score",
-		fmt.Sprintf("%s total=%d", s.playerName(declarerIdx), declarer.GetCumulativeScore()), nil)
+		fmt.Sprintf("%s total=%d", playerName(s.players, declarerIdx), declarer.GetCumulativeScore()), nil)
 
 	s.checkGameEnd()
 }
@@ -1152,7 +1152,7 @@ func (s *Skat) checkGameEnd() {
 			s.round.gameEndFlag = true
 			s.round.phase = SkatPhaseGameEnd
 			s.appendLog(-1, "game_end",
-				fmt.Sprintf("%s reaches %d points and wins!", s.playerName(s.findIndex(p)), p.GetCumulativeScore()), nil)
+				fmt.Sprintf("%s reaches %d points and wins!", playerName(s.players, s.findIndex(p)), p.GetCumulativeScore()), nil)
 			return
 		}
 	}
@@ -1248,17 +1248,6 @@ func (s *Skat) GetHint() *SkatHint {
 		return &SkatHint{CardIndex: &idx, Reason: "best_play"}
 	}
 	return nil
-}
-
-// playerName returns the player display name.
-func (s *Skat) playerName(idx int) string {
-	if idx < 0 || idx >= len(s.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if s.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // gameTypeName returns the human-readable game type.

--- a/internal/domain/SoloWhist.go
+++ b/internal/domain/SoloWhist.go
@@ -238,9 +238,9 @@ func (g *SoloWhist) applyBid(idx int, bid SoloWhistBid) error {
 	g.bids[idx] = bid
 	g.bidDone[idx] = true
 	if bid != SoloWhistBidPass {
-		g.appendLog(idx, "bid", fmt.Sprintf("%s bids %s", g.playerName(idx), soloWhistBidName(bid)), nil)
+		g.appendLog(idx, "bid", fmt.Sprintf("%s bids %s", playerName(g.players, idx), soloWhistBidName(bid)), nil)
 	} else {
-		g.appendLog(idx, "bid", fmt.Sprintf("%s passes", g.playerName(idx)), nil)
+		g.appendLog(idx, "bid", fmt.Sprintf("%s passes", playerName(g.players, idx)), nil)
 	}
 	// 次の未入札プレイヤーへ。
 	for k := 1; k <= SoloWhistPlayerCnt; k++ {
@@ -272,7 +272,7 @@ func (g *SoloWhist) resolveBidding() {
 		g.trumpSuit = g.longestSuit(idx)
 	}
 	g.appendLog(idx, "contract",
-		fmt.Sprintf("%s declares %s (trump %d)", g.playerName(idx), soloWhistBidName(bid), g.trumpSuit), nil)
+		fmt.Sprintf("%s declares %s (trump %d)", playerName(g.players, idx), soloWhistBidName(bid), g.trumpSuit), nil)
 	g.leadPlayerIdx = (g.dealerIdx + 1) % SoloWhistPlayerCnt
 	g.currentPlayerIdx = g.leadPlayerIdx
 	g.phase = SoloWhistPhasePlay
@@ -373,7 +373,7 @@ func (g *SoloWhist) CpuPlay() {
 // playCard カードをプレイする共通処理。
 func (g *SoloWhist) playCard(playerIdx int, card *Card) {
 	g.currentTrick = append(g.currentTrick, &TrickCard{PlayerIdx: playerIdx, Card: card})
-	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", g.playerName(playerIdx), cardStr(card)), []*Card{card})
+	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", playerName(g.players, playerIdx), cardStr(card)), []*Card{card})
 
 	if len(g.currentTrick) == SoloWhistPlayerCnt {
 		g.phase = SoloWhistPhaseTrickEnd
@@ -395,7 +395,7 @@ func (g *SoloWhist) ResolveTrick() {
 	g.players[winnerIdx].AddTrick(trickCards)
 	g.roundTricks[winnerIdx]++
 	g.appendLog(winnerIdx, "trick_win",
-		fmt.Sprintf("%s wins trick %d", g.playerName(winnerIdx), g.trickNumber), trickCards)
+		fmt.Sprintf("%s wins trick %d", playerName(g.players, winnerIdx), g.trickNumber), trickCards)
 
 	g.leadPlayerIdx = winnerIdx
 	if g.trickNumber >= SoloWhistTrickCount {
@@ -469,7 +469,7 @@ func (g *SoloWhist) checkGameEnd() {
 		g.gameEndFlag = true
 		g.winnerPlayer = leader
 		g.phase = SoloWhistPhaseGameEnd
-		g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the match!", g.playerName(leader)), nil)
+		g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the match!", playerName(g.players, leader)), nil)
 	}
 }
 
@@ -572,17 +572,6 @@ func soloWhistSortHand(p *SoloWhistPlayer) {
 	for _, c := range cards {
 		p.AddCard(c)
 	}
-}
-
-// playerName プレイヤー名を返す。
-func (g *SoloWhist) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // indexOfPlayerInTrick currentTrick 内で playerIdx の札の位置を返す (-1=なし)。

--- a/internal/domain/Spades.go
+++ b/internal/domain/Spades.go
@@ -161,7 +161,7 @@ func (s *Spades) PlayerBid(bid int) error {
 	if bid == 0 {
 		bidStr = "Nil"
 	}
-	s.appendLog(humanIdx, "bid", fmt.Sprintf("%s bids %s", s.playerName(humanIdx), bidStr), nil)
+	s.appendLog(humanIdx, "bid", fmt.Sprintf("%s bids %s", playerName(s.players, humanIdx), bidStr), nil)
 
 	s.bidPlayerIdx++
 	s.checkBidComplete()
@@ -186,7 +186,7 @@ func (s *Spades) CpuBid() {
 	if bid == 0 {
 		bidStr = "Nil"
 	}
-	s.appendLog(s.bidPlayerIdx, "bid", fmt.Sprintf("%s bids %s", s.playerName(s.bidPlayerIdx), bidStr), nil)
+	s.appendLog(s.bidPlayerIdx, "bid", fmt.Sprintf("%s bids %s", playerName(s.players, s.bidPlayerIdx), bidStr), nil)
 
 	s.bidPlayerIdx++
 	s.checkBidComplete()
@@ -254,7 +254,7 @@ func (s *Spades) ResolveTrick() {
 
 	s.players[winnerIdx].AddTrick(trickCards)
 
-	winnerName := s.playerName(winnerIdx)
+	winnerName := playerName(s.players, winnerIdx)
 	s.appendLog(winnerIdx, "trick_win", fmt.Sprintf("%s wins trick %d", winnerName, s.trickNumber), trickCards)
 
 	s.leadPlayerIdx = winnerIdx
@@ -292,10 +292,10 @@ func (s *Spades) ScoreRound() {
 			// ニルビッド
 			if tricks == 0 {
 				p.roundScore = s.config.NilBonus
-				s.appendLog(i, "nil_success", fmt.Sprintf("%s nil success! +%d", s.playerName(i), s.config.NilBonus), nil)
+				s.appendLog(i, "nil_success", fmt.Sprintf("%s nil success! +%d", playerName(s.players, i), s.config.NilBonus), nil)
 			} else {
 				p.roundScore = -s.config.NilBonus
-				s.appendLog(i, "nil_fail", fmt.Sprintf("%s nil failed! -%d (%d tricks taken)", s.playerName(i), s.config.NilBonus, tricks), nil)
+				s.appendLog(i, "nil_fail", fmt.Sprintf("%s nil failed! -%d (%d tricks taken)", playerName(s.players, i), s.config.NilBonus, tricks), nil)
 			}
 		} else if tricks >= bid {
 			// ビッド成功
@@ -308,7 +308,7 @@ func (s *Spades) ScoreRound() {
 				penalty := (p.bags / s.config.BagPenaltyThreshold) * 100
 				p.roundScore -= penalty
 				p.bags %= s.config.BagPenaltyThreshold
-				s.appendLog(i, "bag_penalty", fmt.Sprintf("%s bag penalty! -%d", s.playerName(i), penalty), nil)
+				s.appendLog(i, "bag_penalty", fmt.Sprintf("%s bag penalty! -%d", playerName(s.players, i), penalty), nil)
 			}
 		} else {
 			// ビッド失敗
@@ -316,7 +316,7 @@ func (s *Spades) ScoreRound() {
 		}
 
 		s.appendLog(i, "round_score", fmt.Sprintf("%s: bid=%d tricks=%d round=%d bags=%d",
-			s.playerName(i), bid, tricks, p.roundScore, p.bags), nil)
+			playerName(s.players, i), bid, tricks, p.roundScore, p.bags), nil)
 	}
 
 	// 累積スコアに加算
@@ -327,7 +327,7 @@ func (s *Spades) ScoreRound() {
 	// スコアログ
 	for i := 0; i < SpadesPlayerCnt; i++ {
 		s.appendLog(i, "cumulative_score", fmt.Sprintf("%s: total=%d",
-			s.playerName(i), s.players[i].cumulativeScore), nil)
+			playerName(s.players, i), s.players[i].cumulativeScore), nil)
 	}
 
 	// ゲーム終了判定
@@ -476,7 +476,7 @@ func (s *Spades) playCard(playerIdx int, card *Card) {
 		s.spadesBroken = true
 	}
 
-	s.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", s.playerName(playerIdx), cardStr(card)), []*Card{card})
+	s.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", playerName(s.players, playerIdx), cardStr(card)), []*Card{card})
 
 	if len(s.currentTrick) == SpadesPlayerCnt {
 		s.phase = SpadesPhaseTrickEnd
@@ -592,7 +592,7 @@ func (s *Spades) checkGameEnd() {
 			s.winnerIdx = i
 		}
 	}
-	s.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game!", s.playerName(s.winnerIdx)), nil)
+	s.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game!", playerName(s.players, s.winnerIdx)), nil)
 }
 
 // sortAllHands 全プレイヤーの手札をソートする
@@ -610,17 +610,6 @@ func spadeSortHand(p *SpadesPlayer) {
 		}
 		return ci.GetValue() < cj.GetValue()
 	})
-}
-
-// playerName プレイヤー名を返す
-func (s *Spades) playerName(idx int) string {
-	if idx < 0 || idx >= len(s.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if s.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // GetHint ヒントを取得する

--- a/internal/domain/Spades_internal_test.go
+++ b/internal/domain/Spades_internal_test.go
@@ -595,10 +595,10 @@ func TestSpades_cpuPlayHard_Follow_SpadeLeadSuit(t *testing.T) {
 
 func TestSpades_playerName(t *testing.T) {
 	s := newInternalTestSpades()
-	assert.Equal(t, "You", s.playerName(0))
-	assert.Equal(t, "CPU 1", s.playerName(1))
-	assert.Equal(t, "Player -1", s.playerName(-1))
-	assert.Equal(t, "Player 5", s.playerName(5))
+	assert.Equal(t, "You", playerName(s.players, 0))
+	assert.Equal(t, "CPU 1", playerName(s.players, 1))
+	assert.Equal(t, "Player -1", playerName(s.players, -1))
+	assert.Equal(t, "Player 5", playerName(s.players, 5))
 }
 
 func TestSpades_checkGameEnd_NoEnd(t *testing.T) {

--- a/internal/domain/SpoilFive.go
+++ b/internal/domain/SpoilFive.go
@@ -143,7 +143,7 @@ func (g *SpoilFive) startRound() {
 	g.phase = SpoilFivePhasePlay
 	g.appendLog(g.leadPlayerIdx, "round_start",
 		fmt.Sprintf("round %d: trump %d, pot %d, %s leads",
-			g.roundNumber, g.trumpSuit, g.pot, g.playerName(g.leadPlayerIdx)), nil)
+			g.roundNumber, g.trumpSuit, g.pot, playerName(g.players, g.leadPlayerIdx)), nil)
 }
 
 // deal 各プレイヤーへ 5 枚を配る。
@@ -205,7 +205,7 @@ func (g *SpoilFive) CpuPlay() {
 // playCard カードをプレイする共通処理。
 func (g *SpoilFive) playCard(playerIdx int, card *Card) {
 	g.currentTrick = append(g.currentTrick, &TrickCard{PlayerIdx: playerIdx, Card: card})
-	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", g.playerName(playerIdx), cardStr(card)), []*Card{card})
+	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", playerName(g.players, playerIdx), cardStr(card)), []*Card{card})
 
 	if len(g.currentTrick) == SpoilFivePlayerCnt {
 		g.phase = SpoilFivePhaseTrickEnd
@@ -227,7 +227,7 @@ func (g *SpoilFive) ResolveTrick() {
 	g.players[winnerIdx].AddTrick(trickCards)
 	g.players[winnerIdx].IncRoundTricks()
 	g.appendLog(winnerIdx, "trick_win",
-		fmt.Sprintf("%s wins trick %d", g.playerName(winnerIdx), g.trickNumber), trickCards)
+		fmt.Sprintf("%s wins trick %d", playerName(g.players, winnerIdx), g.trickNumber), trickCards)
 
 	g.leadPlayerIdx = winnerIdx
 	if g.players[winnerIdx].GetRoundTricks() >= SpoilFiveWinTricks {
@@ -262,7 +262,7 @@ func (g *SpoilFive) ScoreRound() {
 	if g.roundWinnerIdx >= 0 {
 		g.players[g.roundWinnerIdx].SetScore(g.players[g.roundWinnerIdx].GetScore() + g.pot)
 		g.appendLog(g.roundWinnerIdx, "round_win",
-			fmt.Sprintf("%s wins the pot of %d", g.playerName(g.roundWinnerIdx), g.pot), nil)
+			fmt.Sprintf("%s wins the pot of %d", playerName(g.players, g.roundWinnerIdx), g.pot), nil)
 		g.pot = 0
 		g.checkGameEnd()
 	} else {
@@ -283,7 +283,7 @@ func (g *SpoilFive) checkGameEnd() {
 		g.gameEndFlag = true
 		g.winnerPlayer = leader
 		g.phase = SpoilFivePhaseGameEnd
-		g.appendLog(leader, "game_end", fmt.Sprintf("%s wins the match!", g.playerName(leader)), nil)
+		g.appendLog(leader, "game_end", fmt.Sprintf("%s wins the match!", playerName(g.players, leader)), nil)
 	}
 }
 
@@ -474,17 +474,6 @@ func (g *SpoilFive) spoilSortHand(p *SpoilFivePlayer) {
 	for _, c := range cards {
 		p.AddCard(c)
 	}
-}
-
-// playerName プレイヤー名を返す。
-func (g *SpoilFive) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // indexOfPlayerInTrick currentTrick 内で playerIdx の札の位置を返す (-1=なし)。

--- a/internal/domain/Sueca.go
+++ b/internal/domain/Sueca.go
@@ -201,7 +201,7 @@ func (g *Sueca) CpuPlay() {
 // playCard カードをプレイする共通処理。
 func (g *Sueca) playCard(playerIdx int, card *Card) {
 	g.currentTrick = append(g.currentTrick, &TrickCard{PlayerIdx: playerIdx, Card: card})
-	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", g.playerName(playerIdx), cardStr(card)), []*Card{card})
+	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", playerName(g.players, playerIdx), cardStr(card)), []*Card{card})
 
 	if len(g.currentTrick) == SuecaPlayerCnt {
 		g.phase = SuecaPhaseTrickEnd
@@ -225,7 +225,7 @@ func (g *Sueca) ResolveTrick() {
 	g.players[winnerIdx].AddTrick(trickCards)
 	g.roundCardPts[SuecaTeamOf(winnerIdx)] += pts
 	g.appendLog(winnerIdx, "trick_win",
-		fmt.Sprintf("%s wins trick %d (+%d)", g.playerName(winnerIdx), g.trickNumber, pts), trickCards)
+		fmt.Sprintf("%s wins trick %d (+%d)", playerName(g.players, winnerIdx), g.trickNumber, pts), trickCards)
 
 	g.leadPlayerIdx = winnerIdx
 	// Keep currentTrick intact through TrickEnd so the resolved trick stays
@@ -440,17 +440,6 @@ func suecaSortHand(p *SuecaPlayer) {
 	for _, c := range cards {
 		p.AddCard(c)
 	}
-}
-
-// playerName プレイヤー名を返す。
-func (g *Sueca) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // indexOfPlayerInTrick currentTrick 内で playerIdx の札の位置を返す (-1=なし)。

--- a/internal/domain/Tablanet.go
+++ b/internal/domain/Tablanet.go
@@ -484,7 +484,7 @@ func (g *Tablanet) applyPlay(playerIdx, handIdx int, tableIdxs []int) {
 	if len(tableIdxs) == 0 {
 		// トレイル: 場に置く。
 		g.state.tableCards = append(g.state.tableCards, card)
-		g.appendLog(playerIdx, "trail", fmt.Sprintf("%s trails %s", g.playerName(playerIdx), cardStr(card)),
+		g.appendLog(playerIdx, "trail", fmt.Sprintf("%s trails %s", playerName(g.players, playerIdx), cardStr(card)),
 			[]*Card{card})
 		g.advanceTurn()
 		return
@@ -505,15 +505,15 @@ func (g *Tablanet) applyPlay(playerIdx, handIdx int, tableIdxs []int) {
 	if isTabla {
 		player.IncrementTabla()
 		g.appendLog(playerIdx, "tabla",
-			fmt.Sprintf("%s scores a Tabla! captured %d card(s)", g.playerName(playerIdx), len(captured)-1),
+			fmt.Sprintf("%s scores a Tabla! captured %d card(s)", playerName(g.players, playerIdx), len(captured)-1),
 			captured)
 	} else if tablanetIsJack(card) {
 		g.appendLog(playerIdx, "sweep",
-			fmt.Sprintf("%s sweeps %d card(s) with a Jack", g.playerName(playerIdx), len(captured)-1),
+			fmt.Sprintf("%s sweeps %d card(s) with a Jack", playerName(g.players, playerIdx), len(captured)-1),
 			captured)
 	} else {
 		g.appendLog(playerIdx, "capture",
-			fmt.Sprintf("%s captures %d card(s)", g.playerName(playerIdx), len(captured)-1),
+			fmt.Sprintf("%s captures %d card(s)", playerName(g.players, playerIdx), len(captured)-1),
 			captured)
 	}
 	g.advanceTurn()
@@ -829,16 +829,6 @@ func (g *Tablanet) sortHumanHand() {
 			p.AddCard(c)
 		}
 	}
-}
-
-func (g *Tablanet) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 func (g *Tablanet) appendLog(playerIdx int, actionType, detail string, cards []*Card) {

--- a/internal/domain/Tarneeb.go
+++ b/internal/domain/Tarneeb.go
@@ -219,7 +219,7 @@ func (t *Tarneeb) applyBid(playerIdx, bid int) {
 		t.highestBid = bid
 		t.bidWinnerIdx = playerIdx
 	}
-	t.appendLog(playerIdx, "bid", fmt.Sprintf("%s bids %s", t.playerName(playerIdx), bidLabel), nil)
+	t.appendLog(playerIdx, "bid", fmt.Sprintf("%s bids %s", playerName(t.players, playerIdx), bidLabel), nil)
 
 	t.bidPlayerIdx = (t.bidPlayerIdx + 1) % TarneebPlayerCnt
 	// 4人ビッドし終えたらディーラーの左隣に戻り、フェーズ遷移を判定する。
@@ -240,7 +240,7 @@ func (t *Tarneeb) finishBidPhase() {
 		return
 	}
 	t.appendLog(t.bidWinnerIdx, "bid_win",
-		fmt.Sprintf("%s wins the auction with %d", t.playerName(t.bidWinnerIdx), t.highestBid), nil)
+		fmt.Sprintf("%s wins the auction with %d", playerName(t.players, t.bidWinnerIdx), t.highestBid), nil)
 	t.phase = TarneebPhaseTrumpDeclaration
 }
 
@@ -278,7 +278,7 @@ func (t *Tarneeb) CpuDeclareTrump() {
 func (t *Tarneeb) applyTrumpDeclaration(suit int) {
 	t.trumpSuit = suit
 	t.appendLog(t.bidWinnerIdx, "trump",
-		fmt.Sprintf("%s declares %s as trump", t.playerName(t.bidWinnerIdx), suitName(suit)), nil)
+		fmt.Sprintf("%s declares %s as trump", playerName(t.players, t.bidWinnerIdx), suitName(suit)), nil)
 	t.leadPlayerIdx = t.bidWinnerIdx
 	t.currentPlayerIdx = t.bidWinnerIdx
 	t.trickNumber = 1
@@ -345,7 +345,7 @@ func (t *Tarneeb) ResolveTrick() {
 	}
 	t.players[winnerIdx].AddTrick(trickCards)
 	t.appendLog(winnerIdx, "trick_win",
-		fmt.Sprintf("%s wins trick %d", t.playerName(winnerIdx), t.trickNumber), trickCards)
+		fmt.Sprintf("%s wins trick %d", playerName(t.players, winnerIdx), t.trickNumber), trickCards)
 
 	t.leadPlayerIdx = winnerIdx
 	if t.trickNumber >= TarneebHandSize {
@@ -622,7 +622,7 @@ func (t *Tarneeb) playCard(playerIdx int, card *Card) {
 		Card:      card,
 	})
 	t.appendLog(playerIdx, "play",
-		fmt.Sprintf("%s plays %s", t.playerName(playerIdx), cardStr(card)), []*Card{card})
+		fmt.Sprintf("%s plays %s", playerName(t.players, playerIdx), cardStr(card)), []*Card{card})
 	if len(t.currentTrick) == TarneebPlayerCnt {
 		t.phase = TarneebPhaseTrickEnd
 		return
@@ -691,17 +691,6 @@ func tarneebSortHand(p *TarneebPlayer) {
 		// A > K > … ranking.
 		return tarneebRank(ci.GetValue()) < tarneebRank(cj.GetValue())
 	})
-}
-
-// playerName プレイヤー名を返す
-func (t *Tarneeb) playerName(idx int) string {
-	if idx < 0 || idx >= len(t.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if t.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // isValidSuit 4スートのうちいずれかか

--- a/internal/domain/Tarneeb_coverage_test.go
+++ b/internal/domain/Tarneeb_coverage_test.go
@@ -269,9 +269,9 @@ func TestTarneeb_UnmarshalJSON_OversizedArray(t *testing.T) {
 func TestTarneeb_PlayerName_OutOfRange(t *testing.T) {
 	tn := newCov(TarneebCpuDifficultyNormal)
 	tn.Reset()
-	assert.Contains(t, tn.playerName(-1), "Player")
-	assert.Equal(t, "You", tn.playerName(0))
-	assert.Contains(t, tn.playerName(1), "CPU")
+	assert.Contains(t, playerName(tn.players, -1), "Player")
+	assert.Equal(t, "You", playerName(tn.players, 0))
+	assert.Contains(t, playerName(tn.players, 1), "CPU")
 }
 
 func TestTarneeb_TrickWinner_AllTrumps(t *testing.T) {

--- a/internal/domain/TeenPatti.go
+++ b/internal/domain/TeenPatti.go
@@ -153,7 +153,7 @@ func (g *TeenPatti) startDeal() {
 		g.gameEndFlag = true
 		g.phase = TeenPattiPhaseGameEnd
 		g.matchWinnerIdx = g.firstAlive()
-		g.appendLog(g.matchWinnerIdx, "game_end", fmt.Sprintf("%s wins the match", g.playerName(g.matchWinnerIdx)), nil)
+		g.appendLog(g.matchWinnerIdx, "game_end", fmt.Sprintf("%s wins the match", playerName(g.players, g.matchWinnerIdx)), nil)
 		return
 	}
 	g.trumpCards.Replenish()
@@ -197,7 +197,7 @@ func (g *TeenPatti) PlayerSee() error {
 		return NewDomainError(ErrInvalidPlay, "すでに手札を見ています")
 	}
 	g.players[g.currentPlayerIdx].SetSeen(true)
-	g.appendLog(g.currentPlayerIdx, "see", fmt.Sprintf("%s sees their hand", g.playerName(g.currentPlayerIdx)), nil)
+	g.appendLog(g.currentPlayerIdx, "see", fmt.Sprintf("%s sees their hand", playerName(g.players, g.currentPlayerIdx)), nil)
 	return nil
 }
 
@@ -286,7 +286,7 @@ func (g *TeenPatti) applyRequestSideShow(idx int) {
 	g.phase = TeenPattiPhaseSideShow
 	g.currentPlayerIdx = target
 	g.appendLog(idx, "sideshow_request",
-		fmt.Sprintf("%s requests a side show with %s", g.playerName(idx), g.playerName(target)), nil)
+		fmt.Sprintf("%s requests a side show with %s", playerName(g.players, idx), playerName(g.players, target)), nil)
 }
 
 // applyRespondSideShow サイドショーへの応答を適用する。
@@ -303,14 +303,14 @@ func (g *TeenPatti) applyRespondSideShow(accept bool) {
 		// 表示用に成立したサイドショーの結果を保持する (参加者のカードは deal 更新まで保持される)。
 		g.lastSideShow = &teenPattiSideShow{Requester: req, Target: tgt, Loser: loser}
 		g.appendLog(tgt, "sideshow_accept",
-			fmt.Sprintf("%s accepts; %s loses the side show", g.playerName(tgt), g.playerName(loser)), nil)
+			fmt.Sprintf("%s accepts; %s loses the side show", playerName(g.players, tgt), playerName(g.players, loser)), nil)
 		g.players[loser].SetFolded(true)
 		if g.activeCount() == 1 {
 			g.endDeal([]int{g.firstActive()})
 			return
 		}
 	} else {
-		g.appendLog(tgt, "sideshow_decline", fmt.Sprintf("%s declines the side show", g.playerName(tgt)), nil)
+		g.appendLog(tgt, "sideshow_decline", fmt.Sprintf("%s declines the side show", playerName(g.players, tgt)), nil)
 	}
 	// 申請者の賭けは済んでいるので、申請者の次の手番から再開する。
 	g.phase = TeenPattiPhaseBetting
@@ -368,7 +368,7 @@ func (g *TeenPatti) applyCall(idx int) error {
 	p.AddRoundBet(cost)
 	g.pot += cost
 	g.actionCount++
-	g.appendLog(idx, "bet", fmt.Sprintf("%s bets %d (pot %d)", g.playerName(idx), cost, g.pot), nil)
+	g.appendLog(idx, "bet", fmt.Sprintf("%s bets %d (pot %d)", playerName(g.players, idx), cost, g.pot), nil)
 	g.advanceOrResolve(idx)
 	return nil
 }
@@ -393,7 +393,7 @@ func (g *TeenPatti) applyRaise(idx, newStake int) error {
 	g.pot += cost
 	g.lastAggressorIdx = idx
 	g.actionCount++
-	g.appendLog(idx, "raise", fmt.Sprintf("%s raises to %d, bets %d (pot %d)", g.playerName(idx), newStake, cost, g.pot), nil)
+	g.appendLog(idx, "raise", fmt.Sprintf("%s raises to %d, bets %d (pot %d)", playerName(g.players, idx), newStake, cost, g.pot), nil)
 	g.advanceOrResolve(idx)
 	return nil
 }
@@ -401,7 +401,7 @@ func (g *TeenPatti) applyRaise(idx, newStake int) error {
 // applyFold フォールドを適用する。
 func (g *TeenPatti) applyFold(idx int) {
 	g.players[idx].SetFolded(true)
-	g.appendLog(idx, "fold", fmt.Sprintf("%s folds", g.playerName(idx)), nil)
+	g.appendLog(idx, "fold", fmt.Sprintf("%s folds", playerName(g.players, idx)), nil)
 	if g.activeCount() == 1 {
 		g.endDeal([]int{g.firstActive()})
 		return
@@ -419,7 +419,7 @@ func (g *TeenPatti) applyShow(idx int) {
 	p.SubtractChips(cost)
 	p.AddRoundBet(cost)
 	g.pot += cost
-	g.appendLog(idx, "show", fmt.Sprintf("%s pays %d to see (pot %d)", g.playerName(idx), cost, g.pot), nil)
+	g.appendLog(idx, "show", fmt.Sprintf("%s pays %d to see (pot %d)", playerName(g.players, idx), cost, g.pot), nil)
 	opp := g.otherActive(idx)
 	g.showdown = true
 	g.phase = TeenPattiPhaseShowdown
@@ -478,7 +478,7 @@ func (g *TeenPatti) CpuAct() {
 	// Blind の場合はまず手札を見る (簡易 AI)。
 	if !p.GetSeen() {
 		p.SetSeen(true)
-		g.appendLog(idx, "see", fmt.Sprintf("%s sees their hand", g.playerName(idx)), nil)
+		g.appendLog(idx, "see", fmt.Sprintf("%s sees their hand", playerName(g.players, idx)), nil)
 	}
 	cat, _ := g.handEval(idx)
 	cost := g.callCost(idx)
@@ -529,7 +529,7 @@ func (g *TeenPatti) endDeal(winners []int) {
 		g.players[w].AddChips(amt)
 	}
 	g.roundWinnerIdx = winners[0]
-	g.appendLog(winners[0], "win", fmt.Sprintf("%s wins the pot (%d)", g.playerName(winners[0]), g.pot), nil)
+	g.appendLog(winners[0], "win", fmt.Sprintf("%s wins the pot (%d)", playerName(g.players, winners[0]), g.pot), nil)
 
 	// チップ 0 は脱落。
 	for _, p := range g.players {
@@ -541,7 +541,7 @@ func (g *TeenPatti) endDeal(winners []int) {
 		g.gameEndFlag = true
 		g.phase = TeenPattiPhaseGameEnd
 		g.matchWinnerIdx = g.firstAlive()
-		g.appendLog(g.matchWinnerIdx, "game_end", fmt.Sprintf("%s wins the match", g.playerName(g.matchWinnerIdx)), nil)
+		g.appendLog(g.matchWinnerIdx, "game_end", fmt.Sprintf("%s wins the match", playerName(g.players, g.matchWinnerIdx)), nil)
 		return
 	}
 	g.phase = TeenPattiPhaseRoundEnd
@@ -656,16 +656,6 @@ func (g *TeenPatti) firstAlive() int {
 		}
 	}
 	return 0
-}
-
-func (g *TeenPatti) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // --- State getters ---

--- a/internal/domain/ThirtyOne.go
+++ b/internal/domain/ThirtyOne.go
@@ -173,7 +173,7 @@ func (g *ThirtyOne) checkBlitzOnDeal() {
 			continue
 		}
 		if p.BestSuitScore() == ThirtyOneTarget {
-			g.appendLog(i, "blitz", fmt.Sprintf("%s is dealt 31!", g.playerName(i)), nil)
+			g.appendLog(i, "blitz", fmt.Sprintf("%s is dealt 31!", playerName(g.players, i)), nil)
 			g.declareThirtyOne(i)
 			return
 		}
@@ -265,7 +265,7 @@ func (g *ThirtyOne) drawFromStock(idx int) {
 	card := g.drawPile[len(g.drawPile)-1]
 	g.drawPile = g.drawPile[:len(g.drawPile)-1]
 	g.players[idx].AddCard(card)
-	g.appendLog(idx, "draw_stock", fmt.Sprintf("%s draws from stock", g.playerName(idx)), nil)
+	g.appendLog(idx, "draw_stock", fmt.Sprintf("%s draws from stock", playerName(g.players, idx)), nil)
 	g.phase = ThirtyOnePhaseDiscard
 }
 
@@ -274,7 +274,7 @@ func (g *ThirtyOne) drawFromDiscard(idx int) {
 	card := g.discardPile[len(g.discardPile)-1]
 	g.discardPile = g.discardPile[:len(g.discardPile)-1]
 	g.players[idx].AddCard(card)
-	g.appendLog(idx, "draw_discard", fmt.Sprintf("%s draws %s from discard", g.playerName(idx), cardStr(card)), []*Card{card})
+	g.appendLog(idx, "draw_discard", fmt.Sprintf("%s draws %s from discard", playerName(g.players, idx), cardStr(card)), []*Card{card})
 	g.phase = ThirtyOnePhaseDiscard
 }
 
@@ -282,10 +282,10 @@ func (g *ThirtyOne) drawFromDiscard(idx int) {
 func (g *ThirtyOne) discardAndResolve(idx, cardIndex int) {
 	discarded := g.players[idx].RemoveCard(cardIndex)
 	g.discardPile = append(g.discardPile, discarded)
-	g.appendLog(idx, "discard", fmt.Sprintf("%s discards %s", g.playerName(idx), cardStr(discarded)), []*Card{discarded})
+	g.appendLog(idx, "discard", fmt.Sprintf("%s discards %s", playerName(g.players, idx), cardStr(discarded)), []*Card{discarded})
 
 	if g.players[idx].BestSuitScore() == ThirtyOneTarget {
-		g.appendLog(idx, "thirty_one", fmt.Sprintf("%s reaches 31!", g.playerName(idx)), nil)
+		g.appendLog(idx, "thirty_one", fmt.Sprintf("%s reaches 31!", playerName(g.players, idx)), nil)
 		g.declareThirtyOne(idx)
 		return
 	}
@@ -295,7 +295,7 @@ func (g *ThirtyOne) discardAndResolve(idx, cardIndex int) {
 // knock ノックを記録してターンを進める
 func (g *ThirtyOne) knock(idx int) {
 	g.knockerIdx = idx
-	g.appendLog(idx, "knock", fmt.Sprintf("%s knocks (score: %d)", g.playerName(idx), g.players[idx].BestSuitScore()), nil)
+	g.appendLog(idx, "knock", fmt.Sprintf("%s knocks (score: %d)", playerName(g.players, idx), g.players[idx].BestSuitScore()), nil)
 	g.advanceTurn()
 }
 
@@ -504,7 +504,7 @@ func (g *ThirtyOne) declareThirtyOne(idx int) {
 		p.LoseLife()
 		g.roundLosers = append(g.roundLosers, i)
 	}
-	g.appendLog(idx, "round_win", fmt.Sprintf("%s wins the round with 31", g.playerName(idx)), nil)
+	g.appendLog(idx, "round_win", fmt.Sprintf("%s wins the round with 31", playerName(g.players, idx)), nil)
 	g.finishRound()
 }
 
@@ -538,7 +538,7 @@ func (g *ThirtyOne) endRound(reason string) {
 		if p.BestSuitScore() == minScore {
 			p.LoseLife()
 			g.roundLosers = append(g.roundLosers, i)
-			g.appendLog(i, "lose_life", fmt.Sprintf("%s loses a life (score: %d)", g.playerName(i), minScore), nil)
+			g.appendLog(i, "lose_life", fmt.Sprintf("%s loses a life (score: %d)", playerName(g.players, i), minScore), nil)
 		}
 	}
 	g.finishRound()
@@ -570,7 +570,7 @@ func (g *ThirtyOne) checkGameEnd() {
 	g.gameEndFlag = true
 	g.phase = ThirtyOnePhaseGameEnd
 	g.winnerIdx = g.leaderIdx()
-	g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game!", g.playerName(g.winnerIdx)), nil)
+	g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game!", playerName(g.players, g.winnerIdx)), nil)
 }
 
 // leaderIdx 最もライフが多いプレイヤー (同点は若いインデックス) を返す
@@ -708,17 +708,6 @@ func (g *ThirtyOne) GetConfig() ThirtyOneConfig { return g.config }
 
 // SetConfig ゲーム設定を設定する
 func (g *ThirtyOne) SetConfig(cfg ThirtyOneConfig) { g.config = cfg }
-
-// playerName プレイヤー名を返す
-func (g *ThirtyOne) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
-}
 
 // --- JSON ---
 

--- a/internal/domain/ThreeCardBrag.go
+++ b/internal/domain/ThreeCardBrag.go
@@ -233,7 +233,7 @@ func (g *ThreeCardBrag) startDeal() {
 		g.gameEndFlag = true
 		g.phase = ThreeCardBragPhaseGameEnd
 		g.matchWinnerIdx = g.firstAlive()
-		g.appendLog(g.matchWinnerIdx, "game_end", fmt.Sprintf("%s wins the match", g.playerName(g.matchWinnerIdx)), nil)
+		g.appendLog(g.matchWinnerIdx, "game_end", fmt.Sprintf("%s wins the match", playerName(g.players, g.matchWinnerIdx)), nil)
 		return
 	}
 	g.trumpCards.Replenish()
@@ -277,7 +277,7 @@ func (g *ThreeCardBrag) PlayerSee() error {
 		return NewDomainError(ErrInvalidPlay, "すでに手札を見ています")
 	}
 	g.players[g.currentPlayerIdx].SetSeen(true)
-	g.appendLog(g.currentPlayerIdx, "see", fmt.Sprintf("%s sees their hand", g.playerName(g.currentPlayerIdx)), nil)
+	g.appendLog(g.currentPlayerIdx, "see", fmt.Sprintf("%s sees their hand", playerName(g.players, g.currentPlayerIdx)), nil)
 	return nil
 }
 
@@ -348,7 +348,7 @@ func (g *ThreeCardBrag) applyCall(idx int) error {
 	p.AddRoundBet(cost)
 	g.pot += cost
 	g.actionCount++
-	g.appendLog(idx, "bet", fmt.Sprintf("%s bets %d (pot %d)", g.playerName(idx), cost, g.pot), nil)
+	g.appendLog(idx, "bet", fmt.Sprintf("%s bets %d (pot %d)", playerName(g.players, idx), cost, g.pot), nil)
 	g.advanceOrResolve(idx)
 	return nil
 }
@@ -366,7 +366,7 @@ func (g *ThreeCardBrag) applyRaise(idx, newStake int) error {
 	g.pot += cost
 	g.lastAggressorIdx = idx
 	g.actionCount++
-	g.appendLog(idx, "raise", fmt.Sprintf("%s raises to %d, bets %d (pot %d)", g.playerName(idx), newStake, cost, g.pot), nil)
+	g.appendLog(idx, "raise", fmt.Sprintf("%s raises to %d, bets %d (pot %d)", playerName(g.players, idx), newStake, cost, g.pot), nil)
 	g.advanceOrResolve(idx)
 	return nil
 }
@@ -374,7 +374,7 @@ func (g *ThreeCardBrag) applyRaise(idx, newStake int) error {
 // applyFold フォールドを適用する。
 func (g *ThreeCardBrag) applyFold(idx int) {
 	g.players[idx].SetFolded(true)
-	g.appendLog(idx, "fold", fmt.Sprintf("%s folds", g.playerName(idx)), nil)
+	g.appendLog(idx, "fold", fmt.Sprintf("%s folds", playerName(g.players, idx)), nil)
 	if g.activeCount() == 1 {
 		g.endDeal([]int{g.firstActive()})
 		return
@@ -392,7 +392,7 @@ func (g *ThreeCardBrag) applyShow(idx int) {
 	p.SubtractChips(cost)
 	p.AddRoundBet(cost)
 	g.pot += cost
-	g.appendLog(idx, "show", fmt.Sprintf("%s pays %d to see (pot %d)", g.playerName(idx), cost, g.pot), nil)
+	g.appendLog(idx, "show", fmt.Sprintf("%s pays %d to see (pot %d)", playerName(g.players, idx), cost, g.pot), nil)
 	opp := g.otherActive(idx)
 	g.showdown = true
 	g.phase = ThreeCardBragPhaseShowdown
@@ -440,7 +440,7 @@ func (g *ThreeCardBrag) CpuAct() {
 	// Blind の場合はまず手札を見る (簡易 AI)。
 	if !p.GetSeen() {
 		p.SetSeen(true)
-		g.appendLog(idx, "see", fmt.Sprintf("%s sees their hand", g.playerName(idx)), nil)
+		g.appendLog(idx, "see", fmt.Sprintf("%s sees their hand", playerName(g.players, idx)), nil)
 	}
 	cat, _ := g.handEval(idx)
 	cost := g.callCost(idx)
@@ -491,7 +491,7 @@ func (g *ThreeCardBrag) endDeal(winners []int) {
 		g.players[w].AddChips(amt)
 	}
 	g.roundWinnerIdx = winners[0]
-	g.appendLog(winners[0], "win", fmt.Sprintf("%s wins the pot (%d)", g.playerName(winners[0]), g.pot), nil)
+	g.appendLog(winners[0], "win", fmt.Sprintf("%s wins the pot (%d)", playerName(g.players, winners[0]), g.pot), nil)
 
 	// チップ 0 は脱落。
 	for _, p := range g.players {
@@ -503,7 +503,7 @@ func (g *ThreeCardBrag) endDeal(winners []int) {
 		g.gameEndFlag = true
 		g.phase = ThreeCardBragPhaseGameEnd
 		g.matchWinnerIdx = g.firstAlive()
-		g.appendLog(g.matchWinnerIdx, "game_end", fmt.Sprintf("%s wins the match", g.playerName(g.matchWinnerIdx)), nil)
+		g.appendLog(g.matchWinnerIdx, "game_end", fmt.Sprintf("%s wins the match", playerName(g.players, g.matchWinnerIdx)), nil)
 		return
 	}
 	g.phase = ThreeCardBragPhaseRoundEnd
@@ -618,16 +618,6 @@ func (g *ThreeCardBrag) firstAlive() int {
 		}
 	}
 	return 0
-}
-
-func (g *ThreeCardBrag) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // --- State getters ---

--- a/internal/domain/ThreeThirteen.go
+++ b/internal/domain/ThreeThirteen.go
@@ -246,7 +246,7 @@ func (g *ThreeThirteen) drawFromStock() error {
 	g.players[g.currentPlayerIdx].AddCard(card)
 	g.sortHand(g.currentPlayerIdx)
 
-	g.appendLog(g.currentPlayerIdx, "draw_stock", fmt.Sprintf("%s draws from stock", g.playerName(g.currentPlayerIdx)), nil)
+	g.appendLog(g.currentPlayerIdx, "draw_stock", fmt.Sprintf("%s draws from stock", playerName(g.players, g.currentPlayerIdx)), nil)
 	g.phase = ThreeThirteenPhaseDiscard
 	return nil
 }
@@ -260,7 +260,7 @@ func (g *ThreeThirteen) drawFromDiscard() error {
 	g.players[g.currentPlayerIdx].AddCard(card)
 	g.sortHand(g.currentPlayerIdx)
 
-	g.appendLog(g.currentPlayerIdx, "draw_discard", fmt.Sprintf("%s draws %s from discard", g.playerName(g.currentPlayerIdx), cardStr(card)), []*Card{card})
+	g.appendLog(g.currentPlayerIdx, "draw_discard", fmt.Sprintf("%s draws %s from discard", playerName(g.players, g.currentPlayerIdx), cardStr(card)), []*Card{card})
 	g.phase = ThreeThirteenPhaseDiscard
 	return nil
 }
@@ -329,13 +329,13 @@ func (g *ThreeThirteen) applyDiscard(cardIndex int, knock bool) error {
 
 	discarded := player.RemoveCard(cardIndex)
 	g.discardPile = append(g.discardPile, discarded)
-	g.appendLog(g.currentPlayerIdx, "discard", fmt.Sprintf("%s discards %s", g.playerName(g.currentPlayerIdx), cardStr(discarded)), []*Card{discarded})
+	g.appendLog(g.currentPlayerIdx, "discard", fmt.Sprintf("%s discards %s", playerName(g.players, g.currentPlayerIdx), cardStr(discarded)), []*Card{discarded})
 
 	if knock {
 		g.knockerIdx = g.currentPlayerIdx
 		player.SetIsFinished(true)
 		g.finalTurnsLeft = len(g.players) - 1
-		g.appendLog(g.currentPlayerIdx, "knock", fmt.Sprintf("%s knocks!", g.playerName(g.currentPlayerIdx)), nil)
+		g.appendLog(g.currentPlayerIdx, "knock", fmt.Sprintf("%s knocks!", playerName(g.players, g.currentPlayerIdx)), nil)
 	}
 
 	g.advanceTurn()
@@ -485,7 +485,7 @@ func (g *ThreeThirteen) finishRound() {
 		g.players[i].CommitRoundScore()
 	}
 	if g.knockerIdx >= 0 {
-		g.appendLog(g.knockerIdx, "round_end", fmt.Sprintf("Round %d ends (%s knocked)", g.round, g.playerName(g.knockerIdx)), nil)
+		g.appendLog(g.knockerIdx, "round_end", fmt.Sprintf("Round %d ends (%s knocked)", g.round, playerName(g.players, g.knockerIdx)), nil)
 	} else {
 		g.appendLog(-1, "round_end", fmt.Sprintf("Round %d ends (stock out)", g.round), nil)
 	}
@@ -509,7 +509,7 @@ func (g *ThreeThirteen) finalizeGameEnd() {
 			g.winnerIdx = i
 		}
 	}
-	g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game!", g.playerName(g.winnerIdx)), nil)
+	g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game!", playerName(g.players, g.winnerIdx)), nil)
 }
 
 // --- Getters / Setters ---
@@ -629,16 +629,6 @@ func (g *ThreeThirteen) sortHand(playerIdx int) {
 	for _, c := range cards {
 		p.AddCard(c)
 	}
-}
-
-func (g *ThreeThirteen) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // collectThreeThirteenCards プレイヤーの手札を []*Card で返す

--- a/internal/domain/Tonk.go
+++ b/internal/domain/Tonk.go
@@ -199,7 +199,7 @@ func (g *Tonk) checkTonkOnDeal() {
 		if total == TonkOnDealLow || total == TonkOnDealHigh {
 			g.isTonk = true
 			g.knockerIdx = i
-			g.appendLog(i, "tonk_on_deal", fmt.Sprintf("%s declares Tonk on deal! (hand value: %d)", g.playerName(i), total), nil)
+			g.appendLog(i, "tonk_on_deal", fmt.Sprintf("%s declares Tonk on deal! (hand value: %d)", playerName(g.players, i), total), nil)
 			g.scoreTonk(total)
 			return
 		}
@@ -228,7 +228,7 @@ func (g *Tonk) PlayerDrawFromStock() error {
 	g.players[g.currentPlayerIdx].AddCard(card)
 	g.sortHand(g.currentPlayerIdx)
 
-	g.appendLog(g.currentPlayerIdx, "draw_stock", fmt.Sprintf("%s draws from stock", g.playerName(g.currentPlayerIdx)), nil)
+	g.appendLog(g.currentPlayerIdx, "draw_stock", fmt.Sprintf("%s draws from stock", playerName(g.players, g.currentPlayerIdx)), nil)
 
 	g.phase = TonkPhaseDiscard
 	return nil
@@ -255,7 +255,7 @@ func (g *Tonk) PlayerDrawFromDiscard() error {
 	g.players[g.currentPlayerIdx].AddCard(card)
 	g.sortHand(g.currentPlayerIdx)
 
-	g.appendLog(g.currentPlayerIdx, "draw_discard", fmt.Sprintf("%s draws %s from discard", g.playerName(g.currentPlayerIdx), cardStr(card)), []*Card{card})
+	g.appendLog(g.currentPlayerIdx, "draw_discard", fmt.Sprintf("%s draws %s from discard", playerName(g.players, g.currentPlayerIdx), cardStr(card)), []*Card{card})
 
 	g.phase = TonkPhaseDiscard
 	return nil
@@ -281,7 +281,7 @@ func (g *Tonk) PlayerDiscard(cardIndex int) error {
 	discarded := player.RemoveCard(cardIndex)
 	g.discardPile = append(g.discardPile, discarded)
 
-	g.appendLog(g.currentPlayerIdx, "discard", fmt.Sprintf("%s discards %s", g.playerName(g.currentPlayerIdx), cardStr(discarded)), []*Card{discarded})
+	g.appendLog(g.currentPlayerIdx, "discard", fmt.Sprintf("%s discards %s", playerName(g.players, g.currentPlayerIdx), cardStr(discarded)), []*Card{discarded})
 
 	g.advanceTurn()
 	return nil
@@ -325,7 +325,7 @@ func (g *Tonk) PlayerKnock(cardIndex int) error {
 	g.knockerMelds = melds
 	g.knockerDeadwood = deadwood
 
-	g.appendLog(g.currentPlayerIdx, "knock", fmt.Sprintf("%s knocks (deadwood: %d)", g.playerName(g.currentPlayerIdx), deadwoodValue), []*Card{discarded})
+	g.appendLog(g.currentPlayerIdx, "knock", fmt.Sprintf("%s knocks (deadwood: %d)", playerName(g.players, g.currentPlayerIdx), deadwoodValue), []*Card{discarded})
 
 	g.scoreRound()
 	return nil
@@ -388,7 +388,7 @@ func (g *Tonk) cpuDraw() {
 			g.discardPile = g.discardPile[:len(g.discardPile)-1]
 			g.players[g.currentPlayerIdx].AddCard(card)
 			g.sortHand(g.currentPlayerIdx)
-			g.appendLog(g.currentPlayerIdx, "draw_discard", fmt.Sprintf("%s draws %s from discard", g.playerName(g.currentPlayerIdx), cardStr(card)), []*Card{card})
+			g.appendLog(g.currentPlayerIdx, "draw_discard", fmt.Sprintf("%s draws %s from discard", playerName(g.players, g.currentPlayerIdx), cardStr(card)), []*Card{card})
 			g.phase = TonkPhaseDiscard
 			return
 		}
@@ -403,7 +403,7 @@ func (g *Tonk) cpuDraw() {
 	g.drawPile = g.drawPile[:len(g.drawPile)-1]
 	g.players[g.currentPlayerIdx].AddCard(card)
 	g.sortHand(g.currentPlayerIdx)
-	g.appendLog(g.currentPlayerIdx, "draw_stock", fmt.Sprintf("%s draws from stock", g.playerName(g.currentPlayerIdx)), nil)
+	g.appendLog(g.currentPlayerIdx, "draw_stock", fmt.Sprintf("%s draws from stock", playerName(g.players, g.currentPlayerIdx)), nil)
 	g.phase = TonkPhaseDiscard
 }
 
@@ -444,7 +444,7 @@ func (g *Tonk) cpuDiscardOrKnock() {
 			g.knockerMelds = melds
 			g.knockerDeadwood = deadwood
 
-			g.appendLog(g.currentPlayerIdx, "knock", fmt.Sprintf("%s knocks (deadwood: %d)", g.playerName(g.currentPlayerIdx), deadwoodValue), []*Card{discarded})
+			g.appendLog(g.currentPlayerIdx, "knock", fmt.Sprintf("%s knocks (deadwood: %d)", playerName(g.players, g.currentPlayerIdx), deadwoodValue), []*Card{discarded})
 
 			g.scoreRound()
 			return
@@ -453,7 +453,7 @@ func (g *Tonk) cpuDiscardOrKnock() {
 
 	discarded := player.RemoveCard(bestDiscardIdx)
 	g.discardPile = append(g.discardPile, discarded)
-	g.appendLog(g.currentPlayerIdx, "discard", fmt.Sprintf("%s discards %s", g.playerName(g.currentPlayerIdx), cardStr(discarded)), []*Card{discarded})
+	g.appendLog(g.currentPlayerIdx, "discard", fmt.Sprintf("%s discards %s", playerName(g.players, g.currentPlayerIdx), cardStr(discarded)), []*Card{discarded})
 	g.advanceTurn()
 }
 
@@ -480,11 +480,11 @@ func (g *Tonk) scoreRound() {
 		g.isUndercut = true
 		score := knockerDeadwoodValue - opponentDeadwoodValue + TonkUndercutPenalty
 		g.players[opponentIdx].SetRoundScore(score)
-		g.appendLog(opponentIdx, "undercut", fmt.Sprintf("%s undercuts! Scores %d (penalty %d + difference %d)", g.playerName(opponentIdx), score, TonkUndercutPenalty, knockerDeadwoodValue-opponentDeadwoodValue), nil)
+		g.appendLog(opponentIdx, "undercut", fmt.Sprintf("%s undercuts! Scores %d (penalty %d + difference %d)", playerName(g.players, opponentIdx), score, TonkUndercutPenalty, knockerDeadwoodValue-opponentDeadwoodValue), nil)
 	} else {
 		score := opponentDeadwoodValue - knockerDeadwoodValue
 		g.players[knockerIdx].SetRoundScore(score)
-		g.appendLog(knockerIdx, "score", fmt.Sprintf("%s scores %d (deadwood difference)", g.playerName(knockerIdx), score), nil)
+		g.appendLog(knockerIdx, "score", fmt.Sprintf("%s scores %d (deadwood difference)", playerName(g.players, knockerIdx), score), nil)
 	}
 
 	for i := range g.players {
@@ -521,7 +521,7 @@ func (g *Tonk) scoreTonk(handValue int) {
 
 	score := TonkBonus + handValue
 	g.players[knockerIdx].SetRoundScore(score)
-	g.appendLog(knockerIdx, "tonk_score", fmt.Sprintf("%s scores %d (Tonk bonus %d + hand %d)", g.playerName(knockerIdx), score, TonkBonus, handValue), nil)
+	g.appendLog(knockerIdx, "tonk_score", fmt.Sprintf("%s scores %d (Tonk bonus %d + hand %d)", playerName(g.players, knockerIdx), score, TonkBonus, handValue), nil)
 
 	for i := range g.players {
 		g.players[i].CommitRoundScore()
@@ -581,7 +581,7 @@ func (g *Tonk) checkGameEnd() {
 			g.winnerIdx = i
 		}
 	}
-	g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game!", g.playerName(g.winnerIdx)), nil)
+	g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game!", playerName(g.players, g.winnerIdx)), nil)
 }
 
 // --- State getters ---
@@ -738,17 +738,6 @@ func (g *Tonk) sortHand(playerIdx int) {
 		}
 		return ci.GetValue() < cj.GetValue()
 	})
-}
-
-// playerName プレイヤー名を返す
-func (g *Tonk) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // tonkJSON is the JSON wire format for Tonk.

--- a/internal/domain/Tressette.go
+++ b/internal/domain/Tressette.go
@@ -212,7 +212,7 @@ func (g *Tressette) ResolveTrick() {
 		bonus = " +ultima"
 	}
 	g.appendLog(winnerIdx, "trick_win",
-		fmt.Sprintf("%s wins trick %d (+%d/3%s)", g.playerName(winnerIdx), g.trickNumber, thirds, bonus),
+		fmt.Sprintf("%s wins trick %d (+%d/3%s)", playerName(g.players, winnerIdx), g.trickNumber, thirds, bonus),
 		trickCards)
 
 	g.leadPlayerIdx = winnerIdx
@@ -354,7 +354,7 @@ func (g *Tressette) playCard(playerIdx int, card *Card) {
 		PlayerIdx: playerIdx,
 		Card:      card,
 	})
-	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", g.playerName(playerIdx), cardStr(card)), []*Card{card})
+	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", playerName(g.players, playerIdx), cardStr(card)), []*Card{card})
 
 	if len(g.currentTrick) == TressettePlayerCnt {
 		g.phase = TressettePhaseTrickEnd
@@ -427,17 +427,6 @@ func tressetteSortHand(p *TressettePlayer) {
 		}
 		return tressetteStrength(ci.GetValue()) < tressetteStrength(cj.GetValue())
 	})
-}
-
-// playerName プレイヤー名を返す
-func (g *Tressette) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // teamName チーム表示名 (0=A, 1=B)

--- a/internal/domain/Truco.go
+++ b/internal/domain/Truco.go
@@ -513,7 +513,7 @@ func (t *Truco) callTruco(caller int) {
 	t.responderIdx = 1 - caller
 	t.phase = TrucoPhaseRespond
 	t.appendLog(caller, "truco",
-		fmt.Sprintf("%s calls %s", t.playerName(caller), trucoLevelName(t.pendingLevel)), nil)
+		fmt.Sprintf("%s calls %s", playerName(t.players, caller), trucoLevelName(t.pendingLevel)), nil)
 }
 
 // respond responder が宣言に応答する。
@@ -526,7 +526,7 @@ func (t *Truco) respond(responder int, accept bool) {
 		t.responderIdx = -1
 		t.phase = TrucoPhasePlay
 		t.appendLog(responder, "accept",
-			fmt.Sprintf("%s accepts (stake %d)", t.playerName(responder), t.handStake), nil)
+			fmt.Sprintf("%s accepts (stake %d)", playerName(t.players, responder), t.handStake), nil)
 		return
 	}
 	// 拒否: 宣言者が直前の確定点でマノを取る
@@ -538,7 +538,7 @@ func (t *Truco) respond(responder int, accept bool) {
 	t.phase = TrucoPhaseHandEnd
 	t.appendLog(responder, "decline",
 		fmt.Sprintf("%s declines; %s wins hand (%d pt)",
-			t.playerName(responder), t.playerName(caller), t.handStake), nil)
+			playerName(t.players, responder), playerName(t.players, caller), t.handStake), nil)
 }
 
 // --- Private: trick / hand progression ---
@@ -547,7 +547,7 @@ func (t *Truco) respond(responder int, accept bool) {
 func (t *Truco) playCard(playerIdx int, card *Card) {
 	t.currentTrick = append(t.currentTrick, &TrickCard{PlayerIdx: playerIdx, Card: card})
 	t.appendLog(playerIdx, "play",
-		fmt.Sprintf("%s plays %s", t.playerName(playerIdx), cardStr(card)), []*Card{card})
+		fmt.Sprintf("%s plays %s", playerName(t.players, playerIdx), cardStr(card)), []*Card{card})
 	if len(t.currentTrick) == TrucoPlayerCnt {
 		t.finishBaza()
 	} else {
@@ -566,7 +566,7 @@ func (t *Truco) finishBaza() {
 	} else {
 		t.leadPlayerIdx = result
 		t.appendLog(result, "baza_win",
-			fmt.Sprintf("%s wins baza %d", t.playerName(result), t.trickNumber), cards)
+			fmt.Sprintf("%s wins baza %d", playerName(t.players, result), t.trickNumber), cards)
 	}
 	t.phase = TrucoPhaseTrickEnd
 }
@@ -592,7 +592,7 @@ func (t *Truco) advanceHand() {
 	}
 	t.appendLog(t.handWinnerIdx, "hand_end",
 		fmt.Sprintf("Hand %d: %s +%d (match %d-%d)", t.handNumber,
-			t.playerName(t.handWinnerIdx), t.handStake,
+			playerName(t.players, t.handWinnerIdx), t.handStake,
 			t.playerMatchPoints[0], t.playerMatchPoints[1]), nil)
 
 	if t.playerMatchPoints[t.handWinnerIdx] >= t.matchTarget {
@@ -639,7 +639,7 @@ func (t *Truco) dealHand() {
 	t.currentPlayerIdx = t.manoIdx
 	t.phase = TrucoPhasePlay
 	t.appendLog(-1, "deal", fmt.Sprintf("Hand %d dealt (dealer=%s)",
-		t.handNumber, t.playerName(t.dealerIdx)), nil)
+		t.handNumber, playerName(t.players, t.dealerIdx)), nil)
 }
 
 // --- Pure rule helpers ---
@@ -742,17 +742,6 @@ func (t *Truco) sortAllHands() {
 			p.AddCard(c)
 		}
 	}
-}
-
-// playerName プレイヤー名を返す (ログ用)。
-func (t *Truco) playerName(idx int) string {
-	if idx < 0 || idx >= len(t.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if t.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // trucoLevelName ベッティングレベルの表示名を返す。

--- a/internal/domain/Tute.go
+++ b/internal/domain/Tute.go
@@ -240,7 +240,7 @@ func (g *Tute) applyMarriage(playerIdx, suit int) {
 	team := TuteTeamOf(playerIdx)
 	g.roundTeamPts[team] += pts
 	g.appendLog(playerIdx, "marriage",
-		fmt.Sprintf("%s declares a %s marriage (+%d)", g.playerName(playerIdx), suitStr(suit), pts), nil)
+		fmt.Sprintf("%s declares a %s marriage (+%d)", playerName(g.players, playerIdx), suitStr(suit), pts), nil)
 }
 
 // hasTute プレイヤーが 4 枚の K または 4 枚の Q を持つか。
@@ -255,7 +255,7 @@ func (g *Tute) applyTute(playerIdx int) {
 	g.winnerTeam = team
 	g.phase = TutePhaseGameEnd
 	g.appendLog(playerIdx, "tute",
-		fmt.Sprintf("%s declares TUTE! Team %s wins the game!", g.playerName(playerIdx), teamName(team)), nil)
+		fmt.Sprintf("%s declares TUTE! Team %s wins the game!", playerName(g.players, playerIdx), teamName(team)), nil)
 }
 
 // CpuPlay 現在の手番が CPU の場合に 1 ターン実行する。
@@ -291,7 +291,7 @@ func (g *Tute) CpuPlay() {
 // playCard カードをプレイする共通処理。
 func (g *Tute) playCard(playerIdx int, card *Card) {
 	g.currentTrick = append(g.currentTrick, &TrickCard{PlayerIdx: playerIdx, Card: card})
-	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", g.playerName(playerIdx), cardStr(card)), []*Card{card})
+	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", playerName(g.players, playerIdx), cardStr(card)), []*Card{card})
 
 	if len(g.currentTrick) == TutePlayerCnt {
 		g.phase = TutePhaseTrickEnd
@@ -321,7 +321,7 @@ func (g *Tute) ResolveTrick() {
 		bonus = fmt.Sprintf(" +%d last", TuteLastTrickBonus)
 	}
 	g.appendLog(winnerIdx, "trick_win",
-		fmt.Sprintf("%s wins trick %d (+%d%s)", g.playerName(winnerIdx), g.trickNumber, pts, bonus), trickCards)
+		fmt.Sprintf("%s wins trick %d (+%d%s)", playerName(g.players, winnerIdx), g.trickNumber, pts, bonus), trickCards)
 
 	g.leadPlayerIdx = winnerIdx
 	// Keep currentTrick intact through TrickEnd so the resolved trick stays
@@ -527,17 +527,6 @@ func tuteSortHand(p *TutePlayer) {
 	for _, c := range cards {
 		p.AddCard(c)
 	}
-}
-
-// playerName プレイヤー名を返す。
-func (g *Tute) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // indexOfPlayerInTrick currentTrick 内で playerIdx の札の位置を返す (-1=なし)。

--- a/internal/domain/TwentyNine.go
+++ b/internal/domain/TwentyNine.go
@@ -242,9 +242,9 @@ func (g *TwentyNine) applyBid(idx int, bid TwentyNineBid) error {
 	g.bids[idx] = bid
 	g.bidDone[idx] = true
 	if bid != TwentyNineBidPass {
-		g.appendLog(idx, "bid", fmt.Sprintf("%s bids %d", g.playerName(idx), int(bid)), nil)
+		g.appendLog(idx, "bid", fmt.Sprintf("%s bids %d", playerName(g.players, idx), int(bid)), nil)
 	} else {
-		g.appendLog(idx, "bid", fmt.Sprintf("%s passes", g.playerName(idx)), nil)
+		g.appendLog(idx, "bid", fmt.Sprintf("%s passes", playerName(g.players, idx)), nil)
 	}
 	for k := 1; k <= TwentyNinePlayerCnt; k++ {
 		ni := (idx + k) % TwentyNinePlayerCnt
@@ -271,7 +271,7 @@ func (g *TwentyNine) resolveBidding() {
 	g.trumpSuit = g.longestSuit(idx)
 	g.trumpRevealed = false
 	g.appendLog(idx, "contract",
-		fmt.Sprintf("%s (team %s) bids %d with a hidden trump", g.playerName(idx), twentyNineTeamName(TwentyNineTeamOf(idx)), int(bid)), nil)
+		fmt.Sprintf("%s (team %s) bids %d with a hidden trump", playerName(g.players, idx), twentyNineTeamName(TwentyNineTeamOf(idx)), int(bid)), nil)
 	g.leadPlayerIdx = idx
 	g.currentPlayerIdx = g.leadPlayerIdx
 	g.phase = TwentyNinePhasePlay
@@ -377,7 +377,7 @@ func (g *TwentyNine) playCard(playerIdx int, card *Card) {
 		}
 	}
 	g.currentTrick = append(g.currentTrick, &TrickCard{PlayerIdx: playerIdx, Card: card})
-	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", g.playerName(playerIdx), cardStr(card)), []*Card{card})
+	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", playerName(g.players, playerIdx), cardStr(card)), []*Card{card})
 
 	if len(g.currentTrick) == TwentyNinePlayerCnt {
 		g.phase = TwentyNinePhaseTrickEnd
@@ -407,7 +407,7 @@ func (g *TwentyNine) ResolveTrick() {
 		bonus = " +1 last"
 	}
 	g.appendLog(winnerIdx, "trick_win",
-		fmt.Sprintf("%s wins trick %d (+%d%s)", g.playerName(winnerIdx), g.trickNumber, pts, bonus), trickCards)
+		fmt.Sprintf("%s wins trick %d (+%d%s)", playerName(g.players, winnerIdx), g.trickNumber, pts, bonus), trickCards)
 
 	g.leadPlayerIdx = winnerIdx
 	if g.trickNumber >= TwentyNineTrickCount {
@@ -590,17 +590,6 @@ func twentyNineSortHand(p *TwentyNinePlayer) {
 	for _, c := range cards {
 		p.AddCard(c)
 	}
-}
-
-// playerName プレイヤー名を返す。
-func (g *TwentyNine) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // indexOfPlayerInTrick currentTrick 内で playerIdx の札の位置を返す (-1=なし)。

--- a/internal/domain/TwoTenJack.go
+++ b/internal/domain/TwoTenJack.go
@@ -158,7 +158,7 @@ func (t *TwoTenJack) PlayerDeclareTrump(suit int) error {
 	}
 
 	t.trumpSuit = suit
-	t.appendLog(t.declarerIdx, "declare_trump", fmt.Sprintf("%s declares trump: %s", t.playerName(t.declarerIdx), twoTenJackSuitName(suit)), nil)
+	t.appendLog(t.declarerIdx, "declare_trump", fmt.Sprintf("%s declares trump: %s", playerName(t.players, t.declarerIdx), twoTenJackSuitName(suit)), nil)
 	t.startPlayPhase()
 	return nil
 }
@@ -176,7 +176,7 @@ func (t *TwoTenJack) CpuDeclareTrump() {
 	}
 	suit := t.cpuSelectTrump(t.declarerIdx)
 	t.trumpSuit = suit
-	t.appendLog(t.declarerIdx, "declare_trump", fmt.Sprintf("%s declares trump: %s", t.playerName(t.declarerIdx), twoTenJackSuitName(suit)), nil)
+	t.appendLog(t.declarerIdx, "declare_trump", fmt.Sprintf("%s declares trump: %s", playerName(t.players, t.declarerIdx), twoTenJackSuitName(suit)), nil)
 	t.startPlayPhase()
 }
 
@@ -247,7 +247,7 @@ func (t *TwoTenJack) ResolveTrick() {
 
 	t.players[winnerIdx].AddTrick(trickCards)
 
-	winnerName := t.playerName(winnerIdx)
+	winnerName := playerName(t.players, winnerIdx)
 	t.appendLog(winnerIdx, "trick_win", fmt.Sprintf("%s wins trick %d", winnerName, t.trickNumber), trickCards)
 
 	t.leadPlayerIdx = winnerIdx
@@ -326,7 +326,7 @@ func (t *TwoTenJack) ScoreRound() {
 
 	for i := 0; i < TwoTenJackPlayerCnt; i++ {
 		t.appendLog(i, "cumulative_score", fmt.Sprintf("%s: total=%d",
-			t.playerName(i), t.players[i].GetCumulativeScore()), nil)
+			playerName(t.players, i), t.players[i].GetCumulativeScore()), nil)
 	}
 
 	t.checkGameEnd()
@@ -438,7 +438,7 @@ func (t *TwoTenJack) playCard(playerIdx int, card *Card) {
 		PlayerIdx: playerIdx,
 		Card:      card,
 	})
-	t.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", t.playerName(playerIdx), cardStr(card)), []*Card{card})
+	t.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", playerName(t.players, playerIdx), cardStr(card)), []*Card{card})
 
 	if len(t.currentTrick) == TwoTenJackPlayerCnt {
 		t.phase = TwoTenJackPhaseTrickEnd
@@ -517,17 +517,6 @@ func twoTenJackSortHand(p *TwoTenJackPlayer) {
 		}
 		return ci.GetValue() < cj.GetValue()
 	})
-}
-
-// playerName プレイヤー名を返す
-func (t *TwoTenJack) playerName(idx int) string {
-	if idx < 0 || idx >= len(t.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if t.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // twoTenJackSuitName スート名を返す

--- a/internal/domain/TwoTenJack_internal_test.go
+++ b/internal/domain/TwoTenJack_internal_test.go
@@ -185,10 +185,10 @@ func TestTTJInternal_StartPlayPhase(t *testing.T) {
 
 func TestTTJInternal_PlayerName(t *testing.T) {
 	ttj := newInternalTTJ()
-	assert.Equal(t, "You", ttj.playerName(0))
-	assert.Equal(t, "CPU 1", ttj.playerName(1))
-	assert.Equal(t, "Player -1", ttj.playerName(-1))
-	assert.Equal(t, "Player 99", ttj.playerName(99))
+	assert.Equal(t, "You", playerName(ttj.players, 0))
+	assert.Equal(t, "CPU 1", playerName(ttj.players, 1))
+	assert.Equal(t, "Player -1", playerName(ttj.players, -1))
+	assert.Equal(t, "Player 99", playerName(ttj.players, 99))
 }
 
 func TestTTJInternal_SortAllHands_StableOrder(t *testing.T) {

--- a/internal/domain/Tysiac.go
+++ b/internal/domain/Tysiac.go
@@ -252,11 +252,11 @@ func (g *Tysiac) applyBid(playerIdx int, raise bool) {
 	if raise {
 		g.currentBid += TysiacBidStep
 		g.appendLog(playerIdx, "bid",
-			fmt.Sprintf("%s bids %d", g.playerName(playerIdx), g.currentBid), nil)
+			fmt.Sprintf("%s bids %d", playerName(g.players, playerIdx), g.currentBid), nil)
 	} else {
 		g.bidPassed[playerIdx] = true
 		g.appendLog(playerIdx, "bid_pass",
-			fmt.Sprintf("%s passes", g.playerName(playerIdx)), nil)
+			fmt.Sprintf("%s passes", playerName(g.players, playerIdx)), nil)
 	}
 
 	if g.activeBidders() <= 1 {
@@ -294,7 +294,7 @@ func (g *Tysiac) finalizeAuction() {
 	g.declarerIdx = declarer
 	g.contract = g.currentBid
 	g.appendLog(declarer, "declarer",
-		fmt.Sprintf("%s is declarer with contract %d", g.playerName(declarer), g.contract), nil)
+		fmt.Sprintf("%s is declarer with contract %d", playerName(g.players, declarer), g.contract), nil)
 
 	g.startTalon()
 }
@@ -355,7 +355,7 @@ func (g *Tysiac) startTalon() {
 	g.talon = nil
 	tysiacSortHand(g.players[g.declarerIdx])
 	g.appendLog(g.declarerIdx, "talon_take",
-		fmt.Sprintf("%s takes the talon", g.playerName(g.declarerIdx)), nil)
+		fmt.Sprintf("%s takes the talon", playerName(g.players, g.declarerIdx)), nil)
 	g.discardCount = 0
 	g.currentPlayerIdx = g.declarerIdx
 
@@ -395,7 +395,7 @@ func (g *Tysiac) giveDiscard(cardIndex int) {
 	g.players[recipient].AddCard(card)
 	tysiacSortHand(g.players[recipient])
 	g.appendLog(g.declarerIdx, "discard",
-		fmt.Sprintf("%s gives a card to %s", g.playerName(g.declarerIdx), g.playerName(recipient)), nil)
+		fmt.Sprintf("%s gives a card to %s", playerName(g.players, g.declarerIdx), playerName(g.players, recipient)), nil)
 	g.discardCount++
 }
 
@@ -523,13 +523,13 @@ func (g *Tysiac) maybeDeclareMarriage(playerIdx int, card *Card) {
 	g.roundMarriage[playerIdx] += pts
 	g.appendLog(playerIdx, "marriage",
 		fmt.Sprintf("%s declares a %s marriage (+%d, trump=%s)",
-			g.playerName(playerIdx), tysiacSuitName(suit), pts, tysiacSuitName(suit)), nil)
+			playerName(g.players, playerIdx), tysiacSuitName(suit), pts, tysiacSuitName(suit)), nil)
 }
 
 // playCard カードをプレイする共通処理。
 func (g *Tysiac) playCard(playerIdx int, card *Card) {
 	g.currentTrick = append(g.currentTrick, &TrickCard{PlayerIdx: playerIdx, Card: card})
-	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", g.playerName(playerIdx), cardStr(card)), []*Card{card})
+	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", playerName(g.players, playerIdx), cardStr(card)), []*Card{card})
 
 	if len(g.currentTrick) == TysiacPlayerCnt {
 		g.phase = TysiacPhaseTrickEnd
@@ -553,7 +553,7 @@ func (g *Tysiac) ResolveTrick() {
 	g.players[winnerIdx].AddTrick(trickCards)
 	g.roundCardPts[winnerIdx] += pts
 	g.appendLog(winnerIdx, "trick_win",
-		fmt.Sprintf("%s wins trick %d (+%d)", g.playerName(winnerIdx), g.trickNumber, pts), trickCards)
+		fmt.Sprintf("%s wins trick %d (+%d)", playerName(g.players, winnerIdx), g.trickNumber, pts), trickCards)
 
 	g.leadPlayerIdx = winnerIdx
 	if g.trickNumber >= TysiacTrickCount {
@@ -594,7 +594,7 @@ func (g *Tysiac) ScoreRound() {
 	}
 	g.appendLog(-1, "round_score",
 		fmt.Sprintf("round %d scored: declarer(%s) contract=%d",
-			g.roundNumber, g.playerName(g.declarerIdx), g.contract), nil)
+			g.roundNumber, playerName(g.players, g.declarerIdx), g.contract), nil)
 	g.checkGameEnd()
 }
 
@@ -616,7 +616,7 @@ func (g *Tysiac) checkGameEnd() {
 		g.gameEndFlag = true
 		g.winnerPlayer = leader
 		g.phase = TysiacPhaseGameEnd
-		g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the match!", g.playerName(leader)), nil)
+		g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the match!", playerName(g.players, leader)), nil)
 	}
 }
 
@@ -835,17 +835,6 @@ func tysiacSortHand(p *TysiacPlayer) {
 	for _, c := range cards {
 		p.AddCard(c)
 	}
-}
-
-// playerName プレイヤー名を返す。
-func (g *Tysiac) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // indexOfPlayerInTrick currentTrick 内で playerIdx の札の位置を返す (-1=なし)。

--- a/internal/domain/Ulti.go
+++ b/internal/domain/Ulti.go
@@ -320,7 +320,7 @@ func (g *Ulti) applyBid(contract UltiContract, trumpSuit int) {
 	g.talonTaken = true
 	g.sortAllHands()
 	g.appendLog(g.declarerIdx, "bid",
-		fmt.Sprintf("%s declares %s (trump %s)", g.playerName(g.declarerIdx), ultiContractName(contract), ultiSuitName(g.trumpSuit)), nil)
+		fmt.Sprintf("%s declares %s (trump %s)", playerName(g.players, g.declarerIdx), ultiContractName(contract), ultiSuitName(g.trumpSuit)), nil)
 	g.phase = UltiPhaseDiscard
 }
 
@@ -359,7 +359,7 @@ func (g *Ulti) PlayerDiscard(cardIndices []int) error {
 		g.discards = append(g.discards, player.RemoveCard(idx))
 	}
 	g.appendLog(g.declarerIdx, "discard",
-		fmt.Sprintf("%s discards %d cards", g.playerName(g.declarerIdx), len(g.discards)), append([]*Card(nil), g.discards...))
+		fmt.Sprintf("%s discards %d cards", playerName(g.players, g.declarerIdx), len(g.discards)), append([]*Card(nil), g.discards...))
 	g.startPlay()
 	return nil
 }
@@ -423,7 +423,7 @@ func (g *Ulti) CpuPlay() {
 // playCard カードをプレイする共通処理。
 func (g *Ulti) playCard(playerIdx int, card *Card) {
 	g.currentTrick = append(g.currentTrick, &TrickCard{PlayerIdx: playerIdx, Card: card})
-	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", g.playerName(playerIdx), cardStr(card)), []*Card{card})
+	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", playerName(g.players, playerIdx), cardStr(card)), []*Card{card})
 
 	if len(g.currentTrick) == UltiPlayerCnt {
 		g.phase = UltiPhaseTrickEnd
@@ -444,7 +444,7 @@ func (g *Ulti) ResolveTrick() {
 	}
 	g.players[winnerIdx].AddTrick(trickCards)
 	g.appendLog(winnerIdx, "trick_win",
-		fmt.Sprintf("%s wins trick %d", g.playerName(winnerIdx), g.trickNumber), trickCards)
+		fmt.Sprintf("%s wins trick %d", playerName(g.players, winnerIdx), g.trickNumber), trickCards)
 
 	g.leadPlayerIdx = winnerIdx
 	if g.trickNumber >= UltiTrickCount {
@@ -477,7 +477,7 @@ func (g *Ulti) enterRoundEnd() {
 	g.applyScores(g.outcome)
 	g.appendLog(-1, "round_score",
 		fmt.Sprintf("round %d: declarer(%s) %s %s",
-			g.roundNumber, g.playerName(g.declarerIdx), ultiContractName(g.contract), ultiOutcomeName(g.outcome)), nil)
+			g.roundNumber, playerName(g.players, g.declarerIdx), ultiContractName(g.contract), ultiOutcomeName(g.outcome)), nil)
 	g.checkGameEnd()
 }
 
@@ -588,7 +588,7 @@ func (g *Ulti) checkGameEnd() {
 	g.winnerPlayer = leader
 	g.phase = UltiPhaseGameEnd
 	g.result = g.humanResult(leader, tie)
-	g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the match!", g.playerName(leader)), nil)
+	g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the match!", playerName(g.players, leader)), nil)
 }
 
 // humanResult 人間 (seat 0) の視点でマッチ結果を返す。単独トップなら Win、トップ同点なら None、他は Lose。
@@ -812,17 +812,6 @@ func ultiSortHand(p *UltiPlayer, trump int, contract UltiContract) {
 	for _, c := range cards {
 		p.AddCard(c)
 	}
-}
-
-// playerName プレイヤー名を返す。
-func (g *Ulti) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // ultiContractName コントラクトの表示名を返す。

--- a/internal/domain/Watten.go
+++ b/internal/domain/Watten.go
@@ -269,7 +269,7 @@ func (g *Watten) doDeclare(playerIdx, rank, suit int) {
 	g.criticalSuit = suit
 	g.appendLog(playerIdx, "declare",
 		fmt.Sprintf("%s declares Schlag=%d critical=%s",
-			g.playerName(playerIdx), rank, suitStr(suit)), nil)
+			playerName(g.players, playerIdx), rank, suitStr(suit)), nil)
 	g.sortAllHands()
 	g.startPlayPhase()
 }
@@ -338,7 +338,7 @@ func (g *Watten) CpuPlay() {
 func (g *Watten) playCard(playerIdx int, card *Card) {
 	g.currentTrick = append(g.currentTrick, &TrickCard{PlayerIdx: playerIdx, Card: card})
 	g.appendLog(playerIdx, "play",
-		fmt.Sprintf("%s plays %s", g.playerName(playerIdx), cardStr(card)), []*Card{card})
+		fmt.Sprintf("%s plays %s", playerName(g.players, playerIdx), cardStr(card)), []*Card{card})
 
 	if len(g.currentTrick) == WattenPlayerCnt {
 		g.phase = WattenPhaseTrickEnd
@@ -362,7 +362,7 @@ func (g *Watten) ResolveTrick() {
 	g.teamTricks[winnerTeam]++
 	g.leadPlayerIdx = winnerIdx
 	g.appendLog(winnerIdx, "trick_win",
-		fmt.Sprintf("%s wins trick %d", g.playerName(winnerIdx), g.trickNumber), trickCards)
+		fmt.Sprintf("%s wins trick %d", playerName(g.players, winnerIdx), g.trickNumber), trickCards)
 
 	if g.trickNumber >= WattenHandSize {
 		g.enterRoundEnd(g.dealWinnerByTricks())
@@ -495,7 +495,7 @@ func (g *Watten) respond(responder int, hold bool) {
 		g.currentPlayerIdx = g.leadPlayerIdx
 		g.appendLog(responder, "hold",
 			fmt.Sprintf("%s holds (stake %d, team %d leads)",
-				g.playerName(responder), g.stake, raiser), nil)
+				playerName(g.players, responder), g.stake, raiser), nil)
 		return
 	}
 	// fold: レイズしたチームが直前の確定ステークでディールを取る。
@@ -505,7 +505,7 @@ func (g *Watten) respond(responder int, hold bool) {
 	g.responderIdx = -1
 	g.appendLog(responder, "fold",
 		fmt.Sprintf("%s folds; team %d wins deal (%d pt)",
-			g.playerName(responder), raiser, g.stake), nil)
+			playerName(g.players, responder), raiser, g.stake), nil)
 	g.enterRoundEnd(raiser)
 }
 
@@ -828,16 +828,6 @@ func (g *Watten) sortAllHands() {
 			p.AddCard(c)
 		}
 	}
-}
-
-func (g *Watten) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // --- CPU AI ---

--- a/internal/domain/Whist.go
+++ b/internal/domain/Whist.go
@@ -190,7 +190,7 @@ func (w *Whist) ResolveTrick() {
 
 	w.players[winnerIdx].AddTrick(trickCards)
 
-	winnerName := w.playerName(winnerIdx)
+	winnerName := playerName(w.players, winnerIdx)
 	w.appendLog(winnerIdx, "trick_win", fmt.Sprintf("%s wins trick %d", winnerName, w.trickNumber), trickCards)
 
 	w.leadPlayerIdx = winnerIdx
@@ -390,7 +390,7 @@ func (w *Whist) playCard(playerIdx int, card *Card) {
 		Card:      card,
 	})
 
-	w.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", w.playerName(playerIdx), cardStr(card)), []*Card{card})
+	w.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", playerName(w.players, playerIdx), cardStr(card)), []*Card{card})
 
 	if len(w.currentTrick) == WhistPlayerCnt {
 		w.phase = WhistPhaseTrickEnd
@@ -474,17 +474,6 @@ func whistSortHand(p *WhistPlayer) {
 		}
 		return ci.GetValue() < cj.GetValue()
 	})
-}
-
-// playerName プレイヤー名を返す
-func (w *Whist) playerName(idx int) string {
-	if idx < 0 || idx >= len(w.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if w.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // playHintReason プレイヒントの理由を判定する

--- a/internal/domain/Whist_internal_test.go
+++ b/internal/domain/Whist_internal_test.go
@@ -178,9 +178,9 @@ func TestWhist_findHumanIdx(t *testing.T) {
 
 func TestWhist_playerName(t *testing.T) {
 	w := newInternalTestWhist()
-	assert.Equal(t, "You", w.playerName(0))
-	assert.Equal(t, "CPU 1", w.playerName(1))
-	assert.Contains(t, w.playerName(-1), "Player")
+	assert.Equal(t, "You", playerName(w.players, 0))
+	assert.Equal(t, "CPU 1", playerName(w.players, 1))
+	assert.Contains(t, playerName(w.players, -1), "Player")
 }
 
 // TestWhist_cpuPlayHard_Follow_OverCardLowest pins the follow-to-win branch:

--- a/internal/domain/Wizard.go
+++ b/internal/domain/Wizard.go
@@ -182,7 +182,7 @@ func (o *Wizard) PlayerBid(bid int) error {
 	// Wizardはフックルール（合計制限）を持たない: 合計ビッド≠トリック数を許容する。
 
 	o.players[humanIdx].SetBid(bid)
-	o.appendLog(humanIdx, "bid", fmt.Sprintf("%s bids %d", o.playerName(humanIdx), bid), nil)
+	o.appendLog(humanIdx, "bid", fmt.Sprintf("%s bids %d", playerName(o.players, humanIdx), bid), nil)
 
 	o.advanceBid()
 	return nil
@@ -202,7 +202,7 @@ func (o *Wizard) CpuBid() {
 
 	bid := o.cpuSelectBid(o.bidPlayerIdx)
 	o.players[o.bidPlayerIdx].SetBid(bid)
-	o.appendLog(o.bidPlayerIdx, "bid", fmt.Sprintf("%s bids %d", o.playerName(o.bidPlayerIdx), bid), nil)
+	o.appendLog(o.bidPlayerIdx, "bid", fmt.Sprintf("%s bids %d", playerName(o.players, o.bidPlayerIdx), bid), nil)
 
 	o.advanceBid()
 }
@@ -269,7 +269,7 @@ func (o *Wizard) ResolveTrick() {
 
 	o.players[winnerIdx].AddTrick(trickCards)
 
-	winnerName := o.playerName(winnerIdx)
+	winnerName := playerName(o.players, winnerIdx)
 	o.appendLog(winnerIdx, "trick_win", fmt.Sprintf("%s wins trick %d", winnerName, o.trickNumber), trickCards)
 
 	o.leadPlayerIdx = winnerIdx
@@ -307,7 +307,7 @@ func (o *Wizard) ScoreRound() {
 			// ビッド的中: 20 + 10×bid ポイント
 			p.roundScore = 20 + 10*bid
 			o.appendLog(i, "bid_success", fmt.Sprintf("%s bid %d, took %d: +%d",
-				o.playerName(i), bid, tricks, p.roundScore), nil)
+				playerName(o.players, i), bid, tricks, p.roundScore), nil)
 		} else {
 			// 外れ: -10×|トリック数 - ビッド|
 			diff := tricks - bid
@@ -316,7 +316,7 @@ func (o *Wizard) ScoreRound() {
 			}
 			p.roundScore = -10 * diff
 			o.appendLog(i, "bid_fail", fmt.Sprintf("%s bid %d, took %d: %d",
-				o.playerName(i), bid, tricks, p.roundScore), nil)
+				playerName(o.players, i), bid, tricks, p.roundScore), nil)
 		}
 	}
 
@@ -328,7 +328,7 @@ func (o *Wizard) ScoreRound() {
 	// スコアログ
 	for i := range WizardPlayerCnt {
 		o.appendLog(i, "cumulative_score", fmt.Sprintf("%s: total=%d",
-			o.playerName(i), o.players[i].cumulativeScore), nil)
+			playerName(o.players, i), o.players[i].cumulativeScore), nil)
 	}
 
 	// ゲーム終了判定
@@ -588,7 +588,7 @@ func (o *Wizard) playCard(playerIdx int, card *Card) {
 		Card:      card,
 	})
 
-	o.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", o.playerName(playerIdx), wizardCardStr(card)), []*Card{card})
+	o.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", playerName(o.players, playerIdx), wizardCardStr(card)), []*Card{card})
 
 	if len(o.currentTrick) == WizardPlayerCnt {
 		o.phase = WizardPhaseTrickEnd
@@ -737,7 +737,7 @@ func (o *Wizard) determineWinner() {
 			o.winnerIdx = i
 		}
 	}
-	o.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game!", o.playerName(o.winnerIdx)), nil)
+	o.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game!", playerName(o.players, o.winnerIdx)), nil)
 }
 
 // sortAllHands 全プレイヤーの手札をソートする
@@ -769,17 +769,6 @@ func wizardCardStr(card *Card) string {
 		return "Jester"
 	}
 	return cardStr(card)
-}
-
-// playerName プレイヤー名を返す
-func (o *Wizard) playerName(idx int) string {
-	if idx < 0 || idx >= len(o.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if o.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す

--- a/internal/domain/Yaniv.go
+++ b/internal/domain/Yaniv.go
@@ -253,7 +253,7 @@ func (g *Yaniv) discard(idx int, cardIndices []int) error {
 	sortCardsForDiscard(removed)
 	g.pendingDiscard = removed
 
-	g.appendLog(idx, "discard", fmt.Sprintf("%s discards %s", g.playerName(idx), cardsStr(removed)), removed)
+	g.appendLog(idx, "discard", fmt.Sprintf("%s discards %s", playerName(g.players, idx), cardsStr(removed)), removed)
 	g.phase = YanivPhaseDraw
 	return nil
 }
@@ -288,7 +288,7 @@ func (g *Yaniv) drawFromStock(idx int) {
 	g.drawPile = g.drawPile[:len(g.drawPile)-1]
 	g.players[idx].AddCard(card)
 	g.sortHand(idx)
-	g.appendLog(idx, "draw_stock", fmt.Sprintf("%s draws from stock", g.playerName(idx)), nil)
+	g.appendLog(idx, "draw_stock", fmt.Sprintf("%s draws from stock", playerName(g.players, idx)), nil)
 	g.finalizeDraw(-1)
 }
 
@@ -301,7 +301,7 @@ func (g *Yaniv) drawFromPickup(idx, end int) {
 	card := g.pickupCards[takenIdx]
 	g.players[idx].AddCard(card)
 	g.sortHand(idx)
-	g.appendLog(idx, "draw_pickup", fmt.Sprintf("%s takes %s from the discard", g.playerName(idx), cardStr(card)), []*Card{card})
+	g.appendLog(idx, "draw_pickup", fmt.Sprintf("%s takes %s from the discard", playerName(g.players, idx), cardStr(card)), []*Card{card})
 	g.finalizeDraw(takenIdx)
 }
 
@@ -462,7 +462,7 @@ func (g *Yaniv) resolveYaniv(callerIdx int) {
 		g.asafWinnerIdx = asafWinner
 		scores[callerIdx] = YanivAsafPenalty
 		g.appendLog(callerIdx, "asaf", fmt.Sprintf("%s calls Yaniv (%d) but is undercut by %s (%d)! +%d penalty",
-			g.playerName(callerIdx), callerTotal, g.playerName(asafWinner), minOpp, YanivAsafPenalty), nil)
+			playerName(g.players, callerIdx), callerTotal, playerName(g.players, asafWinner), minOpp, YanivAsafPenalty), nil)
 		for i, p := range g.players {
 			if i == callerIdx || p.IsEliminated() || i == asafWinner {
 				continue
@@ -471,7 +471,7 @@ func (g *Yaniv) resolveYaniv(callerIdx int) {
 		}
 	} else {
 		scores[callerIdx] = 0
-		g.appendLog(callerIdx, "yaniv", fmt.Sprintf("%s calls Yaniv with %d and wins the round!", g.playerName(callerIdx), callerTotal), nil)
+		g.appendLog(callerIdx, "yaniv", fmt.Sprintf("%s calls Yaniv with %d and wins the round!", playerName(g.players, callerIdx), callerTotal), nil)
 		for i, p := range g.players {
 			if i == callerIdx || p.IsEliminated() {
 				continue
@@ -488,7 +488,7 @@ func (g *Yaniv) resolveYaniv(callerIdx int) {
 	for i, p := range g.players {
 		if !p.IsEliminated() && p.GetScore() > g.config.ScoreLimit {
 			p.SetEliminated(true)
-			g.appendLog(i, "eliminate", fmt.Sprintf("%s is eliminated (score: %d)", g.playerName(i), p.GetScore()), nil)
+			g.appendLog(i, "eliminate", fmt.Sprintf("%s is eliminated (score: %d)", playerName(g.players, i), p.GetScore()), nil)
 		}
 	}
 
@@ -529,7 +529,7 @@ func (g *Yaniv) checkGameEnd() {
 	g.gameEndFlag = true
 	g.phase = YanivPhaseGameEnd
 	g.winnerIdx = g.leaderIdx()
-	g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game!", g.playerName(g.winnerIdx)), nil)
+	g.appendLog(-1, "game_end", fmt.Sprintf("%s wins the game!", playerName(g.players, g.winnerIdx)), nil)
 }
 
 // leaderIdx 生存者のうち最も失点が少ないプレイヤー (同点は若いインデックス) を返す
@@ -836,17 +836,6 @@ func (g *Yaniv) sortHand(playerIdx int) {
 	for _, c := range cards {
 		p.AddCard(c)
 	}
-}
-
-// playerName プレイヤー名を返す
-func (g *Yaniv) playerName(idx int) string {
-	if idx < 0 || idx >= len(g.players) {
-		return fmt.Sprintf("Player %d", idx)
-	}
-	if g.players[idx].GetIsHuman() {
-		return "You"
-	}
-	return fmt.Sprintf("CPU %d", idx)
 }
 
 // cardsStr 複数カードを空白区切りの文字列にする

--- a/internal/domain/player_helpers.go
+++ b/internal/domain/player_helpers.go
@@ -1,6 +1,9 @@
 package domain
 
-import "sort"
+import (
+	"fmt"
+	"sort"
+)
 
 // handHolder is the minimal interface for a player whose hand can be sorted in
 // place: enumerate the cards, clear the hand, and re-add them.
@@ -49,6 +52,24 @@ func findHumanIdx[T humanReporter](players []T) int {
 		}
 	}
 	return -1
+}
+
+// playerName renders a seat for display: "You" for the human, "CPU <idx>" for
+// the rest, and "Player <idx>" when idx is outside the roster. 91 games spelled
+// this out identically.
+//
+// The out-of-range branch is not defensive padding -- action-log entries carry
+// a playerIdx of -1 for system events, and several presenters format a seat
+// before the roster is populated. Callers rely on getting a string back rather
+// than a panic. See issue #5185.
+func playerName[T humanReporter](players []T, idx int) string {
+	if idx < 0 || idx >= len(players) {
+		return fmt.Sprintf("Player %d", idx)
+	}
+	if players[idx].GetIsHuman() {
+		return "You"
+	}
+	return fmt.Sprintf("CPU %d", idx)
 }
 
 // nextActivePlayer performs a circular search for the next non-finished player.

--- a/internal/domain/player_helpers_internal_test.go
+++ b/internal/domain/player_helpers_internal_test.go
@@ -195,3 +195,30 @@ func TestFindHumanIdx_AllCPU(t *testing.T) {
 func TestFindHumanIdx_FirstHumanWins(t *testing.T) {
 	assert.Equal(t, 1, findHumanIdx([]fakeSeat{{false}, {true}, {true}}))
 }
+
+func TestPlayerName(t *testing.T) {
+	seats := []fakeSeat{{true}, {false}, {false}}
+
+	assert.Equal(t, "You", playerName(seats, 0))
+	assert.Equal(t, "CPU 1", playerName(seats, 1))
+	assert.Equal(t, "CPU 2", playerName(seats, 2))
+}
+
+// Out-of-range is a real code path, not padding: action-log entries use -1 for
+// system events, and presenters format seats before the roster is filled.
+// Callers want a string, not a panic.
+func TestPlayerName_OutOfRange(t *testing.T) {
+	seats := []fakeSeat{{true}, {false}}
+
+	assert.Equal(t, "Player -1", playerName(seats, -1), "system events use -1")
+	assert.Equal(t, "Player 2", playerName(seats, 2), "one past the end")
+	assert.Equal(t, "Player 0", playerName([]fakeSeat{}, 0), "empty roster")
+}
+
+// Whichever seat is human gets "You" -- it is not assumed to be seat 0.
+func TestPlayerName_HumanNeedNotBeFirst(t *testing.T) {
+	seats := []fakeSeat{{false}, {false}, {true}}
+
+	assert.Equal(t, "CPU 0", playerName(seats, 0))
+	assert.Equal(t, "You", playerName(seats, 2))
+}


### PR DESCRIPTION
## 概要

[#5185](https://github.com/yuta-yoshinaga/go_trumpcards/issues/5185) フェーズ4の第3弾。**979行削除**（726追加 / 1,705削除、762呼び出し箇所）。本バッチ最大の削減です。

## 5ゲームは自前のまま残します

96個中91個が同一でしたが、**5個は本当に違いました**。

| ゲーム | 差異 |
|---|---|
| BidWhist / Bridge | `idx < 0` で **`"System"`**（正典は `"Player -1"`） |
| GoStop ほか | **`"CPU"`**（seat 番号なし。正典は `"CPU 1"`） |
| 1件 | コンパス表記（North/East/South/West） |

いずれも**アクションログに出る表示文字列**なので、汎用ヘルパに寄せると**ユーザー可視の退行**になります。

## ⚠️ 危うく静かに壊すところでした（記録）

最初の書き換えは**定義の削除だけ**を条件分岐し、**呼び出しの置換は全ファイルに適用**していました。結果、5ゲームは自前メソッドが残ったまま呼び出しだけ汎用ヘルパに向き、**自前実装が未参照になっただけ**の状態になりました。

**`go build` も `go vet -tags test` も、domain / usecase / adapter の全テストも通ります。** 未参照メソッドが増えただけなので当然です。しかし BidWhist のシステムログは `"System"` から `"Player -1"` に変わっていました。

気付けたのは、置換後に「例外ファイルに新形式の呼び出しが何件あるか」を**数えたから**です。

```
BidWhist     own_method=1 generic_calls=7   ← 事故
Bridge       own_method=1 generic_calls=7
GoStop       own_method=1 generic_calls=6
HachiHachi   own_method=1 generic_calls=3
KoiKoi       own_method=1 generic_calls=6
```

バックアップから5ファイルを戻し、`generic_calls=0` を確認しています。**定義をスキップするなら、同じファイルの呼び出しもスキップする**——一括置換の鉄則として記録しました。

## 件数の訂正: 88 → 91

これまで `playerName` を「88件」と報告していましたが、**正しくは91件**でした。重複検出スクリプトがボディ正規化でレシーバを部分文字列置換しており、レシーバが `t` のゲームで **`fmt.Sprintf` が `fmR.Sprintf` に化けて**、同一の3件が別クラスタに分かれていました。

```python
n = body.replace(recv+'.', 'R.')              # 誤
n = re.sub(r'\b'+re.escape(recv)+r'\.', 'R.', body)  # 正
```

**既にマージ済みの4クラスタはボディにパッケージセレクタを含まない**ため影響なしです（実測で確認済み。`appendLog` の残存102件も0件、`findHumanIdx` は残存0件）。

## テスト計画

- [x] `playerName` ヘルパの単体テスト（人間/CPU、**範囲外3種**（-1 / 末尾+1 / 空ロスター）、人間が先頭でない場合）
- [x] 範囲外分岐が**実在する経路**であることを明記（アクションログの `playerIdx = -1` はシステムイベント）
- [x] 91メソッドが正典ボディであることを検証してから削除（5件は不一致として除外）
- [x] **例外5ファイルに generic 呼び出しが0件**であることを検算
- [x] `go build ./...` / `go vet -tags test ./internal/domain/` / `gofmt -l` クリーン
- [x] `go test -tags test ./internal/domain/... ./internal/usecase/... ./internal/adapter/...` 通過
- [x] `golangci-lint run ./internal/domain/...` → 0 issues
- [ ] Worker サイズ前後比較（CI 待ち）

Refs #5185