### PR TITLE
fix(cli): colour stderr errors, making --color=auto per-stream real

### DIFF
--- a/internal/color/color.go
+++ b/internal/color/color.go
@@ -44,6 +44,15 @@ func wrap(code, s string, off bool) string {
 	return code + s + reset
 }
 
+// RedStderr wraps s with red ANSI color code, honouring the stderr color
+// setting rather than the stdout one.
+//
+// stderr has its own setting because a run can have one stream on a terminal
+// and the other redirected; `--color=auto` detects each independently. This is
+// the only stderr-targeted colour the CLI needs -- errors routed to stderr by
+// printResult. See issue #5194.
+func RedStderr(s string) string { return wrap("\033[31m", s, noColorStderr.Load()) }
+
 // Red wraps s with red ANSI color code (stdout-targeted).
 func Red(s string) string { return wrap("\033[31m", s, noColorStdout.Load()) }
 

--- a/internal/color/color_test.go
+++ b/internal/color/color_test.go
@@ -131,3 +131,48 @@ func TestStdoutColorFuncsIgnoreStderrFlag(t *testing.T) {
 		t.Errorf("Red should follow stdout flag (off); got %q", got)
 	}
 }
+
+// RedStderr must follow the stderr setting, not the stdout one: a run can have
+// stdout piped and stderr on a terminal, which is what --color=auto detects per
+// stream. Both directions are covered -- a test that only checked "plain when
+// disabled" would pass for a function that never colours, and one that only
+// checked "coloured when enabled" would pass for one that always does.
+func TestRedStderrFollowsTheStderrSetting(t *testing.T) {
+	resetColorState(t)
+
+	SetStderrColor(true)
+	if got, want := RedStderr("boom"), "\033[31mboom"+reset; got != want {
+		t.Errorf("with stderr colour on: RedStderr() = %q, want %q", got, want)
+	}
+
+	SetStderrColor(false)
+	if got := RedStderr("boom"); got != "boom" {
+		t.Errorf("with stderr colour off: RedStderr() = %q, want %q", got, "boom")
+	}
+}
+
+// The streams are independent: silencing stdout must not silence stderr. That
+// independence is the whole point of the per-stream detection, and it was
+// unobservable in production until this function existed (#5194).
+func TestRedStderrIsIndependentOfStdout(t *testing.T) {
+	resetColorState(t)
+
+	SetStdoutColor(false)
+	SetStderrColor(true)
+
+	if got := Red("boom"); got != "boom" {
+		t.Errorf("stdout should be plain: Red() = %q", got)
+	}
+	if got, want := RedStderr("boom"), "\033[31mboom"+reset; got != want {
+		t.Errorf("stderr should still be coloured: RedStderr() = %q, want %q", got, want)
+	}
+}
+
+func TestRedStderrLeavesAnEmptyStringAlone(t *testing.T) {
+	resetColorState(t)
+
+	SetStderrColor(true)
+	if got := RedStderr(""); got != "" {
+		t.Errorf("RedStderr(%q) = %q, want no escape codes", "", got)
+	}
+}

--- a/internal/infrastructure/ui/cui_runner.go
+++ b/internal/infrastructure/ui/cui_runner.go
@@ -9,6 +9,7 @@ import (
 	"syscall"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
@@ -220,7 +221,7 @@ func RunInteractiveCuiLoop(manager *GameManager) int {
 // printResult writes res to stdout, or to stderr when marked as an error.
 func printResult(res string) {
 	if body, isErr := i18n.StripErrorPrefix(res); isErr {
-		fmt.Fprintln(os.Stderr, body)
+		fmt.Fprintln(os.Stderr, color.RedStderr(body))
 		return
 	}
 	fmt.Println(res)

--- a/internal/infrastructure/ui/cui_runner_test.go
+++ b/internal/infrastructure/ui/cui_runner_test.go
@@ -1,8 +1,14 @@
 package ui
 
 import (
+	"bytes"
+	"os"
+	"strings"
 	"syscall"
 	"testing"
+
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 // closeSpyReader is a LineReader whose Close records that it ran, so tests can
@@ -58,5 +64,62 @@ func TestRunSignalWatcher_NormalExitDoesNotRunCleanup(t *testing.T) {
 	stop()
 	if reader.closed != 0 {
 		t.Errorf("cleanup ran on normal exit (%d times); it should only run on a signal", reader.closed)
+	}
+}
+
+// captureStderr runs fn with os.Stderr redirected and returns what it wrote.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	orig := os.Stderr
+	os.Stderr = w
+	defer func() { os.Stderr = orig }()
+
+	fn()
+	_ = w.Close()
+
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	return buf.String()
+}
+
+// printResult must actually apply the stderr colour. The colour package's own
+// tests prove RedStderr colours; only this proves printResult calls it, which
+// is the wiring that was missing entirely (#5194).
+func TestPrintResult_ColoursErrorsOnStderr(t *testing.T) {
+	origStderr := color.NoColorStderr()
+	t.Cleanup(func() { color.SetStderrColor(!origStderr) })
+
+	color.SetStderrColor(true)
+	got := captureStderr(t, func() { printResult(i18n.MarkError("bad command")) })
+
+	if !strings.Contains(got, "\033[31m") {
+		t.Errorf("stderr output should carry the red escape code, got %q", got)
+	}
+	if !strings.Contains(got, "bad command") {
+		t.Errorf("stderr output should contain the message, got %q", got)
+	}
+}
+
+// With colour disabled the same path must emit no escape codes at all -- the
+// other half of the gate, so neither "always plain" nor "always coloured" can
+// pass unnoticed.
+func TestPrintResult_PlainErrorsWhenColourDisabled(t *testing.T) {
+	origStderr := color.NoColorStderr()
+	t.Cleanup(func() { color.SetStderrColor(!origStderr) })
+
+	color.SetStderrColor(false)
+	got := captureStderr(t, func() { printResult(i18n.MarkError("bad command")) })
+
+	if strings.Contains(got, "\033[") {
+		t.Errorf("stderr output should carry no escape codes, got %q", got)
+	}
+	if !strings.Contains(got, "bad command") {
+		t.Errorf("stderr output should still contain the message, got %q", got)
 	}
 }


### PR DESCRIPTION
Closes #5194

## 問題

`--help` は `--color=auto` を **per-stream TTY detect** と説明し、`applyColorMode` も stdout / stderr を独立に設定しています。しかし**本番に stderr 側の読み手が存在せず**、`SetStderrColor` は実質 no-op でした。

その背後にある優先順位ロジック（`--color=never` > `--color=always` > `NO_COLOR` > auto）は **#1554 / #4310 / #1583 で3回調整されている**のに、stderr については一切効いていませんでした。

## 対応（issue の案A）

`RedStderr` を復活させ、CUI がエラーを stderr に出す唯一の箇所 `printResult` に配線しました。

```go
if body, isErr := i18n.StripErrorPrefix(res); isErr {
	fmt.Fprintln(os.Stderr, color.RedStderr(body))
	return
}
```

復活させたのは **`RedStderr` 1つだけ**です。#5186 で削除した他4つ（`GreenStderr` / `YellowStderr` / `BoldStderr` / `BoldYellowStderr`）は呼び出し元が無いままなので戻していません。

## 「赤くするとうるさい」懸念は実測で否定されました

issue には「ゲーム内のエラーメッセージは頻出するため画面がうるさくなる可能性」と書きましたが、**`MarkError` の呼び出しは11箇所しかなく、すべて利用者の入力ミス**です。

- `unknownCommand` / `unknownCommandWithSuggestion`（コマンドの打ち間違い）
- `errBetArgs` / `errRank` / `errAmount` / `betInvalid`（引数不正）

つまり**タイプミスしたときだけ**光ります。通常のプレイ中には出ません。標準的な CLI の挙動です。

## 4経路すべて実機確認しました

| 実行 | stderr |
|---|---|
| `--color=always` | `^[[31m…^[[0m` **赤** |
| `--color=never` | プレーン |
| `NO_COLOR=1` | プレーン |
| auto（パイプ = 非TTY） | プレーン |

**`--help` の記述変更は不要**です。「per-stream TTY detect」は今や**事実**になりました（これまでは実装されていない約束でした）。

## テストは2階層 × 両方向

片方だけでは検出できない失敗モードがあるため、両方を置いています。

| 階層 | 何を証明するか |
|---|---|
| `internal/color` | `RedStderr` が**stderr の設定に従う**こと、**stdout とは独立**であること |
| `internal/infrastructure/ui` | `printResult` が**実際にそれを呼んでいる**こと |

色の有無**両方向**を踏んでいます。「無効時にプレーン」だけだと**一度も色を付けない実装**が通り、「有効時に色付き」だけだと**常に色を付ける実装**が通るためです。

**負のコントロール実測済み**: 配線を戻す（ただし**コンパイルは通る形**で）と、runner 側のテストだけが期待どおり落ちます。

```
--- FAIL: TestPrintResult_ColoursErrorsOnStderr
    stderr output should carry the red escape code, got "bad command\n"
```

最初に単純に `color.RedStderr(...)` を外したときは **import が未使用になりビルドが落ちて**、テストが走る前に止まりました。それでは「テストが検出できる」ことの証明にならないので、import を残したまま挙動だけ戻して確認し直しています。

## 検証

- `go test -tags test ./internal/...` 通過 / `golangci-lint` 0 issues
- **6タグ Worker ビルド通過**（`internal/domain` + `internal/color`。`internal/color` は約250の CUI presenter から import され Worker にも入るため）