### PR TITLE
refactor(domain): delegate 39 trick/log bodies to shared helpers

### DIFF
--- a/internal/domain/BidEuchre.go
+++ b/internal/domain/BidEuchre.go
@@ -263,7 +263,7 @@ type BidEuchre struct {
 	gameEndFlag bool
 	winnerTeam  int
 
-	actionLog []*ActionLogEntry
+	actionLogBase
 }
 
 // NewBidEuchre コンストラクタ
@@ -929,18 +929,9 @@ func (b *BidEuchre) GetConfig() BidEuchreConfig { return b.config }
 // SetConfig は設定をセットする。
 func (b *BidEuchre) SetConfig(c BidEuchreConfig) { b.config = c }
 
-// GetActionLog は棋譜を返す。
-func (b *BidEuchre) GetActionLog() []*ActionLogEntry { return b.actionLog }
-
 // addLog は棋譜を 1 行足す。
 func (b *BidEuchre) addLog(playerIdx int, actionType, detail string, cards []*Card) {
-	b.actionLog = append(b.actionLog, &ActionLogEntry{
-		TurnNumber: len(b.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	b.appendLog(playerIdx, actionType, detail, cards)
 }
 
 // SetPhaseForTest はテスト用にフェーズを設定する。

--- a/internal/domain/Boston.go
+++ b/internal/domain/Boston.go
@@ -101,7 +101,7 @@ type Boston struct {
 	gameEndFlag bool
 	winnerIdx   int
 
-	actionLog []*ActionLogEntry
+	actionLogBase
 }
 
 // NewBoston コンストラクタ
@@ -765,18 +765,9 @@ func (b *Boston) GetConfig() BostonConfig { return b.config }
 // SetConfig は設定をセットする。
 func (b *Boston) SetConfig(c BostonConfig) { b.config = c }
 
-// GetActionLog は棋譜を返す。
-func (b *Boston) GetActionLog() []*ActionLogEntry { return b.actionLog }
-
 // addLog は棋譜を 1 行足す。
 func (b *Boston) addLog(playerIdx int, actionType, detail string, cards []*Card) {
-	b.actionLog = append(b.actionLog, &ActionLogEntry{
-		TurnNumber: len(b.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	b.appendLog(playerIdx, actionType, detail, cards)
 }
 
 // SetPhaseForTest はテスト用にフェーズを設定する。

--- a/internal/domain/Bura.go
+++ b/internal/domain/Bura.go
@@ -254,7 +254,7 @@ type Bura struct {
 	gameEndFlag      bool
 	winnerIdx        int // -1: 未確定または引き分け
 	drawFlag         bool
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // NewBura コンストラクタ
@@ -522,13 +522,7 @@ func (b *Bura) nextPlayer(idx int) int {
 
 // addLog アクションログへ 1 行追加する。
 func (b *Bura) addLog(playerIdx int, actionType, detail string, cards []*Card) {
-	b.actionLog = append(b.actionLog, &ActionLogEntry{
-		TurnNumber: len(b.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	b.appendLog(playerIdx, actionType, detail, cards)
 }
 
 // ---- 公開アクセサ ----
@@ -595,9 +589,6 @@ func (b *Bura) GetConfig() BuraConfig { return b.config }
 
 // SetConfig ゲーム設定を差し替える。
 func (b *Bura) SetConfig(c BuraConfig) { b.config = c }
-
-// GetActionLog アクションログを返す。
-func (b *Bura) GetActionLog() []*ActionLogEntry { return b.actionLog }
 
 // ---- JSON ----
 

--- a/internal/domain/Calabresella.go
+++ b/internal/domain/Calabresella.go
@@ -755,12 +755,7 @@ func calabresellaBidName(bid CalabresellaBid) string {
 
 // indexOfPlayerInTrick currentTrick 内で playerIdx の札の位置を返す (-1=なし)。
 func (g *Calabresella) indexOfPlayerInTrick(playerIdx int) int {
-	for i, tc := range g.currentTrick {
-		if tc.PlayerIdx == playerIdx {
-			return i
-		}
-	}
-	return -1
+	return indexOfPlayerInTrick(g.currentTrick, playerIdx)
 }
 
 // --- CPU AI (play) ---

--- a/internal/domain/ChineseTen.go
+++ b/internal/domain/ChineseTen.go
@@ -145,7 +145,7 @@ type ChineseTen struct {
 	scores      []int
 	gameEndFlag bool
 	winnerIdx   int
-	actionLog   []*ActionLogEntry
+	actionLogBase
 }
 
 // NewChineseTen はコンストラクタ。
@@ -354,13 +354,7 @@ func (c *ChineseTen) finishGame() {
 
 // addLog は棋譜へ 1 行追加する。
 func (c *ChineseTen) addLog(playerIdx int, actionType, detail string, cards []*Card) {
-	c.actionLog = append(c.actionLog, &ActionLogEntry{
-		TurnNumber: len(c.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	c.appendLog(playerIdx, actionType, detail, cards)
 }
 
 // ---- CPU ----
@@ -486,9 +480,6 @@ func (c *ChineseTen) GetConfig() ChineseTenConfig { return c.config }
 
 // SetConfig はゲーム設定を差し替える。
 func (c *ChineseTen) SetConfig(cfg ChineseTenConfig) { c.config = cfg }
-
-// GetActionLog は棋譜を返す。
-func (c *ChineseTen) GetActionLog() []*ActionLogEntry { return c.actionLog }
 
 // ---- JSON ----
 

--- a/internal/domain/Desmoche.go
+++ b/internal/domain/Desmoche.go
@@ -195,7 +195,7 @@ type Desmoche struct {
 
 	gameEndFlag bool
 	winnerIdx   int
-	actionLog   []*ActionLogEntry
+	actionLogBase
 }
 
 // NewDesmoche はコンストラクタ。
@@ -711,9 +711,6 @@ func (d *Desmoche) GetConfig() DesmocheConfig { return d.config }
 // SetConfig はゲーム設定をセットする。
 func (d *Desmoche) SetConfig(c DesmocheConfig) { d.config = c }
 
-// GetActionLog は棋譜を返す。
-func (d *Desmoche) GetActionLog() []*ActionLogEntry { return d.actionLog }
-
 // SetPhaseForTest はテスト用にフェーズを差し替える。
 func (d *Desmoche) SetPhaseForTest(p DesmochePhase) { d.phase = p }
 
@@ -731,13 +728,7 @@ func (d *Desmoche) SetRoundNumberForTest(n int) { d.roundNo = n }
 
 // addLog は棋譜に 1 件追加する。
 func (d *Desmoche) addLog(playerIdx int, actionType, detail string, cards []*Card) {
-	d.actionLog = append(d.actionLog, &ActionLogEntry{
-		TurnNumber: len(d.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	d.appendLog(playerIdx, actionType, detail, cards)
 }
 
 // desmocheJSON is the JSON wire format for Desmoche.

--- a/internal/domain/Doppelkopf.go
+++ b/internal/domain/Doppelkopf.go
@@ -511,12 +511,7 @@ func dkSortHand(p *DoppelkopfPlayer) {
 
 // indexOfPlayerInTrick currentTrick 内で playerIdx の札の位置を返す (-1=なし)。
 func (g *Doppelkopf) indexOfPlayerInTrick(playerIdx int) int {
-	for i, tc := range g.currentTrick {
-		if tc.PlayerIdx == playerIdx {
-			return i
-		}
-	}
-	return -1
+	return indexOfPlayerInTrick(g.currentTrick, playerIdx)
 }
 
 // trickTopStrength 現在のトリック勝者 winnerIdx の札の強さを返す。防御的に、

--- a/internal/domain/FortyFives.go
+++ b/internal/domain/FortyFives.go
@@ -614,12 +614,7 @@ func (g *FortyFives) fortyFivesSortHand(p *FortyFivesPlayer) {
 
 // indexOfPlayerInTrick currentTrick 内で playerIdx の札の位置を返す (-1=なし)。
 func (g *FortyFives) indexOfPlayerInTrick(playerIdx int) int {
-	for i, tc := range g.currentTrick {
-		if tc.PlayerIdx == playerIdx {
-			return i
-		}
-	}
-	return -1
+	return indexOfPlayerInTrick(g.currentTrick, playerIdx)
 }
 
 // trickTopRank 現在のトリック勝者の札のランクを返す。見つからない場合は極小値。

--- a/internal/domain/Kaiser.go
+++ b/internal/domain/Kaiser.go
@@ -208,7 +208,7 @@ type Kaiser struct {
 	gameEndFlag bool
 	winnerTeam  int
 
-	actionLog []*ActionLogEntry
+	actionLogBase
 }
 
 // NewKaiser コンストラクタ
@@ -932,18 +932,9 @@ func (k *Kaiser) GetConfig() KaiserConfig { return k.config }
 // SetConfig は設定をセットする。
 func (k *Kaiser) SetConfig(c KaiserConfig) { k.config = c }
 
-// GetActionLog は棋譜を返す。
-func (k *Kaiser) GetActionLog() []*ActionLogEntry { return k.actionLog }
-
 // addLog は棋譜を 1 行足す。
 func (k *Kaiser) addLog(playerIdx int, actionType, detail string, cards []*Card) {
-	k.actionLog = append(k.actionLog, &ActionLogEntry{
-		TurnNumber: len(k.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	k.appendLog(playerIdx, actionType, detail, cards)
 }
 
 // SetPhaseForTest はテスト用にフェーズを設定する。

--- a/internal/domain/Kille.go
+++ b/internal/domain/Kille.go
@@ -87,7 +87,7 @@ type Kille struct {
 
 	gameEndFlag bool
 	winnerIdx   int
-	actionLog   []*ActionLogEntry
+	actionLogBase
 }
 
 // NewKille はコンストラクタ。
@@ -606,9 +606,6 @@ func (k *Kille) GetConfig() KilleConfig { return k.config }
 // SetConfig はゲーム設定をセットする。
 func (k *Kille) SetConfig(c KilleConfig) { k.config = c }
 
-// GetActionLog は棋譜を返す。
-func (k *Kille) GetActionLog() []*ActionLogEntry { return k.actionLog }
-
 // SetPhaseForTest はテスト用にフェーズを差し替える。
 func (k *Kille) SetPhaseForTest(p KillePhase) { k.phase = p }
 
@@ -634,13 +631,7 @@ func (k *Kille) SetStockForTest(cards []*Card) { k.stock = cards }
 
 // addLog は棋譜に 1 件追加する。
 func (k *Kille) addLog(playerIdx int, actionType, detail string, cards []*Card) {
-	k.actionLog = append(k.actionLog, &ActionLogEntry{
-		TurnNumber: len(k.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	k.appendLog(playerIdx, actionType, detail, cards)
 }
 
 // killeJSON is the JSON wire format for Kille.

--- a/internal/domain/Klaberjass.go
+++ b/internal/domain/Klaberjass.go
@@ -146,7 +146,7 @@ type Klaberjass struct {
 	gameEndFlag bool
 	winnerIdx   int
 
-	actionLog []*ActionLogEntry
+	actionLogBase
 }
 
 // NewKlaberjass コンストラクタ
@@ -1154,9 +1154,6 @@ func (k *Klaberjass) GetConfig() KlaberjassConfig { return k.config }
 // SetConfig は設定をセットする。
 func (k *Klaberjass) SetConfig(c KlaberjassConfig) { k.config = c }
 
-// GetActionLog は棋譜を返す。
-func (k *Klaberjass) GetActionLog() []*ActionLogEntry { return k.actionLog }
-
 // SetPhaseForTest はテスト用にフェーズを設定する。
 func (k *Klaberjass) SetPhaseForTest(p KlaberjassPhase) { k.phase = p }
 
@@ -1214,13 +1211,7 @@ func (k *Klaberjass) FindBelaForTest() { k.findBela() }
 
 // addLog は棋譜を 1 行足す。
 func (k *Klaberjass) addLog(playerIdx int, actionType, detail string, cards []*Card) {
-	k.actionLog = append(k.actionLog, &ActionLogEntry{
-		TurnNumber: len(k.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	k.appendLog(playerIdx, actionType, detail, cards)
 }
 
 // klaberjassJSON is the JSON wire format for Klaberjass.

--- a/internal/domain/Klaverjas.go
+++ b/internal/domain/Klaverjas.go
@@ -584,12 +584,7 @@ func klaverjasSortHand(p *KlaverjasPlayer) {
 
 // indexOfPlayerInTrick currentTrick 内で playerIdx の札の位置を返す (-1=なし)。
 func (g *Klaverjas) indexOfPlayerInTrick(playerIdx int) int {
-	for i, tc := range g.currentTrick {
-		if tc.PlayerIdx == playerIdx {
-			return i
-		}
-	}
-	return -1
+	return indexOfPlayerInTrick(g.currentTrick, playerIdx)
 }
 
 // trickTopRank 現在のトリック勝者の札のランクを返す。見つからない場合は極小値。

--- a/internal/domain/KnockoutWhist.go
+++ b/internal/domain/KnockoutWhist.go
@@ -480,12 +480,7 @@ func knockoutSortHand(p *KnockoutWhistPlayer) {
 
 // indexOfPlayerInTrick currentTrick 内で playerIdx の札の位置を返す (-1=なし)。
 func (g *KnockoutWhist) indexOfPlayerInTrick(playerIdx int) int {
-	for i, tc := range g.currentTrick {
-		if tc.PlayerIdx == playerIdx {
-			return i
-		}
-	}
-	return -1
+	return indexOfPlayerInTrick(g.currentTrick, playerIdx)
 }
 
 // trickTopRank 現在のトリック勝者の札のランクを返す。見つからない場合は極小値。

--- a/internal/domain/Loba.go
+++ b/internal/domain/Loba.go
@@ -246,7 +246,7 @@ type Loba struct {
 
 	gameEndFlag bool
 	winnerIdx   int
-	actionLog   []*ActionLogEntry
+	actionLogBase
 }
 
 // NewLoba はコンストラクタ。
@@ -858,9 +858,6 @@ func (l *Loba) GetConfig() LobaConfig { return l.config }
 // SetConfig はゲーム設定をセットする。
 func (l *Loba) SetConfig(c LobaConfig) { l.config = c }
 
-// GetActionLog は棋譜を返す。
-func (l *Loba) GetActionLog() []*ActionLogEntry { return l.actionLog }
-
 // SetPhaseForTest はテスト用にフェーズを差し替える。
 func (l *Loba) SetPhaseForTest(p LobaPhase) { l.phase = p }
 
@@ -881,13 +878,7 @@ func (l *Loba) SetHasMeldedForTest(idx int, v bool) { l.hasMelded[idx] = v }
 
 // addLog は棋譜に 1 件追加する。
 func (l *Loba) addLog(playerIdx int, actionType, detail string, cards []*Card) {
-	l.actionLog = append(l.actionLog, &ActionLogEntry{
-		TurnNumber: len(l.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	l.appendLog(playerIdx, actionType, detail, cards)
 }
 
 // lobaJSON is the JSON wire format for Loba.

--- a/internal/domain/Loo.go
+++ b/internal/domain/Loo.go
@@ -638,12 +638,7 @@ func looSortHand(p *LooPlayer) {
 
 // indexOfPlayerInTrick は currentTrick 内で playerIdx の札の位置を返す (-1=なし)。
 func (g *Loo) indexOfPlayerInTrick(playerIdx int) int {
-	for i, tc := range g.currentTrick {
-		if tc.PlayerIdx == playerIdx {
-			return i
-		}
-	}
-	return -1
+	return indexOfPlayerInTrick(g.currentTrick, playerIdx)
 }
 
 // trickTopRank は現在のトリック勝者の札のランクを返す。見つからない場合は極小値。

--- a/internal/domain/Manille.go
+++ b/internal/domain/Manille.go
@@ -423,12 +423,7 @@ func manilleSortHand(p *ManillePlayer) {
 
 // indexOfPlayerInTrick currentTrick 内で playerIdx の札の位置を返す (-1=なし)。
 func (g *Manille) indexOfPlayerInTrick(playerIdx int) int {
-	for i, tc := range g.currentTrick {
-		if tc.PlayerIdx == playerIdx {
-			return i
-		}
-	}
-	return -1
+	return indexOfPlayerInTrick(g.currentTrick, playerIdx)
 }
 
 // trickTopRank 現在のトリック勝者の札のランクを返す。見つからない場合は極小値。

--- a/internal/domain/Marias.go
+++ b/internal/domain/Marias.go
@@ -486,12 +486,7 @@ func mariasSortHand(p *MariasPlayer) {
 
 // indexOfPlayerInTrick currentTrick 内で playerIdx の札の位置を返す (-1=なし)。
 func (g *Marias) indexOfPlayerInTrick(playerIdx int) int {
-	for i, tc := range g.currentTrick {
-		if tc.PlayerIdx == playerIdx {
-			return i
-		}
-	}
-	return -1
+	return indexOfPlayerInTrick(g.currentTrick, playerIdx)
 }
 
 // trickTopRank 現在のトリック勝者の札のランクを返す。見つからない場合は極小値。

--- a/internal/domain/Mushi.go
+++ b/internal/domain/Mushi.go
@@ -347,7 +347,7 @@ type Mushi struct {
 	roundResults []int
 	gameEndFlag  bool
 	winnerIdx    int
-	actionLog    []*ActionLogEntry
+	actionLogBase
 }
 
 // NewMushi はコンストラクタ。
@@ -655,13 +655,7 @@ func (m *Mushi) finishGame() {
 
 // addLog は棋譜へ 1 行追加する。
 func (m *Mushi) addLog(playerIdx int, actionType, detail string, cards []*Card) {
-	m.actionLog = append(m.actionLog, &ActionLogEntry{
-		TurnNumber: len(m.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	m.appendLog(playerIdx, actionType, detail, cards)
 }
 
 // ---- 公開アクセサ ----
@@ -753,9 +747,6 @@ func (m *Mushi) GetConfig() MushiConfig { return m.config }
 
 // SetConfig はゲーム設定を差し替える。
 func (m *Mushi) SetConfig(c MushiConfig) { m.config = c }
-
-// GetActionLog は棋譜を返す。
-func (m *Mushi) GetActionLog() []*ActionLogEntry { return m.actionLog }
 
 // ---- JSON ----
 

--- a/internal/domain/NainJaune.go
+++ b/internal/domain/NainJaune.go
@@ -114,7 +114,7 @@ type NainJaune struct {
 	dealWinner  int
 	gameEndFlag bool
 	winnerIdx   int
-	actionLog   []*ActionLogEntry
+	actionLogBase
 }
 
 // NewNainJaune はコンストラクタ。
@@ -445,9 +445,6 @@ func (n *NainJaune) GetConfig() NainJauneConfig { return n.config }
 // SetConfig はゲーム設定をセットする。
 func (n *NainJaune) SetConfig(c NainJauneConfig) { n.config = c }
 
-// GetActionLog は棋譜を返す。
-func (n *NainJaune) GetActionLog() []*ActionLogEntry { return n.actionLog }
-
 // SetPhaseForTest はテスト用にフェーズを差し替える。
 func (n *NainJaune) SetPhaseForTest(p NainJaunePhase) { n.phase = p }
 
@@ -465,13 +462,7 @@ func (n *NainJaune) SetDealNumberForTest(d int) { n.dealNo = d }
 
 // addLog は棋譜に 1 件追加する。
 func (n *NainJaune) addLog(playerIdx int, actionType, detail string, cards []*Card) {
-	n.actionLog = append(n.actionLog, &ActionLogEntry{
-		TurnNumber: len(n.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	n.appendLog(playerIdx, actionType, detail, cards)
 }
 
 // nainJauneJSON is the JSON wire format for NainJaune.

--- a/internal/domain/Nap.go
+++ b/internal/domain/Nap.go
@@ -551,12 +551,7 @@ func napSortHand(p *NapPlayer) {
 
 // indexOfPlayerInTrick currentTrick 内で playerIdx の札の位置を返す (-1=なし)。
 func (g *Nap) indexOfPlayerInTrick(playerIdx int) int {
-	for i, tc := range g.currentTrick {
-		if tc.PlayerIdx == playerIdx {
-			return i
-		}
-	}
-	return -1
+	return indexOfPlayerInTrick(g.currentTrick, playerIdx)
 }
 
 // trickTopRank 現在のトリック勝者の札のランクを返す。見つからない場合は極小値。

--- a/internal/domain/Ombre.go
+++ b/internal/domain/Ombre.go
@@ -968,12 +968,7 @@ func ombreValidSuit(suit int) bool {
 
 // indexOfPlayerInTrick currentTrick 内で playerIdx の札の位置を返す (-1=なし)。
 func (g *Ombre) indexOfPlayerInTrick(playerIdx int) int {
-	for i, tc := range g.currentTrick {
-		if tc.PlayerIdx == playerIdx {
-			return i
-		}
-	}
-	return -1
+	return indexOfPlayerInTrick(g.currentTrick, playerIdx)
 }
 
 // --- CPU AI (play) ---

--- a/internal/domain/Poch.go
+++ b/internal/domain/Poch.go
@@ -173,7 +173,7 @@ type Poch struct {
 	dealWinner  int
 	gameEndFlag bool
 	winnerIdx   int
-	actionLog   []*ActionLogEntry
+	actionLogBase
 }
 
 // NewPoch はコンストラクタ。
@@ -726,9 +726,6 @@ func (p *Poch) GetConfig() PochConfig { return p.config }
 // SetConfig はゲーム設定をセットする。
 func (p *Poch) SetConfig(c PochConfig) { p.config = c }
 
-// GetActionLog は棋譜を返す。
-func (p *Poch) GetActionLog() []*ActionLogEntry { return p.actionLog }
-
 // SetPhaseForTest はテスト用にフェーズを差し替える。
 func (p *Poch) SetPhaseForTest(ph PochPhase) { p.phase = ph }
 
@@ -752,13 +749,7 @@ func (p *Poch) ResolveStakingForTest() { p.resolveStaking() }
 
 // addLog は棋譜に 1 件追加する。
 func (p *Poch) addLog(playerIdx int, actionType, detail string, cards []*Card) {
-	p.actionLog = append(p.actionLog, &ActionLogEntry{
-		TurnNumber: len(p.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	p.appendLog(playerIdx, actionType, detail, cards)
 }
 
 // pochJSON is the JSON wire format for Poch.

--- a/internal/domain/PopeJoan.go
+++ b/internal/domain/PopeJoan.go
@@ -141,7 +141,7 @@ type PopeJoan struct {
 	dealWinner  int
 	gameEndFlag bool
 	winnerIdx   int
-	actionLog   []*ActionLogEntry
+	actionLogBase
 }
 
 // NewPopeJoan はコンストラクタ。
@@ -590,9 +590,6 @@ func (p *PopeJoan) GetConfig() PopeJoanConfig { return p.config }
 // SetConfig はゲーム設定をセットする。
 func (p *PopeJoan) SetConfig(c PopeJoanConfig) { p.config = c }
 
-// GetActionLog は棋譜を返す。
-func (p *PopeJoan) GetActionLog() []*ActionLogEntry { return p.actionLog }
-
 // SetPhaseForTest はテスト用にフェーズを差し替える。
 func (p *PopeJoan) SetPhaseForTest(ph PopeJoanPhase) { p.phase = ph }
 
@@ -619,13 +616,7 @@ func (p *PopeJoan) ResolveTurnUpForTest() { p.resolveTurnUp() }
 
 // addLog は棋譜に 1 件追加する。
 func (p *PopeJoan) addLog(playerIdx int, actionType, detail string, cards []*Card) {
-	p.actionLog = append(p.actionLog, &ActionLogEntry{
-		TurnNumber: len(p.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	p.appendLog(playerIdx, actionType, detail, cards)
 }
 
 // popeJoanJSON is the JSON wire format for PopeJoan.

--- a/internal/domain/Preference.go
+++ b/internal/domain/Preference.go
@@ -574,12 +574,7 @@ func preferenceSortHand(p *PreferencePlayer) {
 
 // indexOfPlayerInTrick currentTrick 内で playerIdx の札の位置を返す (-1=なし)。
 func (g *Preference) indexOfPlayerInTrick(playerIdx int) int {
-	for i, tc := range g.currentTrick {
-		if tc.PlayerIdx == playerIdx {
-			return i
-		}
-	}
-	return -1
+	return indexOfPlayerInTrick(g.currentTrick, playerIdx)
 }
 
 // trickTopRank 現在のトリック勝者の札のランクを返す。見つからない場合は極小値。

--- a/internal/domain/Sheepshead.go
+++ b/internal/domain/Sheepshead.go
@@ -679,12 +679,7 @@ func sheepsheadSortHand(p *SheepsheadPlayer) {
 
 // indexOfPlayerInTrick currentTrick 内で playerIdx の札の位置を返す (-1=なし)。
 func (g *Sheepshead) indexOfPlayerInTrick(playerIdx int) int {
-	for i, tc := range g.currentTrick {
-		if tc.PlayerIdx == playerIdx {
-			return i
-		}
-	}
-	return -1
+	return indexOfPlayerInTrick(g.currentTrick, playerIdx)
 }
 
 // trickTopStrength 現在のトリック勝者 winnerIdx の札の強さを返す。防御的に、

--- a/internal/domain/Sjavs.go
+++ b/internal/domain/Sjavs.go
@@ -226,7 +226,7 @@ type Sjavs struct {
 
 	gameEndFlag bool
 	winnerTeam  int
-	actionLog   []*ActionLogEntry
+	actionLogBase
 }
 
 // SjavsHandResult は 1 ハンドの精算結果。
@@ -864,9 +864,6 @@ func (s *Sjavs) GetConfig() SjavsConfig { return s.config }
 // SetConfig はゲーム設定をセットする。
 func (s *Sjavs) SetConfig(c SjavsConfig) { s.config = c }
 
-// GetActionLog は棋譜を返す。
-func (s *Sjavs) GetActionLog() []*ActionLogEntry { return s.actionLog }
-
 // SetTrumpSuitForTest はテスト用に切札を差し替える。
 func (s *Sjavs) SetTrumpSuitForTest(suit int) { s.trumpSuit = suit }
 
@@ -893,13 +890,7 @@ func (s *Sjavs) SettleHandForTest() { s.settleHand() }
 
 // addLog は棋譜に 1 件追加する。
 func (s *Sjavs) addLog(playerIdx int, actionType, detail string, cards []*Card) {
-	s.actionLog = append(s.actionLog, &ActionLogEntry{
-		TurnNumber: len(s.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	s.appendLog(playerIdx, actionType, detail, cards)
 }
 
 // sjavsTrickCardJSON is the JSON wire format for SjavsTrickCard.

--- a/internal/domain/Skitgubbe.go
+++ b/internal/domain/Skitgubbe.go
@@ -110,7 +110,7 @@ type Skitgubbe struct {
 	finished    []bool
 	loserIdx    int
 	gameEndFlag bool
-	actionLog   []*ActionLogEntry
+	actionLogBase
 }
 
 // NewSkitgubbe はコンストラクタ。
@@ -465,13 +465,7 @@ func (s *Skitgubbe) checkShedEnd() {
 
 // addLog は棋譜へ 1 行追加する。
 func (s *Skitgubbe) addLog(playerIdx int, actionType, detail string, cards []*Card) {
-	s.actionLog = append(s.actionLog, &ActionLogEntry{
-		TurnNumber: len(s.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	s.appendLog(playerIdx, actionType, detail, cards)
 }
 
 // ---- CPU ----
@@ -589,9 +583,6 @@ func (s *Skitgubbe) GetConfig() SkitgubbeConfig { return s.config }
 
 // SetConfig はゲーム設定を差し替える。
 func (s *Skitgubbe) SetConfig(c SkitgubbeConfig) { s.config = c }
-
-// GetActionLog は棋譜を返す。
-func (s *Skitgubbe) GetActionLog() []*ActionLogEntry { return s.actionLog }
 
 // SetTrumpSuitForTest は切札を設定する (テスト用)。
 func (s *Skitgubbe) SetTrumpSuitForTest(suit int) { s.trumpSuit = suit }

--- a/internal/domain/SoloWhist.go
+++ b/internal/domain/SoloWhist.go
@@ -570,12 +570,7 @@ func soloWhistSortHand(p *SoloWhistPlayer) {
 
 // indexOfPlayerInTrick currentTrick 内で playerIdx の札の位置を返す (-1=なし)。
 func (g *SoloWhist) indexOfPlayerInTrick(playerIdx int) int {
-	for i, tc := range g.currentTrick {
-		if tc.PlayerIdx == playerIdx {
-			return i
-		}
-	}
-	return -1
+	return indexOfPlayerInTrick(g.currentTrick, playerIdx)
 }
 
 // trickTopRank 現在のトリック勝者の札のランクを返す。見つからない場合は極小値。

--- a/internal/domain/SpoilFive.go
+++ b/internal/domain/SpoilFive.go
@@ -478,12 +478,7 @@ func (g *SpoilFive) spoilSortHand(p *SpoilFivePlayer) {
 
 // indexOfPlayerInTrick currentTrick 内で playerIdx の札の位置を返す (-1=なし)。
 func (g *SpoilFive) indexOfPlayerInTrick(playerIdx int) int {
-	for i, tc := range g.currentTrick {
-		if tc.PlayerIdx == playerIdx {
-			return i
-		}
-	}
-	return -1
+	return indexOfPlayerInTrick(g.currentTrick, playerIdx)
 }
 
 // trickTopRank 現在のトリック勝者の札のランクを返す。見つからない場合は極小値。

--- a/internal/domain/Sueca.go
+++ b/internal/domain/Sueca.go
@@ -438,12 +438,7 @@ func suecaSortHand(p *SuecaPlayer) {
 
 // indexOfPlayerInTrick currentTrick 内で playerIdx の札の位置を返す (-1=なし)。
 func (g *Sueca) indexOfPlayerInTrick(playerIdx int) int {
-	for i, tc := range g.currentTrick {
-		if tc.PlayerIdx == playerIdx {
-			return i
-		}
-	}
-	return -1
+	return indexOfPlayerInTrick(g.currentTrick, playerIdx)
 }
 
 // trickTopRank 現在のトリック勝者の札のランクを返す。見つからない場合は極小値。

--- a/internal/domain/Toepen.go
+++ b/internal/domain/Toepen.go
@@ -163,7 +163,7 @@ type Toepen struct {
 	handNumber   int
 	gameEndFlag  bool
 	winnerIdx    int
-	actionLog    []*ActionLogEntry
+	actionLogBase
 }
 
 // NewToepen はコンストラクタ。
@@ -608,13 +608,7 @@ func (t *Toepen) nextSeat(idx int) int {
 
 // addLog は棋譜へ 1 行追加する。
 func (t *Toepen) addLog(playerIdx int, actionType, detail string, cards []*Card) {
-	t.actionLog = append(t.actionLog, &ActionLogEntry{
-		TurnNumber: len(t.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	t.appendLog(playerIdx, actionType, detail, cards)
 }
 
 // ---- 公開アクセサ ----
@@ -700,9 +694,6 @@ func (t *Toepen) GetConfig() ToepenConfig { return t.config }
 
 // SetConfig はゲーム設定を差し替える。
 func (t *Toepen) SetConfig(c ToepenConfig) { t.config = c }
-
-// GetActionLog は棋譜を返す。
-func (t *Toepen) GetActionLog() []*ActionLogEntry { return t.actionLog }
 
 // ---- JSON ----
 

--- a/internal/domain/Tressette.go
+++ b/internal/domain/Tressette.go
@@ -506,12 +506,7 @@ func (g *Tressette) playHintReason(playerIdx, chosenIdx int) string {
 
 // indexOfPlayerInTrick currentTrick 内で playerIdx が出したカードの位置を返す (-1=なし)
 func (g *Tressette) indexOfPlayerInTrick(playerIdx int) int {
-	for i, tc := range g.currentTrick {
-		if tc.PlayerIdx == playerIdx {
-			return i
-		}
-	}
-	return -1
+	return indexOfPlayerInTrick(g.currentTrick, playerIdx)
 }
 
 // --- CPU AI ---

--- a/internal/domain/Trex.go
+++ b/internal/domain/Trex.go
@@ -182,7 +182,7 @@ type Trex struct {
 	dealScores []int
 
 	gameEndFlag bool
-	actionLog   []*ActionLogEntry
+	actionLogBase
 }
 
 // NewTrex はコンストラクタ。
@@ -800,9 +800,6 @@ func (t *Trex) GetConfig() TrexConfig { return t.config }
 // SetConfig はゲーム設定をセットする。
 func (t *Trex) SetConfig(c TrexConfig) { t.config = c }
 
-// GetActionLog は棋譜を返す。
-func (t *Trex) GetActionLog() []*ActionLogEntry { return t.actionLog }
-
 // SetPhaseForTest はテスト用にフェーズを差し替える。
 func (t *Trex) SetPhaseForTest(p TrexPhase) { t.phase = p }
 
@@ -820,13 +817,7 @@ func (t *Trex) SetDealNumberForTest(n int) { t.dealNo = n }
 
 // addLog は棋譜に 1 件追加する。
 func (t *Trex) addLog(playerIdx int, actionType, detail string, cards []*Card) {
-	t.actionLog = append(t.actionLog, &ActionLogEntry{
-		TurnNumber: len(t.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	t.appendLog(playerIdx, actionType, detail, cards)
 }
 
 // trexTrickCardJSON is the JSON wire format for TrexTrickCard.

--- a/internal/domain/Tute.go
+++ b/internal/domain/Tute.go
@@ -525,12 +525,7 @@ func tuteSortHand(p *TutePlayer) {
 
 // indexOfPlayerInTrick currentTrick 内で playerIdx の札の位置を返す (-1=なし)。
 func (g *Tute) indexOfPlayerInTrick(playerIdx int) int {
-	for i, tc := range g.currentTrick {
-		if tc.PlayerIdx == playerIdx {
-			return i
-		}
-	}
-	return -1
+	return indexOfPlayerInTrick(g.currentTrick, playerIdx)
 }
 
 // trickTopRank 現在のトリック勝者 winnerIdx の札のランクを返す。見つからない場合は極小値。

--- a/internal/domain/TwentyNine.go
+++ b/internal/domain/TwentyNine.go
@@ -588,12 +588,7 @@ func twentyNineSortHand(p *TwentyNinePlayer) {
 
 // indexOfPlayerInTrick currentTrick 内で playerIdx の札の位置を返す (-1=なし)。
 func (g *TwentyNine) indexOfPlayerInTrick(playerIdx int) int {
-	for i, tc := range g.currentTrick {
-		if tc.PlayerIdx == playerIdx {
-			return i
-		}
-	}
-	return -1
+	return indexOfPlayerInTrick(g.currentTrick, playerIdx)
 }
 
 // trickTopRank 現在のトリック勝者の札のランクを返す。見つからない場合は極小値。

--- a/internal/domain/Tysiac.go
+++ b/internal/domain/Tysiac.go
@@ -833,12 +833,7 @@ func tysiacSortHand(p *TysiacPlayer) {
 
 // indexOfPlayerInTrick currentTrick 内で playerIdx の札の位置を返す (-1=なし)。
 func (g *Tysiac) indexOfPlayerInTrick(playerIdx int) int {
-	for i, tc := range g.currentTrick {
-		if tc.PlayerIdx == playerIdx {
-			return i
-		}
-	}
-	return -1
+	return indexOfPlayerInTrick(g.currentTrick, playerIdx)
 }
 
 // trickTopRank 現在のトリック勝者の札のランクを返す。見つからない場合は極小値。

--- a/internal/domain/Ulti.go
+++ b/internal/domain/Ulti.go
@@ -891,12 +891,7 @@ func ultiFilter(indices []int, pred func(int) bool) []int {
 
 // indexOfPlayerInTrick currentTrick 内で playerIdx の札の位置を返す (-1=なし)。
 func (g *Ulti) indexOfPlayerInTrick(playerIdx int) int {
-	for i, tc := range g.currentTrick {
-		if tc.PlayerIdx == playerIdx {
-			return i
-		}
-	}
-	return -1
+	return indexOfPlayerInTrick(g.currentTrick, playerIdx)
 }
 
 // --- CPU AI (play) ---

--- a/internal/domain/Vint.go
+++ b/internal/domain/Vint.go
@@ -130,7 +130,7 @@ type Vint struct {
 	gameEndFlag bool
 	winnerTeam  int
 
-	actionLog []*ActionLogEntry
+	actionLogBase
 }
 
 // NewVint コンストラクタ
@@ -779,18 +779,9 @@ func (v *Vint) GetConfig() VintConfig { return v.config }
 // SetConfig は設定をセットする。
 func (v *Vint) SetConfig(c VintConfig) { v.config = c }
 
-// GetActionLog は棋譜を返す。
-func (v *Vint) GetActionLog() []*ActionLogEntry { return v.actionLog }
-
 // addLog は棋譜を 1 行足す。
 func (v *Vint) addLog(playerIdx int, actionType, detail string, cards []*Card) {
-	v.actionLog = append(v.actionLog, &ActionLogEntry{
-		TurnNumber: len(v.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	v.appendLog(playerIdx, actionType, detail, cards)
 }
 
 // SetPhaseForTest はテスト用にフェーズを設定する。

--- a/internal/domain/Zwicker.go
+++ b/internal/domain/Zwicker.go
@@ -132,7 +132,7 @@ type Zwicker struct {
 
 	gameEndFlag bool
 	winnerTeam  int
-	actionLog   []*ActionLogEntry
+	actionLogBase
 }
 
 // NewZwicker はコンストラクタ。
@@ -668,9 +668,6 @@ func (z *Zwicker) GetConfig() ZwickerConfig { return z.config }
 // SetConfig はゲーム設定をセットする。
 func (z *Zwicker) SetConfig(c ZwickerConfig) { z.config = c }
 
-// GetActionLog は棋譜を返す。
-func (z *Zwicker) GetActionLog() []*ActionLogEntry { return z.actionLog }
-
 // SetPhaseForTest はテスト用にフェーズを差し替える。
 func (z *Zwicker) SetPhaseForTest(p ZwickerPhase) { z.phase = p }
 
@@ -688,13 +685,7 @@ func (z *Zwicker) SetDealStageForTest(stage int) { z.dealStage = stage }
 
 // addLog は棋譜に 1 件追加する。
 func (z *Zwicker) addLog(playerIdx int, actionType, detail string, cards []*Card) {
-	z.actionLog = append(z.actionLog, &ActionLogEntry{
-		TurnNumber: len(z.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	z.appendLog(playerIdx, actionType, detail, cards)
 }
 
 // zwickerJSON is the JSON wire format for Zwicker.

--- a/internal/domain/action_log_base_adopters_test.go
+++ b/internal/domain/action_log_base_adopters_test.go
@@ -1,0 +1,150 @@
+//go:build test
+
+package domain
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// logReader is the one thing this test needs from a game.
+type logReader interface {
+	GetActionLog() []*ActionLogEntry
+}
+
+// These 19 games moved their action log from an own `actionLog` field to the
+// embedded actionLogBase. Promotion keeps `g.actionLog` compiling in their
+// MarshalJSON/UnmarshalJSON pairs, so nothing in them had to change -- which is
+// exactly why a mistake here would be quiet. The log is persisted to KV for the
+// Cloudflare Workers, so a codec that silently stopped carrying it would drop
+// history per request rather than fail a build.
+//
+// Their existing round-trip tests do not assert on the log (ChineseTen's checks
+// stock, layout, phase, scores and hands), so this covers the gap for all 19.
+func TestActionLogBaseAdopters_LogSurvivesAKVRoundTrip(t *testing.T) {
+	adopters := []struct {
+		name  string
+		build func() (any, any) // a game holding one entry, and an empty one to restore into
+	}{
+		{"BidEuchre", func() (any, any) {
+			g := NewDefaultBidEuchre()
+			g.addLog(1, "act", "detail", nil)
+			return g, NewDefaultBidEuchre()
+		}},
+		{"Boston", func() (any, any) {
+			g := NewDefaultBoston()
+			g.addLog(1, "act", "detail", nil)
+			return g, NewDefaultBoston()
+		}},
+		{"Bura", func() (any, any) {
+			g := NewDefaultBura()
+			g.addLog(1, "act", "detail", nil)
+			return g, NewDefaultBura()
+		}},
+		{"ChineseTen", func() (any, any) {
+			g := NewDefaultChineseTen()
+			g.addLog(1, "act", "detail", nil)
+			return g, NewDefaultChineseTen()
+		}},
+		{"Desmoche", func() (any, any) {
+			g := NewDefaultDesmoche()
+			g.addLog(1, "act", "detail", nil)
+			return g, NewDefaultDesmoche()
+		}},
+		{"Kaiser", func() (any, any) {
+			g := NewDefaultKaiser()
+			g.addLog(1, "act", "detail", nil)
+			return g, NewDefaultKaiser()
+		}},
+		{"Kille", func() (any, any) {
+			g := NewDefaultKille()
+			g.addLog(1, "act", "detail", nil)
+			return g, NewDefaultKille()
+		}},
+		{"Klaberjass", func() (any, any) {
+			g := NewDefaultKlaberjass()
+			g.addLog(1, "act", "detail", nil)
+			return g, NewDefaultKlaberjass()
+		}},
+		{"Loba", func() (any, any) {
+			g := NewDefaultLoba()
+			g.addLog(1, "act", "detail", nil)
+			return g, NewDefaultLoba()
+		}},
+		{"Mushi", func() (any, any) {
+			g := NewDefaultMushi()
+			g.addLog(1, "act", "detail", nil)
+			return g, NewDefaultMushi()
+		}},
+		{"NainJaune", func() (any, any) {
+			g := NewDefaultNainJaune()
+			g.addLog(1, "act", "detail", nil)
+			return g, NewDefaultNainJaune()
+		}},
+		{"Poch", func() (any, any) {
+			g := NewDefaultPoch()
+			g.addLog(1, "act", "detail", nil)
+			return g, NewDefaultPoch()
+		}},
+		{"PopeJoan", func() (any, any) {
+			g := NewDefaultPopeJoan()
+			g.addLog(1, "act", "detail", nil)
+			return g, NewDefaultPopeJoan()
+		}},
+		{"Sjavs", func() (any, any) {
+			g := NewDefaultSjavs()
+			g.addLog(1, "act", "detail", nil)
+			return g, NewDefaultSjavs()
+		}},
+		{"Skitgubbe", func() (any, any) {
+			g := NewDefaultSkitgubbe()
+			g.addLog(1, "act", "detail", nil)
+			return g, NewDefaultSkitgubbe()
+		}},
+		{"Toepen", func() (any, any) {
+			g := NewDefaultToepen()
+			g.addLog(1, "act", "detail", nil)
+			return g, NewDefaultToepen()
+		}},
+		{"Trex", func() (any, any) {
+			g := NewDefaultTrex()
+			g.addLog(1, "act", "detail", nil)
+			return g, NewDefaultTrex()
+		}},
+		{"Vint", func() (any, any) {
+			g := NewDefaultVint()
+			g.addLog(1, "act", "detail", nil)
+			return g, NewDefaultVint()
+		}},
+		{"Zwicker", func() (any, any) {
+			g := NewDefaultZwicker()
+			g.addLog(1, "act", "detail", nil)
+			return g, NewDefaultZwicker()
+		}},
+	}
+
+	assert.Len(t, adopters, 19, "every game delegating addLog to appendLog must be listed")
+
+	for _, a := range adopters {
+		t.Run(a.name, func(t *testing.T) {
+			saved, restored := a.build()
+
+			before := saved.(logReader).GetActionLog()
+			require.Len(t, before, 1, "fixture must actually record an entry")
+
+			data, err := json.Marshal(saved)
+			require.NoError(t, err)
+			require.NoError(t, json.Unmarshal(data, restored))
+
+			after := restored.(logReader).GetActionLog()
+			require.Len(t, after, 1, "the action log did not survive the round trip")
+			assert.Equal(t, before[0].TurnNumber, after[0].TurnNumber)
+			assert.Equal(t, before[0].PlayerIdx, after[0].PlayerIdx)
+			assert.Equal(t, before[0].ActionType, after[0].ActionType)
+			assert.Equal(t, before[0].Detail, after[0].Detail)
+		})
+	}
+}

--- a/internal/domain/player_helpers_internal_test.go
+++ b/internal/domain/player_helpers_internal_test.go
@@ -318,3 +318,32 @@ func TestHandHasSuit(t *testing.T) {
 	assert.True(t, handHasSuit(seats[1], 3))
 	assert.False(t, handHasSuit(seats[2], 1), "empty hand holds no suit")
 }
+
+func TestIndexOfPlayerInTrick(t *testing.T) {
+	trick := []*TrickCard{
+		{PlayerIdx: 2},
+		{PlayerIdx: 0},
+		{PlayerIdx: 3},
+	}
+
+	assert.Equal(t, 0, indexOfPlayerInTrick(trick, 2), "play order, not seat order")
+	assert.Equal(t, 1, indexOfPlayerInTrick(trick, 0))
+	assert.Equal(t, 2, indexOfPlayerInTrick(trick, 3))
+}
+
+// -1 rather than 0: callers compare against -1, and a valid-looking 0 would
+// silently claim the seat led the trick.
+func TestIndexOfPlayerInTrick_Absent(t *testing.T) {
+	trick := []*TrickCard{{PlayerIdx: 1}}
+
+	assert.Equal(t, -1, indexOfPlayerInTrick(trick, 9))
+	assert.Equal(t, -1, indexOfPlayerInTrick(nil, 1), "no trick in progress")
+}
+
+// The first entry wins if a seat somehow appears twice, matching the 20
+// hand-written loops.
+func TestIndexOfPlayerInTrick_FirstMatchWins(t *testing.T) {
+	trick := []*TrickCard{{PlayerIdx: 5}, {PlayerIdx: 5}}
+
+	assert.Equal(t, 0, indexOfPlayerInTrick(trick, 5))
+}

--- a/internal/domain/trick_helpers.go
+++ b/internal/domain/trick_helpers.go
@@ -65,3 +65,19 @@ func ResolveTrickWinner(trick []*TrickCard, trumpSuit int, rank func(*Card) int)
 	}
 	return winnerIdx
 }
+
+// indexOfPlayerInTrick returns the position at which playerIdx played into the
+// current trick, or -1 when that seat has not played yet. Position is play
+// order, not seat order.
+//
+// 20 games had this loop written out. It needs no type parameter: every one of
+// them holds its trick as []*TrickCard, so this is a plain function and adds no
+// monomorphised copies. See issue #5185.
+func indexOfPlayerInTrick(trick []*TrickCard, playerIdx int) int {
+	for i, tc := range trick {
+		if tc.PlayerIdx == playerIdx {
+			return i
+		}
+	}
+	return -1
+}


### PR DESCRIPTION
#5185 の残りクラスタ、その2。

| クラスタ | 件数 | 削減 | 方式 |
|---|---:|---:|---|
| `indexOfPlayerInTrick` | 20 | -100 | **非ジェネリック**の自由関数 |
| `addLog` | 19 | -109 | 既存の `actionLogBase` 埋め込み |
| **合計** | **39** | **-209行** | |

## サイズが増えない方式を選んでいます

7クラスタの実測から得た規則（`fmt` を含む本体のジェネリック化は激増する／既存の仕組みの再利用が最も効く）に沿って、**今回は単相化コピーが1つも増えない方式**を選びました。

- **`indexOfPlayerInTrick`**: 20ゲームすべてが `currentTrick` を**共有型 `[]*TrickCard`** で保持していたので、**型パラメータが不要**です。ただの関数なので単相化そのものが発生しません。
- **`addLog`**: 新しいジェネリックではなく、**フェーズ1で既に入っている `actionLogBase` を埋め込む**だけです。

なお `UndoN`（31件・約228行）は**本体に `fmt.Sprintf` を含むため今回は見送りました**。#5202 で `playerName` が同じ理由で **+4,801 バイト**になっているので、行数だけ見て手を出しません。

## `addLog` がフェーズ1で漏れていた理由

フェーズ1は122ゲームを `actionLogBase` に寄せましたが、**メソッド名が `appendLog` ではなく `addLog`** だったこれらは本体マッチャに掛かりませんでした。ボディは正典と同一です。

各ゲームで「自前の `actionLog` フィールド」「1行の `GetActionLog`」を削除し、`addLog` を委譲に置き換えています。

**7ゲームは自前の本体を維持**します（Cribbage / Guandan / Karnoffel / Literature / Pinochle / ShengJi / SixBidSolo）。正典と違う記録をするためで、置換スクリプトは**ファイル単位で全か無か**（定義を残すなら他の編集もしない）です。

## KV コーデックのガードを追加しました

ここが今回いちばん危ないところです。**昇格フィールドのおかげで各ゲームの `MarshalJSON`/`UnmarshalJSON` は1文字も変えずにコンパイルが通ります。** つまり間違えても静かに壊れます。アクションログは Worker の KV に永続化されるので、コーデックが運ばなくなれば**ビルドを落とさずに毎リクエスト履歴が消えます**。

そして**既存の往復テストはログを検証していませんでした** —— 例えば ChineseTen の `SurvivesAKVRoundTrip` は stock / layout / phase / scores / hands は見ますが、アクションログは見ません。

→ 19ゲーム全部を往復させ、ログが生き残ることを固定するテーブルテストを追加しました。
**ChineseTen のワイヤ形式で `ActionLog` を nil にして、実際に落ちることを確認済み**です（`the action log did not survive the round trip`）。

構造チェックとして、19ゲームすべてで「埋め込みが入り」「marshal が書き」「unmarshal が戻し」「旧フィールドが消えている」ことも機械的に確認しています。

## 検証

- `go test -tags test ./...` 全パッケージ通過
- `golangci-lint run ./internal/...` 0 issues
- ヘルパは call-site 書き換えの**前**に別コミット（`3adb49a`）

Worker サイズは CI 実測後に報告します。

Refs #5185