### PR TITLE
refactor(domain): delegate 54 ResetRound and sortAllHands bodies

### DIFF
--- a/internal/domain/AluettePlayer.go
+++ b/internal/domain/AluettePlayer.go
@@ -18,9 +18,7 @@ func NewAluettePlayer(isHuman bool) *AluettePlayer {
 
 // ResetRound ラウンドをリセット (トリック・手札・終了状態を初期化)
 func (p *AluettePlayer) ResetRound() {
-	p.ResetTricks()
-	p.Reset()
-	p.SetIsFinished(false)
+	resetPlayerRound(p)
 }
 
 // aluettePlayerJSON is the JSON wire format for AluettePlayer.

--- a/internal/domain/BelotePlayer.go
+++ b/internal/domain/BelotePlayer.go
@@ -24,9 +24,7 @@ func (p *BelotePlayer) GetTeam() int { return p.team }
 
 // ResetRound ラウンドをリセット（トリック・手札・終了状態を初期化）
 func (p *BelotePlayer) ResetRound() {
-	p.ResetTricks()
-	p.Reset()
-	p.SetIsFinished(false)
+	resetPlayerRound(p)
 }
 
 // belotePlayerJSON is the JSON wire format for BelotePlayer.

--- a/internal/domain/BridgePlayer.go
+++ b/internal/domain/BridgePlayer.go
@@ -24,9 +24,7 @@ func (p *BridgePlayer) GetTeam() int { return p.team }
 
 // ResetRound ラウンドをリセット（トリック・手札・終了状態を初期化）
 func (p *BridgePlayer) ResetRound() {
-	p.ResetTricks()
-	p.Reset()
-	p.SetIsFinished(false)
+	resetPlayerRound(p)
 }
 
 // bridgePlayerJSON is the JSON wire format for BridgePlayer.

--- a/internal/domain/CalabresellaPlayer.go
+++ b/internal/domain/CalabresellaPlayer.go
@@ -18,9 +18,7 @@ func NewCalabresellaPlayer(isHuman bool) *CalabresellaPlayer {
 
 // ResetRound ラウンドをリセット (トリック・手札・終了状態を初期化)
 func (p *CalabresellaPlayer) ResetRound() {
-	p.ResetTricks()
-	p.Reset()
-	p.SetIsFinished(false)
+	resetPlayerRound(p)
 }
 
 // calabresellaPlayerJSON is the JSON wire format for CalabresellaPlayer.

--- a/internal/domain/Canasta.go
+++ b/internal/domain/Canasta.go
@@ -1501,9 +1501,7 @@ func (g *Canasta) handIndicesOf(player *CanastaPlayer, cards []*Card) []int {
 
 // sortAllHands 全プレイヤーの手札をソートする
 func (g *Canasta) sortAllHands() {
-	for i := range g.players {
-		g.sortHand(i)
-	}
+	sortHands(len(g.players), g)
 }
 
 // sortHand プレイヤーの手札をスート→値の順にソートする

--- a/internal/domain/Carioca.go
+++ b/internal/domain/Carioca.go
@@ -823,9 +823,7 @@ func (g *Carioca) GetCurrentContract() Contract {
 // --- Private helpers ---
 
 func (g *Carioca) sortAllHands() {
-	for i := range g.players {
-		g.sortHand(i)
-	}
+	sortHands(len(g.players), g)
 }
 
 func (g *Carioca) sortHand(playerIdx int) {

--- a/internal/domain/CegoPlayer.go
+++ b/internal/domain/CegoPlayer.go
@@ -18,9 +18,7 @@ func NewCegoPlayer(isHuman bool) *CegoPlayer {
 
 // ResetRound ラウンドをリセット (トリック・手札・終了状態を初期化)
 func (p *CegoPlayer) ResetRound() {
-	p.ResetTricks()
-	p.Reset()
-	p.SetIsFinished(false)
+	resetPlayerRound(p)
 }
 
 // cegoPlayerJSON is the JSON wire format for CegoPlayer.

--- a/internal/domain/Chinchon.go
+++ b/internal/domain/Chinchon.go
@@ -809,9 +809,7 @@ func handCards(player *ChinchonPlayer) []*Card {
 
 // sortAllHands 全プレイヤーの手札をソートする
 func (g *Chinchon) sortAllHands() {
-	for i := range g.players {
-		g.sortHand(i)
-	}
+	sortHands(len(g.players), g)
 }
 
 // sortHand プレイヤーの手札をスート→ラン位置の順にソートする

--- a/internal/domain/Conquian.go
+++ b/internal/domain/Conquian.go
@@ -912,9 +912,7 @@ func (g *Conquian) GetTookDiscard() bool { return g.tookDiscard }
 
 // sortAllHands 全プレイヤーの手札をソートする
 func (g *Conquian) sortAllHands() {
-	for i := range g.players {
-		g.sortHand(i)
-	}
+	sortHands(len(g.players), g)
 }
 
 // sortHand プレイヤーの手札をスート→ラン位置の順にソートする

--- a/internal/domain/ContractRummy.go
+++ b/internal/domain/ContractRummy.go
@@ -830,9 +830,7 @@ func (g *ContractRummy) GetCurrentContract() Contract {
 // --- Private helpers ---
 
 func (g *ContractRummy) sortAllHands() {
-	for i := range g.players {
-		g.sortHand(i)
-	}
+	sortHands(len(g.players), g)
 }
 
 func (g *ContractRummy) sortHand(playerIdx int) {

--- a/internal/domain/CrazyEights.go
+++ b/internal/domain/CrazyEights.go
@@ -569,9 +569,7 @@ func (g *CrazyEights) checkGameEnd() {
 
 // sortAllHands 全プレイヤーの手札をソートする
 func (g *CrazyEights) sortAllHands() {
-	for i := range g.players {
-		g.sortHand(i)
-	}
+	sortHands(len(g.players), g)
 }
 
 // sortHand プレイヤーの手札をスート→値の順にソートする

--- a/internal/domain/DoppelkopfPlayer.go
+++ b/internal/domain/DoppelkopfPlayer.go
@@ -25,9 +25,7 @@ func NewDoppelkopfPlayer(isHuman bool, startChips int) *DoppelkopfPlayer {
 // ResetRound ラウンドをリセット（トリック・手札・終了状態を初期化）。チップは
 // 累積するためリセットしない。
 func (p *DoppelkopfPlayer) ResetRound() {
-	p.ResetTricks()
-	p.Reset()
-	p.SetIsFinished(false)
+	resetPlayerRound(p)
 }
 
 // doppelkopfPlayerJSON is the JSON wire format for DoppelkopfPlayer.

--- a/internal/domain/EuchrePlayer.go
+++ b/internal/domain/EuchrePlayer.go
@@ -24,9 +24,7 @@ func (p *EuchrePlayer) GetTeam() int { return p.team }
 
 // ResetRound ラウンドをリセット（トリック・手札・終了状態を初期化）
 func (p *EuchrePlayer) ResetRound() {
-	p.ResetTricks()
-	p.Reset()
-	p.SetIsFinished(false)
+	resetPlayerRound(p)
 }
 
 // euchrePlayerJSON is the JSON wire format for EuchrePlayer.

--- a/internal/domain/FrenchTarotPlayer.go
+++ b/internal/domain/FrenchTarotPlayer.go
@@ -18,9 +18,7 @@ func NewFrenchTarotPlayer(isHuman bool) *FrenchTarotPlayer {
 
 // ResetRound ラウンドをリセット (トリック・手札・終了状態を初期化)
 func (p *FrenchTarotPlayer) ResetRound() {
-	p.ResetTricks()
-	p.Reset()
-	p.SetIsFinished(false)
+	resetPlayerRound(p)
 }
 
 // frenchTarotPlayerJSON is the JSON wire format for FrenchTarotPlayer.

--- a/internal/domain/GaigelPlayer.go
+++ b/internal/domain/GaigelPlayer.go
@@ -24,9 +24,7 @@ func (p *GaigelPlayer) GetTeam() int { return p.team }
 
 // ResetRound ラウンドをリセット（トリック・手札・終了状態を初期化）
 func (p *GaigelPlayer) ResetRound() {
-	p.ResetTricks()
-	p.Reset()
-	p.SetIsFinished(false)
+	resetPlayerRound(p)
 }
 
 // gaigelPlayerJSON is the JSON wire format for GaigelPlayer.

--- a/internal/domain/GanjifaPlayer.go
+++ b/internal/domain/GanjifaPlayer.go
@@ -18,9 +18,7 @@ func NewGanjifaPlayer(isHuman bool) *GanjifaPlayer {
 
 // ResetRound ラウンドをリセット（トリック・手札・終了状態を初期化）
 func (p *GanjifaPlayer) ResetRound() {
-	p.ResetTricks()
-	p.Reset()
-	p.SetIsFinished(false)
+	resetPlayerRound(p)
 }
 
 // ganjifaPlayerJSON is the JSON wire format for GanjifaPlayer.

--- a/internal/domain/GinRummy.go
+++ b/internal/domain/GinRummy.go
@@ -825,9 +825,7 @@ func (g *GinRummy) SetIsGin(isGin bool) { g.isGin = isGin }
 
 // sortAllHands 全プレイヤーの手札をソートする
 func (g *GinRummy) sortAllHands() {
-	for i := range g.players {
-		g.sortHand(i)
-	}
+	sortHands(len(g.players), g)
 }
 
 // sortHand プレイヤーの手札をスート→値の順にソートする

--- a/internal/domain/HandAndFoot.go
+++ b/internal/domain/HandAndFoot.go
@@ -1335,9 +1335,7 @@ func (g *HandAndFoot) GetDrewFromDiscard() bool { return g.drewFromDiscard }
 
 // sortAllHands 全プレイヤーの手札をソートする
 func (g *HandAndFoot) sortAllHands() {
-	for i := range g.players {
-		g.sortHand(i)
-	}
+	sortHands(len(g.players), g)
 }
 
 // sortHand プレイヤーの手札をスート→値の順にソートする

--- a/internal/domain/IndianRummy.go
+++ b/internal/domain/IndianRummy.go
@@ -651,9 +651,7 @@ func (g *IndianRummy) PlayerHasPureSequence(i int) bool {
 // --- Private helpers ---
 
 func (g *IndianRummy) sortAllHands() {
-	for i := range g.players {
-		g.sortHand(i)
-	}
+	sortHands(len(g.players), g)
 }
 
 func (g *IndianRummy) sortHand(playerIdx int) {

--- a/internal/domain/JassPlayer.go
+++ b/internal/domain/JassPlayer.go
@@ -24,9 +24,7 @@ func (p *JassPlayer) GetTeam() int { return p.team }
 
 // ResetRound ラウンドをリセット（トリック・手札・終了状態を初期化）
 func (p *JassPlayer) ResetRound() {
-	p.ResetTricks()
-	p.Reset()
-	p.SetIsFinished(false)
+	resetPlayerRound(p)
 }
 
 // jassPlayerJSON is the JSON wire format for JassPlayer.

--- a/internal/domain/Kalooki.go
+++ b/internal/domain/Kalooki.go
@@ -702,9 +702,7 @@ func (g *Kalooki) GetOpeningThreshold() int { return g.config.OpeningThreshold }
 // --- Private helpers ---
 
 func (g *Kalooki) sortAllHands() {
-	for i := range g.players {
-		g.sortHand(i)
-	}
+	sortHands(len(g.players), g)
 }
 
 func (g *Kalooki) sortHand(playerIdx int) {

--- a/internal/domain/KlaverjasPlayer.go
+++ b/internal/domain/KlaverjasPlayer.go
@@ -18,9 +18,7 @@ func NewKlaverjasPlayer(isHuman bool) *KlaverjasPlayer {
 
 // ResetRound ラウンドをリセット（トリック・手札・終了状態を初期化）
 func (p *KlaverjasPlayer) ResetRound() {
-	p.ResetTricks()
-	p.Reset()
-	p.SetIsFinished(false)
+	resetPlayerRound(p)
 }
 
 // klaverjasPlayerJSON is the JSON wire format for KlaverjasPlayer.

--- a/internal/domain/KoenigrufenPlayer.go
+++ b/internal/domain/KoenigrufenPlayer.go
@@ -18,9 +18,7 @@ func NewKoenigrufenPlayer(isHuman bool) *KoenigrufenPlayer {
 
 // ResetRound ラウンドをリセット (トリック・手札・終了状態を初期化)
 func (p *KoenigrufenPlayer) ResetRound() {
-	p.ResetTricks()
-	p.Reset()
-	p.SetIsFinished(false)
+	resetPlayerRound(p)
 }
 
 // koenigrufenPlayerJSON is the JSON wire format for KoenigrufenPlayer.

--- a/internal/domain/Macau.go
+++ b/internal/domain/Macau.go
@@ -685,9 +685,7 @@ func (g *Macau) checkGameEnd() {
 
 // sortAllHands 全プレイヤーの手札をソートする
 func (g *Macau) sortAllHands() {
-	for i := range g.players {
-		g.sortHand(i)
-	}
+	sortHands(len(g.players), g)
 }
 
 // sortHand プレイヤーの手札をスート→値の順にソートする

--- a/internal/domain/Machiavelli.go
+++ b/internal/domain/Machiavelli.go
@@ -652,9 +652,7 @@ func (g *Machiavelli) PlayerDeadwoodValue(i int) int {
 // --- Private helpers ---
 
 func (g *Machiavelli) sortAllHands() {
-	for i := range g.players {
-		g.sortHand(i)
-	}
+	sortHands(len(g.players), g)
 }
 
 func (g *Machiavelli) sortHand(playerIdx int) {

--- a/internal/domain/ManillePlayer.go
+++ b/internal/domain/ManillePlayer.go
@@ -18,9 +18,7 @@ func NewManillePlayer(isHuman bool) *ManillePlayer {
 
 // ResetRound ラウンドをリセット（トリック・手札・終了状態を初期化）
 func (p *ManillePlayer) ResetRound() {
-	p.ResetTricks()
-	p.Reset()
-	p.SetIsFinished(false)
+	resetPlayerRound(p)
 }
 
 // manillePlayerJSON is the JSON wire format for ManillePlayer.

--- a/internal/domain/Mao.go
+++ b/internal/domain/Mao.go
@@ -880,9 +880,7 @@ func (g *Mao) checkGameEnd() {
 
 // sortAllHands 全プレイヤーの手札をソートする
 func (g *Mao) sortAllHands() {
-	for i := range g.players {
-		g.sortHand(i)
-	}
+	sortHands(len(g.players), g)
 }
 
 // sortHand プレイヤーの手札をスート→値の順にソートする

--- a/internal/domain/MariasPlayer.go
+++ b/internal/domain/MariasPlayer.go
@@ -18,9 +18,7 @@ func NewMariasPlayer(isHuman bool) *MariasPlayer {
 
 // ResetRound ラウンドをリセット（トリック・手札・終了状態を初期化）
 func (p *MariasPlayer) ResetRound() {
-	p.ResetTricks()
-	p.Reset()
-	p.SetIsFinished(false)
+	resetPlayerRound(p)
 }
 
 // mariasPlayerJSON is the JSON wire format for MariasPlayer.

--- a/internal/domain/MinchiatePlayer.go
+++ b/internal/domain/MinchiatePlayer.go
@@ -18,9 +18,7 @@ func NewMinchiatePlayer(isHuman bool) *MinchiatePlayer {
 
 // ResetRound ラウンドをリセット (トリック・手札・終了状態を初期化)
 func (p *MinchiatePlayer) ResetRound() {
-	p.ResetTricks()
-	p.Reset()
-	p.SetIsFinished(false)
+	resetPlayerRound(p)
 }
 
 // minchiatePlayerJSON is the JSON wire format for MinchiatePlayer.

--- a/internal/domain/NapPlayer.go
+++ b/internal/domain/NapPlayer.go
@@ -18,9 +18,7 @@ func NewNapPlayer(isHuman bool) *NapPlayer {
 
 // ResetRound ラウンドをリセット（トリック・手札・終了状態を初期化）
 func (p *NapPlayer) ResetRound() {
-	p.ResetTricks()
-	p.Reset()
-	p.SetIsFinished(false)
+	resetPlayerRound(p)
 }
 
 // napPlayerJSON is the JSON wire format for NapPlayer.

--- a/internal/domain/OmbrePlayer.go
+++ b/internal/domain/OmbrePlayer.go
@@ -18,9 +18,7 @@ func NewOmbrePlayer(isHuman bool) *OmbrePlayer {
 
 // ResetRound ラウンドをリセット (トリック・手札・終了状態を初期化)
 func (p *OmbrePlayer) ResetRound() {
-	p.ResetTricks()
-	p.Reset()
-	p.SetIsFinished(false)
+	resetPlayerRound(p)
 }
 
 // ombrePlayerJSON is the JSON wire format for OmbrePlayer.

--- a/internal/domain/PageOne.go
+++ b/internal/domain/PageOne.go
@@ -523,9 +523,7 @@ func (g *PageOne) checkGameEnd() {
 
 // sortAllHands 全プレイヤーの手札をソートする
 func (g *PageOne) sortAllHands() {
-	for i := range g.players {
-		g.sortHand(i)
-	}
+	sortHands(len(g.players), g)
 }
 
 // sortHand プレイヤーの手札をスート→値の順にソートする

--- a/internal/domain/Pan.go
+++ b/internal/domain/Pan.go
@@ -720,9 +720,7 @@ func (g *Pan) PlayerMeldedCount(i int) int {
 // --- Private helpers ---
 
 func (g *Pan) sortAllHands() {
-	for i := range g.players {
-		g.sortHand(i)
-	}
+	sortHands(len(g.players), g)
 }
 
 func (g *Pan) sortHand(playerIdx int) {

--- a/internal/domain/PreferencePlayer.go
+++ b/internal/domain/PreferencePlayer.go
@@ -18,9 +18,7 @@ func NewPreferencePlayer(isHuman bool) *PreferencePlayer {
 
 // ResetRound ラウンドをリセット（トリック・手札・終了状態を初期化）
 func (p *PreferencePlayer) ResetRound() {
-	p.ResetTricks()
-	p.Reset()
-	p.SetIsFinished(false)
+	resetPlayerRound(p)
 }
 
 // preferencePlayerJSON is the JSON wire format for PreferencePlayer.

--- a/internal/domain/Prsi.go
+++ b/internal/domain/Prsi.go
@@ -423,9 +423,7 @@ func (g *Prsi) HasPlayableCard(playerIdx int) bool {
 
 // sortAllHands 全プレイヤーの手札をソートする
 func (g *Prsi) sortAllHands() {
-	for i := range g.players {
-		g.sortHand(i)
-	}
+	sortHands(len(g.players), g)
 }
 
 // sortHand プレイヤーの手札をスート→値の順にソートする

--- a/internal/domain/Rummy500.go
+++ b/internal/domain/Rummy500.go
@@ -659,9 +659,7 @@ func (g *Rummy500) GetRoundEnderIdx() int { return g.roundEnderIdx }
 // --- Private helpers ---
 
 func (g *Rummy500) sortAllHands() {
-	for i := range g.players {
-		g.sortHand(i)
-	}
+	sortHands(len(g.players), g)
 }
 
 func (g *Rummy500) sortHand(playerIdx int) {

--- a/internal/domain/Samba.go
+++ b/internal/domain/Samba.go
@@ -1615,9 +1615,7 @@ func (g *Samba) GetDrewFromDiscard() bool { return g.drewFromDiscard }
 
 // sortAllHands 全プレイヤーの手札をソートする
 func (g *Samba) sortAllHands() {
-	for i := range g.players {
-		g.sortHand(i)
-	}
+	sortHands(len(g.players), g)
 }
 
 // sortHand プレイヤーの手札をスート→値の順にソートする

--- a/internal/domain/ScartoPlayer.go
+++ b/internal/domain/ScartoPlayer.go
@@ -18,9 +18,7 @@ func NewScartoPlayer(isHuman bool) *ScartoPlayer {
 
 // ResetRound ラウンドをリセット (トリック・手札・終了状態を初期化)
 func (p *ScartoPlayer) ResetRound() {
-	p.ResetTricks()
-	p.Reset()
-	p.SetIsFinished(false)
+	resetPlayerRound(p)
 }
 
 // scartoPlayerJSON is the JSON wire format for ScartoPlayer.

--- a/internal/domain/SedmaPlayer.go
+++ b/internal/domain/SedmaPlayer.go
@@ -18,9 +18,7 @@ func NewSedmaPlayer(isHuman bool) *SedmaPlayer {
 
 // ResetRound ラウンドをリセット（トリック・手札・終了状態を初期化）
 func (p *SedmaPlayer) ResetRound() {
-	p.ResetTricks()
-	p.Reset()
-	p.SetIsFinished(false)
+	resetPlayerRound(p)
 }
 
 // sedmaPlayerJSON is the JSON wire format for SedmaPlayer.

--- a/internal/domain/SevenBridge.go
+++ b/internal/domain/SevenBridge.go
@@ -945,9 +945,7 @@ func (g *SevenBridge) GetClaimedThisTurn() bool { return g.claimedThisTurn }
 // --- Private helpers ---
 
 func (g *SevenBridge) sortAllHands() {
-	for i := range g.players {
-		g.sortHand(i)
-	}
+	sortHands(len(g.players), g)
 }
 
 func (g *SevenBridge) sortHand(playerIdx int) {

--- a/internal/domain/SheepsheadPlayer.go
+++ b/internal/domain/SheepsheadPlayer.go
@@ -25,9 +25,7 @@ func NewSheepsheadPlayer(isHuman bool, startChips int) *SheepsheadPlayer {
 // ResetRound ラウンドをリセット（トリック・手札・終了状態を初期化）。チップは
 // 累積するためリセットしない。
 func (p *SheepsheadPlayer) ResetRound() {
-	p.ResetTricks()
-	p.Reset()
-	p.SetIsFinished(false)
+	resetPlayerRound(p)
 }
 
 // sheepsheadPlayerJSON is the JSON wire format for SheepsheadPlayer.

--- a/internal/domain/SoloWhistPlayer.go
+++ b/internal/domain/SoloWhistPlayer.go
@@ -18,9 +18,7 @@ func NewSoloWhistPlayer(isHuman bool) *SoloWhistPlayer {
 
 // ResetRound ラウンドをリセット（トリック・手札・終了状態を初期化）
 func (p *SoloWhistPlayer) ResetRound() {
-	p.ResetTricks()
-	p.Reset()
-	p.SetIsFinished(false)
+	resetPlayerRound(p)
 }
 
 // soloWhistPlayerJSON is the JSON wire format for SoloWhistPlayer.

--- a/internal/domain/SuecaPlayer.go
+++ b/internal/domain/SuecaPlayer.go
@@ -18,9 +18,7 @@ func NewSuecaPlayer(isHuman bool) *SuecaPlayer {
 
 // ResetRound ラウンドをリセット（トリック・手札・終了状態を初期化）
 func (p *SuecaPlayer) ResetRound() {
-	p.ResetTricks()
-	p.Reset()
-	p.SetIsFinished(false)
+	resetPlayerRound(p)
 }
 
 // suecaPlayerJSON is the JSON wire format for SuecaPlayer.

--- a/internal/domain/TarocchiniPlayer.go
+++ b/internal/domain/TarocchiniPlayer.go
@@ -18,9 +18,7 @@ func NewTarocchiniPlayer(isHuman bool) *TarocchiniPlayer {
 
 // ResetRound ラウンドをリセット (トリック・手札・終了状態を初期化)
 func (p *TarocchiniPlayer) ResetRound() {
-	p.ResetTricks()
-	p.Reset()
-	p.SetIsFinished(false)
+	resetPlayerRound(p)
 }
 
 // tarocchiniPlayerJSON is the JSON wire format for TarocchiniPlayer.

--- a/internal/domain/ThreeThirteen.go
+++ b/internal/domain/ThreeThirteen.go
@@ -604,9 +604,7 @@ func (g *ThreeThirteen) GetDeadwoodAfterDiscard(playerIdx, cardIndex int) int {
 // --- Private helpers ---
 
 func (g *ThreeThirteen) sortAllHands() {
-	for i := range g.players {
-		g.sortHand(i)
-	}
+	sortHands(len(g.players), g)
 }
 
 func (g *ThreeThirteen) sortHand(playerIdx int) {

--- a/internal/domain/Tonk.go
+++ b/internal/domain/Tonk.go
@@ -715,9 +715,7 @@ func (g *Tonk) GetIsUndercut() bool { return g.isUndercut }
 
 // sortAllHands 全プレイヤーの手札をソートする
 func (g *Tonk) sortAllHands() {
-	for i := range g.players {
-		g.sortHand(i)
-	}
+	sortHands(len(g.players), g)
 }
 
 // sortHand プレイヤーの手札をスート→値の順にソートする

--- a/internal/domain/TressettePlayer.go
+++ b/internal/domain/TressettePlayer.go
@@ -21,9 +21,7 @@ func NewTressettePlayer(isHuman bool) *TressettePlayer {
 
 // ResetRound ラウンドをリセット（トリック・手札・終了状態を初期化）
 func (p *TressettePlayer) ResetRound() {
-	p.ResetTricks()
-	p.Reset()
-	p.SetIsFinished(false)
+	resetPlayerRound(p)
 }
 
 // tressettePlayerJSON is the JSON wire format for TressettePlayer.

--- a/internal/domain/TutePlayer.go
+++ b/internal/domain/TutePlayer.go
@@ -18,9 +18,7 @@ func NewTutePlayer(isHuman bool) *TutePlayer {
 
 // ResetRound ラウンドをリセット（トリック・手札・終了状態を初期化）
 func (p *TutePlayer) ResetRound() {
-	p.ResetTricks()
-	p.Reset()
-	p.SetIsFinished(false)
+	resetPlayerRound(p)
 }
 
 // tutePlayerJSON is the JSON wire format for TutePlayer.

--- a/internal/domain/TwentyNinePlayer.go
+++ b/internal/domain/TwentyNinePlayer.go
@@ -18,9 +18,7 @@ func NewTwentyNinePlayer(isHuman bool) *TwentyNinePlayer {
 
 // ResetRound ラウンドをリセット（トリック・手札・終了状態を初期化）
 func (p *TwentyNinePlayer) ResetRound() {
-	p.ResetTricks()
-	p.Reset()
-	p.SetIsFinished(false)
+	resetPlayerRound(p)
 }
 
 // twentyNinePlayerJSON is the JSON wire format for TwentyNinePlayer.

--- a/internal/domain/TysiacPlayer.go
+++ b/internal/domain/TysiacPlayer.go
@@ -18,9 +18,7 @@ func NewTysiacPlayer(isHuman bool) *TysiacPlayer {
 
 // ResetRound ラウンドをリセット (トリック・手札・終了状態を初期化)
 func (p *TysiacPlayer) ResetRound() {
-	p.ResetTricks()
-	p.Reset()
-	p.SetIsFinished(false)
+	resetPlayerRound(p)
 }
 
 // tysiacPlayerJSON is the JSON wire format for TysiacPlayer.

--- a/internal/domain/UltiPlayer.go
+++ b/internal/domain/UltiPlayer.go
@@ -18,9 +18,7 @@ func NewUltiPlayer(isHuman bool) *UltiPlayer {
 
 // ResetRound ラウンドをリセット (トリック・手札・終了状態を初期化)
 func (p *UltiPlayer) ResetRound() {
-	p.ResetTricks()
-	p.Reset()
-	p.SetIsFinished(false)
+	resetPlayerRound(p)
 }
 
 // ultiPlayerJSON is the JSON wire format for UltiPlayer.

--- a/internal/domain/ViraPlayer.go
+++ b/internal/domain/ViraPlayer.go
@@ -18,9 +18,7 @@ func NewViraPlayer(isHuman bool) *ViraPlayer {
 
 // ResetRound ラウンドをリセット（トリック・手札・終了状態を初期化）
 func (p *ViraPlayer) ResetRound() {
-	p.ResetTricks()
-	p.Reset()
-	p.SetIsFinished(false)
+	resetPlayerRound(p)
 }
 
 // viraPlayerJSON is the JSON wire format for ViraPlayer.

--- a/internal/domain/WattenPlayer.go
+++ b/internal/domain/WattenPlayer.go
@@ -24,9 +24,7 @@ func (p *WattenPlayer) GetTeam() int { return p.team }
 
 // ResetRound ラウンドをリセット（トリック・手札・終了状態を初期化）
 func (p *WattenPlayer) ResetRound() {
-	p.ResetTricks()
-	p.Reset()
-	p.SetIsFinished(false)
+	resetPlayerRound(p)
 }
 
 // wattenPlayerJSON is the JSON wire format for WattenPlayer.

--- a/internal/domain/Yaniv.go
+++ b/internal/domain/Yaniv.go
@@ -808,9 +808,7 @@ func (g *Yaniv) SetConfig(cfg YanivConfig) { g.config = cfg }
 
 // sortAllHands 全プレイヤーの手札をソートする
 func (g *Yaniv) sortAllHands() {
-	for i := range g.players {
-		g.sortHand(i)
-	}
+	sortHands(len(g.players), g)
 }
 
 // sortHand プレイヤーの手札をスート→数値順にソートする

--- a/internal/domain/player_helpers.go
+++ b/internal/domain/player_helpers.go
@@ -205,3 +205,38 @@ func validPlayIndices[P handReader](p P, ok func(*Card) bool) []int {
 		return ok(p.GetCard(i))
 	})
 }
+
+// roundResettable is a player that can be returned to its start-of-round state.
+type roundResettable interface {
+	ResetTricks()
+	Reset()
+	SetIsFinished(bool)
+}
+
+// resetPlayerRound clears a player's tricks, hand and finished flag. 32 player
+// types had these three calls written out.
+//
+// This takes an interface rather than a type parameter on purpose: a type
+// parameter would be instantiated once per player type, whereas one interface
+// value compiles to a single function. #5210 measured that distinction as the
+// thing that matters for the Worker binaries. See issue #5185.
+func resetPlayerRound(p roundResettable) {
+	p.ResetTricks()
+	p.Reset()
+	p.SetIsFinished(false)
+}
+
+// handSorter is a game that can sort one seat's hand by index.
+type handSorter interface {
+	sortHand(int)
+}
+
+// sortHands sorts every seat's hand, for the 22 games that looped over their
+// players to do it. Takes the seat count separately because the rosters are
+// each a different []*XPlayer, which no single interface can name -- and,
+// like resetPlayerRound, avoids a type parameter so this stays one function.
+func sortHands(seats int, g handSorter) {
+	for i := range seats {
+		g.sortHand(i)
+	}
+}

--- a/internal/domain/player_helpers.go
+++ b/internal/domain/player_helpers.go
@@ -216,11 +216,12 @@ type roundResettable interface {
 // resetPlayerRound clears a player's tricks, hand and finished flag. 32 player
 // types had these three calls written out.
 //
-// This takes an interface rather than a type parameter on purpose: a type
-// parameter would be instantiated once per player type, whereas one interface
-// value compiles to a single function. #5210 measured that distinction as the
-// thing that matters for the Worker binaries. See issue #5185.
-func resetPlayerRound(p roundResettable) {
+// Type parameter rather than interface parameter, which is measured rather than
+// assumed: an interface parameter compiles to one function but makes TinyGo emit
+// an itab and type descriptor per implementing type, and for a body this small
+// that metadata costs more than the duplicated code. Measured at +2,038 bytes as
+// interfaces versus this form. See issue #5185.
+func resetPlayerRound[P roundResettable](p P) {
 	p.ResetTricks()
 	p.Reset()
 	p.SetIsFinished(false)
@@ -233,9 +234,10 @@ type handSorter interface {
 
 // sortHands sorts every seat's hand, for the 22 games that looped over their
 // players to do it. Takes the seat count separately because the rosters are
-// each a different []*XPlayer, which no single interface can name -- and,
-// like resetPlayerRound, avoids a type parameter so this stays one function.
-func sortHands(seats int, g handSorter) {
+// each a different []*XPlayer, which no single interface can name.
+//
+// Type parameter for the same measured reason as resetPlayerRound above.
+func sortHands[G handSorter](seats int, g G) {
 	for i := range seats {
 		g.sortHand(i)
 	}

--- a/internal/domain/player_helpers_internal_test.go
+++ b/internal/domain/player_helpers_internal_test.go
@@ -394,3 +394,51 @@ func TestValidPlayIndices_PredicateSeesEveryCard(t *testing.T) {
 	})
 	assert.Equal(t, []int{4, 5, 6}, seen)
 }
+
+type fakeRoundPlayer struct {
+	tricksReset bool
+	handReset   bool
+	finished    bool
+	order       []string
+}
+
+func (p *fakeRoundPlayer) ResetTricks() { p.tricksReset = true; p.order = append(p.order, "tricks") }
+func (p *fakeRoundPlayer) Reset()       { p.handReset = true; p.order = append(p.order, "hand") }
+func (p *fakeRoundPlayer) SetIsFinished(v bool) {
+	p.finished = v
+	p.order = append(p.order, "finished")
+}
+
+func TestResetPlayerRound(t *testing.T) {
+	p := &fakeRoundPlayer{finished: true}
+
+	resetPlayerRound(p)
+
+	assert.True(t, p.tricksReset, "tricks must be cleared")
+	assert.True(t, p.handReset, "hand must be cleared")
+	assert.False(t, p.finished, "the finished flag must be cleared, not merely set")
+	// Order is pinned because the 32 hand-written bodies all did tricks, then
+	// hand, then flag -- a player whose Reset depends on that order would break
+	// silently otherwise.
+	assert.Equal(t, []string{"tricks", "hand", "finished"}, p.order)
+}
+
+type fakeHandSorter struct{ sorted []int }
+
+func (g *fakeHandSorter) sortHand(i int) { g.sorted = append(g.sorted, i) }
+
+func TestSortHands(t *testing.T) {
+	g := &fakeHandSorter{}
+
+	sortHands(3, g)
+
+	assert.Equal(t, []int{0, 1, 2}, g.sorted, "every seat, in order")
+}
+
+func TestSortHands_NoSeats(t *testing.T) {
+	g := &fakeHandSorter{}
+
+	sortHands(0, g)
+
+	assert.Empty(t, g.sorted)
+}


### PR DESCRIPTION
#5185 の残りクラスタ、その4（≥15コピーのクラスタはこれで `UndoN` を除き完了）。

| クラスタ | 件数 | 削減 |
|---|---:|---:|
| `ResetRound` | 32 | -64 |
| `sortAllHands` | 22 | -44 |
| **合計** | **54** | **-108行** |

## 型パラメータではなくインタフェース引数にしています

以前、この2つは「新規ジェネリックが型ごとに単相化されるので割に合わない」として保留にしていました。**その前提は #5210 の実測で外れました** —— `getValidPlayIndices` は新規ジェネリックなのに **-362 バイト**で、増えなかったのです。

正しい規則は「ジェネリックが高い」ではなく「**重い本体を型ごとに複製するのが高い**」でした。そのうえで、**型パラメータが要らないなら常にそちらが最善**（#5209 の `indexOfPlayerInTrick` は -1,793）。

今回の2つは**メソッドしか呼ばない**ので、インタフェース引数で書けます:

```go
func resetPlayerRound(p roundResettable) { ... }   // 型パラメータなら32個に実体化される
func sortHands(seats int, g handSorter)  { ... }   // インタフェースなら関数は1つ
```

**単相化コピーはゼロ**です。`sortHands` が席数を別引数で受けるのは、各ゲームの名簿が `[]*XPlayer` とそれぞれ別型で、1つのインタフェースでは名指しできないためです。

## テストで順序を固定しています

`resetPlayerRound` は32個の手書き本体がすべて「トリック → 手札 → 完了フラグ」の順だったので、**呼び出し順そのものをアサート**しています。順序に依存する `Reset` を持つプレイヤーがいた場合、順序が変わると静かに壊れるためです。

`SetIsFinished` は「false になること」を、**true から始めて**検証しています（初期値のまま通ってしまわないように）。

## 検証

- `go test -tags test ./...` 全パッケージ通過
- `golangci-lint run ./internal/...` 0 issues
- 129件は本体が異なるため自前を維持。置換はファイル単位で全か無か
- ヘルパは call-site 書き換えの**前**に別コミット（`3877d06`）

## これで #5185 の残りは `UndoN` だけです

`UndoN`（31件・約155行）は**本体に `fmt.Sprintf` を含む**ため着手しません。#5202 で同じ形が **+4,801 バイト**を実測しており、155行のために払う額として見合いません。

Worker サイズは CI 実測後に報告します。

Refs #5185