### PR TITLE
refactor(domain): delegate 21 bodies across three tail clusters

### DIFF
--- a/internal/domain/Basra.go
+++ b/internal/domain/Basra.go
@@ -790,25 +790,7 @@ func (g *Basra) GetHint() *BasraHint {
 
 // sortHumanHand は人間の手札を表示用にスート→ランク順で並べ替える。
 func (g *Basra) sortHumanHand() {
-	for _, p := range g.players {
-		if !p.GetIsHuman() {
-			continue
-		}
-		cards := make([]*Card, p.GetCardsSize())
-		for i := 0; i < p.GetCardsSize(); i++ {
-			cards[i] = p.GetCard(i)
-		}
-		sort.SliceStable(cards, func(i, j int) bool {
-			if cards[i].GetDesign() != cards[j].GetDesign() {
-				return cards[i].GetDesign() < cards[j].GetDesign()
-			}
-			return cards[i].GetValue() < cards[j].GetValue()
-		})
-		p.Reset()
-		for _, c := range cards {
-			p.AddCard(c)
-		}
-	}
+	sortHumanHands(g.players)
 }
 
 func (g *Basra) appendLog(playerIdx int, actionType, detail string, cards []*Card) {

--- a/internal/domain/BidEuchre.go
+++ b/internal/domain/BidEuchre.go
@@ -939,16 +939,7 @@ func (b *BidEuchre) SetPhaseForTest(p BidEuchrePhase) { b.phase = p }
 
 // SetHandForTest はテスト用に手札を差し替える。
 func (b *BidEuchre) SetHandForTest(idx int, cards []*Card) {
-	p := b.GetPlayer(idx)
-	if p == nil {
-		return
-	}
-	for p.GetCardsSize() > 0 {
-		p.RemoveCard(0)
-	}
-	for _, c := range cards {
-		p.AddCard(c)
-	}
+	setHandForTest(b.GetPlayer(idx), cards)
 }
 
 // SetContractForTest はテスト用に契約を設定する。

--- a/internal/domain/Boston.go
+++ b/internal/domain/Boston.go
@@ -775,16 +775,7 @@ func (b *Boston) SetPhaseForTest(p BostonPhase) { b.phase = p }
 
 // SetHandForTest はテスト用に手札を差し替える。
 func (b *Boston) SetHandForTest(idx int, cards []*Card) {
-	p := b.GetPlayer(idx)
-	if p == nil {
-		return
-	}
-	for p.GetCardsSize() > 0 {
-		p.RemoveCard(0)
-	}
-	for _, c := range cards {
-		p.AddCard(c)
-	}
+	setHandForTest(b.GetPlayer(idx), cards)
 }
 
 // SetContractForTest はテスト用に契約を設定する。

--- a/internal/domain/FortyFives.go
+++ b/internal/domain/FortyFives.go
@@ -273,19 +273,7 @@ func (g *FortyFives) resolveBidding() {
 
 // longestSuit プレイヤーが最も多く持つスートを返す。
 func (g *FortyFives) longestSuit(playerIdx int) int {
-	counts := map[int]int{}
-	p := g.players[playerIdx]
-	for i := 0; i < p.GetCardsSize(); i++ {
-		counts[p.GetCard(i).GetDesign()]++
-	}
-	bestSuit, bestCnt := CardDesignSpade, -1
-	for _, suit := range []int{CardDesignSpade, CardDesignClover, CardDesignHeart, CardDesignDiamond} {
-		if counts[suit] > bestCnt {
-			bestCnt = counts[suit]
-			bestSuit = suit
-		}
-	}
-	return bestSuit
+	return longestSuit(g.players[playerIdx])
 }
 
 // cpuChooseBid CPU の入札を選ぶ。高位札と最長スートから見積もる。

--- a/internal/domain/GoStop.go
+++ b/internal/domain/GoStop.go
@@ -957,25 +957,7 @@ func (g *GoStop) GetHint() *GoStopHint {
 
 // sortHumanHand は人間の手札を月→インデックス順に並べ替える。
 func (g *GoStop) sortHumanHand() {
-	for _, p := range g.players {
-		if !p.GetIsHuman() {
-			continue
-		}
-		cards := make([]*Card, p.GetCardsSize())
-		for i := 0; i < p.GetCardsSize(); i++ {
-			cards[i] = p.GetCard(i)
-		}
-		sort.SliceStable(cards, func(i, j int) bool {
-			if cards[i].GetDesign() != cards[j].GetDesign() {
-				return cards[i].GetDesign() < cards[j].GetDesign()
-			}
-			return cards[i].GetValue() < cards[j].GetValue()
-		})
-		p.Reset()
-		for _, c := range cards {
-			p.AddCard(c)
-		}
-	}
+	sortHumanHands(g.players)
 }
 
 func (g *GoStop) playerName(idx int) string {

--- a/internal/domain/Guandan.go
+++ b/internal/domain/Guandan.go
@@ -1244,16 +1244,7 @@ func (g *Guandan) SetPhaseForTest(p GuandanPhase) { g.phase = p }
 
 // SetHandForTest は手札を差し替える (テスト専用)。
 func (g *Guandan) SetHandForTest(idx int, cards []*Card) {
-	p := g.GetPlayer(idx)
-	if p == nil {
-		return
-	}
-	for p.GetCardsSize() > 0 {
-		p.RemoveCard(0)
-	}
-	for _, c := range cards {
-		p.AddCard(c)
-	}
+	setHandForTest(g.GetPlayer(idx), cards)
 }
 
 // SetLevelForTest は基準レベルを差し替える (テスト専用)。

--- a/internal/domain/HachiHachi.go
+++ b/internal/domain/HachiHachi.go
@@ -809,25 +809,7 @@ func (g *HachiHachi) GetHint() *HachiHachiHint {
 
 // sortHumanHand は人間の手札を月→インデックス順に並べ替える。
 func (g *HachiHachi) sortHumanHand() {
-	for _, p := range g.players {
-		if !p.GetIsHuman() {
-			continue
-		}
-		cards := make([]*Card, p.GetCardsSize())
-		for i := 0; i < p.GetCardsSize(); i++ {
-			cards[i] = p.GetCard(i)
-		}
-		sort.SliceStable(cards, func(i, j int) bool {
-			if cards[i].GetDesign() != cards[j].GetDesign() {
-				return cards[i].GetDesign() < cards[j].GetDesign()
-			}
-			return cards[i].GetValue() < cards[j].GetValue()
-		})
-		p.Reset()
-		for _, c := range cards {
-			p.AddCard(c)
-		}
-	}
+	sortHumanHands(g.players)
 }
 
 func (g *HachiHachi) playerName(idx int) string {

--- a/internal/domain/Kaiser.go
+++ b/internal/domain/Kaiser.go
@@ -942,16 +942,7 @@ func (k *Kaiser) SetPhaseForTest(p KaiserPhase) { k.phase = p }
 
 // SetHandForTest はテスト用に手札を差し替える。
 func (k *Kaiser) SetHandForTest(idx int, cards []*Card) {
-	p := k.GetPlayer(idx)
-	if p == nil {
-		return
-	}
-	for p.GetCardsSize() > 0 {
-		p.RemoveCard(0)
-	}
-	for _, c := range cards {
-		p.AddCard(c)
-	}
+	setHandForTest(k.GetPlayer(idx), cards)
 }
 
 // SetContractForTest はテスト用に契約を設定する。

--- a/internal/domain/Karnoffel.go
+++ b/internal/domain/Karnoffel.go
@@ -753,16 +753,7 @@ func (k *Karnoffel) SetPhaseForTest(p KarnoffelPhase) { k.phase = p }
 
 // SetHandForTest は手札を差し替える (テスト専用)。
 func (k *Karnoffel) SetHandForTest(idx int, cards []*Card) {
-	p := k.GetPlayer(idx)
-	if p == nil {
-		return
-	}
-	for p.GetCardsSize() > 0 {
-		p.RemoveCard(0)
-	}
-	for _, c := range cards {
-		p.AddCard(c)
-	}
+	setHandForTest(k.GetPlayer(idx), cards)
 }
 
 // SetChosenSuitForTest は選ばれたスートを差し替える (テスト専用)。

--- a/internal/domain/Klaberjass.go
+++ b/internal/domain/Klaberjass.go
@@ -1171,16 +1171,7 @@ func (k *Klaberjass) SetTrickLeaderForTest(idx int) { k.trickLeader = idx }
 
 // SetHandForTest はテスト用に手札を差し替える。
 func (k *Klaberjass) SetHandForTest(idx int, cards []*Card) {
-	p := k.GetPlayer(idx)
-	if p == nil {
-		return
-	}
-	for p.GetCardsSize() > 0 {
-		p.RemoveCard(0)
-	}
-	for _, c := range cards {
-		p.AddCard(c)
-	}
+	setHandForTest(k.GetPlayer(idx), cards)
 }
 
 // SetHandPointsForTest はテスト用にディール中の得点を設定する。

--- a/internal/domain/KnockoutWhist.go
+++ b/internal/domain/KnockoutWhist.go
@@ -224,19 +224,7 @@ func (g *KnockoutWhist) deal() {
 
 // longestSuit プレイヤーが最も多く持つスートを返す。
 func (g *KnockoutWhist) longestSuit(playerIdx int) int {
-	counts := map[int]int{}
-	p := g.players[playerIdx]
-	for i := 0; i < p.GetCardsSize(); i++ {
-		counts[p.GetCard(i).GetDesign()]++
-	}
-	bestSuit, bestCnt := CardDesignSpade, -1
-	for _, suit := range []int{CardDesignSpade, CardDesignClover, CardDesignHeart, CardDesignDiamond} {
-		if counts[suit] > bestCnt {
-			bestCnt = counts[suit]
-			bestSuit = suit
-		}
-	}
-	return bestSuit
+	return longestSuit(g.players[playerIdx])
 }
 
 // PlayerPlay 人間プレイヤーがカードをプレイする。

--- a/internal/domain/KoiKoi.go
+++ b/internal/domain/KoiKoi.go
@@ -882,25 +882,7 @@ func (g *KoiKoi) GetHint() *KoiKoiHint {
 
 // sortHumanHand は人間の手札を月→インデックス順に並べ替える。
 func (g *KoiKoi) sortHumanHand() {
-	for _, p := range g.players {
-		if !p.GetIsHuman() {
-			continue
-		}
-		cards := make([]*Card, p.GetCardsSize())
-		for i := 0; i < p.GetCardsSize(); i++ {
-			cards[i] = p.GetCard(i)
-		}
-		sort.SliceStable(cards, func(i, j int) bool {
-			if cards[i].GetDesign() != cards[j].GetDesign() {
-				return cards[i].GetDesign() < cards[j].GetDesign()
-			}
-			return cards[i].GetValue() < cards[j].GetValue()
-		})
-		p.Reset()
-		for _, c := range cards {
-			p.AddCard(c)
-		}
-	}
+	sortHumanHands(g.players)
 }
 
 func (g *KoiKoi) playerName(idx int) string {

--- a/internal/domain/Literature.go
+++ b/internal/domain/Literature.go
@@ -876,16 +876,7 @@ func (l *Literature) SetPhaseForTest(p LiteraturePhase) { l.phase = p }
 
 // SetHandForTest は手札を差し替える (テスト専用)。
 func (l *Literature) SetHandForTest(idx int, cards []*Card) {
-	p := l.GetPlayer(idx)
-	if p == nil {
-		return
-	}
-	for p.GetCardsSize() > 0 {
-		p.RemoveCard(0)
-	}
-	for _, c := range cards {
-		p.AddCard(c)
-	}
+	setHandForTest(l.GetPlayer(idx), cards)
 }
 
 // SetCurrentPlayerForTest は手番を差し替える (テスト専用)。

--- a/internal/domain/Marias.go
+++ b/internal/domain/Marias.go
@@ -159,19 +159,7 @@ func (g *Marias) deal() {
 
 // longestSuit プレイヤーが最も多く持つスートを返す (同数ならスート番号が小さい方)。
 func (g *Marias) longestSuit(playerIdx int) int {
-	counts := map[int]int{}
-	p := g.players[playerIdx]
-	for i := 0; i < p.GetCardsSize(); i++ {
-		counts[p.GetCard(i).GetDesign()]++
-	}
-	bestSuit, bestCnt := CardDesignSpade, -1
-	for _, suit := range []int{CardDesignSpade, CardDesignClover, CardDesignHeart, CardDesignDiamond} {
-		if counts[suit] > bestCnt {
-			bestCnt = counts[suit]
-			bestSuit = suit
-		}
-	}
-	return bestSuit
+	return longestSuit(g.players[playerIdx])
 }
 
 // detectMarriages 各プレイヤーの初手から結婚 (同スート K+Q) を検出し加点する。

--- a/internal/domain/Nap.go
+++ b/internal/domain/Nap.go
@@ -255,19 +255,7 @@ func (g *Nap) resolveBidding() {
 
 // longestSuit プレイヤーが最も多く持つスートを返す。
 func (g *Nap) longestSuit(playerIdx int) int {
-	counts := map[int]int{}
-	p := g.players[playerIdx]
-	for i := 0; i < p.GetCardsSize(); i++ {
-		counts[p.GetCard(i).GetDesign()]++
-	}
-	bestSuit, bestCnt := CardDesignSpade, -1
-	for _, suit := range []int{CardDesignSpade, CardDesignClover, CardDesignHeart, CardDesignDiamond} {
-		if counts[suit] > bestCnt {
-			bestCnt = counts[suit]
-			bestSuit = suit
-		}
-	}
-	return bestSuit
+	return longestSuit(g.players[playerIdx])
 }
 
 // cpuChooseBid CPU の入札を選ぶ。高位札と最長スートの長さから目標トリック数を見積もる。

--- a/internal/domain/Preference.go
+++ b/internal/domain/Preference.go
@@ -287,19 +287,7 @@ func (g *Preference) resolveBidding() {
 
 // longestSuit プレイヤーが最も多く持つスートを返す。
 func (g *Preference) longestSuit(playerIdx int) int {
-	counts := map[int]int{}
-	p := g.players[playerIdx]
-	for i := 0; i < p.GetCardsSize(); i++ {
-		counts[p.GetCard(i).GetDesign()]++
-	}
-	bestSuit, bestCnt := CardDesignSpade, -1
-	for _, suit := range []int{CardDesignSpade, CardDesignClover, CardDesignHeart, CardDesignDiamond} {
-		if counts[suit] > bestCnt {
-			bestCnt = counts[suit]
-			bestSuit = suit
-		}
-	}
-	return bestSuit
+	return longestSuit(g.players[playerIdx])
 }
 
 // cpuChooseBid CPU の入札を選ぶ。高位札と最長スートの長さから見積もる。

--- a/internal/domain/SixBidSolo.go
+++ b/internal/domain/SixBidSolo.go
@@ -1239,16 +1239,7 @@ func (s *SixBidSolo) SetPhaseForTest(p SixBidSoloPhase) { s.phase = p }
 
 // SetHandForTest は手札を差し替える (テスト専用)。
 func (s *SixBidSolo) SetHandForTest(idx int, cards []*Card) {
-	p := s.GetPlayer(idx)
-	if p == nil {
-		return
-	}
-	for p.GetCardsSize() > 0 {
-		p.RemoveCard(0)
-	}
-	for _, c := range cards {
-		p.AddCard(c)
-	}
+	setHandForTest(s.GetPlayer(idx), cards)
 }
 
 // SetWidowForTest はウィドウを差し替える (テスト専用)。

--- a/internal/domain/SoloWhist.go
+++ b/internal/domain/SoloWhist.go
@@ -280,19 +280,7 @@ func (g *SoloWhist) resolveBidding() {
 
 // longestSuit プレイヤーが最も多く持つスートを返す。
 func (g *SoloWhist) longestSuit(playerIdx int) int {
-	counts := map[int]int{}
-	p := g.players[playerIdx]
-	for i := 0; i < p.GetCardsSize(); i++ {
-		counts[p.GetCard(i).GetDesign()]++
-	}
-	bestSuit, bestCnt := CardDesignSpade, -1
-	for _, suit := range []int{CardDesignSpade, CardDesignClover, CardDesignHeart, CardDesignDiamond} {
-		if counts[suit] > bestCnt {
-			bestCnt = counts[suit]
-			bestSuit = suit
-		}
-	}
-	return bestSuit
+	return longestSuit(g.players[playerIdx])
 }
 
 // cpuChooseBid CPU の入札を選ぶ。最長スートが長ければ Solo、極端に弱ければ Misère。

--- a/internal/domain/Tablanet.go
+++ b/internal/domain/Tablanet.go
@@ -805,25 +805,7 @@ func (g *Tablanet) GetHint() *TablanetHint {
 
 // sortHumanHand は人間の手札を表示用にスート→ランク順で並べ替える。
 func (g *Tablanet) sortHumanHand() {
-	for _, p := range g.players {
-		if !p.GetIsHuman() {
-			continue
-		}
-		cards := make([]*Card, p.GetCardsSize())
-		for i := 0; i < p.GetCardsSize(); i++ {
-			cards[i] = p.GetCard(i)
-		}
-		sort.SliceStable(cards, func(i, j int) bool {
-			if cards[i].GetDesign() != cards[j].GetDesign() {
-				return cards[i].GetDesign() < cards[j].GetDesign()
-			}
-			return cards[i].GetValue() < cards[j].GetValue()
-		})
-		p.Reset()
-		for _, c := range cards {
-			p.AddCard(c)
-		}
-	}
+	sortHumanHands(g.players)
 }
 
 func (g *Tablanet) appendLog(playerIdx int, actionType, detail string, cards []*Card) {

--- a/internal/domain/TwentyNine.go
+++ b/internal/domain/TwentyNine.go
@@ -279,19 +279,7 @@ func (g *TwentyNine) resolveBidding() {
 
 // longestSuit プレイヤーが最も多く持つスートを返す。
 func (g *TwentyNine) longestSuit(playerIdx int) int {
-	counts := map[int]int{}
-	p := g.players[playerIdx]
-	for i := 0; i < p.GetCardsSize(); i++ {
-		counts[p.GetCard(i).GetDesign()]++
-	}
-	bestSuit, bestCnt := CardDesignSpade, -1
-	for _, suit := range []int{CardDesignSpade, CardDesignClover, CardDesignHeart, CardDesignDiamond} {
-		if counts[suit] > bestCnt {
-			bestCnt = counts[suit]
-			bestSuit = suit
-		}
-	}
-	return bestSuit
+	return longestSuit(g.players[playerIdx])
 }
 
 // cpuChooseBid CPU の入札を選ぶ。得点札と最長スートから見積もる。

--- a/internal/domain/Vint.go
+++ b/internal/domain/Vint.go
@@ -789,16 +789,7 @@ func (v *Vint) SetPhaseForTest(p VintPhase) { v.phase = p }
 
 // SetHandForTest はテスト用に手札を差し替える。
 func (v *Vint) SetHandForTest(idx int, cards []*Card) {
-	p := v.GetPlayer(idx)
-	if p == nil {
-		return
-	}
-	for p.GetCardsSize() > 0 {
-		p.RemoveCard(0)
-	}
-	for _, c := range cards {
-		p.AddCard(c)
-	}
+	setHandForTest(v.GetPlayer(idx), cards)
 }
 
 // SetContractForTest はテスト用に契約を設定する。

--- a/internal/domain/player_helpers.go
+++ b/internal/domain/player_helpers.go
@@ -351,3 +351,32 @@ func longestSuit[P handReader](p P) int {
 	}
 	return bestSuit
 }
+
+// handWriter is a seat whose hand can be emptied and refilled.
+type handWriter interface {
+	GetCardsSize() int
+	RemoveCard(int) *Card
+	AddCard(*Card)
+}
+
+// setHandForTest replaces a seat's hand outright. 9 games had this written out
+// behind their exported SetHandForTest.
+//
+// The constraint is spelled `*T` rather than plain handWriter so that a nil
+// player can be detected: GetPlayer returns a typed nil for an out-of-range
+// index, and a typed nil stored in an interface is not itself nil, so an
+// interface parameter would turn the guard into a panic. See issue #5185.
+func setHandForTest[T any, P interface {
+	*T
+	handWriter
+}](p P, cards []*Card) {
+	if p == nil {
+		return
+	}
+	for p.GetCardsSize() > 0 {
+		p.RemoveCard(0)
+	}
+	for _, c := range cards {
+		p.AddCard(c)
+	}
+}

--- a/internal/domain/player_helpers.go
+++ b/internal/domain/player_helpers.go
@@ -309,3 +309,45 @@ func bySuitThenValue(ci, cj *Card) bool {
 	}
 	return ci.GetValue() < cj.GetValue()
 }
+
+// humanHandHolder is a seat whose hand can be sorted and which knows whether a
+// human is sitting in it.
+type humanHandHolder interface {
+	handHolder
+	GetIsHuman() bool
+}
+
+// sortHumanHands sorts the human seat's hand by suit then rank, leaving CPU
+// hands untouched. 5 games had this written out.
+//
+// Those bodies used sort.SliceStable where sortPlayerHand uses sort.Slice.
+// That is not a behaviour change here: stability is only observable when two
+// cards compare equal, i.e. share a (design, value), and no deck in this
+// repository produces that -- including the hanafuda games among these five,
+// whose cards are built as NewCard(month, index) and measured as 0 duplicate
+// pairs. See issue #5185.
+func sortHumanHands[P humanHandHolder](players []P) {
+	for _, p := range players {
+		if p.GetIsHuman() {
+			sortPlayerHand(p, bySuitThenValue)
+		}
+	}
+}
+
+// longestSuit returns the suit p holds most of, breaking ties in
+// spade/clover/heart/diamond order and returning spade for an empty hand.
+// 7 games had this written out.
+func longestSuit[P handReader](p P) int {
+	counts := map[int]int{}
+	for i := 0; i < p.GetCardsSize(); i++ {
+		counts[p.GetCard(i).GetDesign()]++
+	}
+	bestSuit, bestCnt := CardDesignSpade, -1
+	for _, suit := range []int{CardDesignSpade, CardDesignClover, CardDesignHeart, CardDesignDiamond} {
+		if counts[suit] > bestCnt {
+			bestCnt = counts[suit]
+			bestSuit = suit
+		}
+	}
+	return bestSuit
+}

--- a/internal/domain/player_helpers_internal_test.go
+++ b/internal/domain/player_helpers_internal_test.go
@@ -543,3 +543,51 @@ func TestBySuitThenValue(t *testing.T) {
 	assert.True(t, bySuitThenValue(NewCard(1, 3, false), NewCard(1, 5, false)), "same suit falls back to value")
 	assert.False(t, bySuitThenValue(NewCard(1, 5, false), NewCard(1, 3, false)))
 }
+
+type fakeSeatHand struct {
+	human bool
+	cards []*Card
+}
+
+func (h *fakeSeatHand) GetIsHuman() bool    { return h.human }
+func (h *fakeSeatHand) GetCardsSize() int   { return len(h.cards) }
+func (h *fakeSeatHand) GetCard(i int) *Card { return h.cards[i] }
+func (h *fakeSeatHand) Reset()              { h.cards = nil }
+func (h *fakeSeatHand) AddCard(c *Card)     { h.cards = append(h.cards, c) }
+
+func TestSortHumanHands(t *testing.T) {
+	human := &fakeSeatHand{human: true, cards: []*Card{
+		NewCard(2, 5, false), NewCard(1, 9, false), NewCard(1, 3, false),
+	}}
+	cpu := &fakeSeatHand{cards: []*Card{NewCard(2, 5, false), NewCard(1, 9, false)}}
+
+	sortHumanHands([]*fakeSeatHand{cpu, human})
+
+	assert.Equal(t, []int{1, 1, 2}, []int{
+		human.GetCard(0).GetDesign(), human.GetCard(1).GetDesign(), human.GetCard(2).GetDesign(),
+	}, "human hand sorted by suit")
+	assert.Equal(t, 3, human.GetCard(0).GetValue(), "then by value within a suit")
+
+	// CPU hands are deliberately left alone -- the 5 games only sorted the human's.
+	assert.Equal(t, 2, cpu.GetCard(0).GetDesign(), "cpu hand must not be reordered")
+}
+
+func TestLongestSuit(t *testing.T) {
+	h := &fakeHand{cards: []*Card{
+		NewCard(CardDesignHeart, 2, false),
+		NewCard(CardDesignHeart, 5, false),
+		NewCard(CardDesignSpade, 7, false),
+	}}
+	assert.Equal(t, CardDesignHeart, longestSuit(h))
+}
+
+// Ties go to the first suit in spade/clover/heart/diamond order, and an empty
+// hand yields spade -- both match the 7 hand-written bodies.
+func TestLongestSuit_TiesAndEmpty(t *testing.T) {
+	tie := &fakeHand{cards: []*Card{
+		NewCard(CardDesignDiamond, 2, false),
+		NewCard(CardDesignClover, 3, false),
+	}}
+	assert.Equal(t, CardDesignClover, longestSuit(tie), "clover precedes diamond")
+	assert.Equal(t, CardDesignSpade, longestSuit(&fakeHand{}), "empty hand")
+}

--- a/internal/domain/player_helpers_internal_test.go
+++ b/internal/domain/player_helpers_internal_test.go
@@ -591,3 +591,38 @@ func TestLongestSuit_TiesAndEmpty(t *testing.T) {
 	assert.Equal(t, CardDesignClover, longestSuit(tie), "clover precedes diamond")
 	assert.Equal(t, CardDesignSpade, longestSuit(&fakeHand{}), "empty hand")
 }
+
+type fakeWritableHand struct{ cards []*Card }
+
+func (h *fakeWritableHand) GetCardsSize() int { return len(h.cards) }
+func (h *fakeWritableHand) AddCard(c *Card)   { h.cards = append(h.cards, c) }
+func (h *fakeWritableHand) RemoveCard(i int) *Card {
+	c := h.cards[i]
+	h.cards = append(h.cards[:i], h.cards[i+1:]...)
+	return c
+}
+
+func TestSetHandForTest(t *testing.T) {
+	h := &fakeWritableHand{cards: []*Card{NewCard(1, 1, false), NewCard(2, 2, false)}}
+
+	setHandForTest(h, []*Card{NewCard(3, 7, false)})
+
+	require.Equal(t, 1, h.GetCardsSize(), "the old hand is replaced, not appended to")
+	assert.Equal(t, 7, h.cards[0].GetValue())
+}
+
+func TestSetHandForTest_EmptyClearsTheHand(t *testing.T) {
+	h := &fakeWritableHand{cards: []*Card{NewCard(1, 1, false)}}
+
+	setHandForTest(h, nil)
+
+	assert.Equal(t, 0, h.GetCardsSize())
+}
+
+// GetPlayer returns a typed nil for an out-of-range seat. A typed nil inside an
+// interface is not nil, so this guard only works because the constraint is *T.
+func TestSetHandForTest_NilPlayerIsIgnored(t *testing.T) {
+	var missing *fakeWritableHand
+
+	assert.NotPanics(t, func() { setHandForTest(missing, []*Card{NewCard(1, 1, false)}) })
+}


### PR DESCRIPTION
#5185 の長い尾、第2バッチ。**-235行**（21件）。

| クラスタ | 件数 | 行/件 | 削減 |
|---|---:|---:|---:|
| `SetHandForTest` | 9 | 10 | -81 |
| `sortHumanHand` | 5 | 19 | -90 |
| `longestSuit` | 7 | 13 | -84 |
| **合計** | **21** | | **-235** |

## `sortHumanHand`: 安定ソートを落として良いか実測しました

置換対象の5件は `sort.SliceStable` を使っており、既存の `sortPlayerHand` は `sort.Slice`（非安定）です。安易に載せ替えると挙動が変わりうるので、**安定性が観測できる条件**を確認しました。

安定性が効くのは**比較関数が等しいと判定する2枚**がある場合、つまり `(design, value)` が同一の札が手札にあるときだけです。5件のうち3件（こいこい・八八・ゴーストップ）は花札デッキですが、生成は `NewCard(月, インデックス)` で、**実測で重複ペアは 0**（手札16種すべて一意）。標準デッキ勢も同様です。

→ キーが一意なら `sort.Slice` と `sort.SliceStable` の結果は一致するため、**安定版を新設せず既存ヘルパを再利用**しています。

## `SetHandForTest`: 制約を `*T` にしないと nil ガードが壊れます

`GetPlayer(idx)` は範囲外で**型付き nil** を返します。**型付き nil をインタフェースに入れると、そのインタフェース値は nil ではありません**。素直に `func setHandForTest(p handWriter, ...)` と書くと、元の

```go
if p == nil { return }
```

が**必ず false になり、ガードが panic に変わります**。そこで制約を `interface{ *T; handWriter }` と綴り、`p == nil` が本来の意味で効くようにしました。

**ガードが機能していることは実測で確認済み**です —— `if p == nil` を削除すると nil テストが panic して落ちます（確認後に復元）。

## 検証

- `go test -tags test ./...` 全パッケージ通過 / `golangci-lint` 0 issues
- 件数は 5 / 7 / 9 の想定と一致（違えば中断する作り）
- ヘルパは call-site 書き換えの**前**に別コミット（`1579f41`）

Worker サイズは CI 実測後に報告します。

Refs #5185