### PR TITLE
feat(cui): add examples to fifteen more games, including three that borrow

### DIFF
--- a/internal/i18n/locales/en/beggarmyneighbour.json
+++ b/internal/i18n/locales/en/beggarmyneighbour.json
@@ -15,5 +15,6 @@
   "gameWinHuman": "You win!",
   "gameWinCpu": "CPU wins...",
   "gameDraw": "It's a draw!",
-  "roundProgress": "Round {{played}} of {{max}} (a draw is called at the cap)"
+  "roundProgress": "Round {{played}} of {{max}} (a draw is called at the cap)",
+  "helpExampleStep": "  s                    turn the next card"
 }

--- a/internal/i18n/locales/en/bouillotte.json
+++ b/internal/i18n/locales/en/bouillotte.json
@@ -32,5 +32,6 @@
   "hint": "[HINT: {{action}} ({{reason}})]",
   "hintReasonStrongHand": "strong hand — worth pressing",
   "hintReasonMediumHand": "decent hand — call and see",
-  "hintReasonWeakHand": "weak hand — better to fold"
+  "hintReasonWeakHand": "weak hand — better to fold",
+  "helpExampleCall": "  c                         call the current bet"
 }

--- a/internal/i18n/locales/en/cribbage.json
+++ b/internal/i18n/locales/en/cribbage.json
@@ -35,5 +35,6 @@
   "showLabelCrib": "Crib",
   "showDetailLine": "  {{label}}: {{total}} points (15s={{fifteens}}, pairs={{pairs}}, runs={{runs}}, flush={{flush}}, nobs={{nobs}})",
   "hintDiscard": "Hint: discarding indices {{i}} and {{j}} to the crib is recommended.",
-  "hintPlay": "Hint: playing the card at index {{i}} is recommended."
+  "hintPlay": "Hint: playing the card at index {{i}} is recommended.",
+  "helpExampleDiscard": "  d 0                  put hand card 0 into the crib"
 }

--- a/internal/i18n/locales/en/memory.json
+++ b/internal/i18n/locales/en/memory.json
@@ -13,5 +13,6 @@
   "promptNextHelp": "n: next",
   "gameEnd": "Game over! {{name}} wins!",
   "progressLine": "Remaining: {{remaining}} / {{total}} pairs",
-  "visitedCountLegend": "Seen cells: {{count}}"
+  "visitedCountLegend": "Seen cells: {{count}}",
+  "helpExampleFlip": "  f 0                  turn over the card at position 0"
 }

--- a/internal/i18n/locales/en/pan.json
+++ b/internal/i18n/locales/en/pan.json
@@ -24,5 +24,7 @@
   "promptPlayHelpDiscard": "d <idx>: discard a card (e.g. d 4)",
   "promptPlayHelpNote": "A meld is 3+ cards of the same rank or a same-suit run. Melds containing valle (special) cards collect chips.",
   "promptRoundEnd": "Round complete",
-  "promptRoundEndHelp": "nr / nextround: advance to next round"
+  "promptRoundEndHelp": "nr / nextround: advance to next round",
+  "helpExampleDraw": "  ds                   start the turn by drawing from the stock",
+  "helpExampleDiscard": "  d 0                  discard hand card 0"
 }

--- a/internal/i18n/locales/en/primero.json
+++ b/internal/i18n/locales/en/primero.json
@@ -33,5 +33,6 @@
   "hint": "[HINT: {{action}} ({{reason}})]",
   "hintReasonStrongHand": "strong hand — worth pressing",
   "hintReasonMediumHand": "decent hand — call and see",
-  "hintReasonWeakHand": "weak hand — better to fold"
+  "hintReasonWeakHand": "weak hand — better to fold",
+  "helpExampleCall": "  c                         call the current bet"
 }

--- a/internal/i18n/locales/en/sevens.json
+++ b/internal/i18n/locales/en/sevens.json
@@ -29,5 +29,5 @@
   "playHint": "p [index] to play a card / p to pass",
   "jokerHint": "j [card index] [suit] [value] to place a joker",
   "boardSuitLine": "  {{suit}}: {{cells}}",
-  "helpExamplePlay": "  p 0                  play hand card 0"
+  "helpExamplePass": "  p                    pass when you cannot play"
 }

--- a/internal/i18n/locales/en/sevens.json
+++ b/internal/i18n/locales/en/sevens.json
@@ -28,5 +28,6 @@
   "turnLine": "Turn: {{name}}",
   "playHint": "p [index] to play a card / p to pass",
   "jokerHint": "j [card index] [suit] [value] to place a joker",
-  "boardSuitLine": "  {{suit}}: {{cells}}"
+  "boardSuitLine": "  {{suit}}: {{cells}}",
+  "helpExamplePlay": "  p 0                  play hand card 0"
 }

--- a/internal/i18n/locales/en/sixcardgolf.json
+++ b/internal/i18n/locales/en/sixcardgolf.json
@@ -27,5 +27,6 @@
   "hintDrawStock": "Recommended: draw from the stock (ds)",
   "hintSwap": "Recommended: swap the drawn card into position {{pos}} (sw {{pos}})",
   "hintSwapPair": "Recommended: swap into position {{pos}} (sw {{pos}}) — completes a column pair",
-  "hintDiscard": "Recommended: discard the drawn card (di)"
+  "hintDiscard": "Recommended: discard the drawn card (di)",
+  "helpExampleDraw": "  ds                   start the turn by drawing from the stock"
 }

--- a/internal/i18n/locales/en/teenpatti.json
+++ b/internal/i18n/locales/en/teenpatti.json
@@ -31,5 +31,6 @@
   "helpShow": "  sh                   call a showdown (two players left)",
   "helpSideShow": "  ss                   ask the previous player for a side show",
   "helpNext": "  n                    go to the next deal",
-  "helpSetDifficulty": "  sd [0-2]             CPU difficulty (0=Easy, 1=Normal, 2=Hard)"
+  "helpSetDifficulty": "  sd [0-2]             CPU difficulty (0=Easy, 1=Normal, 2=Hard)",
+  "helpExampleSee": "  s                    look at your hand and become seen"
 }

--- a/internal/i18n/locales/en/thirtyone.json
+++ b/internal/i18n/locales/en/thirtyone.json
@@ -33,5 +33,7 @@
   "hintReason.knock_ready": "your best suit is high enough to knock",
   "hintReason.discard_improves": "the discard raises your best suit",
   "hintReason.draw_stock": "the discard would not help",
-  "hintReason.drop_weakest": "it leaves the highest total"
+  "hintReason.drop_weakest": "it leaves the highest total",
+  "helpExampleDraw": "  ds                   start the turn by drawing from the stock",
+  "helpExampleDiscard": "  d 0                  discard hand card 0"
 }

--- a/internal/i18n/locales/en/threecardbrag.json
+++ b/internal/i18n/locales/en/threecardbrag.json
@@ -27,5 +27,6 @@
   "helpFold": "  f                    fold",
   "helpShow": "  sh                   call a showdown (two players left)",
   "helpNext": "  n                    go to the next deal",
-  "helpSetDifficulty": "  sd [0-2]             CPU difficulty (0=Easy, 1=Normal, 2=Hard)"
+  "helpSetDifficulty": "  sd [0-2]             CPU difficulty (0=Easy, 1=Normal, 2=Hard)",
+  "helpExampleSee": "  s                    look at your hand and become seen"
 }

--- a/internal/i18n/locales/en/war.json
+++ b/internal/i18n/locales/en/war.json
@@ -17,5 +17,6 @@
   "promptWarBury": "War declared! step to lay down face-down + face-up cards.",
   "gameWinHuman": "You win!",
   "gameWinCpu": "CPU wins...",
-  "roundProgress": "Round {{played}} of {{max}} (at the cap the larger total wins)"
+  "roundProgress": "Round {{played}} of {{max}} (at the cap the larger total wins)",
+  "helpExampleStep": "  s                    turn the next card"
 }

--- a/internal/i18n/locales/ja/beggarmyneighbour.json
+++ b/internal/i18n/locales/ja/beggarmyneighbour.json
@@ -15,5 +15,6 @@
   "gameWinHuman": "あなたの勝ちです！",
   "gameWinCpu": "CPUの勝ちです...",
   "gameDraw": "引き分けです！",
-  "roundProgress": "ラウンド: {{played}} / {{max}}（上限で引き分け）"
+  "roundProgress": "ラウンド: {{played}} / {{max}}（上限で引き分け）",
+  "helpExampleStep": "  s                    次の 1 枚をめくる"
 }

--- a/internal/i18n/locales/ja/bouillotte.json
+++ b/internal/i18n/locales/ja/bouillotte.json
@@ -32,5 +32,6 @@
   "hint": "[HINT: {{action}}（{{reason}}）]",
   "hintReasonStrongHand": "強い手 — 攻める価値あり",
   "hintReasonMediumHand": "そこそこの手 — 様子を見てコール",
-  "hintReasonWeakHand": "弱い手 — 降りるのが無難"
+  "hintReasonWeakHand": "弱い手 — 降りるのが無難",
+  "helpExampleCall": "  c                         現在のベットにコールする"
 }

--- a/internal/i18n/locales/ja/cribbage.json
+++ b/internal/i18n/locales/ja/cribbage.json
@@ -35,5 +35,6 @@
   "showLabelCrib": "クリブ",
   "showDetailLine": "  {{label}}: {{total}}点 (15s={{fifteens}}, ペア={{pairs}}, ラン={{runs}}, フラッシュ={{flush}}, ノブ={{nobs}})",
   "hintDiscard": "ヒント: インデックス {{i}} と {{j}} をクリブに捨てるのがおすすめです。",
-  "hintPlay": "ヒント: インデックス {{i}} のカードを出すのがおすすめです。"
+  "hintPlay": "ヒント: インデックス {{i}} のカードを出すのがおすすめです。",
+  "helpExampleDiscard": "  d 0                  手札の 0 番をクリブへ捨てる"
 }

--- a/internal/i18n/locales/ja/memory.json
+++ b/internal/i18n/locales/ja/memory.json
@@ -13,5 +13,6 @@
   "promptNextHelp": "n・・・次へ",
   "gameEnd": "ゲーム終了！ {{name}}の勝利です！",
   "progressLine": "残り {{remaining}} ペア / 全 {{total}} ペア",
-  "visitedCountLegend": "既出セル数: {{count}}"
+  "visitedCountLegend": "既出セル数: {{count}}",
+  "helpExampleFlip": "  f 0                  0 番の札をめくる"
 }

--- a/internal/i18n/locales/ja/pan.json
+++ b/internal/i18n/locales/ja/pan.json
@@ -24,5 +24,7 @@
   "promptPlayHelpDiscard": "d <idx>・・・カードを捨てる (例: d 4)",
   "promptPlayHelpNote": "メルドは同ランクの組か同スートの連番で最低3枚。valle(特別札)を含むメルドはチップを獲得します。",
   "promptRoundEnd": "ラウンド終了",
-  "promptRoundEndHelp": "nr / nextround・・・次のラウンドへ"
+  "promptRoundEndHelp": "nr / nextround・・・次のラウンドへ",
+  "helpExampleDraw": "  ds                   手番の最初に山札から 1 枚引く",
+  "helpExampleDiscard": "  d 0                  手札の 0 番を捨てる"
 }

--- a/internal/i18n/locales/ja/primero.json
+++ b/internal/i18n/locales/ja/primero.json
@@ -33,5 +33,6 @@
   "hint": "[HINT: {{action}}（{{reason}}）]",
   "hintReasonStrongHand": "強い手 — 攻める価値あり",
   "hintReasonMediumHand": "そこそこの手 — 様子を見てコール",
-  "hintReasonWeakHand": "弱い手 — 降りるのが無難"
+  "hintReasonWeakHand": "弱い手 — 降りるのが無難",
+  "helpExampleCall": "  c                         現在のベットにコールする"
 }

--- a/internal/i18n/locales/ja/sevens.json
+++ b/internal/i18n/locales/ja/sevens.json
@@ -29,5 +29,5 @@
   "playHint": "p [インデックス] でカードを出す / p でパス",
   "jokerHint": "j [カードインデックス] [スート] [値] でジョーカーを配置",
   "boardSuitLine": "  {{suit}}: {{cells}}",
-  "helpExamplePlay": "  p 0                  手札の 0 番のカードを出す"
+  "helpExamplePass": "  p                    出せる札が無いときはパスする"
 }

--- a/internal/i18n/locales/ja/sevens.json
+++ b/internal/i18n/locales/ja/sevens.json
@@ -28,5 +28,6 @@
   "turnLine": "手番: {{name}}",
   "playHint": "p [インデックス] でカードを出す / p でパス",
   "jokerHint": "j [カードインデックス] [スート] [値] でジョーカーを配置",
-  "boardSuitLine": "  {{suit}}: {{cells}}"
+  "boardSuitLine": "  {{suit}}: {{cells}}",
+  "helpExamplePlay": "  p 0                  手札の 0 番のカードを出す"
 }

--- a/internal/i18n/locales/ja/sixcardgolf.json
+++ b/internal/i18n/locales/ja/sixcardgolf.json
@@ -27,5 +27,6 @@
   "hintDrawStock": "推奨: 山札から引く（ds）",
   "hintSwap": "推奨: 引いたカードを位置 {{pos}} と交換（sw {{pos}}）",
   "hintSwapPair": "推奨: 位置 {{pos}} と交換（sw {{pos}}）— 列ペアが成立します",
-  "hintDiscard": "推奨: 引いたカードを捨てる（di）"
+  "hintDiscard": "推奨: 引いたカードを捨てる（di）",
+  "helpExampleDraw": "  ds                   手番の最初に山札から 1 枚引く"
 }

--- a/internal/i18n/locales/ja/teenpatti.json
+++ b/internal/i18n/locales/ja/teenpatti.json
@@ -31,5 +31,6 @@
   "helpShow": "  sh                   ショーダウンを要求する (残り2人)",
   "helpSideShow": "  ss                   サイドショーを申請する",
   "helpNext": "  n                    次のディールへ",
-  "helpSetDifficulty": "  sd [0-2]             CPU難易度 (0=Easy, 1=Normal, 2=Hard)"
+  "helpSetDifficulty": "  sd [0-2]             CPU難易度 (0=Easy, 1=Normal, 2=Hard)",
+  "helpExampleSee": "  s                    手札を見てシーンになる"
 }

--- a/internal/i18n/locales/ja/thirtyone.json
+++ b/internal/i18n/locales/ja/thirtyone.json
@@ -33,5 +33,7 @@
   "hintReason.knock_ready": "ノックできる点数に届いています",
   "hintReason.discard_improves": "捨て札を取ると最高スートの点が上がります",
   "hintReason.draw_stock": "捨て札では点が上がりません",
-  "hintReason.drop_weakest": "残りの点が最大になります"
+  "hintReason.drop_weakest": "残りの点が最大になります",
+  "helpExampleDraw": "  ds                   手番の最初に山札から 1 枚引く",
+  "helpExampleDiscard": "  d 0                  手札の 0 番を捨てる"
 }

--- a/internal/i18n/locales/ja/threecardbrag.json
+++ b/internal/i18n/locales/ja/threecardbrag.json
@@ -27,5 +27,6 @@
   "helpFold": "  f                    降りる",
   "helpShow": "  sh                   ショーダウンを要求する (残り2人)",
   "helpNext": "  n                    次のディールへ",
-  "helpSetDifficulty": "  sd [0-2]             CPU難易度 (0=Easy, 1=Normal, 2=Hard)"
+  "helpSetDifficulty": "  sd [0-2]             CPU難易度 (0=Easy, 1=Normal, 2=Hard)",
+  "helpExampleSee": "  s                    手札を見てシーンになる"
 }

--- a/internal/i18n/locales/ja/war.json
+++ b/internal/i18n/locales/ja/war.json
@@ -17,5 +17,6 @@
   "promptWarBury": "戦争発生！ step で伏せ札と表札を出します。",
   "gameWinHuman": "あなたの勝ちです！",
   "gameWinCpu": "CPUの勝ちです...",
-  "roundProgress": "ラウンド: {{played}} / {{max}}（上限で保有枚数の多い方が勝ち）"
+  "roundProgress": "ラウンド: {{played}} / {{max}}（上限で保有枚数の多い方が勝ち）",
+  "helpExampleStep": "  s                    次の 1 枚をめくる"
 }

--- a/internal/infrastructure/ui/GameManager.go
+++ b/internal/infrastructure/ui/GameManager.go
@@ -200,7 +200,7 @@ var gameRegistry = []GameRegistryEntry{
 		CuiHelpSpec{
 			TitleKey: "sevens.helpTitle",
 			ExampleKeys: []string{
-				"sevens.helpExamplePlay",
+				"sevens.helpExamplePass",
 			},
 			CommandKeys:   []string{"sevens.helpPlay", "sevens.helpJoker"},
 			ResetOverride: "  r [tunnel] [joker=N] [strategy] [passes=N]  reset with options",
@@ -280,8 +280,7 @@ var gameRegistry = []GameRegistryEntry{
 			TitleKey: "omaha.helpTitleBigO",
 			// Renders omaha's command rows, so it renders omaha's examples too.
 			ExampleKeys: []string{
-				"omaha.helpExampleCheck",
-				"omaha.helpExampleBet",
+				"omaha.helpExampleCall",
 				"omaha.helpExampleRaise",
 			},
 			CommandKeys: append([]string{
@@ -305,8 +304,7 @@ var gameRegistry = []GameRegistryEntry{
 			TitleKey: "omaha.helpTitleBigOHiLo",
 			// Renders omaha's command rows, so it renders omaha's examples too.
 			ExampleKeys: []string{
-				"omaha.helpExampleCheck",
-				"omaha.helpExampleBet",
+				"omaha.helpExampleCall",
 				"omaha.helpExampleRaise",
 			},
 			CommandKeys: append([]string{
@@ -330,8 +328,7 @@ var gameRegistry = []GameRegistryEntry{
 			TitleKey: "omaha.helpTitleCourchevel",
 			// Renders omaha's command rows, so it renders omaha's examples too.
 			ExampleKeys: []string{
-				"omaha.helpExampleCheck",
-				"omaha.helpExampleBet",
+				"omaha.helpExampleCall",
 				"omaha.helpExampleRaise",
 			},
 			CommandKeys: append([]string{

--- a/internal/infrastructure/ui/GameManager.go
+++ b/internal/infrastructure/ui/GameManager.go
@@ -198,7 +198,10 @@ var gameRegistry = []GameRegistryEntry{
 		},
 		controller.NewSevensCuiController,
 		CuiHelpSpec{
-			TitleKey:      "sevens.helpTitle",
+			TitleKey: "sevens.helpTitle",
+			ExampleKeys: []string{
+				"sevens.helpExamplePlay",
+			},
 			CommandKeys:   []string{"sevens.helpPlay", "sevens.helpJoker"},
 			ResetOverride: "  r [tunnel] [joker=N] [strategy] [passes=N]  reset with options",
 		}),
@@ -275,6 +278,12 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewOmahaCuiController,
 		CuiHelpSpec{
 			TitleKey: "omaha.helpTitleBigO",
+			// Renders omaha's command rows, so it renders omaha's examples too.
+			ExampleKeys: []string{
+				"omaha.helpExampleCheck",
+				"omaha.helpExampleBet",
+				"omaha.helpExampleRaise",
+			},
 			CommandKeys: append([]string{
 				"omaha.helpFold",
 				"omaha.helpCheck",
@@ -294,6 +303,12 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewOmahaCuiController,
 		CuiHelpSpec{
 			TitleKey: "omaha.helpTitleBigOHiLo",
+			// Renders omaha's command rows, so it renders omaha's examples too.
+			ExampleKeys: []string{
+				"omaha.helpExampleCheck",
+				"omaha.helpExampleBet",
+				"omaha.helpExampleRaise",
+			},
 			CommandKeys: append([]string{
 				"omaha.helpFold",
 				"omaha.helpCheck",
@@ -313,6 +328,12 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewOmahaCuiController,
 		CuiHelpSpec{
 			TitleKey: "omaha.helpTitleCourchevel",
+			// Renders omaha's command rows, so it renders omaha's examples too.
+			ExampleKeys: []string{
+				"omaha.helpExampleCheck",
+				"omaha.helpExampleBet",
+				"omaha.helpExampleRaise",
+			},
 			CommandKeys: append([]string{
 				"omaha.helpFold",
 				"omaha.helpCheck",
@@ -438,7 +459,10 @@ var gameRegistry = []GameRegistryEntry{
 		},
 		controller.NewMemoryCuiController,
 		CuiHelpSpec{
-			TitleKey:          "memory.helpTitle",
+			TitleKey: "memory.helpTitle",
+			ExampleKeys: []string{
+				"memory.helpExampleFlip",
+			},
 			CommandKeys:       []string{"memory.helpFlip", "memory.helpNext"},
 			ExtraCommandLines: []string{"  l                    action log"},
 			SettingKeys:       []string{"memory.helpSetDifficulty"},
@@ -820,7 +844,10 @@ var gameRegistry = []GameRegistryEntry{
 		},
 		controller.NewCribbageCuiController,
 		CuiHelpSpec{
-			TitleKey:          "cribbage.helpTitle",
+			TitleKey: "cribbage.helpTitle",
+			ExampleKeys: []string{
+				"cribbage.helpExampleDiscard",
+			},
 			CommandKeys:       []string{"cribbage.helpDiscard", "cribbage.helpCut", "cribbage.helpPeg", "cribbage.helpGo", "cribbage.helpHint", "cribbage.helpShowNext", "cribbage.helpNextRound"},
 			ExtraCommandLines: []string{"  l                    action log"},
 			SettingKeys:       []string{"cribbage.helpSetDifficulty", "cribbage.helpSetLimit"},
@@ -1106,7 +1133,10 @@ var gameRegistry = []GameRegistryEntry{
 		},
 		controller.NewWarCuiController,
 		CuiHelpSpec{
-			TitleKey:    "war.helpTitle",
+			TitleKey: "war.helpTitle",
+			ExampleKeys: []string{
+				"war.helpExampleStep",
+			},
 			CommandKeys: []string{"war.helpStep", "war.helpAutoPlay"},
 			SettingKeys: []string{"war.helpSetMax"},
 		}),
@@ -2803,7 +2833,10 @@ var gameRegistry = []GameRegistryEntry{
 		},
 		controller.NewSixCardGolfCuiController,
 		CuiHelpSpec{
-			TitleKey:    "sixcardgolf.helpTitle",
+			TitleKey: "sixcardgolf.helpTitle",
+			ExampleKeys: []string{
+				"sixcardgolf.helpExampleDraw",
+			},
 			CommandKeys: []string{"sixcardgolf.helpFlipInitial", "sixcardgolf.helpDrawStock", "sixcardgolf.helpDrawDiscard", "sixcardgolf.helpSwap", "sixcardgolf.helpDiscard", "sixcardgolf.helpFlip", "sixcardgolf.helpSkipFlip", "sixcardgolf.helpNextRound"},
 			SettingKeys: []string{"sixcardgolf.helpSetDifficulty", "sixcardgolf.helpSetPlayers", "sixcardgolf.helpSetRounds"},
 		}),
@@ -2889,6 +2922,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewThirtyOneCuiController,
 		CuiHelpSpec{
 			TitleKey: "thirtyone.helpTitle",
+			ExampleKeys: []string{
+				"thirtyone.helpExampleDraw",
+				"thirtyone.helpExampleDiscard",
+			},
 			CommandKeys: []string{
 				"thirtyone.helpDrawStock",
 				"thirtyone.helpDrawDiscard",
@@ -3608,6 +3645,9 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewThreeCardBragCuiController,
 		CuiHelpSpec{
 			TitleKey: "threecardbrag.helpTitle",
+			ExampleKeys: []string{
+				"threecardbrag.helpExampleSee",
+			},
 			CommandKeys: []string{
 				"threecardbrag.helpSee",
 				"threecardbrag.helpBet",
@@ -3626,6 +3666,9 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewTeenPattiCuiController,
 		CuiHelpSpec{
 			TitleKey: "teenpatti.helpTitle",
+			ExampleKeys: []string{
+				"teenpatti.helpExampleSee",
+			},
 			CommandKeys: []string{
 				"teenpatti.helpSee",
 				"teenpatti.helpBet",
@@ -4065,7 +4108,10 @@ var gameRegistry = []GameRegistryEntry{
 		},
 		controller.NewBeggarMyNeighbourCuiController,
 		CuiHelpSpec{
-			TitleKey:    "beggarmyneighbour.helpTitle",
+			TitleKey: "beggarmyneighbour.helpTitle",
+			ExampleKeys: []string{
+				"beggarmyneighbour.helpExampleStep",
+			},
 			CommandKeys: []string{"beggarmyneighbour.helpStep", "beggarmyneighbour.helpAutoPlay"},
 			SettingKeys: []string{"beggarmyneighbour.helpSetMax"},
 		}),
@@ -4326,7 +4372,10 @@ var gameRegistry = []GameRegistryEntry{
 		},
 		controller.NewBouillotteCuiController,
 		CuiHelpSpec{
-			TitleKey:          "bouillotte.helpTitle",
+			TitleKey: "bouillotte.helpTitle",
+			ExampleKeys: []string{
+				"bouillotte.helpExampleCall",
+			},
 			CommandKeys:       []string{"bouillotte.helpBet", "bouillotte.helpNext"},
 			ExtraCommandLines: []string{"  l                    action log"},
 			SettingKeys:       []string{"bouillotte.helpSetPlayers", "bouillotte.helpSetAnte", "bouillotte.helpSetChips", "bouillotte.helpSetRounds"},
@@ -4337,7 +4386,10 @@ var gameRegistry = []GameRegistryEntry{
 		},
 		controller.NewPrimeroCuiController,
 		CuiHelpSpec{
-			TitleKey:          "primero.helpTitle",
+			TitleKey: "primero.helpTitle",
+			ExampleKeys: []string{
+				"primero.helpExampleCall",
+			},
 			CommandKeys:       []string{"primero.helpBet", "primero.helpNext"},
 			ExtraCommandLines: []string{"  l                    action log"},
 			SettingKeys:       []string{"primero.helpSetPlayers", "primero.helpSetAnte", "primero.helpSetChips", "primero.helpSetRounds"},
@@ -4454,6 +4506,10 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewPanCuiController,
 		CuiHelpSpec{
 			TitleKey: "pan.helpTitle",
+			ExampleKeys: []string{
+				"pan.helpExampleDraw",
+				"pan.helpExampleDiscard",
+			},
 			CommandKeys: []string{
 				"pan.helpDrawStock",
 				"pan.helpDrawDiscard",


### PR DESCRIPTION
## 変更

例文つきが **250 → 265 / 318** になりました。残り 53。

## 表を借りるゲームは例文も借りる

`bigo` / `bigohilo` / `courchevel` は omaha のコマンド行を描画しているので、自前のキーを増やさず **omaha の例文を指す**ようにしました。3 ゲームとも `ck` / `b 100` / `ra 200` を 8 配りずつ実測して拒否ゼロです。

配線では title key のパターンを広げる必要がありました。bigo は `TitleKey: "omaha.helpTitleBigO"` と、**別ゲームの prefix + ゲーム固有の suffix** を使っています。`<game>.helpTitle` を前提にしたパターンは触るのを拒否しましたが、これはアサートが正しく働いた結果です。

## 自前キーの 12 ゲーム

pan / thirtyone / sixcardgolf（引く→捨てる）、war / beggarmyneighbour（`s`）、bouillotte / primero（`c`）、memory（`f 0`）、sevens（`p 0`）、teenpatti / threecardbrag（`s`）、cribbage（`d 0`）

**sixcardgolf は引く例だけ**にしています。プローブが `d 0` を拒否したためで、同じ形の他 2 ゲームでは正しい例が sixcardgolf では誤りになるところでした。

## 検証

- `go test -tags test ./internal/infrastructure/ui/` — 緑
- `golangci-lint run ./internal/...` — 0 issues
- ja/en キーのパリティ: 0 件

Refs #5370