### PR TITLE
feat(cli): make the Web CLI hint command work for 24 more games

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2655,6 +2655,7 @@ paths:
         | `declare`     | `dc`    | Declare "Macau!" (one card left) |
         | `skipdeclare` | `sk`    | Skip the declaration and take the penalty |
         | `nextround`   | `nr`    | Score the round and start the next |
+        | `hint`        | `h`     | Get a hint for the next move |
         | `log`         | `l`     | View action log |
       operationId: macauExec
       requestBody:
@@ -3216,6 +3217,7 @@ paths:
         | `layoff`      | `lo`    | Add one card to an existing meld (`targetPlayerIdx`, `meldIdx`, `cardIndex`) |
         | `discard`     | `d`     | Discard a card (`cardIndex`) |
         | `nextround`   | `nr`    | Start the next round |
+        | `hint`        | `h`     | Get a hint for the next move |
         | `log`         | `l`     | View action log |
       operationId: sevenbridgeExec
       requestBody:
@@ -3394,6 +3396,7 @@ paths:
         | `discard`      | `d`     | Discard a card (requires `cardIndex`) |
         | `goout`        | `go`    | Go out (requires 1 red and 1 black canasta) |
         | `nextround`    | `nr`    | Score the round and start the next |
+        | `hint`         | `h`     | Get a hint for the next move |
         | `log`          | `l`     | View action log |
       operationId: handAndFootExec
       requestBody:
@@ -3480,6 +3483,7 @@ paths:
         | `discard`      | `d`     | Discard a card (requires `cardIndex`) |
         | `goout`        | `go`    | Go out (requires the pozzetto and at least 1 burraco) |
         | `nextround`    | `nr`    | Score the round and start the next |
+        | `hint`         | `h`     | Get a hint for the next move |
         | `log`          | `l`     | View action log |
       operationId: burracoExec
       requestBody:
@@ -3862,6 +3866,7 @@ paths:
         | `reset` | `r`     | Start / restart a game |
         | `bet`   | `b`     | Place a bet (requires `amount`: 1-5) |
         | `hold`  | `h`     | Hold cards and draw (requires `indices`: array of card positions 0-4) |
+        | `hint`  | `h`     | Get a hint for the next move |
         | `log`   | `l`     | View action log |
       operationId: videoPokerExec
       requestBody:
@@ -4350,6 +4355,7 @@ paths:
         | `nextround`      | `nr`  | Start the next round |
         | `setdifficulty`  | `sd`  | Set CPU difficulty (0=Easy, 1=Normal, 2=Hard) |
         | `setlimit`       | `sl`  | Set point limit |
+        | `hint`           | `h`   | Get a hint for the next move |
         | `log`            | `l`   | View action log |
       operationId: cribbageExec
       requestBody:
@@ -4440,6 +4446,7 @@ paths:
         | `bet`   | `b`     | Place Ante bet (requires `amount`; optional `pairPlusBet`) |
         | `play`  | `p`     | Place Play bet (equal to Ante) and see dealer's hand |
         | `fold`  | `f`     | Forfeit Ante and Pair Plus bets |
+        | `hint`  | `h`     | Get a hint for the next move |
         | `log`   | `l`     | View action log |
       operationId: threecardExec
       requestBody:
@@ -4614,6 +4621,7 @@ paths:
         | `layoff`      | `lo`    | Lay off a card onto an existing meld |
         | `discard`     | `d`     | Discard a card to end the turn |
         | `nextround`   | `nr`    | Advance to the next round after RoundEnd |
+        | `hint`        | `h`     | Get a hint for the next move |
         | `log`         | `l`     | View action log |
       operationId: rummy500Exec
       requestBody:
@@ -4775,6 +4783,7 @@ paths:
         | `bet`   | `b`     | Place Ante bet (requires `amount`; optional `jackpotBet`) |
         | `play`  | `p`     | Call: place Play bet (2x Ante) and reveal dealer hand |
         | `fold`  | `f`     | Forfeit Ante bet |
+        | `hint`  | `h`     | Get a hint for the next move |
         | `log`   | `l`     | View action log |
       operationId: caribbeanstudExec
       requestBody:
@@ -4976,6 +4985,7 @@ paths:
         | `bet`   | `b`     | Place Ante bet (requires `amount`; optional `bonusBet`) |
         | `call`  | `c`     | Bet 2x Ante and reveal turn/river |
         | `fold`  | `f`     | Forfeit Ante (AA Bonus still resolves) |
+        | `hint`  | `h`     | Get a hint for the next move |
         | `log`   | `l`     | View action log |
       operationId: casinoholdemExec
       requestBody:
@@ -5938,6 +5948,7 @@ paths:
         | `muck`  | `m`     | Muck (hide) hand at showdown |
         | `show`  | `sh`    | Show hand at showdown |
         | `log`   | `l`     | View action log |
+        | `hint`  | `h`     | Get a hint for the next move |
         | `quit`  | `q`     | End the session |
       operationId: sevencardstudExec
       requestBody:
@@ -10489,6 +10500,7 @@ paths:
         | `reset` | `r`     | Start / restart a game |
         | `bet`   | `b`     | Place bet (requires `amount`) |
         | `set`   | `s`     | Set low hand cards (requires `low0`, `low1` as card indices) |
+        | `hint`  | `h`     | Get a hint for the next move |
         | `log`   | `l`     | View action log |
       operationId: paigowExec
       requestBody:
@@ -10574,6 +10586,7 @@ paths:
         | `reset` | `r`     | Start / restart a game |
         | `bet`   | `b`     | Place bet (requires `amount`) |
         | `set`   | `s`     | Set hands (requires `frontIndices` [3] and `middleIndices` [5]) |
+        | `hint`  | `h`     | Get a hint for the next move |
         | `log`   | `l`     | View action log |
       operationId: chinesepokerExec
       requestBody:
@@ -12769,6 +12782,7 @@ paths:
         | `draw`  | `d`     | Draw one card from the stock |
         | `place` | `p`     | Place the pending wild at `position` (1..10) |
         | `cpu`   | —       | Advance the CPU turn by one step |
+        | `hint`  | `h`     | Get a hint for the next move |
         | `log`   | `l`     | View action log (available after game over) |
       operationId: trashExec
       requestBody:
@@ -12781,7 +12795,7 @@ paths:
               properties:
                 command:
                   type: string
-                  enum: [reset, r, draw, d, place, p, cpu, log, l, quit, q]
+                  enum: [reset, r, draw, d, place, p, cpu, log, l, quit, q, hint, h]
                 sessionId:
                   type: string
                 position:
@@ -13211,6 +13225,7 @@ paths:
         | `bet`   | `b`     | Place ante (requires `amount`) |
         | `raise` | —       | Raise before third card (requires `amount`, max ante) |
         | `stay`  | `s`     | Stay (no raise) and draw third card |
+        | `hint`  | `h`     | Get a hint for the next move |
         | `log`   | —       | View action log |
       operationId: reddogExec
       requestBody:
@@ -13493,6 +13508,7 @@ paths:
         | `allin`  | `a`     | Go all-in |
         | `exchange` | `e`   | Draw the cards at `indices` (0..3) |
         | `stand`  | `s`     | Stand pat (no exchange) |
+        | `hint`   | `h`     | Get a hint for the next move |
         | `log`    | `l`     | View action log |
       operationId: badugiExec
       requestBody:
@@ -13505,7 +13521,7 @@ paths:
               properties:
                 command:
                   type: string
-                  enum: [reset, r, fold, f, check, ck, call, c, bet, b, raise, ra, allin, a, exchange, e, stand, s, log, l]
+                  enum: [reset, r, fold, f, check, ck, call, c, bet, b, raise, ra, allin, a, exchange, e, stand, s, log, l, hint, h]
                 sessionId:
                   type: string
                 amount:
@@ -13602,6 +13618,7 @@ paths:
         | `allin`  | `a`     | Go all-in |
         | `exchange` | `e`   | Draw the cards at `indices` (0..4) |
         | `stand`  | `s`     | Stand pat (no exchange) |
+        | `hint`   | `h`     | Get a hint for the next move |
         | `log`    | `l`     | View action log |
       operationId: deuceToSevenExec
       requestBody:
@@ -13614,7 +13631,7 @@ paths:
               properties:
                 command:
                   type: string
-                  enum: [reset, r, fold, f, check, ck, call, c, bet, b, raise, ra, allin, a, exchange, e, stand, s, log, l]
+                  enum: [reset, r, fold, f, check, ck, call, c, bet, b, raise, ra, allin, a, exchange, e, stand, s, log, l, hint, h]
                 sessionId:
                   type: string
                 amount:
@@ -13693,6 +13710,7 @@ paths:
         |----------|---------|-------------|
         | `reset`  | `r`     | Start / restart a game |
         | `play`   | `p`     | Play cards at `indices` (empty = pass) |
+        | `hint`   | `h`     | Get a hint for the next move |
         | `log`    | `l`     | View action log |
       operationId: presidentExec
       requestBody:
@@ -13753,6 +13771,7 @@ paths:
         | `build` | `b`     | Create or extend a build of declared value |
         | `trail` | `tr`    | Place the played hand card on the table without capture |
         | `next`  | `n`     | Start the next round |
+        | `hint`  | `h`     | Get a hint for the next move |
         | `log`   | `l`     | View action log |
       operationId: cassinoExec
       requestBody:
@@ -13822,6 +13841,7 @@ paths:
         | `reset` | `r`     | Start / restart a game |
         | `next`  | `n`     | Start the next round |
         | `play`  | `p`     | Play a hand card to capture table cards or lay it |
+        | `hint`  | `h`     | Get a hint for the next move |
         | `log`   | `l`     | View action log |
       operationId: scopaExec
       requestBody:
@@ -13887,6 +13907,7 @@ paths:
         | `play`          | `p`  | Play a hand card to capture table cards or lay it |
         | `setdifficulty` | `sd` | Set CPU difficulty (0-2) |
         | `settarget`     | `st` | Set the target score |
+        | `hint`          | `h`  | Get a hint for the next move |
         | `log`           | `l`  | View action log |
       operationId: scoponeExec
       requestBody:
@@ -13953,6 +13974,7 @@ paths:
         | `play`          | `p`  | Play a hand card to capture table cards or lay it |
         | `setdifficulty` | `sd` | Set CPU difficulty (0-2) |
         | `settarget`     | `st` | Set the target score |
+        | `hint`          | `h`  | Get a hint for the next move |
         | `log`           | `l`  | View action log |
       operationId: escobaExec
       requestBody:
@@ -14012,6 +14034,7 @@ paths:
         | `next`     | `n`     | Start the next deal |
         | `contract` | `c`     | Dealer picks a contract (trumpSuit only for Trumps) |
         | `play`     | `p`     | Play a hand card (handIndex -1 to pass in Dominoes) |
+        | `hint`     | `h`     | Get a hint for the next move |
         | `log`      | `l`     | View action log |
       operationId: barbuExec
       requestBody:
@@ -17806,6 +17829,7 @@ paths:
         | `discard` | `d`     | Discard the two hand `indices` |
         | `play`    | `p`     | Play `cardIndex` |
         | `next`    | `n`     | Deal the next hand |
+        | `hint`    | `h`     | Get a hint for the next move |
         | `log`     | `l`     | Action-log transcript |
       operationId: kaiserExec
       requestBody:
@@ -17820,7 +17844,7 @@ paths:
               properties:
                 command:
                   type: string
-                  enum: [reset, r, bid, b, pass, ps, trump, t, discard, d, play, p, next, n, log, l]
+                  enum: [reset, r, bid, b, pass, ps, trump, t, discard, d, play, p, next, n, log, l, hint, h]
                 sessionId:
                   type: string
                 bid:
@@ -19176,6 +19200,7 @@ paths:
         | `discard`     | `d`     | Discard a card (requires `cardIndex`) |
         | `knock`       | `k`     | Knock (stand pat) |
         | `nextround`   | `nr`    | Score the round and start the next |
+        | `hint`        | `h`     | Get a hint for the next move |
         | `log`         | `l`     | View action log |
       operationId: thirtyoneExec
       requestBody:
@@ -19903,6 +19928,7 @@ paths:
         | `play`  | `p`     | Place Play bet (`multiplier` ∈ {1, 2, 3, 4}) |
         | `check` | `c`     | Pre-flop / Flop: advance without an additional bet |
         | `fold`  | `f`     | River: forfeit Ante + Blind |
+        | `hint`  | `h`     | Get a hint for the next move |
         | `log`   | `l`     | View action log |
       operationId: ultimatetexasholdemExec
       requestBody:
@@ -19983,6 +20009,7 @@ paths:
         | `bet`   | `b`     | Place Ante (`amount`) |
         | `play`  | `p`     | Place street bet (`multiplier` ∈ {1, 2, 3}) |
         | `fold`  | `f`     | Forfeit all bets on the table |
+        | `hint`  | `h`     | Get a hint for the next move |
         | `log`   | `l`     | View action log |
       operationId: mississippistudExec
       requestBody:
@@ -20331,6 +20358,7 @@ paths:
         | `stand`    | `s`     | Skip exchange, advance to action |
         | `play`     | `p`     | Call: place Play bet (2x Ante) and reveal dealer hand |
         | `fold`     | `f`     | Forfeit Ante bet and exchange fee |
+        | `hint`     | `h`     | Get a hint for the next move |
         | `log`      | `l`     | View action log |
       operationId: oasispokerExec
       requestBody:
@@ -20987,6 +21015,7 @@ paths:
         | `bet` / `b`     |         | Place Ante + optional Flush Bonus + Straight Flush Bonus |
         | `raise` / `ra`  |         | Raise with multiplier 1..MaxRaiseMultiplier |
         | `fold` / `f`    |         | Fold and forfeit the Ante (side bets still evaluate) |
+        | `hint` / `h`    |         | Get a hint for the next move |
         | `log` / `l`     |         | View action log |
       operationId: highcardflushExec
       requestBody:
@@ -21001,7 +21030,7 @@ paths:
               properties:
                 command:
                   type: string
-                  enum: [reset, r, bet, b, raise, ra, fold, f, log, l]
+                  enum: [reset, r, bet, b, raise, ra, fold, f, log, l, hint, h]
                 amount:
                   type: integer
                   description: Ante amount for `bet`/`b`
@@ -21091,6 +21120,7 @@ paths:
         | `flip`        | `fl`    | Flip a face-down grid card (requires `position`) |
         | `skipflip`    | `sf`    | Skip the optional flip |
         | `nextround`   | `nr`    | Advance to the next round |
+        | `hint`        | `h`     | Get a hint for the next move |
         | `log`         | `l`     | View action log |
       operationId: sixcardgolfExec
       requestBody:
@@ -21105,7 +21135,7 @@ paths:
               properties:
                 command:
                   type: string
-                  enum: [reset, r, flipinitial, fi, drawstock, ds, drawdiscard, dd, swap, sw, discard, di, flip, fl, skipflip, sf, nextround, nr, log, l]
+                  enum: [reset, r, flipinitial, fi, drawstock, ds, drawdiscard, dd, swap, sw, discard, di, flip, fl, skipflip, sf, nextround, nr, log, l, hint, h]
                 position:
                   type: integer
                   description: Grid slot index (0-5) for flipinitial, swap, and flip commands
@@ -37962,8 +37992,8 @@ components:
           description: |
             Game command.  Accepted values: `reset` (`r`), `play` (`p`),
             `draw` (`d`), `suit` (`s`), `declare` (`dc`), `skipdeclare` (`sk`),
-            `nextround` (`nr`), `log` (`l`).
-          enum: [reset, r, play, p, draw, d, suit, s, declare, dc, skipdeclare, sk, nextround, nr, log, l]
+            `nextround` (`nr`), `log` (`l`), `hint` (`h`).
+          enum: [reset, r, play, p, draw, d, suit, s, declare, dc, skipdeclare, sk, nextround, nr, log, l, hint, h]
           example: reset
         cardIndex:
           type: integer
@@ -38227,8 +38257,8 @@ components:
           description: |
             Game command.  Accepted values: `reset` (`r`), `play` (`p`),
             `draw` (`d`), `declare` (`dc`), `skip` (`sk`),
-            `nextround` (`nr`), `log` (`l`).
-          enum: [reset, r, play, p, draw, d, declare, dc, skip, sk, nextround, nr, log, l]
+            `nextround` (`nr`), `log` (`l`), `hint` (`h`).
+          enum: [reset, r, play, p, draw, d, declare, dc, skip, sk, nextround, nr, log, l, hint, h]
           example: reset
         cardIndex:
           type: integer
@@ -38325,8 +38355,8 @@ components:
           description: |
             Seven Bridge command. Accepted values: `reset` (`r`),
             `drawstock` (`ds`), `pon`, `chi`, `meld` (`m`),
-            `layoff` (`lo`), `discard` (`d`), `nextround` (`nr`), `log` (`l`).
-          enum: [reset, r, drawstock, ds, pon, chi, meld, m, layoff, lo, discard, d, nextround, nr, log, l]
+            `layoff` (`lo`), `discard` (`d`), `nextround` (`nr`), `log` (`l`), `hint` (`h`).
+          enum: [reset, r, drawstock, ds, pon, chi, meld, m, layoff, lo, discard, d, nextround, nr, log, l, hint, h]
           example: reset
         cardIndex:
           type: integer
@@ -39076,8 +39106,8 @@ components:
           description: |
             Game command. Accepted values: `reset` (`r`), `drawstock` (`ds`),
             `drawdiscard` (`dd`), `discard` (`d`), `knock` (`k`),
-            `nextround` (`nr`), `log` (`l`).
-          enum: [reset, r, drawstock, ds, drawdiscard, dd, discard, d, knock, k, nextround, nr, log, l]
+            `nextround` (`nr`), `log` (`l`), `hint` (`h`).
+          enum: [reset, r, drawstock, ds, drawdiscard, dd, discard, d, knock, k, nextround, nr, log, l, hint, h]
           example: reset
         cardIndex:
           type: integer
@@ -39719,8 +39749,8 @@ components:
           description: |
             Game command.  Accepted values: `reset` (`r`), `drawstock` (`ds`),
             `drawdiscard` (`dd`), `meld` (`m`), `skipmeld` (`sm`),
-            `discard` (`d`), `goout` (`go`), `nextround` (`nr`), `log` (`l`).
-          enum: [reset, r, drawstock, ds, drawdiscard, dd, meld, m, skipmeld, sm, discard, d, goout, go, nextround, nr, log, l]
+            `discard` (`d`), `goout` (`go`), `nextround` (`nr`), `log` (`l`), `hint` (`h`).
+          enum: [reset, r, drawstock, ds, drawdiscard, dd, meld, m, skipmeld, sm, discard, d, goout, go, nextround, nr, log, l, hint, h]
           example: reset
         cardIndex:
           type: integer
@@ -39879,8 +39909,8 @@ components:
           description: |
             Game command.  Accepted values: `reset` (`r`), `drawstock` (`ds`),
             `drawdiscard` (`dd`), `meld` (`m`), `skipmeld` (`sm`),
-            `discard` (`d`), `goout` (`go`), `nextround` (`nr`), `log` (`l`).
-          enum: [reset, r, drawstock, ds, drawdiscard, dd, meld, m, skipmeld, sm, discard, d, goout, go, nextround, nr, log, l]
+            `discard` (`d`), `goout` (`go`), `nextround` (`nr`), `log` (`l`), `hint` (`h`).
+          enum: [reset, r, drawstock, ds, drawdiscard, dd, meld, m, skipmeld, sm, discard, d, goout, go, nextround, nr, log, l, hint, h]
           example: reset
         cardIndex:
           type: integer
@@ -40943,8 +40973,8 @@ components:
           type: string
           description: |
             Game command.  Accepted values: `reset` (`r`), `bet` (`b`),
-            `hold` (`h`), `log` (`l`).
-          enum: [reset, r, bet, b, hold, h, log, l]
+            `hold` (`h`), `log` (`l`), `hint` (`h`).
+          enum: [reset, r, bet, b, hold, h, log, l, hint, h]
           example: reset
         amount:
           type: integer
@@ -41460,8 +41490,8 @@ components:
           description: |
             Game command.  Accepted values: `reset` (`r`), `discard` (`d`),
             `peg` (`p`), `go`, `shownext` (`sn`), `nextround` (`nr`),
-            `setdifficulty` (`sd`), `setlimit` (`sl`), `log` (`l`).
-          enum: [reset, r, discard, d, peg, p, go, shownext, sn, nextround, nr, setdifficulty, sd, setlimit, sl, log, l]
+            `setdifficulty` (`sd`), `setlimit` (`sl`), `log` (`l`), `hint` (`h`).
+          enum: [reset, r, discard, d, peg, p, go, shownext, sn, nextround, nr, setdifficulty, sd, setlimit, sl, log, l, hint, h]
           example: discard
         cardIndex:
           type: integer
@@ -41670,8 +41700,8 @@ components:
           type: string
           description: |
             Game command.  Accepted values: `reset` (`r`), `bet` (`b`),
-            `play` (`p`), `fold` (`f`), `log` (`l`).
-          enum: [r, reset, b, bet, p, play, f, fold, log, l]
+            `play` (`p`), `fold` (`f`), `log` (`l`), `hint` (`h`).
+          enum: [r, reset, b, bet, p, play, f, fold, log, l, hint, h]
           example: bet
         amount:
           type: integer
@@ -41958,8 +41988,8 @@ components:
           type: string
           description: |
             Game command. Accepted values: `reset` (`r`), `bet` (`b`),
-            `play` (`p`), `fold` (`f`), `log` (`l`).
-          enum: [r, reset, b, bet, p, play, f, fold, log, l]
+            `play` (`p`), `fold` (`f`), `log` (`l`), `hint` (`h`).
+          enum: [r, reset, b, bet, p, play, f, fold, log, l, hint, h]
           example: bet
         amount:
           type: integer
@@ -42241,8 +42271,8 @@ components:
           type: string
           description: |
             Game command. Accepted values: `reset` (`r`), `bet` (`b`),
-            `call` (`c`), `fold` (`f`), `log` (`l`).
-          enum: [r, reset, b, bet, c, call, f, fold, log, l]
+            `call` (`c`), `fold` (`f`), `log` (`l`), `hint` (`h`).
+          enum: [r, reset, b, bet, c, call, f, fold, log, l, hint, h]
           example: bet
         amount:
           type: integer
@@ -43480,7 +43510,7 @@ components:
             `allin` (`a`), `rebuy` (`rb`), `skiprebuy` (`sr`),
             `addon` (`ad`), `skipaddon` (`sa`), `muck` (`m`),
             `show` (`sh`), `log` (`l`), `quit` (`q`).
-          enum: [r, reset, f, fold, ck, check, c, call, b, bet, ra, raise, a, allin, rb, rebuy, sr, skiprebuy, ad, addon, sa, skipaddon, m, muck, sh, show, log, l, q, quit]
+          enum: [r, reset, f, fold, ck, check, c, call, b, bet, ra, raise, a, allin, rb, rebuy, sr, skiprebuy, ad, addon, sa, skipaddon, m, muck, sh, show, log, l, q, quit, hint, h]
           example: bet
         amount:
           type: integer
@@ -44052,8 +44082,8 @@ components:
           type: string
           description: |
             Game command.  Accepted values: `reset` (`r`), `bet` (`b`),
-            `set` (`s`), `log` (`l`).
-          enum: [r, reset, b, bet, s, set, log, l]
+            `set` (`s`), `log` (`l`), `hint` (`h`).
+          enum: [r, reset, b, bet, s, set, log, l, hint, h]
           example: bet
         amount:
           type: integer
@@ -44478,7 +44508,7 @@ components:
       properties:
         command:
           type: string
-          enum: [reset, r, bet, b, raise, stay, s, log]
+          enum: [reset, r, bet, b, raise, stay, s, log, hint, h]
           description: Game command to execute.
         amount:
           type: integer
@@ -45998,7 +46028,7 @@ components:
         command:
           type: string
           description: President command. Accepted values. `reset` (`r`), `play` (`p`), `log` (`l`).
-          enum: [reset, r, play, p, log, l]
+          enum: [reset, r, play, p, log, l, hint, h]
           example: reset
         indices:
           type: array
@@ -46112,7 +46142,7 @@ components:
         command:
           type: string
           description: Cassino command. Accepted values. `reset` (`r`), `take` (`t`), `build` (`b`), `trail` (`tr`), `next` (`n`), `log` (`l`).
-          enum: [reset, r, take, t, build, b, trail, tr, next, n, log, l]
+          enum: [reset, r, take, t, build, b, trail, tr, next, n, log, l, hint, h]
           example: take
         handIndex:
           type: integer
@@ -46291,7 +46321,7 @@ components:
         command:
           type: string
           description: Scopa command. Accepted values. `reset` (`r`), `next` (`n`), `play` (`p`), `log` (`l`).
-          enum: [reset, r, next, n, play, p, log, l]
+          enum: [reset, r, next, n, play, p, log, l, hint, h]
           example: play
         handIndex:
           type: integer
@@ -46441,7 +46471,7 @@ components:
         command:
           type: string
           description: Scopone command. Accepted values. `reset` (`r`), `next` (`n`), `play` (`p`), `setdifficulty` (`sd`), `settarget` (`st`), `log` (`l`).
-          enum: [reset, r, next, n, play, p, setdifficulty, sd, settarget, st, log, l]
+          enum: [reset, r, next, n, play, p, setdifficulty, sd, settarget, st, log, l, hint, h]
           example: play
         handIndex:
           type: integer
@@ -46589,7 +46619,7 @@ components:
         command:
           type: string
           description: Escoba command. Accepted values. `reset` (`r`), `next` (`n`), `play` (`p`), `setdifficulty` (`sd`), `settarget` (`st`), `log` (`l`).
-          enum: [reset, r, next, n, play, p, setdifficulty, sd, settarget, st, log, l]
+          enum: [reset, r, next, n, play, p, setdifficulty, sd, settarget, st, log, l, hint, h]
           example: play
         handIndex:
           type: integer
@@ -46744,7 +46774,7 @@ components:
         command:
           type: string
           description: Barbu command. Accepted values. `reset` (`r`), `next` (`n`), `contract` (`c`), `play` (`p`), `log` (`l`).
-          enum: [reset, r, next, n, contract, c, play, p, log, l]
+          enum: [reset, r, next, n, contract, c, play, p, log, l, hint, h]
           example: play
         contract:
           type: integer
@@ -53125,8 +53155,8 @@ components:
           type: string
           description: |
             Game command. Accepted values: `reset` (`r`), `bet` (`b`),
-            `play` (`p`), `check` (`c`), `fold` (`f`), `log` (`l`).
-          enum: [r, reset, b, bet, p, play, c, check, f, fold, log, l]
+            `play` (`p`), `check` (`c`), `fold` (`f`), `log` (`l`), `hint` (`h`).
+          enum: [r, reset, b, bet, p, play, c, check, f, fold, log, l, hint, h]
           example: bet
         amount:
           type: integer
@@ -53286,8 +53316,8 @@ components:
           type: string
           description: |
             Game command. Accepted values: `reset` (`r`), `bet` (`b`),
-            `play` (`p`), `fold` (`f`), `log` (`l`).
-          enum: [r, reset, b, bet, p, play, f, fold, log, l]
+            `play` (`p`), `fold` (`f`), `log` (`l`), `hint` (`h`).
+          enum: [r, reset, b, bet, p, play, f, fold, log, l, hint, h]
           example: bet
         amount:
           type: integer
@@ -53916,8 +53946,8 @@ components:
           description: |
             Game command. Accepted values: `reset` (`r`), `bet` (`b`),
             `exchange` (`e`), `stand` (`s`), `play` (`p`), `fold` (`f`),
-            `log` (`l`).
-          enum: [r, reset, b, bet, e, exchange, s, stand, p, play, f, fold, log, l]
+            `log` (`l`), `hint` (`h`).
+          enum: [r, reset, b, bet, e, exchange, s, stand, p, play, f, fold, log, l, hint, h]
           example: exchange
         amount:
           type: integer
@@ -54276,7 +54306,7 @@ components:
       properties:
         command:
           type: string
-          enum: [reset, r, drawstock, ds, drawdiscard, dd, meld, m, layoff, lo, discard, d, nextround, nr, log, l, quit, q]
+          enum: [reset, r, drawstock, ds, drawdiscard, dd, meld, m, layoff, lo, discard, d, nextround, nr, log, l, quit, q, hint, h]
           description: Game command alias.
         sessionId:
           type: string

--- a/frontend/src/api/games/badugi.ts
+++ b/frontend/src/api/games/badugi.ts
@@ -14,7 +14,7 @@ export interface BadugiConfigInput {
 /** API client for the Badugi /badugi/exec endpoint. */
 export const badugiApi = {
   exec: (
-    command: 'reset' | 'exchange' | 'stand' | 'fold' | 'check' | 'call' | 'bet' | 'raise' | 'allin',
+    command: 'reset' | 'exchange' | 'stand' | 'fold' | 'check' | 'call' | 'bet' | 'raise' | 'allin' | 'hint',
     indices?: number[],
     amount?: number,
     config?: BadugiConfigInput,

--- a/frontend/src/api/games/barbu.ts
+++ b/frontend/src/api/games/barbu.ts
@@ -10,7 +10,7 @@ export interface BarbuConfigInput {
 }
 
 /** Command verbs accepted by the Barbu /barbu/exec endpoint (short forms). */
-export type BarbuCommand = 'r' | 'n' | 'c' | 'p' | 'log';
+export type BarbuCommand = 'r' | 'n' | 'c' | 'p' | 'log' | 'hint';
 
 /** Extra payload fields for the Barbu /barbu/exec endpoint. */
 export interface BarbuExecParams {

--- a/frontend/src/api/games/burraco.ts
+++ b/frontend/src/api/games/burraco.ts
@@ -13,7 +13,17 @@ export interface BurracoConfigInput {
 /** API client for the Burraco /burraco/exec endpoint. */
 export const burracoApi = {
   exec: (
-    command: 'reset' | 'drawstock' | 'drawdiscard' | 'meld' | 'skipmeld' | 'discard' | 'goout' | 'nextround' | 'log',
+    command:
+      | 'reset'
+      | 'drawstock'
+      | 'drawdiscard'
+      | 'meld'
+      | 'skipmeld'
+      | 'discard'
+      | 'goout'
+      | 'nextround'
+      | 'log'
+      | 'hint',
     cardIndex?: number,
     config?: BurracoConfigInput,
     naturalPairIndices?: number[],

--- a/frontend/src/api/games/caribbeanstud.ts
+++ b/frontend/src/api/games/caribbeanstud.ts
@@ -6,6 +6,6 @@ import { gameExec } from '../gameExec';
 
 /** API client for the Caribbean Stud Poker /caribbeanstud/exec endpoint. */
 export const caribbeanstudApi = {
-  exec: (command: 'reset' | 'bet' | 'play' | 'fold' | 'log', amount?: number, jackpotBet?: number) =>
+  exec: (command: 'reset' | 'bet' | 'play' | 'fold' | 'log' | 'hint', amount?: number, jackpotBet?: number) =>
     gameExec<CaribbeanStudResponse>('caribbeanstud', { command, amount, jackpotBet }),
 };

--- a/frontend/src/api/games/casinoholdem.ts
+++ b/frontend/src/api/games/casinoholdem.ts
@@ -6,6 +6,6 @@ import { gameExec } from '../gameExec';
 
 /** API client for the Casino Hold'em /casinoholdem/exec endpoint. */
 export const casinoholdemApi = {
-  exec: (command: 'reset' | 'bet' | 'call' | 'fold' | 'log', amount?: number, bonusBet?: number) =>
+  exec: (command: 'reset' | 'bet' | 'call' | 'fold' | 'log' | 'hint', amount?: number, bonusBet?: number) =>
     gameExec<CasinoHoldemResponse>('casinoholdem', { command, amount, bonusBet }),
 };

--- a/frontend/src/api/games/cassino.ts
+++ b/frontend/src/api/games/cassino.ts
@@ -13,7 +13,7 @@ export interface CassinoConfigInput {
 }
 
 /** Command verbs accepted by the Cassino /cassino/exec endpoint. */
-export type CassinoCommand = 'reset' | 'take' | 'build' | 'trail' | 'next' | 'log';
+export type CassinoCommand = 'reset' | 'take' | 'build' | 'trail' | 'next' | 'log' | 'hint';
 
 /** Extra payload fields for the Cassino /cassino/exec endpoint. */
 export interface CassinoExecParams {

--- a/frontend/src/api/games/chinesepoker.ts
+++ b/frontend/src/api/games/chinesepoker.ts
@@ -7,7 +7,7 @@ import { gameExec } from '../gameExec';
 /** API client for the Chinese Poker /chinesepoker/exec endpoint. */
 export const chinesepokerApi = {
   exec: (
-    command: 'reset' | 'bet' | 'set' | 'log',
+    command: 'reset' | 'bet' | 'set' | 'log' | 'hint',
     amount?: number,
     frontIndices?: number[],
     middleIndices?: number[],

--- a/frontend/src/api/games/cribbage.ts
+++ b/frontend/src/api/games/cribbage.ts
@@ -13,7 +13,7 @@ export interface CribbageConfigInput {
 /** API client for the Cribbage /cribbage/exec endpoint. */
 export const cribbageApi = {
   exec: (
-    command: 'reset' | 'discard' | 'cut' | 'peg' | 'go' | 'shownext' | 'nextround' | 'log',
+    command: 'reset' | 'discard' | 'cut' | 'peg' | 'go' | 'shownext' | 'nextround' | 'log' | 'hint',
     cardIndex?: number,
     cardIndices?: number[],
     config?: CribbageConfigInput,

--- a/frontend/src/api/games/deucetoseven.ts
+++ b/frontend/src/api/games/deucetoseven.ts
@@ -14,7 +14,7 @@ export interface DeuceToSevenConfigInput {
 /** API client for the 2-7 Triple Draw /deucetoseven/exec endpoint. */
 export const deuceToSevenApi = {
   exec: (
-    command: 'reset' | 'exchange' | 'stand' | 'fold' | 'check' | 'call' | 'bet' | 'raise' | 'allin',
+    command: 'reset' | 'exchange' | 'stand' | 'fold' | 'check' | 'call' | 'bet' | 'raise' | 'allin' | 'hint',
     indices?: number[],
     amount?: number,
     config?: DeuceToSevenConfigInput,

--- a/frontend/src/api/games/escoba.ts
+++ b/frontend/src/api/games/escoba.ts
@@ -11,7 +11,7 @@ export interface EscobaConfigInput {
 }
 
 /** Command verbs accepted by the Escoba /escoba/exec endpoint (short forms). */
-export type EscobaCommand = 'r' | 'n' | 'p' | 'log';
+export type EscobaCommand = 'r' | 'n' | 'p' | 'log' | 'hint';
 
 /** Extra payload fields for the Escoba /escoba/exec endpoint. */
 export interface EscobaExecParams {

--- a/frontend/src/api/games/handandfoot.ts
+++ b/frontend/src/api/games/handandfoot.ts
@@ -13,7 +13,17 @@ export interface HandAndFootConfigInput {
 /** API client for the Hand and Foot /handandfoot/exec endpoint. */
 export const handandfootApi = {
   exec: (
-    command: 'reset' | 'drawstock' | 'drawdiscard' | 'meld' | 'skipmeld' | 'discard' | 'goout' | 'nextround' | 'log',
+    command:
+      | 'reset'
+      | 'drawstock'
+      | 'drawdiscard'
+      | 'meld'
+      | 'skipmeld'
+      | 'discard'
+      | 'goout'
+      | 'nextround'
+      | 'log'
+      | 'hint',
     cardIndex?: number,
     config?: HandAndFootConfigInput,
     naturalPairIndices?: number[],

--- a/frontend/src/api/games/highcardflush.ts
+++ b/frontend/src/api/games/highcardflush.ts
@@ -7,7 +7,7 @@ import { gameExec } from '../gameExec';
 /** API client for the High Card Flush /highcardflush/exec endpoint. */
 export const highcardflushApi = {
   exec: (
-    command: 'reset' | 'bet' | 'raise' | 'fold' | 'log',
+    command: 'reset' | 'bet' | 'raise' | 'fold' | 'log' | 'hint',
     amount?: number,
     flushBonusBet?: number,
     straightFlushBet?: number,

--- a/frontend/src/api/games/kaiser.ts
+++ b/frontend/src/api/games/kaiser.ts
@@ -12,7 +12,7 @@ export interface KaiserConfigInput {
 }
 
 /** Commands the /kaiser/exec endpoint accepts. */
-export type KaiserCommand = 'reset' | 'bid' | 'pass' | 'trump' | 'discard' | 'play' | 'next' | 'log';
+export type KaiserCommand = 'reset' | 'bid' | 'pass' | 'trump' | 'discard' | 'play' | 'next' | 'log' | 'hint';
 
 /** Options carried alongside a Kaiser command. */
 export interface KaiserExecOptions {

--- a/frontend/src/api/games/macau.ts
+++ b/frontend/src/api/games/macau.ts
@@ -13,7 +13,7 @@ export interface MacauConfigInput {
 /** API client for the Macau /macau/exec endpoint. */
 export const macauApi = {
   exec: (
-    command: 'reset' | 'play' | 'draw' | 'suit' | 'declare' | 'skipdeclare' | 'nextround',
+    command: 'reset' | 'play' | 'draw' | 'suit' | 'declare' | 'skipdeclare' | 'nextround' | 'hint',
     cardIndex?: number,
     suit?: number,
     config?: MacauConfigInput,

--- a/frontend/src/api/games/oasispoker.ts
+++ b/frontend/src/api/games/oasispoker.ts
@@ -7,7 +7,7 @@ import { gameExec } from '../gameExec';
 /** API client for the Oasis Poker /oasispoker/exec endpoint. */
 export const oasispokerApi = {
   exec: (
-    command: 'reset' | 'bet' | 'exchange' | 'stand' | 'play' | 'fold' | 'log',
+    command: 'reset' | 'bet' | 'exchange' | 'stand' | 'play' | 'fold' | 'log' | 'hint',
     amount?: number,
     jackpotBet?: number,
     indices?: number[],

--- a/frontend/src/api/games/pageone.ts
+++ b/frontend/src/api/games/pageone.ts
@@ -13,7 +13,7 @@ export interface PageOneConfigInput {
 /** API client for the Page One /pageone/exec endpoint. */
 export const pageoneApi = {
   exec: (
-    command: 'reset' | 'play' | 'draw' | 'declare' | 'skip' | 'nextround',
+    command: 'reset' | 'play' | 'draw' | 'declare' | 'skip' | 'nextround' | 'hint',
     cardIndex?: number,
     config?: PageOneConfigInput,
   ) =>

--- a/frontend/src/api/games/paigow.ts
+++ b/frontend/src/api/games/paigow.ts
@@ -6,6 +6,6 @@ import { gameExec } from '../gameExec';
 
 /** API client for the Pai Gow Poker /paigow/exec endpoint. */
 export const paigowApi = {
-  exec: (command: 'reset' | 'bet' | 'set' | 'log', amount?: number, low0?: number, low1?: number) =>
+  exec: (command: 'reset' | 'bet' | 'set' | 'log' | 'hint', amount?: number, low0?: number, low1?: number) =>
     gameExec<PaiGowResponse>('paigow', { command, amount, low0, low1 }),
 };

--- a/frontend/src/api/games/president.ts
+++ b/frontend/src/api/games/president.ts
@@ -13,7 +13,7 @@ export interface PresidentConfigInput {
 }
 
 /** Command verbs accepted by the President /president/exec endpoint. */
-export type PresidentCommand = 'reset' | 'play' | 'log';
+export type PresidentCommand = 'reset' | 'play' | 'log' | 'hint';
 
 /** API client for the President /president/exec endpoint. */
 export const presidentApi = {

--- a/frontend/src/api/games/reddog.ts
+++ b/frontend/src/api/games/reddog.ts
@@ -5,4 +5,6 @@ import type { RedDogResponse } from '../../types/card';
 import { createBetAmountApi } from '../gameExec';
 
 /** API client for the Red Dog /reddog/exec endpoint. */
-export const reddogApi = createBetAmountApi<RedDogResponse, 'reset' | 'bet' | 'raise' | 'stay' | 'log'>('reddog');
+export const reddogApi = createBetAmountApi<RedDogResponse, 'reset' | 'bet' | 'raise' | 'stay' | 'log' | 'hint'>(
+  'reddog',
+);

--- a/frontend/src/api/games/scopa.ts
+++ b/frontend/src/api/games/scopa.ts
@@ -11,7 +11,7 @@ export interface ScopaConfigInput {
 }
 
 /** Command verbs accepted by the Scopa /scopa/exec endpoint (short forms). */
-export type ScopaCommand = 'r' | 'n' | 'p' | 'log';
+export type ScopaCommand = 'r' | 'n' | 'p' | 'log' | 'hint';
 
 /** Extra payload fields for the Scopa /scopa/exec endpoint. */
 export interface ScopaExecParams {

--- a/frontend/src/api/games/scopone.ts
+++ b/frontend/src/api/games/scopone.ts
@@ -11,7 +11,7 @@ export interface ScoponeConfigInput {
 }
 
 /** Command verbs accepted by the Scopone /scopone/exec endpoint (short forms). */
-export type ScoponeCommand = 'r' | 'n' | 'p' | 'log';
+export type ScoponeCommand = 'r' | 'n' | 'p' | 'log' | 'hint';
 
 /** Extra payload fields for the Scopone /scopone/exec endpoint. */
 export interface ScoponeExecParams {

--- a/frontend/src/api/games/sevenbridge.ts
+++ b/frontend/src/api/games/sevenbridge.ts
@@ -20,7 +20,8 @@ export type SevenBridgeCommand =
   | 'layoff'
   | 'discard'
   | 'nextround'
-  | 'log';
+  | 'log'
+  | 'hint';
 
 /** API client for the Seven Bridge /sevenbridge/exec endpoint. */
 export const sevenBridgeApi = {

--- a/frontend/src/api/games/threecard.ts
+++ b/frontend/src/api/games/threecard.ts
@@ -6,6 +6,6 @@ import { gameExec } from '../gameExec';
 
 /** API client for the Three Card Poker /threecard/exec endpoint. */
 export const threecardApi = {
-  exec: (command: 'reset' | 'bet' | 'play' | 'fold' | 'log', amount?: number, pairPlusBet?: number) =>
+  exec: (command: 'reset' | 'bet' | 'play' | 'fold' | 'log' | 'hint', amount?: number, pairPlusBet?: number) =>
     gameExec<ThreeCardResponse>('threecard', { command, amount, pairPlusBet }),
 };

--- a/frontend/src/utils/cli/commands/badugiCommands.ts
+++ b/frontend/src/utils/cli/commands/badugiCommands.ts
@@ -23,6 +23,8 @@ const VALID_COMMANDS = [
   'stand',
   'r',
   'reset',
+  'h',
+  'hint',
   'help',
   '?',
 ];
@@ -68,6 +70,9 @@ export function parseBadugiCommand(input: string): CliParseResult<BadugiArgs> {
     case 'r':
     case 'reset':
       return { args: ['reset'] };
+    case 'h':
+    case 'hint':
+      return { args: ['hint'] };
     default: {
       const suggestion = suggestCommand(cmd, VALID_COMMANDS);
       if (suggestion) return { error: `Unknown command: ${cmd}. Did you mean: ${suggestion}?` };
@@ -87,4 +92,5 @@ export const BADUGI_HELP: string[] = [
   'ex <idx...>    - Exchange selected cards (e.g. ex 0 2)',
   'st/stand       - Stand pat (no exchange)',
   'r/reset        - Reset game',
+  'h/hint         - Get a hint',
 ];

--- a/frontend/src/utils/cli/commands/barbuCommands.ts
+++ b/frontend/src/utils/cli/commands/barbuCommands.ts
@@ -39,6 +39,8 @@ export function parseBarbuCommand(input: string): CliParseResult<BarbuCliArgs> {
     return { args: ['p', { handIndex: hand }] };
   }
 
+  if (cmd === 'hint' || cmd === 'h') return { args: ['hint'] };
+
   return { error: `Unknown command: ${cmd}` };
 }
 
@@ -71,4 +73,5 @@ export const BARBU_HELP = [
   'n/next           - Start next deal',
   'r/reset          - Reset game',
   'l/log            - Show action log',
+  'h/hint           - Get a hint',
 ] as const;

--- a/frontend/src/utils/cli/commands/burracoCommands.ts
+++ b/frontend/src/utils/cli/commands/burracoCommands.ts
@@ -21,6 +21,8 @@ const VALID_COMMANDS = [
   'log',
   'r',
   'reset',
+  'h',
+  'hint',
   'help',
   '?',
 ];
@@ -63,6 +65,9 @@ export function parseBurracoCommand(input: string): CliParseResult<BurracoArgs> 
     case 'r':
     case 'reset':
       return { args: ['reset'] };
+    case 'h':
+    case 'hint':
+      return { args: ['hint'] };
     default: {
       const suggestion = suggestCommand(cmd, VALID_COMMANDS);
       if (suggestion) return { error: `Unknown command: ${cmd}. Did you mean: ${suggestion}?` };
@@ -82,4 +87,5 @@ export const BURRACO_HELP: string[] = [
   'nr/nextround   - Next round',
   'log            - Show action log',
   'r/reset        - Reset game',
+  'h/hint         - Get a hint',
 ];

--- a/frontend/src/utils/cli/commands/caribbeanstudCommands.ts
+++ b/frontend/src/utils/cli/commands/caribbeanstudCommands.ts
@@ -4,7 +4,7 @@ import type { CliParseResult } from '../types';
 
 type CaribbeanStudArgs = Parameters<typeof caribbeanstudApi.exec>;
 
-const VALID_COMMANDS = ['b', 'bet', 'p', 'play', 'f', 'fold', 'log', 'r', 'reset', 'help', '?'];
+const VALID_COMMANDS = ['b', 'bet', 'p', 'play', 'f', 'fold', 'log', 'r', 'reset', 'h', 'hint', 'help', '?'];
 
 /** Parse a Caribbean Stud Poker CLI command into API exec arguments. */
 export function parseCaribbeanstudCommand(input: string): CliParseResult<CaribbeanStudArgs> {
@@ -33,6 +33,9 @@ export function parseCaribbeanstudCommand(input: string): CliParseResult<Caribbe
     case 'r':
     case 'reset':
       return { args: ['reset'] };
+    case 'h':
+    case 'hint':
+      return { args: ['hint'] };
     default: {
       const suggestion = suggestCommand(cmd, VALID_COMMANDS);
       if (suggestion) return { error: `Unknown command: ${cmd}. Did you mean: ${suggestion}?` };
@@ -48,4 +51,5 @@ export const CARIBBEANSTUD_HELP: string[] = [
   'f/fold       - Fold hand',
   'log          - Show action log',
   'r/reset      - Reset game',
+  'h/hint       - Get a hint',
 ];

--- a/frontend/src/utils/cli/commands/casinoholdemCommands.ts
+++ b/frontend/src/utils/cli/commands/casinoholdemCommands.ts
@@ -4,7 +4,7 @@ import type { CliParseResult } from '../types';
 
 type CasinoHoldemArgs = Parameters<typeof casinoholdemApi.exec>;
 
-const VALID_COMMANDS = ['b', 'bet', 'c', 'call', 'f', 'fold', 'log', 'r', 'reset', 'help', '?'];
+const VALID_COMMANDS = ['b', 'bet', 'c', 'call', 'f', 'fold', 'log', 'r', 'reset', 'h', 'hint', 'help', '?'];
 
 /** Parse a Casino Hold'em CLI command into API exec arguments. */
 export function parseCasinoholdemCommand(input: string): CliParseResult<CasinoHoldemArgs> {
@@ -33,6 +33,9 @@ export function parseCasinoholdemCommand(input: string): CliParseResult<CasinoHo
     case 'r':
     case 'reset':
       return { args: ['reset'] };
+    case 'h':
+    case 'hint':
+      return { args: ['hint'] };
     default: {
       const suggestion = suggestCommand(cmd, VALID_COMMANDS);
       if (suggestion) return { error: `Unknown command: ${cmd}. Did you mean: ${suggestion}?` };
@@ -48,4 +51,5 @@ export const CASINOHOLDEM_HELP: string[] = [
   'f/fold       - Fold (forfeit ante)',
   'log          - Show action log',
   'r/reset      - Reset game',
+  'h/hint       - Get a hint',
 ];

--- a/frontend/src/utils/cli/commands/cassinoCommands.ts
+++ b/frontend/src/utils/cli/commands/cassinoCommands.ts
@@ -63,6 +63,8 @@ export function parseCassinoCommand(input: string): CliParseResult<CassinoCliArg
     return { args: ['trail', { handIndex: hand }] };
   }
 
+  if (cmd === 'hint' || cmd === 'h') return { args: ['hint'] };
+
   return { error: `Unknown command: ${cmd}` };
 }
 
@@ -93,4 +95,5 @@ export const CASSINO_HELP = [
   'n/next                        - Start next round',
   'r/reset                       - Reset game',
   'l/log                         - Show action log',
+  'h/hint                        - Get a hint',
 ] as const;

--- a/frontend/src/utils/cli/commands/chinesepokerCommands.ts
+++ b/frontend/src/utils/cli/commands/chinesepokerCommands.ts
@@ -4,7 +4,7 @@ import type { CliParseResult } from '../types';
 
 type ChinesePokerArgs = Parameters<typeof chinesepokerApi.exec>;
 
-const VALID_COMMANDS = ['b', 'bet', 's', 'set', 'r', 'reset', 'log', 'l'];
+const VALID_COMMANDS = ['b', 'bet', 's', 'set', 'r', 'reset', 'log', 'l', 'h', 'hint'];
 
 /** Parse a CLI input string into Chinese Poker API arguments. */
 export function parseChinesepokerCommand(input: string): CliParseResult<ChinesePokerArgs> {
@@ -40,6 +40,9 @@ export function parseChinesepokerCommand(input: string): CliParseResult<ChineseP
     case 'r':
     case 'reset':
       return { args: ['reset'] };
+    case 'h':
+    case 'hint':
+      return { args: ['hint'] };
     default: {
       const suggestion = suggestCommand(cmd, VALID_COMMANDS);
       if (suggestion) return { error: `Unknown command: ${cmd}. Did you mean: ${suggestion}?` };
@@ -54,4 +57,5 @@ export const CHINESEPOKER_HELP: string[] = [
   's <f0 f1 f2 m0 m1 m2 m3 m4>      - Set hands (3 front + 5 middle indices)',
   'r                                 - Reset / new game',
   'l                                 - Action log',
+  'h/hint       - Get a hint',
 ];

--- a/frontend/src/utils/cli/commands/cribbageCommands.ts
+++ b/frontend/src/utils/cli/commands/cribbageCommands.ts
@@ -18,6 +18,8 @@ const VALID_COMMANDS = [
   'log',
   'r',
   'reset',
+  'h',
+  'hint',
   'help',
   '?',
 ];
@@ -54,6 +56,9 @@ export function parseCribbageCommand(input: string): CliParseResult<CribbageArgs
     case 'r':
     case 'reset':
       return { args: ['reset'] };
+    case 'h':
+    case 'hint':
+      return { args: ['hint'] };
     default: {
       const suggestion = suggestCommand(cmd, VALID_COMMANDS);
       if (suggestion) return { error: `Unknown command: ${cmd}. Did you mean: ${suggestion}?` };
@@ -72,4 +77,5 @@ export const CRIBBAGE_HELP: string[] = [
   'nr/nextround   - Next round',
   'log            - Show action log',
   'r/reset        - Reset game',
+  'h/hint         - Get a hint',
 ];

--- a/frontend/src/utils/cli/commands/deuceToSevenCommands.ts
+++ b/frontend/src/utils/cli/commands/deuceToSevenCommands.ts
@@ -23,6 +23,8 @@ const VALID_COMMANDS = [
   'stand',
   'r',
   'reset',
+  'h',
+  'hint',
   'help',
   '?',
 ];
@@ -68,6 +70,9 @@ export function parseDeuceToSevenCommand(input: string): CliParseResult<DeuceToS
     case 'r':
     case 'reset':
       return { args: ['reset'] };
+    case 'h':
+    case 'hint':
+      return { args: ['hint'] };
     default: {
       const suggestion = suggestCommand(cmd, VALID_COMMANDS);
       if (suggestion) return { error: `Unknown command: ${cmd}. Did you mean: ${suggestion}?` };
@@ -87,4 +92,5 @@ export const DEUCE_TO_SEVEN_HELP: string[] = [
   'ex <idx...>    - Exchange selected cards (e.g. ex 0 2 4)',
   'st/stand       - Stand pat (no exchange)',
   'r/reset        - Reset game',
+  'h/hint         - Get a hint',
 ];

--- a/frontend/src/utils/cli/commands/escobaCommands.ts
+++ b/frontend/src/utils/cli/commands/escobaCommands.ts
@@ -31,6 +31,8 @@ export function parseEscobaCommand(input: string): CliParseResult<EscobaCliArgs>
     return { args: ['p', { handIndex: hand, tableIndices }] };
   }
 
+  if (cmd === 'hint' || cmd === 'h') return { args: ['hint'] };
+
   return { error: `Unknown command: ${cmd}` };
 }
 
@@ -58,4 +60,5 @@ export const ESCOBA_HELP = [
   'n/next             - Start next round',
   'r/reset            - Reset game',
   'l/log              - Show action log',
+  'h/hint             - Get a hint',
 ] as const;

--- a/frontend/src/utils/cli/commands/handandfootCommands.ts
+++ b/frontend/src/utils/cli/commands/handandfootCommands.ts
@@ -21,6 +21,8 @@ const VALID_COMMANDS = [
   'log',
   'r',
   'reset',
+  'h',
+  'hint',
   'help',
   '?',
 ];
@@ -62,6 +64,9 @@ export function parseHandAndFootCommand(input: string): CliParseResult<HandAndFo
     case 'r':
     case 'reset':
       return { args: ['reset'] };
+    case 'h':
+    case 'hint':
+      return { args: ['hint'] };
     default: {
       const suggestion = suggestCommand(cmd, VALID_COMMANDS);
       if (suggestion) return { error: `Unknown command: ${cmd}. Did you mean: ${suggestion}?` };
@@ -81,4 +86,5 @@ export const HANDANDFOOT_HELP: string[] = [
   'nr/nextround   - Next round',
   'log            - Show action log',
   'r/reset        - Reset game',
+  'h/hint         - Get a hint',
 ];

--- a/frontend/src/utils/cli/commands/highcardflushCommands.ts
+++ b/frontend/src/utils/cli/commands/highcardflushCommands.ts
@@ -4,7 +4,24 @@ import type { CliParseResult } from '../types';
 
 type HighCardFlushArgs = Parameters<typeof highcardflushApi.exec>;
 
-const VALID_COMMANDS = ['b', 'bet', 'ra', 'raise', '1', '2', '3', 'f', 'fold', 'log', 'r', 'reset', 'help', '?'];
+const VALID_COMMANDS = [
+  'b',
+  'bet',
+  'ra',
+  'raise',
+  '1',
+  '2',
+  '3',
+  'f',
+  'fold',
+  'log',
+  'r',
+  'reset',
+  'h',
+  'hint',
+  'help',
+  '?',
+];
 
 /** Parse a raise multiplier (1-3) into the API exec arguments. */
 function raiseArgs(multiplier: number): CliParseResult<HighCardFlushArgs> {
@@ -55,6 +72,9 @@ export function parseHighcardflushCommand(input: string): CliParseResult<HighCar
     case 'r':
     case 'reset':
       return { args: ['reset'] };
+    case 'h':
+    case 'hint':
+      return { args: ['hint'] };
     default: {
       const suggestion = suggestCommand(cmd, VALID_COMMANDS);
       if (suggestion) return { error: `Unknown command: ${cmd}. Did you mean: ${suggestion}?` };
@@ -71,4 +91,5 @@ export const HIGHCARDFLUSH_HELP: string[] = [
   'f/fold             - Fold',
   'log                - Show action log',
   'r/reset            - Reset game',
+  'h/hint             - Get a hint',
 ];

--- a/frontend/src/utils/cli/commands/hintCommandParity.test.ts
+++ b/frontend/src/utils/cli/commands/hintCommandParity.test.ts
@@ -1,22 +1,46 @@
 import { describe, expect, it } from 'vitest';
+import { BADUGI_HELP, parseBadugiCommand } from './badugiCommands';
+import { BARBU_HELP, parseBarbuCommand } from './barbuCommands';
 import { BID_WHIST_HELP, parseBidWhistCommand } from './bidwhistCommands';
 import { BURA_HELP, parseBuraCommand } from './buraCommands';
+import { BURRACO_HELP, parseBurracoCommand } from './burracoCommands';
+import { CARIBBEANSTUD_HELP, parseCaribbeanstudCommand } from './caribbeanstudCommands';
+import { CASINOHOLDEM_HELP, parseCasinoholdemCommand } from './casinoholdemCommands';
+import { CASSINO_HELP, parseCassinoCommand } from './cassinoCommands';
+import { CHINESEPOKER_HELP, parseChinesepokerCommand } from './chinesepokerCommands';
 import { CHINESETEN_HELP, parseChineseTenCommand } from './chinesetenCommands';
 import { CRAZYEIGHTS_HELP, parseCrazyeightsCommand } from './crazyeightsCommands';
+import { CRIBBAGE_HELP, parseCribbageCommand } from './cribbageCommands';
 import { DESMOCHE_HELP, parseDesmocheCommand } from './desmocheCommands';
+import { DEUCE_TO_SEVEN_HELP, parseDeuceToSevenCommand } from './deuceToSevenCommands';
 import { DURAK_HELP, parseDurakCommand } from './durakCommands';
+import { ESCOBA_HELP, parseEscobaCommand } from './escobaCommands';
 import { FIVE_HUNDRED_HELP, parseFiveHundredCommand } from './fivehundredCommands';
+import { HANDANDFOOT_HELP, parseHandAndFootCommand } from './handandfootCommands';
+import { HIGHCARDFLUSH_HELP, parseHighcardflushCommand } from './highcardflushCommands';
+import { KAISER_HELP, parseKaiserCommand } from './kaiserCommands';
 import { LAUGHANDLIEDOWN_HELP, parseLaughAndLieDownCommand } from './laughandliedownCommands';
 import { LOBA_HELP, parseLobaCommand } from './lobaCommands';
+import { MACAU_HELP, parseMacauCommand } from './macauCommands';
 import { MUSHI_HELP, parseMushiCommand } from './mushiCommands';
 import { NAINJAUNE_HELP, parseNainJauneCommand } from './nainjauneCommands';
+import { OASISPOKER_HELP, parseOasispokerCommand } from './oasispokerCommands';
 import { OPENFACECHINESE_HELP, parseOpenfacechineseCommand } from './openfacechineseCommands';
+import { PAGEONE_HELP, parsePageoneCommand } from './pageoneCommands';
+import { PAIGOW_HELP, parsePaigowCommand } from './paigowCommands';
 import { POCH_HELP, parsePochCommand } from './pochCommands';
 import { POKERSQUARES_HELP, parsePokerSquaresCommand } from './pokersquaresCommands';
 import { POPEJOAN_HELP, parsePopeJoanCommand } from './popejoanCommands';
+import { PRESIDENT_HELP, parsePresidentCommand } from './presidentCommands';
+import { parseReddogCommand, REDDOG_HELP } from './reddogCommands';
 import { parseRookCommand, ROOK_HELP } from './rookCommands';
+import { parseScopaCommand, SCOPA_HELP } from './scopaCommands';
+import { parseScoponeCommand, SCOPONE_HELP } from './scoponeCommands';
+import { parseSevenBridgeCommand, SEVENBRIDGE_HELP } from './sevenBridgeCommands';
+import { parseSixCardGolfCommand } from './sixcardgolfCommands';
 import { parseSjavsCommand, SJAVS_HELP } from './sjavsCommands';
 import { parseSkitgubbeCommand, SKITGUBBE_HELP } from './skitgubbeCommands';
+import { parseThreecardCommand, THREECARD_HELP } from './threecardCommands';
 import { parseToepenCommand, TOEPEN_HELP } from './toepenCommands';
 import { parseTrexCommand, TREX_HELP } from './trexCommands';
 import { parseZwickerCommand, ZWICKER_HELP } from './zwickerCommands';
@@ -55,6 +79,30 @@ const WIRED: readonly [string, AnyParser, readonly string[]][] = [
   ['toepen', parseToepenCommand, TOEPEN_HELP],
   ['trex', parseTrexCommand, TREX_HELP],
   ['zwicker', parseZwickerCommand, ZWICKER_HELP],
+  // #5792: these also needed their Web controller and API command union widened.
+  ['badugi', parseBadugiCommand, BADUGI_HELP],
+  ['barbu', parseBarbuCommand, BARBU_HELP],
+  ['burraco', parseBurracoCommand, BURRACO_HELP],
+  ['caribbeanstud', parseCaribbeanstudCommand, CARIBBEANSTUD_HELP],
+  ['casinoholdem', parseCasinoholdemCommand, CASINOHOLDEM_HELP],
+  ['cassino', parseCassinoCommand, CASSINO_HELP],
+  ['chinesepoker', parseChinesepokerCommand, CHINESEPOKER_HELP],
+  ['cribbage', parseCribbageCommand, CRIBBAGE_HELP],
+  ['deuceToSeven', parseDeuceToSevenCommand, DEUCE_TO_SEVEN_HELP],
+  ['escoba', parseEscobaCommand, ESCOBA_HELP],
+  ['handandfoot', parseHandAndFootCommand, HANDANDFOOT_HELP],
+  ['highcardflush', parseHighcardflushCommand, HIGHCARDFLUSH_HELP],
+  ['kaiser', parseKaiserCommand, KAISER_HELP],
+  ['macau', parseMacauCommand, MACAU_HELP],
+  ['oasispoker', parseOasispokerCommand, OASISPOKER_HELP],
+  ['pageone', parsePageoneCommand, PAGEONE_HELP],
+  ['paigow', parsePaigowCommand, PAIGOW_HELP],
+  ['president', parsePresidentCommand, PRESIDENT_HELP],
+  ['reddog', parseReddogCommand, REDDOG_HELP],
+  ['scopa', parseScopaCommand, SCOPA_HELP],
+  ['scopone', parseScoponeCommand, SCOPONE_HELP],
+  ['sevenBridge', parseSevenBridgeCommand, SEVENBRIDGE_HELP],
+  ['threecard', parseThreecardCommand, THREECARD_HELP],
 ];
 
 describe('hint command parity between the GUI and the Web CLI', () => {
@@ -70,7 +118,15 @@ describe('hint command parity between the GUI and the Web CLI', () => {
     ).toBe(true);
   });
 
+  // sixcardgolf builds its CLI help from i18n rather than exporting a *_HELP
+  // array, so only its parser can be asserted here.
+  it('sixcardgolf accepts "hint"', () => {
+    for (const input of ['hint', 'h']) {
+      expect(parseSixCardGolfCommand(input)).not.toHaveProperty('error');
+    }
+  });
+
   it('covers every module this change wired', () => {
-    expect(WIRED).toHaveLength(21);
+    expect(WIRED).toHaveLength(44);
   });
 });

--- a/frontend/src/utils/cli/commands/kaiserCommands.ts
+++ b/frontend/src/utils/cli/commands/kaiserCommands.ts
@@ -22,6 +22,8 @@ const VALID_COMMANDS = [
   'log',
   'r',
   'reset',
+  'h',
+  'hint',
   'help',
   '?',
 ];
@@ -106,6 +108,9 @@ export function parseKaiserCommand(input: string): CliParseResult<KaiserCliArgs>
     case 'r':
     case 'reset':
       return { args: ['reset'] };
+    case 'h':
+    case 'hint':
+      return { args: ['hint'] };
     default: {
       const suggestion = suggestCommand(cmd, VALID_COMMANDS);
       if (suggestion) return { error: `Unknown command: ${cmd}. Did you mean: ${suggestion}?` };
@@ -124,4 +129,5 @@ export const KAISER_HELP: string[] = [
   'n / next            - Deal the next hand',
   'l / log             - Show action log',
   'r / reset           - Reset game',
+  'h/hint       - Get a hint',
 ];

--- a/frontend/src/utils/cli/commands/macauCommands.ts
+++ b/frontend/src/utils/cli/commands/macauCommands.ts
@@ -19,6 +19,8 @@ const VALID_COMMANDS = [
   'nextround',
   'r',
   'reset',
+  'h',
+  'hint',
   'help',
   '?',
 ];
@@ -55,6 +57,9 @@ export function parseMacauCommand(input: string): CliParseResult<MacauArgs> {
     case 'r':
     case 'reset':
       return { args: ['reset'] };
+    case 'h':
+    case 'hint':
+      return { args: ['hint'] };
     default: {
       const suggestion = suggestCommand(cmd, VALID_COMMANDS);
       if (suggestion) return { error: `Unknown command: ${cmd}. Did you mean: ${suggestion}?` };
@@ -72,4 +77,5 @@ export const MACAU_HELP: string[] = [
   'sk          - Skip declaration (take penalty)',
   'nr/nextround- Next round',
   'r/reset     - Reset game',
+  'h/hint      - Get a hint',
 ];

--- a/frontend/src/utils/cli/commands/oasispokerCommands.ts
+++ b/frontend/src/utils/cli/commands/oasispokerCommands.ts
@@ -18,6 +18,8 @@ const VALID_COMMANDS = [
   'log',
   'r',
   'reset',
+  'h',
+  'hint',
   'help',
   '?',
 ];
@@ -63,6 +65,9 @@ export function parseOasispokerCommand(input: string): CliParseResult<OasisPoker
     case 'r':
     case 'reset':
       return { args: ['reset'] };
+    case 'h':
+    case 'hint':
+      return { args: ['hint'] };
     default: {
       const suggestion = suggestCommand(cmd, VALID_COMMANDS);
       if (suggestion) return { error: `Unknown command: ${cmd}. Did you mean: ${suggestion}?` };
@@ -80,4 +85,5 @@ export const OASISPOKER_HELP: string[] = [
   'f/fold        - Fold hand',
   'log           - Show action log',
   'r/reset       - Reset game',
+  'h/hint        - Get a hint',
 ];

--- a/frontend/src/utils/cli/commands/pageoneCommands.ts
+++ b/frontend/src/utils/cli/commands/pageoneCommands.ts
@@ -17,6 +17,8 @@ const VALID_COMMANDS = [
   'nextround',
   'r',
   'reset',
+  'h',
+  'hint',
   'help',
   '?',
 ];
@@ -47,6 +49,9 @@ export function parsePageoneCommand(input: string): CliParseResult<PageOneArgs> 
     case 'r':
     case 'reset':
       return { args: ['reset'] };
+    case 'h':
+    case 'hint':
+      return { args: ['hint'] };
     default: {
       const suggestion = suggestCommand(cmd, VALID_COMMANDS);
       if (suggestion) return { error: `Unknown command: ${cmd}. Did you mean: ${suggestion}?` };
@@ -63,4 +68,5 @@ export const PAGEONE_HELP: string[] = [
   'sk/skip      - Skip declaration (penalty: 2 cards)',
   'nr/nextround - Next round',
   'r/reset      - Reset game',
+  'h/hint       - Get a hint',
 ];

--- a/frontend/src/utils/cli/commands/paigowCommands.ts
+++ b/frontend/src/utils/cli/commands/paigowCommands.ts
@@ -4,7 +4,7 @@ import type { CliParseResult } from '../types';
 
 type PaiGowArgs = Parameters<typeof paigowApi.exec>;
 
-const VALID_COMMANDS = ['b', 'bet', 's', 'set', 'log', 'r', 'reset', 'help', '?'];
+const VALID_COMMANDS = ['b', 'bet', 's', 'set', 'log', 'r', 'reset', 'h', 'hint', 'help', '?'];
 
 /** Parse a Pai Gow Poker CLI command into API exec arguments. */
 export function parsePaigowCommand(input: string): CliParseResult<PaiGowArgs> {
@@ -30,6 +30,9 @@ export function parsePaigowCommand(input: string): CliParseResult<PaiGowArgs> {
     case 'r':
     case 'reset':
       return { args: ['reset'] };
+    case 'h':
+    case 'hint':
+      return { args: ['hint'] };
     default: {
       const suggestion = suggestCommand(cmd, VALID_COMMANDS);
       if (suggestion) return { error: `Unknown command: ${cmd}. Did you mean: ${suggestion}?` };
@@ -44,4 +47,5 @@ export const PAIGOW_HELP: string[] = [
   's <i0> <i1>   - Set low hand (2 card indices)',
   'log            - Show action log',
   'r/reset        - Reset game',
+  'h/hint         - Get a hint',
 ];

--- a/frontend/src/utils/cli/commands/presidentCommands.ts
+++ b/frontend/src/utils/cli/commands/presidentCommands.ts
@@ -18,6 +18,7 @@ export function parsePresidentCommand(input: string): CliParseResult<PresidentCl
     return { args: ['play', indices] };
   }
   if (cmd === 'log' || cmd === 'l') return { args: ['log'] };
+  if (cmd === 'hint' || cmd === 'h') return { args: ['hint'] };
   return { error: `Unknown command: ${cmd}` };
 }
 
@@ -43,4 +44,5 @@ export const PRESIDENT_HELP = [
   'p [idx ...] - Play cards at indices (no index = pass)',
   'r/reset    - Reset game',
   'l/log      - Show action log',
+  'h/hint     - Get a hint',
 ] as const;

--- a/frontend/src/utils/cli/commands/reddogCommands.ts
+++ b/frontend/src/utils/cli/commands/reddogCommands.ts
@@ -4,7 +4,7 @@ import type { CliParseResult } from '../types';
 
 type RedDogArgs = Parameters<typeof reddogApi.exec>;
 
-const VALID_COMMANDS = ['b', 'bet', 'raise', 's', 'stay', 'log', 'r', 'reset', 'help', '?'];
+const VALID_COMMANDS = ['b', 'bet', 'raise', 's', 'stay', 'log', 'r', 'reset', 'h', 'hint', 'help', '?'];
 
 /** Parse a Red Dog CLI command into API exec arguments. */
 export function parseReddogCommand(input: string): CliParseResult<RedDogArgs> {
@@ -30,6 +30,9 @@ export function parseReddogCommand(input: string): CliParseResult<RedDogArgs> {
     case 'r':
     case 'reset':
       return { args: ['reset'] };
+    case 'h':
+    case 'hint':
+      return { args: ['hint'] };
     default: {
       const suggestion = suggestCommand(cmd, VALID_COMMANDS);
       if (suggestion) return { error: `Unknown command: ${cmd}. Did you mean: ${suggestion}?` };
@@ -45,4 +48,5 @@ export const REDDOG_HELP: string[] = [
   's/stay       - Stay (no raise) before drawing third card',
   'log          - Show action log',
   'r/reset      - Reset game',
+  'h/hint       - Get a hint',
 ];

--- a/frontend/src/utils/cli/commands/scopaCommands.ts
+++ b/frontend/src/utils/cli/commands/scopaCommands.ts
@@ -31,6 +31,8 @@ export function parseScopaCommand(input: string): CliParseResult<ScopaCliArgs> {
     return { args: ['p', { handIndex: hand, tableIndices }] };
   }
 
+  if (cmd === 'hint' || cmd === 'h') return { args: ['hint'] };
+
   return { error: `Unknown command: ${cmd}` };
 }
 
@@ -55,4 +57,5 @@ export const SCOPA_HELP = [
   'n/next             - Start next round',
   'r/reset            - Reset game',
   'l/log              - Show action log',
+  'h/hint             - Get a hint',
 ] as const;

--- a/frontend/src/utils/cli/commands/scoponeCommands.ts
+++ b/frontend/src/utils/cli/commands/scoponeCommands.ts
@@ -31,6 +31,8 @@ export function parseScoponeCommand(input: string): CliParseResult<ScoponeCliArg
     return { args: ['p', { handIndex: hand, tableIndices }] };
   }
 
+  if (cmd === 'hint' || cmd === 'h') return { args: ['hint'] };
+
   return { error: `Unknown command: ${cmd}` };
 }
 
@@ -58,4 +60,5 @@ export const SCOPONE_HELP = [
   'n/next             - Start next round',
   'r/reset            - Reset game',
   'l/log              - Show action log',
+  'h/hint             - Get a hint',
 ] as const;

--- a/frontend/src/utils/cli/commands/sevenBridgeCommands.ts
+++ b/frontend/src/utils/cli/commands/sevenBridgeCommands.ts
@@ -24,6 +24,8 @@ const VALID_COMMANDS = [
   'reset',
   'log',
   'l',
+  'h',
+  'hint',
 ];
 
 /** Parse a CLI input string into Seven Bridge API arguments. */
@@ -84,6 +86,9 @@ export function parseSevenBridgeCommand(input: string): CliParseResult<SevenBrid
     case 'r':
     case 'reset':
       return { args: ['reset'] };
+    case 'h':
+    case 'hint':
+      return { args: ['hint'] };
     default: {
       const suggestion = suggestCommand(cmd, VALID_COMMANDS);
       if (suggestion) return { error: `Unknown command: ${cmd}. Did you mean: ${suggestion}?` };
@@ -103,4 +108,5 @@ export const SEVENBRIDGE_HELP: string[] = [
   'n                       - Next round',
   'r                       - Reset / new game',
   'l / log                 - Action log',
+  'h/hint       - Get a hint',
 ];

--- a/frontend/src/utils/cli/commands/sixcardgolfCommands.ts
+++ b/frontend/src/utils/cli/commands/sixcardgolfCommands.ts
@@ -45,6 +45,9 @@ export function parseSixCardGolfCommand(input: string): CliParseResult<SixCardGo
     case 'l':
     case 'log':
       return { args: [{ command: 'log' }] };
+    case 'h':
+    case 'hint':
+      return { args: [{ command: 'hint' }] };
     default:
       return { error: i18n.t('sixcardgolf:cliUnknown', { cmd: cmd ?? '' }) };
   }

--- a/frontend/src/utils/cli/commands/threecardCommands.ts
+++ b/frontend/src/utils/cli/commands/threecardCommands.ts
@@ -4,7 +4,7 @@ import type { CliParseResult } from '../types';
 
 type ThreeCardArgs = Parameters<typeof threecardApi.exec>;
 
-const VALID_COMMANDS = ['b', 'bet', 'p', 'play', 'f', 'fold', 'log', 'r', 'reset', 'help', '?'];
+const VALID_COMMANDS = ['b', 'bet', 'p', 'play', 'f', 'fold', 'log', 'r', 'reset', 'h', 'hint', 'help', '?'];
 
 /** Parse a Three Card Poker CLI command into API exec arguments. */
 export function parseThreecardCommand(input: string): CliParseResult<ThreeCardArgs> {
@@ -33,6 +33,9 @@ export function parseThreecardCommand(input: string): CliParseResult<ThreeCardAr
     case 'r':
     case 'reset':
       return { args: ['reset'] };
+    case 'h':
+    case 'hint':
+      return { args: ['hint'] };
     default: {
       const suggestion = suggestCommand(cmd, VALID_COMMANDS);
       if (suggestion) return { error: `Unknown command: ${cmd}. Did you mean: ${suggestion}?` };
@@ -48,4 +51,5 @@ export const THREECARD_HELP: string[] = [
   'f/fold       - Fold hand',
   'log          - Show action log',
   'r/reset      - Reset game',
+  'h/hint       - Get a hint',
 ];

--- a/internal/adapter/controller/BadugiWebController.go
+++ b/internal/adapter/controller/BadugiWebController.go
@@ -160,7 +160,7 @@ func badugiDispatch(bc *baseController, w http.ResponseWriter, bi usecase.Badugi
 	case "a", "allin":
 		bc.writePresenterResponse(w, bi.Action(domain.BadugiActionAllIn, 0, param.HumanPlayMs))
 	default:
-		return dispatchLog(param.Command, bc, w, bi.ActionLog)
+		return dispatchHintAndLog(param.Command, bc, w, bi.Hint, bi.ActionLog)
 	}
 	return true
 }

--- a/internal/adapter/controller/BarbuWebController.go
+++ b/internal/adapter/controller/BarbuWebController.go
@@ -125,7 +125,7 @@ func barbuDispatch(bc *baseController, w http.ResponseWriter, bi usecase.BarbuIn
 		}
 		bc.writePresenterResponse(w, bi.Play(param.HandIndex, param.TableIndices))
 	default:
-		return dispatchLog(param.Command, bc, w, bi.ActionLog)
+		return dispatchHintAndLog(param.Command, bc, w, bi.Hint, bi.ActionLog)
 	}
 	return true
 }

--- a/internal/adapter/controller/BurracoWebController.go
+++ b/internal/adapter/controller/BurracoWebController.go
@@ -114,5 +114,6 @@ func burracoDispatch(bc *baseController, w http.ResponseWriter, ci usecase.Burra
 		goOut:           ci.GoOut,
 		nextRound:       ci.NextRound,
 		actionLog:       ci.ActionLog,
+		hint:            ci.Hint,
 	}, param.CardIndex, newDefault)
 }

--- a/internal/adapter/controller/CaribbeanStudWebController.go
+++ b/internal/adapter/controller/CaribbeanStudWebController.go
@@ -62,7 +62,7 @@ func caribbeanStudDispatch(bc *baseController, w http.ResponseWriter, ci usecase
 	case "f", "fold":
 		bc.writePresenterResponse(w, ci.Fold())
 	default:
-		return dispatchResetAndLog(param.Command, bc, w, ci.Reset, ci.ActionLog)
+		return dispatchResetHintAndLog(param.Command, bc, w, ci.Reset, ci.Hint, ci.ActionLog)
 	}
 	return true
 }

--- a/internal/adapter/controller/CasinoHoldemWebController.go
+++ b/internal/adapter/controller/CasinoHoldemWebController.go
@@ -64,7 +64,7 @@ func casinoHoldemDispatch(bc *baseController, w http.ResponseWriter, ci usecase.
 	case "f", "fold":
 		bc.writePresenterResponse(w, ci.Fold())
 	default:
-		return dispatchResetAndLog(param.Command, bc, w, ci.Reset, ci.ActionLog)
+		return dispatchResetHintAndLog(param.Command, bc, w, ci.Reset, ci.Hint, ci.ActionLog)
 	}
 	return true
 }

--- a/internal/adapter/controller/CassinoWebController.go
+++ b/internal/adapter/controller/CassinoWebController.go
@@ -144,7 +144,7 @@ func cassinoDispatch(bc *baseController, w http.ResponseWriter, ci usecase.Cassi
 	case "tr", "trail":
 		bc.writePresenterResponse(w, ci.Trail(param.HandIndex))
 	default:
-		return dispatchLog(param.Command, bc, w, ci.ActionLog)
+		return dispatchHintAndLog(param.Command, bc, w, ci.Hint, ci.ActionLog)
 	}
 	return true
 }

--- a/internal/adapter/controller/ChinesePokerWebController.go
+++ b/internal/adapter/controller/ChinesePokerWebController.go
@@ -76,7 +76,7 @@ func chinesePokerDispatch(bc *baseController, w http.ResponseWriter, ci usecase.
 	case "s", "set":
 		bc.writePresenterResponse(w, ci.SetHands(param.FrontIndices, param.MiddleIndices))
 	default:
-		return dispatchResetAndLog(param.Command, bc, w, ci.Reset, ci.ActionLog)
+		return dispatchResetHintAndLog(param.Command, bc, w, ci.Reset, ci.Hint, ci.ActionLog)
 	}
 	return true
 }

--- a/internal/adapter/controller/CribbageWebController.go
+++ b/internal/adapter/controller/CribbageWebController.go
@@ -121,7 +121,7 @@ func cribbageDispatch(bc *baseController, w http.ResponseWriter, ci usecase.Crib
 	case "nr", "nextround":
 		bc.writePresenterResponse(w, ci.NextRound())
 	default:
-		return dispatchLog(param.Command, bc, w, ci.ActionLog)
+		return dispatchHintAndLog(param.Command, bc, w, ci.Hint, ci.ActionLog)
 	}
 	return true
 }

--- a/internal/adapter/controller/DeuceToSevenWebController.go
+++ b/internal/adapter/controller/DeuceToSevenWebController.go
@@ -159,7 +159,7 @@ func deuceToSevenDispatch(bc *baseController, w http.ResponseWriter, di usecase.
 	case "a", "allin":
 		bc.writePresenterResponse(w, di.Action(domain.DeuceToSevenActionAllIn, 0, param.HumanPlayMs))
 	default:
-		return dispatchLog(param.Command, bc, w, di.ActionLog)
+		return dispatchHintAndLog(param.Command, bc, w, di.Hint, di.ActionLog)
 	}
 	return true
 }

--- a/internal/adapter/controller/EscobaWebController.go
+++ b/internal/adapter/controller/EscobaWebController.go
@@ -120,7 +120,7 @@ func escobaDispatch(bc *baseController, w http.ResponseWriter, ei usecase.Escoba
 			bc.writePresenterResponse(w, ei.Reset())
 		}
 	default:
-		return dispatchLog(param.Command, bc, w, ei.ActionLog)
+		return dispatchHintAndLog(param.Command, bc, w, ei.Hint, ei.ActionLog)
 	}
 	return true
 }

--- a/internal/adapter/controller/HandAndFootWebController.go
+++ b/internal/adapter/controller/HandAndFootWebController.go
@@ -119,5 +119,6 @@ func handAndFootDispatch(bc *baseController, w http.ResponseWriter, ci usecase.H
 		goOut:           ci.GoOut,
 		nextRound:       ci.NextRound,
 		actionLog:       ci.ActionLog,
+		hint:            ci.Hint,
 	}, param.CardIndex, newDefault)
 }

--- a/internal/adapter/controller/HighCardFlushWebController.go
+++ b/internal/adapter/controller/HighCardFlushWebController.go
@@ -70,7 +70,7 @@ func highCardFlushDispatch(bc *baseController, w http.ResponseWriter, hi usecase
 	case "f", "fold":
 		bc.writePresenterResponse(w, hi.Fold())
 	default:
-		return dispatchResetAndLog(param.Command, bc, w, hi.Reset, hi.ActionLog)
+		return dispatchResetHintAndLog(param.Command, bc, w, hi.Reset, hi.Hint, hi.ActionLog)
 	}
 	return true
 }

--- a/internal/adapter/controller/KaiserWebController.go
+++ b/internal/adapter/controller/KaiserWebController.go
@@ -163,7 +163,7 @@ func kaiserDispatch(bc *baseController, w http.ResponseWriter, ki usecase.Kaiser
 	case "n", "next":
 		bc.writePresenterResponse(w, ki.NextHand())
 	default:
-		return dispatchLog(param.Command, bc, w, ki.ActionLog)
+		return dispatchHintAndLog(param.Command, bc, w, ki.Hint, ki.ActionLog)
 	}
 	return true
 }

--- a/internal/adapter/controller/MacauWebController.go
+++ b/internal/adapter/controller/MacauWebController.go
@@ -115,7 +115,7 @@ func macauDispatch(bc *baseController, w http.ResponseWriter, ci usecase.MacauIn
 	case "nr", "nextround":
 		bc.writePresenterResponse(w, ci.NextRound())
 	default:
-		return dispatchLog(param.Command, bc, w, ci.ActionLog)
+		return dispatchHintAndLog(param.Command, bc, w, ci.Hint, ci.ActionLog)
 	}
 	return true
 }

--- a/internal/adapter/controller/MississippiStudWebController.go
+++ b/internal/adapter/controller/MississippiStudWebController.go
@@ -64,7 +64,7 @@ func mississippiStudDispatch(bc *baseController, w http.ResponseWriter, mi useca
 	case "f", "fold":
 		bc.writePresenterResponse(w, mi.Fold())
 	default:
-		return dispatchResetAndLog(param.Command, bc, w, mi.Reset, mi.ActionLog)
+		return dispatchResetHintAndLog(param.Command, bc, w, mi.Reset, mi.Hint, mi.ActionLog)
 	}
 	return true
 }

--- a/internal/adapter/controller/OasisPokerWebController.go
+++ b/internal/adapter/controller/OasisPokerWebController.go
@@ -69,7 +69,7 @@ func oasisPokerDispatch(bc *baseController, w http.ResponseWriter, oi usecase.Oa
 	case "f", "fold":
 		bc.writePresenterResponse(w, oi.Fold())
 	default:
-		return dispatchResetAndLog(param.Command, bc, w, oi.Reset, oi.ActionLog)
+		return dispatchResetHintAndLog(param.Command, bc, w, oi.Reset, oi.Hint, oi.ActionLog)
 	}
 	return true
 }

--- a/internal/adapter/controller/PageOneWebController.go
+++ b/internal/adapter/controller/PageOneWebController.go
@@ -100,7 +100,7 @@ func pageOneDispatch(bc *baseController, w http.ResponseWriter, ci usecase.PageO
 	case "nr", "nextround":
 		bc.writePresenterResponse(w, ci.NextRound())
 	default:
-		return dispatchLog(param.Command, bc, w, ci.ActionLog)
+		return dispatchHintAndLog(param.Command, bc, w, ci.Hint, ci.ActionLog)
 	}
 	return true
 }

--- a/internal/adapter/controller/PaiGowWebController.go
+++ b/internal/adapter/controller/PaiGowWebController.go
@@ -78,7 +78,7 @@ func paiGowDispatch(bc *baseController, w http.ResponseWriter, pi usecase.PaiGow
 		low1 := deref(param.Low1)
 		bc.writePresenterResponse(w, pi.SetHands(low0, low1))
 	default:
-		return dispatchResetAndLog(param.Command, bc, w, pi.Reset, pi.ActionLog)
+		return dispatchResetHintAndLog(param.Command, bc, w, pi.Reset, pi.Hint, pi.ActionLog)
 	}
 	return true
 }

--- a/internal/adapter/controller/PresidentWebController.go
+++ b/internal/adapter/controller/PresidentWebController.go
@@ -104,7 +104,7 @@ func presidentDispatch(bc *baseController, w http.ResponseWriter, pi usecase.Pre
 		}
 		bc.writePresenterResponse(w, pi.Play(indices))
 	default:
-		return dispatchLog(param.Command, bc, w, pi.ActionLog)
+		return dispatchHintAndLog(param.Command, bc, w, pi.Hint, pi.ActionLog)
 	}
 	return true
 }

--- a/internal/adapter/controller/RedDogWebController.go
+++ b/internal/adapter/controller/RedDogWebController.go
@@ -53,7 +53,7 @@ func redDogDispatch(bc *baseController, w http.ResponseWriter, ri usecase.RedDog
 	case "s", "stay":
 		bc.writePresenterResponse(w, ri.Stay())
 	default:
-		return dispatchResetAndLog(param.Command, bc, w, ri.Reset, ri.ActionLog)
+		return dispatchResetHintAndLog(param.Command, bc, w, ri.Reset, ri.Hint, ri.ActionLog)
 	}
 	return true
 }

--- a/internal/adapter/controller/Rummy500WebController.go
+++ b/internal/adapter/controller/Rummy500WebController.go
@@ -132,7 +132,7 @@ func rummy500Dispatch(bc *baseController, w http.ResponseWriter, ci usecase.Rumm
 	case "nr", "nextround":
 		bc.writePresenterResponse(w, ci.NextRound())
 	default:
-		return dispatchLog(param.Command, bc, w, ci.ActionLog)
+		return dispatchHintAndLog(param.Command, bc, w, ci.Hint, ci.ActionLog)
 	}
 	return true
 }

--- a/internal/adapter/controller/ScopaWebController.go
+++ b/internal/adapter/controller/ScopaWebController.go
@@ -117,7 +117,7 @@ func scopaDispatch(bc *baseController, w http.ResponseWriter, si usecase.ScopaIn
 		}
 		bc.writePresenterResponse(w, si.Play(param.HandIndex, param.TableIndices))
 	default:
-		return dispatchLog(param.Command, bc, w, si.ActionLog)
+		return dispatchHintAndLog(param.Command, bc, w, si.Hint, si.ActionLog)
 	}
 	return true
 }

--- a/internal/adapter/controller/ScoponeWebController.go
+++ b/internal/adapter/controller/ScoponeWebController.go
@@ -116,7 +116,7 @@ func scoponeDispatch(bc *baseController, w http.ResponseWriter, si usecase.Scopo
 			bc.writePresenterResponse(w, si.Reset())
 		}
 	default:
-		return dispatchLog(param.Command, bc, w, si.ActionLog)
+		return dispatchHintAndLog(param.Command, bc, w, si.Hint, si.ActionLog)
 	}
 	return true
 }

--- a/internal/adapter/controller/SevenBridgeWebController.go
+++ b/internal/adapter/controller/SevenBridgeWebController.go
@@ -118,7 +118,7 @@ func sevenBridgeDispatch(bc *baseController, w http.ResponseWriter, ci usecase.S
 	case "nr", "nextround":
 		bc.writePresenterResponse(w, ci.NextRound())
 	default:
-		return dispatchLog(param.Command, bc, w, ci.ActionLog)
+		return dispatchHintAndLog(param.Command, bc, w, ci.Hint, ci.ActionLog)
 	}
 	return true
 }

--- a/internal/adapter/controller/SevenCardStudWebController.go
+++ b/internal/adapter/controller/SevenCardStudWebController.go
@@ -189,7 +189,7 @@ func sevenCardStudDispatch(bc *baseController, w http.ResponseWriter, sgi usecas
 		}
 		bc.writePresenterResponse(w, sgi.ResetWithConfig(cfg, param.Profile))
 	default:
-		return dispatchLog(param.Command, bc, w, sgi.ActionLog)
+		return dispatchHintAndLog(param.Command, bc, w, sgi.Hint, sgi.ActionLog)
 	}
 	return true
 }

--- a/internal/adapter/controller/SixCardGolfWebController.go
+++ b/internal/adapter/controller/SixCardGolfWebController.go
@@ -126,7 +126,7 @@ func sixCardGolfDispatch(bc *baseController, w http.ResponseWriter, ci usecase.S
 	case "nr", "nextround":
 		bc.writePresenterResponse(w, ci.NextRound())
 	default:
-		return dispatchLog(param.Command, bc, w, ci.ActionLog)
+		return dispatchHintAndLog(param.Command, bc, w, ci.Hint, ci.ActionLog)
 	}
 	return true
 }

--- a/internal/adapter/controller/ThirtyOneWebController.go
+++ b/internal/adapter/controller/ThirtyOneWebController.go
@@ -110,7 +110,7 @@ func thirtyOneDispatch(bc *baseController, w http.ResponseWriter, ci usecase.Thi
 	case "nr", "nextround":
 		bc.writePresenterResponse(w, ci.NextRound())
 	default:
-		return dispatchLog(param.Command, bc, w, ci.ActionLog)
+		return dispatchHintAndLog(param.Command, bc, w, ci.Hint, ci.ActionLog)
 	}
 	return true
 }

--- a/internal/adapter/controller/ThreeCardWebController.go
+++ b/internal/adapter/controller/ThreeCardWebController.go
@@ -63,7 +63,7 @@ func threeCardDispatch(bc *baseController, w http.ResponseWriter, ti usecase.Thr
 	case "f", "fold":
 		bc.writePresenterResponse(w, ti.Fold())
 	default:
-		return dispatchResetAndLog(param.Command, bc, w, ti.Reset, ti.ActionLog)
+		return dispatchResetHintAndLog(param.Command, bc, w, ti.Reset, ti.Hint, ti.ActionLog)
 	}
 	return true
 }

--- a/internal/adapter/controller/TrashWebController.go
+++ b/internal/adapter/controller/TrashWebController.go
@@ -67,7 +67,7 @@ func trashDispatch(bc *baseController, w http.ResponseWriter, ti usecase.TrashIn
 	case "cpu":
 		bc.writePresenterResponse(w, ti.CpuStep())
 	default:
-		return dispatchResetAndLog(param.Command, bc, w, ti.Reset, ti.ActionLog)
+		return dispatchResetHintAndLog(param.Command, bc, w, ti.Reset, ti.Hint, ti.ActionLog)
 	}
 	return true
 }

--- a/internal/adapter/controller/UltimateTexasHoldemWebController.go
+++ b/internal/adapter/controller/UltimateTexasHoldemWebController.go
@@ -70,7 +70,7 @@ func ultimateTexasHoldemDispatch(bc *baseController, w http.ResponseWriter, ui u
 	case "f", "fold":
 		bc.writePresenterResponse(w, ui.Fold())
 	default:
-		return dispatchResetAndLog(param.Command, bc, w, ui.Reset, ui.ActionLog)
+		return dispatchResetHintAndLog(param.Command, bc, w, ui.Reset, ui.Hint, ui.ActionLog)
 	}
 	return true
 }

--- a/internal/adapter/controller/VideoPokerWebController.go
+++ b/internal/adapter/controller/VideoPokerWebController.go
@@ -58,7 +58,7 @@ func videoPokerDispatch(bc *baseController, w http.ResponseWriter, vi usecase.Vi
 		}
 		bc.writePresenterResponse(w, vi.Hold(indices))
 	default:
-		return dispatchResetAndLog(param.Command, bc, w, vi.Reset, vi.ActionLog)
+		return dispatchResetHintAndLog(param.Command, bc, w, vi.Reset, vi.Hint, vi.ActionLog)
 	}
 	return true
 }

--- a/internal/adapter/controller/web_dispatch_helper.go
+++ b/internal/adapter/controller/web_dispatch_helper.go
@@ -195,6 +195,9 @@ type rummyMeldFns struct {
 	goOut           func() string
 	nextRound       func() string
 	actionLog       func() string
+	// hint is optional: Canasta and Samba have no Hint() on their interactor, so
+	// a nil here keeps the old log-only fallthrough for them.
+	hint func() string
 }
 
 // dispatchRummyMeld handles the draw/meld/discard/go-out command set shared by
@@ -227,6 +230,9 @@ func dispatchRummyMeld[O any](cmd string, bc *baseController, w http.ResponseWri
 	case "nr", "nextround":
 		bc.writePresenterResponse(w, fns.nextRound())
 	default:
+		if fns.hint != nil {
+			return dispatchHintAndLog(cmd, bc, w, fns.hint, fns.actionLog)
+		}
 		return dispatchLog(cmd, bc, w, fns.actionLog)
 	}
 	return true

--- a/internal/adapter/controller/web_hint_dispatch_test.go
+++ b/internal/adapter/controller/web_hint_dispatch_test.go
@@ -1,0 +1,114 @@
+//go:build test
+
+package controller_test
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// hintDispatchers are the helper calls that make "h"/"hint" reach the interactor.
+// A controller may also answer it inline, or pass a hint func into a shared
+// dispatcher struct, so the struct-field form counts too.
+var hintDispatchers = []string{
+	"dispatchHintAndLog",
+	"dispatchResetHintAndLog",
+	"hint:",
+	`case "h", "hint"`,
+	`case "hint"`,
+}
+
+var interactorRe = regexp.MustCompile(`usecase\.(\w+)InteractorIF`)
+
+// hintMethodRe matches a Hint() declaration at a token boundary, so ToggleHint()
+// and similar suffixes do not count as the interactor exposing Hint().
+var hintMethodRe = regexp.MustCompile(`(^|[^\w])Hint\(\) string`)
+
+// TestWebControllersDispatchHintWhenTheInteractorHasIt is a structural guard.
+//
+// The Web CLI sends "hint" to the REST endpoint, so the *Web* controller has to
+// route it. That is a different file from the terminal *CuiController, and the
+// distinction is not academic: #5791 shipped a CLI hint command for Durak and
+// Crazy Eights whose Web controllers fell through to dispatchLog, which matches
+// neither "h" nor "hint" -- the request came back 400 "Unsupported command.",
+// strictly worse than the local rejection it replaced. Review caught it; nothing
+// in the test suite did.
+//
+// The rule is keyed on capability rather than a list of game names: a Web
+// controller must dispatch hint exactly when its own interactor exposes Hint().
+// Controllers whose interactor has no Hint() are skipped without needing an
+// allowlist entry, and start being checked the moment one is added.
+func TestWebControllersDispatchHintWhenTheInteractorHasIt(t *testing.T) {
+	files, err := filepath.Glob("*WebController.go")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, files, "no Web controllers found -- the glob is wrong, not the code")
+
+	capable, skipped := 0, 0
+	var missing []string
+
+	for _, path := range files {
+		b, err := os.ReadFile(path) //nolint:gosec // test-only, fixed glob
+		assert.NoError(t, err)
+		src := string(b)
+
+		m := interactorRe.FindStringSubmatch(src)
+		if m == nil {
+			skipped++
+			continue
+		}
+		if !interactorExposesHint(t, m[1]) {
+			skipped++
+			continue
+		}
+		capable++
+
+		found := false
+		for _, d := range hintDispatchers {
+			if strings.Contains(src, d) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			missing = append(missing, path)
+		}
+	}
+
+	// Negative control on the detection itself: if either counter collapses the
+	// guard is inspecting nothing and would pass however broken the code was.
+	assert.Greater(t, capable, 150,
+		"far fewer hint-capable controllers than expected -- the detection is broken, not the code")
+	assert.Greater(t, skipped, 0,
+		"expected some controllers whose interactor has no Hint()")
+	assert.Empty(t, missing,
+		"these Web controllers have an interactor with Hint() but never dispatch it, "+
+			"so the Web CLI's hint command would 400")
+}
+
+// interactorExposesHint reports whether <name>InteractorIF declares Hint().
+func interactorExposesHint(t *testing.T, name string) bool {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join("..", "..", "usecase", name+"Interactor.go")) //nolint:gosec // derived from a matched Go identifier
+	if err != nil {
+		return false
+	}
+	body := string(b)
+	i := strings.Index(body, name+"InteractorIF interface")
+	if i < 0 {
+		return false
+	}
+	end := strings.Index(body[i:], "\n}")
+	if end < 0 {
+		return false
+	}
+	// Must be the method Hint, not a method whose name merely ends in it:
+	// BlackJackInteractorIF has ToggleHint() string, and a substring match
+	// reported it as hint-capable, which sent a "fix" at a method that does
+	// not exist and broke the build.
+	return hintMethodRe.MatchString(body[i : i+end])
+}


### PR DESCRIPTION
Closes #5792

## The issue was scoped wrong (by me)

#5792 said these 24 games needed the API command union widened. I derived that from each
game's terminal `*CuiController.go` — but the Web CLI calls the REST `*WebController.go`.
That is the same mistake the #5791 review caught, and #5792 was filed before I learned it.

Re-measured against the Web controllers, every one of the 24 needs **three** layers:

| layer | change |
|---|---|
| `internal/adapter/controller/<Game>WebController.go` | `dispatchLog` → `dispatchHintAndLog` |
| `frontend/src/api/games/<game>.ts` | add `'hint'` to the command union |
| `frontend/src/utils/cli/commands/<game>Commands.ts` | `case` + help line + suggestion list |

All 24 interactors already expose `Hint()`, so layer 1 is one line each. `rummyMeldFns` gains
an **optional** `hint` field — Burraco and HandAndFoot pass it; Canasta and Samba have no
`Hint()` and keep the log-only fallthrough.

## The guard matters more than the 24 games

`TestWebControllersDispatchHintWhenTheInteractorHasIt` parses every Web controller and requires
it to dispatch hint **exactly when its own interactor exposes `Hint()`**. Capability-keyed, so
there is no allowlist to go stale, and a new game cannot ship the CLI half without the endpoint.

A frontend unit test structurally cannot catch this — which is precisely why #5791 shipped two
games whose `hint` returned `400`.

**It immediately found 8 controllers outside this issue.** Seven were real and are fixed here
(MississippiStud, Rummy500, SevenCardStud, ThirtyOne, Trash, UltimateTexasHoldem, VideoPoker).

**The eighth was a false positive in my own guard.** `BlackJackInteractorIF` has
`ToggleHint() string`, and my substring match read that as `Hint() string` — so the guard aimed a
"fix" at a method that does not exist and broke the build. The detection now matches at a token
boundary, and the comment records why.

## Test plan

- [x] `TestWebControllersDispatchHintWhenTheInteractorHasIt` — passes; asserts `capable > 150` and `skipped > 0` so a broken detector cannot pass on an empty set
- [x] **Negative controls:** reverting Badugi's dispatch → fails with "never dispatch it"; pointing the glob at a non-existent pattern → fails with "the glob is wrong, not the code"
- [x] `hintCommandParity.test.ts` extended 21 → **44** games, plus `sixcardgolf` asserted separately (it builds help from i18n rather than exporting a `*_HELP` array)
- [x] `go test -tags test ./internal/adapter/controller/` — passes
- [x] `golangci-lint run ./internal/adapter/controller/...` — 0 issues
- [x] `bun run typecheck` — clean (this is the gate that proves each API union was actually widened)
- [x] `biome check` on all 48 changed frontend files — clean
- [x] `bunx vitest run src/utils/cli/commands` — 263 files / 3182 tests pass

## Remaining

#5793 (62 games with no backend `hint` at all, needing `localCommand`) is still open; #5473 stays
open until it lands.