### PR TITLE
test: give the faked-setInterval blocks a retry that works

### DIFF
--- a/frontend/src/components/blackjack/BjEndPhaseControls.test.tsx
+++ b/frontend/src/components/blackjack/BjEndPhaseControls.test.tsx
@@ -1,5 +1,6 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { settleUntil } from '../../test/settleUntil';
 import { BjEndPhaseControls, type BjEndPhaseControlsProps } from './BjEndPhaseControls';
 
 function defaultProps(overrides?: Partial<BjEndPhaseControlsProps>): BjEndPhaseControlsProps {
@@ -78,10 +79,10 @@ describe('BjEndPhaseControls', () => {
       expect(screen.getByRole('button', { name: '次のゲーム (3s)' })).toBeInTheDocument();
 
       vi.advanceTimersByTime(1000);
-      await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム (2s)' })).toBeInTheDocument());
+      await settleUntil(() => expect(screen.getByRole('button', { name: '次のゲーム (2s)' })).toBeInTheDocument());
 
       vi.advanceTimersByTime(1000);
-      await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム (1s)' })).toBeInTheDocument());
+      await settleUntil(() => expect(screen.getByRole('button', { name: '次のゲーム (1s)' })).toBeInTheDocument());
     });
 
     it('calls onReset when countdown reaches 0', async () => {
@@ -89,7 +90,7 @@ describe('BjEndPhaseControls', () => {
       render(<BjEndPhaseControls {...defaultProps({ onReset, autoAdvanceSeconds: 2 })} />);
 
       vi.advanceTimersByTime(2000);
-      await waitFor(() => expect(onReset).toHaveBeenCalled());
+      await settleUntil(() => expect(onReset).toHaveBeenCalled());
     });
 
     it('auto-advance fires onReset directly, bypassing onRequestReset', async () => {
@@ -98,7 +99,7 @@ describe('BjEndPhaseControls', () => {
       render(<BjEndPhaseControls {...defaultProps({ onReset, onRequestReset, autoAdvanceSeconds: 2 })} />);
 
       vi.advanceTimersByTime(2000);
-      await waitFor(() => expect(onReset).toHaveBeenCalled());
+      await settleUntil(() => expect(onReset).toHaveBeenCalled());
       // The confirmation path is skipped for auto-advance.
       expect(onRequestReset).not.toHaveBeenCalled();
     });
@@ -108,7 +109,7 @@ describe('BjEndPhaseControls', () => {
       render(<BjEndPhaseControls {...defaultProps({ onReset, autoAdvanceSeconds: 1 })} />);
 
       vi.advanceTimersByTime(1000);
-      await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument());
+      await settleUntil(() => expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument());
     });
   });
 });

--- a/frontend/src/pages/DoubtPage.test.tsx
+++ b/frontend/src/pages/DoubtPage.test.tsx
@@ -4,6 +4,7 @@ import { actionLogApi, doubtApi } from '../api/gameApi';
 import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
 import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
+import { settleUntil } from '../test/settleUntil';
 import type { DoubtConfig, DoubtResponse } from '../types/card';
 import { DoubtPage } from './DoubtPage';
 
@@ -508,7 +509,15 @@ describe('DoubtPage', () => {
 
   describe('countdown timer', () => {
     beforeEach(() => {
-      // Only fake setInterval/clearInterval; leave setTimeout for waitFor retries
+      // Fake only setInterval/clearInterval so the countdown can be advanced.
+      //
+      // NOTE: `waitFor` does not work in this block. @testing-library only
+      // recognises fake timers under Jest (it tests `typeof jest`), so under
+      // Vitest it always takes the real-timer path: it polls through
+      // `setInterval` -- faked here, so the poll never fires -- while its
+      // deadline stays on the real clock. A DOM condition survives on
+      // MutationObserver alone and a non-DOM one cannot retry at all. Use
+      // `settleUntil()`, which retries by advancing the clock instead.
       vi.useFakeTimers({ toFake: ['setInterval', 'clearInterval'] });
     });
     afterEach(() => {
@@ -521,7 +530,7 @@ describe('DoubtPage', () => {
       renderWithProviders(<DoubtPage />);
       // The countdown text appears in both the visible (aria-hidden) node and the
       // throttled sr timer at the 10s mark, so assert at least one is present.
-      await waitFor(() => expect(screen.getAllByText(/残り 10 秒/).length).toBeGreaterThan(0));
+      await settleUntil(() => expect(screen.getAllByText(/残り 10 秒/).length).toBeGreaterThan(0));
     });
 
     it('clears the countdown interval when the page unmounts', async () => {
@@ -533,7 +542,7 @@ describe('DoubtPage', () => {
       // added tests shifted shard timing on CI.
       mockExec.mockResolvedValue(doubtPhaseCpuPlayedState);
       const { unmount } = renderWithProviders(<DoubtPage />);
-      await waitFor(() => expect(screen.getAllByText(/残り 10 秒/).length).toBeGreaterThan(0));
+      await settleUntil(() => expect(screen.getAllByText(/残り 10 秒/).length).toBeGreaterThan(0));
 
       const cleared = vi.spyOn(globalThis, 'clearInterval');
       unmount();
@@ -544,7 +553,7 @@ describe('DoubtPage', () => {
     it('exposes the countdown as a throttled polite role=timer region', async () => {
       mockExec.mockResolvedValue(doubtPhaseCpuPlayedState);
       renderWithProviders(<DoubtPage />);
-      await waitFor(() => expect(screen.getByTestId('countdown-sr-timer')).toBeInTheDocument());
+      await settleUntil(() => expect(screen.getByTestId('countdown-sr-timer')).toBeInTheDocument());
       const timer = screen.getByTestId('countdown-sr-timer');
       expect(timer).toHaveAttribute('role', 'timer');
       expect(timer).toHaveAttribute('aria-live', 'polite');
@@ -554,7 +563,8 @@ describe('DoubtPage', () => {
     it('announces the doubt-window opening via an assertive role=alert region', async () => {
       mockExec.mockResolvedValue(doubtPhaseCpuPlayedState);
       renderWithProviders(<DoubtPage />);
-      const alert = await screen.findByTestId('doubt-window-alert');
+      await settleUntil(() => expect(screen.getByTestId('doubt-window-alert')).toBeInTheDocument());
+      const alert = screen.getByTestId('doubt-window-alert');
       expect(alert).toHaveAttribute('role', 'alert');
       // Stable prompt text (uses the fixed window length, not the live countdown).
       expect(alert.textContent).toMatch(/ダウトしますか|自動スキップ/);
@@ -563,7 +573,7 @@ describe('DoubtPage', () => {
     it('decrements countdown each second', async () => {
       mockExec.mockResolvedValue(doubtPhaseCpuPlayedState);
       renderWithProviders(<DoubtPage />);
-      await waitFor(() => expect(screen.getAllByText(/残り 10 秒/)[0]).toBeInTheDocument());
+      await settleUntil(() => expect(screen.getAllByText(/残り 10 秒/)[0]).toBeInTheDocument());
 
       act(() => {
         vi.advanceTimersByTime(1000);
@@ -576,7 +586,7 @@ describe('DoubtPage', () => {
         .mockResolvedValueOnce(doubtPhaseCpuPlayedState) // initial reset
         .mockResolvedValueOnce(humanTurnState); // skip response → leave doubt phase
       renderWithProviders(<DoubtPage />);
-      await waitFor(() => expect(screen.getAllByText(/残り 10 秒/)[0]).toBeInTheDocument());
+      await settleUntil(() => expect(screen.getAllByText(/残り 10 秒/)[0]).toBeInTheDocument());
 
       act(() => {
         vi.advanceTimersByTime(10000);
@@ -585,33 +595,31 @@ describe('DoubtPage', () => {
       expect(screen.queryByText(/残り/)).not.toBeInTheDocument();
 
       // Auto-skip is called with the correct doubters
-      await waitFor(() => {
-        expect(mockExec).toHaveBeenCalledWith('skip', undefined, undefined, []);
-      });
+      await settleUntil(() => expect(mockExec).toHaveBeenCalledWith('skip', undefined, undefined, []));
     });
 
     it('stops countdown when ダウト！ is clicked', async () => {
       mockExec.mockResolvedValue(doubtPhaseCpuPlayedState);
       renderWithProviders(<DoubtPage />);
-      await waitFor(() => expect(screen.getAllByText(/残り 10 秒/)[0]).toBeInTheDocument());
+      await settleUntil(() => expect(screen.getAllByText(/残り 10 秒/)[0]).toBeInTheDocument());
 
       mockExec.mockResolvedValue(humanTurnState);
       act(() => {
         fireEvent.click(screen.getByRole('button', { name: 'ダウト！' }));
       });
-      await waitFor(() => expect(screen.queryByText(/残り/)).not.toBeInTheDocument());
+      await settleUntil(() => expect(screen.queryByText(/残り/)).not.toBeInTheDocument());
     });
 
     it('stops countdown when スルー is clicked', async () => {
       mockExec.mockResolvedValue(doubtPhaseCpuPlayedState);
       renderWithProviders(<DoubtPage />);
-      await waitFor(() => expect(screen.getAllByText(/残り 10 秒/)[0]).toBeInTheDocument());
+      await settleUntil(() => expect(screen.getAllByText(/残り 10 秒/)[0]).toBeInTheDocument());
 
       mockExec.mockResolvedValue(humanTurnState);
       act(() => {
         fireEvent.click(screen.getByRole('button', { name: 'スルー' }));
       });
-      await waitFor(() => expect(screen.queryByText(/残り/)).not.toBeInTheDocument());
+      await settleUntil(() => expect(screen.queryByText(/残り/)).not.toBeInTheDocument());
     });
   });
 
@@ -1157,7 +1165,7 @@ describe('DoubtPage', () => {
       };
       mockExec.mockResolvedValue(shortState);
       renderWithProviders(<DoubtPage />);
-      await waitFor(() => expect(screen.getAllByText(/残り 3 秒/)[0]).toBeInTheDocument());
+      await settleUntil(() => expect(screen.getAllByText(/残り 3 秒/)[0]).toBeInTheDocument());
     });
 
     it('uses state.doubtWindowSec for countdown (5s)', async () => {
@@ -1167,7 +1175,7 @@ describe('DoubtPage', () => {
       };
       mockExec.mockResolvedValue(midState);
       renderWithProviders(<DoubtPage />);
-      await waitFor(() => expect(screen.getAllByText(/残り 5 秒/)[0]).toBeInTheDocument());
+      await settleUntil(() => expect(screen.getAllByText(/残り 5 秒/)[0]).toBeInTheDocument());
     });
   });
 

--- a/frontend/src/test/flushPendingDispatch.ts
+++ b/frontend/src/test/flushPendingDispatch.ts
@@ -31,7 +31,9 @@ import { vi } from 'vitest';
  * hypothetical, it stalled all 24 of `PokerPage.test.tsx`'s fake-timer tests for
  * 10s each. So the timer is advanced explicitly when they are installed.
  *
- * Positive assertions do not need this — `waitFor` already retries.
+ * Positive assertions usually do not need this — `waitFor` already retries.
+ * The exception is a test that fakes `setInterval`, where `waitFor` cannot
+ * retry at all; use {@link settleUntil} there.
  */
 export async function flushPendingDispatch(): Promise<void> {
   if (vi.isFakeTimers()) {

--- a/frontend/src/test/settleUntil.test.ts
+++ b/frontend/src/test/settleUntil.test.ts
@@ -1,0 +1,52 @@
+import { configure, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { settleUntil } from './settleUntil';
+
+describe('settleUntil', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['setInterval', 'clearInterval'] });
+  });
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it('resolves when the assertion already passes', async () => {
+    const spy = vi.fn();
+    spy();
+    await settleUntil(() => expect(spy).toHaveBeenCalled());
+  });
+
+  it('resolves a condition that only becomes true on a later turn', async () => {
+    const spy = vi.fn();
+    Promise.resolve().then(() => {
+      spy();
+    });
+    await settleUntil(() => expect(spy).toHaveBeenCalled());
+  });
+
+  // Without this the helper would be indistinguishable from one that returns
+  // unconditionally, and every call site would pass while broken.
+  it('rethrows the last failure when the condition never becomes true', async () => {
+    const spy = vi.fn();
+    await expect(settleUntil(() => expect(spy).toHaveBeenCalled(), 3)).rejects.toThrow();
+  });
+
+  // The reason this helper exists, kept executable so it cannot rot into a
+  // comment that is no longer true. If @testing-library ever learns to detect
+  // Vitest's fake timers, this test fails and the helper can be deleted.
+  it('covers a case waitFor cannot: waitFor has no retry while setInterval is faked', async () => {
+    configure({ asyncUtilTimeout: 150 });
+    try {
+      const spy = vi.fn();
+      Promise.resolve().then(() => {
+        spy();
+      });
+      // waitFor polls through the faked setInterval, so its check never runs
+      // again; only its real-clock deadline still fires.
+      await expect(waitFor(() => expect(spy).toHaveBeenCalled())).rejects.toThrow();
+    } finally {
+      configure({ asyncUtilTimeout: 1000 });
+    }
+  });
+});

--- a/frontend/src/test/settleUntil.ts
+++ b/frontend/src/test/settleUntil.ts
@@ -1,0 +1,42 @@
+import { flushPendingDispatch } from './flushPendingDispatch';
+
+/**
+ * Deterministic stand-in for `waitFor` in tests that fake `setInterval`.
+ *
+ * `waitFor` cannot retry in those tests. @testing-library decides whether fake
+ * timers are installed by looking for Jest (`typeof jest !== 'undefined'` in
+ * `jestFakeTimersAreEnabled`), which is never defined under Vitest — so it
+ * always takes its real-timer path:
+ *
+ * ```js
+ * intervalId = setInterval(checkRealTimersCallback, interval); // faked -> never fires
+ * setTimeout(onTimeout, timeout);                              // real   -> still expires
+ * ```
+ *
+ * The poll is frozen while the deadline keeps running on the wall clock, so a
+ * DOM condition survives only on the MutationObserver `waitFor` also installs,
+ * and a **non-DOM** condition (`expect(mockApi).toHaveBeenCalled()`) has no
+ * retry mechanism at all — it passes only if it is already true at the first
+ * check, and otherwise burns the full timeout and fails. Measured directly: a
+ * DOM condition satisfied 120ms after the wait began passed, while the same
+ * wait on a spy failed after 5005ms.
+ *
+ * This retries by advancing the clock instead of consuming real time, so the
+ * result does not depend on how loaded the machine is.
+ *
+ * @param assert - Assertion to retry; the last failure is rethrown if it never passes.
+ * @param turns - How many settle turns to attempt before giving up.
+ */
+export async function settleUntil(assert: () => void, turns = 20): Promise<void> {
+  let lastError: unknown;
+  for (let i = 0; i < turns; i++) {
+    try {
+      assert();
+      return;
+    } catch (error) {
+      lastError = error;
+    }
+    await flushPendingDispatch();
+  }
+  throw lastError;
+}


### PR DESCRIPTION
## 背景

`DoubtPage.test.tsx > countdown timer` が**無関係な PR を2回落としています**（#4958 2026-08-05、#5206 2026-08-09）。1回目は「フレーク」として再実行で流しましたが、**同じ場所で2回目**なので実バグとして原因を特定しました。

## 原因: このブロックでは `waitFor` がそもそもリトライできない

コンポーネントが負荷に弱いのではありません。**`waitFor` の再試行機構が死んでいます。**

@testing-library はフェイクタイマーの有無を**Jest の存在で**判定します（`helpers.js`）:

```js
function jestFakeTimersAreEnabled() {
  if (typeof jest !== 'undefined' && jest !== null) { ... }   // Vitest では常に false
  return false;
}
```

Vitest に `jest` グローバルは無いので、**常に real-timer パス**へ行きます:

```js
intervalId = setInterval(checkRealTimersCallback, interval);  // ← このブロックが fake 化している
setTimeout(onTimeout, timeout);                               // ← real のまま期限だけ進む
```

**ポーリングが凍結された状態で、期限だけが実時間で進む**という組み合わせです。

- **DOM 条件**: `waitFor` が併せて張る MutationObserver だけで辛うじて生き延びる
- **非 DOM 条件**（`expect(mockExec).toHaveBeenCalledWith('skip', ...)` など）: **リトライ手段がゼロ**。最初の1回で真でなければ、タイムアウトまで待って落ちるだけ

`beforeEach` のコメントは `leave setTimeout for waitFor retries`（waitFor のリトライのために setTimeout は残す）でしたが、**その retry は setInterval 側なので、意図が成立していませんでした。**

## 実測（推測ではなく）

最小再現で両方向を測りました:

| 条件 | 結果 |
|---|---|
| waitFor 開始 **後** 120ms で満たされる **DOM** 条件 | パス（MutationObserver が救う） |
| waitFor 開始 **後** 120ms で満たされる **非DOM** 条件 | **5005ms で失敗** |

この 5005ms は、2026-08-05 に「フレーク」として記録したときのタイムアウト時間と一致します。

## 対応

`settleUntil()` を追加しました。**実時間を消費せず、クロックを進めて**リトライします（既存の `flushPendingDispatch()` を利用。新しい綴りを増やさないため既存ヘルパを先に探しました）。

DoubtPage の2つの fake-timer ブロックの**13箇所すべて**を置換。

`BjEndPhaseControls.test.tsx` も**同じパターン**で、うち2箇所は壊れている側の非 DOM 条件（`expect(onReset).toHaveBeenCalled()`）でした。落ちるのを待つ理由が無いので同時に直しています。

## ヘルパ自身のテスト（両方向 + 根拠を実行可能に）

- 条件が**永遠に満たされない場合に最後の失敗を再送出する** — これが無いと「無条件に return するヘルパ」と見分けがつかず、全呼び出し元が壊れたまま通ります
- **`waitFor` が同じケースで落ちること**を固定 — 存在理由をコメントでなくテストで持たせています。将来 @testing-library が Vitest のフェイクタイマーを検出できるようになったら**このテストが落ちるので、そのときヘルパを削除**できます

## 検証

- `DoubtPage` 103 / `BjEndPhaseControls` 13 / `settleUntil` 4 = **120 passed**
- `bun run typecheck`（TypeScript 7）通過
- `bun run check` 通過（Biome + ガード20本）

## 補足

プロダクションコードは変更していません。テストの待ち方のみの修正です。