### PR TITLE
fix(cui): mark rejected arguments as errors

### DIFF
--- a/internal/adapter/controller/AccordionCuiController.go
+++ b/internal/adapter/controller/AccordionCuiController.go
@@ -52,14 +52,14 @@ func (c *AccordionCuiController) handleMove(args []string) string {
 	}
 	fromIdx, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidIndex", "val", args[0])
+		return invalidArg("invalidIndex", "val", args[0])
 	}
 	if len(args) < 2 {
 		return cuiutil.PromptRequest(i18n.T("accordion.promptToIndex"), fmt.Sprintf("m %d {0}", fromIdx))
 	}
 	toIdx, err := strconv.Atoi(args[1])
 	if err != nil {
-		return i18n.Tf("invalidIndex", "val", args[1])
+		return invalidArg("invalidIndex", "val", args[1])
 	}
 	return c.ai.Move(fromIdx, toIdx)
 }

--- a/internal/adapter/controller/AcesUpCuiController.go
+++ b/internal/adapter/controller/AcesUpCuiController.go
@@ -56,7 +56,7 @@ func (c *AcesUpCuiController) handleColCommand(args []string, name string, fn fu
 	col, err := strconv.Atoi(args[0])
 	if err != nil {
 		// 列番号のエラーは共通キーがある。ゲームごとに文言を割らない。
-		return i18n.Tf("invalidColumn", "val", args[0])
+		return invalidArg("invalidColumn", "val", args[0])
 	}
 	return fn(col)
 }

--- a/internal/adapter/controller/AgnesCuiController.go
+++ b/internal/adapter/controller/AgnesCuiController.go
@@ -65,7 +65,7 @@ func (c *AgnesCuiController) handleMove(args []string) string {
 	}
 	fromCol, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[0])
+		return invalidArg("invalidColumn", "val", args[0])
 	}
 	if len(args) < 2 {
 		return cuiutil.PromptRequest(i18n.T("agnes.promptToZone"), fmt.Sprintf("m %s {0}", args[0]))
@@ -75,7 +75,7 @@ func (c *AgnesCuiController) handleMove(args []string) string {
 	}
 	toCol, err := strconv.Atoi(args[1])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[1])
+		return invalidArg("invalidColumn", "val", args[1])
 	}
 	return c.ci.MoveTableauToTableau(fromCol, -1, toCol)
 }

--- a/internal/adapter/controller/AmericanToadCuiController.go
+++ b/internal/adapter/controller/AmericanToadCuiController.go
@@ -68,7 +68,7 @@ func (c *AmericanToadCuiController) handleMove(args []string) string {
 	case "t":
 		return c.handleMoveFromTableau(args[1:])
 	default:
-		return i18n.Tf("americantoad.invalidFromZone", "val", args[0])
+		return invalidArg("americantoad.invalidFromZone", "val", args[0])
 	}
 }
 
@@ -87,11 +87,11 @@ func (c *AmericanToadCuiController) handleMoveFromPile(args []string, prefix str
 		}
 		col, err := strconv.Atoi(args[1])
 		if err != nil {
-			return i18n.Tf("invalidColumn", "val", args[1])
+			return invalidArg("invalidColumn", "val", args[1])
 		}
 		return toTableau(col)
 	default:
-		return i18n.Tf("americantoad.invalidToZone", "val", args[0])
+		return invalidArg("americantoad.invalidToZone", "val", args[0])
 	}
 }
 
@@ -101,7 +101,7 @@ func (c *AmericanToadCuiController) handleMoveFromTableau(args []string) string 
 	}
 	fromCol, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[0])
+		return invalidArg("invalidColumn", "val", args[0])
 	}
 	if len(args) < 2 {
 		return cuiutil.PromptRequest(i18n.T("americantoad.promptToZone"), fmt.Sprintf("m t %s {0}", args[0]))
@@ -115,19 +115,19 @@ func (c *AmericanToadCuiController) handleMoveFromTableau(args []string) string 
 		}
 		toCol, err := strconv.Atoi(args[2])
 		if err != nil {
-			return i18n.Tf("invalidColumn", "val", args[2])
+			return invalidArg("invalidColumn", "val", args[2])
 		}
 		// 連番グループの先頭。省略時は -1 = 最上段 1 枚。
 		cardIndex := -1
 		if len(args) >= 4 {
 			idx, err := strconv.Atoi(args[3])
 			if err != nil {
-				return i18n.Tf("americantoad.invalidCardIndex", "val", args[3])
+				return invalidArg("americantoad.invalidCardIndex", "val", args[3])
 			}
 			cardIndex = idx
 		}
 		return c.ai.MoveTableauToTableau(fromCol, cardIndex, toCol)
 	default:
-		return i18n.Tf("americantoad.invalidToZone", "val", args[1])
+		return invalidArg("americantoad.invalidToZone", "val", args[1])
 	}
 }

--- a/internal/adapter/controller/AuldLangSyneCuiController.go
+++ b/internal/adapter/controller/AuldLangSyneCuiController.go
@@ -53,14 +53,14 @@ func (c *AuldLangSyneCuiController) handleWasteMove(args []string) string {
 	}
 	wasteIdx, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidIndex", "val", args[0])
+		return invalidArg("invalidIndex", "val", args[0])
 	}
 	if len(args) < 3 || args[1] != "f" {
 		return cuiutil.PromptRequest(i18n.T("auldlangsyne.promptFoundationIdx"), fmt.Sprintf("w %d f {0}", wasteIdx))
 	}
 	fIdx, err := strconv.Atoi(args[2])
 	if err != nil {
-		return i18n.Tf("invalidIndex", "val", args[2])
+		return invalidArg("invalidIndex", "val", args[2])
 	}
 	return c.ci.PlayWasteToFoundation(wasteIdx, fIdx)
 }

--- a/internal/adapter/controller/BadugiCuiController.go
+++ b/internal/adapter/controller/BadugiCuiController.go
@@ -85,7 +85,7 @@ func (bcc *BadugiCuiController) Exec(command string) string {
 				}
 				v, err := strconv.Atoi(args[0])
 				if err != nil || v < 0 || v > 1 {
-					return i18n.Tf("invalidMetaAI", "val", args[0]), true
+					return invalidArg("invalidMetaAI", "val", args[0]), true
 				}
 				cfg := bcc.bi.GetConfig()
 				cfg.CpuMetaAI = v == 1

--- a/internal/adapter/controller/BadugiCuiController_test.go
+++ b/internal/adapter/controller/BadugiCuiController_test.go
@@ -167,7 +167,7 @@ func TestBadugiCuiController_MetaAI_Invalid(t *testing.T) {
 	mi := newBadugiMockInteractor()
 	c := NewBadugiCuiController(mi)
 	result := c.Exec("mai abc")
-	assert.Equal(t, i18n.Tf("invalidMetaAI", "val", "abc"), result)
+	assert.Equal(t, invalidArg("invalidMetaAI", "val", "abc"), result)
 }
 
 // --- log ---

--- a/internal/adapter/controller/BakersDozenCuiController.go
+++ b/internal/adapter/controller/BakersDozenCuiController.go
@@ -45,7 +45,7 @@ func (c *BakersDozenCuiController) handleMove(args []string) string {
 	}
 	fromCol, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[0])
+		return invalidArg("invalidColumn", "val", args[0])
 	}
 	if len(args) < 2 {
 		return cuiutil.PromptRequest(i18n.T("bakersdozen.promptToZone"), fmt.Sprintf("m %s {0}", args[0]))
@@ -55,7 +55,7 @@ func (c *BakersDozenCuiController) handleMove(args []string) string {
 	}
 	toCol, err := strconv.Atoi(args[1])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[1])
+		return invalidArg("invalidColumn", "val", args[1])
 	}
 	return c.bi.MoveTableauToTableau(fromCol, -1, toCol)
 }

--- a/internal/adapter/controller/BeleagueredCastleCuiController.go
+++ b/internal/adapter/controller/BeleagueredCastleCuiController.go
@@ -45,7 +45,7 @@ func (c *BeleagueredCastleCuiController) handleMove(args []string) string {
 	}
 	fromCol, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[0])
+		return invalidArg("invalidColumn", "val", args[0])
 	}
 	if len(args) < 2 {
 		return cuiutil.PromptRequest(i18n.T("beleagueredcastle.promptToZone"), fmt.Sprintf("m %s {0}", args[0]))
@@ -55,7 +55,7 @@ func (c *BeleagueredCastleCuiController) handleMove(args []string) string {
 	}
 	toCol, err := strconv.Atoi(args[1])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[1])
+		return invalidArg("invalidColumn", "val", args[1])
 	}
 	return c.bi.MoveTableauToTableau(fromCol, -1, toCol)
 }

--- a/internal/adapter/controller/BisleyCuiController.go
+++ b/internal/adapter/controller/BisleyCuiController.go
@@ -46,7 +46,7 @@ func (c *BisleyCuiController) handleMove(args []string) string {
 	}
 	fromCol, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[0])
+		return invalidArg("invalidColumn", "val", args[0])
 	}
 	if len(args) < 2 {
 		return cuiutil.PromptRequest(i18n.T("bisley.promptToZone"), fmt.Sprintf("m %s {0}", args[0]))
@@ -59,7 +59,7 @@ func (c *BisleyCuiController) handleMove(args []string) string {
 	}
 	toCol, err := strconv.Atoi(args[1])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[1])
+		return invalidArg("invalidColumn", "val", args[1])
 	}
 	return c.bi.MoveTableauToTableau(fromCol, toCol)
 }

--- a/internal/adapter/controller/BraidCuiController.go
+++ b/internal/adapter/controller/BraidCuiController.go
@@ -97,7 +97,7 @@ func (c *BraidCuiController) handleMoveFromBraid(args []string) string {
 		return cuiutil.PromptRequest(i18n.T("braid.promptBraidTo"), "m br {0}")
 	}
 	if args[0] != "f" {
-		return i18n.Tf("braid.onlyToFoundation", "val", args[0])
+		return invalidArg("braid.onlyToFoundation", "val", args[0])
 	}
 	return c.bi.MoveBraidToFoundation()
 }
@@ -115,7 +115,7 @@ func (c *BraidCuiController) handleMoveFromSlot(args []string, zone string, move
 		return cuiutil.PromptRequest(i18n.T("braid.promptBraidTo"), "m "+zone+" "+args[0]+" {0}")
 	}
 	if args[1] != "f" {
-		return i18n.Tf("braid.onlyToFoundation", "val", args[1])
+		return invalidArg("braid.onlyToFoundation", "val", args[1])
 	}
 	return move(idx)
 }

--- a/internal/adapter/controller/BraidCuiController.go
+++ b/internal/adapter/controller/BraidCuiController.go
@@ -60,7 +60,7 @@ func (c *BraidCuiController) handleDirection(args []string) string {
 	case "d", "desc", "down":
 		return c.bi.ChooseDirection(false)
 	default:
-		return i18n.Tf("braid.invalidDirection", "val", args[0])
+		return invalidArg("braid.invalidDirection", "val", args[0])
 	}
 }
 
@@ -87,7 +87,7 @@ func (c *BraidCuiController) handleMove(args []string) string {
 	case "w":
 		return c.handleMoveFromWaste(args[1:])
 	default:
-		return i18n.Tf("braid.invalidFromZone", "val", args[0])
+		return invalidArg("braid.invalidFromZone", "val", args[0])
 	}
 }
 
@@ -109,7 +109,7 @@ func (c *BraidCuiController) handleMoveFromSlot(args []string, zone string, move
 	}
 	idx, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("braid.invalidSlot", "val", args[0])
+		return invalidArg("braid.invalidSlot", "val", args[0])
 	}
 	if len(args) < 2 {
 		return cuiutil.PromptRequest(i18n.T("braid.promptBraidTo"), "m "+zone+" "+args[0]+" {0}")
@@ -133,10 +133,10 @@ func (c *BraidCuiController) handleMoveFromWaste(args []string) string {
 		}
 		idx, err := strconv.Atoi(args[1])
 		if err != nil {
-			return i18n.Tf("braid.invalidSlot", "val", args[1])
+			return invalidArg("braid.invalidSlot", "val", args[1])
 		}
 		return c.bi.MoveWasteToHelper(idx)
 	default:
-		return i18n.Tf("braid.invalidToZone", "val", args[0])
+		return invalidArg("braid.invalidToZone", "val", args[0])
 	}
 }

--- a/internal/adapter/controller/BraidCuiController_test.go
+++ b/internal/adapter/controller/BraidCuiController_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	mockusecase "github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/usecase"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func newMockBraidInteractor() *mockusecase.MockBraidInteractor {
@@ -79,6 +80,27 @@ func TestBraidCuiControllerMoves(t *testing.T) {
 		c := NewBraidCuiController(bi)
 		bi.On("MoveFieldToFoundation", 2).Return("ff")
 		assert.Equal(t, "ff", c.Exec("m fd 2 f"))
+	})
+
+	// The braid and the slots have exactly one destination, so anything but `f`
+	// is refused. Both refusals go through invalidArg, so the reply carries the
+	// error marker and names the token that was rejected.
+	t.Run("rejects a braid destination other than a foundation", func(t *testing.T) {
+		c := NewBraidCuiController(newMockBraidInteractor())
+
+		body, isErr := i18n.StripErrorPrefix(c.Exec("m br t"))
+
+		assert.True(t, isErr, "a refused destination must be marked as an error")
+		assert.Equal(t, i18n.Tf("braid.onlyToFoundation", "val", "t"), body)
+	})
+
+	t.Run("rejects a slot destination other than a foundation", func(t *testing.T) {
+		c := NewBraidCuiController(newMockBraidInteractor())
+
+		body, isErr := i18n.StripErrorPrefix(c.Exec("m fd 2 t"))
+
+		assert.True(t, isErr, "a refused destination must be marked as an error")
+		assert.Equal(t, i18n.Tf("braid.onlyToFoundation", "val", "t"), body)
 	})
 
 	t.Run("helper to a foundation", func(t *testing.T) {

--- a/internal/adapter/controller/BristolCuiController.go
+++ b/internal/adapter/controller/BristolCuiController.go
@@ -72,7 +72,7 @@ func (c *BristolCuiController) handleMove(args []string) string {
 	case "n":
 		return c.handleMoveFromFan(args[1:])
 	default:
-		return i18n.Tf("bristol.invalidFromZone", "val", from)
+		return invalidArg("bristol.invalidFromZone", "val", from)
 	}
 }
 
@@ -83,7 +83,7 @@ func (c *BristolCuiController) handleMoveFromTableau(args []string) string {
 	}
 	fromCol, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[0])
+		return invalidArg("invalidColumn", "val", args[0])
 	}
 	if len(args) < 2 {
 		return cuiutil.PromptRequest(i18n.T("bristol.promptDestination"), "m t "+args[0]+" {0}")
@@ -95,7 +95,7 @@ func (c *BristolCuiController) handleMoveFromTableau(args []string) string {
 		}
 		toCol, err := strconv.Atoi(args[2])
 		if err != nil {
-			return i18n.Tf("invalidColumn", "val", args[2])
+			return invalidArg("invalidColumn", "val", args[2])
 		}
 		return c.bi.MoveTableauToTableau(fromCol, toCol)
 	case "f":
@@ -112,7 +112,7 @@ func (c *BristolCuiController) handleMoveFromFan(args []string) string {
 	}
 	fanIdx, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[0])
+		return invalidArg("invalidColumn", "val", args[0])
 	}
 	if len(args) < 2 {
 		return cuiutil.PromptRequest(i18n.T("bristol.promptDestination"), "m n "+args[0]+" {0}")
@@ -124,7 +124,7 @@ func (c *BristolCuiController) handleMoveFromFan(args []string) string {
 		}
 		toCol, err := strconv.Atoi(args[2])
 		if err != nil {
-			return i18n.Tf("invalidColumn", "val", args[2])
+			return invalidArg("invalidColumn", "val", args[2])
 		}
 		return c.bi.MoveFanToTableau(fanIdx, toCol)
 	case "f":

--- a/internal/adapter/controller/CalculationCuiController.go
+++ b/internal/adapter/controller/CalculationCuiController.go
@@ -53,14 +53,14 @@ func (c *CalculationCuiController) handleStockMove(args []string) string {
 	}
 	dest := args[0]
 	if dest != "f" && dest != "w" {
-		return i18n.Tf("calculation.invalidDestZone", "val", dest)
+		return invalidArg("calculation.invalidDestZone", "val", dest)
 	}
 	if len(args) < 2 {
 		return cuiutil.PromptRequest(i18n.T("calculation.promptIndex"), fmt.Sprintf("s %s {0}", dest))
 	}
 	idx, err := strconv.Atoi(args[1])
 	if err != nil {
-		return i18n.Tf("invalidIndex", "val", args[1])
+		return invalidArg("invalidIndex", "val", args[1])
 	}
 	if dest == "f" {
 		return c.ci.PlayStockToFoundation(idx)
@@ -75,14 +75,14 @@ func (c *CalculationCuiController) handleWasteMove(args []string) string {
 	}
 	wasteIdx, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidIndex", "val", args[0])
+		return invalidArg("invalidIndex", "val", args[0])
 	}
 	if len(args) < 3 || args[1] != "f" {
 		return cuiutil.PromptRequest(i18n.T("calculation.promptFoundationIdx"), fmt.Sprintf("w %d f {0}", wasteIdx))
 	}
 	fIdx, err := strconv.Atoi(args[2])
 	if err != nil {
-		return i18n.Tf("invalidIndex", "val", args[2])
+		return invalidArg("invalidIndex", "val", args[2])
 	}
 	return c.ci.PlayWasteToFoundation(wasteIdx, fIdx)
 }

--- a/internal/adapter/controller/CanfieldCuiController.go
+++ b/internal/adapter/controller/CanfieldCuiController.go
@@ -65,7 +65,7 @@ func (c *CanfieldCuiController) handleMove(args []string) string {
 	}
 	from := args[0]
 	if from != "w" && from != "t" && from != "r" {
-		return i18n.Tf("canfield.invalidFromZone", "val", from)
+		return invalidArg("canfield.invalidFromZone", "val", from)
 	}
 	if len(args) < 2 {
 		switch from {
@@ -96,13 +96,13 @@ func (c *CanfieldCuiController) handleMoveFromWaste(args []string) string {
 		}
 		col, err := strconv.Atoi(args[1])
 		if err != nil {
-			return i18n.Tf("invalidColumn", "val", args[1])
+			return invalidArg("invalidColumn", "val", args[1])
 		}
 		return c.ci.MoveWasteToTableau(col)
 	case "f":
 		return c.ci.MoveWasteToFoundation()
 	default:
-		return i18n.Tf("canfield.invalidToZone", "val", to)
+		return invalidArg("canfield.invalidToZone", "val", to)
 	}
 }
 
@@ -115,13 +115,13 @@ func (c *CanfieldCuiController) handleMoveFromReserve(args []string) string {
 		}
 		col, err := strconv.Atoi(args[1])
 		if err != nil {
-			return i18n.Tf("invalidColumn", "val", args[1])
+			return invalidArg("invalidColumn", "val", args[1])
 		}
 		return c.ci.MoveReserveToTableau(col)
 	case "f":
 		return c.ci.MoveReserveToFoundation()
 	default:
-		return i18n.Tf("canfield.invalidToZone", "val", to)
+		return invalidArg("canfield.invalidToZone", "val", to)
 	}
 }
 
@@ -134,7 +134,7 @@ func (c *CanfieldCuiController) handleMoveFromTableau(args []string) string {
 	}
 	fromCol, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[0])
+		return invalidArg("invalidColumn", "val", args[0])
 	}
 	if args[1] == "f" {
 		return c.ci.MoveTableauToFoundation(fromCol)
@@ -147,11 +147,11 @@ func (c *CanfieldCuiController) handleMoveFromTableau(args []string) string {
 	}
 	cardIdx, err := strconv.Atoi(args[1])
 	if err != nil {
-		return i18n.Tf("invalidCardIndex", "val", args[1])
+		return invalidArg("invalidCardIndex", "val", args[1])
 	}
 	toCol, err := strconv.Atoi(args[3])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[3])
+		return invalidArg("invalidColumn", "val", args[3])
 	}
 	return c.ci.MoveTableauToTableau(fromCol, cardIdx, toCol)
 }
@@ -163,7 +163,7 @@ func (c *CanfieldCuiController) handleMoveShorthand(args []string) string {
 	}
 	toCol, err := strconv.Atoi(args[1])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[1])
+		return invalidArg("invalidColumn", "val", args[1])
 	}
 	return c.ci.MoveTableauToTableau(fromCol, -1, toCol)
 }

--- a/internal/adapter/controller/ColoradoCuiController.go
+++ b/internal/adapter/controller/ColoradoCuiController.go
@@ -65,7 +65,7 @@ func (c *ColoradoCuiController) handleMove(args []string) string {
 	case "s":
 		return c.handleMoveFromStock(args[1:])
 	default:
-		return i18n.Tf("colorado.invalidFromZone", "val", args[0])
+		return invalidArg("colorado.invalidFromZone", "val", args[0])
 	}
 }
 
@@ -77,10 +77,10 @@ func (c *ColoradoCuiController) handleMoveFromTableau(args []string) string {
 	}
 	fromPile, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("colorado.invalidPile", "val", args[0])
+		return invalidArg("colorado.invalidPile", "val", args[0])
 	}
 	if len(args) >= 2 && args[1] != "f" {
-		return i18n.Tf("colorado.invalidToZone", "val", args[1])
+		return invalidArg("colorado.invalidToZone", "val", args[1])
 	}
 	return c.ci.MoveTableauToFoundation(fromPile)
 }
@@ -98,11 +98,11 @@ func (c *ColoradoCuiController) handleMoveFromWaste(args []string) string {
 		}
 		pile, err := strconv.Atoi(args[1])
 		if err != nil {
-			return i18n.Tf("colorado.invalidPile", "val", args[1])
+			return invalidArg("colorado.invalidPile", "val", args[1])
 		}
 		return c.ci.MoveWasteToTableau(pile)
 	default:
-		return i18n.Tf("colorado.invalidToZone", "val", args[0])
+		return invalidArg("colorado.invalidToZone", "val", args[0])
 	}
 }
 
@@ -112,14 +112,14 @@ func (c *ColoradoCuiController) handleMoveFromStock(args []string) string {
 		return cuiutil.PromptRequest(i18n.T("colorado.promptToZone"), "m s {0}")
 	}
 	if args[0] != "t" {
-		return i18n.Tf("colorado.invalidToZone", "val", args[0])
+		return invalidArg("colorado.invalidToZone", "val", args[0])
 	}
 	if len(args) < 2 {
 		return cuiutil.PromptRequest(i18n.T("colorado.promptToPile"), "m s t {0}")
 	}
 	pile, err := strconv.Atoi(args[1])
 	if err != nil {
-		return i18n.Tf("colorado.invalidPile", "val", args[1])
+		return invalidArg("colorado.invalidPile", "val", args[1])
 	}
 	return c.ci.MoveStockToTableau(pile)
 }

--- a/internal/adapter/controller/ColoradoCuiController_test.go
+++ b/internal/adapter/controller/ColoradoCuiController_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	mockusecase "github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/usecase"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func newMockColoradoInteractor() *mockusecase.MockColoradoInteractor {
@@ -67,7 +66,7 @@ func TestColoradoCuiControllerMoves(t *testing.T) {
 		c := NewColoradoCuiController(ci)
 		// 1 文字の Contains は本文がほぼ何であっても通ってしまうので、
 		// 実際に出る文言そのものを見る。
-		assert.Equal(t, i18n.Tf("colorado.invalidToZone", "val", "t"), c.Exec("m t 0 t 5"))
+		assert.Equal(t, invalidArg("colorado.invalidToZone", "val", "t"), c.Exec("m t 0 t 5"))
 		ci.AssertNotCalled(t, "MoveTableauToFoundation", 0)
 	})
 
@@ -96,7 +95,7 @@ func TestColoradoCuiControllerMoves(t *testing.T) {
 	t.Run("rejects the stock to a foundation", func(t *testing.T) {
 		ci := newMockColoradoInteractor()
 		c := NewColoradoCuiController(ci)
-		assert.Equal(t, i18n.Tf("colorado.invalidToZone", "val", "f"), c.Exec("m s f"))
+		assert.Equal(t, invalidArg("colorado.invalidToZone", "val", "f"), c.Exec("m s f"))
 		ci.AssertNotCalled(t, "MoveStockToTableau", 0)
 	})
 }
@@ -114,13 +113,13 @@ func TestColoradoCuiControllerErrors(t *testing.T) {
 	// 期待値は完全一致で持つ。部分一致だと "t" のような 1 文字が
 	// 「たまたま含まれている」だけで通り、壊れても気付けない。
 	for _, tc := range []struct{ cmd, want string }{
-		{"m x f", i18n.Tf("colorado.invalidFromZone", "val", "x")},
-		{"m t abc f", i18n.Tf("colorado.invalidPile", "val", "abc")},
-		{"m t 0 z", i18n.Tf("colorado.invalidToZone", "val", "z")},
-		{"m t 0 t", i18n.Tf("colorado.invalidToZone", "val", "t")},
-		{"m w z", i18n.Tf("colorado.invalidToZone", "val", "z")},
-		{"m w t abc", i18n.Tf("colorado.invalidPile", "val", "abc")},
-		{"m s t abc", i18n.Tf("colorado.invalidPile", "val", "abc")},
+		{"m x f", invalidArg("colorado.invalidFromZone", "val", "x")},
+		{"m t abc f", invalidArg("colorado.invalidPile", "val", "abc")},
+		{"m t 0 z", invalidArg("colorado.invalidToZone", "val", "z")},
+		{"m t 0 t", invalidArg("colorado.invalidToZone", "val", "t")},
+		{"m w z", invalidArg("colorado.invalidToZone", "val", "z")},
+		{"m w t abc", invalidArg("colorado.invalidPile", "val", "abc")},
+		{"m s t abc", invalidArg("colorado.invalidPile", "val", "abc")},
 	} {
 		t.Run(tc.cmd, func(t *testing.T) {
 			ci := newMockColoradoInteractor()

--- a/internal/adapter/controller/CongressCuiController.go
+++ b/internal/adapter/controller/CongressCuiController.go
@@ -67,7 +67,7 @@ func (c *CongressCuiController) handleMove(args []string) string {
 	case "s":
 		return c.handleMoveFromStock(args[1:])
 	default:
-		return i18n.Tf("congress.invalidFromZone", "val", args[0])
+		return invalidArg("congress.invalidFromZone", "val", args[0])
 	}
 }
 
@@ -77,7 +77,7 @@ func (c *CongressCuiController) handleMoveFromTableau(args []string) string {
 	}
 	fromPile, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("congress.invalidPile", "val", args[0])
+		return invalidArg("congress.invalidPile", "val", args[0])
 	}
 	if len(args) < 2 {
 		return cuiutil.PromptRequest(i18n.T("congress.promptToZone"), fmt.Sprintf("m t %s {0}", args[0]))
@@ -91,11 +91,11 @@ func (c *CongressCuiController) handleMoveFromTableau(args []string) string {
 		}
 		toPile, err := strconv.Atoi(args[2])
 		if err != nil {
-			return i18n.Tf("congress.invalidPile", "val", args[2])
+			return invalidArg("congress.invalidPile", "val", args[2])
 		}
 		return c.ci.MoveTableauToTableau(fromPile, toPile)
 	default:
-		return i18n.Tf("congress.invalidToZone", "val", args[1])
+		return invalidArg("congress.invalidToZone", "val", args[1])
 	}
 }
 
@@ -112,11 +112,11 @@ func (c *CongressCuiController) handleMoveFromWaste(args []string) string {
 		}
 		pile, err := strconv.Atoi(args[1])
 		if err != nil {
-			return i18n.Tf("congress.invalidPile", "val", args[1])
+			return invalidArg("congress.invalidPile", "val", args[1])
 		}
 		return c.ci.MoveWasteToTableau(pile)
 	default:
-		return i18n.Tf("congress.invalidToZone", "val", args[0])
+		return invalidArg("congress.invalidToZone", "val", args[0])
 	}
 }
 
@@ -126,14 +126,14 @@ func (c *CongressCuiController) handleMoveFromStock(args []string) string {
 		return cuiutil.PromptRequest(i18n.T("congress.promptToZone"), "m s {0}")
 	}
 	if args[0] != "t" {
-		return i18n.Tf("congress.invalidToZone", "val", args[0])
+		return invalidArg("congress.invalidToZone", "val", args[0])
 	}
 	if len(args) < 2 {
 		return cuiutil.PromptRequest(i18n.T("congress.promptToPile"), "m s t {0}")
 	}
 	pile, err := strconv.Atoi(args[1])
 	if err != nil {
-		return i18n.Tf("congress.invalidPile", "val", args[1])
+		return invalidArg("congress.invalidPile", "val", args[1])
 	}
 	return c.ci.MoveStockToTableau(pile)
 }

--- a/internal/adapter/controller/CrazyQuiltCuiController.go
+++ b/internal/adapter/controller/CrazyQuiltCuiController.go
@@ -63,7 +63,7 @@ func (c *CrazyQuiltCuiController) handleMove(args []string) string {
 	case "w":
 		return c.handleMoveFromWaste(args[1:])
 	default:
-		return i18n.Tf("crazyquilt.invalidFromZone", "val", args[0])
+		return invalidArg("crazyquilt.invalidFromZone", "val", args[0])
 	}
 }
 
@@ -74,7 +74,7 @@ func (c *CrazyQuiltCuiController) handleMoveFromQuilt(args []string) string {
 	}
 	idx, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("crazyquilt.invalidCell", "val", args[0])
+		return invalidArg("crazyquilt.invalidCell", "val", args[0])
 	}
 	if len(args) < 2 {
 		return cuiutil.PromptRequest(i18n.T("crazyquilt.promptToZone"), fmt.Sprintf("m q %s {0}", args[0]))
@@ -85,14 +85,14 @@ func (c *CrazyQuiltCuiController) handleMoveFromQuilt(args []string) string {
 	case "w":
 		return c.ci.MoveQuiltToWaste(idx)
 	default:
-		return i18n.Tf("crazyquilt.invalidToZone", "val", args[1])
+		return invalidArg("crazyquilt.invalidToZone", "val", args[1])
 	}
 }
 
 // handleMoveFromWaste 捨て札は基礎札へしか送れないので行き先を尋ねない。
 func (c *CrazyQuiltCuiController) handleMoveFromWaste(args []string) string {
 	if len(args) >= 1 && args[0] != "f" {
-		return i18n.Tf("crazyquilt.invalidToZone", "val", args[0])
+		return invalidArg("crazyquilt.invalidToZone", "val", args[0])
 	}
 	return c.ci.MoveWasteToFoundation()
 }

--- a/internal/adapter/controller/CrazyQuiltCuiController_test.go
+++ b/internal/adapter/controller/CrazyQuiltCuiController_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	mockusecase "github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/usecase"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func newMockCrazyQuiltInteractor() *mockusecase.MockCrazyQuiltInteractor {
@@ -79,14 +78,14 @@ func TestCrazyQuiltCuiControllerMoves(t *testing.T) {
 	t.Run("rejects the quilt as a destination", func(t *testing.T) {
 		ci := newMockCrazyQuiltInteractor()
 		c := NewCrazyQuiltCuiController(ci)
-		assert.Equal(t, i18n.Tf("crazyquilt.invalidToZone", "val", "q"), c.Exec("m q 2 q"))
+		assert.Equal(t, invalidArg("crazyquilt.invalidToZone", "val", "q"), c.Exec("m q 2 q"))
 		ci.AssertExpectations(t)
 	})
 
 	t.Run("rejects an unknown source zone", func(t *testing.T) {
 		ci := newMockCrazyQuiltInteractor()
 		c := NewCrazyQuiltCuiController(ci)
-		assert.Equal(t, i18n.Tf("crazyquilt.invalidFromZone", "val", "s"), c.Exec("m s t 3"))
+		assert.Equal(t, invalidArg("crazyquilt.invalidFromZone", "val", "s"), c.Exec("m s t 3"))
 		ci.AssertExpectations(t)
 	})
 }

--- a/internal/adapter/controller/CrescentCuiController.go
+++ b/internal/adapter/controller/CrescentCuiController.go
@@ -73,14 +73,14 @@ func (c *CrescentCuiController) handleMove(args []string) string {
 		return c.handleMoveShorthand(args)
 	}
 	if args[0] != "t" {
-		return i18n.Tf("crescent.invalidFromZone", "val", args[0])
+		return invalidArg("crescent.invalidFromZone", "val", args[0])
 	}
 	if len(args) < 2 {
 		return cuiutil.PromptRequest(i18n.T("crescent.promptFromColumn"), "m t {0}")
 	}
 	fromCol, err := strconv.Atoi(args[1])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[1])
+		return invalidArg("invalidColumn", "val", args[1])
 	}
 	if len(args) < 3 {
 		return cuiutil.PromptRequest(i18n.T("crescent.promptToZone"), fmt.Sprintf("m t %s {0}", args[1]))
@@ -92,7 +92,7 @@ func (c *CrescentCuiController) handleMove(args []string) string {
 		}
 		toCol, err := strconv.Atoi(args[3])
 		if err != nil {
-			return i18n.Tf("invalidColumn", "val", args[3])
+			return invalidArg("invalidColumn", "val", args[3])
 		}
 		return c.ci.MoveTableauToTableau(fromCol, toCol)
 	case "f":
@@ -101,7 +101,7 @@ func (c *CrescentCuiController) handleMove(args []string) string {
 		}
 		fIdx, err := strconv.Atoi(args[3])
 		if err != nil {
-			return i18n.Tf("crescent.invalidFoundationId", "val", args[3])
+			return invalidArg("crescent.invalidFoundationId", "val", args[3])
 		}
 		return c.ci.MoveTableauToFoundation(fromCol, fIdx)
 	default:
@@ -116,7 +116,7 @@ func (c *CrescentCuiController) handleMoveShorthand(args []string) string {
 	}
 	toCol, err := strconv.Atoi(args[1])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[1])
+		return invalidArg("invalidColumn", "val", args[1])
 	}
 	return c.ci.MoveTableauToTableau(fromCol, toCol)
 }

--- a/internal/adapter/controller/CruelCuiController.go
+++ b/internal/adapter/controller/CruelCuiController.go
@@ -56,7 +56,7 @@ func (c *CruelCuiController) handleMove(args []string) string {
 
 	fromCol, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[0])
+		return invalidArg("invalidColumn", "val", args[0])
 	}
 
 	if len(args) < 2 {

--- a/internal/adapter/controller/DeuceToSevenCuiController.go
+++ b/internal/adapter/controller/DeuceToSevenCuiController.go
@@ -89,7 +89,7 @@ func (dcc *DeuceToSevenCuiController) Exec(command string) string {
 				}
 				v, err := strconv.Atoi(args[0])
 				if err != nil || v < 0 || v > 1 {
-					return i18n.Tf("invalidMetaAI", "val", args[0]), true
+					return invalidArg("invalidMetaAI", "val", args[0]), true
 				}
 				cfg := dcc.di.GetConfig()
 				cfg.CpuMetaAI = v == 1

--- a/internal/adapter/controller/DeuceToSevenCuiController_test.go
+++ b/internal/adapter/controller/DeuceToSevenCuiController_test.go
@@ -165,7 +165,7 @@ func TestDeuceToSevenCuiController_MetaAI_Invalid(t *testing.T) {
 	mi := newDeuceToSevenMockInteractor()
 	c := NewDeuceToSevenCuiController(mi)
 	result := c.Exec("mai abc")
-	assert.Equal(t, i18n.Tf("invalidMetaAI", "val", "abc"), result)
+	assert.Equal(t, invalidArg("invalidMetaAI", "val", "abc"), result)
 }
 
 func TestDeuceToSevenCuiController_Log(t *testing.T) {

--- a/internal/adapter/controller/DiplomatCuiController.go
+++ b/internal/adapter/controller/DiplomatCuiController.go
@@ -64,7 +64,7 @@ func (c *DiplomatCuiController) handleMove(args []string) string {
 	case "w":
 		return c.handleMoveFromWaste(args[1:])
 	default:
-		return i18n.Tf("diplomat.invalidFromZone", "val", args[0])
+		return invalidArg("diplomat.invalidFromZone", "val", args[0])
 	}
 }
 
@@ -74,7 +74,7 @@ func (c *DiplomatCuiController) handleMoveFromTableau(args []string) string {
 	}
 	fromPile, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("diplomat.invalidPile", "val", args[0])
+		return invalidArg("diplomat.invalidPile", "val", args[0])
 	}
 	if len(args) < 2 {
 		return cuiutil.PromptRequest(i18n.T("diplomat.promptToZone"), fmt.Sprintf("m t %s {0}", args[0]))
@@ -88,11 +88,11 @@ func (c *DiplomatCuiController) handleMoveFromTableau(args []string) string {
 		}
 		toPile, err := strconv.Atoi(args[2])
 		if err != nil {
-			return i18n.Tf("diplomat.invalidPile", "val", args[2])
+			return invalidArg("diplomat.invalidPile", "val", args[2])
 		}
 		return c.ci.MoveTableauToTableau(fromPile, toPile)
 	default:
-		return i18n.Tf("diplomat.invalidToZone", "val", args[1])
+		return invalidArg("diplomat.invalidToZone", "val", args[1])
 	}
 }
 
@@ -109,10 +109,10 @@ func (c *DiplomatCuiController) handleMoveFromWaste(args []string) string {
 		}
 		pile, err := strconv.Atoi(args[1])
 		if err != nil {
-			return i18n.Tf("diplomat.invalidPile", "val", args[1])
+			return invalidArg("diplomat.invalidPile", "val", args[1])
 		}
 		return c.ci.MoveWasteToTableau(pile)
 	default:
-		return i18n.Tf("diplomat.invalidToZone", "val", args[0])
+		return invalidArg("diplomat.invalidToZone", "val", args[0])
 	}
 }

--- a/internal/adapter/controller/DiplomatCuiController_test.go
+++ b/internal/adapter/controller/DiplomatCuiController_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	mockusecase "github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/usecase"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func newMockDiplomatInteractor() *mockusecase.MockDiplomatInteractor {
@@ -78,7 +77,7 @@ func TestDiplomatCuiControllerMoves(t *testing.T) {
 	t.Run("rejects the stock as a source", func(t *testing.T) {
 		ci := newMockDiplomatInteractor()
 		c := NewDiplomatCuiController(ci)
-		assert.Equal(t, i18n.Tf("diplomat.invalidFromZone", "val", "s"), c.Exec("m s t 3"))
+		assert.Equal(t, invalidArg("diplomat.invalidFromZone", "val", "s"), c.Exec("m s t 3"))
 		ci.AssertExpectations(t)
 	})
 }

--- a/internal/adapter/controller/DuchessCuiController.go
+++ b/internal/adapter/controller/DuchessCuiController.go
@@ -57,7 +57,7 @@ func (c *DuchessCuiController) handleBase(args []string) string {
 	}
 	fan, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("duchess.invalidFanIdx", "val", args[0])
+		return invalidArg("duchess.invalidFanIdx", "val", args[0])
 	}
 	return c.di.ChooseBaseRank(fan)
 }
@@ -82,7 +82,7 @@ func (c *DuchessCuiController) handleMove(args []string) string {
 	case "t":
 		return c.handleMoveFromTableau(args[1:])
 	default:
-		return i18n.Tf("duchess.invalidFromZone", "val", args[0])
+		return invalidArg("duchess.invalidFromZone", "val", args[0])
 	}
 }
 
@@ -92,7 +92,7 @@ func (c *DuchessCuiController) handleMoveFromReserve(args []string) string {
 	}
 	fan, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("duchess.invalidFanIdx", "val", args[0])
+		return invalidArg("duchess.invalidFanIdx", "val", args[0])
 	}
 	if len(args) < 2 {
 		return cuiutil.PromptRequest(i18n.T("duchess.promptToZone"), fmt.Sprintf("m r %s {0}", args[0]))
@@ -106,11 +106,11 @@ func (c *DuchessCuiController) handleMoveFromReserve(args []string) string {
 		}
 		col, err := strconv.Atoi(args[2])
 		if err != nil {
-			return i18n.Tf("invalidColumn", "val", args[2])
+			return invalidArg("invalidColumn", "val", args[2])
 		}
 		return c.di.MoveReserveToTableau(fan, col)
 	default:
-		return i18n.Tf("duchess.invalidToZone", "val", args[1])
+		return invalidArg("duchess.invalidToZone", "val", args[1])
 	}
 }
 
@@ -127,11 +127,11 @@ func (c *DuchessCuiController) handleMoveFromWaste(args []string) string {
 		}
 		col, err := strconv.Atoi(args[1])
 		if err != nil {
-			return i18n.Tf("invalidColumn", "val", args[1])
+			return invalidArg("invalidColumn", "val", args[1])
 		}
 		return c.di.MoveWasteToTableau(col)
 	default:
-		return i18n.Tf("duchess.invalidToZone", "val", args[0])
+		return invalidArg("duchess.invalidToZone", "val", args[0])
 	}
 }
 
@@ -141,7 +141,7 @@ func (c *DuchessCuiController) handleMoveFromTableau(args []string) string {
 	}
 	fromCol, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[0])
+		return invalidArg("invalidColumn", "val", args[0])
 	}
 	if len(args) < 2 {
 		return cuiutil.PromptRequest(i18n.T("duchess.promptToZone"), fmt.Sprintf("m t %s {0}", args[0]))
@@ -155,19 +155,19 @@ func (c *DuchessCuiController) handleMoveFromTableau(args []string) string {
 		}
 		toCol, err := strconv.Atoi(args[2])
 		if err != nil {
-			return i18n.Tf("invalidColumn", "val", args[2])
+			return invalidArg("invalidColumn", "val", args[2])
 		}
 		// 連番グループの先頭。省略時は -1 = 最上段 1 枚。
 		cardIndex := -1
 		if len(args) >= 4 {
 			idx, err := strconv.Atoi(args[3])
 			if err != nil {
-				return i18n.Tf("duchess.invalidCardIndex", "val", args[3])
+				return invalidArg("duchess.invalidCardIndex", "val", args[3])
 			}
 			cardIndex = idx
 		}
 		return c.di.MoveTableauToTableau(fromCol, cardIndex, toCol)
 	default:
-		return i18n.Tf("duchess.invalidToZone", "val", args[1])
+		return invalidArg("duchess.invalidToZone", "val", args[1])
 	}
 }

--- a/internal/adapter/controller/EasthavenCuiController.go
+++ b/internal/adapter/controller/EasthavenCuiController.go
@@ -61,7 +61,7 @@ func (c *EasthavenCuiController) handleMove(args []string) string {
 
 	from := args[0]
 	if from != "t" {
-		return i18n.Tf("easthaven.invalidFromZone", "val", from)
+		return invalidArg("easthaven.invalidFromZone", "val", from)
 	}
 
 	if len(args) < 2 {
@@ -80,7 +80,7 @@ func (c *EasthavenCuiController) handleMoveFromTableau(args []string) string {
 	}
 	fromCol, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[0])
+		return invalidArg("invalidColumn", "val", args[0])
 	}
 
 	if args[1] == "f" {
@@ -97,12 +97,12 @@ func (c *EasthavenCuiController) handleMoveFromTableau(args []string) string {
 
 	cardIdx, err := strconv.Atoi(args[1])
 	if err != nil {
-		return i18n.Tf("invalidCardIndex", "val", args[1])
+		return invalidArg("invalidCardIndex", "val", args[1])
 	}
 
 	toCol, err := strconv.Atoi(args[3])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[3])
+		return invalidArg("invalidColumn", "val", args[3])
 	}
 
 	return c.ei.MoveTableauToTableau(fromCol, cardIdx, toCol)
@@ -115,7 +115,7 @@ func (c *EasthavenCuiController) handleMoveShorthand(args []string) string {
 	}
 	toCol, err := strconv.Atoi(args[1])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[1])
+		return invalidArg("invalidColumn", "val", args[1])
 	}
 	return c.ei.MoveTableauToTableau(fromCol, -1, toCol)
 }

--- a/internal/adapter/controller/EightOffCuiController.go
+++ b/internal/adapter/controller/EightOffCuiController.go
@@ -58,7 +58,7 @@ func (c *EightOffCuiController) handleMove(args []string) string {
 	}
 	from := args[0]
 	if from != "t" && from != "c" {
-		return i18n.Tf("eightoff.invalidFromZone", "val", from)
+		return invalidArg("eightoff.invalidFromZone", "val", from)
 	}
 	if len(args) < 2 {
 		switch from {
@@ -85,7 +85,7 @@ func (c *EightOffCuiController) handleMoveFromTableau(args []string) string {
 	}
 	fromCol, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[0])
+		return invalidArg("invalidColumn", "val", args[0])
 	}
 
 	switch args[1] {
@@ -97,7 +97,7 @@ func (c *EightOffCuiController) handleMoveFromTableau(args []string) string {
 		}
 		toCol, err := strconv.Atoi(args[2])
 		if err != nil {
-			return i18n.Tf("invalidColumn", "val", args[2])
+			return invalidArg("invalidColumn", "val", args[2])
 		}
 		return c.ei.MoveTableauToTableau(fromCol, -1, toCol)
 	case "c":
@@ -106,7 +106,7 @@ func (c *EightOffCuiController) handleMoveFromTableau(args []string) string {
 		}
 		cell, err := strconv.Atoi(args[2])
 		if err != nil {
-			return i18n.Tf("invalidCell", "val", args[2])
+			return invalidArg("invalidCell", "val", args[2])
 		}
 		return c.ei.MoveTableauToFreeCell(fromCol, cell)
 	default:
@@ -122,7 +122,7 @@ func (c *EightOffCuiController) handleMoveFromTableau(args []string) string {
 		}
 		toCol, err := strconv.Atoi(args[3])
 		if err != nil {
-			return i18n.Tf("invalidColumn", "val", args[3])
+			return invalidArg("invalidColumn", "val", args[3])
 		}
 		return c.ei.MoveTableauToTableau(fromCol, cardIdx, toCol)
 	}
@@ -137,7 +137,7 @@ func (c *EightOffCuiController) handleMoveFromFreeCell(args []string) string {
 	}
 	cell, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidCell", "val", args[0])
+		return invalidArg("invalidCell", "val", args[0])
 	}
 
 	switch args[1] {
@@ -147,13 +147,13 @@ func (c *EightOffCuiController) handleMoveFromFreeCell(args []string) string {
 		}
 		col, err := strconv.Atoi(args[2])
 		if err != nil {
-			return i18n.Tf("invalidColumn", "val", args[2])
+			return invalidArg("invalidColumn", "val", args[2])
 		}
 		return c.ei.MoveFreeCellToTableau(cell, col)
 	case "f":
 		return c.ei.MoveFreeCellToFoundation(cell)
 	default:
-		return i18n.Tf("eightoff.invalidToZone", "val", args[1])
+		return invalidArg("eightoff.invalidToZone", "val", args[1])
 	}
 }
 
@@ -164,7 +164,7 @@ func (c *EightOffCuiController) handleFoundationShorthand(args []string) string 
 	}
 	col, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[0])
+		return invalidArg("invalidColumn", "val", args[0])
 	}
 	return c.ei.MoveTableauToFoundation(col)
 }
@@ -176,7 +176,7 @@ func (c *EightOffCuiController) handleMoveShorthand(args []string) string {
 	}
 	toCol, err := strconv.Atoi(args[1])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[1])
+		return invalidArg("invalidColumn", "val", args[1])
 	}
 	return c.ei.MoveTableauToTableau(fromCol, -1, toCol)
 }

--- a/internal/adapter/controller/FiveCardStudCuiController.go
+++ b/internal/adapter/controller/FiveCardStudCuiController.go
@@ -91,7 +91,7 @@ func (c *FiveCardStudCuiController) Exec(command string) string {
 				}
 				bl, err := strconv.Atoi(args[0])
 				if err != nil {
-					return i18n.Tf("holdem.invalidBettingLimit", "val", args[0]), true
+					return invalidArg("holdem.invalidBettingLimit", "val", args[0]), true
 				}
 				cfg := c.si.GetConfig()
 				cfg.BettingLimit = domain.BettingLimitType(bl)
@@ -102,7 +102,7 @@ func (c *FiveCardStudCuiController) Exec(command string) string {
 				}
 				v, err := strconv.Atoi(args[0])
 				if err != nil || v < 0 || v > 1 {
-					return i18n.Tf("holdem.invalidTournamentMode", "val", args[0]), true
+					return invalidArg("holdem.invalidTournamentMode", "val", args[0]), true
 				}
 				cfg := c.si.GetConfig()
 				cfg.TournamentMode = v == 1
@@ -113,7 +113,7 @@ func (c *FiveCardStudCuiController) Exec(command string) string {
 				}
 				v, err := strconv.Atoi(args[0])
 				if err != nil {
-					return i18n.Tf("fivecardstud.invalidAnte", "val", args[0]), true
+					return invalidArg("fivecardstud.invalidAnte", "val", args[0]), true
 				}
 				cfg := c.si.GetConfig()
 				cfg.Ante = v
@@ -124,7 +124,7 @@ func (c *FiveCardStudCuiController) Exec(command string) string {
 				}
 				v, err := strconv.Atoi(args[0])
 				if err != nil {
-					return i18n.Tf("fivecardstud.invalidBringIn", "val", args[0]), true
+					return invalidArg("fivecardstud.invalidBringIn", "val", args[0]), true
 				}
 				cfg := c.si.GetConfig()
 				cfg.BringIn = v
@@ -135,7 +135,7 @@ func (c *FiveCardStudCuiController) Exec(command string) string {
 				}
 				v, err := strconv.Atoi(args[0])
 				if err != nil {
-					return i18n.Tf("fivecardstud.invalidSmallBet", "val", args[0]), true
+					return invalidArg("fivecardstud.invalidSmallBet", "val", args[0]), true
 				}
 				cfg := c.si.GetConfig()
 				cfg.SmallBet = v
@@ -146,7 +146,7 @@ func (c *FiveCardStudCuiController) Exec(command string) string {
 				}
 				v, err := strconv.Atoi(args[0])
 				if err != nil {
-					return i18n.Tf("fivecardstud.invalidBigBet", "val", args[0]), true
+					return invalidArg("fivecardstud.invalidBigBet", "val", args[0]), true
 				}
 				cfg := c.si.GetConfig()
 				cfg.BigBet = v
@@ -157,7 +157,7 @@ func (c *FiveCardStudCuiController) Exec(command string) string {
 				}
 				v, err := strconv.Atoi(args[0])
 				if err != nil {
-					return i18n.Tf("holdem.invalidLevelHand", "val", args[0]), true
+					return invalidArg("holdem.invalidLevelHand", "val", args[0]), true
 				}
 				cfg := c.si.GetConfig()
 				cfg.AnteLevelHands = v
@@ -168,7 +168,7 @@ func (c *FiveCardStudCuiController) Exec(command string) string {
 				}
 				v, err := strconv.Atoi(args[0])
 				if err != nil {
-					return i18n.Tf("holdem.invalidTableSize", "val", args[0]), true
+					return invalidArg("holdem.invalidTableSize", "val", args[0]), true
 				}
 				cfg := c.si.GetConfig()
 				cfg.TableSize = v
@@ -179,7 +179,7 @@ func (c *FiveCardStudCuiController) Exec(command string) string {
 				}
 				v, err := strconv.Atoi(args[0])
 				if err != nil || v < 0 || v > 1 {
-					return i18n.Tf("invalidMetaAI", "val", args[0]), true
+					return invalidArg("invalidMetaAI", "val", args[0]), true
 				}
 				cfg := c.si.GetConfig()
 				cfg.CpuMetaAI = v == 1

--- a/internal/adapter/controller/FiveCardStudCuiController_test.go
+++ b/internal/adapter/controller/FiveCardStudCuiController_test.go
@@ -483,7 +483,7 @@ func TestFiveCardStudCuiController_MetaAI_MissingArg(t *testing.T) {
 func TestFiveCardStudCuiController_MetaAI_InvalidArg(t *testing.T) {
 	mi := new(usecase.MockFiveCardStudInteractor)
 	c := NewFiveCardStudCuiController(mi)
-	assert.Equal(t, "無効な値です: abc。0 または 1 を入力してください。", c.Exec("mai abc"))
+	assert.Equal(t, invalidArg("invalidMetaAI", "val", "abc"), c.Exec("mai abc"))
 }
 
 // --- log ---

--- a/internal/adapter/controller/FlowerGardenCuiController.go
+++ b/internal/adapter/controller/FlowerGardenCuiController.go
@@ -51,7 +51,7 @@ func (c *FlowerGardenCuiController) handleMove(args []string) string {
 	if strings.HasPrefix(from, "r") {
 		reserveIdx, err := strconv.Atoi(strings.TrimPrefix(from, "r"))
 		if err != nil {
-			return i18n.Tf("invalidColumn", "val", from)
+			return invalidArg("invalidColumn", "val", from)
 		}
 		if len(args) < 2 {
 			return cuiutil.PromptRequest(i18n.T("flowergarden.promptToZone"), fmt.Sprintf("m %s {0}", from))
@@ -61,14 +61,14 @@ func (c *FlowerGardenCuiController) handleMove(args []string) string {
 		}
 		toCol, err := strconv.Atoi(args[1])
 		if err != nil {
-			return i18n.Tf("invalidColumn", "val", args[1])
+			return invalidArg("invalidColumn", "val", args[1])
 		}
 		return c.bi.MoveReserveToTableau(reserveIdx, toCol)
 	}
 
 	fromCol, err := strconv.Atoi(from)
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", from)
+		return invalidArg("invalidColumn", "val", from)
 	}
 	if len(args) < 2 {
 		return cuiutil.PromptRequest(i18n.T("flowergarden.promptToZone"), fmt.Sprintf("m %s {0}", from))
@@ -78,7 +78,7 @@ func (c *FlowerGardenCuiController) handleMove(args []string) string {
 	}
 	toCol, err := strconv.Atoi(args[1])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[1])
+		return invalidArg("invalidColumn", "val", args[1])
 	}
 	return c.bi.MoveTableauToTableau(fromCol, -1, toCol)
 }

--- a/internal/adapter/controller/FortyAndEightCuiController.go
+++ b/internal/adapter/controller/FortyAndEightCuiController.go
@@ -68,7 +68,7 @@ func (c *FortyAndEightCuiController) handleMove(args []string) string {
 	}
 	from := args[0]
 	if from != "w" && from != "t" {
-		return i18n.Tf("fortyandeight.invalidFromZone", "val", from)
+		return invalidArg("fortyandeight.invalidFromZone", "val", from)
 	}
 	if len(args) < 2 {
 		switch from {
@@ -95,13 +95,13 @@ func (c *FortyAndEightCuiController) handleMoveFromWaste(args []string) string {
 		}
 		col, err := strconv.Atoi(args[1])
 		if err != nil {
-			return i18n.Tf("invalidColumn", "val", args[1])
+			return invalidArg("invalidColumn", "val", args[1])
 		}
 		return c.fi.MoveWasteToTableau(col)
 	case "f":
 		return c.fi.MoveWasteToFoundation()
 	default:
-		return i18n.Tf("fortyandeight.invalidToZone", "val", to)
+		return invalidArg("fortyandeight.invalidToZone", "val", to)
 	}
 }
 
@@ -114,7 +114,7 @@ func (c *FortyAndEightCuiController) handleMoveFromTableau(args []string) string
 	}
 	fromCol, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[0])
+		return invalidArg("invalidColumn", "val", args[0])
 	}
 
 	if args[1] == "f" {
@@ -131,12 +131,12 @@ func (c *FortyAndEightCuiController) handleMoveFromTableau(args []string) string
 
 	cardIdx, err := strconv.Atoi(args[1])
 	if err != nil {
-		return i18n.Tf("invalidCardIndex", "val", args[1])
+		return invalidArg("invalidCardIndex", "val", args[1])
 	}
 
 	toCol, err := strconv.Atoi(args[3])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[3])
+		return invalidArg("invalidColumn", "val", args[3])
 	}
 
 	return c.fi.MoveTableauToTableau(fromCol, cardIdx, toCol)
@@ -149,7 +149,7 @@ func (c *FortyAndEightCuiController) handleMoveShorthand(args []string) string {
 	}
 	toCol, err := strconv.Atoi(args[1])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[1])
+		return invalidArg("invalidColumn", "val", args[1])
 	}
 	return c.fi.MoveTableauToTableau(fromCol, -1, toCol)
 }

--- a/internal/adapter/controller/FortyThievesCuiController.go
+++ b/internal/adapter/controller/FortyThievesCuiController.go
@@ -67,7 +67,7 @@ func (c *FortyThievesCuiController) handleMove(args []string) string {
 	}
 	from := args[0]
 	if from != "w" && from != "t" {
-		return i18n.Tf("fortythieves.invalidFromZone", "val", from)
+		return invalidArg("fortythieves.invalidFromZone", "val", from)
 	}
 	if len(args) < 2 {
 		switch from {
@@ -94,13 +94,13 @@ func (c *FortyThievesCuiController) handleMoveFromWaste(args []string) string {
 		}
 		col, err := strconv.Atoi(args[1])
 		if err != nil {
-			return i18n.Tf("invalidColumn", "val", args[1])
+			return invalidArg("invalidColumn", "val", args[1])
 		}
 		return c.fi.MoveWasteToTableau(col)
 	case "f":
 		return c.fi.MoveWasteToFoundation()
 	default:
-		return i18n.Tf("fortythieves.invalidToZone", "val", to)
+		return invalidArg("fortythieves.invalidToZone", "val", to)
 	}
 }
 
@@ -113,7 +113,7 @@ func (c *FortyThievesCuiController) handleMoveFromTableau(args []string) string 
 	}
 	fromCol, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[0])
+		return invalidArg("invalidColumn", "val", args[0])
 	}
 
 	if args[1] == "f" {
@@ -130,12 +130,12 @@ func (c *FortyThievesCuiController) handleMoveFromTableau(args []string) string 
 
 	cardIdx, err := strconv.Atoi(args[1])
 	if err != nil {
-		return i18n.Tf("invalidCardIndex", "val", args[1])
+		return invalidArg("invalidCardIndex", "val", args[1])
 	}
 
 	toCol, err := strconv.Atoi(args[3])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[3])
+		return invalidArg("invalidColumn", "val", args[3])
 	}
 
 	return c.fi.MoveTableauToTableau(fromCol, cardIdx, toCol)
@@ -148,7 +148,7 @@ func (c *FortyThievesCuiController) handleMoveShorthand(args []string) string {
 	}
 	toCol, err := strconv.Atoi(args[1])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[1])
+		return invalidArg("invalidColumn", "val", args[1])
 	}
 	return c.fi.MoveTableauToTableau(fromCol, -1, toCol)
 }

--- a/internal/adapter/controller/FourSeasonsCuiController.go
+++ b/internal/adapter/controller/FourSeasonsCuiController.go
@@ -73,7 +73,7 @@ func (c *FourSeasonsCuiController) handleMove(args []string) string {
 	case "t":
 		return c.handleFromTableau(args)
 	default:
-		return i18n.Tf("fourseasons.invalidFromZone", "val", args[0])
+		return invalidArg("fourseasons.invalidFromZone", "val", args[0])
 	}
 }
 
@@ -83,14 +83,14 @@ func (c *FourSeasonsCuiController) handleFromWaste(args []string) string {
 	}
 	dest := args[1]
 	if dest != "f" && dest != "t" {
-		return i18n.Tf("fourseasons.invalidToZone", "val", dest)
+		return invalidArg("fourseasons.invalidToZone", "val", dest)
 	}
 	if len(args) < 3 {
 		return cuiutil.PromptRequest(i18n.T("fourseasons.promptIndex"), fmt.Sprintf("m w %s {0}", dest))
 	}
 	idx, err := strconv.Atoi(args[2])
 	if err != nil {
-		return i18n.Tf("invalidIndex", "val", args[2])
+		return invalidArg("invalidIndex", "val", args[2])
 	}
 	if dest == "f" {
 		return c.ci.MoveWasteToFoundation(idx)
@@ -104,21 +104,21 @@ func (c *FourSeasonsCuiController) handleFromTableau(args []string) string {
 	}
 	fromCol, err := strconv.Atoi(args[1])
 	if err != nil {
-		return i18n.Tf("invalidIndex", "val", args[1])
+		return invalidArg("invalidIndex", "val", args[1])
 	}
 	if len(args) < 3 {
 		return cuiutil.PromptRequest(i18n.T("fourseasons.promptToZone"), fmt.Sprintf("m t %d {0}", fromCol))
 	}
 	dest := args[2]
 	if dest != "f" && dest != "t" {
-		return i18n.Tf("fourseasons.invalidToZone", "val", dest)
+		return invalidArg("fourseasons.invalidToZone", "val", dest)
 	}
 	if len(args) < 4 {
 		return cuiutil.PromptRequest(i18n.T("fourseasons.promptIndex"), fmt.Sprintf("m t %d %s {0}", fromCol, dest))
 	}
 	toIdx, err := strconv.Atoi(args[3])
 	if err != nil {
-		return i18n.Tf("invalidIndex", "val", args[3])
+		return invalidArg("invalidIndex", "val", args[3])
 	}
 	if dest == "f" {
 		return c.ci.MoveTableauToFoundation(fromCol, toIdx)

--- a/internal/adapter/controller/FreeCellCuiController.go
+++ b/internal/adapter/controller/FreeCellCuiController.go
@@ -59,7 +59,7 @@ func (c *FreeCellCuiController) handleMove(args []string) string {
 	}
 	from := args[0]
 	if from != "t" && from != "c" {
-		return i18n.Tf("freecell.invalidFromZone", "val", from)
+		return invalidArg("freecell.invalidFromZone", "val", from)
 	}
 	if len(args) < 2 {
 		switch from {
@@ -86,7 +86,7 @@ func (c *FreeCellCuiController) handleMoveFromTableau(args []string) string {
 	}
 	fromCol, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[0])
+		return invalidArg("invalidColumn", "val", args[0])
 	}
 
 	switch args[1] {
@@ -99,7 +99,7 @@ func (c *FreeCellCuiController) handleMoveFromTableau(args []string) string {
 		}
 		toCol, err := strconv.Atoi(args[2])
 		if err != nil {
-			return i18n.Tf("invalidColumn", "val", args[2])
+			return invalidArg("invalidColumn", "val", args[2])
 		}
 		// Use cardIndex = -1 to signal top card; but the interactor expects actual index
 		// For CUI simplicity, top card: cardIndex is len-1, but we don't know from here
@@ -113,7 +113,7 @@ func (c *FreeCellCuiController) handleMoveFromTableau(args []string) string {
 		}
 		cell, err := strconv.Atoi(args[2])
 		if err != nil {
-			return i18n.Tf("invalidCell", "val", args[2])
+			return invalidArg("invalidCell", "val", args[2])
 		}
 		return c.fi.MoveTableauToFreeCell(fromCol, cell)
 	default:
@@ -131,7 +131,7 @@ func (c *FreeCellCuiController) handleMoveFromTableau(args []string) string {
 		}
 		toCol, err := strconv.Atoi(args[3])
 		if err != nil {
-			return i18n.Tf("invalidColumn", "val", args[3])
+			return invalidArg("invalidColumn", "val", args[3])
 		}
 		return c.fi.MoveTableauToTableau(fromCol, cardIdx, toCol)
 	}
@@ -146,7 +146,7 @@ func (c *FreeCellCuiController) handleMoveFromFreeCell(args []string) string {
 	}
 	cell, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidCell", "val", args[0])
+		return invalidArg("invalidCell", "val", args[0])
 	}
 
 	switch args[1] {
@@ -156,13 +156,13 @@ func (c *FreeCellCuiController) handleMoveFromFreeCell(args []string) string {
 		}
 		col, err := strconv.Atoi(args[2])
 		if err != nil {
-			return i18n.Tf("invalidColumn", "val", args[2])
+			return invalidArg("invalidColumn", "val", args[2])
 		}
 		return c.fi.MoveFreeCellToTableau(cell, col)
 	case "f":
 		return c.fi.MoveFreeCellToFoundation(cell)
 	default:
-		return i18n.Tf("freecell.invalidToZone", "val", args[1])
+		return invalidArg("freecell.invalidToZone", "val", args[1])
 	}
 }
 
@@ -173,7 +173,7 @@ func (c *FreeCellCuiController) handleFoundationShorthand(args []string) string 
 	}
 	col, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[0])
+		return invalidArg("invalidColumn", "val", args[0])
 	}
 	return c.fi.MoveTableauToFoundation(col)
 }
@@ -185,7 +185,7 @@ func (c *FreeCellCuiController) handleMoveShorthand(args []string) string {
 	}
 	toCol, err := strconv.Atoi(args[1])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[1])
+		return invalidArg("invalidColumn", "val", args[1])
 	}
 	return c.fi.MoveTableauToTableau(fromCol, -1, toCol)
 }

--- a/internal/adapter/controller/GrandfathersClockCuiController.go
+++ b/internal/adapter/controller/GrandfathersClockCuiController.go
@@ -59,7 +59,7 @@ func (c *GrandfathersClockCuiController) handleMove(args []string) string {
 	}
 	fromCol, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[0])
+		return invalidArg("invalidColumn", "val", args[0])
 	}
 	if len(args) < 2 {
 		return cuiutil.PromptRequest(i18n.T("grandfathersclock.promptToZone"), fmt.Sprintf("m %s {0}", args[0]))
@@ -71,13 +71,13 @@ func (c *GrandfathersClockCuiController) handleMove(args []string) string {
 		}
 		fIdx, err := strconv.Atoi(args[2])
 		if err != nil {
-			return i18n.Tf("grandfathersclock.invalidFaceIdx", "val", args[2])
+			return invalidArg("grandfathersclock.invalidFaceIdx", "val", args[2])
 		}
 		return c.gi.MoveTableauToFoundation(fromCol, fIdx)
 	}
 	toCol, err := strconv.Atoi(args[1])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[1])
+		return invalidArg("invalidColumn", "val", args[1])
 	}
 	return c.gi.MoveTableauToTableau(fromCol, toCol)
 }

--- a/internal/adapter/controller/HoldemCuiController.go
+++ b/internal/adapter/controller/HoldemCuiController.go
@@ -94,7 +94,7 @@ func (c *HoldemCuiController) Exec(command string) string {
 				}
 				bl, err := strconv.Atoi(args[0])
 				if err != nil {
-					return i18n.Tf("holdem.invalidBettingLimit", "val", args[0]), true
+					return invalidArg("holdem.invalidBettingLimit", "val", args[0]), true
 				}
 				cfg := c.hi.GetConfig()
 				cfg.BettingLimit = domain.BettingLimitType(bl)
@@ -105,7 +105,7 @@ func (c *HoldemCuiController) Exec(command string) string {
 				}
 				v, err := strconv.Atoi(args[0])
 				if err != nil || v < 0 || v > 1 {
-					return i18n.Tf("holdem.invalidTournamentMode", "val", args[0]), true
+					return invalidArg("holdem.invalidTournamentMode", "val", args[0]), true
 				}
 				cfg := c.hi.GetConfig()
 				cfg.TournamentMode = v == 1
@@ -116,7 +116,7 @@ func (c *HoldemCuiController) Exec(command string) string {
 				}
 				v, err := strconv.Atoi(args[0])
 				if err != nil {
-					return i18n.Tf("holdem.invalidSmallBlind", "val", args[0]), true
+					return invalidArg("holdem.invalidSmallBlind", "val", args[0]), true
 				}
 				cfg := c.hi.GetConfig()
 				cfg.SmallBlind = v
@@ -127,7 +127,7 @@ func (c *HoldemCuiController) Exec(command string) string {
 				}
 				v, err := strconv.Atoi(args[0])
 				if err != nil {
-					return i18n.Tf("holdem.invalidBigBlind", "val", args[0]), true
+					return invalidArg("holdem.invalidBigBlind", "val", args[0]), true
 				}
 				cfg := c.hi.GetConfig()
 				cfg.BigBlind = v
@@ -138,7 +138,7 @@ func (c *HoldemCuiController) Exec(command string) string {
 				}
 				v, err := strconv.Atoi(args[0])
 				if err != nil {
-					return i18n.Tf("holdem.invalidLevelHand", "val", args[0]), true
+					return invalidArg("holdem.invalidLevelHand", "val", args[0]), true
 				}
 				cfg := c.hi.GetConfig()
 				cfg.BlindLevelHands = v
@@ -149,7 +149,7 @@ func (c *HoldemCuiController) Exec(command string) string {
 				}
 				v, err := strconv.Atoi(args[0])
 				if err != nil {
-					return i18n.Tf("holdem.invalidTableSize", "val", args[0]), true
+					return invalidArg("holdem.invalidTableSize", "val", args[0]), true
 				}
 				cfg := c.hi.GetConfig()
 				cfg.TableSize = v
@@ -160,7 +160,7 @@ func (c *HoldemCuiController) Exec(command string) string {
 				}
 				v, err := strconv.Atoi(args[0])
 				if err != nil || v < 0 || v > 1 {
-					return i18n.Tf("invalidMetaAI", "val", args[0]), true
+					return invalidArg("invalidMetaAI", "val", args[0]), true
 				}
 				cfg := c.hi.GetConfig()
 				cfg.CpuMetaAI = v == 1
@@ -179,7 +179,7 @@ func parseAmount(args []string) (int, error) {
 	}
 	amount, err := strconv.Atoi(args[0])
 	if err != nil || amount <= 0 {
-		return 0, errors.New(i18n.Tf("holdem.invalidAmount", "val", args[0]))
+		return 0, errors.New(invalidArg("holdem.invalidAmount", "val", args[0]))
 	}
 	return amount, nil
 }

--- a/internal/adapter/controller/HoldemCuiController_test.go
+++ b/internal/adapter/controller/HoldemCuiController_test.go
@@ -510,5 +510,5 @@ func TestHoldemCuiController_MetaAI_MissingArg(t *testing.T) {
 func TestHoldemCuiController_MetaAI_InvalidArg(t *testing.T) {
 	mi := new(usecase.MockHoldemInteractor)
 	c := NewHoldemCuiController(mi)
-	assert.Equal(t, "無効な値です: abc。0 または 1 を入力してください。", c.Exec("mai abc"))
+	assert.Equal(t, invalidArg("invalidMetaAI", "val", "abc"), c.Exec("mai abc"))
 }

--- a/internal/adapter/controller/IndianPokerCuiController.go
+++ b/internal/adapter/controller/IndianPokerCuiController.go
@@ -59,7 +59,7 @@ func (c *IndianPokerCuiController) Exec(command string) string {
 				}
 				bl, err := strconv.Atoi(args[0])
 				if err != nil {
-					return i18n.Tf("indianpoker.invalidBettingLimit", "val", args[0]), true
+					return invalidArg("indianpoker.invalidBettingLimit", "val", args[0]), true
 				}
 				cfg := c.ipi.GetConfig()
 				cfg.BettingLimit = domain.BettingLimitType(bl)
@@ -70,7 +70,7 @@ func (c *IndianPokerCuiController) Exec(command string) string {
 				}
 				v, err := strconv.Atoi(args[0])
 				if err != nil || v < 0 || v > 1 {
-					return i18n.Tf("invalidMetaAI", "val", args[0]), true
+					return invalidArg("invalidMetaAI", "val", args[0]), true
 				}
 				cfg := c.ipi.GetConfig()
 				cfg.CpuMetaAI = v == 1
@@ -81,7 +81,7 @@ func (c *IndianPokerCuiController) Exec(command string) string {
 				}
 				v, err := strconv.Atoi(args[0])
 				if err != nil || v < 1 {
-					return i18n.Tf("indianpoker.invalidAnte", "val", args[0]), true
+					return invalidArg("indianpoker.invalidAnte", "val", args[0]), true
 				}
 				cfg := c.ipi.GetConfig()
 				cfg.Ante = v
@@ -100,7 +100,7 @@ func indianPokerParseAmount(args []string) (int, error) {
 	}
 	amount, err := strconv.Atoi(args[0])
 	if err != nil || amount <= 0 {
-		return 0, errors.New(i18n.Tf("indianpoker.invalidAmount", "val", args[0]))
+		return 0, errors.New(invalidArg("indianpoker.invalidAmount", "val", args[0]))
 	}
 	return amount, nil
 }

--- a/internal/adapter/controller/IndianPokerCuiController_test.go
+++ b/internal/adapter/controller/IndianPokerCuiController_test.go
@@ -68,15 +68,15 @@ func TestIndianPokerCuiController_Bet_NoAmount(t *testing.T) {
 func TestIndianPokerCuiController_Bet_InvalidAmount(t *testing.T) {
 	mi := new(usecase.MockIndianPokerInteractor)
 	c := NewIndianPokerCuiController(mi)
-	assert.Equal(t, i18n.Tf("indianpoker.invalidAmount", "val", "abc"), c.Exec("b abc"))
-	assert.Equal(t, i18n.Tf("indianpoker.invalidAmount", "val", "xyz"), c.Exec("bet xyz"))
+	assert.Equal(t, invalidArg("indianpoker.invalidAmount", "val", "abc"), c.Exec("b abc"))
+	assert.Equal(t, invalidArg("indianpoker.invalidAmount", "val", "xyz"), c.Exec("bet xyz"))
 }
 
 func TestIndianPokerCuiController_Bet_NonPositiveAmount(t *testing.T) {
 	mi := new(usecase.MockIndianPokerInteractor)
 	c := NewIndianPokerCuiController(mi)
-	assert.Equal(t, i18n.Tf("indianpoker.invalidAmount", "val", "-50"), c.Exec("b -50"))
-	assert.Equal(t, i18n.Tf("indianpoker.invalidAmount", "val", "0"), c.Exec("bet 0"))
+	assert.Equal(t, invalidArg("indianpoker.invalidAmount", "val", "-50"), c.Exec("b -50"))
+	assert.Equal(t, invalidArg("indianpoker.invalidAmount", "val", "0"), c.Exec("bet 0"))
 }
 
 func TestIndianPokerCuiController_Raise(t *testing.T) {
@@ -97,15 +97,15 @@ func TestIndianPokerCuiController_Raise_NoAmount(t *testing.T) {
 func TestIndianPokerCuiController_Raise_InvalidAmount(t *testing.T) {
 	mi := new(usecase.MockIndianPokerInteractor)
 	c := NewIndianPokerCuiController(mi)
-	assert.Equal(t, i18n.Tf("indianpoker.invalidAmount", "val", "abc"), c.Exec("ra abc"))
-	assert.Equal(t, i18n.Tf("indianpoker.invalidAmount", "val", "xyz"), c.Exec("raise xyz"))
+	assert.Equal(t, invalidArg("indianpoker.invalidAmount", "val", "abc"), c.Exec("ra abc"))
+	assert.Equal(t, invalidArg("indianpoker.invalidAmount", "val", "xyz"), c.Exec("raise xyz"))
 }
 
 func TestIndianPokerCuiController_Raise_NonPositiveAmount(t *testing.T) {
 	mi := new(usecase.MockIndianPokerInteractor)
 	c := NewIndianPokerCuiController(mi)
-	assert.Equal(t, i18n.Tf("indianpoker.invalidAmount", "val", "-30"), c.Exec("ra -30"))
-	assert.Equal(t, i18n.Tf("indianpoker.invalidAmount", "val", "0"), c.Exec("raise 0"))
+	assert.Equal(t, invalidArg("indianpoker.invalidAmount", "val", "-30"), c.Exec("ra -30"))
+	assert.Equal(t, invalidArg("indianpoker.invalidAmount", "val", "0"), c.Exec("raise 0"))
 }
 
 func TestIndianPokerCuiController_AllIn(t *testing.T) {
@@ -146,7 +146,7 @@ func TestIndianPokerCuiController_BettingLimit_NoArgs(t *testing.T) {
 func TestIndianPokerCuiController_BettingLimit_InvalidValue(t *testing.T) {
 	mi := new(usecase.MockIndianPokerInteractor)
 	c := NewIndianPokerCuiController(mi)
-	assert.Equal(t, i18n.Tf("indianpoker.invalidBettingLimit", "val", "abc"), c.Exec("bl abc"))
+	assert.Equal(t, invalidArg("indianpoker.invalidBettingLimit", "val", "abc"), c.Exec("bl abc"))
 }
 
 func TestIndianPokerCuiController_MetaAI_On(t *testing.T) {
@@ -180,14 +180,14 @@ func TestIndianPokerCuiController_MetaAI_MissingArg(t *testing.T) {
 func TestIndianPokerCuiController_MetaAI_InvalidArg(t *testing.T) {
 	mi := new(usecase.MockIndianPokerInteractor)
 	c := NewIndianPokerCuiController(mi)
-	assert.Equal(t, i18n.Tf("invalidMetaAI", "val", "abc"), c.Exec("mai abc"))
+	assert.Equal(t, invalidArg("invalidMetaAI", "val", "abc"), c.Exec("mai abc"))
 }
 
 func TestIndianPokerCuiController_MetaAI_OutOfRange(t *testing.T) {
 	mi := new(usecase.MockIndianPokerInteractor)
 	c := NewIndianPokerCuiController(mi)
-	assert.Equal(t, i18n.Tf("invalidMetaAI", "val", "5"), c.Exec("mai 5"))
-	assert.Equal(t, i18n.Tf("invalidMetaAI", "val", "-1"), c.Exec("mai -1"))
+	assert.Equal(t, invalidArg("invalidMetaAI", "val", "5"), c.Exec("mai 5"))
+	assert.Equal(t, invalidArg("invalidMetaAI", "val", "-1"), c.Exec("mai -1"))
 }
 
 func TestIndianPokerCuiController_Ante_Valid(t *testing.T) {
@@ -211,14 +211,14 @@ func TestIndianPokerCuiController_Ante_NoArgs(t *testing.T) {
 func TestIndianPokerCuiController_Ante_InvalidValue(t *testing.T) {
 	mi := new(usecase.MockIndianPokerInteractor)
 	c := NewIndianPokerCuiController(mi)
-	assert.Equal(t, i18n.Tf("indianpoker.invalidAnte", "val", "abc"), c.Exec("an abc"))
+	assert.Equal(t, invalidArg("indianpoker.invalidAnte", "val", "abc"), c.Exec("an abc"))
 }
 
 func TestIndianPokerCuiController_Ante_NonPositive(t *testing.T) {
 	mi := new(usecase.MockIndianPokerInteractor)
 	c := NewIndianPokerCuiController(mi)
-	assert.Equal(t, i18n.Tf("indianpoker.invalidAnte", "val", "0"), c.Exec("an 0"))
-	assert.Equal(t, i18n.Tf("indianpoker.invalidAnte", "val", "-1"), c.Exec("an -1"))
+	assert.Equal(t, invalidArg("indianpoker.invalidAnte", "val", "0"), c.Exec("an 0"))
+	assert.Equal(t, invalidArg("indianpoker.invalidAnte", "val", "-1"), c.Exec("an -1"))
 }
 
 func TestIndianPokerCuiController_ActionLog(t *testing.T) {

--- a/internal/adapter/controller/KingAlbertCuiController.go
+++ b/internal/adapter/controller/KingAlbertCuiController.go
@@ -51,7 +51,7 @@ func (c *KingAlbertCuiController) handleMove(args []string) string {
 	if strings.HasPrefix(from, "r") {
 		reserveIdx, err := strconv.Atoi(strings.TrimPrefix(from, "r"))
 		if err != nil {
-			return i18n.Tf("invalidColumn", "val", from)
+			return invalidArg("invalidColumn", "val", from)
 		}
 		if len(args) < 2 {
 			return cuiutil.PromptRequest(i18n.T("kingalbert.promptToZone"), fmt.Sprintf("m %s {0}", from))
@@ -61,14 +61,14 @@ func (c *KingAlbertCuiController) handleMove(args []string) string {
 		}
 		toCol, err := strconv.Atoi(args[1])
 		if err != nil {
-			return i18n.Tf("invalidColumn", "val", args[1])
+			return invalidArg("invalidColumn", "val", args[1])
 		}
 		return c.bi.MoveReserveToTableau(reserveIdx, toCol)
 	}
 
 	fromCol, err := strconv.Atoi(from)
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", from)
+		return invalidArg("invalidColumn", "val", from)
 	}
 	if len(args) < 2 {
 		return cuiutil.PromptRequest(i18n.T("kingalbert.promptToZone"), fmt.Sprintf("m %s {0}", from))
@@ -78,7 +78,7 @@ func (c *KingAlbertCuiController) handleMove(args []string) string {
 	}
 	toCol, err := strconv.Atoi(args[1])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[1])
+		return invalidArg("invalidColumn", "val", args[1])
 	}
 	return c.bi.MoveTableauToTableau(fromCol, -1, toCol)
 }

--- a/internal/adapter/controller/KlondikeCuiController.go
+++ b/internal/adapter/controller/KlondikeCuiController.go
@@ -78,7 +78,7 @@ func (c *KlondikeCuiController) handleMove(args []string) string {
 	}
 	from := args[0]
 	if from != "w" && from != "t" {
-		return i18n.Tf("klondike.invalidFromZone", "val", from)
+		return invalidArg("klondike.invalidFromZone", "val", from)
 	}
 	if len(args) < 2 {
 		switch from {
@@ -105,13 +105,13 @@ func (c *KlondikeCuiController) handleMoveFromWaste(args []string) string {
 		}
 		col, err := strconv.Atoi(args[1])
 		if err != nil {
-			return i18n.Tf("invalidColumn", "val", args[1])
+			return invalidArg("invalidColumn", "val", args[1])
 		}
 		return c.ki.MoveWasteToTableau(col)
 	case "f":
 		return c.ki.MoveWasteToFoundation()
 	default:
-		return i18n.Tf("klondike.invalidToZone", "val", to)
+		return invalidArg("klondike.invalidToZone", "val", to)
 	}
 }
 
@@ -124,7 +124,7 @@ func (c *KlondikeCuiController) handleMoveFromTableau(args []string) string {
 	}
 	fromCol, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[0])
+		return invalidArg("invalidColumn", "val", args[0])
 	}
 
 	if args[1] == "f" {
@@ -142,12 +142,12 @@ func (c *KlondikeCuiController) handleMoveFromTableau(args []string) string {
 
 	cardIdx, err := strconv.Atoi(args[1])
 	if err != nil {
-		return i18n.Tf("invalidCardIndex", "val", args[1])
+		return invalidArg("invalidCardIndex", "val", args[1])
 	}
 
 	toCol, err := strconv.Atoi(args[3])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[3])
+		return invalidArg("invalidColumn", "val", args[3])
 	}
 
 	return c.ki.MoveTableauToTableau(fromCol, cardIdx, toCol)
@@ -160,7 +160,7 @@ func (c *KlondikeCuiController) handleFoundationShorthand(args []string) string 
 	}
 	col, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[0])
+		return invalidArg("invalidColumn", "val", args[0])
 	}
 	return c.ki.MoveTableauToFoundation(col)
 }
@@ -172,7 +172,7 @@ func (c *KlondikeCuiController) handleMoveShorthand(args []string) string {
 	}
 	toCol, err := strconv.Atoi(args[1])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[1])
+		return invalidArg("invalidColumn", "val", args[1])
 	}
 	return c.ki.MoveTableauToTableau(fromCol, -1, toCol)
 }

--- a/internal/adapter/controller/MissMilliganCuiController.go
+++ b/internal/adapter/controller/MissMilliganCuiController.go
@@ -57,13 +57,13 @@ func (c *MissMilliganCuiController) handleWaive(args []string) string {
 	}
 	col, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[0])
+		return invalidArg("invalidColumn", "val", args[0])
 	}
 	cardIndex := -1
 	if len(args) >= 2 {
 		idx, err := strconv.Atoi(args[1])
 		if err != nil {
-			return i18n.Tf("missmilligan.invalidCardIndex", "val", args[1])
+			return invalidArg("missmilligan.invalidCardIndex", "val", args[1])
 		}
 		cardIndex = idx
 	}
@@ -86,7 +86,7 @@ func (c *MissMilliganCuiController) handleMove(args []string) string {
 	case "t":
 		return c.handleMoveFromTableau(args[1:])
 	default:
-		return i18n.Tf("missmilligan.invalidFromZone", "val", args[0])
+		return invalidArg("missmilligan.invalidFromZone", "val", args[0])
 	}
 }
 
@@ -103,11 +103,11 @@ func (c *MissMilliganCuiController) handleMoveFromWaived(args []string) string {
 		}
 		col, err := strconv.Atoi(args[1])
 		if err != nil {
-			return i18n.Tf("invalidColumn", "val", args[1])
+			return invalidArg("invalidColumn", "val", args[1])
 		}
 		return c.mi.PlaceWaived(col)
 	default:
-		return i18n.Tf("missmilligan.invalidToZone", "val", args[0])
+		return invalidArg("missmilligan.invalidToZone", "val", args[0])
 	}
 }
 
@@ -117,7 +117,7 @@ func (c *MissMilliganCuiController) handleMoveFromTableau(args []string) string 
 	}
 	fromCol, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[0])
+		return invalidArg("invalidColumn", "val", args[0])
 	}
 	if len(args) < 2 {
 		return cuiutil.PromptRequest(i18n.T("missmilligan.promptToZone"), fmt.Sprintf("m t %s {0}", args[0]))
@@ -131,19 +131,19 @@ func (c *MissMilliganCuiController) handleMoveFromTableau(args []string) string 
 		}
 		toCol, err := strconv.Atoi(args[2])
 		if err != nil {
-			return i18n.Tf("invalidColumn", "val", args[2])
+			return invalidArg("invalidColumn", "val", args[2])
 		}
 		// 連番グループの先頭。省略時は -1 = 最上段 1 枚。
 		cardIndex := -1
 		if len(args) >= 4 {
 			idx, err := strconv.Atoi(args[3])
 			if err != nil {
-				return i18n.Tf("missmilligan.invalidCardIndex", "val", args[3])
+				return invalidArg("missmilligan.invalidCardIndex", "val", args[3])
 			}
 			cardIndex = idx
 		}
 		return c.mi.MoveTableauToTableau(fromCol, cardIndex, toCol)
 	default:
-		return i18n.Tf("missmilligan.invalidToZone", "val", args[1])
+		return invalidArg("missmilligan.invalidToZone", "val", args[1])
 	}
 }

--- a/internal/adapter/controller/NapoleonsSquareCuiController.go
+++ b/internal/adapter/controller/NapoleonsSquareCuiController.go
@@ -65,7 +65,7 @@ func (c *NapoleonsSquareCuiController) handleMove(args []string) string {
 	case "t":
 		return c.handleMoveFromTableau(args[1:])
 	default:
-		return i18n.Tf("napoleonssquare.invalidFromZone", "val", args[0])
+		return invalidArg("napoleonssquare.invalidFromZone", "val", args[0])
 	}
 }
 
@@ -82,11 +82,11 @@ func (c *NapoleonsSquareCuiController) handleMoveFromWaste(args []string) string
 		}
 		col, err := strconv.Atoi(args[1])
 		if err != nil {
-			return i18n.Tf("invalidColumn", "val", args[1])
+			return invalidArg("invalidColumn", "val", args[1])
 		}
 		return c.ni.MoveWasteToTableau(col)
 	default:
-		return i18n.Tf("napoleonssquare.invalidToZone", "val", args[0])
+		return invalidArg("napoleonssquare.invalidToZone", "val", args[0])
 	}
 }
 
@@ -96,7 +96,7 @@ func (c *NapoleonsSquareCuiController) handleMoveFromTableau(args []string) stri
 	}
 	fromCol, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[0])
+		return invalidArg("invalidColumn", "val", args[0])
 	}
 	if len(args) < 2 {
 		return cuiutil.PromptRequest(i18n.T("napoleonssquare.promptToZone"), fmt.Sprintf("m t %s {0}", args[0]))
@@ -110,19 +110,19 @@ func (c *NapoleonsSquareCuiController) handleMoveFromTableau(args []string) stri
 		}
 		toCol, err := strconv.Atoi(args[2])
 		if err != nil {
-			return i18n.Tf("invalidColumn", "val", args[2])
+			return invalidArg("invalidColumn", "val", args[2])
 		}
 		// 連番グループの先頭。省略時は -1 = 最上段 1 枚。
 		cardIndex := -1
 		if len(args) >= 4 {
 			idx, err := strconv.Atoi(args[3])
 			if err != nil {
-				return i18n.Tf("napoleonssquare.invalidCardIndex", "val", args[3])
+				return invalidArg("napoleonssquare.invalidCardIndex", "val", args[3])
 			}
 			cardIndex = idx
 		}
 		return c.ni.MoveTableauToTableau(fromCol, cardIndex, toCol)
 	default:
-		return i18n.Tf("napoleonssquare.invalidToZone", "val", args[1])
+		return invalidArg("napoleonssquare.invalidToZone", "val", args[1])
 	}
 }

--- a/internal/adapter/controller/NertzCuiController.go
+++ b/internal/adapter/controller/NertzCuiController.go
@@ -71,7 +71,7 @@ func (c *NertzCuiController) handleDraw(args []string) string {
 	}
 	p, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidIndex", "val", args[0])
+		return invalidArg("invalidIndex", "val", args[0])
 	}
 	return c.ni.Draw(p)
 }
@@ -82,14 +82,14 @@ func (c *NertzCuiController) handleMoveNF(args []string) string {
 	}
 	p, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidIndex", "val", args[0])
+		return invalidArg("invalidIndex", "val", args[0])
 	}
 	if len(args) < 2 {
 		return cuiutil.PromptRequest(i18n.T("nertz.promptFoundationIdx"), "mnf "+args[0]+" {0}")
 	}
 	f, err := strconv.Atoi(args[1])
 	if err != nil {
-		return i18n.Tf("invalidIndex", "val", args[1])
+		return invalidArg("invalidIndex", "val", args[1])
 	}
 	return c.ni.MoveNertzToFoundation(p, f)
 }
@@ -100,14 +100,14 @@ func (c *NertzCuiController) handleMoveNT(args []string) string {
 	}
 	p, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidIndex", "val", args[0])
+		return invalidArg("invalidIndex", "val", args[0])
 	}
 	if len(args) < 2 {
 		return cuiutil.PromptRequest(i18n.T("nertz.promptTableauCol"), "mnt "+args[0]+" {0}")
 	}
 	col, err := strconv.Atoi(args[1])
 	if err != nil {
-		return i18n.Tf("invalidIndex", "val", args[1])
+		return invalidArg("invalidIndex", "val", args[1])
 	}
 	return c.ni.MoveNertzToTableau(p, col)
 }
@@ -118,14 +118,14 @@ func (c *NertzCuiController) handleMoveWF(args []string) string {
 	}
 	p, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidIndex", "val", args[0])
+		return invalidArg("invalidIndex", "val", args[0])
 	}
 	if len(args) < 2 {
 		return cuiutil.PromptRequest(i18n.T("nertz.promptFoundationIdx"), "mwf "+args[0]+" {0}")
 	}
 	f, err := strconv.Atoi(args[1])
 	if err != nil {
-		return i18n.Tf("invalidIndex", "val", args[1])
+		return invalidArg("invalidIndex", "val", args[1])
 	}
 	return c.ni.MoveWasteToFoundation(p, f)
 }
@@ -136,14 +136,14 @@ func (c *NertzCuiController) handleMoveWT(args []string) string {
 	}
 	p, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidIndex", "val", args[0])
+		return invalidArg("invalidIndex", "val", args[0])
 	}
 	if len(args) < 2 {
 		return cuiutil.PromptRequest(i18n.T("nertz.promptTableauCol"), "mwt "+args[0]+" {0}")
 	}
 	col, err := strconv.Atoi(args[1])
 	if err != nil {
-		return i18n.Tf("invalidIndex", "val", args[1])
+		return invalidArg("invalidIndex", "val", args[1])
 	}
 	return c.ni.MoveWasteToTableau(p, col)
 }
@@ -154,21 +154,21 @@ func (c *NertzCuiController) handleMoveTF(args []string) string {
 	}
 	p, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidIndex", "val", args[0])
+		return invalidArg("invalidIndex", "val", args[0])
 	}
 	if len(args) < 2 {
 		return cuiutil.PromptRequest(i18n.T("nertz.promptTableauCol"), "mtf "+args[0]+" {0} {1}")
 	}
 	col, err := strconv.Atoi(args[1])
 	if err != nil {
-		return i18n.Tf("invalidIndex", "val", args[1])
+		return invalidArg("invalidIndex", "val", args[1])
 	}
 	if len(args) < 3 {
 		return cuiutil.PromptRequest(i18n.T("nertz.promptFoundationIdx"), "mtf "+args[0]+" "+args[1]+" {0}")
 	}
 	f, err := strconv.Atoi(args[2])
 	if err != nil {
-		return i18n.Tf("invalidIndex", "val", args[2])
+		return invalidArg("invalidIndex", "val", args[2])
 	}
 	return c.ni.MoveTableauToFoundation(p, col, f)
 }
@@ -179,28 +179,28 @@ func (c *NertzCuiController) handleMoveTT(args []string) string {
 	}
 	p, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidIndex", "val", args[0])
+		return invalidArg("invalidIndex", "val", args[0])
 	}
 	if len(args) < 2 {
 		return cuiutil.PromptRequest(i18n.T("nertz.promptTableauCol"), "mtt "+args[0]+" {0} {1} {2}")
 	}
 	fromCol, err := strconv.Atoi(args[1])
 	if err != nil {
-		return i18n.Tf("invalidIndex", "val", args[1])
+		return invalidArg("invalidIndex", "val", args[1])
 	}
 	if len(args) < 3 {
 		return cuiutil.PromptRequest(i18n.T("nertz.promptTableauFromIdx"), "mtt "+args[0]+" "+args[1]+" {0} {1}")
 	}
 	fromIdx, err := strconv.Atoi(args[2])
 	if err != nil {
-		return i18n.Tf("invalidIndex", "val", args[2])
+		return invalidArg("invalidIndex", "val", args[2])
 	}
 	if len(args) < 4 {
 		return cuiutil.PromptRequest(i18n.T("nertz.promptTableauToCol"), "mtt "+args[0]+" "+args[1]+" "+args[2]+" {0}")
 	}
 	toCol, err := strconv.Atoi(args[3])
 	if err != nil {
-		return i18n.Tf("invalidIndex", "val", args[3])
+		return invalidArg("invalidIndex", "val", args[3])
 	}
 	return c.ni.MoveTableauToTableau(p, fromCol, fromIdx, toCol)
 }

--- a/internal/adapter/controller/OmahaCuiController.go
+++ b/internal/adapter/controller/OmahaCuiController.go
@@ -91,7 +91,7 @@ func (c *OmahaCuiController) Exec(command string) string {
 				}
 				bl, err := strconv.Atoi(args[0])
 				if err != nil {
-					return i18n.Tf("holdem.invalidBettingLimit", "val", args[0]), true
+					return invalidArg("holdem.invalidBettingLimit", "val", args[0]), true
 				}
 				cfg := c.oi.GetConfig()
 				cfg.BettingLimit = domain.BettingLimitType(bl)
@@ -102,7 +102,7 @@ func (c *OmahaCuiController) Exec(command string) string {
 				}
 				v, err := strconv.Atoi(args[0])
 				if err != nil || v < 0 || v > 1 {
-					return i18n.Tf("holdem.invalidTournamentMode", "val", args[0]), true
+					return invalidArg("holdem.invalidTournamentMode", "val", args[0]), true
 				}
 				cfg := c.oi.GetConfig()
 				cfg.TournamentMode = v == 1
@@ -113,7 +113,7 @@ func (c *OmahaCuiController) Exec(command string) string {
 				}
 				v, err := strconv.Atoi(args[0])
 				if err != nil {
-					return i18n.Tf("holdem.invalidSmallBlind", "val", args[0]), true
+					return invalidArg("holdem.invalidSmallBlind", "val", args[0]), true
 				}
 				cfg := c.oi.GetConfig()
 				cfg.SmallBlind = v
@@ -124,7 +124,7 @@ func (c *OmahaCuiController) Exec(command string) string {
 				}
 				v, err := strconv.Atoi(args[0])
 				if err != nil {
-					return i18n.Tf("holdem.invalidBigBlind", "val", args[0]), true
+					return invalidArg("holdem.invalidBigBlind", "val", args[0]), true
 				}
 				cfg := c.oi.GetConfig()
 				cfg.BigBlind = v
@@ -135,7 +135,7 @@ func (c *OmahaCuiController) Exec(command string) string {
 				}
 				v, err := strconv.Atoi(args[0])
 				if err != nil {
-					return i18n.Tf("holdem.invalidLevelHand", "val", args[0]), true
+					return invalidArg("holdem.invalidLevelHand", "val", args[0]), true
 				}
 				cfg := c.oi.GetConfig()
 				cfg.BlindLevelHands = v
@@ -146,7 +146,7 @@ func (c *OmahaCuiController) Exec(command string) string {
 				}
 				v, err := strconv.Atoi(args[0])
 				if err != nil {
-					return i18n.Tf("holdem.invalidTableSize", "val", args[0]), true
+					return invalidArg("holdem.invalidTableSize", "val", args[0]), true
 				}
 				cfg := c.oi.GetConfig()
 				cfg.TableSize = v
@@ -157,7 +157,7 @@ func (c *OmahaCuiController) Exec(command string) string {
 				}
 				v, err := strconv.Atoi(args[0])
 				if err != nil || v < 0 || v > 1 {
-					return i18n.Tf("invalidMetaAI", "val", args[0]), true
+					return invalidArg("invalidMetaAI", "val", args[0]), true
 				}
 				cfg := c.oi.GetConfig()
 				cfg.CpuMetaAI = v == 1

--- a/internal/adapter/controller/OmahaCuiController_test.go
+++ b/internal/adapter/controller/OmahaCuiController_test.go
@@ -504,5 +504,5 @@ func TestOmahaCuiController_MetaAI_MissingArg(t *testing.T) {
 func TestOmahaCuiController_MetaAI_InvalidArg(t *testing.T) {
 	mi := new(usecase.MockOmahaInteractor)
 	c := NewOmahaCuiController(mi)
-	assert.Equal(t, "無効な値です: abc。0 または 1 を入力してください。", c.Exec("mai abc"))
+	assert.Equal(t, invalidArg("invalidMetaAI", "val", "abc"), c.Exec("mai abc"))
 }

--- a/internal/adapter/controller/OsmosisCuiController.go
+++ b/internal/adapter/controller/OsmosisCuiController.go
@@ -70,7 +70,7 @@ func (c *OsmosisCuiController) handleMove(args []string) string {
 	case "r":
 		return c.handleMoveFromReserve(args[1:])
 	default:
-		return i18n.Tf("osmosis.invalidFromZone", "val", from)
+		return invalidArg("osmosis.invalidFromZone", "val", from)
 	}
 }
 
@@ -84,7 +84,7 @@ func (c *OsmosisCuiController) handleMoveFromWaste(args []string) string {
 	}
 	fIdx, err := strconv.Atoi(args[1])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[1])
+		return invalidArg("invalidColumn", "val", args[1])
 	}
 	return c.oi.MoveWasteToFoundation(fIdx)
 }
@@ -96,7 +96,7 @@ func (c *OsmosisCuiController) handleMoveFromReserve(args []string) string {
 	}
 	rIdx, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[0])
+		return invalidArg("invalidColumn", "val", args[0])
 	}
 	if len(args) < 2 || args[1] != "f" {
 		return i18n.T("osmosis.moveUsage")
@@ -106,7 +106,7 @@ func (c *OsmosisCuiController) handleMoveFromReserve(args []string) string {
 	}
 	fIdx, err := strconv.Atoi(args[2])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[2])
+		return invalidArg("invalidColumn", "val", args[2])
 	}
 	return c.oi.MoveReserveToFoundation(rIdx, fIdx)
 }

--- a/internal/adapter/controller/PenguinCuiController.go
+++ b/internal/adapter/controller/PenguinCuiController.go
@@ -58,7 +58,7 @@ func (c *PenguinCuiController) handleMove(args []string) string {
 	}
 	from := args[0]
 	if from != "t" && from != "c" {
-		return i18n.Tf("penguin.invalidFromZone", "val", from)
+		return invalidArg("penguin.invalidFromZone", "val", from)
 	}
 	if len(args) < 2 {
 		switch from {
@@ -85,7 +85,7 @@ func (c *PenguinCuiController) handleMoveFromTableau(args []string) string {
 	}
 	fromCol, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[0])
+		return invalidArg("invalidColumn", "val", args[0])
 	}
 
 	switch args[1] {
@@ -97,7 +97,7 @@ func (c *PenguinCuiController) handleMoveFromTableau(args []string) string {
 		}
 		toCol, err := strconv.Atoi(args[2])
 		if err != nil {
-			return i18n.Tf("invalidColumn", "val", args[2])
+			return invalidArg("invalidColumn", "val", args[2])
 		}
 		return c.pi.MoveTableauToTableau(fromCol, -1, toCol)
 	case "c":
@@ -106,7 +106,7 @@ func (c *PenguinCuiController) handleMoveFromTableau(args []string) string {
 		}
 		cell, err := strconv.Atoi(args[2])
 		if err != nil {
-			return i18n.Tf("invalidCell", "val", args[2])
+			return invalidArg("invalidCell", "val", args[2])
 		}
 		return c.pi.MoveTableauToFreeCell(fromCol, cell)
 	default:
@@ -122,7 +122,7 @@ func (c *PenguinCuiController) handleMoveFromTableau(args []string) string {
 		}
 		toCol, err := strconv.Atoi(args[3])
 		if err != nil {
-			return i18n.Tf("invalidColumn", "val", args[3])
+			return invalidArg("invalidColumn", "val", args[3])
 		}
 		return c.pi.MoveTableauToTableau(fromCol, cardIdx, toCol)
 	}
@@ -137,7 +137,7 @@ func (c *PenguinCuiController) handleMoveFromFreeCell(args []string) string {
 	}
 	cell, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidCell", "val", args[0])
+		return invalidArg("invalidCell", "val", args[0])
 	}
 
 	switch args[1] {
@@ -147,13 +147,13 @@ func (c *PenguinCuiController) handleMoveFromFreeCell(args []string) string {
 		}
 		col, err := strconv.Atoi(args[2])
 		if err != nil {
-			return i18n.Tf("invalidColumn", "val", args[2])
+			return invalidArg("invalidColumn", "val", args[2])
 		}
 		return c.pi.MoveFreeCellToTableau(cell, col)
 	case "f":
 		return c.pi.MoveFreeCellToFoundation(cell)
 	default:
-		return i18n.Tf("penguin.invalidToZone", "val", args[1])
+		return invalidArg("penguin.invalidToZone", "val", args[1])
 	}
 }
 
@@ -163,7 +163,7 @@ func (c *PenguinCuiController) handleFoundationShorthand(args []string) string {
 	}
 	col, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[0])
+		return invalidArg("invalidColumn", "val", args[0])
 	}
 	return c.pi.MoveTableauToFoundation(col)
 }
@@ -175,7 +175,7 @@ func (c *PenguinCuiController) handleMoveShorthand(args []string) string {
 	}
 	toCol, err := strconv.Atoi(args[1])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[1])
+		return invalidArg("invalidColumn", "val", args[1])
 	}
 	return c.pi.MoveTableauToTableau(fromCol, -1, toCol)
 }

--- a/internal/adapter/controller/PineappleCuiController.go
+++ b/internal/adapter/controller/PineappleCuiController.go
@@ -92,7 +92,7 @@ func (c *PineappleCuiController) Exec(command string) string {
 				}
 				idx, err := strconv.Atoi(args[0])
 				if err != nil {
-					return i18n.Tf("pineapple.invalidDiscardIdx", "val", args[0]), true
+					return invalidArg("pineapple.invalidDiscardIdx", "val", args[0]), true
 				}
 				return c.pi.Discard(idx), true
 			case "bl", "bettinglimit":
@@ -101,7 +101,7 @@ func (c *PineappleCuiController) Exec(command string) string {
 				}
 				bl, err := strconv.Atoi(args[0])
 				if err != nil {
-					return i18n.Tf("holdem.invalidBettingLimit", "val", args[0]), true
+					return invalidArg("holdem.invalidBettingLimit", "val", args[0]), true
 				}
 				cfg := c.pi.GetConfig()
 				cfg.BettingLimit = domain.BettingLimitType(bl)
@@ -112,7 +112,7 @@ func (c *PineappleCuiController) Exec(command string) string {
 				}
 				v, err := strconv.Atoi(args[0])
 				if err != nil || v < 0 || v > 1 {
-					return i18n.Tf("holdem.invalidTournamentMode", "val", args[0]), true
+					return invalidArg("holdem.invalidTournamentMode", "val", args[0]), true
 				}
 				cfg := c.pi.GetConfig()
 				cfg.TournamentMode = v == 1
@@ -123,7 +123,7 @@ func (c *PineappleCuiController) Exec(command string) string {
 				}
 				v, err := strconv.Atoi(args[0])
 				if err != nil {
-					return i18n.Tf("holdem.invalidSmallBlind", "val", args[0]), true
+					return invalidArg("holdem.invalidSmallBlind", "val", args[0]), true
 				}
 				cfg := c.pi.GetConfig()
 				cfg.SmallBlind = v
@@ -134,7 +134,7 @@ func (c *PineappleCuiController) Exec(command string) string {
 				}
 				v, err := strconv.Atoi(args[0])
 				if err != nil {
-					return i18n.Tf("holdem.invalidBigBlind", "val", args[0]), true
+					return invalidArg("holdem.invalidBigBlind", "val", args[0]), true
 				}
 				cfg := c.pi.GetConfig()
 				cfg.BigBlind = v
@@ -145,7 +145,7 @@ func (c *PineappleCuiController) Exec(command string) string {
 				}
 				v, err := strconv.Atoi(args[0])
 				if err != nil {
-					return i18n.Tf("holdem.invalidLevelHand", "val", args[0]), true
+					return invalidArg("holdem.invalidLevelHand", "val", args[0]), true
 				}
 				cfg := c.pi.GetConfig()
 				cfg.BlindLevelHands = v
@@ -156,7 +156,7 @@ func (c *PineappleCuiController) Exec(command string) string {
 				}
 				v, err := strconv.Atoi(args[0])
 				if err != nil {
-					return i18n.Tf("holdem.invalidTableSize", "val", args[0]), true
+					return invalidArg("holdem.invalidTableSize", "val", args[0]), true
 				}
 				cfg := c.pi.GetConfig()
 				cfg.TableSize = v
@@ -167,7 +167,7 @@ func (c *PineappleCuiController) Exec(command string) string {
 				}
 				v, err := strconv.Atoi(args[0])
 				if err != nil || v < 0 || v > 1 {
-					return i18n.Tf("invalidMetaAI", "val", args[0]), true
+					return invalidArg("invalidMetaAI", "val", args[0]), true
 				}
 				cfg := c.pi.GetConfig()
 				cfg.CpuMetaAI = v == 1
@@ -186,7 +186,7 @@ func parsePineappleAmount(args []string) (int, error) {
 	}
 	amount, err := strconv.Atoi(args[0])
 	if err != nil || amount <= 0 {
-		return 0, errors.New(i18n.Tf("holdem.invalidAmount", "val", args[0]))
+		return 0, errors.New(invalidArg("holdem.invalidAmount", "val", args[0]))
 	}
 	return amount, nil
 }

--- a/internal/adapter/controller/PiquetCuiController.go
+++ b/internal/adapter/controller/PiquetCuiController.go
@@ -60,7 +60,7 @@ func (c *PiquetCuiController) handleExchange(args []string, exec func([]int) str
 	}
 	indices, err := parseIndexList(args[0])
 	if err != nil {
-		return i18n.Tf("invalidIndex", "val", args[0])
+		return invalidArg("invalidIndex", "val", args[0])
 	}
 	return exec(indices)
 }
@@ -72,7 +72,7 @@ func (c *PiquetCuiController) handlePlay(args []string) string {
 	}
 	idx, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidIndex", "val", args[0])
+		return invalidArg("invalidIndex", "val", args[0])
 	}
 	return c.pi.Play(idx)
 }

--- a/internal/adapter/controller/PokerCuiController.go
+++ b/internal/adapter/controller/PokerCuiController.go
@@ -98,7 +98,7 @@ func (pcc *PokerCuiController) Exec(command string) string {
 				}
 				v, err := strconv.Atoi(args[0])
 				if err != nil || v < 0 || v > 1 {
-					return i18n.Tf("invalidMetaAI", "val", args[0]), true
+					return invalidArg("invalidMetaAI", "val", args[0]), true
 				}
 				cfg := pcc.pi.GetConfig()
 				cfg.CpuMetaAI = v == 1

--- a/internal/adapter/controller/PokerCuiController_test.go
+++ b/internal/adapter/controller/PokerCuiController_test.go
@@ -470,5 +470,5 @@ func TestPokerCuiController_MetaAI_MissingArg(t *testing.T) {
 func TestPokerCuiController_MetaAI_InvalidArg(t *testing.T) {
 	mi := new(mockUsecase.MockPokerInteractor)
 	c := NewPokerCuiController(mi)
-	assert.Equal(t, "無効な値です: abc。0 または 1 を入力してください。", c.Exec("mai abc"))
+	assert.Equal(t, invalidArg("invalidMetaAI", "val", "abc"), c.Exec("mai abc"))
 }

--- a/internal/adapter/controller/RoyalCotillionCuiController.go
+++ b/internal/adapter/controller/RoyalCotillionCuiController.go
@@ -68,7 +68,7 @@ func (c *RoyalCotillionCuiController) handleMove(args []string) string {
 	case "s":
 		return c.handleMoveFromStock(args[1:])
 	default:
-		return i18n.Tf("royalcotillion.invalidFromZone", "val", args[0])
+		return invalidArg("royalcotillion.invalidFromZone", "val", args[0])
 	}
 }
 
@@ -80,10 +80,10 @@ func (c *RoyalCotillionCuiController) handleMoveFromTableau(args []string) strin
 	}
 	slot, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("royalcotillion.invalidPile", "val", args[0])
+		return invalidArg("royalcotillion.invalidPile", "val", args[0])
 	}
 	if len(args) >= 2 && args[1] != "f" {
-		return i18n.Tf("royalcotillion.invalidToZone", "val", args[1])
+		return invalidArg("royalcotillion.invalidToZone", "val", args[1])
 	}
 	return c.ci.MoveTableauToFoundation(slot)
 }
@@ -95,10 +95,10 @@ func (c *RoyalCotillionCuiController) handleMoveFromReserve(args []string) strin
 	}
 	pile, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("royalcotillion.invalidReserve", "val", args[0])
+		return invalidArg("royalcotillion.invalidReserve", "val", args[0])
 	}
 	if len(args) >= 2 && args[1] != "f" {
-		return i18n.Tf("royalcotillion.invalidToZone", "val", args[1])
+		return invalidArg("royalcotillion.invalidToZone", "val", args[1])
 	}
 	return c.ci.MoveReserveToFoundation(pile)
 }
@@ -116,11 +116,11 @@ func (c *RoyalCotillionCuiController) handleMoveFromWaste(args []string) string 
 		}
 		pile, err := strconv.Atoi(args[1])
 		if err != nil {
-			return i18n.Tf("royalcotillion.invalidPile", "val", args[1])
+			return invalidArg("royalcotillion.invalidPile", "val", args[1])
 		}
 		return c.ci.MoveWasteToTableau(pile)
 	default:
-		return i18n.Tf("royalcotillion.invalidToZone", "val", args[0])
+		return invalidArg("royalcotillion.invalidToZone", "val", args[0])
 	}
 }
 
@@ -130,14 +130,14 @@ func (c *RoyalCotillionCuiController) handleMoveFromStock(args []string) string 
 		return cuiutil.PromptRequest(i18n.T("royalcotillion.promptToZone"), "m s {0}")
 	}
 	if args[0] != "t" {
-		return i18n.Tf("royalcotillion.invalidToZone", "val", args[0])
+		return invalidArg("royalcotillion.invalidToZone", "val", args[0])
 	}
 	if len(args) < 2 {
 		return cuiutil.PromptRequest(i18n.T("royalcotillion.promptToPile"), "m s t {0}")
 	}
 	pile, err := strconv.Atoi(args[1])
 	if err != nil {
-		return i18n.Tf("royalcotillion.invalidPile", "val", args[1])
+		return invalidArg("royalcotillion.invalidPile", "val", args[1])
 	}
 	return c.ci.MoveStockToTableau(pile)
 }

--- a/internal/adapter/controller/RussianSolitaireCuiController.go
+++ b/internal/adapter/controller/RussianSolitaireCuiController.go
@@ -59,7 +59,7 @@ func (c *RussianSolitaireCuiController) handleMove(args []string) string {
 
 	from := args[0]
 	if from != "t" {
-		return i18n.Tf("russiansolitaire.invalidFromZone", "val", from)
+		return invalidArg("russiansolitaire.invalidFromZone", "val", from)
 	}
 
 	if len(args) < 2 {
@@ -78,7 +78,7 @@ func (c *RussianSolitaireCuiController) handleMoveFromTableau(args []string) str
 	}
 	fromCol, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[0])
+		return invalidArg("invalidColumn", "val", args[0])
 	}
 
 	if args[1] == "f" {
@@ -95,12 +95,12 @@ func (c *RussianSolitaireCuiController) handleMoveFromTableau(args []string) str
 
 	cardIdx, err := strconv.Atoi(args[1])
 	if err != nil {
-		return i18n.Tf("invalidCardIndex", "val", args[1])
+		return invalidArg("invalidCardIndex", "val", args[1])
 	}
 
 	toCol, err := strconv.Atoi(args[3])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[3])
+		return invalidArg("invalidColumn", "val", args[3])
 	}
 
 	return c.ri.MoveTableauToTableau(fromCol, cardIdx, toCol)
@@ -113,7 +113,7 @@ func (c *RussianSolitaireCuiController) handleMoveShorthand(args []string) strin
 	}
 	toCol, err := strconv.Atoi(args[1])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[1])
+		return invalidArg("invalidColumn", "val", args[1])
 	}
 	return c.ri.MoveTableauToTableau(fromCol, -1, toCol)
 }

--- a/internal/adapter/controller/ScorpionCuiController.go
+++ b/internal/adapter/controller/ScorpionCuiController.go
@@ -74,7 +74,7 @@ func (c *ScorpionCuiController) handleMove(args []string) string {
 	}
 	fromCol, err := strconv.Atoi(args[1])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[1])
+		return invalidArg("invalidColumn", "val", args[1])
 	}
 	if len(args) < 3 {
 		return cuiutil.PromptRequest(i18n.T("scorpion.promptCardIndex"), fmt.Sprintf("m t %d {0} t", fromCol))
@@ -87,11 +87,11 @@ func (c *ScorpionCuiController) handleMove(args []string) string {
 	}
 	cardIdx, err := strconv.Atoi(args[2])
 	if err != nil {
-		return i18n.Tf("invalidCardIndex", "val", args[2])
+		return invalidArg("invalidCardIndex", "val", args[2])
 	}
 	toCol, err := strconv.Atoi(args[4])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[4])
+		return invalidArg("invalidColumn", "val", args[4])
 	}
 	return c.si.MoveTableauToTableau(fromCol, cardIdx, toCol)
 }
@@ -105,7 +105,7 @@ func (c *ScorpionCuiController) handleLegal(args []string) string {
 	}
 	col, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[0])
+		return invalidArg("invalidColumn", "val", args[0])
 	}
 	return c.si.LegalMoves(col)
 }
@@ -118,17 +118,17 @@ func (c *ScorpionCuiController) handleMoveShorthand(args []string) string {
 	if len(args) == 2 {
 		toCol, err := strconv.Atoi(args[1])
 		if err != nil {
-			return i18n.Tf("invalidColumn", "val", args[1])
+			return invalidArg("invalidColumn", "val", args[1])
 		}
 		return c.si.MoveTableauToTableau(fromCol, -1, toCol)
 	}
 	cardIdx, err := strconv.Atoi(args[1])
 	if err != nil {
-		return i18n.Tf("invalidCardIndex", "val", args[1])
+		return invalidArg("invalidCardIndex", "val", args[1])
 	}
 	toCol, err := strconv.Atoi(args[2])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[2])
+		return invalidArg("invalidColumn", "val", args[2])
 	}
 	return c.si.MoveTableauToTableau(fromCol, cardIdx, toCol)
 }

--- a/internal/adapter/controller/SeahavenTowersCuiController.go
+++ b/internal/adapter/controller/SeahavenTowersCuiController.go
@@ -59,7 +59,7 @@ func (c *SeahavenTowersCuiController) handleMove(args []string) string {
 	}
 	from := args[0]
 	if from != "t" && from != "c" {
-		return i18n.Tf("seahaventowers.invalidFromZone", "val", from)
+		return invalidArg("seahaventowers.invalidFromZone", "val", from)
 	}
 	if len(args) < 2 {
 		switch from {
@@ -86,7 +86,7 @@ func (c *SeahavenTowersCuiController) handleMoveFromTableau(args []string) strin
 	}
 	fromCol, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[0])
+		return invalidArg("invalidColumn", "val", args[0])
 	}
 
 	switch args[1] {
@@ -98,7 +98,7 @@ func (c *SeahavenTowersCuiController) handleMoveFromTableau(args []string) strin
 		}
 		toCol, err := strconv.Atoi(args[2])
 		if err != nil {
-			return i18n.Tf("invalidColumn", "val", args[2])
+			return invalidArg("invalidColumn", "val", args[2])
 		}
 		return c.si.MoveTableauToTableau(fromCol, -1, toCol)
 	case "c":
@@ -107,7 +107,7 @@ func (c *SeahavenTowersCuiController) handleMoveFromTableau(args []string) strin
 		}
 		cell, err := strconv.Atoi(args[2])
 		if err != nil {
-			return i18n.Tf("invalidCell", "val", args[2])
+			return invalidArg("invalidCell", "val", args[2])
 		}
 		return c.si.MoveTableauToFreeCell(fromCol, cell)
 	default:
@@ -123,7 +123,7 @@ func (c *SeahavenTowersCuiController) handleMoveFromTableau(args []string) strin
 		}
 		toCol, err := strconv.Atoi(args[3])
 		if err != nil {
-			return i18n.Tf("invalidColumn", "val", args[3])
+			return invalidArg("invalidColumn", "val", args[3])
 		}
 		return c.si.MoveTableauToTableau(fromCol, cardIdx, toCol)
 	}
@@ -138,7 +138,7 @@ func (c *SeahavenTowersCuiController) handleMoveFromFreeCell(args []string) stri
 	}
 	cell, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidCell", "val", args[0])
+		return invalidArg("invalidCell", "val", args[0])
 	}
 
 	switch args[1] {
@@ -148,13 +148,13 @@ func (c *SeahavenTowersCuiController) handleMoveFromFreeCell(args []string) stri
 		}
 		col, err := strconv.Atoi(args[2])
 		if err != nil {
-			return i18n.Tf("invalidColumn", "val", args[2])
+			return invalidArg("invalidColumn", "val", args[2])
 		}
 		return c.si.MoveFreeCellToTableau(cell, col)
 	case "f":
 		return c.si.MoveFreeCellToFoundation(cell)
 	default:
-		return i18n.Tf("seahaventowers.invalidToZone", "val", args[1])
+		return invalidArg("seahaventowers.invalidToZone", "val", args[1])
 	}
 }
 
@@ -165,7 +165,7 @@ func (c *SeahavenTowersCuiController) handleFoundationShorthand(args []string) s
 	}
 	col, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[0])
+		return invalidArg("invalidColumn", "val", args[0])
 	}
 	return c.si.MoveTableauToFoundation(col)
 }
@@ -177,7 +177,7 @@ func (c *SeahavenTowersCuiController) handleMoveShorthand(args []string) string 
 	}
 	toCol, err := strconv.Atoi(args[1])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[1])
+		return invalidArg("invalidColumn", "val", args[1])
 	}
 	return c.si.MoveTableauToTableau(fromCol, -1, toCol)
 }

--- a/internal/adapter/controller/SevenCardStudCuiController.go
+++ b/internal/adapter/controller/SevenCardStudCuiController.go
@@ -92,7 +92,7 @@ func (c *SevenCardStudCuiController) Exec(command string) string {
 				}
 				bl, err := strconv.Atoi(args[0])
 				if err != nil {
-					return i18n.Tf("holdem.invalidBettingLimit", "val", args[0]), true
+					return invalidArg("holdem.invalidBettingLimit", "val", args[0]), true
 				}
 				cfg := c.si.GetConfig()
 				cfg.BettingLimit = domain.BettingLimitType(bl)
@@ -103,7 +103,7 @@ func (c *SevenCardStudCuiController) Exec(command string) string {
 				}
 				v, err := strconv.Atoi(args[0])
 				if err != nil || v < 0 || v > 1 {
-					return i18n.Tf("holdem.invalidTournamentMode", "val", args[0]), true
+					return invalidArg("holdem.invalidTournamentMode", "val", args[0]), true
 				}
 				cfg := c.si.GetConfig()
 				cfg.TournamentMode = v == 1
@@ -114,7 +114,7 @@ func (c *SevenCardStudCuiController) Exec(command string) string {
 				}
 				v, err := strconv.Atoi(args[0])
 				if err != nil {
-					return i18n.Tf("sevencardstud.invalidAnte", "val", args[0]), true
+					return invalidArg("sevencardstud.invalidAnte", "val", args[0]), true
 				}
 				cfg := c.si.GetConfig()
 				cfg.Ante = v
@@ -125,7 +125,7 @@ func (c *SevenCardStudCuiController) Exec(command string) string {
 				}
 				v, err := strconv.Atoi(args[0])
 				if err != nil {
-					return i18n.Tf("sevencardstud.invalidBringIn", "val", args[0]), true
+					return invalidArg("sevencardstud.invalidBringIn", "val", args[0]), true
 				}
 				cfg := c.si.GetConfig()
 				cfg.BringIn = v
@@ -136,7 +136,7 @@ func (c *SevenCardStudCuiController) Exec(command string) string {
 				}
 				v, err := strconv.Atoi(args[0])
 				if err != nil {
-					return i18n.Tf("sevencardstud.invalidSmallBet", "val", args[0]), true
+					return invalidArg("sevencardstud.invalidSmallBet", "val", args[0]), true
 				}
 				cfg := c.si.GetConfig()
 				cfg.SmallBet = v
@@ -147,7 +147,7 @@ func (c *SevenCardStudCuiController) Exec(command string) string {
 				}
 				v, err := strconv.Atoi(args[0])
 				if err != nil {
-					return i18n.Tf("sevencardstud.invalidBigBet", "val", args[0]), true
+					return invalidArg("sevencardstud.invalidBigBet", "val", args[0]), true
 				}
 				cfg := c.si.GetConfig()
 				cfg.BigBet = v
@@ -158,7 +158,7 @@ func (c *SevenCardStudCuiController) Exec(command string) string {
 				}
 				v, err := strconv.Atoi(args[0])
 				if err != nil {
-					return i18n.Tf("holdem.invalidLevelHand", "val", args[0]), true
+					return invalidArg("holdem.invalidLevelHand", "val", args[0]), true
 				}
 				cfg := c.si.GetConfig()
 				cfg.AnteLevelHands = v
@@ -169,7 +169,7 @@ func (c *SevenCardStudCuiController) Exec(command string) string {
 				}
 				v, err := strconv.Atoi(args[0])
 				if err != nil {
-					return i18n.Tf("holdem.invalidTableSize", "val", args[0]), true
+					return invalidArg("holdem.invalidTableSize", "val", args[0]), true
 				}
 				cfg := c.si.GetConfig()
 				cfg.TableSize = v
@@ -180,7 +180,7 @@ func (c *SevenCardStudCuiController) Exec(command string) string {
 				}
 				v, err := strconv.Atoi(args[0])
 				if err != nil || v < 0 || v > 1 {
-					return i18n.Tf("invalidMetaAI", "val", args[0]), true
+					return invalidArg("invalidMetaAI", "val", args[0]), true
 				}
 				cfg := c.si.GetConfig()
 				cfg.CpuMetaAI = v == 1

--- a/internal/adapter/controller/SevenCardStudCuiController_test.go
+++ b/internal/adapter/controller/SevenCardStudCuiController_test.go
@@ -487,7 +487,7 @@ func TestSevenCardStudCuiController_MetaAI_MissingArg(t *testing.T) {
 func TestSevenCardStudCuiController_MetaAI_InvalidArg(t *testing.T) {
 	mi := new(usecase.MockSevenCardStudInteractor)
 	c := NewSevenCardStudCuiController(mi)
-	assert.Equal(t, "無効な値です: abc。0 または 1 を入力してください。", c.Exec("mai abc"))
+	assert.Equal(t, invalidArg("invalidMetaAI", "val", "abc"), c.Exec("mai abc"))
 }
 
 // --- log ---

--- a/internal/adapter/controller/ShortDeckCuiController.go
+++ b/internal/adapter/controller/ShortDeckCuiController.go
@@ -93,7 +93,7 @@ func (c *ShortDeckCuiController) Exec(command string) string {
 				}
 				bl, err := strconv.Atoi(args[0])
 				if err != nil {
-					return i18n.Tf("holdem.invalidBettingLimit", "val", args[0]), true
+					return invalidArg("holdem.invalidBettingLimit", "val", args[0]), true
 				}
 				cfg := c.oi.GetConfig()
 				cfg.BettingLimit = domain.BettingLimitType(bl)
@@ -104,7 +104,7 @@ func (c *ShortDeckCuiController) Exec(command string) string {
 				}
 				v, err := strconv.Atoi(args[0])
 				if err != nil || v < 0 || v > 1 {
-					return i18n.Tf("holdem.invalidTournamentMode", "val", args[0]), true
+					return invalidArg("holdem.invalidTournamentMode", "val", args[0]), true
 				}
 				cfg := c.oi.GetConfig()
 				cfg.TournamentMode = v == 1
@@ -115,7 +115,7 @@ func (c *ShortDeckCuiController) Exec(command string) string {
 				}
 				v, err := strconv.Atoi(args[0])
 				if err != nil {
-					return i18n.Tf("holdem.invalidSmallBlind", "val", args[0]), true
+					return invalidArg("holdem.invalidSmallBlind", "val", args[0]), true
 				}
 				cfg := c.oi.GetConfig()
 				cfg.SmallBlind = v
@@ -126,7 +126,7 @@ func (c *ShortDeckCuiController) Exec(command string) string {
 				}
 				v, err := strconv.Atoi(args[0])
 				if err != nil {
-					return i18n.Tf("holdem.invalidBigBlind", "val", args[0]), true
+					return invalidArg("holdem.invalidBigBlind", "val", args[0]), true
 				}
 				cfg := c.oi.GetConfig()
 				cfg.BigBlind = v
@@ -137,7 +137,7 @@ func (c *ShortDeckCuiController) Exec(command string) string {
 				}
 				v, err := strconv.Atoi(args[0])
 				if err != nil {
-					return i18n.Tf("holdem.invalidLevelHand", "val", args[0]), true
+					return invalidArg("holdem.invalidLevelHand", "val", args[0]), true
 				}
 				cfg := c.oi.GetConfig()
 				cfg.BlindLevelHands = v
@@ -148,7 +148,7 @@ func (c *ShortDeckCuiController) Exec(command string) string {
 				}
 				v, err := strconv.Atoi(args[0])
 				if err != nil {
-					return i18n.Tf("holdem.invalidTableSize", "val", args[0]), true
+					return invalidArg("holdem.invalidTableSize", "val", args[0]), true
 				}
 				cfg := c.oi.GetConfig()
 				cfg.TableSize = v
@@ -159,7 +159,7 @@ func (c *ShortDeckCuiController) Exec(command string) string {
 				}
 				v, err := strconv.Atoi(args[0])
 				if err != nil || v < 0 || v > 1 {
-					return i18n.Tf("invalidMetaAI", "val", args[0]), true
+					return invalidArg("invalidMetaAI", "val", args[0]), true
 				}
 				cfg := c.oi.GetConfig()
 				cfg.CpuMetaAI = v == 1

--- a/internal/adapter/controller/ShortDeckCuiController_test.go
+++ b/internal/adapter/controller/ShortDeckCuiController_test.go
@@ -504,5 +504,5 @@ func TestShortDeckCuiController_MetaAI_MissingArg(t *testing.T) {
 func TestShortDeckCuiController_MetaAI_InvalidArg(t *testing.T) {
 	mi := new(usecase.MockShortDeckInteractor)
 	c := NewShortDeckCuiController(mi)
-	assert.Equal(t, "無効な値です: abc。0 または 1 を入力してください。", c.Exec("mai abc"))
+	assert.Equal(t, invalidArg("invalidMetaAI", "val", "abc"), c.Exec("mai abc"))
 }

--- a/internal/adapter/controller/SirTommyCuiController.go
+++ b/internal/adapter/controller/SirTommyCuiController.go
@@ -53,14 +53,14 @@ func (c *SirTommyCuiController) handleStockMove(args []string) string {
 	}
 	dest := args[0]
 	if dest != "f" && dest != "w" {
-		return i18n.Tf("sirtommy.invalidDestZone", "val", dest)
+		return invalidArg("sirtommy.invalidDestZone", "val", dest)
 	}
 	if len(args) < 2 {
 		return cuiutil.PromptRequest(i18n.T("sirtommy.promptIndex"), fmt.Sprintf("s %s {0}", dest))
 	}
 	idx, err := strconv.Atoi(args[1])
 	if err != nil {
-		return i18n.Tf("invalidIndex", "val", args[1])
+		return invalidArg("invalidIndex", "val", args[1])
 	}
 	if dest == "f" {
 		return c.ci.PlayStockToFoundation(idx)
@@ -75,14 +75,14 @@ func (c *SirTommyCuiController) handleWasteMove(args []string) string {
 	}
 	wasteIdx, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidIndex", "val", args[0])
+		return invalidArg("invalidIndex", "val", args[0])
 	}
 	if len(args) < 3 || args[1] != "f" {
 		return cuiutil.PromptRequest(i18n.T("sirtommy.promptFoundationIdx"), fmt.Sprintf("w %d f {0}", wasteIdx))
 	}
 	fIdx, err := strconv.Atoi(args[2])
 	if err != nil {
-		return i18n.Tf("invalidIndex", "val", args[2])
+		return invalidArg("invalidIndex", "val", args[2])
 	}
 	return c.ci.PlayWasteToFoundation(wasteIdx, fIdx)
 }

--- a/internal/adapter/controller/SpiderCuiController.go
+++ b/internal/adapter/controller/SpiderCuiController.go
@@ -83,7 +83,7 @@ func (c *SpiderCuiController) handleMove(args []string) string {
 	}
 	fromCol, err := strconv.Atoi(args[1])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[1])
+		return invalidArg("invalidColumn", "val", args[1])
 	}
 	if len(args) < 3 {
 		return cuiutil.PromptRequest(i18n.T("promptCardIndex"), fmt.Sprintf("m t %d {0} t", fromCol))
@@ -96,11 +96,11 @@ func (c *SpiderCuiController) handleMove(args []string) string {
 	}
 	cardIdx, err := strconv.Atoi(args[2])
 	if err != nil {
-		return i18n.Tf("invalidCardIndex", "val", args[2])
+		return invalidArg("invalidCardIndex", "val", args[2])
 	}
 	toCol, err := strconv.Atoi(args[4])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[4])
+		return invalidArg("invalidColumn", "val", args[4])
 	}
 	return c.si.MoveTableauToTableau(fromCol, cardIdx, toCol)
 }
@@ -114,18 +114,18 @@ func (c *SpiderCuiController) handleMoveShorthand(args []string) string {
 	if len(args) == 2 {
 		toCol, err := strconv.Atoi(args[1])
 		if err != nil {
-			return i18n.Tf("invalidColumn", "val", args[1])
+			return invalidArg("invalidColumn", "val", args[1])
 		}
 		return c.si.MoveTableauToTableau(fromCol, -1, toCol)
 	}
 	// m <fromCol> <cardIdx> <toCol>
 	cardIdx, err := strconv.Atoi(args[1])
 	if err != nil {
-		return i18n.Tf("invalidCardIndex", "val", args[1])
+		return invalidArg("invalidCardIndex", "val", args[1])
 	}
 	toCol, err := strconv.Atoi(args[2])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[2])
+		return invalidArg("invalidColumn", "val", args[2])
 	}
 	return c.si.MoveTableauToTableau(fromCol, cardIdx, toCol)
 }

--- a/internal/adapter/controller/SpideretteCuiController.go
+++ b/internal/adapter/controller/SpideretteCuiController.go
@@ -71,7 +71,7 @@ func (c *SpideretteCuiController) handleMove(args []string) string {
 	}
 	fromCol, err := strconv.Atoi(args[1])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[1])
+		return invalidArg("invalidColumn", "val", args[1])
 	}
 	if len(args) < 3 {
 		return cuiutil.PromptRequest(i18n.T("promptCardIndex"), fmt.Sprintf("m t %d {0} t", fromCol))
@@ -84,11 +84,11 @@ func (c *SpideretteCuiController) handleMove(args []string) string {
 	}
 	cardIdx, err := strconv.Atoi(args[2])
 	if err != nil {
-		return i18n.Tf("invalidCardIndex", "val", args[2])
+		return invalidArg("invalidCardIndex", "val", args[2])
 	}
 	toCol, err := strconv.Atoi(args[4])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[4])
+		return invalidArg("invalidColumn", "val", args[4])
 	}
 	return c.si.MoveTableauToTableau(fromCol, cardIdx, toCol)
 }
@@ -101,17 +101,17 @@ func (c *SpideretteCuiController) handleMoveShorthand(args []string) string {
 	if len(args) == 2 {
 		toCol, err := strconv.Atoi(args[1])
 		if err != nil {
-			return i18n.Tf("invalidColumn", "val", args[1])
+			return invalidArg("invalidColumn", "val", args[1])
 		}
 		return c.si.MoveTableauToTableau(fromCol, -1, toCol)
 	}
 	cardIdx, err := strconv.Atoi(args[1])
 	if err != nil {
-		return i18n.Tf("invalidCardIndex", "val", args[1])
+		return invalidArg("invalidCardIndex", "val", args[1])
 	}
 	toCol, err := strconv.Atoi(args[2])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[2])
+		return invalidArg("invalidColumn", "val", args[2])
 	}
 	return c.si.MoveTableauToTableau(fromCol, cardIdx, toCol)
 }

--- a/internal/adapter/controller/SpiteAndMaliceCuiController.go
+++ b/internal/adapter/controller/SpiteAndMaliceCuiController.go
@@ -58,14 +58,14 @@ func (c *SpiteAndMaliceCuiController) handlePlayFromHand(args []string) string {
 	}
 	handIdx, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidIndex", "val", args[0])
+		return invalidArg("invalidIndex", "val", args[0])
 	}
 	if len(args) < 2 {
 		return cuiutil.PromptRequest(i18n.T("spiteandmalice.promptFoundationIdx"), "ph "+args[0]+" {0}")
 	}
 	fIdx, err := strconv.Atoi(args[1])
 	if err != nil {
-		return i18n.Tf("invalidIndex", "val", args[1])
+		return invalidArg("invalidIndex", "val", args[1])
 	}
 	return c.si.PlayFromHand(handIdx, fIdx)
 }
@@ -76,7 +76,7 @@ func (c *SpiteAndMaliceCuiController) handlePlayFromGoal(args []string) string {
 	}
 	fIdx, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidIndex", "val", args[0])
+		return invalidArg("invalidIndex", "val", args[0])
 	}
 	return c.si.PlayFromGoal(fIdx)
 }
@@ -87,14 +87,14 @@ func (c *SpiteAndMaliceCuiController) handlePlayFromSide(args []string) string {
 	}
 	sideIdx, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidIndex", "val", args[0])
+		return invalidArg("invalidIndex", "val", args[0])
 	}
 	if len(args) < 2 {
 		return cuiutil.PromptRequest(i18n.T("spiteandmalice.promptFoundationIdx"), "ps "+args[0]+" {0}")
 	}
 	fIdx, err := strconv.Atoi(args[1])
 	if err != nil {
-		return i18n.Tf("invalidIndex", "val", args[1])
+		return invalidArg("invalidIndex", "val", args[1])
 	}
 	return c.si.PlayFromSide(sideIdx, fIdx)
 }
@@ -105,14 +105,14 @@ func (c *SpiteAndMaliceCuiController) handleDiscard(args []string) string {
 	}
 	handIdx, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidIndex", "val", args[0])
+		return invalidArg("invalidIndex", "val", args[0])
 	}
 	if len(args) < 2 {
 		return cuiutil.PromptRequest(i18n.T("spiteandmalice.promptSideIdx"), "d "+args[0]+" {0}")
 	}
 	sideIdx, err := strconv.Atoi(args[1])
 	if err != nil {
-		return i18n.Tf("invalidIndex", "val", args[1])
+		return invalidArg("invalidIndex", "val", args[1])
 	}
 	return c.si.Discard(handIdx, sideIdx)
 }

--- a/internal/adapter/controller/StreetsAndAlleysCuiController.go
+++ b/internal/adapter/controller/StreetsAndAlleysCuiController.go
@@ -45,7 +45,7 @@ func (c *StreetsAndAlleysCuiController) handleMove(args []string) string {
 	}
 	fromCol, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[0])
+		return invalidArg("invalidColumn", "val", args[0])
 	}
 	if len(args) < 2 {
 		return cuiutil.PromptRequest(i18n.T("streetsandalleys.promptToZone"), fmt.Sprintf("m %s {0}", args[0]))
@@ -55,7 +55,7 @@ func (c *StreetsAndAlleysCuiController) handleMove(args []string) string {
 	}
 	toCol, err := strconv.Atoi(args[1])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[1])
+		return invalidArg("invalidColumn", "val", args[1])
 	}
 	return c.bi.MoveTableauToTableau(fromCol, -1, toCol)
 }

--- a/internal/adapter/controller/SultanCuiController.go
+++ b/internal/adapter/controller/SultanCuiController.go
@@ -77,10 +77,10 @@ func (c *SultanCuiController) handleMove(args []string) string {
 		}
 		idx, err := strconv.Atoi(args[1])
 		if err != nil {
-			return i18n.Tf("sultan.invalidDivanIndex", "val", args[1])
+			return invalidArg("sultan.invalidDivanIndex", "val", args[1])
 		}
 		return c.si.MoveDivanToFoundation(idx)
 	default:
-		return i18n.Tf("sultan.invalidFromZone", "val", from)
+		return invalidArg("sultan.invalidFromZone", "val", from)
 	}
 }

--- a/internal/adapter/controller/TerraceCuiController.go
+++ b/internal/adapter/controller/TerraceCuiController.go
@@ -67,7 +67,7 @@ func (c *TerraceCuiController) handleMove(args []string) string {
 	case "t":
 		return c.handleMoveFromTableau(args[1:])
 	default:
-		return i18n.Tf("terrace.invalidFromZone", "val", args[0])
+		return invalidArg("terrace.invalidFromZone", "val", args[0])
 	}
 }
 
@@ -95,11 +95,11 @@ func (c *TerraceCuiController) handleMoveFromWaste(args []string) string {
 		}
 		pile, err := strconv.Atoi(args[1])
 		if err != nil {
-			return i18n.Tf("terrace.invalidPile", "val", args[1])
+			return invalidArg("terrace.invalidPile", "val", args[1])
 		}
 		return c.ti.MoveWasteToTableau(pile)
 	default:
-		return i18n.Tf("terrace.invalidToZone", "val", args[0])
+		return invalidArg("terrace.invalidToZone", "val", args[0])
 	}
 }
 
@@ -109,7 +109,7 @@ func (c *TerraceCuiController) handleMoveFromTableau(args []string) string {
 	}
 	fromPile, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("terrace.invalidPile", "val", args[0])
+		return invalidArg("terrace.invalidPile", "val", args[0])
 	}
 	if len(args) < 2 {
 		return cuiutil.PromptRequest(i18n.T("terrace.promptToZone"), fmt.Sprintf("m t %s {0}", args[0]))
@@ -123,10 +123,10 @@ func (c *TerraceCuiController) handleMoveFromTableau(args []string) string {
 		}
 		toPile, err := strconv.Atoi(args[2])
 		if err != nil {
-			return i18n.Tf("terrace.invalidPile", "val", args[2])
+			return invalidArg("terrace.invalidPile", "val", args[2])
 		}
 		return c.ti.MoveTableauToTableau(fromPile, toPile)
 	default:
-		return i18n.Tf("terrace.invalidToZone", "val", args[1])
+		return invalidArg("terrace.invalidToZone", "val", args[1])
 	}
 }

--- a/internal/adapter/controller/TerraceCuiController.go
+++ b/internal/adapter/controller/TerraceCuiController.go
@@ -77,7 +77,7 @@ func (c *TerraceCuiController) handleMoveFromReserve(args []string) string {
 		return cuiutil.PromptRequest(i18n.T("terrace.promptReserveTo"), "m r {0}")
 	}
 	if args[0] != "f" {
-		return i18n.Tf("terrace.reserveOnlyToFoundation", "val", args[0])
+		return invalidArg("terrace.reserveOnlyToFoundation", "val", args[0])
 	}
 	return c.ti.MoveReserveToFoundation()
 }

--- a/internal/adapter/controller/TerraceCuiController_test.go
+++ b/internal/adapter/controller/TerraceCuiController_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	mockusecase "github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/usecase"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func newMockTerraceInteractor() *mockusecase.MockTerraceInteractor {
@@ -53,9 +54,18 @@ func TestTerraceCuiControllerMoves(t *testing.T) {
 
 	// The terrace has exactly one destination, so a tableau target is refused
 	// rather than quietly reinterpreted.
+	//
+	// The refusal is asserted through i18n rather than with Contains(out, "t"),
+	// which the previous version used: every rendering of every message in this
+	// package contains a "t", so it held whether the command was refused or run.
 	t.Run("rejects the terrace to a pile", func(t *testing.T) {
 		c := NewTerraceCuiController(newMockTerraceInteractor())
-		assert.Contains(t, c.Exec("m r t 2"), "t")
+
+		out := c.Exec("m r t 2")
+
+		body, isErr := i18n.StripErrorPrefix(out)
+		assert.True(t, isErr, "a refused destination must be marked as an error")
+		assert.Equal(t, i18n.Tf("terrace.reserveOnlyToFoundation", "val", "t"), body)
 	})
 
 	t.Run("waste to a foundation", func(t *testing.T) {

--- a/internal/adapter/controller/TrashCuiController.go
+++ b/internal/adapter/controller/TrashCuiController.go
@@ -50,7 +50,7 @@ func (c *TrashCuiController) handlePlace(args []string) string {
 	}
 	pos, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidIndex", "val", args[0])
+		return invalidArg("invalidIndex", "val", args[0])
 	}
 	return c.ti.PlaceWild(pos)
 }

--- a/internal/adapter/controller/WaspCuiController.go
+++ b/internal/adapter/controller/WaspCuiController.go
@@ -74,7 +74,7 @@ func (c *WaspCuiController) handleMove(args []string) string {
 	}
 	fromCol, err := strconv.Atoi(args[1])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[1])
+		return invalidArg("invalidColumn", "val", args[1])
 	}
 	if len(args) < 3 {
 		return cuiutil.PromptRequest(i18n.T("wasp.promptCardIndex"), fmt.Sprintf("m t %d {0} t", fromCol))
@@ -87,11 +87,11 @@ func (c *WaspCuiController) handleMove(args []string) string {
 	}
 	cardIdx, err := strconv.Atoi(args[2])
 	if err != nil {
-		return i18n.Tf("invalidCardIndex", "val", args[2])
+		return invalidArg("invalidCardIndex", "val", args[2])
 	}
 	toCol, err := strconv.Atoi(args[4])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[4])
+		return invalidArg("invalidColumn", "val", args[4])
 	}
 	return c.si.MoveTableauToTableau(fromCol, cardIdx, toCol)
 }
@@ -105,7 +105,7 @@ func (c *WaspCuiController) handleLegal(args []string) string {
 	}
 	col, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[0])
+		return invalidArg("invalidColumn", "val", args[0])
 	}
 	return c.si.LegalMoves(col)
 }
@@ -118,17 +118,17 @@ func (c *WaspCuiController) handleMoveShorthand(args []string) string {
 	if len(args) == 2 {
 		toCol, err := strconv.Atoi(args[1])
 		if err != nil {
-			return i18n.Tf("invalidColumn", "val", args[1])
+			return invalidArg("invalidColumn", "val", args[1])
 		}
 		return c.si.MoveTableauToTableau(fromCol, -1, toCol)
 	}
 	cardIdx, err := strconv.Atoi(args[1])
 	if err != nil {
-		return i18n.Tf("invalidCardIndex", "val", args[1])
+		return invalidArg("invalidCardIndex", "val", args[1])
 	}
 	toCol, err := strconv.Atoi(args[2])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[2])
+		return invalidArg("invalidColumn", "val", args[2])
 	}
 	return c.si.MoveTableauToTableau(fromCol, cardIdx, toCol)
 }

--- a/internal/adapter/controller/WindmillCuiController.go
+++ b/internal/adapter/controller/WindmillCuiController.go
@@ -67,7 +67,7 @@ func (c *WindmillCuiController) handleMove(args []string) string {
 	case "k":
 		return c.handleMoveFromCorner(args[1:])
 	default:
-		return i18n.Tf("windmill.invalidFromZone", "val", args[0])
+		return invalidArg("windmill.invalidFromZone", "val", args[0])
 	}
 }
 
@@ -77,7 +77,7 @@ func (c *WindmillCuiController) handleMoveFromSail(args []string) string {
 	}
 	sail, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("windmill.invalidSailIdx", "val", args[0])
+		return invalidArg("windmill.invalidSailIdx", "val", args[0])
 	}
 	if len(args) < 2 {
 		return cuiutil.PromptRequest(i18n.T("windmill.promptToZone"), fmt.Sprintf("m s %s {0}", args[0]))
@@ -91,11 +91,11 @@ func (c *WindmillCuiController) handleMoveFromSail(args []string) string {
 		}
 		corner, err := strconv.Atoi(args[2])
 		if err != nil {
-			return i18n.Tf("windmill.invalidCornerIdx", "val", args[2])
+			return invalidArg("windmill.invalidCornerIdx", "val", args[2])
 		}
 		return c.wi.MoveSailToCorner(sail, corner)
 	default:
-		return i18n.Tf("windmill.invalidToZone", "val", args[1])
+		return invalidArg("windmill.invalidToZone", "val", args[1])
 	}
 }
 
@@ -112,11 +112,11 @@ func (c *WindmillCuiController) handleMoveFromWaste(args []string) string {
 		}
 		corner, err := strconv.Atoi(args[1])
 		if err != nil {
-			return i18n.Tf("windmill.invalidCornerIdx", "val", args[1])
+			return invalidArg("windmill.invalidCornerIdx", "val", args[1])
 		}
 		return c.wi.MoveWasteToCorner(corner)
 	default:
-		return i18n.Tf("windmill.invalidToZone", "val", args[0])
+		return invalidArg("windmill.invalidToZone", "val", args[0])
 	}
 }
 
@@ -128,13 +128,13 @@ func (c *WindmillCuiController) handleMoveFromCorner(args []string) string {
 	}
 	corner, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("windmill.invalidCornerIdx", "val", args[0])
+		return invalidArg("windmill.invalidCornerIdx", "val", args[0])
 	}
 	if len(args) < 2 {
 		return cuiutil.PromptRequest(i18n.T("windmill.promptToZone"), fmt.Sprintf("m k %s {0}", args[0]))
 	}
 	if args[1] != "c" {
-		return i18n.Tf("windmill.invalidToZone", "val", args[1])
+		return invalidArg("windmill.invalidToZone", "val", args[1])
 	}
 	return c.wi.MoveCornerToCenter(corner)
 }

--- a/internal/adapter/controller/YukonCuiController.go
+++ b/internal/adapter/controller/YukonCuiController.go
@@ -59,7 +59,7 @@ func (c *YukonCuiController) handleMove(args []string) string {
 
 	from := args[0]
 	if from != "t" {
-		return i18n.Tf("yukon.invalidFromZone", "val", from)
+		return invalidArg("yukon.invalidFromZone", "val", from)
 	}
 
 	if len(args) < 2 {
@@ -78,7 +78,7 @@ func (c *YukonCuiController) handleMoveFromTableau(args []string) string {
 	}
 	fromCol, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[0])
+		return invalidArg("invalidColumn", "val", args[0])
 	}
 
 	if args[1] == "f" {
@@ -95,12 +95,12 @@ func (c *YukonCuiController) handleMoveFromTableau(args []string) string {
 
 	cardIdx, err := strconv.Atoi(args[1])
 	if err != nil {
-		return i18n.Tf("invalidCardIndex", "val", args[1])
+		return invalidArg("invalidCardIndex", "val", args[1])
 	}
 
 	toCol, err := strconv.Atoi(args[3])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[3])
+		return invalidArg("invalidColumn", "val", args[3])
 	}
 
 	return c.yi.MoveTableauToTableau(fromCol, cardIdx, toCol)
@@ -113,7 +113,7 @@ func (c *YukonCuiController) handleMoveShorthand(args []string) string {
 	}
 	toCol, err := strconv.Atoi(args[1])
 	if err != nil {
-		return i18n.Tf("invalidColumn", "val", args[1])
+		return invalidArg("invalidColumn", "val", args[1])
 	}
 	return c.yi.MoveTableauToTableau(fromCol, -1, toCol)
 }

--- a/internal/adapter/controller/cui_error_helper.go
+++ b/internal/adapter/controller/cui_error_helper.go
@@ -8,10 +8,12 @@ import "github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 // The marker is not decoration. Without it a rejection is byte-for-byte an
 // ordinary reply, so nothing downstream -- the CUI's own error styling, or a
 // test executing a documented example -- can tell "the game refused this" from
-// "the game did this". Measured on 2026-08-15, 2 of the 291 games with an
-// argument-taking command marked such a rejection; the other 289 returned a
-// perfectly good message (or, for 27 of them, nothing but a redrawn board)
-// that read as success. See issue #5377.
+// "the game did this".
+//
+// Measured on 2026-08-15 by giving a malformed argument to every one of the 638
+// argument-taking commands in the help tables, on a freshly dealt game: 4 came
+// back marked. The rest returned a perfectly good message that read as success,
+// or (27 commands) nothing but a redrawn board. See issue #5377.
 //
 // The signature deliberately mirrors i18n.Tf so the call sites differ only in
 // the function name.

--- a/internal/adapter/controller/cui_error_helper.go
+++ b/internal/adapter/controller/cui_error_helper.go
@@ -1,0 +1,20 @@
+package controller
+
+import "github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
+
+// invalidArg renders a rejected-argument message with the error marker that
+// unknownCommandMessage already applies.
+//
+// The marker is not decoration. Without it a rejection is byte-for-byte an
+// ordinary reply, so nothing downstream -- the CUI's own error styling, or a
+// test executing a documented example -- can tell "the game refused this" from
+// "the game did this". Measured on 2026-08-15, 2 of the 291 games with an
+// argument-taking command marked such a rejection; the other 289 returned a
+// perfectly good message (or, for 27 of them, nothing but a redrawn board)
+// that read as success. See issue #5377.
+//
+// The signature deliberately mirrors i18n.Tf so the call sites differ only in
+// the function name.
+func invalidArg(key string, params ...string) string {
+	return i18n.MarkError(i18n.Tf(key, params...))
+}

--- a/internal/adapter/controller/cui_error_helper_test.go
+++ b/internal/adapter/controller/cui_error_helper_test.go
@@ -1,0 +1,35 @@
+//go:build test
+
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
+)
+
+// TestInvalidArgMarksTheMessage pins what invalidArg adds, because the tests of
+// the individual controllers now spell their expectations with invalidArg too.
+// That keeps them tied to production, but on its own it would also pass if
+// invalidArg stopped marking anything -- so the marking is asserted here
+// against i18n directly, not against invalidArg.
+func TestInvalidArgMarksTheMessage(t *testing.T) {
+	got := invalidArg("invalidIndex", "val", "zz")
+
+	body, isErr := i18n.StripErrorPrefix(got)
+	assert.True(t, isErr, "invalidArg must mark its message as an error")
+	assert.Equal(t, i18n.Tf("invalidIndex", "val", "zz"), body,
+		"stripping the marker must give back exactly the i18n text")
+	assert.NotEqual(t, i18n.Tf("invalidIndex", "val", "zz"), got,
+		"an unmarked message is indistinguishable from an accepted command")
+}
+
+// TestInvalidArgForwardsParams guards the variadic hand-off: a signature change
+// that dropped the params would still produce a marked string, and every
+// controller test comparing invalidArg against invalidArg would still pass.
+func TestInvalidArgForwardsParams(t *testing.T) {
+	body, _ := i18n.StripErrorPrefix(invalidArg("invalidIndex", "val", "sentinel-42"))
+	assert.Contains(t, body, "sentinel-42")
+}


### PR DESCRIPTION
## 問題

拒否された引数の応答が、**成功した応答とバイト単位で見分けが付きません**。

```
holdem   b abc         -> "Invalid amount: abc"
klondike m t 0 z       -> "Invalid to zone: z. Use 'f' (foundation) or 't' (tableau)."
ginrummy d zznotanumber-> "Invalid card index: zznotanumber"
```

メッセージ自体は具体的で親切です。問題は、これらが `unknownCommandMessage` と違って `i18n.MarkError` を通っていないこと。印が無いので、下流（CUI のエラー表示、および文書化された例文を実行する #5376 のガード）は「ゲームが拒否した」と「ゲームがそう動いた」を区別できません。

**計測**: ヘルプのコマンド表にある引数つきコマンド 638 件すべてに、配った直後の盤面で不正な引数を与えたところ、印付きで返ったのは **4 件**でした。

## 変更

`invalidArg` を追加し、`i18n.Tf` の署名をそのまま写しています。

```go
func invalidArg(key string, params ...string) string {
	return i18n.MarkError(i18n.Tf(key, params...))
}
```

署名が同じなので、**338 箇所の呼び出しは関数名だけが変わります**。置換は compute → validate → write で、以下が全部揃わなければ 1 バイトも書きません。

- 対象箇所数が事前に数えた値と一致すること（177 / 151 / 10 の 3 回に分けて実施）
- 置換後に旧パターンが 0 件であること
- ファイルごとのバイト増分が **ちょうど 3 × 箇所数**（`i18n.Tf("` 9 文字 → `invalidArg("` 12 文字）であること

最後の条件は最初、不等号の向きを取り違えて書いていました（短くなると思っていた）。**アサートが書き込みを止めた**ので、間違った変換が入らずに済んでいます。

## 効果

| | 印付き | 印なし |
|---|---|---|
| Before | 4 | 634 |
| After | **206** | 432 |

（638 = ヘルプのコマンド表にある引数つきコマンドの総数）

残る 432 件は、本スイープが拾わないゲーム個別のメッセージキーで拒否しているか、**27 件は盤面を再描画するだけでメッセージ自体がありません**。どちらも #5377 に残しています。

## テストについて

この変更で 17 のコントローラテストが落ちました。**すべて拒否メッセージの完全一致アサート**で、それ以外は 1 件も落ちていません。変更が意図した経路にだけ届いたことの確認になっています。

期待値は `invalidArg(...)` に揃えました。ただしそれだけだと `invalidArg` が印を付けるのをやめても全部通ってしまう circular なテストになるので、`cui_error_helper_test.go` で **i18n に対して直接**次を検証しています。

- `StripErrorPrefix` が `isError=true` を返すこと
- 印を剥がすと `i18n.Tf` の文言に**完全一致**すること
- 印付きの文字列が素の文言と**一致しない**こと（印が付いていないと受理と区別が付かない、という本 PR の主張そのもの）
- 可変長引数が転送されること（署名が壊れても「印付きの文字列」は返るため、`invalidArg` 同士の比較では検出できない）

6 件のテストは i18n キーではなく日本語のリテラルを直書きしていたので、そちらも i18n 経由に直しました。

## 検証

- `go build ./...` — 通過
- `go vet -tags test ./internal/...` — 警告なし
- `go test -tags test ./internal/...` — 全緑
- `golangci-lint run ./internal/adapter/controller/...` — 0 issues
- 前後の印付き件数を実測（4 → 206）

Refs #5377
