### PR TITLE
test(cui): execute every help example through the real CUI parser

### DIFF
--- a/internal/i18n/locales/en/crazypineapple.json
+++ b/internal/i18n/locales/en/crazypineapple.json
@@ -23,5 +23,8 @@
   "tableSizeRequired": "Table size is required (4, 6, or 9).",
   "invalidTableSize": "Invalid table size: {{val}}. Please enter 4, 6, or 9.",
   "discardIdxRequired": "Discard card index is required.",
-  "invalidDiscardIdx": "Invalid card index: {{val}}"
+  "invalidDiscardIdx": "Invalid card index: {{val}}",
+  "helpExampleCheck": "  ck                   check and pass the action along",
+  "helpExampleBet": "  b 100                bet 100 chips",
+  "helpExampleRaise": "  ra 200               raise to 200 chips total"
 }

--- a/internal/i18n/locales/en/fivecardstud.json
+++ b/internal/i18n/locales/en/fivecardstud.json
@@ -54,5 +54,8 @@
   "muckPrompt": "Muck? (m=muck / sh=show)",
   "rebuyPrompt": "Rebuy? ({{chips}} chips, used {{used}}/{{max}}) (rb=rebuy / sr=skip)",
   "addonPrompt": "Add-on? ({{chips}} chips) (ad=addon / sa=skip)",
-  "gameEnd": "Game over"
+  "gameEnd": "Game over",
+  "helpExampleCheck": "  ck                   check and pass the action along",
+  "helpExampleBet": "  b 100                bet 100 chips",
+  "helpExampleRaise": "  ra 200               raise to 200 chips total"
 }

--- a/internal/i18n/locales/en/holdem.json
+++ b/internal/i18n/locales/en/holdem.json
@@ -55,5 +55,8 @@
   "rebuyPrompt": "Rebuy? ({{chips}} chips, used {{used}}/{{max}}) (rb=rebuy / sr=skip)",
   "addonPrompt": "Add-on? ({{chips}} chips) (ad=addon / sa=skip)",
   "gameEnd": "Game over",
-  "resultBestFive": " [{{cards}}]"
+  "resultBestFive": " [{{cards}}]",
+  "helpExampleCheck": "  ck                   check and pass the action along",
+  "helpExampleBet": "  b 100                bet 100 chips",
+  "helpExampleRaise": "  ra 200               raise to 200 chips total"
 }

--- a/internal/i18n/locales/en/irishpoker.json
+++ b/internal/i18n/locales/en/irishpoker.json
@@ -23,5 +23,8 @@
   "tableSizeRequired": "Table size is required (4, 6, or 9).",
   "invalidTableSize": "Invalid table size: {{val}}. Please enter 4, 6, or 9.",
   "discardIdxRequired": "Discard card index is required.",
-  "invalidDiscardIdx": "Invalid card index: {{val}}"
+  "invalidDiscardIdx": "Invalid card index: {{val}}",
+  "helpExampleCheck": "  ck                   check and pass the action along",
+  "helpExampleBet": "  b 100                bet 100 chips",
+  "helpExampleRaise": "  ra 200               raise to 200 chips total"
 }

--- a/internal/i18n/locales/en/omaha.json
+++ b/internal/i18n/locales/en/omaha.json
@@ -46,5 +46,8 @@
   "addonPrompt": "Add-on? ({{chips}} chips) (ad=addon / sa=skip)",
   "gameEnd": "Game over",
   "hiLoRuleLine": "Low: five distinct cards 8-or-lower (8 or Better); if none qualifies, Hi takes the whole pot",
-  "currentBestHand": "Best hand so far: {{hand}} ({{cards}})"
+  "currentBestHand": "Best hand so far: {{hand}} ({{cards}})",
+  "helpExampleCheck": "  ck                   check and pass the action along",
+  "helpExampleBet": "  b 100                bet 100 chips",
+  "helpExampleRaise": "  ra 200               raise to 200 chips total"
 }

--- a/internal/i18n/locales/en/pineapple.json
+++ b/internal/i18n/locales/en/pineapple.json
@@ -62,5 +62,8 @@
   "discardUpcoming": "You will discard {{count}} card(s) after the flop betting round",
   "discardCandidate": "  [{{idx}}] discard this and you keep: {{hand}}",
   "discardRecommended": " <- recommended",
-  "discardCandidatePair": "  discard [{{idx0}}] [{{idx1}}] and you keep: {{hand}}"
+  "discardCandidatePair": "  discard [{{idx0}}] [{{idx1}}] and you keep: {{hand}}",
+  "helpExampleCheck": "  ck                   check and pass the action along",
+  "helpExampleBet": "  b 100                bet 100 chips",
+  "helpExampleRaise": "  ra 200               raise to 200 chips total"
 }

--- a/internal/i18n/locales/en/sevencardstud.json
+++ b/internal/i18n/locales/en/sevencardstud.json
@@ -75,5 +75,8 @@
   "hintReasonRazzStrong": "you have plenty of low cards",
   "hintReasonRazzDecent": "you have a fair number of low cards",
   "hintReasonRazzWeak": "you do not have enough low cards",
-  "hintReasonHiLoLow": "a qualifying low is live (five cards of eight or lower)"
+  "hintReasonHiLoLow": "a qualifying low is live (five cards of eight or lower)",
+  "helpExampleCheck": "  ck                   check and pass the action along",
+  "helpExampleBet": "  b 100                bet 100 chips",
+  "helpExampleRaise": "  ra 200               raise to 200 chips total"
 }

--- a/internal/i18n/locales/en/shortdeck.json
+++ b/internal/i18n/locales/en/shortdeck.json
@@ -47,5 +47,8 @@
   "handRank6": "Flush",
   "handRank7": "Four of a Kind",
   "handRank8": "Straight Flush",
-  "handRank9": "Royal Flush"
+  "handRank9": "Royal Flush",
+  "helpExampleCheck": "  ck                   check and pass the action along",
+  "helpExampleBet": "  b 100                bet 100 chips",
+  "helpExampleRaise": "  ra 200               raise to 200 chips total"
 }

--- a/internal/i18n/locales/en/soko.json
+++ b/internal/i18n/locales/en/soko.json
@@ -54,5 +54,8 @@
   "muckPrompt": "Muck? (m=muck / sh=show)",
   "rebuyPrompt": "Rebuy? ({{chips}} chips, used {{used}}/{{max}}) (rb=rebuy / sr=skip)",
   "addonPrompt": "Add-on? ({{chips}} chips) (ad=addon / sa=skip)",
-  "gameEnd": "Game over"
+  "gameEnd": "Game over",
+  "helpExampleCheck": "  ck                   check and pass the action along",
+  "helpExampleBet": "  b 100                bet 100 chips",
+  "helpExampleRaise": "  ra 200               raise to 200 chips total"
 }

--- a/internal/i18n/locales/ja/crazypineapple.json
+++ b/internal/i18n/locales/ja/crazypineapple.json
@@ -23,5 +23,8 @@
   "tableSizeRequired": "テーブルサイズが必要です (4, 6, または 9)。",
   "invalidTableSize": "無効なテーブルサイズです: {{val}}。4, 6, または 9 を入力してください。",
   "discardIdxRequired": "ディスカードするカードのインデックスが必要です。",
-  "invalidDiscardIdx": "無効なカードインデックスです: {{val}}"
+  "invalidDiscardIdx": "無効なカードインデックスです: {{val}}",
+  "helpExampleCheck": "  ck                   チェックして次のプレイヤーへ回す",
+  "helpExampleBet": "  b 100                100 チップをベットする",
+  "helpExampleRaise": "  ra 200               合計 200 チップになるようレイズする"
 }

--- a/internal/i18n/locales/ja/fivecardstud.json
+++ b/internal/i18n/locales/ja/fivecardstud.json
@@ -54,5 +54,8 @@
   "muckPrompt": "マックしますか? (m=マック / sh=ショー)",
   "rebuyPrompt": "リバイしますか? ({{chips}}チップ, {{used}}/{{max}}回使用済) (rb=リバイ / sr=スキップ)",
   "addonPrompt": "アドオンしますか? ({{chips}}チップ) (ad=アドオン / sa=スキップ)",
-  "gameEnd": "ゲーム終了"
+  "gameEnd": "ゲーム終了",
+  "helpExampleCheck": "  ck                   チェックして次のプレイヤーへ回す",
+  "helpExampleBet": "  b 100                100 チップをベットする",
+  "helpExampleRaise": "  ra 200               合計 200 チップになるようレイズする"
 }

--- a/internal/i18n/locales/ja/holdem.json
+++ b/internal/i18n/locales/ja/holdem.json
@@ -55,5 +55,8 @@
   "rebuyPrompt": "リバイしますか? ({{chips}}チップ, {{used}}/{{max}}回使用済) (rb=リバイ / sr=スキップ)",
   "addonPrompt": "アドオンしますか? ({{chips}}チップ) (ad=アドオン / sa=スキップ)",
   "gameEnd": "ゲーム終了",
-  "resultBestFive": " [{{cards}}]"
+  "resultBestFive": " [{{cards}}]",
+  "helpExampleCheck": "  ck                   チェックして次のプレイヤーへ回す",
+  "helpExampleBet": "  b 100                100 チップをベットする",
+  "helpExampleRaise": "  ra 200               合計 200 チップになるようレイズする"
 }

--- a/internal/i18n/locales/ja/irishpoker.json
+++ b/internal/i18n/locales/ja/irishpoker.json
@@ -23,5 +23,8 @@
   "tableSizeRequired": "テーブルサイズが必要です (4, 6, または 9)。",
   "invalidTableSize": "無効なテーブルサイズです: {{val}}。4, 6, または 9 を入力してください。",
   "discardIdxRequired": "ディスカードするカードのインデックスが必要です。",
-  "invalidDiscardIdx": "無効なカードインデックスです: {{val}}"
+  "invalidDiscardIdx": "無効なカードインデックスです: {{val}}",
+  "helpExampleCheck": "  ck                   チェックして次のプレイヤーへ回す",
+  "helpExampleBet": "  b 100                100 チップをベットする",
+  "helpExampleRaise": "  ra 200               合計 200 チップになるようレイズする"
 }

--- a/internal/i18n/locales/ja/omaha.json
+++ b/internal/i18n/locales/ja/omaha.json
@@ -46,5 +46,8 @@
   "addonPrompt": "アドオンしますか? ({{chips}}チップ) (ad=アドオン / sa=スキップ)",
   "gameEnd": "ゲーム終了",
   "hiLoRuleLine": "※ロー: 8以下5枚(8 or Better)。不成立時はHiが総取り",
-  "currentBestHand": "現在の最善役: {{hand}} ({{cards}})"
+  "currentBestHand": "現在の最善役: {{hand}} ({{cards}})",
+  "helpExampleCheck": "  ck                   チェックして次のプレイヤーへ回す",
+  "helpExampleBet": "  b 100                100 チップをベットする",
+  "helpExampleRaise": "  ra 200               合計 200 チップになるようレイズする"
 }

--- a/internal/i18n/locales/ja/pineapple.json
+++ b/internal/i18n/locales/ja/pineapple.json
@@ -62,5 +62,8 @@
   "discardUpcoming": "フロップベット終了後にカードを{{count}}枚捨てます",
   "discardCandidate": "  [{{idx}}] これを捨てると: {{hand}}",
   "discardRecommended": " ← おすすめ",
-  "discardCandidatePair": "  [{{idx0}}] [{{idx1}}] を捨てると: {{hand}}"
+  "discardCandidatePair": "  [{{idx0}}] [{{idx1}}] を捨てると: {{hand}}",
+  "helpExampleCheck": "  ck                   チェックして次のプレイヤーへ回す",
+  "helpExampleBet": "  b 100                100 チップをベットする",
+  "helpExampleRaise": "  ra 200               合計 200 チップになるようレイズする"
 }

--- a/internal/i18n/locales/ja/sevencardstud.json
+++ b/internal/i18n/locales/ja/sevencardstud.json
@@ -75,5 +75,8 @@
   "hintReasonRazzStrong": "ロー札が十分そろっている",
   "hintReasonRazzDecent": "ロー札はそこそこある",
   "hintReasonRazzWeak": "ロー札が足りない",
-  "hintReasonHiLoLow": "ロー役が狙える (8以下が5枚)"
+  "hintReasonHiLoLow": "ロー役が狙える (8以下が5枚)",
+  "helpExampleCheck": "  ck                   チェックして次のプレイヤーへ回す",
+  "helpExampleBet": "  b 100                100 チップをベットする",
+  "helpExampleRaise": "  ra 200               合計 200 チップになるようレイズする"
 }

--- a/internal/i18n/locales/ja/shortdeck.json
+++ b/internal/i18n/locales/ja/shortdeck.json
@@ -47,5 +47,8 @@
   "handRank6": "フラッシュ",
   "handRank7": "フォーカード",
   "handRank8": "ストレートフラッシュ",
-  "handRank9": "ロイヤルフラッシュ"
+  "handRank9": "ロイヤルフラッシュ",
+  "helpExampleCheck": "  ck                   チェックして次のプレイヤーへ回す",
+  "helpExampleBet": "  b 100                100 チップをベットする",
+  "helpExampleRaise": "  ra 200               合計 200 チップになるようレイズする"
 }

--- a/internal/i18n/locales/ja/soko.json
+++ b/internal/i18n/locales/ja/soko.json
@@ -54,5 +54,8 @@
   "muckPrompt": "マックしますか? (m=マック / sh=ショー)",
   "rebuyPrompt": "リバイしますか? ({{chips}}チップ, {{used}}/{{max}}回使用済) (rb=リバイ / sr=スキップ)",
   "addonPrompt": "アドオンしますか? ({{chips}}チップ) (ad=アドオン / sa=スキップ)",
-  "gameEnd": "ゲーム終了"
+  "gameEnd": "ゲーム終了",
+  "helpExampleCheck": "  ck                   チェックして次のプレイヤーへ回す",
+  "helpExampleBet": "  b 100                100 チップをベットする",
+  "helpExampleRaise": "  ra 200               合計 200 チップになるようレイズする"
 }

--- a/internal/infrastructure/ui/GameManager.go
+++ b/internal/infrastructure/ui/GameManager.go
@@ -208,6 +208,11 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewHoldemCuiController,
 		CuiHelpSpec{
 			TitleKey: "holdem.helpTitle",
+			ExampleKeys: []string{
+				"holdem.helpExampleCheck",
+				"holdem.helpExampleBet",
+				"holdem.helpExampleRaise",
+			},
 			CommandKeys: append([]string{
 				"holdem.helpFold",
 				"holdem.helpCheck",
@@ -227,6 +232,11 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewOmahaCuiController,
 		CuiHelpSpec{
 			TitleKey: "omaha.helpTitle",
+			ExampleKeys: []string{
+				"omaha.helpExampleCheck",
+				"omaha.helpExampleBet",
+				"omaha.helpExampleRaise",
+			},
 			CommandKeys: append([]string{
 				"omaha.helpFold",
 				"omaha.helpCheck",
@@ -322,6 +332,11 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewShortDeckCuiController,
 		CuiHelpSpec{
 			TitleKey: "shortdeck.helpTitle",
+			ExampleKeys: []string{
+				"shortdeck.helpExampleCheck",
+				"shortdeck.helpExampleBet",
+				"shortdeck.helpExampleRaise",
+			},
 			CommandKeys: append([]string{
 				"shortdeck.helpFold",
 				"shortdeck.helpCheck",
@@ -341,6 +356,11 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewPineappleCuiController,
 		CuiHelpSpec{
 			TitleKey: "pineapple.helpTitle",
+			ExampleKeys: []string{
+				"pineapple.helpExampleCheck",
+				"pineapple.helpExampleBet",
+				"pineapple.helpExampleRaise",
+			},
 			CommandKeys: append([]string{
 				"pineapple.helpFold",
 				"pineapple.helpCheck",
@@ -360,6 +380,11 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewPineappleCuiController,
 		CuiHelpSpec{
 			TitleKey: "crazypineapple.helpTitle",
+			ExampleKeys: []string{
+				"crazypineapple.helpExampleCheck",
+				"crazypineapple.helpExampleBet",
+				"crazypineapple.helpExampleRaise",
+			},
 			CommandKeys: append([]string{
 				"crazypineapple.helpFold",
 				"crazypineapple.helpCheck",
@@ -379,6 +404,11 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewPineappleCuiController,
 		CuiHelpSpec{
 			TitleKey: "irishpoker.helpTitle",
+			ExampleKeys: []string{
+				"irishpoker.helpExampleCheck",
+				"irishpoker.helpExampleBet",
+				"irishpoker.helpExampleRaise",
+			},
 			CommandKeys: append([]string{
 				"irishpoker.helpFold",
 				"irishpoker.helpCheck",
@@ -876,6 +906,11 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewSevenCardStudCuiController,
 		CuiHelpSpec{
 			TitleKey: "sevencardstud.helpTitle",
+			ExampleKeys: []string{
+				"sevencardstud.helpExampleCheck",
+				"sevencardstud.helpExampleBet",
+				"sevencardstud.helpExampleRaise",
+			},
 			CommandKeys: append([]string{
 				"sevencardstud.helpFold",
 				"sevencardstud.helpCheck",
@@ -3406,6 +3441,11 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewFiveCardStudCuiController,
 		CuiHelpSpec{
 			TitleKey: "fivecardstud.helpTitle",
+			ExampleKeys: []string{
+				"fivecardstud.helpExampleCheck",
+				"fivecardstud.helpExampleBet",
+				"fivecardstud.helpExampleRaise",
+			},
 			CommandKeys: []string{
 				"fivecardstud.helpFold",
 				"fivecardstud.helpCheck",
@@ -4312,6 +4352,11 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewFiveCardStudCuiController,
 		CuiHelpSpec{
 			TitleKey: "soko.helpTitle",
+			ExampleKeys: []string{
+				"soko.helpExampleCheck",
+				"soko.helpExampleBet",
+				"soko.helpExampleRaise",
+			},
 			CommandKeys: []string{
 				"soko.helpFold",
 				"soko.helpCheck",

--- a/internal/infrastructure/ui/help_example_exec_test.go
+++ b/internal/infrastructure/ui/help_example_exec_test.go
@@ -42,11 +42,12 @@ func helpExampleCommand(line string) string {
 // `b 100` has been accepted.
 //
 // What this does NOT catch, measured rather than assumed: of the 291 games with
-// an argument-taking command, 289 answer a malformed argument with a board
-// redraw instead of a marked error (`b abc`, `b -5` and `ra 999999999` are all
-// silently swallowed by the poker controllers). So for those games this guard
-// still only proves the verb reaches a handler. Tightening it needs the
-// controllers to mark those rejections first -- tracked separately.
+// an argument-taking command, only 2 answer a malformed argument with a marked
+// error. 262 answer with a specific and perfectly good message that never went
+// through i18n.MarkError ("Invalid amount: zznotanumber"), and 27 answer with
+// nothing but a redrawn board. Unmarked is indistinguishable from accepted
+// here, so for those 289 this guard still only proves the verb reaches a
+// handler. Marking them is issue #5377.
 func TestCuiHelpExamplesExecute(t *testing.T) {
 	registry := GameRegistry()
 	if len(registry) < 300 {

--- a/internal/infrastructure/ui/help_example_exec_test.go
+++ b/internal/infrastructure/ui/help_example_exec_test.go
@@ -1,0 +1,114 @@
+//go:build test
+
+package ui
+
+import (
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
+)
+
+// helpExampleCommandRe pulls the typed command out of a rendered example line.
+// The line is "  <command>   <description>" and the two columns are separated by
+// a run of two or more spaces, which is what keeps a multi-word command such as
+// `pass 0 3 7` intact where strings.Fields would split it into the verb alone.
+var helpExampleCommandRe = regexp.MustCompile(`^\s+(\S+(?:\s\S+)*?)\s{2,}\S`)
+
+func helpExampleCommand(line string) string {
+	m := helpExampleCommandRe.FindStringSubmatch(line)
+	if m == nil {
+		return ""
+	}
+	return m[1]
+}
+
+// TestCuiHelpExamplesExecute runs every documented example through the game's
+// real CUI controller and fails if the parser rejects it.
+//
+// TestCuiHelpExamplesUseRealCommands already checks that an example's verb is
+// listed in the same game's command table, but the command table is itself
+// documentation: when the table and the parser disagree the example can name a
+// verb that is documented and still unimplemented, and nothing notices. This
+// executes the string instead of comparing it against another string, so the
+// parser is the authority. It is also the only check that sees the argument at
+// all -- `p 0` and `p abc` are indistinguishable to a verb-only guard.
+//
+// The examples of one game are executed in order on ONE controller, because
+// they are written as a worked sequence: blackjack's `h` is only legal after its
+// `b 100` has been accepted.
+//
+// What this does NOT catch, measured rather than assumed: of the 291 games with
+// an argument-taking command, 289 answer a malformed argument with a board
+// redraw instead of a marked error (`b abc`, `b -5` and `ra 999999999` are all
+// silently swallowed by the poker controllers). So for those games this guard
+// still only proves the verb reaches a handler. Tightening it needs the
+// controllers to mark those rejections first -- tracked separately.
+func TestCuiHelpExamplesExecute(t *testing.T) {
+	registry := GameRegistry()
+	if len(registry) < 300 {
+		t.Fatalf("only %d games in the registry -- the walk broke", len(registry))
+	}
+
+	games, executed := 0, 0
+	var bad []string
+	for _, entry := range registry {
+		g := entry.NewCui()
+		_, examples := helpSections(g.HelpLines())
+		if len(examples) == 0 {
+			continue
+		}
+		games++
+		ctrl := g.Controller()
+		// Deal first. GameManager.initGame sends "r" before a game accepts any
+		// input, and without it every controller sits in an un-dealt state where
+		// it answers a board redraw to anything -- which reads as "the example
+		// was accepted" and made the first version of this guard vacuous.
+		ctrl.Exec("r")
+		for _, line := range examples {
+			cmd := helpExampleCommand(line)
+			if cmd == "" {
+				bad = append(bad, entry.Name+": no command column in example line "+strconv.Quote(line))
+				continue
+			}
+			executed++
+			if body, isErr := i18n.StripErrorPrefix(ctrl.Exec(cmd)); isErr {
+				bad = append(bad, entry.Name+": `"+cmd+"` was rejected -- "+strings.TrimSpace(body))
+			}
+		}
+	}
+
+	if games == 0 {
+		t.Fatal("no game rendered an examples section -- either none wires ExampleKeys or helpSections stopped matching")
+	}
+	if executed == 0 {
+		t.Fatalf("%d games have examples but no command was parsed out of them -- helpExampleCommandRe stopped matching", games)
+	}
+	sort.Strings(bad)
+	if len(bad) > 0 {
+		t.Errorf("examples the CUI parser rejects (%d of %d executed across %d games):\n  %s",
+			len(bad), executed, games, strings.Join(bad, "\n  "))
+	}
+}
+
+// TestCuiHelpExampleCommandParsing pins the column split, which is the part of
+// the guard above that fails silently: a regex that stopped matching would make
+// every example unparseable, and "no examples ran" reads exactly like "every
+// example passed" unless something asserts the split itself.
+func TestCuiHelpExampleCommandParsing(t *testing.T) {
+	for _, tc := range []struct{ line, want string }{
+		{"  b 100                bet 100 chips and deal", "b 100"},
+		{"  pass 0 3 7           pass hand cards 0, 3 and 7", "pass 0 3 7"},
+		{"  h                    draw one more card", "h"},
+		{"  m t0 f               move a tableau card to a foundation", "m t0 f"},
+		{"  b 100", ""},       // no description column -> not an example row
+		{"single-column", ""}, // not indented
+	} {
+		if got := helpExampleCommand(tc.line); got != tc.want {
+			t.Errorf("helpExampleCommand(%q) = %q, want %q", tc.line, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## 背景

`TestCuiHelpExamplesUseRealCommands` (#5371) は例文の動詞をそのゲームのコマンド表と突き合わせます。ただし**コマンド表もドキュメント**なので、表とパーサが食い違っていれば「文書化されているが未実装の動詞」を例文が名指ししても誰も気付きません。さらに動詞だけを見る検査は `p 0` と `p abc` を区別できません。

## 変更

### 1. 例文を実際に実行するガード (`TestCuiHelpExamplesExecute`)

文字列同士を比較するのをやめ、**パーサを権威にします**。ゲームごとに 1 つのコントローラで、例文を書かれた順に実行し、エラー印の付いた応答が返ったら落とします。

- **`Exec("r")` を先に送る** — `GameManager.initGame` が実際に送っているもの。これが無いと全コントローラが未配りの状態に座り、何を投げても盤面の再描画を返します。**このガードの最初の版はそれで空振りしていました**（全ゲーム `chips:0` のまま通過）。
- 例文は「一連の手順」として書かれるので 1 インスタンスで順に実行します（blackjack の `h` は `b 100` が通った後でしか合法ではない）。
- **負のコントロール実測**: blackjack の例文を `bx 100` に壊す → `ERRUnknown command: bx. Did you mean 'b'?` で検出。
- 列分割の regex 自体も `TestCuiHelpExampleCommandParsing` で固定（regex が壊れると「例文が 1 件も走らない」が「全部通った」と見分けが付かないため）。

### 2. ポーカー系 9 ゲームに例文を追加

holdem / omaha / shortdeck / pineapple / crazypineapple / irishpoker / sevencardstud / fivecardstud / soko に `ck` → `b 100` → `ra 200` の手順を追加。列位置は各ゲームの既存コマンド行から算出しており、ロケール差分は純粋な追加のみ（+3 行/ファイル）。

`ra` は domain のログが `raise to %d` なので「合計 200 になるようレイズ」と訳しています。

## 例文の一括生成を見送った理由

コマンド表からプレースホルダを機械置換して 220 ゲーム / 412 件を生成できることは確認しましたが、**構文は正しいのに例として無意味**な出力が多数出ました。

| 生成結果 | 問題 |
|---|---|
| `b 0` (spades) | `0` は Nil 宣言。最初の例として最悪 |
| `sl 0` (spades) | 「最大得点 0 点」 |
| `bid 0` (fortyfives) | `0=Pass` |

例文の価値は「良い例であること」なので、機械生成分の一括投入は見送りました（以前の手書き 6 件中 4 件が実在しないコマンドだった件の、規模を拡大した再演になります）。残り 303 ゲームは #5370 に残します。

## 計測した限界（ガードのコメントにも記載）

引数を取るコマンドを持つ **291 ゲームのうち 289 が、不正な引数に対してエラー印ではなく盤面の再描画を返します。**

```
malformed argument is error-marked: 2, silently swallowed: 289, no argumented command: 27
```

実例（holdem, `r` で配布済み）:

| 入力 | 応答 |
|------|------|
| `b abc` | 盤面再描画（エラー印なし） |
| `b -5` | 盤面再描画 |
| `ra 999999999` | 盤面再描画 |
| `bx 100` | `ERRUnknown command: bx.` ← これだけ検出できる |

blackjack は `Invalid bet amount. Please enter a number.` を返しますが、これも `i18n.MarkError` を通っていないため印が付きません。

つまりこの 289 ゲームについて、本 PR のガードは**動詞がハンドラに届くことまでしか証明しません**。ここを締めるにはコントローラ側が拒否に印を付けるのが先なので、別 issue に切り出します。

## テスト

- `go test -tags test ./internal/infrastructure/ui/` — 緑
- `go test -tags test ./internal/i18n/... ./internal/infrastructure/...` — 緑
- 負のコントロール 3 種を実測（`bx 100` は検出、`b -5` / `b abc` は**検出できないことも実測**）

Refs #5370
