### PR TITLE
test(zwanzigerrufen): pin the called trump in the own-partner tamper case

### DIFF
--- a/internal/domain/Zwanzigerrufen_test.go
+++ b/internal/domain/Zwanzigerrufen_test.go
@@ -872,7 +872,15 @@ func TestZwanzigerrufenUnmarshal_RejectsTamperedState(t *testing.T) {
 			m["cl"] = -1
 			m["pi"] = 2
 		}, "requires a called trump"},
+		// **呼び札も明示する。**`zwanzigerrufenAtPlay` の局面は配りに依存し、
+		// デクレアラー自身が呼び札を持っていた回は `cl` が -1 のまま返る
+		// (Zwanzigerrufen.resolveCall がその場合パートナー無しに倒す)。
+		// `dc`/`pi` だけを弄ると、その回は先に並ぶ「パートナーには呼び札が要る」
+		// が先に当たり、期待した "own partner" ではなくそちらのエラーになる。
+		// 検証したい違反だけが立つように、他の前提はこのケース内で固定する。
 		{"自分自身がパートナー", func(m map[string]any) {
+			m["co"] = int(ZwanzigerrufenBidRufer)
+			m["cl"] = ZwanzigerrufenCallTrump
 			m["dc"] = 1
 			m["pi"] = 1
 		}, "own partner"},

--- a/internal/domain/Zwanzigerrufen_test.go
+++ b/internal/domain/Zwanzigerrufen_test.go
@@ -872,12 +872,8 @@ func TestZwanzigerrufenUnmarshal_RejectsTamperedState(t *testing.T) {
 			m["cl"] = -1
 			m["pi"] = 2
 		}, "requires a called trump"},
-		// **呼び札も明示する。**`zwanzigerrufenAtPlay` の局面は配りに依存し、
-		// デクレアラー自身が呼び札を持っていた回は `cl` が -1 のまま返る
-		// (Zwanzigerrufen.resolveCall がその場合パートナー無しに倒す)。
-		// `dc`/`pi` だけを弄ると、その回は先に並ぶ「パートナーには呼び札が要る」
-		// が先に当たり、期待した "own partner" ではなくそちらのエラーになる。
-		// 検証したい違反だけが立つように、他の前提はこのケース内で固定する。
+		// **土台の配りに依存させない。** デクレアラーが呼び札を持っていた回は
+		// `cl` が -1 で返るので、`dc`/`pi` だけ弄ると「呼び札が要る」が先に当たる。
 		{"自分自身がパートナー", func(m map[string]any) {
 			m["co"] = int(ZwanzigerrufenBidRufer)
 			m["cl"] = ZwanzigerrufenCallTrump


### PR DESCRIPTION
`TestZwanzigerrufenUnmarshal_RejectsTamperedState/自分自身がパートナー` が**配り依存**で落ちる。PR #5354 の CI で実際に踏んだもので、その PR の変更内容（ドキュメントとガード）とは無関係。

```
Error "zwanzigerrufen: a partner requires a called trump"
  does not contain "own partner"
```

## 原因

改竄テストの土台 `zwanzigerrufenAtPlay` は**本物の局面**なので、`cl`（呼び札）が配りによって変わる。デクレアラー自身が呼び札を持っていた回は `resolveCall` がパートナー無しに倒すため `cl` は -1 のまま返る（この挙動自体は既存テストが固定している）。

検証側の並びは:

```go
if PartnerIdx != -1 && CalledTrump == -1  -> "a partner requires a called trump"
if PartnerIdx != -1 && PartnerIdx == DeclarerIdx -> "own partner"
```

なので `dc`/`pi` だけを弄ると、`cl == -1` を引いた回は**先の条件が当たり**、検証したかった違反に到達しない。

## 修正

隣接ケース（「Trischaken なのに呼び札がある」など）は前提を自分で書いている。同じ形に揃え、`co`/`cl` も明示して**検証したい違反だけが立つ**ようにした。

「本物の局面を 1 か所だけ壊す」という改竄テストの方針は保ったまま、**土台が既に別の規則に違反している回**を排除しただけで、検査している違反は変えていない。

## 検証

- 土台を `cl = -1` に**強制**して落ちる条件を再現し、修正後に通ることを実測（修正前はこの条件で確実に失敗する）
- `go test -tags test ./internal/domain -run TestZwanzigerrufen` を **15 回連続**実行して 0 失敗
- `go vet -tags test ./internal/domain/` 通過

再実行で流さずに原因を特定した: 単体では 12/12 通り、パッケージ全体でだけ出るので「フレーク」に見えるが、実際は土台の配りに依存した決定性バグ。