### PR TITLE
fix(cui): document old maid's draw index, and stop guessing it

### DIFF
--- a/internal/adapter/controller/OldMaidCuiController.go
+++ b/internal/adapter/controller/OldMaidCuiController.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"strconv"
 	"strings"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
@@ -34,7 +35,19 @@ func (c *OldMaidCuiController) Exec(command string) string {
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "d", "draw":
-				return c.omi.Draw(cuiutil.ParseOptionalInt(args, 0, -1)), true
+				// No argument draws at random; a typed one picks which of the next
+				// player's cards to take, so it must not be silently read as -1
+				// (issue #5390) -- that drew a card the player did not choose in
+				// 17 of 30 deals.
+				idx := -1
+				if len(args) > 0 {
+					v, err := strconv.Atoi(args[0])
+					if err != nil {
+						return invalidArg("invalidCardIndex", "val", args[0]), true
+					}
+					idx = v
+				}
+				return c.omi.Draw(idx), true
 			case "s", "shuffle":
 				return c.omi.Shuffle(), true
 			case "ro", "reorder":

--- a/internal/adapter/controller/OldMaidCuiController_test.go
+++ b/internal/adapter/controller/OldMaidCuiController_test.go
@@ -50,6 +50,17 @@ func TestOldMaidCuiController_Method(t *testing.T) {
 	t.Run("success Exec draw 2", func(t *testing.T) {
 		assert.Equal(t, mockOutput, tomc.Exec("draw 2"))
 	})
+	// **打ち間違いを -1 (ランダム) として実行しない。** 30 配り中 17 配りで、
+	// プレイヤーが選んでいない札を引いていた (issue #5390)。
+	t.Run("draw refuses an unparseable index", func(t *testing.T) {
+		refuseMock := new(usecase.MockOldMaidInteractor)
+		refuseMock.On("Draw", mock.Anything).Return(mockOutput)
+		c := controller.NewOldMaidCuiController(refuseMock)
+
+		assert.Contains(t, c.Exec("d zz"), msgInvalidCardIndexPrefix())
+
+		refuseMock.AssertNotCalled(t, "Draw", mock.Anything)
+	})
 	t.Run("success Exec s (shuffle)", func(t *testing.T) {
 		assert.Equal(t, mockOutput, tomc.Exec("s"))
 		omiMock.AssertCalled(t, "Shuffle")

--- a/internal/i18n/locales/en/oldmaid.json
+++ b/internal/i18n/locales/en/oldmaid.json
@@ -1,6 +1,6 @@
 {
   "helpTitle": "Old Maid",
-  "helpDraw": "  d                    draw a card",
+  "helpDraw": "  d [idx]              draw a card (idx picks which of their cards; omit for random)",
   "helpShuffle": "  s                    shuffle hand",
   "helpReorder": "  ro [i0 i1 ...]       reorder hand",
   "helpSetMode": "  sm [0-1]             set mode (0=Normal, 1=JijiNuki)",

--- a/internal/i18n/locales/ja/oldmaid.json
+++ b/internal/i18n/locales/ja/oldmaid.json
@@ -1,6 +1,6 @@
 {
   "helpTitle": "Old Maid (ババ抜き)",
-  "helpDraw": "  d                    draw a card",
+  "helpDraw": "  d [idx]              札を引く (idx で相手の何枚目かを指定、省略でランダム)",
   "helpShuffle": "  s                    shuffle hand",
   "helpReorder": "  ro [i0 i1 ...]       reorder hand",
   "helpSetMode": "  sm [0-1]             set mode (0=Normal, 1=JijiNuki)",


### PR DESCRIPTION
## 問題

`d zz` が **30 配り中 17 配り (57%)** で札を引きます。`ParseOptionalInt` が打ち間違いを既定値 `-1`（＝ランダムに引く）として読むため、**プレイヤーが選んでいない札**が引かれます。

これまで #5390 で測った中で最高率です。

## この引数は「細部」ではありません

`PlayerDraw(cardIdx)` は**相手の手札の何枚目を引くか**を選びます。ババ抜きにおいて、選ぶことそのものがゲームです。

にもかかわらず、コマンド表は引数の存在を書いていませんでした。

```
  d                    draw a card
```

つまり、

- **表が実装より狭い** —— `d <idx>` が文書化されていない
- そのうえで、文書化されていない引数を打ち間違えると黙って別の札を引く

両方直します。行を `d [idx]` にして索引の意味を書き、パースできない引数は既定値に落とさず拒否します。**引数なしのランダム引きは残します**（既存テストもそれを固定しています）。

ja 側の行が英語のままだったのも同じ文字列にあったので直しました。

## 実測

| | 拒否 | 盤面が動いた |
|---|---|---|
| Before | 0/30 | **17/30** |
| After | **30/30** | 0 |

## 残り

同じ `ParseOptionalInt` を使う他 5 ゲーム（speed / sevens / doubt / war / beggarmyneighbour）は、開始局面では既定値がほとんど通らず 0〜1/30 でした。**拒否されているわけではない**ので原則としては同じ扱いが必要で、数値とともに #5390 に残しています。

## 検証

- `go test -tags test ./internal/adapter/controller/ ./internal/infrastructure/ui/` — 緑
- `golangci-lint run ./internal/...` — 0 issues
- 30 配りで前後を実測

Refs #5390
