### PR TITLE
refactor(domain): delegate 68 discard/valid-play bodies to shared helpers

### DIFF
--- a/internal/domain/Belote.go
+++ b/internal/domain/Belote.go
@@ -1024,10 +1024,7 @@ func (b *Belote) GetValidPlayIndices(playerIdx int) []int {
 
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す
 func (b *Belote) getValidPlayIndices(playerIdx int) []int {
-	player := b.players[playerIdx]
-	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
-		return b.validatePlay(playerIdx, player.GetCard(i)) == nil
-	})
+	return validPlayIndices(b.players[playerIdx], func(c *Card) bool { return b.validatePlay(playerIdx, c) == nil })
 }
 
 // --- Game end + bookkeeping ---

--- a/internal/domain/BidWhist.go
+++ b/internal/domain/BidWhist.go
@@ -766,10 +766,7 @@ func (g *BidWhist) GetValidPlayIndices(playerIdx int) []int {
 
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す
 func (g *BidWhist) getValidPlayIndices(playerIdx int) []int {
-	player := g.players[playerIdx]
-	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
-		return g.validatePlay(playerIdx, player.GetCard(i)) == nil
-	})
+	return validPlayIndices(g.players[playerIdx], func(c *Card) bool { return g.validatePlay(playerIdx, c) == nil })
 }
 
 // --- CPU AI ---

--- a/internal/domain/Bridge.go
+++ b/internal/domain/Bridge.go
@@ -1128,10 +1128,7 @@ func (b *Bridge) playerHasSuit(playerIdx int, suit int) bool {
 
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す
 func (b *Bridge) getValidPlayIndices(playerIdx int) []int {
-	player := b.players[playerIdx]
-	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
-		return b.validatePlay(playerIdx, player.GetCard(i)) == nil
-	})
+	return validPlayIndices(b.players[playerIdx], func(c *Card) bool { return b.validatePlay(playerIdx, c) == nil })
 }
 
 // trickWinner トリックの勝者を決定する

--- a/internal/domain/Calabresella.go
+++ b/internal/domain/Calabresella.go
@@ -656,10 +656,7 @@ func (g *Calabresella) trickWinner() int {
 
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す。
 func (g *Calabresella) getValidPlayIndices(playerIdx int) []int {
-	player := g.players[playerIdx]
-	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
-		return g.validatePlay(playerIdx, player.GetCard(i)) == nil
-	})
+	return validPlayIndices(g.players[playerIdx], func(c *Card) bool { return g.validatePlay(playerIdx, c) == nil })
 }
 
 // isCoalition playerIdx が連合 (非ソリスト) 側か。

--- a/internal/domain/CallBreak.go
+++ b/internal/domain/CallBreak.go
@@ -826,10 +826,7 @@ func (cb *CallBreak) summariseTrick(leadSuit int) (highestSpade int, hasSpade bo
 
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す
 func (cb *CallBreak) getValidPlayIndices(playerIdx int) []int {
-	player := cb.players[playerIdx]
-	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
-		return cb.validatePlay(playerIdx, player.GetCard(i)) == nil
-	})
+	return validPlayIndices(cb.players[playerIdx], func(c *Card) bool { return cb.validatePlay(playerIdx, c) == nil })
 }
 
 // GetValidPlayIndices プレイ可能なカードのインデックスリストを返す (Web 用)

--- a/internal/domain/Canasta.go
+++ b/internal/domain/Canasta.go
@@ -1374,10 +1374,7 @@ func (g *Canasta) SetDiscardPile(pile []*Card) { g.discardPile = pile }
 
 // GetDiscardTop 捨て札の一番上を取得
 func (g *Canasta) GetDiscardTop() *Card {
-	if len(g.discardPile) == 0 {
-		return nil
-	}
-	return g.discardPile[len(g.discardPile)-1]
+	return discardTop(g.discardPile)
 }
 
 // GetDrawPileCount 山札の残り枚数取得

--- a/internal/domain/Carioca.go
+++ b/internal/domain/Carioca.go
@@ -783,10 +783,7 @@ func (g *Carioca) SetDiscardPile(p []*Card) { g.discardPile = p }
 
 // GetDiscardTop 捨て札トップ
 func (g *Carioca) GetDiscardTop() *Card {
-	if len(g.discardPile) == 0 {
-		return nil
-	}
-	return g.discardPile[len(g.discardPile)-1]
+	return discardTop(g.discardPile)
 }
 
 // GetDrawPileCount 山札残り枚数

--- a/internal/domain/CatchTen.go
+++ b/internal/domain/CatchTen.go
@@ -772,10 +772,7 @@ func (g *CatchTen) isPartnerWinning(playerIdx int) bool {
 
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す
 func (g *CatchTen) getValidPlayIndices(playerIdx int) []int {
-	player := g.players[playerIdx]
-	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
-		return g.validatePlay(playerIdx, player.GetCard(i)) == nil
-	})
+	return validPlayIndices(g.players[playerIdx], func(c *Card) bool { return g.validatePlay(playerIdx, c) == nil })
 }
 
 // catchTenJSON is the JSON wire format for CatchTen.

--- a/internal/domain/Chinchon.go
+++ b/internal/domain/Chinchon.go
@@ -701,10 +701,7 @@ func (g *Chinchon) SetDiscardPile(pile []*Card) {
 
 // GetDiscardTop 捨て札の一番上を取得
 func (g *Chinchon) GetDiscardTop() *Card {
-	if len(g.discardPile) == 0 {
-		return nil
-	}
-	return g.discardPile[len(g.discardPile)-1]
+	return discardTop(g.discardPile)
 }
 
 // GetDrawPileCount 山札の残り枚数取得

--- a/internal/domain/Cinch.go
+++ b/internal/domain/Cinch.go
@@ -835,10 +835,7 @@ func cinchSortHand(p *CinchPlayer) {
 }
 
 func (g *Cinch) getValidPlayIndices(playerIdx int) []int {
-	player := g.players[playerIdx]
-	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
-		return g.validatePlay(playerIdx, player.GetCard(i)) == nil
-	})
+	return validPlayIndices(g.players[playerIdx], func(c *Card) bool { return g.validatePlay(playerIdx, c) == nil })
 }
 
 // --- 状態アクセサ ---

--- a/internal/domain/Conquian.go
+++ b/internal/domain/Conquian.go
@@ -863,10 +863,7 @@ func (g *Conquian) SetDiscardPile(pile []*Card) {
 
 // GetDiscardTop 捨て札の一番上を取得
 func (g *Conquian) GetDiscardTop() *Card {
-	if len(g.discardPile) == 0 {
-		return nil
-	}
-	return g.discardPile[len(g.discardPile)-1]
+	return discardTop(g.discardPile)
 }
 
 // GetDrawPileCount 山札の残り枚数取得

--- a/internal/domain/ContractRummy.go
+++ b/internal/domain/ContractRummy.go
@@ -790,10 +790,7 @@ func (g *ContractRummy) SetDiscardPile(p []*Card) { g.discardPile = p }
 
 // GetDiscardTop 捨て札トップ
 func (g *ContractRummy) GetDiscardTop() *Card {
-	if len(g.discardPile) == 0 {
-		return nil
-	}
-	return g.discardPile[len(g.discardPile)-1]
+	return discardTop(g.discardPile)
 }
 
 // GetDrawPileCount 山札残り枚数

--- a/internal/domain/CourtPiece.go
+++ b/internal/domain/CourtPiece.go
@@ -640,10 +640,7 @@ func (c *CourtPiece) playHintReason(playerIdx, chosenIdx int) string {
 
 // getValidPlayIndices プレイ可能なカードのインデックスリスト
 func (c *CourtPiece) getValidPlayIndices(playerIdx int) []int {
-	player := c.players[playerIdx]
-	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
-		return c.validatePlay(playerIdx, player.GetCard(i)) == nil
-	})
+	return validPlayIndices(c.players[playerIdx], func(card *Card) bool { return c.validatePlay(playerIdx, card) == nil })
 }
 
 // --- CPU AI ---

--- a/internal/domain/CrazyEights.go
+++ b/internal/domain/CrazyEights.go
@@ -387,10 +387,7 @@ func (g *CrazyEights) SetDiscardPile(pile []*Card) { g.discardPile = pile }
 
 // GetDiscardTop 捨て札の一番上を取得
 func (g *CrazyEights) GetDiscardTop() *Card {
-	if len(g.discardPile) == 0 {
-		return nil
-	}
-	return g.discardPile[len(g.discardPile)-1]
+	return discardTop(g.discardPile)
 }
 
 // GetDrawPileCount 山札の残り枚数取得

--- a/internal/domain/CrazyEights.go
+++ b/internal/domain/CrazyEights.go
@@ -731,10 +731,7 @@ func (g *CrazyEights) countSuits(playerIdx int) map[int]int {
 
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す
 func (g *CrazyEights) getValidPlayIndices(playerIdx int) []int {
-	player := g.players[playerIdx]
-	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
-		return g.isValidPlay(player.GetCard(i))
-	})
+	return validPlayIndices(g.players[playerIdx], func(c *Card) bool { return g.isValidPlay(c) })
 }
 
 // GetValidPlayIndices プレイ可能なカードのインデックスリストを返す (Web用)

--- a/internal/domain/Doppelkopf.go
+++ b/internal/domain/Doppelkopf.go
@@ -475,10 +475,7 @@ func (g *Doppelkopf) trickWinner() int {
 
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す。
 func (g *Doppelkopf) getValidPlayIndices(playerIdx int) []int {
-	player := g.players[playerIdx]
-	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
-		return g.validatePlay(playerIdx, player.GetCard(i)) == nil
-	})
+	return validPlayIndices(g.players[playerIdx], func(c *Card) bool { return g.validatePlay(playerIdx, c) == nil })
 }
 
 // --- Misc helpers ---

--- a/internal/domain/Euchre.go
+++ b/internal/domain/Euchre.go
@@ -972,10 +972,7 @@ func (e *Euchre) GetValidPlayIndices(playerIdx int) []int {
 
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す
 func (e *Euchre) getValidPlayIndices(playerIdx int) []int {
-	player := e.players[playerIdx]
-	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
-		return e.validatePlay(playerIdx, player.GetCard(i)) == nil
-	})
+	return validPlayIndices(e.players[playerIdx], func(c *Card) bool { return e.validatePlay(playerIdx, c) == nil })
 }
 
 // --- CPU AI ---

--- a/internal/domain/FiveHundred.go
+++ b/internal/domain/FiveHundred.go
@@ -1069,10 +1069,7 @@ func (g *FiveHundred) GetValidPlayIndices(playerIdx int) []int {
 
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す
 func (g *FiveHundred) getValidPlayIndices(playerIdx int) []int {
-	player := g.players[playerIdx]
-	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
-		return g.validatePlay(playerIdx, player.GetCard(i)) == nil
-	})
+	return validPlayIndices(g.players[playerIdx], func(c *Card) bool { return g.validatePlay(playerIdx, c) == nil })
 }
 
 // --- Hint ---

--- a/internal/domain/FortyFives.go
+++ b/internal/domain/FortyFives.go
@@ -582,10 +582,7 @@ func fortyFivesPip(v int) int {
 
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す。
 func (g *FortyFives) getValidPlayIndices(playerIdx int) []int {
-	player := g.players[playerIdx]
-	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
-		return g.validatePlay(playerIdx, player.GetCard(i)) == nil
-	})
+	return validPlayIndices(g.players[playerIdx], func(c *Card) bool { return g.validatePlay(playerIdx, c) == nil })
 }
 
 // --- Misc helpers ---

--- a/internal/domain/GinRummy.go
+++ b/internal/domain/GinRummy.go
@@ -763,10 +763,7 @@ func (g *GinRummy) SetDiscardPile(pile []*Card) { g.discardPile = pile }
 
 // GetDiscardTop 捨て札の一番上を取得
 func (g *GinRummy) GetDiscardTop() *Card {
-	if len(g.discardPile) == 0 {
-		return nil
-	}
-	return g.discardPile[len(g.discardPile)-1]
+	return discardTop(g.discardPile)
 }
 
 // GetDrawPileCount 山札の残り枚数取得

--- a/internal/domain/GongZhu.go
+++ b/internal/domain/GongZhu.go
@@ -905,10 +905,7 @@ func (g *GongZhu) cpuDiscard(player *GongZhuPlayer, validIndices []int) int {
 
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す
 func (g *GongZhu) getValidPlayIndices(playerIdx int) []int {
-	player := g.players[playerIdx]
-	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
-		return g.validatePlay(playerIdx, player.GetCard(i)) == nil
-	})
+	return validPlayIndices(g.players[playerIdx], func(c *Card) bool { return g.validatePlay(playerIdx, c) == nil })
 }
 
 // gzLeadDanger リード時のカード危険度（低いほど安全）

--- a/internal/domain/HandAndFoot.go
+++ b/internal/domain/HandAndFoot.go
@@ -1236,10 +1236,7 @@ func (g *HandAndFoot) SetDiscardPile(pile []*Card) { g.discardPile = pile }
 
 // GetDiscardTop 捨て札の一番上を取得
 func (g *HandAndFoot) GetDiscardTop() *Card {
-	if len(g.discardPile) == 0 {
-		return nil
-	}
-	return g.discardPile[len(g.discardPile)-1]
+	return discardTop(g.discardPile)
 }
 
 // GetDrawPileCount 山札の残り枚数取得

--- a/internal/domain/Hearts.go
+++ b/internal/domain/Hearts.go
@@ -1120,10 +1120,7 @@ func (h *Hearts) cpuPlayHard(playerIdx int, validIndices []int) int {
 
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す
 func (h *Hearts) getValidPlayIndices(playerIdx int) []int {
-	player := h.players[playerIdx]
-	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
-		return h.validatePlay(playerIdx, player.GetCard(i)) == nil
-	})
+	return validPlayIndices(h.players[playerIdx], func(c *Card) bool { return h.validatePlay(playerIdx, c) == nil })
 }
 
 // heartsJSON is the JSON wire format for Hearts.

--- a/internal/domain/IndianRummy.go
+++ b/internal/domain/IndianRummy.go
@@ -580,10 +580,7 @@ func (g *IndianRummy) SetDiscardPile(p []*Card) { g.discardPile = p }
 
 // GetDiscardTop 捨て札トップ
 func (g *IndianRummy) GetDiscardTop() *Card {
-	if len(g.discardPile) == 0 {
-		return nil
-	}
-	return g.discardPile[len(g.discardPile)-1]
+	return discardTop(g.discardPile)
 }
 
 // GetDrawPileCount 山札残り枚数

--- a/internal/domain/Jass.go
+++ b/internal/domain/Jass.go
@@ -1033,10 +1033,7 @@ func (g *Jass) GetValidPlayIndices(playerIdx int) []int {
 
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す
 func (g *Jass) getValidPlayIndices(playerIdx int) []int {
-	player := g.players[playerIdx]
-	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
-		return g.validatePlay(playerIdx, player.GetCard(i)) == nil
-	})
+	return validPlayIndices(g.players[playerIdx], func(c *Card) bool { return g.validatePlay(playerIdx, c) == nil })
 }
 
 // --- Game end + bookkeeping ---

--- a/internal/domain/Kalooki.go
+++ b/internal/domain/Kalooki.go
@@ -664,10 +664,7 @@ func (g *Kalooki) SetDiscardPile(p []*Card) { g.discardPile = p }
 
 // GetDiscardTop 捨て札トップ
 func (g *Kalooki) GetDiscardTop() *Card {
-	if len(g.discardPile) == 0 {
-		return nil
-	}
-	return g.discardPile[len(g.discardPile)-1]
+	return discardTop(g.discardPile)
 }
 
 // GetDrawPileCount 山札残り枚数

--- a/internal/domain/Klaverjas.go
+++ b/internal/domain/Klaverjas.go
@@ -468,10 +468,7 @@ func (g *Klaverjas) cardPoints(card *Card) int {
 
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す。
 func (g *Klaverjas) getValidPlayIndices(playerIdx int) []int {
-	player := g.players[playerIdx]
-	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
-		return g.validatePlay(playerIdx, player.GetCard(i)) == nil
-	})
+	return validPlayIndices(g.players[playerIdx], func(c *Card) bool { return g.validatePlay(playerIdx, c) == nil })
 }
 
 // --- Roem detection ---

--- a/internal/domain/KnockoutWhist.go
+++ b/internal/domain/KnockoutWhist.go
@@ -445,10 +445,7 @@ func knockoutCardStrength(value int) int {
 
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す。
 func (g *KnockoutWhist) getValidPlayIndices(playerIdx int) []int {
-	player := g.players[playerIdx]
-	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
-		return g.validatePlay(playerIdx, player.GetCard(i)) == nil
-	})
+	return validPlayIndices(g.players[playerIdx], func(c *Card) bool { return g.validatePlay(playerIdx, c) == nil })
 }
 
 // --- Misc helpers ---

--- a/internal/domain/Loo.go
+++ b/internal/domain/Loo.go
@@ -604,10 +604,7 @@ func (g *Loo) playerHasSuit(playerIdx, suit int) bool {
 
 // getValidPlayIndices はプレイ可能なカードのインデックスリストを返す。
 func (g *Loo) getValidPlayIndices(playerIdx int) []int {
-	player := g.players[playerIdx]
-	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
-		return g.validatePlay(playerIdx, player.GetCard(i)) == nil
-	})
+	return validPlayIndices(g.players[playerIdx], func(c *Card) bool { return g.validatePlay(playerIdx, c) == nil })
 }
 
 // --- ヘルパー ---

--- a/internal/domain/Macau.go
+++ b/internal/domain/Macau.go
@@ -416,10 +416,7 @@ func (g *Macau) SetDiscardPile(pile []*Card) { g.discardPile = pile }
 
 // GetDiscardTop 捨て札の一番上を取得
 func (g *Macau) GetDiscardTop() *Card {
-	if len(g.discardPile) == 0 {
-		return nil
-	}
-	return g.discardPile[len(g.discardPile)-1]
+	return discardTop(g.discardPile)
 }
 
 // GetDrawPileCount 山札の残り枚数取得

--- a/internal/domain/Macau.go
+++ b/internal/domain/Macau.go
@@ -843,10 +843,7 @@ func (g *Macau) countSuits(playerIdx int) map[int]int {
 
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す
 func (g *Macau) getValidPlayIndices(playerIdx int) []int {
-	player := g.players[playerIdx]
-	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
-		return g.isValidPlay(player.GetCard(i))
-	})
+	return validPlayIndices(g.players[playerIdx], func(c *Card) bool { return g.isValidPlay(c) })
 }
 
 // GetValidPlayIndices プレイ可能なカードのインデックスリストを返す (Web用)

--- a/internal/domain/Manille.go
+++ b/internal/domain/Manille.go
@@ -388,10 +388,7 @@ func manilleCardPoints(card *Card) int {
 
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す。
 func (g *Manille) getValidPlayIndices(playerIdx int) []int {
-	player := g.players[playerIdx]
-	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
-		return g.validatePlay(playerIdx, player.GetCard(i)) == nil
-	})
+	return validPlayIndices(g.players[playerIdx], func(c *Card) bool { return g.validatePlay(playerIdx, c) == nil })
 }
 
 // --- Misc helpers ---

--- a/internal/domain/Mao.go
+++ b/internal/domain/Mao.go
@@ -585,10 +585,7 @@ func (g *Mao) SetDiscardPile(pile []*Card) { g.discardPile = pile }
 
 // GetDiscardTop 捨て札の一番上を取得
 func (g *Mao) GetDiscardTop() *Card {
-	if len(g.discardPile) == 0 {
-		return nil
-	}
-	return g.discardPile[len(g.discardPile)-1]
+	return discardTop(g.discardPile)
 }
 
 // GetDrawPileCount 山札の残り枚数取得

--- a/internal/domain/Mao.go
+++ b/internal/domain/Mao.go
@@ -1038,10 +1038,7 @@ func (g *Mao) countSuits(playerIdx int) map[int]int {
 
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す
 func (g *Mao) getValidPlayIndices(playerIdx int) []int {
-	player := g.players[playerIdx]
-	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
-		return g.isValidPlay(player.GetCard(i))
-	})
+	return validPlayIndices(g.players[playerIdx], func(c *Card) bool { return g.isValidPlay(c) })
 }
 
 // GetValidPlayIndices プレイ可能なカードのインデックスリストを返す (Web用)

--- a/internal/domain/Marias.go
+++ b/internal/domain/Marias.go
@@ -451,10 +451,7 @@ func mariasCardPoints(card *Card) int {
 
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す。
 func (g *Marias) getValidPlayIndices(playerIdx int) []int {
-	player := g.players[playerIdx]
-	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
-		return g.validatePlay(playerIdx, player.GetCard(i)) == nil
-	})
+	return validPlayIndices(g.players[playerIdx], func(c *Card) bool { return g.validatePlay(playerIdx, c) == nil })
 }
 
 // --- Misc helpers ---

--- a/internal/domain/Nap.go
+++ b/internal/domain/Nap.go
@@ -516,10 +516,7 @@ func napCardStrength(value int) int {
 
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す。
 func (g *Nap) getValidPlayIndices(playerIdx int) []int {
-	player := g.players[playerIdx]
-	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
-		return g.validatePlay(playerIdx, player.GetCard(i)) == nil
-	})
+	return validPlayIndices(g.players[playerIdx], func(c *Card) bool { return g.validatePlay(playerIdx, c) == nil })
 }
 
 // --- Misc helpers ---

--- a/internal/domain/Napoleon.go
+++ b/internal/domain/Napoleon.go
@@ -1082,10 +1082,7 @@ func (n *Napoleon) playHintReason(chosenIdx int) string {
 
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す
 func (n *Napoleon) getValidPlayIndices(playerIdx int) []int {
-	player := n.players[playerIdx]
-	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
-		return n.validatePlay(playerIdx, player.GetCard(i)) == nil
-	})
+	return validPlayIndices(n.players[playerIdx], func(c *Card) bool { return n.validatePlay(playerIdx, c) == nil })
 }
 
 // --- CPU AI ---

--- a/internal/domain/NinetyNine.go
+++ b/internal/domain/NinetyNine.go
@@ -642,10 +642,7 @@ func ninetyNineSortHand(p *NinetyNinePlayer) {
 
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す
 func (o *NinetyNine) getValidPlayIndices(playerIdx int) []int {
-	player := o.players[playerIdx]
-	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
-		return o.validatePlay(playerIdx, player.GetCard(i)) == nil
-	})
+	return validPlayIndices(o.players[playerIdx], func(c *Card) bool { return o.validatePlay(playerIdx, c) == nil })
 }
 
 // GetHint ヒントを取得する

--- a/internal/domain/OhHell.go
+++ b/internal/domain/OhHell.go
@@ -626,10 +626,7 @@ func ohHellSortHand(p *OhHellPlayer) {
 
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す
 func (o *OhHell) getValidPlayIndices(playerIdx int) []int {
-	player := o.players[playerIdx]
-	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
-		return o.validatePlay(playerIdx, player.GetCard(i)) == nil
-	})
+	return validPlayIndices(o.players[playerIdx], func(c *Card) bool { return o.validatePlay(playerIdx, c) == nil })
 }
 
 // GetHint ヒントを取得する

--- a/internal/domain/Ombre.go
+++ b/internal/domain/Ombre.go
@@ -718,10 +718,7 @@ func (g *Ombre) trickWinner() int {
 
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す。
 func (g *Ombre) getValidPlayIndices(playerIdx int) []int {
-	player := g.players[playerIdx]
-	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
-		return g.validatePlay(playerIdx, player.GetCard(i)) == nil
-	})
+	return validPlayIndices(g.players[playerIdx], func(c *Card) bool { return g.validatePlay(playerIdx, c) == nil })
 }
 
 // isCoalition playerIdx が連合 (非オンブル) 側か。

--- a/internal/domain/PageOne.go
+++ b/internal/domain/PageOne.go
@@ -352,10 +352,7 @@ func (g *PageOne) SetDiscardPile(pile []*Card) { g.discardPile = pile }
 
 // GetDiscardTop 捨て札の一番上を取得
 func (g *PageOne) GetDiscardTop() *Card {
-	if len(g.discardPile) == 0 {
-		return nil
-	}
-	return g.discardPile[len(g.discardPile)-1]
+	return discardTop(g.discardPile)
 }
 
 // GetDrawPileCount 山札の残り枚数取得

--- a/internal/domain/PageOne.go
+++ b/internal/domain/PageOne.go
@@ -612,10 +612,7 @@ func (g *PageOne) countSuits(playerIdx int) map[int]int {
 
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す
 func (g *PageOne) getValidPlayIndices(playerIdx int) []int {
-	player := g.players[playerIdx]
-	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
-		return g.isValidPlay(player.GetCard(i))
-	})
+	return validPlayIndices(g.players[playerIdx], func(c *Card) bool { return g.isValidPlay(c) })
 }
 
 // pageOneCardScore カードのスコアを計算する

--- a/internal/domain/Pan.go
+++ b/internal/domain/Pan.go
@@ -661,10 +661,7 @@ func (g *Pan) SetDiscardPile(p []*Card) { g.discardPile = p }
 
 // GetDiscardTop 捨て札トップ
 func (g *Pan) GetDiscardTop() *Card {
-	if len(g.discardPile) == 0 {
-		return nil
-	}
-	return g.discardPile[len(g.discardPile)-1]
+	return discardTop(g.discardPile)
 }
 
 // GetDrawPileCount 山札残り枚数

--- a/internal/domain/Pitch.go
+++ b/internal/domain/Pitch.go
@@ -766,10 +766,7 @@ func pitchSortHand(pl *PitchPlayer) {
 }
 
 func (p *Pitch) getValidPlayIndices(playerIdx int) []int {
-	player := p.players[playerIdx]
-	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
-		return p.validatePlay(playerIdx, player.GetCard(i)) == nil
-	})
+	return validPlayIndices(p.players[playerIdx], func(c *Card) bool { return p.validatePlay(playerIdx, c) == nil })
 }
 
 // --- CPU AI ---

--- a/internal/domain/Preference.go
+++ b/internal/domain/Preference.go
@@ -539,10 +539,7 @@ func preferenceCardStrength(value int) int {
 
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す。
 func (g *Preference) getValidPlayIndices(playerIdx int) []int {
-	player := g.players[playerIdx]
-	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
-		return g.validatePlay(playerIdx, player.GetCard(i)) == nil
-	})
+	return validPlayIndices(g.players[playerIdx], func(c *Card) bool { return g.validatePlay(playerIdx, c) == nil })
 }
 
 // --- Misc helpers ---

--- a/internal/domain/Prsi.go
+++ b/internal/domain/Prsi.go
@@ -538,10 +538,7 @@ func (g *Prsi) countSuits(playerIdx int) map[int]int {
 
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す
 func (g *Prsi) getValidPlayIndices(playerIdx int) []int {
-	player := g.players[playerIdx]
-	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
-		return g.isValidPlay(player.GetCard(i))
-	})
+	return validPlayIndices(g.players[playerIdx], func(c *Card) bool { return g.isValidPlay(c) })
 }
 
 // GetValidPlayIndices プレイ可能なカードのインデックスリストを返す (Web用)

--- a/internal/domain/Prsi.go
+++ b/internal/domain/Prsi.go
@@ -228,10 +228,7 @@ func (g *Prsi) SetDiscardPile(pile []*Card) { g.discardPile = pile }
 
 // GetDiscardTop 捨て札の一番上を取得
 func (g *Prsi) GetDiscardTop() *Card {
-	if len(g.discardPile) == 0 {
-		return nil
-	}
-	return g.discardPile[len(g.discardPile)-1]
+	return discardTop(g.discardPile)
 }
 
 // GetDrawPileCount 山札の残り枚数取得

--- a/internal/domain/Rook.go
+++ b/internal/domain/Rook.go
@@ -940,10 +940,7 @@ func (g *Rook) GetValidPlayIndices(playerIdx int) []int {
 
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す
 func (g *Rook) getValidPlayIndices(playerIdx int) []int {
-	player := g.players[playerIdx]
-	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
-		return g.validatePlay(playerIdx, player.GetCard(i)) == nil
-	})
+	return validPlayIndices(g.players[playerIdx], func(c *Card) bool { return g.validatePlay(playerIdx, c) == nil })
 }
 
 // --- Hint ---

--- a/internal/domain/Rummy500.go
+++ b/internal/domain/Rummy500.go
@@ -619,10 +619,7 @@ func (g *Rummy500) SetDiscardPile(pile []*Card) { g.discardPile = pile }
 
 // GetDiscardTop 捨て札の一番上を取得
 func (g *Rummy500) GetDiscardTop() *Card {
-	if len(g.discardPile) == 0 {
-		return nil
-	}
-	return g.discardPile[len(g.discardPile)-1]
+	return discardTop(g.discardPile)
 }
 
 // GetDrawPileCount 山札の残り枚数取得

--- a/internal/domain/Samba.go
+++ b/internal/domain/Samba.go
@@ -1544,10 +1544,7 @@ func (g *Samba) SetDiscardPile(pile []*Card) { g.discardPile = pile }
 
 // GetDiscardTop 捨て札の一番上を取得
 func (g *Samba) GetDiscardTop() *Card {
-	if len(g.discardPile) == 0 {
-		return nil
-	}
-	return g.discardPile[len(g.discardPile)-1]
+	return discardTop(g.discardPile)
 }
 
 // GetDrawPileCount 山札の残り枚数取得

--- a/internal/domain/SevenBridge.go
+++ b/internal/domain/SevenBridge.go
@@ -897,10 +897,7 @@ func (g *SevenBridge) SetDiscardPile(pile []*Card) { g.discardPile = pile }
 
 // GetDiscardTop 捨て札トップ
 func (g *SevenBridge) GetDiscardTop() *Card {
-	if len(g.discardPile) == 0 {
-		return nil
-	}
-	return g.discardPile[len(g.discardPile)-1]
+	return discardTop(g.discardPile)
 }
 
 // popDiscardTop 捨て札トップを取り出して返す

--- a/internal/domain/Sheepshead.go
+++ b/internal/domain/Sheepshead.go
@@ -596,10 +596,7 @@ func (g *Sheepshead) trickWinner() int {
 
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す。
 func (g *Sheepshead) getValidPlayIndices(playerIdx int) []int {
-	player := g.players[playerIdx]
-	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
-		return g.validatePlay(playerIdx, player.GetCard(i)) == nil
-	})
+	return validPlayIndices(g.players[playerIdx], func(c *Card) bool { return g.validatePlay(playerIdx, c) == nil })
 }
 
 // --- Call helpers ---

--- a/internal/domain/SixCardGolf.go
+++ b/internal/domain/SixCardGolf.go
@@ -806,10 +806,7 @@ func (g *SixCardGolf) SetCurrentPlayerIdx(idx int) { g.currentPlayerIdx = idx }
 
 // GetDiscardTop 捨て札トップ
 func (g *SixCardGolf) GetDiscardTop() *Card {
-	if len(g.discardPile) == 0 {
-		return nil
-	}
-	return g.discardPile[len(g.discardPile)-1]
+	return discardTop(g.discardPile)
 }
 
 // GetDrawPileCount 山札枚数

--- a/internal/domain/SoloWhist.go
+++ b/internal/domain/SoloWhist.go
@@ -535,10 +535,7 @@ func soloWhistCardStrength(value int) int {
 
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す。
 func (g *SoloWhist) getValidPlayIndices(playerIdx int) []int {
-	player := g.players[playerIdx]
-	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
-		return g.validatePlay(playerIdx, player.GetCard(i)) == nil
-	})
+	return validPlayIndices(g.players[playerIdx], func(c *Card) bool { return g.validatePlay(playerIdx, c) == nil })
 }
 
 // --- Misc helpers ---

--- a/internal/domain/Spades.go
+++ b/internal/domain/Spades.go
@@ -983,10 +983,7 @@ func (s *Spades) cpuPlayHard(playerIdx int, validIndices []int) int {
 
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す
 func (s *Spades) getValidPlayIndices(playerIdx int) []int {
-	player := s.players[playerIdx]
-	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
-		return s.validatePlay(playerIdx, player.GetCard(i)) == nil
-	})
+	return validPlayIndices(s.players[playerIdx], func(c *Card) bool { return s.validatePlay(playerIdx, c) == nil })
 }
 
 // GetValidPlayIndices プレイ可能なカードのインデックスリストを返す (Web用)

--- a/internal/domain/SpoilFive.go
+++ b/internal/domain/SpoilFive.go
@@ -446,10 +446,7 @@ func spoilPlainStrength(v int) int {
 
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す。
 func (g *SpoilFive) getValidPlayIndices(playerIdx int) []int {
-	player := g.players[playerIdx]
-	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
-		return g.validatePlay(playerIdx, player.GetCard(i)) == nil
-	})
+	return validPlayIndices(g.players[playerIdx], func(c *Card) bool { return g.validatePlay(playerIdx, c) == nil })
 }
 
 // --- Misc helpers ---

--- a/internal/domain/Sueca.go
+++ b/internal/domain/Sueca.go
@@ -357,10 +357,7 @@ func (g *Sueca) suecaRank(card *Card) int {
 
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す。
 func (g *Sueca) getValidPlayIndices(playerIdx int) []int {
-	player := g.players[playerIdx]
-	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
-		return g.validatePlay(playerIdx, player.GetCard(i)) == nil
-	})
+	return validPlayIndices(g.players[playerIdx], func(c *Card) bool { return g.validatePlay(playerIdx, c) == nil })
 }
 
 // --- Card helpers ---

--- a/internal/domain/Tarneeb.go
+++ b/internal/domain/Tarneeb.go
@@ -705,10 +705,7 @@ func (t *Tarneeb) playHintReason(playerIdx, chosenIdx int) string {
 
 // getValidPlayIndices プレイ可能なカードのインデックスリスト
 func (t *Tarneeb) getValidPlayIndices(playerIdx int) []int {
-	player := t.players[playerIdx]
-	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
-		return t.validatePlay(playerIdx, player.GetCard(i)) == nil
-	})
+	return validPlayIndices(t.players[playerIdx], func(c *Card) bool { return t.validatePlay(playerIdx, c) == nil })
 }
 
 // --- CPU AI ---

--- a/internal/domain/ThirtyOne.go
+++ b/internal/domain/ThirtyOne.go
@@ -648,10 +648,7 @@ func (g *ThirtyOne) SetCurrentPlayerIdx(idx int) { g.currentPlayerIdx = idx }
 
 // GetDiscardTop 捨て札の一番上を取得する (空なら nil)
 func (g *ThirtyOne) GetDiscardTop() *Card {
-	if len(g.discardPile) == 0 {
-		return nil
-	}
-	return g.discardPile[len(g.discardPile)-1]
+	return discardTop(g.discardPile)
 }
 
 // SetDiscardPile 捨て札を設定する (テスト用)

--- a/internal/domain/ThreeThirteen.go
+++ b/internal/domain/ThreeThirteen.go
@@ -546,10 +546,7 @@ func (g *ThreeThirteen) SetDiscardPile(p []*Card) { g.discardPile = p }
 
 // GetDiscardTop 捨て札トップ
 func (g *ThreeThirteen) GetDiscardTop() *Card {
-	if len(g.discardPile) == 0 {
-		return nil
-	}
-	return g.discardPile[len(g.discardPile)-1]
+	return discardTop(g.discardPile)
 }
 
 // GetDrawPileCount 山札残り枚数

--- a/internal/domain/Tonk.go
+++ b/internal/domain/Tonk.go
@@ -644,10 +644,7 @@ func (g *Tonk) SetDiscardPile(pile []*Card) { g.discardPile = pile }
 
 // GetDiscardTop 捨て札の一番上を取得
 func (g *Tonk) GetDiscardTop() *Card {
-	if len(g.discardPile) == 0 {
-		return nil
-	}
-	return g.discardPile[len(g.discardPile)-1]
+	return discardTop(g.discardPile)
 }
 
 // GetDrawPileCount 山札の残り枚数取得

--- a/internal/domain/Tressette.go
+++ b/internal/domain/Tressette.go
@@ -394,10 +394,7 @@ func (g *Tressette) trickWinner() int {
 
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す
 func (g *Tressette) getValidPlayIndices(playerIdx int) []int {
-	player := g.players[playerIdx]
-	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
-		return g.validatePlay(playerIdx, player.GetCard(i)) == nil
-	})
+	return validPlayIndices(g.players[playerIdx], func(c *Card) bool { return g.validatePlay(playerIdx, c) == nil })
 }
 
 // sortAllHands 全プレイヤーの手札をソートする

--- a/internal/domain/Tute.go
+++ b/internal/domain/Tute.go
@@ -420,10 +420,7 @@ func (g *Tute) tuteRank(card *Card) int {
 
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す。
 func (g *Tute) getValidPlayIndices(playerIdx int) []int {
-	player := g.players[playerIdx]
-	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
-		return g.validatePlay(playerIdx, player.GetCard(i)) == nil
-	})
+	return validPlayIndices(g.players[playerIdx], func(c *Card) bool { return g.validatePlay(playerIdx, c) == nil })
 }
 
 // --- Card helpers ---

--- a/internal/domain/TwentyNine.go
+++ b/internal/domain/TwentyNine.go
@@ -553,10 +553,7 @@ func twentyNineCardPoints(card *Card) int {
 
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す。
 func (g *TwentyNine) getValidPlayIndices(playerIdx int) []int {
-	player := g.players[playerIdx]
-	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
-		return g.validatePlay(playerIdx, player.GetCard(i)) == nil
-	})
+	return validPlayIndices(g.players[playerIdx], func(c *Card) bool { return g.validatePlay(playerIdx, c) == nil })
 }
 
 // --- Misc helpers ---

--- a/internal/domain/TwoTenJack.go
+++ b/internal/domain/TwoTenJack.go
@@ -837,10 +837,7 @@ func (t *TwoTenJack) teamOf(playerIdx int) int {
 
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す
 func (t *TwoTenJack) getValidPlayIndices(playerIdx int) []int {
-	player := t.players[playerIdx]
-	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
-		return t.validatePlay(playerIdx, player.GetCard(i)) == nil
-	})
+	return validPlayIndices(t.players[playerIdx], func(c *Card) bool { return t.validatePlay(playerIdx, c) == nil })
 }
 
 // GetValidPlayIndices プレイ可能なカードのインデックスリストを返す (Web用)

--- a/internal/domain/Tysiac.go
+++ b/internal/domain/Tysiac.go
@@ -798,10 +798,7 @@ func tysiacSuitName(suit int) string {
 
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す。
 func (g *Tysiac) getValidPlayIndices(playerIdx int) []int {
-	player := g.players[playerIdx]
-	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
-		return g.validatePlay(playerIdx, player.GetCard(i)) == nil
-	})
+	return validPlayIndices(g.players[playerIdx], func(c *Card) bool { return g.validatePlay(playerIdx, c) == nil })
 }
 
 // --- Misc helpers ---

--- a/internal/domain/Whist.go
+++ b/internal/domain/Whist.go
@@ -712,10 +712,7 @@ func (w *Whist) isPartnerWinning(playerIdx int) bool {
 
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す
 func (w *Whist) getValidPlayIndices(playerIdx int) []int {
-	player := w.players[playerIdx]
-	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
-		return w.validatePlay(playerIdx, player.GetCard(i)) == nil
-	})
+	return validPlayIndices(w.players[playerIdx], func(c *Card) bool { return w.validatePlay(playerIdx, c) == nil })
 }
 
 // whistJSON is the JSON wire format for Whist.

--- a/internal/domain/Wizard.go
+++ b/internal/domain/Wizard.go
@@ -767,10 +767,7 @@ func wizardCardStr(card *Card) string {
 
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す
 func (o *Wizard) getValidPlayIndices(playerIdx int) []int {
-	player := o.players[playerIdx]
-	return collectValidIndices(player.GetCardsSize(), func(i int) bool {
-		return o.validatePlay(playerIdx, player.GetCard(i)) == nil
-	})
+	return validPlayIndices(o.players[playerIdx], func(c *Card) bool { return o.validatePlay(playerIdx, c) == nil })
 }
 
 // GetHint ヒントを取得する

--- a/internal/domain/player_helpers.go
+++ b/internal/domain/player_helpers.go
@@ -194,3 +194,14 @@ func handHasSuit[P handReader](p P, design int) bool {
 	}
 	return false
 }
+
+// validPlayIndices returns the hand positions of p whose card satisfies ok.
+//
+// 41 games had this written out: fetch the seat, then feed
+// collectValidIndices a closure that indexes back into the same hand. Only the
+// predicate differs between them, so that is what is passed in. See issue #5185.
+func validPlayIndices[P handReader](p P, ok func(*Card) bool) []int {
+	return collectValidIndices(p.GetCardsSize(), func(i int) bool {
+		return ok(p.GetCard(i))
+	})
+}

--- a/internal/domain/player_helpers_internal_test.go
+++ b/internal/domain/player_helpers_internal_test.go
@@ -347,3 +347,17 @@ func TestIndexOfPlayerInTrick_FirstMatchWins(t *testing.T) {
 
 	assert.Equal(t, 0, indexOfPlayerInTrick(trick, 5))
 }
+
+func TestDiscardTop(t *testing.T) {
+	a, b := NewCard(1, 5, false), NewCard(2, 9, false)
+
+	assert.Same(t, b, discardTop([]*Card{a, b}), "the top is the last card added")
+	assert.Same(t, a, discardTop([]*Card{a}))
+}
+
+// nil rather than a panic on an empty pile: callers nil-check, and every one of
+// the 22 hand-written bodies returned nil here.
+func TestDiscardTop_EmptyPile(t *testing.T) {
+	assert.Nil(t, discardTop([]*Card{}))
+	assert.Nil(t, discardTop(nil))
+}

--- a/internal/domain/player_helpers_internal_test.go
+++ b/internal/domain/player_helpers_internal_test.go
@@ -361,3 +361,36 @@ func TestDiscardTop_EmptyPile(t *testing.T) {
 	assert.Nil(t, discardTop([]*Card{}))
 	assert.Nil(t, discardTop(nil))
 }
+
+func TestValidPlayIndices(t *testing.T) {
+	hand := &fakeHand{cards: []*Card{
+		NewCard(1, 2, false),
+		NewCard(2, 7, false),
+		NewCard(1, 9, false),
+	}}
+
+	// Only the cards of design 1 are playable.
+	got := validPlayIndices(hand, func(c *Card) bool { return c.GetDesign() == 1 })
+	assert.Equal(t, []int{0, 2}, got)
+}
+
+func TestValidPlayIndices_NoneAndAll(t *testing.T) {
+	hand := &fakeHand{cards: []*Card{NewCard(1, 2, false), NewCard(1, 3, false)}}
+
+	assert.Empty(t, validPlayIndices(hand, func(*Card) bool { return false }))
+	assert.Equal(t, []int{0, 1}, validPlayIndices(hand, func(*Card) bool { return true }))
+	assert.Empty(t, validPlayIndices(&fakeHand{}, func(*Card) bool { return true }), "empty hand")
+}
+
+// The predicate must see each card, not just the first -- a helper that passed
+// the same card every time would still return a plausible-looking slice.
+func TestValidPlayIndices_PredicateSeesEveryCard(t *testing.T) {
+	hand := &fakeHand{cards: []*Card{NewCard(1, 4, false), NewCard(2, 5, false), NewCard(3, 6, false)}}
+
+	var seen []int
+	validPlayIndices(hand, func(c *Card) bool {
+		seen = append(seen, c.GetValue())
+		return true
+	})
+	assert.Equal(t, []int{4, 5, 6}, seen)
+}

--- a/internal/domain/slice_helpers.go
+++ b/internal/domain/slice_helpers.go
@@ -30,3 +30,16 @@ func sliceOrEmpty[T any](s []T) []T {
 	}
 	return s
 }
+
+// discardTop returns the card most recently added to a discard pile, or nil
+// when the pile is empty.
+//
+// 22 games had this written out. Like indexOfPlayerInTrick it needs no type
+// parameter -- every discard pile is a []*Card -- so it adds no monomorphised
+// copies. See issue #5185.
+func discardTop(pile []*Card) *Card {
+	if len(pile) == 0 {
+		return nil
+	}
+	return pile[len(pile)-1]
+}


### PR DESCRIPTION
#5185 の残りクラスタ、その3。

| クラスタ | 件数 | 削減 | 方式 |
|---|---:|---:|---|
| `GetDiscardTop` | 22 | -66 | **非ジェネリック**の自由関数 |
| `getValidPlayIndices` | 46 | -138 | ジェネリック（**既存の `handReader` を再利用**） |
| **合計** | **68** | **-204行** | |

## 方式の選び方

`GetDiscardTop` は22ゲームすべてが `discardPile []*Card` を持ち、戻り値も `*Card` という**共有型だけ**なので、#5209 の `indexOfPlayerInTrick` と同じく**型パラメータ不要**にできました（#5209 は -1,793 バイト）。

`getValidPlayIndices` はジェネリックが必要ですが、**#5208 で入れた `handReader` を再利用**しており、新しい制約は足していません。述語の形が2種類あります。

- 41件: `validatePlay(playerIdx, card) == nil`
- 5件: `isValidPlay(card)`

共通しているのは「席を取り出して `collectValidIndices` に手札を引き直すクロージャを渡す」足場の部分なので、そこだけを共通化し、**違う部分（述語）は引数で渡し**ています。

## レシーバのシャドウイング

レシーバが `c` のゲームでは、クロージャ引数を `c *Card` にすると**レシーバを隠して `c.validatePlay` が解決できなくなります**。該当は CourtPiece の1件で、そこだけ引数名を `card` にしています。

最初これを踏んでコンパイルエラーになりました。**9ゲームは自前の本体を維持**（どちらの形にも当てはまらない）、`GetDiscardTop` 側も **5ゲームは維持**（AcesUp / Desmoche / Loba / Trash / Yaniv は素の末尾参照ではない）です。置換はファイル単位で全か無かです。

## 検証

- `go test -tags test ./...` 全パッケージ通過
- `golangci-lint run ./internal/...` 0 issues
- ヘルパは各クラスタとも call-site 書き換えの**前**に別コミット（`81f0415` / `e0d5490`）

`getValidPlayIndices` は単相化コピーが増える側なので、Worker サイズは CI 実測後に報告します。#5209 で extra3 に 1,146 バイトの余裕ができているぶんの範囲内に収まる見込みですが、予測では済ませません。

Refs #5185