### PR TITLE
feat(cli): add an examples section to game help, wired for six games

### DIFF
--- a/internal/i18n/locales/en/blackjack.json
+++ b/internal/i18n/locales/en/blackjack.json
@@ -67,5 +67,8 @@
   "payoutRef.insurance": "Insurance (2:1)",
   "payoutRef.push": "Push (tie: bet returned)",
   "payoutRef.surrender": "Surrender (half the bet returned)",
-  "payoutRef.bust": "Bust (over 21: lose)"
+  "payoutRef.bust": "Bust (over 21: lose)",
+  "helpExampleBet": "  b 100                bet 100 chips and deal",
+  "helpExampleHit": "  h                    draw one more card",
+  "helpExampleStand": "  s                    stand and pass to the dealer"
 }

--- a/internal/i18n/locales/en/common.json
+++ b/internal/i18n/locales/en/common.json
@@ -6,6 +6,7 @@
   "gameCommands": "Game commands:",
   "settings": "Settings:",
   "session": "Session:",
+  "examples": "Examples:",
   "helpEntry": "  help, ?              show this help",
   "resetEntry": "  r                    reset game",
   "quitEntry": "  q, quit, exit        quit",

--- a/internal/i18n/locales/en/daifugo.json
+++ b/internal/i18n/locales/en/daifugo.json
@@ -32,5 +32,7 @@
   "promptSevenPass": "[7-pass] choose a card to pass (p [index])",
   "promptTenDiscard": "[10-discard] choose a card to discard (p [index])",
   "promptQueenBomber": "[Queen bomber] enter the rank to remove (p [1-13])",
-  "promptPlay": "p [index...] to play cards / p to pass"
+  "promptPlay": "p [index...] to play cards / p to pass",
+  "helpExamplePlay": "  p 0 2                play hand cards 0 and 2 as a pair",
+  "helpExamplePass": "  p                    pass (no index)"
 }

--- a/internal/i18n/locales/en/gofish.json
+++ b/internal/i18n/locales/en/gofish.json
@@ -17,5 +17,6 @@
   "promptCurrentTurn": "{{name}}'s turn",
   "promptHumanHelp": "ask <opponent> <rank> to request",
   "knownRanks": "{{name}} known ranks: {{ranks}}",
-  "knownRanksLegend": "(* = a rank you also hold = a strong ask target)"
+  "knownRanksLegend": "(* = a rank you also hold = a strong ask target)",
+  "helpExampleAsk": "  ask 1 7              ask player 1 for a 7"
 }

--- a/internal/i18n/locales/en/hearts.json
+++ b/internal/i18n/locales/en/hearts.json
@@ -29,5 +29,7 @@
   "hintCard": "[HINT: {{cards}} ({{reason}})]",
   "hintReasonPassHighRisk": "pass high-risk cards",
   "hintReasonDiscardQueenSpades": "discard the Q♠",
-  "hintReasonDiscardHearts": "discard hearts"
+  "hintReasonDiscardHearts": "discard hearts",
+  "helpExamplePass": "  pass 0 3 7           pass hand cards 0, 3 and 7",
+  "helpExamplePlay": "  p 0                  play hand card 0"
 }

--- a/internal/i18n/locales/en/klondike.json
+++ b/internal/i18n/locales/en/klondike.json
@@ -25,5 +25,8 @@
   "hintToFoundation": "foundation",
   "hintToTableau": "tableau column {{col}}",
   "hintLine": "Hint: {{from}} → {{to}}",
-  "autoCompleteReady": "Auto-complete is available (ac)"
+  "autoCompleteReady": "Auto-complete is available (ac)",
+  "helpExampleDraw": "  d                    draw one card from the stock",
+  "helpExampleMove": "  m w t 1              move waste to tableau column 1",
+  "helpExampleFound": "  m w f                move waste to a foundation"
 }

--- a/internal/i18n/locales/en/speed.json
+++ b/internal/i18n/locales/en/speed.json
@@ -13,5 +13,7 @@
   "promptStuck": "Stuck. Use flip to flip the center cards.",
   "promptStuckHelp": "Command: f / flip — both players flip a new card to break the deadlock",
   "winHuman": "You win!",
-  "winCpu": "CPU wins..."
+  "winCpu": "CPU wins...",
+  "helpExamplePlay": "  p 0 1                play hand card 0 onto pile 1",
+  "helpExampleFlip": "  f                    flip a new centre card when stuck"
 }

--- a/internal/i18n/locales/ja/blackjack.json
+++ b/internal/i18n/locales/ja/blackjack.json
@@ -67,5 +67,8 @@
   "payoutRef.insurance": "インシュランス (2:1)",
   "payoutRef.push": "プッシュ (引き分け: 返金)",
   "payoutRef.surrender": "サレンダー (ベットの半額返金)",
-  "payoutRef.bust": "バスト (21超過: 負け)"
+  "payoutRef.bust": "バスト (21超過: 負け)",
+  "helpExampleBet": "  b 100                100 チップ賭けて配る",
+  "helpExampleHit": "  h                    もう1枚引く",
+  "helpExampleStand": "  s                    スタンドしてディーラーの番へ"
 }

--- a/internal/i18n/locales/ja/common.json
+++ b/internal/i18n/locales/ja/common.json
@@ -6,6 +6,7 @@
   "gameCommands": "ゲームコマンド:",
   "settings": "設定:",
   "session": "セッション:",
+  "examples": "例:",
   "helpEntry": "  help, ?              このヘルプを表示",
   "resetEntry": "  r                    ゲームをリセット",
   "quitEntry": "  q, quit, exit        終了",

--- a/internal/i18n/locales/ja/daifugo.json
+++ b/internal/i18n/locales/ja/daifugo.json
@@ -32,5 +32,7 @@
   "promptSevenPass": "【7渡し】渡すカードを選択してください (p [インデックス])",
   "promptTenDiscard": "【10捨て】捨てるカードを選択してください (p [インデックス])",
   "promptQueenBomber": "【12ボンバー】除去するカードの数字を入力してください (p [1-13])",
-  "promptPlay": "p [インデックス...] でカードを出す / p でパス"
+  "promptPlay": "p [インデックス...] でカードを出す / p でパス",
+  "helpExamplePlay": "  p 0 2                手札の 0 と 2 を出す (ペア)",
+  "helpExamplePass": "  p                    パスする (添字なし)"
 }

--- a/internal/i18n/locales/ja/gofish.json
+++ b/internal/i18n/locales/ja/gofish.json
@@ -17,5 +17,6 @@
   "promptCurrentTurn": "{{name}}のターン",
   "promptHumanHelp": "ask <相手番号> <ランク> で要求",
   "knownRanks": "{{name}}の既知ランク: {{ranks}}",
-  "knownRanksLegend": "(* = あなたも持つランク = 有利な要求先)"
+  "knownRanksLegend": "(* = あなたも持つランク = 有利な要求先)",
+  "helpExampleAsk": "  ask 1 7              プレイヤー1に 7 を要求する"
 }

--- a/internal/i18n/locales/ja/hearts.json
+++ b/internal/i18n/locales/ja/hearts.json
@@ -29,5 +29,7 @@
   "hintCard": "[HINT: {{cards}} ({{reason}})]",
   "hintReasonPassHighRisk": "リスクの高いカードを渡す",
   "hintReasonDiscardQueenSpades": "Q♠を捨てるチャンス",
-  "hintReasonDiscardHearts": "ハートを捨てる"
+  "hintReasonDiscardHearts": "ハートを捨てる",
+  "helpExamplePass": "  pass 0 3 7           手札の 0/3/7 番を渡す",
+  "helpExamplePlay": "  p 0                  手札の 0 番を出す"
 }

--- a/internal/i18n/locales/ja/klondike.json
+++ b/internal/i18n/locales/ja/klondike.json
@@ -25,5 +25,8 @@
   "hintToFoundation": "ファンデーション",
   "hintToTableau": "タブロー列{{col}}",
   "hintLine": "ヒント: {{from}} → {{to}}",
-  "autoCompleteReady": "オートコンプリート可能です (ac)"
+  "autoCompleteReady": "オートコンプリート可能です (ac)",
+  "helpExampleDraw": "  d                    山札から1枚めくる",
+  "helpExampleMove": "  m w t 1              ウェイストから列1へ移す",
+  "helpExampleFound": "  m w f                ウェイストからファウンデーションへ"
 }

--- a/internal/i18n/locales/ja/speed.json
+++ b/internal/i18n/locales/ja/speed.json
@@ -13,5 +13,7 @@
   "promptStuck": "膠着状態です。flip コマンドでカードをめくってください。",
   "promptStuckHelp": "操作: f / flip → お互いが山札から新しいカードをめくり、膠着を解消します",
   "winHuman": "あなたの勝ちです！",
-  "winCpu": "CPUの勝ちです..."
+  "winCpu": "CPUの勝ちです...",
+  "helpExamplePlay": "  p 0 1                手札0を場札1へ重ねる",
+  "helpExampleFlip": "  f                    場札を1枚めくる (詰まったとき)"
 }

--- a/internal/infrastructure/ui/GameManager.go
+++ b/internal/infrastructure/ui/GameManager.go
@@ -121,6 +121,11 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewBlackJackCuiController,
 		CuiHelpSpec{
 			TitleKey: "blackjack.helpTitle",
+			ExampleKeys: []string{
+				"blackjack.helpExampleBet",
+				"blackjack.helpExampleHit",
+				"blackjack.helpExampleStand",
+			},
 			CommandKeys: []string{
 				"blackjack.helpBet",
 				"blackjack.helpHit",
@@ -167,7 +172,11 @@ var gameRegistry = []GameRegistryEntry{
 		},
 		controller.NewDaifugoCuiController,
 		CuiHelpSpec{
-			TitleKey:    "daifugo.helpTitle",
+			TitleKey: "daifugo.helpTitle",
+			ExampleKeys: []string{
+				"daifugo.helpExamplePlay",
+				"daifugo.helpExamplePass",
+			},
 			CommandKeys: []string{"daifugo.helpPlay", "daifugo.helpSort"},
 			SettingKeys: []string{"daifugo.helpSetDifficulty", "daifugo.helpSetJoker", "daifugo.helpSetRule"},
 		}),
@@ -388,7 +397,11 @@ var gameRegistry = []GameRegistryEntry{
 		},
 		controller.NewHeartsCuiController,
 		CuiHelpSpec{
-			TitleKey:          "hearts.helpTitle",
+			TitleKey: "hearts.helpTitle",
+			ExampleKeys: []string{
+				"hearts.helpExamplePass",
+				"hearts.helpExamplePlay",
+			},
 			CommandKeys:       []string{"hearts.helpPass", "hearts.helpPlay", "hearts.helpNext", "hearts.helpNextRound"},
 			ExtraCommandLines: []string{"  l                    action log"},
 			SettingKeys:       []string{"hearts.helpSetDifficulty", "hearts.helpSetLimit"},
@@ -411,6 +424,11 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewKlondikeCuiController,
 		CuiHelpSpec{
 			TitleKey: "klondike.helpTitle",
+			ExampleKeys: []string{
+				"klondike.helpExampleDraw",
+				"klondike.helpExampleMove",
+				"klondike.helpExampleFound",
+			},
 			CommandKeys: []string{
 				"klondike.helpDraw",
 				"klondike.helpMove",
@@ -785,7 +803,11 @@ var gameRegistry = []GameRegistryEntry{
 		},
 		controller.NewSpeedCuiController,
 		CuiHelpSpec{
-			TitleKey:    "speed.helpTitle",
+			TitleKey: "speed.helpTitle",
+			ExampleKeys: []string{
+				"speed.helpExamplePlay",
+				"speed.helpExampleFlip",
+			},
 			CommandKeys: []string{"speed.helpPlay", "speed.helpFlip", "speed.helpHint"},
 			SettingKeys: []string{"speed.helpSetDifficulty"},
 		}),
@@ -795,7 +817,10 @@ var gameRegistry = []GameRegistryEntry{
 		},
 		controller.NewGoFishCuiController,
 		CuiHelpSpec{
-			TitleKey:    "gofish.helpTitle",
+			TitleKey: "gofish.helpTitle",
+			ExampleKeys: []string{
+				"gofish.helpExampleAsk",
+			},
 			CommandKeys: []string{"gofish.helpAsk"},
 			SettingKeys: []string{"gofish.helpSetDifficulty"},
 		}),

--- a/internal/infrastructure/ui/help_text.go
+++ b/internal/infrastructure/ui/help_text.go
@@ -28,6 +28,15 @@ type CuiHelpSpec struct {
 	// ExtraSettingLines are literal lines appended after SettingKeys in the
 	// settings section. Used for settings not yet in i18n.
 	ExtraSettingLines []string
+	// ExampleKeys are i18n keys for a worked sequence of commands, in the order
+	// a player would type them. Optional: when empty the examples section
+	// (header + entries) is omitted entirely, so a game that supplies none
+	// renders exactly as it did before the section existed.
+	//
+	// The command tables above say what each command means; they do not say
+	// which one to type first, and with 318 games each carrying its own
+	// vocabulary that is the question a newcomer actually has (issue #5358).
+	ExampleKeys []string
 	// ResetOverride, when non-empty, replaces the default i18n.T("resetEntry")
 	// line in the session section. Used by games whose reset command accepts
 	// options (e.g. Sevens: "r [tunnel] [joker=N] [strategy] [passes=N]").
@@ -39,9 +48,14 @@ type CuiHelpSpec struct {
 // BuildCuiHelp assembles standard CUI help text from spec. Order:
 // title, blank, gameCommands header, command keys, extra command lines,
 // blank + settings header + setting keys (only when non-empty),
-// blank + session header + reset + quit + help.
+// blank + session header + reset + quit + help,
+// blank + examples header + example keys (only when non-empty).
 // When spec.Body is non-empty the scaffold is skipped entirely and Body
 // is returned verbatim.
+//
+// Examples come last, after the session block: the command tables are the
+// reference a returning player scans, while the worked sequence is for someone
+// who does not yet know which command to type first.
 func BuildCuiHelp(spec CuiHelpSpec) []string {
 	if len(spec.Body) > 0 {
 		return spec.Body
@@ -70,5 +84,11 @@ func BuildCuiHelp(spec CuiHelpSpec) []string {
 		i18n.T("quitEntry"),
 		i18n.T("helpEntry"),
 	)
+	if len(spec.ExampleKeys) > 0 {
+		lines = append(lines, "", i18n.T("examples"))
+		for _, k := range spec.ExampleKeys {
+			lines = append(lines, i18n.T(k))
+		}
+	}
 	return lines
 }

--- a/internal/infrastructure/ui/help_text_test.go
+++ b/internal/infrastructure/ui/help_text_test.go
@@ -3,6 +3,8 @@
 package ui
 
 import (
+	"sort"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -266,4 +268,176 @@ func assertLines(t *testing.T, got, want []string) {
 			t.Errorf("line %d: got %q want %q", i, got[i], want[i])
 		}
 	}
+}
+
+// The examples section is opt-in: a game that supplies no example keys renders
+// exactly as before. That is what lets the mechanism ship for all 318 games
+// while only a few carry content — see issue #5358.
+func TestBuildCuiHelp_omitsExamplesWhenEmpty(t *testing.T) {
+	got := BuildCuiHelp(CuiHelpSpec{
+		TitleKey:    "hearts.helpTitle",
+		CommandKeys: []string{"hearts.helpPass"},
+	})
+
+	for _, line := range got {
+		if line == i18n.T("examples") {
+			t.Fatalf("examples header rendered for a game with no example keys:\n%v", got)
+		}
+	}
+}
+
+// Examples go last, after the session block: the command tables are the
+// reference a returning player scans, and the worked sequence is for someone
+// who does not yet know which command to type first.
+func TestBuildCuiHelp_examplesComeAfterSession(t *testing.T) {
+	got := BuildCuiHelp(CuiHelpSpec{
+		TitleKey:    "blackjack.helpTitle",
+		CommandKeys: []string{"blackjack.helpHit"},
+		ExampleKeys: []string{"blackjack.helpExampleBet", "blackjack.helpExampleHit"},
+	})
+
+	want := []string{
+		i18n.T("blackjack.helpTitle"),
+		"",
+		i18n.T("gameCommands"),
+		i18n.T("blackjack.helpHit"),
+		"",
+		i18n.T("session"),
+		i18n.T("resetEntry"),
+		i18n.T("quitEntry"),
+		i18n.T("helpEntry"),
+		"",
+		i18n.T("examples"),
+		i18n.T("blackjack.helpExampleBet"),
+		i18n.T("blackjack.helpExampleHit"),
+	}
+	assertLines(t, got, want)
+}
+
+// Body short-circuits the whole scaffold, examples included: those games hand
+// author their help and must not gain a section they did not ask for.
+func TestBuildCuiHelp_bodyStillShortCircuitsExamples(t *testing.T) {
+	body := []string{"custom line"}
+	got := BuildCuiHelp(CuiHelpSpec{Body: body, ExampleKeys: []string{"blackjack.helpExampleBet"}})
+	assertLines(t, got, body)
+}
+
+// TestCuiHelpExamplesUseRealCommands asserts that every command shown in a
+// game's examples section is one that game's own command table lists.
+//
+// Examples are prose in a locale file: nothing stops one naming a command the
+// game does not have, and the result renders perfectly. Writing the first six
+// by hand produced four such mistakes — hearts said `p 0 3 7` where the pass
+// command is `pass`, gofish said `a 1 7` where it is `ask`, klondike invented
+// `f 1` for what is `m w f`, and daifugo used a bare index where the play
+// command is `p`. All four looked right until this check ran. See issue #5358.
+//
+// Reads the rendered help rather than the spec: the spec is turned into lines
+// by BuildCuiHelp at registration time and not retained, and the rendered text
+// is what a player actually sees.
+func TestCuiHelpExamplesUseRealCommands(t *testing.T) {
+	registry := GameRegistry()
+	if len(registry) < 300 {
+		t.Fatalf("only %d games in the registry -- the walk broke", len(registry))
+	}
+
+	// Both languages: the example and the command table are separate strings in
+	// separate locale files, so a mismatch can exist in one and not the other.
+	// Checking only the default language is how the first version of this guard
+	// passed while ja/gofish.json still said `a 1 7` -- the tests run in en.
+	original := i18n.Lang()
+	t.Cleanup(func() { i18n.SetLang(original) })
+
+	withExamples, checked := 0, 0
+	var bad []string
+	for _, lang := range []string{"ja", "en"} {
+		i18n.SetLang(lang)
+		for _, entry := range registry {
+			// HelpLines() is evaluated per NewCui() call, so this picks up the
+			// language set above rather than the one at registration time.
+			commands, examples := helpSections(entry.NewCui().HelpLines())
+			if len(examples) == 0 {
+				continue
+			}
+			withExamples++
+			verbs := map[string]bool{}
+			for _, line := range commands {
+				if v := helpLineVerb(line); v != "" {
+					verbs[v] = true
+				}
+			}
+			for _, line := range examples {
+				v := helpLineVerb(line)
+				if v == "" {
+					continue
+				}
+				checked++
+				if !verbs[v] {
+					bad = append(bad, lang+"/"+entry.Name+": example uses `"+v+"`, which its command table does not list")
+				}
+			}
+		}
+	}
+
+	if withExamples == 0 {
+		t.Fatal("no game rendered an examples section in either language -- either none wires ExampleKeys or helpSections stopped matching")
+	}
+	if checked == 0 {
+		t.Fatalf("%d games have examples but no command token was parsed from them -- helpLineVerb stopped matching", withExamples)
+	}
+	sort.Strings(bad)
+	if len(bad) > 0 {
+		t.Errorf("examples naming commands the game does not have (%d bad of %d checked across %d games):\n  %s",
+			len(bad), checked, withExamples, strings.Join(bad, "\n  "))
+	}
+}
+
+// helpSections splits rendered help into its command lines and its example
+// lines, keyed off the localized section headers so it follows a language
+// switch rather than hard-coding Japanese or English.
+func helpSections(lines []string) (commands, examples []string) {
+	cmdHeader, exHeader := i18n.T("gameCommands"), i18n.T("examples")
+	section := ""
+	for _, line := range lines {
+		switch line {
+		case cmdHeader:
+			section = "cmd"
+			continue
+		case exHeader:
+			section = "ex"
+			continue
+		}
+		if strings.TrimSpace(line) == "" {
+			section = ""
+			continue
+		}
+		switch section {
+		case "cmd":
+			commands = append(commands, line)
+		case "ex":
+			examples = append(examples, line)
+		}
+	}
+	return commands, examples
+}
+
+// helpLineVerb extracts the command token from a help line such as
+// "  b <n> ...  bet". Returns "" for a line that does not start with one (a
+// bare index, a continuation line, a localized prose fragment).
+func helpLineVerb(line string) string {
+	fields := strings.Fields(line)
+	if len(fields) == 0 {
+		return ""
+	}
+	verb := fields[0]
+	for _, r := range verb {
+		if (r < 'a' || r > 'z') && (r < '0' || r > '9') {
+			return ""
+		}
+	}
+	// A bare number is an index, not a command.
+	if _, err := strconv.Atoi(verb); err == nil {
+		return ""
+	}
+	return verb
 }


### PR DESCRIPTION
ゲーム別ヘルプはコマンド表を出すが、**典型的な操作の流れを示す例が無い**。318 ゲームがそれぞれ独自のコマンド語彙を持つので、新しいゲームに入るたび「まず何を打てばいいか」を推測することになっていました。

バッチの合意（大物は完走ではなく最小スコープで一区切り）に従い、**仕組み + 代表 6 ゲーム**に絞ります。残り 312 ゲームの例文は別 issue へ。

## 仕組み

`CuiHelpSpec` に `ExampleKeys` を追加し、`BuildCuiHelp` がセッション欄の後に examples セクションを描画します。

**opt-in です。** 例を持たないゲームは以前と 1 バイトも変わりません（`TestBuildCuiHelp_omitsExamplesWhenEmpty` で固定）。`Body` で自前ヘルプを書くゲームも従来どおり素通しします（`TestBuildCuiHelp_bodyStillShortCircuitsExamples`）。

例をセッションの後に置いたのは、コマンド表は戻ってきた人が走査する参照で、流れの例はまだ何を打つか知らない人向けだからです。

```console
$ trumpcards help blackjack
...
セッション:
  r                    ゲームをリセット
  q, quit, exit        終了
  help, ?              このヘルプを表示

例:
  b 100                100 チップ賭けて配る
  h                    もう1枚引く
  s                    スタンドしてディーラーの番へ
```

## 手で書いた 6 件のうち 4 件が間違っていた

例文はロケールファイル中の**散文**なので、存在しないコマンドを書いても完璧に描画されます。実際、最初に書いた 6 ゲームのうち 4 つが誤っていました:

| ゲーム | 書いた例 | 実際のコマンド |
|---|---|---|
| hearts | `p 0 3 7` | pass は `pass` |
| gofish | `a 1 7` | `ask` |
| klondike | `f 1` | そんなコマンドは無い（`m w f`） |
| daifugo | `0 2` | play は `p` |

いずれも見た目には正しく、走らせるまで気付きませんでした。そこで **`TestCuiHelpExamplesUseRealCommands`** を追加し、例に出るコマンドがそのゲームのコマンド表に実在するかを検査します。

ガードは**描画後のヘルプ**を読みます。spec は `BuildCuiHelp` で行に変換されて保持されないうえ、描画結果こそがプレイヤーの見るものだからです。

## 両言語を検査する

最初のガードは既定言語しか見ておらず、**`ja/gofish.json` をわざと壊しても通ってしまいました**（テストは en で走るため）。負のコントロールが通った時点で気付けました。

例文とコマンド表は別ファイルの別文字列なので、片方の言語だけ壊れることがあります。ja / en それぞれで壊して検出されることを実測済みです:

```
ja を壊したとき: ja/gofish: example uses `a`
en を壊したとき: en/gofish: example uses `a`
復元後: ok
```

## 代表 6 ゲームの選定

カテゴリが偏らないよう、ベッティング（blackjack）・トリック（hearts）・ソリティア（klondike）・リアルタイム（speed）・要求型（gofish）・大富豪（daifugo）から 1 つずつ選びました。

## 検証

- `gofmt -l internal/` 0 件
- `go build ./...` 通過
- `go test -tags test ./internal/infrastructure/ui/ ./internal/i18n/...` 通過
- `golangci-lint run ./internal/infrastructure/ui/...` 0 issues
- **6 worker の `GOOS=js GOARCH=wasm`** すべて通過
- ロケール JSON は追加分のみの差分（全文再フォーマットのチャーン無し）

Refs #5358