### PR TITLE
fix(cui): refuse a mistyped optional argument instead of defaulting it

### DIFF
--- a/internal/adapter/controller/BlackJackCuiController.go
+++ b/internal/adapter/controller/BlackJackCuiController.go
@@ -71,9 +71,18 @@ func (bcc *BlackJackCuiController) Exec(command string) string {
 				if !ok {
 					return errMsg, true
 				}
-				ppBet := cuiutil.ParseOptionalInt(args, 1, 0)
-				t3Bet := cuiutil.ParseOptionalInt(args, 2, 0)
-				handCount := cuiutil.ParseOptionalInt(args, 3, 0)
+				ppBet, errMsg, ok := cuiutil.ParseOptionalIntKeys(args, 1, 0, "invalidPairPlusBet")
+				if !ok {
+					return errMsg, true
+				}
+				t3Bet, errMsg, ok := cuiutil.ParseOptionalIntKeys(args, 2, 0, "invalidTripsBet")
+				if !ok {
+					return errMsg, true
+				}
+				handCount, errMsg, ok := cuiutil.ParseOptionalIntKeys(args, 3, 0, "invalidHandCount")
+				if !ok {
+					return errMsg, true
+				}
 				return bcc.bji.Bet(amount, ppBet, t3Bet, handCount), true
 			case "ssr", "setsurrenderrule":
 				return cuiutil.WithParsedIntKeys(args, "surrenderRuleRequired", "invalidSurrenderRuleANumber02", 0, domain.BJSurrenderMax, bcc.bji.SetSurrenderRule)

--- a/internal/adapter/controller/BlackJackCuiController_test.go
+++ b/internal/adapter/controller/BlackJackCuiController_test.go
@@ -178,11 +178,13 @@ func TestBlackJackCuiController_BetWithSideBets(t *testing.T) {
 	t.Run("bet with PP only", func(t *testing.T) {
 		assert.Equal(t, mockOutput, tbc.Exec("b 100 10"))
 	})
-	t.Run("bet with invalid PP (ignored)", func(t *testing.T) {
-		assert.Equal(t, mockOutput, tbc.Exec("b 100 abc"))
+	// 打ち間違いは 0 に落とさず断る。落とすと「サイドベットを賭けたつもりが
+	// 賭けていない」局が静かに成立し、収支だけが合わなくなる。
+	t.Run("bet refuses a mistyped PP", func(t *testing.T) {
+		assert.Equal(t, msgKey("invalidPairPlusBet", "val", "abc"), tbc.Exec("b 100 abc"))
 	})
-	t.Run("bet with PP and invalid T3 (ignored)", func(t *testing.T) {
-		assert.Equal(t, mockOutput, tbc.Exec("b 100 10 xyz"))
+	t.Run("bet refuses a mistyped T3", func(t *testing.T) {
+		assert.Equal(t, msgKey("invalidTripsBet", "val", "xyz"), tbc.Exec("b 100 10 xyz"))
 	})
 }
 
@@ -200,8 +202,8 @@ func TestBlackJackCuiController_BetWithHandCount(t *testing.T) {
 	t.Run("bet with side bets and handCount", func(t *testing.T) {
 		assert.Equal(t, mockOutput, tbc.Exec("b 100 10 20 3"))
 	})
-	t.Run("bet with invalid handCount (ignored)", func(t *testing.T) {
-		assert.Equal(t, mockOutput, tbc.Exec("b 100 0 0 abc"))
+	t.Run("bet refuses a mistyped hand count", func(t *testing.T) {
+		assert.Equal(t, msgKey("invalidHandCount", "val", "abc"), tbc.Exec("b 100 0 0 abc"))
 	})
 }
 

--- a/internal/adapter/controller/SevensCuiController.go
+++ b/internal/adapter/controller/SevensCuiController.go
@@ -68,11 +68,24 @@ func (c *SevensCuiController) Exec(command string) string {
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "p", "play":
-				return c.sgi.Play(cuiutil.ParseOptionalInt(args, 0, -1)), true
+				idx, errMsg, ok := cuiutil.ParseOptionalIntKeys(args, 0, -1, "invalidCardIndex")
+				if !ok {
+					return errMsg, true
+				}
+				return c.sgi.Play(idx), true
 			case "j", "joker":
-				cardIdx := cuiutil.ParseOptionalInt(args, 0, 0)
-				targetSuit := cuiutil.ParseOptionalInt(args, 1, 0)
-				targetValue := cuiutil.ParseOptionalInt(args, 2, 0)
+				cardIdx, errMsg, ok := cuiutil.ParseOptionalIntKeys(args, 0, 0, "invalidCardIndex")
+				if !ok {
+					return errMsg, true
+				}
+				targetSuit, errMsg, ok := cuiutil.ParseOptionalIntKeys(args, 1, 0, "invalidSuit")
+				if !ok {
+					return errMsg, true
+				}
+				targetValue, errMsg, ok := cuiutil.ParseOptionalIntKeys(args, 2, 0, "invalidTargetValue")
+				if !ok {
+					return errMsg, true
+				}
 				return c.sgi.PlayJoker(cardIdx, targetSuit, targetValue), true
 			default:
 				return handleCuiLog(cmd, c.sgi.ActionLog)

--- a/internal/adapter/controller/SevensCuiController_test.go
+++ b/internal/adapter/controller/SevensCuiController_test.go
@@ -221,3 +221,38 @@ func TestSevensCuiController_Exec(t *testing.T) {
 		m.AssertCalled(t, "Reset")
 	})
 }
+
+// 打ち間違えた任意引数は既定値に落とさず断る。落とすと `p abc` が 0 番を出し、
+// プレイヤーが選んでいない札が場に出る (#5390)。
+func TestSevensCuiController_RefusesMistypedOptionalArgs(t *testing.T) {
+	mockOutput := `{"players":[],"currentTurn":0,"tableMinVals":[0,7,7,7,7],"tableMaxVals":[0,7,7,7,7],"gameEndFlag":false,"cpuActions":[],"humanAction":null,"message":""}`
+	newMock := func() *mockUsecases.MockSevensInteractor {
+		m := new(mockUsecases.MockSevensInteractor)
+		m.On("Reset").Return(mockOutput)
+		m.On("Play", mock.Anything).Return(mockOutput)
+		m.On("PlayJoker", mock.Anything, mock.Anything, mock.Anything).Return(mockOutput)
+		return m
+	}
+
+	t.Run("play refuses a mistyped index", func(t *testing.T) {
+		m := newMock()
+		out := controller.NewSevensCuiController(m).Exec("p abc")
+		assert.Equal(t, msgKey("invalidCardIndex", "val", "abc"), out)
+		m.AssertNotCalled(t, "Play", mock.Anything)
+	})
+
+	// **引数なしはパス。** 既定値 -1 が残っていることを一緒に見ておかないと、
+	// 断る側だけ直して省略形を壊しても気付けない。
+	t.Run("play with no argument still passes", func(t *testing.T) {
+		m := newMock()
+		assert.Equal(t, mockOutput, controller.NewSevensCuiController(m).Exec("p"))
+		m.AssertCalled(t, "Play", -1)
+	})
+
+	t.Run("joker refuses a mistyped suit", func(t *testing.T) {
+		m := newMock()
+		out := controller.NewSevensCuiController(m).Exec("j 0 xyz")
+		assert.Equal(t, msgKey("invalidSuit", "val", "xyz"), out)
+		m.AssertNotCalled(t, "PlayJoker", mock.Anything, mock.Anything, mock.Anything)
+	})
+}

--- a/internal/adapter/controller/SevensCuiController_test.go
+++ b/internal/adapter/controller/SevensCuiController_test.go
@@ -249,6 +249,22 @@ func TestSevensCuiController_RefusesMistypedOptionalArgs(t *testing.T) {
 		m.AssertCalled(t, "Play", -1)
 	})
 
+	// **3 つの引数それぞれに分岐がある。** 真ん中だけ試すと、両端が既定値に
+	// 落ちたままでもテストは緑になる。
+	t.Run("joker refuses a mistyped card index", func(t *testing.T) {
+		m := newMock()
+		out := controller.NewSevensCuiController(m).Exec("j abc")
+		assert.Equal(t, msgKey("invalidCardIndex", "val", "abc"), out)
+		m.AssertNotCalled(t, "PlayJoker", mock.Anything, mock.Anything, mock.Anything)
+	})
+
+	t.Run("joker refuses a mistyped target value", func(t *testing.T) {
+		m := newMock()
+		out := controller.NewSevensCuiController(m).Exec("j 0 1 zzz")
+		assert.Equal(t, msgKey("invalidTargetValue", "val", "zzz"), out)
+		m.AssertNotCalled(t, "PlayJoker", mock.Anything, mock.Anything, mock.Anything)
+	})
+
 	t.Run("joker refuses a mistyped suit", func(t *testing.T) {
 		m := newMock()
 		out := controller.NewSevensCuiController(m).Exec("j 0 xyz")

--- a/internal/adapter/controller/SpeedCuiController.go
+++ b/internal/adapter/controller/SpeedCuiController.go
@@ -40,13 +40,22 @@ func (c *SpeedCuiController) Exec(command string) string {
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "p", "play":
-				cardIdx := cuiutil.ParseOptionalInt(args, 0, 0)
-				pileIdx := cuiutil.ParseOptionalInt(args, 1, 0)
+				cardIdx, errMsg, ok := cuiutil.ParseOptionalIntKeys(args, 0, 0, "invalidCardIndex")
+				if !ok {
+					return errMsg, true
+				}
+				pileIdx, errMsg, ok := cuiutil.ParseOptionalIntKeys(args, 1, 0, "invalidPileIndex")
+				if !ok {
+					return errMsg, true
+				}
 				return c.si.Play(cardIdx, pileIdx), true
 			case "f", "flip":
 				return c.si.Flip(), true
 			case "sd", "setdifficulty":
-				val := cuiutil.ParseOptionalInt(args, 0, int(domain.SpeedCpuDifficultyNormal))
+				val, errMsg, ok := cuiutil.ParseOptionalIntKeys(args, 0, int(domain.SpeedCpuDifficultyNormal), "invalidCpuDifficulty")
+				if !ok {
+					return errMsg, true
+				}
 				cfg := c.si.GetConfig()
 				cfg.CpuDifficulty = domain.SpeedCpuDifficulty(val)
 				return c.si.ResetWithConfig(cfg), true

--- a/internal/adapter/controller/SpeedCuiController_test.go
+++ b/internal/adapter/controller/SpeedCuiController_test.go
@@ -98,3 +98,35 @@ func TestSpeedCuiController_Exec(t *testing.T) {
 		assert.NotEmpty(t, result)
 	})
 }
+
+// #5390: `p abc` が 0 番を出し、`sd abc` が Normal でゲームを配り直していた。
+func TestSpeedCuiController_RefusesMistypedOptionalArgs(t *testing.T) {
+	t.Run("play refuses a mistyped card index", func(t *testing.T) {
+		m := newSpeedCuiMock()
+		out := controller.NewSpeedCuiController(m).Exec("p abc")
+		assert.Equal(t, msgKey("invalidCardIndex", "val", "abc"), out)
+		m.AssertNotCalled(t, "Play", mock.Anything, mock.Anything)
+	})
+
+	t.Run("play refuses a mistyped pile index", func(t *testing.T) {
+		m := newSpeedCuiMock()
+		out := controller.NewSpeedCuiController(m).Exec("p 0 xyz")
+		assert.Equal(t, msgKey("invalidPileIndex", "val", "xyz"), out)
+		m.AssertNotCalled(t, "Play", mock.Anything, mock.Anything)
+	})
+
+	t.Run("play with no argument still plays the first card onto the first pile", func(t *testing.T) {
+		m := newSpeedCuiMock()
+		assert.Equal(t, "play-ok", controller.NewSpeedCuiController(m).Exec("p"))
+		m.AssertCalled(t, "Play", 0, 0)
+	})
+
+	// **設定コマンドは特に静か。** 断らないと打ち間違いが Normal での配り直しに
+	// なり、盤面が変わったこと以外に手掛かりが残らない。
+	t.Run("setdifficulty refuses a mistyped level", func(t *testing.T) {
+		m := newSpeedCuiMock()
+		out := controller.NewSpeedCuiController(m).Exec("sd abc")
+		assert.Equal(t, msgKey("invalidCpuDifficulty", "val", "abc"), out)
+		m.AssertNotCalled(t, "ResetWithConfig", mock.Anything)
+	})
+}

--- a/internal/adapter/controller/cuiutil/parse.go
+++ b/internal/adapter/controller/cuiutil/parse.go
@@ -48,6 +48,24 @@ func WithParsedInt(args []string, missingMsg, invalidMsg string, min, max int, f
 	return fn(v), true
 }
 
+// ParseOptionalIntKeys parses an optional argument. An absent argument takes
+// defaultVal, but a present-but-unparseable one is refused rather than
+// silently replaced: `p abc` used to play card 0, which is a move the player
+// never asked for.
+//
+// It returns (value, "", true) when the argument is absent or valid, and
+// (0, message, false) when it is present and cannot be parsed.
+func ParseOptionalIntKeys(args []string, idx, defaultVal int, invalidKey string) (int, string, bool) {
+	if len(args) <= idx {
+		return defaultVal, "", true
+	}
+	v, err := strconv.Atoi(args[idx])
+	if err != nil {
+		return 0, i18n.MarkError(i18n.Tf(invalidKey, "val", args[idx])), false
+	}
+	return v, "", true
+}
+
 // ParseOptionalInt parses args[idx] as an integer, returning defaultVal if absent or invalid.
 func ParseOptionalInt(args []string, idx, defaultVal int) int {
 	if len(args) <= idx {

--- a/internal/adapter/controller/cuiutil/parse_test.go
+++ b/internal/adapter/controller/cuiutil/parse_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 // --- ParseIntArg ---
@@ -281,4 +282,33 @@ func TestPrependSkippedWarning_WithSkipped(t *testing.T) {
 	assert.Contains(t, result, "'abc'")
 	assert.Contains(t, result, "game output")
 	assert.True(t, strings.Index(result, "'abc'") < strings.Index(result, "game output"))
+}
+
+// ParseOptionalIntKeys は「省略」と「打ち間違い」を区別する。既定値に差し替える
+// 実装では `p abc` が 0 番を出してしまい、プレイヤーが選んでいない手が通る。
+func TestParseOptionalIntKeys(t *testing.T) {
+	t.Run("absent takes the default", func(t *testing.T) {
+		v, msg, ok := cuiutil.ParseOptionalIntKeys(nil, 0, 7, "invalidCardIndex")
+		assert.True(t, ok)
+		assert.Equal(t, 7, v)
+		assert.Empty(t, msg)
+	})
+	t.Run("index past the end takes the default", func(t *testing.T) {
+		v, _, ok := cuiutil.ParseOptionalIntKeys([]string{"0"}, 1, -1, "invalidCardIndex")
+		assert.True(t, ok)
+		assert.Equal(t, -1, v)
+	})
+	t.Run("a valid argument wins over the default", func(t *testing.T) {
+		v, _, ok := cuiutil.ParseOptionalIntKeys([]string{"3"}, 0, 7, "invalidCardIndex")
+		assert.True(t, ok)
+		assert.Equal(t, 3, v)
+	})
+	t.Run("a typo is refused, not defaulted", func(t *testing.T) {
+		v, msg, ok := cuiutil.ParseOptionalIntKeys([]string{"abc"}, 0, 7, "invalidCardIndex")
+		assert.False(t, ok)
+		assert.Zero(t, v)
+		body, isErr := i18n.StripErrorPrefix(msg)
+		assert.True(t, isErr, "the refusal has to be marked or callers cannot tell it from output")
+		assert.Contains(t, body, "abc")
+	})
 }

--- a/internal/i18n/locales/en/common.json
+++ b/internal/i18n/locales/en/common.json
@@ -492,5 +492,10 @@
   "invalidRowRaw": "Invalid row: {{val}}.",
   "invalidToCol": "Invalid toCol: {{val}}.",
   "invalidToRow": "Invalid toRow: {{val}}.",
-  "trumpSuitRequiredWords": "Trump suit is required (s=spade, c=club, h=heart, d=diamond)."
+  "trumpSuitRequiredWords": "Trump suit is required (s=spade, c=club, h=heart, d=diamond).",
+  "invalidPileIndex": "Invalid pile index: {{val}}.",
+  "invalidTargetValue": "Invalid target value: {{val}}.",
+  "invalidPairPlusBet": "Invalid Pair Plus bet: {{val}}.",
+  "invalidTripsBet": "Invalid trips bet: {{val}}.",
+  "invalidHandCount": "Invalid hand count: {{val}}."
 }

--- a/internal/i18n/locales/ja/common.json
+++ b/internal/i18n/locales/ja/common.json
@@ -492,5 +492,10 @@
   "invalidRowRaw": "行が不正です: {{val}}。",
   "invalidToCol": "移動先の列が不正です: {{val}}。",
   "invalidToRow": "移動先の行が不正です: {{val}}。",
-  "trumpSuitRequiredWords": "切り札のスートを指定してください (s=スペード, c=クラブ, h=ハート, d=ダイヤ)。"
+  "trumpSuitRequiredWords": "切り札のスートを指定してください (s=スペード, c=クラブ, h=ハート, d=ダイヤ)。",
+  "invalidPileIndex": "山の番号が不正です: {{val}}。",
+  "invalidTargetValue": "指定した値が不正です: {{val}}。",
+  "invalidPairPlusBet": "ペアプラスの賭け金が不正です: {{val}}。",
+  "invalidTripsBet": "トリップスの賭け金が不正です: {{val}}。",
+  "invalidHandCount": "手の数が不正です: {{val}}。"
 }


### PR DESCRIPTION
`Refs #5390`. Stacked on #5406 -- **merge that first** (it carries the keys this uses).

## Measured, 20 deals per command

`ParseOptionalInt` could not tell *absent* from *unparseable* and returned the default
for both. Six commands executed a move the player never typed, every single time:

| game | command | executed |
|---|---|---|
| blackjack | `b 100 abc` | 20/20 — Pair Plus silently becomes 0 |
| sevens | `p abc` | 20/20 — plays card 0 |
| speed | `p abc` | 20/20 — plays card 0 |
| speed | `p 0 abc` | 20/20 — plays onto pile 0 |
| speed | `sd abc` | 20/20 — resets the game at Normal |
| sevens | `p 0 abc` | 20/20 |

**Five are fixed** (re-measured: 0/20). `ParseOptionalIntKeys` keeps the default for an
absent argument and refuses a present-but-unparseable one.

## blackjack's is the one that costs money

`b 100 abc` staked the main bet and quietly set the Pair Plus to nothing. The hand plays
out as if the player had never asked for the side bet; nothing on screen says otherwise
and only the balance disagrees.

## Three tests were named after the bug

```go
t.Run("bet with invalid PP (ignored)", ...)
t.Run("bet with PP and invalid T3 (ignored)", ...)
t.Run("bet with invalid handCount (ignored)", ...)
```

They assert the refusal now. A test named after the bug is how the bug survives.

## The sixth is a different bug

`sevens p 0 abc`: `p` reads one argument and the second is **surplus, not defaulted**.
Refusing surplus arguments is a policy decision for every command at once, so it is not
folded in here.

## Test plan

- [x] `TestParseOptionalIntKeys` — absent takes the default, index past the end takes the
      default, a valid argument wins, a typo is refused **and marked**
- [x] `go test -tags test ./internal/adapter/controller/... ./internal/infrastructure/ui/`
- [x] `golangci-lint run ./internal/adapter/controller/...` — 0 issues
- [x] probe re-measured on this tree: 6 commands → 1