### PR TITLE
fix(cui): mark the rejections the key-based parser returns

### DIFF
--- a/internal/adapter/controller/BasraCuiController.go
+++ b/internal/adapter/controller/BasraCuiController.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -64,11 +63,11 @@ func (c *BasraCuiController) Exec(command string) string {
 // handlePlay は "p <handIdx> [tableIdx...]" を解析して Play を呼ぶ。
 func (c *BasraCuiController) handlePlay(args []string) string {
 	if len(args) == 0 {
-		return i18n.T("cardIndexRequiredCapture")
+		return invalidArg("cardIndexRequiredCapture")
 	}
 	handIdx, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidCardIndex", "val", args[0])
+		return invalidArg("invalidCardIndex", "val", args[0])
 	}
 	tableIdxs, _ := cuiutil.ParseIntSlice(args[1:])
 	return c.bi.Play(handIdx, tableIdxs)

--- a/internal/adapter/controller/BuraCuiController.go
+++ b/internal/adapter/controller/BuraCuiController.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -72,14 +71,14 @@ func (c *BuraCuiController) Exec(command string) string {
 // player verbatim, and Go error strings are not capitalised.
 func buraParseIndices(args []string) ([]int, string) {
 	if len(args) == 0 {
-		return nil, i18n.T("cardIndexRequired")
+		return nil, invalidArg("cardIndexRequired")
 	}
 	seen := map[int]bool{}
 	indices := make([]int, 0, len(args))
 	for _, a := range args {
 		n, err := strconv.Atoi(strings.TrimSpace(a))
 		if err != nil {
-			return nil, i18n.Tf("invalidCardIndex", "val", a)
+			return nil, invalidArg("invalidCardIndex", "val", a)
 		}
 		if seen[n] {
 			return nil, fmt.Sprintf("Duplicate card index: %d.", n)

--- a/internal/adapter/controller/DesmocheCuiController.go
+++ b/internal/adapter/controller/DesmocheCuiController.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -77,7 +76,7 @@ func (c *DesmocheCuiController) meld(args []string) (string, bool) {
 	for _, p := range parts {
 		n, err := strconv.Atoi(strings.TrimSpace(p))
 		if err != nil || n < 0 {
-			return i18n.Tf("invalidCardIndex", "val", p), true
+			return invalidArg("invalidCardIndex", "val", p), true
 		}
 		idxs = append(idxs, n)
 	}
@@ -91,7 +90,7 @@ func (c *DesmocheCuiController) layOff(args []string) (string, bool) {
 	}
 	card, ok := desmocheParseIdx(args[0])
 	if !ok {
-		return i18n.Tf("invalidCardIndex", "val", args[0]), true
+		return invalidArg("invalidCardIndex", "val", args[0]), true
 	}
 	meld, ok := desmocheParseIdx(args[1])
 	if !ok {
@@ -111,7 +110,7 @@ func (c *DesmocheCuiController) desmoche(args []string) (string, bool) {
 	}
 	card, ok := desmocheParseIdx(args[1])
 	if !ok {
-		return i18n.Tf("invalidCardIndex", "val", args[1]), true
+		return invalidArg("invalidCardIndex", "val", args[1]), true
 	}
 	to, ok := desmocheParseIdx(args[2])
 	if !ok {

--- a/internal/adapter/controller/FrenchTarotCuiController.go
+++ b/internal/adapter/controller/FrenchTarotCuiController.go
@@ -5,7 +5,6 @@ package controller
 import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -91,7 +90,7 @@ func (c *FrenchTarotCuiController) execDiscard(args []string) (string, bool) {
 	}
 	indices, skipped := cuiutil.ParseIntSlice(args)
 	if len(skipped) > 0 {
-		return i18n.Tf("invalidCardIndex", "val", skipped[0]), true
+		return invalidArg("invalidCardIndex", "val", skipped[0]), true
 	}
 	return c.di.Discard(indices), true
 }

--- a/internal/adapter/controller/GoStopCuiController.go
+++ b/internal/adapter/controller/GoStopCuiController.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -70,11 +69,11 @@ func (c *GoStopCuiController) Exec(command string) string {
 // handlePlay は "p <handIdx> [fieldIdx]" を解析して Play を呼ぶ。
 func (c *GoStopCuiController) handlePlay(args []string) string {
 	if len(args) == 0 {
-		return i18n.T("cardIndexRequiredField")
+		return invalidArg("cardIndexRequiredField")
 	}
 	handIdx, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidCardIndex", "val", args[0])
+		return invalidArg("invalidCardIndex", "val", args[0])
 	}
 	fieldIdx := -1
 	if len(args) >= 2 {

--- a/internal/adapter/controller/GuandanCuiController.go
+++ b/internal/adapter/controller/GuandanCuiController.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -62,7 +61,7 @@ func guandanParsePlay(args []string, gi usecase.GuandanInteractorIF) (string, bo
 	for _, a := range args {
 		v, err := strconv.Atoi(a)
 		if err != nil || v < 0 || v >= domain.GuandanHandSize {
-			return i18n.Tf("invalidCardIndexRange", "val", a, "max", strconv.Itoa(domain.GuandanHandSize-1)), true
+			return invalidArg("invalidCardIndexRange", "val", a, "max", strconv.Itoa(domain.GuandanHandSize-1)), true
 		}
 		// **同じ札を 2 回数えられない。**
 		if seen[v] {

--- a/internal/adapter/controller/HachiHachiCuiController.go
+++ b/internal/adapter/controller/HachiHachiCuiController.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -63,11 +62,11 @@ func (c *HachiHachiCuiController) Exec(command string) string {
 // handlePlay は "p <handIdx> [fieldIdx]" を解析して Play を呼ぶ。
 func (c *HachiHachiCuiController) handlePlay(args []string) string {
 	if len(args) == 0 {
-		return i18n.T("cardIndexRequiredField")
+		return invalidArg("cardIndexRequiredField")
 	}
 	handIdx, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidCardIndex", "val", args[0])
+		return invalidArg("invalidCardIndex", "val", args[0])
 	}
 	fieldIdx := -1
 	if len(args) >= 2 {

--- a/internal/adapter/controller/KaiserCuiController.go
+++ b/internal/adapter/controller/KaiserCuiController.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -90,7 +89,7 @@ func kaiserParseDiscard(args []string, ki usecase.KaiserInteractorIF) (string, b
 	for _, a := range args[:domain.KaiserKittySize] {
 		v, err := strconv.Atoi(strings.TrimSpace(a))
 		if err != nil || v < 0 {
-			return i18n.Tf("invalidCardIndex", "val", a), true
+			return invalidArg("invalidCardIndex", "val", a), true
 		}
 		idxs = append(idxs, v)
 	}

--- a/internal/adapter/controller/KoenigrufenCuiController.go
+++ b/internal/adapter/controller/KoenigrufenCuiController.go
@@ -5,7 +5,6 @@ package controller
 import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -94,7 +93,7 @@ func (c *KoenigrufenCuiController) execDiscard(args []string) (string, bool) {
 	}
 	indices, skipped := cuiutil.ParseIntSlice(args)
 	if len(skipped) > 0 {
-		return i18n.Tf("invalidCardIndex", "val", skipped[0]), true
+		return invalidArg("invalidCardIndex", "val", skipped[0]), true
 	}
 	return c.di.Discard(indices), true
 }

--- a/internal/adapter/controller/KoiKoiCuiController.go
+++ b/internal/adapter/controller/KoiKoiCuiController.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -70,11 +69,11 @@ func (c *KoiKoiCuiController) Exec(command string) string {
 // handlePlay は "p <handIdx> [fieldIdx]" を解析して Play を呼ぶ。
 func (c *KoiKoiCuiController) handlePlay(args []string) string {
 	if len(args) == 0 {
-		return i18n.T("cardIndexRequiredField")
+		return invalidArg("cardIndexRequiredField")
 	}
 	handIdx, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidCardIndex", "val", args[0])
+		return invalidArg("invalidCardIndex", "val", args[0])
 	}
 	fieldIdx := -1
 	if len(args) >= 2 {

--- a/internal/adapter/controller/LaughAndLieDownCuiController.go
+++ b/internal/adapter/controller/LaughAndLieDownCuiController.go
@@ -5,7 +5,6 @@ package controller
 import (
 	"strconv"
 
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -53,11 +52,11 @@ func (c *LaughAndLieDownCuiController) Exec(command string) string {
 // 選択肢なので、毎回打たせるのは無駄が多い。
 func (c *LaughAndLieDownCuiController) play(args []string) (string, bool) {
 	if len(args) == 0 {
-		return i18n.T("cardIndexRequired"), true
+		return invalidArg("cardIndexRequired"), true
 	}
 	handIdx, err := strconv.Atoi(args[0])
 	if err != nil || handIdx < 0 {
-		return i18n.Tf("invalidCardIndex", "val", args[0]), true
+		return invalidArg("invalidCardIndex", "val", args[0]), true
 	}
 	take := 1
 	if len(args) > 1 {

--- a/internal/adapter/controller/LobaCuiController.go
+++ b/internal/adapter/controller/LobaCuiController.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -74,7 +73,7 @@ func (c *LobaCuiController) meld(args []string) (string, bool) {
 	for _, p := range parts {
 		n, err := strconv.Atoi(strings.TrimSpace(p))
 		if err != nil || n < 0 {
-			return i18n.Tf("invalidCardIndex", "val", p), true
+			return invalidArg("invalidCardIndex", "val", p), true
 		}
 		idxs = append(idxs, n)
 	}
@@ -88,7 +87,7 @@ func (c *LobaCuiController) layOff(args []string) (string, bool) {
 	}
 	card, err := strconv.Atoi(args[0])
 	if err != nil || card < 0 {
-		return i18n.Tf("invalidCardIndex", "val", args[0]), true
+		return invalidArg("invalidCardIndex", "val", args[0]), true
 	}
 	meld, err := strconv.Atoi(args[1])
 	if err != nil || meld < 0 {

--- a/internal/adapter/controller/MinchiateCuiController.go
+++ b/internal/adapter/controller/MinchiateCuiController.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -79,7 +78,7 @@ func (c *MinchiateCuiController) execScarto(args []string) (string, bool) {
 	}
 	indices, skipped := cuiutil.ParseIntSlice(args)
 	if len(skipped) > 0 {
-		return i18n.Tf("invalidCardIndex", "val", skipped[0]), true
+		return invalidArg("invalidCardIndex", "val", skipped[0]), true
 	}
 	return c.di.Discard(indices), true
 }

--- a/internal/adapter/controller/SakuraCuiController.go
+++ b/internal/adapter/controller/SakuraCuiController.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -75,11 +74,11 @@ func (c *SakuraCuiController) Exec(command string) string {
 // handlePlay は "p <handIdx> [fieldIdx]" を解析して Play を呼ぶ。
 func (c *SakuraCuiController) handlePlay(args []string) string {
 	if len(args) == 0 {
-		return i18n.T("cardIndexRequiredField")
+		return invalidArg("cardIndexRequiredField")
 	}
 	handIdx, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidCardIndex", "val", args[0])
+		return invalidArg("invalidCardIndex", "val", args[0])
 	}
 	fieldIdx := -1
 	if len(args) >= 2 {

--- a/internal/adapter/controller/ScartoCuiController.go
+++ b/internal/adapter/controller/ScartoCuiController.go
@@ -5,7 +5,6 @@ package controller
 import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -74,7 +73,7 @@ func (c *ScartoCuiController) execScarto(args []string) (string, bool) {
 	}
 	indices, skipped := cuiutil.ParseIntSlice(args)
 	if len(skipped) > 0 {
-		return i18n.Tf("invalidCardIndex", "val", skipped[0]), true
+		return invalidArg("invalidCardIndex", "val", skipped[0]), true
 	}
 	return c.di.Discard(indices), true
 }

--- a/internal/adapter/controller/ShengJiCuiController.go
+++ b/internal/adapter/controller/ShengJiCuiController.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -71,7 +70,7 @@ func shengJiParseIndexes(args []string, want, maxIdx int, apply func([]int) stri
 	for _, a := range args {
 		v, err := strconv.Atoi(a)
 		if err != nil || v < 0 || v > maxIdx {
-			return i18n.Tf("invalidCardIndexRange", "val", a, "max", strconv.Itoa(maxIdx)), true
+			return invalidArg("invalidCardIndexRange", "val", a, "max", strconv.Itoa(maxIdx)), true
 		}
 		// **同じ札を 2 回数えられない。**通すと 1 枚から対子が作れてしまう。
 		if seen[v] {

--- a/internal/adapter/controller/StealingBundlesCuiController.go
+++ b/internal/adapter/controller/StealingBundlesCuiController.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -60,11 +59,11 @@ func (c *StealingBundlesCuiController) Exec(command string) string {
 // **札と相手の両方が要ります。** どちらが欠けているかを言い分けます。
 func (c *StealingBundlesCuiController) execSteal(args []string) (string, bool) {
 	if len(args) < 1 {
-		return i18n.T("cardIndexRequired"), true
+		return invalidArg("cardIndexRequired"), true
 	}
 	cardIdx, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidCardIndex", "val", args[0]), true
+		return invalidArg("invalidCardIndex", "val", args[0]), true
 	}
 	if len(args) < 2 {
 		return "Victim index is required.", true

--- a/internal/adapter/controller/TablanetCuiController.go
+++ b/internal/adapter/controller/TablanetCuiController.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -64,11 +63,11 @@ func (c *TablanetCuiController) Exec(command string) string {
 // handlePlay は "p <handIdx> [tableIdx...]" を解析して Play を呼ぶ。
 func (c *TablanetCuiController) handlePlay(args []string) string {
 	if len(args) == 0 {
-		return i18n.T("cardIndexRequiredCapture")
+		return invalidArg("cardIndexRequiredCapture")
 	}
 	handIdx, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidCardIndex", "val", args[0])
+		return invalidArg("invalidCardIndex", "val", args[0])
 	}
 	tableIdxs, _ := cuiutil.ParseIntSlice(args[1:])
 	return c.bi.Play(handIdx, tableIdxs)

--- a/internal/adapter/controller/TarocchiniCuiController.go
+++ b/internal/adapter/controller/TarocchiniCuiController.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -79,7 +78,7 @@ func (c *TarocchiniCuiController) execScarto(args []string) (string, bool) {
 	}
 	indices, skipped := cuiutil.ParseIntSlice(args)
 	if len(skipped) > 0 {
-		return i18n.Tf("invalidCardIndex", "val", skipped[0]), true
+		return invalidArg("invalidCardIndex", "val", skipped[0]), true
 	}
 	return c.di.Discard(indices), true
 }

--- a/internal/adapter/controller/TuSacCuiController.go
+++ b/internal/adapter/controller/TuSacCuiController.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -65,13 +64,13 @@ func (cc *TuSacCuiController) Exec(command string) string {
 // tuSacParseIndexes は "1 4 7" のような並びを 0 始まりの添字にする。
 func tuSacParseIndexes(args []string) ([]int, string, bool) {
 	if len(args) == 0 {
-		return nil, i18n.T("cardIndexesRequiredMeld"), false
+		return nil, invalidArg("cardIndexesRequiredMeld"), false
 	}
 	out := make([]int, 0, len(args))
 	for _, a := range args {
 		n, err := strconv.Atoi(strings.TrimSpace(a))
 		if err != nil || n < 1 {
-			return nil, i18n.T("invalidIndexFromOne"), false
+			return nil, invalidArg("invalidIndexFromOne"), false
 		}
 		out = append(out, n-1)
 	}

--- a/internal/adapter/controller/UltiCuiController.go
+++ b/internal/adapter/controller/UltiCuiController.go
@@ -5,7 +5,6 @@ package controller
 import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -126,7 +125,7 @@ func (c *UltiCuiController) execDiscard(args []string) (string, bool) {
 	}
 	indices, skipped := cuiutil.ParseIntSlice(args)
 	if len(skipped) > 0 {
-		return i18n.Tf("invalidCardIndex", "val", skipped[0]), true
+		return invalidArg("invalidCardIndex", "val", skipped[0]), true
 	}
 	return c.di.Discard(indices), true
 }

--- a/internal/adapter/controller/VideoPokerCuiController.go
+++ b/internal/adapter/controller/VideoPokerCuiController.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -65,7 +64,7 @@ func parseHoldIndices(args []string) ([]int, string) {
 		}
 		idx, err := strconv.Atoi(arg)
 		if err != nil || idx < 0 || idx > 4 {
-			return nil, i18n.T("invalidCardIndexHold")
+			return nil, invalidArg("invalidCardIndexHold")
 		}
 		indices = append(indices, idx)
 	}

--- a/internal/adapter/controller/ZwanzigerrufenCuiController.go
+++ b/internal/adapter/controller/ZwanzigerrufenCuiController.go
@@ -5,7 +5,6 @@ package controller
 import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -105,7 +104,7 @@ func (c *ZwanzigerrufenCuiController) execDiscard(args []string) (string, bool) 
 	}
 	indices, skipped := cuiutil.ParseIntSlice(args)
 	if len(skipped) > 0 {
-		return i18n.Tf("invalidCardIndex", "val", skipped[0]), true
+		return invalidArg("invalidCardIndex", "val", skipped[0]), true
 	}
 	return c.zi.Discard(indices), true
 }

--- a/internal/adapter/controller/ZwickerCuiController.go
+++ b/internal/adapter/controller/ZwickerCuiController.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -67,7 +66,7 @@ func (c *ZwickerCuiController) take(args []string) (string, bool) {
 	}
 	hand, ok := zwickerParseIdx(args[0])
 	if !ok {
-		return i18n.Tf("invalidCardIndex", "val", args[0]), true
+		return invalidArg("invalidCardIndex", "val", args[0]), true
 	}
 	value, err := strconv.Atoi(strings.TrimSpace(args[1]))
 	if err != nil || value <= 0 {
@@ -98,7 +97,7 @@ func (c *ZwickerCuiController) build(args []string) (string, bool) {
 	}
 	hand, ok := zwickerParseIdx(args[0])
 	if !ok {
-		return i18n.Tf("invalidCardIndex", "val", args[0]), true
+		return invalidArg("invalidCardIndex", "val", args[0]), true
 	}
 	table, _, ok := zwickerParseList(args[1])
 	if !ok || len(table) == 0 {

--- a/internal/adapter/controller/cui_error_helper.go
+++ b/internal/adapter/controller/cui_error_helper.go
@@ -10,10 +10,12 @@ import "github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 // test executing a documented example -- can tell "the game refused this" from
 // "the game did this".
 //
-// Measured on 2026-08-15 by giving a malformed argument to every one of the 638
-// argument-taking commands in the help tables, on a freshly dealt game: 4 came
-// back marked. The rest returned a perfectly good message that read as success,
-// or (27 commands) nothing but a redrawn board. See issue #5377.
+// Measured by giving a malformed argument to every argument-taking command in
+// the help tables, on a freshly dealt game. When this helper was introduced on
+// 2026-08-15, 4 of 638 came back marked; after the i18n migration moved most
+// rejections onto cuiutil.ParseIntArgKeys and that path started marking too,
+// it is 668 of 994. The rest still return a message that reads as success, or
+// (45 commands) nothing but a redrawn board -- issues #5377 and #5390.
 //
 // The signature deliberately mirrors i18n.Tf so the call sites differ only in
 // the function name.

--- a/internal/adapter/controller/cui_msg_ext_test.go
+++ b/internal/adapter/controller/cui_msg_ext_test.go
@@ -10,9 +10,11 @@ import (
 
 // The same helpers as cui_msg_test.go, for the test files in the external
 // package. See there for why the assertions go through i18n.
-func msgCardIndexRequired() string { return i18n.T("cardIndexRequired") }
+func msgCardIndexRequired() string { return i18n.MarkError(i18n.T("cardIndexRequired")) }
 
-func msgInvalidCardIndex(val string) string { return i18n.Tf("invalidCardIndex", "val", val) }
+func msgInvalidCardIndex(val string) string {
+	return i18n.MarkError(i18n.Tf("invalidCardIndex", "val", val))
+}
 
 // msgInvalidCardIndexPrefix is the part of the message before the offending
 // value, for the assertions that only check that the rejection happened.
@@ -26,9 +28,9 @@ func msgInvalidCardIndexPrefix() string {
 }
 
 // The two card-index prompts that carry a usage example.
-func msgCardIndexRequiredField() string { return i18n.T("cardIndexRequiredField") }
+func msgCardIndexRequiredField() string { return i18n.MarkError(i18n.T("cardIndexRequiredField")) }
 
-func msgCardIndexRequiredCapture() string { return i18n.T("cardIndexRequiredCapture") }
+func msgCardIndexRequiredCapture() string { return i18n.MarkError(i18n.T("cardIndexRequiredCapture")) }
 
 // msgInvalidDiscardIndexPrefix is msgInvalidCardIndexPrefix for the discard pile.
 func msgInvalidDiscardIndexPrefix() string {
@@ -39,7 +41,7 @@ func msgInvalidDiscardIndexPrefix() string {
 // The CPU-difficulty rejections. The prefix form is for the assertions that
 // only check that the value was refused; see msgInvalidCardIndexPrefix.
 func msgInvalidCpuDifficulty(val string) string {
-	return i18n.Tf("invalidCpuDifficulty", "val", val)
+	return i18n.MarkError(i18n.Tf("invalidCpuDifficulty", "val", val))
 }
 
 func msgInvalidCpuDifficultyPrefix() string {
@@ -47,53 +49,61 @@ func msgInvalidCpuDifficultyPrefix() string {
 	return strings.TrimRight(stem, ":. ")
 }
 
-func msgCpuDifficultyRequired() string { return i18n.T("cpuDifficultyRequired") }
+func msgCpuDifficultyRequired() string { return i18n.MarkError(i18n.T("cpuDifficultyRequired")) }
 
 // msgCpuDifficultyRequiredAlt is the wording used by the games whose difficulty
 // scale starts at Normal.
-func msgCpuDifficultyRequiredAlt() string { return i18n.T("cpuDifficultyRequiredAlt") }
+func msgCpuDifficultyRequiredAlt() string { return i18n.MarkError(i18n.T("cpuDifficultyRequiredAlt")) }
 
 // Generated per-family renderers for the #5384 migration; see the note on
 // msgCardIndexRequired for why the tests go through i18n at all.
-func msgPointLimitRequired() string { return i18n.T("pointLimitRequired") }
+func msgPointLimitRequired() string { return i18n.MarkError(i18n.T("pointLimitRequired")) }
 
-func msgInvalidPointLimit(val string) string { return i18n.Tf("invalidPointLimit", "val", val) }
+func msgInvalidPointLimit(val string) string {
+	return i18n.MarkError(i18n.Tf("invalidPointLimit", "val", val))
+}
 
 func msgInvalidPointLimitPrefix() string {
 	stem := strings.SplitN(i18n.Tf("invalidPointLimit", "val", "\x00"), "\x00", 2)[0]
 	return strings.TrimRight(stem, ":. ")
 }
 
-func msgBetAmountRequired() string { return i18n.T("betAmountRequired") }
+func msgBetAmountRequired() string { return i18n.MarkError(i18n.T("betAmountRequired")) }
 
 func msgInvalidBetAmountPrefix() string {
 	stem := strings.SplitN(i18n.Tf("invalidBetAmount", "val", "\x00"), "\x00", 2)[0]
 	return strings.TrimRight(stem, ":. ")
 }
 
-func msgTargetScoreRequired() string { return i18n.T("targetScoreRequired") }
+func msgTargetScoreRequired() string { return i18n.MarkError(i18n.T("targetScoreRequired")) }
 
-func msgInvalidTargetScore(val string) string { return i18n.Tf("invalidTargetScore", "val", val) }
+func msgInvalidTargetScore(val string) string {
+	return i18n.MarkError(i18n.Tf("invalidTargetScore", "val", val))
+}
 
-func msgAnteAmountRequired() string { return i18n.T("anteAmountRequired") }
+func msgAnteAmountRequired() string { return i18n.MarkError(i18n.T("anteAmountRequired")) }
 
 func msgInvalidAnteAmountPrefix() string {
 	stem := strings.SplitN(i18n.Tf("invalidAnteAmount", "val", "\x00"), "\x00", 2)[0]
 	return strings.TrimRight(stem, ":. ")
 }
 
-func msgInvalidPlayerCount(val string) string { return i18n.Tf("invalidPlayerCount", "val", val) }
+func msgInvalidPlayerCount(val string) string {
+	return i18n.MarkError(i18n.Tf("invalidPlayerCount", "val", val))
+}
 
 func msgInvalidPlayerCountPrefix() string {
 	stem := strings.SplitN(i18n.Tf("invalidPlayerCount", "val", "\x00"), "\x00", 2)[0]
 	return strings.TrimRight(stem, ":. ")
 }
 
-func msgAmountRequired() string { return i18n.T("amountRequired") }
+func msgAmountRequired() string { return i18n.MarkError(i18n.T("amountRequired")) }
 
 func msgInvalidAmountPrefix() string {
 	stem := strings.SplitN(i18n.Tf("invalidAmountNotANumber", "val", "\x00"), "\x00", 2)[0]
 	return strings.TrimRight(stem, ":. ")
 }
 
-func msgInvalidBetAmount(val string) string { return i18n.Tf("invalidBetAmount", "val", val) }
+func msgInvalidBetAmount(val string) string {
+	return i18n.MarkError(i18n.Tf("invalidBetAmount", "val", val))
+}

--- a/internal/adapter/controller/cui_msg_test.go
+++ b/internal/adapter/controller/cui_msg_test.go
@@ -19,18 +19,20 @@ import (
 //
 // cui_msg_ext_test.go carries the same helpers for the external test package,
 // plus the ones only it needs.
-func msgCardIndexRequired() string { return i18n.T("cardIndexRequired") }
+func msgCardIndexRequired() string { return i18n.MarkError(i18n.T("cardIndexRequired")) }
 
-func msgInvalidCardIndex(val string) string { return i18n.Tf("invalidCardIndex", "val", val) }
+func msgInvalidCardIndex(val string) string {
+	return i18n.MarkError(i18n.Tf("invalidCardIndex", "val", val))
+}
 
 func msgInvalidCpuDifficultyPrefix() string {
 	stem := strings.SplitN(i18n.Tf("invalidCpuDifficulty", "val", "\x00"), "\x00", 2)[0]
 	return strings.TrimRight(stem, ":. ")
 }
 
-func msgCpuDifficultyRequired() string { return i18n.T("cpuDifficultyRequired") }
+func msgCpuDifficultyRequired() string { return i18n.MarkError(i18n.T("cpuDifficultyRequired")) }
 
-func msgBetAmountRequired() string { return i18n.T("betAmountRequired") }
+func msgBetAmountRequired() string { return i18n.MarkError(i18n.T("betAmountRequired")) }
 
 func msgInvalidBetAmountPrefix() string {
 	stem := strings.SplitN(i18n.Tf("invalidBetAmount", "val", "\x00"), "\x00", 2)[0]

--- a/internal/adapter/controller/cuiutil/parse.go
+++ b/internal/adapter/controller/cuiutil/parse.go
@@ -128,11 +128,11 @@ func ParseIntArgKeys(args []string, missingKey, invalidKey string, min, max int)
 		if missingKey == "" {
 			return 0, "", false
 		}
-		return 0, i18n.T(missingKey), false
+		return 0, i18n.MarkError(i18n.T(missingKey)), false
 	}
 	v, err := strconv.Atoi(args[0])
 	if err != nil || v < min || v > max {
-		return 0, i18n.Tf(invalidKey, "val", args[0]), false
+		return 0, i18n.MarkError(i18n.Tf(invalidKey, "val", args[0])), false
 	}
 	return v, "", true
 }


### PR DESCRIPTION
## 問題

#5378 で「拒否にはエラー印を付ける」を入れました。その後の i18n 移行（#5385 / #5386 / #5387）で大半の拒否が `cuiutil.ParseIntArgKeys` 経由に変わりましたが、**この関数は文言を描画するだけで印を付けていませんでした**。

結果として、**日本語化したばかりのファミリが「成功と区別できない応答」に戻っていました**。i18n 化と印付けを別 PR に分けた副作用です。

## 変更

1. `ParseIntArgKeys` の 2 つの拒否経路（引数なし / パース失敗・範囲外）を `i18n.MarkError` に通す
2. 拒否キーをその場で描画していた **38 箇所**を `invalidArg` 経由にする

2 が必要だったのは、#5378 のスイープが `return i18n.T(` という形だけを見ており、

```go
return nil, i18n.T("cardIndexRequired")      // ← 2 つ目の戻り値なので未検出
```

のような形を取りこぼしていたためです。今回はキー名で全用例を拾いました。

## 実測

ヘルプの全行にある引数つきコマンドに、配った直後の盤面で不正な引数を与えた結果です。

| | 印付きで拒否 | 印なし |
|---|---|---|
| Before | 297 | 697 |
| After | **668** | 326 |

（994 = 引数つきコマンドの総数）

## テストについて

ヘルパ（`msgCardIndexRequired()` など）も印付きを返すようにしました。ヘルパは「パーサが実際に返すもの」を描画する役なので当然ですが、**これだけだと循環**になります。

そうならないのは `cui_error_helper_test.go` が **i18n に対して直接**次を検証しているからです。

- `StripErrorPrefix` が `isError=true` を返す
- 印を剥がすと `i18n.Tf` の文言に完全一致する
- 印付きの文字列が素の文言と**一致しない**

`invalidArg` から `MarkError` を外すと、この 3 つが落ちます（ヘルパ同士の比較なら全部通ってしまう）。

## 残り

印が付かない 326 コマンドは、キーではなく別経路（ゲーム個別のメッセージ、盤面再描画のみ）で拒否しています。うち 53 は**メッセージ自体が無く盤面を再描画するだけ**で、#5377 に残ります。

## 検証

- `go test -tags test ./internal/adapter/controller/ ./internal/infrastructure/ui/` — 緑
- `go build ./...` — 通過
- `golangci-lint run ./internal/...` — 0 issues

Refs #5377
