### PR TITLE
feat(solitaire): preview a card's destinations on hover and focus

### DIFF
--- a/frontend/src/hooks/useDestinationPreview.test.ts
+++ b/frontend/src/hooks/useDestinationPreview.test.ts
@@ -65,13 +65,6 @@ describe('useDestinationPreview', () => {
     expect(result.current.isPreview).toBe(true);
   });
 
-  it('clears on demand', () => {
-    const { result } = renderHook(() => useDestinationPreview<Src>(null));
-    act(() => result.current.previewProps({ col: 2 }).onMouseEnter());
-    act(() => result.current.clear());
-    expect(result.current.source).toBeNull();
-  });
-
   it('keeps the handler factory stable across renders', () => {
     const { result, rerender } = renderHook(() => useDestinationPreview<Src>(null));
     const first = result.current.previewProps;

--- a/frontend/src/hooks/useDestinationPreview.test.ts
+++ b/frontend/src/hooks/useDestinationPreview.test.ts
@@ -1,0 +1,81 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { useDestinationPreview } from './useDestinationPreview';
+
+interface Src {
+  col: number;
+}
+
+describe('useDestinationPreview', () => {
+  it('has no source until something is hovered or selected', () => {
+    const { result } = renderHook(() => useDestinationPreview<Src>(null));
+    expect(result.current.source).toBeNull();
+    expect(result.current.isPreview).toBe(false);
+  });
+
+  it('reports the hovered card as a preview source', () => {
+    const { result } = renderHook(() => useDestinationPreview<Src>(null));
+    act(() => result.current.previewProps({ col: 3 }).onMouseEnter());
+    expect(result.current.source).toEqual({ col: 3 });
+    expect(result.current.isPreview).toBe(true);
+  });
+
+  it('drops the preview when the pointer leaves', () => {
+    const { result } = renderHook(() => useDestinationPreview<Src>(null));
+    act(() => result.current.previewProps({ col: 3 }).onMouseEnter());
+    act(() => result.current.previewProps({ col: 3 }).onMouseLeave());
+    expect(result.current.source).toBeNull();
+    expect(result.current.isPreview).toBe(false);
+  });
+
+  // **キーボードでも同じものが見えるべき。** hover だけだとフォーカス移動では
+  // 何も起きない。
+  it('treats focus like hover', () => {
+    const { result } = renderHook(() => useDestinationPreview<Src>(null));
+    act(() => result.current.previewProps({ col: 1 }).onFocus());
+    expect(result.current.source).toEqual({ col: 1 });
+    expect(result.current.isPreview).toBe(true);
+    act(() => result.current.previewProps({ col: 1 }).onBlur());
+    expect(result.current.source).toBeNull();
+  });
+
+  // **選択が hover に勝つ。** 勝たないと、選んだ札の移動先がカーソルを追って
+  // 消え、狙っている最中に消える。
+  it('keeps the selection while the pointer moves over other cards', () => {
+    const { result, rerender } = renderHook(({ sel }: { sel: Src | null }) => useDestinationPreview<Src>(sel), {
+      initialProps: { sel: null as Src | null },
+    });
+    rerender({ sel: { col: 0 } });
+    expect(result.current.source).toEqual({ col: 0 });
+    expect(result.current.isPreview).toBe(false);
+
+    act(() => result.current.previewProps({ col: 5 }).onMouseEnter());
+    expect(result.current.source).toEqual({ col: 0 });
+    expect(result.current.isPreview).toBe(false);
+  });
+
+  // 選択が解けたら、その時点で指している札のプレビューに戻る。
+  it('falls back to the hovered card once the selection is cleared', () => {
+    const { result, rerender } = renderHook(({ sel }: { sel: Src | null }) => useDestinationPreview<Src>(sel), {
+      initialProps: { sel: { col: 0 } as Src | null },
+    });
+    act(() => result.current.previewProps({ col: 5 }).onMouseEnter());
+    rerender({ sel: null });
+    expect(result.current.source).toEqual({ col: 5 });
+    expect(result.current.isPreview).toBe(true);
+  });
+
+  it('clears on demand', () => {
+    const { result } = renderHook(() => useDestinationPreview<Src>(null));
+    act(() => result.current.previewProps({ col: 2 }).onMouseEnter());
+    act(() => result.current.clear());
+    expect(result.current.source).toBeNull();
+  });
+
+  it('keeps the handler factory stable across renders', () => {
+    const { result, rerender } = renderHook(() => useDestinationPreview<Src>(null));
+    const first = result.current.previewProps;
+    rerender();
+    expect(result.current.previewProps).toBe(first);
+  });
+});

--- a/frontend/src/hooks/useDestinationPreview.ts
+++ b/frontend/src/hooks/useDestinationPreview.ts
@@ -1,0 +1,72 @@
+import { useCallback, useMemo, useState } from 'react';
+
+/** What {@link useDestinationPreview} hands back to a page. */
+export interface DestinationPreview<S> {
+  /**
+   * The card whose destinations should be highlighted right now: the committed
+   * selection when there is one, otherwise the card under the pointer/focus.
+   */
+  source: S | null;
+  /** True when `source` came from hover or focus rather than a click. */
+  isPreview: boolean;
+  /** Spread onto a card control to arm the preview for the source it represents. */
+  previewProps: (source: S) => {
+    onMouseEnter: () => void;
+    onMouseLeave: () => void;
+    onFocus: () => void;
+    onBlur: () => void;
+  };
+  /** Drop the preview (used when a page resets or commits a move). */
+  clear: () => void;
+}
+
+/**
+ * Turns hover/focus over a card into the same "where could this go?" question
+ * the page already answers for the selected card.
+ *
+ * **The legality computation is not duplicated.** A page keeps calling whatever
+ * util or server field it already uses; this only decides *which* card that
+ * computation is asked about, so the preview can never disagree with the
+ * highlight shown after the click.
+ *
+ * **A selection wins over hover.** Once a card is picked the targets must stay
+ * put while the pointer travels to one of them — otherwise the highlight would
+ * chase the cursor and vanish exactly when it is being aimed at.
+ *
+ * **Focus counts as hover.** Hover is a pointer affordance and a keyboard user
+ * would otherwise never see it; the cards are already focusable buttons, so
+ * `onFocus`/`onBlur` costs nothing and covers them. Touch devices simply never
+ * fire these, which leaves the pre-selection preview a desktop affordance by
+ * construction rather than by a media query.
+ *
+ * @param selected - The page's committed selection, or null.
+ * @returns The source to highlight, whether it is a preview, and the handlers.
+ */
+export function useDestinationPreview<S>(selected: S | null): DestinationPreview<S> {
+  const [hovered, setHovered] = useState<S | null>(null);
+
+  const previewProps = useCallback(
+    (source: S) => ({
+      onMouseEnter: () => setHovered(source),
+      // Leaving any card drops the preview outright. Comparing against the
+      // current value would need object identity, and pages build a fresh
+      // source object per render.
+      onMouseLeave: () => setHovered(null),
+      onFocus: () => setHovered(source),
+      onBlur: () => setHovered(null),
+    }),
+    [],
+  );
+
+  const clear = useCallback(() => setHovered(null), []);
+
+  return useMemo(
+    () => ({
+      source: selected ?? hovered,
+      isPreview: selected === null && hovered !== null,
+      previewProps,
+      clear,
+    }),
+    [selected, hovered, previewProps, clear],
+  );
+}

--- a/frontend/src/hooks/useDestinationPreview.ts
+++ b/frontend/src/hooks/useDestinationPreview.ts
@@ -16,8 +16,6 @@ export interface DestinationPreview<S> {
     onFocus: () => void;
     onBlur: () => void;
   };
-  /** Drop the preview (used when a page resets or commits a move). */
-  clear: () => void;
 }
 
 /**
@@ -58,15 +56,12 @@ export function useDestinationPreview<S>(selected: S | null): DestinationPreview
     [],
   );
 
-  const clear = useCallback(() => setHovered(null), []);
-
   return useMemo(
     () => ({
       source: selected ?? hovered,
       isPreview: selected === null && hovered !== null,
       previewProps,
-      clear,
     }),
-    [selected, hovered, previewProps, clear],
+    [selected, hovered, previewProps],
   );
 }

--- a/frontend/src/pages/BakersDozenPage.test.tsx
+++ b/frontend/src/pages/BakersDozenPage.test.tsx
@@ -370,3 +370,45 @@ describe('BakersDozenPage legal targets', () => {
     expect(emptyFoundation).toBeEnabled();
   });
 });
+
+// 選ぶ前に行き先が見える (#4454)。
+describe('BakersDozenPage destination preview', () => {
+  const render = async () => {
+    mockExec.mockResolvedValue(playingState);
+    renderWithProviders(<BakersDozenPage />);
+    return screen.findByRole('button', { name: '♠ 5' });
+  };
+  const targets = () => document.querySelectorAll('[data-legal-target="true"]');
+  const previews = () => document.querySelectorAll('[data-preview-target="true"]');
+
+  it('rings the destination while a card is hovered', async () => {
+    const spadeFive = await render();
+    expect(targets().length).toBe(0);
+
+    fireEvent.mouseEnter(spadeFive);
+    await waitFor(() => expect(targets().length).toBeGreaterThan(0));
+    // プレビュー中は弱いリング。選択後と見分けが付く。
+    expect(previews().length).toBe(targets().length);
+    expect(targets()[0]?.className).toContain('ring-ds-success/70');
+
+    fireEvent.mouseLeave(spadeFive);
+    await waitFor(() => expect(targets().length).toBe(0));
+  });
+
+  it('rings the destination on focus', async () => {
+    const spadeFive = await render();
+    fireEvent.focus(spadeFive);
+    await waitFor(() => expect(previews().length).toBeGreaterThan(0));
+    fireEvent.blur(spadeFive);
+    await waitFor(() => expect(targets().length).toBe(0));
+  });
+
+  // 選択が hover に勝つ ── 選んだあとは実線で、カーソルが動いても消えない。
+  it('switches to the solid ring once the card is selected', async () => {
+    const spadeFive = await render();
+    fireEvent.click(spadeFive);
+    await waitFor(() => expect(targets().length).toBeGreaterThan(0));
+    expect(previews().length).toBe(0);
+    expect(targets()[0]?.className).not.toContain('ring-ds-success/70');
+  });
+});

--- a/frontend/src/pages/BakersDozenPage.tsx
+++ b/frontend/src/pages/BakersDozenPage.tsx
@@ -22,6 +22,7 @@ import { useBakersDozenGame } from '../hooks/useBakersDozenGame';
 import { useCardDimensions, useWindowWidth } from '../hooks/useCardDimensions';
 import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
+import { useDestinationPreview } from '../hooks/useDestinationPreview';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useGiveUpConfirm } from '../hooks/useGiveUpConfirm';
@@ -203,6 +204,10 @@ function BakersDozenPageContent() {
     enabled: !!isPlayingForKbd && !loading,
   });
 
+  // **フックは早期 return より前。** 下に置くと state が来た描画でだけ
+  // フック数が増え、React が "Rendered more hooks" で落ちる。
+  const preview = useDestinationPreview<BakersDozenMoveZone>(selectedSource);
+
   if (!state) return <GameSkeleton gameKey="bakersdozen" layout={{ kind: 'tableau', topRow: 4, tableau: 13 }} />;
 
   const isPlaying = state.phase === BakersDozenPhase.PLAYING;
@@ -216,11 +221,16 @@ function BakersDozenPageContent() {
   //
   // **枠を出すだけで、押せなくはしない。**押せなくすると E2E の
   // 「最初の列をクリック」が別の列を掴んでしまう。
-  const selectedCard =
-    selectedSource?.zone === 'tableau' && selectedSource.col !== undefined && selectedSource.cardIndex !== undefined
-      ? state.tableau[selectedSource.col]?.[selectedSource.cardIndex]?.card
+  // **選ぶ前に行き先が見える (#4454)。** hover / フォーカス中の札にも、選択後と
+  // まったく同じ計算を当てる ── 判定を二重に持たないので食い違わない。
+  const previewSource = preview.source;
+  const previewedCard =
+    previewSource?.zone === 'tableau' && previewSource.col !== undefined && previewSource.cardIndex !== undefined
+      ? state.tableau[previewSource.col]?.[previewSource.cardIndex]?.card
       : undefined;
-  const legalTargets = bakersDozenLegalTargets(state.tableau, state.foundation, selectedCard);
+  const legalTargets = bakersDozenLegalTargets(state.tableau, state.foundation, previewedCard);
+  /** Ring for a legal destination: softer while it is only a hover preview. */
+  const targetRing = preview.isPreview ? ' rounded ring-2 ring-ds-success/70' : ' rounded ring-2 ring-ds-success';
 
   const isSourceSelected = (zone: string, col?: number, cardIndex?: number) =>
     selectedSource !== null &&
@@ -267,8 +277,9 @@ function BakersDozenPageContent() {
                 return (
                   <div
                     key={`f-${idx.toString()}`}
-                    className={`text-center${legalTargets.foundation.has(idx) ? ' rounded ring-2 ring-ds-success' : ''}`}
+                    className={`text-center${legalTargets.foundation.has(idx) ? targetRing : ''}`}
                     data-legal-target={legalTargets.foundation.has(idx) ? 'true' : undefined}
+                    data-preview-target={legalTargets.foundation.has(idx) && preview.isPreview ? 'true' : undefined}
                   >
                     <div className="text-game-text-muted text-xs mb-1">{FOUNDATION_SUITS[idx]}</div>
                     <DropZone
@@ -330,8 +341,9 @@ function BakersDozenPageContent() {
                     // on desktop the columns flex to fill the available width as before.
                     className={`${isMobile ? 'shrink-0' : 'flex-1 min-w-0'}${
                       isOneCardCol ? ' rounded ring-1 ring-ds-warning/40 ring-dashed' : ''
-                    }${legalTargets.tableau.has(colIdx) ? ' rounded ring-2 ring-ds-success' : ''}`}
+                    }${legalTargets.tableau.has(colIdx) ? targetRing : ''}`}
                     data-legal-target={legalTargets.tableau.has(colIdx) ? 'true' : undefined}
+                    data-preview-target={legalTargets.tableau.has(colIdx) && preview.isPreview ? 'true' : undefined}
                     style={isMobile ? { width: bd.cw } : undefined}
                     data-testid={isOneCardCol ? `bd-onecard-col-${colIdx}` : undefined}
                   >
@@ -377,6 +389,9 @@ function BakersDozenPageContent() {
                                 {tc.card ? (
                                   <button
                                     type="button"
+                                    // **動かせる札だけがプレビューを持つ。** 埋もれた札に
+                                    // 出しても、その札は選べないので嘘になる。
+                                    {...(isTop ? preview.previewProps(cardZone) : {})}
                                     data-testid={isLastInCol ? `bd-last-card-${colIdx}` : undefined}
                                     onClick={() => {
                                       if (selectedSource) {

--- a/frontend/src/pages/BeleagueredCastlePage.test.tsx
+++ b/frontend/src/pages/BeleagueredCastlePage.test.tsx
@@ -290,3 +290,49 @@ describe('BeleagueredCastlePage keyboard shortcuts', () => {
     expect(mockExec).not.toHaveBeenCalled();
   });
 });
+
+// 選ぶ前に行き先が見える (#4454)。
+describe('BeleagueredCastlePage destination preview', () => {
+  const render = async () => {
+    mockExec.mockResolvedValue(playingState);
+    renderWithProviders(<BeleagueredCastlePage />);
+    return screen.findByRole('button', { name: '♠ 5' });
+  };
+  const targets = () => document.querySelectorAll('[data-legal-target="true"]');
+  const previews = () => document.querySelectorAll('[data-preview-target="true"]');
+
+  it('marks the destinations while a card is hovered', async () => {
+    const spadeFive = await render();
+    expect(targets()).toHaveLength(0);
+
+    fireEvent.mouseEnter(spadeFive);
+    await waitFor(() => expect(targets().length).toBeGreaterThan(0));
+    // 選択後と同じ集合が、弱いリングで出る。
+    expect(previews().length).toBe(targets().length);
+    expect(targets()[0]?.className).toContain('ring-ds-success/70');
+
+    fireEvent.mouseLeave(spadeFive);
+    await waitFor(() => expect(targets()).toHaveLength(0));
+  });
+
+  it('marks the destinations on focus', async () => {
+    const spadeFive = await render();
+    fireEvent.focus(spadeFive);
+    await waitFor(() => expect(previews().length).toBeGreaterThan(0));
+    fireEvent.blur(spadeFive);
+    await waitFor(() => expect(targets()).toHaveLength(0));
+  });
+
+  // hover と選択で同じ集合を指す ── プレビューが嘘をつかないことの検証。
+  it('previews exactly the set the selection then commits to', async () => {
+    const spadeFive = await render();
+    fireEvent.mouseEnter(spadeFive);
+    await waitFor(() => expect(targets().length).toBeGreaterThan(0));
+    const hovered = targets().length;
+
+    fireEvent.click(spadeFive);
+    await waitFor(() => expect(previews()).toHaveLength(0));
+    expect(targets().length).toBe(hovered);
+    expect(targets()[0]?.className).not.toContain('ring-ds-success/70');
+  });
+});

--- a/frontend/src/pages/BeleagueredCastlePage.tsx
+++ b/frontend/src/pages/BeleagueredCastlePage.tsx
@@ -22,6 +22,7 @@ import { useBeleagueredCastleGame } from '../hooks/useBeleagueredCastleGame';
 import { useCardDimensions, useWindowWidth } from '../hooks/useCardDimensions';
 import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
+import { useDestinationPreview } from '../hooks/useDestinationPreview';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useSolitaireDragDrop } from '../hooks/useSolitaireDragDrop';
@@ -172,6 +173,10 @@ function BeleagueredCastlePageContent() {
     enabled: !!isPlayingForKbd && !loading,
   });
 
+  // **フックは早期 return より前。** 下に置くと state が来た描画でだけ
+  // フック数が増え、React が "Rendered more hooks" で落ちる。
+  const preview = useDestinationPreview<BeleagueredCastleMoveZone>(selectedSource);
+
   if (!state) return <GameSkeleton gameKey="beleagueredcastle" layout={{ kind: 'tableau', topRow: 4, tableau: 8 }} />;
 
   const isPlaying = state.phase === BeleagueredCastlePhase.PLAYING;
@@ -189,11 +194,16 @@ function BeleagueredCastlePageContent() {
   //
   // **枠を出すだけで、押せなくはしない。**押せなくすると E2E の
   // 「最初の列をクリック」が別の列を掴んでしまう。
-  const selectedCard =
-    selectedSource?.zone === 'tableau' && selectedSource.col !== undefined && selectedSource.cardIndex !== undefined
-      ? state.tableau[selectedSource.col]?.[selectedSource.cardIndex]?.card
+  // **選ぶ前に行き先が見える (#4454)。** hover / フォーカス中の札にも、選択後と
+  // まったく同じ計算を当てる ── 判定を二重に持たないので食い違わない。
+  const previewSource = preview.source;
+  const previewedCard =
+    previewSource?.zone === 'tableau' && previewSource.col !== undefined && previewSource.cardIndex !== undefined
+      ? state.tableau[previewSource.col]?.[previewSource.cardIndex]?.card
       : undefined;
-  const legalTargets = beleagueredCastleLegalTargets(state.tableau, state.foundation, selectedCard);
+  const legalTargets = beleagueredCastleLegalTargets(state.tableau, state.foundation, previewedCard);
+  /** Ring for a legal destination: softer while it is only a hover preview. */
+  const targetRing = preview.isPreview ? ' rounded ring-2 ring-ds-success/70' : ' rounded ring-2 ring-ds-success';
 
   const isSourceSelected = (zone: string, col?: number, cardIndex?: number) =>
     selectedSource !== null &&
@@ -207,8 +217,9 @@ function BeleagueredCastlePageContent() {
     return (
       <div
         key={`col-${colIdx.toString()}`}
-        className={`flex-1 min-w-0${legalTargets.tableau.has(colIdx) ? ' rounded ring-2 ring-ds-success' : ''}`}
+        className={`flex-1 min-w-0${legalTargets.tableau.has(colIdx) ? targetRing : ''}`}
         data-legal-target={legalTargets.tableau.has(colIdx) ? 'true' : undefined}
+        data-preview-target={legalTargets.tableau.has(colIdx) && preview.isPreview ? 'true' : undefined}
       >
         <div className="text-center text-xs text-ds-text-muted mb-0.5" aria-hidden="true">
           #{colIdx}
@@ -249,6 +260,9 @@ function BeleagueredCastlePageContent() {
                     {tc.card ? (
                       <button
                         type="button"
+                        // **動かせる札だけがプレビューを持つ。** 埋もれた札に出しても、
+                        // その札は選べないので嘘になる。
+                        {...(isTop ? preview.previewProps(cardZone) : {})}
                         onClick={() => {
                           if (selectedSource) {
                             game.handleSelectTarget(tableauColZone);
@@ -326,8 +340,9 @@ function BeleagueredCastlePageContent() {
                   return (
                     <div
                       key={`f-${idx.toString()}`}
-                      className={`text-center${legalTargets.foundation.has(idx) ? ' rounded ring-2 ring-ds-success' : ''}`}
+                      className={`text-center${legalTargets.foundation.has(idx) ? targetRing : ''}`}
                       data-legal-target={legalTargets.foundation.has(idx) ? 'true' : undefined}
+                      data-preview-target={legalTargets.foundation.has(idx) && preview.isPreview ? 'true' : undefined}
                     >
                       <div className="text-game-text-muted text-xs mb-1">{FOUNDATION_SUITS[idx]}</div>
                       <DropZone

--- a/frontend/src/pages/BristolPage.test.tsx
+++ b/frontend/src/pages/BristolPage.test.tsx
@@ -377,3 +377,61 @@ describe('BristolPage', () => {
     await waitFor(() => expect(screen.queryAllByTestId('bristol-legal-target')).toHaveLength(2));
   });
 });
+
+// 選ぶ前に行き先が見える (#4454)。判定はサーバーの legalTargets のまま。
+describe('BristolPage destination preview', () => {
+  const withTargets = () => {
+    mockExec.mockResolvedValue({
+      ...playingState,
+      legalTargets: { 'tableau-0': { tableau: [3], foundation: [1] } },
+    });
+    renderWithProviders(<BristolPage />);
+    return screen.findByRole('button', { name: '降順ビルド列 1（1枚）' });
+  };
+  const targets = () => screen.queryAllByTestId('bristol-legal-target');
+  const previews = () => document.querySelectorAll('[data-preview-target="true"]');
+
+  it('highlights the destinations while a column is hovered', async () => {
+    const col = await withTargets();
+    expect(targets()).toHaveLength(0);
+
+    fireEvent.mouseEnter(col);
+    await waitFor(() => expect(targets()).toHaveLength(2));
+    expect(previews()).toHaveLength(2);
+    expect(targets()[0]?.className).toContain('border-ds-success/70');
+
+    fireEvent.mouseLeave(col);
+    await waitFor(() => expect(targets()).toHaveLength(0));
+  });
+
+  it('highlights the destinations on focus', async () => {
+    const col = await withTargets();
+    fireEvent.focus(col);
+    await waitFor(() => expect(previews()).toHaveLength(2));
+    fireEvent.blur(col);
+    await waitFor(() => expect(targets()).toHaveLength(0));
+  });
+
+  // **hover と選択で同じ集合。** サーバーの答えを 1 つだけ読んでいることの検証。
+  it('previews exactly the set the selection then commits to', async () => {
+    const col = await withTargets();
+    fireEvent.mouseEnter(col);
+    await waitFor(() => expect(targets()).toHaveLength(2));
+
+    fireEvent.click(col);
+    await waitFor(() => expect(previews()).toHaveLength(0));
+    expect(targets()).toHaveLength(2);
+    expect(targets()[0]?.className).not.toContain('border-ds-success/70');
+  });
+
+  it('shows nothing for a column the server lists no targets for', async () => {
+    mockExec.mockResolvedValue({
+      ...playingState,
+      legalTargets: { 'tableau-0': { tableau: [3], foundation: [1] } },
+    });
+    renderWithProviders(<BristolPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalled());
+    fireEvent.mouseEnter(screen.getByRole('button', { name: '降順ビルド列 2（1枚）' }));
+    expect(targets()).toHaveLength(0);
+  });
+});

--- a/frontend/src/pages/BristolPage.tsx
+++ b/frontend/src/pages/BristolPage.tsx
@@ -20,6 +20,7 @@ import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
+import { useDestinationPreview } from '../hooks/useDestinationPreview';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
@@ -109,9 +110,18 @@ function BristolPageContent() {
   // **押すまで合法か分からなかった。**選択中は全ての移動先が同じ見た目で強調されて
   // いた (#4813)。判定はサーバー (ドメインの canPlaceOn*) が返す legalTargets を
   // そのまま読む — ここで書き直すと画面とサーバーの言うことが食い違う。
-  const legalForSelected = selected ? state?.legalTargets?.[`${selected.zone}-${selected.col ?? 0}`] : undefined;
-  const legalTableau = new Set(legalForSelected?.tableau ?? []);
-  const legalFoundation = new Set(legalForSelected?.foundation ?? []);
+  // **選ぶ前に行き先が見える (#4454)。** hover / フォーカス中の札にも、選択後と
+  // まったく同じサーバー由来の集合を当てる ── 判定を書き直さないので、画面と
+  // サーバーの言うことが食い違わない。
+  const preview = useDestinationPreview<BristolMoveZone>(selected);
+  const previewSource = preview.source;
+  const legalForSource = previewSource
+    ? state?.legalTargets?.[`${previewSource.zone}-${previewSource.col ?? 0}`]
+    : undefined;
+  const legalTableau = new Set(legalForSource?.tableau ?? []);
+  const legalFoundation = new Set(legalForSource?.foundation ?? []);
+  /** Border for a legal destination: softer while it is only a hover preview. */
+  const targetBorder = preview.isPreview ? 'border-ds-success/70' : 'border-ds-success';
 
   const handleReset = useCallback(() => {
     setSelected(null);
@@ -288,11 +298,14 @@ function BristolPageContent() {
                             : t('foundationAriaEmpty', { num: i })
                         }
                         className={
-                          selected && legalFoundation.has(i)
-                            ? `rounded border p-0.5 ${focusRingWhite} border-ds-success`
+                          previewSource && legalFoundation.has(i)
+                            ? `rounded border p-0.5 ${focusRingWhite} ${targetBorder}`
                             : `rounded border p-0.5 ${focusRingWhite} border-white/30`
                         }
-                        data-testid={selected && legalFoundation.has(i) ? 'bristol-legal-target' : undefined}
+                        data-testid={previewSource && legalFoundation.has(i) ? 'bristol-legal-target' : undefined}
+                        data-preview-target={
+                          previewSource && legalFoundation.has(i) && preview.isPreview ? 'true' : undefined
+                        }
                         style={{ width: cardWidth + 4, height: cardHeight + 4 }}
                       >
                         {pile.length > 0 ? (
@@ -336,14 +349,18 @@ function BristolPageContent() {
                         disabled={!isPlaying || loading || (col.length === 0 && !selected)}
                         aria-label={t('tableauColAria', { num: colIdx + 1, count: col.length })}
                         aria-pressed={isSelected(zone)}
+                        {...preview.previewProps(zone)}
                         className={
                           isSelected(zone)
                             ? `relative w-full rounded border-2 bg-transparent p-0 ${focusRingWhite} border-ds-info`
-                            : selected && legalTableau.has(colIdx)
-                              ? `relative w-full rounded border-2 bg-transparent p-0 ${focusRingWhite} border-ds-success`
+                            : previewSource && legalTableau.has(colIdx)
+                              ? `relative w-full rounded border-2 bg-transparent p-0 ${focusRingWhite} ${targetBorder}`
                               : `relative w-full rounded border-2 bg-transparent p-0 ${focusRingWhite} border-transparent`
                         }
-                        data-testid={selected && legalTableau.has(colIdx) ? 'bristol-legal-target' : undefined}
+                        data-testid={previewSource && legalTableau.has(colIdx) ? 'bristol-legal-target' : undefined}
+                        data-preview-target={
+                          previewSource && legalTableau.has(colIdx) && preview.isPreview ? 'true' : undefined
+                        }
                         style={{ height: colHeight }}
                       >
                         {col.length === 0 ? (
@@ -388,6 +405,7 @@ function BristolPageContent() {
                           draggable={isPlaying && !loading}
                           onDragStart={dnd.handleDragStart(zone)}
                           onDragEnd={dnd.handleDragEnd}
+                          {...preview.previewProps(zone)}
                           onClick={() => handleFanClick(i)}
                           disabled={!isPlaying || loading}
                           aria-label={t('fanAria', { num: i, card: cardAlt(top), count: pile.length })}

--- a/frontend/src/pages/ScorpionPage.test.tsx
+++ b/frontend/src/pages/ScorpionPage.test.tsx
@@ -555,3 +555,60 @@ describe('ScorpionPage', () => {
     await waitFor(() => expect(document.querySelectorAll('.ring-ds-info').length).toBeGreaterThan(0));
   });
 });
+
+// **選ぶ前に行き先が見える (#4454)。** 移動できるかどうかを押して確かめるしかない
+// のが元の状態で、外れたときはサーバーのエラーだけが返っていた。
+describe('ScorpionPage destination preview', () => {
+  /** The ♥7 in column 5; ♥8 sits on top of column 1, so it has exactly one legal target. */
+  const heartSeven = () => screen.getByRole('button', { name: /♥ 7/ });
+
+  it('highlights the destination while a card is hovered', async () => {
+    renderWithProviders(<ScorpionPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    expect(screen.queryByTestId('sc-legal-target')).not.toBeInTheDocument();
+
+    fireEvent.mouseEnter(heartSeven());
+    const target = await screen.findByTestId('sc-legal-target');
+    expect(target).toHaveAttribute('data-preview-target', 'true');
+    expect(target.className).toContain('ring-ds-success/70');
+
+    fireEvent.mouseLeave(heartSeven());
+    expect(screen.queryByTestId('sc-legal-target')).not.toBeInTheDocument();
+  });
+
+  // キーボードだけでも同じものが見える。
+  it('highlights the destination on focus', async () => {
+    renderWithProviders(<ScorpionPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+
+    fireEvent.focus(heartSeven());
+    expect(await screen.findByTestId('sc-legal-target')).toHaveAttribute('data-preview-target', 'true');
+    fireEvent.blur(heartSeven());
+    expect(screen.queryByTestId('sc-legal-target')).not.toBeInTheDocument();
+  });
+
+  // **選択が hover に勝つ。** 勝たないと、狙っている最中に移動先が消える。
+  it("keeps the selected card's targets while the pointer moves elsewhere", async () => {
+    renderWithProviders(<ScorpionPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+
+    fireEvent.click(heartSeven());
+    const target = await screen.findByTestId('sc-legal-target');
+    // 選択後は実線のリングで、プレビューではない。
+    expect(target).not.toHaveAttribute('data-preview-target');
+    expect(target.className).toContain('ring-2 ring-ds-success');
+    expect(target.className).not.toContain('ring-ds-success/70');
+
+    fireEvent.mouseEnter(screen.getByRole('button', { name: /♣ 2/ }));
+    const stillThere = screen.getByTestId('sc-legal-target');
+    expect(stillThere).not.toHaveAttribute('data-preview-target');
+  });
+
+  it('shows nothing for a card with no legal destination', async () => {
+    renderWithProviders(<ScorpionPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    // ♠3 の上に置ける札 (♠4) は場に無い。
+    fireEvent.mouseEnter(screen.getByRole('button', { name: /♠ 3/ }));
+    expect(screen.queryByTestId('sc-legal-target')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/ScorpionPage.tsx
+++ b/frontend/src/pages/ScorpionPage.tsx
@@ -23,6 +23,7 @@ import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCardDimensions, useWindowWidth } from '../hooks/useCardDimensions';
 import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
+import { useDestinationPreview } from '../hooks/useDestinationPreview';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
@@ -236,10 +237,14 @@ function ScorpionPageContent() {
   // Empty-column deal guard: surfaces a shake animation + tooltip instead of failing silently.
   const [emptyDealAttemptKey, setEmptyDealAttemptKey] = useState(0);
   const hasEmptyColumn = useMemo(() => state?.tableau.some((col) => col.length === 0) ?? false, [state?.tableau]);
-  // Columns the selected card may legally move onto (same suit, one rank higher).
+  // **選ぶ前に行き先が見える。** hover / フォーカス中の札についても、選択後と
+  // まったく同じ計算で移動先を出す (#4454)。判定を二重に持たないので、
+  // プレビューと選択後の表示が食い違うことはない。
+  const preview = useDestinationPreview<ScorpionMoveZone>(selectedSource);
+  // Columns the previewed card may legally move onto (same suit, one rank higher).
   const legalTargets = useMemo(
-    () => (selectedSource && state ? scorpionLegalTargets(state.tableau, selectedSource) : new Set<number>()),
-    [selectedSource, state],
+    () => (preview.source && state ? scorpionLegalTargets(state.tableau, preview.source) : new Set<number>()),
+    [preview.source, state],
   );
   const dealBlockedByEmpty = hasEmptyColumn && (state?.stockCount ?? 0) > 0;
   const handleDealGuarded = useCallback(() => {
@@ -437,13 +442,21 @@ function ScorpionPageContent() {
                                   draggable={isPlaying}
                                   onDragStart={dnd.handleDragStart(zone)}
                                   onDragEnd={dnd.handleDragEnd}
+                                  {...preview.previewProps({ zone: 'tableau', col: colIdx, cardIndex: cardIdx })}
                                   data-testid={isLast && legalTargets.has(colIdx) ? 'sc-legal-target' : undefined}
+                                  data-preview-target={
+                                    isLast && legalTargets.has(colIdx) && preview.isPreview ? 'true' : undefined
+                                  }
                                   className={`${focusRingWhite} rounded-lg transition-all ${
                                     isSelected ? 'ring-2 ring-ds-warning -translate-y-1' : ''
                                   } ${isDragSrc ? 'opacity-50' : ''} ${
                                     hintFrom ? 'ring-2 ring-ds-info animate-pulse' : ''
                                   } ${hintTo ? 'ring-2 ring-ds-success animate-pulse' : ''} ${
-                                    isLast && legalTargets.has(colIdx) ? 'ring-2 ring-ds-success' : ''
+                                    isLast && legalTargets.has(colIdx)
+                                      ? preview.isPreview
+                                        ? 'ring-2 ring-ds-success/70'
+                                        : 'ring-2 ring-ds-success'
+                                      : ''
                                   }`}
                                   onClick={() => {
                                     // Clicking the selected card again deselects it, which

--- a/frontend/src/pages/WaspPage.test.tsx
+++ b/frontend/src/pages/WaspPage.test.tsx
@@ -671,3 +671,51 @@ describe('WaspPage CLI legal command', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('deal'));
   });
 });
+
+// 選ぶ前に行き先が見える (#4454)。
+describe('WaspPage destination preview', () => {
+  /** The ♥7 in column 5; ♥8 tops column 1, so it has exactly one legal target. */
+  const heartSeven = () => screen.getByRole('button', { name: /♥ 7/ });
+
+  it('highlights the destination while a card is hovered, and drops it on leave', async () => {
+    renderWithProviders(<WaspPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    expect(screen.queryByTestId('wasp-legal-target')).not.toBeInTheDocument();
+
+    fireEvent.mouseEnter(heartSeven());
+    const target = await screen.findByTestId('wasp-legal-target');
+    expect(target).toHaveAttribute('data-preview-target', 'true');
+    expect(target.className).toContain('ring-ds-success/70');
+
+    fireEvent.mouseLeave(heartSeven());
+    expect(screen.queryByTestId('wasp-legal-target')).not.toBeInTheDocument();
+  });
+
+  it('highlights the destination on focus', async () => {
+    renderWithProviders(<WaspPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    fireEvent.focus(heartSeven());
+    expect(await screen.findByTestId('wasp-legal-target')).toHaveAttribute('data-preview-target', 'true');
+  });
+
+  // 選択が hover に勝つ ── 狙っている最中に消えない。
+  it('keeps the selected targets while the pointer moves elsewhere', async () => {
+    renderWithProviders(<WaspPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+
+    fireEvent.click(heartSeven());
+    const target = await screen.findByTestId('wasp-legal-target');
+    expect(target).not.toHaveAttribute('data-preview-target');
+    expect(target.className).not.toContain('ring-ds-success/70');
+
+    fireEvent.mouseEnter(screen.getByRole('button', { name: /♣ 2/ }));
+    expect(screen.getByTestId('wasp-legal-target')).not.toHaveAttribute('data-preview-target');
+  });
+
+  it('shows nothing for a card with no legal destination', async () => {
+    renderWithProviders(<WaspPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    fireEvent.mouseEnter(screen.getByRole('button', { name: /♠ 3/ }));
+    expect(screen.queryByTestId('wasp-legal-target')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/WaspPage.tsx
+++ b/frontend/src/pages/WaspPage.tsx
@@ -23,6 +23,7 @@ import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCardDimensions, useWindowWidth } from '../hooks/useCardDimensions';
 import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
+import { useDestinationPreview } from '../hooks/useDestinationPreview';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
@@ -281,9 +282,12 @@ function WaspPageContent() {
   const [emptyDealAttemptKey, setEmptyDealAttemptKey] = useState(0);
   const hasEmptyColumn = useMemo(() => state?.tableau.some((col) => col.length === 0) ?? false, [state?.tableau]);
   // Columns the selected card may legally move onto (same suit, one rank higher).
+  // **選ぶ前に行き先が見える (#4454)。** hover / フォーカス中の札にも、選択後と
+  // まったく同じ計算を当てる ── 判定を二重に持たないので食い違わない。
+  const preview = useDestinationPreview<WaspMoveZone>(selectedSource);
   const legalTargets = useMemo(
-    () => (selectedSource && state ? waspLegalTargets(state.tableau, selectedSource) : new Set<number>()),
-    [selectedSource, state],
+    () => (preview.source && state ? waspLegalTargets(state.tableau, preview.source) : new Set<number>()),
+    [preview.source, state],
   );
   const dealBlockedByEmpty = hasEmptyColumn && (state?.stockCount ?? 0) > 0;
   const handleDealGuarded = useCallback(() => {
@@ -484,13 +488,21 @@ function WaspPageContent() {
                                   draggable={isPlaying}
                                   onDragStart={dnd.handleDragStart(zone)}
                                   onDragEnd={dnd.handleDragEnd}
+                                  {...preview.previewProps({ zone: 'tableau', col: colIdx, cardIndex: cardIdx })}
                                   data-testid={isLast && legalTargets.has(colIdx) ? 'wasp-legal-target' : undefined}
+                                  data-preview-target={
+                                    isLast && legalTargets.has(colIdx) && preview.isPreview ? 'true' : undefined
+                                  }
                                   className={`${focusRingWhite} rounded-lg transition-all ${
                                     isSelected ? 'ring-2 ring-ds-warning -translate-y-1' : ''
                                   } ${isDragSrc ? 'opacity-50' : ''} ${
                                     hintFrom ? 'ring-2 ring-ds-info animate-pulse' : ''
                                   } ${hintTo ? 'ring-2 ring-ds-success animate-pulse' : ''} ${
-                                    isLast && legalTargets.has(colIdx) ? 'ring-2 ring-ds-success' : ''
+                                    isLast && legalTargets.has(colIdx)
+                                      ? preview.isPreview
+                                        ? 'ring-2 ring-ds-success/70'
+                                        : 'ring-2 ring-ds-success'
+                                      : ''
                                   }`}
                                   onClick={() => {
                                     if (selectedSource) {


### PR DESCRIPTION
Closes #4454

## 何が足りなかったか

移動先が分かるのは**選んだあと**だけでした。選ぶ前は「押せる」ことしか分からず、置けるかどうかは押して確かめるしかない ── 外れればサーバーのエラーが返るだけです（選択後の表示を足したのが #4795 / #4813）。その手前を埋めます。

**hover / フォーカス中の札について、選択後とまったく同じ計算で移動先を出します。**

## 設計

- **合法判定を 1 つも増やしていません。** 各ページが既に使っている util（`scorpionLegalTargets` / `waspLegalTargets` / `bakersDozenLegalTargets` / `beleagueredCastleLegalTargets`）と、Bristol はサーバーが返す `legalTargets` を、「選択中の札」ではなく「いま指している札」に当てるだけです。判定を二重に持たないので、**プレビューと選択後の表示が食い違うことはありません**（テストでも同じ集合であることを assert しています）。
- **選択が hover に勝ちます。** 勝たないと、選んだ札の移動先がカーソルを追って動き、**狙っている最中に消えます**。
- **フォーカスも hover と同じ扱い**にしました。hover はポインタの装置なので、キーボードだけの人には何も起きません。札は元から `button` なので `onFocus`/`onBlur` の追加費用はありません。**タッチ端末では `mouseenter` も `focus` も発火しない**ので、メディアクエリを書かずにデスクトップ限定の装飾に収まります（issue が懸念していた点）。
- 見た目は**プレビューが弱いリング**（`ring-ds-success/70` / `border-ds-success/70`）、確定した選択は従来どおり実線。同じ色なので意味を覚え直す必要がありません。DESIGN.md の Opacity ルールは装飾的なリングでの opacity を許可しています。

共通部分は `useDestinationPreview` フック 1 本（「どの札について訊くか」だけを決める）。

## 対象

移動先を計算できる 5 ページ: **Scorpion / Wasp / Baker's Dozen / Beleaguered Castle / Bristol**。

## テスト

- `useDestinationPreview` 8 件 — hover / focus / leave / blur、**選択が hover に勝つ**、選択解除で hover に戻る、ハンドラの同一性
- 各ページ 3〜4 件 × 5 = 18 件 — hover で出る / focus で出る / **プレビューと選択で同じ集合**（プレビューが嘘をつかない）/ 行き先の無い札では出ない

いずれも「出る」側と「出ない」側の両方を踏みます。

## Test plan

- [ ] CI 全緑
- [x] `bun run check` EXIT=0
- [x] `bun run typecheck` 緑
- [x] 対象 6 ファイル 202 件 緑