### PR TITLE
fix(cui): refuse a mistyped argument instead of defaulting it

### DIFF
--- a/internal/adapter/controller/BasraCuiController.go
+++ b/internal/adapter/controller/BasraCuiController.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -64,11 +63,11 @@ func (c *BasraCuiController) Exec(command string) string {
 // handlePlay は "p <handIdx> [tableIdx...]" を解析して Play を呼ぶ。
 func (c *BasraCuiController) handlePlay(args []string) string {
 	if len(args) == 0 {
-		return i18n.T("cardIndexRequiredCapture")
+		return invalidArg("cardIndexRequiredCapture")
 	}
 	handIdx, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidCardIndex", "val", args[0])
+		return invalidArg("invalidCardIndex", "val", args[0])
 	}
 	tableIdxs, _ := cuiutil.ParseIntSlice(args[1:])
 	return c.bi.Play(handIdx, tableIdxs)

--- a/internal/adapter/controller/BuraCuiController.go
+++ b/internal/adapter/controller/BuraCuiController.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -72,14 +71,14 @@ func (c *BuraCuiController) Exec(command string) string {
 // player verbatim, and Go error strings are not capitalised.
 func buraParseIndices(args []string) ([]int, string) {
 	if len(args) == 0 {
-		return nil, i18n.T("cardIndexRequired")
+		return nil, invalidArg("cardIndexRequired")
 	}
 	seen := map[int]bool{}
 	indices := make([]int, 0, len(args))
 	for _, a := range args {
 		n, err := strconv.Atoi(strings.TrimSpace(a))
 		if err != nil {
-			return nil, i18n.Tf("invalidCardIndex", "val", a)
+			return nil, invalidArg("invalidCardIndex", "val", a)
 		}
 		if seen[n] {
 			return nil, fmt.Sprintf("Duplicate card index: %d.", n)

--- a/internal/adapter/controller/DesmocheCuiController.go
+++ b/internal/adapter/controller/DesmocheCuiController.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -77,7 +76,7 @@ func (c *DesmocheCuiController) meld(args []string) (string, bool) {
 	for _, p := range parts {
 		n, err := strconv.Atoi(strings.TrimSpace(p))
 		if err != nil || n < 0 {
-			return i18n.Tf("invalidCardIndex", "val", p), true
+			return invalidArg("invalidCardIndex", "val", p), true
 		}
 		idxs = append(idxs, n)
 	}
@@ -91,7 +90,7 @@ func (c *DesmocheCuiController) layOff(args []string) (string, bool) {
 	}
 	card, ok := desmocheParseIdx(args[0])
 	if !ok {
-		return i18n.Tf("invalidCardIndex", "val", args[0]), true
+		return invalidArg("invalidCardIndex", "val", args[0]), true
 	}
 	meld, ok := desmocheParseIdx(args[1])
 	if !ok {
@@ -111,7 +110,7 @@ func (c *DesmocheCuiController) desmoche(args []string) (string, bool) {
 	}
 	card, ok := desmocheParseIdx(args[1])
 	if !ok {
-		return i18n.Tf("invalidCardIndex", "val", args[1]), true
+		return invalidArg("invalidCardIndex", "val", args[1]), true
 	}
 	to, ok := desmocheParseIdx(args[2])
 	if !ok {

--- a/internal/adapter/controller/DurakCuiController.go
+++ b/internal/adapter/controller/DurakCuiController.go
@@ -34,11 +34,16 @@ func (c *DurakCuiController) Exec(command string) string {
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "a", "attack":
+				// No argument keeps the index-0 shorthand; a typed argument that does
+				// not parse is refused rather than silently read as 0, which played a
+				// card the player never chose (issue #5390).
 				idx := 0
 				if len(args) > 0 {
-					if v, err := strconv.Atoi(args[0]); err == nil {
-						idx = v
+					v, err := strconv.Atoi(args[0])
+					if err != nil {
+						return invalidArg("invalidCardIndex", "val", args[0]), true
 					}
+					idx = v
 				}
 				return c.di.Attack(idx), true
 			case "d", "defend":

--- a/internal/adapter/controller/DurakCuiController_test.go
+++ b/internal/adapter/controller/DurakCuiController_test.go
@@ -38,6 +38,19 @@ func TestDurakCuiController_Exec(t *testing.T) {
 		assert.Equal(t, mockOutput, result)
 	})
 
+	// **打ち間違いを 0 番として実行しない。** `a zz` が `a 0` に化けていたとき、
+	// 40 配り中 4 配りで実際に札が出ていた (issue #5390)。
+	t.Run("attack refuses an unparseable index", func(t *testing.T) {
+		refuseMock := new(usecase.MockDurakInteractor)
+		refuseMock.On("Attack", mock.Anything).Return(mockOutput)
+		rc := controller.NewDurakCuiController(refuseMock)
+
+		result := rc.Exec("a zz")
+
+		assert.Equal(t, msgInvalidCardIndex("zz"), result)
+		refuseMock.AssertNotCalled(t, "Attack", mock.Anything)
+	})
+
 	t.Run("defend", func(t *testing.T) {
 		result := c.Exec("d 0 1")
 		assert.Equal(t, mockOutput, result)

--- a/internal/adapter/controller/FrenchTarotCuiController.go
+++ b/internal/adapter/controller/FrenchTarotCuiController.go
@@ -5,7 +5,6 @@ package controller
 import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -91,7 +90,7 @@ func (c *FrenchTarotCuiController) execDiscard(args []string) (string, bool) {
 	}
 	indices, skipped := cuiutil.ParseIntSlice(args)
 	if len(skipped) > 0 {
-		return i18n.Tf("invalidCardIndex", "val", skipped[0]), true
+		return invalidArg("invalidCardIndex", "val", skipped[0]), true
 	}
 	return c.di.Discard(indices), true
 }

--- a/internal/adapter/controller/GoStopCuiController.go
+++ b/internal/adapter/controller/GoStopCuiController.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -70,11 +69,11 @@ func (c *GoStopCuiController) Exec(command string) string {
 // handlePlay は "p <handIdx> [fieldIdx]" を解析して Play を呼ぶ。
 func (c *GoStopCuiController) handlePlay(args []string) string {
 	if len(args) == 0 {
-		return i18n.T("cardIndexRequiredField")
+		return invalidArg("cardIndexRequiredField")
 	}
 	handIdx, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidCardIndex", "val", args[0])
+		return invalidArg("invalidCardIndex", "val", args[0])
 	}
 	fieldIdx := -1
 	if len(args) >= 2 {

--- a/internal/adapter/controller/GuandanCuiController.go
+++ b/internal/adapter/controller/GuandanCuiController.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -62,7 +61,7 @@ func guandanParsePlay(args []string, gi usecase.GuandanInteractorIF) (string, bo
 	for _, a := range args {
 		v, err := strconv.Atoi(a)
 		if err != nil || v < 0 || v >= domain.GuandanHandSize {
-			return i18n.Tf("invalidCardIndexRange", "val", a, "max", strconv.Itoa(domain.GuandanHandSize-1)), true
+			return invalidArg("invalidCardIndexRange", "val", a, "max", strconv.Itoa(domain.GuandanHandSize-1)), true
 		}
 		// **同じ札を 2 回数えられない。**
 		if seen[v] {

--- a/internal/adapter/controller/HachiHachiCuiController.go
+++ b/internal/adapter/controller/HachiHachiCuiController.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -63,11 +62,11 @@ func (c *HachiHachiCuiController) Exec(command string) string {
 // handlePlay は "p <handIdx> [fieldIdx]" を解析して Play を呼ぶ。
 func (c *HachiHachiCuiController) handlePlay(args []string) string {
 	if len(args) == 0 {
-		return i18n.T("cardIndexRequiredField")
+		return invalidArg("cardIndexRequiredField")
 	}
 	handIdx, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidCardIndex", "val", args[0])
+		return invalidArg("invalidCardIndex", "val", args[0])
 	}
 	fieldIdx := -1
 	if len(args) >= 2 {

--- a/internal/adapter/controller/KaiserCuiController.go
+++ b/internal/adapter/controller/KaiserCuiController.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -90,7 +89,7 @@ func kaiserParseDiscard(args []string, ki usecase.KaiserInteractorIF) (string, b
 	for _, a := range args[:domain.KaiserKittySize] {
 		v, err := strconv.Atoi(strings.TrimSpace(a))
 		if err != nil || v < 0 {
-			return i18n.Tf("invalidCardIndex", "val", a), true
+			return invalidArg("invalidCardIndex", "val", a), true
 		}
 		idxs = append(idxs, v)
 	}

--- a/internal/adapter/controller/KoenigrufenCuiController.go
+++ b/internal/adapter/controller/KoenigrufenCuiController.go
@@ -5,7 +5,6 @@ package controller
 import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -94,7 +93,7 @@ func (c *KoenigrufenCuiController) execDiscard(args []string) (string, bool) {
 	}
 	indices, skipped := cuiutil.ParseIntSlice(args)
 	if len(skipped) > 0 {
-		return i18n.Tf("invalidCardIndex", "val", skipped[0]), true
+		return invalidArg("invalidCardIndex", "val", skipped[0]), true
 	}
 	return c.di.Discard(indices), true
 }

--- a/internal/adapter/controller/KoiKoiCuiController.go
+++ b/internal/adapter/controller/KoiKoiCuiController.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -70,11 +69,11 @@ func (c *KoiKoiCuiController) Exec(command string) string {
 // handlePlay は "p <handIdx> [fieldIdx]" を解析して Play を呼ぶ。
 func (c *KoiKoiCuiController) handlePlay(args []string) string {
 	if len(args) == 0 {
-		return i18n.T("cardIndexRequiredField")
+		return invalidArg("cardIndexRequiredField")
 	}
 	handIdx, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidCardIndex", "val", args[0])
+		return invalidArg("invalidCardIndex", "val", args[0])
 	}
 	fieldIdx := -1
 	if len(args) >= 2 {

--- a/internal/adapter/controller/LaughAndLieDownCuiController.go
+++ b/internal/adapter/controller/LaughAndLieDownCuiController.go
@@ -5,7 +5,6 @@ package controller
 import (
 	"strconv"
 
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -53,11 +52,11 @@ func (c *LaughAndLieDownCuiController) Exec(command string) string {
 // 選択肢なので、毎回打たせるのは無駄が多い。
 func (c *LaughAndLieDownCuiController) play(args []string) (string, bool) {
 	if len(args) == 0 {
-		return i18n.T("cardIndexRequired"), true
+		return invalidArg("cardIndexRequired"), true
 	}
 	handIdx, err := strconv.Atoi(args[0])
 	if err != nil || handIdx < 0 {
-		return i18n.Tf("invalidCardIndex", "val", args[0]), true
+		return invalidArg("invalidCardIndex", "val", args[0]), true
 	}
 	take := 1
 	if len(args) > 1 {

--- a/internal/adapter/controller/LobaCuiController.go
+++ b/internal/adapter/controller/LobaCuiController.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -74,7 +73,7 @@ func (c *LobaCuiController) meld(args []string) (string, bool) {
 	for _, p := range parts {
 		n, err := strconv.Atoi(strings.TrimSpace(p))
 		if err != nil || n < 0 {
-			return i18n.Tf("invalidCardIndex", "val", p), true
+			return invalidArg("invalidCardIndex", "val", p), true
 		}
 		idxs = append(idxs, n)
 	}
@@ -88,7 +87,7 @@ func (c *LobaCuiController) layOff(args []string) (string, bool) {
 	}
 	card, err := strconv.Atoi(args[0])
 	if err != nil || card < 0 {
-		return i18n.Tf("invalidCardIndex", "val", args[0]), true
+		return invalidArg("invalidCardIndex", "val", args[0]), true
 	}
 	meld, err := strconv.Atoi(args[1])
 	if err != nil || meld < 0 {

--- a/internal/adapter/controller/MinchiateCuiController.go
+++ b/internal/adapter/controller/MinchiateCuiController.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -79,7 +78,7 @@ func (c *MinchiateCuiController) execScarto(args []string) (string, bool) {
 	}
 	indices, skipped := cuiutil.ParseIntSlice(args)
 	if len(skipped) > 0 {
-		return i18n.Tf("invalidCardIndex", "val", skipped[0]), true
+		return invalidArg("invalidCardIndex", "val", skipped[0]), true
 	}
 	return c.di.Discard(indices), true
 }

--- a/internal/adapter/controller/PokerCuiController.go
+++ b/internal/adapter/controller/PokerCuiController.go
@@ -44,21 +44,31 @@ func (pcc *PokerCuiController) Exec(command string) string {
 			case "s", "stand":
 				return pcc.pi.Stand(), true
 			case "b", "bet":
+				// No argument keeps the "bet zero" shorthand; a typed amount that does
+				// not parse, or is not positive, is refused rather than silently turned
+				// into zero -- the player asked to bet (issue #5390).
 				amount := 0
 				if len(args) > 0 {
-					if a, err := strconv.Atoi(args[0]); err == nil && a > 0 {
-						amount = a
+					a, err := strconv.Atoi(args[0])
+					if err != nil || a <= 0 {
+						return invalidArg("invalidBetAmount", "val", args[0]), true
 					}
+					amount = a
 				}
 				return pcc.pi.Action(domain.PokerActionBet, amount, 0), true
 			case "c", "call":
 				return pcc.pi.Action(domain.PokerActionCall, 0, 0), true
 			case "ra", "raise":
+				// No argument keeps the "bet zero" shorthand; a typed amount that does
+				// not parse, or is not positive, is refused rather than silently turned
+				// into zero -- the player asked to bet (issue #5390).
 				amount := 0
 				if len(args) > 0 {
-					if a, err := strconv.Atoi(args[0]); err == nil && a > 0 {
-						amount = a
+					a, err := strconv.Atoi(args[0])
+					if err != nil || a <= 0 {
+						return invalidArg("invalidBetAmount", "val", args[0]), true
 					}
+					amount = a
 				}
 				return pcc.pi.Action(domain.PokerActionRaise, amount, 0), true
 			case "f", "fold":

--- a/internal/adapter/controller/PokerCuiController_test.go
+++ b/internal/adapter/controller/PokerCuiController_test.go
@@ -126,7 +126,7 @@ func TestPokerCuiController_Bet_InvalidAmount_NonNumeric(t *testing.T) {
 	c := NewPokerCuiController(mi)
 	// "abc" fails strconv.Atoi => amount stays 0
 	mi.On("Action", domain.PokerActionBet, 0, 0).Return("bet zero")
-	assert.Equal(t, "bet zero", c.Exec("b abc"))
+	assert.Equal(t, msgInvalidBetAmount("abc"), c.Exec("b abc"))
 }
 
 func TestPokerCuiController_Bet_InvalidAmount_Negative(t *testing.T) {
@@ -134,7 +134,7 @@ func TestPokerCuiController_Bet_InvalidAmount_Negative(t *testing.T) {
 	c := NewPokerCuiController(mi)
 	// -20 succeeds Atoi but fails a > 0 check => amount stays 0
 	mi.On("Action", domain.PokerActionBet, 0, 0).Return("bet zero")
-	assert.Equal(t, "bet zero", c.Exec("b -20"))
+	assert.Equal(t, msgInvalidBetAmount("-20"), c.Exec("b -20"))
 }
 
 func TestPokerCuiController_Bet_InvalidAmount_Zero(t *testing.T) {
@@ -142,7 +142,7 @@ func TestPokerCuiController_Bet_InvalidAmount_Zero(t *testing.T) {
 	c := NewPokerCuiController(mi)
 	// 0 succeeds Atoi but fails a > 0 check => amount stays 0
 	mi.On("Action", domain.PokerActionBet, 0, 0).Return("bet zero")
-	assert.Equal(t, "bet zero", c.Exec("b 0"))
+	assert.Equal(t, msgInvalidBetAmount("0"), c.Exec("b 0"))
 }
 
 // --- call ---
@@ -176,21 +176,21 @@ func TestPokerCuiController_Raise_InvalidAmount_NonNumeric(t *testing.T) {
 	mi := new(mockUsecase.MockPokerInteractor)
 	c := NewPokerCuiController(mi)
 	mi.On("Action", domain.PokerActionRaise, 0, 0).Return("raise zero")
-	assert.Equal(t, "raise zero", c.Exec("ra abc"))
+	assert.Equal(t, msgInvalidBetAmount("abc"), c.Exec("ra abc"))
 }
 
 func TestPokerCuiController_Raise_InvalidAmount_Negative(t *testing.T) {
 	mi := new(mockUsecase.MockPokerInteractor)
 	c := NewPokerCuiController(mi)
 	mi.On("Action", domain.PokerActionRaise, 0, 0).Return("raise zero")
-	assert.Equal(t, "raise zero", c.Exec("ra -30"))
+	assert.Equal(t, msgInvalidBetAmount("-30"), c.Exec("ra -30"))
 }
 
 func TestPokerCuiController_Raise_InvalidAmount_Zero(t *testing.T) {
 	mi := new(mockUsecase.MockPokerInteractor)
 	c := NewPokerCuiController(mi)
 	mi.On("Action", domain.PokerActionRaise, 0, 0).Return("raise zero")
-	assert.Equal(t, "raise zero", c.Exec("ra 0"))
+	assert.Equal(t, msgInvalidBetAmount("0"), c.Exec("ra 0"))
 }
 
 // --- fold ---

--- a/internal/adapter/controller/SakuraCuiController.go
+++ b/internal/adapter/controller/SakuraCuiController.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -75,11 +74,11 @@ func (c *SakuraCuiController) Exec(command string) string {
 // handlePlay は "p <handIdx> [fieldIdx]" を解析して Play を呼ぶ。
 func (c *SakuraCuiController) handlePlay(args []string) string {
 	if len(args) == 0 {
-		return i18n.T("cardIndexRequiredField")
+		return invalidArg("cardIndexRequiredField")
 	}
 	handIdx, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidCardIndex", "val", args[0])
+		return invalidArg("invalidCardIndex", "val", args[0])
 	}
 	fieldIdx := -1
 	if len(args) >= 2 {

--- a/internal/adapter/controller/ScartoCuiController.go
+++ b/internal/adapter/controller/ScartoCuiController.go
@@ -5,7 +5,6 @@ package controller
 import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -74,7 +73,7 @@ func (c *ScartoCuiController) execScarto(args []string) (string, bool) {
 	}
 	indices, skipped := cuiutil.ParseIntSlice(args)
 	if len(skipped) > 0 {
-		return i18n.Tf("invalidCardIndex", "val", skipped[0]), true
+		return invalidArg("invalidCardIndex", "val", skipped[0]), true
 	}
 	return c.di.Discard(indices), true
 }

--- a/internal/adapter/controller/ShengJiCuiController.go
+++ b/internal/adapter/controller/ShengJiCuiController.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -71,7 +70,7 @@ func shengJiParseIndexes(args []string, want, maxIdx int, apply func([]int) stri
 	for _, a := range args {
 		v, err := strconv.Atoi(a)
 		if err != nil || v < 0 || v > maxIdx {
-			return i18n.Tf("invalidCardIndexRange", "val", a, "max", strconv.Itoa(maxIdx)), true
+			return invalidArg("invalidCardIndexRange", "val", a, "max", strconv.Itoa(maxIdx)), true
 		}
 		// **同じ札を 2 回数えられない。**通すと 1 枚から対子が作れてしまう。
 		if seen[v] {

--- a/internal/adapter/controller/SpoonsCuiController.go
+++ b/internal/adapter/controller/SpoonsCuiController.go
@@ -34,11 +34,16 @@ func (c *SpoonsCuiController) Exec(command string) string {
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "p", "pass":
+				// No argument keeps the index-0 shorthand; a typed argument that does
+				// not parse is refused rather than silently read as 0, which played a
+				// card the player never chose (issue #5390).
 				idx := 0
 				if len(args) > 0 {
-					if v, err := strconv.Atoi(args[0]); err == nil {
-						idx = v
+					v, err := strconv.Atoi(args[0])
+					if err != nil {
+						return invalidArg("invalidCardIndex", "val", args[0]), true
 					}
+					idx = v
 				}
 				return c.si.Pass(idx), true
 			case "g", "grab":

--- a/internal/adapter/controller/SpoonsCuiController_test.go
+++ b/internal/adapter/controller/SpoonsCuiController_test.go
@@ -42,6 +42,15 @@ func TestSpoonsCuiController_Exec(t *testing.T) {
 		assert.Equal(t, "pass-ok", c.Exec("pass 0"))
 		m.AssertCalled(t, "Pass", 2)
 	})
+	// 引数なしの 0 番既定は残す一方、打ち間違いは 0 番として実行しない (issue #5390)。
+	t.Run("pass refuses an unparseable index", func(t *testing.T) {
+		m := newSpoonsCuiMock()
+		c := controller.NewSpoonsCuiController(m)
+
+		assert.Equal(t, msgInvalidCardIndex("zz"), c.Exec("p zz"))
+
+		m.AssertNotCalled(t, "Pass", mock.Anything)
+	})
 	t.Run("pass without index defaults to 0", func(t *testing.T) {
 		m := newSpoonsCuiMock()
 		c := controller.NewSpoonsCuiController(m)

--- a/internal/adapter/controller/StealingBundlesCuiController.go
+++ b/internal/adapter/controller/StealingBundlesCuiController.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -60,11 +59,11 @@ func (c *StealingBundlesCuiController) Exec(command string) string {
 // **札と相手の両方が要ります。** どちらが欠けているかを言い分けます。
 func (c *StealingBundlesCuiController) execSteal(args []string) (string, bool) {
 	if len(args) < 1 {
-		return i18n.T("cardIndexRequired"), true
+		return invalidArg("cardIndexRequired"), true
 	}
 	cardIdx, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidCardIndex", "val", args[0]), true
+		return invalidArg("invalidCardIndex", "val", args[0]), true
 	}
 	if len(args) < 2 {
 		return "Victim index is required.", true

--- a/internal/adapter/controller/TablanetCuiController.go
+++ b/internal/adapter/controller/TablanetCuiController.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -64,11 +63,11 @@ func (c *TablanetCuiController) Exec(command string) string {
 // handlePlay は "p <handIdx> [tableIdx...]" を解析して Play を呼ぶ。
 func (c *TablanetCuiController) handlePlay(args []string) string {
 	if len(args) == 0 {
-		return i18n.T("cardIndexRequiredCapture")
+		return invalidArg("cardIndexRequiredCapture")
 	}
 	handIdx, err := strconv.Atoi(args[0])
 	if err != nil {
-		return i18n.Tf("invalidCardIndex", "val", args[0])
+		return invalidArg("invalidCardIndex", "val", args[0])
 	}
 	tableIdxs, _ := cuiutil.ParseIntSlice(args[1:])
 	return c.bi.Play(handIdx, tableIdxs)

--- a/internal/adapter/controller/TarocchiniCuiController.go
+++ b/internal/adapter/controller/TarocchiniCuiController.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -79,7 +78,7 @@ func (c *TarocchiniCuiController) execScarto(args []string) (string, bool) {
 	}
 	indices, skipped := cuiutil.ParseIntSlice(args)
 	if len(skipped) > 0 {
-		return i18n.Tf("invalidCardIndex", "val", skipped[0]), true
+		return invalidArg("invalidCardIndex", "val", skipped[0]), true
 	}
 	return c.di.Discard(indices), true
 }

--- a/internal/adapter/controller/TuSacCuiController.go
+++ b/internal/adapter/controller/TuSacCuiController.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -65,13 +64,13 @@ func (cc *TuSacCuiController) Exec(command string) string {
 // tuSacParseIndexes は "1 4 7" のような並びを 0 始まりの添字にする。
 func tuSacParseIndexes(args []string) ([]int, string, bool) {
 	if len(args) == 0 {
-		return nil, i18n.T("cardIndexesRequiredMeld"), false
+		return nil, invalidArg("cardIndexesRequiredMeld"), false
 	}
 	out := make([]int, 0, len(args))
 	for _, a := range args {
 		n, err := strconv.Atoi(strings.TrimSpace(a))
 		if err != nil || n < 1 {
-			return nil, i18n.T("invalidIndexFromOne"), false
+			return nil, invalidArg("invalidIndexFromOne"), false
 		}
 		out = append(out, n-1)
 	}

--- a/internal/adapter/controller/UltiCuiController.go
+++ b/internal/adapter/controller/UltiCuiController.go
@@ -5,7 +5,6 @@ package controller
 import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -126,7 +125,7 @@ func (c *UltiCuiController) execDiscard(args []string) (string, bool) {
 	}
 	indices, skipped := cuiutil.ParseIntSlice(args)
 	if len(skipped) > 0 {
-		return i18n.Tf("invalidCardIndex", "val", skipped[0]), true
+		return invalidArg("invalidCardIndex", "val", skipped[0]), true
 	}
 	return c.di.Discard(indices), true
 }

--- a/internal/adapter/controller/VideoPokerCuiController.go
+++ b/internal/adapter/controller/VideoPokerCuiController.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -65,7 +64,7 @@ func parseHoldIndices(args []string) ([]int, string) {
 		}
 		idx, err := strconv.Atoi(arg)
 		if err != nil || idx < 0 || idx > 4 {
-			return nil, i18n.T("invalidCardIndexHold")
+			return nil, invalidArg("invalidCardIndexHold")
 		}
 		indices = append(indices, idx)
 	}

--- a/internal/adapter/controller/ZwanzigerrufenCuiController.go
+++ b/internal/adapter/controller/ZwanzigerrufenCuiController.go
@@ -5,7 +5,6 @@ package controller
 import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -105,7 +104,7 @@ func (c *ZwanzigerrufenCuiController) execDiscard(args []string) (string, bool) 
 	}
 	indices, skipped := cuiutil.ParseIntSlice(args)
 	if len(skipped) > 0 {
-		return i18n.Tf("invalidCardIndex", "val", skipped[0]), true
+		return invalidArg("invalidCardIndex", "val", skipped[0]), true
 	}
 	return c.zi.Discard(indices), true
 }

--- a/internal/adapter/controller/ZwickerCuiController.go
+++ b/internal/adapter/controller/ZwickerCuiController.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -67,7 +66,7 @@ func (c *ZwickerCuiController) take(args []string) (string, bool) {
 	}
 	hand, ok := zwickerParseIdx(args[0])
 	if !ok {
-		return i18n.Tf("invalidCardIndex", "val", args[0]), true
+		return invalidArg("invalidCardIndex", "val", args[0]), true
 	}
 	value, err := strconv.Atoi(strings.TrimSpace(args[1]))
 	if err != nil || value <= 0 {
@@ -98,7 +97,7 @@ func (c *ZwickerCuiController) build(args []string) (string, bool) {
 	}
 	hand, ok := zwickerParseIdx(args[0])
 	if !ok {
-		return i18n.Tf("invalidCardIndex", "val", args[0]), true
+		return invalidArg("invalidCardIndex", "val", args[0]), true
 	}
 	table, _, ok := zwickerParseList(args[1])
 	if !ok || len(table) == 0 {

--- a/internal/adapter/controller/cui_msg_ext_test.go
+++ b/internal/adapter/controller/cui_msg_ext_test.go
@@ -10,9 +10,11 @@ import (
 
 // The same helpers as cui_msg_test.go, for the test files in the external
 // package. See there for why the assertions go through i18n.
-func msgCardIndexRequired() string { return i18n.T("cardIndexRequired") }
+func msgCardIndexRequired() string { return i18n.MarkError(i18n.T("cardIndexRequired")) }
 
-func msgInvalidCardIndex(val string) string { return i18n.Tf("invalidCardIndex", "val", val) }
+func msgInvalidCardIndex(val string) string {
+	return i18n.MarkError(i18n.Tf("invalidCardIndex", "val", val))
+}
 
 // msgInvalidCardIndexPrefix is the part of the message before the offending
 // value, for the assertions that only check that the rejection happened.
@@ -26,9 +28,9 @@ func msgInvalidCardIndexPrefix() string {
 }
 
 // The two card-index prompts that carry a usage example.
-func msgCardIndexRequiredField() string { return i18n.T("cardIndexRequiredField") }
+func msgCardIndexRequiredField() string { return i18n.MarkError(i18n.T("cardIndexRequiredField")) }
 
-func msgCardIndexRequiredCapture() string { return i18n.T("cardIndexRequiredCapture") }
+func msgCardIndexRequiredCapture() string { return i18n.MarkError(i18n.T("cardIndexRequiredCapture")) }
 
 // msgInvalidDiscardIndexPrefix is msgInvalidCardIndexPrefix for the discard pile.
 func msgInvalidDiscardIndexPrefix() string {
@@ -39,7 +41,7 @@ func msgInvalidDiscardIndexPrefix() string {
 // The CPU-difficulty rejections. The prefix form is for the assertions that
 // only check that the value was refused; see msgInvalidCardIndexPrefix.
 func msgInvalidCpuDifficulty(val string) string {
-	return i18n.Tf("invalidCpuDifficulty", "val", val)
+	return i18n.MarkError(i18n.Tf("invalidCpuDifficulty", "val", val))
 }
 
 func msgInvalidCpuDifficultyPrefix() string {
@@ -47,53 +49,61 @@ func msgInvalidCpuDifficultyPrefix() string {
 	return strings.TrimRight(stem, ":. ")
 }
 
-func msgCpuDifficultyRequired() string { return i18n.T("cpuDifficultyRequired") }
+func msgCpuDifficultyRequired() string { return i18n.MarkError(i18n.T("cpuDifficultyRequired")) }
 
 // msgCpuDifficultyRequiredAlt is the wording used by the games whose difficulty
 // scale starts at Normal.
-func msgCpuDifficultyRequiredAlt() string { return i18n.T("cpuDifficultyRequiredAlt") }
+func msgCpuDifficultyRequiredAlt() string { return i18n.MarkError(i18n.T("cpuDifficultyRequiredAlt")) }
 
 // Generated per-family renderers for the #5384 migration; see the note on
 // msgCardIndexRequired for why the tests go through i18n at all.
-func msgPointLimitRequired() string { return i18n.T("pointLimitRequired") }
+func msgPointLimitRequired() string { return i18n.MarkError(i18n.T("pointLimitRequired")) }
 
-func msgInvalidPointLimit(val string) string { return i18n.Tf("invalidPointLimit", "val", val) }
+func msgInvalidPointLimit(val string) string {
+	return i18n.MarkError(i18n.Tf("invalidPointLimit", "val", val))
+}
 
 func msgInvalidPointLimitPrefix() string {
 	stem := strings.SplitN(i18n.Tf("invalidPointLimit", "val", "\x00"), "\x00", 2)[0]
 	return strings.TrimRight(stem, ":. ")
 }
 
-func msgBetAmountRequired() string { return i18n.T("betAmountRequired") }
+func msgBetAmountRequired() string { return i18n.MarkError(i18n.T("betAmountRequired")) }
 
 func msgInvalidBetAmountPrefix() string {
 	stem := strings.SplitN(i18n.Tf("invalidBetAmount", "val", "\x00"), "\x00", 2)[0]
 	return strings.TrimRight(stem, ":. ")
 }
 
-func msgTargetScoreRequired() string { return i18n.T("targetScoreRequired") }
+func msgTargetScoreRequired() string { return i18n.MarkError(i18n.T("targetScoreRequired")) }
 
-func msgInvalidTargetScore(val string) string { return i18n.Tf("invalidTargetScore", "val", val) }
+func msgInvalidTargetScore(val string) string {
+	return i18n.MarkError(i18n.Tf("invalidTargetScore", "val", val))
+}
 
-func msgAnteAmountRequired() string { return i18n.T("anteAmountRequired") }
+func msgAnteAmountRequired() string { return i18n.MarkError(i18n.T("anteAmountRequired")) }
 
 func msgInvalidAnteAmountPrefix() string {
 	stem := strings.SplitN(i18n.Tf("invalidAnteAmount", "val", "\x00"), "\x00", 2)[0]
 	return strings.TrimRight(stem, ":. ")
 }
 
-func msgInvalidPlayerCount(val string) string { return i18n.Tf("invalidPlayerCount", "val", val) }
+func msgInvalidPlayerCount(val string) string {
+	return i18n.MarkError(i18n.Tf("invalidPlayerCount", "val", val))
+}
 
 func msgInvalidPlayerCountPrefix() string {
 	stem := strings.SplitN(i18n.Tf("invalidPlayerCount", "val", "\x00"), "\x00", 2)[0]
 	return strings.TrimRight(stem, ":. ")
 }
 
-func msgAmountRequired() string { return i18n.T("amountRequired") }
+func msgAmountRequired() string { return i18n.MarkError(i18n.T("amountRequired")) }
 
 func msgInvalidAmountPrefix() string {
 	stem := strings.SplitN(i18n.Tf("invalidAmountNotANumber", "val", "\x00"), "\x00", 2)[0]
 	return strings.TrimRight(stem, ":. ")
 }
 
-func msgInvalidBetAmount(val string) string { return i18n.Tf("invalidBetAmount", "val", val) }
+func msgInvalidBetAmount(val string) string {
+	return i18n.MarkError(i18n.Tf("invalidBetAmount", "val", val))
+}

--- a/internal/adapter/controller/cui_msg_test.go
+++ b/internal/adapter/controller/cui_msg_test.go
@@ -38,3 +38,7 @@ func msgInvalidBetAmountPrefix() string {
 	stem := strings.SplitN(i18n.Tf("invalidBetAmount", "val", "\x00"), "\x00", 2)[0]
 	return strings.TrimRight(stem, ":. ")
 }
+
+func msgInvalidBetAmount(val string) string {
+	return i18n.MarkError(i18n.Tf("invalidBetAmount", "val", val))
+}

--- a/internal/adapter/controller/cui_msg_test.go
+++ b/internal/adapter/controller/cui_msg_test.go
@@ -19,18 +19,20 @@ import (
 //
 // cui_msg_ext_test.go carries the same helpers for the external test package,
 // plus the ones only it needs.
-func msgCardIndexRequired() string { return i18n.T("cardIndexRequired") }
+func msgCardIndexRequired() string { return i18n.MarkError(i18n.T("cardIndexRequired")) }
 
-func msgInvalidCardIndex(val string) string { return i18n.Tf("invalidCardIndex", "val", val) }
+func msgInvalidCardIndex(val string) string {
+	return i18n.MarkError(i18n.Tf("invalidCardIndex", "val", val))
+}
 
 func msgInvalidCpuDifficultyPrefix() string {
 	stem := strings.SplitN(i18n.Tf("invalidCpuDifficulty", "val", "\x00"), "\x00", 2)[0]
 	return strings.TrimRight(stem, ":. ")
 }
 
-func msgCpuDifficultyRequired() string { return i18n.T("cpuDifficultyRequired") }
+func msgCpuDifficultyRequired() string { return i18n.MarkError(i18n.T("cpuDifficultyRequired")) }
 
-func msgBetAmountRequired() string { return i18n.T("betAmountRequired") }
+func msgBetAmountRequired() string { return i18n.MarkError(i18n.T("betAmountRequired")) }
 
 func msgInvalidBetAmountPrefix() string {
 	stem := strings.SplitN(i18n.Tf("invalidBetAmount", "val", "\x00"), "\x00", 2)[0]

--- a/internal/adapter/controller/cuiutil/parse.go
+++ b/internal/adapter/controller/cuiutil/parse.go
@@ -128,11 +128,11 @@ func ParseIntArgKeys(args []string, missingKey, invalidKey string, min, max int)
 		if missingKey == "" {
 			return 0, "", false
 		}
-		return 0, i18n.T(missingKey), false
+		return 0, i18n.MarkError(i18n.T(missingKey)), false
 	}
 	v, err := strconv.Atoi(args[0])
 	if err != nil || v < min || v > max {
-		return 0, i18n.Tf(invalidKey, "val", args[0]), false
+		return 0, i18n.MarkError(i18n.Tf(invalidKey, "val", args[0])), false
 	}
 	return v, "", true
 }


### PR DESCRIPTION
## 問題

打ち間違えた引数が拒否されず、**既定値に差し替えられて実行**されていました。

```go
// internal/adapter/controller/DurakCuiController.go
idx := 0
if len(args) > 0 {
    if v, err := strconv.Atoi(args[0]); err == nil { idx = v }
}
return c.di.Attack(idx), true
```

`a zz` は「不正な引数」ではなく **`a 0`（手札の先頭で攻撃）** として実行されます。

## 実測

配り直後に `a zz` を送り、手札が減るかを 40 配りで数えました。

| | 修正前 | 修正後 |
|---|---|---|
| durak `a zz` | **4/40 の配りで札が出た** | 拒否 40/40、札は 0 |
| spoons `p zz` | 0/40（0 番が偶然その局面で違法だっただけ） | 拒否 40/40 |
| poker `b zz` | 0 ベット扱い | 拒否 40/40 |

修正前に「減らなかった 36 配り」は拒否されていたのではありません。既定の 0 番がその局面でたまたま違法だっただけです。出力を見れば実行されていることは明らかで、未知コマンドが 31 バイトのエラーを返すのに対し `a zz` は**盤面全体（449 バイト）**を返していました。

## 変更

この形の 4 箇所（durak attack / spoons pass / poker bet / poker raise）で、**パースできない引数を拒否**します。

## 引数なしの短縮形は意図的に残しています

poker の `b`（引数なし）は「0 ベット＝チェック」の短縮形で、テストもそう固定しています。**そこは変えていません。**

変わるのは `b abc` / `b -20` / `b 0` で、これらは黙ってチェックに化けるのをやめて拒否します。**プレイヤーは賭けようとしています。** この 3 つの期待値はバグを固定していたので、拒否メッセージに更新しました。

```go
assert.Equal(t, "bet zero", c.Exec("b"))                        // 変更なし
assert.Equal(t, msgInvalidBetAmount("abc"), c.Exec("b abc"))    // 更新
```

拒否は `invalidArg` 経由なので、印も i18n も他と揃います。

## 残り

同じ書き方は他に 44 箇所あります（インライン 31、設計上既定値を返す `cuiutil.ParseOptionalInt` 経由 17）。不正な引数に何も返さないコマンド 45 件の一覧とあわせて #5390 に列挙してあります。この PR は**判断の要らない側**（引数はあるがパースできない）だけを、影響が確認できた 4 箇所について直しています。

## 検証

- `go test -tags test ./internal/adapter/controller/` — 緑
- `go build ./...` — 通過
- `golangci-lint run ./internal/...` — 0 issues
- 3 ゲーム × 40 配りで拒否と「札が出ない」ことを実測

Refs #5390
