### PR TITLE
feat(cui): add examples to the 41 solitaire games, and unskip 73 command rows

### DIFF
--- a/internal/i18n/locales/en/accordion.json
+++ b/internal/i18n/locales/en/accordion.json
@@ -16,5 +16,6 @@
   "header": "Piles remaining: {{count}}",
   "pileSingle": "[{{idx}}]{{card}} ",
   "pileStack": "[{{idx}}]{{card}}(+{{count}}) ",
-  "hintLine": "Hint: pile {{from}} → pile {{to}}"
+  "hintLine": "Hint: pile {{from}} → pile {{to}}",
+  "helpExampleHint": "  h                   ask for a move"
 }

--- a/internal/i18n/locales/en/acesup.json
+++ b/internal/i18n/locales/en/acesup.json
@@ -15,5 +15,6 @@
   "hintDraw": "Hint: deal a card to each column",
   "hintUnknown": "Hint: unknown",
   "markerLegend": "Markers: * = removable / > = movable to an empty column",
-  "usageCol": "Usage: {{cmd}} <col>"
+  "usageCol": "Usage: {{cmd}} <col>",
+  "helpExampleHint": "  h                         ask for a move"
 }

--- a/internal/i18n/locales/en/agnes.json
+++ b/internal/i18n/locales/en/agnes.json
@@ -18,5 +18,6 @@
   "hintFromTableau": "tableau column {{col}}[{{idx}}]",
   "hintToFoundation": "foundation",
   "hintToTableau": "tableau column {{col}}",
-  "hintLine": "Hint: {{from}} → {{to}}"
+  "hintLine": "Hint: {{from}} → {{to}}",
+  "helpExampleHint": "  h                    ask for a move"
 }

--- a/internal/i18n/locales/en/americantoad.json
+++ b/internal/i18n/locales/en/americantoad.json
@@ -33,5 +33,7 @@
   "hintToTableau": "tableau column {{col}}",
   "hintToWaste": "turn it to the waste",
   "hintLine": "Hint: {{from}} → {{to}}",
-  "undoToEscape": "Undo {{count}} move(s) to escape the dead end (undo {{count}}, or repeat u)"
+  "undoToEscape": "Undo {{count}} move(s) to escape the dead end (undo {{count}}, or repeat u)",
+  "helpExampleHint": "  h                        ask for a move",
+  "helpExampleAuto": "  ac                       send everything that can go to a foundation"
 }

--- a/internal/i18n/locales/en/badugi.json
+++ b/internal/i18n/locales/en/badugi.json
@@ -44,5 +44,5 @@
   "handRank3": "3-card",
   "handRank4": "Badugi",
   "handRankUnknown": "Unknown",
-  "helpExampleBet": "  b 100                bet 100 chips"
+  "helpExampleCall": "  c                    call the current bet"
 }

--- a/internal/i18n/locales/en/baloot.json
+++ b/internal/i18n/locales/en/baloot.json
@@ -39,5 +39,5 @@
   "suitClover": "Clubs",
   "suitHeart": "Hearts",
   "suitDiamond": "Diamonds",
-  "helpExamplePlay": "  p 0                  play hand card 0"
+  "helpExampleGiveUp": "  g                    give the round up"
 }

--- a/internal/i18n/locales/en/bigtwo.json
+++ b/internal/i18n/locales/en/bigtwo.json
@@ -18,7 +18,5 @@
   "gameEnd": "Game Over!",
   "rankN": "Rank {{rank}}",
   "yourTurn": "Your turn",
-  "actionPass": "pass",
-  "helpExamplePlay": "  p 0                  play hand card 0 on its own",
-  "helpExamplePass": "  p                    pass by naming no cards"
+  "actionPass": "pass"
 }

--- a/internal/i18n/locales/en/bisley.json
+++ b/internal/i18n/locales/en/bisley.json
@@ -16,5 +16,7 @@
   "hintToKing": "descending foundation {{idx}}",
   "hintToTableau": "tableau column {{col}}",
   "hintLine": "Hint: {{from}} → {{to}}",
-  "undoToEscape": "Undo {{count}} move(s) to escape the dead end (undo {{count}}, or repeat u)"
+  "undoToEscape": "Undo {{count}} move(s) to escape the dead end (undo {{count}}, or repeat u)",
+  "helpExampleHint": "  h                    ask for a move",
+  "helpExampleAuto": "  ac                   send everything that can go to a foundation"
 }

--- a/internal/i18n/locales/en/blackhole.json
+++ b/internal/i18n/locales/en/blackhole.json
@@ -8,5 +8,6 @@
   "hintLine": "[HINT: fan {{fan}} can be played]",
   "acceptableRanks": "Accepted ranks: {{ranks}}",
   "acceptableRanksNone": "Accepted ranks: none",
-  "legalMoveCount": "Legal moves: {{count}}"
+  "legalMoveCount": "Legal moves: {{count}}",
+  "helpExampleUndo": "  u                    take the last move back"
 }

--- a/internal/i18n/locales/en/blackhole.json
+++ b/internal/i18n/locales/en/blackhole.json
@@ -8,6 +8,5 @@
   "hintLine": "[HINT: fan {{fan}} can be played]",
   "acceptableRanks": "Accepted ranks: {{ranks}}",
   "acceptableRanksNone": "Accepted ranks: none",
-  "legalMoveCount": "Legal moves: {{count}}",
-  "helpExampleUndo": "  u                    take the last move back"
+  "legalMoveCount": "Legal moves: {{count}}"
 }

--- a/internal/i18n/locales/en/botifarra.json
+++ b/internal/i18n/locales/en/botifarra.json
@@ -33,5 +33,5 @@
   "hintPlay": "Card {{index}} looks best ({{reason}})",
   "botifarraDeclareLongest": "make your longest suit trump",
   "botifarraMustWin": "you must win the trick if you can",
-  "helpExamplePlay": "  p 0                  play hand card 0"
+  "helpExampleHint": "  hint                 ask for a move"
 }

--- a/internal/i18n/locales/en/braid.json
+++ b/internal/i18n/locales/en/braid.json
@@ -44,5 +44,7 @@
   "hintToHelper": "helper {{idx}}",
   "hintToWaste": "turn a card to the waste",
   "hintLine": "Hint: {{from}} -> {{to}}",
-  "undoToEscape": "Undo {{count}} move(s) to escape (undo {{count}} or repeat u)"
+  "undoToEscape": "Undo {{count}} move(s) to escape (undo {{count}} or repeat u)",
+  "helpExampleHint": "  h                        ask for a move",
+  "helpExampleAuto": "  ac                       send everything that can go to a foundation"
 }

--- a/internal/i18n/locales/en/bristol.json
+++ b/internal/i18n/locales/en/bristol.json
@@ -30,5 +30,7 @@
   "hintFromFan": "fan {{col}}",
   "hintToFoundation": "foundation {{idx}}",
   "hintToTableau": "tableau col {{idx}}",
-  "hintLine": "Hint: {{from}} → {{to}}"
+  "hintLine": "Hint: {{from}} → {{to}}",
+  "helpExampleHint": "  h                    ask for a move",
+  "helpExampleAuto": "  ac                   send everything that can go to a foundation"
 }

--- a/internal/i18n/locales/en/canfield.json
+++ b/internal/i18n/locales/en/canfield.json
@@ -34,6 +34,5 @@
   "hintToFoundation": "foundation",
   "hintToTableau": "tableau column {{col}}",
   "hintLine": "Hint: {{from}} → {{to}}",
-  "helpExampleHint": "  h                    ask for a move",
-  "helpExampleAuto": "  ac                   send everything that can go to a foundation"
+  "helpExampleDraw": "  d                    turn one card from the stock"
 }

--- a/internal/i18n/locales/en/canfield.json
+++ b/internal/i18n/locales/en/canfield.json
@@ -33,5 +33,7 @@
   "hintFromWaste": "waste",
   "hintToFoundation": "foundation",
   "hintToTableau": "tableau column {{col}}",
-  "hintLine": "Hint: {{from}} → {{to}}"
+  "hintLine": "Hint: {{from}} → {{to}}",
+  "helpExampleHint": "  h                    ask for a move",
+  "helpExampleAuto": "  ac                   send everything that can go to a foundation"
 }

--- a/internal/i18n/locales/en/colorado.json
+++ b/internal/i18n/locales/en/colorado.json
@@ -29,5 +29,7 @@
   "hintToTableau": "tableau pile {{pile}}",
   "hintToWaste": "turn it to the waste",
   "hintLine": "Hint: {{from}} → {{to}}",
-  "undoToEscape": "Undo {{count}} move(s) to escape the dead end (undo {{count}}, or repeat u)"
+  "undoToEscape": "Undo {{count}} move(s) to escape the dead end (undo {{count}}, or repeat u)",
+  "helpExampleHint": "  h                        ask for a move",
+  "helpExampleAuto": "  ac                       send everything that can go to a foundation"
 }

--- a/internal/i18n/locales/en/colourwhist.json
+++ b/internal/i18n/locales/en/colourwhist.json
@@ -38,5 +38,5 @@
   "hintPlay": "Card {{index}} looks best ({{reason}})",
   "colourWhistBidStrength": "based on your hand's strength",
   "colourWhistFollowSuit": "you must follow suit",
-  "helpExampleHint": "  hint                 ask for a move"
+  "helpExampleGiveUp": "  g                    give the round up"
 }

--- a/internal/i18n/locales/en/colourwhist.json
+++ b/internal/i18n/locales/en/colourwhist.json
@@ -38,5 +38,5 @@
   "hintPlay": "Card {{index}} looks best ({{reason}})",
   "colourWhistBidStrength": "based on your hand's strength",
   "colourWhistFollowSuit": "you must follow suit",
-  "helpExamplePass": "  pass                 drop out of the bidding"
+  "helpExamplePass": "  pass                 stay out of this auction"
 }

--- a/internal/i18n/locales/en/colourwhist.json
+++ b/internal/i18n/locales/en/colourwhist.json
@@ -38,5 +38,5 @@
   "hintPlay": "Card {{index}} looks best ({{reason}})",
   "colourWhistBidStrength": "based on your hand's strength",
   "colourWhistFollowSuit": "you must follow suit",
-  "helpExamplePlay": "  p 0                  play hand card 0"
+  "helpExampleHint": "  hint                 ask for a move"
 }

--- a/internal/i18n/locales/en/colourwhist.json
+++ b/internal/i18n/locales/en/colourwhist.json
@@ -38,5 +38,5 @@
   "hintPlay": "Card {{index}} looks best ({{reason}})",
   "colourWhistBidStrength": "based on your hand's strength",
   "colourWhistFollowSuit": "you must follow suit",
-  "helpExampleGiveUp": "  g                    give the round up"
+  "helpExamplePass": "  pass                 drop out of the bidding"
 }

--- a/internal/i18n/locales/en/congress.json
+++ b/internal/i18n/locales/en/congress.json
@@ -30,5 +30,7 @@
   "hintToTableau": "tableau pile {{pile}}",
   "hintToWaste": "turn it to the waste",
   "hintLine": "Hint: {{from}} → {{to}}",
-  "undoToEscape": "Undo {{count}} move(s) to escape the dead end (undo {{count}}, or repeat u)"
+  "undoToEscape": "Undo {{count}} move(s) to escape the dead end (undo {{count}}, or repeat u)",
+  "helpExampleHint": "  h                        ask for a move",
+  "helpExampleAuto": "  ac                       send everything that can go to a foundation"
 }

--- a/internal/i18n/locales/en/crazypineapple.json
+++ b/internal/i18n/locales/en/crazypineapple.json
@@ -24,7 +24,6 @@
   "invalidTableSize": "Invalid table size: {{val}}. Please enter 4, 6, or 9.",
   "discardIdxRequired": "Discard card index is required.",
   "invalidDiscardIdx": "Invalid card index: {{val}}",
-  "helpExampleCheck": "  ck                   check and pass the action along",
-  "helpExampleBet": "  b 100                bet 100 chips",
-  "helpExampleRaise": "  ra 200               raise to 200 chips total"
+  "helpExampleRaise": "  ra 200               raise to 200 chips total",
+  "helpExampleCall": "  c                    call the current bet"
 }

--- a/internal/i18n/locales/en/crazyquilt.json
+++ b/internal/i18n/locales/en/crazyquilt.json
@@ -27,5 +27,7 @@
   "hintToFoundation": "foundation {{idx}}",
   "hintToWaste": "onto the waste",
   "hintLine": "Hint: {{from}} → {{to}}",
-  "undoToEscape": "Undo {{count}} move(s) to escape the dead end (undo {{count}}, or repeat u)"
+  "undoToEscape": "Undo {{count}} move(s) to escape the dead end (undo {{count}}, or repeat u)",
+  "helpExampleHint": "  h                        ask for a move",
+  "helpExampleAuto": "  ac                       send everything that can go to a foundation"
 }

--- a/internal/i18n/locales/en/crescent.json
+++ b/internal/i18n/locales/en/crescent.json
@@ -26,5 +26,7 @@
   "gameClear": "Game cleared in {{moveCount}} moves!",
   "gameOver": "Game over",
   "hintAvailable": "Hint available",
-  "noHint": "No hint available"
+  "noHint": "No hint available",
+  "helpExampleHint": "  h                        ask for a move",
+  "helpExampleAuto": "  ac                       send everything that can go to a foundation"
 }

--- a/internal/i18n/locales/en/cruel.json
+++ b/internal/i18n/locales/en/cruel.json
@@ -26,5 +26,7 @@
   "hintFrom": "tableau column {{col}}",
   "hintToFoundation": "foundation",
   "hintToTableau": "tableau column {{col}}",
-  "hintLine": "Hint: {{from}} → {{to}}"
+  "hintLine": "Hint: {{from}} → {{to}}",
+  "helpExampleHint": "  h                    ask for a move",
+  "helpExampleAuto": "  ac                   send everything that can go to a foundation"
 }

--- a/internal/i18n/locales/en/cucumber.json
+++ b/internal/i18n/locales/en/cucumber.json
@@ -22,6 +22,5 @@
   "hintReasonLead": "You lead, so anything is legal",
   "hintReasonBeat": "The cheapest card that still beats it -- do not carry high cards into the last trick",
   "hintReasonForced": "You cannot beat it, so this card is forced",
-  "helpExamplePlay": "  p 0                  play hand card 0",
-  "helpExampleNext": "  n                    read the round result, then continue"
+  "helpExampleGiveUp": "  g                    give the round up"
 }

--- a/internal/i18n/locales/en/daifugo.json
+++ b/internal/i18n/locales/en/daifugo.json
@@ -33,6 +33,5 @@
   "promptTenDiscard": "[10-discard] choose a card to discard (p [index])",
   "promptQueenBomber": "[Queen bomber] enter the rank to remove (p [1-13])",
   "promptPlay": "p [index...] to play cards / p to pass",
-  "helpExamplePlay": "  p 0 2                play hand cards 0 and 2 as a pair",
-  "helpExamplePass": "  p                    pass (no index)"
+  "helpExamplePass": "  p                    pass when you cannot play"
 }

--- a/internal/i18n/locales/en/deucetoseven.json
+++ b/internal/i18n/locales/en/deucetoseven.json
@@ -37,5 +37,5 @@
   "hintExchange": "Suggestion: exchange hand [{{idxs}}] ({{cards}}) with e {{cmd}}",
   "hintStandPat": "Suggestion: made low — stand pat (s).",
   "hintNotYourTurn": "It is not your draw phase right now.",
-  "helpExampleCall": "  c                    call the current bet"
+  "helpExampleFold": "  f                    fold this hand"
 }

--- a/internal/i18n/locales/en/deucetoseven.json
+++ b/internal/i18n/locales/en/deucetoseven.json
@@ -37,5 +37,5 @@
   "hintExchange": "Suggestion: exchange hand [{{idxs}}] ({{cards}}) with e {{cmd}}",
   "hintStandPat": "Suggestion: made low — stand pat (s).",
   "hintNotYourTurn": "It is not your draw phase right now.",
-  "helpExampleBet": "  b 100                bet 100 chips"
+  "helpExampleCall": "  c                    call the current bet"
 }

--- a/internal/i18n/locales/en/diplomat.json
+++ b/internal/i18n/locales/en/diplomat.json
@@ -29,5 +29,7 @@
   "hintToTableau": "column {{pile}}",
   "hintToWaste": "turn it to the waste",
   "hintLine": "Hint: {{from}} → {{to}}",
-  "undoToEscape": "Undo {{count}} move(s) to escape the dead end (undo {{count}}, or repeat u)"
+  "undoToEscape": "Undo {{count}} move(s) to escape the dead end (undo {{count}}, or repeat u)",
+  "helpExampleHint": "  h                        ask for a move",
+  "helpExampleAuto": "  ac                       send everything that can go to a foundation"
 }

--- a/internal/i18n/locales/en/doubleklondike.json
+++ b/internal/i18n/locales/en/doubleklondike.json
@@ -12,5 +12,6 @@
   "hintLine": "[HINT: {{from}}{{fromCol}} -> {{to}}{{toCol}}]",
   "zoneWaste": "Waste",
   "zoneTableau": "Tableau",
-  "zoneFoundation": "Foundation"
+  "zoneFoundation": "Foundation",
+  "helpExampleUndo": "  u                                  take the last move back"
 }

--- a/internal/i18n/locales/en/doubleklondike.json
+++ b/internal/i18n/locales/en/doubleklondike.json
@@ -13,5 +13,5 @@
   "zoneWaste": "Waste",
   "zoneTableau": "Tableau",
   "zoneFoundation": "Foundation",
-  "helpExampleUndo": "  u                                  take the last move back"
+  "helpExampleDraw": "  d                     turn one card from the stock"
 }

--- a/internal/i18n/locales/en/duchess.json
+++ b/internal/i18n/locales/en/duchess.json
@@ -37,5 +37,7 @@
   "hintToWaste": "turn it to the waste",
   "hintToTableau": "tableau column {{col}}",
   "hintLine": "Hint: {{from}} → {{to}}",
-  "undoToEscape": "Undo {{count}} move(s) to escape the dead end (undo {{count}}, or repeat u)"
+  "undoToEscape": "Undo {{count}} move(s) to escape the dead end (undo {{count}}, or repeat u)",
+  "helpExampleHint": "  h                        ask for a move",
+  "helpExampleAuto": "  ac                       send everything that can go to a foundation"
 }

--- a/internal/i18n/locales/en/easthaven.json
+++ b/internal/i18n/locales/en/easthaven.json
@@ -23,5 +23,7 @@
   "hintFrom": "tableau col {{col}}[{{idx}}]",
   "hintToFoundation": "foundation",
   "hintToTableau": "tableau col {{col}}",
-  "hintLine": "Hint: {{from}} -> {{to}}"
+  "hintLine": "Hint: {{from}} -> {{to}}",
+  "helpExampleHint": "  h                    ask for a move",
+  "helpExampleAuto": "  ac                   send everything that can go to a foundation"
 }

--- a/internal/i18n/locales/en/escoba.json
+++ b/internal/i18n/locales/en/escoba.json
@@ -20,5 +20,5 @@
   "promptNext": "n to start the next round",
   "promptCurrentTurn": "Current turn: {{name}}",
   "promptHelp": "p <hand> [table...] to capture or lay / n for the next round",
-  "helpExamplePlay": "  p 0                      play hand card 0"
+  "helpExampleNext": "  n                        read the round result, then continue"
 }

--- a/internal/i18n/locales/en/fivecardstud.json
+++ b/internal/i18n/locales/en/fivecardstud.json
@@ -55,7 +55,6 @@
   "rebuyPrompt": "Rebuy? ({{chips}} chips, used {{used}}/{{max}}) (rb=rebuy / sr=skip)",
   "addonPrompt": "Add-on? ({{chips}} chips) (ad=addon / sa=skip)",
   "gameEnd": "Game over",
-  "helpExampleCheck": "  ck                   check and pass the action along",
-  "helpExampleBet": "  b 100                bet 100 chips",
-  "helpExampleRaise": "  ra 200               raise to 200 chips total"
+  "helpExampleRaise": "  ra 200               raise to 200 chips total",
+  "helpExampleCall": "  c                    call the current bet"
 }

--- a/internal/i18n/locales/en/fivecardstud.json
+++ b/internal/i18n/locales/en/fivecardstud.json
@@ -55,6 +55,5 @@
   "rebuyPrompt": "Rebuy? ({{chips}} chips, used {{used}}/{{max}}) (rb=rebuy / sr=skip)",
   "addonPrompt": "Add-on? ({{chips}} chips) (ad=addon / sa=skip)",
   "gameEnd": "Game over",
-  "helpExampleRaise": "  ra 200               raise to 200 chips total",
-  "helpExampleCall": "  c                    call the current bet"
+  "helpExampleFold": "  f                    fold this hand"
 }

--- a/internal/i18n/locales/en/flowergarden.json
+++ b/internal/i18n/locales/en/flowergarden.json
@@ -15,5 +15,7 @@
   "hintFromReserve": "bouquet {{idx}}",
   "hintToFoundation": "foundation",
   "hintToTableau": "flower bed {{col}}",
-  "hintLine": "Hint: {{from}} → {{to}}"
+  "hintLine": "Hint: {{from}} → {{to}}",
+  "helpExampleHint": "  h                    ask for a move",
+  "helpExampleAuto": "  ac                   send everything that can go to a foundation"
 }

--- a/internal/i18n/locales/en/fortyandeight.json
+++ b/internal/i18n/locales/en/fortyandeight.json
@@ -22,5 +22,7 @@
   "hintToFoundation": "foundation",
   "hintToTableau": "tableau column {{col}}",
   "hintLine": "Hint: {{from}} → {{to}}",
-  "foundationLabel": "[f{{idx}}]"
+  "foundationLabel": "[f{{idx}}]",
+  "helpExampleHint": "  h                    ask for a move",
+  "helpExampleAuto": "  ac                   send everything that can go to a foundation"
 }

--- a/internal/i18n/locales/en/fortyfives.json
+++ b/internal/i18n/locales/en/fortyfives.json
@@ -45,7 +45,5 @@
   "contractMade": "made",
   "contractFailed": "can no longer be made",
   "contractNeedMore": "{{remaining}} more needed",
-  "helpExampleBid": "  bid 20                   bid 20",
-  "helpExamplePlay": "  play 0                   play hand card 0",
-  "helpExampleNext": "  n                        read the trick result, then start the next trick"
+  "helpExampleBid": "  pass                      drop out of the bidding"
 }

--- a/internal/i18n/locales/en/fortythieves.json
+++ b/internal/i18n/locales/en/fortythieves.json
@@ -18,5 +18,7 @@
   "hintFromWaste": "waste",
   "hintToFoundation": "foundation",
   "hintToTableau": "tableau column {{col}}",
-  "hintLine": "Hint: {{from}} → {{to}}"
+  "hintLine": "Hint: {{from}} → {{to}}",
+  "helpExampleHint": "  h                    ask for a move",
+  "helpExampleAuto": "  ac                   send everything that can go to a foundation"
 }

--- a/internal/i18n/locales/en/fourseasons.json
+++ b/internal/i18n/locales/en/fourseasons.json
@@ -31,5 +31,7 @@
   "gameClear": "Game Clear! Moves: {{moveCount}}",
   "gameOver": "Game Over",
   "hintAvailable": "Hint available",
-  "noHint": "No hint"
+  "noHint": "No hint",
+  "helpExampleHint": "  h                                              ask for a move",
+  "helpExampleAuto": "  ac                                             send everything that can go to a foundation"
 }

--- a/internal/i18n/locales/en/gaps.json
+++ b/internal/i18n/locales/en/gaps.json
@@ -18,5 +18,6 @@
   "lockedLegend": "* = kept on redeal",
   "gapBlocked": "[ x ]",
   "gapAnySuit": "[{{rank}}?]",
-  "gapNeeded": "[{{card}}]"
+  "gapNeeded": "[{{card}}]",
+  "helpExampleHint": "  h                         ask for a move"
 }

--- a/internal/i18n/locales/en/grandfathersclock.json
+++ b/internal/i18n/locales/en/grandfathersclock.json
@@ -18,5 +18,7 @@
   "hintToFoundation": "clock face {{idx}}",
   "hintToTableau": "tableau column {{col}}",
   "hintLine": "Hint: {{from}} → {{to}}",
-  "undoToEscape": "Undo {{count}} move(s) to escape the dead end (undo {{count}}, or repeat u)"
+  "undoToEscape": "Undo {{count}} move(s) to escape the dead end (undo {{count}}, or repeat u)",
+  "helpExampleHint": "  h                    ask for a move",
+  "helpExampleAuto": "  ac                   send everything that can go to a foundation"
 }

--- a/internal/i18n/locales/en/holdem.json
+++ b/internal/i18n/locales/en/holdem.json
@@ -56,7 +56,6 @@
   "addonPrompt": "Add-on? ({{chips}} chips) (ad=addon / sa=skip)",
   "gameEnd": "Game over",
   "resultBestFive": " [{{cards}}]",
-  "helpExampleCheck": "  ck                   check and pass the action along",
-  "helpExampleBet": "  b 100                bet 100 chips",
-  "helpExampleRaise": "  ra 200               raise to 200 chips total"
+  "helpExampleRaise": "  ra 200               raise to 200 chips total",
+  "helpExampleCall": "  c                    call the current bet"
 }

--- a/internal/i18n/locales/en/honeymoonbridge.json
+++ b/internal/i18n/locales/en/honeymoonbridge.json
@@ -34,5 +34,5 @@
   "suitHeart": "H",
   "suitDiamond": "D",
   "suitNoTrump": "NT",
-  "helpExamplePlay": "  p 0                  play hand card 0"
+  "helpExampleGiveUp": "  g                    give the round up"
 }

--- a/internal/i18n/locales/en/indianpoker.json
+++ b/internal/i18n/locales/en/indianpoker.json
@@ -37,5 +37,5 @@
   "resultName": "  {{name}}",
   "wonAmount": " → won {{total}} chips",
   "gameEnd": "Game over",
-  "helpExampleBet": "  b 100                bet 100 chips"
+  "helpExampleFold": "  f                    fold this hand"
 }

--- a/internal/i18n/locales/en/irishpoker.json
+++ b/internal/i18n/locales/en/irishpoker.json
@@ -24,7 +24,6 @@
   "invalidTableSize": "Invalid table size: {{val}}. Please enter 4, 6, or 9.",
   "discardIdxRequired": "Discard card index is required.",
   "invalidDiscardIdx": "Invalid card index: {{val}}",
-  "helpExampleCheck": "  ck                   check and pass the action along",
-  "helpExampleBet": "  b 100                bet 100 chips",
-  "helpExampleRaise": "  ra 200               raise to 200 chips total"
+  "helpExampleRaise": "  ra 200               raise to 200 chips total",
+  "helpExampleCall": "  c                    call the current bet"
 }

--- a/internal/i18n/locales/en/kingalbert.json
+++ b/internal/i18n/locales/en/kingalbert.json
@@ -16,5 +16,7 @@
   "hintFromReserve": "reserve {{idx}}",
   "hintToFoundation": "foundation",
   "hintToTableau": "tableau column {{col}}",
-  "hintLine": "Hint: {{from}} → {{to}}"
+  "hintLine": "Hint: {{from}} → {{to}}",
+  "helpExampleHint": "  h                    ask for a move",
+  "helpExampleAuto": "  ac                   send everything that can go to a foundation"
 }

--- a/internal/i18n/locales/en/klondike.json
+++ b/internal/i18n/locales/en/klondike.json
@@ -26,7 +26,5 @@
   "hintToTableau": "tableau column {{col}}",
   "hintLine": "Hint: {{from}} → {{to}}",
   "autoCompleteReady": "Auto-complete is available (ac)",
-  "helpExampleDraw": "  d                    draw one card from the stock",
-  "helpExampleMove": "  m w t 1              move waste to tableau column 1",
-  "helpExampleFound": "  m w f                move waste to a foundation"
+  "helpExampleDraw": "  d                    draw one card from the stock"
 }

--- a/internal/i18n/locales/en/labellelucie.json
+++ b/internal/i18n/locales/en/labellelucie.json
@@ -13,5 +13,6 @@
   "hintLine": "[HINT: move fan {{from}} to {{to}}]",
   "foundationCount": "({{count}} cards)",
   "redealRecommended": "No legal moves. Redeal recommended (nr).",
-  "stuckDeadlock": "No legal move remains and no redeals are left - type giveup to concede."
+  "stuckDeadlock": "No legal move remains and no redeals are left - type giveup to concede.",
+  "helpExampleAuto": "  ac                   send everything that can go to a foundation"
 }

--- a/internal/i18n/locales/en/mendikot.json
+++ b/internal/i18n/locales/en/mendikot.json
@@ -31,6 +31,5 @@
   "suitClover": "Clubs",
   "suitHeart": "Hearts",
   "suitDiamond": "Diamonds",
-  "helpExamplePlay": "  p 0                  play hand card 0",
-  "helpExampleNext": "  n                    read the round result, then continue"
+  "helpExampleGiveUp": "  g                    give the round up"
 }

--- a/internal/i18n/locales/en/michigan.json
+++ b/internal/i18n/locales/en/michigan.json
@@ -45,5 +45,5 @@
   "roundEndHumanLose": "A rival did better this round.",
   "result.humanWin": "Game over! You win!",
   "result.cpuWin": "Game over! CPU {{player}} wins!",
-  "helpExampleBet": "  b 25 25 25 25             stake 25 on each of the four boodles"
+  "helpExampleNext": "  n                         go to the next deal"
 }

--- a/internal/i18n/locales/en/minibridge.json
+++ b/internal/i18n/locales/en/minibridge.json
@@ -33,5 +33,5 @@
   "suitHeart": "H",
   "suitDiamond": "D",
   "suitNoTrump": "NT",
-  "helpExamplePlay": "  p 0                  play hand card 0"
+  "helpExampleGiveUp": "  g                    give the round up"
 }

--- a/internal/i18n/locales/en/missmilligan.json
+++ b/internal/i18n/locales/en/missmilligan.json
@@ -27,5 +27,7 @@
   "hintToTableau": "tableau column {{col}}",
   "hintToDeal": "deal a row",
   "hintLine": "Hint: {{from}} → {{to}}",
-  "undoToEscape": "Undo {{count}} move(s) to escape the dead end (undo {{count}}, or repeat u)"
+  "undoToEscape": "Undo {{count}} move(s) to escape the dead end (undo {{count}}, or repeat u)",
+  "helpExampleHint": "  h                        ask for a move",
+  "helpExampleAuto": "  ac                       send everything that can go to a foundation"
 }

--- a/internal/i18n/locales/en/nainjaune.json
+++ b/internal/i18n/locales/en/nainjaune.json
@@ -27,6 +27,5 @@
   "hintReasonLead": "the run is stopped, so start low",
   "hintReasonFollow": "this continues the run",
   "hintReasonBox": "this card claims a box",
-  "helpExamplePlay": "  p 0                      play hand card 0",
   "helpExampleNext": "  n                        read the trick result, then continue"
 }

--- a/internal/i18n/locales/en/nap.json
+++ b/internal/i18n/locales/en/nap.json
@@ -42,7 +42,5 @@
   "promptBidHolder": "Current high bidder: {{name}}",
   "declarerProgress": "Declarer: {{won}}/{{needed}} tricks ({{remaining}} left)",
   "contractUnreachable": " - the contract can no longer be made",
-  "helpExampleBid": "  bid 3                    declare three tricks",
-  "helpExamplePlay": "  play 0                   play hand card 0",
-  "helpExampleNext": "  n                        read the trick result, then start the next trick"
+  "helpExampleBid": "  pass                      drop out of the bidding"
 }

--- a/internal/i18n/locales/en/napoleonssquare.json
+++ b/internal/i18n/locales/en/napoleonssquare.json
@@ -26,5 +26,7 @@
   "hintToWaste": "waste",
   "hintToTableau": "tableau column {{col}}",
   "hintLine": "Hint: {{from}} → {{to}}",
-  "undoToEscape": "Undo {{count}} move(s) to escape the dead end (undo {{count}}, or repeat u)"
+  "undoToEscape": "Undo {{count}} move(s) to escape the dead end (undo {{count}}, or repeat u)",
+  "helpExampleHint": "  h                        ask for a move",
+  "helpExampleAuto": "  ac                       send everything that can go to a foundation"
 }

--- a/internal/i18n/locales/en/nertz.json
+++ b/internal/i18n/locales/en/nertz.json
@@ -41,5 +41,6 @@
   "zoneWaste": "Waste",
   "zoneTableau": "Tableau {{col}}",
   "zoneTableauWithIdx": "Tableau {{col}} (idx={{idx}})",
-  "zoneFoundation": "Foundation {{col}}"
+  "zoneFoundation": "Foundation {{col}}",
+  "helpExampleHint": "  h                   ask for a move"
 }

--- a/internal/i18n/locales/en/omaha.json
+++ b/internal/i18n/locales/en/omaha.json
@@ -47,7 +47,6 @@
   "gameEnd": "Game over",
   "hiLoRuleLine": "Low: five distinct cards 8-or-lower (8 or Better); if none qualifies, Hi takes the whole pot",
   "currentBestHand": "Best hand so far: {{hand}} ({{cards}})",
-  "helpExampleCheck": "  ck                   check and pass the action along",
-  "helpExampleBet": "  b 100                bet 100 chips",
-  "helpExampleRaise": "  ra 200               raise to 200 chips total"
+  "helpExampleRaise": "  ra 200               raise to 200 chips total",
+  "helpExampleCall": "  c                    call the current bet"
 }

--- a/internal/i18n/locales/en/osmosis.json
+++ b/internal/i18n/locales/en/osmosis.json
@@ -29,5 +29,7 @@
   "hintToFoundation": "foundation {{idx}}",
   "allowedRanks": "[playable: {{ranks}}]",
   "anyRank": "any rank",
-  "hintLine": "Hint: {{from}} → {{to}} (allowed: {{allowed}})"
+  "hintLine": "Hint: {{from}} → {{to}} (allowed: {{allowed}})",
+  "helpExampleHint": "  h                    ask for a move",
+  "helpExampleAuto": "  ac                   send everything that can go to a foundation"
 }

--- a/internal/i18n/locales/en/pasur.json
+++ b/internal/i18n/locales/en/pasur.json
@@ -19,5 +19,5 @@
   "hintReasonSoor": "This empties the table -- that capture scores double",
   "hintReasonCapture": "It takes cards that score",
   "hintReasonTrail": "Nothing adds to 11; lay down your least valuable card",
-  "helpExamplePlay": "  p 0                  play hand card 0"
+  "helpExampleGiveUp": "  g                    give the round up"
 }

--- a/internal/i18n/locales/en/pineapple.json
+++ b/internal/i18n/locales/en/pineapple.json
@@ -63,7 +63,6 @@
   "discardCandidate": "  [{{idx}}] discard this and you keep: {{hand}}",
   "discardRecommended": " <- recommended",
   "discardCandidatePair": "  discard [{{idx0}}] [{{idx1}}] and you keep: {{hand}}",
-  "helpExampleCheck": "  ck                   check and pass the action along",
-  "helpExampleBet": "  b 100                bet 100 chips",
-  "helpExampleRaise": "  ra 200               raise to 200 chips total"
+  "helpExampleRaise": "  ra 200               raise to 200 chips total",
+  "helpExampleCall": "  c                    call the current bet"
 }

--- a/internal/i18n/locales/en/poker.json
+++ b/internal/i18n/locales/en/poker.json
@@ -44,5 +44,5 @@
   "phaseEnd": "End",
   "promptBet": "Commands: bet <amount> / call / raise <amount> / fold",
   "promptExchange": "Commands: exchange <card indices> (exchange alone to keep all)",
-  "helpExampleCall": "  c                    call the current bet"
+  "helpExampleFold": "  f                    fold this hand"
 }

--- a/internal/i18n/locales/en/poker.json
+++ b/internal/i18n/locales/en/poker.json
@@ -44,5 +44,5 @@
   "phaseEnd": "End",
   "promptBet": "Commands: bet <amount> / call / raise <amount> / fold",
   "promptExchange": "Commands: exchange <card indices> (exchange alone to keep all)",
-  "helpExampleBet": "  b 100                bet 100 chips"
+  "helpExampleCall": "  c                    call the current bet"
 }

--- a/internal/i18n/locales/en/popejoan.json
+++ b/internal/i18n/locales/en/popejoan.json
@@ -30,6 +30,5 @@
   "hintReasonNotYourTurn": "it is not your turn",
   "hintReasonLead": "the run is stopped, so lead your lowest card",
   "hintReasonFollow": "the next higher card of the same suit",
-  "helpExamplePlay": "  p 0                      play hand card 0",
   "helpExampleNext": "  n                        read the trick result, then continue"
 }

--- a/internal/i18n/locales/en/preference.json
+++ b/internal/i18n/locales/en/preference.json
@@ -45,7 +45,5 @@
   "roundEnd": "Round complete",
   "result.humanWin": "Game over! You win!",
   "result.cpuWin": "Game over! Player {{player}} wins!",
-  "helpExampleBid": "  bid 1                    declare Six",
-  "helpExamplePlay": "  play 0                   play hand card 0",
-  "helpExampleNext": "  n                        read the trick result, then start the next trick"
+  "helpExampleBid": "  pass                      drop out of the bidding"
 }

--- a/internal/i18n/locales/en/reversis.json
+++ b/internal/i18n/locales/en/reversis.json
@@ -22,6 +22,5 @@
   "hintReasonAvoidPoints": "penalty cards are on the table -- let someone else take it",
   "hintReasonLeadSafe": "lead a low card that scores nothing",
   "hintReasonDumpHigh": "safe trick: shed a high card now",
-  "helpExamplePlay": "  p 0                  play hand card 0",
-  "helpExampleNext": "  n                    read the round result, then continue"
+  "helpExampleGiveUp": "  g                    give the round up"
 }

--- a/internal/i18n/locales/en/rikken.json
+++ b/internal/i18n/locales/en/rikken.json
@@ -38,5 +38,5 @@
   "rikkenBidStrength": "based on your hand's strength",
   "rikkenFollowSuit": "you must follow suit",
   "openHandLine": "Open hand (seat {{seat}}): {{cards}}",
-  "helpExamplePlay": "  p 0                  play hand card 0"
+  "helpExampleHint": "  hint                 ask for a move"
 }

--- a/internal/i18n/locales/en/royalcotillion.json
+++ b/internal/i18n/locales/en/royalcotillion.json
@@ -35,5 +35,7 @@
   "hintToTableau": "slot {{pile}}",
   "hintToWaste": "turn it to the waste",
   "hintLine": "Hint: {{from}} → {{to}}",
-  "undoToEscape": "Undo {{count}} move(s) to escape the dead end (undo {{count}}, or repeat u)"
+  "undoToEscape": "Undo {{count}} move(s) to escape the dead end (undo {{count}}, or repeat u)",
+  "helpExampleHint": "  h                        ask for a move",
+  "helpExampleAuto": "  ac                       send everything that can go to a foundation"
 }

--- a/internal/i18n/locales/en/russiansolitaire.json
+++ b/internal/i18n/locales/en/russiansolitaire.json
@@ -21,5 +21,7 @@
   "hintFrom": "tableau column {{col}}[{{idx}}]",
   "hintToFoundation": "foundation",
   "hintToTableau": "tableau column {{col}}",
-  "hintLine": "Hint: {{from}} → {{to}}"
+  "hintLine": "Hint: {{from}} → {{to}}",
+  "helpExampleHint": "  h                    ask for a move",
+  "helpExampleAuto": "  ac                   send everything that can go to a foundation"
 }

--- a/internal/i18n/locales/en/scopa.json
+++ b/internal/i18n/locales/en/scopa.json
@@ -28,6 +28,5 @@
   "category.denari": "Denari (most diamonds)",
   "category.primiera": "Primiera (most sevens)",
   "category.settebello": "Settebello (7 of diamonds)",
-  "helpExamplePlay": "  p 0                      lay hand card 0 on the table, capturing nothing",
   "helpExampleNext": "  n                        read the round result, then continue"
 }

--- a/internal/i18n/locales/en/scopone.json
+++ b/internal/i18n/locales/en/scopone.json
@@ -20,5 +20,5 @@
   "promptNext": "n to start the next round",
   "promptCurrentTurn": "Current turn: {{name}} (Team {{team}})",
   "promptHelp": "p <hand> [table...] to capture or lay / n for the next round",
-  "helpExamplePlay": "  p 0                      play hand card 0"
+  "helpExampleNext": "  n                        read the round result, then continue"
 }

--- a/internal/i18n/locales/en/scorpion.json
+++ b/internal/i18n/locales/en/scorpion.json
@@ -26,5 +26,7 @@
   "legalTargetEmpty": "  column {{col}} (empty — accepts a King)",
   "legalNone": "  none",
   "legalNoCard": "Column {{col}} has no movable face-up card",
-  "legalNotPlaying": "No legal moves to show (game is not in play)"
+  "legalNotPlaying": "No legal moves to show (game is not in play)",
+  "helpExampleHint": "  h                    ask for a move",
+  "helpExampleAuto": "  ac                   send everything that can go to a foundation"
 }

--- a/internal/i18n/locales/en/sevencardstud.json
+++ b/internal/i18n/locales/en/sevencardstud.json
@@ -76,7 +76,5 @@
   "hintReasonRazzDecent": "you have a fair number of low cards",
   "hintReasonRazzWeak": "you do not have enough low cards",
   "hintReasonHiLoLow": "a qualifying low is live (five cards of eight or lower)",
-  "helpExampleCheck": "  ck                   check and pass the action along",
-  "helpExampleBet": "  b 100                bet 100 chips",
-  "helpExampleRaise": "  ra 200               raise to 200 chips total"
+  "helpExampleFold": "  f                    fold this hand"
 }

--- a/internal/i18n/locales/en/shortdeck.json
+++ b/internal/i18n/locales/en/shortdeck.json
@@ -48,7 +48,6 @@
   "handRank7": "Four of a Kind",
   "handRank8": "Straight Flush",
   "handRank9": "Royal Flush",
-  "helpExampleCheck": "  ck                   check and pass the action along",
-  "helpExampleBet": "  b 100                bet 100 chips",
-  "helpExampleRaise": "  ra 200               raise to 200 chips total"
+  "helpExampleRaise": "  ra 200               raise to 200 chips total",
+  "helpExampleCall": "  c                    call the current bet"
 }

--- a/internal/i18n/locales/en/simplesimon.json
+++ b/internal/i18n/locales/en/simplesimon.json
@@ -5,5 +5,6 @@
   "helpGiveUp": "  g / giveup           give up",
   "colLabel": "Col {{idx}}:",
   "completedLine": "Completed suits: {{count}} / 4",
-  "hintLine": "[HINT: move col {{from}}[{{idx}}] to col {{to}}]"
+  "hintLine": "[HINT: move col {{from}}[{{idx}}] to col {{to}}]",
+  "helpExampleUndo": "  u                    take the last move back"
 }

--- a/internal/i18n/locales/en/simplesimon.json
+++ b/internal/i18n/locales/en/simplesimon.json
@@ -5,6 +5,5 @@
   "helpGiveUp": "  g / giveup           give up",
   "colLabel": "Col {{idx}}:",
   "completedLine": "Completed suits: {{count}} / 4",
-  "hintLine": "[HINT: move col {{from}}[{{idx}}] to col {{to}}]",
-  "helpExampleUndo": "  u                    take the last move back"
+  "hintLine": "[HINT: move col {{from}}[{{idx}}] to col {{to}}]"
 }

--- a/internal/i18n/locales/en/slobberhannes.json
+++ b/internal/i18n/locales/en/slobberhannes.json
@@ -23,6 +23,5 @@
   "hintReasonAvoid": "this trick carries a penalty -- don't take it",
   "hintReasonDump": "safe trick: get rid of a high card now",
   "hintReasonLeadLow": "lead low and see what happens",
-  "helpExamplePlay": "  p 0                  play hand card 0",
-  "helpExampleNext": "  n                    read the round result, then continue"
+  "helpExampleGiveUp": "  g                    give the round up"
 }

--- a/internal/i18n/locales/en/soko.json
+++ b/internal/i18n/locales/en/soko.json
@@ -55,7 +55,5 @@
   "rebuyPrompt": "Rebuy? ({{chips}} chips, used {{used}}/{{max}}) (rb=rebuy / sr=skip)",
   "addonPrompt": "Add-on? ({{chips}} chips) (ad=addon / sa=skip)",
   "gameEnd": "Game over",
-  "helpExampleCheck": "  ck                   check and pass the action along",
-  "helpExampleBet": "  b 100                bet 100 chips",
-  "helpExampleRaise": "  ra 200               raise to 200 chips total"
+  "helpExampleFold": "  f                    fold this hand"
 }

--- a/internal/i18n/locales/en/solowhist.json
+++ b/internal/i18n/locales/en/solowhist.json
@@ -39,7 +39,5 @@
   "result.humanWin": "Game over! You win!",
   "result.cpuWin": "Game over! Player {{player}} wins!",
   "bidHistory": "Bids: {{bids}}",
-  "helpExampleBid": "  bid 1                    declare Solo",
-  "helpExamplePlay": "  play 0                   play hand card 0",
-  "helpExampleNext": "  n                        read the trick result, then start the next trick"
+  "helpExampleBid": "  pass                      drop out of the bidding"
 }

--- a/internal/i18n/locales/en/speed.json
+++ b/internal/i18n/locales/en/speed.json
@@ -14,6 +14,5 @@
   "promptStuckHelp": "Command: f / flip — both players flip a new card to break the deadlock",
   "winHuman": "You win!",
   "winCpu": "CPU wins...",
-  "helpExamplePlay": "  p 0 1                play hand card 0 onto pile 1",
-  "helpExampleFlip": "  f                    flip a new centre card when stuck"
+  "helpExampleHint": "  h                    ask for a move"
 }

--- a/internal/i18n/locales/en/spider.json
+++ b/internal/i18n/locales/en/spider.json
@@ -11,5 +11,7 @@
   "gameClearLine": "Game clear! Moves: {{moves}} Score: {{score}}",
   "hintLine": "Hint: tableau column {{fromCol}}[{{idx}}] → tableau column {{toCol}}",
   "difficultyLine": "Difficulty: {{suits}}-suit / Deals left: {{deals}}",
-  "dealBlockedEmpty": "Cannot deal while a column is empty (fill every column first)"
+  "dealBlockedEmpty": "Cannot deal while a column is empty (fill every column first)",
+  "helpExampleHint": "  h                        ask for a move",
+  "helpExampleAuto": "  ac                       send everything that can go to a foundation"
 }

--- a/internal/i18n/locales/en/spiderette.json
+++ b/internal/i18n/locales/en/spiderette.json
@@ -10,5 +10,7 @@
   "columnLabel": "Column {{col}}:",
   "gameClearLine": "Game clear! Moves: {{moves}} Score: {{score}}",
   "hintLine": "Hint: tableau column {{fromCol}}[{{idx}}] → tableau column {{toCol}}",
-  "dealsRemaining": " | Deals left: {{count}}"
+  "dealsRemaining": " | Deals left: {{count}}",
+  "helpExampleHint": "  h                        ask for a move",
+  "helpExampleAuto": "  ac                       send everything that can go to a foundation"
 }

--- a/internal/i18n/locales/en/sultan.json
+++ b/internal/i18n/locales/en/sultan.json
@@ -22,5 +22,7 @@
   "promptSourceZone": "Specify the source (d <idx> or w)",
   "promptDivanIndex": "Specify the divan slot index",
   "invalidDivanIndex": "Invalid divan index: {{val}}",
-  "invalidFromZone": "Invalid source zone: {{val}}"
+  "invalidFromZone": "Invalid source zone: {{val}}",
+  "helpExampleHint": "  h                    ask for a move",
+  "helpExampleAuto": "  ac                   send everything that can go to a foundation"
 }

--- a/internal/i18n/locales/en/tarabish.json
+++ b/internal/i18n/locales/en/tarabish.json
@@ -36,5 +36,5 @@
   "suitClover": "Clubs",
   "suitHeart": "Hearts",
   "suitDiamond": "Diamonds",
-  "helpExamplePlay": "  p 0                  play hand card 0"
+  "helpExampleNext": "  n                    read the trick result, then continue"
 }

--- a/internal/i18n/locales/en/terrace.json
+++ b/internal/i18n/locales/en/terrace.json
@@ -36,5 +36,7 @@
   "hintToTableau": "tableau pile {{pile}}",
   "hintToWaste": "turn it to the waste",
   "hintLine": "Hint: {{from}} → {{to}}",
-  "undoToEscape": "Undo {{count}} move(s) to escape the dead end (undo {{count}}, or repeat u)"
+  "undoToEscape": "Undo {{count}} move(s) to escape the dead end (undo {{count}}, or repeat u)",
+  "helpExampleHint": "  h                        ask for a move",
+  "helpExampleAuto": "  ac                       send everything that can go to a foundation"
 }

--- a/internal/i18n/locales/en/tienlen.json
+++ b/internal/i18n/locales/en/tienlen.json
@@ -19,7 +19,5 @@
   "comboStraight": "Straight",
   "comboThreePairRun": "Three-pair run",
   "comboFourOfAKind": "Four of a kind",
-  "comboInvalid": "Unknown",
-  "helpExamplePlay": "  p 0                  play hand card 0 on its own",
-  "helpExamplePass": "  p                    pass by naming no cards"
+  "comboInvalid": "Unknown"
 }

--- a/internal/i18n/locales/en/toepen.json
+++ b/internal/i18n/locales/en/toepen.json
@@ -27,5 +27,5 @@
   "hintReasonPlay": "this is the cheapest card that still takes the trick",
   "helpRedeal": "  d                        throw in a poverty hand (only A/K/Q/J) for a redeal",
   "promptRedeal": "your hand is nothing but A/K/Q/J -- d asks for a redeal",
-  "helpExamplePlay": "  p 0                      play hand card 0"
+  "helpExampleFold": "  f                        fold this round"
 }

--- a/internal/i18n/locales/en/twentynine.json
+++ b/internal/i18n/locales/en/twentynine.json
@@ -41,7 +41,5 @@
   "roundEnd": "Round complete",
   "result.humanWin": "Game over! Your team wins!",
   "result.cpuWin": "Game over! Team {{team}} wins!",
-  "helpExampleBid": "  bid 20                   bid 20",
-  "helpExamplePlay": "  play 0                   play hand card 0",
-  "helpExampleNext": "  n                        read the trick result, then start the next trick"
+  "helpExampleBid": "  pass                      drop out of the bidding"
 }

--- a/internal/i18n/locales/en/vira.json
+++ b/internal/i18n/locales/en/vira.json
@@ -40,7 +40,5 @@
   "helpNext": "  n                    go to next trick",
   "helpNextRound": "  nr                   go to next round",
   "helpSetDifficulty": "  sd [0-2]             CPU difficulty (0=Easy, 1=Normal, 2=Hard)",
-  "helpExampleBid": "  b 2                  declare Solo",
-  "helpExamplePlay": "  play 0               play hand card 0",
-  "helpExampleNext": "  n                    read the trick result, then start the next trick"
+  "helpExampleBid": "  pass                 drop out of the bidding"
 }

--- a/internal/i18n/locales/en/wasp.json
+++ b/internal/i18n/locales/en/wasp.json
@@ -26,5 +26,7 @@
   "legalTargetEmpty": "  column {{col}} (empty — accepts any card)",
   "legalNone": "  none",
   "legalNoCard": "Column {{col}} has no movable face-up card",
-  "legalNotPlaying": "No legal moves to show (game is not in play)"
+  "legalNotPlaying": "No legal moves to show (game is not in play)",
+  "helpExampleHint": "  h                    ask for a move",
+  "helpExampleAuto": "  ac                   send everything that can go to a foundation"
 }

--- a/internal/i18n/locales/en/windmill.json
+++ b/internal/i18n/locales/en/windmill.json
@@ -34,5 +34,7 @@
   "hintToCorner": "corner foundation {{idx}}",
   "hintToWaste": "turn it to the waste",
   "hintLine": "Hint: {{from}} → {{to}}",
-  "undoToEscape": "Undo {{count}} move(s) to escape the dead end (undo {{count}}, or repeat u)"
+  "undoToEscape": "Undo {{count}} move(s) to escape the dead end (undo {{count}}, or repeat u)",
+  "helpExampleHint": "  h                        ask for a move",
+  "helpExampleAuto": "  ac                       send everything that can go to a foundation"
 }

--- a/internal/i18n/locales/en/yukon.json
+++ b/internal/i18n/locales/en/yukon.json
@@ -24,5 +24,7 @@
   "hintToTableau": "tableau column {{col}}",
   "hintLine": "Hint: {{from}} → {{to}} {{confidence}}",
   "hintConfidenceFoundation": "(priority: high - safe move to a foundation)",
-  "hintConfidenceTableau": "(priority: medium - tableau reorganization)"
+  "hintConfidenceTableau": "(priority: medium - tableau reorganization)",
+  "helpExampleHint": "  h                    ask for a move",
+  "helpExampleAuto": "  ac                   send everything that can go to a foundation"
 }

--- a/internal/i18n/locales/en/zheng.json
+++ b/internal/i18n/locales/en/zheng.json
@@ -11,7 +11,5 @@
   "playerYou": "You",
   "yourTurn": "Your turn",
   "comboRulesHint": "Combos: single/pair/triple/run(3..A)/pair run(3..A). Ranks 3<...<A<2<small Joker<big Joker; suits never matter. A bomb (four of a kind) cuts any normal combo, and the two Jokers together beat everything.",
-  "actionPass": "pass",
-  "helpExamplePlay": "  p 0                  play hand card 0 on its own",
-  "helpExamplePass": "  p                    pass by naming no cards"
+  "actionPass": "pass"
 }

--- a/internal/i18n/locales/ja/accordion.json
+++ b/internal/i18n/locales/ja/accordion.json
@@ -16,5 +16,6 @@
   "header": "残りパイル: {{count}}",
   "pileSingle": "[{{idx}}]{{card}} ",
   "pileStack": "[{{idx}}]{{card}}(+{{count}}) ",
-  "hintLine": "ヒント: パイル{{from}} → パイル{{to}}"
+  "hintLine": "ヒント: パイル{{from}} → パイル{{to}}",
+  "helpExampleHint": "  h                   次の一手を教えてもらう"
 }

--- a/internal/i18n/locales/ja/acesup.json
+++ b/internal/i18n/locales/ja/acesup.json
@@ -15,5 +15,6 @@
   "hintDraw": "ヒント: 各列にカードを配ってください",
   "hintUnknown": "ヒント: 不明",
   "markerLegend": "マーカー: * = 捨て可能 / > = 空き列へ移動可能",
-  "usageCol": "使い方: {{cmd}} <列番号>"
+  "usageCol": "使い方: {{cmd}} <列番号>",
+  "helpExampleHint": "  h                         次の一手を教えてもらう"
 }

--- a/internal/i18n/locales/ja/agnes.json
+++ b/internal/i18n/locales/ja/agnes.json
@@ -18,5 +18,6 @@
   "hintFromTableau": "タブロー列{{col}}[{{idx}}]",
   "hintToFoundation": "ファンデーション",
   "hintToTableau": "タブロー列{{col}}",
-  "hintLine": "ヒント: {{from}} → {{to}}"
+  "hintLine": "ヒント: {{from}} → {{to}}",
+  "helpExampleHint": "  h                    次の一手を教えてもらう"
 }

--- a/internal/i18n/locales/ja/americantoad.json
+++ b/internal/i18n/locales/ja/americantoad.json
@@ -33,5 +33,7 @@
   "hintToTableau": "タブロー列{{col}}",
   "hintToWaste": "捨て札へめくる",
   "hintLine": "ヒント: {{from}} → {{to}}",
-  "undoToEscape": "脱出には {{count}} 手戻す必要があります（undo {{count}} または u を繰り返す）"
+  "undoToEscape": "脱出には {{count}} 手戻す必要があります（undo {{count}} または u を繰り返す）",
+  "helpExampleHint": "  h                        次の一手を教えてもらう",
+  "helpExampleAuto": "  ac                       組札へ送れる札を自動で送る"
 }

--- a/internal/i18n/locales/ja/badugi.json
+++ b/internal/i18n/locales/ja/badugi.json
@@ -44,5 +44,5 @@
   "handRank3": "3カード",
   "handRank4": "バドゥーギ",
   "handRankUnknown": "不明",
-  "helpExampleBet": "  b 100                100 チップを賭ける"
+  "helpExampleCall": "  c                    現在のベットにコールする"
 }

--- a/internal/i18n/locales/ja/baloot.json
+++ b/internal/i18n/locales/ja/baloot.json
@@ -39,5 +39,5 @@
   "suitClover": "クラブ",
   "suitHeart": "ハート",
   "suitDiamond": "ダイヤ",
-  "helpExamplePlay": "  p 0                  手札の 0 番のカードを出す"
+  "helpExampleGiveUp": "  g                    この局を投了する"
 }

--- a/internal/i18n/locales/ja/bigtwo.json
+++ b/internal/i18n/locales/ja/bigtwo.json
@@ -18,7 +18,5 @@
   "gameEnd": "ゲーム終了！",
   "rankN": "{{rank}}位",
   "yourTurn": "あなたのターンです",
-  "actionPass": "パス",
-  "helpExamplePlay": "  p 0                  手札の 0 番を 1 枚出す",
-  "helpExamplePass": "  p                    指定なしでパスする"
+  "actionPass": "パス"
 }

--- a/internal/i18n/locales/ja/bisley.json
+++ b/internal/i18n/locales/ja/bisley.json
@@ -16,5 +16,7 @@
   "hintToKing": "降順基礎札{{idx}}",
   "hintToTableau": "タブロー列{{col}}",
   "hintLine": "ヒント: {{from}} → {{to}}",
-  "undoToEscape": "脱出には {{count}} 手戻す必要があります（undo {{count}} または u を繰り返す）"
+  "undoToEscape": "脱出には {{count}} 手戻す必要があります（undo {{count}} または u を繰り返す）",
+  "helpExampleHint": "  h                    次の一手を教えてもらう",
+  "helpExampleAuto": "  ac                   組札へ送れる札を自動で送る"
 }

--- a/internal/i18n/locales/ja/blackhole.json
+++ b/internal/i18n/locales/ja/blackhole.json
@@ -8,6 +8,5 @@
   "hintLine": "[HINT: 扇{{fan}} を積めます]",
   "acceptableRanks": "出せるランク: {{ranks}}",
   "acceptableRanksNone": "出せるランク: なし",
-  "legalMoveCount": "残り合法手: {{count}}",
-  "helpExampleUndo": "  u                    直前の 1 手を取り消す"
+  "legalMoveCount": "残り合法手: {{count}}"
 }

--- a/internal/i18n/locales/ja/blackhole.json
+++ b/internal/i18n/locales/ja/blackhole.json
@@ -8,5 +8,6 @@
   "hintLine": "[HINT: 扇{{fan}} を積めます]",
   "acceptableRanks": "出せるランク: {{ranks}}",
   "acceptableRanksNone": "出せるランク: なし",
-  "legalMoveCount": "残り合法手: {{count}}"
+  "legalMoveCount": "残り合法手: {{count}}",
+  "helpExampleUndo": "  u                    直前の 1 手を取り消す"
 }

--- a/internal/i18n/locales/ja/botifarra.json
+++ b/internal/i18n/locales/ja/botifarra.json
@@ -33,5 +33,5 @@
   "hintPlay": "{{index}} 番目の札が良さそうです（{{reason}}）",
   "botifarraDeclareLongest": "いちばん長いスートを切り札にする",
   "botifarraMustWin": "勝てるなら勝つ義務がある",
-  "helpExamplePlay": "  p 0                  手札の 0 番のカードを出す"
+  "helpExampleHint": "  hint                 次の一手を教えてもらう"
 }

--- a/internal/i18n/locales/ja/braid.json
+++ b/internal/i18n/locales/ja/braid.json
@@ -44,5 +44,7 @@
   "hintToHelper": "ヘルパー{{idx}}",
   "hintToWaste": "捨て札へめくる",
   "hintLine": "ヒント: {{from}} → {{to}}",
-  "undoToEscape": "脱出には {{count}} 手戻す必要があります（undo {{count}} または u を繰り返す）"
+  "undoToEscape": "脱出には {{count}} 手戻す必要があります（undo {{count}} または u を繰り返す）",
+  "helpExampleHint": "  h                        次の一手を教えてもらう",
+  "helpExampleAuto": "  ac                       組札へ送れる札を自動で送る"
 }

--- a/internal/i18n/locales/ja/bristol.json
+++ b/internal/i18n/locales/ja/bristol.json
@@ -30,5 +30,7 @@
   "hintFromFan": "ファン{{col}}",
   "hintToFoundation": "組札{{idx}}",
   "hintToTableau": "タブロー{{idx}}列",
-  "hintLine": "ヒント: {{from}} → {{to}}"
+  "hintLine": "ヒント: {{from}} → {{to}}",
+  "helpExampleHint": "  h                    次の一手を教えてもらう",
+  "helpExampleAuto": "  ac                   組札へ送れる札を自動で送る"
 }

--- a/internal/i18n/locales/ja/canfield.json
+++ b/internal/i18n/locales/ja/canfield.json
@@ -33,5 +33,7 @@
   "hintFromWaste": "ウェイスト",
   "hintToFoundation": "ファンデーション",
   "hintToTableau": "タブロー列{{col}}",
-  "hintLine": "ヒント: {{from}} → {{to}}"
+  "hintLine": "ヒント: {{from}} → {{to}}",
+  "helpExampleHint": "  h                    次の一手を教えてもらう",
+  "helpExampleAuto": "  ac                   組札へ送れる札を自動で送る"
 }

--- a/internal/i18n/locales/ja/canfield.json
+++ b/internal/i18n/locales/ja/canfield.json
@@ -34,6 +34,5 @@
   "hintToFoundation": "ファンデーション",
   "hintToTableau": "タブロー列{{col}}",
   "hintLine": "ヒント: {{from}} → {{to}}",
-  "helpExampleHint": "  h                    次の一手を教えてもらう",
-  "helpExampleAuto": "  ac                   組札へ送れる札を自動で送る"
+  "helpExampleDraw": "  d                    ストックから 1 枚めくる"
 }

--- a/internal/i18n/locales/ja/colorado.json
+++ b/internal/i18n/locales/ja/colorado.json
@@ -29,5 +29,7 @@
   "hintToTableau": "タブロー山{{pile}}",
   "hintToWaste": "捨て札へめくる",
   "hintLine": "ヒント: {{from}} → {{to}}",
-  "undoToEscape": "脱出には {{count}} 手戻す必要があります（undo {{count}} または u を繰り返す）"
+  "undoToEscape": "脱出には {{count}} 手戻す必要があります（undo {{count}} または u を繰り返す）",
+  "helpExampleHint": "  h                        次の一手を教えてもらう",
+  "helpExampleAuto": "  ac                       組札へ送れる札を自動で送る"
 }

--- a/internal/i18n/locales/ja/colourwhist.json
+++ b/internal/i18n/locales/ja/colourwhist.json
@@ -38,5 +38,5 @@
   "hintPlay": "{{index}} 番目の札が良さそうです（{{reason}}）",
   "colourWhistBidStrength": "手札の強さから見た契約",
   "colourWhistFollowSuit": "フォローの義務がある",
-  "helpExampleGiveUp": "  g                    この局を投了する"
+  "helpExamplePass": "  pass                 競りを降りる"
 }

--- a/internal/i18n/locales/ja/colourwhist.json
+++ b/internal/i18n/locales/ja/colourwhist.json
@@ -38,5 +38,5 @@
   "hintPlay": "{{index}} 番目の札が良さそうです（{{reason}}）",
   "colourWhistBidStrength": "手札の強さから見た契約",
   "colourWhistFollowSuit": "フォローの義務がある",
-  "helpExamplePlay": "  p 0                  手札の 0 番のカードを出す"
+  "helpExampleHint": "  hint                 次の一手を教えてもらう"
 }

--- a/internal/i18n/locales/ja/colourwhist.json
+++ b/internal/i18n/locales/ja/colourwhist.json
@@ -38,5 +38,5 @@
   "hintPlay": "{{index}} 番目の札が良さそうです（{{reason}}）",
   "colourWhistBidStrength": "手札の強さから見た契約",
   "colourWhistFollowSuit": "フォローの義務がある",
-  "helpExampleHint": "  hint                 次の一手を教えてもらう"
+  "helpExampleGiveUp": "  g                    この局を投了する"
 }

--- a/internal/i18n/locales/ja/colourwhist.json
+++ b/internal/i18n/locales/ja/colourwhist.json
@@ -38,5 +38,5 @@
   "hintPlay": "{{index}} 番目の札が良さそうです（{{reason}}）",
   "colourWhistBidStrength": "手札の強さから見た契約",
   "colourWhistFollowSuit": "フォローの義務がある",
-  "helpExamplePass": "  pass                 競りを降りる"
+  "helpExamplePass": "  pass                 この競りには乗らない"
 }

--- a/internal/i18n/locales/ja/congress.json
+++ b/internal/i18n/locales/ja/congress.json
@@ -30,5 +30,7 @@
   "hintToTableau": "タブロー山{{pile}}",
   "hintToWaste": "捨て札へめくる",
   "hintLine": "ヒント: {{from}} → {{to}}",
-  "undoToEscape": "脱出には {{count}} 手戻す必要があります（undo {{count}} または u を繰り返す）"
+  "undoToEscape": "脱出には {{count}} 手戻す必要があります（undo {{count}} または u を繰り返す）",
+  "helpExampleHint": "  h                        次の一手を教えてもらう",
+  "helpExampleAuto": "  ac                       組札へ送れる札を自動で送る"
 }

--- a/internal/i18n/locales/ja/crazypineapple.json
+++ b/internal/i18n/locales/ja/crazypineapple.json
@@ -24,7 +24,6 @@
   "invalidTableSize": "無効なテーブルサイズです: {{val}}。4, 6, または 9 を入力してください。",
   "discardIdxRequired": "ディスカードするカードのインデックスが必要です。",
   "invalidDiscardIdx": "無効なカードインデックスです: {{val}}",
-  "helpExampleCheck": "  ck                   チェックして次のプレイヤーへ回す",
-  "helpExampleBet": "  b 100                100 チップをベットする",
-  "helpExampleRaise": "  ra 200               合計 200 チップになるようレイズする"
+  "helpExampleRaise": "  ra 200               合計 200 チップになるようレイズする",
+  "helpExampleCall": "  c                    現在のベットにコールする"
 }

--- a/internal/i18n/locales/ja/crazyquilt.json
+++ b/internal/i18n/locales/ja/crazyquilt.json
@@ -27,5 +27,7 @@
   "hintToFoundation": "組札{{idx}}",
   "hintToWaste": "捨て札へ",
   "hintLine": "ヒント: {{from}} → {{to}}",
-  "undoToEscape": "脱出には {{count}} 手戻す必要があります（undo {{count}} または u を繰り返す）"
+  "undoToEscape": "脱出には {{count}} 手戻す必要があります（undo {{count}} または u を繰り返す）",
+  "helpExampleHint": "  h                        次の一手を教えてもらう",
+  "helpExampleAuto": "  ac                       組札へ送れる札を自動で送る"
 }

--- a/internal/i18n/locales/ja/crescent.json
+++ b/internal/i18n/locales/ja/crescent.json
@@ -26,5 +26,7 @@
   "gameClear": "{{moveCount}}手でゲームクリア！",
   "gameOver": "ゲームオーバー",
   "hintAvailable": "ヒントあり",
-  "noHint": "ヒントなし"
+  "noHint": "ヒントなし",
+  "helpExampleHint": "  h                        次の一手を教えてもらう",
+  "helpExampleAuto": "  ac                       組札へ送れる札を自動で送る"
 }

--- a/internal/i18n/locales/ja/cruel.json
+++ b/internal/i18n/locales/ja/cruel.json
@@ -26,5 +26,7 @@
   "hintFrom": "タブロー列{{col}}",
   "hintToFoundation": "ファウンデーション",
   "hintToTableau": "タブロー列{{col}}",
-  "hintLine": "ヒント: {{from}} → {{to}}"
+  "hintLine": "ヒント: {{from}} → {{to}}",
+  "helpExampleHint": "  h                    次の一手を教えてもらう",
+  "helpExampleAuto": "  ac                   組札へ送れる札を自動で送る"
 }

--- a/internal/i18n/locales/ja/cucumber.json
+++ b/internal/i18n/locales/ja/cucumber.json
@@ -22,6 +22,5 @@
   "hintReasonLead": "リードなので何を出してもよい",
   "hintReasonBeat": "更新できる中でいちばん低い札。高い札は終盤に残さない",
   "hintReasonForced": "更新できないので、この札に決まっている",
-  "helpExamplePlay": "  p 0                  手札の 0 番のカードを出す",
-  "helpExampleNext": "  n                    ラウンドの結果を見てから次へ"
+  "helpExampleGiveUp": "  g                    この局を投了する"
 }

--- a/internal/i18n/locales/ja/daifugo.json
+++ b/internal/i18n/locales/ja/daifugo.json
@@ -33,6 +33,5 @@
   "promptTenDiscard": "【10捨て】捨てるカードを選択してください (p [インデックス])",
   "promptQueenBomber": "【12ボンバー】除去するカードの数字を入力してください (p [1-13])",
   "promptPlay": "p [インデックス...] でカードを出す / p でパス",
-  "helpExamplePlay": "  p 0 2                手札の 0 と 2 を出す (ペア)",
-  "helpExamplePass": "  p                    パスする (添字なし)"
+  "helpExamplePass": "  p                    出せる手が無いときはパスする"
 }

--- a/internal/i18n/locales/ja/deucetoseven.json
+++ b/internal/i18n/locales/ja/deucetoseven.json
@@ -37,5 +37,5 @@
   "hintExchange": "推奨: 手札 [{{idxs}}] ({{cards}}) を交換 (e {{cmd}})",
   "hintStandPat": "推奨: 完成ロー。スタンドパット (s) しましょう。",
   "hintNotYourTurn": "今はあなたのドローフェーズではありません。",
-  "helpExampleBet": "  b 100                100 チップを賭ける"
+  "helpExampleCall": "  c                    現在のベットにコールする"
 }

--- a/internal/i18n/locales/ja/deucetoseven.json
+++ b/internal/i18n/locales/ja/deucetoseven.json
@@ -37,5 +37,5 @@
   "hintExchange": "推奨: 手札 [{{idxs}}] ({{cards}}) を交換 (e {{cmd}})",
   "hintStandPat": "推奨: 完成ロー。スタンドパット (s) しましょう。",
   "hintNotYourTurn": "今はあなたのドローフェーズではありません。",
-  "helpExampleCall": "  c                    現在のベットにコールする"
+  "helpExampleFold": "  f                    この手を降りる"
 }

--- a/internal/i18n/locales/ja/diplomat.json
+++ b/internal/i18n/locales/ja/diplomat.json
@@ -29,5 +29,7 @@
   "hintToTableau": "タブロー列{{pile}}",
   "hintToWaste": "捨て札へめくる",
   "hintLine": "ヒント: {{from}} → {{to}}",
-  "undoToEscape": "脱出には {{count}} 手戻す必要があります（undo {{count}} または u を繰り返す）"
+  "undoToEscape": "脱出には {{count}} 手戻す必要があります（undo {{count}} または u を繰り返す）",
+  "helpExampleHint": "  h                        次の一手を教えてもらう",
+  "helpExampleAuto": "  ac                       組札へ送れる札を自動で送る"
 }

--- a/internal/i18n/locales/ja/doubleklondike.json
+++ b/internal/i18n/locales/ja/doubleklondike.json
@@ -12,5 +12,6 @@
   "hintLine": "[HINT: {{from}}{{fromCol}} → {{to}}{{toCol}}]",
   "zoneWaste": "ウェイスト",
   "zoneTableau": "タブロー",
-  "zoneFoundation": "ファウンデーション"
+  "zoneFoundation": "ファウンデーション",
+  "helpExampleUndo": "  u                                  直前の 1 手を取り消す"
 }

--- a/internal/i18n/locales/ja/doubleklondike.json
+++ b/internal/i18n/locales/ja/doubleklondike.json
@@ -13,5 +13,5 @@
   "zoneWaste": "ウェイスト",
   "zoneTableau": "タブロー",
   "zoneFoundation": "ファウンデーション",
-  "helpExampleUndo": "  u                                  直前の 1 手を取り消す"
+  "helpExampleDraw": "  d                     ストックから 1 枚めくる"
 }

--- a/internal/i18n/locales/ja/duchess.json
+++ b/internal/i18n/locales/ja/duchess.json
@@ -37,5 +37,7 @@
   "hintToWaste": "ウェイストへめくる",
   "hintToTableau": "タブロー列{{col}}",
   "hintLine": "ヒント: {{from}} → {{to}}",
-  "undoToEscape": "脱出には {{count}} 手戻す必要があります（undo {{count}} または u を繰り返す）"
+  "undoToEscape": "脱出には {{count}} 手戻す必要があります（undo {{count}} または u を繰り返す）",
+  "helpExampleHint": "  h                        次の一手を教えてもらう",
+  "helpExampleAuto": "  ac                       組札へ送れる札を自動で送る"
 }

--- a/internal/i18n/locales/ja/easthaven.json
+++ b/internal/i18n/locales/ja/easthaven.json
@@ -23,5 +23,7 @@
   "hintFrom": "タブロー列{{col}}[{{idx}}]",
   "hintToFoundation": "ファンデーション",
   "hintToTableau": "タブロー列{{col}}",
-  "hintLine": "ヒント: {{from}} → {{to}}"
+  "hintLine": "ヒント: {{from}} → {{to}}",
+  "helpExampleHint": "  h                    次の一手を教えてもらう",
+  "helpExampleAuto": "  ac                   組札へ送れる札を自動で送る"
 }

--- a/internal/i18n/locales/ja/escoba.json
+++ b/internal/i18n/locales/ja/escoba.json
@@ -20,5 +20,5 @@
   "promptNext": "n で次のラウンドを開始する",
   "promptCurrentTurn": "手番: {{name}}",
   "promptHelp": "p <hand> [table...] で捕獲または場に置く / n で次のラウンド",
-  "helpExamplePlay": "  p 0                      手札の 0 番のカードを出す"
+  "helpExampleNext": "  n                        ラウンドの結果を見てから次へ"
 }

--- a/internal/i18n/locales/ja/fivecardstud.json
+++ b/internal/i18n/locales/ja/fivecardstud.json
@@ -55,7 +55,6 @@
   "rebuyPrompt": "リバイしますか? ({{chips}}チップ, {{used}}/{{max}}回使用済) (rb=リバイ / sr=スキップ)",
   "addonPrompt": "アドオンしますか? ({{chips}}チップ) (ad=アドオン / sa=スキップ)",
   "gameEnd": "ゲーム終了",
-  "helpExampleCheck": "  ck                   チェックして次のプレイヤーへ回す",
-  "helpExampleBet": "  b 100                100 チップをベットする",
-  "helpExampleRaise": "  ra 200               合計 200 チップになるようレイズする"
+  "helpExampleRaise": "  ra 200               合計 200 チップになるようレイズする",
+  "helpExampleCall": "  c                    現在のベットにコールする"
 }

--- a/internal/i18n/locales/ja/fivecardstud.json
+++ b/internal/i18n/locales/ja/fivecardstud.json
@@ -55,6 +55,5 @@
   "rebuyPrompt": "リバイしますか? ({{chips}}チップ, {{used}}/{{max}}回使用済) (rb=リバイ / sr=スキップ)",
   "addonPrompt": "アドオンしますか? ({{chips}}チップ) (ad=アドオン / sa=スキップ)",
   "gameEnd": "ゲーム終了",
-  "helpExampleRaise": "  ra 200               合計 200 チップになるようレイズする",
-  "helpExampleCall": "  c                    現在のベットにコールする"
+  "helpExampleFold": "  f                    この手を降りる"
 }

--- a/internal/i18n/locales/ja/flowergarden.json
+++ b/internal/i18n/locales/ja/flowergarden.json
@@ -15,5 +15,7 @@
   "hintFromReserve": "ブーケ{{idx}}",
   "hintToFoundation": "ファンデーション",
   "hintToTableau": "フラワーベッド{{col}}",
-  "hintLine": "ヒント: {{from}} → {{to}}"
+  "hintLine": "ヒント: {{from}} → {{to}}",
+  "helpExampleHint": "  h                    次の一手を教えてもらう",
+  "helpExampleAuto": "  ac                   組札へ送れる札を自動で送る"
 }

--- a/internal/i18n/locales/ja/fortyandeight.json
+++ b/internal/i18n/locales/ja/fortyandeight.json
@@ -22,5 +22,7 @@
   "hintToFoundation": "ファンデーション",
   "hintToTableau": "タブロー列{{col}}",
   "hintLine": "ヒント: {{from}} → {{to}}",
-  "foundationLabel": "[f{{idx}}]"
+  "foundationLabel": "[f{{idx}}]",
+  "helpExampleHint": "  h                    次の一手を教えてもらう",
+  "helpExampleAuto": "  ac                   組札へ送れる札を自動で送る"
 }

--- a/internal/i18n/locales/ja/fortyfives.json
+++ b/internal/i18n/locales/ja/fortyfives.json
@@ -45,7 +45,5 @@
   "contractMade": "成立",
   "contractFailed": "不成立が確定",
   "contractNeedMore": "あと{{remaining}}点",
-  "helpExampleBid": "  bid 20                   20 点を宣言する",
-  "helpExamplePlay": "  play 0                   手札の 0 番のカードを出す",
-  "helpExampleNext": "  n                        トリックの決着を見てから次のトリックへ"
+  "helpExampleBid": "  pass                      入札を降りる"
 }

--- a/internal/i18n/locales/ja/fortythieves.json
+++ b/internal/i18n/locales/ja/fortythieves.json
@@ -18,5 +18,7 @@
   "hintFromWaste": "ウェイスト",
   "hintToFoundation": "ファンデーション",
   "hintToTableau": "タブロー列{{col}}",
-  "hintLine": "ヒント: {{from}} → {{to}}"
+  "hintLine": "ヒント: {{from}} → {{to}}",
+  "helpExampleHint": "  h                    次の一手を教えてもらう",
+  "helpExampleAuto": "  ac                   組札へ送れる札を自動で送る"
 }

--- a/internal/i18n/locales/ja/fourseasons.json
+++ b/internal/i18n/locales/ja/fourseasons.json
@@ -31,5 +31,7 @@
   "gameClear": "ゲームクリア！ 手数: {{moveCount}}",
   "gameOver": "ゲームオーバー",
   "hintAvailable": "ヒントがあります",
-  "noHint": "ヒントはありません"
+  "noHint": "ヒントはありません",
+  "helpExampleHint": "  h                   次の一手を教えてもらう",
+  "helpExampleAuto": "  ac                  組札へ送れる札を自動で送る"
 }

--- a/internal/i18n/locales/ja/gaps.json
+++ b/internal/i18n/locales/ja/gaps.json
@@ -18,5 +18,6 @@
   "lockedLegend": "* = 再配布で保持されるカード",
   "gapBlocked": "[ x ]",
   "gapAnySuit": "[{{rank}}?]",
-  "gapNeeded": "[{{card}}]"
+  "gapNeeded": "[{{card}}]",
+  "helpExampleHint": "  h                         次の一手を教えてもらう"
 }

--- a/internal/i18n/locales/ja/grandfathersclock.json
+++ b/internal/i18n/locales/ja/grandfathersclock.json
@@ -18,5 +18,7 @@
   "hintToFoundation": "文字盤{{idx}}",
   "hintToTableau": "タブロー列{{col}}",
   "hintLine": "ヒント: {{from}} → {{to}}",
-  "undoToEscape": "脱出には {{count}} 手戻す必要があります（undo {{count}} または u を繰り返す）"
+  "undoToEscape": "脱出には {{count}} 手戻す必要があります（undo {{count}} または u を繰り返す）",
+  "helpExampleHint": "  h                    次の一手を教えてもらう",
+  "helpExampleAuto": "  ac                   組札へ送れる札を自動で送る"
 }

--- a/internal/i18n/locales/ja/holdem.json
+++ b/internal/i18n/locales/ja/holdem.json
@@ -56,7 +56,6 @@
   "addonPrompt": "アドオンしますか? ({{chips}}チップ) (ad=アドオン / sa=スキップ)",
   "gameEnd": "ゲーム終了",
   "resultBestFive": " [{{cards}}]",
-  "helpExampleCheck": "  ck                   チェックして次のプレイヤーへ回す",
-  "helpExampleBet": "  b 100                100 チップをベットする",
-  "helpExampleRaise": "  ra 200               合計 200 チップになるようレイズする"
+  "helpExampleRaise": "  ra 200               合計 200 チップになるようレイズする",
+  "helpExampleCall": "  c                    現在のベットにコールする"
 }

--- a/internal/i18n/locales/ja/honeymoonbridge.json
+++ b/internal/i18n/locales/ja/honeymoonbridge.json
@@ -34,5 +34,5 @@
   "suitHeart": "♥",
   "suitDiamond": "♦",
   "suitNoTrump": "NT",
-  "helpExamplePlay": "  p 0                  手札の 0 番のカードを出す"
+  "helpExampleGiveUp": "  g                    この局を投了する"
 }

--- a/internal/i18n/locales/ja/indianpoker.json
+++ b/internal/i18n/locales/ja/indianpoker.json
@@ -37,5 +37,5 @@
   "resultName": "  {{name}}",
   "wonAmount": " → {{total}}チップ獲得",
   "gameEnd": "ゲーム終了",
-  "helpExampleBet": "  b 100                100 チップを賭ける"
+  "helpExampleFold": "  f                    この手を降りる"
 }

--- a/internal/i18n/locales/ja/irishpoker.json
+++ b/internal/i18n/locales/ja/irishpoker.json
@@ -24,7 +24,6 @@
   "invalidTableSize": "無効なテーブルサイズです: {{val}}。4, 6, または 9 を入力してください。",
   "discardIdxRequired": "ディスカードするカードのインデックスが必要です。",
   "invalidDiscardIdx": "無効なカードインデックスです: {{val}}",
-  "helpExampleCheck": "  ck                   チェックして次のプレイヤーへ回す",
-  "helpExampleBet": "  b 100                100 チップをベットする",
-  "helpExampleRaise": "  ra 200               合計 200 チップになるようレイズする"
+  "helpExampleRaise": "  ra 200               合計 200 チップになるようレイズする",
+  "helpExampleCall": "  c                    現在のベットにコールする"
 }

--- a/internal/i18n/locales/ja/kingalbert.json
+++ b/internal/i18n/locales/ja/kingalbert.json
@@ -16,5 +16,7 @@
   "hintFromReserve": "リザーブ{{idx}}",
   "hintToFoundation": "ファンデーション",
   "hintToTableau": "タブロー列{{col}}",
-  "hintLine": "ヒント: {{from}} → {{to}}"
+  "hintLine": "ヒント: {{from}} → {{to}}",
+  "helpExampleHint": "  h                    次の一手を教えてもらう",
+  "helpExampleAuto": "  ac                   組札へ送れる札を自動で送る"
 }

--- a/internal/i18n/locales/ja/klondike.json
+++ b/internal/i18n/locales/ja/klondike.json
@@ -26,7 +26,5 @@
   "hintToTableau": "タブロー列{{col}}",
   "hintLine": "ヒント: {{from}} → {{to}}",
   "autoCompleteReady": "オートコンプリート可能です (ac)",
-  "helpExampleDraw": "  d                    山札から1枚めくる",
-  "helpExampleMove": "  m w t 1              ウェイストから列1へ移す",
-  "helpExampleFound": "  m w f                ウェイストからファウンデーションへ"
+  "helpExampleDraw": "  d                    山札から1枚めくる"
 }

--- a/internal/i18n/locales/ja/labellelucie.json
+++ b/internal/i18n/locales/ja/labellelucie.json
@@ -13,5 +13,6 @@
   "hintLine": "[HINT: 扇{{from}} を {{to}} へ]",
   "foundationCount": "(計{{count}}枚)",
   "redealRecommended": "合法手がありません。nr でリディールを推奨します。",
-  "stuckDeadlock": "これ以上動かせる手がありません。再配札も残っていません — giveup でギブアップできます。"
+  "stuckDeadlock": "これ以上動かせる手がありません。再配札も残っていません — giveup でギブアップできます。",
+  "helpExampleAuto": "  ac                   組札へ送れる札を自動で送る"
 }

--- a/internal/i18n/locales/ja/mendikot.json
+++ b/internal/i18n/locales/ja/mendikot.json
@@ -31,6 +31,5 @@
   "suitClover": "クラブ",
   "suitHeart": "ハート",
   "suitDiamond": "ダイヤ",
-  "helpExamplePlay": "  p 0                  手札の 0 番のカードを出す",
-  "helpExampleNext": "  n                    ラウンドの結果を見てから次へ"
+  "helpExampleGiveUp": "  g                    この局を投了する"
 }

--- a/internal/i18n/locales/ja/michigan.json
+++ b/internal/i18n/locales/ja/michigan.json
@@ -45,5 +45,5 @@
   "roundEndHumanLose": "他のプレイヤーの方が稼ぎました。",
   "result.humanWin": "ゲーム終了！あなたの勝ち！",
   "result.cpuWin": "ゲーム終了！CPU {{player}} の勝ち！",
-  "helpExampleBet": "  b 25 25 25 25             4 つのブードルに 25 ずつ賭ける"
+  "helpExampleNext": "  n                         次のディールへ進む"
 }

--- a/internal/i18n/locales/ja/minibridge.json
+++ b/internal/i18n/locales/ja/minibridge.json
@@ -33,5 +33,5 @@
   "suitHeart": "♥",
   "suitDiamond": "♦",
   "suitNoTrump": "NT",
-  "helpExamplePlay": "  p 0                  手札の 0 番のカードを出す"
+  "helpExampleGiveUp": "  g                    この局を投了する"
 }

--- a/internal/i18n/locales/ja/missmilligan.json
+++ b/internal/i18n/locales/ja/missmilligan.json
@@ -27,5 +27,7 @@
   "hintToTableau": "タブロー列{{col}}",
   "hintToDeal": "各列へ配り足す",
   "hintLine": "ヒント: {{from}} → {{to}}",
-  "undoToEscape": "脱出には {{count}} 手戻す必要があります（undo {{count}} または u を繰り返す）"
+  "undoToEscape": "脱出には {{count}} 手戻す必要があります（undo {{count}} または u を繰り返す）",
+  "helpExampleHint": "  h                        次の一手を教えてもらう",
+  "helpExampleAuto": "  ac                       組札へ送れる札を自動で送る"
 }

--- a/internal/i18n/locales/ja/nainjaune.json
+++ b/internal/i18n/locales/ja/nainjaune.json
@@ -27,6 +27,5 @@
   "hintReasonLead": "並びが止まっているので、低い札から始めます",
   "hintReasonFollow": "並びの続きになる札です",
   "hintReasonBox": "この札は区画のチップを取れます",
-  "helpExamplePlay": "  p 0                      手札の 0 番のカードを出す",
   "helpExampleNext": "  n                        トリックの決着を見てから次へ"
 }

--- a/internal/i18n/locales/ja/nap.json
+++ b/internal/i18n/locales/ja/nap.json
@@ -42,7 +42,5 @@
   "promptBidHolder": "現在の最高入札者: {{name}}",
   "declarerProgress": "宣言者: {{won}}/{{needed}} トリック (残り{{remaining}})",
   "contractUnreachable": " — 達成不可能が確定",
-  "helpExampleBid": "  bid 3                    3 トリックを宣言する",
-  "helpExamplePlay": "  play 0                   手札の 0 番のカードを出す",
-  "helpExampleNext": "  n                        トリックの決着を見てから次のトリックへ"
+  "helpExampleBid": "  pass                      入札を降りる"
 }

--- a/internal/i18n/locales/ja/napoleonssquare.json
+++ b/internal/i18n/locales/ja/napoleonssquare.json
@@ -26,5 +26,7 @@
   "hintToWaste": "ウェイスト",
   "hintToTableau": "タブロー列{{col}}",
   "hintLine": "ヒント: {{from}} → {{to}}",
-  "undoToEscape": "脱出には {{count}} 手戻す必要があります（undo {{count}} または u を繰り返す）"
+  "undoToEscape": "脱出には {{count}} 手戻す必要があります（undo {{count}} または u を繰り返す）",
+  "helpExampleHint": "  h                        次の一手を教えてもらう",
+  "helpExampleAuto": "  ac                       組札へ送れる札を自動で送る"
 }

--- a/internal/i18n/locales/ja/nertz.json
+++ b/internal/i18n/locales/ja/nertz.json
@@ -41,5 +41,6 @@
   "zoneWaste": "ウェイスト",
   "zoneTableau": "タブロー{{col}}",
   "zoneTableauWithIdx": "タブロー{{col}}(idx={{idx}})",
-  "zoneFoundation": "ファウンデーション{{col}}"
+  "zoneFoundation": "ファウンデーション{{col}}",
+  "helpExampleHint": "  h                   次の一手を教えてもらう"
 }

--- a/internal/i18n/locales/ja/omaha.json
+++ b/internal/i18n/locales/ja/omaha.json
@@ -47,7 +47,6 @@
   "gameEnd": "ゲーム終了",
   "hiLoRuleLine": "※ロー: 8以下5枚(8 or Better)。不成立時はHiが総取り",
   "currentBestHand": "現在の最善役: {{hand}} ({{cards}})",
-  "helpExampleCheck": "  ck                   チェックして次のプレイヤーへ回す",
-  "helpExampleBet": "  b 100                100 チップをベットする",
-  "helpExampleRaise": "  ra 200               合計 200 チップになるようレイズする"
+  "helpExampleRaise": "  ra 200               合計 200 チップになるようレイズする",
+  "helpExampleCall": "  c                    現在のベットにコールする"
 }

--- a/internal/i18n/locales/ja/osmosis.json
+++ b/internal/i18n/locales/ja/osmosis.json
@@ -29,5 +29,7 @@
   "hintToFoundation": "組札{{idx}}段",
   "allowedRanks": "[置ける: {{ranks}}]",
   "anyRank": "任意ランク",
-  "hintLine": "ヒント: {{from}} → {{to}} (配置可能: {{allowed}})"
+  "hintLine": "ヒント: {{from}} → {{to}} (配置可能: {{allowed}})",
+  "helpExampleHint": "  h                    次の一手を教えてもらう",
+  "helpExampleAuto": "  ac                   組札へ送れる札を自動で送る"
 }

--- a/internal/i18n/locales/ja/pasur.json
+++ b/internal/i18n/locales/ja/pasur.json
@@ -19,5 +19,5 @@
   "hintReasonSoor": "場を空にできる。この捕獲は得点が2倍",
   "hintReasonCapture": "点になる札を取れる",
   "hintReasonTrail": "取れる組み合わせが無い。いちばん点にならない札を置く",
-  "helpExamplePlay": "  p 0                  手札の 0 番のカードを出す"
+  "helpExampleGiveUp": "  g                    この局を投了する"
 }

--- a/internal/i18n/locales/ja/pineapple.json
+++ b/internal/i18n/locales/ja/pineapple.json
@@ -63,7 +63,6 @@
   "discardCandidate": "  [{{idx}}] これを捨てると: {{hand}}",
   "discardRecommended": " ← おすすめ",
   "discardCandidatePair": "  [{{idx0}}] [{{idx1}}] を捨てると: {{hand}}",
-  "helpExampleCheck": "  ck                   チェックして次のプレイヤーへ回す",
-  "helpExampleBet": "  b 100                100 チップをベットする",
-  "helpExampleRaise": "  ra 200               合計 200 チップになるようレイズする"
+  "helpExampleRaise": "  ra 200               合計 200 チップになるようレイズする",
+  "helpExampleCall": "  c                    現在のベットにコールする"
 }

--- a/internal/i18n/locales/ja/poker.json
+++ b/internal/i18n/locales/ja/poker.json
@@ -44,5 +44,5 @@
   "phaseEnd": "終了",
   "promptBet": "操作: bet <額> / call / raise <額> / fold",
   "promptExchange": "操作: exchange <カード番号...>（交換なしは exchange のみ）",
-  "helpExampleBet": "  b 100                100 チップを賭ける"
+  "helpExampleCall": "  c                    現在のベットにコールする"
 }

--- a/internal/i18n/locales/ja/poker.json
+++ b/internal/i18n/locales/ja/poker.json
@@ -44,5 +44,5 @@
   "phaseEnd": "終了",
   "promptBet": "操作: bet <額> / call / raise <額> / fold",
   "promptExchange": "操作: exchange <カード番号...>（交換なしは exchange のみ）",
-  "helpExampleCall": "  c                    現在のベットにコールする"
+  "helpExampleFold": "  f                    この手を降りる"
 }

--- a/internal/i18n/locales/ja/popejoan.json
+++ b/internal/i18n/locales/ja/popejoan.json
@@ -30,6 +30,5 @@
   "hintReasonNotYourTurn": "あなたの手番ではありません",
   "hintReasonLead": "並びが止まっているので、最も低い札から始めます",
   "hintReasonFollow": "同じスートの次に高い札です",
-  "helpExamplePlay": "  p 0                      手札の 0 番のカードを出す",
   "helpExampleNext": "  n                        トリックの決着を見てから次へ"
 }

--- a/internal/i18n/locales/ja/preference.json
+++ b/internal/i18n/locales/ja/preference.json
@@ -45,7 +45,5 @@
   "roundEnd": "ラウンド終了",
   "result.humanWin": "ゲーム終了！ あなたの勝ち！",
   "result.cpuWin": "ゲーム終了！ プレイヤー{{player}}の勝ち！",
-  "helpExampleBid": "  bid 1                    シックスを宣言する",
-  "helpExamplePlay": "  play 0                   手札の 0 番のカードを出す",
-  "helpExampleNext": "  n                        トリックの決着を見てから次のトリックへ"
+  "helpExampleBid": "  pass                      入札を降りる"
 }

--- a/internal/i18n/locales/ja/reversis.json
+++ b/internal/i18n/locales/ja/reversis.json
@@ -22,6 +22,5 @@
   "hintReasonAvoidPoints": "失点札が乗っているので取らない",
   "hintReasonLeadSafe": "失点にならない低い札でリードする",
   "hintReasonDumpHigh": "安全なうちに高い札を処分する",
-  "helpExamplePlay": "  p 0                  手札の 0 番のカードを出す",
-  "helpExampleNext": "  n                    ラウンドの結果を見てから次へ"
+  "helpExampleGiveUp": "  g                    この局を投了する"
 }

--- a/internal/i18n/locales/ja/rikken.json
+++ b/internal/i18n/locales/ja/rikken.json
@@ -38,5 +38,5 @@
   "rikkenBidStrength": "手札の強さから見た契約",
   "rikkenFollowSuit": "フォローの義務がある",
   "openHandLine": "公開手札（席 {{seat}}）: {{cards}}",
-  "helpExamplePlay": "  p 0                  手札の 0 番のカードを出す"
+  "helpExampleHint": "  hint                 次の一手を教えてもらう"
 }

--- a/internal/i18n/locales/ja/royalcotillion.json
+++ b/internal/i18n/locales/ja/royalcotillion.json
@@ -35,5 +35,7 @@
   "hintToTableau": "タブロー枠{{pile}}",
   "hintToWaste": "捨て札へめくる",
   "hintLine": "ヒント: {{from}} → {{to}}",
-  "undoToEscape": "脱出には {{count}} 手戻す必要があります（undo {{count}} または u を繰り返す）"
+  "undoToEscape": "脱出には {{count}} 手戻す必要があります（undo {{count}} または u を繰り返す）",
+  "helpExampleHint": "  h                        次の一手を教えてもらう",
+  "helpExampleAuto": "  ac                       組札へ送れる札を自動で送る"
 }

--- a/internal/i18n/locales/ja/russiansolitaire.json
+++ b/internal/i18n/locales/ja/russiansolitaire.json
@@ -21,5 +21,7 @@
   "hintFrom": "タブロー列{{col}}[{{idx}}]",
   "hintToFoundation": "ファンデーション",
   "hintToTableau": "タブロー列{{col}}",
-  "hintLine": "ヒント: {{from}} → {{to}}"
+  "hintLine": "ヒント: {{from}} → {{to}}",
+  "helpExampleHint": "  h                    次の一手を教えてもらう",
+  "helpExampleAuto": "  ac                   組札へ送れる札を自動で送る"
 }

--- a/internal/i18n/locales/ja/scopa.json
+++ b/internal/i18n/locales/ja/scopa.json
@@ -28,6 +28,5 @@
   "category.denari": "デナリ(ダイヤ最多)",
   "category.primiera": "プリミエラ(7最多)",
   "category.settebello": "セッテベッロ(7♦)",
-  "helpExamplePlay": "  p 0                      手札の 0 番を場に置く (場札を取らない)",
   "helpExampleNext": "  n                        ラウンドの結果を見てから次へ"
 }

--- a/internal/i18n/locales/ja/scopone.json
+++ b/internal/i18n/locales/ja/scopone.json
@@ -20,5 +20,5 @@
   "promptNext": "n で次のラウンドを開始する",
   "promptCurrentTurn": "手番: {{name}} (チーム{{team}})",
   "promptHelp": "p <hand> [table...] で捕獲または場に置く / n で次のラウンド",
-  "helpExamplePlay": "  p 0                      手札の 0 番のカードを出す"
+  "helpExampleNext": "  n                        ラウンドの結果を見てから次へ"
 }

--- a/internal/i18n/locales/ja/scorpion.json
+++ b/internal/i18n/locales/ja/scorpion.json
@@ -26,5 +26,7 @@
   "legalTargetEmpty": "  列{{col}} (空列 — Kのみ可)",
   "legalNone": "  なし",
   "legalNoCard": "列{{col}}には移動可能な表向きカードがありません",
-  "legalNotPlaying": "表示できる合法手はありません（プレイ中ではありません）"
+  "legalNotPlaying": "表示できる合法手はありません（プレイ中ではありません）",
+  "helpExampleHint": "  h                    次の一手を教えてもらう",
+  "helpExampleAuto": "  ac                   組札へ送れる札を自動で送る"
 }

--- a/internal/i18n/locales/ja/sevencardstud.json
+++ b/internal/i18n/locales/ja/sevencardstud.json
@@ -76,7 +76,5 @@
   "hintReasonRazzDecent": "ロー札はそこそこある",
   "hintReasonRazzWeak": "ロー札が足りない",
   "hintReasonHiLoLow": "ロー役が狙える (8以下が5枚)",
-  "helpExampleCheck": "  ck                   チェックして次のプレイヤーへ回す",
-  "helpExampleBet": "  b 100                100 チップをベットする",
-  "helpExampleRaise": "  ra 200               合計 200 チップになるようレイズする"
+  "helpExampleFold": "  f                    この手を降りる"
 }

--- a/internal/i18n/locales/ja/shortdeck.json
+++ b/internal/i18n/locales/ja/shortdeck.json
@@ -48,7 +48,6 @@
   "handRank7": "フォーカード",
   "handRank8": "ストレートフラッシュ",
   "handRank9": "ロイヤルフラッシュ",
-  "helpExampleCheck": "  ck                   チェックして次のプレイヤーへ回す",
-  "helpExampleBet": "  b 100                100 チップをベットする",
-  "helpExampleRaise": "  ra 200               合計 200 チップになるようレイズする"
+  "helpExampleRaise": "  ra 200               合計 200 チップになるようレイズする",
+  "helpExampleCall": "  c                    現在のベットにコールする"
 }

--- a/internal/i18n/locales/ja/simplesimon.json
+++ b/internal/i18n/locales/ja/simplesimon.json
@@ -5,6 +5,5 @@
   "helpGiveUp": "  g / giveup           投了する",
   "colLabel": "列{{idx}}:",
   "completedLine": "完成スート: {{count}} / 4",
-  "hintLine": "[HINT: 列{{from}}[{{idx}}] を 列{{to}} へ]",
-  "helpExampleUndo": "  u                    直前の 1 手を取り消す"
+  "hintLine": "[HINT: 列{{from}}[{{idx}}] を 列{{to}} へ]"
 }

--- a/internal/i18n/locales/ja/simplesimon.json
+++ b/internal/i18n/locales/ja/simplesimon.json
@@ -5,5 +5,6 @@
   "helpGiveUp": "  g / giveup           投了する",
   "colLabel": "列{{idx}}:",
   "completedLine": "完成スート: {{count}} / 4",
-  "hintLine": "[HINT: 列{{from}}[{{idx}}] を 列{{to}} へ]"
+  "hintLine": "[HINT: 列{{from}}[{{idx}}] を 列{{to}} へ]",
+  "helpExampleUndo": "  u                    直前の 1 手を取り消す"
 }

--- a/internal/i18n/locales/ja/slobberhannes.json
+++ b/internal/i18n/locales/ja/slobberhannes.json
@@ -23,6 +23,5 @@
   "hintReasonAvoid": "罰点のトリックなので取らない",
   "hintReasonDump": "安全なうちに高い札を処分する",
   "hintReasonLeadLow": "低い札でリードして様子を見る",
-  "helpExamplePlay": "  p 0                  手札の 0 番のカードを出す",
-  "helpExampleNext": "  n                    ラウンドの結果を見てから次へ"
+  "helpExampleGiveUp": "  g                    この局を投了する"
 }

--- a/internal/i18n/locales/ja/soko.json
+++ b/internal/i18n/locales/ja/soko.json
@@ -55,7 +55,5 @@
   "rebuyPrompt": "リバイしますか? ({{chips}}チップ, {{used}}/{{max}}回使用済) (rb=リバイ / sr=スキップ)",
   "addonPrompt": "アドオンしますか? ({{chips}}チップ) (ad=アドオン / sa=スキップ)",
   "gameEnd": "ゲーム終了",
-  "helpExampleCheck": "  ck                   チェックして次のプレイヤーへ回す",
-  "helpExampleBet": "  b 100                100 チップをベットする",
-  "helpExampleRaise": "  ra 200               合計 200 チップになるようレイズする"
+  "helpExampleFold": "  f                    この手を降りる"
 }

--- a/internal/i18n/locales/ja/solowhist.json
+++ b/internal/i18n/locales/ja/solowhist.json
@@ -39,7 +39,5 @@
   "result.humanWin": "ゲーム終了！ あなたの勝ち！",
   "result.cpuWin": "ゲーム終了！ プレイヤー{{player}}の勝ち！",
   "bidHistory": "ビッド状況: {{bids}}",
-  "helpExampleBid": "  bid 1                    ソロを宣言する",
-  "helpExamplePlay": "  play 0                   手札の 0 番のカードを出す",
-  "helpExampleNext": "  n                        トリックの決着を見てから次のトリックへ"
+  "helpExampleBid": "  pass                      入札を降りる"
 }

--- a/internal/i18n/locales/ja/speed.json
+++ b/internal/i18n/locales/ja/speed.json
@@ -14,6 +14,5 @@
   "promptStuckHelp": "操作: f / flip → お互いが山札から新しいカードをめくり、膠着を解消します",
   "winHuman": "あなたの勝ちです！",
   "winCpu": "CPUの勝ちです...",
-  "helpExamplePlay": "  p 0 1                手札0を場札1へ重ねる",
-  "helpExampleFlip": "  f                    場札を1枚めくる (詰まったとき)"
+  "helpExampleHint": "  h                    次の一手を教えてもらう"
 }

--- a/internal/i18n/locales/ja/spider.json
+++ b/internal/i18n/locales/ja/spider.json
@@ -11,5 +11,7 @@
   "gameClearLine": "ゲームクリア！ 手数: {{moves}} スコア: {{score}}",
   "hintLine": "ヒント: タブロー列{{fromCol}}[{{idx}}] → タブロー列{{toCol}}",
   "difficultyLine": "難易度: {{suits}}スート / 残りディール: {{deals}}回",
-  "dealBlockedEmpty": "空の列があるためディール不可（全列にカードを置いてください）"
+  "dealBlockedEmpty": "空の列があるためディール不可（全列にカードを置いてください）",
+  "helpExampleHint": "  h                        次の一手を教えてもらう",
+  "helpExampleAuto": "  ac                       組札へ送れる札を自動で送る"
 }

--- a/internal/i18n/locales/ja/spiderette.json
+++ b/internal/i18n/locales/ja/spiderette.json
@@ -10,5 +10,7 @@
   "columnLabel": "列{{col}}:",
   "gameClearLine": "ゲームクリア！ 手数: {{moves}} スコア: {{score}}",
   "hintLine": "ヒント: タブロー列{{fromCol}}[{{idx}}] → タブロー列{{toCol}}",
-  "dealsRemaining": " | 残り配布: {{count}}回"
+  "dealsRemaining": " | 残り配布: {{count}}回",
+  "helpExampleHint": "  h                        次の一手を教えてもらう",
+  "helpExampleAuto": "  ac                       組札へ送れる札を自動で送る"
 }

--- a/internal/i18n/locales/ja/sultan.json
+++ b/internal/i18n/locales/ja/sultan.json
@@ -22,5 +22,7 @@
   "promptSourceZone": "移動元を指定してください (d <idx> または w)",
   "promptDivanIndex": "ディヴァンのスロット番号を指定してください",
   "invalidDivanIndex": "無効なディヴァン番号です: {{val}}",
-  "invalidFromZone": "無効な移動元です: {{val}}"
+  "invalidFromZone": "無効な移動元です: {{val}}",
+  "helpExampleHint": "  h                    次の一手を教えてもらう",
+  "helpExampleAuto": "  ac                   組札へ送れる札を自動で送る"
 }

--- a/internal/i18n/locales/ja/tarabish.json
+++ b/internal/i18n/locales/ja/tarabish.json
@@ -36,5 +36,5 @@
   "suitClover": "クラブ",
   "suitHeart": "ハート",
   "suitDiamond": "ダイヤ",
-  "helpExamplePlay": "  p 0                  手札の 0 番のカードを出す"
+  "helpExampleNext": "  n                    トリックの決着を見てから次へ"
 }

--- a/internal/i18n/locales/ja/terrace.json
+++ b/internal/i18n/locales/ja/terrace.json
@@ -36,5 +36,7 @@
   "hintToTableau": "タブロー山{{pile}}",
   "hintToWaste": "捨て札へめくる",
   "hintLine": "ヒント: {{from}} → {{to}}",
-  "undoToEscape": "脱出には {{count}} 手戻す必要があります（undo {{count}} または u を繰り返す）"
+  "undoToEscape": "脱出には {{count}} 手戻す必要があります（undo {{count}} または u を繰り返す）",
+  "helpExampleHint": "  h                        次の一手を教えてもらう",
+  "helpExampleAuto": "  ac                       組札へ送れる札を自動で送る"
 }

--- a/internal/i18n/locales/ja/tienlen.json
+++ b/internal/i18n/locales/ja/tienlen.json
@@ -19,7 +19,5 @@
   "comboStraight": "ストレート",
   "comboThreePairRun": "3連ペア",
   "comboFourOfAKind": "フォーカード",
-  "comboInvalid": "不明",
-  "helpExamplePlay": "  p 0                  手札の 0 番を 1 枚出す",
-  "helpExamplePass": "  p                    指定なしでパスする"
+  "comboInvalid": "不明"
 }

--- a/internal/i18n/locales/ja/toepen.json
+++ b/internal/i18n/locales/ja/toepen.json
@@ -27,5 +27,5 @@
   "hintReasonPlay": "この札が最も安く取りに行けます",
   "helpRedeal": "  d                        貧民（A/K/Q/J のみ）の手札を捨てて配り直す",
   "promptRedeal": "手札が A/K/Q/J だけです。d で配り直しを要求できます",
-  "helpExamplePlay": "  p 0                      手札の 0 番のカードを出す"
+  "helpExampleFold": "  f                        この局を降りる"
 }

--- a/internal/i18n/locales/ja/twentynine.json
+++ b/internal/i18n/locales/ja/twentynine.json
@@ -41,7 +41,5 @@
   "roundEnd": "ラウンド終了",
   "result.humanWin": "ゲーム終了！ あなたのチームの勝ち！",
   "result.cpuWin": "ゲーム終了！ チーム{{team}}の勝ち！",
-  "helpExampleBid": "  bid 20                   20 点を宣言する",
-  "helpExamplePlay": "  play 0                   手札の 0 番のカードを出す",
-  "helpExampleNext": "  n                        トリックの決着を見てから次のトリックへ"
+  "helpExampleBid": "  pass                      入札を降りる"
 }

--- a/internal/i18n/locales/ja/vira.json
+++ b/internal/i18n/locales/ja/vira.json
@@ -40,7 +40,5 @@
   "helpNext": "  n                    次のトリックへ",
   "helpNextRound": "  nr                   次のラウンドへ",
   "helpSetDifficulty": "  sd [0-2]             CPU難易度 (0=Easy, 1=Normal, 2=Hard)",
-  "helpExampleBid": "  b 2                  ソロを宣言する",
-  "helpExamplePlay": "  play 0               手札の 0 番のカードを出す",
-  "helpExampleNext": "  n                    トリックの決着を見てから次のトリックへ"
+  "helpExampleBid": "  pass                 入札を降りる"
 }

--- a/internal/i18n/locales/ja/wasp.json
+++ b/internal/i18n/locales/ja/wasp.json
@@ -26,5 +26,7 @@
   "legalTargetEmpty": "  列{{col}} (空列 — 任意のカード可)",
   "legalNone": "  なし",
   "legalNoCard": "列{{col}}には移動可能な表向きカードがありません",
-  "legalNotPlaying": "表示できる合法手はありません（プレイ中ではありません）"
+  "legalNotPlaying": "表示できる合法手はありません（プレイ中ではありません）",
+  "helpExampleHint": "  h                    次の一手を教えてもらう",
+  "helpExampleAuto": "  ac                   組札へ送れる札を自動で送る"
 }

--- a/internal/i18n/locales/ja/windmill.json
+++ b/internal/i18n/locales/ja/windmill.json
@@ -34,5 +34,7 @@
   "hintToCorner": "四隅基礎札{{idx}}",
   "hintToWaste": "捨て札へめくる",
   "hintLine": "ヒント: {{from}} → {{to}}",
-  "undoToEscape": "脱出には {{count}} 手戻す必要があります（undo {{count}} または u を繰り返す）"
+  "undoToEscape": "脱出には {{count}} 手戻す必要があります（undo {{count}} または u を繰り返す）",
+  "helpExampleHint": "  h                        次の一手を教えてもらう",
+  "helpExampleAuto": "  ac                       組札へ送れる札を自動で送る"
 }

--- a/internal/i18n/locales/ja/yukon.json
+++ b/internal/i18n/locales/ja/yukon.json
@@ -24,5 +24,7 @@
   "hintToTableau": "タブロー列{{col}}",
   "hintLine": "ヒント: {{from}} → {{to}} {{confidence}}",
   "hintConfidenceFoundation": "（優先度: 高・基礎へ送れる安全手）",
-  "hintConfidenceTableau": "（優先度: 中・盤面を整える手）"
+  "hintConfidenceTableau": "（優先度: 中・盤面を整える手）",
+  "helpExampleHint": "  h                    次の一手を教えてもらう",
+  "helpExampleAuto": "  ac                   組札へ送れる札を自動で送る"
 }

--- a/internal/i18n/locales/ja/zheng.json
+++ b/internal/i18n/locales/ja/zheng.json
@@ -11,7 +11,5 @@
   "playerYou": "あなた",
   "yourTurn": "あなたのターンです",
   "comboRulesHint": "役: シングル/ペア/3カード/連番(3..A)/連続ペア(3..A)。強さは 3<...<A<2<小J<大J でスートは無関係。爆弾(同ランク4枚)は通常役を切れ、ジョーカー2枚は全てに勝ちます。",
-  "actionPass": "パス",
-  "helpExamplePlay": "  p 0                  手札の 0 番を 1 枚出す",
-  "helpExamplePass": "  p                    指定なしでパスする"
+  "actionPass": "パス"
 }

--- a/internal/infrastructure/ui/GameManager.go
+++ b/internal/infrastructure/ui/GameManager.go
@@ -145,7 +145,7 @@ var gameRegistry = []GameRegistryEntry{
 		CuiHelpSpec{
 			TitleKey: "poker.helpTitle",
 			ExampleKeys: []string{
-				"poker.helpExampleCall",
+				"poker.helpExampleFold",
 			},
 			CommandKeys: []string{
 				"poker.helpBet",
@@ -1293,7 +1293,7 @@ var gameRegistry = []GameRegistryEntry{
 		CuiHelpSpec{
 			TitleKey: "deucetoseven.helpTitle",
 			ExampleKeys: []string{
-				"deucetoseven.helpExampleCall",
+				"deucetoseven.helpExampleFold",
 			},
 			CommandKeys: []string{
 				"deucetoseven.helpBet",
@@ -3606,7 +3606,7 @@ var gameRegistry = []GameRegistryEntry{
 		CuiHelpSpec{
 			TitleKey: "scopone.helpTitle",
 			ExampleKeys: []string{
-				"scopone.helpExamplePlay",
+				"scopone.helpExampleNext",
 			},
 			CommandKeys: []string{
 				"scopone.helpPlay",
@@ -3864,8 +3864,7 @@ var gameRegistry = []GameRegistryEntry{
 		CuiHelpSpec{
 			TitleKey: "fivecardstud.helpTitle",
 			ExampleKeys: []string{
-				"fivecardstud.helpExampleCall",
-				"fivecardstud.helpExampleRaise",
+				"fivecardstud.helpExampleFold",
 			},
 			CommandKeys: []string{
 				"fivecardstud.helpFold",
@@ -5582,7 +5581,7 @@ var gameRegistry = []GameRegistryEntry{
 		CuiHelpSpec{
 			TitleKey: "colourwhist.helpTitle",
 			ExampleKeys: []string{
-				"colourwhist.helpExampleHint",
+				"colourwhist.helpExampleGiveUp",
 			},
 			CommandKeys: []string{
 				"colourwhist.helpPlay",

--- a/internal/infrastructure/ui/GameManager.go
+++ b/internal/infrastructure/ui/GameManager.go
@@ -3624,7 +3624,7 @@ var gameRegistry = []GameRegistryEntry{
 		CuiHelpSpec{
 			TitleKey: "escoba.helpTitle",
 			ExampleKeys: []string{
-				"escoba.helpExamplePlay",
+				"escoba.helpExampleNext",
 			},
 			CommandKeys: []string{
 				"escoba.helpPlay",

--- a/internal/infrastructure/ui/GameManager.go
+++ b/internal/infrastructure/ui/GameManager.go
@@ -5581,7 +5581,7 @@ var gameRegistry = []GameRegistryEntry{
 		CuiHelpSpec{
 			TitleKey: "colourwhist.helpTitle",
 			ExampleKeys: []string{
-				"colourwhist.helpExampleGiveUp",
+				"colourwhist.helpExamplePass",
 			},
 			CommandKeys: []string{
 				"colourwhist.helpPlay",

--- a/internal/infrastructure/ui/GameManager.go
+++ b/internal/infrastructure/ui/GameManager.go
@@ -145,7 +145,7 @@ var gameRegistry = []GameRegistryEntry{
 		CuiHelpSpec{
 			TitleKey: "poker.helpTitle",
 			ExampleKeys: []string{
-				"poker.helpExampleBet",
+				"poker.helpExampleCall",
 			},
 			CommandKeys: []string{
 				"poker.helpBet",
@@ -177,7 +177,6 @@ var gameRegistry = []GameRegistryEntry{
 		CuiHelpSpec{
 			TitleKey: "daifugo.helpTitle",
 			ExampleKeys: []string{
-				"daifugo.helpExamplePlay",
 				"daifugo.helpExamplePass",
 			},
 			CommandKeys: []string{"daifugo.helpPlay", "daifugo.helpSort"},
@@ -189,11 +188,7 @@ var gameRegistry = []GameRegistryEntry{
 		},
 		controller.NewBigTwoCuiController,
 		CuiHelpSpec{
-			TitleKey: "bigtwo.helpTitle",
-			ExampleKeys: []string{
-				"bigtwo.helpExamplePlay",
-				"bigtwo.helpExamplePass",
-			},
+			TitleKey:    "bigtwo.helpTitle",
 			CommandKeys: []string{"bigtwo.helpPlay"},
 			SettingKeys: []string{"bigtwo.helpSetDifficulty"},
 		}),
@@ -216,8 +211,7 @@ var gameRegistry = []GameRegistryEntry{
 		CuiHelpSpec{
 			TitleKey: "holdem.helpTitle",
 			ExampleKeys: []string{
-				"holdem.helpExampleCheck",
-				"holdem.helpExampleBet",
+				"holdem.helpExampleCall",
 				"holdem.helpExampleRaise",
 			},
 			CommandKeys: append([]string{
@@ -240,8 +234,7 @@ var gameRegistry = []GameRegistryEntry{
 		CuiHelpSpec{
 			TitleKey: "omaha.helpTitle",
 			ExampleKeys: []string{
-				"omaha.helpExampleCheck",
-				"omaha.helpExampleBet",
+				"omaha.helpExampleCall",
 				"omaha.helpExampleRaise",
 			},
 			CommandKeys: append([]string{
@@ -340,8 +333,7 @@ var gameRegistry = []GameRegistryEntry{
 		CuiHelpSpec{
 			TitleKey: "shortdeck.helpTitle",
 			ExampleKeys: []string{
-				"shortdeck.helpExampleCheck",
-				"shortdeck.helpExampleBet",
+				"shortdeck.helpExampleCall",
 				"shortdeck.helpExampleRaise",
 			},
 			CommandKeys: append([]string{
@@ -364,8 +356,7 @@ var gameRegistry = []GameRegistryEntry{
 		CuiHelpSpec{
 			TitleKey: "pineapple.helpTitle",
 			ExampleKeys: []string{
-				"pineapple.helpExampleCheck",
-				"pineapple.helpExampleBet",
+				"pineapple.helpExampleCall",
 				"pineapple.helpExampleRaise",
 			},
 			CommandKeys: append([]string{
@@ -388,8 +379,7 @@ var gameRegistry = []GameRegistryEntry{
 		CuiHelpSpec{
 			TitleKey: "crazypineapple.helpTitle",
 			ExampleKeys: []string{
-				"crazypineapple.helpExampleCheck",
-				"crazypineapple.helpExampleBet",
+				"crazypineapple.helpExampleCall",
 				"crazypineapple.helpExampleRaise",
 			},
 			CommandKeys: append([]string{
@@ -412,8 +402,7 @@ var gameRegistry = []GameRegistryEntry{
 		CuiHelpSpec{
 			TitleKey: "irishpoker.helpTitle",
 			ExampleKeys: []string{
-				"irishpoker.helpExampleCheck",
-				"irishpoker.helpExampleBet",
+				"irishpoker.helpExampleCall",
 				"irishpoker.helpExampleRaise",
 			},
 			CommandKeys: append([]string{
@@ -463,8 +452,6 @@ var gameRegistry = []GameRegistryEntry{
 			TitleKey: "klondike.helpTitle",
 			ExampleKeys: []string{
 				"klondike.helpExampleDraw",
-				"klondike.helpExampleMove",
-				"klondike.helpExampleFound",
 			},
 			CommandKeys: []string{
 				"klondike.helpDraw",
@@ -711,7 +698,7 @@ var gameRegistry = []GameRegistryEntry{
 		CuiHelpSpec{
 			TitleKey: "indianpoker.helpTitle",
 			ExampleKeys: []string{
-				"indianpoker.helpExampleBet",
+				"indianpoker.helpExampleFold",
 			},
 			CommandKeys: []string{
 				"indianpoker.helpFold",
@@ -898,8 +885,7 @@ var gameRegistry = []GameRegistryEntry{
 		CuiHelpSpec{
 			TitleKey: "speed.helpTitle",
 			ExampleKeys: []string{
-				"speed.helpExamplePlay",
-				"speed.helpExampleFlip",
+				"speed.helpExampleHint",
 			},
 			CommandKeys: []string{"speed.helpPlay", "speed.helpFlip", "speed.helpHint"},
 			SettingKeys: []string{"speed.helpSetDifficulty"},
@@ -966,9 +952,7 @@ var gameRegistry = []GameRegistryEntry{
 		CuiHelpSpec{
 			TitleKey: "sevencardstud.helpTitle",
 			ExampleKeys: []string{
-				"sevencardstud.helpExampleCheck",
-				"sevencardstud.helpExampleBet",
-				"sevencardstud.helpExampleRaise",
+				"sevencardstud.helpExampleFold",
 			},
 			CommandKeys: append([]string{
 				"sevencardstud.helpFold",
@@ -1117,8 +1101,7 @@ var gameRegistry = []GameRegistryEntry{
 		CuiHelpSpec{
 			TitleKey: "canfield.helpTitle",
 			ExampleKeys: []string{
-				"canfield.helpExampleHint",
-				"canfield.helpExampleAuto",
+				"canfield.helpExampleDraw",
 			},
 			CommandKeys: []string{
 				"canfield.helpDraw",
@@ -1288,7 +1271,7 @@ var gameRegistry = []GameRegistryEntry{
 		CuiHelpSpec{
 			TitleKey: "badugi.helpTitle",
 			ExampleKeys: []string{
-				"badugi.helpExampleBet",
+				"badugi.helpExampleCall",
 			},
 			CommandKeys: []string{
 				"badugi.helpBet",
@@ -1310,7 +1293,7 @@ var gameRegistry = []GameRegistryEntry{
 		CuiHelpSpec{
 			TitleKey: "deucetoseven.helpTitle",
 			ExampleKeys: []string{
-				"deucetoseven.helpExampleBet",
+				"deucetoseven.helpExampleCall",
 			},
 			CommandKeys: []string{
 				"deucetoseven.helpBet",
@@ -1934,7 +1917,7 @@ var gameRegistry = []GameRegistryEntry{
 		CuiHelpSpec{
 			TitleKey: "toepen.helpTitle",
 			ExampleKeys: []string{
-				"toepen.helpExamplePlay",
+				"toepen.helpExampleFold",
 			},
 			CommandKeys: []string{
 				"toepen.helpPlay",
@@ -2814,7 +2797,6 @@ var gameRegistry = []GameRegistryEntry{
 		CuiHelpSpec{
 			TitleKey: "scopa.helpTitle",
 			ExampleKeys: []string{
-				"scopa.helpExamplePlay",
 				"scopa.helpExampleNext",
 			},
 			CommandKeys: []string{"scopa.helpPlay", "scopa.helpNext"},
@@ -2884,11 +2866,7 @@ var gameRegistry = []GameRegistryEntry{
 		},
 		controller.NewTienLenCuiController,
 		CuiHelpSpec{
-			TitleKey: "tienlen.helpTitle",
-			ExampleKeys: []string{
-				"tienlen.helpExamplePlay",
-				"tienlen.helpExamplePass",
-			},
+			TitleKey:    "tienlen.helpTitle",
 			CommandKeys: []string{"tienlen.helpPlay"},
 			SettingKeys: []string{"tienlen.helpSetDifficulty"},
 		}),
@@ -3281,8 +3259,6 @@ var gameRegistry = []GameRegistryEntry{
 			TitleKey: "fortyfives.helpTitle",
 			ExampleKeys: []string{
 				"fortyfives.helpExampleBid",
-				"fortyfives.helpExamplePlay",
-				"fortyfives.helpExampleNext",
 			},
 			CommandKeys: []string{
 				"fortyfives.helpBid",
@@ -3303,8 +3279,6 @@ var gameRegistry = []GameRegistryEntry{
 			TitleKey: "twentynine.helpTitle",
 			ExampleKeys: []string{
 				"twentynine.helpExampleBid",
-				"twentynine.helpExamplePlay",
-				"twentynine.helpExampleNext",
 			},
 			CommandKeys: []string{
 				"twentynine.helpBid",
@@ -3401,8 +3375,6 @@ var gameRegistry = []GameRegistryEntry{
 			TitleKey: "solowhist.helpTitle",
 			ExampleKeys: []string{
 				"solowhist.helpExampleBid",
-				"solowhist.helpExamplePlay",
-				"solowhist.helpExampleNext",
 			},
 			CommandKeys: []string{
 				"solowhist.helpBid",
@@ -3442,8 +3414,6 @@ var gameRegistry = []GameRegistryEntry{
 			TitleKey: "nap.helpTitle",
 			ExampleKeys: []string{
 				"nap.helpExampleBid",
-				"nap.helpExamplePlay",
-				"nap.helpExampleNext",
 			},
 			CommandKeys: []string{
 				"nap.helpBid",
@@ -3464,8 +3434,6 @@ var gameRegistry = []GameRegistryEntry{
 			TitleKey: "preference.helpTitle",
 			ExampleKeys: []string{
 				"preference.helpExampleBid",
-				"preference.helpExamplePlay",
-				"preference.helpExampleNext",
 			},
 			CommandKeys: []string{
 				"preference.helpBid",
@@ -3505,8 +3473,6 @@ var gameRegistry = []GameRegistryEntry{
 			TitleKey: "vira.helpTitle",
 			ExampleKeys: []string{
 				"vira.helpExampleBid",
-				"vira.helpExamplePlay",
-				"vira.helpExampleNext",
 			},
 			CommandKeys: []string{
 				"vira.helpBid",
@@ -3898,8 +3864,7 @@ var gameRegistry = []GameRegistryEntry{
 		CuiHelpSpec{
 			TitleKey: "fivecardstud.helpTitle",
 			ExampleKeys: []string{
-				"fivecardstud.helpExampleCheck",
-				"fivecardstud.helpExampleBet",
+				"fivecardstud.helpExampleCall",
 				"fivecardstud.helpExampleRaise",
 			},
 			CommandKeys: []string{
@@ -3997,9 +3962,6 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewSimpleSimonCuiController,
 		CuiHelpSpec{
 			TitleKey: "simplesimon.helpTitle",
-			ExampleKeys: []string{
-				"simplesimon.helpExampleUndo",
-			},
 			CommandKeys: []string{
 				"simplesimon.helpMove",
 				"simplesimon.helpUndo",
@@ -4014,7 +3976,7 @@ var gameRegistry = []GameRegistryEntry{
 		CuiHelpSpec{
 			TitleKey: "doubleklondike.helpTitle",
 			ExampleKeys: []string{
-				"doubleklondike.helpExampleUndo",
+				"doubleklondike.helpExampleDraw",
 			},
 			CommandKeys: []string{
 				"doubleklondike.helpDraw",
@@ -4032,9 +3994,6 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewBlackHoleCuiController,
 		CuiHelpSpec{
 			TitleKey: "blackhole.helpTitle",
-			ExampleKeys: []string{
-				"blackhole.helpExampleUndo",
-			},
 			CommandKeys: []string{
 				"blackhole.helpMove",
 				"blackhole.helpUndo",
@@ -4332,7 +4291,7 @@ var gameRegistry = []GameRegistryEntry{
 		CuiHelpSpec{
 			TitleKey: "michigan.helpTitle",
 			ExampleKeys: []string{
-				"michigan.helpExampleBet",
+				"michigan.helpExampleNext",
 			},
 			CommandKeys:       []string{"michigan.helpBet", "michigan.helpPlay", "michigan.helpNext"},
 			ExtraCommandLines: []string{"  l                    action log"},
@@ -4644,11 +4603,7 @@ var gameRegistry = []GameRegistryEntry{
 		},
 		controller.NewZhengCuiController,
 		CuiHelpSpec{
-			TitleKey: "zheng.helpTitle",
-			ExampleKeys: []string{
-				"zheng.helpExamplePlay",
-				"zheng.helpExamplePass",
-			},
+			TitleKey:    "zheng.helpTitle",
 			CommandKeys: []string{"zheng.helpPlay"},
 			SettingKeys: []string{"zheng.helpSetDifficulty"},
 		}),
@@ -4711,7 +4666,6 @@ var gameRegistry = []GameRegistryEntry{
 		CuiHelpSpec{
 			TitleKey: "popejoan.helpTitle",
 			ExampleKeys: []string{
-				"popejoan.helpExamplePlay",
 				"popejoan.helpExampleNext",
 			},
 			CommandKeys: []string{
@@ -4728,7 +4682,6 @@ var gameRegistry = []GameRegistryEntry{
 		CuiHelpSpec{
 			TitleKey: "nainjaune.helpTitle",
 			ExampleKeys: []string{
-				"nainjaune.helpExamplePlay",
 				"nainjaune.helpExampleNext",
 			},
 			CommandKeys: []string{
@@ -4960,9 +4913,7 @@ var gameRegistry = []GameRegistryEntry{
 		CuiHelpSpec{
 			TitleKey: "soko.helpTitle",
 			ExampleKeys: []string{
-				"soko.helpExampleCheck",
-				"soko.helpExampleBet",
-				"soko.helpExampleRaise",
+				"soko.helpExampleFold",
 			},
 			CommandKeys: []string{
 				"soko.helpFold",
@@ -5134,8 +5085,7 @@ var gameRegistry = []GameRegistryEntry{
 		CuiHelpSpec{
 			TitleKey: "slobberhannes.helpTitle",
 			ExampleKeys: []string{
-				"slobberhannes.helpExamplePlay",
-				"slobberhannes.helpExampleNext",
+				"slobberhannes.helpExampleGiveUp",
 			},
 			CommandKeys: []string{
 				"slobberhannes.helpPlay",
@@ -5171,8 +5121,7 @@ var gameRegistry = []GameRegistryEntry{
 		CuiHelpSpec{
 			TitleKey: "reversis.helpTitle",
 			ExampleKeys: []string{
-				"reversis.helpExamplePlay",
-				"reversis.helpExampleNext",
+				"reversis.helpExampleGiveUp",
 			},
 			CommandKeys: []string{
 				"reversis.helpPlay",
@@ -5205,7 +5154,7 @@ var gameRegistry = []GameRegistryEntry{
 		CuiHelpSpec{
 			TitleKey: "tarabish.helpTitle",
 			ExampleKeys: []string{
-				"tarabish.helpExamplePlay",
+				"tarabish.helpExampleNext",
 			},
 			CommandKeys: []string{
 				"tarabish.helpTake",
@@ -5224,7 +5173,7 @@ var gameRegistry = []GameRegistryEntry{
 		CuiHelpSpec{
 			TitleKey: "baloot.helpTitle",
 			ExampleKeys: []string{
-				"baloot.helpExamplePlay",
+				"baloot.helpExampleGiveUp",
 			},
 			CommandKeys: []string{
 				"baloot.helpSun",
@@ -5322,8 +5271,7 @@ var gameRegistry = []GameRegistryEntry{
 		CuiHelpSpec{
 			TitleKey: "mendikot.helpTitle",
 			ExampleKeys: []string{
-				"mendikot.helpExamplePlay",
-				"mendikot.helpExampleNext",
+				"mendikot.helpExampleGiveUp",
 			},
 			CommandKeys: []string{
 				"mendikot.helpPlay",
@@ -5413,7 +5361,7 @@ var gameRegistry = []GameRegistryEntry{
 		CuiHelpSpec{
 			TitleKey: "honeymoonbridge.helpTitle",
 			ExampleKeys: []string{
-				"honeymoonbridge.helpExamplePlay",
+				"honeymoonbridge.helpExampleGiveUp",
 			},
 			CommandKeys: []string{
 				"honeymoonbridge.helpBid",
@@ -5432,7 +5380,7 @@ var gameRegistry = []GameRegistryEntry{
 		CuiHelpSpec{
 			TitleKey: "minibridge.helpTitle",
 			ExampleKeys: []string{
-				"minibridge.helpExamplePlay",
+				"minibridge.helpExampleGiveUp",
 			},
 			CommandKeys: []string{
 				"minibridge.helpContract",
@@ -5450,7 +5398,7 @@ var gameRegistry = []GameRegistryEntry{
 		CuiHelpSpec{
 			TitleKey: "pasur.helpTitle",
 			ExampleKeys: []string{
-				"pasur.helpExamplePlay",
+				"pasur.helpExampleGiveUp",
 			},
 			CommandKeys: []string{
 				"pasur.helpPlay",
@@ -5544,8 +5492,7 @@ var gameRegistry = []GameRegistryEntry{
 		CuiHelpSpec{
 			TitleKey: "cucumber.helpTitle",
 			ExampleKeys: []string{
-				"cucumber.helpExamplePlay",
-				"cucumber.helpExampleNext",
+				"cucumber.helpExampleGiveUp",
 			},
 			CommandKeys: []string{
 				"cucumber.helpPlay",
@@ -5593,7 +5540,7 @@ var gameRegistry = []GameRegistryEntry{
 		CuiHelpSpec{
 			TitleKey: "botifarra.helpTitle",
 			ExampleKeys: []string{
-				"botifarra.helpExamplePlay",
+				"botifarra.helpExampleHint",
 			},
 			CommandKeys: []string{
 				"botifarra.helpPlay",
@@ -5614,7 +5561,7 @@ var gameRegistry = []GameRegistryEntry{
 		CuiHelpSpec{
 			TitleKey: "rikken.helpTitle",
 			ExampleKeys: []string{
-				"rikken.helpExamplePlay",
+				"rikken.helpExampleHint",
 			},
 			CommandKeys: []string{
 				"rikken.helpPlay",
@@ -5635,7 +5582,7 @@ var gameRegistry = []GameRegistryEntry{
 		CuiHelpSpec{
 			TitleKey: "colourwhist.helpTitle",
 			ExampleKeys: []string{
-				"colourwhist.helpExamplePlay",
+				"colourwhist.helpExampleHint",
 			},
 			CommandKeys: []string{
 				"colourwhist.helpPlay",

--- a/internal/infrastructure/ui/GameManager.go
+++ b/internal/infrastructure/ui/GameManager.go
@@ -541,6 +541,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewCruelCuiController,
 		CuiHelpSpec{
 			TitleKey: "cruel.helpTitle",
+			ExampleKeys: []string{
+				"cruel.helpExampleHint",
+				"cruel.helpExampleAuto",
+			},
 			CommandKeys: []string{
 				"cruel.helpMove",
 				"cruel.helpMoveTF",
@@ -664,6 +668,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewSpiderCuiController,
 		CuiHelpSpec{
 			TitleKey: "spider.helpTitle",
+			ExampleKeys: []string{
+				"spider.helpExampleHint",
+				"spider.helpExampleAuto",
+			},
 			CommandKeys: []string{
 				"spider.helpDeal",
 				"spider.helpMove",
@@ -1010,6 +1018,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewFortyThievesCuiController,
 		CuiHelpSpec{
 			TitleKey: "fortythieves.helpTitle",
+			ExampleKeys: []string{
+				"fortythieves.helpExampleHint",
+				"fortythieves.helpExampleAuto",
+			},
 			CommandKeys: []string{
 				"fortythieves.helpDraw",
 				"fortythieves.helpMove",
@@ -1104,6 +1116,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewCanfieldCuiController,
 		CuiHelpSpec{
 			TitleKey: "canfield.helpTitle",
+			ExampleKeys: []string{
+				"canfield.helpExampleHint",
+				"canfield.helpExampleAuto",
+			},
 			CommandKeys: []string{
 				"canfield.helpDraw",
 				"canfield.helpMove",
@@ -1135,6 +1151,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewYukonCuiController,
 		CuiHelpSpec{
 			TitleKey: "yukon.helpTitle",
+			ExampleKeys: []string{
+				"yukon.helpExampleHint",
+				"yukon.helpExampleAuto",
+			},
 			CommandKeys: []string{
 				"yukon.helpMove",
 				"yukon.helpMoveTF",
@@ -1152,6 +1172,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewRussianSolitaireCuiController,
 		CuiHelpSpec{
 			TitleKey: "russiansolitaire.helpTitle",
+			ExampleKeys: []string{
+				"russiansolitaire.helpExampleHint",
+				"russiansolitaire.helpExampleAuto",
+			},
 			CommandKeys: []string{
 				"russiansolitaire.helpMove",
 				"russiansolitaire.helpMoveTF",
@@ -1346,6 +1370,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewScorpionCuiController,
 		CuiHelpSpec{
 			TitleKey: "scorpion.helpTitle",
+			ExampleKeys: []string{
+				"scorpion.helpExampleHint",
+				"scorpion.helpExampleAuto",
+			},
 			CommandKeys: []string{
 				"scorpion.helpMove",
 				"scorpion.helpMoveTT",
@@ -1364,6 +1392,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewWaspCuiController,
 		CuiHelpSpec{
 			TitleKey: "wasp.helpTitle",
+			ExampleKeys: []string{
+				"wasp.helpExampleHint",
+				"wasp.helpExampleAuto",
+			},
 			CommandKeys: []string{
 				"wasp.helpMove",
 				"wasp.helpMoveTT",
@@ -1382,6 +1414,9 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewAccordionCuiController,
 		CuiHelpSpec{
 			TitleKey: "accordion.helpTitle",
+			ExampleKeys: []string{
+				"accordion.helpExampleHint",
+			},
 			CommandKeys: []string{
 				"accordion.helpMove",
 				"accordion.helpGiveup",
@@ -1523,6 +1558,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewBisleyCuiController,
 		CuiHelpSpec{
 			TitleKey: "bisley.helpTitle",
+			ExampleKeys: []string{
+				"bisley.helpExampleHint",
+				"bisley.helpExampleAuto",
+			},
 			CommandKeys: []string{
 				"bisley.helpMoveTA",
 				"bisley.helpMoveTK",
@@ -1541,6 +1580,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewNapoleonsSquareCuiController,
 		CuiHelpSpec{
 			TitleKey: "napoleonssquare.helpTitle",
+			ExampleKeys: []string{
+				"napoleonssquare.helpExampleHint",
+				"napoleonssquare.helpExampleAuto",
+			},
 			CommandKeys: []string{
 				"napoleonssquare.helpDraw",
 				"napoleonssquare.helpMoveWF",
@@ -1561,6 +1604,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewGrandfathersClockCuiController,
 		CuiHelpSpec{
 			TitleKey: "grandfathersclock.helpTitle",
+			ExampleKeys: []string{
+				"grandfathersclock.helpExampleHint",
+				"grandfathersclock.helpExampleAuto",
+			},
 			CommandKeys: []string{
 				"grandfathersclock.helpMoveTF",
 				"grandfathersclock.helpMoveTT",
@@ -1578,6 +1625,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewMissMilliganCuiController,
 		CuiHelpSpec{
 			TitleKey: "missmilligan.helpTitle",
+			ExampleKeys: []string{
+				"missmilligan.helpExampleHint",
+				"missmilligan.helpExampleAuto",
+			},
 			CommandKeys: []string{
 				"missmilligan.helpDeal",
 				"missmilligan.helpMoveTF",
@@ -1599,6 +1650,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewDuchessCuiController,
 		CuiHelpSpec{
 			TitleKey: "duchess.helpTitle",
+			ExampleKeys: []string{
+				"duchess.helpExampleHint",
+				"duchess.helpExampleAuto",
+			},
 			CommandKeys: []string{
 				"duchess.helpBase",
 				"duchess.helpDraw",
@@ -1622,6 +1677,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewWindmillCuiController,
 		CuiHelpSpec{
 			TitleKey: "windmill.helpTitle",
+			ExampleKeys: []string{
+				"windmill.helpExampleHint",
+				"windmill.helpExampleAuto",
+			},
 			CommandKeys: []string{
 				"windmill.helpDraw",
 				"windmill.helpMoveSC",
@@ -1643,6 +1702,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewAmericanToadCuiController,
 		CuiHelpSpec{
 			TitleKey: "americantoad.helpTitle",
+			ExampleKeys: []string{
+				"americantoad.helpExampleHint",
+				"americantoad.helpExampleAuto",
+			},
 			CommandKeys: []string{
 				"americantoad.helpDraw",
 				"americantoad.helpMoveRF",
@@ -1704,6 +1767,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewCongressCuiController,
 		CuiHelpSpec{
 			TitleKey: "congress.helpTitle",
+			ExampleKeys: []string{
+				"congress.helpExampleHint",
+				"congress.helpExampleAuto",
+			},
 			CommandKeys: []string{
 				"congress.helpDraw",
 				"congress.helpMoveTF",
@@ -1725,6 +1792,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewTerraceCuiController,
 		CuiHelpSpec{
 			TitleKey: "terrace.helpTitle",
+			ExampleKeys: []string{
+				"terrace.helpExampleHint",
+				"terrace.helpExampleAuto",
+			},
 			CommandKeys: []string{
 				"terrace.helpDraw",
 				"terrace.helpMoveRF",
@@ -1746,6 +1817,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewBraidCuiController,
 		CuiHelpSpec{
 			TitleKey: "braid.helpTitle",
+			ExampleKeys: []string{
+				"braid.helpExampleHint",
+				"braid.helpExampleAuto",
+			},
 			CommandKeys: []string{
 				"braid.helpDraw",
 				"braid.helpDirection",
@@ -1994,6 +2069,9 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewNertzCuiController,
 		CuiHelpSpec{
 			TitleKey: "nertz.helpTitle",
+			ExampleKeys: []string{
+				"nertz.helpExampleHint",
+			},
 			CommandKeys: []string{
 				"nertz.helpDraw",
 				"nertz.helpMoveNF",
@@ -2194,6 +2272,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewCrescentCuiController,
 		CuiHelpSpec{
 			TitleKey: "crescent.helpTitle",
+			ExampleKeys: []string{
+				"crescent.helpExampleHint",
+				"crescent.helpExampleAuto",
+			},
 			CommandKeys: []string{
 				"crescent.helpMoveTT",
 				"crescent.helpMoveTF",
@@ -2250,6 +2332,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewSpideretteCuiController,
 		CuiHelpSpec{
 			TitleKey: "spiderette.helpTitle",
+			ExampleKeys: []string{
+				"spiderette.helpExampleHint",
+				"spiderette.helpExampleAuto",
+			},
 			CommandKeys: []string{
 				"spiderette.helpDeal",
 				"spiderette.helpMove",
@@ -2348,6 +2434,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewKingAlbertCuiController,
 		CuiHelpSpec{
 			TitleKey: "kingalbert.helpTitle",
+			ExampleKeys: []string{
+				"kingalbert.helpExampleHint",
+				"kingalbert.helpExampleAuto",
+			},
 			CommandKeys: []string{
 				"kingalbert.helpMoveTT",
 				"kingalbert.helpMoveTF",
@@ -2366,6 +2456,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewFlowerGardenCuiController,
 		CuiHelpSpec{
 			TitleKey: "flowergarden.helpTitle",
+			ExampleKeys: []string{
+				"flowergarden.helpExampleHint",
+				"flowergarden.helpExampleAuto",
+			},
 			CommandKeys: []string{
 				"flowergarden.helpMoveTT",
 				"flowergarden.helpMoveTF",
@@ -2384,6 +2478,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewFortyAndEightCuiController,
 		CuiHelpSpec{
 			TitleKey: "fortyandeight.helpTitle",
+			ExampleKeys: []string{
+				"fortyandeight.helpExampleHint",
+				"fortyandeight.helpExampleAuto",
+			},
 			CommandKeys: []string{
 				"fortyandeight.helpDraw",
 				"fortyandeight.helpRedeal",
@@ -2404,6 +2502,9 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewAgnesCuiController,
 		CuiHelpSpec{
 			TitleKey: "agnes.helpTitle",
+			ExampleKeys: []string{
+				"agnes.helpExampleHint",
+			},
 			CommandKeys: []string{
 				"agnes.helpDeal",
 				"agnes.helpMoveTT",
@@ -2420,6 +2521,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewSultanCuiController,
 		CuiHelpSpec{
 			TitleKey: "sultan.helpTitle",
+			ExampleKeys: []string{
+				"sultan.helpExampleHint",
+				"sultan.helpExampleAuto",
+			},
 			CommandKeys: []string{
 				"sultan.helpDraw",
 				"sultan.helpRedeal",
@@ -2536,6 +2641,9 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewGapsCuiController,
 		CuiHelpSpec{
 			TitleKey: "gaps.helpTitle",
+			ExampleKeys: []string{
+				"gaps.helpExampleHint",
+			},
 			CommandKeys: []string{
 				"gaps.helpMove",
 				"gaps.helpRedeal",
@@ -2718,7 +2826,10 @@ var gameRegistry = []GameRegistryEntry{
 		},
 		controller.NewAcesUpCuiController,
 		CuiHelpSpec{
-			TitleKey:          "acesup.helpTitle",
+			TitleKey: "acesup.helpTitle",
+			ExampleKeys: []string{
+				"acesup.helpExampleHint",
+			},
 			CommandKeys:       []string{"acesup.helpDraw", "acesup.helpRemove", "acesup.helpMove", "acesup.helpGiveUp", "acesup.helpHint"},
 			ExtraCommandLines: []string{"  l                        action log"},
 		}),
@@ -2788,6 +2899,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewOsmosisCuiController,
 		CuiHelpSpec{
 			TitleKey: "osmosis.helpTitle",
+			ExampleKeys: []string{
+				"osmosis.helpExampleHint",
+				"osmosis.helpExampleAuto",
+			},
 			CommandKeys: []string{
 				"osmosis.helpDraw",
 				"osmosis.helpMoveWF",
@@ -2912,6 +3027,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewBristolCuiController,
 		CuiHelpSpec{
 			TitleKey: "bristol.helpTitle",
+			ExampleKeys: []string{
+				"bristol.helpExampleHint",
+				"bristol.helpExampleAuto",
+			},
 			CommandKeys: []string{
 				"bristol.helpDraw",
 				"bristol.helpMoveTT",
@@ -2976,6 +3095,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewEasthavenCuiController,
 		CuiHelpSpec{
 			TitleKey: "easthaven.helpTitle",
+			ExampleKeys: []string{
+				"easthaven.helpExampleHint",
+				"easthaven.helpExampleAuto",
+			},
 			CommandKeys: []string{
 				"easthaven.helpMove",
 				"easthaven.helpMoveTF",
@@ -3856,6 +3979,9 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewLaBelleLucieCuiController,
 		CuiHelpSpec{
 			TitleKey: "labellelucie.helpTitle",
+			ExampleKeys: []string{
+				"labellelucie.helpExampleAuto",
+			},
 			CommandKeys: []string{
 				"labellelucie.helpMove",
 				"labellelucie.helpRedeal",
@@ -3871,6 +3997,9 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewSimpleSimonCuiController,
 		CuiHelpSpec{
 			TitleKey: "simplesimon.helpTitle",
+			ExampleKeys: []string{
+				"simplesimon.helpExampleUndo",
+			},
 			CommandKeys: []string{
 				"simplesimon.helpMove",
 				"simplesimon.helpUndo",
@@ -3884,6 +4013,9 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewDoubleKlondikeCuiController,
 		CuiHelpSpec{
 			TitleKey: "doubleklondike.helpTitle",
+			ExampleKeys: []string{
+				"doubleklondike.helpExampleUndo",
+			},
 			CommandKeys: []string{
 				"doubleklondike.helpDraw",
 				"doubleklondike.helpMoveWaste",
@@ -3900,6 +4032,9 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewBlackHoleCuiController,
 		CuiHelpSpec{
 			TitleKey: "blackhole.helpTitle",
+			ExampleKeys: []string{
+				"blackhole.helpExampleUndo",
+			},
 			CommandKeys: []string{
 				"blackhole.helpMove",
 				"blackhole.helpUndo",
@@ -4849,6 +4984,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewFourSeasonsCuiController,
 		CuiHelpSpec{
 			TitleKey: "fourseasons.helpTitle",
+			ExampleKeys: []string{
+				"fourseasons.helpExampleHint",
+				"fourseasons.helpExampleAuto",
+			},
 			CommandKeys: []string{
 				"fourseasons.helpDraw",
 				"fourseasons.helpMoveWaste",
@@ -4867,6 +5006,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewColoradoCuiController,
 		CuiHelpSpec{
 			TitleKey: "colorado.helpTitle",
+			ExampleKeys: []string{
+				"colorado.helpExampleHint",
+				"colorado.helpExampleAuto",
+			},
 			CommandKeys: []string{
 				"colorado.helpDraw",
 				"colorado.helpMoveTF",
@@ -4902,6 +5045,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewDiplomatCuiController,
 		CuiHelpSpec{
 			TitleKey: "diplomat.helpTitle",
+			ExampleKeys: []string{
+				"diplomat.helpExampleHint",
+				"diplomat.helpExampleAuto",
+			},
 			CommandKeys: []string{
 				"diplomat.helpDraw",
 				"diplomat.helpMoveTF",
@@ -4922,6 +5069,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewRoyalCotillionCuiController,
 		CuiHelpSpec{
 			TitleKey: "royalcotillion.helpTitle",
+			ExampleKeys: []string{
+				"royalcotillion.helpExampleHint",
+				"royalcotillion.helpExampleAuto",
+			},
 			CommandKeys: []string{
 				"royalcotillion.helpDraw",
 				"royalcotillion.helpMoveTF",
@@ -4943,6 +5094,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewCrazyQuiltCuiController,
 		CuiHelpSpec{
 			TitleKey: "crazyquilt.helpTitle",
+			ExampleKeys: []string{
+				"crazyquilt.helpExampleHint",
+				"crazyquilt.helpExampleAuto",
+			},
 			CommandKeys: []string{
 				"crazyquilt.helpDraw",
 				"crazyquilt.helpMoveQF",

--- a/internal/infrastructure/ui/help_example_exec_test.go
+++ b/internal/infrastructure/ui/help_example_exec_test.go
@@ -116,7 +116,36 @@ func TestCuiHelpExampleCommandParsing(t *testing.T) {
 
 // exampleRefusalRe matches the wording a controller uses when it turns a
 // command down. It is a heuristic, and deliberately so: see below.
-var exampleRefusalRe = regexp.MustCompile(`(?i)invalid|required|must |cannot|不正|無効|必要|できません`)
+var exampleRefusalRe = regexp.MustCompile(`(?i)invalid|required|must |cannot|nothing to|no .* to |not your|too few|too many|不正|無効|必要|できません|ありません`)
+
+// exampleErrorLineRe matches cuiErrorBlock's output: the presenters render a
+// rejection as a red line inside the board, so it is not a short reply and
+// cannot be found by looking at the whole output's length.
+var exampleErrorLineRe = regexp.MustCompile("\x1b\\[31m(.*?)\x1b\\[0m")
+
+// exampleRefusalLine reports the line on which the game turned the command
+// down, if it did.
+//
+// Two shapes, because the CUI has two. A game that answers with nothing but a
+// message is a short reply; a game that redraws the board puts the message
+// inside it as a red line, which an earlier version of this guard missed
+// entirely -- it required the whole reply to be under 200 bytes, and a board is
+// not. blackhole's `u` answered "blackhole: nothing to undo" in 965 bytes of
+// board and sailed straight through.
+func exampleRefusalLine(out string) (string, bool) {
+	// Red is not only for errors -- hearts and diamonds are red too, so a red
+	// run has to read like a refusal before it counts as one.
+	for _, m := range exampleErrorLineRe.FindAllStringSubmatch(out, -1) {
+		line := strings.TrimSpace(m[1])
+		if line != "" && exampleRefusalRe.MatchString(line) {
+			return line, true
+		}
+	}
+	if len(out) < 200 && exampleRefusalRe.MatchString(out) {
+		return strings.TrimSpace(out), true
+	}
+	return "", false
+}
 
 // TestCuiHelpExamplesAreNotQuietlyRefused catches the refusals
 // TestCuiHelpExamplesExecute cannot see.
@@ -167,8 +196,8 @@ func TestCuiHelpExamplesAreNotQuietlyRefused(t *testing.T) {
 			if _, isErr := i18n.StripErrorPrefix(out); isErr {
 				continue // TestCuiHelpExamplesExecute owns the marked ones
 			}
-			if len(out) < 200 && exampleRefusalRe.MatchString(out) {
-				bad = append(bad, entry.Name+": `"+cmd+"` -> "+strings.TrimSpace(out))
+			if line, ok := exampleRefusalLine(out); ok {
+				bad = append(bad, entry.Name+": `"+cmd+"` -> "+line)
 			}
 		}
 	}

--- a/internal/infrastructure/ui/help_text_test.go
+++ b/internal/infrastructure/ui/help_text_test.go
@@ -433,7 +433,11 @@ func helpLineVerb(line string) string {
 	if len(fields) == 0 {
 		return ""
 	}
-	verb := fields[0]
+	// A row may list aliases as "h, hint" or "n / next"; the command is the
+	// first of them. Without this the whole row is skipped, and a guard that
+	// silently skips a row cannot fail on it -- which is how `h` looked absent
+	// from accordion's table while being right there.
+	verb := strings.TrimSuffix(fields[0], ",")
 	for _, r := range verb {
 		if (r < 'a' || r > 'z') && (r < '0' || r > '9') {
 			return ""


### PR DESCRIPTION
## 変更

例文つきのゲームが **191 → 232** になりました。残り 85。

ソリティア 41 ゲームに `h`（ヒント）と `ac`（オートコンプリート）を追加しています。

## 移動を例文にしていない理由

ソリティアの移動は配りに依存します。`m <col> f` が通るにはその列の一番上がエースである必要があり、**たまにしか合法でない例は例が無いより悪い**ので採用していません。`h` と `ac` はどの局面からでも通ります。5 配りずつ実測して拒否ゼロです。

## 副産物: 73 行がガードの検査対象から漏れていました

書いている途中で、3 ゲームが「表に無いコマンドを使っている」と報告されました。

```
en/accordion: example uses `h`, which its command table does not list
```

**`h` は表にあります。`h, hint` と書いてあるだけです。**

`helpLineVerb` が `fields[0]` をそのまま動詞として扱っていたため、末尾のカンマが付いた行は**動詞なしとして丸ごとスキップ**されていました。そしてスキップされた行はガードが落としようがありません。

同じ書き方の行はレジストリ全体で **73 行**あり、いずれも検査されていませんでした。修正後 `TestCuiHelpTableVerbsDispatch` の検査対象は **1839 → 1884 動詞**になり、全部ディスパッチされます。

列位置の検出も広げました。コマンド綴りが長い数行は、説明の前が通常の 2 スペースではなく 1 スペースです。

## 検証

- `go test -tags test ./internal/infrastructure/ui/` — 緑
- `go build ./...` — 通過
- `golangci-lint run ./internal/...` — 0 issues

Refs #5370
