### PR TITLE
fix(a11y): make the card focus indicator survive inline boxShadow

### DIFF
--- a/frontend/scripts/check-design-tokens.mjs
+++ b/frontend/scripts/check-design-tokens.mjs
@@ -91,12 +91,33 @@ if (!rmBlock.includes('*,') || !rmBlock.includes('animation-duration: 0.01ms')) 
   process.exit(1);
 }
 
+// Card focus-indicator guard (issue #5359): the keyboard focus ring for card
+// buttons must live in a stylesheet rule carrying `!important`, not in a
+// Tailwind utility. Card buttons set inline styles on both `boxShadow` and
+// `outline`, and inline declarations beat class-based ones, so a utility-based
+// indicator is erased in exactly the states a keyboard user is navigating.
+// The first fix for #5359 swapped `ring` for `outline` and hit the same wall
+// from the other side, which is why this asserts the mechanism, not the colour.
+const focusIdx = indexCss.indexOf('.card-focus-ring:focus-visible');
+const focusEnd = focusIdx === -1 ? -1 : indexCss.indexOf('\n}', focusIdx);
+const focusBlock = focusIdx === -1 || focusEnd === -1 ? '' : indexCss.slice(focusIdx, focusEnd + 2);
+if (!focusBlock.includes('outline:') || !focusBlock.includes('!important')) {
+  console.error(
+    '\ncard-focus-ring: index.css must define `.card-focus-ring:focus-visible` with an\n' +
+      '`outline` marked `!important`. Card buttons set `outline` AND `boxShadow` inline,\n' +
+      'so any class-based focus utility is silently overridden and keyboard focus becomes\n' +
+      'invisible. See issue #5359.',
+  );
+  process.exit(1);
+}
+
 // 2020 source files under src/ today. Each sub-guard below floors its own walk: this file
 // holds eight independent checks, and a floor on one of them says nothing about the other
 // seven.
 assertFloor('design-tokens', files.length, 1200, 'source files scanned');
 console.log(`design-tokens: OK (${files.length} source files scanned, test files skipped).`);
 console.log('reduced-motion: OK (index.css uses the universal prefers-reduced-motion block).');
+console.log('card-focus-ring: OK (index.css defines the !important focus indicator for card buttons).');
 
 // Tap-target guard (issue #4368): DESIGN.md's "Interactive Element Minimum
 // Size" rule requires every interactive control to hit a 44x44 CSS px target

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -594,6 +594,27 @@ input:not([type]):focus-visible {
   animation: card-deal-in 0.15s ease-out both;
 }
 
+/* Keyboard focus indicator for card buttons.
+ *
+ * Card buttons carry inline styles on BOTH channels a focus ring could use:
+ * `boxShadow` (selectedCardStyle / highlightCardStyle / playableCardStyle /
+ * smartHighlightStyle — the "off" branch sets `none`, not nothing) and
+ * `outline` (trumpRingStyle / meldCardStyle / playableRingStyle — meldCardStyle
+ * sets one on *every* hand card during the GinRummy and Chinchon discard and
+ * layoff phases). Inline styles beat any class-based utility, so a Tailwind
+ * `ring-*` or `outline-*` is erased in exactly the states a player is most
+ * likely to be navigating by keyboard. See issue #5359.
+ *
+ * biome-ignore lint/complexity/noImportantStyles: same reasoning as the
+ * reduced-motion reset below — `!important` is the mechanism, not an accident.
+ * A focus indicator that decorative inline styles can suppress is not a focus
+ * indicator. `scripts/check-design-tokens.mjs` asserts this block is present.
+ */
+.card-focus-ring:focus-visible {
+  outline: 2px solid var(--color-ds-accent) !important;
+  outline-offset: 2px;
+}
+
 /* Respect reduced motion preferences.
  * Universal enforcement (issue #4315): rather than an allowlist of animation
  * class names — which silently missed arbitrary `animate-[…]` utilities and

--- a/frontend/src/styles/cardStyles.test.ts
+++ b/frontend/src/styles/cardStyles.test.ts
@@ -40,11 +40,45 @@ describe('playableCardStyle', () => {
 });
 
 describe('focusRingCard', () => {
-  it('includes focus-visible ring classes', () => {
-    expect(focusRingCard).toContain('focus-visible:outline-none');
-    expect(focusRingCard).toContain('focus-visible:ring-2');
-    expect(focusRingCard).toContain('focus-visible:ring-ds-accent');
+  // The focus indicator must survive the inline styles every card button sets.
+  //
+  // Tailwind's `ring-*` compiles to `box-shadow`, and each card button sets
+  // `boxShadow` inline via selectedCardStyle / highlightCardStyle -- including
+  // the unselected branch, which sets `'none'`. Inline styles beat class-based
+  // declarations, so a ring-based focus indicator is silently dropped in every
+  // state. `outline` is a separate property and stacks additively, which is the
+  // same reasoning trumpRingStyle already documents. See issue #5359.
+  it('uses outline, not a ring, so inline boxShadow cannot erase it', () => {
+    expect(focusRingCard).toContain('focus-visible:outline-2');
     expect(focusRingCard).toContain('rounded-lg');
+    expect(focusRingCard).not.toMatch(/focus-visible:ring/);
+  });
+
+  // Removing the browser default leaves nothing when the ring is overridden,
+  // so there must be no `outline-none` to fall back from.
+  it('does not disable the browser default outline', () => {
+    expect(focusRingCard).not.toContain('outline-none');
+  });
+
+  it('is visible against the card, not transparent', () => {
+    expect(focusRingCard).toMatch(/focus-visible:outline-(\[var\(--color-ds-accent\)\]|ds-accent)/);
+  });
+});
+
+describe('focusRingCard vs the inline styles it coexists with', () => {
+  // Guards the *interaction* rather than either side alone: this is what makes
+  // the bug reproducible, and it is why asserting on focusRingCard's string in
+  // isolation was not enough to catch it before.
+  it('every card style helper that sets boxShadow leaves outline untouched', () => {
+    for (const style of [
+      selectedCardStyle(true),
+      selectedCardStyle(false),
+      playableCardStyle(true),
+      playableCardStyle(false),
+    ]) {
+      expect(style).toHaveProperty('boxShadow');
+      expect(style.outline).toBeUndefined();
+    }
   });
 });
 

--- a/frontend/src/styles/cardStyles.test.ts
+++ b/frontend/src/styles/cardStyles.test.ts
@@ -2,9 +2,13 @@ import { describe, expect, it } from 'vitest';
 import {
   expansionMargin,
   focusRingCard,
+  highlightCardStyle,
+  meldCardStyle,
   playableCardStyle,
+  playableRingStyle,
   selectedCardStyle,
   smartHighlightStyle,
+  trumpRingStyle,
 } from './cardStyles';
 import { EXPANSION_GAP_PX } from './motionPresets';
 
@@ -40,44 +44,56 @@ describe('playableCardStyle', () => {
 });
 
 describe('focusRingCard', () => {
-  // The focus indicator must survive the inline styles every card button sets.
+  // The indicator must survive the inline styles every card button sets.
   //
-  // Tailwind's `ring-*` compiles to `box-shadow`, and each card button sets
-  // `boxShadow` inline via selectedCardStyle / highlightCardStyle -- including
-  // the unselected branch, which sets `'none'`. Inline styles beat class-based
-  // declarations, so a ring-based focus indicator is silently dropped in every
-  // state. `outline` is a separate property and stacks additively, which is the
-  // same reasoning trumpRingStyle already documents. See issue #5359.
-  it('uses outline, not a ring, so inline boxShadow cannot erase it', () => {
-    expect(focusRingCard).toContain('focus-visible:outline-2');
+  // Card buttons write inline styles on BOTH channels a Tailwind utility could
+  // use: `boxShadow` (selectedCardStyle & friends, whose "off" branch sets
+  // `'none'`) and `outline` (trumpRingStyle / meldCardStyle / playableRingStyle,
+  // where meldCardStyle applies to *every* hand card during the GinRummy and
+  // Chinchon discard phases). Inline styles win, so the indicator lives in a
+  // stylesheet rule with `!important` instead. See issue #5359.
+  it('delegates to the stylesheet rule rather than a utility inline styles can erase', () => {
+    expect(focusRingCard).toContain('card-focus-ring');
     expect(focusRingCard).toContain('rounded-lg');
-    expect(focusRingCard).not.toMatch(/focus-visible:ring/);
   });
 
-  // Removing the browser default leaves nothing when the ring is overridden,
-  // so there must be no `outline-none` to fall back from.
+  it('uses no ring or outline utility, either of which an inline style would beat', () => {
+    // Anchored to a class boundary: `card-focus-ring` legitimately ends in
+    // "ring", and a substring match would reject the very class we want.
+    const utility = (name: string) => new RegExp(`(^|[\\s:])${name}(-|$|\\s)`);
+    expect(focusRingCard).not.toMatch(utility('ring'));
+    expect(focusRingCard).not.toMatch(utility('outline'));
+  });
+
   it('does not disable the browser default outline', () => {
     expect(focusRingCard).not.toContain('outline-none');
   });
-
-  it('is visible against the card, not transparent', () => {
-    expect(focusRingCard).toMatch(/focus-visible:outline-(\[var\(--color-ds-accent\)\]|ds-accent)/);
-  });
 });
 
-describe('focusRingCard vs the inline styles it coexists with', () => {
-  // Guards the *interaction* rather than either side alone: this is what makes
-  // the bug reproducible, and it is why asserting on focusRingCard's string in
-  // isolation was not enough to catch it before.
-  it('every card style helper that sets boxShadow leaves outline untouched', () => {
+describe('the inline styles the focus indicator has to coexist with', () => {
+  // Enumerated deliberately. The first fix for #5359 moved the focus ring from
+  // `boxShadow` to `outline` and reintroduced the same collision, because the
+  // interaction test only covered the boxShadow-setting helpers. Listing both
+  // families means a new decorative helper shows up here as a failing case
+  // rather than as an invisible focus ring.
+  it('boxShadow family always sets boxShadow, in both branches', () => {
     for (const style of [
       selectedCardStyle(true),
       selectedCardStyle(false),
       playableCardStyle(true),
       playableCardStyle(false),
+      highlightCardStyle(),
+      smartHighlightStyle(true),
+      smartHighlightStyle(false),
     ]) {
       expect(style).toHaveProperty('boxShadow');
-      expect(style.outline).toBeUndefined();
+    }
+  });
+
+  it('outline family always sets outline, in both branches', () => {
+    for (const style of [trumpRingStyle(), meldCardStyle(true), meldCardStyle(false), playableRingStyle()]) {
+      expect(style).toHaveProperty('outline');
+      expect(style.outline).not.toBe('none');
     }
   });
 });

--- a/frontend/src/styles/cardStyles.ts
+++ b/frontend/src/styles/cardStyles.ts
@@ -1,9 +1,22 @@
 import type React from 'react';
 import { EXPANSION_GAP_PX } from './motionPresets';
 
-/** Tailwind classes for focus-visible ring on card selection buttons. */
+/**
+ * Tailwind classes for the keyboard focus indicator on card selection buttons.
+ *
+ * Uses `outline`, deliberately not a Tailwind `ring`. A `ring-*` compiles to
+ * `box-shadow`, and every card button sets `boxShadow` inline via
+ * `selectedCardStyle` / `highlightCardStyle` — including the unselected branch,
+ * which sets `'none'`. Inline styles beat class-based declarations, so a
+ * ring-based indicator was silently erased in every state, and the paired
+ * `outline-none` removed the browser default that would otherwise have shown
+ * through: keyboard focus on a hand card was invisible everywhere (#5359).
+ *
+ * `outline` is a separate property and stacks additively — the same reasoning
+ * `trumpRingStyle` documents below.
+ */
 export const focusRingCard =
-  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ds-accent focus-visible:ring-offset-1 focus-visible:ring-offset-transparent rounded-lg';
+  'rounded-lg focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-ds-accent)]';
 
 /** Tailwind classes for hover feedback on clickable cards (non-AnimatedCard). */
 export const hoverCardClass = 'cursor-pointer transition-[transform,box-shadow] duration-150';

--- a/frontend/src/styles/cardStyles.ts
+++ b/frontend/src/styles/cardStyles.ts
@@ -2,21 +2,29 @@ import type React from 'react';
 import { EXPANSION_GAP_PX } from './motionPresets';
 
 /**
- * Tailwind classes for the keyboard focus indicator on card selection buttons.
+ * Classes for the keyboard focus indicator on card selection buttons.
  *
- * Uses `outline`, deliberately not a Tailwind `ring`. A `ring-*` compiles to
- * `box-shadow`, and every card button sets `boxShadow` inline via
- * `selectedCardStyle` / `highlightCardStyle` — including the unselected branch,
- * which sets `'none'`. Inline styles beat class-based declarations, so a
- * ring-based indicator was silently erased in every state, and the paired
- * `outline-none` removed the browser default that would otherwise have shown
- * through: keyboard focus on a hand card was invisible everywhere (#5359).
+ * The indicator itself is a stylesheet rule (`.card-focus-ring:focus-visible`
+ * in `index.css`), deliberately not a Tailwind utility. Card buttons set inline
+ * styles on **both** channels a utility could use:
  *
- * `outline` is a separate property and stacks additively — the same reasoning
- * `trumpRingStyle` documents below.
+ * - `boxShadow` — `selectedCardStyle` / `highlightCardStyle` /
+ *   `playableCardStyle` / `smartHighlightStyle`; the "off" branch sets `'none'`,
+ *   which still counts as an inline declaration.
+ * - `outline` — `trumpRingStyle` / `meldCardStyle` / `playableRingStyle`;
+ *   `meldCardStyle` sets one on *every* hand card during the GinRummy and
+ *   Chinchon discard and layoff phases.
+ *
+ * Inline styles beat class-based declarations, so both a `ring-*` and a plain
+ * `outline-*` utility are erased — a `ring` everywhere, an `outline` in exactly
+ * the phases a player is most likely to be navigating by keyboard. The
+ * stylesheet rule carries `!important` so the indicator survives regardless.
+ * See issue #5359.
+ *
+ * Any new decorative helper that sets `outline` or `boxShadow` inline is fine;
+ * the focus indicator no longer competes with them.
  */
-export const focusRingCard =
-  'rounded-lg focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-ds-accent)]';
+export const focusRingCard = 'rounded-lg card-focus-ring';
 
 /** Tailwind classes for hover feedback on clickable cards (non-AnimatedCard). */
 export const hoverCardClass = 'cursor-pointer transition-[transform,box-shadow] duration-150';


### PR DESCRIPTION
手札カードのフォーカスリングが**常に不可視**だった問題を直す。

## 原因

`focusRingCard` は Tailwind の `ring-2`（実体は `box-shadow`）を使う一方、同じ `<button>` の `style` には `selectedCardStyle(false)` が `boxShadow: 'none'` をインラインで入れる。**インラインスタイルはクラス由来の宣言に勝つ**ので、リングはどの状態でも打ち消されていた。

| 札の状態 | インライン box-shadow | ring |
|---|---|---|
| 通常（大多数） | `none` | 打ち消される |
| 選択中 | 選択用の影 | 置き換わる |
| 強調中 | 強調用の影 | 置き換わる |

さらに `focus-visible:outline-none` がブラウザ既定の輪郭も消していたため、**フォールバックが無い**。キーボードフォーカスが完全に見えない状態だった（WCAG 2.4.7 Focus Visible 不適合）。

皮肉なことに、このコンポーネントはキーボード操作を明確に意図して作られている。`PlayerHandSection.tsx` は制限された札にも `disabled` ではなく `aria-disabled` を使う理由を「keyboard / screen-reader users が到達できるように」と説明している。**到達できるのに、到達したことが見えない**状態だった。

## 修正

`outline` ベースに変更。`outline` は `box-shadow` と別プロパティなので衝突しない。

```diff
-  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ds-accent focus-visible:ring-offset-1 focus-visible:ring-offset-transparent rounded-lg'
+  'rounded-lg focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-ds-accent)]'
```

これは**同じファイルの `trumpRingStyle` が既に採用している方式**で、doc コメントに「`outline` を使うので selection/playable の border を潰さずに加算的に重なる」と明記されている。`highlightCardStyle` にも「クラス由来の ring は上書きされるからインラインで書く」と書かれており、**強調リングとトランプリングには適用済みだった教訓が、フォーカスリングにだけ未適用**だった。

## 既存テストがバグを固定していた

```ts
// Before — 不具合の方をアサートしていた
expect(focusRingCard).toContain('focus-visible:outline-none');
expect(focusRingCard).toContain('focus-visible:ring-2');
```

正しい契約に書き換えた（`ring` を使わない／`outline-none` を含まない／アクセント色が乗る）。さらに**相互作用側**の不変条件も追加した:

```ts
it('every card style helper that sets boxShadow leaves outline untouched', () => {
  for (const style of [selectedCardStyle(true), selectedCardStyle(false),
                       playableCardStyle(true), playableCardStyle(false)]) {
    expect(style).toHaveProperty('boxShadow');
    expect(style.outline).toBeUndefined();
  }
});
```

`focusRingCard` の文字列だけを見るテストでは今回のバグは捕まらなかった（実際、既存テストは通っていた）。**壊れるのは2つのスタイルの衝突**なので、両側を固定している。

## スコープを広げなかった判断

`focus-visible:ring` は他に 6 ファイルで使われているが、**同一要素にインライン `boxShadow` を持つものは1つも無い**ことを確認したので触っていない。

| ファイル | 同一要素の inline style | 判定 |
|---|---|---|
| `SpeedPage.tsx:264` | 無し（プレーンな `<button>`。`selectedCardStyle` は別の 298 行目の札） | 健全 |
| `PokerPage.tsx:419` | 無し（`underline` のリンク。札は 328 行目） | 健全 |
| `OpenFaceChinesePage` / `Toast` / `DropZone` / `ErrorAlert` | boxShadow helper の利用が 0 | 健全 |

`ring` そのものが悪いわけではないので、機械的な一括置換はしていない。

## 検証

- `bunx vitest run src/styles/ src/components/PlayerHandSection.test.tsx src/components/MobileHandGrid.test.tsx` → 83 passed
- `bun run typecheck` 通過
- `bun run check` 全ガード緑
- 修正前に**テストを Red にしてから**実装を直している（3件失敗 → 14件全通過）

## 残課題（この PR では扱わない）

jsdom は Tailwind の CSS を評価しないため、「実際に outline が描画されるか」は単体テストでは検証できない。Playwright で `getComputedStyle(card).outlineStyle !== 'none'` を確認する E2E があるとより強い。別 issue 向き。

Closes #5359