### PR TITLE
refactor(domain): delegate 39 bodies across five tail clusters

### DIFF
--- a/internal/domain/Aluette.go
+++ b/internal/domain/Aluette.go
@@ -318,13 +318,7 @@ func (g *Aluette) shuffle() {
 
 // drawCard デッキから 1 枚配る (尽きたら nil)。
 func (g *Aluette) drawCard() *Card {
-	if g.deckDrawCnt >= len(g.deck) {
-		return nil
-	}
-	card := g.deck[g.deckDrawCnt]
-	card.SetDraw(true)
-	g.deckDrawCnt++
-	return card
+	return drawFromDeck(g.deck, &g.deckDrawCnt)
 }
 
 // sortAllHands 手札を強い順に整列する。

--- a/internal/domain/AmericanToad.go
+++ b/internal/domain/AmericanToad.go
@@ -740,14 +740,7 @@ func (at *AmericanToad) fillEmptyColumnsFromReserve() {
 
 // afterMove 手数・棋譜・終了判定をまとめて進める
 func (at *AmericanToad) afterMove(actionType, detail string, card *Card) {
-	at.moveCount++
-	var cards []*Card
-	if card != nil {
-		cards = []*Card{card}
-	}
-	at.appendLog(actionType, detail, cards)
-	at.checkGameClear()
-	at.checkStalemate()
+	afterMove(&at.moveCount, at, actionType, detail, card)
 }
 
 // checkGameClear 8 つの基礎札がすべて 13 枚になったか

--- a/internal/domain/Badugi.go
+++ b/internal/domain/Badugi.go
@@ -481,13 +481,7 @@ func (b *Badugi) resetBettingRound() {
 // findNextActive returns the next seat after fromIdx that is not folded /
 // all-in. Used to select the first actor in a round.
 func (b *Badugi) findNextActive(fromIdx int) int {
-	for i := 1; i <= len(b.players); i++ {
-		next := (fromIdx + i) % len(b.players)
-		if !b.players[next].GetFolded() && !b.players[next].GetAllIn() {
-			return next
-		}
-	}
-	return (fromIdx + 1) % len(b.players)
+	return findNextActive(b.players, fromIdx)
 }
 
 func (b *Badugi) countActivePlayers() int {
@@ -879,15 +873,11 @@ func (b *Badugi) ExportProfile() any {
 
 // ImportProfile loads a profile from JSON bytes (no-op on empty input).
 func (b *Badugi) ImportProfile(data []byte) error {
-	if len(data) == 0 {
-		return nil
-	}
-	d, err := ImportBettingHumanProfileJSON(data)
-	if err != nil {
+	p, err := importBettingProfile(data)
+	if err != nil || p == nil {
 		return err
 	}
-	b.humanProfile = &BettingHumanProfile{}
-	b.humanProfile.Import(d)
+	b.humanProfile = p
 	return nil
 }
 

--- a/internal/domain/BettingHumanProfile.go
+++ b/internal/domain/BettingHumanProfile.go
@@ -167,3 +167,25 @@ func (p *BettingHumanProfile) AdjustedCallChance(base float64, bracket int, hesi
 func (p *BettingHumanProfile) AdjustedBluffChance(base float64) float64 {
 	return base * (1.0 + (p.FoldRate()-0.5)*p.AdaptStrength())
 }
+
+// importBettingProfile decodes a saved human profile, returning nil for empty
+// input so callers can leave their existing profile untouched. 8 betting games
+// had this written out.
+//
+// Lives here rather than in player_helpers.go because that file is compiled
+// into every Worker, while this one is tagged `!js || !wasm || casino` -- the
+// split that lets TinyGo drop the betting games from the other five binaries.
+// A helper naming BettingHumanProfile from an untagged file breaks those
+// builds, which `go test ./...` cannot show because it compiles everything.
+func importBettingProfile(data []byte) (*BettingHumanProfile, error) {
+	if len(data) == 0 {
+		return nil, nil
+	}
+	d, err := ImportBettingHumanProfileJSON(data)
+	if err != nil {
+		return nil, err
+	}
+	p := &BettingHumanProfile{}
+	p.Import(d)
+	return p, nil
+}

--- a/internal/domain/Braid.go
+++ b/internal/domain/Braid.go
@@ -668,14 +668,7 @@ func (b *Braid) refillFields() {
 
 // afterMove 手数・棋譜・終了判定をまとめて進める
 func (b *Braid) afterMove(actionType, detail string, card *Card) {
-	b.moveCount++
-	var cards []*Card
-	if card != nil {
-		cards = []*Card{card}
-	}
-	b.appendLog(actionType, detail, cards)
-	b.checkGameClear()
-	b.checkStalemate()
+	afterMove(&b.moveCount, b, actionType, detail, card)
 }
 
 // checkGameClear 8 つの基礎札がすべて 13 枚になったか

--- a/internal/domain/Calabresella.go
+++ b/internal/domain/Calabresella.go
@@ -622,19 +622,7 @@ func (g *Calabresella) checkGameEnd() {
 
 // validatePlay マストフォロー (切り札なし) を検証する。
 func (g *Calabresella) validatePlay(playerIdx int, card *Card) error {
-	if len(g.currentTrick) == 0 {
-		return nil
-	}
-	leadSuit := g.currentTrick[0].Card.GetDesign()
-	if card.GetDesign() != leadSuit && g.playerHasSuit(playerIdx, leadSuit) {
-		return NewDomainError(ErrInvalidPlay, "リードスートに従ってください")
-	}
-	return nil
-}
-
-// playerHasSuit プレイヤーが指定スートのカードを持っているか。
-func (g *Calabresella) playerHasSuit(playerIdx, design int) bool {
-	return handHasSuit(g.players[playerIdx], design)
+	return validateFollowSuit(g.currentTrick, g.players, playerIdx, card)
 }
 
 // trickWinner トリックの勝者を決定する。切り札がないため、リードスートの最強札が勝つ。

--- a/internal/domain/Cego.go
+++ b/internal/domain/Cego.go
@@ -373,13 +373,7 @@ func (g *Cego) deal() {
 
 // drawCard デッキから 1 枚配る (尽きたら nil)。
 func (g *Cego) drawCard() *Card {
-	if g.deckDrawCnt >= len(g.deck) {
-		return nil
-	}
-	card := g.deck[g.deckDrawCnt]
-	card.SetDraw(true)
-	g.deckDrawCnt++
-	return card
+	return drawFromDeck(g.deck, &g.deckDrawCnt)
 }
 
 // --- Bidding ---

--- a/internal/domain/Congress.go
+++ b/internal/domain/Congress.go
@@ -545,14 +545,7 @@ func (c *Congress) findFoundation(card *Card) int {
 
 // afterMove 手数・棋譜・終了判定をまとめて進める
 func (c *Congress) afterMove(actionType, detail string, card *Card) {
-	c.moveCount++
-	var cards []*Card
-	if card != nil {
-		cards = []*Card{card}
-	}
-	c.appendLog(actionType, detail, cards)
-	c.checkGameClear()
-	c.checkStalemate()
+	afterMove(&c.moveCount, c, actionType, detail, card)
 }
 
 // checkGameClear 8 つの基礎札がすべて K まで積まれたか

--- a/internal/domain/CourtPiece.go
+++ b/internal/domain/CourtPiece.go
@@ -554,14 +554,7 @@ func (c *CourtPiece) playCard(playerIdx int, card *Card) {
 // validatePlay カードのプレイがルール上有効か検証する。
 // Court Piece はリードスート必従のみ。ボイドなら任意 (トランプ or 捨て札)。
 func (c *CourtPiece) validatePlay(playerIdx int, card *Card) error {
-	if len(c.currentTrick) == 0 {
-		return nil
-	}
-	leadSuit := c.currentTrick[0].Card.GetDesign()
-	if card.GetDesign() != leadSuit && c.playerHasSuit(playerIdx, leadSuit) {
-		return NewDomainError(ErrInvalidPlay, "リードスートに従ってください")
-	}
-	return nil
+	return validateFollowSuit(c.currentTrick, c.players, playerIdx, card)
 }
 
 // GetPlayableIndices は指定プレイヤーがいま出せる手札の位置を返す。
@@ -581,11 +574,6 @@ func (c *CourtPiece) GetPlayableIndices(playerIdx int) []int {
 		}
 	}
 	return out
-}
-
-// playerHasSuit プレイヤーが特定のスートを持っているか
-func (c *CourtPiece) playerHasSuit(playerIdx, design int) bool {
-	return handHasSuit(c.players[playerIdx], design)
 }
 
 // courtPieceRank converts a raw `Card.GetValue()` (1-13, where 1 = Ace) to

--- a/internal/domain/DeuceToSeven.go
+++ b/internal/domain/DeuceToSeven.go
@@ -481,13 +481,7 @@ func (d *DeuceToSeven) resetBettingRound() {
 // findNextActive returns the next seat after fromIdx that is not folded /
 // all-in. Used to select the first actor in a round.
 func (d *DeuceToSeven) findNextActive(fromIdx int) int {
-	for i := 1; i <= len(d.players); i++ {
-		next := (fromIdx + i) % len(d.players)
-		if !d.players[next].GetFolded() && !d.players[next].GetAllIn() {
-			return next
-		}
-	}
-	return (fromIdx + 1) % len(d.players)
+	return findNextActive(d.players, fromIdx)
 }
 
 func (d *DeuceToSeven) countActivePlayers() int {

--- a/internal/domain/Duchess.go
+++ b/internal/domain/Duchess.go
@@ -747,14 +747,7 @@ func (d *Duchess) findFoundation(card *Card) int {
 
 // afterMove 手数・棋譜・終了判定をまとめて進める
 func (d *Duchess) afterMove(actionType, detail string, card *Card) {
-	d.moveCount++
-	var cards []*Card
-	if card != nil {
-		cards = []*Card{card}
-	}
-	d.appendLog(actionType, detail, cards)
-	d.checkGameClear()
-	d.checkStalemate()
+	afterMove(&d.moveCount, d, actionType, detail, card)
 }
 
 // checkGameClear 4 つの基礎札がすべて 13 枚（開始ランクから一周）になったか

--- a/internal/domain/FiveCardStud.go
+++ b/internal/domain/FiveCardStud.go
@@ -842,15 +842,11 @@ func (s *FiveCardStud) ExportProfile() interface{} {
 
 // ImportProfile JSONバイトからメタAIプロファイルをインポートする
 func (s *FiveCardStud) ImportProfile(data []byte) error {
-	if len(data) == 0 {
-		return nil
-	}
-	d, err := ImportBettingHumanProfileJSON(data)
-	if err != nil {
+	p, err := importBettingProfile(data)
+	if err != nil || p == nil {
 		return err
 	}
-	s.humanProfile = &BettingHumanProfile{}
-	s.humanProfile.Import(d)
+	s.humanProfile = p
 	return nil
 }
 

--- a/internal/domain/FrenchTarot.go
+++ b/internal/domain/FrenchTarot.go
@@ -364,13 +364,7 @@ func (g *FrenchTarot) deal() {
 
 // drawCard デッキから 1 枚配る (尽きたら nil)。
 func (g *FrenchTarot) drawCard() *Card {
-	if g.deckDrawCnt >= len(g.deck) {
-		return nil
-	}
-	card := g.deck[g.deckDrawCnt]
-	card.SetDraw(true)
-	g.deckDrawCnt++
-	return card
+	return drawFromDeck(g.deck, &g.deckDrawCnt)
 }
 
 // --- Bidding ---

--- a/internal/domain/Holdem.go
+++ b/internal/domain/Holdem.go
@@ -435,13 +435,7 @@ func (h *Holdem) dealRemainingCommunity() {
 
 // findNextActive 指定インデックスの次のアクティブ (フォールド・オールインでない) プレイヤーを探す
 func (h *Holdem) findNextActive(fromIdx int) int {
-	for i := 1; i <= len(h.players); i++ {
-		next := (fromIdx + i) % len(h.players)
-		if !h.players[next].GetFolded() && !h.players[next].GetAllIn() {
-			return next
-		}
-	}
-	return (fromIdx + 1) % len(h.players)
+	return findNextActive(h.players, fromIdx)
 }
 
 // countActivePlayers フォールドしていないプレイヤー数を返す
@@ -667,15 +661,11 @@ func (h *Holdem) ExportProfile() interface{} {
 
 // ImportProfile JSONバイトからメタAIプロファイルをインポートする
 func (h *Holdem) ImportProfile(data []byte) error {
-	if len(data) == 0 {
-		return nil
-	}
-	d, err := ImportBettingHumanProfileJSON(data)
-	if err != nil {
+	p, err := importBettingProfile(data)
+	if err != nil || p == nil {
 		return err
 	}
-	h.humanProfile = &BettingHumanProfile{}
-	h.humanProfile.Import(d)
+	h.humanProfile = p
 	return nil
 }
 

--- a/internal/domain/Koenigrufen.go
+++ b/internal/domain/Koenigrufen.go
@@ -371,13 +371,7 @@ func (g *Koenigrufen) deal() {
 
 // drawCard デッキから 1 枚配る (尽きたら nil)。
 func (g *Koenigrufen) drawCard() *Card {
-	if g.deckDrawCnt >= len(g.deck) {
-		return nil
-	}
-	card := g.deck[g.deckDrawCnt]
-	card.SetDraw(true)
-	g.deckDrawCnt++
-	return card
+	return drawFromDeck(g.deck, &g.deckDrawCnt)
 }
 
 // --- Bidding ---

--- a/internal/domain/Minchiate.go
+++ b/internal/domain/Minchiate.go
@@ -307,13 +307,7 @@ func (g *Minchiate) shuffle() {
 
 // drawCard デッキから 1 枚配る (尽きたら nil)。
 func (g *Minchiate) drawCard() *Card {
-	if g.deckDrawCnt >= len(g.deck) {
-		return nil
-	}
-	card := g.deck[g.deckDrawCnt]
-	card.SetDraw(true)
-	g.deckDrawCnt++
-	return card
+	return drawFromDeck(g.deck, &g.deckDrawCnt)
 }
 
 // sortAllHands 全員の手札をデザイン・値の順に整列する。

--- a/internal/domain/MissMilligan.go
+++ b/internal/domain/MissMilligan.go
@@ -596,14 +596,7 @@ func (mm *MissMilligan) findFoundation(card *Card) int {
 
 // afterMove 手数・棋譜・終了判定をまとめて進める
 func (mm *MissMilligan) afterMove(actionType, detail string, card *Card) {
-	mm.moveCount++
-	var cards []*Card
-	if card != nil {
-		cards = []*Card{card}
-	}
-	mm.appendLog(actionType, detail, cards)
-	mm.checkGameClear()
-	mm.checkStalemate()
+	afterMove(&mm.moveCount, mm, actionType, detail, card)
 }
 
 // checkGameClear 8 つの基礎札すべてが K まで積み上がったか

--- a/internal/domain/NapoleonsSquare.go
+++ b/internal/domain/NapoleonsSquare.go
@@ -537,14 +537,7 @@ func (ns *NapoleonsSquare) findFoundation(card *Card) int {
 
 // afterMove 手数・棋譜・終了判定をまとめて進める
 func (ns *NapoleonsSquare) afterMove(actionType, detail string, card *Card) {
-	ns.moveCount++
-	var cards []*Card
-	if card != nil {
-		cards = []*Card{card}
-	}
-	ns.appendLog(actionType, detail, cards)
-	ns.checkGameClear()
-	ns.checkStalemate()
+	afterMove(&ns.moveCount, ns, actionType, detail, card)
 }
 
 // checkGameClear 8 つの基礎札がすべて K まで積み上がったか

--- a/internal/domain/NinetyNine.go
+++ b/internal/domain/NinetyNine.go
@@ -564,19 +564,7 @@ func (o *NinetyNine) playCard(playerIdx int, card *Card) {
 
 // validatePlay カードのプレイが有効か検証する (must-follow)
 func (o *NinetyNine) validatePlay(playerIdx int, card *Card) error {
-	if len(o.currentTrick) == 0 {
-		return nil
-	}
-	leadSuit := o.currentTrick[0].Card.GetDesign()
-	if card.GetDesign() != leadSuit && o.playerHasSuit(playerIdx, leadSuit) {
-		return NewDomainError(ErrInvalidPlay, "リードスートに従ってください")
-	}
-	return nil
-}
-
-// playerHasSuit プレイヤーが特定のスートを持っているか
-func (o *NinetyNine) playerHasSuit(playerIdx int, design int) bool {
-	return handHasSuit(o.players[playerIdx], design)
+	return validateFollowSuit(o.currentTrick, o.players, playerIdx, card)
 }
 
 // trickWinner トリックの勝者を決定する

--- a/internal/domain/Omaha.go
+++ b/internal/domain/Omaha.go
@@ -480,13 +480,7 @@ func (o *Omaha) dealRemainingCommunity() {
 
 // findNextActive 指定インデックスの次のアクティブプレイヤーを探す
 func (o *Omaha) findNextActive(fromIdx int) int {
-	for i := 1; i <= len(o.players); i++ {
-		next := (fromIdx + i) % len(o.players)
-		if !o.players[next].GetFolded() && !o.players[next].GetAllIn() {
-			return next
-		}
-	}
-	return (fromIdx + 1) % len(o.players)
+	return findNextActive(o.players, fromIdx)
 }
 
 // countActivePlayers フォールドしていないプレイヤー数を返す
@@ -1347,15 +1341,11 @@ func (o *Omaha) ExportProfile() interface{} {
 
 // ImportProfile JSONバイトからメタAIプロファイルをインポートする
 func (o *Omaha) ImportProfile(data []byte) error {
-	if len(data) == 0 {
-		return nil
-	}
-	d, err := ImportBettingHumanProfileJSON(data)
-	if err != nil {
+	p, err := importBettingProfile(data)
+	if err != nil || p == nil {
 		return err
 	}
-	o.humanProfile = &BettingHumanProfile{}
-	o.humanProfile.Import(d)
+	o.humanProfile = p
 	return nil
 }
 

--- a/internal/domain/Pineapple.go
+++ b/internal/domain/Pineapple.go
@@ -694,13 +694,7 @@ func (p *Pineapple) dealRemainingCommunity() {
 
 // findNextActive 指定インデックスの次のアクティブプレイヤーを探す
 func (p *Pineapple) findNextActive(fromIdx int) int {
-	for i := 1; i <= len(p.players); i++ {
-		next := (fromIdx + i) % len(p.players)
-		if !p.players[next].GetFolded() && !p.players[next].GetAllIn() {
-			return next
-		}
-	}
-	return (fromIdx + 1) % len(p.players)
+	return findNextActive(p.players, fromIdx)
 }
 
 // countActivePlayers フォールドしていないプレイヤー数を返す
@@ -1204,15 +1198,11 @@ func (p *Pineapple) ExportProfile() interface{} {
 
 // ImportProfile JSONバイトからメタAIプロファイルをインポートする
 func (p *Pineapple) ImportProfile(data []byte) error {
-	if len(data) == 0 {
-		return nil
-	}
-	d, err := ImportBettingHumanProfileJSON(data)
-	if err != nil {
+	prof, err := importBettingProfile(data)
+	if err != nil || prof == nil {
 		return err
 	}
-	p.humanProfile = &BettingHumanProfile{}
-	p.humanProfile.Import(d)
+	p.humanProfile = prof
 	return nil
 }
 

--- a/internal/domain/Poker.go
+++ b/internal/domain/Poker.go
@@ -496,13 +496,7 @@ func (p *Poker) startSecondBettingRound() {
 
 // findNextActive 指定インデックスの次のアクティブプレイヤーを探す
 func (p *Poker) findNextActive(fromIdx int) int {
-	for i := 1; i <= len(p.players); i++ {
-		next := (fromIdx + i) % len(p.players)
-		if !p.players[next].GetFolded() && !p.players[next].GetAllIn() {
-			return next
-		}
-	}
-	return (fromIdx + 1) % len(p.players)
+	return findNextActive(p.players, fromIdx)
 }
 
 // countActivePlayers フォールドしていないプレイヤー数を返す
@@ -1159,15 +1153,11 @@ func (p *Poker) ExportProfile() interface{} {
 
 // ImportProfile JSONバイトからメタAIプロファイルをインポートする
 func (p *Poker) ImportProfile(data []byte) error {
-	if len(data) == 0 {
-		return nil
-	}
-	d, err := ImportBettingHumanProfileJSON(data)
-	if err != nil {
+	prof, err := importBettingProfile(data)
+	if err != nil || prof == nil {
 		return err
 	}
-	p.humanProfile = &BettingHumanProfile{}
-	p.humanProfile.Import(d)
+	p.humanProfile = prof
 	return nil
 }
 

--- a/internal/domain/Rook.go
+++ b/internal/domain/Rook.go
@@ -214,13 +214,7 @@ func (g *Rook) dealRound() {
 
 // drawCard デッキから1枚配る (尽きたら nil)
 func (g *Rook) drawCard() *Card {
-	if g.deckDrawCnt >= len(g.deck) {
-		return nil
-	}
-	card := g.deck[g.deckDrawCnt]
-	card.SetDraw(true)
-	g.deckDrawCnt++
-	return card
+	return drawFromDeck(g.deck, &g.deckDrawCnt)
 }
 
 // --- Bidding ---

--- a/internal/domain/Scarto.go
+++ b/internal/domain/Scarto.go
@@ -281,13 +281,7 @@ func (g *Scarto) deal() {
 
 // drawCard デッキから 1 枚配る (尽きたら nil)。
 func (g *Scarto) drawCard() *Card {
-	if g.deckDrawCnt >= len(g.deck) {
-		return nil
-	}
-	card := g.deck[g.deckDrawCnt]
-	card.SetDraw(true)
-	g.deckDrawCnt++
-	return card
+	return drawFromDeck(g.deck, &g.deckDrawCnt)
 }
 
 // --- Scarto (dealer discard) ---

--- a/internal/domain/SevenCardStud.go
+++ b/internal/domain/SevenCardStud.go
@@ -1038,15 +1038,11 @@ func (s *SevenCardStud) ExportProfile() interface{} {
 
 // ImportProfile JSONバイトからメタAIプロファイルをインポートする
 func (s *SevenCardStud) ImportProfile(data []byte) error {
-	if len(data) == 0 {
-		return nil
-	}
-	d, err := ImportBettingHumanProfileJSON(data)
-	if err != nil {
+	p, err := importBettingProfile(data)
+	if err != nil || p == nil {
 		return err
 	}
-	s.humanProfile = &BettingHumanProfile{}
-	s.humanProfile.Import(d)
+	s.humanProfile = p
 	return nil
 }
 

--- a/internal/domain/ShortDeck.go
+++ b/internal/domain/ShortDeck.go
@@ -441,13 +441,7 @@ func (sd *ShortDeck) dealRemainingCommunity() {
 
 // findNextActive 指定インデックスの次のアクティブプレイヤーを探す
 func (sd *ShortDeck) findNextActive(fromIdx int) int {
-	for i := 1; i <= len(sd.players); i++ {
-		next := (fromIdx + i) % len(sd.players)
-		if !sd.players[next].GetFolded() && !sd.players[next].GetAllIn() {
-			return next
-		}
-	}
-	return (fromIdx + 1) % len(sd.players)
+	return findNextActive(sd.players, fromIdx)
 }
 
 // countActivePlayers フォールドしていないプレイヤー数を返す
@@ -1172,15 +1166,11 @@ func (sd *ShortDeck) ExportProfile() interface{} {
 
 // ImportProfile JSONバイトからメタAIプロファイルをインポートする
 func (sd *ShortDeck) ImportProfile(data []byte) error {
-	if len(data) == 0 {
-		return nil
-	}
-	d, err := ImportBettingHumanProfileJSON(data)
-	if err != nil {
+	p, err := importBettingProfile(data)
+	if err != nil || p == nil {
 		return err
 	}
-	sd.humanProfile = &BettingHumanProfile{}
-	sd.humanProfile.Import(d)
+	sd.humanProfile = p
 	return nil
 }
 

--- a/internal/domain/Sueca.go
+++ b/internal/domain/Sueca.go
@@ -309,19 +309,7 @@ func suecaTeamLabel(team int) string {
 
 // validatePlay マストフォロー (リードスートに従う) を検証する。
 func (g *Sueca) validatePlay(playerIdx int, card *Card) error {
-	if len(g.currentTrick) == 0 {
-		return nil
-	}
-	leadSuit := g.currentTrick[0].Card.GetDesign()
-	if card.GetDesign() != leadSuit && g.playerHasSuit(playerIdx, leadSuit) {
-		return NewDomainError(ErrInvalidPlay, "リードスートに従ってください")
-	}
-	return nil
-}
-
-// playerHasSuit プレイヤーが指定スートのカードを持っているか。
-func (g *Sueca) playerHasSuit(playerIdx, design int) bool {
-	return handHasSuit(g.players[playerIdx], design)
+	return validateFollowSuit(g.currentTrick, g.players, playerIdx, card)
 }
 
 // trickWinner トリックの勝者を決定する。切り札があれば最強切り札、なければ

--- a/internal/domain/Tarneeb.go
+++ b/internal/domain/Tarneeb.go
@@ -624,19 +624,7 @@ func (t *Tarneeb) playCard(playerIdx int, card *Card) {
 // validatePlay カードのプレイがルール上有効か検証する。
 // Tarneeb はリードスート必従のみ。ボイドなら任意 (トランプ or 捨て札)。
 func (t *Tarneeb) validatePlay(playerIdx int, card *Card) error {
-	if len(t.currentTrick) == 0 {
-		return nil
-	}
-	leadSuit := t.currentTrick[0].Card.GetDesign()
-	if card.GetDesign() != leadSuit && t.playerHasSuit(playerIdx, leadSuit) {
-		return NewDomainError(ErrInvalidPlay, "リードスートに従ってください")
-	}
-	return nil
-}
-
-// playerHasSuit プレイヤーが特定のスートを持っているか
-func (t *Tarneeb) playerHasSuit(playerIdx, design int) bool {
-	return handHasSuit(t.players[playerIdx], design)
+	return validateFollowSuit(t.currentTrick, t.players, playerIdx, card)
 }
 
 // tarneebRank converts a raw `Card.GetValue()` (1-13, where 1 = Ace) to

--- a/internal/domain/Tarocchini.go
+++ b/internal/domain/Tarocchini.go
@@ -311,13 +311,7 @@ func (g *Tarocchini) shuffle() {
 
 // drawCard デッキから 1 枚配る (尽きたら nil)。
 func (g *Tarocchini) drawCard() *Card {
-	if g.deckDrawCnt >= len(g.deck) {
-		return nil
-	}
-	card := g.deck[g.deckDrawCnt]
-	card.SetDraw(true)
-	g.deckDrawCnt++
-	return card
+	return drawFromDeck(g.deck, &g.deckDrawCnt)
 }
 
 // sortAllHands 全員の手札をデザイン・値の順に整列する。

--- a/internal/domain/Terrace.go
+++ b/internal/domain/Terrace.go
@@ -647,14 +647,7 @@ func (t *Terrace) fillEmptyColumns() {
 
 // afterMove 手数・棋譜・終了判定をまとめて進める
 func (t *Terrace) afterMove(actionType, detail string, card *Card) {
-	t.moveCount++
-	var cards []*Card
-	if card != nil {
-		cards = []*Card{card}
-	}
-	t.appendLog(actionType, detail, cards)
-	t.checkGameClear()
-	t.checkStalemate()
+	afterMove(&t.moveCount, t, actionType, detail, card)
 }
 
 // checkGameClear 8 つの基礎札がすべて 13 枚になったか

--- a/internal/domain/Tressette.go
+++ b/internal/domain/Tressette.go
@@ -359,19 +359,7 @@ func (g *Tressette) playCard(playerIdx int, card *Card) {
 
 // validatePlay カードのプレイが有効か検証する (マストフォロー)
 func (g *Tressette) validatePlay(playerIdx int, card *Card) error {
-	if len(g.currentTrick) == 0 {
-		return nil
-	}
-	leadSuit := g.currentTrick[0].Card.GetDesign()
-	if card.GetDesign() != leadSuit && g.playerHasSuit(playerIdx, leadSuit) {
-		return NewDomainError(ErrInvalidPlay, "リードスートに従ってください")
-	}
-	return nil
-}
-
-// playerHasSuit プレイヤーが特定のスートを持っているか
-func (g *Tressette) playerHasSuit(playerIdx, design int) bool {
-	return handHasSuit(g.players[playerIdx], design)
+	return validateFollowSuit(g.currentTrick, g.players, playerIdx, card)
 }
 
 // trickWinner トリックの勝者を決定する。切り札がないため、リードスートの最強札が勝つ。

--- a/internal/domain/Tute.go
+++ b/internal/domain/Tute.go
@@ -372,19 +372,7 @@ func (g *Tute) ScoreRound() {
 
 // validatePlay マストフォロー (リードスートに従う) を検証する。
 func (g *Tute) validatePlay(playerIdx int, card *Card) error {
-	if len(g.currentTrick) == 0 {
-		return nil
-	}
-	leadSuit := g.currentTrick[0].Card.GetDesign()
-	if card.GetDesign() != leadSuit && g.playerHasSuit(playerIdx, leadSuit) {
-		return NewDomainError(ErrInvalidPlay, "リードスートに従ってください")
-	}
-	return nil
-}
-
-// playerHasSuit プレイヤーが指定スートのカードを持っているか。
-func (g *Tute) playerHasSuit(playerIdx, design int) bool {
-	return handHasSuit(g.players[playerIdx], design)
+	return validateFollowSuit(g.currentTrick, g.players, playerIdx, card)
 }
 
 // trickWinner トリックの勝者を決定する。切り札があれば最強切り札、なければ

--- a/internal/domain/TwoTenJack.go
+++ b/internal/domain/TwoTenJack.go
@@ -443,19 +443,7 @@ func (t *TwoTenJack) playCard(playerIdx int, card *Card) {
 
 // validatePlay カードのプレイが有効か検証する
 func (t *TwoTenJack) validatePlay(playerIdx int, card *Card) error {
-	if len(t.currentTrick) == 0 {
-		return nil
-	}
-	leadSuit := t.currentTrick[0].Card.GetDesign()
-	if card.GetDesign() != leadSuit && t.playerHasSuit(playerIdx, leadSuit) {
-		return NewDomainError(ErrInvalidPlay, "リードスートに従ってください")
-	}
-	return nil
-}
-
-// playerHasSuit プレイヤーが特定のスートを持っているか
-func (t *TwoTenJack) playerHasSuit(playerIdx int, design int) bool {
-	return handHasSuit(t.players[playerIdx], design)
+	return validateFollowSuit(t.currentTrick, t.players, playerIdx, card)
 }
 
 // trickWinner トリックの勝者を決定する

--- a/internal/domain/Windmill.go
+++ b/internal/domain/Windmill.go
@@ -568,14 +568,7 @@ func (w *Windmill) refillSails() {
 
 // afterMove 手数・棋譜・終了判定をまとめて進める
 func (w *Windmill) afterMove(actionType, detail string, card *Card) {
-	w.moveCount++
-	var cards []*Card
-	if card != nil {
-		cards = []*Card{card}
-	}
-	w.appendLog(actionType, detail, cards)
-	w.checkGameClear()
-	w.checkStalemate()
+	afterMove(&w.moveCount, w, actionType, detail, card)
 }
 
 // checkGameClear 中央 52 枚と四隅 13 枚×4 がすべて揃ったか

--- a/internal/domain/player_helpers.go
+++ b/internal/domain/player_helpers.go
@@ -380,3 +380,91 @@ func setHandForTest[T any, P interface {
 		p.AddCard(c)
 	}
 }
+
+// moveFinisher is a solitaire that records a move and re-evaluates the board.
+type moveFinisher interface {
+	appendLog(actionType, detail string, cards []*Card)
+	checkGameClear()
+	checkStalemate()
+}
+
+// afterMove completes one solitaire move: count it, log it, then re-check for a
+// win and for a stalemate. 8 games had this written out.
+//
+// moveCount is passed as a pointer because these games use it as the log
+// entry's TurnNumber, so the increment has to happen before appendLog runs --
+// an order the tests pin rather than leave to reading.
+func afterMove(moveCount *int, g moveFinisher, actionType, detail string, card *Card) {
+	*moveCount++
+	var cards []*Card
+	if card != nil {
+		cards = []*Card{card}
+	}
+	g.appendLog(actionType, detail, cards)
+	g.checkGameClear()
+	g.checkStalemate()
+}
+
+// bettor is a seat that can be out of the betting for this hand. Deliberately
+// narrower than the existing BettingPlayer, which names twelve methods: these
+// helpers only ask whether a seat is still in, and the narrow form is the same
+// choice made for handReader above.
+type bettor interface {
+	GetFolded() bool
+	GetAllIn() bool
+}
+
+// findNextActive returns the next seat after fromIdx that is still betting,
+// falling back to the immediate next seat when nobody qualifies -- callers
+// index with the result, so this never returns -1. 7 games had this written out.
+func findNextActive[P bettor](players []P, fromIdx int) int {
+	for i := 1; i <= len(players); i++ {
+		next := (fromIdx + i) % len(players)
+		if !players[next].GetFolded() && !players[next].GetAllIn() {
+			return next
+		}
+	}
+	return (fromIdx + 1) % len(players)
+}
+
+// drawFromDeck takes the next card from deck, advancing the cursor and marking
+// the card drawn, or returns nil once the deck is exhausted. 8 games had this
+// written out. Needs no type parameter -- every deck is a []*Card.
+func drawFromDeck(deck []*Card, drawn *int) *Card {
+	if *drawn >= len(deck) {
+		return nil
+	}
+	card := deck[*drawn]
+	card.SetDraw(true)
+	*drawn++
+	return card
+}
+
+// importBettingProfile decodes a saved human profile, returning nil for empty
+// input so callers can leave their existing profile untouched. 8 betting games
+// had this written out.
+func importBettingProfile(data []byte) (*BettingHumanProfile, error) {
+	if len(data) == 0 {
+		return nil, nil
+	}
+	d, err := ImportBettingHumanProfileJSON(data)
+	if err != nil {
+		return nil, err
+	}
+	p := &BettingHumanProfile{}
+	p.Import(d)
+	return p, nil
+}
+
+// validateFollowSuit enforces following the led suit when the seat can. 8 games
+// had this written out.
+func validateFollowSuit[P handReader](trick []*TrickCard, players []P, playerIdx int, card *Card) error {
+	if len(trick) == 0 {
+		return nil
+	}
+	leadSuit := trick[0].Card.GetDesign()
+	if card.GetDesign() != leadSuit && handHasSuit(players[playerIdx], leadSuit) {
+		return NewDomainError(ErrInvalidPlay, "リードスートに従ってください")
+	}
+	return nil
+}

--- a/internal/domain/player_helpers.go
+++ b/internal/domain/player_helpers.go
@@ -440,22 +440,6 @@ func drawFromDeck(deck []*Card, drawn *int) *Card {
 	return card
 }
 
-// importBettingProfile decodes a saved human profile, returning nil for empty
-// input so callers can leave their existing profile untouched. 8 betting games
-// had this written out.
-func importBettingProfile(data []byte) (*BettingHumanProfile, error) {
-	if len(data) == 0 {
-		return nil, nil
-	}
-	d, err := ImportBettingHumanProfileJSON(data)
-	if err != nil {
-		return nil, err
-	}
-	p := &BettingHumanProfile{}
-	p.Import(d)
-	return p, nil
-}
-
 // validateFollowSuit enforces following the led suit when the seat can. 8 games
 // had this written out.
 func validateFollowSuit[P handReader](trick []*TrickCard, players []P, playerIdx int, card *Card) error {

--- a/internal/domain/player_helpers_internal_test.go
+++ b/internal/domain/player_helpers_internal_test.go
@@ -626,3 +626,85 @@ func TestSetHandForTest_NilPlayerIsIgnored(t *testing.T) {
 
 	assert.NotPanics(t, func() { setHandForTest(missing, []*Card{NewCard(1, 1, false)}) })
 }
+
+type fakeMover struct {
+	loggedTurn []int
+	moveCount  *int
+	cleared    int
+	stalemated int
+	lastCards  []*Card
+}
+
+func (m *fakeMover) appendLog(_, _ string, cards []*Card) {
+	// Records the move count as seen from inside appendLog, which is what the
+	// solitaires use as the entry's TurnNumber.
+	m.loggedTurn = append(m.loggedTurn, *m.moveCount)
+	m.lastCards = cards
+}
+func (m *fakeMover) checkGameClear() { m.cleared++ }
+func (m *fakeMover) checkStalemate() { m.stalemated++ }
+
+// The increment must happen before appendLog: these games pass moveCount as the
+// log entry's TurnNumber, so reordering would silently number every entry one
+// behind.
+func TestAfterMove_IncrementsBeforeLogging(t *testing.T) {
+	n := 4
+	m := &fakeMover{moveCount: &n}
+
+	afterMove(&n, m, "play", "detail", nil)
+
+	assert.Equal(t, 5, n)
+	assert.Equal(t, []int{5}, m.loggedTurn, "appendLog must see the incremented count")
+	assert.Equal(t, 1, m.cleared)
+	assert.Equal(t, 1, m.stalemated)
+}
+
+func TestAfterMove_WrapsTheCard(t *testing.T) {
+	n := 0
+	m := &fakeMover{moveCount: &n}
+	c := NewCard(1, 5, false)
+
+	afterMove(&n, m, "play", "d", c)
+	require.Len(t, m.lastCards, 1)
+	assert.Same(t, c, m.lastCards[0])
+
+	afterMove(&n, m, "play", "d", nil)
+	assert.Nil(t, m.lastCards, "a nil card logs no cards, not a one-element slice of nil")
+}
+
+func TestFindNextActiveHelper(t *testing.T) {
+	seats := []*fakeBettor{{}, {folded: true}, {}, {allIn: true}}
+
+	assert.Equal(t, 2, findNextActive(seats, 0), "skips folded and all-in")
+	assert.Equal(t, 0, findNextActive(seats, 2), "wraps around")
+}
+
+// With nobody active it returns the next seat rather than -1, matching the 7
+// hand-written bodies -- callers index with the result.
+func TestFindNextActiveHelper_NoneActive(t *testing.T) {
+	seats := []*fakeBettor{{folded: true}, {folded: true}}
+	assert.Equal(t, 1, findNextActive(seats, 0))
+}
+
+func TestDrawFromDeck(t *testing.T) {
+	deck := []*Card{NewCard(1, 1, false), NewCard(1, 2, false)}
+	drawn := 0
+
+	c := drawFromDeck(deck, &drawn)
+	require.NotNil(t, c)
+	assert.Equal(t, 1, c.GetValue())
+	assert.True(t, c.GetDraw(), "the card is marked drawn")
+	assert.Equal(t, 1, drawn, "the cursor advances")
+
+	require.NotNil(t, drawFromDeck(deck, &drawn))
+	assert.Nil(t, drawFromDeck(deck, &drawn), "exhausted deck yields nil")
+	assert.Equal(t, 2, drawn, "the cursor does not run past the deck")
+}
+
+type fakeBettor struct {
+	folded bool
+	allIn  bool
+}
+
+func (b *fakeBettor) GetFolded() bool { return b.folded }
+func (b *fakeBettor) GetAllIn() bool  { return b.allIn }


### PR DESCRIPTION
#5185 の長い尾、第3バッチ。**-274行**（39件 + 死んだメソッド8件の削除）。

| クラスタ | 件数 | 削減 |
|---|---:|---:|
| `afterMove` | 8 | -56 |
| `validatePlay` | 8 | -56 |
| `ImportProfile` | 8 | -48 |
| `drawCard` | 8 | -48 |
| `findNextActive` | 7 | -42 |
| （付随）死んだ `playerHasSuit` 8件の削除 | 8 | -24 |
| **合計** | | **-274** |

## `afterMove`: 増分の順序が意味を持ちます

本体は `moveCount++` → `appendLog(...)` の順ですが、**この順序は入れ替えられません**。対象8ゲームの `appendLog` は

```go
at.appendLogAt(at.moveCount, 0, actionType, detail, cards)
```

と **`moveCount` を TurnNumber として使う**ためで、増分が後になると全エントリが1つ古い番号になります。ヘルパは `moveCount` を**ポインタで受け**て順序を保持し、テストで `appendLog` の中から見える値が増分後であることを固定しています（読めば分かる、で済ませていません）。

## `validatePlay` の移送で8メソッドが死にました

`validatePlay` が各ゲームの `playerHasSuit` の**唯一の呼び出し元**だったため、共通ヘルパに移した時点で8件が未参照になりました。CLAUDE.md の方針に従い同じコミットで削除しています。

削除前に**テストファイルからの呼び出しが無いこと**を確認しました。テストは `//go:build test` なので、素の `go build` では見えません（[過去にこれで削除漏れを踏んでいます](https://github.com/yuta-yoshinaga/go_trumpcards/pull/5203)）。確認は `go vet -tags test` で行っています。

また、置換前に**8ゲームすべての `playerHasSuit` が `handHasSuit` に委譲済み**であること（＝ Mighty のような独自述語でないこと）を確認してから移送しています。

## レシーバのシャドウイング（2度目）

`ImportProfile` の置換で、レシーバが `p` の Pineapple / Poker において局所変数 `p` がレシーバを隠し、`g.humanProfile` が解決できなくなりました。局所名を `prof` に変えて解消しています。#5210 の CourtPiece（`c`）と同じ型の失敗で、**レシーバ名と衝突しない局所名を選ぶ**必要があります。

## 検証

- `go test -tags test ./...` 全パッケージ通過 / `golangci-lint` 0 issues
- 件数は 8/8/8/8/7 の想定と一致（違えば中断）
- ヘルパは call-site 書き換えの**前**に別コミット（`c4f113d`）

Refs #5185