### PR TITLE
fix(cui): drop colourwhist's example -- develop is 12% red without this

### DIFF
--- a/internal/i18n/locales/en/colourwhist.json
+++ b/internal/i18n/locales/en/colourwhist.json
@@ -37,6 +37,5 @@
   "hintBid": "{{contract}} looks right ({{reason}})",
   "hintPlay": "Card {{index}} looks best ({{reason}})",
   "colourWhistBidStrength": "based on your hand's strength",
-  "colourWhistFollowSuit": "you must follow suit",
-  "helpExamplePass": "  pass                 stay out of this auction"
+  "colourWhistFollowSuit": "you must follow suit"
 }

--- a/internal/i18n/locales/ja/colourwhist.json
+++ b/internal/i18n/locales/ja/colourwhist.json
@@ -37,6 +37,5 @@
   "hintBid": "{{contract}} が良さそうです（{{reason}}）",
   "hintPlay": "{{index}} 番目の札が良さそうです（{{reason}}）",
   "colourWhistBidStrength": "手札の強さから見た契約",
-  "colourWhistFollowSuit": "フォローの義務がある",
-  "helpExamplePass": "  pass                 この競りには乗らない"
+  "colourWhistFollowSuit": "フォローの義務がある"
 }

--- a/internal/infrastructure/ui/GameManager.go
+++ b/internal/infrastructure/ui/GameManager.go
@@ -5648,9 +5648,6 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewColourWhistCuiController,
 		CuiHelpSpec{
 			TitleKey: "colourwhist.helpTitle",
-			ExampleKeys: []string{
-				"colourwhist.helpExamplePass",
-			},
 			CommandKeys: []string{
 				"colourwhist.helpPlay",
 				"colourwhist.helpBid",


### PR DESCRIPTION
`Refs #5370`. **Straight to develop, ahead of the example stack**, because the
defect is already merged: `colourwhist`'s `pass` example landed in #5399 and
develop's `TestCuiHelpExamplesExecute` fails on roughly one run in eight.

This is what took #5402's Backend Tests down; it is not that PR's change.

## Measured, 60 deals, every argument-free command

```
pass 53/60    hint 54/60    next 0/60    log 0/60    giveup 60/60
```

`pass` is refused on 7 deals in 60 — the auction is already over by the human's
first turn. Only `giveup` never fails, and an example that tells the player to
resign is worse than no example, so colourwhist joins simplesimon and blackhole
with none.

## Third time for this one game

`hint` (guard false positive) → `g` (**not one of its commands**) → `pass` (12%).
Each replacement was verified against a single deal, and at 12% a single run is
right seven times out of eight.

## Test plan

- [x] `TestCuiHelp*` run 5 times, green every time
- [x] `go build ./...`