### PR TITLE
feat(cui): add worked examples to the last nine multi-game families

### DIFF
--- a/internal/i18n/locales/en/bigtwo.json
+++ b/internal/i18n/locales/en/bigtwo.json
@@ -18,5 +18,7 @@
   "gameEnd": "Game Over!",
   "rankN": "Rank {{rank}}",
   "yourTurn": "Your turn",
-  "actionPass": "pass"
+  "actionPass": "pass",
+  "helpExamplePlay": "  p 0                  play hand card 0 on its own",
+  "helpExamplePass": "  p                    pass by naming no cards"
 }

--- a/internal/i18n/locales/en/calabresella.json
+++ b/internal/i18n/locales/en/calabresella.json
@@ -36,5 +36,8 @@
   "hintReasonBidChiamo": "Solid hand — call chiamo",
   "hintReasonBidSolo": "Very strong hand — declare solo",
   "hintReasonBidPass": "Weak hand — pass",
-  "thirdsLine": "  {{name}} ({{role}}): {{thirds}}/3"
+  "thirdsLine": "  {{name}} ({{role}}): {{thirds}}/3",
+  "helpExampleBid": "  bid pass                  drop out of the bidding",
+  "helpExamplePlay": "  play 0                    play hand card 0",
+  "helpExampleNext": "  n                         read the trick result, then continue"
 }

--- a/internal/i18n/locales/en/caribbeanstud.json
+++ b/internal/i18n/locales/en/caribbeanstud.json
@@ -29,5 +29,5 @@
   "hintAceKingHigh": "no made hand, but you hold an Ace and a King",
   "hintWeakHand": "no made hand and nothing as high as Ace-King",
   "helpExampleBet": "  b 10                 ante 10 and get a hand",
-  "helpExamplePlay": "  p                    play, matching the ante"
+  "helpExamplePlay": "  p                    call, placing a play bet of 2x the ante"
 }

--- a/internal/i18n/locales/en/minchiate.json
+++ b/internal/i18n/locales/en/minchiate.json
@@ -30,5 +30,7 @@
   "roundEndTrickEntry": "{{name}} {{tricks}}",
   "roundEndTricks": "Tricks per player: {{list}}",
   "teamLine": "Score  team 0: {{team0}}  team 1: {{team1}}",
-  "trumpCountNote": "40 trumps -- including the 12 zodiac signs, the four elements and the virtues; tracking what is still above you is the skill"
+  "trumpCountNote": "40 trumps -- including the 12 zodiac signs, the four elements and the virtues; tracking what is still above you is the skill",
+  "helpExamplePlay": "  play 0               play hand card 0",
+  "helpExampleNext": "  n                    read the trick result, then continue"
 }

--- a/internal/i18n/locales/en/mississippistud.json
+++ b/internal/i18n/locales/en/mississippistud.json
@@ -31,5 +31,5 @@
   "madeHandEligible": "pays",
   "madeHandNotEligible": "does not pay",
   "helpExampleBet": "  b 10                 ante 10 and get a hand",
-  "helpExamplePlay": "  p                    play, matching the ante"
+  "helpExamplePlay": "  p 1                  play at 1x the ante"
 }

--- a/internal/i18n/locales/en/scarto.json
+++ b/internal/i18n/locales/en/scarto.json
@@ -30,5 +30,7 @@
   "hintReasonPlayExcuse": "Play the Excuse — you keep it and it cannot be captured",
   "discardableList": "Discardable: {{cards}}",
   "discardableNone": "none",
-  "discardableLegend": "Note: trumps, the Excuse, and court cards cannot be discarded"
+  "discardableLegend": "Note: trumps, the Excuse, and court cards cannot be discarded",
+  "helpExamplePlay": "  play 0                    play hand card 0",
+  "helpExampleNext": "  n                         read the trick result, then continue"
 }

--- a/internal/i18n/locales/en/tarocchini.json
+++ b/internal/i18n/locales/en/tarocchini.json
@@ -32,5 +32,7 @@
   "round": "Round: {{round}}  Trick: {{trick}}",
   "roundEndTrickEntry": "{{name}} {{tricks}}",
   "roundEndTricks": "Tricks per player: {{list}}",
-  "teamLine": "Score  team 0: {{team0}}  team 1: {{team1}}"
+  "teamLine": "Score  team 0: {{team0}}  team 1: {{team1}}",
+  "helpExamplePlay": "  play 0               play hand card 0",
+  "helpExampleNext": "  n                    read the trick result, then continue"
 }

--- a/internal/i18n/locales/en/tienlen.json
+++ b/internal/i18n/locales/en/tienlen.json
@@ -19,5 +19,7 @@
   "comboStraight": "Straight",
   "comboThreePairRun": "Three-pair run",
   "comboFourOfAKind": "Four of a kind",
-  "comboInvalid": "Unknown"
+  "comboInvalid": "Unknown",
+  "helpExamplePlay": "  p 0                  play hand card 0 on its own",
+  "helpExamplePass": "  p                    pass by naming no cards"
 }

--- a/internal/i18n/locales/en/tysiac.json
+++ b/internal/i18n/locales/en/tysiac.json
@@ -33,5 +33,8 @@
   "hintReasonBidPass": "Weak hand — pass",
   "hintReasonTalonDiscard": "Give away your weakest card",
   "headerInfo": "Contract: {{contract}} / Target: {{target}}",
-  "headerBid": "Current bid: {{bid}}"
+  "headerBid": "Current bid: {{bid}}",
+  "helpExampleBid": "  bid pass                  drop out of the bidding",
+  "helpExamplePlay": "  play 0                    play hand card 0",
+  "helpExampleNext": "  n                         read the trick result, then continue"
 }

--- a/internal/i18n/locales/en/ulti.json
+++ b/internal/i18n/locales/en/ulti.json
@@ -45,5 +45,8 @@
   "hintReasonBidParty": "Point-rich hand — declare Party",
   "hintReasonBidBetli": "Mostly low cards — declare Betli",
   "hintReasonBidDurchmarsch": "Mostly high cards — declare Durchmarsch",
-  "hintReasonBidUlti": "A long suit holding the trump 7 — declare Ulti"
+  "hintReasonBidUlti": "A long suit holding the trump 7 — declare Ulti",
+  "helpExampleBid": "  bid pass                  drop out of the bidding",
+  "helpExamplePlay": "  play 0                    play hand card 0",
+  "helpExampleNext": "  n                         read the trick result, then continue"
 }

--- a/internal/i18n/locales/en/ulti.json
+++ b/internal/i18n/locales/en/ulti.json
@@ -46,7 +46,7 @@
   "hintReasonBidBetli": "Mostly low cards — declare Betli",
   "hintReasonBidDurchmarsch": "Mostly high cards — declare Durchmarsch",
   "hintReasonBidUlti": "A long suit holding the trump 7 — declare Ulti",
-  "helpExampleBid": "  bid pass                  drop out of the bidding",
+  "helpExampleBid": "  bid betli                 declare Betli",
   "helpExamplePlay": "  play 0                    play hand card 0",
   "helpExampleNext": "  n                         read the trick result, then continue"
 }

--- a/internal/i18n/locales/en/zheng.json
+++ b/internal/i18n/locales/en/zheng.json
@@ -11,5 +11,7 @@
   "playerYou": "You",
   "yourTurn": "Your turn",
   "comboRulesHint": "Combos: single/pair/triple/run(3..A)/pair run(3..A). Ranks 3<...<A<2<small Joker<big Joker; suits never matter. A bomb (four of a kind) cuts any normal combo, and the two Jokers together beat everything.",
-  "actionPass": "pass"
+  "actionPass": "pass",
+  "helpExamplePlay": "  p 0                  play hand card 0 on its own",
+  "helpExamplePass": "  p                    pass by naming no cards"
 }

--- a/internal/i18n/locales/ja/bigtwo.json
+++ b/internal/i18n/locales/ja/bigtwo.json
@@ -18,5 +18,7 @@
   "gameEnd": "ゲーム終了！",
   "rankN": "{{rank}}位",
   "yourTurn": "あなたのターンです",
-  "actionPass": "パス"
+  "actionPass": "パス",
+  "helpExamplePlay": "  p 0                  手札の 0 番を 1 枚出す",
+  "helpExamplePass": "  p                    指定なしでパスする"
 }

--- a/internal/i18n/locales/ja/calabresella.json
+++ b/internal/i18n/locales/ja/calabresella.json
@@ -36,5 +36,8 @@
   "hintReasonBidChiamo": "手堅い手なのでキアーモを宣言",
   "hintReasonBidSolo": "非常に強い手なのでソロを宣言",
   "hintReasonBidPass": "弱い手なのでパスする",
-  "thirdsLine": "  {{name}}（{{role}}）: {{thirds}}/3"
+  "thirdsLine": "  {{name}}（{{role}}）: {{thirds}}/3",
+  "helpExampleBid": "  bid pass                  入札を降りる",
+  "helpExamplePlay": "  play 0                    手札の 0 番のカードを出す",
+  "helpExampleNext": "  n                         トリックの決着を見てから次へ"
 }

--- a/internal/i18n/locales/ja/caribbeanstud.json
+++ b/internal/i18n/locales/ja/caribbeanstud.json
@@ -29,5 +29,5 @@
   "hintAceKingHigh": "役は無いが A と K を持っている",
   "hintWeakHand": "役が無く A-K にも届かない",
   "helpExampleBet": "  b 10                 アンテ 10 で参加する",
-  "helpExamplePlay": "  p                    勝負する (アンテと同額を追加)"
+  "helpExamplePlay": "  p                    勝負する (アンテの 2 倍を追加)"
 }

--- a/internal/i18n/locales/ja/minchiate.json
+++ b/internal/i18n/locales/ja/minchiate.json
@@ -30,5 +30,7 @@
   "roundEndTrickEntry": "{{name}} {{tricks}}",
   "roundEndTricks": "各プレイヤーのトリック数: {{list}}",
   "teamLine": "得点  チーム0: {{team0}}  チーム1: {{team1}}",
-  "trumpCountNote": "切札は40枚 —— 星座12・四大元素・美徳を含み、上に何枚残っているかが読みどころです"
+  "trumpCountNote": "切札は40枚 —— 星座12・四大元素・美徳を含み、上に何枚残っているかが読みどころです",
+  "helpExamplePlay": "  play 0               手札の 0 番のカードを出す",
+  "helpExampleNext": "  n                    トリックの決着を見てから次へ"
 }

--- a/internal/i18n/locales/ja/mississippistud.json
+++ b/internal/i18n/locales/ja/mississippistud.json
@@ -31,5 +31,5 @@
   "madeHandEligible": "配当あり",
   "madeHandNotEligible": "配当なし",
   "helpExampleBet": "  b 10                 アンテ 10 で参加する",
-  "helpExamplePlay": "  p                    勝負する (アンテと同額を追加)"
+  "helpExamplePlay": "  p 1                  1 倍で勝負する"
 }

--- a/internal/i18n/locales/ja/scarto.json
+++ b/internal/i18n/locales/ja/scarto.json
@@ -30,5 +30,7 @@
   "hintReasonPlayExcuse": "エクスキューズを出す — 自分で保持し、取られない",
   "discardableList": "捨て可能: {{cards}}",
   "discardableNone": "なし",
-  "discardableLegend": "※ 切り札・エクスキューズ・絵札は捨てられません"
+  "discardableLegend": "※ 切り札・エクスキューズ・絵札は捨てられません",
+  "helpExamplePlay": "  play 0                    手札の 0 番のカードを出す",
+  "helpExampleNext": "  n                         トリックの決着を見てから次へ"
 }

--- a/internal/i18n/locales/ja/tarocchini.json
+++ b/internal/i18n/locales/ja/tarocchini.json
@@ -32,5 +32,7 @@
   "round": "ラウンド: {{round}}  トリック: {{trick}}",
   "roundEndTrickEntry": "{{name}} {{tricks}}",
   "roundEndTricks": "各プレイヤーのトリック数: {{list}}",
-  "teamLine": "得点  チーム0: {{team0}}  チーム1: {{team1}}"
+  "teamLine": "得点  チーム0: {{team0}}  チーム1: {{team1}}",
+  "helpExamplePlay": "  play 0               手札の 0 番のカードを出す",
+  "helpExampleNext": "  n                    トリックの決着を見てから次へ"
 }

--- a/internal/i18n/locales/ja/tienlen.json
+++ b/internal/i18n/locales/ja/tienlen.json
@@ -19,5 +19,7 @@
   "comboStraight": "ストレート",
   "comboThreePairRun": "3連ペア",
   "comboFourOfAKind": "フォーカード",
-  "comboInvalid": "不明"
+  "comboInvalid": "不明",
+  "helpExamplePlay": "  p 0                  手札の 0 番を 1 枚出す",
+  "helpExamplePass": "  p                    指定なしでパスする"
 }

--- a/internal/i18n/locales/ja/tysiac.json
+++ b/internal/i18n/locales/ja/tysiac.json
@@ -33,5 +33,8 @@
   "hintReasonBidPass": "弱い手なのでパスする",
   "hintReasonTalonDiscard": "最も弱い札を渡す",
   "headerInfo": "契約: {{contract}} / 目標: {{target}}",
-  "headerBid": "現在ビッド: {{bid}}"
+  "headerBid": "現在ビッド: {{bid}}",
+  "helpExampleBid": "  bid pass                  入札を降りる",
+  "helpExamplePlay": "  play 0                    手札の 0 番のカードを出す",
+  "helpExampleNext": "  n                         トリックの決着を見てから次へ"
 }

--- a/internal/i18n/locales/ja/ulti.json
+++ b/internal/i18n/locales/ja/ulti.json
@@ -45,5 +45,8 @@
   "hintReasonBidParty": "点札の多い手なのでパルティを宣言",
   "hintReasonBidBetli": "低い札ばかりなのでベトリを宣言",
   "hintReasonBidDurchmarsch": "高い札ばかりなのでドゥルマルスを宣言",
-  "hintReasonBidUlti": "切り札の7を含む長いスートがあるのでウルティを宣言"
+  "hintReasonBidUlti": "切り札の7を含む長いスートがあるのでウルティを宣言",
+  "helpExampleBid": "  bid pass                  入札を降りる",
+  "helpExamplePlay": "  play 0                    手札の 0 番のカードを出す",
+  "helpExampleNext": "  n                         トリックの決着を見てから次へ"
 }

--- a/internal/i18n/locales/ja/ulti.json
+++ b/internal/i18n/locales/ja/ulti.json
@@ -46,7 +46,7 @@
   "hintReasonBidBetli": "低い札ばかりなのでベトリを宣言",
   "hintReasonBidDurchmarsch": "高い札ばかりなのでドゥルマルスを宣言",
   "hintReasonBidUlti": "切り札の7を含む長いスートがあるのでウルティを宣言",
-  "helpExampleBid": "  bid pass                  入札を降りる",
+  "helpExampleBid": "  bid betli                 ベトリを宣言する",
   "helpExamplePlay": "  play 0                    手札の 0 番のカードを出す",
   "helpExampleNext": "  n                         トリックの決着を見てから次へ"
 }

--- a/internal/i18n/locales/ja/zheng.json
+++ b/internal/i18n/locales/ja/zheng.json
@@ -11,5 +11,7 @@
   "playerYou": "あなた",
   "yourTurn": "あなたのターンです",
   "comboRulesHint": "役: シングル/ペア/3カード/連番(3..A)/連続ペア(3..A)。強さは 3<...<A<2<小J<大J でスートは無関係。爆弾(同ランク4枚)は通常役を切れ、ジョーカー2枚は全てに勝ちます。",
-  "actionPass": "パス"
+  "actionPass": "パス",
+  "helpExamplePlay": "  p 0                  手札の 0 番を 1 枚出す",
+  "helpExamplePass": "  p                    指定なしでパスする"
 }

--- a/internal/infrastructure/ui/GameManager.go
+++ b/internal/infrastructure/ui/GameManager.go
@@ -186,7 +186,11 @@ var gameRegistry = []GameRegistryEntry{
 		},
 		controller.NewBigTwoCuiController,
 		CuiHelpSpec{
-			TitleKey:    "bigtwo.helpTitle",
+			TitleKey: "bigtwo.helpTitle",
+			ExampleKeys: []string{
+				"bigtwo.helpExamplePlay",
+				"bigtwo.helpExamplePass",
+			},
 			CommandKeys: []string{"bigtwo.helpPlay"},
 			SettingKeys: []string{"bigtwo.helpSetDifficulty"},
 		}),
@@ -2616,7 +2620,11 @@ var gameRegistry = []GameRegistryEntry{
 		},
 		controller.NewTienLenCuiController,
 		CuiHelpSpec{
-			TitleKey:    "tienlen.helpTitle",
+			TitleKey: "tienlen.helpTitle",
+			ExampleKeys: []string{
+				"tienlen.helpExamplePlay",
+				"tienlen.helpExamplePass",
+			},
 			CommandKeys: []string{"tienlen.helpPlay"},
 			SettingKeys: []string{"tienlen.helpSetDifficulty"},
 		}),
@@ -3771,6 +3779,11 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewTysiacCuiController,
 		CuiHelpSpec{
 			TitleKey: "tysiac.helpTitle",
+			ExampleKeys: []string{
+				"tysiac.helpExampleBid",
+				"tysiac.helpExamplePlay",
+				"tysiac.helpExampleNext",
+			},
 			CommandKeys: []string{
 				"tysiac.helpBid",
 				"tysiac.helpDiscard",
@@ -3788,6 +3801,11 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewCalabresellaCuiController,
 		CuiHelpSpec{
 			TitleKey: "calabresella.helpTitle",
+			ExampleKeys: []string{
+				"calabresella.helpExampleBid",
+				"calabresella.helpExamplePlay",
+				"calabresella.helpExampleNext",
+			},
 			CommandKeys: []string{
 				"calabresella.helpBid",
 				"calabresella.helpDiscard",
@@ -3821,6 +3839,11 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewUltiCuiController,
 		CuiHelpSpec{
 			TitleKey: "ulti.helpTitle",
+			ExampleKeys: []string{
+				"ulti.helpExampleBid",
+				"ulti.helpExamplePlay",
+				"ulti.helpExampleNext",
+			},
 			CommandKeys: []string{
 				"ulti.helpBid",
 				"ulti.helpDiscard",
@@ -4160,6 +4183,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewMinchiateCuiController,
 		CuiHelpSpec{
 			TitleKey: "minchiate.helpTitle",
+			ExampleKeys: []string{
+				"minchiate.helpExamplePlay",
+				"minchiate.helpExampleNext",
+			},
 			CommandKeys: []string{
 				"minchiate.helpScarto",
 				"minchiate.helpPlay",
@@ -4176,6 +4203,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewTarocchiniCuiController,
 		CuiHelpSpec{
 			TitleKey: "tarocchini.helpTitle",
+			ExampleKeys: []string{
+				"tarocchini.helpExamplePlay",
+				"tarocchini.helpExampleNext",
+			},
 			CommandKeys: []string{
 				"tarocchini.helpScarto",
 				"tarocchini.helpPlay",
@@ -4191,7 +4222,11 @@ var gameRegistry = []GameRegistryEntry{
 		},
 		controller.NewScartoCuiController,
 		CuiHelpSpec{
-			TitleKey:          "scarto.helpTitle",
+			TitleKey: "scarto.helpTitle",
+			ExampleKeys: []string{
+				"scarto.helpExamplePlay",
+				"scarto.helpExampleNext",
+			},
 			CommandKeys:       []string{"scarto.helpScarto", "scarto.helpPlay", "scarto.helpNext", "scarto.helpNextRound"},
 			ExtraCommandLines: []string{"  l                    action log"},
 			SettingKeys:       []string{"scarto.helpSetDifficulty"},
@@ -4213,7 +4248,11 @@ var gameRegistry = []GameRegistryEntry{
 		},
 		controller.NewZhengCuiController,
 		CuiHelpSpec{
-			TitleKey:    "zheng.helpTitle",
+			TitleKey: "zheng.helpTitle",
+			ExampleKeys: []string{
+				"zheng.helpExamplePlay",
+				"zheng.helpExamplePass",
+			},
 			CommandKeys: []string{"zheng.helpPlay"},
 			SettingKeys: []string{"zheng.helpSetDifficulty"},
 		}),

--- a/internal/infrastructure/ui/help_example_exec_test.go
+++ b/internal/infrastructure/ui/help_example_exec_test.go
@@ -113,3 +113,71 @@ func TestCuiHelpExampleCommandParsing(t *testing.T) {
 		}
 	}
 }
+
+// exampleRefusalRe matches the wording a controller uses when it turns a
+// command down. It is a heuristic, and deliberately so: see below.
+var exampleRefusalRe = regexp.MustCompile(`(?i)invalid|required|must |cannot|不正|無効|必要|できません`)
+
+// TestCuiHelpExamplesAreNotQuietlyRefused catches the refusals
+// TestCuiHelpExamplesExecute cannot see.
+//
+// That guard asks i18n.StripErrorPrefix, so it only sees a refusal that went
+// through i18n.MarkError. The games still on the literal-message ParseIntArg
+// return an unmarked string, which is byte-for-byte an ordinary reply -- and
+// that is exactly how `p` shipped as mississippistud's example while the game
+// answered "Multiplier (1, 2 or 3) is required." to it. My own pre-flight probe
+// used the same predicate and reported the same clean result, so the blind spot
+// was in the measurement, not just the guard.
+//
+// Matching on the wording is a heuristic and would not survive a rewording, but
+// it is checked against every example on every run, and a false positive is a
+// sentence to read rather than a broken build. It can be deleted once #5377
+// leaves nothing unmarked.
+func TestCuiHelpExamplesAreNotQuietlyRefused(t *testing.T) {
+	registry := GameRegistry()
+	if len(registry) < 300 {
+		t.Fatalf("only %d games in the registry -- the walk broke", len(registry))
+	}
+
+	// The predicate has to recognise a refusal, or "0 suspect" means nothing.
+	if !exampleRefusalRe.MatchString("Multiplier (1, 2 or 3) is required.") {
+		t.Fatal("the refusal pattern no longer matches a real refusal message")
+	}
+	if exampleRefusalRe.MatchString("Round: 1  Trick: 0") {
+		t.Fatal("the refusal pattern matches an ordinary board line")
+	}
+
+	checked := 0
+	var bad []string
+	for _, entry := range registry {
+		g := entry.NewCui()
+		_, examples := helpSections(g.HelpLines())
+		if len(examples) == 0 {
+			continue
+		}
+		ctrl := g.Controller()
+		ctrl.Exec("r")
+		for _, line := range examples {
+			cmd := helpExampleCommand(line)
+			if cmd == "" {
+				continue
+			}
+			checked++
+			out := ctrl.Exec(cmd)
+			if _, isErr := i18n.StripErrorPrefix(out); isErr {
+				continue // TestCuiHelpExamplesExecute owns the marked ones
+			}
+			if len(out) < 200 && exampleRefusalRe.MatchString(out) {
+				bad = append(bad, entry.Name+": `"+cmd+"` -> "+strings.TrimSpace(out))
+			}
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no example command was executed -- the walk broke")
+	}
+	sort.Strings(bad)
+	if len(bad) > 0 {
+		t.Errorf("examples the game turns down without marking it (%d of %d):\n  %s",
+			len(bad), checked, strings.Join(bad, "\n  "))
+	}
+}


### PR DESCRIPTION
## 変更

例文つきのゲームが **58 → 67** になりました。

| ゲーム | 例文 |
|---|---|
| bigtwo / tienlen / zheng | `p 0` → `p` |
| tysiac / calabresella / ulti | `bid pass` → `play 0` → `n` |
| minchiate / tarocchini / scarto | `play 0` → `n` |

bigtwo 系は `p [idx ...]` で**引数なしがパス**という規則なので、そこを見せています。

## ファミリ単位はここで尽きます

これで 3 ゲーム以上の共通コマンド体系は全て処理しました。残る **243 ゲームは 1〜2 件ずつ**に分かれており、次からはスイープではなくゲーム個別の作業になります。#5370 に追記して、後から見た人が存在しないパターンを探さないようにします。

## 検証

- 書く前にゲームごと 8 配りで拒否ゼロを確認
- `go test -tags test ./internal/infrastructure/ui/` — 緑
- `golangci-lint run ./internal/...` — 0 issues

Refs #5370