### PR TITLE
refactor(domain): 3-4 copy band, first 36 methods

### DIFF
--- a/internal/domain/Aluette.go
+++ b/internal/domain/Aluette.go
@@ -224,7 +224,7 @@ type Aluette struct {
 	roundTricks      [AluettePlayerCnt]int
 	gameEndFlag      bool
 	winnerTeam       int // -1 = 未確定 (同点)
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // NewAluette コンストラクタ。
@@ -369,13 +369,7 @@ func (g *Aluette) finishMatch() {
 
 // appendLog 棋譜に 1 件追加する。
 func (g *Aluette) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: g.trickNumber,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	g.appendLogAt(g.trickNumber, playerIdx, actionType, detail, cards)
 }
 
 // --- トリックプレイ ---

--- a/internal/domain/Anaconda.go
+++ b/internal/domain/Anaconda.go
@@ -863,13 +863,7 @@ func (g *Anaconda) nextActive(from int) int {
 
 // solventCount はアンティを払える (非脱落かつチップ >= アンティ) プレイヤー数を返す。
 func (g *Anaconda) solventCount() int {
-	n := 0
-	for _, p := range g.players {
-		if !p.GetOut() && p.GetChips() >= g.config.Ante {
-			n++
-		}
-	}
-	return n
+	return countPlayers(g.players, func(p *AnacondaPlayer) bool { return !p.GetOut() && p.GetChips() >= g.config.Ante })
 }
 
 // richestIdx はチップが最多のプレイヤーのインデックスを返す (同数は座席番号の小さい方)。

--- a/internal/domain/Anaconda.go
+++ b/internal/domain/Anaconda.go
@@ -835,13 +835,7 @@ func (g *Anaconda) participantSeats() []int {
 
 // activeSeats は未フォールド・非脱落プレイヤーのインデックス列 (昇順) を返す。
 func (g *Anaconda) activeSeats() []int {
-	out := make([]int, 0, len(g.players))
-	for i, p := range g.players {
-		if !p.GetOut() && !p.GetFolded() {
-			out = append(out, i)
-		}
-	}
-	return out
+	return collectValidIndices(len(g.players), func(i int) bool { p := g.players[i]; return !p.GetOut() && !p.GetFolded() })
 }
 
 // activeCount は未フォールド・非脱落プレイヤー数を返す。
@@ -851,14 +845,7 @@ func (g *Anaconda) activeCount() int {
 
 // nextActive は from の次の未フォールド・非脱落プレイヤーを返す。
 func (g *Anaconda) nextActive(from int) int {
-	n := len(g.players)
-	for i := 1; i <= n; i++ {
-		idx := (from + i) % n
-		if !g.players[idx].GetOut() && !g.players[idx].GetFolded() {
-			return idx
-		}
-	}
-	return from
+	return nextIndexWhere(g.players, from, func(p *AnacondaPlayer) bool { return !p.GetOut() && !p.GetFolded() })
 }
 
 // solventCount はアンティを払える (非脱落かつチップ >= アンティ) プレイヤー数を返す。

--- a/internal/domain/Badugi.go
+++ b/internal/domain/Badugi.go
@@ -481,13 +481,7 @@ func (b *Badugi) findNextActive(fromIdx int) int {
 }
 
 func (b *Badugi) countActivePlayers() int {
-	cnt := 0
-	for _, pl := range b.players {
-		if !pl.GetFolded() {
-			cnt++
-		}
-	}
-	return cnt
+	return countPlayers(b.players, func(p *BadugiPlayer) bool { return !p.GetFolded() })
 }
 
 // resolveLastPlayer awards the pot to the sole surviving player (everyone

--- a/internal/domain/Barbu.go
+++ b/internal/domain/Barbu.go
@@ -543,19 +543,7 @@ func (b *Barbu) GetRoundWinners() []int {
 	if !b.gameEndFlag {
 		return nil
 	}
-	best := b.players[0].GetTotalScore()
-	for _, p := range b.players[1:] {
-		if p.GetTotalScore() > best {
-			best = p.GetTotalScore()
-		}
-	}
-	winners := make([]int, 0)
-	for i, p := range b.players {
-		if p.GetTotalScore() == best {
-			winners = append(winners, i)
-		}
-	}
-	return winners
+	return topScorers(b.players)
 }
 
 // --- JSON Serialization ---

--- a/internal/domain/BarbuCPU.go
+++ b/internal/domain/BarbuCPU.go
@@ -147,17 +147,7 @@ func (b *Barbu) getValidTrickIndices(playerIdx int) []int {
 
 // currentWinningCard は進行中トリックで現在勝っているカードを返す (空なら nil)。
 func (b *Barbu) currentWinningCard() *Card {
-	if len(b.currentTrick) == 0 {
-		return nil
-	}
-	leadSuit := b.currentTrick[0].Card.GetDesign()
-	winner := b.currentTrick[0].Card
-	for _, tc := range b.currentTrick[1:] {
-		if b.cardBeats(tc.Card, winner, leadSuit) {
-			winner = tc.Card
-		}
-	}
-	return winner
+	return currentTrickWinnerCard(b.currentTrick, b)
 }
 
 // cpuSelectTrickCard は CPU がプレイするトリックカードのインデックスを返す。

--- a/internal/domain/Bezique.go
+++ b/internal/domain/Bezique.go
@@ -653,16 +653,7 @@ func (b *Bezique) allHandsEmpty() bool {
 
 // validatePlay カードのプレイがルール上有効かを検証する。
 func (b *Bezique) validatePlay(playerIdx int, card *Card) error {
-	if card == nil {
-		return NewDomainError(ErrInvalidCard, "カードが nil です")
-	}
-	if !b.IsEndgame() || len(b.currentTrick) == 0 {
-		return nil
-	}
-	if !b.cardSatisfiesFollow(playerIdx, card) {
-		return NewDomainError(ErrInvalidCard, "第2フェーズではフォロールールに従う必要があります")
-	}
-	return nil
+	return validateEndgameFollow(b.currentTrick, b, playerIdx, card)
 }
 
 // cardSatisfiesFollow 第2フェーズの追随時に card が合法かを返す。

--- a/internal/domain/Bezique.go
+++ b/internal/domain/Bezique.go
@@ -696,14 +696,7 @@ func (b *Bezique) cardSatisfiesFollow(playerIdx int, card *Card) bool {
 
 // legalPlayIndices validatePlay を満たすカードのインデックス集合を返す。
 func (b *Bezique) legalPlayIndices(playerIdx int) []int {
-	p := b.players[playerIdx]
-	out := make([]int, 0, p.GetCardsSize())
-	for i := 0; i < p.GetCardsSize(); i++ {
-		if b.validatePlay(playerIdx, p.GetCard(i)) == nil {
-			out = append(out, i)
-		}
-	}
-	return out
+	return validPlayIndices(b.players[playerIdx], func(c *Card) bool { return b.validatePlay(playerIdx, c) == nil })
 }
 
 // beziquePlayerHasSuit プレイヤーが指定スートのカードを持つか

--- a/internal/domain/Bezique.go
+++ b/internal/domain/Bezique.go
@@ -610,15 +610,7 @@ func (b *Bezique) drawReplenish() {
 
 // drawOne 山札 → 切り札表示カード の順に 1 枚引く。
 func (b *Bezique) drawOne() *Card {
-	if c := b.trumpCards.DrawCard(); c != nil {
-		return c
-	}
-	if b.trumpCard != nil {
-		c := b.trumpCard
-		b.trumpCard = nil
-		return c
-	}
-	return nil
+	return drawOrTakeTrump(b.trumpCards, &b.trumpCard)
 }
 
 // scoreDeal ディールを集計して累積し、ゲーム終了を判定する。

--- a/internal/domain/BidWhist.go
+++ b/internal/domain/BidWhist.go
@@ -717,19 +717,7 @@ func (g *BidWhist) trickScore(c *Card, ls int) int {
 
 // trickWinner トリックの勝者を決定する
 func (g *BidWhist) trickWinner() int {
-	if len(g.currentTrick) == 0 {
-		return 0
-	}
-	ls := g.leadSuit()
-	winnerIdx := g.currentTrick[0].PlayerIdx
-	winnerScore := g.trickScore(g.currentTrick[0].Card, ls)
-	for _, tc := range g.currentTrick[1:] {
-		if s := g.trickScore(tc.Card, ls); s > winnerScore {
-			winnerScore = s
-			winnerIdx = tc.PlayerIdx
-		}
-	}
-	return winnerIdx
+	return trickWinnerByScore(g.currentTrick, g)
 }
 
 // validatePlay カードのプレイが有効か検証する

--- a/internal/domain/BlackHole.go
+++ b/internal/domain/BlackHole.go
@@ -44,8 +44,8 @@ type BlackHole struct {
 	blackHole  []*Card
 	phase      BlackHolePhase
 	moveCount  int
-	actionLog  []*ActionLogEntry
-	history    []*blackHoleSnapshot
+	actionLogBase
+	history []*blackHoleSnapshot
 }
 
 // blackHoleSnapshot Undo 用スナップショット。
@@ -322,11 +322,5 @@ func (g *BlackHole) GetActionLog() []*ActionLogEntry { return g.actionLog }
 
 // appendLog アクションログを追加する。
 func (g *BlackHole) appendLog(action, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: g.moveCount,
-		PlayerIdx:  0,
-		ActionType: action,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	g.appendLogAt(g.moveCount, 0, action, detail, cards)
 }

--- a/internal/domain/Bouillotte.go
+++ b/internal/domain/Bouillotte.go
@@ -628,13 +628,7 @@ func (g *Bouillotte) nextActive(from int) int {
 
 // solventCount はアンティを払える (非脱落かつチップ >= アンティ) プレイヤー数を返す。
 func (g *Bouillotte) solventCount() int {
-	n := 0
-	for _, p := range g.players {
-		if !p.GetOut() && p.GetChips() >= g.config.Ante {
-			n++
-		}
-	}
-	return n
+	return countPlayers(g.players, func(p *BouillottePlayer) bool { return !p.GetOut() && p.GetChips() >= g.config.Ante })
 }
 
 // richestIdx はチップが最多のプレイヤーのインデックスを返す (同数は座席番号の小さい方)。

--- a/internal/domain/Bouillotte.go
+++ b/internal/domain/Bouillotte.go
@@ -600,13 +600,7 @@ func (g *Bouillotte) bestHand(seats []int) int {
 
 // activeSeats は未フォールド・非脱落プレイヤーのインデックス列 (昇順) を返す。
 func (g *Bouillotte) activeSeats() []int {
-	out := make([]int, 0, len(g.players))
-	for i, p := range g.players {
-		if !p.GetOut() && !p.GetFolded() {
-			out = append(out, i)
-		}
-	}
-	return out
+	return collectValidIndices(len(g.players), func(i int) bool { p := g.players[i]; return !p.GetOut() && !p.GetFolded() })
 }
 
 // activeCount は未フォールド・非脱落プレイヤー数を返す。
@@ -616,14 +610,7 @@ func (g *Bouillotte) activeCount() int {
 
 // nextActive は from の次の未フォールド・非脱落プレイヤーを返す。
 func (g *Bouillotte) nextActive(from int) int {
-	n := len(g.players)
-	for i := 1; i <= n; i++ {
-		idx := (from + i) % n
-		if !g.players[idx].GetOut() && !g.players[idx].GetFolded() {
-			return idx
-		}
-	}
-	return from
+	return nextIndexWhere(g.players, from, func(p *BouillottePlayer) bool { return !p.GetOut() && !p.GetFolded() })
 }
 
 // solventCount はアンティを払える (非脱落かつチップ >= アンティ) プレイヤー数を返す。

--- a/internal/domain/Briscola.go
+++ b/internal/domain/Briscola.go
@@ -487,15 +487,7 @@ func (b *Briscola) drawReplenish() {
 
 // drawOne 山札またはトランプカードから 1 枚引く。優先順位は山札 → トランプカード。
 func (b *Briscola) drawOne() *Card {
-	if c := b.trumpCards.DrawCard(); c != nil {
-		return c
-	}
-	if b.trumpCard != nil {
-		c := b.trumpCard
-		b.trumpCard = nil
-		return c
-	}
-	return nil
+	return drawOrTakeTrump(b.trumpCards, &b.trumpCard)
 }
 
 // allHandsEmpty 全プレイヤーの手札が空かを返す

--- a/internal/domain/CaribbeanStud.go
+++ b/internal/domain/CaribbeanStud.go
@@ -235,20 +235,7 @@ func (cs *CaribbeanStud) compareHands() int {
 
 // checkDealerQualifies ディーラークオリファイ条件: ペア以上、または A-K ハイ
 func (cs *CaribbeanStud) checkDealerQualifies() bool {
-	if cs.dealerHandRank >= PokerHandOnePair {
-		return true
-	}
-	hasAce := false
-	hasKing := false
-	for _, c := range cs.dealerHand {
-		switch c.GetValue() {
-		case 1:
-			hasAce = true
-		case 13:
-			hasKing = true
-		}
-	}
-	return hasAce && hasKing
+	return dealerQualifies(cs.dealerHandRank, cs.dealerHand)
 }
 
 // calculatePayouts アンテ／プレイの配当計算

--- a/internal/domain/CariocaPlayer.go
+++ b/internal/domain/CariocaPlayer.go
@@ -83,9 +83,7 @@ func (p *CariocaPlayer) SetContractIndex(idx []int) {
 
 // ResetRound ラウンドをリセット（手札・スコア・メルド・終了状態を初期化）
 func (p *CariocaPlayer) ResetRound() {
-	p.SetRoundScore(0)
-	p.Reset()
-	p.SetIsFinished(false)
+	resetRoundScored(p)
 	p.ClearMelds()
 }
 

--- a/internal/domain/Cassino.go
+++ b/internal/domain/Cassino.go
@@ -633,14 +633,7 @@ func sortIndicesDescending(idxs []int) []int {
 
 // removeTableCardsByIndex は降順に並び替えてから tableCards を削除する。
 func (c *Cassino) removeTableCardsByIndex(idxs []int) {
-	if len(idxs) == 0 {
-		return
-	}
-	for _, idx := range sortIndicesDescending(idxs) {
-		if idx >= 0 && idx < len(c.round.tableCards) {
-			c.round.tableCards = append(c.round.tableCards[:idx], c.round.tableCards[idx+1:]...)
-		}
-	}
+	c.round.tableCards = removeIndices(c.round.tableCards, idxs)
 }
 
 // removeBuildsByIndex は降順に並び替えてから builds を削除する。

--- a/internal/domain/Cego.go
+++ b/internal/domain/Cego.go
@@ -988,14 +988,7 @@ func (g *Cego) highestTrumpInTrick() int {
 
 // validatePlay マストフォロー + 切り札義務 + オーバートランプ義務を検証する。
 func (g *Cego) validatePlay(playerIdx int, card *Card) error {
-	valid := g.getValidPlayIndices(playerIdx)
-	player := g.players[playerIdx]
-	for _, idx := range valid {
-		if player.GetCard(idx) == card {
-			return nil
-		}
-	}
-	return NewDomainError(ErrInvalidPlay, "フォロー義務・切り札義務・オーバートランプ義務に反しています")
+	return validateCardIsPlayable(g.getValidPlayIndices(playerIdx), g.players[playerIdx], card)
 }
 
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す。

--- a/internal/domain/Cinch.go
+++ b/internal/domain/Cinch.go
@@ -965,19 +965,7 @@ func (g *Cinch) GetRoundWinners() []int {
 	if !g.gameEndFlag {
 		return nil
 	}
-	best := g.players[0].GetTotalScore()
-	for _, p := range g.players[1:] {
-		if p.GetTotalScore() > best {
-			best = p.GetTotalScore()
-		}
-	}
-	winners := make([]int, 0)
-	for i, p := range g.players {
-		if p.GetTotalScore() == best {
-			winners = append(winners, i)
-		}
-	}
-	return winners
+	return topScorers(g.players)
 }
 
 // --- JSON Serialization ---

--- a/internal/domain/CinchCPU.go
+++ b/internal/domain/CinchCPU.go
@@ -219,17 +219,7 @@ func (g *Cinch) trickCarriesPoints() bool {
 
 // currentWinningCard は進行中トリックで現在勝っているカードを返す (空なら nil)。
 func (g *Cinch) currentWinningCard() *Card {
-	if len(g.currentTrick) == 0 {
-		return nil
-	}
-	leadSuit := g.currentTrick[0].Card.GetDesign()
-	winner := g.currentTrick[0].Card
-	for _, tc := range g.currentTrick[1:] {
-		if g.cardBeats(tc.Card, winner, leadSuit) {
-			winner = tc.Card
-		}
-	}
-	return winner
+	return currentTrickWinnerCard(g.currentTrick, g)
 }
 
 // cinchStrength はカードの絶対的な強さ (切り札は +100 でオフ切り札より必ず強い)。

--- a/internal/domain/ContractRummyPlayer.go
+++ b/internal/domain/ContractRummyPlayer.go
@@ -83,9 +83,7 @@ func (p *ContractRummyPlayer) SetContractIndex(idx []int) {
 
 // ResetRound ラウンドをリセット（手札・スコア・メルド・終了状態を初期化）
 func (p *ContractRummyPlayer) ResetRound() {
-	p.SetRoundScore(0)
-	p.Reset()
-	p.SetIsFinished(false)
+	resetRoundScored(p)
 	p.ClearMelds()
 }
 

--- a/internal/domain/CrazyEights.go
+++ b/internal/domain/CrazyEights.go
@@ -689,17 +689,7 @@ func (g *CrazyEights) cpuSelectSuitRandom() int {
 
 // cpuSelectSuitSmart 手札で最も多いスートを選択
 func (g *CrazyEights) cpuSelectSuitSmart(playerIdx int) int {
-	suitCount := g.countSuits(playerIdx)
-
-	bestSuit := CardDesignSpade
-	bestCount := 0
-	for suit := CardDesignSpade; suit <= CardDesignDiamond; suit++ {
-		if suitCount[suit] > bestCount {
-			bestCount = suitCount[suit]
-			bestSuit = suit
-		}
-	}
-	return bestSuit
+	return bestSuitFrom(g.countSuits(playerIdx))
 }
 
 // countSuits プレイヤーの手札のスート別枚数をカウント (8は除外)

--- a/internal/domain/Cuarenta.go
+++ b/internal/domain/Cuarenta.go
@@ -424,14 +424,7 @@ func (g *Cuarenta) scoreRound() *CuarentaRoundDetail {
 
 // removeTableCardsByIndex は降順に並び替えてから tableCards を削除する。
 func (g *Cuarenta) removeTableCardsByIndex(idxs []int) {
-	if len(idxs) == 0 {
-		return
-	}
-	for _, idx := range sortIndicesDescending(idxs) {
-		if idx >= 0 && idx < len(g.round.tableCards) {
-			g.round.tableCards = append(g.round.tableCards[:idx], g.round.tableCards[idx+1:]...)
-		}
-	}
+	g.round.tableCards = removeIndices(g.round.tableCards, idxs)
 }
 
 // appendLog 棋譜にエントリを追加する。

--- a/internal/domain/Cuckoo.go
+++ b/internal/domain/Cuckoo.go
@@ -516,14 +516,7 @@ func (g *Cuckoo) firstActiveFrom(from int) int {
 
 // nextActiveIdx from の次のアクティブプレイヤーのインデックスを返す
 func (g *Cuckoo) nextActiveIdx(from int) int {
-	n := len(g.players)
-	for step := 1; step <= n; step++ {
-		idx := (from + step) % n
-		if !g.players[idx].IsEliminated() {
-			return idx
-		}
-	}
-	return from
+	return nextIndexWhere(g.players, from, func(p *CuckooPlayer) bool { return !p.IsEliminated() })
 }
 
 // humanIdx 人間プレイヤーのインデックスを返す (-1 = 不在)

--- a/internal/domain/DeuceToSeven.go
+++ b/internal/domain/DeuceToSeven.go
@@ -481,13 +481,7 @@ func (d *DeuceToSeven) findNextActive(fromIdx int) int {
 }
 
 func (d *DeuceToSeven) countActivePlayers() int {
-	cnt := 0
-	for _, pl := range d.players {
-		if !pl.GetFolded() {
-			cnt++
-		}
-	}
-	return cnt
+	return countPlayers(d.players, func(p *DeuceToSevenPlayer) bool { return !p.GetFolded() })
 }
 
 // resolveLastPlayer awards the pot to the sole surviving player (everyone else

--- a/internal/domain/DoubleKlondike.go
+++ b/internal/domain/DoubleKlondike.go
@@ -57,8 +57,8 @@ type DoubleKlondike struct {
 	foundation [DoubleKlondikeFoundationCnt][]*Card
 	phase      DoubleKlondikePhase
 	moveCount  int
-	actionLog  []*ActionLogEntry
-	history    []*doubleKlondikeSnapshot
+	actionLogBase
+	history []*doubleKlondikeSnapshot
 }
 
 // doubleKlondikeSnapshot Undo 用スナップショット。
@@ -439,13 +439,7 @@ func (g *DoubleKlondike) GetHint() *DoubleKlondikeHint {
 }
 
 func (g *DoubleKlondike) appendLog(action, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: g.moveCount,
-		PlayerIdx:  0,
-		ActionType: action,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	g.appendLogAt(g.moveCount, 0, action, detail, cards)
 }
 
 // --- undo ---

--- a/internal/domain/Ecarte.go
+++ b/internal/domain/Ecarte.go
@@ -546,14 +546,7 @@ func (e *Ecarte) cardSatisfiesFollow(playerIdx int, card *Card) bool {
 
 // legalPlayIndices validatePlay を満たすカードのインデックス集合を返す。
 func (e *Ecarte) legalPlayIndices(playerIdx int) []int {
-	p := e.players[playerIdx]
-	out := make([]int, 0, p.GetCardsSize())
-	for i := 0; i < p.GetCardsSize(); i++ {
-		if e.validatePlay(playerIdx, p.GetCard(i)) == nil {
-			out = append(out, i)
-		}
-	}
-	return out
+	return validPlayIndices(e.players[playerIdx], func(c *Card) bool { return e.validatePlay(playerIdx, c) == nil })
 }
 
 func ecartePlayerHasSuit(player *EcartePlayer, suit int) bool {

--- a/internal/domain/FiveCardStud.go
+++ b/internal/domain/FiveCardStud.go
@@ -424,15 +424,7 @@ func (s *FiveCardStud) advanceTurn() {
 
 // isBettingRoundComplete ベッティングラウンドが完了したかチェック
 func (s *FiveCardStud) isBettingRoundComplete() bool {
-	for i, p := range s.players {
-		if p.GetFolded() || p.GetAllIn() {
-			continue
-		}
-		if !s.actedFlags[i] {
-			return false
-		}
-	}
-	return true
+	return bettingRoundComplete(s.players, s.actedFlags)
 }
 
 // advancePhase 次のフェーズに進める

--- a/internal/domain/FiveHundred.go
+++ b/internal/domain/FiveHundred.go
@@ -797,19 +797,7 @@ func (g *FiveHundred) trickScore(c *Card, leadSuit int) int {
 
 // trickWinner トリックの勝者を決定する
 func (g *FiveHundred) trickWinner() int {
-	if len(g.currentTrick) == 0 {
-		return 0
-	}
-	ls := g.leadSuit()
-	winnerIdx := g.currentTrick[0].PlayerIdx
-	winnerScore := g.trickScore(g.currentTrick[0].Card, ls)
-	for _, tc := range g.currentTrick[1:] {
-		if s := g.trickScore(tc.Card, ls); s > winnerScore {
-			winnerScore = s
-			winnerIdx = tc.PlayerIdx
-		}
-	}
-	return winnerIdx
+	return trickWinnerByScore(g.currentTrick, g)
 }
 
 // validatePlay カードのプレイが有効か検証する

--- a/internal/domain/FortyFivesPlayer.go
+++ b/internal/domain/FortyFivesPlayer.go
@@ -20,9 +20,7 @@ func NewFortyFivesPlayer(isHuman bool) *FortyFivesPlayer {
 
 // ResetRound ラウンドをリセット（トリック・手札・ラウンドトリック数を初期化）
 func (p *FortyFivesPlayer) ResetRound() {
-	p.ResetTricks()
-	p.Reset()
-	p.SetIsFinished(false)
+	resetPlayerRound(p)
 	p.roundTricks = 0
 }
 

--- a/internal/domain/FrenchTarot.go
+++ b/internal/domain/FrenchTarot.go
@@ -971,14 +971,7 @@ func (g *FrenchTarot) highestTrumpInTrick() int {
 
 // validatePlay マストフォロー + 切り札義務 + オーバートランプ義務を検証する。
 func (g *FrenchTarot) validatePlay(playerIdx int, card *Card) error {
-	valid := g.getValidPlayIndices(playerIdx)
-	player := g.players[playerIdx]
-	for _, idx := range valid {
-		if player.GetCard(idx) == card {
-			return nil
-		}
-	}
-	return NewDomainError(ErrInvalidPlay, "フォロー義務・切り札義務・オーバートランプ義務に反しています")
+	return validateCardIsPlayable(g.getValidPlayIndices(playerIdx), g.players[playerIdx], card)
 }
 
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す。

--- a/internal/domain/Gaigel.go
+++ b/internal/domain/Gaigel.go
@@ -548,14 +548,7 @@ func (g *Gaigel) cardSatisfiesFollow(playerIdx int, card *Card) bool {
 
 // legalPlayIndices validatePlay を満たすカードのインデックス集合を返す。
 func (g *Gaigel) legalPlayIndices(playerIdx int) []int {
-	p := g.players[playerIdx]
-	out := make([]int, 0, p.GetCardsSize())
-	for i := 0; i < p.GetCardsSize(); i++ {
-		if g.validatePlay(playerIdx, p.GetCard(i)) == nil {
-			out = append(out, i)
-		}
-	}
-	return out
+	return validPlayIndices(g.players[playerIdx], func(c *Card) bool { return g.validatePlay(playerIdx, c) == nil })
 }
 
 // gaigelPlayerHasSuit プレイヤーが指定スートのカードを持つか

--- a/internal/domain/Gaigel.go
+++ b/internal/domain/Gaigel.go
@@ -509,16 +509,7 @@ func (g *Gaigel) IsEndgame() bool {
 // validatePlay カードのプレイがルール上有効かを検証する。
 // 第1フェーズ・リード時は常に有効。第2フェーズの追随時のみマストフォローを課す。
 func (g *Gaigel) validatePlay(playerIdx int, card *Card) error {
-	if card == nil {
-		return NewDomainError(ErrInvalidCard, "カードが nil です")
-	}
-	if !g.IsEndgame() || len(g.currentTrick) == 0 {
-		return nil
-	}
-	if !g.cardSatisfiesFollow(playerIdx, card) {
-		return NewDomainError(ErrInvalidCard, "第2フェーズではフォロールールに従う必要があります")
-	}
-	return nil
+	return validateEndgameFollow(g.currentTrick, g, playerIdx, card)
 }
 
 // cardSatisfiesFollow 第2フェーズの追随時に card が合法かを返す。

--- a/internal/domain/Gaigel.go
+++ b/internal/domain/Gaigel.go
@@ -491,15 +491,7 @@ func (g *Gaigel) drawReplenish() {
 
 // drawOne 山札または切り札表示カードから 1 枚引く。優先順位は山札 → 切り札表示カード。
 func (g *Gaigel) drawOne() *Card {
-	if c := g.trumpCards.DrawCard(); c != nil {
-		return c
-	}
-	if g.trumpCard != nil {
-		c := g.trumpCard
-		g.trumpCard = nil
-		return c
-	}
-	return nil
+	return drawOrTakeTrump(g.trumpCards, &g.trumpCard)
 }
 
 // allHandsEmpty 全プレイヤーの手札が空かを返す

--- a/internal/domain/GongZhu.go
+++ b/internal/domain/GongZhu.go
@@ -558,15 +558,7 @@ func (g *GongZhu) startPlayPhase() {
 
 // findTwoOfClubs ♣2を持つプレイヤーのインデックスを返す
 func (g *GongZhu) findTwoOfClubs() int {
-	for i, p := range g.players {
-		for j := 0; j < p.GetCardsSize(); j++ {
-			card := p.GetCard(j)
-			if card.GetDesign() == CardDesignClover && card.GetValue() == 2 {
-				return i
-			}
-		}
-	}
-	return -1
+	return seatHoldingCard(g.players, func(c *Card) bool { return c.GetDesign() == CardDesignClover && c.GetValue() == 2 })
 }
 
 // playCard カードをプレイする共通処理

--- a/internal/domain/Guts.go
+++ b/internal/domain/Guts.go
@@ -429,13 +429,7 @@ func (g *Guts) inPlayers() []int {
 
 // solventCount はアンティを払える (非脱落かつチップ >= アンティ) プレイヤー数を返す。
 func (g *Guts) solventCount() int {
-	n := 0
-	for _, p := range g.players {
-		if !p.GetOut() && p.GetChips() >= g.config.Ante {
-			n++
-		}
-	}
-	return n
+	return countPlayers(g.players, func(p *GutsPlayer) bool { return !p.GetOut() && p.GetChips() >= g.config.Ante })
 }
 
 // richestIdx はチップが最多のプレイヤーのインデックスを返す (同数は座席番号の小さい方)。

--- a/internal/domain/Hearts.go
+++ b/internal/domain/Hearts.go
@@ -513,15 +513,7 @@ func (h *Hearts) startPlayPhase() {
 
 // findTwoOfClubs 2♣を持つプレイヤーのインデックスを返す
 func (h *Hearts) findTwoOfClubs() int {
-	for i, p := range h.players {
-		for j := 0; j < p.GetCardsSize(); j++ {
-			card := p.GetCard(j)
-			if card.GetDesign() == CardDesignClover && card.GetValue() == 2 {
-				return i
-			}
-		}
-	}
-	return -1
+	return seatHoldingCard(h.players, func(c *Card) bool { return c.GetDesign() == CardDesignClover && c.GetValue() == 2 })
 }
 
 // playCard カードをプレイする共通処理

--- a/internal/domain/Holdem.go
+++ b/internal/domain/Holdem.go
@@ -424,13 +424,7 @@ func (h *Holdem) advancePhase() {
 
 // dealRemainingCommunity 残りのコミュニティカードを全て配る
 func (h *Holdem) dealRemainingCommunity() {
-	for len(h.communityCards) < 5 {
-		card := h.trumpCards.DrawCard()
-		if card == nil {
-			break
-		}
-		h.communityCards = append(h.communityCards, card)
-	}
+	dealUpTo(&h.communityCards, h.trumpCards, 5)
 }
 
 // findNextActive 指定インデックスの次のアクティブ (フォールド・オールインでない) プレイヤーを探す

--- a/internal/domain/HoldemCPU.go
+++ b/internal/domain/HoldemCPU.go
@@ -377,14 +377,7 @@ func (h *Holdem) cpuBetOrAllIn(p *HoldemPlayer, betAmt int) (int, int) {
 
 // cpuPotBet ポット比率ベースのベット額を計算 (最低BB, 最低minRaise)
 func (h *Holdem) cpuPotBet(potPct int) int {
-	bet := h.pot * potPct / 100
-	if bet < h.config.BigBlind {
-		bet = h.config.BigBlind
-	}
-	if bet < h.minRaise {
-		bet = h.minRaise
-	}
-	return bet
+	return potBet(h.pot, potPct, h.config.BigBlind, h.minRaise)
 }
 
 // cpuDecidePreFlop プリフロップのCPU意思決定

--- a/internal/domain/IndianPoker.go
+++ b/internal/domain/IndianPoker.go
@@ -280,15 +280,7 @@ func (ip *IndianPoker) advanceTurn() {
 
 // isBettingRoundComplete ベッティングラウンドが完了したかチェック
 func (ip *IndianPoker) isBettingRoundComplete() bool {
-	for i, p := range ip.players {
-		if p.GetFolded() || p.GetAllIn() {
-			continue
-		}
-		if !ip.actedFlags[i] {
-			return false
-		}
-	}
-	return true
+	return bettingRoundComplete(ip.players, ip.actedFlags)
 }
 
 // bettingLimits ベッティングリミット設定からmaxRaisesとmaxBetAmountを計算

--- a/internal/domain/KalookiPlayer.go
+++ b/internal/domain/KalookiPlayer.go
@@ -67,9 +67,7 @@ func (p *KalookiPlayer) SetHasOpened(opened bool) { p.hasOpened = opened }
 
 // ResetRound ラウンドをリセット（手札・スコア・メルド・終了状態を初期化）
 func (p *KalookiPlayer) ResetRound() {
-	p.SetRoundScore(0)
-	p.Reset()
-	p.SetIsFinished(false)
+	resetRoundScored(p)
 	p.ClearMelds()
 }
 

--- a/internal/domain/King.go
+++ b/internal/domain/King.go
@@ -570,19 +570,7 @@ func (g *King) GetRoundWinners() []int {
 	if !g.gameEndFlag {
 		return nil
 	}
-	best := g.players[0].GetTotalScore()
-	for _, p := range g.players[1:] {
-		if p.GetTotalScore() > best {
-			best = p.GetTotalScore()
-		}
-	}
-	winners := make([]int, 0)
-	for i, p := range g.players {
-		if p.GetTotalScore() == best {
-			winners = append(winners, i)
-		}
-	}
-	return winners
+	return topScorers(g.players)
 }
 
 // --- JSON Serialization ---

--- a/internal/domain/KingCPU.go
+++ b/internal/domain/KingCPU.go
@@ -149,17 +149,7 @@ func (g *King) getValidTrickIndices(playerIdx int) []int {
 
 // currentWinningCard は進行中トリックで現在勝っているカードを返す (空なら nil)。
 func (g *King) currentWinningCard() *Card {
-	if len(g.currentTrick) == 0 {
-		return nil
-	}
-	leadSuit := g.currentTrick[0].Card.GetDesign()
-	winner := g.currentTrick[0].Card
-	for _, tc := range g.currentTrick[1:] {
-		if g.cardBeats(tc.Card, winner, leadSuit) {
-			winner = tc.Card
-		}
-	}
-	return winner
+	return currentTrickWinnerCard(g.currentTrick, g)
 }
 
 // cpuSelectTrickCard は CPU がプレイするトリックカードのインデックスを返す。

--- a/internal/domain/KnockoutWhistPlayer.go
+++ b/internal/domain/KnockoutWhistPlayer.go
@@ -23,9 +23,7 @@ func NewKnockoutWhistPlayer(isHuman bool) *KnockoutWhistPlayer {
 // ResetRound ラウンドをリセット（トリック・手札・ラウンドトリック数を初期化）。
 // 脱落状態と Dogbone 残数はラウンドをまたいで保持する。
 func (p *KnockoutWhistPlayer) ResetRound() {
-	p.ResetTricks()
-	p.Reset()
-	p.SetIsFinished(false)
+	resetPlayerRound(p)
 	p.roundTricks = 0
 }
 

--- a/internal/domain/Koenigrufen.go
+++ b/internal/domain/Koenigrufen.go
@@ -1057,14 +1057,7 @@ func (g *Koenigrufen) highestTrumpInTrick() int {
 
 // validatePlay マストフォロー + 切り札義務 + オーバートランプ義務を検証する。
 func (g *Koenigrufen) validatePlay(playerIdx int, card *Card) error {
-	valid := g.getValidPlayIndices(playerIdx)
-	player := g.players[playerIdx]
-	for _, idx := range valid {
-		if player.GetCard(idx) == card {
-			return nil
-		}
-	}
-	return NewDomainError(ErrInvalidPlay, "フォロー義務・切り札義務・オーバートランプ義務に反しています")
+	return validateCardIsPlayable(g.getValidPlayIndices(playerIdx), g.players[playerIdx], card)
 }
 
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す。

--- a/internal/domain/LaBelleLucie.go
+++ b/internal/domain/LaBelleLucie.go
@@ -49,8 +49,8 @@ type LaBelleLucie struct {
 	redealsLeft int
 	phase       LaBelleLuciePhase
 	moveCount   int
-	actionLog   []*ActionLogEntry
-	history     []*laBelleLucieSnapshot
+	actionLogBase
+	history []*laBelleLucieSnapshot
 }
 
 // laBelleLucieSnapshot Undo 用スナップショット。
@@ -367,13 +367,7 @@ func (g *LaBelleLucie) UndoN(n int) error {
 }
 
 func (g *LaBelleLucie) appendLog(action, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: g.moveCount,
-		PlayerIdx:  0,
-		ActionType: action,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	g.appendLogAt(g.moveCount, 0, action, detail, cards)
 }
 
 // --- accessors ---

--- a/internal/domain/Macau.go
+++ b/internal/domain/Macau.go
@@ -776,17 +776,7 @@ func (g *Macau) cpuSelectSuitRandom() int {
 
 // cpuSelectSuitSmart 手札で最も多いスートを選択
 func (g *Macau) cpuSelectSuitSmart(playerIdx int) int {
-	suitCount := g.countSuits(playerIdx)
-
-	bestSuit := CardDesignSpade
-	bestCount := 0
-	for suit := CardDesignSpade; suit <= CardDesignDiamond; suit++ {
-		if suitCount[suit] > bestCount {
-			bestCount = suitCount[suit]
-			bestSuit = suit
-		}
-	}
-	return bestSuit
+	return bestSuitFrom(g.countSuits(playerIdx))
 }
 
 // countSuits プレイヤーの手札のスート別枚数をカウント (8は除外)

--- a/internal/domain/Macau.go
+++ b/internal/domain/Macau.go
@@ -628,19 +628,7 @@ func (g *Macau) drawCards(playerIdx, n int) int {
 
 // recycleDrawPile 捨て札から山札を再構築する
 func (g *Macau) recycleDrawPile() {
-	if len(g.discardPile) <= 1 {
-		return
-	}
-
-	top := g.discardPile[len(g.discardPile)-1]
-	recycled := g.discardPile[:len(g.discardPile)-1]
-	g.discardPile = []*Card{top}
-
-	rand.Shuffle(len(recycled), func(i, j int) {
-		recycled[i], recycled[j] = recycled[j], recycled[i]
-	})
-
-	g.drawPile = recycled
+	recycleDiscardToDraw(&g.discardPile, &g.drawPile)
 }
 
 // hasPlayableCard プレイヤーが出せるカードを持っているか

--- a/internal/domain/Macau.go
+++ b/internal/domain/Macau.go
@@ -610,20 +610,7 @@ func (g *Macau) drawCard(playerIdx int) error {
 
 // drawCards 指定枚数を引く (山札が尽きたら捨て札を再利用)。実際に引けた枚数を返す。
 func (g *Macau) drawCards(playerIdx, n int) int {
-	drawn := 0
-	for i := 0; i < n; i++ {
-		if len(g.drawPile) == 0 {
-			g.recycleDrawPile()
-		}
-		if len(g.drawPile) == 0 {
-			break
-		}
-		card := g.drawPile[len(g.drawPile)-1]
-		g.drawPile = g.drawPile[:len(g.drawPile)-1]
-		g.players[playerIdx].AddCard(card)
-		drawn++
-	}
-	return drawn
+	return drawFromPile(&g.drawPile, g.players[playerIdx], n, g.recycleDrawPile)
 }
 
 // recycleDrawPile 捨て札から山札を再構築する

--- a/internal/domain/MacauPlayer.go
+++ b/internal/domain/MacauPlayer.go
@@ -20,9 +20,7 @@ func NewMacauPlayer(isHuman bool) *MacauPlayer {
 
 // ResetRound ラウンドをリセット（手札・スコア・終了状態・宣言フラグを初期化）
 func (p *MacauPlayer) ResetRound() {
-	p.SetRoundScore(0)
-	p.Reset()
-	p.SetIsFinished(false)
+	resetRoundScored(p)
 	p.hasDeclared = false
 }
 

--- a/internal/domain/Mao.go
+++ b/internal/domain/Mao.go
@@ -823,19 +823,7 @@ func (g *Mao) drawCards(playerIdx, n int) int {
 
 // recycleDrawPile 捨て札から山札を再構築する
 func (g *Mao) recycleDrawPile() {
-	if len(g.discardPile) <= 1 {
-		return
-	}
-
-	top := g.discardPile[len(g.discardPile)-1]
-	recycled := g.discardPile[:len(g.discardPile)-1]
-	g.discardPile = []*Card{top}
-
-	rand.Shuffle(len(recycled), func(i, j int) {
-		recycled[i], recycled[j] = recycled[j], recycled[i]
-	})
-
-	g.drawPile = recycled
+	recycleDiscardToDraw(&g.discardPile, &g.drawPile)
 }
 
 // hasPlayableCard プレイヤーが出せるカードを持っているか

--- a/internal/domain/Mao.go
+++ b/internal/domain/Mao.go
@@ -805,20 +805,7 @@ func (g *Mao) drawCard(playerIdx int) error {
 
 // drawCards 指定枚数を引く (山札が尽きたら捨て札を再利用)。実際に引けた枚数を返す。
 func (g *Mao) drawCards(playerIdx, n int) int {
-	drawn := 0
-	for i := 0; i < n; i++ {
-		if len(g.drawPile) == 0 {
-			g.recycleDrawPile()
-		}
-		if len(g.drawPile) == 0 {
-			break
-		}
-		card := g.drawPile[len(g.drawPile)-1]
-		g.drawPile = g.drawPile[:len(g.drawPile)-1]
-		g.players[playerIdx].AddCard(card)
-		drawn++
-	}
-	return drawn
+	return drawFromPile(&g.drawPile, g.players[playerIdx], n, g.recycleDrawPile)
 }
 
 // recycleDrawPile 捨て札から山札を再構築する

--- a/internal/domain/Mao.go
+++ b/internal/domain/Mao.go
@@ -971,17 +971,7 @@ func (g *Mao) cpuSelectSuitRandom() int {
 
 // cpuSelectSuitSmart 手札で最も多いスートを選択
 func (g *Mao) cpuSelectSuitSmart(playerIdx int) int {
-	suitCount := g.countSuits(playerIdx)
-
-	bestSuit := CardDesignSpade
-	bestCount := 0
-	for suit := CardDesignSpade; suit <= CardDesignDiamond; suit++ {
-		if suitCount[suit] > bestCount {
-			bestCount = suitCount[suit]
-			bestSuit = suit
-		}
-	}
-	return bestSuit
+	return bestSuitFrom(g.countSuits(playerIdx))
 }
 
 // countSuits プレイヤーの手札のスート別枚数をカウント (8は除外)

--- a/internal/domain/MaoPlayer.go
+++ b/internal/domain/MaoPlayer.go
@@ -20,9 +20,7 @@ func NewMaoPlayer(isHuman bool) *MaoPlayer {
 
 // ResetRound ラウンドをリセット（手札・スコア・終了状態・宣言フラグを初期化）
 func (p *MaoPlayer) ResetRound() {
-	p.SetRoundScore(0)
-	p.Reset()
-	p.SetIsFinished(false)
+	resetRoundScored(p)
 	p.hasDeclared = false
 }
 

--- a/internal/domain/Mighty.go
+++ b/internal/domain/Mighty.go
@@ -734,10 +734,7 @@ func (m *Mighty) SetJokerPlayed(v bool) { m.round.jokerPlayed = v }
 
 // IsHumanTurn 現在の手番が人間かどうか
 func (m *Mighty) IsHumanTurn() bool {
-	if m.round.currentPlayerIdx < 0 || m.round.currentPlayerIdx >= len(m.players) {
-		return false
-	}
-	return m.players[m.round.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(m.players, m.round.currentPlayerIdx)
 }
 
 // IsHumanBidTurn 現在のビッド手番が人間かどうか

--- a/internal/domain/Minchiate.go
+++ b/internal/domain/Minchiate.go
@@ -204,7 +204,7 @@ type Minchiate struct {
 	roundTricks      [MinchiatePlayerCnt]int
 	gameEndFlag      bool
 	winnerTeam       int // -1 = 未確定 (同点)
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // NewMinchiate コンストラクタ。
@@ -348,13 +348,7 @@ func (g *Minchiate) finishMatch() {
 
 // appendLog 棋譜に 1 件追加する。
 func (g *Minchiate) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: g.trickNumber,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	g.appendLogAt(g.trickNumber, playerIdx, actionType, detail, cards)
 }
 
 // --- スカルト (ディーラーの捨て札) ---

--- a/internal/domain/Napoleon.go
+++ b/internal/domain/Napoleon.go
@@ -593,10 +593,7 @@ func (n *Napoleon) SetPassCount(cnt int) { n.round.passCount = cnt }
 
 // IsHumanTurn 現在の手番が人間かどうか
 func (n *Napoleon) IsHumanTurn() bool {
-	if n.round.currentPlayerIdx < 0 || n.round.currentPlayerIdx >= len(n.players) {
-		return false
-	}
-	return n.players[n.round.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(n.players, n.round.currentPlayerIdx)
 }
 
 // IsHumanBidTurn 現在のビッド手番が人間かどうか

--- a/internal/domain/OasisPoker.go
+++ b/internal/domain/OasisPoker.go
@@ -285,20 +285,7 @@ func (op *OasisPoker) compareHands() int {
 
 // checkDealerQualifies ディーラークオリファイ条件: ペア以上、または A-K ハイ
 func (op *OasisPoker) checkDealerQualifies() bool {
-	if op.dealerHandRank >= PokerHandOnePair {
-		return true
-	}
-	hasAce := false
-	hasKing := false
-	for _, c := range op.dealerHand {
-		switch c.GetValue() {
-		case 1:
-			hasAce = true
-		case 13:
-			hasKing = true
-		}
-	}
-	return hasAce && hasKing
+	return dealerQualifies(op.dealerHandRank, op.dealerHand)
 }
 
 // calculatePayouts アンテ／プレイの配当計算

--- a/internal/domain/Omaha.go
+++ b/internal/domain/Omaha.go
@@ -469,13 +469,7 @@ func (o *Omaha) advancePhase() {
 
 // dealRemainingCommunity 残りのコミュニティカードを全て配る
 func (o *Omaha) dealRemainingCommunity() {
-	for len(o.communityCards) < 5 {
-		card := o.trumpCards.DrawCard()
-		if card == nil {
-			break
-		}
-		o.communityCards = append(o.communityCards, card)
-	}
+	dealUpTo(&o.communityCards, o.trumpCards, 5)
 }
 
 // findNextActive 指定インデックスの次のアクティブプレイヤーを探す
@@ -840,14 +834,7 @@ func (o *Omaha) cpuBetOrAllIn(p *OmahaPlayer, betAmt int) (int, int) {
 
 // cpuPotBet ポット比率ベースのベット額を計算
 func (o *Omaha) cpuPotBet(potPct int) int {
-	bet := o.pot * potPct / 100
-	if bet < o.config.BigBlind {
-		bet = o.config.BigBlind
-	}
-	if bet < o.minRaise {
-		bet = o.minRaise
-	}
-	return bet
+	return potBet(o.pot, potPct, o.config.BigBlind, o.minRaise)
 }
 
 // cpuDecidePreFlop プリフロップのCPU意思決定

--- a/internal/domain/Omaha.go
+++ b/internal/domain/Omaha.go
@@ -246,37 +246,7 @@ func (o *Omaha) continueReset() error {
 
 // postBlinds ブラインド投入
 func (o *Omaha) postBlinds() {
-	sbIdx := (o.dealerIdx + 1) % len(o.players)
-	bbIdx := (o.dealerIdx + 2) % len(o.players)
-
-	sbAmount := o.config.SmallBlind
-	if o.players[sbIdx].GetChips() < sbAmount {
-		sbAmount = o.players[sbIdx].GetChips()
-	}
-	o.players[sbIdx].SubtractChips(sbAmount)
-	o.players[sbIdx].SetCurrentBet(sbAmount)
-	o.pot += sbAmount
-	o.appendLog(sbIdx, "blind", fmt.Sprintf("posts small blind %d", sbAmount), nil)
-
-	bbAmount := o.config.BigBlind
-	if o.players[bbIdx].GetChips() < bbAmount {
-		bbAmount = o.players[bbIdx].GetChips()
-	}
-	o.players[bbIdx].SubtractChips(bbAmount)
-	o.players[bbIdx].SetCurrentBet(bbAmount)
-	o.pot += bbAmount
-	o.appendLog(bbIdx, "blind", fmt.Sprintf("posts big blind %d", bbAmount), nil)
-
-	o.lastBet = bbAmount
-
-	if o.players[sbIdx].GetChips() == 0 {
-		o.players[sbIdx].SetAllIn(true)
-		o.actedFlags[sbIdx] = true
-	}
-	if o.players[bbIdx].GetChips() == 0 {
-		o.players[bbIdx].SetAllIn(true)
-		o.actedFlags[bbIdx] = true
-	}
+	postBlindsFor(o.players, o.dealerIdx, o.config.SmallBlind, o.config.BigBlind, &o.pot, &o.lastBet, o.actedFlags, o)
 }
 
 // PlayerAction 人間プレイヤーのアクション実行

--- a/internal/domain/PageOne.go
+++ b/internal/domain/PageOne.go
@@ -467,19 +467,7 @@ func (g *PageOne) drawCard(playerIdx int) error {
 
 // recycleDrawPile 捨て札から山札を再構築する
 func (g *PageOne) recycleDrawPile() {
-	if len(g.discardPile) <= 1 {
-		return
-	}
-
-	top := g.discardPile[len(g.discardPile)-1]
-	recycled := g.discardPile[:len(g.discardPile)-1]
-	g.discardPile = []*Card{top}
-
-	rand.Shuffle(len(recycled), func(i, j int) {
-		recycled[i], recycled[j] = recycled[j], recycled[i]
-	})
-
-	g.drawPile = recycled
+	recycleDiscardToDraw(&g.discardPile, &g.drawPile)
 }
 
 // hasPlayableCard プレイヤーが出せるカードを持っているか

--- a/internal/domain/PageOnePlayer.go
+++ b/internal/domain/PageOnePlayer.go
@@ -18,9 +18,7 @@ func NewPageOnePlayer(isHuman bool) *PageOnePlayer {
 
 // ResetRound ラウンドをリセット（手札・スコア・終了状態・宣言フラグを初期化）
 func (p *PageOnePlayer) ResetRound() {
-	p.SetRoundScore(0)
-	p.Reset()
-	p.SetIsFinished(false)
+	resetRoundScored(p)
 	p.hasDeclared = false
 }
 

--- a/internal/domain/Pineapple.go
+++ b/internal/domain/Pineapple.go
@@ -683,13 +683,7 @@ func (p *Pineapple) IsDiscardPhase() bool {
 
 // dealRemainingCommunity 残りのコミュニティカードを全て配る
 func (p *Pineapple) dealRemainingCommunity() {
-	for len(p.communityCards) < 5 {
-		card := p.trumpCards.DrawCard()
-		if card == nil {
-			break
-		}
-		p.communityCards = append(p.communityCards, card)
-	}
+	dealUpTo(&p.communityCards, p.trumpCards, 5)
 }
 
 // findNextActive 指定インデックスの次のアクティブプレイヤーを探す

--- a/internal/domain/Pineapple.go
+++ b/internal/domain/Pineapple.go
@@ -699,13 +699,7 @@ func (p *Pineapple) findNextActive(fromIdx int) int {
 
 // countActivePlayers フォールドしていないプレイヤー数を返す
 func (p *Pineapple) countActivePlayers() int {
-	cnt := 0
-	for _, pl := range p.players {
-		if !pl.GetFolded() {
-			cnt++
-		}
-	}
-	return cnt
+	return countPlayers(p.players, func(pl *PineapplePlayer) bool { return !pl.GetFolded() })
 }
 
 // resolveLastPlayer 全員フォールドで最後のプレイヤーが勝利

--- a/internal/domain/Pineapple.go
+++ b/internal/domain/Pineapple.go
@@ -270,37 +270,7 @@ func (p *Pineapple) continueReset() error {
 
 // postBlinds ブラインド投入
 func (p *Pineapple) postBlinds() {
-	sbIdx := (p.dealerIdx + 1) % len(p.players)
-	bbIdx := (p.dealerIdx + 2) % len(p.players)
-
-	sbAmount := p.config.SmallBlind
-	if p.players[sbIdx].GetChips() < sbAmount {
-		sbAmount = p.players[sbIdx].GetChips()
-	}
-	p.players[sbIdx].SubtractChips(sbAmount)
-	p.players[sbIdx].SetCurrentBet(sbAmount)
-	p.pot += sbAmount
-	p.appendLog(sbIdx, "blind", fmt.Sprintf("posts small blind %d", sbAmount), nil)
-
-	bbAmount := p.config.BigBlind
-	if p.players[bbIdx].GetChips() < bbAmount {
-		bbAmount = p.players[bbIdx].GetChips()
-	}
-	p.players[bbIdx].SubtractChips(bbAmount)
-	p.players[bbIdx].SetCurrentBet(bbAmount)
-	p.pot += bbAmount
-	p.appendLog(bbIdx, "blind", fmt.Sprintf("posts big blind %d", bbAmount), nil)
-
-	p.lastBet = bbAmount
-
-	if p.players[sbIdx].GetChips() == 0 {
-		p.players[sbIdx].SetAllIn(true)
-		p.actedFlags[sbIdx] = true
-	}
-	if p.players[bbIdx].GetChips() == 0 {
-		p.players[bbIdx].SetAllIn(true)
-		p.actedFlags[bbIdx] = true
-	}
+	postBlindsFor(p.players, p.dealerIdx, p.config.SmallBlind, p.config.BigBlind, &p.pot, &p.lastBet, p.actedFlags, p)
 }
 
 // PlayerAction 人間プレイヤーのアクション実行

--- a/internal/domain/PineappleCPU.go
+++ b/internal/domain/PineappleCPU.go
@@ -158,14 +158,7 @@ func (p *Pineapple) cpuBetOrAllIn(pl *PineapplePlayer, betAmt int) (int, int) {
 
 // cpuPotBet ポット比率ベースのベット額を計算
 func (p *Pineapple) cpuPotBet(potPct int) int {
-	bet := p.pot * potPct / 100
-	if bet < p.config.BigBlind {
-		bet = p.config.BigBlind
-	}
-	if bet < p.minRaise {
-		bet = p.minRaise
-	}
-	return bet
+	return potBet(p.pot, potPct, p.config.BigBlind, p.minRaise)
 }
 
 // cpuDecidePreFlop プリフロップのCPU意思決定

--- a/internal/domain/Poker.go
+++ b/internal/domain/Poker.go
@@ -497,13 +497,7 @@ func (p *Poker) findNextActive(fromIdx int) int {
 
 // countActivePlayers フォールドしていないプレイヤー数を返す
 func (p *Poker) countActivePlayers() int {
-	cnt := 0
-	for _, pl := range p.players {
-		if !pl.GetFolded() {
-			cnt++
-		}
-	}
-	return cnt
+	return countPlayers(p.players, func(pl *PokerPlayer) bool { return !pl.GetFolded() })
 }
 
 // resolveLastPlayer 全員フォールドで最後のプレイヤーが勝利

--- a/internal/domain/Primero.go
+++ b/internal/domain/Primero.go
@@ -659,13 +659,7 @@ func (g *Primero) nextActive(from int) int {
 
 // solventCount はアンティを払える (非脱落かつチップ >= アンティ) プレイヤー数を返す。
 func (g *Primero) solventCount() int {
-	n := 0
-	for _, p := range g.players {
-		if !p.GetOut() && p.GetChips() >= g.config.Ante {
-			n++
-		}
-	}
-	return n
+	return countPlayers(g.players, func(p *PrimeroPlayer) bool { return !p.GetOut() && p.GetChips() >= g.config.Ante })
 }
 
 // richestIdx はチップが最多のプレイヤーのインデックスを返す (同数は座席番号の小さい方)。

--- a/internal/domain/Primero.go
+++ b/internal/domain/Primero.go
@@ -631,13 +631,7 @@ func (g *Primero) bestHand(seats []int) int {
 
 // activeSeats は未フォールド・非脱落プレイヤーのインデックス列 (昇順) を返す。
 func (g *Primero) activeSeats() []int {
-	out := make([]int, 0, len(g.players))
-	for i, p := range g.players {
-		if !p.GetOut() && !p.GetFolded() {
-			out = append(out, i)
-		}
-	}
-	return out
+	return collectValidIndices(len(g.players), func(i int) bool { p := g.players[i]; return !p.GetOut() && !p.GetFolded() })
 }
 
 // activeCount は未フォールド・非脱落プレイヤー数を返す。
@@ -647,14 +641,7 @@ func (g *Primero) activeCount() int {
 
 // nextActive は from の次の未フォールド・非脱落プレイヤーを返す。
 func (g *Primero) nextActive(from int) int {
-	n := len(g.players)
-	for i := 1; i <= n; i++ {
-		idx := (from + i) % n
-		if !g.players[idx].GetOut() && !g.players[idx].GetFolded() {
-			return idx
-		}
-	}
-	return from
+	return nextIndexWhere(g.players, from, func(p *PrimeroPlayer) bool { return !p.GetOut() && !p.GetFolded() })
 }
 
 // solventCount はアンティを払える (非脱落かつチップ >= アンティ) プレイヤー数を返す。

--- a/internal/domain/Prsi.go
+++ b/internal/domain/Prsi.go
@@ -369,20 +369,7 @@ func (g *Prsi) drawCard(playerIdx int) error {
 
 // drawCards 指定枚数を引く (山札が尽きたら捨て札を再利用)。実際に引けた枚数を返す。
 func (g *Prsi) drawCards(playerIdx, n int) int {
-	drawn := 0
-	for i := 0; i < n; i++ {
-		if len(g.drawPile) == 0 {
-			g.recycleDrawPile()
-		}
-		if len(g.drawPile) == 0 {
-			break
-		}
-		card := g.drawPile[len(g.drawPile)-1]
-		g.drawPile = g.drawPile[:len(g.drawPile)-1]
-		g.players[playerIdx].AddCard(card)
-		drawn++
-	}
-	return drawn
+	return drawFromPile(&g.drawPile, g.players[playerIdx], n, g.recycleDrawPile)
 }
 
 // recycleDrawPile 捨て札から山札を再構築する

--- a/internal/domain/Prsi.go
+++ b/internal/domain/Prsi.go
@@ -387,19 +387,7 @@ func (g *Prsi) drawCards(playerIdx, n int) int {
 
 // recycleDrawPile 捨て札から山札を再構築する
 func (g *Prsi) recycleDrawPile() {
-	if len(g.discardPile) <= 1 {
-		return
-	}
-
-	top := g.discardPile[len(g.discardPile)-1]
-	recycled := g.discardPile[:len(g.discardPile)-1]
-	g.discardPile = []*Card{top}
-
-	rand.Shuffle(len(recycled), func(i, j int) {
-		recycled[i], recycled[j] = recycled[j], recycled[i]
-	})
-
-	g.drawPile = recycled
+	recycleDiscardToDraw(&g.discardPile, &g.drawPile)
 }
 
 // hasPlayableCard プレイヤーが出せるカードを持っているか

--- a/internal/domain/Rook.go
+++ b/internal/domain/Rook.go
@@ -659,19 +659,7 @@ func (g *Rook) trickScore(c *Card, leadSuit int) int {
 
 // trickWinner トリックの勝者を決定する
 func (g *Rook) trickWinner() int {
-	if len(g.currentTrick) == 0 {
-		return 0
-	}
-	ls := g.leadSuit()
-	winnerIdx := g.currentTrick[0].PlayerIdx
-	winnerScore := g.trickScore(g.currentTrick[0].Card, ls)
-	for _, tc := range g.currentTrick[1:] {
-		if s := g.trickScore(tc.Card, ls); s > winnerScore {
-			winnerScore = s
-			winnerIdx = tc.PlayerIdx
-		}
-	}
-	return winnerIdx
+	return trickWinnerByScore(g.currentTrick, g)
 }
 
 // validatePlay カードのプレイが有効か検証する。ルーク鳥はいつでもプレイ可能。

--- a/internal/domain/RussianPoker.go
+++ b/internal/domain/RussianPoker.go
@@ -372,20 +372,7 @@ func (rp *RussianPoker) compareHands() int {
 
 // checkDealerQualifies ディーラークオリファイ条件: ペア以上、または A-K ハイ
 func (rp *RussianPoker) checkDealerQualifies() bool {
-	if rp.dealerHandRank >= PokerHandOnePair {
-		return true
-	}
-	hasAce := false
-	hasKing := false
-	for _, c := range rp.dealerHand {
-		switch c.GetValue() {
-		case 1:
-			hasAce = true
-		case 13:
-			hasKing = true
-		}
-	}
-	return hasAce && hasKing
+	return dealerQualifies(rp.dealerHandRank, rp.dealerHand)
 }
 
 // calculatePayouts アンテ／プレイの配当計算

--- a/internal/domain/Scarto.go
+++ b/internal/domain/Scarto.go
@@ -702,14 +702,7 @@ func (g *Scarto) highestTrumpInTrick() int {
 
 // validatePlay マストフォロー + 切り札義務 + オーバートランプ義務を検証する。
 func (g *Scarto) validatePlay(playerIdx int, card *Card) error {
-	valid := g.getValidPlayIndices(playerIdx)
-	player := g.players[playerIdx]
-	for _, idx := range valid {
-		if player.GetCard(idx) == card {
-			return nil
-		}
-	}
-	return NewDomainError(ErrInvalidPlay, "フォロー義務・切り札義務・オーバートランプ義務に反しています")
+	return validateCardIsPlayable(g.getValidPlayIndices(playerIdx), g.players[playerIdx], card)
 }
 
 // getValidPlayIndices プレイ可能なカードのインデックスリストを返す。

--- a/internal/domain/Schnapsen.go
+++ b/internal/domain/Schnapsen.go
@@ -592,14 +592,7 @@ func (s *Schnapsen) cardSatisfiesFollow(playerIdx int, card *Card) bool {
 
 // legalPlayIndices validatePlay を満たすカードのインデックス集合を返す。
 func (s *Schnapsen) legalPlayIndices(playerIdx int) []int {
-	p := s.players[playerIdx]
-	out := make([]int, 0, p.GetCardsSize())
-	for i := 0; i < p.GetCardsSize(); i++ {
-		if s.validatePlay(playerIdx, p.GetCard(i)) == nil {
-			out = append(out, i)
-		}
-	}
-	return out
+	return validPlayIndices(s.players[playerIdx], func(c *Card) bool { return s.validatePlay(playerIdx, c) == nil })
 }
 
 // playerHasSuitWinner プレイヤーが同スートで leadCard に勝てるカードを持つか

--- a/internal/domain/Schnapsen.go
+++ b/internal/domain/Schnapsen.go
@@ -553,16 +553,7 @@ func (s *Schnapsen) playCard(playerIdx int, card *Card) {
 // validatePlay カードのプレイがルール上有効かを検証する。
 // 第1フェーズ・リード時は常に有効。第2フェーズの追随時のみマストフォローを課す。
 func (s *Schnapsen) validatePlay(playerIdx int, card *Card) error {
-	if card == nil {
-		return NewDomainError(ErrInvalidCard, "カードが nil です")
-	}
-	if !s.IsEndgame() || len(s.currentTrick) == 0 {
-		return nil
-	}
-	if !s.cardSatisfiesFollow(playerIdx, card) {
-		return NewDomainError(ErrInvalidCard, "第2フェーズではフォロールールに従う必要があります")
-	}
-	return nil
+	return validateEndgameFollow(s.currentTrick, s, playerIdx, card)
 }
 
 // cardSatisfiesFollow 第2フェーズの追随時に card が合法かを返す。

--- a/internal/domain/Schnapsen.go
+++ b/internal/domain/Schnapsen.go
@@ -671,15 +671,7 @@ func (s *Schnapsen) drawReplenish() {
 
 // drawOne 山札または切り札表示カードから 1 枚引く。優先順位は山札 → 切り札表示カード。
 func (s *Schnapsen) drawOne() *Card {
-	if c := s.trumpCards.DrawCard(); c != nil {
-		return c
-	}
-	if s.trumpCard != nil {
-		c := s.trumpCard
-		s.trumpCard = nil
-		return c
-	}
-	return nil
+	return drawOrTakeTrump(s.trumpCards, &s.trumpCard)
 }
 
 // allHandsEmpty 全プレイヤーの手札が空かを返す

--- a/internal/domain/Scopa.go
+++ b/internal/domain/Scopa.go
@@ -438,14 +438,7 @@ func ScopaCategoryWinners(det *ScopaScoreDetail) []ScopaCategoryWinner {
 
 // removeTableCardsByIndex は降順に並び替えてから tableCards を削除する。
 func (s *Scopa) removeTableCardsByIndex(idxs []int) {
-	if len(idxs) == 0 {
-		return
-	}
-	for _, idx := range sortIndicesDescending(idxs) {
-		if idx >= 0 && idx < len(s.round.tableCards) {
-			s.round.tableCards = append(s.round.tableCards[:idx], s.round.tableCards[idx+1:]...)
-		}
-	}
+	s.round.tableCards = removeIndices(s.round.tableCards, idxs)
 }
 
 // appendLog 棋譜にエントリを追加する。

--- a/internal/domain/SevenBridgePlayer.go
+++ b/internal/domain/SevenBridgePlayer.go
@@ -57,9 +57,7 @@ func (p *SevenBridgePlayer) ClearMelds() { p.melds = nil }
 
 // ResetRound ラウンドをリセット（手札・スコア・メルド・終了状態を初期化）
 func (p *SevenBridgePlayer) ResetRound() {
-	p.SetRoundScore(0)
-	p.Reset()
-	p.SetIsFinished(false)
+	resetRoundScored(p)
 	p.ClearMelds()
 }
 

--- a/internal/domain/SevenCardStud.go
+++ b/internal/domain/SevenCardStud.go
@@ -484,15 +484,7 @@ func (s *SevenCardStud) advanceTurn() {
 
 // isBettingRoundComplete ベッティングラウンドが完了したかチェック
 func (s *SevenCardStud) isBettingRoundComplete() bool {
-	for i, p := range s.players {
-		if p.GetFolded() || p.GetAllIn() {
-			continue
-		}
-		if !s.actedFlags[i] {
-			return false
-		}
-	}
-	return true
+	return bettingRoundComplete(s.players, s.actedFlags)
 }
 
 // advancePhase 次のフェーズに進める

--- a/internal/domain/ShortDeck.go
+++ b/internal/domain/ShortDeck.go
@@ -207,37 +207,7 @@ func (sd *ShortDeck) continueReset() error {
 
 // postBlinds ブラインド投入
 func (sd *ShortDeck) postBlinds() {
-	sbIdx := (sd.dealerIdx + 1) % len(sd.players)
-	bbIdx := (sd.dealerIdx + 2) % len(sd.players)
-
-	sbAmount := sd.config.SmallBlind
-	if sd.players[sbIdx].GetChips() < sbAmount {
-		sbAmount = sd.players[sbIdx].GetChips()
-	}
-	sd.players[sbIdx].SubtractChips(sbAmount)
-	sd.players[sbIdx].SetCurrentBet(sbAmount)
-	sd.pot += sbAmount
-	sd.appendLog(sbIdx, "blind", fmt.Sprintf("posts small blind %d", sbAmount), nil)
-
-	bbAmount := sd.config.BigBlind
-	if sd.players[bbIdx].GetChips() < bbAmount {
-		bbAmount = sd.players[bbIdx].GetChips()
-	}
-	sd.players[bbIdx].SubtractChips(bbAmount)
-	sd.players[bbIdx].SetCurrentBet(bbAmount)
-	sd.pot += bbAmount
-	sd.appendLog(bbIdx, "blind", fmt.Sprintf("posts big blind %d", bbAmount), nil)
-
-	sd.lastBet = bbAmount
-
-	if sd.players[sbIdx].GetChips() == 0 {
-		sd.players[sbIdx].SetAllIn(true)
-		sd.actedFlags[sbIdx] = true
-	}
-	if sd.players[bbIdx].GetChips() == 0 {
-		sd.players[bbIdx].SetAllIn(true)
-		sd.actedFlags[bbIdx] = true
-	}
+	postBlindsFor(sd.players, sd.dealerIdx, sd.config.SmallBlind, sd.config.BigBlind, &sd.pot, &sd.lastBet, sd.actedFlags, sd)
 }
 
 // PlayerAction 人間プレイヤーのアクション実行

--- a/internal/domain/ShortDeck.go
+++ b/internal/domain/ShortDeck.go
@@ -430,13 +430,7 @@ func (sd *ShortDeck) advancePhase() {
 
 // dealRemainingCommunity 残りのコミュニティカードを全て配る
 func (sd *ShortDeck) dealRemainingCommunity() {
-	for len(sd.communityCards) < 5 {
-		card := sd.trumpCards.DrawCard()
-		if card == nil {
-			break
-		}
-		sd.communityCards = append(sd.communityCards, card)
-	}
+	dealUpTo(&sd.communityCards, sd.trumpCards, 5)
 }
 
 // findNextActive 指定インデックスの次のアクティブプレイヤーを探す
@@ -713,14 +707,7 @@ func (sd *ShortDeck) cpuBetOrAllIn(p *ShortDeckPlayer, betAmt int) (int, int) {
 
 // cpuPotBet ポット比率ベースのベット額を計算
 func (sd *ShortDeck) cpuPotBet(potPct int) int {
-	bet := sd.pot * potPct / 100
-	if bet < sd.config.BigBlind {
-		bet = sd.config.BigBlind
-	}
-	if bet < sd.minRaise {
-		bet = sd.minRaise
-	}
-	return bet
+	return potBet(sd.pot, potPct, sd.config.BigBlind, sd.minRaise)
 }
 
 // cpuDecidePreFlop プリフロップのCPU意思決定

--- a/internal/domain/SimpleSimon.go
+++ b/internal/domain/SimpleSimon.go
@@ -47,8 +47,8 @@ type SimpleSimon struct {
 	completedSuits int
 	phase          SimpleSimonPhase
 	moveCount      int
-	actionLog      []*ActionLogEntry
-	history        []*simpleSimonSnapshot
+	actionLogBase
+	history []*simpleSimonSnapshot
 }
 
 // simpleSimonSnapshot Undo 用スナップショット。
@@ -240,13 +240,7 @@ func (g *SimpleSimon) GetHint() *SimpleSimonHint {
 }
 
 func (g *SimpleSimon) appendLog(action, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: g.moveCount,
-		PlayerIdx:  0,
-		ActionType: action,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	g.appendLogAt(g.moveCount, 0, action, detail, cards)
 }
 
 // --- undo ---

--- a/internal/domain/Skat.go
+++ b/internal/domain/Skat.go
@@ -1170,10 +1170,7 @@ func (s *Skat) findIndex(p *SkatPlayer) int {
 
 // IsHumanTurn reports whether the current player is human (play phase).
 func (s *Skat) IsHumanTurn() bool {
-	if s.round.currentPlayerIdx < 0 || s.round.currentPlayerIdx >= len(s.players) {
-		return false
-	}
-	return s.players[s.round.currentPlayerIdx].GetIsHuman()
+	return isHumanTurn(s.players, s.round.currentPlayerIdx)
 }
 
 // IsHumanDeclarerTurn reports whether the declarer is human (used for skat

--- a/internal/domain/Spades.go
+++ b/internal/domain/Spades.go
@@ -444,15 +444,7 @@ func (s *Spades) startPlayPhase() {
 
 // findTwoOfClubs 2♣を持つプレイヤーのインデックスを返す
 func (s *Spades) findTwoOfClubs() int {
-	for i, p := range s.players {
-		for j := 0; j < p.GetCardsSize(); j++ {
-			card := p.GetCard(j)
-			if card.GetDesign() == CardDesignClover && card.GetValue() == 2 {
-				return i
-			}
-		}
-	}
-	return -1
+	return seatHoldingCard(s.players, func(c *Card) bool { return c.GetDesign() == CardDesignClover && c.GetValue() == 2 })
 }
 
 // playCard カードをプレイする共通処理

--- a/internal/domain/SpoilFivePlayer.go
+++ b/internal/domain/SpoilFivePlayer.go
@@ -21,9 +21,7 @@ func NewSpoilFivePlayer(isHuman bool) *SpoilFivePlayer {
 // ResetRound ラウンドをリセット（トリック・手札・ラウンドトリック数を初期化）。
 // 累積得点はラウンドをまたいで保持する。
 func (p *SpoilFivePlayer) ResetRound() {
-	p.ResetTricks()
-	p.Reset()
-	p.SetIsFinished(false)
+	resetPlayerRound(p)
 	p.roundTricks = 0
 }
 

--- a/internal/domain/Tarocchini.go
+++ b/internal/domain/Tarocchini.go
@@ -202,7 +202,7 @@ type Tarocchini struct {
 	roundTricks      [TarocchiniPlayerCnt]int
 	gameEndFlag      bool
 	winnerTeam       int // -1 = 未確定 (同点)
-	actionLog        []*ActionLogEntry
+	actionLogBase
 }
 
 // tarocchiniTeamCnt チーム数。
@@ -352,13 +352,7 @@ func (g *Tarocchini) finishMatch() {
 
 // appendLog 棋譜に 1 件追加する。
 func (g *Tarocchini) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	g.actionLog = append(g.actionLog, &ActionLogEntry{
-		TurnNumber: g.trickNumber,
-		PlayerIdx:  playerIdx,
-		ActionType: actionType,
-		Detail:     detail,
-		Cards:      cards,
-	})
+	g.appendLogAt(g.trickNumber, playerIdx, actionType, detail, cards)
 }
 
 // --- スカルト (ディーラーの捨て札) ---

--- a/internal/domain/ThirtyOne.go
+++ b/internal/domain/ThirtyOne.go
@@ -609,14 +609,7 @@ func (g *ThirtyOne) firstActiveIdx() int {
 
 // nextActiveIdx from の次のアクティブプレイヤーのインデックスを返す
 func (g *ThirtyOne) nextActiveIdx(from int) int {
-	n := len(g.players)
-	for step := 1; step <= n; step++ {
-		idx := (from + step) % n
-		if !g.players[idx].IsEliminated() {
-			return idx
-		}
-	}
-	return from
+	return nextIndexWhere(g.players, from, func(p *ThirtyOnePlayer) bool { return !p.IsEliminated() })
 }
 
 // humanIdx 人間プレイヤーのインデックスを返す (-1 = 不在)

--- a/internal/domain/Yaniv.go
+++ b/internal/domain/Yaniv.go
@@ -572,14 +572,7 @@ func (g *Yaniv) firstActiveIdx() int {
 
 // nextActiveIdx from の次のアクティブプレイヤーのインデックスを返す
 func (g *Yaniv) nextActiveIdx(from int) int {
-	n := len(g.players)
-	for step := 1; step <= n; step++ {
-		idx := (from + step) % n
-		if !g.players[idx].IsEliminated() {
-			return idx
-		}
-	}
-	return from
+	return nextIndexWhere(g.players, from, func(p *YanivPlayer) bool { return !p.IsEliminated() })
 }
 
 // humanIdx 人間プレイヤーのインデックスを返す (-1 = 不在)

--- a/internal/domain/action_log_base_adopters_test.go
+++ b/internal/domain/action_log_base_adopters_test.go
@@ -15,7 +15,7 @@ type logReader interface {
 	GetActionLog() []*ActionLogEntry
 }
 
-// These 30 games moved their action log from an own `actionLog` field to the
+// These 37 games moved their action log from an own `actionLog` field to the
 // embedded actionLogBase. Promotion keeps `g.actionLog` compiling in their
 // MarshalJSON/UnmarshalJSON pairs, so nothing in them had to change -- which is
 // exactly why a mistake here would be quiet. The log is persisted to KV for the
@@ -187,9 +187,51 @@ func TestActionLogBaseAdopters_LogSurvivesAKVRoundTrip(t *testing.T) {
 			g.addLog(1, "act", "detail", nil)
 			return g, NewDefaultSixBidSolo()
 		}},
+		{"Aluette", func() (any, any) {
+			g := NewDefaultAluette()
+			g.Reset()
+			g.appendLog(1, "act", "detail", nil)
+			return g, NewDefaultAluette()
+		}},
+		{"Minchiate", func() (any, any) {
+			g := NewDefaultMinchiate()
+			g.Reset()
+			g.appendLog(1, "act", "detail", nil)
+			return g, NewDefaultMinchiate()
+		}},
+		{"Tarocchini", func() (any, any) {
+			g := NewDefaultTarocchini()
+			g.Reset()
+			g.appendLog(1, "act", "detail", nil)
+			return g, NewDefaultTarocchini()
+		}},
+		{"BlackHole", func() (any, any) {
+			g := NewDefaultBlackHole()
+			g.Reset()
+			g.appendLog("act", "detail", nil)
+			return g, NewDefaultBlackHole()
+		}},
+		{"DoubleKlondike", func() (any, any) {
+			g := NewDefaultDoubleKlondike()
+			g.Reset()
+			g.appendLog("act", "detail", nil)
+			return g, NewDefaultDoubleKlondike()
+		}},
+		{"LaBelleLucie", func() (any, any) {
+			g := NewDefaultLaBelleLucie()
+			g.Reset()
+			g.appendLog("act", "detail", nil)
+			return g, NewDefaultLaBelleLucie()
+		}},
+		{"SimpleSimon", func() (any, any) {
+			g := NewDefaultSimpleSimon()
+			g.Reset()
+			g.appendLog("act", "detail", nil)
+			return g, NewDefaultSimpleSimon()
+		}},
 	}
 
-	assert.Len(t, adopters, 30, "every game embedding actionLogBase via addLog/appendLog must be listed")
+	assert.Len(t, adopters, 37, "every game embedding actionLogBase via addLog/appendLog must be listed")
 
 	for _, a := range adopters {
 		t.Run(a.name, func(t *testing.T) {

--- a/internal/domain/betting.go
+++ b/internal/domain/betting.go
@@ -587,3 +587,41 @@ func potBet(pot, potPct, bigBlind, minRaise int) int {
 	}
 	return bet
 }
+
+// blindLogger records the blinds as they are posted.
+type blindLogger interface {
+	appendLog(playerIdx int, actionType, detail string, cards []*Card)
+}
+
+// postBlindsFor takes the small and big blinds from the two seats after the
+// dealer, capping each at what the seat actually has and marking it all-in when
+// that empties its stack. lastBet ends up at the big blind. 3 games had this
+// written out.
+//
+// pot, lastBet and actedFlags are passed directly because the helper writes all
+// three; keeping the fmt.Sprintf here means one copy rather than one per game.
+func postBlindsFor[P BettingPlayer](players []P, dealerIdx, smallBlind, bigBlind int,
+	pot, lastBet *int, actedFlags []bool, g blindLogger,
+) {
+	// Returns what was actually posted, which is less than asked for when the
+	// seat is too short to cover the blind.
+	post := func(idx, want int, label string) int {
+		amount := want
+		if players[idx].GetChips() < amount {
+			amount = players[idx].GetChips()
+		}
+		players[idx].SubtractChips(amount)
+		players[idx].SetCurrentBet(amount)
+		*pot += amount
+		g.appendLog(idx, "blind", fmt.Sprintf("posts %s %d", label, amount), nil)
+		if players[idx].GetChips() == 0 {
+			players[idx].SetAllIn(true)
+			actedFlags[idx] = true
+		}
+		return amount
+	}
+	sbIdx := (dealerIdx + 1) % len(players)
+	bbIdx := (dealerIdx + 2) % len(players)
+	post(sbIdx, smallBlind, "small blind")
+	*lastBet = post(bbIdx, bigBlind, "big blind")
+}

--- a/internal/domain/betting.go
+++ b/internal/domain/betting.go
@@ -574,3 +574,16 @@ func addonAvailable[P humanChipHolder](enabled bool, handCount, afterHand int, p
 	}
 	return false
 }
+
+// potBet sizes a CPU bet as a percentage of the pot, floored by the big blind
+// and by any outstanding minimum raise. 4 games had this written out.
+func potBet(pot, potPct, bigBlind, minRaise int) int {
+	bet := pot * potPct / 100
+	if bet < bigBlind {
+		bet = bigBlind
+	}
+	if bet < minRaise {
+		bet = minRaise
+	}
+	return bet
+}

--- a/internal/domain/betting_test.go
+++ b/internal/domain/betting_test.go
@@ -1223,3 +1223,73 @@ func TestFindPotWinnersRazz_SingleEligible(t *testing.T) {
 	winners := FindPotWinnersRazz(players, []int{0})
 	assert.Equal(t, []int{0}, winners)
 }
+
+type fakeBlindSeat struct {
+	chips int
+	bet   int
+	allIn bool
+}
+
+func (p *fakeBlindSeat) GetChips() int               { return p.chips }
+func (p *fakeBlindSeat) SubtractChips(n int) bool    { p.chips -= n; return true }
+func (p *fakeBlindSeat) AddChips(n int)              { p.chips += n }
+func (p *fakeBlindSeat) GetCurrentBet() int          { return p.bet }
+func (p *fakeBlindSeat) SetCurrentBet(n int)         { p.bet = n }
+func (p *fakeBlindSeat) GetFolded() bool             { return false }
+func (p *fakeBlindSeat) SetFolded(bool)              {}
+func (p *fakeBlindSeat) GetAllIn() bool              { return p.allIn }
+func (p *fakeBlindSeat) SetAllIn(v bool)             { p.allIn = v }
+func (p *fakeBlindSeat) GetHandRank() int            { return 0 }
+func (p *fakeBlindSeat) GetComparisonCards() []*Card { return nil }
+
+type fakeBlindLogger struct{ details []string }
+
+func (g *fakeBlindLogger) appendLog(_ int, _, detail string, _ []*Card) {
+	g.details = append(g.details, detail)
+}
+
+func TestPostBlindsFor(t *testing.T) {
+	seats := []*fakeBlindSeat{{chips: 100}, {chips: 100}, {chips: 100}}
+	pot, lastBet := 0, 0
+	acted := make([]bool, 3)
+	g := &fakeBlindLogger{}
+
+	// Dealer at 0, so seat 1 posts the small blind and seat 2 the big blind.
+	postBlindsFor(seats, 0, 5, 10, &pot, &lastBet, acted, g)
+
+	assert.Equal(t, 95, seats[1].chips)
+	assert.Equal(t, 90, seats[2].chips)
+	assert.Equal(t, 15, pot)
+	assert.Equal(t, 10, lastBet, "lastBet is the big blind")
+	assert.Equal(t, []string{"posts small blind 5", "posts big blind 10"}, g.details)
+}
+
+// A seat too short for the blind posts what it has and is marked all-in, with
+// its acted flag set so the round does not wait on it.
+func TestPostBlindsFor_ShortStackGoesAllIn(t *testing.T) {
+	seats := []*fakeBlindSeat{{chips: 100}, {chips: 3}, {chips: 100}}
+	pot, lastBet := 0, 0
+	acted := make([]bool, 3)
+	g := &fakeBlindLogger{}
+
+	postBlindsFor(seats, 0, 5, 10, &pot, &lastBet, acted, g)
+
+	assert.Equal(t, 0, seats[1].chips)
+	assert.True(t, seats[1].allIn)
+	assert.True(t, acted[1])
+	assert.Equal(t, 13, pot, "only what the short stack had")
+	assert.Equal(t, "posts small blind 3", g.details[0], "the log shows the capped amount")
+	assert.False(t, seats[2].allIn, "the full stack is not all-in")
+}
+
+// The blinds wrap around the table.
+func TestPostBlindsFor_WrapsAroundFromTheDealer(t *testing.T) {
+	seats := []*fakeBlindSeat{{chips: 100}, {chips: 100}, {chips: 100}}
+	pot, lastBet := 0, 0
+	acted := make([]bool, 3)
+
+	postBlindsFor(seats, 2, 5, 10, &pot, &lastBet, acted, &fakeBlindLogger{})
+
+	assert.Equal(t, 95, seats[0].chips, "small blind wraps to seat 0")
+	assert.Equal(t, 90, seats[1].chips, "big blind to seat 1")
+}

--- a/internal/domain/player_helpers.go
+++ b/internal/domain/player_helpers.go
@@ -572,3 +572,74 @@ func bettingRoundComplete[P bettor](players []P, acted []bool) bool {
 	}
 	return true
 }
+
+// totalScorer is a seat with a running game score.
+type totalScorer interface {
+	GetTotalScore() int
+}
+
+// topScorers returns the indices of every seat tied for the highest total
+// score. 3 games had this two-pass scan written out.
+func topScorers[P totalScorer](players []P) []int {
+	if len(players) == 0 {
+		return []int{}
+	}
+	best := players[0].GetTotalScore()
+	for _, p := range players[1:] {
+		if p.GetTotalScore() > best {
+			best = p.GetTotalScore()
+		}
+	}
+	winners := make([]int, 0)
+	for i, p := range players {
+		if p.GetTotalScore() == best {
+			winners = append(winners, i)
+		}
+	}
+	return winners
+}
+
+// trickScorer is a game that can rank the cards in the current trick.
+type trickScorer interface {
+	leadSuit() int
+	trickScore(*Card, int) int
+}
+
+// trickWinnerByScore returns the seat that played the highest-scoring card in
+// the trick, or 0 when no card has been played. Ties keep the earliest play,
+// matching the bodies replaced, which compared with a strict >.
+func trickWinnerByScore(trick []*TrickCard, g trickScorer) int {
+	if len(trick) == 0 {
+		return 0
+	}
+	ls := g.leadSuit()
+	winnerIdx := trick[0].PlayerIdx
+	winnerScore := g.trickScore(trick[0].Card, ls)
+	for _, tc := range trick[1:] {
+		if s := g.trickScore(tc.Card, ls); s > winnerScore {
+			winnerScore = s
+			winnerIdx = tc.PlayerIdx
+		}
+	}
+	return winnerIdx
+}
+
+// drawFromPile deals up to n cards off the end of pile into to, recycling once
+// the pile runs dry and stopping when recycling cannot refill it. Returns how
+// many were actually dealt. 3 games had this written out.
+func drawFromPile[P interface{ AddCard(*Card) }](pile *[]*Card, to P, n int, recycle func()) int {
+	drawn := 0
+	for i := 0; i < n; i++ {
+		if len(*pile) == 0 {
+			recycle()
+		}
+		if len(*pile) == 0 {
+			break
+		}
+		card := (*pile)[len(*pile)-1]
+		*pile = (*pile)[:len(*pile)-1]
+		to.AddCard(card)
+		drawn++
+	}
+	return drawn
+}

--- a/internal/domain/player_helpers.go
+++ b/internal/domain/player_helpers.go
@@ -545,3 +545,30 @@ func recycleDiscardIntoStock(discard, draw *[]*Card, g stockRecycler) bool {
 	g.appendLog(-1, "recycle", fmt.Sprintf("Discard pile recycled into stock (%d cards)", len(rest)), nil)
 	return true
 }
+
+// seatHoldingCard returns the index of the first seat holding a card that
+// satisfies want, or -1 when nobody does. 3 games looked for the two of clubs
+// this way.
+func seatHoldingCard[P handReader](players []P, want func(*Card) bool) int {
+	for i, p := range players {
+		if handHasAny(p, want) {
+			return i
+		}
+	}
+	return -1
+}
+
+// bettingRoundComplete reports whether every seat still in the hand has acted.
+// 3 games had this written out. Reuses the bettor constraint rather than
+// declaring a second interface with the same two methods.
+func bettingRoundComplete[P bettor](players []P, acted []bool) bool {
+	for i, p := range players {
+		if p.GetFolded() || p.GetAllIn() {
+			continue
+		}
+		if !acted[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/domain/player_helpers.go
+++ b/internal/domain/player_helpers.go
@@ -687,3 +687,56 @@ func drawOrTakeTrump(deck *TrumpCards, trump **Card) *Card {
 	}
 	return nil
 }
+
+// cardComparer is a game that can rank two cards against the led suit.
+type cardComparer interface {
+	cardBeats(a, b *Card, leadSuit int) bool
+}
+
+// currentTrickWinnerCard returns the card currently winning the trick, or nil
+// when nothing has been played. 3 games had this written out.
+func currentTrickWinnerCard(trick []*TrickCard, g cardComparer) *Card {
+	if len(trick) == 0 {
+		return nil
+	}
+	leadSuit := trick[0].Card.GetDesign()
+	winner := trick[0].Card
+	for _, tc := range trick[1:] {
+		if g.cardBeats(tc.Card, winner, leadSuit) {
+			winner = tc.Card
+		}
+	}
+	return winner
+}
+
+// validateCardIsPlayable checks that card is one of the seat's legal plays,
+// comparing by identity as the 4 bodies it replaces did. See issue #5185.
+func validateCardIsPlayable[P handReader](valid []int, p P, card *Card) error {
+	for _, idx := range valid {
+		if p.GetCard(idx) == card {
+			return nil
+		}
+	}
+	return NewDomainError(ErrInvalidPlay, "フォロー義務・切り札義務・オーバートランプ義務に反しています")
+}
+
+// endgameFollower is a game whose follow rules only apply in its second phase.
+type endgameFollower interface {
+	IsEndgame() bool
+	cardSatisfiesFollow(playerIdx int, card *Card) bool
+}
+
+// validateEndgameFollow enforces following suit once the endgame has started
+// and a trick is under way. 3 games had this written out.
+func validateEndgameFollow(trick []*TrickCard, g endgameFollower, playerIdx int, card *Card) error {
+	if card == nil {
+		return NewDomainError(ErrInvalidCard, "カードが nil です")
+	}
+	if !g.IsEndgame() || len(trick) == 0 {
+		return nil
+	}
+	if !g.cardSatisfiesFollow(playerIdx, card) {
+		return NewDomainError(ErrInvalidCard, "第2フェーズではフォロールールに従う必要があります")
+	}
+	return nil
+}

--- a/internal/domain/player_helpers.go
+++ b/internal/domain/player_helpers.go
@@ -673,3 +673,17 @@ func dealUpTo(cards *[]*Card, deck *TrumpCards, target int) {
 		*cards = append(*cards, card)
 	}
 }
+
+// drawOrTakeTrump draws from the deck, falling back to the face-up trump card
+// once the deck is empty and consuming it. 3 games had this written out.
+func drawOrTakeTrump(deck *TrumpCards, trump **Card) *Card {
+	if c := deck.DrawCard(); c != nil {
+		return c
+	}
+	if *trump != nil {
+		c := *trump
+		*trump = nil
+		return c
+	}
+	return nil
+}

--- a/internal/domain/player_helpers.go
+++ b/internal/domain/player_helpers.go
@@ -643,3 +643,33 @@ func drawFromPile[P interface{ AddCard(*Card) }](pile *[]*Card, to P, n int, rec
 	}
 	return drawn
 }
+
+// bestSuitFrom returns the suit with the highest count, breaking ties in
+// spade/clover/heart/diamond order and defaulting to spade when every count is
+// zero. 3 games had this scan written out over a precomputed tally.
+//
+// Unlike longestSuit, which counts a hand itself, this takes the tally the
+// caller already built.
+func bestSuitFrom(counts map[int]int) int {
+	bestSuit := CardDesignSpade
+	bestCount := 0
+	for suit := CardDesignSpade; suit <= CardDesignDiamond; suit++ {
+		if counts[suit] > bestCount {
+			bestCount = counts[suit]
+			bestSuit = suit
+		}
+	}
+	return bestSuit
+}
+
+// dealUpTo appends cards from the deck until the slice holds target cards or
+// the deck runs out. 4 games had this written out for the community cards.
+func dealUpTo(cards *[]*Card, deck *TrumpCards, target int) {
+	for len(*cards) < target {
+		card := deck.DrawCard()
+		if card == nil {
+			break
+		}
+		*cards = append(*cards, card)
+	}
+}

--- a/internal/domain/player_helpers_internal_test.go
+++ b/internal/domain/player_helpers_internal_test.go
@@ -924,3 +924,82 @@ func TestBettingRoundComplete(t *testing.T) {
 func TestBettingRoundComplete_NoSeats(t *testing.T) {
 	assert.True(t, bettingRoundComplete([]*fakeBettor{}, nil), "nothing outstanding is complete")
 }
+
+type fakeScorer struct{ total int }
+
+func (p *fakeScorer) GetTotalScore() int { return p.total }
+
+func TestTopScorers(t *testing.T) {
+	assert.Equal(t, []int{1}, topScorers([]*fakeScorer{{3}, {9}, {4}}))
+	assert.Equal(t, []int{0, 2}, topScorers([]*fakeScorer{{9}, {3}, {9}}), "every seat tied for the top")
+	assert.Equal(t, []int{}, topScorers([]*fakeScorer{}), "empty roster yields an empty slice, not nil")
+}
+
+// Negative totals must not be beaten by the zero value -- seeding best from
+// players[0] rather than 0 is what makes that work.
+func TestTopScorers_AllNegative(t *testing.T) {
+	assert.Equal(t, []int{1}, topScorers([]*fakeScorer{{-9}, {-2}, {-5}}))
+}
+
+type fakeTrickScorer struct{ lead int }
+
+func (g *fakeTrickScorer) leadSuit() int { return g.lead }
+func (g *fakeTrickScorer) trickScore(c *Card, lead int) int {
+	if c.GetDesign() != lead {
+		return 0
+	}
+	return c.GetValue()
+}
+
+func TestTrickWinnerByScore(t *testing.T) {
+	g := &fakeTrickScorer{lead: 1}
+	trick := []*TrickCard{
+		{PlayerIdx: 2, Card: NewCard(1, 5, false)},
+		{PlayerIdx: 0, Card: NewCard(2, 13, false)}, // off-suit, scores 0
+		{PlayerIdx: 3, Card: NewCard(1, 9, false)},
+	}
+	assert.Equal(t, 3, trickWinnerByScore(trick, g))
+	assert.Equal(t, 0, trickWinnerByScore(nil, g), "no cards played")
+}
+
+// A tie keeps the earliest play, which is what a strict > gives.
+func TestTrickWinnerByScore_TieKeepsEarliest(t *testing.T) {
+	g := &fakeTrickScorer{lead: 1}
+	trick := []*TrickCard{
+		{PlayerIdx: 2, Card: NewCard(1, 7, false)},
+		{PlayerIdx: 1, Card: NewCard(1, 7, false)},
+	}
+	assert.Equal(t, 2, trickWinnerByScore(trick, g))
+}
+
+func TestDrawFromPile(t *testing.T) {
+	pile := []*Card{NewCard(1, 1, false), NewCard(1, 2, false), NewCard(1, 3, false)}
+	hand := &fakeSeatHand{}
+
+	assert.Equal(t, 2, drawFromPile(&pile, hand, 2, func() {}))
+	assert.Equal(t, 2, hand.GetCardsSize())
+	assert.Len(t, pile, 1, "cards come off the end")
+}
+
+// The recycle hook is called when the pile empties, and the draw stops if it
+// cannot refill -- otherwise this would loop forever on an exhausted deck.
+func TestDrawFromPile_RecyclesThenGivesUp(t *testing.T) {
+	pile := []*Card{NewCard(1, 1, false)}
+	hand := &fakeSeatHand{}
+	recycled := 0
+
+	got := drawFromPile(&pile, hand, 5, func() { recycled++ })
+
+	assert.Equal(t, 1, got, "only what was available")
+	assert.Equal(t, 1, recycled, "recycle attempted once, then the loop stops")
+}
+
+func TestDealerQualifies(t *testing.T) {
+	// A made hand qualifies regardless of the cards.
+	assert.True(t, dealerQualifies(PokerHandOnePair, nil))
+
+	ak := []*Card{NewCard(1, 1, false), NewCard(2, 13, false)}
+	assert.True(t, dealerQualifies(0, ak), "ace-king qualifies below one pair")
+	assert.False(t, dealerQualifies(0, []*Card{NewCard(1, 1, false)}), "ace alone does not")
+	assert.False(t, dealerQualifies(0, []*Card{NewCard(1, 13, false)}), "king alone does not")
+}

--- a/internal/domain/player_helpers_internal_test.go
+++ b/internal/domain/player_helpers_internal_test.go
@@ -1066,3 +1066,71 @@ func TestDrawOrTakeTrump_FallsBackToTrumpThenNil(t *testing.T) {
 	assert.Nil(t, trump, "and is consumed")
 	assert.Nil(t, drawOrTakeTrump(deck, &trump), "nothing left")
 }
+
+type fakeBeater struct{}
+
+// Higher value wins, but only among cards of the led suit.
+func (fakeBeater) cardBeats(a, b *Card, leadSuit int) bool {
+	if a.GetDesign() != leadSuit {
+		return false
+	}
+	if b.GetDesign() != leadSuit {
+		return true
+	}
+	return a.GetValue() > b.GetValue()
+}
+
+func TestCurrentTrickWinnerCard(t *testing.T) {
+	high := NewCard(1, 9, false)
+	trick := []*TrickCard{
+		{PlayerIdx: 0, Card: NewCard(1, 4, false)},
+		{PlayerIdx: 1, Card: NewCard(2, 13, false)}, // off-suit
+		{PlayerIdx: 2, Card: high},
+	}
+	assert.Same(t, high, currentTrickWinnerCard(trick, fakeBeater{}))
+	assert.Nil(t, currentTrickWinnerCard(nil, fakeBeater{}))
+}
+
+func TestValidateCardIsPlayable(t *testing.T) {
+	a, b := NewCard(1, 2, false), NewCard(1, 3, false)
+	h := &fakeHand{cards: []*Card{a, b}}
+
+	require.NoError(t, validateCardIsPlayable([]int{0}, h, a))
+	// Identity, not equality: an identical-looking card that is not in the hand
+	// is rejected, which is what the bodies replaced did.
+	assert.Error(t, validateCardIsPlayable([]int{0}, h, NewCard(1, 2, false)))
+	assert.Error(t, validateCardIsPlayable([]int{0}, h, b), "b is in the hand but not among the valid indices")
+	assert.Error(t, validateCardIsPlayable(nil, h, a), "nothing is playable")
+}
+
+type fakeEndgame struct {
+	endgame   bool
+	satisfies bool
+}
+
+func (g fakeEndgame) IsEndgame() bool                         { return g.endgame }
+func (g fakeEndgame) cardSatisfiesFollow(_ int, _ *Card) bool { return g.satisfies }
+
+func TestValidateEndgameFollow(t *testing.T) {
+	trick := []*TrickCard{{PlayerIdx: 0, Card: NewCard(1, 5, false)}}
+	card := NewCard(1, 2, false)
+
+	assert.Error(t, validateEndgameFollow(trick, fakeEndgame{}, 0, nil), "a nil card is rejected first")
+	require.NoError(t, validateEndgameFollow(trick, fakeEndgame{endgame: false}, 0, card), "no rule before the endgame")
+	require.NoError(t, validateEndgameFollow(nil, fakeEndgame{endgame: true}, 0, card), "no rule when leading")
+	assert.Error(t, validateEndgameFollow(trick, fakeEndgame{endgame: true, satisfies: false}, 0, card))
+	require.NoError(t, validateEndgameFollow(trick, fakeEndgame{endgame: true, satisfies: true}, 0, card))
+}
+
+func TestRemoveIndices(t *testing.T) {
+	assert.Equal(t, []int{1, 3}, removeIndices([]int{1, 2, 3, 4}, []int{1, 3}))
+	assert.Equal(t, []int{1, 2}, removeIndices([]int{1, 2}, nil), "no indices leaves the slice alone")
+	assert.Equal(t, []int{1, 2}, removeIndices([]int{1, 2}, []int{5, -1}), "out-of-range indices are ignored")
+}
+
+// Removal must run highest-first; ascending order would shift the later
+// indices and delete the wrong elements.
+func TestRemoveIndices_OrderIndependent(t *testing.T) {
+	assert.Equal(t, []int{20}, removeIndices([]int{10, 20, 30}, []int{0, 2}))
+	assert.Equal(t, []int{20}, removeIndices([]int{10, 20, 30}, []int{2, 0}), "input order must not matter")
+}

--- a/internal/domain/player_helpers_internal_test.go
+++ b/internal/domain/player_helpers_internal_test.go
@@ -898,3 +898,29 @@ func TestRecycleDiscardToDraw_NothingToRecycle(t *testing.T) {
 		assert.Len(t, draw, 1, "n=%d: draw pile untouched", n)
 	}
 }
+
+func TestSeatHoldingCard(t *testing.T) {
+	seats := []*fakeHand{
+		{cards: []*Card{NewCard(1, 5, false)}},
+		{cards: []*Card{NewCard(CardDesignClover, 2, false)}},
+	}
+	isTwoOfClubs := func(c *Card) bool {
+		return c.GetDesign() == CardDesignClover && c.GetValue() == 2
+	}
+
+	assert.Equal(t, 1, seatHoldingCard(seats, isTwoOfClubs))
+	assert.Equal(t, -1, seatHoldingCard([]*fakeHand{{}}, isTwoOfClubs), "nobody holding yields -1, not 0")
+}
+
+func TestBettingRoundComplete(t *testing.T) {
+	seats := []*fakeBettor{{}, {folded: true}, {allIn: true}}
+
+	// Seat 0 is the only one that must act; folded and all-in seats are skipped
+	// even though their acted flags are false.
+	assert.True(t, bettingRoundComplete(seats, []bool{true, false, false}))
+	assert.False(t, bettingRoundComplete(seats, []bool{false, true, true}))
+}
+
+func TestBettingRoundComplete_NoSeats(t *testing.T) {
+	assert.True(t, bettingRoundComplete([]*fakeBettor{}, nil), "nothing outstanding is complete")
+}

--- a/internal/domain/player_helpers_internal_test.go
+++ b/internal/domain/player_helpers_internal_test.go
@@ -869,3 +869,32 @@ func TestRecycleDiscardIntoStock_NothingToRecycle(t *testing.T) {
 		assert.Equal(t, 0, g.logged, "n=%d: nothing logged", n)
 	}
 }
+
+func TestRecycleDiscardToDraw(t *testing.T) {
+	discard := []*Card{NewCard(1, 1, false), NewCard(1, 2, false), NewCard(1, 3, false)}
+	draw := []*Card{NewCard(2, 9, false)}
+	top := discard[len(discard)-1]
+
+	recycleDiscardToDraw(&discard, &draw)
+
+	require.Len(t, discard, 1)
+	assert.Same(t, top, discard[0], "the visible top card stays")
+	// Unlike recycleDiscardIntoStock this replaces the draw pile rather than
+	// appending to it -- the four bodies it folds in did exactly that.
+	assert.Len(t, draw, 2, "the old draw pile is replaced, not extended")
+}
+
+func TestRecycleDiscardToDraw_NothingToRecycle(t *testing.T) {
+	for _, n := range []int{0, 1} {
+		discard := make([]*Card, n)
+		for i := range discard {
+			discard[i] = NewCard(1, i+1, false)
+		}
+		draw := []*Card{NewCard(3, 3, false)}
+
+		recycleDiscardToDraw(&discard, &draw)
+
+		assert.Len(t, discard, n, "n=%d", n)
+		assert.Len(t, draw, 1, "n=%d: draw pile untouched", n)
+	}
+}

--- a/internal/domain/player_helpers_internal_test.go
+++ b/internal/domain/player_helpers_internal_test.go
@@ -1003,3 +1003,29 @@ func TestDealerQualifies(t *testing.T) {
 	assert.False(t, dealerQualifies(0, []*Card{NewCard(1, 1, false)}), "ace alone does not")
 	assert.False(t, dealerQualifies(0, []*Card{NewCard(1, 13, false)}), "king alone does not")
 }
+
+func TestBestSuitFrom(t *testing.T) {
+	assert.Equal(t, CardDesignHeart, bestSuitFrom(map[int]int{CardDesignHeart: 3, CardDesignSpade: 1}))
+	assert.Equal(t, CardDesignSpade, bestSuitFrom(map[int]int{}), "no cards defaults to spade")
+	assert.Equal(t, CardDesignClover, bestSuitFrom(map[int]int{CardDesignClover: 2, CardDesignDiamond: 2}),
+		"ties resolve in spade/clover/heart/diamond order")
+}
+
+func TestDealUpTo(t *testing.T) {
+	tc := NewTrumpCards(0)
+	tc.Shuffle()
+	cards := []*Card{}
+
+	dealUpTo(&cards, tc, 5)
+	assert.Len(t, cards, 5)
+
+	// Already at target: nothing more is drawn.
+	dealUpTo(&cards, tc, 5)
+	assert.Len(t, cards, 5)
+}
+
+func TestPotBet(t *testing.T) {
+	assert.Equal(t, 50, potBet(100, 50, 10, 0), "half pot")
+	assert.Equal(t, 10, potBet(4, 50, 10, 0), "floored by the big blind")
+	assert.Equal(t, 30, potBet(100, 10, 10, 30), "floored by the minimum raise")
+}

--- a/internal/domain/player_helpers_internal_test.go
+++ b/internal/domain/player_helpers_internal_test.go
@@ -1029,3 +1029,40 @@ func TestPotBet(t *testing.T) {
 	assert.Equal(t, 10, potBet(4, 50, 10, 0), "floored by the big blind")
 	assert.Equal(t, 30, potBet(100, 10, 10, 30), "floored by the minimum raise")
 }
+
+func TestNextIndexWhere(t *testing.T) {
+	s := []bool{false, true, false, true}
+	ok := func(v bool) bool { return v }
+
+	assert.Equal(t, 1, nextIndexWhere(s, 0, ok))
+	assert.Equal(t, 3, nextIndexWhere(s, 1, ok), "starts after from")
+	assert.Equal(t, 1, nextIndexWhere(s, 3, ok), "wraps around")
+}
+
+// With nobody eligible it returns from rather than -1, because callers index
+// with the result. An empty slice must not divide by zero.
+func TestNextIndexWhere_NoneAndEmpty(t *testing.T) {
+	assert.Equal(t, 2, nextIndexWhere([]bool{false, false, false}, 2, func(v bool) bool { return v }))
+	assert.NotPanics(t, func() { nextIndexWhere([]bool{}, 0, func(bool) bool { return true }) })
+}
+
+func TestDrawOrTakeTrump(t *testing.T) {
+	deck := NewTrumpCards(0)
+	deck.Shuffle()
+	var trump *Card
+
+	assert.NotNil(t, drawOrTakeTrump(deck, &trump), "comes off the deck while it lasts")
+}
+
+func TestDrawOrTakeTrump_FallsBackToTrumpThenNil(t *testing.T) {
+	deck := NewTrumpCards(0)
+	deck.Shuffle()
+	for deck.DrawCard() != nil { //nolint:revive // drain the deck
+	}
+	held := NewCard(1, 5, false)
+	trump := held
+
+	assert.Same(t, held, drawOrTakeTrump(deck, &trump), "the trump card is dealt once the deck runs out")
+	assert.Nil(t, trump, "and is consumed")
+	assert.Nil(t, drawOrTakeTrump(deck, &trump), "nothing left")
+}

--- a/internal/domain/poker_hand_rank.go
+++ b/internal/domain/poker_hand_rank.go
@@ -44,3 +44,22 @@ func pokerHandName(rank int) string {
 	}
 	return "Unknown"
 }
+
+// dealerQualifies reports whether the dealer's hand meets the usual
+// ace-king-or-better qualification. 3 casino games had this written out.
+func dealerQualifies(handRank int, hand []*Card) bool {
+	if handRank >= PokerHandOnePair {
+		return true
+	}
+	hasAce := false
+	hasKing := false
+	for _, c := range hand {
+		switch c.GetValue() {
+		case 1:
+			hasAce = true
+		case 13:
+			hasKing = true
+		}
+	}
+	return hasAce && hasKing
+}

--- a/internal/domain/slice_helpers.go
+++ b/internal/domain/slice_helpers.go
@@ -7,6 +7,8 @@
 // rebucketing any game that used it to another worker).
 package domain
 
+import "math/rand"
+
 // collectValidIndices returns the indices in [0, size) for which ok reports
 // true. It factors out the "scan a hand and keep the playable card indices"
 // loop duplicated across dozens of trick-taking / shedding games (issue #4299):
@@ -90,4 +92,19 @@ func percentOf(count, total int) int {
 		return 0
 	}
 	return count * 100 / total
+}
+
+// recycleDiscardToDraw moves everything but the top discard into the draw pile,
+// shuffled, replacing whatever the draw pile held. 4 games had this written out.
+// Unlike recycleDiscardIntoStock it neither logs nor keeps the old draw pile,
+// which is why the two are separate.
+func recycleDiscardToDraw(discard, draw *[]*Card) {
+	if len(*discard) <= 1 {
+		return
+	}
+	top := (*discard)[len(*discard)-1]
+	recycled := (*discard)[:len(*discard)-1]
+	*discard = []*Card{top}
+	rand.Shuffle(len(recycled), func(i, j int) { recycled[i], recycled[j] = recycled[j], recycled[i] })
+	*draw = recycled
 }

--- a/internal/domain/slice_helpers.go
+++ b/internal/domain/slice_helpers.go
@@ -108,3 +108,17 @@ func recycleDiscardToDraw(discard, draw *[]*Card) {
 	rand.Shuffle(len(recycled), func(i, j int) { recycled[i], recycled[j] = recycled[j], recycled[i] })
 	*draw = recycled
 }
+
+// nextIndexWhere returns the first index after from, wrapping, whose element
+// satisfies ok -- or from itself when none does. Callers index with the result,
+// so it never returns -1. Two "next active seat" variants shared this shape.
+func nextIndexWhere[T any](s []T, from int, ok func(T) bool) int {
+	n := len(s)
+	for i := 1; i <= n; i++ {
+		idx := (from + i) % n
+		if ok(s[idx]) {
+			return idx
+		}
+	}
+	return from
+}

--- a/internal/domain/slice_helpers.go
+++ b/internal/domain/slice_helpers.go
@@ -122,3 +122,18 @@ func nextIndexWhere[T any](s []T, from int, ok func(T) bool) int {
 	}
 	return from
 }
+
+// removeIndices returns s without the elements at the given indices. Removal
+// runs highest-first so earlier indices stay valid, and out-of-range entries are
+// ignored. 3 games had this written out.
+func removeIndices[T any](s []T, idxs []int) []T {
+	if len(idxs) == 0 {
+		return s
+	}
+	for _, idx := range sortIndicesDescending(idxs) {
+		if idx >= 0 && idx < len(s) {
+			s = append(s[:idx], s[idx+1:]...)
+		}
+	}
+	return s
+}


### PR DESCRIPTION
#5185 の 3〜4コピー帯の第1弾です。36メソッド / **-107行**（正味）。

| クラスタ | 件数 | 方式 |
|---|---:|---|
| `countActivePlayers` | 4 | **既存 `countPlayers`** |
| `ResetRound`（3変種） | 10 | **既存 `resetRoundScored` / `resetPlayerRound`** + 各1行 |
| `IsHumanTurn`（ネスト） | 3 | **既存 `isHumanTurn`** |
| `appendLog`（moveCount / trickNumber 版） | 7 | **既存 `actionLogBase`** 採用 |
| `legalPlayIndices` | 4 | **既存 `validPlayIndices`** |
| `solventCount` | 4 | **既存 `countPlayers`** |
| `recycleDrawPile` | 4 | 新規ヘルパ1つ |

**36メソッド中32が既存ヘルパへの委譲のみで、新規は1つだけ**です。

## 行数が減らないクラスタは見送りました

`IsHumanTurn` のうち `gameEndFlag` を見る2クラスタ（6メソッド）は、共通ヘルパに載せ替えても**行数が同じ**でした。

```go
if g.state.gameEndFlag { return false }
return g.players[g.state.currentTurn].GetIsHuman()   // → isHumanTurn(...) でも4行のまま
```

境界チェックが増える（安全側）という違いはありますが、DRY 上の利得が無いので churn を避けて据え置きます。

## `recycleDrawPile` は既存の `recycleDiscardIntoStock` と統合していません

似ていますが**振る舞いが違います**。

| | ログ | 既存 draw pile |
|---|---|---|
| `recycleDiscardIntoStock`（既存） | 記録する | **末尾に足す** |
| `recycleDiscardToDraw`（新規） | 記録しない | **置き換える** |

無理に1つにすると分岐が増えるので分けました。テストで「置き換える」ほうを明示的に固定しています。

## KV 往復ガードを 30 → 37 に拡張

新たに7ゲームが `actionLogBase` を採用したので追加しました。

## 分析スクリプトのバグを1件修正

本体の正規化で `receiver + "."` を単純置換していたため、**レシーバが `g` のとき `config.Ante` が `confi` + `g.` + `Ante` と解釈され `confiRECV.Ante` に化けて**いました。両辺に同じ変換がかかるためマッチング自体は壊れていませんでしたが、表示が誤るので単語境界付き（`\bg\.`）に修正しています。

## 検証

- `go test -tags test ./...` 全パッケージ通過 / `golangci-lint` 0 issues
- **6タグ Worker ビルド全通過**（push 前ローカル、#5215 の教訓）
- 置換は件数不一致で中断

残りの 3〜4 帯（約43クラスタ・-900行）は続けて別 PR で進めます。

Refs #5185