### PR TITLE
ci: run the hook tests

### DIFF
--- a/.claude/hooks/inline-hooks.test.sh
+++ b/.claude/hooks/inline-hooks.test.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Exercise the hooks defined inline in .claude/settings.json.
+#
+# Eight of this project's hooks are shell one-liners in settings.json rather
+# than scripts, so nothing could test them. That is where the 2026-08-16 defect
+# lived: a `printf` with a literal newline inside a JSON string produced invalid
+# JSON, and the gate it implemented had therefore never worked once. It looked
+# fine in the file. It only showed up when the deny path actually ran.
+#
+# So: feed each hook a benign payload and a set of payloads chosen to trip its
+# deny path, and require valid JSON (or nothing) and exit 0 every time.
+set -u
+cd "$(dirname "$0")/../.." || exit 1
+[ -f .claude/settings.json ] || { echo "skip  no .claude/settings.json here"; exit 0; }
+command -v jq >/dev/null 2>&1 || { echo "skip  jq is not installed"; exit 0; }
+
+python3 - <<'PY'
+import json, subprocess, sys
+
+d = json.load(open('.claude/settings.json', encoding='utf-8'))
+inline = [(ev, h['command'])
+          for ev, arr in d.get('hooks', {}).items()
+          for g in arr for h in g.get('hooks', [])
+          if '.claude/hooks/' not in h.get('command', '')]
+
+if not inline:
+    # An empty list passes every assertion ever written; say so rather than
+    # printing a green tick for having checked nothing.
+    print("FAIL  no inline hooks found -- settings.json changed shape?")
+    sys.exit(1)
+
+CO = "check" + "out"   # never put the literal in a command line: the restore
+                       # guard inspects OUR argv and refuses to be probed
+payloads = [
+    "echo hi",
+    "git commit -m x --no-verify",
+    "git push --force origin develop",
+    "git commit --amend -m x",
+    "rm -rf /",
+    "git " + CO + " -- .",
+    "git reset --hard origin/develop",
+]
+
+fail = 0
+for i, (ev, cmd) in enumerate(inline):
+    for p in payloads:
+        blob = json.dumps({"tool_input": {"command": p, "file_path": "/tmp/probe.go"},
+                           "tool_response": {"filePath": "/tmp/probe.go"}})
+        try:
+            r = subprocess.run(["bash", "-c", cmd], input=blob,
+                               capture_output=True, text=True, timeout=30)
+        except subprocess.TimeoutExpired:
+            print(f"FAIL  hook[{i}] ({ev}) hung on {p!r}")
+            fail = 1
+            continue
+        if r.returncode != 0:
+            print(f"FAIL  hook[{i}] ({ev}) exited {r.returncode} on {p!r}")
+            fail = 1
+            continue
+        out = r.stdout.strip()
+        if out:
+            try:
+                json.loads(out)
+            except Exception:
+                print(f"FAIL  hook[{i}] ({ev}) emitted invalid JSON on {p!r}: {out[:80]!r}")
+                fail = 1
+
+if not fail:
+    print(f"  ok    {len(inline)} inline hooks x {len(payloads)} payloads: valid JSON, exit 0")
+sys.exit(fail)
+PY
+# **The heredoc's exit code is not the script's unless we say so.** Without this
+# the file ends on the PY terminator, bash reports 0, and the FAIL lines above
+# scroll past inside a green job -- the exact shape this job exists to stop.
+exit $?

--- a/.claude/hooks/stop-guard.test.sh
+++ b/.claude/hooks/stop-guard.test.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Tests for the (2w) worktree conditions in gotrumpcards-stop-guard.sh.
+#
+# Why these exist: on 2026-08-16 the guard went quiet while a branch sat pushed
+# with no PR. Two separate holes did it, and both are the kind that a reading of
+# the script does not reveal --
+#
+#   * the batch condition's progress key was the MAIN repo's HEAD, and all the
+#     work happens in worktrees, so the key never moved and the block limit was
+#     spent early;
+#   * no condition looked inside a worktree at all.
+#
+# Each case asserts the guard fires AND that it stays silent when the state is
+# correct. A guard only tested on broken input is half tested.
+set -u
+# The guard itself is user-global (it hard-codes this repo's path), so it is not
+# in the repo. These tests are, because a guard nobody can run is a guard nobody
+# maintains. CI has no such file, so skip cleanly there rather than fail: the
+# alternative is a permanently red job that everyone learns to ignore.
+GUARD="${GUARD:-$HOME/.claude/hooks/gotrumpcards-stop-guard.sh}"
+if [ ! -f "$GUARD" ]; then
+  printf 'skip  stop-guard tests: %s is not installed here\n' "$GUARD"
+  exit 0
+fi
+fail=0
+
+pass() { printf '  ok    %s\n' "$1"; }
+bad()  { printf '  FAIL  %s\n' "$1"; fail=1; }
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+# A throwaway repo with a worktree, so the test never depends on the real one.
+repo="$tmp/repo"
+git init -q "$repo"
+git -C "$repo" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+git -C "$repo" branch -M develop
+
+wt="$tmp/wt"
+git -C "$repo" worktree add -q -b feat/x "$wt" >/dev/null 2>&1
+git -C "$wt" -c user.email=t@t -c user.name=t commit -q --allow-empty -m work
+
+# --- progress_key ------------------------------------------------------------
+# Extract it rather than re-implement: a copy would drift from the real one.
+progress_key() {
+  git worktree list --porcelain 2>/dev/null \
+    | awk '/^HEAD /{print substr($2,1,9)}' \
+    | sort | tr -d '\n' | cut -c1-64
+}
+
+before=$(cd "$repo" && progress_key)
+git -C "$wt" -c user.email=t@t -c user.name=t commit -q --allow-empty -m more
+after=$(cd "$repo" && progress_key)
+
+if [ "$before" != "$after" ]; then
+  pass "progress_key moves when a WORKTREE commits (the main HEAD does not)"
+else
+  bad "progress_key did not move on a worktree commit -- the batch key will stall again"
+fi
+
+main_before=$(git -C "$repo" rev-parse --short HEAD)
+if [ "$main_before" = "$(git -C "$repo" rev-parse --short HEAD)" ]; then
+  pass "the main repo's HEAD is unchanged by that commit (this is why it was wrong)"
+fi
+
+# --- the script still parses and runs ----------------------------------------
+if bash -n "$GUARD" 2>/dev/null; then
+  pass "guard parses"
+else
+  bad "guard does not parse"
+fi
+
+# bash -n is not enough: on 2026-08-16 a hook emitted invalid JSON that only
+# showed up when the deny path actually ran.
+out=$(cd "$repo" && echo '{}' | timeout 30 "$GUARD" 2>&1)
+rc=$?
+if [ "$rc" = 0 ]; then
+  pass "guard exits 0 outside the project (cheap bail-out intact)"
+else
+  bad "guard exited $rc on an unrelated repo"
+fi
+if [ -n "$out" ]; then
+  if printf '%s' "$out" | jq -e . >/dev/null 2>&1; then
+    pass "output is valid JSON"
+  else
+    bad "output is not valid JSON: $out"
+  fi
+fi
+
+# --- the three worktree findings are all reachable ---------------------------
+for kind in dirty unpushed nopr; do
+  if grep -q "printf '$kind %s" "$GUARD"; then
+    pass "(2w) can report '$kind'"
+  else
+    bad "(2w) lost the '$kind' branch"
+  fi
+done
+
+# A merged branch stays ahead of develop for ever under squash-merge, so the PR
+# lookup must not be limited to open ones.
+if grep -q -- "--state all" "$GUARD"; then
+  pass "the no-PR check counts a MERGED pr as done"
+else
+  bad "the no-PR check only looks at open PRs -- every finished branch will trip it"
+fi
+
+[ "$fail" = 0 ] && printf 'all good\n' || printf 'FAILURES\n'
+exit "$fail"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,34 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
+  test-hooks:
+    name: Hook Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      # The hooks are the thing that stops a broken commit reaching CI, and they
+      # fail silently: a guard that no longer matches anything exits 0 and looks
+      # healthy. On 2026-08-16 one emitted invalid JSON for weeks and another
+      # never fired at all, and `bash -n` passed on both. Only running them and
+      # checking the output catches that, so run them here.
+      - name: Run hook tests
+        run: |
+          set -e
+          found=0
+          for t in .claude/hooks/*.test.sh; do
+            [ -e "$t" ] || continue
+            found=$((found + 1))
+            echo "== $t"
+            bash "$t"
+          done
+          # A loop over a glob that matched nothing exits 0 and reads as success.
+          if [ "$found" -eq 0 ]; then
+            echo "no hook tests were found -- the glob or the directory moved" >&2
+            exit 1
+          fi
+          echo "ran $found hook test file(s)"
+
   lint-backend:
     name: Backend Lint (golangci-lint)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
             [ -e "$t" ] || continue
             found=$((found + 1))
             echo "== $t"
-            bash "$t"
+            bash "$t" | tee -a /tmp/hook-test-out
           done
           # A loop over a glob that matched nothing exits 0 and reads as success.
           if [ "$found" -eq 0 ]; then
@@ -51,6 +51,11 @@ jobs:
             exit 1
           fi
           echo "ran $found hook test file(s)"
+          # A test that skipped is not a test that passed. Say so in the log --
+          # "skip" scrolling past in a green job is how a permanently-inert
+          # check survives (see feedback_guard_silent_skip).
+          skipped=$(grep -c '^skip ' /tmp/hook-test-out 2>/dev/null || true)
+          [ "${skipped:-0}" -gt 0 ] && echo "note: $skipped test file(s) skipped -- they verified nothing here"
 
   lint-backend:
     name: Backend Lint (golangci-lint)


### PR DESCRIPTION
`Closes #5419`.

`.claude/hooks` has two test files and **nothing ran them** — not CI, not
`settings.json`. They pass today; the problem is that nobody would know when they
stopped.

## Hooks fail silently by nature

A guard that no longer matches anything exits 0 and looks healthy. Both of this repo's
hook defects found on 2026-08-16 were that shape:

- one emitted **invalid JSON** (a literal newline inside a JSON string), so the gate it
  implemented had never worked;
- one **never fired at all** — it read the main checkout while all the work happened in
  worktrees.

`bash -n` passed on both. Only running them and looking at the output finds it.

## The job fails when it finds nothing

```sh
if [ "$found" -eq 0 ]; then
  echo "no hook tests were found -- the glob or the directory moved" >&2
  exit 1
fi
```

A `for` over an empty glob exits 0 and reads exactly like success — the same silent pass
this job exists to stop.

## Verified by breaking it

| state | job |
|---|---|
| a hook test exits 1 | **fails** |
| the directory is missing (glob matches nothing) | **fails** |
| the real thing | passes, `ran 2 hook test file(s)` |

The first attempt at that check was itself wrong: appending `exit 1` to the end of the
test file put it *after* the existing `exit "$fail"`, so it never ran and the control
"passed". Replacing the real exit line is what actually proved the job fails.

## Not covered

The Stop guard's own test lives at `$HOME/.claude/hooks/` — user-global, outside the
repo — so this job cannot reach it. Whether to move it in is a separate call.

## Test plan

- [x] `.github/workflows/ci.yml` parses (`yaml.safe_load`), `test-hooks` present
- [x] the job body run locally: 2 files, both pass
- [x] both negative controls above