### PR TITLE
refactor(controller): consolidate 6 identical solitaire CUI Exec bodies

### DIFF
--- a/internal/adapter/controller/BakersDozenCuiController.go
+++ b/internal/adapter/controller/BakersDozenCuiController.go
@@ -23,27 +23,15 @@ func NewBakersDozenCuiController(bi usecase.BakersDozenInteractorIF) *BakersDoze
 
 // Exec コマンド実行
 func (c *BakersDozenCuiController) Exec(command string) string {
-	return execCuiCommand(
-		command,
-		func(_ []string) string {
-			return c.bi.Reset()
-		},
-		[]string{"m", "move", "g", "giveup", "h", "hint", "ac", "autocomplete", "log", "l", "u", "undo"},
-		func(cmd string, args []string) (string, bool) {
-			switch cmd {
-			case "m", "move":
-				return c.handleMove(args), true
-			case "g", "giveup":
-				return c.bi.GiveUp(), true
-			case "ac", "autocomplete":
-				return c.bi.AutoComplete(), true
-			case "u", "undo":
-				return c.bi.Undo(), true
-			default:
-				return handleCuiHintAndLog(cmd, c.bi.Hint, c.bi.ActionLog)
-			}
-		},
-	)
+	return execSolitaireCui(command, solitaireCuiFns{
+		reset:        c.bi.Reset,
+		move:         c.handleMove,
+		giveUp:       c.bi.GiveUp,
+		autoComplete: c.bi.AutoComplete,
+		undo:         c.bi.Undo,
+		hint:         c.bi.Hint,
+		actionLog:    c.bi.ActionLog,
+	})
 }
 
 // handleMove 移動コマンドを処理

--- a/internal/adapter/controller/BeleagueredCastleCuiController.go
+++ b/internal/adapter/controller/BeleagueredCastleCuiController.go
@@ -23,27 +23,15 @@ func NewBeleagueredCastleCuiController(bi usecase.BeleagueredCastleInteractorIF)
 
 // Exec コマンド実行
 func (c *BeleagueredCastleCuiController) Exec(command string) string {
-	return execCuiCommand(
-		command,
-		func(_ []string) string {
-			return c.bi.Reset()
-		},
-		[]string{"m", "move", "g", "giveup", "h", "hint", "ac", "autocomplete", "log", "l", "u", "undo"},
-		func(cmd string, args []string) (string, bool) {
-			switch cmd {
-			case "m", "move":
-				return c.handleMove(args), true
-			case "g", "giveup":
-				return c.bi.GiveUp(), true
-			case "ac", "autocomplete":
-				return c.bi.AutoComplete(), true
-			case "u", "undo":
-				return c.bi.Undo(), true
-			default:
-				return handleCuiHintAndLog(cmd, c.bi.Hint, c.bi.ActionLog)
-			}
-		},
-	)
+	return execSolitaireCui(command, solitaireCuiFns{
+		reset:        c.bi.Reset,
+		move:         c.handleMove,
+		giveUp:       c.bi.GiveUp,
+		autoComplete: c.bi.AutoComplete,
+		undo:         c.bi.Undo,
+		hint:         c.bi.Hint,
+		actionLog:    c.bi.ActionLog,
+	})
 }
 
 // handleMove 移動コマンドを処理

--- a/internal/adapter/controller/BisleyCuiController.go
+++ b/internal/adapter/controller/BisleyCuiController.go
@@ -23,27 +23,15 @@ func NewBisleyCuiController(bi usecase.BisleyInteractorIF) *BisleyCuiController 
 
 // Exec コマンド実行
 func (c *BisleyCuiController) Exec(command string) string {
-	return execCuiCommand(
-		command,
-		func(_ []string) string {
-			return c.bi.Reset()
-		},
-		[]string{"m", "move", "g", "giveup", "h", "hint", "ac", "autocomplete", "log", "l", "u", "undo"},
-		func(cmd string, args []string) (string, bool) {
-			switch cmd {
-			case "m", "move":
-				return c.handleMove(args), true
-			case "g", "giveup":
-				return c.bi.GiveUp(), true
-			case "ac", "autocomplete":
-				return c.bi.AutoComplete(), true
-			case "u", "undo":
-				return c.bi.Undo(), true
-			default:
-				return handleCuiHintAndLog(cmd, c.bi.Hint, c.bi.ActionLog)
-			}
-		},
-	)
+	return execSolitaireCui(command, solitaireCuiFns{
+		reset:        c.bi.Reset,
+		move:         c.handleMove,
+		giveUp:       c.bi.GiveUp,
+		autoComplete: c.bi.AutoComplete,
+		undo:         c.bi.Undo,
+		hint:         c.bi.Hint,
+		actionLog:    c.bi.ActionLog,
+	})
 }
 
 // handleMove 移動コマンドを処理

--- a/internal/adapter/controller/FlowerGardenCuiController.go
+++ b/internal/adapter/controller/FlowerGardenCuiController.go
@@ -24,27 +24,15 @@ func NewFlowerGardenCuiController(bi usecase.FlowerGardenInteractorIF) *FlowerGa
 
 // Exec コマンド実行
 func (c *FlowerGardenCuiController) Exec(command string) string {
-	return execCuiCommand(
-		command,
-		func(_ []string) string {
-			return c.bi.Reset()
-		},
-		[]string{"m", "move", "g", "giveup", "h", "hint", "ac", "autocomplete", "log", "l", "u", "undo"},
-		func(cmd string, args []string) (string, bool) {
-			switch cmd {
-			case "m", "move":
-				return c.handleMove(args), true
-			case "g", "giveup":
-				return c.bi.GiveUp(), true
-			case "ac", "autocomplete":
-				return c.bi.AutoComplete(), true
-			case "u", "undo":
-				return c.bi.Undo(), true
-			default:
-				return handleCuiHintAndLog(cmd, c.bi.Hint, c.bi.ActionLog)
-			}
-		},
-	)
+	return execSolitaireCui(command, solitaireCuiFns{
+		reset:        c.bi.Reset,
+		move:         c.handleMove,
+		giveUp:       c.bi.GiveUp,
+		autoComplete: c.bi.AutoComplete,
+		undo:         c.bi.Undo,
+		hint:         c.bi.Hint,
+		actionLog:    c.bi.ActionLog,
+	})
 }
 
 // handleMove 移動コマンドを処理。

--- a/internal/adapter/controller/KingAlbertCuiController.go
+++ b/internal/adapter/controller/KingAlbertCuiController.go
@@ -24,27 +24,15 @@ func NewKingAlbertCuiController(bi usecase.KingAlbertInteractorIF) *KingAlbertCu
 
 // Exec コマンド実行
 func (c *KingAlbertCuiController) Exec(command string) string {
-	return execCuiCommand(
-		command,
-		func(_ []string) string {
-			return c.bi.Reset()
-		},
-		[]string{"m", "move", "g", "giveup", "h", "hint", "ac", "autocomplete", "log", "l", "u", "undo"},
-		func(cmd string, args []string) (string, bool) {
-			switch cmd {
-			case "m", "move":
-				return c.handleMove(args), true
-			case "g", "giveup":
-				return c.bi.GiveUp(), true
-			case "ac", "autocomplete":
-				return c.bi.AutoComplete(), true
-			case "u", "undo":
-				return c.bi.Undo(), true
-			default:
-				return handleCuiHintAndLog(cmd, c.bi.Hint, c.bi.ActionLog)
-			}
-		},
-	)
+	return execSolitaireCui(command, solitaireCuiFns{
+		reset:        c.bi.Reset,
+		move:         c.handleMove,
+		giveUp:       c.bi.GiveUp,
+		autoComplete: c.bi.AutoComplete,
+		undo:         c.bi.Undo,
+		hint:         c.bi.Hint,
+		actionLog:    c.bi.ActionLog,
+	})
 }
 
 // handleMove 移動コマンドを処理。

--- a/internal/adapter/controller/StreetsAndAlleysCuiController.go
+++ b/internal/adapter/controller/StreetsAndAlleysCuiController.go
@@ -23,27 +23,15 @@ func NewStreetsAndAlleysCuiController(bi usecase.StreetsAndAlleysInteractorIF) *
 
 // Exec コマンド実行
 func (c *StreetsAndAlleysCuiController) Exec(command string) string {
-	return execCuiCommand(
-		command,
-		func(_ []string) string {
-			return c.bi.Reset()
-		},
-		[]string{"m", "move", "g", "giveup", "h", "hint", "ac", "autocomplete", "log", "l", "u", "undo"},
-		func(cmd string, args []string) (string, bool) {
-			switch cmd {
-			case "m", "move":
-				return c.handleMove(args), true
-			case "g", "giveup":
-				return c.bi.GiveUp(), true
-			case "ac", "autocomplete":
-				return c.bi.AutoComplete(), true
-			case "u", "undo":
-				return c.bi.Undo(), true
-			default:
-				return handleCuiHintAndLog(cmd, c.bi.Hint, c.bi.ActionLog)
-			}
-		},
-	)
+	return execSolitaireCui(command, solitaireCuiFns{
+		reset:        c.bi.Reset,
+		move:         c.handleMove,
+		giveUp:       c.bi.GiveUp,
+		autoComplete: c.bi.AutoComplete,
+		undo:         c.bi.Undo,
+		hint:         c.bi.Hint,
+		actionLog:    c.bi.ActionLog,
+	})
 }
 
 // handleMove 移動コマンドを処理

--- a/internal/adapter/controller/cui_controller_helper.go
+++ b/internal/adapter/controller/cui_controller_helper.go
@@ -68,3 +68,49 @@ func execCuiCommand(
 		return unknownCommandMessage(fields[0], allCommands)
 	}
 }
+
+// solitaireCuiFns is the interactor surface of the tableau-solitaire CUI
+// command set, taken as function values because each game has its own
+// interactor type with no shared interface.
+type solitaireCuiFns struct {
+	reset        func() string
+	move         func(args []string) string
+	giveUp       func() string
+	autoComplete func() string
+	undo         func() string
+	hint         func() string
+	actionLog    func() string
+}
+
+// execSolitaireCui runs the move/giveup/autocomplete/undo command set shared by
+// the tableau solitaires, delegating quit/reset and unknown-command suggestions
+// to execCuiCommand.
+//
+// Consolidates 6 byte-identical Exec bodies: BakersDozen, BeleagueredCastle,
+// Bisley, FlowerGarden, KingAlbert, StreetsAndAlleys. They differed only in
+// receiver name and in which interactor the closures called — see issue #5368.
+//
+// The command list is passed to execCuiCommand unchanged, so a typo still
+// reaches the shared suggestion path ("もしかして 'move' ですか？") instead of
+// being swallowed here.
+func execSolitaireCui(command string, fns solitaireCuiFns) string {
+	return execCuiCommand(
+		command,
+		func(_ []string) string { return fns.reset() },
+		[]string{"m", "move", "g", "giveup", "h", "hint", "ac", "autocomplete", "log", "l", "u", "undo"},
+		func(cmd string, args []string) (string, bool) {
+			switch cmd {
+			case "m", "move":
+				return fns.move(args), true
+			case "g", "giveup":
+				return fns.giveUp(), true
+			case "ac", "autocomplete":
+				return fns.autoComplete(), true
+			case "u", "undo":
+				return fns.undo(), true
+			default:
+				return handleCuiHintAndLog(cmd, fns.hint, fns.actionLog)
+			}
+		},
+	)
+}

--- a/internal/adapter/controller/cui_controller_helper_test.go
+++ b/internal/adapter/controller/cui_controller_helper_test.go
@@ -3,6 +3,7 @@
 package controller
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -86,5 +87,61 @@ func TestExecCuiCommand(t *testing.T) {
 	t.Run("unhandled game command no suggestion", func(t *testing.T) {
 		result := execCuiCommand("zzzzzzz", resetFn, validCmds, gameHandler)
 		assert.Equal(t, i18n.ErrorPrefix+"コマンドが不明です: zzzzzzz", result)
+	})
+}
+
+// execSolitaireCui consolidates 6 byte-identical Exec bodies across the
+// tableau solitaires (BakersDozen, BeleagueredCastle, Bisley, FlowerGarden,
+// KingAlbert, StreetsAndAlleys). They differed only in receiver and in which
+// interactor the closures called — see issue #5368.
+func TestExecSolitaireCui(t *testing.T) {
+	fns := func(calls *[]string) solitaireCuiFns {
+		rec := func(name string) func() string {
+			return func() string { *calls = append(*calls, name); return name }
+		}
+		return solitaireCuiFns{
+			reset:        rec("reset"),
+			giveUp:       rec("giveup"),
+			autoComplete: rec("autocomplete"),
+			undo:         rec("undo"),
+			hint:         rec("hint"),
+			actionLog:    rec("log"),
+			move: func(args []string) string {
+				*calls = append(*calls, "move:"+strings.Join(args, ","))
+				return "moved"
+			},
+		}
+	}
+
+	cases := []struct{ cmd, want string }{
+		{"r", "reset"}, {"reset", "reset"},
+		{"g", "giveup"}, {"giveup", "giveup"},
+		{"ac", "autocomplete"}, {"autocomplete", "autocomplete"},
+		{"u", "undo"}, {"undo", "undo"},
+		{"h", "hint"}, {"hint", "hint"},
+		{"l", "log"}, {"log", "log"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.cmd, func(t *testing.T) {
+			var calls []string
+			execSolitaireCui(tc.cmd, fns(&calls))
+			assert.Equal(t, []string{tc.want}, calls)
+		})
+	}
+
+	t.Run("move forwards its arguments", func(t *testing.T) {
+		var calls []string
+		got := execSolitaireCui("m w 1", fns(&calls))
+		assert.Equal(t, "moved", got)
+		assert.Equal(t, []string{"move:w,1"}, calls)
+	})
+
+	// An unknown command must reach the shared suggestion path rather than
+	// being answered here: that is what produces "もしかして…" for a typo.
+	t.Run("unknown command is not answered by any of the callbacks", func(t *testing.T) {
+		var calls []string
+		out := execSolitaireCui("frobnicate", fns(&calls))
+		assert.Empty(t, calls, "no interactor method should have run")
+		assert.NotEmpty(t, out, "the shared helper still answers with a suggestion")
 	})
 }

--- a/internal/infrastructure/games/manual_template_test.go
+++ b/internal/infrastructure/games/manual_template_test.go
@@ -3,6 +3,9 @@ package games_test
 import (
 	"encoding/json"
 	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -535,6 +538,13 @@ var manualUniversalCommands = map[string]bool{
 // a literal used for something else would pass -- because the alternative
 // (parsing each controller's switch) breaks on the games whose arguments are
 // matched in a nested switch.
+//
+// Since #5375 a controller may hand its whole command set to a shared helper
+// (execSolitaireCui takes the six tableau-solitaire games), which moves the
+// literals out of the controller file and made this guard report all six as
+// documenting commands they "never receive". So the literals of a helper the
+// controller calls count as the controller's own -- delegation does not change
+// which commands reach the dispatcher.
 func TestManualCommandsAreDispatchable(t *testing.T) {
 	src, err := os.ReadFile(filepath.Join(repoRoot, "internal/infrastructure/ui/GameManager.go"))
 	if err != nil {
@@ -549,6 +559,8 @@ func TestManualCommandsAreDispatchable(t *testing.T) {
 			"fix manualBindCuiRe rather than trusting a clean run", len(owner), len(games.All()))
 	}
 
+	helperLiterals := manualControllerHelperLiterals(t)
+
 	checked := 0
 	for _, g := range games.All() {
 		typ, ok := owner[g.Name]
@@ -559,10 +571,13 @@ func TestManualCommandsAreDispatchable(t *testing.T) {
 		if err != nil {
 			continue
 		}
-		literals := map[string]bool{}
-		for _, q := range manualGoStringRe.FindAllString(string(ctl), -1) {
-			if s, err := strconv.Unquote(q); err == nil {
-				literals[s] = true
+		literals := manualStringLiterals(string(ctl))
+		for name, lits := range helperLiterals {
+			if !strings.Contains(string(ctl), name) {
+				continue
+			}
+			for lit := range lits {
+				literals[lit] = true
 			}
 		}
 		rel := filepath.Join("docs/manual/cui", g.Name+".md")
@@ -695,4 +710,66 @@ func TestManualGoStringReSurvivesEscapes(t *testing.T) {
 	if !slices.Contains(got, "take") || !slices.Contains(got, "t") {
 		t.Errorf("lost a literal after an escaped one: %v", got)
 	}
+}
+
+// manualStringLiterals returns every Go string literal in src.
+func manualStringLiterals(src string) map[string]bool {
+	out := map[string]bool{}
+	for _, q := range manualGoStringRe.FindAllString(src, -1) {
+		if s, err := strconv.Unquote(q); err == nil {
+			out[s] = true
+		}
+	}
+	return out
+}
+
+// manualControllerHelperLiterals maps each top-level function declared in a
+// *_helper.go of internal/adapter/controller to the string literals in its
+// body, so a controller that delegates its dispatch to one of them still
+// accounts for the commands that helper accepts.
+//
+// Per function rather than per file: a whole-file union would let any manual
+// document any token mentioned anywhere in the helper file, which is looser
+// than this guard is anywhere else.
+func manualControllerHelperLiterals(t *testing.T) map[string]map[string]bool {
+	t.Helper()
+	dir := filepath.Join(repoRoot, "internal/adapter/controller")
+	paths, err := filepath.Glob(filepath.Join(dir, "*_helper.go"))
+	if err != nil || len(paths) == 0 {
+		t.Fatalf("no *_helper.go found under %s (err=%v) -- the delegation lookup would silently do nothing", dir, err)
+	}
+	out := map[string]map[string]bool{}
+	for _, path := range paths {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, path, data, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil {
+				continue
+			}
+			lits := map[string]bool{}
+			ast.Inspect(fn.Body, func(n ast.Node) bool {
+				if lit, ok := n.(*ast.BasicLit); ok && lit.Kind == token.STRING {
+					if s, err := strconv.Unquote(lit.Value); err == nil {
+						lits[s] = true
+					}
+				}
+				return true
+			})
+			if len(lits) > 0 {
+				out[fn.Name.Name] = lits
+			}
+		}
+	}
+	if len(out) == 0 {
+		t.Fatal("no helper function contributed a string literal -- the AST walk broke")
+	}
+	return out
 }


### PR DESCRIPTION
BakersDozen / BeleagueredCastle / Bisley / FlowerGarden / KingAlbert / StreetsAndAlleys。[#5368](https://github.com/yuta-yoshinaga/go_trumpcards/issues/5368) が挙げた最後のクラスタです。

既に `execCuiCommand` を使う形だったので、差は `handleMove` と interactor の参照先だけでした。`solitaireCuiFns` で関数値を束ねます。

コマンド一覧は `execCuiCommand` へそのまま渡すので、typo が共通の候補提示（「もしかして 'move' ですか？」）に到達し続けます。これをテストで固定しました。

呼び出し側 6 ファイル: **-72 行**

## #5361 と同じ指標で再測定しました（正直な数字）

| | グループ | 重複行 |
|---|---|---|
| 起票時 | 99 | 4014 |
| 現在 | 98 | 3551 |
| 差分 | **-1** | **-463** |

**行は 463 減りましたが、グループ数はほぼ変わっていません。**

大きいクラスタ（dispatch 27 / `NextRound` 22 / presenter hint 54 / `Exec` 6）を潰しても、3〜5 箇所規模の小さいグループが多数残っているためです。#5361 の「99 グループ」という数字は、**残りが同じ密度で片付くことを意味しません** —— 上位が大きく裾が長い分布でした。

残りに手を付けるかは費用対効果の判断になるので、この PR では止めます。#5368 が名指ししたクラスタはすべて消化済みです。

## 検証

- `go build ./...` 通過
- `go test -tags test ./internal/adapter/controller/` 通過
- `golangci-lint run ./internal/adapter/...` 0 issues
- **6 worker の `GOOS=js GOARCH=wasm`** すべて通過
- 置換件数 6 が期待値と一致（不一致なら中止）

Closes #5368