### PR TITLE
feat(cui): add worked examples to fifteen more games

### DIFF
--- a/internal/i18n/locales/en/bakersdozen.json
+++ b/internal/i18n/locales/en/bakersdozen.json
@@ -12,5 +12,7 @@
   "hintFrom": "tableau column {{col}}[{{idx}}]",
   "hintToFoundation": "foundation",
   "hintToTableau": "tableau column {{col}}",
-  "hintLine": "Hint: {{from}} → {{to}}"
+  "hintLine": "Hint: {{from}} → {{to}}",
+  "helpExampleHint": "  h                    ask for a move",
+  "helpExampleAuto": "  ac                   send everything that can go to a foundation"
 }

--- a/internal/i18n/locales/en/bakersgame.json
+++ b/internal/i18n/locales/en/bakersgame.json
@@ -19,5 +19,8 @@
   "hintToFoundation": "foundation",
   "hintToTableau": "tableau column {{col}}",
   "hintToFreeCell": "free cell {{col}}",
-  "hintLine": "Hint: {{from}} → {{to}}"
+  "hintLine": "Hint: {{from}} → {{to}}",
+  "helpExampleMoveCell": "  m t 0 c 0            park the top of column 0 in free cell 0",
+  "helpExampleHint": "  h                    ask for a move",
+  "helpExampleAuto": "  ac                   send everything that can go to a foundation"
 }

--- a/internal/i18n/locales/en/basra.json
+++ b/internal/i18n/locales/en/basra.json
@@ -16,5 +16,7 @@
   "hintReasonCapture": "Capture the most valuable table cards",
   "hintReasonTrail": "No capture — trail a low card",
   "result.scores": "Game over! Scores: {{scores}}",
-  "captureHint": "{{hand}} → table {{table}}"
+  "captureHint": "{{hand}} → table {{table}}",
+  "helpExamplePlay": "  p 0                       lay hand card 0 on the table, capturing nothing",
+  "helpExampleNext": "  nr                        start a new game"
 }

--- a/internal/i18n/locales/en/beleagueredcastle.json
+++ b/internal/i18n/locales/en/beleagueredcastle.json
@@ -11,5 +11,7 @@
   "hintToFoundation": "foundation",
   "hintToTableau": "tableau column {{col}}",
   "hintLine": "Hint: {{from}} → {{to}}",
-  "undoToEscape": "Undo {{count}} move(s) to escape the dead end (undo {{count}}, or repeat u)"
+  "undoToEscape": "Undo {{count}} move(s) to escape the dead end (undo {{count}}, or repeat u)",
+  "helpExampleHint": "  h                    ask for a move",
+  "helpExampleAuto": "  ac                   send everything that can go to a foundation"
 }

--- a/internal/i18n/locales/en/bhabhi.json
+++ b/internal/i18n/locales/en/bhabhi.json
@@ -23,5 +23,6 @@
   "suitSpade": "Spades",
   "suitClover": "Clubs",
   "suitHeart": "Hearts",
-  "suitDiamond": "Diamonds"
+  "suitDiamond": "Diamonds",
+  "helpExamplePlay": "  p 0                  play hand card 0"
 }

--- a/internal/i18n/locales/en/briscola.json
+++ b/internal/i18n/locales/en/briscola.json
@@ -21,5 +21,7 @@
   "hintReasonLeadValue": "lead with a value card",
   "hintReasonFollowCut": "cut with trump",
   "hintReasonFollowWin": "win this trick",
-  "hintReasonFollowDump": "dump a low-value card"
+  "hintReasonFollowDump": "dump a low-value card",
+  "helpExamplePlay": "  p 0                  play hand card 0",
+  "helpExampleNext": "  n                    read the trick result, then continue"
 }

--- a/internal/i18n/locales/en/caribbeanstud.json
+++ b/internal/i18n/locales/en/caribbeanstud.json
@@ -27,5 +27,7 @@
   "hintFold": "fold",
   "hintPairOrBetter": "you have one pair or better",
   "hintAceKingHigh": "no made hand, but you hold an Ace and a King",
-  "hintWeakHand": "no made hand and nothing as high as Ace-King"
+  "hintWeakHand": "no made hand and nothing as high as Ace-King",
+  "helpExampleBet": "  b 10                 ante 10 and get a hand",
+  "helpExamplePlay": "  p                    play, matching the ante"
 }

--- a/internal/i18n/locales/en/cuarenta.json
+++ b/internal/i18n/locales/en/cuarenta.json
@@ -19,5 +19,7 @@
   "scoreEntry": "  Team {{team}}: {{score}} pts",
   "promptCurrentTurn": "Turn: {{name}}",
   "promptHelp": "p <hand> to capture or lay / n for next round",
-  "teamCaptured": "Team {{team}} captured: {{count}} ({{need}}+ earns +{{bonus}})"
+  "teamCaptured": "Team {{team}} captured: {{count}} ({{need}}+ earns +{{bonus}})",
+  "helpExamplePlay": "  p 0                      lay hand card 0 on the table, capturing nothing",
+  "helpExampleNext": "  n                        read the round result, then continue"
 }

--- a/internal/i18n/locales/en/cucumber.json
+++ b/internal/i18n/locales/en/cucumber.json
@@ -21,5 +21,7 @@
   "hintCard": "[HINT: [{{idx}}]{{card}} ({{reason}})]",
   "hintReasonLead": "You lead, so anything is legal",
   "hintReasonBeat": "The cheapest card that still beats it -- do not carry high cards into the last trick",
-  "hintReasonForced": "You cannot beat it, so this card is forced"
+  "hintReasonForced": "You cannot beat it, so this card is forced",
+  "helpExamplePlay": "  p 0                  play hand card 0",
+  "helpExampleNext": "  n                    read the round result, then continue"
 }

--- a/internal/i18n/locales/en/eightoff.json
+++ b/internal/i18n/locales/en/eightoff.json
@@ -20,5 +20,8 @@
   "hintToTableau": "tableau column {{col}}",
   "hintToFreeCell": "free cell {{col}}",
   "hintLine": "Hint: {{from}} → {{to}}",
-  "supermoveLine": "Max cards per move: {{limit}} (free cells {{cells}}, empty columns {{cols}})"
+  "supermoveLine": "Max cards per move: {{limit}} (free cells {{cells}}, empty columns {{cols}})",
+  "helpExampleMoveCell": "  m t 0 c 0            park the top of column 0 in free cell 0",
+  "helpExampleHint": "  h                    ask for a move",
+  "helpExampleAuto": "  ac                   send everything that can go to a foundation"
 }

--- a/internal/i18n/locales/en/fourcardpoker.json
+++ b/internal/i18n/locales/en/fourcardpoker.json
@@ -24,5 +24,7 @@
   "antePayoutLine": "Ante payout: {{payout}}",
   "playPayoutLine": "Play payout: {{payout}}",
   "anteBonusPayoutLine": "Ante bonus: {{payout}}",
-  "acesUpPayoutLine": "Aces Up: {{payout}}"
+  "acesUpPayoutLine": "Aces Up: {{payout}}",
+  "helpExampleBet": "  b 10                 ante 10 and get a hand",
+  "helpExamplePlay": "  p                    play, matching the ante"
 }

--- a/internal/i18n/locales/en/freecell.json
+++ b/internal/i18n/locales/en/freecell.json
@@ -21,5 +21,8 @@
   "hintToFreeCell": "free cell {{col}}",
   "hintLine": "Hint: {{from}} → {{to}}",
   "supermoveLine": "Supermove: up to {{limit}} cards (free cells {{cells}} / empty columns {{cols}})",
-  "supermoveToEmpty": " / {{limit}} onto an empty column"
+  "supermoveToEmpty": " / {{limit}} onto an empty column",
+  "helpExampleMoveCell": "  m t 0 c 0            park the top of column 0 in free cell 0",
+  "helpExampleHint": "  h                    ask for a move",
+  "helpExampleAuto": "  ac                   send everything that can go to a foundation"
 }

--- a/internal/i18n/locales/en/germanwhist.json
+++ b/internal/i18n/locales/en/germanwhist.json
@@ -22,5 +22,6 @@
   "suitSpade": "Spades",
   "suitClover": "Clubs",
   "suitHeart": "Hearts",
-  "suitDiamond": "Diamonds"
+  "suitDiamond": "Diamonds",
+  "helpExamplePlay": "  p 0                  play hand card 0"
 }

--- a/internal/i18n/locales/en/karnoffel.json
+++ b/internal/i18n/locales/en/karnoffel.json
@@ -22,5 +22,7 @@
   "handEnd": "Hand over",
   "handDrawn": "Hand over — neither side reached three tricks",
   "result.humanWin": "Game over! Your team wins!",
-  "result.cpuWin": "Game over! The other team wins."
+  "result.cpuWin": "Game over! The other team wins.",
+  "helpExamplePlay": "  p 0                       play hand card 0",
+  "helpExampleNext": "  n                         read the trick result, then continue"
 }

--- a/internal/i18n/locales/en/lingerlonger.json
+++ b/internal/i18n/locales/en/lingerlonger.json
@@ -17,5 +17,6 @@
   "hintCard": "[HINT: [{{idx}}]{{card}} ({{reason}})]",
   "hintReasonWinTrick": "Take it and you draw a replacement",
   "hintReasonNoStock": "You can take it, but the stock is empty -- no refill",
-  "hintReasonDuck": "You cannot take it, so play low"
+  "hintReasonDuck": "You cannot take it, so play low",
+  "helpExamplePlay": "  p 0                  play hand card 0"
 }

--- a/internal/i18n/locales/en/mendikot.json
+++ b/internal/i18n/locales/en/mendikot.json
@@ -30,5 +30,7 @@
   "suitSpade": "Spades",
   "suitClover": "Clubs",
   "suitHeart": "Hearts",
-  "suitDiamond": "Diamonds"
+  "suitDiamond": "Diamonds",
+  "helpExamplePlay": "  p 0                  play hand card 0",
+  "helpExampleNext": "  n                    read the round result, then continue"
 }

--- a/internal/i18n/locales/en/mississippistud.json
+++ b/internal/i18n/locales/en/mississippistud.json
@@ -29,5 +29,7 @@
   "hintFold": "Recommended: fold",
   "madeHandLine": "Current hand: {{hand}} ({{eligible}})",
   "madeHandEligible": "pays",
-  "madeHandNotEligible": "does not pay"
+  "madeHandNotEligible": "does not pay",
+  "helpExampleBet": "  b 10                 ante 10 and get a hand",
+  "helpExamplePlay": "  p                    play, matching the ante"
 }

--- a/internal/i18n/locales/en/nainjaune.json
+++ b/internal/i18n/locales/en/nainjaune.json
@@ -26,5 +26,7 @@
   "hintReasonNotYourTurn": "it is not your turn",
   "hintReasonLead": "the run is stopped, so start low",
   "hintReasonFollow": "this continues the run",
-  "hintReasonBox": "this card claims a box"
+  "hintReasonBox": "this card claims a box",
+  "helpExamplePlay": "  p 0                      play hand card 0",
+  "helpExampleNext": "  n                        read the trick result, then continue"
 }

--- a/internal/i18n/locales/en/pasur.json
+++ b/internal/i18n/locales/en/pasur.json
@@ -18,5 +18,6 @@
   "hintTrail": "[HINT: lay [{{idx}}]{{card}} on the table ({{reason}})]",
   "hintReasonSoor": "This empties the table -- that capture scores double",
   "hintReasonCapture": "It takes cards that score",
-  "hintReasonTrail": "Nothing adds to 11; lay down your least valuable card"
+  "hintReasonTrail": "Nothing adds to 11; lay down your least valuable card",
+  "helpExamplePlay": "  p 0                  play hand card 0"
 }

--- a/internal/i18n/locales/en/penguin.json
+++ b/internal/i18n/locales/en/penguin.json
@@ -28,5 +28,8 @@
   "hintToFreeCell": "free cell {{col}}",
   "hintLine": "Hint: {{from}} → {{to}}",
   "supermoveLine": "Supermove: up to {{limit}} cards (free cells {{cells}} / empty columns {{cols}})",
-  "supermoveToEmpty": " / {{limit}} onto an empty column"
+  "supermoveToEmpty": " / {{limit}} onto an empty column",
+  "helpExampleMoveCell": "  m t 0 c 0            park the top of column 0 in free cell 0",
+  "helpExampleHint": "  h                    ask for a move",
+  "helpExampleAuto": "  ac                   send everything that can go to a foundation"
 }

--- a/internal/i18n/locales/en/popejoan.json
+++ b/internal/i18n/locales/en/popejoan.json
@@ -29,5 +29,7 @@
   "hintReasonDealEnd": "this deal is already over",
   "hintReasonNotYourTurn": "it is not your turn",
   "hintReasonLead": "the run is stopped, so lead your lowest card",
-  "hintReasonFollow": "the next higher card of the same suit"
+  "hintReasonFollow": "the next higher card of the same suit",
+  "helpExamplePlay": "  p 0                      play hand card 0",
+  "helpExampleNext": "  n                        read the trick result, then continue"
 }

--- a/internal/i18n/locales/en/reversis.json
+++ b/internal/i18n/locales/en/reversis.json
@@ -21,5 +21,7 @@
   "hintReasonAvoidMarked": "the Quinola or the A of diamonds is on the table -- do not take this",
   "hintReasonAvoidPoints": "penalty cards are on the table -- let someone else take it",
   "hintReasonLeadSafe": "lead a low card that scores nothing",
-  "hintReasonDumpHigh": "safe trick: shed a high card now"
+  "hintReasonDumpHigh": "safe trick: shed a high card now",
+  "helpExamplePlay": "  p 0                  play hand card 0",
+  "helpExampleNext": "  n                    read the round result, then continue"
 }

--- a/internal/i18n/locales/en/scopa.json
+++ b/internal/i18n/locales/en/scopa.json
@@ -27,5 +27,7 @@
   "category.cards": "Carte (most cards)",
   "category.denari": "Denari (most diamonds)",
   "category.primiera": "Primiera (most sevens)",
-  "category.settebello": "Settebello (7 of diamonds)"
+  "category.settebello": "Settebello (7 of diamonds)",
+  "helpExamplePlay": "  p 0                      lay hand card 0 on the table, capturing nothing",
+  "helpExampleNext": "  n                        read the round result, then continue"
 }

--- a/internal/i18n/locales/en/seahaventowers.json
+++ b/internal/i18n/locales/en/seahaventowers.json
@@ -26,5 +26,8 @@
   "invalidFromZone": "invalid source zone: {{val}}",
   "invalidToZone": "invalid destination zone: {{val}}",
   "moveUsage": "usage: m t <col> [<idx>] t|f|c <toCol|cell>",
-  "supermoveLine": "Max cards per move: {{limit}} (empty reserved cells {{reserved}})"
+  "supermoveLine": "Max cards per move: {{limit}} (empty reserved cells {{reserved}})",
+  "helpExampleMoveCell": "  m t 0 c 0            park the top of column 0 in free cell 0",
+  "helpExampleHint": "  h                    ask for a move",
+  "helpExampleAuto": "  ac                   send everything that can go to a foundation"
 }

--- a/internal/i18n/locales/en/slobberhannes.json
+++ b/internal/i18n/locales/en/slobberhannes.json
@@ -22,5 +22,7 @@
   "hintCard": "[HINT: [{{idx}}]{{card}} ({{reason}})]",
   "hintReasonAvoid": "this trick carries a penalty -- don't take it",
   "hintReasonDump": "safe trick: get rid of a high card now",
-  "hintReasonLeadLow": "lead low and see what happens"
+  "hintReasonLeadLow": "lead low and see what happens",
+  "helpExamplePlay": "  p 0                  play hand card 0",
+  "helpExampleNext": "  n                    read the round result, then continue"
 }

--- a/internal/i18n/locales/en/streetsandalleys.json
+++ b/internal/i18n/locales/en/streetsandalleys.json
@@ -10,5 +10,7 @@
   "hintFrom": "tableau column {{col}}[{{idx}}]",
   "hintToFoundation": "foundation",
   "hintToTableau": "tableau column {{col}}",
-  "hintLine": "Hint: {{from}} → {{to}}"
+  "hintLine": "Hint: {{from}} → {{to}}",
+  "helpExampleHint": "  h                    ask for a move",
+  "helpExampleAuto": "  ac                   send everything that can go to a foundation"
 }

--- a/internal/i18n/locales/en/tablanet.json
+++ b/internal/i18n/locales/en/tablanet.json
@@ -16,5 +16,7 @@
   "hintReasonCapture": "Capture the most valuable table cards",
   "hintReasonTrail": "No capture — trail a low card",
   "result.scores": "Game over! Scores: {{scores}}",
-  "captureHint": "{{hand}} → table {{table}}"
+  "captureHint": "{{hand}} → table {{table}}",
+  "helpExamplePlay": "  p 0                       lay hand card 0 on the table, capturing nothing",
+  "helpExampleNext": "  nr                        start a new game"
 }

--- a/internal/i18n/locales/en/threecard.json
+++ b/internal/i18n/locales/en/threecard.json
@@ -25,5 +25,7 @@
   "push": "Push!",
   "anteBonusPayoutLine": "Ante bonus payout: {{payout}}",
   "pairPlusPayoutLine": "Pair Plus payout: {{payout}}",
-  "totalPayoutLine": "total payout: {{payout}}"
+  "totalPayoutLine": "total payout: {{payout}}",
+  "helpExampleBet": "  b 10                 ante 10 and get a hand",
+  "helpExamplePlay": "  p                    play, matching the ante"
 }

--- a/internal/i18n/locales/ja/bakersdozen.json
+++ b/internal/i18n/locales/ja/bakersdozen.json
@@ -12,5 +12,7 @@
   "hintFrom": "タブロー列{{col}}[{{idx}}]",
   "hintToFoundation": "ファンデーション",
   "hintToTableau": "タブロー列{{col}}",
-  "hintLine": "ヒント: {{from}} → {{to}}"
+  "hintLine": "ヒント: {{from}} → {{to}}",
+  "helpExampleHint": "  h                    次の一手を教えてもらう",
+  "helpExampleAuto": "  ac                   組札へ送れる札を自動で送る"
 }

--- a/internal/i18n/locales/ja/bakersgame.json
+++ b/internal/i18n/locales/ja/bakersgame.json
@@ -19,5 +19,8 @@
   "hintToFoundation": "ファンデーション",
   "hintToTableau": "タブロー列{{col}}",
   "hintToFreeCell": "フリーセル{{col}}",
-  "hintLine": "ヒント: {{from}} → {{to}}"
+  "hintLine": "ヒント: {{from}} → {{to}}",
+  "helpExampleMoveCell": "  m t 0 c 0            列 0 の一番上を空きセル 0 へ逃がす",
+  "helpExampleHint": "  h                    次の一手を教えてもらう",
+  "helpExampleAuto": "  ac                   組札へ送れる札を自動で送る"
 }

--- a/internal/i18n/locales/ja/basra.json
+++ b/internal/i18n/locales/ja/basra.json
@@ -16,5 +16,7 @@
   "hintReasonCapture": "価値の高い場札を捕獲する",
   "hintReasonTrail": "捕獲できないので低い札を捨てる",
   "result.scores": "ゲーム終了！ 得点: {{scores}}",
-  "captureHint": "{{hand}} → 場{{table}}"
+  "captureHint": "{{hand}} → 場{{table}}",
+  "helpExamplePlay": "  p 0                       手札の 0 番を場に置く (場札を取らない)",
+  "helpExampleNext": "  nr                        新しいゲームを始める"
 }

--- a/internal/i18n/locales/ja/beleagueredcastle.json
+++ b/internal/i18n/locales/ja/beleagueredcastle.json
@@ -11,5 +11,7 @@
   "hintToFoundation": "ファンデーション",
   "hintToTableau": "タブロー列{{col}}",
   "hintLine": "ヒント: {{from}} → {{to}}",
-  "undoToEscape": "脱出には {{count}} 手戻す必要があります（undo {{count}} または u を繰り返す）"
+  "undoToEscape": "脱出には {{count}} 手戻す必要があります（undo {{count}} または u を繰り返す）",
+  "helpExampleHint": "  h                    次の一手を教えてもらう",
+  "helpExampleAuto": "  ac                   組札へ送れる札を自動で送る"
 }

--- a/internal/i18n/locales/ja/bhabhi.json
+++ b/internal/i18n/locales/ja/bhabhi.json
@@ -23,5 +23,6 @@
   "suitSpade": "スペード",
   "suitClover": "クラブ",
   "suitHeart": "ハート",
-  "suitDiamond": "ダイヤ"
+  "suitDiamond": "ダイヤ",
+  "helpExamplePlay": "  p 0                  手札の 0 番のカードを出す"
 }

--- a/internal/i18n/locales/ja/briscola.json
+++ b/internal/i18n/locales/ja/briscola.json
@@ -21,5 +21,7 @@
   "hintReasonLeadValue": "得点札でリード",
   "hintReasonFollowCut": "トランプでカット",
   "hintReasonFollowWin": "このトリックを取る",
-  "hintReasonFollowDump": "低価値の札を捨てる"
+  "hintReasonFollowDump": "低価値の札を捨てる",
+  "helpExamplePlay": "  p 0                  手札の 0 番のカードを出す",
+  "helpExampleNext": "  n                    トリックの決着を見てから次へ"
 }

--- a/internal/i18n/locales/ja/caribbeanstud.json
+++ b/internal/i18n/locales/ja/caribbeanstud.json
@@ -27,5 +27,7 @@
   "hintFold": "フォールド",
   "hintPairOrBetter": "ワンペア以上ある",
   "hintAceKingHigh": "役は無いが A と K を持っている",
-  "hintWeakHand": "役が無く A-K にも届かない"
+  "hintWeakHand": "役が無く A-K にも届かない",
+  "helpExampleBet": "  b 10                 アンテ 10 で参加する",
+  "helpExamplePlay": "  p                    勝負する (アンテと同額を追加)"
 }

--- a/internal/i18n/locales/ja/cuarenta.json
+++ b/internal/i18n/locales/ja/cuarenta.json
@@ -19,5 +19,7 @@
   "scoreEntry": "  チーム{{team}}: {{score}}点",
   "promptCurrentTurn": "手番: {{name}}",
   "promptHelp": "p <hand> で捕獲または場に置く / n で次のラウンド",
-  "teamCaptured": "チーム{{team}} 捕獲: {{count}}枚（{{need}}枚以上で +{{bonus}}）"
+  "teamCaptured": "チーム{{team}} 捕獲: {{count}}枚（{{need}}枚以上で +{{bonus}}）",
+  "helpExamplePlay": "  p 0                      手札の 0 番を場に置く (場札を取らない)",
+  "helpExampleNext": "  n                        ラウンドの結果を見てから次へ"
 }

--- a/internal/i18n/locales/ja/cucumber.json
+++ b/internal/i18n/locales/ja/cucumber.json
@@ -21,5 +21,7 @@
   "hintCard": "[HINT: [{{idx}}]{{card}} ({{reason}})]",
   "hintReasonLead": "リードなので何を出してもよい",
   "hintReasonBeat": "更新できる中でいちばん低い札。高い札は終盤に残さない",
-  "hintReasonForced": "更新できないので、この札に決まっている"
+  "hintReasonForced": "更新できないので、この札に決まっている",
+  "helpExamplePlay": "  p 0                  手札の 0 番のカードを出す",
+  "helpExampleNext": "  n                    ラウンドの結果を見てから次へ"
 }

--- a/internal/i18n/locales/ja/eightoff.json
+++ b/internal/i18n/locales/ja/eightoff.json
@@ -20,5 +20,8 @@
   "hintToTableau": "タブロー列{{col}}",
   "hintToFreeCell": "フリーセル{{col}}",
   "hintLine": "ヒント: {{from}} → {{to}}",
-  "supermoveLine": "一度に移動可能: {{limit}}枚（空きセル{{cells}}・空き列{{cols}}）"
+  "supermoveLine": "一度に移動可能: {{limit}}枚（空きセル{{cells}}・空き列{{cols}}）",
+  "helpExampleMoveCell": "  m t 0 c 0            列 0 の一番上を空きセル 0 へ逃がす",
+  "helpExampleHint": "  h                    次の一手を教えてもらう",
+  "helpExampleAuto": "  ac                   組札へ送れる札を自動で送る"
 }

--- a/internal/i18n/locales/ja/fourcardpoker.json
+++ b/internal/i18n/locales/ja/fourcardpoker.json
@@ -24,5 +24,7 @@
   "antePayoutLine": "アンテ払戻し: {{payout}}",
   "playPayoutLine": "プレイ払戻し: {{payout}}",
   "anteBonusPayoutLine": "アンテボーナス: {{payout}}",
-  "acesUpPayoutLine": "エースアップ: {{payout}}"
+  "acesUpPayoutLine": "エースアップ: {{payout}}",
+  "helpExampleBet": "  b 10                 アンテ 10 で参加する",
+  "helpExamplePlay": "  p                    勝負する (アンテと同額を追加)"
 }

--- a/internal/i18n/locales/ja/freecell.json
+++ b/internal/i18n/locales/ja/freecell.json
@@ -21,5 +21,8 @@
   "hintToFreeCell": "フリーセル{{col}}",
   "hintLine": "ヒント: {{from}} → {{to}}",
   "supermoveLine": "一括移動: 最大{{limit}}枚 (空きセル{{cells}} / 空き列{{cols}})",
-  "supermoveToEmpty": " / 空き列へは{{limit}}枚"
+  "supermoveToEmpty": " / 空き列へは{{limit}}枚",
+  "helpExampleMoveCell": "  m t 0 c 0            列 0 の一番上を空きセル 0 へ逃がす",
+  "helpExampleHint": "  h                    次の一手を教えてもらう",
+  "helpExampleAuto": "  ac                   組札へ送れる札を自動で送る"
 }

--- a/internal/i18n/locales/ja/germanwhist.json
+++ b/internal/i18n/locales/ja/germanwhist.json
@@ -22,5 +22,6 @@
   "suitSpade": "スペード",
   "suitClover": "クラブ",
   "suitHeart": "ハート",
-  "suitDiamond": "ダイヤ"
+  "suitDiamond": "ダイヤ",
+  "helpExamplePlay": "  p 0                  手札の 0 番のカードを出す"
 }

--- a/internal/i18n/locales/ja/karnoffel.json
+++ b/internal/i18n/locales/ja/karnoffel.json
@@ -22,5 +22,7 @@
   "handEnd": "局終了",
   "handDrawn": "局終了（どちらも3トリックに届かず）",
   "result.humanWin": "ゲーム終了！ あなたのチームの勝ちです！",
-  "result.cpuWin": "ゲーム終了！ 相手チームの勝ちです。"
+  "result.cpuWin": "ゲーム終了！ 相手チームの勝ちです。",
+  "helpExamplePlay": "  p 0                       手札の 0 番のカードを出す",
+  "helpExampleNext": "  n                         トリックの決着を見てから次へ"
 }

--- a/internal/i18n/locales/ja/lingerlonger.json
+++ b/internal/i18n/locales/ja/lingerlonger.json
@@ -17,5 +17,6 @@
   "hintCard": "[HINT: [{{idx}}]{{card}} ({{reason}})]",
   "hintReasonWinTrick": "取れば山札から1枚補充できる",
   "hintReasonNoStock": "取れるが山札が空なので補充は無い",
-  "hintReasonDuck": "取れないので安い札から"
+  "hintReasonDuck": "取れないので安い札から",
+  "helpExamplePlay": "  p 0                  手札の 0 番のカードを出す"
 }

--- a/internal/i18n/locales/ja/mendikot.json
+++ b/internal/i18n/locales/ja/mendikot.json
@@ -30,5 +30,7 @@
   "suitSpade": "スペード",
   "suitClover": "クラブ",
   "suitHeart": "ハート",
-  "suitDiamond": "ダイヤ"
+  "suitDiamond": "ダイヤ",
+  "helpExamplePlay": "  p 0                  手札の 0 番のカードを出す",
+  "helpExampleNext": "  n                    ラウンドの結果を見てから次へ"
 }

--- a/internal/i18n/locales/ja/mississippistud.json
+++ b/internal/i18n/locales/ja/mississippistud.json
@@ -29,5 +29,7 @@
   "hintFold": "推奨: フォールド",
   "madeHandLine": "現在の役: {{hand}} ({{eligible}})",
   "madeHandEligible": "配当あり",
-  "madeHandNotEligible": "配当なし"
+  "madeHandNotEligible": "配当なし",
+  "helpExampleBet": "  b 10                 アンテ 10 で参加する",
+  "helpExamplePlay": "  p                    勝負する (アンテと同額を追加)"
 }

--- a/internal/i18n/locales/ja/nainjaune.json
+++ b/internal/i18n/locales/ja/nainjaune.json
@@ -26,5 +26,7 @@
   "hintReasonNotYourTurn": "あなたの手番ではありません",
   "hintReasonLead": "並びが止まっているので、低い札から始めます",
   "hintReasonFollow": "並びの続きになる札です",
-  "hintReasonBox": "この札は区画のチップを取れます"
+  "hintReasonBox": "この札は区画のチップを取れます",
+  "helpExamplePlay": "  p 0                      手札の 0 番のカードを出す",
+  "helpExampleNext": "  n                        トリックの決着を見てから次へ"
 }

--- a/internal/i18n/locales/ja/pasur.json
+++ b/internal/i18n/locales/ja/pasur.json
@@ -18,5 +18,6 @@
   "hintTrail": "[HINT: [{{idx}}]{{card}} を場に置く ({{reason}})]",
   "hintReasonSoor": "場を空にできる。この捕獲は得点が2倍",
   "hintReasonCapture": "点になる札を取れる",
-  "hintReasonTrail": "取れる組み合わせが無い。いちばん点にならない札を置く"
+  "hintReasonTrail": "取れる組み合わせが無い。いちばん点にならない札を置く",
+  "helpExamplePlay": "  p 0                  手札の 0 番のカードを出す"
 }

--- a/internal/i18n/locales/ja/penguin.json
+++ b/internal/i18n/locales/ja/penguin.json
@@ -28,5 +28,8 @@
   "hintToFreeCell": "フリーセル{{col}}",
   "hintLine": "ヒント: {{from}} → {{to}}",
   "supermoveLine": "一括移動: 最大{{limit}}枚 (空きセル{{cells}} / 空き列{{cols}})",
-  "supermoveToEmpty": " / 空き列へは{{limit}}枚"
+  "supermoveToEmpty": " / 空き列へは{{limit}}枚",
+  "helpExampleMoveCell": "  m t 0 c 0            列 0 の一番上を空きセル 0 へ逃がす",
+  "helpExampleHint": "  h                    次の一手を教えてもらう",
+  "helpExampleAuto": "  ac                   組札へ送れる札を自動で送る"
 }

--- a/internal/i18n/locales/ja/popejoan.json
+++ b/internal/i18n/locales/ja/popejoan.json
@@ -29,5 +29,7 @@
   "hintReasonDealEnd": "このディールは終わっています",
   "hintReasonNotYourTurn": "あなたの手番ではありません",
   "hintReasonLead": "並びが止まっているので、最も低い札から始めます",
-  "hintReasonFollow": "同じスートの次に高い札です"
+  "hintReasonFollow": "同じスートの次に高い札です",
+  "helpExamplePlay": "  p 0                      手札の 0 番のカードを出す",
+  "helpExampleNext": "  n                        トリックの決着を見てから次へ"
 }

--- a/internal/i18n/locales/ja/reversis.json
+++ b/internal/i18n/locales/ja/reversis.json
@@ -21,5 +21,7 @@
   "hintReasonAvoidMarked": "キノラか♦Aが乗っている。絶対に取らない",
   "hintReasonAvoidPoints": "失点札が乗っているので取らない",
   "hintReasonLeadSafe": "失点にならない低い札でリードする",
-  "hintReasonDumpHigh": "安全なうちに高い札を処分する"
+  "hintReasonDumpHigh": "安全なうちに高い札を処分する",
+  "helpExamplePlay": "  p 0                  手札の 0 番のカードを出す",
+  "helpExampleNext": "  n                    ラウンドの結果を見てから次へ"
 }

--- a/internal/i18n/locales/ja/scopa.json
+++ b/internal/i18n/locales/ja/scopa.json
@@ -27,5 +27,7 @@
   "category.cards": "カルテ(最多枚数)",
   "category.denari": "デナリ(ダイヤ最多)",
   "category.primiera": "プリミエラ(7最多)",
-  "category.settebello": "セッテベッロ(7♦)"
+  "category.settebello": "セッテベッロ(7♦)",
+  "helpExamplePlay": "  p 0                      手札の 0 番を場に置く (場札を取らない)",
+  "helpExampleNext": "  n                        ラウンドの結果を見てから次へ"
 }

--- a/internal/i18n/locales/ja/seahaventowers.json
+++ b/internal/i18n/locales/ja/seahaventowers.json
@@ -26,5 +26,8 @@
   "invalidFromZone": "無効な移動元です: {{val}}",
   "invalidToZone": "無効な移動先です: {{val}}",
   "moveUsage": "使い方: m t <col> [<idx>] t|f|c <toCol|cell>",
-  "supermoveLine": "一括移動可能: 最大{{limit}}枚（空きリザーブ{{reserved}}）"
+  "supermoveLine": "一括移動可能: 最大{{limit}}枚（空きリザーブ{{reserved}}）",
+  "helpExampleMoveCell": "  m t 0 c 0            列 0 の一番上を空きセル 0 へ逃がす",
+  "helpExampleHint": "  h                    次の一手を教えてもらう",
+  "helpExampleAuto": "  ac                   組札へ送れる札を自動で送る"
 }

--- a/internal/i18n/locales/ja/slobberhannes.json
+++ b/internal/i18n/locales/ja/slobberhannes.json
@@ -22,5 +22,7 @@
   "hintCard": "[HINT: [{{idx}}]{{card}} ({{reason}})]",
   "hintReasonAvoid": "罰点のトリックなので取らない",
   "hintReasonDump": "安全なうちに高い札を処分する",
-  "hintReasonLeadLow": "低い札でリードして様子を見る"
+  "hintReasonLeadLow": "低い札でリードして様子を見る",
+  "helpExamplePlay": "  p 0                  手札の 0 番のカードを出す",
+  "helpExampleNext": "  n                    ラウンドの結果を見てから次へ"
 }

--- a/internal/i18n/locales/ja/streetsandalleys.json
+++ b/internal/i18n/locales/ja/streetsandalleys.json
@@ -10,5 +10,7 @@
   "hintFrom": "タブロー列{{col}}[{{idx}}]",
   "hintToFoundation": "ファンデーション",
   "hintToTableau": "タブロー列{{col}}",
-  "hintLine": "ヒント: {{from}} → {{to}}"
+  "hintLine": "ヒント: {{from}} → {{to}}",
+  "helpExampleHint": "  h                    次の一手を教えてもらう",
+  "helpExampleAuto": "  ac                   組札へ送れる札を自動で送る"
 }

--- a/internal/i18n/locales/ja/tablanet.json
+++ b/internal/i18n/locales/ja/tablanet.json
@@ -16,5 +16,7 @@
   "hintReasonCapture": "価値の高い場札を捕獲する",
   "hintReasonTrail": "捕獲できないので低い札を捨てる",
   "result.scores": "ゲーム終了！ 得点: {{scores}}",
-  "captureHint": "{{hand}} → 場{{table}}"
+  "captureHint": "{{hand}} → 場{{table}}",
+  "helpExamplePlay": "  p 0                       手札の 0 番を場に置く (場札を取らない)",
+  "helpExampleNext": "  nr                        新しいゲームを始める"
 }

--- a/internal/i18n/locales/ja/threecard.json
+++ b/internal/i18n/locales/ja/threecard.json
@@ -25,5 +25,7 @@
   "push": "プッシュ！",
   "anteBonusPayoutLine": "アンテボーナス配当: {{payout}}",
   "pairPlusPayoutLine": "ペアプラス配当: {{payout}}",
-  "totalPayoutLine": "合計払戻し: {{payout}}"
+  "totalPayoutLine": "合計払戻し: {{payout}}",
+  "helpExampleBet": "  b 10                 アンテ 10 で参加する",
+  "helpExamplePlay": "  p                    勝負する (アンテと同額を追加)"
 }

--- a/internal/infrastructure/ui/GameManager.go
+++ b/internal/infrastructure/ui/GameManager.go
@@ -794,7 +794,11 @@ var gameRegistry = []GameRegistryEntry{
 		},
 		controller.NewThreeCardCuiController,
 		CuiHelpSpec{
-			TitleKey:          "threecard.helpTitle",
+			TitleKey: "threecard.helpTitle",
+			ExampleKeys: []string{
+				"threecard.helpExampleBet",
+				"threecard.helpExamplePlay",
+			},
 			CommandKeys:       []string{"threecard.helpBet", "threecard.helpPlay", "threecard.helpFold"},
 			ExtraCommandLines: []string{"  log                  action log"},
 		}),
@@ -1013,7 +1017,11 @@ var gameRegistry = []GameRegistryEntry{
 		},
 		controller.NewCaribbeanStudCuiController,
 		CuiHelpSpec{
-			TitleKey:          "caribbeanstud.helpTitle",
+			TitleKey: "caribbeanstud.helpTitle",
+			ExampleKeys: []string{
+				"caribbeanstud.helpExampleBet",
+				"caribbeanstud.helpExamplePlay",
+			},
 			CommandKeys:       []string{"caribbeanstud.helpBet", "caribbeanstud.helpPlay", "caribbeanstud.helpFold"},
 			ExtraCommandLines: []string{"  log                  action log"},
 		}),
@@ -1934,6 +1942,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewBakersDozenCuiController,
 		CuiHelpSpec{
 			TitleKey: "bakersdozen.helpTitle",
+			ExampleKeys: []string{
+				"bakersdozen.helpExampleHint",
+				"bakersdozen.helpExampleAuto",
+			},
 			CommandKeys: []string{
 				"bakersdozen.helpMoveTT",
 				"bakersdozen.helpMoveTF",
@@ -2081,6 +2093,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewMississippiStudCuiController,
 		CuiHelpSpec{
 			TitleKey: "mississippistud.helpTitle",
+			ExampleKeys: []string{
+				"mississippistud.helpExampleBet",
+				"mississippistud.helpExamplePlay",
+			},
 			CommandKeys: []string{
 				"mississippistud.helpBet",
 				"mississippistud.helpPlay",
@@ -2165,6 +2181,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewBeleagueredCastleCuiController,
 		CuiHelpSpec{
 			TitleKey: "beleagueredcastle.helpTitle",
+			ExampleKeys: []string{
+				"beleagueredcastle.helpExampleHint",
+				"beleagueredcastle.helpExampleAuto",
+			},
 			CommandKeys: []string{
 				"beleagueredcastle.helpMoveTT",
 				"beleagueredcastle.helpMoveTF",
@@ -2181,6 +2201,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewStreetsAndAlleysCuiController,
 		CuiHelpSpec{
 			TitleKey: "streetsandalleys.helpTitle",
+			ExampleKeys: []string{
+				"streetsandalleys.helpExampleHint",
+				"streetsandalleys.helpExampleAuto",
+			},
 			CommandKeys: []string{
 				"streetsandalleys.helpMoveTT",
 				"streetsandalleys.helpMoveTF",
@@ -2385,7 +2409,11 @@ var gameRegistry = []GameRegistryEntry{
 		},
 		controller.NewFourCardPokerCuiController,
 		CuiHelpSpec{
-			TitleKey:          "fourcardpoker.helpTitle",
+			TitleKey: "fourcardpoker.helpTitle",
+			ExampleKeys: []string{
+				"fourcardpoker.helpExampleBet",
+				"fourcardpoker.helpExamplePlay",
+			},
 			CommandKeys:       []string{"fourcardpoker.helpBet", "fourcardpoker.helpPlay", "fourcardpoker.helpFold"},
 			ExtraCommandLines: []string{"  log                  action log"},
 		}),
@@ -4613,6 +4641,9 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewGermanWhistCuiController,
 		CuiHelpSpec{
 			TitleKey: "germanwhist.helpTitle",
+			ExampleKeys: []string{
+				"germanwhist.helpExamplePlay",
+			},
 			CommandKeys: []string{
 				"germanwhist.helpPlay",
 				"germanwhist.helpGiveUp",
@@ -4626,6 +4657,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewSlobberhannesCuiController,
 		CuiHelpSpec{
 			TitleKey: "slobberhannes.helpTitle",
+			ExampleKeys: []string{
+				"slobberhannes.helpExamplePlay",
+				"slobberhannes.helpExampleNext",
+			},
 			CommandKeys: []string{
 				"slobberhannes.helpPlay",
 				"slobberhannes.helpNext",
@@ -4656,6 +4691,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewReversisCuiController,
 		CuiHelpSpec{
 			TitleKey: "reversis.helpTitle",
+			ExampleKeys: []string{
+				"reversis.helpExamplePlay",
+				"reversis.helpExampleNext",
+			},
 			CommandKeys: []string{
 				"reversis.helpPlay",
 				"reversis.helpNext",
@@ -4785,6 +4824,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewMendikotCuiController,
 		CuiHelpSpec{
 			TitleKey: "mendikot.helpTitle",
+			ExampleKeys: []string{
+				"mendikot.helpExamplePlay",
+				"mendikot.helpExampleNext",
+			},
 			CommandKeys: []string{
 				"mendikot.helpPlay",
 				"mendikot.helpNext",
@@ -4799,6 +4842,9 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewBhabhiCuiController,
 		CuiHelpSpec{
 			TitleKey: "bhabhi.helpTitle",
+			ExampleKeys: []string{
+				"bhabhi.helpExamplePlay",
+			},
 			CommandKeys: []string{
 				"bhabhi.helpPlay",
 				"bhabhi.helpGiveUp",
@@ -4891,6 +4937,9 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewPasurCuiController,
 		CuiHelpSpec{
 			TitleKey: "pasur.helpTitle",
+			ExampleKeys: []string{
+				"pasur.helpExamplePlay",
+			},
 			CommandKeys: []string{
 				"pasur.helpPlay",
 				"pasur.helpGiveUp",
@@ -4933,6 +4982,9 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewLingerLongerCuiController,
 		CuiHelpSpec{
 			TitleKey: "lingerlonger.helpTitle",
+			ExampleKeys: []string{
+				"lingerlonger.helpExamplePlay",
+			},
 			CommandKeys: []string{
 				"lingerlonger.helpPlay",
 				"lingerlonger.helpGiveUp",
@@ -4976,6 +5028,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewCucumberCuiController,
 		CuiHelpSpec{
 			TitleKey: "cucumber.helpTitle",
+			ExampleKeys: []string{
+				"cucumber.helpExamplePlay",
+				"cucumber.helpExampleNext",
+			},
 			CommandKeys: []string{
 				"cucumber.helpPlay",
 				"cucumber.helpNext",

--- a/internal/infrastructure/ui/GameManager.go
+++ b/internal/infrastructure/ui/GameManager.go
@@ -480,6 +480,11 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewFreeCellCuiController,
 		CuiHelpSpec{
 			TitleKey: "freecell.helpTitle",
+			ExampleKeys: []string{
+				"freecell.helpExampleMoveCell",
+				"freecell.helpExampleHint",
+				"freecell.helpExampleAuto",
+			},
 			CommandKeys: []string{
 				"freecell.helpMove",
 				"freecell.helpMoveTF",
@@ -502,6 +507,11 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewSeahavenTowersCuiController,
 		CuiHelpSpec{
 			TitleKey: "seahaventowers.helpTitle",
+			ExampleKeys: []string{
+				"seahaventowers.helpExampleMoveCell",
+				"seahaventowers.helpExampleHint",
+				"seahaventowers.helpExampleAuto",
+			},
 			CommandKeys: []string{
 				"seahaventowers.helpMove",
 				"seahaventowers.helpMoveTF",
@@ -2345,7 +2355,11 @@ var gameRegistry = []GameRegistryEntry{
 		},
 		controller.NewBriscolaCuiController,
 		CuiHelpSpec{
-			TitleKey:          "briscola.helpTitle",
+			TitleKey: "briscola.helpTitle",
+			ExampleKeys: []string{
+				"briscola.helpExamplePlay",
+				"briscola.helpExampleNext",
+			},
 			CommandKeys:       []string{"briscola.helpPlay", "briscola.helpNext"},
 			ExtraCommandLines: []string{"  l                    action log"},
 		}),
@@ -2400,6 +2414,11 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewEightOffCuiController,
 		CuiHelpSpec{
 			TitleKey: "eightoff.helpTitle",
+			ExampleKeys: []string{
+				"eightoff.helpExampleMoveCell",
+				"eightoff.helpExampleHint",
+				"eightoff.helpExampleAuto",
+			},
 			CommandKeys: []string{
 				"eightoff.helpMove",
 				"eightoff.helpMoveTF",
@@ -2441,6 +2460,11 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewPenguinCuiController,
 		CuiHelpSpec{
 			TitleKey: "penguin.helpTitle",
+			ExampleKeys: []string{
+				"penguin.helpExampleMoveCell",
+				"penguin.helpExampleHint",
+				"penguin.helpExampleAuto",
+			},
 			CommandKeys: []string{
 				"penguin.helpMove",
 				"penguin.helpMoveTF",
@@ -2501,7 +2525,11 @@ var gameRegistry = []GameRegistryEntry{
 		},
 		controller.NewScopaCuiController,
 		CuiHelpSpec{
-			TitleKey:    "scopa.helpTitle",
+			TitleKey: "scopa.helpTitle",
+			ExampleKeys: []string{
+				"scopa.helpExamplePlay",
+				"scopa.helpExampleNext",
+			},
 			CommandKeys: []string{"scopa.helpPlay", "scopa.helpNext"},
 			SettingKeys: []string{"scopa.helpSetDifficulty"},
 		}),
@@ -2774,6 +2802,11 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewFreeCellCuiController,
 		CuiHelpSpec{
 			TitleKey: "bakersgame.helpTitle",
+			ExampleKeys: []string{
+				"bakersgame.helpExampleMoveCell",
+				"bakersgame.helpExampleHint",
+				"bakersgame.helpExampleAuto",
+			},
 			CommandKeys: []string{
 				"bakersgame.helpMove",
 				"bakersgame.helpMoveTF",
@@ -3487,6 +3520,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewCuarentaCuiController,
 		CuiHelpSpec{
 			TitleKey: "cuarenta.helpTitle",
+			ExampleKeys: []string{
+				"cuarenta.helpExamplePlay",
+				"cuarenta.helpExampleNext",
+			},
 			CommandKeys: []string{
 				"cuarenta.helpPlay",
 				"cuarenta.helpNext",
@@ -3805,7 +3842,11 @@ var gameRegistry = []GameRegistryEntry{
 		},
 		controller.NewBasraCuiController,
 		CuiHelpSpec{
-			TitleKey:          "basra.helpTitle",
+			TitleKey: "basra.helpTitle",
+			ExampleKeys: []string{
+				"basra.helpExamplePlay",
+				"basra.helpExampleNext",
+			},
 			CommandKeys:       []string{"basra.helpPlay", "basra.helpNext"},
 			ExtraCommandLines: []string{"  l                    action log"},
 			SettingKeys:       []string{"basra.helpSetDifficulty"},
@@ -3816,7 +3857,11 @@ var gameRegistry = []GameRegistryEntry{
 		},
 		controller.NewTablanetCuiController,
 		CuiHelpSpec{
-			TitleKey:          "tablanet.helpTitle",
+			TitleKey: "tablanet.helpTitle",
+			ExampleKeys: []string{
+				"tablanet.helpExamplePlay",
+				"tablanet.helpExampleNext",
+			},
 			CommandKeys:       []string{"tablanet.helpPlay", "tablanet.helpNext"},
 			ExtraCommandLines: []string{"  l                    action log"},
 			SettingKeys:       []string{"tablanet.helpSetDifficulty"},
@@ -4199,6 +4244,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewPopeJoanCuiController,
 		CuiHelpSpec{
 			TitleKey: "popejoan.helpTitle",
+			ExampleKeys: []string{
+				"popejoan.helpExamplePlay",
+				"popejoan.helpExampleNext",
+			},
 			CommandKeys: []string{
 				"popejoan.helpPlay",
 				"popejoan.helpNext",
@@ -4212,6 +4261,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewNainJauneCuiController,
 		CuiHelpSpec{
 			TitleKey: "nainjaune.helpTitle",
+			ExampleKeys: []string{
+				"nainjaune.helpExamplePlay",
+				"nainjaune.helpExampleNext",
+			},
 			CommandKeys: []string{
 				"nainjaune.helpPlay",
 				"nainjaune.helpNext",
@@ -4345,6 +4398,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewKarnoffelCuiController,
 		CuiHelpSpec{
 			TitleKey: "karnoffel.helpTitle",
+			ExampleKeys: []string{
+				"karnoffel.helpExamplePlay",
+				"karnoffel.helpExampleNext",
+			},
 			CommandKeys: []string{
 				"karnoffel.helpPlay",
 				"karnoffel.helpNext",


### PR DESCRIPTION
## 変更

例文つきのゲームが **43 → 58** になりました（#5393 / #5394 の続き）。残り 259。

| ファミリ | ゲーム | 例文 |
|---|---|---|
| ステークポーカー系 | threecard / caribbeanstud / mississippistud / fourcardpoker | `b 10` → `p` |
| play のみ | germanwhist / bhabhi / pasur / lingerlonger | `p 0` |
| play + next | slobberhannes / reversis / mendikot / cucumber | `p 0` → `n` |
| bakersdozen 系 | bakersdozen / beleagueredcastle / streetsandalleys | `h` → `ac` |

## bakersdozen 系だけ移動の例を出していません

このファミリの移動は `m <col> f`（タブロー → 組札）ですが、これが通るには**その列の一番上がエースである必要**があり、配りに依存します。**たまにしか合法でない例は、例が無いより悪い**ので、どの局面からでも通る `h`（ヒント）と `ac`（オートコンプリート）にしました。

## 配り依存の確認

候補は書く前に**ゲームごと 8 配り**で拒否ゼロを確認し、追加後に例文ガードを 25 回繰り返して緑を確認しています。

```
go test -tags test ./internal/infrastructure/ui/ -run TestCuiHelpExamples -count=25  →  ok (165.8s)
```

## 検証

- `go test -tags test ./internal/infrastructure/ui/` — 緑（例文実行・動詞・生キー・表→パーサの各ガード）
- `go build ./...` — 通過
- `golangci-lint run ./internal/...` — 0 issues

Refs #5370
