### PR TITLE
feat(cui): add examples to eight more games, and drop colourwhist's

### DIFF
--- a/internal/i18n/locales/en/deuceswild.json
+++ b/internal/i18n/locales/en/deuceswild.json
@@ -9,5 +9,6 @@
   "hand.fullHouse": "Full House",
   "hand.flush": "Flush",
   "hand.straight": "Straight",
-  "hand.threeOfAKind": "Three of a Kind"
+  "hand.threeOfAKind": "Three of a Kind",
+  "helpExampleHint": "  hint                 see which cards to keep"
 }

--- a/internal/i18n/locales/en/jokerpoker.json
+++ b/internal/i18n/locales/en/jokerpoker.json
@@ -1,3 +1,4 @@
 {
-  "helpTitle": "Joker Poker (Kings or Better)"
+  "helpTitle": "Joker Poker (Kings or Better)",
+  "helpExampleHint": "  hint                 see which cards to keep"
 }

--- a/internal/i18n/locales/en/oldmaid.json
+++ b/internal/i18n/locales/en/oldmaid.json
@@ -24,5 +24,6 @@
   "gameEndLoser": "{{name}} loses!",
   "gameEndJijiNukiSuffix": " (removed card: {{card}})",
   "promptCurrentTurnWithTarget": "{{name}} to act → drawing from {{target}}",
-  "promptCurrentTurn": "{{name}} to act"
+  "promptCurrentTurn": "{{name}} to act",
+  "helpExampleD": "  d                    draw one card at random"
 }

--- a/internal/i18n/locales/en/omahahilo.json
+++ b/internal/i18n/locales/en/omahahilo.json
@@ -1,3 +1,4 @@
 {
-  "helpTitle": "Omaha Hi-Lo / 8 or Better"
+  "helpTitle": "Omaha Hi-Lo / 8 or Better",
+  "helpExampleF": "  f                    drop out of this hand"
 }

--- a/internal/i18n/locales/en/razz.json
+++ b/internal/i18n/locales/en/razz.json
@@ -1,3 +1,4 @@
 {
-  "helpTitle": "Razz"
+  "helpTitle": "Razz",
+  "helpExampleF": "  f                    drop out of this hand"
 }

--- a/internal/i18n/locales/en/sevencardstudhilo.json
+++ b/internal/i18n/locales/en/sevencardstudhilo.json
@@ -1,3 +1,4 @@
 {
-  "helpTitle": "Seven Card Stud Hi-Lo"
+  "helpTitle": "Seven Card Stud Hi-Lo",
+  "helpExampleF": "  f                    drop out of this hand"
 }

--- a/internal/i18n/locales/en/spanish21.json
+++ b/internal/i18n/locales/en/spanish21.json
@@ -20,5 +20,6 @@
   "payoutRef.bonusSixCard21": "6-card 21 (2:1)",
   "payoutRef.bonusSevenCard21": "7+ card 21 (3:1)",
   "payoutRef.bonus678": "6-7-8 (3:2 / same suit 2:1 / all spades 3:1)",
-  "payoutRef.bonus777": "7-7-7 (3:2 / same suit 2:1 / all spades 3:1)"
+  "payoutRef.bonus777": "7-7-7 (3:2 / same suit 2:1 / all spades 3:1)",
+  "helpExampleH": "  h                    take one more card"
 }

--- a/internal/i18n/locales/en/zwicker.json
+++ b/internal/i18n/locales/en/zwicker.json
@@ -22,5 +22,6 @@
   "hintReasonRoundEnd": "this deal is already over",
   "hintReasonNotYourTurn": "it is not your turn",
   "hintReasonTake": "this capture picks up scoring cards",
-  "hintReasonTrail": "nothing is takeable, so trail a card that scores nothing"
+  "hintReasonTrail": "nothing is takeable, so trail a card that scores nothing",
+  "helpExampleN": "  n                        move on to the next deal"
 }

--- a/internal/i18n/locales/ja/deuceswild.json
+++ b/internal/i18n/locales/ja/deuceswild.json
@@ -9,5 +9,6 @@
   "hand.fullHouse": "フルハウス",
   "hand.flush": "フラッシュ",
   "hand.straight": "ストレート",
-  "hand.threeOfAKind": "スリーカード"
+  "hand.threeOfAKind": "スリーカード",
+  "helpExampleHint": "  hint                 残す札の推奨を見る"
 }

--- a/internal/i18n/locales/ja/jokerpoker.json
+++ b/internal/i18n/locales/ja/jokerpoker.json
@@ -1,3 +1,4 @@
 {
-  "helpTitle": "Joker Poker (ジョーカーポーカー)"
+  "helpTitle": "Joker Poker (ジョーカーポーカー)",
+  "helpExampleHint": "  hint                 残す札の推奨を見る"
 }

--- a/internal/i18n/locales/ja/oldmaid.json
+++ b/internal/i18n/locales/ja/oldmaid.json
@@ -24,5 +24,6 @@
   "gameEndLoser": "{{name}}の負け！",
   "gameEndJijiNukiSuffix": "（除外カード: {{card}}）",
   "promptCurrentTurnWithTarget": "手番: {{name}} → {{target}}から引きます",
-  "promptCurrentTurn": "手番: {{name}}"
+  "promptCurrentTurn": "手番: {{name}}",
+  "helpExampleD": "  d                    相手から 1 枚引く (無作為)"
 }

--- a/internal/i18n/locales/ja/omahahilo.json
+++ b/internal/i18n/locales/ja/omahahilo.json
@@ -1,3 +1,4 @@
 {
-  "helpTitle": "Omaha Hi-Lo / 8 or Better (オマハ ハイロー)"
+  "helpTitle": "Omaha Hi-Lo / 8 or Better (オマハ ハイロー)",
+  "helpExampleF": "  f                    この手を降りる"
 }

--- a/internal/i18n/locales/ja/razz.json
+++ b/internal/i18n/locales/ja/razz.json
@@ -1,3 +1,4 @@
 {
-  "helpTitle": "Razz (ラズ)"
+  "helpTitle": "Razz (ラズ)",
+  "helpExampleF": "  f                    この手を降りる"
 }

--- a/internal/i18n/locales/ja/sevencardstudhilo.json
+++ b/internal/i18n/locales/ja/sevencardstudhilo.json
@@ -1,3 +1,4 @@
 {
-  "helpTitle": "セブンカードスタッド ハイロー (Seven Card Stud Hi-Lo)"
+  "helpTitle": "セブンカードスタッド ハイロー (Seven Card Stud Hi-Lo)",
+  "helpExampleF": "  f                    この手を降りる"
 }

--- a/internal/i18n/locales/ja/spanish21.json
+++ b/internal/i18n/locales/ja/spanish21.json
@@ -20,5 +20,6 @@
   "payoutRef.bonusSixCard21": "6枚で21 (2:1)",
   "payoutRef.bonusSevenCard21": "7枚以上で21 (3:1)",
   "payoutRef.bonus678": "6-7-8 (3:2 / 同スート 2:1 / 全スペード 3:1)",
-  "payoutRef.bonus777": "7-7-7 (3:2 / 同スート 2:1 / 全スペード 3:1)"
+  "payoutRef.bonus777": "7-7-7 (3:2 / 同スート 2:1 / 全スペード 3:1)",
+  "helpExampleH": "  h                    もう 1 枚引く"
 }

--- a/internal/i18n/locales/ja/zwicker.json
+++ b/internal/i18n/locales/ja/zwicker.json
@@ -22,5 +22,6 @@
   "hintReasonRoundEnd": "このディールは終わっています",
   "hintReasonNotYourTurn": "あなたの手番ではありません",
   "hintReasonTake": "得点札を含めて取れます",
-  "hintReasonTrail": "取れる札がないので、点にならない札を置きます"
+  "hintReasonTrail": "取れる札がないので、点にならない札を置きます",
+  "helpExampleN": "  n                        次のディールを配る"
 }

--- a/internal/infrastructure/ui/GameManager.go
+++ b/internal/infrastructure/ui/GameManager.go
@@ -166,6 +166,7 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewOldMaidCuiController,
 		CuiHelpSpec{
 			TitleKey:    "oldmaid.helpTitle",
+			ExampleKeys: []string{"oldmaid.helpExampleD"},
 			CommandKeys: []string{"oldmaid.helpDraw", "oldmaid.helpShuffle", "oldmaid.helpReorder"},
 			SettingKeys: []string{"oldmaid.helpSetMode", "oldmaid.helpSetPlacement", "oldmaid.helpSetMemoryAI"},
 		}),
@@ -258,7 +259,8 @@ var gameRegistry = []GameRegistryEntry{
 		},
 		controller.NewOmahaCuiController,
 		CuiHelpSpec{
-			TitleKey: "omahahilo.helpTitle",
+			TitleKey:    "omahahilo.helpTitle",
+			ExampleKeys: []string{"omahahilo.helpExampleF"},
 			CommandKeys: append([]string{
 				"omaha.helpFold",
 				"omaha.helpCheck",
@@ -759,6 +761,7 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewVideoPokerCuiController,
 		CuiHelpSpec{
 			TitleKey:          "deuceswild.helpTitle",
+			ExampleKeys:       []string{"deuceswild.helpExampleHint"},
 			CommandKeys:       []string{"videopoker.helpBet", "videopoker.helpHold", "videopoker.helpHint"},
 			ExtraCommandLines: []string{"  log                  action log"},
 		}),
@@ -769,6 +772,7 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewVideoPokerCuiController,
 		CuiHelpSpec{
 			TitleKey:          "jokerpoker.helpTitle",
+			ExampleKeys:       []string{"jokerpoker.helpExampleHint"},
 			CommandKeys:       []string{"videopoker.helpBet", "videopoker.helpHold", "videopoker.helpHint"},
 			ExtraCommandLines: []string{"  log                  action log"},
 		}),
@@ -1367,7 +1371,8 @@ var gameRegistry = []GameRegistryEntry{
 		},
 		controller.NewSevenCardStudCuiController,
 		CuiHelpSpec{
-			TitleKey: "razz.helpTitle",
+			TitleKey:    "razz.helpTitle",
+			ExampleKeys: []string{"razz.helpExampleF"},
 			CommandKeys: append([]string{
 				"sevencardstud.helpFold",
 				"sevencardstud.helpCheck",
@@ -1386,7 +1391,8 @@ var gameRegistry = []GameRegistryEntry{
 		},
 		controller.NewSevenCardStudCuiController,
 		CuiHelpSpec{
-			TitleKey: "sevencardstudhilo.helpTitle",
+			TitleKey:    "sevencardstudhilo.helpTitle",
+			ExampleKeys: []string{"sevencardstudhilo.helpExampleF"},
 			CommandKeys: append([]string{
 				"sevencardstud.helpFold",
 				"sevencardstud.helpCheck",
@@ -1551,7 +1557,8 @@ var gameRegistry = []GameRegistryEntry{
 		},
 		controller.NewBlackJackCuiController,
 		CuiHelpSpec{
-			TitleKey: "spanish21.helpTitle",
+			TitleKey:    "spanish21.helpTitle",
+			ExampleKeys: []string{"spanish21.helpExampleH"},
 			CommandKeys: []string{
 				"blackjack.helpBet",
 				"blackjack.helpHit",
@@ -4829,7 +4836,8 @@ var gameRegistry = []GameRegistryEntry{
 		},
 		controller.NewZwickerCuiController,
 		CuiHelpSpec{
-			TitleKey: "zwicker.helpTitle",
+			TitleKey:    "zwicker.helpTitle",
+			ExampleKeys: []string{"zwicker.helpExampleN"},
 			CommandKeys: []string{
 				"zwicker.helpTake",
 				"zwicker.helpBuild",


### PR DESCRIPTION
`Refs #5370`. Stacked on #5403 -- merge that first.

## Found by asking, not guessing

19 games still had no example. For each, every **argument-free** command in its
own table was run over 25 deals, keeping only the ones accepted every time:

| game | safe commands |
|---|---|
| omahahilo / razz / sevencardstudhilo | `f` and the setting commands |
| spanish21 | `h` `s` `d` `sp` `i` `di` |
| deuceswild / jokerpoker | `hint` |
| oldmaid | `d` `s` |
| zwicker | `n` |
| simplesimon / blackhole | `g` only |
| bigtwo, canasta, bridge, durak, pokersquares, tienlen, burraco, zheng | none |

Eight get an example here.

**simplesimon and blackhole are deliberately left without one**: their only
always-legal command is `g` (resign), and an example that tells the player to give
up is worse than no example. **doubt** is a legacy registration with no
`CuiHelpSpec`, so there is nowhere to wire `ExampleKeys`.

## colourwhist loses its example

`pass` is refused on **7 deals in 60** -- the auction is already over by the human's
first turn. All five of its argument-free commands, over 60 deals:

```
pass 53/60    hint 54/60    next 0/60    log 0/60    giveup 60/60
```

Only `giveup` never fails. So colourwhist joins simplesimon and blackhole with none.

This is the **third** wording this game has been through this session -- `hint`, then
`g` (which is not one of its commands), then `pass` -- and each replacement was
checked against a single deal. The lesson is the number: at 12%, one run is right
seven times out of eight.

## And the duplicate-line guard fired again

zwicker's English example was byte-identical to its own `n` command row. Second time
this session. An example says what the command does *in this situation*; it is not a
second copy of the table entry.

## Test plan

- [x] `go test -tags test ./internal/infrastructure/ui/` — green
- [x] `TestCuiHelp*` run **6 times** after the colourwhist removal, green every time
      (it was 1-in-5 red before)
- [x] `go build ./...`, `gofmt`