### PR TITLE
feat(cui): add examples to the rummy, golf and calculation families

### DIFF
--- a/internal/i18n/locales/en/calculation.json
+++ b/internal/i18n/locales/en/calculation.json
@@ -28,5 +28,7 @@
   "stockNext": " next: {{card}}",
   "hintStock": "Hint: stock → foundation {{foundation}}",
   "hintWaste": "Hint: waste {{waste}} → foundation {{foundation}}",
-  "nextRank": " -> next: {{rank}}"
+  "nextRank": " -> next: {{rank}}",
+  "helpExampleHint": "  h                   ask for a move",
+  "helpExampleAuto": "  ac                  play everything that can go up"
 }

--- a/internal/i18n/locales/en/carioca.json
+++ b/internal/i18n/locales/en/carioca.json
@@ -35,5 +35,7 @@
   "slotDetailSet": "{{n}} of the same rank",
   "slotDetailRun": "{{n}} consecutive of the same suit",
   "slotLine": "  Slot [{{idx}}]: {{detail}}",
-  "meldSyntaxHint": "  meld <slot> <card indices> (e.g. meld 0 1 2 3)"
+  "meldSyntaxHint": "  meld <slot> <card indices> (e.g. meld 0 1 2 3)",
+  "helpExampleDraw": "  ds                   start the turn by drawing from the stock",
+  "helpExampleDiscard": "  d 0                  discard hand card 0"
 }

--- a/internal/i18n/locales/en/chinchon.json
+++ b/internal/i18n/locales/en/chinchon.json
@@ -36,5 +36,7 @@
   "meldedLine": "  Melded: {{melds}}",
   "deadwoodBreakdown": "  Deadwood: {{cards}} ({{sum}} = {{total}})",
   "deadwoodLine": "Deadwood: {{value}} (knock at {{threshold}} or less)",
-  "knockReady": "→ ready to knock"
+  "knockReady": "→ ready to knock",
+  "helpExampleDraw": "  ds                   start the turn by drawing from the stock",
+  "helpExampleDiscard": "  d 0                  discard hand card 0"
 }

--- a/internal/i18n/locales/en/conquian.json
+++ b/internal/i18n/locales/en/conquian.json
@@ -27,5 +27,7 @@
   "promptRoundEnd": "Round complete",
   "promptRoundEndHelp": "nr / nextround: advance to next round",
   "result.humanWin": "Game over! You win!",
-  "result.cpuWin": "Game over! CPU {{cpuId}} wins!"
+  "result.cpuWin": "Game over! CPU {{cpuId}} wins!",
+  "helpExampleDraw": "  ds                   start the turn by drawing from the stock",
+  "helpExampleDiscard": "  d 0                  discard hand card 0"
 }

--- a/internal/i18n/locales/en/contractrummy.json
+++ b/internal/i18n/locales/en/contractrummy.json
@@ -30,5 +30,7 @@
   "promptPlayHelpLayoff": "lo <pIdx> <mIdx> <cIdx>: add a card to an existing meld",
   "promptPlayHelpDiscard": "d <idx>: discard a card",
   "promptRoundEnd": "Round complete",
-  "promptRoundEndHelp": "nr / nextround: advance to next round"
+  "promptRoundEndHelp": "nr / nextround: advance to next round",
+  "helpExampleDraw": "  ds                   start the turn by drawing from the stock",
+  "helpExampleDiscard": "  d 0                  discard hand card 0"
 }

--- a/internal/i18n/locales/en/ginrummy.json
+++ b/internal/i18n/locales/en/ginrummy.json
@@ -28,5 +28,7 @@
   "promptLayoffHelp": "lo <idx,idx,...>: choose cards to lay off",
   "promptLayoffSkip": "lo: skip layoff and score",
   "promptRoundEnd": "Round complete",
-  "promptRoundEndHelp": "nr / nextround: advance to next round"
+  "promptRoundEndHelp": "nr / nextround: advance to next round",
+  "helpExampleDraw": "  ds                   start the turn by drawing from the stock",
+  "helpExampleDiscard": "  d 0                  discard hand card 0"
 }

--- a/internal/i18n/locales/en/golf.json
+++ b/internal/i18n/locales/en/golf.json
@@ -13,5 +13,6 @@
   "roundComplete": "Round complete — {{total}} strokes over {{holes}} holes",
   "hintRemove": "Hint: remove column {{col}}",
   "hintDraw": "Hint: draw from stock",
-  "hintUnknown": "Hint: unknown"
+  "hintUnknown": "Hint: unknown",
+  "helpExampleHint": "  h                        ask for a move"
 }

--- a/internal/i18n/locales/en/handandfoot.json
+++ b/internal/i18n/locales/en/handandfoot.json
@@ -47,5 +47,7 @@
   "goOutBlocked": "  Cannot go out yet: {{reasons}}",
   "goOutNeedFoot": "foot not picked up",
   "goOutNeedRed": "red canastas {{have}}/{{need}}",
-  "goOutNeedBlack": "black canastas {{have}}/{{need}}"
+  "goOutNeedBlack": "black canastas {{have}}/{{need}}",
+  "helpExampleDraw": "  ds                   start the turn by drawing from the stock",
+  "helpExampleDiscard": "  d 0                  discard hand card 0"
 }

--- a/internal/i18n/locales/en/indianrummy.json
+++ b/internal/i18n/locales/en/indianrummy.json
@@ -23,5 +23,7 @@
   "promptDiscardHelp": "d <idx>: discard a card",
   "promptDeclareHelp": "de <idx>: declare (discard 14th and go out)",
   "promptRoundEnd": "Round complete",
-  "promptRoundEndHelp": "nr / nextround: advance to next round"
+  "promptRoundEndHelp": "nr / nextround: advance to next round",
+  "helpExampleDraw": "  ds                   start the turn by drawing from the stock",
+  "helpExampleDiscard": "  d 0                  discard hand card 0"
 }

--- a/internal/i18n/locales/en/kalooki.json
+++ b/internal/i18n/locales/en/kalooki.json
@@ -30,5 +30,7 @@
   "promptRoundEnd": "Round complete",
   "promptRoundEndHelp": "nr / nextround: advance to next round",
   "result.humanWin": "You win!",
-  "result.cpuWin": "CPU {{cpuId}} wins"
+  "result.cpuWin": "CPU {{cpuId}} wins",
+  "helpExampleDraw": "  ds                   start the turn by drawing from the stock",
+  "helpExampleDiscard": "  d 0                  discard hand card 0"
 }

--- a/internal/i18n/locales/en/loba.json
+++ b/internal/i18n/locales/en/loba.json
@@ -30,6 +30,5 @@
   "hintReasonDraw": "you must draw first",
   "hintReasonMeld": "these three make a meld",
   "hintReasonDiscard": "this card connects to nothing",
-  "helpExampleDraw": "  ds                       start the turn by drawing from the stock",
-  "helpExampleDiscard": "  d 0                      discard hand card 0"
+  "helpExampleDraw": "  ds                       start the turn by drawing from the stock"
 }

--- a/internal/i18n/locales/en/loba.json
+++ b/internal/i18n/locales/en/loba.json
@@ -29,5 +29,7 @@
   "hintReasonNotYourTurn": "it is not your turn",
   "hintReasonDraw": "you must draw first",
   "hintReasonMeld": "these three make a meld",
-  "hintReasonDiscard": "this card connects to nothing"
+  "hintReasonDiscard": "this card connects to nothing",
+  "helpExampleDraw": "  ds                       start the turn by drawing from the stock",
+  "helpExampleDiscard": "  d 0                      discard hand card 0"
 }

--- a/internal/i18n/locales/en/pyramid.json
+++ b/internal/i18n/locales/en/pyramid.json
@@ -18,5 +18,6 @@
   "hintWastePair": "Hint: pair waste with pyramid ({{row}},{{col}})",
   "hintUnknown": "Hint: unknown",
   "exposedKing": "({{row}},{{col}}){{card}}[K]",
-  "wasteKing": " | Waste: {{card}}[K]"
+  "wasteKing": " | Waste: {{card}}[K]",
+  "helpExampleHint": "  h                        ask for a move"
 }

--- a/internal/i18n/locales/en/rummy500.json
+++ b/internal/i18n/locales/en/rummy500.json
@@ -32,5 +32,7 @@
   "hintMeld": "Meld candidates: {{cands}} (m <idx...> to lay down)",
   "hintNoMeld": "No meldable combination. Consider discarding with d <idx>.",
   "hintLayoff": "Layoff: {{cands}}",
-  "hintLayoffEntry": "{{card}} -> {{name}} [{{meld}}]"
+  "hintLayoffEntry": "{{card}} -> {{name}} [{{meld}}]",
+  "helpExampleDraw": "  ds                   start the turn by drawing from the stock",
+  "helpExampleDiscard": "  d 0                  discard hand card 0"
 }

--- a/internal/i18n/locales/en/samba.json
+++ b/internal/i18n/locales/en/samba.json
@@ -35,5 +35,7 @@
   "promptGoOutHelp": "go: go out (team needs 2+ completed melds)",
   "promptRoundEnd": "Round complete",
   "promptRoundEndHelp": "nr / nextround: advance to next round",
-  "promptDrawHelpFrozen": "  Note (frozen): taking the discard requires showing two natural matching cards from hand"
+  "promptDrawHelpFrozen": "  Note (frozen): taking the discard requires showing two natural matching cards from hand",
+  "helpExampleDraw": "  ds                   start the turn by drawing from the stock",
+  "helpExampleDiscard": "  d 0                  discard hand card 0"
 }

--- a/internal/i18n/locales/en/sirtommy.json
+++ b/internal/i18n/locales/en/sirtommy.json
@@ -29,5 +29,7 @@
   "stockLine": "Stock: {{count}}",
   "stockNext": " next: {{card}}",
   "hintStock": "Hint: stock → foundation {{foundation}}",
-  "hintWaste": "Hint: waste {{waste}} → foundation {{foundation}}"
+  "hintWaste": "Hint: waste {{waste}} → foundation {{foundation}}",
+  "helpExampleHint": "  h                   ask for a move",
+  "helpExampleAuto": "  ac                  play everything that can go up"
 }

--- a/internal/i18n/locales/en/threethirteen.json
+++ b/internal/i18n/locales/en/threethirteen.json
@@ -24,5 +24,7 @@
   "promptRoundEnd": "Round complete",
   "promptRoundEndHelp": "nr / nextround: advance to next round",
   "result.humanWin": "You win!",
-  "result.cpuWin": "CPU {{cpuId}} wins"
+  "result.cpuWin": "CPU {{cpuId}} wins",
+  "helpExampleDraw": "  ds                   start the turn by drawing from the stock",
+  "helpExampleDiscard": "  d 0                  discard hand card 0"
 }

--- a/internal/i18n/locales/en/tonk.json
+++ b/internal/i18n/locales/en/tonk.json
@@ -27,5 +27,7 @@
   "meldRun": "run",
   "revealedHand": "{{name}} hand: {{cards}}",
   "promptRoundEnd": "Round complete",
-  "promptRoundEndHelp": "nr / nextround: advance to next round"
+  "promptRoundEndHelp": "nr / nextround: advance to next round",
+  "helpExampleDraw": "  ds                   start the turn by drawing from the stock",
+  "helpExampleDiscard": "  d 0                  discard hand card 0"
 }

--- a/internal/i18n/locales/en/tripeaks.json
+++ b/internal/i18n/locales/en/tripeaks.json
@@ -14,5 +14,6 @@
   "wasteEmpty": " | Waste: [empty]",
   "hintRemove": "Hint: remove ({{row}},{{col}})",
   "hintDraw": "Hint: draw from stock",
-  "hintUnknown": "Hint: unknown"
+  "hintUnknown": "Hint: unknown",
+  "helpExampleHint": "  h                        ask for a move"
 }

--- a/internal/i18n/locales/ja/calculation.json
+++ b/internal/i18n/locales/ja/calculation.json
@@ -28,5 +28,7 @@
   "stockNext": " 次のカード: {{card}}",
   "hintStock": "ヒント: ストック → ファンデーション{{foundation}}",
   "hintWaste": "ヒント: ウェイスト{{waste}} → ファンデーション{{foundation}}",
-  "nextRank": " → 次: {{rank}}"
+  "nextRank": " → 次: {{rank}}",
+  "helpExampleHint": "  h                   次の一手を教えてもらう",
+  "helpExampleAuto": "  ac                  置ける札を自動で送る"
 }

--- a/internal/i18n/locales/ja/carioca.json
+++ b/internal/i18n/locales/ja/carioca.json
@@ -35,5 +35,7 @@
   "slotDetailSet": "同ランク{{n}}枚",
   "slotDetailRun": "同スート{{n}}枚の連番",
   "slotLine": "  スロット[{{idx}}]: {{detail}}",
-  "meldSyntaxHint": "  meld <スロット番号> <カード番号...>（例: meld 0 1 2 3）"
+  "meldSyntaxHint": "  meld <スロット番号> <カード番号...>（例: meld 0 1 2 3）",
+  "helpExampleDraw": "  ds                   手番の最初に山札から 1 枚引く",
+  "helpExampleDiscard": "  d 0                  手札の 0 番を捨てる"
 }

--- a/internal/i18n/locales/ja/chinchon.json
+++ b/internal/i18n/locales/ja/chinchon.json
@@ -36,5 +36,7 @@
   "meldedLine": "  メルド済み: {{melds}}",
   "deadwoodBreakdown": "  デッドウッド: {{cards}} ({{sum}} = {{total}})",
   "deadwoodLine": "デッドウッド: {{value}}点 (ノック閾値 {{threshold}}点以下)",
-  "knockReady": "→ ノック可能"
+  "knockReady": "→ ノック可能",
+  "helpExampleDraw": "  ds                   手番の最初に山札から 1 枚引く",
+  "helpExampleDiscard": "  d 0                  手札の 0 番を捨てる"
 }

--- a/internal/i18n/locales/ja/conquian.json
+++ b/internal/i18n/locales/ja/conquian.json
@@ -27,5 +27,7 @@
   "promptRoundEnd": "ラウンド終了",
   "promptRoundEndHelp": "nr / nextround・・・次のラウンドへ",
   "result.humanWin": "ゲーム終了！ あなたの勝ち！",
-  "result.cpuWin": "ゲーム終了！ CPU {{cpuId}}の勝ち！"
+  "result.cpuWin": "ゲーム終了！ CPU {{cpuId}}の勝ち！",
+  "helpExampleDraw": "  ds                   手番の最初に山札から 1 枚引く",
+  "helpExampleDiscard": "  d 0                  手札の 0 番を捨てる"
 }

--- a/internal/i18n/locales/ja/contractrummy.json
+++ b/internal/i18n/locales/ja/contractrummy.json
@@ -30,5 +30,7 @@
   "promptPlayHelpLayoff": "lo <pIdx> <mIdx> <cIdx>・・・既存メルドにカード追加",
   "promptPlayHelpDiscard": "d <idx>・・・カードを捨てる",
   "promptRoundEnd": "ラウンド終了",
-  "promptRoundEndHelp": "nr / nextround・・・次のラウンドへ"
+  "promptRoundEndHelp": "nr / nextround・・・次のラウンドへ",
+  "helpExampleDraw": "  ds                   手番の最初に山札から 1 枚引く",
+  "helpExampleDiscard": "  d 0                  手札の 0 番を捨てる"
 }

--- a/internal/i18n/locales/ja/ginrummy.json
+++ b/internal/i18n/locales/ja/ginrummy.json
@@ -28,5 +28,7 @@
   "promptLayoffHelp": "lo <idx,idx,...>・・・レイオフするカードを選択",
   "promptLayoffSkip": "lo・・・レイオフなしでスコアリング",
   "promptRoundEnd": "ラウンド終了",
-  "promptRoundEndHelp": "nr / nextround・・・次のラウンドへ"
+  "promptRoundEndHelp": "nr / nextround・・・次のラウンドへ",
+  "helpExampleDraw": "  ds                   手番の最初に山札から 1 枚引く",
+  "helpExampleDiscard": "  d 0                  手札の 0 番を捨てる"
 }

--- a/internal/i18n/locales/ja/golf.json
+++ b/internal/i18n/locales/ja/golf.json
@@ -13,5 +13,6 @@
   "roundComplete": "{{holes}}ホール終了！ 合計 {{total}} 打",
   "hintRemove": "ヒント: カード除去: 列{{col}}",
   "hintDraw": "ヒント: ストックからカードを引いてください",
-  "hintUnknown": "ヒント: 不明"
+  "hintUnknown": "ヒント: 不明",
+  "helpExampleHint": "  h                        次の一手を教えてもらう"
 }

--- a/internal/i18n/locales/ja/handandfoot.json
+++ b/internal/i18n/locales/ja/handandfoot.json
@@ -47,5 +47,7 @@
   "goOutBlocked": "  まだ上がれません: {{reasons}}",
   "goOutNeedFoot": "フット未突入",
   "goOutNeedRed": "赤キャナスタ {{have}}/{{need}}",
-  "goOutNeedBlack": "黒キャナスタ {{have}}/{{need}}"
+  "goOutNeedBlack": "黒キャナスタ {{have}}/{{need}}",
+  "helpExampleDraw": "  ds                   手番の最初に山札から 1 枚引く",
+  "helpExampleDiscard": "  d 0                  手札の 0 番を捨てる"
 }

--- a/internal/i18n/locales/ja/indianrummy.json
+++ b/internal/i18n/locales/ja/indianrummy.json
@@ -23,5 +23,7 @@
   "promptDiscardHelp": "d <idx>・・・カードを捨てる",
   "promptDeclareHelp": "de <idx>・・・宣言 (14枚目を捨てて上がり)",
   "promptRoundEnd": "ラウンド終了",
-  "promptRoundEndHelp": "nr / nextround・・・次のラウンドへ"
+  "promptRoundEndHelp": "nr / nextround・・・次のラウンドへ",
+  "helpExampleDraw": "  ds                   手番の最初に山札から 1 枚引く",
+  "helpExampleDiscard": "  d 0                  手札の 0 番を捨てる"
 }

--- a/internal/i18n/locales/ja/kalooki.json
+++ b/internal/i18n/locales/ja/kalooki.json
@@ -30,5 +30,7 @@
   "promptRoundEnd": "ラウンド終了",
   "promptRoundEndHelp": "nr / nextround・・・次のラウンドへ",
   "result.humanWin": "あなたの勝利です！",
-  "result.cpuWin": "CPU {{cpuId}}の勝利です"
+  "result.cpuWin": "CPU {{cpuId}}の勝利です",
+  "helpExampleDraw": "  ds                   手番の最初に山札から 1 枚引く",
+  "helpExampleDiscard": "  d 0                  手札の 0 番を捨てる"
 }

--- a/internal/i18n/locales/ja/loba.json
+++ b/internal/i18n/locales/ja/loba.json
@@ -30,6 +30,5 @@
   "hintReasonDraw": "まず1枚引いてください",
   "hintReasonMeld": "この3枚でメルドになります",
   "hintReasonDiscard": "どこにも繋がらない札です",
-  "helpExampleDraw": "  ds                       手番の最初に山札から 1 枚引く",
-  "helpExampleDiscard": "  d 0                      手札の 0 番を捨てる"
+  "helpExampleDraw": "  ds                       手番の最初に山札から 1 枚引く"
 }

--- a/internal/i18n/locales/ja/loba.json
+++ b/internal/i18n/locales/ja/loba.json
@@ -29,5 +29,7 @@
   "hintReasonNotYourTurn": "あなたの手番ではありません",
   "hintReasonDraw": "まず1枚引いてください",
   "hintReasonMeld": "この3枚でメルドになります",
-  "hintReasonDiscard": "どこにも繋がらない札です"
+  "hintReasonDiscard": "どこにも繋がらない札です",
+  "helpExampleDraw": "  ds                       手番の最初に山札から 1 枚引く",
+  "helpExampleDiscard": "  d 0                      手札の 0 番を捨てる"
 }

--- a/internal/i18n/locales/ja/pyramid.json
+++ b/internal/i18n/locales/ja/pyramid.json
@@ -18,5 +18,6 @@
   "hintWastePair": "ヒント: ウェイスト+ピラミッド({{row}},{{col}})",
   "hintUnknown": "ヒント: 不明",
   "exposedKing": "({{row}},{{col}}){{card}}[K]",
-  "wasteKing": " | Waste: {{card}}[K]"
+  "wasteKing": " | Waste: {{card}}[K]",
+  "helpExampleHint": "  h                        次の一手を教えてもらう"
 }

--- a/internal/i18n/locales/ja/rummy500.json
+++ b/internal/i18n/locales/ja/rummy500.json
@@ -32,5 +32,7 @@
   "hintMeld": "メルド候補: {{cands}}（m <idx...> で場に出す）",
   "hintNoMeld": "メルドできる組み合わせがありません。d <idx> で捨て札を検討してください。",
   "hintLayoff": "レイオフ候補: {{cands}}",
-  "hintLayoffEntry": "{{card}} -> {{name}} の [{{meld}}]"
+  "hintLayoffEntry": "{{card}} -> {{name}} の [{{meld}}]",
+  "helpExampleDraw": "  ds                   手番の最初に山札から 1 枚引く",
+  "helpExampleDiscard": "  d 0                  手札の 0 番を捨てる"
 }

--- a/internal/i18n/locales/ja/samba.json
+++ b/internal/i18n/locales/ja/samba.json
@@ -35,5 +35,7 @@
   "promptGoOutHelp": "go・・・上がる (チームで2個以上の完成メルドが必要)",
   "promptRoundEnd": "ラウンド終了",
   "promptRoundEndHelp": "nr / nextround・・・次のラウンドへ",
-  "promptDrawHelpFrozen": "  ※凍結中: 捨札の取得には手札から同ランクの札2枚の提示が必要"
+  "promptDrawHelpFrozen": "  ※凍結中: 捨札の取得には手札から同ランクの札2枚の提示が必要",
+  "helpExampleDraw": "  ds                   手番の最初に山札から 1 枚引く",
+  "helpExampleDiscard": "  d 0                  手札の 0 番を捨てる"
 }

--- a/internal/i18n/locales/ja/sirtommy.json
+++ b/internal/i18n/locales/ja/sirtommy.json
@@ -29,5 +29,7 @@
   "stockLine": "ストック: {{count}}枚",
   "stockNext": " 次のカード: {{card}}",
   "hintStock": "ヒント: ストック → ファンデーション{{foundation}}",
-  "hintWaste": "ヒント: ウェイスト{{waste}} → ファンデーション{{foundation}}"
+  "hintWaste": "ヒント: ウェイスト{{waste}} → ファンデーション{{foundation}}",
+  "helpExampleHint": "  h                   次の一手を教えてもらう",
+  "helpExampleAuto": "  ac                  置ける札を自動で送る"
 }

--- a/internal/i18n/locales/ja/threethirteen.json
+++ b/internal/i18n/locales/ja/threethirteen.json
@@ -24,5 +24,7 @@
   "promptRoundEnd": "ラウンド終了",
   "promptRoundEndHelp": "nr / nextround・・・次のラウンドへ",
   "result.humanWin": "あなたの勝利です！",
-  "result.cpuWin": "CPU {{cpuId}}の勝利です"
+  "result.cpuWin": "CPU {{cpuId}}の勝利です",
+  "helpExampleDraw": "  ds                   手番の最初に山札から 1 枚引く",
+  "helpExampleDiscard": "  d 0                  手札の 0 番を捨てる"
 }

--- a/internal/i18n/locales/ja/tonk.json
+++ b/internal/i18n/locales/ja/tonk.json
@@ -27,5 +27,7 @@
   "meldRun": "ラン",
   "revealedHand": "{{name}}の手札: {{cards}}",
   "promptRoundEnd": "ラウンド終了",
-  "promptRoundEndHelp": "nr / nextround・・・次のラウンドへ"
+  "promptRoundEndHelp": "nr / nextround・・・次のラウンドへ",
+  "helpExampleDraw": "  ds                   手番の最初に山札から 1 枚引く",
+  "helpExampleDiscard": "  d 0                  手札の 0 番を捨てる"
 }

--- a/internal/i18n/locales/ja/tripeaks.json
+++ b/internal/i18n/locales/ja/tripeaks.json
@@ -14,5 +14,6 @@
   "wasteEmpty": " | Waste: [空]",
   "hintRemove": "ヒント: カード除去: ({{row}},{{col}})",
   "hintDraw": "ヒント: ストックからカードを引いてください",
-  "hintUnknown": "ヒント: 不明"
+  "hintUnknown": "ヒント: 不明",
+  "helpExampleHint": "  h                        次の一手を教えてもらう"
 }

--- a/internal/infrastructure/ui/GameManager.go
+++ b/internal/infrastructure/ui/GameManager.go
@@ -593,6 +593,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewGinRummyCuiController,
 		CuiHelpSpec{
 			TitleKey: "ginrummy.helpTitle",
+			ExampleKeys: []string{
+				"ginrummy.helpExampleDraw",
+				"ginrummy.helpExampleDiscard",
+			},
 			CommandKeys: []string{
 				"ginrummy.helpDrawStock",
 				"ginrummy.helpDrawDiscard",
@@ -611,6 +615,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewIndianRummyCuiController,
 		CuiHelpSpec{
 			TitleKey: "indianrummy.helpTitle",
+			ExampleKeys: []string{
+				"indianrummy.helpExampleDraw",
+				"indianrummy.helpExampleDiscard",
+			},
 			CommandKeys: []string{
 				"indianrummy.helpDrawStock",
 				"indianrummy.helpDrawDiscard",
@@ -774,6 +782,9 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewPyramidCuiController,
 		CuiHelpSpec{
 			TitleKey: "pyramid.helpTitle",
+			ExampleKeys: []string{
+				"pyramid.helpExampleHint",
+			},
 			CommandKeys: []string{
 				"pyramid.helpDraw",
 				"pyramid.helpRemoveKing",
@@ -792,6 +803,9 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewTriPeaksCuiController,
 		CuiHelpSpec{
 			TitleKey: "tripeaks.helpTitle",
+			ExampleKeys: []string{
+				"tripeaks.helpExampleHint",
+			},
 			CommandKeys: []string{
 				"tripeaks.helpDraw",
 				"tripeaks.helpRemove",
@@ -931,7 +945,10 @@ var gameRegistry = []GameRegistryEntry{
 		},
 		controller.NewGolfCuiController,
 		CuiHelpSpec{
-			TitleKey:          "golf.helpTitle",
+			TitleKey: "golf.helpTitle",
+			ExampleKeys: []string{
+				"golf.helpExampleHint",
+			},
 			CommandKeys:       []string{"golf.helpDraw", "golf.helpRemove", "golf.helpGiveUp", "golf.helpHint"},
 			ExtraCommandLines: []string{"  l                        action log"},
 		}),
@@ -1505,6 +1522,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewCalculationCuiController,
 		CuiHelpSpec{
 			TitleKey: "calculation.helpTitle",
+			ExampleKeys: []string{
+				"calculation.helpExampleHint",
+				"calculation.helpExampleAuto",
+			},
 			CommandKeys: []string{
 				"calculation.helpStockToFoundation",
 				"calculation.helpStockToWaste",
@@ -1523,6 +1544,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewSirTommyCuiController,
 		CuiHelpSpec{
 			TitleKey: "sirtommy.helpTitle",
+			ExampleKeys: []string{
+				"sirtommy.helpExampleHint",
+				"sirtommy.helpExampleAuto",
+			},
 			CommandKeys: []string{
 				"sirtommy.helpStockToFoundation",
 				"sirtommy.helpStockToWaste",
@@ -1986,6 +2011,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewLobaCuiController,
 		CuiHelpSpec{
 			TitleKey: "loba.helpTitle",
+			ExampleKeys: []string{
+				"loba.helpExampleDraw",
+				"loba.helpExampleDiscard",
+			},
 			CommandKeys: []string{
 				"loba.helpDrawStock",
 				"loba.helpDrawDiscard",
@@ -2126,6 +2155,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewTonkCuiController,
 		CuiHelpSpec{
 			TitleKey: "tonk.helpTitle",
+			ExampleKeys: []string{
+				"tonk.helpExampleDraw",
+				"tonk.helpExampleDiscard",
+			},
 			CommandKeys: []string{
 				"tonk.helpDrawStock",
 				"tonk.helpDrawDiscard",
@@ -2219,6 +2252,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewContractRummyCuiController,
 		CuiHelpSpec{
 			TitleKey: "contractrummy.helpTitle",
+			ExampleKeys: []string{
+				"contractrummy.helpExampleDraw",
+				"contractrummy.helpExampleDiscard",
+			},
 			CommandKeys: []string{
 				"contractrummy.helpDrawStock",
 				"contractrummy.helpDrawDiscard",
@@ -2657,6 +2694,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewRummy500CuiController,
 		CuiHelpSpec{
 			TitleKey: "rummy500.helpTitle",
+			ExampleKeys: []string{
+				"rummy500.helpExampleDraw",
+				"rummy500.helpExampleDiscard",
+			},
 			CommandKeys: []string{
 				"rummy500.helpDrawStock",
 				"rummy500.helpDrawDiscard",
@@ -3641,6 +3682,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewHandAndFootCuiController,
 		CuiHelpSpec{
 			TitleKey: "handandfoot.helpTitle",
+			ExampleKeys: []string{
+				"handandfoot.helpExampleDraw",
+				"handandfoot.helpExampleDiscard",
+			},
 			CommandKeys: []string{
 				"handandfoot.helpDrawStock",
 				"handandfoot.helpDrawDiscard",
@@ -3664,6 +3709,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewConquianCuiController,
 		CuiHelpSpec{
 			TitleKey: "conquian.helpTitle",
+			ExampleKeys: []string{
+				"conquian.helpExampleDraw",
+				"conquian.helpExampleDiscard",
+			},
 			CommandKeys: []string{
 				"conquian.helpDrawStock",
 				"conquian.helpDrawDiscard",
@@ -3684,6 +3733,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewChinchonCuiController,
 		CuiHelpSpec{
 			TitleKey: "chinchon.helpTitle",
+			ExampleKeys: []string{
+				"chinchon.helpExampleDraw",
+				"chinchon.helpExampleDiscard",
+			},
 			CommandKeys: []string{
 				"chinchon.helpDrawStock",
 				"chinchon.helpDrawDiscard",
@@ -3705,6 +3758,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewKalookiCuiController,
 		CuiHelpSpec{
 			TitleKey: "kalooki.helpTitle",
+			ExampleKeys: []string{
+				"kalooki.helpExampleDraw",
+				"kalooki.helpExampleDiscard",
+			},
 			CommandKeys: []string{
 				"kalooki.helpDrawStock",
 				"kalooki.helpDrawDiscard",
@@ -3727,6 +3784,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewThreeThirteenCuiController,
 		CuiHelpSpec{
 			TitleKey: "threethirteen.helpTitle",
+			ExampleKeys: []string{
+				"threethirteen.helpExampleDraw",
+				"threethirteen.helpExampleDiscard",
+			},
 			CommandKeys: []string{
 				"threethirteen.helpDrawStock",
 				"threethirteen.helpDrawDiscard",
@@ -4323,6 +4384,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewCariocaCuiController,
 		CuiHelpSpec{
 			TitleKey: "carioca.helpTitle",
+			ExampleKeys: []string{
+				"carioca.helpExampleDraw",
+				"carioca.helpExampleDiscard",
+			},
 			CommandKeys: []string{
 				"carioca.helpDrawStock",
 				"carioca.helpDrawDiscard",
@@ -4341,6 +4406,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewSambaCuiController,
 		CuiHelpSpec{
 			TitleKey: "samba.helpTitle",
+			ExampleKeys: []string{
+				"samba.helpExampleDraw",
+				"samba.helpExampleDiscard",
+			},
 			CommandKeys: []string{
 				"samba.helpDrawStock",
 				"samba.helpDrawDiscard",

--- a/internal/infrastructure/ui/GameManager.go
+++ b/internal/infrastructure/ui/GameManager.go
@@ -2013,7 +2013,6 @@ var gameRegistry = []GameRegistryEntry{
 			TitleKey: "loba.helpTitle",
 			ExampleKeys: []string{
 				"loba.helpExampleDraw",
-				"loba.helpExampleDiscard",
 			},
 			CommandKeys: []string{
 				"loba.helpDrawStock",


### PR DESCRIPTION
## 変更

例文つきのゲームが **232 → 250** になりました。残り 67。

- ラミー系 13 ゲーム: `ds` → `d 0`
- golf / pyramid / tripeaks: `h`
- calculation / sirtommy: `h` → `ac`

## 除外したもの

**canasta と burraco** は別ゲームのキーを描画しているため外しました。`canasta.helpExample*` を書いても誰も読まないロケール項目になります。prefix 一致のアサートが検出し、先に書き込まれていた項目は孤児にせず削除しています。

**egyptianratscrew と slapjack** も外しました。`sl` は叩ける場面が要るのでプローブが拒否を検出しました（プローブが正しく働いた例）。

## ガードが 2 件の誤りを止めました

**1. 重複行ガード** — `ds  draw from the stock` が loba のコマンド行と一字一句同じでした。例文は「手番のどこに位置する操作か」を言うべきなので、`start the turn by drawing from the stock` に変えています。

**2. その一括書き換えが klondike を壊した** — klondike には既に draw の例文があり、しかもその動詞は `ds` ではなく `d` です。**動詞ガードと実行ガードの両方**が落ちました。HEAD から復元し、他に既存例文を上書きしていないことも確認済み（0 件）。

## 検証

- `go test -tags test ./internal/infrastructure/ui/` — 緑
- `golangci-lint run ./internal/...` — 0 issues
- ja/en キーのパリティ: 0 件

Refs #5370