### PR TITLE
docs: close the three items deferred from the drift sweep (counts, knip, core types)

### DIFF
--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -78,5 +78,11 @@ The Web GUI supports Japanese (ja) / English (en) via `react-i18next` + `i18next
 ## Dead Code
 
 - Always remove dead code encountered when modifying code
-- Detection tool: `knip`
+- Detection tool: `cd frontend && bun run deadcode` (knip、設定は `frontend/knip.json`)
+- `bun run check` には**繋いでいない**。dead code の削除は判断を伴うので、CI で
+  自動的に落とすのではなく着手時に自分で走らせる
+- `knip.json` の `ignoreDependencies` にある 2 件は検証済みの false positive:
+  `typescript7` は `bun run typecheck` が叩くエイリアス済みバイナリ、`tailwindcss` は
+  `src/index.css` の `@import "tailwindcss"` 経由で使う v4 エンジン（knip は CSS の
+  import を追わないと自分で報告する）
 - Verify manually before deleting (beware of false positives from static analysis)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,7 +182,7 @@ Where to document design decisions that don't warrant an ADR:
 - **Simplicity First**: Make every change as simple as possible. Impact minimal code.
 - **No Laziness**: Find root causes. No temporary fixes. Senior developer standards.
 - **Minimal Impact**: Changes should only touch what's necessary. Avoid introducing bugs.
-- **Dead Code Cleanup**: When modifying code, always remove any dead code or dead files you encounter. Use `golang.org/x/tools/cmd/deadcode` for Go and `knip` for TypeScript to identify unused code. Verify findings manually before deleting -- static analysis tools can produce false positives (e.g., interface implementations called via reflection, mock methods). Delete confirmed dead code in the same commit as your feature or fix.
+- **Dead Code Cleanup**: When modifying code, always remove any dead code or dead files you encounter. Use `golang.org/x/tools/cmd/deadcode` for Go and `cd frontend && bun run deadcode` (knip) for TypeScript to identify unused code. Verify findings manually before deleting -- static analysis tools can produce false positives (e.g., interface implementations called via reflection, mock methods). Delete confirmed dead code in the same commit as your feature or fix.
 
 ## Design System
 

--- a/docs/design/backend.md
+++ b/docs/design/backend.md
@@ -10,6 +10,7 @@
   - [1.3 ユースケース層 (Interactor・Presenter)](#13-ユースケース層-interactorpresenter)
   - [1.4 アダプタ層 (Controller・Presenter実装)](#14-アダプタ層-controllerpresenter実装)
   - [1.5 インフラストラクチャ層](#15-インフラストラクチャ層)
+  - [1.6 セッションと Cloudflare Worker 層](#16-セッションと-cloudflare-worker-層)
 - [2. シーケンス図](#2-シーケンス図)
   - [2.1 CUIゲーム実行フロー](#21-cuiゲーム実行フロー)
   - [2.2 Web APIゲーム実行フロー](#22-web-apiゲーム実行フロー)
@@ -157,6 +158,48 @@ classDiagram
     RankedGamePlayer --|> GamePlayer : extends
     GamePlayer *-- ChipHolder : mixin
 ```
+
+#### 共有ミックスイン
+
+318 ゲームの多くが同じ関心事を持つので、以下は**埋め込みで共有**している。
+§1.2 以降の per-game クラス図に現れる `GetActionLog()` / `GetTricksTaken()` /
+`GetRoundScore()` などは、たいていここから昇格してきたメソッドで、
+per-game 型が自前で定義しているわけではない。
+
+```mermaid
+classDiagram
+    class actionLogBase {
+        +GetActionLog() []*ActionLogEntry
+    }
+
+    class TrickHolder {
+        +GetTricksTaken() [][]*Card
+        +GetTrickCount() int
+        +AddTrick(cards) void
+        +ResetTricks() void
+        +MarshalJSON() []byte, error
+        +UnmarshalJSON(data) error
+    }
+
+    class RoundScoreHolder {
+        +GetRoundScore() int
+        +SetRoundScore(score) void
+        +GetCumulativeScore() int
+        +SetCumulativeScore(score) void
+        +CommitRoundScore() void
+        +MarshalJSON() []byte, error
+        +UnmarshalJSON(data) error
+    }
+
+    note for actionLogBase "272 ファイルが埋め込む (domain/action_log_base.go)。\n非公開の appendLog / appendLogAt で行を足し\nGetActionLog で読み出す"
+    note for TrickHolder "89 ファイル (domain/TrickHolder.go)。\nトリックテイキング系の取り札を保持"
+    note for RoundScoreHolder "39 ファイル (domain/RoundScoreHolder.go)。\nラウンド得点と累計得点、CommitRoundScore で確定"
+```
+
+`TrickHolder` と `RoundScoreHolder` が自前の `MarshalJSON` / `UnmarshalJSON` を
+持つのは、非公開フィールドが KV セッションの往復で消えないようにするため。
+新しいゲームでこれらを埋め込む場合、ゲーム側のコーデックがこの往復を壊していないか
+確認すること（[ADR-0031](../adr/0031-registry-consolidation.md) の登録手順を参照）。
 
 ### 1.2 ゲームドメイン (全318ゲーム)
 
@@ -1700,19 +1743,30 @@ classDiagram
         ゲーム固有アクション() string
     }
 
+    class GameBase~G~ {
+        +Game G
+        +Snapshot() []byte, error
+    }
+
     class GameInteractor {
-        -game GameInterface
-        -presenter GamePresenter
-        +execAndPresent(fn) string
-        +runAndPresent(fn) string
+        -bjp GamePresenter
     }
 
     GameInteractor ..|> GameInteractorIF : implements
+    GameInteractor --|> GameBase~G~ : embeds
     GameInteractor --> GamePresenter~G~ : uses
     GameInteractor --> GameInterface : uses
 
-    note for GameInteractor "execAndPresent: error返却アクション実行後Presenter呼出\nrunAndPresent: void アクション実行後Presenter呼出"
+    note for GameBase~G~ "全 305 interactor が埋め込む総称基底\n(usecase/interactor_base.go)。Snapshot が\nKV 永続化用の JSON 化を一手に引き受ける"
+    note for GameInteractor "GameInteractor はここでは 305 個の per-game\ninteractor を代表する placeholder。実体は\nBlackJackInteractor などで、いずれも\nGameBase[G] を埋め込み Presenter を1つ持つ"
 ```
+
+`execAndPresent` / `runAndPresent` は **Interactor のメソッドではなく
+`usecase/interactor_helper.go` のパッケージレベル総称関数**で、
+`execAndPresent(game, presenter, action)` の形で呼ぶ
+（`resetWithValidatedConfig` も同じ場所にある同種のヘルパ）。
+per-game interactor が `GameBase[G]` を埋め込むことで `Snapshot()` を得ており、
+これが Cloudflare Worker の KV 永続化の土台になっている（§1.6）。
 
 ### 1.4 アダプタ層 (Controller・Presenter実装)
 
@@ -1763,8 +1817,8 @@ classDiagram
     GameCuiPresenter ..|> GamePresenter : implements
     GameWebPresenter ..|> GamePresenter : implements
 
-    note for GameCuiController "318ゲーム × CUI/Web = 636 Controller\nGameCuiController / GameWebController は\n各ゲーム毎に具体的な実装が存在"
-    note for GameCuiPresenter "318ゲーム × CUI/Web = 636 Presenter 実装"
+    note for GameCuiController "318ゲーム × CUI/Web = 636 バインディング\n実装型は 610 種類 (CuiController 305 + WebController 305)\n差分は複数ゲームで共有される Controller\n(総称基底 GameWebController[I,P,O] は別)"
+    note for GameCuiPresenter "318ゲーム × CUI/Web = 636 バインディング\n実装型は 612 種類 (CuiPresenter 306 + WebPresenter 306)"
 ```
 
 ### 1.5 インフラストラクチャ層
@@ -1808,6 +1862,75 @@ classDiagram
     GameCui ..|> CuiExecer : implements
     GameCui --> GameCuiController : delegates
 ```
+
+### 1.6 セッションと Cloudflare Worker 層
+
+Web リクエストが interactor に届くまでの経路は、HTTP サーバと Worker で
+**同じ `SessionProvider` インタフェースの差し替え**で実現している。
+`GameWebController` は `SessionStore` を直接触らず、必ず provider 越しに取る。
+
+```mermaid
+classDiagram
+    class SessionProvider~T~ {
+        <<interface>>
+        +Acquire(id, factory) T, SessionRelease, bool
+        +Stop() void
+    }
+
+    class MemorySessionProvider~T~ {
+        +Acquire(id, factory) T, SessionRelease, bool
+        +Stop() void
+        +Store() *SessionStore~T~
+    }
+
+    class KVSessionProvider~T~ {
+        +Acquire(id, factory) T, SessionRelease, bool
+        +Stop() void
+    }
+
+    class SessionStore~T~ {
+        +GetWithLock(id, factory) T, bool
+    }
+
+    MemorySessionProvider~T~ ..|> SessionProvider~T~ : implements
+    KVSessionProvider~T~ ..|> SessionProvider~T~ : implements
+    MemorySessionProvider~T~ --> SessionStore~T~ : wraps
+
+    note for SessionProvider~T~ "Acquire は解放コールバック SessionRelease を返す。\n呼び出し側は必ず defer で解放する"
+    note for MemorySessionProvider~T~ "HTTP サーバ用。プロセス内 map + per-session mutex"
+    note for KVSessionProvider~T~ "Worker 用。リクエスト毎に KV から復元し、\nGameBase.Snapshot() の JSON を書き戻す。\nプロセスが持続しないので状態は毎回 KV 往復する"
+```
+
+Worker 側はゲームをカテゴリ単位で 6 バイナリに分割している。
+`Category` は**バイナリのサイズバケットであってユーザ向けの分類ではない**
+（[ADR-0032](../adr/0032-fourth-worker-capacity.md) /
+[ADR-0036](../adr/0036-fifth-sixth-worker-capacity.md)）。
+
+```mermaid
+classDiagram
+    class Game {
+        +Name string
+        +Category Category
+    }
+
+    class Category {
+        <<enumeration>>
+        CategoryCasino
+        CategoryClassic
+        CategorySolo
+        CategoryExtra
+        CategoryExtra2
+        CategoryExtra3
+    }
+
+    Game --> Category : size bucket
+
+    note for Game "registry.go が 318 件の Name+Category だけを持つ。\nゲーム実装への参照は持たないので、TinyGo が\n他カテゴリを dead-code elimination できる"
+    note for Category "6 バケットは 1 MB gzip 無料枠に収めるための分割。\n各 Worker は自分のカテゴリだけを blank import する"
+```
+
+詳細な per-worker のゲーム一覧とビルド手順は
+[`docs/cloudflare-workers.md`](../cloudflare-workers.md) を参照。
 
 ---
 
@@ -1888,28 +2011,39 @@ sequenceDiagram
     participant C1 as クライアント A
     participant C2 as クライアント B
     participant WebCtrl as WebController
+    participant Prov as MemorySessionProvider
     participant Store as SessionStore
 
     C1->>WebCtrl: POST {"sessionId":"sess-1","cmd":"reset"}
-    WebCtrl->>Store: GetWithLock("sess-1")
+    WebCtrl->>Prov: execWithSession → Acquire("sess-1", factory)
+    Prov->>Store: GetWithLock("sess-1")
     Store->>Store: entries["sess-1"] 作成 + mutex lock
     Note over Store: Interactor A 生成
-    Store-->>WebCtrl: Interactor A (locked)
+    Store-->>Prov: Interactor A (locked)
+    Prov-->>WebCtrl: Interactor A + SessionRelease
     WebCtrl->>WebCtrl: reset コマンドを dispatch
-    WebCtrl->>Store: mutex unlock
+    WebCtrl->>Prov: defer で SessionRelease を呼ぶ
     WebCtrl-->>C1: レスポンス
 
     C2->>WebCtrl: POST {"sessionId":"sess-2","cmd":"reset"}
-    WebCtrl->>Store: GetWithLock("sess-2")
-    Store->>Store: sessions["sess-2"] 作成 + mutex lock
+    WebCtrl->>Prov: execWithSession → Acquire("sess-2", factory)
+    Prov->>Store: GetWithLock("sess-2")
+    Store->>Store: entries["sess-2"] 作成 + mutex lock
     Note over Store: Interactor B 生成 (独立)
-    Store-->>WebCtrl: Interactor B (locked)
+    Store-->>Prov: Interactor B (locked)
+    Prov-->>WebCtrl: Interactor B + SessionRelease
     WebCtrl->>WebCtrl: reset コマンドを dispatch
-    WebCtrl->>Store: mutex unlock
+    WebCtrl->>Prov: defer で SessionRelease を呼ぶ
     WebCtrl-->>C2: レスポンス
 
     Note over Store: 各セッションは独立した<br/>ゲーム状態を保持
 ```
+
+Controller は `SessionStore` を直接触らない。`execWithSession`
+(`adapter/controller/base_controller.go:92`) が provider から
+interactor と解放コールバックを受け取り、`defer release()` で必ず解放する。
+Cloudflare Worker ではこの `MemorySessionProvider` が `KVSessionProvider` に
+差し替わり、`GetWithLock` の代わりに KV からの復元と書き戻しが走る（§1.6）。
 
 ### 2.4 VideoPoker ベット・ホールドフロー
 

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -32,6 +32,7 @@
         "@vitest/coverage-v8": "^4.1.10",
         "happy-dom": "^20.11.1",
         "jsdom": "^28.1.0",
+        "knip": "^6.32.2",
         "tailwindcss": "^4.3.3",
         "typedoc": "^0.28.20",
         "typescript": "~5.9.3",
@@ -106,9 +107,9 @@
 
     "@csstools/css-tokenizer": ["@csstools/css-tokenizer@4.0.0", "", {}, "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA=="],
 
-    "@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
+    "@emnapi/core": ["@emnapi/core@1.11.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA=="],
 
-    "@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
+    "@emnapi/runtime": ["@emnapi/runtime@1.11.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA=="],
 
     "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
 
@@ -186,7 +187,83 @@
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
 
-    "@oxc-project/types": ["@oxc-project/types@0.139.0", "", {}, "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw=="],
+    "@oxc-parser/binding-android-arm-eabi": ["@oxc-parser/binding-android-arm-eabi@0.143.0", "", { "os": "android", "cpu": "arm" }, "sha512-n9uozULWflPqBtdmI8lAabLqGKNgLVNN0ZH8HfgCwpKGNtzRzauB76jTiW/3YLkcA7N1zskpi9GdVnZuu1SAvg=="],
+
+    "@oxc-parser/binding-android-arm64": ["@oxc-parser/binding-android-arm64@0.143.0", "", { "os": "android", "cpu": "arm64" }, "sha512-9BbdjHETk6O3zH/DDid9IgBtF0GlpLabNKN231uraXpRDSfY+iiZxTP5bk1Z63GBownVdhdINFIeddmMz4MzpQ=="],
+
+    "@oxc-parser/binding-darwin-arm64": ["@oxc-parser/binding-darwin-arm64@0.143.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gh+6ecoHUy4/sUcolBl/1qPXKBbYNxFY0Pk0ujgQvINTMSftJY7o4yb8gOkDJPeZeB8+a+u7xTe6umoP8N5HFA=="],
+
+    "@oxc-parser/binding-darwin-x64": ["@oxc-parser/binding-darwin-x64@0.143.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-qd1hl2d+lXgHv/VQ/M9qm8TrMC5T4RqDBwtOnl+1D0QMjwcz+8AaB4JSg8STgeag0GP6a6L74XEGAsrTSJWNzQ=="],
+
+    "@oxc-parser/binding-freebsd-x64": ["@oxc-parser/binding-freebsd-x64@0.143.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-M5XXcNa7aOqLPKTR41msfghKu2yQ4xWvCm11/gwU0JzOzHNk5sgW//rVEjJ+LO48+VDAMzXTSzurUVxIDKwozw=="],
+
+    "@oxc-parser/binding-linux-arm-gnueabihf": ["@oxc-parser/binding-linux-arm-gnueabihf@0.143.0", "", { "os": "linux", "cpu": "arm" }, "sha512-T/GXusuOkPNQhCQCSBbcU/N8j0rAypuDBl1IyFK+lyYT594XsVz80clPC/OtbSSpBGyJxj8uYEfctxVuxVYoww=="],
+
+    "@oxc-parser/binding-linux-arm-musleabihf": ["@oxc-parser/binding-linux-arm-musleabihf@0.143.0", "", { "os": "linux", "cpu": "arm" }, "sha512-oKu4RcBlXSqo3OC62dp6YTnQaZIurNDpCX3BnAM3+bJxt7s8J2TJKMnC0UYer1qhlRaDCg6wkTaTw+2IlsZ12w=="],
+
+    "@oxc-parser/binding-linux-arm64-gnu": ["@oxc-parser/binding-linux-arm64-gnu@0.143.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-WJBbD186AZmMGaSIhlktC+rPl8L3peCTXAh88Ih9uEvK0en2mPojGyCGYiL6mHtV1RPV3JyfJW5t6n5hh0lXhA=="],
+
+    "@oxc-parser/binding-linux-arm64-musl": ["@oxc-parser/binding-linux-arm64-musl@0.143.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-t1AcYOwEzgceadT4v5e+vaCCb0AncCA3v5AyzfBAz/tMq11qzVccXKzNHtkWdjBsgvTKwRkaUF3QvT4kot8vcQ=="],
+
+    "@oxc-parser/binding-linux-ppc64-gnu": ["@oxc-parser/binding-linux-ppc64-gnu@0.143.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-RsnO/NoD8376LMJq8JS8TwI0ieNaFRTuNe2GVJntQg6gwZNMENZsEbknHdVwjpOmxdGLGodcwaGSbAeRr5Bgjw=="],
+
+    "@oxc-parser/binding-linux-riscv64-gnu": ["@oxc-parser/binding-linux-riscv64-gnu@0.143.0", "", { "os": "linux", "cpu": "none" }, "sha512-48fSVfR9TZi5CASZFyv0VC6z6BCoeihFsX031mAD/oSH7d9PYsPgIqza7d9mjP7Z2KTEpTFyH6SIu0Ui6R1vdg=="],
+
+    "@oxc-parser/binding-linux-riscv64-musl": ["@oxc-parser/binding-linux-riscv64-musl@0.143.0", "", { "os": "linux", "cpu": "none" }, "sha512-T8CpdD+SfE01DnIOD4HpVxu0ZJOfMJ/VhCvikKfaXAxkZ+9veyLM/D2hpi7Y2hFUyPmVQO3FNZHmYzV/WlVR4g=="],
+
+    "@oxc-parser/binding-linux-s390x-gnu": ["@oxc-parser/binding-linux-s390x-gnu@0.143.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-QLdeMsCcacenPEFsfxnBUDF1y6opyz5+fmOz9bfD5Y7fiGCMupUCuB3KTPQhNwshIG1P9fPqar9MHxuBDd4bwQ=="],
+
+    "@oxc-parser/binding-linux-x64-gnu": ["@oxc-parser/binding-linux-x64-gnu@0.143.0", "", { "os": "linux", "cpu": "x64" }, "sha512-659ujfqLy6k7cuH3sbzhd8b+ztSq+i6E2E9pG78Q0BmHjAExfGIdgc8cGgMdwAozDXeZFHkJ+LXYJdWsaGdgyw=="],
+
+    "@oxc-parser/binding-linux-x64-musl": ["@oxc-parser/binding-linux-x64-musl@0.143.0", "", { "os": "linux", "cpu": "x64" }, "sha512-/Mw/9j4TfZcnKphPrzOE6t4MMknXadcAAuVUlDRTF/ETWB5xOgQvOJV2Mh9We/bWxZdoxaGAdc+hy4GuYwQ2yQ=="],
+
+    "@oxc-parser/binding-openharmony-arm64": ["@oxc-parser/binding-openharmony-arm64@0.143.0", "", { "os": "none", "cpu": "arm64" }, "sha512-8rIKWR2BFuifbIK/1XB9wTaSdtuJ25dlE7ZQYDnEwj/2xH2vHsxnvIjHT3ZjSVuLLwGGlSslIG/fbOJ8TV8rTw=="],
+
+    "@oxc-parser/binding-win32-arm64-msvc": ["@oxc-parser/binding-win32-arm64-msvc@0.143.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-5U9kQYMfRRI6Zq7KDxgbIP0RMnKrfn3gLepRMgJuRkPSUALTiRCk9d/uyhb4lGDjUdzwK7mBkKqhLgzBPCmLpQ=="],
+
+    "@oxc-parser/binding-win32-ia32-msvc": ["@oxc-parser/binding-win32-ia32-msvc@0.143.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-25P7AaHk4R88Yv2XH4gToDVmh0cOu+bEURQU10CRrmvgabfRArSGAP5osmwUKeSUHj0VS50upbpbRWWW/m7mHA=="],
+
+    "@oxc-parser/binding-win32-x64-msvc": ["@oxc-parser/binding-win32-x64-msvc@0.143.0", "", { "os": "win32", "cpu": "x64" }, "sha512-ORMh3JE1s6V7ySicdRK7vgaDQnn5o+UHg9ct989PlWHbel8O9ARrmWXM6kZjrBMtNucxNayQ8g69G0VfWzhANw=="],
+
+    "@oxc-project/types": ["@oxc-project/types@0.143.0", "", {}, "sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA=="],
+
+    "@oxc-resolver/binding-android-arm-eabi": ["@oxc-resolver/binding-android-arm-eabi@11.24.2", "", { "os": "android", "cpu": "arm" }, "sha512-y09e0L0SRI2OA2tUIrjBgoV3eH5hvUKXNkJqXmNo5V2WxIjyC7I7aJfRLMEVpA8yi95f90gFDvO0VMgrDw+vwA=="],
+
+    "@oxc-resolver/binding-android-arm64": ["@oxc-resolver/binding-android-arm64@11.24.2", "", { "os": "android", "cpu": "arm64" }, "sha512-cl4icWaZFnLdg8m6qtnh5rBMuGbxc/ptStFHLeCNwr+2cZjkjNwQu/jYRS0CHlnPecOJMpuS5M6/BH+0J/YkEg=="],
+
+    "@oxc-resolver/binding-darwin-arm64": ["@oxc-resolver/binding-darwin-arm64@11.24.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-At29QEMF6HajbQvgY8K6OXnHD1x9rad74xBEfmCB6ZqCGsdq75aK7tOYcTbOanMy8qdIBrfL3SMr3p/lfSlb9w=="],
+
+    "@oxc-resolver/binding-darwin-x64": ["@oxc-resolver/binding-darwin-x64@11.24.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-A5Kqr1EUj4oIL5CF4WRssq/o5P0Y11cwoFouMRmQ7YnC/A8V93nv1nb7aSU8HwcgmXropjLNkVTl4MN87cu28Q=="],
+
+    "@oxc-resolver/binding-freebsd-x64": ["@oxc-resolver/binding-freebsd-x64@11.24.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-R5xkRBRRz7ceH/P5Jrc6G7FmdUdgpLYyESFAUDVTNQ9K0sGPxcp4ljiwEwEqsvNcQ4sYbMRrWcHHBCu7ksAJVw=="],
+
+    "@oxc-resolver/binding-linux-arm-gnueabihf": ["@oxc-resolver/binding-linux-arm-gnueabihf@11.24.2", "", { "os": "linux", "cpu": "arm" }, "sha512-k/RuYL4L/R58IBn3wT5ma3Wh4k62bp1eYCFRWCmMsasUOqL+H6sW0VGFadEzKWXFFlz+2uIMoeMk9ySSZJHgbg=="],
+
+    "@oxc-resolver/binding-linux-arm-musleabihf": ["@oxc-resolver/binding-linux-arm-musleabihf@11.24.2", "", { "os": "linux", "cpu": "arm" }, "sha512-bnHAak3ujYfH5pKk4NieFNbvYvernfoQDgwLddbZ3OtMYrem87/qjlA+u+aKG0oZcqSLGCful/6/CEA+aeAgaA=="],
+
+    "@oxc-resolver/binding-linux-arm64-gnu": ["@oxc-resolver/binding-linux-arm64-gnu@11.24.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-vDT3KHgzYp47gmtNOqL2VNhCyl5Zv643eyxm//A68J8DeUGXrvD1pZFiaT4jSfe+RInfnn1R2yVHye4enx6RnA=="],
+
+    "@oxc-resolver/binding-linux-arm64-musl": ["@oxc-resolver/binding-linux-arm64-musl@11.24.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-+kMlQvbzfyEYtu5FcjE4p+ttBLpKW4d/AsAsuE69BxV6V4twZJeIQZFfD8gh/wqglY0MkPSezWXQH0jBV13MUw=="],
+
+    "@oxc-resolver/binding-linux-ppc64-gnu": ["@oxc-resolver/binding-linux-ppc64-gnu@11.24.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-shjfMhmZ3gq9fv/w7bi3PnZlgOPG+2QAOFf0BJF0EgBSIGZ6PMLN2zbGEblTUYB/NKVDRyYhE2ff3dJ1QqNPkA=="],
+
+    "@oxc-resolver/binding-linux-riscv64-gnu": ["@oxc-resolver/binding-linux-riscv64-gnu@11.24.2", "", { "os": "linux", "cpu": "none" }, "sha512-zGelwFR5oRo+b69k8Lrzun86DyUHzfKN6cnjbR9l7Z7NIRznOE/2ZvPa1IUKqAL2PzAXOdwkfVqNvO1H2RlpAw=="],
+
+    "@oxc-resolver/binding-linux-riscv64-musl": ["@oxc-resolver/binding-linux-riscv64-musl@11.24.2", "", { "os": "linux", "cpu": "none" }, "sha512-qxZ1SWCXJY0eyhAlP6Lmo9F2Nrtx7EkYj9oCgL8apDPCwXwCEDA2U697bbT81JIc2IrVjxO4KX6WU2N+oN9Z4w=="],
+
+    "@oxc-resolver/binding-linux-s390x-gnu": ["@oxc-resolver/binding-linux-s390x-gnu@11.24.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-sGCecF3cx2DFlH4t/z7ApnOnXqN48p5p5mlHDEnHTAukQa2P+qMVE4CwyWE9W+q/m3QJ7kKfGrIjax31f44oFQ=="],
+
+    "@oxc-resolver/binding-linux-x64-gnu": ["@oxc-resolver/binding-linux-x64-gnu@11.24.2", "", { "os": "linux", "cpu": "x64" }, "sha512-k/VlMMcSzMlahb3/fENM4rTlsJ0s3fFROA0KXPBmKggqmTSaE383sl8F3KCOXPLmVsYfW6hCitMhXCEtNeZxxg=="],
+
+    "@oxc-resolver/binding-linux-x64-musl": ["@oxc-resolver/binding-linux-x64-musl@11.24.2", "", { "os": "linux", "cpu": "x64" }, "sha512-8hbnZyNi97b/8wapYaIF9+t9GmZKBW2vunaOc3h9HGJptH7b7XpvZqOTBSm/MpTjr7H497BlgOaSfLUdhmy2bw=="],
+
+    "@oxc-resolver/binding-openharmony-arm64": ["@oxc-resolver/binding-openharmony-arm64@11.24.2", "", { "os": "none", "cpu": "arm64" }, "sha512-MvyGik3a6pVgZ0t/kWlbmFxFLmXQJwgLsY2eYFHLpy0wGwRbfzeIGgDwQ3kXqE30z+kSXennRkCrT7TUvkptNg=="],
+
+    "@oxc-resolver/binding-wasm32-wasi": ["@oxc-resolver/binding-wasm32-wasi@11.24.2", "", { "dependencies": { "@emnapi/core": "1.11.2", "@emnapi/runtime": "1.11.2", "@napi-rs/wasm-runtime": "^1.1.6" }, "cpu": "none" }, "sha512-vHcssMPwO08RTvj/c0iOBz90attxyG3wQJ0dTcyEQK43LRpcdLWZlV5feBhv6Isn6ahbQIzHbCgfa81+RiML0Q=="],
+
+    "@oxc-resolver/binding-win32-arm64-msvc": ["@oxc-resolver/binding-win32-arm64-msvc@11.24.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-uokJqro2iBqkFvJdKQLP7d8/BUmFwESQFVmIJUQKj1Xn1a/LysJoe1vmeECLF5b3jsV8CAL5sEMJXX6SdK9Nhg=="],
+
+    "@oxc-resolver/binding-win32-x64-msvc": ["@oxc-resolver/binding-win32-x64-msvc@11.24.2", "", { "os": "win32", "cpu": "x64" }, "sha512-UqGPmo56KDfLlfXFAFIrNflHT8tFxWGEivWg3Zeyp4Uy2NlKN1FGPr6/BxcLGG3+kZ6Wp14g5Uj+n71boqZfiw=="],
 
     "@playwright/test": ["@playwright/test@1.62.0", "", { "dependencies": { "playwright": "1.62.0" }, "bin": { "playwright": "cli.js" } }, "sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA=="],
 
@@ -608,11 +685,17 @@
 
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
+    "fd-package-json": ["fd-package-json@2.0.0", "", { "dependencies": { "walk-up-path": "^4.0.0" } }, "sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ=="],
+
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "formatly": ["formatly@0.3.0", "", { "dependencies": { "fd-package-json": "^2.0.0" }, "bin": { "formatly": "bin/index.mjs" } }, "sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w=="],
 
     "framer-motion": ["framer-motion@12.42.2", "", { "dependencies": { "motion-dom": "^12.42.2", "motion-utils": "^12.39.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-5XY9luDiu0oHfHBjpDthFMh0ES+122w6p/papSJBweMkO8Sn+PW2QaEgRblQBpWFnuvZS5qvarpt/hO2pjGmnw=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "get-tsconfig": ["get-tsconfig@4.14.1", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-Dz/6HxkrxgNehhxLVeyv8sad9UzF2xBVeaKBQNDfJ5XiSXmp2gTR0eO0RWiT2NCKS5aGP9jjkOMggTN90qU50A=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
@@ -679,6 +762,8 @@
     "katex": ["katex@0.16.47", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg=="],
 
     "khroma": ["khroma@2.1.0", "", {}, "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="],
+
+    "knip": ["knip@6.32.2", "", { "dependencies": { "fdir": "^6.5.0", "formatly": "^0.3.0", "get-tsconfig": "4.14.1", "jiti": "^2.7.0", "oxc-parser": "^0.143.0", "oxc-resolver": "11.24.2", "picomatch": "^4.0.5", "smol-toml": "^1.7.1", "strip-json-comments": "5.0.3", "tinyglobby": "^0.2.17", "unbash": "^4.0.9", "yaml": "^2.9.0", "zod": "^4.4.3" }, "bin": { "knip": "bin/knip.js", "knip-bun": "bin/knip-bun.js" } }, "sha512-WXTXbmocrw7gqm1A1TQvFN0OgJ7hUSU6E1g6SPRIzzHFogUBhXByc7cYeOFVtJ2uODg7DP4VbESYBYnfbtBYsg=="],
 
     "layout-base": ["layout-base@1.0.2", "", {}, "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg=="],
 
@@ -838,6 +923,10 @@
 
     "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
 
+    "oxc-parser": ["oxc-parser@0.143.0", "", { "dependencies": { "@oxc-project/types": "^0.143.0" }, "optionalDependencies": { "@oxc-parser/binding-android-arm-eabi": "0.143.0", "@oxc-parser/binding-android-arm64": "0.143.0", "@oxc-parser/binding-darwin-arm64": "0.143.0", "@oxc-parser/binding-darwin-x64": "0.143.0", "@oxc-parser/binding-freebsd-x64": "0.143.0", "@oxc-parser/binding-linux-arm-gnueabihf": "0.143.0", "@oxc-parser/binding-linux-arm-musleabihf": "0.143.0", "@oxc-parser/binding-linux-arm64-gnu": "0.143.0", "@oxc-parser/binding-linux-arm64-musl": "0.143.0", "@oxc-parser/binding-linux-ppc64-gnu": "0.143.0", "@oxc-parser/binding-linux-riscv64-gnu": "0.143.0", "@oxc-parser/binding-linux-riscv64-musl": "0.143.0", "@oxc-parser/binding-linux-s390x-gnu": "0.143.0", "@oxc-parser/binding-linux-x64-gnu": "0.143.0", "@oxc-parser/binding-linux-x64-musl": "0.143.0", "@oxc-parser/binding-openharmony-arm64": "0.143.0", "@oxc-parser/binding-win32-arm64-msvc": "0.143.0", "@oxc-parser/binding-win32-ia32-msvc": "0.143.0", "@oxc-parser/binding-win32-x64-msvc": "0.143.0" } }, "sha512-ov0NzaDCOInknS7mP1cwKdJERt3utPW8ldjtdUXQ8Ty0GEFD08wk422vCUN0d7pST6kqtV7dxoI9w1Zi0l/9TA=="],
+
+    "oxc-resolver": ["oxc-resolver@11.24.2", "", { "optionalDependencies": { "@oxc-resolver/binding-android-arm-eabi": "11.24.2", "@oxc-resolver/binding-android-arm64": "11.24.2", "@oxc-resolver/binding-darwin-arm64": "11.24.2", "@oxc-resolver/binding-darwin-x64": "11.24.2", "@oxc-resolver/binding-freebsd-x64": "11.24.2", "@oxc-resolver/binding-linux-arm-gnueabihf": "11.24.2", "@oxc-resolver/binding-linux-arm-musleabihf": "11.24.2", "@oxc-resolver/binding-linux-arm64-gnu": "11.24.2", "@oxc-resolver/binding-linux-arm64-musl": "11.24.2", "@oxc-resolver/binding-linux-ppc64-gnu": "11.24.2", "@oxc-resolver/binding-linux-riscv64-gnu": "11.24.2", "@oxc-resolver/binding-linux-riscv64-musl": "11.24.2", "@oxc-resolver/binding-linux-s390x-gnu": "11.24.2", "@oxc-resolver/binding-linux-x64-gnu": "11.24.2", "@oxc-resolver/binding-linux-x64-musl": "11.24.2", "@oxc-resolver/binding-openharmony-arm64": "11.24.2", "@oxc-resolver/binding-wasm32-wasi": "11.24.2", "@oxc-resolver/binding-win32-arm64-msvc": "11.24.2", "@oxc-resolver/binding-win32-x64-msvc": "11.24.2" } }, "sha512-FY91FiDBj7ls5MsFS9jN3tjz2o0/zsdSsymlakySaBwVJZorHhkWyICLZMKxlu1R9vYo+sd3z1jwb4J8x7bNDw=="],
+
     "package-manager-detector": ["package-manager-detector@1.6.0", "", {}, "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA=="],
 
     "parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
@@ -898,6 +987,8 @@
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
+    "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
+
     "robust-predicates": ["robust-predicates@3.0.3", "", {}, "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA=="],
 
     "rolldown": ["rolldown@1.1.5", "", { "dependencies": { "@oxc-project/types": "=0.139.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.1.5", "@rolldown/binding-darwin-arm64": "1.1.5", "@rolldown/binding-darwin-x64": "1.1.5", "@rolldown/binding-freebsd-x64": "1.1.5", "@rolldown/binding-linux-arm-gnueabihf": "1.1.5", "@rolldown/binding-linux-arm64-gnu": "1.1.5", "@rolldown/binding-linux-arm64-musl": "1.1.5", "@rolldown/binding-linux-ppc64-gnu": "1.1.5", "@rolldown/binding-linux-s390x-gnu": "1.1.5", "@rolldown/binding-linux-x64-gnu": "1.1.5", "@rolldown/binding-linux-x64-musl": "1.1.5", "@rolldown/binding-openharmony-arm64": "1.1.5", "@rolldown/binding-wasm32-wasi": "1.1.5", "@rolldown/binding-win32-arm64-msvc": "1.1.5", "@rolldown/binding-win32-x64-msvc": "1.1.5" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA=="],
@@ -918,6 +1009,8 @@
 
     "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
 
+    "smol-toml": ["smol-toml@1.8.0", "", {}, "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ=="],
+
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
@@ -929,6 +1022,8 @@
     "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
 
     "strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
+
+    "strip-json-comments": ["strip-json-comments@5.0.3", "", {}, "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw=="],
 
     "style-to-js": ["style-to-js@1.1.21", "", { "dependencies": { "style-to-object": "1.0.14" } }, "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ=="],
 
@@ -978,6 +1073,8 @@
 
     "ufo": ["ufo@1.6.3", "", {}, "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q=="],
 
+    "unbash": ["unbash@4.0.10", "", {}, "sha512-b7zoBQvpWp0vuN5q2vK2RRBR2SvuruQAs50DApdDveBSn3eSYd84IaHodFqQIMlvY9K2VnyBUEXgwOBuGU9GBg=="],
+
     "undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
 
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
@@ -1008,6 +1105,8 @@
 
     "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
 
+    "walk-up-path": ["walk-up-path@4.0.0", "", {}, "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A=="],
+
     "webidl-conversions": ["webidl-conversions@8.0.1", "", {}, "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ=="],
 
     "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
@@ -1024,9 +1123,15 @@
 
     "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
     "@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "@rolldown/binding-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
+
+    "@rolldown/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.3", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.3", "tslib": "^2.4.0" }, "bundled": true }, "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg=="],
 
@@ -1067,6 +1172,8 @@
     "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "react-i18next/@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
+
+    "rolldown/@oxc-project/types": ["@oxc-project/types@0.139.0", "", {}, "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw=="],
 
     "vitest/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 

--- a/frontend/knip.json
+++ b/frontend/knip.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://unpkg.com/knip@6/schema.json",
+  "entry": ["src/**/*.test.{ts,tsx}", "e2e/**/*.spec.ts", "scripts/*.mjs"],
+  "project": ["src/**/*.{ts,tsx}", "scripts/**/*.mjs"],
+  "ignoreDependencies": ["typescript7", "tailwindcss"]
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,8 @@
     "e2e:ui": "playwright test --ui",
     "e2e:headed": "playwright test --headed",
     "docs:generate": "typedoc",
-    "typecheck": "bun ./node_modules/typescript7/bin/tsc -b"
+    "typecheck": "bun ./node_modules/typescript7/bin/tsc -b",
+    "deadcode": "knip"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.101.4",
@@ -53,6 +54,7 @@
     "@vitest/coverage-v8": "^4.1.10",
     "happy-dom": "^20.11.1",
     "jsdom": "^28.1.0",
+    "knip": "^6.32.2",
     "tailwindcss": "^4.3.3",
     "typedoc": "^0.28.20",
     "typescript": "~5.9.3",

--- a/frontend/src/hooks/useCassinoGame.test.tsx
+++ b/frontend/src/hooks/useCassinoGame.test.tsx
@@ -47,7 +47,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 // Use renderWithProviders' Provider tree by wrapping a placeholder.
 // renderHook needs a wrapper element, so we forward the providers manually.
 import type { ReactNode } from 'react';
-import { MemoryRouter } from 'react-router';
+import { MemoryRouter } from 'react-router-dom';
 import { flushPendingDispatch } from '../test/flushPendingDispatch';
 
 function Hookwrapper({ children }: { children: ReactNode }) {

--- a/frontend/src/i18n/buildResources.ts
+++ b/frontend/src/i18n/buildResources.ts
@@ -4,7 +4,7 @@
  * which mounts on `/discover` and is ~25-35 KB gzipped — not worth
  * carrying for users who never open the concierge).
  */
-export const LAZY_NAMESPACES: ReadonlySet<string> = new Set<string>(['discover']);
+const LAZY_NAMESPACES: ReadonlySet<string> = new Set<string>(['discover']);
 
 /** Options for the resource builder. */
 export interface BuildResourcesOptions {

--- a/internal/infrastructure/games/design_doc_diagrams_test.go
+++ b/internal/infrastructure/games/design_doc_diagrams_test.go
@@ -33,6 +33,12 @@ import (
 var (
 	// headingRe captures the identifier in `### 3.12 Cruel フェーズ遷移`.
 	headingRe = regexp.MustCompile(`^#{2,4}\s+[\d.]+\s+([A-Za-z][A-Za-z0-9]*)`)
+	// anyHeadingRe matches a section heading whatever its title. Tracking must
+	// not be limited to headings headingRe understands: a Japanese-titled
+	// section such as `### 2.3 セッション管理フロー` names no Go type, but if it
+	// does not update the current heading then its diagrams get reported under
+	// the previous section and the error message points at the wrong place.
+	anyHeadingRe = regexp.MustCompile(`^#{2,4}\s+\S`)
 	// fenceOpenRe/fenceCloseRe bracket a mermaid block.
 	fenceOpenRe  = regexp.MustCompile("^\\s*```mermaid\\s*$")
 	fenceCloseRe = regexp.MustCompile("^\\s*```\\s*$")
@@ -110,7 +116,7 @@ func readDesignDoc(t *testing.T, path string) []docBlock {
 		case inFence:
 			cur = append(cur, line)
 		default:
-			if m := headingRe.FindStringSubmatch(line); m != nil {
+			if anyHeadingRe.MatchString(line) {
 				heading = strings.TrimSpace(strings.TrimLeft(line, "# "))
 			}
 		}
@@ -390,6 +396,60 @@ func TestDesignDocDiagramParsersCatchBreakage(t *testing.T) {
 	}
 	if surface.consts["NoSuchPhaseConstant"] {
 		t.Error("surface claims NoSuchPhaseConstant exists -- the const collector is too permissive")
+	}
+}
+
+// TestDesignDocHeadingTrackingFollowsNonASCIISections asserts that a section
+// whose title is not ASCII still becomes the current heading.
+//
+// headingRe only matches a heading that names a bare identifier, and using it
+// for *tracking* meant `### 2.3 セッション管理フロー` left the heading pointing at
+// the previous English-titled section -- so a finding in 2.3 was reported as
+// living in 2.2, sending the reader to the wrong diagram.
+func TestDesignDocHeadingTrackingFollowsNonASCIISections(t *testing.T) {
+	doc := "## 2.2 Web APIゲーム実行フロー\n\n" +
+		"```mermaid\nsequenceDiagram\n    participant A as Durak\n    A->>A: Reset()\n```\n\n" +
+		"### 2.3 セッション管理フロー\n\n" +
+		"```mermaid\nsequenceDiagram\n    participant B as Durak\n    B->>B: Reset()\n```\n"
+
+	path := filepath.Join(t.TempDir(), "doc.md")
+	if err := os.WriteFile(path, []byte(doc), 0o600); err != nil {
+		t.Fatalf("write temp doc: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read temp doc: %v", err)
+	}
+
+	var blocks []docBlock
+	heading, inFence := "", false
+	var cur []string
+	for line := range strings.SplitSeq(string(data), "\n") {
+		switch {
+		case !inFence && fenceOpenRe.MatchString(line):
+			inFence, cur = true, nil
+		case inFence && fenceCloseRe.MatchString(line):
+			blocks = append(blocks, docBlock{heading: heading, body: strings.Join(cur, "\n")})
+			inFence = false
+		case inFence:
+			cur = append(cur, line)
+		default:
+			if anyHeadingRe.MatchString(line) {
+				heading = strings.TrimSpace(strings.TrimLeft(line, "# "))
+			}
+		}
+	}
+
+	if len(blocks) != 2 {
+		t.Fatalf("parsed %d blocks, want 2", len(blocks))
+	}
+	if want := "2.3 セッション管理フロー"; blocks[1].heading != want {
+		t.Errorf("second block attributed to %q, want %q -- a non-ASCII heading did not update tracking",
+			blocks[1].heading, want)
+	}
+	// The owner extraction is deliberately stricter: this heading names no type.
+	if owner := headingOwner(blocks[1].heading); owner != "" {
+		t.Errorf("headingOwner(%q) = %q, want \"\" -- it must not invent an owner", blocks[1].heading, owner)
 	}
 }
 

--- a/internal/infrastructure/games/docs_drift_guards_test.go
+++ b/internal/infrastructure/games/docs_drift_guards_test.go
@@ -252,7 +252,12 @@ func countImplTypes(t *testing.T, dir, suffix string) int {
 // but that is a count of *bindings*, not of types: several controllers serve
 // more than one game (`NewOmahaWebController` is bound for 5, VideoPoker /
 // SevenCardStud / Pineapple for 3 each, BlackJack / FreeCell / FiveCardStud for
-// 2), so there are 611 controller and 612 presenter types, not 636 of each.
+// 2), so there are 610 controller and 612 presenter types, not 636 of each.
+// (610 = CuiController 305 + WebController 305; the generic base
+// GameWebController[I,P,O] is not a per-game implementation and is excluded.
+// Hand-counting it in is how this comment first said 611 -- the guard below
+// caught that, which is the entire reason the number is asserted and not
+// written down once.)
 //
 // Reading 636 as "636 implementations" is what #5350 flagged and could not fix:
 // correcting the prose alone would have contradicted the binding guard, so the

--- a/internal/infrastructure/games/docs_drift_guards_test.go
+++ b/internal/infrastructure/games/docs_drift_guards_test.go
@@ -2,10 +2,12 @@ package games_test
 
 import (
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/infrastructure/games"
@@ -201,6 +203,98 @@ func TestDesignDocCountsMatchRegistry(t *testing.T) {
 					got := m[i+1]
 					if got != fmt.Sprint(want) {
 						t.Errorf("%s: %q says %s where the registry implies %d", c.path, m[0], got, want)
+					}
+				}
+			}
+		})
+	}
+}
+
+// implTypeRe matches a per-game implementation type declaration such as
+// `type BlackJackCuiController struct`.
+func implTypeRe(suffix string) *regexp.Regexp {
+	return regexp.MustCompile(`(?m)^type ([A-Za-z0-9_]+` + suffix + `) `)
+}
+
+// countImplTypes returns how many distinct types under dir end in suffix.
+// Production files only: the document describes shipped code.
+func countImplTypes(t *testing.T, dir, suffix string) int {
+	t.Helper()
+	re := implTypeRe(suffix)
+	seen := map[string]bool{}
+	root := filepath.Join(repoRoot, dir)
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return err
+		}
+		data, rerr := os.ReadFile(path)
+		if rerr != nil {
+			return rerr
+		}
+		for _, m := range re.FindAllSubmatch(data, -1) {
+			seen[string(m[1])] = true
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", dir, err)
+	}
+	if len(seen) < 100 {
+		t.Fatalf("only %d %s types found under %s -- the declaration regex stopped matching", len(seen), suffix, dir)
+	}
+	return len(seen)
+}
+
+// TestDesignDocImplementationCountsMatchCode asserts the *type* counts the
+// design document states for the per-game controllers and presenters.
+//
+// TestDesignDocCountsMatchRegistry already guards `318ゲーム × CUI/Web = 636`,
+// but that is a count of *bindings*, not of types: several controllers serve
+// more than one game (`NewOmahaWebController` is bound for 5, VideoPoker /
+// SevenCardStud / Pineapple for 3 each, BlackJack / FreeCell / FiveCardStud for
+// 2), so there are 611 controller and 612 presenter types, not 636 of each.
+//
+// Reading 636 as "636 implementations" is what #5350 flagged and could not fix:
+// correcting the prose alone would have contradicted the binding guard, so the
+// number needed a guard of its own before the wording could say both things.
+func TestDesignDocImplementationCountsMatchCode(t *testing.T) {
+	cui := countImplTypes(t, "internal/adapter/controller", "CuiController")
+	web := countImplTypes(t, "internal/adapter/controller", "WebController")
+	cuiP := countImplTypes(t, "internal/adapter/presenter", "CuiPresenter")
+	webP := countImplTypes(t, "internal/adapter/presenter", "WebPresenter")
+
+	data, err := os.ReadFile(filepath.Join(repoRoot, "docs/design/backend.md"))
+	if err != nil {
+		t.Fatalf("read backend.md: %v", err)
+	}
+	doc := string(data)
+
+	cases := []struct {
+		name string
+		re   *regexp.Regexp
+		want []int
+	}{
+		{
+			"controller implementation types",
+			regexp.MustCompile(`実装型は (\d+) 種類 \(CuiController (\d+) \+ WebController (\d+)\)`),
+			[]int{cui + web, cui, web},
+		},
+		{
+			"presenter implementation types",
+			regexp.MustCompile(`実装型は (\d+) 種類 \(CuiPresenter (\d+) \+ WebPresenter (\d+)\)`),
+			[]int{cuiP + webP, cuiP, webP},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			matches := c.re.FindAllStringSubmatch(doc, -1)
+			if len(matches) == 0 {
+				t.Fatalf("backend.md: pattern %q matched nothing -- the wording changed; update the regex here", c.re)
+			}
+			for _, m := range matches {
+				for i, want := range c.want {
+					if m[i+1] != fmt.Sprint(want) {
+						t.Errorf("backend.md: %q says %s where the code has %d", m[0], m[i+1], want)
 					}
 				}
 			}


### PR DESCRIPTION
#5350 の drift sweep で「方針判断が要る」として意図的に保留した 3 件を全部片付ける。

## 1. `636` は実装数ではなくバインディング数だった

`318ゲーム × CUI/Web = 636` という式自体は正しいが、それを「636 Controller 実装」と
読ませていた。実測:

| | 実装型 | 内訳 |
|---|---|---|
| Controller | **610** | CuiController 305 + WebController 305 |
| Presenter | **612** | CuiPresenter 306 + WebPresenter 306 |

差は**共有**。`NewOmahaWebController` は 5 ゲーム、VideoPoker / SevenCardStud /
Pineapple は各 3 ゲーム、BlackJack / FreeCell / FiveCardStud は各 2 ゲームに
束ねられている（`games_server.go`）。

**なぜ #5350 で直せなかったか**: `TestDesignDocCountsMatchRegistry` が
`perGamePair := total * 2` をハードコードしているので、文言だけ直すと CI が落ちる。

**今回の解**: 先に `TestDesignDocImplementationCountsMatchCode` を追加して
`internal/adapter/{controller,presenter}` から型数を**実際に数える**ようにし、
その上で「バインディング」と「実装型」を書き分けた。既存のバインディング guard は
そのまま通る（両方が別々の事実を守る）。

> 副産物: #5350 のレビューでは 611 とされ、自分も手 grep で 611 と数えていたが、
> **新ガードが 610 だと指摘した**。611 に含まれていた 1 件は総称基底
> `GameWebController[I any, P WebInput, O any]` で、per-game 実装ではない。
> 手で数えた数字がそのまま入るのを防ぐのがこのガードの主旨なので、初仕事として妥当。

## 2. `knip` は文書化されているだけで存在しなかった

`CLAUDE.md:185` と `.claude/rules/frontend.md:81` が TypeScript の dead code 検出に
`knip` を指定していたが、devDependency にも設定ファイルにも `scripts` にも無く、
リポジトリ全体で "knip" の出現は**この 2 行だけ**だった（= 指示どおり実行すると
未設定のまま cold download される）。

knip (ISC) を devDependency に追加し、`frontend/knip.json` と
`bun run deadcode` を用意して、**文書に書いてあるとおりに実行できる**状態にした。

`bun run check` には**繋いでいない**。dead code の削除は判断を伴い、既存方針も
「静的解析は false positive を出すので必ず手動で確認してから削除」なので、
CI で自動的に落とすものではないと判断した。

初回実行は 3 件を報告し、**1 件ずつ検証**した:

| 報告 | 判定 | 対応 |
|---|---|---|
| `tailwindcss` が未使用 devDependency | **false positive** | `src/index.css` の `@import "tailwindcss"` で使う v4 エンジン。knip は CSS の import を追わないと自分の configuration hints で報告している。`ignoreDependencies` に記載 |
| `react-router` が未宣言依存 | **実問題** | 26 箇所が `react-router-dom` を import する中、`useCassinoGame.test.tsx` だけが推移的依存を直接 import していた。揃えた |
| `LAZY_NAMESPACES` が未使用 export | **実問題** | `buildResources.ts` 内でしか使わないので `export` を外した |

修正後 `bun run deadcode` は exit 0。`check-dependency-licenses` も 492 packages で緑
（+17 は knip の依存、いずれも互換ライセンス）。

## 3. `backend.md` に中核型が 1 つも載っていなかった

「誤り」ではなく**不足**。図に一度も出てこないのに実装を支配していた型を追加した。

- **§1.1 に共有ミックスインを追加** — `actionLogBase`（272 ファイルが埋め込み）/
  `TrickHolder`（89）/ `RoundScoreHolder`（39）。per-game 図に出てくる
  `GetActionLog()` / `GetTricksTaken()` / `GetRoundScore()` は per-game 型の自前定義
  ではなく**ここからの昇格**だと明記。`TrickHolder` / `RoundScoreHolder` が独自の
  `MarshalJSON` を持つ理由（非公開フィールドが KV 往復で消える）も併記
- **§1.3 の `GameInteractor` は実在しない** placeholder だった。実体である
  `GameBase[G]`（305 interactor が埋め込み、`Snapshot()` を供給）を描き、
  `execAndPresent` / `runAndPresent` が**メソッドではなく
  `usecase/interactor_helper.go` のパッケージレベル総称関数**であることを訂正
- **§1.6 を新設** — `SessionProvider` / `MemorySessionProvider` /
  `KVSessionProvider` / `SessionRelease` と、`games.Category` の 6 バケット
  Worker 層。`Category` がユーザ向け分類ではなくサイズバケットである点も明記
- **§2.3 の経路を訂正** — `WebController → SessionStore.GetWithLock` を直接
  描いていたが、実際は `execWithSession`（`base_controller.go:92`）が
  `provider.Acquire()` を呼び `defer release()` する。Worker ではこの provider が
  `KVSessionProvider` に差し替わるだけ、という対称性が見えるようにした

## ガード自身の修正（#5352 の積み残し）

`readDesignDoc` の見出し追跡が `headingRe`（ASCII 識別子を要求）を使っていたため、
`### 2.3 セッション管理フロー` のような**日本語見出しが現在見出しを更新せず**、
2.3 の指摘が「2.2 のもの」として報告されていた。実際に今回それを踏んで気付いた
（自分の新しい図の誤りが隣の節のものとして出た）。任意の見出しで追跡するよう
`anyHeadingRe` を分離し、回帰テストを追加。持ち主の抽出は従来どおり厳格なまま
（見出しが Go の型を指さないステート図はスキップ）。

> なお §1.6 / §2.3 を書いている最中に、#5352 のガードが自分の新しい図の
> `defer release()` を「`MemorySessionProvider` にそんなメソッドは無い」と弾いた。
> `release` は `Acquire` が返すコールバックであってメソッドではないので指摘が正しく、
> 散文に直した。**ガードが書き手の新規記述にも効いている**ことの確認になった。

## 検証

- `go build ./...` / `go test -tags test ./internal/infrastructure/games/` 通過
- `golangci-lint run ./internal/infrastructure/games/...` 0 issues
- `cd frontend && bun run check` 全ガード緑（mermaid は 778→**781** ブロックで
  新しい 3 図を実パースしている）
- `cd frontend && bun run typecheck` 通過
- `bunx vitest run src/hooks/useCassinoGame.test.tsx src/i18n` 16 passed
- `bun run deadcode` exit 0

## テスト計画

- [x] 新カウントガードを Red から書き、文言修正で Green
- [x] knip の 3 報告を 1 件ずつ実コードで検証（false positive 1 / 実問題 2）
- [x] 見出し追跡の回帰テスト
- [x] 新規に書いた図が既存の識別子ガードを通ることを確認
- [ ] CI 全緑を確認

Closes #5353
