### PR TITLE
fix(usecase): bound the remaining 40 CPU loops

### DIFF
--- a/internal/usecase/BeloteInteractor.go
+++ b/internal/usecase/BeloteInteractor.go
@@ -172,7 +172,10 @@ func (bi *BeloteInteractor) ActionLog() string {
 
 // runCpuBids ビッドフェーズでCPUを自動実行する (PickUp と CallTrump)
 func (bi *BeloteInteractor) runCpuBids() {
-	for !bi.Game.GetGameEndFlag() {
+	for i := 0; i < MaxCpuIterations; i++ {
+		if bi.Game.GetGameEndFlag() {
+			return
+		}
 		phase := bi.Game.GetPhase()
 		switch phase {
 		case domain.BelotePhaseBidPickUp:

--- a/internal/usecase/BigTwoInteractor_test.go
+++ b/internal/usecase/BigTwoInteractor_test.go
@@ -1,0 +1,39 @@
+//go:build test
+
+package usecase_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
+)
+
+// BigTwo has no generated presenter mock, so stub the two methods the way
+// interactor_snapshot_test.go does.
+type stubBigTwoPresenter struct{ calls int }
+
+func (s *stubBigTwoPresenter) Output(_ interfaces.BigTwoGame, _ error) string {
+	s.calls++
+	return `{}`
+}
+func (s *stubBigTwoPresenter) ActionLogOutput(_ interfaces.BigTwoGame) string { return `{}` }
+
+// runCpuTurns was the only function in this interactor with no test at all
+// (0% on develop). #5418 put an iteration cap in it, so drive it once.
+func TestBigTwoInteractor_ResetRunsCpuTurns(t *testing.T) {
+	game := domain.NewDefaultBigTwo()
+	p := &stubBigTwoPresenter{}
+
+	bi := usecase.NewBigTwoInteractor(game, p)
+	assert.Equal(t, `{}`, bi.Reset())
+	assert.Equal(t, 1, p.calls)
+
+	// **配った直後は必ず人間の手番か終局。** どちらでもないなら CPU ループが
+	// 上限まで空回りして返ってきたということで、それがこの上限の直す対象。
+	assert.True(t, game.IsHumanTurn() || game.GetGameEndFlag(),
+		"Reset 後に人間の手番でも終局でもない -- CPU ループが進まないまま抜けている")
+}

--- a/internal/usecase/BourreInteractor.go
+++ b/internal/usecase/BourreInteractor.go
@@ -116,19 +116,10 @@ func (bi *BourreInteractor) ActionLog() string {
 // runCpuTurns ゲーム終了・人間の手番・ハンド終了のいずれかになるまでCPUを進める
 func (bi *BourreInteractor) runCpuTurns() {
 	g := bi.Game
-	for i := 0; i < MaxCpuIterations; i++ {
-		if g.GetGameEndFlag() {
-			return
-		}
+	runCpuTurnsUntil(g, func() bool {
 		phase := g.GetPhase()
-		if phase == domain.BourrePhaseRoundEnd || phase == domain.BourrePhaseGameEnd {
-			return
-		}
-		if g.IsHumanTurn() {
-			return
-		}
-		g.CpuPlay()
-	}
+		return phase == domain.BourrePhaseRoundEnd || phase == domain.BourrePhaseGameEnd || g.IsHumanTurn()
+	}, g.CpuPlay)
 }
 
 // RestoreBourreInteractor deserialises JSON into a BourreInteractor.

--- a/internal/usecase/BourreInteractor.go
+++ b/internal/usecase/BourreInteractor.go
@@ -116,13 +116,16 @@ func (bi *BourreInteractor) ActionLog() string {
 // runCpuTurns ゲーム終了・人間の手番・ハンド終了のいずれかになるまでCPUを進める
 func (bi *BourreInteractor) runCpuTurns() {
 	g := bi.Game
-	for !g.GetGameEndFlag() {
+	for i := 0; i < MaxCpuIterations; i++ {
+		if g.GetGameEndFlag() {
+			return
+		}
 		phase := g.GetPhase()
 		if phase == domain.BourrePhaseRoundEnd || phase == domain.BourrePhaseGameEnd {
-			break
+			return
 		}
 		if g.IsHumanTurn() {
-			break
+			return
 		}
 		g.CpuPlay()
 	}

--- a/internal/usecase/BurracoInteractor.go
+++ b/internal/usecase/BurracoInteractor.go
@@ -162,13 +162,16 @@ func (ci *BurracoInteractor) ActionLog() string {
 
 // runCpuTurns CPUターンを実行
 func (ci *BurracoInteractor) runCpuTurns() {
-	for !ci.Game.GetGameEndFlag() {
+	for i := 0; i < MaxCpuIterations; i++ {
+		if ci.Game.GetGameEndFlag() {
+			return
+		}
 		phase := ci.Game.GetPhase()
 		if phase == domain.BurracoPhaseRoundEnd || phase == domain.BurracoPhaseGameEnd {
-			break
+			return
 		}
 		if ci.Game.IsHumanTurn() {
-			break
+			return
 		}
 		ci.Game.CpuPlay()
 	}

--- a/internal/usecase/BurracoInteractor.go
+++ b/internal/usecase/BurracoInteractor.go
@@ -162,19 +162,10 @@ func (ci *BurracoInteractor) ActionLog() string {
 
 // runCpuTurns CPUターンを実行
 func (ci *BurracoInteractor) runCpuTurns() {
-	for i := 0; i < MaxCpuIterations; i++ {
-		if ci.Game.GetGameEndFlag() {
-			return
-		}
+	runCpuTurnsUntil(ci.Game, func() bool {
 		phase := ci.Game.GetPhase()
-		if phase == domain.BurracoPhaseRoundEnd || phase == domain.BurracoPhaseGameEnd {
-			return
-		}
-		if ci.Game.IsHumanTurn() {
-			return
-		}
-		ci.Game.CpuPlay()
-	}
+		return phase == domain.BurracoPhaseRoundEnd || phase == domain.BurracoPhaseGameEnd || ci.Game.IsHumanTurn()
+	}, ci.Game.CpuPlay)
 }
 
 // RestoreBurracoInteractor deserialises JSON into a BurracoInteractor.

--- a/internal/usecase/CanastaInteractor.go
+++ b/internal/usecase/CanastaInteractor.go
@@ -155,13 +155,16 @@ func (ci *CanastaInteractor) ActionLog() string {
 
 // runCpuTurns CPUターンを実行
 func (ci *CanastaInteractor) runCpuTurns() {
-	for !ci.Game.GetGameEndFlag() {
+	for i := 0; i < MaxCpuIterations; i++ {
+		if ci.Game.GetGameEndFlag() {
+			return
+		}
 		phase := ci.Game.GetPhase()
 		if phase == domain.CanastaPhaseRoundEnd || phase == domain.CanastaPhaseGameEnd {
-			break
+			return
 		}
 		if ci.Game.IsHumanTurn() {
-			break
+			return
 		}
 		ci.Game.CpuPlay()
 	}

--- a/internal/usecase/CanastaInteractor.go
+++ b/internal/usecase/CanastaInteractor.go
@@ -155,19 +155,10 @@ func (ci *CanastaInteractor) ActionLog() string {
 
 // runCpuTurns CPUターンを実行
 func (ci *CanastaInteractor) runCpuTurns() {
-	for i := 0; i < MaxCpuIterations; i++ {
-		if ci.Game.GetGameEndFlag() {
-			return
-		}
+	runCpuTurnsUntil(ci.Game, func() bool {
 		phase := ci.Game.GetPhase()
-		if phase == domain.CanastaPhaseRoundEnd || phase == domain.CanastaPhaseGameEnd {
-			return
-		}
-		if ci.Game.IsHumanTurn() {
-			return
-		}
-		ci.Game.CpuPlay()
-	}
+		return phase == domain.CanastaPhaseRoundEnd || phase == domain.CanastaPhaseGameEnd || ci.Game.IsHumanTurn()
+	}, ci.Game.CpuPlay)
 }
 
 // RestoreCanastaInteractor deserialises JSON into a CanastaInteractor.

--- a/internal/usecase/CariocaInteractor.go
+++ b/internal/usecase/CariocaInteractor.go
@@ -149,19 +149,10 @@ func (ci *CariocaInteractor) ActionLog() string {
 
 // runCpuTurns CPU ターンを連続で処理する
 func (ci *CariocaInteractor) runCpuTurns() {
-	for i := 0; i < MaxCpuIterations; i++ {
-		if ci.Game.GetGameEndFlag() {
-			return
-		}
+	runCpuTurnsUntil(ci.Game, func() bool {
 		phase := ci.Game.GetPhase()
-		if phase == domain.CariocaPhaseRoundEnd || phase == domain.CariocaPhaseGameEnd {
-			return
-		}
-		if ci.Game.IsHumanTurn() {
-			return
-		}
-		ci.Game.CpuPlay()
-	}
+		return phase == domain.CariocaPhaseRoundEnd || phase == domain.CariocaPhaseGameEnd || ci.Game.IsHumanTurn()
+	}, ci.Game.CpuPlay)
 }
 
 // RestoreCariocaInteractor JSON から CariocaInteractor を復元する

--- a/internal/usecase/CariocaInteractor.go
+++ b/internal/usecase/CariocaInteractor.go
@@ -149,13 +149,16 @@ func (ci *CariocaInteractor) ActionLog() string {
 
 // runCpuTurns CPU ターンを連続で処理する
 func (ci *CariocaInteractor) runCpuTurns() {
-	for !ci.Game.GetGameEndFlag() {
+	for i := 0; i < MaxCpuIterations; i++ {
+		if ci.Game.GetGameEndFlag() {
+			return
+		}
 		phase := ci.Game.GetPhase()
 		if phase == domain.CariocaPhaseRoundEnd || phase == domain.CariocaPhaseGameEnd {
-			break
+			return
 		}
 		if ci.Game.IsHumanTurn() {
-			break
+			return
 		}
 		ci.Game.CpuPlay()
 	}

--- a/internal/usecase/CegoInteractor.go
+++ b/internal/usecase/CegoInteractor.go
@@ -174,17 +174,13 @@ func (ci *CegoInteractor) ActionLog() string {
 func (ci *CegoInteractor) advance() {
 	runCpuBidsLoop[domain.CegoPhase](ci.Game, domain.CegoPhaseBid)
 	// CPU デクレアラーのコントラクト選択を自動実行する。
-	for !ci.Game.GetGameEndFlag() &&
-		ci.Game.GetPhase() == domain.CegoPhaseContract &&
-		!ci.Game.IsHumanContractTurn() {
-		ci.Game.CpuChooseContract()
-	}
+	runCpuTurnsUntil(ci.Game, func() bool {
+		return ci.Game.GetPhase() != domain.CegoPhaseContract || ci.Game.IsHumanContractTurn()
+	}, ci.Game.CpuChooseContract)
 	// CPU デクレアラーの場札交換を自動実行する。
-	for !ci.Game.GetGameEndFlag() &&
-		ci.Game.GetPhase() == domain.CegoPhaseExchange &&
-		!ci.Game.IsHumanExchangeTurn() {
-		ci.Game.CpuDiscard()
-	}
+	runCpuTurnsUntil(ci.Game, func() bool {
+		return ci.Game.GetPhase() != domain.CegoPhaseExchange || ci.Game.IsHumanExchangeTurn()
+	}, ci.Game.CpuDiscard)
 	runCpuTurnsLoop(ci.Game, cegoTrickPhases())
 }
 

--- a/internal/usecase/ConquianInteractor.go
+++ b/internal/usecase/ConquianInteractor.go
@@ -129,19 +129,10 @@ func (ci *ConquianInteractor) ActionLog() string {
 
 // runCpuTurns CPUターンを実行
 func (ci *ConquianInteractor) runCpuTurns() {
-	for i := 0; i < MaxCpuIterations; i++ {
-		if ci.Game.GetGameEndFlag() {
-			return
-		}
+	runCpuTurnsUntil(ci.Game, func() bool {
 		phase := ci.Game.GetPhase()
-		if phase == domain.ConquianPhaseRoundEnd || phase == domain.ConquianPhaseGameEnd {
-			return
-		}
-		if ci.Game.IsHumanTurn() {
-			return
-		}
-		ci.Game.CpuPlay()
-	}
+		return phase == domain.ConquianPhaseRoundEnd || phase == domain.ConquianPhaseGameEnd || ci.Game.IsHumanTurn()
+	}, ci.Game.CpuPlay)
 }
 
 // RestoreConquianInteractor deserialises JSON into a ConquianInteractor.

--- a/internal/usecase/ConquianInteractor.go
+++ b/internal/usecase/ConquianInteractor.go
@@ -129,13 +129,16 @@ func (ci *ConquianInteractor) ActionLog() string {
 
 // runCpuTurns CPUターンを実行
 func (ci *ConquianInteractor) runCpuTurns() {
-	for !ci.Game.GetGameEndFlag() {
+	for i := 0; i < MaxCpuIterations; i++ {
+		if ci.Game.GetGameEndFlag() {
+			return
+		}
 		phase := ci.Game.GetPhase()
 		if phase == domain.ConquianPhaseRoundEnd || phase == domain.ConquianPhaseGameEnd {
-			break
+			return
 		}
 		if ci.Game.IsHumanTurn() {
-			break
+			return
 		}
 		ci.Game.CpuPlay()
 	}

--- a/internal/usecase/ContractRummyInteractor.go
+++ b/internal/usecase/ContractRummyInteractor.go
@@ -149,19 +149,10 @@ func (ci *ContractRummyInteractor) ActionLog() string {
 
 // runCpuTurns CPU ターンを連続で処理する
 func (ci *ContractRummyInteractor) runCpuTurns() {
-	for i := 0; i < MaxCpuIterations; i++ {
-		if ci.Game.GetGameEndFlag() {
-			return
-		}
+	runCpuTurnsUntil(ci.Game, func() bool {
 		phase := ci.Game.GetPhase()
-		if phase == domain.ContractRummyPhaseRoundEnd || phase == domain.ContractRummyPhaseGameEnd {
-			return
-		}
-		if ci.Game.IsHumanTurn() {
-			return
-		}
-		ci.Game.CpuPlay()
-	}
+		return phase == domain.ContractRummyPhaseRoundEnd || phase == domain.ContractRummyPhaseGameEnd || ci.Game.IsHumanTurn()
+	}, ci.Game.CpuPlay)
 }
 
 // RestoreContractRummyInteractor JSON から ContractRummyInteractor を復元する

--- a/internal/usecase/ContractRummyInteractor.go
+++ b/internal/usecase/ContractRummyInteractor.go
@@ -149,13 +149,16 @@ func (ci *ContractRummyInteractor) ActionLog() string {
 
 // runCpuTurns CPU ターンを連続で処理する
 func (ci *ContractRummyInteractor) runCpuTurns() {
-	for !ci.Game.GetGameEndFlag() {
+	for i := 0; i < MaxCpuIterations; i++ {
+		if ci.Game.GetGameEndFlag() {
+			return
+		}
 		phase := ci.Game.GetPhase()
 		if phase == domain.ContractRummyPhaseRoundEnd || phase == domain.ContractRummyPhaseGameEnd {
-			break
+			return
 		}
 		if ci.Game.IsHumanTurn() {
-			break
+			return
 		}
 		ci.Game.CpuPlay()
 	}

--- a/internal/usecase/CrazyEightsInteractor.go
+++ b/internal/usecase/CrazyEightsInteractor.go
@@ -133,7 +133,10 @@ func (ci *CrazyEightsInteractor) IsHumanChooseSuitTurn() bool {
 
 // runCpuTurns ゲームが終わるか人間の手番またはラウンド/ゲーム終了になるまでCPUターンを実行
 func (ci *CrazyEightsInteractor) runCpuTurns() {
-	for !ci.Game.GetGameEndFlag() {
+	for i := 0; i < MaxCpuIterations; i++ {
+		if ci.Game.GetGameEndFlag() {
+			return
+		}
 		phase := ci.Game.GetPhase()
 		if phase == CrazyEightsPhaseRoundEnd || phase == CrazyEightsPhaseGameEnd {
 			break

--- a/internal/usecase/CribbageInteractor.go
+++ b/internal/usecase/CribbageInteractor.go
@@ -146,7 +146,10 @@ func (ci *CribbageInteractor) ActionLog() string {
 
 // runCpuTurns CPUターンを実行
 func (ci *CribbageInteractor) runCpuTurns() {
-	for !ci.Game.GetGameEndFlag() {
+	for i := 0; i < MaxCpuIterations; i++ {
+		if ci.Game.GetGameEndFlag() {
+			return
+		}
 		phase := ci.Game.GetPhase()
 		if phase == domain.CribbagePhaseRoundEnd || phase == domain.CribbagePhaseGameEnd ||
 			phase == domain.CribbagePhaseShow {

--- a/internal/usecase/CribbageInteractor.go
+++ b/internal/usecase/CribbageInteractor.go
@@ -146,20 +146,10 @@ func (ci *CribbageInteractor) ActionLog() string {
 
 // runCpuTurns CPUターンを実行
 func (ci *CribbageInteractor) runCpuTurns() {
-	for i := 0; i < MaxCpuIterations; i++ {
-		if ci.Game.GetGameEndFlag() {
-			return
-		}
+	runCpuTurnsUntil(ci.Game, func() bool {
 		phase := ci.Game.GetPhase()
-		if phase == domain.CribbagePhaseRoundEnd || phase == domain.CribbagePhaseGameEnd ||
-			phase == domain.CribbagePhaseShow {
-			break
-		}
-		if ci.Game.IsHumanTurn() {
-			break
-		}
-		ci.Game.CpuPlay()
-	}
+		return phase == domain.CribbagePhaseRoundEnd || phase == domain.CribbagePhaseGameEnd || phase == domain.CribbagePhaseShow || ci.Game.IsHumanTurn()
+	}, ci.Game.CpuPlay)
 }
 
 // RestoreCribbageInteractor deserialises JSON into a CribbageInteractor.

--- a/internal/usecase/DoubtInteractor.go
+++ b/internal/usecase/DoubtInteractor.go
@@ -102,7 +102,10 @@ func (di *DoubtInteractor) ActionLog() string {
 
 // runCpuTurns ゲームが終わるか人間の手番またはダウトフェーズになるまでCPUターンを実行
 func (di *DoubtInteractor) runCpuTurns() {
-	for !di.Game.GetGameEndFlag() {
+	for i := 0; i < MaxCpuIterations; i++ {
+		if di.Game.GetGameEndFlag() {
+			return
+		}
 		if di.Game.GetPhase() == domain.DoubtPhaseDoubt {
 			break
 		}

--- a/internal/usecase/DoubtInteractor.go
+++ b/internal/usecase/DoubtInteractor.go
@@ -102,18 +102,9 @@ func (di *DoubtInteractor) ActionLog() string {
 
 // runCpuTurns ゲームが終わるか人間の手番またはダウトフェーズになるまでCPUターンを実行
 func (di *DoubtInteractor) runCpuTurns() {
-	for i := 0; i < MaxCpuIterations; i++ {
-		if di.Game.GetGameEndFlag() {
-			return
-		}
-		if di.Game.GetPhase() == domain.DoubtPhaseDoubt {
-			break
-		}
-		if di.Game.IsHumanTurn() {
-			break
-		}
-		di.Game.CpuPlay()
-	}
+	runCpuTurnsUntil(di.Game, func() bool {
+		return di.Game.GetPhase() == domain.DoubtPhaseDoubt || di.Game.IsHumanTurn()
+	}, di.Game.CpuPlay)
 }
 
 // RestoreDoubtInteractor deserialises JSON into a DoubtInteractor.

--- a/internal/usecase/EuchreInteractor.go
+++ b/internal/usecase/EuchreInteractor.go
@@ -192,7 +192,10 @@ func (ei *EuchreInteractor) ActionLog() string {
 
 // runCpuBids PickUpとCallTrumpフェーズでCPUを自動実行する
 func (ei *EuchreInteractor) runCpuBids() {
-	for !ei.Game.GetGameEndFlag() {
+	for i := 0; i < MaxCpuIterations; i++ {
+		if ei.Game.GetGameEndFlag() {
+			return
+		}
 		phase := ei.Game.GetPhase()
 		if phase == domain.EuchrePhasePickUp {
 			if ei.Game.IsHumanBidTurn() {

--- a/internal/usecase/FrenchTarotInteractor.go
+++ b/internal/usecase/FrenchTarotInteractor.go
@@ -160,11 +160,9 @@ func (ci *FrenchTarotInteractor) ActionLog() string {
 func (ci *FrenchTarotInteractor) advance() {
 	runCpuBidsLoop[domain.FrenchTarotPhase](ci.Game, domain.FrenchTarotPhaseBid)
 	// CPU デクレアラーのシアン交換を自動実行する。
-	for !ci.Game.GetGameEndFlag() &&
-		ci.Game.GetPhase() == domain.FrenchTarotPhaseChien &&
-		!ci.Game.IsHumanDiscardTurn() {
-		ci.Game.CpuDiscard()
-	}
+	runCpuTurnsUntil(ci.Game, func() bool {
+		return ci.Game.GetPhase() != domain.FrenchTarotPhaseChien || ci.Game.IsHumanDiscardTurn()
+	}, ci.Game.CpuDiscard)
 	runCpuTurnsLoop(ci.Game, frenchTarotTrickPhases())
 }
 

--- a/internal/usecase/GinRummyInteractor.go
+++ b/internal/usecase/GinRummyInteractor.go
@@ -140,13 +140,16 @@ func (ci *GinRummyInteractor) ActionLog() string {
 
 // runCpuTurns CPUターンを実行
 func (ci *GinRummyInteractor) runCpuTurns() {
-	for !ci.Game.GetGameEndFlag() {
+	for i := 0; i < MaxCpuIterations; i++ {
+		if ci.Game.GetGameEndFlag() {
+			return
+		}
 		phase := ci.Game.GetPhase()
 		if phase == domain.GinRummyPhaseRoundEnd || phase == domain.GinRummyPhaseGameEnd {
-			break
+			return
 		}
 		if ci.Game.IsHumanTurn() {
-			break
+			return
 		}
 		ci.Game.CpuPlay()
 	}

--- a/internal/usecase/GinRummyInteractor.go
+++ b/internal/usecase/GinRummyInteractor.go
@@ -140,19 +140,10 @@ func (ci *GinRummyInteractor) ActionLog() string {
 
 // runCpuTurns CPUターンを実行
 func (ci *GinRummyInteractor) runCpuTurns() {
-	for i := 0; i < MaxCpuIterations; i++ {
-		if ci.Game.GetGameEndFlag() {
-			return
-		}
+	runCpuTurnsUntil(ci.Game, func() bool {
 		phase := ci.Game.GetPhase()
-		if phase == domain.GinRummyPhaseRoundEnd || phase == domain.GinRummyPhaseGameEnd {
-			return
-		}
-		if ci.Game.IsHumanTurn() {
-			return
-		}
-		ci.Game.CpuPlay()
-	}
+		return phase == domain.GinRummyPhaseRoundEnd || phase == domain.GinRummyPhaseGameEnd || ci.Game.IsHumanTurn()
+	}, ci.Game.CpuPlay)
 }
 
 // RestoreGinRummyInteractor deserialises JSON into a GinRummyInteractor.

--- a/internal/usecase/HandAndFootInteractor.go
+++ b/internal/usecase/HandAndFootInteractor.go
@@ -162,19 +162,10 @@ func (ci *HandAndFootInteractor) ActionLog() string {
 
 // runCpuTurns CPUターンを実行
 func (ci *HandAndFootInteractor) runCpuTurns() {
-	for i := 0; i < MaxCpuIterations; i++ {
-		if ci.Game.GetGameEndFlag() {
-			return
-		}
+	runCpuTurnsUntil(ci.Game, func() bool {
 		phase := ci.Game.GetPhase()
-		if phase == domain.HandAndFootPhaseRoundEnd || phase == domain.HandAndFootPhaseGameEnd {
-			return
-		}
-		if ci.Game.IsHumanTurn() {
-			return
-		}
-		ci.Game.CpuPlay()
-	}
+		return phase == domain.HandAndFootPhaseRoundEnd || phase == domain.HandAndFootPhaseGameEnd || ci.Game.IsHumanTurn()
+	}, ci.Game.CpuPlay)
 }
 
 // RestoreHandAndFootInteractor deserialises JSON into a HandAndFootInteractor.

--- a/internal/usecase/HandAndFootInteractor.go
+++ b/internal/usecase/HandAndFootInteractor.go
@@ -162,13 +162,16 @@ func (ci *HandAndFootInteractor) ActionLog() string {
 
 // runCpuTurns CPUターンを実行
 func (ci *HandAndFootInteractor) runCpuTurns() {
-	for !ci.Game.GetGameEndFlag() {
+	for i := 0; i < MaxCpuIterations; i++ {
+		if ci.Game.GetGameEndFlag() {
+			return
+		}
 		phase := ci.Game.GetPhase()
 		if phase == domain.HandAndFootPhaseRoundEnd || phase == domain.HandAndFootPhaseGameEnd {
-			break
+			return
 		}
 		if ci.Game.IsHumanTurn() {
-			break
+			return
 		}
 		ci.Game.CpuPlay()
 	}

--- a/internal/usecase/IndianRummyInteractor.go
+++ b/internal/usecase/IndianRummyInteractor.go
@@ -121,19 +121,10 @@ func (ci *IndianRummyInteractor) ActionLog() string {
 
 // runCpuTurns CPU ターンを連続で処理する
 func (ci *IndianRummyInteractor) runCpuTurns() {
-	for i := 0; i < MaxCpuIterations; i++ {
-		if ci.Game.GetGameEndFlag() {
-			return
-		}
+	runCpuTurnsUntil(ci.Game, func() bool {
 		phase := ci.Game.GetPhase()
-		if phase == domain.IndianRummyPhaseRoundEnd || phase == domain.IndianRummyPhaseGameEnd {
-			return
-		}
-		if ci.Game.IsHumanTurn() {
-			return
-		}
-		ci.Game.CpuPlay()
-	}
+		return phase == domain.IndianRummyPhaseRoundEnd || phase == domain.IndianRummyPhaseGameEnd || ci.Game.IsHumanTurn()
+	}, ci.Game.CpuPlay)
 }
 
 // RestoreIndianRummyInteractor JSON から IndianRummyInteractor を復元する

--- a/internal/usecase/IndianRummyInteractor.go
+++ b/internal/usecase/IndianRummyInteractor.go
@@ -121,13 +121,16 @@ func (ci *IndianRummyInteractor) ActionLog() string {
 
 // runCpuTurns CPU ターンを連続で処理する
 func (ci *IndianRummyInteractor) runCpuTurns() {
-	for !ci.Game.GetGameEndFlag() {
+	for i := 0; i < MaxCpuIterations; i++ {
+		if ci.Game.GetGameEndFlag() {
+			return
+		}
 		phase := ci.Game.GetPhase()
 		if phase == domain.IndianRummyPhaseRoundEnd || phase == domain.IndianRummyPhaseGameEnd {
-			break
+			return
 		}
 		if ci.Game.IsHumanTurn() {
-			break
+			return
 		}
 		ci.Game.CpuPlay()
 	}

--- a/internal/usecase/JassInteractor.go
+++ b/internal/usecase/JassInteractor.go
@@ -139,7 +139,10 @@ func (ji *JassInteractor) ActionLog() string {
 
 // runCpuBids ビッドフェーズでCPUを自動実行する (切り札選択 / Schieben)
 func (ji *JassInteractor) runCpuBids() {
-	for !ji.Game.GetGameEndFlag() {
+	for i := 0; i < MaxCpuIterations; i++ {
+		if ji.Game.GetGameEndFlag() {
+			return
+		}
 		phase := ji.Game.GetPhase()
 		if phase != domain.JassPhaseBidTrump && phase != domain.JassPhaseBidPartner {
 			return

--- a/internal/usecase/KalookiInteractor.go
+++ b/internal/usecase/KalookiInteractor.go
@@ -135,13 +135,16 @@ func (ci *KalookiInteractor) ActionLog() string {
 
 // runCpuTurns CPU ターンを連続で処理する
 func (ci *KalookiInteractor) runCpuTurns() {
-	for !ci.Game.GetGameEndFlag() {
+	for i := 0; i < MaxCpuIterations; i++ {
+		if ci.Game.GetGameEndFlag() {
+			return
+		}
 		phase := ci.Game.GetPhase()
 		if phase == domain.KalookiPhaseRoundEnd || phase == domain.KalookiPhaseGameEnd {
-			break
+			return
 		}
 		if ci.Game.IsHumanTurn() {
-			break
+			return
 		}
 		ci.Game.CpuPlay()
 	}

--- a/internal/usecase/KalookiInteractor.go
+++ b/internal/usecase/KalookiInteractor.go
@@ -135,19 +135,10 @@ func (ci *KalookiInteractor) ActionLog() string {
 
 // runCpuTurns CPU ターンを連続で処理する
 func (ci *KalookiInteractor) runCpuTurns() {
-	for i := 0; i < MaxCpuIterations; i++ {
-		if ci.Game.GetGameEndFlag() {
-			return
-		}
+	runCpuTurnsUntil(ci.Game, func() bool {
 		phase := ci.Game.GetPhase()
-		if phase == domain.KalookiPhaseRoundEnd || phase == domain.KalookiPhaseGameEnd {
-			return
-		}
-		if ci.Game.IsHumanTurn() {
-			return
-		}
-		ci.Game.CpuPlay()
-	}
+		return phase == domain.KalookiPhaseRoundEnd || phase == domain.KalookiPhaseGameEnd || ci.Game.IsHumanTurn()
+	}, ci.Game.CpuPlay)
 }
 
 // RestoreKalookiInteractor JSON から KalookiInteractor を復元する

--- a/internal/usecase/KoenigrufenInteractor.go
+++ b/internal/usecase/KoenigrufenInteractor.go
@@ -174,17 +174,13 @@ func (ci *KoenigrufenInteractor) ActionLog() string {
 func (ci *KoenigrufenInteractor) advance() {
 	runCpuBidsLoop[domain.KoenigrufenPhase](ci.Game, domain.KoenigrufenPhaseBid)
 	// CPU デクレアラーの王呼びを自動実行する。
-	for !ci.Game.GetGameEndFlag() &&
-		ci.Game.GetPhase() == domain.KoenigrufenPhaseCall &&
-		!ci.Game.IsHumanCallTurn() {
-		ci.Game.CpuCallKing()
-	}
+	runCpuTurnsUntil(ci.Game, func() bool {
+		return ci.Game.GetPhase() != domain.KoenigrufenPhaseCall || ci.Game.IsHumanCallTurn()
+	}, ci.Game.CpuCallKing)
 	// CPU デクレアラーの場札交換を自動実行する。
-	for !ci.Game.GetGameEndFlag() &&
-		ci.Game.GetPhase() == domain.KoenigrufenPhaseTalon &&
-		!ci.Game.IsHumanDiscardTurn() {
-		ci.Game.CpuDiscard()
-	}
+	runCpuTurnsUntil(ci.Game, func() bool {
+		return ci.Game.GetPhase() != domain.KoenigrufenPhaseTalon || ci.Game.IsHumanDiscardTurn()
+	}, ci.Game.CpuDiscard)
 	runCpuTurnsLoop(ci.Game, koenigrufenTrickPhases())
 }
 

--- a/internal/usecase/MacauInteractor.go
+++ b/internal/usecase/MacauInteractor.go
@@ -171,7 +171,10 @@ func (ci *MacauInteractor) IsHumanDeclareTurn() bool {
 
 // runCpuTurns ゲームが終わるか人間の手番またはラウンド/ゲーム終了になるまでCPUターンを実行
 func (ci *MacauInteractor) runCpuTurns() {
-	for !ci.Game.GetGameEndFlag() {
+	for i := 0; i < MaxCpuIterations; i++ {
+		if ci.Game.GetGameEndFlag() {
+			return
+		}
 		phase := ci.Game.GetPhase()
 		if phase == MacauPhaseRoundEnd || phase == MacauPhaseGameEnd {
 			break

--- a/internal/usecase/MachiavelliInteractor.go
+++ b/internal/usecase/MachiavelliInteractor.go
@@ -121,13 +121,16 @@ func (ci *MachiavelliInteractor) ActionLog() string {
 
 // runCpuTurns CPU ターンを連続で処理する
 func (ci *MachiavelliInteractor) runCpuTurns() {
-	for !ci.Game.GetGameEndFlag() {
+	for i := 0; i < MaxCpuIterations; i++ {
+		if ci.Game.GetGameEndFlag() {
+			return
+		}
 		phase := ci.Game.GetPhase()
 		if phase == domain.MachiavelliPhaseRoundEnd || phase == domain.MachiavelliPhaseGameEnd {
-			break
+			return
 		}
 		if ci.Game.IsHumanTurn() {
-			break
+			return
 		}
 		ci.Game.CpuPlay()
 	}

--- a/internal/usecase/MachiavelliInteractor.go
+++ b/internal/usecase/MachiavelliInteractor.go
@@ -121,19 +121,10 @@ func (ci *MachiavelliInteractor) ActionLog() string {
 
 // runCpuTurns CPU ターンを連続で処理する
 func (ci *MachiavelliInteractor) runCpuTurns() {
-	for i := 0; i < MaxCpuIterations; i++ {
-		if ci.Game.GetGameEndFlag() {
-			return
-		}
+	runCpuTurnsUntil(ci.Game, func() bool {
 		phase := ci.Game.GetPhase()
-		if phase == domain.MachiavelliPhaseRoundEnd || phase == domain.MachiavelliPhaseGameEnd {
-			return
-		}
-		if ci.Game.IsHumanTurn() {
-			return
-		}
-		ci.Game.CpuPlay()
-	}
+		return phase == domain.MachiavelliPhaseRoundEnd || phase == domain.MachiavelliPhaseGameEnd || ci.Game.IsHumanTurn()
+	}, ci.Game.CpuPlay)
 }
 
 // RestoreMachiavelliInteractor JSON から MachiavelliInteractor を復元する

--- a/internal/usecase/MaoInteractor.go
+++ b/internal/usecase/MaoInteractor.go
@@ -190,7 +190,10 @@ func (ci *MaoInteractor) IsHumanAwaitingWord() bool {
 // CPUターンを実行する。隠しルールの宣言待ち (awaitingWord) のときは、人間が
 // 言葉を宣言するまでCPUを進めない。
 func (ci *MaoInteractor) runCpuTurns() {
-	for !ci.Game.GetGameEndFlag() {
+	for i := 0; i < MaxCpuIterations; i++ {
+		if ci.Game.GetGameEndFlag() {
+			return
+		}
 		// 人間が隠しルールの言葉を宣言すべき状態なら一旦停止する。
 		if ci.Game.GetAwaitingWord() {
 			break

--- a/internal/usecase/MemoryInteractor.go
+++ b/internal/usecase/MemoryInteractor.go
@@ -83,7 +83,10 @@ func (mi *MemoryInteractor) ActionLog() string {
 
 // runCpuTurns ゲームが終わるか人間の手番になるまでCPUターンを実行
 func (mi *MemoryInteractor) runCpuTurns() {
-	for !mi.Game.GetGameEndFlag() {
+	for i := 0; i < MaxCpuIterations; i++ {
+		if mi.Game.GetGameEndFlag() {
+			return
+		}
 		if mi.Game.GetPhase() != domain.MemoryPhaseFlip1 {
 			break
 		}

--- a/internal/usecase/MinchiateInteractor.go
+++ b/internal/usecase/MinchiateInteractor.go
@@ -132,11 +132,9 @@ func (ci *MinchiateInteractor) ActionLog() string {
 // **スカルトのループを先に回す。**ディーラーが CPU の局は、捨て終わるまで
 // プレイフェーズに入らないので、トリックのループだけでは前に進まない。
 func (ci *MinchiateInteractor) advance() {
-	for !ci.Game.GetGameEndFlag() &&
-		ci.Game.GetPhase() == domain.MinchiatePhaseScarto &&
-		!ci.Game.IsHumanScartoTurn() {
-		ci.Game.CpuScarto()
-	}
+	runCpuTurnsUntil(ci.Game, func() bool {
+		return ci.Game.GetPhase() != domain.MinchiatePhaseScarto || ci.Game.IsHumanScartoTurn()
+	}, ci.Game.CpuScarto)
 	runCpuTurnsLoop(ci.Game, minchiateTrickPhases())
 }
 

--- a/internal/usecase/MusInteractor.go
+++ b/internal/usecase/MusInteractor.go
@@ -118,7 +118,10 @@ func (mi *MusInteractor) ActionLog() string {
 // Mus/Discard/Grande/Chica/Pares/Juego フェーズの CPU アクションを自動進行し、
 // Showdown を解決し、RoundEnd で待機する。
 func (mi *MusInteractor) runCpuTurns() {
-	for !mi.Game.GetGameEndFlag() {
+	for i := 0; i < MaxCpuIterations; i++ {
+		if mi.Game.GetGameEndFlag() {
+			return
+		}
 		switch mi.Game.GetPhase() {
 		case domain.MusPhaseMus, domain.MusPhaseDiscard,
 			domain.MusPhaseGrande, domain.MusPhaseChica,

--- a/internal/usecase/PageOneInteractor.go
+++ b/internal/usecase/PageOneInteractor.go
@@ -136,7 +136,10 @@ func (ci *PageOneInteractor) Hint() string {
 
 // runCpuTurns ゲームが終わるか人間の手番またはラウンド/ゲーム終了になるまでCPUターンを実行
 func (ci *PageOneInteractor) runCpuTurns() {
-	for !ci.Game.GetGameEndFlag() {
+	for i := 0; i < MaxCpuIterations; i++ {
+		if ci.Game.GetGameEndFlag() {
+			return
+		}
 		phase := ci.Game.GetPhase()
 		if phase == PageOnePhaseRoundEnd || phase == PageOnePhaseGameEnd {
 			break

--- a/internal/usecase/PanInteractor.go
+++ b/internal/usecase/PanInteractor.go
@@ -135,13 +135,16 @@ func (ci *PanInteractor) ActionLog() string {
 
 // runCpuTurns CPU ターンを連続で処理する
 func (ci *PanInteractor) runCpuTurns() {
-	for !ci.Game.GetGameEndFlag() {
+	for i := 0; i < MaxCpuIterations; i++ {
+		if ci.Game.GetGameEndFlag() {
+			return
+		}
 		phase := ci.Game.GetPhase()
 		if phase == domain.PanPhaseRoundEnd || phase == domain.PanPhaseGameEnd {
-			break
+			return
 		}
 		if ci.Game.IsHumanTurn() {
-			break
+			return
 		}
 		ci.Game.CpuPlay()
 	}

--- a/internal/usecase/PanInteractor.go
+++ b/internal/usecase/PanInteractor.go
@@ -135,19 +135,10 @@ func (ci *PanInteractor) ActionLog() string {
 
 // runCpuTurns CPU ターンを連続で処理する
 func (ci *PanInteractor) runCpuTurns() {
-	for i := 0; i < MaxCpuIterations; i++ {
-		if ci.Game.GetGameEndFlag() {
-			return
-		}
+	runCpuTurnsUntil(ci.Game, func() bool {
 		phase := ci.Game.GetPhase()
-		if phase == domain.PanPhaseRoundEnd || phase == domain.PanPhaseGameEnd {
-			return
-		}
-		if ci.Game.IsHumanTurn() {
-			return
-		}
-		ci.Game.CpuPlay()
-	}
+		return phase == domain.PanPhaseRoundEnd || phase == domain.PanPhaseGameEnd || ci.Game.IsHumanTurn()
+	}, ci.Game.CpuPlay)
 }
 
 // RestorePanInteractor JSON から PanInteractor を復元する

--- a/internal/usecase/PinochleInteractor.go
+++ b/internal/usecase/PinochleInteractor.go
@@ -159,7 +159,10 @@ func (pi *PinochleInteractor) ActionLog() string {
 
 // runCpuBids ビッドおよびトランプ宣言フェーズでCPUを自動実行する
 func (pi *PinochleInteractor) runCpuBids() {
-	for !pi.Game.GetGameEndFlag() {
+	for i := 0; i < MaxCpuIterations; i++ {
+		if pi.Game.GetGameEndFlag() {
+			return
+		}
 		phase := pi.Game.GetPhase()
 		if phase == domain.PinochlePhaseBid {
 			if pi.Game.IsHumanBidTurn() {

--- a/internal/usecase/PiquetInteractor.go
+++ b/internal/usecase/PiquetInteractor.go
@@ -163,18 +163,9 @@ func (pi *PiquetInteractor) runCpuExchange() {
 
 // runCpuPlay プレイフェーズでCPUの手番を自動実行する
 func (pi *PiquetInteractor) runCpuPlay() {
-	for i := 0; i < MaxCpuIterations; i++ {
-		if pi.Game.GetGameEndFlag() {
-			return
-		}
-		if pi.Game.GetPhase() != domain.PiquetPhasePlay {
-			return
-		}
-		if pi.Game.IsHumanTurn() {
-			return
-		}
-		pi.Game.CpuPlay()
-	}
+	runCpuTurnsUntil(pi.Game, func() bool {
+		return pi.Game.GetPhase() != domain.PiquetPhasePlay || pi.Game.IsHumanTurn()
+	}, pi.Game.CpuPlay)
 }
 
 // RestorePiquetInteractor deserialises JSON into a PiquetInteractor.

--- a/internal/usecase/PiquetInteractor.go
+++ b/internal/usecase/PiquetInteractor.go
@@ -136,7 +136,10 @@ func (pi *PiquetInteractor) GetConfig() domain.PiquetConfig {
 
 // runCpuExchange 交換フェーズでCPUの手番を自動実行する
 func (pi *PiquetInteractor) runCpuExchange() {
-	for !pi.Game.GetGameEndFlag() {
+	for i := 0; i < MaxCpuIterations; i++ {
+		if pi.Game.GetGameEndFlag() {
+			return
+		}
 		if pi.Game.GetPhase() != domain.PiquetPhaseExchange {
 			return
 		}
@@ -160,7 +163,10 @@ func (pi *PiquetInteractor) runCpuExchange() {
 
 // runCpuPlay プレイフェーズでCPUの手番を自動実行する
 func (pi *PiquetInteractor) runCpuPlay() {
-	for !pi.Game.GetGameEndFlag() {
+	for i := 0; i < MaxCpuIterations; i++ {
+		if pi.Game.GetGameEndFlag() {
+			return
+		}
 		if pi.Game.GetPhase() != domain.PiquetPhasePlay {
 			return
 		}

--- a/internal/usecase/PrsiInteractor.go
+++ b/internal/usecase/PrsiInteractor.go
@@ -88,18 +88,9 @@ func (ci *PrsiInteractor) ActionLog() string {
 // 勝敗判定・スキップ・ペナルティはすべてドメインで処理されるため、どの席
 // (人間/CPU) が終端アクションを起こしても正しく処理される。
 func (ci *PrsiInteractor) runCpuTurns() {
-	for i := 0; i < MaxCpuIterations; i++ {
-		if ci.Game.GetGameEndFlag() {
-			return
-		}
-		if ci.Game.GetPhase() != domain.PrsiPhasePlay {
-			break
-		}
-		if ci.Game.IsHumanTurn() {
-			break
-		}
-		ci.Game.CpuPlay()
-	}
+	runCpuTurnsUntil(ci.Game, func() bool {
+		return ci.Game.GetPhase() != domain.PrsiPhasePlay || ci.Game.IsHumanTurn()
+	}, ci.Game.CpuPlay)
 }
 
 // RestorePrsiInteractor deserialises JSON into a PrsiInteractor.

--- a/internal/usecase/PrsiInteractor.go
+++ b/internal/usecase/PrsiInteractor.go
@@ -88,7 +88,10 @@ func (ci *PrsiInteractor) ActionLog() string {
 // 勝敗判定・スキップ・ペナルティはすべてドメインで処理されるため、どの席
 // (人間/CPU) が終端アクションを起こしても正しく処理される。
 func (ci *PrsiInteractor) runCpuTurns() {
-	for !ci.Game.GetGameEndFlag() {
+	for i := 0; i < MaxCpuIterations; i++ {
+		if ci.Game.GetGameEndFlag() {
+			return
+		}
 		if ci.Game.GetPhase() != domain.PrsiPhasePlay {
 			break
 		}

--- a/internal/usecase/Rummy500Interactor.go
+++ b/internal/usecase/Rummy500Interactor.go
@@ -140,19 +140,10 @@ func (ci *Rummy500Interactor) Hint() string {
 
 // runCpuTurns CPUターンを連続実行
 func (ci *Rummy500Interactor) runCpuTurns() {
-	for i := 0; i < MaxCpuIterations; i++ {
-		if ci.Game.GetGameEndFlag() {
-			return
-		}
+	runCpuTurnsUntil(ci.Game, func() bool {
 		phase := ci.Game.GetPhase()
-		if phase == domain.Rummy500PhaseRoundEnd || phase == domain.Rummy500PhaseGameEnd {
-			return
-		}
-		if ci.Game.IsHumanTurn() {
-			return
-		}
-		ci.Game.CpuPlay()
-	}
+		return phase == domain.Rummy500PhaseRoundEnd || phase == domain.Rummy500PhaseGameEnd || ci.Game.IsHumanTurn()
+	}, ci.Game.CpuPlay)
 }
 
 // RestoreRummy500Interactor deserialises JSON into a Rummy500Interactor.

--- a/internal/usecase/Rummy500Interactor.go
+++ b/internal/usecase/Rummy500Interactor.go
@@ -140,13 +140,16 @@ func (ci *Rummy500Interactor) Hint() string {
 
 // runCpuTurns CPUターンを連続実行
 func (ci *Rummy500Interactor) runCpuTurns() {
-	for !ci.Game.GetGameEndFlag() {
+	for i := 0; i < MaxCpuIterations; i++ {
+		if ci.Game.GetGameEndFlag() {
+			return
+		}
 		phase := ci.Game.GetPhase()
 		if phase == domain.Rummy500PhaseRoundEnd || phase == domain.Rummy500PhaseGameEnd {
-			break
+			return
 		}
 		if ci.Game.IsHumanTurn() {
-			break
+			return
 		}
 		ci.Game.CpuPlay()
 	}

--- a/internal/usecase/SambaInteractor.go
+++ b/internal/usecase/SambaInteractor.go
@@ -155,13 +155,16 @@ func (ci *SambaInteractor) ActionLog() string {
 
 // runCpuTurns CPUターンを実行
 func (ci *SambaInteractor) runCpuTurns() {
-	for !ci.Game.GetGameEndFlag() {
+	for i := 0; i < MaxCpuIterations; i++ {
+		if ci.Game.GetGameEndFlag() {
+			return
+		}
 		phase := ci.Game.GetPhase()
 		if phase == domain.SambaPhaseRoundEnd || phase == domain.SambaPhaseGameEnd {
-			break
+			return
 		}
 		if ci.Game.IsHumanTurn() {
-			break
+			return
 		}
 		ci.Game.CpuPlay()
 	}

--- a/internal/usecase/SambaInteractor.go
+++ b/internal/usecase/SambaInteractor.go
@@ -155,19 +155,10 @@ func (ci *SambaInteractor) ActionLog() string {
 
 // runCpuTurns CPUターンを実行
 func (ci *SambaInteractor) runCpuTurns() {
-	for i := 0; i < MaxCpuIterations; i++ {
-		if ci.Game.GetGameEndFlag() {
-			return
-		}
+	runCpuTurnsUntil(ci.Game, func() bool {
 		phase := ci.Game.GetPhase()
-		if phase == domain.SambaPhaseRoundEnd || phase == domain.SambaPhaseGameEnd {
-			return
-		}
-		if ci.Game.IsHumanTurn() {
-			return
-		}
-		ci.Game.CpuPlay()
-	}
+		return phase == domain.SambaPhaseRoundEnd || phase == domain.SambaPhaseGameEnd || ci.Game.IsHumanTurn()
+	}, ci.Game.CpuPlay)
 }
 
 // RestoreSambaInteractor deserialises JSON into a SambaInteractor.

--- a/internal/usecase/ScartoInteractor.go
+++ b/internal/usecase/ScartoInteractor.go
@@ -131,11 +131,9 @@ func (ci *ScartoInteractor) ActionLog() string {
 // 自動実行する。
 func (ci *ScartoInteractor) advance() {
 	// CPU の親のスカルトを自動実行する。
-	for !ci.Game.GetGameEndFlag() &&
-		ci.Game.GetPhase() == domain.ScartoPhaseScarto &&
-		!ci.Game.IsHumanScartoTurn() {
-		ci.Game.CpuScarto()
-	}
+	runCpuTurnsUntil(ci.Game, func() bool {
+		return ci.Game.GetPhase() != domain.ScartoPhaseScarto || ci.Game.IsHumanScartoTurn()
+	}, ci.Game.CpuScarto)
 	runCpuTurnsLoop(ci.Game, scartoTrickPhases())
 }
 

--- a/internal/usecase/SevenBridgeInteractor.go
+++ b/internal/usecase/SevenBridgeInteractor.go
@@ -156,19 +156,10 @@ func (ci *SevenBridgeInteractor) Hint() string {
 
 // runCpuTurns CPU ターンを連続で処理する
 func (ci *SevenBridgeInteractor) runCpuTurns() {
-	for i := 0; i < MaxCpuIterations; i++ {
-		if ci.Game.GetGameEndFlag() {
-			return
-		}
+	runCpuTurnsUntil(ci.Game, func() bool {
 		phase := ci.Game.GetPhase()
-		if phase == domain.SevenBridgePhaseRoundEnd || phase == domain.SevenBridgePhaseGameEnd {
-			return
-		}
-		if ci.Game.IsHumanTurn() {
-			return
-		}
-		ci.Game.CpuPlay()
-	}
+		return phase == domain.SevenBridgePhaseRoundEnd || phase == domain.SevenBridgePhaseGameEnd || ci.Game.IsHumanTurn()
+	}, ci.Game.CpuPlay)
 }
 
 // RestoreSevenBridgeInteractor deserialises JSON into a SevenBridgeInteractor.

--- a/internal/usecase/SevenBridgeInteractor.go
+++ b/internal/usecase/SevenBridgeInteractor.go
@@ -156,13 +156,16 @@ func (ci *SevenBridgeInteractor) Hint() string {
 
 // runCpuTurns CPU ターンを連続で処理する
 func (ci *SevenBridgeInteractor) runCpuTurns() {
-	for !ci.Game.GetGameEndFlag() {
+	for i := 0; i < MaxCpuIterations; i++ {
+		if ci.Game.GetGameEndFlag() {
+			return
+		}
 		phase := ci.Game.GetPhase()
 		if phase == domain.SevenBridgePhaseRoundEnd || phase == domain.SevenBridgePhaseGameEnd {
-			break
+			return
 		}
 		if ci.Game.IsHumanTurn() {
-			break
+			return
 		}
 		ci.Game.CpuPlay()
 	}

--- a/internal/usecase/SevensInteractor.go
+++ b/internal/usecase/SevensInteractor.go
@@ -85,7 +85,10 @@ func (si *SevensInteractor) ActionLog() string {
 // runCpuTurns ゲームが終わるか人間の手番になるまでCPUターンを実行
 // 人間の手番になった場合でも選択肢がなければ自動処理する
 func (si *SevensInteractor) runCpuTurns() {
-	for !si.Game.GetGameEndFlag() {
+	for i := 0; i < MaxCpuIterations; i++ {
+		if si.Game.GetGameEndFlag() {
+			return
+		}
 		if si.Game.IsHumanTurn() {
 			// 人間に選択肢がなければ自動処理 (失格)
 			if !si.Game.HasAnyOption(si.Game.GetCurrentTurn()) {

--- a/internal/usecase/SheepsheadInteractor.go
+++ b/internal/usecase/SheepsheadInteractor.go
@@ -154,7 +154,10 @@ func (si *SheepsheadInteractor) ActionLog() string {
 // runCpuTurns ゲーム終了・人間の手番・トリック/ラウンド終了になるまで CPU ターンを
 // 実行する。ピック/埋め/呼びの各フェーズも CPU が自動進行する。
 func (si *SheepsheadInteractor) runCpuTurns() {
-	for !si.Game.GetGameEndFlag() {
+	for i := 0; i < MaxCpuIterations; i++ {
+		if si.Game.GetGameEndFlag() {
+			return
+		}
 		switch si.Game.GetPhase() {
 		case domain.SheepsheadPhasePick, domain.SheepsheadPhaseBury, domain.SheepsheadPhaseCall:
 			if si.Game.IsHumanTurn() {

--- a/internal/usecase/SixCardGolfInteractor.go
+++ b/internal/usecase/SixCardGolfInteractor.go
@@ -176,13 +176,16 @@ func (ci *SixCardGolfInteractor) Hint() string {
 
 // runCpuTurns CPUターンループ
 func (ci *SixCardGolfInteractor) runCpuTurns() {
-	for !ci.Game.GetGameEndFlag() {
+	for i := 0; i < MaxCpuIterations; i++ {
+		if ci.Game.GetGameEndFlag() {
+			return
+		}
 		phase := ci.Game.GetPhase()
 		if phase == domain.SixCardGolfPhaseRoundOver || phase == domain.SixCardGolfPhaseGameOver {
-			break
+			return
 		}
 		if ci.Game.IsHumanTurn() {
-			break
+			return
 		}
 		ci.Game.CpuPlay()
 	}

--- a/internal/usecase/SixCardGolfInteractor.go
+++ b/internal/usecase/SixCardGolfInteractor.go
@@ -176,19 +176,10 @@ func (ci *SixCardGolfInteractor) Hint() string {
 
 // runCpuTurns CPUターンループ
 func (ci *SixCardGolfInteractor) runCpuTurns() {
-	for i := 0; i < MaxCpuIterations; i++ {
-		if ci.Game.GetGameEndFlag() {
-			return
-		}
+	runCpuTurnsUntil(ci.Game, func() bool {
 		phase := ci.Game.GetPhase()
-		if phase == domain.SixCardGolfPhaseRoundOver || phase == domain.SixCardGolfPhaseGameOver {
-			return
-		}
-		if ci.Game.IsHumanTurn() {
-			return
-		}
-		ci.Game.CpuPlay()
-	}
+		return phase == domain.SixCardGolfPhaseRoundOver || phase == domain.SixCardGolfPhaseGameOver || ci.Game.IsHumanTurn()
+	}, ci.Game.CpuPlay)
 }
 
 // RestoreSixCardGolfInteractor JSON復元

--- a/internal/usecase/SixCardGolfInteractor_test.go
+++ b/internal/usecase/SixCardGolfInteractor_test.go
@@ -21,3 +21,20 @@ func TestSixCardGolfInteractor_Hint(t *testing.T) {
 	assert.Equal(t, "hint", ci.Hint())
 	pMock.AssertExpectations(t)
 }
+
+// runCpuTurns はこのファイルで唯一テストの無い関数だった (develop 上で 0%)。
+// #5418 で反復上限を入れたので、その分岐も含めて一度通しておく。
+func TestSixCardGolfInteractor_ResetRunsCpuTurns(t *testing.T) {
+	game := domain.NewDefaultSixCardGolf()
+	pMock := new(presenter.MockSixCardGolfPresenter)
+	pMock.On("Output", game, nil).Return("board")
+
+	ci := usecase.NewSixCardGolfInteractor(game, pMock)
+	assert.Equal(t, "board", ci.Reset())
+
+	// **配った直後は人間の手番。** ここで CPU が動き続けていたら、上限に当たるまで
+	// 回ってから返ってくる = セットアップが壊れている。
+	assert.True(t, game.IsHumanTurn(), "Reset 後に人間の手番になっていない")
+	assert.False(t, game.GetGameEndFlag())
+	pMock.AssertExpectations(t)
+}

--- a/internal/usecase/SkatInteractor.go
+++ b/internal/usecase/SkatInteractor.go
@@ -170,7 +170,10 @@ func (si *SkatInteractor) runCpuBids() {
 // runCpuDeclarerPhases drives skat-pickup, discard, and game-declaration when
 // the declarer is a CPU.
 func (si *SkatInteractor) runCpuDeclarerPhases() {
-	for !si.Game.GetGameEndFlag() {
+	for i := 0; i < MaxCpuIterations; i++ {
+		if si.Game.GetGameEndFlag() {
+			return
+		}
 		phase := si.Game.GetPhase()
 		switch phase {
 		case domain.SkatPhaseSkatPickup:

--- a/internal/usecase/TarocchiniInteractor.go
+++ b/internal/usecase/TarocchiniInteractor.go
@@ -132,11 +132,9 @@ func (ci *TarocchiniInteractor) ActionLog() string {
 // **スカルトのループを先に回す。**ディーラーが CPU の局は、捨て終わるまで
 // プレイフェーズに入らないので、トリックのループだけでは前に進まない。
 func (ci *TarocchiniInteractor) advance() {
-	for !ci.Game.GetGameEndFlag() &&
-		ci.Game.GetPhase() == domain.TarocchiniPhaseScarto &&
-		!ci.Game.IsHumanScartoTurn() {
-		ci.Game.CpuScarto()
-	}
+	runCpuTurnsUntil(ci.Game, func() bool {
+		return ci.Game.GetPhase() != domain.TarocchiniPhaseScarto || ci.Game.IsHumanScartoTurn()
+	}, ci.Game.CpuScarto)
 	runCpuTurnsLoop(ci.Game, tarocchiniTrickPhases())
 }
 

--- a/internal/usecase/ThreeThirteenInteractor.go
+++ b/internal/usecase/ThreeThirteenInteractor.go
@@ -121,19 +121,10 @@ func (ci *ThreeThirteenInteractor) ActionLog() string {
 
 // runCpuTurns CPU ターンを連続で処理する
 func (ci *ThreeThirteenInteractor) runCpuTurns() {
-	for i := 0; i < MaxCpuIterations; i++ {
-		if ci.Game.GetGameEndFlag() {
-			return
-		}
+	runCpuTurnsUntil(ci.Game, func() bool {
 		phase := ci.Game.GetPhase()
-		if phase == domain.ThreeThirteenPhaseRoundEnd || phase == domain.ThreeThirteenPhaseGameEnd {
-			return
-		}
-		if ci.Game.IsHumanTurn() {
-			return
-		}
-		ci.Game.CpuPlay()
-	}
+		return phase == domain.ThreeThirteenPhaseRoundEnd || phase == domain.ThreeThirteenPhaseGameEnd || ci.Game.IsHumanTurn()
+	}, ci.Game.CpuPlay)
 }
 
 // RestoreThreeThirteenInteractor JSON から ThreeThirteenInteractor を復元する

--- a/internal/usecase/ThreeThirteenInteractor.go
+++ b/internal/usecase/ThreeThirteenInteractor.go
@@ -121,13 +121,16 @@ func (ci *ThreeThirteenInteractor) ActionLog() string {
 
 // runCpuTurns CPU ターンを連続で処理する
 func (ci *ThreeThirteenInteractor) runCpuTurns() {
-	for !ci.Game.GetGameEndFlag() {
+	for i := 0; i < MaxCpuIterations; i++ {
+		if ci.Game.GetGameEndFlag() {
+			return
+		}
 		phase := ci.Game.GetPhase()
 		if phase == domain.ThreeThirteenPhaseRoundEnd || phase == domain.ThreeThirteenPhaseGameEnd {
-			break
+			return
 		}
 		if ci.Game.IsHumanTurn() {
-			break
+			return
 		}
 		ci.Game.CpuPlay()
 	}

--- a/internal/usecase/TonkInteractor.go
+++ b/internal/usecase/TonkInteractor.go
@@ -123,13 +123,16 @@ func (ci *TonkInteractor) ActionLog() string {
 
 // runCpuTurns CPUターンを実行
 func (ci *TonkInteractor) runCpuTurns() {
-	for !ci.Game.GetGameEndFlag() {
+	for i := 0; i < MaxCpuIterations; i++ {
+		if ci.Game.GetGameEndFlag() {
+			return
+		}
 		phase := ci.Game.GetPhase()
 		if phase == domain.TonkPhaseRoundEnd || phase == domain.TonkPhaseGameEnd {
-			break
+			return
 		}
 		if ci.Game.IsHumanTurn() {
-			break
+			return
 		}
 		ci.Game.CpuPlay()
 	}

--- a/internal/usecase/TonkInteractor.go
+++ b/internal/usecase/TonkInteractor.go
@@ -123,19 +123,10 @@ func (ci *TonkInteractor) ActionLog() string {
 
 // runCpuTurns CPUターンを実行
 func (ci *TonkInteractor) runCpuTurns() {
-	for i := 0; i < MaxCpuIterations; i++ {
-		if ci.Game.GetGameEndFlag() {
-			return
-		}
+	runCpuTurnsUntil(ci.Game, func() bool {
 		phase := ci.Game.GetPhase()
-		if phase == domain.TonkPhaseRoundEnd || phase == domain.TonkPhaseGameEnd {
-			return
-		}
-		if ci.Game.IsHumanTurn() {
-			return
-		}
-		ci.Game.CpuPlay()
-	}
+		return phase == domain.TonkPhaseRoundEnd || phase == domain.TonkPhaseGameEnd || ci.Game.IsHumanTurn()
+	}, ci.Game.CpuPlay)
 }
 
 // RestoreTonkInteractor deserialises JSON into a TonkInteractor.

--- a/internal/usecase/TrucoInteractor.go
+++ b/internal/usecase/TrucoInteractor.go
@@ -120,7 +120,10 @@ func (ti *TrucoInteractor) ActionLog() string {
 // 共通の runCpuTurnsLoop ではなく専用ループを用いる。
 func (ti *TrucoInteractor) runCpuTurns() {
 	g := ti.Game
-	for !g.GetGameEndFlag() {
+	for i := 0; i < MaxCpuIterations; i++ {
+		if g.GetGameEndFlag() {
+			return
+		}
 		switch g.GetPhase() {
 		case domain.TrucoPhasePlay, domain.TrucoPhaseRespond:
 			if g.IsHumanTurn() {

--- a/internal/usecase/TwoTenJackInteractor.go
+++ b/internal/usecase/TwoTenJackInteractor.go
@@ -123,7 +123,10 @@ func (ti *TwoTenJackInteractor) ActionLog() string {
 
 // runCpuDeclares ゲームが終わるか人間の宣言番または宣言フェーズが終了するまでCPU宣言を実行
 func (ti *TwoTenJackInteractor) runCpuDeclares() {
-	for !ti.Game.GetGameEndFlag() {
+	for i := 0; i < MaxCpuIterations; i++ {
+		if ti.Game.GetGameEndFlag() {
+			return
+		}
 		if ti.Game.GetPhase() != domain.TwoTenJackPhaseDeclare {
 			break
 		}

--- a/internal/usecase/WattenInteractor.go
+++ b/internal/usecase/WattenInteractor.go
@@ -139,7 +139,10 @@ func (wi *WattenInteractor) ActionLog() string {
 // 生成的な runCpuTurnsLoop では Respond フェーズを扱えないため専用ループを持つ。
 func (wi *WattenInteractor) runCpu() {
 	g := wi.Game
-	for !g.GetGameEndFlag() {
+	for i := 0; i < MaxCpuIterations; i++ {
+		if g.GetGameEndFlag() {
+			return
+		}
 		switch g.GetPhase() {
 		case domain.WattenPhaseDeclare:
 			if g.IsHumanDeclareTurn() {

--- a/internal/usecase/cpu_loop_progress_test.go
+++ b/internal/usecase/cpu_loop_progress_test.go
@@ -47,3 +47,43 @@ func TestRunCpuTurnsLoopTerminatesWithEmptyHand(t *testing.T) {
 		t.Fatal("CPU ターンのループが 3 秒で終わらなかった: 手札の尽きた席で進行が止まっている")
 	}
 }
+
+// stalledBidGame は「ビッドが一度も進まない」ドメインを演じる。
+//
+// 実物のゲームでは上限に当たらせられない——どのゲームも数十手で phase が変わるので、
+// 1000 回に届く前に別の条件で抜けてしまい、**上限の分岐を一度も踏まないまま緑になる**。
+// 上限が守っているのは「ドメインが壊れたとき」であって、壊れたドメインは自分で
+// 用意するしかない。
+type stalledBidGame struct{ bids int }
+
+func (g *stalledBidGame) GetGameEndFlag() bool { return false }
+func (g *stalledBidGame) GetPhase() int        { return 1 }
+func (g *stalledBidGame) IsHumanBidTurn() bool { return false }
+
+// CpuBid は数えるだけで phase も手番も動かさない。#5416 のドメインバグの形。
+func (g *stalledBidGame) CpuBid() { g.bids++ }
+
+// runCpuBidsLoop も runCpuTurnsLoop と同じく、進まないドメインから戻れること。
+// 兄弟の runCpuTurnsLoop には #4607 由来のテストがあったが、こちらには無かった
+// (PR #5418 のレビュー指摘)。
+func TestRunCpuBidsLoopTerminatesWhenBiddingNeverAdvances(t *testing.T) {
+	g := &stalledBidGame{}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		runCpuBidsLoop(g, 1)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("ビッドのループが 3 秒で終わらなかった: 進まないビッドから戻れていない")
+	}
+
+	// **「終わった」だけでは上限が効いた証拠にならない。** 他の条件で抜けたのでは
+	// なく上限で抜けたことを、回った回数で押さえる。
+	if g.bids != maxCpuTurnsPerCall {
+		t.Fatalf("上限で抜けていない: CpuBid が %d 回 (期待 %d)", g.bids, maxCpuTurnsPerCall)
+	}
+}

--- a/internal/usecase/interactor_guard.go
+++ b/internal/usecase/interactor_guard.go
@@ -67,18 +67,13 @@ func advanceRound[G roundAdvancer](game G, p outputPresenter[G], runCpu func()) 
 // 通常 1 局で CPU が動くのは数十回なので、1000 に達したらドメイン側のバグ。
 const MaxCpuIterations = 1000
 
-// runCpuTurnsCapped はゲームが終わるか人間の手番になるまで play を回す。
+// runCpuTurnsUntil は「ゲームが終わる」以外にも抜ける条件があるループ用。stop が
+// true を返したら抜ける。stop は play の**前**に読むので、既に抜ける局面で始まった
+// 場合は一度も play しない。
 //
-// 戻り値は上限に当たらずに抜けたかどうか。**false はドメインのバグを意味する**ので、
-// 呼び出し側が握り潰さずに扱えるよう返している。
-// runCpuTurnsUntil is runCpuTurnsCapped for the loops that also have to look at
-// the phase between turns. `stop` reports whether this iteration should end the
-// loop; it is read before play() so a game that starts in a stopping phase does
-// nothing.
-//
-// One helper rather than the same five lines in 40 files: the cap branch is
-// otherwise unreachable per game (a real game reaches its phase guard long
-// before 1000 turns), so 40 copies means 40 untested `return`s.
+// 同じ 5 行を 31 箇所に書き写さずヘルパ 1 つにしたのは、上限に当たる分岐が
+// **ゲームごとには到達不能**だから。実物の局は 1000 手のはるか手前で phase ガードに
+// 当たるので、31 箇所に書き写すとどのテストも実行できない `return` が 31 個できる。
 func runCpuTurnsUntil(g gameEndChecker, stop func() bool, play func()) bool {
 	for i := 0; i < MaxCpuIterations; i++ {
 		if g.GetGameEndFlag() || stop() {
@@ -89,6 +84,10 @@ func runCpuTurnsUntil(g gameEndChecker, stop func() bool, play func()) bool {
 	return false
 }
 
+// runCpuTurnsCapped はゲームが終わるか人間の手番になるまで play を回す。
+//
+// 戻り値は上限に当たらずに抜けたかどうか。**false はドメインのバグを意味する**ので、
+// 呼び出し側が握り潰さずに扱えるよう返している。
 func runCpuTurnsCapped(g playableGame, play func()) bool {
 	for i := 0; i < MaxCpuIterations; i++ {
 		if g.GetGameEndFlag() || g.IsHumanTurn() {

--- a/internal/usecase/interactor_guard.go
+++ b/internal/usecase/interactor_guard.go
@@ -71,6 +71,24 @@ const MaxCpuIterations = 1000
 //
 // 戻り値は上限に当たらずに抜けたかどうか。**false はドメインのバグを意味する**ので、
 // 呼び出し側が握り潰さずに扱えるよう返している。
+// runCpuTurnsUntil is runCpuTurnsCapped for the loops that also have to look at
+// the phase between turns. `stop` reports whether this iteration should end the
+// loop; it is read before play() so a game that starts in a stopping phase does
+// nothing.
+//
+// One helper rather than the same five lines in 40 files: the cap branch is
+// otherwise unreachable per game (a real game reaches its phase guard long
+// before 1000 turns), so 40 copies means 40 untested `return`s.
+func runCpuTurnsUntil(g gameEndChecker, stop func() bool, play func()) bool {
+	for i := 0; i < MaxCpuIterations; i++ {
+		if g.GetGameEndFlag() || stop() {
+			return true
+		}
+		play()
+	}
+	return false
+}
+
 func runCpuTurnsCapped(g playableGame, play func()) bool {
 	for i := 0; i < MaxCpuIterations; i++ {
 		if g.GetGameEndFlag() || g.IsHumanTurn() {

--- a/internal/usecase/interactor_guard_test.go
+++ b/internal/usecase/interactor_guard_test.go
@@ -178,3 +178,41 @@ func TestRunCpuTurnsCapped(t *testing.T) {
 		assert.Equal(t, MaxCpuIterations, calls)
 	})
 }
+
+// runCpuTurnsUntil のほうは 18 ゲームが共有するので、上限に当たる分岐を
+// ここで踏んでおけば全部が守られる。各ゲームに書くと、実ゲームは 1000 手より
+// ずっと手前でフェーズガードに当たるため **その return は永久に未実行**になる。
+func TestRunCpuTurnsUntil(t *testing.T) {
+	t.Run("stops on the game end flag", func(t *testing.T) {
+		g := &mockGameEndChecker{gameEnd: true}
+		calls := 0
+		assert.True(t, runCpuTurnsUntil(g, func() bool { return false }, func() { calls++ }))
+		assert.Zero(t, calls, "終局しているのに play が呼ばれた")
+	})
+
+	t.Run("stops when the phase guard says so", func(t *testing.T) {
+		g := &mockGameEndChecker{}
+		calls := 0
+		stopAfter := 3
+		ok := runCpuTurnsUntil(g, func() bool { return calls >= stopAfter }, func() { calls++ })
+		assert.True(t, ok)
+		assert.Equal(t, stopAfter, calls)
+	})
+
+	// **本題。** 進まないゲームでも必ず戻り、false を返す。
+	t.Run("gives up at the cap", func(t *testing.T) {
+		g := &mockGameEndChecker{}
+		calls := 0
+		assert.False(t, runCpuTurnsUntil(g, func() bool { return false }, func() { calls++ }),
+			"上限に当たったのに true を返している")
+		assert.Equal(t, MaxCpuIterations, calls)
+	})
+
+	// stop は play の前に読む -- 開始時点で止まる局面なら 1 手も進めない。
+	t.Run("reads stop before playing", func(t *testing.T) {
+		g := &mockGameEndChecker{}
+		calls := 0
+		assert.True(t, runCpuTurnsUntil(g, func() bool { return true }, func() { calls++ }))
+		assert.Zero(t, calls)
+	})
+}

--- a/internal/usecase/interactor_trick.go
+++ b/internal/usecase/interactor_trick.go
@@ -29,7 +29,12 @@ type bidGame[P comparable] interface {
 // runCpuBidsLoop ビッドフェーズでCPUのビッドを自動実行するループ。
 // bidPhase に該当するフェーズの間、人間の手番になるまでCPUにビッドさせる。
 func runCpuBidsLoop[P comparable](g bidGame[P], bidPhase P) {
-	for !g.GetGameEndFlag() {
+	// runCpuTurnsLoop と同じ理由で上限を持つ。ビッドが進まないまま回ると
+	// goroutine が戻らない (#5416)。
+	for turns := 0; !g.GetGameEndFlag(); turns++ {
+		if turns >= maxCpuTurnsPerCall {
+			return
+		}
 		if g.GetPhase() != bidPhase {
 			break
 		}


### PR DESCRIPTION
`Closes #5416`. #5417 covered the first two sweeps and has merged; this is the last PR for the issue.

## The other 40

#5417 covered the 13 loops that pair the end flag with `IsHumanTurn()`. Scanning for
loops whose **only** condition is the end flag found 40 more, **none of them bounded**.

## Two commits, because only one half is machine-checkable

**18 share one body exactly.** After the rewrite all 18 normalise to a single string —
that equality is the check that the transform did not quietly do something different to
one of them. `break` became `return`: inside a bounded `for i := ...` a `break` falls
through to whatever follows the loop. Nothing follows today, but it would be a silent
behaviour change the first time someone adds a line.

**22 do not.** 19 distinct bodies among them, so only the loop header changes — each
body keeps its own breaks and returns. Rewriting 19 different bodies into one form would
be a much larger diff to review for no gain.

## Two of them are shared helpers

- **`runCpuBidsLoop`** had no bound at all, while its sibling `runCpuTurnsLoop` **in the
  same file** has had one since it was written.
- **`EuchreInteractor.runCpuBids`** is a second, separate loop in a game whose main loop
  was already bounded. Being bounded in one place says nothing about the other.

## Result

**Corrected after review** -- the original claim here (`0 remaining`) was true only of the
shape the grep spelled out, and the review found a third shape: 8 more sites across 6
files, all in `advance()`, sandwiched between two loops this PR had already bounded.
They are fixed in `60acc175d`.

Re-counted with `go/ast` instead of a grep, so the predicate cannot be blind to a shape:

| | count |
|---|---|
| folded into `runCpuTurnsUntil` | 30 |
| folded into `runCpuTurnsCapped` | 13 |
| written out, cap in the condition | 28 |
| written out, cap checked in the body | 20 |
| **bounded loops, total** | **91** |
| **`for <cond> {}` with no bound, in `internal/usecase`** | **0** |
| same, in `internal/adapter` | 0 |

The unbounded scan enumerates every `for <cond> {}` with no init and no post -- a shape
that cannot bound itself by construction -- and never reads the condition at all.

## Test plan

- [x] `go test -tags test ./internal/usecase/` — green
- [x] `golangci-lint run ./internal/usecase/...` — 0 issues
- [x] the 18 rewritten bodies normalise to exactly 1 distinct string
- [x] scanned for a `break` that would fall past a newly-bounded loop — the one hit was
      the regex reaching into the next function, verified by reading it

