### PR TITLE
test(e2e): handle the minibridge deal the human never plays

### DIFF
--- a/frontend/e2e/minibridge.spec.ts
+++ b/frontend/e2e/minibridge.spec.ts
@@ -11,6 +11,38 @@ const ownHand = (page: Page) => page.getByRole('button', { name: /^(?!ダミー�
 /** Contract buttons, only rendered when the human is the declarer. */
 const contractBtn = (page: Page) => page.locator('[data-testid^="mb-contract-"]:not([disabled])');
 
+/**
+ * True when the human sits in the dummy seat.
+ *
+ * **落札者が両方の手を打つので、そのとき人間には一度も手番が来ない** ——
+ * そしてディールは人間の入力を一切待たずに 13 トリックぶん進み切る。契約が
+ * 決まった直後に見に行っても、盤面は既に「ディール終了」で全員の手札が空。
+ *
+ * ダミーは落札者の相方 (declarer+2)%4、落札者は HCP 最大の席なので、これは
+ * 2000 配りの実測で 26.6% 起きる。押せる札や公開されたダミーの手札がある
+ * ことを無条件に期待すると、その配りでは確定的に落ちる (issue #5381)。
+ */
+const humanIsDummy = async (page: Page) => {
+  for (const id of [0, 1, 2, 3]) {
+    const text = ((await page.getByTestId(`mb-seat-${id.toString()}`).textContent()) ?? '').trim();
+    if (!/^(あなた|You)/.test(text)) continue;
+    return /\[(ダミー|dummy)\]/.test(text);
+  }
+  throw new Error('no seat row is labelled as the human — the seat header changed');
+};
+
+/** Tricks taken across all four seats; 13 once the deal is played out. */
+const totalTricks = async (page: Page) => {
+  let total = 0;
+  for (const id of [0, 1, 2, 3]) {
+    const text = (await page.getByTestId(`mb-seat-${id.toString()}`).textContent()) ?? '';
+    const match = text.match(/(?:獲得|tricks)\s*(\d+)/);
+    expect(match, `seat ${id.toString()} shows its trick count`).not.toBeNull();
+    total += Number(match?.[1] ?? 0);
+  }
+  return total;
+};
+
 test.describe('Minibridge E2E', () => {
   test('navigates to minibridge and renders initial game state', async ({ page }) => {
     await navigateTo(page, '/minibridge');
@@ -56,6 +88,13 @@ test.describe('Minibridge E2E', () => {
   test('settles the contract and reveals the dummy', async ({ page }) => {
     await navigateTo(page, '/minibridge');
     await settleContract(page);
+
+    if (await humanIsDummy(page)) {
+      // 自分がダミーなら、公開されるのは自分の手札 —— 席行のダミー表示がその印。
+      // 盤面は既にディールを打ち切っているので、**素通りさせずそれを主張する**。
+      await expect.poll(async () => totalTricks(page), { timeout: TIMEOUT_ACTION }).toBe(13);
+      return;
+    }
     // **ダミーは契約が決まると公開される。**
     await expect(page.getByTestId('mb-dummy')).toBeVisible({ timeout: TIMEOUT_ACTION });
   });
@@ -64,11 +103,20 @@ test.describe('Minibridge E2E', () => {
     await navigateTo(page, '/minibridge');
     await settleContract(page);
 
-    await expect(legalCard(page).first()).toBeVisible({ timeout: TIMEOUT_ACTION });
+    if (await humanIsDummy(page)) {
+      // 人間がダミーの配りには出す手札が残っていない。**素通りさせず**、
+      // CPU が最後まで打ち切ったこと（13 トリック）と、押せる札が 1 枚も
+      // 出ていないことを主張する —— 出せたらサーバが拒否するのでバグ。
+      await expect.poll(async () => totalTricks(page), { timeout: TIMEOUT_ACTION }).toBe(13);
+      await expect(legalCard(page)).toHaveCount(0);
+      return;
+    }
+
     // **必ず動く信号は手札の枚数。** 取ったかどうかに依らない。
     const before = (await ownHand(page).count()) + (await page.getByRole('button', { name: /^ダミーの/ }).count());
     expect(before).toBeGreaterThan(0);
 
+    await expect(legalCard(page).first()).toBeVisible({ timeout: TIMEOUT_ACTION });
     await expect(legalCard(page).first()).toBeEnabled({ timeout: TIMEOUT_ACTION });
     await legalCard(page).first().click();
 


### PR DESCRIPTION
## 問題

`minibridge.spec.ts` の 2 つのテストが「人間には必ず手番が来る」と仮定していました。**人間がダミーの席に座ると手番は来ません** —— 落札者が両方の手を打つ規則だからです。しかも CPU の落札者は人間の入力を一切待たずに 13 トリックを打ち切るので、契約が決まった直後に見に行っても盤面は既に「ディール終了」で全員の手札が空です。

失敗時のスナップショットがそのまま証拠になっています。

```
現在のフェーズ: ディール終了、待機中
あなた[ダミー]: HCP9 / 獲得4   CPU1: HCP7 / 獲得1
CPU2[デクレアラー]: HCP13 / 獲得5   CPU3: HCP11 / 獲得3
```

獲得の合計が 4+1+5+3 = 13 で、既に打ち切られています。

- `settles the contract and reveals the dummy` は `mb-dummy` パネルを待ちますが、これは `state.dummyHand.length > 0` のときだけ描画されます
- `plays a card and the hand shrinks` は `button.ring-ds-success` を待ちますが、人間が操作できない席に緑枠は付きません

**バグはページではなくテストの前提側です。** `MinibridgePage.tsx` の `seatIsControllable` は「ダミーの席かどうかを先に見る」で正しく実装されています。

## 発生率（推測ではなく実測）

`dummyIdx = (declarerIdx + 2) % 4`、落札者は HCP 最大の席です。

```
of 2000 deals: human(seat 0) is dummy 532 (26.6%), is declarer 577 (28.9%)
```

ローカルで `reveals the dummy` だけを 40 回:

```
9 failed / 31 passed   (22.5%)
```

E2E は全 PR で走るので、**Web コードを 1 行も触っていない変更の CI がこの率で赤くなります**（#5378 がそれです）。

## 変更

席を仮定せず分岐します。そして **ダミー側の分岐はスキップせず主張します**。

```ts
if (await humanIsDummy(page)) {
  await expect.poll(async () => totalTricks(page), { timeout: TIMEOUT_ACTION }).toBe(13);
  await expect(legalCard(page)).toHaveCount(0);
  return;
}
```

- 「CPU が最後まで打ち切った」＝ 4 席の獲得トリック合計が 13
- 「押せる札が 1 枚も出ていない」＝ 出せてしまったらサーバが拒否するので、それ自体がバグ

`humanIsDummy` は席行を人間ラベル（あなた / You）で探してからダミー表示を見ます。**席 0 が人間だと決め打ちしていません**。人間の席行が 1 つも無ければ throw します（席ヘッダが変わったのを黙って通さないため）。

`totalTricks` は各席が獲得数を表示していることを `expect(match).not.toBeNull()` で確かめてから足します。表示が消えたら 0 を足して静かに通る、という形にはしていません。

## コントロール（両方ローカルの実サーバで実測）

| 操作 | 結果 |
|---|---|
| spec 全体を 15 回繰り返し | **105/105 pass**（修正前は 22.5% が失敗） |
| `humanIsDummy` を `true` に固定 | **12/16 fail** |

2 つ目が重要です。固定すると人間がダミーでない配り（約 73%）で 13 トリックに到達せず落ちます。**通った 4/16 = 25% は、人間が本当にダミーだった配りそのもの**で、実測の 26.6% と一致します。つまりダミー分岐のアサートは効いており（空振りしておらず）、条件がそれを選び分けています。

## 検証

- `bunx playwright test e2e/minibridge.spec.ts --repeat-each=15` — 105/105
- `bun run typecheck` — 通過
- `bunx biome check` — 0 issues

Closes #5381
