### PR TITLE
fix(cui): translate the 58 help lines that rendered as raw i18n keys

### DIFF
--- a/internal/i18n/locales/en/bezique.json
+++ b/internal/i18n/locales/en/bezique.json
@@ -39,5 +39,10 @@
   "suitSpade": "Spades",
   "suitClover": "Clubs",
   "suitHeart": "Hearts",
-  "suitDiamond": "Diamonds"
+  "suitDiamond": "Diamonds",
+  "helpPlay": "  p <idx>              play hand card idx",
+  "helpMeld": "  m <idx>              declare meld idx (trick winner only)",
+  "helpSkip": "  s                    skip the meld",
+  "helpNext": "  n                    go to the next trick or deal",
+  "helpSetDifficulty": "  sd [0-2]             CPU difficulty (0=Easy, 1=Normal, 2=Hard)"
 }

--- a/internal/i18n/locales/en/courtpiece.json
+++ b/internal/i18n/locales/en/courtpiece.json
@@ -1,0 +1,8 @@
+{
+  "helpTitle": "Court Piece",
+  "helpTrump": "  t <1-4>              call trump (1=S 2=C 3=H 4=D)",
+  "helpPlay": "  p <idx>              play a card",
+  "helpNext": "  n                    go to next trick",
+  "helpNextRound": "  nr                   go to next round",
+  "helpSetDifficulty": "  sd [0-2]             CPU difficulty (0=Easy, 1=Normal, 2=Hard)"
+}

--- a/internal/i18n/locales/en/ecarte.json
+++ b/internal/i18n/locales/en/ecarte.json
@@ -35,5 +35,11 @@
   "suitSpade": "Spades",
   "suitClover": "Clubs",
   "suitHeart": "Hearts",
-  "suitDiamond": "Diamonds"
+  "suitDiamond": "Diamonds",
+  "helpPropose": "  pr                   propose an exchange (elder)",
+  "helpStand": "  st                   play without exchanging (elder)",
+  "helpDiscard": "  d <i j k>            discard the given cards and redraw",
+  "helpPlay": "  p <idx>              play a card",
+  "helpNext": "  n                    go to the next trick or deal",
+  "helpSetDifficulty": "  sd [0-2]             CPU difficulty (0=Easy, 1=Normal, 2=Hard)"
 }

--- a/internal/i18n/locales/en/ganjifa.json
+++ b/internal/i18n/locales/en/ganjifa.json
@@ -21,5 +21,9 @@
   "roundEndTrickEntry": "{{name}} {{tricks}}",
   "roundEndTricks": "Tricks per player: {{list}}",
   "trumpGroupStrong": "Trump is a strong suit — higher numbers win",
-  "trumpGroupWeak": "Trump is a weak suit — lower numbers win"
+  "trumpGroupWeak": "Trump is a weak suit — lower numbers win",
+  "helpPlay": "  play <idx>           play a card",
+  "helpNext": "  n                    go to next trick",
+  "helpNextRound": "  nr                   go to next round",
+  "helpSetDifficulty": "  sd [0-2]             CPU difficulty (0=Easy, 1=Normal, 2=Hard)"
 }

--- a/internal/i18n/locales/en/pitch.json
+++ b/internal/i18n/locales/en/pitch.json
@@ -23,5 +23,11 @@
   "hintReasonTrumpCut": "cut with trump",
   "hintReasonBidStrong": "bid with a strong hand",
   "hintReasonBidPass": "pass with a weak hand",
-  "handPips": "Game pips in hand: {{total}} ({{breakdown}})"
+  "handPips": "Game pips in hand: {{total}} ({{breakdown}})",
+  "helpBid": "  b <n>                bid (0=pass, 2-4)",
+  "helpPlay": "  p <idx>              play a card",
+  "helpNext": "  n                    go to next trick",
+  "helpNextRound": "  nr                   score the round and go to the next one",
+  "helpSetDifficulty": "  sd [0-2]             CPU difficulty (0=Easy, 1=Normal, 2=Hard)",
+  "helpSetLimit": "  sl <n>               point limit"
 }

--- a/internal/i18n/locales/en/sevencardstudhilo.json
+++ b/internal/i18n/locales/en/sevencardstudhilo.json
@@ -1,0 +1,3 @@
+{
+  "helpTitle": "Seven Card Stud Hi-Lo"
+}

--- a/internal/i18n/locales/en/tarneeb.json
+++ b/internal/i18n/locales/en/tarneeb.json
@@ -1,0 +1,11 @@
+{
+  "helpTitle": "Tarneeb",
+  "helpBid": "  b <n>                bid (0=pass, 7-13)",
+  "helpTrump": "  t <1-4>              call trump (1=S 2=C 3=H 4=D)",
+  "helpPlay": "  p <idx>              play a card",
+  "helpNext": "  n                    go to next trick",
+  "helpNextRound": "  nr                   score the round and go to the next one",
+  "helpSetDifficulty": "  sd [0-2]             CPU difficulty (0=Easy, 1=Normal, 2=Hard)",
+  "helpSetLimit": "  sl <n>               target score",
+  "helpSetMinBid": "  sm <1-13>            minimum bid"
+}

--- a/internal/i18n/locales/en/teenpatti.json
+++ b/internal/i18n/locales/en/teenpatti.json
@@ -23,5 +23,13 @@
   "hintReasonSeeFirst": "see your hand first",
   "hintReasonStrongHand": "strong hand",
   "hintReasonMediumHand": "decent hand",
-  "hintReasonWeakHand": "weak hand"
+  "hintReasonWeakHand": "weak hand",
+  "helpSee": "  s                    look at your hand and become seen (while blind)",
+  "helpBet": "  b                    call the current stake",
+  "helpRaise": "  rs <n>               raise the stake and call",
+  "helpFold": "  f                    fold",
+  "helpShow": "  sh                   call a showdown (two players left)",
+  "helpSideShow": "  ss                   ask the previous player for a side show",
+  "helpNext": "  n                    go to the next deal",
+  "helpSetDifficulty": "  sd [0-2]             CPU difficulty (0=Easy, 1=Normal, 2=Hard)"
 }

--- a/internal/i18n/locales/en/threecardbrag.json
+++ b/internal/i18n/locales/en/threecardbrag.json
@@ -20,5 +20,12 @@
   "hintReasonSeeFirst": "see your hand first",
   "hintReasonStrongHand": "strong hand",
   "hintReasonMediumHand": "decent hand",
-  "hintReasonWeakHand": "weak hand"
+  "hintReasonWeakHand": "weak hand",
+  "helpSee": "  s                    look at your hand and become seen (while blind)",
+  "helpBet": "  b                    call the current stake",
+  "helpRaise": "  rs <n>               raise the stake and call",
+  "helpFold": "  f                    fold",
+  "helpShow": "  sh                   call a showdown (two players left)",
+  "helpNext": "  n                    go to the next deal",
+  "helpSetDifficulty": "  sd [0-2]             CPU difficulty (0=Easy, 1=Normal, 2=Hard)"
 }

--- a/internal/i18n/locales/en/vira.json
+++ b/internal/i18n/locales/en/vira.json
@@ -33,5 +33,11 @@
   "roleDefender": "Defender",
   "round": "Round: {{round}}  Trick: {{trick}}  Trump: {{trump}}",
   "roundEndTrickEntry": "{{name}} {{tricks}}",
-  "roundEndTricks": "Tricks per player: {{list}}"
+  "roundEndTricks": "Tricks per player: {{list}}",
+  "helpBid": "  b <0-4>              bid (0=pass, 1=Gask, 2=Solo, 3=Misere, 4=Vira)",
+  "helpPass": "  pass                 pass (same as bid 0)",
+  "helpPlay": "  play <idx>           play a card",
+  "helpNext": "  n                    go to next trick",
+  "helpNextRound": "  nr                   go to next round",
+  "helpSetDifficulty": "  sd [0-2]             CPU difficulty (0=Easy, 1=Normal, 2=Hard)"
 }

--- a/internal/i18n/locales/ja/bezique.json
+++ b/internal/i18n/locales/ja/bezique.json
@@ -39,5 +39,10 @@
   "suitSpade": "スペード",
   "suitClover": "クラブ",
   "suitHeart": "ハート",
-  "suitDiamond": "ダイヤ"
+  "suitDiamond": "ダイヤ",
+  "helpPlay": "  p <idx>              手札の idx 番のカードを出す",
+  "helpMeld": "  m <idx>              一覧 idx 番のメルドを宣言 (トリックの勝者のみ)",
+  "helpSkip": "  s                    メルドを宣言しない",
+  "helpNext": "  n                    次のトリック／ディールへ",
+  "helpSetDifficulty": "  sd [0-2]             CPU難易度 (0=Easy, 1=Normal, 2=Hard)"
 }

--- a/internal/i18n/locales/ja/courtpiece.json
+++ b/internal/i18n/locales/ja/courtpiece.json
@@ -1,0 +1,8 @@
+{
+  "helpTitle": "コートピース (Court Piece)",
+  "helpTrump": "  t <1-4>              切り札を宣言 (1=♠ 2=♣ 3=♥ 4=♦)",
+  "helpPlay": "  p <idx>              カードを出す",
+  "helpNext": "  n                    次のトリックへ",
+  "helpNextRound": "  nr                   次のラウンドへ",
+  "helpSetDifficulty": "  sd [0-2]             CPU難易度 (0=Easy, 1=Normal, 2=Hard)"
+}

--- a/internal/i18n/locales/ja/ecarte.json
+++ b/internal/i18n/locales/ja/ecarte.json
@@ -35,5 +35,11 @@
   "suitSpade": "スペード",
   "suitClover": "クラブ",
   "suitHeart": "ハート",
-  "suitDiamond": "ダイヤ"
+  "suitDiamond": "ダイヤ",
+  "helpPropose": "  pr                   交換を提案する (エルダー)",
+  "helpStand": "  st                   交換せず勝負する (エルダー)",
+  "helpDiscard": "  d <i j k>            指定した札を捨てて引き直す",
+  "helpPlay": "  p <idx>              カードを出す",
+  "helpNext": "  n                    次のトリック／ディールへ",
+  "helpSetDifficulty": "  sd [0-2]             CPU難易度 (0=Easy, 1=Normal, 2=Hard)"
 }

--- a/internal/i18n/locales/ja/ganjifa.json
+++ b/internal/i18n/locales/ja/ganjifa.json
@@ -21,5 +21,9 @@
   "roundEndTrickEntry": "{{name}} {{tricks}}",
   "roundEndTricks": "各プレイヤーのトリック数: {{list}}",
   "trumpGroupStrong": "切り札は強い群 — 数字が大きいほど強い",
-  "trumpGroupWeak": "切り札は弱い群 — 数字が小さいほど強い"
+  "trumpGroupWeak": "切り札は弱い群 — 数字が小さいほど強い",
+  "helpPlay": "  play <idx>           カードを出す",
+  "helpNext": "  n                    次のトリックへ",
+  "helpNextRound": "  nr                   次のラウンドへ",
+  "helpSetDifficulty": "  sd [0-2]             CPU難易度 (0=Easy, 1=Normal, 2=Hard)"
 }

--- a/internal/i18n/locales/ja/pitch.json
+++ b/internal/i18n/locales/ja/pitch.json
@@ -23,5 +23,11 @@
   "hintReasonTrumpCut": "トランプでカット",
   "hintReasonBidStrong": "強い手札なので入札",
   "hintReasonBidPass": "弱い手札なのでパス",
-  "handPips": "手札のゲーム得点: {{total}} ({{breakdown}})"
+  "handPips": "手札のゲーム得点: {{total}} ({{breakdown}})",
+  "helpBid": "  b <n>                ビッドを宣言 (0=Pass, 2-4)",
+  "helpPlay": "  p <idx>              カードを出す",
+  "helpNext": "  n                    次のトリックへ",
+  "helpNextRound": "  nr                   ラウンドを集計して次のラウンドへ",
+  "helpSetDifficulty": "  sd [0-2]             CPU難易度 (0=Easy, 1=Normal, 2=Hard)",
+  "helpSetLimit": "  sl <n>               ポイント上限"
 }

--- a/internal/i18n/locales/ja/sevencardstudhilo.json
+++ b/internal/i18n/locales/ja/sevencardstudhilo.json
@@ -1,0 +1,3 @@
+{
+  "helpTitle": "セブンカードスタッド ハイロー (Seven Card Stud Hi-Lo)"
+}

--- a/internal/i18n/locales/ja/tarneeb.json
+++ b/internal/i18n/locales/ja/tarneeb.json
@@ -1,0 +1,11 @@
+{
+  "helpTitle": "タルニーブ (Tarneeb)",
+  "helpBid": "  b <n>                ビッドを宣言 (0=Pass, 7-13)",
+  "helpTrump": "  t <1-4>              切り札を宣言 (1=♠ 2=♣ 3=♥ 4=♦)",
+  "helpPlay": "  p <idx>              カードを出す",
+  "helpNext": "  n                    次のトリックへ",
+  "helpNextRound": "  nr                   ラウンドを集計して次のラウンドへ",
+  "helpSetDifficulty": "  sd [0-2]             CPU難易度 (0=Easy, 1=Normal, 2=Hard)",
+  "helpSetLimit": "  sl <n>               目標点",
+  "helpSetMinBid": "  sm <1-13>            最低ビッド"
+}

--- a/internal/i18n/locales/ja/teenpatti.json
+++ b/internal/i18n/locales/ja/teenpatti.json
@@ -23,5 +23,13 @@
   "hintReasonSeeFirst": "まず手札を見ましょう",
   "hintReasonStrongHand": "強い手です",
   "hintReasonMediumHand": "そこそこの手です",
-  "hintReasonWeakHand": "弱い手です"
+  "hintReasonWeakHand": "弱い手です",
+  "helpSee": "  s                    手札を見てシーンになる (ブラインド時)",
+  "helpBet": "  b                    現在のステークにコールする",
+  "helpRaise": "  rs <n>               ステークを上げてコールする",
+  "helpFold": "  f                    降りる",
+  "helpShow": "  sh                   ショーダウンを要求する (残り2人)",
+  "helpSideShow": "  ss                   サイドショーを申請する",
+  "helpNext": "  n                    次のディールへ",
+  "helpSetDifficulty": "  sd [0-2]             CPU難易度 (0=Easy, 1=Normal, 2=Hard)"
 }

--- a/internal/i18n/locales/ja/threecardbrag.json
+++ b/internal/i18n/locales/ja/threecardbrag.json
@@ -20,5 +20,12 @@
   "hintReasonSeeFirst": "まず手札を見ましょう",
   "hintReasonStrongHand": "強い手です",
   "hintReasonMediumHand": "そこそこの手です",
-  "hintReasonWeakHand": "弱い手です"
+  "hintReasonWeakHand": "弱い手です",
+  "helpSee": "  s                    手札を見てシーンになる (ブラインド時)",
+  "helpBet": "  b                    現在のステークにコールする",
+  "helpRaise": "  rs <n>               ステークを上げてコールする",
+  "helpFold": "  f                    降りる",
+  "helpShow": "  sh                   ショーダウンを要求する (残り2人)",
+  "helpNext": "  n                    次のディールへ",
+  "helpSetDifficulty": "  sd [0-2]             CPU難易度 (0=Easy, 1=Normal, 2=Hard)"
 }

--- a/internal/i18n/locales/ja/vira.json
+++ b/internal/i18n/locales/ja/vira.json
@@ -33,5 +33,11 @@
   "roleDefender": "ディフェンダー",
   "round": "ラウンド: {{round}}  トリック: {{trick}}  切り札: {{trump}}",
   "roundEndTrickEntry": "{{name}} {{tricks}}",
-  "roundEndTricks": "各プレイヤーのトリック数: {{list}}"
+  "roundEndTricks": "各プレイヤーのトリック数: {{list}}",
+  "helpBid": "  b <0-4>              入札 (0=Pass, 1=Gask, 2=Solo, 3=Misère, 4=Vira)",
+  "helpPass": "  pass                 パス (bid 0 と同じ)",
+  "helpPlay": "  play <idx>           カードを出す",
+  "helpNext": "  n                    次のトリックへ",
+  "helpNextRound": "  nr                   次のラウンドへ",
+  "helpSetDifficulty": "  sd [0-2]             CPU難易度 (0=Easy, 1=Normal, 2=Hard)"
 }

--- a/internal/infrastructure/ui/help_table_test.go
+++ b/internal/infrastructure/ui/help_table_test.go
@@ -1,0 +1,137 @@
+//go:build test
+
+package ui
+
+import (
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
+)
+
+// helpRawKeyRe matches a help line that is nothing but an i18n key, which is
+// what i18n.T returns when the key has no translation.
+var helpRawKeyRe = regexp.MustCompile(`^[a-z0-9]+\.[a-zA-Z][a-zA-Z0-9]*$`)
+
+// TestCuiHelpRendersNoRawKeys fails when a game's help shows an untranslated
+// key instead of a command row.
+//
+// Ten games shipped this way: bezique, courtpiece, ecarte, ganjifa, pitch,
+// sevencardstudhilo, tarneeb, teenpatti, threecardbrag and vira rendered 58
+// lines that read `vira.helpBid`, `pitch.helpPlay` and so on -- their whole
+// command table was unreadable, in both languages, and `tarneeb` had no locale
+// file at all. Nothing caught it: the parity checker compares ja against en, and
+// these were missing from both, so the two agreed perfectly.
+func TestCuiHelpRendersNoRawKeys(t *testing.T) {
+	registry := GameRegistry()
+	if len(registry) < 300 {
+		t.Fatalf("only %d games in the registry -- the walk broke", len(registry))
+	}
+
+	original := i18n.Lang()
+	t.Cleanup(func() { i18n.SetLang(original) })
+
+	checked := 0
+	var bad []string
+	for _, lang := range []string{"ja", "en"} {
+		i18n.SetLang(lang)
+		for _, entry := range registry {
+			for _, line := range entry.NewCui().HelpLines() {
+				checked++
+				if s := strings.TrimSpace(line); helpRawKeyRe.MatchString(s) {
+					bad = append(bad, lang+"/"+entry.Name+": "+s)
+				}
+			}
+		}
+	}
+	if checked < 300 {
+		t.Fatalf("only %d help lines were read -- the walk broke", checked)
+	}
+	sort.Strings(bad)
+	if len(bad) > 0 {
+		t.Errorf("help lines rendering an untranslated i18n key (%d of %d lines):\n  %s",
+			len(bad), checked, strings.Join(bad, "\n  "))
+	}
+}
+
+// TestCuiHelpRawKeyPatternMatchesAKey pins the pattern, because a regex that
+// stopped matching would make the guard above report zero for every possible
+// state of the locale files.
+func TestCuiHelpRawKeyPatternMatchesAKey(t *testing.T) {
+	for _, s := range []string{"vira.helpBid", "pitch.helpPlay", "tarneeb.helpTitle"} {
+		if !helpRawKeyRe.MatchString(s) {
+			t.Errorf("%q should look like an untranslated key", s)
+		}
+	}
+	for _, s := range []string{"b <n>", "bid (0=pass, 7-13)", "Tarneeb", "スエカ (Sueca)", ""} {
+		if helpRawKeyRe.MatchString(s) {
+			t.Errorf("%q should NOT look like an untranslated key", s)
+		}
+	}
+}
+
+// helpVerbIsUnknown reports whether ctrl answered `verb` with its
+// unknown-command message rather than dispatching it.
+func helpVerbIsUnknown(out, verb string) bool {
+	body, _ := i18n.StripErrorPrefix(out)
+	full := i18n.Tf("unknownCommand", "cmd", verb)
+	// The suggestion variant appends to the same prefix, so match on the head
+	// rather than the whole string.
+	head := strings.SplitN(full, ":", 2)[0] + ": " + verb
+	return strings.Contains(body, full) || strings.HasPrefix(body, head)
+}
+
+// TestCuiHelpTableVerbsDispatch is the direction TestCuiHelpCommandKeysCoverLocale
+// does not check: that one starts from the parser and asks whether the table
+// lists it, this one starts from the table and asks whether the parser answers.
+// A row documenting a command the controller never had would pass the former.
+func TestCuiHelpTableVerbsDispatch(t *testing.T) {
+	registry := GameRegistry()
+	if len(registry) < 300 {
+		t.Fatalf("only %d games in the registry -- the walk broke", len(registry))
+	}
+
+	// Positive control first: if the detector cannot recognise a command that is
+	// certainly unknown, "0 undispatchable" below means nothing.
+	detected := 0
+	for _, entry := range registry {
+		c := entry.NewCui().Controller()
+		c.Exec("r")
+		if helpVerbIsUnknown(c.Exec("zzbogusverb"), "zzbogusverb") {
+			detected++
+		}
+	}
+	if detected != len(registry) {
+		t.Fatalf("the unknown-command detector recognised a bogus verb in only %d of %d games; "+
+			"fix helpVerbIsUnknown rather than trusting the result below", detected, len(registry))
+	}
+
+	checked := 0
+	var bad []string
+	for _, entry := range registry {
+		g := entry.NewCui()
+		commands, _ := helpSections(g.HelpLines())
+		ctrl := g.Controller()
+		ctrl.Exec("r")
+		for _, line := range commands {
+			verb := helpLineVerb(line)
+			if verb == "" {
+				continue
+			}
+			checked++
+			if helpVerbIsUnknown(ctrl.Exec(verb), verb) {
+				bad = append(bad, entry.Name+": documents `"+verb+"`, which its controller answers as unknown")
+			}
+		}
+	}
+	if checked < len(registry) {
+		t.Fatalf("only %d command verbs were read for %d games -- the walk broke", checked, len(registry))
+	}
+	sort.Strings(bad)
+	if len(bad) > 0 {
+		t.Errorf("documented commands the parser does not have (%d of %d):\n  %s",
+			len(bad), checked, strings.Join(bad, "\n  "))
+	}
+}


### PR DESCRIPTION
## 問題

**10 ゲームがコマンド表をキー名のまま表示していました。** `vira` の `help` はこう答えます。

```
Game commands:
vira.helpBid
vira.helpPass
vira.helpPlay
vira.helpNext
vira.helpNextRound
```

対象は bezique / courtpiece / ecarte / ganjifa / pitch / sevencardstudhilo / tarneeb / teenpatti / threecardbrag / vira の 10 ゲーム、**58 行**。ja と en で完全に同一です。`courtpiece` `sevencardstudhilo` `tarneeb` に至ってはロケールファイル自体がありませんでした。

**既存のガードが 1 つも反応しなかった理由**: 対訳パリティチェックは ja と en を突き合わせるものです。これらのキーは**両方から等しく欠けていた**ので、パリティは完璧に一致していました。

## 変更

### 58 キーを ja/en 両方に追加

行の内容は `docs/manual/cui/<game>.md` から取りました。そこのトークンは `TestManualCommandsAreDispatchable` によってコントローラと突き合わせ済みなので、**コマンド名を自分で推測していません**（過去に手書きした例文 6 件中 4 件が実在しないコマンドだった件の再発防止）。列位置は `BuildCuiHelp` がセッション行に使っている 23 桁グリッドに合わせています。

```
Tarneeb

Game commands:
  b <n>                bid (0=pass, 7-13)
  t <1-4>              call trump (1=S 2=C 3=H 4=D)
  p <idx>              play a card
  n                    go to next trick
  nr                   score the round and go to the next one
  l                    action log

Settings:
  sd [0-2]             CPU difficulty (0=Easy, 1=Normal, 2=Hard)
  sl <n>               target score
  sm <1-13>            minimum bid
```

### ガード 2 本

ゲームが存在する限りずっと壊れていた種類のバグなので、修正だけでは足りません。

**`TestCuiHelpRendersNoRawKeys`** — 全ゲームの全ヘルプ行を両言語で走査します。正規表現が壊れると「ロケールがどんな状態でも 0 件」と報告してしまうので、**パターン自体を別テストで固定**しています（`vira.helpBid` は一致し、`b <n>` / `Tarneeb` / `スエカ (Sueca)` は一致しない）。

**`TestCuiHelpTableVerbsDispatch`** — `TestCuiHelpCommandKeysCoverLocale` (#5371) が見ていない**逆方向**です。あちらはパーサから出発して「表に載っているか」を見ます。こちらは表から出発して「パーサが答えるか」を見るので、**実装されていないコマンドを文書化した行**はあちらを通ってしまいます。1839 個の動詞、全部ディスパッチされました。

その 0 件を報告する前に、**318 ゲーム全部で bogus な動詞を unknown と認識できることを確認**してから進みます（[[「対象0件でskip」は通過行がカバレッジに見える]] 型の失敗を防ぐため）。認識できなければ `t.Fatal` で、クリーンな実行には見えません。

## コントロール（両方とも実測）

| 操作 | 結果 |
|---|---|
| `vira.helpBid` を ja/en から削除 | `TestCuiHelpRendersNoRawKeys` が `ja/vira: vira.helpBid` / `en/vira: vira.helpBid` で FAIL |
| `vira.helpPass` を存在しない動詞 `zznosuch` に差し替え | `TestCuiHelpTableVerbsDispatch` が「documents \`zznosuch\`, which its controller answers as unknown」で FAIL |
| 両方戻す | PASS |

修正後の生キー数: **ja 58 → 0、en 58 → 0**。

## 続きがあります（別 PR）

`courtpiece` と `tarneeb` はロケールファイルが無かったので、**ヘルプ以外も生キーです**。開始画面の時点でこうなります。

```
tarneeb:    6 distinct raw keys — tarneeb.round, tarneeb.trumpLine, tarneeb.scoreLine,
            tarneeb.playerLine, tarneeb.promptBid, tarneeb.promptBidHelp
courtpiece: 7 distinct raw keys — courtpiece.round, courtpiece.trumpLine, courtpiece.scoreLine,
            courtpiece.callerLine, courtpiece.playerLine, courtpiece.promptTrump, ...
```

Go 側で使われているキーは courtpiece が 34、tarneeb が 45 で、**この 2 ゲームは CUI では実質プレイ不能**です。盤面行の文言は書き起こしが必要なので、本 PR とは分けて次に出します（そちらでガードをゲームプレイ出力にも広げます）。

## 検証

- `go test -tags test ./internal/infrastructure/ui/` — 緑
- `go build ./...` — 通過
- `golangci-lint run ./internal/infrastructure/ui/...` — 0 issues

Refs #5370
