### PR TITLE
test(docs): guard the per-game manuals against their templates

### DIFF
--- a/docs/documentation-maintenance.md
+++ b/docs/documentation-maintenance.md
@@ -15,6 +15,7 @@
 | Change frontend tooling or scripts | [`frontend/README.md`](../frontend/README.md) (Scripts, Tooling) |
 | Change game rules or game flow logic | `docs/manual/cui/<game>.md` and `docs/manual/web/<game>.md` for the affected game (follow `docs/manual/cui_template.md` / `docs/manual/web_template.md` format) |
 | Add a new game manual | Copy `docs/manual/cui_template.md` → `docs/manual/cui/<game>.md`, `docs/manual/web_template.md` → `docs/manual/web/<game>.md` and fill in game-specific content. Also import in `frontend/src/constants/manualTexts.ts` and add route mapping |
+| Edit any per-game manual | The template structure is enforced by `TestPerGameManualsFollowTemplate` (`internal/infrastructure/games/manual_template_test.go`): H1 exactly `# <ja nav label>（CUI版\|Web版）遊び方`, the required H2s in template order, a Mermaid `flowchart` under `## ゲームの流れ`, the documented launch commands, and (CUI) a three-column command table with `reset`/`quit`/`help`. Run `bun scripts/audit-manual-template.mjs` for a worklist grouped by issue class |
 | Change Go testing policy or mock patterns | Update Testing section in [`CLAUDE.md`](../CLAUDE.md) and [`internal/CLAUDE.md`](../internal/CLAUDE.md) |
 | Make an architectural decision that passes the ADR litmus test (see Workflow section in [`CLAUDE.md`](../CLAUDE.md#workflow--principles)) | Add or update an ADR in [`docs/adr/`](adr/) (written in Japanese) and update the index in [`docs/adr/README.md`](adr/README.md) |
 | Add/modify exported Go symbol | Ensure GoDoc comment (`// SymbolName description`) is present |

--- a/docs/manual/cui_template.md
+++ b/docs/manual/cui_template.md
@@ -4,6 +4,9 @@
 <!-- ＜ゲーム名＞を実際のゲーム名に置き換えてください -->
 <!-- 各セクションのガイドラインに従い、ゲーム固有の内容を記載してください -->
 <!-- ゲーム固有のセクション（例: 特殊ルール）を追加しても構いません -->
+<!-- この構成は internal/infrastructure/games/manual_template_test.go の -->
+<!-- TestPerGameManualsFollowTemplate が検査します。見出し名・順序・Mermaid flowchart・ -->
+<!-- 起動コマンドが合わないと CI が落ちます。worklist は bun scripts/audit-manual-template.mjs -->
 
 ## ゲーム概要
 
@@ -57,4 +60,4 @@ flowchart TD
 
 ## 遊び方のコツ
 
-<!-- 任意セクション。戦略やヒントを箇条書きで記載 -->
+<!-- 任意セクション（ガードは必須にしていません）。戦略やヒントを箇条書きで記載 -->

--- a/docs/manual/web_template.md
+++ b/docs/manual/web_template.md
@@ -4,6 +4,9 @@
 <!-- ＜ゲーム名＞を実際のゲーム名に置き換えてください -->
 <!-- 各セクションのガイドラインに従い、ゲーム固有の内容を記載してください -->
 <!-- ゲーム固有のセクション（例: 特殊ルール）を追加しても構いません -->
+<!-- この構成は internal/infrastructure/games/manual_template_test.go の -->
+<!-- TestPerGameManualsFollowTemplate が検査します。見出し名・順序・Mermaid flowchart・ -->
+<!-- 起動コマンドが合わないと CI が落ちます。worklist は bun scripts/audit-manual-template.mjs -->
 <!-- API仕様は api/openapi.yaml に記載するため、このファイルには含めないこと -->
 
 ## ゲーム概要
@@ -60,4 +63,4 @@ flowchart TD
 
 ## 遊び方のコツ
 
-<!-- 任意セクション。戦略やヒントを箇条書きで記載 -->
+<!-- 任意セクション（ガードは必須にしていません）。戦略やヒントを箇条書きで記載 -->

--- a/docs/new-game-checklist.md
+++ b/docs/new-game-checklist.md
@@ -54,9 +54,16 @@ When adding a new game, follow this checklist to avoid post-feat fix commits. Co
     at something, and that they point at the RIGHT something.
     **The file is CRLF** -- anything that rewrites it must preserve the line endings or the diff becomes every line.
 22. **`docs/manual/cui/<game>.md`** and **`docs/manual/web/<game>.md`**: Create from the templates below and **include every required section**:
-    - CUI (`docs/manual/cui_template.md`): `## ゲーム概要` / `## 起動方法` / `## ルール` / `## ゲームの流れ` (Mermaid flowchart — **mandatory**) / `## コマンド一覧` / `## 画面の見方` / `## 遊び方のコツ`
-    - Web (`docs/manual/web_template.md`): `## ゲーム概要` / `## 起動方法` / `## ルール` / `## ゲームの流れ` (Mermaid flowchart — **mandatory**) / `## 画面の操作方法` / `## 画面構成` / `## 遊び方のコツ`
-    - Do not skip sections even if short; a brief stub is preferable to a missing section so future readers can rely on a consistent structure.
+    - CUI (`docs/manual/cui_template.md`): `## ゲーム概要` / `## 起動方法` / `## ルール` / `## ゲームの流れ` (Mermaid flowchart — **mandatory**) / `## コマンド一覧` / `## 画面の見方`, plus the optional `## 遊び方のコツ`
+    - Web (`docs/manual/web_template.md`): `## ゲーム概要` / `## 起動方法` / `## ルール` / `## ゲームの流れ` (Mermaid flowchart — **mandatory**) / `## 画面の操作方法` / `## 画面構成`, plus the optional `## 遊び方のコツ`
+    - Do not skip the required sections even if short; a brief stub is preferable to a missing section so future readers can rely on a consistent structure.
+    - The H1 must be exactly `# <ja nav label>（CUI版|Web版）遊び方`, where the label is `nav.<game>` in
+      `frontend/src/i18n/locales/ja/common.json` — the same string the Web GUI's navigation shows.
+    - The CUI `## コマンド一覧` table needs all three columns (`| コマンド | 短縮形 | 説明 |`) and rows for
+      `reset` / `quit` / `help`, which every game accepts via `execCuiCommand`.
+    - **All of this is enforced** by `TestPerGameManualsFollowTemplate`
+      (`internal/infrastructure/games/manual_template_test.go`); run
+      `bun scripts/audit-manual-template.mjs` for a worklist grouped by issue class.
 23. **`frontend/src/constants/manualTexts.ts`**: Import the **Web** manual and add route mapping entry
 24. **`frontend/src/constants/cuiManualTexts.ts`**: Import the **CUI** manual and add route mapping entry (this is the manual displayed when CLI mode is active — easy to forget)
 
@@ -72,8 +79,9 @@ When adding a new game, follow this checklist to avoid post-feat fix commits. Co
 
 Run through this cross-check for the new `<game>`:
 
-- [ ] `docs/manual/cui/<game>.md` exists and contains every section listed in item 22 (including the Mermaid flowchart)
-- [ ] `docs/manual/web/<game>.md` exists and contains every section listed in item 22 (including the Mermaid flowchart)
+- [ ] `docs/manual/cui/<game>.md` exists and contains every required section from item 22 (including the Mermaid flowchart)
+- [ ] `docs/manual/web/<game>.md` exists and contains every required section from item 22 (including the Mermaid flowchart)
+- [ ] `bun scripts/audit-manual-template.mjs` reports OK
 - [ ] `frontend/src/constants/manualTexts.ts` has both the `import` and the route mapping for `<game>`
 - [ ] `frontend/src/constants/cuiManualTexts.ts` has both the `import` and the route mapping for `<game>`
 - [ ] `frontend/src/utils/hints/<game>Hint.ts` exists (real implementation or documented `null` stub)

--- a/internal/infrastructure/games/docs_consistency_test.go
+++ b/internal/infrastructure/games/docs_consistency_test.go
@@ -155,6 +155,9 @@ func TestArchitectureDocEndpointCountMatchesRegistry(t *testing.T) {
 // catches both a missing manual for a freshly added game and an orphan manual
 // left behind by a rename or removal. Template files live at
 // docs/manual/{cui,web}_template.md (outside these dirs) and are not counted.
+//
+// This checks only that a manual exists. Its structure is checked by
+// TestPerGameManualsFollowTemplate in manual_template_test.go.
 func TestPerGameManualsMatchRegistry(t *testing.T) {
 	all := games.All()
 	names := make(map[string]bool, len(all))

--- a/internal/infrastructure/games/manual_template_test.go
+++ b/internal/infrastructure/games/manual_template_test.go
@@ -1,0 +1,453 @@
+package games_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/infrastructure/games"
+)
+
+// TestPerGameManualsFollowTemplate guards the structure of every per-game
+// manual against docs/manual/{cui,web}_template.md. Its sibling
+// TestPerGameManualsMatchRegistry (docs_consistency_test.go) checks only that a
+// manual exists; nothing checked what was inside one, and 380 of the 528
+// manuals had drifted by 2026-08: 110 CUI command tables never mentioned
+// `help`, 106 Web manuals omitted `go run ./cmd/server`, and 12 CUI manuals
+// still told the reader to run `go run ./cmd/cli <game>` -- a binary this repo
+// does not have. These files are not internal notes:
+// frontend/src/constants/{cuiManualTexts,manualTexts}.ts glob-import them into
+// the Web GUI, so a stale launch line ships to players.
+//
+// Three things this test deliberately does not do:
+//
+//   - It does not parse the Mermaid. frontend/scripts/check-mermaid.mjs already
+//     runs the real mermaid.parse() over every block in the repo. Adding a
+//     second, weaker parser here would just disagree with it eventually.
+//   - It does not require 遊び方のコツ. Both templates mark that section
+//     `<!-- 任意セクション -->`.
+//   - It has no allowlist. An exemption here is precisely the drift this guard
+//     exists to catch -- see docsExemptFromBucketEnum's own warning.
+//
+// scripts/audit-manual-template.mjs asserts the same rules and prints a
+// worklist grouped by issue class. Keep the two in sync.
+func TestPerGameManualsFollowTemplate(t *testing.T) {
+	all := games.All()
+	nav := loadNavLabels(t)
+	if len(nav) < len(all) {
+		t.Fatalf("frontend/src/i18n/locales/ja/common.json yielded %d nav labels for %d games — "+
+			"the `nav` object moved or was renamed; this test cannot check H1s without it", len(nav), len(all))
+	}
+
+	checked := 0
+	for _, spec := range manualSpecs {
+		for _, g := range all {
+			rel := filepath.Join(spec.dir, g.Name+".md")
+			data, err := os.ReadFile(filepath.Join(repoRoot, rel))
+			if err != nil {
+				// A missing manual is TestPerGameManualsMatchRegistry's report
+				// to make; failing twice for one cause helps nobody.
+				continue
+			}
+			checked++
+			t.Run(rel, func(t *testing.T) {
+				checkManual(t, spec, g.Name, nav[g.Name], string(data), rel)
+			})
+		}
+	}
+	if checked != 2*len(all) {
+		t.Fatalf("checked %d manuals but the registry has %d games across two directories — "+
+			"the walk broke rather than the manuals being clean; fix it in manual_template_test.go",
+			checked, 2*len(all))
+	}
+}
+
+// manualSpec is one directory's contract, in the order the template lays the
+// sections out.
+type manualSpec struct {
+	dir      string
+	kind     string // the version marker inside the H1 parenthesis
+	sections []string
+}
+
+var manualSpecs = []manualSpec{
+	{
+		dir:      "docs/manual/cui",
+		kind:     "CUI",
+		sections: []string{"ゲーム概要", "起動方法", "ルール", "ゲームの流れ", "コマンド一覧", "画面の見方"},
+	},
+	{
+		dir:      "docs/manual/web",
+		kind:     "Web",
+		sections: []string{"ゲーム概要", "起動方法", "ルール", "ゲームの流れ", "画面の操作方法", "画面構成"},
+	},
+}
+
+// manualFenceRe matches a fence opening or closing a code block.
+var manualFenceRe = regexp.MustCompile("^\\s*(?:`{3,}|~{3,})")
+
+// manualCommandRowRe builds the check for one mandatory command-table row. The
+// command may carry arguments -- spider documents `reset [1\|2\|4]` -- so it
+// matches the token rather than requiring a closing backtick right after it.
+func manualCommandRowRe(cmd string) *regexp.Regexp {
+	return regexp.MustCompile(`\|\s*` + "`" + regexp.QuoteMeta(cmd) + `\b`)
+}
+
+// manualAPIPathRe matches an HTTP route written outside a code fence. The Web
+// template says API specs belong in api/openapi.yaml, not in a manual.
+var manualAPIPathRe = regexp.MustCompile(`^\s*(?:GET|POST|PUT|PATCH|DELETE)\s+/`)
+
+// loadNavLabels reads the Japanese navigation label for every game. This is the
+// same string the Web GUI shows in its navigation, so a manual's H1 and the nav
+// entry for one game cannot disagree.
+func loadNavLabels(t *testing.T) map[string]string {
+	t.Helper()
+	path := filepath.Join(repoRoot, "frontend/src/i18n/locales/ja/common.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var parsed struct {
+		Nav map[string]string `json:"nav"`
+	}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	return parsed.Nav
+}
+
+// manualHeadings splits a manual into its H1s and its ordered H2s, ignoring
+// anything inside a fenced code block.
+//
+// The fence skip is load-bearing, not defensive: a `# 英語表示:` comment inside
+// a ```sh block is not a heading, and counting it as one produced 13 phantom
+// "duplicate H1" reports the first time these manuals were measured.
+func manualHeadings(src string) (h1 []string, h2 []string) {
+	inFence := false
+	for line := range strings.SplitSeq(src, "\n") {
+		if manualFenceRe.MatchString(line) {
+			inFence = !inFence
+			continue
+		}
+		if inFence {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(line, "## "):
+			h2 = append(h2, strings.TrimSpace(line[3:]))
+		case strings.HasPrefix(line, "# "):
+			h1 = append(h1, strings.TrimSpace(line))
+		}
+	}
+	return h1, h2
+}
+
+// manualSection returns the body of one H2 section, fences included, and
+// whether it is present. The boundary is located on the fence-aware heading
+// scan: searching raw lines ended four manuals' 起動方法 at a `# または`
+// comment inside their ```sh block, hiding the `go run ./cmd/server` that
+// followed it.
+func manualSection(src, name string) (string, bool) {
+	lines := strings.Split(src, "\n")
+	inFence, start := false, -1
+	for i, line := range lines {
+		if manualFenceRe.MatchString(line) {
+			inFence = !inFence
+			continue
+		}
+		if inFence || !strings.HasPrefix(line, "## ") {
+			continue
+		}
+		if start >= 0 {
+			return strings.Join(lines[start+1:i], "\n"), true
+		}
+		if strings.TrimSpace(line[3:]) == name {
+			start = i
+		}
+	}
+	if start < 0 {
+		return "", false
+	}
+	return strings.Join(lines[start+1:], "\n"), true
+}
+
+// checkManual reports every way one manual departs from its template. All
+// failures are t.Errorf so a single run lists every problem in the file.
+func checkManual(t *testing.T, spec manualSpec, game, navLabel, src, rel string) {
+	t.Helper()
+	h1, h2 := manualHeadings(src)
+
+	wantTitle := fmt.Sprintf("# %s（%s版）遊び方", navLabel, spec.kind)
+	switch {
+	case len(h1) == 0:
+		t.Errorf("%s: no H1. Want %q per docs/manual/%s_template.md", rel, wantTitle, strings.ToLower(spec.kind))
+	case len(h1) > 1:
+		t.Errorf("%s: %d H1 headings, want exactly one (%q)", rel, len(h1), wantTitle)
+	case h1[0] != wantTitle:
+		t.Errorf("%s: H1 is %q, want %q. The game name comes from nav.%s in "+
+			"frontend/src/i18n/locales/ja/common.json — the label the Web GUI's navigation shows.",
+			rel, h1[0], wantTitle, game)
+	}
+
+	// Presence and order in one comparison: filter the document's H2 sequence
+	// down to the required names and compare it to the template's order.
+	var got []string
+	for _, h := range h2 {
+		if slices.Contains(spec.sections, h) && !slices.Contains(got, h) {
+			got = append(got, h)
+		}
+	}
+	if !slices.Equal(got, spec.sections) {
+		t.Errorf("%s: required sections are %v, want exactly %v in that order (docs/manual/%s_template.md)",
+			rel, got, spec.sections, strings.ToLower(spec.kind))
+	}
+	for _, s := range spec.sections {
+		if n := strings.Count("\x00"+strings.Join(h2, "\x00"), "\x00"+s); n > 1 {
+			t.Errorf("%s: section %q appears %d times, want once", rel, s, n)
+		}
+	}
+
+	if flow, ok := manualSection(src, "ゲームの流れ"); ok && !hasMermaidFlowchart(flow) {
+		t.Errorf("%s: ゲームの流れ has no ```mermaid block starting with `flowchart`. "+
+			"Both templates mark the flowchart mandatory. (Diagram validity is "+
+			"frontend/scripts/check-mermaid.mjs's job — do not add a parser here.)", rel)
+	}
+
+	launch, _ := manualSection(src, "起動方法")
+	if spec.kind == "CUI" {
+		want := "go run ./cmd/trumpcards " + game
+		if !strings.Contains(launch, want) {
+			t.Errorf("%s: 起動方法 does not document %q", rel, want)
+		}
+		if strings.Contains(launch, "./cmd/cli") {
+			t.Errorf("%s: 起動方法 tells the reader to run `go run ./cmd/cli %s`, but cmd/ holds "+
+				"only server, trumpcards and workers — use `go run ./cmd/trumpcards %s`", rel, game, game)
+		}
+		cmds, _ := manualSection(src, "コマンド一覧")
+		if !regexp.MustCompile(`\|\s*コマンド\s*\|\s*短縮形\s*\|\s*説明\s*\|`).MatchString(cmds) {
+			t.Errorf("%s: コマンド一覧 has no `| コマンド | 短縮形 | 説明 |` table header", rel)
+		}
+		for _, c := range []string{"reset", "quit", "help"} {
+			if !manualCommandRowRe(c).MatchString(cmds) {
+				t.Errorf("%s: コマンド一覧 has no `%s` row. Every game accepts it — execCuiCommand in "+
+					"internal/adapter/controller/cui_controller_helper.go handles it before the game does.", rel, c)
+			}
+		}
+	} else {
+		for _, want := range []string{"go run ./cmd/trumpcards web", "go run ./cmd/server"} {
+			if !strings.Contains(launch, want) {
+				t.Errorf("%s: 起動方法 does not document %q", rel, want)
+			}
+		}
+		if line, ok := firstAPIPathOutsideFence(src); ok {
+			t.Errorf("%s: documents the HTTP API (%q). The Web template keeps API specs in "+
+				"api/openapi.yaml so they cannot drift from the served routes.", rel, line)
+		}
+	}
+
+	for _, leftover := range []string{"＜ゲーム名＞", "<!-- テンプレート:", "<!-- API仕様は"} {
+		if strings.Contains(src, leftover) {
+			t.Errorf("%s: still contains the template scaffolding %q", rel, leftover)
+		}
+	}
+}
+
+// hasMermaidFlowchart reports whether body holds a ```mermaid block whose first
+// non-blank line starts with `flowchart`.
+func hasMermaidFlowchart(body string) bool {
+	lines := strings.Split(body, "\n")
+	for i, line := range lines {
+		if strings.TrimSpace(line) != "```mermaid" {
+			continue
+		}
+		for _, next := range lines[i+1:] {
+			if strings.TrimSpace(next) == "" {
+				continue
+			}
+			return strings.HasPrefix(strings.TrimSpace(next), "flowchart")
+		}
+	}
+	return false
+}
+
+// firstAPIPathOutsideFence finds an HTTP route written as prose. Routes inside
+// code fences are fine — a manual may show a curl example — and comments are
+// skipped so the template's own "keep API specs out" note is not a hit.
+func firstAPIPathOutsideFence(src string) (string, bool) {
+	inFence := false
+	for line := range strings.SplitSeq(src, "\n") {
+		if manualFenceRe.MatchString(line) {
+			inFence = !inFence
+			continue
+		}
+		if inFence || strings.Contains(line, "<!--") {
+			continue
+		}
+		if manualAPIPathRe.MatchString(line) {
+			return strings.TrimSpace(line), true
+		}
+	}
+	return "", false
+}
+
+// conformingManual is the minimum CUI manual that satisfies every rule above.
+// The mutations in TestManualTemplateGuardCatchesEachViolation each break
+// exactly one of them, so the guard is checked in both directions: it must stay
+// silent on a good file and must fire on each specific defect. A guard verified
+// only against the repository's own (now clean) manuals would pass just as
+// happily with its checks deleted.
+const conformingManual = "# テスト（CUI版）遊び方\n" + `
+## ゲーム概要
+
+テスト用。
+
+## 起動方法
+
+` + "```sh" + `
+go run ./cmd/trumpcards testgame
+# または
+go run ./cmd/trumpcards --lang en testgame
+` + "```" + `
+
+## ルール
+
+無し。
+
+## ゲームの流れ
+
+` + "```mermaid" + `
+flowchart TD
+    A[開始] --> B[終了]
+` + "```" + `
+
+## コマンド一覧
+
+| コマンド | 短縮形 | 説明 |
+|----------|--------|------|
+| ` + "`reset`" + ` | ` + "`r`" + ` | 新しいゲームを開始 |
+| ` + "`quit`" + ` | ` + "`q`" + ` | ゲーム終了 |
+| ` + "`help`" + ` | ` + "`?`" + ` | コマンド一覧を表示 |
+
+## 画面の見方
+
+` + "```" + `
+==========
+テスト
+==========
+# これは見出しではない
+` + "```" + `
+`
+
+// cuiSpec is the CUI contract, looked up rather than duplicated so the control
+// tests cannot drift from the rules the real run enforces.
+var cuiSpec = manualSpecs[0]
+
+func TestManualTemplateGuardAcceptsAConformingManual(t *testing.T) {
+	fake := &testing.T{}
+	checkManual(fake, cuiSpec, "testgame", "テスト", conformingManual, "docs/manual/cui/testgame.md")
+	if fake.Failed() {
+		t.Error("the guard rejected a manual that follows the template — it would fire on correct work")
+	}
+}
+
+func TestManualTemplateGuardCatchesEachViolation(t *testing.T) {
+	cases := []struct {
+		name string
+		mut  func(string) string
+	}{
+		{"wrong H1", func(s string) string {
+			return strings.Replace(s, "# テスト（CUI版）遊び方", "# テスト (American Toad) — CUI マニュアル", 1)
+		}},
+		{"second H1", func(s string) string { return s + "\n# もう一つ\n" }},
+		{"missing section", func(s string) string { return strings.Replace(s, "## ルール", "## 規則", 1) }},
+		{"sections out of order", func(s string) string {
+			return strings.Replace(s, "## ルール", "## 画面の見方", 1)
+		}},
+		{"duplicate section", func(s string) string { return s + "\n## ルール\n\nふたつめ。\n" }},
+		{"mermaid replaced by a state diagram", func(s string) string {
+			return strings.Replace(s, "flowchart TD", "stateDiagram-v2", 1)
+		}},
+		{"mermaid block removed", func(s string) string {
+			return strings.Replace(s, "```mermaid", "```text", 1)
+		}},
+		{"launch command missing", func(s string) string {
+			return strings.Replace(s, "go run ./cmd/trumpcards testgame", "go run ./cmd/x testgame", 1)
+		}},
+		{"launch command points at the deleted cmd/cli", func(s string) string {
+			return strings.Replace(s, "go run ./cmd/trumpcards testgame", "go run ./cmd/cli testgame", 1)
+		}},
+		{"command table lost its 短縮形 column", func(s string) string {
+			return strings.Replace(s, "| コマンド | 短縮形 | 説明 |", "| コマンド | 説明 |", 1)
+		}},
+		{"help row missing", func(s string) string {
+			return strings.Replace(s, "| `help` | `?` | コマンド一覧を表示 |", "", 1)
+		}},
+		{"reset row missing", func(s string) string {
+			return strings.Replace(s, "| `reset` | `r` | 新しいゲームを開始 |", "", 1)
+		}},
+		{"template scaffolding left behind", func(s string) string {
+			return strings.Replace(s, "テスト用。", "＜ゲーム名＞ の説明", 1)
+		}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			fake := &testing.T{}
+			checkManual(fake, cuiSpec, "testgame", "テスト", c.mut(conformingManual), "docs/manual/cui/testgame.md")
+			if !fake.Failed() {
+				t.Errorf("the guard stayed silent on %q — that defect would ship unnoticed", c.name)
+			}
+		})
+	}
+}
+
+// The Web contract adds two launch commands and forbids HTTP routes in prose.
+func TestManualTemplateGuardChecksTheWebSpecifics(t *testing.T) {
+	webSpec := manualSpecs[1]
+	base := strings.NewReplacer(
+		"（CUI版）", "（Web版）",
+		"## コマンド一覧", "## 画面の操作方法",
+		"## 画面の見方", "## 画面構成",
+		"go run ./cmd/trumpcards testgame\n# または\ngo run ./cmd/trumpcards --lang en testgame",
+		"go run ./cmd/trumpcards web\n# または\ngo run ./cmd/server",
+	).Replace(conformingManual)
+
+	fake := &testing.T{}
+	checkManual(fake, webSpec, "testgame", "テスト", base, "docs/manual/web/testgame.md")
+	if fake.Failed() {
+		t.Fatal("the Web control manual should conform; fix the fixture before trusting the mutations")
+	}
+
+	for _, c := range []struct {
+		name string
+		src  string
+	}{
+		{"cmd/server missing", strings.Replace(base, "go run ./cmd/server", "go run ./cmd/other", 1)},
+		{"API route documented in prose", base + "\nPOST /testgame/exec で状態を進めます。\n"},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			fake := &testing.T{}
+			checkManual(fake, webSpec, "testgame", "テスト", c.src, "docs/manual/web/testgame.md")
+			if !fake.Failed() {
+				t.Errorf("the guard stayed silent on %q", c.name)
+			}
+		})
+	}
+}
+
+// A `#` inside a fenced block is not a heading. Getting this wrong produced 13
+// phantom "duplicate H1" reports when these manuals were first measured, so it
+// gets its own test rather than riding on the cases above.
+func TestManualHeadingsIgnoresFencedCode(t *testing.T) {
+	h1, h2 := manualHeadings(conformingManual)
+	if len(h1) != 1 {
+		t.Errorf("got %d H1 headings %q, want 1 — a `#` comment inside a fence was counted", len(h1), h1)
+	}
+	if slices.Contains(h2, "これは見出しではない") {
+		t.Errorf("a fenced `#` line was parsed as a heading: %v", h2)
+	}
+}

--- a/internal/infrastructure/games/manual_template_test.go
+++ b/internal/infrastructure/games/manual_template_test.go
@@ -223,10 +223,20 @@ func checkManual(t *testing.T, spec manualSpec, game, navLabel, src, rel string)
 		}
 	}
 
-	if flow, ok := manualSection(src, "ゲームの流れ"); ok && !hasMermaidFlowchart(flow) {
-		t.Errorf("%s: ゲームの流れ has no ```mermaid block starting with `flowchart`. "+
-			"Both templates mark the flowchart mandatory. (Diagram validity is "+
-			"frontend/scripts/check-mermaid.mjs's job — do not add a parser here.)", rel)
+	if flow, ok := manualSection(src, "ゲームの流れ"); ok {
+		if !hasMermaidFlowchart(flow) {
+			t.Errorf("%s: ゲームの流れ has no ```mermaid block starting with `flowchart`. "+
+				"Both templates mark the flowchart mandatory. (Diagram validity is "+
+				"frontend/scripts/check-mermaid.mjs's job — do not add a parser here.)", rel)
+		}
+		// Exactly one. Twelve manuals briefly carried two: they already had a
+		// hand-written diagram under ルール, an authoring pass added a second
+		// derived one here, and a later pass then rewrote whichever came first
+		// in the file. A reader cannot tell which of two diagrams is current.
+		if n := strings.Count(flow, "```mermaid"); n > 1 {
+			t.Errorf("%s: ゲームの流れ has %d ```mermaid blocks, want exactly one — "+
+				"a second diagram leaves the reader guessing which one is current", rel, n)
+		}
 	}
 
 	launch, _ := manualSection(src, "起動方法")
@@ -382,6 +392,10 @@ func TestManualTemplateGuardCatchesEachViolation(t *testing.T) {
 		{"duplicate section", func(s string) string { return s + "\n## ルール\n\nふたつめ。\n" }},
 		{"mermaid replaced by a state diagram", func(s string) string {
 			return strings.Replace(s, "flowchart TD", "stateDiagram-v2", 1)
+		}},
+		{"a second diagram in ゲームの流れ", func(s string) string {
+			return strings.Replace(s, "```mermaid\nflowchart TD\n    A[開始] --> B[終了]\n```",
+				"```mermaid\nflowchart TD\n    A[開始] --> B[終了]\n```\n\n```mermaid\nflowchart TD\n    X[古い図] --> Y[終了]\n```", 1)
 		}},
 		{"mermaid block removed", func(s string) string {
 			return strings.Replace(s, "```mermaid", "```text", 1)

--- a/internal/infrastructure/games/manual_template_test.go
+++ b/internal/infrastructure/games/manual_template_test.go
@@ -206,8 +206,19 @@ func checkManual(t *testing.T, spec manualSpec, game, navLabel, src, rel string)
 		t.Errorf("%s: required sections are %v, want exactly %v in that order (docs/manual/%s_template.md)",
 			rel, got, spec.sections, strings.ToLower(spec.kind))
 	}
+	// Counted by exact equality, not by substring. A NUL-delimited
+	// strings.Count matched any permitted heading that merely starts with a
+	// required name -- `## ルール一覧` beside `## ルール` would have been
+	// reported as a duplicate. It also diverged from the JS twin, which counts
+	// with a plain equality filter.
 	for _, s := range spec.sections {
-		if n := strings.Count("\x00"+strings.Join(h2, "\x00"), "\x00"+s); n > 1 {
+		n := 0
+		for _, h := range h2 {
+			if h == s {
+				n++
+			}
+		}
+		if n > 1 {
 			t.Errorf("%s: section %q appears %d times, want once", rel, s, n)
 		}
 	}
@@ -436,6 +447,20 @@ func TestManualTemplateGuardChecksTheWebSpecifics(t *testing.T) {
 				t.Errorf("the guard stayed silent on %q", c.name)
 			}
 		})
+	}
+}
+
+// A permitted extra heading that merely starts with a required section's name
+// must not read as a duplicate of it. The check used to count NUL-delimited
+// substrings, so `## ルール一覧` beside `## ルール` would have failed a manual
+// that is perfectly legal -- the templates explicitly allow game-specific
+// sections.
+func TestManualTemplateGuardAllowsHeadingsPrefixedByARequiredName(t *testing.T) {
+	src := strings.Replace(conformingManual, "## ルール\n", "## ルール\n\n無し。\n\n## ルール一覧\n", 1)
+	fake := &testing.T{}
+	checkManual(fake, cuiSpec, "testgame", "テスト", src, "docs/manual/cui/testgame.md")
+	if fake.Failed() {
+		t.Error("the guard rejected a manual whose extra heading merely shares a prefix with a required one")
 	}
 }
 

--- a/scripts/audit-manual-template.mjs
+++ b/scripts/audit-manual-template.mjs
@@ -17,8 +17,9 @@
  * what matters. Trust a fresh run over any number written in prose.
  *
  * This script is the human-facing worklist. The commit gate is the Go test
- * `TestPerGameManualsFollowTemplate` in internal/infrastructure/games/
- * docs_consistency_test.go, which asserts the same rules — keep the two in sync.
+ * `TestPerGameManualsFollowTemplate` in
+ * internal/infrastructure/games/manual_template_test.go, which asserts the
+ * same rules — keep the two in sync.
  *
  * Usage:
  *   bun scripts/audit-manual-template.mjs           # grouped report


### PR DESCRIPTION
**シリーズ最後の PR。** #5220 / #5226 / #5222 / #5223 はマージ済み。#5224 の後にこれを入れると `develop` が 528/528 準拠＋ガード付きになります。

## 背景

`TestPerGameManualsMatchRegistry` はマニュアルの**存在**しか見ていなかった。中身は無検査で、その結果 528 本中 **380 本**がテンプレから外れていた:

- **110 本**の CUI コマンド表が `help` を一切載せていない
- **106 本**の Web マニュアルが `go run ./cmd/server` を落としている
- **12 本**の CUI マニュアルが `go run ./cmd/cli <game>` を案内していた — **このリポジトリに存在しないバイナリ**

これらは内部メモではない。`frontend/src/constants/{cuiManualTexts,manualTexts}.ts` が glob import して Web GUI に描画するので、古い起動行はそのままプレイヤーに出荷される。

## `TestPerGameManualsFollowTemplate`

528 本すべてに対して次を主張する:

| 検査 | 内容 |
|---|---|
| H1 | ちょうど1本、`# <ja nav 表示名>（CUI版\|Web版）遊び方` と完全一致。表示名は `nav.<game>`（`ja/common.json`）＝ **Web GUI のナビが表示している文字列そのもの**なので、マニュアルとナビが食い違えない |
| セクション | 必須 H2 が**各1回ずつ・テンプレ順**で並ぶ |
| 図 | `## ゲームの流れ` の下に、1行目が `flowchart` の ` ```mermaid ` ブロック |
| 起動方法 | テンプレが載せる起動コマンドを含み、`cmd/cli` を参照しない |
| コマンド表 (CUI) | `\| コマンド \| 短縮形 \| 説明 \|` と `reset` / `quit` / `help` の行 |
| API (Web) | 地の文に HTTP ルートが無い（API 仕様は `api/openapi.yaml`） |
| 雛形の残骸 | `＜ゲーム名＞` などが残っていない |

### 意図的にやらないこと3つ（doc コメントに明記）

後から「改善」されないように理由ごと書いてある:

1. **Mermaid をパースしない** — `check-mermaid.mjs` が既に本物の `mermaid.parse()` で全ブロックを検証している。2つ目の弱いパーサを置けばいずれ食い違う
2. **`遊び方のコツ` を必須にしない** — 両テンプレが `<!-- 任意セクション -->` と明記している
3. **例外リストを持たない** — ここでの例外こそが、このガードが捕まえたいドリフトそのもの（`docsExemptFromBucketEnum` 自身の警告と同じ理由）

## 負のコントロール — **両方向**を検査

「正しいコードで鳴らない」と「壊れたら必ず鳴る」の両方を検査する。**リポジトリの（今や綺麗な）マニュアルに対してだけ検証したガードは、検査を全部消しても同じように緑になる。**

- `TestManualTemplateGuardAcceptsAConformingManual` — 準拠した合成マニュアルで沈黙すること
- `TestManualTemplateGuardCatchesEachViolation` — **14 ケース**、1つずつ規則を壊し、ガードが黙ったら失敗
- `TestManualTemplateGuardAllowsHeadingsPrefixedByARequiredName` — `## ルール一覧` を `## ルール` の重複と誤認しないこと（偽陽性側）
- `TestManualTemplateGuardChecksTheWebSpecifics` — Web 固有の2件
- `TestManualHeadingsIgnoresFencedCode` — フェンス内の `#`

```
--- PASS: .../wrong_H1
--- PASS: .../second_H1
--- PASS: .../missing_section
--- PASS: .../sections_out_of_order
--- PASS: .../duplicate_section
--- PASS: .../mermaid_replaced_by_a_state_diagram
--- PASS: .../mermaid_block_removed
--- PASS: .../launch_command_missing
--- PASS: .../launch_command_points_at_the_deleted_cmd/cli
--- PASS: .../command_table_lost_its_短縮形_column
--- PASS: .../help_row_missing
--- PASS: .../reset_row_missing
--- PASS: .../a_second_diagram_in_ゲームの流れ
--- PASS: .../template_scaffolding_left_behind
--- PASS: .../cmd/server_missing
--- PASS: .../API_route_documented_in_prose
```

### フェンススキップは防御ではなく本質

```sh ブロック内の `# 英語表示:` は見出しではない。これを見出しと数えて**偽の「H1 重複」が 13 件**出た。さらにセクション境界を生の行から探すと、4本のマニュアルの起動方法が ```sh 内の `# または` で打ち切られ、直後の `go run ./cmd/server` が見えなくなっていた。`TestManualHeadingsIgnoresFencedCode` が両方を固定する。

## ドキュメントの整合

- 両テンプレ / `docs/new-game-checklist.md`: 構成が機械検査されることと、**`遊び方のコツ` が任意**であることを明記（チェックリストは必須として列挙しており、両テンプレと矛盾していた）
- `docs/documentation-maintenance.md`: ガードと監査スクリプトへの参照を追加

## シリーズ全体の結果

`audit-manual-template.mjs`: **380 → 0**（528 本すべて準拠）

## テスト計画

- [x] `go test -tags test ./...` — 全パッケージ ok
- [x] `golangci-lint run ./internal/infrastructure/games/...` — 0 issues
- [x] `goimports -w` 済み
- [x] 15 の変異ケースすべてが**実行され**検出されたことを `-v` で確認
- [x] `bun scripts/audit-manual-template.mjs` — OK (528/528)
- [x] `bun scripts/check-markdown-tables.mjs` / `check-mermaid.mjs` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## レビュー反映（#5225 / #5226 の指摘）

- **重複セクション判定を完全一致に**: NUL 区切りの部分文字列で数えていたため `## ルール一覧` が `## ルール` の重複と誤検出されうる潜在バグ。両テンプレはゲーム固有セクションを明示的に許可しているので、これは**正当なマニュアルを落とす**検査だった。偽陽性側のコントロールテストつきで修正
- **`ゲームの流れ` の図はちょうど1つ**: 12ゲームが一時的に図を2つ持った（`## ルール` 配下の手書き図＋執筆パスが挿入した導出図）。存在チェックでは捕まらない（2つのうち1つが `flowchart` で始まれば通る）ので本数を数える検査を追加
- **docstring のパス修正**: 監査スクリプトが gate を `docs_consistency_test.go` と書いていたが、実体は `manual_template_test.go`

## 既知の残件

コマンド列のトークンが実在するかは**この PR の範囲外**（19ゲームに既存の記載ミスがある）。issue #5227 に切り出し済み。
