### PR TITLE
fix(hooks): deny the tool call instead of killing the turn

### DIFF
--- a/.claude/hooks/commit-sanity.sh
+++ b/.claude/hooks/commit-sanity.sh
@@ -18,6 +18,14 @@
 # line of angle brackets in prose or a shell heredoc does not trip it either.
 #
 # Reads the hook payload on stdin, writes a hook decision object on stdout.
+#
+# Decision shape: this guard denies ONE tool call, so it emits
+# hookSpecificOutput.permissionDecision = "deny". It must never emit
+# {"continue": false}, which is the kill switch: that ends the whole turn, and
+# its stopReason is documented as "Not shown to Claude" -- so the agent is
+# stopped without ever learning why, and the Stop hook does not run either.
+# Every guard in this repo used the kill switch until 2026-08-16; that is what
+# was behind the recurring "a hook block ended my turn" failures.
 set -uo pipefail
 
 payload=$(cat)
@@ -37,10 +45,13 @@ esac
 
 if [ -z "$(git diff --cached --name-only)" ] && [ "$allows_empty" -eq 0 ]; then
   jq -nc '{
-    continue: false,
-    stopReason: ("Blocked: nothing is staged, so this commit would record zero changes. " +
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: ("Blocked: nothing is staged, so this commit would record zero changes. " +
                  "Check `git status` -- a `git add` that matched no paths is silent. " +
                  "Pass --allow-empty if an empty commit really is what you want.")
+    }
   }'
   exit 0
 fi
@@ -53,10 +64,13 @@ conflicted=$(git diff --cached -U0 | awk '
 
 if [ -n "$conflicted" ]; then
   jq -nc --arg files "$conflicted" '{
-    continue: false,
-    stopReason: ("Blocked: staged content contains merge conflict markers. Neither tsc nor " +
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: ("Blocked: staged content contains merge conflict markers. Neither tsc nor " +
                  "vitest fails on these -- only the E2E production build does, minutes into CI. " +
                  "Resolve them in:\n" + $files)
+    }
   }'
   exit 0
 fi

--- a/.claude/hooks/commit-sanity.test.sh
+++ b/.claude/hooks/commit-sanity.test.sh
@@ -21,7 +21,14 @@ run() {
   local expect=$1 desc=$2 cmd=$3 out
   out=$(printf '{"tool_input":{"command":%s}}' "$(printf '%s' "$cmd" | jq -Rs .)" | bash "$HOOK")
   local blocked=pass
-  printf '%s' "$out" | grep -q '"continue": *false' && blocked=block
+  # A guard denies one tool call; it must never use the `continue:false` kill
+  # switch, which ends the whole turn and whose stopReason is never shown to
+  # Claude. Assert the shape, not just "something was refused".
+  printf '%s' "$out" | grep -q '"permissionDecision": *"deny"' && blocked=block
+  if printf '%s' "$out" | grep -q '"continue" *: *false'; then
+    printf '  FAIL  %s: hook used the continue:false kill switch\n' "$desc"
+    fail=1
+  fi
   if [ "$blocked" = "$expect" ]; then
     printf '  ok    %s (%s)\n' "$desc" "$expect"
   else

--- a/.claude/hooks/git-restore-guard.sh
+++ b/.claude/hooks/git-restore-guard.sh
@@ -24,6 +24,14 @@
 # `git restore --staged <path>` only rewrites the index, so it is left alone.
 #
 # Reads the hook payload on stdin, writes a hook decision object on stdout.
+#
+# Decision shape: this guard denies ONE tool call, so it emits
+# hookSpecificOutput.permissionDecision = "deny". It must never emit
+# {"continue": false}, which is the kill switch: that ends the whole turn, and
+# its stopReason is documented as "Not shown to Claude" -- so the agent is
+# stopped without ever learning why, and the Stop hook does not run either.
+# Every guard in this repo used the kill switch until 2026-08-16; that is what
+# was behind the recurring "a hook block ended my turn" failures.
 set -uo pipefail
 
 payload=$(cat)
@@ -75,10 +83,13 @@ esac
 # waving it through is worst.
 if [ "$parse_failed" -eq 1 ]; then
   jq -nc '{
-    continue: false,
-    stopReason: ("Blocked: could not parse the paths out of this restore command (unbalanced quotes?), " +
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: ("Blocked: could not parse the paths out of this restore command (unbalanced quotes?), " +
                  "so it cannot be checked for uncommitted work. Refusing to guess -- rerun with simple " +
                  "quoting, or use `git stash push -- <paths>` which is recoverable either way.")
+    }
   }'
   exit 0
 fi
@@ -101,11 +112,14 @@ if [ -z "$at_risk" ]; then
 fi
 
 jq -nc --arg files "$(printf '%s' "$at_risk" | sed '/^$/d')" '{
-  continue: false,
-  stopReason: ("Blocked: this would discard uncommitted changes with no way back. " +
+  hookSpecificOutput: {
+    hookEventName: "PreToolUse",
+    permissionDecision: "deny",
+    permissionDecisionReason: ("Blocked: this would discard uncommitted changes with no way back. " +
                "It prints nothing on success, so the loss is silent and the next green " +
                "test run reads like confirmation.\n\nAt risk:\n" + $files +
                "\n\nUse `git stash push -- <paths>` instead (recoverable via `git stash pop`), " +
                "or commit first. If you are restoring a file you deliberately broke for a " +
                "test, stash before breaking it rather than restoring after.")
+  }
 }'

--- a/.claude/hooks/git-restore-guard.test.sh
+++ b/.claude/hooks/git-restore-guard.test.sh
@@ -37,7 +37,14 @@ run() {
   local expect=$1 desc=$2 cmd=$3 out
   out=$(printf '{"tool_input":{"command":%s}}' "$(printf '%s' "$cmd" | jq -Rs .)" | bash "$HOOK")
   local blocked=pass
-  printf '%s' "$out" | grep -q '"continue": *false' && blocked=block
+  # A guard denies one tool call; it must never use the `continue:false` kill
+  # switch, which ends the whole turn and whose stopReason is never shown to
+  # Claude. Assert the shape, not just "something was refused".
+  printf '%s' "$out" | grep -q '"permissionDecision": *"deny"' && blocked=block
+  if printf '%s' "$out" | grep -q '"continue" *: *false'; then
+    printf '  FAIL  %s: hook used the continue:false kill switch\n' "$desc"
+    fail=1
+  fi
   if [ "$blocked" = "$expect" ]; then
     printf '  ok    %s (%s)\n' "$desc" "$expect"
   else

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,25 +21,25 @@
           },
           {
             "type": "command",
-            "command": "cmd=$(jq -r '.tool_input.command'); if printf '%s' \"$cmd\" | grep -qE '(^|[^[:alnum:]_-])git[[:space:]]+(add[[:space:]]+(-A|--all|\\.)([[:space:]/]|$)|checkout[[:space:]]+[^[:space:]]+[[:space:]]+--[[:space:]]+\\.([[:space:]]|$))'; then printf '%s' '{\"continue\": false, \"stopReason\": \"Blocked: do not use git add -A / git add . / git checkout <ref> -- . in this worktree. It has local-only files (node_modules, vendored .claude/skills, casino/classic/solo TinyGo build dirs, public/sounds) that must never be staged. Stage specific paths instead, e.g. git add path/to/file.\"}'; else echo '{}'; fi",
+            "command": "cmd=$(jq -r '.tool_input.command'); if printf '%s' \"$cmd\" | grep -qE '(^|[^[:alnum:]_-])git[[:space:]]+(add[[:space:]]+(-A|--all|\\.)([[:space:]/]|$)|checkout[[:space:]]+[^[:space:]]+[[:space:]]+--[[:space:]]+\\.([[:space:]]|$))'; then printf '%s' '{\"hookSpecificOutput\": {\"hookEventName\": \"PreToolUse\", \"permissionDecision\": \"deny\", \"permissionDecisionReason\": \"Blocked: do not use git add -A / git add . / git checkout <ref> -- . in this worktree. It has local-only files (node_modules, vendored .claude/skills, casino/classic/solo TinyGo build dirs, public/sounds) that must never be staged. Stage specific paths instead, e.g. git add path/to/file.\"}}'; else echo '{}'; fi",
             "timeout": 5,
             "statusMessage": "Guarding against bulk git add..."
           },
           {
             "type": "command",
-            "command": "jq -r '.tool_input.command' | { read -r cmd; case \"$cmd\" in git\\ commit*) if git diff --cached --name-only | grep -q '\\.go$'; then output=$(golangci-lint run ./... 2>&1 | head -30); if [ -n \"$output\" ]; then printf '{\"continue\": false, \"stopReason\": \"golangci-lint failed:\\n%s\"}' \"$output\"; else echo '{}'; fi; else echo '{}'; fi ;; *) echo '{}' ;; esac; }",
+            "command": "jq -r '.tool_input.command' | { read -r cmd; case \"$cmd\" in git\\ commit*) if git diff --cached --name-only | grep -q '\\.go$'; then output=$(golangci-lint run ./... 2>&1 | head -30); if [ -n \"$output\" ]; then jq -nc --arg msg \"$output\" '{hookSpecificOutput: {hookEventName: \"PreToolUse\", permissionDecision: \"deny\", permissionDecisionReason: (\"golangci-lint failed:\\n\" + $msg)}}'; else echo '{}'; fi; else echo '{}'; fi ;; *) echo '{}' ;; esac; }",
             "timeout": 120,
             "statusMessage": "Running golangci-lint..."
           },
           {
             "type": "command",
-            "command": "jq -r '.tool_input.command' | { read -r cmd; case \"$cmd\" in git\\ commit*) if git diff --cached --name-only | grep -qE '\\.(ts|tsx|mjs)$'; then cd frontend && output=$(bun run check 2>&1); if [ $? -ne 0 ]; then jq -nc --arg msg \"$(printf '%s' \"$output\" | tail -30)\" '{continue: false, stopReason: (\"bun run check failed (biome + the guard scripts):\\n\" + $msg)}'; else echo '{}'; fi; else echo '{}'; fi ;; *) echo '{}' ;; esac; }",
+            "command": "jq -r '.tool_input.command' | { read -r cmd; case \"$cmd\" in git\\ commit*) if git diff --cached --name-only | grep -qE '\\.(ts|tsx|mjs)$'; then cd frontend && output=$(bun run check 2>&1); if [ $? -ne 0 ]; then jq -nc --arg msg \"$(printf '%s' \"$output\" | tail -30)\" '{hookSpecificOutput: {hookEventName: \"PreToolUse\", permissionDecision: \"deny\", permissionDecisionReason: (\"bun run check failed (biome + the guard scripts):\\n\" + $msg)}}'; else echo '{}'; fi; else echo '{}'; fi ;; *) echo '{}' ;; esac; }",
             "timeout": 60,
             "statusMessage": "Running biome check + guard floors..."
           },
           {
             "type": "command",
-            "command": "jq -r '.tool_input.command' | { read -r cmd; case \"$cmd\" in git\\ commit*) if git diff --cached --name-only | grep -qE '\\.(ts|tsx)$'; then cd frontend && output=$(bun run typecheck 2>&1); if [ $? -ne 0 ]; then jq -nc --arg msg \"$(printf '%s' \"$output\" | head -30)\" '{continue: false, stopReason: (\"tsc type-check failed (TypeScript 7 via bun run typecheck; vitest/biome do not catch this):\\n\" + $msg)}'; else echo '{}'; fi; else echo '{}'; fi ;; *) echo '{}' ;; esac; }",
+            "command": "jq -r '.tool_input.command' | { read -r cmd; case \"$cmd\" in git\\ commit*) if git diff --cached --name-only | grep -qE '\\.(ts|tsx)$'; then cd frontend && output=$(bun run typecheck 2>&1); if [ $? -ne 0 ]; then jq -nc --arg msg \"$(printf '%s' \"$output\" | head -30)\" '{hookSpecificOutput: {hookEventName: \"PreToolUse\", permissionDecision: \"deny\", permissionDecisionReason: (\"tsc type-check failed (TypeScript 7 via bun run typecheck; vitest/biome do not catch this):\\n\" + $msg)}}'; else echo '{}'; fi; else echo '{}'; fi ;; *) echo '{}' ;; esac; }",
             "timeout": 180,
             "statusMessage": "Running tsc type-check..."
           },
@@ -51,7 +51,7 @@
           },
           {
             "type": "command",
-            "command": "jq -r '.tool_input.command' | { read -r cmd; case \"$cmd\" in git\\ commit*) script=.claude/skills/new-game/scripts/count-audit.sh; if [ -f \"$script\" ] && git diff --cached --name-only | grep -qE 'internal/infrastructure/games/(registry(_test)?\\.go|[a-z0-9]+/)|frontend/src/(hooks/useTutorialProgress\\.test\\.ts|components/tutorial/TutorialProgressPanel\\.test\\.tsx)'; then output=$(bash \"$script\" 2>&1); if [ $? -ne 0 ]; then jq -nc --arg msg \"$output\" '{continue: false, stopReason: (\"game-count assertions are inconsistent \\u2014 bump them in the same commit before committing:\\n\" + $msg)}'; else echo '{}'; fi; else echo '{}'; fi ;; *) echo '{}' ;; esac; }",
+            "command": "jq -r '.tool_input.command' | { read -r cmd; case \"$cmd\" in git\\ commit*) script=.claude/skills/new-game/scripts/count-audit.sh; if [ -f \"$script\" ] && git diff --cached --name-only | grep -qE 'internal/infrastructure/games/(registry(_test)?\\.go|[a-z0-9]+/)|frontend/src/(hooks/useTutorialProgress\\.test\\.ts|components/tutorial/TutorialProgressPanel\\.test\\.tsx)'; then output=$(bash \"$script\" 2>&1); if [ $? -ne 0 ]; then jq -nc --arg msg \"$output\" '{hookSpecificOutput: {hookEventName: \"PreToolUse\", permissionDecision: \"deny\", permissionDecisionReason: (\"game-count assertions are inconsistent \\u2014 bump them in the same commit before committing:\\n\" + $msg)}}'; else echo '{}'; fi; else echo '{}'; fi ;; *) echo '{}' ;; esac; }",
             "timeout": 30,
             "statusMessage": "Auditing game-count assertions..."
           }


### PR DESCRIPTION
## 問題

このリポジトリの PreToolUse ガードは、全て次を返していました。

```json
{"continue": false, "stopReason": "Blocked: ..."}
```

これは「このコマンドを拒否する」ではありません。**キルスイッチ**です。公式ドキュメントの記述:

> `continue: false` — If false, Claude stops processing entirely after the hook runs.
>
> `stopReason` — **Not shown to Claude.**

つまり restore のブロックも、コミット時の golangci-lint 失敗も、tsc エラーも、**その場でターンを丸ごと終わらせ、理由はエージェントに一切渡っていませんでした**。Stop フック（未完了作業を検出して続行を促すもの）もこの経路では走りません。

「フックにブロックされるとターンが終わる」は 17 回記録されてきましたが、対策はずっと助言的なメモでした。**効くはずがありませんでした ―― メッセージが配送されていなかったので。**

## 変更

「この呼び出しだけ拒否し、理由をエージェントに返し、ターンは続ける」の正しい形に、**9 箇所すべて**を移しました。

```json
{"hookSpecificOutput": {"hookEventName": "PreToolUse",
  "permissionDecision": "deny", "permissionDecisionReason": "..."}}
```

- `.claude/hooks/git-restore-guard.sh` — 2 箇所
- `.claude/hooks/commit-sanity.sh` — 2 箇所
- `.claude/settings.json` のインライン — 5 箇所（staging ガード、golangci-lint、bun run check、typecheck、game-count）

なぜ deny なのかは両スクリプトのヘッダにコメントとして残しました。

## 形を「実行して」確かめたら 2 件の欠陥が出ました

**1. golangci-lint フックは不正な JSON を出していた。**

```sh
printf '{"continue": false, "stopReason": "golangci-lint failed:\n%s"}' "$output"
```

`printf` の `\n` は **JSON 文字列の中に生の改行**を書き込み、さらに lint 出力が無エスケープで埋め込まれます（引用符 1 つで壊れる）。パース不能なので、**このゲートは元から機能していませんでした**。jq で組み立てる形に直し、改行と二重引用符を含むメッセージで検証済みです。

**2. 入れ子を 1 段足したらスクリプト側 4 箇所すべてで閉じ括弧が落ちた。** `bash -n` は通ります。実行して初めて分かりました。

## ガード

両テストハーネスが deny 形を assert し、**キルスイッチを使ったら名指しで落とします**。

```
FAIL  commit with nothing staged: hook used the continue:false kill switch
```

コントロール実測: `commit-sanity.sh` に構文的に正しい `{"continue": false}` を戻すと上記で落ち、戻すと全件通過します。

## 検証

- `bash .claude/hooks/git-restore-guard.test.sh` — all cases passed
- `bash .claude/hooks/commit-sanity.test.sh` — FAIL 0 件
- 9 箇所すべての deny 出力を実行して JSON をパース検証（`permissionDecision == "deny"`、`continue` キーなし）
- `.claude/settings.json` がパースでき、リポジトリ内のフックに `continue: false` は 1 件も残っていない

## 注意

フックはセッション開始時にスナップショットされるため、**この変更が効くのは次のセッションから**です。
