### PR TITLE
refactor(domain): delegate 152 GetPlayer bodies to the shared helper

### DIFF
--- a/internal/domain/AllFours.go
+++ b/internal/domain/AllFours.go
@@ -679,10 +679,7 @@ func (a *AllFours) GetPlayerCnt() int { return len(a.players) }
 
 // GetPlayer プレイヤー取得
 func (a *AllFours) GetPlayer(i int) *AllFoursPlayer {
-	if i < 0 || i >= len(a.players) {
-		return nil
-	}
-	return a.players[i]
+	return getPlayer(a.players, i)
 }
 
 // IsHumanTurn 現在の手番が人間かどうか

--- a/internal/domain/Aluette.go
+++ b/internal/domain/Aluette.go
@@ -669,10 +669,7 @@ func (g *Aluette) GetPlayerCnt() int { return AluettePlayerCnt }
 
 // GetPlayer 指定席のプレイヤー。
 func (g *Aluette) GetPlayer(i int) *AluettePlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // GetPlayers 全プレイヤー。

--- a/internal/domain/Anaconda.go
+++ b/internal/domain/Anaconda.go
@@ -1082,10 +1082,7 @@ func (g *Anaconda) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer は指定インデックスのプレイヤーを返す。
 func (g *Anaconda) GetPlayer(i int) *AnacondaPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // GetChips は人間 (seat 0) の保有チップを返す。

--- a/internal/domain/Barbu.go
+++ b/internal/domain/Barbu.go
@@ -491,10 +491,7 @@ func (b *Barbu) GetPlayerCnt() int { return len(b.players) }
 
 // GetPlayer は指定インデックスのプレイヤーを返す。
 func (b *Barbu) GetPlayer(i int) *BarbuPlayer {
-	if i < 0 || i >= len(b.players) {
-		return nil
-	}
-	return b.players[i]
+	return getPlayer(b.players, i)
 }
 
 // GetCurrentTurn は現在の手番プレイヤーインデックスを返す。

--- a/internal/domain/Basra.go
+++ b/internal/domain/Basra.go
@@ -856,10 +856,7 @@ func (g *Basra) GetLastCaptureIdx() int { return g.state.lastCaptureIdx }
 
 // GetPlayer は指定インデックスのプレイヤーを返す。
 func (g *Basra) GetPlayer(i int) *BasraPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // GetPlayerCnt はプレイヤー数を返す。

--- a/internal/domain/Belote.go
+++ b/internal/domain/Belote.go
@@ -604,10 +604,7 @@ func (b *Belote) GetPlayerCnt() int { return len(b.players) }
 
 // GetPlayer プレイヤー取得
 func (b *Belote) GetPlayer(i int) *BelotePlayer {
-	if i < 0 || i >= len(b.players) {
-		return nil
-	}
-	return b.players[i]
+	return getPlayer(b.players, i)
 }
 
 // GetLeadPlayerIdx リードプレイヤーインデックス取得

--- a/internal/domain/Bezique.go
+++ b/internal/domain/Bezique.go
@@ -414,10 +414,7 @@ func (b *Bezique) GetPlayerCnt() int { return len(b.players) }
 
 // GetPlayer プレイヤー取得
 func (b *Bezique) GetPlayer(i int) *BeziquePlayer {
-	if i < 0 || i >= len(b.players) {
-		return nil
-	}
-	return b.players[i]
+	return getPlayer(b.players, i)
 }
 
 // GetDealPoints プレイヤーの当ディール得点取得

--- a/internal/domain/BidEuchre.go
+++ b/internal/domain/BidEuchre.go
@@ -853,10 +853,7 @@ func (b *BidEuchre) GetPlayers() []*BidEuchrePlayer { return b.players }
 
 // GetPlayer は idx のプレイヤーを返す。
 func (b *BidEuchre) GetPlayer(idx int) *BidEuchrePlayer {
-	if idx < 0 || idx >= len(b.players) {
-		return nil
-	}
-	return b.players[idx]
+	return getPlayer(b.players, idx)
 }
 
 // GetPhase は現在のフェーズを返す。

--- a/internal/domain/BidWhist.go
+++ b/internal/domain/BidWhist.go
@@ -1057,10 +1057,7 @@ func (g *BidWhist) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer プレイヤー取得
 func (g *BidWhist) GetPlayer(i int) *BidWhistPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // GetLeadPlayerIdx リードプレイヤーインデックス取得

--- a/internal/domain/BigTwo.go
+++ b/internal/domain/BigTwo.go
@@ -306,10 +306,7 @@ func (bt *BigTwo) GetLastPlayPlayerIdx() int { return bt.round.lastPlayPlayerIdx
 
 // GetPlayer プレイヤー取得
 func (bt *BigTwo) GetPlayer(idx int) *BigTwoPlayer {
-	if idx < 0 || idx >= len(bt.players) {
-		return nil
-	}
-	return bt.players[idx]
+	return getPlayer(bt.players, idx)
 }
 
 // GetPlayerCnt プレイヤー数取得

--- a/internal/domain/Boston.go
+++ b/internal/domain/Boston.go
@@ -686,10 +686,7 @@ func (b *Boston) GetPlayers() []*BostonPlayer { return b.players }
 
 // GetPlayer は idx のプレイヤーを返す。
 func (b *Boston) GetPlayer(idx int) *BostonPlayer {
-	if idx < 0 || idx >= len(b.players) {
-		return nil
-	}
-	return b.players[idx]
+	return getPlayer(b.players, idx)
 }
 
 // GetPhase は現在のフェーズを返す。

--- a/internal/domain/Bouillotte.go
+++ b/internal/domain/Bouillotte.go
@@ -756,10 +756,7 @@ func (g *Bouillotte) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer は指定インデックスのプレイヤーを返す。
 func (g *Bouillotte) GetPlayer(i int) *BouillottePlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // GetChips は人間 (seat 0) の保有チップを返す。

--- a/internal/domain/Bourre.go
+++ b/internal/domain/Bourre.go
@@ -832,10 +832,7 @@ func (b *Bourre) GetPlayerCnt() int { return len(b.players) }
 
 // GetPlayer プレイヤー取得
 func (b *Bourre) GetPlayer(i int) *BourrePlayer {
-	if i < 0 || i >= len(b.players) {
-		return nil
-	}
-	return b.players[i]
+	return getPlayer(b.players, i)
 }
 
 // GetCurrentPlayerIdx 現在の手番プレイヤーインデックス取得

--- a/internal/domain/Bridge.go
+++ b/internal/domain/Bridge.go
@@ -867,10 +867,7 @@ func (b *Bridge) GetPlayerCnt() int { return len(b.players) }
 
 // GetPlayer プレイヤー取得
 func (b *Bridge) GetPlayer(i int) *BridgePlayer {
-	if i < 0 || i >= len(b.players) {
-		return nil
-	}
-	return b.players[i]
+	return getPlayer(b.players, i)
 }
 
 // GetLeadPlayerIdx リードプレイヤーインデックス取得

--- a/internal/domain/Briscola.go
+++ b/internal/domain/Briscola.go
@@ -295,10 +295,7 @@ func (b *Briscola) GetPlayerCnt() int { return len(b.players) }
 
 // GetPlayer プレイヤー取得
 func (b *Briscola) GetPlayer(i int) *BriscolaPlayer {
-	if i < 0 || i >= len(b.players) {
-		return nil
-	}
-	return b.players[i]
+	return getPlayer(b.players, i)
 }
 
 // GetPlayerPoints プレイヤーの累積得点取得

--- a/internal/domain/Bura.go
+++ b/internal/domain/Bura.go
@@ -538,10 +538,7 @@ func (b *Bura) GetPlayers() []*BuraPlayer { return b.players }
 
 // GetPlayer idx のプレイヤーを返す。範囲外は nil。
 func (b *Bura) GetPlayer(idx int) *BuraPlayer {
-	if idx < 0 || idx >= len(b.players) {
-		return nil
-	}
-	return b.players[idx]
+	return getPlayer(b.players, idx)
 }
 
 // GetStock 山札 (切札指示カードを含まない) を返す。

--- a/internal/domain/Calabresella.go
+++ b/internal/domain/Calabresella.go
@@ -1021,10 +1021,7 @@ func (g *Calabresella) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer プレイヤー取得
 func (g *Calabresella) GetPlayer(i int) *CalabresellaPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // IsHumanTurn 現在の手番 (プレイ) が人間か。

--- a/internal/domain/CallBreak.go
+++ b/internal/domain/CallBreak.go
@@ -375,10 +375,7 @@ func (cb *CallBreak) GetPlayerCnt() int { return len(cb.players) }
 
 // GetPlayer プレイヤー取得
 func (cb *CallBreak) GetPlayer(i int) *CallBreakPlayer {
-	if i < 0 || i >= len(cb.players) {
-		return nil
-	}
-	return cb.players[i]
+	return getPlayer(cb.players, i)
 }
 
 // GetLeadPlayerIdx リードプレイヤーインデックス取得

--- a/internal/domain/Canasta.go
+++ b/internal/domain/Canasta.go
@@ -1424,10 +1424,7 @@ func (g *Canasta) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer プレイヤー取得
 func (g *Canasta) GetPlayer(i int) *CanastaPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // IsHumanTurn 現在の手番が人間かどうか

--- a/internal/domain/Carioca.go
+++ b/internal/domain/Carioca.go
@@ -806,10 +806,7 @@ func (g *Carioca) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer プレイヤー取得
 func (g *Carioca) GetPlayer(i int) *CariocaPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/Cassino.go
+++ b/internal/domain/Cassino.go
@@ -689,10 +689,7 @@ func (c *Cassino) GetBuilds() []*CassinoBuild { return c.round.builds }
 
 // GetPlayer プレイヤー取得
 func (c *Cassino) GetPlayer(idx int) *CassinoPlayer {
-	if idx < 0 || idx >= len(c.players) {
-		return nil
-	}
-	return c.players[idx]
+	return getPlayer(c.players, idx)
 }
 
 // GetPlayerCnt プレイヤー数取得

--- a/internal/domain/CatchTen.go
+++ b/internal/domain/CatchTen.go
@@ -342,10 +342,7 @@ func (g *CatchTen) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer プレイヤー取得
 func (g *CatchTen) GetPlayer(i int) *CatchTenPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // GetLeadPlayerIdx リードプレイヤーインデックス取得

--- a/internal/domain/Cego.go
+++ b/internal/domain/Cego.go
@@ -1617,10 +1617,7 @@ func (g *Cego) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer プレイヤー取得
 func (g *Cego) GetPlayer(i int) *CegoPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // IsHumanTurn 現在の手番 (Play) が人間か。

--- a/internal/domain/Chinchon.go
+++ b/internal/domain/Chinchon.go
@@ -729,10 +729,7 @@ func (g *Chinchon) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer プレイヤー取得
 func (g *Chinchon) GetPlayer(i int) *ChinchonPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // IsHumanTurn 現在の手番が人間かどうか

--- a/internal/domain/ChineseTen.go
+++ b/internal/domain/ChineseTen.go
@@ -425,10 +425,7 @@ func (c *ChineseTen) GetPlayers() []*ChineseTenPlayer { return c.players }
 
 // GetPlayer は idx のプレイヤーを返す。範囲外は nil。
 func (c *ChineseTen) GetPlayer(idx int) *ChineseTenPlayer {
-	if idx < 0 || idx >= len(c.players) {
-		return nil
-	}
-	return c.players[idx]
+	return getPlayer(c.players, idx)
 }
 
 // GetLayout は場札を返す。

--- a/internal/domain/Cinch.go
+++ b/internal/domain/Cinch.go
@@ -926,10 +926,7 @@ func (g *Cinch) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer は指定インデックスのプレイヤーを返す。
 func (g *Cinch) GetPlayer(i int) *CinchPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // GetLastDealDetail は直前ディールの得点内訳を返す (nil の場合もある)。

--- a/internal/domain/Conquian.go
+++ b/internal/domain/Conquian.go
@@ -894,10 +894,7 @@ func (g *Conquian) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer プレイヤー取得
 func (g *Conquian) GetPlayer(i int) *ConquianPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // IsHumanTurn 現在の手番が人間かどうか

--- a/internal/domain/ContractRummy.go
+++ b/internal/domain/ContractRummy.go
@@ -813,10 +813,7 @@ func (g *ContractRummy) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer プレイヤー取得
 func (g *ContractRummy) GetPlayer(i int) *ContractRummyPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/CourtPiece.go
+++ b/internal/domain/CourtPiece.go
@@ -480,10 +480,7 @@ func (c *CourtPiece) GetPlayerCnt() int { return len(c.players) }
 
 // GetPlayer プレイヤー取得
 func (c *CourtPiece) GetPlayer(i int) *CourtPiecePlayer {
-	if i < 0 || i >= len(c.players) {
-		return nil
-	}
-	return c.players[i]
+	return getPlayer(c.players, i)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/CrazyEights.go
+++ b/internal/domain/CrazyEights.go
@@ -416,10 +416,7 @@ func (g *CrazyEights) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer プレイヤー取得
 func (g *CrazyEights) GetPlayer(i int) *CrazyEightsPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // IsHumanTurn 現在の手番が人間かどうか

--- a/internal/domain/Cribbage.go
+++ b/internal/domain/Cribbage.go
@@ -826,10 +826,7 @@ func (g *Cribbage) GetActionLog() []*ActionLogEntry { return g.actionLog }
 
 // GetPlayer プレイヤー取得
 func (g *Cribbage) GetPlayer(idx int) *CribbagePlayer {
-	if idx < 0 || idx >= len(g.players) {
-		return nil
-	}
-	return g.players[idx]
+	return getPlayer(g.players, idx)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/Cuarenta.go
+++ b/internal/domain/Cuarenta.go
@@ -465,10 +465,7 @@ func (g *Cuarenta) GetTableCards() []*Card { return g.round.tableCards }
 
 // GetPlayer プレイヤー取得。
 func (g *Cuarenta) GetPlayer(idx int) *CuarentaPlayer {
-	if idx < 0 || idx >= len(g.players) {
-		return nil
-	}
-	return g.players[idx]
+	return getPlayer(g.players, idx)
 }
 
 // GetPlayerCnt プレイヤー数取得。

--- a/internal/domain/Cuckoo.go
+++ b/internal/domain/Cuckoo.go
@@ -570,10 +570,7 @@ func (g *Cuckoo) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer 指定インデックスのプレイヤーを取得する
 func (g *Cuckoo) GetPlayer(i int) *CuckooPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // IsHumanTurn 現在の手番が人間かを返す (ターン or 拒否フェーズ)

--- a/internal/domain/Daifugo.go
+++ b/internal/domain/Daifugo.go
@@ -424,10 +424,7 @@ func (d *Daifugo) GetLastPlayPlayerIdx() int { return d.round.lastPlayPlayerIdx 
 
 // GetPlayer プレイヤー取得
 func (d *Daifugo) GetPlayer(idx int) *DaifugoPlayer {
-	if idx < 0 || idx >= len(d.players) {
-		return nil
-	}
-	return d.players[idx]
+	return getPlayer(d.players, idx)
 }
 
 // GetPlayerCnt プレイヤー数取得

--- a/internal/domain/Desmoche.go
+++ b/internal/domain/Desmoche.go
@@ -656,10 +656,7 @@ func (d *Desmoche) GetPlayers() []*DesmochePlayer { return d.players }
 
 // GetPlayer は idx のプレイヤーを返す。
 func (d *Desmoche) GetPlayer(idx int) *DesmochePlayer {
-	if idx < 0 || idx >= len(d.players) {
-		return nil
-	}
-	return d.players[idx]
+	return getPlayer(d.players, idx)
 }
 
 // GetPhase は現在のフェーズを返す。

--- a/internal/domain/Doppelkopf.go
+++ b/internal/domain/Doppelkopf.go
@@ -744,10 +744,7 @@ func (g *Doppelkopf) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer プレイヤー取得
 func (g *Doppelkopf) GetPlayer(i int) *DoppelkopfPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // IsHumanTurn 現在の手番が人間かどうか。

--- a/internal/domain/Doubt.go
+++ b/internal/domain/Doubt.go
@@ -567,10 +567,7 @@ func (d *Doubt) GetPlayerCnt() int { return len(d.players) }
 
 // GetPlayer プレイヤー取得
 func (d *Doubt) GetPlayer(i int) *DoubtPlayer {
-	if i < 0 || i >= len(d.players) {
-		return nil
-	}
-	return d.players[i]
+	return getPlayer(d.players, i)
 }
 
 // GetTableCardCount テーブルカード枚数取得

--- a/internal/domain/Doudizhu.go
+++ b/internal/domain/Doudizhu.go
@@ -411,10 +411,7 @@ func (d *Doudizhu) GetLastPlayIdx() int { return d.round.lastPlayIdx }
 
 // GetPlayer プレイヤー取得
 func (d *Doudizhu) GetPlayer(idx int) *DoudizhuPlayer {
-	if idx < 0 || idx >= len(d.players) {
-		return nil
-	}
-	return d.players[idx]
+	return getPlayer(d.players, idx)
 }
 
 // GetPlayerCnt プレイヤー数取得

--- a/internal/domain/Ecarte.go
+++ b/internal/domain/Ecarte.go
@@ -730,10 +730,7 @@ func (e *Ecarte) GetPlayerCnt() int { return len(e.players) }
 
 // GetPlayer プレイヤー取得
 func (e *Ecarte) GetPlayer(i int) *EcartePlayer {
-	if i < 0 || i >= len(e.players) {
-		return nil
-	}
-	return e.players[i]
+	return getPlayer(e.players, i)
 }
 
 // GetStockRemaining 山札の残り枚数

--- a/internal/domain/Escoba.go
+++ b/internal/domain/Escoba.go
@@ -471,10 +471,7 @@ func (e *Escoba) GetPlayerCnt() int { return len(e.players) }
 
 // GetPlayer プレイヤー取得
 func (e *Escoba) GetPlayer(i int) *ScopaPlayer {
-	if i < 0 || i >= len(e.players) {
-		return nil
-	}
-	return e.players[i]
+	return getPlayer(e.players, i)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/Euchre.go
+++ b/internal/domain/Euchre.go
@@ -582,10 +582,7 @@ func (e *Euchre) GetPlayerCnt() int { return len(e.players) }
 
 // GetPlayer プレイヤー取得
 func (e *Euchre) GetPlayer(i int) *EuchrePlayer {
-	if i < 0 || i >= len(e.players) {
-		return nil
-	}
-	return e.players[i]
+	return getPlayer(e.players, i)
 }
 
 // GetLeadPlayerIdx リードプレイヤーインデックス取得

--- a/internal/domain/FiftyOne.go
+++ b/internal/domain/FiftyOne.go
@@ -546,10 +546,7 @@ func (fo *FiftyOne) GetPlayerCnt() int { return len(fo.players) }
 
 // GetPlayer 指定インデックスのプレイヤー
 func (fo *FiftyOne) GetPlayer(i int) *FiftyOnePlayer {
-	if i < 0 || i >= len(fo.players) {
-		return nil
-	}
-	return fo.players[i]
+	return getPlayer(fo.players, i)
 }
 
 // GetWinnerIdx 勝者インデックス (-1 = 未確定)

--- a/internal/domain/FiveHundred.go
+++ b/internal/domain/FiveHundred.go
@@ -1178,10 +1178,7 @@ func (g *FiveHundred) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer プレイヤー取得
 func (g *FiveHundred) GetPlayer(i int) *FiveHundredPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // GetLeadPlayerIdx リードプレイヤーインデックス取得

--- a/internal/domain/FortyFives.go
+++ b/internal/domain/FortyFives.go
@@ -866,10 +866,7 @@ func (g *FortyFives) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer プレイヤー取得
 func (g *FortyFives) GetPlayer(i int) *FortyFivesPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // IsHumanTurn 現在の手番が人間か (プレイフェーズ)。

--- a/internal/domain/FrenchTarot.go
+++ b/internal/domain/FrenchTarot.go
@@ -1675,10 +1675,7 @@ func (g *FrenchTarot) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer プレイヤー取得
 func (g *FrenchTarot) GetPlayer(i int) *FrenchTarotPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // IsHumanTurn 現在の手番 (Play) が人間か。

--- a/internal/domain/Gaigel.go
+++ b/internal/domain/Gaigel.go
@@ -693,10 +693,7 @@ func (g *Gaigel) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer プレイヤー取得
 func (g *Gaigel) GetPlayer(i int) *GaigelPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // GetLeadPlayerIdx リードプレイヤーインデックス取得

--- a/internal/domain/Ganjifa.go
+++ b/internal/domain/Ganjifa.go
@@ -744,10 +744,7 @@ func (g *Ganjifa) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer 指定席のプレイヤー。範囲外は nil。
 func (g *Ganjifa) GetPlayer(idx int) *GanjifaPlayer {
-	if idx < 0 || idx >= len(g.players) {
-		return nil
-	}
-	return g.players[idx]
+	return getPlayer(g.players, idx)
 }
 
 // GetConfig 設定。

--- a/internal/domain/GinRummy.go
+++ b/internal/domain/GinRummy.go
@@ -786,10 +786,7 @@ func (g *GinRummy) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer プレイヤー取得
 func (g *GinRummy) GetPlayer(i int) *GinRummyPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // IsHumanTurn 現在の手番が人間かどうか

--- a/internal/domain/GoFish.go
+++ b/internal/domain/GoFish.go
@@ -635,10 +635,7 @@ func (g *GoFish) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer 指定インデックスのプレイヤーを取得する
 func (g *GoFish) GetPlayer(i int) *GoFishPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // GetDeckRemaining 山札の残り枚数を取得する

--- a/internal/domain/GoStop.go
+++ b/internal/domain/GoStop.go
@@ -1125,10 +1125,7 @@ func (g *GoStop) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer は指定インデックスのプレイヤーを返す。
 func (g *GoStop) GetPlayer(i int) *GoStopPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // GetConfig はローカルルール設定を返す。

--- a/internal/domain/GongZhu.go
+++ b/internal/domain/GongZhu.go
@@ -468,10 +468,7 @@ func (g *GongZhu) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer プレイヤー取得
 func (g *GongZhu) GetPlayer(i int) *GongZhuPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // GetLeadPlayerIdx リードプレイヤーインデックス取得

--- a/internal/domain/Guandan.go
+++ b/internal/domain/Guandan.go
@@ -1168,10 +1168,7 @@ func (g *Guandan) GetPlayers() []*GuandanPlayer { return g.players }
 
 // GetPlayer は指定インデックスのプレイヤーを返す。
 func (g *Guandan) GetPlayer(idx int) *GuandanPlayer {
-	if idx < 0 || idx >= len(g.players) {
-		return nil
-	}
-	return g.players[idx]
+	return getPlayer(g.players, idx)
 }
 
 // GetPhase は現在のフェーズを返す。

--- a/internal/domain/Guts.go
+++ b/internal/domain/Guts.go
@@ -536,10 +536,7 @@ func (g *Guts) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer は指定インデックスのプレイヤーを返す。
 func (g *Guts) GetPlayer(i int) *GutsPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // GetChips は人間 (seat 0) の保有チップを返す。

--- a/internal/domain/HachiHachi.go
+++ b/internal/domain/HachiHachi.go
@@ -967,10 +967,7 @@ func (g *HachiHachi) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer は指定インデックスのプレイヤーを返す。
 func (g *HachiHachi) GetPlayer(i int) *HachiHachiPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // GetConfig はローカルルール設定を返す。

--- a/internal/domain/HandAndFoot.go
+++ b/internal/domain/HandAndFoot.go
@@ -1285,10 +1285,7 @@ func (g *HandAndFoot) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer プレイヤー取得
 func (g *HandAndFoot) GetPlayer(i int) *HandAndFootPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // GetTeamMelds 指定チームのメルドを取得

--- a/internal/domain/Hearts.go
+++ b/internal/domain/Hearts.go
@@ -458,10 +458,7 @@ func (h *Hearts) GetPlayerCnt() int { return len(h.players) }
 
 // GetPlayer プレイヤー取得
 func (h *Hearts) GetPlayer(i int) *HeartsPlayer {
-	if i < 0 || i >= len(h.players) {
-		return nil
-	}
-	return h.players[i]
+	return getPlayer(h.players, i)
 }
 
 // GetLeadPlayerIdx リードプレイヤーインデックス取得

--- a/internal/domain/IndianRummy.go
+++ b/internal/domain/IndianRummy.go
@@ -612,10 +612,7 @@ func (g *IndianRummy) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer プレイヤー取得
 func (g *IndianRummy) GetPlayer(i int) *IndianRummyPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/Jass.go
+++ b/internal/domain/Jass.go
@@ -438,10 +438,7 @@ func (g *Jass) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer プレイヤー取得
 func (g *Jass) GetPlayer(i int) *JassPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // GetLeadPlayerIdx リードプレイヤーインデックス取得

--- a/internal/domain/Kaiser.go
+++ b/internal/domain/Kaiser.go
@@ -847,10 +847,7 @@ func (k *Kaiser) GetPlayers() []*KaiserPlayer { return k.players }
 
 // GetPlayer は idx のプレイヤーを返す。
 func (k *Kaiser) GetPlayer(idx int) *KaiserPlayer {
-	if idx < 0 || idx >= len(k.players) {
-		return nil
-	}
-	return k.players[idx]
+	return getPlayer(k.players, idx)
 }
 
 // GetPhase は現在のフェーズを返す。

--- a/internal/domain/Kalooki.go
+++ b/internal/domain/Kalooki.go
@@ -687,10 +687,7 @@ func (g *Kalooki) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer プレイヤー取得
 func (g *Kalooki) GetPlayer(i int) *KalookiPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/Karnoffel.go
+++ b/internal/domain/Karnoffel.go
@@ -664,10 +664,7 @@ func (k *Karnoffel) GetPlayers() []*KarnoffelPlayer { return k.players }
 
 // GetPlayer は指定インデックスのプレイヤーを返す。
 func (k *Karnoffel) GetPlayer(idx int) *KarnoffelPlayer {
-	if idx < 0 || idx >= len(k.players) {
-		return nil
-	}
-	return k.players[idx]
+	return getPlayer(k.players, idx)
 }
 
 // GetPhase は現在のフェーズを返す。

--- a/internal/domain/Kille.go
+++ b/internal/domain/Kille.go
@@ -567,10 +567,7 @@ func (k *Kille) GetPlayers() []*KillePlayer { return k.players }
 
 // GetPlayer は idx のプレイヤーを返す。
 func (k *Kille) GetPlayer(idx int) *KillePlayer {
-	if idx < 0 || idx >= len(k.players) {
-		return nil
-	}
-	return k.players[idx]
+	return getPlayer(k.players, idx)
 }
 
 // GetPhase は現在のフェーズを返す。

--- a/internal/domain/King.go
+++ b/internal/domain/King.go
@@ -494,10 +494,7 @@ func (g *King) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer は指定インデックスのプレイヤーを返す。
 func (g *King) GetPlayer(i int) *KingPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // GetCurrentTurn は現在の手番プレイヤーインデックスを返す。

--- a/internal/domain/Klaberjass.go
+++ b/internal/domain/Klaberjass.go
@@ -1058,10 +1058,7 @@ func (k *Klaberjass) GetPlayers() []*KlaberjassPlayer { return k.players }
 
 // GetPlayer は idx のプレイヤーを返す。
 func (k *Klaberjass) GetPlayer(idx int) *KlaberjassPlayer {
-	if idx < 0 || idx >= len(k.players) {
-		return nil
-	}
-	return k.players[idx]
+	return getPlayer(k.players, idx)
 }
 
 // GetPhase は現在のフェーズを返す。

--- a/internal/domain/Klaverjas.go
+++ b/internal/domain/Klaverjas.go
@@ -773,10 +773,7 @@ func (g *Klaverjas) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer プレイヤー取得
 func (g *Klaverjas) GetPlayer(i int) *KlaverjasPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // IsHumanTurn 現在の手番が人間か。

--- a/internal/domain/KnockoutWhist.go
+++ b/internal/domain/KnockoutWhist.go
@@ -649,10 +649,7 @@ func (g *KnockoutWhist) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer プレイヤー取得
 func (g *KnockoutWhist) GetPlayer(i int) *KnockoutWhistPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // GetActiveCount 残存プレイヤー数を返す。

--- a/internal/domain/Koenigrufen.go
+++ b/internal/domain/Koenigrufen.go
@@ -1725,10 +1725,7 @@ func (g *Koenigrufen) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer プレイヤー取得
 func (g *Koenigrufen) GetPlayer(i int) *KoenigrufenPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // IsHumanTurn 現在の手番 (Play) が人間か。

--- a/internal/domain/KoiKoi.go
+++ b/internal/domain/KoiKoi.go
@@ -1040,10 +1040,7 @@ func (g *KoiKoi) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer は指定インデックスのプレイヤーを返す。
 func (g *KoiKoi) GetPlayer(i int) *KoiKoiPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // GetConfig はローカルルール設定を返す。

--- a/internal/domain/LaughAndLieDown.go
+++ b/internal/domain/LaughAndLieDown.go
@@ -438,10 +438,7 @@ func (l *LaughAndLieDown) GetPlayers() []*LaughAndLieDownPlayer { return l.playe
 
 // GetPlayer は idx のプレイヤーを返す。
 func (l *LaughAndLieDown) GetPlayer(idx int) *LaughAndLieDownPlayer {
-	if idx < 0 || idx >= len(l.players) {
-		return nil
-	}
-	return l.players[idx]
+	return getPlayer(l.players, idx)
 }
 
 // GetPhase は現在のフェーズを返す。

--- a/internal/domain/Literature.go
+++ b/internal/domain/Literature.go
@@ -807,10 +807,7 @@ func (l *Literature) GetPlayers() []*LiteraturePlayer { return l.players }
 
 // GetPlayer は指定インデックスのプレイヤーを返す。
 func (l *Literature) GetPlayer(idx int) *LiteraturePlayer {
-	if idx < 0 || idx >= len(l.players) {
-		return nil
-	}
-	return l.players[idx]
+	return getPlayer(l.players, idx)
 }
 
 // GetPhase は現在のフェーズを返す。

--- a/internal/domain/Loba.go
+++ b/internal/domain/Loba.go
@@ -790,10 +790,7 @@ func (l *Loba) GetPlayers() []*LobaPlayer { return l.players }
 
 // GetPlayer は idx のプレイヤーを返す。
 func (l *Loba) GetPlayer(idx int) *LobaPlayer {
-	if idx < 0 || idx >= len(l.players) {
-		return nil
-	}
-	return l.players[idx]
+	return getPlayer(l.players, idx)
 }
 
 // GetPhase は現在のフェーズを返す。

--- a/internal/domain/Loo.go
+++ b/internal/domain/Loo.go
@@ -885,10 +885,7 @@ func (g *Loo) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer は指定インデックスのプレイヤーを返す。
 func (g *Loo) GetPlayer(i int) *LooPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // GetLastDealDetail は直前ディールの精算内訳を返す (nil の場合もある)。

--- a/internal/domain/Macau.go
+++ b/internal/domain/Macau.go
@@ -457,10 +457,7 @@ func (g *Macau) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer プレイヤー取得
 func (g *Macau) GetPlayer(i int) *MacauPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // IsHumanTurn 現在の手番が人間かどうか

--- a/internal/domain/Machiavelli.go
+++ b/internal/domain/Machiavelli.go
@@ -628,10 +628,7 @@ func (g *Machiavelli) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer プレイヤー取得
 func (g *Machiavelli) GetPlayer(i int) *MachiavelliPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/Manille.go
+++ b/internal/domain/Manille.go
@@ -609,10 +609,7 @@ func (g *Manille) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer プレイヤー取得
 func (g *Manille) GetPlayer(i int) *ManillePlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // IsHumanTurn 現在の手番が人間か。

--- a/internal/domain/Mao.go
+++ b/internal/domain/Mao.go
@@ -626,10 +626,7 @@ func (g *Mao) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer プレイヤー取得
 func (g *Mao) GetPlayer(i int) *MaoPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // IsHumanTurn 現在の手番が人間かどうか

--- a/internal/domain/Marias.go
+++ b/internal/domain/Marias.go
@@ -675,10 +675,7 @@ func (g *Marias) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer プレイヤー取得
 func (g *Marias) GetPlayer(i int) *MariasPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // IsHumanTurn 現在の手番が人間か。

--- a/internal/domain/Memory.go
+++ b/internal/domain/Memory.go
@@ -294,10 +294,7 @@ func (m *Memory) GetPlayerCnt() int { return len(m.players) }
 
 // GetPlayer プレイヤーを取得
 func (m *Memory) GetPlayer(i int) *MemoryPlayer {
-	if i < 0 || i >= len(m.players) {
-		return nil
-	}
-	return m.players[i]
+	return getPlayer(m.players, i)
 }
 
 // GetBoard ボードカードを取得

--- a/internal/domain/Michigan.go
+++ b/internal/domain/Michigan.go
@@ -731,10 +731,7 @@ func (g *Michigan) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer は指定インデックスのプレイヤーを返す。
 func (g *Michigan) GetPlayer(i int) *MichiganPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // GetChips は人間 (seat 0) の保有チップを返す。

--- a/internal/domain/Mighty.go
+++ b/internal/domain/Mighty.go
@@ -675,10 +675,7 @@ func (m *Mighty) GetPlayerCnt() int { return len(m.players) }
 
 // GetPlayer プレイヤー取得
 func (m *Mighty) GetPlayer(i int) *MightyPlayer {
-	if i < 0 || i >= len(m.players) {
-		return nil
-	}
-	return m.players[i]
+	return getPlayer(m.players, i)
 }
 
 // GetPlayers 全プレイヤーを取得

--- a/internal/domain/Minchiate.go
+++ b/internal/domain/Minchiate.go
@@ -783,10 +783,7 @@ func (g *Minchiate) GetPlayerCnt() int { return MinchiatePlayerCnt }
 
 // GetPlayer 指定席のプレイヤー。
 func (g *Minchiate) GetPlayer(i int) *MinchiatePlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // GetPlayers 全プレイヤー。

--- a/internal/domain/Mus.go
+++ b/internal/domain/Mus.go
@@ -1056,10 +1056,7 @@ func (g *Mus) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer プレイヤー取得
 func (g *Mus) GetPlayer(i int) *MusPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // IsHumanTurn 現在の手番が人間か。

--- a/internal/domain/Mushi.go
+++ b/internal/domain/Mushi.go
@@ -671,10 +671,7 @@ func (m *Mushi) GetPlayers() []*MushiPlayer { return m.players }
 
 // GetPlayer は idx のプレイヤーを返す。範囲外は nil。
 func (m *Mushi) GetPlayer(idx int) *MushiPlayer {
-	if idx < 0 || idx >= len(m.players) {
-		return nil
-	}
-	return m.players[idx]
+	return getPlayer(m.players, idx)
 }
 
 // GetField は場札を返す。

--- a/internal/domain/NainJaune.go
+++ b/internal/domain/NainJaune.go
@@ -403,10 +403,7 @@ func (n *NainJaune) GetPlayers() []*NainJaunePlayer { return n.players }
 
 // GetPlayer は idx のプレイヤーを返す。
 func (n *NainJaune) GetPlayer(idx int) *NainJaunePlayer {
-	if idx < 0 || idx >= len(n.players) {
-		return nil
-	}
-	return n.players[idx]
+	return getPlayer(n.players, idx)
 }
 
 // GetPhase は現在のフェーズを返す。

--- a/internal/domain/Nap.go
+++ b/internal/domain/Nap.go
@@ -787,10 +787,7 @@ func (g *Nap) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer プレイヤー取得
 func (g *Nap) GetPlayer(i int) *NapPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // IsHumanTurn 現在の手番が人間か (プレイフェーズ)。

--- a/internal/domain/Napoleon.go
+++ b/internal/domain/Napoleon.go
@@ -552,10 +552,7 @@ func (n *Napoleon) GetPlayerCnt() int { return len(n.players) }
 
 // GetPlayer プレイヤー取得
 func (n *Napoleon) GetPlayer(i int) *NapoleonPlayer {
-	if i < 0 || i >= len(n.players) {
-		return nil
-	}
-	return n.players[i]
+	return getPlayer(n.players, i)
 }
 
 // GetLeadPlayerIdx リードプレイヤーインデックス取得

--- a/internal/domain/NinetyNine.go
+++ b/internal/domain/NinetyNine.go
@@ -420,10 +420,7 @@ func (o *NinetyNine) GetPlayerCnt() int { return len(o.players) }
 
 // GetPlayer プレイヤー取得
 func (o *NinetyNine) GetPlayer(i int) *NinetyNinePlayer {
-	if i < 0 || i >= len(o.players) {
-		return nil
-	}
-	return o.players[i]
+	return getPlayer(o.players, i)
 }
 
 // GetLeadPlayerIdx リードプレイヤーインデックス取得

--- a/internal/domain/OhHell.go
+++ b/internal/domain/OhHell.go
@@ -387,10 +387,7 @@ func (o *OhHell) GetPlayerCnt() int { return len(o.players) }
 
 // GetPlayer プレイヤー取得
 func (o *OhHell) GetPlayer(i int) *OhHellPlayer {
-	if i < 0 || i >= len(o.players) {
-		return nil
-	}
-	return o.players[i]
+	return getPlayer(o.players, i)
 }
 
 // GetLeadPlayerIdx リードプレイヤーインデックス取得

--- a/internal/domain/OldMaid.go
+++ b/internal/domain/OldMaid.go
@@ -660,10 +660,7 @@ func (o *OldMaid) GetLoserIdx() int {
 
 // GetPlayer プレイヤー取得
 func (o *OldMaid) GetPlayer(idx int) *OldMaidPlayer {
-	if idx < 0 || idx >= len(o.players) {
-		return nil
-	}
-	return o.players[idx]
+	return getPlayer(o.players, idx)
 }
 
 // GetPlayerCnt プレイヤー数取得

--- a/internal/domain/Ombre.go
+++ b/internal/domain/Ombre.go
@@ -1242,10 +1242,7 @@ func (g *Ombre) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer プレイヤー取得
 func (g *Ombre) GetPlayer(i int) *OmbrePlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // IsHumanTurn 現在の手番 (プレイ) が人間か。

--- a/internal/domain/OpenFaceChinese.go
+++ b/internal/domain/OpenFaceChinese.go
@@ -565,10 +565,7 @@ func (g *OpenFaceChinese) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer プレイヤー取得
 func (g *OpenFaceChinese) GetPlayer(i int) *OpenFaceChinesePlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/PageOne.go
+++ b/internal/domain/PageOne.go
@@ -375,10 +375,7 @@ func (g *PageOne) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer プレイヤー取得
 func (g *PageOne) GetPlayer(i int) *PageOnePlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // IsHumanTurn 現在の手番が人間かどうか

--- a/internal/domain/Pan.go
+++ b/internal/domain/Pan.go
@@ -684,10 +684,7 @@ func (g *Pan) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer プレイヤー取得
 func (g *Pan) GetPlayer(i int) *PanPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/PigsTail.go
+++ b/internal/domain/PigsTail.go
@@ -307,10 +307,7 @@ func (pt *PigsTail) GetPlayerCnt() int { return len(pt.players) }
 
 // GetPlayer 指定インデックスのプレイヤーを取得する
 func (pt *PigsTail) GetPlayer(i int) *PigsTailPlayer {
-	if i < 0 || i >= len(pt.players) {
-		return nil
-	}
-	return pt.players[i]
+	return getPlayer(pt.players, i)
 }
 
 // GetCurrentTurn 現在の手番プレイヤーインデックスを取得する

--- a/internal/domain/Pishti.go
+++ b/internal/domain/Pishti.go
@@ -558,10 +558,7 @@ func (g *Pishti) GetLastCaptureIdx() int { return g.state.lastCaptureIdx }
 
 // GetPlayer は指定インデックスのプレイヤーを返す。
 func (g *Pishti) GetPlayer(idx int) *PishtiPlayer {
-	if idx < 0 || idx >= len(g.players) {
-		return nil
-	}
-	return g.players[idx]
+	return getPlayer(g.players, idx)
 }
 
 // GetPlayerCnt はプレイヤー数を返す。

--- a/internal/domain/Pitch.go
+++ b/internal/domain/Pitch.go
@@ -727,10 +727,7 @@ func (p *Pitch) GetPlayerCnt() int { return len(p.players) }
 
 // GetPlayer プレイヤー取得
 func (p *Pitch) GetPlayer(i int) *PitchPlayer {
-	if i < 0 || i >= len(p.players) {
-		return nil
-	}
-	return p.players[i]
+	return getPlayer(p.players, i)
 }
 
 // IsHumanTurn 現在の手番が人間かどうか

--- a/internal/domain/Poch.go
+++ b/internal/domain/Poch.go
@@ -669,10 +669,7 @@ func (p *Poch) GetPlayers() []*PochPlayer { return p.players }
 
 // GetPlayer は idx のプレイヤーを返す。
 func (p *Poch) GetPlayer(idx int) *PochPlayer {
-	if idx < 0 || idx >= len(p.players) {
-		return nil
-	}
-	return p.players[idx]
+	return getPlayer(p.players, idx)
 }
 
 // GetPhase は現在のフェーズを返す。

--- a/internal/domain/PopeJoan.go
+++ b/internal/domain/PopeJoan.go
@@ -542,10 +542,7 @@ func (p *PopeJoan) GetPlayers() []*PopeJoanPlayer { return p.players }
 
 // GetPlayer は idx のプレイヤーを返す。
 func (p *PopeJoan) GetPlayer(idx int) *PopeJoanPlayer {
-	if idx < 0 || idx >= len(p.players) {
-		return nil
-	}
-	return p.players[idx]
+	return getPlayer(p.players, idx)
 }
 
 // GetPhase は現在のフェーズを返す。

--- a/internal/domain/Preference.go
+++ b/internal/domain/Preference.go
@@ -771,10 +771,7 @@ func (g *Preference) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer プレイヤー取得
 func (g *Preference) GetPlayer(i int) *PreferencePlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // IsHumanTurn 現在の手番が人間か (プレイフェーズ)。

--- a/internal/domain/President.go
+++ b/internal/domain/President.go
@@ -395,10 +395,7 @@ func (p *President) GetLastPlayPlayerIdx() int { return p.round.lastPlayPlayerId
 
 // GetPlayer プレイヤー取得
 func (p *President) GetPlayer(idx int) *PresidentPlayer {
-	if idx < 0 || idx >= len(p.players) {
-		return nil
-	}
-	return p.players[idx]
+	return getPlayer(p.players, idx)
 }
 
 // GetPlayerCnt プレイヤー数取得

--- a/internal/domain/Primero.go
+++ b/internal/domain/Primero.go
@@ -783,10 +783,7 @@ func (g *Primero) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer は指定インデックスのプレイヤーを返す。
 func (g *Primero) GetPlayer(i int) *PrimeroPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // GetChips は人間 (seat 0) の保有チップを返す。

--- a/internal/domain/Prsi.go
+++ b/internal/domain/Prsi.go
@@ -263,10 +263,7 @@ func (g *Prsi) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer プレイヤー取得
 func (g *Prsi) GetPlayer(i int) *PrsiPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // IsHumanTurn 現在の手番が人間かどうか

--- a/internal/domain/Rook.go
+++ b/internal/domain/Rook.go
@@ -1043,10 +1043,7 @@ func (g *Rook) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer プレイヤー取得
 func (g *Rook) GetPlayer(i int) *RookPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // GetLeadPlayerIdx リードプレイヤーインデックス取得

--- a/internal/domain/Rummy500.go
+++ b/internal/domain/Rummy500.go
@@ -642,10 +642,7 @@ func (g *Rummy500) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer プレイヤー取得
 func (g *Rummy500) GetPlayer(i int) *Rummy500Player {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // IsHumanTurn 現在の手番が人間かどうか

--- a/internal/domain/RussianBank.go
+++ b/internal/domain/RussianBank.go
@@ -184,10 +184,7 @@ func (g *RussianBank) GetPlayers() []*RussianBankPlayer { return g.players }
 
 // GetPlayer seat のプレイヤーを返す (範囲外は nil)。
 func (g *RussianBank) GetPlayer(seat int) *RussianBankPlayer {
-	if seat < 0 || seat >= len(g.players) {
-		return nil
-	}
-	return g.players[seat]
+	return getPlayer(g.players, seat)
 }
 
 // GetTableau 共有タブローを返す。

--- a/internal/domain/Samba.go
+++ b/internal/domain/Samba.go
@@ -1579,10 +1579,7 @@ func (g *Samba) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer プレイヤー取得
 func (g *Samba) GetPlayer(i int) *SambaPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // GetTeamCount チーム数取得

--- a/internal/domain/Scarto.go
+++ b/internal/domain/Scarto.go
@@ -1259,10 +1259,7 @@ func (g *Scarto) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer プレイヤー取得
 func (g *Scarto) GetPlayer(i int) *ScartoPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // IsHumanTurn 現在の手番 (Play) が人間か。

--- a/internal/domain/Schnapsen.go
+++ b/internal/domain/Schnapsen.go
@@ -346,10 +346,7 @@ func (s *Schnapsen) GetPlayerCnt() int { return len(s.players) }
 
 // GetPlayer プレイヤー取得
 func (s *Schnapsen) GetPlayer(i int) *SchnapsenPlayer {
-	if i < 0 || i >= len(s.players) {
-		return nil
-	}
-	return s.players[i]
+	return getPlayer(s.players, i)
 }
 
 // GetPlayerPoints プレイヤーの累積得点取得 (カード点 + マリアージュボーナス)

--- a/internal/domain/Scopa.go
+++ b/internal/domain/Scopa.go
@@ -479,10 +479,7 @@ func (s *Scopa) GetTableCards() []*Card { return s.round.tableCards }
 
 // GetPlayer プレイヤー取得
 func (s *Scopa) GetPlayer(idx int) *ScopaPlayer {
-	if idx < 0 || idx >= len(s.players) {
-		return nil
-	}
-	return s.players[idx]
+	return getPlayer(s.players, idx)
 }
 
 // GetPlayerCnt プレイヤー数取得

--- a/internal/domain/Scopone.go
+++ b/internal/domain/Scopone.go
@@ -419,10 +419,7 @@ func (s *Scopone) GetPlayerCnt() int { return len(s.players) }
 
 // GetPlayer プレイヤー取得
 func (s *Scopone) GetPlayer(i int) *ScopaPlayer {
-	if i < 0 || i >= len(s.players) {
-		return nil
-	}
-	return s.players[i]
+	return getPlayer(s.players, i)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/Sedma.go
+++ b/internal/domain/Sedma.go
@@ -508,10 +508,7 @@ func (g *Sedma) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer プレイヤー取得
 func (g *Sedma) GetPlayer(i int) *SedmaPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // IsHumanTurn 現在の手番が人間か。

--- a/internal/domain/SevenBridge.go
+++ b/internal/domain/SevenBridge.go
@@ -930,10 +930,7 @@ func (g *SevenBridge) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer プレイヤー取得
 func (g *SevenBridge) GetPlayer(i int) *SevenBridgePlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/Sevens.go
+++ b/internal/domain/Sevens.go
@@ -1099,10 +1099,7 @@ func (s *Sevens) GetTableMaxVals() [5]int {
 
 // GetPlayer プレイヤー取得
 func (s *Sevens) GetPlayer(idx int) *SevensPlayer {
-	if idx < 0 || idx >= len(s.players) {
-		return nil
-	}
-	return s.players[idx]
+	return getPlayer(s.players, idx)
 }
 
 // GetPlayerCnt プレイヤー数取得

--- a/internal/domain/Sheepshead.go
+++ b/internal/domain/Sheepshead.go
@@ -908,10 +908,7 @@ func (g *Sheepshead) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer プレイヤー取得
 func (g *Sheepshead) GetPlayer(i int) *SheepsheadPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // IsHumanTurn 現在の手番が人間かどうか。

--- a/internal/domain/ShengJi.go
+++ b/internal/domain/ShengJi.go
@@ -996,10 +996,7 @@ func (s *ShengJi) GetPlayers() []*ShengJiPlayer { return s.players }
 
 // GetPlayer は指定インデックスのプレイヤーを返す。
 func (s *ShengJi) GetPlayer(idx int) *ShengJiPlayer {
-	if idx < 0 || idx >= len(s.players) {
-		return nil
-	}
-	return s.players[idx]
+	return getPlayer(s.players, idx)
 }
 
 // GetPhase は現在のフェーズを返す。

--- a/internal/domain/Shithead.go
+++ b/internal/domain/Shithead.go
@@ -179,10 +179,7 @@ func (s *Shithead) GetPlayerCnt() int { return len(s.players) }
 
 // GetPlayer 指定インデックスのプレイヤーを返す
 func (s *Shithead) GetPlayer(i int) *ShitheadPlayer {
-	if i < 0 || i >= len(s.players) {
-		return nil
-	}
-	return s.players[i]
+	return getPlayer(s.players, i)
 }
 
 // GetCurrentTurn 現在の手番プレイヤーインデックス

--- a/internal/domain/SixBidSolo.go
+++ b/internal/domain/SixBidSolo.go
@@ -1093,10 +1093,7 @@ func (s *SixBidSolo) GetPlayers() []*SixBidSoloPlayer { return s.players }
 
 // GetPlayer は指定インデックスのプレイヤーを返す。
 func (s *SixBidSolo) GetPlayer(idx int) *SixBidSoloPlayer {
-	if idx < 0 || idx >= len(s.players) {
-		return nil
-	}
-	return s.players[idx]
+	return getPlayer(s.players, idx)
 }
 
 // GetPhase は現在のフェーズを返す。

--- a/internal/domain/SixCardGolf.go
+++ b/internal/domain/SixCardGolf.go
@@ -823,10 +823,7 @@ func (g *SixCardGolf) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer プレイヤー取得
 func (g *SixCardGolf) GetPlayer(i int) *SixCardGolfPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // GetDrawnCard 引いたカード

--- a/internal/domain/Sjavs.go
+++ b/internal/domain/Sjavs.go
@@ -784,10 +784,7 @@ func (s *Sjavs) GetPlayers() []*SjavsPlayer { return s.players }
 
 // GetPlayer は idx のプレイヤーを返す。
 func (s *Sjavs) GetPlayer(idx int) *SjavsPlayer {
-	if idx < 0 || idx >= len(s.players) {
-		return nil
-	}
-	return s.players[idx]
+	return getPlayer(s.players, idx)
 }
 
 // GetPhase は現在のフェーズを返す。

--- a/internal/domain/Skat.go
+++ b/internal/domain/Skat.go
@@ -1384,10 +1384,7 @@ func (s *Skat) GetPlayerCnt() int { return len(s.players) }
 
 // GetPlayer returns the i-th player (nil if out of range).
 func (s *Skat) GetPlayer(i int) *SkatPlayer {
-	if i < 0 || i >= len(s.players) {
-		return nil
-	}
-	return s.players[i]
+	return getPlayer(s.players, i)
 }
 
 // GetLeadPlayerIdx returns the lead player index.

--- a/internal/domain/Skitgubbe.go
+++ b/internal/domain/Skitgubbe.go
@@ -541,10 +541,7 @@ func (s *Skitgubbe) GetPlayers() []*SkitgubbePlayer { return s.players }
 
 // GetPlayer は idx のプレイヤーを返す。範囲外は nil。
 func (s *Skitgubbe) GetPlayer(idx int) *SkitgubbePlayer {
-	if idx < 0 || idx >= len(s.players) {
-		return nil
-	}
-	return s.players[idx]
+	return getPlayer(s.players, idx)
 }
 
 // GetPhase は現在のフェーズを返す。

--- a/internal/domain/SoloWhist.go
+++ b/internal/domain/SoloWhist.go
@@ -769,10 +769,7 @@ func (g *SoloWhist) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer プレイヤー取得
 func (g *SoloWhist) GetPlayer(i int) *SoloWhistPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // IsHumanTurn 現在の手番が人間か (プレイフェーズ)。

--- a/internal/domain/Spades.go
+++ b/internal/domain/Spades.go
@@ -383,10 +383,7 @@ func (s *Spades) GetPlayerCnt() int { return len(s.players) }
 
 // GetPlayer プレイヤー取得
 func (s *Spades) GetPlayer(i int) *SpadesPlayer {
-	if i < 0 || i >= len(s.players) {
-		return nil
-	}
-	return s.players[i]
+	return getPlayer(s.players, i)
 }
 
 // GetLeadPlayerIdx リードプレイヤーインデックス取得

--- a/internal/domain/SpoilFive.go
+++ b/internal/domain/SpoilFive.go
@@ -638,10 +638,7 @@ func (g *SpoilFive) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer プレイヤー取得
 func (g *SpoilFive) GetPlayer(i int) *SpoilFivePlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // IsHumanTurn 現在の手番が人間か。

--- a/internal/domain/Sueca.go
+++ b/internal/domain/Sueca.go
@@ -651,10 +651,7 @@ func (g *Sueca) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer プレイヤー取得
 func (g *Sueca) GetPlayer(i int) *SuecaPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // IsHumanTurn 現在の手番が人間か。

--- a/internal/domain/Tablanet.go
+++ b/internal/domain/Tablanet.go
@@ -871,10 +871,7 @@ func (g *Tablanet) GetLastCaptureIdx() int { return g.state.lastCaptureIdx }
 
 // GetPlayer は指定インデックスのプレイヤーを返す。
 func (g *Tablanet) GetPlayer(i int) *TablanetPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // GetPlayerCnt はプレイヤー数を返す。

--- a/internal/domain/Tarneeb.go
+++ b/internal/domain/Tarneeb.go
@@ -532,10 +532,7 @@ func (t *Tarneeb) GetPlayerCnt() int { return len(t.players) }
 
 // GetPlayer プレイヤー取得
 func (t *Tarneeb) GetPlayer(i int) *TarneebPlayer {
-	if i < 0 || i >= len(t.players) {
-		return nil
-	}
-	return t.players[i]
+	return getPlayer(t.players, i)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/Tarocchini.go
+++ b/internal/domain/Tarocchini.go
@@ -768,10 +768,7 @@ func (g *Tarocchini) GetPlayerCnt() int { return TarocchiniPlayerCnt }
 
 // GetPlayer 指定席のプレイヤー。
 func (g *Tarocchini) GetPlayer(i int) *TarocchiniPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // GetPlayers 全プレイヤー。

--- a/internal/domain/TeenPatti.go
+++ b/internal/domain/TeenPatti.go
@@ -732,10 +732,7 @@ func (g *TeenPatti) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer プレイヤー取得
 func (g *TeenPatti) GetPlayer(i int) *TeenPattiPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/ThirtyOne.go
+++ b/internal/domain/ThirtyOne.go
@@ -674,10 +674,7 @@ func (g *ThirtyOne) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer 指定インデックスのプレイヤーを取得する
 func (g *ThirtyOne) GetPlayer(i int) *ThirtyOnePlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // IsHumanTurn 現在の手番が人間かを返す

--- a/internal/domain/ThreeCardBrag.go
+++ b/internal/domain/ThreeCardBrag.go
@@ -672,10 +672,7 @@ func (g *ThreeCardBrag) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer プレイヤー取得
 func (g *ThreeCardBrag) GetPlayer(i int) *ThreeCardBragPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/ThreeThirteen.go
+++ b/internal/domain/ThreeThirteen.go
@@ -569,10 +569,7 @@ func (g *ThreeThirteen) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer プレイヤー取得
 func (g *ThreeThirteen) GetPlayer(i int) *ThreeThirteenPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/Tichu.go
+++ b/internal/domain/Tichu.go
@@ -565,10 +565,7 @@ func (t *Tichu) GetFinishOrder() []int { return t.round.finishOrder }
 
 // GetPlayer プレイヤー取得
 func (t *Tichu) GetPlayer(idx int) *TichuPlayer {
-	if idx < 0 || idx >= len(t.players) {
-		return nil
-	}
-	return t.players[idx]
+	return getPlayer(t.players, idx)
 }
 
 // GetPlayerCnt プレイヤー数取得

--- a/internal/domain/TienLen.go
+++ b/internal/domain/TienLen.go
@@ -322,10 +322,7 @@ func (tl *TienLen) GetLastPlayPlayerIdx() int { return tl.round.lastPlayPlayerId
 
 // GetPlayer プレイヤー取得
 func (tl *TienLen) GetPlayer(idx int) *TienLenPlayer {
-	if idx < 0 || idx >= len(tl.players) {
-		return nil
-	}
-	return tl.players[idx]
+	return getPlayer(tl.players, idx)
 }
 
 // GetPlayerCnt プレイヤー数取得

--- a/internal/domain/Toepen.go
+++ b/internal/domain/Toepen.go
@@ -624,10 +624,7 @@ func (t *Toepen) GetPlayers() []*ToepenPlayer { return t.players }
 
 // GetPlayer は idx のプレイヤーを返す。範囲外は nil。
 func (t *Toepen) GetPlayer(idx int) *ToepenPlayer {
-	if idx < 0 || idx >= len(t.players) {
-		return nil
-	}
-	return t.players[idx]
+	return getPlayer(t.players, idx)
 }
 
 // GetLives は idx の累計失点を返す。

--- a/internal/domain/Tonk.go
+++ b/internal/domain/Tonk.go
@@ -667,10 +667,7 @@ func (g *Tonk) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer プレイヤー取得
 func (g *Tonk) GetPlayer(i int) *TonkPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // IsHumanTurn 現在の手番が人間かどうか

--- a/internal/domain/Tressette.go
+++ b/internal/domain/Tressette.go
@@ -318,10 +318,7 @@ func (g *Tressette) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer プレイヤー取得
 func (g *Tressette) GetPlayer(i int) *TressettePlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // IsHumanTurn 現在の手番が人間かどうか

--- a/internal/domain/Trex.go
+++ b/internal/domain/Trex.go
@@ -706,10 +706,7 @@ func (t *Trex) GetPlayers() []*TrexPlayer { return t.players }
 
 // GetPlayer は idx のプレイヤーを返す。
 func (t *Trex) GetPlayer(idx int) *TrexPlayer {
-	if idx < 0 || idx >= len(t.players) {
-		return nil
-	}
-	return t.players[idx]
+	return getPlayer(t.players, idx)
 }
 
 // GetPhase は現在のフェーズを返す。

--- a/internal/domain/Truco.go
+++ b/internal/domain/Truco.go
@@ -394,10 +394,7 @@ func (t *Truco) GetPlayerCnt() int { return len(t.players) }
 
 // GetPlayer プレイヤー取得
 func (t *Truco) GetPlayer(i int) *TrucoPlayer {
-	if i < 0 || i >= len(t.players) {
-		return nil
-	}
-	return t.players[i]
+	return getPlayer(t.players, i)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/Tute.go
+++ b/internal/domain/Tute.go
@@ -763,10 +763,7 @@ func (g *Tute) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer プレイヤー取得
 func (g *Tute) GetPlayer(i int) *TutePlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // IsHumanTurn 現在の手番が人間か。

--- a/internal/domain/TwentyNine.go
+++ b/internal/domain/TwentyNine.go
@@ -783,10 +783,7 @@ func (g *TwentyNine) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer プレイヤー取得
 func (g *TwentyNine) GetPlayer(i int) *TwentyNinePlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // IsHumanTurn 現在の手番が人間か (プレイフェーズ)。

--- a/internal/domain/TwoTenJack.go
+++ b/internal/domain/TwoTenJack.go
@@ -393,10 +393,7 @@ func (t *TwoTenJack) GetPlayerCnt() int { return len(t.players) }
 
 // GetPlayer プレイヤー取得
 func (t *TwoTenJack) GetPlayer(i int) *TwoTenJackPlayer {
-	if i < 0 || i >= len(t.players) {
-		return nil
-	}
-	return t.players[i]
+	return getPlayer(t.players, i)
 }
 
 // IsHumanTurn 現在の手番が人間かどうか

--- a/internal/domain/Tysiac.go
+++ b/internal/domain/Tysiac.go
@@ -1087,10 +1087,7 @@ func (g *Tysiac) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer プレイヤー取得
 func (g *Tysiac) GetPlayer(i int) *TysiacPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // IsHumanTurn 現在の手番 (プレイ) が人間か。

--- a/internal/domain/Ulti.go
+++ b/internal/domain/Ulti.go
@@ -1227,10 +1227,7 @@ func (g *Ulti) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer プレイヤー取得
 func (g *Ulti) GetPlayer(i int) *UltiPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // IsHumanTurn 現在の手番 (Bid/Discard/Play) が人間か。

--- a/internal/domain/Vint.go
+++ b/internal/domain/Vint.go
@@ -693,10 +693,7 @@ func (v *Vint) GetPlayers() []*VintPlayer { return v.players }
 
 // GetPlayer は idx のプレイヤーを返す。
 func (v *Vint) GetPlayer(idx int) *VintPlayer {
-	if idx < 0 || idx >= len(v.players) {
-		return nil
-	}
-	return v.players[idx]
+	return getPlayer(v.players, idx)
 }
 
 // GetPhase は現在のフェーズを返す。

--- a/internal/domain/Vira.go
+++ b/internal/domain/Vira.go
@@ -841,10 +841,7 @@ func (g *Vira) GetPlayers() []*ViraPlayer { return g.players }
 
 // GetPlayer 指定席のプレイヤー。範囲外は nil。
 func (g *Vira) GetPlayer(idx int) *ViraPlayer {
-	if idx < 0 || idx >= len(g.players) {
-		return nil
-	}
-	return g.players[idx]
+	return getPlayer(g.players, idx)
 }
 
 // GetConfig 設定。

--- a/internal/domain/Watten.go
+++ b/internal/domain/Watten.go
@@ -1170,10 +1170,7 @@ func (g *Watten) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer プレイヤー取得
 func (g *Watten) GetPlayer(i int) *WattenPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // IsHumanTurn 現在のプレイ手番が人間かどうか

--- a/internal/domain/Whist.go
+++ b/internal/domain/Whist.go
@@ -291,10 +291,7 @@ func (w *Whist) GetPlayerCnt() int { return len(w.players) }
 
 // GetPlayer プレイヤー取得
 func (w *Whist) GetPlayer(i int) *WhistPlayer {
-	if i < 0 || i >= len(w.players) {
-		return nil
-	}
-	return w.players[i]
+	return getPlayer(w.players, i)
 }
 
 // GetLeadPlayerIdx リードプレイヤーインデックス取得

--- a/internal/domain/Wizard.go
+++ b/internal/domain/Wizard.go
@@ -409,10 +409,7 @@ func (o *Wizard) GetPlayerCnt() int { return len(o.players) }
 
 // GetPlayer プレイヤー取得
 func (o *Wizard) GetPlayer(i int) *WizardPlayer {
-	if i < 0 || i >= len(o.players) {
-		return nil
-	}
-	return o.players[i]
+	return getPlayer(o.players, i)
 }
 
 // GetLeadPlayerIdx リードプレイヤーインデックス取得

--- a/internal/domain/Yaniv.go
+++ b/internal/domain/Yaniv.go
@@ -775,10 +775,7 @@ func (g *Yaniv) GetPlayerCnt() int { return len(g.players) }
 
 // GetPlayer 指定インデックスのプレイヤーを取得する
 func (g *Yaniv) GetPlayer(i int) *YanivPlayer {
-	if i < 0 || i >= len(g.players) {
-		return nil
-	}
-	return g.players[i]
+	return getPlayer(g.players, i)
 }
 
 // IsHumanTurn 現在の手番が人間かを返す

--- a/internal/domain/Zheng.go
+++ b/internal/domain/Zheng.go
@@ -311,10 +311,7 @@ func (z *Zheng) GetLastPlayPlayerIdx() int { return z.round.lastPlayPlayerIdx }
 
 // GetPlayer プレイヤー取得
 func (z *Zheng) GetPlayer(idx int) *ZhengPlayer {
-	if idx < 0 || idx >= len(z.players) {
-		return nil
-	}
-	return z.players[idx]
+	return getPlayer(z.players, idx)
 }
 
 // GetPlayerCnt プレイヤー数取得

--- a/internal/domain/Zwicker.go
+++ b/internal/domain/Zwicker.go
@@ -632,10 +632,7 @@ func (z *Zwicker) GetPlayers() []*ZwickerPlayer { return z.players }
 
 // GetPlayer は idx のプレイヤーを返す。
 func (z *Zwicker) GetPlayer(idx int) *ZwickerPlayer {
-	if idx < 0 || idx >= len(z.players) {
-		return nil
-	}
-	return z.players[idx]
+	return getPlayer(z.players, idx)
 }
 
 // GetPhase は現在のフェーズを返す。

--- a/internal/domain/player_helpers.go
+++ b/internal/domain/player_helpers.go
@@ -36,6 +36,20 @@ type finishable interface {
 	GetIsFinished() bool
 }
 
+// getPlayer returns the seat at idx, or the zero value (nil for the pointer
+// types every game uses) when idx is outside the roster. 152 games had this
+// exact body.
+//
+// Constrained by `any` rather than an interface: the games' player types share
+// no method this needs, and the helper only indexes. See issue #5185.
+func getPlayer[T any](players []T, idx int) T {
+	if idx < 0 || idx >= len(players) {
+		var zero T
+		return zero
+	}
+	return players[idx]
+}
+
 // humanReporter is the minimal view needed to tell the human player apart from
 // the CPUs.
 type humanReporter interface {

--- a/internal/domain/player_helpers_internal_test.go
+++ b/internal/domain/player_helpers_internal_test.go
@@ -242,3 +242,21 @@ func TestIsHumanTurn_OutOfRangeIsFalseNotPanic(t *testing.T) {
 	assert.False(t, isHumanTurn(seats, 1))
 	assert.False(t, isHumanTurn([]fakeSeat{}, 0))
 }
+
+func TestGetPlayer(t *testing.T) {
+	a, b := &fakeSeat{true}, &fakeSeat{false}
+	seats := []*fakeSeat{a, b}
+
+	assert.Same(t, a, getPlayer(seats, 0))
+	assert.Same(t, b, getPlayer(seats, 1))
+}
+
+// Out of range yields the zero value -- nil for the pointer types every game
+// uses -- rather than panicking. Callers nil-check, so this is the contract.
+func TestGetPlayer_OutOfRangeIsZero(t *testing.T) {
+	seats := []*fakeSeat{{true}}
+
+	assert.Nil(t, getPlayer(seats, -1))
+	assert.Nil(t, getPlayer(seats, 1))
+	assert.Nil(t, getPlayer([]*fakeSeat{}, 0))
+}


### PR DESCRIPTION
## 概要

[#5185](https://github.com/yuta-yoshinaga/go_trumpcards/issues/5185) の残りクラスタのうち最大のものです。**456行削除**。

`GetPlayer` は公開メソッドで **interfaces の339ファイル**が宣言しているため、[#5203 の `IsHumanTurn`](https://github.com/yuta-yoshinaga/go_trumpcards/pull/5203) と同じく**メソッドは残し、本体だけ1行委譲**にします。呼び出し側は一切変更していません。

```go
func (g *AllFours) GetPlayer(i int) *AllFoursPlayer {
	return getPlayer(g.players, i)
}
```

## 16件は自前のまま

168件中、変換するのは**同一ボディの152件のみ**です。

| 種別 | 件数 | 理由 |
|---|---:|---|
| 境界チェックが逆向き | 7 | `if i >= 0 && i < len(p) { return p[i] }; return nil`。**意味は同じ**だが textual に不一致 |
| ゲーム固有の定数で境界判定 | 3 | `i >= BeggarMyNeighbourPlayerCnt` など。`len(players)` とは**別のチェック** |
| その他 | 6 | 個別のボディ |

逆向きの7件は De Morgan で等価だと分かりますが、**このバッチでは一貫して「等価性を推論せず textual 一致のみ」で進めてきた**ので、同じ基準を維持します。定数で境界を見る3件は、スライス長と定数がずれた場合に**挙動が変わる**ため対象外です。

変換後に検算し、**152件が委譲・16件が自前・合計168件**であることを確認しました。

## ヘルパの型制約

`getPlayer[T any]` です。ゲームのプレイヤー型はこのヘルパが必要とするメソッドを共有しておらず、**インデックスするだけ**なので `any` で足ります。範囲外はゼロ値（各ゲームのポインタ型では nil）を返し、既存の nil チェックと整合します。

## テスト計画

- [x] `getPlayer` の単体テスト（該当インデックス、**範囲外3種で nil**）
- [x] 152件が正典ボディであることを検証してから変換（`conv != 152` で中断する実装）
- [x] 変換後に **152/16/168 の内訳を再検算**
- [x] `go build ./...` / `go vet -tags test ./internal/domain/` / `gofmt -l` クリーン
- [x] `go test -tags test ./internal/domain/... ./internal/usecase/...` 通過（domain 51.3s）
- [x] `golangci-lint run ./internal/domain/...` → 0 issues
- [ ] Worker サイズ前後比較（CI 待ち）

## サイズ見込み

本体は境界チェックとインデックスのみで **`fmt` を含みません**。[6クラスタの実測](https://github.com/yuta-yoshinaga/go_trumpcards/pull/5203#issuecomment-5226931349)では `fmt` の有無が支配的だったので、`IsHumanTurn`（+176）に近い横ばいを見込みます。ただし**ゼロ近傍の符号は予測できない**ことが分かっているので、実測して報告します。

Refs #5185