### PR TITLE
fix(skat): deal the German 32-card pack, not 32 cards of any kind

### DIFF
--- a/internal/domain/Skat.go
+++ b/internal/domain/Skat.go
@@ -163,10 +163,13 @@ func NewDefaultSkat() *Skat {
 }
 
 // newSkatDeck builds the 32-card Skat deck (7..A across the four standard suits).
+//
+// **NewTrumpCardsWithSuits(32, …) では作れない。** 枚数で打ち切る汎用
+// コンストラクタなので、♠13 + ♣13 + ♥6 + ♦0 になり**ダイヤが 1 枚も入らない**。
+// 切り札スートを選ぶゲームでこれをやると、選べるのに 1 枚も存在しない切り札が
+// できる (#5296)。German 32 枚パックは Skat / Belote / Prsi で共通。
 func newSkatDeck() *TrumpCards {
-	suits := []int{CardDesignSpade, CardDesignClover, CardDesignHeart, CardDesignDiamond}
-	t := NewTrumpCardsWithSuits(SkatTotalCards, suits)
-	return t
+	return NewTrumpCards32()
 }
 
 // Reset initializes a new game session.

--- a/internal/domain/Skat.go
+++ b/internal/domain/Skat.go
@@ -17,9 +17,6 @@ const SkatHandSize = 10
 // SkatSkatSize face-down cards (the "Skat")
 const SkatSkatSize = 2
 
-// SkatTotalCards 32-card deck (7..A across 4 suits)
-const SkatTotalCards = 32
-
 // SkatTricksPerRound number of tricks per round
 const SkatTricksPerRound = 10
 

--- a/internal/domain/TrumpCards.go
+++ b/internal/domain/TrumpCards.go
@@ -139,18 +139,22 @@ func NewTrumpCardsEuchre() *TrumpCards {
 	return t
 }
 
-// NewTrumpCardsBelote ベロート用32枚デッキコンストラクタ
+// NewTrumpCards32 German/Czech 32枚デッキコンストラクタ
 // 7,8,9,10,J,Q,K,A (値: 1,7,8,9,10,11,12,13) × 4スート = 32枚
-func NewTrumpCardsBelote() *TrumpCards {
-	beloteValues := []int{1, 7, 8, 9, 10, 11, 12, 13} // A,7,8,9,10,J,Q,K
+//
+// **枚数を指定する NewTrumpCardsWithSuits では作れない。** あちらはスートごとに
+// 値 1..13 を回して指定枚数で打ち切るので、32 を渡すと 13+13+6+0 になり
+// ダイヤが 1 枚も入らない (実測)。使う値を並べて作るのはそのため。
+func NewTrumpCards32() *TrumpCards {
+	values := []int{1, 7, 8, 9, 10, 11, 12, 13} // A,7,8,9,10,J,Q,K
 	suits := []int{CardDesignSpade, CardDesignClover, CardDesignHeart, CardDesignDiamond}
-	totalCards := len(beloteValues) * len(suits) // 32
+	totalCards := len(values) * len(suits) // 32
 
 	t := new(TrumpCards)
 	t.deckCnt = totalCards
 	t.deck = make([]*Card, 0, totalCards)
 	for _, suit := range suits {
-		for _, val := range beloteValues {
+		for _, val := range values {
 			t.deck = append(t.deck, NewCard(suit, val, false))
 		}
 	}
@@ -158,24 +162,17 @@ func NewTrumpCardsBelote() *TrumpCards {
 	return t
 }
 
+// NewTrumpCardsBelote ベロート用32枚デッキコンストラクタ
+// 7,8,9,10,J,Q,K,A (値: 1,7,8,9,10,11,12,13) × 4スート = 32枚
+func NewTrumpCardsBelote() *TrumpCards {
+	return NewTrumpCards32()
+}
+
 // NewTrumpCardsPrsi プルシー(チェコ版クレイジーエイト/Mau Mau)用32枚デッキコンストラクタ
 // 7,8,9,10,J,Q,K,A (値: 1,7,8,9,10,11,12,13) × 4スート = 32枚
 // ベロートと同一構成 (German/Czech 32-card pack)。
 func NewTrumpCardsPrsi() *TrumpCards {
-	prsiValues := []int{1, 7, 8, 9, 10, 11, 12, 13} // A,7,8,9,10,J,Q,K
-	suits := []int{CardDesignSpade, CardDesignClover, CardDesignHeart, CardDesignDiamond}
-	totalCards := len(prsiValues) * len(suits) // 32
-
-	t := new(TrumpCards)
-	t.deckCnt = totalCards
-	t.deck = make([]*Card, 0, totalCards)
-	for _, suit := range suits {
-		for _, val := range prsiValues {
-			t.deck = append(t.deck, NewCard(suit, val, false))
-		}
-	}
-	t.deckInit()
-	return t
+	return NewTrumpCards32()
 }
 
 // NewTrumpCardsHasenpfeffer ハーゼンプフェファー用25枚デッキコンストラクタ

--- a/internal/domain/skat_deck_test.go
+++ b/internal/domain/skat_deck_test.go
@@ -1,0 +1,90 @@
+//go:build test
+
+package domain_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+)
+
+// **枚数だけの assert はこの不具合を通す。** 32 枚は合っていながら、
+// ♠13 + ♣13 + ♥6 + ♦0 という「ダイヤが 1 枚も無い」デッキが配られていた。
+// スートごとの枚数と値の集合まで見る。
+func TestNewTrumpCards32_IsTheGerman32CardPack(t *testing.T) {
+	want := map[int]bool{1: true, 7: true, 8: true, 9: true, 10: true, 11: true, 12: true, 13: true}
+
+	for _, tt := range []struct {
+		name string
+		deck *domain.TrumpCards
+	}{
+		{"32", domain.NewTrumpCards32()},
+		{"belote", domain.NewTrumpCardsBelote()},
+		{"prsi", domain.NewTrumpCardsPrsi()},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, 32, tt.deck.GetTotalCount())
+
+			suits := map[int]int{}
+			values := map[int]int{}
+			for i := range 32 {
+				c := tt.deck.DrawCard()
+				require.NotNil(t, c, "index %d", i)
+				assert.True(t, want[c.GetValue()], "値 %d はこのデッキに入らない", c.GetValue())
+				suits[c.GetDesign()]++
+				values[c.GetValue()]++
+			}
+			// **4 スートがそれぞれ 8 枚。** 切り札スートを選ぶゲームでは、
+			// 1 スートでも欠けると「選べるのに 1 枚も無い切り札」ができる。
+			for s := domain.CardDesignSpade; s <= domain.CardDesignDiamond; s++ {
+				assert.Equal(t, 8, suits[s], "スート %d の枚数", s)
+			}
+			for v := range want {
+				assert.Equal(t, 4, values[v], "値 %d の枚数", v)
+			}
+			assert.Nil(t, tt.deck.DrawCard(), "32 枚を超えて引けている")
+		})
+	}
+}
+
+// **スカートの卓に配られる 32 枚も同じ内容。** 得点計算 (skatCardPoints) も
+// 序列も値 {A,7,8,9,10,J,Q,K} を前提に書かれているので、2〜6 が混ざると
+// 「0 点で最弱の札」が静かに増える。
+func TestSkat_DealsTheGerman32CardPack(t *testing.T) {
+	g := domain.NewDefaultSkat()
+	g.Reset()
+
+	suits := map[int]int{}
+	values := map[int]int{}
+	count := func(c *domain.Card) {
+		suits[c.GetDesign()]++
+		values[c.GetValue()]++
+	}
+	for i := range g.GetPlayerCnt() {
+		p := g.GetPlayer(i)
+		for j := range p.GetCardsSize() {
+			count(p.GetCard(j))
+		}
+	}
+	for _, c := range g.GetSkat() {
+		count(c)
+	}
+
+	total := 0
+	for _, n := range suits {
+		total += n
+	}
+	require.Equal(t, 32, total, "配られた枚数")
+	for s := domain.CardDesignSpade; s <= domain.CardDesignDiamond; s++ {
+		assert.Equal(t, 8, suits[s], "スート %d が配られていない", s)
+	}
+	for _, v := range []int{1, 7, 8, 9, 10, 11, 12, 13} {
+		assert.Equal(t, 4, values[v], "値 %d の枚数", v)
+	}
+	for _, v := range []int{2, 3, 4, 5, 6} {
+		assert.Zero(t, values[v], "スカートに入らない値 %d が配られている", v)
+	}
+}


### PR DESCRIPTION
Closes #5296

## 症状

`newSkatDeck()` が作る 32 枚が、スカートのデッキになっていませんでした。

| スート | 修正前 | 修正後 |
|---|---:|---:|
| ♠ | 13 (値 1〜13) | 8 (A,7,8,9,10,J,Q,K) |
| ♣ | 13 (値 1〜13) | 8 |
| ♥ | 6 (値 1〜6) | 8 |
| ♦ | **0** | 8 |

## 原因

`NewTrumpCardsWithSuits(32, 4スート)` は**スートごとに値 1..13 を回して指定枚数で打ち切る**汎用コンストラクタで、7〜A に絞る機能はありません。13 + 13 + 6 + 0 = 32 で止まります。doc コメントの「7..A across the four standard suits」は実装が満たしていない約束でした。

## 影響

スカートは**切り札スートを選ぶ**ゲームなので、表面的な不備ではありません。

- ダイヤを切り札に選んでも、その札は 1 枚も存在しない
- ハートは 6 枚しかなく、しかも A〜6 という本来入らない札
- 2〜6 が ♠♣♥ に混ざっており、`skatCardPoints` も序列もこれらを **0 点・最弱**として扱う（ルール側は値 {A,7,8,9,10,J,Q,K} 前提で書かれている）

## 修正

同じ 32 枚を正しく作る関数が既に 2 つあり（`NewTrumpCardsBelote` / `NewTrumpCardsPrsi`）、**中身は完全に同一**でした。`NewTrumpCards32` に寄せ、3 つともそこから作ります。カードの並び順（スート順 × 値順）は従来の 2 つと同一なので、既存ゲームの挙動は変わりません。

## テスト

**枚数だけの assert はこの不具合を通します。**

- `TestNewTrumpCards32_IsTheGerman32CardPack` — 3 つの入口すべてで、4 スートが各 8 枚・値の集合が {1,7,8,9,10,11,12,13}・各値が 4 枚
- `TestSkat_DealsTheGerman32CardPack` — 実際に配られた 32 枚（手札 3×10 + スカート 2）を数え、**2〜6 が 1 枚も無い**ことまで見る

## Test plan

- [ ] CI 全緑
- [x] `go test -tags test ./internal/domain/` 緑（全体）
- [x] `golangci-lint run ./internal/domain/` 0 issues