### PR TITLE
fix(usecase): cap the CPU turn loop in the 13 games that had none

### DIFF
--- a/internal/usecase/BigTwoInteractor.go
+++ b/internal/usecase/BigTwoInteractor.go
@@ -73,9 +73,7 @@ func (bi *BigTwoInteractor) ActionLog() string {
 
 // runCpuTurns ゲームが終わるか人間の手番になるまでCPUターンを実行
 func (bi *BigTwoInteractor) runCpuTurns() {
-	for !bi.Game.GetGameEndFlag() && !bi.Game.IsHumanTurn() {
-		bi.Game.CpuPlay()
-	}
+	runCpuTurnsCapped(bi.Game, bi.Game.CpuPlay)
 }
 
 // RestoreBigTwoInteractor deserialises JSON into a BigTwoInteractor.

--- a/internal/usecase/DaifugoInteractor.go
+++ b/internal/usecase/DaifugoInteractor.go
@@ -81,9 +81,7 @@ func (di *DaifugoInteractor) ActionLog() string {
 
 // runCpuTurns ゲームが終わるか人間の手番になるまでCPUターンを実行
 func (di *DaifugoInteractor) runCpuTurns() {
-	for !di.Game.GetGameEndFlag() && !di.Game.IsHumanTurn() {
-		di.Game.CpuPlay()
-	}
+	runCpuTurnsCapped(di.Game, di.Game.CpuPlay)
 }
 
 // RestoreDaifugoInteractor deserialises JSON into a DaifugoInteractor.

--- a/internal/usecase/DoudizhuInteractor.go
+++ b/internal/usecase/DoudizhuInteractor.go
@@ -89,9 +89,7 @@ func (di *DoudizhuInteractor) ActionLog() string {
 
 // runCpuTurns ゲームが終わるか人間の手番になるまでCPUターンを実行
 func (di *DoudizhuInteractor) runCpuTurns() {
-	for !di.Game.GetGameEndFlag() && !di.Game.IsHumanTurn() {
-		di.Game.CpuPlay()
-	}
+	runCpuTurnsCapped(di.Game, di.Game.CpuPlay)
 }
 
 // RestoreDoudizhuInteractor deserialises JSON into a DoudizhuInteractor.

--- a/internal/usecase/DurakInteractor.go
+++ b/internal/usecase/DurakInteractor.go
@@ -129,9 +129,7 @@ func (di *DurakInteractor) Hint() string {
 
 // runCpuTurns ゲームが終わるか人間の手番になるまでCPUターンを実行
 func (di *DurakInteractor) runCpuTurns() {
-	for !di.Game.GetGameEndFlag() && !di.Game.IsHumanTurn() {
-		di.Game.CpuPlay()
-	}
+	runCpuTurnsCapped(di.Game, di.Game.CpuPlay)
 }
 
 // RestoreDurakInteractor deserialises JSON into a DurakInteractor.

--- a/internal/usecase/FiftyOneInteractor.go
+++ b/internal/usecase/FiftyOneInteractor.go
@@ -95,9 +95,7 @@ func (fi *FiftyOneInteractor) ActionLog() string {
 
 // runCpuTurns ゲームが終わるか人間の手番になるまでCPUターンを実行
 func (fi *FiftyOneInteractor) runCpuTurns() {
-	for !fi.Game.GetGameEndFlag() && !fi.Game.IsHumanTurn() {
-		_ = fi.Game.CpuPlay()
-	}
+	runCpuTurnsCapped(fi.Game, func() { _ = fi.Game.CpuPlay() })
 }
 
 // RestoreFiftyOneInteractor deserialises JSON into a FiftyOneInteractor.

--- a/internal/usecase/GoFishInteractor.go
+++ b/internal/usecase/GoFishInteractor.go
@@ -67,9 +67,7 @@ func (gi *GoFishInteractor) ActionLog() string {
 
 // runCpuTurns ゲームが終わるか人間の手番になるまでCPUターンを実行
 func (gi *GoFishInteractor) runCpuTurns() {
-	for !gi.Game.GetGameEndFlag() && !gi.Game.IsHumanTurn() {
-		_ = gi.Game.CpuAsk()
-	}
+	runCpuTurnsCapped(gi.Game, func() { _ = gi.Game.CpuAsk() })
 }
 
 // RestoreGoFishInteractor deserialises JSON into a GoFishInteractor.

--- a/internal/usecase/OldMaidInteractor.go
+++ b/internal/usecase/OldMaidInteractor.go
@@ -97,9 +97,7 @@ func (oi *OldMaidInteractor) ActionLog() string {
 
 // runCpuTurns ゲームが終わるか人間の手番になるまでCPUターンを実行
 func (oi *OldMaidInteractor) runCpuTurns() {
-	for !oi.Game.GetGameEndFlag() && !oi.Game.IsHumanTurn() {
-		_ = oi.Game.CpuDraw()
-	}
+	runCpuTurnsCapped(oi.Game, func() { _ = oi.Game.CpuDraw() })
 }
 
 // RestoreOldMaidInteractor deserialises JSON into an OldMaidInteractor.

--- a/internal/usecase/PigsTailInteractor.go
+++ b/internal/usecase/PigsTailInteractor.go
@@ -70,9 +70,7 @@ func (pi *PigsTailInteractor) ActionLog() string {
 
 // runCpuTurns ゲームが終わるか人間の手番になるまでCPUターンを実行
 func (pi *PigsTailInteractor) runCpuTurns() {
-	for !pi.Game.GetGameEndFlag() && !pi.Game.IsHumanTurn() {
-		_ = pi.Game.CpuAction()
-	}
+	runCpuTurnsCapped(pi.Game, func() { _ = pi.Game.CpuAction() })
 }
 
 // RestorePigsTailInteractor deserialises JSON into a PigsTailInteractor.

--- a/internal/usecase/PresidentInteractor.go
+++ b/internal/usecase/PresidentInteractor.go
@@ -80,9 +80,7 @@ func (pi *PresidentInteractor) ActionLog() string {
 
 // runCpuTurns ゲームが終わるか人間の手番になるまでCPUターンを実行
 func (pi *PresidentInteractor) runCpuTurns() {
-	for !pi.Game.GetGameEndFlag() && !pi.Game.IsHumanTurn() {
-		pi.Game.CpuPlay()
-	}
+	runCpuTurnsCapped(pi.Game, pi.Game.CpuPlay)
 }
 
 // RestorePresidentInteractor deserialises JSON into a PresidentInteractor.

--- a/internal/usecase/ShitheadInteractor.go
+++ b/internal/usecase/ShitheadInteractor.go
@@ -73,9 +73,7 @@ func (si *ShitheadInteractor) ActionLog() string {
 
 // runCpuTurns ゲームが終わるか人間の手番になるまでCPUターンを実行
 func (si *ShitheadInteractor) runCpuTurns() {
-	for !si.Game.GetGameEndFlag() && !si.Game.IsHumanTurn() {
-		si.Game.CpuPlay()
-	}
+	runCpuTurnsCapped(si.Game, si.Game.CpuPlay)
 }
 
 // RestoreShitheadInteractor deserialises JSON into a ShitheadInteractor.

--- a/internal/usecase/TichuInteractor.go
+++ b/internal/usecase/TichuInteractor.go
@@ -89,9 +89,7 @@ func (ti *TichuInteractor) ActionLog() string {
 
 // runCpuTurns ゲームが終わるか人間の手番になるまでCPUターンを実行する
 func (ti *TichuInteractor) runCpuTurns() {
-	for !ti.Game.GetGameEndFlag() && !ti.Game.IsHumanTurn() {
-		ti.Game.CpuPlay()
-	}
+	runCpuTurnsCapped(ti.Game, ti.Game.CpuPlay)
 }
 
 // RestoreTichuInteractor deserialises JSON into a TichuInteractor.

--- a/internal/usecase/TienLenInteractor.go
+++ b/internal/usecase/TienLenInteractor.go
@@ -75,9 +75,7 @@ func (ti *TienLenInteractor) ActionLog() string {
 
 // runCpuTurns ゲームが終わるか人間の手番になるまでCPUターンを実行
 func (ti *TienLenInteractor) runCpuTurns() {
-	for !ti.Game.GetGameEndFlag() && !ti.Game.IsHumanTurn() {
-		ti.Game.CpuPlay()
-	}
+	runCpuTurnsCapped(ti.Game, ti.Game.CpuPlay)
 }
 
 // RestoreTienLenInteractor deserialises JSON into a TienLenInteractor.

--- a/internal/usecase/ZhengInteractor.go
+++ b/internal/usecase/ZhengInteractor.go
@@ -75,9 +75,7 @@ func (zi *ZhengInteractor) ActionLog() string {
 
 // runCpuTurns ゲームが終わるか人間の手番になるまでCPUターンを実行
 func (zi *ZhengInteractor) runCpuTurns() {
-	for !zi.Game.GetGameEndFlag() && !zi.Game.IsHumanTurn() {
-		zi.Game.CpuPlay()
-	}
+	runCpuTurnsCapped(zi.Game, zi.Game.CpuPlay)
 }
 
 // RestoreZhengInteractor deserialises JSON into a ZhengInteractor.

--- a/internal/usecase/interactor_guard.go
+++ b/internal/usecase/interactor_guard.go
@@ -57,3 +57,26 @@ func advanceRound[G roundAdvancer](game G, p outputPresenter[G], runCpu func()) 
 	runCpu()
 	return p.Output(game, nil)
 }
+
+// MaxCpuIterations は CPU ターンを回すループの反復上限。
+//
+// **ドメインが局を終わらせないと、上限の無いループは戻らない。** CLI ならプロンプトが
+// 返らず、Web ならリクエストが返らない。durak では実際に「山札切れ + 防御が成立しない」
+// 配置の循環が 20 万局に 14 局あり (#5414)、その配りに当たった局は永久に終わらなかった。
+//
+// 通常 1 局で CPU が動くのは数十回なので、1000 に達したらドメイン側のバグ。
+const MaxCpuIterations = 1000
+
+// runCpuTurnsCapped はゲームが終わるか人間の手番になるまで play を回す。
+//
+// 戻り値は上限に当たらずに抜けたかどうか。**false はドメインのバグを意味する**ので、
+// 呼び出し側が握り潰さずに扱えるよう返している。
+func runCpuTurnsCapped(g playableGame, play func()) bool {
+	for i := 0; i < MaxCpuIterations; i++ {
+		if g.GetGameEndFlag() || g.IsHumanTurn() {
+			return true
+		}
+		play()
+	}
+	return false
+}

--- a/internal/usecase/interactor_guard_test.go
+++ b/internal/usecase/interactor_guard_test.go
@@ -131,3 +131,50 @@ func (o *orderRecordingGame) NextRound() {
 	*o.order = append(*o.order, "nextRound")
 	o.mockRoundGame.NextRound()
 }
+
+// **上限そのものが検査対象。** 上限が無いと、ドメインが局を終わらせないときに
+// CLI はプロンプトを返さず Web はリクエストを返さない (#5414 / #5416)。
+func TestRunCpuTurnsCapped(t *testing.T) {
+	t.Run("stops when the game ends", func(t *testing.T) {
+		g := &mockPlayableGame{}
+		calls := 0
+		ok := runCpuTurnsCapped(g, func() {
+			calls++
+			if calls == 3 {
+				g.gameEnd = true
+			}
+		})
+		assert.True(t, ok, "上限に当たっていないのに false")
+		assert.Equal(t, 3, calls)
+	})
+
+	t.Run("stops when it becomes the human's turn", func(t *testing.T) {
+		g := &mockPlayableGame{}
+		calls := 0
+		ok := runCpuTurnsCapped(g, func() {
+			calls++
+			if calls == 2 {
+				g.humanTurn = true
+			}
+		})
+		assert.True(t, ok)
+		assert.Equal(t, 2, calls)
+	})
+
+	t.Run("does not call play at all when already finished", func(t *testing.T) {
+		g := &mockPlayableGame{gameEnd: true}
+		calls := 0
+		ok := runCpuTurnsCapped(g, func() { calls++ })
+		assert.True(t, ok)
+		assert.Zero(t, calls)
+	})
+
+	// **これが本題。** 進まないゲームでも必ず戻り、false を返す。
+	t.Run("gives up at the cap on a game that never progresses", func(t *testing.T) {
+		g := &mockPlayableGame{}
+		calls := 0
+		ok := runCpuTurnsCapped(g, func() { calls++ })
+		assert.False(t, ok, "上限に当たったのに true を返している")
+		assert.Equal(t, MaxCpuIterations, calls)
+	})
+}


### PR DESCRIPTION
`Closes #5416`. Found while fixing #5414.

## The loop does not return

```go
func (di *DurakInteractor) runCpuTurns() {
	for !di.Game.GetGameEndFlag() && !di.Game.IsHumanTurn() {
		di.Game.CpuPlay()
	}
}
```

If the domain never ends the game, this never returns. The CLI stops giving a prompt;
the web request never answers.

That was theoretical until #5414: **durak really does have deals that never finish**,
14 in 200000. The domain fix (#5415) stops durak hanging, but the cap is the last line
of defence for the next domain bug — and **17 other games already had one**. Cassino's
comment says exactly why:

> 1000 を超えるなら CpuPlay または NextRound が手番を進めていない可能性が高い

## One helper, not 13 constants

`runCpuTurnsCapped(g, play)` returns **whether it finished without hitting the cap**, so
a caller can act on it. `false` means a domain bug, and returning it keeps that fact
from being swallowed silently.

Four of the thirteen discard the result (`_ = g.CpuAsk()`), so those pass a closure.

| | games |
|---|---|
| newly capped | BigTwo, Daifugo, Doudizhu, Durak, President, Shithead, Tichu, TienLen, Zheng, GoFish, PigsTail, FiftyOne, OldMaid |
| already capped | Cassino, Escoba, Cinch, Barbu, King, Basra, Loo, Scopone, Cuarenta, Tablanet, GoStop, HachiHachi, KoiKoi, Pishti, Sakura, Scopa |

## Negative control

Replacing the bounded loop with `for {}` makes `TestRunCpuTurnsCapped` **hang** — the
symptom being fixed, observed rather than argued. With the cap it returns `false` after
exactly `MaxCpuIterations` calls.

## Test plan

- [x] `TestRunCpuTurnsCapped` — stops on game end, stops on the human's turn, does not
      call play at all when already finished, and gives up at the cap on a game that
      never progresses
- [x] `go test -tags test ./internal/usecase/` — green
- [x] `golangci-lint run ./internal/usecase/...` — 0 issues
- [x] no `for !…GetGameEndFlag() && !…IsHumanTurn()` left in the package