### PR TITLE
feat(guard): check that move-zone fields agree between Go and TypeScript

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,7 @@
     "lint": "biome lint .",
     "lint:tokens": "bun scripts/check-design-tokens.mjs",
     "format": "biome format --write .",
-    "check": "biome check . && bun scripts/check-guard-floors.mjs && bun scripts/check-design-tokens.mjs && bun scripts/check-modal-focus-trap.mjs && bun scripts/check-discover-blurbs.mjs && bun scripts/check-message-codes.mjs && bun scripts/check-hint-coverage.mjs && bun scripts/check-hint-reasons.mjs && bun scripts/check-markdown-tables.mjs && bun scripts/check-hint-gate.mjs && bun scripts/check-dependency-licenses.mjs && bun scripts/check-trademark-terms.mjs && bun scripts/check-asset-provenance.mjs && bun scripts/check-codecov-uploads.mjs && bun scripts/check-mermaid.mjs && bun scripts/check-design-doc-identifiers.mjs",
+    "check": "biome check . && bun scripts/check-guard-floors.mjs && bun scripts/check-design-tokens.mjs && bun scripts/check-modal-focus-trap.mjs && bun scripts/check-discover-blurbs.mjs && bun scripts/check-message-codes.mjs && bun scripts/check-move-zone-fields.mjs && bun scripts/check-hint-coverage.mjs && bun scripts/check-hint-reasons.mjs && bun scripts/check-markdown-tables.mjs && bun scripts/check-hint-gate.mjs && bun scripts/check-dependency-licenses.mjs && bun scripts/check-trademark-terms.mjs && bun scripts/check-asset-provenance.mjs && bun scripts/check-codecov-uploads.mjs && bun scripts/check-mermaid.mjs && bun scripts/check-design-doc-identifiers.mjs",
     "check:write": "biome check --write .",
     "preview": "vite preview",
     "test": "vitest run",

--- a/frontend/scripts/check-move-zone-fields.mjs
+++ b/frontend/scripts/check-move-zone-fields.mjs
@@ -32,17 +32,35 @@ const TS_DIRS = process.argv[3]
 const REAL_FLOOR = 30;
 const FIXTURE_FLOOR = 1;
 
-/** Fields of every `type <Game>WebZone struct` in the Go controllers. */
+/**
+ * Fields of every `type <Game>WebZone struct` under the Go controller tree.
+ *
+ * The walk recurses. Everything lives at the top level today, but a zone struct
+ * added one directory down would otherwise not be scanned — and an unscanned
+ * struct is not a finding, it is an absence, which reads exactly like agreement.
+ */
 async function goZones(dir) {
   const out = new Map();
-  for (const name of (await readdir(dir)).filter((f) => f.endsWith('.go') && !f.endsWith('_test.go'))) {
-    const text = await readFile(join(dir, name), 'utf8');
+  const entries = await readdir(dir, { withFileTypes: true, recursive: true });
+  for (const e of entries) {
+    if (!e.isFile() || !e.name.endsWith('.go') || e.name.endsWith('_test.go')) continue;
+    const text = await readFile(join(e.parentPath ?? e.path ?? dir, e.name), 'utf8');
     for (const m of text.matchAll(/type\s+([A-Za-z0-9]+)WebZone\s+struct\s*\{([\s\S]*?)\n\}/g)) {
       const fields = new Set();
-      for (const f of m[2].matchAll(/`json:"([^",]+)/g)) {
-        if (f[1] !== '-') fields.add(f[1]);
+      for (const line of m[2].split('\n')) {
+        // The tag is matched on its own: folding it into the declaration pattern as an
+        // optional group makes it optional in practice too, since nothing after it forces
+        // the engine to try — every field then reports its Go name and all 48 zones
+        // "mismatch" at once (measured).
+        const decl = line.match(/^\s*([A-Z][A-Za-z0-9]*)\s+\S/);
+        if (!decl) continue;
+        const tag = line.match(/`json:"([^",]+)/);
+        // **タグの無いフィールドも数える。** encoding/json はその場合フィールド名を
+        // そのまま使うので、読み飛ばすと「TS に無い」ことに気付けない。
+        const name = tag ? tag[1] : decl[1];
+        if (name !== '-') fields.add(name);
       }
-      out.set(m[1], { fields, file: name });
+      out.set(m[1], { fields, file: e.name });
     }
   }
   return out;
@@ -60,7 +78,11 @@ async function tsZones(dirs) {
     }
     for (const name of names) {
       const text = await readFile(join(dir, name), 'utf8');
-      for (const m of text.matchAll(/export\s+interface\s+([A-Za-z0-9]+)MoveZone\s*\{([\s\S]*?)\n\}/g)) {
+      // `extends` を挟んでも拾う。取りこぼすとその対だけが比較から外れ、
+      // 「不一致が無い」ではなく「見ていない」状態になる。
+      for (const m of text.matchAll(
+        /export\s+interface\s+([A-Za-z0-9]+)MoveZone\s*(?:extends\s+[^{]+)?\{([\s\S]*?)\n\}/g,
+      )) {
         const fields = new Set();
         for (const f of m[2].matchAll(/^\s*([a-zA-Z0-9_]+)\??\s*:/gm)) fields.add(f[1]);
         out.set(m[1], { fields, file: `${relative(FRONTEND, dir)}/${name}` });

--- a/frontend/scripts/check-move-zone-fields.mjs
+++ b/frontend/scripts/check-move-zone-fields.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env bun
+// Guard that a game's move-zone field names agree between Go and TypeScript.
+// See issue #5289.
+//
+// The index field is spelled two ways across the repo — `col` in 44 Go
+// controllers, `idx` in 7 — and both are correct where they are used. The
+// hazard is a *new* game assembled from two templates: take the domain from
+// Congress (`col`) and the page from Four Seasons (`idx`) and the two halves
+// disagree while every existing check still passes.
+//
+// Nothing else covers it. The page test mocks the API module and asserts the
+// argument object, so it never crosses the wire. The Go controller test builds
+// the request body itself, so it agrees with the bug. And tsc does not read Go
+// struct tags. #5288 (Colorado) shipped that way and every move with a
+// destination came back 400 — only E2E caught it, and only for the one game
+// that had a spec exercising a destination.
+
+import { readdir, readFile } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { assertFloor } from './lib/floor.mjs';
+
+const FRONTEND = fileURLToPath(new URL('..', import.meta.url));
+const REPO = join(FRONTEND, '..');
+// Roots are overridable by argv so this guard's own test can point it at a
+// fixture; a guard that can only run against the real tree cannot be shown to
+// fail on bad input.
+const GO_DIR = process.argv[2] ?? join(REPO, 'internal/adapter/controller');
+const TS_DIRS = process.argv[3]
+  ? [process.argv[3]]
+  : [join(FRONTEND, 'src/api/games'), join(FRONTEND, 'src/types/games')];
+const REAL_FLOOR = 30;
+const FIXTURE_FLOOR = 1;
+
+/** Fields of every `type <Game>WebZone struct` in the Go controllers. */
+async function goZones(dir) {
+  const out = new Map();
+  for (const name of (await readdir(dir)).filter((f) => f.endsWith('.go') && !f.endsWith('_test.go'))) {
+    const text = await readFile(join(dir, name), 'utf8');
+    for (const m of text.matchAll(/type\s+([A-Za-z0-9]+)WebZone\s+struct\s*\{([\s\S]*?)\n\}/g)) {
+      const fields = new Set();
+      for (const f of m[2].matchAll(/`json:"([^",]+)/g)) {
+        if (f[1] !== '-') fields.add(f[1]);
+      }
+      out.set(m[1], { fields, file: name });
+    }
+  }
+  return out;
+}
+
+/** Properties of every `export interface <Game>MoveZone` on the TypeScript side. */
+async function tsZones(dirs) {
+  const out = new Map();
+  for (const dir of dirs) {
+    let names;
+    try {
+      names = (await readdir(dir)).filter((f) => f.endsWith('.ts') && !f.endsWith('.test.ts'));
+    } catch {
+      continue; // an absent directory is not a finding; the floor below covers a bad root
+    }
+    for (const name of names) {
+      const text = await readFile(join(dir, name), 'utf8');
+      for (const m of text.matchAll(/export\s+interface\s+([A-Za-z0-9]+)MoveZone\s*\{([\s\S]*?)\n\}/g)) {
+        const fields = new Set();
+        for (const f of m[2].matchAll(/^\s*([a-zA-Z0-9_]+)\??\s*:/gm)) fields.add(f[1]);
+        out.set(m[1], { fields, file: `${relative(FRONTEND, dir)}/${name}` });
+      }
+    }
+  }
+  return out;
+}
+
+const go = await goZones(GO_DIR);
+const ts = await tsZones(TS_DIRS);
+// Both floors are plain literals so the number can be read (and reviewed) off the
+// source — check-guard-floors rejects a computed one. A fixture run has a handful of
+// structs by design; the real run keeps the number that matters.
+if (process.argv[2]) {
+  assertFloor('move-zone-fields', go.size, FIXTURE_FLOOR, 'WebZone structs in the fixture');
+} else {
+  assertFloor('move-zone-fields', go.size, REAL_FLOOR, `<Game>WebZone structs in ${relative(REPO, GO_DIR)}`);
+}
+
+const problems = [];
+for (const [game, g] of go) {
+  const t = ts.get(game);
+  // A Go zone with no TypeScript counterpart is not a mismatch: some games
+  // never send a zone from the client. Only a pair that exists on both sides
+  // can disagree, and that is the case this guard is about.
+  if (!t) continue;
+  const onlyGo = [...g.fields].filter((f) => !t.fields.has(f));
+  const onlyTs = [...t.fields].filter((f) => !g.fields.has(f));
+  if (onlyGo.length === 0 && onlyTs.length === 0) continue;
+  problems.push(
+    `  ${game}: ${[...g.fields].join(', ')}  (Go: ${g.file})\n` +
+      `  ${' '.repeat(game.length)}  ${[...t.fields].join(', ')}  (TS: ${t.file})\n` +
+      (onlyGo.length > 0 ? `      only in Go: ${onlyGo.join(', ')}\n` : '') +
+      (onlyTs.length > 0 ? `      only in TS: ${onlyTs.join(', ')}\n` : ''),
+  );
+}
+
+if (problems.length > 0) {
+  console.error('\nMove-zone fields disagree between Go and TypeScript:\n');
+  for (const p of problems) console.error(p);
+  console.error(
+    `${problems.length} mismatched zone(s). The client's index field must be spelled exactly as the` +
+      ' Go struct tag, or the destination never reaches the server and every move with a target 400s.\n' +
+      '  See issue #5289.',
+  );
+  process.exit(1);
+}
+
+const paired = [...go.keys()].filter((g) => ts.has(g)).length;
+console.log(`move-zone-fields: OK (${paired} of ${go.size} zone struct(s) paired with TypeScript, all fields agree).`);

--- a/frontend/scripts/check-move-zone-fields.test.mjs
+++ b/frontend/scripts/check-move-zone-fields.test.mjs
@@ -1,0 +1,67 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, describe, expect, it } from 'vitest';
+
+const GUARD = join(process.cwd(), 'scripts', 'check-move-zone-fields.mjs');
+if (!existsSync(GUARD)) throw new Error(`check-move-zone-fields.mjs not found at ${GUARD} (cwd: ${process.cwd()})`);
+
+const dirs = [];
+afterAll(() => {
+  for (const d of dirs) rmSync(d, { recursive: true, force: true });
+});
+
+const goZone = (game, fields) =>
+  `package controller\n\ntype ${game}WebZone struct {\n${fields
+    .map((f) => `\t${f[0].toUpperCase()}${f.slice(1)} *int \`json:"${f},omitempty"\`\n`)
+    .join('')}}\n`;
+
+const tsZone = (game, fields) =>
+  `export interface ${game}MoveZone {\n${fields.map((f) => `  ${f}?: number;\n`).join('')}}\n`;
+
+function check(goSrc, tsSrc) {
+  const dir = mkdtempSync(join(tmpdir(), 'move-zone-'));
+  dirs.push(dir);
+  mkdirSync(join(dir, 'go'));
+  mkdirSync(join(dir, 'ts'));
+  writeFileSync(join(dir, 'go', 'DemoWebController.go'), goSrc);
+  writeFileSync(join(dir, 'ts', 'demo.ts'), tsSrc);
+  const r = spawnSync(process.execPath, [GUARD, join(dir, 'go'), join(dir, 'ts')], { encoding: 'utf8' });
+  return { code: r.status, out: `${r.stdout}${r.stderr}` };
+}
+
+describe('check-move-zone-fields', () => {
+  it('accepts a zone whose fields match on both sides', () => {
+    const r = check(goZone('Demo', ['zone', 'col']), tsZone('Demo', ['zone', 'col']));
+    expect(r.code).toBe(0);
+    expect(r.out).toContain('OK');
+  });
+
+  it('accepts the other spelling when both sides use it', () => {
+    const r = check(goZone('Demo', ['zone', 'idx']), tsZone('Demo', ['zone', 'idx']));
+    expect(r.code).toBe(0);
+  });
+
+  // **これが #5288 (Colorado) そのもの。** Go が col、TS が idx で、型検査も
+  // 単体テストも通ったまま、行き先つきの移動が全部 400 になった。
+  it('rejects the col/idx split that shipped in #5288', () => {
+    const r = check(goZone('Demo', ['zone', 'col']), tsZone('Demo', ['zone', 'idx']));
+    expect(r.code).toBe(1);
+    expect(r.out).toContain('only in Go: col');
+    expect(r.out).toContain('only in TS: idx');
+  });
+
+  it('rejects a field the client never sends', () => {
+    const r = check(goZone('Demo', ['zone', 'col', 'cardIndex']), tsZone('Demo', ['zone', 'col']));
+    expect(r.code).toBe(1);
+    expect(r.out).toContain('only in Go: cardIndex');
+  });
+
+  // 片側にしか無いゲームは不一致ではない (クライアントがゾーンを送らない設計)。
+  it('ignores a Go zone with no TypeScript counterpart', () => {
+    const r = check(goZone('Demo', ['zone', 'col']), 'export interface OtherMoveZone {\n  zone?: number;\n}\n');
+    expect(r.code).toBe(0);
+    expect(r.out).toContain('0 of 1');
+  });
+});

--- a/frontend/scripts/check-move-zone-fields.test.mjs
+++ b/frontend/scripts/check-move-zone-fields.test.mjs
@@ -58,6 +58,37 @@ describe('check-move-zone-fields', () => {
     expect(r.out).toContain('only in Go: cardIndex');
   });
 
+  // **タグの無いフィールドは Go のフィールド名で送られる。** 読み飛ばすと
+  // 「TS に無い」ことに気付けないまま通ってしまう。
+  it('counts a Go field that carries no json tag', () => {
+    const goSrc = 'package controller\n\ntype DemoWebZone struct {\n\tZone string `json:"zone"`\n\tCol *int\n}\n';
+    const r = check(goSrc, tsZone('Demo', ['zone', 'col']));
+    expect(r.code).toBe(1);
+    expect(r.out).toContain('only in Go: Col');
+  });
+
+  // extends を挟んだ宣言も拾う。取りこぼすと比較から静かに外れる。
+  it('reads an interface declared with extends', () => {
+    const ts =
+      'interface Base {\n  zone: string;\n}\nexport interface DemoMoveZone extends Base {\n  idx?: number;\n}\n';
+    const r = check(goZone('Demo', ['zone', 'col']), ts);
+    expect(r.code).toBe(1);
+    expect(r.out).toContain('only in TS: idx');
+  });
+
+  // サブディレクトリに置かれた構造体も走査する。走査漏れは「一致」に見える。
+  it('walks sub-directories of the Go controller tree', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'move-zone-'));
+    dirs.push(dir);
+    mkdirSync(join(dir, 'go', 'nested'), { recursive: true });
+    mkdirSync(join(dir, 'ts'));
+    writeFileSync(join(dir, 'go', 'nested', 'DemoWebController.go'), goZone('Demo', ['zone', 'col']));
+    writeFileSync(join(dir, 'ts', 'demo.ts'), tsZone('Demo', ['zone', 'idx']));
+    const r = spawnSync(process.execPath, [GUARD, join(dir, 'go'), join(dir, 'ts')], { encoding: 'utf8' });
+    expect(r.status).toBe(1);
+    expect(`${r.stdout}${r.stderr}`).toContain('only in Go: col');
+  });
+
   // 片側にしか無いゲームは不一致ではない (クライアントがゾーンを送らない設計)。
   it('ignores a Go zone with no TypeScript counterpart', () => {
     const r = check(goZone('Demo', ['zone', 'col']), 'export interface OtherMoveZone {\n  zone?: number;\n}\n');


### PR DESCRIPTION
Closes #5289

## 問題

`<Game>WebZone` の索引フィールド名は Go と TypeScript の両方で 2 通りに割れています（Go: `col` 44 / `idx` 7、TS: `col` 20 / `idx` 7）。どちらも使われている場所では正しく、既存ゲームに実害はありません。

危ないのは**新しいゲームを既存の雛形からコピーしたとき**です。ドメインを Congress（`col`）から、ページを Four Seasons（`idx`）から持ってくると、**その 2 つが食い違ったまま型検査も単体テストも全部通ります**。

## なぜ既存のどれも検出できないのか

- ページのテストは `vi.mock('../api/gameApi')` で API モジュールごとモックし、引数オブジェクトをアサートするので**ワイヤを渡りません**
- Go のコントローラテストはリクエストボディを自分で組み立てるので、**バグと同じ綴りで一致します**（両側が揃って間違える）
- `bun run typecheck` は Go の構造体タグを知りません

#5288（Colorado）はこれで出荷され、行き先を伴う移動がすべて 400（`param error: to.col is required.`）になりました。検出できたのは E2E だけです。

## 追加したガード

`frontend/scripts/check-move-zone-fields.mjs` を `bun run check` の連鎖に入れました。Go の `type <Game>WebZone struct` の json タグと、TS の `export interface <Game>MoveZone` のプロパティ名を突き合わせます。

```
move-zone-fields: OK (48 of 48 zone struct(s) paired with TypeScript, all fields agree).
```

片側にしか無いゾーンは不一致として扱いません（クライアントがゾーンを送らない設計があるため）。両側に在るものだけが食い違い得ます。

## 検証

**実際の #5288 を現在のツリーで再現して確かめました。** `colorado.ts` の `idx` を `col` に戻すとガードが落ち（`only in Go: idx` / `only in TS: col`）、戻すと通ります。正しい状態の 48 ゾーンで誤検知しないことも確認済みです。

ガードのテスト（5 ケース）は両方向を踏みます — 一致する 2 通りの綴りを受け入れ、col/idx の食い違いと Go 側だけのフィールドを弾き、片側だけのゾーンは無視する。

## Test plan

- [ ] CI 全緑
- [x] `bun run check` EXIT=0
- [x] `bunx vitest run scripts/check-move-zone-fields.test.mjs` 5/5