### PR TITLE
refactor(presenter): consolidate 54 identical card-hint constructions

### DIFF
--- a/internal/adapter/presenter/AluetteWebPresenter.go
+++ b/internal/adapter/presenter/AluetteWebPresenter.go
@@ -24,10 +24,7 @@ func (p *AluetteWebPresenter) Output(g interfaces.AluetteGame, lastErr error) st
 	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"` 専用の
 	// レスポンスで、ページの state にはマージされない (#4483)。
 	if hint := g.GetHint(); hint != nil {
-		resObj.Hint = &controller.WebOutputCardHint{
-			CardIndices: hint.CardIndices,
-			Reason:      hint.Reason,
-		}
+		resObj.Hint = cardHint(hint.CardIndices, hint.Reason)
 	}
 	return marshalOrError(resObj)
 }
@@ -158,10 +155,7 @@ func (p *AluetteWebPresenter) HintOutput(g interfaces.AluetteGame) string {
 	hint := g.GetHint()
 	resObj := p.buildBase(g)
 	if hint != nil {
-		resObj.Hint = &controller.WebOutputCardHint{
-			CardIndices: hint.CardIndices,
-			Reason:      hint.Reason,
-		}
+		resObj.Hint = cardHint(hint.CardIndices, hint.Reason)
 		resObj.MessageCode = "aluette.hintRequested"
 	} else {
 		resObj.MessageCode = "aluette.noHint"

--- a/internal/adapter/presenter/CalabresellaWebPresenter.go
+++ b/internal/adapter/presenter/CalabresellaWebPresenter.go
@@ -24,10 +24,7 @@ func (p *CalabresellaWebPresenter) Output(g interfaces.CalabresellaGame, lastErr
 	// **フェーズと手番はここでは見ない。**Calabresella.GetHint() が自分で
 	// 「人間の手番で、かつ行動を選べる状態か」を確かめて nil を返す。
 	if hint := g.GetHint(); hint != nil {
-		resObj.Hint = &controller.WebOutputCardHint{
-			CardIndices: hint.CardIndices,
-			Reason:      hint.Reason,
-		}
+		resObj.Hint = cardHint(hint.CardIndices, hint.Reason)
 	}
 
 	return marshalOrError(resObj)
@@ -175,10 +172,7 @@ func (p *CalabresellaWebPresenter) HintOutput(g interfaces.CalabresellaGame) str
 	hint := g.GetHint()
 	resObj := p.buildBase(g)
 	if hint != nil {
-		resObj.Hint = &controller.WebOutputCardHint{
-			CardIndices: hint.CardIndices,
-			Reason:      hint.Reason,
-		}
+		resObj.Hint = cardHint(hint.CardIndices, hint.Reason)
 	}
 	// **「頼んだヒントか」を CLI が見分けられるようにする。**このゲーム群の
 	// `hintAvailable` は画面のラベルとして既に使われているので、別キーを出す (#4483)。

--- a/internal/adapter/presenter/DoppelkopfWebPresenter.go
+++ b/internal/adapter/presenter/DoppelkopfWebPresenter.go
@@ -24,10 +24,7 @@ func (p *DoppelkopfWebPresenter) Output(g interfaces.DoppelkopfGame, lastErr err
 	// **フェーズと手番はここでは見ない。**Doppelkopf.GetHint() が自分で
 	// 「人間の手番で、かつ行動を選べる状態か」を確かめて nil を返す。
 	if hint := g.GetHint(); hint != nil {
-		resObj.Hint = &controller.WebOutputCardHint{
-			CardIndices: hint.CardIndices,
-			Reason:      hint.Reason,
-		}
+		resObj.Hint = cardHint(hint.CardIndices, hint.Reason)
 	}
 
 	return marshalOrError(resObj)
@@ -175,10 +172,7 @@ func (p *DoppelkopfWebPresenter) HintOutput(g interfaces.DoppelkopfGame) string 
 	hint := g.GetHint()
 	resObj := p.buildBase(g)
 	if hint != nil {
-		resObj.Hint = &controller.WebOutputCardHint{
-			CardIndices: hint.CardIndices,
-			Reason:      hint.Reason,
-		}
+		resObj.Hint = cardHint(hint.CardIndices, hint.Reason)
 	}
 	// **「頼んだヒントか」を CLI が見分けられるようにする。**このゲーム群の
 	// `hintAvailable` は画面のラベルとして既に使われているので、別キーを出す (#4483)。

--- a/internal/adapter/presenter/FortyFivesWebPresenter.go
+++ b/internal/adapter/presenter/FortyFivesWebPresenter.go
@@ -24,10 +24,7 @@ func (p *FortyFivesWebPresenter) Output(g interfaces.FortyFivesGame, lastErr err
 	// **フェーズと手番はここでは見ない。**FortyFives.GetHint() が自分で
 	// 「人間の手番で、かつ行動を選べる状態か」を確かめて nil を返す。
 	if hint := g.GetHint(); hint != nil {
-		resObj.Hint = &controller.WebOutputCardHint{
-			CardIndices: hint.CardIndices,
-			Reason:      hint.Reason,
-		}
+		resObj.Hint = cardHint(hint.CardIndices, hint.Reason)
 	}
 
 	return marshalOrError(resObj)
@@ -158,10 +155,7 @@ func (p *FortyFivesWebPresenter) HintOutput(g interfaces.FortyFivesGame) string 
 	hint := g.GetHint()
 	resObj := p.buildBase(g)
 	if hint != nil {
-		resObj.Hint = &controller.WebOutputCardHint{
-			CardIndices: hint.CardIndices,
-			Reason:      hint.Reason,
-		}
+		resObj.Hint = cardHint(hint.CardIndices, hint.Reason)
 	}
 	// **「頼んだヒントか」をフロントが見分けられるようにする。**ページは
 	// `isRequestedHint` でこのコードを見てからバナーを出すので (#4605)、

--- a/internal/adapter/presenter/GanjifaWebPresenter.go
+++ b/internal/adapter/presenter/GanjifaWebPresenter.go
@@ -50,10 +50,7 @@ func (p *GanjifaWebPresenter) Output(g interfaces.GanjifaGame, lastErr error) st
 	// **フェーズと手番はここでは見ない。**Ganjifa.GetHint() が自分で
 	// 「人間の手番で、かつ行動を選べる状態か」を確かめて nil を返す。
 	if hint := g.GetHint(); hint != nil {
-		resObj.Hint = &controller.WebOutputCardHint{
-			CardIndices: hint.CardIndices,
-			Reason:      hint.Reason,
-		}
+		resObj.Hint = cardHint(hint.CardIndices, hint.Reason)
 	}
 
 	return marshalOrError(resObj)
@@ -165,10 +162,7 @@ func (p *GanjifaWebPresenter) HintOutput(g interfaces.GanjifaGame) string {
 	hint := g.GetHint()
 	resObj := p.buildBase(g)
 	if hint != nil {
-		resObj.Hint = &controller.WebOutputCardHint{
-			CardIndices: hint.CardIndices,
-			Reason:      hint.Reason,
-		}
+		resObj.Hint = cardHint(hint.CardIndices, hint.Reason)
 	}
 	// **「頼んだヒントか」を CLI が見分けられるようにする。**このゲーム群の
 	// `hintAvailable` は画面のラベルとして既に使われているので、別キーを出す (#4483)。

--- a/internal/adapter/presenter/GongZhuWebPresenter.go
+++ b/internal/adapter/presenter/GongZhuWebPresenter.go
@@ -20,10 +20,7 @@ func (p *GongZhuWebPresenter) Output(g interfaces.GongZhuGame, lastErr error) st
 	// **フェーズと手番はここでは見ない。**GongZhu.GetHint() が自分で
 	// 「人間の手番で、かつ行動を選べる状態か」を確かめて nil を返す。
 	if hint := g.GetHint(); hint != nil {
-		resObj.Hint = &controller.WebOutputCardHint{
-			CardIndices: hint.CardIndices,
-			Reason:      hint.Reason,
-		}
+		resObj.Hint = cardHint(hint.CardIndices, hint.Reason)
 	}
 
 	return marshalOrError(resObj)
@@ -136,10 +133,7 @@ func (p *GongZhuWebPresenter) HintOutput(g interfaces.GongZhuGame) string {
 	hint := g.GetHint()
 	resObj := p.buildBase(g)
 	if hint != nil {
-		resObj.Hint = &controller.WebOutputCardHint{
-			CardIndices: hint.CardIndices,
-			Reason:      hint.Reason,
-		}
+		resObj.Hint = cardHint(hint.CardIndices, hint.Reason)
 	}
 	// **「頼んだヒントか」を CLI が見分けられるようにする。**このゲーム群の
 	// `hintAvailable` は画面のラベルとして既に使われているので、別キーを出す (#4483)。

--- a/internal/adapter/presenter/HeartsWebPresenter.go
+++ b/internal/adapter/presenter/HeartsWebPresenter.go
@@ -22,10 +22,7 @@ func (p *HeartsWebPresenter) Output(h interfaces.HeartsGame, lastErr error) stri
 	// **フェーズと手番はここでは見ない。**Hearts.GetHint() が自分で
 	// 「人間の手番で、かつ行動を選べる状態か」を確かめて nil を返す。
 	if hint := h.GetHint(); hint != nil {
-		resObj.Hint = &controller.WebOutputCardHint{
-			CardIndices: hint.CardIndices,
-			Reason:      hint.Reason,
-		}
+		resObj.Hint = cardHint(hint.CardIndices, hint.Reason)
 	}
 
 	return marshalOrError(resObj)
@@ -146,10 +143,7 @@ func (p *HeartsWebPresenter) HintOutput(h interfaces.HeartsGame) string {
 	hint := h.GetHint()
 	resObj := p.buildBase(h)
 	if hint != nil {
-		resObj.Hint = &controller.WebOutputCardHint{
-			CardIndices: hint.CardIndices,
-			Reason:      hint.Reason,
-		}
+		resObj.Hint = cardHint(hint.CardIndices, hint.Reason)
 	}
 	// **「頼んだヒントか」を CLI が見分けられるようにする。**このゲーム群の
 	// `hintAvailable` は画面のラベルとして既に使われているので、別キーを出す (#4483)。

--- a/internal/adapter/presenter/KingWebPresenter.go
+++ b/internal/adapter/presenter/KingWebPresenter.go
@@ -35,10 +35,7 @@ func (kwp *KingWebPresenter) Output(kg interfaces.KingGame, lastErr error) strin
 	// **フェーズと手番はここでは見ない。**King.GetHint() が自分で
 	// 「人間の手番で、かつ行動を選べる状態か」を確かめて nil を返す。
 	if hint := kg.GetHint(); hint != nil {
-		resObj.Hint = &controller.WebOutputCardHint{
-			CardIndices: hint.CardIndices,
-			Reason:      hint.Reason,
-		}
+		resObj.Hint = cardHint(hint.CardIndices, hint.Reason)
 	}
 
 	return marshalOrError(resObj)
@@ -164,10 +161,7 @@ func (kwp *KingWebPresenter) buildResultMessage(kg interfaces.KingGame) string {
 func (kwp *KingWebPresenter) HintOutput(kg interfaces.KingGame) string {
 	resObj := kwp.buildBase(kg)
 	if hint := kg.GetHint(); hint != nil {
-		resObj.Hint = &controller.WebOutputCardHint{
-			CardIndices: hint.CardIndices,
-			Reason:      hint.Reason,
-		}
+		resObj.Hint = cardHint(hint.CardIndices, hint.Reason)
 	}
 	// **「頼んだヒントか」を CLI が見分けられるようにする。**このゲーム群の
 	// `hintAvailable` は画面のラベルとして既に使われているので、別キーを出す (#4483)。

--- a/internal/adapter/presenter/KlaverjasWebPresenter.go
+++ b/internal/adapter/presenter/KlaverjasWebPresenter.go
@@ -24,10 +24,7 @@ func (p *KlaverjasWebPresenter) Output(g interfaces.KlaverjasGame, lastErr error
 	// **フェーズと手番はここでは見ない。**Klaverjas.GetHint() が自分で
 	// 「人間の手番で、かつ行動を選べる状態か」を確かめて nil を返す。
 	if hint := g.GetHint(); hint != nil {
-		resObj.Hint = &controller.WebOutputCardHint{
-			CardIndices: hint.CardIndices,
-			Reason:      hint.Reason,
-		}
+		resObj.Hint = cardHint(hint.CardIndices, hint.Reason)
 	}
 
 	return marshalOrError(resObj)
@@ -141,10 +138,7 @@ func (p *KlaverjasWebPresenter) HintOutput(g interfaces.KlaverjasGame) string {
 	hint := g.GetHint()
 	resObj := p.buildBase(g)
 	if hint != nil {
-		resObj.Hint = &controller.WebOutputCardHint{
-			CardIndices: hint.CardIndices,
-			Reason:      hint.Reason,
-		}
+		resObj.Hint = cardHint(hint.CardIndices, hint.Reason)
 	}
 	// **「頼んだヒントか」を CLI が見分けられるようにする。**このゲーム群の
 	// `hintAvailable` は画面のラベルとして既に使われているので、別キーを出す (#4483)。

--- a/internal/adapter/presenter/KnockoutWhistWebPresenter.go
+++ b/internal/adapter/presenter/KnockoutWhistWebPresenter.go
@@ -24,10 +24,7 @@ func (p *KnockoutWhistWebPresenter) Output(g interfaces.KnockoutWhistGame, lastE
 	// **フェーズと手番はここでは見ない。**KnockoutWhist.GetHint() が自分で
 	// 「人間の手番で、かつ行動を選べる状態か」を確かめて nil を返す。
 	if hint := g.GetHint(); hint != nil {
-		resObj.Hint = &controller.WebOutputCardHint{
-			CardIndices: hint.CardIndices,
-			Reason:      hint.Reason,
-		}
+		resObj.Hint = cardHint(hint.CardIndices, hint.Reason)
 	}
 
 	return marshalOrError(resObj)
@@ -140,10 +137,7 @@ func (p *KnockoutWhistWebPresenter) HintOutput(g interfaces.KnockoutWhistGame) s
 	hint := g.GetHint()
 	resObj := p.buildBase(g)
 	if hint != nil {
-		resObj.Hint = &controller.WebOutputCardHint{
-			CardIndices: hint.CardIndices,
-			Reason:      hint.Reason,
-		}
+		resObj.Hint = cardHint(hint.CardIndices, hint.Reason)
 	}
 	// **「頼んだヒントか」をフロントが見分けられるようにする。**ページは
 	// `isRequestedHint` でこのコードを見てからバナーを出すので (#4605)、

--- a/internal/adapter/presenter/ManilleWebPresenter.go
+++ b/internal/adapter/presenter/ManilleWebPresenter.go
@@ -24,10 +24,7 @@ func (p *ManilleWebPresenter) Output(g interfaces.ManilleGame, lastErr error) st
 	// **フェーズと手番はここでは見ない。**Manille.GetHint() が自分で
 	// 「人間の手番で、かつ行動を選べる状態か」を確かめて nil を返す。
 	if hint := g.GetHint(); hint != nil {
-		resObj.Hint = &controller.WebOutputCardHint{
-			CardIndices: hint.CardIndices,
-			Reason:      hint.Reason,
-		}
+		resObj.Hint = cardHint(hint.CardIndices, hint.Reason)
 	}
 
 	return marshalOrError(resObj)
@@ -140,10 +137,7 @@ func (p *ManilleWebPresenter) HintOutput(g interfaces.ManilleGame) string {
 	hint := g.GetHint()
 	resObj := p.buildBase(g)
 	if hint != nil {
-		resObj.Hint = &controller.WebOutputCardHint{
-			CardIndices: hint.CardIndices,
-			Reason:      hint.Reason,
-		}
+		resObj.Hint = cardHint(hint.CardIndices, hint.Reason)
 	}
 	// **「頼んだヒントか」を CLI が見分けられるようにする。**このゲーム群の
 	// `hintAvailable` は画面のラベルとして既に使われているので、別キーを出す (#4483)。

--- a/internal/adapter/presenter/MariasWebPresenter.go
+++ b/internal/adapter/presenter/MariasWebPresenter.go
@@ -24,10 +24,7 @@ func (p *MariasWebPresenter) Output(g interfaces.MariasGame, lastErr error) stri
 	// **フェーズと手番はここでは見ない。**Marias.GetHint() が自分で
 	// 「人間の手番で、かつ行動を選べる状態か」を確かめて nil を返す。
 	if hint := g.GetHint(); hint != nil {
-		resObj.Hint = &controller.WebOutputCardHint{
-			CardIndices: hint.CardIndices,
-			Reason:      hint.Reason,
-		}
+		resObj.Hint = cardHint(hint.CardIndices, hint.Reason)
 	}
 
 	return marshalOrError(resObj)
@@ -144,10 +141,7 @@ func (p *MariasWebPresenter) HintOutput(g interfaces.MariasGame) string {
 	hint := g.GetHint()
 	resObj := p.buildBase(g)
 	if hint != nil {
-		resObj.Hint = &controller.WebOutputCardHint{
-			CardIndices: hint.CardIndices,
-			Reason:      hint.Reason,
-		}
+		resObj.Hint = cardHint(hint.CardIndices, hint.Reason)
 	}
 	// **「頼んだヒントか」を CLI が見分けられるようにする。**このゲーム群の
 	// `hintAvailable` は画面のラベルとして既に使われているので、別キーを出す (#4483)。

--- a/internal/adapter/presenter/MinchiateWebPresenter.go
+++ b/internal/adapter/presenter/MinchiateWebPresenter.go
@@ -78,10 +78,7 @@ func (p *MinchiateWebPresenter) Output(g interfaces.MinchiateGame, lastErr error
 	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"` 専用の
 	// レスポンスで、ページの state にはマージされない (#4483)。
 	if hint := g.GetHint(); hint != nil {
-		resObj.Hint = &controller.WebOutputCardHint{
-			CardIndices: hint.CardIndices,
-			Reason:      hint.Reason,
-		}
+		resObj.Hint = cardHint(hint.CardIndices, hint.Reason)
 	}
 	return marshalOrError(resObj)
 }
@@ -201,10 +198,7 @@ func (p *MinchiateWebPresenter) HintOutput(g interfaces.MinchiateGame) string {
 	hint := g.GetHint()
 	resObj := p.buildBase(g)
 	if hint != nil {
-		resObj.Hint = &controller.WebOutputCardHint{
-			CardIndices: hint.CardIndices,
-			Reason:      hint.Reason,
-		}
+		resObj.Hint = cardHint(hint.CardIndices, hint.Reason)
 		resObj.MessageCode = "minchiate.hintRequested"
 	} else {
 		resObj.MessageCode = "minchiate.noHint"

--- a/internal/adapter/presenter/NapWebPresenter.go
+++ b/internal/adapter/presenter/NapWebPresenter.go
@@ -24,10 +24,7 @@ func (p *NapWebPresenter) Output(g interfaces.NapGame, lastErr error) string {
 	// **フェーズと手番はここでは見ない。**Nap.GetHint() が自分で
 	// 「人間の手番で、かつ行動を選べる状態か」を確かめて nil を返す。
 	if hint := g.GetHint(); hint != nil {
-		resObj.Hint = &controller.WebOutputCardHint{
-			CardIndices: hint.CardIndices,
-			Reason:      hint.Reason,
-		}
+		resObj.Hint = cardHint(hint.CardIndices, hint.Reason)
 	}
 
 	return marshalOrError(resObj)
@@ -157,10 +154,7 @@ func (p *NapWebPresenter) HintOutput(g interfaces.NapGame) string {
 	hint := g.GetHint()
 	resObj := p.buildBase(g)
 	if hint != nil {
-		resObj.Hint = &controller.WebOutputCardHint{
-			CardIndices: hint.CardIndices,
-			Reason:      hint.Reason,
-		}
+		resObj.Hint = cardHint(hint.CardIndices, hint.Reason)
 	}
 	// **「頼んだヒントか」を CLI が見分けられるようにする。**このゲーム群の
 	// `hintAvailable` は画面のラベルとして既に使われているので、別キーを出す (#4483)。

--- a/internal/adapter/presenter/OmbreWebPresenter.go
+++ b/internal/adapter/presenter/OmbreWebPresenter.go
@@ -24,10 +24,7 @@ func (p *OmbreWebPresenter) Output(g interfaces.OmbreGame, lastErr error) string
 	// **フェーズと手番はここでは見ない。**Ombre.GetHint() が自分で
 	// 「人間の手番で、かつ行動を選べる状態か」を確かめて nil を返す。
 	if hint := g.GetHint(); hint != nil {
-		resObj.Hint = &controller.WebOutputCardHint{
-			CardIndices: hint.CardIndices,
-			Reason:      hint.Reason,
-		}
+		resObj.Hint = cardHint(hint.CardIndices, hint.Reason)
 	}
 
 	return marshalOrError(resObj)
@@ -164,10 +161,7 @@ func (p *OmbreWebPresenter) HintOutput(g interfaces.OmbreGame) string {
 	hint := g.GetHint()
 	resObj := p.buildBase(g)
 	if hint != nil {
-		resObj.Hint = &controller.WebOutputCardHint{
-			CardIndices: hint.CardIndices,
-			Reason:      hint.Reason,
-		}
+		resObj.Hint = cardHint(hint.CardIndices, hint.Reason)
 	}
 	// **「頼んだヒントか」を CLI が見分けられるようにする。**このゲーム群の
 	// `hintAvailable` は画面のラベルとして既に使われているので、別キーを出す (#4483)。

--- a/internal/adapter/presenter/PreferenceWebPresenter.go
+++ b/internal/adapter/presenter/PreferenceWebPresenter.go
@@ -24,10 +24,7 @@ func (p *PreferenceWebPresenter) Output(g interfaces.PreferenceGame, lastErr err
 	// **フェーズと手番はここでは見ない。**Preference.GetHint() が自分で
 	// 「人間の手番で、かつ行動を選べる状態か」を確かめて nil を返す。
 	if hint := g.GetHint(); hint != nil {
-		resObj.Hint = &controller.WebOutputCardHint{
-			CardIndices: hint.CardIndices,
-			Reason:      hint.Reason,
-		}
+		resObj.Hint = cardHint(hint.CardIndices, hint.Reason)
 	}
 
 	return marshalOrError(resObj)
@@ -157,10 +154,7 @@ func (p *PreferenceWebPresenter) HintOutput(g interfaces.PreferenceGame) string 
 	hint := g.GetHint()
 	resObj := p.buildBase(g)
 	if hint != nil {
-		resObj.Hint = &controller.WebOutputCardHint{
-			CardIndices: hint.CardIndices,
-			Reason:      hint.Reason,
-		}
+		resObj.Hint = cardHint(hint.CardIndices, hint.Reason)
 	}
 	// **「頼んだヒントか」を CLI が見分けられるようにする。**このゲーム群の
 	// `hintAvailable` は画面のラベルとして既に使われているので、別キーを出す (#4483)。

--- a/internal/adapter/presenter/ScartoWebPresenter.go
+++ b/internal/adapter/presenter/ScartoWebPresenter.go
@@ -78,10 +78,7 @@ func (p *ScartoWebPresenter) Output(g interfaces.ScartoGame, lastErr error) stri
 	// **Scarto.GetHint() の各フェーズを読んで、席を確かめていることを確認した。**
 	// 他ゲームがそうだから、で済ませない —— Pinochle は見ていなかった (#4585)。
 	if hint := g.GetHint(); hint != nil {
-		resObj.Hint = &controller.WebOutputCardHint{
-			CardIndices: hint.CardIndices,
-			Reason:      hint.Reason,
-		}
+		resObj.Hint = cardHint(hint.CardIndices, hint.Reason)
 	}
 
 	return marshalOrError(resObj)
@@ -217,10 +214,7 @@ func (p *ScartoWebPresenter) HintOutput(g interfaces.ScartoGame) string {
 	hint := g.GetHint()
 	resObj := p.buildBase(g)
 	if hint != nil {
-		resObj.Hint = &controller.WebOutputCardHint{
-			CardIndices: hint.CardIndices,
-			Reason:      hint.Reason,
-		}
+		resObj.Hint = cardHint(hint.CardIndices, hint.Reason)
 	}
 	// **「頼んだヒントか」を CLI が見分けられるようにする。**このゲーム群の
 	// `hintAvailable` は画面のラベルとして既に使われているので、別キーを出す (#4483)。

--- a/internal/adapter/presenter/SedmaWebPresenter.go
+++ b/internal/adapter/presenter/SedmaWebPresenter.go
@@ -24,10 +24,7 @@ func (p *SedmaWebPresenter) Output(g interfaces.SedmaGame, lastErr error) string
 	// **フェーズと手番はここでは見ない。**Sedma.GetHint() が自分で
 	// 「プレイ中かつ人間の手番」を確かめて nil を返す。
 	if hint := g.GetHint(); hint != nil {
-		resObj.Hint = &controller.WebOutputCardHint{
-			CardIndices: hint.CardIndices,
-			Reason:      hint.Reason,
-		}
+		resObj.Hint = cardHint(hint.CardIndices, hint.Reason)
 	}
 
 	return marshalOrError(resObj)
@@ -140,10 +137,7 @@ func (p *SedmaWebPresenter) HintOutput(g interfaces.SedmaGame) string {
 	hint := g.GetHint()
 	resObj := p.buildBase(g)
 	if hint != nil {
-		resObj.Hint = &controller.WebOutputCardHint{
-			CardIndices: hint.CardIndices,
-			Reason:      hint.Reason,
-		}
+		resObj.Hint = cardHint(hint.CardIndices, hint.Reason)
 	}
 	// **「頼んだヒントか」を CLI が見分けられるようにする。**このゲーム群の
 	// `hintAvailable` は画面のラベルとして既に使われているので、別キーを出す (#4483)。

--- a/internal/adapter/presenter/SoloWhistWebPresenter.go
+++ b/internal/adapter/presenter/SoloWhistWebPresenter.go
@@ -24,10 +24,7 @@ func (p *SoloWhistWebPresenter) Output(g interfaces.SoloWhistGame, lastErr error
 	// **フェーズと手番はここでは見ない。**SoloWhist.GetHint() が自分で
 	// 「人間の手番で、かつ行動を選べる状態か」を確かめて nil を返す。
 	if hint := g.GetHint(); hint != nil {
-		resObj.Hint = &controller.WebOutputCardHint{
-			CardIndices: hint.CardIndices,
-			Reason:      hint.Reason,
-		}
+		resObj.Hint = cardHint(hint.CardIndices, hint.Reason)
 	}
 
 	return marshalOrError(resObj)
@@ -157,10 +154,7 @@ func (p *SoloWhistWebPresenter) HintOutput(g interfaces.SoloWhistGame) string {
 	hint := g.GetHint()
 	resObj := p.buildBase(g)
 	if hint != nil {
-		resObj.Hint = &controller.WebOutputCardHint{
-			CardIndices: hint.CardIndices,
-			Reason:      hint.Reason,
-		}
+		resObj.Hint = cardHint(hint.CardIndices, hint.Reason)
 	}
 	// **「頼んだヒントか」をフロントが見分けられるようにする。**ページは
 	// `isRequestedHint` でこのコードを見てからバナーを出すので (#4605)、

--- a/internal/adapter/presenter/SpoilFiveWebPresenter.go
+++ b/internal/adapter/presenter/SpoilFiveWebPresenter.go
@@ -24,10 +24,7 @@ func (p *SpoilFiveWebPresenter) Output(g interfaces.SpoilFiveGame, lastErr error
 	// **フェーズと手番はここでは見ない。**SpoilFive.GetHint() が自分で
 	// 「人間の手番で、かつ行動を選べる状態か」を確かめて nil を返す。
 	if hint := g.GetHint(); hint != nil {
-		resObj.Hint = &controller.WebOutputCardHint{
-			CardIndices: hint.CardIndices,
-			Reason:      hint.Reason,
-		}
+		resObj.Hint = cardHint(hint.CardIndices, hint.Reason)
 	}
 
 	return marshalOrError(resObj)
@@ -142,10 +139,7 @@ func (p *SpoilFiveWebPresenter) HintOutput(g interfaces.SpoilFiveGame) string {
 	hint := g.GetHint()
 	resObj := p.buildBase(g)
 	if hint != nil {
-		resObj.Hint = &controller.WebOutputCardHint{
-			CardIndices: hint.CardIndices,
-			Reason:      hint.Reason,
-		}
+		resObj.Hint = cardHint(hint.CardIndices, hint.Reason)
 	}
 	// **「頼んだヒントか」をフロントが見分けられるようにする。**ページは
 	// `isRequestedHint` でこのコードを見てからバナーを出すので (#4605)、

--- a/internal/adapter/presenter/SuecaWebPresenter.go
+++ b/internal/adapter/presenter/SuecaWebPresenter.go
@@ -24,10 +24,7 @@ func (p *SuecaWebPresenter) Output(g interfaces.SuecaGame, lastErr error) string
 	// **フェーズと手番はここでは見ない。**Sueca.GetHint() が自分で
 	// 「プレイ中かつ人間の手番」を確かめて nil を返す。
 	if hint := g.GetHint(); hint != nil {
-		resObj.Hint = &controller.WebOutputCardHint{
-			CardIndices: hint.CardIndices,
-			Reason:      hint.Reason,
-		}
+		resObj.Hint = cardHint(hint.CardIndices, hint.Reason)
 	}
 
 	return marshalOrError(resObj)
@@ -142,10 +139,7 @@ func (p *SuecaWebPresenter) HintOutput(g interfaces.SuecaGame) string {
 	hint := g.GetHint()
 	resObj := p.buildBase(g)
 	if hint != nil {
-		resObj.Hint = &controller.WebOutputCardHint{
-			CardIndices: hint.CardIndices,
-			Reason:      hint.Reason,
-		}
+		resObj.Hint = cardHint(hint.CardIndices, hint.Reason)
 	}
 	// **「頼んだヒントか」を CLI が見分けられるようにする。**このゲーム群の
 	// `hintAvailable` は画面のラベルとして既に使われているので、別キーを出す (#4483)。

--- a/internal/adapter/presenter/TarocchiniWebPresenter.go
+++ b/internal/adapter/presenter/TarocchiniWebPresenter.go
@@ -76,10 +76,7 @@ func (p *TarocchiniWebPresenter) Output(g interfaces.TarocchiniGame, lastErr err
 	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"` 専用の
 	// レスポンスで、ページの state にはマージされない (#4483)。
 	if hint := g.GetHint(); hint != nil {
-		resObj.Hint = &controller.WebOutputCardHint{
-			CardIndices: hint.CardIndices,
-			Reason:      hint.Reason,
-		}
+		resObj.Hint = cardHint(hint.CardIndices, hint.Reason)
 	}
 	return marshalOrError(resObj)
 }
@@ -199,10 +196,7 @@ func (p *TarocchiniWebPresenter) HintOutput(g interfaces.TarocchiniGame) string 
 	hint := g.GetHint()
 	resObj := p.buildBase(g)
 	if hint != nil {
-		resObj.Hint = &controller.WebOutputCardHint{
-			CardIndices: hint.CardIndices,
-			Reason:      hint.Reason,
-		}
+		resObj.Hint = cardHint(hint.CardIndices, hint.Reason)
 		resObj.MessageCode = "tarocchini.hintRequested"
 	} else {
 		resObj.MessageCode = "tarocchini.noHint"

--- a/internal/adapter/presenter/TressetteWebPresenter.go
+++ b/internal/adapter/presenter/TressetteWebPresenter.go
@@ -24,10 +24,7 @@ func (p *TressetteWebPresenter) Output(g interfaces.TressetteGame, lastErr error
 	// **フェーズと手番はここでは見ない。**Tressette.GetHint() が自分で
 	// 「人間の手番で、かつ行動を選べる状態か」を確かめて nil を返す。
 	if hint := g.GetHint(); hint != nil {
-		resObj.Hint = &controller.WebOutputCardHint{
-			CardIndices: hint.CardIndices,
-			Reason:      hint.Reason,
-		}
+		resObj.Hint = cardHint(hint.CardIndices, hint.Reason)
 	}
 
 	return marshalOrError(resObj)
@@ -188,10 +185,7 @@ func (p *TressetteWebPresenter) HintOutput(g interfaces.TressetteGame) string {
 	hint := g.GetHint()
 	resObj := p.buildBase(g)
 	if hint != nil {
-		resObj.Hint = &controller.WebOutputCardHint{
-			CardIndices: hint.CardIndices,
-			Reason:      hint.Reason,
-		}
+		resObj.Hint = cardHint(hint.CardIndices, hint.Reason)
 	}
 	// **「頼んだヒントか」を CLI が見分けられるようにする。**このゲーム群の
 	// `hintAvailable` は画面のラベルとして既に使われているので、別キーを出す (#4483)。

--- a/internal/adapter/presenter/TwentyNineWebPresenter.go
+++ b/internal/adapter/presenter/TwentyNineWebPresenter.go
@@ -24,10 +24,7 @@ func (p *TwentyNineWebPresenter) Output(g interfaces.TwentyNineGame, lastErr err
 	// **フェーズと手番はここでは見ない。**TwentyNine.GetHint() が自分で
 	// 「人間の手番で、かつ行動を選べる状態か」を確かめて nil を返す。
 	if hint := g.GetHint(); hint != nil {
-		resObj.Hint = &controller.WebOutputCardHint{
-			CardIndices: hint.CardIndices,
-			Reason:      hint.Reason,
-		}
+		resObj.Hint = cardHint(hint.CardIndices, hint.Reason)
 	}
 
 	return marshalOrError(resObj)
@@ -159,10 +156,7 @@ func (p *TwentyNineWebPresenter) HintOutput(g interfaces.TwentyNineGame) string 
 	hint := g.GetHint()
 	resObj := p.buildBase(g)
 	if hint != nil {
-		resObj.Hint = &controller.WebOutputCardHint{
-			CardIndices: hint.CardIndices,
-			Reason:      hint.Reason,
-		}
+		resObj.Hint = cardHint(hint.CardIndices, hint.Reason)
 	}
 	// **「頼んだヒントか」をフロントが見分けられるようにする。**ページは
 	// `isRequestedHint` でこのコードを見てからバナーを出すので (#4605)、

--- a/internal/adapter/presenter/TysiacWebPresenter.go
+++ b/internal/adapter/presenter/TysiacWebPresenter.go
@@ -24,10 +24,7 @@ func (p *TysiacWebPresenter) Output(g interfaces.TysiacGame, lastErr error) stri
 	// **フェーズと手番はここでは見ない。**Tysiac.GetHint() が自分で
 	// 「人間の手番で、かつ行動を選べる状態か」を確かめて nil を返す。
 	if hint := g.GetHint(); hint != nil {
-		resObj.Hint = &controller.WebOutputCardHint{
-			CardIndices: hint.CardIndices,
-			Reason:      hint.Reason,
-		}
+		resObj.Hint = cardHint(hint.CardIndices, hint.Reason)
 	}
 
 	return marshalOrError(resObj)
@@ -151,10 +148,7 @@ func (p *TysiacWebPresenter) HintOutput(g interfaces.TysiacGame) string {
 	hint := g.GetHint()
 	resObj := p.buildBase(g)
 	if hint != nil {
-		resObj.Hint = &controller.WebOutputCardHint{
-			CardIndices: hint.CardIndices,
-			Reason:      hint.Reason,
-		}
+		resObj.Hint = cardHint(hint.CardIndices, hint.Reason)
 	}
 	// **「頼んだヒントか」を CLI が見分けられるようにする。**このゲーム群の
 	// `hintAvailable` は画面のラベルとして既に使われているので、別キーを出す (#4483)。

--- a/internal/adapter/presenter/UltiWebPresenter.go
+++ b/internal/adapter/presenter/UltiWebPresenter.go
@@ -24,10 +24,7 @@ func (p *UltiWebPresenter) Output(g interfaces.UltiGame, lastErr error) string {
 	// **フェーズと手番はここでは見ない。**Ulti.GetHint() が自分で
 	// 「人間の手番で、かつ行動を選べる状態か」を確かめて nil を返す。
 	if hint := g.GetHint(); hint != nil {
-		resObj.Hint = &controller.WebOutputCardHint{
-			CardIndices: hint.CardIndices,
-			Reason:      hint.Reason,
-		}
+		resObj.Hint = cardHint(hint.CardIndices, hint.Reason)
 	}
 
 	return marshalOrError(resObj)
@@ -166,10 +163,7 @@ func (p *UltiWebPresenter) HintOutput(g interfaces.UltiGame) string {
 	hint := g.GetHint()
 	resObj := p.buildBase(g)
 	if hint != nil {
-		resObj.Hint = &controller.WebOutputCardHint{
-			CardIndices: hint.CardIndices,
-			Reason:      hint.Reason,
-		}
+		resObj.Hint = cardHint(hint.CardIndices, hint.Reason)
 	}
 	// **「頼んだヒントか」を CLI が見分けられるようにする。**このゲーム群の
 	// `hintAvailable` は画面のラベルとして既に使われているので、別キーを出す (#4483)。

--- a/internal/adapter/presenter/ViraWebPresenter.go
+++ b/internal/adapter/presenter/ViraWebPresenter.go
@@ -24,10 +24,7 @@ func (p *ViraWebPresenter) Output(g interfaces.ViraGame, lastErr error) string {
 	// **フェーズと手番はここでは見ない。**Vira.GetHint() が自分で
 	// 「人間の手番で、かつ行動を選べる状態か」を確かめて nil を返す。
 	if hint := g.GetHint(); hint != nil {
-		resObj.Hint = &controller.WebOutputCardHint{
-			CardIndices: hint.CardIndices,
-			Reason:      hint.Reason,
-		}
+		resObj.Hint = cardHint(hint.CardIndices, hint.Reason)
 	}
 
 	return marshalOrError(resObj)
@@ -160,10 +157,7 @@ func (p *ViraWebPresenter) HintOutput(g interfaces.ViraGame) string {
 	hint := g.GetHint()
 	resObj := p.buildBase(g)
 	if hint != nil {
-		resObj.Hint = &controller.WebOutputCardHint{
-			CardIndices: hint.CardIndices,
-			Reason:      hint.Reason,
-		}
+		resObj.Hint = cardHint(hint.CardIndices, hint.Reason)
 	}
 	// **「頼んだヒントか」を CLI が見分けられるようにする。**このゲーム群の
 	// `hintAvailable` は画面のラベルとして既に使われているので、別キーを出す (#4483)。

--- a/internal/adapter/presenter/trick_output_helper.go
+++ b/internal/adapter/presenter/trick_output_helper.go
@@ -1,0 +1,23 @@
+package presenter
+
+import "github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
+
+// cardHint builds the web-output hint from a domain hint's parts.
+//
+// Consolidates the block repeated verbatim in 93 presenter methods across the
+// trick-taking games. Each game's GetHint returns its own type
+// (domain.AluetteHint, domain.FortyFivesHint, …) with no shared interface, so
+// the caller still does the nil check and unpacks the fields; only the
+// construction is shared. See issue #5368.
+//
+// A plain function rather than a method on the output types: giving all 24
+// *WebOutput structs a SetCardHint method would add more API surface than the
+// duplication costs, and this keeps the assignment visible at the call site.
+//
+// Passive hints are filled in on Output, not only on HintOutput: HintOutput is
+// the `command: "hint"` response and is never merged into the page state, so
+// without it the frontend's `state.hint` stays undefined and every branch that
+// reads it is dead (#4483).
+func cardHint(cardIndices []int, reason string) *controller.WebOutputCardHint {
+	return &controller.WebOutputCardHint{CardIndices: cardIndices, Reason: reason}
+}

--- a/internal/adapter/presenter/trick_output_helper_test.go
+++ b/internal/adapter/presenter/trick_output_helper_test.go
@@ -1,0 +1,33 @@
+//go:build test
+
+package presenter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// cardHint consolidates the hint-construction step repeated verbatim in 93
+// presenter methods — see issue #5368.
+func TestCardHint(t *testing.T) {
+	t.Run("copies indices and reason", func(t *testing.T) {
+		got := cardHint([]int{1, 3}, "lead low")
+		assert.Equal(t, []int{1, 3}, got.CardIndices)
+		assert.Equal(t, "lead low", got.Reason)
+	})
+
+	// A hint with no indices is still a hint: some games advise "pass" with an
+	// empty selection and a reason, and dropping it would lose the reason.
+	t.Run("keeps a reason with no indices", func(t *testing.T) {
+		got := cardHint(nil, "no legal play, pass")
+		assert.Empty(t, got.CardIndices)
+		assert.Equal(t, "no legal play, pass", got.Reason)
+	})
+
+	// Never returns nil: the caller's own nil check decides whether to assign,
+	// and a nil return here would silently blank a hint the game did provide.
+	t.Run("always returns a value", func(t *testing.T) {
+		assert.NotNil(t, cardHint(nil, ""))
+	})
+}


### PR DESCRIPTION
trick 系 presenter が同じヒント構築を **54 箇所**で繰り返していました。**-162 行**。

```go
resObj.Hint = &controller.WebOutputCardHint{
    CardIndices: hint.CardIndices,
    Reason:      hint.Reason,
}
```

## 数え方を2度間違えました

最初「93 箇所」と数えましたが、これは `if hint := g.GetHint(); hint != nil` の出現数で、**中身がゲーム固有のヒント型のものまで含んでいました**。

| 種別 | 箇所 | 統合 |
|---|---|---|
| 共通型 `WebOutputCardHint` | 55（うち 1 はヘルパ自身の定義） | ✅ 54 箇所 |
| ゲーム固有型（`SergeantMajorWebOutputHint` / `MendikotWebOutputHint` / `FreeCellWebOutputHint` …） | 345 | ❌ フィールドが違う（`CardIndex` 単数 / `FromZone`+`FromCol` …） |

**件数アサートが 2 度とも書き込みを止めました**（93→25 で不一致、55→54 で不一致）。おかげで誤った一括置換にはなっていません。「見つけたか」ではなく「結果が期待どおりか」を検査する方式が効いた形です。

## 方式の選択

出力型 24 個に `SetCardHint` メソッドを生やすインタフェース方式も実装して比較しましたが、**足す API のほうが消す重複より多い**ので捨てました。素の関数にして、nil 判定と代入は呼び出し側に残しています。呼び出し箇所で「ヒントが有るときだけ入れる」ことが読めるほうが良いと判断しました。

戻り値は決して nil にしません。呼び出し側の nil 判定が代入の可否を決めるので、ここで nil を返すと**ゲームが出したヒントを黙って消す**ことになります（テストで固定）。

空の選択肢＋理由だけのヒント（「打てる札が無いのでパス」）も保持します。`len(indices) == 0` を「ヒント無し」とみなすと理由が失われるためです。

## 検証

- `go build ./...` 通過
- `go test -tags test ./internal/adapter/presenter/` 通過
- `golangci-lint run ./internal/adapter/presenter/...` 0 issues
- **6 worker の `GOOS=js GOARCH=wasm`** すべて通過

## 残り

#5368 のうち dispatch 27 箇所は [#5372](https://github.com/yuta-yoshinaga/go_trumpcards/pull/5372)、`NextRound` 22 箇所は [#5373](https://github.com/yuta-yoshinaga/go_trumpcards/pull/5373)、本 PR で presenter のヒント 54 箇所。残るはソリティア `Exec` ×6 です。

Refs #5368