### PR TITLE
refactor(domain): clear the entire 5-9 copy band (192 methods)

### DIFF
--- a/internal/domain/AllFoursPlayer.go
+++ b/internal/domain/AllFoursPlayer.go
@@ -18,10 +18,7 @@ func NewAllFoursPlayer(isHuman bool) *AllFoursPlayer {
 
 // ResetRound ラウンドをリセット (得点・トリック・手札・終了状態を初期化)
 func (p *AllFoursPlayer) ResetRound() {
-	p.SetRoundScore(0)
-	p.ResetTricks()
-	p.Reset()
-	p.SetIsFinished(false)
+	resetRoundWithTricks(p)
 }
 
 // allFoursPlayerJSON is the JSON wire format for AllFoursPlayer.

--- a/internal/domain/AmericanToad.go
+++ b/internal/domain/AmericanToad.go
@@ -633,17 +633,12 @@ func (at *AmericanToad) popReserve() {
 
 // wasteTop 捨て札の一番上（空なら nil）
 func (at *AmericanToad) wasteTop() *Card {
-	if len(at.waste) == 0 {
-		return nil
-	}
-	return at.waste[len(at.waste)-1]
+	return discardTop(at.waste)
 }
 
 // popWaste 捨て札の一番上を取り除く
 func (at *AmericanToad) popWaste() {
-	if len(at.waste) > 0 {
-		at.waste = at.waste[:len(at.waste)-1]
-	}
+	at.waste = dropLast(at.waste)
 }
 
 // tableauTop 列の一番上（空なら nil）

--- a/internal/domain/Anaconda.go
+++ b/internal/domain/Anaconda.go
@@ -1075,10 +1075,7 @@ func (g *Anaconda) GetPlayer(i int) *AnacondaPlayer {
 
 // GetChips は人間 (seat 0) の保有チップを返す。
 func (g *Anaconda) GetChips() int {
-	if len(g.players) == 0 {
-		return 0
-	}
-	return g.players[0].GetChips()
+	return chipsOfFirst(g.players)
 }
 
 // IsHumanTurn は現在がロールフェーズの人間 (seat 0) 手番かどうかを返す。

--- a/internal/domain/Anaconda.go
+++ b/internal/domain/Anaconda.go
@@ -846,13 +846,7 @@ func (g *Anaconda) activeSeats() []int {
 
 // activeCount は未フォールド・非脱落プレイヤー数を返す。
 func (g *Anaconda) activeCount() int {
-	n := 0
-	for _, p := range g.players {
-		if !p.GetOut() && !p.GetFolded() {
-			n++
-		}
-	}
-	return n
+	return countPlayers(g.players, func(p *AnacondaPlayer) bool { return !p.GetOut() && !p.GetFolded() })
 }
 
 // nextActive は from の次の未フォールド・非脱落プレイヤーを返す。

--- a/internal/domain/Anaconda.go
+++ b/internal/domain/Anaconda.go
@@ -874,13 +874,7 @@ func (g *Anaconda) solventCount() int {
 
 // richestIdx はチップが最多のプレイヤーのインデックスを返す (同数は座席番号の小さい方)。
 func (g *Anaconda) richestIdx() int {
-	best := 0
-	for i, p := range g.players {
-		if p.GetChips() > g.players[best].GetChips() {
-			best = i
-		}
-	}
-	return best
+	return maxIndexBy(g.players, func(p *AnacondaPlayer) int { return p.GetChips() })
 }
 
 // anacondaValidateIndices はカードインデックス列の妥当性 (枚数・範囲・重複なし) を検証する。

--- a/internal/domain/Badugi.go
+++ b/internal/domain/Badugi.go
@@ -316,11 +316,7 @@ func (b *Badugi) applyExchange(playerIdx int, indices []int) {
 // bettingPlayers adapts the concrete player slice to the BettingPlayer
 // interface slice consumed by the shared betting helpers.
 func (b *Badugi) bettingPlayers() []BettingPlayer {
-	bp := make([]BettingPlayer, len(b.players))
-	for i, pl := range b.players {
-		bp[i] = pl
-	}
-	return bp
+	return toBettingPlayers(b.players)
 }
 
 // executeAction runs a single betting action for playerIdx.

--- a/internal/domain/Bouillotte.go
+++ b/internal/domain/Bouillotte.go
@@ -639,13 +639,7 @@ func (g *Bouillotte) solventCount() int {
 
 // richestIdx はチップが最多のプレイヤーのインデックスを返す (同数は座席番号の小さい方)。
 func (g *Bouillotte) richestIdx() int {
-	best := 0
-	for i, p := range g.players {
-		if p.GetChips() > g.players[best].GetChips() {
-			best = i
-		}
-	}
-	return best
+	return maxIndexBy(g.players, func(p *BouillottePlayer) int { return p.GetChips() })
 }
 
 func (g *Bouillotte) appendLog(playerIdx int, actionType, detail string, cards []*Card) {

--- a/internal/domain/Bouillotte.go
+++ b/internal/domain/Bouillotte.go
@@ -749,10 +749,7 @@ func (g *Bouillotte) GetPlayer(i int) *BouillottePlayer {
 
 // GetChips は人間 (seat 0) の保有チップを返す。
 func (g *Bouillotte) GetChips() int {
-	if len(g.players) == 0 {
-		return 0
-	}
-	return g.players[0].GetChips()
+	return chipsOfFirst(g.players)
 }
 
 // IsHumanTurn は現在の手番が人間 (seat 0) かどうかを返す。

--- a/internal/domain/Bouillotte.go
+++ b/internal/domain/Bouillotte.go
@@ -611,13 +611,7 @@ func (g *Bouillotte) activeSeats() []int {
 
 // activeCount は未フォールド・非脱落プレイヤー数を返す。
 func (g *Bouillotte) activeCount() int {
-	n := 0
-	for _, p := range g.players {
-		if !p.GetOut() && !p.GetFolded() {
-			n++
-		}
-	}
-	return n
+	return countPlayers(g.players, func(p *BouillottePlayer) bool { return !p.GetOut() && !p.GetFolded() })
 }
 
 // nextActive は from の次の未フォールド・非脱落プレイヤーを返す。

--- a/internal/domain/Braid.go
+++ b/internal/domain/Braid.go
@@ -604,17 +604,12 @@ func (b *Braid) braidTail() *Card {
 
 // wasteTop 捨て札の一番上（空なら nil）
 func (b *Braid) wasteTop() *Card {
-	if len(b.waste) == 0 {
-		return nil
-	}
-	return b.waste[len(b.waste)-1]
+	return discardTop(b.waste)
 }
 
 // popWaste 捨て札の一番上を取り除く
 func (b *Braid) popWaste() {
-	if len(b.waste) > 0 {
-		b.waste = b.waste[:len(b.waste)-1]
-	}
+	b.waste = dropLast(b.waste)
 }
 
 // canPlaceOnFoundation 基礎札に置けるか（同スート、選んだ向きに 1 つずつ）

--- a/internal/domain/BuraPlayer.go
+++ b/internal/domain/BuraPlayer.go
@@ -18,8 +18,7 @@ func NewBuraPlayer(isHuman bool) *BuraPlayer {
 
 // ResetGame ゲームをリセット (手札と上がり状態を初期化)
 func (p *BuraPlayer) ResetGame() {
-	p.Reset()
-	p.SetIsFinished(false)
+	resetPlayer(p)
 }
 
 // buraPlayerJSON is the JSON wire format for BuraPlayer.

--- a/internal/domain/CallBreakPlayer.go
+++ b/internal/domain/CallBreakPlayer.go
@@ -45,10 +45,7 @@ func (p *CallBreakPlayer) GetBags() int {
 // ResetRound ラウンドをリセット（ビッド・トリック・手札・終了状態を初期化）
 func (p *CallBreakPlayer) ResetRound() {
 	p.bid = -1
-	p.SetRoundScore(0)
-	p.ResetTricks()
-	p.Reset()
-	p.SetIsFinished(false)
+	resetRoundWithTricks(p)
 }
 
 // callBreakPlayerJSON is the JSON wire format for CallBreakPlayer.

--- a/internal/domain/Carioca.go
+++ b/internal/domain/Carioca.go
@@ -537,12 +537,7 @@ func (g *Carioca) CpuPlay() {
 
 // cpuDraw CPU の引き処理。捨て札トップが手役を進めるなら拾い、そうでなければ山札から引く
 func (g *Carioca) cpuDraw() {
-	top := g.GetDiscardTop()
-	if top != nil && g.cpuShouldTakeDiscard(top) {
-		_ = g.drawFromDiscard()
-		return
-	}
-	_ = g.drawFromStock()
+	cpuDrawTurn(g)
 }
 
 // cpuShouldTakeDiscard 捨て札トップを拾うべきかを返す

--- a/internal/domain/Carioca.go
+++ b/internal/domain/Carioca.go
@@ -275,16 +275,7 @@ func (g *Carioca) drawFromDiscard() error {
 // recycleDiscardIntoStock 山札が空のとき捨て札トップ 1 枚を残して残りを山札へ戻しシャッフルする。
 // 戻り値は補充できたかどうか（捨て札も枯渇していれば false）。
 func (g *Carioca) recycleDiscardIntoStock() bool {
-	if len(g.discardPile) <= 1 {
-		return false
-	}
-	top := g.discardPile[len(g.discardPile)-1]
-	rest := g.discardPile[:len(g.discardPile)-1]
-	g.discardPile = []*Card{top}
-	rand.Shuffle(len(rest), func(i, j int) { rest[i], rest[j] = rest[j], rest[i] })
-	g.drawPile = append(g.drawPile, rest...)
-	g.appendLog(-1, "recycle", fmt.Sprintf("Discard pile recycled into stock (%d cards)", len(rest)), nil)
-	return true
+	return recycleDiscardIntoStock(&g.discardPile, &g.drawPile, g)
 }
 
 // PlayerMeldContract 人間プレイヤーがコントラクトを達成する。
@@ -827,16 +818,7 @@ func (g *Carioca) sortAllHands() {
 }
 
 func (g *Carioca) sortHand(playerIdx int) {
-	p := g.players[playerIdx]
-	cards := make([]*Card, p.GetCardsSize())
-	for i := 0; i < p.GetCardsSize(); i++ {
-		cards[i] = p.GetCard(i)
-	}
-	sortCards(cards)
-	p.Reset()
-	for _, c := range cards {
-		p.AddCard(c)
-	}
+	sortHandInPlace(g.players[playerIdx], sortCards)
 }
 
 // --- Pure Carioca helpers (joker-aware) ---

--- a/internal/domain/CatchTenPlayer.go
+++ b/internal/domain/CatchTenPlayer.go
@@ -29,10 +29,7 @@ func (p *CatchTenPlayer) GetTeam() int { return p.team }
 
 // ResetRound ラウンドをリセット（トリック・手札・終了状態を初期化）
 func (p *CatchTenPlayer) ResetRound() {
-	p.SetRoundScore(0)
-	p.ResetTricks()
-	p.Reset()
-	p.SetIsFinished(false)
+	resetRoundWithTricks(p)
 }
 
 // catchTenPlayerJSON is the JSON wire format for CatchTenPlayer.

--- a/internal/domain/Cego.go
+++ b/internal/domain/Cego.go
@@ -1657,10 +1657,7 @@ func (g *Cego) SetConfig(cfg CegoConfig) { g.config = cfg }
 
 // GetActionLog 棋譜取得
 func (g *Cego) GetActionLog() []*ActionLogEntry {
-	if g.actionLog == nil {
-		return []*ActionLogEntry{}
-	}
-	return g.actionLog
+	return sliceOrEmpty(g.actionLog)
 }
 
 // GetPlayableIndices プレイ可能なカードのインデックス一覧を返す。

--- a/internal/domain/Cego.go
+++ b/internal/domain/Cego.go
@@ -254,7 +254,7 @@ type Cego struct {
 	scored          bool
 	gameEndFlag     bool
 	winnerPlayer    int
-	actionLog       []*ActionLogEntry
+	actionLogBase
 }
 
 // NewCego コンストラクタ
@@ -1413,13 +1413,7 @@ func (g *Cego) isHumanBidTurn() bool {
 
 // appendLog 棋譜にエントリを追加する。
 func (g *Cego) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	g.appendLogAt(len(g.actionLog)+1, playerIdx, actionType, detail, cards)
 }
 
 // cegoBidName 入札の表示名を返す。

--- a/internal/domain/ChinchonPlayer.go
+++ b/internal/domain/ChinchonPlayer.go
@@ -30,9 +30,7 @@ func (p *ChinchonPlayer) SetEliminated(v bool) { p.eliminated = v }
 
 // ResetRound ラウンドをリセットする (手札・ラウンド点・終了状態を初期化、累積点と脱落状態は維持)。
 func (p *ChinchonPlayer) ResetRound() {
-	p.SetRoundScore(0)
-	p.Reset()
-	p.SetIsFinished(false)
+	resetRoundScored(p)
 }
 
 // chinchonPlayerJSON is the JSON wire format for ChinchonPlayer.

--- a/internal/domain/ChineseTen.go
+++ b/internal/domain/ChineseTen.go
@@ -438,10 +438,7 @@ func (c *ChineseTen) GetCaptured(idx int) []*Card {
 
 // GetScore は idx の得点を返す。
 func (c *ChineseTen) GetScore(idx int) int {
-	if idx < 0 || idx >= len(c.scores) {
-		return 0
-	}
-	return c.scores[idx]
+	return elemAt(c.scores, idx)
 }
 
 // SetScore は idx の得点を設定する (テスト用)。

--- a/internal/domain/ChineseTenPlayer.go
+++ b/internal/domain/ChineseTenPlayer.go
@@ -16,8 +16,7 @@ func NewChineseTenPlayer(isHuman bool) *ChineseTenPlayer {
 
 // ResetGame は手札と上がり状態を初期化する。
 func (p *ChineseTenPlayer) ResetGame() {
-	p.Reset()
-	p.SetIsFinished(false)
+	resetPlayer(p)
 }
 
 // chineseTenPlayerJSON is the JSON wire format for ChineseTenPlayer.

--- a/internal/domain/Congress.go
+++ b/internal/domain/Congress.go
@@ -485,17 +485,12 @@ func (c *Congress) tableauTop(pile int) *Card {
 
 // wasteTop 捨て札の一番上（空なら nil）
 func (c *Congress) wasteTop() *Card {
-	if len(c.waste) == 0 {
-		return nil
-	}
-	return c.waste[len(c.waste)-1]
+	return discardTop(c.waste)
 }
 
 // popWaste 捨て札の一番上を取り除く
 func (c *Congress) popWaste() {
-	if len(c.waste) > 0 {
-		c.waste = c.waste[:len(c.waste)-1]
-	}
+	c.waste = dropLast(c.waste)
 }
 
 // canPlaceOnTableau タブローに置けるか（スート無視の降順、A の下には何も置けない）。

--- a/internal/domain/ContractRummy.go
+++ b/internal/domain/ContractRummy.go
@@ -282,16 +282,7 @@ func (g *ContractRummy) drawFromDiscard() error {
 // recycleDiscardIntoStock 山札が空のとき捨て札トップ 1 枚を残して残りを山札へ戻しシャッフルする。
 // 戻り値は補充できたかどうか（捨て札も枯渇していれば false）。
 func (g *ContractRummy) recycleDiscardIntoStock() bool {
-	if len(g.discardPile) <= 1 {
-		return false
-	}
-	top := g.discardPile[len(g.discardPile)-1]
-	rest := g.discardPile[:len(g.discardPile)-1]
-	g.discardPile = []*Card{top}
-	rand.Shuffle(len(rest), func(i, j int) { rest[i], rest[j] = rest[j], rest[i] })
-	g.drawPile = append(g.drawPile, rest...)
-	g.appendLog(-1, "recycle", fmt.Sprintf("Discard pile recycled into stock (%d cards)", len(rest)), nil)
-	return true
+	return recycleDiscardIntoStock(&g.discardPile, &g.drawPile, g)
 }
 
 // PlayerMeldContract 人間プレイヤーがコントラクトを達成する。
@@ -834,16 +825,7 @@ func (g *ContractRummy) sortAllHands() {
 }
 
 func (g *ContractRummy) sortHand(playerIdx int) {
-	p := g.players[playerIdx]
-	cards := make([]*Card, p.GetCardsSize())
-	for i := 0; i < p.GetCardsSize(); i++ {
-		cards[i] = p.GetCard(i)
-	}
-	sortCards(cards)
-	p.Reset()
-	for _, c := range cards {
-		p.AddCard(c)
-	}
+	sortHandInPlace(g.players[playerIdx], sortCards)
 }
 
 // --- Pure helpers ---

--- a/internal/domain/ContractRummy.go
+++ b/internal/domain/ContractRummy.go
@@ -544,12 +544,7 @@ func (g *ContractRummy) CpuPlay() {
 
 // cpuDraw CPU の引き処理。捨て札トップが手役を進めるなら拾い、そうでなければ山札から引く
 func (g *ContractRummy) cpuDraw() {
-	top := g.GetDiscardTop()
-	if top != nil && g.cpuShouldTakeDiscard(top) {
-		_ = g.drawFromDiscard()
-		return
-	}
-	_ = g.drawFromStock()
+	cpuDrawTurn(g)
 }
 
 // cpuShouldTakeDiscard 捨て札トップを拾うべきかを返す
@@ -1471,4 +1466,25 @@ func (g *ContractRummy) UnmarshalJSON(data []byte) error {
 	g.roundWinnerIdx = j.RoundWinnerIdx
 	g.startingPlayer = j.StartingPlayer
 	return nil
+}
+
+// discardDrawer is a rummy-style game that chooses between the discard pile and
+// the stock on the CPU's turn.
+type discardDrawer interface {
+	GetDiscardTop() *Card
+	cpuShouldTakeDiscard(*Card) bool
+	drawFromDiscard() error
+	drawFromStock() error
+}
+
+// cpuDrawTurn takes the discard when the CPU wants it and the stock otherwise.
+// 5 games had this written out. Lives here rather than player_helpers.go
+// because all five callers are `extra`-tagged, as is this file.
+func cpuDrawTurn(g discardDrawer) {
+	top := g.GetDiscardTop()
+	if top != nil && g.cpuShouldTakeDiscard(top) {
+		_ = g.drawFromDiscard()
+		return
+	}
+	_ = g.drawFromStock()
 }

--- a/internal/domain/CourtPiecePlayer.go
+++ b/internal/domain/CourtPiecePlayer.go
@@ -33,10 +33,7 @@ func (p *CourtPiecePlayer) GetTeam() int { return p.team }
 
 // ResetRound ラウンド単位の状態をリセット
 func (p *CourtPiecePlayer) ResetRound() {
-	p.SetRoundScore(0)
-	p.ResetTricks()
-	p.Reset()
-	p.SetIsFinished(false)
+	resetRoundWithTricks(p)
 }
 
 // courtPiecePlayerJSON is the JSON wire format for CourtPiecePlayer.

--- a/internal/domain/CrazyEights.go
+++ b/internal/domain/CrazyEights.go
@@ -529,13 +529,7 @@ func (g *CrazyEights) recycleDrawPile() {
 
 // hasPlayableCard プレイヤーが出せるカードを持っているか
 func (g *CrazyEights) hasPlayableCard(playerIdx int) bool {
-	player := g.players[playerIdx]
-	for i := 0; i < player.GetCardsSize(); i++ {
-		if g.isValidPlay(player.GetCard(i)) {
-			return true
-		}
-	}
-	return false
+	return handHasAny(g.players[playerIdx], g.isValidPlay)
 }
 
 // checkGameEnd ゲーム終了判定

--- a/internal/domain/CrazyEightsPlayer.go
+++ b/internal/domain/CrazyEightsPlayer.go
@@ -17,9 +17,7 @@ func NewCrazyEightsPlayer(isHuman bool) *CrazyEightsPlayer {
 
 // ResetRound ラウンドをリセット（手札・スコア・終了状態を初期化）
 func (p *CrazyEightsPlayer) ResetRound() {
-	p.SetRoundScore(0)
-	p.Reset()
-	p.SetIsFinished(false)
+	resetRoundScored(p)
 }
 
 // crazyEightsPlayerJSON is the JSON wire format for CrazyEightsPlayer.

--- a/internal/domain/CribbagePlayer.go
+++ b/internal/domain/CribbagePlayer.go
@@ -50,7 +50,5 @@ func NewCribbagePlayer(isHuman bool) *CribbagePlayer {
 
 // ResetRound ラウンドをリセット（手札・スコア・終了状態を初期化）
 func (p *CribbagePlayer) ResetRound() {
-	p.SetRoundScore(0)
-	p.Reset()
-	p.SetIsFinished(false)
+	resetRoundScored(p)
 }

--- a/internal/domain/Desmoche.go
+++ b/internal/domain/Desmoche.go
@@ -684,10 +684,7 @@ func (d *Desmoche) GetPot() int { return d.pot }
 
 // GetScore は idx の収支を返す。
 func (d *Desmoche) GetScore(idx int) int {
-	if idx < 0 || idx >= len(d.scores) {
-		return 0
-	}
-	return d.scores[idx]
+	return elemAt(d.scores, idx)
 }
 
 // GetRoundNumber は完了したラウンド数を返す。

--- a/internal/domain/DeuceToSeven.go
+++ b/internal/domain/DeuceToSeven.go
@@ -316,11 +316,7 @@ func (d *DeuceToSeven) applyExchange(playerIdx int, indices []int) {
 // bettingPlayers adapts the concrete player slice to the BettingPlayer
 // interface slice consumed by the shared betting helpers.
 func (d *DeuceToSeven) bettingPlayers() []BettingPlayer {
-	bp := make([]BettingPlayer, len(d.players))
-	for i, pl := range d.players {
-		bp[i] = pl
-	}
-	return bp
+	return toBettingPlayers(d.players)
 }
 
 // executeAction runs a single betting action for playerIdx.

--- a/internal/domain/FiveCardStud.go
+++ b/internal/domain/FiveCardStud.go
@@ -360,11 +360,7 @@ func (s *FiveCardStud) PlayerAction(action, amount, humanPlayMs int) error {
 
 // bettingPlayers BettingPlayerスライスを生成
 func (s *FiveCardStud) bettingPlayers() []BettingPlayer {
-	bp := make([]BettingPlayer, len(s.players))
-	for i, pl := range s.players {
-		bp[i] = pl
-	}
-	return bp
+	return toBettingPlayers(s.players)
 }
 
 // executeAction 指定プレイヤーのアクション実行
@@ -573,13 +569,7 @@ func (s *FiveCardStud) determineBettingLeader() int {
 
 // countActivePlayers フォールドしていないプレイヤー数を返す
 func (s *FiveCardStud) countActivePlayers() int {
-	cnt := 0
-	for _, p := range s.players {
-		if !p.GetFolded() {
-			cnt++
-		}
-	}
-	return cnt
+	return countPlayers(s.players, func(p *FiveCardStudPlayer) bool { return !p.GetFolded() })
 }
 
 // bettingLimits ベッティングリミット設定
@@ -858,10 +848,7 @@ func (s *FiveCardStud) SetConfig(cfg FiveCardStudConfig) { s.config = cfg }
 
 // IsHumanTurn 人間のターンかチェック
 func (s *FiveCardStud) IsHumanTurn() bool {
-	if s.currentTurn >= 0 && s.currentTurn < len(s.players) {
-		return s.players[s.currentTurn].GetIsHuman()
-	}
-	return false
+	return isHumanTurn(s.players, s.currentTurn)
 }
 
 // GetActedFlags actedフラグ取得

--- a/internal/domain/FiveCardStud.go
+++ b/internal/domain/FiveCardStud.go
@@ -735,10 +735,7 @@ func (s *FiveCardStud) IsMuckAvailable() bool {
 
 // getHandName ハンドランクから名前を返す
 func (s *FiveCardStud) getHandName(rank int) string {
-	if rank >= 0 && rank < len(PokerHandNames) {
-		return PokerHandNames[rank]
-	}
-	return "Unknown"
+	return pokerHandName(rank)
 }
 
 // --- 棋譜 ---
@@ -853,9 +850,7 @@ func (s *FiveCardStud) IsHumanTurn() bool {
 
 // GetActedFlags actedフラグ取得
 func (s *FiveCardStud) GetActedFlags() []bool {
-	result := make([]bool, len(s.actedFlags))
-	copy(result, s.actedFlags)
-	return result
+	return copyOf(s.actedFlags)
 }
 
 // GetHandCount ハンド数取得

--- a/internal/domain/FiveCardStudPlayer.go
+++ b/internal/domain/FiveCardStudPlayer.go
@@ -4,7 +4,6 @@ package domain
 
 import (
 	"encoding/json"
-	"fmt"
 	"sort"
 )
 
@@ -142,13 +141,7 @@ func (p *FiveCardStudPlayer) IncrementPostFlopCall() { p.postFlopCall++ }
 
 // GetAFDisplay AF表示文字列取得 ("-"=アクションなし, "∞"=コールなし, "X.X"=通常)
 func (p *FiveCardStudPlayer) GetAFDisplay() string {
-	if p.postFlopBetRaise == 0 && p.postFlopCall == 0 {
-		return "-"
-	}
-	if p.postFlopCall == 0 {
-		return "∞"
-	}
-	return fmt.Sprintf("%.1f", float64(p.postFlopBetRaise)/float64(p.postFlopCall))
+	return afDisplay(p.postFlopBetRaise, p.postFlopCall)
 }
 
 // GetComparisonCards ハンド比較用カード取得 (BettingPlayerインターフェース)

--- a/internal/domain/FiveCardStudPlayer.go
+++ b/internal/domain/FiveCardStudPlayer.go
@@ -94,18 +94,12 @@ func (p *FiveCardStudPlayer) GetPFRCount() int { return p.pfrCount }
 
 // GetVPIP VPIP%取得 (0 if totalHands==0)
 func (p *FiveCardStudPlayer) GetVPIP() int {
-	if p.totalHands == 0 {
-		return 0
-	}
-	return p.vpipCount * 100 / p.totalHands
+	return percentOf(p.vpipCount, p.totalHands)
 }
 
 // GetPFR PFR%取得 (0 if totalHands==0)
 func (p *FiveCardStudPlayer) GetPFR() int {
-	if p.totalHands == 0 {
-		return 0
-	}
-	return p.pfrCount * 100 / p.totalHands
+	return percentOf(p.pfrCount, p.totalHands)
 }
 
 // IncrementTotalHands 総ハンド数をインクリメント
@@ -125,10 +119,7 @@ func (p *FiveCardStudPlayer) GetThreeBetCount() int { return p.threeBetCount }
 
 // GetThreeBet 3Bet%取得 (0 if threeBetOpportunity==0)
 func (p *FiveCardStudPlayer) GetThreeBet() int {
-	if p.threeBetOpportunity == 0 {
-		return 0
-	}
-	return p.threeBetCount * 100 / p.threeBetOpportunity
+	return percentOf(p.threeBetCount, p.threeBetOpportunity)
 }
 
 // IncrementThreeBetOpportunity 3Bet機会数をインクリメント
@@ -162,9 +153,7 @@ func (p *FiveCardStudPlayer) GetAFDisplay() string {
 
 // GetComparisonCards ハンド比較用カード取得 (BettingPlayerインターフェース)
 func (p *FiveCardStudPlayer) GetComparisonCards() []*Card {
-	cards := make([]*Card, len(p.bestHand))
-	copy(cards, p.bestHand)
-	return cards
+	return copyOf(p.bestHand)
 }
 
 // EvalBestHand 全カード (最大5枚) からベスト5枚を評価

--- a/internal/domain/FiveCardStudRebuy.go
+++ b/internal/domain/FiveCardStudRebuy.go
@@ -117,16 +117,12 @@ func (s *FiveCardStud) IsAddonAvailable() bool {
 
 // GetRebuyCounts プレイヤーごとのリバイ回数取得
 func (s *FiveCardStud) GetRebuyCounts() []int {
-	result := make([]int, len(s.rebuyCounts))
-	copy(result, s.rebuyCounts)
-	return result
+	return copyOf(s.rebuyCounts)
 }
 
 // GetAddonUsed プレイヤーごとのアドオン使用フラグ取得
 func (s *FiveCardStud) GetAddonUsed() []bool {
-	result := make([]bool, len(s.addonUsed))
-	copy(result, s.addonUsed)
-	return result
+	return copyOf(s.addonUsed)
 }
 
 // GetRebuyPhaseType リバイフェーズ種別取得

--- a/internal/domain/FiveCardStudRebuy.go
+++ b/internal/domain/FiveCardStudRebuy.go
@@ -91,28 +91,12 @@ func (s *FiveCardStud) SkipAddon() error {
 
 // IsRebuyAvailable 人間プレイヤーがリバイ可能かどうか
 func (s *FiveCardStud) IsRebuyAvailable() bool {
-	if !s.config.RebuyEnabled || s.handCount > s.config.RebuyPeriodHands {
-		return false
-	}
-	for i, p := range s.players {
-		if p.GetIsHuman() && p.GetChips() <= 0 && s.rebuyCounts[i] < s.config.RebuyMaxCount {
-			return true
-		}
-	}
-	return false
+	return rebuyAvailable(s.config.RebuyEnabled, s.handCount, s.config.RebuyPeriodHands, s.players, s.rebuyCounts, s.config.RebuyMaxCount)
 }
 
 // IsAddonAvailable 人間プレイヤーがアドオン可能かどうか
 func (s *FiveCardStud) IsAddonAvailable() bool {
-	if !s.config.AddonEnabled || s.handCount != s.config.AddonAfterHand {
-		return false
-	}
-	for i, p := range s.players {
-		if p.GetIsHuman() && !s.addonUsed[i] {
-			return true
-		}
-	}
-	return false
+	return addonAvailable(s.config.AddonEnabled, s.handCount, s.config.AddonAfterHand, s.players, s.addonUsed)
 }
 
 // GetRebuyCounts プレイヤーごとのリバイ回数取得

--- a/internal/domain/FortyAndEight.go
+++ b/internal/domain/FortyAndEight.go
@@ -526,14 +526,7 @@ func (ft *FortyAndEight) canPlaceOnTableau(card *Card, col int) bool {
 
 // canPlaceOnFoundation ファンデーションにカードを置けるか判定
 func (ft *FortyAndEight) canPlaceOnFoundation(card *Card, fIdx int) bool {
-	pile := ft.foundation[fIdx]
-	if len(pile) == 0 {
-		// 空のファンデーションにはAのみ置ける
-		return card.GetValue() == 1
-	}
-	topCard := pile[len(pile)-1]
-	// 同じスートで昇順
-	return card.GetDesign() == topCard.GetDesign() && card.GetValue() == topCard.GetValue()+1
+	return canPlaceOnFoundationPile(ft.foundation[fIdx], card)
 }
 
 // findFoundation カードを置けるファンデーションのインデックスを探す（見つからない場合-1）

--- a/internal/domain/FortyThieves.go
+++ b/internal/domain/FortyThieves.go
@@ -483,14 +483,7 @@ func (ft *FortyThieves) canPlaceOnTableau(card *Card, col int) bool {
 
 // canPlaceOnFoundation ファンデーションにカードを置けるか判定
 func (ft *FortyThieves) canPlaceOnFoundation(card *Card, fIdx int) bool {
-	pile := ft.foundation[fIdx]
-	if len(pile) == 0 {
-		// 空のファンデーションにはAのみ置ける
-		return card.GetValue() == 1
-	}
-	topCard := pile[len(pile)-1]
-	// 同じスートで昇順
-	return card.GetDesign() == topCard.GetDesign() && card.GetValue() == topCard.GetValue()+1
+	return canPlaceOnFoundationPile(ft.foundation[fIdx], card)
 }
 
 // findFoundation カードを置けるファンデーションのインデックスを探す（見つからない場合-1）

--- a/internal/domain/FrenchTarot.go
+++ b/internal/domain/FrenchTarot.go
@@ -1707,10 +1707,7 @@ func (g *FrenchTarot) SetConfig(cfg FrenchTarotConfig) { g.config = cfg }
 
 // GetActionLog 棋譜取得
 func (g *FrenchTarot) GetActionLog() []*ActionLogEntry {
-	if g.actionLog == nil {
-		return []*ActionLogEntry{}
-	}
-	return g.actionLog
+	return sliceOrEmpty(g.actionLog)
 }
 
 // GetPlayableIndices プレイ可能なカードのインデックス一覧を返す。

--- a/internal/domain/FrenchTarot.go
+++ b/internal/domain/FrenchTarot.go
@@ -245,7 +245,7 @@ type FrenchTarot struct {
 	scored          bool
 	gameEndFlag     bool
 	winnerPlayer    int
-	actionLog       []*ActionLogEntry
+	actionLogBase
 }
 
 // NewFrenchTarot コンストラクタ
@@ -1466,13 +1466,7 @@ func (g *FrenchTarot) isHumanBidTurn() bool {
 
 // appendLog 棋譜にエントリを追加する。
 func (g *FrenchTarot) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	g.appendLogAt(len(g.actionLog)+1, playerIdx, actionType, detail, cards)
 }
 
 // frenchTarotBidName 入札の表示名を返す。

--- a/internal/domain/Ganjifa.go
+++ b/internal/domain/Ganjifa.go
@@ -132,7 +132,7 @@ type Ganjifa struct {
 	playerScores     [GanjifaPlayerCnt]int
 	gameEndFlag      bool
 	winnerPlayer     int // -1 = 未確定 (同点)
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // ganjifaJSON is the JSON wire format for Ganjifa.
@@ -412,13 +412,7 @@ func (g *Ganjifa) sortAllHands() {
 
 // appendLog 棋譜に 1 行追加する。
 func (g *Ganjifa) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	g.appendLogAt(len(g.actionLog)+1, playerIdx, actionType, detail, cards)
 }
 
 // finishMatch マッチを終え、獲得トリック数の累計が最大のプレイヤーを勝者にする。

--- a/internal/domain/Ganjifa.go
+++ b/internal/domain/Ganjifa.go
@@ -749,10 +749,7 @@ func (g *Ganjifa) SetConfig(c GanjifaConfig) { g.config = c }
 
 // GetActionLog 棋譜。
 func (g *Ganjifa) GetActionLog() []*ActionLogEntry {
-	if g.actionLog == nil {
-		return []*ActionLogEntry{}
-	}
-	return g.actionLog
+	return sliceOrEmpty(g.actionLog)
 }
 
 // GetHint 人間プレイヤーへのヒント。手番でなければ nil。

--- a/internal/domain/GinRummyPlayer.go
+++ b/internal/domain/GinRummyPlayer.go
@@ -17,9 +17,7 @@ func NewGinRummyPlayer(isHuman bool) *GinRummyPlayer {
 
 // ResetRound ラウンドをリセット（手札・スコア・終了状態を初期化）
 func (p *GinRummyPlayer) ResetRound() {
-	p.SetRoundScore(0)
-	p.Reset()
-	p.SetIsFinished(false)
+	resetRoundScored(p)
 }
 
 // ginRummyPlayerJSON is the JSON wire format for GinRummyPlayer.

--- a/internal/domain/GongZhuPlayer.go
+++ b/internal/domain/GongZhuPlayer.go
@@ -18,10 +18,7 @@ func NewGongZhuPlayer(isHuman bool) *GongZhuPlayer {
 
 // ResetRound ラウンドをリセット（スコア・トリック・手札・終了状態を初期化）
 func (p *GongZhuPlayer) ResetRound() {
-	p.SetRoundScore(0)
-	p.ResetTricks()
-	p.Reset()
-	p.SetIsFinished(false)
+	resetRoundWithTricks(p)
 }
 
 // gongZhuPlayerJSON is the JSON wire format for GongZhuPlayer.

--- a/internal/domain/Guandan.go
+++ b/internal/domain/Guandan.go
@@ -211,7 +211,7 @@ type Guandan struct {
 	handNumber       int
 	gameEndFlag      bool
 	winnerTeam       int
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // GuandanTribute は 1 件の進貢の記録。
@@ -1229,12 +1229,7 @@ func (g *Guandan) GetActionLog() []*ActionLogEntry { return g.actionLog }
 
 // addLog は棋譜を 1 件追加する。
 func (g *Guandan) addLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	g.appendLogAt(0, playerIdx, actionType, detail, cards)
 }
 
 // ---- テスト用 ----

--- a/internal/domain/Guts.go
+++ b/internal/domain/Guts.go
@@ -535,10 +535,7 @@ func (g *Guts) GetPlayer(i int) *GutsPlayer {
 
 // GetChips は人間 (seat 0) の保有チップを返す。
 func (g *Guts) GetChips() int {
-	if len(g.players) == 0 {
-		return 0
-	}
-	return g.players[0].GetChips()
+	return chipsOfFirst(g.players)
 }
 
 // GetConfig はローカルルール設定を返す。

--- a/internal/domain/Guts.go
+++ b/internal/domain/Guts.go
@@ -440,13 +440,7 @@ func (g *Guts) solventCount() int {
 
 // richestIdx はチップが最多のプレイヤーのインデックスを返す (同数は座席番号の小さい方)。
 func (g *Guts) richestIdx() int {
-	best := 0
-	for i, p := range g.players {
-		if p.GetChips() > g.players[best].GetChips() {
-			best = i
-		}
-	}
-	return best
+	return maxIndexBy(g.players, func(p *GutsPlayer) int { return p.GetChips() })
 }
 
 // gutsDeclareText は宣言の棋譜テキストを返す。

--- a/internal/domain/HeartsPlayer.go
+++ b/internal/domain/HeartsPlayer.go
@@ -18,10 +18,7 @@ func NewHeartsPlayer(isHuman bool) *HeartsPlayer {
 
 // ResetRound ラウンドをリセット（スコア・トリック・手札・終了状態を初期化）
 func (p *HeartsPlayer) ResetRound() {
-	p.SetRoundScore(0)
-	p.ResetTricks()
-	p.Reset()
-	p.SetIsFinished(false)
+	resetRoundWithTricks(p)
 }
 
 // heartsPlayerJSON is the JSON wire format for HeartsPlayer.

--- a/internal/domain/Holdem.go
+++ b/internal/domain/Holdem.go
@@ -440,13 +440,7 @@ func (h *Holdem) findNextActive(fromIdx int) int {
 
 // countActivePlayers フォールドしていないプレイヤー数を返す
 func (h *Holdem) countActivePlayers() int {
-	cnt := 0
-	for _, p := range h.players {
-		if !p.GetFolded() {
-			cnt++
-		}
-	}
-	return cnt
+	return countPlayers(h.players, func(p *HoldemPlayer) bool { return !p.GetFolded() })
 }
 
 // bettingLimits ベッティングリミット設定からmaxRaisesとmaxBetAmountを計算
@@ -677,10 +671,7 @@ func (h *Holdem) SetConfig(cfg HoldemConfig) { h.config = cfg }
 
 // IsHumanTurn 人間のターンかチェック
 func (h *Holdem) IsHumanTurn() bool {
-	if h.currentTurn >= 0 && h.currentTurn < len(h.players) {
-		return h.players[h.currentTurn].GetIsHuman()
-	}
-	return false
+	return isHumanTurn(h.players, h.currentTurn)
 }
 
 // GetActedFlags actedフラグ取得

--- a/internal/domain/Holdem.go
+++ b/internal/domain/Holdem.go
@@ -676,9 +676,7 @@ func (h *Holdem) IsHumanTurn() bool {
 
 // GetActedFlags actedフラグ取得
 func (h *Holdem) GetActedFlags() []bool {
-	result := make([]bool, len(h.actedFlags))
-	copy(result, h.actedFlags)
-	return result
+	return copyOf(h.actedFlags)
 }
 
 // GetHandCount ハンド数取得

--- a/internal/domain/HoldemEval.go
+++ b/internal/domain/HoldemEval.go
@@ -160,8 +160,5 @@ func (h *Holdem) IsMuckAvailable() bool {
 
 // getHandName ハンドランクから名前を返す
 func (h *Holdem) getHandName(rank int) string {
-	if rank >= 0 && rank < len(PokerHandNames) {
-		return PokerHandNames[rank]
-	}
-	return "Unknown"
+	return pokerHandName(rank)
 }

--- a/internal/domain/HoldemPlayer.go
+++ b/internal/domain/HoldemPlayer.go
@@ -59,18 +59,12 @@ func (hp *HoldemPlayer) GetPFRCount() int { return hp.pfrCount }
 
 // GetVPIP VPIP%取得 (0 if totalHands==0)
 func (hp *HoldemPlayer) GetVPIP() int {
-	if hp.totalHands == 0 {
-		return 0
-	}
-	return hp.vpipCount * 100 / hp.totalHands
+	return percentOf(hp.vpipCount, hp.totalHands)
 }
 
 // GetPFR PFR%取得 (0 if totalHands==0)
 func (hp *HoldemPlayer) GetPFR() int {
-	if hp.totalHands == 0 {
-		return 0
-	}
-	return hp.pfrCount * 100 / hp.totalHands
+	return percentOf(hp.pfrCount, hp.totalHands)
 }
 
 // IncrementTotalHands 総ハンド数をインクリメント
@@ -90,10 +84,7 @@ func (hp *HoldemPlayer) GetThreeBetCount() int { return hp.threeBetCount }
 
 // GetThreeBet 3Bet%取得 (0 if threeBetOpportunity==0)
 func (hp *HoldemPlayer) GetThreeBet() int {
-	if hp.threeBetOpportunity == 0 {
-		return 0
-	}
-	return hp.threeBetCount * 100 / hp.threeBetOpportunity
+	return percentOf(hp.threeBetCount, hp.threeBetOpportunity)
 }
 
 // IncrementThreeBetOpportunity 3Bet機会数をインクリメント
@@ -127,9 +118,7 @@ func (hp *HoldemPlayer) GetAFDisplay() string {
 
 // GetComparisonCards ハンド比較用カード取得 (BettingPlayerインターフェース)
 func (hp *HoldemPlayer) GetComparisonCards() []*Card {
-	cards := make([]*Card, len(hp.bestHand))
-	copy(cards, hp.bestHand)
-	return cards
+	return copyOf(hp.bestHand)
 }
 
 // holdemPlayerJSON is the JSON wire format for HoldemPlayer.

--- a/internal/domain/HoldemPlayer.go
+++ b/internal/domain/HoldemPlayer.go
@@ -4,7 +4,6 @@ package domain
 
 import (
 	"encoding/json"
-	"fmt"
 	"sort"
 )
 
@@ -107,13 +106,7 @@ func (hp *HoldemPlayer) IncrementPostFlopCall() { hp.postFlopCall++ }
 
 // GetAFDisplay AF表示文字列取得 ("-"=アクションなし, "∞"=コールなし, "X.X"=通常)
 func (hp *HoldemPlayer) GetAFDisplay() string {
-	if hp.postFlopBetRaise == 0 && hp.postFlopCall == 0 {
-		return "-"
-	}
-	if hp.postFlopCall == 0 {
-		return "∞"
-	}
-	return fmt.Sprintf("%.1f", float64(hp.postFlopBetRaise)/float64(hp.postFlopCall))
+	return afDisplay(hp.postFlopBetRaise, hp.postFlopCall)
 }
 
 // GetComparisonCards ハンド比較用カード取得 (BettingPlayerインターフェース)

--- a/internal/domain/HoldemRebuy.go
+++ b/internal/domain/HoldemRebuy.go
@@ -120,16 +120,12 @@ func (h *Holdem) IsAddonAvailable() bool {
 
 // GetRebuyCounts プレイヤーごとのリバイ回数取得
 func (h *Holdem) GetRebuyCounts() []int {
-	result := make([]int, len(h.rebuyCounts))
-	copy(result, h.rebuyCounts)
-	return result
+	return copyOf(h.rebuyCounts)
 }
 
 // GetAddonUsed プレイヤーごとのアドオン使用フラグ取得
 func (h *Holdem) GetAddonUsed() []bool {
-	result := make([]bool, len(h.addonUsed))
-	copy(result, h.addonUsed)
-	return result
+	return copyOf(h.addonUsed)
 }
 
 // GetRebuyPhaseType リバイフェーズ種別取得

--- a/internal/domain/HoldemRebuy.go
+++ b/internal/domain/HoldemRebuy.go
@@ -94,28 +94,12 @@ func (h *Holdem) SkipAddon() error {
 
 // IsRebuyAvailable 人間プレイヤーがリバイ可能かどうか
 func (h *Holdem) IsRebuyAvailable() bool {
-	if !h.config.RebuyEnabled || h.handCount > h.config.RebuyPeriodHands {
-		return false
-	}
-	for i, p := range h.players {
-		if p.GetIsHuman() && p.GetChips() <= 0 && h.rebuyCounts[i] < h.config.RebuyMaxCount {
-			return true
-		}
-	}
-	return false
+	return rebuyAvailable(h.config.RebuyEnabled, h.handCount, h.config.RebuyPeriodHands, h.players, h.rebuyCounts, h.config.RebuyMaxCount)
 }
 
 // IsAddonAvailable 人間プレイヤーがアドオン可能かどうか
 func (h *Holdem) IsAddonAvailable() bool {
-	if !h.config.AddonEnabled || h.handCount != h.config.AddonAfterHand {
-		return false
-	}
-	for i, p := range h.players {
-		if p.GetIsHuman() && !h.addonUsed[i] {
-			return true
-		}
-	}
-	return false
+	return addonAvailable(h.config.AddonEnabled, h.handCount, h.config.AddonAfterHand, h.players, h.addonUsed)
 }
 
 // GetRebuyCounts プレイヤーごとのリバイ回数取得

--- a/internal/domain/IndianPoker.go
+++ b/internal/domain/IndianPoker.go
@@ -721,9 +721,7 @@ func (ip *IndianPoker) IsHumanTurn() bool {
 
 // GetActedFlags actedフラグ取得
 func (ip *IndianPoker) GetActedFlags() []bool {
-	result := make([]bool, len(ip.actedFlags))
-	copy(result, ip.actedFlags)
-	return result
+	return copyOf(ip.actedFlags)
 }
 
 // GetHandCount ハンド数取得

--- a/internal/domain/IndianPoker.go
+++ b/internal/domain/IndianPoker.go
@@ -219,11 +219,7 @@ func (ip *IndianPoker) PlayerAction(action, amount, humanPlayMs int) error {
 
 // bettingPlayers BettingPlayerスライスを生成
 func (ip *IndianPoker) bettingPlayers() []BettingPlayer {
-	bp := make([]BettingPlayer, len(ip.players))
-	for i, pl := range ip.players {
-		bp[i] = pl
-	}
-	return bp
+	return toBettingPlayers(ip.players)
 }
 
 // executeAction 指定プレイヤーのアクション実行
@@ -302,13 +298,7 @@ func (ip *IndianPoker) bettingLimits() (maxRaises, maxBetAmount int) {
 
 // countActivePlayers フォールドしていないプレイヤー数を返す
 func (ip *IndianPoker) countActivePlayers() int {
-	cnt := 0
-	for _, p := range ip.players {
-		if !p.GetFolded() {
-			cnt++
-		}
-	}
-	return cnt
+	return countPlayers(ip.players, func(p *IndianPokerPlayer) bool { return !p.GetFolded() })
 }
 
 // resolveLastPlayer 最後の1人が残った場合のポット配分
@@ -726,10 +716,7 @@ func (ip *IndianPoker) SetConfig(cfg IndianPokerConfig) { ip.config = cfg }
 
 // IsHumanTurn 人間のターンかチェック
 func (ip *IndianPoker) IsHumanTurn() bool {
-	if ip.currentTurn >= 0 && ip.currentTurn < len(ip.players) {
-		return ip.players[ip.currentTurn].GetIsHuman()
-	}
-	return false
+	return isHumanTurn(ip.players, ip.currentTurn)
 }
 
 // GetActedFlags actedフラグ取得

--- a/internal/domain/IndianRummy.go
+++ b/internal/domain/IndianRummy.go
@@ -396,12 +396,7 @@ func (g *IndianRummy) CpuPlay() {
 
 // cpuDraw CPU の引き処理。捨て札トップが役を進めるなら拾い、そうでなければ山札から引く。
 func (g *IndianRummy) cpuDraw() {
-	top := g.GetDiscardTop()
-	if top != nil && g.cpuShouldTakeDiscard(top) {
-		_ = g.drawFromDiscard()
-		return
-	}
-	_ = g.drawFromStock()
+	cpuDrawTurn(g)
 }
 
 // cpuShouldTakeDiscard 捨て札トップを拾うべきかを返す

--- a/internal/domain/IndianRummy.go
+++ b/internal/domain/IndianRummy.go
@@ -301,16 +301,7 @@ func (g *IndianRummy) drawFromDiscard() error {
 
 // recycleDiscardIntoStock 山札が空のとき捨て札トップ 1 枚を残して残りを山札へ戻しシャッフルする。
 func (g *IndianRummy) recycleDiscardIntoStock() bool {
-	if len(g.discardPile) <= 1 {
-		return false
-	}
-	top := g.discardPile[len(g.discardPile)-1]
-	rest := g.discardPile[:len(g.discardPile)-1]
-	g.discardPile = []*Card{top}
-	rand.Shuffle(len(rest), func(i, j int) { rest[i], rest[j] = rest[j], rest[i] })
-	g.drawPile = append(g.drawPile, rest...)
-	g.appendLog(-1, "recycle", fmt.Sprintf("Discard pile recycled into stock (%d cards)", len(rest)), nil)
-	return true
+	return recycleDiscardIntoStock(&g.discardPile, &g.drawPile, g)
 }
 
 // PlayerDiscard 人間プレイヤーが手札 1 枚を捨ててターンを終了する
@@ -655,16 +646,7 @@ func (g *IndianRummy) sortAllHands() {
 }
 
 func (g *IndianRummy) sortHand(playerIdx int) {
-	p := g.players[playerIdx]
-	cards := make([]*Card, p.GetCardsSize())
-	for i := 0; i < p.GetCardsSize(); i++ {
-		cards[i] = p.GetCard(i)
-	}
-	sortCards(cards)
-	p.Reset()
-	for _, c := range cards {
-		p.AddCard(c)
-	}
+	sortHandInPlace(g.players[playerIdx], sortCards)
 }
 
 // indianRummyCollectCards プレイヤーの手札を []*Card で返す

--- a/internal/domain/IndianRummyPlayer.go
+++ b/internal/domain/IndianRummyPlayer.go
@@ -19,9 +19,7 @@ func NewIndianRummyPlayer(isHuman bool) *IndianRummyPlayer {
 
 // ResetRound ラウンドをリセット（手札・スコア・終了状態を初期化）
 func (p *IndianRummyPlayer) ResetRound() {
-	p.SetRoundScore(0)
-	p.Reset()
-	p.SetIsFinished(false)
+	resetRoundScored(p)
 }
 
 // indianRummyPlayerJSON は IndianRummyPlayer の JSON 表現。

--- a/internal/domain/Kalooki.go
+++ b/internal/domain/Kalooki.go
@@ -441,12 +441,7 @@ func (g *Kalooki) CpuPlay() {
 
 // cpuDraw CPU の引き処理。捨て札トップが手役を進めるなら拾い、そうでなければ山札から引く
 func (g *Kalooki) cpuDraw() {
-	top := g.GetDiscardTop()
-	if top != nil && g.cpuShouldTakeDiscard(top) {
-		_ = g.drawFromDiscard()
-		return
-	}
-	_ = g.drawFromStock()
+	cpuDrawTurn(g)
 }
 
 // cpuShouldTakeDiscard 捨て札トップを拾うべきかを返す

--- a/internal/domain/Kalooki.go
+++ b/internal/domain/Kalooki.go
@@ -234,16 +234,7 @@ func (g *Kalooki) drawFromDiscard() error {
 
 // recycleDiscardIntoStock 山札が空のとき捨て札トップ 1 枚を残して残りを山札へ戻しシャッフルする。
 func (g *Kalooki) recycleDiscardIntoStock() bool {
-	if len(g.discardPile) <= 1 {
-		return false
-	}
-	top := g.discardPile[len(g.discardPile)-1]
-	rest := g.discardPile[:len(g.discardPile)-1]
-	g.discardPile = []*Card{top}
-	rand.Shuffle(len(rest), func(i, j int) { rest[i], rest[j] = rest[j], rest[i] })
-	g.drawPile = append(g.drawPile, rest...)
-	g.appendLog(-1, "recycle", fmt.Sprintf("Discard pile recycled into stock (%d cards)", len(rest)), nil)
-	return true
+	return recycleDiscardIntoStock(&g.discardPile, &g.drawPile, g)
 }
 
 // PlayerMeld 人間プレイヤーがメルド群を場に出す。
@@ -706,16 +697,7 @@ func (g *Kalooki) sortAllHands() {
 }
 
 func (g *Kalooki) sortHand(playerIdx int) {
-	p := g.players[playerIdx]
-	cards := make([]*Card, p.GetCardsSize())
-	for i := 0; i < p.GetCardsSize(); i++ {
-		cards[i] = p.GetCard(i)
-	}
-	sortCards(cards)
-	p.Reset()
-	for _, c := range cards {
-		p.AddCard(c)
-	}
+	sortHandInPlace(g.players[playerIdx], sortCards)
 }
 
 // --- Pure card-evaluation helpers ---

--- a/internal/domain/Karnoffel.go
+++ b/internal/domain/Karnoffel.go
@@ -275,7 +275,7 @@ type Karnoffel struct {
 	handNumber  int
 	gameEndFlag bool
 	winnerTeam  int
-	actionLog   []*ActionLogEntry
+	actionLogBase
 }
 
 // NewKarnoffel コンストラクタ
@@ -738,12 +738,7 @@ func (k *Karnoffel) GetActionLog() []*ActionLogEntry { return k.actionLog }
 
 // addLog は棋譜を 1 件追加する。
 func (k *Karnoffel) addLog(playerIdx int, actionType, detail string, cards []*Card) {
-	k.actionLog = append(k.actionLog, &ActionLogEntry{
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	k.appendLogAt(0, playerIdx, actionType, detail, cards)
 }
 
 // ---- テスト用 ----

--- a/internal/domain/Klondike.go
+++ b/internal/domain/Klondike.go
@@ -617,14 +617,7 @@ func (k *Klondike) canPlaceOnTableau(card *Card, col int) bool {
 
 // canPlaceOnFoundation ファンデーションにカードを置けるか判定
 func (k *Klondike) canPlaceOnFoundation(card *Card, fIdx int) bool {
-	pile := k.foundation[fIdx]
-	if len(pile) == 0 {
-		// 空のファンデーションにはAのみ置ける
-		return card.GetValue() == 1
-	}
-	topCard := pile[len(pile)-1]
-	// 同じスートで昇順
-	return card.GetDesign() == topCard.GetDesign() && card.GetValue() == topCard.GetValue()+1
+	return canPlaceOnFoundationPile(k.foundation[fIdx], card)
 }
 
 // isAlternateColor 交互の色かどうか判定

--- a/internal/domain/KnockoutWhist.go
+++ b/internal/domain/KnockoutWhist.go
@@ -378,19 +378,7 @@ func (g *KnockoutWhist) mostTricksPlayer() int {
 
 // validatePlay マストフォローを検証する。
 func (g *KnockoutWhist) validatePlay(playerIdx int, card *Card) error {
-	if len(g.currentTrick) == 0 {
-		return nil
-	}
-	leadSuit := g.currentTrick[0].Card.GetDesign()
-	if g.playerHasSuit(playerIdx, leadSuit) && card.GetDesign() != leadSuit {
-		return NewDomainError(ErrInvalidPlay, "リードスートに従ってください")
-	}
-	return nil
-}
-
-// playerHasSuit プレイヤーが指定スートのカードを持っているか。
-func (g *KnockoutWhist) playerHasSuit(playerIdx, design int) bool {
-	return handHasSuit(g.players[playerIdx], design)
+	return validateFollowSuit(g.currentTrick, g.players, playerIdx, card)
 }
 
 // trickWinner トリックの勝者を決定する。切り札があれば最強切り札、なければ

--- a/internal/domain/Koenigrufen.go
+++ b/internal/domain/Koenigrufen.go
@@ -245,7 +245,7 @@ type Koenigrufen struct {
 	scored          bool
 	gameEndFlag     bool
 	winnerPlayer    int
-	actionLog       []*ActionLogEntry
+	actionLogBase
 }
 
 // NewKoenigrufen コンストラクタ
@@ -1529,13 +1529,7 @@ func (g *Koenigrufen) isHumanBidTurn() bool {
 
 // appendLog 棋譜にエントリを追加する。
 func (g *Koenigrufen) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	g.appendLogAt(len(g.actionLog)+1, playerIdx, actionType, detail, cards)
 }
 
 // koenigrufenBidName 入札の表示名を返す。

--- a/internal/domain/Koenigrufen.go
+++ b/internal/domain/Koenigrufen.go
@@ -1765,10 +1765,7 @@ func (g *Koenigrufen) SetConfig(cfg KoenigrufenConfig) { g.config = cfg }
 
 // GetActionLog 棋譜取得
 func (g *Koenigrufen) GetActionLog() []*ActionLogEntry {
-	if g.actionLog == nil {
-		return []*ActionLogEntry{}
-	}
-	return g.actionLog
+	return sliceOrEmpty(g.actionLog)
 }
 
 // GetPlayableIndices プレイ可能なカードのインデックス一覧を返す。

--- a/internal/domain/LaughAndLieDown.go
+++ b/internal/domain/LaughAndLieDown.go
@@ -468,10 +468,7 @@ func (l *LaughAndLieDown) IsLaidDown(idx int) bool {
 
 // GetScore は idx の収支を返す。
 func (l *LaughAndLieDown) GetScore(idx int) int {
-	if idx < 0 || idx >= len(l.scores) {
-		return 0
-	}
-	return l.scores[idx]
+	return elemAt(l.scores, idx)
 }
 
 // GetDealerIdx は親の添字を返す。

--- a/internal/domain/LaughAndLieDownPlayer.go
+++ b/internal/domain/LaughAndLieDownPlayer.go
@@ -16,8 +16,7 @@ func NewLaughAndLieDownPlayer(isHuman bool) *LaughAndLieDownPlayer {
 
 // ResetGame は手札と上がり状態を初期化する。
 func (p *LaughAndLieDownPlayer) ResetGame() {
-	p.Reset()
-	p.SetIsFinished(false)
+	resetPlayer(p)
 }
 
 // laughAndLieDownPlayerJSON is the JSON wire format for LaughAndLieDownPlayer.

--- a/internal/domain/Literature.go
+++ b/internal/domain/Literature.go
@@ -179,7 +179,7 @@ type Literature struct {
 	lastClaim   *LiteratureClaimResult
 	gameEndFlag bool
 	winnerTeam  int
-	actionLog   []*ActionLogEntry
+	actionLogBase
 }
 
 // NewLiterature コンストラクタ
@@ -853,12 +853,7 @@ func (l *Literature) GetActionLog() []*ActionLogEntry { return l.actionLog }
 
 // addLog は棋譜を 1 件追加する。
 func (l *Literature) addLog(playerIdx int, actionType, detail string, cards []*Card) {
-	l.actionLog = append(l.actionLog, &ActionLogEntry{
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	l.appendLogAt(0, playerIdx, actionType, detail, cards)
 }
 
 // literatureCardName は札の内部名を返す (棋譜用)。

--- a/internal/domain/Loba.go
+++ b/internal/domain/Loba.go
@@ -823,10 +823,7 @@ func (l *Loba) HasMelded(idx int) bool {
 
 // GetScore は idx の累計失点を返す。
 func (l *Loba) GetScore(idx int) int {
-	if idx < 0 || idx >= len(l.scores) {
-		return 0
-	}
-	return l.scores[idx]
+	return elemAt(l.scores, idx)
 }
 
 // IsEliminated は idx が脱落しているかを返す。

--- a/internal/domain/LobaPlayer.go
+++ b/internal/domain/LobaPlayer.go
@@ -16,8 +16,7 @@ func NewLobaPlayer(isHuman bool) *LobaPlayer {
 
 // ResetGame は手札と上がり状態を初期化する。
 func (p *LobaPlayer) ResetGame() {
-	p.Reset()
-	p.SetIsFinished(false)
+	resetPlayer(p)
 }
 
 // lobaPlayerJSON is the JSON wire format for LobaPlayer.

--- a/internal/domain/Macau.go
+++ b/internal/domain/Macau.go
@@ -645,13 +645,7 @@ func (g *Macau) recycleDrawPile() {
 
 // hasPlayableCard プレイヤーが出せるカードを持っているか
 func (g *Macau) hasPlayableCard(playerIdx int) bool {
-	player := g.players[playerIdx]
-	for i := 0; i < player.GetCardsSize(); i++ {
-		if g.isValidPlay(player.GetCard(i)) {
-			return true
-		}
-	}
-	return false
+	return handHasAny(g.players[playerIdx], g.isValidPlay)
 }
 
 // checkGameEnd ゲーム終了判定

--- a/internal/domain/Machiavelli.go
+++ b/internal/domain/Machiavelli.go
@@ -656,16 +656,7 @@ func (g *Machiavelli) sortAllHands() {
 }
 
 func (g *Machiavelli) sortHand(playerIdx int) {
-	p := g.players[playerIdx]
-	cards := make([]*Card, p.GetCardsSize())
-	for i := 0; i < p.GetCardsSize(); i++ {
-		cards[i] = p.GetCard(i)
-	}
-	sortCards(cards)
-	p.Reset()
-	for _, c := range cards {
-		p.AddCard(c)
-	}
+	sortHandInPlace(g.players[playerIdx], sortCards)
 }
 
 // machiavelliCollectCards プレイヤーの手札を []*Card で返す

--- a/internal/domain/MachiavelliPlayer.go
+++ b/internal/domain/MachiavelliPlayer.go
@@ -19,9 +19,7 @@ func NewMachiavelliPlayer(isHuman bool) *MachiavelliPlayer {
 
 // ResetRound ラウンドをリセット（手札・スコア・終了状態を初期化）
 func (p *MachiavelliPlayer) ResetRound() {
-	p.SetRoundScore(0)
-	p.Reset()
-	p.SetIsFinished(false)
+	resetRoundScored(p)
 }
 
 // machiavelliPlayerJSON は MachiavelliPlayer の JSON 表現。

--- a/internal/domain/Mao.go
+++ b/internal/domain/Mao.go
@@ -840,13 +840,7 @@ func (g *Mao) recycleDrawPile() {
 
 // hasPlayableCard プレイヤーが出せるカードを持っているか
 func (g *Mao) hasPlayableCard(playerIdx int) bool {
-	player := g.players[playerIdx]
-	for i := 0; i < player.GetCardsSize(); i++ {
-		if g.isValidPlay(player.GetCard(i)) {
-			return true
-		}
-	}
-	return false
+	return handHasAny(g.players[playerIdx], g.isValidPlay)
 }
 
 // checkGameEnd ゲーム終了判定

--- a/internal/domain/Michigan.go
+++ b/internal/domain/Michigan.go
@@ -599,13 +599,7 @@ func (g *Michigan) endGame() {
 
 // richestIdx はチップが最多のプレイヤーのインデックスを返す (同数は座席番号の小さい方)。
 func (g *Michigan) richestIdx() int {
-	best := 0
-	for i, p := range g.players {
-		if p.GetChips() > g.players[best].GetChips() {
-			best = i
-		}
-	}
-	return best
+	return maxIndexBy(g.players, func(p *MichiganPlayer) int { return p.GetChips() })
 }
 
 // --- Hint ---

--- a/internal/domain/Michigan.go
+++ b/internal/domain/Michigan.go
@@ -730,10 +730,7 @@ func (g *Michigan) GetPlayer(i int) *MichiganPlayer {
 
 // GetChips は人間 (seat 0) の保有チップを返す。
 func (g *Michigan) GetChips() int {
-	if len(g.players) == 0 {
-		return 0
-	}
-	return g.players[0].GetChips()
+	return chipsOfFirst(g.players)
 }
 
 // IsHumanTurn は現在人間 (seat 0) の入力待ちかどうかを返す。

--- a/internal/domain/Mushi.go
+++ b/internal/domain/Mushi.go
@@ -696,10 +696,7 @@ func (m *Mushi) GetRoundNumber() int { return m.roundNumber }
 
 // GetScore は idx の累計得点を返す。
 func (m *Mushi) GetScore(idx int) int {
-	if idx < 0 || idx >= len(m.scores) {
-		return 0
-	}
-	return m.scores[idx]
+	return elemAt(m.scores, idx)
 }
 
 // SetScore は idx の累計得点を設定する (テスト用)。

--- a/internal/domain/MushiPlayer.go
+++ b/internal/domain/MushiPlayer.go
@@ -16,8 +16,7 @@ func NewMushiPlayer(isHuman bool) *MushiPlayer {
 
 // ResetGame は手札と上がり状態を初期化する。
 func (p *MushiPlayer) ResetGame() {
-	p.Reset()
-	p.SetIsFinished(false)
+	resetPlayer(p)
 }
 
 // mushiPlayerJSON is the JSON wire format for MushiPlayer.

--- a/internal/domain/Nap.go
+++ b/internal/domain/Nap.go
@@ -449,19 +449,7 @@ func (g *Nap) checkGameEnd() {
 
 // validatePlay マストフォローを検証する。
 func (g *Nap) validatePlay(playerIdx int, card *Card) error {
-	if len(g.currentTrick) == 0 {
-		return nil
-	}
-	leadSuit := g.currentTrick[0].Card.GetDesign()
-	if g.playerHasSuit(playerIdx, leadSuit) && card.GetDesign() != leadSuit {
-		return NewDomainError(ErrInvalidPlay, "リードスートに従ってください")
-	}
-	return nil
-}
-
-// playerHasSuit プレイヤーが指定スートのカードを持っているか。
-func (g *Nap) playerHasSuit(playerIdx, design int) bool {
-	return handHasSuit(g.players[playerIdx], design)
+	return validateFollowSuit(g.currentTrick, g.players, playerIdx, card)
 }
 
 // trickWinner トリックの勝者を決定する。切り札があれば最強切り札、なければ

--- a/internal/domain/OhHellPlayer.go
+++ b/internal/domain/OhHellPlayer.go
@@ -27,10 +27,7 @@ func (p *OhHellPlayer) SetBid(bid int) { p.bid = bid }
 // ResetRound ラウンドをリセット（ビッド・トリック・手札・終了状態を初期化）
 func (p *OhHellPlayer) ResetRound() {
 	p.bid = -1
-	p.SetRoundScore(0)
-	p.ResetTricks()
-	p.Reset()
-	p.SetIsFinished(false)
+	resetRoundWithTricks(p)
 }
 
 // ohHellPlayerJSON is the JSON wire format for OhHellPlayer.

--- a/internal/domain/Omaha.go
+++ b/internal/domain/Omaha.go
@@ -1171,28 +1171,12 @@ func (o *Omaha) SkipAddon() error {
 
 // IsRebuyAvailable 人間プレイヤーがリバイ可能かどうか
 func (o *Omaha) IsRebuyAvailable() bool {
-	if !o.config.RebuyEnabled || o.handCount > o.config.RebuyPeriodHands {
-		return false
-	}
-	for i, p := range o.players {
-		if p.GetIsHuman() && p.GetChips() <= 0 && o.rebuyCounts[i] < o.config.RebuyMaxCount {
-			return true
-		}
-	}
-	return false
+	return rebuyAvailable(o.config.RebuyEnabled, o.handCount, o.config.RebuyPeriodHands, o.players, o.rebuyCounts, o.config.RebuyMaxCount)
 }
 
 // IsAddonAvailable 人間プレイヤーがアドオン可能かどうか
 func (o *Omaha) IsAddonAvailable() bool {
-	if !o.config.AddonEnabled || o.handCount != o.config.AddonAfterHand {
-		return false
-	}
-	for i, p := range o.players {
-		if p.GetIsHuman() && !o.addonUsed[i] {
-			return true
-		}
-	}
-	return false
+	return addonAvailable(o.config.AddonEnabled, o.handCount, o.config.AddonAfterHand, o.players, o.addonUsed)
 }
 
 // GetRebuyCounts プレイヤーごとのリバイ回数取得

--- a/internal/domain/Omaha.go
+++ b/internal/domain/Omaha.go
@@ -485,13 +485,7 @@ func (o *Omaha) findNextActive(fromIdx int) int {
 
 // countActivePlayers フォールドしていないプレイヤー数を返す
 func (o *Omaha) countActivePlayers() int {
-	cnt := 0
-	for _, p := range o.players {
-		if !p.GetFolded() {
-			cnt++
-		}
-	}
-	return cnt
+	return countPlayers(o.players, func(p *OmahaPlayer) bool { return !p.GetFolded() })
 }
 
 // resolveLastPlayer 全員フォールドで最後のプレイヤーが勝利
@@ -1357,10 +1351,7 @@ func (o *Omaha) SetConfig(cfg OmahaConfig) { o.config = cfg }
 
 // IsHumanTurn 人間のターンかチェック
 func (o *Omaha) IsHumanTurn() bool {
-	if o.currentTurn >= 0 && o.currentTurn < len(o.players) {
-		return o.players[o.currentTurn].GetIsHuman()
-	}
-	return false
+	return isHumanTurn(o.players, o.currentTurn)
 }
 
 // GetActedFlags actedフラグ取得

--- a/internal/domain/Omaha.go
+++ b/internal/domain/Omaha.go
@@ -682,10 +682,7 @@ func (o *Omaha) IsMuckAvailable() bool {
 
 // getHandName ハンドランクから名前を返す
 func (o *Omaha) getHandName(rank int) string {
-	if rank >= 0 && rank < len(PokerHandNames) {
-		return PokerHandNames[rank]
-	}
-	return "Unknown"
+	return pokerHandName(rank)
 }
 
 // runCpuActions CPUプレイヤーのアクションを実行
@@ -1200,16 +1197,12 @@ func (o *Omaha) IsAddonAvailable() bool {
 
 // GetRebuyCounts プレイヤーごとのリバイ回数取得
 func (o *Omaha) GetRebuyCounts() []int {
-	result := make([]int, len(o.rebuyCounts))
-	copy(result, o.rebuyCounts)
-	return result
+	return copyOf(o.rebuyCounts)
 }
 
 // GetAddonUsed プレイヤーごとのアドオン使用フラグ取得
 func (o *Omaha) GetAddonUsed() []bool {
-	result := make([]bool, len(o.addonUsed))
-	copy(result, o.addonUsed)
-	return result
+	return copyOf(o.addonUsed)
 }
 
 // GetRebuyPhaseType リバイフェーズ種別取得
@@ -1356,9 +1349,7 @@ func (o *Omaha) IsHumanTurn() bool {
 
 // GetActedFlags actedフラグ取得
 func (o *Omaha) GetActedFlags() []bool {
-	result := make([]bool, len(o.actedFlags))
-	copy(result, o.actedFlags)
-	return result
+	return copyOf(o.actedFlags)
 }
 
 // GetHandCount ハンド数取得

--- a/internal/domain/OmahaPlayer.go
+++ b/internal/domain/OmahaPlayer.go
@@ -60,18 +60,12 @@ func (op *OmahaPlayer) GetPFRCount() int { return op.pfrCount }
 
 // GetVPIP VPIP%取得 (0 if totalHands==0)
 func (op *OmahaPlayer) GetVPIP() int {
-	if op.totalHands == 0 {
-		return 0
-	}
-	return op.vpipCount * 100 / op.totalHands
+	return percentOf(op.vpipCount, op.totalHands)
 }
 
 // GetPFR PFR%取得 (0 if totalHands==0)
 func (op *OmahaPlayer) GetPFR() int {
-	if op.totalHands == 0 {
-		return 0
-	}
-	return op.pfrCount * 100 / op.totalHands
+	return percentOf(op.pfrCount, op.totalHands)
 }
 
 // IncrementTotalHands 総ハンド数をインクリメント
@@ -91,10 +85,7 @@ func (op *OmahaPlayer) GetThreeBetCount() int { return op.threeBetCount }
 
 // GetThreeBet 3Bet%取得 (0 if threeBetOpportunity==0)
 func (op *OmahaPlayer) GetThreeBet() int {
-	if op.threeBetOpportunity == 0 {
-		return 0
-	}
-	return op.threeBetCount * 100 / op.threeBetOpportunity
+	return percentOf(op.threeBetCount, op.threeBetOpportunity)
 }
 
 // IncrementThreeBetOpportunity 3Bet機会数をインクリメント
@@ -128,9 +119,7 @@ func (op *OmahaPlayer) GetAFDisplay() string {
 
 // GetComparisonCards ハンド比較用カード取得 (BettingPlayerインターフェース)
 func (op *OmahaPlayer) GetComparisonCards() []*Card {
-	cards := make([]*Card, len(op.bestHand))
-	copy(cards, op.bestHand)
-	return cards
+	return copyOf(op.bestHand)
 }
 
 // GetLowBestHand Hi-Lo用ローベスト5枚取得 (未評価/不成立時はnil)

--- a/internal/domain/OmahaPlayer.go
+++ b/internal/domain/OmahaPlayer.go
@@ -4,7 +4,6 @@ package domain
 
 import (
 	"encoding/json"
-	"fmt"
 )
 
 // OmahaPlayer オマハホールデムプレイヤークラス
@@ -108,13 +107,7 @@ func (op *OmahaPlayer) IncrementPostFlopCall() { op.postFlopCall++ }
 
 // GetAFDisplay AF表示文字列取得 ("-"=アクションなし, "∞"=コールなし, "X.X"=通常)
 func (op *OmahaPlayer) GetAFDisplay() string {
-	if op.postFlopBetRaise == 0 && op.postFlopCall == 0 {
-		return "-"
-	}
-	if op.postFlopCall == 0 {
-		return "∞"
-	}
-	return fmt.Sprintf("%.1f", float64(op.postFlopBetRaise)/float64(op.postFlopCall))
+	return afDisplay(op.postFlopBetRaise, op.postFlopCall)
 }
 
 // GetComparisonCards ハンド比較用カード取得 (BettingPlayerインターフェース)

--- a/internal/domain/PageOne.go
+++ b/internal/domain/PageOne.go
@@ -484,13 +484,7 @@ func (g *PageOne) recycleDrawPile() {
 
 // hasPlayableCard プレイヤーが出せるカードを持っているか
 func (g *PageOne) hasPlayableCard(playerIdx int) bool {
-	player := g.players[playerIdx]
-	for i := 0; i < player.GetCardsSize(); i++ {
-		if g.isValidPlay(player.GetCard(i)) {
-			return true
-		}
-	}
-	return false
+	return handHasAny(g.players[playerIdx], g.isValidPlay)
 }
 
 // checkGameEnd ゲーム終了判定

--- a/internal/domain/Pineapple.go
+++ b/internal/domain/Pineapple.go
@@ -1214,10 +1214,7 @@ func (p *Pineapple) SetConfig(cfg PineappleConfig) { p.config = cfg }
 
 // IsHumanTurn 人間のターンかチェック
 func (p *Pineapple) IsHumanTurn() bool {
-	if p.currentTurn >= 0 && p.currentTurn < len(p.players) {
-		return p.players[p.currentTurn].GetIsHuman()
-	}
-	return false
+	return isHumanTurn(p.players, p.currentTurn)
 }
 
 // GetActedFlags actedフラグ取得

--- a/internal/domain/Pineapple.go
+++ b/internal/domain/Pineapple.go
@@ -811,10 +811,7 @@ func (p *Pineapple) IsMuckAvailable() bool {
 
 // getHandName ハンドランクから名前を返す
 func (p *Pineapple) getHandName(rank int) string {
-	if rank >= 0 && rank < len(PokerHandNames) {
-		return PokerHandNames[rank]
-	}
-	return "Unknown"
+	return pokerHandName(rank)
 }
 
 // bettingLimits ベッティングリミット設定からmaxRaisesとmaxBetAmountを計算
@@ -1111,16 +1108,12 @@ func (p *Pineapple) IsAddonAvailable() bool {
 
 // GetRebuyCounts プレイヤーごとのリバイ回数取得
 func (p *Pineapple) GetRebuyCounts() []int {
-	result := make([]int, len(p.rebuyCounts))
-	copy(result, p.rebuyCounts)
-	return result
+	return copyOf(p.rebuyCounts)
 }
 
 // GetAddonUsed プレイヤーごとのアドオン使用フラグ取得
 func (p *Pineapple) GetAddonUsed() []bool {
-	result := make([]bool, len(p.addonUsed))
-	copy(result, p.addonUsed)
-	return result
+	return copyOf(p.addonUsed)
 }
 
 // GetRebuyPhaseType リバイフェーズ種別取得
@@ -1219,9 +1212,7 @@ func (p *Pineapple) IsHumanTurn() bool {
 
 // GetActedFlags actedフラグ取得
 func (p *Pineapple) GetActedFlags() []bool {
-	result := make([]bool, len(p.actedFlags))
-	copy(result, p.actedFlags)
-	return result
+	return copyOf(p.actedFlags)
 }
 
 // GetHandCount ハンド数取得

--- a/internal/domain/PineapplePlayer.go
+++ b/internal/domain/PineapplePlayer.go
@@ -58,18 +58,12 @@ func (pp *PineapplePlayer) GetPFRCount() int { return pp.pfrCount }
 
 // GetVPIP VPIP%取得 (0 if totalHands==0)
 func (pp *PineapplePlayer) GetVPIP() int {
-	if pp.totalHands == 0 {
-		return 0
-	}
-	return pp.vpipCount * 100 / pp.totalHands
+	return percentOf(pp.vpipCount, pp.totalHands)
 }
 
 // GetPFR PFR%取得 (0 if totalHands==0)
 func (pp *PineapplePlayer) GetPFR() int {
-	if pp.totalHands == 0 {
-		return 0
-	}
-	return pp.pfrCount * 100 / pp.totalHands
+	return percentOf(pp.pfrCount, pp.totalHands)
 }
 
 // IncrementTotalHands 総ハンド数をインクリメント
@@ -89,10 +83,7 @@ func (pp *PineapplePlayer) GetThreeBetCount() int { return pp.threeBetCount }
 
 // GetThreeBet 3Bet%取得 (0 if threeBetOpportunity==0)
 func (pp *PineapplePlayer) GetThreeBet() int {
-	if pp.threeBetOpportunity == 0 {
-		return 0
-	}
-	return pp.threeBetCount * 100 / pp.threeBetOpportunity
+	return percentOf(pp.threeBetCount, pp.threeBetOpportunity)
 }
 
 // IncrementThreeBetOpportunity 3Bet機会数をインクリメント
@@ -126,9 +117,7 @@ func (pp *PineapplePlayer) GetAFDisplay() string {
 
 // GetComparisonCards ハンド比較用カード取得 (BettingPlayerインターフェース)
 func (pp *PineapplePlayer) GetComparisonCards() []*Card {
-	cards := make([]*Card, len(pp.bestHand))
-	copy(cards, pp.bestHand)
-	return cards
+	return copyOf(pp.bestHand)
 }
 
 // EvalBestHand コミュニティカードとホールカードからベスト5枚を評価

--- a/internal/domain/PineapplePlayer.go
+++ b/internal/domain/PineapplePlayer.go
@@ -4,7 +4,6 @@ package domain
 
 import (
 	"encoding/json"
-	"fmt"
 )
 
 // PineapplePlayer パイナップルポーカープレイヤークラス
@@ -106,13 +105,7 @@ func (pp *PineapplePlayer) IncrementPostFlopCall() { pp.postFlopCall++ }
 
 // GetAFDisplay AF表示文字列取得 ("-"=アクションなし, "∞"=コールなし, "X.X"=通常)
 func (pp *PineapplePlayer) GetAFDisplay() string {
-	if pp.postFlopBetRaise == 0 && pp.postFlopCall == 0 {
-		return "-"
-	}
-	if pp.postFlopCall == 0 {
-		return "∞"
-	}
-	return fmt.Sprintf("%.1f", float64(pp.postFlopBetRaise)/float64(pp.postFlopCall))
+	return afDisplay(pp.postFlopBetRaise, pp.postFlopCall)
 }
 
 // GetComparisonCards ハンド比較用カード取得 (BettingPlayerインターフェース)

--- a/internal/domain/PitchPlayer.go
+++ b/internal/domain/PitchPlayer.go
@@ -27,10 +27,7 @@ func (p *PitchPlayer) SetBid(bid int) { p.bid = bid }
 // ResetRound ラウンドをリセット (ビッド・トリック・手札・終了状態を初期化)
 func (p *PitchPlayer) ResetRound() {
 	p.bid = -1
-	p.SetRoundScore(0)
-	p.ResetTricks()
-	p.Reset()
-	p.SetIsFinished(false)
+	resetRoundWithTricks(p)
 }
 
 // pitchPlayerJSON is the JSON wire format for PitchPlayer.

--- a/internal/domain/Poker.go
+++ b/internal/domain/Poker.go
@@ -341,11 +341,7 @@ func (p *Poker) PlayerStand() error {
 
 // bettingPlayers BettingPlayerスライスを生成
 func (p *Poker) bettingPlayers() []BettingPlayer {
-	bp := make([]BettingPlayer, len(p.players))
-	for i, pl := range p.players {
-		bp[i] = pl
-	}
-	return bp
+	return toBettingPlayers(p.players)
 }
 
 // executeAction 指定プレイヤーのアクション実行

--- a/internal/domain/Preference.go
+++ b/internal/domain/Preference.go
@@ -469,19 +469,7 @@ func (g *Preference) checkGameEnd() {
 
 // validatePlay マストフォローを検証する。
 func (g *Preference) validatePlay(playerIdx int, card *Card) error {
-	if len(g.currentTrick) == 0 {
-		return nil
-	}
-	leadSuit := g.currentTrick[0].Card.GetDesign()
-	if g.playerHasSuit(playerIdx, leadSuit) && card.GetDesign() != leadSuit {
-		return NewDomainError(ErrInvalidPlay, "リードスートに従ってください")
-	}
-	return nil
-}
-
-// playerHasSuit プレイヤーが指定スートのカードを持っているか。
-func (g *Preference) playerHasSuit(playerIdx, design int) bool {
-	return handHasSuit(g.players[playerIdx], design)
+	return validateFollowSuit(g.currentTrick, g.players, playerIdx, card)
 }
 
 // trickWinner トリックの勝者を決定する。切り札があれば最強切り札、なければ

--- a/internal/domain/Primero.go
+++ b/internal/domain/Primero.go
@@ -670,13 +670,7 @@ func (g *Primero) solventCount() int {
 
 // richestIdx はチップが最多のプレイヤーのインデックスを返す (同数は座席番号の小さい方)。
 func (g *Primero) richestIdx() int {
-	best := 0
-	for i, p := range g.players {
-		if p.GetChips() > g.players[best].GetChips() {
-			best = i
-		}
-	}
-	return best
+	return maxIndexBy(g.players, func(p *PrimeroPlayer) int { return p.GetChips() })
 }
 
 func (g *Primero) appendLog(playerIdx int, actionType, detail string, cards []*Card) {

--- a/internal/domain/Primero.go
+++ b/internal/domain/Primero.go
@@ -776,10 +776,7 @@ func (g *Primero) GetPlayer(i int) *PrimeroPlayer {
 
 // GetChips は人間 (seat 0) の保有チップを返す。
 func (g *Primero) GetChips() int {
-	if len(g.players) == 0 {
-		return 0
-	}
-	return g.players[0].GetChips()
+	return chipsOfFirst(g.players)
 }
 
 // IsHumanTurn は現在の手番が人間 (seat 0) かどうかを返す。

--- a/internal/domain/Primero.go
+++ b/internal/domain/Primero.go
@@ -642,13 +642,7 @@ func (g *Primero) activeSeats() []int {
 
 // activeCount は未フォールド・非脱落プレイヤー数を返す。
 func (g *Primero) activeCount() int {
-	n := 0
-	for _, p := range g.players {
-		if !p.GetOut() && !p.GetFolded() {
-			n++
-		}
-	}
-	return n
+	return countPlayers(g.players, func(p *PrimeroPlayer) bool { return !p.GetOut() && !p.GetFolded() })
 }
 
 // nextActive は from の次の未フォールド・非脱落プレイヤーを返す。

--- a/internal/domain/Prsi.go
+++ b/internal/domain/Prsi.go
@@ -404,13 +404,7 @@ func (g *Prsi) recycleDrawPile() {
 
 // hasPlayableCard プレイヤーが出せるカードを持っているか
 func (g *Prsi) hasPlayableCard(playerIdx int) bool {
-	player := g.players[playerIdx]
-	for i := 0; i < player.GetCardsSize(); i++ {
-		if g.isValidPlay(player.GetCard(i)) {
-			return true
-		}
-	}
-	return false
+	return handHasAny(g.players[playerIdx], g.isValidPlay)
 }
 
 // HasPlayableCard プレイヤーが出せるカードを持っているか (Web/ヒント用)

--- a/internal/domain/RussianSolitaire.go
+++ b/internal/domain/RussianSolitaire.go
@@ -414,14 +414,7 @@ func (y *RussianSolitaire) canPlaceOnTableau(card *Card, col int) bool {
 
 // canPlaceOnFoundation ファンデーションにカードを置けるか判定
 func (y *RussianSolitaire) canPlaceOnFoundation(card *Card, fIdx int) bool {
-	pile := y.foundation[fIdx]
-	if len(pile) == 0 {
-		// 空のファンデーションにはAのみ置ける
-		return card.GetValue() == 1
-	}
-	topCard := pile[len(pile)-1]
-	// 同じスートで昇順
-	return card.GetDesign() == topCard.GetDesign() && card.GetValue() == topCard.GetValue()+1
+	return canPlaceOnFoundationPile(y.foundation[fIdx], card)
 }
 
 // autoFlipTableau タブローの最上部の裏カードを自動フリップ

--- a/internal/domain/Scarto.go
+++ b/internal/domain/Scarto.go
@@ -170,7 +170,7 @@ type Scarto struct {
 	scored          bool
 	gameEndFlag     bool
 	winnerPlayer    int
-	actionLog       []*ActionLogEntry
+	actionLogBase
 }
 
 // NewScarto コンストラクタ
@@ -1100,13 +1100,7 @@ func (g *Scarto) isHumanScartoTurn() bool {
 
 // appendLog 棋譜にエントリを追加する。
 func (g *Scarto) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	g.appendLogAt(len(g.actionLog)+1, playerIdx, actionType, detail, cards)
 }
 
 // scartoCardStr カードのログ表示文字列 (切り札・エクスキューズ対応)。

--- a/internal/domain/Scarto.go
+++ b/internal/domain/Scarto.go
@@ -1283,10 +1283,7 @@ func (g *Scarto) SetConfig(cfg ScartoConfig) { g.config = cfg }
 
 // GetActionLog 棋譜取得
 func (g *Scarto) GetActionLog() []*ActionLogEntry {
-	if g.actionLog == nil {
-		return []*ActionLogEntry{}
-	}
-	return g.actionLog
+	return sliceOrEmpty(g.actionLog)
 }
 
 // GetPlayableIndices プレイ可能なカードのインデックス一覧を返す。

--- a/internal/domain/SevenCardStud.go
+++ b/internal/domain/SevenCardStud.go
@@ -899,10 +899,7 @@ func (s *SevenCardStud) IsMuckAvailable() bool {
 
 // getHandName ハンドランクから名前を返す
 func (s *SevenCardStud) getHandName(rank int) string {
-	if rank >= 0 && rank < len(PokerHandNames) {
-		return PokerHandNames[rank]
-	}
-	return "Unknown"
+	return pokerHandName(rank)
 }
 
 // getRazzHandName Razz用ハンド名を返す (例: "8-Low", "Wheel", "One Pair")
@@ -1049,9 +1046,7 @@ func (s *SevenCardStud) IsHumanTurn() bool {
 
 // GetActedFlags actedフラグ取得
 func (s *SevenCardStud) GetActedFlags() []bool {
-	result := make([]bool, len(s.actedFlags))
-	copy(result, s.actedFlags)
-	return result
+	return copyOf(s.actedFlags)
 }
 
 // GetHandCount ハンド数取得

--- a/internal/domain/SevenCardStud.go
+++ b/internal/domain/SevenCardStud.go
@@ -420,11 +420,7 @@ func (s *SevenCardStud) PlayerAction(action, amount, humanPlayMs int) error {
 
 // bettingPlayers BettingPlayerスライスを生成
 func (s *SevenCardStud) bettingPlayers() []BettingPlayer {
-	bp := make([]BettingPlayer, len(s.players))
-	for i, pl := range s.players {
-		bp[i] = pl
-	}
-	return bp
+	return toBettingPlayers(s.players)
 }
 
 // executeAction 指定プレイヤーのアクション実行
@@ -647,13 +643,7 @@ func (s *SevenCardStud) determineBettingLeader() int {
 
 // countActivePlayers フォールドしていないプレイヤー数を返す
 func (s *SevenCardStud) countActivePlayers() int {
-	cnt := 0
-	for _, p := range s.players {
-		if !p.GetFolded() {
-			cnt++
-		}
-	}
-	return cnt
+	return countPlayers(s.players, func(p *SevenCardStudPlayer) bool { return !p.GetFolded() })
 }
 
 // bettingLimits ベッティングリミット設定
@@ -1054,10 +1044,7 @@ func (s *SevenCardStud) SetConfig(cfg SevenCardStudConfig) { s.config = cfg }
 
 // IsHumanTurn 人間のターンかチェック
 func (s *SevenCardStud) IsHumanTurn() bool {
-	if s.currentTurn >= 0 && s.currentTurn < len(s.players) {
-		return s.players[s.currentTurn].GetIsHuman()
-	}
-	return false
+	return isHumanTurn(s.players, s.currentTurn)
 }
 
 // GetActedFlags actedフラグ取得

--- a/internal/domain/SevenCardStudPlayer.go
+++ b/internal/domain/SevenCardStudPlayer.go
@@ -4,7 +4,6 @@ package domain
 
 import (
 	"encoding/json"
-	"fmt"
 	"sort"
 )
 
@@ -144,13 +143,7 @@ func (p *SevenCardStudPlayer) IncrementPostFlopCall() { p.postFlopCall++ }
 
 // GetAFDisplay AF表示文字列取得 ("-"=アクションなし, "∞"=コールなし, "X.X"=通常)
 func (p *SevenCardStudPlayer) GetAFDisplay() string {
-	if p.postFlopBetRaise == 0 && p.postFlopCall == 0 {
-		return "-"
-	}
-	if p.postFlopCall == 0 {
-		return "∞"
-	}
-	return fmt.Sprintf("%.1f", float64(p.postFlopBetRaise)/float64(p.postFlopCall))
+	return afDisplay(p.postFlopBetRaise, p.postFlopCall)
 }
 
 // GetComparisonCards ハンド比較用カード取得 (BettingPlayerインターフェース)

--- a/internal/domain/SevenCardStudPlayer.go
+++ b/internal/domain/SevenCardStudPlayer.go
@@ -96,18 +96,12 @@ func (p *SevenCardStudPlayer) GetPFRCount() int { return p.pfrCount }
 
 // GetVPIP VPIP%取得 (0 if totalHands==0)
 func (p *SevenCardStudPlayer) GetVPIP() int {
-	if p.totalHands == 0 {
-		return 0
-	}
-	return p.vpipCount * 100 / p.totalHands
+	return percentOf(p.vpipCount, p.totalHands)
 }
 
 // GetPFR PFR%取得 (0 if totalHands==0)
 func (p *SevenCardStudPlayer) GetPFR() int {
-	if p.totalHands == 0 {
-		return 0
-	}
-	return p.pfrCount * 100 / p.totalHands
+	return percentOf(p.pfrCount, p.totalHands)
 }
 
 // IncrementTotalHands 総ハンド数をインクリメント
@@ -127,10 +121,7 @@ func (p *SevenCardStudPlayer) GetThreeBetCount() int { return p.threeBetCount }
 
 // GetThreeBet 3Bet%取得 (0 if threeBetOpportunity==0)
 func (p *SevenCardStudPlayer) GetThreeBet() int {
-	if p.threeBetOpportunity == 0 {
-		return 0
-	}
-	return p.threeBetCount * 100 / p.threeBetOpportunity
+	return percentOf(p.threeBetCount, p.threeBetOpportunity)
 }
 
 // IncrementThreeBetOpportunity 3Bet機会数をインクリメント
@@ -164,9 +155,7 @@ func (p *SevenCardStudPlayer) GetAFDisplay() string {
 
 // GetComparisonCards ハンド比較用カード取得 (BettingPlayerインターフェース)
 func (p *SevenCardStudPlayer) GetComparisonCards() []*Card {
-	cards := make([]*Card, len(p.bestHand))
-	copy(cards, p.bestHand)
-	return cards
+	return copyOf(p.bestHand)
 }
 
 // PeekBestHand は現在の持ち札から最善の 5 枚役を求めて返す。**状態を変えない。**

--- a/internal/domain/SevenCardStudRebuy.go
+++ b/internal/domain/SevenCardStudRebuy.go
@@ -91,28 +91,12 @@ func (s *SevenCardStud) SkipAddon() error {
 
 // IsRebuyAvailable 人間プレイヤーがリバイ可能かどうか
 func (s *SevenCardStud) IsRebuyAvailable() bool {
-	if !s.config.RebuyEnabled || s.handCount > s.config.RebuyPeriodHands {
-		return false
-	}
-	for i, p := range s.players {
-		if p.GetIsHuman() && p.GetChips() <= 0 && s.rebuyCounts[i] < s.config.RebuyMaxCount {
-			return true
-		}
-	}
-	return false
+	return rebuyAvailable(s.config.RebuyEnabled, s.handCount, s.config.RebuyPeriodHands, s.players, s.rebuyCounts, s.config.RebuyMaxCount)
 }
 
 // IsAddonAvailable 人間プレイヤーがアドオン可能かどうか
 func (s *SevenCardStud) IsAddonAvailable() bool {
-	if !s.config.AddonEnabled || s.handCount != s.config.AddonAfterHand {
-		return false
-	}
-	for i, p := range s.players {
-		if p.GetIsHuman() && !s.addonUsed[i] {
-			return true
-		}
-	}
-	return false
+	return addonAvailable(s.config.AddonEnabled, s.handCount, s.config.AddonAfterHand, s.players, s.addonUsed)
 }
 
 // GetRebuyCounts プレイヤーごとのリバイ回数取得

--- a/internal/domain/SevenCardStudRebuy.go
+++ b/internal/domain/SevenCardStudRebuy.go
@@ -117,16 +117,12 @@ func (s *SevenCardStud) IsAddonAvailable() bool {
 
 // GetRebuyCounts プレイヤーごとのリバイ回数取得
 func (s *SevenCardStud) GetRebuyCounts() []int {
-	result := make([]int, len(s.rebuyCounts))
-	copy(result, s.rebuyCounts)
-	return result
+	return copyOf(s.rebuyCounts)
 }
 
 // GetAddonUsed プレイヤーごとのアドオン使用フラグ取得
 func (s *SevenCardStud) GetAddonUsed() []bool {
-	result := make([]bool, len(s.addonUsed))
-	copy(result, s.addonUsed)
-	return result
+	return copyOf(s.addonUsed)
 }
 
 // GetRebuyPhaseType リバイフェーズ種別取得

--- a/internal/domain/ShengJi.go
+++ b/internal/domain/ShengJi.go
@@ -178,7 +178,7 @@ type ShengJi struct {
 	handNumber     int
 	gameEndFlag    bool
 	winnerTeam     int
-	actionLog      []*ActionLogEntry
+	actionLogBase
 }
 
 // NewShengJi コンストラクタ
@@ -1082,12 +1082,7 @@ func (s *ShengJi) GetActionLog() []*ActionLogEntry { return s.actionLog }
 
 // addLog は棋譜に 1 件追加する。
 func (s *ShengJi) addLog(playerIdx int, actionType, detail string, cards []*Card) {
-	s.actionLog = append(s.actionLog, &ActionLogEntry{
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	s.appendLogAt(0, playerIdx, actionType, detail, cards)
 }
 
 // IsHumanTurn は現在の手番が人間かを返す。

--- a/internal/domain/ShortDeck.go
+++ b/internal/domain/ShortDeck.go
@@ -999,28 +999,12 @@ func (sd *ShortDeck) SkipAddon() error {
 
 // IsRebuyAvailable 人間プレイヤーがリバイ可能かどうか
 func (sd *ShortDeck) IsRebuyAvailable() bool {
-	if !sd.config.RebuyEnabled || sd.handCount > sd.config.RebuyPeriodHands {
-		return false
-	}
-	for i, p := range sd.players {
-		if p.GetIsHuman() && p.GetChips() <= 0 && sd.rebuyCounts[i] < sd.config.RebuyMaxCount {
-			return true
-		}
-	}
-	return false
+	return rebuyAvailable(sd.config.RebuyEnabled, sd.handCount, sd.config.RebuyPeriodHands, sd.players, sd.rebuyCounts, sd.config.RebuyMaxCount)
 }
 
 // IsAddonAvailable 人間プレイヤーがアドオン可能かどうか
 func (sd *ShortDeck) IsAddonAvailable() bool {
-	if !sd.config.AddonEnabled || sd.handCount != sd.config.AddonAfterHand {
-		return false
-	}
-	for i, p := range sd.players {
-		if p.GetIsHuman() && !sd.addonUsed[i] {
-			return true
-		}
-	}
-	return false
+	return addonAvailable(sd.config.AddonEnabled, sd.handCount, sd.config.AddonAfterHand, sd.players, sd.addonUsed)
 }
 
 // GetRebuyCounts プレイヤーごとのリバイ回数取得

--- a/internal/domain/ShortDeck.go
+++ b/internal/domain/ShortDeck.go
@@ -1025,16 +1025,12 @@ func (sd *ShortDeck) IsAddonAvailable() bool {
 
 // GetRebuyCounts プレイヤーごとのリバイ回数取得
 func (sd *ShortDeck) GetRebuyCounts() []int {
-	result := make([]int, len(sd.rebuyCounts))
-	copy(result, sd.rebuyCounts)
-	return result
+	return copyOf(sd.rebuyCounts)
 }
 
 // GetAddonUsed プレイヤーごとのアドオン使用フラグ取得
 func (sd *ShortDeck) GetAddonUsed() []bool {
-	result := make([]bool, len(sd.addonUsed))
-	copy(result, sd.addonUsed)
-	return result
+	return copyOf(sd.addonUsed)
 }
 
 // GetRebuyPhaseType リバイフェーズ種別取得
@@ -1181,9 +1177,7 @@ func (sd *ShortDeck) IsHumanTurn() bool {
 
 // GetActedFlags actedフラグ取得
 func (sd *ShortDeck) GetActedFlags() []bool {
-	result := make([]bool, len(sd.actedFlags))
-	copy(result, sd.actedFlags)
-	return result
+	return copyOf(sd.actedFlags)
 }
 
 // GetHandCount ハンド数取得

--- a/internal/domain/ShortDeck.go
+++ b/internal/domain/ShortDeck.go
@@ -446,13 +446,7 @@ func (sd *ShortDeck) findNextActive(fromIdx int) int {
 
 // countActivePlayers フォールドしていないプレイヤー数を返す
 func (sd *ShortDeck) countActivePlayers() int {
-	cnt := 0
-	for _, p := range sd.players {
-		if !p.GetFolded() {
-			cnt++
-		}
-	}
-	return cnt
+	return countPlayers(sd.players, func(p *ShortDeckPlayer) bool { return !p.GetFolded() })
 }
 
 // resolveLastPlayer 全員フォールドで最後のプレイヤーが勝利
@@ -1182,10 +1176,7 @@ func (sd *ShortDeck) SetConfig(cfg ShortDeckConfig) { sd.config = cfg }
 
 // IsHumanTurn 人間のターンかチェック
 func (sd *ShortDeck) IsHumanTurn() bool {
-	if sd.currentTurn >= 0 && sd.currentTurn < len(sd.players) {
-		return sd.players[sd.currentTurn].GetIsHuman()
-	}
-	return false
+	return isHumanTurn(sd.players, sd.currentTurn)
 }
 
 // GetActedFlags actedフラグ取得

--- a/internal/domain/ShortDeckPlayer.go
+++ b/internal/domain/ShortDeckPlayer.go
@@ -58,18 +58,12 @@ func (sp *ShortDeckPlayer) GetPFRCount() int { return sp.pfrCount }
 
 // GetVPIP VPIP%取得 (0 if totalHands==0)
 func (sp *ShortDeckPlayer) GetVPIP() int {
-	if sp.totalHands == 0 {
-		return 0
-	}
-	return sp.vpipCount * 100 / sp.totalHands
+	return percentOf(sp.vpipCount, sp.totalHands)
 }
 
 // GetPFR PFR%取得 (0 if totalHands==0)
 func (sp *ShortDeckPlayer) GetPFR() int {
-	if sp.totalHands == 0 {
-		return 0
-	}
-	return sp.pfrCount * 100 / sp.totalHands
+	return percentOf(sp.pfrCount, sp.totalHands)
 }
 
 // IncrementTotalHands 総ハンド数をインクリメント
@@ -89,10 +83,7 @@ func (sp *ShortDeckPlayer) GetThreeBetCount() int { return sp.threeBetCount }
 
 // GetThreeBet 3Bet%取得 (0 if threeBetOpportunity==0)
 func (sp *ShortDeckPlayer) GetThreeBet() int {
-	if sp.threeBetOpportunity == 0 {
-		return 0
-	}
-	return sp.threeBetCount * 100 / sp.threeBetOpportunity
+	return percentOf(sp.threeBetCount, sp.threeBetOpportunity)
 }
 
 // IncrementThreeBetOpportunity 3Bet機会数をインクリメント
@@ -126,9 +117,7 @@ func (sp *ShortDeckPlayer) GetAFDisplay() string {
 
 // GetComparisonCards ハンド比較用カード取得 (BettingPlayerインターフェース)
 func (sp *ShortDeckPlayer) GetComparisonCards() []*Card {
-	cards := make([]*Card, len(sp.bestHand))
-	copy(cards, sp.bestHand)
-	return cards
+	return copyOf(sp.bestHand)
 }
 
 // shortDeckPlayerJSON is the JSON wire format for ShortDeckPlayer.

--- a/internal/domain/ShortDeckPlayer.go
+++ b/internal/domain/ShortDeckPlayer.go
@@ -4,7 +4,6 @@ package domain
 
 import (
 	"encoding/json"
-	"fmt"
 )
 
 // ShortDeckPlayer ショートデックホールデムプレイヤークラス
@@ -106,13 +105,7 @@ func (sp *ShortDeckPlayer) IncrementPostFlopCall() { sp.postFlopCall++ }
 
 // GetAFDisplay AF表示文字列取得 ("-"=アクションなし, "∞"=コールなし, "X.X"=通常)
 func (sp *ShortDeckPlayer) GetAFDisplay() string {
-	if sp.postFlopBetRaise == 0 && sp.postFlopCall == 0 {
-		return "-"
-	}
-	if sp.postFlopCall == 0 {
-		return "∞"
-	}
-	return fmt.Sprintf("%.1f", float64(sp.postFlopBetRaise)/float64(sp.postFlopCall))
+	return afDisplay(sp.postFlopBetRaise, sp.postFlopCall)
 }
 
 // GetComparisonCards ハンド比較用カード取得 (BettingPlayerインターフェース)

--- a/internal/domain/SixBidSolo.go
+++ b/internal/domain/SixBidSolo.go
@@ -290,7 +290,7 @@ type SixBidSolo struct {
 	handNumber  int
 	gameEndFlag bool
 	winnerIdx   int
-	actionLog   []*ActionLogEntry
+	actionLogBase
 }
 
 // NewSixBidSolo コンストラクタ
@@ -1190,12 +1190,7 @@ func (s *SixBidSolo) GetActionLog() []*ActionLogEntry { return s.actionLog }
 
 // addLog は棋譜を 1 件追加する。
 func (s *SixBidSolo) addLog(playerIdx int, actionType, detail string, cards []*Card) {
-	s.actionLog = append(s.actionLog, &ActionLogEntry{
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	s.appendLogAt(0, playerIdx, actionType, detail, cards)
 }
 
 // sixBidSoloBidName はビッドの内部名を返す (棋譜用)。

--- a/internal/domain/SjavsPlayer.go
+++ b/internal/domain/SjavsPlayer.go
@@ -16,8 +16,7 @@ func NewSjavsPlayer(isHuman bool) *SjavsPlayer {
 
 // ResetGame は手札と上がり状態を初期化する。
 func (p *SjavsPlayer) ResetGame() {
-	p.Reset()
-	p.SetIsFinished(false)
+	resetPlayer(p)
 }
 
 // sjavsPlayerJSON is the JSON wire format for SjavsPlayer.

--- a/internal/domain/SkitgubbePlayer.go
+++ b/internal/domain/SkitgubbePlayer.go
@@ -16,8 +16,7 @@ func NewSkitgubbePlayer(isHuman bool) *SkitgubbePlayer {
 
 // ResetGame は手札と上がり状態を初期化する。
 func (p *SkitgubbePlayer) ResetGame() {
-	p.Reset()
-	p.SetIsFinished(false)
+	resetPlayer(p)
 }
 
 // skitgubbePlayerJSON is the JSON wire format for SkitgubbePlayer.

--- a/internal/domain/SoloWhist.go
+++ b/internal/domain/SoloWhist.go
@@ -465,19 +465,7 @@ func (g *SoloWhist) checkGameEnd() {
 
 // validatePlay マストフォローを検証する。
 func (g *SoloWhist) validatePlay(playerIdx int, card *Card) error {
-	if len(g.currentTrick) == 0 {
-		return nil
-	}
-	leadSuit := g.currentTrick[0].Card.GetDesign()
-	if g.playerHasSuit(playerIdx, leadSuit) && card.GetDesign() != leadSuit {
-		return NewDomainError(ErrInvalidPlay, "リードスートに従ってください")
-	}
-	return nil
-}
-
-// playerHasSuit プレイヤーが指定スートのカードを持っているか。
-func (g *SoloWhist) playerHasSuit(playerIdx, design int) bool {
-	return handHasSuit(g.players[playerIdx], design)
+	return validateFollowSuit(g.currentTrick, g.players, playerIdx, card)
 }
 
 // trickWinner トリックの勝者を決定する。切り札があれば最強切り札、なければ

--- a/internal/domain/SpadesPlayer.go
+++ b/internal/domain/SpadesPlayer.go
@@ -34,10 +34,7 @@ func (p *SpadesPlayer) SetBags(bags int) { p.bags = bags }
 // ResetRound ラウンドをリセット（ビッド・トリック・手札・終了状態を初期化）
 func (p *SpadesPlayer) ResetRound() {
 	p.bid = -1
-	p.SetRoundScore(0)
-	p.ResetTricks()
-	p.Reset()
-	p.SetIsFinished(false)
+	resetRoundWithTricks(p)
 }
 
 // spadesPlayerJSON is the JSON wire format for SpadesPlayer.

--- a/internal/domain/TarneebPlayer.go
+++ b/internal/domain/TarneebPlayer.go
@@ -43,10 +43,7 @@ func (p *TarneebPlayer) SetBid(bid int) { p.bid = bid }
 // ResetRound ラウンド単位の状態をリセット
 func (p *TarneebPlayer) ResetRound() {
 	p.bid = -1
-	p.SetRoundScore(0)
-	p.ResetTricks()
-	p.Reset()
-	p.SetIsFinished(false)
+	resetRoundWithTricks(p)
 }
 
 // tarneebPlayerJSON is the JSON wire format for TarneebPlayer.

--- a/internal/domain/TeenPatti.go
+++ b/internal/domain/TeenPatti.go
@@ -597,13 +597,7 @@ func (g *TeenPatti) canShow(idx int) bool {
 
 // activeCount 未フォールド・非脱落のプレイヤー数。
 func (g *TeenPatti) activeCount() int {
-	n := 0
-	for _, p := range g.players {
-		if !p.GetOut() && !p.GetFolded() {
-			n++
-		}
-	}
-	return n
+	return countPlayers(g.players, func(p *TeenPattiPlayer) bool { return !p.GetOut() && !p.GetFolded() })
 }
 
 // firstActive 最初の未フォールド・非脱落プレイヤー。

--- a/internal/domain/Terrace.go
+++ b/internal/domain/Terrace.go
@@ -540,17 +540,12 @@ func (t *Terrace) popReserve() {
 
 // wasteTop 捨て札の一番上（空なら nil）
 func (t *Terrace) wasteTop() *Card {
-	if len(t.waste) == 0 {
-		return nil
-	}
-	return t.waste[len(t.waste)-1]
+	return discardTop(t.waste)
 }
 
 // popWaste 捨て札の一番上を取り除く
 func (t *Terrace) popWaste() {
-	if len(t.waste) > 0 {
-		t.waste = t.waste[:len(t.waste)-1]
-	}
+	t.waste = dropLast(t.waste)
 }
 
 // tableauTop 山の一番上（空なら nil）

--- a/internal/domain/ThreeCardBrag.go
+++ b/internal/domain/ThreeCardBrag.go
@@ -559,13 +559,7 @@ func (g *ThreeCardBrag) canShow(idx int) bool {
 
 // activeCount 未フォールド・非脱落のプレイヤー数。
 func (g *ThreeCardBrag) activeCount() int {
-	n := 0
-	for _, p := range g.players {
-		if !p.GetOut() && !p.GetFolded() {
-			n++
-		}
-	}
-	return n
+	return countPlayers(g.players, func(p *ThreeCardBragPlayer) bool { return !p.GetOut() && !p.GetFolded() })
 }
 
 // firstActive 最初の未フォールド・非脱落プレイヤー。

--- a/internal/domain/ThreeThirteen.go
+++ b/internal/domain/ThreeThirteen.go
@@ -386,12 +386,7 @@ func (g *ThreeThirteen) CpuPlay() {
 
 // cpuDraw CPU の引き処理。捨て札トップが手役のデッドウッドを減らすなら拾い、そうでなければ山札から引く。
 func (g *ThreeThirteen) cpuDraw() {
-	top := g.GetDiscardTop()
-	if top != nil && g.cpuShouldTakeDiscard(top) {
-		_ = g.drawFromDiscard()
-		return
-	}
-	_ = g.drawFromStock()
+	cpuDrawTurn(g)
 }
 
 // cpuShouldTakeDiscard 捨て札トップを拾うべきかを返す。

--- a/internal/domain/ThreeThirteen.go
+++ b/internal/domain/ThreeThirteen.go
@@ -267,16 +267,7 @@ func (g *ThreeThirteen) drawFromDiscard() error {
 
 // recycleDiscardIntoStock 山札が空のとき捨て札トップ 1 枚を残して残りを山札へ戻しシャッフルする。
 func (g *ThreeThirteen) recycleDiscardIntoStock() bool {
-	if len(g.discardPile) <= 1 {
-		return false
-	}
-	top := g.discardPile[len(g.discardPile)-1]
-	rest := g.discardPile[:len(g.discardPile)-1]
-	g.discardPile = []*Card{top}
-	rand.Shuffle(len(rest), func(i, j int) { rest[i], rest[j] = rest[j], rest[i] })
-	g.drawPile = append(g.drawPile, rest...)
-	g.appendLog(-1, "recycle", fmt.Sprintf("Discard pile recycled into stock (%d cards)", len(rest)), nil)
-	return true
+	return recycleDiscardIntoStock(&g.discardPile, &g.drawPile, g)
 }
 
 // PlayerDiscard 人間プレイヤーが手札 1 枚を捨ててターン終了する
@@ -608,16 +599,7 @@ func (g *ThreeThirteen) sortAllHands() {
 }
 
 func (g *ThreeThirteen) sortHand(playerIdx int) {
-	p := g.players[playerIdx]
-	cards := make([]*Card, p.GetCardsSize())
-	for i := 0; i < p.GetCardsSize(); i++ {
-		cards[i] = p.GetCard(i)
-	}
-	sortCards(cards)
-	p.Reset()
-	for _, c := range cards {
-		p.AddCard(c)
-	}
+	sortHandInPlace(g.players[playerIdx], sortCards)
 }
 
 // collectThreeThirteenCards プレイヤーの手札を []*Card で返す

--- a/internal/domain/ThreeThirteenPlayer.go
+++ b/internal/domain/ThreeThirteenPlayer.go
@@ -19,9 +19,7 @@ func NewThreeThirteenPlayer(isHuman bool) *ThreeThirteenPlayer {
 
 // ResetRound ラウンドをリセット（手札・ラウンドスコア・終了状態を初期化）
 func (p *ThreeThirteenPlayer) ResetRound() {
-	p.SetRoundScore(0)
-	p.Reset()
-	p.SetIsFinished(false)
+	resetRoundScored(p)
 }
 
 // threeThirteenPlayerJSON は ThreeThirteenPlayer の JSON 表現。

--- a/internal/domain/ToepenPlayer.go
+++ b/internal/domain/ToepenPlayer.go
@@ -16,8 +16,7 @@ func NewToepenPlayer(isHuman bool) *ToepenPlayer {
 
 // ResetGame は手札と上がり状態を初期化する。
 func (p *ToepenPlayer) ResetGame() {
-	p.Reset()
-	p.SetIsFinished(false)
+	resetPlayer(p)
 }
 
 // toepenPlayerJSON is the JSON wire format for ToepenPlayer.

--- a/internal/domain/TonkPlayer.go
+++ b/internal/domain/TonkPlayer.go
@@ -17,9 +17,7 @@ func NewTonkPlayer(isHuman bool) *TonkPlayer {
 
 // ResetRound ラウンドをリセット（手札・スコア・終了状態を初期化）
 func (p *TonkPlayer) ResetRound() {
-	p.SetRoundScore(0)
-	p.Reset()
-	p.SetIsFinished(false)
+	resetRoundScored(p)
 }
 
 // tonkPlayerJSON is the JSON wire format for TonkPlayer.

--- a/internal/domain/Trex.go
+++ b/internal/domain/Trex.go
@@ -740,10 +740,7 @@ func (t *Trex) GetTricksWon(idx int) int {
 
 // GetScore は idx の累計得点を返す。
 func (t *Trex) GetScore(idx int) int {
-	if idx < 0 || idx >= len(t.scores) {
-		return 0
-	}
-	return t.scores[idx]
+	return elemAt(t.scores, idx)
 }
 
 // GetDealScore は idx の今ディールの得点を返す。

--- a/internal/domain/TrexPlayer.go
+++ b/internal/domain/TrexPlayer.go
@@ -16,8 +16,7 @@ func NewTrexPlayer(isHuman bool) *TrexPlayer {
 
 // ResetGame は手札と上がり状態を初期化する。
 func (p *TrexPlayer) ResetGame() {
-	p.Reset()
-	p.SetIsFinished(false)
+	resetPlayer(p)
 }
 
 // trexPlayerJSON is the JSON wire format for TrexPlayer.

--- a/internal/domain/TwentyNine.go
+++ b/internal/domain/TwentyNine.go
@@ -459,19 +459,7 @@ func (g *TwentyNine) checkGameEnd() {
 
 // validatePlay マストフォローを検証する。
 func (g *TwentyNine) validatePlay(playerIdx int, card *Card) error {
-	if len(g.currentTrick) == 0 {
-		return nil
-	}
-	leadSuit := g.currentTrick[0].Card.GetDesign()
-	if g.playerHasSuit(playerIdx, leadSuit) && card.GetDesign() != leadSuit {
-		return NewDomainError(ErrInvalidPlay, "リードスートに従ってください")
-	}
-	return nil
-}
-
-// playerHasSuit プレイヤーが指定スートのカードを持っているか。
-func (g *TwentyNine) playerHasSuit(playerIdx, design int) bool {
-	return handHasSuit(g.players[playerIdx], design)
+	return validateFollowSuit(g.currentTrick, g.players, playerIdx, card)
 }
 
 // trickWinner トリックの勝者を決定する。切り札があれば最強切り札、なければ

--- a/internal/domain/TwoTenJackPlayer.go
+++ b/internal/domain/TwoTenJackPlayer.go
@@ -18,10 +18,7 @@ func NewTwoTenJackPlayer(isHuman bool) *TwoTenJackPlayer {
 
 // ResetRound ラウンドをリセット
 func (p *TwoTenJackPlayer) ResetRound() {
-	p.SetRoundScore(0)
-	p.ResetTricks()
-	p.Reset()
-	p.SetIsFinished(false)
+	resetRoundWithTricks(p)
 }
 
 // GetCapturedPointCards 獲得した点札の合計得点 (A=1, 10=10, J=1)

--- a/internal/domain/Vira.go
+++ b/internal/domain/Vira.go
@@ -850,10 +850,7 @@ func (g *Vira) SetConfig(c ViraConfig) { g.config = c }
 
 // GetActionLog 棋譜。
 func (g *Vira) GetActionLog() []*ActionLogEntry {
-	if g.actionLog == nil {
-		return []*ActionLogEntry{}
-	}
-	return g.actionLog
+	return sliceOrEmpty(g.actionLog)
 }
 
 // ForcePassForTest 指定席を強制的にパスさせる (テスト用)。

--- a/internal/domain/Vira.go
+++ b/internal/domain/Vira.go
@@ -139,8 +139,8 @@ type Vira struct {
 	lastRoundMade    bool
 	gameEndFlag      bool
 	winnerPlayer     int // -1 = 未確定 (同点)
-	actionLog        []*ActionLogEntry
-	shuffled         []*Card // rng 差し替え時の並べ替え済み山
+	actionLogBase
+	shuffled []*Card // rng 差し替え時の並べ替え済み山
 }
 
 // NewVira コンストラクタ。
@@ -474,13 +474,7 @@ func (g *Vira) longestSuit(playerIdx int) int {
 
 // appendLog 棋譜に 1 行追加する。
 func (g *Vira) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: len(g.actionLog) + 1,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	g.appendLogAt(len(g.actionLog)+1, playerIdx, actionType, detail, cards)
 }
 
 // finishMatch マッチを終え、持ち点最大のプレイヤーを勝者にする。

--- a/internal/domain/WhistPlayer.go
+++ b/internal/domain/WhistPlayer.go
@@ -29,10 +29,7 @@ func (p *WhistPlayer) GetTeam() int { return p.team }
 
 // ResetRound ラウンドをリセット（トリック・手札・終了状態を初期化）
 func (p *WhistPlayer) ResetRound() {
-	p.SetRoundScore(0)
-	p.ResetTricks()
-	p.Reset()
-	p.SetIsFinished(false)
+	resetRoundWithTricks(p)
 }
 
 // whistPlayerJSON is the JSON wire format for WhistPlayer.

--- a/internal/domain/Windmill.go
+++ b/internal/domain/Windmill.go
@@ -528,17 +528,12 @@ func (w *Windmill) cornerTop(cornerIdx int) *Card {
 
 // wasteTop 捨て札の一番上（空なら nil）
 func (w *Windmill) wasteTop() *Card {
-	if len(w.waste) == 0 {
-		return nil
-	}
-	return w.waste[len(w.waste)-1]
+	return discardTop(w.waste)
 }
 
 // popWaste 捨て札の一番上を取り除く
 func (w *Windmill) popWaste() {
-	if len(w.waste) > 0 {
-		w.waste = w.waste[:len(w.waste)-1]
-	}
+	w.waste = dropLast(w.waste)
 }
 
 // pushCenter 帆・捨て札から中央へ置く。引き戻しの禁止を解除するのはこの経路だけ。

--- a/internal/domain/WizardPlayer.go
+++ b/internal/domain/WizardPlayer.go
@@ -27,10 +27,7 @@ func (p *WizardPlayer) SetBid(bid int) { p.bid = bid }
 // ResetRound ラウンドをリセット（ビッド・トリック・手札・終了状態を初期化）
 func (p *WizardPlayer) ResetRound() {
 	p.bid = -1
-	p.SetRoundScore(0)
-	p.ResetTricks()
-	p.Reset()
-	p.SetIsFinished(false)
+	resetRoundWithTricks(p)
 }
 
 // wizardPlayerJSON is the JSON wire format for WizardPlayer.

--- a/internal/domain/Yukon.go
+++ b/internal/domain/Yukon.go
@@ -410,14 +410,7 @@ func (y *Yukon) canPlaceOnTableau(card *Card, col int) bool {
 
 // canPlaceOnFoundation ファンデーションにカードを置けるか判定
 func (y *Yukon) canPlaceOnFoundation(card *Card, fIdx int) bool {
-	pile := y.foundation[fIdx]
-	if len(pile) == 0 {
-		// 空のファンデーションにはAのみ置ける
-		return card.GetValue() == 1
-	}
-	topCard := pile[len(pile)-1]
-	// 同じスートで昇順
-	return card.GetDesign() == topCard.GetDesign() && card.GetValue() == topCard.GetValue()+1
+	return canPlaceOnFoundationPile(y.foundation[fIdx], card)
 }
 
 // isAlternateColor 交互の色かどうか判定

--- a/internal/domain/action_log_base_adopters_test.go
+++ b/internal/domain/action_log_base_adopters_test.go
@@ -15,7 +15,7 @@ type logReader interface {
 	GetActionLog() []*ActionLogEntry
 }
 
-// These 19 games moved their action log from an own `actionLog` field to the
+// These 30 games moved their action log from an own `actionLog` field to the
 // embedded actionLogBase. Promotion keeps `g.actionLog` compiling in their
 // MarshalJSON/UnmarshalJSON pairs, so nothing in them had to change -- which is
 // exactly why a mistake here would be quiet. The log is persisted to KV for the
@@ -124,27 +124,93 @@ func TestActionLogBaseAdopters_LogSurvivesAKVRoundTrip(t *testing.T) {
 			g.addLog(1, "act", "detail", nil)
 			return g, NewDefaultZwicker()
 		}},
+		{"Cego", func() (any, any) {
+			g := NewDefaultCego()
+			g.appendLog(1, "act", "detail", nil)
+			return g, NewDefaultCego()
+		}},
+		{"FrenchTarot", func() (any, any) {
+			g := NewDefaultFrenchTarot()
+			g.appendLog(1, "act", "detail", nil)
+			return g, NewDefaultFrenchTarot()
+		}},
+		{"Ganjifa", func() (any, any) {
+			g := NewDefaultGanjifa()
+			// Unlike the others, this game's UnmarshalJSON validates the state and
+			// rejects a never-Reset game ("invalid state values in json"), so the
+			// fixture has to be a dealt one.
+			g.Reset()
+			g.appendLog(1, "act", "detail", nil)
+			return g, NewDefaultGanjifa()
+		}},
+		{"Koenigrufen", func() (any, any) {
+			g := NewDefaultKoenigrufen()
+			g.appendLog(1, "act", "detail", nil)
+			return g, NewDefaultKoenigrufen()
+		}},
+		{"Scarto", func() (any, any) {
+			g := NewDefaultScarto()
+			g.appendLog(1, "act", "detail", nil)
+			return g, NewDefaultScarto()
+		}},
+		{"Vira", func() (any, any) {
+			g := NewDefaultVira()
+			// Unlike the others, this game's UnmarshalJSON validates the state and
+			// rejects a never-Reset game ("invalid state values in json"), so the
+			// fixture has to be a dealt one.
+			g.Reset()
+			g.appendLog(1, "act", "detail", nil)
+			return g, NewDefaultVira()
+		}},
+		{"Guandan", func() (any, any) {
+			g := NewDefaultGuandan()
+			g.addLog(1, "act", "detail", nil)
+			return g, NewDefaultGuandan()
+		}},
+		{"Karnoffel", func() (any, any) {
+			g := NewDefaultKarnoffel()
+			g.addLog(1, "act", "detail", nil)
+			return g, NewDefaultKarnoffel()
+		}},
+		{"Literature", func() (any, any) {
+			g := NewDefaultLiterature()
+			g.addLog(1, "act", "detail", nil)
+			return g, NewDefaultLiterature()
+		}},
+		{"ShengJi", func() (any, any) {
+			g := NewDefaultShengJi()
+			g.addLog(1, "act", "detail", nil)
+			return g, NewDefaultShengJi()
+		}},
+		{"SixBidSolo", func() (any, any) {
+			g := NewDefaultSixBidSolo()
+			g.addLog(1, "act", "detail", nil)
+			return g, NewDefaultSixBidSolo()
+		}},
 	}
 
-	assert.Len(t, adopters, 19, "every game delegating addLog to appendLog must be listed")
+	assert.Len(t, adopters, 30, "every game embedding actionLogBase via addLog/appendLog must be listed")
 
 	for _, a := range adopters {
 		t.Run(a.name, func(t *testing.T) {
 			saved, restored := a.build()
 
 			before := saved.(logReader).GetActionLog()
-			require.Len(t, before, 1, "fixture must actually record an entry")
+			require.NotEmpty(t, before, "fixture must actually record an entry")
 
 			data, err := json.Marshal(saved)
 			require.NoError(t, err)
 			require.NoError(t, json.Unmarshal(data, restored))
 
 			after := restored.(logReader).GetActionLog()
-			require.Len(t, after, 1, "the action log did not survive the round trip")
-			assert.Equal(t, before[0].TurnNumber, after[0].TurnNumber)
-			assert.Equal(t, before[0].PlayerIdx, after[0].PlayerIdx)
-			assert.Equal(t, before[0].ActionType, after[0].ActionType)
-			assert.Equal(t, before[0].Detail, after[0].Detail)
+			require.Len(t, after, len(before), "the action log did not survive the round trip")
+			// Compare the entry the fixture appended, which is the last one --
+			// some games log during Reset, so it is not always the only one.
+			b, a := before[len(before)-1], after[len(after)-1]
+			assert.Equal(t, b.TurnNumber, a.TurnNumber)
+			assert.Equal(t, b.PlayerIdx, a.PlayerIdx)
+			assert.Equal(t, b.ActionType, a.ActionType)
+			assert.Equal(t, b.Detail, a.Detail)
 		})
 	}
 }

--- a/internal/domain/betting.go
+++ b/internal/domain/betting.go
@@ -2,7 +2,10 @@
 
 package domain
 
-import "sort"
+import (
+	"fmt"
+	"sort"
+)
 
 // BettingLimitType ベッティングリミットタイプ
 type BettingLimitType int
@@ -521,4 +524,17 @@ func CpuRaiseOrBet(chips, callAmount, raiseAmt int) (int, int) {
 		return bettingActionRaise, raiseAmt
 	}
 	return bettingActionBet, raiseAmt
+}
+
+// afDisplay renders the aggression factor: "-" when the player has neither bet
+// nor called, "∞" when they have been aggressive but never called, and the
+// ratio otherwise. 6 betting games had this written out.
+func afDisplay(betRaise, call int) string {
+	if betRaise == 0 && call == 0 {
+		return "-"
+	}
+	if call == 0 {
+		return "∞"
+	}
+	return fmt.Sprintf("%.1f", float64(betRaise)/float64(call))
 }

--- a/internal/domain/betting.go
+++ b/internal/domain/betting.go
@@ -538,3 +538,39 @@ func afDisplay(betRaise, call int) string {
 	}
 	return fmt.Sprintf("%.1f", float64(betRaise)/float64(call))
 }
+
+// humanChipHolder is a seat that can be identified as the human and asked for
+// its chip count.
+type humanChipHolder interface {
+	GetIsHuman() bool
+	GetChips() int
+}
+
+// rebuyAvailable reports whether the human may still rebuy: the option must be
+// enabled, the rebuy period not yet past, and the human broke with rebuys left.
+// 5 games had this written out.
+func rebuyAvailable[P humanChipHolder](enabled bool, handCount, periodHands int, players []P, counts []int, maxCount int) bool {
+	if !enabled || handCount > periodHands {
+		return false
+	}
+	for i, p := range players {
+		if p.GetIsHuman() && p.GetChips() <= 0 && counts[i] < maxCount {
+			return true
+		}
+	}
+	return false
+}
+
+// addonAvailable reports whether the human may take the add-on, which is
+// offered on exactly one hand and only once. 5 games had this written out.
+func addonAvailable[P humanChipHolder](enabled bool, handCount, afterHand int, players []P, used []bool) bool {
+	if !enabled || handCount != afterHand {
+		return false
+	}
+	for i, p := range players {
+		if p.GetIsHuman() && !used[i] {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/domain/player_helpers.go
+++ b/internal/domain/player_helpers.go
@@ -65,11 +65,7 @@ type finishable interface {
 // Constrained by `any` rather than an interface: the games' player types share
 // no method this needs, and the helper only indexes. See issue #5185.
 func getPlayer[T any](players []T, idx int) T {
-	if idx < 0 || idx >= len(players) {
-		var zero T
-		return zero
-	}
-	return players[idx]
+	return elemAt(players, idx)
 }
 
 // humanReporter is the minimal view needed to tell the human player apart from
@@ -451,4 +447,11 @@ func validateFollowSuit[P handReader](trick []*TrickCard, players []P, playerIdx
 		return NewDomainError(ErrInvalidPlay, "リードスートに従ってください")
 	}
 	return nil
+}
+
+// resetPlayer clears a player's hand and finished flag, for games whose reset
+// does not also clear tricks. 9 player types had these two calls written out.
+func resetPlayer[P resettable](p P) {
+	p.Reset()
+	p.SetIsFinished(false)
 }

--- a/internal/domain/player_helpers.go
+++ b/internal/domain/player_helpers.go
@@ -3,6 +3,7 @@ package domain
 import (
 	"errors"
 	"fmt"
+	"math/rand"
 	"sort"
 )
 
@@ -454,4 +455,93 @@ func validateFollowSuit[P handReader](trick []*TrickCard, players []P, playerIdx
 func resetPlayer[P resettable](p P) {
 	p.Reset()
 	p.SetIsFinished(false)
+}
+
+// sortHandInPlace reorders a seat's hand with a whole-slice sorter, for games
+// whose ordering is expressed as a sort over []*Card rather than a comparator.
+// 6 games had the extract/sort/Reset/re-add round trip written out.
+func sortHandInPlace[P handHolder](p P, sortFn func([]*Card)) {
+	cards := make([]*Card, p.GetCardsSize())
+	for i := 0; i < p.GetCardsSize(); i++ {
+		cards[i] = p.GetCard(i)
+	}
+	sortFn(cards)
+	p.Reset()
+	for _, c := range cards {
+		p.AddCard(c)
+	}
+}
+
+// handHasAny reports whether any card in p satisfies ok. 5 games had this loop
+// written out.
+func handHasAny[P handReader](p P, ok func(*Card) bool) bool {
+	for i := 0; i < p.GetCardsSize(); i++ {
+		if ok(p.GetCard(i)) {
+			return true
+		}
+	}
+	return false
+}
+
+// chipsOfFirst returns the first seat's chip count, or 0 when there are no
+// seats. 5 games had this written out.
+func chipsOfFirst[P interface{ GetChips() int }](players []P) int {
+	if len(players) == 0 {
+		return 0
+	}
+	return players[0].GetChips()
+}
+
+// roundScorable is a player whose per-round score can be cleared along with the
+// rest of its round state.
+type roundScorable interface {
+	resettable
+	SetRoundScore(int)
+}
+
+// resetRoundScored clears a player's round score, hand and finished flag.
+func resetRoundScored[P roundScorable](p P) {
+	p.SetRoundScore(0)
+	p.Reset()
+	p.SetIsFinished(false)
+}
+
+// trickRoundScorable additionally tracks tricks taken.
+type trickRoundScorable interface {
+	roundScorable
+	ResetTricks()
+}
+
+// resetRoundWithTricks clears a player's round score, tricks, hand and finished
+// flag, in that order -- the order the bodies it replaces used.
+func resetRoundWithTricks[P trickRoundScorable](p P) {
+	p.SetRoundScore(0)
+	p.ResetTricks()
+	p.Reset()
+	p.SetIsFinished(false)
+}
+
+// stockRecycler is a game that can record recycling the discard pile.
+type stockRecycler interface {
+	appendLog(playerIdx int, actionType, detail string, cards []*Card)
+}
+
+// recycleDiscardIntoStock moves everything but the top discard back under the
+// draw pile, shuffled, and logs it. Returns false when there is nothing to
+// recycle. 5 games had this written out.
+//
+// The piles are passed by pointer because the helper rewrites both. Keeping the
+// fmt.Sprintf here rather than at each call site means one copy of it instead
+// of five.
+func recycleDiscardIntoStock(discard, draw *[]*Card, g stockRecycler) bool {
+	if len(*discard) <= 1 {
+		return false
+	}
+	top := (*discard)[len(*discard)-1]
+	rest := (*discard)[:len(*discard)-1]
+	*discard = []*Card{top}
+	rand.Shuffle(len(rest), func(i, j int) { rest[i], rest[j] = rest[j], rest[i] })
+	*draw = append(*draw, rest...)
+	g.appendLog(-1, "recycle", fmt.Sprintf("Discard pile recycled into stock (%d cards)", len(rest)), nil)
+	return true
 }

--- a/internal/domain/player_helpers_internal_test.go
+++ b/internal/domain/player_helpers_internal_test.go
@@ -708,3 +708,67 @@ type fakeBettor struct {
 
 func (b *fakeBettor) GetFolded() bool { return b.folded }
 func (b *fakeBettor) GetAllIn() bool  { return b.allIn }
+
+func TestCopyOf(t *testing.T) {
+	orig := []int{1, 2, 3}
+	got := copyOf(orig)
+
+	assert.Equal(t, orig, got)
+	got[0] = 99
+	assert.Equal(t, 1, orig[0], "the copy must not alias the original")
+}
+
+func TestCopyOf_EmptyAndNil(t *testing.T) {
+	assert.Empty(t, copyOf([]bool{}))
+	assert.Empty(t, copyOf[[]*Card](nil))
+}
+
+func TestPercentOf(t *testing.T) {
+	assert.Equal(t, 50, percentOf(1, 2))
+	assert.Equal(t, 33, percentOf(1, 3), "integer division, matching the bodies replaced")
+	assert.Equal(t, 100, percentOf(7, 7))
+}
+
+// A zero total yields 0 rather than dividing by zero.
+func TestPercentOf_ZeroTotal(t *testing.T) {
+	assert.Equal(t, 0, percentOf(5, 0))
+	assert.Equal(t, 0, percentOf(0, 0))
+}
+
+func TestElemAt(t *testing.T) {
+	s := []int{10, 20}
+	assert.Equal(t, 10, elemAt(s, 0))
+	assert.Equal(t, 20, elemAt(s, 1))
+}
+
+// Out of range yields the zero value, which is what the bodies returned.
+func TestElemAt_OutOfRange(t *testing.T) {
+	s := []int{10}
+	assert.Equal(t, 0, elemAt(s, -1))
+	assert.Equal(t, 0, elemAt(s, 1))
+	assert.Equal(t, 0, elemAt([]int{}, 0))
+}
+
+func TestDropLast(t *testing.T) {
+	assert.Equal(t, []int{1, 2}, dropLast([]int{1, 2, 3}))
+	assert.Empty(t, dropLast([]int{1}))
+	assert.Empty(t, dropLast([]int{}), "already empty stays empty rather than panicking")
+}
+
+func TestMaxIndexBy(t *testing.T) {
+	assert.Equal(t, 1, maxIndexBy([]int{3, 9, 4}, func(v int) int { return v }))
+	assert.Equal(t, 0, maxIndexBy([]int{5}, func(v int) int { return v }))
+}
+
+// Ties keep the earliest index, and an empty slice yields 0 -- both match the
+// bodies replaced, which seeded best := 0 and used a strict >.
+func TestMaxIndexBy_TiesAndEmpty(t *testing.T) {
+	assert.Equal(t, 0, maxIndexBy([]int{7, 7}, func(v int) int { return v }))
+	assert.Equal(t, 0, maxIndexBy([]int{}, func(v int) int { return v }))
+}
+
+func TestPokerHandName(t *testing.T) {
+	assert.Equal(t, PokerHandNames[0], pokerHandName(0))
+	assert.Equal(t, "Unknown", pokerHandName(-1))
+	assert.Equal(t, "Unknown", pokerHandName(len(PokerHandNames)))
+}

--- a/internal/domain/player_helpers_internal_test.go
+++ b/internal/domain/player_helpers_internal_test.go
@@ -772,3 +772,100 @@ func TestPokerHandName(t *testing.T) {
 	assert.Equal(t, "Unknown", pokerHandName(-1))
 	assert.Equal(t, "Unknown", pokerHandName(len(PokerHandNames)))
 }
+
+func TestSortHandInPlace(t *testing.T) {
+	h := &fakeSeatHand{cards: []*Card{NewCard(2, 9, false), NewCard(1, 3, false)}}
+
+	sortHandInPlace(h, func(cards []*Card) {
+		if cards[0].GetValue() > cards[1].GetValue() {
+			cards[0], cards[1] = cards[1], cards[0]
+		}
+	})
+
+	require.Equal(t, 2, h.GetCardsSize(), "no cards lost in the Reset/re-add round trip")
+	assert.Equal(t, 3, h.GetCard(0).GetValue())
+}
+
+func TestHandHasAny(t *testing.T) {
+	h := &fakeHand{cards: []*Card{NewCard(1, 2, false), NewCard(2, 7, false)}}
+
+	assert.True(t, handHasAny(h, func(c *Card) bool { return c.GetValue() == 7 }), "not just the first card")
+	assert.False(t, handHasAny(h, func(c *Card) bool { return c.GetValue() == 9 }))
+	assert.False(t, handHasAny(&fakeHand{}, func(*Card) bool { return true }), "empty hand")
+}
+
+func TestAFDisplay(t *testing.T) {
+	assert.Equal(t, "-", afDisplay(0, 0), "no aggression and no calls is undefined, not zero")
+	assert.Equal(t, "∞", afDisplay(3, 0), "aggression with no calls is infinite")
+	assert.Equal(t, "1.5", afDisplay(3, 2))
+	assert.Equal(t, "0.0", afDisplay(0, 4))
+}
+
+func TestChipsOfFirst(t *testing.T) {
+	assert.Equal(t, 250, chipsOfFirst([]*fakeChipHolder{{chips: 250}, {chips: 10}}))
+	assert.Equal(t, 0, chipsOfFirst([]*fakeChipHolder{}), "no seats yields zero, not a panic")
+}
+
+type fakeChipHolder struct{ chips int }
+
+func (c *fakeChipHolder) GetChips() int { return c.chips }
+
+type fakeRoundScorer struct {
+	order []string
+	score int
+}
+
+func (p *fakeRoundScorer) SetRoundScore(v int)  { p.score = v; p.order = append(p.order, "score") }
+func (p *fakeRoundScorer) ResetTricks()         { p.order = append(p.order, "tricks") }
+func (p *fakeRoundScorer) Reset()               { p.order = append(p.order, "hand") }
+func (p *fakeRoundScorer) SetIsFinished(_ bool) { p.order = append(p.order, "finished") }
+
+func TestResetRoundScored(t *testing.T) {
+	p := &fakeRoundScorer{score: 7}
+	resetRoundScored(p)
+	assert.Equal(t, 0, p.score)
+	assert.Equal(t, []string{"score", "hand", "finished"}, p.order)
+}
+
+func TestResetRoundWithTricks(t *testing.T) {
+	p := &fakeRoundScorer{score: 7}
+	resetRoundWithTricks(p)
+	assert.Equal(t, []string{"score", "tricks", "hand", "finished"}, p.order,
+		"tricks are cleared between the score and the hand")
+}
+
+type fakeRecycleLogger struct{ logged int }
+
+func (g *fakeRecycleLogger) appendLog(_ int, _, _ string, _ []*Card) { g.logged++ }
+
+func TestRecycleDiscardIntoStock(t *testing.T) {
+	discard := []*Card{NewCard(1, 1, false), NewCard(1, 2, false), NewCard(1, 3, false)}
+	draw := []*Card{NewCard(2, 9, false)}
+	top := discard[len(discard)-1]
+	g := &fakeRecycleLogger{}
+
+	require.True(t, recycleDiscardIntoStock(&discard, &draw, g))
+
+	require.Len(t, discard, 1)
+	assert.Same(t, top, discard[0], "the visible top card stays on the discard pile")
+	assert.Len(t, draw, 3, "the rest goes under the draw pile")
+	assert.Equal(t, 1, g.logged)
+}
+
+// One card or none is not recyclable: taking the top would leave nothing to
+// move, so the piles must be untouched and nothing logged.
+func TestRecycleDiscardIntoStock_NothingToRecycle(t *testing.T) {
+	for _, n := range []int{0, 1} {
+		discard := make([]*Card, n)
+		for i := range discard {
+			discard[i] = NewCard(1, i+1, false)
+		}
+		draw := []*Card{}
+		g := &fakeRecycleLogger{}
+
+		assert.False(t, recycleDiscardIntoStock(&discard, &draw, g), "n=%d", n)
+		assert.Len(t, discard, n, "n=%d: discard untouched", n)
+		assert.Empty(t, draw, "n=%d: draw untouched", n)
+		assert.Equal(t, 0, g.logged, "n=%d: nothing logged", n)
+	}
+}

--- a/internal/domain/poker_hand_rank.go
+++ b/internal/domain/poker_hand_rank.go
@@ -35,3 +35,12 @@ var PokerHandNames = []string{
 	"Royal Flush",
 	"Five of a Kind",
 }
+
+// pokerHandName returns the display name for a hand rank, or "Unknown" when the
+// rank is outside the table. 5 betting games had this written out.
+func pokerHandName(rank int) string {
+	if rank >= 0 && rank < len(PokerHandNames) {
+		return PokerHandNames[rank]
+	}
+	return "Unknown"
+}

--- a/internal/domain/slice_helpers.go
+++ b/internal/domain/slice_helpers.go
@@ -43,3 +43,51 @@ func discardTop(pile []*Card) *Card {
 	}
 	return pile[len(pile)-1]
 }
+
+// copyOf returns a copy of s, so callers can hand out a slice without exposing
+// the backing array. Four accessors had make+copy written out.
+func copyOf[T any](s []T) []T {
+	out := make([]T, len(s))
+	copy(out, s)
+	return out
+}
+
+// elemAt returns s[i], or the zero value when i is outside the slice. Callers
+// treat the zero value as "absent" rather than checking bounds themselves.
+func elemAt[T any](s []T, i int) T {
+	var zero T
+	if i < 0 || i >= len(s) {
+		return zero
+	}
+	return s[i]
+}
+
+// dropLast returns s without its final element, or s unchanged when empty.
+func dropLast[T any](s []T) []T {
+	if len(s) == 0 {
+		return s
+	}
+	return s[:len(s)-1]
+}
+
+// maxIndexBy returns the index of the highest-scoring element, keeping the
+// earliest on a tie and returning 0 for an empty slice -- the behaviour of the
+// bodies it replaces, which seeded best := 0 and compared with a strict >.
+func maxIndexBy[T any](s []T, score func(T) int) int {
+	best := 0
+	for i := range s {
+		if i > 0 && score(s[i]) > score(s[best]) {
+			best = i
+		}
+	}
+	return best
+}
+
+// percentOf returns count as an integer percentage of total, or 0 when total is
+// zero. Three betting statistics had this written out.
+func percentOf(count, total int) int {
+	if total == 0 {
+		return 0
+	}
+	return count * 100 / total
+}


### PR DESCRIPTION
#5185 の **5〜9コピー帯を1 PR で全部**片付けます。33クラスタ / 192メソッド / **-807行**。

ローカルゲートが揃った（全テスト + lint + **6タグ Worker ビルド**）ので、CI 往復を待たずにまとめて検証しました。

## 内訳（4波）

| 波 | 内容 | メソッド | 削減 |
|---|---|---:|---:|
| 1 | **既存ヘルパの再利用のみ**（新規ゼロ） | 34 | -206 |
| 2 | アクセサ族（コピー/割合/境界/末尾） | 78 | -201 |
| 3 | sortHand・ResetRound 3種・recycle ほか | 54 | -259 |
| 4 | actionLogBase 追加採用 11 + rebuy/addon/cpuDraw | 26 | -166 |

**波1は新しいヘルパを1つも足していません。** `validateFollowSuit` / `canPlaceOnFoundationPile` / `isHumanTurn` / `countPlayers` / `toBettingPlayers` という**既にあるもの**への委譲だけで34メソッドが畳めました。既存の `countPlayers` と `toBettingPlayers` は探して見つけたもので、新規に書きかけて気付いた形です。

## 誤検出を1件除外しました

クラスタ一覧に `ImportProfile` 6件が挙がっていましたが、これは**バッチ3で私が書いた委譲そのもの**でした。共通化済みの本体が「6ゲームで同一」として再カウントされていたもので、自分の出力を重複として二重に最適化しかけました。既存ヘルパ呼び出しを含むクラスタを除外して数え直しています。

## 配置は build タグに合わせています（#5215 の教訓）

`player_helpers.go` は**無タグ＝全6 Worker にコンパイル**されるので、カテゴリ限定の型を参照できません。

| ヘルパ | 置き場所 | 理由 |
|---|---|---|
| `afDisplay` / `rebuyAvailable` / `addonAvailable` | `betting.go` | casino タグ。呼び出し元6件も casino |
| `cpuDrawTurn` | `ContractRummy.go` | extra タグ。呼び出し元5件も extra |
| `pokerHandName` | `poker_hand_rank.go` | 無タグなので参照は安全 |

push 前に6タグすべてでビルドを通しています。

```sh
for tag in casino classic solo extra extra2 extra3; do
  GOOS=js GOARCH=wasm go build -tags "$tag" ./internal/domain/
done
```

## KV 往復ガードを 19 → 30 ゲームに拡張、その過程で元のガードの穴も塞ぎました

新たに11ゲームが `actionLogBase` を採用したのでガードに追加したところ、2件が落ちました。

1. **Ganjifa / Vira は `UnmarshalJSON` が状態を検証**しており、`Reset()` していないゲームを `invalid state values in json` で弾きます → フィクスチャを配り済みに変更。
2. それを直すと今度は**「エントリはちょうど1件」という元のガードの前提**が壊れました。`Reset()` 中にログを書くゲームがあるためです → ログ全体を比較し、**フィクスチャが追加した最後のエントリ**を検証する形に一般化。

**負のコントロール再確認済み**: Cego の `ActionLog` を nil にすると `the action log did not survive the round trip` で落ち、戻すと通ります。

## その他、テストで固定した挙動

- `maxIndexBy` は**同点なら先頭**、空スライスなら 0（置換元が `best := 0` + 厳密 `>` だったため）
- `resetRoundWithTricks` は **score → tricks → hand → finished の順**
- `percentOf` は整数除算、分母0で0
- `copyOf` は**元をエイリアスしない**こと（防御的コピーの目的そのもの）

## 検証

- `go test -tags test ./...` 全パッケージ通過 / `golangci-lint run ./internal/...` 0 issues
- 6タグ Worker ビルド 全通過
- 各クラスタとも件数が想定と一致しなければ中断する置換スクリプト
- ヘルパは各波とも call-site 書き換えの**前**に別コミット

Refs #5185