### PR TITLE
fix(durak): end the game when a bout cycle makes it unwinnable

### DIFF
--- a/internal/domain/Durak.go
+++ b/internal/domain/Durak.go
@@ -45,6 +45,16 @@ const (
 	DurakActionTake   = 3 // 引き取り
 )
 
+// DurakMaxBouts は 1 局のバウト数の上限。
+//
+// **山札が尽きた後、カードが場から消えるのは防御成功のときだけ**で、防御失敗なら
+// 防御者が全部引き取るので手札の総数は変わらない。CPU の手選択に乱数は無く、同じ
+// 局面からは必ず同じ手が選ばれるため、「山札切れ + 防御が成立しない配置」の循環に
+// 一度入ると永久に出られない。20 万局に 14 局(0.007%)で実際に起きる。
+//
+// 通常局は 44 バウト前後、実測の最大が 78 なので、200 は健全な局に触れない。
+const DurakMaxBouts = 200
+
 // DurakCpuAction CPUまたは人間の1ターン分の行動記録
 type DurakCpuAction struct {
 	PlayerIdx  int   // 行動したプレイヤーインデックス
@@ -639,6 +649,25 @@ func (d *Durak) endBout(defended bool) {
 
 	// ゲーム終了チェック
 	activePlayers := d.countActivePlayers()
+	if activePlayers > 1 && d.round.boutNumber >= DurakMaxBouts {
+		// 循環に入っている。引き分けにはしない -- loserIdx = -1 は「全員上がり」
+		// の意味なので、混ぜると別の結末と区別できなくなる。手札が最も多い
+		// プレイヤーを敗者にする。同数なら座順の早い方。
+		d.round.gameEndFlag = true
+		d.round.phase = DurakPhaseGameEnd
+		worst, worstCnt := -1, -1
+		for i, p := range d.players {
+			if p.GetIsFinished() {
+				continue
+			}
+			if n := p.GetCardsSize(); n > worstCnt {
+				worst, worstCnt = i, n
+			}
+		}
+		d.round.loserIdx = worst
+		d.appendLog(-1, "bout", "bout limit reached, the player holding the most cards loses", nil)
+		return
+	}
 	if activePlayers <= 1 {
 		d.round.gameEndFlag = true
 		d.round.phase = DurakPhaseGameEnd

--- a/internal/domain/Durak_test.go
+++ b/internal/domain/Durak_test.go
@@ -859,3 +859,62 @@ func TestDurak_GetHint(t *testing.T) {
 		}
 	})
 }
+
+// **上限に当たった局も必ず終わり、必ず敗者が決まる。** 引き分け (loserIdx = -1) は
+// 「全員上がり」の意味なので、循環の打ち切りをそこへ流すと別の結末と区別できなくなる。
+//
+// 20 万局に 14 局という頻度なので、1 局ずつ回して踏むのを待つのは現実的でない。
+// ここでは上限そのものの規則を確かめ、頻度は #5414 の実測に任せる。
+func TestDurak_BoutLimitEndsTheGame(t *testing.T) {
+	players := []*domain.DurakPlayer{
+		domain.NewDurakPlayer(false), domain.NewDurakPlayer(false),
+		domain.NewDurakPlayer(false), domain.NewDurakPlayer(false),
+	}
+	d := domain.NewDurak(domain.NewTrumpCardsShortDeck(), players)
+
+	// 健全な局は上限に触れない (実測の最大は 78 バウト)。
+	t.Run("a normal game finishes well inside the limit", func(t *testing.T) {
+		for range 200 {
+			d.Reset()
+			turns := 0
+			for !d.GetGameEndFlag() && turns < 500 {
+				d.CpuPlay()
+				turns++
+			}
+			assert.True(t, d.GetGameEndFlag())
+			assert.Less(t, d.GetBoutNumber(), domain.DurakMaxBouts)
+		}
+	})
+
+	// 上限は健全な局の 2 倍以上離れていること。近すぎると普通の局を打ち切る。
+	t.Run("the limit is far above a normal game", func(t *testing.T) {
+		assert.Greater(t, domain.DurakMaxBouts, 150)
+	})
+
+	// 終わった局は必ず敗者を持つ (全員上がりを除く)。
+	t.Run("every finished game names a loser", func(t *testing.T) {
+		for range 500 {
+			d.Reset()
+			turns := 0
+			for !d.GetGameEndFlag() && turns < 500 {
+				d.CpuPlay()
+				turns++
+			}
+			if !d.GetGameEndFlag() {
+				continue
+			}
+			active := 0
+			for i := 0; i < d.GetPlayerCnt(); i++ {
+				if !d.GetPlayer(i).GetIsFinished() {
+					active++
+				}
+			}
+			if active == 0 {
+				assert.Equal(t, -1, d.GetLoserIdx(), "全員上がりのときだけ -1")
+				continue
+			}
+			assert.GreaterOrEqual(t, d.GetLoserIdx(), 0, "敗者が決まっていない")
+			assert.False(t, d.GetPlayer(d.GetLoserIdx()).GetIsFinished(), "上がった人が敗者になっている")
+		}
+	})
+}

--- a/internal/domain/Durak_test.go
+++ b/internal/domain/Durak_test.go
@@ -918,3 +918,81 @@ func TestDurak_BoutLimitEndsTheGame(t *testing.T) {
 		}
 	})
 }
+
+// **打ち切り経路を直接踏む。** 20 万局に 14 局という頻度なので、局を回して
+// 待っていては CI で一度も通らない。JSON 往復でバウト数を上限直前に置き、
+// 次の bout 終了で必ず打ち切りに入る局面を作る。
+func TestDurak_BoutLimitCutoffPath(t *testing.T) {
+	newGame := func() *domain.Durak {
+		players := []*domain.DurakPlayer{
+			domain.NewDurakPlayer(false), domain.NewDurakPlayer(false),
+			domain.NewDurakPlayer(false), domain.NewDurakPlayer(false),
+		}
+		d := domain.NewDurak(domain.NewTrumpCardsShortDeck(), players)
+		d.Reset()
+		return d
+	}
+
+	// バウト数だけ上限直前へ動かす。他の状態は配ったままなので、続きを回せば
+	// 数バウトで上限に当たる。
+	atLimit := func(d *domain.Durak) *domain.Durak {
+		raw, err := json.Marshal(d)
+		assert.NoError(t, err)
+		var m map[string]any
+		assert.NoError(t, json.Unmarshal(raw, &m))
+		m["bn"] = domain.DurakMaxBouts - 1
+		patched, err := json.Marshal(m)
+		assert.NoError(t, err)
+		out := newGame()
+		assert.NoError(t, json.Unmarshal(patched, out))
+		return out
+	}
+
+	t.Run("the game ends at the limit", func(t *testing.T) {
+		d := atLimit(newGame())
+		turns := 0
+		for !d.GetGameEndFlag() && turns < 500 {
+			d.CpuPlay()
+			turns++
+		}
+		assert.True(t, d.GetGameEndFlag(), "上限を越えても終わっていない")
+		assert.GreaterOrEqual(t, d.GetBoutNumber(), domain.DurakMaxBouts)
+
+		// **打ち切りで終わったことを確かめる。** 自然終了なら上がっていない
+		// プレイヤーは 1 人だけ。2 人以上残っているなら、終わらせたのは上限。
+		active := 0
+		for i := 0; i < d.GetPlayerCnt(); i++ {
+			if !d.GetPlayer(i).GetIsFinished() {
+				active++
+			}
+		}
+		assert.Greater(t, active, 1,
+			"自然終了してしまっている -- この局面では打ち切り経路を踏めていない")
+	})
+
+	t.Run("the cutoff names a loser who still holds cards", func(t *testing.T) {
+		d := atLimit(newGame())
+		turns := 0
+		for !d.GetGameEndFlag() && turns < 500 {
+			d.CpuPlay()
+			turns++
+		}
+		loser := d.GetLoserIdx()
+		if loser < 0 {
+			// 全員上がりで終わった場合だけ -1 が許される
+			for i := 0; i < d.GetPlayerCnt(); i++ {
+				assert.True(t, d.GetPlayer(i).GetIsFinished())
+			}
+			return
+		}
+		assert.False(t, d.GetPlayer(loser).GetIsFinished(), "上がった人が敗者になっている")
+
+		// 敗者は手札が最多であること。少ない人を負けにすると規則が逆になる。
+		for i := 0; i < d.GetPlayerCnt(); i++ {
+			if d.GetPlayer(i).GetIsFinished() {
+				continue
+			}
+			assert.LessOrEqual(t, d.GetPlayer(i).GetCardsSize(), d.GetPlayer(loser).GetCardsSize())
+		}
+	})
+}


### PR DESCRIPTION
`Closes #5414`. A durak game can run forever, and `TestDurak_FullGame_CpuOnly` has been
failing on it since at least 2026-08-10 — filed as a flake both times.

## It is not a flake

After the stock empties, cards only leave the table on a **successful defence**. A failed
one moves them to the defender, so the total in hand is unchanged. `CpuPlay` has no
randomness — `cpuFindWeakestAttackCard` and `cpuFindDefenseCard` pick from the position —
so the same position always yields the same move. Once a *"stock empty, no defence lands"*
configuration is reached, it repeats for good.

| 200000 CPU-only games, one instance | never ended | hit the bout limit |
|---|---|---|
| before | **14** (50000 extra turns finished none of them) | — |
| after | **0** | 11 |

A normal game is 44 bouts (p50), 78 at most over 2000 games. A limit of 200 does not
touch a healthy one.

## It names a loser, not a draw

`loserIdx = -1` already means *"everyone went out"*. Routing a cycle there would make two
different endings indistinguishable. The player holding the most cards loses; ties go to
the earlier seat.

## Why it looked like a flake

The test reuses **one** `Durak` across 20 `Reset()`s, so reproducing it needs a particular
history — 20000 rounds on one instance before the first failure. Constructing a fresh
`Durak` each time never fails, which is exactly what "ran it 12 times, all green" showed
on 2026-08-10.

My own first probe made the same mistake in the other direction: it used
`NewDefaultDurak()` instead of the test's four-CPU short-deck setup and reported 400/400
games hitting the cap, which contradicted the test passing at all.

## Test plan

- [x] `TestDurak_BoutLimitEndsTheGame` — a normal game finishes well inside the limit, the
      limit is far above a normal game, and every finished game names a loser (except the
      everyone-went-out case, which keeps `-1`)
- [x] negative control: lowering the limit to 2 fails 2 of the 3 subtests, and the
      "names a loser" one still passes — the cutoff path really does pick a loser
- [x] `go test -tags test ./internal/domain/` — green
- [x] `golangci-lint run ./internal/domain/...` — 0 issues
- [x] 200000-round sweep re-measured after the fix: 0 unfinished