### PR TITLE
feat(solitaire): tell CUI players how many undos escape a stalemate

### DIFF
--- a/internal/adapter/presenter/AccordionCuiPresenter.go
+++ b/internal/adapter/presenter/AccordionCuiPresenter.go
@@ -50,6 +50,12 @@ func (p *AccordionCuiPresenter) Output(a interfaces.AccordionGame, lastErr error
 		case domain.AccordionPhasePlaying:
 			if a.IsStalemate() {
 				b.WriteString(color.Red(i18n.T("cuiSolitaireStalemate")) + "\n")
+				// Tell the player how many undos escape the dead end, matching the
+				// web StalemateEscapeButton.
+				if n := a.UndoToEscape(); n > 0 {
+					b.WriteString(color.Yellow(i18n.Tf("cuiSolitaireUndoToEscape",
+						"count", strconv.Itoa(n))) + "\n")
+				}
 			}
 			b.WriteString(i18n.Tf("cuiSolitaireMoves",
 				"count", strconv.Itoa(a.GetMoveCount())) + "\n")

--- a/internal/adapter/presenter/AccordionCuiPresenter_test.go
+++ b/internal/adapter/presenter/AccordionCuiPresenter_test.go
@@ -15,6 +15,7 @@ func setupAccordionCuiMockDefaults(ag *interfaces.MockAccordionGame) {
 	ag.On("GetPhase").Return(domain.AccordionPhasePlaying).Maybe()
 	ag.On("GetMoveCount").Return(0).Maybe()
 	ag.On("IsStalemate").Return(false).Maybe()
+	ag.On("UndoToEscape").Return(0).Maybe()
 	ag.On("GetPileCount").Return(3).Maybe()
 	piles := [][]*domain.Card{
 		{domain.NewCard(domain.CardDesignSpade, 1, false)},
@@ -52,6 +53,7 @@ func TestAccordionCuiPresenter_Output(t *testing.T) {
 		ag.On("GetPhase").Return(domain.AccordionPhasePlaying).Maybe()
 		ag.On("GetMoveCount").Return(5).Maybe()
 		ag.On("IsStalemate").Return(true).Maybe()
+		ag.On("UndoToEscape").Return(0).Maybe()
 		ag.On("GetPileCount").Return(40).Maybe()
 		ag.On("GetPiles").Return([][]*domain.Card{}).Maybe()
 

--- a/internal/adapter/presenter/AcesUpCuiPresenter.go
+++ b/internal/adapter/presenter/AcesUpCuiPresenter.go
@@ -61,6 +61,12 @@ func (pr *AcesUpCuiPresenter) Output(g interfaces.AcesUpGame, lastErr error) str
 		case domain.AcesUpPhasePlaying:
 			if g.IsStalemate() {
 				b.WriteString(color.Red(i18n.T("cuiSolitaireStalemate")) + "\n")
+				// Tell the player how many undos escape the dead end, matching the
+				// web StalemateEscapeButton.
+				if n := g.UndoToEscape(); n > 0 {
+					b.WriteString(color.Yellow(i18n.Tf("cuiSolitaireUndoToEscape",
+						"count", strconv.Itoa(n))) + "\n")
+				}
 			}
 			b.WriteString(i18n.Tf("cuiSolitaireMoves",
 				"count", strconv.Itoa(g.GetMoveCount())) + "\n")

--- a/internal/adapter/presenter/AcesUpCuiPresenter_test.go
+++ b/internal/adapter/presenter/AcesUpCuiPresenter_test.go
@@ -22,6 +22,7 @@ func setupAcesUpCuiMockDefaults(g *interfaces.MockAcesUpGame) {
 	g.On("GetStockCount").Return(44).Maybe()
 	g.On("GetDiscardCount").Return(4).Maybe()
 	g.On("IsStalemate").Return(false).Maybe()
+	g.On("UndoToEscape").Return(0).Maybe()
 	g.On("GetColumns").Return(sampleAcesUpColumns()).Maybe()
 	g.On("CanRemove", mock.AnythingOfType("int")).Return(false).Maybe()
 	g.On("CanMove", mock.AnythingOfType("int")).Return(false).Maybe()
@@ -83,6 +84,7 @@ func TestAcesUpCuiPresenterOutput_Stalemate(t *testing.T) {
 	g.On("GetStockCount").Return(0).Maybe()
 	g.On("GetDiscardCount").Return(10).Maybe()
 	g.On("IsStalemate").Return(true).Maybe()
+	g.On("UndoToEscape").Return(0).Maybe()
 	var cols [domain.AcesUpColCnt][]*domain.Card
 	g.On("GetColumns").Return(cols).Maybe()
 	p := &AcesUpCuiPresenter{}

--- a/internal/adapter/presenter/AuldLangSyneCuiPresenter.go
+++ b/internal/adapter/presenter/AuldLangSyneCuiPresenter.go
@@ -82,6 +82,12 @@ func (p *AuldLangSyneCuiPresenter) Output(g interfaces.AuldLangSyneGame, lastErr
 		case domain.AuldLangSynePhasePlaying:
 			if g.IsStalemate() {
 				b.WriteString(color.Red(i18n.T("cuiSolitaireStalemate")) + "\n")
+				// Tell the player how many undos escape the dead end, matching the
+				// web StalemateEscapeButton.
+				if n := g.UndoToEscape(); n > 0 {
+					b.WriteString(color.Yellow(i18n.Tf("cuiSolitaireUndoToEscape",
+						"count", strconv.Itoa(n))) + "\n")
+				}
 			}
 			b.WriteString(i18n.Tf("cuiSolitaireMoves",
 				"count", strconv.Itoa(g.GetMoveCount())) + "\n")

--- a/internal/adapter/presenter/AuldLangSyneCuiPresenter_test.go
+++ b/internal/adapter/presenter/AuldLangSyneCuiPresenter_test.go
@@ -24,6 +24,7 @@ func setupAuldLangSyneCuiMockDefaults(g *interfaces.MockAuldLangSyneGame) {
 	g.On("GetPhase").Return(domain.AuldLangSynePhasePlaying).Maybe()
 	g.On("GetMoveCount").Return(0).Maybe()
 	g.On("IsStalemate").Return(false).Maybe()
+	g.On("UndoToEscape").Return(0).Maybe()
 	g.On("GetStockCount").Return(44).Maybe()
 	g.On("GetFoundations").Return(acesOnMockFoundations()).Maybe()
 
@@ -83,6 +84,7 @@ func TestAuldLangSyneCuiPresenter_Output(t *testing.T) {
 	t.Run("stalemate", func(t *testing.T) {
 		g := new(interfaces.MockAuldLangSyneGame)
 		g.On("IsStalemate").Return(true)
+		g.On("UndoToEscape").Return(0).Maybe()
 		setupAuldLangSyneCuiMockDefaults(g)
 		p := new(AuldLangSyneCuiPresenter)
 

--- a/internal/adapter/presenter/BakersDozenCuiPresenter.go
+++ b/internal/adapter/presenter/BakersDozenCuiPresenter.go
@@ -72,6 +72,12 @@ func (p *BakersDozenCuiPresenter) Output(bd interfaces.BakersDozenGame, lastErr 
 		case domain.BakersDozenPhasePlaying:
 			if bd.IsStalemate() {
 				b.WriteString(color.Red(i18n.T("cuiSolitaireStalemate")) + "\n")
+				// Tell the player how many undos escape the dead end, matching the
+				// web StalemateEscapeButton.
+				if n := bd.UndoToEscape(); n > 0 {
+					b.WriteString(color.Yellow(i18n.Tf("cuiSolitaireUndoToEscape",
+						"count", strconv.Itoa(n))) + "\n")
+				}
 			}
 			b.WriteString(i18n.T("bakersdozen.emptyColNote") + "\n")
 			b.WriteString(i18n.Tf("cuiSolitaireMoves",

--- a/internal/adapter/presenter/BakersDozenCuiPresenter_test.go
+++ b/internal/adapter/presenter/BakersDozenCuiPresenter_test.go
@@ -17,6 +17,7 @@ func setupBakersDozenCuiMockDefaults(bg *interfaces.MockBakersDozenGame) {
 	bg.On("GetPhase").Return(domain.BakersDozenPhasePlaying).Maybe()
 	bg.On("GetMoveCount").Return(0).Maybe()
 	bg.On("IsStalemate").Return(false).Maybe()
+	bg.On("UndoToEscape").Return(0).Maybe()
 
 	var tableau [domain.BakersDozenTableauCnt][]*domain.BakersDozenTableauCard
 	for i := range domain.BakersDozenTableauCnt {
@@ -115,6 +116,7 @@ func TestBakersDozenCuiPresenter_Output(t *testing.T) {
 		setupBakersDozenCuiMockDefaults(bg)
 		bg.ExpectedCalls = filterCalls(bg.ExpectedCalls, "IsStalemate")
 		bg.On("IsStalemate").Return(true)
+		bg.On("UndoToEscape").Return(0).Maybe()
 
 		p := new(BakersDozenCuiPresenter)
 		result := p.Output(bg, nil)

--- a/internal/adapter/presenter/BakersGameCuiPresenter.go
+++ b/internal/adapter/presenter/BakersGameCuiPresenter.go
@@ -78,6 +78,12 @@ func (p *BakersGameCuiPresenter) Output(f interfaces.FreeCellGame, lastErr error
 		case domain.FreeCellPhasePlaying:
 			if f.IsStalemate() {
 				b.WriteString(color.Red(i18n.T("cuiSolitaireStalemate")) + "\n")
+				// Tell the player how many undos escape the dead end, matching the
+				// web StalemateEscapeButton.
+				if n := f.UndoToEscape(); n > 0 {
+					b.WriteString(color.Yellow(i18n.Tf("cuiSolitaireUndoToEscape",
+						"count", strconv.Itoa(n))) + "\n")
+				}
 			}
 			b.WriteString(i18n.Tf("cuiSolitaireMoves",
 				"count", strconv.Itoa(f.GetMoveCount())) + "\n")

--- a/internal/adapter/presenter/CalculationCuiPresenter.go
+++ b/internal/adapter/presenter/CalculationCuiPresenter.go
@@ -78,6 +78,12 @@ func (p *CalculationCuiPresenter) Output(g interfaces.CalculationGame, lastErr e
 		case domain.CalculationPhasePlaying:
 			if g.IsStalemate() {
 				b.WriteString(color.Red(i18n.T("cuiSolitaireStalemate")) + "\n")
+				// Tell the player how many undos escape the dead end, matching the
+				// web StalemateEscapeButton.
+				if n := g.UndoToEscape(); n > 0 {
+					b.WriteString(color.Yellow(i18n.Tf("cuiSolitaireUndoToEscape",
+						"count", strconv.Itoa(n))) + "\n")
+				}
 			}
 			b.WriteString(i18n.Tf("cuiSolitaireMoves",
 				"count", strconv.Itoa(g.GetMoveCount())) + "\n")

--- a/internal/adapter/presenter/CalculationCuiPresenter_test.go
+++ b/internal/adapter/presenter/CalculationCuiPresenter_test.go
@@ -17,6 +17,7 @@ func setupCalculationCuiMockDefaults(g *interfaces.MockCalculationGame) {
 	g.On("GetPhase").Return(domain.CalculationPhasePlaying).Maybe()
 	g.On("GetMoveCount").Return(0).Maybe()
 	g.On("IsStalemate").Return(false).Maybe()
+	g.On("UndoToEscape").Return(0).Maybe()
 	g.On("GetStockCount").Return(5).Maybe()
 	g.On("GetStockTop").Return(domain.NewCard(domain.CardDesignSpade, 7, false)).Maybe()
 
@@ -58,6 +59,7 @@ func TestCalculationCuiPresenter_Output(t *testing.T) {
 		g.On("GetPhase").Return(domain.CalculationPhasePlaying).Maybe()
 		g.On("GetMoveCount").Return(1).Maybe()
 		g.On("IsStalemate").Return(true).Maybe()
+		g.On("UndoToEscape").Return(0).Maybe()
 		g.On("GetStockCount").Return(0).Maybe()
 		g.On("GetStockTop").Return((*domain.Card)(nil)).Maybe()
 		var foundations [domain.CalculationFoundationCnt][]*domain.Card

--- a/internal/adapter/presenter/CrescentCuiPresenter.go
+++ b/internal/adapter/presenter/CrescentCuiPresenter.go
@@ -86,6 +86,12 @@ func (p *CrescentCuiPresenter) Output(cr interfaces.CrescentGame, lastErr error)
 		case domain.CrescentPhasePlaying:
 			if cr.IsStalemate() {
 				b.WriteString(color.Red(i18n.T("cuiSolitaireStalemate")) + "\n")
+				// Tell the player how many undos escape the dead end, matching the
+				// web StalemateEscapeButton.
+				if n := cr.UndoToEscape(); n > 0 {
+					b.WriteString(color.Yellow(i18n.Tf("cuiSolitaireUndoToEscape",
+						"count", strconv.Itoa(n))) + "\n")
+				}
 			}
 			b.WriteString(i18n.Tf("cuiSolitaireMoves",
 				"count", strconv.Itoa(cr.GetMoveCount())) + "\n")

--- a/internal/adapter/presenter/CrescentCuiPresenter_test.go
+++ b/internal/adapter/presenter/CrescentCuiPresenter_test.go
@@ -16,6 +16,7 @@ func setupCrescentCuiMockDefaults(cg *interfaces.MockCrescentGame) {
 	cg.On("GetMoveCount").Return(0).Maybe()
 	cg.On("GetRedealsRemaining").Return(domain.CrescentMaxRedeals).Maybe()
 	cg.On("IsStalemate").Return(false).Maybe()
+	cg.On("UndoToEscape").Return(0).Maybe()
 
 	var tableau [domain.CrescentTableauCnt][]*domain.CrescentTableauCard
 	tableau[0] = []*domain.CrescentTableauCard{
@@ -67,6 +68,7 @@ func TestCrescentCuiPresenter_Output(t *testing.T) {
 		setupCrescentCuiMockDefaults(cg)
 		cg.ExpectedCalls = filterCalls(cg.ExpectedCalls, "IsStalemate")
 		cg.On("IsStalemate").Return(true)
+		cg.On("UndoToEscape").Return(0).Maybe()
 		p := new(CrescentCuiPresenter)
 		out := p.Output(cg, nil)
 		assert.NotEmpty(t, out)

--- a/internal/adapter/presenter/CruelCuiPresenter.go
+++ b/internal/adapter/presenter/CruelCuiPresenter.go
@@ -63,6 +63,12 @@ func (p *CruelCuiPresenter) Output(c interfaces.CruelGame, lastErr error) string
 		case domain.CruelPhasePlaying:
 			if c.IsStalemate() {
 				b.WriteString(color.Red(i18n.T("cuiSolitaireStalemate")) + "\n")
+				// Tell the player how many undos escape the dead end, matching the
+				// web StalemateEscapeButton.
+				if n := c.UndoToEscape(); n > 0 {
+					b.WriteString(color.Yellow(i18n.Tf("cuiSolitaireUndoToEscape",
+						"count", strconv.Itoa(n))) + "\n")
+				}
 				b.WriteString(i18n.T("cruel.shiftHint") + "\n")
 				b.WriteString(color.Yellow(i18n.T("cruel.stalemateGiveUp")) + "\n")
 			}

--- a/internal/adapter/presenter/CruelCuiPresenter_test.go
+++ b/internal/adapter/presenter/CruelCuiPresenter_test.go
@@ -15,6 +15,7 @@ func setupCruelCuiMockDefaults(cg *interfaces.MockCruelGame) {
 	cg.On("GetPhase").Return(domain.CruelPhasePlaying).Maybe()
 	cg.On("GetMoveCount").Return(0).Maybe()
 	cg.On("IsStalemate").Return(false).Maybe()
+	cg.On("UndoToEscape").Return(0).Maybe()
 
 	var tableau [domain.CruelTableauCnt][]*domain.KlondikeTableauCard
 	for i := range domain.CruelTableauCnt {
@@ -57,6 +58,7 @@ func TestCruelCuiPresenter_Output(t *testing.T) {
 		cg.On("GetPhase").Return(domain.CruelPhasePlaying).Maybe()
 		cg.On("GetMoveCount").Return(5).Maybe()
 		cg.On("IsStalemate").Return(true).Maybe()
+		cg.On("UndoToEscape").Return(0).Maybe()
 		var tableau [domain.CruelTableauCnt][]*domain.KlondikeTableauCard
 		cg.On("GetTableau").Return(tableau).Maybe()
 		var foundation [domain.CruelFoundationCnt][]*domain.Card

--- a/internal/adapter/presenter/EasthavenCuiPresenter.go
+++ b/internal/adapter/presenter/EasthavenCuiPresenter.go
@@ -61,6 +61,12 @@ func (p *EasthavenCuiPresenter) Output(e interfaces.EasthavenGame, lastErr error
 		case domain.EasthavenPhasePlaying:
 			if e.IsStalemate() {
 				b.WriteString(color.Red(i18n.T("cuiSolitaireStalemate")) + "\n")
+				// Tell the player how many undos escape the dead end, matching the
+				// web StalemateEscapeButton.
+				if n := e.UndoToEscape(); n > 0 {
+					b.WriteString(color.Yellow(i18n.Tf("cuiSolitaireUndoToEscape",
+						"count", strconv.Itoa(n))) + "\n")
+				}
 			}
 			b.WriteString(i18n.Tf("cuiSolitaireMoves",
 				"count", strconv.Itoa(e.GetMoveCount())) + "\n")

--- a/internal/adapter/presenter/EasthavenCuiPresenter_test.go
+++ b/internal/adapter/presenter/EasthavenCuiPresenter_test.go
@@ -16,6 +16,7 @@ func setupEasthavenCuiMockDefaults(eg *interfaces.MockEasthavenGame) {
 	eg.On("GetMoveCount").Return(0).Maybe()
 	eg.On("GetStockCount").Return(31).Maybe()
 	eg.On("IsStalemate").Return(false).Maybe()
+	eg.On("UndoToEscape").Return(0).Maybe()
 
 	var tableau [domain.EasthavenTableauCnt][]*domain.KlondikeTableauCard
 	for i := range domain.EasthavenTableauCnt {
@@ -54,6 +55,7 @@ func TestEasthavenCuiPresenter_Output(t *testing.T) {
 		eg.On("GetMoveCount").Return(5).Maybe()
 		eg.On("GetStockCount").Return(0).Maybe()
 		eg.On("IsStalemate").Return(true).Maybe()
+		eg.On("UndoToEscape").Return(0).Maybe()
 		var tableau [domain.EasthavenTableauCnt][]*domain.KlondikeTableauCard
 		eg.On("GetTableau").Return(tableau).Maybe()
 		var foundation [domain.EasthavenFoundationCnt][]*domain.Card

--- a/internal/adapter/presenter/EightOffCuiPresenter.go
+++ b/internal/adapter/presenter/EightOffCuiPresenter.go
@@ -75,6 +75,12 @@ func (p *EightOffCuiPresenter) Output(e interfaces.EightOffGame, lastErr error) 
 		case domain.EightOffPhasePlaying:
 			if e.IsStalemate() {
 				b.WriteString(color.Red(i18n.T("cuiSolitaireStalemate")) + "\n")
+				// Tell the player how many undos escape the dead end, matching the
+				// web StalemateEscapeButton.
+				if n := e.UndoToEscape(); n > 0 {
+					b.WriteString(color.Yellow(i18n.Tf("cuiSolitaireUndoToEscape",
+						"count", strconv.Itoa(n))) + "\n")
+				}
 			}
 			// Show how many cards can be moved as one stack — (1 + empty free
 			// cells) * 2^(empty columns), the same formula the web UI uses — so the

--- a/internal/adapter/presenter/FlowerGardenCuiPresenter.go
+++ b/internal/adapter/presenter/FlowerGardenCuiPresenter.go
@@ -90,6 +90,12 @@ func (p *FlowerGardenCuiPresenter) Output(bc interfaces.FlowerGardenGame, lastEr
 		case domain.FlowerGardenPhasePlaying:
 			if bc.IsStalemate() {
 				b.WriteString(color.Red(i18n.T("cuiSolitaireStalemate")) + "\n")
+				// Tell the player how many undos escape the dead end, matching the
+				// web StalemateEscapeButton.
+				if n := bc.UndoToEscape(); n > 0 {
+					b.WriteString(color.Yellow(i18n.Tf("cuiSolitaireUndoToEscape",
+						"count", strconv.Itoa(n))) + "\n")
+				}
 			}
 			b.WriteString(i18n.Tf("cuiSolitaireMoves",
 				"count", strconv.Itoa(bc.GetMoveCount())) + "\n")

--- a/internal/adapter/presenter/FlowerGardenCuiPresenter_test.go
+++ b/internal/adapter/presenter/FlowerGardenCuiPresenter_test.go
@@ -18,6 +18,7 @@ func setupFlowerGardenCuiMockDefaults(bg *interfaces.MockFlowerGardenGame) {
 	bg.On("GetPhase").Return(domain.FlowerGardenPhasePlaying).Maybe()
 	bg.On("GetMoveCount").Return(0).Maybe()
 	bg.On("IsStalemate").Return(false).Maybe()
+	bg.On("UndoToEscape").Return(0).Maybe()
 
 	var tableau [domain.FlowerGardenTableauCnt][]*domain.FlowerGardenTableauCard
 	for i := range domain.FlowerGardenTableauCnt {
@@ -112,6 +113,7 @@ func TestFlowerGardenCuiPresenter_Output(t *testing.T) {
 		setupFlowerGardenCuiMockDefaults(bg)
 		bg.ExpectedCalls = filterCalls(bg.ExpectedCalls, "IsStalemate")
 		bg.On("IsStalemate").Return(true)
+		bg.On("UndoToEscape").Return(0).Maybe()
 
 		p := new(FlowerGardenCuiPresenter)
 		result := p.Output(bg, nil)

--- a/internal/adapter/presenter/FortyAndEightCuiPresenter.go
+++ b/internal/adapter/presenter/FortyAndEightCuiPresenter.go
@@ -87,6 +87,12 @@ func (p *FortyAndEightCuiPresenter) Output(ft interfaces.FortyAndEightGame, last
 		case domain.FortyAndEightPhasePlaying:
 			if ft.IsStalemate() {
 				b.WriteString(color.Red(i18n.T("cuiSolitaireStalemate")) + "\n")
+				// Tell the player how many undos escape the dead end, matching the
+				// web StalemateEscapeButton.
+				if n := ft.UndoToEscape(); n > 0 {
+					b.WriteString(color.Yellow(i18n.Tf("cuiSolitaireUndoToEscape",
+						"count", strconv.Itoa(n))) + "\n")
+				}
 			}
 			b.WriteString(i18n.T("fortyandeight.cuiCommandHint") + "\n")
 			b.WriteString(i18n.Tf("cuiSolitaireMoves",

--- a/internal/adapter/presenter/FortyAndEightCuiPresenter_test.go
+++ b/internal/adapter/presenter/FortyAndEightCuiPresenter_test.go
@@ -19,6 +19,7 @@ func setupFortyAndEightCuiMockDefaults(fg *interfaces.MockFortyAndEightGame) {
 	fg.On("GetStockCount").Return(64).Maybe()
 	fg.On("GetWaste").Return(([]*domain.Card)(nil)).Maybe()
 	fg.On("IsStalemate").Return(false).Maybe()
+	fg.On("UndoToEscape").Return(0).Maybe()
 	fg.On("GetRedealUsed").Return(false).Maybe()
 
 	var tableau [domain.FortyAndEightTableauCnt][]*domain.FortyAndEightTableauCard
@@ -121,6 +122,7 @@ func TestFortyAndEightCuiPresenter_Output(t *testing.T) {
 		setupFortyAndEightCuiMockDefaults(fg)
 		fg.ExpectedCalls = filterCalls(fg.ExpectedCalls, "IsStalemate")
 		fg.On("IsStalemate").Return(true)
+		fg.On("UndoToEscape").Return(0).Maybe()
 
 		p := new(FortyAndEightCuiPresenter)
 		result := p.Output(fg, nil)

--- a/internal/adapter/presenter/FortyThievesCuiPresenter.go
+++ b/internal/adapter/presenter/FortyThievesCuiPresenter.go
@@ -79,6 +79,12 @@ func (p *FortyThievesCuiPresenter) Output(ft interfaces.FortyThievesGame, lastEr
 		case domain.FortyThievesPhasePlaying:
 			if ft.IsStalemate() {
 				b.WriteString(color.Red(i18n.T("cuiSolitaireStalemate")) + "\n")
+				// Tell the player how many undos escape the dead end, matching the
+				// web StalemateEscapeButton.
+				if n := ft.UndoToEscape(); n > 0 {
+					b.WriteString(color.Yellow(i18n.Tf("cuiSolitaireUndoToEscape",
+						"count", strconv.Itoa(n))) + "\n")
+				}
 			}
 			b.WriteString(i18n.T("fortythieves.cuiCommandHint") + "\n")
 			b.WriteString(i18n.Tf("cuiSolitaireMoves",

--- a/internal/adapter/presenter/FortyThievesCuiPresenter_test.go
+++ b/internal/adapter/presenter/FortyThievesCuiPresenter_test.go
@@ -19,6 +19,7 @@ func setupFortyThievesCuiMockDefaults(fg *interfaces.MockFortyThievesGame) {
 	fg.On("GetStockCount").Return(64).Maybe()
 	fg.On("GetWaste").Return(([]*domain.Card)(nil)).Maybe()
 	fg.On("IsStalemate").Return(false).Maybe()
+	fg.On("UndoToEscape").Return(0).Maybe()
 
 	var tableau [domain.FortyThievesTableauCnt][]*domain.FortyThievesTableauCard
 	for i := range domain.FortyThievesTableauCnt {
@@ -106,6 +107,7 @@ func TestFortyThievesCuiPresenter_Output(t *testing.T) {
 		setupFortyThievesCuiMockDefaults(fg)
 		fg.ExpectedCalls = filterCalls(fg.ExpectedCalls, "IsStalemate")
 		fg.On("IsStalemate").Return(true)
+		fg.On("UndoToEscape").Return(0).Maybe()
 
 		p := new(FortyThievesCuiPresenter)
 		result := p.Output(fg, nil)

--- a/internal/adapter/presenter/FreeCellCuiPresenter.go
+++ b/internal/adapter/presenter/FreeCellCuiPresenter.go
@@ -97,6 +97,12 @@ func (p *FreeCellCuiPresenter) Output(f interfaces.FreeCellGame, lastErr error) 
 		case domain.FreeCellPhasePlaying:
 			if f.IsStalemate() {
 				b.WriteString(color.Red(i18n.T("cuiSolitaireStalemate")) + "\n")
+				// Tell the player how many undos escape the dead end, matching the
+				// web StalemateEscapeButton.
+				if n := f.UndoToEscape(); n > 0 {
+					b.WriteString(color.Yellow(i18n.Tf("cuiSolitaireUndoToEscape",
+						"count", strconv.Itoa(n))) + "\n")
+				}
 			}
 			// **何枚まとめて動かせるかは CUI に出ていなかった (#4777)。**Web は
 			// fc-supermove-limit で常時出し、上限を超える列には赤いリングまで

--- a/internal/adapter/presenter/GapsCuiPresenter.go
+++ b/internal/adapter/presenter/GapsCuiPresenter.go
@@ -55,6 +55,12 @@ func (pr *GapsCuiPresenter) Output(g interfaces.GapsGame, lastErr error) string 
 		case domain.GapsPhasePlaying:
 			if g.IsStalemate() {
 				b.WriteString(color.Red(i18n.T("cuiSolitaireStalemate")) + "\n")
+				// Tell the player how many undos escape the dead end, matching the
+				// web StalemateEscapeButton.
+				if n := g.UndoToEscape(); n > 0 {
+					b.WriteString(color.Yellow(i18n.Tf("cuiSolitaireUndoToEscape",
+						"count", strconv.Itoa(n))) + "\n")
+				}
 			}
 			b.WriteString(i18n.Tf("cuiSolitaireMoves",
 				"count", strconv.Itoa(g.GetMoveCount())) + "\n")

--- a/internal/adapter/presenter/GolfCuiPresenter.go
+++ b/internal/adapter/presenter/GolfCuiPresenter.go
@@ -155,6 +155,12 @@ func (pr *GolfCuiPresenter) Output(g interfaces.GolfGame, lastErr error) string 
 		case domain.GolfPhasePlaying:
 			if g.IsStalemate() {
 				b.WriteString(color.Red(i18n.T("cuiSolitaireStalemate")) + "\n")
+				// Tell the player how many undos escape the dead end, matching the
+				// web StalemateEscapeButton.
+				if n := g.UndoToEscape(); n > 0 {
+					b.WriteString(color.Yellow(i18n.Tf("cuiSolitaireUndoToEscape",
+						"count", strconv.Itoa(n))) + "\n")
+				}
 			}
 			b.WriteString(i18n.Tf("cuiSolitaireMoves",
 				"count", strconv.Itoa(g.GetMoveCount())) + "\n")

--- a/internal/adapter/presenter/GolfCuiPresenter_test.go
+++ b/internal/adapter/presenter/GolfCuiPresenter_test.go
@@ -20,6 +20,7 @@ func setupGolfCuiMockDefaults(gg *interfaces.MockGolfGame) {
 	gg.On("GetStockCount").Return(16).Maybe()
 	gg.On("GetWaste").Return(([]*domain.Card)(nil)).Maybe()
 	gg.On("IsStalemate").Return(false).Maybe()
+	gg.On("UndoToEscape").Return(0).Maybe()
 
 	var layout [domain.GolfColCnt][domain.GolfRowCnt]*domain.GolfCard
 	// Add some cards
@@ -100,6 +101,7 @@ func TestGolfCuiPresenterOutput_Stalemate(t *testing.T) {
 	gg.On("GetStockCount").Return(0).Maybe()
 	gg.On("GetWaste").Return(([]*domain.Card)(nil)).Maybe()
 	gg.On("IsStalemate").Return(true).Maybe()
+	gg.On("UndoToEscape").Return(0).Maybe()
 	var layout [domain.GolfColCnt][domain.GolfRowCnt]*domain.GolfCard
 	gg.On("GetLayout").Return(layout).Maybe()
 	for c := range domain.GolfColCnt {

--- a/internal/adapter/presenter/KlondikeCuiPresenter.go
+++ b/internal/adapter/presenter/KlondikeCuiPresenter.go
@@ -113,6 +113,12 @@ func (p *KlondikeCuiPresenter) Output(k interfaces.KlondikeGame, lastErr error) 
 		case domain.KlondikePhasePlaying:
 			if k.IsStalemate() {
 				b.WriteString(color.Red(i18n.T("cuiSolitaireStalemate")) + "\n")
+				// Tell the player how many undos escape the dead end, matching the
+				// web StalemateEscapeButton.
+				if n := k.UndoToEscape(); n > 0 {
+					b.WriteString(color.Yellow(i18n.Tf("cuiSolitaireUndoToEscape",
+						"count", strconv.Itoa(n))) + "\n")
+				}
 			}
 			// **もう自動で揃えられることを能動的に知らせる (#4776)。**Web は
 			// 条件が揃うとボタンを光らせバッジも出すのに、CUI は ac コマンドが

--- a/internal/adapter/presenter/KlondikeCuiPresenter_test.go
+++ b/internal/adapter/presenter/KlondikeCuiPresenter_test.go
@@ -19,6 +19,7 @@ func setupKlondikeCuiMockDefaults(kg *interfaces.MockKlondikeGame) {
 	kg.On("GetStockCount").Return(24).Maybe()
 	kg.On("GetWaste").Return(([]*domain.Card)(nil)).Maybe()
 	kg.On("IsStalemate").Return(false).Maybe()
+	kg.On("UndoToEscape").Return(0).Maybe()
 	kg.On("CanAutoComplete").Return(false).Maybe()
 	kg.On("GetDrawCount").Return(1).Maybe()
 	kg.On("GetScore").Return(0).Maybe()
@@ -147,6 +148,7 @@ func TestKlondikeCuiPresenter_Output(t *testing.T) {
 		kg.ExpectedCalls = filterCalls(kg.ExpectedCalls, "IsStalemate")
 		kg.On("CanAutoComplete").Return(false).Maybe()
 		kg.On("IsStalemate").Return(true)
+		kg.On("UndoToEscape").Return(0).Maybe()
 
 		p := new(KlondikeCuiPresenter)
 		result := p.Output(kg, nil)

--- a/internal/adapter/presenter/MonteCarloCuiPresenter_test.go
+++ b/internal/adapter/presenter/MonteCarloCuiPresenter_test.go
@@ -17,6 +17,7 @@ func setupMonteCarloCuiMockDefaults(g *interfaces.MockMonteCarloGame) {
 	g.On("GetRemovedCount").Return(0).Maybe()
 	g.On("GetDealCount").Return(0).Maybe()
 	g.On("IsStalemate").Return(false).Maybe()
+	g.On("UndoToEscape").Return(0).Maybe()
 	var board [domain.MonteCarloGridSize][domain.MonteCarloGridSize]*domain.Card
 	board[0][0] = domain.NewCard(domain.CardDesignSpade, 7, false)
 	g.On("GetBoard").Return(board).Maybe()
@@ -47,6 +48,7 @@ func TestMonteCarloCuiPresenter_Output(t *testing.T) {
 		g.On("GetRemovedCount").Return(40).Maybe()
 		g.On("GetDealCount").Return(3).Maybe()
 		g.On("IsStalemate").Return(true).Maybe()
+		g.On("UndoToEscape").Return(0).Maybe()
 		var board [domain.MonteCarloGridSize][domain.MonteCarloGridSize]*domain.Card
 		g.On("GetBoard").Return(board).Maybe()
 

--- a/internal/adapter/presenter/MonteCarloCuiPresenter_test.go
+++ b/internal/adapter/presenter/MonteCarloCuiPresenter_test.go
@@ -17,7 +17,6 @@ func setupMonteCarloCuiMockDefaults(g *interfaces.MockMonteCarloGame) {
 	g.On("GetRemovedCount").Return(0).Maybe()
 	g.On("GetDealCount").Return(0).Maybe()
 	g.On("IsStalemate").Return(false).Maybe()
-	g.On("UndoToEscape").Return(0).Maybe()
 	var board [domain.MonteCarloGridSize][domain.MonteCarloGridSize]*domain.Card
 	board[0][0] = domain.NewCard(domain.CardDesignSpade, 7, false)
 	g.On("GetBoard").Return(board).Maybe()
@@ -48,7 +47,6 @@ func TestMonteCarloCuiPresenter_Output(t *testing.T) {
 		g.On("GetRemovedCount").Return(40).Maybe()
 		g.On("GetDealCount").Return(3).Maybe()
 		g.On("IsStalemate").Return(true).Maybe()
-		g.On("UndoToEscape").Return(0).Maybe()
 		var board [domain.MonteCarloGridSize][domain.MonteCarloGridSize]*domain.Card
 		g.On("GetBoard").Return(board).Maybe()
 

--- a/internal/adapter/presenter/OsmosisCuiPresenter_test.go
+++ b/internal/adapter/presenter/OsmosisCuiPresenter_test.go
@@ -14,6 +14,7 @@ import (
 
 func setupOsmosisCuiMockDefaults(og *interfaces.MockOsmosisGame) {
 	og.On("IsStalemate").Return(false).Maybe()
+	og.On("UndoToEscape").Return(0).Maybe()
 	og.On("GetPhase").Return(domain.OsmosisPhasePlaying).Maybe()
 	og.On("GetMoveCount").Return(0).Maybe()
 	og.On("GetStockCount").Return(34).Maybe()
@@ -42,6 +43,7 @@ func TestOsmosisCuiPresenter_Output(t *testing.T) {
 		og := new(interfaces.MockOsmosisGame)
 		// 先に登録した期待が勝つ。defaults の IsStalemate(false) より前に置く。
 		og.On("IsStalemate").Return(true)
+		og.On("UndoToEscape").Return(0).Maybe()
 		setupOsmosisCuiMockDefaults(og)
 		p := new(OsmosisCuiPresenter)
 		assert.Contains(t, p.Output(og, nil), "手詰まり")

--- a/internal/adapter/presenter/OsmosisCuiPresenter_test.go
+++ b/internal/adapter/presenter/OsmosisCuiPresenter_test.go
@@ -14,7 +14,6 @@ import (
 
 func setupOsmosisCuiMockDefaults(og *interfaces.MockOsmosisGame) {
 	og.On("IsStalemate").Return(false).Maybe()
-	og.On("UndoToEscape").Return(0).Maybe()
 	og.On("GetPhase").Return(domain.OsmosisPhasePlaying).Maybe()
 	og.On("GetMoveCount").Return(0).Maybe()
 	og.On("GetStockCount").Return(34).Maybe()
@@ -43,7 +42,6 @@ func TestOsmosisCuiPresenter_Output(t *testing.T) {
 		og := new(interfaces.MockOsmosisGame)
 		// 先に登録した期待が勝つ。defaults の IsStalemate(false) より前に置く。
 		og.On("IsStalemate").Return(true)
-		og.On("UndoToEscape").Return(0).Maybe()
 		setupOsmosisCuiMockDefaults(og)
 		p := new(OsmosisCuiPresenter)
 		assert.Contains(t, p.Output(og, nil), "手詰まり")

--- a/internal/adapter/presenter/PenguinCuiPresenter.go
+++ b/internal/adapter/presenter/PenguinCuiPresenter.go
@@ -80,6 +80,12 @@ func (p *PenguinCuiPresenter) Output(pg interfaces.PenguinGame, lastErr error) s
 		case domain.PenguinPhasePlaying:
 			if pg.IsStalemate() {
 				b.WriteString(color.Red(i18n.T("cuiSolitaireStalemate")) + "\n")
+				// Tell the player how many undos escape the dead end, matching the
+				// web StalemateEscapeButton.
+				if n := pg.UndoToEscape(); n > 0 {
+					b.WriteString(color.Yellow(i18n.Tf("cuiSolitaireUndoToEscape",
+						"count", strconv.Itoa(n))) + "\n")
+				}
 			}
 			// **上限が出ておらず、拒否されたコマンドで初めて気づく形だった
 			// (#4802)。**姉妹の Eight Off は supermoveLine を毎ターン出し、

--- a/internal/adapter/presenter/PyramidCuiPresenter.go
+++ b/internal/adapter/presenter/PyramidCuiPresenter.go
@@ -82,6 +82,12 @@ func (pr *PyramidCuiPresenter) Output(p interfaces.PyramidGame, lastErr error) s
 		case domain.PyramidPhasePlaying:
 			if p.IsStalemate() {
 				b.WriteString(color.Red(i18n.T("cuiSolitaireStalemate")) + "\n")
+				// Tell the player how many undos escape the dead end, matching the
+				// web StalemateEscapeButton.
+				if n := p.UndoToEscape(); n > 0 {
+					b.WriteString(color.Yellow(i18n.Tf("cuiSolitaireUndoToEscape",
+						"count", strconv.Itoa(n))) + "\n")
+				}
 			}
 			b.WriteString(i18n.Tf("cuiSolitaireMoves",
 				"count", strconv.Itoa(p.GetMoveCount())) + "\n")

--- a/internal/adapter/presenter/PyramidCuiPresenter_test.go
+++ b/internal/adapter/presenter/PyramidCuiPresenter_test.go
@@ -30,6 +30,7 @@ func setupPyramidCuiMock() *interfaces.MockPyramidGame {
 	pg.On("GetStockCount").Return(24).Maybe()
 	pg.On("GetWaste").Return(([]*domain.Card)(nil)).Maybe()
 	pg.On("IsStalemate").Return(false).Maybe()
+	pg.On("UndoToEscape").Return(0).Maybe()
 	pg.On("IsWasteKingRemovable").Return(false).Maybe()
 	addPyramidExposedExpectations(pg)
 
@@ -187,6 +188,7 @@ func TestPyramidCuiPresenterOutput_StalemateAndNonEmptyWaste(t *testing.T) {
 		domain.NewCard(domain.CardDesignSpade, 7, false),
 	}).Maybe()
 	pg.On("IsStalemate").Return(true).Maybe()
+	pg.On("UndoToEscape").Return(0).Maybe()
 	pg.On("IsWasteKingRemovable").Return(false).Maybe()
 	addPyramidExposedExpectations(pg)
 

--- a/internal/adapter/presenter/RussianSolitaireCuiPresenter.go
+++ b/internal/adapter/presenter/RussianSolitaireCuiPresenter.go
@@ -57,6 +57,12 @@ func (p *RussianSolitaireCuiPresenter) Output(r interfaces.RussianSolitaireGame,
 		case domain.RussianSolitairePhasePlaying:
 			if r.IsStalemate() {
 				b.WriteString(color.Red(i18n.T("cuiSolitaireStalemate")) + "\n")
+				// Tell the player how many undos escape the dead end, matching the
+				// web StalemateEscapeButton.
+				if n := r.UndoToEscape(); n > 0 {
+					b.WriteString(color.Yellow(i18n.Tf("cuiSolitaireUndoToEscape",
+						"count", strconv.Itoa(n))) + "\n")
+				}
 			}
 			b.WriteString(i18n.Tf("cuiSolitaireMoves",
 				"count", strconv.Itoa(r.GetMoveCount())) + "\n")

--- a/internal/adapter/presenter/RussianSolitaireCuiPresenter_test.go
+++ b/internal/adapter/presenter/RussianSolitaireCuiPresenter_test.go
@@ -15,6 +15,7 @@ func setupRussianSolitaireCuiMockDefaults(rg *interfaces.MockRussianSolitaireGam
 	rg.On("GetPhase").Return(domain.RussianSolitairePhasePlaying).Maybe()
 	rg.On("GetMoveCount").Return(0).Maybe()
 	rg.On("IsStalemate").Return(false).Maybe()
+	rg.On("UndoToEscape").Return(0).Maybe()
 
 	var tableau [domain.RussianSolitaireTableauCnt][]*domain.KlondikeTableauCard
 	for i := range domain.RussianSolitaireTableauCnt {
@@ -54,6 +55,7 @@ func TestRussianSolitaireCuiPresenter_Output(t *testing.T) {
 		rg.On("GetPhase").Return(domain.RussianSolitairePhasePlaying).Maybe()
 		rg.On("GetMoveCount").Return(5).Maybe()
 		rg.On("IsStalemate").Return(true).Maybe()
+		rg.On("UndoToEscape").Return(0).Maybe()
 		var tableau [domain.RussianSolitaireTableauCnt][]*domain.KlondikeTableauCard
 		rg.On("GetTableau").Return(tableau).Maybe()
 		var foundation [domain.RussianSolitaireFoundationCnt][]*domain.Card

--- a/internal/adapter/presenter/ScorpionCuiPresenter.go
+++ b/internal/adapter/presenter/ScorpionCuiPresenter.go
@@ -45,6 +45,12 @@ func (p *ScorpionCuiPresenter) Output(s interfaces.ScorpionGame, lastErr error) 
 		case domain.ScorpionPhasePlaying:
 			if s.IsStalemate() {
 				b.WriteString(color.Red(i18n.T("cuiSolitaireStalemate")) + "\n")
+				// Tell the player how many undos escape the dead end, matching the
+				// web StalemateEscapeButton.
+				if n := s.UndoToEscape(); n > 0 {
+					b.WriteString(color.Yellow(i18n.Tf("cuiSolitaireUndoToEscape",
+						"count", strconv.Itoa(n))) + "\n")
+				}
 			}
 			b.WriteString(i18n.Tf("cuiSolitaireMoves",
 				"count", strconv.Itoa(s.GetMoveCount())) + "\n")

--- a/internal/adapter/presenter/ScorpionCuiPresenter_test.go
+++ b/internal/adapter/presenter/ScorpionCuiPresenter_test.go
@@ -15,6 +15,7 @@ func setupScorpionCuiMockDefaults(sg *interfaces.MockScorpionGame) {
 	sg.On("GetPhase").Return(domain.ScorpionPhasePlaying).Maybe()
 	sg.On("GetMoveCount").Return(0).Maybe()
 	sg.On("IsStalemate").Return(false).Maybe()
+	sg.On("UndoToEscape").Return(0).Maybe()
 	sg.On("GetCompletedSuits").Return(0).Maybe()
 	sg.On("GetStockCount").Return(3).Maybe()
 
@@ -53,6 +54,7 @@ func TestScorpionCuiPresenter_Output(t *testing.T) {
 		sg.On("GetPhase").Return(domain.ScorpionPhasePlaying).Maybe()
 		sg.On("GetMoveCount").Return(5).Maybe()
 		sg.On("IsStalemate").Return(true).Maybe()
+		sg.On("UndoToEscape").Return(0).Maybe()
 		sg.On("GetCompletedSuits").Return(0).Maybe()
 		sg.On("GetStockCount").Return(0).Maybe()
 		var tableau [domain.ScorpionTableauCnt][]*domain.KlondikeTableauCard

--- a/internal/adapter/presenter/SeahavenTowersCuiPresenter.go
+++ b/internal/adapter/presenter/SeahavenTowersCuiPresenter.go
@@ -75,6 +75,12 @@ func (p *SeahavenTowersCuiPresenter) Output(s interfaces.SeahavenTowersGame, las
 		case domain.SeahavenTowersPhasePlaying:
 			if s.IsStalemate() {
 				b.WriteString(color.Red(i18n.T("cuiSolitaireStalemate")) + "\n")
+				// Tell the player how many undos escape the dead end, matching the
+				// web StalemateEscapeButton.
+				if n := s.UndoToEscape(); n > 0 {
+					b.WriteString(color.Yellow(i18n.Tf("cuiSolitaireUndoToEscape",
+						"count", strconv.Itoa(n))) + "\n")
+				}
 			}
 			// Show the one-move stack limit (1 + empty reserved cells, the web
 			// formula) so the human isn't surprised by a rejected multi-card move.

--- a/internal/adapter/presenter/SirTommyCuiPresenter.go
+++ b/internal/adapter/presenter/SirTommyCuiPresenter.go
@@ -83,6 +83,12 @@ func (p *SirTommyCuiPresenter) Output(g interfaces.SirTommyGame, lastErr error) 
 		case domain.SirTommyPhasePlaying:
 			if g.IsStalemate() {
 				b.WriteString(color.Red(i18n.T("cuiSolitaireStalemate")) + "\n")
+				// Tell the player how many undos escape the dead end, matching the
+				// web StalemateEscapeButton.
+				if n := g.UndoToEscape(); n > 0 {
+					b.WriteString(color.Yellow(i18n.Tf("cuiSolitaireUndoToEscape",
+						"count", strconv.Itoa(n))) + "\n")
+				}
 			}
 			b.WriteString(i18n.Tf("cuiSolitaireMoves",
 				"count", strconv.Itoa(g.GetMoveCount())) + "\n")

--- a/internal/adapter/presenter/SirTommyCuiPresenter_test.go
+++ b/internal/adapter/presenter/SirTommyCuiPresenter_test.go
@@ -15,6 +15,7 @@ func setupSirTommyCuiMockDefaults(g *interfaces.MockSirTommyGame) {
 	g.On("GetPhase").Return(domain.SirTommyPhasePlaying).Maybe()
 	g.On("GetMoveCount").Return(0).Maybe()
 	g.On("IsStalemate").Return(false).Maybe()
+	g.On("UndoToEscape").Return(0).Maybe()
 	g.On("GetStockCount").Return(5).Maybe()
 	g.On("GetStockTop").Return(domain.NewCard(domain.CardDesignSpade, 7, false)).Maybe()
 
@@ -82,6 +83,7 @@ func TestSirTommyCuiPresenter_Output(t *testing.T) {
 		g.On("GetPhase").Return(domain.SirTommyPhasePlaying).Maybe()
 		g.On("GetMoveCount").Return(1).Maybe()
 		g.On("IsStalemate").Return(true).Maybe()
+		g.On("UndoToEscape").Return(0).Maybe()
 		g.On("GetStockCount").Return(0).Maybe()
 		g.On("GetStockTop").Return((*domain.Card)(nil)).Maybe()
 		var foundations [domain.SirTommyFoundationCnt][]*domain.Card

--- a/internal/adapter/presenter/SpiderCuiPresenter.go
+++ b/internal/adapter/presenter/SpiderCuiPresenter.go
@@ -74,6 +74,12 @@ func (p *SpiderCuiPresenter) Output(s interfaces.SpiderGame, lastErr error) stri
 		case domain.SpiderPhasePlaying:
 			if s.IsStalemate() {
 				b.WriteString(color.Red(i18n.T("cuiSolitaireStalemate")) + "\n")
+				// Tell the player how many undos escape the dead end, matching the
+				// web StalemateEscapeButton.
+				if n := s.UndoToEscape(); n > 0 {
+					b.WriteString(color.Yellow(i18n.Tf("cuiSolitaireUndoToEscape",
+						"count", strconv.Itoa(n))) + "\n")
+				}
 			}
 			b.WriteString(i18n.Tf("cuiSolitaireMoves",
 				"count", strconv.Itoa(s.GetMoveCount())) + "\n")

--- a/internal/adapter/presenter/SpiderCuiPresenter_test.go
+++ b/internal/adapter/presenter/SpiderCuiPresenter_test.go
@@ -22,6 +22,7 @@ func setupSpiderCuiMockDefaults(sg *interfaces.MockSpiderGame) {
 	sg.On("GetScore").Return(500).Maybe()
 	sg.On("GetDifficulty").Return(domain.SpiderDifficulty1Suit).Maybe()
 	sg.On("IsStalemate").Return(false).Maybe()
+	sg.On("UndoToEscape").Return(0).Maybe()
 
 	var tableau [domain.SpiderTableauCnt][]*domain.SpiderTableauCard
 	for i := 0; i < domain.SpiderTableauCnt; i++ {
@@ -111,6 +112,7 @@ func TestSpiderCuiPresenter_Output(t *testing.T) {
 		setupSpiderCuiMockDefaults(sg)
 		sg.ExpectedCalls = filterCalls(sg.ExpectedCalls, "IsStalemate")
 		sg.On("IsStalemate").Return(true)
+		sg.On("UndoToEscape").Return(0).Maybe()
 
 		p := new(SpiderCuiPresenter)
 		result := p.Output(sg, nil)

--- a/internal/adapter/presenter/SpideretteCuiPresenter.go
+++ b/internal/adapter/presenter/SpideretteCuiPresenter.go
@@ -65,6 +65,12 @@ func (p *SpideretteCuiPresenter) Output(s interfaces.SpideretteGame, lastErr err
 		case domain.SpiderettePhasePlaying:
 			if s.IsStalemate() {
 				b.WriteString(color.Red(i18n.T("cuiSolitaireStalemate")) + "\n")
+				// Tell the player how many undos escape the dead end, matching the
+				// web StalemateEscapeButton.
+				if n := s.UndoToEscape(); n > 0 {
+					b.WriteString(color.Yellow(i18n.Tf("cuiSolitaireUndoToEscape",
+						"count", strconv.Itoa(n))) + "\n")
+				}
 			}
 			b.WriteString(i18n.Tf("cuiSolitaireMoves", "count", strconv.Itoa(s.GetMoveCount())) + "\n")
 		case domain.SpiderettePhaseGameClear:

--- a/internal/adapter/presenter/SpideretteCuiPresenter_test.go
+++ b/internal/adapter/presenter/SpideretteCuiPresenter_test.go
@@ -20,6 +20,7 @@ func setupSpideretteCuiMockDefaults(sg *interfaces.MockSpideretteGame) {
 	sg.On("GetCompletedSuits").Return(0).Maybe()
 	sg.On("GetScore").Return(500).Maybe()
 	sg.On("IsStalemate").Return(false).Maybe()
+	sg.On("UndoToEscape").Return(0).Maybe()
 
 	var tableau [domain.SpideretteTableauCnt][]*domain.SpideretteTableauCard
 	for i := 0; i < domain.SpideretteTableauCnt; i++ {
@@ -89,6 +90,7 @@ func TestSpideretteCuiPresenter_Output(t *testing.T) {
 		setupSpideretteCuiMockDefaults(sg)
 		sg.ExpectedCalls = filterCalls(sg.ExpectedCalls, "IsStalemate")
 		sg.On("IsStalemate").Return(true)
+		sg.On("UndoToEscape").Return(0).Maybe()
 
 		p := new(SpideretteCuiPresenter)
 		result := p.Output(sg, nil)

--- a/internal/adapter/presenter/StreetsAndAlleysCuiPresenter.go
+++ b/internal/adapter/presenter/StreetsAndAlleysCuiPresenter.go
@@ -67,6 +67,12 @@ func (p *StreetsAndAlleysCuiPresenter) Output(bc interfaces.StreetsAndAlleysGame
 		case domain.StreetsAndAlleysPhasePlaying:
 			if bc.IsStalemate() {
 				b.WriteString(color.Red(i18n.T("cuiSolitaireStalemate")) + "\n")
+				// Tell the player how many undos escape the dead end, matching the
+				// web StalemateEscapeButton.
+				if n := bc.UndoToEscape(); n > 0 {
+					b.WriteString(color.Yellow(i18n.Tf("cuiSolitaireUndoToEscape",
+						"count", strconv.Itoa(n))) + "\n")
+				}
 			}
 			b.WriteString(i18n.Tf("cuiSolitaireMoves",
 				"count", strconv.Itoa(bc.GetMoveCount())) + "\n")

--- a/internal/adapter/presenter/StreetsAndAlleysCuiPresenter_test.go
+++ b/internal/adapter/presenter/StreetsAndAlleysCuiPresenter_test.go
@@ -17,6 +17,7 @@ func setupStreetsAndAlleysCuiMockDefaults(bg *interfaces.MockStreetsAndAlleysGam
 	bg.On("GetPhase").Return(domain.StreetsAndAlleysPhasePlaying).Maybe()
 	bg.On("GetMoveCount").Return(0).Maybe()
 	bg.On("IsStalemate").Return(false).Maybe()
+	bg.On("UndoToEscape").Return(0).Maybe()
 
 	var tableau [domain.StreetsAndAlleysTableauCnt][]*domain.StreetsAndAlleysTableauCard
 	for i := range domain.StreetsAndAlleysTableauCnt {
@@ -90,6 +91,7 @@ func TestStreetsAndAlleysCuiPresenter_Output(t *testing.T) {
 		setupStreetsAndAlleysCuiMockDefaults(bg)
 		bg.ExpectedCalls = filterCalls(bg.ExpectedCalls, "IsStalemate")
 		bg.On("IsStalemate").Return(true)
+		bg.On("UndoToEscape").Return(0).Maybe()
 
 		p := new(StreetsAndAlleysCuiPresenter)
 		result := p.Output(bg, nil)

--- a/internal/adapter/presenter/TriPeaksCuiPresenter.go
+++ b/internal/adapter/presenter/TriPeaksCuiPresenter.go
@@ -111,6 +111,12 @@ func (pr *TriPeaksCuiPresenter) Output(t interfaces.TriPeaksGame, lastErr error)
 		case domain.TriPeaksPhasePlaying:
 			if t.IsStalemate() {
 				b.WriteString(color.Red(i18n.T("cuiSolitaireStalemate")) + "\n")
+				// Tell the player how many undos escape the dead end, matching the
+				// web StalemateEscapeButton.
+				if n := t.UndoToEscape(); n > 0 {
+					b.WriteString(color.Yellow(i18n.Tf("cuiSolitaireUndoToEscape",
+						"count", strconv.Itoa(n))) + "\n")
+				}
 			}
 			b.WriteString(i18n.Tf("cuiSolitaireMoves",
 				"count", strconv.Itoa(t.GetMoveCount())) + "\n")

--- a/internal/adapter/presenter/TriPeaksCuiPresenter_test.go
+++ b/internal/adapter/presenter/TriPeaksCuiPresenter_test.go
@@ -18,6 +18,7 @@ func setupTriPeaksCuiMockDefaults(tg *interfaces.MockTriPeaksGame) {
 	tg.On("GetStockCount").Return(23).Maybe()
 	tg.On("GetWaste").Return(([]*domain.Card)(nil)).Maybe()
 	tg.On("IsStalemate").Return(false).Maybe()
+	tg.On("UndoToEscape").Return(0).Maybe()
 
 	var layout [domain.TriPeaksRowCnt][domain.TriPeaksColCnt]*domain.TriPeaksCard
 	// Add some cards at row 3
@@ -97,6 +98,7 @@ func TestTriPeaksCuiPresenterOutput_Stalemate(t *testing.T) {
 	tg.On("GetStockCount").Return(0).Maybe()
 	tg.On("GetWaste").Return(([]*domain.Card)(nil)).Maybe()
 	tg.On("IsStalemate").Return(true).Maybe()
+	tg.On("UndoToEscape").Return(0).Maybe()
 	var layout [domain.TriPeaksRowCnt][domain.TriPeaksColCnt]*domain.TriPeaksCard
 	tg.On("GetLayout").Return(layout).Maybe()
 

--- a/internal/adapter/presenter/WaspCuiPresenter.go
+++ b/internal/adapter/presenter/WaspCuiPresenter.go
@@ -45,6 +45,12 @@ func (p *WaspCuiPresenter) Output(s interfaces.WaspGame, lastErr error) string {
 		case domain.WaspPhasePlaying:
 			if s.IsStalemate() {
 				b.WriteString(color.Red(i18n.T("cuiSolitaireStalemate")) + "\n")
+				// Tell the player how many undos escape the dead end, matching the
+				// web StalemateEscapeButton.
+				if n := s.UndoToEscape(); n > 0 {
+					b.WriteString(color.Yellow(i18n.Tf("cuiSolitaireUndoToEscape",
+						"count", strconv.Itoa(n))) + "\n")
+				}
 			}
 			b.WriteString(i18n.Tf("cuiSolitaireMoves",
 				"count", strconv.Itoa(s.GetMoveCount())) + "\n")

--- a/internal/adapter/presenter/WaspCuiPresenter_test.go
+++ b/internal/adapter/presenter/WaspCuiPresenter_test.go
@@ -15,6 +15,7 @@ func setupWaspCuiMockDefaults(sg *interfaces.MockWaspGame) {
 	sg.On("GetPhase").Return(domain.WaspPhasePlaying).Maybe()
 	sg.On("GetMoveCount").Return(0).Maybe()
 	sg.On("IsStalemate").Return(false).Maybe()
+	sg.On("UndoToEscape").Return(0).Maybe()
 	sg.On("GetCompletedSuits").Return(0).Maybe()
 	sg.On("GetStockCount").Return(3).Maybe()
 
@@ -53,6 +54,7 @@ func TestWaspCuiPresenter_Output(t *testing.T) {
 		sg.On("GetPhase").Return(domain.WaspPhasePlaying).Maybe()
 		sg.On("GetMoveCount").Return(5).Maybe()
 		sg.On("IsStalemate").Return(true).Maybe()
+		sg.On("UndoToEscape").Return(0).Maybe()
 		sg.On("GetCompletedSuits").Return(0).Maybe()
 		sg.On("GetStockCount").Return(0).Maybe()
 		var tableau [domain.WaspTableauCnt][]*domain.KlondikeTableauCard

--- a/internal/adapter/presenter/YukonCuiPresenter.go
+++ b/internal/adapter/presenter/YukonCuiPresenter.go
@@ -57,6 +57,12 @@ func (p *YukonCuiPresenter) Output(y interfaces.YukonGame, lastErr error) string
 		case domain.YukonPhasePlaying:
 			if y.IsStalemate() {
 				b.WriteString(color.Red(i18n.T("cuiSolitaireStalemate")) + "\n")
+				// Tell the player how many undos escape the dead end, matching the
+				// web StalemateEscapeButton.
+				if n := y.UndoToEscape(); n > 0 {
+					b.WriteString(color.Yellow(i18n.Tf("cuiSolitaireUndoToEscape",
+						"count", strconv.Itoa(n))) + "\n")
+				}
 			}
 			b.WriteString(i18n.Tf("cuiSolitaireMoves",
 				"count", strconv.Itoa(y.GetMoveCount())) + "\n")

--- a/internal/adapter/presenter/YukonCuiPresenter_test.go
+++ b/internal/adapter/presenter/YukonCuiPresenter_test.go
@@ -15,6 +15,7 @@ func setupYukonCuiMockDefaults(yg *interfaces.MockYukonGame) {
 	yg.On("GetPhase").Return(domain.YukonPhasePlaying).Maybe()
 	yg.On("GetMoveCount").Return(0).Maybe()
 	yg.On("IsStalemate").Return(false).Maybe()
+	yg.On("UndoToEscape").Return(0).Maybe()
 
 	var tableau [domain.YukonTableauCnt][]*domain.KlondikeTableauCard
 	for i := range domain.YukonTableauCnt {
@@ -72,6 +73,7 @@ func TestYukonCuiPresenter_Output(t *testing.T) {
 		yg.On("GetPhase").Return(domain.YukonPhasePlaying).Maybe()
 		yg.On("GetMoveCount").Return(5).Maybe()
 		yg.On("IsStalemate").Return(true).Maybe()
+		yg.On("UndoToEscape").Return(0).Maybe()
 		var tableau [domain.YukonTableauCnt][]*domain.KlondikeTableauCard
 		yg.On("GetTableau").Return(tableau).Maybe()
 		var foundation [domain.YukonFoundationCnt][]*domain.Card

--- a/internal/adapter/presenter/cui_solitaire_stalemate_test.go
+++ b/internal/adapter/presenter/cui_solitaire_stalemate_test.go
@@ -1,0 +1,387 @@
+//go:build test
+
+package presenter
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+)
+
+// escapeMoves is an arbitrary positive undo count: the guidance only renders when
+// UndoToEscape() > 0, so 0 would silently prove nothing.
+const escapeMoves = 3
+
+func assertEscapeHint(t *testing.T, result string) {
+	t.Helper()
+	assert.Contains(t, result, "手詰まりです",
+		"stalemate banner missing -- the fixture did not reach the stalemate branch")
+	assert.Contains(t, result, "脱出には",
+		"stalemate screen does not tell the player how many undos escape the dead end")
+	assert.Contains(t, result, strconv.Itoa(escapeMoves),
+		"escape guidance does not carry the undo count from UndoToEscape()")
+}
+
+// TestSolitaireCuiUndoToEscapeHint covers the solitaires whose web page offers a
+// StalemateEscapeButton while their CUI said only "手詰まりです".
+func TestSolitaireCuiUndoToEscapeHint(t *testing.T) {
+	t.Run("Accordion", func(t *testing.T) {
+		m := new(interfaces.MockAccordionGame)
+		setupAccordionCuiMockDefaults(m)
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "GetPhase")
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "IsStalemate")
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "UndoToEscape")
+		m.On("GetPhase").Return(domain.AccordionPhasePlaying)
+		m.On("IsStalemate").Return(true)
+		m.On("UndoToEscape").Return(escapeMoves)
+
+		assertEscapeHint(t, new(AccordionCuiPresenter).Output(m, nil))
+	})
+	t.Run("AcesUp", func(t *testing.T) {
+		m := new(interfaces.MockAcesUpGame)
+		setupAcesUpCuiMockDefaults(m)
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "GetPhase")
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "IsStalemate")
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "UndoToEscape")
+		m.On("GetPhase").Return(domain.AcesUpPhasePlaying)
+		m.On("IsStalemate").Return(true)
+		m.On("UndoToEscape").Return(escapeMoves)
+
+		assertEscapeHint(t, new(AcesUpCuiPresenter).Output(m, nil))
+	})
+	t.Run("AuldLangSyne", func(t *testing.T) {
+		m := new(interfaces.MockAuldLangSyneGame)
+		setupAuldLangSyneCuiMockDefaults(m)
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "GetPhase")
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "IsStalemate")
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "UndoToEscape")
+		m.On("GetPhase").Return(domain.AuldLangSynePhasePlaying)
+		m.On("IsStalemate").Return(true)
+		m.On("UndoToEscape").Return(escapeMoves)
+
+		assertEscapeHint(t, new(AuldLangSyneCuiPresenter).Output(m, nil))
+	})
+	t.Run("BakersDozen", func(t *testing.T) {
+		m := new(interfaces.MockBakersDozenGame)
+		setupBakersDozenCuiMockDefaults(m)
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "GetPhase")
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "IsStalemate")
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "UndoToEscape")
+		m.On("GetPhase").Return(domain.BakersDozenPhasePlaying)
+		m.On("IsStalemate").Return(true)
+		m.On("UndoToEscape").Return(escapeMoves)
+
+		assertEscapeHint(t, new(BakersDozenCuiPresenter).Output(m, nil))
+	})
+	t.Run("Calculation", func(t *testing.T) {
+		m := new(interfaces.MockCalculationGame)
+		setupCalculationCuiMockDefaults(m)
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "GetPhase")
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "IsStalemate")
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "UndoToEscape")
+		m.On("GetPhase").Return(domain.CalculationPhasePlaying)
+		m.On("IsStalemate").Return(true)
+		m.On("UndoToEscape").Return(escapeMoves)
+
+		assertEscapeHint(t, new(CalculationCuiPresenter).Output(m, nil))
+	})
+	t.Run("Crescent", func(t *testing.T) {
+		m := new(interfaces.MockCrescentGame)
+		setupCrescentCuiMockDefaults(m)
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "GetPhase")
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "IsStalemate")
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "UndoToEscape")
+		m.On("GetPhase").Return(domain.CrescentPhasePlaying)
+		m.On("IsStalemate").Return(true)
+		m.On("UndoToEscape").Return(escapeMoves)
+
+		assertEscapeHint(t, new(CrescentCuiPresenter).Output(m, nil))
+	})
+	t.Run("Cruel", func(t *testing.T) {
+		m := new(interfaces.MockCruelGame)
+		setupCruelCuiMockDefaults(m)
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "GetPhase")
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "IsStalemate")
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "UndoToEscape")
+		m.On("GetPhase").Return(domain.CruelPhasePlaying)
+		m.On("IsStalemate").Return(true)
+		m.On("UndoToEscape").Return(escapeMoves)
+
+		assertEscapeHint(t, new(CruelCuiPresenter).Output(m, nil))
+	})
+	t.Run("Easthaven", func(t *testing.T) {
+		m := new(interfaces.MockEasthavenGame)
+		setupEasthavenCuiMockDefaults(m)
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "GetPhase")
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "IsStalemate")
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "UndoToEscape")
+		m.On("GetPhase").Return(domain.EasthavenPhasePlaying)
+		m.On("IsStalemate").Return(true)
+		m.On("UndoToEscape").Return(escapeMoves)
+
+		assertEscapeHint(t, new(EasthavenCuiPresenter).Output(m, nil))
+	})
+	t.Run("FlowerGarden", func(t *testing.T) {
+		m := new(interfaces.MockFlowerGardenGame)
+		setupFlowerGardenCuiMockDefaults(m)
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "GetPhase")
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "IsStalemate")
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "UndoToEscape")
+		m.On("GetPhase").Return(domain.FlowerGardenPhasePlaying)
+		m.On("IsStalemate").Return(true)
+		m.On("UndoToEscape").Return(escapeMoves)
+
+		assertEscapeHint(t, new(FlowerGardenCuiPresenter).Output(m, nil))
+	})
+	t.Run("FortyAndEight", func(t *testing.T) {
+		m := new(interfaces.MockFortyAndEightGame)
+		setupFortyAndEightCuiMockDefaults(m)
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "GetPhase")
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "IsStalemate")
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "UndoToEscape")
+		m.On("GetPhase").Return(domain.FortyAndEightPhasePlaying)
+		m.On("IsStalemate").Return(true)
+		m.On("UndoToEscape").Return(escapeMoves)
+
+		assertEscapeHint(t, new(FortyAndEightCuiPresenter).Output(m, nil))
+	})
+	t.Run("FortyThieves", func(t *testing.T) {
+		m := new(interfaces.MockFortyThievesGame)
+		setupFortyThievesCuiMockDefaults(m)
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "GetPhase")
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "IsStalemate")
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "UndoToEscape")
+		m.On("GetPhase").Return(domain.FortyThievesPhasePlaying)
+		m.On("IsStalemate").Return(true)
+		m.On("UndoToEscape").Return(escapeMoves)
+
+		assertEscapeHint(t, new(FortyThievesCuiPresenter).Output(m, nil))
+	})
+	t.Run("Golf", func(t *testing.T) {
+		m := new(interfaces.MockGolfGame)
+		setupGolfCuiMockDefaults(m)
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "GetPhase")
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "IsStalemate")
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "UndoToEscape")
+		m.On("GetPhase").Return(domain.GolfPhasePlaying)
+		m.On("IsStalemate").Return(true)
+		m.On("UndoToEscape").Return(escapeMoves)
+
+		assertEscapeHint(t, new(GolfCuiPresenter).Output(m, nil))
+	})
+	t.Run("Klondike", func(t *testing.T) {
+		m := new(interfaces.MockKlondikeGame)
+		setupKlondikeCuiMockDefaults(m)
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "GetPhase")
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "IsStalemate")
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "UndoToEscape")
+		m.On("GetPhase").Return(domain.KlondikePhasePlaying)
+		m.On("IsStalemate").Return(true)
+		m.On("UndoToEscape").Return(escapeMoves)
+
+		assertEscapeHint(t, new(KlondikeCuiPresenter).Output(m, nil))
+	})
+	t.Run("RussianSolitaire", func(t *testing.T) {
+		m := new(interfaces.MockRussianSolitaireGame)
+		setupRussianSolitaireCuiMockDefaults(m)
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "GetPhase")
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "IsStalemate")
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "UndoToEscape")
+		m.On("GetPhase").Return(domain.RussianSolitairePhasePlaying)
+		m.On("IsStalemate").Return(true)
+		m.On("UndoToEscape").Return(escapeMoves)
+
+		assertEscapeHint(t, new(RussianSolitaireCuiPresenter).Output(m, nil))
+	})
+	t.Run("Scorpion", func(t *testing.T) {
+		m := new(interfaces.MockScorpionGame)
+		setupScorpionCuiMockDefaults(m)
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "GetPhase")
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "IsStalemate")
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "UndoToEscape")
+		m.On("GetPhase").Return(domain.ScorpionPhasePlaying)
+		m.On("IsStalemate").Return(true)
+		m.On("UndoToEscape").Return(escapeMoves)
+
+		assertEscapeHint(t, new(ScorpionCuiPresenter).Output(m, nil))
+	})
+	t.Run("SirTommy", func(t *testing.T) {
+		m := new(interfaces.MockSirTommyGame)
+		setupSirTommyCuiMockDefaults(m)
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "GetPhase")
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "IsStalemate")
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "UndoToEscape")
+		m.On("GetPhase").Return(domain.SirTommyPhasePlaying)
+		m.On("IsStalemate").Return(true)
+		m.On("UndoToEscape").Return(escapeMoves)
+
+		assertEscapeHint(t, new(SirTommyCuiPresenter).Output(m, nil))
+	})
+	t.Run("Spider", func(t *testing.T) {
+		m := new(interfaces.MockSpiderGame)
+		setupSpiderCuiMockDefaults(m)
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "GetPhase")
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "IsStalemate")
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "UndoToEscape")
+		m.On("GetPhase").Return(domain.SpiderPhasePlaying)
+		m.On("IsStalemate").Return(true)
+		m.On("UndoToEscape").Return(escapeMoves)
+
+		assertEscapeHint(t, new(SpiderCuiPresenter).Output(m, nil))
+	})
+	t.Run("Spiderette", func(t *testing.T) {
+		m := new(interfaces.MockSpideretteGame)
+		setupSpideretteCuiMockDefaults(m)
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "GetPhase")
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "IsStalemate")
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "UndoToEscape")
+		m.On("GetPhase").Return(domain.SpiderettePhasePlaying)
+		m.On("IsStalemate").Return(true)
+		m.On("UndoToEscape").Return(escapeMoves)
+
+		assertEscapeHint(t, new(SpideretteCuiPresenter).Output(m, nil))
+	})
+	t.Run("StreetsAndAlleys", func(t *testing.T) {
+		m := new(interfaces.MockStreetsAndAlleysGame)
+		setupStreetsAndAlleysCuiMockDefaults(m)
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "GetPhase")
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "IsStalemate")
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "UndoToEscape")
+		m.On("GetPhase").Return(domain.StreetsAndAlleysPhasePlaying)
+		m.On("IsStalemate").Return(true)
+		m.On("UndoToEscape").Return(escapeMoves)
+
+		assertEscapeHint(t, new(StreetsAndAlleysCuiPresenter).Output(m, nil))
+	})
+	t.Run("TriPeaks", func(t *testing.T) {
+		m := new(interfaces.MockTriPeaksGame)
+		setupTriPeaksCuiMockDefaults(m)
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "GetPhase")
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "IsStalemate")
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "UndoToEscape")
+		m.On("GetPhase").Return(domain.TriPeaksPhasePlaying)
+		m.On("IsStalemate").Return(true)
+		m.On("UndoToEscape").Return(escapeMoves)
+
+		assertEscapeHint(t, new(TriPeaksCuiPresenter).Output(m, nil))
+	})
+	t.Run("Wasp", func(t *testing.T) {
+		m := new(interfaces.MockWaspGame)
+		setupWaspCuiMockDefaults(m)
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "GetPhase")
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "IsStalemate")
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "UndoToEscape")
+		m.On("GetPhase").Return(domain.WaspPhasePlaying)
+		m.On("IsStalemate").Return(true)
+		m.On("UndoToEscape").Return(escapeMoves)
+
+		assertEscapeHint(t, new(WaspCuiPresenter).Output(m, nil))
+	})
+	t.Run("Yukon", func(t *testing.T) {
+		m := new(interfaces.MockYukonGame)
+		setupYukonCuiMockDefaults(m)
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "GetPhase")
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "IsStalemate")
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "UndoToEscape")
+		m.On("GetPhase").Return(domain.YukonPhasePlaying)
+		m.On("IsStalemate").Return(true)
+		m.On("UndoToEscape").Return(escapeMoves)
+
+		assertEscapeHint(t, new(YukonCuiPresenter).Output(m, nil))
+	})
+}
+
+// TestEverySolitaireStalemateBranchReportsTheEscapeCount is a structural guard.
+//
+// Six of the wired presenters (BakersGame, EightOff, FreeCell, Penguin, Pyramid,
+// SeahavenTowers) drive their tests from real domain objects rather than mocks, and a
+// freshly reset game has no undo history, so UndoToEscape() returns 0 and the
+// behavioural test above cannot reach them. This parses every CUI presenter instead.
+//
+// The rule is keyed on capability, not on a hardcoded list of game names: a presenter
+// must report UndoToEscape() in its IsStalemate() branch exactly when its own game
+// interface actually exposes that method. That way the guard needs no allowlist to
+// excuse Agnes / MonteCarlo / Osmosis / Bhabhi (whose interfaces do not expose it, so
+// they *cannot* report it), and it still fails the moment one of them gains the method
+// without reporting it -- or a brand-new solitaire presenter forgets the guidance.
+func TestEverySolitaireStalemateBranchReportsTheEscapeCount(t *testing.T) {
+	files, err := filepath.Glob("*CuiPresenter.go")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, files, "no presenters found -- the glob is wrong, not the code")
+
+	capable, missing, skipped := 0, []string{}, 0
+	for _, path := range files {
+		srcBytes, err := os.ReadFile(path) //nolint:gosec // test-only, fixed glob
+		assert.NoError(t, err)
+		src := string(srcBytes)
+		if !strings.Contains(src, "IsStalemate()") {
+			continue
+		}
+		if !gameInterfaceExposesUndoToEscape(t, src) {
+			skipped++
+			continue
+		}
+		capable++
+
+		fset := token.NewFileSet()
+		f, err := parser.ParseFile(fset, path, src, 0)
+		assert.NoError(t, err)
+
+		found := false
+		ast.Inspect(f, func(n ast.Node) bool {
+			ifStmt, ok := n.(*ast.IfStmt)
+			if !ok || !strings.Contains(exprText(fset, src, ifStmt.Cond), "IsStalemate()") {
+				return true
+			}
+			if strings.Contains(exprText(fset, src, ifStmt.Body), "UndoToEscape()") {
+				found = true
+			}
+			return true
+		})
+		if !found {
+			missing = append(missing, path)
+		}
+	}
+
+	// Negative control on the detection itself: if these counters collapse the guard
+	// is inspecting nothing and would pass no matter how broken the presenters were.
+	assert.Greater(t, capable, 40,
+		"far fewer capable presenters than expected -- the detection is broken, not the code")
+	assert.Greater(t, skipped, 0,
+		"expected some stalemate presenters whose interface cannot report an escape count")
+	assert.Empty(t, missing,
+		"these presenters branch on IsStalemate() and their interface exposes UndoToEscape(), but they never report it")
+}
+
+// gameInterfaceExposesUndoToEscape reports whether the game interface a presenter's
+// Output takes declares UndoToEscape, directly or via the embedded SolitaireGame.
+func gameInterfaceExposesUndoToEscape(t *testing.T, presenterSrc string) bool {
+	t.Helper()
+	m := regexp.MustCompile(`Output\(\w+ interfaces\.(\w+)Game`).FindStringSubmatch(presenterSrc)
+	if m == nil {
+		return false
+	}
+	ifacePath := filepath.Join("..", "..", "domain", "interfaces", strings.ToLower(m[1])+".go")
+	b, err := os.ReadFile(ifacePath) //nolint:gosec // test-only, derived from a matched identifier
+	if err != nil {
+		return false
+	}
+	body := string(b)
+	return strings.Contains(body, "UndoToEscape() int") || strings.Contains(body, "SolitaireGame")
+}
+
+// exprText returns the source text spanned by a node.
+func exprText(fset *token.FileSet, src string, n ast.Node) string {
+	return src[fset.Position(n.Pos()).Offset:fset.Position(n.End()).Offset]
+}

--- a/internal/adapter/presenter/cui_solitaire_stalemate_test.go
+++ b/internal/adapter/presenter/cui_solitaire_stalemate_test.go
@@ -300,14 +300,41 @@ func TestSolitaireCuiUndoToEscapeHint(t *testing.T) {
 
 		assertEscapeHint(t, new(YukonCuiPresenter).Output(m, nil))
 	})
+	// Pyramid and Gaps are mock-based like the 22 above, but their fixtures use a
+	// differently named constructor (setupXCuiMock returning the mock) rather than a
+	// setupXCuiMockDefaults(mock) helper, so they are wired here by hand.
+	t.Run("Pyramid", func(t *testing.T) {
+		m := setupPyramidCuiMock()
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "GetPhase")
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "IsStalemate")
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "UndoToEscape")
+		m.On("GetPhase").Return(domain.PyramidPhasePlaying)
+		m.On("IsStalemate").Return(true)
+		m.On("UndoToEscape").Return(escapeMoves)
+
+		assertEscapeHint(t, new(PyramidCuiPresenter).Output(m, nil))
+	})
+
+	t.Run("Gaps", func(t *testing.T) {
+		m := setupGapsCuiMock()
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "GetPhase")
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "IsStalemate")
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "UndoToEscape")
+		m.On("GetPhase").Return(domain.GapsPhasePlaying)
+		m.On("IsStalemate").Return(true)
+		m.On("UndoToEscape").Return(escapeMoves)
+
+		assertEscapeHint(t, new(GapsCuiPresenter).Output(m, nil))
+	})
 }
 
 // TestEverySolitaireStalemateBranchReportsTheEscapeCount is a structural guard.
 //
-// Six of the wired presenters (BakersGame, EightOff, FreeCell, Penguin, Pyramid,
-// SeahavenTowers) drive their tests from real domain objects rather than mocks, and a
+// Four of the wired presenters (BakersGame, EightOff, FreeCell, SeahavenTowers)
+// drive their tests from real domain objects rather than mocks, and a
 // freshly reset game has no undo history, so UndoToEscape() returns 0 and the
 // behavioural test above cannot reach them. This parses every CUI presenter instead.
+// (Penguin mixes both styles and is likewise only covered structurally.)
 //
 // The rule is keyed on capability, not on a hardcoded list of game names: a presenter
 // must report UndoToEscape() in its IsStalemate() branch exactly when its own game

--- a/internal/i18n/locales/en/cui_common.json
+++ b/internal/i18n/locales/en/cui_common.json
@@ -21,6 +21,7 @@
   "cuiHintWeakHand": "Weak hand",
   "cuiHintNone": "No hint available.",
   "cuiSolitaireStalemate": "Stalemate",
+  "cuiSolitaireUndoToEscape": "Undo {{count}} move(s) to escape the dead end (undo {{count}}, or repeat u)",
   "cuiSolitaireGameClear": "Game clear!",
   "cuiSolitaireGameOver": "Game over",
   "cuiSolitaireGameOverSummary": "Reached {{count}}/{{total}} cards on the foundations ({{percent}}%)",

--- a/internal/i18n/locales/ja/cui_common.json
+++ b/internal/i18n/locales/ja/cui_common.json
@@ -21,6 +21,7 @@
   "cuiHintWeakHand": "弱い手札",
   "cuiHintNone": "ヒントはありません。",
   "cuiSolitaireStalemate": "手詰まりです",
+  "cuiSolitaireUndoToEscape": "脱出には {{count}} 手戻す必要があります（undo {{count}} または u を繰り返す）",
   "cuiSolitaireGameClear": "ゲームクリア！",
   "cuiSolitaireGameOver": "ゲームオーバー",
   "cuiSolitaireGameOverSummary": "組札 {{count}}/{{total}} 枚（{{percent}}%）まで到達",


### PR DESCRIPTION
Closes #5472

## What

29 solitaires printed only `手詰まりです` on a dead end, while their web page offered a
`StalemateEscapeButton` telling the player how many undos reach a playable position again.
The CUI player could see they were stuck, but not that the game was *recoverable* — so the
only obvious move was to reset a deal that was still winnable.

`UndoToEscape()` already lives on the shared `interfaces.SolitaireGame` that all of these
embed, so this is wiring, not new logic.

## Two corrections to the issue

| issue says | actual | why |
|---|---|---|
| 78 pages use `undoToEscape` | **44** | the 78 counted `*.test.tsx` files |
| 27 games affected | **29** | `BakersGame` reuses the FreeCell domain rather than defining its own, so my filter skipped it; `Gaps` has no escape button on its page, but its interface exposes `UndoToEscape()` and its CUI branch never reported it |

## One deliberate deviation

The issue's acceptance criteria said to match the existing per-game key naming. I used a single
shared `cuiSolitaireUndoToEscape` in `cui_common.json` instead, because the existing 17 presenters
already use **three different wordings** between them:

- `"undoToEscape"` — 14 files
- `"undoToEscape"` — 1 file, different phrasing
- `"stalemateEscape"` — 2 files (Sultan, KingAlbert)

Adding 29 more per-game copies would deepen exactly the duplication `cui_common.json` exists to
prevent. The new key uses the dominant wording (14 of 15). **Migrating the existing 17 is
intentionally not in this PR** — it changes user-visible strings for games this issue does not
touch, and belongs in its own reviewable diff.

## Test plan

- [x] **24 games covered behaviourally** via their mock fixtures — stalemate forced, `UndoToEscape` stubbed to a positive value, asserting the banner, the guidance, and the count.
- [x] **Structural guard covers every presenter.** Four of the 29 (`BakersGame`, `EightOff`, `FreeCell`, `SeahavenTowers`; `Penguin` mixes both styles) drive tests from real domain objects, where a freshly reset game has no undo history so `UndoToEscape()` is 0 and no behavioural fixture can reach the line. The guard parses the sources instead.
- [x] **The guard is keyed on capability, not a name allowlist**: a stalemate branch must report `UndoToEscape()` exactly when its own game interface exposes it. Agnes / MonteCarlo / Osmosis / Bhabhi therefore need no excuse entry — and the guard starts failing the moment any of them gains the method without reporting it, or a new solitaire forgets it.
- [x] **Negative controls run on the guard itself:**
      - strip the hint from Yukon → fails with "…never report it"
      - point the glob at a non-existent pattern → fails with "the glob is wrong, not the code" (rather than vacuously passing on an empty set)
- [x] Existing stalemate tests keep passing: the 25 fixtures that never stubbed `UndoToEscape` now default it to **0**, so their assertions are unchanged. An earlier attempt defaulted it to a positive value and broke Bisley's `"stalemate with no escape hides the guidance"` negative test — that is why the default is 0.
- [x] `go test -tags test ./internal/adapter/presenter/` — passes
- [x] `golangci-lint run ./internal/adapter/presenter/...` — 0 issues
- [x] `goimports -l` — clean
- [x] ja/en placeholder parity for the new key


## Post-review corrections

Both review findings were correct and are fixed:

- **Dead mock stubs removed.** `MonteCarlo`/`Osmosis` picked up an `UndoToEscape` stub from the bulk fixture edit, but their mocks have no such method — testify registers by string name without validating, so the lines were silent no-ops. Scanned the mock sources for other instances: these two were the only ones.
- **Pyramid was misclassified by me.** `Pyramid` and `Gaps` are mock-based, not real-domain-based — they just use a `setup<G>CuiMock()` constructor rather than `setup<G>CuiMockDefaults(mock)`, so my generator skipped them. Both now have behavioural assertions (22 → **24**), verified by mutation.