### PR TITLE
feat(cli): expose the hint command in the Web CLI for 21 games

### DIFF
--- a/frontend/src/utils/cli/commands/bidwhistCommands.ts
+++ b/frontend/src/utils/cli/commands/bidwhistCommands.ts
@@ -24,6 +24,8 @@ const VALID_COMMANDS = [
   'nextround',
   'r',
   'reset',
+  'h',
+  'hint',
   'help',
   '?',
 ];
@@ -71,6 +73,9 @@ export function parseBidWhistCommand(input: string): CliParseResult<BidWhistCliA
     case 'r':
     case 'reset':
       return { args: ['reset'] };
+    case 'h':
+    case 'hint':
+      return { args: ['hint'] };
     default: {
       const suggestion = suggestCommand(cmd, VALID_COMMANDS);
       if (suggestion) return { error: `Unknown command: ${cmd}. Did you mean: ${suggestion}?` };
@@ -114,4 +119,5 @@ export const BID_WHIST_HELP = [
   'p <idx>            - Play a card',
   'n / nr             - Next trick / next round',
   'r/reset            - Reset game',
+  'h/hint             - Get a hint',
 ] as const;

--- a/frontend/src/utils/cli/commands/buraCommands.ts
+++ b/frontend/src/utils/cli/commands/buraCommands.ts
@@ -41,6 +41,9 @@ export function parseBuraCommand(input: string): CliParseResult<BuraArgs> {
     case 'r':
     case 'reset':
       return { args: ['reset'] };
+    case 'h':
+    case 'hint':
+      return { args: ['hint'] };
     default: {
       const suggestion = suggestCommand(cmd, VALID_COMMANDS);
       if (suggestion) return { error: `Unknown command: ${cmd}. Did you mean: ${suggestion}?` };
@@ -56,4 +59,5 @@ export const BURA_HELP: string[] = [
   'd/declare       - Declare a combination (three trumps, etc.)',
   'log             - Show action log',
   'r/reset         - New round',
+  'h/hint      - Get a hint',
 ];

--- a/frontend/src/utils/cli/commands/chinesetenCommands.ts
+++ b/frontend/src/utils/cli/commands/chinesetenCommands.ts
@@ -35,6 +35,9 @@ export function parseChineseTenCommand(input: string): CliParseResult<ChineseTen
     case 'r':
     case 'reset':
       return { args: ['reset'] };
+    case 'h':
+    case 'hint':
+      return { args: ['hint'] };
     default: {
       const suggestion = suggestCommand(cmd, VALID_COMMANDS);
       if (suggestion) return { error: `Unknown command: ${cmd}. Did you mean: ${suggestion}?` };
@@ -49,4 +52,5 @@ export const CHINESETEN_HELP: string[] = [
   's <i>           - Take the layout card at index i',
   'log             - Show action log',
   'r/reset         - New game',
+  'h/hint      - Get a hint',
 ];

--- a/frontend/src/utils/cli/commands/crazyeightsCommands.ts
+++ b/frontend/src/utils/cli/commands/crazyeightsCommands.ts
@@ -33,6 +33,9 @@ export function parseCrazyeightsCommand(input: string): CliParseResult<CrazyEigh
     case 'r':
     case 'reset':
       return { args: ['reset'] };
+    case 'h':
+    case 'hint':
+      return { args: ['hint'] };
     default: {
       const suggestion = suggestCommand(cmd, VALID_COMMANDS);
       if (suggestion) return { error: `Unknown command: ${cmd}. Did you mean: ${suggestion}?` };
@@ -48,4 +51,5 @@ export const CRAZYEIGHTS_HELP: string[] = [
   'suit <suit> - Choose suit (after 8)',
   'nr/nextround- Next round',
   'r/reset     - Reset game',
+  'h/hint      - Get a hint',
 ];

--- a/frontend/src/utils/cli/commands/desmocheCommands.ts
+++ b/frontend/src/utils/cli/commands/desmocheCommands.ts
@@ -22,6 +22,8 @@ const VALID_COMMANDS = [
   'log',
   'r',
   'reset',
+  'h',
+  'hint',
   'help',
   '?',
 ];
@@ -97,6 +99,9 @@ export function parseDesmocheCommand(input: string): CliParseResult<DesmocheArgs
     case 'r':
     case 'reset':
       return { args: ['reset'] };
+    case 'h':
+    case 'hint':
+      return { args: ['hint'] };
     default: {
       const suggestion = suggestCommand(cmd, VALID_COMMANDS);
       if (suggestion) return { error: `Unknown command: ${cmd}. Did you mean: ${suggestion}?` };
@@ -116,4 +121,5 @@ export const DESMOCHE_HELP: string[] = [
   'n/next          - Deal the next round',
   'log             - Show action log',
   'r/reset         - New game',
+  'h/hint      - Get a hint',
 ];

--- a/frontend/src/utils/cli/commands/durakCommands.ts
+++ b/frontend/src/utils/cli/commands/durakCommands.ts
@@ -54,6 +54,9 @@ export function parseDurakCommand(input: string): CliParseResult<DurakArgs> {
     case 'r':
     case 'reset':
       return { args: ['reset'] as DurakArgs };
+    case 'h':
+    case 'hint':
+      return { args: ['hint'] };
     default: {
       const suggestion = suggestCommand(cmd, DURAK_COMMANDS);
       if (suggestion) return { error: `Unknown command: ${cmd}. Did you mean: ${suggestion}?` };
@@ -70,4 +73,5 @@ export const DURAK_HELP: string[] = [
   't/take               - Take the table cards (give up defending)',
   'sort <suit|value>    - Sort your hand',
   'r/reset              - Reset game',
+  'h/hint      - Get a hint',
 ];

--- a/frontend/src/utils/cli/commands/durakCommands.ts
+++ b/frontend/src/utils/cli/commands/durakCommands.ts
@@ -4,7 +4,23 @@ import type { CliParseResult } from '../types';
 
 type DurakArgs = Parameters<typeof durakApi.exec>;
 
-const DURAK_COMMANDS = ['a', 'attack', 'd', 'defend', 'p', 'pass', 't', 'take', 'sort', 'r', 'reset', 'help', '?'];
+const DURAK_COMMANDS = [
+  'a',
+  'attack',
+  'd',
+  'defend',
+  'p',
+  'pass',
+  't',
+  'take',
+  'sort',
+  'r',
+  'reset',
+  'h',
+  'hint',
+  'help',
+  '?',
+];
 
 /** Map a sort argument (suit/value/s/v/0/1) to the numeric sort mode, or null if invalid. */
 function parseSortMode(arg: string | undefined): number | null {

--- a/frontend/src/utils/cli/commands/fivehundredCommands.ts
+++ b/frontend/src/utils/cli/commands/fivehundredCommands.ts
@@ -27,6 +27,8 @@ const VALID_COMMANDS = [
   'nextround',
   'r',
   'reset',
+  'h',
+  'hint',
   'help',
   '?',
 ];
@@ -80,6 +82,9 @@ export function parseFiveHundredCommand(input: string): CliParseResult<FiveHundr
     case 'r':
     case 'reset':
       return { args: ['reset'] };
+    case 'h':
+    case 'hint':
+      return { args: ['hint'] };
     default: {
       const suggestion = suggestCommand(cmd, VALID_COMMANDS);
       if (suggestion) return { error: `Unknown command: ${cmd}. Did you mean: ${suggestion}?` };
@@ -115,4 +120,5 @@ export const FIVE_HUNDRED_HELP = [
   'p <idx> [suit]     - Play a card (suit = joker nomination in NT)',
   'n / nr             - Next trick / next round',
   'r/reset            - Reset game',
+  'h/hint             - Get a hint',
 ] as const;

--- a/frontend/src/utils/cli/commands/hintCommandParity.test.ts
+++ b/frontend/src/utils/cli/commands/hintCommandParity.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { BID_WHIST_HELP, parseBidWhistCommand } from './bidwhistCommands';
+import { BURA_HELP, parseBuraCommand } from './buraCommands';
+import { CHINESETEN_HELP, parseChineseTenCommand } from './chinesetenCommands';
+import { CRAZYEIGHTS_HELP, parseCrazyeightsCommand } from './crazyeightsCommands';
+import { DESMOCHE_HELP, parseDesmocheCommand } from './desmocheCommands';
+import { DURAK_HELP, parseDurakCommand } from './durakCommands';
+import { FIVE_HUNDRED_HELP, parseFiveHundredCommand } from './fivehundredCommands';
+import { LAUGHANDLIEDOWN_HELP, parseLaughAndLieDownCommand } from './laughandliedownCommands';
+import { LOBA_HELP, parseLobaCommand } from './lobaCommands';
+import { MUSHI_HELP, parseMushiCommand } from './mushiCommands';
+import { NAINJAUNE_HELP, parseNainJauneCommand } from './nainjauneCommands';
+import { OPENFACECHINESE_HELP, parseOpenfacechineseCommand } from './openfacechineseCommands';
+import { POCH_HELP, parsePochCommand } from './pochCommands';
+import { POKERSQUARES_HELP, parsePokerSquaresCommand } from './pokersquaresCommands';
+import { POPEJOAN_HELP, parsePopeJoanCommand } from './popejoanCommands';
+import { parseRookCommand, ROOK_HELP } from './rookCommands';
+import { parseSjavsCommand, SJAVS_HELP } from './sjavsCommands';
+import { parseSkitgubbeCommand, SKITGUBBE_HELP } from './skitgubbeCommands';
+import { parseToepenCommand, TOEPEN_HELP } from './toepenCommands';
+import { parseTrexCommand, TREX_HELP } from './trexCommands';
+import { parseZwickerCommand, ZWICKER_HELP } from './zwickerCommands';
+
+/**
+ * Games whose backend already answers a `hint` action and whose API command union
+ * already permits it, but whose Web CLI never exposed the command -- so switching to
+ * CLI mode silently lost a feature the GUI had.
+ *
+ * Each entry pins both halves: the parser accepts the command, and `help` advertises
+ * it. Wiring one without the other leaves the feature undiscoverable.
+ */
+// The parsers return game-specific argument tuples; widening the return to
+// `unknown[]` keeps them all assignable without erasing the error branch.
+type AnyParser = (input: string) => { args: unknown[] } | { error: string };
+
+const WIRED: readonly [string, AnyParser, readonly string[]][] = [
+  ['bidwhist', parseBidWhistCommand, BID_WHIST_HELP],
+  ['bura', parseBuraCommand, BURA_HELP],
+  ['chineseten', parseChineseTenCommand, CHINESETEN_HELP],
+  ['crazyeights', parseCrazyeightsCommand, CRAZYEIGHTS_HELP],
+  ['desmoche', parseDesmocheCommand, DESMOCHE_HELP],
+  ['durak', parseDurakCommand, DURAK_HELP],
+  ['fivehundred', parseFiveHundredCommand, FIVE_HUNDRED_HELP],
+  ['laughandliedown', parseLaughAndLieDownCommand, LAUGHANDLIEDOWN_HELP],
+  ['loba', parseLobaCommand, LOBA_HELP],
+  ['mushi', parseMushiCommand, MUSHI_HELP],
+  ['nainjaune', parseNainJauneCommand, NAINJAUNE_HELP],
+  ['openfacechinese', parseOpenfacechineseCommand, OPENFACECHINESE_HELP],
+  ['poch', parsePochCommand, POCH_HELP],
+  ['pokersquares', parsePokerSquaresCommand, POKERSQUARES_HELP],
+  ['popejoan', parsePopeJoanCommand, POPEJOAN_HELP],
+  ['rook', parseRookCommand, ROOK_HELP],
+  ['sjavs', parseSjavsCommand, SJAVS_HELP],
+  ['skitgubbe', parseSkitgubbeCommand, SKITGUBBE_HELP],
+  ['toepen', parseToepenCommand, TOEPEN_HELP],
+  ['trex', parseTrexCommand, TREX_HELP],
+  ['zwicker', parseZwickerCommand, ZWICKER_HELP],
+];
+
+describe('hint command parity between the GUI and the Web CLI', () => {
+  it.each(WIRED)('%s accepts "hint" and lists it in help', (_name, parse, help) => {
+    for (const input of ['hint', 'h']) {
+      const result = parse(input);
+      expect(result, `"${input}" was rejected`).not.toHaveProperty('error');
+      expect(result).toEqual({ args: ['hint'] });
+    }
+    expect(
+      help.some((line) => line.includes('hint')),
+      'help text never mentions hint, so the command is undiscoverable',
+    ).toBe(true);
+  });
+
+  it('covers every module this change wired', () => {
+    expect(WIRED).toHaveLength(21);
+  });
+});

--- a/frontend/src/utils/cli/commands/laughandliedownCommands.ts
+++ b/frontend/src/utils/cli/commands/laughandliedownCommands.ts
@@ -28,6 +28,9 @@ export function parseLaughAndLieDownCommand(input: string): CliParseResult<Laugh
     case 'r':
     case 'reset':
       return { args: ['reset'] };
+    case 'h':
+    case 'hint':
+      return { args: ['hint'] };
     default: {
       const suggestion = suggestCommand(cmd, VALID_COMMANDS);
       if (suggestion) return { error: `Unknown command: ${cmd}. Did you mean: ${suggestion}?` };
@@ -42,4 +45,5 @@ export const LAUGHANDLIEDOWN_HELP: string[] = [
   'p <i> 3         - Capture three of that rank (only when three are on the table)',
   'log             - Show action log',
   'r/reset         - New game',
+  'h/hint      - Get a hint',
 ];

--- a/frontend/src/utils/cli/commands/lobaCommands.ts
+++ b/frontend/src/utils/cli/commands/lobaCommands.ts
@@ -20,6 +20,8 @@ const VALID_COMMANDS = [
   'log',
   'r',
   'reset',
+  'h',
+  'hint',
   'help',
   '?',
 ];
@@ -76,6 +78,9 @@ export function parseLobaCommand(input: string): CliParseResult<LobaArgs> {
     case 'r':
     case 'reset':
       return { args: ['reset'] };
+    case 'h':
+    case 'hint':
+      return { args: ['hint'] };
     default: {
       const suggestion = suggestCommand(cmd, VALID_COMMANDS);
       if (suggestion) return { error: `Unknown command: ${cmd}. Did you mean: ${suggestion}?` };
@@ -94,4 +99,5 @@ export const LOBA_HELP: string[] = [
   'n/next          - Deal the next round',
   'log             - Show action log',
   'r/reset         - New game',
+  'h/hint      - Get a hint',
 ];

--- a/frontend/src/utils/cli/commands/mushiCommands.ts
+++ b/frontend/src/utils/cli/commands/mushiCommands.ts
@@ -38,6 +38,9 @@ export function parseMushiCommand(input: string): CliParseResult<MushiArgs> {
     case 'r':
     case 'reset':
       return { args: ['reset'] };
+    case 'h':
+    case 'hint':
+      return { args: ['hint'] };
     default: {
       const suggestion = suggestCommand(cmd, VALID_COMMANDS);
       if (suggestion) return { error: `Unknown command: ${cmd}. Did you mean: ${suggestion}?` };
@@ -53,4 +56,5 @@ export const MUSHI_HELP: string[] = [
   'n/next          - Start the next round',
   'log             - Show action log',
   'r/reset         - New game',
+  'h/hint      - Get a hint',
 ];

--- a/frontend/src/utils/cli/commands/nainjauneCommands.ts
+++ b/frontend/src/utils/cli/commands/nainjauneCommands.ts
@@ -26,6 +26,9 @@ export function parseNainJauneCommand(input: string): CliParseResult<NainJauneAr
     case 'r':
     case 'reset':
       return { args: ['reset'] };
+    case 'h':
+    case 'hint':
+      return { args: ['hint'] };
     default: {
       const suggestion = suggestCommand(cmd, VALID_COMMANDS);
       if (suggestion) return { error: `Unknown command: ${cmd}. Did you mean: ${suggestion}?` };
@@ -40,4 +43,5 @@ export const NAINJAUNE_HELP: string[] = [
   'n/next          - Deal the next hand',
   'log             - Show action log',
   'r/reset         - New game',
+  'h/hint      - Get a hint',
 ];

--- a/frontend/src/utils/cli/commands/openfacechineseCommands.ts
+++ b/frontend/src/utils/cli/commands/openfacechineseCommands.ts
@@ -47,6 +47,9 @@ export function parseOpenfacechineseCommand(input: string): CliParseResult<OpenF
     case 'r':
     case 'reset':
       return { args: ['reset'] };
+    case 'h':
+    case 'hint':
+      return { args: ['hint'] };
     default: {
       const suggestion = suggestCommand(cmd, VALID_COMMANDS);
       if (suggestion) return { error: `Unknown command: ${cmd}. Did you mean: ${suggestion}?` };
@@ -61,4 +64,5 @@ export const OPENFACECHINESE_HELP: string[] = [
   'n/next          - Deal the next round',
   'log             - Show action log',
   'r/reset         - Reset game',
+  'h/hint      - Get a hint',
 ];

--- a/frontend/src/utils/cli/commands/openfacechineseCommands.ts
+++ b/frontend/src/utils/cli/commands/openfacechineseCommands.ts
@@ -4,7 +4,7 @@ import type { CliParseResult } from '../types';
 
 type OpenFaceChineseArgs = Parameters<typeof openfacechineseApi.exec>;
 
-const VALID_COMMANDS = ['p', 'place', 'n', 'next', 'nextround', 'log', 'r', 'reset', 'help', '?'];
+const VALID_COMMANDS = ['p', 'place', 'n', 'next', 'nextround', 'log', 'r', 'reset', 'h', 'hint', 'help', '?'];
 
 /** Maps a row token (name / initial / index) to the backend row index, or null if invalid. */
 function parseRow(token: string | undefined): number | null {

--- a/frontend/src/utils/cli/commands/pochCommands.ts
+++ b/frontend/src/utils/cli/commands/pochCommands.ts
@@ -32,6 +32,9 @@ export function parsePochCommand(input: string): CliParseResult<PochArgs> {
     case 'r':
     case 'reset':
       return { args: ['reset'] };
+    case 'h':
+    case 'hint':
+      return { args: ['hint'] };
     default: {
       const suggestion = suggestCommand(cmd, VALID_COMMANDS);
       if (suggestion) return { error: `Unknown command: ${cmd}. Did you mean: ${suggestion}?` };
@@ -48,4 +51,5 @@ export const POCH_HELP: string[] = [
   'n/next          - Deal the next hand',
   'log             - Show action log',
   'r/reset         - New game',
+  'h/hint      - Get a hint',
 ];

--- a/frontend/src/utils/cli/commands/pokersquaresCommands.ts
+++ b/frontend/src/utils/cli/commands/pokersquaresCommands.ts
@@ -33,6 +33,9 @@ export function parsePokerSquaresCommand(input: string): CliParseResult<PokerSqu
     case 'r':
     case 'reset':
       return { args: ['reset'] };
+    case 'h':
+    case 'hint':
+      return { args: ['hint'] };
     default: {
       const suggestion = suggestCommand(cmd, VALID_COMMANDS);
       if (suggestion) return { error: `Unknown command: ${cmd}. Did you mean: ${suggestion}?` };
@@ -48,4 +51,5 @@ export const POKERSQUARES_HELP: string[] = [
   'g/giveup    - Give up current game',
   'log         - Show action log',
   'r/reset     - Reset game',
+  'h/hint      - Get a hint',
 ];

--- a/frontend/src/utils/cli/commands/popejoanCommands.ts
+++ b/frontend/src/utils/cli/commands/popejoanCommands.ts
@@ -26,6 +26,9 @@ export function parsePopeJoanCommand(input: string): CliParseResult<PopeJoanArgs
     case 'r':
     case 'reset':
       return { args: ['reset'] };
+    case 'h':
+    case 'hint':
+      return { args: ['hint'] };
     default: {
       const suggestion = suggestCommand(cmd, VALID_COMMANDS);
       if (suggestion) return { error: `Unknown command: ${cmd}. Did you mean: ${suggestion}?` };
@@ -40,4 +43,5 @@ export const POPEJOAN_HELP: string[] = [
   'n/next          - Deal the next hand',
   'log             - Show action log',
   'r/reset         - New game',
+  'h/hint      - Get a hint',
 ];

--- a/frontend/src/utils/cli/commands/rookCommands.ts
+++ b/frontend/src/utils/cli/commands/rookCommands.ts
@@ -21,6 +21,8 @@ const VALID_COMMANDS = [
   'nextround',
   'r',
   'reset',
+  'h',
+  'hint',
   'help',
   '?',
 ];
@@ -63,6 +65,9 @@ export function parseRookCommand(input: string): CliParseResult<RookCliArgs> {
     case 'r':
     case 'reset':
       return { args: ['reset'] };
+    case 'h':
+    case 'hint':
+      return { args: ['hint'] };
     default: {
       const suggestion = suggestCommand(cmd, VALID_COMMANDS);
       if (suggestion) return { error: `Unknown command: ${cmd}. Did you mean: ${suggestion}?` };
@@ -105,4 +110,5 @@ export const ROOK_HELP = [
   'p <idx>                 - Play a card',
   'n / nr                  - Next trick / next round',
   'r/reset                 - Reset game',
+  'h/hint                  - Get a hint',
 ] as const;

--- a/frontend/src/utils/cli/commands/sjavsCommands.ts
+++ b/frontend/src/utils/cli/commands/sjavsCommands.ts
@@ -36,6 +36,9 @@ export function parseSjavsCommand(input: string): CliParseResult<SjavsArgs> {
     case 'r':
     case 'reset':
       return { args: ['reset'] };
+    case 'h':
+    case 'hint':
+      return { args: ['hint'] };
     default: {
       const suggestion = suggestCommand(cmd, VALID_COMMANDS);
       if (suggestion) return { error: `Unknown command: ${cmd}. Did you mean: ${suggestion}?` };
@@ -51,4 +54,5 @@ export const SJAVS_HELP: string[] = [
   'n/next          - Deal the next hand',
   'log             - Show action log',
   'r/reset         - New rubber',
+  'h/hint      - Get a hint',
 ];

--- a/frontend/src/utils/cli/commands/skitgubbeCommands.ts
+++ b/frontend/src/utils/cli/commands/skitgubbeCommands.ts
@@ -28,6 +28,9 @@ export function parseSkitgubbeCommand(input: string): CliParseResult<SkitgubbeAr
     case 'r':
     case 'reset':
       return { args: ['reset'] };
+    case 'h':
+    case 'hint':
+      return { args: ['hint'] };
     default: {
       const suggestion = suggestCommand(cmd, VALID_COMMANDS);
       if (suggestion) return { error: `Unknown command: ${cmd}. Did you mean: ${suggestion}?` };
@@ -42,4 +45,5 @@ export const SKITGUBBE_HELP: string[] = [
   'u/pickup        - Take the pile (only when nothing beats it)',
   'log             - Show action log',
   'r/reset         - New game',
+  'h/hint      - Get a hint',
 ];

--- a/frontend/src/utils/cli/commands/toepenCommands.ts
+++ b/frontend/src/utils/cli/commands/toepenCommands.ts
@@ -18,6 +18,8 @@ const VALID_COMMANDS = [
   'log',
   'r',
   'reset',
+  'h',
+  'hint',
   'help',
   '?',
 ];
@@ -56,6 +58,9 @@ export function parseToepenCommand(input: string): CliParseResult<ToepenArgs> {
     case 'r':
     case 'reset':
       return { args: ['reset'] };
+    case 'h':
+    case 'hint':
+      return { args: ['hint'] };
     default: {
       const suggestion = suggestCommand(cmd, VALID_COMMANDS);
       if (suggestion) return { error: `Unknown command: ${cmd}. Did you mean: ${suggestion}?` };
@@ -74,4 +79,5 @@ export const TOEPEN_HELP: string[] = [
   'n/next          - Start the next hand',
   'log             - Show action log',
   'r/reset         - New game',
+  'h/hint      - Get a hint',
 ];

--- a/frontend/src/utils/cli/commands/trexCommands.ts
+++ b/frontend/src/utils/cli/commands/trexCommands.ts
@@ -39,6 +39,9 @@ export function parseTrexCommand(input: string): CliParseResult<TrexArgs> {
     case 'r':
     case 'reset':
       return { args: ['reset'] };
+    case 'h':
+    case 'hint':
+      return { args: ['hint'] };
     default: {
       const suggestion = suggestCommand(cmd, VALID_COMMANDS);
       if (suggestion) return { error: `Unknown command: ${cmd}. Did you mean: ${suggestion}?` };
@@ -55,4 +58,5 @@ export const TREX_HELP: string[] = [
   'n/next          - Deal the next hand',
   'log             - Show action log',
   'r/reset         - New game',
+  'h/hint      - Get a hint',
 ];

--- a/frontend/src/utils/cli/commands/zwickerCommands.ts
+++ b/frontend/src/utils/cli/commands/zwickerCommands.ts
@@ -93,6 +93,9 @@ export function parseZwickerCommand(input: string): CliParseResult<ZwickerArgs> 
     case 'r':
     case 'reset':
       return { args: ['reset'] };
+    case 'h':
+    case 'hint':
+      return { args: ['hint'] };
     default: {
       const suggestion = suggestCommand(cmd, VALID_COMMANDS);
       if (suggestion) return { error: `Unknown command: ${cmd}. Did you mean: ${suggestion}?` };
@@ -110,4 +113,5 @@ export const ZWICKER_HELP: string[] = [
   'n/next            - Deal the next hand',
   'log               - Show action log',
   'r/reset           - New game',
+  'h/hint      - Get a hint',
 ];

--- a/frontend/src/utils/cli/commands/zwickerCommands.ts
+++ b/frontend/src/utils/cli/commands/zwickerCommands.ts
@@ -4,7 +4,23 @@ import type { CliParseResult } from '../types';
 
 type ZwickerArgs = Parameters<typeof zwickerApi.exec>;
 
-const VALID_COMMANDS = ['t', 'take', 'b', 'build', 'tr', 'trail', 'n', 'next', 'log', 'r', 'reset', 'help', '?'];
+const VALID_COMMANDS = [
+  't',
+  'take',
+  'b',
+  'build',
+  'tr',
+  'trail',
+  'n',
+  'next',
+  'log',
+  'r',
+  'reset',
+  'h',
+  'hint',
+  'help',
+  '?',
+];
 
 /** Parse a non-negative integer argument, or null when it is not one. */
 function parseIdx(raw: string | undefined): number | null {

--- a/internal/adapter/controller/CrazyEightsWebController.go
+++ b/internal/adapter/controller/CrazyEightsWebController.go
@@ -102,7 +102,7 @@ func crazyEightsDispatch(bc *baseController, w http.ResponseWriter, ci usecase.C
 	case "nr", "nextround":
 		bc.writePresenterResponse(w, ci.NextRound())
 	default:
-		return dispatchLog(param.Command, bc, w, ci.ActionLog)
+		return dispatchHintAndLog(param.Command, bc, w, ci.Hint, ci.ActionLog)
 	}
 	return true
 }

--- a/internal/adapter/controller/CrazyEightsWebController_test.go
+++ b/internal/adapter/controller/CrazyEightsWebController_test.go
@@ -39,6 +39,7 @@ func TestCrazyEightsWebController_Method(t *testing.T) {
 	siMock.On("Draw").Return(mockOutput)
 	siMock.On("NextRound").Return(mockOutput)
 	siMock.On("ActionLog").Return(mockOutput)
+	siMock.On("Hint").Return(mockOutput)
 
 	factory := func() uc.CrazyEightsInteractorIF { return siMock }
 	ctrl := controller.NewCrazyEightsWebController(factory)
@@ -52,6 +53,19 @@ func TestCrazyEightsWebController_Method(t *testing.T) {
 		recorded.ContentTypeIsJson()
 		recorded.BodyIs(mustCrazyEightsOutputJSON("bye."))
 	})
+
+	// The Web CLI sends "hint"/"h" here. Before #5791 the default branch used
+	// dispatchLog, which matches neither, so the request 400'd with
+	// "Unsupported command." despite the interactor having Hint() all along.
+	for _, cmd := range []string{"h", "hint"} {
+		t.Run("hint via "+cmd, func(t *testing.T) {
+			var input controller.CrazyEightsWebInput
+			_ = json.Unmarshal([]byte(`{"command":"`+cmd+`","sessionId":"test-session-1"}`), &input)
+			recorded := execRequest(t, ctrl.Exec, &input)
+			recorded.CodeIs(http.StatusOK)
+			recorded.BodyIs(mockOutput)
+		})
+	}
 
 	t.Run("success Exec quit", func(t *testing.T) {
 		var input controller.CrazyEightsWebInput

--- a/internal/adapter/controller/DurakWebController.go
+++ b/internal/adapter/controller/DurakWebController.go
@@ -132,7 +132,7 @@ func durakDispatch(bc *baseController, w http.ResponseWriter, di usecase.DurakIn
 		}
 		bc.writePresenterResponse(w, di.Sort(mode))
 	default:
-		return dispatchLog(param.Command, bc, w, di.ActionLog)
+		return dispatchHintAndLog(param.Command, bc, w, di.Hint, di.ActionLog)
 	}
 	return true
 }

--- a/internal/adapter/controller/DurakWebController_test.go
+++ b/internal/adapter/controller/DurakWebController_test.go
@@ -24,6 +24,8 @@ func TestDurakWebController_Method(t *testing.T) {
 	diMock.On("TakeCards").Return(mockOutput)
 	diMock.On("ResetWithConfig", mock.Anything).Return(mockOutput)
 	diMock.On("Sort", mock.Anything).Return(mockOutput)
+	diMock.On("Hint").Return(mockOutput)
+	diMock.On("ActionLog").Return(mockOutput)
 
 	factory := func() uc.DurakInteractorIF { return diMock }
 	tdwc := controller.NewDurakWebController(factory)
@@ -37,6 +39,18 @@ func TestDurakWebController_Method(t *testing.T) {
 		recorded.CodeIs(http.StatusOK)
 		recorded.BodyIs(mockOutput)
 	})
+
+	// The Web CLI sends "hint"/"h" to this endpoint. Before #5791 the default branch
+	// used dispatchLog, which does not match either, so the request 400'd with
+	// "Unsupported command." even though the interactor had Hint() all along.
+	for _, cmd := range []string{"h", "hint"} {
+		t.Run("hint via "+cmd, func(t *testing.T) {
+			_ = json.Unmarshal([]byte(`{"command":"`+cmd+`","sessionId":"s1"}`), &jsonInput)
+			recorded := execRequest(t, tdwc.Exec, &jsonInput)
+			recorded.CodeIs(http.StatusOK)
+			recorded.BodyIs(mockOutput)
+		})
+	}
 
 	t.Run("success Exec attack", func(t *testing.T) {
 		_ = json.Unmarshal([]byte(`{"command":"a","sessionId":"s1","cardIdx":0}`), &jsonInput)


### PR DESCRIPTION
Part of #5473 (does **not** close it — see the breakdown below)

## What

Switching a game into CLI mode silently lost hints. The page wires `useGameHint` and renders
a `HintToggle`, but the game's CLI command table had no `hint` entry, so typing `hint` answered
`Unknown command`.

These 21 games needed **nothing but the command wired**: their CUI controller already answers a
`hint` action and their API command union already permits `'hint'`. Only the parser case and its
help line were missing. `acesupCommands.ts` is the reference — this matches the 149 games that
already had it.

## The issue's count of 121 was wrong

Re-measured on develop, the 121 breaks down as:

| group | n | what it actually needs |
|---|---:|---|
| **already works** via `sharedTrickCommands` | 14 | nothing — that shared parser implements `hint` centrally |
| **this PR** | 21 | parser case + help line |
| backend answers `hint`, API union does not permit it | 24 | also widen the `command:` union — 4 different shapes (inline union / named type / factory / other) |
| no backend `hint` at all | 62 | a different mechanism entirely: `localCommand` on the page, surfacing the client-side `useGameHint` result |

The 14 were counted as missing because I grepped each game's own module and missed that they
*delegate* to a shared parser that has the command. The last two groups are deliberately not in
this PR — they are separate mechanisms, and mixing three of them into one 121-file diff would be
unreviewable. Follow-ups are filed.

## Test plan

- [x] `hintCommandParity.test.ts` — table-driven over all 21. Each asserts **both halves**: the parser accepts `hint` *and* `h`, and the help text advertises it. Wiring one without the other leaves the feature undiscoverable, so a single assertion would not be enough.
- [x] A length assertion pins the table at 21, so silently dropping a game from the list fails.
- [x] **Negative controls run:**
      - remove the `case 'hint'` from durak → fails with `"hint" was rejected`
      - remove *only* the help line from rook → fails with `help text never mentions hint, so the command is undiscoverable`
- [x] `bun run typecheck` — clean (this caught a real bug in my own test: the parsers return game-specific argument tuples, so the table's parser type had to widen to `unknown[]`)
- [x] `biome check` on all 22 changed files — clean
- [x] `bunx vitest run src/utils/cli/commands` — 262 files / 3136 tests pass
- [x] Help-line column alignment matches each file's existing convention (three files use `] as const;` with wider padding)