### PR TITLE
refactor(controller): move test-only exports behind the test build tag

### DIFF
--- a/internal/adapter/controller/ChineseTenWebController.go
+++ b/internal/adapter/controller/ChineseTenWebController.go
@@ -137,9 +137,3 @@ func chineseTenDispatch(bc *baseController, w http.ResponseWriter, ci usecase.Ch
 	}
 	return true
 }
-
-// NewChineseTenDefaultOutputForTest exposes the default-output builder to the
-// external controller_test package.
-func NewChineseTenDefaultOutputForTest(msg string) *ChineseTenWebOutput {
-	return newChineseTenDefaultOutput(msg)
-}

--- a/internal/adapter/controller/ChineseTen_testhelpers.go
+++ b/internal/adapter/controller/ChineseTen_testhelpers.go
@@ -1,0 +1,15 @@
+//go:build test
+
+package controller
+
+// NewChineseTenDefaultOutputForTest exposes the default-output builder to the
+// external controller_test package.
+//
+// Lives behind the `test` tag so it never reaches a shipped binary — the same
+// convention as internal/domain/*_testhelpers.go. The category half of the
+// constraint is copied from ChineseTenWebController.go: ChineseTenWebOutput is
+// declared there, so a bare `test` tag would break any build that has `test`
+// set without this game's category.
+func NewChineseTenDefaultOutputForTest(msg string) *ChineseTenWebOutput {
+	return newChineseTenDefaultOutput(msg)
+}

--- a/internal/adapter/controller/ChineseTen_testhelpers.go
+++ b/internal/adapter/controller/ChineseTen_testhelpers.go
@@ -6,10 +6,7 @@ package controller
 // external controller_test package.
 //
 // Lives behind the `test` tag so it never reaches a shipped binary — the same
-// convention as internal/domain/*_testhelpers.go. The category half of the
-// constraint is copied from ChineseTenWebController.go: ChineseTenWebOutput is
-// declared there, so a bare `test` tag would break any build that has `test`
-// set without this game's category.
+// convention as internal/domain/*_testhelpers.go.
 func NewChineseTenDefaultOutputForTest(msg string) *ChineseTenWebOutput {
 	return newChineseTenDefaultOutput(msg)
 }

--- a/internal/adapter/controller/DesmocheWebController.go
+++ b/internal/adapter/controller/DesmocheWebController.go
@@ -166,9 +166,3 @@ func desmocheDispatch(bc *baseController, w http.ResponseWriter, di usecase.Desm
 	}
 	return true
 }
-
-// NewDesmocheDefaultOutputForTest exposes the default-output builder to the
-// external controller_test package.
-func NewDesmocheDefaultOutputForTest(msg string) *DesmocheWebOutput {
-	return newDesmocheDefaultOutput(msg)
-}

--- a/internal/adapter/controller/Desmoche_testhelpers.go
+++ b/internal/adapter/controller/Desmoche_testhelpers.go
@@ -1,0 +1,12 @@
+//go:build test
+
+package controller
+
+// NewDesmocheDefaultOutputForTest exposes the default-output builder to the
+// external controller_test package.
+//
+// Lives behind the `test` tag so it never reaches a shipped binary — the same
+// convention as internal/domain/*_testhelpers.go.
+func NewDesmocheDefaultOutputForTest(msg string) *DesmocheWebOutput {
+	return newDesmocheDefaultOutput(msg)
+}

--- a/internal/adapter/controller/LaughAndLieDownWebController.go
+++ b/internal/adapter/controller/LaughAndLieDownWebController.go
@@ -139,9 +139,3 @@ func laughAndLieDownDispatch(bc *baseController, w http.ResponseWriter, li useca
 	}
 	return true
 }
-
-// NewLaughAndLieDownDefaultOutputForTest exposes the default-output builder to
-// the external controller_test package.
-func NewLaughAndLieDownDefaultOutputForTest(msg string) *LaughAndLieDownWebOutput {
-	return newLaughAndLieDownDefaultOutput(msg)
-}

--- a/internal/adapter/controller/LaughAndLieDown_testhelpers.go
+++ b/internal/adapter/controller/LaughAndLieDown_testhelpers.go
@@ -1,0 +1,12 @@
+//go:build test
+
+package controller
+
+// NewLaughAndLieDownDefaultOutputForTest exposes the default-output builder to the
+// external controller_test package.
+//
+// Lives behind the `test` tag so it never reaches a shipped binary — the same
+// convention as internal/domain/*_testhelpers.go.
+func NewLaughAndLieDownDefaultOutputForTest(msg string) *LaughAndLieDownWebOutput {
+	return newLaughAndLieDownDefaultOutput(msg)
+}

--- a/internal/adapter/controller/LobaWebController.go
+++ b/internal/adapter/controller/LobaWebController.go
@@ -156,9 +156,3 @@ func lobaDispatch(bc *baseController, w http.ResponseWriter, li usecase.LobaInte
 	}
 	return true
 }
-
-// NewLobaDefaultOutputForTest exposes the default-output builder to the
-// external controller_test package.
-func NewLobaDefaultOutputForTest(msg string) *LobaWebOutput {
-	return newLobaDefaultOutput(msg)
-}

--- a/internal/adapter/controller/Loba_testhelpers.go
+++ b/internal/adapter/controller/Loba_testhelpers.go
@@ -1,0 +1,12 @@
+//go:build test
+
+package controller
+
+// NewLobaDefaultOutputForTest exposes the default-output builder to the
+// external controller_test package.
+//
+// Lives behind the `test` tag so it never reaches a shipped binary — the same
+// convention as internal/domain/*_testhelpers.go.
+func NewLobaDefaultOutputForTest(msg string) *LobaWebOutput {
+	return newLobaDefaultOutput(msg)
+}

--- a/internal/adapter/controller/MushiWebController.go
+++ b/internal/adapter/controller/MushiWebController.go
@@ -158,7 +158,3 @@ func mushiDispatch(bc *baseController, w http.ResponseWriter, mi usecase.MushiIn
 	}
 	return true
 }
-
-// NewMushiDefaultOutputForTest exposes the default-output builder to the
-// external controller_test package, which cannot reach the unexported one.
-func NewMushiDefaultOutputForTest(msg string) *MushiWebOutput { return newMushiDefaultOutput(msg) }

--- a/internal/adapter/controller/Mushi_testhelpers.go
+++ b/internal/adapter/controller/Mushi_testhelpers.go
@@ -1,0 +1,10 @@
+//go:build test
+
+package controller
+
+// NewMushiDefaultOutputForTest exposes the default-output builder to the
+// external controller_test package.
+//
+// Lives behind the `test` tag so it never reaches a shipped binary — the same
+// convention as internal/domain/*_testhelpers.go.
+func NewMushiDefaultOutputForTest(msg string) *MushiWebOutput { return newMushiDefaultOutput(msg) }

--- a/internal/adapter/controller/NainJauneWebController.go
+++ b/internal/adapter/controller/NainJauneWebController.go
@@ -150,9 +150,3 @@ func nainJauneDispatch(bc *baseController, w http.ResponseWriter, ni usecase.Nai
 	}
 	return true
 }
-
-// NewNainJauneDefaultOutputForTest exposes the default-output builder to the
-// external controller_test package.
-func NewNainJauneDefaultOutputForTest(msg string) *NainJauneWebOutput {
-	return newNainJauneDefaultOutput(msg)
-}

--- a/internal/adapter/controller/NainJaune_testhelpers.go
+++ b/internal/adapter/controller/NainJaune_testhelpers.go
@@ -1,0 +1,12 @@
+//go:build test
+
+package controller
+
+// NewNainJauneDefaultOutputForTest exposes the default-output builder to the
+// external controller_test package.
+//
+// Lives behind the `test` tag so it never reaches a shipped binary — the same
+// convention as internal/domain/*_testhelpers.go.
+func NewNainJauneDefaultOutputForTest(msg string) *NainJauneWebOutput {
+	return newNainJauneDefaultOutput(msg)
+}

--- a/internal/adapter/controller/PochWebController.go
+++ b/internal/adapter/controller/PochWebController.go
@@ -167,9 +167,3 @@ func pochDispatch(bc *baseController, w http.ResponseWriter, pi usecase.PochInte
 	}
 	return true
 }
-
-// NewPochDefaultOutputForTest exposes the default-output builder to the
-// external controller_test package.
-func NewPochDefaultOutputForTest(msg string) *PochWebOutput {
-	return newPochDefaultOutput(msg)
-}

--- a/internal/adapter/controller/Poch_testhelpers.go
+++ b/internal/adapter/controller/Poch_testhelpers.go
@@ -1,0 +1,12 @@
+//go:build test
+
+package controller
+
+// NewPochDefaultOutputForTest exposes the default-output builder to the
+// external controller_test package.
+//
+// Lives behind the `test` tag so it never reaches a shipped binary — the same
+// convention as internal/domain/*_testhelpers.go.
+func NewPochDefaultOutputForTest(msg string) *PochWebOutput {
+	return newPochDefaultOutput(msg)
+}

--- a/internal/adapter/controller/PopeJoanWebController.go
+++ b/internal/adapter/controller/PopeJoanWebController.go
@@ -155,9 +155,3 @@ func popeJoanDispatch(bc *baseController, w http.ResponseWriter, pi usecase.Pope
 	}
 	return true
 }
-
-// NewPopeJoanDefaultOutputForTest exposes the default-output builder to the
-// external controller_test package.
-func NewPopeJoanDefaultOutputForTest(msg string) *PopeJoanWebOutput {
-	return newPopeJoanDefaultOutput(msg)
-}

--- a/internal/adapter/controller/PopeJoan_testhelpers.go
+++ b/internal/adapter/controller/PopeJoan_testhelpers.go
@@ -1,0 +1,12 @@
+//go:build test
+
+package controller
+
+// NewPopeJoanDefaultOutputForTest exposes the default-output builder to the
+// external controller_test package.
+//
+// Lives behind the `test` tag so it never reaches a shipped binary — the same
+// convention as internal/domain/*_testhelpers.go.
+func NewPopeJoanDefaultOutputForTest(msg string) *PopeJoanWebOutput {
+	return newPopeJoanDefaultOutput(msg)
+}

--- a/internal/adapter/controller/SjavsWebController.go
+++ b/internal/adapter/controller/SjavsWebController.go
@@ -172,9 +172,3 @@ func sjavsDispatch(bc *baseController, w http.ResponseWriter, si usecase.SjavsIn
 	}
 	return true
 }
-
-// NewSjavsDefaultOutputForTest exposes the default-output builder to the
-// external controller_test package.
-func NewSjavsDefaultOutputForTest(msg string) *SjavsWebOutput {
-	return newSjavsDefaultOutput(msg)
-}

--- a/internal/adapter/controller/Sjavs_testhelpers.go
+++ b/internal/adapter/controller/Sjavs_testhelpers.go
@@ -1,0 +1,12 @@
+//go:build test
+
+package controller
+
+// NewSjavsDefaultOutputForTest exposes the default-output builder to the
+// external controller_test package.
+//
+// Lives behind the `test` tag so it never reaches a shipped binary — the same
+// convention as internal/domain/*_testhelpers.go.
+func NewSjavsDefaultOutputForTest(msg string) *SjavsWebOutput {
+	return newSjavsDefaultOutput(msg)
+}

--- a/internal/adapter/controller/SkitgubbeWebController.go
+++ b/internal/adapter/controller/SkitgubbeWebController.go
@@ -133,9 +133,3 @@ func skitgubbeDispatch(bc *baseController, w http.ResponseWriter, si usecase.Ski
 	}
 	return true
 }
-
-// NewSkitgubbeDefaultOutputForTest exposes the default-output builder to the
-// external controller_test package.
-func NewSkitgubbeDefaultOutputForTest(msg string) *SkitgubbeWebOutput {
-	return newSkitgubbeDefaultOutput(msg)
-}

--- a/internal/adapter/controller/Skitgubbe_testhelpers.go
+++ b/internal/adapter/controller/Skitgubbe_testhelpers.go
@@ -1,0 +1,12 @@
+//go:build test
+
+package controller
+
+// NewSkitgubbeDefaultOutputForTest exposes the default-output builder to the
+// external controller_test package.
+//
+// Lives behind the `test` tag so it never reaches a shipped binary — the same
+// convention as internal/domain/*_testhelpers.go.
+func NewSkitgubbeDefaultOutputForTest(msg string) *SkitgubbeWebOutput {
+	return newSkitgubbeDefaultOutput(msg)
+}

--- a/internal/adapter/controller/ToepenWebController.go
+++ b/internal/adapter/controller/ToepenWebController.go
@@ -153,7 +153,3 @@ func toepenDispatch(bc *baseController, w http.ResponseWriter, ti usecase.Toepen
 	}
 	return true
 }
-
-// NewToepenDefaultOutputForTest exposes the default-output builder to the
-// external controller_test package.
-func NewToepenDefaultOutputForTest(msg string) *ToepenWebOutput { return newToepenDefaultOutput(msg) }

--- a/internal/adapter/controller/Toepen_testhelpers.go
+++ b/internal/adapter/controller/Toepen_testhelpers.go
@@ -1,0 +1,10 @@
+//go:build test
+
+package controller
+
+// NewToepenDefaultOutputForTest exposes the default-output builder to the
+// external controller_test package.
+//
+// Lives behind the `test` tag so it never reaches a shipped binary — the same
+// convention as internal/domain/*_testhelpers.go.
+func NewToepenDefaultOutputForTest(msg string) *ToepenWebOutput { return newToepenDefaultOutput(msg) }

--- a/internal/adapter/controller/TrexWebController.go
+++ b/internal/adapter/controller/TrexWebController.go
@@ -169,9 +169,3 @@ func trexDispatch(bc *baseController, w http.ResponseWriter, ti usecase.TrexInte
 	}
 	return true
 }
-
-// NewTrexDefaultOutputForTest exposes the default-output builder to the
-// external controller_test package.
-func NewTrexDefaultOutputForTest(msg string) *TrexWebOutput {
-	return newTrexDefaultOutput(msg)
-}

--- a/internal/adapter/controller/Trex_testhelpers.go
+++ b/internal/adapter/controller/Trex_testhelpers.go
@@ -1,0 +1,12 @@
+//go:build test
+
+package controller
+
+// NewTrexDefaultOutputForTest exposes the default-output builder to the
+// external controller_test package.
+//
+// Lives behind the `test` tag so it never reaches a shipped binary — the same
+// convention as internal/domain/*_testhelpers.go.
+func NewTrexDefaultOutputForTest(msg string) *TrexWebOutput {
+	return newTrexDefaultOutput(msg)
+}

--- a/internal/adapter/controller/ZwickerWebController.go
+++ b/internal/adapter/controller/ZwickerWebController.go
@@ -180,9 +180,3 @@ func zwickerDispatch(bc *baseController, w http.ResponseWriter, zi usecase.Zwick
 	}
 	return true
 }
-
-// NewZwickerDefaultOutputForTest exposes the default-output builder to the
-// external controller_test package.
-func NewZwickerDefaultOutputForTest(msg string) *ZwickerWebOutput {
-	return newZwickerDefaultOutput(msg)
-}

--- a/internal/adapter/controller/Zwicker_testhelpers.go
+++ b/internal/adapter/controller/Zwicker_testhelpers.go
@@ -1,0 +1,12 @@
+//go:build test
+
+package controller
+
+// NewZwickerDefaultOutputForTest exposes the default-output builder to the
+// external controller_test package.
+//
+// Lives behind the `test` tag so it never reaches a shipped binary — the same
+// convention as internal/domain/*_testhelpers.go.
+func NewZwickerDefaultOutputForTest(msg string) *ZwickerWebOutput {
+	return newZwickerDefaultOutput(msg)
+}


### PR DESCRIPTION
`internal/adapter/` の本番ファイルにあったテスト専用エクスポート 13 個を、`internal/domain` で確立している `*_testhelpers.go` + `//go:build test` の規約へ揃える。

## 先に訂正: issue に書いた効果の 2/3 は誤りだった

着手して実測した結果です。[issue にも訂正を投稿](https://github.com/yuta-yoshinaga/go_trumpcards/issues/5362#issuecomment-5301111933)しました。

| issue の主張 | 実測 | 判定 |
|---|---|---|
| deadcode の誤検知が 31 件減る | 修正前 13/411 → 修正後 **13/411** | ❌ 誤り |
| 本番バイナリに含まれる | develop / 本ブランチ両方で `go tool nm` → **0 と 0** | ❌ 誤り |
| 本番の API 表面にテスト専用関数が混ざる | 解消 | ✅ 有効 |

**deadcode が減らない理由**: `deadcode -tags test` は `test` タグ付きファイルも解析対象に含めるため、置き場所を変えても main からの到達性は変わりません。

**バイナリに含まれない理由**: 参照の無いエクスポート関数はリンカが既に除去しています。当初 `go tool nm` で 0/0 と出たとき、`git stash` が**未追跡の新規 helper を含めない**せいで「修正前」のビルドが関数重複で失敗しており、計測が無効でした。develop の worktree を作り直して測り直しています。

## 残る効果

`controller` パッケージの本番ビルドのエクスポート面からテスト専用関数が消え、**「テスト専用」がコンパイラに強制される**ようになります。従来は `ForTest` という命名規約への信頼だけでした。効果は当初想定より小さいですが、62 ファイルで確立した規約に adapter が揃う一貫性の改善としては有効と判断しています。

## build タグは素の `test` にした

issue では合成タグ (`test && (!js || !wasm || extra2)`) が要るかもしれないと書きましたが、負のコントロールで確認したところ **worker + test の組み合わせは既存の `internal/domain/*_testhelpers.go` でも同様にコンパイルできず**、サポートされたビルドではありませんでした:

```console
$ GOOS=js GOARCH=wasm go build -tags "test,extra3" ./cmd/workers/extra3
internal/domain/Badugi_testhelpers.go:9:10: undefined: Badugi   # 既存ファイルで発生
```

合成タグは 62 ファイルの規約から外れるだけで新しい保護を生まないので、素の `test` に揃えました。

## 検証

実際に使われるビルド 3 系統すべて:

```
go build ./...                            通過
go vet -tags test ./internal/adapter/...  通過
go test -tags test ./internal/adapter/controller/   通過
6 worker の GOOS=js GOARCH=wasm            すべて通過
golangci-lint run ./internal/adapter/...  0 issues
```

移設後、本番ファイルに `DefaultOutputForTest` が **0 件**、helper ファイルが **13 件**あることを確認しています。テスト側の呼び出しは変更不要でした（`go test -tags test` が既定の実行方法なのでシンボルはそのまま解決します）。

## 差分の内訳

13 ゲーム分 × (本番ファイルから削除 + helper 新規) = 26 ファイル。3 件はコメントの改行位置や 1 行 body が他と違ったため、一括正規表現では拾えず個別に処理しています（移設漏れが無いことは移設後の grep 0 件で確認）。

Closes #5362