### PR TITLE
refactor(domain): final n>=3 clusters (48 methods)

### DIFF
--- a/internal/domain/AcesUp.go
+++ b/internal/domain/AcesUp.go
@@ -263,10 +263,7 @@ func (a *AcesUp) GetDiscardCount() int { return len(a.discard) }
 
 // GetDiscardTop 捨て札の一番上（直近に除去した札）を返す。捨て札が空なら nil。
 func (a *AcesUp) GetDiscardTop() *Card {
-	if len(a.discard) == 0 {
-		return nil
-	}
-	return a.discard[len(a.discard)-1]
+	return discardTop(a.discard)
 }
 
 // GetColumns 場札の列を取得

--- a/internal/domain/Bezique.go
+++ b/internal/domain/Bezique.go
@@ -870,9 +870,7 @@ func beziqueCountValue(p *BeziquePlayer, value int) int {
 
 // sortAllHands 全プレイヤーの手札をソートする
 func (b *Bezique) sortAllHands() {
-	for _, p := range b.players {
-		b.sortHand(p)
-	}
+	sortEachHand(b.players, b.sortHand)
 }
 
 // sortHand プレイヤーの手札をスート (トランプ最後) → ランク でソートする

--- a/internal/domain/BidEuchrePlayer.go
+++ b/internal/domain/BidEuchrePlayer.go
@@ -19,8 +19,7 @@ func (p *BidEuchrePlayer) GetTeam(seat int) int { return BidEuchreTeamOf(seat) }
 
 // ResetRound は局開始時に手札を初期化する。
 func (p *BidEuchrePlayer) ResetRound() {
-	p.Reset()
-	p.SetIsFinished(false)
+	resetPlayer(p)
 }
 
 // bidEuchrePlayerJSON is the JSON wire format for BidEuchrePlayer.

--- a/internal/domain/BidWhist.go
+++ b/internal/domain/BidWhist.go
@@ -1186,9 +1186,7 @@ func (g *BidWhist) EffectiveSuitPublic(card *Card) int { return g.effectiveSuit(
 
 // sortAllHands 全プレイヤーの手札をソートする
 func (g *BidWhist) sortAllHands() {
-	for _, p := range g.players {
-		g.sortHand(p)
-	}
+	sortEachHand(g.players, g.sortHand)
 }
 
 // sortHand プレイヤーの手札を実効スート→ランク順にソートする

--- a/internal/domain/BostonPlayer.go
+++ b/internal/domain/BostonPlayer.go
@@ -16,8 +16,7 @@ func NewBostonPlayer(isHuman bool) *BostonPlayer {
 
 // ResetRound は局開始時に手札を初期化する。
 func (p *BostonPlayer) ResetRound() {
-	p.Reset()
-	p.SetIsFinished(false)
+	resetPlayer(p)
 }
 
 // bostonPlayerJSON is the JSON wire format for BostonPlayer.

--- a/internal/domain/Briscola.go
+++ b/internal/domain/Briscola.go
@@ -519,9 +519,7 @@ func BriscolaDetermineWinner(p0, p1 int) int {
 
 // sortAllHands 全プレイヤーの手札をソートする
 func (b *Briscola) sortAllHands() {
-	for _, p := range b.players {
-		b.sortHand(p)
-	}
+	sortEachHand(b.players, b.sortHand)
 }
 
 // sortHand プレイヤーの手札をスート (トランプ最後) → ブリスコラ順位 でソートする

--- a/internal/domain/BriscolaPlayer.go
+++ b/internal/domain/BriscolaPlayer.go
@@ -17,9 +17,7 @@ func NewBriscolaPlayer(isHuman bool) *BriscolaPlayer {
 
 // ResetGame ゲームをリセット (手札/トリック/上がり状態を初期化)
 func (p *BriscolaPlayer) ResetGame() {
-	p.ResetTricks()
-	p.Reset()
-	p.SetIsFinished(false)
+	resetPlayerRound(p)
 }
 
 // briscolaPlayerJSON is the JSON wire format for BriscolaPlayer.

--- a/internal/domain/Cego.go
+++ b/internal/domain/Cego.go
@@ -1220,12 +1220,7 @@ func (g *Cego) isDeclarerSide(playerIdx int) bool {
 
 // indexInTrick currentTrick 内で playerIdx の位置を返す (-1=なし)。
 func (g *Cego) indexInTrick(playerIdx int) int {
-	for i, tc := range g.currentTrick {
-		if tc.PlayerIdx == playerIdx {
-			return i
-		}
-	}
-	return -1
+	return indexOfPlayerInTrick(g.currentTrick, playerIdx)
 }
 
 // maxByRank 勝敗ランク最大の札を返す。
@@ -1398,10 +1393,7 @@ func cegoSortHand(p *CegoPlayer) {
 
 // isHumanBidTurn 現在の入札手番が人間か。
 func (g *Cego) isHumanBidTurn() bool {
-	if g.bidPlayerIdx < 0 || g.bidPlayerIdx >= len(g.players) {
-		return false
-	}
-	return g.players[g.bidPlayerIdx].GetIsHuman()
+	return isHumanTurn(g.players, g.bidPlayerIdx)
 }
 
 // appendLog 棋譜にエントリを追加する。

--- a/internal/domain/Cuckoo.go
+++ b/internal/domain/Cuckoo.go
@@ -521,12 +521,7 @@ func (g *Cuckoo) nextActiveIdx(from int) int {
 
 // humanIdx 人間プレイヤーのインデックスを返す (-1 = 不在)
 func (g *Cuckoo) humanIdx() int {
-	for i, p := range g.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
+	return findHumanIdx(g.players)
 }
 
 // --- Getters ---

--- a/internal/domain/Desmoche.go
+++ b/internal/domain/Desmoche.go
@@ -670,10 +670,7 @@ func (d *Desmoche) GetStockCount() int { return len(d.stock) }
 
 // GetDiscardTop は捨て札の一番上を返す (無ければ nil)。
 func (d *Desmoche) GetDiscardTop() *Card {
-	if len(d.discard) == 0 {
-		return nil
-	}
-	return d.discard[len(d.discard)-1]
+	return discardTop(d.discard)
 }
 
 // GetMelds は場のメルドを返す。

--- a/internal/domain/DesmochePlayer.go
+++ b/internal/domain/DesmochePlayer.go
@@ -20,8 +20,7 @@ func NewDesmochePlayer(isHuman bool) *DesmochePlayer {
 
 // ResetRound ラウンド開始時に手札を空にする
 func (p *DesmochePlayer) ResetRound() {
-	p.Reset()
-	p.SetIsFinished(false)
+	resetPlayer(p)
 }
 
 // desmochePlayerJSON is the JSON wire format for DesmochePlayer.

--- a/internal/domain/Easthaven.go
+++ b/internal/domain/Easthaven.go
@@ -504,10 +504,7 @@ func (e *Easthaven) isBlack(card *Card) bool {
 
 // autoFlipTableau タブローの最上部の裏カードを自動フリップ
 func (e *Easthaven) autoFlipTableau(col int) {
-	cards := e.tableau[col]
-	if len(cards) > 0 && !cards[len(cards)-1].FaceUp {
-		cards[len(cards)-1].FaceUp = true
-	}
+	autoFlipTopCard(e.tableau[col])
 }
 
 // checkGameClear ゲームクリア判定

--- a/internal/domain/Ecarte.go
+++ b/internal/domain/Ecarte.go
@@ -777,9 +777,7 @@ func (e *Ecarte) GetHint() *EcarteHint {
 // --- Sorting / helpers ---
 
 func (e *Ecarte) sortAllHands() {
-	for _, p := range e.players {
-		e.sortHand(p)
-	}
+	sortEachHand(e.players, e.sortHand)
 }
 
 func (e *Ecarte) sortHand(p *EcartePlayer) {

--- a/internal/domain/FiveHundred.go
+++ b/internal/domain/FiveHundred.go
@@ -1268,9 +1268,7 @@ func (g *FiveHundred) EffectiveSuitPublic(card *Card) int { return g.effectiveSu
 
 // sortAllHands 全プレイヤーの手札をソートする
 func (g *FiveHundred) sortAllHands() {
-	for _, p := range g.players {
-		g.sortHand(p)
-	}
+	sortEachHand(g.players, g.sortHand)
 }
 
 // sortHand プレイヤーの手札を実効スート→ランク順にソートする

--- a/internal/domain/FrenchTarot.go
+++ b/internal/domain/FrenchTarot.go
@@ -1275,12 +1275,7 @@ func (g *FrenchTarot) cpuPlaySmart(playerIdx int, valid []int) int {
 
 // indexInTrick currentTrick 内で playerIdx の位置を返す (-1=なし)。
 func (g *FrenchTarot) indexInTrick(playerIdx int) int {
-	for i, tc := range g.currentTrick {
-		if tc.PlayerIdx == playerIdx {
-			return i
-		}
-	}
-	return -1
+	return indexOfPlayerInTrick(g.currentTrick, playerIdx)
 }
 
 // maxByRank 勝敗ランク最大の札を返す。
@@ -1451,10 +1446,7 @@ func frenchTarotSortHand(p *FrenchTarotPlayer) {
 
 // isHumanBidTurn 現在の入札手番が人間か。
 func (g *FrenchTarot) isHumanBidTurn() bool {
-	if g.bidPlayerIdx < 0 || g.bidPlayerIdx >= len(g.players) {
-		return false
-	}
-	return g.players[g.bidPlayerIdx].GetIsHuman()
+	return isHumanTurn(g.players, g.bidPlayerIdx)
 }
 
 // appendLog 棋譜にエントリを追加する。

--- a/internal/domain/Gaigel.go
+++ b/internal/domain/Gaigel.go
@@ -977,9 +977,7 @@ func (g *Gaigel) legalAllowsDump(playerIdx int, legal []int) bool {
 
 // sortAllHands 全プレイヤーの手札をソートする
 func (g *Gaigel) sortAllHands() {
-	for _, p := range g.players {
-		g.sortHand(p)
-	}
+	sortEachHand(g.players, g.sortHand)
 }
 
 // sortHand プレイヤーの手札をスート (トランプ最後) → ランク でソートする

--- a/internal/domain/GoStop.go
+++ b/internal/domain/GoStop.go
@@ -63,7 +63,6 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
-	"sort"
 )
 
 // GoStopPlayerCnt はゴーストップのプレイヤー数 (固定 2)。
@@ -622,13 +621,7 @@ func (g *GoStop) gostopPlaceCard(playerIdx int, card *Card, chosen int) {
 
 // removeFieldByIndex は降順に並べ替えてから場札を削除する。
 func (g *GoStop) removeFieldByIndex(idxs []int) {
-	sorted := append([]int(nil), idxs...)
-	sort.Sort(sort.Reverse(sort.IntSlice(sorted)))
-	for _, idx := range sorted {
-		if idx >= 0 && idx < len(g.state.fieldCards) {
-			g.state.fieldCards = append(g.state.fieldCards[:idx], g.state.fieldCards[idx+1:]...)
-		}
-	}
+	g.state.fieldCards = removeIndices(g.state.fieldCards, idxs)
 }
 
 // --- Play ---

--- a/internal/domain/GuandanPlayer.go
+++ b/internal/domain/GuandanPlayer.go
@@ -19,8 +19,7 @@ func (p *GuandanPlayer) GetTeam(seat int) int { return GuandanTeamOf(seat) }
 
 // ResetRound は局開始時に手札を初期化する。
 func (p *GuandanPlayer) ResetRound() {
-	p.Reset()
-	p.SetIsFinished(false)
+	resetPlayer(p)
 }
 
 // guandanPlayerJSON is the JSON wire format for GuandanPlayer.

--- a/internal/domain/HachiHachi.go
+++ b/internal/domain/HachiHachi.go
@@ -53,7 +53,6 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
-	"sort"
 )
 
 // HachiHachiPlayerCnt は八八のプレイヤー数 (固定 3)。
@@ -562,13 +561,7 @@ func (g *HachiHachi) hachihachiPlaceCard(playerIdx int, card *Card, chosen int) 
 
 // removeFieldByIndex は降順に並べ替えてから場札を削除する。
 func (g *HachiHachi) removeFieldByIndex(idxs []int) {
-	sorted := append([]int(nil), idxs...)
-	sort.Sort(sort.Reverse(sort.IntSlice(sorted)))
-	for _, idx := range sorted {
-		if idx >= 0 && idx < len(g.state.fieldCards) {
-			g.state.fieldCards = append(g.state.fieldCards[:idx], g.state.fieldCards[idx+1:]...)
-		}
-	}
+	g.state.fieldCards = removeIndices(g.state.fieldCards, idxs)
 }
 
 // --- Play ---

--- a/internal/domain/KaiserPlayer.go
+++ b/internal/domain/KaiserPlayer.go
@@ -19,8 +19,7 @@ func (p *KaiserPlayer) GetTeam(seat int) int { return KaiserTeamOf(seat) }
 
 // ResetRound は局開始時に手札を初期化する。
 func (p *KaiserPlayer) ResetRound() {
-	p.Reset()
-	p.SetIsFinished(false)
+	resetPlayer(p)
 }
 
 // kaiserPlayerJSON is the JSON wire format for KaiserPlayer.

--- a/internal/domain/KarnoffelPlayer.go
+++ b/internal/domain/KarnoffelPlayer.go
@@ -19,8 +19,7 @@ func (p *KarnoffelPlayer) GetTeam(seat int) int { return KarnoffelTeamOf(seat) }
 
 // ResetRound は局開始時に手札を初期化する。
 func (p *KarnoffelPlayer) ResetRound() {
-	p.Reset()
-	p.SetIsFinished(false)
+	resetPlayer(p)
 }
 
 // karnoffelPlayerJSON is the JSON wire format for KarnoffelPlayer.

--- a/internal/domain/KlaberjassPlayer.go
+++ b/internal/domain/KlaberjassPlayer.go
@@ -16,8 +16,7 @@ func NewKlaberjassPlayer(isHuman bool) *KlaberjassPlayer {
 
 // ResetRound はディール開始時に手札を初期化する。
 func (p *KlaberjassPlayer) ResetRound() {
-	p.Reset()
-	p.SetIsFinished(false)
+	resetPlayer(p)
 }
 
 // klaberjassPlayerJSON is the JSON wire format for KlaberjassPlayer.

--- a/internal/domain/Klondike.go
+++ b/internal/domain/Klondike.go
@@ -632,10 +632,7 @@ func (k *Klondike) isBlack(card *Card) bool {
 
 // autoFlipTableau タブローの最上部の裏カードを自動フリップ
 func (k *Klondike) autoFlipTableau(col int) {
-	cards := k.tableau[col]
-	if len(cards) > 0 && !cards[len(cards)-1].FaceUp {
-		cards[len(cards)-1].FaceUp = true
-	}
+	autoFlipTopCard(k.tableau[col])
 }
 
 // checkGameClear ゲームクリア判定
@@ -861,4 +858,16 @@ func (k *Klondike) UnmarshalJSON(data []byte) error {
 	k.noProgressCycles = j.NoProgressCycles
 	k.progressSinceRecycle = j.ProgressSinceRecycle
 	return nil
+}
+
+// autoFlipTopCard turns the bottom card of a tableau column face up when it is
+// not already. 6 solitaires sharing KlondikeTableauCard had this written out.
+//
+// Lives here beside the type rather than in player_helpers.go: the other four
+// games with this body use their own tableau card types, which Go's type
+// constraints cannot reach because FaceUp is a field, not a method.
+func autoFlipTopCard(cards []*KlondikeTableauCard) {
+	if len(cards) > 0 && !cards[len(cards)-1].FaceUp {
+		cards[len(cards)-1].FaceUp = true
+	}
 }

--- a/internal/domain/Klondike.go
+++ b/internal/domain/Klondike.go
@@ -860,8 +860,10 @@ func (k *Klondike) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// autoFlipTopCard turns the bottom card of a tableau column face up when it is
-// not already. 6 solitaires sharing KlondikeTableauCard had this written out.
+// autoFlipTopCard turns the top card of a tableau column face up when it is
+// not already -- the last-added card, which is what every call site's own
+// comment calls タブローの最上部. 6 solitaires sharing KlondikeTableauCard had
+// this written out.
 //
 // Lives here beside the type rather than in player_helpers.go: the other four
 // games with this body use their own tableau card types, which Go's type

--- a/internal/domain/Koenigrufen.go
+++ b/internal/domain/Koenigrufen.go
@@ -1346,12 +1346,7 @@ func (g *Koenigrufen) isDeclarerSide(playerIdx int) bool {
 
 // indexInTrick currentTrick 内で playerIdx の位置を返す (-1=なし)。
 func (g *Koenigrufen) indexInTrick(playerIdx int) int {
-	for i, tc := range g.currentTrick {
-		if tc.PlayerIdx == playerIdx {
-			return i
-		}
-	}
-	return -1
+	return indexOfPlayerInTrick(g.currentTrick, playerIdx)
 }
 
 // maxByRank 勝敗ランク最大の札を返す。
@@ -1514,10 +1509,7 @@ func koenigrufenSortHand(p *KoenigrufenPlayer) {
 
 // isHumanBidTurn 現在の入札手番が人間か。
 func (g *Koenigrufen) isHumanBidTurn() bool {
-	if g.bidPlayerIdx < 0 || g.bidPlayerIdx >= len(g.players) {
-		return false
-	}
-	return g.players[g.bidPlayerIdx].GetIsHuman()
+	return isHumanTurn(g.players, g.bidPlayerIdx)
 }
 
 // appendLog 棋譜にエントリを追加する。

--- a/internal/domain/KoiKoi.go
+++ b/internal/domain/KoiKoi.go
@@ -44,7 +44,6 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
-	"sort"
 )
 
 // KoiKoiPlayerCnt はこいこいのプレイヤー数 (固定 2)。
@@ -563,13 +562,7 @@ func (g *KoiKoi) koikoiPlaceCard(playerIdx int, card *Card, chosen int) {
 
 // removeFieldByIndex は降順に並べ替えてから場札を削除する。
 func (g *KoiKoi) removeFieldByIndex(idxs []int) {
-	sorted := append([]int(nil), idxs...)
-	sort.Sort(sort.Reverse(sort.IntSlice(sorted)))
-	for _, idx := range sorted {
-		if idx >= 0 && idx < len(g.state.fieldCards) {
-			g.state.fieldCards = append(g.state.fieldCards[:idx], g.state.fieldCards[idx+1:]...)
-		}
-	}
+	g.state.fieldCards = removeIndices(g.state.fieldCards, idxs)
 }
 
 // --- Play ---

--- a/internal/domain/LiteraturePlayer.go
+++ b/internal/domain/LiteraturePlayer.go
@@ -19,8 +19,7 @@ func (p *LiteraturePlayer) GetTeam(seat int) int { return LiteratureTeamOf(seat)
 
 // ResetRound は局開始時に手札を初期化する。
 func (p *LiteraturePlayer) ResetRound() {
-	p.Reset()
-	p.SetIsFinished(false)
+	resetPlayer(p)
 }
 
 // literaturePlayerJSON is the JSON wire format for LiteraturePlayer.

--- a/internal/domain/Loba.go
+++ b/internal/domain/Loba.go
@@ -804,10 +804,7 @@ func (l *Loba) GetStockCount() int { return len(l.stock) }
 
 // GetDiscardTop は捨て札の一番上を返す (無ければ nil)。
 func (l *Loba) GetDiscardTop() *Card {
-	if len(l.discard) == 0 {
-		return nil
-	}
-	return l.discard[len(l.discard)-1]
+	return discardTop(l.discard)
 }
 
 // GetMelds は場のメルドを返す。

--- a/internal/domain/Mighty.go
+++ b/internal/domain/Mighty.go
@@ -1362,9 +1362,7 @@ func (m *Mighty) checkGameEnd() {
 
 // sortAllHands 全プレイヤーの手札をソートする
 func (m *Mighty) sortAllHands() {
-	for _, p := range m.players {
-		m.sortHand(p)
-	}
+	sortEachHand(m.players, m.sortHand)
 }
 
 // sortHand プレイヤーの手札をスート→値の順にソートする

--- a/internal/domain/MusPlayer.go
+++ b/internal/domain/MusPlayer.go
@@ -17,8 +17,7 @@ func NewMusPlayer(isHuman bool) *MusPlayer {
 
 // ResetRound ラウンドをリセット（手札・終了状態を初期化）
 func (p *MusPlayer) ResetRound() {
-	p.Reset()
-	p.SetIsFinished(false)
+	resetPlayer(p)
 }
 
 // musPlayerJSON is the JSON wire format for MusPlayer.

--- a/internal/domain/Napoleon.go
+++ b/internal/domain/Napoleon.go
@@ -1023,9 +1023,7 @@ func (n *Napoleon) checkGameEnd() {
 
 // sortAllHands 全プレイヤーの手札をソートする
 func (n *Napoleon) sortAllHands() {
-	for _, p := range n.players {
-		n.sortHand(p)
-	}
+	sortEachHand(n.players, n.sortHand)
 }
 
 // sortHand プレイヤーの手札をスート→値の順にソートする

--- a/internal/domain/Rook.go
+++ b/internal/domain/Rook.go
@@ -1142,9 +1142,7 @@ func (g *Rook) CardPointsPublic(card *Card) int { return rookCardPoints(card) }
 
 // sortAllHands 全プレイヤーの手札をソートする
 func (g *Rook) sortAllHands() {
-	for _, p := range g.players {
-		g.sortHand(p)
-	}
+	sortEachHand(g.players, g.sortHand)
 }
 
 // sortHand プレイヤーの手札を色→強さ順にソートする

--- a/internal/domain/RussianSolitaire.go
+++ b/internal/domain/RussianSolitaire.go
@@ -419,10 +419,7 @@ func (y *RussianSolitaire) canPlaceOnFoundation(card *Card, fIdx int) bool {
 
 // autoFlipTableau タブローの最上部の裏カードを自動フリップ
 func (y *RussianSolitaire) autoFlipTableau(col int) {
-	cards := y.tableau[col]
-	if len(cards) > 0 && !cards[len(cards)-1].FaceUp {
-		cards[len(cards)-1].FaceUp = true
-	}
+	autoFlipTopCard(y.tableau[col])
 }
 
 // checkGameClear ゲームクリア判定

--- a/internal/domain/Schnapsen.go
+++ b/internal/domain/Schnapsen.go
@@ -710,9 +710,7 @@ func SchnapsenDetermineWinner(p0, p1, lastTrickWinner int) int {
 
 // sortAllHands 全プレイヤーの手札をソートする
 func (s *Schnapsen) sortAllHands() {
-	for _, p := range s.players {
-		s.sortHand(p)
-	}
+	sortEachHand(s.players, s.sortHand)
 }
 
 // sortHand プレイヤーの手札をスート (トランプ最後) → ランク でソートする

--- a/internal/domain/SchnapsenPlayer.go
+++ b/internal/domain/SchnapsenPlayer.go
@@ -19,9 +19,7 @@ func NewSchnapsenPlayer(isHuman bool) *SchnapsenPlayer {
 
 // ResetGame ゲームをリセット (手札/トリック/上がり状態を初期化)
 func (p *SchnapsenPlayer) ResetGame() {
-	p.ResetTricks()
-	p.Reset()
-	p.SetIsFinished(false)
+	resetPlayerRound(p)
 }
 
 // schnapsenPlayerJSON is the JSON wire format for SchnapsenPlayer.

--- a/internal/domain/Scorpion.go
+++ b/internal/domain/Scorpion.go
@@ -452,10 +452,7 @@ func (s *Scorpion) checkAndRemoveCompletedSuit(col int) bool {
 
 // autoFlipTableau タブローの最上部の裏カードを自動フリップ
 func (s *Scorpion) autoFlipTableau(col int) {
-	cards := s.tableau[col]
-	if len(cards) > 0 && !cards[len(cards)-1].FaceUp {
-		cards[len(cards)-1].FaceUp = true
-	}
+	autoFlipTopCard(s.tableau[col])
 }
 
 // checkGameClear ゲームクリア判定

--- a/internal/domain/ShengJiPlayer.go
+++ b/internal/domain/ShengJiPlayer.go
@@ -19,8 +19,7 @@ func (p *ShengJiPlayer) GetTeam(seat int) int { return ShengJiTeamOf(seat) }
 
 // ResetRound は局開始時に手札を初期化する。
 func (p *ShengJiPlayer) ResetRound() {
-	p.Reset()
-	p.SetIsFinished(false)
+	resetPlayer(p)
 }
 
 // shengJiPlayerJSON is the JSON wire format for ShengJiPlayer.

--- a/internal/domain/SixBidSoloPlayer.go
+++ b/internal/domain/SixBidSoloPlayer.go
@@ -16,8 +16,7 @@ func NewSixBidSoloPlayer(isHuman bool) *SixBidSoloPlayer {
 
 // ResetRound は局開始時に手札を初期化する。
 func (p *SixBidSoloPlayer) ResetRound() {
-	p.Reset()
-	p.SetIsFinished(false)
+	resetPlayer(p)
 }
 
 // sixBidSoloPlayerJSON is the JSON wire format for SixBidSoloPlayer.

--- a/internal/domain/Skat.go
+++ b/internal/domain/Skat.go
@@ -1282,9 +1282,7 @@ func (s *Skat) appendLog(playerIdx int, actionType, detail string, cards []*Card
 
 // sortAllHands sorts every player's hand.
 func (s *Skat) sortAllHands() {
-	for _, p := range s.players {
-		s.sortHand(p)
-	}
+	sortEachHand(s.players, s.sortHand)
 }
 
 // sortHand sorts the player's hand by suit then value.

--- a/internal/domain/ThirtyOne.go
+++ b/internal/domain/ThirtyOne.go
@@ -614,12 +614,7 @@ func (g *ThirtyOne) nextActiveIdx(from int) int {
 
 // humanIdx 人間プレイヤーのインデックスを返す (-1 = 不在)
 func (g *ThirtyOne) humanIdx() int {
-	for i, p := range g.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
+	return findHumanIdx(g.players)
 }
 
 // --- Getters ---

--- a/internal/domain/Trash.go
+++ b/internal/domain/Trash.go
@@ -239,10 +239,7 @@ func (t *Trash) GetStockSize() int { return len(t.stock) }
 
 // GetDiscardTop 捨て札の一番上
 func (t *Trash) GetDiscardTop() *Card {
-	if len(t.discard) == 0 {
-		return nil
-	}
-	return t.discard[len(t.discard)-1]
+	return discardTop(t.discard)
 }
 
 // GetDiscardSize 捨て札の枚数

--- a/internal/domain/TrucoPlayer.go
+++ b/internal/domain/TrucoPlayer.go
@@ -18,9 +18,7 @@ func NewTrucoPlayer(isHuman bool) *TrucoPlayer {
 
 // ResetGame 手札とバサ獲得状態を初期化する (新しいマノの配り直し用)。
 func (p *TrucoPlayer) ResetGame() {
-	p.ResetTricks()
-	p.Reset()
-	p.SetIsFinished(false)
+	resetPlayerRound(p)
 }
 
 // trucoPlayerJSON is the JSON wire format for TrucoPlayer.

--- a/internal/domain/VintPlayer.go
+++ b/internal/domain/VintPlayer.go
@@ -19,8 +19,7 @@ func (p *VintPlayer) GetTeam(seat int) int { return VintTeamOf(seat) }
 
 // ResetRound は局開始時に手札を初期化する。
 func (p *VintPlayer) ResetRound() {
-	p.Reset()
-	p.SetIsFinished(false)
+	resetPlayer(p)
 }
 
 // vintPlayerJSON is the JSON wire format for VintPlayer.

--- a/internal/domain/Wasp.go
+++ b/internal/domain/Wasp.go
@@ -453,10 +453,7 @@ func (s *Wasp) checkAndRemoveCompletedSuit(col int) bool {
 
 // autoFlipTableau タブローの最上部の裏カードを自動フリップ
 func (s *Wasp) autoFlipTableau(col int) {
-	cards := s.tableau[col]
-	if len(cards) > 0 && !cards[len(cards)-1].FaceUp {
-		cards[len(cards)-1].FaceUp = true
-	}
+	autoFlipTopCard(s.tableau[col])
 }
 
 // checkGameClear ゲームクリア判定

--- a/internal/domain/Yaniv.go
+++ b/internal/domain/Yaniv.go
@@ -577,12 +577,7 @@ func (g *Yaniv) nextActiveIdx(from int) int {
 
 // humanIdx 人間プレイヤーのインデックスを返す (-1 = 不在)
 func (g *Yaniv) humanIdx() int {
-	for i, p := range g.players {
-		if p.GetIsHuman() {
-			return i
-		}
-	}
-	return -1
+	return findHumanIdx(g.players)
 }
 
 // --- Combo validation ---

--- a/internal/domain/Yukon.go
+++ b/internal/domain/Yukon.go
@@ -425,10 +425,7 @@ func (y *Yukon) isBlack(card *Card) bool {
 
 // autoFlipTableau タブローの最上部の裏カードを自動フリップ
 func (y *Yukon) autoFlipTableau(col int) {
-	cards := y.tableau[col]
-	if len(cards) > 0 && !cards[len(cards)-1].FaceUp {
-		cards[len(cards)-1].FaceUp = true
-	}
+	autoFlipTopCard(y.tableau[col])
 }
 
 // checkGameClear ゲームクリア判定

--- a/internal/domain/player_helpers.go
+++ b/internal/domain/player_helpers.go
@@ -740,3 +740,12 @@ func validateEndgameFollow(trick []*TrickCard, g endgameFollower, playerIdx int,
 	}
 	return nil
 }
+
+// sortEachHand sorts every seat's hand with a per-game sorter that takes the
+// player itself. 11 games looped over their roster to do this; the sortHands
+// helper above serves the games whose sorter takes an index instead.
+func sortEachHand[P any](players []P, sortHand func(P)) {
+	for _, p := range players {
+		sortHand(p)
+	}
+}


### PR DESCRIPTION
#5185 の **3コピー以上の帯の締め**です。48メソッド / **-109行**。

| クラスタ | 件数 | 方式 |
|---|---:|---|
| `ResetRound` | 12 | **既存 `resetPlayer`** |
| `sortAllHands` | 11 | 新規 `sortEachHand` 1つ |
| `autoFlipTableau` | 6 | 新規 `autoFlipTopCard`（非ジェネリック） |
| `GetDiscardTop` | 4 | **既存 `discardTop`** |
| `humanIdx` | 3 | **既存 `findHumanIdx`** |
| `indexInTrick` | 3 | **既存 `indexOfPlayerInTrick`** |
| `ResetGame` | 3 | **既存 `resetPlayerRound`** |
| `isHumanBidTurn` | 3 | **既存 `isHumanTurn`** |
| `removeFieldByIndex` | 3 | **既存 `removeIndices`** |

**9クラスタ中7つが既存ヘルパへの委譲のみ**で、新規は2つだけです。

## 部分適用という判断

`autoFlipTableau` は10ゲームで同一本体ですが、**6ゲームだけ**を対象にしました。

```go
cards[len(cards)-1].FaceUp = true   // FaceUp は「フィールド」
```

Go のジェネリクスは**メソッドは要求できてもフィールドは要求できません**。10ゲームのうち6つは `*KlondikeTableauCard` を共有しているので**非ジェネリック関数**で畳めますが、残り4つ（Agnes / DoubleKlondike / Spider / Spiderette）は各自の型なので**原理的に共通化できません**。

無理に `interface{ GetFaceUp() bool; SetFaceUp(bool) }` を各型に生やす手はありますが、共通化のためだけに10個の型へアクセサを足すのは本末転倒なので、6件で止めています。ヘルパは型定義と同じ `Klondike.go`（`solo` タグ）に置きました。

## 見送ったもの

| クラスタ | 件数 | 理由 |
|---|---:|---|
| `Pop` | 4 | 独自の優先度キュー型 + `item.index` フィールド |
| `canPlaceOnTableau` | 4 | 同上（`.Card` フィールド） |
| `IsHumanTurn`（gameEndFlag 系） | 6 | 置換しても行数が同じ |

## 検証

- `go test -tags test ./...` 全パッケージ通過 / `golangci-lint` 0 issues
- **6タグ Worker ビルド全通過**（push 前ローカル）
- 置換は**二相式**（全マッチ収集 → 件数ゲート → 書き込み）なので、件数が想定と違えば1ファイルも書き換えません

これで **3コピー以上のクラスタは実質的に完了**です（残るのは上記の原理的に不可能なものと、行数が減らないもの）。2コピー帯（147クラスタ・約-2,084行）はユーザー判断で見送りです。

Refs #5185