### PR TITLE
refactor(domain): delegate 31 UndoN bodies to the shared helper

### DIFF
--- a/internal/domain/Accordion.go
+++ b/internal/domain/Accordion.go
@@ -207,12 +207,7 @@ func (a *Accordion) UndoToEscape() int {
 
 // UndoN n回連続でアンドゥを実行する
 func (a *Accordion) UndoN(n int) error {
-	for i := range n {
-		if err := a.Undo(); err != nil {
-			return fmt.Errorf("undo step %d failed: %w", i+1, err)
-		}
-	}
-	return nil
+	return undoN(a, n)
 }
 
 // --- State getters/setters ---

--- a/internal/domain/AcesUp.go
+++ b/internal/domain/AcesUp.go
@@ -241,12 +241,7 @@ func (a *AcesUp) UndoToEscape() int {
 
 // UndoN n回連続でアンドゥを実行する。
 func (a *AcesUp) UndoN(n int) error {
-	for i := 0; i < n; i++ {
-		if err := a.Undo(); err != nil {
-			return fmt.Errorf("undo step %d failed: %w", i+1, err)
-		}
-	}
-	return nil
+	return undoN(a, n)
 }
 
 // --- State getters/setters ---

--- a/internal/domain/Agnes.go
+++ b/internal/domain/Agnes.go
@@ -337,12 +337,7 @@ func (a *Agnes) CanUndo() bool {
 
 // UndoN n回連続アンドゥ
 func (a *Agnes) UndoN(n int) error {
-	for i := 0; i < n; i++ {
-		if err := a.Undo(); err != nil {
-			return fmt.Errorf("undo step %d failed: %w", i+1, err)
-		}
-	}
-	return nil
+	return undoN(a, n)
 }
 
 // --- Private helpers ---

--- a/internal/domain/BakersDozen.go
+++ b/internal/domain/BakersDozen.go
@@ -340,12 +340,7 @@ func (bd *BakersDozen) UndoToEscape() int {
 
 // UndoN n回連続でアンドゥを実行する。
 func (bd *BakersDozen) UndoN(n int) error {
-	for i := range n {
-		if err := bd.Undo(); err != nil {
-			return fmt.Errorf("undo step %d failed: %w", i+1, err)
-		}
-	}
-	return nil
+	return undoN(bd, n)
 }
 
 // --- Private helpers ---

--- a/internal/domain/BeleagueredCastle.go
+++ b/internal/domain/BeleagueredCastle.go
@@ -364,12 +364,7 @@ func (bc *BeleagueredCastle) UndoToEscape() int {
 
 // UndoN n回連続でアンドゥを実行する。
 func (bc *BeleagueredCastle) UndoN(n int) error {
-	for i := range n {
-		if err := bc.Undo(); err != nil {
-			return fmt.Errorf("undo step %d failed: %w", i+1, err)
-		}
-	}
-	return nil
+	return undoN(bc, n)
 }
 
 // --- Private helpers ---

--- a/internal/domain/Bristol.go
+++ b/internal/domain/Bristol.go
@@ -423,12 +423,7 @@ func (b *Bristol) CanUndo() bool {
 
 // UndoN n回連続アンドゥ
 func (b *Bristol) UndoN(n int) error {
-	for i := 0; i < n; i++ {
-		if err := b.Undo(); err != nil {
-			return fmt.Errorf("undo step %d failed: %w", i+1, err)
-		}
-	}
-	return nil
+	return undoN(b, n)
 }
 
 // --- Private helpers ---

--- a/internal/domain/Calculation.go
+++ b/internal/domain/Calculation.go
@@ -283,12 +283,7 @@ func (c *Calculation) UndoToEscape() int {
 
 // UndoN n回連続でアンドゥを実行する
 func (c *Calculation) UndoN(n int) error {
-	for i := range n {
-		if err := c.Undo(); err != nil {
-			return fmt.Errorf("undo step %d failed: %w", i+1, err)
-		}
-	}
-	return nil
+	return undoN(c, n)
 }
 
 // --- Getters ---

--- a/internal/domain/Canfield.go
+++ b/internal/domain/Canfield.go
@@ -490,12 +490,7 @@ func (c *Canfield) CanUndo() bool {
 
 // UndoN n回連続アンドゥ
 func (c *Canfield) UndoN(n int) error {
-	for i := 0; i < n; i++ {
-		if err := c.Undo(); err != nil {
-			return fmt.Errorf("undo step %d failed: %w", i+1, err)
-		}
-	}
-	return nil
+	return undoN(c, n)
 }
 
 // --- Private helpers ---

--- a/internal/domain/Crescent.go
+++ b/internal/domain/Crescent.go
@@ -401,12 +401,7 @@ func (cr *Crescent) UndoToEscape() int {
 
 // UndoN n 回アンドゥする。
 func (cr *Crescent) UndoN(n int) error {
-	for i := range n {
-		if err := cr.Undo(); err != nil {
-			return fmt.Errorf("undo step %d failed: %w", i+1, err)
-		}
-	}
-	return nil
+	return undoN(cr, n)
 }
 
 // --- Private helpers ---

--- a/internal/domain/Cruel.go
+++ b/internal/domain/Cruel.go
@@ -402,12 +402,7 @@ func (c *Cruel) UndoToEscape() int {
 
 // UndoN n回連続でアンドゥを実行する。
 func (c *Cruel) UndoN(n int) error {
-	for i := range n {
-		if err := c.Undo(); err != nil {
-			return fmt.Errorf("undo step %d failed: %w", i+1, err)
-		}
-	}
-	return nil
+	return undoN(c, n)
 }
 
 // --- Private helpers ---

--- a/internal/domain/Easthaven.go
+++ b/internal/domain/Easthaven.go
@@ -432,12 +432,7 @@ func (e *Easthaven) UndoToEscape() int {
 
 // UndoN n回連続でアンドゥを実行する。
 func (e *Easthaven) UndoN(n int) error {
-	for i := range n {
-		if err := e.Undo(); err != nil {
-			return fmt.Errorf("undo step %d failed: %w", i+1, err)
-		}
-	}
-	return nil
+	return undoN(e, n)
 }
 
 // --- Private helpers ---

--- a/internal/domain/EightOff.go
+++ b/internal/domain/EightOff.go
@@ -481,12 +481,7 @@ func (e *EightOff) UndoToEscape() int {
 
 // UndoN n回連続でアンドゥを実行する。
 func (e *EightOff) UndoN(n int) error {
-	for i := 0; i < n; i++ {
-		if err := e.Undo(); err != nil {
-			return fmt.Errorf("undo step %d failed: %w", i+1, err)
-		}
-	}
-	return nil
+	return undoN(e, n)
 }
 
 // --- State getters/setters ---

--- a/internal/domain/FlowerGarden.go
+++ b/internal/domain/FlowerGarden.go
@@ -516,12 +516,7 @@ func (fg *FlowerGarden) UndoToEscape() int {
 
 // UndoN n回連続でアンドゥを実行する。
 func (fg *FlowerGarden) UndoN(n int) error {
-	for i := range n {
-		if err := fg.Undo(); err != nil {
-			return fmt.Errorf("undo step %d failed: %w", i+1, err)
-		}
-	}
-	return nil
+	return undoN(fg, n)
 }
 
 // --- Private helpers ---

--- a/internal/domain/FortyAndEight.go
+++ b/internal/domain/FortyAndEight.go
@@ -507,12 +507,7 @@ func (ft *FortyAndEight) UndoToEscape() int {
 
 // UndoN n回連続でアンドゥを実行する。
 func (ft *FortyAndEight) UndoN(n int) error {
-	for i := range n {
-		if err := ft.Undo(); err != nil {
-			return fmt.Errorf("undo step %d failed: %w", i+1, err)
-		}
-	}
-	return nil
+	return undoN(ft, n)
 }
 
 // --- Private helpers ---

--- a/internal/domain/FortyThieves.go
+++ b/internal/domain/FortyThieves.go
@@ -464,12 +464,7 @@ func (ft *FortyThieves) UndoToEscape() int {
 
 // UndoN n回連続でアンドゥを実行する。
 func (ft *FortyThieves) UndoN(n int) error {
-	for i := range n {
-		if err := ft.Undo(); err != nil {
-			return fmt.Errorf("undo step %d failed: %w", i+1, err)
-		}
-	}
-	return nil
+	return undoN(ft, n)
 }
 
 // --- Private helpers ---

--- a/internal/domain/FreeCell.go
+++ b/internal/domain/FreeCell.go
@@ -569,12 +569,7 @@ func (f *FreeCell) UndoToEscape() int {
 
 // UndoN n回連続でアンドゥを実行する。
 func (f *FreeCell) UndoN(n int) error {
-	for i := 0; i < n; i++ {
-		if err := f.Undo(); err != nil {
-			return fmt.Errorf("undo step %d failed: %w", i+1, err)
-		}
-	}
-	return nil
+	return undoN(f, n)
 }
 
 // --- State getters/setters ---

--- a/internal/domain/Golf.go
+++ b/internal/domain/Golf.go
@@ -237,12 +237,7 @@ func (g *Golf) UndoToEscape() int {
 
 // UndoN n回連続でアンドゥを実行する。
 func (g *Golf) UndoN(n int) error {
-	for i := 0; i < n; i++ {
-		if err := g.Undo(); err != nil {
-			return fmt.Errorf("undo step %d failed: %w", i+1, err)
-		}
-	}
-	return nil
+	return undoN(g, n)
 }
 
 // --- State getters/setters ---

--- a/internal/domain/KingAlbert.go
+++ b/internal/domain/KingAlbert.go
@@ -516,12 +516,7 @@ func (ka *KingAlbert) UndoToEscape() int {
 
 // UndoN n回連続でアンドゥを実行する。
 func (ka *KingAlbert) UndoN(n int) error {
-	for i := range n {
-		if err := ka.Undo(); err != nil {
-			return fmt.Errorf("undo step %d failed: %w", i+1, err)
-		}
-	}
-	return nil
+	return undoN(ka, n)
 }
 
 // --- Private helpers ---

--- a/internal/domain/Klondike.go
+++ b/internal/domain/Klondike.go
@@ -583,12 +583,7 @@ func (k *Klondike) UndoToEscape() int {
 
 // UndoN n回連続でアンドゥを実行する。
 func (k *Klondike) UndoN(n int) error {
-	for i := 0; i < n; i++ {
-		if err := k.Undo(); err != nil {
-			return fmt.Errorf("undo step %d failed: %w", i+1, err)
-		}
-	}
-	return nil
+	return undoN(k, n)
 }
 
 // GetScore スコア取得 (ベガス式: -52 + 5 * ファンデーション枚数)

--- a/internal/domain/Osmosis.go
+++ b/internal/domain/Osmosis.go
@@ -377,12 +377,7 @@ func (o *Osmosis) CanUndo() bool {
 
 // UndoN n回連続アンドゥ
 func (o *Osmosis) UndoN(n int) error {
-	for i := 0; i < n; i++ {
-		if err := o.Undo(); err != nil {
-			return fmt.Errorf("undo step %d failed: %w", i+1, err)
-		}
-	}
-	return nil
+	return undoN(o, n)
 }
 
 // --- Private helpers ---

--- a/internal/domain/Penguin.go
+++ b/internal/domain/Penguin.go
@@ -499,12 +499,7 @@ func (p *Penguin) UndoToEscape() int {
 
 // UndoN n回連続でアンドゥを実行する
 func (p *Penguin) UndoN(n int) error {
-	for i := 0; i < n; i++ {
-		if err := p.Undo(); err != nil {
-			return fmt.Errorf("undo step %d failed: %w", i+1, err)
-		}
-	}
-	return nil
+	return undoN(p, n)
 }
 
 // --- State getters/setters ---

--- a/internal/domain/Pyramid.go
+++ b/internal/domain/Pyramid.go
@@ -376,12 +376,7 @@ func (p *Pyramid) UndoToEscape() int {
 
 // UndoN n回連続でアンドゥを実行する。
 func (p *Pyramid) UndoN(n int) error {
-	for i := 0; i < n; i++ {
-		if err := p.Undo(); err != nil {
-			return fmt.Errorf("undo step %d failed: %w", i+1, err)
-		}
-	}
-	return nil
+	return undoN(p, n)
 }
 
 // --- State getters/setters ---

--- a/internal/domain/RussianSolitaire.go
+++ b/internal/domain/RussianSolitaire.go
@@ -395,12 +395,7 @@ func (y *RussianSolitaire) UndoToEscape() int {
 
 // UndoN n回連続でアンドゥを実行する。
 func (y *RussianSolitaire) UndoN(n int) error {
-	for i := range n {
-		if err := y.Undo(); err != nil {
-			return fmt.Errorf("undo step %d failed: %w", i+1, err)
-		}
-	}
-	return nil
+	return undoN(y, n)
 }
 
 // --- Private helpers ---

--- a/internal/domain/Scorpion.go
+++ b/internal/domain/Scorpion.go
@@ -358,12 +358,7 @@ func (s *Scorpion) UndoToEscape() int {
 
 // UndoN n回連続でアンドゥを実行する。
 func (s *Scorpion) UndoN(n int) error {
-	for i := range n {
-		if err := s.Undo(); err != nil {
-			return fmt.Errorf("undo step %d failed: %w", i+1, err)
-		}
-	}
-	return nil
+	return undoN(s, n)
 }
 
 // --- State getters/setters ---

--- a/internal/domain/SeahavenTowers.go
+++ b/internal/domain/SeahavenTowers.go
@@ -476,12 +476,7 @@ func (s *SeahavenTowers) UndoToEscape() int {
 
 // UndoN n回連続でアンドゥを実行する。
 func (s *SeahavenTowers) UndoN(n int) error {
-	for i := 0; i < n; i++ {
-		if err := s.Undo(); err != nil {
-			return fmt.Errorf("undo step %d failed: %w", i+1, err)
-		}
-	}
-	return nil
+	return undoN(s, n)
 }
 
 // --- State getters/setters ---

--- a/internal/domain/Spider.go
+++ b/internal/domain/Spider.go
@@ -376,12 +376,7 @@ func (s *Spider) UndoToEscape() int {
 
 // UndoN n回連続でアンドゥを実行する。
 func (s *Spider) UndoN(n int) error {
-	for i := 0; i < n; i++ {
-		if err := s.Undo(); err != nil {
-			return fmt.Errorf("undo step %d failed: %w", i+1, err)
-		}
-	}
-	return nil
+	return undoN(s, n)
 }
 
 // --- State getters/setters ---

--- a/internal/domain/Spiderette.go
+++ b/internal/domain/Spiderette.go
@@ -352,12 +352,7 @@ func (s *Spiderette) UndoToEscape() int {
 
 // UndoN n回連続でアンドゥを実行する。
 func (s *Spiderette) UndoN(n int) error {
-	for i := 0; i < n; i++ {
-		if err := s.Undo(); err != nil {
-			return fmt.Errorf("undo step %d failed: %w", i+1, err)
-		}
-	}
-	return nil
+	return undoN(s, n)
 }
 
 // --- State getters/setters ---

--- a/internal/domain/StreetsAndAlleys.go
+++ b/internal/domain/StreetsAndAlleys.go
@@ -359,12 +359,7 @@ func (sa *StreetsAndAlleys) UndoToEscape() int {
 
 // UndoN n回連続でアンドゥを実行する。
 func (sa *StreetsAndAlleys) UndoN(n int) error {
-	for i := range n {
-		if err := sa.Undo(); err != nil {
-			return fmt.Errorf("undo step %d failed: %w", i+1, err)
-		}
-	}
-	return nil
+	return undoN(sa, n)
 }
 
 // --- Private helpers ---

--- a/internal/domain/Sultan.go
+++ b/internal/domain/Sultan.go
@@ -399,12 +399,7 @@ func (su *Sultan) UndoToEscape() int {
 
 // UndoN n回連続でアンドゥを実行する。
 func (su *Sultan) UndoN(n int) error {
-	for i := range n {
-		if err := su.Undo(); err != nil {
-			return fmt.Errorf("undo step %d failed: %w", i+1, err)
-		}
-	}
-	return nil
+	return undoN(su, n)
 }
 
 // --- Private helpers ---

--- a/internal/domain/Wasp.go
+++ b/internal/domain/Wasp.go
@@ -358,12 +358,7 @@ func (s *Wasp) UndoToEscape() int {
 
 // UndoN n回連続でアンドゥを実行する。
 func (s *Wasp) UndoN(n int) error {
-	for i := range n {
-		if err := s.Undo(); err != nil {
-			return fmt.Errorf("undo step %d failed: %w", i+1, err)
-		}
-	}
-	return nil
+	return undoN(s, n)
 }
 
 // --- State getters/setters ---

--- a/internal/domain/Yukon.go
+++ b/internal/domain/Yukon.go
@@ -391,12 +391,7 @@ func (y *Yukon) UndoToEscape() int {
 
 // UndoN n回連続でアンドゥを実行する。
 func (y *Yukon) UndoN(n int) error {
-	for i := 0; i < n; i++ {
-		if err := y.Undo(); err != nil {
-			return fmt.Errorf("undo step %d failed: %w", i+1, err)
-		}
-	}
-	return nil
+	return undoN(y, n)
 }
 
 // --- Private helpers ---

--- a/internal/domain/player_helpers.go
+++ b/internal/domain/player_helpers.go
@@ -242,3 +242,26 @@ func sortHands[G handSorter](seats int, g G) {
 		g.sortHand(i)
 	}
 }
+
+// undoer is a game that can step one move backwards.
+type undoer interface {
+	Undo() error
+}
+
+// undoN undoes n moves, stopping at the first failure and reporting which step
+// failed with the cause wrapped. 31 solitaires had this loop written out.
+//
+// Interface parameter rather than a type parameter, which is the opposite
+// choice from resetPlayerRound above and for a measured reason: this body
+// contains a fmt.Errorf, and fmt is the one thing that is genuinely expensive
+// to duplicate per type (#5202 measured +4,801 bytes for that shape). Those 31
+// copies already exist, so collapsing them to one shared body is a saving,
+// whereas a type parameter would keep them. See issue #5185.
+func undoN(g undoer, n int) error {
+	for i := range n {
+		if err := g.Undo(); err != nil {
+			return fmt.Errorf("undo step %d failed: %w", i+1, err)
+		}
+	}
+	return nil
+}

--- a/internal/domain/player_helpers_internal_test.go
+++ b/internal/domain/player_helpers_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // --- nextActivePlayer tests ---
@@ -441,4 +442,48 @@ func TestSortHands_NoSeats(t *testing.T) {
 	sortHands(0, g)
 
 	assert.Empty(t, g.sorted)
+}
+
+type fakeUndoer struct {
+	calls  int
+	failAt int // 1-based step that returns an error; 0 never fails
+}
+
+func (u *fakeUndoer) Undo() error {
+	u.calls++
+	if u.failAt != 0 && u.calls == u.failAt {
+		return assert.AnError
+	}
+	return nil
+}
+
+func TestUndoN(t *testing.T) {
+	u := &fakeUndoer{}
+
+	require.NoError(t, undoN(u, 3))
+	assert.Equal(t, 3, u.calls, "exactly n steps")
+}
+
+// Zero and negative are both no-ops. `for i := range n` iterates zero times for
+// a negative n, matching the `for i := 0; i < n; i++` bodies this replaces --
+// Gaps has a test pinning that a negative count undoes nothing.
+func TestUndoN_ZeroOrNegativeIsNoop(t *testing.T) {
+	u := &fakeUndoer{}
+
+	require.NoError(t, undoN(u, 0))
+	require.NoError(t, undoN(u, -3))
+	assert.Equal(t, 0, u.calls)
+}
+
+// The failing step number appears in the message and the cause is wrapped, so
+// callers can still errors.Is the original.
+func TestUndoN_StopsAtTheFailingStep(t *testing.T) {
+	u := &fakeUndoer{failAt: 2}
+
+	err := undoN(u, 5)
+
+	require.Error(t, err)
+	assert.Equal(t, 2, u.calls, "must stop, not run all 5")
+	assert.Contains(t, err.Error(), "undo step 2 failed")
+	assert.ErrorIs(t, err, assert.AnError, "the cause must stay wrapped")
 }


### PR DESCRIPTION
#5185 の最後のクラスタです。**-155行**（31件）。

## 前言撤回: これは「着手しない」と2回書きましたが、根拠が誤っていました

`UndoN` は本体に `fmt.Sprintf` 系を含むため、#5202（`playerName` で **+4,801 バイト**）の前例から「共通化するとバイナリが増える」と判断して見送っていました。

**その一般化が誤りでした。** #5202 で増えたのは**型パラメータで型ごとに `fmt` が複製された**からです。`UndoN` の場合、

- **31個の `fmt.Errorf` は既に複製済み**（現状のコード）
- **インタフェース引数**で畳めば実体は**1つ**になる

つまり同じ `fmt` でも、`playerName` は「1個を31個に増やす」話、`UndoN` は「31個を1個に減らす」話で、向きが逆でした。

## 形の選択は #5211 の A/B に基づいています

同じセッションで、54箇所の呼び出し側を固定したままヘルパのシグネチャだけを変えて実測しました。

| 形 | delta |
|---|---:|
| インタフェース引数 | **+2,038** |
| 型パラメータ | **-28** |

**本体が3行と小さい場合は型パラメータが圧勝**でした（インタフェースは実装型ごとに itab と型ディスクリプタが要る）。

本PRは**逆に**インタフェース引数を選んでいます。本体に `fmt.Errorf` があり、**複製されるコードのほうが itab メタデータより高い**と見込まれるためです。判断基準はこうなります。

| 本体 | 選ぶ形 |
|---|---|
| 共有型だけで済む | 型パラメータ不要の関数（最良・#5209 は -1,793） |
| 数行・軽い | **型パラメータ**（#5211: -28） |
| **`fmt` など重い** | **インタフェース引数**（本PR） |

見込みどおりかは実測して報告します。増えるようなら型パラメータ版と A/B して安いほうを採ります。

## カーブアウト

**17ゲームは自前の本体を維持**します（AmericanToad / Bisley / BlackHole / Braid / Congress / DoubleKlondike / Duchess / Gaps / GrandfathersClock / LaBelleLucie / MissMilligan / NapoleonsSquare / SimpleSimon / SirTommy / Terrace / TriPeaks / Windmill）。`Undo` を繰り返す以上のことをしています。置換はファイル単位で全か無かです。

## テスト

- **失敗ステップで止まること**を検証（5回指示して2回目で失敗 → 呼び出しは2回）
- エラー文に**何ステップ目か**が出ること、`errors.Is` で**原因が辿れる**こと（`%w`）
- **0 と負数が no-op** であること —— `for i := range n` は負数で0回まわり、置換元の `for i := 0; i < n; i++` と一致します。Gaps に負数を固定するテストが既にあるため、ヘルパ側でも固定しました

## 検証

- `go test -tags test ./...` 全パッケージ通過 / `golangci-lint` 0 issues
- `goimports -l` で**未使用になった `fmt` import が無い**ことを確認
- ヘルパは call-site 書き換えの**前**に別コミット（`8b94940`）

Refs #5185