### PR TITLE
test(guard): check sequence and state diagrams, and the owner of each identifier

### DIFF
--- a/docs/design/backend.md
+++ b/docs/design/backend.md
@@ -1828,7 +1828,7 @@ sequenceDiagram
 
     User->>Main: go run ./cmd/trumpcards
     Main->>GM: NewGameManager()
-    Main->>GM: RunInteractiveCuiLoop()
+    Main->>GM: ui.RunInteractiveCuiLoop(manager)
 
     loop REPL ループ
         User->>GM: コマンド入力 (例: "hit")
@@ -1865,7 +1865,7 @@ sequenceDiagram
 
     WebCtrl->>Store: GetWithLock("abc123", factory)
     alt 新規セッション
-        Store->>Store: factory() でInteractor生成
+        Store->>Store: factory フィールドで Interactor 生成
         Store-->>WebCtrl: 新規Interactor
     else 既存セッション
         Store-->>WebCtrl: 既存Interactor (mutex lock)
@@ -1895,7 +1895,7 @@ sequenceDiagram
     Store->>Store: entries["sess-1"] 作成 + mutex lock
     Note over Store: Interactor A 生成
     Store-->>WebCtrl: Interactor A (locked)
-    WebCtrl->>WebCtrl: Reset() 実行
+    WebCtrl->>WebCtrl: reset コマンドを dispatch
     WebCtrl->>Store: mutex unlock
     WebCtrl-->>C1: レスポンス
 
@@ -1904,7 +1904,7 @@ sequenceDiagram
     Store->>Store: sessions["sess-2"] 作成 + mutex lock
     Note over Store: Interactor B 生成 (独立)
     Store-->>WebCtrl: Interactor B (locked)
-    WebCtrl->>WebCtrl: Reset() 実行
+    WebCtrl->>WebCtrl: reset コマンドを dispatch
     WebCtrl->>Store: mutex unlock
     WebCtrl-->>C2: レスポンス
 
@@ -1958,7 +1958,7 @@ sequenceDiagram
     Note over User,Pres: ベットフロー
     User->>Ctrl: bet 100 50
     Ctrl->>Interactor: Bet(100, 50)
-    Interactor->>Domain: PlayerBet(100, 50)
+    Interactor->>Domain: Bet(100, 50)
     Domain->>Domain: チップ減算 → 3枚ずつ配布 → phase=Action
     Domain-->>Interactor: nil
     Interactor->>Pres: Output(game, nil)
@@ -1967,7 +1967,7 @@ sequenceDiagram
     Note over User,Pres: プレイフロー
     User->>Ctrl: play
     Ctrl->>Interactor: Play()
-    Interactor->>Domain: PlayerPlay()
+    Interactor->>Domain: Play()
     Domain->>Domain: プレイベット = アンティ額
     Domain->>Eval: evalThreeCardHand(playerHand)
     Eval-->>Domain: playerRank
@@ -2023,7 +2023,7 @@ sequenceDiagram
     Note over User,Pres: オークションフロー
     User->>Ctrl: bid 1 1 5
     Ctrl->>Interactor: Bid(1, 1, 5)
-    Interactor->>Domain: Bid(BidTypeNormal, 1, NoTrump)
+    Interactor->>Domain: PlayerBid(BidTypeNormal, 1, NoTrump)
     Domain->>Domain: ビッド記録 → CPU自動ビッド → コントラクト確定 → phase=Play
     Domain-->>Interactor: nil
     Interactor->>Pres: Output(game, nil)
@@ -2032,7 +2032,7 @@ sequenceDiagram
     Note over User,Pres: トリックプレイフロー
     User->>Ctrl: play 3
     Ctrl->>Interactor: Play(3)
-    Interactor->>Domain: PlayCard(3)
+    Interactor->>Domain: PlayerPlay(3)
     Domain->>Domain: フォロースート検証 → カード出し → CPU/ダミー自動プレイ
     Domain->>Domain: トリック勝者判定 → phase=TrickEnd
     Domain-->>Interactor: nil
@@ -2053,7 +2053,7 @@ sequenceDiagram
     Note over User,Pres: フロップベッティング完了 → ディスカードフェーズ
     User->>Ctrl: discard 1
     Ctrl->>Interactor: Discard(1)
-    Interactor->>Domain: PlayerDiscard(1)
+    Interactor->>Domain: DiscardCard(1)
     Domain->>Domain: ホールカード[1]を除去 → CPU自動ディスカード → phase=Turn
     Domain-->>Interactor: nil
     Interactor->>Pres: Output(game, nil)
@@ -2073,7 +2073,7 @@ sequenceDiagram
     Note over User,Pres: プレイフロー
     User->>Ctrl: play 0 1
     Ctrl->>Interactor: Play(0, 1)
-    Interactor->>Domain: Play(0, 1)
+    Interactor->>Domain: PlayerPlay(0, 1)
     Domain->>Domain: 手札[0]を場札[1]に出す → 手札補充 → CPU自動プレイ
     Domain-->>Interactor: nil
     Interactor->>Pres: Output(game, nil)
@@ -2102,7 +2102,7 @@ sequenceDiagram
     Note over User,Pres: 要求フロー
     User->>Ctrl: ask 1 7
     Ctrl->>Interactor: Ask(1, 7)
-    Interactor->>Domain: Ask(1, 7)
+    Interactor->>Domain: PlayerAsk(1, 7)
     Domain->>Domain: 相手が持っていればカード移動 → ブックチェック → CPU自動プレイ
     Domain-->>Interactor: nil
     Interactor->>Pres: Output(game, nil)
@@ -2111,7 +2111,7 @@ sequenceDiagram
     Note over User,Pres: Go Fish (相手が持っていない場合)
     User->>Ctrl: ask 2 13
     Ctrl->>Interactor: Ask(2, 13)
-    Interactor->>Domain: Ask(2, 13)
+    Interactor->>Domain: PlayerAsk(2, 13)
     Domain->>Domain: 相手が持っていない → 山札から1枚引く → ブックチェック → CPU自動プレイ
     Domain-->>Interactor: nil
     Interactor->>Pres: Output(game, nil)
@@ -2130,8 +2130,8 @@ sequenceDiagram
 
     Note over User,Pres: ドローフロー
     User->>Ctrl: draw
-    Ctrl->>Interactor: Draw()
-    Interactor->>Domain: Draw()
+    Ctrl->>Interactor: Action()
+    Interactor->>Domain: PlayerAction()
     Domain->>Domain: 山札から1枚引く → スート一致判定 → ペナルティ or 場に置く → CPU自動プレイ
     Domain-->>Interactor: nil
     Interactor->>Pres: Output(game, nil)
@@ -2209,7 +2209,7 @@ sequenceDiagram
     Note over User,Pres: アタックフロー
     User->>Ctrl: attack 0
     Ctrl->>Interactor: Attack(0)
-    Interactor->>Domain: Attack(0)
+    Interactor->>Domain: PlayerAttack(0)
     Domain->>Domain: カード出す → テーブルに配置 → CPU自動ディフェンス判定
     Domain-->>Interactor: nil
     Interactor->>Pres: Output(game, nil)
@@ -2218,7 +2218,7 @@ sequenceDiagram
     Note over User,Pres: ディフェンスフロー
     User->>Ctrl: defend 2
     Ctrl->>Interactor: Defend(2)
-    Interactor->>Domain: Defend(2)
+    Interactor->>Domain: PlayerDefend(2)
     Domain->>Domain: 防御カード配置 → 切り札/同スート判定 → ビート成否
     Domain-->>Interactor: nil
     Interactor->>Pres: Output(game, nil)
@@ -2255,8 +2255,8 @@ sequenceDiagram
 
     Note over User,Pres: ムーブフロー
     User->>Ctrl: move w f1
-    Ctrl->>Interactor: Move("w", "f1")
-    Interactor->>Domain: Move("w", "f1")
+    Ctrl->>Interactor: MoveWasteToFoundation()
+    Interactor->>Domain: MoveWasteToFoundation()
     Domain->>Domain: ウェスト → 組札1へ移動 → 同スート昇順チェック
     Domain-->>Interactor: nil
     Interactor->>Pres: Output(game, nil)
@@ -2486,7 +2486,7 @@ sequenceDiagram
 
     Note over User,Pres: トリック終了 (phase=TrickEnd)
     User->>Ctrl: next
-    Ctrl->>Interactor: Next()
+    Ctrl->>Interactor: NextTrick()
     Interactor->>Domain: NextTrick()
     Domain->>Domain: 10トリック未満なら phase=Play
     Domain->>Domain: 10トリック完了で phase=RoundEnd
@@ -2506,6 +2506,17 @@ sequenceDiagram
 ---
 
 ## 3. ステートマシン図
+
+遷移ラベルのメソッド名と `note` のフェーズ定数名は、
+`TestDesignDocStateTransitionsExistInGo` と `TestDesignDocStateConstantsExistInGo`
+が節見出しのゲーム名を持ち主として実コードと照合している（
+`internal/infrastructure/games/design_doc_diagrams_test.go`）。
+
+末尾に `*` を付けた `Move*()` は**兄弟メソッド群の略記**で、ラベルに列挙するには
+長すぎる場合にだけ使う（例: `MoveTableauToTableau` / `MoveTableauToFoundation` /
+`MoveTableauToFreeCell` / `MoveFreeCellToTableau` / `MoveFreeCellToFoundation`）。
+ガードは `*` 付きを実メソッド名として照合しない。逆に言えば、`*` の無い名前は
+すべて実在するメソッドでなければならない。
 
 ### 3.1 BlackJack フェーズ遷移
 
@@ -3047,7 +3058,7 @@ stateDiagram-v2
 ```mermaid
 stateDiagram-v2
     [*] --> Playing : Reset()
-    Playing --> Playing : Draw() / Move() / Undo() / Hint() / AutoComplete()
+    Playing --> Playing : Draw() / Move*() / Undo() / Hint() / AutoComplete()
     Playing --> GameClear : 8組札すべて完成
     Playing --> GameOver : 移動可能な手なし
     GameOver --> [*]
@@ -3526,7 +3537,7 @@ stateDiagram-v2
 ```mermaid
 stateDiagram-v2
     [*] --> Playing : Reset()
-    Playing --> Playing : Move() / Undo() / Hint() / AutoComplete()
+    Playing --> Playing : Move*() / Undo() / Hint() / AutoComplete()
     Playing --> GameClear : 組札4スート全完成
     Playing --> GameOver : GiveUp()
     GameClear --> [*]
@@ -3544,7 +3555,7 @@ Penguin は FreeCell のバリアントで、最初に配られたカードの�
 ```mermaid
 stateDiagram-v2
     [*] --> Playing : Reset()
-    Playing --> Playing : Move() / Undo() / Hint() / AutoComplete()
+    Playing --> Playing : Move*() / Undo() / Hint() / AutoComplete()
     Playing --> GameClear : 組札4スート全完成
     Playing --> GameOver : GiveUp()
     GameClear --> [*]

--- a/frontend/scripts/check-design-doc-identifiers.mjs
+++ b/frontend/scripts/check-design-doc-identifiers.mjs
@@ -60,6 +60,27 @@ const EXPORT_LIST = /export\s*(?:type\s+)?\{([^}]*)\}/g;
 const EXPORT_DEFAULT_IDENT = /export\s+default\s+([A-Za-z0-9_$]+)\s*;/g;
 
 const CLASS_DECL = /^\s*class\s+([A-Za-z0-9_]+)/;
+/** `class Foo {` — a node that opens a member body. */
+const CLASS_OPEN = /^\s*class\s+([A-Za-z0-9_~]+)\s*\{/;
+const CLASS_CLOSE = /^\s*\}/;
+
+/**
+ * Identifiers that legitimately appear under a different game's node because
+ * the type really is shared. Verified by import, not assumed: `yukon.ts:5` and
+ * `russiansolitaire.ts:5` both `import type { KlondikeTableauCard }`.
+ *
+ * Keep this list short. Every entry is a claim that two games share a type on
+ * purpose, and a wrong entry silences the check for that identifier everywhere.
+ */
+const SHARED_ACROSS_GAMES = new Set(['KlondikeTableauCard']);
+
+/**
+ * The game a node belongs to, from `useKlondikeGame` or `KlondikeResponse`.
+ * Returns null for nodes that are not game-scoped.
+ */
+function gameOf(node) {
+  return /^use([A-Z][A-Za-z0-9]*)Game$/.exec(node)?.[1] ?? /^([A-Z][A-Za-z0-9]*)Response$/.exec(node)?.[1] ?? null;
+}
 
 async function* sourceFiles(dir) {
   for (const entry of await readdir(dir, { withFileTypes: true })) {
@@ -109,11 +130,52 @@ for await (const name of directories(SRC)) known.add(name);
 
 const doc = await readFile(DOC, 'utf8');
 const classes = new Set();
+/** node name -> its member lines, for the cross-game check below. */
+const members = new Map();
 for (const block of doc.matchAll(/```mermaid\n([\s\S]*?)```/g)) {
   if (!/^\s*classDiagram/m.test(block[1])) continue;
+  let open = null;
   for (const line of block[1].split('\n')) {
     const m = line.match(CLASS_DECL);
     if (m) classes.add(m[1]);
+    const o = line.match(CLASS_OPEN);
+    if (o) {
+      open = o[1];
+      if (!members.has(open)) members.set(open, []);
+      continue;
+    }
+    if (open && CLASS_CLOSE.test(line)) {
+      open = null;
+      continue;
+    }
+    if (open) members.get(open).push(line);
+  }
+}
+
+// Cross-game consistency. `design_doc_identifiers_test.go` and the class check
+// above both ask only "does this identifier exist somewhere", and that is not
+// the question: `FortyThievesMoveZone` exists, but writing it under
+// `useKlondikeGame` (which uses `KlondikeMoveZone`) still shipped a wrong type
+// into the diagram (#5350). Existence is not correctness — the owner decides.
+//
+// The game vocabulary comes from the document itself, so this needs no game
+// list to drift against: every `use<Game>Game` / `<Game>Response` node
+// contributes its game.
+const gameNames = new Set([...members.keys()].map(gameOf).filter(Boolean));
+const crossGame = [];
+for (const [node, lines] of members) {
+  const owner = gameOf(node);
+  if (!owner) continue;
+  for (const line of lines) {
+    for (const [, ident] of line.matchAll(/\b([A-Z][A-Za-z0-9]*)\b/g)) {
+      if (SHARED_ACROSS_GAMES.has(ident)) continue;
+      // Longest match wins so `VideoPoker…` is not read as `Poker…`.
+      let other = null;
+      for (const g of gameNames) {
+        if (ident.startsWith(g) && ident.length > g.length && (!other || g.length > other.length)) other = g;
+      }
+      if (other && other !== owner) crossGame.push({ node, ident, owner, other });
+    }
   }
 }
 
@@ -124,6 +186,20 @@ if (SCANNING_REPO) {
 }
 
 const unknown = [...classes].filter((c) => !PLACEHOLDERS.has(c) && !known.has(c)).sort();
+
+if (crossGame.length > 0) {
+  console.error(`\ndesign-doc-identifiers: ${crossGame.length} member(s) reference another game's type.\n`);
+  for (const { node, ident, owner, other } of crossGame) {
+    console.error(`  ${node} (${owner}) references ${ident} (${other})`);
+  }
+  console.error(
+    '\nThe identifier exists, but not for this game -- each game has its own\n' +
+      "<Game>MoveZone, <Game>Response and friends. Use this node's own type, or,\n" +
+      'if the type really is shared, add it to SHARED_ACROSS_GAMES in this script\n' +
+      'after confirming the import.\n',
+  );
+  process.exit(1);
+}
 
 if (unknown.length > 0) {
   console.error(

--- a/frontend/scripts/check-design-doc-identifiers.test.mjs
+++ b/frontend/scripts/check-design-doc-identifiers.test.mjs
@@ -103,4 +103,83 @@ describe('check-design-doc-identifiers', () => {
     expect(r.out).toContain('GhostOne');
     expect(r.out).toContain('GhostTwo');
   });
+
+  // Cross-game consistency (#5350). The first fix for that issue replaced a
+  // dead `MoveZone` with `FortyThievesMoveZone` under `useKlondikeGame` — an
+  // identifier that exists, on the wrong game. Every check here had passed it,
+  // because all of them only ever asked whether the name exists somewhere.
+  describe('cross-game references', () => {
+    /** A doc whose nodes carry the given member lines verbatim. */
+    function membersDoc(nodes) {
+      const body = Object.entries(nodes)
+        .map(([name, lines]) => `    class ${name} {\n${lines.map((l) => `        ${l}`).join('\n')}\n    }`)
+        .join('\n');
+      return ['# Design', '', '```mermaid', 'classDiagram', body, '```', ''].join('\n');
+    }
+
+    function checkDoc(nodes, sources = {}) {
+      const dir = mkdtempSync(join(tmpdir(), 'design-doc-ids-x-'));
+      dirs.push(dir);
+      const src = join(dir, 'src');
+      mkdirSync(src, { recursive: true });
+      // Export every node so the class-existence check passes and these cases
+      // isolate the cross-game rule.
+      writeFileSync(
+        join(src, 'a.ts'),
+        Object.keys(nodes)
+          .map((n) => `export const ${n} = 1;`)
+          .join('\n'),
+      );
+      for (const [name, body] of Object.entries(sources)) writeFileSync(join(src, name), body);
+      const docFile = join(dir, 'design.md');
+      writeFileSync(docFile, membersDoc(nodes));
+      const r = spawnSync(process.execPath, [GUARD, src, docFile], { encoding: 'utf8', cwd: process.cwd() });
+      return { code: r.status, out: `${r.stdout}${r.stderr}` };
+    }
+
+    it("rejects a member typed with another game's type", () => {
+      const r = checkDoc({
+        useKlondikeGame: ['+FortyThievesMoveZone selectedSource'],
+        FortyThievesResponse: ['+number stockCount'],
+      });
+      expect(r.code).toBe(1);
+      expect(r.out).toContain('FortyThievesMoveZone');
+      expect(r.out).toContain('useKlondikeGame');
+    });
+
+    it("accepts a member typed with its own game's type", () => {
+      const r = checkDoc({
+        useKlondikeGame: ['+KlondikeMoveZone selectedSource'],
+        FortyThievesResponse: ['+number stockCount'],
+      });
+      expect(r.code).toBe(0);
+    });
+
+    it('accepts an identifier listed as shared across games', () => {
+      // Yukon and RussianSolitaire really do import Klondike's tableau type.
+      const r = checkDoc({
+        YukonResponse: ['+KlondikeTableauCard[][] tableau'],
+        KlondikeResponse: ['+number stockCount'],
+      });
+      expect(r.code).toBe(0);
+    });
+
+    it('does not read a longer game name as a shorter one', () => {
+      // `VideoPokerResponse` must not be treated as belonging to `Poker`, or
+      // every one of its own types would look cross-game.
+      const r = checkDoc({
+        VideoPokerResponse: ['+VideoPokerHand hand'],
+        PokerResponse: ['+number pot'],
+      });
+      expect(r.code).toBe(0);
+    });
+
+    it('ignores nodes that are not game-scoped', () => {
+      const r = checkDoc({
+        useCardSelection: ['+KlondikeMoveZone zone'],
+        KlondikeResponse: ['+number stockCount'],
+      });
+      expect(r.code).toBe(0);
+    });
+  });
 });

--- a/internal/infrastructure/games/design_doc_diagrams_test.go
+++ b/internal/infrastructure/games/design_doc_diagrams_test.go
@@ -1,0 +1,426 @@
+//go:build test
+
+package games_test
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// The identifier guard in design_doc_identifiers_test.go reads `classDiagram`
+// blocks and nothing else. That covers 12 of the 91 mermaid blocks in
+// docs/design/backend.md; the other 79 -- every sequence and state diagram --
+// were unchecked, and that is exactly where the drift sat.
+//
+// The 2026-08-15 sweep (#5350) found 18 dead identifiers in this document and
+// every one of them was in a sequence or state diagram: Durak `PickUp`, Cruel
+// `Redeal`, Calculation `MoveStockToFoundation`, Cassino/Scopa `NewRound` and
+// `CpuStep`, PaiGow `evalPaiGowLow`, PigsTail `Draw`. The class diagrams, which
+// were guarded, were clean.
+//
+// The three checks below close that hole. Each one resolves an *owner* before
+// it resolves a name, because "the identifier exists somewhere" is not the
+// question -- `FortyThievesMoveZone` exists, but not on `useKlondikeGame`, and
+// that wrong-game reference is what shipped in the first fix of #5350.
+//
+// Precision comes from refusing to guess: a message whose target is not a real
+// Go type is skipped, and a state diagram whose section heading does not name a
+// real Go type is skipped. A guard that reports false positives gets switched
+// off, so the checks only fire where the owner is unambiguous.
+
+var (
+	// headingRe captures the identifier in `### 3.12 Cruel フェーズ遷移`.
+	headingRe = regexp.MustCompile(`^#{2,4}\s+[\d.]+\s+([A-Za-z][A-Za-z0-9]*)`)
+	// fenceOpenRe/fenceCloseRe bracket a mermaid block.
+	fenceOpenRe  = regexp.MustCompile("^\\s*```mermaid\\s*$")
+	fenceCloseRe = regexp.MustCompile("^\\s*```\\s*$")
+	// sequenceKindRe / stateKindRe identify the diagram kind.
+	sequenceKindRe = regexp.MustCompile(`(?m)^\s*sequenceDiagram`)
+	stateKindRe    = regexp.MustCompile(`(?m)^\s*stateDiagram-v2`)
+	// participantRe matches `participant Interactor as DurakInteractor` and the
+	// bare `participant Durak`. The label is what names a Go type; the alias is
+	// only how the arrows refer to it.
+	participantRe = regexp.MustCompile(`^\s*participant\s+(\S+)(?:\s+as\s+(.+?))?\s*$`)
+	// messageLabelRe splits `Ctrl->>Interactor: TakeCards()` into target and
+	// label, for every mermaid arrow spelling.
+	messageLabelRe = regexp.MustCompile(`^\s*\S+\s*--?>>?\s*([^:\s]+?)\s*:\s*(.+)$`)
+	// stateConstNoteRe matches `note right of Playing : FortyThievesPhasePlaying = 0`.
+	// The name must start uppercase: the notes also carry unexported field
+	// shorthand such as `gameEndFlag = false`, which names no Go constant.
+	stateConstNoteRe = regexp.MustCompile(`^\s*note\b[^:]*:\s*([A-Z][A-Za-z0-9_]*)\s*=\s*\S+\s*$`)
+	// stateTransitionLabelRe captures the label of `Playing --> GameEnd : Shift()`.
+	stateTransitionLabelRe = regexp.MustCompile(`^\s*\S+\s*-->\s*\S+\s*:\s*(.+)$`)
+	// callRe finds every `identifier(` in a label, so a compound label such as
+	// `Reset() / NextRound()` is checked in full rather than only its first
+	// call. An identifier followed by anything other than `(` is not a call:
+	// that is what makes `Move*()` read as "the Move* family" and skip, which
+	// is how the diagrams denote a group of sibling methods too long to list.
+	//
+	// The optional leading qualifier is captured so that a package-level call
+	// such as `ui.RunInteractiveCuiLoop(manager)` can be skipped -- it is not a
+	// method on the participant, and checking it against one would be wrong.
+	callRe = regexp.MustCompile(`(?:([A-Za-z][A-Za-z0-9_]*)\.)?([A-Za-z][A-Za-z0-9_]*)\(`)
+	// camelWordRe counts the words in a CamelCase identifier.
+	camelWordRe = regexp.MustCompile(`[A-Z][a-z0-9]*`)
+)
+
+// docBlock is one mermaid block together with the section heading it sits
+// under. The heading is what supplies the owner for a state diagram, which
+// unlike a sequence diagram never names the receiver on the transition itself.
+type docBlock struct {
+	heading string
+	body    string
+}
+
+// diagramRef is one identifier the document attributes to one owner.
+type diagramRef struct {
+	heading string
+	owner   string
+	name    string
+}
+
+func (r diagramRef) String() string {
+	if r.owner == "" {
+		return r.name + "  (" + r.heading + ")"
+	}
+	return r.owner + "." + r.name + "  (" + r.heading + ")"
+}
+
+// readDesignDoc returns the document split into mermaid blocks tagged with
+// their heading.
+func readDesignDoc(t *testing.T, path string) []docBlock {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(repoRoot, path))
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+
+	var blocks []docBlock
+	heading, inFence := "", false
+	var cur []string
+	for line := range strings.SplitSeq(string(data), "\n") {
+		switch {
+		case !inFence && fenceOpenRe.MatchString(line):
+			inFence, cur = true, nil
+		case inFence && fenceCloseRe.MatchString(line):
+			blocks = append(blocks, docBlock{heading: heading, body: strings.Join(cur, "\n")})
+			inFence = false
+		case inFence:
+			cur = append(cur, line)
+		default:
+			if m := headingRe.FindStringSubmatch(line); m != nil {
+				heading = strings.TrimSpace(strings.TrimLeft(line, "# "))
+			}
+		}
+	}
+	if len(blocks) < 50 {
+		t.Fatalf("only %d mermaid blocks parsed from %s -- the fence scan broke", len(blocks), path)
+	}
+	return blocks
+}
+
+// headingOwner returns the identifier a section heading names, e.g. `Cruel`
+// for `### 3.12 Cruel フェーズ遷移`. It returns "" when the heading is prose or
+// names something that is not a bare identifier (`Texas Hold'em`).
+func headingOwner(heading string) string {
+	if m := headingRe.FindStringSubmatch("### " + heading); m != nil {
+		return m[1]
+	}
+	return ""
+}
+
+// sequenceCalls returns every `Target: Method(` message whose target resolves,
+// through the participant list, to a name the document itself declares.
+func sequenceCalls(blocks []docBlock) []diagramRef {
+	var refs []diagramRef
+	for _, b := range blocks {
+		if !sequenceKindRe.MatchString(b.body) {
+			continue
+		}
+		label := map[string]string{}
+		for line := range strings.SplitSeq(b.body, "\n") {
+			if m := participantRe.FindStringSubmatch(line); m != nil {
+				name := m[1]
+				if m[2] != "" {
+					name = strings.TrimSpace(m[2])
+				}
+				label[m[1]] = name
+			}
+		}
+		for line := range strings.SplitSeq(b.body, "\n") {
+			m := messageLabelRe.FindStringSubmatch(line)
+			if m == nil {
+				continue
+			}
+			target := m[1]
+			if l, ok := label[target]; ok {
+				target = l
+			}
+			for _, c := range callRe.FindAllStringSubmatch(m[2], -1) {
+				if c[1] != "" {
+					continue // `pkg.Func()` -- not a method on this participant
+				}
+				refs = append(refs, diagramRef{heading: b.heading, owner: target, name: c[2]})
+			}
+		}
+	}
+	return refs
+}
+
+// stateConstantRefs returns the constants declared in state-diagram notes.
+//
+// A note reads `note right of Playing : FortyThievesPhasePlaying = 0`. Only
+// multi-word CamelCase names are treated as constant references: the diagrams
+// also carry shorthand notes such as `Phase = 1` and `gameEndFlag = false`
+// that name no Go symbol.
+func stateConstantRefs(blocks []docBlock) []diagramRef {
+	var refs []diagramRef
+	for _, b := range blocks {
+		if !stateKindRe.MatchString(b.body) {
+			continue
+		}
+		for line := range strings.SplitSeq(b.body, "\n") {
+			m := stateConstNoteRe.FindStringSubmatch(line)
+			if m == nil {
+				continue
+			}
+			if len(camelWordRe.FindAllString(m[1], -1)) < 2 {
+				continue
+			}
+			refs = append(refs, diagramRef{heading: b.heading, name: m[1]})
+		}
+	}
+	return refs
+}
+
+// stateTransitionRefs returns every `Method()` transition label, attributed to
+// the game its section heading names.
+func stateTransitionRefs(blocks []docBlock) []diagramRef {
+	var refs []diagramRef
+	for _, b := range blocks {
+		if !stateKindRe.MatchString(b.body) {
+			continue
+		}
+		owner := headingOwner(b.heading)
+		if owner == "" {
+			continue
+		}
+		for line := range strings.SplitSeq(b.body, "\n") {
+			m := stateTransitionLabelRe.FindStringSubmatch(line)
+			if m == nil {
+				continue
+			}
+			for _, c := range callRe.FindAllStringSubmatch(m[1], -1) {
+				if c[1] != "" {
+					continue // `pkg.Func()` -- not a method on this game
+				}
+				refs = append(refs, diagramRef{heading: b.heading, owner: owner, name: c[2]})
+			}
+		}
+	}
+	return refs
+}
+
+// TestDesignDocSequenceCallsExistInGo asserts that every method a sequence
+// diagram sends to a participant that names a real Go type exists on that type.
+//
+// This is what would have caught Durak `PickUp()` (renamed to `TakeCards`) and
+// PaiGow `evalPaiGowLow` (never existed; the function is `evalPaiGowLowHand`).
+// Participants such as `Controller`, `Presenter` and `ユーザー` name no Go type
+// and are skipped -- the check fires only where the receiver is unambiguous.
+func TestDesignDocSequenceCallsExistInGo(t *testing.T) {
+	blocks := readDesignDoc(t, designDocPath)
+	surface := parseGoSurface(t, goSourceRoot)
+
+	checked := 0
+	var missing []string
+	for _, ref := range sequenceCalls(blocks) {
+		if !surface.types[ref.owner] {
+			continue // a prose participant, not a Go type
+		}
+		checked++
+		if !surface.has(ref.owner, ref.name, map[string]bool{}) {
+			missing = append(missing, ref.String())
+		}
+	}
+	if checked < 60 {
+		t.Fatalf("only %d sequence calls checked in %s -- participantRe or messageCallRe stopped matching",
+			checked, designDocPath)
+	}
+	sort.Strings(missing)
+
+	if len(missing) > 0 {
+		t.Errorf("sequence-diagram calls in %s with no such method on the target type (%d of %d checked):\n  %s\n"+
+			"Rename them in the diagram to match the code.",
+			designDocPath, len(missing), checked, strings.Join(missing, "\n  "))
+	}
+}
+
+// TestDesignDocStateConstantsExistInGo asserts that every constant named in a
+// state-diagram note exists in Go.
+//
+// This is what would have caught `SevenCardStudPhaseThirdSt` (the real name
+// ends `ThirdStreet`), `FortyThievesPlaying` (`FortyThievesPhasePlaying`) and
+// `LetItRidePhaseDecision1` (`LetItRidePhaseFirstDecision`) -- three families
+// whose *values* were right, so nothing else would ever have flagged them.
+func TestDesignDocStateConstantsExistInGo(t *testing.T) {
+	blocks := readDesignDoc(t, designDocPath)
+	surface := parseGoSurface(t, goSourceRoot)
+
+	refs := stateConstantRefs(blocks)
+	if len(refs) < 120 {
+		t.Fatalf("only %d state-diagram constants parsed from %s -- stateConstNoteRe stopped matching",
+			len(refs), designDocPath)
+	}
+
+	var missing []string
+	for _, ref := range refs {
+		if !surface.consts[ref.name] {
+			missing = append(missing, ref.String())
+		}
+	}
+	sort.Strings(missing)
+
+	if len(missing) > 0 {
+		t.Errorf("constants in %s state-diagram notes that do not exist in Go (%d of %d checked):\n  %s\n"+
+			"Rename them in the diagram to match the code.",
+			designDocPath, len(missing), len(refs), strings.Join(missing, "\n  "))
+	}
+}
+
+// TestDesignDocStateTransitionsExistInGo asserts that every `Method()`
+// transition label names a method on the game its section heading identifies,
+// or on that game's interactor.
+//
+// This is what would have caught Cruel `Redeal()` (the method is `Shift`),
+// Cassino/PageOne/SevenBridge/Scopa `NewRound()` (`NextRound`) and Scopa/Barbu
+// `CpuStep()` (`CpuPlay`). Note that grepping for those names without a
+// receiver finds hundreds of hits and concludes they exist -- `NextRound` alone
+// is defined 578 times. The owner is the whole point of the check.
+func TestDesignDocStateTransitionsExistInGo(t *testing.T) {
+	blocks := readDesignDoc(t, designDocPath)
+	surface := parseGoSurface(t, goSourceRoot)
+
+	checked := 0
+	var missing []string
+	for _, ref := range stateTransitionRefs(blocks) {
+		owners := []string{ref.owner, ref.owner + "Interactor"}
+		known := false
+		for _, o := range owners {
+			if surface.types[o] {
+				known = true
+			}
+		}
+		if !known {
+			continue // heading names no Go type (e.g. a cross-cutting section)
+		}
+		checked++
+		found := false
+		for _, o := range owners {
+			if surface.types[o] && surface.has(o, ref.name, map[string]bool{}) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			missing = append(missing, ref.String())
+		}
+	}
+	if checked < 120 {
+		t.Fatalf("only %d state transitions checked in %s -- stateTransitionRe or headingRe stopped matching",
+			checked, designDocPath)
+	}
+	sort.Strings(missing)
+
+	if len(missing) > 0 {
+		t.Errorf("state-diagram transitions in %s with no such method on the game or its interactor (%d of %d checked):\n  %s\n"+
+			"Rename them in the diagram to match the code.",
+			designDocPath, len(missing), checked, strings.Join(missing, "\n  "))
+	}
+}
+
+// TestDesignDocDiagramParsersCatchBreakage is the negative control for the
+// three checks above.
+//
+// A guard that never fires is indistinguishable from a guard that passes, and
+// the count floors only prove that *something* was parsed. These synthetic
+// diagrams carry a known-bad identifier each; if a parser silently stops
+// matching, the corresponding case here goes green and says so.
+func TestDesignDocDiagramParsersCatchBreakage(t *testing.T) {
+	const broken = "```mermaid\n" +
+		"sequenceDiagram\n" +
+		"    participant Ctrl as Controller\n" +
+		"    participant Interactor as DurakInteractor\n" +
+		"    Ctrl->>Interactor: NoSuchMethod()\n" +
+		"```\n"
+
+	blocks := []docBlock{{heading: "3.1 Durak フェーズ遷移", body: strings.TrimSuffix(
+		strings.TrimPrefix(broken, "```mermaid\n"), "```\n")}}
+
+	calls := sequenceCalls(blocks)
+	if len(calls) != 1 {
+		t.Fatalf("sequenceCalls found %d calls in the synthetic diagram, want 1", len(calls))
+	}
+	if calls[0].owner != "DurakInteractor" || calls[0].name != "NoSuchMethod" {
+		t.Errorf("sequenceCalls resolved %v, want DurakInteractor.NoSuchMethod -- alias resolution broke", calls[0])
+	}
+	surface := parseGoSurface(t, goSourceRoot)
+	if surface.has("DurakInteractor", "NoSuchMethod", map[string]bool{}) {
+		t.Error("surface claims DurakInteractor.NoSuchMethod exists -- the resolver is too permissive")
+	}
+
+	stateBlocks := []docBlock{{
+		heading: "3.1 Cruel フェーズ遷移",
+		body: "stateDiagram-v2\n" +
+			"    Playing --> GameOver : NoSuchAction()\n" +
+			"    note right of Playing : NoSuchPhaseConstant = 0\n" +
+			"    note right of Playing : Phase = 1\n",
+	}}
+
+	trans := stateTransitionRefs(stateBlocks)
+	if len(trans) != 1 || trans[0].owner != "Cruel" || trans[0].name != "NoSuchAction" {
+		t.Errorf("stateTransitionRefs resolved %v, want one Cruel.NoSuchAction -- heading attribution broke", trans)
+	}
+
+	consts := stateConstantRefs(stateBlocks)
+	if len(consts) != 1 || consts[0].name != "NoSuchPhaseConstant" {
+		t.Errorf("stateConstantRefs resolved %v, want only NoSuchPhaseConstant -- the single-word filter broke", consts)
+	}
+	if surface.consts["NoSuchPhaseConstant"] {
+		t.Error("surface claims NoSuchPhaseConstant exists -- the const collector is too permissive")
+	}
+}
+
+// TestDesignDocDiagramParsersAcceptCorrectInput is the positive control: the
+// parsers must stay quiet on diagrams that match the code.
+//
+// Without this, tightening a regex until it matches nothing would look like a
+// clean bill of health in every other test here.
+func TestDesignDocDiagramParsersAcceptCorrectInput(t *testing.T) {
+	surface := parseGoSurface(t, goSourceRoot)
+
+	good := []docBlock{{
+		heading: "2.14 Durak アタック・ディフェンスフロー",
+		body: "sequenceDiagram\n" +
+			"    participant Interactor as DurakInteractor\n" +
+			"    participant Domain as Durak\n" +
+			"    Ctrl->>Interactor: TakeCards()\n" +
+			"    Interactor->>Domain: PlayerTakeCards()\n" +
+			"    Domain-->>Interactor: nil\n" +
+			"    Domain->>Domain: カード出す → テーブルに配置\n",
+	}}
+
+	calls := sequenceCalls(good)
+	if len(calls) != 2 {
+		t.Fatalf("sequenceCalls found %d calls, want 2 -- prose labels and `nil` returns must not be read as calls: %v", len(calls), calls)
+	}
+	for _, c := range calls {
+		if !surface.has(c.owner, c.name, map[string]bool{}) {
+			t.Errorf("%v reported missing, but it exists in Go -- the check would fire on a correct diagram", c)
+		}
+	}
+}

--- a/internal/infrastructure/games/design_doc_diagrams_test.go
+++ b/internal/infrastructure/games/design_doc_diagrams_test.go
@@ -1,5 +1,3 @@
-//go:build test
-
 package games_test
 
 import (

--- a/internal/infrastructure/games/design_doc_identifiers_test.go
+++ b/internal/infrastructure/games/design_doc_identifiers_test.go
@@ -112,6 +112,10 @@ type goSurface struct {
 	types    map[string]bool
 	methods  map[string]map[string]bool
 	embedded map[string][]string
+	// consts holds every package-level constant name. The state-diagram notes
+	// in the design document name phase constants directly, with no receiver to
+	// scope them, so they are checked against this flat set.
+	consts map[string]bool
 }
 
 // has reports whether typ (or anything it embeds) provides method. Embedding is
@@ -177,6 +181,7 @@ func parseGoSurface(t *testing.T, root string) *goSurface {
 		types:    map[string]bool{},
 		methods:  map[string]map[string]bool{},
 		embedded: map[string][]string{},
+		consts:   map[string]bool{},
 	}
 	addMethod := func(typ, name string) {
 		if s.methods[typ] == nil {
@@ -203,6 +208,13 @@ func parseGoSurface(t *testing.T, root string) *goSurface {
 			switch d := decl.(type) {
 			case *ast.GenDecl:
 				for _, spec := range d.Specs {
+					if d.Tok == token.CONST {
+						if vs, ok := spec.(*ast.ValueSpec); ok {
+							for _, n := range vs.Names {
+								s.consts[n.Name] = true
+							}
+						}
+					}
 					ts, ok := spec.(*ast.TypeSpec)
 					if !ok {
 						continue


### PR DESCRIPTION
#5351 のレビューで見つかった 2 つのガードの穴を塞ぐ。

## 穴 1: 図の 87% が無検査だった

`design_doc_identifiers_test.go` は `mermaidBlockRe` で拾ったあと `classDiagramRe` で
弾いていたので、**読んでいたのは `docs/design/backend.md` の 91 ブロック中 12 だけ**。
残る 79（sequenceDiagram 20 + stateDiagram-v2 59）は完全に無検査で、#5350 が見つけた
**死んだ識別子 18 件は全部そちら側**にあった。守られていたクラス図は全部きれいだった。

## 穴 2: 「存在するか」を「正しいか」として扱っていた

`FortyThievesMoveZone` は実在する。ただし `useKlondikeGame` の型ではない。
#5351 の最初の修正でこの取り違えが**全チェック緑のまま**入った。
存在は正しさではなく、決めるのは**持ち主**。

## 追加した検査（いずれも名前より先に持ち主を解決する）

| テスト | 何を照合するか | これが捕まえるもの |
|---|---|---|
| `TestDesignDocSequenceCallsExistInGo` | participant 宣言経由でメッセージの宛先を Go の型に解決し、その型にメソッドがあるか | Durak `PickUp()`、PaiGow `evalPaiGowLow` |
| `TestDesignDocStateConstantsExistInGo` | `note` の `Ident = value` の定数が実在するか | `…PhaseThirdSt` / `FortyThievesPlaying` / `LetItRidePhaseDecision1`。**値は正しかった**ので他の何物も検出できなかった |
| `TestDesignDocStateTransitionsExistInGo` | 遷移ラベルを節見出しのゲームに帰属させ、ゲームか interactor にメソッドがあるか | Cruel `Redeal()`、Cassino/Scopa `NewRound()`、`CpuStep()` |

**受信者を指定しない grep はこれらを「存在する」と誤判定する** —— `NextRound` だけで
578 定義ある。持ち主の解決こそが検査の本体。

精度は「推測を拒む」ことで確保している: 宛先が Go の型でない participant
（`Controller` / `Presenter` / `ユーザー`）はスキップ、節見出しが Go の型を指さない
ステート図もスキップ。`pkg.Func()` の形も「その participant のメソッドではない」ので
スキップする。

フロントエンド側 (`check-design-doc-identifiers.mjs`) には**別ゲームの型を参照している
メンバー**の検出を追加した。ゲーム語彙は**ドキュメント自身**（`use<Game>Game` /
`<Game>Response` ノード）から作るので、drift する対象リストを持たない。
最長一致なので `VideoPoker…` を `Poker…` と読み違えない。実測での該当は
`KlondikeTableauCard` を Yukon / RussianSolitaire が共有する 2 件だけで、これは
`yukon.ts:5` / `russiansolitaire.ts:5` の `import type` で**実際に共有**していることを
確認したうえで `SHARED_ACROSS_GAMES` に載せた。

## 正・負の両コントロール

「鳴らないガード」と「通っているガード」は見分けがつかないので、両方向を検査した。

- Go: `TestDesignDocDiagramParsersCatchBreakage` は既知の壊れた図で 3 つのパーサが
  ちゃんと参照を拾うことを、`…AcceptCorrectInput` は正しい図で**沈黙する**ことと
  散文ラベル・`nil` 戻り値をメソッド呼び出しと誤読しないことを検査
- frontend: 別ゲーム型（落ちる）/ 自ゲーム型（通る）/ 共有型（通る）/
  接頭辞衝突 `VideoPoker` vs `Poker`（通る）/ 非ゲームノード（通る）の 5 ケース
- 件数フロア (`checked < N` で `Fatalf`) も併設。正規表現が黙って何もマッチしなく
  なる壊れ方は、フロアでしか気付けない

実測: 新ガードを #5351 の修正前の状態に当てると、`useKlondikeGame` の
`FortyThievesMoveZone` で exit 1 になることを確認済み。

## 新ガードが見つけた追加の乖離 22 件（本 PR で修正）

sequence 図はこれまで一度も検査されたことがなかったので、`docs/games.md` 側の
命名規約（ドメインは `Player*` 接頭辞、interactor は短い名前）と食い違ったまま残っていた。

- ThreeCard: `PlayerBet` / `PlayerPlay` → 実際のドメインメソッドは `Bet` / `Play`（**逆方向の取り違え**）
- Bridge: `Bid` → `PlayerBid`、`PlayCard` → `PlayerPlay`
- Durak: `Attack` / `Defend` → `PlayerAttack` / `PlayerDefend`
- GoFish: `Ask` → `PlayerAsk`（2 箇所）
- Speed: `Play` → `PlayerPlay`
- Pineapple: `PlayerDiscard` → `DiscardCard`
- PigsTail: `Draw` → `Action` / `PlayerAction`（FortyThieves の `Draw()` は実在するので、
  同一文字列でも**そちらは変えていない**）
- Mighty: `Next()` → `NextTrick()`
- FortyThieves: `Move("w","f1")` → `MoveWasteToFoundation()`
- `GameManager.RunInteractiveCuiLoop()` → `ui.RunInteractiveCuiLoop(manager)`。
  これは GameManager のメソッドではなく **`ui` パッケージの関数**（`cui_runner.go:183`）
- `SessionStore.factory()` → `factory` はメソッドではなく**フィールド**なので散文に
- `WebController.Reset()` → `WebController` interface は `Exec`/`Stop` のみ。
  reset は dispatch されるコマンドなので散文に

## `Move*()` 記法

Penguin / EightOff / FortyThieves の遷移ラベルにあった `Move()` は実在しない。
実体は `MoveTableauToTableau` / `MoveTableauToFoundation` / `MoveTableauToFreeCell` /
`MoveFreeCellToTableau` / `MoveFreeCellToFoundation` の 5 つで、ラベルに列挙するには
長すぎる。末尾 `*` を**兄弟メソッド群の明示的な略記**として導入し、ガードは `*` 付きを
実メソッド名として照合しない。§3 冒頭にこの規約を明記した（`*` の無い名前は
すべて実在しなければならない、という含意も込みで）。

## 検証

- `go test -tags test ./internal/infrastructure/games/` 通過（新旧ガード全緑）
- `golangci-lint run ./internal/infrastructure/games/...` 0 issues
- `bunx vitest run scripts/check-design-doc-identifiers.test.mjs` 14 passed
- `cd frontend && bun run check` 全ガード緑
- 検査規模: sequence 113 呼び出し / state 定数 167 / state 遷移 215（従来のクラス図
  219 クラス・516 メソッドに加えて）

## テスト計画

- [x] 新ガードの正・負コントロール
- [x] 既存ガードの回帰
- [x] 実バグ（#5351 の `FortyThievesMoveZone`）を再現して exit 1 を確認
- [ ] CI 全緑を確認

Refs #5350
