### PR TITLE
refactor(domain): delegate 49 hand-predicate bodies to shared helpers

### DIFF
--- a/internal/domain/AllFours.go
+++ b/internal/domain/AllFours.go
@@ -385,13 +385,7 @@ func (a *AllFours) validatePlay(playerIdx int, card *Card) error {
 
 // playerHasSuit プレイヤーが特定のスートを持っているか
 func (a *AllFours) playerHasSuit(playerIdx, design int) bool {
-	pl := a.players[playerIdx]
-	for i := 0; i < pl.GetCardsSize(); i++ {
-		if pl.GetCard(i).GetDesign() == design {
-			return true
-		}
-	}
-	return false
+	return handHasSuit(a.players[playerIdx], design)
 }
 
 // ResolveTrick トリックを解決して勝者を決定する

--- a/internal/domain/Barbu.go
+++ b/internal/domain/Barbu.go
@@ -317,13 +317,7 @@ func (b *Barbu) validateTrickPlay(playerIdx int, card *Card) error {
 
 // playerHasSuit はプレイヤーが指定スートを持っているか。
 func (b *Barbu) playerHasSuit(playerIdx, design int) bool {
-	p := b.players[playerIdx]
-	for i := 0; i < p.GetCardsSize(); i++ {
-		if p.GetCard(i).GetDesign() == design {
-			return true
-		}
-	}
-	return false
+	return handHasSuit(b.players[playerIdx], design)
 }
 
 // resolveTrick は完成したトリックの勝者を決定し、次トリックへ進める。

--- a/internal/domain/Basra.go
+++ b/internal/domain/Basra.go
@@ -218,12 +218,7 @@ func (g *Basra) dealInitialTable() {
 
 // allHandsEmpty は全員の手札が空かどうか。
 func (g *Basra) allHandsEmpty() bool {
-	for _, p := range g.players {
-		if p.GetCardsSize() > 0 {
-			return false
-		}
-	}
-	return true
+	return allHandsEmpty(g.players)
 }
 
 // --- 捕獲ロジック (インライン) ---

--- a/internal/domain/Bezique.go
+++ b/internal/domain/Bezique.go
@@ -656,12 +656,7 @@ func (b *Bezique) finishGame() {
 
 // allHandsEmpty 全プレイヤーの手札が空かを返す
 func (b *Bezique) allHandsEmpty() bool {
-	for _, p := range b.players {
-		if p.GetCardsSize() > 0 {
-			return false
-		}
-	}
-	return true
+	return allHandsEmpty(b.players)
 }
 
 // validatePlay カードのプレイがルール上有効かを検証する。

--- a/internal/domain/Briscola.go
+++ b/internal/domain/Briscola.go
@@ -500,12 +500,7 @@ func (b *Briscola) drawOne() *Card {
 
 // allHandsEmpty 全プレイヤーの手札が空かを返す
 func (b *Briscola) allHandsEmpty() bool {
-	for _, p := range b.players {
-		if p.GetCardsSize() > 0 {
-			return false
-		}
-	}
-	return true
+	return allHandsEmpty(b.players)
 }
 
 // finishGame ゲームを終了させ、勝者を決定する

--- a/internal/domain/Bura.go
+++ b/internal/domain/Bura.go
@@ -700,12 +700,7 @@ func clampPlayerIdx(idx, n int) int {
 
 // allHandsEmpty 全プレイヤーの手札が尽きているかを返す。
 func (b *Bura) allHandsEmpty() bool {
-	for _, p := range b.players {
-		if p.GetCardsSize() > 0 {
-			return false
-		}
-	}
-	return true
+	return allHandsEmpty(b.players)
 }
 
 // ---- CPU ----

--- a/internal/domain/Calabresella.go
+++ b/internal/domain/Calabresella.go
@@ -634,13 +634,7 @@ func (g *Calabresella) validatePlay(playerIdx int, card *Card) error {
 
 // playerHasSuit プレイヤーが指定スートのカードを持っているか。
 func (g *Calabresella) playerHasSuit(playerIdx, design int) bool {
-	p := g.players[playerIdx]
-	for i := 0; i < p.GetCardsSize(); i++ {
-		if p.GetCard(i).GetDesign() == design {
-			return true
-		}
-	}
-	return false
+	return handHasSuit(g.players[playerIdx], design)
 }
 
 // trickWinner トリックの勝者を決定する。切り札がないため、リードスートの最強札が勝つ。

--- a/internal/domain/CallBreak.go
+++ b/internal/domain/CallBreak.go
@@ -480,13 +480,7 @@ func (cb *CallBreak) validatePlay(playerIdx int, card *Card) error {
 
 // playerHasSuit プレイヤーが特定のスートを持っているか
 func (cb *CallBreak) playerHasSuit(playerIdx, design int) bool {
-	p := cb.players[playerIdx]
-	for i := 0; i < p.GetCardsSize(); i++ {
-		if p.GetCard(i).GetDesign() == design {
-			return true
-		}
-	}
-	return false
+	return handHasSuit(cb.players[playerIdx], design)
 }
 
 // playerHasNonSpade プレイヤーがスペード以外のカードを持っているか

--- a/internal/domain/Cassino.go
+++ b/internal/domain/Cassino.go
@@ -193,12 +193,7 @@ func (c *Cassino) dealNextPack() {
 
 // allHandsEmpty は全員の手札が空か。
 func (c *Cassino) allHandsEmpty() bool {
-	for _, p := range c.players {
-		if p.GetCardsSize() > 0 {
-			return false
-		}
-	}
-	return true
+	return allHandsEmpty(c.players)
 }
 
 // PlayerTake は人間プレイヤーが take を実行する。

--- a/internal/domain/CatchTen.go
+++ b/internal/domain/CatchTen.go
@@ -464,13 +464,7 @@ func (g *CatchTen) validatePlay(playerIdx int, card *Card) error {
 
 // playerHasSuit プレイヤーが特定のスートを持っているか
 func (g *CatchTen) playerHasSuit(playerIdx int, design int) bool {
-	p := g.players[playerIdx]
-	for i := 0; i < p.GetCardsSize(); i++ {
-		if p.GetCard(i).GetDesign() == design {
-			return true
-		}
-	}
-	return false
+	return handHasSuit(g.players[playerIdx], design)
 }
 
 // cardStrength はカードのトリック内での強さ (大きいほど強い) を返す。

--- a/internal/domain/CourtPiece.go
+++ b/internal/domain/CourtPiece.go
@@ -585,13 +585,7 @@ func (c *CourtPiece) GetPlayableIndices(playerIdx int) []int {
 
 // playerHasSuit プレイヤーが特定のスートを持っているか
 func (c *CourtPiece) playerHasSuit(playerIdx, design int) bool {
-	p := c.players[playerIdx]
-	for i := 0; i < p.GetCardsSize(); i++ {
-		if p.GetCard(i).GetDesign() == design {
-			return true
-		}
-	}
-	return false
+	return handHasSuit(c.players[playerIdx], design)
 }
 
 // courtPieceRank converts a raw `Card.GetValue()` (1-13, where 1 = Ace) to

--- a/internal/domain/Cuarenta.go
+++ b/internal/domain/Cuarenta.go
@@ -211,12 +211,7 @@ func (g *Cuarenta) dealNextPack() {
 
 // allHandsEmpty は全員の手札が空か。
 func (g *Cuarenta) allHandsEmpty() bool {
-	for _, p := range g.players {
-		if p.GetCardsSize() > 0 {
-			return false
-		}
-	}
-	return true
+	return allHandsEmpty(g.players)
 }
 
 // PlayerPlay は人間プレイヤーが手札 handIdx を出す。

--- a/internal/domain/Ecarte.go
+++ b/internal/domain/Ecarte.go
@@ -506,12 +506,7 @@ func (e *Ecarte) finishGame() {
 
 // allHandsEmpty 全プレイヤーの手札が空かを返す
 func (e *Ecarte) allHandsEmpty() bool {
-	for _, p := range e.players {
-		if p.GetCardsSize() > 0 {
-			return false
-		}
-	}
-	return true
+	return allHandsEmpty(e.players)
 }
 
 // validatePlay マストフォロー (フォロー→勝てるなら勝つ→出せないなら切り札) を検証する。

--- a/internal/domain/Escoba.go
+++ b/internal/domain/Escoba.go
@@ -388,12 +388,7 @@ func (e *Escoba) removeTableCardsByIndex(idxs []int) {
 
 // allHandsEmpty 全プレイヤーの手札が空か。
 func (e *Escoba) allHandsEmpty() bool {
-	for _, p := range e.players {
-		if p.GetCardsSize() > 0 {
-			return false
-		}
-	}
-	return true
+	return allHandsEmpty(e.players)
 }
 
 // chooseCpuPlay は CPU の手を選ぶ。15 で捕獲できるなら最大枚数 (エスコバ優先)、無ければ最大値を置く。

--- a/internal/domain/Gaigel.go
+++ b/internal/domain/Gaigel.go
@@ -504,12 +504,7 @@ func (g *Gaigel) drawOne() *Card {
 
 // allHandsEmpty 全プレイヤーの手札が空かを返す
 func (g *Gaigel) allHandsEmpty() bool {
-	for _, p := range g.players {
-		if p.GetCardsSize() > 0 {
-			return false
-		}
-	}
-	return true
+	return allHandsEmpty(g.players)
 }
 
 // IsEndgame 第2フェーズ (山札と切り札表示カードが尽きてマストフォローになる) かを返す

--- a/internal/domain/Ganjifa.go
+++ b/internal/domain/Ganjifa.go
@@ -507,13 +507,7 @@ func (g *Ganjifa) validatePlay(playerIdx int, card *Card) error {
 
 // playerHasSuit プレイヤーが指定スートを持っているか。
 func (g *Ganjifa) playerHasSuit(playerIdx, design int) bool {
-	p := g.players[playerIdx]
-	for i := 0; i < p.GetCardsSize(); i++ {
-		if p.GetCard(i).GetDesign() == design {
-			return true
-		}
-	}
-	return false
+	return handHasSuit(g.players[playerIdx], design)
 }
 
 // GetValidPlayIndices 出せる手札の位置を返す。

--- a/internal/domain/GoStop.go
+++ b/internal/domain/GoStop.go
@@ -535,12 +535,7 @@ func (g *GoStop) startRound() {
 
 // allHandsEmpty は全員の手札が空かどうか。
 func (g *GoStop) allHandsEmpty() bool {
-	for _, p := range g.players {
-		if p.GetCardsSize() > 0 {
-			return false
-		}
-	}
-	return true
+	return allHandsEmpty(g.players)
 }
 
 // --- 捕獲ロジック (Koi-Koi と同一) ---

--- a/internal/domain/GongZhu.go
+++ b/internal/domain/GongZhu.go
@@ -629,13 +629,7 @@ func (g *GongZhu) GetPlayableIndices(playerIdx int) []int {
 
 // playerHasSuit プレイヤーが特定のスートを持っているか
 func (g *GongZhu) playerHasSuit(playerIdx int, design int) bool {
-	p := g.players[playerIdx]
-	for i := 0; i < p.GetCardsSize(); i++ {
-		if p.GetCard(i).GetDesign() == design {
-			return true
-		}
-	}
-	return false
+	return handHasSuit(g.players[playerIdx], design)
 }
 
 // playerHasNonHeart プレイヤーがハート以外のカードを持っているか

--- a/internal/domain/HachiHachi.go
+++ b/internal/domain/HachiHachi.go
@@ -486,12 +486,7 @@ func (g *HachiHachi) startRound() {
 
 // allHandsEmpty は全員の手札が空かどうか。
 func (g *HachiHachi) allHandsEmpty() bool {
-	for _, p := range g.players {
-		if p.GetCardsSize() > 0 {
-			return false
-		}
-	}
-	return true
+	return allHandsEmpty(g.players)
 }
 
 // --- 捕獲ロジック ---

--- a/internal/domain/Hearts.go
+++ b/internal/domain/Hearts.go
@@ -601,13 +601,7 @@ func (h *Hearts) playerHasCard(playerIdx int, design, value int) bool {
 
 // playerHasSuit プレイヤーが特定のスートを持っているか
 func (h *Hearts) playerHasSuit(playerIdx int, design int) bool {
-	p := h.players[playerIdx]
-	for i := 0; i < p.GetCardsSize(); i++ {
-		if p.GetCard(i).GetDesign() == design {
-			return true
-		}
-	}
-	return false
+	return handHasSuit(h.players[playerIdx], design)
 }
 
 // playerHasNonHeart プレイヤーがハート以外のカードを持っているか

--- a/internal/domain/King.go
+++ b/internal/domain/King.go
@@ -318,13 +318,7 @@ func (g *King) validateTrickPlay(playerIdx int, card *Card) error {
 
 // playerHasSuit はプレイヤーが指定スートを持っているか。
 func (g *King) playerHasSuit(playerIdx, design int) bool {
-	p := g.players[playerIdx]
-	for i := 0; i < p.GetCardsSize(); i++ {
-		if p.GetCard(i).GetDesign() == design {
-			return true
-		}
-	}
-	return false
+	return handHasSuit(g.players[playerIdx], design)
 }
 
 // resolveTrick は完成したトリックの勝者を決定し、次トリックへ進める。

--- a/internal/domain/Klaverjas.go
+++ b/internal/domain/Klaverjas.go
@@ -354,13 +354,7 @@ func (g *Klaverjas) canOvertrump(playerIdx, strength int) bool {
 
 // playerHasSuit プレイヤーが指定スートのカードを持っているか。
 func (g *Klaverjas) playerHasSuit(playerIdx, design int) bool {
-	p := g.players[playerIdx]
-	for i := 0; i < p.GetCardsSize(); i++ {
-		if p.GetCard(i).GetDesign() == design {
-			return true
-		}
-	}
-	return false
+	return handHasSuit(g.players[playerIdx], design)
 }
 
 // trickWinner トリックの勝者を決定する。切り札があれば最強切り札、なければ

--- a/internal/domain/KnockoutWhist.go
+++ b/internal/domain/KnockoutWhist.go
@@ -402,13 +402,7 @@ func (g *KnockoutWhist) validatePlay(playerIdx int, card *Card) error {
 
 // playerHasSuit プレイヤーが指定スートのカードを持っているか。
 func (g *KnockoutWhist) playerHasSuit(playerIdx, design int) bool {
-	p := g.players[playerIdx]
-	for i := 0; i < p.GetCardsSize(); i++ {
-		if p.GetCard(i).GetDesign() == design {
-			return true
-		}
-	}
-	return false
+	return handHasSuit(g.players[playerIdx], design)
 }
 
 // trickWinner トリックの勝者を決定する。切り札があれば最強切り札、なければ

--- a/internal/domain/KoiKoi.go
+++ b/internal/domain/KoiKoi.go
@@ -474,12 +474,7 @@ func (g *KoiKoi) startRound() {
 
 // allHandsEmpty は全員の手札が空かどうか。
 func (g *KoiKoi) allHandsEmpty() bool {
-	for _, p := range g.players {
-		if p.GetCardsSize() > 0 {
-			return false
-		}
-	}
-	return true
+	return allHandsEmpty(g.players)
 }
 
 // --- 捕獲ロジック ---

--- a/internal/domain/Manille.go
+++ b/internal/domain/Manille.go
@@ -314,13 +314,7 @@ func (g *Manille) partnerWinning(playerIdx int) bool {
 
 // playerHasSuit プレイヤーが指定スートのカードを持っているか。
 func (g *Manille) playerHasSuit(playerIdx, design int) bool {
-	p := g.players[playerIdx]
-	for i := 0; i < p.GetCardsSize(); i++ {
-		if p.GetCard(i).GetDesign() == design {
-			return true
-		}
-	}
-	return false
+	return handHasSuit(g.players[playerIdx], design)
 }
 
 // trickWinner トリックの勝者を決定する。切り札があれば最強切り札、なければ

--- a/internal/domain/Marias.go
+++ b/internal/domain/Marias.go
@@ -377,13 +377,7 @@ func (g *Marias) validatePlay(playerIdx int, card *Card) error {
 
 // playerHasSuit プレイヤーが指定スートのカードを持っているか。
 func (g *Marias) playerHasSuit(playerIdx, design int) bool {
-	p := g.players[playerIdx]
-	for i := 0; i < p.GetCardsSize(); i++ {
-		if p.GetCard(i).GetDesign() == design {
-			return true
-		}
-	}
-	return false
+	return handHasSuit(g.players[playerIdx], design)
 }
 
 // trickWinner トリックの勝者を決定する。切り札があれば最強切り札、なければ

--- a/internal/domain/Nap.go
+++ b/internal/domain/Nap.go
@@ -473,13 +473,7 @@ func (g *Nap) validatePlay(playerIdx int, card *Card) error {
 
 // playerHasSuit プレイヤーが指定スートのカードを持っているか。
 func (g *Nap) playerHasSuit(playerIdx, design int) bool {
-	p := g.players[playerIdx]
-	for i := 0; i < p.GetCardsSize(); i++ {
-		if p.GetCard(i).GetDesign() == design {
-			return true
-		}
-	}
-	return false
+	return handHasSuit(g.players[playerIdx], design)
 }
 
 // trickWinner トリックの勝者を決定する。切り札があれば最強切り札、なければ

--- a/internal/domain/Napoleon.go
+++ b/internal/domain/Napoleon.go
@@ -984,14 +984,7 @@ func (n *Napoleon) checkAdjutantReveal(playerIdx int, card *Card) {
 
 // playerHasSuit プレイヤーが特定のスートを持っているか (ジョーカーは除外)
 func (n *Napoleon) playerHasSuit(playerIdx int, design int) bool {
-	p := n.players[playerIdx]
-	for i := 0; i < p.GetCardsSize(); i++ {
-		c := p.GetCard(i)
-		if c.GetDesign() == design {
-			return true
-		}
-	}
-	return false
+	return handHasSuit(n.players[playerIdx], design)
 }
 
 // checkGameEnd ゲーム終了判定

--- a/internal/domain/NinetyNine.go
+++ b/internal/domain/NinetyNine.go
@@ -579,13 +579,7 @@ func (o *NinetyNine) validatePlay(playerIdx int, card *Card) error {
 
 // playerHasSuit プレイヤーが特定のスートを持っているか
 func (o *NinetyNine) playerHasSuit(playerIdx int, design int) bool {
-	p := o.players[playerIdx]
-	for i := 0; i < p.GetCardsSize(); i++ {
-		if p.GetCard(i).GetDesign() == design {
-			return true
-		}
-	}
-	return false
+	return handHasSuit(o.players[playerIdx], design)
 }
 
 // trickWinner トリックの勝者を決定する

--- a/internal/domain/OhHell.go
+++ b/internal/domain/OhHell.go
@@ -586,13 +586,7 @@ func (o *OhHell) validatePlay(playerIdx int, card *Card) error {
 
 // playerHasSuit プレイヤーが特定のスートを持っているか
 func (o *OhHell) playerHasSuit(playerIdx int, design int) bool {
-	p := o.players[playerIdx]
-	for i := 0; i < p.GetCardsSize(); i++ {
-		if p.GetCard(i).GetDesign() == design {
-			return true
-		}
-	}
-	return false
+	return handHasSuit(o.players[playerIdx], design)
 }
 
 // trickWinner トリックの勝者を決定する

--- a/internal/domain/Pishti.go
+++ b/internal/domain/Pishti.go
@@ -209,12 +209,7 @@ func (g *Pishti) pileTop() *Card {
 
 // allHandsEmpty は全員の手札が空かどうか。
 func (g *Pishti) allHandsEmpty() bool {
-	for _, p := range g.players {
-		if p.GetCardsSize() > 0 {
-			return false
-		}
-	}
-	return true
+	return allHandsEmpty(g.players)
 }
 
 // PlayerPlay は人間プレイヤーが手札 cardIndex を場へ出す。

--- a/internal/domain/Pitch.go
+++ b/internal/domain/Pitch.go
@@ -374,13 +374,7 @@ func (p *Pitch) validatePlay(playerIdx int, card *Card) error {
 
 // playerHasSuit プレイヤーが特定のスートを持っているか
 func (p *Pitch) playerHasSuit(playerIdx, design int) bool {
-	pl := p.players[playerIdx]
-	for i := 0; i < pl.GetCardsSize(); i++ {
-		if pl.GetCard(i).GetDesign() == design {
-			return true
-		}
-	}
-	return false
+	return handHasSuit(p.players[playerIdx], design)
 }
 
 // ResolveTrick トリックを解決して勝者を決定する

--- a/internal/domain/Preference.go
+++ b/internal/domain/Preference.go
@@ -493,13 +493,7 @@ func (g *Preference) validatePlay(playerIdx int, card *Card) error {
 
 // playerHasSuit プレイヤーが指定スートのカードを持っているか。
 func (g *Preference) playerHasSuit(playerIdx, design int) bool {
-	p := g.players[playerIdx]
-	for i := 0; i < p.GetCardsSize(); i++ {
-		if p.GetCard(i).GetDesign() == design {
-			return true
-		}
-	}
-	return false
+	return handHasSuit(g.players[playerIdx], design)
 }
 
 // trickWinner トリックの勝者を決定する。切り札があれば最強切り札、なければ

--- a/internal/domain/Schnapsen.go
+++ b/internal/domain/Schnapsen.go
@@ -574,7 +574,7 @@ func (s *Schnapsen) cardSatisfiesFollow(playerIdx int, card *Card) bool {
 	leadCard := s.currentTrick[0].Card
 	leadSuit := leadCard.GetDesign()
 
-	if playerHasSuit(player, leadSuit) {
+	if handHasSuit(player, leadSuit) {
 		if card.GetDesign() != leadSuit {
 			return false
 		}
@@ -584,7 +584,7 @@ func (s *Schnapsen) cardSatisfiesFollow(playerIdx int, card *Card) bool {
 		}
 		return true
 	}
-	if playerHasSuit(player, s.trumpSuit) {
+	if handHasSuit(player, s.trumpSuit) {
 		return card.GetDesign() == s.trumpSuit
 	}
 	return true
@@ -600,16 +600,6 @@ func (s *Schnapsen) legalPlayIndices(playerIdx int) []int {
 		}
 	}
 	return out
-}
-
-// playerHasSuit プレイヤーが指定スートのカードを持つか
-func playerHasSuit(player *SchnapsenPlayer, suit int) bool {
-	for i := 0; i < player.GetCardsSize(); i++ {
-		if player.GetCard(i).GetDesign() == suit {
-			return true
-		}
-	}
-	return false
 }
 
 // playerHasSuitWinner プレイヤーが同スートで leadCard に勝てるカードを持つか
@@ -701,12 +691,7 @@ func (s *Schnapsen) drawOne() *Card {
 
 // allHandsEmpty 全プレイヤーの手札が空かを返す
 func (s *Schnapsen) allHandsEmpty() bool {
-	for _, p := range s.players {
-		if p.GetCardsSize() > 0 {
-			return false
-		}
-	}
-	return true
+	return allHandsEmpty(s.players)
 }
 
 // finishGame ゲームを終了させ、勝者を決定する

--- a/internal/domain/Scopa.go
+++ b/internal/domain/Scopa.go
@@ -182,12 +182,7 @@ func (s *Scopa) dealNextPack() {
 
 // allHandsEmpty は全員の手札が空か。
 func (s *Scopa) allHandsEmpty() bool {
-	for _, p := range s.players {
-		if p.GetCardsSize() > 0 {
-			return false
-		}
-	}
-	return true
+	return allHandsEmpty(s.players)
 }
 
 // PlayerPlay は人間プレイヤーが手札 handIdx を出す。

--- a/internal/domain/Scopone.go
+++ b/internal/domain/Scopone.go
@@ -316,12 +316,7 @@ func (s *Scopone) removeTableCardsByIndex(idxs []int) {
 
 // allHandsEmpty 全プレイヤーの手札が空か。
 func (s *Scopone) allHandsEmpty() bool {
-	for _, p := range s.players {
-		if p.GetCardsSize() > 0 {
-			return false
-		}
-	}
-	return true
+	return allHandsEmpty(s.players)
 }
 
 // --- CPU ---

--- a/internal/domain/SoloWhist.go
+++ b/internal/domain/SoloWhist.go
@@ -489,13 +489,7 @@ func (g *SoloWhist) validatePlay(playerIdx int, card *Card) error {
 
 // playerHasSuit プレイヤーが指定スートのカードを持っているか。
 func (g *SoloWhist) playerHasSuit(playerIdx, design int) bool {
-	p := g.players[playerIdx]
-	for i := 0; i < p.GetCardsSize(); i++ {
-		if p.GetCard(i).GetDesign() == design {
-			return true
-		}
-	}
-	return false
+	return handHasSuit(g.players[playerIdx], design)
 }
 
 // trickWinner トリックの勝者を決定する。切り札があれば最強切り札、なければ

--- a/internal/domain/Spades.go
+++ b/internal/domain/Spades.go
@@ -525,13 +525,7 @@ func (s *Spades) playerHasCard(playerIdx int, design, value int) bool {
 
 // playerHasSuit プレイヤーが特定のスートを持っているか
 func (s *Spades) playerHasSuit(playerIdx int, design int) bool {
-	p := s.players[playerIdx]
-	for i := 0; i < p.GetCardsSize(); i++ {
-		if p.GetCard(i).GetDesign() == design {
-			return true
-		}
-	}
-	return false
+	return handHasSuit(s.players[playerIdx], design)
 }
 
 // playerHasNonSpade プレイヤーがスペード以外のカードを持っているか

--- a/internal/domain/Sueca.go
+++ b/internal/domain/Sueca.go
@@ -321,13 +321,7 @@ func (g *Sueca) validatePlay(playerIdx int, card *Card) error {
 
 // playerHasSuit プレイヤーが指定スートのカードを持っているか。
 func (g *Sueca) playerHasSuit(playerIdx, design int) bool {
-	p := g.players[playerIdx]
-	for i := 0; i < p.GetCardsSize(); i++ {
-		if p.GetCard(i).GetDesign() == design {
-			return true
-		}
-	}
-	return false
+	return handHasSuit(g.players[playerIdx], design)
 }
 
 // trickWinner トリックの勝者を決定する。切り札があれば最強切り札、なければ

--- a/internal/domain/Tablanet.go
+++ b/internal/domain/Tablanet.go
@@ -225,12 +225,7 @@ func (g *Tablanet) dealInitialTable() {
 
 // allHandsEmpty は全員の手札が空かどうか。
 func (g *Tablanet) allHandsEmpty() bool {
-	for _, p := range g.players {
-		if p.GetCardsSize() > 0 {
-			return false
-		}
-	}
-	return true
+	return allHandsEmpty(g.players)
 }
 
 // --- 捕獲ロジック (インライン) ---

--- a/internal/domain/Tarneeb.go
+++ b/internal/domain/Tarneeb.go
@@ -639,13 +639,7 @@ func (t *Tarneeb) validatePlay(playerIdx int, card *Card) error {
 
 // playerHasSuit プレイヤーが特定のスートを持っているか
 func (t *Tarneeb) playerHasSuit(playerIdx, design int) bool {
-	p := t.players[playerIdx]
-	for i := 0; i < p.GetCardsSize(); i++ {
-		if p.GetCard(i).GetDesign() == design {
-			return true
-		}
-	}
-	return false
+	return handHasSuit(t.players[playerIdx], design)
 }
 
 // tarneebRank converts a raw `Card.GetValue()` (1-13, where 1 = Ace) to

--- a/internal/domain/Tressette.go
+++ b/internal/domain/Tressette.go
@@ -371,13 +371,7 @@ func (g *Tressette) validatePlay(playerIdx int, card *Card) error {
 
 // playerHasSuit プレイヤーが特定のスートを持っているか
 func (g *Tressette) playerHasSuit(playerIdx, design int) bool {
-	p := g.players[playerIdx]
-	for i := 0; i < p.GetCardsSize(); i++ {
-		if p.GetCard(i).GetDesign() == design {
-			return true
-		}
-	}
-	return false
+	return handHasSuit(g.players[playerIdx], design)
 }
 
 // trickWinner トリックの勝者を決定する。切り札がないため、リードスートの最強札が勝つ。

--- a/internal/domain/Tute.go
+++ b/internal/domain/Tute.go
@@ -384,13 +384,7 @@ func (g *Tute) validatePlay(playerIdx int, card *Card) error {
 
 // playerHasSuit プレイヤーが指定スートのカードを持っているか。
 func (g *Tute) playerHasSuit(playerIdx, design int) bool {
-	p := g.players[playerIdx]
-	for i := 0; i < p.GetCardsSize(); i++ {
-		if p.GetCard(i).GetDesign() == design {
-			return true
-		}
-	}
-	return false
+	return handHasSuit(g.players[playerIdx], design)
 }
 
 // trickWinner トリックの勝者を決定する。切り札があれば最強切り札、なければ

--- a/internal/domain/TwentyNine.go
+++ b/internal/domain/TwentyNine.go
@@ -483,13 +483,7 @@ func (g *TwentyNine) validatePlay(playerIdx int, card *Card) error {
 
 // playerHasSuit プレイヤーが指定スートのカードを持っているか。
 func (g *TwentyNine) playerHasSuit(playerIdx, design int) bool {
-	p := g.players[playerIdx]
-	for i := 0; i < p.GetCardsSize(); i++ {
-		if p.GetCard(i).GetDesign() == design {
-			return true
-		}
-	}
-	return false
+	return handHasSuit(g.players[playerIdx], design)
 }
 
 // trickWinner トリックの勝者を決定する。切り札があれば最強切り札、なければ

--- a/internal/domain/TwoTenJack.go
+++ b/internal/domain/TwoTenJack.go
@@ -455,13 +455,7 @@ func (t *TwoTenJack) validatePlay(playerIdx int, card *Card) error {
 
 // playerHasSuit プレイヤーが特定のスートを持っているか
 func (t *TwoTenJack) playerHasSuit(playerIdx int, design int) bool {
-	p := t.players[playerIdx]
-	for i := 0; i < p.GetCardsSize(); i++ {
-		if p.GetCard(i).GetDesign() == design {
-			return true
-		}
-	}
-	return false
+	return handHasSuit(t.players[playerIdx], design)
 }
 
 // trickWinner トリックの勝者を決定する

--- a/internal/domain/Tysiac.go
+++ b/internal/domain/Tysiac.go
@@ -677,13 +677,7 @@ func (g *Tysiac) canOvertrump(playerIdx, rank int) bool {
 
 // playerHasSuit プレイヤーが指定スートのカードを持っているか。
 func (g *Tysiac) playerHasSuit(playerIdx, design int) bool {
-	p := g.players[playerIdx]
-	for i := 0; i < p.GetCardsSize(); i++ {
-		if p.GetCard(i).GetDesign() == design {
-			return true
-		}
-	}
-	return false
+	return handHasSuit(g.players[playerIdx], design)
 }
 
 // playerHasCard プレイヤーが指定スート・ランクの札を持っているか。

--- a/internal/domain/Vira.go
+++ b/internal/domain/Vira.go
@@ -570,13 +570,7 @@ func (g *Vira) validatePlay(playerIdx int, card *Card) error {
 
 // playerHasSuit プレイヤーが指定スートを持っているか。
 func (g *Vira) playerHasSuit(playerIdx, design int) bool {
-	p := g.players[playerIdx]
-	for i := 0; i < p.GetCardsSize(); i++ {
-		if p.GetCard(i).GetDesign() == design {
-			return true
-		}
-	}
-	return false
+	return handHasSuit(g.players[playerIdx], design)
 }
 
 // GetValidPlayIndices 出せる手札の位置を返す。

--- a/internal/domain/Whist.go
+++ b/internal/domain/Whist.go
@@ -413,13 +413,7 @@ func (w *Whist) validatePlay(playerIdx int, card *Card) error {
 
 // playerHasSuit プレイヤーが特定のスートを持っているか
 func (w *Whist) playerHasSuit(playerIdx int, design int) bool {
-	p := w.players[playerIdx]
-	for i := 0; i < p.GetCardsSize(); i++ {
-		if p.GetCard(i).GetDesign() == design {
-			return true
-		}
-	}
-	return false
+	return handHasSuit(w.players[playerIdx], design)
 }
 
 // trickWinner トリックの勝者を決定する

--- a/internal/domain/Zwicker.go
+++ b/internal/domain/Zwicker.go
@@ -440,12 +440,7 @@ func (z *Zwicker) advance() {
 
 // allHandsEmpty は全員の手札が空かを返す。
 func (z *Zwicker) allHandsEmpty() bool {
-	for _, p := range z.players {
-		if p.GetCardsSize() > 0 {
-			return false
-		}
-	}
-	return true
+	return allHandsEmpty(z.players)
 }
 
 // finishRound はディールを精算する。

--- a/internal/domain/player_helpers.go
+++ b/internal/domain/player_helpers.go
@@ -162,3 +162,35 @@ func countPlayers[T any](players []T, pred func(T) bool) int {
 	}
 	return cnt
 }
+
+// handReader is the read-only view of a player's hand: how many cards it holds
+// and what each one is. Deliberately narrower than handHolder, which also
+// requires Reset/AddCard -- the predicates below never mutate a hand.
+type handReader interface {
+	GetCardsSize() int
+	GetCard(int) *Card
+}
+
+// allHandsEmpty reports whether every seat has run out of cards. 18 games had
+// this loop written out. An empty roster counts as empty: no seat is holding.
+func allHandsEmpty[P handReader](players []P) bool {
+	for _, p := range players {
+		if p.GetCardsSize() > 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// handHasSuit reports whether p holds a card of the given design. 30 games had
+// this loop written out as a playerHasSuit method, and Schnapsen had a 31st as
+// a free function taking the player directly -- which is why this takes the
+// player rather than (players, idx): that shape serves both. See issue #5185.
+func handHasSuit[P handReader](p P, design int) bool {
+	for i := 0; i < p.GetCardsSize(); i++ {
+		if p.GetCard(i).GetDesign() == design {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/domain/player_helpers_internal_test.go
+++ b/internal/domain/player_helpers_internal_test.go
@@ -287,3 +287,34 @@ func TestGetPlayer_OutOfRangeIsZero(t *testing.T) {
 	assert.Nil(t, getPlayer(seats, 1))
 	assert.Nil(t, getPlayer([]*fakeSeat{}, 0))
 }
+
+type fakeHand struct{ cards []*Card }
+
+func (h *fakeHand) GetCardsSize() int   { return len(h.cards) }
+func (h *fakeHand) GetCard(i int) *Card { return h.cards[i] }
+
+func TestAllHandsEmpty(t *testing.T) {
+	empty := &fakeHand{}
+	held := &fakeHand{cards: []*Card{NewCard(1, 5, false)}}
+
+	assert.True(t, allHandsEmpty([]*fakeHand{empty, empty}))
+	assert.True(t, allHandsEmpty([]*fakeHand{}), "no seats means no cards outstanding")
+	assert.False(t, allHandsEmpty([]*fakeHand{empty, held}), "one seat still holding is enough")
+	assert.False(t, allHandsEmpty([]*fakeHand{held, empty}), "position must not matter")
+}
+
+func TestHandHasSuit(t *testing.T) {
+	// design is the suit; value is deliberately varied so a body that compares
+	// the wrong field fails rather than coincidentally passing.
+	seats := []*fakeHand{
+		{cards: []*Card{NewCard(1, 3, false), NewCard(2, 7, false)}},
+		{cards: []*Card{NewCard(3, 1, false)}},
+		{},
+	}
+
+	assert.True(t, handHasSuit(seats[0], 1))
+	assert.True(t, handHasSuit(seats[0], 2), "not just the first card")
+	assert.False(t, handHasSuit(seats[0], 3))
+	assert.True(t, handHasSuit(seats[1], 3))
+	assert.False(t, handHasSuit(seats[2], 1), "empty hand holds no suit")
+}


### PR DESCRIPTION
#5185 の残りクラスタ、その1。

## 対象

| クラスタ | 件数 | 削減 |
|---|---:|---:|
| `allHandsEmpty` | 18 | 90 |
| `playerHasSuit` → `handHasSuit` | **31** | ~197 |
| **合計** | **49** | **-287行** |

`playerHasSuit` が31件なのは、30個のメソッドに加えて **Schnapsen が同じループを自由関数として持っていた**からです。ジェネリックの引数を `(players, idx)` ではなく **`(player, design)`** にしたのはこのためで、両方の形を1つで賄えます。新しい綴りを足すのではなく、既存の31個目を吸収しました（[#5200 で `minBy` を新設しかけて既存の `pickLowest` に気付いた件](https://github.com/yuta-yoshinaga/go_trumpcards/pull/5200)と同じ轍を踏まないため、実装前に自由関数を grep しています）。

## なぜ今回は呼び出し側を触らないのか

**対象は全て非公開メソッドなので、本体だけを1行委譲に置き換え、呼び出し側 `g.playerHasSuit(...)` は一切変更しません。**

これが安全性の要点です。#5202 では「定義は例外として残すが呼び出しは全ファイル置換」してしまい、5ゲームの表示文字列が**ビルドもテストも通ったまま**変わりました。今回は書き換える呼び出し側が存在しないので、その事故モードが原理的に起きません。

## カーブアウト

**Mighty は自前の本体を残します。**

```go
if c.GetDesign() == design && !m.isMighty(c) {   // ← マイティ札を除外する別の述語
```

名前が同じだけで**意味が違う**ため、機械置換から除外しました（置換スクリプトは本体がバイト一致しないものを自動的にスキップし、件数が想定の18/30と違えば中断する作りにしています）。

Napoleon は一時変数 `c := p.GetCard(i)` を挟むだけの差だったので変換対象です。

検算として、Mighty に `handHasSuit` が1件も入っていないことを確認済みです。

## 設計

`handReader` は既存の `handHolder` より**狭く**しています。この述語群は手札を変更しないので、`Reset`/`AddCard` を要求するのは過剰制約です。

```go
type handReader interface {
	GetCardsSize() int
	GetCard(int) *Card
}
```

## 検証

- `go test -tags test ./...` 全パッケージ通過
- `golangci-lint run ./internal/...` 0 issues
- ヘルパは**呼び出し側書き換えの前に別コミット**（`c9d3469`）。一括置換だけを単独で revert できます

Worker サイズは CI の `tinygo-build` ログから実測して報告します。本体に `fmt` を含まないクラスタなので横ばい予想ですが、[#5202 で +4,801 バイトを踏んでいる](https://github.com/yuta-yoshinaga/go_trumpcards/pull/5202)ので予測では済ませません。

Refs #5185