### PR TITLE
refactor(domain): delegate 40 UndoToEscape bodies to the shared helper

### DIFF
--- a/internal/domain/Accordion.go
+++ b/internal/domain/Accordion.go
@@ -202,15 +202,7 @@ func (a *Accordion) CanUndo() bool {
 
 // UndoToEscape 膠着状態から抜けるために必要なアンドゥ回数を返す。膠着状態でなければ0、脱出不可なら-1。
 func (a *Accordion) UndoToEscape() int {
-	if !a.isStalemate {
-		return 0
-	}
-	for i := len(a.history) - 1; i >= 0; i-- {
-		if !a.history[i].isStalemate {
-			return len(a.history) - i
-		}
-	}
-	return -1
+	return undoToEscape(a.isStalemate, a.history, func(s *accordionSnapshot) bool { return s.isStalemate })
 }
 
 // UndoN n回連続でアンドゥを実行する

--- a/internal/domain/AcesUp.go
+++ b/internal/domain/AcesUp.go
@@ -236,15 +236,7 @@ func (a *AcesUp) CanUndo() bool {
 
 // UndoToEscape 膠着状態から抜けるために必要なアンドゥ回数を返す。膠着状態でなければ0、脱出不可なら-1。
 func (a *AcesUp) UndoToEscape() int {
-	if !a.isStalemate {
-		return 0
-	}
-	for i := len(a.history) - 1; i >= 0; i-- {
-		if !a.history[i].isStalemate {
-			return len(a.history) - i
-		}
-	}
-	return -1
+	return undoToEscape(a.isStalemate, a.history, func(s *acesUpSnapshot) bool { return s.isStalemate })
 }
 
 // UndoN n回連続でアンドゥを実行する。

--- a/internal/domain/AmericanToad.go
+++ b/internal/domain/AmericanToad.go
@@ -541,15 +541,7 @@ func (at *AmericanToad) UndoN(n int) error {
 
 // UndoToEscape 膠着状態から抜けるのに必要なアンドゥ回数（膠着でなければ 0、不可なら -1）
 func (at *AmericanToad) UndoToEscape() int {
-	if !at.isStalemate {
-		return 0
-	}
-	for i := len(at.history) - 1; i >= 0; i-- {
-		if !at.history[i].isStalemate {
-			return len(at.history) - i
-		}
-	}
-	return -1
+	return undoToEscape(at.isStalemate, at.history, func(s *americanToadSnapshot) bool { return s.isStalemate })
 }
 
 // AllFaceUp 常に全札が表向き

--- a/internal/domain/BakersDozen.go
+++ b/internal/domain/BakersDozen.go
@@ -335,15 +335,7 @@ func (bd *BakersDozen) CanUndo() bool {
 // UndoToEscape 膠着状態から抜けるために必要なアンドゥ回数を返す。
 // 膠着状態でなければ0、脱出不可なら-1。
 func (bd *BakersDozen) UndoToEscape() int {
-	if !bd.isStalemate {
-		return 0
-	}
-	for i := len(bd.history) - 1; i >= 0; i-- {
-		if !bd.history[i].isStalemate {
-			return len(bd.history) - i
-		}
-	}
-	return -1
+	return undoToEscape(bd.isStalemate, bd.history, func(s *bakersDozenSnapshot) bool { return s.isStalemate })
 }
 
 // UndoN n回連続でアンドゥを実行する。

--- a/internal/domain/BeleagueredCastle.go
+++ b/internal/domain/BeleagueredCastle.go
@@ -359,15 +359,7 @@ func (bc *BeleagueredCastle) CanUndo() bool {
 // UndoToEscape 膠着状態から抜けるために必要なアンドゥ回数を返す。
 // 膠着状態でなければ0、脱出不可なら-1。
 func (bc *BeleagueredCastle) UndoToEscape() int {
-	if !bc.isStalemate {
-		return 0
-	}
-	for i := len(bc.history) - 1; i >= 0; i-- {
-		if !bc.history[i].isStalemate {
-			return len(bc.history) - i
-		}
-	}
-	return -1
+	return undoToEscape(bc.isStalemate, bc.history, func(s *beleagueredCastleSnapshot) bool { return s.isStalemate })
 }
 
 // UndoN n回連続でアンドゥを実行する。

--- a/internal/domain/Bisley.go
+++ b/internal/domain/Bisley.go
@@ -342,15 +342,7 @@ func (b *Bisley) UndoN(n int) error {
 
 // UndoToEscape 膠着状態から抜けるのに必要なアンドゥ回数（膠着でなければ 0、不可なら -1）
 func (b *Bisley) UndoToEscape() int {
-	if !b.isStalemate {
-		return 0
-	}
-	for i := len(b.history) - 1; i >= 0; i-- {
-		if !b.history[i].isStalemate {
-			return len(b.history) - i
-		}
-	}
-	return -1
+	return undoToEscape(b.isStalemate, b.history, func(s *bisleySnapshot) bool { return s.isStalemate })
 }
 
 // AllFaceUp ビズリーは常に全札が表向き

--- a/internal/domain/Braid.go
+++ b/internal/domain/Braid.go
@@ -514,15 +514,7 @@ func (b *Braid) UndoN(n int) error {
 
 // UndoToEscape 膠着状態から抜けるのに必要なアンドゥ回数（膠着でなければ 0、不可なら -1）
 func (b *Braid) UndoToEscape() int {
-	if !b.isStalemate {
-		return 0
-	}
-	for i := len(b.history) - 1; i >= 0; i-- {
-		if !b.history[i].isStalemate {
-			return len(b.history) - i
-		}
-	}
-	return -1
+	return undoToEscape(b.isStalemate, b.history, func(s *braidSnapshot) bool { return s.isStalemate })
 }
 
 // AllFaceUp 常に全札が表向き

--- a/internal/domain/Calculation.go
+++ b/internal/domain/Calculation.go
@@ -278,15 +278,7 @@ func (c *Calculation) CanUndo() bool {
 
 // UndoToEscape 膠着状態から抜けるために必要なアンドゥ回数を返す。膠着状態でなければ0、脱出不可なら-1。
 func (c *Calculation) UndoToEscape() int {
-	if !c.isStalemate {
-		return 0
-	}
-	for i := len(c.history) - 1; i >= 0; i-- {
-		if !c.history[i].isStalemate {
-			return len(c.history) - i
-		}
-	}
-	return -1
+	return undoToEscape(c.isStalemate, c.history, func(s *calculationSnapshot) bool { return s.isStalemate })
 }
 
 // UndoN n回連続でアンドゥを実行する

--- a/internal/domain/Congress.go
+++ b/internal/domain/Congress.go
@@ -438,15 +438,7 @@ func (c *Congress) UndoN(n int) error {
 
 // UndoToEscape 膠着状態から抜けるのに必要なアンドゥ回数（膠着でなければ 0、不可なら -1）
 func (c *Congress) UndoToEscape() int {
-	if !c.isStalemate {
-		return 0
-	}
-	for i := len(c.history) - 1; i >= 0; i-- {
-		if !c.history[i].isStalemate {
-			return len(c.history) - i
-		}
-	}
-	return -1
+	return undoToEscape(c.isStalemate, c.history, func(s *congressSnapshot) bool { return s.isStalemate })
 }
 
 // AllFaceUp 常に全札が表向き

--- a/internal/domain/Crescent.go
+++ b/internal/domain/Crescent.go
@@ -396,15 +396,7 @@ func (cr *Crescent) CanUndo() bool {
 
 // UndoToEscape 手詰まりから脱出するためのアンドゥ回数。手詰まりでなければ 0、脱出不可なら -1。
 func (cr *Crescent) UndoToEscape() int {
-	if !cr.isStalemate {
-		return 0
-	}
-	for i := len(cr.history) - 1; i >= 0; i-- {
-		if !cr.history[i].isStalemate {
-			return len(cr.history) - i
-		}
-	}
-	return -1
+	return undoToEscape(cr.isStalemate, cr.history, func(s *crescentSnapshot) bool { return s.isStalemate })
 }
 
 // UndoN n 回アンドゥする。

--- a/internal/domain/Cruel.go
+++ b/internal/domain/Cruel.go
@@ -397,15 +397,7 @@ func (c *Cruel) CanUndo() bool {
 // UndoToEscape 膠着状態から抜けるために必要なアンドゥ回数を返す。
 // 膠着状態でなければ 0、脱出不可なら -1。
 func (c *Cruel) UndoToEscape() int {
-	if !c.isStalemate {
-		return 0
-	}
-	for i := len(c.history) - 1; i >= 0; i-- {
-		if !c.history[i].isStalemate {
-			return len(c.history) - i
-		}
-	}
-	return -1
+	return undoToEscape(c.isStalemate, c.history, func(s *cruelSnapshot) bool { return s.isStalemate })
 }
 
 // UndoN n回連続でアンドゥを実行する。

--- a/internal/domain/Duchess.go
+++ b/internal/domain/Duchess.go
@@ -568,15 +568,7 @@ func (d *Duchess) UndoN(n int) error {
 
 // UndoToEscape 膠着状態から抜けるのに必要なアンドゥ回数（膠着でなければ 0、不可なら -1）
 func (d *Duchess) UndoToEscape() int {
-	if !d.isStalemate {
-		return 0
-	}
-	for i := len(d.history) - 1; i >= 0; i-- {
-		if !d.history[i].isStalemate {
-			return len(d.history) - i
-		}
-	}
-	return -1
+	return undoToEscape(d.isStalemate, d.history, func(s *duchessSnapshot) bool { return s.isStalemate })
 }
 
 // AllFaceUp 常に全札が表向き

--- a/internal/domain/Easthaven.go
+++ b/internal/domain/Easthaven.go
@@ -427,15 +427,7 @@ func (e *Easthaven) CanUndo() bool {
 
 // UndoToEscape 膠着状態から抜けるために必要なアンドゥ回数を返す。膠着状態でなければ0、脱出不可なら-1。
 func (e *Easthaven) UndoToEscape() int {
-	if !e.isStalemate {
-		return 0
-	}
-	for i := len(e.history) - 1; i >= 0; i-- {
-		if !e.history[i].isStalemate {
-			return len(e.history) - i
-		}
-	}
-	return -1
+	return undoToEscape(e.isStalemate, e.history, func(s *easthavenSnapshot) bool { return s.isStalemate })
 }
 
 // UndoN n回連続でアンドゥを実行する。

--- a/internal/domain/EightOff.go
+++ b/internal/domain/EightOff.go
@@ -476,15 +476,7 @@ func (e *EightOff) CanUndo() bool {
 
 // UndoToEscape 膠着状態から抜けるために必要なアンドゥ回数を返す。膠着状態でなければ0、脱出不可なら-1。
 func (e *EightOff) UndoToEscape() int {
-	if !e.isStalemate {
-		return 0
-	}
-	for i := len(e.history) - 1; i >= 0; i-- {
-		if !e.history[i].isStalemate {
-			return len(e.history) - i
-		}
-	}
-	return -1
+	return undoToEscape(e.isStalemate, e.history, func(s *eightOffSnapshot) bool { return s.isStalemate })
 }
 
 // UndoN n回連続でアンドゥを実行する。

--- a/internal/domain/FlowerGarden.go
+++ b/internal/domain/FlowerGarden.go
@@ -511,15 +511,7 @@ func (fg *FlowerGarden) CanUndo() bool {
 // UndoToEscape 膠着状態から抜けるために必要なアンドゥ回数を返す。
 // 膠着状態でなければ0、脱出不可なら-1。
 func (fg *FlowerGarden) UndoToEscape() int {
-	if !fg.isStalemate {
-		return 0
-	}
-	for i := len(fg.history) - 1; i >= 0; i-- {
-		if !fg.history[i].isStalemate {
-			return len(fg.history) - i
-		}
-	}
-	return -1
+	return undoToEscape(fg.isStalemate, fg.history, func(s *flowerGardenSnapshot) bool { return s.isStalemate })
 }
 
 // UndoN n回連続でアンドゥを実行する。

--- a/internal/domain/FortyAndEight.go
+++ b/internal/domain/FortyAndEight.go
@@ -502,15 +502,7 @@ func (ft *FortyAndEight) CanUndo() bool {
 
 // UndoToEscape 膠着状態から抜けるために必要なアンドゥ回数を返す。膠着状態でなければ0、脱出不可なら-1。
 func (ft *FortyAndEight) UndoToEscape() int {
-	if !ft.isStalemate {
-		return 0
-	}
-	for i := len(ft.history) - 1; i >= 0; i-- {
-		if !ft.history[i].isStalemate {
-			return len(ft.history) - i
-		}
-	}
-	return -1
+	return undoToEscape(ft.isStalemate, ft.history, func(s *fortyAndEightSnapshot) bool { return s.isStalemate })
 }
 
 // UndoN n回連続でアンドゥを実行する。

--- a/internal/domain/FortyThieves.go
+++ b/internal/domain/FortyThieves.go
@@ -459,15 +459,7 @@ func (ft *FortyThieves) CanUndo() bool {
 
 // UndoToEscape 膠着状態から抜けるために必要なアンドゥ回数を返す。膠着状態でなければ0、脱出不可なら-1。
 func (ft *FortyThieves) UndoToEscape() int {
-	if !ft.isStalemate {
-		return 0
-	}
-	for i := len(ft.history) - 1; i >= 0; i-- {
-		if !ft.history[i].isStalemate {
-			return len(ft.history) - i
-		}
-	}
-	return -1
+	return undoToEscape(ft.isStalemate, ft.history, func(s *fortyThievesSnapshot) bool { return s.isStalemate })
 }
 
 // UndoN n回連続でアンドゥを実行する。

--- a/internal/domain/FreeCell.go
+++ b/internal/domain/FreeCell.go
@@ -564,15 +564,7 @@ func (f *FreeCell) CanUndo() bool {
 
 // UndoToEscape 膠着状態から抜けるために必要なアンドゥ回数を返す。膠着状態でなければ0、脱出不可なら-1。
 func (f *FreeCell) UndoToEscape() int {
-	if !f.isStalemate {
-		return 0
-	}
-	for i := len(f.history) - 1; i >= 0; i-- {
-		if !f.history[i].isStalemate {
-			return len(f.history) - i
-		}
-	}
-	return -1
+	return undoToEscape(f.isStalemate, f.history, func(s *freeCellSnapshot) bool { return s.isStalemate })
 }
 
 // UndoN n回連続でアンドゥを実行する。

--- a/internal/domain/Gaps.go
+++ b/internal/domain/Gaps.go
@@ -318,15 +318,7 @@ func (g *Gaps) CanUndo() bool {
 // UndoToEscape は手詰まりから抜けるために必要なUndo回数を返す。
 // 手詰まりでなければ0、脱出不能なら-1。
 func (g *Gaps) UndoToEscape() int {
-	if !g.isStalemate {
-		return 0
-	}
-	for i := len(g.history) - 1; i >= 0; i-- {
-		if !g.history[i].isStalemate {
-			return len(g.history) - i
-		}
-	}
-	return -1
+	return undoToEscape(g.isStalemate, g.history, func(s *gapsSnapshot) bool { return s.isStalemate })
 }
 
 // UndoN はn回連続でUndoを試みる。n<=0なら何もしない。

--- a/internal/domain/Golf.go
+++ b/internal/domain/Golf.go
@@ -232,15 +232,7 @@ func (g *Golf) CanUndo() bool {
 
 // UndoToEscape 膠着状態から抜けるために必要なアンドゥ回数を返す。膠着状態でなければ0、脱出不可なら-1。
 func (g *Golf) UndoToEscape() int {
-	if !g.isStalemate {
-		return 0
-	}
-	for i := len(g.history) - 1; i >= 0; i-- {
-		if !g.history[i].isStalemate {
-			return len(g.history) - i
-		}
-	}
-	return -1
+	return undoToEscape(g.isStalemate, g.history, func(s *golfSnapshot) bool { return s.isStalemate })
 }
 
 // UndoN n回連続でアンドゥを実行する。

--- a/internal/domain/GrandfathersClock.go
+++ b/internal/domain/GrandfathersClock.go
@@ -350,15 +350,7 @@ func (gc *GrandfathersClock) UndoN(n int) error {
 
 // UndoToEscape 膠着状態から抜けるのに必要なアンドゥ回数（膠着でなければ 0、不可なら -1）
 func (gc *GrandfathersClock) UndoToEscape() int {
-	if !gc.isStalemate {
-		return 0
-	}
-	for i := len(gc.history) - 1; i >= 0; i-- {
-		if !gc.history[i].isStalemate {
-			return len(gc.history) - i
-		}
-	}
-	return -1
+	return undoToEscape(gc.isStalemate, gc.history, func(s *grandfathersClockSnapshot) bool { return s.isStalemate })
 }
 
 // AllFaceUp 常に全札が表向き

--- a/internal/domain/KingAlbert.go
+++ b/internal/domain/KingAlbert.go
@@ -511,15 +511,7 @@ func (ka *KingAlbert) CanUndo() bool {
 // UndoToEscape 膠着状態から抜けるために必要なアンドゥ回数を返す。
 // 膠着状態でなければ0、脱出不可なら-1。
 func (ka *KingAlbert) UndoToEscape() int {
-	if !ka.isStalemate {
-		return 0
-	}
-	for i := len(ka.history) - 1; i >= 0; i-- {
-		if !ka.history[i].isStalemate {
-			return len(ka.history) - i
-		}
-	}
-	return -1
+	return undoToEscape(ka.isStalemate, ka.history, func(s *kingAlbertSnapshot) bool { return s.isStalemate })
 }
 
 // UndoN n回連続でアンドゥを実行する。

--- a/internal/domain/Klondike.go
+++ b/internal/domain/Klondike.go
@@ -578,15 +578,7 @@ func (k *Klondike) CanUndo() bool {
 
 // UndoToEscape 膠着状態から抜けるために必要なアンドゥ回数を返す。膠着状態でなければ0、脱出不可なら-1。
 func (k *Klondike) UndoToEscape() int {
-	if !k.isStalemate {
-		return 0
-	}
-	for i := len(k.history) - 1; i >= 0; i-- {
-		if !k.history[i].isStalemate {
-			return len(k.history) - i
-		}
-	}
-	return -1
+	return undoToEscape(k.isStalemate, k.history, func(s *klondikeSnapshot) bool { return s.isStalemate })
 }
 
 // UndoN n回連続でアンドゥを実行する。

--- a/internal/domain/MissMilligan.go
+++ b/internal/domain/MissMilligan.go
@@ -485,15 +485,7 @@ func (mm *MissMilligan) UndoN(n int) error {
 
 // UndoToEscape 膠着状態から抜けるのに必要なアンドゥ回数（膠着でなければ 0、不可なら -1）
 func (mm *MissMilligan) UndoToEscape() int {
-	if !mm.isStalemate {
-		return 0
-	}
-	for i := len(mm.history) - 1; i >= 0; i-- {
-		if !mm.history[i].isStalemate {
-			return len(mm.history) - i
-		}
-	}
-	return -1
+	return undoToEscape(mm.isStalemate, mm.history, func(s *missMilliganSnapshot) bool { return s.isStalemate })
 }
 
 // AllFaceUp 常に全札が表向き

--- a/internal/domain/NapoleonsSquare.go
+++ b/internal/domain/NapoleonsSquare.go
@@ -449,15 +449,7 @@ func (ns *NapoleonsSquare) UndoN(n int) error {
 
 // UndoToEscape 膠着状態から抜けるのに必要なアンドゥ回数（膠着でなければ 0、不可なら -1）
 func (ns *NapoleonsSquare) UndoToEscape() int {
-	if !ns.isStalemate {
-		return 0
-	}
-	for i := len(ns.history) - 1; i >= 0; i-- {
-		if !ns.history[i].isStalemate {
-			return len(ns.history) - i
-		}
-	}
-	return -1
+	return undoToEscape(ns.isStalemate, ns.history, func(s *napoleonsSquareSnapshot) bool { return s.isStalemate })
 }
 
 // AllFaceUp ナポレオンズ・スクエアは常に全札が表向き

--- a/internal/domain/Penguin.go
+++ b/internal/domain/Penguin.go
@@ -494,15 +494,7 @@ func (p *Penguin) CanUndo() bool {
 
 // UndoToEscape 膠着状態から抜けるために必要なアンドゥ回数を返す
 func (p *Penguin) UndoToEscape() int {
-	if !p.isStalemate {
-		return 0
-	}
-	for i := len(p.history) - 1; i >= 0; i-- {
-		if !p.history[i].isStalemate {
-			return len(p.history) - i
-		}
-	}
-	return -1
+	return undoToEscape(p.isStalemate, p.history, func(s *penguinSnapshot) bool { return s.isStalemate })
 }
 
 // UndoN n回連続でアンドゥを実行する

--- a/internal/domain/Pyramid.go
+++ b/internal/domain/Pyramid.go
@@ -371,15 +371,7 @@ func (p *Pyramid) CanUndo() bool {
 
 // UndoToEscape 膠着状態から抜けるために必要なアンドゥ回数を返す。膠着状態でなければ0、脱出不可なら-1。
 func (p *Pyramid) UndoToEscape() int {
-	if !p.isStalemate {
-		return 0
-	}
-	for i := len(p.history) - 1; i >= 0; i-- {
-		if !p.history[i].isStalemate {
-			return len(p.history) - i
-		}
-	}
-	return -1
+	return undoToEscape(p.isStalemate, p.history, func(s *pyramidSnapshot) bool { return s.isStalemate })
 }
 
 // UndoN n回連続でアンドゥを実行する。

--- a/internal/domain/RussianSolitaire.go
+++ b/internal/domain/RussianSolitaire.go
@@ -390,15 +390,7 @@ func (y *RussianSolitaire) CanUndo() bool {
 
 // UndoToEscape 膠着状態から抜けるために必要なアンドゥ回数を返す。膠着状態でなければ0、脱出不可なら-1。
 func (y *RussianSolitaire) UndoToEscape() int {
-	if !y.isStalemate {
-		return 0
-	}
-	for i := len(y.history) - 1; i >= 0; i-- {
-		if !y.history[i].isStalemate {
-			return len(y.history) - i
-		}
-	}
-	return -1
+	return undoToEscape(y.isStalemate, y.history, func(s *russianSolitaireSnapshot) bool { return s.isStalemate })
 }
 
 // UndoN n回連続でアンドゥを実行する。

--- a/internal/domain/Scorpion.go
+++ b/internal/domain/Scorpion.go
@@ -353,15 +353,7 @@ func (s *Scorpion) CanUndo() bool {
 
 // UndoToEscape 膠着状態から抜けるために必要なアンドゥ回数を返す。膠着状態でなければ0、脱出不可なら-1。
 func (s *Scorpion) UndoToEscape() int {
-	if !s.isStalemate {
-		return 0
-	}
-	for i := len(s.history) - 1; i >= 0; i-- {
-		if !s.history[i].isStalemate {
-			return len(s.history) - i
-		}
-	}
-	return -1
+	return undoToEscape(s.isStalemate, s.history, func(s *scorpionSnapshot) bool { return s.isStalemate })
 }
 
 // UndoN n回連続でアンドゥを実行する。

--- a/internal/domain/SeahavenTowers.go
+++ b/internal/domain/SeahavenTowers.go
@@ -471,15 +471,7 @@ func (s *SeahavenTowers) CanUndo() bool {
 
 // UndoToEscape 膠着状態から抜けるために必要なアンドゥ回数を返す。膠着状態でなければ0、脱出不可なら-1。
 func (s *SeahavenTowers) UndoToEscape() int {
-	if !s.isStalemate {
-		return 0
-	}
-	for i := len(s.history) - 1; i >= 0; i-- {
-		if !s.history[i].isStalemate {
-			return len(s.history) - i
-		}
-	}
-	return -1
+	return undoToEscape(s.isStalemate, s.history, func(s *seahavenTowersSnapshot) bool { return s.isStalemate })
 }
 
 // UndoN n回連続でアンドゥを実行する。

--- a/internal/domain/SirTommy.go
+++ b/internal/domain/SirTommy.go
@@ -259,15 +259,7 @@ func (s *SirTommy) CanUndo() bool { return len(s.history) > 0 }
 // UndoToEscape 膠着状態から抜けるために必要なアンドゥ回数を返す。
 // 膠着状態でなければ 0、履歴を遡っても抜けられなければ -1。
 func (s *SirTommy) UndoToEscape() int {
-	if !s.isStalemate {
-		return 0
-	}
-	for i := len(s.history) - 1; i >= 0; i-- {
-		if !s.history[i].isStalemate {
-			return len(s.history) - i
-		}
-	}
-	return -1
+	return undoToEscape(s.isStalemate, s.history, func(s *sirTommySnapshot) bool { return s.isStalemate })
 }
 
 // AllFaceUp すべてのカードが見えているか。

--- a/internal/domain/Spider.go
+++ b/internal/domain/Spider.go
@@ -371,15 +371,7 @@ func (s *Spider) CanUndo() bool {
 
 // UndoToEscape 膠着状態から抜けるために必要なアンドゥ回数を返す。膠着状態でなければ0、脱出不可なら-1。
 func (s *Spider) UndoToEscape() int {
-	if !s.isStalemate {
-		return 0
-	}
-	for i := len(s.history) - 1; i >= 0; i-- {
-		if !s.history[i].isStalemate {
-			return len(s.history) - i
-		}
-	}
-	return -1
+	return undoToEscape(s.isStalemate, s.history, func(s *spiderSnapshot) bool { return s.isStalemate })
 }
 
 // UndoN n回連続でアンドゥを実行する。

--- a/internal/domain/Spiderette.go
+++ b/internal/domain/Spiderette.go
@@ -347,15 +347,7 @@ func (s *Spiderette) CanUndo() bool {
 
 // UndoToEscape 膠着状態から抜けるために必要なアンドゥ回数。膠着でなければ0、脱出不可なら-1。
 func (s *Spiderette) UndoToEscape() int {
-	if !s.isStalemate {
-		return 0
-	}
-	for i := len(s.history) - 1; i >= 0; i-- {
-		if !s.history[i].isStalemate {
-			return len(s.history) - i
-		}
-	}
-	return -1
+	return undoToEscape(s.isStalemate, s.history, func(s *spideretteSnapshot) bool { return s.isStalemate })
 }
 
 // UndoN n回連続でアンドゥを実行する。

--- a/internal/domain/StreetsAndAlleys.go
+++ b/internal/domain/StreetsAndAlleys.go
@@ -354,15 +354,7 @@ func (sa *StreetsAndAlleys) CanUndo() bool {
 // UndoToEscape 膠着状態から抜けるために必要なアンドゥ回数を返す。
 // 膠着状態でなければ0、脱出不可なら-1。
 func (sa *StreetsAndAlleys) UndoToEscape() int {
-	if !sa.isStalemate {
-		return 0
-	}
-	for i := len(sa.history) - 1; i >= 0; i-- {
-		if !sa.history[i].isStalemate {
-			return len(sa.history) - i
-		}
-	}
-	return -1
+	return undoToEscape(sa.isStalemate, sa.history, func(s *streetsAndAlleysSnapshot) bool { return s.isStalemate })
 }
 
 // UndoN n回連続でアンドゥを実行する。

--- a/internal/domain/Sultan.go
+++ b/internal/domain/Sultan.go
@@ -394,15 +394,7 @@ func (su *Sultan) CanUndo() bool {
 
 // UndoToEscape 膠着状態から抜けるために必要なアンドゥ回数を返す。膠着状態でなければ0、脱出不可なら-1。
 func (su *Sultan) UndoToEscape() int {
-	if !su.isStalemate {
-		return 0
-	}
-	for i := len(su.history) - 1; i >= 0; i-- {
-		if !su.history[i].isStalemate {
-			return len(su.history) - i
-		}
-	}
-	return -1
+	return undoToEscape(su.isStalemate, su.history, func(s *sultanSnapshot) bool { return s.isStalemate })
 }
 
 // UndoN n回連続でアンドゥを実行する。

--- a/internal/domain/Terrace.go
+++ b/internal/domain/Terrace.go
@@ -462,15 +462,7 @@ func (t *Terrace) UndoN(n int) error {
 
 // UndoToEscape 膠着状態から抜けるのに必要なアンドゥ回数（膠着でなければ 0、不可なら -1）
 func (t *Terrace) UndoToEscape() int {
-	if !t.isStalemate {
-		return 0
-	}
-	for i := len(t.history) - 1; i >= 0; i-- {
-		if !t.history[i].isStalemate {
-			return len(t.history) - i
-		}
-	}
-	return -1
+	return undoToEscape(t.isStalemate, t.history, func(s *terraceSnapshot) bool { return s.isStalemate })
 }
 
 // AllFaceUp 常に全札が表向き

--- a/internal/domain/TriPeaks.go
+++ b/internal/domain/TriPeaks.go
@@ -291,15 +291,7 @@ func (t *TriPeaks) CanUndo() bool {
 
 // UndoToEscape 膠着状態から抜けるために必要なアンドゥ回数を返す。膠着状態でなければ0、脱出不可なら-1。
 func (t *TriPeaks) UndoToEscape() int {
-	if !t.isStalemate {
-		return 0
-	}
-	for i := len(t.history) - 1; i >= 0; i-- {
-		if !t.history[i].isStalemate {
-			return len(t.history) - i
-		}
-	}
-	return -1
+	return undoToEscape(t.isStalemate, t.history, func(s *triPeaksSnapshot) bool { return s.isStalemate })
 }
 
 // UndoN n回連続でアンドゥを実行する。

--- a/internal/domain/Wasp.go
+++ b/internal/domain/Wasp.go
@@ -353,15 +353,7 @@ func (s *Wasp) CanUndo() bool {
 
 // UndoToEscape 膠着状態から抜けるために必要なアンドゥ回数を返す。膠着状態でなければ0、脱出不可なら-1。
 func (s *Wasp) UndoToEscape() int {
-	if !s.isStalemate {
-		return 0
-	}
-	for i := len(s.history) - 1; i >= 0; i-- {
-		if !s.history[i].isStalemate {
-			return len(s.history) - i
-		}
-	}
-	return -1
+	return undoToEscape(s.isStalemate, s.history, func(s *waspSnapshot) bool { return s.isStalemate })
 }
 
 // UndoN n回連続でアンドゥを実行する。

--- a/internal/domain/Windmill.go
+++ b/internal/domain/Windmill.go
@@ -427,15 +427,7 @@ func (w *Windmill) UndoN(n int) error {
 
 // UndoToEscape 膠着状態から抜けるのに必要なアンドゥ回数（膠着でなければ 0、不可なら -1）
 func (w *Windmill) UndoToEscape() int {
-	if !w.isStalemate {
-		return 0
-	}
-	for i := len(w.history) - 1; i >= 0; i-- {
-		if !w.history[i].isStalemate {
-			return len(w.history) - i
-		}
-	}
-	return -1
+	return undoToEscape(w.isStalemate, w.history, func(s *windmillSnapshot) bool { return s.isStalemate })
 }
 
 // AllFaceUp 常に全札が表向き

--- a/internal/domain/Yukon.go
+++ b/internal/domain/Yukon.go
@@ -386,15 +386,7 @@ func (y *Yukon) CanUndo() bool {
 
 // UndoToEscape 膠着状態から抜けるために必要なアンドゥ回数を返す。膠着状態でなければ0、脱出不可なら-1。
 func (y *Yukon) UndoToEscape() int {
-	if !y.isStalemate {
-		return 0
-	}
-	for i := len(y.history) - 1; i >= 0; i-- {
-		if !y.history[i].isStalemate {
-			return len(y.history) - i
-		}
-	}
-	return -1
+	return undoToEscape(y.isStalemate, y.history, func(s *yukonSnapshot) bool { return s.isStalemate })
 }
 
 // UndoN n回連続でアンドゥを実行する。

--- a/internal/domain/player_helpers.go
+++ b/internal/domain/player_helpers.go
@@ -30,8 +30,6 @@ func sortPlayerHand[T handHolder](p T, less func(ci, cj *Card) bool) {
 	}
 }
 
-// finishable is the minimal interface satisfied by OldMaidPlayer,
-// SevensPlayer, DaifugoPlayer, etc.
 // undoToEscape reports how many undos are needed to leave a stalemate: 0 when
 // not stalemated, the distance back to the most recent non-stalemate snapshot
 // otherwise, and -1 when every snapshot in history is also a stalemate.
@@ -53,6 +51,8 @@ func undoToEscape[T any](isStalemate bool, history []T, wasStalemate func(T) boo
 	return -1
 }
 
+// finishable is the minimal interface satisfied by OldMaidPlayer,
+// SevensPlayer, DaifugoPlayer, etc.
 type finishable interface {
 	GetIsFinished() bool
 }

--- a/internal/domain/player_helpers.go
+++ b/internal/domain/player_helpers.go
@@ -32,6 +32,27 @@ func sortPlayerHand[T handHolder](p T, less func(ci, cj *Card) bool) {
 
 // finishable is the minimal interface satisfied by OldMaidPlayer,
 // SevensPlayer, DaifugoPlayer, etc.
+// undoToEscape reports how many undos are needed to leave a stalemate: 0 when
+// not stalemated, the distance back to the most recent non-stalemate snapshot
+// otherwise, and -1 when every snapshot in history is also a stalemate.
+//
+// 40 solitaires had this loop written out. The predicate is passed in because
+// each game's snapshot type is its own struct with an unexported isStalemate
+// field, and Go constraints cannot require a field -- only a method. The part
+// worth sharing is the walk and the `len(history) - i` distance, not the field
+// access. See issue #5185.
+func undoToEscape[T any](isStalemate bool, history []T, wasStalemate func(T) bool) int {
+	if !isStalemate {
+		return 0
+	}
+	for i := len(history) - 1; i >= 0; i-- {
+		if !wasStalemate(history[i]) {
+			return len(history) - i
+		}
+	}
+	return -1
+}
+
 type finishable interface {
 	GetIsFinished() bool
 }

--- a/internal/domain/player_helpers_internal_test.go
+++ b/internal/domain/player_helpers_internal_test.go
@@ -242,3 +242,30 @@ func TestIsHumanTurn_OutOfRangeIsFalseNotPanic(t *testing.T) {
 	assert.False(t, isHumanTurn(seats, 1))
 	assert.False(t, isHumanTurn([]fakeSeat{}, 0))
 }
+
+type snap struct{ stale bool }
+
+func staleOf(s snap) bool { return s.stale }
+
+func TestUndoToEscape_NotStalematedNeedsNoUndo(t *testing.T) {
+	assert.Equal(t, 0, undoToEscape(false, []snap{{true}, {true}}, staleOf),
+		"not stalemated: nothing to undo, regardless of history")
+}
+
+// The distance is counted from the end, so the most recent non-stalemate
+// snapshot one step back is 1 undo away.
+func TestUndoToEscape_DistanceToLastGoodSnapshot(t *testing.T) {
+	assert.Equal(t, 1, undoToEscape(true, []snap{{false}}, staleOf))
+	assert.Equal(t, 2, undoToEscape(true, []snap{{false}, {true}}, staleOf))
+	assert.Equal(t, 3, undoToEscape(true, []snap{{false}, {true}, {true}}, staleOf))
+}
+
+// The most recent non-stalemate wins, not the earliest.
+func TestUndoToEscape_PicksTheNearestEscape(t *testing.T) {
+	assert.Equal(t, 2, undoToEscape(true, []snap{{false}, {false}, {true}}, staleOf))
+}
+
+func TestUndoToEscape_NoEscapeAnywhere(t *testing.T) {
+	assert.Equal(t, -1, undoToEscape(true, []snap{{true}, {true}}, staleOf))
+	assert.Equal(t, -1, undoToEscape(true, []snap{}, staleOf), "empty history cannot escape")
+}

--- a/internal/domain/undo_to_escape_wiring_test.go
+++ b/internal/domain/undo_to_escape_wiring_test.go
@@ -1,0 +1,325 @@
+//go:build test
+
+package domain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Each of the 40 solitaires delegates UndoToEscape to the shared undoToEscape
+// helper, passing a closure that reads its own snapshot type's isStalemate
+// field. The closure only runs when the game is stalemated AND history is
+// non-empty, so the pre-existing per-game tests (which cover the "not
+// stalemated" and "empty history" paths) never execute it. This table drives
+// every game through the closure so a snapshot wired to the wrong field is
+// caught.
+func TestUndoToEscape_ClosureReadsEachGamesOwnSnapshot(t *testing.T) {
+	games := []struct {
+		name string
+		run  func(stale []bool) int
+	}{
+		{"Accordion", func(stale []bool) int {
+			g := &Accordion{isStalemate: true}
+			for _, s := range stale {
+				g.history = append(g.history, &accordionSnapshot{isStalemate: s})
+			}
+			return g.UndoToEscape()
+		}},
+		{"AcesUp", func(stale []bool) int {
+			g := &AcesUp{isStalemate: true}
+			for _, s := range stale {
+				g.history = append(g.history, &acesUpSnapshot{isStalemate: s})
+			}
+			return g.UndoToEscape()
+		}},
+		{"AmericanToad", func(stale []bool) int {
+			g := &AmericanToad{isStalemate: true}
+			for _, s := range stale {
+				g.history = append(g.history, &americanToadSnapshot{isStalemate: s})
+			}
+			return g.UndoToEscape()
+		}},
+		{"BakersDozen", func(stale []bool) int {
+			g := &BakersDozen{isStalemate: true}
+			for _, s := range stale {
+				g.history = append(g.history, &bakersDozenSnapshot{isStalemate: s})
+			}
+			return g.UndoToEscape()
+		}},
+		{"BeleagueredCastle", func(stale []bool) int {
+			g := &BeleagueredCastle{isStalemate: true}
+			for _, s := range stale {
+				g.history = append(g.history, &beleagueredCastleSnapshot{isStalemate: s})
+			}
+			return g.UndoToEscape()
+		}},
+		{"Bisley", func(stale []bool) int {
+			g := &Bisley{isStalemate: true}
+			for _, s := range stale {
+				g.history = append(g.history, &bisleySnapshot{isStalemate: s})
+			}
+			return g.UndoToEscape()
+		}},
+		{"Braid", func(stale []bool) int {
+			g := &Braid{isStalemate: true}
+			for _, s := range stale {
+				g.history = append(g.history, &braidSnapshot{isStalemate: s})
+			}
+			return g.UndoToEscape()
+		}},
+		{"Calculation", func(stale []bool) int {
+			g := &Calculation{isStalemate: true}
+			for _, s := range stale {
+				g.history = append(g.history, &calculationSnapshot{isStalemate: s})
+			}
+			return g.UndoToEscape()
+		}},
+		{"Congress", func(stale []bool) int {
+			g := &Congress{isStalemate: true}
+			for _, s := range stale {
+				g.history = append(g.history, &congressSnapshot{isStalemate: s})
+			}
+			return g.UndoToEscape()
+		}},
+		{"Crescent", func(stale []bool) int {
+			g := &Crescent{isStalemate: true}
+			for _, s := range stale {
+				g.history = append(g.history, &crescentSnapshot{isStalemate: s})
+			}
+			return g.UndoToEscape()
+		}},
+		{"Cruel", func(stale []bool) int {
+			g := &Cruel{isStalemate: true}
+			for _, s := range stale {
+				g.history = append(g.history, &cruelSnapshot{isStalemate: s})
+			}
+			return g.UndoToEscape()
+		}},
+		{"Duchess", func(stale []bool) int {
+			g := &Duchess{isStalemate: true}
+			for _, s := range stale {
+				g.history = append(g.history, &duchessSnapshot{isStalemate: s})
+			}
+			return g.UndoToEscape()
+		}},
+		{"Easthaven", func(stale []bool) int {
+			g := &Easthaven{isStalemate: true}
+			for _, s := range stale {
+				g.history = append(g.history, &easthavenSnapshot{isStalemate: s})
+			}
+			return g.UndoToEscape()
+		}},
+		{"EightOff", func(stale []bool) int {
+			g := &EightOff{isStalemate: true}
+			for _, s := range stale {
+				g.history = append(g.history, &eightOffSnapshot{isStalemate: s})
+			}
+			return g.UndoToEscape()
+		}},
+		{"FlowerGarden", func(stale []bool) int {
+			g := &FlowerGarden{isStalemate: true}
+			for _, s := range stale {
+				g.history = append(g.history, &flowerGardenSnapshot{isStalemate: s})
+			}
+			return g.UndoToEscape()
+		}},
+		{"FortyAndEight", func(stale []bool) int {
+			g := &FortyAndEight{isStalemate: true}
+			for _, s := range stale {
+				g.history = append(g.history, &fortyAndEightSnapshot{isStalemate: s})
+			}
+			return g.UndoToEscape()
+		}},
+		{"FortyThieves", func(stale []bool) int {
+			g := &FortyThieves{isStalemate: true}
+			for _, s := range stale {
+				g.history = append(g.history, &fortyThievesSnapshot{isStalemate: s})
+			}
+			return g.UndoToEscape()
+		}},
+		{"FreeCell", func(stale []bool) int {
+			g := &FreeCell{isStalemate: true}
+			for _, s := range stale {
+				g.history = append(g.history, &freeCellSnapshot{isStalemate: s})
+			}
+			return g.UndoToEscape()
+		}},
+		{"Gaps", func(stale []bool) int {
+			g := &Gaps{isStalemate: true}
+			for _, s := range stale {
+				g.history = append(g.history, &gapsSnapshot{isStalemate: s})
+			}
+			return g.UndoToEscape()
+		}},
+		{"Golf", func(stale []bool) int {
+			g := &Golf{isStalemate: true}
+			for _, s := range stale {
+				g.history = append(g.history, &golfSnapshot{isStalemate: s})
+			}
+			return g.UndoToEscape()
+		}},
+		{"GrandfathersClock", func(stale []bool) int {
+			g := &GrandfathersClock{isStalemate: true}
+			for _, s := range stale {
+				g.history = append(g.history, &grandfathersClockSnapshot{isStalemate: s})
+			}
+			return g.UndoToEscape()
+		}},
+		{"KingAlbert", func(stale []bool) int {
+			g := &KingAlbert{isStalemate: true}
+			for _, s := range stale {
+				g.history = append(g.history, &kingAlbertSnapshot{isStalemate: s})
+			}
+			return g.UndoToEscape()
+		}},
+		{"Klondike", func(stale []bool) int {
+			g := &Klondike{isStalemate: true}
+			for _, s := range stale {
+				g.history = append(g.history, &klondikeSnapshot{isStalemate: s})
+			}
+			return g.UndoToEscape()
+		}},
+		{"MissMilligan", func(stale []bool) int {
+			g := &MissMilligan{isStalemate: true}
+			for _, s := range stale {
+				g.history = append(g.history, &missMilliganSnapshot{isStalemate: s})
+			}
+			return g.UndoToEscape()
+		}},
+		{"NapoleonsSquare", func(stale []bool) int {
+			g := &NapoleonsSquare{isStalemate: true}
+			for _, s := range stale {
+				g.history = append(g.history, &napoleonsSquareSnapshot{isStalemate: s})
+			}
+			return g.UndoToEscape()
+		}},
+		{"Penguin", func(stale []bool) int {
+			g := &Penguin{isStalemate: true}
+			for _, s := range stale {
+				g.history = append(g.history, &penguinSnapshot{isStalemate: s})
+			}
+			return g.UndoToEscape()
+		}},
+		{"Pyramid", func(stale []bool) int {
+			g := &Pyramid{isStalemate: true}
+			for _, s := range stale {
+				g.history = append(g.history, &pyramidSnapshot{isStalemate: s})
+			}
+			return g.UndoToEscape()
+		}},
+		{"RussianSolitaire", func(stale []bool) int {
+			g := &RussianSolitaire{isStalemate: true}
+			for _, s := range stale {
+				g.history = append(g.history, &russianSolitaireSnapshot{isStalemate: s})
+			}
+			return g.UndoToEscape()
+		}},
+		{"Scorpion", func(stale []bool) int {
+			g := &Scorpion{isStalemate: true}
+			for _, s := range stale {
+				g.history = append(g.history, &scorpionSnapshot{isStalemate: s})
+			}
+			return g.UndoToEscape()
+		}},
+		{"SeahavenTowers", func(stale []bool) int {
+			g := &SeahavenTowers{isStalemate: true}
+			for _, s := range stale {
+				g.history = append(g.history, &seahavenTowersSnapshot{isStalemate: s})
+			}
+			return g.UndoToEscape()
+		}},
+		{"SirTommy", func(stale []bool) int {
+			g := &SirTommy{isStalemate: true}
+			for _, s := range stale {
+				g.history = append(g.history, &sirTommySnapshot{isStalemate: s})
+			}
+			return g.UndoToEscape()
+		}},
+		{"Spider", func(stale []bool) int {
+			g := &Spider{isStalemate: true}
+			for _, s := range stale {
+				g.history = append(g.history, &spiderSnapshot{isStalemate: s})
+			}
+			return g.UndoToEscape()
+		}},
+		{"Spiderette", func(stale []bool) int {
+			g := &Spiderette{isStalemate: true}
+			for _, s := range stale {
+				g.history = append(g.history, &spideretteSnapshot{isStalemate: s})
+			}
+			return g.UndoToEscape()
+		}},
+		{"StreetsAndAlleys", func(stale []bool) int {
+			g := &StreetsAndAlleys{isStalemate: true}
+			for _, s := range stale {
+				g.history = append(g.history, &streetsAndAlleysSnapshot{isStalemate: s})
+			}
+			return g.UndoToEscape()
+		}},
+		{"Sultan", func(stale []bool) int {
+			g := &Sultan{isStalemate: true}
+			for _, s := range stale {
+				g.history = append(g.history, &sultanSnapshot{isStalemate: s})
+			}
+			return g.UndoToEscape()
+		}},
+		{"Terrace", func(stale []bool) int {
+			g := &Terrace{isStalemate: true}
+			for _, s := range stale {
+				g.history = append(g.history, &terraceSnapshot{isStalemate: s})
+			}
+			return g.UndoToEscape()
+		}},
+		{"TriPeaks", func(stale []bool) int {
+			g := &TriPeaks{isStalemate: true}
+			for _, s := range stale {
+				g.history = append(g.history, &triPeaksSnapshot{isStalemate: s})
+			}
+			return g.UndoToEscape()
+		}},
+		{"Wasp", func(stale []bool) int {
+			g := &Wasp{isStalemate: true}
+			for _, s := range stale {
+				g.history = append(g.history, &waspSnapshot{isStalemate: s})
+			}
+			return g.UndoToEscape()
+		}},
+		{"Windmill", func(stale []bool) int {
+			g := &Windmill{isStalemate: true}
+			for _, s := range stale {
+				g.history = append(g.history, &windmillSnapshot{isStalemate: s})
+			}
+			return g.UndoToEscape()
+		}},
+		{"Yukon", func(stale []bool) int {
+			g := &Yukon{isStalemate: true}
+			for _, s := range stale {
+				g.history = append(g.history, &yukonSnapshot{isStalemate: s})
+			}
+			return g.UndoToEscape()
+		}},
+	}
+
+	// Distance is counted from the end of history, so the flags must be read
+	// per element: a closure hardwired to false would return 1 for both cases,
+	// and one hardwired to true would return -1.
+	scenarios := []struct {
+		name  string
+		stale []bool
+		want  int
+	}{
+		{"escape is the most recent snapshot", []bool{true, false}, 1},
+		{"must walk past a stalemated tail", []bool{false, true}, 2},
+		{"no escape anywhere", []bool{true, true}, -1},
+	}
+
+	assert.Len(t, games, 40, "every game delegating to undoToEscape must be listed")
+
+	for _, g := range games {
+		for _, sc := range scenarios {
+			assert.Equal(t, sc.want, g.run(sc.stale), "%s: %s", g.name, sc.name)
+		}
+	}
+}


### PR DESCRIPTION
## 概要

[#5185](https://github.com/yuta-yoshinaga/go_trumpcards/issues/5185) の残りクラスタ。**320行削除**。

**このバッチで唯一、ボディが1種類しかないクラスタ**でした（40件すべてバイト同一）。`UndoToEscape` は interfaces の59ファイルが宣言しているため、メソッドは残し本体だけ委譲します。

## 呼び出し側にクロージャが乗ります（トレードオフ）

```go
func (a *AcesUp) UndoToEscape() int {
	return undoToEscape(a.isStalemate, a.history,
		func(s *acesUpSnapshot) bool { return s.isStalemate })
}
```

これは**好みではなく回避不能**です。各ゲームのスナップショットは固有の構造体
（`*acesUpSnapshot` / `*accordionSnapshot` / …）で、`isStalemate` は**非公開フィールド**です。
Go の型制約は**メソッドは要求できてもフィールドは要求できません**。

代替案として40個のスナップショット型に `stalemate()` アクセサを足すことも考えましたが、
**置き換える loop より行数が増える**ので採りませんでした。

## 共有する価値があるのは loop 側です

```go
for i := len(history) - 1; i >= 0; i-- {
	if !wasStalemate(history[i]) {
		return len(history) - i      // ← ここが off-by-one を作りやすい
	}
}
return -1
```

クロージャ側は単なるフィールドアクセスで、間違えようがありません。**距離計算と
「全部スタルメイトなら -1」の分岐**が本体で、それが40箇所に散っていて**どこにもテストが無い**
状態でした。

## テスト計画

- [x] スタルメイトでなければ 0（履歴の内容によらない）
- [x] **距離の計算**: 1手前 → 1、2手前 → 2、3手前 → 3
- [x] **最も近い脱出点**を選ぶこと（最古ではない）
- [x] 全部スタルメイトなら -1、**空の履歴でも -1**
- [x] 40件が正典ボディであることを検証してから変換（`conv != 40` で中断）
- [x] `go build ./...` / `go vet -tags test ./internal/domain/` / `gofmt -l` クリーン
- [x] `go test -tags test ./internal/domain/... ./internal/usecase/...` 通過（domain 50.6s）
- [x] `golangci-lint run ./internal/domain/...` → 0 issues
- [ ] Worker サイズ前後比較（CI 待ち）

## サイズ見込み

本体に `fmt` はありませんが、**クロージャが40個の異なる型で単相化**されます。[これまでの6クラスタ](https://github.com/yuta-yoshinaga/go_trumpcards/pull/5203#issuecomment-5226931349)では `fmt` の有無が支配的でしたが、クロージャ渡しは初めてのパターンなので**予測せず実測します**。増えるようなら報告のうえ判断を仰ぎます。

Refs #5185