### PR TITLE
refactor(usecase): consolidate 22 identical NextRound implementations

### DIFF
--- a/internal/usecase/BurracoInteractor.go
+++ b/internal/usecase/BurracoInteractor.go
@@ -142,12 +142,7 @@ func (ci *BurracoInteractor) GoOut() string {
 
 // NextRound 次のラウンドへ進む
 func (ci *BurracoInteractor) NextRound() string {
-	if out, blocked := guardGameEnd(ci.Game, ci.gp); blocked {
-		return out
-	}
-	ci.Game.NextRound()
-	ci.runCpuTurns()
-	return ci.gp.Output(ci.Game, nil)
+	return advanceRound(ci.Game, ci.gp, ci.runCpuTurns)
 }
 
 // GetConfig 現在の設定を取得

--- a/internal/usecase/CanastaInteractor.go
+++ b/internal/usecase/CanastaInteractor.go
@@ -140,12 +140,7 @@ func (ci *CanastaInteractor) GoOut() string {
 
 // NextRound 次のラウンドへ進む
 func (ci *CanastaInteractor) NextRound() string {
-	if out, blocked := guardGameEnd(ci.Game, ci.gp); blocked {
-		return out
-	}
-	ci.Game.NextRound()
-	ci.runCpuTurns()
-	return ci.gp.Output(ci.Game, nil)
+	return advanceRound(ci.Game, ci.gp, ci.runCpuTurns)
 }
 
 // GetConfig 現在の設定を取得

--- a/internal/usecase/CariocaInteractor.go
+++ b/internal/usecase/CariocaInteractor.go
@@ -134,12 +134,7 @@ func (ci *CariocaInteractor) Discard(cardIndex int) string {
 
 // NextRound 次のラウンドへ進む
 func (ci *CariocaInteractor) NextRound() string {
-	if out, blocked := guardGameEnd(ci.Game, ci.gp); blocked {
-		return out
-	}
-	ci.Game.NextRound()
-	ci.runCpuTurns()
-	return ci.gp.Output(ci.Game, nil)
+	return advanceRound(ci.Game, ci.gp, ci.runCpuTurns)
 }
 
 // GetConfig 現在の設定を取得

--- a/internal/usecase/ChinchonInteractor.go
+++ b/internal/usecase/ChinchonInteractor.go
@@ -120,12 +120,7 @@ func (ci *ChinchonInteractor) Layoff(cardIndices []int) string {
 
 // NextRound 次のラウンドへ進む
 func (ci *ChinchonInteractor) NextRound() string {
-	if out, blocked := guardGameEnd(ci.Game, ci.gp); blocked {
-		return out
-	}
-	ci.Game.NextRound()
-	ci.runCpuTurns()
-	return ci.gp.Output(ci.Game, nil)
+	return advanceRound(ci.Game, ci.gp, ci.runCpuTurns)
 }
 
 // GetConfig 現在の設定を取得

--- a/internal/usecase/ConquianInteractor.go
+++ b/internal/usecase/ConquianInteractor.go
@@ -114,12 +114,7 @@ func (ci *ConquianInteractor) Discard(cardIndex int) string {
 
 // NextRound 次のラウンドへ進む
 func (ci *ConquianInteractor) NextRound() string {
-	if out, blocked := guardGameEnd(ci.Game, ci.gp); blocked {
-		return out
-	}
-	ci.Game.NextRound()
-	ci.runCpuTurns()
-	return ci.gp.Output(ci.Game, nil)
+	return advanceRound(ci.Game, ci.gp, ci.runCpuTurns)
 }
 
 // GetConfig 現在の設定を取得

--- a/internal/usecase/ContractRummyInteractor.go
+++ b/internal/usecase/ContractRummyInteractor.go
@@ -134,12 +134,7 @@ func (ci *ContractRummyInteractor) Discard(cardIndex int) string {
 
 // NextRound 次のラウンドへ進む
 func (ci *ContractRummyInteractor) NextRound() string {
-	if out, blocked := guardGameEnd(ci.Game, ci.gp); blocked {
-		return out
-	}
-	ci.Game.NextRound()
-	ci.runCpuTurns()
-	return ci.gp.Output(ci.Game, nil)
+	return advanceRound(ci.Game, ci.gp, ci.runCpuTurns)
 }
 
 // GetConfig 現在の設定を取得

--- a/internal/usecase/CribbageInteractor.go
+++ b/internal/usecase/CribbageInteractor.go
@@ -131,12 +131,7 @@ func (ci *CribbageInteractor) ShowNext() string {
 
 // NextRound 次のラウンドへ進む
 func (ci *CribbageInteractor) NextRound() string {
-	if out, blocked := guardGameEnd(ci.Game, ci.gp); blocked {
-		return out
-	}
-	ci.Game.NextRound()
-	ci.runCpuTurns()
-	return ci.gp.Output(ci.Game, nil)
+	return advanceRound(ci.Game, ci.gp, ci.runCpuTurns)
 }
 
 // GetConfig 現在の設定を取得

--- a/internal/usecase/CuckooInteractor.go
+++ b/internal/usecase/CuckooInteractor.go
@@ -90,12 +90,7 @@ func (ci *CuckooInteractor) act(action func() error) string {
 
 // NextRound 次のラウンドへ進む
 func (ci *CuckooInteractor) NextRound() string {
-	if out, blocked := guardGameEnd(ci.Game, ci.gp); blocked {
-		return out
-	}
-	ci.Game.NextRound()
-	ci.runCpuTurns()
-	return ci.gp.Output(ci.Game, nil)
+	return advanceRound(ci.Game, ci.gp, ci.runCpuTurns)
 }
 
 // GetConfig 現在の設定を取得

--- a/internal/usecase/GinRummyInteractor.go
+++ b/internal/usecase/GinRummyInteractor.go
@@ -125,12 +125,7 @@ func (ci *GinRummyInteractor) Layoff(cardIndices []int) string {
 
 // NextRound 次のラウンドへ進む
 func (ci *GinRummyInteractor) NextRound() string {
-	if out, blocked := guardGameEnd(ci.Game, ci.gp); blocked {
-		return out
-	}
-	ci.Game.NextRound()
-	ci.runCpuTurns()
-	return ci.gp.Output(ci.Game, nil)
+	return advanceRound(ci.Game, ci.gp, ci.runCpuTurns)
 }
 
 // GetConfig 現在の設定を取得

--- a/internal/usecase/HandAndFootInteractor.go
+++ b/internal/usecase/HandAndFootInteractor.go
@@ -142,12 +142,7 @@ func (ci *HandAndFootInteractor) GoOut() string {
 
 // NextRound 次のラウンドへ進む
 func (ci *HandAndFootInteractor) NextRound() string {
-	if out, blocked := guardGameEnd(ci.Game, ci.gp); blocked {
-		return out
-	}
-	ci.Game.NextRound()
-	ci.runCpuTurns()
-	return ci.gp.Output(ci.Game, nil)
+	return advanceRound(ci.Game, ci.gp, ci.runCpuTurns)
 }
 
 // GetConfig 現在の設定を取得

--- a/internal/usecase/IndianRummyInteractor.go
+++ b/internal/usecase/IndianRummyInteractor.go
@@ -106,12 +106,7 @@ func (ci *IndianRummyInteractor) Declare(cardIndex int) string {
 
 // NextRound 次のラウンドへ進む
 func (ci *IndianRummyInteractor) NextRound() string {
-	if out, blocked := guardGameEnd(ci.Game, ci.gp); blocked {
-		return out
-	}
-	ci.Game.NextRound()
-	ci.runCpuTurns()
-	return ci.gp.Output(ci.Game, nil)
+	return advanceRound(ci.Game, ci.gp, ci.runCpuTurns)
 }
 
 // GetConfig 現在の設定を取得

--- a/internal/usecase/KalookiInteractor.go
+++ b/internal/usecase/KalookiInteractor.go
@@ -120,12 +120,7 @@ func (ci *KalookiInteractor) Discard(cardIndex int) string {
 
 // NextRound 次のラウンドへ進む
 func (ci *KalookiInteractor) NextRound() string {
-	if out, blocked := guardGameEnd(ci.Game, ci.gp); blocked {
-		return out
-	}
-	ci.Game.NextRound()
-	ci.runCpuTurns()
-	return ci.gp.Output(ci.Game, nil)
+	return advanceRound(ci.Game, ci.gp, ci.runCpuTurns)
 }
 
 // GetConfig 現在の設定を取得

--- a/internal/usecase/MachiavelliInteractor.go
+++ b/internal/usecase/MachiavelliInteractor.go
@@ -106,12 +106,7 @@ func (ci *MachiavelliInteractor) Layoff(meldIdx, handIndex int) string {
 
 // NextRound 次のラウンドへ進む
 func (ci *MachiavelliInteractor) NextRound() string {
-	if out, blocked := guardGameEnd(ci.Game, ci.gp); blocked {
-		return out
-	}
-	ci.Game.NextRound()
-	ci.runCpuTurns()
-	return ci.gp.Output(ci.Game, nil)
+	return advanceRound(ci.Game, ci.gp, ci.runCpuTurns)
 }
 
 // GetConfig 現在の設定を取得

--- a/internal/usecase/PanInteractor.go
+++ b/internal/usecase/PanInteractor.go
@@ -120,12 +120,7 @@ func (ci *PanInteractor) Discard(cardIndex int) string {
 
 // NextRound 次のラウンドへ進む
 func (ci *PanInteractor) NextRound() string {
-	if out, blocked := guardGameEnd(ci.Game, ci.gp); blocked {
-		return out
-	}
-	ci.Game.NextRound()
-	ci.runCpuTurns()
-	return ci.gp.Output(ci.Game, nil)
+	return advanceRound(ci.Game, ci.gp, ci.runCpuTurns)
 }
 
 // GetConfig 現在の設定を取得

--- a/internal/usecase/Rummy500Interactor.go
+++ b/internal/usecase/Rummy500Interactor.go
@@ -120,12 +120,7 @@ func (ci *Rummy500Interactor) Discard(cardIndex int) string {
 
 // NextRound 次のラウンドへ進む
 func (ci *Rummy500Interactor) NextRound() string {
-	if out, blocked := guardGameEnd(ci.Game, ci.gp); blocked {
-		return out
-	}
-	ci.Game.NextRound()
-	ci.runCpuTurns()
-	return ci.gp.Output(ci.Game, nil)
+	return advanceRound(ci.Game, ci.gp, ci.runCpuTurns)
 }
 
 // GetConfig 現在の設定を取得

--- a/internal/usecase/SambaInteractor.go
+++ b/internal/usecase/SambaInteractor.go
@@ -140,12 +140,7 @@ func (ci *SambaInteractor) GoOut() string {
 
 // NextRound 次のラウンドへ進む
 func (ci *SambaInteractor) NextRound() string {
-	if out, blocked := guardGameEnd(ci.Game, ci.gp); blocked {
-		return out
-	}
-	ci.Game.NextRound()
-	ci.runCpuTurns()
-	return ci.gp.Output(ci.Game, nil)
+	return advanceRound(ci.Game, ci.gp, ci.runCpuTurns)
 }
 
 // GetConfig 現在の設定を取得

--- a/internal/usecase/SevenBridgeInteractor.go
+++ b/internal/usecase/SevenBridgeInteractor.go
@@ -136,12 +136,7 @@ func (ci *SevenBridgeInteractor) Discard(cardIndex int) string {
 
 // NextRound 次のラウンドへ進む
 func (ci *SevenBridgeInteractor) NextRound() string {
-	if out, blocked := guardGameEnd(ci.Game, ci.gp); blocked {
-		return out
-	}
-	ci.Game.NextRound()
-	ci.runCpuTurns()
-	return ci.gp.Output(ci.Game, nil)
+	return advanceRound(ci.Game, ci.gp, ci.runCpuTurns)
 }
 
 // GetConfig 現在の設定を取得

--- a/internal/usecase/SixCardGolfInteractor.go
+++ b/internal/usecase/SixCardGolfInteractor.go
@@ -156,12 +156,7 @@ func (ci *SixCardGolfInteractor) SkipFlip() string {
 
 // NextRound 次のラウンドへ
 func (ci *SixCardGolfInteractor) NextRound() string {
-	if out, blocked := guardGameEnd(ci.Game, ci.gp); blocked {
-		return out
-	}
-	ci.Game.NextRound()
-	ci.runCpuTurns()
-	return ci.gp.Output(ci.Game, nil)
+	return advanceRound(ci.Game, ci.gp, ci.runCpuTurns)
 }
 
 // GetConfig 設定取得

--- a/internal/usecase/ThirtyOneInteractor.go
+++ b/internal/usecase/ThirtyOneInteractor.go
@@ -108,12 +108,7 @@ func (ci *ThirtyOneInteractor) Knock() string {
 
 // NextRound 次のラウンドへ進む
 func (ci *ThirtyOneInteractor) NextRound() string {
-	if out, blocked := guardGameEnd(ci.Game, ci.gp); blocked {
-		return out
-	}
-	ci.Game.NextRound()
-	ci.runCpuTurns()
-	return ci.gp.Output(ci.Game, nil)
+	return advanceRound(ci.Game, ci.gp, ci.runCpuTurns)
 }
 
 // GetConfig 現在の設定を取得

--- a/internal/usecase/ThreeThirteenInteractor.go
+++ b/internal/usecase/ThreeThirteenInteractor.go
@@ -106,12 +106,7 @@ func (ci *ThreeThirteenInteractor) Knock(cardIndex int) string {
 
 // NextRound 次のラウンドへ進む
 func (ci *ThreeThirteenInteractor) NextRound() string {
-	if out, blocked := guardGameEnd(ci.Game, ci.gp); blocked {
-		return out
-	}
-	ci.Game.NextRound()
-	ci.runCpuTurns()
-	return ci.gp.Output(ci.Game, nil)
+	return advanceRound(ci.Game, ci.gp, ci.runCpuTurns)
 }
 
 // GetConfig 現在の設定を取得

--- a/internal/usecase/TonkInteractor.go
+++ b/internal/usecase/TonkInteractor.go
@@ -108,12 +108,7 @@ func (ci *TonkInteractor) Knock(cardIndex int) string {
 
 // NextRound 次のラウンドへ進む
 func (ci *TonkInteractor) NextRound() string {
-	if out, blocked := guardGameEnd(ci.Game, ci.gp); blocked {
-		return out
-	}
-	ci.Game.NextRound()
-	ci.runCpuTurns()
-	return ci.gp.Output(ci.Game, nil)
+	return advanceRound(ci.Game, ci.gp, ci.runCpuTurns)
 }
 
 // GetConfig 現在の設定を取得

--- a/internal/usecase/YanivInteractor.go
+++ b/internal/usecase/YanivInteractor.go
@@ -106,12 +106,7 @@ func (ci *YanivInteractor) DrawFromPickup(end int) string {
 
 // NextRound 次のラウンドへ進む
 func (ci *YanivInteractor) NextRound() string {
-	if out, blocked := guardGameEnd(ci.Game, ci.gp); blocked {
-		return out
-	}
-	ci.Game.NextRound()
-	ci.runCpuTurns()
-	return ci.gp.Output(ci.Game, nil)
+	return advanceRound(ci.Game, ci.gp, ci.runCpuTurns)
 }
 
 // GetConfig 現在の設定を取得

--- a/internal/usecase/interactor_guard.go
+++ b/internal/usecase/interactor_guard.go
@@ -28,3 +28,32 @@ func guardGameEnd[G gameEndChecker](game G, p outputPresenter[G]) (string, bool)
 	}
 	return "", false
 }
+
+// roundAdvancer is a game that can start its next round.
+type roundAdvancer interface {
+	gameEndChecker
+	NextRound()
+}
+
+// advanceRound runs the shared "start the next round" step: bail out if the
+// game is over, advance, let the CPUs play, then present.
+//
+// Consolidates 22 byte-identical NextRound implementations across the rummy and
+// trick-taking interactors (Burraco, Canasta, Carioca, Chinchon, Conquian,
+// ContractRummy, …). They differed only in receiver name and concrete type,
+// which is why a name-based search never grouped them — see issue #5368.
+//
+// runCpu is a callback rather than a method on the interface: each interactor's
+// runCpuTurns is unexported, so no interface can name it.
+//
+// The guard is the reason all 22 bodies were identical: without it a finished
+// game deals another round. Order matters too — the CPUs must act on the new
+// round, not the one that just ended. Both are pinned by tests.
+func advanceRound[G roundAdvancer](game G, p outputPresenter[G], runCpu func()) string {
+	if out, blocked := guardGameEnd(game, p); blocked {
+		return out
+	}
+	game.NextRound()
+	runCpu()
+	return p.Output(game, nil)
+}

--- a/internal/usecase/interactor_guard_test.go
+++ b/internal/usecase/interactor_guard_test.go
@@ -111,12 +111,11 @@ func TestAdvanceRound(t *testing.T) {
 
 	// Order matters: the CPU must act on the new round, not the old one.
 	t.Run("runs the CPU after the round advances", func(t *testing.T) {
-		g := &mockRoundGame{}
 		var order []string
-		p := &mockPresenter[*mockRoundGame]{output: "out"}
-		orderedGame := &orderRecordingGame{mockRoundGame: g, order: &order}
+		game := &orderRecordingGame{mockRoundGame: &mockRoundGame{}, order: &order}
 
-		advanceRound(orderedGame, p2(p), func() { order = append(order, "cpu") })
+		advanceRound(game, &mockPresenter[*orderRecordingGame]{output: "out"},
+			func() { order = append(order, "cpu") })
 
 		assert.Equal(t, []string{"nextRound", "cpu"}, order)
 	})
@@ -131,9 +130,4 @@ type orderRecordingGame struct {
 func (o *orderRecordingGame) NextRound() {
 	*o.order = append(*o.order, "nextRound")
 	o.mockRoundGame.NextRound()
-}
-
-// p2 adapts the presenter's type parameter to the wrapper type.
-func p2(_ *mockPresenter[*mockRoundGame]) *mockPresenter[*orderRecordingGame] {
-	return &mockPresenter[*orderRecordingGame]{output: "out"}
 }

--- a/internal/usecase/interactor_guard_test.go
+++ b/internal/usecase/interactor_guard_test.go
@@ -70,3 +70,70 @@ func TestGuardGameEnd(t *testing.T) {
 		assert.Equal(t, "", out)
 	})
 }
+
+// advanceRound consolidates 22 byte-identical NextRound implementations
+// (Burraco, Canasta, Carioca, Chinchon, Conquian, ContractRummy, …) that
+// differed only in receiver name and concrete type — see issue #5368.
+type mockRoundGame struct {
+	gameEnd    bool
+	roundCalls int
+}
+
+func (m *mockRoundGame) GetGameEndFlag() bool { return m.gameEnd }
+func (m *mockRoundGame) NextRound()           { m.roundCalls++ }
+
+func TestAdvanceRound(t *testing.T) {
+	t.Run("advances the round and runs the CPU", func(t *testing.T) {
+		g := &mockRoundGame{}
+		p := &mockPresenter[*mockRoundGame]{output: "out"}
+		cpuRuns := 0
+
+		got := advanceRound(g, p, func() { cpuRuns++ })
+
+		assert.Equal(t, "out", got)
+		assert.Equal(t, 1, g.roundCalls)
+		assert.Equal(t, 1, cpuRuns)
+	})
+
+	// The guard is the whole reason these 22 bodies were identical: without it
+	// a finished game would deal another round.
+	t.Run("does nothing once the game has ended", func(t *testing.T) {
+		g := &mockRoundGame{gameEnd: true}
+		p := &mockPresenter[*mockRoundGame]{output: "ended"}
+		cpuRuns := 0
+
+		got := advanceRound(g, p, func() { cpuRuns++ })
+
+		assert.Equal(t, "ended", got)
+		assert.Equal(t, 0, g.roundCalls, "the round must not advance after the game ends")
+		assert.Equal(t, 0, cpuRuns, "the CPU must not play after the game ends")
+	})
+
+	// Order matters: the CPU must act on the new round, not the old one.
+	t.Run("runs the CPU after the round advances", func(t *testing.T) {
+		g := &mockRoundGame{}
+		var order []string
+		p := &mockPresenter[*mockRoundGame]{output: "out"}
+		orderedGame := &orderRecordingGame{mockRoundGame: g, order: &order}
+
+		advanceRound(orderedGame, p2(p), func() { order = append(order, "cpu") })
+
+		assert.Equal(t, []string{"nextRound", "cpu"}, order)
+	})
+}
+
+// orderRecordingGame records when NextRound runs relative to the CPU callback.
+type orderRecordingGame struct {
+	*mockRoundGame
+	order *[]string
+}
+
+func (o *orderRecordingGame) NextRound() {
+	*o.order = append(*o.order, "nextRound")
+	o.mockRoundGame.NextRound()
+}
+
+// p2 adapts the presenter's type parameter to the wrapper type.
+func p2(_ *mockPresenter[*mockRoundGame]) *mockPresenter[*orderRecordingGame] {
+	return &mockPresenter[*orderRecordingGame]{output: "out"}
+}


### PR DESCRIPTION
本文がバイト単位で一致する `NextRound` が **22 個**あり、違うのは**レシーバ名と具象型だけ**でした。

Burraco / Canasta / Carioca / Chinchon / Conquian / ContractRummy / … [#5368](https://github.com/yuta-yoshinaga/go_trumpcards/issues/5368) の 3 つ目のクラスタです。

```go
func (ci *BurracoInteractor) NextRound() string {
	if out, blocked := guardGameEnd(ci.Game, ci.gp); blocked {
		return out
	}
	ci.Game.NextRound()
	ci.runCpuTurns()
	return ci.gp.Output(ci.Game, nil)
}
```

## 受け皿は既存

`internal/usecase/interactor_guard.go` に住む `guardGameEnd` が、まさにこの 22 個が共有していたガードです。`advanceRound` はその周りの定型（ガード → `NextRound` → CPU → 出力）を束ねます。

`runCpuTurns` はコールバックで受けます。各 interactor の `runCpuTurns` は**非公開**なので、インタフェースでは名指しできません。

```go
func (ci *BurracoInteractor) NextRound() string {
	return advanceRound(ci.Game, ci.gp, ci.runCpuTurns)
}
```

## テストで固定した不変条件

**終局後は `NextRound` も CPU も呼ばれない** —— このガードが無いと、終わったゲームがもう 1 ラウンド配ります。22 個が同じ本文だった理由そのものなので、消えていないことを検査します。

**CPU はラウンドが進んだ後に動く** —— 順序が逆だと古いラウンドで打ちます。出力からは気付きにくいので、呼び出し順を記録する fake で固定しました。

## 行数

呼び出し側 22 ファイル: **-110 行**

## 検証

- `go build ./...` 通過
- `go test -tags test ./internal/usecase/` 通過（11.8s）
- `golangci-lint run ./internal/usecase/...` 0 issues
- **6 worker の `GOOS=js GOARCH=wasm`** すべて通過
- 置換件数 22 が期待値と一致（不一致なら書き込みを中止する方式）

## 残り

#5368 のうち dispatch 27 箇所は [PR #5372](https://github.com/yuta-yoshinaga/go_trumpcards/pull/5372)、本 PR で `NextRound` 22 箇所。残るは `Output` ×24（presenter）とソリティア `Exec` ×6 です。

Refs #5368