### PR TITLE
refactor(domain): delegate 68 IsHumanTurn bodies to the shared helper

### DIFF
--- a/internal/domain/AllFours.go
+++ b/internal/domain/AllFours.go
@@ -687,10 +687,7 @@ func (a *AllFours) GetPlayer(i int) *AllFoursPlayer {
 
 // IsHumanTurn 現在の手番が人間かどうか
 func (a *AllFours) IsHumanTurn() bool {
-	if a.currentPlayerIdx < 0 || a.currentPlayerIdx >= len(a.players) {
-		return false
-	}
-	return a.players[a.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(a.players, a.currentPlayerIdx)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/Belote.go
+++ b/internal/domain/Belote.go
@@ -686,10 +686,7 @@ func (b *Belote) GetRoundBeloteBonus(team int) int {
 
 // IsHumanTurn 現在の手番が人間かどうか
 func (b *Belote) IsHumanTurn() bool {
-	if b.currentPlayerIdx < 0 || b.currentPlayerIdx >= len(b.players) {
-		return false
-	}
-	return b.players[b.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(b.players, b.currentPlayerIdx)
 }
 
 // IsHumanBidTurn 現在のビッド手番が人間かどうか

--- a/internal/domain/Bezique.go
+++ b/internal/domain/Bezique.go
@@ -481,10 +481,7 @@ func (b *Bezique) IsEndgame() bool {
 
 // IsHumanTurn 現在の手番が人間かどうか
 func (b *Bezique) IsHumanTurn() bool {
-	if b.currentPlayerIdx < 0 || b.currentPlayerIdx >= len(b.players) {
-		return false
-	}
-	return b.players[b.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(b.players, b.currentPlayerIdx)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/BidWhist.go
+++ b/internal/domain/BidWhist.go
@@ -1172,10 +1172,7 @@ func (g *BidWhist) SetTeamScore(team, score int) {
 
 // IsHumanTurn 現在の手番が人間かどうか
 func (g *BidWhist) IsHumanTurn() bool {
-	if g.currentPlayerIdx < 0 || g.currentPlayerIdx >= len(g.players) {
-		return false
-	}
-	return g.players[g.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(g.players, g.currentPlayerIdx)
 }
 
 // IsHumanBidTurn 現在のビッド手番が人間かどうか

--- a/internal/domain/Briscola.go
+++ b/internal/domain/Briscola.go
@@ -336,10 +336,7 @@ func (b *Briscola) GetStockRemaining() int {
 
 // IsHumanTurn 現在の手番が人間かどうか
 func (b *Briscola) IsHumanTurn() bool {
-	if b.currentPlayerIdx < 0 || b.currentPlayerIdx >= len(b.players) {
-		return false
-	}
-	return b.players[b.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(b.players, b.currentPlayerIdx)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/Calabresella.go
+++ b/internal/domain/Calabresella.go
@@ -1029,10 +1029,7 @@ func (g *Calabresella) GetPlayer(i int) *CalabresellaPlayer {
 
 // IsHumanTurn 現在の手番 (プレイ) が人間か。
 func (g *Calabresella) IsHumanTurn() bool {
-	if g.currentPlayerIdx < 0 || g.currentPlayerIdx >= len(g.players) {
-		return false
-	}
-	return g.players[g.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(g.players, g.currentPlayerIdx)
 }
 
 // IsHumanBidTurn 現在のビッド手番が人間か。

--- a/internal/domain/CallBreak.go
+++ b/internal/domain/CallBreak.go
@@ -395,10 +395,7 @@ func (cb *CallBreak) SetBidPlayerIdx(idx int) { cb.bidPlayerIdx = idx }
 
 // IsHumanTurn 現在の手番が人間かどうか
 func (cb *CallBreak) IsHumanTurn() bool {
-	if cb.currentPlayerIdx < 0 || cb.currentPlayerIdx >= len(cb.players) {
-		return false
-	}
-	return cb.players[cb.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(cb.players, cb.currentPlayerIdx)
 }
 
 // IsHumanBidTurn 現在のビッド手番が人間かどうか

--- a/internal/domain/Canasta.go
+++ b/internal/domain/Canasta.go
@@ -1432,10 +1432,7 @@ func (g *Canasta) GetPlayer(i int) *CanastaPlayer {
 
 // IsHumanTurn 現在の手番が人間かどうか
 func (g *Canasta) IsHumanTurn() bool {
-	if g.currentPlayerIdx < 0 || g.currentPlayerIdx >= len(g.players) {
-		return false
-	}
-	return g.players[g.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(g.players, g.currentPlayerIdx)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/Carioca.go
+++ b/internal/domain/Carioca.go
@@ -524,10 +524,7 @@ func (g *Carioca) advanceTurn() {
 
 // IsHumanTurn 現在の手番が人間かどうか
 func (g *Carioca) IsHumanTurn() bool {
-	if g.currentPlayerIdx < 0 || g.currentPlayerIdx >= len(g.players) {
-		return false
-	}
-	return g.players[g.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(g.players, g.currentPlayerIdx)
 }
 
 // CpuPlay 現在の手番が CPU の場合にターンを実行する

--- a/internal/domain/CatchTen.go
+++ b/internal/domain/CatchTen.go
@@ -377,10 +377,7 @@ func (g *CatchTen) SetTeamScore(team, score int) {
 
 // IsHumanTurn 現在の手番が人間かどうか
 func (g *CatchTen) IsHumanTurn() bool {
-	if g.currentPlayerIdx < 0 || g.currentPlayerIdx >= len(g.players) {
-		return false
-	}
-	return g.players[g.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(g.players, g.currentPlayerIdx)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/Chinchon.go
+++ b/internal/domain/Chinchon.go
@@ -737,10 +737,7 @@ func (g *Chinchon) GetPlayer(i int) *ChinchonPlayer {
 
 // IsHumanTurn 現在の手番が人間かどうか
 func (g *Chinchon) IsHumanTurn() bool {
-	if g.currentPlayerIdx < 0 || g.currentPlayerIdx >= len(g.players) {
-		return false
-	}
-	return g.players[g.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(g.players, g.currentPlayerIdx)
 }
 
 // GetPlayerDeadwoodValue はプレイヤーの手札を最善メルド分割したときのデッドウッド点を返す（プレゼンター向け）。

--- a/internal/domain/Conquian.go
+++ b/internal/domain/Conquian.go
@@ -902,10 +902,7 @@ func (g *Conquian) GetPlayer(i int) *ConquianPlayer {
 
 // IsHumanTurn 現在の手番が人間かどうか
 func (g *Conquian) IsHumanTurn() bool {
-	if g.currentPlayerIdx < 0 || g.currentPlayerIdx >= len(g.players) {
-		return false
-	}
-	return g.players[g.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(g.players, g.currentPlayerIdx)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/ContractRummy.go
+++ b/internal/domain/ContractRummy.go
@@ -531,10 +531,7 @@ func (g *ContractRummy) advanceTurn() {
 
 // IsHumanTurn 現在の手番が人間かどうか
 func (g *ContractRummy) IsHumanTurn() bool {
-	if g.currentPlayerIdx < 0 || g.currentPlayerIdx >= len(g.players) {
-		return false
-	}
-	return g.players[g.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(g.players, g.currentPlayerIdx)
 }
 
 // CpuPlay 現在の手番が CPU の場合にターンを実行する

--- a/internal/domain/CourtPiece.go
+++ b/internal/domain/CourtPiece.go
@@ -494,10 +494,7 @@ func (c *CourtPiece) SetConfig(cfg CourtPieceConfig) { c.config = cfg }
 
 // IsHumanTurn 現在の手番が人間かどうか
 func (c *CourtPiece) IsHumanTurn() bool {
-	if c.currentPlayerIdx < 0 || c.currentPlayerIdx >= len(c.players) {
-		return false
-	}
-	return c.players[c.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(c.players, c.currentPlayerIdx)
 }
 
 // IsHumanTrumpTurn 現在のトランプ宣言手番が人間かどうか

--- a/internal/domain/CrazyEights.go
+++ b/internal/domain/CrazyEights.go
@@ -424,10 +424,7 @@ func (g *CrazyEights) GetPlayer(i int) *CrazyEightsPlayer {
 
 // IsHumanTurn 現在の手番が人間かどうか
 func (g *CrazyEights) IsHumanTurn() bool {
-	if g.currentPlayerIdx < 0 || g.currentPlayerIdx >= len(g.players) {
-		return false
-	}
-	return g.players[g.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(g.players, g.currentPlayerIdx)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/Doppelkopf.go
+++ b/internal/domain/Doppelkopf.go
@@ -752,10 +752,7 @@ func (g *Doppelkopf) GetPlayer(i int) *DoppelkopfPlayer {
 
 // IsHumanTurn 現在の手番が人間かどうか。
 func (g *Doppelkopf) IsHumanTurn() bool {
-	if g.currentPlayerIdx < 0 || g.currentPlayerIdx >= len(g.players) {
-		return false
-	}
-	return g.players[g.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(g.players, g.currentPlayerIdx)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/Ecarte.go
+++ b/internal/domain/Ecarte.go
@@ -741,10 +741,7 @@ func (e *Ecarte) GetStockRemaining() int { return e.trumpCards.GetRemainingCount
 
 // IsHumanTurn 現在の手番が人間かどうか
 func (e *Ecarte) IsHumanTurn() bool {
-	if e.currentPlayerIdx < 0 || e.currentPlayerIdx >= len(e.players) {
-		return false
-	}
-	return e.players[e.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(e.players, e.currentPlayerIdx)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/Euchre.go
+++ b/internal/domain/Euchre.go
@@ -656,10 +656,7 @@ func (e *Euchre) GetKitty() []*Card { return e.kitty }
 
 // IsHumanTurn 現在の手番が人間かどうか
 func (e *Euchre) IsHumanTurn() bool {
-	if e.currentPlayerIdx < 0 || e.currentPlayerIdx >= len(e.players) {
-		return false
-	}
-	return e.players[e.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(e.players, e.currentPlayerIdx)
 }
 
 // IsHumanBidTurn 現在のビッド手番が人間かどうか

--- a/internal/domain/FiveHundred.go
+++ b/internal/domain/FiveHundred.go
@@ -1262,10 +1262,7 @@ func (g *FiveHundred) SetTeamScore(team, score int) {
 
 // IsHumanTurn 現在の手番が人間かどうか
 func (g *FiveHundred) IsHumanTurn() bool {
-	if g.currentPlayerIdx < 0 || g.currentPlayerIdx >= len(g.players) {
-		return false
-	}
-	return g.players[g.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(g.players, g.currentPlayerIdx)
 }
 
 // IsHumanBidTurn 現在のビッド手番が人間かどうか

--- a/internal/domain/FortyFives.go
+++ b/internal/domain/FortyFives.go
@@ -874,10 +874,7 @@ func (g *FortyFives) GetPlayer(i int) *FortyFivesPlayer {
 
 // IsHumanTurn 現在の手番が人間か (プレイフェーズ)。
 func (g *FortyFives) IsHumanTurn() bool {
-	if g.currentPlayerIdx < 0 || g.currentPlayerIdx >= len(g.players) {
-		return false
-	}
-	return g.players[g.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(g.players, g.currentPlayerIdx)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/Gaigel.go
+++ b/internal/domain/Gaigel.go
@@ -750,10 +750,7 @@ func (g *Gaigel) GetStockRemaining() int {
 
 // IsHumanTurn 現在の手番が人間かどうか
 func (g *Gaigel) IsHumanTurn() bool {
-	if g.currentPlayerIdx < 0 || g.currentPlayerIdx >= len(g.players) {
-		return false
-	}
-	return g.players[g.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(g.players, g.currentPlayerIdx)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/GinRummy.go
+++ b/internal/domain/GinRummy.go
@@ -794,10 +794,7 @@ func (g *GinRummy) GetPlayer(i int) *GinRummyPlayer {
 
 // IsHumanTurn 現在の手番が人間かどうか
 func (g *GinRummy) IsHumanTurn() bool {
-	if g.currentPlayerIdx < 0 || g.currentPlayerIdx >= len(g.players) {
-		return false
-	}
-	return g.players[g.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(g.players, g.currentPlayerIdx)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/GongZhu.go
+++ b/internal/domain/GongZhu.go
@@ -482,10 +482,7 @@ func (g *GongZhu) SetLeadPlayerIdx(idx int) { g.leadPlayerIdx = idx }
 
 // IsHumanTurn 現在の手番が人間かどうか
 func (g *GongZhu) IsHumanTurn() bool {
-	if g.currentPlayerIdx < 0 || g.currentPlayerIdx >= len(g.players) {
-		return false
-	}
-	return g.players[g.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(g.players, g.currentPlayerIdx)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/HandAndFoot.go
+++ b/internal/domain/HandAndFoot.go
@@ -1325,10 +1325,7 @@ func (g *HandAndFoot) SetTeamRed3s(team int, red3s []*Card) {
 
 // IsHumanTurn 現在の手番が人間かどうか
 func (g *HandAndFoot) IsHumanTurn() bool {
-	if g.currentPlayerIdx < 0 || g.currentPlayerIdx >= len(g.players) {
-		return false
-	}
-	return g.players[g.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(g.players, g.currentPlayerIdx)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/Hearts.go
+++ b/internal/domain/Hearts.go
@@ -472,10 +472,7 @@ func (h *Hearts) SetLeadPlayerIdx(idx int) { h.leadPlayerIdx = idx }
 
 // IsHumanTurn 現在の手番が人間かどうか
 func (h *Hearts) IsHumanTurn() bool {
-	if h.currentPlayerIdx < 0 || h.currentPlayerIdx >= len(h.players) {
-		return false
-	}
-	return h.players[h.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(h.players, h.currentPlayerIdx)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/IndianRummy.go
+++ b/internal/domain/IndianRummy.go
@@ -384,10 +384,7 @@ func (g *IndianRummy) advanceTurn() {
 
 // IsHumanTurn 現在の手番が人間かどうか
 func (g *IndianRummy) IsHumanTurn() bool {
-	if g.currentPlayerIdx < 0 || g.currentPlayerIdx >= len(g.players) {
-		return false
-	}
-	return g.players[g.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(g.players, g.currentPlayerIdx)
 }
 
 // CpuPlay 現在の手番が CPU の場合にターンを実行する

--- a/internal/domain/Jass.go
+++ b/internal/domain/Jass.go
@@ -524,10 +524,7 @@ func (g *Jass) GetRoundStockPoints(team int) int {
 
 // IsHumanTurn 現在の手番が人間かどうか
 func (g *Jass) IsHumanTurn() bool {
-	if g.currentPlayerIdx < 0 || g.currentPlayerIdx >= len(g.players) {
-		return false
-	}
-	return g.players[g.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(g.players, g.currentPlayerIdx)
 }
 
 // IsHumanBidTurn 現在のビッド手番が人間かどうか

--- a/internal/domain/Kalooki.go
+++ b/internal/domain/Kalooki.go
@@ -420,10 +420,7 @@ func (g *Kalooki) advanceTurn() {
 
 // IsHumanTurn 現在の手番が人間かどうか
 func (g *Kalooki) IsHumanTurn() bool {
-	if g.currentPlayerIdx < 0 || g.currentPlayerIdx >= len(g.players) {
-		return false
-	}
-	return g.players[g.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(g.players, g.currentPlayerIdx)
 }
 
 // CpuPlay 現在の手番が CPU の場合にターンを実行する

--- a/internal/domain/Klaverjas.go
+++ b/internal/domain/Klaverjas.go
@@ -781,10 +781,7 @@ func (g *Klaverjas) GetPlayer(i int) *KlaverjasPlayer {
 
 // IsHumanTurn 現在の手番が人間か。
 func (g *Klaverjas) IsHumanTurn() bool {
-	if g.currentPlayerIdx < 0 || g.currentPlayerIdx >= len(g.players) {
-		return false
-	}
-	return g.players[g.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(g.players, g.currentPlayerIdx)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/KnockoutWhist.go
+++ b/internal/domain/KnockoutWhist.go
@@ -660,10 +660,7 @@ func (g *KnockoutWhist) GetActiveCount() int { return g.activeCount() }
 
 // IsHumanTurn 現在の手番が人間か。
 func (g *KnockoutWhist) IsHumanTurn() bool {
-	if g.currentPlayerIdx < 0 || g.currentPlayerIdx >= len(g.players) {
-		return false
-	}
-	return g.players[g.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(g.players, g.currentPlayerIdx)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/Macau.go
+++ b/internal/domain/Macau.go
@@ -465,10 +465,7 @@ func (g *Macau) GetPlayer(i int) *MacauPlayer {
 
 // IsHumanTurn 現在の手番が人間かどうか
 func (g *Macau) IsHumanTurn() bool {
-	if g.currentPlayerIdx < 0 || g.currentPlayerIdx >= len(g.players) {
-		return false
-	}
-	return g.players[g.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(g.players, g.currentPlayerIdx)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/Manille.go
+++ b/internal/domain/Manille.go
@@ -617,10 +617,7 @@ func (g *Manille) GetPlayer(i int) *ManillePlayer {
 
 // IsHumanTurn 現在の手番が人間か。
 func (g *Manille) IsHumanTurn() bool {
-	if g.currentPlayerIdx < 0 || g.currentPlayerIdx >= len(g.players) {
-		return false
-	}
-	return g.players[g.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(g.players, g.currentPlayerIdx)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/Mao.go
+++ b/internal/domain/Mao.go
@@ -634,10 +634,7 @@ func (g *Mao) GetPlayer(i int) *MaoPlayer {
 
 // IsHumanTurn 現在の手番が人間かどうか
 func (g *Mao) IsHumanTurn() bool {
-	if g.currentPlayerIdx < 0 || g.currentPlayerIdx >= len(g.players) {
-		return false
-	}
-	return g.players[g.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(g.players, g.currentPlayerIdx)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/Marias.go
+++ b/internal/domain/Marias.go
@@ -683,10 +683,7 @@ func (g *Marias) GetPlayer(i int) *MariasPlayer {
 
 // IsHumanTurn 現在の手番が人間か。
 func (g *Marias) IsHumanTurn() bool {
-	if g.currentPlayerIdx < 0 || g.currentPlayerIdx >= len(g.players) {
-		return false
-	}
-	return g.players[g.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(g.players, g.currentPlayerIdx)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/Nap.go
+++ b/internal/domain/Nap.go
@@ -795,10 +795,7 @@ func (g *Nap) GetPlayer(i int) *NapPlayer {
 
 // IsHumanTurn 現在の手番が人間か (プレイフェーズ)。
 func (g *Nap) IsHumanTurn() bool {
-	if g.currentPlayerIdx < 0 || g.currentPlayerIdx >= len(g.players) {
-		return false
-	}
-	return g.players[g.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(g.players, g.currentPlayerIdx)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/NinetyNine.go
+++ b/internal/domain/NinetyNine.go
@@ -443,10 +443,7 @@ func (o *NinetyNine) GetTargetScore() int { return o.config.TargetScore }
 
 // IsHumanTurn 現在の手番が人間かどうか
 func (o *NinetyNine) IsHumanTurn() bool {
-	if o.currentPlayerIdx < 0 || o.currentPlayerIdx >= len(o.players) {
-		return false
-	}
-	return o.players[o.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(o.players, o.currentPlayerIdx)
 }
 
 // IsHumanBidTurn 現在のビッド手番が人間かどうか

--- a/internal/domain/OhHell.go
+++ b/internal/domain/OhHell.go
@@ -407,10 +407,7 @@ func (o *OhHell) SetBidPlayerIdx(idx int) { o.bidPlayerIdx = idx }
 
 // IsHumanTurn 現在の手番が人間かどうか
 func (o *OhHell) IsHumanTurn() bool {
-	if o.currentPlayerIdx < 0 || o.currentPlayerIdx >= len(o.players) {
-		return false
-	}
-	return o.players[o.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(o.players, o.currentPlayerIdx)
 }
 
 // IsHumanBidTurn 現在のビッド手番が人間かどうか

--- a/internal/domain/Ombre.go
+++ b/internal/domain/Ombre.go
@@ -1250,10 +1250,7 @@ func (g *Ombre) GetPlayer(i int) *OmbrePlayer {
 
 // IsHumanTurn 現在の手番 (プレイ) が人間か。
 func (g *Ombre) IsHumanTurn() bool {
-	if g.currentPlayerIdx < 0 || g.currentPlayerIdx >= len(g.players) {
-		return false
-	}
-	return g.players[g.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(g.players, g.currentPlayerIdx)
 }
 
 // IsHumanBidTurn 現在のビッド手番が人間か。

--- a/internal/domain/PageOne.go
+++ b/internal/domain/PageOne.go
@@ -383,10 +383,7 @@ func (g *PageOne) GetPlayer(i int) *PageOnePlayer {
 
 // IsHumanTurn 現在の手番が人間かどうか
 func (g *PageOne) IsHumanTurn() bool {
-	if g.currentPlayerIdx < 0 || g.currentPlayerIdx >= len(g.players) {
-		return false
-	}
-	return g.players[g.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(g.players, g.currentPlayerIdx)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/Pan.go
+++ b/internal/domain/Pan.go
@@ -443,10 +443,7 @@ func (g *Pan) guardHumanAction(want PanPhase) error {
 
 // IsHumanTurn 現在の手番が人間かどうか
 func (g *Pan) IsHumanTurn() bool {
-	if g.currentPlayerIdx < 0 || g.currentPlayerIdx >= len(g.players) {
-		return false
-	}
-	return g.players[g.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(g.players, g.currentPlayerIdx)
 }
 
 // --- CPU ---

--- a/internal/domain/Pitch.go
+++ b/internal/domain/Pitch.go
@@ -735,10 +735,7 @@ func (p *Pitch) GetPlayer(i int) *PitchPlayer {
 
 // IsHumanTurn 現在の手番が人間かどうか
 func (p *Pitch) IsHumanTurn() bool {
-	if p.currentPlayerIdx < 0 || p.currentPlayerIdx >= len(p.players) {
-		return false
-	}
-	return p.players[p.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(p.players, p.currentPlayerIdx)
 }
 
 // IsHumanBidTurn 現在のビッド手番が人間かどうか

--- a/internal/domain/Preference.go
+++ b/internal/domain/Preference.go
@@ -779,10 +779,7 @@ func (g *Preference) GetPlayer(i int) *PreferencePlayer {
 
 // IsHumanTurn 現在の手番が人間か (プレイフェーズ)。
 func (g *Preference) IsHumanTurn() bool {
-	if g.currentPlayerIdx < 0 || g.currentPlayerIdx >= len(g.players) {
-		return false
-	}
-	return g.players[g.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(g.players, g.currentPlayerIdx)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/Prsi.go
+++ b/internal/domain/Prsi.go
@@ -271,10 +271,7 @@ func (g *Prsi) GetPlayer(i int) *PrsiPlayer {
 
 // IsHumanTurn 現在の手番が人間かどうか
 func (g *Prsi) IsHumanTurn() bool {
-	if g.currentPlayerIdx < 0 || g.currentPlayerIdx >= len(g.players) {
-		return false
-	}
-	return g.players[g.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(g.players, g.currentPlayerIdx)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/Rook.go
+++ b/internal/domain/Rook.go
@@ -1139,10 +1139,7 @@ func (g *Rook) GetTeamPoints(team int) int {
 
 // IsHumanTurn 現在の手番が人間かどうか
 func (g *Rook) IsHumanTurn() bool {
-	if g.currentPlayerIdx < 0 || g.currentPlayerIdx >= len(g.players) {
-		return false
-	}
-	return g.players[g.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(g.players, g.currentPlayerIdx)
 }
 
 // IsHumanBidTurn 現在のビッド手番が人間かどうか

--- a/internal/domain/Rummy500.go
+++ b/internal/domain/Rummy500.go
@@ -650,10 +650,7 @@ func (g *Rummy500) GetPlayer(i int) *Rummy500Player {
 
 // IsHumanTurn 現在の手番が人間かどうか
 func (g *Rummy500) IsHumanTurn() bool {
-	if g.currentPlayerIdx < 0 || g.currentPlayerIdx >= len(g.players) {
-		return false
-	}
-	return g.players[g.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(g.players, g.currentPlayerIdx)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/Samba.go
+++ b/internal/domain/Samba.go
@@ -1605,10 +1605,7 @@ func (g *Samba) SetTeamScore(team, score int) {
 
 // IsHumanTurn 現在の手番が人間かどうか
 func (g *Samba) IsHumanTurn() bool {
-	if g.currentPlayerIdx < 0 || g.currentPlayerIdx >= len(g.players) {
-		return false
-	}
-	return g.players[g.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(g.players, g.currentPlayerIdx)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/Schnapsen.go
+++ b/internal/domain/Schnapsen.go
@@ -392,10 +392,7 @@ func (s *Schnapsen) IsEndgame() bool {
 
 // IsHumanTurn 現在の手番が人間かどうか
 func (s *Schnapsen) IsHumanTurn() bool {
-	if s.currentPlayerIdx < 0 || s.currentPlayerIdx >= len(s.players) {
-		return false
-	}
-	return s.players[s.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(s.players, s.currentPlayerIdx)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/Sedma.go
+++ b/internal/domain/Sedma.go
@@ -516,10 +516,7 @@ func (g *Sedma) GetPlayer(i int) *SedmaPlayer {
 
 // IsHumanTurn 現在の手番が人間か。
 func (g *Sedma) IsHumanTurn() bool {
-	if g.currentPlayerIdx < 0 || g.currentPlayerIdx >= len(g.players) {
-		return false
-	}
-	return g.players[g.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(g.players, g.currentPlayerIdx)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/SevenBridge.go
+++ b/internal/domain/SevenBridge.go
@@ -512,10 +512,7 @@ func (g *SevenBridge) advanceTurn() {
 
 // IsHumanTurn 現在の手番が人間かどうか
 func (g *SevenBridge) IsHumanTurn() bool {
-	if g.currentPlayerIdx < 0 || g.currentPlayerIdx >= len(g.players) {
-		return false
-	}
-	return g.players[g.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(g.players, g.currentPlayerIdx)
 }
 
 // CpuPlay 現在の手番が CPU の場合にターンを実行

--- a/internal/domain/SoloWhist.go
+++ b/internal/domain/SoloWhist.go
@@ -777,10 +777,7 @@ func (g *SoloWhist) GetPlayer(i int) *SoloWhistPlayer {
 
 // IsHumanTurn 現在の手番が人間か (プレイフェーズ)。
 func (g *SoloWhist) IsHumanTurn() bool {
-	if g.currentPlayerIdx < 0 || g.currentPlayerIdx >= len(g.players) {
-		return false
-	}
-	return g.players[g.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(g.players, g.currentPlayerIdx)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/Spades.go
+++ b/internal/domain/Spades.go
@@ -403,10 +403,7 @@ func (s *Spades) SetBidPlayerIdx(idx int) { s.bidPlayerIdx = idx }
 
 // IsHumanTurn 現在の手番が人間かどうか
 func (s *Spades) IsHumanTurn() bool {
-	if s.currentPlayerIdx < 0 || s.currentPlayerIdx >= len(s.players) {
-		return false
-	}
-	return s.players[s.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(s.players, s.currentPlayerIdx)
 }
 
 // IsHumanBidTurn 現在のビッド手番が人間かどうか

--- a/internal/domain/SpoilFive.go
+++ b/internal/domain/SpoilFive.go
@@ -646,10 +646,7 @@ func (g *SpoilFive) GetPlayer(i int) *SpoilFivePlayer {
 
 // IsHumanTurn 現在の手番が人間か。
 func (g *SpoilFive) IsHumanTurn() bool {
-	if g.currentPlayerIdx < 0 || g.currentPlayerIdx >= len(g.players) {
-		return false
-	}
-	return g.players[g.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(g.players, g.currentPlayerIdx)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/Sueca.go
+++ b/internal/domain/Sueca.go
@@ -659,10 +659,7 @@ func (g *Sueca) GetPlayer(i int) *SuecaPlayer {
 
 // IsHumanTurn 現在の手番が人間か。
 func (g *Sueca) IsHumanTurn() bool {
-	if g.currentPlayerIdx < 0 || g.currentPlayerIdx >= len(g.players) {
-		return false
-	}
-	return g.players[g.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(g.players, g.currentPlayerIdx)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/Tarneeb.go
+++ b/internal/domain/Tarneeb.go
@@ -546,10 +546,7 @@ func (t *Tarneeb) SetConfig(cfg TarneebConfig) { t.config = cfg }
 
 // IsHumanTurn 現在の手番が人間かどうか
 func (t *Tarneeb) IsHumanTurn() bool {
-	if t.currentPlayerIdx < 0 || t.currentPlayerIdx >= len(t.players) {
-		return false
-	}
-	return t.players[t.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(t.players, t.currentPlayerIdx)
 }
 
 // IsHumanBidTurn 現在のビッド手番が人間かどうか

--- a/internal/domain/TeenPatti.go
+++ b/internal/domain/TeenPatti.go
@@ -746,10 +746,7 @@ func (g *TeenPatti) SetConfig(cfg TeenPattiConfig) { g.config = cfg }
 
 // IsHumanTurn 現在の手番が人間かどうか
 func (g *TeenPatti) IsHumanTurn() bool {
-	if g.currentPlayerIdx < 0 || g.currentPlayerIdx >= len(g.players) {
-		return false
-	}
-	return g.players[g.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(g.players, g.currentPlayerIdx)
 }
 
 // CanShow 現在の手番プレイヤーが Show を要求できるか (Web/CUI 用)。

--- a/internal/domain/ThirtyOne.go
+++ b/internal/domain/ThirtyOne.go
@@ -682,10 +682,7 @@ func (g *ThirtyOne) GetPlayer(i int) *ThirtyOnePlayer {
 
 // IsHumanTurn 現在の手番が人間かを返す
 func (g *ThirtyOne) IsHumanTurn() bool {
-	if g.currentPlayerIdx < 0 || g.currentPlayerIdx >= len(g.players) {
-		return false
-	}
-	return g.players[g.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(g.players, g.currentPlayerIdx)
 }
 
 // GetKnockerIdx ノックしたプレイヤーインデックスを取得する (-1 = 未ノック)

--- a/internal/domain/ThreeCardBrag.go
+++ b/internal/domain/ThreeCardBrag.go
@@ -686,10 +686,7 @@ func (g *ThreeCardBrag) SetConfig(cfg ThreeCardBragConfig) { g.config = cfg }
 
 // IsHumanTurn 現在の手番が人間かどうか
 func (g *ThreeCardBrag) IsHumanTurn() bool {
-	if g.currentPlayerIdx < 0 || g.currentPlayerIdx >= len(g.players) {
-		return false
-	}
-	return g.players[g.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(g.players, g.currentPlayerIdx)
 }
 
 // CanShow 現在の手番プレイヤーが Show を要求できるか (Web/CUI 用)。

--- a/internal/domain/ThreeThirteen.go
+++ b/internal/domain/ThreeThirteen.go
@@ -362,10 +362,7 @@ func (g *ThreeThirteen) advanceTurn() {
 
 // IsHumanTurn 現在の手番が人間かどうか
 func (g *ThreeThirteen) IsHumanTurn() bool {
-	if g.currentPlayerIdx < 0 || g.currentPlayerIdx >= len(g.players) {
-		return false
-	}
-	return g.players[g.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(g.players, g.currentPlayerIdx)
 }
 
 // CpuPlay 現在の手番が CPU の場合にターンを実行する

--- a/internal/domain/Tonk.go
+++ b/internal/domain/Tonk.go
@@ -675,10 +675,7 @@ func (g *Tonk) GetPlayer(i int) *TonkPlayer {
 
 // IsHumanTurn 現在の手番が人間かどうか
 func (g *Tonk) IsHumanTurn() bool {
-	if g.currentPlayerIdx < 0 || g.currentPlayerIdx >= len(g.players) {
-		return false
-	}
-	return g.players[g.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(g.players, g.currentPlayerIdx)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/Tressette.go
+++ b/internal/domain/Tressette.go
@@ -326,10 +326,7 @@ func (g *Tressette) GetPlayer(i int) *TressettePlayer {
 
 // IsHumanTurn 現在の手番が人間かどうか
 func (g *Tressette) IsHumanTurn() bool {
-	if g.currentPlayerIdx < 0 || g.currentPlayerIdx >= len(g.players) {
-		return false
-	}
-	return g.players[g.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(g.players, g.currentPlayerIdx)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/Tute.go
+++ b/internal/domain/Tute.go
@@ -771,10 +771,7 @@ func (g *Tute) GetPlayer(i int) *TutePlayer {
 
 // IsHumanTurn 現在の手番が人間か。
 func (g *Tute) IsHumanTurn() bool {
-	if g.currentPlayerIdx < 0 || g.currentPlayerIdx >= len(g.players) {
-		return false
-	}
-	return g.players[g.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(g.players, g.currentPlayerIdx)
 }
 
 // CanHumanDeclareMarriage 人間が今いずれかのスートで結婚宣言できるか。

--- a/internal/domain/TwentyNine.go
+++ b/internal/domain/TwentyNine.go
@@ -791,10 +791,7 @@ func (g *TwentyNine) GetPlayer(i int) *TwentyNinePlayer {
 
 // IsHumanTurn 現在の手番が人間か (プレイフェーズ)。
 func (g *TwentyNine) IsHumanTurn() bool {
-	if g.currentPlayerIdx < 0 || g.currentPlayerIdx >= len(g.players) {
-		return false
-	}
-	return g.players[g.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(g.players, g.currentPlayerIdx)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/TwoTenJack.go
+++ b/internal/domain/TwoTenJack.go
@@ -401,10 +401,7 @@ func (t *TwoTenJack) GetPlayer(i int) *TwoTenJackPlayer {
 
 // IsHumanTurn 現在の手番が人間かどうか
 func (t *TwoTenJack) IsHumanTurn() bool {
-	if t.currentPlayerIdx < 0 || t.currentPlayerIdx >= len(t.players) {
-		return false
-	}
-	return t.players[t.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(t.players, t.currentPlayerIdx)
 }
 
 // IsHumanDeclareTurn 現在の宣言手番が人間かどうか

--- a/internal/domain/Tysiac.go
+++ b/internal/domain/Tysiac.go
@@ -1095,10 +1095,7 @@ func (g *Tysiac) GetPlayer(i int) *TysiacPlayer {
 
 // IsHumanTurn 現在の手番 (プレイ) が人間か。
 func (g *Tysiac) IsHumanTurn() bool {
-	if g.currentPlayerIdx < 0 || g.currentPlayerIdx >= len(g.players) {
-		return false
-	}
-	return g.players[g.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(g.players, g.currentPlayerIdx)
 }
 
 // IsHumanBidTurn 現在のビッド手番が人間か。

--- a/internal/domain/Watten.go
+++ b/internal/domain/Watten.go
@@ -1178,10 +1178,7 @@ func (g *Watten) GetPlayer(i int) *WattenPlayer {
 
 // IsHumanTurn 現在のプレイ手番が人間かどうか
 func (g *Watten) IsHumanTurn() bool {
-	if g.currentPlayerIdx < 0 || g.currentPlayerIdx >= len(g.players) {
-		return false
-	}
-	return g.players[g.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(g.players, g.currentPlayerIdx)
 }
 
 // IsHumanDeclareTurn 現在の宣言手番 (ディーラー) が人間かどうか

--- a/internal/domain/Whist.go
+++ b/internal/domain/Whist.go
@@ -326,10 +326,7 @@ func (w *Whist) SetTeamScore(team, score int) {
 
 // IsHumanTurn 現在の手番が人間かどうか
 func (w *Whist) IsHumanTurn() bool {
-	if w.currentPlayerIdx < 0 || w.currentPlayerIdx >= len(w.players) {
-		return false
-	}
-	return w.players[w.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(w.players, w.currentPlayerIdx)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/Wizard.go
+++ b/internal/domain/Wizard.go
@@ -429,10 +429,7 @@ func (o *Wizard) SetBidPlayerIdx(idx int) { o.bidPlayerIdx = idx }
 
 // IsHumanTurn 現在の手番が人間かどうか
 func (o *Wizard) IsHumanTurn() bool {
-	if o.currentPlayerIdx < 0 || o.currentPlayerIdx >= len(o.players) {
-		return false
-	}
-	return o.players[o.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(o.players, o.currentPlayerIdx)
 }
 
 // IsHumanBidTurn 現在のビッド手番が人間かどうか

--- a/internal/domain/Yaniv.go
+++ b/internal/domain/Yaniv.go
@@ -783,10 +783,7 @@ func (g *Yaniv) GetPlayer(i int) *YanivPlayer {
 
 // IsHumanTurn 現在の手番が人間かを返す
 func (g *Yaniv) IsHumanTurn() bool {
-	if g.currentPlayerIdx < 0 || g.currentPlayerIdx >= len(g.players) {
-		return false
-	}
-	return g.players[g.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(g.players, g.currentPlayerIdx)
 }
 
 // GetCallerIdx Yaniv を宣言したプレイヤーインデックスを取得する (-1 = なし)

--- a/internal/domain/player_helpers.go
+++ b/internal/domain/player_helpers.go
@@ -54,6 +54,18 @@ func findHumanIdx[T humanReporter](players []T) int {
 	return -1
 }
 
+// isHumanTurn reports whether the seat at idx is the human, returning false
+// rather than panicking when idx is outside the roster. 68 games had this exact
+// body; another 81 differ for real reasons -- some omit the bounds check (and so
+// panic where this returns false), and several gate on game state such as
+// `phase == XPhasePlay` or `!gameEndFlag`. Those keep their own. See issue #5185.
+func isHumanTurn[T humanReporter](players []T, idx int) bool {
+	if idx < 0 || idx >= len(players) {
+		return false
+	}
+	return players[idx].GetIsHuman()
+}
+
 // playerName renders a seat for display: "You" for the human, "CPU <idx>" for
 // the rest, and "Player <idx>" when idx is outside the roster. 91 games spelled
 // this out identically.

--- a/internal/domain/player_helpers_internal_test.go
+++ b/internal/domain/player_helpers_internal_test.go
@@ -222,3 +222,23 @@ func TestPlayerName_HumanNeedNotBeFirst(t *testing.T) {
 	assert.Equal(t, "CPU 0", playerName(seats, 0))
 	assert.Equal(t, "You", playerName(seats, 2))
 }
+
+func TestIsHumanTurn(t *testing.T) {
+	seats := []fakeSeat{{false}, {true}, {false}}
+
+	assert.True(t, isHumanTurn(seats, 1))
+	assert.False(t, isHumanTurn(seats, 0))
+	assert.False(t, isHumanTurn(seats, 2))
+}
+
+// Out-of-range returns false instead of panicking. 81 other games deliberately
+// keep their own version -- 22 of them omit this check and would panic here --
+// so the boundary is the reason those were not folded in.
+func TestIsHumanTurn_OutOfRangeIsFalseNotPanic(t *testing.T) {
+	seats := []fakeSeat{{true}}
+
+	assert.NotPanics(t, func() { isHumanTurn(seats, -1) })
+	assert.False(t, isHumanTurn(seats, -1))
+	assert.False(t, isHumanTurn(seats, 1))
+	assert.False(t, isHumanTurn([]fakeSeat{}, 0))
+}


### PR DESCRIPTION
## 概要

[#5185](https://github.com/yuta-yoshinaga/go_trumpcards/issues/5185) フェーズ4の最終クラスタ。**204行削除**（68追加 / 272削除）。

## 前クラスタとの決定的な違い: メソッドは残します

`findHumanIdx` / `playerName` は**非公開**だったのでメソッドごと削除できましたが、**`IsHumanTurn` は公開メソッドで、usecase 層が使うドメインインタフェースの一部**です。`internal/domain/interfaces/` の**301ファイル**が宣言しています。

削除を試みたところ即座にビルドが落ちました。

```
cannot use g (variable of type *domain.AllFours) as interfaces.AllFoursGame value:
  *domain.AllFours does not implement interfaces.AllFoursGame (missing method IsHumanTurn)
```

したがって**各ゲームはメソッドを保持し、本体だけを1行委譲に**します。

```go
func (g *AllFours) IsHumanTurn() bool {
	return isHumanTurn(g.players, g.currentPlayerIdx)
}
```

呼び出し側（101箇所）は**一切変更していません**。`g.IsHumanTurn()` のままです。

## 81件は重複ではありません

149件中、変換するのは**同一ボディの68件のみ**です。残り81件は本当に違います。

| 種別 | 件数 | 差異 |
|---|---:|---|
| 境界チェック無し | 22 | 範囲外で **panic**（正典は `false`） |
| phase ゲート | 数件 | `phase == ViraPhasePlay && ...` |
| gameEnd ゲート | 1 | `!gameEndFlag && ...` |
| 別のインデックス | 多数 | `currentTurn` / `round.currentTurn` |

**これらを畳むと「リファクタ」と称して挙動を変えることになります。** 変換後に検算し、**68件が委譲・81件が自前ロジック・合計149件**であることを確認しました。

## テスト計画

- [x] `isHumanTurn` ヘルパの単体テスト（人間/CPU、**範囲外で panic せず false**、空ロスター）
- [x] 境界の意味を明記（22件が境界チェック無しで panic するため、それらを畳まない理由そのもの）
- [x] 68件が正典ボディであることを検証してから変換（不一致なら中断、`converted != 68` でも中断）
- [x] 変換後に **68/81/149 の内訳を再検算**
- [x] `go build ./...` / `go vet -tags test ./internal/domain/` / `gofmt -l` クリーン
- [x] `go test -tags test ./internal/domain/... ./internal/usecase/...` 通過（domain 51.3s）
- [x] `golangci-lint run ./internal/domain/...` → 0 issues
- [ ] Worker サイズ前後比較（CI 待ち）

## サイズ見込み

本体は `players[idx].GetIsHuman()` と境界チェックのみで、**`fmt` を含みません**。[#5202 で `fmt` を含む `playerName` が +4,801 バイト増えた](https://github.com/yuta-yoshinaga/go_trumpcards/pull/5202#issuecomment-5226400249)のに対し、こちらは `findHumanIdx`（-425）に近い横ばいを見込んでいます。実測して報告します。

Refs #5185