### PR TITLE
feat(cui): add examples to twelve more games

### DIFF
--- a/internal/i18n/locales/en/auldlangsyne.json
+++ b/internal/i18n/locales/en/auldlangsyne.json
@@ -23,5 +23,6 @@
   "wasteEmpty": "(empty)",
   "wasteFilled": "{{card}} ({{count}})",
   "stockLine": "Stock: {{count}} ({{deals}} deals left)",
-  "hintWaste": "Hint: waste {{waste}} → foundation {{foundation}}"
+  "hintWaste": "Hint: waste {{waste}} → foundation {{foundation}}",
+  "helpExampleHint": "  h                   ask for a move"
 }

--- a/internal/i18n/locales/en/cassino.json
+++ b/internal/i18n/locales/en/cassino.json
@@ -28,5 +28,6 @@
   "hintBuild": "Suggestion: play {{card}} to make a build of {{value}} (build)",
   "hintTrail": "Suggestion: trail {{card}} (trail)",
   "hintNotYourTurn": "It is not your turn right now.",
-  "hintNoMove": "No move can be recommended."
+  "hintNoMove": "No move can be recommended.",
+  "helpExampleHint": "  h                        ask for a move"
 }

--- a/internal/i18n/locales/en/clocksolitaire.json
+++ b/internal/i18n/locales/en/clocksolitaire.json
@@ -13,5 +13,6 @@
   "gameClearLine": "Game clear! Steps: {{count}}",
   "gameOverLine": "Game over. Steps: {{count}}",
   "actionLogTitle": "Clock Solitaire Action Log",
-  "actionLogEntry": "[{{turn}}] {{detail}}"
+  "actionLogEntry": "[{{turn}}] {{detail}}",
+  "helpExampleStep": "  s                        turn the next card"
 }

--- a/internal/i18n/locales/en/colourwhist.json
+++ b/internal/i18n/locales/en/colourwhist.json
@@ -37,6 +37,5 @@
   "hintBid": "{{contract}} looks right ({{reason}})",
   "hintPlay": "Card {{index}} looks best ({{reason}})",
   "colourWhistBidStrength": "based on your hand's strength",
-  "colourWhistFollowSuit": "you must follow suit",
-  "helpExamplePass": "  pass                 stay out of this auction"
+  "colourWhistFollowSuit": "you must follow suit"
 }

--- a/internal/i18n/locales/en/cribbagesquares.json
+++ b/internal/i18n/locales/en/cribbagesquares.json
@@ -26,5 +26,6 @@
   "hintLine": "Hint: place {{card}} at ({{r}},{{c}}) - {{reason}}",
   "hintSynergy": "it makes fifteens, pairs or runs with what is already in that row or column",
   "hintAny": "nothing combines yet; any empty cell will do",
-  "gameComplete": "Game over. Total score: {{score}} (target {{target}})"
+  "gameComplete": "Game over. Total score: {{score}} (target {{target}})",
+  "helpExampleHint": "  h                        ask for a move"
 }

--- a/internal/i18n/locales/en/egyptianratscrew.json
+++ b/internal/i18n/locales/en/egyptianratscrew.json
@@ -33,5 +33,6 @@
   "responderCpu": "CPU",
   "chanceTrigger": "Triggered by: {{card}}",
   "difficultyRequired": "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).",
-  "difficultyInvalid": "Invalid CPU difficulty: %s. Please enter 0-2."
+  "difficultyInvalid": "Invalid CPU difficulty: %s. Please enter 0-2.",
+  "helpExampleStep": "  s                    turn the next card"
 }

--- a/internal/i18n/locales/en/montecarlo.json
+++ b/internal/i18n/locales/en/montecarlo.json
@@ -17,5 +17,6 @@
   "header": "Stock: {{stock}}  Removed: {{removed}}/52  Deals: {{deals}}",
   "hintLineRemove": "Hint: remove ({{r1}},{{c1}}) and ({{r2}},{{c2}})",
   "hintLineRemoveCard": "Hint: remove ({{r1}},{{c1}}){{card1}} and ({{r2}},{{c2}}){{card2}}",
-  "hintLineDeal": "Hint: deal from stock"
+  "hintLineDeal": "Hint: deal from stock",
+  "helpExampleHint": "  h                   ask for a move"
 }

--- a/internal/i18n/locales/en/president.json
+++ b/internal/i18n/locales/en/president.json
@@ -28,5 +28,6 @@
   "rankUnknown": "unknown",
   "hintPlay": "Suggestion: play hand [{{idxs}}] ({{cards}})",
   "hintPass": "Suggestion: no legal play — pass (p).",
-  "hintNotYourTurn": "It is not your turn right now."
+  "hintNotYourTurn": "It is not your turn right now.",
+  "helpExampleHint": "  h                    ask for a move"
 }

--- a/internal/i18n/locales/en/sevenbridge.json
+++ b/internal/i18n/locales/en/sevenbridge.json
@@ -31,5 +31,6 @@
   "hintNotYourTurn": "It is not your play phase right now.",
   "hintPon": "You can pon with {{idxs}} ({{cards}})",
   "hintChi": "You can chi with {{idxs}} ({{cards}})",
-  "hintDraw": "The discard is no use here; draw from the stock."
+  "hintDraw": "The discard is no use here; draw from the stock.",
+  "helpExampleHint": "  h                    ask for a move"
 }

--- a/internal/i18n/locales/en/slapjack.json
+++ b/internal/i18n/locales/en/slapjack.json
@@ -22,5 +22,6 @@
   "winHuman": "You win!",
   "winCpu": "CPU wins...",
   "difficultyRequired": "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).",
-  "difficultyInvalid": "Invalid CPU difficulty: %s. Please enter 0-2."
+  "difficultyInvalid": "Invalid CPU difficulty: %s. Please enter 0-2.",
+  "helpExampleStep": "  s                    turn the next card"
 }

--- a/internal/i18n/locales/en/snap.json
+++ b/internal/i18n/locales/en/snap.json
@@ -24,5 +24,6 @@
   "hintWait": "[HINT: wait ({{reason}})]",
   "hintReasonDeclare": "The top card matches the one before it",
   "hintReasonStep": "It is your turn to turn a card",
-  "hintReasonWait": "No match yet -- calling wrongly costs a card"
+  "hintReasonWait": "No match yet -- calling wrongly costs a card",
+  "helpExampleStep": "  s                    turn the next card"
 }

--- a/internal/i18n/locales/en/spiteandmalice.json
+++ b/internal/i18n/locales/en/spiteandmalice.json
@@ -37,5 +37,6 @@
   "hintDiscard": "Hint: discard hand[{{idx}}] to side[{{foundation}}]",
   "hintGoal": "Hint: goal → foundation {{foundation}}",
   "hintHand": "Hint: hand[{{idx}}] → foundation {{foundation}}",
-  "hintSide": "Hint: side[{{idx}}] → foundation {{foundation}}"
+  "hintSide": "Hint: side[{{idx}}] → foundation {{foundation}}",
+  "helpExampleHint": "  h                   ask for a move"
 }

--- a/internal/i18n/locales/en/trash.json
+++ b/internal/i18n/locales/en/trash.json
@@ -35,5 +35,6 @@
   "hintTakeDiscardWild": "The top discard is a wild -- take it and place it in any slot.",
   "hintDrawStock": "The discard is not useful. Draw from the stock.",
   "hintGameOver": "The game is over.",
-  "hintNotYourTurn": "It is not your turn right now."
+  "hintNotYourTurn": "It is not your turn right now.",
+  "helpExampleHint": "  h                   ask for a move"
 }

--- a/internal/i18n/locales/ja/auldlangsyne.json
+++ b/internal/i18n/locales/ja/auldlangsyne.json
@@ -23,5 +23,6 @@
   "wasteEmpty": "(空)",
   "wasteFilled": "{{card}} ({{count}}枚)",
   "stockLine": "ストック: {{count}}枚 (残り{{deals}}回配れます)",
-  "hintWaste": "ヒント: ウェイスト{{waste}} → ファンデーション{{foundation}}"
+  "hintWaste": "ヒント: ウェイスト{{waste}} → ファンデーション{{foundation}}",
+  "helpExampleHint": "  h                   次の一手を教えてもらう"
 }

--- a/internal/i18n/locales/ja/cassino.json
+++ b/internal/i18n/locales/ja/cassino.json
@@ -28,5 +28,6 @@
   "hintBuild": "推奨: 手札 {{card}} でビルド値 {{value}} を作成 (build)",
   "hintTrail": "推奨: 手札 {{card}} を場に置く (trail)",
   "hintNotYourTurn": "今はあなたの番ではありません。",
-  "hintNoMove": "推奨できる手がありません。"
+  "hintNoMove": "推奨できる手がありません。",
+  "helpExampleHint": "  h                        次の一手を教えてもらう"
 }

--- a/internal/i18n/locales/ja/clocksolitaire.json
+++ b/internal/i18n/locales/ja/clocksolitaire.json
@@ -13,5 +13,6 @@
   "gameClearLine": "ゲームクリア！ ステップ数: {{count}}",
   "gameOverLine": "ゲームオーバー ステップ数: {{count}}",
   "actionLogTitle": "Clock Solitaire Action Log",
-  "actionLogEntry": "[{{turn}}] {{detail}}"
+  "actionLogEntry": "[{{turn}}] {{detail}}",
+  "helpExampleStep": "  s                        次の 1 枚をめくる"
 }

--- a/internal/i18n/locales/ja/colourwhist.json
+++ b/internal/i18n/locales/ja/colourwhist.json
@@ -37,6 +37,5 @@
   "hintBid": "{{contract}} が良さそうです（{{reason}}）",
   "hintPlay": "{{index}} 番目の札が良さそうです（{{reason}}）",
   "colourWhistBidStrength": "手札の強さから見た契約",
-  "colourWhistFollowSuit": "フォローの義務がある",
-  "helpExamplePass": "  pass                 この競りには乗らない"
+  "colourWhistFollowSuit": "フォローの義務がある"
 }

--- a/internal/i18n/locales/ja/cribbagesquares.json
+++ b/internal/i18n/locales/ja/cribbagesquares.json
@@ -26,5 +26,6 @@
   "hintLine": "ヒント: {{card}} を ({{r}},{{c}}) に置く - {{reason}}",
   "hintSynergy": "同じ行・列の既存カードと15・ペア・ランを作れます",
   "hintAny": "まだ噛み合うカードがありません。空きマスならどこでも大丈夫です",
-  "gameComplete": "ゲーム終了 合計得点: {{score}} (クリア基準 {{target}}点)"
+  "gameComplete": "ゲーム終了 合計得点: {{score}} (クリア基準 {{target}}点)",
+  "helpExampleHint": "  h                        次の一手を教えてもらう"
 }

--- a/internal/i18n/locales/ja/egyptianratscrew.json
+++ b/internal/i18n/locales/ja/egyptianratscrew.json
@@ -33,5 +33,6 @@
   "responderCpu": "CPU",
   "chanceTrigger": "発動カード: {{card}}",
   "difficultyRequired": "CPU難易度を指定してください (0=Easy, 1=Normal, 2=Hard)。",
-  "difficultyInvalid": "CPU難易度が不正です: %s。0〜2 を指定してください。"
+  "difficultyInvalid": "CPU難易度が不正です: %s。0〜2 を指定してください。",
+  "helpExampleStep": "  s                    次の 1 枚をめくる"
 }

--- a/internal/i18n/locales/ja/montecarlo.json
+++ b/internal/i18n/locales/ja/montecarlo.json
@@ -17,5 +17,6 @@
   "header": "残り山札: {{stock}}  取り除いた枚数: {{removed}}/52  補充回数: {{deals}}",
   "hintLineRemove": "ヒント: ({{r1}},{{c1}}) と ({{r2}},{{c2}}) を取り除く",
   "hintLineRemoveCard": "ヒント: ({{r1}},{{c1}}){{card1}} と ({{r2}},{{c2}}){{card2}} を取り除く",
-  "hintLineDeal": "ヒント: 山札から補充 (deal)"
+  "hintLineDeal": "ヒント: 山札から補充 (deal)",
+  "helpExampleHint": "  h                   次の一手を教えてもらう"
 }

--- a/internal/i18n/locales/ja/president.json
+++ b/internal/i18n/locales/ja/president.json
@@ -28,5 +28,6 @@
   "rankUnknown": "不明",
   "hintPlay": "推奨: 手札 [{{idxs}}] ({{cards}}) を出す",
   "hintPass": "推奨: 出せる手がないのでパス (p) しましょう。",
-  "hintNotYourTurn": "今はあなたの番ではありません。"
+  "hintNotYourTurn": "今はあなたの番ではありません。",
+  "helpExampleHint": "  h                    次の一手を教えてもらう"
 }

--- a/internal/i18n/locales/ja/sevenbridge.json
+++ b/internal/i18n/locales/ja/sevenbridge.json
@@ -31,5 +31,6 @@
   "hintNotYourTurn": "今はあなたのプレイフェーズではありません。",
   "hintPon": "ポンできます: 手札 {{idxs}} ({{cards}})",
   "hintChi": "チーできます: 手札 {{idxs}} ({{cards}})",
-  "hintDraw": "捨て札は使えません。山札から引きましょう。"
+  "hintDraw": "捨て札は使えません。山札から引きましょう。",
+  "helpExampleHint": "  h                    次の一手を教えてもらう"
 }

--- a/internal/i18n/locales/ja/slapjack.json
+++ b/internal/i18n/locales/ja/slapjack.json
@@ -22,5 +22,6 @@
   "winHuman": "あなたの勝ちです！",
   "winCpu": "CPUの勝ちです...",
   "difficultyRequired": "CPU難易度を指定してください (0=Easy, 1=Normal, 2=Hard)。",
-  "difficultyInvalid": "CPU難易度が不正です: %s。0〜2 を指定してください。"
+  "difficultyInvalid": "CPU難易度が不正です: %s。0〜2 を指定してください。",
+  "helpExampleStep": "  s                    次の 1 枚をめくる"
 }

--- a/internal/i18n/locales/ja/snap.json
+++ b/internal/i18n/locales/ja/snap.json
@@ -24,5 +24,6 @@
   "hintWait": "[HINT: 待つ ({{reason}})]",
   "hintReasonDeclare": "直前の札と同じランクが出ている",
   "hintReasonStep": "あなたがめくる番",
-  "hintReasonWait": "まだ揃っていない。誤宣言はペナルティ"
+  "hintReasonWait": "まだ揃っていない。誤宣言はペナルティ",
+  "helpExampleStep": "  s                    次の 1 枚をめくる"
 }

--- a/internal/i18n/locales/ja/spiteandmalice.json
+++ b/internal/i18n/locales/ja/spiteandmalice.json
@@ -37,5 +37,6 @@
   "hintDiscard": "ヒント: 手札{{idx}} をサイド{{foundation}} にディスカード",
   "hintGoal": "ヒント: ゴール → ファウンデーション{{foundation}}",
   "hintHand": "ヒント: 手札{{idx}} → ファウンデーション{{foundation}}",
-  "hintSide": "ヒント: サイド{{idx}} → ファウンデーション{{foundation}}"
+  "hintSide": "ヒント: サイド{{idx}} → ファウンデーション{{foundation}}",
+  "helpExampleHint": "  h                   次の一手を教えてもらう"
 }

--- a/internal/i18n/locales/ja/trash.json
+++ b/internal/i18n/locales/ja/trash.json
@@ -35,5 +35,6 @@
   "hintTakeDiscardWild": "捨て札の一番上はワイルドです。取って好きなスロットに置けます。",
   "hintDrawStock": "捨て札は使えません。山札から引きましょう。",
   "hintGameOver": "ゲームは終了しています。",
-  "hintNotYourTurn": "今はあなたの番ではありません。"
+  "hintNotYourTurn": "今はあなたの番ではありません。",
+  "helpExampleHint": "  h                   次の一手を教えてもらう"
 }

--- a/internal/infrastructure/ui/GameManager.go
+++ b/internal/infrastructure/ui/GameManager.go
@@ -1013,7 +1013,10 @@ var gameRegistry = []GameRegistryEntry{
 		},
 		controller.NewClockSolitaireCuiController,
 		CuiHelpSpec{
-			TitleKey:          "clocksolitaire.helpTitle",
+			TitleKey: "clocksolitaire.helpTitle",
+			ExampleKeys: []string{
+				"clocksolitaire.helpExampleStep",
+			},
 			CommandKeys:       []string{"clocksolitaire.helpStep", "clocksolitaire.helpAutoPlay", "clocksolitaire.helpUndo"},
 			ExtraCommandLines: []string{"  l                        action log"},
 		}),
@@ -1459,6 +1462,9 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewTrashCuiController,
 		CuiHelpSpec{
 			TitleKey: "trash.helpTitle",
+			ExampleKeys: []string{
+				"trash.helpExampleHint",
+			},
 			CommandKeys: []string{
 				"trash.helpDraw",
 				"trash.helpPlace",
@@ -1474,6 +1480,9 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewSevenBridgeCuiController,
 		CuiHelpSpec{
 			TitleKey: "sevenbridge.helpTitle",
+			ExampleKeys: []string{
+				"sevenbridge.helpExampleHint",
+			},
 			CommandKeys: []string{
 				"sevenbridge.helpDrawStock",
 				"sevenbridge.helpPon",
@@ -1493,6 +1502,9 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewPresidentCuiController,
 		CuiHelpSpec{
 			TitleKey: "president.helpTitle",
+			ExampleKeys: []string{
+				"president.helpExampleHint",
+			},
 			CommandKeys: []string{
 				"president.helpPlay",
 				"president.helpPass",
@@ -1511,6 +1523,9 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewCassinoCuiController,
 		CuiHelpSpec{
 			TitleKey: "cassino.helpTitle",
+			ExampleKeys: []string{
+				"cassino.helpExampleHint",
+			},
 			CommandKeys: []string{
 				"cassino.helpTake",
 				"cassino.helpBuild",
@@ -1763,6 +1778,9 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewSpiteAndMaliceCuiController,
 		CuiHelpSpec{
 			TitleKey: "spiteandmalice.helpTitle",
+			ExampleKeys: []string{
+				"spiteandmalice.helpExampleHint",
+			},
 			CommandKeys: []string{
 				"spiteandmalice.helpPlayHand",
 				"spiteandmalice.helpPlayGoal",
@@ -2131,6 +2149,9 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewSlapjackCuiController,
 		CuiHelpSpec{
 			TitleKey: "slapjack.helpTitle",
+			ExampleKeys: []string{
+				"slapjack.helpExampleStep",
+			},
 			CommandKeys: []string{
 				"slapjack.helpStep",
 				"slapjack.helpSlap",
@@ -2146,6 +2167,9 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewEgyptianRatscrewCuiController,
 		CuiHelpSpec{
 			TitleKey: "egyptianratscrew.helpTitle",
+			ExampleKeys: []string{
+				"egyptianratscrew.helpExampleStep",
+			},
 			CommandKeys: []string{
 				"egyptianratscrew.helpStep",
 				"egyptianratscrew.helpSlap",
@@ -2262,6 +2286,9 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewMonteCarloCuiController,
 		CuiHelpSpec{
 			TitleKey: "montecarlo.helpTitle",
+			ExampleKeys: []string{
+				"montecarlo.helpExampleHint",
+			},
 			CommandKeys: []string{
 				"montecarlo.helpRemove",
 				"montecarlo.helpDeal",
@@ -5015,6 +5042,9 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewAuldLangSyneCuiController,
 		CuiHelpSpec{
 			TitleKey: "auldlangsyne.helpTitle",
+			ExampleKeys: []string{
+				"auldlangsyne.helpExampleHint",
+			},
 			CommandKeys: []string{
 				"auldlangsyne.helpDeal",
 				"auldlangsyne.helpWasteToFoundation",
@@ -5101,6 +5131,9 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewCribbageSquaresCuiController,
 		CuiHelpSpec{
 			TitleKey: "cribbagesquares.helpTitle",
+			ExampleKeys: []string{
+				"cribbagesquares.helpExampleHint",
+			},
 			CommandKeys: []string{
 				"cribbagesquares.helpPlace",
 				"cribbagesquares.helpHint",
@@ -5533,6 +5566,9 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewSnapCuiController,
 		CuiHelpSpec{
 			TitleKey: "snap.helpTitle",
+			ExampleKeys: []string{
+				"snap.helpExampleStep",
+			},
 			CommandKeys: []string{
 				"snap.helpStep",
 				"snap.helpSnap",

--- a/internal/infrastructure/ui/GameManager.go
+++ b/internal/infrastructure/ui/GameManager.go
@@ -5737,9 +5737,6 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewColourWhistCuiController,
 		CuiHelpSpec{
 			TitleKey: "colourwhist.helpTitle",
-			ExampleKeys: []string{
-				"colourwhist.helpExamplePass",
-			},
 			CommandKeys: []string{
 				"colourwhist.helpPlay",
 				"colourwhist.helpBid",


### PR DESCRIPTION
## 変更

例文つきが **265 → 277 / 318** になりました。残り 41。

- ヒントを持つ 8 ゲーム: `h`
- 1 枚ずつめくる 4 ゲーム（clocksolitaire / egyptianratscrew / slapjack / snap）: `s`

## tusac を外しています

tusac も `helpHint` を持ちますが、**プローブが `h` を拒否**しました。他の 7 ゲームと見た目は同じでも別の例文が要るということなので、この回には含めていません。

## 検証

- ゲームごと 6 配りで実測、tusac 以外に拒否なし
- `go test -tags test ./internal/infrastructure/ui/` — 緑
- `golangci-lint run ./internal/...` — 0 issues

Refs #5370