### PR TITLE
fix(cui): put the CPU-difficulty rejections through i18n

### DIFF
--- a/internal/adapter/controller/AllFoursCuiController.go
+++ b/internal/adapter/controller/AllFoursCuiController.go
@@ -63,7 +63,7 @@ func (c *AllFoursCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.ai.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.ai.GetConfig()
 					cfg.CpuDifficulty = domain.AllFoursCpuDifficulty(v)
 					return c.ai.ResetWithConfig(cfg)

--- a/internal/adapter/controller/AluetteCuiController.go
+++ b/internal/adapter/controller/AluetteCuiController.go
@@ -49,7 +49,7 @@ func (c *AluetteCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.di.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.di.GetConfig()
 					cfg.CpuDifficulty = domain.AluetteCpuDifficulty(v)
 					return c.di.ResetWithConfig(cfg)

--- a/internal/adapter/controller/AluetteCuiController_test.go
+++ b/internal/adapter/controller/AluetteCuiController_test.go
@@ -79,7 +79,7 @@ func TestAluetteCuiController_Exec(t *testing.T) {
 	})
 
 	t.Run("setdifficulty invalid", func(t *testing.T) {
-		assert.Contains(t, controller.NewAluetteCuiController(newMock()).Exec("sd 9"), "Invalid CPU difficulty")
+		assert.Contains(t, controller.NewAluetteCuiController(newMock()).Exec("sd 9"), msgInvalidCpuDifficultyPrefix())
 	})
 
 	t.Run("hint / log", func(t *testing.T) {

--- a/internal/adapter/controller/BarbuCuiController.go
+++ b/internal/adapter/controller/BarbuCuiController.go
@@ -44,7 +44,7 @@ func (c *BarbuCuiController) Exec(command string) string {
 			case "n", "next":
 				return c.bi.NextDeal(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.bi.GetConfig()
 					cfg.CpuDifficulty = domain.BarbuCpuDifficulty(v)
 					return c.bi.ResetWithConfig(cfg)

--- a/internal/adapter/controller/BasraCuiController.go
+++ b/internal/adapter/controller/BasraCuiController.go
@@ -49,7 +49,7 @@ func (c *BasraCuiController) Exec(command string) string {
 			case "n", "next", "nr", "nextround":
 				return c.bi.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.bi.GetConfig()
 					cfg.CpuDifficulty = domain.BasraCpuDifficulty(v)
 					return c.bi.ResetWithConfig(cfg)

--- a/internal/adapter/controller/BeloteCuiController.go
+++ b/internal/adapter/controller/BeloteCuiController.go
@@ -68,7 +68,7 @@ func (c *BeloteCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.bi.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.bi.GetConfig()
 					cfg.CpuDifficulty = domain.BeloteCpuDifficulty(v)
 					return c.bi.ResetWithConfig(cfg)

--- a/internal/adapter/controller/BeloteCuiController_test.go
+++ b/internal/adapter/controller/BeloteCuiController_test.go
@@ -140,12 +140,12 @@ func TestBeloteCuiController_Exec(t *testing.T) {
 
 	t.Run("setdifficulty invalid", func(t *testing.T) {
 		c := controller.NewBeloteCuiController(newMock())
-		assert.Contains(t, c.Exec("sd abc"), "Invalid CPU difficulty")
+		assert.Contains(t, c.Exec("sd abc"), msgInvalidCpuDifficultyPrefix())
 	})
 
 	t.Run("setdifficulty no args", func(t *testing.T) {
 		c := controller.NewBeloteCuiController(newMock())
-		assert.Contains(t, c.Exec("sd"), "required")
+		assert.Contains(t, c.Exec("sd"), msgCpuDifficultyRequired())
 	})
 
 	t.Run("settarget valid", func(t *testing.T) {

--- a/internal/adapter/controller/BeziqueCuiController.go
+++ b/internal/adapter/controller/BeziqueCuiController.go
@@ -57,7 +57,7 @@ func (c *BeziqueCuiController) Exec(command string) string {
 			case "n", "next", "nextround":
 				return c.bi.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.bi.GetConfig()
 					cfg.CpuDifficulty = domain.BeziqueCpuDifficulty(v)
 					return c.bi.ResetWithConfig(cfg)

--- a/internal/adapter/controller/BidWhistCuiController.go
+++ b/internal/adapter/controller/BidWhistCuiController.go
@@ -97,7 +97,7 @@ func (c *BidWhistCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.bi.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.bi.GetConfig()
 					cfg.CpuDifficulty = domain.BidWhistCpuDifficulty(v)
 					return c.bi.ResetWithConfig(cfg)

--- a/internal/adapter/controller/BigTwoCuiController.go
+++ b/internal/adapter/controller/BigTwoCuiController.go
@@ -31,7 +31,7 @@ func (c *BigTwoCuiController) Exec(command string) string {
 				indices, skipped := cuiutil.ParseIntSlice(args)
 				return cuiutil.PrependSkippedWarning(c.bti.Play(indices), skipped), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Normal, 1=Easy, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequiredAlt", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.bti.GetConfig()
 					cfg.CpuDifficulty = domain.BigTwoCpuDifficulty(v)
 					return c.bti.ResetWithConfig(cfg)

--- a/internal/adapter/controller/BourreCuiController.go
+++ b/internal/adapter/controller/BourreCuiController.go
@@ -46,7 +46,7 @@ func (c *BourreCuiController) Exec(command string) string {
 			case "n", "next":
 				return c.bgi.NextHand(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Normal, 1=Easy, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequiredAlt", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.bgi.GetConfig()
 					cfg.CpuDifficulty = domain.BourreCpuDifficulty(v)
 					return c.bgi.ResetWithConfig(cfg)

--- a/internal/adapter/controller/BourreCuiController_test.go
+++ b/internal/adapter/controller/BourreCuiController_test.go
@@ -79,7 +79,7 @@ func TestBourreCuiController_Exec(t *testing.T) {
 	})
 	t.Run("setdifficulty invalid", func(t *testing.T) {
 		c := controller.NewBourreCuiController(newMock())
-		assert.Contains(t, c.Exec("sd 9"), "Invalid CPU difficulty")
+		assert.Contains(t, c.Exec("sd 9"), msgInvalidCpuDifficultyPrefix())
 	})
 	t.Run("log", func(t *testing.T) {
 		m := newMock()

--- a/internal/adapter/controller/BridgeCuiController.go
+++ b/internal/adapter/controller/BridgeCuiController.go
@@ -59,7 +59,7 @@ func (c *BridgeCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.bi.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.bi.GetConfig()
 					cfg.CpuDifficulty = domain.BridgeCpuDifficulty(v)
 					return c.bi.ResetWithConfig(cfg)

--- a/internal/adapter/controller/BridgeCuiController_test.go
+++ b/internal/adapter/controller/BridgeCuiController_test.go
@@ -187,25 +187,25 @@ func TestBridgeCuiController_Exec(t *testing.T) {
 	t.Run("setdifficulty no args", func(t *testing.T) {
 		c := controller.NewBridgeCuiController(newMock())
 		result := c.Exec("sd")
-		assert.Contains(t, result, "required")
+		assert.Contains(t, result, msgCpuDifficultyRequired())
 	})
 
 	t.Run("setdifficulty invalid value", func(t *testing.T) {
 		c := controller.NewBridgeCuiController(newMock())
 		result := c.Exec("sd abc")
-		assert.Contains(t, result, "Invalid CPU difficulty")
+		assert.Contains(t, result, msgInvalidCpuDifficultyPrefix())
 	})
 
 	t.Run("setdifficulty negative", func(t *testing.T) {
 		c := controller.NewBridgeCuiController(newMock())
 		result := c.Exec("sd -1")
-		assert.Equal(t, "Invalid CPU difficulty: -1. Please enter 0-2.", result)
+		assert.Equal(t, msgInvalidCpuDifficulty("-1"), result)
 	})
 
 	t.Run("setdifficulty over 2", func(t *testing.T) {
 		c := controller.NewBridgeCuiController(newMock())
 		result := c.Exec("sd 3")
-		assert.Equal(t, "Invalid CPU difficulty: 3. Please enter 0-2.", result)
+		assert.Equal(t, msgInvalidCpuDifficulty("3"), result)
 	})
 
 	// log

--- a/internal/adapter/controller/BurracoCuiController.go
+++ b/internal/adapter/controller/BurracoCuiController.go
@@ -59,7 +59,7 @@ func (c *BurracoCuiController) Exec(command string) string {
 			case "d", "discard":
 				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.ci.Discard)
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.ci.GetConfig()
 					cfg.CpuDifficulty = domain.BurracoCpuDifficulty(v)
 					return c.ci.ResetWithConfig(cfg)

--- a/internal/adapter/controller/BurracoCuiController_test.go
+++ b/internal/adapter/controller/BurracoCuiController_test.go
@@ -233,19 +233,19 @@ func TestBurracoCuiController_Exec(t *testing.T) {
 	t.Run("setdifficulty no args", func(t *testing.T) {
 		c := controller.NewBurracoCuiController(newMock())
 		result := c.Exec("sd")
-		assert.Contains(t, result, "required")
+		assert.Contains(t, result, msgCpuDifficultyRequired())
 	})
 
 	t.Run("setdifficulty invalid value", func(t *testing.T) {
 		c := controller.NewBurracoCuiController(newMock())
 		result := c.Exec("sd abc")
-		assert.Contains(t, result, "Invalid CPU difficulty")
+		assert.Contains(t, result, msgInvalidCpuDifficultyPrefix())
 	})
 
 	t.Run("setdifficulty negative", func(t *testing.T) {
 		c := controller.NewBurracoCuiController(newMock())
 		result := c.Exec("sd -1")
-		assert.Contains(t, result, "Invalid CPU difficulty")
+		assert.Contains(t, result, msgInvalidCpuDifficultyPrefix())
 	})
 
 	// setlimit

--- a/internal/adapter/controller/CalabresellaCuiController.go
+++ b/internal/adapter/controller/CalabresellaCuiController.go
@@ -68,7 +68,7 @@ func (c *CalabresellaCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.di.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.di.GetConfig()
 					cfg.CpuDifficulty = domain.CalabresellaCpuDifficulty(v)
 					return c.di.ResetWithConfig(cfg)

--- a/internal/adapter/controller/CalabresellaCuiController_test.go
+++ b/internal/adapter/controller/CalabresellaCuiController_test.go
@@ -117,7 +117,7 @@ func TestCalabresellaCuiController_Exec(t *testing.T) {
 
 	t.Run("setdifficulty invalid", func(t *testing.T) {
 		result := controller.NewCalabresellaCuiController(newMock()).Exec("sd 9")
-		assert.Contains(t, result, "Invalid CPU difficulty")
+		assert.Contains(t, result, msgInvalidCpuDifficultyPrefix())
 	})
 
 	t.Run("hint / log", func(t *testing.T) {

--- a/internal/adapter/controller/CallBreakCuiController.go
+++ b/internal/adapter/controller/CallBreakCuiController.go
@@ -53,7 +53,7 @@ func (c *CallBreakCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.ci.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.ci.GetConfig()
 					cfg.CpuDifficulty = domain.CallBreakCpuDifficulty(v)
 					return c.ci.ResetWithConfig(cfg)

--- a/internal/adapter/controller/CallBreakCuiController_test.go
+++ b/internal/adapter/controller/CallBreakCuiController_test.go
@@ -101,10 +101,10 @@ func TestCallBreakCuiController_Exec(t *testing.T) {
 		m.AssertCalled(t, "ResetWithConfig", expected)
 	})
 	t.Run("setdifficulty invalid", func(t *testing.T) {
-		assert.Contains(t, controller.NewCallBreakCuiController(newMock()).Exec("sd 5"), "Invalid CPU difficulty")
+		assert.Contains(t, controller.NewCallBreakCuiController(newMock()).Exec("sd 5"), msgInvalidCpuDifficultyPrefix())
 	})
 	t.Run("setdifficulty no args", func(t *testing.T) {
-		assert.Contains(t, controller.NewCallBreakCuiController(newMock()).Exec("sd"), "required")
+		assert.Contains(t, controller.NewCallBreakCuiController(newMock()).Exec("sd"), msgCpuDifficultyRequired())
 	})
 
 	t.Run("setrounds valid", func(t *testing.T) {

--- a/internal/adapter/controller/CanastaCuiController.go
+++ b/internal/adapter/controller/CanastaCuiController.go
@@ -59,7 +59,7 @@ func (c *CanastaCuiController) Exec(command string) string {
 			case "d", "discard":
 				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.ci.Discard)
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.ci.GetConfig()
 					cfg.CpuDifficulty = domain.CanastaCpuDifficulty(v)
 					return c.ci.ResetWithConfig(cfg)

--- a/internal/adapter/controller/CanastaCuiController_test.go
+++ b/internal/adapter/controller/CanastaCuiController_test.go
@@ -232,19 +232,19 @@ func TestCanastaCuiController_Exec(t *testing.T) {
 	t.Run("setdifficulty no args", func(t *testing.T) {
 		c := controller.NewCanastaCuiController(newMock())
 		result := c.Exec("sd")
-		assert.Contains(t, result, "required")
+		assert.Contains(t, result, msgCpuDifficultyRequired())
 	})
 
 	t.Run("setdifficulty invalid value", func(t *testing.T) {
 		c := controller.NewCanastaCuiController(newMock())
 		result := c.Exec("sd abc")
-		assert.Contains(t, result, "Invalid CPU difficulty")
+		assert.Contains(t, result, msgInvalidCpuDifficultyPrefix())
 	})
 
 	t.Run("setdifficulty negative", func(t *testing.T) {
 		c := controller.NewCanastaCuiController(newMock())
 		result := c.Exec("sd -1")
-		assert.Contains(t, result, "Invalid CPU difficulty")
+		assert.Contains(t, result, msgInvalidCpuDifficultyPrefix())
 	})
 
 	// setlimit

--- a/internal/adapter/controller/CariocaCuiController.go
+++ b/internal/adapter/controller/CariocaCuiController.go
@@ -67,7 +67,7 @@ func (c *CariocaCuiController) Exec(command string) string {
 					return c.ci.ResetWithConfig(cfg)
 				})
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.ci.GetConfig()
 					cfg.CpuDifficulty = domain.CariocaCpuDifficulty(v)
 					return c.ci.ResetWithConfig(cfg)

--- a/internal/adapter/controller/CassinoCuiController.go
+++ b/internal/adapter/controller/CassinoCuiController.go
@@ -103,7 +103,7 @@ func (c *CassinoCuiController) Exec(command string) string {
 			case "h", "hint":
 				return c.ci.Hint(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.ci.GetConfig()
 					cfg.CpuDifficulty = domain.CassinoCpuDifficulty(v)
 					return c.ci.ResetWithConfig(cfg)

--- a/internal/adapter/controller/CatchTenCuiController.go
+++ b/internal/adapter/controller/CatchTenCuiController.go
@@ -50,7 +50,7 @@ func (c *CatchTenCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.ci.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.ci.GetConfig()
 					cfg.CpuDifficulty = domain.CatchTenCpuDifficulty(v)
 					return c.ci.ResetWithConfig(cfg)

--- a/internal/adapter/controller/CegoCuiController.go
+++ b/internal/adapter/controller/CegoCuiController.go
@@ -67,7 +67,7 @@ func (c *CegoCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.di.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.di.GetConfig()
 					cfg.CpuDifficulty = domain.CegoCpuDifficulty(v)
 					return c.di.ResetWithConfig(cfg)

--- a/internal/adapter/controller/ChinchonCuiController.go
+++ b/internal/adapter/controller/ChinchonCuiController.go
@@ -50,7 +50,7 @@ func (c *ChinchonCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.ci.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.ci.GetConfig()
 					cfg.CpuDifficulty = domain.ChinchonCpuDifficulty(v)
 					return c.ci.ResetWithConfig(cfg)

--- a/internal/adapter/controller/ChinchonCuiController_test.go
+++ b/internal/adapter/controller/ChinchonCuiController_test.go
@@ -109,7 +109,7 @@ func TestChinchonCuiController_Exec(t *testing.T) {
 
 	t.Run("setdifficulty sd over 2", func(t *testing.T) {
 		result := controller.NewChinchonCuiController(newMock()).Exec("sd 3")
-		assert.Equal(t, "Invalid CPU difficulty: 3. Please enter 0-2.", result)
+		assert.Equal(t, msgInvalidCpuDifficulty("3"), result)
 	})
 
 	t.Run("setplayers sp valid", func(t *testing.T) {

--- a/internal/adapter/controller/CinchCuiController.go
+++ b/internal/adapter/controller/CinchCuiController.go
@@ -52,7 +52,7 @@ func (c *CinchCuiController) Exec(command string) string {
 			case "n", "next", "nr", "nextround":
 				return c.ci.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.ci.GetConfig()
 					cfg.CpuDifficulty = domain.CinchCpuDifficulty(v)
 					return c.ci.ResetWithConfig(cfg)

--- a/internal/adapter/controller/ConquianCuiController.go
+++ b/internal/adapter/controller/ConquianCuiController.go
@@ -51,7 +51,7 @@ func (c *ConquianCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.ci.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.ci.GetConfig()
 					cfg.CpuDifficulty = domain.ConquianCpuDifficulty(v)
 					return c.ci.ResetWithConfig(cfg)

--- a/internal/adapter/controller/ConquianCuiController_test.go
+++ b/internal/adapter/controller/ConquianCuiController_test.go
@@ -97,12 +97,12 @@ func TestConquianCuiController_Exec(t *testing.T) {
 
 	t.Run("setdifficulty sd no args", func(t *testing.T) {
 		result := controller.NewConquianCuiController(newMock()).Exec("sd")
-		assert.Contains(t, result, "required")
+		assert.Contains(t, result, msgCpuDifficultyRequired())
 	})
 
 	t.Run("setdifficulty sd over 2", func(t *testing.T) {
 		result := controller.NewConquianCuiController(newMock()).Exec("sd 3")
-		assert.Equal(t, "Invalid CPU difficulty: 3. Please enter 0-2.", result)
+		assert.Equal(t, msgInvalidCpuDifficulty("3"), result)
 	})
 
 	t.Run("setwins sw valid", func(t *testing.T) {

--- a/internal/adapter/controller/ContractRummyCuiController.go
+++ b/internal/adapter/controller/ContractRummyCuiController.go
@@ -64,7 +64,7 @@ func (c *ContractRummyCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.ci.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.ci.GetConfig()
 					cfg.CpuDifficulty = domain.ContractRummyCpuDifficulty(v)
 					return c.ci.ResetWithConfig(cfg)

--- a/internal/adapter/controller/CourtPieceCuiController.go
+++ b/internal/adapter/controller/CourtPieceCuiController.go
@@ -55,7 +55,7 @@ func (c *CourtPieceCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.ti.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.ti.GetConfig()
 					cfg.CpuDifficulty = domain.CourtPieceCpuDifficulty(v)
 					return c.ti.ResetWithConfig(cfg)

--- a/internal/adapter/controller/CrazyEightsCuiController.go
+++ b/internal/adapter/controller/CrazyEightsCuiController.go
@@ -56,7 +56,7 @@ func (c *CrazyEightsCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.ci.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.ci.GetConfig()
 					cfg.CpuDifficulty = domain.CrazyEightsCpuDifficulty(v)
 					return c.ci.ResetWithConfig(cfg)

--- a/internal/adapter/controller/CrazyEightsCuiController_test.go
+++ b/internal/adapter/controller/CrazyEightsCuiController_test.go
@@ -214,25 +214,25 @@ func TestCrazyEightsCuiController_Exec(t *testing.T) {
 	t.Run("setdifficulty no args", func(t *testing.T) {
 		c := controller.NewCrazyEightsCuiController(newMock())
 		result := c.Exec("sd")
-		assert.Contains(t, result, "required")
+		assert.Contains(t, result, msgCpuDifficultyRequired())
 	})
 
 	t.Run("setdifficulty invalid value", func(t *testing.T) {
 		c := controller.NewCrazyEightsCuiController(newMock())
 		result := c.Exec("sd abc")
-		assert.Contains(t, result, "Invalid CPU difficulty")
+		assert.Contains(t, result, msgInvalidCpuDifficultyPrefix())
 	})
 
 	t.Run("setdifficulty negative", func(t *testing.T) {
 		c := controller.NewCrazyEightsCuiController(newMock())
 		result := c.Exec("sd -1")
-		assert.Equal(t, "Invalid CPU difficulty: -1. Please enter 0-2.", result)
+		assert.Equal(t, msgInvalidCpuDifficulty("-1"), result)
 	})
 
 	t.Run("setdifficulty over 2", func(t *testing.T) {
 		c := controller.NewCrazyEightsCuiController(newMock())
 		result := c.Exec("sd 3")
-		assert.Equal(t, "Invalid CPU difficulty: 3. Please enter 0-2.", result)
+		assert.Equal(t, msgInvalidCpuDifficulty("3"), result)
 	})
 
 	// setlimit

--- a/internal/adapter/controller/CribbageCuiController.go
+++ b/internal/adapter/controller/CribbageCuiController.go
@@ -52,7 +52,7 @@ func (c *CribbageCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.ci.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.ci.GetConfig()
 					cfg.CpuDifficulty = domain.CribbageCpuDifficulty(v)
 					return c.ci.ResetWithConfig(cfg)

--- a/internal/adapter/controller/CribbageCuiController_test.go
+++ b/internal/adapter/controller/CribbageCuiController_test.go
@@ -216,25 +216,25 @@ func TestCribbageCuiController_Exec(t *testing.T) {
 	t.Run("setdifficulty no args", func(t *testing.T) {
 		c := controller.NewCribbageCuiController(newMock())
 		result := c.Exec("sd")
-		assert.Contains(t, result, "required")
+		assert.Contains(t, result, msgCpuDifficultyRequired())
 	})
 
 	t.Run("setdifficulty invalid value", func(t *testing.T) {
 		c := controller.NewCribbageCuiController(newMock())
 		result := c.Exec("sd abc")
-		assert.Contains(t, result, "Invalid CPU difficulty")
+		assert.Contains(t, result, msgInvalidCpuDifficultyPrefix())
 	})
 
 	t.Run("setdifficulty negative", func(t *testing.T) {
 		c := controller.NewCribbageCuiController(newMock())
 		result := c.Exec("sd -1")
-		assert.Equal(t, "Invalid CPU difficulty: -1. Please enter 0-2.", result)
+		assert.Equal(t, msgInvalidCpuDifficulty("-1"), result)
 	})
 
 	t.Run("setdifficulty over 2", func(t *testing.T) {
 		c := controller.NewCribbageCuiController(newMock())
 		result := c.Exec("sd 3")
-		assert.Equal(t, "Invalid CPU difficulty: 3. Please enter 0-2.", result)
+		assert.Equal(t, msgInvalidCpuDifficulty("3"), result)
 	})
 
 	// setlimit

--- a/internal/adapter/controller/CuarentaCuiController.go
+++ b/internal/adapter/controller/CuarentaCuiController.go
@@ -41,7 +41,7 @@ func (c *CuarentaCuiController) Exec(command string) string {
 			case "n", "next":
 				return c.ci.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.ci.GetConfig()
 					cfg.CpuDifficulty = domain.CuarentaCpuDifficulty(v)
 					return c.ci.ResetWithConfig(cfg)

--- a/internal/adapter/controller/CuckooCuiController.go
+++ b/internal/adapter/controller/CuckooCuiController.go
@@ -45,7 +45,7 @@ func (c *CuckooCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.ci.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.ci.GetConfig()
 					cfg.CpuDifficulty = domain.CuckooCpuDifficulty(v)
 					return c.ci.ResetWithConfig(cfg)

--- a/internal/adapter/controller/CuckooCuiController_test.go
+++ b/internal/adapter/controller/CuckooCuiController_test.go
@@ -84,9 +84,9 @@ func TestCuckooCuiController_Exec(t *testing.T) {
 
 	t.Run("setdifficulty errors", func(t *testing.T) {
 		c := controller.NewCuckooCuiController(newMock())
-		assert.Contains(t, c.Exec("sd"), "required")
-		assert.Contains(t, c.Exec("sd abc"), "Invalid CPU difficulty")
-		assert.Contains(t, c.Exec("sd 9"), "Invalid CPU difficulty")
+		assert.Contains(t, c.Exec("sd"), msgCpuDifficultyRequired())
+		assert.Contains(t, c.Exec("sd abc"), msgInvalidCpuDifficultyPrefix())
+		assert.Contains(t, c.Exec("sd 9"), msgInvalidCpuDifficultyPrefix())
 	})
 
 	t.Run("setlives valid", func(t *testing.T) {

--- a/internal/adapter/controller/DaifugoCuiController.go
+++ b/internal/adapter/controller/DaifugoCuiController.go
@@ -173,7 +173,7 @@ func (c *DaifugoCuiController) Exec(command string) string {
 				}
 				return c.dgi.Sort(mode), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Normal, 1=Easy, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequiredAlt", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.dgi.GetConfig()
 					cfg.CpuDifficulty = domain.DaifugoCpuDifficulty(v)
 					return c.dgi.ResetWithConfig(cfg)

--- a/internal/adapter/controller/DaifugoCuiController_test.go
+++ b/internal/adapter/controller/DaifugoCuiController_test.go
@@ -173,17 +173,17 @@ func TestDaifugoCuiController_SetDifficulty_LongCommand(t *testing.T) {
 func TestDaifugoCuiController_SetDifficulty_NoArgs(t *testing.T) {
 	mi := new(mockUsecases.MockDaifugoInteractor)
 	c := controller.NewDaifugoCuiController(mi)
-	assert.Contains(t, c.Exec("sd"), "CPU difficulty is required")
+	assert.Contains(t, c.Exec("sd"), msgCpuDifficultyRequiredAlt())
 }
 
 func TestDaifugoCuiController_SetDifficulty_InvalidValue(t *testing.T) {
 	mi := new(mockUsecases.MockDaifugoInteractor)
 	c := controller.NewDaifugoCuiController(mi)
 	// non-numeric: controller catches
-	assert.Contains(t, c.Exec("sd abc"), "Invalid CPU difficulty: abc")
+	assert.Contains(t, c.Exec("sd abc"), msgInvalidCpuDifficultyPrefix())
 	// numeric out-of-range: controller catches via ParseIntArg bounds
-	assert.Equal(t, "Invalid CPU difficulty: 3. Please enter 0-2.", c.Exec("sd 3"))
-	assert.Equal(t, "Invalid CPU difficulty: -1. Please enter 0-2.", c.Exec("sd -1"))
+	assert.Equal(t, msgInvalidCpuDifficulty("3"), c.Exec("sd 3"))
+	assert.Equal(t, msgInvalidCpuDifficulty("-1"), c.Exec("sd -1"))
 }
 
 // --- setjoker ---

--- a/internal/adapter/controller/DoppelkopfCuiController.go
+++ b/internal/adapter/controller/DoppelkopfCuiController.go
@@ -56,7 +56,7 @@ func (c *DoppelkopfCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.di.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.di.GetConfig()
 					cfg.CpuDifficulty = domain.DoppelkopfCpuDifficulty(v)
 					return c.di.ResetWithConfig(cfg)

--- a/internal/adapter/controller/DoppelkopfCuiController_test.go
+++ b/internal/adapter/controller/DoppelkopfCuiController_test.go
@@ -87,7 +87,7 @@ func TestDoppelkopfCuiController_Exec(t *testing.T) {
 
 	t.Run("setdifficulty invalid", func(t *testing.T) {
 		result := controller.NewDoppelkopfCuiController(newMock()).Exec("sd 9")
-		assert.Contains(t, result, "Invalid CPU difficulty")
+		assert.Contains(t, result, msgInvalidCpuDifficultyPrefix())
 	})
 
 	t.Run("setchips", func(t *testing.T) {

--- a/internal/adapter/controller/DoudizhuCuiController.go
+++ b/internal/adapter/controller/DoudizhuCuiController.go
@@ -47,7 +47,7 @@ func (c *DoudizhuCuiController) Exec(command string) string {
 				}
 				return c.dgi.Bid(v), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Normal, 1=Easy, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequiredAlt", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.dgi.GetConfig()
 					cfg.CpuDifficulty = domain.DoudizhuCpuDifficulty(v)
 					return c.dgi.ResetWithConfig(cfg)

--- a/internal/adapter/controller/DurakCuiController.go
+++ b/internal/adapter/controller/DurakCuiController.go
@@ -68,7 +68,7 @@ func (c *DurakCuiController) Exec(command string) string {
 				}
 				return c.di.Sort(mode), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Normal, 1=Easy, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequiredAlt", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.di.GetConfig()
 					cfg.CpuDifficulty = domain.DurakCpuDifficulty(v)
 					return c.di.ResetWithConfig(cfg)

--- a/internal/adapter/controller/EcarteCuiController.go
+++ b/internal/adapter/controller/EcarteCuiController.go
@@ -68,7 +68,7 @@ func (c *EcarteCuiController) Exec(command string) string {
 			case "n", "next", "nextround":
 				return c.ei.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.ei.GetConfig()
 					cfg.CpuDifficulty = domain.EcarteCpuDifficulty(v)
 					return c.ei.ResetWithConfig(cfg)

--- a/internal/adapter/controller/EscobaCuiController.go
+++ b/internal/adapter/controller/EscobaCuiController.go
@@ -43,7 +43,7 @@ func (c *EscobaCuiController) Exec(command string) string {
 			case "n", "next", "nextround":
 				return c.ei.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.ei.GetConfig()
 					cfg.CpuDifficulty = domain.EscobaCpuDifficulty(v)
 					return c.ei.ResetWithConfig(cfg)

--- a/internal/adapter/controller/EuchreCuiController.go
+++ b/internal/adapter/controller/EuchreCuiController.go
@@ -79,7 +79,7 @@ func (c *EuchreCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.ei.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.ei.GetConfig()
 					cfg.CpuDifficulty = domain.EuchreCpuDifficulty(v)
 					return c.ei.ResetWithConfig(cfg)

--- a/internal/adapter/controller/EuchreCuiController_test.go
+++ b/internal/adapter/controller/EuchreCuiController_test.go
@@ -293,25 +293,25 @@ func TestEuchreCuiController_Exec(t *testing.T) {
 	t.Run("setdifficulty no args", func(t *testing.T) {
 		c := controller.NewEuchreCuiController(newMock())
 		result := c.Exec("sd")
-		assert.Contains(t, result, "required")
+		assert.Contains(t, result, msgCpuDifficultyRequired())
 	})
 
 	t.Run("setdifficulty invalid value", func(t *testing.T) {
 		c := controller.NewEuchreCuiController(newMock())
 		result := c.Exec("sd abc")
-		assert.Contains(t, result, "Invalid CPU difficulty")
+		assert.Contains(t, result, msgInvalidCpuDifficultyPrefix())
 	})
 
 	t.Run("setdifficulty negative", func(t *testing.T) {
 		c := controller.NewEuchreCuiController(newMock())
 		result := c.Exec("sd -1")
-		assert.Equal(t, "Invalid CPU difficulty: -1. Please enter 0-2.", result)
+		assert.Equal(t, msgInvalidCpuDifficulty("-1"), result)
 	})
 
 	t.Run("setdifficulty over 2", func(t *testing.T) {
 		c := controller.NewEuchreCuiController(newMock())
 		result := c.Exec("sd 3")
-		assert.Equal(t, "Invalid CPU difficulty: 3. Please enter 0-2.", result)
+		assert.Equal(t, msgInvalidCpuDifficulty("3"), result)
 	})
 
 	// setlimit

--- a/internal/adapter/controller/FiftyOneCuiController.go
+++ b/internal/adapter/controller/FiftyOneCuiController.go
@@ -49,7 +49,7 @@ func (c *FiftyOneCuiController) Exec(command string) string {
 			case "stop":
 				return c.fi.Stop(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.fi.GetConfig()
 					cfg.CpuDifficulty = domain.FiftyOneCpuDifficulty(v)
 					return c.fi.Reset(cfg)

--- a/internal/adapter/controller/FiveHundredCuiController.go
+++ b/internal/adapter/controller/FiveHundredCuiController.go
@@ -104,7 +104,7 @@ func (c *FiveHundredCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.fi.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.fi.GetConfig()
 					cfg.CpuDifficulty = domain.FiveHundredCpuDifficulty(v)
 					return c.fi.ResetWithConfig(cfg)

--- a/internal/adapter/controller/FortyFivesCuiController.go
+++ b/internal/adapter/controller/FortyFivesCuiController.go
@@ -58,7 +58,7 @@ func (c *FortyFivesCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.di.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.di.GetConfig()
 					cfg.CpuDifficulty = domain.FortyFivesCpuDifficulty(v)
 					return c.di.ResetWithConfig(cfg)

--- a/internal/adapter/controller/FortyFivesCuiController_test.go
+++ b/internal/adapter/controller/FortyFivesCuiController_test.go
@@ -97,7 +97,7 @@ func TestFortyFivesCuiController_Exec(t *testing.T) {
 
 	t.Run("setdifficulty invalid", func(t *testing.T) {
 		result := controller.NewFortyFivesCuiController(newMock()).Exec("sd 9")
-		assert.Contains(t, result, "Invalid CPU difficulty")
+		assert.Contains(t, result, msgInvalidCpuDifficultyPrefix())
 	})
 
 	t.Run("hint / log", func(t *testing.T) {

--- a/internal/adapter/controller/FrenchTarotCuiController.go
+++ b/internal/adapter/controller/FrenchTarotCuiController.go
@@ -60,7 +60,7 @@ func (c *FrenchTarotCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.di.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.di.GetConfig()
 					cfg.CpuDifficulty = domain.FrenchTarotCpuDifficulty(v)
 					return c.di.ResetWithConfig(cfg)

--- a/internal/adapter/controller/FrenchTarotCuiController_test.go
+++ b/internal/adapter/controller/FrenchTarotCuiController_test.go
@@ -122,7 +122,7 @@ func TestFrenchTarotCuiController_Exec(t *testing.T) {
 
 	t.Run("setdifficulty invalid", func(t *testing.T) {
 		result := controller.NewFrenchTarotCuiController(newMock()).Exec("sd 9")
-		assert.Contains(t, result, "Invalid CPU difficulty")
+		assert.Contains(t, result, msgInvalidCpuDifficultyPrefix())
 	})
 
 	t.Run("hint / log", func(t *testing.T) {

--- a/internal/adapter/controller/GaigelCuiController.go
+++ b/internal/adapter/controller/GaigelCuiController.go
@@ -58,7 +58,7 @@ func (c *GaigelCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.gi.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.gi.GetConfig()
 					cfg.CpuDifficulty = domain.GaigelCpuDifficulty(v)
 					return c.gi.ResetWithConfig(cfg)

--- a/internal/adapter/controller/GanjifaCuiController.go
+++ b/internal/adapter/controller/GanjifaCuiController.go
@@ -50,7 +50,7 @@ func (c *GanjifaCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.di.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.di.GetConfig()
 					cfg.CpuDifficulty = domain.GanjifaCpuDifficulty(v)
 					return c.di.ResetWithConfig(cfg)

--- a/internal/adapter/controller/GanjifaCuiController_test.go
+++ b/internal/adapter/controller/GanjifaCuiController_test.go
@@ -80,7 +80,7 @@ func TestGanjifaCuiController_Exec(t *testing.T) {
 
 	t.Run("setdifficulty invalid", func(t *testing.T) {
 		result := controller.NewGanjifaCuiController(newMock()).Exec("sd 9")
-		assert.Contains(t, result, "Invalid CPU difficulty")
+		assert.Contains(t, result, msgInvalidCpuDifficultyPrefix())
 	})
 
 	t.Run("hint / log", func(t *testing.T) {

--- a/internal/adapter/controller/GinRummyCuiController.go
+++ b/internal/adapter/controller/GinRummyCuiController.go
@@ -50,7 +50,7 @@ func (c *GinRummyCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.ci.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.ci.GetConfig()
 					cfg.CpuDifficulty = domain.GinRummyCpuDifficulty(v)
 					return c.ci.ResetWithConfig(cfg)

--- a/internal/adapter/controller/GinRummyCuiController_test.go
+++ b/internal/adapter/controller/GinRummyCuiController_test.go
@@ -236,25 +236,25 @@ func TestGinRummyCuiController_Exec(t *testing.T) {
 	t.Run("setdifficulty no args", func(t *testing.T) {
 		c := controller.NewGinRummyCuiController(newMock())
 		result := c.Exec("sd")
-		assert.Contains(t, result, "required")
+		assert.Contains(t, result, msgCpuDifficultyRequired())
 	})
 
 	t.Run("setdifficulty invalid value", func(t *testing.T) {
 		c := controller.NewGinRummyCuiController(newMock())
 		result := c.Exec("sd abc")
-		assert.Contains(t, result, "Invalid CPU difficulty")
+		assert.Contains(t, result, msgInvalidCpuDifficultyPrefix())
 	})
 
 	t.Run("setdifficulty negative", func(t *testing.T) {
 		c := controller.NewGinRummyCuiController(newMock())
 		result := c.Exec("sd -1")
-		assert.Equal(t, "Invalid CPU difficulty: -1. Please enter 0-2.", result)
+		assert.Equal(t, msgInvalidCpuDifficulty("-1"), result)
 	})
 
 	t.Run("setdifficulty over 2", func(t *testing.T) {
 		c := controller.NewGinRummyCuiController(newMock())
 		result := c.Exec("sd 3")
-		assert.Equal(t, "Invalid CPU difficulty: 3. Please enter 0-2.", result)
+		assert.Equal(t, msgInvalidCpuDifficulty("3"), result)
 	})
 
 	// setlimit

--- a/internal/adapter/controller/GoFishCuiController.go
+++ b/internal/adapter/controller/GoFishCuiController.go
@@ -46,7 +46,7 @@ func (c *GoFishCuiController) Exec(command string) string {
 				}
 				return c.gi.Ask(targetIdx, rank), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.gi.GetConfig()
 					cfg.CpuDifficulty = domain.GoFishCpuDifficulty(v)
 					return c.gi.Reset(cfg)

--- a/internal/adapter/controller/GoStopCuiController.go
+++ b/internal/adapter/controller/GoStopCuiController.go
@@ -55,7 +55,7 @@ func (c *GoStopCuiController) Exec(command string) string {
 			case "n", "next", "nr", "nextround":
 				return c.ki.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.ki.GetConfig()
 					cfg.CpuDifficulty = domain.GoStopCpuDifficulty(v)
 					return c.ki.ResetWithConfig(cfg)

--- a/internal/adapter/controller/GongZhuCuiController.go
+++ b/internal/adapter/controller/GongZhuCuiController.go
@@ -54,7 +54,7 @@ func (c *GongZhuCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.gi.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.gi.GetConfig()
 					cfg.CpuDifficulty = domain.GongZhuCpuDifficulty(v)
 					return c.gi.ResetWithConfig(cfg)

--- a/internal/adapter/controller/GongZhuCuiController_test.go
+++ b/internal/adapter/controller/GongZhuCuiController_test.go
@@ -95,7 +95,7 @@ func TestGongZhuCuiController_Exec(t *testing.T) {
 
 	t.Run("setdifficulty invalid", func(t *testing.T) {
 		result := controller.NewGongZhuCuiController(newMock()).Exec("sd 9")
-		assert.Contains(t, result, "Invalid CPU difficulty")
+		assert.Contains(t, result, msgInvalidCpuDifficultyPrefix())
 	})
 
 	t.Run("setlimit", func(t *testing.T) {

--- a/internal/adapter/controller/HachiHachiCuiController.go
+++ b/internal/adapter/controller/HachiHachiCuiController.go
@@ -48,7 +48,7 @@ func (c *HachiHachiCuiController) Exec(command string) string {
 			case "n", "next", "nr", "nextround":
 				return c.ki.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.ki.GetConfig()
 					cfg.CpuDifficulty = domain.HachiHachiCpuDifficulty(v)
 					return c.ki.ResetWithConfig(cfg)

--- a/internal/adapter/controller/HandAndFootCuiController.go
+++ b/internal/adapter/controller/HandAndFootCuiController.go
@@ -59,7 +59,7 @@ func (c *HandAndFootCuiController) Exec(command string) string {
 			case "d", "discard":
 				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.ci.Discard)
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.ci.GetConfig()
 					cfg.CpuDifficulty = domain.HandAndFootCpuDifficulty(v)
 					return c.ci.ResetWithConfig(cfg)

--- a/internal/adapter/controller/HandAndFootCuiController_test.go
+++ b/internal/adapter/controller/HandAndFootCuiController_test.go
@@ -123,7 +123,7 @@ func TestHandAndFootCuiController_Exec(t *testing.T) {
 
 	t.Run("setdifficulty invalid", func(t *testing.T) {
 		c := controller.NewHandAndFootCuiController(newMock())
-		assert.Contains(t, c.Exec("sd abc"), "Invalid CPU difficulty")
+		assert.Contains(t, c.Exec("sd abc"), msgInvalidCpuDifficultyPrefix())
 	})
 
 	t.Run("setlimit sl valid", func(t *testing.T) {

--- a/internal/adapter/controller/HeartsCuiController.go
+++ b/internal/adapter/controller/HeartsCuiController.go
@@ -60,7 +60,7 @@ func (c *HeartsCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.hi.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.hi.GetConfig()
 					cfg.CpuDifficulty = domain.HeartsCpuDifficulty(v)
 					return c.hi.ResetWithConfig(cfg)

--- a/internal/adapter/controller/HeartsCuiController_test.go
+++ b/internal/adapter/controller/HeartsCuiController_test.go
@@ -196,25 +196,25 @@ func TestHeartsCuiController_Exec(t *testing.T) {
 	t.Run("setdifficulty no args", func(t *testing.T) {
 		c := controller.NewHeartsCuiController(newMock())
 		result := c.Exec("sd")
-		assert.Contains(t, result, "required")
+		assert.Contains(t, result, msgCpuDifficultyRequired())
 	})
 
 	t.Run("setdifficulty invalid value", func(t *testing.T) {
 		c := controller.NewHeartsCuiController(newMock())
 		result := c.Exec("sd abc")
-		assert.Contains(t, result, "Invalid CPU difficulty")
+		assert.Contains(t, result, msgInvalidCpuDifficultyPrefix())
 	})
 
 	t.Run("setdifficulty negative", func(t *testing.T) {
 		c := controller.NewHeartsCuiController(newMock())
 		result := c.Exec("sd -1")
-		assert.Equal(t, "Invalid CPU difficulty: -1. Please enter 0-2.", result)
+		assert.Equal(t, msgInvalidCpuDifficulty("-1"), result)
 	})
 
 	t.Run("setdifficulty over 2", func(t *testing.T) {
 		c := controller.NewHeartsCuiController(newMock())
 		result := c.Exec("sd 3")
-		assert.Equal(t, "Invalid CPU difficulty: 3. Please enter 0-2.", result)
+		assert.Equal(t, msgInvalidCpuDifficulty("3"), result)
 	})
 
 	// setlimit

--- a/internal/adapter/controller/IndianRummyCuiController.go
+++ b/internal/adapter/controller/IndianRummyCuiController.go
@@ -55,7 +55,7 @@ func (c *IndianRummyCuiController) Exec(command string) string {
 					return c.ci.ResetWithConfig(cfg)
 				})
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.ci.GetConfig()
 					cfg.CpuDifficulty = domain.IndianRummyCpuDifficulty(v)
 					return c.ci.ResetWithConfig(cfg)

--- a/internal/adapter/controller/JassCuiController.go
+++ b/internal/adapter/controller/JassCuiController.go
@@ -64,7 +64,7 @@ func (c *JassCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.ji.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.ji.GetConfig()
 					cfg.CpuDifficulty = domain.JassCpuDifficulty(v)
 					return c.ji.ResetWithConfig(cfg)

--- a/internal/adapter/controller/KalookiCuiController.go
+++ b/internal/adapter/controller/KalookiCuiController.go
@@ -58,7 +58,7 @@ func (c *KalookiCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.ci.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.ci.GetConfig()
 					cfg.CpuDifficulty = domain.KalookiCpuDifficulty(v)
 					return c.ci.ResetWithConfig(cfg)

--- a/internal/adapter/controller/KingCuiController.go
+++ b/internal/adapter/controller/KingCuiController.go
@@ -45,7 +45,7 @@ func (c *KingCuiController) Exec(command string) string {
 			case "n", "next":
 				return c.ki.NextDeal(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.ki.GetConfig()
 					cfg.CpuDifficulty = domain.KingCpuDifficulty(v)
 					return c.ki.ResetWithConfig(cfg)

--- a/internal/adapter/controller/KlaverjasCuiController.go
+++ b/internal/adapter/controller/KlaverjasCuiController.go
@@ -50,7 +50,7 @@ func (c *KlaverjasCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.di.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.di.GetConfig()
 					cfg.CpuDifficulty = domain.KlaverjasCpuDifficulty(v)
 					return c.di.ResetWithConfig(cfg)

--- a/internal/adapter/controller/KlaverjasCuiController_test.go
+++ b/internal/adapter/controller/KlaverjasCuiController_test.go
@@ -72,7 +72,7 @@ func TestKlaverjasCuiController_Exec(t *testing.T) {
 
 	t.Run("setdifficulty invalid", func(t *testing.T) {
 		result := controller.NewKlaverjasCuiController(newMock()).Exec("sd 9")
-		assert.Contains(t, result, "Invalid CPU difficulty")
+		assert.Contains(t, result, msgInvalidCpuDifficultyPrefix())
 	})
 
 	t.Run("hint / log", func(t *testing.T) {

--- a/internal/adapter/controller/KnockoutWhistCuiController.go
+++ b/internal/adapter/controller/KnockoutWhistCuiController.go
@@ -53,7 +53,7 @@ func (c *KnockoutWhistCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.di.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.di.GetConfig()
 					cfg.CpuDifficulty = domain.KnockoutWhistCpuDifficulty(v)
 					return c.di.ResetWithConfig(cfg)

--- a/internal/adapter/controller/KnockoutWhistCuiController_test.go
+++ b/internal/adapter/controller/KnockoutWhistCuiController_test.go
@@ -85,7 +85,7 @@ func TestKnockoutWhistCuiController_Exec(t *testing.T) {
 
 	t.Run("setdifficulty invalid", func(t *testing.T) {
 		result := controller.NewKnockoutWhistCuiController(newMock()).Exec("sd 9")
-		assert.Contains(t, result, "Invalid CPU difficulty")
+		assert.Contains(t, result, msgInvalidCpuDifficultyPrefix())
 	})
 
 	t.Run("hint / log", func(t *testing.T) {

--- a/internal/adapter/controller/KoenigrufenCuiController.go
+++ b/internal/adapter/controller/KoenigrufenCuiController.go
@@ -63,7 +63,7 @@ func (c *KoenigrufenCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.di.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.di.GetConfig()
 					cfg.CpuDifficulty = domain.KoenigrufenCpuDifficulty(v)
 					return c.di.ResetWithConfig(cfg)

--- a/internal/adapter/controller/KoenigrufenCuiController_test.go
+++ b/internal/adapter/controller/KoenigrufenCuiController_test.go
@@ -133,7 +133,7 @@ func TestKoenigrufenCuiController_Exec(t *testing.T) {
 
 	t.Run("setdifficulty invalid", func(t *testing.T) {
 		result := controller.NewKoenigrufenCuiController(newMock()).Exec("sd 9")
-		assert.Contains(t, result, "Invalid CPU difficulty")
+		assert.Contains(t, result, msgInvalidCpuDifficultyPrefix())
 	})
 
 	t.Run("hint / log", func(t *testing.T) {

--- a/internal/adapter/controller/KoiKoiCuiController.go
+++ b/internal/adapter/controller/KoiKoiCuiController.go
@@ -55,7 +55,7 @@ func (c *KoiKoiCuiController) Exec(command string) string {
 			case "n", "next", "nr", "nextround":
 				return c.ki.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.ki.GetConfig()
 					cfg.CpuDifficulty = domain.KoiKoiCpuDifficulty(v)
 					return c.ki.ResetWithConfig(cfg)

--- a/internal/adapter/controller/LooCuiController.go
+++ b/internal/adapter/controller/LooCuiController.go
@@ -55,7 +55,7 @@ func (c *LooCuiController) Exec(command string) string {
 			case "n", "next", "nr", "nextround":
 				return c.li.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.li.GetConfig()
 					cfg.CpuDifficulty = domain.LooCpuDifficulty(v)
 					return c.li.ResetWithConfig(cfg)

--- a/internal/adapter/controller/MacauCuiController.go
+++ b/internal/adapter/controller/MacauCuiController.go
@@ -62,7 +62,7 @@ func (c *MacauCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.ci.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.ci.GetConfig()
 					cfg.CpuDifficulty = domain.MacauCpuDifficulty(v)
 					return c.ci.ResetWithConfig(cfg)

--- a/internal/adapter/controller/MacauCuiController_test.go
+++ b/internal/adapter/controller/MacauCuiController_test.go
@@ -163,7 +163,7 @@ func TestMacauCuiController_Exec(t *testing.T) {
 	})
 
 	t.Run("setdifficulty out of range", func(t *testing.T) {
-		assert.Equal(t, "Invalid CPU difficulty: 3. Please enter 0-2.", controller.NewMacauCuiController(newMock()).Exec("sd 3"))
+		assert.Equal(t, msgInvalidCpuDifficulty("3"), controller.NewMacauCuiController(newMock()).Exec("sd 3"))
 	})
 
 	t.Run("setlimit valid", func(t *testing.T) {

--- a/internal/adapter/controller/MachiavelliCuiController.go
+++ b/internal/adapter/controller/MachiavelliCuiController.go
@@ -60,7 +60,7 @@ func (c *MachiavelliCuiController) Exec(command string) string {
 					return c.ci.ResetWithConfig(cfg)
 				})
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.ci.GetConfig()
 					cfg.CpuDifficulty = domain.MachiavelliCpuDifficulty(v)
 					return c.ci.ResetWithConfig(cfg)

--- a/internal/adapter/controller/ManilleCuiController.go
+++ b/internal/adapter/controller/ManilleCuiController.go
@@ -50,7 +50,7 @@ func (c *ManilleCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.di.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.di.GetConfig()
 					cfg.CpuDifficulty = domain.ManilleCpuDifficulty(v)
 					return c.di.ResetWithConfig(cfg)

--- a/internal/adapter/controller/ManilleCuiController_test.go
+++ b/internal/adapter/controller/ManilleCuiController_test.go
@@ -72,7 +72,7 @@ func TestManilleCuiController_Exec(t *testing.T) {
 
 	t.Run("setdifficulty invalid", func(t *testing.T) {
 		result := controller.NewManilleCuiController(newMock()).Exec("sd 9")
-		assert.Contains(t, result, "Invalid CPU difficulty")
+		assert.Contains(t, result, msgInvalidCpuDifficultyPrefix())
 	})
 
 	t.Run("hint / log", func(t *testing.T) {

--- a/internal/adapter/controller/MaoCuiController.go
+++ b/internal/adapter/controller/MaoCuiController.go
@@ -74,7 +74,7 @@ func (c *MaoCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.ci.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.ci.GetConfig()
 					cfg.CpuDifficulty = domain.MaoCpuDifficulty(v)
 					return c.ci.ResetWithConfig(cfg)

--- a/internal/adapter/controller/MariasCuiController.go
+++ b/internal/adapter/controller/MariasCuiController.go
@@ -50,7 +50,7 @@ func (c *MariasCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.di.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.di.GetConfig()
 					cfg.CpuDifficulty = domain.MariasCpuDifficulty(v)
 					return c.di.ResetWithConfig(cfg)

--- a/internal/adapter/controller/MariasCuiController_test.go
+++ b/internal/adapter/controller/MariasCuiController_test.go
@@ -72,7 +72,7 @@ func TestMariasCuiController_Exec(t *testing.T) {
 
 	t.Run("setdifficulty invalid", func(t *testing.T) {
 		result := controller.NewMariasCuiController(newMock()).Exec("sd 9")
-		assert.Contains(t, result, "Invalid CPU difficulty")
+		assert.Contains(t, result, msgInvalidCpuDifficultyPrefix())
 	})
 
 	t.Run("hint / log", func(t *testing.T) {

--- a/internal/adapter/controller/MemoryCuiController.go
+++ b/internal/adapter/controller/MemoryCuiController.go
@@ -34,7 +34,7 @@ func (c *MemoryCuiController) Exec(command string) string {
 			case "n", "next":
 				return c.mi.Next(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.mi.GetConfig()
 					cfg.CpuDifficulty = domain.MemoryCpuDifficulty(v)
 					return c.mi.ResetWithConfig(cfg)

--- a/internal/adapter/controller/MemoryCuiController_test.go
+++ b/internal/adapter/controller/MemoryCuiController_test.go
@@ -91,19 +91,19 @@ func TestMemoryCuiControllerSetDifficulty(t *testing.T) {
 		mi := newMockMemoryInteractor()
 		c := NewMemoryCuiController(mi)
 		result := c.Exec("sd")
-		assert.Contains(t, result, "CPU difficulty is required")
+		assert.Contains(t, result, msgCpuDifficultyRequired())
 	})
 	t.Run("invalid difficulty", func(t *testing.T) {
 		mi := newMockMemoryInteractor()
 		c := NewMemoryCuiController(mi)
 		result := c.Exec("sd 5")
-		assert.Contains(t, result, "Invalid CPU difficulty")
+		assert.Contains(t, result, msgInvalidCpuDifficultyPrefix())
 	})
 	t.Run("non-numeric difficulty", func(t *testing.T) {
 		mi := newMockMemoryInteractor()
 		c := NewMemoryCuiController(mi)
 		result := c.Exec("sd abc")
-		assert.Contains(t, result, "Invalid CPU difficulty")
+		assert.Contains(t, result, msgInvalidCpuDifficultyPrefix())
 	})
 }
 

--- a/internal/adapter/controller/MightyCuiController.go
+++ b/internal/adapter/controller/MightyCuiController.go
@@ -124,7 +124,7 @@ func (c *MightyCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.mi.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.mi.GetConfig()
 					cfg.CpuDifficulty = domain.MightyCpuDifficulty(v)
 					return c.mi.ResetWithConfig(cfg)

--- a/internal/adapter/controller/MightyCuiController_test.go
+++ b/internal/adapter/controller/MightyCuiController_test.go
@@ -249,12 +249,12 @@ func TestMightyCuiController_Exec(t *testing.T) {
 
 	t.Run("setdifficulty over range", func(t *testing.T) {
 		c := controller.NewMightyCuiController(newMightyCuiMock(mockOutput))
-		assert.Equal(t, "Invalid CPU difficulty: 3. Please enter 0-2.", c.Exec("sd 3"))
+		assert.Equal(t, msgInvalidCpuDifficulty("3"), c.Exec("sd 3"))
 	})
 
 	t.Run("setdifficulty negative", func(t *testing.T) {
 		c := controller.NewMightyCuiController(newMightyCuiMock(mockOutput))
-		assert.Equal(t, "Invalid CPU difficulty: -1. Please enter 0-2.", c.Exec("sd -1"))
+		assert.Equal(t, msgInvalidCpuDifficulty("-1"), c.Exec("sd -1"))
 	})
 
 	t.Run("setlimit valid", func(t *testing.T) {

--- a/internal/adapter/controller/MinchiateCuiController.go
+++ b/internal/adapter/controller/MinchiateCuiController.go
@@ -57,7 +57,7 @@ func (c *MinchiateCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.di.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.di.GetConfig()
 					cfg.CpuDifficulty = domain.MinchiateCpuDifficulty(v)
 					return c.di.ResetWithConfig(cfg)

--- a/internal/adapter/controller/MinchiateCuiController_test.go
+++ b/internal/adapter/controller/MinchiateCuiController_test.go
@@ -114,7 +114,7 @@ func TestMinchiateCuiController_Exec(t *testing.T) {
 	})
 
 	t.Run("setdifficulty invalid", func(t *testing.T) {
-		assert.Contains(t, controller.NewMinchiateCuiController(newMock()).Exec("sd 9"), "Invalid CPU difficulty")
+		assert.Contains(t, controller.NewMinchiateCuiController(newMock()).Exec("sd 9"), msgInvalidCpuDifficultyPrefix())
 	})
 
 	t.Run("hint / log", func(t *testing.T) {

--- a/internal/adapter/controller/MusCuiController.go
+++ b/internal/adapter/controller/MusCuiController.go
@@ -77,7 +77,7 @@ func (c *MusCuiController) Exec(command string) string {
 			case "n", "next":
 				return c.mi.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.mi.GetConfig()
 					cfg.CpuDifficulty = domain.MusCpuDifficulty(v)
 					return c.mi.ResetWithConfig(cfg)

--- a/internal/adapter/controller/MusCuiController_test.go
+++ b/internal/adapter/controller/MusCuiController_test.go
@@ -167,7 +167,7 @@ func TestMusCuiController_Exec(t *testing.T) {
 
 	t.Run("setdifficulty invalid", func(t *testing.T) {
 		result := controller.NewMusCuiController(newMock()).Exec("sd 9")
-		assert.Contains(t, result, "Invalid CPU difficulty")
+		assert.Contains(t, result, msgInvalidCpuDifficultyPrefix())
 	})
 
 	t.Run("hint / log", func(t *testing.T) {

--- a/internal/adapter/controller/NapCuiController.go
+++ b/internal/adapter/controller/NapCuiController.go
@@ -58,7 +58,7 @@ func (c *NapCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.di.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.di.GetConfig()
 					cfg.CpuDifficulty = domain.NapCpuDifficulty(v)
 					return c.di.ResetWithConfig(cfg)

--- a/internal/adapter/controller/NapCuiController_test.go
+++ b/internal/adapter/controller/NapCuiController_test.go
@@ -97,7 +97,7 @@ func TestNapCuiController_Exec(t *testing.T) {
 
 	t.Run("setdifficulty invalid", func(t *testing.T) {
 		result := controller.NewNapCuiController(newMock()).Exec("sd 9")
-		assert.Contains(t, result, "Invalid CPU difficulty")
+		assert.Contains(t, result, msgInvalidCpuDifficultyPrefix())
 	})
 
 	t.Run("hint / log", func(t *testing.T) {

--- a/internal/adapter/controller/NapoleonCuiController.go
+++ b/internal/adapter/controller/NapoleonCuiController.go
@@ -79,7 +79,7 @@ func (c *NapoleonCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.ni.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.ni.GetConfig()
 					cfg.CpuDifficulty = domain.NapoleonCpuDifficulty(v)
 					return c.ni.ResetWithConfig(cfg)

--- a/internal/adapter/controller/NapoleonCuiController_test.go
+++ b/internal/adapter/controller/NapoleonCuiController_test.go
@@ -307,25 +307,25 @@ func TestNapoleonCuiController_Exec(t *testing.T) {
 	t.Run("setdifficulty no args", func(t *testing.T) {
 		c := controller.NewNapoleonCuiController(newMock())
 		result := c.Exec("sd")
-		assert.Contains(t, result, "required")
+		assert.Contains(t, result, msgCpuDifficultyRequired())
 	})
 
 	t.Run("setdifficulty invalid value", func(t *testing.T) {
 		c := controller.NewNapoleonCuiController(newMock())
 		result := c.Exec("sd abc")
-		assert.Contains(t, result, "Invalid CPU difficulty")
+		assert.Contains(t, result, msgInvalidCpuDifficultyPrefix())
 	})
 
 	t.Run("setdifficulty negative", func(t *testing.T) {
 		c := controller.NewNapoleonCuiController(newMock())
 		result := c.Exec("sd -1")
-		assert.Equal(t, "Invalid CPU difficulty: -1. Please enter 0-2.", result)
+		assert.Equal(t, msgInvalidCpuDifficulty("-1"), result)
 	})
 
 	t.Run("setdifficulty over 2", func(t *testing.T) {
 		c := controller.NewNapoleonCuiController(newMock())
 		result := c.Exec("sd 3")
-		assert.Equal(t, "Invalid CPU difficulty: 3. Please enter 0-2.", result)
+		assert.Equal(t, msgInvalidCpuDifficulty("3"), result)
 	})
 
 	// setlimit

--- a/internal/adapter/controller/NinetyNineCuiController.go
+++ b/internal/adapter/controller/NinetyNineCuiController.go
@@ -58,7 +58,7 @@ func (c *NinetyNineCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.oi.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.oi.GetConfig()
 					cfg.CpuDifficulty = domain.NinetyNineCpuDifficulty(v)
 					return c.oi.ResetWithConfig(cfg)

--- a/internal/adapter/controller/NinetyNineCuiController_test.go
+++ b/internal/adapter/controller/NinetyNineCuiController_test.go
@@ -92,11 +92,11 @@ func TestNinetyNineCuiController_Exec_Errors(t *testing.T) {
 	assert.Contains(t, c.Exec("b 0 1"), "required")
 	assert.Contains(t, c.Exec("b a b c"), "Invalid")
 	assert.Contains(t, c.Exec("p"), msgCardIndexRequired())
-	assert.Contains(t, c.Exec("sd"), "required")
+	assert.Contains(t, c.Exec("sd"), msgCpuDifficultyRequired())
 	assert.Contains(t, c.Exec("st"), "required")
 
 	assert.Contains(t, c.Exec("p abc"), msgInvalidCardIndexPrefix())
-	assert.Contains(t, c.Exec("sd 99"), "Invalid")
+	assert.Contains(t, c.Exec("sd 99"), msgInvalidCpuDifficultyPrefix())
 	assert.Contains(t, c.Exec("st 5"), "Invalid")
 	assert.Contains(t, c.Exec("st 9999"), "Invalid")
 }

--- a/internal/adapter/controller/OhHellCuiController.go
+++ b/internal/adapter/controller/OhHellCuiController.go
@@ -51,7 +51,7 @@ func (c *OhHellCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.oi.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.oi.GetConfig()
 					cfg.CpuDifficulty = domain.OhHellCpuDifficulty(v)
 					return c.oi.ResetWithConfig(cfg)

--- a/internal/adapter/controller/OhHellCuiController_test.go
+++ b/internal/adapter/controller/OhHellCuiController_test.go
@@ -92,12 +92,12 @@ func TestOhHellCuiController_Exec_Errors(t *testing.T) {
 	// Missing args
 	assert.Contains(t, c.Exec("b"), "required")
 	assert.Contains(t, c.Exec("p"), msgCardIndexRequired())
-	assert.Contains(t, c.Exec("sd"), "required")
+	assert.Contains(t, c.Exec("sd"), msgCpuDifficultyRequired())
 	assert.Contains(t, c.Exec("sm"), "required")
 
 	// Invalid args
 	assert.Contains(t, c.Exec("b abc"), "Invalid")
-	assert.Contains(t, c.Exec("sd 99"), "Invalid")
+	assert.Contains(t, c.Exec("sd 99"), msgInvalidCpuDifficultyPrefix())
 	assert.Contains(t, c.Exec("sm 0"), "Invalid")
 	assert.Contains(t, c.Exec("sm 14"), "Invalid")
 }

--- a/internal/adapter/controller/OmbreCuiController.go
+++ b/internal/adapter/controller/OmbreCuiController.go
@@ -71,7 +71,7 @@ func (c *OmbreCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.di.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.di.GetConfig()
 					cfg.CpuDifficulty = domain.OmbreCpuDifficulty(v)
 					return c.di.ResetWithConfig(cfg)

--- a/internal/adapter/controller/OmbreCuiController_test.go
+++ b/internal/adapter/controller/OmbreCuiController_test.go
@@ -114,7 +114,7 @@ func TestOmbreCuiController_Exec(t *testing.T) {
 
 	t.Run("setdifficulty invalid", func(t *testing.T) {
 		result := controller.NewOmbreCuiController(newMock()).Exec("sd 9")
-		assert.Contains(t, result, "Invalid CPU difficulty")
+		assert.Contains(t, result, msgInvalidCpuDifficultyPrefix())
 	})
 
 	t.Run("hint / log", func(t *testing.T) {

--- a/internal/adapter/controller/OpenFaceChineseCuiController.go
+++ b/internal/adapter/controller/OpenFaceChineseCuiController.go
@@ -59,7 +59,7 @@ func (c *OpenFaceChineseCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.di.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.di.GetConfig()
 					cfg.CpuDifficulty = domain.OpenFaceChineseCpuDifficulty(v)
 					return c.di.ResetWithConfig(cfg)

--- a/internal/adapter/controller/OpenFaceChineseCuiController_test.go
+++ b/internal/adapter/controller/OpenFaceChineseCuiController_test.go
@@ -85,7 +85,7 @@ func TestOpenFaceChineseCuiController_Exec(t *testing.T) {
 
 	t.Run("setdifficulty invalid", func(t *testing.T) {
 		result := controller.NewOpenFaceChineseCuiController(newMock()).Exec("sd 9")
-		assert.Contains(t, result, "Invalid CPU difficulty")
+		assert.Contains(t, result, msgInvalidCpuDifficultyPrefix())
 	})
 
 	t.Run("setplayers", func(t *testing.T) {

--- a/internal/adapter/controller/PageOneCuiController.go
+++ b/internal/adapter/controller/PageOneCuiController.go
@@ -51,7 +51,7 @@ func (c *PageOneCuiController) Exec(command string) string {
 			case "p", "play":
 				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.ci.Play)
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.ci.GetConfig()
 					cfg.CpuDifficulty = domain.PageOneCpuDifficulty(v)
 					return c.ci.ResetWithConfig(cfg)

--- a/internal/adapter/controller/PageOneCuiController_test.go
+++ b/internal/adapter/controller/PageOneCuiController_test.go
@@ -108,11 +108,11 @@ func TestPageOneCuiController_Exec(t *testing.T) {
 	})
 	t.Run("setdifficulty no args", func(t *testing.T) {
 		c := controller.NewPageOneCuiController(newMock())
-		assert.Contains(t, c.Exec("sd"), "required")
+		assert.Contains(t, c.Exec("sd"), msgCpuDifficultyRequired())
 	})
 	t.Run("setdifficulty out of range", func(t *testing.T) {
 		c := controller.NewPageOneCuiController(newMock())
-		assert.Contains(t, c.Exec("sd 3"), "Invalid CPU difficulty")
+		assert.Contains(t, c.Exec("sd 3"), msgInvalidCpuDifficultyPrefix())
 	})
 	t.Run("setlimit valid", func(t *testing.T) {
 		m := newMock()

--- a/internal/adapter/controller/PanCuiController.go
+++ b/internal/adapter/controller/PanCuiController.go
@@ -59,7 +59,7 @@ func (c *PanCuiController) Exec(command string) string {
 					return c.ci.ResetWithConfig(cfg)
 				})
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.ci.GetConfig()
 					cfg.CpuDifficulty = domain.PanCpuDifficulty(v)
 					return c.ci.ResetWithConfig(cfg)

--- a/internal/adapter/controller/PanCuiController_test.go
+++ b/internal/adapter/controller/PanCuiController_test.go
@@ -115,7 +115,7 @@ func TestPanCuiController_Exec(t *testing.T) {
 
 	t.Run("setdifficulty sd out of range", func(t *testing.T) {
 		result := controller.NewPanCuiController(newMock()).Exec("sd 9")
-		assert.Contains(t, result, "Invalid CPU difficulty")
+		assert.Contains(t, result, msgInvalidCpuDifficultyPrefix())
 	})
 
 	t.Run("setrounds sr valid", func(t *testing.T) {

--- a/internal/adapter/controller/PinochleCuiController.go
+++ b/internal/adapter/controller/PinochleCuiController.go
@@ -70,7 +70,7 @@ func (c *PinochleCuiController) Exec(command string) string {
 			case "p", "play":
 				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.pi.Play)
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.pi.GetConfig()
 					cfg.CpuDifficulty = domain.PinochleCpuDifficulty(v)
 					return c.pi.ResetWithConfig(cfg)

--- a/internal/adapter/controller/PinochleCuiController_test.go
+++ b/internal/adapter/controller/PinochleCuiController_test.go
@@ -252,19 +252,19 @@ func TestPinochleCuiController_Exec(t *testing.T) {
 	t.Run("setdifficulty no args", func(t *testing.T) {
 		c := controller.NewPinochleCuiController(newPinochleMock())
 		result := c.Exec("sd")
-		assert.Contains(t, result, "required")
+		assert.Contains(t, result, msgCpuDifficultyRequired())
 	})
 
 	t.Run("setdifficulty invalid", func(t *testing.T) {
 		c := controller.NewPinochleCuiController(newPinochleMock())
 		result := c.Exec("sd abc")
-		assert.Contains(t, result, "Invalid CPU difficulty")
+		assert.Contains(t, result, msgInvalidCpuDifficultyPrefix())
 	})
 
 	t.Run("setdifficulty out of range", func(t *testing.T) {
 		c := controller.NewPinochleCuiController(newPinochleMock())
 		result := c.Exec("sd 3")
-		assert.Contains(t, result, "Invalid CPU difficulty: 3")
+		assert.Contains(t, result, msgInvalidCpuDifficultyPrefix())
 	})
 
 	// setlimit

--- a/internal/adapter/controller/PishtiCuiController.go
+++ b/internal/adapter/controller/PishtiCuiController.go
@@ -43,7 +43,7 @@ func (c *PishtiCuiController) Exec(command string) string {
 			case "n", "next":
 				return c.pi.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.pi.GetConfig()
 					cfg.CpuDifficulty = domain.PishtiCpuDifficulty(v)
 					return c.pi.ResetWithConfig(cfg)

--- a/internal/adapter/controller/PishtiCuiController_test.go
+++ b/internal/adapter/controller/PishtiCuiController_test.go
@@ -78,7 +78,7 @@ func TestPishtiCuiController_Exec(t *testing.T) {
 		m := newMock()
 		c := controller.NewPishtiCuiController(m)
 		out := c.Exec("sd 9")
-		assert.Contains(t, out, "Invalid")
+		assert.Contains(t, out, msgInvalidCpuDifficultyPrefix())
 	})
 
 	t.Run("set players", func(t *testing.T) {

--- a/internal/adapter/controller/PitchCuiController.go
+++ b/internal/adapter/controller/PitchCuiController.go
@@ -53,7 +53,7 @@ func (c *PitchCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.pi.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.pi.GetConfig()
 					cfg.CpuDifficulty = domain.PitchCpuDifficulty(v)
 					return c.pi.ResetWithConfig(cfg)

--- a/internal/adapter/controller/PreferenceCuiController.go
+++ b/internal/adapter/controller/PreferenceCuiController.go
@@ -58,7 +58,7 @@ func (c *PreferenceCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.di.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.di.GetConfig()
 					cfg.CpuDifficulty = domain.PreferenceCpuDifficulty(v)
 					return c.di.ResetWithConfig(cfg)

--- a/internal/adapter/controller/PreferenceCuiController_test.go
+++ b/internal/adapter/controller/PreferenceCuiController_test.go
@@ -104,7 +104,7 @@ func TestPreferenceCuiController_Exec(t *testing.T) {
 
 	t.Run("setdifficulty invalid", func(t *testing.T) {
 		result := controller.NewPreferenceCuiController(newMock()).Exec("sd 9")
-		assert.Contains(t, result, "Invalid CPU difficulty")
+		assert.Contains(t, result, msgInvalidCpuDifficultyPrefix())
 	})
 
 	t.Run("hint / log", func(t *testing.T) {

--- a/internal/adapter/controller/PresidentCuiController.go
+++ b/internal/adapter/controller/PresidentCuiController.go
@@ -94,7 +94,7 @@ func (c *PresidentCuiController) Exec(command string) string {
 			case "h", "hint":
 				return c.pi.Hint(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.pi.GetConfig()
 					cfg.CpuDifficulty = domain.PresidentCpuDifficulty(v)
 					return c.pi.ResetWithConfig(cfg)

--- a/internal/adapter/controller/PresidentCuiController_test.go
+++ b/internal/adapter/controller/PresidentCuiController_test.go
@@ -68,12 +68,12 @@ func TestPresidentCuiController_Exec(t *testing.T) {
 
 	t.Run("set difficulty requires arg", func(t *testing.T) {
 		c := controller.NewPresidentCuiController(newMock())
-		assert.Contains(t, c.Exec("sd"), "required")
+		assert.Contains(t, c.Exec("sd"), msgCpuDifficultyRequired())
 	})
 
 	t.Run("set difficulty invalid arg", func(t *testing.T) {
 		c := controller.NewPresidentCuiController(newMock())
-		assert.Contains(t, c.Exec("sd 9"), "Invalid")
+		assert.Contains(t, c.Exec("sd 9"), msgInvalidCpuDifficultyPrefix())
 	})
 
 	t.Run("setrule list", func(t *testing.T) {

--- a/internal/adapter/controller/PrsiCuiController.go
+++ b/internal/adapter/controller/PrsiCuiController.go
@@ -35,7 +35,7 @@ func (c *PrsiCuiController) Exec(command string) string {
 			case "d", "draw":
 				return c.ci.Draw(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.ci.GetConfig()
 					cfg.CpuDifficulty = domain.PrsiCpuDifficulty(v)
 					return c.ci.ResetWithConfig(cfg)

--- a/internal/adapter/controller/RookCuiController.go
+++ b/internal/adapter/controller/RookCuiController.go
@@ -86,7 +86,7 @@ func (c *RookCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.fi.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.fi.GetConfig()
 					cfg.CpuDifficulty = domain.RookCpuDifficulty(v)
 					return c.fi.ResetWithConfig(cfg)

--- a/internal/adapter/controller/Rummy500CuiController.go
+++ b/internal/adapter/controller/Rummy500CuiController.go
@@ -57,7 +57,7 @@ func (c *Rummy500CuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.ci.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.ci.GetConfig()
 					cfg.CpuDifficulty = domain.Rummy500CpuDifficulty(v)
 					return c.ci.ResetWithConfig(cfg)

--- a/internal/adapter/controller/Rummy500CuiController_test.go
+++ b/internal/adapter/controller/Rummy500CuiController_test.go
@@ -143,7 +143,7 @@ func TestRummy500CuiController_Exec(t *testing.T) {
 
 	t.Run("setdifficulty sd out of range", func(t *testing.T) {
 		result := controller.NewRummy500CuiController(newMock()).Exec("sd 9")
-		assert.Contains(t, result, "Invalid CPU difficulty")
+		assert.Contains(t, result, msgInvalidCpuDifficultyPrefix())
 	})
 
 	t.Run("setlimit sl valid", func(t *testing.T) {

--- a/internal/adapter/controller/RussianBankCuiController.go
+++ b/internal/adapter/controller/RussianBankCuiController.go
@@ -99,8 +99,8 @@ func (c *RussianBankCuiController) Exec(command string) string {
 			case "u", "undo":
 				return c.di.Undo(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).",
-					"Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired",
+					"invalidCpuDifficulty", 0, 2, func(v int) string {
 						cfg := c.di.GetConfig()
 						cfg.CpuDifficulty = domain.RussianBankCpuDifficulty(v)
 						return c.di.ResetWithConfig(cfg)

--- a/internal/adapter/controller/SambaCuiController.go
+++ b/internal/adapter/controller/SambaCuiController.go
@@ -58,7 +58,7 @@ func (c *SambaCuiController) Exec(command string) string {
 			case "d", "discard":
 				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.ci.Discard)
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.ci.GetConfig()
 					cfg.CpuDifficulty = domain.SambaCpuDifficulty(v)
 					return c.ci.ResetWithConfig(cfg)

--- a/internal/adapter/controller/SambaCuiController_test.go
+++ b/internal/adapter/controller/SambaCuiController_test.go
@@ -126,8 +126,8 @@ func TestSambaCuiController_Exec(t *testing.T) {
 
 	t.Run("setdifficulty invalid", func(t *testing.T) {
 		c := controller.NewSambaCuiController(newMock())
-		assert.Contains(t, c.Exec("sd abc"), "Invalid CPU difficulty")
-		assert.Contains(t, c.Exec("sd -1"), "Invalid CPU difficulty")
+		assert.Contains(t, c.Exec("sd abc"), msgInvalidCpuDifficultyPrefix())
+		assert.Contains(t, c.Exec("sd -1"), msgInvalidCpuDifficultyPrefix())
 	})
 
 	t.Run("setlimit valid", func(t *testing.T) {

--- a/internal/adapter/controller/ScartoCuiController.go
+++ b/internal/adapter/controller/ScartoCuiController.go
@@ -55,7 +55,7 @@ func (c *ScartoCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.di.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.di.GetConfig()
 					cfg.CpuDifficulty = domain.ScartoCpuDifficulty(v)
 					return c.di.ResetWithConfig(cfg)

--- a/internal/adapter/controller/ScartoCuiController_test.go
+++ b/internal/adapter/controller/ScartoCuiController_test.go
@@ -96,7 +96,7 @@ func TestScartoCuiController_Exec(t *testing.T) {
 
 	t.Run("setdifficulty invalid", func(t *testing.T) {
 		result := controller.NewScartoCuiController(newMock()).Exec("sd 9")
-		assert.Contains(t, result, "Invalid CPU difficulty")
+		assert.Contains(t, result, msgInvalidCpuDifficultyPrefix())
 	})
 
 	t.Run("hint / log", func(t *testing.T) {

--- a/internal/adapter/controller/ScopaCuiController.go
+++ b/internal/adapter/controller/ScopaCuiController.go
@@ -41,7 +41,7 @@ func (c *ScopaCuiController) Exec(command string) string {
 			case "n", "next":
 				return c.si.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.si.GetConfig()
 					cfg.CpuDifficulty = domain.ScopaCpuDifficulty(v)
 					return c.si.ResetWithConfig(cfg)

--- a/internal/adapter/controller/ScoponeCuiController.go
+++ b/internal/adapter/controller/ScoponeCuiController.go
@@ -43,7 +43,7 @@ func (c *ScoponeCuiController) Exec(command string) string {
 			case "n", "next", "nextround":
 				return c.si.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.si.GetConfig()
 					cfg.CpuDifficulty = domain.ScoponeCpuDifficulty(v)
 					return c.si.ResetWithConfig(cfg)

--- a/internal/adapter/controller/SedmaCuiController.go
+++ b/internal/adapter/controller/SedmaCuiController.go
@@ -50,7 +50,7 @@ func (c *SedmaCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.di.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.di.GetConfig()
 					cfg.CpuDifficulty = domain.SedmaCpuDifficulty(v)
 					return c.di.ResetWithConfig(cfg)

--- a/internal/adapter/controller/SedmaCuiController_test.go
+++ b/internal/adapter/controller/SedmaCuiController_test.go
@@ -72,7 +72,7 @@ func TestSedmaCuiController_Exec(t *testing.T) {
 
 	t.Run("setdifficulty invalid", func(t *testing.T) {
 		result := controller.NewSedmaCuiController(newMock()).Exec("sd 9")
-		assert.Contains(t, result, "Invalid CPU difficulty")
+		assert.Contains(t, result, msgInvalidCpuDifficultyPrefix())
 	})
 
 	t.Run("hint / log", func(t *testing.T) {

--- a/internal/adapter/controller/SevenBridgeCuiController.go
+++ b/internal/adapter/controller/SevenBridgeCuiController.go
@@ -61,7 +61,7 @@ func (c *SevenBridgeCuiController) Exec(command string) string {
 			case "h", "hint":
 				return c.ci.Hint(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.ci.GetConfig()
 					cfg.CpuDifficulty = domain.SevenBridgeCpuDifficulty(v)
 					return c.ci.ResetWithConfig(cfg)

--- a/internal/adapter/controller/SevenBridgeCuiController_test.go
+++ b/internal/adapter/controller/SevenBridgeCuiController_test.go
@@ -144,12 +144,12 @@ func TestSevenBridgeCuiController_Exec(t *testing.T) {
 
 	t.Run("setdifficulty out of range", func(t *testing.T) {
 		c := controller.NewSevenBridgeCuiController(newMock())
-		assert.Contains(t, c.Exec("sd 9"), "Invalid CPU difficulty")
+		assert.Contains(t, c.Exec("sd 9"), msgInvalidCpuDifficultyPrefix())
 	})
 
 	t.Run("setdifficulty no args", func(t *testing.T) {
 		c := controller.NewSevenBridgeCuiController(newMock())
-		assert.Contains(t, c.Exec("sd"), "CPU difficulty is required")
+		assert.Contains(t, c.Exec("sd"), msgCpuDifficultyRequired())
 	})
 
 	t.Run("setlimit valid", func(t *testing.T) {

--- a/internal/adapter/controller/SheepsheadCuiController.go
+++ b/internal/adapter/controller/SheepsheadCuiController.go
@@ -65,7 +65,7 @@ func (c *SheepsheadCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.si.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.si.GetConfig()
 					cfg.CpuDifficulty = domain.SheepsheadCpuDifficulty(v)
 					return c.si.ResetWithConfig(cfg)

--- a/internal/adapter/controller/SheepsheadCuiController_test.go
+++ b/internal/adapter/controller/SheepsheadCuiController_test.go
@@ -144,7 +144,7 @@ func TestSheepsheadCuiController_Exec(t *testing.T) {
 
 	t.Run("setdifficulty invalid", func(t *testing.T) {
 		result := controller.NewSheepsheadCuiController(newMock()).Exec("sd 9")
-		assert.Contains(t, result, "Invalid CPU difficulty")
+		assert.Contains(t, result, msgInvalidCpuDifficultyPrefix())
 	})
 
 	t.Run("setchips", func(t *testing.T) {

--- a/internal/adapter/controller/ShitheadCuiController.go
+++ b/internal/adapter/controller/ShitheadCuiController.go
@@ -104,7 +104,7 @@ func (c *ShitheadCuiController) Exec(command string) string {
 				indices, skipped := cuiutil.ParseIntSlice(args)
 				return cuiutil.PrependSkippedWarning(c.si.Play(indices), skipped), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.si.GetConfig()
 					cfg.CpuDifficulty = domain.ShitheadCpuDifficulty(v)
 					return c.si.ResetWithConfig(cfg)

--- a/internal/adapter/controller/ShitheadCuiController_test.go
+++ b/internal/adapter/controller/ShitheadCuiController_test.go
@@ -58,12 +58,12 @@ func TestShitheadCuiController_Exec(t *testing.T) {
 
 	t.Run("set difficulty requires arg", func(t *testing.T) {
 		c := controller.NewShitheadCuiController(newMock())
-		assert.Contains(t, c.Exec("sd"), "required")
+		assert.Contains(t, c.Exec("sd"), msgCpuDifficultyRequired())
 	})
 
 	t.Run("set difficulty invalid arg", func(t *testing.T) {
 		c := controller.NewShitheadCuiController(newMock())
-		assert.Contains(t, c.Exec("sd 9"), "Invalid")
+		assert.Contains(t, c.Exec("sd 9"), msgInvalidCpuDifficultyPrefix())
 	})
 
 	t.Run("setrule list", func(t *testing.T) {

--- a/internal/adapter/controller/SixCardGolfCuiController.go
+++ b/internal/adapter/controller/SixCardGolfCuiController.go
@@ -50,7 +50,7 @@ func (c *SixCardGolfCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.ci.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.ci.GetConfig()
 					cfg.CpuDifficulty = domain.SixCardGolfCpuDifficulty(v)
 					return c.ci.ResetWithConfig(cfg)

--- a/internal/adapter/controller/SkatCuiController.go
+++ b/internal/adapter/controller/SkatCuiController.go
@@ -98,7 +98,7 @@ func (c *SkatCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.si.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.si.GetConfig()
 					cfg.CpuDifficulty = domain.SkatCpuDifficulty(v)
 					return c.si.ResetWithConfig(cfg)

--- a/internal/adapter/controller/SoloWhistCuiController.go
+++ b/internal/adapter/controller/SoloWhistCuiController.go
@@ -58,7 +58,7 @@ func (c *SoloWhistCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.di.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.di.GetConfig()
 					cfg.CpuDifficulty = domain.SoloWhistCpuDifficulty(v)
 					return c.di.ResetWithConfig(cfg)

--- a/internal/adapter/controller/SoloWhistCuiController_test.go
+++ b/internal/adapter/controller/SoloWhistCuiController_test.go
@@ -97,7 +97,7 @@ func TestSoloWhistCuiController_Exec(t *testing.T) {
 
 	t.Run("setdifficulty invalid", func(t *testing.T) {
 		result := controller.NewSoloWhistCuiController(newMock()).Exec("sd 9")
-		assert.Contains(t, result, "Invalid CPU difficulty")
+		assert.Contains(t, result, msgInvalidCpuDifficultyPrefix())
 	})
 
 	t.Run("hint / log", func(t *testing.T) {

--- a/internal/adapter/controller/SpadesCuiController.go
+++ b/internal/adapter/controller/SpadesCuiController.go
@@ -53,7 +53,7 @@ func (c *SpadesCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.si.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.si.GetConfig()
 					cfg.CpuDifficulty = domain.SpadesCpuDifficulty(v)
 					return c.si.ResetWithConfig(cfg)

--- a/internal/adapter/controller/SpadesCuiController_test.go
+++ b/internal/adapter/controller/SpadesCuiController_test.go
@@ -187,25 +187,25 @@ func TestSpadesCuiController_Exec(t *testing.T) {
 	t.Run("setdifficulty no args", func(t *testing.T) {
 		c := controller.NewSpadesCuiController(newMock())
 		result := c.Exec("sd")
-		assert.Contains(t, result, "required")
+		assert.Contains(t, result, msgCpuDifficultyRequired())
 	})
 
 	t.Run("setdifficulty invalid value", func(t *testing.T) {
 		c := controller.NewSpadesCuiController(newMock())
 		result := c.Exec("sd abc")
-		assert.Contains(t, result, "Invalid CPU difficulty")
+		assert.Contains(t, result, msgInvalidCpuDifficultyPrefix())
 	})
 
 	t.Run("setdifficulty negative", func(t *testing.T) {
 		c := controller.NewSpadesCuiController(newMock())
 		result := c.Exec("sd -1")
-		assert.Equal(t, "Invalid CPU difficulty: -1. Please enter 0-2.", result)
+		assert.Equal(t, msgInvalidCpuDifficulty("-1"), result)
 	})
 
 	t.Run("setdifficulty over 2", func(t *testing.T) {
 		c := controller.NewSpadesCuiController(newMock())
 		result := c.Exec("sd 3")
-		assert.Equal(t, "Invalid CPU difficulty: 3. Please enter 0-2.", result)
+		assert.Equal(t, msgInvalidCpuDifficulty("3"), result)
 	})
 
 	// setlimit

--- a/internal/adapter/controller/SpoilFiveCuiController.go
+++ b/internal/adapter/controller/SpoilFiveCuiController.go
@@ -50,7 +50,7 @@ func (c *SpoilFiveCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.di.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.di.GetConfig()
 					cfg.CpuDifficulty = domain.SpoilFiveCpuDifficulty(v)
 					return c.di.ResetWithConfig(cfg)

--- a/internal/adapter/controller/SpoilFiveCuiController_test.go
+++ b/internal/adapter/controller/SpoilFiveCuiController_test.go
@@ -72,7 +72,7 @@ func TestSpoilFiveCuiController_Exec(t *testing.T) {
 
 	t.Run("setdifficulty invalid", func(t *testing.T) {
 		result := controller.NewSpoilFiveCuiController(newMock()).Exec("sd 9")
-		assert.Contains(t, result, "Invalid CPU difficulty")
+		assert.Contains(t, result, msgInvalidCpuDifficultyPrefix())
 	})
 
 	t.Run("hint / log", func(t *testing.T) {

--- a/internal/adapter/controller/SuecaCuiController.go
+++ b/internal/adapter/controller/SuecaCuiController.go
@@ -50,7 +50,7 @@ func (c *SuecaCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.di.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.di.GetConfig()
 					cfg.CpuDifficulty = domain.SuecaCpuDifficulty(v)
 					return c.di.ResetWithConfig(cfg)

--- a/internal/adapter/controller/SuecaCuiController_test.go
+++ b/internal/adapter/controller/SuecaCuiController_test.go
@@ -72,7 +72,7 @@ func TestSuecaCuiController_Exec(t *testing.T) {
 
 	t.Run("setdifficulty invalid", func(t *testing.T) {
 		result := controller.NewSuecaCuiController(newMock()).Exec("sd 9")
-		assert.Contains(t, result, "Invalid CPU difficulty")
+		assert.Contains(t, result, msgInvalidCpuDifficultyPrefix())
 	})
 
 	t.Run("hint / log", func(t *testing.T) {

--- a/internal/adapter/controller/TablanetCuiController.go
+++ b/internal/adapter/controller/TablanetCuiController.go
@@ -49,7 +49,7 @@ func (c *TablanetCuiController) Exec(command string) string {
 			case "n", "next", "nr", "nextround":
 				return c.bi.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.bi.GetConfig()
 					cfg.CpuDifficulty = domain.TablanetCpuDifficulty(v)
 					return c.bi.ResetWithConfig(cfg)

--- a/internal/adapter/controller/TarneebCuiController.go
+++ b/internal/adapter/controller/TarneebCuiController.go
@@ -59,7 +59,7 @@ func (c *TarneebCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.ti.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.ti.GetConfig()
 					cfg.CpuDifficulty = domain.TarneebCpuDifficulty(v)
 					return c.ti.ResetWithConfig(cfg)

--- a/internal/adapter/controller/TarocchiniCuiController.go
+++ b/internal/adapter/controller/TarocchiniCuiController.go
@@ -57,7 +57,7 @@ func (c *TarocchiniCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.di.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.di.GetConfig()
 					cfg.CpuDifficulty = domain.TarocchiniCpuDifficulty(v)
 					return c.di.ResetWithConfig(cfg)

--- a/internal/adapter/controller/TarocchiniCuiController_test.go
+++ b/internal/adapter/controller/TarocchiniCuiController_test.go
@@ -95,7 +95,7 @@ func TestTarocchiniCuiController_Exec(t *testing.T) {
 	})
 
 	t.Run("setdifficulty invalid", func(t *testing.T) {
-		assert.Contains(t, controller.NewTarocchiniCuiController(newMock()).Exec("sd 9"), "Invalid CPU difficulty")
+		assert.Contains(t, controller.NewTarocchiniCuiController(newMock()).Exec("sd 9"), msgInvalidCpuDifficultyPrefix())
 	})
 
 	t.Run("hint / log", func(t *testing.T) {

--- a/internal/adapter/controller/TeenPattiCuiController.go
+++ b/internal/adapter/controller/TeenPattiCuiController.go
@@ -82,7 +82,7 @@ func (c *TeenPattiCuiController) Exec(command string) string {
 			case "n", "next", "nextround":
 				return c.ti.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.ti.GetConfig()
 					cfg.CpuDifficulty = domain.TeenPattiCpuDifficulty(v)
 					return c.ti.ResetWithConfig(cfg)

--- a/internal/adapter/controller/TeenPattiCuiController_test.go
+++ b/internal/adapter/controller/TeenPattiCuiController_test.go
@@ -140,7 +140,7 @@ func TestTeenPattiCuiController_Exec(t *testing.T) {
 
 	t.Run("setdifficulty invalid", func(t *testing.T) {
 		result := controller.NewTeenPattiCuiController(newMock()).Exec("sd 9")
-		assert.Contains(t, result, "Invalid CPU difficulty")
+		assert.Contains(t, result, msgInvalidCpuDifficultyPrefix())
 	})
 
 	t.Run("setante", func(t *testing.T) {

--- a/internal/adapter/controller/ThirtyOneCuiController.go
+++ b/internal/adapter/controller/ThirtyOneCuiController.go
@@ -48,7 +48,7 @@ func (c *ThirtyOneCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.ci.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.ci.GetConfig()
 					cfg.CpuDifficulty = domain.ThirtyOneCpuDifficulty(v)
 					return c.ci.ResetWithConfig(cfg)

--- a/internal/adapter/controller/ThirtyOneCuiController_test.go
+++ b/internal/adapter/controller/ThirtyOneCuiController_test.go
@@ -97,9 +97,9 @@ func TestThirtyOneCuiController_Exec(t *testing.T) {
 
 	t.Run("setdifficulty errors", func(t *testing.T) {
 		c := controller.NewThirtyOneCuiController(newMock())
-		assert.Contains(t, c.Exec("sd"), "required")
-		assert.Contains(t, c.Exec("sd abc"), "Invalid CPU difficulty")
-		assert.Contains(t, c.Exec("sd 9"), "Invalid CPU difficulty")
+		assert.Contains(t, c.Exec("sd"), msgCpuDifficultyRequired())
+		assert.Contains(t, c.Exec("sd abc"), msgInvalidCpuDifficultyPrefix())
+		assert.Contains(t, c.Exec("sd 9"), msgInvalidCpuDifficultyPrefix())
 	})
 
 	t.Run("setlives valid", func(t *testing.T) {

--- a/internal/adapter/controller/ThreeCardBragCuiController.go
+++ b/internal/adapter/controller/ThreeCardBragCuiController.go
@@ -70,7 +70,7 @@ func (c *ThreeCardBragCuiController) Exec(command string) string {
 			case "n", "next", "nextround":
 				return c.ti.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.ti.GetConfig()
 					cfg.CpuDifficulty = domain.ThreeCardBragCpuDifficulty(v)
 					return c.ti.ResetWithConfig(cfg)

--- a/internal/adapter/controller/ThreeCardBragCuiController_test.go
+++ b/internal/adapter/controller/ThreeCardBragCuiController_test.go
@@ -114,7 +114,7 @@ func TestThreeCardBragCuiController_Exec(t *testing.T) {
 
 	t.Run("setdifficulty invalid", func(t *testing.T) {
 		result := controller.NewThreeCardBragCuiController(newMock()).Exec("sd 9")
-		assert.Contains(t, result, "Invalid CPU difficulty")
+		assert.Contains(t, result, msgInvalidCpuDifficultyPrefix())
 	})
 
 	t.Run("setante", func(t *testing.T) {

--- a/internal/adapter/controller/ThreeThirteenCuiController.go
+++ b/internal/adapter/controller/ThreeThirteenCuiController.go
@@ -47,7 +47,7 @@ func (c *ThreeThirteenCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.ci.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.ci.GetConfig()
 					cfg.CpuDifficulty = domain.ThreeThirteenCpuDifficulty(v)
 					return c.ci.ResetWithConfig(cfg)

--- a/internal/adapter/controller/TichuCuiController.go
+++ b/internal/adapter/controller/TichuCuiController.go
@@ -43,7 +43,7 @@ func (c *TichuCuiController) Exec(command string) string {
 					return c.tgi.Declare(v)
 				})
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Normal, 1=Easy, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequiredAlt", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.tgi.GetConfig()
 					cfg.CpuDifficulty = domain.TichuCpuDifficulty(v)
 					return c.tgi.ResetWithConfig(cfg)

--- a/internal/adapter/controller/TichuCuiController_test.go
+++ b/internal/adapter/controller/TichuCuiController_test.go
@@ -71,7 +71,7 @@ func TestTichuCuiController_Exec(t *testing.T) {
 	})
 	t.Run("setdifficulty invalid", func(t *testing.T) {
 		c := controller.NewTichuCuiController(newMock())
-		assert.Contains(t, c.Exec("sd 9"), "Invalid CPU difficulty")
+		assert.Contains(t, c.Exec("sd 9"), msgInvalidCpuDifficultyPrefix())
 	})
 	t.Run("log", func(t *testing.T) {
 		m := newMock()

--- a/internal/adapter/controller/TienLenCuiController.go
+++ b/internal/adapter/controller/TienLenCuiController.go
@@ -33,7 +33,7 @@ func (c *TienLenCuiController) Exec(command string) string {
 				indices, skipped := cuiutil.ParseIntSlice(args)
 				return cuiutil.PrependSkippedWarning(c.tli.Play(indices), skipped), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Normal, 1=Easy, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequiredAlt", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.tli.GetConfig()
 					cfg.CpuDifficulty = domain.TienLenCpuDifficulty(v)
 					return c.tli.ResetWithConfig(cfg)

--- a/internal/adapter/controller/TienLenCuiController_test.go
+++ b/internal/adapter/controller/TienLenCuiController_test.go
@@ -66,9 +66,9 @@ func TestTienLenCuiController_Exec(t *testing.T) {
 
 	t.Run("setdifficulty errors", func(t *testing.T) {
 		c := controller.NewTienLenCuiController(newMock())
-		assert.Contains(t, c.Exec("sd"), "required")
-		assert.Contains(t, c.Exec("sd abc"), "Invalid CPU difficulty")
-		assert.Contains(t, c.Exec("sd 9"), "Invalid CPU difficulty")
+		assert.Contains(t, c.Exec("sd"), msgCpuDifficultyRequiredAlt())
+		assert.Contains(t, c.Exec("sd abc"), msgInvalidCpuDifficultyPrefix())
+		assert.Contains(t, c.Exec("sd 9"), msgInvalidCpuDifficultyPrefix())
 	})
 
 	t.Run("log", func(t *testing.T) {

--- a/internal/adapter/controller/TonkCuiController.go
+++ b/internal/adapter/controller/TonkCuiController.go
@@ -45,7 +45,7 @@ func (c *TonkCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.ci.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.ci.GetConfig()
 					cfg.CpuDifficulty = domain.TonkCpuDifficulty(v)
 					return c.ci.ResetWithConfig(cfg)

--- a/internal/adapter/controller/TonkCuiController_test.go
+++ b/internal/adapter/controller/TonkCuiController_test.go
@@ -108,10 +108,10 @@ func TestTonkCuiController_Exec(t *testing.T) {
 
 	t.Run("setdifficulty errors", func(t *testing.T) {
 		c := controller.NewTonkCuiController(newMock())
-		assert.Contains(t, c.Exec("sd"), "required")
-		assert.Contains(t, c.Exec("sd abc"), "Invalid CPU difficulty")
-		assert.Equal(t, "Invalid CPU difficulty: -1. Please enter 0-2.", c.Exec("sd -1"))
-		assert.Equal(t, "Invalid CPU difficulty: 3. Please enter 0-2.", c.Exec("sd 3"))
+		assert.Contains(t, c.Exec("sd"), msgCpuDifficultyRequired())
+		assert.Contains(t, c.Exec("sd abc"), msgInvalidCpuDifficultyPrefix())
+		assert.Equal(t, msgInvalidCpuDifficulty("-1"), c.Exec("sd -1"))
+		assert.Equal(t, msgInvalidCpuDifficulty("3"), c.Exec("sd 3"))
 	})
 
 	t.Run("setlimit valid", func(t *testing.T) {

--- a/internal/adapter/controller/TressetteCuiController.go
+++ b/internal/adapter/controller/TressetteCuiController.go
@@ -52,7 +52,7 @@ func (c *TressetteCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.ti.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.ti.GetConfig()
 					cfg.CpuDifficulty = domain.TressetteCpuDifficulty(v)
 					return c.ti.ResetWithConfig(cfg)

--- a/internal/adapter/controller/TressetteCuiController_test.go
+++ b/internal/adapter/controller/TressetteCuiController_test.go
@@ -72,7 +72,7 @@ func TestTressetteCuiController_Exec(t *testing.T) {
 
 	t.Run("setdifficulty invalid", func(t *testing.T) {
 		result := controller.NewTressetteCuiController(newMock()).Exec("sd 9")
-		assert.Contains(t, result, "Invalid CPU difficulty")
+		assert.Contains(t, result, msgInvalidCpuDifficultyPrefix())
 	})
 
 	t.Run("settarget", func(t *testing.T) {

--- a/internal/adapter/controller/TrogguCuiController.go
+++ b/internal/adapter/controller/TrogguCuiController.go
@@ -56,9 +56,9 @@ func (c *TrogguCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.ti.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args,
-					"CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).",
-					"Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args,
+					"cpuDifficultyRequired",
+					"invalidCpuDifficulty", 0, 2, func(v int) string {
 						cfg := c.ti.GetConfig()
 						cfg.CpuDifficulty = domain.TrogguCpuDifficulty(v)
 						return c.ti.ResetWithConfig(cfg)

--- a/internal/adapter/controller/TrogguCuiController_test.go
+++ b/internal/adapter/controller/TrogguCuiController_test.go
@@ -104,7 +104,7 @@ func TestTrogguCuiController_Exec(t *testing.T) {
 	t.Run("set difficulty rejects out-of-range", func(t *testing.T) {
 		m := newMock()
 		out := controller.NewTrogguCuiController(m).Exec("sd 9")
-		assert.Contains(t, out, "Invalid CPU difficulty")
+		assert.Contains(t, out, msgInvalidCpuDifficultyPrefix())
 		m.AssertNotCalled(t, "ResetWithConfig", mock.Anything)
 	})
 	t.Run("set deals", func(t *testing.T) {

--- a/internal/adapter/controller/TuteCuiController.go
+++ b/internal/adapter/controller/TuteCuiController.go
@@ -56,7 +56,7 @@ func (c *TuteCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.di.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.di.GetConfig()
 					cfg.CpuDifficulty = domain.TuteCpuDifficulty(v)
 					return c.di.ResetWithConfig(cfg)

--- a/internal/adapter/controller/TuteCuiController_test.go
+++ b/internal/adapter/controller/TuteCuiController_test.go
@@ -105,7 +105,7 @@ func TestTuteCuiController_Exec(t *testing.T) {
 
 	t.Run("setdifficulty invalid", func(t *testing.T) {
 		result := controller.NewTuteCuiController(newMock()).Exec("sd 9")
-		assert.Contains(t, result, "Invalid CPU difficulty")
+		assert.Contains(t, result, msgInvalidCpuDifficultyPrefix())
 	})
 
 	t.Run("hint / log", func(t *testing.T) {

--- a/internal/adapter/controller/TwentyNineCuiController.go
+++ b/internal/adapter/controller/TwentyNineCuiController.go
@@ -58,7 +58,7 @@ func (c *TwentyNineCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.di.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.di.GetConfig()
 					cfg.CpuDifficulty = domain.TwentyNineCpuDifficulty(v)
 					return c.di.ResetWithConfig(cfg)

--- a/internal/adapter/controller/TwentyNineCuiController_test.go
+++ b/internal/adapter/controller/TwentyNineCuiController_test.go
@@ -104,7 +104,7 @@ func TestTwentyNineCuiController_Exec(t *testing.T) {
 
 	t.Run("setdifficulty invalid", func(t *testing.T) {
 		result := controller.NewTwentyNineCuiController(newMock()).Exec("sd 9")
-		assert.Contains(t, result, "Invalid CPU difficulty")
+		assert.Contains(t, result, msgInvalidCpuDifficultyPrefix())
 	})
 
 	t.Run("hint / log", func(t *testing.T) {

--- a/internal/adapter/controller/TwoTenJackCuiController.go
+++ b/internal/adapter/controller/TwoTenJackCuiController.go
@@ -52,7 +52,7 @@ func (c *TwoTenJackCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.ti.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.ti.GetConfig()
 					cfg.CpuDifficulty = domain.TwoTenJackCpuDifficulty(v)
 					return c.ti.ResetWithConfig(cfg)

--- a/internal/adapter/controller/TwoTenJackCuiController_test.go
+++ b/internal/adapter/controller/TwoTenJackCuiController_test.go
@@ -105,9 +105,9 @@ func TestTwoTenJackCuiController_Exec(t *testing.T) {
 		expected := domain.DefaultTwoTenJackConfig()
 		expected.CpuDifficulty = domain.TwoTenJackCpuDifficultyHard
 		m.AssertCalled(t, "ResetWithConfig", expected)
-		assert.Contains(t, c.Exec("sd"), "required")
-		assert.Contains(t, c.Exec("sd abc"), "Invalid CPU difficulty")
-		assert.Contains(t, c.Exec("sd 3"), "Invalid CPU difficulty")
+		assert.Contains(t, c.Exec("sd"), msgCpuDifficultyRequired())
+		assert.Contains(t, c.Exec("sd abc"), msgInvalidCpuDifficultyPrefix())
+		assert.Contains(t, c.Exec("sd 3"), msgInvalidCpuDifficultyPrefix())
 	})
 
 	t.Run("setlimit", func(t *testing.T) {

--- a/internal/adapter/controller/TysiacCuiController.go
+++ b/internal/adapter/controller/TysiacCuiController.go
@@ -66,7 +66,7 @@ func (c *TysiacCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.di.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.di.GetConfig()
 					cfg.CpuDifficulty = domain.TysiacCpuDifficulty(v)
 					return c.di.ResetWithConfig(cfg)

--- a/internal/adapter/controller/TysiacCuiController_test.go
+++ b/internal/adapter/controller/TysiacCuiController_test.go
@@ -110,7 +110,7 @@ func TestTysiacCuiController_Exec(t *testing.T) {
 
 	t.Run("setdifficulty invalid", func(t *testing.T) {
 		result := controller.NewTysiacCuiController(newMock()).Exec("sd 9")
-		assert.Contains(t, result, "Invalid CPU difficulty")
+		assert.Contains(t, result, msgInvalidCpuDifficultyPrefix())
 	})
 
 	t.Run("hint / log", func(t *testing.T) {

--- a/internal/adapter/controller/UltiCuiController.go
+++ b/internal/adapter/controller/UltiCuiController.go
@@ -76,7 +76,7 @@ func (c *UltiCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.di.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.di.GetConfig()
 					cfg.CpuDifficulty = domain.UltiCpuDifficulty(v)
 					return c.di.ResetWithConfig(cfg)

--- a/internal/adapter/controller/UltiCuiController_test.go
+++ b/internal/adapter/controller/UltiCuiController_test.go
@@ -132,7 +132,7 @@ func TestUltiCuiController_Exec(t *testing.T) {
 
 	t.Run("setdifficulty invalid", func(t *testing.T) {
 		result := controller.NewUltiCuiController(newMock()).Exec("sd 9")
-		assert.Contains(t, result, "Invalid CPU difficulty")
+		assert.Contains(t, result, msgInvalidCpuDifficultyPrefix())
 	})
 
 	t.Run("hint / log", func(t *testing.T) {

--- a/internal/adapter/controller/ViraCuiController.go
+++ b/internal/adapter/controller/ViraCuiController.go
@@ -58,7 +58,7 @@ func (c *ViraCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.di.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.di.GetConfig()
 					cfg.CpuDifficulty = domain.ViraCpuDifficulty(v)
 					return c.di.ResetWithConfig(cfg)

--- a/internal/adapter/controller/ViraCuiController_test.go
+++ b/internal/adapter/controller/ViraCuiController_test.go
@@ -109,7 +109,7 @@ func TestViraCuiController_Exec(t *testing.T) {
 
 	t.Run("setdifficulty invalid", func(t *testing.T) {
 		result := controller.NewViraCuiController(newMock()).Exec("sd 9")
-		assert.Contains(t, result, "Invalid CPU difficulty")
+		assert.Contains(t, result, msgInvalidCpuDifficultyPrefix())
 	})
 
 	t.Run("hint / log", func(t *testing.T) {

--- a/internal/adapter/controller/WattenCuiController.go
+++ b/internal/adapter/controller/WattenCuiController.go
@@ -63,7 +63,7 @@ func (c *WattenCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.wi.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.wi.GetConfig()
 					cfg.CpuDifficulty = domain.WattenCpuDifficulty(v)
 					return c.wi.ResetWithConfig(cfg)

--- a/internal/adapter/controller/WhistCuiController.go
+++ b/internal/adapter/controller/WhistCuiController.go
@@ -50,7 +50,7 @@ func (c *WhistCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.wi.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.wi.GetConfig()
 					cfg.CpuDifficulty = domain.WhistCpuDifficulty(v)
 					return c.wi.ResetWithConfig(cfg)

--- a/internal/adapter/controller/WizardCuiController.go
+++ b/internal/adapter/controller/WizardCuiController.go
@@ -50,7 +50,7 @@ func (c *WizardCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.oi.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.oi.GetConfig()
 					cfg.CpuDifficulty = domain.WizardCpuDifficulty(v)
 					return c.oi.ResetWithConfig(cfg)

--- a/internal/adapter/controller/WizardCuiController_test.go
+++ b/internal/adapter/controller/WizardCuiController_test.go
@@ -81,11 +81,11 @@ func TestWizardCuiController_Exec_Errors(t *testing.T) {
 	// Missing args
 	assert.Contains(t, c.Exec("b"), "required")
 	assert.Contains(t, c.Exec("p"), msgCardIndexRequired())
-	assert.Contains(t, c.Exec("sd"), "required")
+	assert.Contains(t, c.Exec("sd"), msgCpuDifficultyRequired())
 
 	// Invalid args
 	assert.Contains(t, c.Exec("b abc"), "Invalid")
-	assert.Contains(t, c.Exec("sd 99"), "Invalid")
+	assert.Contains(t, c.Exec("sd 99"), msgInvalidCpuDifficultyPrefix())
 }
 
 func TestWizardCuiController_Exec_UnknownCommand(t *testing.T) {

--- a/internal/adapter/controller/YanivCuiController.go
+++ b/internal/adapter/controller/YanivCuiController.go
@@ -46,7 +46,7 @@ func (c *YanivCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.ci.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.ci.GetConfig()
 					cfg.CpuDifficulty = domain.YanivCpuDifficulty(v)
 					return c.ci.ResetWithConfig(cfg)

--- a/internal/adapter/controller/YanivCuiController_test.go
+++ b/internal/adapter/controller/YanivCuiController_test.go
@@ -94,8 +94,8 @@ func TestYanivCuiController_Exec(t *testing.T) {
 
 	t.Run("setdifficulty errors", func(t *testing.T) {
 		c := controller.NewYanivCuiController(newMock())
-		assert.Contains(t, c.Exec("sd"), "required")
-		assert.Contains(t, c.Exec("sd 9"), "Invalid CPU difficulty")
+		assert.Contains(t, c.Exec("sd"), msgCpuDifficultyRequired())
+		assert.Contains(t, c.Exec("sd 9"), msgInvalidCpuDifficultyPrefix())
 	})
 
 	t.Run("setlimit valid", func(t *testing.T) {

--- a/internal/adapter/controller/ZhengCuiController.go
+++ b/internal/adapter/controller/ZhengCuiController.go
@@ -33,7 +33,7 @@ func (c *ZhengCuiController) Exec(command string) string {
 				indices, skipped := cuiutil.ParseIntSlice(args)
 				return cuiutil.PrependSkippedWarning(c.zi.Play(indices), skipped), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Normal, 1=Easy, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequiredAlt", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.zi.GetConfig()
 					cfg.CpuDifficulty = domain.ZhengCpuDifficulty(v)
 					return c.zi.ResetWithConfig(cfg)

--- a/internal/adapter/controller/ZhengCuiController_test.go
+++ b/internal/adapter/controller/ZhengCuiController_test.go
@@ -66,9 +66,9 @@ func TestZhengCuiController_Exec(t *testing.T) {
 
 	t.Run("setdifficulty errors", func(t *testing.T) {
 		c := controller.NewZhengCuiController(newMock())
-		assert.Contains(t, c.Exec("sd"), "required")
-		assert.Contains(t, c.Exec("sd abc"), "Invalid CPU difficulty")
-		assert.Contains(t, c.Exec("sd 9"), "Invalid CPU difficulty")
+		assert.Contains(t, c.Exec("sd"), msgCpuDifficultyRequiredAlt())
+		assert.Contains(t, c.Exec("sd abc"), msgInvalidCpuDifficultyPrefix())
+		assert.Contains(t, c.Exec("sd 9"), msgInvalidCpuDifficultyPrefix())
 	})
 
 	t.Run("log", func(t *testing.T) {

--- a/internal/adapter/controller/ZwanzigerrufenCuiController.go
+++ b/internal/adapter/controller/ZwanzigerrufenCuiController.go
@@ -60,9 +60,9 @@ func (c *ZwanzigerrufenCuiController) Exec(command string) string {
 			case "nr", "nextround":
 				return c.zi.NextRound(), true
 			case "sd", "setdifficulty":
-				return cuiutil.WithParsedInt(args,
-					"CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).",
-					"Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
+				return cuiutil.WithParsedIntKeys(args,
+					"cpuDifficultyRequired",
+					"invalidCpuDifficulty", 0, 2, func(v int) string {
 						cfg := c.zi.GetConfig()
 						cfg.CpuDifficulty = domain.ZwanzigerrufenCpuDifficulty(v)
 						return c.zi.ResetWithConfig(cfg)

--- a/internal/adapter/controller/ZwanzigerrufenCuiController_test.go
+++ b/internal/adapter/controller/ZwanzigerrufenCuiController_test.go
@@ -116,7 +116,7 @@ func TestZwanzigerrufenCuiController_Exec(t *testing.T) {
 	t.Run("set difficulty rejects out-of-range", func(t *testing.T) {
 		m := newMock()
 		out := controller.NewZwanzigerrufenCuiController(m).Exec("sd 9")
-		assert.Contains(t, out, "Invalid CPU difficulty")
+		assert.Contains(t, out, msgInvalidCpuDifficultyPrefix())
 		m.AssertNotCalled(t, "ResetWithConfig", mock.Anything)
 	})
 	t.Run("set deals", func(t *testing.T) {

--- a/internal/adapter/controller/cui_msg_ext_test.go
+++ b/internal/adapter/controller/cui_msg_ext_test.go
@@ -35,3 +35,20 @@ func msgInvalidDiscardIndexPrefix() string {
 	stem := strings.SplitN(i18n.Tf("invalidDiscardIndex", "val", "\x00"), "\x00", 2)[0]
 	return strings.TrimRight(stem, ":. ")
 }
+
+// The CPU-difficulty rejections. The prefix form is for the assertions that
+// only check that the value was refused; see msgInvalidCardIndexPrefix.
+func msgInvalidCpuDifficulty(val string) string {
+	return i18n.Tf("invalidCpuDifficulty", "val", val)
+}
+
+func msgInvalidCpuDifficultyPrefix() string {
+	stem := strings.SplitN(i18n.Tf("invalidCpuDifficulty", "val", "\x00"), "\x00", 2)[0]
+	return strings.TrimRight(stem, ":. ")
+}
+
+func msgCpuDifficultyRequired() string { return i18n.T("cpuDifficultyRequired") }
+
+// msgCpuDifficultyRequiredAlt is the wording used by the games whose difficulty
+// scale starts at Normal.
+func msgCpuDifficultyRequiredAlt() string { return i18n.T("cpuDifficultyRequiredAlt") }

--- a/internal/adapter/controller/cui_msg_test.go
+++ b/internal/adapter/controller/cui_msg_test.go
@@ -2,7 +2,11 @@
 
 package controller
 
-import "github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
+import (
+	"strings"
+
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
+)
 
 // msgCardIndexRequired and msgInvalidCardIndex render the two card-index
 // rejections the way the controllers do.
@@ -18,3 +22,10 @@ import "github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 func msgCardIndexRequired() string { return i18n.T("cardIndexRequired") }
 
 func msgInvalidCardIndex(val string) string { return i18n.Tf("invalidCardIndex", "val", val) }
+
+func msgInvalidCpuDifficultyPrefix() string {
+	stem := strings.SplitN(i18n.Tf("invalidCpuDifficulty", "val", "\x00"), "\x00", 2)[0]
+	return strings.TrimRight(stem, ":. ")
+}
+
+func msgCpuDifficultyRequired() string { return i18n.T("cpuDifficultyRequired") }

--- a/internal/i18n/locales/en/common.json
+++ b/internal/i18n/locales/en/common.json
@@ -151,5 +151,8 @@
   "cardIndexRequiredField": "Card index is required (e.g. p 0, or p 0 3 to pick a field card).",
   "cardIndexRequiredCapture": "Card index is required (e.g. p 0, or p 0 1 2 to capture table cards).",
   "cardIndexesRequiredMeld": "Card indexes are required (e.g. meld 1 4 7).",
-  "invalidIndexFromOne": "Invalid index. Please enter numbers from 1."
+  "invalidIndexFromOne": "Invalid index. Please enter numbers from 1.",
+  "cpuDifficultyRequired": "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).",
+  "cpuDifficultyRequiredAlt": "CPU difficulty is required (0=Normal, 1=Easy, 2=Hard).",
+  "invalidCpuDifficulty": "Invalid CPU difficulty: {{val}}. Please enter 0-2."
 }

--- a/internal/i18n/locales/ja/common.json
+++ b/internal/i18n/locales/ja/common.json
@@ -151,5 +151,8 @@
   "cardIndexRequiredField": "カードのインデックスを指定してください (例: p 0 / 場札を取るなら p 0 3)。",
   "cardIndexRequiredCapture": "カードのインデックスを指定してください (例: p 0 / 場札を取るなら p 0 1 2)。",
   "cardIndexesRequiredMeld": "メルドするカードのインデックスを指定してください (例: meld 1 4 7)。",
-  "invalidIndexFromOne": "無効なインデックスです。1 以上の数値を入力してください。"
+  "invalidIndexFromOne": "無効なインデックスです。1 以上の数値を入力してください。",
+  "cpuDifficultyRequired": "CPU難易度を指定してください (0=Easy, 1=Normal, 2=Hard)。",
+  "cpuDifficultyRequiredAlt": "CPU難易度を指定してください (0=Normal, 1=Easy, 2=Hard)。",
+  "invalidCpuDifficulty": "無効なCPU難易度です: {{val}}。0-2 を指定してください。"
 }


### PR DESCRIPTION
## 変更

#5384 の 2 つ目のファミリです。#5385 (card index) と同じ手順で、**CPU 難易度の 120 箇所**を i18n に載せました。

```
[ja] before:  sd zz  -> "Invalid CPU difficulty: zz. Please enter 0-2."
[ja] after:   sd zz  -> "無効なCPU難易度です: zz。0-2 を指定してください。"
```

### 2 つの文言を統合していません

大半のゲームは `0=Easy, 1=Normal, 2=Hard` ですが、**8 ゲームは `0=Normal, 1=Easy, 2=Hard`** です。1 つのキーに潰すと、その 8 ゲームのプレイヤーに**間違った対応表**を見せることになるので、`cpuDifficultyRequired` と `cpuDifficultyRequiredAlt` に分けています。

### 実測した効果

ヘルプのコマンド表**と設定表**にある引数つきコマンド全件に、ja で不正な引数を与えた結果です（`sd` は設定側なので、コマンド表だけを見る #5385 の指標には出ません）。

| | 英語で返る | 日本語で返る |
|---|---|---|
| Before (このブランチの前) | 439 | 480 |
| After | **322** | **597** |

**117 コマンドが日本語で応答するようになりました。**

## テスト

103 のリテラルをヘルパ経由に置き換え、さらに **30 のアサートが `"required"` / `"Invalid"` という素の英単語**を見ていたのも直しました。後者はコントローラが英語で答えていたから通っていたもので、放置すると「訳した結果たまたまその語を含む」ときだけ通る、理由の違う緑になります。

置換は件数を先に数えてから書き込む方式です。103 件のパスは**合計ではなくリテラルごとのタリー**で検証しました。形ごとの件数が入れ替わっても合計は一致しうるためです。

```
tally: {'"Invalid CPU difficulty: 3. Please enter 0-2."': 14,
        '"Invalid CPU difficulty: -1. Please enter 0-2."': 11,
        '"Invalid CPU difficulty: abc"': 1, '"Invalid CPU difficulty: 3"': 1,
        '"Invalid CPU difficulty"': 73, '"CPU difficulty is required"': 3} => total 103
```

## 残り

英語のまま残るのは 322 コマンド。ポイント上限 (22)、ベット額 (13)、目標スコア (10)、アンティ額 (9) などが続きます。53 コマンドは**メッセージ自体が無く盤面を再描画するだけ**で、そちらは #5377 の範囲です。

## 検証

- `go test -tags test ./internal/adapter/controller/` — 緑
- `go build ./...` — 通過
- `golangci-lint run ./internal/...` — 0 issues

Refs #5384
