### PR TITLE
test(domain): cover the 25 games whose IsHumanTurn had no test

### DIFF
--- a/internal/domain/is_human_turn_wiring_test.go
+++ b/internal/domain/is_human_turn_wiring_test.go
@@ -1,0 +1,65 @@
+//go:build test
+
+package domain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// humanTurnGame is the slice of a game this test needs: whether it is the
+// human's turn.
+type humanTurnGame interface {
+	IsHumanTurn() bool
+}
+
+// These 25 games' IsHumanTurn had no test at all. The bodies now delegate to
+// the shared isHumanTurn helper (#5203), and codecov flagged the delegation as
+// uncovered patch -- correctly, since the pre-existing bodies were untested
+// too. The helper's own semantics are pinned in player_helpers_internal_test.go;
+// what these assert is that each game is actually wired to it and answers
+// without panicking on a freshly dealt game.
+func TestIsHumanTurnWiredForEveryGame(t *testing.T) {
+	t.Parallel()
+
+	games := []struct {
+		name string
+		make func() humanTurnGame
+	}{
+		{"Belote", func() humanTurnGame { return NewDefaultBelote() }},
+		{"Bezique", func() humanTurnGame { return NewDefaultBezique() }},
+		{"BidWhist", func() humanTurnGame { return NewDefaultBidWhist() }},
+		{"CourtPiece", func() humanTurnGame { return NewDefaultCourtPiece() }},
+		{"Doppelkopf", func() humanTurnGame { return NewDefaultDoppelkopf() }},
+		{"Ecarte", func() humanTurnGame { return NewDefaultEcarte() }},
+		{"FiveHundred", func() humanTurnGame { return NewDefaultFiveHundred() }},
+		{"FortyFives", func() humanTurnGame { return NewDefaultFortyFives() }},
+		{"Kalooki", func() humanTurnGame { return NewDefaultKalooki() }},
+		{"Klaverjas", func() humanTurnGame { return NewDefaultKlaverjas() }},
+		{"KnockoutWhist", func() humanTurnGame { return NewDefaultKnockoutWhist() }},
+		{"Manille", func() humanTurnGame { return NewDefaultManille() }},
+		{"Mao", func() humanTurnGame { return NewDefaultMao() }},
+		{"Marias", func() humanTurnGame { return NewDefaultMarias() }},
+		{"Nap", func() humanTurnGame { return NewDefaultNap() }},
+		{"Preference", func() humanTurnGame { return NewDefaultPreference() }},
+		{"Sedma", func() humanTurnGame { return NewDefaultSedma() }},
+		{"SoloWhist", func() humanTurnGame { return NewDefaultSoloWhist() }},
+		{"SpoilFive", func() humanTurnGame { return NewDefaultSpoilFive() }},
+		{"Sueca", func() humanTurnGame { return NewDefaultSueca() }},
+		{"TeenPatti", func() humanTurnGame { return NewDefaultTeenPatti() }},
+		{"ThreeCardBrag", func() humanTurnGame { return NewDefaultThreeCardBrag() }},
+		{"Tressette", func() humanTurnGame { return NewDefaultTressette() }},
+		{"Tute", func() humanTurnGame { return NewDefaultTute() }},
+		{"TwentyNine", func() humanTurnGame { return NewDefaultTwentyNine() }},
+	}
+
+	for _, g := range games {
+		t.Run(g.name, func(t *testing.T) {
+			t.Parallel()
+			game := g.make()
+			assert.NotPanics(t, func() { _ = game.IsHumanTurn() },
+				"a freshly constructed game must answer IsHumanTurn without panicking")
+		})
+	}
+}

--- a/internal/domain/is_human_turn_wiring_test.go
+++ b/internal/domain/is_human_turn_wiring_test.go
@@ -60,6 +60,13 @@ func TestIsHumanTurnWiredForEveryGame(t *testing.T) {
 			game := g.make()
 			assert.NotPanics(t, func() { _ = game.IsHumanTurn() },
 				"a freshly constructed game must answer IsHumanTurn without panicking")
+			// NewDefault* seats the human first and starts the turn there, so a
+			// correctly wired delegation returns true here. Verified true for all
+			// 25 before asserting it. NotPanics alone would also pass for a body
+			// hardcoded to `return false`; this pins the answer as well as the
+			// wiring. Raised in review on #5204.
+			assert.True(t, game.IsHumanTurn(),
+				"the human is seated first on a fresh game, so it is their turn")
 		})
 	}
 }


### PR DESCRIPTION
## 経緯: #5203 を codecov/patch が落ちる前にマージしてしまいました

[#5203](https://github.com/yuta-yoshinaga/go_trumpcards/pull/5203) をマージした時点で `gh pr checks` は **18 pass / no failures** を返していました。しかし `codecov/patch` は**まだ結果を出しておらず**、その後 **fail** になりました。

**「no failures」を「全チェック完了」と読んだのが誤り**です。チェックが一覧に出ていないことと、通っていることは別でした。fix-forward します。

## 何が落ちたか

#5203 は68ゲームの `IsHumanTurn` 本体を1行委譲に置き換えました。この**委譲行68本のうち25本がテストで踏まれていません**（43/68 = 63%、閾値80%未満）。

**これは退行ではありません。** 該当25ゲームの `IsHumanTurn` は**変更前から未テスト**でした。本体を書き換えたことで、codecov が同じ行を「新規の未カバー行」として数え直しただけです。

とはいえ、**公開インタフェースのメソッドが25ゲーム分まったく検証されていない**のは事実で、ゲートが正しく指摘しています。

## 対応

`isHumanTurn` ヘルパ自体の意味論は `player_helpers_internal_test.go` で既に固定済みです（人間/CPU判定、範囲外で panic せず false、空ロスター）。**欠けていたのは「各ゲームが実際にそのヘルパに繋がっているか」の証拠**でした。

テーブル駆動で25ゲームを構築し、`IsHumanTurn` が panic せず応答することを検証します。

```go
type humanTurnGame interface{ IsHumanTurn() bool }

games := []struct{ name string; make func() humanTurnGame }{
	{"Belote", func() humanTurnGame { return NewDefaultBelote() }},
	// ... 25件
}
```

## テスト計画

- [x] 25ゲームすべてで `IsHumanTurn` が**新規構築直後に panic せず応答**すること
- [x] 委譲行のカバレッジを**再計測**: 43/68 → **68/68（100%）**
- [x] `go test -tags test ./internal/domain/` 通過（53.7s、statements 90.8%）
- [x] `golangci-lint run ./internal/domain/...` → 0 issues
- [x] `gofmt -w` 済み
- [x] `t.Parallel()` を親子とも付与（25サブテストが直列にならないよう）

## 記録

このバッチでは「PR head の SHA 一致」「no failures」を確認してマージする手順を通してきましたが、**チェック一覧が完全である保証を取っていませんでした**。今後は `all(.bucket != "pending")` が真であることに加え、**期待するチェック名（codecov/patch を含む）が揃っていること**を確認します。