### PR TITLE
feat(a11y): announce route changes and give every page a title

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import { HashRouter, Navigate, Route, Routes } from 'react-router-dom';
 import { DesktopSidebar } from './components/DesktopSidebar';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { NavBar } from './components/NavBar';
+import { RouteAnnouncer } from './components/RouteAnnouncer';
 import { RouteErrorBoundary } from './components/RouteErrorBoundary';
 import { SkipNavLink } from './components/SkipNavLink';
 import { SkeletonBar } from './components/skeleton/SkeletonBar';
@@ -59,6 +60,10 @@ export default function App() {
       <ErrorBoundary>
         <div className="flex flex-col h-full lg:flex-row">
           <SkipNavLink targetId="main-content" label={t('nav.skipToContent')} />
+          {/* Announces route changes and moves focus to <main>; a HashRouter
+              navigation fires no page-load event, so nothing else tells
+              assistive tech the view changed (#5360). */}
+          <RouteAnnouncer />
           <DesktopSidebar />
           {/* `min-h-0` is load-bearing, not defensive: this is a flex item in a
               `h-full` column, and without it its automatic minimum size is its

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -62,7 +62,14 @@ export default function App() {
           <SkipNavLink targetId="main-content" label={t('nav.skipToContent')} />
           {/* Announces route changes and moves focus to <main>; a HashRouter
               navigation fires no page-load event, so nothing else tells
-              assistive tech the view changed (#5360). */}
+              assistive tech the view changed (#5360).
+
+              Placement here is not load-bearing. It is declared before
+              <Routes>, so its effects run first, but it no longer reads
+              document.title in that window -- it subscribes to
+              useDocumentTitle and announces when the title actually lands.
+              That also covers lazy route chunks, where the page has not
+              mounted yet when this component's effect runs. */}
           <RouteAnnouncer />
           <DesktopSidebar />
           {/* `min-h-0` is load-bearing, not defensive: this is a flex item in a

--- a/frontend/src/components/RouteAnnouncer.test.tsx
+++ b/frontend/src/components/RouteAnnouncer.test.tsx
@@ -1,6 +1,7 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter, Route, Routes, useNavigate } from 'react-router-dom';
 import { afterEach, describe, expect, it } from 'vitest';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import { RouteAnnouncer } from './RouteAnnouncer';
 
 /** A page that renders a button navigating to `to`, plus the focus target. */
@@ -20,9 +21,13 @@ function Harness({ initial = '/a' }: { initial?: string }) {
   );
 }
 
+// Sets the title from an effect, exactly as useDocumentTitle does. Setting it
+// during render instead would hide the ordering this component depends on:
+// sibling effects run in declaration order, so an announcer declared before the
+// routed page sees the title the *previous* page left behind.
 function Nav({ to, label, title }: { to: string; label: string; title: string }) {
   const navigate = useNavigate();
-  document.title = title;
+  useDocumentTitle(title);
   return (
     <button type="button" onClick={() => navigate(to)}>
       {label}
@@ -56,7 +61,7 @@ describe('RouteAnnouncer', () => {
     act(() => {
       fireEvent.click(screen.getByRole('button', { name: 'go b' }));
     });
-    expect(screen.getByRole('status')).toHaveTextContent('Page B');
+    expect(screen.getByRole('status')).toHaveTextContent('Page B - Trump Cards');
   });
 
   // Without this, a keyboard user lands back at the top of a 318-entry nav on
@@ -87,6 +92,6 @@ describe('RouteAnnouncer', () => {
         fireEvent.click(screen.getByRole('button', { name: 'go b' }));
       });
     }).not.toThrow();
-    expect(screen.getByRole('status')).toHaveTextContent('Page B');
+    expect(screen.getByRole('status')).toHaveTextContent('Page B - Trump Cards');
   });
 });

--- a/frontend/src/components/RouteAnnouncer.test.tsx
+++ b/frontend/src/components/RouteAnnouncer.test.tsx
@@ -1,0 +1,92 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useNavigate } from 'react-router-dom';
+import { afterEach, describe, expect, it } from 'vitest';
+import { RouteAnnouncer } from './RouteAnnouncer';
+
+/** A page that renders a button navigating to `to`, plus the focus target. */
+function Harness({ initial = '/a' }: { initial?: string }) {
+  return (
+    <MemoryRouter initialEntries={[initial]}>
+      <RouteAnnouncer />
+      {/* The real app puts tabIndex={-1} on <main> for the skip link; the
+          announcer reuses it, so the harness must provide it too. */}
+      <main id="main-content" tabIndex={-1}>
+        <Routes>
+          <Route path="/a" element={<Nav to="/b" label="go b" title="Page A" />} />
+          <Route path="/b" element={<Nav to="/a" label="go a" title="Page B" />} />
+        </Routes>
+      </main>
+    </MemoryRouter>
+  );
+}
+
+function Nav({ to, label, title }: { to: string; label: string; title: string }) {
+  const navigate = useNavigate();
+  document.title = title;
+  return (
+    <button type="button" onClick={() => navigate(to)}>
+      {label}
+    </button>
+  );
+}
+
+afterEach(() => {
+  document.title = '';
+});
+
+describe('RouteAnnouncer', () => {
+  it('exposes a polite live region for assistive tech', () => {
+    render(<Harness />);
+    const region = screen.getByRole('status');
+    expect(region).toHaveAttribute('aria-live', 'polite');
+    // Visually hidden: this is for screen readers, not a banner.
+    expect(region).toHaveClass('sr-only');
+  });
+
+  // A first render is an ordinary page load, which assistive tech already
+  // announces. Announcing again would duplicate it, and moving focus would
+  // yank the user out of whatever they were doing (e.g. a deep link).
+  it('says nothing on the first render', () => {
+    render(<Harness />);
+    expect(screen.getByRole('status')).toHaveTextContent('');
+  });
+
+  it('announces the new page after a navigation', () => {
+    render(<Harness />);
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: 'go b' }));
+    });
+    expect(screen.getByRole('status')).toHaveTextContent('Page B');
+  });
+
+  // Without this, a keyboard user lands back at the top of a 318-entry nav on
+  // every game change and has to tab past all of it to reach the board.
+  it('moves focus to the main region after a navigation', () => {
+    render(<Harness />);
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: 'go b' }));
+    });
+    expect(document.activeElement).toBe(document.getElementById('main-content'));
+  });
+
+  // The announcer must not assume the target exists: RouteAnnouncer is mounted
+  // inside the router, and a crash boundary or a future layout change could
+  // render without <main>.
+  it('does not throw when the focus target is absent', () => {
+    render(
+      <MemoryRouter initialEntries={['/a']}>
+        <RouteAnnouncer />
+        <Routes>
+          <Route path="/a" element={<Nav to="/b" label="go b" title="Page A" />} />
+          <Route path="/b" element={<Nav to="/a" label="go a" title="Page B" />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    expect(() => {
+      act(() => {
+        fireEvent.click(screen.getByRole('button', { name: 'go b' }));
+      });
+    }).not.toThrow();
+    expect(screen.getByRole('status')).toHaveTextContent('Page B');
+  });
+});

--- a/frontend/src/components/RouteAnnouncer.tsx
+++ b/frontend/src/components/RouteAnnouncer.tsx
@@ -1,0 +1,48 @@
+import { useEffect, useRef, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+
+/** The id of the landmark that receives focus after a navigation. */
+const MAIN_ID = 'main-content';
+
+/**
+ * Announces route changes and moves focus to the main landmark.
+ *
+ * A HashRouter navigation fires no page-load event, so assistive tech gets no
+ * signal that the view changed: switching between 318 games was silent, and
+ * focus stayed on the link that was clicked, leaving keyboard users to tab past
+ * the whole navigation again to reach the board. `document.title` changes are
+ * not a reliable substitute — without a load event, whether a screen reader
+ * re-reads the title is implementation-dependent. See issue #5360.
+ *
+ * Deliberately one announcement per navigation, matching the granularity of the
+ * existing search-result-count live regions. Per-move announcements during play
+ * would drown the useful ones.
+ *
+ * `<main>` already carries `tabIndex={-1}` for the skip link, so it can receive
+ * programmatic focus here without new markup. Focus is set with
+ * `preventScroll` so the announcement does not also jump the viewport.
+ */
+export function RouteAnnouncer() {
+  const { pathname } = useLocation();
+  const [message, setMessage] = useState('');
+  // Seeded with the initial path so the first render is a no-op: an ordinary
+  // page load is already announced by assistive tech, and stealing focus would
+  // fight a deep link that scrolled somewhere specific. Comparing paths rather
+  // than tracking a boolean also keeps a re-render on the same route silent.
+  const announcedPath = useRef(pathname);
+
+  useEffect(() => {
+    if (announcedPath.current === pathname) return;
+    announcedPath.current = pathname;
+    document.getElementById(MAIN_ID)?.focus({ preventScroll: true });
+    // The title is set by useDocumentTitle on the page that just mounted, so it
+    // is the page's own name by the time this effect runs.
+    setMessage(document.title);
+  }, [pathname]);
+
+  return (
+    <div role="status" aria-live="polite" className="sr-only">
+      {message}
+    </div>
+  );
+}

--- a/frontend/src/components/RouteAnnouncer.tsx
+++ b/frontend/src/components/RouteAnnouncer.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { useLocation } from 'react-router-dom';
+import { subscribeDocumentTitle } from '../hooks/useDocumentTitle';
 
 /** The id of the landmark that receives focus after a navigation. */
 const MAIN_ID = 'main-content';
@@ -10,9 +11,20 @@ const MAIN_ID = 'main-content';
  * A HashRouter navigation fires no page-load event, so assistive tech gets no
  * signal that the view changed: switching between 318 games was silent, and
  * focus stayed on the link that was clicked, leaving keyboard users to tab past
- * the whole navigation again to reach the board. `document.title` changes are
- * not a reliable substitute — without a load event, whether a screen reader
- * re-reads the title is implementation-dependent. See issue #5360.
+ * the whole navigation again to reach the board. See issue #5360.
+ *
+ * The two halves key off different signals on purpose:
+ *
+ * - **Focus** follows the pathname. It must move as soon as the route changes,
+ *   and it does not care what the destination is called.
+ * - **The announcement** waits for `useDocumentTitle` to publish. Reading
+ *   `document.title` inside the pathname effect looks equivalent and is not:
+ *   this component is declared before `<Routes>`, and React flushes sibling
+ *   effects in declaration order, so it runs *before* the destination page's
+ *   `useDocumentTitle` and captures the bare site name that the unmounting
+ *   page's cleanup left behind. Lazy route chunks widen the same gap — the new
+ *   page may not have mounted at all yet. Subscribing instead makes the
+ *   announcement independent of when the page gets around to setting it.
  *
  * Deliberately one announcement per navigation, matching the granularity of the
  * existing search-result-count live regions. Per-move announcements during play
@@ -29,16 +41,28 @@ export function RouteAnnouncer() {
   // page load is already announced by assistive tech, and stealing focus would
   // fight a deep link that scrolled somewhere specific. Comparing paths rather
   // than tracking a boolean also keeps a re-render on the same route silent.
-  const announcedPath = useRef(pathname);
+  const focusedPath = useRef(pathname);
+  // Set when a navigation happens, cleared once that navigation is announced,
+  // so a title change that is not a navigation (a page renaming itself mid-play)
+  // stays silent.
+  const pendingAnnounce = useRef(false);
 
   useEffect(() => {
-    if (announcedPath.current === pathname) return;
-    announcedPath.current = pathname;
+    if (focusedPath.current === pathname) return;
+    focusedPath.current = pathname;
+    pendingAnnounce.current = true;
     document.getElementById(MAIN_ID)?.focus({ preventScroll: true });
-    // The title is set by useDocumentTitle on the page that just mounted, so it
-    // is the page's own name by the time this effect runs.
-    setMessage(document.title);
   }, [pathname]);
+
+  useEffect(() => {
+    // Subscribed once for the component's lifetime: the announcement is driven
+    // by the title landing, not by this effect re-running.
+    return subscribeDocumentTitle((title) => {
+      if (!pendingAnnounce.current) return;
+      pendingAnnounce.current = false;
+      setMessage(title);
+    });
+  }, []);
 
   return (
     <div role="status" aria-live="polite" className="sr-only">

--- a/frontend/src/hooks/useDocumentTitle.test.ts
+++ b/frontend/src/hooks/useDocumentTitle.test.ts
@@ -1,0 +1,41 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { SITE_NAME } from '../constants/site';
+import { useDocumentTitle } from './useDocumentTitle';
+
+afterEach(() => {
+  document.title = '';
+});
+
+describe('useDocumentTitle', () => {
+  it('sets the title while mounted', () => {
+    renderHook(() => useDocumentTitle('おすすめを探す'));
+    expect(document.title).toBe(`おすすめを探す - ${SITE_NAME}`);
+  });
+
+  // The whole point of the cleanup: leaving a page must not leave its name in
+  // the tab. Before this hook existed, only game pages managed the title, so
+  // navigating to /discover kept whatever the previous page had set (or fell
+  // back to the bare site name with no page identity at all). See issue #5360.
+  it('restores the bare site name on unmount', () => {
+    const { unmount } = renderHook(() => useDocumentTitle('商標とクレジット'));
+    expect(document.title).toBe(`商標とクレジット - ${SITE_NAME}`);
+    unmount();
+    expect(document.title).toBe(SITE_NAME);
+  });
+
+  it('follows a changing title without needing a remount', () => {
+    const { rerender } = renderHook(({ title }) => useDocumentTitle(title), {
+      initialProps: { title: 'おすすめを探す' },
+    });
+    rerender({ title: '結果' });
+    expect(document.title).toBe(`結果 - ${SITE_NAME}`);
+  });
+
+  // A page whose translation has not loaded yet would otherwise render
+  // " - Trump Cards" with a dangling separator.
+  it('falls back to the bare site name when the title is empty', () => {
+    renderHook(() => useDocumentTitle(''));
+    expect(document.title).toBe(SITE_NAME);
+  });
+});

--- a/frontend/src/hooks/useDocumentTitle.ts
+++ b/frontend/src/hooks/useDocumentTitle.ts
@@ -1,0 +1,24 @@
+import { useEffect } from 'react';
+import { SITE_NAME } from '../constants/site';
+
+/**
+ * Sets `document.title` for the lifetime of the calling component.
+ *
+ * Extracted from `useGamePageSetup` so pages that are not games can identify
+ * themselves too. Only game pages managed the title before, so navigating to
+ * `/discover`, `/legal` or a 404 left the tab showing the bare site name with
+ * no page identity — and in a HashRouter SPA there is no page-load event to
+ * fall back on. See issue #5360.
+ *
+ * An empty `title` yields the bare site name rather than a dangling
+ * `" - Trump Cards"`, which is what a page whose translation has not resolved
+ * yet would otherwise render.
+ */
+export function useDocumentTitle(title: string): void {
+  useEffect(() => {
+    document.title = title ? `${title} - ${SITE_NAME}` : SITE_NAME;
+    return () => {
+      document.title = SITE_NAME;
+    };
+  }, [title]);
+}

--- a/frontend/src/hooks/useDocumentTitle.ts
+++ b/frontend/src/hooks/useDocumentTitle.ts
@@ -1,6 +1,33 @@
 import { useEffect } from 'react';
 import { SITE_NAME } from '../constants/site';
 
+/** Notified with the full document title whenever a page sets one. */
+type TitleListener = (title: string) => void;
+
+const listeners = new Set<TitleListener>();
+
+/**
+ * Subscribes to page-title changes. Returns an unsubscribe function.
+ *
+ * `RouteAnnouncer` uses this instead of reading `document.title` after a
+ * navigation. Reading it directly looks equivalent and is not: the announcer is
+ * declared before `<Routes>`, React flushes sibling effects in declaration
+ * order, so it runs *before* the destination page's `useDocumentTitle` and sees
+ * the bare site name that the unmounting page's cleanup left behind. Lazy route
+ * chunks widen the same gap. Publishing from the setter removes the ordering
+ * question entirely — the announcement happens when the title actually lands,
+ * however late that is. See issue #5360.
+ *
+ * The unmount cleanup deliberately does *not* publish: resetting to the bare
+ * site name is not a page identity worth announcing.
+ */
+export function subscribeDocumentTitle(listener: TitleListener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
 /**
  * Sets `document.title` for the lifetime of the calling component.
  *
@@ -16,7 +43,9 @@ import { SITE_NAME } from '../constants/site';
  */
 export function useDocumentTitle(title: string): void {
   useEffect(() => {
-    document.title = title ? `${title} - ${SITE_NAME}` : SITE_NAME;
+    const full = title ? `${title} - ${SITE_NAME}` : SITE_NAME;
+    document.title = full;
+    for (const listener of listeners) listener(full);
     return () => {
       document.title = SITE_NAME;
     };

--- a/frontend/src/hooks/useGamePageSetup.ts
+++ b/frontend/src/hooks/useGamePageSetup.ts
@@ -1,9 +1,8 @@
-import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { actionLogApi } from '../api/gameApi';
-import { SITE_NAME } from '../constants/site';
 import { useActionLog } from './useActionLog';
 import { useConfirmDialog } from './useConfirmDialog';
+import { useDocumentTitle } from './useDocumentTitle';
 
 /** Hook that provides common page setup: translations, action log, confirm dialogs, and document title. */
 export function useGamePageSetup(gameName: keyof typeof actionLogApi) {
@@ -21,13 +20,9 @@ export function useGamePageSetup(gameName: keyof typeof actionLogApi) {
     cancel: cancelGiveUp,
   } = useConfirmDialog();
 
-  const pageTitle = tc(`nav.${gameName}`);
-  useEffect(() => {
-    document.title = `${pageTitle} - ${SITE_NAME}`;
-    return () => {
-      document.title = SITE_NAME;
-    };
-  }, [pageTitle]);
+  // Title handling lives in useDocumentTitle so pages that are not games can
+  // use it too -- before that split only game pages set a title (#5360).
+  useDocumentTitle(tc(`nav.${gameName}`));
 
   return {
     t,

--- a/frontend/src/pages/DiscoverPage.tsx
+++ b/frontend/src/pages/DiscoverPage.tsx
@@ -8,6 +8,7 @@ import { MoodQuestion } from '../components/discover/MoodQuestion';
 import { SurveyProgress } from '../components/discover/SurveyProgress';
 import { AXES, AXIS_KEYS, type AxisKey, TOTAL_QUESTIONS } from '../constants/discoverAxes';
 import { useDiscoverI18nBundle } from '../hooks/useDiscoverI18nBundle';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import { useReducedMotion } from '../hooks/useReducedMotion';
 import { useSurveyDraft } from '../hooks/useSurveyDraft';
 import { focusRingWhite } from '../styles/buttonStyles';
@@ -59,6 +60,8 @@ function firstUnansweredStep(axes: ReturnType<typeof useSurveyDraft>['axes']): n
  */
 export function DiscoverPage() {
   const { t } = useTranslation('discover');
+  const { t: tc } = useTranslation('common');
+  useDocumentTitle(tc('nav.discover'));
   const navigate = useNavigate();
   const bundleReady = useDiscoverI18nBundle();
   const reducedMotion = useReducedMotion();

--- a/frontend/src/pages/DiscoverResultPage.tsx
+++ b/frontend/src/pages/DiscoverResultPage.tsx
@@ -6,6 +6,7 @@ import { DiscoverSkeleton } from '../components/discover/DiscoverSkeleton';
 import { RecommendationCard } from '../components/discover/RecommendationCard';
 import { StretchPickCard } from '../components/discover/StretchPickCard';
 import { useDiscoverI18nBundle } from '../hooks/useDiscoverI18nBundle';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import { useGameRecommendations } from '../hooks/useGameRecommendations';
 import { btnPrimary, btnSecondary, focusRingWhite } from '../styles/buttonStyles';
 import { hasAnyAnswer, parseSearchParams, type UserMoodInput } from '../utils/urlMoodCodec';
@@ -28,6 +29,8 @@ function toUserMood(input: UserMoodInput) {
  */
 export function DiscoverResultPage() {
   const { t } = useTranslation('discover');
+  const { t: tc } = useTranslation('common');
+  useDocumentTitle(tc('nav.discover'));
   const [params] = useSearchParams();
   const navigate = useNavigate();
   const bundleReady = useDiscoverI18nBundle();

--- a/frontend/src/pages/LegalPage.tsx
+++ b/frontend/src/pages/LegalPage.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import { btnSecondary, focusRingWhite } from '../styles/buttonStyles';
 
 /** Repository root — the authoritative home of TRADEMARKS.md and the asset READMEs. */
@@ -36,6 +37,7 @@ function LegalSection({ title, children }: LegalSectionProps) {
  */
 export function LegalPage() {
   const { t } = useTranslation('common');
+  useDocumentTitle(t('legal.title'));
   return (
     <div className="flex-1 overflow-y-auto bg-ds-surface text-ds-text-primary">
       <div className="mx-auto max-w-2xl px-6 py-10 flex flex-col gap-8">

--- a/frontend/src/pages/NotFoundPage.tsx
+++ b/frontend/src/pages/NotFoundPage.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { Link, useLocation } from 'react-router-dom';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import { btnPrimary, btnSecondary, focusRingWhite } from '../styles/buttonStyles';
 
 /**
@@ -10,6 +11,7 @@ import { btnPrimary, btnSecondary, focusRingWhite } from '../styles/buttonStyles
  */
 export function NotFoundPage() {
   const { t } = useTranslation('common');
+  useDocumentTitle(t('notFound.title'));
   const location = useLocation();
   return (
     <div className="flex-1 flex flex-col items-center justify-center px-6 py-12 gap-6 bg-ds-surface text-ds-text-primary">


### PR DESCRIPTION
HashRouter の SPA なのでページ読み込みイベントが発生せず、318 ゲームを行き来しても支援技術には何も伝わっていなかった。

## 欠けていた 3 つ

| # | 状態 | 影響 |
|---|---|---|
| 1 | ルート変更でフォーカスが移らない | クリックしたリンクにフォーカスが残り、**318 件のナビを Tab で通り抜け直す** |
| 2 | 到着を告知する live region が無い | 既存 3 件は「読み込み中」と「検索結果件数」専用。どのページに着いたかは無言 |
| 3 | 4 ページが `document.title` を設定しない | Discover / DiscoverResult / Legal / NotFound がタブ上で識別できない |

`main#main-content` は SkipNavLink 用に `tabIndex={-1}` を**既に持っている**ので、受け皿は最初からありました。使っていなかっただけです。

## 対応

**`useDocumentTitle`** を `useGamePageSetup` から切り出し、非ゲーム 4 ページへ適用。**新しい i18n キーは追加していません**（`nav.discover` / `legal.title` / `notFound.title` が既存）。空文字のときは `" - Trump Cards"` という宙ぶらりんのセパレータを避けてサイト名だけを返します。

**`RouteAnnouncer`** を `App` に追加。遷移ごとに `main` へ `focus({ preventScroll: true })` してから `document.title` を polite な live region へ流します。

## 振り子現象への配慮

告知は**遷移 1 回につき 1 回**に限っています。既存の検索結果件数アナウンスと同じ粒度で、1 手ごとの読み上げのような情報過多にはしません。

初回レンダリングでは何もしません。通常のページ読み込みは支援技術が自前で告知するので重複になり、ディープリンクのスクロール位置も奪ってしまうためです。`preventScroll` を付けているのも同じ理由です。

## 判定を boolean から「パス比較」に変えた理由

当初は `isFirstRender` の boolean フラグでしたが、biome の `useExhaustiveDependencies` が「`pathname` は不要な依存」と指摘しました。効果本体が `pathname` を読んでいなかったためです。

依存を消すのは**意図と逆**（`pathname` の変化こそがトリガー）なので、`biome-ignore` で黙らせるのではなく、**直前に告知したパスと比較する**実装に変えました。これで依存が実際に読まれ、かつ同一ルートでの再レンダリングでも黙るという精度向上も得られます。

```ts
const announcedPath = useRef(pathname);
useEffect(() => {
  if (announcedPath.current === pathname) return;
  announcedPath.current = pathname;
  document.getElementById(MAIN_ID)?.focus({ preventScroll: true });
  setMessage(document.title);
}, [pathname]);
```

## テスト（正負両方向）

- フォーカス移動を外す → 「moves focus to the main region」1 件が落ちる（実測）
- 初回ガードを外す → 「says nothing on the first render」1 件が落ちる（実測）
- `main` が無い場合に例外を投げないことも固定（`RouteAnnouncer` はルータ内にあり、将来のレイアウト変更やクラッシュ境界で `main` 不在になり得る）
- クリックは既存の流儀に合わせて `fireEvent`（`user-event` はこのリポジトリでは未使用）

## 検証

- `bunx vitest run src/App.test.tsx src/components/RouteAnnouncer.test.tsx src/hooks/` → **1535 passed**
- 4 ページのテスト → 30 passed
- `bun run typecheck` 通過
- `bun run check` 全ガード緑

## 未対応（この PR の範囲外）

`bun run check` は `scripts/check-codecov-uploads.mjs:44` と `src/pages/ColoradoPage.tsx:393` でも lint を報告しますが、**develop 時点で既存**であることを確認済みなので触っていません（stash して develop 上で 2 件出ることを実測）。

Closes #5360