### PR TITLE
feat(cui): add worked examples to thirteen more games

### DIFF
--- a/internal/i18n/locales/en/bakersgame.json
+++ b/internal/i18n/locales/en/bakersgame.json
@@ -19,5 +19,8 @@
   "hintToFoundation": "foundation",
   "hintToTableau": "tableau column {{col}}",
   "hintToFreeCell": "free cell {{col}}",
-  "hintLine": "Hint: {{from}} → {{to}}"
+  "hintLine": "Hint: {{from}} → {{to}}",
+  "helpExampleMoveCell": "  m t 0 c 0            park the top of column 0 in free cell 0",
+  "helpExampleHint": "  h                    ask for a move",
+  "helpExampleAuto": "  ac                   send everything that can go to a foundation"
 }

--- a/internal/i18n/locales/en/basra.json
+++ b/internal/i18n/locales/en/basra.json
@@ -16,5 +16,7 @@
   "hintReasonCapture": "Capture the most valuable table cards",
   "hintReasonTrail": "No capture — trail a low card",
   "result.scores": "Game over! Scores: {{scores}}",
-  "captureHint": "{{hand}} → table {{table}}"
+  "captureHint": "{{hand}} → table {{table}}",
+  "helpExamplePlay": "  p 0                       lay hand card 0 on the table, capturing nothing",
+  "helpExampleNext": "  nr                        start a new game"
 }

--- a/internal/i18n/locales/en/briscola.json
+++ b/internal/i18n/locales/en/briscola.json
@@ -21,5 +21,7 @@
   "hintReasonLeadValue": "lead with a value card",
   "hintReasonFollowCut": "cut with trump",
   "hintReasonFollowWin": "win this trick",
-  "hintReasonFollowDump": "dump a low-value card"
+  "hintReasonFollowDump": "dump a low-value card",
+  "helpExamplePlay": "  p 0                  play hand card 0",
+  "helpExampleNext": "  n                    read the trick result, then continue"
 }

--- a/internal/i18n/locales/en/cuarenta.json
+++ b/internal/i18n/locales/en/cuarenta.json
@@ -19,5 +19,7 @@
   "scoreEntry": "  Team {{team}}: {{score}} pts",
   "promptCurrentTurn": "Turn: {{name}}",
   "promptHelp": "p <hand> to capture or lay / n for next round",
-  "teamCaptured": "Team {{team}} captured: {{count}} ({{need}}+ earns +{{bonus}})"
+  "teamCaptured": "Team {{team}} captured: {{count}} ({{need}}+ earns +{{bonus}})",
+  "helpExamplePlay": "  p 0                      lay hand card 0 on the table, capturing nothing",
+  "helpExampleNext": "  n                        read the round result, then continue"
 }

--- a/internal/i18n/locales/en/eightoff.json
+++ b/internal/i18n/locales/en/eightoff.json
@@ -20,5 +20,8 @@
   "hintToTableau": "tableau column {{col}}",
   "hintToFreeCell": "free cell {{col}}",
   "hintLine": "Hint: {{from}} → {{to}}",
-  "supermoveLine": "Max cards per move: {{limit}} (free cells {{cells}}, empty columns {{cols}})"
+  "supermoveLine": "Max cards per move: {{limit}} (free cells {{cells}}, empty columns {{cols}})",
+  "helpExampleMoveCell": "  m t 0 c 0            park the top of column 0 in free cell 0",
+  "helpExampleHint": "  h                    ask for a move",
+  "helpExampleAuto": "  ac                   send everything that can go to a foundation"
 }

--- a/internal/i18n/locales/en/freecell.json
+++ b/internal/i18n/locales/en/freecell.json
@@ -21,5 +21,8 @@
   "hintToFreeCell": "free cell {{col}}",
   "hintLine": "Hint: {{from}} → {{to}}",
   "supermoveLine": "Supermove: up to {{limit}} cards (free cells {{cells}} / empty columns {{cols}})",
-  "supermoveToEmpty": " / {{limit}} onto an empty column"
+  "supermoveToEmpty": " / {{limit}} onto an empty column",
+  "helpExampleMoveCell": "  m t 0 c 0            park the top of column 0 in free cell 0",
+  "helpExampleHint": "  h                    ask for a move",
+  "helpExampleAuto": "  ac                   send everything that can go to a foundation"
 }

--- a/internal/i18n/locales/en/karnoffel.json
+++ b/internal/i18n/locales/en/karnoffel.json
@@ -22,5 +22,7 @@
   "handEnd": "Hand over",
   "handDrawn": "Hand over — neither side reached three tricks",
   "result.humanWin": "Game over! Your team wins!",
-  "result.cpuWin": "Game over! The other team wins."
+  "result.cpuWin": "Game over! The other team wins.",
+  "helpExamplePlay": "  p 0                       play hand card 0",
+  "helpExampleNext": "  n                         read the trick result, then continue"
 }

--- a/internal/i18n/locales/en/nainjaune.json
+++ b/internal/i18n/locales/en/nainjaune.json
@@ -26,5 +26,7 @@
   "hintReasonNotYourTurn": "it is not your turn",
   "hintReasonLead": "the run is stopped, so start low",
   "hintReasonFollow": "this continues the run",
-  "hintReasonBox": "this card claims a box"
+  "hintReasonBox": "this card claims a box",
+  "helpExamplePlay": "  p 0                      play hand card 0",
+  "helpExampleNext": "  n                        read the trick result, then continue"
 }

--- a/internal/i18n/locales/en/penguin.json
+++ b/internal/i18n/locales/en/penguin.json
@@ -28,5 +28,8 @@
   "hintToFreeCell": "free cell {{col}}",
   "hintLine": "Hint: {{from}} → {{to}}",
   "supermoveLine": "Supermove: up to {{limit}} cards (free cells {{cells}} / empty columns {{cols}})",
-  "supermoveToEmpty": " / {{limit}} onto an empty column"
+  "supermoveToEmpty": " / {{limit}} onto an empty column",
+  "helpExampleMoveCell": "  m t 0 c 0            park the top of column 0 in free cell 0",
+  "helpExampleHint": "  h                    ask for a move",
+  "helpExampleAuto": "  ac                   send everything that can go to a foundation"
 }

--- a/internal/i18n/locales/en/popejoan.json
+++ b/internal/i18n/locales/en/popejoan.json
@@ -29,5 +29,7 @@
   "hintReasonDealEnd": "this deal is already over",
   "hintReasonNotYourTurn": "it is not your turn",
   "hintReasonLead": "the run is stopped, so lead your lowest card",
-  "hintReasonFollow": "the next higher card of the same suit"
+  "hintReasonFollow": "the next higher card of the same suit",
+  "helpExamplePlay": "  p 0                      play hand card 0",
+  "helpExampleNext": "  n                        read the trick result, then continue"
 }

--- a/internal/i18n/locales/en/scopa.json
+++ b/internal/i18n/locales/en/scopa.json
@@ -27,5 +27,7 @@
   "category.cards": "Carte (most cards)",
   "category.denari": "Denari (most diamonds)",
   "category.primiera": "Primiera (most sevens)",
-  "category.settebello": "Settebello (7 of diamonds)"
+  "category.settebello": "Settebello (7 of diamonds)",
+  "helpExamplePlay": "  p 0                      lay hand card 0 on the table, capturing nothing",
+  "helpExampleNext": "  n                        read the round result, then continue"
 }

--- a/internal/i18n/locales/en/seahaventowers.json
+++ b/internal/i18n/locales/en/seahaventowers.json
@@ -26,5 +26,8 @@
   "invalidFromZone": "invalid source zone: {{val}}",
   "invalidToZone": "invalid destination zone: {{val}}",
   "moveUsage": "usage: m t <col> [<idx>] t|f|c <toCol|cell>",
-  "supermoveLine": "Max cards per move: {{limit}} (empty reserved cells {{reserved}})"
+  "supermoveLine": "Max cards per move: {{limit}} (empty reserved cells {{reserved}})",
+  "helpExampleMoveCell": "  m t 0 c 0            park the top of column 0 in free cell 0",
+  "helpExampleHint": "  h                    ask for a move",
+  "helpExampleAuto": "  ac                   send everything that can go to a foundation"
 }

--- a/internal/i18n/locales/en/tablanet.json
+++ b/internal/i18n/locales/en/tablanet.json
@@ -16,5 +16,7 @@
   "hintReasonCapture": "Capture the most valuable table cards",
   "hintReasonTrail": "No capture — trail a low card",
   "result.scores": "Game over! Scores: {{scores}}",
-  "captureHint": "{{hand}} → table {{table}}"
+  "captureHint": "{{hand}} → table {{table}}",
+  "helpExamplePlay": "  p 0                       lay hand card 0 on the table, capturing nothing",
+  "helpExampleNext": "  nr                        start a new game"
 }

--- a/internal/i18n/locales/ja/bakersgame.json
+++ b/internal/i18n/locales/ja/bakersgame.json
@@ -19,5 +19,8 @@
   "hintToFoundation": "ファンデーション",
   "hintToTableau": "タブロー列{{col}}",
   "hintToFreeCell": "フリーセル{{col}}",
-  "hintLine": "ヒント: {{from}} → {{to}}"
+  "hintLine": "ヒント: {{from}} → {{to}}",
+  "helpExampleMoveCell": "  m t 0 c 0            列 0 の一番上を空きセル 0 へ逃がす",
+  "helpExampleHint": "  h                    次の一手を教えてもらう",
+  "helpExampleAuto": "  ac                   組札へ送れる札を自動で送る"
 }

--- a/internal/i18n/locales/ja/basra.json
+++ b/internal/i18n/locales/ja/basra.json
@@ -16,5 +16,7 @@
   "hintReasonCapture": "価値の高い場札を捕獲する",
   "hintReasonTrail": "捕獲できないので低い札を捨てる",
   "result.scores": "ゲーム終了！ 得点: {{scores}}",
-  "captureHint": "{{hand}} → 場{{table}}"
+  "captureHint": "{{hand}} → 場{{table}}",
+  "helpExamplePlay": "  p 0                       手札の 0 番を場に置く (場札を取らない)",
+  "helpExampleNext": "  nr                        新しいゲームを始める"
 }

--- a/internal/i18n/locales/ja/briscola.json
+++ b/internal/i18n/locales/ja/briscola.json
@@ -21,5 +21,7 @@
   "hintReasonLeadValue": "得点札でリード",
   "hintReasonFollowCut": "トランプでカット",
   "hintReasonFollowWin": "このトリックを取る",
-  "hintReasonFollowDump": "低価値の札を捨てる"
+  "hintReasonFollowDump": "低価値の札を捨てる",
+  "helpExamplePlay": "  p 0                  手札の 0 番のカードを出す",
+  "helpExampleNext": "  n                    トリックの決着を見てから次へ"
 }

--- a/internal/i18n/locales/ja/cuarenta.json
+++ b/internal/i18n/locales/ja/cuarenta.json
@@ -19,5 +19,7 @@
   "scoreEntry": "  チーム{{team}}: {{score}}点",
   "promptCurrentTurn": "手番: {{name}}",
   "promptHelp": "p <hand> で捕獲または場に置く / n で次のラウンド",
-  "teamCaptured": "チーム{{team}} 捕獲: {{count}}枚（{{need}}枚以上で +{{bonus}}）"
+  "teamCaptured": "チーム{{team}} 捕獲: {{count}}枚（{{need}}枚以上で +{{bonus}}）",
+  "helpExamplePlay": "  p 0                      手札の 0 番を場に置く (場札を取らない)",
+  "helpExampleNext": "  n                        ラウンドの結果を見てから次へ"
 }

--- a/internal/i18n/locales/ja/eightoff.json
+++ b/internal/i18n/locales/ja/eightoff.json
@@ -20,5 +20,8 @@
   "hintToTableau": "タブロー列{{col}}",
   "hintToFreeCell": "フリーセル{{col}}",
   "hintLine": "ヒント: {{from}} → {{to}}",
-  "supermoveLine": "一度に移動可能: {{limit}}枚（空きセル{{cells}}・空き列{{cols}}）"
+  "supermoveLine": "一度に移動可能: {{limit}}枚（空きセル{{cells}}・空き列{{cols}}）",
+  "helpExampleMoveCell": "  m t 0 c 0            列 0 の一番上を空きセル 0 へ逃がす",
+  "helpExampleHint": "  h                    次の一手を教えてもらう",
+  "helpExampleAuto": "  ac                   組札へ送れる札を自動で送る"
 }

--- a/internal/i18n/locales/ja/freecell.json
+++ b/internal/i18n/locales/ja/freecell.json
@@ -21,5 +21,8 @@
   "hintToFreeCell": "フリーセル{{col}}",
   "hintLine": "ヒント: {{from}} → {{to}}",
   "supermoveLine": "一括移動: 最大{{limit}}枚 (空きセル{{cells}} / 空き列{{cols}})",
-  "supermoveToEmpty": " / 空き列へは{{limit}}枚"
+  "supermoveToEmpty": " / 空き列へは{{limit}}枚",
+  "helpExampleMoveCell": "  m t 0 c 0            列 0 の一番上を空きセル 0 へ逃がす",
+  "helpExampleHint": "  h                    次の一手を教えてもらう",
+  "helpExampleAuto": "  ac                   組札へ送れる札を自動で送る"
 }

--- a/internal/i18n/locales/ja/karnoffel.json
+++ b/internal/i18n/locales/ja/karnoffel.json
@@ -22,5 +22,7 @@
   "handEnd": "局終了",
   "handDrawn": "局終了（どちらも3トリックに届かず）",
   "result.humanWin": "ゲーム終了！ あなたのチームの勝ちです！",
-  "result.cpuWin": "ゲーム終了！ 相手チームの勝ちです。"
+  "result.cpuWin": "ゲーム終了！ 相手チームの勝ちです。",
+  "helpExamplePlay": "  p 0                       手札の 0 番のカードを出す",
+  "helpExampleNext": "  n                         トリックの決着を見てから次へ"
 }

--- a/internal/i18n/locales/ja/nainjaune.json
+++ b/internal/i18n/locales/ja/nainjaune.json
@@ -26,5 +26,7 @@
   "hintReasonNotYourTurn": "あなたの手番ではありません",
   "hintReasonLead": "並びが止まっているので、低い札から始めます",
   "hintReasonFollow": "並びの続きになる札です",
-  "hintReasonBox": "この札は区画のチップを取れます"
+  "hintReasonBox": "この札は区画のチップを取れます",
+  "helpExamplePlay": "  p 0                      手札の 0 番のカードを出す",
+  "helpExampleNext": "  n                        トリックの決着を見てから次へ"
 }

--- a/internal/i18n/locales/ja/penguin.json
+++ b/internal/i18n/locales/ja/penguin.json
@@ -28,5 +28,8 @@
   "hintToFreeCell": "フリーセル{{col}}",
   "hintLine": "ヒント: {{from}} → {{to}}",
   "supermoveLine": "一括移動: 最大{{limit}}枚 (空きセル{{cells}} / 空き列{{cols}})",
-  "supermoveToEmpty": " / 空き列へは{{limit}}枚"
+  "supermoveToEmpty": " / 空き列へは{{limit}}枚",
+  "helpExampleMoveCell": "  m t 0 c 0            列 0 の一番上を空きセル 0 へ逃がす",
+  "helpExampleHint": "  h                    次の一手を教えてもらう",
+  "helpExampleAuto": "  ac                   組札へ送れる札を自動で送る"
 }

--- a/internal/i18n/locales/ja/popejoan.json
+++ b/internal/i18n/locales/ja/popejoan.json
@@ -29,5 +29,7 @@
   "hintReasonDealEnd": "このディールは終わっています",
   "hintReasonNotYourTurn": "あなたの手番ではありません",
   "hintReasonLead": "並びが止まっているので、最も低い札から始めます",
-  "hintReasonFollow": "同じスートの次に高い札です"
+  "hintReasonFollow": "同じスートの次に高い札です",
+  "helpExamplePlay": "  p 0                      手札の 0 番のカードを出す",
+  "helpExampleNext": "  n                        トリックの決着を見てから次へ"
 }

--- a/internal/i18n/locales/ja/scopa.json
+++ b/internal/i18n/locales/ja/scopa.json
@@ -27,5 +27,7 @@
   "category.cards": "カルテ(最多枚数)",
   "category.denari": "デナリ(ダイヤ最多)",
   "category.primiera": "プリミエラ(7最多)",
-  "category.settebello": "セッテベッロ(7♦)"
+  "category.settebello": "セッテベッロ(7♦)",
+  "helpExamplePlay": "  p 0                      手札の 0 番を場に置く (場札を取らない)",
+  "helpExampleNext": "  n                        ラウンドの結果を見てから次へ"
 }

--- a/internal/i18n/locales/ja/seahaventowers.json
+++ b/internal/i18n/locales/ja/seahaventowers.json
@@ -26,5 +26,8 @@
   "invalidFromZone": "無効な移動元です: {{val}}",
   "invalidToZone": "無効な移動先です: {{val}}",
   "moveUsage": "使い方: m t <col> [<idx>] t|f|c <toCol|cell>",
-  "supermoveLine": "一括移動可能: 最大{{limit}}枚（空きリザーブ{{reserved}}）"
+  "supermoveLine": "一括移動可能: 最大{{limit}}枚（空きリザーブ{{reserved}}）",
+  "helpExampleMoveCell": "  m t 0 c 0            列 0 の一番上を空きセル 0 へ逃がす",
+  "helpExampleHint": "  h                    次の一手を教えてもらう",
+  "helpExampleAuto": "  ac                   組札へ送れる札を自動で送る"
 }

--- a/internal/i18n/locales/ja/tablanet.json
+++ b/internal/i18n/locales/ja/tablanet.json
@@ -16,5 +16,7 @@
   "hintReasonCapture": "価値の高い場札を捕獲する",
   "hintReasonTrail": "捕獲できないので低い札を捨てる",
   "result.scores": "ゲーム終了！ 得点: {{scores}}",
-  "captureHint": "{{hand}} → 場{{table}}"
+  "captureHint": "{{hand}} → 場{{table}}",
+  "helpExamplePlay": "  p 0                       手札の 0 番を場に置く (場札を取らない)",
+  "helpExampleNext": "  nr                        新しいゲームを始める"
 }

--- a/internal/infrastructure/ui/GameManager.go
+++ b/internal/infrastructure/ui/GameManager.go
@@ -480,6 +480,11 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewFreeCellCuiController,
 		CuiHelpSpec{
 			TitleKey: "freecell.helpTitle",
+			ExampleKeys: []string{
+				"freecell.helpExampleMoveCell",
+				"freecell.helpExampleHint",
+				"freecell.helpExampleAuto",
+			},
 			CommandKeys: []string{
 				"freecell.helpMove",
 				"freecell.helpMoveTF",
@@ -502,6 +507,11 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewSeahavenTowersCuiController,
 		CuiHelpSpec{
 			TitleKey: "seahaventowers.helpTitle",
+			ExampleKeys: []string{
+				"seahaventowers.helpExampleMoveCell",
+				"seahaventowers.helpExampleHint",
+				"seahaventowers.helpExampleAuto",
+			},
 			CommandKeys: []string{
 				"seahaventowers.helpMove",
 				"seahaventowers.helpMoveTF",
@@ -2345,7 +2355,11 @@ var gameRegistry = []GameRegistryEntry{
 		},
 		controller.NewBriscolaCuiController,
 		CuiHelpSpec{
-			TitleKey:          "briscola.helpTitle",
+			TitleKey: "briscola.helpTitle",
+			ExampleKeys: []string{
+				"briscola.helpExamplePlay",
+				"briscola.helpExampleNext",
+			},
 			CommandKeys:       []string{"briscola.helpPlay", "briscola.helpNext"},
 			ExtraCommandLines: []string{"  l                    action log"},
 		}),
@@ -2400,6 +2414,11 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewEightOffCuiController,
 		CuiHelpSpec{
 			TitleKey: "eightoff.helpTitle",
+			ExampleKeys: []string{
+				"eightoff.helpExampleMoveCell",
+				"eightoff.helpExampleHint",
+				"eightoff.helpExampleAuto",
+			},
 			CommandKeys: []string{
 				"eightoff.helpMove",
 				"eightoff.helpMoveTF",
@@ -2441,6 +2460,11 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewPenguinCuiController,
 		CuiHelpSpec{
 			TitleKey: "penguin.helpTitle",
+			ExampleKeys: []string{
+				"penguin.helpExampleMoveCell",
+				"penguin.helpExampleHint",
+				"penguin.helpExampleAuto",
+			},
 			CommandKeys: []string{
 				"penguin.helpMove",
 				"penguin.helpMoveTF",
@@ -2501,7 +2525,11 @@ var gameRegistry = []GameRegistryEntry{
 		},
 		controller.NewScopaCuiController,
 		CuiHelpSpec{
-			TitleKey:    "scopa.helpTitle",
+			TitleKey: "scopa.helpTitle",
+			ExampleKeys: []string{
+				"scopa.helpExamplePlay",
+				"scopa.helpExampleNext",
+			},
 			CommandKeys: []string{"scopa.helpPlay", "scopa.helpNext"},
 			SettingKeys: []string{"scopa.helpSetDifficulty"},
 		}),
@@ -2774,6 +2802,11 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewFreeCellCuiController,
 		CuiHelpSpec{
 			TitleKey: "bakersgame.helpTitle",
+			ExampleKeys: []string{
+				"bakersgame.helpExampleMoveCell",
+				"bakersgame.helpExampleHint",
+				"bakersgame.helpExampleAuto",
+			},
 			CommandKeys: []string{
 				"bakersgame.helpMove",
 				"bakersgame.helpMoveTF",
@@ -3487,6 +3520,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewCuarentaCuiController,
 		CuiHelpSpec{
 			TitleKey: "cuarenta.helpTitle",
+			ExampleKeys: []string{
+				"cuarenta.helpExamplePlay",
+				"cuarenta.helpExampleNext",
+			},
 			CommandKeys: []string{
 				"cuarenta.helpPlay",
 				"cuarenta.helpNext",
@@ -3805,7 +3842,11 @@ var gameRegistry = []GameRegistryEntry{
 		},
 		controller.NewBasraCuiController,
 		CuiHelpSpec{
-			TitleKey:          "basra.helpTitle",
+			TitleKey: "basra.helpTitle",
+			ExampleKeys: []string{
+				"basra.helpExamplePlay",
+				"basra.helpExampleNext",
+			},
 			CommandKeys:       []string{"basra.helpPlay", "basra.helpNext"},
 			ExtraCommandLines: []string{"  l                    action log"},
 			SettingKeys:       []string{"basra.helpSetDifficulty"},
@@ -3816,7 +3857,11 @@ var gameRegistry = []GameRegistryEntry{
 		},
 		controller.NewTablanetCuiController,
 		CuiHelpSpec{
-			TitleKey:          "tablanet.helpTitle",
+			TitleKey: "tablanet.helpTitle",
+			ExampleKeys: []string{
+				"tablanet.helpExamplePlay",
+				"tablanet.helpExampleNext",
+			},
 			CommandKeys:       []string{"tablanet.helpPlay", "tablanet.helpNext"},
 			ExtraCommandLines: []string{"  l                    action log"},
 			SettingKeys:       []string{"tablanet.helpSetDifficulty"},
@@ -4199,6 +4244,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewPopeJoanCuiController,
 		CuiHelpSpec{
 			TitleKey: "popejoan.helpTitle",
+			ExampleKeys: []string{
+				"popejoan.helpExamplePlay",
+				"popejoan.helpExampleNext",
+			},
 			CommandKeys: []string{
 				"popejoan.helpPlay",
 				"popejoan.helpNext",
@@ -4212,6 +4261,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewNainJauneCuiController,
 		CuiHelpSpec{
 			TitleKey: "nainjaune.helpTitle",
+			ExampleKeys: []string{
+				"nainjaune.helpExamplePlay",
+				"nainjaune.helpExampleNext",
+			},
 			CommandKeys: []string{
 				"nainjaune.helpPlay",
 				"nainjaune.helpNext",
@@ -4345,6 +4398,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewKarnoffelCuiController,
 		CuiHelpSpec{
 			TitleKey: "karnoffel.helpTitle",
+			ExampleKeys: []string{
+				"karnoffel.helpExamplePlay",
+				"karnoffel.helpExampleNext",
+			},
 			CommandKeys: []string{
 				"karnoffel.helpPlay",
 				"karnoffel.helpNext",


### PR DESCRIPTION
## 変更

例文つきのゲームが **30 → 43** になりました（#5393 の続き）。

| ファミリ | ゲーム | 例文 |
|---|---|---|
| freecell 系 | freecell / seahaventowers / eightoff / penguin / bakersgame | `m t 0 c 0` → `h` → `ac` |
| briscola 系 | briscola / popejoan / nainjaune / karnoffel | `p 0` → `n` |
| scopa 系 | scopa / cuarenta / basra / tablanet | `p 0` → 各ゲームの次コマンド |

## ガードが 2 件の誤りを止めました

**1. 同じ位置のコマンドでも動詞と意味が違う。**

scopa と cuarenta は `n`（次のラウンド）ですが、**basra と tablanet は `nr`（新しいゲーム）**です。4 ゲームすべてに `n` を書いても、**コントローラは受け付けるので私のプローブは通りました**。止めたのは表を見るガードです。

```
--- FAIL: TestCuiHelpExamplesUseRealCommands
    en/basra: example uses `n`, which its command table does not list
```

basra / tablanet は `nr` にし、説明も「新しいゲームを始める」に変えています（`n` の「次のトリックへ」ではありません）。

**2. 配線スクリプトの正規表現が隣のゲームに滑った。**

`BindCuiFor("briscola", .*? TitleKey:` は briscola 自身のブロックを越えて後続のゲームに届いていました（briscola は `TitleKey:` を整列用の空白付きで書いているため）。**「解決した prefix がゲーム名と一致する」というアサート**が書き込み前に止めました。

```
ABORT: briscola renders under gaps
```

いまはゲーム自身のブロックに範囲を限定してから `TitleKey` を探します。

## 配り依存の確認

候補は書く前に**ゲームごと 8 配り**で拒否ゼロを確認しました。13 ゲームすべて拒否なしです。

`ac`（オートコンプリート）を含む freecell 系は 1 回の実行が重く、パッケージ全体でも 6.3 秒かかります。繰り返し実行は別途回しています。

## 検証

- `go test -tags test ./internal/infrastructure/ui/` — 緑（例文実行・動詞・生キー・表→パーサの各ガード）
- `go build ./...` — 通過
- `golangci-lint run ./internal/...` — 0 issues

Refs #5370
