### PR TITLE
test(guard): check Discover wording and survey definitions, not just presence

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -121,7 +121,7 @@ bun run build && bun run check && bun run test
 
 ## Guard scripts (`scripts/check-*.mjs`)
 
-`bun run check` is Biome plus sixteen guard scripts, each pinning down an invariant that no
+`bun run check` is Biome plus seventeen guard scripts, each pinning down an invariant that no
 type or test covers (design tokens, discover blurbs, message codes, hint coverage, markdown
 tables, mermaid diagrams, design-doc identifiers, dependency licences, trademark terms,
 asset provenance, …).

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,7 @@
     "lint": "biome lint .",
     "lint:tokens": "bun scripts/check-design-tokens.mjs",
     "format": "biome format --write .",
-    "check": "biome check . && bun scripts/check-guard-floors.mjs && bun scripts/check-design-tokens.mjs && bun scripts/check-modal-focus-trap.mjs && bun scripts/check-discover-blurbs.mjs && bun scripts/check-message-codes.mjs && bun scripts/check-move-zone-fields.mjs && bun scripts/check-hint-coverage.mjs && bun scripts/check-hint-reasons.mjs && bun scripts/check-markdown-tables.mjs && bun scripts/check-hint-gate.mjs && bun scripts/check-dependency-licenses.mjs && bun scripts/check-trademark-terms.mjs && bun scripts/check-asset-provenance.mjs && bun scripts/check-codecov-uploads.mjs && bun scripts/check-mermaid.mjs && bun scripts/check-design-doc-identifiers.mjs",
+    "check": "biome check . && bun scripts/check-guard-floors.mjs && bun scripts/check-design-tokens.mjs && bun scripts/check-modal-focus-trap.mjs && bun scripts/check-discover-blurbs.mjs && bun scripts/check-discover-axes.mjs && bun scripts/check-message-codes.mjs && bun scripts/check-move-zone-fields.mjs && bun scripts/check-hint-coverage.mjs && bun scripts/check-hint-reasons.mjs && bun scripts/check-markdown-tables.mjs && bun scripts/check-hint-gate.mjs && bun scripts/check-dependency-licenses.mjs && bun scripts/check-trademark-terms.mjs && bun scripts/check-asset-provenance.mjs && bun scripts/check-codecov-uploads.mjs && bun scripts/check-mermaid.mjs && bun scripts/check-design-doc-identifiers.mjs",
     "check:write": "biome check --write .",
     "preview": "vite preview",
     "test": "vitest run",

--- a/frontend/scripts/check-discover-axes.mjs
+++ b/frontend/scripts/check-discover-axes.mjs
@@ -78,7 +78,15 @@ if (!Number.isInteger(profileMax)) {
 
 if (SCANNING_REPO) {
   assertFloor('discover-axes', keys.length, 24, 'axis/question/option i18n keys');
+  // Exact, not the usual two-thirds: the axis set is structural (mood, skill,
+  // social, theme), not a list that grows. Adding a fifth axis still passes;
+  // silently dropping one to three does not, which is the point.
   assertFloor('discover-axes', axisLengths.size, 4, 'axes with a profileLength');
+}
+
+/** Read a dotted path out of a nested locale object. */
+function getPath(obj, dotted) {
+  return dotted.split('.').reduce((o, k) => (o == null ? o : o[k]), obj);
 }
 
 const problems = [];
@@ -91,10 +99,6 @@ for (const lang of ['ja', 'en']) {
     if (!present.has(key)) problems.push(`MISSING KEY   ${lang}/discover.json  ${key}`);
     else if (String(getPath(locale, key)).trim() === '') problems.push(`EMPTY KEY     ${lang}/discover.json  ${key}`);
   }
-}
-
-function getPath(obj, dotted) {
-  return dotted.split('.').reduce((o, k) => (o == null ? o : o[k]), obj);
 }
 
 // 2. every game's profile vector matches its axis length and value range.

--- a/frontend/scripts/check-discover-axes.mjs
+++ b/frontend/scripts/check-discover-axes.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env bun
+// Guard that the Discover survey's axis definitions stay wired to the locale
+// files and to every game's profile vector.
+//
+// Usage: check-discover-axes.mjs [srcDir]
+//
+// check-discover-blurbs.mjs covers the per-game prose. The survey *around* that
+// prose is defined as data in `constants/discoverAxes.ts` -- axis labels,
+// sub-question prompts and option labels are all `i18nKey` strings resolved at
+// render time -- and nothing checked them.
+//
+// Two failure modes, both silent:
+//
+//   1. A new axis or option ships without translations. i18next returns the
+//      key's last segment on a miss, so the radio renders as "lively" or the
+//      heading as "label". It looks like a copy tweak nobody finished, not a
+//      missing translation, and it is invisible to the ja/en parity check
+//      because a key absent from *both* locales is symmetric.
+//   2. A game's profile vector drifts from its axis length. `GameProfile`
+//      types mood/skill as fixed 4-tuples so tsc catches those, but the tuple
+//      lengths live in gameRoutes.ts while `profileLength` lives in
+//      discoverAxes.ts -- nothing ties the two files together, and nothing
+//      constrains the *values*. An out-of-range score does not crash; it
+//      quietly skews every recommendation that reads that slot.
+//
+// Both are cheap to assert and neither is observable from a rendered page.
+
+import { readFile } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { assertFloor } from './lib/floor.mjs';
+
+const FRONTEND = fileURLToPath(new URL('..', import.meta.url));
+const SRC = process.argv[2] ? resolve(process.argv[2]) : join(FRONTEND, 'src');
+const SCANNING_REPO = !process.argv[2];
+
+const AXES_FILE = join(SRC, 'constants/discoverAxes.ts');
+const ROUTES_FILE = join(SRC, 'constants/gameRoutes.ts');
+const LOCALES = join(SRC, 'i18n/locales');
+
+/** Every `…I18nKey: '…'` in the axis definitions. */
+const I18N_KEY = /(?:i18nKey|labelI18nKey|questionI18nKey):\s*'([^']+)'/g;
+/** `mood: { … profileLength: 4` — the axis name and its vector length. */
+const AXIS_LENGTH = /^ {2}(\w+):\s*\{[\s\S]*?profileLength:\s*(\d+)/gm;
+/** `PROFILE_MAX = 5` */
+const PROFILE_MAX_RE = /PROFILE_MAX\s*(?::\s*number)?\s*=\s*(\d+)/;
+/**
+ * A route's `page` and its `profile` object. The profile is written on one
+ * line, so the body is matched non-greedily up to the closing brace rather
+ * than to an indented one; `[\s\S]*?` between them stays inside the entry
+ * because `page` is the last field before `profile`.
+ */
+const ROUTE_ENTRY = /page:\s*'([A-Za-z0-9]+)',\s*\n\s*profile:\s*\{([^}]*)\}/g;
+/** `mood: [4, 1, 3, 2]` inside a profile block. */
+const AXIS_VECTOR = /(\w+):\s*\[([^\]]*)\]/g;
+
+/** Flatten a nested locale object to dotted leaf paths. */
+function leafKeys(obj, prefix = '', out = new Set()) {
+  for (const [k, v] of Object.entries(obj)) {
+    const path = prefix ? `${prefix}.${k}` : k;
+    if (v && typeof v === 'object' && !Array.isArray(v)) leafKeys(v, path, out);
+    else out.add(path);
+  }
+  return out;
+}
+
+const axesSrc = await readFile(AXES_FILE, 'utf8');
+const routesSrc = await readFile(ROUTES_FILE, 'utf8');
+
+const keys = [...axesSrc.matchAll(I18N_KEY)].map((m) => m[1]);
+const axisLengths = new Map([...axesSrc.matchAll(AXIS_LENGTH)].map((m) => [m[1], Number(m[2])]));
+const profileMax = Number(PROFILE_MAX_RE.exec(axesSrc)?.[1]);
+
+if (!Number.isInteger(profileMax)) {
+  console.error('discover-axes: PROFILE_MAX not found in discoverAxes.ts -- the declaration changed.');
+  process.exit(1);
+}
+
+if (SCANNING_REPO) {
+  assertFloor('discover-axes', keys.length, 24, 'axis/question/option i18n keys');
+  assertFloor('discover-axes', axisLengths.size, 4, 'axes with a profileLength');
+}
+
+const problems = [];
+
+// 1. every data-defined key resolves, in both locales.
+for (const lang of ['ja', 'en']) {
+  const locale = JSON.parse(await readFile(join(LOCALES, lang, 'discover.json'), 'utf8'));
+  const present = leafKeys(locale);
+  for (const key of keys) {
+    if (!present.has(key)) problems.push(`MISSING KEY   ${lang}/discover.json  ${key}`);
+    else if (String(getPath(locale, key)).trim() === '') problems.push(`EMPTY KEY     ${lang}/discover.json  ${key}`);
+  }
+}
+
+function getPath(obj, dotted) {
+  return dotted.split('.').reduce((o, k) => (o == null ? o : o[k]), obj);
+}
+
+// 2. every game's profile vector matches its axis length and value range.
+let routeCount = 0;
+for (const [, page, block] of routesSrc.matchAll(ROUTE_ENTRY)) {
+  routeCount++;
+  const seen = new Set();
+  for (const [, axis, body] of block.matchAll(AXIS_VECTOR)) {
+    seen.add(axis);
+    const expected = axisLengths.get(axis);
+    if (expected === undefined) {
+      problems.push(`UNKNOWN AXIS  ${page}.profile.${axis}  (no such axis in discoverAxes.ts)`);
+      continue;
+    }
+    const values = [...body.matchAll(/-?\d+/g)].map((m) => Number(m[0]));
+    if (values.length !== expected) {
+      problems.push(`WRONG LENGTH  ${page}.profile.${axis}  has ${values.length}, profileLength is ${expected}`);
+    }
+    for (const v of values) {
+      if (v < 0 || v > profileMax) {
+        problems.push(`OUT OF RANGE  ${page}.profile.${axis}  ${v} not in 0..${profileMax}`);
+      }
+    }
+  }
+  for (const axis of axisLengths.keys()) {
+    if (!seen.has(axis)) problems.push(`MISSING AXIS  ${page}.profile.${axis}`);
+  }
+}
+
+if (SCANNING_REPO) assertFloor('discover-axes', routeCount, 200, 'game profiles in gameRoutes.ts');
+
+if (problems.length > 0) {
+  console.error('\ndiscover-axes: survey definitions are out of step.\n');
+  for (const p of problems) console.error(`  ${p}`);
+  console.error(
+    '\nA missing key renders as its own last segment (i18next falls back rather than\n' +
+      'throwing), and a bad profile slot silently skews recommendations. Neither is\n' +
+      'visible from the page.\n',
+  );
+  process.exit(1);
+}
+
+console.log(
+  `discover-axes: OK (${keys.length} survey i18n keys resolve in ja + en; ` +
+    `${routeCount} profiles match ${axisLengths.size} axis lengths, values within 0..${profileMax}).`,
+);

--- a/frontend/scripts/check-discover-axes.test.mjs
+++ b/frontend/scripts/check-discover-axes.test.mjs
@@ -1,0 +1,161 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, describe, expect, it } from 'vitest';
+
+// Same resolution note as check-design-doc-identifiers.test.mjs: vitest serves
+// test modules under a non-file URL, so resolve the guard from cwd (the vitest
+// root is `frontend/`) and assert it is there -- otherwise every case below
+// silently becomes a spawn of a missing file.
+const GUARD = join(process.cwd(), 'scripts', 'check-discover-axes.mjs');
+if (!existsSync(GUARD)) throw new Error(`guard not found at ${GUARD} (cwd: ${process.cwd()})`);
+
+const dirs = [];
+afterAll(() => {
+  for (const d of dirs) rmSync(d, { recursive: true, force: true });
+});
+
+const AXES = `
+export const PROFILE_MAX = 5;
+export const AXES = {
+  mood: {
+    labelI18nKey: 'axis.mood.label',
+    profileLength: 2,
+    questions: [
+      {
+        questionI18nKey: 'axis.mood.q1',
+        options: [
+          { key: 'calm', i18nKey: 'option.mood.calm', profileIdx: 0 },
+          { key: 'lively', i18nKey: 'option.mood.lively', profileIdx: 1 },
+        ],
+      },
+    ],
+  },
+};
+`;
+
+/** A locale object covering every key the fixture axes declare. */
+function fullLocale() {
+  return {
+    axis: { mood: { label: '雰囲気', q1: 'どんな気分？' } },
+    option: { mood: { calm: '静か', lively: 'にぎやか' } },
+  };
+}
+
+function routes(profiles) {
+  const entries = profiles
+    .map(
+      ([page, body]) => `      {
+        path: '/${page.toLowerCase()}',
+        page: '${page}',
+        profile: { ${body} },
+      },`,
+    )
+    .join('\n');
+  return `export const GAME_ROUTES = [\n  {\n    routes: [\n${entries}\n    ],\n  },\n];\n`;
+}
+
+function fixture({ axes = AXES, ja = fullLocale(), en = fullLocale(), profiles = [['BlackJack', 'mood: [3, 2]']] }) {
+  const dir = mkdtempSync(join(tmpdir(), 'discover-axes-'));
+  dirs.push(dir);
+  const src = join(dir, 'src');
+  mkdirSync(join(src, 'constants'), { recursive: true });
+  mkdirSync(join(src, 'i18n/locales/ja'), { recursive: true });
+  mkdirSync(join(src, 'i18n/locales/en'), { recursive: true });
+  writeFileSync(join(src, 'constants/discoverAxes.ts'), axes);
+  writeFileSync(join(src, 'constants/gameRoutes.ts'), routes(profiles));
+  writeFileSync(join(src, 'i18n/locales/ja/discover.json'), JSON.stringify(ja));
+  writeFileSync(join(src, 'i18n/locales/en/discover.json'), JSON.stringify(en));
+  return src;
+}
+
+function check(src) {
+  const r = spawnSync(process.execPath, [GUARD, src], { encoding: 'utf8', cwd: process.cwd() });
+  return { code: r.status, out: `${r.stdout}${r.stderr}` };
+}
+
+describe('check-discover-axes', () => {
+  // Positive control first. Every case below asserts the guard *fires*; without
+  // this one, a guard that always failed would look equally healthy.
+  it('accepts definitions whose keys resolve and whose profiles fit', () => {
+    const r = check(fixture({}));
+    expect(r.code).toBe(0);
+    expect(r.out).toContain('discover-axes: OK');
+  });
+
+  it('rejects an option key missing from ja', () => {
+    const ja = fullLocale();
+    delete ja.option.mood.lively;
+    const r = check(fixture({ ja }));
+    expect(r.code).toBe(1);
+    expect(r.out).toContain('option.mood.lively');
+  });
+
+  it('rejects an axis label missing from en only', () => {
+    const en = fullLocale();
+    delete en.axis.mood.label;
+    const r = check(fixture({ en }));
+    expect(r.code).toBe(1);
+    expect(r.out).toContain('axis.mood.label');
+  });
+
+  it('rejects an empty translation, which renders as blank rather than as a miss', () => {
+    const ja = fullLocale();
+    ja.option.mood.calm = '   ';
+    const r = check(fixture({ ja }));
+    expect(r.code).toBe(1);
+    expect(r.out).toContain('EMPTY KEY');
+  });
+
+  it('rejects a profile vector shorter than profileLength', () => {
+    const r = check(fixture({ profiles: [['BlackJack', 'mood: [3]']] }));
+    expect(r.code).toBe(1);
+    expect(r.out).toContain('WRONG LENGTH');
+  });
+
+  it('rejects a profile value above PROFILE_MAX', () => {
+    const r = check(fixture({ profiles: [['BlackJack', 'mood: [3, 9]']] }));
+    expect(r.code).toBe(1);
+    expect(r.out).toContain('OUT OF RANGE');
+  });
+
+  it('rejects a negative profile value', () => {
+    const r = check(fixture({ profiles: [['BlackJack', 'mood: [3, -1]']] }));
+    expect(r.code).toBe(1);
+    expect(r.out).toContain('OUT OF RANGE');
+  });
+
+  it('rejects a game missing an axis entirely', () => {
+    const r = check(fixture({ profiles: [['BlackJack', 'theme: [1, 1]']] }));
+    expect(r.code).toBe(1);
+    expect(r.out).toContain('MISSING AXIS');
+  });
+
+  it('rejects an axis that discoverAxes.ts does not define', () => {
+    const r = check(fixture({ profiles: [['BlackJack', 'mood: [3, 2], vibes: [1]']] }));
+    expect(r.code).toBe(1);
+    expect(r.out).toContain('UNKNOWN AXIS');
+  });
+
+  it('reports every offending game, not just the first', () => {
+    const r = check(
+      fixture({
+        profiles: [
+          ['BlackJack', 'mood: [3]'],
+          ['Poker', 'mood: [9, 9]'],
+        ],
+      }),
+    );
+    expect(r.code).toBe(1);
+    expect(r.out).toContain('BlackJack');
+    expect(r.out).toContain('Poker');
+  });
+
+  it('fails loudly when PROFILE_MAX cannot be found', () => {
+    // A guard that cannot parse its own inputs must say so rather than pass.
+    const r = check(fixture({ axes: AXES.replace('export const PROFILE_MAX = 5;', '') }));
+    expect(r.code).toBe(1);
+    expect(r.out).toContain('PROFILE_MAX');
+  });
+});

--- a/frontend/scripts/check-discover-blurbs.mjs
+++ b/frontend/scripts/check-discover-blurbs.mjs
@@ -15,16 +15,28 @@
 //
 // This is a *vertical* check, route table to locale, matching
 // check-message-codes.mjs.
+//
+// Presence is necessary but not sufficient, so the text itself is checked too.
+// The realistic way a blurb goes wrong is not deletion but **copy-paste**: a new
+// game is added by duplicating a neighbouring entry and the prose is never
+// rewritten, so two unrelated games carry the same description. That renders
+// perfectly, reads plausibly, and is wrong -- no presence check can see it.
+// The same applies to a ja entry pasted into en, which looks translated until
+// you read it.
 
 import { readFile } from 'node:fs/promises';
-import { join, relative } from 'node:path';
+import { join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { assertFloor } from './lib/floor.mjs';
 
 const FRONTEND = fileURLToPath(new URL('..', import.meta.url));
 const REPO = join(FRONTEND, '..');
-const ROUTES = join(FRONTEND, 'src/constants/gameRoutes.ts');
-const LOCALES = join(FRONTEND, 'src/i18n/locales');
+// An optional srcDir lets the self-test point the guard at a fixture tree.
+// Without it the floors below would have to be met by a two-game fixture.
+const SRC = process.argv[2] ? resolve(process.argv[2]) : join(FRONTEND, 'src');
+const SCANNING_REPO = !process.argv[2];
+const ROUTES = join(SRC, 'constants/gameRoutes.ts');
+const LOCALES = join(SRC, 'i18n/locales');
 const SECTIONS = ['blurb', 'stretch_blurb'];
 
 /**
@@ -47,10 +59,12 @@ const games = await registeredGames();
 // 264 games are registered today. A regex that has drifted usually still matches *some*
 // entries, so `> 0` is not the interesting boundary -- checking 12 games and declaring all
 // blurbs present is the failure this floor exists to catch.
-assertFloor('discover-blurbs', games.size, 200, `game pages in ${relative(REPO, ROUTES)}`);
+if (SCANNING_REPO) assertFloor('discover-blurbs', games.size, 200, `game pages in ${relative(REPO, ROUTES)}`);
 
 const gaps = [];
 const empties = [];
+/** lang -> section -> game -> text, for the wording checks below. */
+const text = { ja: {}, en: {} };
 for (const lang of ['ja', 'en']) {
   const file = join(LOCALES, lang, 'discover.json');
   const data = JSON.parse(await readFile(file, 'utf8'));
@@ -60,9 +74,11 @@ for (const lang of ['ja', 'en']) {
       console.error(`discover-blurbs: ${lang}/discover.json has no "${section}" section.`);
       process.exit(1);
     }
+    text[lang][section] = {};
     for (const game of games) {
       if (!(game in map)) gaps.push({ lang, section, game });
       else if (String(map[game]).trim() === '') empties.push({ lang, section, game });
+      else text[lang][section][game] = String(map[game]).trim();
     }
     // A key with no matching route is dead weight and usually a rename.
     for (const key of Object.keys(map)) {
@@ -89,4 +105,65 @@ if (gaps.length > 0 || empties.length > 0) {
   process.exit(1);
 }
 
-console.log(`discover-blurbs: OK (all ${games.size} games have ja + en blurb and stretch_blurb).`);
+// --- wording checks -------------------------------------------------------
+//
+// Only run once presence is established, so a missing blurb is reported as
+// missing rather than as a wording fault.
+
+/** Placeholder text that should never ship. */
+const PLACEHOLDER = /\b(TODO|FIXME|WIP|Lorem ipsum|xxx)\b/i;
+/**
+ * Shortest believable blurb. The real ones run far longer; this only has to
+ * catch a stub such as "準備中" or "TBD" that survived review.
+ */
+const MIN_CHARS = 8;
+
+const wording = [];
+for (const section of SECTIONS) {
+  for (const lang of ['ja', 'en']) {
+    const entries = Object.entries(text[lang][section]);
+
+    // Two games sharing one description -- the copy-paste failure.
+    const byText = new Map();
+    for (const [game, body] of entries) {
+      const seen = byText.get(body);
+      if (seen) wording.push({ kind: 'DUPLICATE', lang, section, game, other: seen, body });
+      else byText.set(body, game);
+    }
+
+    for (const [game, body] of entries) {
+      if (PLACEHOLDER.test(body)) wording.push({ kind: 'PLACEHOLDER', lang, section, game, body });
+      else if ([...body].length < MIN_CHARS) wording.push({ kind: 'TOO SHORT', lang, section, game, body });
+    }
+  }
+
+  // A ja entry pasted verbatim into en (or the reverse) is untranslated. Games
+  // whose blurb is legitimately identical in both languages do not exist here:
+  // every one is prose, not a bare proper noun.
+  for (const game of Object.keys(text.ja[section])) {
+    const ja = text.ja[section][game];
+    const en = text.en[section][game];
+    if (en !== undefined && ja === en) {
+      wording.push({ kind: 'UNTRANSLATED', lang: 'ja=en', section, game, body: ja });
+    }
+  }
+}
+
+if (wording.length > 0) {
+  console.error('\nDiscover blurb wording problems:\n');
+  for (const w of wording) {
+    const where = `${w.lang}/discover.json  ${w.section}.${w.game}`;
+    const detail = w.kind === 'DUPLICATE' ? `  (identical to ${w.section}.${w.other})` : '';
+    console.error(`  ${w.kind.padEnd(12)} ${where}${detail}\n${' '.repeat(16)}"${w.body.slice(0, 70)}"`);
+  }
+  console.error(
+    `\n${wording.length} problem(s). A duplicated or untranslated blurb renders perfectly` +
+      ' and reads plausibly, so nothing else in the pipeline will catch it.',
+  );
+  process.exit(1);
+}
+
+console.log(
+  `discover-blurbs: OK (all ${games.size} games have ja + en blurb and stretch_blurb;` +
+    ` ${games.size * SECTIONS.length * 2} entries checked for duplicates, placeholders and untranslated text).`,
+);

--- a/frontend/scripts/check-discover-blurbs.test.mjs
+++ b/frontend/scripts/check-discover-blurbs.test.mjs
@@ -1,0 +1,128 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, describe, expect, it } from 'vitest';
+
+const GUARD = join(process.cwd(), 'scripts', 'check-discover-blurbs.mjs');
+if (!existsSync(GUARD)) throw new Error(`guard not found at ${GUARD} (cwd: ${process.cwd()})`);
+
+const dirs = [];
+afterAll(() => {
+  for (const d of dirs) rmSync(d, { recursive: true, force: true });
+});
+
+function routes(pages) {
+  const entries = pages
+    .map(
+      (page) => `      {
+        path: '/${page.toLowerCase()}',
+        page: '${page}',
+      },`,
+    )
+    .join('\n');
+  return `export const GAME_ROUTES = [\n  {\n    routes: [\n${entries}\n    ],\n  },\n];\n`;
+}
+
+/** ja/en blurb maps that are complete and distinct — the healthy baseline. */
+function locales() {
+  return {
+    ja: {
+      blurb: { blackjack: '手札を21に近づける定番のゲーム。', poker: '役の強さを競うカードゲーム。' },
+      stretch_blurb: { blackjack: '基本戦略を覚えると勝率が上がる。', poker: 'ブラフの読み合いが醍醐味。' },
+    },
+    en: {
+      blurb: { blackjack: 'Get as close to 21 as you dare.', poker: 'Bet on the strength of your hand.' },
+      stretch_blurb: { blackjack: 'Basic strategy sharpens your edge.', poker: 'Reading a bluff is the real game.' },
+    },
+  };
+}
+
+function fixture({ pages = ['BlackJack', 'Poker'], ja, en } = {}) {
+  const base = locales();
+  const dir = mkdtempSync(join(tmpdir(), 'discover-blurbs-'));
+  dirs.push(dir);
+  const src = join(dir, 'src');
+  mkdirSync(join(src, 'constants'), { recursive: true });
+  mkdirSync(join(src, 'i18n/locales/ja'), { recursive: true });
+  mkdirSync(join(src, 'i18n/locales/en'), { recursive: true });
+  writeFileSync(join(src, 'constants/gameRoutes.ts'), routes(pages));
+  writeFileSync(join(src, 'i18n/locales/ja/discover.json'), JSON.stringify(ja ?? base.ja));
+  writeFileSync(join(src, 'i18n/locales/en/discover.json'), JSON.stringify(en ?? base.en));
+  return src;
+}
+
+function check(src) {
+  const r = spawnSync(process.execPath, [GUARD, src], { encoding: 'utf8', cwd: process.cwd() });
+  return { code: r.status, out: `${r.stdout}${r.stderr}` };
+}
+
+describe('check-discover-blurbs', () => {
+  // Positive control. The wording rules below are heuristics, so the case that
+  // matters most is the one where correct prose stays quiet.
+  it('accepts complete, distinct, translated blurbs', () => {
+    const r = check(fixture());
+    expect(r.code).toBe(0);
+    expect(r.out).toContain('discover-blurbs: OK');
+  });
+
+  it('rejects a game with no blurb', () => {
+    const { ja, en } = locales();
+    delete ja.blurb.poker;
+    const r = check(fixture({ ja, en }));
+    expect(r.code).toBe(1);
+    expect(r.out).toContain('MISSING');
+  });
+
+  // The wording checks. Each of these renders perfectly on the page.
+  it('rejects two games sharing one blurb', () => {
+    const { ja, en } = locales();
+    ja.blurb.poker = ja.blurb.blackjack;
+    const r = check(fixture({ ja, en }));
+    expect(r.code).toBe(1);
+    expect(r.out).toContain('DUPLICATE');
+    expect(r.out).toContain('poker');
+  });
+
+  it('rejects an en entry left identical to ja', () => {
+    const { ja, en } = locales();
+    en.blurb.poker = ja.blurb.poker;
+    const r = check(fixture({ ja, en }));
+    expect(r.code).toBe(1);
+    expect(r.out).toContain('UNTRANSLATED');
+  });
+
+  it('rejects placeholder text', () => {
+    const { ja, en } = locales();
+    ja.blurb.poker = 'TODO あとで書く';
+    const r = check(fixture({ ja, en }));
+    expect(r.code).toBe(1);
+    expect(r.out).toContain('PLACEHOLDER');
+  });
+
+  it('rejects a stub too short to be a description', () => {
+    const { ja, en } = locales();
+    ja.blurb.poker = '準備中';
+    const r = check(fixture({ ja, en }));
+    expect(r.code).toBe(1);
+    expect(r.out).toContain('TOO SHORT');
+  });
+
+  it('checks stretch_blurb as well as blurb', () => {
+    const { ja, en } = locales();
+    ja.stretch_blurb.poker = ja.stretch_blurb.blackjack;
+    const r = check(fixture({ ja, en }));
+    expect(r.code).toBe(1);
+    expect(r.out).toContain('stretch_blurb');
+  });
+
+  it('does not confuse a duplicate across sections with a duplicate within one', () => {
+    // The same sentence used once as a blurb and once as a stretch_blurb is
+    // odd but not the failure being hunted; only collisions inside a single
+    // section mean two games share a description.
+    const { ja, en } = locales();
+    ja.stretch_blurb.blackjack = ja.blurb.blackjack;
+    const r = check(fixture({ ja, en }));
+    expect(r.code).toBe(0);
+  });
+});


### PR DESCRIPTION
discover は**現状どこも壊れていない** —— blurb 318/318、重複 0、未翻訳 0、プレースホルダ 0、profile 違反 0、`t()` キー欠落 0。実測してから書いているので、これは修正ではなく**予防**の PR。

押さえるのはいずれも「壊れても画面が正常に見える」種類の不変条件。

## 1. blurb は「在るか」だけ見ていた

`check-discover-blurbs.mjs` は存在と空文字だけを検査していた。現実的な壊れ方は削除ではなく**コピペ**で、新規ゲームを隣の項目を複製して足し、本文を書き換え忘れる。無関係な 2 ゲームが同じ説明を持っても**描画は完璧で、文章としても成立している**ので、存在チェックでは原理的に見えない。ja をそのまま en に貼った場合も同様で、読むまで翻訳済みに見える。

| 追加した検査 | 何を捕まえるか |
|---|---|
| `DUPLICATE` | 同一セクション内で本文が重複（＝2ゲームが同じ説明） |
| `UNTRANSLATED` | ja と en が同一 |
| `PLACEHOLDER` | `TODO` / `FIXME` / `WIP` / `Lorem ipsum` / `xxx` |
| `TOO SHORT` | 8 文字未満（「準備中」「TBD」の残存） |

セクションを跨いだ重複（同じ文が blurb と stretch_blurb に出る）は**意図的に検出しない**。狙いは「2 ゲームが同じ説明を持つこと」なので、そこまで広げると誤検出になる。この線引き自体もテストで固定した。

## 2. サーベイ定義は誰も見ていなかった（新規 `check-discover-axes.mjs`）

軸ラベル・小問・選択肢は `constants/discoverAxes.ts` の `i18nKey` として**データ定義**されている。壊れ方が 2 つ、どちらも無言:

**(a) 新しい軸や選択肢を訳無しで足す** —— i18next はキーの最終セグメントを返すので、ラジオが `lively`、見出しが `label` と描画される。訳の欠落ではなく「書きかけのコピー」に見える。そして**両ロケールから同時に欠けるので ja/en パリティ検査は通る**（対称なので）。

**(b) profile ベクタが軸長からずれる** —— `GameProfile` は mood/skill を 4 要素タプルにしているので長さは tsc が見る。ただし**タプル長は `gameRoutes.ts`、`profileLength` は `discoverAxes.ts`** にあり、両者を結ぶものが何も無い。値の範囲も型では縛れない。範囲外の点数は落ちずに**推薦結果だけを静かに歪める**。

32 キー × ja/en と、318 ゲーム × 4 軸（mood 4 / skill 4 / social 5 / theme 6）の長さ・範囲 `0..PROFILE_MAX`・軸の欠落／未知軸を照合する。

## 検査したことの検査

「鳴らないガード」と「通っているガード」は見分けがつかないので、両方向を固定した。

- **自己テスト 19 件**（`check-discover-axes.test.mjs` 11 / `check-discover-blurbs.test.mjs` 8）。正のコントロール（正しいデータで沈黙する）を各ファイルの先頭に置き、以降で各故障モードを 1 件ずつ
- **実データへの故障注入**でも実測: blurb 4 種・axes 4 種すべて exit 1 を確認し、注入後にロケールと `gameRoutes.ts` が**バイト単位で復元**されていることを `git diff --numstat` が空であることで確認
- `check-discover-blurbs.mjs` に `[srcDir]` 引数を足した。これが無いと fixture を食わせられず、新しい wording 検査を CI で検証できないため（floor は実リポジトリ走査時のみ）

> 執筆中に **floor が自分の壊れた正規表現を検出した**。`profile` を複数行ブロックだと誤認していて、0 件走査のまま「違反なし」を報告しかけた。`assertFloor` が無ければ、何も見ていないガードが緑で入っていた。

## 検証

- `cd frontend && bun run check` 全緑。`guard-floors` は 15→**16 スクリプト / 28→31 floor** を自動追随
- `bunx vitest run scripts/check-discover-{axes,blurbs}.test.mjs` 19 passed
- `bunx biome check` 新規 4 ファイル clean
- `frontend/CLAUDE.md` のガード本数を sixteen → **seventeen** に更新

## テスト計画

- [x] 正のコントロール（正しい discover データで両ガードが沈黙）
- [x] 負のコントロール（8 故障モードを注入して exit 1）
- [x] 実データ注入 → 復元がバイト一致
- [ ] CI 全緑を確認