### PR TITLE
refactor(domain): delegate 46 bodies across four tail clusters

### DIFF
--- a/internal/domain/AmericanToad.go
+++ b/internal/domain/AmericanToad.go
@@ -525,18 +525,7 @@ func (at *AmericanToad) CanUndo() bool { return len(at.history) > 0 }
 
 // UndoN n 手戻す
 func (at *AmericanToad) UndoN(n int) error {
-	if n <= 0 {
-		return errors.New("n must be positive")
-	}
-	if n > len(at.history) {
-		return errors.New("not enough history")
-	}
-	for range n {
-		if err := at.Undo(); err != nil {
-			return err
-		}
-	}
-	return nil
+	return undoNChecked(at, n, len(at.history))
 }
 
 // UndoToEscape 膠着状態から抜けるのに必要なアンドゥ回数（膠着でなければ 0、不可なら -1）

--- a/internal/domain/BakersDozen.go
+++ b/internal/domain/BakersDozen.go
@@ -358,12 +358,7 @@ func (bd *BakersDozen) canPlaceOnTableau(card *Card, col int) bool {
 
 // canPlaceOnFoundation ファンデーションにカードを置けるか判定
 func (bd *BakersDozen) canPlaceOnFoundation(card *Card, fIdx int) bool {
-	pile := bd.foundation[fIdx]
-	if len(pile) == 0 {
-		return card.GetValue() == 1
-	}
-	topCard := pile[len(pile)-1]
-	return card.GetDesign() == topCard.GetDesign() && card.GetValue() == topCard.GetValue()+1
+	return canPlaceOnFoundationPile(bd.foundation[fIdx], card)
 }
 
 // findFoundation カードを置けるファンデーションのインデックスを探す（見つからない場合-1）

--- a/internal/domain/BeleagueredCastle.go
+++ b/internal/domain/BeleagueredCastle.go
@@ -384,12 +384,7 @@ func (bc *BeleagueredCastle) canPlaceOnTableau(card *Card, col int) bool {
 
 // canPlaceOnFoundation ファンデーションにカードを置けるか判定
 func (bc *BeleagueredCastle) canPlaceOnFoundation(card *Card, fIdx int) bool {
-	pile := bc.foundation[fIdx]
-	if len(pile) == 0 {
-		return card.GetValue() == 1
-	}
-	topCard := pile[len(pile)-1]
-	return card.GetDesign() == topCard.GetDesign() && card.GetValue() == topCard.GetValue()+1
+	return canPlaceOnFoundationPile(bc.foundation[fIdx], card)
 }
 
 // findFoundation カードを置けるファンデーションのインデックスを探す（見つからない場合-1）

--- a/internal/domain/Belote.go
+++ b/internal/domain/Belote.go
@@ -688,10 +688,7 @@ func (b *Belote) IsHumanTurn() bool {
 
 // IsHumanBidTurn 現在のビッド手番が人間かどうか
 func (b *Belote) IsHumanBidTurn() bool {
-	if b.bidPlayerIdx < 0 || b.bidPlayerIdx >= len(b.players) {
-		return false
-	}
-	return b.players[b.bidPlayerIdx].GetIsHuman()
+	return isHumanTurn(b.players, b.bidPlayerIdx)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/BidWhist.go
+++ b/internal/domain/BidWhist.go
@@ -1171,10 +1171,7 @@ func (g *BidWhist) IsHumanTurn() bool {
 
 // IsHumanBidTurn 現在のビッド手番が人間かどうか
 func (g *BidWhist) IsHumanBidTurn() bool {
-	if g.bidPlayerIdx < 0 || g.bidPlayerIdx >= len(g.players) {
-		return false
-	}
-	return g.players[g.bidPlayerIdx].GetIsHuman()
+	return isHumanTurn(g.players, g.bidPlayerIdx)
 }
 
 // IsHumanDeclarerTurn 現在の落札者(切り札宣言/キティ交換手番)が人間かどうか

--- a/internal/domain/Bisley.go
+++ b/internal/domain/Bisley.go
@@ -326,18 +326,7 @@ func (b *Bisley) CanUndo() bool { return len(b.history) > 0 }
 
 // UndoN n 手戻す
 func (b *Bisley) UndoN(n int) error {
-	if n <= 0 {
-		return errors.New("n must be positive")
-	}
-	if n > len(b.history) {
-		return errors.New("not enough history")
-	}
-	for range n {
-		if err := b.Undo(); err != nil {
-			return err
-		}
-	}
-	return nil
+	return undoNChecked(b, n, len(b.history))
 }
 
 // UndoToEscape 膠着状態から抜けるのに必要なアンドゥ回数（膠着でなければ 0、不可なら -1）

--- a/internal/domain/Braid.go
+++ b/internal/domain/Braid.go
@@ -498,18 +498,7 @@ func (b *Braid) CanUndo() bool { return len(b.history) > 0 }
 
 // UndoN n 手戻す
 func (b *Braid) UndoN(n int) error {
-	if n <= 0 {
-		return errors.New("n must be positive")
-	}
-	if n > len(b.history) {
-		return errors.New("not enough history")
-	}
-	for range n {
-		if err := b.Undo(); err != nil {
-			return err
-		}
-	}
-	return nil
+	return undoNChecked(b, n, len(b.history))
 }
 
 // UndoToEscape 膠着状態から抜けるのに必要なアンドゥ回数（膠着でなければ 0、不可なら -1）

--- a/internal/domain/Bridge.go
+++ b/internal/domain/Bridge.go
@@ -1005,10 +1005,7 @@ func (b *Bridge) IsHumanTurn() bool {
 
 // IsHumanBidTurn 現在のビッド手番が人間かどうか
 func (b *Bridge) IsHumanBidTurn() bool {
-	if b.bidPlayerIdx < 0 || b.bidPlayerIdx >= len(b.players) {
-		return false
-	}
-	return b.players[b.bidPlayerIdx].GetIsHuman()
+	return isHumanTurn(b.players, b.bidPlayerIdx)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/CallBreak.go
+++ b/internal/domain/CallBreak.go
@@ -397,10 +397,7 @@ func (cb *CallBreak) IsHumanTurn() bool {
 
 // IsHumanBidTurn 現在のビッド手番が人間かどうか
 func (cb *CallBreak) IsHumanBidTurn() bool {
-	if cb.bidPlayerIdx < 0 || cb.bidPlayerIdx >= len(cb.players) {
-		return false
-	}
-	return cb.players[cb.bidPlayerIdx].GetIsHuman()
+	return isHumanTurn(cb.players, cb.bidPlayerIdx)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/Canasta.go
+++ b/internal/domain/Canasta.go
@@ -1506,13 +1506,7 @@ func (g *Canasta) sortAllHands() {
 
 // sortHand プレイヤーの手札をスート→値の順にソートする
 func (g *Canasta) sortHand(playerIdx int) {
-	p := g.players[playerIdx]
-	sortPlayerHand(p, func(ci, cj *Card) bool {
-		if ci.GetDesign() != cj.GetDesign() {
-			return ci.GetDesign() < cj.GetDesign()
-		}
-		return ci.GetValue() < cj.GetValue()
-	})
+	sortPlayerHand(g.players[playerIdx], bySuitThenValue)
 }
 
 // canastaTypeStr カナスタの種別文字列を返す

--- a/internal/domain/Congress.go
+++ b/internal/domain/Congress.go
@@ -422,18 +422,7 @@ func (c *Congress) CanUndo() bool { return len(c.history) > 0 }
 
 // UndoN n 手戻す
 func (c *Congress) UndoN(n int) error {
-	if n <= 0 {
-		return errors.New("n must be positive")
-	}
-	if n > len(c.history) {
-		return errors.New("not enough history")
-	}
-	for range n {
-		if err := c.Undo(); err != nil {
-			return err
-		}
-	}
-	return nil
+	return undoNChecked(c, n, len(c.history))
 }
 
 // UndoToEscape 膠着状態から抜けるのに必要なアンドゥ回数（膠着でなければ 0、不可なら -1）

--- a/internal/domain/CrazyEights.go
+++ b/internal/domain/CrazyEights.go
@@ -574,13 +574,7 @@ func (g *CrazyEights) sortAllHands() {
 
 // sortHand プレイヤーの手札をスート→値の順にソートする
 func (g *CrazyEights) sortHand(playerIdx int) {
-	p := g.players[playerIdx]
-	sortPlayerHand(p, func(ci, cj *Card) bool {
-		if ci.GetDesign() != cj.GetDesign() {
-			return ci.GetDesign() < cj.GetDesign()
-		}
-		return ci.GetValue() < cj.GetValue()
-	})
+	sortPlayerHand(g.players[playerIdx], bySuitThenValue)
 }
 
 // --- CPU AI ---

--- a/internal/domain/Cruel.go
+++ b/internal/domain/Cruel.go
@@ -421,12 +421,7 @@ func (c *Cruel) canPlaceOnTableau(card *Card, col int) bool {
 // canPlaceOnFoundation ファウンデーションにカードを置けるか判定。
 // Reset() で各ファウンデーションに A を1枚配置済みなので、空のケースは通常発生しない。
 func (c *Cruel) canPlaceOnFoundation(card *Card, fIdx int) bool {
-	pile := c.foundation[fIdx]
-	if len(pile) == 0 {
-		return card.GetValue() == 1
-	}
-	topCard := pile[len(pile)-1]
-	return card.GetDesign() == topCard.GetDesign() && card.GetValue() == topCard.GetValue()+1
+	return canPlaceOnFoundationPile(c.foundation[fIdx], card)
 }
 
 // checkGameClear ゲームクリア判定

--- a/internal/domain/Duchess.go
+++ b/internal/domain/Duchess.go
@@ -552,18 +552,7 @@ func (d *Duchess) CanUndo() bool { return len(d.history) > 0 }
 
 // UndoN n 手戻す
 func (d *Duchess) UndoN(n int) error {
-	if n <= 0 {
-		return errors.New("n must be positive")
-	}
-	if n > len(d.history) {
-		return errors.New("not enough history")
-	}
-	for range n {
-		if err := d.Undo(); err != nil {
-			return err
-		}
-	}
-	return nil
+	return undoNChecked(d, n, len(d.history))
 }
 
 // UndoToEscape 膠着状態から抜けるのに必要なアンドゥ回数（膠着でなければ 0、不可なら -1）

--- a/internal/domain/EightOff.go
+++ b/internal/domain/EightOff.go
@@ -539,12 +539,7 @@ func (e *EightOff) canPlaceOnTableau(card *Card, col int) bool {
 
 // canPlaceOnFoundation ファンデーションにカードを置けるか判定
 func (e *EightOff) canPlaceOnFoundation(card *Card, fIdx int) bool {
-	pile := e.foundation[fIdx]
-	if len(pile) == 0 {
-		return card.GetValue() == 1
-	}
-	topCard := pile[len(pile)-1]
-	return card.GetDesign() == topCard.GetDesign() && card.GetValue() == topCard.GetValue()+1
+	return canPlaceOnFoundationPile(e.foundation[fIdx], card)
 }
 
 // isSameSuit 同じスートかどうか判定

--- a/internal/domain/Euchre.go
+++ b/internal/domain/Euchre.go
@@ -658,10 +658,7 @@ func (e *Euchre) IsHumanTurn() bool {
 
 // IsHumanBidTurn 現在のビッド手番が人間かどうか
 func (e *Euchre) IsHumanBidTurn() bool {
-	if e.bidPlayerIdx < 0 || e.bidPlayerIdx >= len(e.players) {
-		return false
-	}
-	return e.players[e.bidPlayerIdx].GetIsHuman()
+	return isHumanTurn(e.players, e.bidPlayerIdx)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/FiveHundred.go
+++ b/internal/domain/FiveHundred.go
@@ -1261,10 +1261,7 @@ func (g *FiveHundred) IsHumanTurn() bool {
 
 // IsHumanBidTurn 現在のビッド手番が人間かどうか
 func (g *FiveHundred) IsHumanBidTurn() bool {
-	if g.bidPlayerIdx < 0 || g.bidPlayerIdx >= len(g.players) {
-		return false
-	}
-	return g.players[g.bidPlayerIdx].GetIsHuman()
+	return isHumanTurn(g.players, g.bidPlayerIdx)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/FlowerGarden.go
+++ b/internal/domain/FlowerGarden.go
@@ -536,12 +536,7 @@ func (fg *FlowerGarden) canPlaceOnTableau(card *Card, col int) bool {
 
 // canPlaceOnFoundation ファンデーションにカードを置けるか判定（Aceから同スートで昇順）
 func (fg *FlowerGarden) canPlaceOnFoundation(card *Card, fIdx int) bool {
-	pile := fg.foundation[fIdx]
-	if len(pile) == 0 {
-		return card.GetValue() == 1
-	}
-	topCard := pile[len(pile)-1]
-	return card.GetDesign() == topCard.GetDesign() && card.GetValue() == topCard.GetValue()+1
+	return canPlaceOnFoundationPile(fg.foundation[fIdx], card)
 }
 
 // findFoundation カードを置けるファンデーションのインデックスを探す（見つからない場合-1）

--- a/internal/domain/FreeCell.go
+++ b/internal/domain/FreeCell.go
@@ -640,12 +640,7 @@ func (f *FreeCell) tableauStackable(upper, lower *Card) bool {
 
 // canPlaceOnFoundation ファンデーションにカードを置けるか判定
 func (f *FreeCell) canPlaceOnFoundation(card *Card, fIdx int) bool {
-	pile := f.foundation[fIdx]
-	if len(pile) == 0 {
-		return card.GetValue() == 1
-	}
-	topCard := pile[len(pile)-1]
-	return card.GetDesign() == topCard.GetDesign() && card.GetValue() == topCard.GetValue()+1
+	return canPlaceOnFoundationPile(f.foundation[fIdx], card)
 }
 
 // isAlternateColor 交互の色かどうか判定

--- a/internal/domain/GinRummy.go
+++ b/internal/domain/GinRummy.go
@@ -830,13 +830,7 @@ func (g *GinRummy) sortAllHands() {
 
 // sortHand プレイヤーの手札をスート→値の順にソートする
 func (g *GinRummy) sortHand(playerIdx int) {
-	p := g.players[playerIdx]
-	sortPlayerHand(p, func(ci, cj *Card) bool {
-		if ci.GetDesign() != cj.GetDesign() {
-			return ci.GetDesign() < cj.GetDesign()
-		}
-		return ci.GetValue() < cj.GetValue()
-	})
+	sortPlayerHand(g.players[playerIdx], bySuitThenValue)
 }
 
 // --- Meld Detection ---

--- a/internal/domain/GrandfathersClock.go
+++ b/internal/domain/GrandfathersClock.go
@@ -334,18 +334,7 @@ func (gc *GrandfathersClock) CanUndo() bool { return len(gc.history) > 0 }
 
 // UndoN n 手戻す
 func (gc *GrandfathersClock) UndoN(n int) error {
-	if n <= 0 {
-		return errors.New("n must be positive")
-	}
-	if n > len(gc.history) {
-		return errors.New("not enough history")
-	}
-	for range n {
-		if err := gc.Undo(); err != nil {
-			return err
-		}
-	}
-	return nil
+	return undoNChecked(gc, n, len(gc.history))
 }
 
 // UndoToEscape 膠着状態から抜けるのに必要なアンドゥ回数（膠着でなければ 0、不可なら -1）

--- a/internal/domain/HandAndFoot.go
+++ b/internal/domain/HandAndFoot.go
@@ -1340,13 +1340,7 @@ func (g *HandAndFoot) sortAllHands() {
 
 // sortHand プレイヤーの手札をスート→値の順にソートする
 func (g *HandAndFoot) sortHand(playerIdx int) {
-	p := g.players[playerIdx]
-	sortPlayerHand(p, func(ci, cj *Card) bool {
-		if ci.GetDesign() != cj.GetDesign() {
-			return ci.GetDesign() < cj.GetDesign()
-		}
-		return ci.GetValue() < cj.GetValue()
-	})
+	sortPlayerHand(g.players[playerIdx], bySuitThenValue)
 }
 
 // --- JSON serialization ---

--- a/internal/domain/Jass.go
+++ b/internal/domain/Jass.go
@@ -526,10 +526,7 @@ func (g *Jass) IsHumanTurn() bool {
 
 // IsHumanBidTurn 現在のビッド手番が人間かどうか
 func (g *Jass) IsHumanBidTurn() bool {
-	if g.bidPlayerIdx < 0 || g.bidPlayerIdx >= len(g.players) {
-		return false
-	}
-	return g.players[g.bidPlayerIdx].GetIsHuman()
+	return isHumanTurn(g.players, g.bidPlayerIdx)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/KingAlbert.go
+++ b/internal/domain/KingAlbert.go
@@ -546,12 +546,7 @@ func (ka *KingAlbert) isBlack(card *Card) bool {
 
 // canPlaceOnFoundation ファンデーションにカードを置けるか判定（Aceから同スートで昇順）
 func (ka *KingAlbert) canPlaceOnFoundation(card *Card, fIdx int) bool {
-	pile := ka.foundation[fIdx]
-	if len(pile) == 0 {
-		return card.GetValue() == 1
-	}
-	topCard := pile[len(pile)-1]
-	return card.GetDesign() == topCard.GetDesign() && card.GetValue() == topCard.GetValue()+1
+	return canPlaceOnFoundationPile(ka.foundation[fIdx], card)
 }
 
 // findFoundation カードを置けるファンデーションのインデックスを探す（見つからない場合-1）

--- a/internal/domain/Macau.go
+++ b/internal/domain/Macau.go
@@ -690,13 +690,7 @@ func (g *Macau) sortAllHands() {
 
 // sortHand プレイヤーの手札をスート→値の順にソートする
 func (g *Macau) sortHand(playerIdx int) {
-	p := g.players[playerIdx]
-	sortPlayerHand(p, func(ci, cj *Card) bool {
-		if ci.GetDesign() != cj.GetDesign() {
-			return ci.GetDesign() < cj.GetDesign()
-		}
-		return ci.GetValue() < cj.GetValue()
-	})
+	sortPlayerHand(g.players[playerIdx], bySuitThenValue)
 }
 
 // --- CPU AI ---

--- a/internal/domain/Mao.go
+++ b/internal/domain/Mao.go
@@ -885,13 +885,7 @@ func (g *Mao) sortAllHands() {
 
 // sortHand プレイヤーの手札をスート→値の順にソートする
 func (g *Mao) sortHand(playerIdx int) {
-	p := g.players[playerIdx]
-	sortPlayerHand(p, func(ci, cj *Card) bool {
-		if ci.GetDesign() != cj.GetDesign() {
-			return ci.GetDesign() < cj.GetDesign()
-		}
-		return ci.GetValue() < cj.GetValue()
-	})
+	sortPlayerHand(g.players[playerIdx], bySuitThenValue)
 }
 
 // --- CPU AI ---

--- a/internal/domain/MissMilligan.go
+++ b/internal/domain/MissMilligan.go
@@ -469,18 +469,7 @@ func (mm *MissMilligan) CanUndo() bool { return len(mm.history) > 0 }
 
 // UndoN n 手戻す
 func (mm *MissMilligan) UndoN(n int) error {
-	if n <= 0 {
-		return errors.New("n must be positive")
-	}
-	if n > len(mm.history) {
-		return errors.New("not enough history")
-	}
-	for range n {
-		if err := mm.Undo(); err != nil {
-			return err
-		}
-	}
-	return nil
+	return undoNChecked(mm, n, len(mm.history))
 }
 
 // UndoToEscape 膠着状態から抜けるのに必要なアンドゥ回数（膠着でなければ 0、不可なら -1）

--- a/internal/domain/NapoleonsSquare.go
+++ b/internal/domain/NapoleonsSquare.go
@@ -433,18 +433,7 @@ func (ns *NapoleonsSquare) CanUndo() bool { return len(ns.history) > 0 }
 
 // UndoN n 手戻す
 func (ns *NapoleonsSquare) UndoN(n int) error {
-	if n <= 0 {
-		return errors.New("n must be positive")
-	}
-	if n > len(ns.history) {
-		return errors.New("not enough history")
-	}
-	for range n {
-		if err := ns.Undo(); err != nil {
-			return err
-		}
-	}
-	return nil
+	return undoNChecked(ns, n, len(ns.history))
 }
 
 // UndoToEscape 膠着状態から抜けるのに必要なアンドゥ回数（膠着でなければ 0、不可なら -1）

--- a/internal/domain/NinetyNine.go
+++ b/internal/domain/NinetyNine.go
@@ -445,10 +445,7 @@ func (o *NinetyNine) IsHumanTurn() bool {
 
 // IsHumanBidTurn 現在のビッド手番が人間かどうか
 func (o *NinetyNine) IsHumanBidTurn() bool {
-	if o.bidPlayerIdx < 0 || o.bidPlayerIdx >= len(o.players) {
-		return false
-	}
-	return o.players[o.bidPlayerIdx].GetIsHuman()
+	return isHumanTurn(o.players, o.bidPlayerIdx)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/OhHell.go
+++ b/internal/domain/OhHell.go
@@ -409,10 +409,7 @@ func (o *OhHell) IsHumanTurn() bool {
 
 // IsHumanBidTurn 現在のビッド手番が人間かどうか
 func (o *OhHell) IsHumanBidTurn() bool {
-	if o.bidPlayerIdx < 0 || o.bidPlayerIdx >= len(o.players) {
-		return false
-	}
-	return o.players[o.bidPlayerIdx].GetIsHuman()
+	return isHumanTurn(o.players, o.bidPlayerIdx)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/PageOne.go
+++ b/internal/domain/PageOne.go
@@ -528,13 +528,7 @@ func (g *PageOne) sortAllHands() {
 
 // sortHand プレイヤーの手札をスート→値の順にソートする
 func (g *PageOne) sortHand(playerIdx int) {
-	p := g.players[playerIdx]
-	sortPlayerHand(p, func(ci, cj *Card) bool {
-		if ci.GetDesign() != cj.GetDesign() {
-			return ci.GetDesign() < cj.GetDesign()
-		}
-		return ci.GetValue() < cj.GetValue()
-	})
+	sortPlayerHand(g.players[playerIdx], bySuitThenValue)
 }
 
 // --- CPU AI ---

--- a/internal/domain/Pan.go
+++ b/internal/domain/Pan.go
@@ -724,13 +724,7 @@ func (g *Pan) sortAllHands() {
 }
 
 func (g *Pan) sortHand(playerIdx int) {
-	p := g.players[playerIdx]
-	sortPlayerHand(p, func(ci, cj *Card) bool {
-		if ci.GetDesign() != cj.GetDesign() {
-			return ci.GetDesign() < cj.GetDesign()
-		}
-		return ci.GetValue() < cj.GetValue()
-	})
+	sortPlayerHand(g.players[playerIdx], bySuitThenValue)
 }
 
 // --- Scoring / meld helpers ---

--- a/internal/domain/Pitch.go
+++ b/internal/domain/Pitch.go
@@ -731,10 +731,7 @@ func (p *Pitch) IsHumanTurn() bool {
 
 // IsHumanBidTurn 現在のビッド手番が人間かどうか
 func (p *Pitch) IsHumanBidTurn() bool {
-	if p.bidPlayerIdx < 0 || p.bidPlayerIdx >= len(p.players) {
-		return false
-	}
-	return p.players[p.bidPlayerIdx].GetIsHuman()
+	return isHumanTurn(p.players, p.bidPlayerIdx)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/Prsi.go
+++ b/internal/domain/Prsi.go
@@ -428,13 +428,7 @@ func (g *Prsi) sortAllHands() {
 
 // sortHand プレイヤーの手札をスート→値の順にソートする
 func (g *Prsi) sortHand(playerIdx int) {
-	p := g.players[playerIdx]
-	sortPlayerHand(p, func(ci, cj *Card) bool {
-		if ci.GetDesign() != cj.GetDesign() {
-			return ci.GetDesign() < cj.GetDesign()
-		}
-		return ci.GetValue() < cj.GetValue()
-	})
+	sortPlayerHand(g.players[playerIdx], bySuitThenValue)
 }
 
 // --- CPU AI ---

--- a/internal/domain/Rook.go
+++ b/internal/domain/Rook.go
@@ -1138,10 +1138,7 @@ func (g *Rook) IsHumanTurn() bool {
 
 // IsHumanBidTurn 現在のビッド手番が人間かどうか
 func (g *Rook) IsHumanBidTurn() bool {
-	if g.bidPlayerIdx < 0 || g.bidPlayerIdx >= len(g.players) {
-		return false
-	}
-	return g.players[g.bidPlayerIdx].GetIsHuman()
+	return isHumanTurn(g.players, g.bidPlayerIdx)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/Rummy500.go
+++ b/internal/domain/Rummy500.go
@@ -663,13 +663,7 @@ func (g *Rummy500) sortAllHands() {
 }
 
 func (g *Rummy500) sortHand(playerIdx int) {
-	p := g.players[playerIdx]
-	sortPlayerHand(p, func(ci, cj *Card) bool {
-		if ci.GetDesign() != cj.GetDesign() {
-			return ci.GetDesign() < cj.GetDesign()
-		}
-		return ci.GetValue() < cj.GetValue()
-	})
+	sortPlayerHand(g.players[playerIdx], bySuitThenValue)
 }
 
 // --- Meld / Run / Set / Layoff helpers ---

--- a/internal/domain/Samba.go
+++ b/internal/domain/Samba.go
@@ -1620,13 +1620,7 @@ func (g *Samba) sortAllHands() {
 
 // sortHand プレイヤーの手札をスート→値の順にソートする
 func (g *Samba) sortHand(playerIdx int) {
-	p := g.players[playerIdx]
-	sortPlayerHand(p, func(ci, cj *Card) bool {
-		if ci.GetDesign() != cj.GetDesign() {
-			return ci.GetDesign() < cj.GetDesign()
-		}
-		return ci.GetValue() < cj.GetValue()
-	})
+	sortPlayerHand(g.players[playerIdx], bySuitThenValue)
 }
 
 // --- JSON serialization ---

--- a/internal/domain/SeahavenTowers.go
+++ b/internal/domain/SeahavenTowers.go
@@ -536,12 +536,7 @@ func (s *SeahavenTowers) canPlaceOnTableau(card *Card, col int) bool {
 
 // canPlaceOnFoundation ファンデーションにカードを置けるか判定
 func (s *SeahavenTowers) canPlaceOnFoundation(card *Card, fIdx int) bool {
-	pile := s.foundation[fIdx]
-	if len(pile) == 0 {
-		return card.GetValue() == 1
-	}
-	topCard := pile[len(pile)-1]
-	return card.GetDesign() == topCard.GetDesign() && card.GetValue() == topCard.GetValue()+1
+	return canPlaceOnFoundationPile(s.foundation[fIdx], card)
 }
 
 // isSameSuitDescending lower が upper の上に積めるか判定 (同スートで lower.value == upper.value - 1)

--- a/internal/domain/SevenBridge.go
+++ b/internal/domain/SevenBridge.go
@@ -949,13 +949,7 @@ func (g *SevenBridge) sortAllHands() {
 }
 
 func (g *SevenBridge) sortHand(playerIdx int) {
-	p := g.players[playerIdx]
-	sortPlayerHand(p, func(ci, cj *Card) bool {
-		if ci.GetDesign() != cj.GetDesign() {
-			return ci.GetDesign() < cj.GetDesign()
-		}
-		return ci.GetValue() < cj.GetValue()
-	})
+	sortPlayerHand(g.players[playerIdx], bySuitThenValue)
 }
 
 // --- Pure helpers ---

--- a/internal/domain/Spades.go
+++ b/internal/domain/Spades.go
@@ -405,10 +405,7 @@ func (s *Spades) IsHumanTurn() bool {
 
 // IsHumanBidTurn 現在のビッド手番が人間かどうか
 func (s *Spades) IsHumanBidTurn() bool {
-	if s.bidPlayerIdx < 0 || s.bidPlayerIdx >= len(s.players) {
-		return false
-	}
-	return s.players[s.bidPlayerIdx].GetIsHuman()
+	return isHumanTurn(s.players, s.bidPlayerIdx)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/StreetsAndAlleys.go
+++ b/internal/domain/StreetsAndAlleys.go
@@ -379,12 +379,7 @@ func (sa *StreetsAndAlleys) canPlaceOnTableau(card *Card, col int) bool {
 
 // canPlaceOnFoundation ファンデーションにカードを置けるか判定
 func (sa *StreetsAndAlleys) canPlaceOnFoundation(card *Card, fIdx int) bool {
-	pile := sa.foundation[fIdx]
-	if len(pile) == 0 {
-		return card.GetValue() == 1
-	}
-	topCard := pile[len(pile)-1]
-	return card.GetDesign() == topCard.GetDesign() && card.GetValue() == topCard.GetValue()+1
+	return canPlaceOnFoundationPile(sa.foundation[fIdx], card)
 }
 
 // findFoundation カードを置けるファンデーションのインデックスを探す（見つからない場合-1）

--- a/internal/domain/Tarneeb.go
+++ b/internal/domain/Tarneeb.go
@@ -548,10 +548,7 @@ func (t *Tarneeb) IsHumanTurn() bool {
 
 // IsHumanBidTurn 現在のビッド手番が人間かどうか
 func (t *Tarneeb) IsHumanBidTurn() bool {
-	if t.bidPlayerIdx < 0 || t.bidPlayerIdx >= len(t.players) {
-		return false
-	}
-	return t.players[t.bidPlayerIdx].GetIsHuman()
+	return isHumanTurn(t.players, t.bidPlayerIdx)
 }
 
 // IsHumanTrumpTurn 現在のトランプ宣言手番が人間かどうか

--- a/internal/domain/Terrace.go
+++ b/internal/domain/Terrace.go
@@ -446,18 +446,7 @@ func (t *Terrace) CanUndo() bool { return len(t.history) > 0 }
 
 // UndoN n 手戻す
 func (t *Terrace) UndoN(n int) error {
-	if n <= 0 {
-		return errors.New("n must be positive")
-	}
-	if n > len(t.history) {
-		return errors.New("not enough history")
-	}
-	for range n {
-		if err := t.Undo(); err != nil {
-			return err
-		}
-	}
-	return nil
+	return undoNChecked(t, n, len(t.history))
 }
 
 // UndoToEscape 膠着状態から抜けるのに必要なアンドゥ回数（膠着でなければ 0、不可なら -1）

--- a/internal/domain/Tonk.go
+++ b/internal/domain/Tonk.go
@@ -720,13 +720,7 @@ func (g *Tonk) sortAllHands() {
 
 // sortHand プレイヤーの手札をスート→値の順にソートする
 func (g *Tonk) sortHand(playerIdx int) {
-	p := g.players[playerIdx]
-	sortPlayerHand(p, func(ci, cj *Card) bool {
-		if ci.GetDesign() != cj.GetDesign() {
-			return ci.GetDesign() < cj.GetDesign()
-		}
-		return ci.GetValue() < cj.GetValue()
-	})
+	sortPlayerHand(g.players[playerIdx], bySuitThenValue)
 }
 
 // tonkJSON is the JSON wire format for Tonk.

--- a/internal/domain/Windmill.go
+++ b/internal/domain/Windmill.go
@@ -411,18 +411,7 @@ func (w *Windmill) CanUndo() bool { return len(w.history) > 0 }
 
 // UndoN n 手戻す
 func (w *Windmill) UndoN(n int) error {
-	if n <= 0 {
-		return errors.New("n must be positive")
-	}
-	if n > len(w.history) {
-		return errors.New("not enough history")
-	}
-	for range n {
-		if err := w.Undo(); err != nil {
-			return err
-		}
-	}
-	return nil
+	return undoNChecked(w, n, len(w.history))
 }
 
 // UndoToEscape 膠着状態から抜けるのに必要なアンドゥ回数（膠着でなければ 0、不可なら -1）

--- a/internal/domain/Wizard.go
+++ b/internal/domain/Wizard.go
@@ -431,10 +431,7 @@ func (o *Wizard) IsHumanTurn() bool {
 
 // IsHumanBidTurn 現在のビッド手番が人間かどうか
 func (o *Wizard) IsHumanBidTurn() bool {
-	if o.bidPlayerIdx < 0 || o.bidPlayerIdx >= len(o.players) {
-		return false
-	}
-	return o.players[o.bidPlayerIdx].GetIsHuman()
+	return isHumanTurn(o.players, o.bidPlayerIdx)
 }
 
 // GetConfig 設定取得

--- a/internal/domain/player_helpers.go
+++ b/internal/domain/player_helpers.go
@@ -1,6 +1,7 @@
 package domain
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 )
@@ -264,4 +265,47 @@ func undoN(g undoer, n int) error {
 		}
 	}
 	return nil
+}
+
+// undoNChecked undoes n moves after validating the request against the history
+// length, so a bad n is rejected before the game is half-rewound. 10 solitaires
+// had this written out.
+//
+// The history is passed as a length rather than a slice because each game's
+// snapshot type is its own struct. Interface parameter for the same reason as
+// undoN above: it keeps one copy of the shared body. See issue #5185.
+func undoNChecked(g undoer, n, historyLen int) error {
+	if n <= 0 {
+		return errors.New("n must be positive")
+	}
+	if n > historyLen {
+		return errors.New("not enough history")
+	}
+	for range n {
+		if err := g.Undo(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// canPlaceOnFoundationPile reports whether card may go on a foundation pile:
+// an ace onto an empty pile, otherwise the next rank up in the same suit.
+// 9 solitaires had this written out. Needs no type parameter -- every
+// foundation is a [][]*Card. See issue #5185.
+func canPlaceOnFoundationPile(pile []*Card, card *Card) bool {
+	if len(pile) == 0 {
+		return card.GetValue() == 1
+	}
+	top := pile[len(pile)-1]
+	return card.GetDesign() == top.GetDesign() && card.GetValue() == top.GetValue()+1
+}
+
+// bySuitThenValue orders cards by suit, then by rank within a suit. 13 games
+// passed this exact comparator to sortPlayerHand.
+func bySuitThenValue(ci, cj *Card) bool {
+	if ci.GetDesign() != cj.GetDesign() {
+		return ci.GetDesign() < cj.GetDesign()
+	}
+	return ci.GetValue() < cj.GetValue()
 }

--- a/internal/domain/player_helpers_internal_test.go
+++ b/internal/domain/player_helpers_internal_test.go
@@ -487,3 +487,59 @@ func TestUndoN_StopsAtTheFailingStep(t *testing.T) {
 	assert.Contains(t, err.Error(), "undo step 2 failed")
 	assert.ErrorIs(t, err, assert.AnError, "the cause must stay wrapped")
 }
+
+func TestUndoNChecked(t *testing.T) {
+	u := &fakeUndoer{}
+
+	require.NoError(t, undoNChecked(u, 2, 5))
+	assert.Equal(t, 2, u.calls)
+}
+
+// n and the history length are both rejected before any Undo runs, so a bad
+// request cannot leave the game half-rewound.
+func TestUndoNChecked_RejectsBeforeUndoing(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		n, history int
+		want       string
+	}{
+		{"zero", 0, 5, "n must be positive"},
+		{"negative", -1, 5, "n must be positive"},
+		{"beyond history", 6, 5, "not enough history"},
+		{"empty history", 1, 0, "not enough history"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			u := &fakeUndoer{}
+			err := undoNChecked(u, tc.n, tc.history)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.want)
+			assert.Equal(t, 0, u.calls, "must not undo anything")
+		})
+	}
+}
+
+func TestUndoNChecked_StopsOnFailure(t *testing.T) {
+	u := &fakeUndoer{failAt: 2}
+
+	require.Error(t, undoNChecked(u, 4, 9))
+	assert.Equal(t, 2, u.calls)
+}
+
+func TestCanPlaceOnFoundationPile(t *testing.T) {
+	// An empty foundation takes only an ace.
+	assert.True(t, canPlaceOnFoundationPile(nil, NewCard(1, 1, false)))
+	assert.False(t, canPlaceOnFoundationPile(nil, NewCard(1, 2, false)))
+
+	pile := []*Card{NewCard(1, 1, false)}
+	assert.True(t, canPlaceOnFoundationPile(pile, NewCard(1, 2, false)), "same suit, next rank")
+	assert.False(t, canPlaceOnFoundationPile(pile, NewCard(2, 2, false)), "wrong suit")
+	assert.False(t, canPlaceOnFoundationPile(pile, NewCard(1, 3, false)), "skips a rank")
+	assert.False(t, canPlaceOnFoundationPile(pile, NewCard(1, 1, false)), "same rank")
+}
+
+func TestBySuitThenValue(t *testing.T) {
+	assert.True(t, bySuitThenValue(NewCard(1, 9, false), NewCard(2, 2, false)), "suit wins over value")
+	assert.False(t, bySuitThenValue(NewCard(2, 2, false), NewCard(1, 9, false)))
+	assert.True(t, bySuitThenValue(NewCard(1, 3, false), NewCard(1, 5, false)), "same suit falls back to value")
+	assert.False(t, bySuitThenValue(NewCard(1, 5, false), NewCard(1, 3, false)))
+}


### PR DESCRIPTION
#5185 の残り（≥15 の帯を片付けた後の長い尾）の第1バッチです。**-275行**。

| クラスタ | 件数 | 行/件 | 削減 | 方式 |
|---|---:|---:|---:|---|
| `UndoN`（12行の検査つき版） | 10 | 12 | -110 | インタフェース引数 |
| `sortHand` | 13 | 7 | -78 | **既存 `sortPlayerHand` + 比較関数の命名** |
| `canPlaceOnFoundation` | 9 | 6 | -45 | **型パラメータ不要の関数** |
| `IsHumanBidTurn` | 14 | 4 | -42 | **既存 `isHumanTurn` を再利用** |
| **合計** | **46** | | **-275** | |

## 4件中2件は新しいものを足していません

- `IsHumanBidTurn` は #5203 で入れた `isHumanTurn(players, idx)` に委譲するだけです。境界チェックの意味論も一致しています（範囲外は false）。
- `sortHand` は既存の `sortPlayerHand` を呼んでおり、13箇所で書き写されていた比較関数に `bySuitThenValue` という名前を与えただけです。

`canPlaceOnFoundation` は `foundation [][]*Card` が共有型なので**型パラメータ不要**にできました（#5209 で -1,793 を出した形）。

`UndoN` の12行版は #5212 で畳んだ6行版とは別本体です。`n` と履歴長を**両方 Undo 実行前に検査**するので、不正な要求でゲームが途中まで巻き戻ることがありません。テストでその順序（検査 → Undo）を、`u.calls == 0` で固定しています。

## 検証

- `go test -tags test ./...` 全パッケージ通過 / `golangci-lint` 0 issues
- 各クラスタとも**本体がバイト一致するものだけ**を置換し、件数が想定（10/9/13/14）と違えば中断する作りです
- `goimports -l` が空 = 未使用 import なし
- ヘルパは call-site 書き換えの**前**に別コミット（`5871272`）

Worker サイズは CI 実測後に報告します。

Refs #5185