### PR TITLE
feat(cui): mark the refusals that live inside a board

### DIFF
--- a/internal/adapter/presenter/BaccaratCuiPresenter.go
+++ b/internal/adapter/presenter/BaccaratCuiPresenter.go
@@ -73,7 +73,7 @@ func (bp *BaccaratCuiPresenter) Output(b interfaces.BaccaratGame, lastErr error)
 	sb.WriteString("----------\n")
 
 	if lastErr != nil {
-		sb.WriteString(color.Red(lastErr.Error()) + "\n")
+		sb.WriteString(i18n.MarkErrorLine(color.Red(lastErr.Error())) + "\n")
 	}
 
 	if b.GetGameEndFlag() {

--- a/internal/adapter/presenter/BlackJackCuiPresenter.go
+++ b/internal/adapter/presenter/BlackJackCuiPresenter.go
@@ -196,7 +196,7 @@ func (bjp *BlackJackCuiPresenter) Output(bj interfaces.BlackJackGame, lastErr er
 	}
 
 	if lastErr != nil {
-		fmt.Fprintf(&b, "%s\n", color.Red(lastErr.Error()))
+		fmt.Fprintf(&b, "%s\n", i18n.MarkErrorLine(color.Red(lastErr.Error())))
 	}
 
 	if bj.GetGameEndFlag() {

--- a/internal/adapter/presenter/CaribbeanStudCuiPresenter.go
+++ b/internal/adapter/presenter/CaribbeanStudCuiPresenter.go
@@ -73,7 +73,7 @@ func (cp *CaribbeanStudCuiPresenter) Output(cs interfaces.CaribbeanStudGame, las
 	sb.WriteString("----------\n")
 
 	if lastErr != nil {
-		sb.WriteString(color.Red(lastErr.Error()) + "\n")
+		sb.WriteString(i18n.MarkErrorLine(color.Red(lastErr.Error())) + "\n")
 	}
 
 	if cs.GetGameEndFlag() {

--- a/internal/adapter/presenter/CasinoHoldemCuiPresenter.go
+++ b/internal/adapter/presenter/CasinoHoldemCuiPresenter.go
@@ -76,7 +76,7 @@ func (cp *CasinoHoldemCuiPresenter) Output(g interfaces.CasinoHoldemGame, lastEr
 	sb.WriteString("----------\n")
 
 	if lastErr != nil {
-		fmt.Fprintf(&sb, "%s\n", color.Red(lastErr.Error()))
+		fmt.Fprintf(&sb, "%s\n", i18n.MarkErrorLine(color.Red(lastErr.Error())))
 	}
 
 	if g.GetGameEndFlag() {

--- a/internal/adapter/presenter/CasinoWarCuiPresenter.go
+++ b/internal/adapter/presenter/CasinoWarCuiPresenter.go
@@ -63,7 +63,7 @@ func (cp *CasinoWarCuiPresenter) Output(cw interfaces.CasinoWarGame, lastErr err
 	sb.WriteString("----------\n")
 
 	if lastErr != nil {
-		sb.WriteString(color.Red(lastErr.Error()) + "\n")
+		sb.WriteString(i18n.MarkErrorLine(color.Red(lastErr.Error())) + "\n")
 	}
 
 	if cw.GetGameEndFlag() {

--- a/internal/adapter/presenter/ChinesePokerCuiPresenter.go
+++ b/internal/adapter/presenter/ChinesePokerCuiPresenter.go
@@ -87,7 +87,7 @@ func (pp *ChinesePokerCuiPresenter) Output(cp interfaces.ChinesePokerGame, lastE
 	sb.WriteString("----------\n")
 
 	if lastErr != nil {
-		sb.WriteString(color.Red(lastErr.Error()) + "\n")
+		sb.WriteString(i18n.MarkErrorLine(color.Red(lastErr.Error())) + "\n")
 	}
 
 	if cp.GetGameEndFlag() {

--- a/internal/adapter/presenter/DaifugoCuiPresenter.go
+++ b/internal/adapter/presenter/DaifugoCuiPresenter.go
@@ -142,7 +142,7 @@ func (p *DaifugoCuiPresenter) Output(dg interfaces.DaifugoGame, lastErr error) s
 		}
 
 		if lastErr != nil {
-			fmt.Fprintf(b, "%s\n", color.Red(lastErr.Error()))
+			fmt.Fprintf(b, "%s\n", i18n.MarkErrorLine(color.Red(lastErr.Error())))
 		}
 
 		if dg.GetGameEndFlag() {

--- a/internal/adapter/presenter/DoudizhuCuiPresenter.go
+++ b/internal/adapter/presenter/DoudizhuCuiPresenter.go
@@ -69,7 +69,7 @@ func (p *DoudizhuCuiPresenter) Output(dg interfaces.DoudizhuGame, lastErr error)
 		}
 
 		if lastErr != nil {
-			b.WriteString(color.Red(lastErr.Error()) + "\n")
+			b.WriteString(i18n.MarkErrorLine(color.Red(lastErr.Error())) + "\n")
 		}
 	})
 }

--- a/internal/adapter/presenter/FaroCuiPresenter.go
+++ b/internal/adapter/presenter/FaroCuiPresenter.go
@@ -69,7 +69,7 @@ func (fp *FaroCuiPresenter) Output(f interfaces.FaroGame, lastErr error) string 
 	sb.WriteString("----------\n")
 
 	if lastErr != nil {
-		sb.WriteString(color.Red(lastErr.Error()) + "\n")
+		sb.WriteString(i18n.MarkErrorLine(color.Red(lastErr.Error())) + "\n")
 	}
 
 	if f.GetPhase() == domain.FaroPhaseRoundEnd || f.GetPhase() == domain.FaroPhaseGameEnd {

--- a/internal/adapter/presenter/FourCardPokerCuiPresenter.go
+++ b/internal/adapter/presenter/FourCardPokerCuiPresenter.go
@@ -84,7 +84,7 @@ func (p *FourCardPokerCuiPresenter) Output(g interfaces.FourCardPokerGame, lastE
 	sb.WriteString("----------\n")
 
 	if lastErr != nil {
-		sb.WriteString(color.Red(lastErr.Error()) + "\n")
+		sb.WriteString(i18n.MarkErrorLine(color.Red(lastErr.Error())) + "\n")
 	}
 
 	if g.GetGameEndFlag() {

--- a/internal/adapter/presenter/HighCardFlushCuiPresenter.go
+++ b/internal/adapter/presenter/HighCardFlushCuiPresenter.go
@@ -56,7 +56,7 @@ func (hp *HighCardFlushCuiPresenter) Output(hcf interfaces.HighCardFlushGame, la
 	sb.WriteString("----------\n")
 
 	if lastErr != nil {
-		sb.WriteString(color.Red(lastErr.Error()) + "\n")
+		sb.WriteString(i18n.MarkErrorLine(color.Red(lastErr.Error())) + "\n")
 	}
 
 	if hcf.GetGameEndFlag() {

--- a/internal/adapter/presenter/LetItRideCuiPresenter.go
+++ b/internal/adapter/presenter/LetItRideCuiPresenter.go
@@ -75,7 +75,7 @@ func (lp *LetItRideCuiPresenter) Output(lir interfaces.LetItRideGame, lastErr er
 	sb.WriteString("----------\n")
 
 	if lastErr != nil {
-		fmt.Fprintf(&sb, "%s\n", color.Red(lastErr.Error()))
+		fmt.Fprintf(&sb, "%s\n", i18n.MarkErrorLine(color.Red(lastErr.Error())))
 	}
 
 	if lir.GetGameEndFlag() {

--- a/internal/adapter/presenter/OasisPokerCuiPresenter.go
+++ b/internal/adapter/presenter/OasisPokerCuiPresenter.go
@@ -76,7 +76,7 @@ func (op *OasisPokerCuiPresenter) Output(g interfaces.OasisPokerGame, lastErr er
 	sb.WriteString("----------\n")
 
 	if lastErr != nil {
-		sb.WriteString(color.Red(lastErr.Error()) + "\n")
+		sb.WriteString(i18n.MarkErrorLine(color.Red(lastErr.Error())) + "\n")
 	}
 
 	if g.GetExchangeCount() > 0 {

--- a/internal/adapter/presenter/OichoKabuCuiPresenter.go
+++ b/internal/adapter/presenter/OichoKabuCuiPresenter.go
@@ -72,7 +72,7 @@ func (p *OichoKabuCuiPresenter) Output(o interfaces.OichoKabuGame, lastErr error
 	sb.WriteString("----------\n")
 
 	if lastErr != nil {
-		sb.WriteString(color.Red(lastErr.Error()) + "\n")
+		sb.WriteString(i18n.MarkErrorLine(color.Red(lastErr.Error())) + "\n")
 	}
 
 	if o.GetGameEndFlag() {

--- a/internal/adapter/presenter/PageOneCuiPresenter.go
+++ b/internal/adapter/presenter/PageOneCuiPresenter.go
@@ -65,7 +65,7 @@ func (p *PageOneCuiPresenter) Output(g interfaces.PageOneGame, lastErr error) st
 		b.WriteString("----------\n")
 
 		if lastErr != nil {
-			fmt.Fprintf(b, "%s\n", color.Red(lastErr.Error()))
+			fmt.Fprintf(b, "%s\n", i18n.MarkErrorLine(color.Red(lastErr.Error())))
 		}
 
 		if g.GetGameEndFlag() {

--- a/internal/adapter/presenter/PaiGowCuiPresenter.go
+++ b/internal/adapter/presenter/PaiGowCuiPresenter.go
@@ -73,7 +73,7 @@ func (pp *PaiGowCuiPresenter) Output(pg interfaces.PaiGowGame, lastErr error) st
 	sb.WriteString("----------\n")
 
 	if lastErr != nil {
-		sb.WriteString(color.Red(lastErr.Error()) + "\n")
+		sb.WriteString(i18n.MarkErrorLine(color.Red(lastErr.Error())) + "\n")
 	}
 
 	if pg.GetGameEndFlag() {

--- a/internal/adapter/presenter/RedDogCuiPresenter.go
+++ b/internal/adapter/presenter/RedDogCuiPresenter.go
@@ -98,7 +98,7 @@ func (rp *RedDogCuiPresenter) Output(rd interfaces.RedDogGame, lastErr error) st
 	sb.WriteString("----------\n")
 
 	if lastErr != nil {
-		sb.WriteString(color.Red(lastErr.Error()) + "\n")
+		sb.WriteString(i18n.MarkErrorLine(color.Red(lastErr.Error())) + "\n")
 	}
 
 	if rd.GetGameEndFlag() {

--- a/internal/adapter/presenter/RussianPokerCuiPresenter.go
+++ b/internal/adapter/presenter/RussianPokerCuiPresenter.go
@@ -74,7 +74,7 @@ func (rp *RussianPokerCuiPresenter) Output(g interfaces.RussianPokerGame, lastEr
 	sb.WriteString("----------\n")
 
 	if lastErr != nil {
-		sb.WriteString(color.Red(lastErr.Error()) + "\n")
+		sb.WriteString(i18n.MarkErrorLine(color.Red(lastErr.Error())) + "\n")
 	}
 
 	if g.GetExchangeCount() > 0 {

--- a/internal/adapter/presenter/TexasHoldemBonusCuiPresenter.go
+++ b/internal/adapter/presenter/TexasHoldemBonusCuiPresenter.go
@@ -90,7 +90,7 @@ func (tp *TexasHoldemBonusCuiPresenter) Output(g interfaces.TexasHoldemBonusGame
 	sb.WriteString("----------\n")
 
 	if lastErr != nil {
-		fmt.Fprintf(&sb, "%s\n", color.Red(lastErr.Error()))
+		fmt.Fprintf(&sb, "%s\n", i18n.MarkErrorLine(color.Red(lastErr.Error())))
 	}
 
 	if g.GetGameEndFlag() {

--- a/internal/adapter/presenter/ThreeCardCuiPresenter.go
+++ b/internal/adapter/presenter/ThreeCardCuiPresenter.go
@@ -63,7 +63,7 @@ func (tp *ThreeCardCuiPresenter) Output(tc interfaces.ThreeCardGame, lastErr err
 	sb.WriteString("----------\n")
 
 	if lastErr != nil {
-		sb.WriteString(color.Red(lastErr.Error()) + "\n")
+		sb.WriteString(i18n.MarkErrorLine(color.Red(lastErr.Error())) + "\n")
 	}
 
 	if tc.GetGameEndFlag() {

--- a/internal/adapter/presenter/TichuCuiPresenter.go
+++ b/internal/adapter/presenter/TichuCuiPresenter.go
@@ -63,7 +63,7 @@ func (p *TichuCuiPresenter) Output(tg interfaces.TichuGame, lastErr error) strin
 		}
 
 		if lastErr != nil {
-			b.WriteString(color.Red(lastErr.Error()) + "\n")
+			b.WriteString(i18n.MarkErrorLine(color.Red(lastErr.Error())) + "\n")
 		}
 	})
 }

--- a/internal/adapter/presenter/UltimateTexasHoldemCuiPresenter.go
+++ b/internal/adapter/presenter/UltimateTexasHoldemCuiPresenter.go
@@ -89,7 +89,7 @@ func (up *UltimateTexasHoldemCuiPresenter) Output(g interfaces.UltimateTexasHold
 	sb.WriteString("----------\n")
 
 	if lastErr != nil {
-		fmt.Fprintf(&sb, "%s\n", color.Red(lastErr.Error()))
+		fmt.Fprintf(&sb, "%s\n", i18n.MarkErrorLine(color.Red(lastErr.Error())))
 	}
 
 	if g.GetGameEndFlag() {

--- a/internal/adapter/presenter/VideoPokerCuiPresenter.go
+++ b/internal/adapter/presenter/VideoPokerCuiPresenter.go
@@ -50,7 +50,7 @@ func (vpp *VideoPokerCuiPresenter) Output(vp interfaces.VideoPokerGame, lastErr 
 	sb.WriteString("----------\n")
 
 	if lastErr != nil {
-		sb.WriteString(color.Red(lastErr.Error()) + "\n")
+		sb.WriteString(i18n.MarkErrorLine(color.Red(lastErr.Error())) + "\n")
 	}
 
 	if vp.GetGameEndFlag() {

--- a/internal/adapter/presenter/cui_output_helper.go
+++ b/internal/adapter/presenter/cui_output_helper.go
@@ -44,7 +44,9 @@ func cuiTrickBlock[TC any](b *strings.Builder, trick []TC, playerIdx func(TC) in
 // cuiErrorBlock writes the error line if lastErr is non-nil.
 func cuiErrorBlock(b *strings.Builder, lastErr error) {
 	if lastErr != nil {
-		fmt.Fprintf(b, "%s\n", color.Red(lastErr.Error()))
+		// Marked per line, not per reply: the reply is a board and belongs on
+		// stdout. i18n.StripErrorLines takes the marker off before display.
+		fmt.Fprintf(b, "%s\n", i18n.MarkErrorLine(color.Red(lastErr.Error())))
 	}
 }
 

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -23,6 +23,31 @@ func MarkError(msg string) string {
 	return ErrorPrefix + msg
 }
 
+// ErrorLinePrefix marks one line inside an otherwise ordinary reply as a
+// rejection. The board games render a refusal as a red line inside the board,
+// so the reply as a whole is a board and must stay on stdout -- marking it with
+// ErrorPrefix would send the whole board to stderr in red. This says "there is
+// a refusal in here" without claiming the reply is one.
+const ErrorLinePrefix = "\x1eERRLN\x1e"
+
+// MarkErrorLine marks a single line as a rejection. Returns line unchanged if
+// it is empty or already marked.
+func MarkErrorLine(line string) string {
+	if line == "" || strings.HasPrefix(line, ErrorLinePrefix) {
+		return line
+	}
+	return ErrorLinePrefix + line
+}
+
+// StripErrorLines removes every ErrorLinePrefix from msg and reports whether
+// any was present. Callers display the result; the marker never reaches a user.
+func StripErrorLines(msg string) (body string, hadError bool) {
+	if !strings.Contains(msg, ErrorLinePrefix) {
+		return msg, false
+	}
+	return strings.ReplaceAll(msg, ErrorLinePrefix, ""), true
+}
+
 // StripErrorPrefix removes ErrorPrefix from msg and reports whether it was present.
 func StripErrorPrefix(msg string) (body string, isError bool) {
 	if strings.HasPrefix(msg, ErrorPrefix) {

--- a/internal/i18n/i18n_test.go
+++ b/internal/i18n/i18n_test.go
@@ -208,3 +208,45 @@ func TestSetLang_ResetToJa(t *testing.T) {
 	i18n.SetLang("ja")
 	assert.Equal(t, "ja", i18n.Lang())
 }
+
+// **印がユーザーに届いてはいけない。** 行単位の印は盤面の途中に埋まるので、
+// 剥がし忘れると制御文字が画面に出る。
+func TestMarkErrorLineRoundTrip(t *testing.T) {
+	t.Run("marks and strips", func(t *testing.T) {
+		marked := i18n.MarkErrorLine("cannot move")
+		assert.NotEqual(t, "cannot move", marked)
+		body, had := i18n.StripErrorLines(marked)
+		assert.True(t, had)
+		assert.Equal(t, "cannot move", body)
+	})
+
+	t.Run("empty stays empty", func(t *testing.T) {
+		assert.Equal(t, "", i18n.MarkErrorLine(""))
+	})
+
+	t.Run("marking twice does not nest", func(t *testing.T) {
+		once := i18n.MarkErrorLine("x")
+		assert.Equal(t, once, i18n.MarkErrorLine(once))
+	})
+
+	t.Run("an unmarked board is reported as clean", func(t *testing.T) {
+		body, had := i18n.StripErrorLines("plain board\nsecond line")
+		assert.False(t, had)
+		assert.Equal(t, "plain board\nsecond line", body)
+	})
+
+	// 盤面の途中の 1 行だけが印つき、という本来の使い方。
+	t.Run("strips a marker buried in a board", func(t *testing.T) {
+		board := "top\n" + i18n.MarkErrorLine("refused") + "\nbottom"
+		body, had := i18n.StripErrorLines(board)
+		assert.True(t, had)
+		assert.Equal(t, "top\nrefused\nbottom", body)
+		assert.NotContains(t, body, i18n.ErrorLinePrefix)
+	})
+
+	// 行の印と返答全体の印は別物。混ざると盤面が stderr へ流れる。
+	t.Run("a line marker is not a reply marker", func(t *testing.T) {
+		_, isErr := i18n.StripErrorPrefix(i18n.MarkErrorLine("refused"))
+		assert.False(t, isErr)
+	})
+}

--- a/internal/infrastructure/ui/cui_runner.go
+++ b/internal/infrastructure/ui/cui_runner.go
@@ -183,7 +183,9 @@ func filterByPrefix(candidates []string, token string) []string {
 func RunInteractiveCuiLoop(manager *GameManager) int {
 	initMsg := manager.InitCurrentGame()
 	if initMsg != "" {
-		fmt.Println(initMsg)
+		// through printResult, not fmt.Println: the first deal is the one place
+		// a raw marker would reach the screen unnoticed.
+		printResult(initMsg)
 	}
 	fmt.Println(i18n.T("typeHelp"))
 	reader := newDefaultLineReader()
@@ -239,7 +241,7 @@ func printResult(res string) {
 // Returns 0 on normal exit (EOF, "quit", QuitSentinel) and 1 when stdin
 // reads fail with a non-EOF I/O error (issue #1839). See issue #1605.
 func RunCuiLoop(gameName string, controller CuiExecer, helpLines []string) int {
-	fmt.Println(controller.Exec("r"))
+	printResult(controller.Exec("r"))
 	fmt.Println(i18n.T("typeHelp"))
 	reader := newDefaultLineReader()
 	defer func() { _ = reader.Close() }()

--- a/internal/infrastructure/ui/cui_runner.go
+++ b/internal/infrastructure/ui/cui_runner.go
@@ -224,7 +224,10 @@ func printResult(res string) {
 		fmt.Fprintln(os.Stderr, color.RedStderr(body))
 		return
 	}
-	fmt.Println(res)
+	// A board carrying a refusal line stays on stdout -- it is a board. The
+	// marker exists so callers can tell, not to change where it goes.
+	body, _ := i18n.StripErrorLines(res)
+	fmt.Println(body)
 }
 
 // RunCuiLoop runs a single-game CUI loop. gameName is shown in the prompt

--- a/internal/infrastructure/ui/help_table_test.go
+++ b/internal/infrastructure/ui/help_table_test.go
@@ -289,3 +289,36 @@ func TestCuiHelpTableCoversTheParser(t *testing.T) {
 			len(bad), strings.Join(bad, "\n  "))
 	}
 }
+
+// TestCuiNoRawMarkersAtRuntime checks that neither marker survives to the
+// screen. ErrorLinePrefix sits in the middle of a board, so forgetting to strip
+// it prints a control character between the cards -- and the presenter tests
+// never see it, because they assert on the presenter's output rather than on
+// what the runner prints.
+func TestCuiNoRawMarkersAtRuntime(t *testing.T) {
+	registry := GameRegistry()
+	checked := 0
+	var bad []string
+	for _, entry := range registry {
+		ctrl := entry.NewCui().Controller()
+		for _, cmd := range []string{"r", "zzbogusverb", "p zzz", "m zzz", "b zzz"} {
+			out := ctrl.Exec(cmd)
+			checked++
+			// what the runner would print: the reply marker is stripped when it
+			// routes to stderr, the line marker when it prints the board
+			body, _ := i18n.StripErrorPrefix(out)
+			body, _ = i18n.StripErrorLines(body)
+			if strings.Contains(body, i18n.ErrorPrefix) || strings.Contains(body, i18n.ErrorLinePrefix) {
+				bad = append(bad, entry.Name+": `"+cmd+"` leaves a marker in what the user sees")
+			}
+		}
+	}
+	if checked < len(registry) {
+		t.Fatalf("only %d replies were read for %d games -- the walk broke", checked, len(registry))
+	}
+	sort.Strings(bad)
+	if len(bad) > 0 {
+		t.Errorf("markers reaching the screen (%d of %d replies):\n  %s",
+			len(bad), checked, strings.Join(bad, "\n  "))
+	}
+}


### PR DESCRIPTION
`Refs #5377`. The last class of unmarked rejections.

## Why ErrorPrefix could not express these

`cuiErrorBlock` renders a refusal as a **red line inside the board**. `ErrorPrefix`
means *"this reply is an error"*, and `printResult` acts on it:

```go
if body, isErr := i18n.StripErrorPrefix(res); isErr {
    fmt.Fprintln(os.Stderr, color.RedStderr(body))
    return
}
```

Marking a board would put the hand, the table and the score on **stderr, coloured red**,
with nothing on stdout. That is not a patch, it is a different program.

## A second marker, at line level

`ErrorLinePrefix` says *"there is a refusal in here"* without claiming the reply is one.

- `cuiErrorBlock` applies it in the **one place** it renders, so none of the **289** call
  sites change.
- `printResult` strips it before printing. The board still goes to stdout and **still
  looks exactly the same** — this adds no visible change at all.

**21 replies are identifiable that were not.** Measured across every argument-taking
command given a bad argument: 680 marked, **21 line-marked**, 71 still plain.

## Two guards, both with negative controls

- **`TestMarkErrorLineRoundTrip`** pins the contract, including that *a line marker is
  not a reply marker*. Confusing the two is exactly what would route a board to stderr.
- **`TestCuiNoRawMarkersAtRuntime`** checks neither marker survives to the screen. A line
  marker sits in the middle of a board, so forgetting to strip it prints a control
  character between the cards — and **the presenter tests cannot see that**, because they
  assert on the presenter's output rather than on what the runner prints. Removing the
  strip fails the guard on **29 of 1590** replies.

## Test plan

- [x] `go test -tags test ./internal/i18n/ ./internal/adapter/presenter/ ./internal/infrastructure/ui/ ./internal/adapter/controller/` — green
- [x] `golangci-lint` on all three changed packages — 0 issues
- [x] marker probe: 680 / 21 / 71
- [x] negative control: dropping the strip fails the leak guard on 29 replies