### PR TITLE
fix(cui): refuse a multi-card command with an unparseable index

### DIFF
--- a/internal/adapter/controller/AnacondaCuiController.go
+++ b/internal/adapter/controller/AnacondaCuiController.go
@@ -3,6 +3,8 @@
 package controller
 
 import (
+	"strings"
+
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
@@ -53,10 +55,22 @@ func (c *AnacondaCuiController) Exec(command string) string {
 			switch cmd {
 			case "p", "pass":
 				indices, skipped := cuiutil.ParseIntSlice(args)
-				return cuiutil.PrependSkippedWarning(c.ti.Pass(indices), skipped), true
+				// Refuse before playing. PrependSkippedWarning ran the move first and
+				// put the warning above the new board, so a mistyped index was dropped
+				// and the remaining ones played as a different, legal move (issue #5390).
+				if len(skipped) > 0 {
+					return invalidArg("invalidCardIndex", "val", strings.Join(skipped, ", ")), true
+				}
+				return c.ti.Pass(indices), true
 			case "k", "keep":
 				indices, skipped := cuiutil.ParseIntSlice(args)
-				return cuiutil.PrependSkippedWarning(c.ti.Keep(indices), skipped), true
+				// Refuse before playing. PrependSkippedWarning ran the move first and
+				// put the warning above the new board, so a mistyped index was dropped
+				// and the remaining ones played as a different, legal move (issue #5390).
+				if len(skipped) > 0 {
+					return invalidArg("invalidCardIndex", "val", strings.Join(skipped, ", ")), true
+				}
+				return c.ti.Keep(indices), true
 			case "c", "call":
 				return c.ti.Call(), true
 			case "ra", "raise":

--- a/internal/adapter/controller/AnacondaCuiController_test.go
+++ b/internal/adapter/controller/AnacondaCuiController_test.go
@@ -111,4 +111,15 @@ func TestAnacondaCuiController_Exec(t *testing.T) {
 	t.Run("unknown", func(t *testing.T) {
 		assert.NotEmpty(t, controller.NewAnacondaCuiController(newMock()).Exec("zzz"))
 	})
+
+	// **落として残りで実行しない。** 打ち間違いを捨てると、プレイヤーが
+	// 選んでいない組み合わせが実行される (issue #5390)。
+	t.Run("refuses a mistyped index", func(t *testing.T) {
+		m := newMock()
+		c := controller.NewAnacondaCuiController(m)
+		assert.Contains(t, c.Exec("p 0 zz"), msgInvalidCardIndexPrefix(),
+			"a mistyped index must be refused, not dropped")
+		assert.Contains(t, c.Exec("k 0 zz"), msgInvalidCardIndexPrefix(),
+			"a mistyped index must be refused, not dropped")
+	})
 }

--- a/internal/adapter/controller/BadugiCuiController.go
+++ b/internal/adapter/controller/BadugiCuiController.go
@@ -4,6 +4,7 @@ package controller
 
 import (
 	"strconv"
+	"strings"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
@@ -50,7 +51,13 @@ func (bcc *BadugiCuiController) Exec(command string) string {
 			switch cmd {
 			case "e", "exchange":
 				indices, skipped := cuiutil.ParseBoundedIntSlice(args, 0, domain.BadugiHandSize-1)
-				return cuiutil.PrependSkippedWarning(bcc.bi.Exchange(indices), skipped), true
+				// Refuse before playing. PrependSkippedWarning ran the move first and
+				// put the warning above the new board, so a mistyped index was dropped
+				// and the remaining ones played as a different, legal move (issue #5390).
+				if len(skipped) > 0 {
+					return invalidArg("invalidCardIndex", "val", strings.Join(skipped, ", ")), true
+				}
+				return bcc.bi.Exchange(indices), true
 			case "s", "stand":
 				return bcc.bi.Stand(), true
 			case "b", "bet":

--- a/internal/adapter/controller/BadugiCuiController_test.go
+++ b/internal/adapter/controller/BadugiCuiController_test.go
@@ -46,10 +46,9 @@ func TestBadugiCuiController_Exchange_OutOfRangeSkipped(t *testing.T) {
 	mi := newBadugiMockInteractor()
 	c := NewBadugiCuiController(mi)
 	// Badugi uses 4 cards, valid range 0..3. 4 is skipped, 1 is valid.
-	mi.On("Exchange", []int{1}).Return("exchange ok")
 	result := c.Exec("e 4 1")
-	assert.Contains(t, result, "'4'")
-	assert.Contains(t, result, "exchange ok")
+	assert.Contains(t, result, "4")
+	mi.AssertNotCalled(t, "Exchange", mock.Anything)
 }
 
 func TestBadugiCuiController_Exchange_NoIndices(t *testing.T) {

--- a/internal/adapter/controller/BigTwoCuiController.go
+++ b/internal/adapter/controller/BigTwoCuiController.go
@@ -1,6 +1,8 @@
 package controller
 
 import (
+	"strings"
+
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
@@ -29,7 +31,13 @@ func (c *BigTwoCuiController) Exec(command string) string {
 			switch cmd {
 			case "p", "play":
 				indices, skipped := cuiutil.ParseIntSlice(args)
-				return cuiutil.PrependSkippedWarning(c.bti.Play(indices), skipped), true
+				// Refuse before playing. PrependSkippedWarning ran the move first and
+				// put the warning above the new board, so a mistyped index was dropped
+				// and the remaining ones played as a different, legal move (issue #5390).
+				if len(skipped) > 0 {
+					return invalidArg("invalidCardIndex", "val", strings.Join(skipped, ", ")), true
+				}
+				return c.bti.Play(indices), true
 			case "sd", "setdifficulty":
 				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequiredAlt", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.bti.GetConfig()

--- a/internal/adapter/controller/BigTwoCuiController_test.go
+++ b/internal/adapter/controller/BigTwoCuiController_test.go
@@ -1,0 +1,78 @@
+//go:build test
+
+package controller_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
+	mockUsecases "github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/usecase"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+)
+
+// Big Two had no controller test at all -- and no interactor mock to write one
+// with -- which is why its rejection branch showed as 0% covered.
+func TestBigTwoCuiController_Exec(t *testing.T) {
+	mockOutput := `{"players":[]}`
+
+	newMock := func() *mockUsecases.MockBigTwoInteractor {
+		m := new(mockUsecases.MockBigTwoInteractor)
+		m.On("Reset").Return(mockOutput)
+		m.On("ResetWithConfig", mock.Anything).Return(mockOutput)
+		m.On("GetConfig").Return(domain.DefaultBigTwoConfig())
+		m.On("Play", mock.Anything).Return(mockOutput)
+		m.On("ActionLog").Return("log output")
+		return m
+	}
+
+	t.Run("play with indices", func(t *testing.T) {
+		m := newMock()
+		c := controller.NewBigTwoCuiController(m)
+
+		assert.Equal(t, mockOutput, c.Exec("p 0 1"))
+
+		m.AssertCalled(t, "Play", []int{0, 1})
+	})
+
+	// **引数なしがパス。** `p [idx ...]` の規則そのものなので、空スライスで
+	// 呼ばれることを固定しておく。
+	t.Run("play with no index passes", func(t *testing.T) {
+		m := newMock()
+		c := controller.NewBigTwoCuiController(m)
+
+		assert.Equal(t, mockOutput, c.Exec("p"))
+
+		m.AssertCalled(t, "Play", []int{})
+	})
+
+	// **落として残りで実行しない。** `p 0 zz` で zz を捨てると、ペアのつもりが
+	// 単札という別の合法手になる (issue #5390)。
+	t.Run("refuses a mistyped index", func(t *testing.T) {
+		m := newMock()
+		c := controller.NewBigTwoCuiController(m)
+
+		assert.Contains(t, c.Exec("p 0 zz"), msgInvalidCardIndexPrefix(),
+			"a mistyped index must be refused, not dropped")
+
+		m.AssertNotCalled(t, "Play", mock.Anything)
+	})
+
+	t.Run("set difficulty", func(t *testing.T) {
+		m := newMock()
+		c := controller.NewBigTwoCuiController(m)
+
+		assert.Equal(t, mockOutput, c.Exec("sd 1"))
+
+		m.AssertCalled(t, "ResetWithConfig", mock.Anything)
+	})
+
+	t.Run("action log", func(t *testing.T) {
+		m := newMock()
+		c := controller.NewBigTwoCuiController(m)
+
+		assert.Equal(t, "log output", c.Exec("l"))
+	})
+}

--- a/internal/adapter/controller/BourreCuiController.go
+++ b/internal/adapter/controller/BourreCuiController.go
@@ -3,6 +3,8 @@
 package controller
 
 import (
+	"strings"
+
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
@@ -38,7 +40,13 @@ func (c *BourreCuiController) Exec(command string) string {
 				})
 			case "dr", "draw":
 				indices, skipped := cuiutil.ParseIntSlice(args)
-				return cuiutil.PrependSkippedWarning(c.bgi.Draw(indices), skipped), true
+				// Refuse before playing. PrependSkippedWarning ran the move first and
+				// put the warning above the new board, so a mistyped index was dropped
+				// and the remaining ones played as a different, legal move (issue #5390).
+				if len(skipped) > 0 {
+					return invalidArg("invalidCardIndex", "val", strings.Join(skipped, ", ")), true
+				}
+				return c.bgi.Draw(indices), true
 			case "p", "play":
 				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", 0, 4, func(v int) string {
 					return c.bgi.Play(v)

--- a/internal/adapter/controller/BourreCuiController_test.go
+++ b/internal/adapter/controller/BourreCuiController_test.go
@@ -86,4 +86,13 @@ func TestBourreCuiController_Exec(t *testing.T) {
 		c := controller.NewBourreCuiController(m)
 		assert.Equal(t, `{"entries":[]}`, c.Exec("log"))
 	})
+
+	// **落として残りで実行しない。** 打ち間違いを捨てると、プレイヤーが
+	// 選んでいない組み合わせが実行される (issue #5390)。
+	t.Run("refuses a mistyped index", func(t *testing.T) {
+		m := newMock()
+		c := controller.NewBourreCuiController(m)
+		assert.Contains(t, c.Exec("dr 0 zz"), msgInvalidCardIndexPrefix(),
+			"a mistyped index must be refused, not dropped")
+	})
 }

--- a/internal/adapter/controller/CassinoCuiController.go
+++ b/internal/adapter/controller/CassinoCuiController.go
@@ -156,7 +156,10 @@ func (c *CassinoCuiController) handleTake(args []string) (string, bool) {
 	tableIdxs, skippedT := parseIntListArg(tableArgs)
 	buildIdxs, skippedB := parseIntListArg(buildArgs)
 	skipped := append(skippedT, skippedB...)
-	return cuiutil.PrependSkippedWarning(c.ci.Take(handIdx, tableIdxs, buildIdxs), skipped), true
+	if len(skipped) > 0 {
+		return invalidArg("invalidCardIndex", "val", strings.Join(skipped, ", ")), true
+	}
+	return c.ci.Take(handIdx, tableIdxs, buildIdxs), true
 }
 
 // handleBuild は `b <h> <value> <t1 t2 ...>` を処理する。
@@ -173,7 +176,10 @@ func (c *CassinoCuiController) handleBuild(args []string) (string, bool) {
 		return "Invalid build value: " + args[1], true
 	}
 	tableIdxs, skipped := parseIntListArg(args[2:])
-	return cuiutil.PrependSkippedWarning(c.ci.Build(handIdx, tableIdxs, value), skipped), true
+	if len(skipped) > 0 {
+		return invalidArg("invalidCardIndex", "val", strings.Join(skipped, ", ")), true
+	}
+	return c.ci.Build(handIdx, tableIdxs, value), true
 }
 
 // handleTrail は `tr <h>` を処理する。

--- a/internal/adapter/controller/CassinoCuiController_test.go
+++ b/internal/adapter/controller/CassinoCuiController_test.go
@@ -156,4 +156,15 @@ func TestCassinoCuiController_Exec(t *testing.T) {
 		c := controller.NewCassinoCuiController(m)
 		assert.Equal(t, "log", c.Exec("log"))
 	})
+
+	// **落として残りで実行しない。** 打ち間違いを捨てると、プレイヤーが
+	// 選んでいない組み合わせが実行される (issue #5390)。
+	t.Run("refuses a mistyped index", func(t *testing.T) {
+		m := newMock()
+		c := controller.NewCassinoCuiController(m)
+		assert.Contains(t, c.Exec("t 0 zz"), msgInvalidCardIndexPrefix(),
+			"a mistyped index must be refused, not dropped")
+		assert.Contains(t, c.Exec("t 0 b zz"), msgInvalidCardIndexPrefix(),
+			"a mistyped index must be refused, not dropped")
+	})
 }

--- a/internal/adapter/controller/DaifugoCuiController.go
+++ b/internal/adapter/controller/DaifugoCuiController.go
@@ -163,7 +163,13 @@ func (c *DaifugoCuiController) Exec(command string) string {
 			switch cmd {
 			case "p", "play":
 				indices, skipped := cuiutil.ParseIntSlice(args)
-				return cuiutil.PrependSkippedWarning(c.dgi.Play(indices), skipped), true
+				// Refuse before playing. PrependSkippedWarning ran the move first and
+				// put the warning above the new board, so a mistyped index was dropped
+				// and the remaining ones played as a different, legal move (issue #5390).
+				if len(skipped) > 0 {
+					return invalidArg("invalidCardIndex", "val", strings.Join(skipped, ", ")), true
+				}
+				return c.dgi.Play(indices), true
 			case "sort":
 				mode := domain.DaifugoSortByStrength
 				if len(args) > 0 {

--- a/internal/adapter/controller/DaifugoCuiController_test.go
+++ b/internal/adapter/controller/DaifugoCuiController_test.go
@@ -130,13 +130,14 @@ func TestDaifugoCuiController_Exec(t *testing.T) {
 		m.AssertCalled(t, "Sort", domain.DaifugoSortByStrength)
 	})
 
-	t.Run("play command ignores non-numeric index with warning", func(t *testing.T) {
+	// **打ち間違いを捨てて残りで出さない。** 3 枚のつもりが 2 枚として通ると、
+	// 単札とペアのように別の合法手になってしまう (issue #5390)。
+	t.Run("play command refuses a non-numeric index", func(t *testing.T) {
 		m := newMock()
 		c := controller.NewDaifugoCuiController(m)
 		result := c.Exec("p 0 abc 2")
-		assert.Contains(t, result, "'abc'")
-		assert.Contains(t, result, mockOutput)
-		m.AssertCalled(t, "Play", []int{0, 2})
+		assert.Contains(t, result, "abc")
+		m.AssertNotCalled(t, "Play", mock.Anything)
 	})
 
 	t.Run("play command no warning when all valid", func(t *testing.T) {

--- a/internal/adapter/controller/DeuceToSevenCuiController.go
+++ b/internal/adapter/controller/DeuceToSevenCuiController.go
@@ -4,6 +4,7 @@ package controller
 
 import (
 	"strconv"
+	"strings"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
@@ -52,7 +53,13 @@ func (dcc *DeuceToSevenCuiController) Exec(command string) string {
 			switch cmd {
 			case "e", "exchange":
 				indices, skipped := cuiutil.ParseBoundedIntSlice(args, 0, domain.DeuceToSevenHandSize-1)
-				return cuiutil.PrependSkippedWarning(dcc.di.Exchange(indices), skipped), true
+				// Refuse before playing. PrependSkippedWarning ran the move first and
+				// put the warning above the new board, so a mistyped index was dropped
+				// and the remaining ones played as a different, legal move (issue #5390).
+				if len(skipped) > 0 {
+					return invalidArg("invalidCardIndex", "val", strings.Join(skipped, ", ")), true
+				}
+				return dcc.di.Exchange(indices), true
 			case "s", "stand":
 				return dcc.di.Stand(), true
 			case "h", "hint":

--- a/internal/adapter/controller/DeuceToSevenCuiController_test.go
+++ b/internal/adapter/controller/DeuceToSevenCuiController_test.go
@@ -49,10 +49,9 @@ func TestDeuceToSevenCuiController_Exchange_OutOfRangeSkipped(t *testing.T) {
 	mi := newDeuceToSevenMockInteractor()
 	c := NewDeuceToSevenCuiController(mi)
 	// 2-7 uses 5 cards, valid range 0..4. 5 is skipped, 1 is valid.
-	mi.On("Exchange", []int{1}).Return("exchange ok")
 	result := c.Exec("e 5 1")
-	assert.Contains(t, result, "'5'")
-	assert.Contains(t, result, "exchange ok")
+	assert.Contains(t, result, "5")
+	mi.AssertNotCalled(t, "Exchange", mock.Anything)
 }
 
 func TestDeuceToSevenCuiController_Exchange_NoIndices(t *testing.T) {

--- a/internal/adapter/controller/DoubtCuiController.go
+++ b/internal/adapter/controller/DoubtCuiController.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"math"
+	"strings"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
@@ -52,10 +53,22 @@ func (c *DoubtCuiController) Exec(command string) string {
 					cardArgs = args[1:]
 				}
 				indices, skipped := cuiutil.ParseIntSlice(cardArgs)
-				return cuiutil.PrependSkippedWarning(c.di.Play(indices, claimedValue, 0), skipped), true
+				// Refuse before playing. PrependSkippedWarning ran the move first and
+				// put the warning above the new board, so a mistyped index was dropped
+				// and the remaining ones played as a different, legal move (issue #5390).
+				if len(skipped) > 0 {
+					return invalidArg("invalidCardIndex", "val", strings.Join(skipped, ", ")), true
+				}
+				return c.di.Play(indices, claimedValue, 0), true
 			case "d", "doubt":
 				indices, skipped := cuiutil.ParseIntSlice(args)
-				return cuiutil.PrependSkippedWarning(c.di.ResolveDoubt(indices), skipped), true
+				// Refuse before playing. PrependSkippedWarning ran the move first and
+				// put the warning above the new board, so a mistyped index was dropped
+				// and the remaining ones played as a different, legal move (issue #5390).
+				if len(skipped) > 0 {
+					return invalidArg("invalidCardIndex", "val", strings.Join(skipped, ", ")), true
+				}
+				return c.di.ResolveDoubt(indices), true
 			case "s", "skip":
 				return c.di.SkipDoubt(), true
 			case "sw", "setwindow":

--- a/internal/adapter/controller/DoubtCuiController_test.go
+++ b/internal/adapter/controller/DoubtCuiController_test.go
@@ -306,22 +306,20 @@ func TestDoubtCuiController_Exec(t *testing.T) {
 		m.AssertCalled(t, "ResetProfile")
 	})
 
-	t.Run("play command with invalid card args shows warning", func(t *testing.T) {
+	t.Run("play command refuses invalid card args", func(t *testing.T) {
 		m := newMock()
 		c := controller.NewDoubtCuiController(m)
 		result := c.Exec("p 5 abc 2")
-		assert.Contains(t, result, "'abc'")
-		assert.Contains(t, result, mockOutput)
-		m.AssertCalled(t, "Play", []int{2}, 5, 0)
+		assert.Contains(t, result, "abc")
+		m.AssertNotCalled(t, "Play", mock.Anything, mock.Anything, mock.Anything)
 	})
 
-	t.Run("doubt command with invalid args shows warning", func(t *testing.T) {
+	t.Run("doubt command refuses invalid args", func(t *testing.T) {
 		m := newMock()
 		c := controller.NewDoubtCuiController(m)
 		result := c.Exec("d xyz 1")
-		assert.Contains(t, result, "'xyz'")
-		assert.Contains(t, result, mockOutput)
-		m.AssertCalled(t, "ResolveDoubt", []int{1})
+		assert.Contains(t, result, "xyz")
+		m.AssertNotCalled(t, "ResolveDoubt", mock.Anything)
 	})
 
 	t.Run("unknown command", func(t *testing.T) {

--- a/internal/adapter/controller/DoudizhuCuiController.go
+++ b/internal/adapter/controller/DoudizhuCuiController.go
@@ -4,6 +4,7 @@ package controller
 
 import (
 	"strconv"
+	"strings"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
@@ -36,7 +37,13 @@ func (c *DoudizhuCuiController) Exec(command string) string {
 			switch cmd {
 			case "p", "play":
 				indices, skipped := cuiutil.ParseIntSlice(args)
-				return cuiutil.PrependSkippedWarning(c.dgi.Play(indices), skipped), true
+				// Refuse before playing. PrependSkippedWarning ran the move first and
+				// put the warning above the new board, so a mistyped index was dropped
+				// and the remaining ones played as a different, legal move (issue #5390).
+				if len(skipped) > 0 {
+					return invalidArg("invalidCardIndex", "val", strings.Join(skipped, ", ")), true
+				}
+				return c.dgi.Play(indices), true
 			case "b", "bid":
 				if len(args) == 0 {
 					return c.dgi.Bid(0), true

--- a/internal/adapter/controller/DoudizhuCuiController_test.go
+++ b/internal/adapter/controller/DoudizhuCuiController_test.go
@@ -83,4 +83,13 @@ func TestDoudizhuCuiController_Exec(t *testing.T) {
 		c := controller.NewDoudizhuCuiController(m)
 		assert.Equal(t, `{"entries":[]}`, c.Exec("log"))
 	})
+
+	// **落として残りで実行しない。** 打ち間違いを捨てると、プレイヤーが
+	// 選んでいない組み合わせが実行される (issue #5390)。
+	t.Run("refuses a mistyped index", func(t *testing.T) {
+		m := newMock()
+		c := controller.NewDoudizhuCuiController(m)
+		assert.Contains(t, c.Exec("p 0 zz"), msgInvalidCardIndexPrefix(),
+			"a mistyped index must be refused, not dropped")
+	})
 }

--- a/internal/adapter/controller/DurakCuiController.go
+++ b/internal/adapter/controller/DurakCuiController.go
@@ -47,17 +47,23 @@ func (c *DurakCuiController) Exec(command string) string {
 				}
 				return c.di.Attack(idx), true
 			case "d", "defend":
+				// Same rule as attack: a typed argument that does not parse is
+				// refused rather than read as 0 (issue #5390).
 				atkIdx := 0
 				handIdx := 0
 				if len(args) > 0 {
-					if v, err := strconv.Atoi(args[0]); err == nil {
-						atkIdx = v
+					v, err := strconv.Atoi(args[0])
+					if err != nil {
+						return invalidArg("invalidCardIndex", "val", args[0]), true
 					}
+					atkIdx = v
 				}
 				if len(args) > 1 {
-					if v, err := strconv.Atoi(args[1]); err == nil {
-						handIdx = v
+					v, err := strconv.Atoi(args[1])
+					if err != nil {
+						return invalidArg("invalidCardIndex", "val", args[1]), true
 					}
+					handIdx = v
 				}
 				return c.di.Defend(atkIdx, handIdx), true
 			case "p", "pass":

--- a/internal/adapter/controller/DurakCuiController_test.go
+++ b/internal/adapter/controller/DurakCuiController_test.go
@@ -40,6 +40,17 @@ func TestDurakCuiController_Exec(t *testing.T) {
 
 	// **打ち間違いを 0 番として実行しない。** `a zz` が `a 0` に化けていたとき、
 	// 40 配り中 4 配りで実際に札が出ていた (issue #5390)。
+	t.Run("defend refuses an unparseable index", func(t *testing.T) {
+		refuseMock := new(usecase.MockDurakInteractor)
+		refuseMock.On("Defend", mock.Anything, mock.Anything).Return(mockOutput)
+		rc := controller.NewDurakCuiController(refuseMock)
+
+		assert.Equal(t, msgInvalidCardIndex("zz"), rc.Exec("d zz 1"))
+		assert.Equal(t, msgInvalidCardIndex("zz"), rc.Exec("d 0 zz"))
+
+		refuseMock.AssertNotCalled(t, "Defend", mock.Anything, mock.Anything)
+	})
+
 	t.Run("attack refuses an unparseable index", func(t *testing.T) {
 		refuseMock := new(usecase.MockDurakInteractor)
 		refuseMock.On("Attack", mock.Anything).Return(mockOutput)

--- a/internal/adapter/controller/EcarteCuiController.go
+++ b/internal/adapter/controller/EcarteCuiController.go
@@ -4,6 +4,7 @@ package controller
 
 import (
 	"math"
+	"strings"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
@@ -62,7 +63,13 @@ func (c *EcarteCuiController) Exec(command string) string {
 				return c.ei.Respond(false), true
 			case "d", "discard":
 				indices, skipped := cuiutil.ParseBoundedIntSlice(args, 0, domain.EcarteHandSize-1)
-				return cuiutil.PrependSkippedWarning(c.ei.Discard(indices), skipped), true
+				// Refuse before playing. PrependSkippedWarning ran the move first and
+				// put the warning above the new board, so a mistyped index was dropped
+				// and the remaining ones played as a different, legal move (issue #5390).
+				if len(skipped) > 0 {
+					return invalidArg("invalidCardIndex", "val", strings.Join(skipped, ", ")), true
+				}
+				return c.ei.Discard(indices), true
 			case "p", "play":
 				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.ei.Play)
 			case "n", "next", "nextround":

--- a/internal/adapter/controller/EcarteCuiController_test.go
+++ b/internal/adapter/controller/EcarteCuiController_test.go
@@ -176,4 +176,13 @@ func TestEcarteCuiController_Exec(t *testing.T) {
 		assert.NotEqual(t, "bye.", got)
 		assert.NotEmpty(t, got)
 	})
+
+	// **落として残りで実行しない。** 打ち間違いを捨てると、プレイヤーが
+	// 選んでいない組み合わせが実行される (issue #5390)。
+	t.Run("refuses a mistyped index", func(t *testing.T) {
+		m := newMock()
+		c := controller.NewEcarteCuiController(m)
+		assert.Contains(t, c.Exec("d 0 zz"), msgInvalidCardIndexPrefix(),
+			"a mistyped index must be refused, not dropped")
+	})
 }

--- a/internal/adapter/controller/EscobaCuiController.go
+++ b/internal/adapter/controller/EscobaCuiController.go
@@ -3,6 +3,8 @@
 package controller
 
 import (
+	"strings"
+
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
@@ -71,5 +73,11 @@ func (c *EscobaCuiController) handlePlay(args []string) (string, bool) {
 		return "Invalid hand index: " + args[0], true
 	}
 	tableIdxs, skipped := cuiutil.ParseIntSlice(args[1:])
-	return cuiutil.PrependSkippedWarning(c.ei.Play(handIdx, tableIdxs), skipped), true
+	// Refuse before playing. PrependSkippedWarning ran the move first and
+	// put the warning above the new board, so a mistyped index was dropped
+	// and the remaining ones played as a different, legal move (issue #5390).
+	if len(skipped) > 0 {
+		return invalidArg("invalidCardIndex", "val", strings.Join(skipped, ", ")), true
+	}
+	return c.ei.Play(handIdx, tableIdxs), true
 }

--- a/internal/adapter/controller/EscobaCuiController_test.go
+++ b/internal/adapter/controller/EscobaCuiController_test.go
@@ -100,4 +100,13 @@ func TestEscobaCuiController_Exec(t *testing.T) {
 		c := controller.NewEscobaCuiController(m)
 		assert.Equal(t, "log", c.Exec("log"))
 	})
+
+	// **落として残りで実行しない。** 打ち間違いを捨てると、プレイヤーが
+	// 選んでいない組み合わせが実行される (issue #5390)。
+	t.Run("refuses a mistyped index", func(t *testing.T) {
+		m := newMock()
+		c := controller.NewEscobaCuiController(m)
+		assert.Contains(t, c.Exec("p 0 zz"), msgInvalidCardIndexPrefix(),
+			"a mistyped index must be refused, not dropped")
+	})
 }

--- a/internal/adapter/controller/GongZhuCuiController.go
+++ b/internal/adapter/controller/GongZhuCuiController.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"math"
+	"strings"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
@@ -46,7 +47,13 @@ func (c *GongZhuCuiController) Exec(command string) string {
 			switch cmd {
 			case "expose":
 				indices, skipped := cuiutil.ParseIntSlice(args)
-				return cuiutil.PrependSkippedWarning(c.gi.Expose(indices), skipped), true
+				// Refuse before playing. PrependSkippedWarning ran the move first and
+				// put the warning above the new board, so a mistyped index was dropped
+				// and the remaining ones played as a different, legal move (issue #5390).
+				if len(skipped) > 0 {
+					return invalidArg("invalidCardIndex", "val", strings.Join(skipped, ", ")), true
+				}
+				return c.gi.Expose(indices), true
 			case "p", "play":
 				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.gi.Play)
 			case "n", "next":

--- a/internal/adapter/controller/GongZhuCuiController_test.go
+++ b/internal/adapter/controller/GongZhuCuiController_test.go
@@ -55,12 +55,12 @@ func TestGongZhuCuiController_Exec(t *testing.T) {
 		m.AssertCalled(t, "Expose", []int{})
 	})
 
-	t.Run("expose with invalid arg shows warning", func(t *testing.T) {
+	t.Run("expose refuses an invalid arg", func(t *testing.T) {
 		m := newMock()
 		c := controller.NewGongZhuCuiController(m)
 		result := c.Exec("expose 0 x 1")
-		assert.Contains(t, result, "'x'")
-		m.AssertCalled(t, "Expose", []int{0, 1})
+		assert.Contains(t, result, "x")
+		m.AssertNotCalled(t, "Expose", mock.Anything)
 	})
 
 	t.Run("play", func(t *testing.T) {

--- a/internal/adapter/controller/HeartsCuiController.go
+++ b/internal/adapter/controller/HeartsCuiController.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"math"
+	"strings"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
@@ -46,13 +47,15 @@ func (c *HeartsCuiController) Exec(command string) string {
 			switch cmd {
 			case "pass":
 				indices, skipped := cuiutil.ParseIntSlice(args)
-				var result string
-				if len(indices) != 3 {
-					result = "Pass requires exactly 3 card indices."
-				} else {
-					result = c.hi.Pass(indices)
+				// Refuse before counting: dropping a mistyped index could leave
+				// exactly three and pass a hand the player never chose (#5390).
+				if len(skipped) > 0 {
+					return invalidArg("invalidCardIndex", "val", strings.Join(skipped, ", ")), true
 				}
-				return cuiutil.PrependSkippedWarning(result, skipped), true
+				if len(indices) != 3 {
+					return "Pass requires exactly 3 card indices.", true
+				}
+				return c.hi.Pass(indices), true
 			case "p", "play":
 				return cuiutil.WithParsedIntKeys(args, "cardIndexRequired", "invalidCardIndex", cuiutil.NoMin, cuiutil.NoMax, c.hi.Play)
 			case "n", "next":

--- a/internal/adapter/controller/HeartsCuiController_test.go
+++ b/internal/adapter/controller/HeartsCuiController_test.go
@@ -86,27 +86,37 @@ func TestHeartsCuiController_Exec(t *testing.T) {
 		assert.Contains(t, result, "exactly 3")
 	})
 
-	t.Run("pass with non-numeric args shows warning", func(t *testing.T) {
+	t.Run("pass refuses non-numeric args", func(t *testing.T) {
 		c := controller.NewHeartsCuiController(newMock())
 		result := c.Exec("pass a b c")
-		assert.Contains(t, result, "exactly 3")
 		assert.Contains(t, result, "a")
+		assert.NotContains(t, result, "exactly 3",
+			"the count is only meaningful once every index parsed")
 	})
 
-	t.Run("pass with mixed numeric and non-numeric args shows warning", func(t *testing.T) {
-		c := controller.NewHeartsCuiController(newMock())
-		result := c.Exec("pass 0 a 2")
-		assert.Contains(t, result, "exactly 3")
-		assert.Contains(t, result, "a")
-	})
-
-	t.Run("pass with 3 valid and invalid args shows warning", func(t *testing.T) {
+	// **落として数えない。** `pass 0 a 2 3` は a を捨てると 3 枚になり、
+	// プレイヤーが選んでいない組み合わせを渡してしまう (issue #5390)。
+	t.Run("pass refuses a mistyped index instead of dropping it", func(t *testing.T) {
 		m := newMock()
 		c := controller.NewHeartsCuiController(m)
+
+		result := c.Exec("pass 0 a 2 3")
+
+		assert.Contains(t, result, "a")
+		m.AssertNotCalled(t, "Pass", mock.Anything)
+	})
+
+	// This is the case the drop-and-continue behaviour was worst for: `abc` is
+	// discarded, the remaining three happen to be a legal pass, and a hand the
+	// player never chose goes across (issue #5390).
+	t.Run("pass refuses even when the survivors number three", func(t *testing.T) {
+		m := newMock()
+		c := controller.NewHeartsCuiController(m)
+
 		result := c.Exec("pass 0 abc 1 2")
+
 		assert.Contains(t, result, "abc")
-		assert.Contains(t, result, mockOutput)
-		m.AssertCalled(t, "Pass", []int{0, 1, 2})
+		m.AssertNotCalled(t, "Pass", mock.Anything)
 	})
 
 	// play

--- a/internal/adapter/controller/HeartsCuiController_test.go
+++ b/internal/adapter/controller/HeartsCuiController_test.go
@@ -90,21 +90,21 @@ func TestHeartsCuiController_Exec(t *testing.T) {
 		c := controller.NewHeartsCuiController(newMock())
 		result := c.Exec("pass a b c")
 		assert.Contains(t, result, "exactly 3")
-		assert.Contains(t, result, "'a'")
+		assert.Contains(t, result, "a")
 	})
 
 	t.Run("pass with mixed numeric and non-numeric args shows warning", func(t *testing.T) {
 		c := controller.NewHeartsCuiController(newMock())
 		result := c.Exec("pass 0 a 2")
 		assert.Contains(t, result, "exactly 3")
-		assert.Contains(t, result, "'a'")
+		assert.Contains(t, result, "a")
 	})
 
 	t.Run("pass with 3 valid and invalid args shows warning", func(t *testing.T) {
 		m := newMock()
 		c := controller.NewHeartsCuiController(m)
 		result := c.Exec("pass 0 abc 1 2")
-		assert.Contains(t, result, "'abc'")
+		assert.Contains(t, result, "abc")
 		assert.Contains(t, result, mockOutput)
 		m.AssertCalled(t, "Pass", []int{0, 1, 2})
 	})

--- a/internal/adapter/controller/OasisPokerCuiController.go
+++ b/internal/adapter/controller/OasisPokerCuiController.go
@@ -4,6 +4,7 @@ package controller
 
 import (
 	"math"
+	"strings"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
@@ -45,7 +46,13 @@ func (oc *OasisPokerCuiController) Exec(command string) string {
 				return oc.oi.Bet(ante, jackpot), true
 			case "e", "exchange":
 				indices, skipped := cuiutil.ParseBoundedIntSlice(args, 0, 4)
-				return cuiutil.PrependSkippedWarning(oc.oi.Exchange(indices), skipped), true
+				// Refuse before playing. PrependSkippedWarning ran the move first and
+				// put the warning above the new board, so a mistyped index was dropped
+				// and the remaining ones played as a different, legal move (issue #5390).
+				if len(skipped) > 0 {
+					return invalidArg("invalidCardIndex", "val", strings.Join(skipped, ", ")), true
+				}
+				return oc.oi.Exchange(indices), true
 			case "s", "stand":
 				return oc.oi.Stand(), true
 			case "p", "play":

--- a/internal/adapter/controller/OasisPokerCuiController_test.go
+++ b/internal/adapter/controller/OasisPokerCuiController_test.go
@@ -163,3 +163,12 @@ func TestOasisPokerCuiController_Hint(t *testing.T) {
 	assert.Equal(t, "hint result", c.Exec("hint"))
 	m.AssertCalled(t, "Hint")
 }
+
+// **落として残りで実行しない。** 打ち間違いを捨てると、プレイヤーが選んで
+// いない組み合わせが実行される (issue #5390)。
+func TestOasisPokerCuiController_RefusesMistypedIndex(t *testing.T) {
+	m := newMockOasisPokerInteractor()
+	c := controller.NewOasisPokerCuiController(m)
+	assert.Contains(t, c.Exec("e 0 zz"), msgInvalidCardIndexPrefix(),
+		"a mistyped index must be refused, not dropped")
+}

--- a/internal/adapter/controller/OldMaidCuiController.go
+++ b/internal/adapter/controller/OldMaidCuiController.go
@@ -1,6 +1,8 @@
 package controller
 
 import (
+	"strings"
+
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
@@ -37,7 +39,13 @@ func (c *OldMaidCuiController) Exec(command string) string {
 				return c.omi.Shuffle(), true
 			case "ro", "reorder":
 				indices, skipped := cuiutil.ParseIntSlice(args)
-				return cuiutil.PrependSkippedWarning(c.omi.Reorder(indices), skipped), true
+				// Refuse before playing. PrependSkippedWarning ran the move first and
+				// put the warning above the new board, so a mistyped index was dropped
+				// and the remaining ones played as a different, legal move (issue #5390).
+				if len(skipped) > 0 {
+					return invalidArg("invalidCardIndex", "val", strings.Join(skipped, ", ")), true
+				}
+				return c.omi.Reorder(indices), true
 			case "sm", "setmode":
 				return cuiutil.WithParsedInt(args, "Game mode is required (0=Normal, 1=JijiNuki).", "Invalid game mode: %s. Please enter 0-1.", 0, 1, func(v int) string {
 					cfg := c.omi.GetConfig()

--- a/internal/adapter/controller/OldMaidCuiController_test.go
+++ b/internal/adapter/controller/OldMaidCuiController_test.go
@@ -94,8 +94,8 @@ func TestOldMaidCuiController_Reorder_InvalidIndex_NonNumeric(t *testing.T) {
 	c := controller.NewOldMaidCuiController(mi)
 	mi.On("Reorder", []int{2}).Return("reorder ok")
 	result := c.Exec("ro abc 2")
-	assert.Contains(t, result, "'abc'")
-	assert.Contains(t, result, "reorder ok")
+	assert.Contains(t, result, "abc")
+	mi.AssertNotCalled(t, "Reorder", mock.Anything)
 }
 
 // --- set mode ---

--- a/internal/adapter/controller/PokerCuiController.go
+++ b/internal/adapter/controller/PokerCuiController.go
@@ -4,6 +4,7 @@ package controller
 
 import (
 	"strconv"
+	"strings"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
@@ -40,7 +41,13 @@ func (pcc *PokerCuiController) Exec(command string) string {
 			switch cmd {
 			case "e", "exchange":
 				indices, skipped := cuiutil.ParseBoundedIntSlice(args, 0, 4)
-				return cuiutil.PrependSkippedWarning(pcc.pi.Exchange(indices), skipped), true
+				// Refuse before playing. PrependSkippedWarning ran the move first and
+				// put the warning above the new board, so a mistyped index was dropped
+				// and the remaining ones played as a different, legal move (issue #5390).
+				if len(skipped) > 0 {
+					return invalidArg("invalidCardIndex", "val", strings.Join(skipped, ", ")), true
+				}
+				return pcc.pi.Exchange(indices), true
 			case "s", "stand":
 				return pcc.pi.Stand(), true
 			case "b", "bet":
@@ -97,7 +104,13 @@ func (pcc *PokerCuiController) Exec(command string) string {
 				})
 			case "o", "odds":
 				indices, skipped := cuiutil.ParseBoundedIntSlice(args, 0, 4)
-				return cuiutil.PrependSkippedWarning(pcc.pi.Odds(indices), skipped), true
+				// Refuse before playing. PrependSkippedWarning ran the move first and
+				// put the warning above the new board, so a mistyped index was dropped
+				// and the remaining ones played as a different, legal move (issue #5390).
+				if len(skipped) > 0 {
+					return invalidArg("invalidCardIndex", "val", strings.Join(skipped, ", ")), true
+				}
+				return pcc.pi.Odds(indices), true
 			case "lw", "lowball":
 				cfg := pcc.pi.GetConfig()
 				cfg.IsLowball = !cfg.IsLowball

--- a/internal/adapter/controller/PokerCuiController_test.go
+++ b/internal/adapter/controller/PokerCuiController_test.go
@@ -57,40 +57,36 @@ func TestPokerCuiController_Exchange_InvalidIndex_NonNumeric(t *testing.T) {
 	mi := new(mockUsecase.MockPokerInteractor)
 	c := NewPokerCuiController(mi)
 	// "abc" fails strconv.Atoi => err != nil => skipped; "2" is valid
-	mi.On("Exchange", []int{2}).Return("exchange ok")
 	result := c.Exec("e abc 2")
-	assert.Contains(t, result, "'abc'")
-	assert.Contains(t, result, "exchange ok")
+	assert.Contains(t, result, "abc")
+	mi.AssertNotCalled(t, "Exchange", mock.Anything)
 }
 
 func TestPokerCuiController_Exchange_InvalidIndex_OutOfRange_Negative(t *testing.T) {
 	mi := new(mockUsecase.MockPokerInteractor)
 	c := NewPokerCuiController(mi)
 	// -1 fails 0 <= idx check => skipped; "3" is valid
-	mi.On("Exchange", []int{3}).Return("exchange ok")
 	result := c.Exec("e -1 3")
-	assert.Contains(t, result, "'-1'")
-	assert.Contains(t, result, "exchange ok")
+	assert.Contains(t, result, "-1")
+	mi.AssertNotCalled(t, "Exchange", mock.Anything)
 }
 
 func TestPokerCuiController_Exchange_InvalidIndex_OutOfRange_Above(t *testing.T) {
 	mi := new(mockUsecase.MockPokerInteractor)
 	c := NewPokerCuiController(mi)
 	// 5 fails idx <= 4 check => skipped; "0" is valid
-	mi.On("Exchange", []int{0}).Return("exchange ok")
 	result := c.Exec("e 5 0")
-	assert.Contains(t, result, "'5'")
-	assert.Contains(t, result, "exchange ok")
+	assert.Contains(t, result, "5")
+	mi.AssertNotCalled(t, "Exchange", mock.Anything)
 }
 
 func TestPokerCuiController_Exchange_AllInvalid(t *testing.T) {
 	mi := new(mockUsecase.MockPokerInteractor)
 	c := NewPokerCuiController(mi)
 	// All indices invalid => empty slice
-	mi.On("Exchange", []int{}).Return("exchange empty")
 	result := c.Exec("e abc -1 5 99")
-	assert.Contains(t, result, "'abc'")
-	assert.Contains(t, result, "exchange empty")
+	assert.Contains(t, result, "abc")
+	mi.AssertNotCalled(t, "Exchange", mock.Anything)
 }
 
 // --- stand ---
@@ -413,28 +409,25 @@ func TestPokerCuiController_Odds_NoIndices(t *testing.T) {
 func TestPokerCuiController_Odds_InvalidIndex_NonNumeric(t *testing.T) {
 	mi := new(mockUsecase.MockPokerInteractor)
 	c := NewPokerCuiController(mi)
-	mi.On("Odds", []int{2}).Return("odds ok")
 	result := c.Exec("o abc 2")
-	assert.Contains(t, result, "'abc'")
-	assert.Contains(t, result, "odds ok")
+	assert.Contains(t, result, "abc")
+	mi.AssertNotCalled(t, "Odds", mock.Anything)
 }
 
 func TestPokerCuiController_Odds_InvalidIndex_OutOfRange(t *testing.T) {
 	mi := new(mockUsecase.MockPokerInteractor)
 	c := NewPokerCuiController(mi)
-	mi.On("Odds", []int{0}).Return("odds ok")
 	result := c.Exec("o -1 0 5")
-	assert.Contains(t, result, "'-1'")
-	assert.Contains(t, result, "odds ok")
+	assert.Contains(t, result, "-1")
+	mi.AssertNotCalled(t, "Odds", mock.Anything)
 }
 
 func TestPokerCuiController_Odds_AllInvalid(t *testing.T) {
 	mi := new(mockUsecase.MockPokerInteractor)
 	c := NewPokerCuiController(mi)
-	mi.On("Odds", []int{}).Return("odds empty")
 	result := c.Exec("o abc -1 5 99")
-	assert.Contains(t, result, "'abc'")
-	assert.Contains(t, result, "odds empty")
+	assert.Contains(t, result, "abc")
+	mi.AssertNotCalled(t, "Odds", mock.Anything)
 }
 
 // --- metaai ---

--- a/internal/adapter/controller/PresidentCuiController.go
+++ b/internal/adapter/controller/PresidentCuiController.go
@@ -90,7 +90,13 @@ func (c *PresidentCuiController) Exec(command string) string {
 			switch cmd {
 			case "p", "play":
 				indices, skipped := cuiutil.ParseIntSlice(args)
-				return cuiutil.PrependSkippedWarning(c.pi.Play(indices), skipped), true
+				// Refuse before playing. PrependSkippedWarning ran the move first and
+				// put the warning above the new board, so a mistyped index was dropped
+				// and the remaining ones played as a different, legal move (issue #5390).
+				if len(skipped) > 0 {
+					return invalidArg("invalidCardIndex", "val", strings.Join(skipped, ", ")), true
+				}
+				return c.pi.Play(indices), true
 			case "h", "hint":
 				return c.pi.Hint(), true
 			case "sd", "setdifficulty":

--- a/internal/adapter/controller/PresidentCuiController_test.go
+++ b/internal/adapter/controller/PresidentCuiController_test.go
@@ -105,4 +105,13 @@ func TestPresidentCuiController_Exec(t *testing.T) {
 		result := c.Exec("sr revolution 0")
 		assert.Equal(t, mockOutput, result)
 	})
+
+	// **落として残りで実行しない。** 打ち間違いを捨てると、プレイヤーが
+	// 選んでいない組み合わせが実行される (issue #5390)。
+	t.Run("refuses a mistyped index", func(t *testing.T) {
+		m := newMock()
+		c := controller.NewPresidentCuiController(m)
+		assert.Contains(t, c.Exec("p 0 zz"), msgInvalidCardIndexPrefix(),
+			"a mistyped index must be refused, not dropped")
+	})
 }

--- a/internal/adapter/controller/RussianPokerCuiController.go
+++ b/internal/adapter/controller/RussianPokerCuiController.go
@@ -4,6 +4,7 @@ package controller
 
 import (
 	"math"
+	"strings"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
@@ -38,7 +39,13 @@ func (rc *RussianPokerCuiController) Exec(command string) string {
 				return rc.ri.Bet(ante), true
 			case "e", "exchange":
 				indices, skipped := cuiutil.ParseBoundedIntSlice(args, 0, 4)
-				return cuiutil.PrependSkippedWarning(rc.ri.Exchange(indices), skipped), true
+				// Refuse before playing. PrependSkippedWarning ran the move first and
+				// put the warning above the new board, so a mistyped index was dropped
+				// and the remaining ones played as a different, legal move (issue #5390).
+				if len(skipped) > 0 {
+					return invalidArg("invalidCardIndex", "val", strings.Join(skipped, ", ")), true
+				}
+				return rc.ri.Exchange(indices), true
 			case "6", "buy6th":
 				return rc.ri.Buy6th(), true
 			case "sel", "select":

--- a/internal/adapter/controller/RussianPokerCuiController_test.go
+++ b/internal/adapter/controller/RussianPokerCuiController_test.go
@@ -190,3 +190,12 @@ func TestRussianPokerCuiController_Empty(t *testing.T) {
 	result := c.Exec("")
 	assert.Contains(t, result, "'help' でコマンド一覧を表示します。")
 }
+
+// **落として残りで実行しない。** 打ち間違いを捨てると、プレイヤーが選んで
+// いない組み合わせが実行される (issue #5390)。
+func TestRussianPokerCuiController_RefusesMistypedIndex(t *testing.T) {
+	m := newMockRussianPokerInteractor()
+	c := controller.NewRussianPokerCuiController(m)
+	assert.Contains(t, c.Exec("e 0 zz"), msgInvalidCardIndexPrefix(),
+		"a mistyped index must be refused, not dropped")
+}

--- a/internal/adapter/controller/ScopaCuiController.go
+++ b/internal/adapter/controller/ScopaCuiController.go
@@ -3,6 +3,8 @@
 package controller
 
 import (
+	"strings"
+
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
@@ -63,5 +65,11 @@ func (c *ScopaCuiController) handlePlay(args []string) (string, bool) {
 		return "Invalid hand index: " + args[0], true
 	}
 	tableIdxs, skipped := cuiutil.ParseIntSlice(args[1:])
-	return cuiutil.PrependSkippedWarning(c.si.Play(handIdx, tableIdxs), skipped), true
+	// Refuse before playing. PrependSkippedWarning ran the move first and
+	// put the warning above the new board, so a mistyped index was dropped
+	// and the remaining ones played as a different, legal move (issue #5390).
+	if len(skipped) > 0 {
+		return invalidArg("invalidCardIndex", "val", strings.Join(skipped, ", ")), true
+	}
+	return c.si.Play(handIdx, tableIdxs), true
 }

--- a/internal/adapter/controller/ScoponeCuiController.go
+++ b/internal/adapter/controller/ScoponeCuiController.go
@@ -3,6 +3,8 @@
 package controller
 
 import (
+	"strings"
+
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
@@ -71,5 +73,11 @@ func (c *ScoponeCuiController) handlePlay(args []string) (string, bool) {
 		return "Invalid hand index: " + args[0], true
 	}
 	tableIdxs, skipped := cuiutil.ParseIntSlice(args[1:])
-	return cuiutil.PrependSkippedWarning(c.si.Play(handIdx, tableIdxs), skipped), true
+	// Refuse before playing. PrependSkippedWarning ran the move first and
+	// put the warning above the new board, so a mistyped index was dropped
+	// and the remaining ones played as a different, legal move (issue #5390).
+	if len(skipped) > 0 {
+		return invalidArg("invalidCardIndex", "val", strings.Join(skipped, ", ")), true
+	}
+	return c.si.Play(handIdx, tableIdxs), true
 }

--- a/internal/adapter/controller/ShitheadCuiController.go
+++ b/internal/adapter/controller/ShitheadCuiController.go
@@ -102,7 +102,13 @@ func (c *ShitheadCuiController) Exec(command string) string {
 			switch cmd {
 			case "p", "play":
 				indices, skipped := cuiutil.ParseIntSlice(args)
-				return cuiutil.PrependSkippedWarning(c.si.Play(indices), skipped), true
+				// Refuse before playing. PrependSkippedWarning ran the move first and
+				// put the warning above the new board, so a mistyped index was dropped
+				// and the remaining ones played as a different, legal move (issue #5390).
+				if len(skipped) > 0 {
+					return invalidArg("invalidCardIndex", "val", strings.Join(skipped, ", ")), true
+				}
+				return c.si.Play(indices), true
 			case "sd", "setdifficulty":
 				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequired", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.si.GetConfig()

--- a/internal/adapter/controller/TichuCuiController.go
+++ b/internal/adapter/controller/TichuCuiController.go
@@ -3,6 +3,8 @@
 package controller
 
 import (
+	"strings"
+
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
@@ -34,7 +36,13 @@ func (c *TichuCuiController) Exec(command string) string {
 			switch cmd {
 			case "p", "play":
 				indices, skipped := cuiutil.ParseIntSlice(args)
-				return cuiutil.PrependSkippedWarning(c.tgi.Play(indices), skipped), true
+				// Refuse before playing. PrependSkippedWarning ran the move first and
+				// put the warning above the new board, so a mistyped index was dropped
+				// and the remaining ones played as a different, legal move (issue #5390).
+				if len(skipped) > 0 {
+					return invalidArg("invalidCardIndex", "val", strings.Join(skipped, ", ")), true
+				}
+				return c.tgi.Play(indices), true
 			case "d", "declare":
 				if len(args) == 0 {
 					return c.tgi.Declare(0), true

--- a/internal/adapter/controller/TienLenCuiController.go
+++ b/internal/adapter/controller/TienLenCuiController.go
@@ -3,6 +3,8 @@
 package controller
 
 import (
+	"strings"
+
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
@@ -31,7 +33,13 @@ func (c *TienLenCuiController) Exec(command string) string {
 			switch cmd {
 			case "p", "play":
 				indices, skipped := cuiutil.ParseIntSlice(args)
-				return cuiutil.PrependSkippedWarning(c.tli.Play(indices), skipped), true
+				// Refuse before playing. PrependSkippedWarning ran the move first and
+				// put the warning above the new board, so a mistyped index was dropped
+				// and the remaining ones played as a different, legal move (issue #5390).
+				if len(skipped) > 0 {
+					return invalidArg("invalidCardIndex", "val", strings.Join(skipped, ", ")), true
+				}
+				return c.tli.Play(indices), true
 			case "sd", "setdifficulty":
 				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequiredAlt", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.tli.GetConfig()

--- a/internal/adapter/controller/YanivCuiController.go
+++ b/internal/adapter/controller/YanivCuiController.go
@@ -3,6 +3,8 @@
 package controller
 
 import (
+	"strings"
+
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
@@ -36,7 +38,13 @@ func (c *YanivCuiController) Exec(command string) string {
 			switch cmd {
 			case "d", "discard":
 				indices, skipped := cuiutil.ParseIntSlice(args)
-				return cuiutil.PrependSkippedWarning(c.ci.Discard(indices), skipped), true
+				// Refuse before playing. PrependSkippedWarning ran the move first and
+				// put the warning above the new board, so a mistyped index was dropped
+				// and the remaining ones played as a different, legal move (issue #5390).
+				if len(skipped) > 0 {
+					return invalidArg("invalidCardIndex", "val", strings.Join(skipped, ", ")), true
+				}
+				return c.ci.Discard(indices), true
 			case "y", "yaniv":
 				return c.ci.DeclareYaniv(), true
 			case "ds", "drawstock":

--- a/internal/adapter/controller/ZhengCuiController.go
+++ b/internal/adapter/controller/ZhengCuiController.go
@@ -3,6 +3,8 @@
 package controller
 
 import (
+	"strings"
+
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
@@ -31,7 +33,13 @@ func (c *ZhengCuiController) Exec(command string) string {
 			switch cmd {
 			case "p", "play":
 				indices, skipped := cuiutil.ParseIntSlice(args)
-				return cuiutil.PrependSkippedWarning(c.zi.Play(indices), skipped), true
+				// Refuse before playing. PrependSkippedWarning ran the move first and
+				// put the warning above the new board, so a mistyped index was dropped
+				// and the remaining ones played as a different, legal move (issue #5390).
+				if len(skipped) > 0 {
+					return invalidArg("invalidCardIndex", "val", strings.Join(skipped, ", ")), true
+				}
+				return c.zi.Play(indices), true
 			case "sd", "setdifficulty":
 				return cuiutil.WithParsedIntKeys(args, "cpuDifficultyRequiredAlt", "invalidCpuDifficulty", 0, 2, func(v int) string {
 					cfg := c.zi.GetConfig()

--- a/internal/adapter/controller/usecase/BigTwoInteractor_mock.go
+++ b/internal/adapter/controller/usecase/BigTwoInteractor_mock.go
@@ -1,0 +1,50 @@
+//go:build test
+
+package usecase
+
+import (
+	"github.com/stretchr/testify/mock"
+
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+)
+
+// MockBigTwoInteractor 大富豪(Big Two)のインタラクターモック
+type MockBigTwoInteractor struct {
+	mock.Mock
+}
+
+// Snapshot モック
+func (_m *MockBigTwoInteractor) Snapshot() ([]byte, error) {
+	ret := _m.Called()
+	return ret.Get(0).([]byte), ret.Error(1)
+}
+
+// Reset モック
+func (_m *MockBigTwoInteractor) Reset() string {
+	ret := _m.Called()
+	return ret.Get(0).(string)
+}
+
+// Play モック
+func (_m *MockBigTwoInteractor) Play(indices []int) string {
+	ret := _m.Called(indices)
+	return ret.Get(0).(string)
+}
+
+// ResetWithConfig モック
+func (_m *MockBigTwoInteractor) ResetWithConfig(config domain.BigTwoConfig) string {
+	ret := _m.Called(config)
+	return ret.Get(0).(string)
+}
+
+// GetConfig モック
+func (_m *MockBigTwoInteractor) GetConfig() domain.BigTwoConfig {
+	ret := _m.Called()
+	return ret.Get(0).(domain.BigTwoConfig)
+}
+
+// ActionLog モック
+func (_m *MockBigTwoInteractor) ActionLog() string {
+	ret := _m.Called()
+	return ret.Get(0).(string)
+}


### PR DESCRIPTION
## 問題

`ParseIntSlice` は**パースできない値を捨てて残りを返し**、呼び出し側は**その残りで手を実行してから**警告を前置していました。

```go
// internal/adapter/controller/BigTwoCuiController.go
indices, skipped := cuiutil.ParseIntSlice(args)
return cuiutil.PrependSkippedWarning(c.bti.Play(indices), skipped), true
//                                   ^^^^^^^^^^^^^^^^^^^ 先に実行される
```

警告は**取り返しのつかない操作の後**に、変わってしまった盤面の上に出ます。

**枚数が手の意味そのものであるゲームでは、これは「入力ミスが通った」ではありません。** 2 枚出すつもりが 1 枚出れば、ペアではなく単札という**別の合法手**が成立します。

## 実測

`p 0 zz`（2 枚のつもりで 1 枚打ち間違い）を配り直後に送り、手札の減り方を 40 配りで数えました。

| ゲーム | 修正前: ちょうど 1 枚出た | 修正後 |
|---|---|---|
| bigtwo | **30/40 (75%)** | 拒否 40/40、0 枚 |
| daifugo | 13/40 | 拒否 40/40、0 枚 |
| president | 15/40 | 拒否 40/40、0 枚 |

「何も起きなかった」分は拒否されていたのではなく、残った 1 枚がその局面でたまたま違法だっただけです。

## 変更

**26 箇所**が `skipped` を先に検査し、空でなければ実行せずに拒否します。拒否は `invalidArg` 経由なので印も i18n も他と揃います。

## テストがこの挙動を名前ごと固定していました

```go
t.Run("play command ignores non-numeric index with warning", func(t *testing.T) {
    result := c.Exec("p 0 abc 2")
    assert.Contains(t, result, mockOutput)
    m.AssertCalled(t, "Play", []int{0, 2})   // ← 3 枚要求して 2 枚出ている
})
```

13 件をすべて「インタラクタが呼ばれないこと」の検証に置き換えました。

**モック期待の除去で一度失敗しています。** 同じファイル内の正常系テストが同一の戻り値文字列（`"exchange ok"` など）を使っており、先頭一致で消すとそちらの期待を奪ってしまいました。テスト名を鍵にして 1 件ずつ戻しています。

## レビュー後の追加（d87fe0e8）

最初のスイープの正規表現は `ParseIntSlice` と `PrependSkippedWarning` が**隣接行**であることを要求しており、4 箇所を取りこぼしていました。レビューの指摘で判明し、すべて直しています。

- **durak `defend`** — 直した `attack` の 3 行下。単一引数の形しか見ていなかったため（defend は 2 つ取る）
- **cassino `take` / `build`** — `skipped` を 2 グループから組み立てている
- **hearts `pass`** — 先に `result` を計算してから警告を前置していた

hearts が最悪でした。`pass 0 abc 1 2` は `abc` を捨てると残り 3 枚がちょうど枚数チェックを通り、**プレイヤーが選んでいない組み合わせが渡ります**。テストが `m.AssertCalled(t, "Pass", []int{0, 1, 2})` でそれを固定していました。実測で 30 配りすべて拒否・手札の移動 0 になりました。

`cuiutil.PrependSkippedWarning` の呼び出しはパッケージ内に **0 件**です。

## 残り

`ParseOptionalInt` 経由（17 箇所）は #5390 に残ります。

## 検証

- `go test -tags test ./internal/adapter/controller/` — 緑
- `go build ./...` — 通過
- `golangci-lint run ./internal/...` — 0 issues
- 3 ゲーム × 40 配りで前後を実測

Refs #5390
