### PR TITLE
refactor(controller): consolidate all 27 duplicate dispatchers into six helpers

### DIFF
--- a/internal/adapter/controller/AluetteWebController.go
+++ b/internal/adapter/controller/AluetteWebController.go
@@ -121,20 +121,12 @@ func newAluetteDefaultOutput(msg string) *AluetteWebOutput {
 }
 
 func aluetteDispatch(bc *baseController, w http.ResponseWriter, di usecase.AluetteInteractorIF, param AluetteWebInput, newDefault func(string) *AluetteWebOutput) bool {
-	switch param.Command {
-	case "r", "reset":
-		bc.writePresenterResponse(w, di.ResetWithConfig(param.ToConfig()))
-	case "p", "play":
-		if !requireParam(bc, w, newDefault, param.CardIndex == nil, "param error: cardIndex is required.") {
-			return true
-		}
-		bc.writePresenterResponse(w, di.Play(*param.CardIndex))
-	case "n", "next":
-		bc.writePresenterResponse(w, di.NextTrick())
-	case "nr", "nextround":
-		bc.writePresenterResponse(w, di.NextRound())
-	default:
-		return dispatchHintAndLog(param.Command, bc, w, di.Hint, di.ActionLog)
-	}
-	return true
+	return dispatchTrickPlay(param.Command, bc, w, trickPlayFns{
+		resetWithConfig: func() string { return di.ResetWithConfig(param.ToConfig()) },
+		play:            di.Play,
+		nextTrick:       di.NextTrick,
+		nextRound:       di.NextRound,
+		hint:            di.Hint,
+		actionLog:       di.ActionLog,
+	}, param.CardIndex, newDefault)
 }

--- a/internal/adapter/controller/BakersDozenWebController.go
+++ b/internal/adapter/controller/BakersDozenWebController.go
@@ -84,28 +84,15 @@ func bakersDozenDispatch(bc *baseController, w http.ResponseWriter, bi usecase.B
 }
 
 func bakersDozenMoveDispatch(bc *baseController, w http.ResponseWriter, bi usecase.BakersDozenInteractorIF, param BakersDozenWebInput, newDefault func(string) *BakersDozenWebOutput) bool {
-	if !requireParam(bc, w, newDefault, param.From == nil || param.To == nil, "param error: from and to are required.") {
-		return true
+	mv := topCardMove{haveFrom: param.From != nil, haveTo: param.To != nil}
+	if param.From != nil {
+		mv.fromZone, mv.fromCol = param.From.Zone, param.From.Col
 	}
-	fromZone := param.From.Zone
-	toZone := param.To.Zone
-
-	switch {
-	case fromZone == "tableau" && toZone == "tableau":
-		if !requireParam(bc, w, newDefault, param.From.Col == nil || param.To.Col == nil, "param error: from.col and to.col are required.") {
-			return true
-		}
-		// Pass -1 so the domain resolves the index from its own state — Baker's
-		// Dozen only ever moves the top card, so trusting the client cardIndex
-		// adds nothing and gives the server one less untrusted input.
-		bc.writePresenterResponse(w, bi.MoveTableauToTableau(*param.From.Col, -1, *param.To.Col))
-	case fromZone == "tableau" && toZone == "foundation":
-		if !requireParam(bc, w, newDefault, param.From.Col == nil, "param error: from.col is required.") {
-			return true
-		}
-		bc.writePresenterResponse(w, bi.MoveTableauToFoundation(*param.From.Col))
-	default:
-		bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: invalid move zones."))
+	if param.To != nil {
+		mv.toZone, mv.toCol = param.To.Zone, param.To.Col
 	}
-	return true
+	return dispatchTopCardMove(bc, w, mv, topCardMoveFns{
+		tableauToTableau:    bi.MoveTableauToTableau,
+		tableauToFoundation: bi.MoveTableauToFoundation,
+	}, newDefault)
 }

--- a/internal/adapter/controller/BeleagueredCastleWebController.go
+++ b/internal/adapter/controller/BeleagueredCastleWebController.go
@@ -84,27 +84,15 @@ func beleagueredCastleDispatch(bc *baseController, w http.ResponseWriter, bi use
 }
 
 func beleagueredCastleMoveDispatch(bc *baseController, w http.ResponseWriter, bi usecase.BeleagueredCastleInteractorIF, param BeleagueredCastleWebInput, newDefault func(string) *BeleagueredCastleWebOutput) bool {
-	if !requireParam(bc, w, newDefault, param.From == nil || param.To == nil, "param error: from and to are required.") {
-		return true
+	mv := topCardMove{haveFrom: param.From != nil, haveTo: param.To != nil}
+	if param.From != nil {
+		mv.fromZone, mv.fromCol = param.From.Zone, param.From.Col
 	}
-	fromZone := param.From.Zone
-	toZone := param.To.Zone
-
-	switch {
-	case fromZone == "tableau" && toZone == "tableau":
-		if !requireParam(bc, w, newDefault, param.From.Col == nil || param.To.Col == nil, "param error: from.col and to.col are required.") {
-			return true
-		}
-		// Beleaguered Castle only ever moves the top card; pass -1 so the
-		// domain resolves the index from its own state.
-		bc.writePresenterResponse(w, bi.MoveTableauToTableau(*param.From.Col, -1, *param.To.Col))
-	case fromZone == "tableau" && toZone == "foundation":
-		if !requireParam(bc, w, newDefault, param.From.Col == nil, "param error: from.col is required.") {
-			return true
-		}
-		bc.writePresenterResponse(w, bi.MoveTableauToFoundation(*param.From.Col))
-	default:
-		bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: invalid move zones."))
+	if param.To != nil {
+		mv.toZone, mv.toCol = param.To.Zone, param.To.Col
 	}
-	return true
+	return dispatchTopCardMove(bc, w, mv, topCardMoveFns{
+		tableauToTableau:    bi.MoveTableauToTableau,
+		tableauToFoundation: bi.MoveTableauToFoundation,
+	}, newDefault)
 }

--- a/internal/adapter/controller/BurracoWebController.go
+++ b/internal/adapter/controller/BurracoWebController.go
@@ -104,28 +104,15 @@ func newBurracoDefaultOutput(msg string) *BurracoWebOutput {
 }
 
 func burracoDispatch(bc *baseController, w http.ResponseWriter, ci usecase.BurracoInteractorIF, param BurracoWebInput, newDefault func(string) *BurracoWebOutput) bool {
-	switch param.Command {
-	case "r", "reset":
-		bc.writePresenterResponse(w, ci.ResetWithConfig(param.ToConfig()))
-	case "ds", "drawstock":
-		bc.writePresenterResponse(w, ci.DrawFromStock())
-	case "dd", "drawdiscard":
-		bc.writePresenterResponse(w, ci.DrawFromDiscard(param.NaturalPairIndices))
-	case "m", "meld":
-		bc.writePresenterResponse(w, ci.Meld(param.MeldGroups))
-	case "sm", "skipmeld":
-		bc.writePresenterResponse(w, ci.SkipMeld())
-	case "d", "discard":
-		if !requireParam(bc, w, newDefault, param.CardIndex == nil, "param error: cardIndex is required.") {
-			return true
-		}
-		bc.writePresenterResponse(w, ci.Discard(*param.CardIndex))
-	case "go", "goout":
-		bc.writePresenterResponse(w, ci.GoOut())
-	case "nr", "nextround":
-		bc.writePresenterResponse(w, ci.NextRound())
-	default:
-		return dispatchLog(param.Command, bc, w, ci.ActionLog)
-	}
-	return true
+	return dispatchRummyMeld(param.Command, bc, w, rummyMeldFns{
+		resetWithConfig: func() string { return ci.ResetWithConfig(param.ToConfig()) },
+		drawFromStock:   ci.DrawFromStock,
+		drawFromDiscard: func() string { return ci.DrawFromDiscard(param.NaturalPairIndices) },
+		meld:            func() string { return ci.Meld(param.MeldGroups) },
+		skipMeld:        ci.SkipMeld,
+		discard:         ci.Discard,
+		goOut:           ci.GoOut,
+		nextRound:       ci.NextRound,
+		actionLog:       ci.ActionLog,
+	}, param.CardIndex, newDefault)
 }

--- a/internal/adapter/controller/CanastaWebController.go
+++ b/internal/adapter/controller/CanastaWebController.go
@@ -101,28 +101,15 @@ func newCanastaDefaultOutput(msg string) *CanastaWebOutput {
 }
 
 func canastaDispatch(bc *baseController, w http.ResponseWriter, ci usecase.CanastaInteractorIF, param CanastaWebInput, newDefault func(string) *CanastaWebOutput) bool {
-	switch param.Command {
-	case "r", "reset":
-		bc.writePresenterResponse(w, ci.ResetWithConfig(param.ToConfig()))
-	case "ds", "drawstock":
-		bc.writePresenterResponse(w, ci.DrawFromStock())
-	case "dd", "drawdiscard":
-		bc.writePresenterResponse(w, ci.DrawFromDiscard(param.NaturalPairIndices))
-	case "m", "meld":
-		bc.writePresenterResponse(w, ci.Meld(param.MeldGroups))
-	case "sm", "skipmeld":
-		bc.writePresenterResponse(w, ci.SkipMeld())
-	case "d", "discard":
-		if !requireParam(bc, w, newDefault, param.CardIndex == nil, "param error: cardIndex is required.") {
-			return true
-		}
-		bc.writePresenterResponse(w, ci.Discard(*param.CardIndex))
-	case "go", "goout":
-		bc.writePresenterResponse(w, ci.GoOut())
-	case "nr", "nextround":
-		bc.writePresenterResponse(w, ci.NextRound())
-	default:
-		return dispatchLog(param.Command, bc, w, ci.ActionLog)
-	}
-	return true
+	return dispatchRummyMeld(param.Command, bc, w, rummyMeldFns{
+		resetWithConfig: func() string { return ci.ResetWithConfig(param.ToConfig()) },
+		drawFromStock:   ci.DrawFromStock,
+		drawFromDiscard: func() string { return ci.DrawFromDiscard(param.NaturalPairIndices) },
+		meld:            func() string { return ci.Meld(param.MeldGroups) },
+		skipMeld:        ci.SkipMeld,
+		discard:         ci.Discard,
+		goOut:           ci.GoOut,
+		nextRound:       ci.NextRound,
+		actionLog:       ci.ActionLog,
+	}, param.CardIndex, newDefault)
 }

--- a/internal/adapter/controller/FortyFivesWebController.go
+++ b/internal/adapter/controller/FortyFivesWebController.go
@@ -104,25 +104,13 @@ func newFortyFivesDefaultOutput(msg string) *FortyFivesWebOutput {
 }
 
 func fortyFivesDispatch(bc *baseController, w http.ResponseWriter, di usecase.FortyFivesInteractorIF, param FortyFivesWebInput, newDefault func(string) *FortyFivesWebOutput) bool {
-	switch param.Command {
-	case "r", "reset":
-		bc.writePresenterResponse(w, di.ResetWithConfig(param.ToConfig()))
-	case "b", "bid":
-		if !requireParam(bc, w, newDefault, param.Bid == nil, "param error: bid is required.") {
-			return true
-		}
-		bc.writePresenterResponse(w, di.Bid(*param.Bid))
-	case "p", "play":
-		if !requireParam(bc, w, newDefault, param.CardIndex == nil, "param error: cardIndex is required.") {
-			return true
-		}
-		bc.writePresenterResponse(w, di.Play(*param.CardIndex))
-	case "n", "next":
-		bc.writePresenterResponse(w, di.NextTrick())
-	case "nr", "nextround":
-		bc.writePresenterResponse(w, di.NextRound())
-	default:
-		return dispatchHintAndLog(param.Command, bc, w, di.Hint, di.ActionLog)
-	}
-	return true
+	return dispatchBidTrickPlay(param.Command, bc, w, bidTrickPlayFns{
+		resetWithConfig: func() string { return di.ResetWithConfig(param.ToConfig()) },
+		bid:             di.Bid,
+		play:            di.Play,
+		nextTrick:       di.NextTrick,
+		nextRound:       di.NextRound,
+		hint:            di.Hint,
+		actionLog:       di.ActionLog,
+	}, param.Bid, param.CardIndex, newDefault)
 }

--- a/internal/adapter/controller/GanjifaWebController.go
+++ b/internal/adapter/controller/GanjifaWebController.go
@@ -96,20 +96,12 @@ func newGanjifaDefaultOutput(msg string) *GanjifaWebOutput {
 }
 
 func ganjifaDispatch(bc *baseController, w http.ResponseWriter, di usecase.GanjifaInteractorIF, param GanjifaWebInput, newDefault func(string) *GanjifaWebOutput) bool {
-	switch param.Command {
-	case "r", "reset":
-		bc.writePresenterResponse(w, di.ResetWithConfig(param.ToConfig()))
-	case "p", "play":
-		if !requireParam(bc, w, newDefault, param.CardIndex == nil, "param error: cardIndex is required.") {
-			return true
-		}
-		bc.writePresenterResponse(w, di.Play(*param.CardIndex))
-	case "n", "next":
-		bc.writePresenterResponse(w, di.NextTrick())
-	case "nr", "nextround":
-		bc.writePresenterResponse(w, di.NextRound())
-	default:
-		return dispatchHintAndLog(param.Command, bc, w, di.Hint, di.ActionLog)
-	}
-	return true
+	return dispatchTrickPlay(param.Command, bc, w, trickPlayFns{
+		resetWithConfig: func() string { return di.ResetWithConfig(param.ToConfig()) },
+		play:            di.Play,
+		nextTrick:       di.NextTrick,
+		nextRound:       di.NextRound,
+		hint:            di.Hint,
+		actionLog:       di.ActionLog,
+	}, param.CardIndex, newDefault)
 }

--- a/internal/adapter/controller/HandAndFootWebController.go
+++ b/internal/adapter/controller/HandAndFootWebController.go
@@ -109,28 +109,15 @@ func newHandAndFootDefaultOutput(msg string) *HandAndFootWebOutput {
 }
 
 func handAndFootDispatch(bc *baseController, w http.ResponseWriter, ci usecase.HandAndFootInteractorIF, param HandAndFootWebInput, newDefault func(string) *HandAndFootWebOutput) bool {
-	switch param.Command {
-	case "r", "reset":
-		bc.writePresenterResponse(w, ci.ResetWithConfig(param.ToConfig()))
-	case "ds", "drawstock":
-		bc.writePresenterResponse(w, ci.DrawFromStock())
-	case "dd", "drawdiscard":
-		bc.writePresenterResponse(w, ci.DrawFromDiscard(param.NaturalPairIndices))
-	case "m", "meld":
-		bc.writePresenterResponse(w, ci.Meld(param.MeldGroups))
-	case "sm", "skipmeld":
-		bc.writePresenterResponse(w, ci.SkipMeld())
-	case "d", "discard":
-		if !requireParam(bc, w, newDefault, param.CardIndex == nil, "param error: cardIndex is required.") {
-			return true
-		}
-		bc.writePresenterResponse(w, ci.Discard(*param.CardIndex))
-	case "go", "goout":
-		bc.writePresenterResponse(w, ci.GoOut())
-	case "nr", "nextround":
-		bc.writePresenterResponse(w, ci.NextRound())
-	default:
-		return dispatchLog(param.Command, bc, w, ci.ActionLog)
-	}
-	return true
+	return dispatchRummyMeld(param.Command, bc, w, rummyMeldFns{
+		resetWithConfig: func() string { return ci.ResetWithConfig(param.ToConfig()) },
+		drawFromStock:   ci.DrawFromStock,
+		drawFromDiscard: func() string { return ci.DrawFromDiscard(param.NaturalPairIndices) },
+		meld:            func() string { return ci.Meld(param.MeldGroups) },
+		skipMeld:        ci.SkipMeld,
+		discard:         ci.Discard,
+		goOut:           ci.GoOut,
+		nextRound:       ci.NextRound,
+		actionLog:       ci.ActionLog,
+	}, param.CardIndex, newDefault)
 }

--- a/internal/adapter/controller/KlaverjasWebController.go
+++ b/internal/adapter/controller/KlaverjasWebController.go
@@ -97,20 +97,12 @@ func newKlaverjasDefaultOutput(msg string) *KlaverjasWebOutput {
 }
 
 func klaverjasDispatch(bc *baseController, w http.ResponseWriter, di usecase.KlaverjasInteractorIF, param KlaverjasWebInput, newDefault func(string) *KlaverjasWebOutput) bool {
-	switch param.Command {
-	case "r", "reset":
-		bc.writePresenterResponse(w, di.ResetWithConfig(param.ToConfig()))
-	case "p", "play":
-		if !requireParam(bc, w, newDefault, param.CardIndex == nil, "param error: cardIndex is required.") {
-			return true
-		}
-		bc.writePresenterResponse(w, di.Play(*param.CardIndex))
-	case "n", "next":
-		bc.writePresenterResponse(w, di.NextTrick())
-	case "nr", "nextround":
-		bc.writePresenterResponse(w, di.NextRound())
-	default:
-		return dispatchHintAndLog(param.Command, bc, w, di.Hint, di.ActionLog)
-	}
-	return true
+	return dispatchTrickPlay(param.Command, bc, w, trickPlayFns{
+		resetWithConfig: func() string { return di.ResetWithConfig(param.ToConfig()) },
+		play:            di.Play,
+		nextTrick:       di.NextTrick,
+		nextRound:       di.NextRound,
+		hint:            di.Hint,
+		actionLog:       di.ActionLog,
+	}, param.CardIndex, newDefault)
 }

--- a/internal/adapter/controller/ManilleWebController.go
+++ b/internal/adapter/controller/ManilleWebController.go
@@ -96,20 +96,12 @@ func newManilleDefaultOutput(msg string) *ManilleWebOutput {
 }
 
 func manilleDispatch(bc *baseController, w http.ResponseWriter, di usecase.ManilleInteractorIF, param ManilleWebInput, newDefault func(string) *ManilleWebOutput) bool {
-	switch param.Command {
-	case "r", "reset":
-		bc.writePresenterResponse(w, di.ResetWithConfig(param.ToConfig()))
-	case "p", "play":
-		if !requireParam(bc, w, newDefault, param.CardIndex == nil, "param error: cardIndex is required.") {
-			return true
-		}
-		bc.writePresenterResponse(w, di.Play(*param.CardIndex))
-	case "n", "next":
-		bc.writePresenterResponse(w, di.NextTrick())
-	case "nr", "nextround":
-		bc.writePresenterResponse(w, di.NextRound())
-	default:
-		return dispatchHintAndLog(param.Command, bc, w, di.Hint, di.ActionLog)
-	}
-	return true
+	return dispatchTrickPlay(param.Command, bc, w, trickPlayFns{
+		resetWithConfig: func() string { return di.ResetWithConfig(param.ToConfig()) },
+		play:            di.Play,
+		nextTrick:       di.NextTrick,
+		nextRound:       di.NextRound,
+		hint:            di.Hint,
+		actionLog:       di.ActionLog,
+	}, param.CardIndex, newDefault)
 }

--- a/internal/adapter/controller/MariasWebController.go
+++ b/internal/adapter/controller/MariasWebController.go
@@ -101,20 +101,12 @@ func newMariasDefaultOutput(msg string) *MariasWebOutput {
 }
 
 func mariasDispatch(bc *baseController, w http.ResponseWriter, di usecase.MariasInteractorIF, param MariasWebInput, newDefault func(string) *MariasWebOutput) bool {
-	switch param.Command {
-	case "r", "reset":
-		bc.writePresenterResponse(w, di.ResetWithConfig(param.ToConfig()))
-	case "p", "play":
-		if !requireParam(bc, w, newDefault, param.CardIndex == nil, "param error: cardIndex is required.") {
-			return true
-		}
-		bc.writePresenterResponse(w, di.Play(*param.CardIndex))
-	case "n", "next":
-		bc.writePresenterResponse(w, di.NextTrick())
-	case "nr", "nextround":
-		bc.writePresenterResponse(w, di.NextRound())
-	default:
-		return dispatchHintAndLog(param.Command, bc, w, di.Hint, di.ActionLog)
-	}
-	return true
+	return dispatchTrickPlay(param.Command, bc, w, trickPlayFns{
+		resetWithConfig: func() string { return di.ResetWithConfig(param.ToConfig()) },
+		play:            di.Play,
+		nextTrick:       di.NextTrick,
+		nextRound:       di.NextRound,
+		hint:            di.Hint,
+		actionLog:       di.ActionLog,
+	}, param.CardIndex, newDefault)
 }

--- a/internal/adapter/controller/MinchiateWebController.go
+++ b/internal/adapter/controller/MinchiateWebController.go
@@ -105,25 +105,13 @@ func newMinchiateDefaultOutput(msg string) *MinchiateWebOutput {
 }
 
 func minchiateDispatch(bc *baseController, w http.ResponseWriter, di usecase.MinchiateInteractorIF, param MinchiateWebInput, newDefault func(string) *MinchiateWebOutput) bool {
-	switch param.Command {
-	case "r", "reset":
-		bc.writePresenterResponse(w, di.ResetWithConfig(param.ToConfig()))
-	case "s", "scarto", "d", "discard":
-		if !requireParam(bc, w, newDefault, param.CardIndices == nil, "param error: cardIndices is required.") {
-			return true
-		}
-		bc.writePresenterResponse(w, di.Discard(param.CardIndices))
-	case "p", "play":
-		if !requireParam(bc, w, newDefault, param.CardIndex == nil, "param error: cardIndex is required.") {
-			return true
-		}
-		bc.writePresenterResponse(w, di.Play(*param.CardIndex))
-	case "n", "next":
-		bc.writePresenterResponse(w, di.NextTrick())
-	case "nr", "nextround":
-		bc.writePresenterResponse(w, di.NextRound())
-	default:
-		return dispatchHintAndLog(param.Command, bc, w, di.Hint, di.ActionLog)
-	}
-	return true
+	return dispatchTarotDiscardPlay(param.Command, bc, w, tarotDiscardPlayFns{
+		resetWithConfig: func() string { return di.ResetWithConfig(param.ToConfig()) },
+		discard:         di.Discard,
+		play:            di.Play,
+		nextTrick:       di.NextTrick,
+		nextRound:       di.NextRound,
+		hint:            di.Hint,
+		actionLog:       di.ActionLog,
+	}, param.CardIndices, param.CardIndex, newDefault)
 }

--- a/internal/adapter/controller/NapWebController.go
+++ b/internal/adapter/controller/NapWebController.go
@@ -104,25 +104,13 @@ func newNapDefaultOutput(msg string) *NapWebOutput {
 }
 
 func napDispatch(bc *baseController, w http.ResponseWriter, di usecase.NapInteractorIF, param NapWebInput, newDefault func(string) *NapWebOutput) bool {
-	switch param.Command {
-	case "r", "reset":
-		bc.writePresenterResponse(w, di.ResetWithConfig(param.ToConfig()))
-	case "b", "bid":
-		if !requireParam(bc, w, newDefault, param.Bid == nil, "param error: bid is required.") {
-			return true
-		}
-		bc.writePresenterResponse(w, di.Bid(*param.Bid))
-	case "p", "play":
-		if !requireParam(bc, w, newDefault, param.CardIndex == nil, "param error: cardIndex is required.") {
-			return true
-		}
-		bc.writePresenterResponse(w, di.Play(*param.CardIndex))
-	case "n", "next":
-		bc.writePresenterResponse(w, di.NextTrick())
-	case "nr", "nextround":
-		bc.writePresenterResponse(w, di.NextRound())
-	default:
-		return dispatchHintAndLog(param.Command, bc, w, di.Hint, di.ActionLog)
-	}
-	return true
+	return dispatchBidTrickPlay(param.Command, bc, w, bidTrickPlayFns{
+		resetWithConfig: func() string { return di.ResetWithConfig(param.ToConfig()) },
+		bid:             di.Bid,
+		play:            di.Play,
+		nextTrick:       di.NextTrick,
+		nextRound:       di.NextRound,
+		hint:            di.Hint,
+		actionLog:       di.ActionLog,
+	}, param.Bid, param.CardIndex, newDefault)
 }

--- a/internal/adapter/controller/PreferenceWebController.go
+++ b/internal/adapter/controller/PreferenceWebController.go
@@ -104,25 +104,13 @@ func newPreferenceDefaultOutput(msg string) *PreferenceWebOutput {
 }
 
 func preferenceDispatch(bc *baseController, w http.ResponseWriter, di usecase.PreferenceInteractorIF, param PreferenceWebInput, newDefault func(string) *PreferenceWebOutput) bool {
-	switch param.Command {
-	case "r", "reset":
-		bc.writePresenterResponse(w, di.ResetWithConfig(param.ToConfig()))
-	case "b", "bid":
-		if !requireParam(bc, w, newDefault, param.Bid == nil, "param error: bid is required.") {
-			return true
-		}
-		bc.writePresenterResponse(w, di.Bid(*param.Bid))
-	case "p", "play":
-		if !requireParam(bc, w, newDefault, param.CardIndex == nil, "param error: cardIndex is required.") {
-			return true
-		}
-		bc.writePresenterResponse(w, di.Play(*param.CardIndex))
-	case "n", "next":
-		bc.writePresenterResponse(w, di.NextTrick())
-	case "nr", "nextround":
-		bc.writePresenterResponse(w, di.NextRound())
-	default:
-		return dispatchHintAndLog(param.Command, bc, w, di.Hint, di.ActionLog)
-	}
-	return true
+	return dispatchBidTrickPlay(param.Command, bc, w, bidTrickPlayFns{
+		resetWithConfig: func() string { return di.ResetWithConfig(param.ToConfig()) },
+		bid:             di.Bid,
+		play:            di.Play,
+		nextTrick:       di.NextTrick,
+		nextRound:       di.NextRound,
+		hint:            di.Hint,
+		actionLog:       di.ActionLog,
+	}, param.Bid, param.CardIndex, newDefault)
 }

--- a/internal/adapter/controller/SambaWebController.go
+++ b/internal/adapter/controller/SambaWebController.go
@@ -108,28 +108,15 @@ func newSambaDefaultOutput(msg string) *SambaWebOutput {
 }
 
 func sambaDispatch(bc *baseController, w http.ResponseWriter, ci usecase.SambaInteractorIF, param SambaWebInput, newDefault func(string) *SambaWebOutput) bool {
-	switch param.Command {
-	case "r", "reset":
-		bc.writePresenterResponse(w, ci.ResetWithConfig(param.ToConfig()))
-	case "ds", "drawstock":
-		bc.writePresenterResponse(w, ci.DrawFromStock())
-	case "dd", "drawdiscard":
-		bc.writePresenterResponse(w, ci.DrawFromDiscard(param.NaturalPairIndices))
-	case "m", "meld":
-		bc.writePresenterResponse(w, ci.Meld(param.MeldGroups))
-	case "sm", "skipmeld":
-		bc.writePresenterResponse(w, ci.SkipMeld())
-	case "d", "discard":
-		if !requireParam(bc, w, newDefault, param.CardIndex == nil, "param error: cardIndex is required.") {
-			return true
-		}
-		bc.writePresenterResponse(w, ci.Discard(*param.CardIndex))
-	case "go", "goout":
-		bc.writePresenterResponse(w, ci.GoOut())
-	case "nr", "nextround":
-		bc.writePresenterResponse(w, ci.NextRound())
-	default:
-		return dispatchLog(param.Command, bc, w, ci.ActionLog)
-	}
-	return true
+	return dispatchRummyMeld(param.Command, bc, w, rummyMeldFns{
+		resetWithConfig: func() string { return ci.ResetWithConfig(param.ToConfig()) },
+		drawFromStock:   ci.DrawFromStock,
+		drawFromDiscard: func() string { return ci.DrawFromDiscard(param.NaturalPairIndices) },
+		meld:            func() string { return ci.Meld(param.MeldGroups) },
+		skipMeld:        ci.SkipMeld,
+		discard:         ci.Discard,
+		goOut:           ci.GoOut,
+		nextRound:       ci.NextRound,
+		actionLog:       ci.ActionLog,
+	}, param.CardIndex, newDefault)
 }

--- a/internal/adapter/controller/ScartoWebController.go
+++ b/internal/adapter/controller/ScartoWebController.go
@@ -105,25 +105,13 @@ func newScartoDefaultOutput(msg string) *ScartoWebOutput {
 }
 
 func scartoDispatch(bc *baseController, w http.ResponseWriter, di usecase.ScartoInteractorIF, param ScartoWebInput, newDefault func(string) *ScartoWebOutput) bool {
-	switch param.Command {
-	case "r", "reset":
-		bc.writePresenterResponse(w, di.ResetWithConfig(param.ToConfig()))
-	case "s", "scarto", "d", "discard":
-		if !requireParam(bc, w, newDefault, param.CardIndices == nil, "param error: cardIndices is required.") {
-			return true
-		}
-		bc.writePresenterResponse(w, di.Discard(param.CardIndices))
-	case "p", "play":
-		if !requireParam(bc, w, newDefault, param.CardIndex == nil, "param error: cardIndex is required.") {
-			return true
-		}
-		bc.writePresenterResponse(w, di.Play(*param.CardIndex))
-	case "n", "next":
-		bc.writePresenterResponse(w, di.NextTrick())
-	case "nr", "nextround":
-		bc.writePresenterResponse(w, di.NextRound())
-	default:
-		return dispatchHintAndLog(param.Command, bc, w, di.Hint, di.ActionLog)
-	}
-	return true
+	return dispatchTarotDiscardPlay(param.Command, bc, w, tarotDiscardPlayFns{
+		resetWithConfig: func() string { return di.ResetWithConfig(param.ToConfig()) },
+		discard:         di.Discard,
+		play:            di.Play,
+		nextTrick:       di.NextTrick,
+		nextRound:       di.NextRound,
+		hint:            di.Hint,
+		actionLog:       di.ActionLog,
+	}, param.CardIndices, param.CardIndex, newDefault)
 }

--- a/internal/adapter/controller/ScorpionWebController.go
+++ b/internal/adapter/controller/ScorpionWebController.go
@@ -79,15 +79,12 @@ func scorpionDispatch(bc *baseController, w http.ResponseWriter, si usecase.Scor
 }
 
 func scorpionMoveDispatch(bc *baseController, w http.ResponseWriter, si usecase.ScorpionInteractorIF, param ScorpionWebInput, newDefault func(string) *ScorpionWebOutput) bool {
-	if !requireParam(bc, w, newDefault, param.From == nil || param.To == nil, "param error: from and to are required.") {
-		return true
+	mv := tableauMove{haveFrom: param.From != nil, haveTo: param.To != nil}
+	if param.From != nil {
+		mv.fromZone, mv.fromCol, mv.fromCardIndex = param.From.Zone, param.From.Col, param.From.CardIndex
 	}
-	if !requireParam(bc, w, newDefault, param.From.Zone != "tableau" || param.To.Zone != "tableau", "param error: invalid move zones. Only tableau to tableau is supported.") {
-		return true
+	if param.To != nil {
+		mv.toZone, mv.toCol = param.To.Zone, param.To.Col
 	}
-	if !requireParam(bc, w, newDefault, param.From.Col == nil || param.From.CardIndex == nil || param.To.Col == nil, "param error: from.col, from.cardIndex, to.col are required.") {
-		return true
-	}
-	bc.writePresenterResponse(w, si.MoveTableauToTableau(*param.From.Col, *param.From.CardIndex, *param.To.Col))
-	return true
+	return dispatchTableauOnlyMove(bc, w, mv, si.MoveTableauToTableau, newDefault)
 }

--- a/internal/adapter/controller/SedmaWebController.go
+++ b/internal/adapter/controller/SedmaWebController.go
@@ -95,20 +95,12 @@ func newSedmaDefaultOutput(msg string) *SedmaWebOutput {
 }
 
 func sedmaDispatch(bc *baseController, w http.ResponseWriter, di usecase.SedmaInteractorIF, param SedmaWebInput, newDefault func(string) *SedmaWebOutput) bool {
-	switch param.Command {
-	case "r", "reset":
-		bc.writePresenterResponse(w, di.ResetWithConfig(param.ToConfig()))
-	case "p", "play":
-		if !requireParam(bc, w, newDefault, param.CardIndex == nil, "param error: cardIndex is required.") {
-			return true
-		}
-		bc.writePresenterResponse(w, di.Play(*param.CardIndex))
-	case "n", "next":
-		bc.writePresenterResponse(w, di.NextTrick())
-	case "nr", "nextround":
-		bc.writePresenterResponse(w, di.NextRound())
-	default:
-		return dispatchHintAndLog(param.Command, bc, w, di.Hint, di.ActionLog)
-	}
-	return true
+	return dispatchTrickPlay(param.Command, bc, w, trickPlayFns{
+		resetWithConfig: func() string { return di.ResetWithConfig(param.ToConfig()) },
+		play:            di.Play,
+		nextTrick:       di.NextTrick,
+		nextRound:       di.NextRound,
+		hint:            di.Hint,
+		actionLog:       di.ActionLog,
+	}, param.CardIndex, newDefault)
 }

--- a/internal/adapter/controller/SoloWhistWebController.go
+++ b/internal/adapter/controller/SoloWhistWebController.go
@@ -104,25 +104,13 @@ func newSoloWhistDefaultOutput(msg string) *SoloWhistWebOutput {
 }
 
 func soloWhistDispatch(bc *baseController, w http.ResponseWriter, di usecase.SoloWhistInteractorIF, param SoloWhistWebInput, newDefault func(string) *SoloWhistWebOutput) bool {
-	switch param.Command {
-	case "r", "reset":
-		bc.writePresenterResponse(w, di.ResetWithConfig(param.ToConfig()))
-	case "b", "bid":
-		if !requireParam(bc, w, newDefault, param.Bid == nil, "param error: bid is required.") {
-			return true
-		}
-		bc.writePresenterResponse(w, di.Bid(*param.Bid))
-	case "p", "play":
-		if !requireParam(bc, w, newDefault, param.CardIndex == nil, "param error: cardIndex is required.") {
-			return true
-		}
-		bc.writePresenterResponse(w, di.Play(*param.CardIndex))
-	case "n", "next":
-		bc.writePresenterResponse(w, di.NextTrick())
-	case "nr", "nextround":
-		bc.writePresenterResponse(w, di.NextRound())
-	default:
-		return dispatchHintAndLog(param.Command, bc, w, di.Hint, di.ActionLog)
-	}
-	return true
+	return dispatchBidTrickPlay(param.Command, bc, w, bidTrickPlayFns{
+		resetWithConfig: func() string { return di.ResetWithConfig(param.ToConfig()) },
+		bid:             di.Bid,
+		play:            di.Play,
+		nextTrick:       di.NextTrick,
+		nextRound:       di.NextRound,
+		hint:            di.Hint,
+		actionLog:       di.ActionLog,
+	}, param.Bid, param.CardIndex, newDefault)
 }

--- a/internal/adapter/controller/SpideretteWebController.go
+++ b/internal/adapter/controller/SpideretteWebController.go
@@ -88,15 +88,12 @@ func spideretteDispatch(bc *baseController, w http.ResponseWriter, si usecase.Sp
 }
 
 func spideretteMoveDispatch(bc *baseController, w http.ResponseWriter, si usecase.SpideretteInteractorIF, param SpideretteWebInput, newDefault func(string) *SpideretteWebOutput) bool {
-	if !requireParam(bc, w, newDefault, param.From == nil || param.To == nil, "param error: from and to are required.") {
-		return true
+	mv := tableauMove{haveFrom: param.From != nil, haveTo: param.To != nil}
+	if param.From != nil {
+		mv.fromZone, mv.fromCol, mv.fromCardIndex = param.From.Zone, param.From.Col, param.From.CardIndex
 	}
-	if !requireParam(bc, w, newDefault, param.From.Zone != "tableau" || param.To.Zone != "tableau", "param error: invalid move zones. Only tableau to tableau is supported.") {
-		return true
+	if param.To != nil {
+		mv.toZone, mv.toCol = param.To.Zone, param.To.Col
 	}
-	if !requireParam(bc, w, newDefault, param.From.Col == nil || param.From.CardIndex == nil || param.To.Col == nil, "param error: from.col, from.cardIndex, to.col are required.") {
-		return true
-	}
-	bc.writePresenterResponse(w, si.MoveTableauToTableau(*param.From.Col, *param.From.CardIndex, *param.To.Col))
-	return true
+	return dispatchTableauOnlyMove(bc, w, mv, si.MoveTableauToTableau, newDefault)
 }

--- a/internal/adapter/controller/SpoilFiveWebController.go
+++ b/internal/adapter/controller/SpoilFiveWebController.go
@@ -96,20 +96,12 @@ func newSpoilFiveDefaultOutput(msg string) *SpoilFiveWebOutput {
 }
 
 func spoilFiveDispatch(bc *baseController, w http.ResponseWriter, di usecase.SpoilFiveInteractorIF, param SpoilFiveWebInput, newDefault func(string) *SpoilFiveWebOutput) bool {
-	switch param.Command {
-	case "r", "reset":
-		bc.writePresenterResponse(w, di.ResetWithConfig(param.ToConfig()))
-	case "p", "play":
-		if !requireParam(bc, w, newDefault, param.CardIndex == nil, "param error: cardIndex is required.") {
-			return true
-		}
-		bc.writePresenterResponse(w, di.Play(*param.CardIndex))
-	case "n", "next":
-		bc.writePresenterResponse(w, di.NextTrick())
-	case "nr", "nextround":
-		bc.writePresenterResponse(w, di.NextRound())
-	default:
-		return dispatchHintAndLog(param.Command, bc, w, di.Hint, di.ActionLog)
-	}
-	return true
+	return dispatchTrickPlay(param.Command, bc, w, trickPlayFns{
+		resetWithConfig: func() string { return di.ResetWithConfig(param.ToConfig()) },
+		play:            di.Play,
+		nextTrick:       di.NextTrick,
+		nextRound:       di.NextRound,
+		hint:            di.Hint,
+		actionLog:       di.ActionLog,
+	}, param.CardIndex, newDefault)
 }

--- a/internal/adapter/controller/StreetsAndAlleysWebController.go
+++ b/internal/adapter/controller/StreetsAndAlleysWebController.go
@@ -84,27 +84,15 @@ func streetsAndAlleysDispatch(bc *baseController, w http.ResponseWriter, bi usec
 }
 
 func streetsAndAlleysMoveDispatch(bc *baseController, w http.ResponseWriter, bi usecase.StreetsAndAlleysInteractorIF, param StreetsAndAlleysWebInput, newDefault func(string) *StreetsAndAlleysWebOutput) bool {
-	if !requireParam(bc, w, newDefault, param.From == nil || param.To == nil, "param error: from and to are required.") {
-		return true
+	mv := topCardMove{haveFrom: param.From != nil, haveTo: param.To != nil}
+	if param.From != nil {
+		mv.fromZone, mv.fromCol = param.From.Zone, param.From.Col
 	}
-	fromZone := param.From.Zone
-	toZone := param.To.Zone
-
-	switch {
-	case fromZone == "tableau" && toZone == "tableau":
-		if !requireParam(bc, w, newDefault, param.From.Col == nil || param.To.Col == nil, "param error: from.col and to.col are required.") {
-			return true
-		}
-		// Streets and Alleys only ever moves the top card; pass -1 so the
-		// domain resolves the index from its own state.
-		bc.writePresenterResponse(w, bi.MoveTableauToTableau(*param.From.Col, -1, *param.To.Col))
-	case fromZone == "tableau" && toZone == "foundation":
-		if !requireParam(bc, w, newDefault, param.From.Col == nil, "param error: from.col is required.") {
-			return true
-		}
-		bc.writePresenterResponse(w, bi.MoveTableauToFoundation(*param.From.Col))
-	default:
-		bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: invalid move zones."))
+	if param.To != nil {
+		mv.toZone, mv.toCol = param.To.Zone, param.To.Col
 	}
-	return true
+	return dispatchTopCardMove(bc, w, mv, topCardMoveFns{
+		tableauToTableau:    bi.MoveTableauToTableau,
+		tableauToFoundation: bi.MoveTableauToFoundation,
+	}, newDefault)
 }

--- a/internal/adapter/controller/SuecaWebController.go
+++ b/internal/adapter/controller/SuecaWebController.go
@@ -99,20 +99,12 @@ func newSuecaDefaultOutput(msg string) *SuecaWebOutput {
 }
 
 func suecaDispatch(bc *baseController, w http.ResponseWriter, di usecase.SuecaInteractorIF, param SuecaWebInput, newDefault func(string) *SuecaWebOutput) bool {
-	switch param.Command {
-	case "r", "reset":
-		bc.writePresenterResponse(w, di.ResetWithConfig(param.ToConfig()))
-	case "p", "play":
-		if !requireParam(bc, w, newDefault, param.CardIndex == nil, "param error: cardIndex is required.") {
-			return true
-		}
-		bc.writePresenterResponse(w, di.Play(*param.CardIndex))
-	case "n", "next":
-		bc.writePresenterResponse(w, di.NextTrick())
-	case "nr", "nextround":
-		bc.writePresenterResponse(w, di.NextRound())
-	default:
-		return dispatchHintAndLog(param.Command, bc, w, di.Hint, di.ActionLog)
-	}
-	return true
+	return dispatchTrickPlay(param.Command, bc, w, trickPlayFns{
+		resetWithConfig: func() string { return di.ResetWithConfig(param.ToConfig()) },
+		play:            di.Play,
+		nextTrick:       di.NextTrick,
+		nextRound:       di.NextRound,
+		hint:            di.Hint,
+		actionLog:       di.ActionLog,
+	}, param.CardIndex, newDefault)
 }

--- a/internal/adapter/controller/TarocchiniWebController.go
+++ b/internal/adapter/controller/TarocchiniWebController.go
@@ -105,25 +105,13 @@ func newTarocchiniDefaultOutput(msg string) *TarocchiniWebOutput {
 }
 
 func tarocchiniDispatch(bc *baseController, w http.ResponseWriter, di usecase.TarocchiniInteractorIF, param TarocchiniWebInput, newDefault func(string) *TarocchiniWebOutput) bool {
-	switch param.Command {
-	case "r", "reset":
-		bc.writePresenterResponse(w, di.ResetWithConfig(param.ToConfig()))
-	case "s", "scarto", "d", "discard":
-		if !requireParam(bc, w, newDefault, param.CardIndices == nil, "param error: cardIndices is required.") {
-			return true
-		}
-		bc.writePresenterResponse(w, di.Discard(param.CardIndices))
-	case "p", "play":
-		if !requireParam(bc, w, newDefault, param.CardIndex == nil, "param error: cardIndex is required.") {
-			return true
-		}
-		bc.writePresenterResponse(w, di.Play(*param.CardIndex))
-	case "n", "next":
-		bc.writePresenterResponse(w, di.NextTrick())
-	case "nr", "nextround":
-		bc.writePresenterResponse(w, di.NextRound())
-	default:
-		return dispatchHintAndLog(param.Command, bc, w, di.Hint, di.ActionLog)
-	}
-	return true
+	return dispatchTarotDiscardPlay(param.Command, bc, w, tarotDiscardPlayFns{
+		resetWithConfig: func() string { return di.ResetWithConfig(param.ToConfig()) },
+		discard:         di.Discard,
+		play:            di.Play,
+		nextTrick:       di.NextTrick,
+		nextRound:       di.NextRound,
+		hint:            di.Hint,
+		actionLog:       di.ActionLog,
+	}, param.CardIndices, param.CardIndex, newDefault)
 }

--- a/internal/adapter/controller/TwentyNineWebController.go
+++ b/internal/adapter/controller/TwentyNineWebController.go
@@ -105,25 +105,13 @@ func newTwentyNineDefaultOutput(msg string) *TwentyNineWebOutput {
 }
 
 func twentyNineDispatch(bc *baseController, w http.ResponseWriter, di usecase.TwentyNineInteractorIF, param TwentyNineWebInput, newDefault func(string) *TwentyNineWebOutput) bool {
-	switch param.Command {
-	case "r", "reset":
-		bc.writePresenterResponse(w, di.ResetWithConfig(param.ToConfig()))
-	case "b", "bid":
-		if !requireParam(bc, w, newDefault, param.Bid == nil, "param error: bid is required.") {
-			return true
-		}
-		bc.writePresenterResponse(w, di.Bid(*param.Bid))
-	case "p", "play":
-		if !requireParam(bc, w, newDefault, param.CardIndex == nil, "param error: cardIndex is required.") {
-			return true
-		}
-		bc.writePresenterResponse(w, di.Play(*param.CardIndex))
-	case "n", "next":
-		bc.writePresenterResponse(w, di.NextTrick())
-	case "nr", "nextround":
-		bc.writePresenterResponse(w, di.NextRound())
-	default:
-		return dispatchHintAndLog(param.Command, bc, w, di.Hint, di.ActionLog)
-	}
-	return true
+	return dispatchBidTrickPlay(param.Command, bc, w, bidTrickPlayFns{
+		resetWithConfig: func() string { return di.ResetWithConfig(param.ToConfig()) },
+		bid:             di.Bid,
+		play:            di.Play,
+		nextTrick:       di.NextTrick,
+		nextRound:       di.NextRound,
+		hint:            di.Hint,
+		actionLog:       di.ActionLog,
+	}, param.Bid, param.CardIndex, newDefault)
 }

--- a/internal/adapter/controller/ViraWebController.go
+++ b/internal/adapter/controller/ViraWebController.go
@@ -111,25 +111,13 @@ func newViraDefaultOutput(msg string) *ViraWebOutput {
 }
 
 func viraDispatch(bc *baseController, w http.ResponseWriter, di usecase.ViraInteractorIF, param ViraWebInput, newDefault func(string) *ViraWebOutput) bool {
-	switch param.Command {
-	case "r", "reset":
-		bc.writePresenterResponse(w, di.ResetWithConfig(param.ToConfig()))
-	case "b", "bid":
-		if !requireParam(bc, w, newDefault, param.Bid == nil, "param error: bid is required.") {
-			return true
-		}
-		bc.writePresenterResponse(w, di.Bid(*param.Bid))
-	case "p", "play":
-		if !requireParam(bc, w, newDefault, param.CardIndex == nil, "param error: cardIndex is required.") {
-			return true
-		}
-		bc.writePresenterResponse(w, di.Play(*param.CardIndex))
-	case "n", "next":
-		bc.writePresenterResponse(w, di.NextTrick())
-	case "nr", "nextround":
-		bc.writePresenterResponse(w, di.NextRound())
-	default:
-		return dispatchHintAndLog(param.Command, bc, w, di.Hint, di.ActionLog)
-	}
-	return true
+	return dispatchBidTrickPlay(param.Command, bc, w, bidTrickPlayFns{
+		resetWithConfig: func() string { return di.ResetWithConfig(param.ToConfig()) },
+		bid:             di.Bid,
+		play:            di.Play,
+		nextTrick:       di.NextTrick,
+		nextRound:       di.NextRound,
+		hint:            di.Hint,
+		actionLog:       di.ActionLog,
+	}, param.Bid, param.CardIndex, newDefault)
 }

--- a/internal/adapter/controller/WaspWebController.go
+++ b/internal/adapter/controller/WaspWebController.go
@@ -79,15 +79,12 @@ func waspDispatch(bc *baseController, w http.ResponseWriter, si usecase.WaspInte
 }
 
 func waspMoveDispatch(bc *baseController, w http.ResponseWriter, si usecase.WaspInteractorIF, param WaspWebInput, newDefault func(string) *WaspWebOutput) bool {
-	if !requireParam(bc, w, newDefault, param.From == nil || param.To == nil, "param error: from and to are required.") {
-		return true
+	mv := tableauMove{haveFrom: param.From != nil, haveTo: param.To != nil}
+	if param.From != nil {
+		mv.fromZone, mv.fromCol, mv.fromCardIndex = param.From.Zone, param.From.Col, param.From.CardIndex
 	}
-	if !requireParam(bc, w, newDefault, param.From.Zone != "tableau" || param.To.Zone != "tableau", "param error: invalid move zones. Only tableau to tableau is supported.") {
-		return true
+	if param.To != nil {
+		mv.toZone, mv.toCol = param.To.Zone, param.To.Col
 	}
-	if !requireParam(bc, w, newDefault, param.From.Col == nil || param.From.CardIndex == nil || param.To.Col == nil, "param error: from.col, from.cardIndex, to.col are required.") {
-		return true
-	}
-	bc.writePresenterResponse(w, si.MoveTableauToTableau(*param.From.Col, *param.From.CardIndex, *param.To.Col))
-	return true
+	return dispatchTableauOnlyMove(bc, w, mv, si.MoveTableauToTableau, newDefault)
 }

--- a/internal/adapter/controller/web_dispatch_helper.go
+++ b/internal/adapter/controller/web_dispatch_helper.go
@@ -134,3 +134,47 @@ func dispatchTrickPlay[O any](cmd string, bc *baseController, w http.ResponseWri
 	}
 	return true
 }
+
+// bidTrickPlayFns is trickPlayFns plus the bid step used by the trick-taking
+// games that open with an auction.
+type bidTrickPlayFns struct {
+	resetWithConfig func() string
+	bid             func(bid int) string
+	play            func(cardIndex int) string
+	nextTrick       func() string
+	nextRound       func() string
+	hint            func() string
+	actionLog       func() string
+}
+
+// dispatchBidTrickPlay handles reset/bid/play/next/nextround, falling through
+// to dispatchHintAndLog. Consolidates 6 byte-identical dispatchers:
+// fortyFivesDispatch, napDispatch, preferenceDispatch, soloWhistDispatch,
+// twentyNineDispatch, viraDispatch. See issue #5368.
+//
+// A separate helper rather than an optional bid field on trickPlayFns: a
+// nil-able function would let a game accept "b" and silently do nothing, and
+// the compiler would not notice. Two structs make the command set explicit.
+func dispatchBidTrickPlay[O any](cmd string, bc *baseController, w http.ResponseWriter, fns bidTrickPlayFns, bid, cardIndex *int, newDefault func(string) O) bool {
+	switch cmd {
+	case "r", "reset":
+		bc.writePresenterResponse(w, fns.resetWithConfig())
+	case "b", "bid":
+		if !requireParam(bc, w, newDefault, bid == nil, "param error: bid is required.") {
+			return true
+		}
+		bc.writePresenterResponse(w, fns.bid(*bid))
+	case "p", "play":
+		if !requireParam(bc, w, newDefault, cardIndex == nil, "param error: cardIndex is required.") {
+			return true
+		}
+		bc.writePresenterResponse(w, fns.play(*cardIndex))
+	case "n", "next":
+		bc.writePresenterResponse(w, fns.nextTrick())
+	case "nr", "nextround":
+		bc.writePresenterResponse(w, fns.nextRound())
+	default:
+		return dispatchHintAndLog(cmd, bc, w, fns.hint, fns.actionLog)
+	}
+	return true
+}

--- a/internal/adapter/controller/web_dispatch_helper.go
+++ b/internal/adapter/controller/web_dispatch_helper.go
@@ -178,3 +178,56 @@ func dispatchBidTrickPlay[O any](cmd string, bc *baseController, w http.Response
 	}
 	return true
 }
+
+// rummyMeldFns is the interactor surface of the canasta-family command set.
+//
+// drawFromDiscard and meld take their argument from the request rather than as
+// a parameter here: the games differ in what they pass (natural-pair indices,
+// meld groups), and closing over param at the call site keeps that difference
+// out of this helper.
+type rummyMeldFns struct {
+	resetWithConfig func() string
+	drawFromStock   func() string
+	drawFromDiscard func() string
+	meld            func() string
+	skipMeld        func() string
+	discard         func(cardIndex int) string
+	goOut           func() string
+	nextRound       func() string
+	actionLog       func() string
+}
+
+// dispatchRummyMeld handles the draw/meld/discard/go-out command set shared by
+// the canasta family, falling through to dispatchLog for "log"/"l".
+//
+// Consolidates 4 byte-identical dispatchers: burracoDispatch, canastaDispatch,
+// handAndFootDispatch, sambaDispatch. See issue #5368.
+//
+// dispatchLog, not dispatchHintAndLog: these games have no hint command, so
+// "h" must fall through to the caller's default rather than be answered here.
+func dispatchRummyMeld[O any](cmd string, bc *baseController, w http.ResponseWriter, fns rummyMeldFns, cardIndex *int, newDefault func(string) O) bool {
+	switch cmd {
+	case "r", "reset":
+		bc.writePresenterResponse(w, fns.resetWithConfig())
+	case "ds", "drawstock":
+		bc.writePresenterResponse(w, fns.drawFromStock())
+	case "dd", "drawdiscard":
+		bc.writePresenterResponse(w, fns.drawFromDiscard())
+	case "m", "meld":
+		bc.writePresenterResponse(w, fns.meld())
+	case "sm", "skipmeld":
+		bc.writePresenterResponse(w, fns.skipMeld())
+	case "d", "discard":
+		if !requireParam(bc, w, newDefault, cardIndex == nil, "param error: cardIndex is required.") {
+			return true
+		}
+		bc.writePresenterResponse(w, fns.discard(*cardIndex))
+	case "go", "goout":
+		bc.writePresenterResponse(w, fns.goOut())
+	case "nr", "nextround":
+		bc.writePresenterResponse(w, fns.nextRound())
+	default:
+		return dispatchLog(cmd, bc, w, fns.actionLog)
+	}
+	return true
+}

--- a/internal/adapter/controller/web_dispatch_helper.go
+++ b/internal/adapter/controller/web_dispatch_helper.go
@@ -86,3 +86,51 @@ func dispatchResetStepLog(cmd string, bc *baseController, w http.ResponseWriter,
 	}
 	return false
 }
+
+// trickPlayFns is the set of interactor actions the trick-taking command set
+// needs, passed as function values rather than as an interface.
+//
+// An interface cannot express this: every game's ResetWithConfig takes its own
+// config type (domain.AluetteConfig, domain.ManilleConfig, …), so there is no
+// single method set they share. Binding the calls at the call site — where the
+// concrete type is still known — is what lets one dispatcher serve all of them.
+// Same reasoning as dispatchResetHintAndLog's resetFn/hintFn/actionLogFn.
+type trickPlayFns struct {
+	resetWithConfig func() string
+	play            func(cardIndex int) string
+	nextTrick       func() string
+	nextRound       func() string
+	hint            func() string
+	actionLog       func() string
+}
+
+// dispatchTrickPlay handles the reset/play/next/nextround command set shared by
+// the trick-taking games, falling through to dispatchHintAndLog for "h"/"log".
+// Returns false for a command it does not own so the caller can handle it.
+//
+// Consolidates 8 byte-identical dispatchers that differed only in name and in
+// the concrete interactor type: aluetteDispatch, ganjifaDispatch,
+// klaverjasDispatch, manilleDispatch, mariasDispatch, sedmaDispatch,
+// spoilFiveDispatch, suecaDispatch. Being spelled differently per game is why a
+// name-based search never grouped them — see issue #5368.
+//
+// cardIndex is a pointer because it is optional on the wire; "p" with none set
+// must answer 400 rather than dereference nil.
+func dispatchTrickPlay[O any](cmd string, bc *baseController, w http.ResponseWriter, fns trickPlayFns, cardIndex *int, newDefault func(string) O) bool {
+	switch cmd {
+	case "r", "reset":
+		bc.writePresenterResponse(w, fns.resetWithConfig())
+	case "p", "play":
+		if !requireParam(bc, w, newDefault, cardIndex == nil, "param error: cardIndex is required.") {
+			return true
+		}
+		bc.writePresenterResponse(w, fns.play(*cardIndex))
+	case "n", "next":
+		bc.writePresenterResponse(w, fns.nextTrick())
+	case "nr", "nextround":
+		bc.writePresenterResponse(w, fns.nextRound())
+	default:
+		return dispatchHintAndLog(cmd, bc, w, fns.hint, fns.actionLog)
+	}
+	return true
+}

--- a/internal/adapter/controller/web_dispatch_helper.go
+++ b/internal/adapter/controller/web_dispatch_helper.go
@@ -231,3 +231,43 @@ func dispatchRummyMeld[O any](cmd string, bc *baseController, w http.ResponseWri
 	}
 	return true
 }
+
+// tableauMove is one move request, unpacked from whichever per-game zone type
+// carried it.
+//
+// Every solitaire declares its own zone struct (ScorpionWebZone,
+// SpideretteWebZone, WaspWebZone, …) with identical fields, and Go has no
+// structural typing, so there is nothing common to accept. The caller unpacks
+// its own type into this; the helper owns the validation order.
+type tableauMove struct {
+	haveFrom, haveTo bool
+	fromZone, toZone string
+	fromCol          *int
+	fromCardIndex    *int
+	toCol            *int
+}
+
+// dispatchTableauOnlyMove validates and performs a tableau-to-tableau move for
+// the solitaires that allow no other kind, answering 400 for anything else.
+//
+// Consolidates 3 byte-identical dispatchers: scorpionMoveDispatch,
+// spideretteMoveDispatch, waspMoveDispatch. See issue #5368.
+//
+// Always returns true: unlike the command dispatchers, this one owns the whole
+// request. Reporting false would leave the caller to answer a request that has
+// already been written to.
+func dispatchTableauOnlyMove[O any](bc *baseController, w http.ResponseWriter, mv tableauMove, move func(fromCol, cardIndex, toCol int) string, newDefault func(string) O) bool {
+	if !requireParam(bc, w, newDefault, !mv.haveFrom || !mv.haveTo, "param error: from and to are required.") {
+		return true
+	}
+	if !requireParam(bc, w, newDefault, mv.fromZone != "tableau" || mv.toZone != "tableau",
+		"param error: invalid move zones. Only tableau to tableau is supported.") {
+		return true
+	}
+	if !requireParam(bc, w, newDefault, mv.fromCol == nil || mv.fromCardIndex == nil || mv.toCol == nil,
+		"param error: from.col, from.cardIndex, to.col are required.") {
+		return true
+	}
+	bc.writePresenterResponse(w, move(*mv.fromCol, *mv.fromCardIndex, *mv.toCol))
+	return true
+}

--- a/internal/adapter/controller/web_dispatch_helper.go
+++ b/internal/adapter/controller/web_dispatch_helper.go
@@ -271,3 +271,95 @@ func dispatchTableauOnlyMove[O any](bc *baseController, w http.ResponseWriter, m
 	bc.writePresenterResponse(w, move(*mv.fromCol, *mv.fromCardIndex, *mv.toCol))
 	return true
 }
+
+// tarotDiscardPlayFns is the interactor surface of the tarot command set.
+type tarotDiscardPlayFns struct {
+	resetWithConfig func() string
+	discard         func(cardIndices []int) string
+	play            func(cardIndex int) string
+	nextTrick       func() string
+	nextRound       func() string
+	hint            func() string
+	actionLog       func() string
+}
+
+// dispatchTarotDiscardPlay handles reset/discard/play/next/nextround for the
+// tarot games, falling through to dispatchHintAndLog.
+//
+// Consolidates 3 byte-identical dispatchers: minchiateDispatch, scartoDispatch,
+// tarocchiniDispatch. See issue #5368.
+//
+// The discard step answers to two spellings ("s"/"scarto" and "d"/"discard")
+// and takes a slice, so its missing-check is nil rather than len == 0: an empty
+// slice is a legal "discard nothing", and rejecting it would 400 a valid
+// request.
+func dispatchTarotDiscardPlay[O any](cmd string, bc *baseController, w http.ResponseWriter, fns tarotDiscardPlayFns, cardIndices []int, cardIndex *int, newDefault func(string) O) bool {
+	switch cmd {
+	case "r", "reset":
+		bc.writePresenterResponse(w, fns.resetWithConfig())
+	case "s", "scarto", "d", "discard":
+		if !requireParam(bc, w, newDefault, cardIndices == nil, "param error: cardIndices is required.") {
+			return true
+		}
+		bc.writePresenterResponse(w, fns.discard(cardIndices))
+	case "p", "play":
+		if !requireParam(bc, w, newDefault, cardIndex == nil, "param error: cardIndex is required.") {
+			return true
+		}
+		bc.writePresenterResponse(w, fns.play(*cardIndex))
+	case "n", "next":
+		bc.writePresenterResponse(w, fns.nextTrick())
+	case "nr", "nextround":
+		bc.writePresenterResponse(w, fns.nextRound())
+	default:
+		return dispatchHintAndLog(cmd, bc, w, fns.hint, fns.actionLog)
+	}
+	return true
+}
+
+// topCardMove is one move request for the top-card-only solitaires, unpacked
+// from whichever per-game zone type carried it. Same reasoning as tableauMove.
+type topCardMove struct {
+	haveFrom, haveTo bool
+	fromZone, toZone string
+	fromCol          *int
+	toCol            *int
+}
+
+// topCardMoveFns is the interactor surface these moves need.
+type topCardMoveFns struct {
+	tableauToTableau    func(fromCol, cardIndex, toCol int) string
+	tableauToFoundation func(col int) string
+}
+
+// dispatchTopCardMove validates and performs a move for the solitaires that
+// only ever move the top card of a column.
+//
+// Consolidates 3 byte-identical dispatchers: bakersDozenMoveDispatch,
+// beleagueredCastleMoveDispatch, streetsAndAlleysMoveDispatch. See #5368.
+//
+// Passes -1 as the card index rather than the client's value: these games move
+// only the top card, so the domain resolves the index from its own state and
+// the server has one less untrusted input. That contract is pinned by a test —
+// forwarding the client value instead would let a request name a card that is
+// not on top, and the move would still look legal.
+func dispatchTopCardMove[O any](bc *baseController, w http.ResponseWriter, mv topCardMove, fns topCardMoveFns, newDefault func(string) O) bool {
+	if !requireParam(bc, w, newDefault, !mv.haveFrom || !mv.haveTo, "param error: from and to are required.") {
+		return true
+	}
+	switch {
+	case mv.fromZone == "tableau" && mv.toZone == "tableau":
+		if !requireParam(bc, w, newDefault, mv.fromCol == nil || mv.toCol == nil, "param error: from.col and to.col are required.") {
+			return true
+		}
+		bc.writePresenterResponse(w, fns.tableauToTableau(*mv.fromCol, -1, *mv.toCol))
+	case mv.fromZone == "tableau" && mv.toZone == "foundation":
+		if !requireParam(bc, w, newDefault, mv.fromCol == nil, "param error: from.col is required.") {
+			return true
+		}
+		bc.writePresenterResponse(w, fns.tableauToFoundation(*mv.fromCol))
+	default:
+		bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: invalid move zones."))
+	}
+	return true
+}

--- a/internal/adapter/controller/web_dispatch_helper_test.go
+++ b/internal/adapter/controller/web_dispatch_helper_test.go
@@ -327,3 +327,60 @@ func TestDispatchRummyMeld_HintIsNotHandled(t *testing.T) {
 	assert.False(t, handled)
 	assert.Empty(t, w.Body.String())
 }
+
+// dispatchTableauOnlyMove consolidates scorpionMoveDispatch,
+// spideretteMoveDispatch and waspMoveDispatch — solitaires whose only legal
+// move is tableau-to-tableau, so anything else is a 400 rather than a branch.
+//
+// Zones are passed as plain values, not as a struct: every game declares its
+// own zone type (ScorpionWebZone, SpideretteWebZone, …) with identical fields,
+// and there is no shared type to accept. The caller unpacks; the helper decides.
+func TestDispatchTableauOnlyMove(t *testing.T) {
+	col, idx := 1, 2
+
+	cases := []struct {
+		name                       string
+		haveFrom, haveTo           bool
+		fromZone, toZone           string
+		fromCol, fromIdx, toColPtr *int
+		wantBody                   string
+		wantCode                   int
+	}{
+		{"tableau to tableau", true, true, "tableau", "tableau", &col, &idx, &col, `{"moved":true}`, 200},
+		{"missing from", false, true, "", "tableau", nil, nil, &col, "from and to are required", 400},
+		{"missing to", true, false, "tableau", "", &col, &idx, nil, "from and to are required", 400},
+		{"foundation is not a legal target", true, true, "tableau", "foundation", &col, &idx, &col, "Only tableau to tableau", 400},
+		{"waste is not a legal source", true, true, "waste", "tableau", &col, &idx, &col, "Only tableau to tableau", 400},
+		{"missing cardIndex", true, true, "tableau", "tableau", &col, nil, &col, "from.cardIndex", 400},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			handled := dispatchTableauOnlyMove(&baseController{}, w, tableauMove{
+				haveFrom: tc.haveFrom, haveTo: tc.haveTo,
+				fromZone: tc.fromZone, toZone: tc.toZone,
+				fromCol: tc.fromCol, fromCardIndex: tc.fromIdx, toCol: tc.toColPtr,
+			}, func(fromCol, cardIndex, toCol int) string { return `{"moved":true}` },
+				func(msg string) any { return map[string]string{"message": msg} })
+			assert.True(t, handled, "the helper always answers -- it never falls through")
+			assert.Equal(t, tc.wantCode, w.Code)
+			assert.Contains(t, w.Body.String(), tc.wantBody)
+		})
+	}
+}
+
+// The move function must receive the indices in the documented order; swapping
+// fromCol and toCol renders a legal-looking move that plays the wrong card.
+func TestDispatchTableauOnlyMove_PassesIndicesInOrder(t *testing.T) {
+	from, ci, to := 3, 4, 5
+	var got []int
+	w := httptest.NewRecorder()
+	dispatchTableauOnlyMove(&baseController{}, w, tableauMove{
+		haveFrom: true, haveTo: true, fromZone: "tableau", toZone: "tableau",
+		fromCol: &from, fromCardIndex: &ci, toCol: &to,
+	}, func(fromCol, cardIndex, toCol int) string {
+		got = []int{fromCol, cardIndex, toCol}
+		return "{}"
+	}, func(msg string) any { return msg })
+	assert.Equal(t, []int{3, 4, 5}, got)
+}

--- a/internal/adapter/controller/web_dispatch_helper_test.go
+++ b/internal/adapter/controller/web_dispatch_helper_test.go
@@ -266,3 +266,64 @@ func TestDispatchBidTrickPlay_UnknownCommandIsNotHandled(t *testing.T) {
 	assert.False(t, handled)
 	assert.Empty(t, w.Body.String())
 }
+
+// dispatchRummyMeld consolidates the 4 identical canasta-family dispatchers:
+// burracoDispatch, canastaDispatch, handAndFootDispatch, sambaDispatch.
+// Falls through to dispatchLog (not dispatchHintAndLog) — these games have no
+// hint command, and wiring one that does not exist would answer a hint request
+// with a nil call.
+func TestDispatchRummyMeld(t *testing.T) {
+	cases := []struct {
+		name     string
+		cmd      string
+		cardIdx  *int
+		wantBody string
+		wantCode int
+	}{
+		{"reset", "r", nil, `{"method":"reset"}`, 200},
+		{"draw stock", "ds", nil, `{"method":"drawstock"}`, 200},
+		{"draw stock long form", "drawstock", nil, `{"method":"drawstock"}`, 200},
+		{"draw discard", "dd", nil, `{"method":"drawdiscard"}`, 200},
+		{"meld", "m", nil, `{"method":"meld"}`, 200},
+		{"skip meld", "sm", nil, `{"method":"skipmeld"}`, 200},
+		{"discard", "d", intPtr(4), `{"method":"discard:4"}`, 200},
+		{"go out", "go", nil, `{"method":"goout"}`, 200},
+		{"next round", "nr", nil, `{"method":"nextround"}`, 200},
+		{"log", "log", nil, `{"method":"log"}`, 200},
+		{"discard without an index", "d", nil, "cardIndex is required", 400},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			handled := dispatchRummyMeld(tc.cmd, &baseController{}, w, rummyMeldFns{
+				resetWithConfig: func() string { return `{"method":"reset"}` },
+				drawFromStock:   func() string { return `{"method":"drawstock"}` },
+				drawFromDiscard: func() string { return `{"method":"drawdiscard"}` },
+				meld:            func() string { return `{"method":"meld"}` },
+				skipMeld:        func() string { return `{"method":"skipmeld"}` },
+				discard:         func(i int) string { return `{"method":"discard:` + strconv.Itoa(i) + `"}` },
+				goOut:           func() string { return `{"method":"goout"}` },
+				nextRound:       func() string { return `{"method":"nextround"}` },
+				actionLog:       func() string { return `{"method":"log"}` },
+			}, tc.cardIdx, func(msg string) any { return map[string]string{"message": msg} })
+			assert.True(t, handled)
+			assert.Equal(t, tc.wantCode, w.Code)
+			assert.Contains(t, w.Body.String(), tc.wantBody)
+		})
+	}
+}
+
+// "h"/"hint" must fall through unhandled: these games have no hint, and the
+// caller's default branch is what answers.
+func TestDispatchRummyMeld_HintIsNotHandled(t *testing.T) {
+	w := httptest.NewRecorder()
+	handled := dispatchRummyMeld("h", &baseController{}, w, rummyMeldFns{
+		resetWithConfig: func() string { return "" }, drawFromStock: func() string { return "" },
+		drawFromDiscard: func() string { return "" }, meld: func() string { return "" },
+		skipMeld: func() string { return "" }, discard: func(int) string { return "" },
+		goOut: func() string { return "" }, nextRound: func() string { return "" },
+		actionLog: func() string { return "" },
+	}, nil, func(msg string) any { return msg })
+	assert.False(t, handled)
+	assert.Empty(t, w.Body.String())
+}

--- a/internal/adapter/controller/web_dispatch_helper_test.go
+++ b/internal/adapter/controller/web_dispatch_helper_test.go
@@ -210,3 +210,59 @@ func TestDispatchTrickPlay_UnknownCommandIsNotHandled(t *testing.T) {
 	assert.Equal(t, 200, w.Code, "nothing should have been written")
 	assert.Empty(t, w.Body.String())
 }
+
+// dispatchBidTrickPlay is dispatchTrickPlay plus a bid step, consolidating
+// 6 more byte-identical dispatchers: fortyFivesDispatch, napDispatch,
+// preferenceDispatch, soloWhistDispatch, twentyNineDispatch, viraDispatch.
+// Kept separate from dispatchTrickPlay rather than making bid optional: a
+// nil-able function field would let a game silently accept "b" and do nothing.
+func TestDispatchBidTrickPlay(t *testing.T) {
+	cases := []struct {
+		name     string
+		cmd      string
+		bid      *int
+		cardIdx  *int
+		wantBody string
+		wantCode int
+	}{
+		{"reset", "r", nil, nil, `{"method":"reset"}`, 200},
+		{"bid", "b", intPtr(3), nil, `{"method":"bid:3"}`, 200},
+		{"bid long form", "bid", intPtr(0), nil, `{"method":"bid:0"}`, 200},
+		{"play", "p", nil, intPtr(5), `{"method":"play:5"}`, 200},
+		{"next trick", "n", nil, nil, `{"method":"next"}`, 200},
+		{"next round", "nr", nil, nil, `{"method":"nextround"}`, 200},
+		{"hint", "h", nil, nil, `{"method":"hint"}`, 200},
+		{"log", "log", nil, nil, `{"method":"log"}`, 200},
+		{"bid without a value", "b", nil, nil, "bid is required", 400},
+		{"play without an index", "p", nil, nil, "cardIndex is required", 400},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			handled := dispatchBidTrickPlay(tc.cmd, &baseController{}, w, bidTrickPlayFns{
+				resetWithConfig: func() string { return `{"method":"reset"}` },
+				bid:             func(b int) string { return `{"method":"bid:` + strconv.Itoa(b) + `"}` },
+				play:            func(i int) string { return `{"method":"play:` + strconv.Itoa(i) + `"}` },
+				nextTrick:       func() string { return `{"method":"next"}` },
+				nextRound:       func() string { return `{"method":"nextround"}` },
+				hint:            func() string { return `{"method":"hint"}` },
+				actionLog:       func() string { return `{"method":"log"}` },
+			}, tc.bid, tc.cardIdx, func(msg string) any { return map[string]string{"message": msg} })
+			assert.True(t, handled)
+			assert.Equal(t, tc.wantCode, w.Code)
+			assert.Contains(t, w.Body.String(), tc.wantBody)
+		})
+	}
+}
+
+func TestDispatchBidTrickPlay_UnknownCommandIsNotHandled(t *testing.T) {
+	w := httptest.NewRecorder()
+	handled := dispatchBidTrickPlay("frobnicate", &baseController{}, w, bidTrickPlayFns{
+		resetWithConfig: func() string { return "" }, bid: func(int) string { return "" },
+		play: func(int) string { return "" }, nextTrick: func() string { return "" },
+		nextRound: func() string { return "" }, hint: func() string { return "" },
+		actionLog: func() string { return "" },
+	}, nil, nil, func(msg string) any { return msg })
+	assert.False(t, handled)
+	assert.Empty(t, w.Body.String())
+}

--- a/internal/adapter/controller/web_dispatch_helper_test.go
+++ b/internal/adapter/controller/web_dispatch_helper_test.go
@@ -4,6 +4,7 @@ package controller
 
 import (
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -141,4 +142,71 @@ func TestDispatchResetHintAndLog(t *testing.T) {
 			assert.Equal(t, tc.wantBody, strings.TrimSpace(w.Body.String()))
 		})
 	}
+}
+
+// dispatchTrickPlay consolidates 8 byte-identical per-game dispatchers
+// (aluetteDispatch, ganjifaDispatch, klaverjasDispatch, manilleDispatch,
+// mariasDispatch, sedmaDispatch, spoilFiveDispatch, suecaDispatch). They
+// differed only in name and in the concrete interactor type — see #5368.
+//
+// Taking function values rather than an interface is what makes that possible:
+// each game's ResetWithConfig takes its own config type, so no single interface
+// can cover them. That is the same reason dispatchResetHintAndLog above takes
+// resetFn/hintFn/actionLogFn.
+func TestDispatchTrickPlay(t *testing.T) {
+	cases := []struct {
+		name     string
+		cmd      string
+		cardIdx  *int
+		wantBody string
+		wantCode int
+	}{
+		{"reset", "r", nil, `{"method":"reset"}`, 200},
+		{"reset long form", "reset", nil, `{"method":"reset"}`, 200},
+		{"play", "p", intPtr(2), `{"method":"play:2"}`, 200},
+		{"play long form", "play", intPtr(0), `{"method":"play:0"}`, 200},
+		{"next trick", "n", nil, `{"method":"next"}`, 200},
+		{"next trick long form", "next", nil, `{"method":"next"}`, 200},
+		{"next round", "nr", nil, `{"method":"nextround"}`, 200},
+		{"next round long form", "nextround", nil, `{"method":"nextround"}`, 200},
+		{"hint falls through to the shared helper", "h", nil, `{"method":"hint"}`, 200},
+		{"log falls through to the shared helper", "log", nil, `{"method":"log"}`, 200},
+		// The missing-parameter path must 400 rather than dereference nil.
+		{"play without an index", "p", nil, "cardIndex is required", 400},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			bc := &baseController{}
+			handled := dispatchTrickPlay(tc.cmd, bc, w, trickPlayFns{
+				resetWithConfig: func() string { return `{"method":"reset"}` },
+				play:            func(i int) string { return `{"method":"play:` + strconv.Itoa(i) + `"}` },
+				nextTrick:       func() string { return `{"method":"next"}` },
+				nextRound:       func() string { return `{"method":"nextround"}` },
+				hint:            func() string { return `{"method":"hint"}` },
+				actionLog:       func() string { return `{"method":"log"}` },
+			}, tc.cardIdx, func(msg string) any { return map[string]string{"message": msg} })
+			assert.True(t, handled, "every command in this table is handled")
+			assert.Equal(t, tc.wantCode, w.Code)
+			assert.True(t, strings.Contains(w.Body.String(), tc.wantBody),
+				"body %q should contain %q", w.Body.String(), tc.wantBody)
+		})
+	}
+}
+
+// An unknown command must NOT be swallowed: the caller falls back to its own
+// default branch, and reporting true here would silently drop the request.
+func TestDispatchTrickPlay_UnknownCommandIsNotHandled(t *testing.T) {
+	w := httptest.NewRecorder()
+	handled := dispatchTrickPlay("frobnicate", &baseController{}, w, trickPlayFns{
+		resetWithConfig: func() string { return "" },
+		play:            func(int) string { return "" },
+		nextTrick:       func() string { return "" },
+		nextRound:       func() string { return "" },
+		hint:            func() string { return "" },
+		actionLog:       func() string { return "" },
+	}, nil, func(msg string) any { return msg })
+	assert.False(t, handled)
+	assert.Equal(t, 200, w.Code, "nothing should have been written")
+	assert.Empty(t, w.Body.String())
 }

--- a/internal/adapter/controller/web_dispatch_helper_test.go
+++ b/internal/adapter/controller/web_dispatch_helper_test.go
@@ -384,3 +384,117 @@ func TestDispatchTableauOnlyMove_PassesIndicesInOrder(t *testing.T) {
 	}, func(msg string) any { return msg })
 	assert.Equal(t, []int{3, 4, 5}, got)
 }
+
+// dispatchTarotDiscardPlay consolidates minchiateDispatch, scartoDispatch and
+// tarocchiniDispatch — tarot games whose discard step takes a slice of indices
+// and answers to two command spellings ("s"/"scarto" as well as "d"/"discard").
+func TestDispatchTarotDiscardPlay(t *testing.T) {
+	idx := 3
+	cases := []struct {
+		name     string
+		cmd      string
+		indices  []int
+		cardIdx  *int
+		wantBody string
+		wantCode int
+	}{
+		{"reset", "r", nil, nil, `{"method":"reset"}`, 200},
+		{"discard as scarto", "s", []int{1, 2}, nil, `{"method":"discard:2"}`, 200},
+		{"discard as scarto long form", "scarto", []int{1}, nil, `{"method":"discard:1"}`, 200},
+		{"discard", "d", []int{1, 2, 3}, nil, `{"method":"discard:3"}`, 200},
+		{"discard long form", "discard", []int{}, nil, `{"method":"discard:0"}`, 200},
+		{"play", "p", nil, &idx, `{"method":"play:3"}`, 200},
+		{"next trick", "n", nil, nil, `{"method":"next"}`, 200},
+		{"next round", "nr", nil, nil, `{"method":"nextround"}`, 200},
+		{"hint", "h", nil, nil, `{"method":"hint"}`, 200},
+		{"log", "log", nil, nil, `{"method":"log"}`, 200},
+		{"discard without indices", "d", nil, nil, "cardIndices is required", 400},
+		{"play without an index", "p", nil, nil, "cardIndex is required", 400},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			handled := dispatchTarotDiscardPlay(tc.cmd, &baseController{}, w, tarotDiscardPlayFns{
+				resetWithConfig: func() string { return `{"method":"reset"}` },
+				discard:         func(ix []int) string { return `{"method":"discard:` + strconv.Itoa(len(ix)) + `"}` },
+				play:            func(i int) string { return `{"method":"play:` + strconv.Itoa(i) + `"}` },
+				nextTrick:       func() string { return `{"method":"next"}` },
+				nextRound:       func() string { return `{"method":"nextround"}` },
+				hint:            func() string { return `{"method":"hint"}` },
+				actionLog:       func() string { return `{"method":"log"}` },
+			}, tc.indices, tc.cardIdx, func(msg string) any { return map[string]string{"message": msg} })
+			assert.True(t, handled)
+			assert.Equal(t, tc.wantCode, w.Code)
+			assert.Contains(t, w.Body.String(), tc.wantBody)
+		})
+	}
+}
+
+// An empty (but non-nil) slice is a legal discard — "discard nothing" differs
+// from "the field was omitted", and conflating them would 400 a valid request.
+func TestDispatchTarotDiscardPlay_EmptySliceIsNotMissing(t *testing.T) {
+	w := httptest.NewRecorder()
+	dispatchTarotDiscardPlay("d", &baseController{}, w, tarotDiscardPlayFns{
+		discard: func(ix []int) string { return `{"n":` + strconv.Itoa(len(ix)) + `}` },
+	}, []int{}, nil, func(msg string) any { return msg })
+	assert.Equal(t, 200, w.Code)
+	assert.Contains(t, w.Body.String(), `{"n":0}`)
+}
+
+// dispatchTopCardMove consolidates bakersDozenMoveDispatch,
+// beleagueredCastleMoveDispatch and streetsAndAlleysMoveDispatch — solitaires
+// that move only the top card, so the domain resolves the index itself and the
+// client's cardIndex is never trusted.
+func TestDispatchTopCardMove(t *testing.T) {
+	col := 2
+	cases := []struct {
+		name             string
+		haveFrom, haveTo bool
+		fromZone, toZone string
+		fromCol, toCol   *int
+		wantBody         string
+		wantCode         int
+	}{
+		{"tableau to tableau", true, true, "tableau", "tableau", &col, &col, `{"tt":true}`, 200},
+		{"tableau to foundation", true, true, "tableau", "foundation", &col, nil, `{"tf":true}`, 200},
+		{"missing from", false, true, "", "tableau", nil, &col, "from and to are required", 400},
+		{"unsupported zone pair", true, true, "waste", "tableau", &col, &col, "invalid move zones", 400},
+		{"tableau to tableau without to.col", true, true, "tableau", "tableau", &col, nil, "from.col and to.col", 400},
+		{"tableau to foundation without from.col", true, true, "tableau", "foundation", nil, nil, "from.col is required", 400},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			handled := dispatchTopCardMove(&baseController{}, w, topCardMove{
+				haveFrom: tc.haveFrom, haveTo: tc.haveTo,
+				fromZone: tc.fromZone, toZone: tc.toZone,
+				fromCol: tc.fromCol, toCol: tc.toCol,
+			}, topCardMoveFns{
+				tableauToTableau:    func(from, idx, to int) string { return `{"tt":true}` },
+				tableauToFoundation: func(col int) string { return `{"tf":true}` },
+			}, func(msg string) any { return map[string]string{"message": msg} })
+			assert.True(t, handled)
+			assert.Equal(t, tc.wantCode, w.Code)
+			assert.Contains(t, w.Body.String(), tc.wantBody)
+		})
+	}
+}
+
+// -1 is the contract with the domain: "resolve the index yourself". Passing
+// the client's value instead would let a request name a card that is not on top.
+func TestDispatchTopCardMove_PassesMinusOneAsTheIndex(t *testing.T) {
+	from, to := 1, 4
+	var got []int
+	w := httptest.NewRecorder()
+	dispatchTopCardMove(&baseController{}, w, topCardMove{
+		haveFrom: true, haveTo: true, fromZone: "tableau", toZone: "tableau",
+		fromCol: &from, toCol: &to,
+	}, topCardMoveFns{
+		tableauToTableau: func(fromCol, cardIndex, toCol int) string {
+			got = []int{fromCol, cardIndex, toCol}
+			return "{}"
+		},
+		tableauToFoundation: func(int) string { return "{}" },
+	}, func(msg string) any { return msg })
+	assert.Equal(t, []int{1, -1, 4}, got)
+}


### PR DESCRIPTION
本文がバイト単位で一致する dispatcher を **27 箇所・6 クラスタ**すべて統合します。違うのは**名前と interactor の具象型だけ**でした。

[PR #5367](https://github.com/yuta-yoshinaga/go_trumpcards/pull/5367)（`*Filter` 26 箇所）と同じ「別名・同一本文」クラスで、名前ベースの探索では集まりません。**統合後、dispatch の重複グループは 0 になりました**（走査で確認）。

| ヘルパ | 数 | 対象 |
|---|---|---|
| `dispatchTrickPlay` | 8 | aluette / ganjifa / klaverjas / manille / marias / sedma / spoilFive / sueca |
| `dispatchBidTrickPlay` | 6 | fortyFives / nap / preference / soloWhist / twentyNine / vira |
| `dispatchRummyMeld` | 4 | burraco / canasta / handAndFoot / samba |
| `dispatchTableauOnlyMove` | 3 | scorpion / spiderette / wasp |
| `dispatchTarotDiscardPlay` | 3 | minchiate / scarto / tarocchini |
| `dispatchTopCardMove` | 3 | bakersDozen / beleagueredCastle / streetsAndAlleys |

## インタフェースでは統合できない

各ゲームの `ResetWithConfig` は**自分の設定型**を取ります（`domain.AluetteConfig` / `domain.ManilleConfig` / …）。共通のメソッドセットが無いので単一インタフェースでは表現できません。**関数値**で受け、具象型がまだ分かっている呼び出し側で束ねます。

移動系はさらに厳しく、ゾーン型すら共通化されていません（`ScorpionWebZone` / `SpideretteWebZone` / … がフィールド同一で別型）。Go には構造的型付けが無いので、呼び出し側が自分の型を `tableauMove` / `topCardMove` に展開し、**検証順はヘルパが持つ**形にしました。

## 設計判断（テストで固定したもの）

**ヘルパを分けた** — `trickPlayFns` に nil 許容の `bid` を足す案は却下しました。nil のまま `"b"` を受け付けて何もしないゲームを作れてしまい、コンパイラが気付きません。

**カナスタ系は `dispatchLog` に落とす** — この系統に hint は無く、存在しないものを配線すると hint 要求に nil 呼び出しで答えます。`"h"` が未処理で返ることをテストで固定。

**タロットの discard は nil 判定** — 空スライスは「何も捨てない」という正当な要求で、`len == 0` で弾くと有効なリクエストに 400 を返します。

**トップカード系は `-1` を渡す契約** — ドメインが自分の状態から添字を解決するので、サーバは信頼できない入力を 1 つ減らせます。クライアント値を渡すと「一番上でない札」を指定でき、しかも**移動は合法に見えます**。

**引数の順序** — `(fromCol, cardIndex, toCol)` が入れ替わっても合法に見える移動になり出力から気付けないので、順序もテストで固定しました。

## 行数

呼び出し側 27 ファイル: **-197 行**。ヘルパ +約 230 行（テスト別）。

## 検証

- `go build ./...` / `go vet -tags test ./internal/adapter/...` 通過
- `go test -tags test ./internal/adapter/controller/` 通過（新規 6 テスト群・約 60 ケース）
- `golangci-lint run ./internal/adapter/...` 0 issues
- **6 worker の `GOOS=js GOARCH=wasm`** すべて通過
- 各クラスタで置換件数が期待値と一致（不一致なら書き込みを中止する方式）
- 統合後の再走査で**重複グループ 0** を確認

Closes #5368 の dispatch 部分。`Output` ×24 / `NextRound` ×22 / ソリティア `Exec` ×6 のクラスタは別 PR に分割します。

Refs #5368