### PR TITLE
feat(cui): add worked examples to fifteen trick-taking games

### DIFF
--- a/internal/i18n/locales/en/aluette.json
+++ b/internal/i18n/locales/en/aluette.json
@@ -25,5 +25,7 @@
   "round": "Mene: {{round}}  trick: {{trick}}",
   "roundEndTrickEntry": "{{name}} {{tricks}}",
   "roundEndTricks": "Tricks per player: {{list}}",
-  "teamLine": "Score  team 0: {{team0}}  team 1: {{team1}}  (first to {{target}})"
+  "teamLine": "Score  team 0: {{team0}}  team 1: {{team1}}  (first to {{target}})",
+  "helpExamplePlay": "  play 0               play hand card 0",
+  "helpExampleNext": "  n                    read the trick result, then start the next trick"
 }

--- a/internal/i18n/locales/en/fortyfives.json
+++ b/internal/i18n/locales/en/fortyfives.json
@@ -44,5 +44,8 @@
   "contractProgress": "Contract: {{team}} {{got}}/{{contract}} points - {{status}}",
   "contractMade": "made",
   "contractFailed": "can no longer be made",
-  "contractNeedMore": "{{remaining}} more needed"
+  "contractNeedMore": "{{remaining}} more needed",
+  "helpExampleBid": "  bid 20                   bid 20",
+  "helpExamplePlay": "  play 0                   play hand card 0",
+  "helpExampleNext": "  n                        read the trick result, then start the next trick"
 }

--- a/internal/i18n/locales/en/ganjifa.json
+++ b/internal/i18n/locales/en/ganjifa.json
@@ -25,5 +25,7 @@
   "helpPlay": "  play <idx>           play a card",
   "helpNext": "  n                    go to next trick",
   "helpNextRound": "  nr                   go to next round",
-  "helpSetDifficulty": "  sd [0-2]             CPU difficulty (0=Easy, 1=Normal, 2=Hard)"
+  "helpSetDifficulty": "  sd [0-2]             CPU difficulty (0=Easy, 1=Normal, 2=Hard)",
+  "helpExamplePlay": "  play 0               play hand card 0",
+  "helpExampleNext": "  n                    read the trick result, then start the next trick"
 }

--- a/internal/i18n/locales/en/klaverjas.json
+++ b/internal/i18n/locales/en/klaverjas.json
@@ -19,5 +19,7 @@
   "hintReasonFollowWin": "Points on the table — win the trick",
   "hintReasonFollowDuck": "Cannot/should not win — duck",
   "hintReasonDiscardLow": "Cannot follow suit — discard a low card",
-  "promptRoundEndRoem": "Roem: A +{{roemA}} / B +{{roemB}} (total A {{totalA}} / B {{totalB}})"
+  "promptRoundEndRoem": "Roem: A +{{roemA}} / B +{{roemB}} (total A {{totalA}} / B {{totalB}})",
+  "helpExamplePlay": "  play 0                   play hand card 0",
+  "helpExampleNext": "  n                        read the trick result, then start the next trick"
 }

--- a/internal/i18n/locales/en/knockoutwhist.json
+++ b/internal/i18n/locales/en/knockoutwhist.json
@@ -23,5 +23,7 @@
   "hintReasonFollowDuck": "Cannot win — follow with a low card",
   "hintReasonDiscardLow": "Cannot follow suit — discard a low card",
   "leaderMark": "▶(lead) ",
-  "winnerMark": "★(winner) "
+  "winnerMark": "★(winner) ",
+  "helpExamplePlay": "  play 0                   play hand card 0",
+  "helpExampleNext": "  n                        read the trick result, then start the next trick"
 }

--- a/internal/i18n/locales/en/manille.json
+++ b/internal/i18n/locales/en/manille.json
@@ -19,5 +19,7 @@
   "hintReasonFollowWin": "Points on the table — win the trick",
   "hintReasonFollowDuck": "Cannot/should not win — duck",
   "hintReasonDiscardLow": "Cannot follow suit — discard a low card",
-  "rankHelp": "Rank order: 10 > A > K > Q > J > 9 > 8 > 7 (points: 10=5, A=4, K=3, Q=2, J=1)"
+  "rankHelp": "Rank order: 10 > A > K > Q > J > 9 > 8 > 7 (points: 10=5, A=4, K=3, Q=2, J=1)",
+  "helpExamplePlay": "  play 0                   play hand card 0",
+  "helpExampleNext": "  n                        read the trick result, then start the next trick"
 }

--- a/internal/i18n/locales/en/marias.json
+++ b/internal/i18n/locales/en/marias.json
@@ -22,5 +22,7 @@
   "hintReasonFollowWin": "Points on the table — win the trick",
   "hintReasonFollowDuck": "Cannot/should not win — duck",
   "hintReasonDiscardLow": "Cannot follow suit — discard a low card",
-  "promptRoundEndDefenders": "Defenders total: {{pts}} pts"
+  "promptRoundEndDefenders": "Defenders total: {{pts}} pts",
+  "helpExamplePlay": "  play 0                   play hand card 0",
+  "helpExampleNext": "  n                        read the trick result, then start the next trick"
 }

--- a/internal/i18n/locales/en/nap.json
+++ b/internal/i18n/locales/en/nap.json
@@ -41,5 +41,8 @@
   "result.cpuWin": "Game over! Player {{player}} wins!",
   "promptBidHolder": "Current high bidder: {{name}}",
   "declarerProgress": "Declarer: {{won}}/{{needed}} tricks ({{remaining}} left)",
-  "contractUnreachable": " - the contract can no longer be made"
+  "contractUnreachable": " - the contract can no longer be made",
+  "helpExampleBid": "  bid 3                    declare three tricks",
+  "helpExamplePlay": "  play 0                   play hand card 0",
+  "helpExampleNext": "  n                        read the trick result, then start the next trick"
 }

--- a/internal/i18n/locales/en/preference.json
+++ b/internal/i18n/locales/en/preference.json
@@ -44,5 +44,8 @@
   "trickEnd": "Trick complete",
   "roundEnd": "Round complete",
   "result.humanWin": "Game over! You win!",
-  "result.cpuWin": "Game over! Player {{player}} wins!"
+  "result.cpuWin": "Game over! Player {{player}} wins!",
+  "helpExampleBid": "  bid 1                    declare Six",
+  "helpExamplePlay": "  play 0                   play hand card 0",
+  "helpExampleNext": "  n                        read the trick result, then start the next trick"
 }

--- a/internal/i18n/locales/en/sedma.json
+++ b/internal/i18n/locales/en/sedma.json
@@ -18,5 +18,7 @@
   "hintReasonLeadLow": "Lead a low card to conserve points",
   "hintReasonCapture": "Capture the trick (same rank or a 7)",
   "hintReasonDiscardLow": "Cannot/should not capture — discard a low card",
-  "trickWinner": "{{name}} won the trick (+{{points}} pts)"
+  "trickWinner": "{{name}} won the trick (+{{points}} pts)",
+  "helpExamplePlay": "  play 0                   play hand card 0",
+  "helpExampleNext": "  n                        read the trick result, then start the next trick"
 }

--- a/internal/i18n/locales/en/solowhist.json
+++ b/internal/i18n/locales/en/solowhist.json
@@ -38,5 +38,8 @@
   "roundEnd": "Round complete",
   "result.humanWin": "Game over! You win!",
   "result.cpuWin": "Game over! Player {{player}} wins!",
-  "bidHistory": "Bids: {{bids}}"
+  "bidHistory": "Bids: {{bids}}",
+  "helpExampleBid": "  bid 1                    declare Solo",
+  "helpExamplePlay": "  play 0                   play hand card 0",
+  "helpExampleNext": "  n                        read the trick result, then start the next trick"
 }

--- a/internal/i18n/locales/en/spoilfive.json
+++ b/internal/i18n/locales/en/spoilfive.json
@@ -21,5 +21,7 @@
   "hintReasonDiscardLow": "Cannot win — discard a low card",
   "leaderMark": "▶(lead) ",
   "winnerMark": "★(winner) ",
-  "topTrumpLine": "Ranking: {{cards}} > other trumps > non-trumps"
+  "topTrumpLine": "Ranking: {{cards}} > other trumps > non-trumps",
+  "helpExamplePlay": "  play 0                   play hand card 0",
+  "helpExampleNext": "  n                        read the trick result, then start the next trick"
 }

--- a/internal/i18n/locales/en/sueca.json
+++ b/internal/i18n/locales/en/sueca.json
@@ -20,5 +20,7 @@
   "hintReasonFollowDuck": "Cannot/should not win — duck",
   "hintReasonDiscardLow": "Cannot follow suit — discard a low card",
   "trickWinner": "{{name}} (Team {{team}}) won the trick",
-  "roundPoints": "Card points -- Team A: {{ptsA}} / Team B: {{ptsB}} (win at {{win}})"
+  "roundPoints": "Card points -- Team A: {{ptsA}} / Team B: {{ptsB}} (win at {{win}})",
+  "helpExamplePlay": "  play 0                   play hand card 0",
+  "helpExampleNext": "  n                        read the trick result, then start the next trick"
 }

--- a/internal/i18n/locales/en/twentynine.json
+++ b/internal/i18n/locales/en/twentynine.json
@@ -40,5 +40,8 @@
   "trickEnd": "Trick complete",
   "roundEnd": "Round complete",
   "result.humanWin": "Game over! Your team wins!",
-  "result.cpuWin": "Game over! Team {{team}} wins!"
+  "result.cpuWin": "Game over! Team {{team}} wins!",
+  "helpExampleBid": "  bid 20                   bid 20",
+  "helpExamplePlay": "  play 0                   play hand card 0",
+  "helpExampleNext": "  n                        read the trick result, then start the next trick"
 }

--- a/internal/i18n/locales/en/vira.json
+++ b/internal/i18n/locales/en/vira.json
@@ -39,5 +39,8 @@
   "helpPlay": "  play <idx>           play a card",
   "helpNext": "  n                    go to next trick",
   "helpNextRound": "  nr                   go to next round",
-  "helpSetDifficulty": "  sd [0-2]             CPU difficulty (0=Easy, 1=Normal, 2=Hard)"
+  "helpSetDifficulty": "  sd [0-2]             CPU difficulty (0=Easy, 1=Normal, 2=Hard)",
+  "helpExampleBid": "  b 2                  declare Solo",
+  "helpExamplePlay": "  play 0               play hand card 0",
+  "helpExampleNext": "  n                    read the trick result, then start the next trick"
 }

--- a/internal/i18n/locales/ja/aluette.json
+++ b/internal/i18n/locales/ja/aluette.json
@@ -25,5 +25,7 @@
   "round": "メーヌ: {{round}}  トリック: {{trick}}",
   "roundEndTrickEntry": "{{name}} {{tricks}}",
   "roundEndTricks": "各プレイヤーのトリック数: {{list}}",
-  "teamLine": "得点  チーム0: {{team0}}  チーム1: {{team1}}  （{{target}}点先取）"
+  "teamLine": "得点  チーム0: {{team0}}  チーム1: {{team1}}  （{{target}}点先取）",
+  "helpExamplePlay": "  play 0               手札の 0 番のカードを出す",
+  "helpExampleNext": "  n                    トリックの決着を見てから次のトリックへ"
 }

--- a/internal/i18n/locales/ja/fortyfives.json
+++ b/internal/i18n/locales/ja/fortyfives.json
@@ -44,5 +44,8 @@
   "contractProgress": "契約: {{team}} {{got}}/{{contract}} 点 — {{status}}",
   "contractMade": "成立",
   "contractFailed": "不成立が確定",
-  "contractNeedMore": "あと{{remaining}}点"
+  "contractNeedMore": "あと{{remaining}}点",
+  "helpExampleBid": "  bid 20                   20 点を宣言する",
+  "helpExamplePlay": "  play 0                   手札の 0 番のカードを出す",
+  "helpExampleNext": "  n                        トリックの決着を見てから次のトリックへ"
 }

--- a/internal/i18n/locales/ja/ganjifa.json
+++ b/internal/i18n/locales/ja/ganjifa.json
@@ -25,5 +25,7 @@
   "helpPlay": "  play <idx>           カードを出す",
   "helpNext": "  n                    次のトリックへ",
   "helpNextRound": "  nr                   次のラウンドへ",
-  "helpSetDifficulty": "  sd [0-2]             CPU難易度 (0=Easy, 1=Normal, 2=Hard)"
+  "helpSetDifficulty": "  sd [0-2]             CPU難易度 (0=Easy, 1=Normal, 2=Hard)",
+  "helpExamplePlay": "  play 0               手札の 0 番のカードを出す",
+  "helpExampleNext": "  n                    トリックの決着を見てから次のトリックへ"
 }

--- a/internal/i18n/locales/ja/klaverjas.json
+++ b/internal/i18n/locales/ja/klaverjas.json
@@ -19,5 +19,7 @@
   "hintReasonFollowWin": "得点があるので勝ちに行く",
   "hintReasonFollowDuck": "取れない／取る価値がないのでダック",
   "hintReasonDiscardLow": "フォローできないので低い札を捨てる",
-  "promptRoundEndRoem": "Roem: A +{{roemA}} / B +{{roemB}}（合計 A {{totalA}} / B {{totalB}}）"
+  "promptRoundEndRoem": "Roem: A +{{roemA}} / B +{{roemB}}（合計 A {{totalA}} / B {{totalB}}）",
+  "helpExamplePlay": "  play 0                   手札の 0 番のカードを出す",
+  "helpExampleNext": "  n                        トリックの決着を見てから次のトリックへ"
 }

--- a/internal/i18n/locales/ja/knockoutwhist.json
+++ b/internal/i18n/locales/ja/knockoutwhist.json
@@ -23,5 +23,7 @@
   "hintReasonFollowDuck": "取れないのでリードスートの低い札で受ける",
   "hintReasonDiscardLow": "リードに従えないので低い札を捨てる",
   "leaderMark": "▶(リード) ",
-  "winnerMark": "★(勝者) "
+  "winnerMark": "★(勝者) ",
+  "helpExamplePlay": "  play 0                   手札の 0 番のカードを出す",
+  "helpExampleNext": "  n                        トリックの決着を見てから次のトリックへ"
 }

--- a/internal/i18n/locales/ja/manille.json
+++ b/internal/i18n/locales/ja/manille.json
@@ -19,5 +19,7 @@
   "hintReasonFollowWin": "得点があるので勝ちに行く",
   "hintReasonFollowDuck": "取れない／取る価値がないのでダック",
   "hintReasonDiscardLow": "フォローできないので低い札を捨てる",
-  "rankHelp": "ランク順: 10 > A > K > Q > J > 9 > 8 > 7（得点: 10=5, A=4, K=3, Q=2, J=1）"
+  "rankHelp": "ランク順: 10 > A > K > Q > J > 9 > 8 > 7（得点: 10=5, A=4, K=3, Q=2, J=1）",
+  "helpExamplePlay": "  play 0                   手札の 0 番のカードを出す",
+  "helpExampleNext": "  n                        トリックの決着を見てから次のトリックへ"
 }

--- a/internal/i18n/locales/ja/marias.json
+++ b/internal/i18n/locales/ja/marias.json
@@ -22,5 +22,7 @@
   "hintReasonFollowWin": "得点があるので勝ちに行く",
   "hintReasonFollowDuck": "取れない／取る価値がないのでダック",
   "hintReasonDiscardLow": "フォローできないので低い札を捨てる",
-  "promptRoundEndDefenders": "ディフェンダー合計: {{pts}}点"
+  "promptRoundEndDefenders": "ディフェンダー合計: {{pts}}点",
+  "helpExamplePlay": "  play 0                   手札の 0 番のカードを出す",
+  "helpExampleNext": "  n                        トリックの決着を見てから次のトリックへ"
 }

--- a/internal/i18n/locales/ja/nap.json
+++ b/internal/i18n/locales/ja/nap.json
@@ -41,5 +41,8 @@
   "result.cpuWin": "ゲーム終了！ プレイヤー{{player}}の勝ち！",
   "promptBidHolder": "現在の最高入札者: {{name}}",
   "declarerProgress": "宣言者: {{won}}/{{needed}} トリック (残り{{remaining}})",
-  "contractUnreachable": " — 達成不可能が確定"
+  "contractUnreachable": " — 達成不可能が確定",
+  "helpExampleBid": "  bid 3                    3 トリックを宣言する",
+  "helpExamplePlay": "  play 0                   手札の 0 番のカードを出す",
+  "helpExampleNext": "  n                        トリックの決着を見てから次のトリックへ"
 }

--- a/internal/i18n/locales/ja/preference.json
+++ b/internal/i18n/locales/ja/preference.json
@@ -44,5 +44,8 @@
   "trickEnd": "トリック終了",
   "roundEnd": "ラウンド終了",
   "result.humanWin": "ゲーム終了！ あなたの勝ち！",
-  "result.cpuWin": "ゲーム終了！ プレイヤー{{player}}の勝ち！"
+  "result.cpuWin": "ゲーム終了！ プレイヤー{{player}}の勝ち！",
+  "helpExampleBid": "  bid 1                    シックスを宣言する",
+  "helpExamplePlay": "  play 0                   手札の 0 番のカードを出す",
+  "helpExampleNext": "  n                        トリックの決着を見てから次のトリックへ"
 }

--- a/internal/i18n/locales/ja/sedma.json
+++ b/internal/i18n/locales/ja/sedma.json
@@ -18,5 +18,7 @@
   "hintReasonLeadLow": "低い札でリードして温存する",
   "hintReasonCapture": "奪取する（同ランクまたは7）",
   "hintReasonDiscardLow": "取れない／取る価値がないので低い札を捨てる",
-  "trickWinner": "{{name}} がトリックを獲得 (+{{points}}点)"
+  "trickWinner": "{{name}} がトリックを獲得 (+{{points}}点)",
+  "helpExamplePlay": "  play 0                   手札の 0 番のカードを出す",
+  "helpExampleNext": "  n                        トリックの決着を見てから次のトリックへ"
 }

--- a/internal/i18n/locales/ja/solowhist.json
+++ b/internal/i18n/locales/ja/solowhist.json
@@ -38,5 +38,8 @@
   "roundEnd": "ラウンド終了",
   "result.humanWin": "ゲーム終了！ あなたの勝ち！",
   "result.cpuWin": "ゲーム終了！ プレイヤー{{player}}の勝ち！",
-  "bidHistory": "ビッド状況: {{bids}}"
+  "bidHistory": "ビッド状況: {{bids}}",
+  "helpExampleBid": "  bid 1                    ソロを宣言する",
+  "helpExamplePlay": "  play 0                   手札の 0 番のカードを出す",
+  "helpExampleNext": "  n                        トリックの決着を見てから次のトリックへ"
 }

--- a/internal/i18n/locales/ja/spoilfive.json
+++ b/internal/i18n/locales/ja/spoilfive.json
@@ -21,5 +21,7 @@
   "hintReasonDiscardLow": "取れないので低い札を捨てる",
   "leaderMark": "▶(リード) ",
   "winnerMark": "★(勝者) ",
-  "topTrumpLine": "強さ順: {{cards}} > その他の切り札 > 非切り札"
+  "topTrumpLine": "強さ順: {{cards}} > その他の切り札 > 非切り札",
+  "helpExamplePlay": "  play 0                   手札の 0 番のカードを出す",
+  "helpExampleNext": "  n                        トリックの決着を見てから次のトリックへ"
 }

--- a/internal/i18n/locales/ja/sueca.json
+++ b/internal/i18n/locales/ja/sueca.json
@@ -20,5 +20,7 @@
   "hintReasonFollowDuck": "取れない／取る価値がないのでダック",
   "hintReasonDiscardLow": "フォローできないので低い札を捨てる",
   "trickWinner": "{{name}}（チーム{{team}}）がトリックを獲得",
-  "roundPoints": "カード獲得点 — チームA: {{ptsA}}点 / チームB: {{ptsB}}点（勝利ライン {{win}}点）"
+  "roundPoints": "カード獲得点 — チームA: {{ptsA}}点 / チームB: {{ptsB}}点（勝利ライン {{win}}点）",
+  "helpExamplePlay": "  play 0                   手札の 0 番のカードを出す",
+  "helpExampleNext": "  n                        トリックの決着を見てから次のトリックへ"
 }

--- a/internal/i18n/locales/ja/twentynine.json
+++ b/internal/i18n/locales/ja/twentynine.json
@@ -40,5 +40,8 @@
   "trickEnd": "トリック終了",
   "roundEnd": "ラウンド終了",
   "result.humanWin": "ゲーム終了！ あなたのチームの勝ち！",
-  "result.cpuWin": "ゲーム終了！ チーム{{team}}の勝ち！"
+  "result.cpuWin": "ゲーム終了！ チーム{{team}}の勝ち！",
+  "helpExampleBid": "  bid 20                   20 点を宣言する",
+  "helpExamplePlay": "  play 0                   手札の 0 番のカードを出す",
+  "helpExampleNext": "  n                        トリックの決着を見てから次のトリックへ"
 }

--- a/internal/i18n/locales/ja/vira.json
+++ b/internal/i18n/locales/ja/vira.json
@@ -39,5 +39,8 @@
   "helpPlay": "  play <idx>           カードを出す",
   "helpNext": "  n                    次のトリックへ",
   "helpNextRound": "  nr                   次のラウンドへ",
-  "helpSetDifficulty": "  sd [0-2]             CPU難易度 (0=Easy, 1=Normal, 2=Hard)"
+  "helpSetDifficulty": "  sd [0-2]             CPU難易度 (0=Easy, 1=Normal, 2=Hard)",
+  "helpExampleBid": "  b 2                  ソロを宣言する",
+  "helpExamplePlay": "  play 0               手札の 0 番のカードを出す",
+  "helpExampleNext": "  n                    トリックの決着を見てから次のトリックへ"
 }

--- a/internal/infrastructure/ui/GameManager.go
+++ b/internal/infrastructure/ui/GameManager.go
@@ -2891,6 +2891,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewSuecaCuiController,
 		CuiHelpSpec{
 			TitleKey: "sueca.helpTitle",
+			ExampleKeys: []string{
+				"sueca.helpExamplePlay",
+				"sueca.helpExampleNext",
+			},
 			CommandKeys: []string{
 				"sueca.helpPlay",
 				"sueca.helpNext",
@@ -2906,6 +2910,11 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewFortyFivesCuiController,
 		CuiHelpSpec{
 			TitleKey: "fortyfives.helpTitle",
+			ExampleKeys: []string{
+				"fortyfives.helpExampleBid",
+				"fortyfives.helpExamplePlay",
+				"fortyfives.helpExampleNext",
+			},
 			CommandKeys: []string{
 				"fortyfives.helpBid",
 				"fortyfives.helpPass",
@@ -2923,6 +2932,11 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewTwentyNineCuiController,
 		CuiHelpSpec{
 			TitleKey: "twentynine.helpTitle",
+			ExampleKeys: []string{
+				"twentynine.helpExampleBid",
+				"twentynine.helpExamplePlay",
+				"twentynine.helpExampleNext",
+			},
 			CommandKeys: []string{
 				"twentynine.helpBid",
 				"twentynine.helpPass",
@@ -2940,6 +2954,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewKlaverjasCuiController,
 		CuiHelpSpec{
 			TitleKey: "klaverjas.helpTitle",
+			ExampleKeys: []string{
+				"klaverjas.helpExamplePlay",
+				"klaverjas.helpExampleNext",
+			},
 			CommandKeys: []string{
 				"klaverjas.helpPlay",
 				"klaverjas.helpNext",
@@ -2955,6 +2973,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewManilleCuiController,
 		CuiHelpSpec{
 			TitleKey: "manille.helpTitle",
+			ExampleKeys: []string{
+				"manille.helpExamplePlay",
+				"manille.helpExampleNext",
+			},
 			CommandKeys: []string{
 				"manille.helpPlay",
 				"manille.helpNext",
@@ -2970,6 +2992,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewMariasCuiController,
 		CuiHelpSpec{
 			TitleKey: "marias.helpTitle",
+			ExampleKeys: []string{
+				"marias.helpExamplePlay",
+				"marias.helpExampleNext",
+			},
 			CommandKeys: []string{
 				"marias.helpPlay",
 				"marias.helpNext",
@@ -2985,6 +3011,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewSedmaCuiController,
 		CuiHelpSpec{
 			TitleKey: "sedma.helpTitle",
+			ExampleKeys: []string{
+				"sedma.helpExamplePlay",
+				"sedma.helpExampleNext",
+			},
 			CommandKeys: []string{
 				"sedma.helpPlay",
 				"sedma.helpNext",
@@ -3000,6 +3030,11 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewSoloWhistCuiController,
 		CuiHelpSpec{
 			TitleKey: "solowhist.helpTitle",
+			ExampleKeys: []string{
+				"solowhist.helpExampleBid",
+				"solowhist.helpExamplePlay",
+				"solowhist.helpExampleNext",
+			},
 			CommandKeys: []string{
 				"solowhist.helpBid",
 				"solowhist.helpPass",
@@ -3017,6 +3052,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewKnockoutWhistCuiController,
 		CuiHelpSpec{
 			TitleKey: "knockoutwhist.helpTitle",
+			ExampleKeys: []string{
+				"knockoutwhist.helpExamplePlay",
+				"knockoutwhist.helpExampleNext",
+			},
 			CommandKeys: []string{
 				"knockoutwhist.helpPlay",
 				"knockoutwhist.helpNext",
@@ -3032,6 +3071,11 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewNapCuiController,
 		CuiHelpSpec{
 			TitleKey: "nap.helpTitle",
+			ExampleKeys: []string{
+				"nap.helpExampleBid",
+				"nap.helpExamplePlay",
+				"nap.helpExampleNext",
+			},
 			CommandKeys: []string{
 				"nap.helpBid",
 				"nap.helpPass",
@@ -3049,6 +3093,11 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewPreferenceCuiController,
 		CuiHelpSpec{
 			TitleKey: "preference.helpTitle",
+			ExampleKeys: []string{
+				"preference.helpExampleBid",
+				"preference.helpExamplePlay",
+				"preference.helpExampleNext",
+			},
 			CommandKeys: []string{
 				"preference.helpBid",
 				"preference.helpPass",
@@ -3066,6 +3115,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewGanjifaCuiController,
 		CuiHelpSpec{
 			TitleKey: "ganjifa.helpTitle",
+			ExampleKeys: []string{
+				"ganjifa.helpExamplePlay",
+				"ganjifa.helpExampleNext",
+			},
 			CommandKeys: []string{
 				"ganjifa.helpPlay",
 				"ganjifa.helpNext",
@@ -3081,6 +3134,11 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewViraCuiController,
 		CuiHelpSpec{
 			TitleKey: "vira.helpTitle",
+			ExampleKeys: []string{
+				"vira.helpExampleBid",
+				"vira.helpExamplePlay",
+				"vira.helpExampleNext",
+			},
 			CommandKeys: []string{
 				"vira.helpBid",
 				"vira.helpPass",
@@ -3098,6 +3156,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewSpoilFiveCuiController,
 		CuiHelpSpec{
 			TitleKey: "spoilfive.helpTitle",
+			ExampleKeys: []string{
+				"spoilfive.helpExamplePlay",
+				"spoilfive.helpExampleNext",
+			},
 			CommandKeys: []string{
 				"spoilfive.helpPlay",
 				"spoilfive.helpNext",
@@ -4006,6 +4068,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewAluetteCuiController,
 		CuiHelpSpec{
 			TitleKey: "aluette.helpTitle",
+			ExampleKeys: []string{
+				"aluette.helpExamplePlay",
+				"aluette.helpExampleNext",
+			},
 			CommandKeys: []string{
 				"aluette.helpPlay",
 				"aluette.helpNext",


### PR DESCRIPTION
## 変更

例文つきのゲームが **15 → 30** になりました。

- **play のみの 9 ゲーム**（sueca / klaverjas / manille / marias / sedma / knockoutwhist / ganjifa / spoilfive / aluette）に `play 0` → `n`
- **入札つきの 6 ゲーム**（fortyfives / twentynine / solowhist / nap / preference / vira）はその前に入札を 1 手

```
Examples:
  bid 3                    declare three tricks
  play 0                   play hand card 0
  n                        read the trick result, then start the next trick
```

## 入札値はゲームごとに違います

共有の値を使っていません。各ゲームの**自分のコマンド行から**取っています。

| ゲーム | 例文 | そのゲームの入札表 |
|---|---|---|
| fortyfives | `bid 20` | 0=Pass, 15, 20, 25 |
| twentynine | `bid 20` | 0=Pass, 16, 20, 24, 28 |
| solowhist | `bid 1` | 0=Pass, **1=Solo**, 2=Misère, 3=Abundance |
| nap | `bid 3` | 0=Pass, **2/3/4=トリック数**, 5=Nap |
| preference | `bid 1` | 0=Pass, **1=Six**, 2=Misère, 3=Seven, 4=Eight |
| vira | `b 2` | 動詞が `b`。0=Pass, 1=Gask, **2=Solo** |

共通の値にすると、そのゲームに存在しない入札を例示することになります。

## 今やる理由

**#5389 で拒否に印が付くようになり、`TestCuiHelpExamplesExecute` が「動詞」だけでなく「引数」の誤りも見るようになりました。**

書き始める前にそれを確かめています。blackjack の例文を `b abc` に差し替えると:

```
--- FAIL: TestCuiHelpExamplesExecute
    blackjack: `b abc` was rejected -- Invalid bet amount. Please enter a number.
```

印が付く前は、これは**素通りしていました**。以前に手書きした例文 6 件中 4 件が実在しないコマンドだった件を踏まえると、この検証が効くようになってから進めるのが順序として正しいと判断しました。

## 配り依存の確認

```
go test -tags test ./internal/infrastructure/ui/ -run TestCuiHelpExamples -count=120  →  ok (28.1s)
```

120 回とも緑なので、どの例文も配りに依存しません。

## 検証

- `go test -tags test ./internal/infrastructure/ui/` — 緑（例文実行ガード、動詞ガード、生キーガード、表→パーサのガードを含む）
- `go build ./...` — 通過
- `golangci-lint run ./internal/...` — 0 issues

Refs #5370
