### PR TITLE
fix(cui): put the card-index rejections through i18n

### DIFF
--- a/internal/adapter/controller/AllFoursCuiController.go
+++ b/internal/adapter/controller/AllFoursCuiController.go
@@ -57,7 +57,7 @@ func (c *AllFoursCuiController) Exec(command string) string {
 			case "run":
 				return c.ai.RespondBeg(true), true
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.ai.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.ai.Play)
 			case "n", "next":
 				return c.ai.NextTrick(), true
 			case "nr", "nextround":

--- a/internal/adapter/controller/AluetteCuiController.go
+++ b/internal/adapter/controller/AluetteCuiController.go
@@ -43,7 +43,7 @@ func (c *AluetteCuiController) Exec(command string) string {
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.di.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.di.Play)
 			case "n", "next":
 				return c.di.NextTrick(), true
 			case "nr", "nextround":

--- a/internal/adapter/controller/AluetteCuiController_test.go
+++ b/internal/adapter/controller/AluetteCuiController_test.go
@@ -46,11 +46,11 @@ func TestAluetteCuiController_Exec(t *testing.T) {
 	})
 
 	t.Run("play no args", func(t *testing.T) {
-		assert.Contains(t, controller.NewAluetteCuiController(newMock()).Exec("play"), "Card index is required")
+		assert.Contains(t, controller.NewAluetteCuiController(newMock()).Exec("play"), msgCardIndexRequired())
 	})
 
 	t.Run("play with a non-numeric index", func(t *testing.T) {
-		assert.Contains(t, controller.NewAluetteCuiController(newMock()).Exec("play x"), "Invalid card index")
+		assert.Contains(t, controller.NewAluetteCuiController(newMock()).Exec("play x"), msgInvalidCardIndexPrefix())
 	})
 
 	// **捨て札も入札もこのゲームには無い。**タロー系から写すと scarto / bid が

--- a/internal/adapter/controller/BalootCuiController.go
+++ b/internal/adapter/controller/BalootCuiController.go
@@ -46,7 +46,7 @@ func (c *BalootCuiController) Exec(command string) string {
 			case "pass":
 				return c.bi.PassDeclaration(), true
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.bi.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.bi.Play)
 			case "n", "next":
 				return c.bi.NextRound(), true
 			case "g", "giveup":

--- a/internal/adapter/controller/BalootCuiController_test.go
+++ b/internal/adapter/controller/BalootCuiController_test.go
@@ -117,8 +117,8 @@ func TestBalootCuiControllerPlay(t *testing.T) {
 
 func TestBalootCuiControllerPlayRejectsBadArgs(t *testing.T) {
 	for _, tc := range []struct{ name, cmd, want string }{
-		{"missing index", "p", "Card index is required."},
-		{"non-numeric", "p abc", "Invalid card index: abc."},
+		{"missing index", "p", msgCardIndexRequired()},
+		{"non-numeric", "p abc", msgInvalidCardIndex("abc")},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			bi := newMockBalootInteractor()

--- a/internal/adapter/controller/BasraCuiController.go
+++ b/internal/adapter/controller/BasraCuiController.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -63,11 +64,11 @@ func (c *BasraCuiController) Exec(command string) string {
 // handlePlay は "p <handIdx> [tableIdx...]" を解析して Play を呼ぶ。
 func (c *BasraCuiController) handlePlay(args []string) string {
 	if len(args) == 0 {
-		return "Card index is required (e.g. p 0, or p 0 1 2 to capture table cards)."
+		return i18n.T("cardIndexRequiredCapture")
 	}
 	handIdx, err := strconv.Atoi(args[0])
 	if err != nil {
-		return "Invalid card index: " + args[0] + "."
+		return i18n.Tf("invalidCardIndex", "val", args[0])
 	}
 	tableIdxs, _ := cuiutil.ParseIntSlice(args[1:])
 	return c.bi.Play(handIdx, tableIdxs)

--- a/internal/adapter/controller/BasraCuiController_test.go
+++ b/internal/adapter/controller/BasraCuiController_test.go
@@ -48,11 +48,11 @@ func TestBasraCuiController_Exec(t *testing.T) {
 	})
 	t.Run("play missing index", func(t *testing.T) {
 		out := controller.NewBasraCuiController(newMock()).Exec("p")
-		assert.Contains(t, out, "required")
+		assert.Contains(t, out, msgCardIndexRequiredCapture())
 	})
 	t.Run("play invalid index", func(t *testing.T) {
 		out := controller.NewBasraCuiController(newMock()).Exec("p xyz")
-		assert.Contains(t, out, "Invalid card index")
+		assert.Contains(t, out, msgInvalidCardIndexPrefix())
 	})
 	t.Run("next round", func(t *testing.T) {
 		m := newMock()

--- a/internal/adapter/controller/BeloteCuiController.go
+++ b/internal/adapter/controller/BeloteCuiController.go
@@ -62,7 +62,7 @@ func (c *BeloteCuiController) Exec(command string) string {
 					return c.bi.CallTrump(suit)
 				})
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.bi.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.bi.Play)
 			case "n", "next":
 				return c.bi.NextTrick(), true
 			case "nr", "nextround":

--- a/internal/adapter/controller/BeloteCuiController_test.go
+++ b/internal/adapter/controller/BeloteCuiController_test.go
@@ -107,12 +107,12 @@ func TestBeloteCuiController_Exec(t *testing.T) {
 
 	t.Run("play no args", func(t *testing.T) {
 		c := controller.NewBeloteCuiController(newMock())
-		assert.Contains(t, c.Exec("p"), "Card index is required")
+		assert.Contains(t, c.Exec("p"), msgCardIndexRequired())
 	})
 
 	t.Run("play invalid arg", func(t *testing.T) {
 		c := controller.NewBeloteCuiController(newMock())
-		assert.Contains(t, c.Exec("p abc"), "Invalid card index")
+		assert.Contains(t, c.Exec("p abc"), msgInvalidCardIndexPrefix())
 	})
 
 	t.Run("next n", func(t *testing.T) {

--- a/internal/adapter/controller/BeziqueCuiController.go
+++ b/internal/adapter/controller/BeziqueCuiController.go
@@ -49,7 +49,7 @@ func (c *BeziqueCuiController) Exec(command string) string {
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.bi.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.bi.Play)
 			case "m", "meld":
 				return cuiutil.WithParsedInt(args, "Meld index is required.", "Invalid meld index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.bi.DeclareMeld)
 			case "s", "skip":

--- a/internal/adapter/controller/BeziqueCuiController_test.go
+++ b/internal/adapter/controller/BeziqueCuiController_test.go
@@ -52,12 +52,12 @@ func TestBeziqueCuiController_Exec(t *testing.T) {
 
 	t.Run("play missing index", func(t *testing.T) {
 		c := controller.NewBeziqueCuiController(newMock())
-		assert.Contains(t, c.Exec("p"), "Card index is required")
+		assert.Contains(t, c.Exec("p"), msgCardIndexRequired())
 	})
 
 	t.Run("play invalid index", func(t *testing.T) {
 		c := controller.NewBeziqueCuiController(newMock())
-		assert.Contains(t, c.Exec("p abc"), "Invalid card index")
+		assert.Contains(t, c.Exec("p abc"), msgInvalidCardIndexPrefix())
 	})
 
 	t.Run("meld with index", func(t *testing.T) {

--- a/internal/adapter/controller/BhabhiCuiController.go
+++ b/internal/adapter/controller/BhabhiCuiController.go
@@ -37,7 +37,7 @@ func (c *BhabhiCuiController) Exec(command string) string {
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.bi.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.bi.Play)
 			case "g", "giveup":
 				return c.bi.GiveUp(), true
 			default:

--- a/internal/adapter/controller/BhabhiCuiController_test.go
+++ b/internal/adapter/controller/BhabhiCuiController_test.go
@@ -48,8 +48,8 @@ func TestBhabhiCuiControllerPlay(t *testing.T) {
 
 func TestBhabhiCuiControllerPlayRejectsBadArgs(t *testing.T) {
 	for _, tc := range []struct{ name, cmd, want string }{
-		{"missing index", "p", "Card index is required."},
-		{"non-numeric", "p abc", "Invalid card index: abc."},
+		{"missing index", "p", msgCardIndexRequired()},
+		{"non-numeric", "p abc", msgInvalidCardIndex("abc")},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			bi := newMockBhabhiInteractor()

--- a/internal/adapter/controller/BidEuchreCuiController.go
+++ b/internal/adapter/controller/BidEuchreCuiController.go
@@ -43,7 +43,7 @@ func (c *BidEuchreCuiController) Exec(command string) string {
 						return c.bi.ChooseTrump(v)
 					})
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", 0, domain.BidEuchreHandSize-1, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", 0, domain.BidEuchreHandSize-1, func(v int) string {
 					return c.bi.PlayCard(v)
 				})
 			case "n", "next":

--- a/internal/adapter/controller/BidEuchreCuiController_test.go
+++ b/internal/adapter/controller/BidEuchreCuiController_test.go
@@ -78,8 +78,8 @@ func TestBidEuchreCuiController_Exec(t *testing.T) {
 		m.AssertCalled(t, "PlayCard", 5)
 		assert.Equal(t, mockOutput, c.Exec("n"))
 		m.AssertCalled(t, "NextHand")
-		assert.Contains(t, c.Exec("p abc"), "Invalid card index")
-		assert.Contains(t, c.Exec("p 6"), "Invalid card index")
+		assert.Contains(t, c.Exec("p abc"), msgInvalidCardIndexPrefix())
+		assert.Contains(t, c.Exec("p 6"), msgInvalidCardIndexPrefix())
 	})
 
 	t.Run("log and unknown", func(t *testing.T) {

--- a/internal/adapter/controller/BidWhistCuiController.go
+++ b/internal/adapter/controller/BidWhistCuiController.go
@@ -79,7 +79,7 @@ func (c *BidWhistCuiController) Exec(command string) string {
 				}
 				idxs := make([]int, domain.BidWhistKittySize)
 				for i := 0; i < domain.BidWhistKittySize; i++ {
-					v, errMsg, ok := cuiutil.ParseIntArg(args[i:i+1], "", "Invalid card index: %s.", 0, math.MaxInt)
+					v, errMsg, ok := cuiutil.ParseIntArgKeys(args[i:i+1], "", "invalidCardIndex", 0, math.MaxInt)
 					if !ok {
 						return errMsg, true
 					}
@@ -87,7 +87,7 @@ func (c *BidWhistCuiController) Exec(command string) string {
 				}
 				return c.bi.ExchangeKitty(idxs), true
 			case "p", "play":
-				cardIdx, errMsg, ok := cuiutil.ParseIntArg(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax)
+				cardIdx, errMsg, ok := cuiutil.ParseIntArgKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax)
 				if !ok {
 					return errMsg, true
 				}

--- a/internal/adapter/controller/BidWhistCuiController_test.go
+++ b/internal/adapter/controller/BidWhistCuiController_test.go
@@ -72,7 +72,7 @@ func TestBidWhistCuiController_Usage(t *testing.T) {
 	if got := c.Exec("e 0 1 2"); !strings.Contains(got, "Usage") {
 		t.Errorf("exchange with too few args should show usage, got %q", got)
 	}
-	if got := c.Exec("p"); !strings.Contains(got, "required") {
+	if got := c.Exec("p"); !strings.Contains(got, msgCardIndexRequired()) {
 		t.Errorf("play without args should require index, got %q", got)
 	}
 	if got := c.Exec("t"); !strings.Contains(got, "required") {

--- a/internal/adapter/controller/BostonCuiController.go
+++ b/internal/adapter/controller/BostonCuiController.go
@@ -41,7 +41,7 @@ func (c *BostonCuiController) Exec(command string) string {
 			case "cp", "callpartner":
 				return bostonParseCallPartner(args, c.bi)
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", 0, domain.BostonHandSize-1, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", 0, domain.BostonHandSize-1, func(v int) string {
 					return c.bi.PlayCard(v)
 				})
 			case "n", "next":

--- a/internal/adapter/controller/BostonCuiController_test.go
+++ b/internal/adapter/controller/BostonCuiController_test.go
@@ -80,8 +80,8 @@ func TestBostonCuiController_Exec(t *testing.T) {
 		m.AssertCalled(t, "PlayCard", 12)
 		assert.Equal(t, mockOutput, c.Exec("n"))
 		m.AssertCalled(t, "NextHand")
-		assert.Contains(t, c.Exec("p abc"), "Invalid card index")
-		assert.Contains(t, c.Exec("p 13"), "Invalid card index")
+		assert.Contains(t, c.Exec("p abc"), msgInvalidCardIndexPrefix())
+		assert.Contains(t, c.Exec("p 13"), msgInvalidCardIndexPrefix())
 	})
 
 	t.Run("log and unknown", func(t *testing.T) {

--- a/internal/adapter/controller/BotifarraCuiController.go
+++ b/internal/adapter/controller/BotifarraCuiController.go
@@ -31,8 +31,8 @@ func (bc *BotifarraCuiController) Exec(command string) string {
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "p", "play":
-				idx, errMsg, ok := cuiutil.ParseIntArg(args,
-					"Card index is required.", "Invalid card index. Please enter a number.", 0, math.MaxInt)
+				idx, errMsg, ok := cuiutil.ParseIntArgKeys(args,
+					"cardIndexRequired", "invalidCardIndexNotANumber", 0, math.MaxInt)
 				if !ok {
 					return errMsg, true
 				}

--- a/internal/adapter/controller/BotifarraCuiController_test.go
+++ b/internal/adapter/controller/BotifarraCuiController_test.go
@@ -42,8 +42,8 @@ func TestBotifarraCuiController_Play(t *testing.T) {
 	c := controller.NewBotifarraCuiController(newMockBotifarraInteractor())
 	assert.Equal(t, "played 3", c.Exec("p 3"))
 	assert.Equal(t, "played 3", c.Exec("play 3"))
-	assert.Contains(t, c.Exec("p"), "required")
-	assert.Contains(t, c.Exec("p abc"), "Invalid card index")
+	assert.Contains(t, c.Exec("p"), msgCardIndexRequired())
+	assert.Contains(t, c.Exec("p abc"), msgInvalidCardIndexPrefix())
 }
 
 // **切り札なし (n) も有効な宣言。** 「指定が無い」とは区別します。

--- a/internal/adapter/controller/BourreCuiController.go
+++ b/internal/adapter/controller/BourreCuiController.go
@@ -40,7 +40,7 @@ func (c *BourreCuiController) Exec(command string) string {
 				indices, skipped := cuiutil.ParseIntSlice(args)
 				return cuiutil.PrependSkippedWarning(c.bgi.Draw(indices), skipped), true
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", 0, 4, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", 0, 4, func(v int) string {
 					return c.bgi.Play(v)
 				})
 			case "n", "next":

--- a/internal/adapter/controller/BridgeCuiController.go
+++ b/internal/adapter/controller/BridgeCuiController.go
@@ -53,7 +53,7 @@ func (c *BridgeCuiController) Exec(command string) string {
 					return c.bi.Bid(bidType, bidLevel, bidSuit)
 				})
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.bi.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.bi.Play)
 			case "n", "next":
 				return c.bi.NextTrick(), true
 			case "nr", "nextround":

--- a/internal/adapter/controller/BridgeCuiController_test.go
+++ b/internal/adapter/controller/BridgeCuiController_test.go
@@ -120,13 +120,13 @@ func TestBridgeCuiController_Exec(t *testing.T) {
 	t.Run("play command p no args", func(t *testing.T) {
 		c := controller.NewBridgeCuiController(newMock())
 		result := c.Exec("p")
-		assert.Contains(t, result, "Card index is required")
+		assert.Contains(t, result, msgCardIndexRequired())
 	})
 
 	t.Run("play command p invalid arg", func(t *testing.T) {
 		c := controller.NewBridgeCuiController(newMock())
 		result := c.Exec("p abc")
-		assert.Contains(t, result, "Invalid card index")
+		assert.Contains(t, result, msgInvalidCardIndexPrefix())
 	})
 
 	// next

--- a/internal/adapter/controller/BriscolaCuiController.go
+++ b/internal/adapter/controller/BriscolaCuiController.go
@@ -37,7 +37,7 @@ func (c *BriscolaCuiController) Exec(command string) string {
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.bi.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.bi.Play)
 			case "n", "next":
 				return c.bi.NextTrick(), true
 			default:

--- a/internal/adapter/controller/BriscolaCuiController_test.go
+++ b/internal/adapter/controller/BriscolaCuiController_test.go
@@ -56,13 +56,13 @@ func TestBriscolaCuiController_Exec(t *testing.T) {
 	t.Run("play missing index", func(t *testing.T) {
 		c := controller.NewBriscolaCuiController(newMock())
 		got := c.Exec("p")
-		assert.Contains(t, got, "Card index is required")
+		assert.Contains(t, got, msgCardIndexRequired())
 	})
 
 	t.Run("play invalid index", func(t *testing.T) {
 		c := controller.NewBriscolaCuiController(newMock())
 		got := c.Exec("p abc")
-		assert.Contains(t, got, "Invalid card index")
+		assert.Contains(t, got, msgInvalidCardIndexPrefix())
 	})
 
 	t.Run("next short", func(t *testing.T) {

--- a/internal/adapter/controller/BuraCuiController.go
+++ b/internal/adapter/controller/BuraCuiController.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -71,14 +72,14 @@ func (c *BuraCuiController) Exec(command string) string {
 // player verbatim, and Go error strings are not capitalised.
 func buraParseIndices(args []string) ([]int, string) {
 	if len(args) == 0 {
-		return nil, "Card index is required."
+		return nil, i18n.T("cardIndexRequired")
 	}
 	seen := map[int]bool{}
 	indices := make([]int, 0, len(args))
 	for _, a := range args {
 		n, err := strconv.Atoi(strings.TrimSpace(a))
 		if err != nil {
-			return nil, fmt.Sprintf("Invalid card index: %s.", a)
+			return nil, i18n.Tf("invalidCardIndex", "val", a)
 		}
 		if seen[n] {
 			return nil, fmt.Sprintf("Duplicate card index: %d.", n)

--- a/internal/adapter/controller/BuraCuiController_test.go
+++ b/internal/adapter/controller/BuraCuiController_test.go
@@ -28,8 +28,8 @@ func TestBuraCuiController_PlayParsesOneToThreeIndices(t *testing.T) {
 
 func TestBuraCuiController_PlayRejectsBadInput(t *testing.T) {
 	cases := map[string]string{
-		"p":     "Card index is required.",
-		"p x":   "Invalid card index: x.",
+		"p":     msgCardIndexRequired(),
+		"p x":   msgInvalidCardIndex("x"),
 		"p 1 1": "Duplicate card index: 1.",
 	}
 	for input, want := range cases {

--- a/internal/adapter/controller/BurracoCuiController.go
+++ b/internal/adapter/controller/BurracoCuiController.go
@@ -57,7 +57,7 @@ func (c *BurracoCuiController) Exec(command string) string {
 				groups := parseMeldGroups(args)
 				return c.ci.Meld(groups), true
 			case "d", "discard":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.ci.Discard)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.ci.Discard)
 			case "sd", "setdifficulty":
 				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
 					cfg := c.ci.GetConfig()

--- a/internal/adapter/controller/BurracoCuiController_test.go
+++ b/internal/adapter/controller/BurracoCuiController_test.go
@@ -166,13 +166,13 @@ func TestBurracoCuiController_Exec(t *testing.T) {
 	t.Run("discard command d no args", func(t *testing.T) {
 		c := controller.NewBurracoCuiController(newMock())
 		result := c.Exec("d")
-		assert.Contains(t, result, "Card index is required")
+		assert.Contains(t, result, msgCardIndexRequired())
 	})
 
 	t.Run("discard command d invalid arg", func(t *testing.T) {
 		c := controller.NewBurracoCuiController(newMock())
 		result := c.Exec("d abc")
-		assert.Contains(t, result, "Invalid card index")
+		assert.Contains(t, result, msgInvalidCardIndexPrefix())
 	})
 
 	// goout

--- a/internal/adapter/controller/CalabresellaCuiController.go
+++ b/internal/adapter/controller/CalabresellaCuiController.go
@@ -60,9 +60,9 @@ func (c *CalabresellaCuiController) Exec(command string) string {
 					return "Invalid bid action: " + args[0] + ". Please enter pass, chiamo, or solo.", true
 				}
 			case "d", "discard":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.di.Discard)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.di.Discard)
 			case "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.di.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.di.Play)
 			case "n", "next":
 				return c.di.NextTrick(), true
 			case "nr", "nextround":

--- a/internal/adapter/controller/CalabresellaCuiController_test.go
+++ b/internal/adapter/controller/CalabresellaCuiController_test.go
@@ -82,7 +82,7 @@ func TestCalabresellaCuiController_Exec(t *testing.T) {
 
 	t.Run("discard no args", func(t *testing.T) {
 		result := controller.NewCalabresellaCuiController(newMock()).Exec("discard")
-		assert.Contains(t, result, "Card index is required")
+		assert.Contains(t, result, msgCardIndexRequired())
 	})
 
 	t.Run("play card", func(t *testing.T) {
@@ -94,7 +94,7 @@ func TestCalabresellaCuiController_Exec(t *testing.T) {
 
 	t.Run("play no args", func(t *testing.T) {
 		result := controller.NewCalabresellaCuiController(newMock()).Exec("play")
-		assert.Contains(t, result, "Card index is required")
+		assert.Contains(t, result, msgCardIndexRequired())
 	})
 
 	t.Run("next / nextround", func(t *testing.T) {

--- a/internal/adapter/controller/CallBreakCuiController.go
+++ b/internal/adapter/controller/CallBreakCuiController.go
@@ -47,7 +47,7 @@ func (c *CallBreakCuiController) Exec(command string) string {
 			case "b", "bid":
 				return cuiutil.WithParsedInt(args, "Bid value is required (1-13).", "Invalid bid value: %s.", domain.CallBreakMinBid, domain.CallBreakHandSize, c.ci.Bid)
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.ci.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.ci.Play)
 			case "n", "next":
 				return c.ci.NextTrick(), true
 			case "nr", "nextround":

--- a/internal/adapter/controller/CallBreakCuiController_test.go
+++ b/internal/adapter/controller/CallBreakCuiController_test.go
@@ -76,10 +76,10 @@ func TestCallBreakCuiController_Exec(t *testing.T) {
 		m.AssertCalled(t, "Play", 5)
 	})
 	t.Run("play no args", func(t *testing.T) {
-		assert.Contains(t, controller.NewCallBreakCuiController(newMock()).Exec("p"), "Card index is required")
+		assert.Contains(t, controller.NewCallBreakCuiController(newMock()).Exec("p"), msgCardIndexRequired())
 	})
 	t.Run("play invalid arg", func(t *testing.T) {
-		assert.Contains(t, controller.NewCallBreakCuiController(newMock()).Exec("p abc"), "Invalid card index")
+		assert.Contains(t, controller.NewCallBreakCuiController(newMock()).Exec("p abc"), msgInvalidCardIndexPrefix())
 	})
 
 	t.Run("next n", func(t *testing.T) {

--- a/internal/adapter/controller/CanastaCuiController.go
+++ b/internal/adapter/controller/CanastaCuiController.go
@@ -57,7 +57,7 @@ func (c *CanastaCuiController) Exec(command string) string {
 				groups := parseMeldGroups(args)
 				return c.ci.Meld(groups), true
 			case "d", "discard":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.ci.Discard)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.ci.Discard)
 			case "sd", "setdifficulty":
 				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
 					cfg := c.ci.GetConfig()

--- a/internal/adapter/controller/CanastaCuiController_test.go
+++ b/internal/adapter/controller/CanastaCuiController_test.go
@@ -165,13 +165,13 @@ func TestCanastaCuiController_Exec(t *testing.T) {
 	t.Run("discard command d no args", func(t *testing.T) {
 		c := controller.NewCanastaCuiController(newMock())
 		result := c.Exec("d")
-		assert.Contains(t, result, "Card index is required")
+		assert.Contains(t, result, msgCardIndexRequired())
 	})
 
 	t.Run("discard command d invalid arg", func(t *testing.T) {
 		c := controller.NewCanastaCuiController(newMock())
 		result := c.Exec("d abc")
-		assert.Contains(t, result, "Invalid card index")
+		assert.Contains(t, result, msgInvalidCardIndexPrefix())
 	})
 
 	// goout

--- a/internal/adapter/controller/CariocaCuiController.go
+++ b/internal/adapter/controller/CariocaCuiController.go
@@ -57,7 +57,7 @@ func (c *CariocaCuiController) Exec(command string) string {
 				}
 				return c.ci.Layoff(idx[0], idx[1], idx[2]), true
 			case "d", "discard":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.ci.Discard)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.ci.Discard)
 			case "nr", "nextround":
 				return c.ci.NextRound(), true
 			case "pc", "setplayers":

--- a/internal/adapter/controller/CatchTenCuiController.go
+++ b/internal/adapter/controller/CatchTenCuiController.go
@@ -44,7 +44,7 @@ func (c *CatchTenCuiController) Exec(command string) string {
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.ci.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.ci.Play)
 			case "n", "next":
 				return c.ci.NextTrick(), true
 			case "nr", "nextround":

--- a/internal/adapter/controller/CegoCuiController.go
+++ b/internal/adapter/controller/CegoCuiController.go
@@ -57,11 +57,11 @@ func (c *CegoCuiController) Exec(command string) string {
 			case "handspiel", "solo":
 				return c.di.ChooseContract(domain.CegoContractHandspiel), true
 			case "discard":
-				return cuiutil.WithParsedInt(args, "Card index to keep is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cardIndexToKeepRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, func(v int) string {
 					return c.di.Discard([]int{v})
 				})
 			case "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.di.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.di.Play)
 			case "n", "next":
 				return c.di.NextTrick(), true
 			case "nr", "nextround":

--- a/internal/adapter/controller/ChinchonCuiController.go
+++ b/internal/adapter/controller/ChinchonCuiController.go
@@ -42,9 +42,9 @@ func (c *ChinchonCuiController) Exec(command string) string {
 			case "dd", "drawdiscard":
 				return c.ci.DrawFromDiscard(), true
 			case "d", "discard":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.ci.Discard)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.ci.Discard)
 			case "k", "knock":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.ci.Knock)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.ci.Knock)
 			case "lo", "layoff":
 				return c.ci.Layoff(parseIntList(args)), true
 			case "nr", "nextround":

--- a/internal/adapter/controller/ChinchonCuiController_test.go
+++ b/internal/adapter/controller/ChinchonCuiController_test.go
@@ -61,12 +61,12 @@ func TestChinchonCuiController_Exec(t *testing.T) {
 
 	t.Run("discard d no args", func(t *testing.T) {
 		result := controller.NewChinchonCuiController(newMock()).Exec("d")
-		assert.Contains(t, result, "Card index is required")
+		assert.Contains(t, result, msgCardIndexRequired())
 	})
 
 	t.Run("discard d invalid", func(t *testing.T) {
 		result := controller.NewChinchonCuiController(newMock()).Exec("d abc")
-		assert.Contains(t, result, "Invalid card index")
+		assert.Contains(t, result, msgInvalidCardIndexPrefix())
 	})
 
 	t.Run("knock k with index", func(t *testing.T) {
@@ -77,7 +77,7 @@ func TestChinchonCuiController_Exec(t *testing.T) {
 
 	t.Run("knock k no args", func(t *testing.T) {
 		result := controller.NewChinchonCuiController(newMock()).Exec("k")
-		assert.Contains(t, result, "Card index is required")
+		assert.Contains(t, result, msgCardIndexRequired())
 	})
 
 	t.Run("layoff lo with indices", func(t *testing.T) {

--- a/internal/adapter/controller/ChineseTenCuiController.go
+++ b/internal/adapter/controller/ChineseTenCuiController.go
@@ -37,7 +37,7 @@ func (c *ChineseTenCuiController) Exec(command string) string {
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.ci.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.ci.Play)
 			case "s", "select":
 				return cuiutil.WithParsedInt(args, "Layout index is required.", "Invalid layout index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.ci.Select)
 			default:

--- a/internal/adapter/controller/CinchCuiController.go
+++ b/internal/adapter/controller/CinchCuiController.go
@@ -48,7 +48,7 @@ func (c *CinchCuiController) Exec(command string) string {
 			case "t", "trump":
 				return cuiutil.WithParsedInt(args, "Trump suit is required (1-4).", "Invalid trump suit: %s. Please enter 1-4.", domain.CardDesignSpade, domain.CardDesignDiamond, c.ci.NameTrump)
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", 0, domain.CinchHandSize-1, c.ci.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", 0, domain.CinchHandSize-1, c.ci.Play)
 			case "n", "next", "nr", "nextround":
 				return c.ci.NextRound(), true
 			case "sd", "setdifficulty":

--- a/internal/adapter/controller/CinchCuiController_test.go
+++ b/internal/adapter/controller/CinchCuiController_test.go
@@ -67,7 +67,7 @@ func TestCinchCuiController_Exec(t *testing.T) {
 	})
 	t.Run("play invalid arg", func(t *testing.T) {
 		out := controller.NewCinchCuiController(newMock()).Exec("p xyz")
-		assert.Contains(t, out, "Invalid card index")
+		assert.Contains(t, out, msgInvalidCardIndexPrefix())
 	})
 	t.Run("next round", func(t *testing.T) {
 		m := newMock()

--- a/internal/adapter/controller/ColourWhistCuiController.go
+++ b/internal/adapter/controller/ColourWhistCuiController.go
@@ -32,8 +32,8 @@ func (cc *ColourWhistCuiController) Exec(command string) string {
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "p", "play":
-				idx, errMsg, ok := cuiutil.ParseIntArg(args,
-					"Card index is required.", "Invalid card index. Please enter a number.", 0, math.MaxInt)
+				idx, errMsg, ok := cuiutil.ParseIntArgKeys(args,
+					"cardIndexRequired", "invalidCardIndexNotANumber", 0, math.MaxInt)
 				if !ok {
 					return errMsg, true
 				}

--- a/internal/adapter/controller/ColourWhistCuiController_test.go
+++ b/internal/adapter/controller/ColourWhistCuiController_test.go
@@ -37,8 +37,8 @@ func TestColourWhistCuiController_QuitAndReset(t *testing.T) {
 func TestColourWhistCuiController_Play(t *testing.T) {
 	c := controller.NewColourWhistCuiController(newMockColourWhistInteractor())
 	assert.Equal(t, "played 2", c.Exec("p 2"))
-	assert.Contains(t, c.Exec("p"), "required")
-	assert.Contains(t, c.Exec("p abc"), "Invalid card index")
+	assert.Contains(t, c.Exec("p"), msgCardIndexRequired())
+	assert.Contains(t, c.Exec("p abc"), msgInvalidCardIndexPrefix())
 }
 
 // **競れる契約は3つだけ。** troel は配りでしか成立しないので語彙に入れません。

--- a/internal/adapter/controller/ConquianCuiController.go
+++ b/internal/adapter/controller/ConquianCuiController.go
@@ -47,7 +47,7 @@ func (c *ConquianCuiController) Exec(command string) string {
 			case "m", "meld":
 				return c.ci.Meld(parseMeldGroups(args)), true
 			case "d", "discard":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.ci.Discard)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.ci.Discard)
 			case "nr", "nextround":
 				return c.ci.NextRound(), true
 			case "sd", "setdifficulty":

--- a/internal/adapter/controller/ConquianCuiController_test.go
+++ b/internal/adapter/controller/ConquianCuiController_test.go
@@ -72,12 +72,12 @@ func TestConquianCuiController_Exec(t *testing.T) {
 
 	t.Run("discard d no args", func(t *testing.T) {
 		result := controller.NewConquianCuiController(newMock()).Exec("d")
-		assert.Contains(t, result, "Card index is required")
+		assert.Contains(t, result, msgCardIndexRequired())
 	})
 
 	t.Run("discard d invalid", func(t *testing.T) {
 		result := controller.NewConquianCuiController(newMock()).Exec("d abc")
-		assert.Contains(t, result, "Invalid card index")
+		assert.Contains(t, result, msgInvalidCardIndexPrefix())
 	})
 
 	t.Run("nextround nr", func(t *testing.T) {

--- a/internal/adapter/controller/ContractRummyCuiController.go
+++ b/internal/adapter/controller/ContractRummyCuiController.go
@@ -60,7 +60,7 @@ func (c *ContractRummyCuiController) Exec(command string) string {
 				}
 				return c.ci.Layoff(idx[0], idx[1], idx[2]), true
 			case "d", "discard":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.ci.Discard)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.ci.Discard)
 			case "nr", "nextround":
 				return c.ci.NextRound(), true
 			case "sd", "setdifficulty":

--- a/internal/adapter/controller/CourtPieceCuiController.go
+++ b/internal/adapter/controller/CourtPieceCuiController.go
@@ -49,7 +49,7 @@ func (c *CourtPieceCuiController) Exec(command string) string {
 			case "t", "trump":
 				return cuiutil.WithParsedInt(args, "Trump suit is required (1=Spade 2=Club 3=Heart 4=Diamond).", "Invalid suit: %s.", domain.CardDesignSpade, domain.CardDesignDiamond, c.ti.DeclareTrump)
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.ti.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.ti.Play)
 			case "n", "next":
 				return c.ti.NextTrick(), true
 			case "nr", "nextround":

--- a/internal/adapter/controller/CrazyEightsCuiController.go
+++ b/internal/adapter/controller/CrazyEightsCuiController.go
@@ -48,7 +48,7 @@ func (c *CrazyEightsCuiController) Exec(command string) string {
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.playWithSuitPrompt)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.playWithSuitPrompt)
 			case "d", "draw":
 				return c.ci.Draw(), true
 			case "s", "suit":

--- a/internal/adapter/controller/CrazyEightsCuiController_test.go
+++ b/internal/adapter/controller/CrazyEightsCuiController_test.go
@@ -82,13 +82,13 @@ func TestCrazyEightsCuiController_Exec(t *testing.T) {
 	t.Run("play command p no args", func(t *testing.T) {
 		c := controller.NewCrazyEightsCuiController(newMock())
 		result := c.Exec("p")
-		assert.Contains(t, result, "Card index is required")
+		assert.Contains(t, result, msgCardIndexRequired())
 	})
 
 	t.Run("play command p invalid arg", func(t *testing.T) {
 		c := controller.NewCrazyEightsCuiController(newMock())
 		result := c.Exec("p abc")
-		assert.Contains(t, result, "Invalid card index")
+		assert.Contains(t, result, msgInvalidCardIndexPrefix())
 	})
 
 	t.Run("playing an 8 inlines a suit prompt instead of forcing 's' on the next line", func(t *testing.T) {

--- a/internal/adapter/controller/CribbageCuiController.go
+++ b/internal/adapter/controller/CribbageCuiController.go
@@ -42,7 +42,7 @@ func (c *CribbageCuiController) Exec(command string) string {
 			case "c", "cut":
 				return c.ci.Cut(), true
 			case "p", "peg":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.ci.Peg)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.ci.Peg)
 			case "go":
 				return c.ci.Go(), true
 			case "h", "hint":

--- a/internal/adapter/controller/CribbageCuiController_test.go
+++ b/internal/adapter/controller/CribbageCuiController_test.go
@@ -140,13 +140,13 @@ func TestCribbageCuiController_Exec(t *testing.T) {
 	t.Run("peg command p no args", func(t *testing.T) {
 		c := controller.NewCribbageCuiController(newMock())
 		result := c.Exec("p")
-		assert.Contains(t, result, "Card index is required")
+		assert.Contains(t, result, msgCardIndexRequired())
 	})
 
 	t.Run("peg command p invalid arg", func(t *testing.T) {
 		c := controller.NewCribbageCuiController(newMock())
 		result := c.Exec("p abc")
-		assert.Contains(t, result, "Invalid card index")
+		assert.Contains(t, result, msgInvalidCardIndexPrefix())
 	})
 
 	// go

--- a/internal/adapter/controller/CucumberCuiController.go
+++ b/internal/adapter/controller/CucumberCuiController.go
@@ -35,7 +35,7 @@ func (c *CucumberCuiController) Exec(command string) string {
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.",
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex",
 					cuiutil.NoMin, cuiutil.NoMax, c.ci.Play)
 			case "n", "next":
 				return c.ci.NextRound(), true

--- a/internal/adapter/controller/CucumberCuiController_test.go
+++ b/internal/adapter/controller/CucumberCuiController_test.go
@@ -47,8 +47,8 @@ func TestCucumberCuiController_Commands(t *testing.T) {
 
 func TestCucumberCuiController_PlayRejectsBadArgs(t *testing.T) {
 	for _, tc := range []struct{ name, cmd, want string }{
-		{"index missing", "p", "Card index is required."},
-		{"index not a number", "p x", "Invalid card index: x."},
+		{"index missing", "p", msgCardIndexRequired()},
+		{"index not a number", "p x", msgInvalidCardIndex("x")},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			c, ci := newCucumberCui()

--- a/internal/adapter/controller/DesmocheCuiController.go
+++ b/internal/adapter/controller/DesmocheCuiController.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -55,7 +56,7 @@ func (c *DesmocheCuiController) Exec(command string) string {
 			case "x", "desmoche":
 				return c.desmoche(args)
 			case "d", "discard":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.di.Discard)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.di.Discard)
 			case "n", "next":
 				return c.di.NextRound(), true
 			default:
@@ -76,7 +77,7 @@ func (c *DesmocheCuiController) meld(args []string) (string, bool) {
 	for _, p := range parts {
 		n, err := strconv.Atoi(strings.TrimSpace(p))
 		if err != nil || n < 0 {
-			return "Invalid card index: " + p + ".", true
+			return i18n.Tf("invalidCardIndex", "val", p), true
 		}
 		idxs = append(idxs, n)
 	}
@@ -90,7 +91,7 @@ func (c *DesmocheCuiController) layOff(args []string) (string, bool) {
 	}
 	card, ok := desmocheParseIdx(args[0])
 	if !ok {
-		return "Invalid card index: " + args[0] + ".", true
+		return i18n.Tf("invalidCardIndex", "val", args[0]), true
 	}
 	meld, ok := desmocheParseIdx(args[1])
 	if !ok {
@@ -110,7 +111,7 @@ func (c *DesmocheCuiController) desmoche(args []string) (string, bool) {
 	}
 	card, ok := desmocheParseIdx(args[1])
 	if !ok {
-		return "Invalid card index: " + args[1] + ".", true
+		return i18n.Tf("invalidCardIndex", "val", args[1]), true
 	}
 	to, ok := desmocheParseIdx(args[2])
 	if !ok {

--- a/internal/adapter/controller/DoppelkopfCuiController.go
+++ b/internal/adapter/controller/DoppelkopfCuiController.go
@@ -48,7 +48,7 @@ func (c *DoppelkopfCuiController) Exec(command string) string {
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.di.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.di.Play)
 			case "a", "announce":
 				return c.di.Announce(), true
 			case "n", "next":

--- a/internal/adapter/controller/DoppelkopfCuiController_test.go
+++ b/internal/adapter/controller/DoppelkopfCuiController_test.go
@@ -50,7 +50,7 @@ func TestDoppelkopfCuiController_Exec(t *testing.T) {
 
 	t.Run("play no args", func(t *testing.T) {
 		result := controller.NewDoppelkopfCuiController(newMock()).Exec("play")
-		assert.Contains(t, result, "Card index is required")
+		assert.Contains(t, result, msgCardIndexRequired())
 	})
 
 	t.Run("announce shorthand a", func(t *testing.T) {

--- a/internal/adapter/controller/EcarteCuiController.go
+++ b/internal/adapter/controller/EcarteCuiController.go
@@ -64,7 +64,7 @@ func (c *EcarteCuiController) Exec(command string) string {
 				indices, skipped := cuiutil.ParseBoundedIntSlice(args, 0, domain.EcarteHandSize-1)
 				return cuiutil.PrependSkippedWarning(c.ei.Discard(indices), skipped), true
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.ei.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.ei.Play)
 			case "n", "next", "nextround":
 				return c.ei.NextRound(), true
 			case "sd", "setdifficulty":

--- a/internal/adapter/controller/EcarteCuiController_test.go
+++ b/internal/adapter/controller/EcarteCuiController_test.go
@@ -110,12 +110,12 @@ func TestEcarteCuiController_Exec(t *testing.T) {
 
 	t.Run("play missing index", func(t *testing.T) {
 		c := controller.NewEcarteCuiController(newMock())
-		assert.Contains(t, c.Exec("p"), "Card index is required")
+		assert.Contains(t, c.Exec("p"), msgCardIndexRequired())
 	})
 
 	t.Run("play invalid index", func(t *testing.T) {
 		c := controller.NewEcarteCuiController(newMock())
-		assert.Contains(t, c.Exec("p abc"), "Invalid card index")
+		assert.Contains(t, c.Exec("p abc"), msgInvalidCardIndexPrefix())
 	})
 
 	t.Run("next short", func(t *testing.T) {

--- a/internal/adapter/controller/EstimationCuiController.go
+++ b/internal/adapter/controller/EstimationCuiController.go
@@ -44,7 +44,7 @@ func (c *EstimationCuiController) Exec(command string) string {
 				return cuiutil.WithParsedInt(args, "Bid is required.", "Invalid bid: %s.",
 					0, domain.EstimationHandSize, c.ei.Bid)
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.ei.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.ei.Play)
 			case "n", "next":
 				return c.ei.NextRound(), true
 			case "g", "giveup":

--- a/internal/adapter/controller/EstimationCuiController_test.go
+++ b/internal/adapter/controller/EstimationCuiController_test.go
@@ -143,8 +143,8 @@ func TestEstimationCuiControllerPlay(t *testing.T) {
 
 func TestEstimationCuiControllerPlayRejectsBadArgs(t *testing.T) {
 	for _, tc := range []struct{ name, cmd, want string }{
-		{"missing index", "p", "Card index is required."},
-		{"non-numeric", "p abc", "Invalid card index: abc."},
+		{"missing index", "p", msgCardIndexRequired()},
+		{"non-numeric", "p abc", msgInvalidCardIndex("abc")},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			ei := newMockEstimationInteractor()

--- a/internal/adapter/controller/EuchreCuiController.go
+++ b/internal/adapter/controller/EuchreCuiController.go
@@ -71,9 +71,9 @@ func (c *EuchreCuiController) Exec(command string) string {
 					return c.ei.CallTrump(suit, true)
 				})
 			case "d", "discard":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.ei.Discard)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.ei.Discard)
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.ei.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.ei.Play)
 			case "n", "next":
 				return c.ei.NextTrick(), true
 			case "nr", "nextround":

--- a/internal/adapter/controller/EuchreCuiController_test.go
+++ b/internal/adapter/controller/EuchreCuiController_test.go
@@ -197,13 +197,13 @@ func TestEuchreCuiController_Exec(t *testing.T) {
 	t.Run("discard command d no args", func(t *testing.T) {
 		c := controller.NewEuchreCuiController(newMock())
 		result := c.Exec("d")
-		assert.Contains(t, result, "Card index is required")
+		assert.Contains(t, result, msgCardIndexRequired())
 	})
 
 	t.Run("discard command d invalid arg", func(t *testing.T) {
 		c := controller.NewEuchreCuiController(newMock())
 		result := c.Exec("d abc")
-		assert.Contains(t, result, "Invalid card index")
+		assert.Contains(t, result, msgInvalidCardIndexPrefix())
 	})
 
 	// play
@@ -226,13 +226,13 @@ func TestEuchreCuiController_Exec(t *testing.T) {
 	t.Run("play command p no args", func(t *testing.T) {
 		c := controller.NewEuchreCuiController(newMock())
 		result := c.Exec("p")
-		assert.Contains(t, result, "Card index is required")
+		assert.Contains(t, result, msgCardIndexRequired())
 	})
 
 	t.Run("play command p invalid arg", func(t *testing.T) {
 		c := controller.NewEuchreCuiController(newMock())
 		result := c.Exec("p abc")
-		assert.Contains(t, result, "Invalid card index")
+		assert.Contains(t, result, msgInvalidCardIndexPrefix())
 	})
 
 	// next

--- a/internal/adapter/controller/FiveHundredCuiController.go
+++ b/internal/adapter/controller/FiveHundredCuiController.go
@@ -85,7 +85,7 @@ func (c *FiveHundredCuiController) Exec(command string) string {
 				}
 				idxs := make([]int, 3)
 				for i := 0; i < 3; i++ {
-					v, errMsg, ok := cuiutil.ParseIntArg(args[i:i+1], "", "Invalid card index: %s.", 0, math.MaxInt)
+					v, errMsg, ok := cuiutil.ParseIntArgKeys(args[i:i+1], "", "invalidCardIndex", 0, math.MaxInt)
 					if !ok {
 						return errMsg, true
 					}
@@ -93,7 +93,7 @@ func (c *FiveHundredCuiController) Exec(command string) string {
 				}
 				return c.fi.ExchangeKitty(idxs), true
 			case "p", "play":
-				cardIdx, errMsg, ok := cuiutil.ParseIntArg(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax)
+				cardIdx, errMsg, ok := cuiutil.ParseIntArgKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax)
 				if !ok {
 					return errMsg, true
 				}

--- a/internal/adapter/controller/FiveHundredCuiController_test.go
+++ b/internal/adapter/controller/FiveHundredCuiController_test.go
@@ -76,7 +76,7 @@ func TestFiveHundredCuiController_Usage(t *testing.T) {
 	if got := c.Exec("e 0"); !strings.Contains(got, "Usage") {
 		t.Errorf("exchange with one arg should show usage, got %q", got)
 	}
-	if got := c.Exec("p"); !strings.Contains(got, "required") {
+	if got := c.Exec("p"); !strings.Contains(got, msgCardIndexRequired()) {
 		t.Errorf("play without args should require index, got %q", got)
 	}
 }

--- a/internal/adapter/controller/FortyFivesCuiController.go
+++ b/internal/adapter/controller/FortyFivesCuiController.go
@@ -52,7 +52,7 @@ func (c *FortyFivesCuiController) Exec(command string) string {
 			case "pass":
 				return c.di.Bid(int(domain.FortyFivesBidPass)), true
 			case "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.di.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.di.Play)
 			case "n", "next":
 				return c.di.NextTrick(), true
 			case "nr", "nextround":

--- a/internal/adapter/controller/FortyFivesCuiController_test.go
+++ b/internal/adapter/controller/FortyFivesCuiController_test.go
@@ -74,7 +74,7 @@ func TestFortyFivesCuiController_Exec(t *testing.T) {
 
 	t.Run("play no args", func(t *testing.T) {
 		result := controller.NewFortyFivesCuiController(newMock()).Exec("play")
-		assert.Contains(t, result, "Card index is required")
+		assert.Contains(t, result, msgCardIndexRequired())
 	})
 
 	t.Run("next / nextround", func(t *testing.T) {

--- a/internal/adapter/controller/FrenchTarotCuiController.go
+++ b/internal/adapter/controller/FrenchTarotCuiController.go
@@ -5,6 +5,7 @@ package controller
 import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -53,7 +54,7 @@ func (c *FrenchTarotCuiController) Exec(command string) string {
 			case "discard":
 				return c.execDiscard(args)
 			case "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.di.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.di.Play)
 			case "n", "next":
 				return c.di.NextTrick(), true
 			case "nr", "nextround":
@@ -90,7 +91,7 @@ func (c *FrenchTarotCuiController) execDiscard(args []string) (string, bool) {
 	}
 	indices, skipped := cuiutil.ParseIntSlice(args)
 	if len(skipped) > 0 {
-		return "Invalid card index: " + skipped[0] + ".", true
+		return i18n.Tf("invalidCardIndex", "val", skipped[0]), true
 	}
 	return c.di.Discard(indices), true
 }

--- a/internal/adapter/controller/FrenchTarotCuiController_test.go
+++ b/internal/adapter/controller/FrenchTarotCuiController_test.go
@@ -87,7 +87,7 @@ func TestFrenchTarotCuiController_Exec(t *testing.T) {
 
 	t.Run("discard invalid index", func(t *testing.T) {
 		result := controller.NewFrenchTarotCuiController(newMock()).Exec("discard 0 1 2 3 4 x")
-		assert.Contains(t, result, "Invalid card index")
+		assert.Contains(t, result, msgInvalidCardIndexPrefix())
 	})
 
 	t.Run("play card", func(t *testing.T) {
@@ -99,7 +99,7 @@ func TestFrenchTarotCuiController_Exec(t *testing.T) {
 
 	t.Run("play no args", func(t *testing.T) {
 		result := controller.NewFrenchTarotCuiController(newMock()).Exec("play")
-		assert.Contains(t, result, "Card index is required")
+		assert.Contains(t, result, msgCardIndexRequired())
 	})
 
 	t.Run("next / nextround", func(t *testing.T) {

--- a/internal/adapter/controller/GaigelCuiController.go
+++ b/internal/adapter/controller/GaigelCuiController.go
@@ -50,9 +50,9 @@ func (c *GaigelCuiController) Exec(command string) string {
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.gi.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.gi.Play)
 			case "m", "marriage":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.gi.DeclareMarriage)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.gi.DeclareMarriage)
 			case "n", "next":
 				return c.gi.NextTrick(), true
 			case "nr", "nextround":

--- a/internal/adapter/controller/GaigelCuiController_test.go
+++ b/internal/adapter/controller/GaigelCuiController_test.go
@@ -50,7 +50,7 @@ func TestGaigelCuiController_Exec(t *testing.T) {
 
 	t.Run("play no args", func(t *testing.T) {
 		c := controller.NewGaigelCuiController(newMock())
-		assert.Contains(t, c.Exec("p"), "Card index is required")
+		assert.Contains(t, c.Exec("p"), msgCardIndexRequired())
 	})
 
 	t.Run("marriage m with index", func(t *testing.T) {
@@ -69,7 +69,7 @@ func TestGaigelCuiController_Exec(t *testing.T) {
 
 	t.Run("marriage no args", func(t *testing.T) {
 		c := controller.NewGaigelCuiController(newMock())
-		assert.Contains(t, c.Exec("m"), "Card index is required")
+		assert.Contains(t, c.Exec("m"), msgCardIndexRequired())
 	})
 
 	t.Run("next n", func(t *testing.T) {

--- a/internal/adapter/controller/GanjifaCuiController.go
+++ b/internal/adapter/controller/GanjifaCuiController.go
@@ -44,7 +44,7 @@ func (c *GanjifaCuiController) Exec(command string) string {
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.di.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.di.Play)
 			case "n", "next":
 				return c.di.NextTrick(), true
 			case "nr", "nextround":

--- a/internal/adapter/controller/GanjifaCuiController_test.go
+++ b/internal/adapter/controller/GanjifaCuiController_test.go
@@ -49,7 +49,7 @@ func TestGanjifaCuiController_Exec(t *testing.T) {
 
 	t.Run("play no args", func(t *testing.T) {
 		result := controller.NewGanjifaCuiController(newMock()).Exec("play")
-		assert.Contains(t, result, "Card index is required")
+		assert.Contains(t, result, msgCardIndexRequired())
 	})
 
 	// Ganjifa has no bidding, so bid/pass must not silently resolve to something.

--- a/internal/adapter/controller/GermanWhistCuiController.go
+++ b/internal/adapter/controller/GermanWhistCuiController.go
@@ -34,7 +34,7 @@ func (c *GermanWhistCuiController) Exec(command string) string {
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.gi.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.gi.Play)
 			case "g", "giveup":
 				return c.gi.GiveUp(), true
 			default:

--- a/internal/adapter/controller/GermanWhistCuiController_test.go
+++ b/internal/adapter/controller/GermanWhistCuiController_test.go
@@ -55,8 +55,8 @@ func TestGermanWhistCuiControllerPlay(t *testing.T) {
 // 引数の欠落と不正はそれぞれ固有の文言で断り、インタラクターには届かない。
 func TestGermanWhistCuiControllerPlayRejectsBadArgs(t *testing.T) {
 	for _, tc := range []struct{ name, cmd, want string }{
-		{"missing index", "p", "Card index is required."},
-		{"non-numeric", "p abc", "Invalid card index: abc."},
+		{"missing index", "p", msgCardIndexRequired()},
+		{"non-numeric", "p abc", msgInvalidCardIndex("abc")},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			gi := newMockGermanWhistInteractor()

--- a/internal/adapter/controller/GinRummyCuiController.go
+++ b/internal/adapter/controller/GinRummyCuiController.go
@@ -41,9 +41,9 @@ func (c *GinRummyCuiController) Exec(command string) string {
 			case "dd", "drawdiscard":
 				return c.ci.DrawFromDiscard(), true
 			case "d", "discard":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.ci.Discard)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.ci.Discard)
 			case "k", "knock":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.ci.Knock)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.ci.Knock)
 			case "lo", "layoff":
 				indices := parseIntList(args)
 				return c.ci.Layoff(indices), true

--- a/internal/adapter/controller/GinRummyCuiController_test.go
+++ b/internal/adapter/controller/GinRummyCuiController_test.go
@@ -114,13 +114,13 @@ func TestGinRummyCuiController_Exec(t *testing.T) {
 	t.Run("discard command d no args", func(t *testing.T) {
 		c := controller.NewGinRummyCuiController(newMock())
 		result := c.Exec("d")
-		assert.Contains(t, result, "Card index is required")
+		assert.Contains(t, result, msgCardIndexRequired())
 	})
 
 	t.Run("discard command d invalid arg", func(t *testing.T) {
 		c := controller.NewGinRummyCuiController(newMock())
 		result := c.Exec("d abc")
-		assert.Contains(t, result, "Invalid card index")
+		assert.Contains(t, result, msgInvalidCardIndexPrefix())
 	})
 
 	// knock
@@ -143,13 +143,13 @@ func TestGinRummyCuiController_Exec(t *testing.T) {
 	t.Run("knock command k no args", func(t *testing.T) {
 		c := controller.NewGinRummyCuiController(newMock())
 		result := c.Exec("k")
-		assert.Contains(t, result, "Card index is required")
+		assert.Contains(t, result, msgCardIndexRequired())
 	})
 
 	t.Run("knock command k invalid arg", func(t *testing.T) {
 		c := controller.NewGinRummyCuiController(newMock())
 		result := c.Exec("k abc")
-		assert.Contains(t, result, "Invalid card index")
+		assert.Contains(t, result, msgInvalidCardIndexPrefix())
 	})
 
 	// layoff

--- a/internal/adapter/controller/GoStopCuiController.go
+++ b/internal/adapter/controller/GoStopCuiController.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -69,11 +70,11 @@ func (c *GoStopCuiController) Exec(command string) string {
 // handlePlay は "p <handIdx> [fieldIdx]" を解析して Play を呼ぶ。
 func (c *GoStopCuiController) handlePlay(args []string) string {
 	if len(args) == 0 {
-		return "Card index is required (e.g. p 0, or p 0 3 to pick a field card)."
+		return i18n.T("cardIndexRequiredField")
 	}
 	handIdx, err := strconv.Atoi(args[0])
 	if err != nil {
-		return "Invalid card index: " + args[0] + "."
+		return i18n.Tf("invalidCardIndex", "val", args[0])
 	}
 	fieldIdx := -1
 	if len(args) >= 2 {

--- a/internal/adapter/controller/GoStopCuiController_test.go
+++ b/internal/adapter/controller/GoStopCuiController_test.go
@@ -49,11 +49,11 @@ func TestGoStopCuiController_Exec(t *testing.T) {
 	})
 	t.Run("play missing index", func(t *testing.T) {
 		out := controller.NewGoStopCuiController(newMock()).Exec("p")
-		assert.Contains(t, out, "required")
+		assert.Contains(t, out, msgCardIndexRequiredField())
 	})
 	t.Run("play invalid index", func(t *testing.T) {
 		out := controller.NewGoStopCuiController(newMock()).Exec("p xyz")
-		assert.Contains(t, out, "Invalid card index")
+		assert.Contains(t, out, msgInvalidCardIndexPrefix())
 	})
 	t.Run("go", func(t *testing.T) {
 		m := newMock()

--- a/internal/adapter/controller/GongZhuCuiController.go
+++ b/internal/adapter/controller/GongZhuCuiController.go
@@ -48,7 +48,7 @@ func (c *GongZhuCuiController) Exec(command string) string {
 				indices, skipped := cuiutil.ParseIntSlice(args)
 				return cuiutil.PrependSkippedWarning(c.gi.Expose(indices), skipped), true
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.gi.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.gi.Play)
 			case "n", "next":
 				return c.gi.NextTrick(), true
 			case "nr", "nextround":

--- a/internal/adapter/controller/GongZhuCuiController_test.go
+++ b/internal/adapter/controller/GongZhuCuiController_test.go
@@ -72,7 +72,7 @@ func TestGongZhuCuiController_Exec(t *testing.T) {
 
 	t.Run("play no args", func(t *testing.T) {
 		result := controller.NewGongZhuCuiController(newMock()).Exec("p")
-		assert.Contains(t, result, "Card index is required")
+		assert.Contains(t, result, msgCardIndexRequired())
 	})
 
 	t.Run("next / nextround", func(t *testing.T) {

--- a/internal/adapter/controller/GoofspielCuiController.go
+++ b/internal/adapter/controller/GoofspielCuiController.go
@@ -35,7 +35,7 @@ func (c *GoofspielCuiController) Exec(command string) string {
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "b", "bid":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.",
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex",
 					cuiutil.NoMin, cuiutil.NoMax, c.gi.Bid)
 			case "n", "next":
 				return c.gi.NextRound(), true

--- a/internal/adapter/controller/GoofspielCuiController_test.go
+++ b/internal/adapter/controller/GoofspielCuiController_test.go
@@ -47,8 +47,8 @@ func TestGoofspielCuiController_Commands(t *testing.T) {
 
 func TestGoofspielCuiController_BidRejectsBadArgs(t *testing.T) {
 	for _, tc := range []struct{ name, cmd, want string }{
-		{"index missing", "b", "Card index is required."},
-		{"index not a number", "b x", "Invalid card index: x."},
+		{"index missing", "b", msgCardIndexRequired()},
+		{"index not a number", "b x", msgInvalidCardIndex("x")},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			c, gi := newGoofspielCui()

--- a/internal/adapter/controller/GuandanCuiController.go
+++ b/internal/adapter/controller/GuandanCuiController.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -36,7 +37,7 @@ func (c *GuandanCuiController) Exec(command string) string {
 			case "ps", "pass":
 				return c.gi.Pass(), true
 			case "t", "tribute":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.",
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex",
 					0, domain.GuandanHandSize-1, func(v int) string {
 						return c.gi.ReturnTribute(v)
 					})
@@ -61,8 +62,7 @@ func guandanParsePlay(args []string, gi usecase.GuandanInteractorIF) (string, bo
 	for _, a := range args {
 		v, err := strconv.Atoi(a)
 		if err != nil || v < 0 || v >= domain.GuandanHandSize {
-			return "Invalid card index: " + a + ". Please enter 0-" +
-				strconv.Itoa(domain.GuandanHandSize-1) + ".", true
+			return i18n.Tf("invalidCardIndexRange", "val", a, "max", strconv.Itoa(domain.GuandanHandSize-1)), true
 		}
 		// **同じ札を 2 回数えられない。**
 		if seen[v] {

--- a/internal/adapter/controller/GuandanCuiController_test.go
+++ b/internal/adapter/controller/GuandanCuiController_test.go
@@ -49,9 +49,9 @@ func TestGuandanCuiController_Exec(t *testing.T) {
 	t.Run("play rejects bad input", func(t *testing.T) {
 		c := controller.NewGuandanCuiController(newMock())
 		assert.Contains(t, c.Exec("p"), "Card indexes are required")
-		assert.Contains(t, c.Exec("p abc"), "Invalid card index")
-		assert.Contains(t, c.Exec("p -1"), "Invalid card index")
-		assert.Contains(t, c.Exec("p 27"), "Invalid card index")
+		assert.Contains(t, c.Exec("p abc"), msgInvalidCardIndexPrefix())
+		assert.Contains(t, c.Exec("p -1"), msgInvalidCardIndexPrefix())
+		assert.Contains(t, c.Exec("p 27"), msgInvalidCardIndexPrefix())
 		// **同じ札を 2 回数えられない。**通すとペアが 1 枚から作れてしまう。
 		assert.Contains(t, c.Exec("p 1 1"), "twice")
 	})
@@ -73,9 +73,9 @@ func TestGuandanCuiController_Exec(t *testing.T) {
 
 	t.Run("tribute rejects bad input", func(t *testing.T) {
 		c := controller.NewGuandanCuiController(newMock())
-		assert.Contains(t, c.Exec("t"), "Card index is required")
-		assert.Contains(t, c.Exec("t abc"), "Invalid card index")
-		assert.Contains(t, c.Exec("t 27"), "Invalid card index")
+		assert.Contains(t, c.Exec("t"), msgCardIndexRequired())
+		assert.Contains(t, c.Exec("t abc"), msgInvalidCardIndexPrefix())
+		assert.Contains(t, c.Exec("t 27"), msgInvalidCardIndexPrefix())
 	})
 
 	t.Run("log and unknown", func(t *testing.T) {

--- a/internal/adapter/controller/HachiHachiCuiController.go
+++ b/internal/adapter/controller/HachiHachiCuiController.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -62,11 +63,11 @@ func (c *HachiHachiCuiController) Exec(command string) string {
 // handlePlay は "p <handIdx> [fieldIdx]" を解析して Play を呼ぶ。
 func (c *HachiHachiCuiController) handlePlay(args []string) string {
 	if len(args) == 0 {
-		return "Card index is required (e.g. p 0, or p 0 3 to pick a field card)."
+		return i18n.T("cardIndexRequiredField")
 	}
 	handIdx, err := strconv.Atoi(args[0])
 	if err != nil {
-		return "Invalid card index: " + args[0] + "."
+		return i18n.Tf("invalidCardIndex", "val", args[0])
 	}
 	fieldIdx := -1
 	if len(args) >= 2 {

--- a/internal/adapter/controller/HachiHachiCuiController_test.go
+++ b/internal/adapter/controller/HachiHachiCuiController_test.go
@@ -48,11 +48,11 @@ func TestHachiHachiCuiController_Exec(t *testing.T) {
 	})
 	t.Run("play missing index", func(t *testing.T) {
 		out := controller.NewHachiHachiCuiController(newMock()).Exec("p")
-		assert.Contains(t, out, "required")
+		assert.Contains(t, out, msgCardIndexRequiredField())
 	})
 	t.Run("play invalid index", func(t *testing.T) {
 		out := controller.NewHachiHachiCuiController(newMock()).Exec("p xyz")
-		assert.Contains(t, out, "Invalid card index")
+		assert.Contains(t, out, msgInvalidCardIndexPrefix())
 	})
 	t.Run("next round", func(t *testing.T) {
 		m := newMock()

--- a/internal/adapter/controller/HandAndFootCuiController.go
+++ b/internal/adapter/controller/HandAndFootCuiController.go
@@ -57,7 +57,7 @@ func (c *HandAndFootCuiController) Exec(command string) string {
 				groups := parseMeldGroups(args)
 				return c.ci.Meld(groups), true
 			case "d", "discard":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.ci.Discard)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.ci.Discard)
 			case "sd", "setdifficulty":
 				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
 					cfg := c.ci.GetConfig()

--- a/internal/adapter/controller/HandAndFootCuiController_test.go
+++ b/internal/adapter/controller/HandAndFootCuiController_test.go
@@ -90,12 +90,12 @@ func TestHandAndFootCuiController_Exec(t *testing.T) {
 
 	t.Run("discard d no args", func(t *testing.T) {
 		c := controller.NewHandAndFootCuiController(newMock())
-		assert.Contains(t, c.Exec("d"), "Card index is required")
+		assert.Contains(t, c.Exec("d"), msgCardIndexRequired())
 	})
 
 	t.Run("discard d invalid arg", func(t *testing.T) {
 		c := controller.NewHandAndFootCuiController(newMock())
-		assert.Contains(t, c.Exec("d abc"), "Invalid card index")
+		assert.Contains(t, c.Exec("d abc"), msgInvalidCardIndexPrefix())
 	})
 
 	t.Run("goout go", func(t *testing.T) {

--- a/internal/adapter/controller/HasenpfefferCuiController.go
+++ b/internal/adapter/controller/HasenpfefferCuiController.go
@@ -48,7 +48,7 @@ func (c *HasenpfefferCuiController) Exec(command string) string {
 			case "d", "discard":
 				return c.discard(args)
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.hi.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.hi.Play)
 			case "n", "next":
 				return c.hi.NextHand(), true
 			case "g", "giveup":
@@ -65,7 +65,7 @@ func (c *HasenpfefferCuiController) Exec(command string) string {
 // **どちらも既定値で埋めない。** 埋めると捨てていない札が捨てられたり、
 // 選んでいないスートが切り札になる。
 func (c *HasenpfefferCuiController) discard(args []string) (string, bool) {
-	idx, errMsg, ok := cuiutil.ParseIntArg(args, "Card index is required.", "Invalid card index: %s.",
+	idx, errMsg, ok := cuiutil.ParseIntArgKeys(args, "cardIndexRequired", "invalidCardIndex",
 		cuiutil.NoMin, cuiutil.NoMax)
 	if !ok {
 		return errMsg, true

--- a/internal/adapter/controller/HasenpfefferCuiController_test.go
+++ b/internal/adapter/controller/HasenpfefferCuiController_test.go
@@ -94,9 +94,9 @@ func TestHasenpfefferCuiControllerDiscard(t *testing.T) {
 // **どちらの引数も既定値で埋めない。** 埋めると選んでいないスートが切り札になる。
 func TestHasenpfefferCuiControllerDiscardRejectsBadArgs(t *testing.T) {
 	for _, tc := range []struct{ name, cmd, want string }{
-		{"no args", "d", "Card index is required."},
+		{"no args", "d", msgCardIndexRequired()},
 		{"only the index", "d 2", "Suit is required."},
-		{"non-numeric index", "d x 3", "Invalid card index: x."},
+		{"non-numeric index", "d x 3", msgInvalidCardIndex("x")},
 		{"non-numeric suit", "d 2 x", "Invalid suit: x."},
 		{"suit below the range", "d 2 0", "Invalid suit: 0."},
 		{"suit above the range", "d 2 5", "Invalid suit: 5."},
@@ -124,8 +124,8 @@ func TestHasenpfefferCuiControllerPlay(t *testing.T) {
 
 func TestHasenpfefferCuiControllerPlayRejectsBadArgs(t *testing.T) {
 	for _, tc := range []struct{ name, cmd, want string }{
-		{"missing index", "p", "Card index is required."},
-		{"non-numeric", "p abc", "Invalid card index: abc."},
+		{"missing index", "p", msgCardIndexRequired()},
+		{"non-numeric", "p abc", msgInvalidCardIndex("abc")},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			hi := newMockHasenpfefferInteractor()

--- a/internal/adapter/controller/HeartsCuiController.go
+++ b/internal/adapter/controller/HeartsCuiController.go
@@ -54,7 +54,7 @@ func (c *HeartsCuiController) Exec(command string) string {
 				}
 				return cuiutil.PrependSkippedWarning(result, skipped), true
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.hi.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.hi.Play)
 			case "n", "next":
 				return c.hi.NextTrick(), true
 			case "nr", "nextround":

--- a/internal/adapter/controller/HeartsCuiController_test.go
+++ b/internal/adapter/controller/HeartsCuiController_test.go
@@ -129,13 +129,13 @@ func TestHeartsCuiController_Exec(t *testing.T) {
 	t.Run("play command p no args", func(t *testing.T) {
 		c := controller.NewHeartsCuiController(newMock())
 		result := c.Exec("p")
-		assert.Contains(t, result, "Card index is required")
+		assert.Contains(t, result, msgCardIndexRequired())
 	})
 
 	t.Run("play command p invalid arg", func(t *testing.T) {
 		c := controller.NewHeartsCuiController(newMock())
 		result := c.Exec("p abc")
-		assert.Contains(t, result, "Invalid card index")
+		assert.Contains(t, result, msgInvalidCardIndexPrefix())
 	})
 
 	// next

--- a/internal/adapter/controller/HokmCuiController.go
+++ b/internal/adapter/controller/HokmCuiController.go
@@ -40,7 +40,7 @@ func (c *HokmCuiController) Exec(command string) string {
 				return cuiutil.WithParsedInt(args, "Suit is required.", "Invalid suit: %s.",
 					domain.CardDesignSpade, domain.CardDesignMax, c.hi.DeclareTrump)
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.hi.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.hi.Play)
 			case "n", "next":
 				return c.hi.NextHand(), true
 			case "g", "giveup":

--- a/internal/adapter/controller/HokmCuiController_test.go
+++ b/internal/adapter/controller/HokmCuiController_test.go
@@ -99,8 +99,8 @@ func TestHokmCuiControllerPlay(t *testing.T) {
 
 func TestHokmCuiControllerPlayRejectsBadArgs(t *testing.T) {
 	for _, tc := range []struct{ name, cmd, want string }{
-		{"missing index", "p", "Card index is required."},
-		{"non-numeric", "p abc", "Invalid card index: abc."},
+		{"missing index", "p", msgCardIndexRequired()},
+		{"non-numeric", "p abc", msgInvalidCardIndex("abc")},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			hi := newMockHokmInteractor()

--- a/internal/adapter/controller/HoneymoonBridgeCuiController.go
+++ b/internal/adapter/controller/HoneymoonBridgeCuiController.go
@@ -44,7 +44,7 @@ func (c *HoneymoonBridgeCuiController) Exec(command string) string {
 			case "pass":
 				return c.hi.Pass(), true
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.hi.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.hi.Play)
 			case "n", "next":
 				return c.hi.NextRound(), true
 			case "g", "giveup":

--- a/internal/adapter/controller/HoneymoonBridgeCuiController_test.go
+++ b/internal/adapter/controller/HoneymoonBridgeCuiController_test.go
@@ -72,8 +72,8 @@ func TestHoneymoonBridgeCuiController_BidRejectsBadArgs(t *testing.T) {
 
 func TestHoneymoonBridgeCuiController_PlayRejectsBadArgs(t *testing.T) {
 	for _, tc := range []struct{ name, cmd, want string }{
-		{"index missing", "p", "Card index is required."},
-		{"index not a number", "p x", "Invalid card index: x."},
+		{"index missing", "p", msgCardIndexRequired()},
+		{"index not a number", "p x", msgInvalidCardIndex("x")},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			c, hi := newHoneymoonBridgeCui()

--- a/internal/adapter/controller/IndianRummyCuiController.go
+++ b/internal/adapter/controller/IndianRummyCuiController.go
@@ -43,9 +43,9 @@ func (c *IndianRummyCuiController) Exec(command string) string {
 			case "dd", "drawdiscard":
 				return c.ci.DrawFromDiscard(), true
 			case "d", "discard":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.ci.Discard)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.ci.Discard)
 			case "de", "declare":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.ci.Declare)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.ci.Declare)
 			case "nr", "nextround":
 				return c.ci.NextRound(), true
 			case "pc", "setplayers":

--- a/internal/adapter/controller/IsraeliWhistCuiController.go
+++ b/internal/adapter/controller/IsraeliWhistCuiController.go
@@ -46,7 +46,7 @@ func (c *IsraeliWhistCuiController) Exec(command string) string {
 				return cuiutil.WithParsedInt(args, "Bid is required.", "Invalid bid: %s.",
 					0, domain.IsraeliWhistHandSize, c.wi.Bid)
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.wi.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.wi.Play)
 			case "n", "next":
 				return c.wi.NextRound(), true
 			case "g", "giveup":

--- a/internal/adapter/controller/IsraeliWhistCuiController_test.go
+++ b/internal/adapter/controller/IsraeliWhistCuiController_test.go
@@ -149,8 +149,8 @@ func TestIsraeliWhistCuiControllerPlay(t *testing.T) {
 
 func TestIsraeliWhistCuiControllerPlayRejectsBadArgs(t *testing.T) {
 	for _, tc := range []struct{ name, cmd, want string }{
-		{"missing index", "p", "Card index is required."},
-		{"non-numeric", "p abc", "Invalid card index: abc."},
+		{"missing index", "p", msgCardIndexRequired()},
+		{"non-numeric", "p abc", msgInvalidCardIndex("abc")},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			wi := newMockIsraeliWhistInteractor()

--- a/internal/adapter/controller/JassCuiController.go
+++ b/internal/adapter/controller/JassCuiController.go
@@ -58,7 +58,7 @@ func (c *JassCuiController) Exec(command string) string {
 			case "sc", "schieben":
 				return c.ji.Schieben(), true
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.ji.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.ji.Play)
 			case "n", "next":
 				return c.ji.NextTrick(), true
 			case "nr", "nextround":

--- a/internal/adapter/controller/JassCuiController_test.go
+++ b/internal/adapter/controller/JassCuiController_test.go
@@ -89,7 +89,7 @@ func TestJassCuiController_Exec(t *testing.T) {
 
 	t.Run("play no args", func(t *testing.T) {
 		c := controller.NewJassCuiController(newMock())
-		assert.Contains(t, c.Exec("p"), "Card index is required")
+		assert.Contains(t, c.Exec("p"), msgCardIndexRequired())
 	})
 
 	t.Run("next n", func(t *testing.T) {

--- a/internal/adapter/controller/KaiserCuiController.go
+++ b/internal/adapter/controller/KaiserCuiController.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -46,7 +47,7 @@ func (c *KaiserCuiController) Exec(command string) string {
 			case "d", "discard":
 				return kaiserParseDiscard(args, c.ki)
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", 0, domain.KaiserHandSize+domain.KaiserKittySize-1, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", 0, domain.KaiserHandSize+domain.KaiserKittySize-1, func(v int) string {
 					return c.ki.PlayCard(v)
 				})
 			case "n", "next":
@@ -89,7 +90,7 @@ func kaiserParseDiscard(args []string, ki usecase.KaiserInteractorIF) (string, b
 	for _, a := range args[:domain.KaiserKittySize] {
 		v, err := strconv.Atoi(strings.TrimSpace(a))
 		if err != nil || v < 0 {
-			return "Invalid card index: " + a + ".", true
+			return i18n.Tf("invalidCardIndex", "val", a), true
 		}
 		idxs = append(idxs, v)
 	}

--- a/internal/adapter/controller/KaiserCuiController_test.go
+++ b/internal/adapter/controller/KaiserCuiController_test.go
@@ -91,7 +91,7 @@ func TestKaiserCuiController_Exec(t *testing.T) {
 		m.AssertCalled(t, "Discard", []int{0, 3})
 		assert.Contains(t, c.Exec("d 0"), "Two card indices")
 		assert.Contains(t, c.Exec("d"), "Two card indices")
-		assert.Contains(t, c.Exec("d a b"), "Invalid card index")
+		assert.Contains(t, c.Exec("d a b"), msgInvalidCardIndexPrefix())
 	})
 
 	t.Run("play and next", func(t *testing.T) {
@@ -101,7 +101,7 @@ func TestKaiserCuiController_Exec(t *testing.T) {
 		m.AssertCalled(t, "PlayCard", 2)
 		assert.Equal(t, mockOutput, c.Exec("n"))
 		m.AssertCalled(t, "NextHand")
-		assert.Contains(t, c.Exec("p abc"), "Invalid card index")
+		assert.Contains(t, c.Exec("p abc"), msgInvalidCardIndexPrefix())
 	})
 
 	t.Run("log and unknown", func(t *testing.T) {

--- a/internal/adapter/controller/KalookiCuiController.go
+++ b/internal/adapter/controller/KalookiCuiController.go
@@ -54,7 +54,7 @@ func (c *KalookiCuiController) Exec(command string) string {
 				}
 				return c.ci.Layoff(idx[0], idx[1], idx[2]), true
 			case "d", "discard":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.ci.Discard)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.ci.Discard)
 			case "nr", "nextround":
 				return c.ci.NextRound(), true
 			case "sd", "setdifficulty":

--- a/internal/adapter/controller/KarnoffelCuiController.go
+++ b/internal/adapter/controller/KarnoffelCuiController.go
@@ -30,7 +30,7 @@ func (c *KarnoffelCuiController) Exec(command string) string {
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.",
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex",
 					0, domain.KarnoffelHandSize-1, func(v int) string {
 						return c.ki.PlayCard(v)
 					})

--- a/internal/adapter/controller/KarnoffelCuiController_test.go
+++ b/internal/adapter/controller/KarnoffelCuiController_test.go
@@ -44,10 +44,10 @@ func TestKarnoffelCuiController_Exec(t *testing.T) {
 		m.AssertCalled(t, "PlayCard", 0)
 		assert.Equal(t, mockOutput, c.Exec("n"))
 		m.AssertCalled(t, "NextHand")
-		assert.Contains(t, c.Exec("p"), "required")
-		assert.Contains(t, c.Exec("p abc"), "Invalid card index")
-		assert.Contains(t, c.Exec("p 5"), "Invalid card index")
-		assert.Contains(t, c.Exec("p -1"), "Invalid card index")
+		assert.Contains(t, c.Exec("p"), msgCardIndexRequired())
+		assert.Contains(t, c.Exec("p abc"), msgInvalidCardIndexPrefix())
+		assert.Contains(t, c.Exec("p 5"), msgInvalidCardIndexPrefix())
+		assert.Contains(t, c.Exec("p -1"), msgInvalidCardIndexPrefix())
 	})
 
 	t.Run("log and unknown", func(t *testing.T) {

--- a/internal/adapter/controller/KlaberjassCuiController.go
+++ b/internal/adapter/controller/KlaberjassCuiController.go
@@ -49,7 +49,7 @@ func (c *KlaberjassCuiController) Exec(command string) string {
 			case "no":
 				return c.ki.AnswerSchmeiss(false), true
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", 0, 8, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", 0, 8, func(v int) string {
 					return c.ki.PlayCard(v)
 				})
 			case "n", "next":

--- a/internal/adapter/controller/KlaberjassCuiController_test.go
+++ b/internal/adapter/controller/KlaberjassCuiController_test.go
@@ -84,9 +84,9 @@ func TestKlaberjassCuiController_Exec(t *testing.T) {
 
 	t.Run("play rejects a bad index", func(t *testing.T) {
 		c := controller.NewKlaberjassCuiController(newMock())
-		assert.Contains(t, c.Exec("p"), "required")
-		assert.Contains(t, c.Exec("p abc"), "Invalid card index")
-		assert.Contains(t, c.Exec("p 9"), "Invalid card index")
+		assert.Contains(t, c.Exec("p"), msgCardIndexRequired())
+		assert.Contains(t, c.Exec("p abc"), msgInvalidCardIndexPrefix())
+		assert.Contains(t, c.Exec("p 9"), msgInvalidCardIndexPrefix())
 	})
 
 	t.Run("settarget", func(t *testing.T) {

--- a/internal/adapter/controller/KlaverjasCuiController.go
+++ b/internal/adapter/controller/KlaverjasCuiController.go
@@ -44,7 +44,7 @@ func (c *KlaverjasCuiController) Exec(command string) string {
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.di.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.di.Play)
 			case "n", "next":
 				return c.di.NextTrick(), true
 			case "nr", "nextround":

--- a/internal/adapter/controller/KlaverjasCuiController_test.go
+++ b/internal/adapter/controller/KlaverjasCuiController_test.go
@@ -49,7 +49,7 @@ func TestKlaverjasCuiController_Exec(t *testing.T) {
 
 	t.Run("play no args", func(t *testing.T) {
 		result := controller.NewKlaverjasCuiController(newMock()).Exec("play")
-		assert.Contains(t, result, "Card index is required")
+		assert.Contains(t, result, msgCardIndexRequired())
 	})
 
 	t.Run("next / nextround", func(t *testing.T) {

--- a/internal/adapter/controller/KnockoutWhistCuiController.go
+++ b/internal/adapter/controller/KnockoutWhistCuiController.go
@@ -45,7 +45,7 @@ func (c *KnockoutWhistCuiController) Exec(command string) string {
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.di.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.di.Play)
 			case "st", "selecttrump":
 				return cuiutil.WithParsedInt(args, "Trump suit is required (1=S, 2=C, 3=H, 4=D).", "Invalid trump suit: %s. Please enter 1-4.", 1, 4, c.di.SelectTrump)
 			case "n", "next":

--- a/internal/adapter/controller/KnockoutWhistCuiController_test.go
+++ b/internal/adapter/controller/KnockoutWhistCuiController_test.go
@@ -50,7 +50,7 @@ func TestKnockoutWhistCuiController_Exec(t *testing.T) {
 
 	t.Run("play no args", func(t *testing.T) {
 		result := controller.NewKnockoutWhistCuiController(newMock()).Exec("play")
-		assert.Contains(t, result, "Card index is required")
+		assert.Contains(t, result, msgCardIndexRequired())
 	})
 
 	t.Run("next / nextround", func(t *testing.T) {

--- a/internal/adapter/controller/KoenigrufenCuiController.go
+++ b/internal/adapter/controller/KoenigrufenCuiController.go
@@ -5,6 +5,7 @@ package controller
 import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -56,7 +57,7 @@ func (c *KoenigrufenCuiController) Exec(command string) string {
 			case "discard":
 				return c.execDiscard(args)
 			case "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.di.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.di.Play)
 			case "n", "next":
 				return c.di.NextTrick(), true
 			case "nr", "nextround":
@@ -93,7 +94,7 @@ func (c *KoenigrufenCuiController) execDiscard(args []string) (string, bool) {
 	}
 	indices, skipped := cuiutil.ParseIntSlice(args)
 	if len(skipped) > 0 {
-		return "Invalid card index: " + skipped[0] + ".", true
+		return i18n.Tf("invalidCardIndex", "val", skipped[0]), true
 	}
 	return c.di.Discard(indices), true
 }

--- a/internal/adapter/controller/KoenigrufenCuiController_test.go
+++ b/internal/adapter/controller/KoenigrufenCuiController_test.go
@@ -98,7 +98,7 @@ func TestKoenigrufenCuiController_Exec(t *testing.T) {
 
 	t.Run("discard invalid index", func(t *testing.T) {
 		result := controller.NewKoenigrufenCuiController(newMock()).Exec("discard 0 1 2 3 4 x")
-		assert.Contains(t, result, "Invalid card index")
+		assert.Contains(t, result, msgInvalidCardIndexPrefix())
 	})
 
 	t.Run("play card", func(t *testing.T) {
@@ -110,7 +110,7 @@ func TestKoenigrufenCuiController_Exec(t *testing.T) {
 
 	t.Run("play no args", func(t *testing.T) {
 		result := controller.NewKoenigrufenCuiController(newMock()).Exec("play")
-		assert.Contains(t, result, "Card index is required")
+		assert.Contains(t, result, msgCardIndexRequired())
 	})
 
 	t.Run("next / nextround", func(t *testing.T) {

--- a/internal/adapter/controller/KoiKoiCuiController.go
+++ b/internal/adapter/controller/KoiKoiCuiController.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -69,11 +70,11 @@ func (c *KoiKoiCuiController) Exec(command string) string {
 // handlePlay は "p <handIdx> [fieldIdx]" を解析して Play を呼ぶ。
 func (c *KoiKoiCuiController) handlePlay(args []string) string {
 	if len(args) == 0 {
-		return "Card index is required (e.g. p 0, or p 0 3 to pick a field card)."
+		return i18n.T("cardIndexRequiredField")
 	}
 	handIdx, err := strconv.Atoi(args[0])
 	if err != nil {
-		return "Invalid card index: " + args[0] + "."
+		return i18n.Tf("invalidCardIndex", "val", args[0])
 	}
 	fieldIdx := -1
 	if len(args) >= 2 {

--- a/internal/adapter/controller/KoiKoiCuiController_test.go
+++ b/internal/adapter/controller/KoiKoiCuiController_test.go
@@ -49,11 +49,11 @@ func TestKoiKoiCuiController_Exec(t *testing.T) {
 	})
 	t.Run("play missing index", func(t *testing.T) {
 		out := controller.NewKoiKoiCuiController(newMock()).Exec("p")
-		assert.Contains(t, out, "required")
+		assert.Contains(t, out, msgCardIndexRequiredField())
 	})
 	t.Run("play invalid index", func(t *testing.T) {
 		out := controller.NewKoiKoiCuiController(newMock()).Exec("p xyz")
-		assert.Contains(t, out, "Invalid card index")
+		assert.Contains(t, out, msgInvalidCardIndexPrefix())
 	})
 	t.Run("koikoi", func(t *testing.T) {
 		m := newMock()

--- a/internal/adapter/controller/LaughAndLieDownCuiController.go
+++ b/internal/adapter/controller/LaughAndLieDownCuiController.go
@@ -5,6 +5,7 @@ package controller
 import (
 	"strconv"
 
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -52,11 +53,11 @@ func (c *LaughAndLieDownCuiController) Exec(command string) string {
 // 選択肢なので、毎回打たせるのは無駄が多い。
 func (c *LaughAndLieDownCuiController) play(args []string) (string, bool) {
 	if len(args) == 0 {
-		return "Card index is required.", true
+		return i18n.T("cardIndexRequired"), true
 	}
 	handIdx, err := strconv.Atoi(args[0])
 	if err != nil || handIdx < 0 {
-		return "Invalid card index: " + args[0] + ".", true
+		return i18n.Tf("invalidCardIndex", "val", args[0]), true
 	}
 	take := 1
 	if len(args) > 1 {

--- a/internal/adapter/controller/LingerLongerCuiController.go
+++ b/internal/adapter/controller/LingerLongerCuiController.go
@@ -36,7 +36,7 @@ func (c *LingerLongerCuiController) Exec(command string) string {
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.",
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex",
 					cuiutil.NoMin, cuiutil.NoMax, c.li.Play)
 			case "g", "giveup":
 				return c.li.GiveUp(), true

--- a/internal/adapter/controller/LingerLongerCuiController_test.go
+++ b/internal/adapter/controller/LingerLongerCuiController_test.go
@@ -56,8 +56,8 @@ func TestLingerLongerCuiController_HasNoDrawCommand(t *testing.T) {
 
 func TestLingerLongerCuiController_PlayRejectsBadArgs(t *testing.T) {
 	for _, tc := range []struct{ name, cmd, want string }{
-		{"index missing", "p", "Card index is required."},
-		{"index not a number", "p x", "Invalid card index: x."},
+		{"index missing", "p", msgCardIndexRequired()},
+		{"index not a number", "p x", msgInvalidCardIndex("x")},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			c, li := newLingerLongerCui()

--- a/internal/adapter/controller/LobaCuiController.go
+++ b/internal/adapter/controller/LobaCuiController.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -52,7 +53,7 @@ func (c *LobaCuiController) Exec(command string) string {
 			case "o", "layoff":
 				return c.layOff(args)
 			case "d", "discard":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.li.Discard)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.li.Discard)
 			case "n", "next":
 				return c.li.NextRound(), true
 			default:
@@ -73,7 +74,7 @@ func (c *LobaCuiController) meld(args []string) (string, bool) {
 	for _, p := range parts {
 		n, err := strconv.Atoi(strings.TrimSpace(p))
 		if err != nil || n < 0 {
-			return "Invalid card index: " + p + ".", true
+			return i18n.Tf("invalidCardIndex", "val", p), true
 		}
 		idxs = append(idxs, n)
 	}
@@ -87,7 +88,7 @@ func (c *LobaCuiController) layOff(args []string) (string, bool) {
 	}
 	card, err := strconv.Atoi(args[0])
 	if err != nil || card < 0 {
-		return "Invalid card index: " + args[0] + ".", true
+		return i18n.Tf("invalidCardIndex", "val", args[0]), true
 	}
 	meld, err := strconv.Atoi(args[1])
 	if err != nil || meld < 0 {

--- a/internal/adapter/controller/LooCuiController.go
+++ b/internal/adapter/controller/LooCuiController.go
@@ -51,7 +51,7 @@ func (c *LooCuiController) Exec(command string) string {
 			case "pass":
 				return c.li.Decide(false), true
 			case "p":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", 0, domain.LooHandSize-1, c.li.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", 0, domain.LooHandSize-1, c.li.Play)
 			case "n", "next", "nr", "nextround":
 				return c.li.NextRound(), true
 			case "sd", "setdifficulty":

--- a/internal/adapter/controller/LooCuiController_test.go
+++ b/internal/adapter/controller/LooCuiController_test.go
@@ -72,7 +72,7 @@ func TestLooCuiController_Exec(t *testing.T) {
 	})
 	t.Run("play invalid arg", func(t *testing.T) {
 		out := controller.NewLooCuiController(newMock()).Exec("p xyz")
-		assert.Contains(t, out, "Invalid card index")
+		assert.Contains(t, out, msgInvalidCardIndexPrefix())
 	})
 	t.Run("next round", func(t *testing.T) {
 		m := newMock()

--- a/internal/adapter/controller/MacauCuiController.go
+++ b/internal/adapter/controller/MacauCuiController.go
@@ -50,7 +50,7 @@ func (c *MacauCuiController) Exec(command string) string {
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.playWithPrompts)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.playWithPrompts)
 			case "d", "draw":
 				return c.ci.Draw(), true
 			case "s", "suit":

--- a/internal/adapter/controller/MacauCuiController_test.go
+++ b/internal/adapter/controller/MacauCuiController_test.go
@@ -61,11 +61,11 @@ func TestMacauCuiController_Exec(t *testing.T) {
 	})
 
 	t.Run("play no args", func(t *testing.T) {
-		assert.Contains(t, controller.NewMacauCuiController(newMock()).Exec("p"), "Card index is required")
+		assert.Contains(t, controller.NewMacauCuiController(newMock()).Exec("p"), msgCardIndexRequired())
 	})
 
 	t.Run("play invalid arg", func(t *testing.T) {
-		assert.Contains(t, controller.NewMacauCuiController(newMock()).Exec("p abc"), "Invalid card index")
+		assert.Contains(t, controller.NewMacauCuiController(newMock()).Exec("p abc"), msgInvalidCardIndexPrefix())
 	})
 
 	t.Run("playing an 8 inlines a suit prompt", func(t *testing.T) {

--- a/internal/adapter/controller/ManilleCuiController.go
+++ b/internal/adapter/controller/ManilleCuiController.go
@@ -44,7 +44,7 @@ func (c *ManilleCuiController) Exec(command string) string {
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.di.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.di.Play)
 			case "n", "next":
 				return c.di.NextTrick(), true
 			case "nr", "nextround":

--- a/internal/adapter/controller/ManilleCuiController_test.go
+++ b/internal/adapter/controller/ManilleCuiController_test.go
@@ -49,7 +49,7 @@ func TestManilleCuiController_Exec(t *testing.T) {
 
 	t.Run("play no args", func(t *testing.T) {
 		result := controller.NewManilleCuiController(newMock()).Exec("play")
-		assert.Contains(t, result, "Card index is required")
+		assert.Contains(t, result, msgCardIndexRequired())
 	})
 
 	t.Run("next / nextround", func(t *testing.T) {

--- a/internal/adapter/controller/MaoCuiController.go
+++ b/internal/adapter/controller/MaoCuiController.go
@@ -56,7 +56,7 @@ func (c *MaoCuiController) Exec(command string) string {
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.playWithPrompts)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.playWithPrompts)
 			case "d", "draw":
 				return c.ci.Draw(), true
 			case "s", "suit":

--- a/internal/adapter/controller/MaoCuiController_test.go
+++ b/internal/adapter/controller/MaoCuiController_test.go
@@ -53,7 +53,7 @@ func TestMaoCuiController_Exec(t *testing.T) {
 	})
 
 	t.Run("play no args", func(t *testing.T) {
-		assert.Contains(t, controller.NewMaoCuiController(newMaoCuiMock()).Exec("p"), "Card index is required")
+		assert.Contains(t, controller.NewMaoCuiController(newMaoCuiMock()).Exec("p"), msgCardIndexRequired())
 	})
 
 	t.Run("draw", func(t *testing.T) {

--- a/internal/adapter/controller/MariasCuiController.go
+++ b/internal/adapter/controller/MariasCuiController.go
@@ -44,7 +44,7 @@ func (c *MariasCuiController) Exec(command string) string {
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.di.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.di.Play)
 			case "n", "next":
 				return c.di.NextTrick(), true
 			case "nr", "nextround":

--- a/internal/adapter/controller/MariasCuiController_test.go
+++ b/internal/adapter/controller/MariasCuiController_test.go
@@ -49,7 +49,7 @@ func TestMariasCuiController_Exec(t *testing.T) {
 
 	t.Run("play no args", func(t *testing.T) {
 		result := controller.NewMariasCuiController(newMock()).Exec("play")
-		assert.Contains(t, result, "Card index is required")
+		assert.Contains(t, result, msgCardIndexRequired())
 	})
 
 	t.Run("next / nextround", func(t *testing.T) {

--- a/internal/adapter/controller/MendikotCuiController.go
+++ b/internal/adapter/controller/MendikotCuiController.go
@@ -38,7 +38,7 @@ func (c *MendikotCuiController) Exec(command string) string {
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.mi.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.mi.Play)
 			case "n", "next":
 				return c.mi.NextHand(), true
 			case "g", "giveup":

--- a/internal/adapter/controller/MendikotCuiController_test.go
+++ b/internal/adapter/controller/MendikotCuiController_test.go
@@ -49,8 +49,8 @@ func TestMendikotCuiControllerPlay(t *testing.T) {
 
 func TestMendikotCuiControllerPlayRejectsBadArgs(t *testing.T) {
 	for _, tc := range []struct{ name, cmd, want string }{
-		{"missing index", "p", "Card index is required."},
-		{"non-numeric", "p abc", "Invalid card index: abc."},
+		{"missing index", "p", msgCardIndexRequired()},
+		{"non-numeric", "p abc", msgInvalidCardIndex("abc")},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			mi := newMockMendikotInteractor()

--- a/internal/adapter/controller/MichiganCuiController.go
+++ b/internal/adapter/controller/MichiganCuiController.go
@@ -53,7 +53,7 @@ func (c *MichiganCuiController) Exec(command string) string {
 			case "b", "bet":
 				return c.handleBet(args), true
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required (e.g. p 0).", "Invalid card index: %s.", 0, 51, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequiredExample", "invalidCardIndex", 0, 51, func(v int) string {
 					return c.ti.Play(v)
 				})
 			case "n", "next", "nr", "nextround":

--- a/internal/adapter/controller/MichiganCuiController_test.go
+++ b/internal/adapter/controller/MichiganCuiController_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	mockUsecases "github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/usecase"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func TestMichiganCuiController_Exec(t *testing.T) {
@@ -61,7 +62,7 @@ func TestMichiganCuiController_Exec(t *testing.T) {
 	})
 	t.Run("play missing arg", func(t *testing.T) {
 		out := controller.NewMichiganCuiController(newMock()).Exec("p")
-		assert.Contains(t, out, "required")
+		assert.Contains(t, out, i18n.T("cardIndexRequiredExample"))
 	})
 	t.Run("next round", func(t *testing.T) {
 		m := newMock()

--- a/internal/adapter/controller/MightyCuiController.go
+++ b/internal/adapter/controller/MightyCuiController.go
@@ -97,7 +97,7 @@ func (c *MightyCuiController) Exec(command string) string {
 				}
 				idxs := make([]int, 3)
 				for i := 0; i < 3; i++ {
-					v, errMsg, ok := cuiutil.ParseIntArg(args[i:i+1], "", "Invalid card index: %s.", 0, math.MaxInt)
+					v, errMsg, ok := cuiutil.ParseIntArgKeys(args[i:i+1], "", "invalidCardIndex", 0, math.MaxInt)
 					if !ok {
 						return errMsg, true
 					}
@@ -105,12 +105,12 @@ func (c *MightyCuiController) Exec(command string) string {
 				}
 				return c.mi.ExchangeKitty(idxs), true
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.mi.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.mi.Play)
 			case "jl", "jokerlead":
 				if len(args) < 2 {
 					return "Usage: jokerlead <cardIndex> <demandSuit>\n  demandSuit: 1=Spade 2=Clover 3=Heart 4=Diamond\n", true
 				}
-				cardIdx, errMsg, ok := cuiutil.ParseIntArg(args[:1], "", "Invalid card index: %s.", 0, math.MaxInt)
+				cardIdx, errMsg, ok := cuiutil.ParseIntArgKeys(args[:1], "", "invalidCardIndex", 0, math.MaxInt)
 				if !ok {
 					return errMsg, true
 				}

--- a/internal/adapter/controller/MightyCuiController_test.go
+++ b/internal/adapter/controller/MightyCuiController_test.go
@@ -171,7 +171,7 @@ func TestMightyCuiController_Exec(t *testing.T) {
 
 	t.Run("exchange invalid index", func(t *testing.T) {
 		c := controller.NewMightyCuiController(newMightyCuiMock(mockOutput))
-		assert.Contains(t, c.Exec("e abc 1 2"), "Invalid card index")
+		assert.Contains(t, c.Exec("e abc 1 2"), msgInvalidCardIndexPrefix())
 	})
 
 	// play
@@ -184,12 +184,12 @@ func TestMightyCuiController_Exec(t *testing.T) {
 
 	t.Run("play no args", func(t *testing.T) {
 		c := controller.NewMightyCuiController(newMightyCuiMock(mockOutput))
-		assert.Contains(t, c.Exec("p"), "Card index is required")
+		assert.Contains(t, c.Exec("p"), msgCardIndexRequired())
 	})
 
 	t.Run("play invalid", func(t *testing.T) {
 		c := controller.NewMightyCuiController(newMightyCuiMock(mockOutput))
-		assert.Contains(t, c.Exec("play foo"), "Invalid card index")
+		assert.Contains(t, c.Exec("play foo"), msgInvalidCardIndexPrefix())
 	})
 
 	// jokerlead (Mighty-specific)

--- a/internal/adapter/controller/MinchiateCuiController.go
+++ b/internal/adapter/controller/MinchiateCuiController.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -50,7 +51,7 @@ func (c *MinchiateCuiController) Exec(command string) string {
 			case "scarto", "discard":
 				return c.execScarto(args)
 			case "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.di.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.di.Play)
 			case "n", "next":
 				return c.di.NextTrick(), true
 			case "nr", "nextround":
@@ -78,7 +79,7 @@ func (c *MinchiateCuiController) execScarto(args []string) (string, bool) {
 	}
 	indices, skipped := cuiutil.ParseIntSlice(args)
 	if len(skipped) > 0 {
-		return "Invalid card index: " + skipped[0] + ".", true
+		return i18n.Tf("invalidCardIndex", "val", skipped[0]), true
 	}
 	return c.di.Discard(indices), true
 }

--- a/internal/adapter/controller/MinchiateCuiController_test.go
+++ b/internal/adapter/controller/MinchiateCuiController_test.go
@@ -76,7 +76,7 @@ func TestMinchiateCuiController_Exec(t *testing.T) {
 	t.Run("scarto with a non-numeric index", func(t *testing.T) {
 		args, _ := surplusArgs()
 		out := controller.NewMinchiateCuiController(newMock()).Exec("scarto" + args + " x")
-		assert.Contains(t, out, "Invalid card index")
+		assert.Contains(t, out, msgInvalidCardIndexPrefix())
 	})
 
 	t.Run("play card", func(t *testing.T) {
@@ -86,7 +86,7 @@ func TestMinchiateCuiController_Exec(t *testing.T) {
 	})
 
 	t.Run("play no args", func(t *testing.T) {
-		assert.Contains(t, controller.NewMinchiateCuiController(newMock()).Exec("play"), "Card index is required")
+		assert.Contains(t, controller.NewMinchiateCuiController(newMock()).Exec("play"), msgCardIndexRequired())
 	})
 
 	// このゲームに入札は無い。bid/pass が黙って別の動作に落ちてはならない。

--- a/internal/adapter/controller/MinibridgeCuiController.go
+++ b/internal/adapter/controller/MinibridgeCuiController.go
@@ -42,7 +42,7 @@ func (c *MinibridgeCuiController) Exec(command string) string {
 			case "c", "contract":
 				return c.contract(args)
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.mi.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.mi.Play)
 			case "n", "next":
 				return c.mi.NextRound(), true
 			case "g", "giveup":

--- a/internal/adapter/controller/MinibridgeCuiController_test.go
+++ b/internal/adapter/controller/MinibridgeCuiController_test.go
@@ -70,8 +70,8 @@ func TestMinibridgeCuiController_ContractRejectsBadArgs(t *testing.T) {
 
 func TestMinibridgeCuiController_PlayRejectsBadArgs(t *testing.T) {
 	for _, tc := range []struct{ name, cmd, want string }{
-		{"index missing", "p", "Card index is required."},
-		{"index not a number", "p x", "Invalid card index: x."},
+		{"index missing", "p", msgCardIndexRequired()},
+		{"index not a number", "p x", msgInvalidCardIndex("x")},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			c, mi := newMinibridgeCui()

--- a/internal/adapter/controller/MushiCuiController.go
+++ b/internal/adapter/controller/MushiCuiController.go
@@ -40,7 +40,7 @@ func (c *MushiCuiController) Exec(command string) string {
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.mi.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.mi.Play)
 			case "s", "select":
 				return cuiutil.WithParsedInt(args, "Field index is required.", "Invalid field index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.mi.Select)
 			case "n", "next":

--- a/internal/adapter/controller/NainJauneCuiController.go
+++ b/internal/adapter/controller/NainJauneCuiController.go
@@ -38,7 +38,7 @@ func (c *NainJauneCuiController) Exec(command string) string {
 			switch cmd {
 			case "p", "play":
 				// 下限を 0 に。NoMin だと `p -1` がそのままドメインまで届く。
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", 0, cuiutil.NoMax, c.pi.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", 0, cuiutil.NoMax, c.pi.Play)
 			case "n", "next":
 				return c.pi.NextDeal(), true
 			default:

--- a/internal/adapter/controller/NapCuiController.go
+++ b/internal/adapter/controller/NapCuiController.go
@@ -52,7 +52,7 @@ func (c *NapCuiController) Exec(command string) string {
 			case "pass":
 				return c.di.Bid(int(domain.NapBidPass)), true
 			case "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.di.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.di.Play)
 			case "n", "next":
 				return c.di.NextTrick(), true
 			case "nr", "nextround":

--- a/internal/adapter/controller/NapCuiController_test.go
+++ b/internal/adapter/controller/NapCuiController_test.go
@@ -74,7 +74,7 @@ func TestNapCuiController_Exec(t *testing.T) {
 
 	t.Run("play no args", func(t *testing.T) {
 		result := controller.NewNapCuiController(newMock()).Exec("play")
-		assert.Contains(t, result, "Card index is required")
+		assert.Contains(t, result, msgCardIndexRequired())
 	})
 
 	t.Run("next / nextround", func(t *testing.T) {

--- a/internal/adapter/controller/NapoleonCuiController.go
+++ b/internal/adapter/controller/NapoleonCuiController.go
@@ -71,9 +71,9 @@ func (c *NapoleonCuiController) Exec(command string) string {
 				}
 				return c.ni.DeclareTrump(suit, adjSuit, adjVal), true
 			case "e", "exchange":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.ni.ExchangeKitty)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.ni.ExchangeKitty)
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.ni.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.ni.Play)
 			case "n", "next":
 				return c.ni.NextTrick(), true
 			case "nr", "nextround":

--- a/internal/adapter/controller/NapoleonCuiController_test.go
+++ b/internal/adapter/controller/NapoleonCuiController_test.go
@@ -211,13 +211,13 @@ func TestNapoleonCuiController_Exec(t *testing.T) {
 	t.Run("exchange command e no args", func(t *testing.T) {
 		c := controller.NewNapoleonCuiController(newMock())
 		result := c.Exec("e")
-		assert.Contains(t, result, "Card index is required")
+		assert.Contains(t, result, msgCardIndexRequired())
 	})
 
 	t.Run("exchange command e invalid arg", func(t *testing.T) {
 		c := controller.NewNapoleonCuiController(newMock())
 		result := c.Exec("e abc")
-		assert.Contains(t, result, "Invalid card index")
+		assert.Contains(t, result, msgInvalidCardIndexPrefix())
 	})
 
 	// play
@@ -240,13 +240,13 @@ func TestNapoleonCuiController_Exec(t *testing.T) {
 	t.Run("play command p no args", func(t *testing.T) {
 		c := controller.NewNapoleonCuiController(newMock())
 		result := c.Exec("p")
-		assert.Contains(t, result, "Card index is required")
+		assert.Contains(t, result, msgCardIndexRequired())
 	})
 
 	t.Run("play command p invalid arg", func(t *testing.T) {
 		c := controller.NewNapoleonCuiController(newMock())
 		result := c.Exec("p abc")
-		assert.Contains(t, result, "Invalid card index")
+		assert.Contains(t, result, msgInvalidCardIndexPrefix())
 	})
 
 	// next

--- a/internal/adapter/controller/NinetyNineCuiController.go
+++ b/internal/adapter/controller/NinetyNineCuiController.go
@@ -52,7 +52,7 @@ func (c *NinetyNineCuiController) Exec(command string) string {
 				}
 				return c.oi.Bid(idxs[:domain.NinetyNineBurySize]), true
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.oi.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.oi.Play)
 			case "n", "next":
 				return c.oi.NextTrick(), true
 			case "nr", "nextround":

--- a/internal/adapter/controller/NinetyNineCuiController_test.go
+++ b/internal/adapter/controller/NinetyNineCuiController_test.go
@@ -91,11 +91,11 @@ func TestNinetyNineCuiController_Exec_Errors(t *testing.T) {
 	assert.Contains(t, c.Exec("b"), "required")
 	assert.Contains(t, c.Exec("b 0 1"), "required")
 	assert.Contains(t, c.Exec("b a b c"), "Invalid")
-	assert.Contains(t, c.Exec("p"), "required")
+	assert.Contains(t, c.Exec("p"), msgCardIndexRequired())
 	assert.Contains(t, c.Exec("sd"), "required")
 	assert.Contains(t, c.Exec("st"), "required")
 
-	assert.Contains(t, c.Exec("p abc"), "Invalid")
+	assert.Contains(t, c.Exec("p abc"), msgInvalidCardIndexPrefix())
 	assert.Contains(t, c.Exec("sd 99"), "Invalid")
 	assert.Contains(t, c.Exec("st 5"), "Invalid")
 	assert.Contains(t, c.Exec("st 9999"), "Invalid")

--- a/internal/adapter/controller/OhHellCuiController.go
+++ b/internal/adapter/controller/OhHellCuiController.go
@@ -45,7 +45,7 @@ func (c *OhHellCuiController) Exec(command string) string {
 			case "b", "bid":
 				return cuiutil.WithParsedInt(args, "Bid value is required.", "Invalid bid value: %s.", 0, cuiutil.NoMax, c.oi.Bid)
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.oi.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.oi.Play)
 			case "n", "next":
 				return c.oi.NextTrick(), true
 			case "nr", "nextround":

--- a/internal/adapter/controller/OhHellCuiController_test.go
+++ b/internal/adapter/controller/OhHellCuiController_test.go
@@ -91,7 +91,7 @@ func TestOhHellCuiController_Exec_Errors(t *testing.T) {
 
 	// Missing args
 	assert.Contains(t, c.Exec("b"), "required")
-	assert.Contains(t, c.Exec("p"), "required")
+	assert.Contains(t, c.Exec("p"), msgCardIndexRequired())
 	assert.Contains(t, c.Exec("sd"), "required")
 	assert.Contains(t, c.Exec("sm"), "required")
 

--- a/internal/adapter/controller/OmbreCuiController.go
+++ b/internal/adapter/controller/OmbreCuiController.go
@@ -65,7 +65,7 @@ func (c *OmbreCuiController) Exec(command string) string {
 			case "bid":
 				return c.execBid(args)
 			case "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.di.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.di.Play)
 			case "n", "next":
 				return c.di.NextTrick(), true
 			case "nr", "nextround":

--- a/internal/adapter/controller/OmbreCuiController_test.go
+++ b/internal/adapter/controller/OmbreCuiController_test.go
@@ -91,7 +91,7 @@ func TestOmbreCuiController_Exec(t *testing.T) {
 
 	t.Run("play no args", func(t *testing.T) {
 		result := controller.NewOmbreCuiController(newMock()).Exec("play")
-		assert.Contains(t, result, "Card index is required")
+		assert.Contains(t, result, msgCardIndexRequired())
 	})
 
 	t.Run("next / nextround", func(t *testing.T) {

--- a/internal/adapter/controller/PageOneCuiController.go
+++ b/internal/adapter/controller/PageOneCuiController.go
@@ -49,7 +49,7 @@ func (c *PageOneCuiController) Exec(command string) string {
 			}
 			switch cmd {
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.ci.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.ci.Play)
 			case "sd", "setdifficulty":
 				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
 					cfg := c.ci.GetConfig()

--- a/internal/adapter/controller/PageOneCuiController_test.go
+++ b/internal/adapter/controller/PageOneCuiController_test.go
@@ -56,11 +56,11 @@ func TestPageOneCuiController_Exec(t *testing.T) {
 	})
 	t.Run("play no args", func(t *testing.T) {
 		c := controller.NewPageOneCuiController(newMock())
-		assert.Contains(t, c.Exec("p"), "Card index is required")
+		assert.Contains(t, c.Exec("p"), msgCardIndexRequired())
 	})
 	t.Run("play invalid", func(t *testing.T) {
 		c := controller.NewPageOneCuiController(newMock())
-		assert.Contains(t, c.Exec("p abc"), "Invalid card index")
+		assert.Contains(t, c.Exec("p abc"), msgInvalidCardIndexPrefix())
 	})
 	t.Run("draw d", func(t *testing.T) {
 		m := newMock()

--- a/internal/adapter/controller/PanCuiController.go
+++ b/internal/adapter/controller/PanCuiController.go
@@ -49,7 +49,7 @@ func (c *PanCuiController) Exec(command string) string {
 				}
 				return c.ci.Layoff(indices[0], indices[1], indices[2]), true
 			case "d", "discard":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.ci.Discard)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.ci.Discard)
 			case "nr", "nextround":
 				return c.ci.NextRound(), true
 			case "pc", "setplayers":

--- a/internal/adapter/controller/PanCuiController_test.go
+++ b/internal/adapter/controller/PanCuiController_test.go
@@ -83,7 +83,7 @@ func TestPanCuiController_Exec(t *testing.T) {
 
 	t.Run("discard d no args", func(t *testing.T) {
 		result := controller.NewPanCuiController(newMock()).Exec("d")
-		assert.Contains(t, result, "Card index is required")
+		assert.Contains(t, result, msgCardIndexRequired())
 	})
 
 	t.Run("nextround nr", func(t *testing.T) {

--- a/internal/adapter/controller/PasurCuiController.go
+++ b/internal/adapter/controller/PasurCuiController.go
@@ -51,7 +51,7 @@ func (c *PasurCuiController) Exec(command string) string {
 
 // play は手札インデックスと、取る場札の番号（可変長）を取る。
 func (c *PasurCuiController) play(args []string) (string, bool) {
-	idx, errMsg, ok := cuiutil.ParseIntArg(args, "Card index is required.", "Invalid card index: %s.",
+	idx, errMsg, ok := cuiutil.ParseIntArgKeys(args, "cardIndexRequired", "invalidCardIndex",
 		cuiutil.NoMin, cuiutil.NoMax)
 	if !ok {
 		return errMsg, true

--- a/internal/adapter/controller/PasurCuiController_test.go
+++ b/internal/adapter/controller/PasurCuiController_test.go
@@ -46,8 +46,8 @@ func TestPasurCuiController_Commands(t *testing.T) {
 
 func TestPasurCuiController_PlayRejectsBadArgs(t *testing.T) {
 	for _, tc := range []struct{ name, cmd, want string }{
-		{"index missing", "p", "Card index is required."},
-		{"index not a number", "p x", "Invalid card index: x."},
+		{"index missing", "p", msgCardIndexRequired()},
+		{"index not a number", "p x", msgInvalidCardIndex("x")},
 		{"table index not a number", "p 1 x", "Invalid table index: x."},
 		{"a later table index is bad", "p 1 0 y", "Invalid table index: y."},
 	} {

--- a/internal/adapter/controller/PigCuiController.go
+++ b/internal/adapter/controller/PigCuiController.go
@@ -36,7 +36,7 @@ func (c *PigCuiController) Exec(command string) string {
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "p", "pass":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.",
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex",
 					cuiutil.NoMin, cuiutil.NoMax, c.pi.Pass)
 			case "s", "signal":
 				return c.pi.Signal(), true

--- a/internal/adapter/controller/PigCuiController_test.go
+++ b/internal/adapter/controller/PigCuiController_test.go
@@ -51,8 +51,8 @@ func TestPigCuiController_Commands(t *testing.T) {
 
 func TestPigCuiController_PassRejectsBadArgs(t *testing.T) {
 	for _, tc := range []struct{ name, cmd, want string }{
-		{"index missing", "p", "Card index is required."},
-		{"index not a number", "p x", "Invalid card index: x."},
+		{"index missing", "p", msgCardIndexRequired()},
+		{"index not a number", "p x", msgInvalidCardIndex("x")},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			c, pi := newPigCui()

--- a/internal/adapter/controller/PinochleCuiController.go
+++ b/internal/adapter/controller/PinochleCuiController.go
@@ -68,7 +68,7 @@ func (c *PinochleCuiController) Exec(command string) string {
 			case "t", "trump":
 				return cuiutil.WithParsedInt(args, "Suit is required (1-4).", "Invalid suit: %s.", 1, 4, c.pi.CallTrump)
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.pi.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.pi.Play)
 			case "sd", "setdifficulty":
 				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
 					cfg := c.pi.GetConfig()

--- a/internal/adapter/controller/PinochleCuiController_test.go
+++ b/internal/adapter/controller/PinochleCuiController_test.go
@@ -185,13 +185,13 @@ func TestPinochleCuiController_Exec(t *testing.T) {
 	t.Run("play command no args", func(t *testing.T) {
 		c := controller.NewPinochleCuiController(newPinochleMock())
 		result := c.Exec("p")
-		assert.Contains(t, result, "Card index is required")
+		assert.Contains(t, result, msgCardIndexRequired())
 	})
 
 	t.Run("play command invalid arg", func(t *testing.T) {
 		c := controller.NewPinochleCuiController(newPinochleMock())
 		result := c.Exec("p abc")
-		assert.Contains(t, result, "Invalid card index")
+		assert.Contains(t, result, msgInvalidCardIndexPrefix())
 	})
 
 	// next

--- a/internal/adapter/controller/PitchCuiController.go
+++ b/internal/adapter/controller/PitchCuiController.go
@@ -47,7 +47,7 @@ func (c *PitchCuiController) Exec(command string) string {
 			case "b", "bid":
 				return cuiutil.WithParsedInt(args, "Bid value is required (0=pass, 2-4).", "Invalid bid value: %s.", domain.PitchPassBid, domain.PitchMaxBid, c.pi.Bid)
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.pi.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.pi.Play)
 			case "n", "next":
 				return c.pi.NextTrick(), true
 			case "nr", "nextround":

--- a/internal/adapter/controller/PochCuiController.go
+++ b/internal/adapter/controller/PochCuiController.go
@@ -45,7 +45,7 @@ func (c *PochCuiController) Exec(command string) string {
 			case "p", "play":
 				// 下限を 0 にしておく。NoMin だと `p -1` がそのまま
 				// ドメインまで届き、同じ拒否をもう一段深いところでやることになる。
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", 0, cuiutil.NoMax, c.pi.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", 0, cuiutil.NoMax, c.pi.Play)
 			case "n", "next":
 				return c.pi.NextDeal(), true
 			default:

--- a/internal/adapter/controller/PolignacCuiController.go
+++ b/internal/adapter/controller/PolignacCuiController.go
@@ -41,7 +41,7 @@ func (c *PolignacCuiController) Exec(command string) string {
 			case "pass":
 				return c.pi.Pass(), true
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.pi.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.pi.Play)
 			case "n", "next":
 				return c.pi.NextRound(), true
 			case "g", "giveup":

--- a/internal/adapter/controller/PolignacCuiController_test.go
+++ b/internal/adapter/controller/PolignacCuiController_test.go
@@ -70,8 +70,8 @@ func TestPolignacCuiControllerPlay(t *testing.T) {
 
 func TestPolignacCuiControllerPlayRejectsBadArgs(t *testing.T) {
 	for _, tc := range []struct{ name, cmd, want string }{
-		{"missing index", "p", "Card index is required."},
-		{"non-numeric", "p abc", "Invalid card index: abc."},
+		{"missing index", "p", msgCardIndexRequired()},
+		{"non-numeric", "p abc", msgInvalidCardIndex("abc")},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			pi := newMockPolignacInteractor()

--- a/internal/adapter/controller/PopeJoanCuiController.go
+++ b/internal/adapter/controller/PopeJoanCuiController.go
@@ -38,7 +38,7 @@ func (c *PopeJoanCuiController) Exec(command string) string {
 			switch cmd {
 			case "p", "play":
 				// 下限を 0 に。NoMin だと `p -1` がそのままドメインまで届く。
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", 0, cuiutil.NoMax, c.pi.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", 0, cuiutil.NoMax, c.pi.Play)
 			case "n", "next":
 				return c.pi.NextDeal(), true
 			default:

--- a/internal/adapter/controller/PreferenceCuiController.go
+++ b/internal/adapter/controller/PreferenceCuiController.go
@@ -52,7 +52,7 @@ func (c *PreferenceCuiController) Exec(command string) string {
 			case "pass":
 				return c.di.Bid(int(domain.PreferenceBidPass)), true
 			case "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.di.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.di.Play)
 			case "n", "next":
 				return c.di.NextTrick(), true
 			case "nr", "nextround":

--- a/internal/adapter/controller/PreferenceCuiController_test.go
+++ b/internal/adapter/controller/PreferenceCuiController_test.go
@@ -81,7 +81,7 @@ func TestPreferenceCuiController_Exec(t *testing.T) {
 
 	t.Run("play no args", func(t *testing.T) {
 		result := controller.NewPreferenceCuiController(newMock()).Exec("play")
-		assert.Contains(t, result, "Card index is required")
+		assert.Contains(t, result, msgCardIndexRequired())
 	})
 
 	t.Run("next / nextround", func(t *testing.T) {

--- a/internal/adapter/controller/PrsiCuiController.go
+++ b/internal/adapter/controller/PrsiCuiController.go
@@ -31,7 +31,7 @@ func (c *PrsiCuiController) Exec(command string) string {
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.ci.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.ci.Play)
 			case "d", "draw":
 				return c.ci.Draw(), true
 			case "sd", "setdifficulty":

--- a/internal/adapter/controller/RamsCuiController.go
+++ b/internal/adapter/controller/RamsCuiController.go
@@ -41,7 +41,7 @@ func (c *RamsCuiController) Exec(command string) string {
 			case "out", "pass":
 				return c.ri.Pass(), true
 			case "c", "card":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.ri.PlayCard)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.ri.PlayCard)
 			case "n", "next":
 				return c.ri.NextRound(), true
 			case "g", "giveup":

--- a/internal/adapter/controller/RamsCuiController_test.go
+++ b/internal/adapter/controller/RamsCuiController_test.go
@@ -83,8 +83,8 @@ func TestRamsCuiControllerCard(t *testing.T) {
 
 func TestRamsCuiControllerCardRejectsBadArgs(t *testing.T) {
 	for _, tc := range []struct{ name, cmd, want string }{
-		{"missing index", "c", "Card index is required."},
-		{"non-numeric", "c abc", "Invalid card index: abc."},
+		{"missing index", "c", msgCardIndexRequired()},
+		{"non-numeric", "c abc", msgInvalidCardIndex("abc")},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			ri := newMockRamsInteractor()

--- a/internal/adapter/controller/ReversisCuiController.go
+++ b/internal/adapter/controller/ReversisCuiController.go
@@ -35,7 +35,7 @@ func (c *ReversisCuiController) Exec(command string) string {
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.ri.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.ri.Play)
 			case "n", "next":
 				return c.ri.NextRound(), true
 			case "g", "giveup":

--- a/internal/adapter/controller/ReversisCuiController_test.go
+++ b/internal/adapter/controller/ReversisCuiController_test.go
@@ -68,8 +68,8 @@ func TestReversisCuiControllerPlay(t *testing.T) {
 
 func TestReversisCuiControllerPlayRejectsBadArgs(t *testing.T) {
 	for _, tc := range []struct{ name, cmd, want string }{
-		{"missing index", "p", "Card index is required."},
-		{"non-numeric", "p abc", "Invalid card index: abc."},
+		{"missing index", "p", msgCardIndexRequired()},
+		{"non-numeric", "p abc", msgInvalidCardIndex("abc")},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			ri := newMockReversisInteractor()

--- a/internal/adapter/controller/RikkenCuiController.go
+++ b/internal/adapter/controller/RikkenCuiController.go
@@ -32,8 +32,8 @@ func (rc *RikkenCuiController) Exec(command string) string {
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "p", "play":
-				idx, errMsg, ok := cuiutil.ParseIntArg(args,
-					"Card index is required.", "Invalid card index. Please enter a number.", 0, math.MaxInt)
+				idx, errMsg, ok := cuiutil.ParseIntArgKeys(args,
+					"cardIndexRequired", "invalidCardIndexNotANumber", 0, math.MaxInt)
 				if !ok {
 					return errMsg, true
 				}

--- a/internal/adapter/controller/RikkenCuiController_test.go
+++ b/internal/adapter/controller/RikkenCuiController_test.go
@@ -41,8 +41,8 @@ func TestRikkenCuiController_Play(t *testing.T) {
 	c := controller.NewRikkenCuiController(newMockRikkenInteractor())
 	assert.Equal(t, "played 3", c.Exec("p 3"))
 	assert.Equal(t, "played 3", c.Exec("play 3"))
-	assert.Contains(t, c.Exec("p"), "required")
-	assert.Contains(t, c.Exec("p abc"), "Invalid card index")
+	assert.Contains(t, c.Exec("p"), msgCardIndexRequired())
+	assert.Contains(t, c.Exec("p abc"), msgInvalidCardIndexPrefix())
 }
 
 // **4 種類の契約とパスが全部通る。** パスは契約 0 で、別経路にはしていません。

--- a/internal/adapter/controller/RollingStoneCuiController.go
+++ b/internal/adapter/controller/RollingStoneCuiController.go
@@ -38,7 +38,7 @@ func (c *RollingStoneCuiController) Exec(command string) string {
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.",
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex",
 					cuiutil.NoMin, cuiutil.NoMax, c.ri.Play)
 			case "u", "pickup":
 				return c.ri.PickUp(), true

--- a/internal/adapter/controller/RollingStoneCuiController_test.go
+++ b/internal/adapter/controller/RollingStoneCuiController_test.go
@@ -47,8 +47,8 @@ func TestRollingStoneCuiController_Commands(t *testing.T) {
 
 func TestRollingStoneCuiController_PlayRejectsBadArgs(t *testing.T) {
 	for _, tc := range []struct{ name, cmd, want string }{
-		{"index missing", "p", "Card index is required."},
-		{"index not a number", "p x", "Invalid card index: x."},
+		{"index missing", "p", msgCardIndexRequired()},
+		{"index not a number", "p x", msgInvalidCardIndex("x")},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			c, ri := newRollingStoneCui()

--- a/internal/adapter/controller/RookCuiController.go
+++ b/internal/adapter/controller/RookCuiController.go
@@ -64,7 +64,7 @@ func (c *RookCuiController) Exec(command string) string {
 				}
 				idxs := make([]int, 5)
 				for i := 0; i < 5; i++ {
-					v, errMsg, ok := cuiutil.ParseIntArg(args[i:i+1], "", "Invalid card index: %s.", 0, math.MaxInt)
+					v, errMsg, ok := cuiutil.ParseIntArgKeys(args[i:i+1], "", "invalidCardIndex", 0, math.MaxInt)
 					if !ok {
 						return errMsg, true
 					}
@@ -76,7 +76,7 @@ func (c *RookCuiController) Exec(command string) string {
 				}
 				return c.fi.ExchangeNest(idxs, color), true
 			case "p", "play":
-				cardIdx, errMsg, ok := cuiutil.ParseIntArg(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax)
+				cardIdx, errMsg, ok := cuiutil.ParseIntArgKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax)
 				if !ok {
 					return errMsg, true
 				}

--- a/internal/adapter/controller/RookCuiController_test.go
+++ b/internal/adapter/controller/RookCuiController_test.go
@@ -68,7 +68,7 @@ func TestRookCuiController_Usage(t *testing.T) {
 	if got := c.Exec("e 0 1 2"); !strings.Contains(got, "Usage") {
 		t.Errorf("exchange with few args should show usage, got %q", got)
 	}
-	if got := c.Exec("p"); !strings.Contains(got, "required") {
+	if got := c.Exec("p"); !strings.Contains(got, msgCardIndexRequired()) {
 		t.Errorf("play without args should require index, got %q", got)
 	}
 }

--- a/internal/adapter/controller/Rummy500CuiController.go
+++ b/internal/adapter/controller/Rummy500CuiController.go
@@ -43,7 +43,7 @@ func (c *Rummy500CuiController) Exec(command string) string {
 				if len(args) == 0 {
 					return c.ci.DrawFromDiscard(-1), true
 				}
-				return cuiutil.WithParsedInt(args, "Discard index is required.", "Invalid discard index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.ci.DrawFromDiscard)
+				return cuiutil.WithParsedIntKeys(args, "discardIndexRequired", "invalidDiscardIndex", cuiutil.NoMin, cuiutil.NoMax, c.ci.DrawFromDiscard)
 			case "m", "meld":
 				return c.ci.Meld(parseIntList(args)), true
 			case "lo", "layoff":
@@ -53,7 +53,7 @@ func (c *Rummy500CuiController) Exec(command string) string {
 				}
 				return c.ci.Layoff(indices[0], indices[1], indices[2]), true
 			case "d", "discard":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.ci.Discard)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.ci.Discard)
 			case "nr", "nextround":
 				return c.ci.NextRound(), true
 			case "sd", "setdifficulty":

--- a/internal/adapter/controller/Rummy500CuiController_test.go
+++ b/internal/adapter/controller/Rummy500CuiController_test.go
@@ -75,7 +75,7 @@ func TestRummy500CuiController_Exec(t *testing.T) {
 	t.Run("drawdiscard invalid arg", func(t *testing.T) {
 		c := controller.NewRummy500CuiController(newMock())
 		result := c.Exec("dd xx")
-		assert.Contains(t, result, "Invalid discard index")
+		assert.Contains(t, result, msgInvalidDiscardIndexPrefix())
 	})
 
 	t.Run("meld m with indices", func(t *testing.T) {
@@ -122,7 +122,7 @@ func TestRummy500CuiController_Exec(t *testing.T) {
 	t.Run("discard d no args", func(t *testing.T) {
 		c := controller.NewRummy500CuiController(newMock())
 		result := c.Exec("d")
-		assert.Contains(t, result, "Card index is required")
+		assert.Contains(t, result, msgCardIndexRequired())
 	})
 
 	t.Run("nextround nr", func(t *testing.T) {

--- a/internal/adapter/controller/SakuraCuiController.go
+++ b/internal/adapter/controller/SakuraCuiController.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -74,11 +75,11 @@ func (c *SakuraCuiController) Exec(command string) string {
 // handlePlay は "p <handIdx> [fieldIdx]" を解析して Play を呼ぶ。
 func (c *SakuraCuiController) handlePlay(args []string) string {
 	if len(args) == 0 {
-		return "Card index is required (e.g. p 0, or p 0 3 to pick a field card)."
+		return i18n.T("cardIndexRequiredField")
 	}
 	handIdx, err := strconv.Atoi(args[0])
 	if err != nil {
-		return "Invalid card index: " + args[0] + "."
+		return i18n.Tf("invalidCardIndex", "val", args[0])
 	}
 	fieldIdx := -1
 	if len(args) >= 2 {

--- a/internal/adapter/controller/SakuraCuiController_test.go
+++ b/internal/adapter/controller/SakuraCuiController_test.go
@@ -49,13 +49,13 @@ func TestSakuraCuiController_Exec(t *testing.T) {
 	t.Run("play needs a card index", func(t *testing.T) {
 		m := newMock()
 		out := controller.NewSakuraCuiController(m).Exec("p")
-		assert.Contains(t, out, "Card index is required")
+		assert.Contains(t, out, msgCardIndexRequiredField())
 		m.AssertNotCalled(t, "Play", mock.Anything, mock.Anything)
 	})
 	t.Run("play rejects a non-numeric index", func(t *testing.T) {
 		m := newMock()
 		out := controller.NewSakuraCuiController(m).Exec("p x")
-		assert.Contains(t, out, "Invalid card index")
+		assert.Contains(t, out, msgInvalidCardIndexPrefix())
 		m.AssertNotCalled(t, "Play", mock.Anything, mock.Anything)
 	})
 	// **場札インデックスが数字でなければ「指定なし」に倒す。** 途中で止めると

--- a/internal/adapter/controller/SambaCuiController.go
+++ b/internal/adapter/controller/SambaCuiController.go
@@ -56,7 +56,7 @@ func (c *SambaCuiController) Exec(command string) string {
 				groups := parseMeldGroups(args)
 				return c.ci.Meld(groups), true
 			case "d", "discard":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.ci.Discard)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.ci.Discard)
 			case "sd", "setdifficulty":
 				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
 					cfg := c.ci.GetConfig()

--- a/internal/adapter/controller/SambaCuiController_test.go
+++ b/internal/adapter/controller/SambaCuiController_test.go
@@ -91,12 +91,12 @@ func TestSambaCuiController_Exec(t *testing.T) {
 
 	t.Run("discard no args", func(t *testing.T) {
 		c := controller.NewSambaCuiController(newMock())
-		assert.Contains(t, c.Exec("d"), "Card index is required")
+		assert.Contains(t, c.Exec("d"), msgCardIndexRequired())
 	})
 
 	t.Run("discard invalid arg", func(t *testing.T) {
 		c := controller.NewSambaCuiController(newMock())
-		assert.Contains(t, c.Exec("d abc"), "Invalid card index")
+		assert.Contains(t, c.Exec("d abc"), msgInvalidCardIndexPrefix())
 	})
 
 	t.Run("goout", func(t *testing.T) {

--- a/internal/adapter/controller/ScartoCuiController.go
+++ b/internal/adapter/controller/ScartoCuiController.go
@@ -5,6 +5,7 @@ package controller
 import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -48,7 +49,7 @@ func (c *ScartoCuiController) Exec(command string) string {
 			case "scarto", "discard":
 				return c.execScarto(args)
 			case "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.di.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.di.Play)
 			case "n", "next":
 				return c.di.NextTrick(), true
 			case "nr", "nextround":
@@ -73,7 +74,7 @@ func (c *ScartoCuiController) execScarto(args []string) (string, bool) {
 	}
 	indices, skipped := cuiutil.ParseIntSlice(args)
 	if len(skipped) > 0 {
-		return "Invalid card index: " + skipped[0] + ".", true
+		return i18n.Tf("invalidCardIndex", "val", skipped[0]), true
 	}
 	return c.di.Discard(indices), true
 }

--- a/internal/adapter/controller/ScartoCuiController_test.go
+++ b/internal/adapter/controller/ScartoCuiController_test.go
@@ -61,7 +61,7 @@ func TestScartoCuiController_Exec(t *testing.T) {
 
 	t.Run("scarto invalid index", func(t *testing.T) {
 		result := controller.NewScartoCuiController(newMock()).Exec("scarto 0 1 x")
-		assert.Contains(t, result, "Invalid card index")
+		assert.Contains(t, result, msgInvalidCardIndexPrefix())
 	})
 
 	t.Run("play card", func(t *testing.T) {
@@ -73,7 +73,7 @@ func TestScartoCuiController_Exec(t *testing.T) {
 
 	t.Run("play no args", func(t *testing.T) {
 		result := controller.NewScartoCuiController(newMock()).Exec("play")
-		assert.Contains(t, result, "Card index is required")
+		assert.Contains(t, result, msgCardIndexRequired())
 	})
 
 	t.Run("next / nextround", func(t *testing.T) {

--- a/internal/adapter/controller/SchnapsenCuiController.go
+++ b/internal/adapter/controller/SchnapsenCuiController.go
@@ -40,9 +40,9 @@ func (c *SchnapsenCuiController) Exec(command string) string {
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.si.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.si.Play)
 			case "m", "marriage":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.si.DeclareMarriage)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.si.DeclareMarriage)
 			case "n", "next":
 				return c.si.NextTrick(), true
 			default:

--- a/internal/adapter/controller/SchnapsenCuiController_test.go
+++ b/internal/adapter/controller/SchnapsenCuiController_test.go
@@ -51,12 +51,12 @@ func TestSchnapsenCuiController_Exec(t *testing.T) {
 
 	t.Run("play missing index", func(t *testing.T) {
 		c := controller.NewSchnapsenCuiController(newMock())
-		assert.Contains(t, c.Exec("p"), "Card index is required")
+		assert.Contains(t, c.Exec("p"), msgCardIndexRequired())
 	})
 
 	t.Run("play invalid index", func(t *testing.T) {
 		c := controller.NewSchnapsenCuiController(newMock())
-		assert.Contains(t, c.Exec("p abc"), "Invalid card index")
+		assert.Contains(t, c.Exec("p abc"), msgInvalidCardIndexPrefix())
 	})
 
 	t.Run("marriage with index", func(t *testing.T) {
@@ -69,7 +69,7 @@ func TestSchnapsenCuiController_Exec(t *testing.T) {
 
 	t.Run("marriage missing index", func(t *testing.T) {
 		c := controller.NewSchnapsenCuiController(newMock())
-		assert.Contains(t, c.Exec("marriage"), "Card index is required")
+		assert.Contains(t, c.Exec("marriage"), msgCardIndexRequired())
 	})
 
 	t.Run("next short", func(t *testing.T) {

--- a/internal/adapter/controller/SedmaCuiController.go
+++ b/internal/adapter/controller/SedmaCuiController.go
@@ -44,7 +44,7 @@ func (c *SedmaCuiController) Exec(command string) string {
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.di.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.di.Play)
 			case "n", "next":
 				return c.di.NextTrick(), true
 			case "nr", "nextround":

--- a/internal/adapter/controller/SedmaCuiController_test.go
+++ b/internal/adapter/controller/SedmaCuiController_test.go
@@ -49,7 +49,7 @@ func TestSedmaCuiController_Exec(t *testing.T) {
 
 	t.Run("play no args", func(t *testing.T) {
 		result := controller.NewSedmaCuiController(newMock()).Exec("play")
-		assert.Contains(t, result, "Card index is required")
+		assert.Contains(t, result, msgCardIndexRequired())
 	})
 
 	t.Run("next / nextround", func(t *testing.T) {

--- a/internal/adapter/controller/SergeantMajorCuiController.go
+++ b/internal/adapter/controller/SergeantMajorCuiController.go
@@ -45,7 +45,7 @@ func (c *SergeantMajorCuiController) Exec(command string) string {
 			case "d", "discard":
 				return c.discard(args)
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.si.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.si.Play)
 			case "n", "next":
 				return c.si.NextRound(), true
 			case "g", "giveup":
@@ -66,7 +66,7 @@ func (c *SergeantMajorCuiController) discard(args []string) (string, bool) {
 	}
 	indices := make([]int, 0, domain.SergeantMajorKittySize)
 	for i := range domain.SergeantMajorKittySize {
-		v, errMsg, ok := cuiutil.ParseIntArg(args[i:], "Card index is required.", "Invalid card index: %s.",
+		v, errMsg, ok := cuiutil.ParseIntArgKeys(args[i:], "cardIndexRequired", "invalidCardIndex",
 			cuiutil.NoMin, cuiutil.NoMax)
 		if !ok {
 			return errMsg, true

--- a/internal/adapter/controller/SergeantMajorCuiController_test.go
+++ b/internal/adapter/controller/SergeantMajorCuiController_test.go
@@ -83,7 +83,7 @@ func TestSergeantMajorCuiControllerDiscardRejectsBadArgs(t *testing.T) {
 	for _, tc := range []struct{ name, cmd, want string }{
 		{"no args", "d", "Four card indices are required."},
 		{"too few", "d 0 1 2", "Four card indices are required."},
-		{"non-numeric", "d 0 x 2 3", "Invalid card index: x."},
+		{"non-numeric", "d 0 x 2 3", msgInvalidCardIndex("x")},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			si := newMockSergeantMajorInteractor()
@@ -108,8 +108,8 @@ func TestSergeantMajorCuiControllerPlay(t *testing.T) {
 
 func TestSergeantMajorCuiControllerPlayRejectsBadArgs(t *testing.T) {
 	for _, tc := range []struct{ name, cmd, want string }{
-		{"missing index", "p", "Card index is required."},
-		{"non-numeric", "p abc", "Invalid card index: abc."},
+		{"missing index", "p", msgCardIndexRequired()},
+		{"non-numeric", "p abc", msgInvalidCardIndex("abc")},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			si := newMockSergeantMajorInteractor()

--- a/internal/adapter/controller/SevenBridgeCuiController.go
+++ b/internal/adapter/controller/SevenBridgeCuiController.go
@@ -55,7 +55,7 @@ func (c *SevenBridgeCuiController) Exec(command string) string {
 				}
 				return c.ci.Layoff(idx[0], idx[1], idx[2]), true
 			case "d", "discard":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.ci.Discard)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.ci.Discard)
 			case "nr", "nextround":
 				return c.ci.NextRound(), true
 			case "h", "hint":

--- a/internal/adapter/controller/SevenBridgeCuiController_test.go
+++ b/internal/adapter/controller/SevenBridgeCuiController_test.go
@@ -116,12 +116,12 @@ func TestSevenBridgeCuiController_Exec(t *testing.T) {
 
 	t.Run("discard no args", func(t *testing.T) {
 		c := controller.NewSevenBridgeCuiController(newMock())
-		assert.Contains(t, c.Exec("d"), "Card index is required")
+		assert.Contains(t, c.Exec("d"), msgCardIndexRequired())
 	})
 
 	t.Run("discard invalid", func(t *testing.T) {
 		c := controller.NewSevenBridgeCuiController(newMock())
-		assert.Contains(t, c.Exec("d abc"), "Invalid card index")
+		assert.Contains(t, c.Exec("d abc"), msgInvalidCardIndexPrefix())
 	})
 
 	t.Run("nextround aliases", func(t *testing.T) {

--- a/internal/adapter/controller/SheepsheadCuiController.go
+++ b/internal/adapter/controller/SheepsheadCuiController.go
@@ -59,7 +59,7 @@ func (c *SheepsheadCuiController) Exec(command string) string {
 			case "c", "call":
 				return cuiutil.WithParsedInt(args, "Suit is required (1=♠ 2=♣ 3=♥).", "Invalid suit: %s. Please enter 1-3.", domain.CardDesignSpade, domain.CardDesignHeart, c.si.Call)
 			case "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.si.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.si.Play)
 			case "n", "next":
 				return c.si.NextTrick(), true
 			case "nr", "nextround":

--- a/internal/adapter/controller/SheepsheadCuiController_test.go
+++ b/internal/adapter/controller/SheepsheadCuiController_test.go
@@ -121,7 +121,7 @@ func TestSheepsheadCuiController_Exec(t *testing.T) {
 
 	t.Run("play no args", func(t *testing.T) {
 		result := controller.NewSheepsheadCuiController(newMock()).Exec("play")
-		assert.Contains(t, result, "Card index is required")
+		assert.Contains(t, result, msgCardIndexRequired())
 	})
 
 	t.Run("next / nextround", func(t *testing.T) {

--- a/internal/adapter/controller/ShelemCuiController.go
+++ b/internal/adapter/controller/ShelemCuiController.go
@@ -49,7 +49,7 @@ func (c *ShelemCuiController) Exec(command string) string {
 			case "d", "discard":
 				return c.discard(args)
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.si.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.si.Play)
 			case "n", "next":
 				return c.si.NextRound(), true
 			case "g", "giveup":
@@ -71,7 +71,7 @@ func (c *ShelemCuiController) discard(args []string) (string, bool) {
 	}
 	indices := make([]int, 0, domain.ShelemWidowSize)
 	for i := range domain.ShelemWidowSize {
-		v, errMsg, ok := cuiutil.ParseIntArg(args[i:], "Card index is required.", "Invalid card index: %s.",
+		v, errMsg, ok := cuiutil.ParseIntArgKeys(args[i:], "cardIndexRequired", "invalidCardIndex",
 			cuiutil.NoMin, cuiutil.NoMax)
 		if !ok {
 			return errMsg, true

--- a/internal/adapter/controller/ShelemCuiController_test.go
+++ b/internal/adapter/controller/ShelemCuiController_test.go
@@ -109,7 +109,7 @@ func TestShelemCuiControllerDiscardRejectsBadArgs(t *testing.T) {
 	for _, tc := range []struct{ name, cmd, want string }{
 		{"no args", "d", "Four card indices and a suit are required."},
 		{"too few", "d 0 1 2 3", "Four card indices and a suit are required."},
-		{"non-numeric index", "d 0 x 2 3 1", "Invalid card index: x."},
+		{"non-numeric index", "d 0 x 2 3 1", msgInvalidCardIndex("x")},
 		{"suit out of range", "d 0 1 2 3 5", "Invalid suit: 5."},
 		{"non-numeric suit", "d 0 1 2 3 x", "Invalid suit: x."},
 	} {
@@ -155,8 +155,8 @@ func TestShelemCuiControllerPlay(t *testing.T) {
 
 func TestShelemCuiControllerPlayRejectsBadArgs(t *testing.T) {
 	for _, tc := range []struct{ name, cmd, want string }{
-		{"missing index", "p", "Card index is required."},
-		{"non-numeric", "p abc", "Invalid card index: abc."},
+		{"missing index", "p", msgCardIndexRequired()},
+		{"non-numeric", "p abc", msgInvalidCardIndex("abc")},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			si := newMockShelemInteractor()

--- a/internal/adapter/controller/ShengJiCuiController.go
+++ b/internal/adapter/controller/ShengJiCuiController.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -70,7 +71,7 @@ func shengJiParseIndexes(args []string, want, maxIdx int, apply func([]int) stri
 	for _, a := range args {
 		v, err := strconv.Atoi(a)
 		if err != nil || v < 0 || v > maxIdx {
-			return "Invalid card index: " + a + ". Please enter 0-" + strconv.Itoa(maxIdx) + ".", true
+			return i18n.Tf("invalidCardIndexRange", "val", a, "max", strconv.Itoa(maxIdx)), true
 		}
 		// **同じ札を 2 回数えられない。**通すと 1 枚から対子が作れてしまう。
 		if seen[v] {

--- a/internal/adapter/controller/ShengJiCuiController_test.go
+++ b/internal/adapter/controller/ShengJiCuiController_test.go
@@ -62,7 +62,7 @@ func TestShengJiCuiController_Exec(t *testing.T) {
 		m.AssertCalled(t, "BuryKitty", []int{0, 1, 2, 3, 4, 5, 6, 7})
 		// **底牌を拾った直後は 25 + 8 枚**あるので、埋め戻しの上限は広い。
 		assert.Equal(t, mockOutput, c.Exec("b 25 26 27 28 29 30 31 32"))
-		assert.Contains(t, c.Exec("b 33 0 1 2 3 4 5 6"), "Invalid card index")
+		assert.Contains(t, c.Exec("b 33 0 1 2 3 4 5 6"), msgInvalidCardIndexPrefix())
 		assert.Contains(t, c.Exec("b 0 1"), "exactly 8")
 		assert.Contains(t, c.Exec("b"), "Card indexes are required")
 	})
@@ -79,11 +79,11 @@ func TestShengJiCuiController_Exec(t *testing.T) {
 	t.Run("play rejects bad input", func(t *testing.T) {
 		c := controller.NewShengJiCuiController(newMock())
 		assert.Contains(t, c.Exec("p"), "Card indexes are required")
-		assert.Contains(t, c.Exec("p abc"), "Invalid card index")
-		assert.Contains(t, c.Exec("p -1"), "Invalid card index")
-		assert.Contains(t, c.Exec("p 99"), "Invalid card index")
+		assert.Contains(t, c.Exec("p abc"), msgInvalidCardIndexPrefix())
+		assert.Contains(t, c.Exec("p -1"), msgInvalidCardIndexPrefix())
+		assert.Contains(t, c.Exec("p 99"), msgInvalidCardIndexPrefix())
 		// **プレイ中の手札は 25 枚。**底牌を拾った直後の上限 (32) を使い回すと緩い。
-		assert.Contains(t, c.Exec("p 25"), "Invalid card index")
+		assert.Contains(t, c.Exec("p 25"), msgInvalidCardIndexPrefix())
 		assert.Equal(t, mockOutput, c.Exec("p 24"))
 		// **同じ札を 2 回数えられない。**通すと 1 枚から対子が作れてしまう。
 		assert.Contains(t, c.Exec("p 1 1"), "twice")

--- a/internal/adapter/controller/SixBidSoloCuiController.go
+++ b/internal/adapter/controller/SixBidSoloCuiController.go
@@ -43,7 +43,7 @@ func (c *SixBidSoloCuiController) Exec(command string) string {
 			case "d", "declare":
 				return sixBidSoloParseDeclare(args, c.si)
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.",
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex",
 					0, domain.SixBidSoloHandSize-1, func(v int) string {
 						return c.si.PlayCard(v)
 					})

--- a/internal/adapter/controller/SixBidSoloCuiController_test.go
+++ b/internal/adapter/controller/SixBidSoloCuiController_test.go
@@ -97,8 +97,8 @@ func TestSixBidSoloCuiController_Exec(t *testing.T) {
 		m.AssertCalled(t, "PlayCard", 10)
 		assert.Equal(t, mockOutput, c.Exec("n"))
 		m.AssertCalled(t, "NextHand")
-		assert.Contains(t, c.Exec("p abc"), "Invalid card index")
-		assert.Contains(t, c.Exec("p 11"), "Invalid card index")
+		assert.Contains(t, c.Exec("p abc"), msgInvalidCardIndexPrefix())
+		assert.Contains(t, c.Exec("p 11"), msgInvalidCardIndexPrefix())
 	})
 
 	t.Run("log and unknown", func(t *testing.T) {

--- a/internal/adapter/controller/SjavsCuiController.go
+++ b/internal/adapter/controller/SjavsCuiController.go
@@ -40,7 +40,7 @@ func (c *SjavsCuiController) Exec(command string) string {
 			case "b", "bid":
 				return cuiutil.WithParsedInt(args, "Bid length is required.", "Invalid bid length: %s.", cuiutil.NoMin, cuiutil.NoMax, c.si.Bid)
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.si.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.si.Play)
 			case "n", "next":
 				return c.si.NextHand(), true
 			default:

--- a/internal/adapter/controller/SkatCuiController.go
+++ b/internal/adapter/controller/SkatCuiController.go
@@ -65,11 +65,11 @@ func (c *SkatCuiController) Exec(command string) string {
 				if len(args) < 2 {
 					return "Usage: discard <i> <j> (two card indices)\n", true
 				}
-				idxA, errMsg, ok := cuiutil.ParseIntArg(args[:1], "", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax)
+				idxA, errMsg, ok := cuiutil.ParseIntArgKeys(args[:1], "", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax)
 				if !ok {
 					return errMsg, true
 				}
-				idxB, errMsg, ok := cuiutil.ParseIntArg(args[1:2], "", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax)
+				idxB, errMsg, ok := cuiutil.ParseIntArgKeys(args[1:2], "", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax)
 				if !ok {
 					return errMsg, true
 				}
@@ -92,7 +92,7 @@ func (c *SkatCuiController) Exec(command string) string {
 				}
 				return c.si.DeclareGame(domain.SkatGameType(gt), trump), true
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.si.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.si.Play)
 			case "n", "next":
 				return c.si.NextTrick(), true
 			case "nr", "nextround":

--- a/internal/adapter/controller/SkatCuiController_test.go
+++ b/internal/adapter/controller/SkatCuiController_test.go
@@ -103,7 +103,7 @@ func TestSkatCuiController_Exec(t *testing.T) {
 
 	t.Run("discard invalid first arg", func(t *testing.T) {
 		c := controller.NewSkatCuiController(newMock())
-		assert.Contains(t, c.Exec("d abc 1"), "Invalid card index")
+		assert.Contains(t, c.Exec("d abc 1"), msgInvalidCardIndexPrefix())
 	})
 
 	t.Run("game suit + trump", func(t *testing.T) {

--- a/internal/adapter/controller/SkitgubbeCuiController.go
+++ b/internal/adapter/controller/SkitgubbeCuiController.go
@@ -37,7 +37,7 @@ func (c *SkitgubbeCuiController) Exec(command string) string {
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.si.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.si.Play)
 			case "u", "pickup":
 				return c.si.PickUp(), true
 			default:

--- a/internal/adapter/controller/SlobberhannesCuiController.go
+++ b/internal/adapter/controller/SlobberhannesCuiController.go
@@ -37,7 +37,7 @@ func (c *SlobberhannesCuiController) Exec(command string) string {
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.si.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.si.Play)
 			case "n", "next":
 				return c.si.NextRound(), true
 			case "g", "giveup":

--- a/internal/adapter/controller/SlobberhannesCuiController_test.go
+++ b/internal/adapter/controller/SlobberhannesCuiController_test.go
@@ -69,8 +69,8 @@ func TestSlobberhannesCuiControllerPlay(t *testing.T) {
 
 func TestSlobberhannesCuiControllerPlayRejectsBadArgs(t *testing.T) {
 	for _, tc := range []struct{ name, cmd, want string }{
-		{"missing index", "p", "Card index is required."},
-		{"non-numeric", "p abc", "Invalid card index: abc."},
+		{"missing index", "p", msgCardIndexRequired()},
+		{"non-numeric", "p abc", msgInvalidCardIndex("abc")},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			si := newMockSlobberhannesInteractor()

--- a/internal/adapter/controller/SoloWhistCuiController.go
+++ b/internal/adapter/controller/SoloWhistCuiController.go
@@ -52,7 +52,7 @@ func (c *SoloWhistCuiController) Exec(command string) string {
 			case "pass":
 				return c.di.Bid(int(domain.SoloWhistBidPass)), true
 			case "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.di.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.di.Play)
 			case "n", "next":
 				return c.di.NextTrick(), true
 			case "nr", "nextround":

--- a/internal/adapter/controller/SoloWhistCuiController_test.go
+++ b/internal/adapter/controller/SoloWhistCuiController_test.go
@@ -74,7 +74,7 @@ func TestSoloWhistCuiController_Exec(t *testing.T) {
 
 	t.Run("play no args", func(t *testing.T) {
 		result := controller.NewSoloWhistCuiController(newMock()).Exec("play")
-		assert.Contains(t, result, "Card index is required")
+		assert.Contains(t, result, msgCardIndexRequired())
 	})
 
 	t.Run("next / nextround", func(t *testing.T) {

--- a/internal/adapter/controller/SpadesCuiController.go
+++ b/internal/adapter/controller/SpadesCuiController.go
@@ -47,7 +47,7 @@ func (c *SpadesCuiController) Exec(command string) string {
 			case "b", "bid":
 				return cuiutil.WithParsedInt(args, "Bid value is required (0-13).", "Invalid bid value: %s.", 0, 13, c.si.Bid)
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.si.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.si.Play)
 			case "n", "next":
 				return c.si.NextTrick(), true
 			case "nr", "nextround":

--- a/internal/adapter/controller/SpadesCuiController_test.go
+++ b/internal/adapter/controller/SpadesCuiController_test.go
@@ -120,13 +120,13 @@ func TestSpadesCuiController_Exec(t *testing.T) {
 	t.Run("play command p no args", func(t *testing.T) {
 		c := controller.NewSpadesCuiController(newMock())
 		result := c.Exec("p")
-		assert.Contains(t, result, "Card index is required")
+		assert.Contains(t, result, msgCardIndexRequired())
 	})
 
 	t.Run("play command p invalid arg", func(t *testing.T) {
 		c := controller.NewSpadesCuiController(newMock())
 		result := c.Exec("p abc")
-		assert.Contains(t, result, "Invalid card index")
+		assert.Contains(t, result, msgInvalidCardIndexPrefix())
 	})
 
 	// next

--- a/internal/adapter/controller/SpoilFiveCuiController.go
+++ b/internal/adapter/controller/SpoilFiveCuiController.go
@@ -44,7 +44,7 @@ func (c *SpoilFiveCuiController) Exec(command string) string {
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.di.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.di.Play)
 			case "n", "next":
 				return c.di.NextTrick(), true
 			case "nr", "nextround":

--- a/internal/adapter/controller/SpoilFiveCuiController_test.go
+++ b/internal/adapter/controller/SpoilFiveCuiController_test.go
@@ -49,7 +49,7 @@ func TestSpoilFiveCuiController_Exec(t *testing.T) {
 
 	t.Run("play no args", func(t *testing.T) {
 		result := controller.NewSpoilFiveCuiController(newMock()).Exec("play")
-		assert.Contains(t, result, "Card index is required")
+		assert.Contains(t, result, msgCardIndexRequired())
 	})
 
 	t.Run("next / nextround", func(t *testing.T) {

--- a/internal/adapter/controller/StealingBundlesCuiController.go
+++ b/internal/adapter/controller/StealingBundlesCuiController.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -38,10 +39,10 @@ func (c *StealingBundlesCuiController) Exec(command string) string {
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "t", "take":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.",
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex",
 					cuiutil.NoMin, cuiutil.NoMax, c.si.Take)
 			case "d", "trail":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.",
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex",
 					cuiutil.NoMin, cuiutil.NoMax, c.si.Trail)
 			case "s", "steal":
 				return c.execSteal(args)
@@ -59,11 +60,11 @@ func (c *StealingBundlesCuiController) Exec(command string) string {
 // **札と相手の両方が要ります。** どちらが欠けているかを言い分けます。
 func (c *StealingBundlesCuiController) execSteal(args []string) (string, bool) {
 	if len(args) < 1 {
-		return "Card index is required.", true
+		return i18n.T("cardIndexRequired"), true
 	}
 	cardIdx, err := strconv.Atoi(args[0])
 	if err != nil {
-		return "Invalid card index: " + args[0] + ".", true
+		return i18n.Tf("invalidCardIndex", "val", args[0]), true
 	}
 	if len(args) < 2 {
 		return "Victim index is required.", true

--- a/internal/adapter/controller/StealingBundlesCuiController_test.go
+++ b/internal/adapter/controller/StealingBundlesCuiController_test.go
@@ -52,8 +52,8 @@ func TestStealingBundlesCuiController_Commands(t *testing.T) {
 // **どちらの引数が欠けているかを言い分けます。**
 func TestStealingBundlesCuiController_StealRejectsBadArgs(t *testing.T) {
 	for _, tc := range []struct{ name, cmd, want string }{
-		{"no args", "s", "Card index is required."},
-		{"card not a number", "s x 1", "Invalid card index: x."},
+		{"no args", "s", msgCardIndexRequired()},
+		{"card not a number", "s x 1", msgInvalidCardIndex("x")},
 		{"victim missing", "s 1", "Victim index is required."},
 		{"victim not a number", "s 1 y", "Invalid victim index: y."},
 	} {
@@ -67,10 +67,10 @@ func TestStealingBundlesCuiController_StealRejectsBadArgs(t *testing.T) {
 
 func TestStealingBundlesCuiController_TakeAndTrailRejectBadArgs(t *testing.T) {
 	for _, tc := range []struct{ name, cmd, want string }{
-		{"take missing", "t", "Card index is required."},
-		{"take not a number", "t x", "Invalid card index: x."},
-		{"trail missing", "d", "Card index is required."},
-		{"trail not a number", "d x", "Invalid card index: x."},
+		{"take missing", "t", msgCardIndexRequired()},
+		{"take not a number", "t x", msgInvalidCardIndex("x")},
+		{"trail missing", "d", msgCardIndexRequired()},
+		{"trail not a number", "d x", msgInvalidCardIndex("x")},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			c, si := newStealingBundlesCui()

--- a/internal/adapter/controller/SuecaCuiController.go
+++ b/internal/adapter/controller/SuecaCuiController.go
@@ -44,7 +44,7 @@ func (c *SuecaCuiController) Exec(command string) string {
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.di.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.di.Play)
 			case "n", "next":
 				return c.di.NextTrick(), true
 			case "nr", "nextround":

--- a/internal/adapter/controller/SuecaCuiController_test.go
+++ b/internal/adapter/controller/SuecaCuiController_test.go
@@ -49,7 +49,7 @@ func TestSuecaCuiController_Exec(t *testing.T) {
 
 	t.Run("play no args", func(t *testing.T) {
 		result := controller.NewSuecaCuiController(newMock()).Exec("play")
-		assert.Contains(t, result, "Card index is required")
+		assert.Contains(t, result, msgCardIndexRequired())
 	})
 
 	t.Run("next / nextround", func(t *testing.T) {

--- a/internal/adapter/controller/TablanetCuiController.go
+++ b/internal/adapter/controller/TablanetCuiController.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -63,11 +64,11 @@ func (c *TablanetCuiController) Exec(command string) string {
 // handlePlay は "p <handIdx> [tableIdx...]" を解析して Play を呼ぶ。
 func (c *TablanetCuiController) handlePlay(args []string) string {
 	if len(args) == 0 {
-		return "Card index is required (e.g. p 0, or p 0 1 2 to capture table cards)."
+		return i18n.T("cardIndexRequiredCapture")
 	}
 	handIdx, err := strconv.Atoi(args[0])
 	if err != nil {
-		return "Invalid card index: " + args[0] + "."
+		return i18n.Tf("invalidCardIndex", "val", args[0])
 	}
 	tableIdxs, _ := cuiutil.ParseIntSlice(args[1:])
 	return c.bi.Play(handIdx, tableIdxs)

--- a/internal/adapter/controller/TablanetCuiController_test.go
+++ b/internal/adapter/controller/TablanetCuiController_test.go
@@ -48,11 +48,11 @@ func TestTablanetCuiController_Exec(t *testing.T) {
 	})
 	t.Run("play missing index", func(t *testing.T) {
 		out := controller.NewTablanetCuiController(newMock()).Exec("p")
-		assert.Contains(t, out, "required")
+		assert.Contains(t, out, msgCardIndexRequiredCapture())
 	})
 	t.Run("play invalid index", func(t *testing.T) {
 		out := controller.NewTablanetCuiController(newMock()).Exec("p xyz")
-		assert.Contains(t, out, "Invalid card index")
+		assert.Contains(t, out, msgInvalidCardIndexPrefix())
 	})
 	t.Run("next round", func(t *testing.T) {
 		m := newMock()

--- a/internal/adapter/controller/TarabishCuiController.go
+++ b/internal/adapter/controller/TarabishCuiController.go
@@ -41,7 +41,7 @@ func (c *TarabishCuiController) Exec(command string) string {
 			case "pass":
 				return c.ti.PassTrump(), true
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.ti.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.ti.Play)
 			case "n", "next":
 				return c.ti.NextRound(), true
 			case "g", "giveup":

--- a/internal/adapter/controller/TarabishCuiController_test.go
+++ b/internal/adapter/controller/TarabishCuiController_test.go
@@ -83,8 +83,8 @@ func TestTarabishCuiControllerPlay(t *testing.T) {
 
 func TestTarabishCuiControllerPlayRejectsBadArgs(t *testing.T) {
 	for _, tc := range []struct{ name, cmd, want string }{
-		{"missing index", "p", "Card index is required."},
-		{"non-numeric", "p abc", "Invalid card index: abc."},
+		{"missing index", "p", msgCardIndexRequired()},
+		{"non-numeric", "p abc", msgInvalidCardIndex("abc")},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			ti := newMockTarabishInteractor()

--- a/internal/adapter/controller/TarneebCuiController.go
+++ b/internal/adapter/controller/TarneebCuiController.go
@@ -53,7 +53,7 @@ func (c *TarneebCuiController) Exec(command string) string {
 			case "t", "trump":
 				return cuiutil.WithParsedInt(args, "Trump suit is required (1=Spade 2=Club 3=Heart 4=Diamond).", "Invalid suit: %s.", domain.CardDesignSpade, domain.CardDesignDiamond, c.ti.DeclareTrump)
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.ti.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.ti.Play)
 			case "n", "next":
 				return c.ti.NextTrick(), true
 			case "nr", "nextround":

--- a/internal/adapter/controller/TarocchiniCuiController.go
+++ b/internal/adapter/controller/TarocchiniCuiController.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -50,7 +51,7 @@ func (c *TarocchiniCuiController) Exec(command string) string {
 			case "scarto", "discard":
 				return c.execScarto(args)
 			case "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.di.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.di.Play)
 			case "n", "next":
 				return c.di.NextTrick(), true
 			case "nr", "nextround":
@@ -78,7 +79,7 @@ func (c *TarocchiniCuiController) execScarto(args []string) (string, bool) {
 	}
 	indices, skipped := cuiutil.ParseIntSlice(args)
 	if len(skipped) > 0 {
-		return "Invalid card index: " + skipped[0] + ".", true
+		return i18n.Tf("invalidCardIndex", "val", skipped[0]), true
 	}
 	return c.di.Discard(indices), true
 }

--- a/internal/adapter/controller/TarocchiniCuiController_test.go
+++ b/internal/adapter/controller/TarocchiniCuiController_test.go
@@ -57,7 +57,7 @@ func TestTarocchiniCuiController_Exec(t *testing.T) {
 
 	t.Run("scarto with a non-numeric index", func(t *testing.T) {
 		out := controller.NewTarocchiniCuiController(newMock()).Exec("scarto x y")
-		assert.Contains(t, out, "Invalid card index")
+		assert.Contains(t, out, msgInvalidCardIndexPrefix())
 	})
 
 	t.Run("play card", func(t *testing.T) {
@@ -67,7 +67,7 @@ func TestTarocchiniCuiController_Exec(t *testing.T) {
 	})
 
 	t.Run("play no args", func(t *testing.T) {
-		assert.Contains(t, controller.NewTarocchiniCuiController(newMock()).Exec("play"), "Card index is required")
+		assert.Contains(t, controller.NewTarocchiniCuiController(newMock()).Exec("play"), msgCardIndexRequired())
 	})
 
 	// このゲームに入札は無い。bid/pass が黙って別の動作に落ちてはならない。

--- a/internal/adapter/controller/TeenDoPaanchCuiController.go
+++ b/internal/adapter/controller/TeenDoPaanchCuiController.go
@@ -43,7 +43,7 @@ func (c *TeenDoPaanchCuiController) Exec(command string) string {
 				return cuiutil.WithParsedInt(args, "Suit is required.", "Invalid suit: %s.",
 					domain.CardDesignSpade, domain.CardDesignDiamond, c.ti.DeclareTrump)
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.ti.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.ti.Play)
 			case "n", "next":
 				return c.ti.NextRound(), true
 			case "g", "giveup":

--- a/internal/adapter/controller/TeenDoPaanchCuiController_test.go
+++ b/internal/adapter/controller/TeenDoPaanchCuiController_test.go
@@ -80,8 +80,8 @@ func TestTeenDoPaanchCuiControllerPlay(t *testing.T) {
 
 func TestTeenDoPaanchCuiControllerPlayRejectsBadArgs(t *testing.T) {
 	for _, tc := range []struct{ name, cmd, want string }{
-		{"missing index", "p", "Card index is required."},
-		{"non-numeric", "p abc", "Invalid card index: abc."},
+		{"missing index", "p", msgCardIndexRequired()},
+		{"non-numeric", "p abc", msgInvalidCardIndex("abc")},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			ti := newMockTeenDoPaanchInteractor()

--- a/internal/adapter/controller/ThirtyOneCuiController.go
+++ b/internal/adapter/controller/ThirtyOneCuiController.go
@@ -40,7 +40,7 @@ func (c *ThirtyOneCuiController) Exec(command string) string {
 			case "dd", "drawdiscard":
 				return c.ci.DrawFromDiscard(), true
 			case "d", "discard":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.ci.Discard)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.ci.Discard)
 			case "k", "knock":
 				return c.ci.Knock(), true
 			case "h", "hint":

--- a/internal/adapter/controller/ThirtyOneCuiController_test.go
+++ b/internal/adapter/controller/ThirtyOneCuiController_test.go
@@ -66,8 +66,8 @@ func TestThirtyOneCuiController_Exec(t *testing.T) {
 
 	t.Run("discard no args", func(t *testing.T) {
 		c := controller.NewThirtyOneCuiController(newMock())
-		assert.Contains(t, c.Exec("d"), "Card index is required")
-		assert.Contains(t, c.Exec("d abc"), "Invalid card index")
+		assert.Contains(t, c.Exec("d"), msgCardIndexRequired())
+		assert.Contains(t, c.Exec("d abc"), msgInvalidCardIndexPrefix())
 	})
 
 	t.Run("knock takes no index", func(t *testing.T) {

--- a/internal/adapter/controller/ThreeThirteenCuiController.go
+++ b/internal/adapter/controller/ThreeThirteenCuiController.go
@@ -41,9 +41,9 @@ func (c *ThreeThirteenCuiController) Exec(command string) string {
 			case "dd", "drawdiscard":
 				return c.ci.DrawFromDiscard(), true
 			case "d", "discard":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.ci.Discard)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.ci.Discard)
 			case "k", "knock":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.ci.Knock)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.ci.Knock)
 			case "nr", "nextround":
 				return c.ci.NextRound(), true
 			case "sd", "setdifficulty":

--- a/internal/adapter/controller/ToepenCuiController.go
+++ b/internal/adapter/controller/ToepenCuiController.go
@@ -43,7 +43,7 @@ func (c *ToepenCuiController) Exec(command string) string {
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.ti.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.ti.Play)
 			case "t", "toep":
 				return c.ti.Toep(), true
 			case "s", "stay":

--- a/internal/adapter/controller/TonkCuiController.go
+++ b/internal/adapter/controller/TonkCuiController.go
@@ -39,9 +39,9 @@ func (c *TonkCuiController) Exec(command string) string {
 			case "dd", "drawdiscard":
 				return c.ci.DrawFromDiscard(), true
 			case "d", "discard":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.ci.Discard)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.ci.Discard)
 			case "k", "knock":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.ci.Knock)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.ci.Knock)
 			case "nr", "nextround":
 				return c.ci.NextRound(), true
 			case "sd", "setdifficulty":

--- a/internal/adapter/controller/TonkCuiController_test.go
+++ b/internal/adapter/controller/TonkCuiController_test.go
@@ -70,8 +70,8 @@ func TestTonkCuiController_Exec(t *testing.T) {
 
 	t.Run("discard no args", func(t *testing.T) {
 		c := controller.NewTonkCuiController(newMock())
-		assert.Contains(t, c.Exec("d"), "Card index is required")
-		assert.Contains(t, c.Exec("d abc"), "Invalid card index")
+		assert.Contains(t, c.Exec("d"), msgCardIndexRequired())
+		assert.Contains(t, c.Exec("d abc"), msgInvalidCardIndexPrefix())
 	})
 
 	t.Run("knock with index", func(t *testing.T) {
@@ -85,8 +85,8 @@ func TestTonkCuiController_Exec(t *testing.T) {
 
 	t.Run("knock no args", func(t *testing.T) {
 		c := controller.NewTonkCuiController(newMock())
-		assert.Contains(t, c.Exec("k"), "Card index is required")
-		assert.Contains(t, c.Exec("k abc"), "Invalid card index")
+		assert.Contains(t, c.Exec("k"), msgCardIndexRequired())
+		assert.Contains(t, c.Exec("k abc"), msgInvalidCardIndexPrefix())
 	})
 
 	t.Run("nextround", func(t *testing.T) {

--- a/internal/adapter/controller/TressetteCuiController.go
+++ b/internal/adapter/controller/TressetteCuiController.go
@@ -46,7 +46,7 @@ func (c *TressetteCuiController) Exec(command string) string {
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.ti.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.ti.Play)
 			case "n", "next":
 				return c.ti.NextTrick(), true
 			case "nr", "nextround":

--- a/internal/adapter/controller/TressetteCuiController_test.go
+++ b/internal/adapter/controller/TressetteCuiController_test.go
@@ -49,7 +49,7 @@ func TestTressetteCuiController_Exec(t *testing.T) {
 
 	t.Run("play no args", func(t *testing.T) {
 		result := controller.NewTressetteCuiController(newMock()).Exec("p")
-		assert.Contains(t, result, "Card index is required")
+		assert.Contains(t, result, msgCardIndexRequired())
 	})
 
 	t.Run("next / nextround", func(t *testing.T) {

--- a/internal/adapter/controller/TrexCuiController.go
+++ b/internal/adapter/controller/TrexCuiController.go
@@ -41,7 +41,7 @@ func (c *TrexCuiController) Exec(command string) string {
 			case "c", "choose":
 				return cuiutil.WithParsedInt(args, "Contract number is required.", "Invalid contract: %s.", cuiutil.NoMin, cuiutil.NoMax, c.ti.Choose)
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.ti.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.ti.Play)
 			case "s", "pass":
 				return c.ti.Pass(), true
 			case "n", "next":

--- a/internal/adapter/controller/TrogguCuiController.go
+++ b/internal/adapter/controller/TrogguCuiController.go
@@ -49,8 +49,8 @@ func (c *TrogguCuiController) Exec(command string) string {
 			case "pass":
 				return c.ti.Pass(), true
 			case "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.",
-					"Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.ti.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired",
+					"invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.ti.Play)
 			case "n", "next":
 				return c.ti.NextTrick(), true
 			case "nr", "nextround":

--- a/internal/adapter/controller/TrogguCuiController_test.go
+++ b/internal/adapter/controller/TrogguCuiController_test.go
@@ -83,7 +83,7 @@ func TestTrogguCuiController_Exec(t *testing.T) {
 	t.Run("play rejects a non-numeric index", func(t *testing.T) {
 		m := newMock()
 		out := controller.NewTrogguCuiController(m).Exec("play x")
-		assert.Contains(t, out, "Invalid card index")
+		assert.Contains(t, out, msgInvalidCardIndexPrefix())
 		m.AssertNotCalled(t, "Play", mock.Anything)
 	})
 	t.Run("next trick and next round", func(t *testing.T) {

--- a/internal/adapter/controller/TrucoCuiController.go
+++ b/internal/adapter/controller/TrucoCuiController.go
@@ -41,7 +41,7 @@ func (c *TrucoCuiController) Exec(command string) string {
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.ti.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.ti.Play)
 			case "t", "truco":
 				return c.ti.Truco(), true
 			case "a", "accept":

--- a/internal/adapter/controller/TrucoCuiController_test.go
+++ b/internal/adapter/controller/TrucoCuiController_test.go
@@ -50,12 +50,12 @@ func TestTrucoCuiController_Exec(t *testing.T) {
 
 	t.Run("play missing index", func(t *testing.T) {
 		got := controller.NewTrucoCuiController(newMock()).Exec("p")
-		assert.Contains(t, got, "Card index is required")
+		assert.Contains(t, got, msgCardIndexRequired())
 	})
 
 	t.Run("play invalid index", func(t *testing.T) {
 		got := controller.NewTrucoCuiController(newMock()).Exec("p abc")
-		assert.Contains(t, got, "Invalid card index")
+		assert.Contains(t, got, msgInvalidCardIndexPrefix())
 	})
 
 	t.Run("truco", func(t *testing.T) {

--- a/internal/adapter/controller/TuSacController_test.go
+++ b/internal/adapter/controller/TuSacController_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/usecase"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	uc "github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -197,11 +198,11 @@ func TestTuSacCuiController(t *testing.T) {
 	assert.NotEmpty(t, c.Exec("x 1"))
 	m.AssertCalled(t, "Discard", 0)
 
-	assert.Contains(t, c.Exec("meld"), "required")
-	assert.Contains(t, c.Exec("meld abc"), "Invalid")
-	assert.Contains(t, c.Exec("meld 0"), "Invalid", "0 番を受け付けている")
-	assert.Contains(t, c.Exec("discard"), "required")
-	assert.Contains(t, c.Exec("discard xyz"), "Invalid")
+	assert.Contains(t, c.Exec("meld"), i18n.T("cardIndexesRequiredMeld"))
+	assert.Contains(t, c.Exec("meld abc"), i18n.T("invalidIndexFromOne"))
+	assert.Contains(t, c.Exec("meld 0"), i18n.T("invalidIndexFromOne"), "0 番を受け付けている")
+	assert.Contains(t, c.Exec("discard"), msgCardIndexRequired())
+	assert.Contains(t, c.Exec("discard xyz"), i18n.T("invalidIndexNotANumber"))
 
 	for _, cmd := range []string{"next", "hint", "log"} {
 		assert.NotEmpty(t, c.Exec(cmd), "command %s produced nothing", cmd)

--- a/internal/adapter/controller/TuSacCuiController.go
+++ b/internal/adapter/controller/TuSacCuiController.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -43,8 +44,8 @@ func (cc *TuSacCuiController) Exec(command string) string {
 				}
 				return cc.ci.Meld(indexes), true
 			case "discard", "x":
-				index, errMsg, ok := cuiutil.ParseIntArg(args,
-					"Card index is required.", "Invalid index. Please enter a number.", 0, math.MaxInt)
+				index, errMsg, ok := cuiutil.ParseIntArgKeys(args,
+					"cardIndexRequired", "invalidIndexNotANumber", 0, math.MaxInt)
 				if !ok {
 					return errMsg, true
 				}
@@ -64,13 +65,13 @@ func (cc *TuSacCuiController) Exec(command string) string {
 // tuSacParseIndexes は "1 4 7" のような並びを 0 始まりの添字にする。
 func tuSacParseIndexes(args []string) ([]int, string, bool) {
 	if len(args) == 0 {
-		return nil, "Card indexes are required (e.g. meld 1 4 7).", false
+		return nil, i18n.T("cardIndexesRequiredMeld"), false
 	}
 	out := make([]int, 0, len(args))
 	for _, a := range args {
 		n, err := strconv.Atoi(strings.TrimSpace(a))
 		if err != nil || n < 1 {
-			return nil, "Invalid index. Please enter numbers from 1.", false
+			return nil, i18n.T("invalidIndexFromOne"), false
 		}
 		out = append(out, n-1)
 	}

--- a/internal/adapter/controller/TuteCuiController.go
+++ b/internal/adapter/controller/TuteCuiController.go
@@ -46,7 +46,7 @@ func (c *TuteCuiController) Exec(command string) string {
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.di.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.di.Play)
 			case "m", "marriage":
 				return cuiutil.WithParsedInt(args, "Suit is required (1=♠ 2=♣ 3=♥ 4=♦).", "Invalid suit: %s. Please enter 1-4.", 1, domain.CardDesignMax, c.di.DeclareMarriage)
 			case "tute":

--- a/internal/adapter/controller/TuteCuiController_test.go
+++ b/internal/adapter/controller/TuteCuiController_test.go
@@ -51,7 +51,7 @@ func TestTuteCuiController_Exec(t *testing.T) {
 
 	t.Run("play no args", func(t *testing.T) {
 		result := controller.NewTuteCuiController(newMock()).Exec("play")
-		assert.Contains(t, result, "Card index is required")
+		assert.Contains(t, result, msgCardIndexRequired())
 	})
 
 	t.Run("marriage shorthand m", func(t *testing.T) {

--- a/internal/adapter/controller/TwentyNineCuiController.go
+++ b/internal/adapter/controller/TwentyNineCuiController.go
@@ -52,7 +52,7 @@ func (c *TwentyNineCuiController) Exec(command string) string {
 			case "pass":
 				return c.di.Bid(int(domain.TwentyNineBidPass)), true
 			case "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.di.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.di.Play)
 			case "n", "next":
 				return c.di.NextTrick(), true
 			case "nr", "nextround":

--- a/internal/adapter/controller/TwentyNineCuiController_test.go
+++ b/internal/adapter/controller/TwentyNineCuiController_test.go
@@ -81,7 +81,7 @@ func TestTwentyNineCuiController_Exec(t *testing.T) {
 
 	t.Run("play no args", func(t *testing.T) {
 		result := controller.NewTwentyNineCuiController(newMock()).Exec("play")
-		assert.Contains(t, result, "Card index is required")
+		assert.Contains(t, result, msgCardIndexRequired())
 	})
 
 	t.Run("next / nextround", func(t *testing.T) {

--- a/internal/adapter/controller/TwoTenJackCuiController.go
+++ b/internal/adapter/controller/TwoTenJackCuiController.go
@@ -46,7 +46,7 @@ func (c *TwoTenJackCuiController) Exec(command string) string {
 			case "d", "declare":
 				return cuiutil.WithParsedInt(args, "Trump suit is required (1=S, 2=C, 3=H, 4=D).", "Invalid trump suit: %s.", domain.CardDesignSpade, domain.CardDesignDiamond, c.ti.DeclareTrump)
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.ti.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.ti.Play)
 			case "n", "next":
 				return c.ti.NextTrick(), true
 			case "nr", "nextround":

--- a/internal/adapter/controller/TwoTenJackCuiController_test.go
+++ b/internal/adapter/controller/TwoTenJackCuiController_test.go
@@ -79,12 +79,12 @@ func TestTwoTenJackCuiController_Exec(t *testing.T) {
 
 	t.Run("play missing arg", func(t *testing.T) {
 		c := controller.NewTwoTenJackCuiController(newMock())
-		assert.Contains(t, c.Exec("p"), "Card index is required")
+		assert.Contains(t, c.Exec("p"), msgCardIndexRequired())
 	})
 
 	t.Run("play invalid arg", func(t *testing.T) {
 		c := controller.NewTwoTenJackCuiController(newMock())
-		assert.Contains(t, c.Exec("p abc"), "Invalid card index")
+		assert.Contains(t, c.Exec("p abc"), msgInvalidCardIndexPrefix())
 	})
 
 	t.Run("next/nextround", func(t *testing.T) {

--- a/internal/adapter/controller/TysiacCuiController.go
+++ b/internal/adapter/controller/TysiacCuiController.go
@@ -58,9 +58,9 @@ func (c *TysiacCuiController) Exec(command string) string {
 					return "Invalid bid action: " + args[0] + ". Please enter raise or pass.", true
 				}
 			case "d", "discard":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.di.Discard)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.di.Discard)
 			case "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.di.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.di.Play)
 			case "n", "next":
 				return c.di.NextTrick(), true
 			case "nr", "nextround":

--- a/internal/adapter/controller/TysiacCuiController_test.go
+++ b/internal/adapter/controller/TysiacCuiController_test.go
@@ -75,7 +75,7 @@ func TestTysiacCuiController_Exec(t *testing.T) {
 
 	t.Run("discard no args", func(t *testing.T) {
 		result := controller.NewTysiacCuiController(newMock()).Exec("discard")
-		assert.Contains(t, result, "Card index is required")
+		assert.Contains(t, result, msgCardIndexRequired())
 	})
 
 	t.Run("play card", func(t *testing.T) {
@@ -87,7 +87,7 @@ func TestTysiacCuiController_Exec(t *testing.T) {
 
 	t.Run("play no args", func(t *testing.T) {
 		result := controller.NewTysiacCuiController(newMock()).Exec("play")
-		assert.Contains(t, result, "Card index is required")
+		assert.Contains(t, result, msgCardIndexRequired())
 	})
 
 	t.Run("next / nextround", func(t *testing.T) {

--- a/internal/adapter/controller/UltiCuiController.go
+++ b/internal/adapter/controller/UltiCuiController.go
@@ -5,6 +5,7 @@ package controller
 import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -69,7 +70,7 @@ func (c *UltiCuiController) Exec(command string) string {
 			case "discard":
 				return c.execDiscard(args)
 			case "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.di.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.di.Play)
 			case "n", "next":
 				return c.di.NextTrick(), true
 			case "nr", "nextround":
@@ -125,7 +126,7 @@ func (c *UltiCuiController) execDiscard(args []string) (string, bool) {
 	}
 	indices, skipped := cuiutil.ParseIntSlice(args)
 	if len(skipped) > 0 {
-		return "Invalid card index: " + skipped[0] + ".", true
+		return i18n.Tf("invalidCardIndex", "val", skipped[0]), true
 	}
 	return c.di.Discard(indices), true
 }

--- a/internal/adapter/controller/UltiCuiController_test.go
+++ b/internal/adapter/controller/UltiCuiController_test.go
@@ -97,7 +97,7 @@ func TestUltiCuiController_Exec(t *testing.T) {
 
 	t.Run("discard invalid index", func(t *testing.T) {
 		result := controller.NewUltiCuiController(newMock()).Exec("discard 0 x")
-		assert.Contains(t, result, "Invalid card index")
+		assert.Contains(t, result, msgInvalidCardIndexPrefix())
 	})
 
 	t.Run("play card", func(t *testing.T) {
@@ -109,7 +109,7 @@ func TestUltiCuiController_Exec(t *testing.T) {
 
 	t.Run("play no args", func(t *testing.T) {
 		result := controller.NewUltiCuiController(newMock()).Exec("play")
-		assert.Contains(t, result, "Card index is required")
+		assert.Contains(t, result, msgCardIndexRequired())
 	})
 
 	t.Run("next / nextround", func(t *testing.T) {

--- a/internal/adapter/controller/VideoPokerCuiController.go
+++ b/internal/adapter/controller/VideoPokerCuiController.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -64,7 +65,7 @@ func parseHoldIndices(args []string) ([]int, string) {
 		}
 		idx, err := strconv.Atoi(arg)
 		if err != nil || idx < 0 || idx > 4 {
-			return nil, "Invalid card index. Use 0-4."
+			return nil, i18n.T("invalidCardIndexHold")
 		}
 		indices = append(indices, idx)
 	}

--- a/internal/adapter/controller/VideoPokerCuiController_test.go
+++ b/internal/adapter/controller/VideoPokerCuiController_test.go
@@ -94,17 +94,17 @@ func TestVideoPokerCuiController_Hold_Errors(t *testing.T) {
 
 	t.Run("invalid index text", func(t *testing.T) {
 		result := c.Exec("h abc")
-		assert.Contains(t, result, "Invalid card index")
+		assert.Contains(t, result, msgInvalidCardIndexPrefix())
 	})
 
 	t.Run("index out of range", func(t *testing.T) {
 		result := c.Exec("h 5")
-		assert.Contains(t, result, "Invalid card index")
+		assert.Contains(t, result, msgInvalidCardIndexPrefix())
 	})
 
 	t.Run("negative index", func(t *testing.T) {
 		result := c.Exec("h -1")
-		assert.Contains(t, result, "Invalid card index")
+		assert.Contains(t, result, msgInvalidCardIndexPrefix())
 	})
 }
 

--- a/internal/adapter/controller/VintCuiController.go
+++ b/internal/adapter/controller/VintCuiController.go
@@ -36,7 +36,7 @@ func (c *VintCuiController) Exec(command string) string {
 			case "ps", "pass":
 				return c.vi.PassBid(), true
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", 0, domain.VintHandSize-1, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", 0, domain.VintHandSize-1, func(v int) string {
 					return c.vi.PlayCard(v)
 				})
 			case "n", "next":

--- a/internal/adapter/controller/VintCuiController_test.go
+++ b/internal/adapter/controller/VintCuiController_test.go
@@ -66,8 +66,8 @@ func TestVintCuiController_Exec(t *testing.T) {
 		m.AssertCalled(t, "PlayCard", 12)
 		assert.Equal(t, mockOutput, c.Exec("n"))
 		m.AssertCalled(t, "NextHand")
-		assert.Contains(t, c.Exec("p abc"), "Invalid card index")
-		assert.Contains(t, c.Exec("p 13"), "Invalid card index")
+		assert.Contains(t, c.Exec("p abc"), msgInvalidCardIndexPrefix())
+		assert.Contains(t, c.Exec("p 13"), msgInvalidCardIndexPrefix())
 	})
 
 	t.Run("log and unknown", func(t *testing.T) {

--- a/internal/adapter/controller/ViraCuiController.go
+++ b/internal/adapter/controller/ViraCuiController.go
@@ -52,7 +52,7 @@ func (c *ViraCuiController) Exec(command string) string {
 			case "pass":
 				return c.di.Bid(int(domain.ViraBidPass)), true
 			case "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.di.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.di.Play)
 			case "n", "next":
 				return c.di.NextTrick(), true
 			case "nr", "nextround":

--- a/internal/adapter/controller/ViraCuiController_test.go
+++ b/internal/adapter/controller/ViraCuiController_test.go
@@ -86,7 +86,7 @@ func TestViraCuiController_Exec(t *testing.T) {
 
 	t.Run("play no args", func(t *testing.T) {
 		result := controller.NewViraCuiController(newMock()).Exec("play")
-		assert.Contains(t, result, "Card index is required")
+		assert.Contains(t, result, msgCardIndexRequired())
 	})
 
 	t.Run("next / nextround", func(t *testing.T) {

--- a/internal/adapter/controller/WattenCuiController.go
+++ b/internal/adapter/controller/WattenCuiController.go
@@ -55,7 +55,7 @@ func (c *WattenCuiController) Exec(command string) string {
 			case "d", "declare":
 				return c.handleDeclare(args)
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.wi.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.wi.Play)
 			case "rz", "raise":
 				return c.wi.Raise(), true
 			case "resp", "respond":

--- a/internal/adapter/controller/WattenCuiController_test.go
+++ b/internal/adapter/controller/WattenCuiController_test.go
@@ -75,7 +75,7 @@ func TestWattenCuiController_Exec(t *testing.T) {
 
 	t.Run("play no args", func(t *testing.T) {
 		c := controller.NewWattenCuiController(newMock())
-		assert.Contains(t, c.Exec("p"), "Card index is required")
+		assert.Contains(t, c.Exec("p"), msgCardIndexRequired())
 	})
 
 	t.Run("raise rz", func(t *testing.T) {

--- a/internal/adapter/controller/WhistCuiController.go
+++ b/internal/adapter/controller/WhistCuiController.go
@@ -44,7 +44,7 @@ func (c *WhistCuiController) Exec(command string) string {
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.wi.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.wi.Play)
 			case "n", "next":
 				return c.wi.NextTrick(), true
 			case "nr", "nextround":

--- a/internal/adapter/controller/WizardCuiController.go
+++ b/internal/adapter/controller/WizardCuiController.go
@@ -44,7 +44,7 @@ func (c *WizardCuiController) Exec(command string) string {
 			case "b", "bid":
 				return cuiutil.WithParsedInt(args, "Bid value is required.", "Invalid bid value: %s.", 0, cuiutil.NoMax, c.oi.Bid)
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.oi.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.oi.Play)
 			case "n", "next":
 				return c.oi.NextTrick(), true
 			case "nr", "nextround":

--- a/internal/adapter/controller/WizardCuiController_test.go
+++ b/internal/adapter/controller/WizardCuiController_test.go
@@ -80,7 +80,7 @@ func TestWizardCuiController_Exec_Errors(t *testing.T) {
 
 	// Missing args
 	assert.Contains(t, c.Exec("b"), "required")
-	assert.Contains(t, c.Exec("p"), "required")
+	assert.Contains(t, c.Exec("p"), msgCardIndexRequired())
 	assert.Contains(t, c.Exec("sd"), "required")
 
 	// Invalid args

--- a/internal/adapter/controller/ZwanzigerrufenCuiController.go
+++ b/internal/adapter/controller/ZwanzigerrufenCuiController.go
@@ -5,6 +5,7 @@ package controller
 import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -52,8 +53,8 @@ func (c *ZwanzigerrufenCuiController) Exec(command string) string {
 			case "discard":
 				return c.execDiscard(args)
 			case "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.",
-					"Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.zi.Play)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired",
+					"invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.zi.Play)
 			case "n", "next":
 				return c.zi.NextTrick(), true
 			case "nr", "nextround":
@@ -104,7 +105,7 @@ func (c *ZwanzigerrufenCuiController) execDiscard(args []string) (string, bool) 
 	}
 	indices, skipped := cuiutil.ParseIntSlice(args)
 	if len(skipped) > 0 {
-		return "Invalid card index: " + skipped[0] + ".", true
+		return i18n.Tf("invalidCardIndex", "val", skipped[0]), true
 	}
 	return c.zi.Discard(indices), true
 }

--- a/internal/adapter/controller/ZwanzigerrufenCuiController_test.go
+++ b/internal/adapter/controller/ZwanzigerrufenCuiController_test.go
@@ -84,7 +84,7 @@ func TestZwanzigerrufenCuiController_Exec(t *testing.T) {
 	t.Run("discard rejects a non-numeric index", func(t *testing.T) {
 		m := newMock()
 		out := controller.NewZwanzigerrufenCuiController(m).Exec("discard 0 1 2 3 4 x")
-		assert.Contains(t, out, "Invalid card index")
+		assert.Contains(t, out, msgInvalidCardIndexPrefix())
 		m.AssertNotCalled(t, "Discard", mock.Anything)
 	})
 	t.Run("play", func(t *testing.T) {
@@ -95,7 +95,7 @@ func TestZwanzigerrufenCuiController_Exec(t *testing.T) {
 	t.Run("play rejects a non-numeric index", func(t *testing.T) {
 		m := newMock()
 		out := controller.NewZwanzigerrufenCuiController(m).Exec("play x")
-		assert.Contains(t, out, "Invalid card index")
+		assert.Contains(t, out, msgInvalidCardIndexPrefix())
 		m.AssertNotCalled(t, "Play", mock.Anything)
 	})
 	t.Run("next trick and next round", func(t *testing.T) {

--- a/internal/adapter/controller/ZwickerCuiController.go
+++ b/internal/adapter/controller/ZwickerCuiController.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -46,7 +47,7 @@ func (c *ZwickerCuiController) Exec(command string) string {
 			case "b", "build":
 				return c.build(args)
 			case "tr", "trail":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.zi.Trail)
+				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.zi.Trail)
 			case "n", "next":
 				return c.zi.NextRound(), true
 			default:
@@ -66,7 +67,7 @@ func (c *ZwickerCuiController) take(args []string) (string, bool) {
 	}
 	hand, ok := zwickerParseIdx(args[0])
 	if !ok {
-		return "Invalid card index: " + args[0] + ".", true
+		return i18n.Tf("invalidCardIndex", "val", args[0]), true
 	}
 	value, err := strconv.Atoi(strings.TrimSpace(args[1]))
 	if err != nil || value <= 0 {
@@ -97,7 +98,7 @@ func (c *ZwickerCuiController) build(args []string) (string, bool) {
 	}
 	hand, ok := zwickerParseIdx(args[0])
 	if !ok {
-		return "Invalid card index: " + args[0] + ".", true
+		return i18n.Tf("invalidCardIndex", "val", args[0]), true
 	}
 	table, _, ok := zwickerParseList(args[1])
 	if !ok || len(table) == 0 {

--- a/internal/adapter/controller/cui_msg_ext_test.go
+++ b/internal/adapter/controller/cui_msg_ext_test.go
@@ -1,0 +1,37 @@
+//go:build test
+
+package controller_test
+
+import (
+	"strings"
+
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
+)
+
+// The same helpers as cui_msg_test.go, for the test files in the external
+// package. See there for why the assertions go through i18n.
+func msgCardIndexRequired() string { return i18n.T("cardIndexRequired") }
+
+func msgInvalidCardIndex(val string) string { return i18n.Tf("invalidCardIndex", "val", val) }
+
+// msgInvalidCardIndexPrefix is the part of the message before the offending
+// value, for the assertions that only check that the rejection happened.
+// Split on a sentinel rather than on ": " so it holds in any language.
+func msgInvalidCardIndexPrefix() string {
+	stem := strings.SplitN(i18n.Tf("invalidCardIndex", "val", "\x00"), "\x00", 2)[0]
+	// Trim the punctuation that introduces the value, so the stem also matches
+	// invalidCardIndexNotANumber -- the assertions using this only care that the
+	// index was rejected, not which of the two wordings said so.
+	return strings.TrimRight(stem, ":. ")
+}
+
+// The two card-index prompts that carry a usage example.
+func msgCardIndexRequiredField() string { return i18n.T("cardIndexRequiredField") }
+
+func msgCardIndexRequiredCapture() string { return i18n.T("cardIndexRequiredCapture") }
+
+// msgInvalidDiscardIndexPrefix is msgInvalidCardIndexPrefix for the discard pile.
+func msgInvalidDiscardIndexPrefix() string {
+	stem := strings.SplitN(i18n.Tf("invalidDiscardIndex", "val", "\x00"), "\x00", 2)[0]
+	return strings.TrimRight(stem, ":. ")
+}

--- a/internal/adapter/controller/cui_msg_test.go
+++ b/internal/adapter/controller/cui_msg_test.go
@@ -1,0 +1,20 @@
+//go:build test
+
+package controller
+
+import "github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
+
+// msgCardIndexRequired and msgInvalidCardIndex render the two card-index
+// rejections the way the controllers do.
+//
+// The tests used to spell these as English literals, which worked only while
+// the controllers passed English literals of their own (issue #5384). Going
+// through i18n keeps them correct in whichever language the suite runs in, and
+// makes them fail if the key is renamed or deleted rather than if the wording
+// is polished.
+//
+// cui_msg_ext_test.go carries the same helpers for the external test package,
+// plus the ones only it needs.
+func msgCardIndexRequired() string { return i18n.T("cardIndexRequired") }
+
+func msgInvalidCardIndex(val string) string { return i18n.Tf("invalidCardIndex", "val", val) }

--- a/internal/adapter/controller/cuiutil/parse.go
+++ b/internal/adapter/controller/cuiutil/parse.go
@@ -109,3 +109,40 @@ func PrependSkippedWarning(result string, skipped []string) string {
 	}
 	return result
 }
+
+// ParseIntArgKeys is ParseIntArg with i18n keys instead of message strings.
+//
+// ParseIntArg takes the two messages as Go literals, and all 588 call sites
+// passed English ones -- so a player running in Japanese got a Japanese board,
+// Japanese prompts and a Japanese "unknown command", then `Invalid card index:
+// zz.` the moment they mistyped an argument (issue #5384). Taking keys instead
+// puts these messages through the same i18n path as every other string the CUI
+// prints.
+//
+// invalidKey is rendered with the offending argument as {{val}}; a message that
+// does not name the value simply omits the placeholder.
+// An empty missingKey means "this call cannot be reached with no argument";
+// it yields an empty message rather than i18n.T("")'s literal empty key.
+func ParseIntArgKeys(args []string, missingKey, invalidKey string, min, max int) (int, string, bool) {
+	if len(args) < 1 {
+		if missingKey == "" {
+			return 0, "", false
+		}
+		return 0, i18n.T(missingKey), false
+	}
+	v, err := strconv.Atoi(args[0])
+	if err != nil || v < min || v > max {
+		return 0, i18n.Tf(invalidKey, "val", args[0]), false
+	}
+	return v, "", true
+}
+
+// WithParsedIntKeys is WithParsedInt with i18n keys instead of message strings.
+// See ParseIntArgKeys.
+func WithParsedIntKeys(args []string, missingKey, invalidKey string, min, max int, fn func(int) string) (string, bool) {
+	v, errMsg, ok := ParseIntArgKeys(args, missingKey, invalidKey, min, max)
+	if !ok {
+		return errMsg, true
+	}
+	return fn(v), true
+}

--- a/internal/i18n/locales/en/common.json
+++ b/internal/i18n/locales/en/common.json
@@ -138,5 +138,18 @@
   "realtime.labelNormal": "set CPU difficulty Normal and reset",
   "realtime.labelHard": "set CPU difficulty Hard and reset",
   "realtime.labelHelp": "show this key list again",
-  "realtime.labelQuit": "quit"
+  "realtime.labelQuit": "quit",
+  "cardIndexRequired": "Card index is required.",
+  "invalidCardIndexNotANumber": "Invalid card index. Please enter a number.",
+  "invalidIndexNotANumber": "Invalid index. Please enter a number.",
+  "discardIndexRequired": "Discard index is required.",
+  "invalidDiscardIndex": "Invalid discard index: {{val}}",
+  "cardIndexRequiredExample": "Card index is required (e.g. p 0).",
+  "cardIndexToKeepRequired": "Card index to keep is required.",
+  "invalidCardIndexRange": "Invalid card index: {{val}}. Please enter 0-{{max}}.",
+  "invalidCardIndexHold": "Invalid card index. Use 0-4.",
+  "cardIndexRequiredField": "Card index is required (e.g. p 0, or p 0 3 to pick a field card).",
+  "cardIndexRequiredCapture": "Card index is required (e.g. p 0, or p 0 1 2 to capture table cards).",
+  "cardIndexesRequiredMeld": "Card indexes are required (e.g. meld 1 4 7).",
+  "invalidIndexFromOne": "Invalid index. Please enter numbers from 1."
 }

--- a/internal/i18n/locales/ja/common.json
+++ b/internal/i18n/locales/ja/common.json
@@ -138,5 +138,18 @@
   "realtime.labelNormal": "CPU難易度 Normal にしてリセット",
   "realtime.labelHard": "CPU難易度 Hard にしてリセット",
   "realtime.labelHelp": "このキー一覧を再表示",
-  "realtime.labelQuit": "終了"
+  "realtime.labelQuit": "終了",
+  "cardIndexRequired": "カードのインデックスを指定してください。",
+  "invalidCardIndexNotANumber": "無効なカードインデックスです。数値を入力してください。",
+  "invalidIndexNotANumber": "無効なインデックスです。数値を入力してください。",
+  "discardIndexRequired": "捨てるカードのインデックスを指定してください。",
+  "invalidDiscardIndex": "無効な捨て札インデックスです: {{val}}",
+  "cardIndexRequiredExample": "カードのインデックスを指定してください (例: p 0)。",
+  "cardIndexToKeepRequired": "残すカードのインデックスを指定してください。",
+  "invalidCardIndexRange": "無効なカードインデックスです: {{val}}。0-{{max}} を指定してください。",
+  "invalidCardIndexHold": "無効なカードインデックスです。0-4 を指定してください。",
+  "cardIndexRequiredField": "カードのインデックスを指定してください (例: p 0 / 場札を取るなら p 0 3)。",
+  "cardIndexRequiredCapture": "カードのインデックスを指定してください (例: p 0 / 場札を取るなら p 0 1 2)。",
+  "cardIndexesRequiredMeld": "メルドするカードのインデックスを指定してください (例: meld 1 4 7)。",
+  "invalidIndexFromOne": "無効なインデックスです。1 以上の数値を入力してください。"
 }


### PR DESCRIPTION
## 問題

日本語で遊んでいるプレイヤーは、盤面もプロンプトもヘルパも「コマンドが不明です」も日本語で受け取ります。**入力を間違えた瞬間だけ英語になります。**

```
[ja] spades  p zz  -> "Invalid card index: zz."
[ja] spades  p     -> "Card index is required."
```

`cuiutil.ParseIntArg` はメッセージを**引数として受け取る**設計で、**588 の呼び出しすべてが Go の英語リテラルを渡していました**（i18n を通しているものは 0 件）。

## 変更

キーを受け取る `ParseIntArgKeys` / `WithParsedIntKeys` を足し、**card index 系の 187 箇所**を移行しました。

```go
func ParseIntArgKeys(args []string, missingKey, invalidKey string, min, max int) (int, string, bool)
```

`invalidKey` は不正な値を `{{val}}` として描画します。値を出さない文言はプレースホルダを持たないだけです。空の `missingKey` は「引数なしでは到達しない呼び出し」を意味し、`i18n.T("")` がキー名を返すのを避けて空文字を返します。

### 実測した効果

ヘルプのコマンド表にある引数つきコマンド全件に、ja で不正な引数を与えた結果です。

| | 英語で返る | 日本語で返る |
|---|---|---|
| Before | 383 | 219 |
| After | **215** | **387** |

**168 コマンドが日本語で応答するようになりました。**

### 用例つきの文言は用例を保持しています

`"Card index is required (e.g. p 0, or p 0 3 to pick a field card)."` のような文言は、汎用キーに潰さず `cardIndexRequiredField` / `cardIndexRequiredCapture` として別キーにしました。用例を落とすのは、その用例を出しているゲーム（GoStop / KoiKoi / HachiHachi / Sakura / Basra / Tablanet / Michigan）にとって機能後退だからです。

## テストがバグ側に固定されていた

**219 のアサートがこれらの文言を英語リテラルで書いていました。** コントローラも英語リテラルだったので通っていただけです。

```go
assert.Contains(t, c.Exec("p abc"), "Invalid card index")   // before
assert.Contains(t, c.Exec("p abc"), msgInvalidCardIndexPrefix())  // after
```

`cui_msg_test.go` / `cui_msg_ext_test.go`（内部・外部の両テストパッケージ）にヘルパを置き、テストが**走る言語に依らず正しく**、かつ「文言を推敲した」ではなく「キーを消した／改名した」ときに落ちるようにしました。

プレフィックスを取るヘルパは `": "` ではなく**センチネルで分割**して値の直前までを取り、末尾の句読点を落とします。`invalidCardIndex`（`: {{val}}` 付き）と `invalidCardIndexNotANumber`（値を出さない）の両方に効かせるためで、これらのアサートは「拒否されたこと」だけを見ているので語幹一致で十分です。

## 置換の安全策

すべての一括書き換えは**件数を先に数え、一致しなければ 1 バイトも書かない**方式で行いました。**実際に 3 回中断しています**。

- 「4 箇所のはず」が 7 箇所（テストファイルを glob に含めていた）
- 「3 箇所のはず」が 11 箇所（同上）
- 「1 種類のはず」の連結が 2 種類（Guandan は 2 行に折り返していた）

いずれも中断してから直しており、誤った変換は入っていません。

## 残り（#5384 に残す）

- 英語のまま残るのは 215 コマンド。CPU 難易度 (112 箇所)、ポイント上限 (22)、ベット額 (13)、目標スコア (10)、アンティ額 (9) などが主で、**同じ手順でそのまま片付きます**
- そのうち 53 コマンドは**メッセージ自体が無く盤面を再描画するだけ**で、こちらは #5377 の範囲

## 検証

- `go test -tags test ./internal/adapter/controller/ ./internal/infrastructure/ui/` — 緑
- `go build ./...` — 通過
- `golangci-lint run ./internal/...` — 0 issues
- ja / en 双方で実際の応答を確認

Refs #5384
