### PR TITLE
test(horse): stop the rotation test from busting the table

### DIFF
--- a/internal/domain/Horse_test.go
+++ b/internal/domain/Horse_test.go
@@ -72,7 +72,10 @@ func TestHorse_DisciplineNames(t *testing.T) {
 // **設定したハンド数ごとに切り替わり、E の次は H に戻る。**
 func TestHorse_RotatesEveryNHands(t *testing.T) {
 	t.Parallel()
-	g := NewHorse(HorseConfig{Seats: 4, InitialChips: HorseDefaultChips, HandsPerDiscipline: 2})
+	// **12 ハンド打ち切れる残高を積む。** 既定の 1000 だと CPU 同士の全賭けで
+	// 席が飛び、マッチが終わって 11 ハンドに届かない ── 実測 13/300 (4.3%) で、
+	// 配り依存のまま放置すると自分の PR とは無関係に落ち続ける。5000 では 0/300。
+	g := NewHorse(HorseConfig{Seats: 4, InitialChips: 5000, HandsPerDiscipline: 2})
 	g.Reset()
 
 	seen := make([]HorseDiscipline, 0, 12)
@@ -85,14 +88,18 @@ func TestHorse_RotatesEveryNHands(t *testing.T) {
 		require.NoError(t, g.NextHand())
 	}
 
-	require.GreaterOrEqual(t, len(seen), 11, "12 ハンド回らなかった")
 	// 2 ハンドずつ H,H,O,O,R,R,S,S,E,E,H,H
 	want := []HorseDiscipline{
 		HorseHoldem, HorseHoldem, HorseOmahaHiLo, HorseOmahaHiLo,
 		HorseRazz, HorseRazz, HorseStud, HorseStud,
 		HorseStudHiLo, HorseStudHiLo, HorseHoldem,
 	}
-	assert.Equal(t, want, seen[:len(want)], "種目のローテーションが H-O-R-S-E で回っていない")
+	// **打てたぶんは必ず並びどおり。** 早く終わった配りでも、ここまでは言える。
+	require.LessOrEqual(t, len(seen), len(want)+1)
+	assert.Equal(t, want[:min(len(seen), len(want))], seen[:min(len(seen), len(want))],
+		"種目のローテーションが H-O-R-S-E で回っていない")
+	// E の次に H へ戻るところまで見るには 11 ハンド要る。
+	require.GreaterOrEqual(t, len(seen), 11, "12 ハンド回らなかった")
 }
 
 // **1 ハンドごとの設定でも回る。**

--- a/internal/domain/Horse_test.go
+++ b/internal/domain/Horse_test.go
@@ -105,7 +105,9 @@ func TestHorse_RotatesEveryNHands(t *testing.T) {
 // **1 ハンドごとの設定でも回る。**
 func TestHorse_RotatesEveryHandWhenConfiguredSo(t *testing.T) {
 	t.Parallel()
-	g := NewHorse(HorseConfig{Seats: 4, InitialChips: HorseDefaultChips, HandsPerDiscipline: 1})
+	// 既定の 1000 だと 6 ハンドでも席が飛びうる (実測 5/400)。上の 12 ハンドの
+	// テストと同じ理由で、卓を打ち切れる残高で作る。
+	g := NewHorse(HorseConfig{Seats: 4, InitialChips: 5000, HandsPerDiscipline: 1})
 	g.Reset()
 
 	seen := make([]HorseDiscipline, 0, 6)
@@ -117,10 +119,12 @@ func TestHorse_RotatesEveryHandWhenConfiguredSo(t *testing.T) {
 		}
 		require.NoError(t, g.NextHand())
 	}
-	require.GreaterOrEqual(t, len(seen), 6)
-	assert.Equal(t, []HorseDiscipline{
+	want := []HorseDiscipline{
 		HorseHoldem, HorseOmahaHiLo, HorseRazz, HorseStud, HorseStudHiLo, HorseHoldem,
-	}, seen[:6])
+	}
+	// 打てたぶんは必ず並びどおり ── 早く終わっても言えることは言う。
+	assert.Equal(t, want[:min(len(seen), len(want))], seen[:min(len(seen), len(want))])
+	require.GreaterOrEqual(t, len(seen), 6)
 }
 
 // **ハンドの途中で種目は変わらない。**


### PR DESCRIPTION
`TestHorse_RotatesEveryNHands` が配り依存で落ちます（#5344 の CI で顕在化）。

```
--- FAIL: TestHorse_RotatesEveryNHands
    Error: "8" is not greater than or equal to "11"
```

## 原因

既定の 1000 チップだと、12 ハンド折り続ける間に **CPU 同士の全賭けで席が飛ぶ**ことがあります。H.O.R.S.E. は 1 席でも飛べばマッチ終了なので、11 ハンドに届きません。

**実測**（各 300 回）:

| 初期チップ | 11 ハンド未満 |
|---:|---:|
| 1000（既定） | 13/300 (4.3%) |
| 5000 | 0/300 |
| 100000 | 0/300 |

## 修正

- 卓を 5000 チップで作る（12 ハンド折り続けても飛ばない）
- **打てたぶんの並びを先に assert する** — 早く終わった配りでも「H,H,O,O,R,R,S,S,E,E,H の前置と一致するか」は言えます。長さの要求はそのあとに置き、E→H の折り返しを見るために 11 ハンドを要求します

## Test plan

- [ ] CI 全緑
- [x] `go test -tags test ./internal/domain/ -run TestHorse_RotatesEveryNHands -count=60` 緑
- [x] `golangci-lint run ./internal/domain/` 0 issues