### PR TITLE
refactor(domain): consolidate 26 identical index filters into filterIndices

### DIFF
--- a/internal/domain/Calabresella.go
+++ b/internal/domain/Calabresella.go
@@ -794,13 +794,13 @@ func (g *Calabresella) cpuPlaySmart(playerIdx int, valid []int) int {
 		})
 	}
 
-	winners := calabresellaFilter(follows, func(idx int) bool {
+	winners := filterIndices(follows, func(idx int) bool {
 		return calabresellaStrength(player.GetCard(idx).GetValue()) > topStrength
 	})
 
 	if partnerWinning {
 		// 味方が勝っている: 上書きせず得点札を渡す。
-		nonWinners := calabresellaFilter(follows, func(idx int) bool {
+		nonWinners := filterIndices(follows, func(idx int) bool {
 			return calabresellaStrength(player.GetCard(idx).GetValue()) < topStrength
 		})
 		if len(nonWinners) > 0 {
@@ -819,17 +819,6 @@ func (g *Calabresella) cpuPlaySmart(playerIdx int, valid []int) int {
 	return pickLowest(player, follows, func(c *Card) int {
 		return calabresellaThirds(c.GetValue())*100 + calabresellaStrength(c.GetValue())
 	})
-}
-
-// calabresellaFilter 述語を満たすインデックスを抽出する。
-func calabresellaFilter(indices []int, pred func(int) bool) []int {
-	var out []int
-	for _, idx := range indices {
-		if pred(idx) {
-			out = append(out, idx)
-		}
-	}
-	return out
 }
 
 // --- Hint ---

--- a/internal/domain/Cego.go
+++ b/internal/domain/Cego.go
@@ -1022,7 +1022,7 @@ func (g *Cego) trumpFollowIndices(player *CegoPlayer, highestTrump int) []int {
 	if len(trumps) == 0 {
 		return g.allIndices(player)
 	}
-	higher := cegoFilter(trumps, func(idx int) bool {
+	higher := filterIndices(trumps, func(idx int) bool {
 		return cegoTrumpValue(player.GetCard(idx)) > highestTrump
 	})
 	if len(higher) > 0 {
@@ -1041,7 +1041,7 @@ func (g *Cego) suitFollowIndices(player *CegoPlayer, led, highestTrump int) []in
 	if len(trumps) == 0 {
 		return g.allIndices(player)
 	}
-	higher := cegoFilter(trumps, func(idx int) bool {
+	higher := filterIndices(trumps, func(idx int) bool {
 		return cegoTrumpValue(player.GetCard(idx)) > highestTrump
 	})
 	if highestTrump > 0 && len(higher) > 0 {
@@ -1201,7 +1201,7 @@ func (g *Cego) cpuPlaySmart(playerIdx int, valid []int) int {
 	winCard := g.currentTrick[g.indexInTrick(winnerIdx)].Card
 	winnerSide := g.isDeclarerSide(winnerIdx)
 	mySide := g.isDeclarerSide(playerIdx)
-	winners := cegoFilter(valid, func(idx int) bool {
+	winners := filterIndices(valid, func(idx int) bool {
 		return cegoWinRank(p.GetCard(idx), led) > cegoWinRank(winCard, led)
 	})
 	if winnerSide == mySide {
@@ -1453,17 +1453,6 @@ func cegoValidBid(bid CegoBid) bool {
 // cegoValidBidVal bid が定義済みの入札値 (Pass 含む) か。
 func cegoValidBidVal(bid CegoBid) bool {
 	return bid >= CegoBidPass && bid <= CegoBidPlay
-}
-
-// cegoFilter 述語を満たすインデックスを抽出する。
-func cegoFilter(indices []int, pred func(int) bool) []int {
-	var out []int
-	for _, idx := range indices {
-		if pred(idx) {
-			out = append(out, idx)
-		}
-	}
-	return out
 }
 
 // --- State getters / setters ---

--- a/internal/domain/Doppelkopf.go
+++ b/internal/domain/Doppelkopf.go
@@ -864,12 +864,12 @@ func (g *Doppelkopf) cpuPlaySmart(playerIdx int, valid []int) int {
 		})
 	}
 
-	winners := dkFilter(follows, func(idx int) bool {
+	winners := filterIndices(follows, func(idx int) bool {
 		return dkStrength(player.GetCard(idx)) > topStrength
 	})
 
 	if partnerWinning {
-		nonWinners := dkFilter(follows, func(idx int) bool {
+		nonWinners := filterIndices(follows, func(idx int) bool {
 			return dkStrength(player.GetCard(idx)) < topStrength
 		})
 		if len(nonWinners) > 0 {
@@ -886,17 +886,6 @@ func (g *Doppelkopf) cpuPlaySmart(playerIdx int, valid []int) int {
 	return pickLowest(player, follows, func(c *Card) int {
 		return dkCardPoints(c.GetValue())*100 + dkStrength(c)
 	})
-}
-
-// dkFilter 述語を満たすインデックスを抽出する。
-func dkFilter(indices []int, pred func(int) bool) []int {
-	var out []int
-	for _, idx := range indices {
-		if pred(idx) {
-			out = append(out, idx)
-		}
-	}
-	return out
 }
 
 // --- JSON ---

--- a/internal/domain/FortyFives.go
+++ b/internal/domain/FortyFives.go
@@ -637,7 +637,7 @@ func (g *FortyFives) cpuPlaySmart(playerIdx int, valid []int) int {
 	winnerIdx := g.trickWinner()
 	topRank := g.trickTopRank(winnerIdx)
 	partnerWinning := FortyFivesTeamOf(winnerIdx) == FortyFivesTeamOf(playerIdx) && winnerIdx != playerIdx
-	winners := fortyFivesFilter(valid, func(idx int) bool { return g.fortyFivesRank(player.GetCard(idx)) > topRank })
+	winners := filterIndices(valid, func(idx int) bool { return g.fortyFivesRank(player.GetCard(idx)) > topRank })
 	if partnerWinning {
 		// 味方が勝っている: 最弱札を温存・捨てる。
 		return pickLowest(player, valid, func(c *Card) int { return g.fortyFivesRank(c) })
@@ -646,17 +646,6 @@ func (g *FortyFives) cpuPlaySmart(playerIdx int, valid []int) int {
 		return pickLowest(player, winners, func(c *Card) int { return g.fortyFivesRank(c) })
 	}
 	return pickLowest(player, valid, func(c *Card) int { return g.fortyFivesRank(c) })
-}
-
-// fortyFivesFilter 述語を満たすインデックスを抽出する。
-func fortyFivesFilter(indices []int, pred func(int) bool) []int {
-	var out []int
-	for _, idx := range indices {
-		if pred(idx) {
-			out = append(out, idx)
-		}
-	}
-	return out
 }
 
 // --- Hint ---

--- a/internal/domain/FrenchTarot.go
+++ b/internal/domain/FrenchTarot.go
@@ -1019,7 +1019,7 @@ func (g *FrenchTarot) trumpFollowIndices(player *FrenchTarotPlayer, highestTrump
 	if len(trumps) == 0 {
 		return g.nonExcuseIndices(player) // 切り札なし → 任意の非エクスキューズ札
 	}
-	higher := frenchTarotFilter(trumps, func(idx int) bool {
+	higher := filterIndices(trumps, func(idx int) bool {
 		return player.GetCard(idx).GetValue() > highestTrump
 	})
 	if len(higher) > 0 {
@@ -1039,7 +1039,7 @@ func (g *FrenchTarot) suitFollowIndices(player *FrenchTarotPlayer, led, highestT
 		return g.nonExcuseIndices(player) // ボイド + 切り札なし → 任意
 	}
 	// ボイド → 切り札義務 (+ 場に切り札があればオーバートランプ義務)。
-	higher := frenchTarotFilter(trumps, func(idx int) bool {
+	higher := filterIndices(trumps, func(idx int) bool {
 		return player.GetCard(idx).GetValue() > highestTrump
 	})
 	if highestTrump > 0 && len(higher) > 0 {
@@ -1258,7 +1258,7 @@ func (g *FrenchTarot) cpuPlaySmart(playerIdx int, valid []int) int {
 	winnerIsDecl := winnerIdx == g.declarerIdx
 	iAmDecl := playerIdx == g.declarerIdx
 	// 勝てる札。
-	winners := frenchTarotFilter(valid, func(idx int) bool {
+	winners := filterIndices(valid, func(idx int) bool {
 		return frenchTarotWinRank(p.GetCard(idx), led) > frenchTarotWinRank(winCard, led)
 	})
 	sameSideWinning := winnerIsDecl == iAmDecl
@@ -1502,17 +1502,6 @@ func frenchTarotValidBid(bid FrenchTarotBid) bool {
 // frenchTarotValidBidVal bid が定義済みの入札値 (Pass 含む) か。
 func frenchTarotValidBidVal(bid FrenchTarotBid) bool {
 	return bid >= FrenchTarotBidPass && bid <= FrenchTarotBidGardeContre
-}
-
-// frenchTarotFilter 述語を満たすインデックスを抽出する。
-func frenchTarotFilter(indices []int, pred func(int) bool) []int {
-	var out []int
-	for _, idx := range indices {
-		if pred(idx) {
-			out = append(out, idx)
-		}
-	}
-	return out
 }
 
 // frenchTarotAppendUnique スライスに未含有のインデックスを追加する。

--- a/internal/domain/GongZhu.go
+++ b/internal/domain/GongZhu.go
@@ -863,14 +863,14 @@ func (g *GongZhu) cpuPlaySmart(playerIdx int, validIndices []int) int {
 func (g *GongZhu) cpuFollow(player *GongZhuPlayer, follows []int, topValue int, trickHasSheep, trickNegative bool) int {
 	if trickHasSheep {
 		// 羊（+100）を奪いに行く: 勝てる最高札を出す
-		winners := gzFilter(follows, func(idx int) bool { return gzRankValue(player.GetCard(idx)) > topValue })
+		winners := filterIndices(follows, func(idx int) bool { return gzRankValue(player.GetCard(idx)) > topValue })
 		if len(winners) > 0 {
 			return gzHighest(player, winners)
 		}
 	}
 	if trickNegative {
 		// マイナスのトリックは避ける: 勝たない最高札（ダックの最大）を出す
-		ducks := gzFilter(follows, func(idx int) bool { return gzRankValue(player.GetCard(idx)) < topValue })
+		ducks := filterIndices(follows, func(idx int) bool { return gzRankValue(player.GetCard(idx)) < topValue })
 		if len(ducks) > 0 {
 			return gzHighest(player, ducks)
 		}
@@ -927,17 +927,6 @@ func gzDiscardScore(c *Card) int {
 		score += 100 + gzHeartPenalty(c.GetValue())
 	}
 	return score
-}
-
-// gzFilter 述語を満たすインデックスを抽出する
-func gzFilter(indices []int, pred func(int) bool) []int {
-	var out []int
-	for _, idx := range indices {
-		if pred(idx) {
-			out = append(out, idx)
-		}
-	}
-	return out
 }
 
 // gzHighest 指定インデックス群のうち最も強いカードのインデックスを返す

--- a/internal/domain/Klaverjas.go
+++ b/internal/domain/Klaverjas.go
@@ -625,10 +625,10 @@ func (g *Klaverjas) cpuPlaySmart(playerIdx int, valid []int) int {
 	for _, tc := range g.currentTrick {
 		trickPts += g.cardPoints(tc.Card)
 	}
-	winners := klaverjasFilter(valid, func(idx int) bool { return g.klaverjasRank(player.GetCard(idx)) > topRank })
+	winners := filterIndices(valid, func(idx int) bool { return g.klaverjasRank(player.GetCard(idx)) > topRank })
 	if partnerWinning {
 		// 味方が勝っている: 得点の高い札を渡す (勝ち札以外があればそれ)。
-		nonWinners := klaverjasFilter(valid, func(idx int) bool { return g.klaverjasRank(player.GetCard(idx)) < topRank })
+		nonWinners := filterIndices(valid, func(idx int) bool { return g.klaverjasRank(player.GetCard(idx)) < topRank })
 		if len(nonWinners) > 0 {
 			return pickHighest(player, nonWinners, func(c *Card) int { return g.cardPoints(c) })
 		}
@@ -640,17 +640,6 @@ func (g *Klaverjas) cpuPlaySmart(playerIdx int, valid []int) int {
 	return pickLowest(player, valid, func(c *Card) int {
 		return g.cardPoints(c)*100 + g.klaverjasRank(c)
 	})
-}
-
-// klaverjasFilter 述語を満たすインデックスを抽出する。
-func klaverjasFilter(indices []int, pred func(int) bool) []int {
-	var out []int
-	for _, idx := range indices {
-		if pred(idx) {
-			out = append(out, idx)
-		}
-	}
-	return out
 }
 
 // --- Hint ---

--- a/internal/domain/KnockoutWhist.go
+++ b/internal/domain/KnockoutWhist.go
@@ -491,24 +491,13 @@ func (g *KnockoutWhist) cpuPlaySmart(playerIdx int, valid []int) int {
 	}
 	winnerIdx := g.trickWinner()
 	topRank := g.trickTopRank(winnerIdx)
-	winners := knockoutFilter(valid, func(idx int) bool { return g.knockoutRank(player.GetCard(idx)) > topRank })
+	winners := filterIndices(valid, func(idx int) bool { return g.knockoutRank(player.GetCard(idx)) > topRank })
 	if len(winners) > 0 {
 		// 最小コストで勝てる札。
 		return pickLowest(player, winners, func(c *Card) int { return g.knockoutRank(c) })
 	}
 	// 勝てない: 最弱札を捨てる。
 	return pickLowest(player, valid, func(c *Card) int { return g.knockoutRank(c) })
-}
-
-// knockoutFilter 述語を満たすインデックスを抽出する。
-func knockoutFilter(indices []int, pred func(int) bool) []int {
-	var out []int
-	for _, idx := range indices {
-		if pred(idx) {
-			out = append(out, idx)
-		}
-	}
-	return out
 }
 
 // --- Hint ---

--- a/internal/domain/Koenigrufen.go
+++ b/internal/domain/Koenigrufen.go
@@ -1091,7 +1091,7 @@ func (g *Koenigrufen) trumpFollowIndices(player *KoenigrufenPlayer, highestTrump
 	if len(trumps) == 0 {
 		return g.allIndices(player) // 切り札なし → 任意の札
 	}
-	higher := koenigrufenFilter(trumps, func(idx int) bool {
+	higher := filterIndices(trumps, func(idx int) bool {
 		return koenigrufenTrumpValue(player.GetCard(idx)) > highestTrump
 	})
 	if len(higher) > 0 {
@@ -1110,7 +1110,7 @@ func (g *Koenigrufen) suitFollowIndices(player *KoenigrufenPlayer, led, highestT
 	if len(trumps) == 0 {
 		return g.allIndices(player) // ボイド + 切り札なし → 任意
 	}
-	higher := koenigrufenFilter(trumps, func(idx int) bool {
+	higher := filterIndices(trumps, func(idx int) bool {
 		return koenigrufenTrumpValue(player.GetCard(idx)) > highestTrump
 	})
 	if highestTrump > 0 && len(higher) > 0 {
@@ -1324,7 +1324,7 @@ func (g *Koenigrufen) cpuPlaySmart(playerIdx int, valid []int) int {
 	winCard := g.currentTrick[g.indexInTrick(winnerIdx)].Card
 	winnerSide := g.isDeclarerSide(winnerIdx)
 	mySide := g.isDeclarerSide(playerIdx)
-	winners := koenigrufenFilter(valid, func(idx int) bool {
+	winners := filterIndices(valid, func(idx int) bool {
 		return koenigrufenWinRank(p.GetCard(idx), led) > koenigrufenWinRank(winCard, led)
 	})
 	if winnerSide == mySide {
@@ -1557,17 +1557,6 @@ func koenigrufenValidBid(bid KoenigrufenBid) bool {
 // koenigrufenValidBidVal bid が定義済みの入札値 (Pass 含む) か。
 func koenigrufenValidBidVal(bid KoenigrufenBid) bool {
 	return bid >= KoenigrufenBidPass && bid <= KoenigrufenBidRufer
-}
-
-// koenigrufenFilter 述語を満たすインデックスを抽出する。
-func koenigrufenFilter(indices []int, pred func(int) bool) []int {
-	var out []int
-	for _, idx := range indices {
-		if pred(idx) {
-			out = append(out, idx)
-		}
-	}
-	return out
 }
 
 // --- State getters / setters ---

--- a/internal/domain/Loo.go
+++ b/internal/domain/Loo.go
@@ -704,23 +704,13 @@ func (g *Loo) cpuPlaySmart(playerIdx int, valid []int) int {
 	}
 	winnerIdx := g.trickWinner()
 	top := g.trickTopRank(winnerIdx)
-	winners := looFilter(valid, func(idx int) bool { return g.looRank(player.GetCard(idx)) > top })
+	winners := filterIndices(valid, func(idx int) bool { return g.looRank(player.GetCard(idx)) > top })
 	if len(winners) > 0 {
 		// 勝てるなら最小の勝ち札で勝つ。
 		return pickLowest(player, winners, func(c *Card) int { return g.looRank(c) })
 	}
 	// 勝てない: 最小の札を捨てる。
 	return pickLowest(player, valid, func(c *Card) int { return g.looRank(c) })
-}
-
-func looFilter(indices []int, pred func(int) bool) []int {
-	var out []int
-	for _, idx := range indices {
-		if pred(idx) {
-			out = append(out, idx)
-		}
-	}
-	return out
 }
 
 // --- Hint ---

--- a/internal/domain/Manille.go
+++ b/internal/domain/Manille.go
@@ -464,10 +464,10 @@ func (g *Manille) cpuPlaySmart(playerIdx int, valid []int) int {
 	for _, tc := range g.currentTrick {
 		trickPts += manilleCardPoints(tc.Card)
 	}
-	winners := manilleFilter(valid, func(idx int) bool { return g.manilleRank(player.GetCard(idx)) > topRank })
+	winners := filterIndices(valid, func(idx int) bool { return g.manilleRank(player.GetCard(idx)) > topRank })
 	if partnerWinning {
 		// 味方が勝っている: 得点の高い札を渡す。
-		nonWinners := manilleFilter(valid, func(idx int) bool { return g.manilleRank(player.GetCard(idx)) < topRank })
+		nonWinners := filterIndices(valid, func(idx int) bool { return g.manilleRank(player.GetCard(idx)) < topRank })
 		if len(nonWinners) > 0 {
 			return pickHighest(player, nonWinners, func(c *Card) int { return manilleCardPoints(c) })
 		}
@@ -479,17 +479,6 @@ func (g *Manille) cpuPlaySmart(playerIdx int, valid []int) int {
 	return pickLowest(player, valid, func(c *Card) int {
 		return manilleCardPoints(c)*100 + g.manilleRank(c)
 	})
-}
-
-// manilleFilter 述語を満たすインデックスを抽出する。
-func manilleFilter(indices []int, pred func(int) bool) []int {
-	var out []int
-	for _, idx := range indices {
-		if pred(idx) {
-			out = append(out, idx)
-		}
-	}
-	return out
 }
 
 // --- Hint ---

--- a/internal/domain/Marias.go
+++ b/internal/domain/Marias.go
@@ -514,24 +514,13 @@ func (g *Marias) cpuPlaySmart(playerIdx int, valid []int) int {
 	for _, tc := range g.currentTrick {
 		trickPts += mariasCardPoints(tc.Card)
 	}
-	winners := mariasFilter(valid, func(idx int) bool { return g.mariasRank(player.GetCard(idx)) > topRank })
+	winners := filterIndices(valid, func(idx int) bool { return g.mariasRank(player.GetCard(idx)) > topRank })
 	if trickPts > 0 && len(winners) > 0 {
 		return pickLowest(player, winners, func(c *Card) int { return g.mariasRank(c) })
 	}
 	return pickLowest(player, valid, func(c *Card) int {
 		return mariasCardPoints(c)*100 + g.mariasRank(c)
 	})
-}
-
-// mariasFilter 述語を満たすインデックスを抽出する。
-func mariasFilter(indices []int, pred func(int) bool) []int {
-	var out []int
-	for _, idx := range indices {
-		if pred(idx) {
-			out = append(out, idx)
-		}
-	}
-	return out
 }
 
 // --- Hint ---

--- a/internal/domain/Nap.go
+++ b/internal/domain/Nap.go
@@ -565,7 +565,7 @@ func (g *Nap) cpuPlaySmart(playerIdx int, valid []int) int {
 	}
 	winnerIdx := g.trickWinner()
 	topRank := g.trickTopRank(winnerIdx)
-	winners := napFilter(valid, func(idx int) bool { return g.napRank(player.GetCard(idx)) > topRank })
+	winners := filterIndices(valid, func(idx int) bool { return g.napRank(player.GetCard(idx)) > topRank })
 	// 宣言者は勝ちたい; 防御は宣言者が勝っているトリックを奪いたい。
 	declarerWinning := winnerIdx == g.declarerIdx
 	wantWin := isDeclarer || !declarerWinning
@@ -573,17 +573,6 @@ func (g *Nap) cpuPlaySmart(playerIdx int, valid []int) int {
 		return pickLowest(player, winners, func(c *Card) int { return g.napRank(c) })
 	}
 	return pickLowest(player, valid, func(c *Card) int { return g.napRank(c) })
-}
-
-// napFilter 述語を満たすインデックスを抽出する。
-func napFilter(indices []int, pred func(int) bool) []int {
-	var out []int
-	for _, idx := range indices {
-		if pred(idx) {
-			out = append(out, idx)
-		}
-	}
-	return out
 }
 
 // --- Hint ---

--- a/internal/domain/Ombre.go
+++ b/internal/domain/Ombre.go
@@ -1015,7 +1015,7 @@ func (g *Ombre) cpuPlaySmart(playerIdx int, valid []int) int {
 		return g.minByStrength(player, valid)
 	}
 
-	winners := ombreFilter(follows, func(idx int) bool {
+	winners := filterIndices(follows, func(idx int) bool {
 		return ombreCardStrength(player.GetCard(idx), trump) > topStr
 	})
 
@@ -1054,17 +1054,6 @@ func (g *Ombre) maxByStrength(player *OmbrePlayer, indices []int) int {
 		}
 	}
 	return best
-}
-
-// ombreFilter 述語を満たすインデックスを抽出する。
-func ombreFilter(indices []int, pred func(int) bool) []int {
-	var out []int
-	for _, idx := range indices {
-		if pred(idx) {
-			out = append(out, idx)
-		}
-	}
-	return out
 }
 
 // --- Hint ---

--- a/internal/domain/Preference.go
+++ b/internal/domain/Preference.go
@@ -592,23 +592,12 @@ func (g *Preference) cpuPlaySmart(playerIdx int, valid []int) int {
 	}
 	winnerIdx := g.trickWinner()
 	topRank := g.trickTopRank(winnerIdx)
-	winners := preferenceFilter(valid, func(idx int) bool { return g.preferenceRank(player.GetCard(idx)) > topRank })
+	winners := filterIndices(valid, func(idx int) bool { return g.preferenceRank(player.GetCard(idx)) > topRank })
 	wantWin := isDeclarer != misere
 	if wantWin && len(winners) > 0 {
 		return pickLowest(player, winners, func(c *Card) int { return g.preferenceRank(c) })
 	}
 	return pickLowest(player, valid, func(c *Card) int { return g.preferenceRank(c) })
-}
-
-// preferenceFilter 述語を満たすインデックスを抽出する。
-func preferenceFilter(indices []int, pred func(int) bool) []int {
-	var out []int
-	for _, idx := range indices {
-		if pred(idx) {
-			out = append(out, idx)
-		}
-	}
-	return out
 }
 
 // --- Hint ---

--- a/internal/domain/Scarto.go
+++ b/internal/domain/Scarto.go
@@ -748,7 +748,7 @@ func (g *Scarto) trumpFollowIndices(player *ScartoPlayer, highestTrump int) []in
 	if len(trumps) == 0 {
 		return g.nonExcuseIndices(player)
 	}
-	higher := scartoFilter(trumps, func(idx int) bool {
+	higher := filterIndices(trumps, func(idx int) bool {
 		c := player.GetCard(idx)
 		return c != nil && c.GetValue() > highestTrump
 	})
@@ -768,7 +768,7 @@ func (g *Scarto) suitFollowIndices(player *ScartoPlayer, led, highestTrump int) 
 	if len(trumps) == 0 {
 		return g.nonExcuseIndices(player)
 	}
-	higher := scartoFilter(trumps, func(idx int) bool {
+	higher := filterIndices(trumps, func(idx int) bool {
 		c := player.GetCard(idx)
 		return c != nil && c.GetValue() > highestTrump
 	})
@@ -928,7 +928,7 @@ func (g *Scarto) cpuPlaySmart(playerIdx int, valid []int) int {
 		return g.minByPoints(playerIdx, valid)
 	}
 	winCard := g.currentTrick[pos].Card
-	winners := scartoFilter(valid, func(idx int) bool {
+	winners := filterIndices(valid, func(idx int) bool {
 		c := p.GetCard(idx)
 		return c != nil && scartoWinRank(c, led) > scartoWinRank(winCard, led)
 	})
@@ -1118,17 +1118,6 @@ func scartoCardStr(c *Card) string {
 		s = "?"
 	}
 	return fmt.Sprintf("%s%d", s, c.GetValue())
-}
-
-// scartoFilter 述語を満たすインデックスを抽出する。
-func scartoFilter(indices []int, pred func(int) bool) []int {
-	var out []int
-	for _, idx := range indices {
-		if pred(idx) {
-			out = append(out, idx)
-		}
-	}
-	return out
 }
 
 // scartoAppendUnique スライスに未含有のインデックスを追加する。

--- a/internal/domain/Sedma.go
+++ b/internal/domain/Sedma.go
@@ -376,7 +376,7 @@ func (g *Sedma) cpuPlaySmart(playerIdx int, valid []int) int {
 	}
 	currentWinner := g.trickWinner()
 	partnerWinning := SedmaTeamOf(currentWinner) == SedmaTeamOf(playerIdx) && currentWinner != playerIdx
-	captures := sedmaFilter(valid, func(idx int) bool {
+	captures := filterIndices(valid, func(idx int) bool {
 		v := player.GetCard(idx).GetValue()
 		return v == leadRank || v == SedmaWildValue
 	})
@@ -386,7 +386,7 @@ func (g *Sedma) cpuPlaySmart(playerIdx int, valid []int) int {
 	}
 	// ポイントがあり奪取できるなら、まず同ランク、無ければ 7 で奪取。
 	if trickPts > 0 && len(captures) > 0 {
-		nonWild := sedmaFilter(captures, func(idx int) bool { return player.GetCard(idx).GetValue() != SedmaWildValue })
+		nonWild := filterIndices(captures, func(idx int) bool { return player.GetCard(idx).GetValue() != SedmaWildValue })
 		if len(nonWild) > 0 {
 			return nonWild[0]
 		}
@@ -402,17 +402,6 @@ func sedmaLeadCost(c *Card) int {
 		return 100 // 7 は最後まで温存
 	}
 	return sedmaCardPoints(c)*10 + sedmaSortRank(c.GetValue())
-}
-
-// sedmaFilter 述語を満たすインデックスを抽出する。
-func sedmaFilter(indices []int, pred func(int) bool) []int {
-	var out []int
-	for _, idx := range indices {
-		if pred(idx) {
-			out = append(out, idx)
-		}
-	}
-	return out
 }
 
 // --- Hint ---

--- a/internal/domain/Sheepshead.go
+++ b/internal/domain/Sheepshead.go
@@ -1117,12 +1117,12 @@ func (g *Sheepshead) cpuPlaySmart(playerIdx int, valid []int) int {
 		})
 	}
 
-	winners := sheepsheadFilter(follows, func(idx int) bool {
+	winners := filterIndices(follows, func(idx int) bool {
 		return sheepsheadStrength(player.GetCard(idx)) > topStrength
 	})
 
 	if partnerWinning {
-		nonWinners := sheepsheadFilter(follows, func(idx int) bool {
+		nonWinners := filterIndices(follows, func(idx int) bool {
 			return sheepsheadStrength(player.GetCard(idx)) < topStrength
 		})
 		if len(nonWinners) > 0 {
@@ -1145,17 +1145,6 @@ func (g *Sheepshead) cpuPlaySmart(playerIdx int, valid []int) int {
 // CPU はチーム構成を把握しているものとして扱う (簡易 AI)。
 func (g *Sheepshead) cpuSameTeam(a, b int) bool {
 	return g.isPickerTeam(a) == g.isPickerTeam(b)
-}
-
-// sheepsheadFilter 述語を満たすインデックスを抽出する。
-func sheepsheadFilter(indices []int, pred func(int) bool) []int {
-	var out []int
-	for _, idx := range indices {
-		if pred(idx) {
-			out = append(out, idx)
-		}
-	}
-	return out
 }
 
 // --- JSON ---

--- a/internal/domain/SoloWhist.go
+++ b/internal/domain/SoloWhist.go
@@ -590,23 +590,12 @@ func (g *SoloWhist) cpuPlaySmart(playerIdx int, valid []int) int {
 	}
 	winnerIdx := g.trickWinner()
 	topRank := g.trickTopRank(winnerIdx)
-	winners := soloWhistFilter(valid, func(idx int) bool { return g.soloWhistRank(player.GetCard(idx)) > topRank })
+	winners := filterIndices(valid, func(idx int) bool { return g.soloWhistRank(player.GetCard(idx)) > topRank })
 	wantWin := isDeclarer != misere // 宣言者(非Misère)は勝ちたい; 防御は宣言者を負かしたい
 	if wantWin && len(winners) > 0 {
 		return pickLowest(player, winners, func(c *Card) int { return g.soloWhistRank(c) })
 	}
 	return pickLowest(player, valid, func(c *Card) int { return g.soloWhistRank(c) })
-}
-
-// soloWhistFilter 述語を満たすインデックスを抽出する。
-func soloWhistFilter(indices []int, pred func(int) bool) []int {
-	var out []int
-	for _, idx := range indices {
-		if pred(idx) {
-			out = append(out, idx)
-		}
-	}
-	return out
 }
 
 // --- Hint ---

--- a/internal/domain/SpoilFive.go
+++ b/internal/domain/SpoilFive.go
@@ -513,24 +513,13 @@ func (g *SpoilFive) cpuPlaySmart(playerIdx int, valid []int) int {
 	}
 	winnerIdx := g.trickWinner()
 	topRank := g.trickTopRank(winnerIdx)
-	winners := spoilFilter(valid, func(idx int) bool { return g.spoilRank(player.GetCard(idx)) > topRank })
+	winners := filterIndices(valid, func(idx int) bool { return g.spoilRank(player.GetCard(idx)) > topRank })
 	if len(winners) > 0 {
 		// 最小コストで勝てる札。
 		return pickLowest(player, winners, func(c *Card) int { return g.spoilRank(c) })
 	}
 	// 勝てない: 最弱札を捨てる。
 	return pickLowest(player, valid, func(c *Card) int { return g.spoilRank(c) })
-}
-
-// spoilFilter 述語を満たすインデックスを抽出する。
-func spoilFilter(indices []int, pred func(int) bool) []int {
-	var out []int
-	for _, idx := range indices {
-		if pred(idx) {
-			out = append(out, idx)
-		}
-	}
-	return out
 }
 
 // --- Hint ---

--- a/internal/domain/Sueca.go
+++ b/internal/domain/Sueca.go
@@ -487,9 +487,9 @@ func (g *Sueca) cpuPlaySmart(playerIdx int, valid []int) int {
 			return suecaCardPoints(c.GetValue())*100 + suecaStrength(c.GetValue())
 		})
 	}
-	winners := suecaFilter(follows, func(idx int) bool { return g.suecaRank(player.GetCard(idx)) > topRank })
+	winners := filterIndices(follows, func(idx int) bool { return g.suecaRank(player.GetCard(idx)) > topRank })
 	if partnerWinning {
-		nonWinners := suecaFilter(follows, func(idx int) bool { return g.suecaRank(player.GetCard(idx)) < topRank })
+		nonWinners := filterIndices(follows, func(idx int) bool { return g.suecaRank(player.GetCard(idx)) < topRank })
 		if len(nonWinners) > 0 {
 			return pickHighest(player, nonWinners, func(c *Card) int {
 				return suecaCardPoints(c.GetValue())*100 - suecaStrength(c.GetValue())
@@ -503,17 +503,6 @@ func (g *Sueca) cpuPlaySmart(playerIdx int, valid []int) int {
 	return pickLowest(player, follows, func(c *Card) int {
 		return suecaCardPoints(c.GetValue())*100 + suecaStrength(c.GetValue())
 	})
-}
-
-// suecaFilter 述語を満たすインデックスを抽出する。
-func suecaFilter(indices []int, pred func(int) bool) []int {
-	var out []int
-	for _, idx := range indices {
-		if pred(idx) {
-			out = append(out, idx)
-		}
-	}
-	return out
 }
 
 // --- Hint ---

--- a/internal/domain/Tressette.go
+++ b/internal/domain/Tressette.go
@@ -545,13 +545,13 @@ func (g *Tressette) cpuPlaySmart(playerIdx int, valid []int) int {
 		})
 	}
 
-	winners := tressetteFilter(follows, func(idx int) bool {
+	winners := filterIndices(follows, func(idx int) bool {
 		return tressetteStrength(player.GetCard(idx).GetValue()) > topStrength
 	})
 
 	if partnerWinning {
 		// 味方が勝っている: 得点札を渡しつつ、無駄に上書きしない。
-		nonWinners := tressetteFilter(follows, func(idx int) bool {
+		nonWinners := filterIndices(follows, func(idx int) bool {
 			return tressetteStrength(player.GetCard(idx).GetValue()) < topStrength
 		})
 		if len(nonWinners) > 0 {
@@ -572,17 +572,6 @@ func (g *Tressette) cpuPlaySmart(playerIdx int, valid []int) int {
 	return pickLowest(player, follows, func(c *Card) int {
 		return tressetteThirds(c.GetValue())*100 + tressetteStrength(c.GetValue())
 	})
-}
-
-// tressetteFilter 述語を満たすインデックスを抽出する
-func tressetteFilter(indices []int, pred func(int) bool) []int {
-	var out []int
-	for _, idx := range indices {
-		if pred(idx) {
-			out = append(out, idx)
-		}
-	}
-	return out
 }
 
 // --- JSON ---

--- a/internal/domain/Tute.go
+++ b/internal/domain/Tute.go
@@ -591,9 +591,9 @@ func (g *Tute) cpuPlaySmart(playerIdx int, valid []int) int {
 			return tuteCardPoints(c.GetValue())*100 + tuteStrength(c.GetValue())
 		})
 	}
-	winners := tuteFilter(follows, func(idx int) bool { return g.tuteRank(player.GetCard(idx)) > topRank })
+	winners := filterIndices(follows, func(idx int) bool { return g.tuteRank(player.GetCard(idx)) > topRank })
 	if partnerWinning {
-		nonWinners := tuteFilter(follows, func(idx int) bool { return g.tuteRank(player.GetCard(idx)) < topRank })
+		nonWinners := filterIndices(follows, func(idx int) bool { return g.tuteRank(player.GetCard(idx)) < topRank })
 		if len(nonWinners) > 0 {
 			return pickHighest(player, nonWinners, func(c *Card) int {
 				return tuteCardPoints(c.GetValue())*100 - tuteStrength(c.GetValue())
@@ -607,17 +607,6 @@ func (g *Tute) cpuPlaySmart(playerIdx int, valid []int) int {
 	return pickLowest(player, follows, func(c *Card) int {
 		return tuteCardPoints(c.GetValue())*100 + tuteStrength(c.GetValue())
 	})
-}
-
-// tuteFilter 述語を満たすインデックスを抽出する。
-func tuteFilter(indices []int, pred func(int) bool) []int {
-	var out []int
-	for _, idx := range indices {
-		if pred(idx) {
-			out = append(out, idx)
-		}
-	}
-	return out
 }
 
 // --- Hint ---

--- a/internal/domain/TwentyNine.go
+++ b/internal/domain/TwentyNine.go
@@ -599,7 +599,7 @@ func (g *TwentyNine) cpuPlaySmart(playerIdx int, valid []int) int {
 	winnerIdx := g.trickWinner()
 	topRank := g.trickTopRank(winnerIdx)
 	partnerWinning := TwentyNineTeamOf(winnerIdx) == TwentyNineTeamOf(playerIdx) && winnerIdx != playerIdx
-	winners := twentyNineFilter(valid, func(idx int) bool { return g.twentyNineRank(player.GetCard(idx)) > topRank })
+	winners := filterIndices(valid, func(idx int) bool { return g.twentyNineRank(player.GetCard(idx)) > topRank })
 	if partnerWinning {
 		// 味方が勝っている: 得点札を渡す。
 		return pickHighest(player, valid, func(c *Card) int { return twentyNineCardPoints(c) })
@@ -608,17 +608,6 @@ func (g *TwentyNine) cpuPlaySmart(playerIdx int, valid []int) int {
 		return pickLowest(player, winners, func(c *Card) int { return g.twentyNineRank(c) })
 	}
 	return pickLowest(player, valid, func(c *Card) int { return twentyNineCardPoints(c)*100 + g.twentyNineRank(c) })
-}
-
-// twentyNineFilter 述語を満たすインデックスを抽出する。
-func twentyNineFilter(indices []int, pred func(int) bool) []int {
-	var out []int
-	for _, idx := range indices {
-		if pred(idx) {
-			out = append(out, idx)
-		}
-	}
-	return out
 }
 
 // --- Hint ---

--- a/internal/domain/Tysiac.go
+++ b/internal/domain/Tysiac.go
@@ -877,7 +877,7 @@ func (g *Tysiac) cpuPlaySmart(playerIdx int, valid []int) int {
 	for _, tc := range g.currentTrick {
 		trickPts += tysiacCardPoints(tc.Card)
 	}
-	winners := tysiacFilter(valid, func(idx int) bool { return g.tysiacRank(player.GetCard(idx)) > topRank })
+	winners := filterIndices(valid, func(idx int) bool { return g.tysiacRank(player.GetCard(idx)) > topRank })
 	if trickPts > 0 && len(winners) > 0 {
 		return pickLowest(player, winners, func(c *Card) int { return g.tysiacRank(c) })
 	}
@@ -906,17 +906,6 @@ func (g *Tysiac) cpuMarriageLead(playerIdx int, valid []int) int {
 		}
 	}
 	return best
-}
-
-// tysiacFilter 述語を満たすインデックスを抽出する。
-func tysiacFilter(indices []int, pred func(int) bool) []int {
-	var out []int
-	for _, idx := range indices {
-		if pred(idx) {
-			out = append(out, idx)
-		}
-	}
-	return out
 }
 
 // --- Hint ---

--- a/internal/domain/Ulti.go
+++ b/internal/domain/Ulti.go
@@ -640,7 +640,7 @@ func (g *Ulti) getValidPlayIndices(playerIdx int) []int {
 	}
 	led := g.currentTrick[0].Card.GetDesign()
 	// リードスートを持っていれば必ず従う。
-	follows := ultiFilter(all, func(idx int) bool {
+	follows := filterIndices(all, func(idx int) bool {
 		return player.GetCard(idx).GetDesign() == led
 	})
 	if len(follows) > 0 {
@@ -655,7 +655,7 @@ func (g *Ulti) getValidPlayIndices(playerIdx int) []int {
 	if !hasTrumpInTrick {
 		return all
 	}
-	beating := ultiFilter(all, func(idx int) bool {
+	beating := filterIndices(all, func(idx int) bool {
 		c := player.GetCard(idx)
 		return c.GetDesign() == g.trumpSuit && ultiTrickRank(c.GetValue()) > highestTrumpRank
 	})
@@ -878,17 +878,6 @@ func ultiHasTrump(contract UltiContract, trump int) bool {
 	return ultiContractNeedsTrump(contract) && ultiValidSuit(trump)
 }
 
-// ultiFilter 述語を満たすインデックスを抽出する。
-func ultiFilter(indices []int, pred func(int) bool) []int {
-	var out []int
-	for _, idx := range indices {
-		if pred(idx) {
-			out = append(out, idx)
-		}
-	}
-	return out
-}
-
 // indexOfPlayerInTrick currentTrick 内で playerIdx の札の位置を返す (-1=なし)。
 func (g *Ulti) indexOfPlayerInTrick(playerIdx int) int {
 	return indexOfPlayerInTrick(g.currentTrick, playerIdx)
@@ -934,10 +923,10 @@ func (g *Ulti) cpuPlaySmart(playerIdx int, valid []int) int {
 	winnerIdx := g.trickWinner()
 	winCard := g.currentTrick[g.indexOfPlayerInTrick(winnerIdx)].Card
 	declWinning := winnerIdx == g.declarerIdx
-	winners := ultiFilter(valid, func(idx int) bool {
+	winners := filterIndices(valid, func(idx int) bool {
 		return g.ultiBeats(g.players[playerIdx].GetCard(idx), winCard, g.currentTrick[0].Card.GetDesign())
 	})
-	nonWinners := ultiFilter(valid, func(idx int) bool {
+	nonWinners := filterIndices(valid, func(idx int) bool {
 		return !g.ultiBeats(g.players[playerIdx].GetCard(idx), winCard, g.currentTrick[0].Card.GetDesign())
 	})
 

--- a/internal/domain/slice_helpers.go
+++ b/internal/domain/slice_helpers.go
@@ -109,6 +109,26 @@ func recycleDiscardToDraw(discard, draw *[]*Card) {
 	*draw = recycled
 }
 
+// filterIndices returns the elements of indices for which keep reports true.
+//
+// Consolidates 26 byte-identical per-game copies that differed only in name
+// (koenigrufenFilter, gzFilter, twentyNineFilter, …). Being spelled differently
+// per game is exactly why a name-based search never grouped them and each new
+// game grew another one -- see issue #5361.
+//
+// Returns nil rather than an empty slice when nothing matches, matching what
+// the copies did (`var out []int` plus append), so callers that distinguish
+// nil from empty are unaffected. The input is never modified.
+func filterIndices(indices []int, keep func(int) bool) []int {
+	var out []int
+	for _, idx := range indices {
+		if keep(idx) {
+			out = append(out, idx)
+		}
+	}
+	return out
+}
+
 // nextIndexWhere returns the first index after from, wrapping, whose element
 // satisfies ok -- or from itself when none does. Callers index with the result,
 // so it never returns -1. Two "next active seat" variants shared this shape.

--- a/internal/domain/slice_helpers_internal_test.go
+++ b/internal/domain/slice_helpers_internal_test.go
@@ -31,3 +31,42 @@ func TestCollectValidIndices(t *testing.T) {
 		})
 	}
 }
+
+// filterIndices replaced 26 byte-identical per-game copies (koenigrufenFilter,
+// gzFilter, twentyNineFilter, …). They differed only in name, which is why a
+// name-based search never grouped them — see issue #5361.
+func TestFilterIndices(t *testing.T) {
+	tests := []struct {
+		name    string
+		indices []int
+		pred    func(int) bool
+		want    []int
+	}{
+		{"keeps the matching indices", []int{1, 2, 3, 4}, func(i int) bool { return i%2 == 0 }, []int{2, 4}},
+		{"keeps everything when the predicate always holds", []int{7, 8}, func(int) bool { return true }, []int{7, 8}},
+		// nil, not an empty slice: the copies all started from `var out []int`
+		// and appended, so a caller that distinguishes the two keeps working.
+		{"returns nil when nothing matches", []int{1, 3}, func(i int) bool { return i%2 == 0 }, nil},
+		{"returns nil for an empty input", []int{}, func(int) bool { return true }, nil},
+		{"returns nil for a nil input", nil, func(int) bool { return true }, nil},
+		{"preserves order and duplicates", []int{5, 1, 5, 2}, func(i int) bool { return i != 2 }, []int{5, 1, 5}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := filterIndices(tt.indices, tt.pred)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("filterIndices() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// The input must not be modified: several callers pass a slice they keep using
+// (a hand's valid-index list) and then filter it again with a second predicate.
+func TestFilterIndices_DoesNotMutateInput(t *testing.T) {
+	in := []int{1, 2, 3, 4}
+	_ = filterIndices(in, func(i int) bool { return i > 2 })
+	if want := []int{1, 2, 3, 4}; !reflect.DeepEqual(in, want) {
+		t.Errorf("input mutated: got %v, want %v", in, want)
+	}
+}


### PR DESCRIPTION
本文がバイト単位で一致する `filter []int by predicate` が 26 個あり、違うのは**名前だけ**だった。

```go
// internal/domain/Koenigrufen.go
func koenigrufenFilter(indices []int, pred func(int) bool) []int {
	var out []int
	for _, idx := range indices {
		if pred(idx) { out = append(out, idx) }
	}
	return out
}

// internal/domain/GongZhu.go — 1 文字も違わない
func gzFilter(indices []int, pred func(int) bool) []int { ... }
```

同型が `twentyNineFilter` / `soloWhistFilter` / `sheepsheadFilter` ほか計 26。**名前が違うので名前ベースの探索では集まらず**、#5185 の DRY 一掃（-7,089 行）が取り逃したクラスです。

## 受け皿は既存

`internal/domain/slice_helpers.go`（**build タグ無し** = 全 Worker を含む全ビルドに入る）に汎用ヘルパが 11 個あります。filter 相当が未実装であることを、名前ではなく**引数の形** `[]int, func(int) bool` で全域検索して確認しました。3 つ目の綴りを足す事故は避けています。

戻り値は空スライスではなく **nil**。26 個の複製が `var out []int` + append だったので、nil と空を区別する呼び出し側の挙動を変えません（テストで固定）。

## 一括置換は compute → validate → write

全ファイルの変換をメモリ上で先に計算し、**削除定義数 26 と置換呼び出し数 47 が事前に数えた期待値と一致したときだけ書き込む**形にしました。一致しなければ何も書かずに中止します。

```
削除した定義=26 (期待26)  置換した呼び出し=47 (期待47)  変更ファイル=26
書き込み完了
```

「見つけたか」ではなく「結果が正しいか」を検査する形です。置換後に残存 `*Filter(` が 0 件であることも確認しています。

## 検証

| 項目 | 結果 |
|---|---|
| `gofmt` / `goimports` 差分 | 0 |
| `go build ./...` | 通過 |
| `go vet -tags test ./internal/domain/` | 通過 |
| `go test -tags test ./internal/domain/` | 通過 (202s) |
| `golangci-lint run ./internal/domain/...` | 0 issues |
| 6 worker の `GOOS=js GOARCH=wasm` | すべて通過 |
| 残存する `*Filter(` 呼び出し | 0 件 |

Worker ビルドを 6 種すべて確認したのは、`slice_helpers.go` が**無タグで全ワーカーに入る**ためです。ここにカテゴリ限定の型を持ち込むと 5 Worker が落ちる、という事故が過去にありました。今回のヘルパは `[]int` と関数だけを扱うので該当しません。

## スコープ

正味 **-226 行**。#5361 が挙げた 99 グループのうち**最大クラスタ 1 つぶん**です。バッチの合意（大物は完走ではなく最小スコープで一区切り）に従い、残り 95 グループ（`Output` ×24 / `NextRound` ×22 / `*Dispatch` ×14 / ソリティア `Exec` ×6 ほか）はフォローアップ issue に分割します。

`Refs`（`Closes` ではない）にしているのはそのためです。

Refs #5361