### PR TITLE
feat(solitaire): show the foundation-progress summary on the CUI game-over screen

### DIFF
--- a/internal/adapter/presenter/AmericanToadCuiPresenter.go
+++ b/internal/adapter/presenter/AmericanToadCuiPresenter.go
@@ -106,6 +106,9 @@ func (p *AmericanToadCuiPresenter) Output(at interfaces.AmericanToadGame, lastEr
 				i18n.Tf("cuiSolitaireMoves", "count", strconv.Itoa(at.GetMoveCount())) + "\n")
 		case domain.AmericanToadPhaseGameOver:
 			b.WriteString(color.Red(i18n.T("cuiSolitaireGameOver")) + "\n")
+			fnd := at.GetFoundation()
+			b.WriteString(color.Yellow(cuiSolitaireGameOverSummary(
+				cuiCountPileCards(fnd[:]...), domain.AmericanToadTotalCards)) + "\n")
 		}
 	})
 }

--- a/internal/adapter/presenter/BeleagueredCastleCuiPresenter.go
+++ b/internal/adapter/presenter/BeleagueredCastleCuiPresenter.go
@@ -81,6 +81,9 @@ func (p *BeleagueredCastleCuiPresenter) Output(bc interfaces.BeleagueredCastleGa
 				i18n.Tf("cuiSolitaireMoves", "count", strconv.Itoa(bc.GetMoveCount())) + "\n")
 		case domain.BeleagueredCastlePhaseGameOver:
 			b.WriteString(color.Red(i18n.T("cuiSolitaireGameOver")) + "\n")
+			fnd := bc.GetFoundation()
+			b.WriteString(color.Yellow(cuiSolitaireGameOverSummary(
+				cuiCountPileCards(fnd[:]...), domain.BeleagueredCastleFoundationCnt*domain.CardValueMax)) + "\n")
 		}
 	})
 }

--- a/internal/adapter/presenter/BisleyCuiPresenter.go
+++ b/internal/adapter/presenter/BisleyCuiPresenter.go
@@ -86,6 +86,11 @@ func (p *BisleyCuiPresenter) Output(bg interfaces.BisleyGame, lastErr error) str
 				i18n.Tf("cuiSolitaireMoves", "count", strconv.Itoa(bg.GetMoveCount())) + "\n")
 		case domain.BisleyPhaseGameOver:
 			b.WriteString(color.Red(i18n.T("cuiSolitaireGameOver")) + "\n")
+			af := bg.GetAceFoundations()
+			kf := bg.GetKingFoundations()
+			b.WriteString(color.Yellow(cuiSolitaireGameOverSummary(
+				cuiCountPileCards(af[:]...)+cuiCountPileCards(kf[:]...),
+				domain.BisleyFoundationCnt*domain.CardValueMax)) + "\n")
 		}
 	})
 }

--- a/internal/adapter/presenter/BraidCuiPresenter.go
+++ b/internal/adapter/presenter/BraidCuiPresenter.go
@@ -108,6 +108,9 @@ func (p *BraidCuiPresenter) Output(b interfaces.BraidGame, lastErr error) string
 				i18n.Tf("cuiSolitaireMoves", "count", strconv.Itoa(b.GetMoveCount())) + "\n")
 		case domain.BraidPhaseGameOver:
 			sb.WriteString(color.Red(i18n.T("cuiSolitaireGameOver")) + "\n")
+			fnd := b.GetFoundation()
+			sb.WriteString(color.Yellow(cuiSolitaireGameOverSummary(
+				cuiCountPileCards(fnd[:]...), domain.BraidTotalCards)) + "\n")
 		}
 	})
 }

--- a/internal/adapter/presenter/CongressCuiPresenter.go
+++ b/internal/adapter/presenter/CongressCuiPresenter.go
@@ -89,6 +89,9 @@ func (p *CongressCuiPresenter) Output(c interfaces.CongressGame, lastErr error) 
 				i18n.Tf("cuiSolitaireMoves", "count", strconv.Itoa(c.GetMoveCount())) + "\n")
 		case domain.CongressPhaseGameOver:
 			b.WriteString(color.Red(i18n.T("cuiSolitaireGameOver")) + "\n")
+			fnd := c.GetFoundation()
+			b.WriteString(color.Yellow(cuiSolitaireGameOverSummary(
+				cuiCountPileCards(fnd[:]...), domain.CongressTotalCards)) + "\n")
 		}
 	})
 }

--- a/internal/adapter/presenter/CrazyQuiltCuiPresenter.go
+++ b/internal/adapter/presenter/CrazyQuiltCuiPresenter.go
@@ -98,6 +98,9 @@ func (p *CrazyQuiltCuiPresenter) Output(c interfaces.CrazyQuiltGame, lastErr err
 				i18n.Tf("cuiSolitaireMoves", "count", strconv.Itoa(c.GetMoveCount())) + "\n")
 		case domain.CrazyQuiltPhaseGameOver:
 			b.WriteString(color.Red(i18n.T("cuiSolitaireGameOver")) + "\n")
+			fnd := c.GetFoundation()
+			b.WriteString(color.Yellow(cuiSolitaireGameOverSummary(
+				cuiCountPileCards(fnd[:]...), domain.CrazyQuiltTotalCards)) + "\n")
 		}
 	})
 }

--- a/internal/adapter/presenter/DiplomatCuiPresenter.go
+++ b/internal/adapter/presenter/DiplomatCuiPresenter.go
@@ -89,6 +89,9 @@ func (p *DiplomatCuiPresenter) Output(c interfaces.DiplomatGame, lastErr error) 
 				i18n.Tf("cuiSolitaireMoves", "count", strconv.Itoa(c.GetMoveCount())) + "\n")
 		case domain.DiplomatPhaseGameOver:
 			b.WriteString(color.Red(i18n.T("cuiSolitaireGameOver")) + "\n")
+			fnd := c.GetFoundation()
+			b.WriteString(color.Yellow(cuiSolitaireGameOverSummary(
+				cuiCountPileCards(fnd[:]...), domain.DiplomatTotalCards)) + "\n")
 		}
 	})
 }

--- a/internal/adapter/presenter/DuchessCuiPresenter.go
+++ b/internal/adapter/presenter/DuchessCuiPresenter.go
@@ -120,6 +120,9 @@ func (p *DuchessCuiPresenter) Output(d interfaces.DuchessGame, lastErr error) st
 				i18n.Tf("cuiSolitaireMoves", "count", strconv.Itoa(d.GetMoveCount())) + "\n")
 		case domain.DuchessPhaseGameOver:
 			b.WriteString(color.Red(i18n.T("cuiSolitaireGameOver")) + "\n")
+			fnd := d.GetFoundation()
+			b.WriteString(color.Yellow(cuiSolitaireGameOverSummary(
+				cuiCountPileCards(fnd[:]...), domain.DuchessFoundationCnt*domain.CardValueMax)) + "\n")
 		}
 	})
 }

--- a/internal/adapter/presenter/FlowerGardenCuiPresenter.go
+++ b/internal/adapter/presenter/FlowerGardenCuiPresenter.go
@@ -98,6 +98,9 @@ func (p *FlowerGardenCuiPresenter) Output(bc interfaces.FlowerGardenGame, lastEr
 				i18n.Tf("cuiSolitaireMoves", "count", strconv.Itoa(bc.GetMoveCount())) + "\n")
 		case domain.FlowerGardenPhaseGameOver:
 			b.WriteString(color.Red(i18n.T("cuiSolitaireGameOver")) + "\n")
+			fnd := bc.GetFoundation()
+			b.WriteString(color.Yellow(cuiSolitaireGameOverSummary(
+				cuiCountPileCards(fnd[:]...), domain.FlowerGardenFoundationCnt*domain.CardValueMax)) + "\n")
 		}
 	})
 }

--- a/internal/adapter/presenter/GrandfathersClockCuiPresenter.go
+++ b/internal/adapter/presenter/GrandfathersClockCuiPresenter.go
@@ -87,6 +87,14 @@ func (p *GrandfathersClockCuiPresenter) Output(gc interfaces.GrandfathersClockGa
 				i18n.Tf("cuiSolitaireMoves", "count", strconv.Itoa(gc.GetMoveCount())) + "\n")
 		case domain.GrandfathersClockPhaseGameOver:
 			b.WriteString(color.Red(i18n.T("cuiSolitaireGameOver")) + "\n")
+			faces := 0
+			for i := range gc.GetFoundation() {
+				if gc.IsFoundationComplete(i) {
+					faces++
+				}
+			}
+			b.WriteString(color.Yellow(cuiSolitaireGameOverFaces(
+				faces, domain.GrandfathersClockFoundationCnt)) + "\n")
 		}
 	})
 }

--- a/internal/adapter/presenter/KingAlbertCuiPresenter.go
+++ b/internal/adapter/presenter/KingAlbertCuiPresenter.go
@@ -100,6 +100,9 @@ func (p *KingAlbertCuiPresenter) Output(bc interfaces.KingAlbertGame, lastErr er
 				i18n.Tf("cuiSolitaireMoves", "count", strconv.Itoa(bc.GetMoveCount())) + "\n")
 		case domain.KingAlbertPhaseGameOver:
 			b.WriteString(color.Red(i18n.T("cuiSolitaireGameOver")) + "\n")
+			fnd := bc.GetFoundation()
+			b.WriteString(color.Yellow(cuiSolitaireGameOverSummary(
+				cuiCountPileCards(fnd[:]...), domain.KingAlbertFoundationCnt*domain.CardValueMax)) + "\n")
 		}
 	})
 }

--- a/internal/adapter/presenter/MissMilliganCuiPresenter.go
+++ b/internal/adapter/presenter/MissMilliganCuiPresenter.go
@@ -96,6 +96,9 @@ func (p *MissMilliganCuiPresenter) Output(mm interfaces.MissMilliganGame, lastEr
 				i18n.Tf("cuiSolitaireMoves", "count", strconv.Itoa(mm.GetMoveCount())) + "\n")
 		case domain.MissMilliganPhaseGameOver:
 			b.WriteString(color.Red(i18n.T("cuiSolitaireGameOver")) + "\n")
+			fnd := mm.GetFoundation()
+			b.WriteString(color.Yellow(cuiSolitaireGameOverSummary(
+				cuiCountPileCards(fnd[:]...), domain.MissMilliganFoundationCnt*domain.CardValueMax)) + "\n")
 		}
 	})
 }

--- a/internal/adapter/presenter/NapoleonsSquareCuiPresenter.go
+++ b/internal/adapter/presenter/NapoleonsSquareCuiPresenter.go
@@ -94,6 +94,9 @@ func (p *NapoleonsSquareCuiPresenter) Output(ns interfaces.NapoleonsSquareGame, 
 				i18n.Tf("cuiSolitaireMoves", "count", strconv.Itoa(ns.GetMoveCount())) + "\n")
 		case domain.NapoleonsSquarePhaseGameOver:
 			b.WriteString(color.Red(i18n.T("cuiSolitaireGameOver")) + "\n")
+			fnd := ns.GetFoundation()
+			b.WriteString(color.Yellow(cuiSolitaireGameOverSummary(
+				cuiCountPileCards(fnd[:]...), domain.NapoleonsSquareFoundationCnt*domain.CardValueMax)) + "\n")
 		}
 	})
 }

--- a/internal/adapter/presenter/RoyalCotillionCuiPresenter.go
+++ b/internal/adapter/presenter/RoyalCotillionCuiPresenter.go
@@ -114,6 +114,9 @@ func (p *RoyalCotillionCuiPresenter) Output(c interfaces.RoyalCotillionGame, las
 				i18n.Tf("cuiSolitaireMoves", "count", strconv.Itoa(c.GetMoveCount())) + "\n")
 		case domain.RoyalCotillionPhaseGameOver:
 			b.WriteString(color.Red(i18n.T("cuiSolitaireGameOver")) + "\n")
+			fnd := c.GetFoundation()
+			b.WriteString(color.Yellow(cuiSolitaireGameOverSummary(
+				cuiCountPileCards(fnd[:]...), domain.RoyalCotillionTotalCards)) + "\n")
 		}
 	})
 }

--- a/internal/adapter/presenter/StreetsAndAlleysCuiPresenter.go
+++ b/internal/adapter/presenter/StreetsAndAlleysCuiPresenter.go
@@ -75,6 +75,9 @@ func (p *StreetsAndAlleysCuiPresenter) Output(bc interfaces.StreetsAndAlleysGame
 				i18n.Tf("cuiSolitaireMoves", "count", strconv.Itoa(bc.GetMoveCount())) + "\n")
 		case domain.StreetsAndAlleysPhaseGameOver:
 			b.WriteString(color.Red(i18n.T("cuiSolitaireGameOver")) + "\n")
+			fnd := bc.GetFoundation()
+			b.WriteString(color.Yellow(cuiSolitaireGameOverSummary(
+				cuiCountPileCards(fnd[:]...), domain.StreetsAndAlleysFoundationCnt*domain.CardValueMax)) + "\n")
 		}
 	})
 }

--- a/internal/adapter/presenter/TerraceCuiPresenter.go
+++ b/internal/adapter/presenter/TerraceCuiPresenter.go
@@ -106,6 +106,9 @@ func (p *TerraceCuiPresenter) Output(t interfaces.TerraceGame, lastErr error) st
 				i18n.Tf("cuiSolitaireMoves", "count", strconv.Itoa(t.GetMoveCount())) + "\n")
 		case domain.TerracePhaseGameOver:
 			b.WriteString(color.Red(i18n.T("cuiSolitaireGameOver")) + "\n")
+			fnd := t.GetFoundation()
+			b.WriteString(color.Yellow(cuiSolitaireGameOverSummary(
+				cuiCountPileCards(fnd[:]...), domain.TerraceTotalCards)) + "\n")
 		}
 	})
 }

--- a/internal/adapter/presenter/WindmillCuiPresenter.go
+++ b/internal/adapter/presenter/WindmillCuiPresenter.go
@@ -101,6 +101,10 @@ func (p *WindmillCuiPresenter) Output(w interfaces.WindmillGame, lastErr error) 
 				i18n.Tf("cuiSolitaireMoves", "count", strconv.Itoa(w.GetMoveCount())) + "\n")
 		case domain.WindmillPhaseGameOver:
 			b.WriteString(color.Red(i18n.T("cuiSolitaireGameOver")) + "\n")
+			corners := w.GetCorners()
+			b.WriteString(color.Yellow(cuiSolitaireGameOverSummary(
+				len(w.GetCenter())+cuiCountPileCards(corners[:]...),
+				domain.WindmillTotalCards)) + "\n")
 		}
 	})
 }

--- a/internal/adapter/presenter/cui_solitaire_gameover_test.go
+++ b/internal/adapter/presenter/cui_solitaire_gameover_test.go
@@ -1,0 +1,197 @@
+//go:build test
+
+package presenter
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+)
+
+// assertGameOverSummary checks that a solitaire CUI game-over screen carries the
+// foundation-progress line the web page shows.
+//
+// It pins the denominator rather than the count: the count depends on each
+// game's mock fixture, but the denominator is the game's deck size, so a
+// presenter wired to the wrong total constant (52 vs 104) fails here. The
+// count/percent arithmetic itself is pinned in cui_solitaire_helper_test.go.
+func assertGameOverSummary(t *testing.T, result string, total int) {
+	t.Helper()
+	assert.Contains(t, result, "まで到達",
+		"game over screen is missing the foundation-progress line")
+	assert.Contains(t, result, "/"+strconv.Itoa(total)+" 枚",
+		"foundation-progress line reports the wrong deck total")
+	// The progress line must come after the game-over banner, not replace it.
+	assert.Contains(t, result, "ゲームオーバー")
+	assert.Less(t, strings.Index(result, "ゲームオーバー"), strings.Index(result, "まで到達"))
+}
+
+// TestSolitaireCuiGameOverSummary covers every solitaire whose web page renders a
+// gameOverSummary; before this the CUI printed only "ゲームオーバー" and dropped the
+// near-miss detail entirely.
+func TestSolitaireCuiGameOverSummary(t *testing.T) {
+	t.Run("AmericanToad", func(t *testing.T) {
+		g := new(interfaces.MockAmericanToadGame)
+		setupAmericanToadCuiMockDefaults(g)
+		g.ExpectedCalls = filterCalls(g.ExpectedCalls, "GetPhase")
+		g.On("GetPhase").Return(domain.AmericanToadPhaseGameOver)
+
+		result := new(AmericanToadCuiPresenter).Output(g, nil)
+		assertGameOverSummary(t, result, domain.AmericanToadTotalCards)
+	})
+	t.Run("BeleagueredCastle", func(t *testing.T) {
+		g := new(interfaces.MockBeleagueredCastleGame)
+		setupBeleagueredCastleCuiMockDefaults(g)
+		g.ExpectedCalls = filterCalls(g.ExpectedCalls, "GetPhase")
+		g.On("GetPhase").Return(domain.BeleagueredCastlePhaseGameOver)
+
+		result := new(BeleagueredCastleCuiPresenter).Output(g, nil)
+		assertGameOverSummary(t, result, domain.BeleagueredCastleFoundationCnt*domain.CardValueMax)
+	})
+	t.Run("Bisley", func(t *testing.T) {
+		g := new(interfaces.MockBisleyGame)
+		setupBisleyCuiMockDefaults(g)
+		g.ExpectedCalls = filterCalls(g.ExpectedCalls, "GetPhase")
+		g.On("GetPhase").Return(domain.BisleyPhaseGameOver)
+
+		result := new(BisleyCuiPresenter).Output(g, nil)
+		assertGameOverSummary(t, result, domain.BisleyFoundationCnt*domain.CardValueMax)
+	})
+	t.Run("Braid", func(t *testing.T) {
+		g := new(interfaces.MockBraidGame)
+		setupBraidCuiMockDefaults(g)
+		g.ExpectedCalls = filterCalls(g.ExpectedCalls, "GetPhase")
+		g.On("GetPhase").Return(domain.BraidPhaseGameOver)
+
+		result := new(BraidCuiPresenter).Output(g, nil)
+		assertGameOverSummary(t, result, domain.BraidTotalCards)
+	})
+	t.Run("Congress", func(t *testing.T) {
+		g := new(interfaces.MockCongressGame)
+		setupCongressCuiMockDefaults(g)
+		g.ExpectedCalls = filterCalls(g.ExpectedCalls, "GetPhase")
+		g.On("GetPhase").Return(domain.CongressPhaseGameOver)
+
+		result := new(CongressCuiPresenter).Output(g, nil)
+		assertGameOverSummary(t, result, domain.CongressTotalCards)
+	})
+	t.Run("CrazyQuilt", func(t *testing.T) {
+		g := new(interfaces.MockCrazyQuiltGame)
+		setupCrazyQuiltCuiMockDefaults(g)
+		g.ExpectedCalls = filterCalls(g.ExpectedCalls, "GetPhase")
+		g.On("GetPhase").Return(domain.CrazyQuiltPhaseGameOver)
+
+		result := new(CrazyQuiltCuiPresenter).Output(g, nil)
+		assertGameOverSummary(t, result, domain.CrazyQuiltTotalCards)
+	})
+	t.Run("Diplomat", func(t *testing.T) {
+		g := new(interfaces.MockDiplomatGame)
+		setupDiplomatCuiMockDefaults(g)
+		g.ExpectedCalls = filterCalls(g.ExpectedCalls, "GetPhase")
+		g.On("GetPhase").Return(domain.DiplomatPhaseGameOver)
+
+		result := new(DiplomatCuiPresenter).Output(g, nil)
+		assertGameOverSummary(t, result, domain.DiplomatTotalCards)
+	})
+	t.Run("Duchess", func(t *testing.T) {
+		g := new(interfaces.MockDuchessGame)
+		setupDuchessCuiMockDefaults(g)
+		g.ExpectedCalls = filterCalls(g.ExpectedCalls, "GetPhase")
+		g.On("GetPhase").Return(domain.DuchessPhaseGameOver)
+
+		result := new(DuchessCuiPresenter).Output(g, nil)
+		assertGameOverSummary(t, result, domain.DuchessFoundationCnt*domain.CardValueMax)
+	})
+	t.Run("FlowerGarden", func(t *testing.T) {
+		g := new(interfaces.MockFlowerGardenGame)
+		setupFlowerGardenCuiMockDefaults(g)
+		g.ExpectedCalls = filterCalls(g.ExpectedCalls, "GetPhase")
+		g.On("GetPhase").Return(domain.FlowerGardenPhaseGameOver)
+
+		result := new(FlowerGardenCuiPresenter).Output(g, nil)
+		assertGameOverSummary(t, result, domain.FlowerGardenFoundationCnt*domain.CardValueMax)
+	})
+	t.Run("KingAlbert", func(t *testing.T) {
+		g := new(interfaces.MockKingAlbertGame)
+		setupKingAlbertCuiMockDefaults(g)
+		g.ExpectedCalls = filterCalls(g.ExpectedCalls, "GetPhase")
+		g.On("GetPhase").Return(domain.KingAlbertPhaseGameOver)
+
+		result := new(KingAlbertCuiPresenter).Output(g, nil)
+		assertGameOverSummary(t, result, domain.KingAlbertFoundationCnt*domain.CardValueMax)
+	})
+	t.Run("MissMilligan", func(t *testing.T) {
+		g := new(interfaces.MockMissMilliganGame)
+		setupMissMilliganCuiMockDefaults(g)
+		g.ExpectedCalls = filterCalls(g.ExpectedCalls, "GetPhase")
+		g.On("GetPhase").Return(domain.MissMilliganPhaseGameOver)
+
+		result := new(MissMilliganCuiPresenter).Output(g, nil)
+		assertGameOverSummary(t, result, domain.MissMilliganFoundationCnt*domain.CardValueMax)
+	})
+	t.Run("NapoleonsSquare", func(t *testing.T) {
+		g := new(interfaces.MockNapoleonsSquareGame)
+		setupNapoleonsSquareCuiMockDefaults(g)
+		g.ExpectedCalls = filterCalls(g.ExpectedCalls, "GetPhase")
+		g.On("GetPhase").Return(domain.NapoleonsSquarePhaseGameOver)
+
+		result := new(NapoleonsSquareCuiPresenter).Output(g, nil)
+		assertGameOverSummary(t, result, domain.NapoleonsSquareFoundationCnt*domain.CardValueMax)
+	})
+	t.Run("RoyalCotillion", func(t *testing.T) {
+		g := new(interfaces.MockRoyalCotillionGame)
+		setupRoyalCotillionCuiMockDefaults(g)
+		g.ExpectedCalls = filterCalls(g.ExpectedCalls, "GetPhase")
+		g.On("GetPhase").Return(domain.RoyalCotillionPhaseGameOver)
+
+		result := new(RoyalCotillionCuiPresenter).Output(g, nil)
+		assertGameOverSummary(t, result, domain.RoyalCotillionTotalCards)
+	})
+	t.Run("StreetsAndAlleys", func(t *testing.T) {
+		g := new(interfaces.MockStreetsAndAlleysGame)
+		setupStreetsAndAlleysCuiMockDefaults(g)
+		g.ExpectedCalls = filterCalls(g.ExpectedCalls, "GetPhase")
+		g.On("GetPhase").Return(domain.StreetsAndAlleysPhaseGameOver)
+
+		result := new(StreetsAndAlleysCuiPresenter).Output(g, nil)
+		assertGameOverSummary(t, result, domain.StreetsAndAlleysFoundationCnt*domain.CardValueMax)
+	})
+	t.Run("Terrace", func(t *testing.T) {
+		g := new(interfaces.MockTerraceGame)
+		setupTerraceCuiMockDefaults(g)
+		g.ExpectedCalls = filterCalls(g.ExpectedCalls, "GetPhase")
+		g.On("GetPhase").Return(domain.TerracePhaseGameOver)
+
+		result := new(TerraceCuiPresenter).Output(g, nil)
+		assertGameOverSummary(t, result, domain.TerraceTotalCards)
+	})
+	t.Run("Windmill", func(t *testing.T) {
+		g := new(interfaces.MockWindmillGame)
+		setupWindmillCuiMockDefaults(g)
+		g.ExpectedCalls = filterCalls(g.ExpectedCalls, "GetPhase")
+		g.On("GetPhase").Return(domain.WindmillPhaseGameOver)
+
+		result := new(WindmillCuiPresenter).Output(g, nil)
+		assertGameOverSummary(t, result, domain.WindmillTotalCards)
+	})
+}
+
+// TestGrandfathersClockCuiGameOverFaces is separate because that game reports
+// completed clock faces instead of a card count, so a percentage is meaningless.
+func TestGrandfathersClockCuiGameOverFaces(t *testing.T) {
+	g := new(interfaces.MockGrandfathersClockGame)
+	setupGrandfathersClockCuiMockDefaults(g)
+	g.ExpectedCalls = filterCalls(g.ExpectedCalls, "GetPhase")
+	g.On("GetPhase").Return(domain.GrandfathersClockPhaseGameOver)
+
+	result := new(GrandfathersClockCuiPresenter).Output(g, nil)
+	assert.Contains(t, result, "個を完成",
+		"game over screen is missing the completed-faces line")
+	assert.Contains(t, result, "/"+strconv.Itoa(domain.GrandfathersClockFoundationCnt)+" 個")
+	assert.Contains(t, result, "ゲームオーバー")
+}

--- a/internal/adapter/presenter/cui_solitaire_helper.go
+++ b/internal/adapter/presenter/cui_solitaire_helper.go
@@ -1,0 +1,52 @@
+package presenter
+
+import (
+	"math"
+	"strconv"
+
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
+)
+
+// cuiCountPileCards sums the cards held across every given pile.
+//
+// The solitaire domains expose their foundations as fixed-size arrays whose
+// length differs per game ([4][]*Card, [8][]*Card, ...). Those are distinct Go
+// types, so callers slice the array (f[:]...) and the counting itself lives
+// here once instead of being re-spelled in every presenter.
+func cuiCountPileCards(piles ...[]*domain.Card) int {
+	n := 0
+	for _, p := range piles {
+		n += len(p)
+	}
+	return n
+}
+
+// cuiSolitaireProgressPercent converts a foundation count into the whole-number
+// percentage the web pages show, matching their Math.round semantics. A total of
+// zero or less yields 0 rather than dividing by zero.
+func cuiSolitaireProgressPercent(count, total int) int {
+	if total <= 0 {
+		return 0
+	}
+	return int(math.Round(float64(count) / float64(total) * 100))
+}
+
+// cuiSolitaireGameOverSummary renders the "reached N of total cards (P%)" line
+// that the web pages display at game over, so a CUI player learns how close the
+// deal came instead of only that it ended.
+func cuiSolitaireGameOverSummary(count, total int) string {
+	return i18n.Tf("cuiSolitaireGameOverSummary",
+		"count", strconv.Itoa(count),
+		"total", strconv.Itoa(total),
+		"percent", strconv.Itoa(cuiSolitaireProgressPercent(count, total)))
+}
+
+// cuiSolitaireGameOverFaces is the Grandfather's Clock variant of
+// cuiSolitaireGameOverSummary: that game's web page reports completed clock
+// faces rather than a card count, so a percentage would be meaningless.
+func cuiSolitaireGameOverFaces(count, total int) string {
+	return i18n.Tf("cuiSolitaireGameOverFaces",
+		"count", strconv.Itoa(count),
+		"total", strconv.Itoa(total))
+}

--- a/internal/adapter/presenter/cui_solitaire_helper_test.go
+++ b/internal/adapter/presenter/cui_solitaire_helper_test.go
@@ -1,0 +1,90 @@
+//go:build test
+// +build test
+
+package presenter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+)
+
+// pile builds a pile of n placeholder cards. Only the length matters here --
+// the summary counts cards, it never inspects them.
+func pile(n int) []*domain.Card {
+	p := make([]*domain.Card, n)
+	for i := range p {
+		p[i] = &domain.Card{}
+	}
+	return p
+}
+
+func TestCuiCountPileCards(t *testing.T) {
+	t.Run("sums every pile", func(t *testing.T) {
+		assert.Equal(t, 6, cuiCountPileCards(pile(1), pile(2), pile(3)))
+	})
+
+	t.Run("no piles is zero", func(t *testing.T) {
+		assert.Equal(t, 0, cuiCountPileCards())
+	})
+
+	t.Run("empty piles are zero", func(t *testing.T) {
+		assert.Equal(t, 0, cuiCountPileCards(pile(0), pile(0)))
+	})
+
+	t.Run("nil pile contributes nothing", func(t *testing.T) {
+		assert.Equal(t, 2, cuiCountPileCards(nil, pile(2)))
+	})
+}
+
+func TestCuiSolitaireProgressPercent(t *testing.T) {
+	cases := []struct {
+		name         string
+		count, total int
+		want         int
+	}{
+		{"none reached", 0, 52, 0},
+		{"all reached", 52, 52, 100},
+		{"half reached", 26, 52, 50},
+		{"rounds to nearest", 17, 52, 33},    // 32.69 -> 33
+		{"rounds up at .5", 26, 104, 25},     // 25.0 exactly
+		{"double deck partial", 51, 104, 49}, // 49.03 -> 49
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.want, cuiSolitaireProgressPercent(c.count, c.total))
+		})
+	}
+
+	t.Run("zero total does not divide by zero", func(t *testing.T) {
+		assert.Equal(t, 0, cuiSolitaireProgressPercent(3, 0))
+	})
+
+	t.Run("negative total is treated as zero", func(t *testing.T) {
+		assert.Equal(t, 0, cuiSolitaireProgressPercent(3, -1))
+	})
+}
+
+func TestCuiSolitaireGameOverSummary(t *testing.T) {
+	t.Run("includes count, total and percent", func(t *testing.T) {
+		got := cuiSolitaireGameOverSummary(26, 52)
+		assert.Contains(t, got, "26")
+		assert.Contains(t, got, "52")
+		assert.Contains(t, got, "50")
+	})
+
+	t.Run("zero total still renders without dividing by zero", func(t *testing.T) {
+		got := cuiSolitaireGameOverSummary(0, 0)
+		assert.Contains(t, got, "0")
+	})
+}
+
+func TestCuiSolitaireGameOverFaces(t *testing.T) {
+	t.Run("includes completed and total faces", func(t *testing.T) {
+		got := cuiSolitaireGameOverFaces(7, 12)
+		assert.Contains(t, got, "7")
+		assert.Contains(t, got, "12")
+	})
+}

--- a/internal/adapter/presenter/cui_solitaire_helper_test.go
+++ b/internal/adapter/presenter/cui_solitaire_helper_test.go
@@ -49,8 +49,13 @@ func TestCuiSolitaireProgressPercent(t *testing.T) {
 		{"all reached", 52, 52, 100},
 		{"half reached", 26, 52, 50},
 		{"rounds to nearest", 17, 52, 33},    // 32.69 -> 33
-		{"rounds up at .5", 26, 104, 25},     // 25.0 exactly
+		{"exact quarter", 26, 104, 25},       // 25.0 exactly, no rounding involved
 		{"double deck partial", 51, 104, 49}, // 49.03 -> 49
+		// A genuine .5 tie. Go's math.Round and JS Math.round agree here
+		// (both round half away from zero for positive input), which is what
+		// keeps the CUI line identical to the web page's percentage.
+		{"half rounds away from zero", 3, 8, 38}, // 37.5 -> 38
+		{"half rounds up again", 1, 8, 13},       // 12.5 -> 13
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/internal/i18n/locales/en/cui_common.json
+++ b/internal/i18n/locales/en/cui_common.json
@@ -23,6 +23,8 @@
   "cuiSolitaireStalemate": "Stalemate",
   "cuiSolitaireGameClear": "Game clear!",
   "cuiSolitaireGameOver": "Game over",
+  "cuiSolitaireGameOverSummary": "Reached {{count}}/{{total}} cards on the foundations ({{percent}}%)",
+  "cuiSolitaireGameOverFaces": "Completed {{count}}/{{total}} clock faces",
   "cuiSolitaireMoves": "Moves: {{count}}",
   "cuiEmptyCol": "[empty]",
   "pokerHandRank0": "High Card",

--- a/internal/i18n/locales/ja/cui_common.json
+++ b/internal/i18n/locales/ja/cui_common.json
@@ -23,6 +23,8 @@
   "cuiSolitaireStalemate": "手詰まりです",
   "cuiSolitaireGameClear": "ゲームクリア！",
   "cuiSolitaireGameOver": "ゲームオーバー",
+  "cuiSolitaireGameOverSummary": "組札 {{count}}/{{total}} 枚（{{percent}}%）まで到達",
+  "cuiSolitaireGameOverFaces": "文字盤 {{count}}/{{total}} 個を完成",
   "cuiSolitaireMoves": "手数: {{count}}",
   "cuiEmptyCol": "[空]",
   "pokerHandRank0": "ハイカード",


### PR DESCRIPTION
Closes #5471

## What

17 solitaires render a `gameOverSummary` line on their web page — how far the deal
got before it died ("組札 26/52 枚（50%）まで到達") — but their CUI presenters printed
only `cuiSolitaireGameOver` and dropped it. This wires the same information into the CUI.

Measured on develop before the change:

| | count |
|---|---:|
| pages rendering `gameOverSummary` | 17 |
| CUI presenters printing it | **0** |

The numbers already exist in the domain (`GetFoundation`, `GetAceFoundations` +
`GetKingFoundations`, `GetCenter` + `GetCorners`), so this is wiring, not new logic.

## How

`internal/adapter/presenter/cui_solitaire_helper.go` holds the single copy of the
pile summing, the `Math.round`-compatible percentage, and the message assembly.
Each presenter supplies only its own piles and its deck total, taken from the
game's own constant (`<Game>TotalCards`, or `<Game>FoundationCnt * CardValueMax`)
rather than a literal 52/104.

**Grandfather's Clock is deliberately different.** Its page reports *completed clock
faces*, not a card count, so a percentage would be meaningless; it uses a separate
`cuiSolitaireGameOverFaces` key and is tested separately.

## Correction to the issue

#5471 stated the existing frontend `gameOverSummary` locale key could be reused and
that no new keys were needed. **That is wrong** — the CUI reads `internal/i18n`, a
separate catalogue from `frontend/src/i18n`, and it has no such key. Two shared keys
are added to `internal/i18n/locales/{ja,en}/cui_common.json` instead. Placeholder sets
match across both locales.

## Test plan

- [x] `cui_solitaire_helper_test.go` — pins the arithmetic: rounding to nearest,
      two genuine .5 rounding ties (37.5→38, 12.5→13; the original ".5" case was 25.0 exactly and pinned nothing — fixed after review), double-deck partials, and the divide-by-zero / negative-total guards.
- [x] `cui_solitaire_gameover_test.go` — all 17 games. Asserts the progress line is
      present, that it reports the **right deck total** (so a 52-vs-104 mix-up fails),
      and that it appears *after* the game-over banner rather than replacing it.
- [x] **Negative control run** — mutation testing, not just green tests:
      - deleting the summary from Bisley → fails with "missing the foundation-progress line"
      - changing Duchess's total 52→104 → fails with "reports the wrong deck total"
- [x] `go test -tags test ./internal/adapter/presenter/` — passes (cache cleared)
- [x] `golangci-lint run ./internal/adapter/presenter/...` — 0 issues
- [x] `goimports -l` — clean
- [x] ja/en key parity in `cui_common.json` — verified
- [x] Locale diffs are +2/-0 each, no reformatting